### PR TITLE
Go implementation of bridge script

### DIFF
--- a/cmd/juju-bridge/main.go
+++ b/cmd/juju-bridge/main.go
@@ -1,0 +1,88 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/juju/juju/network/debinterfaces"
+	"github.com/juju/utils/clock"
+)
+
+const usage = `
+Bridge existing devices
+
+usage: [ -p ] [ -b <bridge-prefix ] <filename> <device-name>...
+
+Options:
+
+  -b -- prefix to add before each device name to be bridged (default "br-")
+  -p -- parse and print to stdout, no activation
+
+Example:
+
+  $ juju-bridge /etc/network/interfaces ens3 bond0.150
+`
+
+func printParseError(err error) {
+	if pe, ok := err.(*debinterfaces.ParseError); ok {
+		fmt.Printf("error: %q:%d: %s: %s\n", pe.Filename, pe.LineNum, pe.Line, pe.Message)
+	} else {
+		fmt.Printf("error: %v\n", err)
+	}
+}
+
+func main() {
+	parseOnlyFlag := flag.Bool("p", false, "parse and print to stdout, no activation")
+	bridgePrefixFlag := flag.String("b", "br-", "bridge prefix")
+
+	flag.Parse()
+	args := flag.Args()
+
+	if len(args) < 2 {
+		fmt.Fprintln(os.Stderr, usage)
+		os.Exit(1)
+	}
+
+	if *parseOnlyFlag {
+		stanzas, err := debinterfaces.Parse(args[0])
+
+		if err != nil {
+			printParseError(err)
+			os.Exit(1)
+		}
+
+		fmt.Println(debinterfaces.FormatStanzas(debinterfaces.FlattenStanzas(stanzas), 4))
+		os.Exit(0)
+	}
+
+	params := debinterfaces.ActivationParams{
+		BridgePrefix:     *bridgePrefixFlag,
+		Clock:            clock.WallClock,
+		Filename:         args[0],
+		DeviceNames:      args[1:],
+		ReconfigureDelay: 10,
+		Timeout:          5 * time.Minute,
+	}
+
+	result, err := debinterfaces.BridgeAndActivate(params)
+
+	if err != nil {
+		printParseError(err)
+		os.Exit(1)
+	} else if result != nil {
+		if result.Code != 0 {
+			if len(result.Stdout) > 0 {
+				fmt.Fprintln(os.Stderr, string(result.Stdout))
+			}
+			if len(result.Stderr) > 0 {
+				fmt.Fprintln(os.Stderr, string(result.Stderr))
+			}
+		}
+		os.Exit(result.Code)
+	}
+}

--- a/network/debinterfaces/activate.go
+++ b/network/debinterfaces/activate.go
@@ -1,0 +1,134 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package debinterfaces
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/juju/loggo"
+	"github.com/juju/utils/clock"
+	"github.com/pkg/errors"
+)
+
+var logger = loggo.GetLogger("juju.network.debinterfaces")
+
+// ActivationParams contains options to use when bridging interfaces
+type ActivationParams struct {
+	BackupFilename   string
+	BridgePrefix     string
+	Clock            clock.Clock
+	DeviceNames      []string
+	DryRun           bool
+	Filename         string
+	ReconfigureDelay int
+	Timeout          time.Duration
+}
+
+// ActivationResult captures the result of actively bridging the
+// interfaces using ifup/ifdown.
+type ActivationResult struct {
+	Stdout []byte
+	Stderr []byte
+	Code   int
+}
+
+func activationCmd(oldContent, newContent string, params *ActivationParams) string {
+	if params.ReconfigureDelay < 0 {
+		params.ReconfigureDelay = 0
+	}
+
+	return fmt.Sprintf(`
+#!/bin/bash
+
+set -eu
+
+: ${DRYRUN:=}
+
+write_backup() {
+    cat << 'EOF' > "$1"
+%[3]s
+EOF
+}
+
+write_content() {
+    cat << 'EOF' > "$1"
+%[4]s
+EOF
+}
+
+if [ -n %[6]q ]; then
+    ${DRYRUN} write_backup %[6]q
+fi
+
+${DRYRUN} ifdown --interfaces=%[1]q %[5]s
+${DRYRUN} sleep %[2]d
+${DRYRUN} write_content %[1]q
+${DRYRUN} ifup --interfaces=%[1]q -a
+`,
+		params.Filename,
+		params.ReconfigureDelay,
+		oldContent,
+		newContent,
+		strings.Join(params.DeviceNames, " "),
+		params.BackupFilename)[1:]
+}
+
+// BridgeAndActivate will parse a debian-styled interfaces(5) file,
+// change the stanza definitions of the requested devices to be
+// bridged, then reconfigure the network using the ifupdown package
+// for the new bridges.
+func BridgeAndActivate(params ActivationParams) (*ActivationResult, error) {
+	if len(params.DeviceNames) == 0 {
+		return nil, errors.Errorf("no devices specified")
+	}
+
+	stanzas, err := Parse(params.Filename)
+
+	if err != nil {
+		return nil, err
+	}
+
+	origContent := FormatStanzas(FlattenStanzas(stanzas), 4)
+	bridgedStanzas := Bridge(params.BridgePrefix, stanzas, params.DeviceNames...)
+	bridgedContent := FormatStanzas(FlattenStanzas(bridgedStanzas), 4)
+
+	if origContent == bridgedContent {
+		return nil, nil // nothing to do; old == new.
+	}
+
+	cmd := activationCmd(origContent, bridgedContent, &params)
+
+	environ := os.Environ()
+	if params.DryRun {
+		environ = append(environ, "DRYRUN=echo")
+	}
+
+	result, err := runCommand(cmd, environ, params.Clock, params.Timeout)
+
+	activationResult := ActivationResult{
+		Stderr: result.Stderr,
+		Stdout: result.Stdout,
+		Code:   result.Code,
+	}
+
+	if err != nil {
+		return &activationResult, errors.Errorf("bridge activation error: %s", err)
+	}
+
+	logger.Infof("bridge activation result=%v", result.Code)
+
+	if result.Code != 0 {
+		logger.Errorf("bridge activation stdout\n%s\n", result.Stdout)
+		logger.Errorf("bridge activation stderr\n%s\n", result.Stderr)
+		return &activationResult, errors.Errorf("bridge activation failed: %s", string(result.Stderr))
+	}
+
+	logger.Tracef("bridge activation stdout\n%s\n", result.Stdout)
+	logger.Tracef("bridge activation stderr\n%s\n", result.Stderr)
+
+	return &activationResult, nil
+}

--- a/network/debinterfaces/activate_test.go
+++ b/network/debinterfaces/activate_test.go
@@ -1,0 +1,168 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package debinterfaces_test
+
+// These tests verify the commands that would be executed, but using a
+// dryrun option to the script that is executed.
+
+import (
+	"runtime"
+	"time"
+
+	"github.com/juju/juju/network/debinterfaces"
+	"github.com/juju/testing"
+	"github.com/juju/utils/clock"
+	gc "gopkg.in/check.v1"
+)
+
+type ActivationSuite struct {
+	testing.IsolationSuite
+}
+
+var _ = gc.Suite(&ActivationSuite{})
+
+func (s *ActivationSuite) SetUpSuite(c *gc.C) {
+	if runtime.GOOS == "windows" {
+		c.Skip("skipping ActivationSuite tests on windows")
+	}
+	s.IsolationSuite.SetUpSuite(c)
+}
+
+func (*BridgeSuite) TestActivateNonExistentDeviceOrDeviceThatIsAlreadyBridged(c *gc.C) {
+	params := debinterfaces.ActivationParams{
+		DryRun:           true,
+		BridgePrefix:     "br-",
+		Clock:            clock.WallClock,
+		DeviceNames:      []string{"non-existent"},
+		Filename:         "testdata/TestInputSourceStanza/interfaces",
+		ReconfigureDelay: 10,
+		Timeout:          5 * time.Minute,
+	}
+
+	result, err := debinterfaces.BridgeAndActivate(params)
+	c.Assert(err, gc.IsNil)
+	c.Assert(result, gc.IsNil)
+}
+
+func (*BridgeSuite) TestActivateEth0WithBackup(c *gc.C) {
+	filename := "testdata/TestInputSourceStanza/interfaces"
+
+	params := debinterfaces.ActivationParams{
+		BackupFilename:   filename + ".backup",
+		BridgePrefix:     "br-",
+		Clock:            clock.WallClock,
+		DeviceNames:      []string{"eth0", "eth1"},
+		DryRun:           true,
+		Filename:         filename,
+		ReconfigureDelay: 10,
+		Timeout:          5 * time.Minute,
+	}
+
+	result, err := debinterfaces.BridgeAndActivate(params)
+	c.Assert(err, gc.IsNil)
+	c.Assert(result, gc.NotNil)
+	c.Assert(result.Code, gc.Equals, 0)
+
+	expected := `
+write_backup testdata/TestInputSourceStanza/interfaces.backup
+ifdown --interfaces=testdata/TestInputSourceStanza/interfaces eth0 eth1
+sleep 10
+write_content testdata/TestInputSourceStanza/interfaces
+ifup --interfaces=testdata/TestInputSourceStanza/interfaces -a
+`
+	c.Assert(string(result.Stdout), gc.Equals, expected[1:])
+}
+
+func (*BridgeSuite) TestActivateEth0WithoutBackup(c *gc.C) {
+	filename := "testdata/TestInputSourceStanza/interfaces"
+
+	params := debinterfaces.ActivationParams{
+		BridgePrefix:     "br-",
+		Clock:            clock.WallClock,
+		DeviceNames:      []string{"eth0", "eth1"},
+		DryRun:           true,
+		Filename:         filename,
+		ReconfigureDelay: 100,
+		Timeout:          5 * time.Minute,
+	}
+
+	result, err := debinterfaces.BridgeAndActivate(params)
+	c.Assert(err, gc.IsNil)
+	c.Assert(result, gc.NotNil)
+	c.Assert(result.Code, gc.Equals, 0)
+
+	expected := `
+ifdown --interfaces=testdata/TestInputSourceStanza/interfaces eth0 eth1
+sleep 100
+write_content testdata/TestInputSourceStanza/interfaces
+ifup --interfaces=testdata/TestInputSourceStanza/interfaces -a
+`
+	c.Assert(string(result.Stdout), gc.Equals, expected[1:])
+}
+
+func (*BridgeSuite) TestActivateWithNegativeReconfigureDelay(c *gc.C) {
+	filename := "testdata/TestInputSourceStanza/interfaces"
+
+	params := debinterfaces.ActivationParams{
+		BridgePrefix:     "br-",
+		Clock:            clock.WallClock,
+		DeviceNames:      []string{"eth0", "eth1"},
+		DryRun:           true,
+		Filename:         filename,
+		ReconfigureDelay: -3,
+		Timeout:          5 * time.Minute,
+	}
+
+	result, err := debinterfaces.BridgeAndActivate(params)
+	c.Assert(err, gc.IsNil)
+	c.Assert(result, gc.NotNil)
+	c.Assert(result.Code, gc.Equals, 0)
+
+	expected := `
+ifdown --interfaces=testdata/TestInputSourceStanza/interfaces eth0 eth1
+sleep 0
+write_content testdata/TestInputSourceStanza/interfaces
+ifup --interfaces=testdata/TestInputSourceStanza/interfaces -a
+`
+	c.Assert(string(result.Stdout), gc.Equals, expected[1:])
+}
+
+func (*BridgeSuite) TestActivateWithNoDevicesSpecified(c *gc.C) {
+	filename := "testdata/TestInputSourceStanza/interfaces"
+
+	params := debinterfaces.ActivationParams{
+		BridgePrefix: "br-",
+		Clock:        clock.WallClock,
+		DeviceNames:  []string{},
+		DryRun:       true,
+		Filename:     filename,
+	}
+
+	_, err := debinterfaces.BridgeAndActivate(params)
+	c.Assert(err, gc.NotNil)
+	c.Assert(err, gc.ErrorMatches, "no devices specified")
+}
+
+func (*BridgeSuite) TestActivateWithParsingError(c *gc.C) {
+	filename := "testdata/TestInputSourceStanzaWithErrors/interfaces"
+
+	params := debinterfaces.ActivationParams{
+		BridgePrefix: "br-",
+		Clock:        clock.WallClock,
+		DeviceNames:  []string{"eth0"},
+		DryRun:       true,
+		Filename:     filename,
+	}
+
+	_, err := debinterfaces.BridgeAndActivate(params)
+	c.Assert(err, gc.NotNil)
+	c.Assert(err, gc.FitsTypeOf, &debinterfaces.ParseError{})
+	parseError := err.(*debinterfaces.ParseError)
+	c.Assert(parseError, gc.DeepEquals, &debinterfaces.ParseError{
+		Filename: "testdata/TestInputSourceStanzaWithErrors/interfaces.d/eth1.cfg",
+		Line:     "iface",
+		LineNum:  2,
+		Message:  "missing device name",
+	})
+}

--- a/network/debinterfaces/bridge.go
+++ b/network/debinterfaces/bridge.go
@@ -1,0 +1,169 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package debinterfaces
+
+import (
+	"fmt"
+	"strings"
+)
+
+type deviceNameSet map[string]bool
+
+// The set of options which should be moved from an existing 'iface'
+// stanza when turning it into a bridged device.
+var bridgeOnlyOptions = []string{
+	"address",
+	"gateway",
+	"netmask",
+	"dns-nameservers",
+	"dns-search",
+	"dns-sortlist",
+}
+
+func pruneOptions(options []string, names ...string) []string {
+	toPrune := map[string]bool{}
+	for _, v := range names {
+		toPrune[v] = true
+	}
+	result := make([]string, 0, len(options))
+	for _, o := range options {
+		words := strings.Fields(o)
+		if len(words) >= 1 && !toPrune[words[0]] {
+			result = append(result, o)
+		}
+	}
+	return result
+}
+
+func pruneOptionsWithPrefix(options []string, prefix string) []string {
+	result := make([]string, 0, len(options))
+	for _, o := range options {
+		words := strings.Fields(o)
+		if len(words) >= 1 && !strings.HasPrefix(words[0], prefix) {
+			result = append(result, o)
+		}
+	}
+	return result
+}
+
+func isLoopbackDevice(s *IfaceStanza) bool {
+	words := strings.Fields(s.Definition()[0])
+	return len(words) >= 4 && words[3] == "loopback"
+}
+
+func newAutoStanza(deviceNames ...string) *AutoStanza {
+	return &AutoStanza{
+		stanza: stanza{
+			definition: fmt.Sprintf("auto %s", strings.Join(deviceNames, " ")),
+		},
+		DeviceNames: deviceNames,
+	}
+}
+
+func isDefinitionBridgeable(iface *IfaceStanza) bool {
+	definitions := iface.definition
+	words := strings.Fields(definitions)
+	return len(words) >= 4
+}
+
+func turnManual(prefix string, iface IfaceStanza) *IfaceStanza {
+	if iface.IsAlias {
+		words := strings.Fields(iface.definition)
+		words[1] = prefix + words[1]
+		iface.definition = strings.Join(words, " ")
+		return &iface
+	}
+	words := strings.Fields(iface.definition)
+	words[3] = "manual"
+	iface.definition = strings.Join(words, " ")
+	iface.Options = pruneOptions(iface.Options, bridgeOnlyOptions...)
+	return &iface
+}
+
+func bridgeInterface(bridgeName string, iface IfaceStanza) *IfaceStanza {
+	words := strings.Fields(iface.definition)
+	words[1] = bridgeName
+	iface.definition = strings.Join(words, " ")
+	iface.Options = pruneOptions(iface.Options, "mtu")
+	if iface.IsVLAN {
+		iface.Options = pruneOptions(iface.Options, "vlan_id", "vlan-raw-device")
+	}
+	if iface.HasBondOptions {
+		iface.Options = pruneOptionsWithPrefix(iface.Options, "bond-")
+	}
+	iface.Options = append(iface.Options, fmt.Sprintf("bridge_ports %s", iface.DeviceName))
+	return &iface
+}
+
+func isBridgeable(iface *IfaceStanza) bool {
+	return isDefinitionBridgeable(iface) &&
+		!isLoopbackDevice(iface) &&
+		!iface.IsBridged &&
+		!iface.HasBondMasterOption
+}
+
+// Bridge turns existing devices into bridged devices.
+func Bridge(prefix string, stanzas []Stanza, devices ...string) []Stanza {
+	result := make([]Stanza, 0)
+	autoStanzaSet := map[string]bool{}
+	ifacesToBridge := make([]IfaceStanza, 0)
+	devicesToBridge := deviceNameSet{}
+
+	for _, name := range devices {
+		devicesToBridge[name] = true
+	}
+
+	// We don't want to perturb the existing order, except for
+	// aliases which we do mutate in situ. All the bridged stanzas
+	// are added to the end of the original input.
+
+	for _, s := range stanzas {
+		switch v := s.(type) {
+		case IfaceStanza:
+			if devicesToBridge[v.DeviceName] && isBridgeable(&v) {
+				result = append(result, *turnManual(prefix, v))
+				ifacesToBridge = append(ifacesToBridge, v)
+			} else {
+				result = append(result, s)
+			}
+		case AutoStanza:
+			names := v.DeviceNames
+			for i, name := range names {
+				if isAlias(name) && devicesToBridge[name] {
+					names[i] = prefix + name
+					autoStanzaSet[names[i]] = true
+				} else {
+					autoStanzaSet[names[i]] = true
+				}
+			}
+			result = append(result, *newAutoStanza(names...))
+		case SourceStanza:
+			v.Stanzas = Bridge(prefix, v.Stanzas, devices...)
+			result = append(result, v)
+		case SourceDirectoryStanza:
+			v.Stanzas = Bridge(prefix, v.Stanzas, devices...)
+			result = append(result, v)
+		default:
+			result = append(result, v)
+		}
+	}
+
+	for _, iface := range ifacesToBridge {
+		bridgeName := prefix + iface.DeviceName
+		// If there was a `auto $DEVICE` stanza make sure we
+		// create the complementary auto stanza for the bridge
+		// device.
+		if autoStanzaSet[iface.DeviceName] {
+			if !autoStanzaSet[bridgeName] {
+				autoStanzaSet[bridgeName] = true
+				result = append(result, *newAutoStanza(bridgeName))
+			}
+		}
+		if isBridgeable(&iface) && !iface.IsAlias {
+			result = append(result, *bridgeInterface(bridgeName, iface))
+		}
+	}
+
+	return result
+}

--- a/network/debinterfaces/bridge_test.go
+++ b/network/debinterfaces/bridge_test.go
@@ -1,0 +1,326 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package debinterfaces_test
+
+import (
+	"github.com/juju/testing"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/network/debinterfaces"
+)
+
+type BridgeSuite struct {
+	testing.IsolationSuite
+
+	expander debinterfaces.WordExpander
+}
+
+var _ = gc.Suite(&BridgeSuite{})
+
+func format(stanzas []debinterfaces.Stanza) string {
+	return debinterfaces.FormatStanzas(stanzas, 4)
+}
+
+func (s *BridgeSuite) SetUpTest(c *gc.C) {
+	s.expander = debinterfaces.NewWordExpander()
+}
+
+func (s *BridgeSuite) assertParse(c *gc.C, content string) []debinterfaces.Stanza {
+	stanzas, err := debinterfaces.ParseSource("", content, s.expander)
+	c.Assert(err, gc.IsNil)
+	return stanzas
+}
+
+func (s *BridgeSuite) assertBridge(input, expected, prefix string, c *gc.C, devices ...string) {
+	stanzas := s.assertParse(c, input)
+	bridged := debinterfaces.Bridge(prefix, stanzas, devices...)
+	c.Assert(format(bridged), gc.Equals, expected)
+	s.assertParse(c, format(bridged))
+}
+
+func (s *BridgeSuite) TestBridgeDeviceNameNotMatched(c *gc.C) {
+	input := `
+auto eth0
+iface eth0 inet manual`
+	s.assertBridge(input, input[1:], "br-", c, "non-existent-interface")
+}
+
+func (s *BridgeSuite) TestBridgeDeviceNameAlreadyBridged(c *gc.C) {
+	input := `
+auto br-eth0
+iface br-eth0 inet dhcp
+    bridge_ports eth0`
+	s.assertBridge(input, input[1:], "br-", c, "br-eth0")
+}
+
+func (s *BridgeSuite) TestBridgeDeviceIsBridgeable(c *gc.C) {
+	input := `
+auto eth0
+iface eth0 inet dhcp`
+
+	expected := `
+auto eth0
+iface eth0 inet manual
+
+auto br-eth0
+iface br-eth0 inet dhcp
+    bridge_ports eth0`
+	s.assertBridge(input, expected[1:], "br-", c, "eth0")
+}
+
+func (s *BridgeSuite) TestBridgeDeviceIsBridgeableButHasNoAutoStanza(c *gc.C) {
+	input := `
+iface eth0 inet dhcp`
+
+	expected := `
+iface eth0 inet manual
+
+iface br-eth0 inet dhcp
+    bridge_ports eth0`
+	s.assertBridge(input, expected[1:], "br-", c, "eth0")
+}
+
+func (s *BridgeSuite) TestBridgeDeviceIsNotBridgeable(c *gc.C) {
+	input := `
+iface work-wireless bootp`
+	s.assertBridge(input, input[1:], "br-", c, "work-wireless")
+}
+
+func (s *BridgeSuite) TestBridgeSpecialOptionsGetMoved(c *gc.C) {
+	input := `
+auto eth0
+iface eth0 inet static
+    mtu 1500
+
+auto eth1
+iface eth1 inet static
+    address 192.168.1.254
+    gateway 192.168.1.1
+    netmask 255.255.255.0
+    dns-nameservers 8.8.8.8
+    dns-search ubuntu.com
+    dns-sortlist 192.168.1.1/24 10.245.168.0/21 192.168.1.0/24
+    mtu 1500`
+
+	expected := `
+auto eth0
+iface eth0 inet manual
+    mtu 1500
+
+auto eth1
+iface eth1 inet manual
+    mtu 1500
+
+auto br-eth0
+iface br-eth0 inet static
+    bridge_ports eth0
+
+auto br-eth1
+iface br-eth1 inet static
+    address 192.168.1.254
+    gateway 192.168.1.1
+    netmask 255.255.255.0
+    dns-nameservers 8.8.8.8
+    dns-search ubuntu.com
+    dns-sortlist 192.168.1.1/24 10.245.168.0/21 192.168.1.0/24
+    bridge_ports eth1`
+	s.assertBridge(input, expected[1:], "br-", c, "eth0", "eth1")
+}
+
+func (s *BridgeSuite) TestBridgeVLAN(c *gc.C) {
+	input := `
+auto eth0.2
+iface eth0.2 inet static
+    address 192.168.2.3/24
+    vlan-raw-device eth0
+    mtu 1500
+    vlan_id 2`
+
+	expected := `
+auto eth0.2
+iface eth0.2 inet manual
+    vlan-raw-device eth0
+    mtu 1500
+    vlan_id 2
+
+auto br-eth0.2
+iface br-eth0.2 inet static
+    address 192.168.2.3/24
+    bridge_ports eth0.2`
+	s.assertBridge(input, expected[1:], "br-", c, "eth0.2")
+}
+
+func (s *BridgeSuite) TestBridgeBond(c *gc.C) {
+	input := `
+auto bond0
+iface bond0 inet static
+    address 10.17.20.211/24
+    gateway 10.17.20.1
+    dns-nameservers 10.17.20.200
+    bond-slaves none
+    bond-mode active-backup
+    bond-xmit_hash_policy layer2
+    bond-miimon 100
+    mtu 1500
+    hwaddress 52:54:00:1c:f1:5b
+    bond-lacp_rate slow`
+
+	expected := `
+auto bond0
+iface bond0 inet manual
+    bond-slaves none
+    bond-mode active-backup
+    bond-xmit_hash_policy layer2
+    bond-miimon 100
+    mtu 1500
+    hwaddress 52:54:00:1c:f1:5b
+    bond-lacp_rate slow
+
+auto br-bond0
+iface br-bond0 inet static
+    address 10.17.20.211/24
+    gateway 10.17.20.1
+    dns-nameservers 10.17.20.200
+    hwaddress 52:54:00:1c:f1:5b
+    bridge_ports bond0`
+	s.assertBridge(input, expected[1:], "br-", c, "bond0")
+}
+
+func (s *BridgeSuite) TestBridgeNoIfacesDefined(c *gc.C) {
+	input := `
+mapping eth0
+    script /path/to/pcmcia-compat.sh
+    map home,*,*,*                  home
+    map work,*,*,00:11:22:33:44:55  work-wireless
+    map work,*,*,01:12:23:34:45:50  work-static`
+	s.assertBridge(input, input[1:], "br-", c, "eth0")
+}
+
+func (s *BridgeSuite) TestBridgeBondMaster(c *gc.C) {
+	input := `
+auto ens5
+iface ens5 inet manual
+    bond-lacp_rate slow
+    mtu 1500
+    bond-master bond0
+    bond-xmit_hash_policy layer2
+    bond-mode active-backup
+    bond-miimon 100`
+	s.assertBridge(input, input[1:], "br-", c, "eth0")
+}
+
+func (s *BridgeSuite) TestBridgeNoIfacesDefinedFromFile(c *gc.C) {
+	stanzas, err := debinterfaces.ParseSource("testdata/ifupdown-examples", nil, s.expander)
+	c.Assert(err, gc.IsNil)
+	input := format(stanzas)
+	s.assertBridge(input, input, "br-", c, "non-existent-iface")
+}
+
+func (s *BridgeSuite) TestBridgeAlias(c *gc.C) {
+	input := `
+auto eth0
+iface eth0 inet static
+    gateway 10.14.0.1
+    address 10.14.0.102/24
+
+auto eth0:1
+iface eth0:1 inet static
+    address 1.2.3.5`
+
+	expected := `
+auto eth0
+iface eth0 inet manual
+
+auto br-eth0:1
+iface br-eth0:1 inet static
+    address 1.2.3.5
+
+auto br-eth0
+iface br-eth0 inet static
+    gateway 10.14.0.1
+    address 10.14.0.102/24
+    bridge_ports eth0`
+	s.assertBridge(input, expected[1:], "br-", c, "eth0", "eth0:1")
+}
+
+func (s *BridgeSuite) TestBridgeMultipleInterfaces(c *gc.C) {
+	input := `
+auto enp1s0f3
+iface enp1s0f3 inet static
+  address 192.168.1.64/24
+  gateway 192.168.1.254
+  dns-nameservers 192.168.1.254
+  dns-search home
+
+iface enp1s0f3 inet6 dhcp`
+
+	expected := `
+auto enp1s0f3
+iface enp1s0f3 inet manual
+
+iface enp1s0f3 inet6 manual
+
+auto br-enp1s0f3
+iface br-enp1s0f3 inet static
+    address 192.168.1.64/24
+    gateway 192.168.1.254
+    dns-nameservers 192.168.1.254
+    dns-search home
+    bridge_ports enp1s0f3
+
+iface br-enp1s0f3 inet6 dhcp
+    bridge_ports enp1s0f3`
+	s.assertBridge(input, expected[1:], "br-", c, "enp1s0f3")
+}
+
+func (s *BridgeSuite) TestSourceStanzaWithRelativeFilenames(c *gc.C) {
+	stanzas, err := debinterfaces.Parse("testdata/TestInputSourceStanza/interfaces")
+	c.Assert(err, gc.IsNil)
+	c.Assert(stanzas, gc.HasLen, 3)
+	bridged := debinterfaces.Bridge("br-", stanzas, "eth0")
+
+	expected := `
+auto lo
+iface lo inet loopback
+
+auto eth0
+iface eth0 inet manual
+
+auto eth1
+iface eth1 inet static
+    address 192.168.1.64
+    dns-nameservers 192.168.1.254
+
+auto eth2
+iface eth2 inet manual
+
+auto br-eth0
+iface br-eth0 inet dhcp
+    bridge_ports eth0`
+
+	c.Assert(debinterfaces.FormatStanzas(debinterfaces.FlattenStanzas(bridged), 4), gc.Equals, expected[1:])
+}
+
+func (s *BridgeSuite) TestSourceDirectoryStanzaWithRelativeFilenames(c *gc.C) {
+	stanzas, err := debinterfaces.Parse("testdata/TestInputSourceDirectoryStanza/interfaces")
+	c.Assert(err, gc.IsNil)
+	c.Assert(stanzas, gc.HasLen, 3)
+
+	bridged := debinterfaces.Bridge("br-", stanzas, "eth3")
+
+	expected := `
+auto lo
+iface lo inet loopback
+
+auto eth3
+iface eth3 inet manual
+
+auto br-eth3
+iface br-eth3 inet static
+    address 192.168.1.128
+    dns-nameservers 192.168.1.254
+    bridge_ports eth3`
+
+	c.Assert(debinterfaces.FormatStanzas(debinterfaces.FlattenStanzas(bridged), 4), gc.Equals, expected[1:])
+}

--- a/network/debinterfaces/export_test.go
+++ b/network/debinterfaces/export_test.go
@@ -1,0 +1,10 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package debinterfaces
+
+var (
+	NewWordExpander = newWordExpander
+	ParseSource     = parseSource
+	RunCommand      = runCommand
+)

--- a/network/debinterfaces/format.go
+++ b/network/debinterfaces/format.go
@@ -1,0 +1,75 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package debinterfaces
+
+import (
+	"bytes"
+	"strings"
+)
+
+// FlattenStanzas flattens all stanzas, and recursively for all
+// 'source' and 'source-directory' stanzas, returning a single slice.
+func FlattenStanzas(stanzas []Stanza) []Stanza {
+	result := make([]Stanza, 0)
+
+	for _, s := range stanzas {
+		switch v := s.(type) {
+		case SourceStanza:
+			result = append(result, v.Stanzas...)
+		case SourceDirectoryStanza:
+			result = append(result, v.Stanzas...)
+		default:
+			result = append(result, v)
+		}
+	}
+
+	return result
+}
+
+// FormatStanzas returns a string representing all stanzas
+// definitions, recursively expanding stanzas found in both source and
+// source-directory definitions.
+func FormatStanzas(stanzas []Stanza, count int) string {
+	var buffer bytes.Buffer
+
+	for i, s := range stanzas {
+		buffer.WriteString(FormatDefinition(s.Definition(), count))
+		buffer.WriteString("\n")
+		// If the current stanza is 'auto' and the next one is
+		// 'iface' then don't add an additional blank line
+		// between them.
+		if _, ok := stanzas[i].(AutoStanza); ok {
+			if i+1 < len(stanzas) {
+				if _, ok := stanzas[i+1].(IfaceStanza); !ok {
+					buffer.WriteString("\n")
+				}
+			}
+		} else if i+1 < len(stanzas) {
+			buffer.WriteString("\n")
+		}
+	}
+
+	return strings.TrimSuffix(buffer.String(), "\n")
+}
+
+// FormatDefinition formats the complete stanza, indenting any options
+// with count leading spaces.
+func FormatDefinition(definition []string, count int) string {
+	var buffer bytes.Buffer
+
+	spacer := strings.Repeat(" ", count)
+
+	for i, d := range definition {
+		if i == 0 {
+			buffer.WriteString(d)
+			buffer.WriteString("\n")
+		} else {
+			buffer.WriteString(spacer)
+			buffer.WriteString(d)
+			buffer.WriteString("\n")
+		}
+	}
+
+	return strings.TrimSuffix(buffer.String(), "\n")
+}

--- a/network/debinterfaces/package_test.go
+++ b/network/debinterfaces/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package debinterfaces_test
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func TestAll(t *testing.T) {
+	gc.TestingT(t)
+}

--- a/network/debinterfaces/parser.go
+++ b/network/debinterfaces/parser.go
@@ -1,0 +1,422 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package debinterfaces
+
+import (
+	"io/ioutil"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+const (
+	unknown kind = iota
+	allow
+	auto
+	iface
+	mapping
+	noAutoDown
+	noscripts
+	source
+	sourceDirectory
+)
+
+var validSourceDirectoryFilename = regexp.MustCompile(`^[a-zA-Z0-9_-]+$`)
+
+type parser struct {
+	scanner  *lineScanner
+	expander WordExpander
+}
+
+// Type is the set of lexical tokens that represent top-level stanza
+// identifiers based on the description in the interfaces(5) man page.
+type kind int
+
+// ParseError represents an error when parsing a line of a
+// Debian-style interfaces definition. This only covers top-level
+// definitions.
+type ParseError struct {
+	Filename string
+	Line     string
+	LineNum  int
+	Message  string
+}
+
+// Error returns the parsing error.
+func (p *ParseError) Error() string {
+	return p.Message
+}
+
+func newParseError(s *lineScanner, msg string) *ParseError {
+	return &ParseError{
+		Filename: s.filename,
+		Line:     s.line,
+		LineNum:  s.n,
+		Message:  msg,
+	}
+}
+
+func (p parser) newStanzaBase() *stanza {
+	return &stanza{
+		location: Location{
+			Filename: p.scanner.filename,
+			LineNum:  p.scanner.n,
+		},
+		definition: p.scanner.line,
+	}
+}
+
+func (p parser) parseOptions() []string {
+	options := []string{}
+	for {
+		if !p.scanner.nextLine() {
+			return options
+		}
+		line := p.scanner.line
+		if stanzaType(line) != unknown {
+			// go back a line
+			p.scanner.n--
+			p.scanner.line = strings.TrimSpace(p.scanner.lines[p.scanner.n])
+			return options
+		}
+		options = append(options, line)
+	}
+}
+
+func (p parser) parseAllowStanza() (*AllowStanza, error) {
+	words := strings.Fields(p.scanner.line)
+	if len(words) < 2 {
+		return nil, newParseError(p.scanner, "missing device name")
+	}
+	return &AllowStanza{
+		stanza:      *p.newStanzaBase(),
+		DeviceNames: words[1:],
+	}, nil
+}
+
+func (p parser) parseAutoStanza() (*AutoStanza, error) {
+	words := strings.Fields(p.scanner.line)
+	if len(words) < 2 {
+		return nil, newParseError(p.scanner, "missing device name")
+	}
+	return &AutoStanza{
+		stanza:      *p.newStanzaBase(),
+		DeviceNames: words[1:],
+	}, nil
+}
+
+func (p parser) parseIfaceStanza() (*IfaceStanza, error) {
+	s := p.newStanzaBase()
+	words := strings.Fields(p.scanner.line)
+
+	if len(words) < 2 {
+		return nil, newParseError(p.scanner, "missing device name")
+	}
+
+	options := p.parseOptions()
+
+	return &IfaceStanza{
+		stanza:              *s,
+		DeviceName:          words[1],
+		HasBondMasterOption: hasBondMasterOption(options),
+		HasBondOptions:      hasBondOptions(options),
+		IsAlias:             isAlias(words[1]),
+		IsBridged:           hasBridgePortsOption(options),
+		IsVLAN:              isVLAN(options),
+		Options:             options,
+	}, nil
+}
+
+func (p parser) parseMappingStanza() (*MappingStanza, error) {
+	s := p.newStanzaBase()
+	words := strings.Fields(p.scanner.line)
+	if len(words) < 2 {
+		return nil, newParseError(p.scanner, "missing device name")
+	}
+
+	options := p.parseOptions()
+
+	return &MappingStanza{
+		stanza:      *s,
+		DeviceNames: words[1:],
+		Options:     options,
+	}, nil
+}
+
+func (p parser) parseNoAutoDownStanza() (*NoAutoDownStanza, error) {
+	words := strings.Fields(p.scanner.line)
+	if len(words) < 2 {
+		return nil, newParseError(p.scanner, "missing device name")
+	}
+	return &NoAutoDownStanza{
+		stanza:      *p.newStanzaBase(),
+		DeviceNames: words[1:],
+	}, nil
+}
+
+func (p parser) parseNoScriptsStanza() (*NoScriptsStanza, error) {
+	words := strings.Fields(p.scanner.line)
+	if len(words) < 2 {
+		return nil, newParseError(p.scanner, "missing device name")
+	}
+	return &NoScriptsStanza{
+		stanza:      *p.newStanzaBase(),
+		DeviceNames: words[1:],
+	}, nil
+}
+
+func (p parser) parseSourceStanza() (*SourceStanza, error) {
+	words := strings.Fields(p.scanner.line)
+	if len(words) < 2 {
+		return nil, newParseError(p.scanner, "missing filename")
+	}
+
+	pattern := words[1]
+
+	if !strings.HasPrefix(words[1], "/") {
+		pattern = filepath.Join(filepath.Dir(p.scanner.filename), words[1])
+	}
+
+	files, err := p.expander.Expand(pattern)
+
+	if err != nil {
+		return nil, newParseError(p.scanner, err.Error())
+	}
+
+	srcStanza := &SourceStanza{
+		stanza:  *p.newStanzaBase(),
+		Path:    words[1],
+		Sources: []string{},
+		Stanzas: []Stanza{},
+	}
+
+	for _, file := range files {
+		stanzas, err := parseSource(file, nil, p.expander)
+		if err != nil {
+			return nil, err
+		}
+		srcStanza.Sources = append(srcStanza.Sources, file)
+		srcStanza.Stanzas = append(srcStanza.Stanzas, stanzas...)
+	}
+
+	return srcStanza, nil
+}
+
+func (p parser) parseSourceDirectoryStanza() (*SourceDirectoryStanza, error) {
+	words := strings.Fields(p.scanner.line)
+	if len(words) < 2 {
+		return nil, newParseError(p.scanner, "missing directory")
+	}
+
+	expansions, err := p.expander.Expand(words[1])
+
+	if err != nil {
+		// We want file/line number information so use the
+		// Expand() error as the message but let
+		// newParseError() record on which line it happened.
+		return nil, newParseError(p.scanner, err.Error())
+	}
+
+	var dir = words[1]
+
+	if len(expansions) > 0 {
+		dir = expansions[0]
+	}
+
+	if !strings.HasPrefix(dir, "/") {
+		// find directory relative to current input file
+		dir = filepath.Join(filepath.Dir(p.scanner.filename), dir)
+	}
+
+	files, err := ioutil.ReadDir(dir)
+
+	if err != nil {
+		return nil, newParseError(p.scanner, err.Error())
+	}
+
+	dirStanza := &SourceDirectoryStanza{
+		stanza:  *p.newStanzaBase(),
+		Path:    words[1],
+		Sources: []string{},
+		Stanzas: []Stanza{},
+	}
+
+	for _, file := range files {
+		if !validSourceDirectoryFilename.MatchString(file.Name()) {
+			continue
+		}
+		path := filepath.Join(dir, file.Name())
+		stanzas, err := parseSource(path, nil, p.expander)
+		if err != nil {
+			return nil, err
+		}
+		dirStanza.Sources = append(dirStanza.Sources, path)
+		dirStanza.Stanzas = append(dirStanza.Stanzas, stanzas...)
+	}
+
+	return dirStanza, nil
+}
+
+func (p parser) parseInput() ([]Stanza, error) {
+	stanzas := []Stanza{}
+
+	for {
+		if !p.scanner.nextLine() {
+			break
+		}
+
+		switch stanzaType(p.scanner.line) {
+		case allow:
+			allowStanza, err := p.parseAllowStanza()
+			if err != nil {
+				return nil, err
+			}
+			stanzas = append(stanzas, *allowStanza)
+		case auto:
+			autoStanza, err := p.parseAutoStanza()
+			if err != nil {
+				return nil, err
+			}
+			stanzas = append(stanzas, *autoStanza)
+		case iface:
+			ifaceStanza, err := p.parseIfaceStanza()
+			if err != nil {
+				return nil, err
+			}
+			stanzas = append(stanzas, *ifaceStanza)
+		case mapping:
+			mappingStanza, err := p.parseMappingStanza()
+			if err != nil {
+				return nil, err
+			}
+			stanzas = append(stanzas, *mappingStanza)
+		case noAutoDown:
+			noAutoDownStanza, err := p.parseNoAutoDownStanza()
+			if err != nil {
+				return nil, err
+			}
+			stanzas = append(stanzas, *noAutoDownStanza)
+		case noscripts:
+			noScriptsStanza, err := p.parseNoScriptsStanza()
+			if err != nil {
+				return nil, err
+			}
+			stanzas = append(stanzas, *noScriptsStanza)
+		case source:
+			sourceStanza, err := p.parseSourceStanza()
+			if err != nil {
+				return nil, err
+			}
+			stanzas = append(stanzas, *sourceStanza)
+		case sourceDirectory:
+			sourceDirectoryStanza, err := p.parseSourceDirectoryStanza()
+			if err != nil {
+				return nil, err
+			}
+			stanzas = append(stanzas, *sourceDirectoryStanza)
+		default:
+			return nil, newParseError(p.scanner, "misplaced option")
+		}
+	}
+
+	return stanzas, nil
+}
+
+func stanzaType(definition string) kind {
+	words := strings.Fields(definition)
+	if len(words) > 0 {
+		switch words[0] {
+		case "auto":
+			return auto
+		case "iface":
+			return iface
+		case "mapping":
+			return mapping
+		case "no-auto-down":
+			return noAutoDown
+		case "no-scripts":
+			return noscripts
+		case "source":
+			return source
+		case "source-directory":
+			return sourceDirectory
+		}
+		if strings.HasPrefix(words[0], "allow-") {
+			return allow
+		}
+	}
+	return unknown
+}
+
+// If input is not nil, parseSource parses the source from input; the
+// filename is only used when recording position information. The type
+// of the argument for the input parameter must be string, []byte, or
+// io.Reader. If input == nil, Parse parses the file specified by
+// filename.
+//
+// If the source could not be read, then Stanzas is nil and the error
+// indicates the specific failure.
+func parseSource(filename string, src interface{}, wordExpander WordExpander) ([]Stanza, error) {
+	scanner, err := newScanner(filename, src)
+
+	if err != nil {
+		return nil, err
+	}
+
+	p := parser{
+		expander: wordExpander,
+		scanner:  scanner,
+	}
+
+	return p.parseInput()
+}
+
+func hasOptionIdent(ident string, options []string) bool {
+	for _, o := range options {
+		words := strings.Fields(o)
+		if len(words) > 0 && words[0] == ident {
+			return true
+		}
+	}
+	return false
+}
+
+func hasOptionPrefix(prefix string, options []string) bool {
+	for _, o := range options {
+		words := strings.Fields(o)
+		for _, w := range words {
+			if strings.HasPrefix(w, prefix) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func hasBridgePortsOption(options []string) bool {
+	return hasOptionIdent("bridge_ports", options)
+}
+
+func isVLAN(options []string) bool {
+	return hasOptionIdent("vlan-raw-device", options)
+}
+
+func hasBondOptions(options []string) bool {
+	return hasOptionPrefix("bond-", options)
+}
+
+func hasBondMasterOption(options []string) bool {
+	return hasOptionIdent("bond-master", options)
+}
+
+func isAlias(name string) bool {
+	return strings.Contains(name, ":")
+}
+
+// Parse parses the definitions of a single Debian style network
+// interfaces(5) file and returns the corresponding set of stanza
+// definitions.
+func Parse(filename string) ([]Stanza, error) {
+	return parseSource(filename, nil, newWordExpander())
+}

--- a/network/debinterfaces/parser_test.go
+++ b/network/debinterfaces/parser_test.go
@@ -1,0 +1,727 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package debinterfaces_test
+
+import (
+	"fmt"
+	"io/ioutil"
+	"path/filepath"
+	"runtime"
+
+	"github.com/juju/testing"
+	"github.com/pkg/errors"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/network/debinterfaces"
+)
+
+type ParserSuite struct {
+	testing.IsolationSuite
+
+	expander debinterfaces.WordExpander
+}
+
+var _ = gc.Suite(&ParserSuite{})
+
+// Ensure wordExpanderWithError is a WordExpander
+var _ debinterfaces.WordExpander = (*wordExpanderErrors)(nil)
+
+type wordExpanderErrors struct {
+	errmsg string
+}
+
+func wordExpanderWithError(errmsg string) debinterfaces.WordExpander {
+	return &wordExpanderErrors{errmsg: errmsg}
+}
+
+func (w *wordExpanderErrors) Expand(s string) ([]string, error) {
+	return nil, errors.Errorf("word expansion failed: %s", w.errmsg)
+}
+
+func (s *ParserSuite) SetUpTest(c *gc.C) {
+	s.expander = debinterfaces.NewWordExpander()
+}
+
+func (s *ParserSuite) TestNilInput(c *gc.C) {
+	interfaces, err := debinterfaces.ParseSource("", nil, s.expander)
+	c.Assert(interfaces, gc.IsNil)
+	c.Check(err, gc.ErrorMatches, "filename and input is nil")
+}
+
+func (s *ParserSuite) TestNilInputAndNoFilename(c *gc.C) {
+	stanzas, err := debinterfaces.ParseSource("", "", s.expander)
+	c.Assert(err, gc.IsNil)
+	c.Check(stanzas, gc.HasLen, 0)
+}
+
+func (s *ParserSuite) TestUnsupportedInputType(c *gc.C) {
+	stanzas, err := debinterfaces.ParseSource("", []float64{3.141}, s.expander)
+	c.Assert(err, gc.ErrorMatches, "invalid source type")
+	c.Check(stanzas, gc.IsNil)
+}
+
+func (s *ParserSuite) TestFilenameEmpty(c *gc.C) {
+	emptyFile := filepath.Join(c.MkDir(), "TestFilenameEmpty")
+	err := ioutil.WriteFile(emptyFile, []byte(""), 0644)
+	c.Assert(err, gc.IsNil)
+	stanzas, err := debinterfaces.ParseSource(emptyFile, nil, s.expander)
+	c.Assert(err, gc.IsNil)
+	c.Check(stanzas, gc.HasLen, 0)
+}
+
+func (s *ParserSuite) TestParseErrorObject(c *gc.C) {
+	content := `hunky dory`
+	_, err := debinterfaces.ParseSource("", content, s.expander)
+	c.Assert(err, gc.NotNil)
+	_, parseError := err.(*debinterfaces.ParseError)
+	c.Assert(parseError, gc.NotNil)
+	c.Assert(err, gc.ErrorMatches, "misplaced option")
+}
+
+func (s *ParserSuite) TestCommentsAndBlankLinesOnly(c *gc.C) {
+	content := `
+
+# Comment 1.
+
+# Comment 2, after empty line.
+
+  # An indented comment, followed by a line with leading whitespace
+
+`
+	stanzas, err := debinterfaces.ParseSource("", content, s.expander)
+	c.Assert(err, gc.IsNil)
+	c.Assert(stanzas, gc.HasLen, 0)
+}
+
+func (s *ParserSuite) TestAllowStanzaMissingArg(c *gc.C) {
+	_, err := debinterfaces.ParseSource("", "allow-hotplug", s.expander)
+	c.Assert(err, gc.NotNil)
+	c.Check(err, gc.ErrorMatches, "missing device name")
+}
+
+func (s *ParserSuite) TestAutoStanzaMissingArg(c *gc.C) {
+	_, err := debinterfaces.ParseSource("", "auto", s.expander)
+	c.Assert(err, gc.NotNil)
+	c.Check(err, gc.ErrorMatches, "missing device name")
+}
+
+func (s *ParserSuite) TestIfaceStanzaMissingArg(c *gc.C) {
+	_, err := debinterfaces.ParseSource("", "iface", s.expander)
+	c.Assert(err, gc.NotNil)
+	c.Check(err, gc.ErrorMatches, "missing device name")
+}
+
+func (s *ParserSuite) TestMappingStanzaMissingArg(c *gc.C) {
+	_, err := debinterfaces.ParseSource("", "mapping", s.expander)
+	c.Assert(err, gc.NotNil)
+	c.Check(err, gc.ErrorMatches, "missing device name")
+}
+
+func (s *ParserSuite) TestNoAutoDownStanzaMissingArg(c *gc.C) {
+	_, err := debinterfaces.ParseSource("", "no-auto-down", s.expander)
+	c.Assert(err, gc.NotNil)
+	c.Check(err, gc.ErrorMatches, "missing device name")
+}
+
+func (s *ParserSuite) TestNoScriptsStanzaMissingArg(c *gc.C) {
+	_, err := debinterfaces.ParseSource("", "no-scripts", s.expander)
+	c.Assert(err, gc.NotNil)
+	c.Check(err, gc.ErrorMatches, "missing device name")
+}
+
+func (s *ParserSuite) TestSourceStanzaMissingArg(c *gc.C) {
+	_, err := debinterfaces.ParseSource("", "source", s.expander)
+	c.Assert(err, gc.NotNil)
+	c.Check(err, gc.ErrorMatches, "missing filename")
+}
+
+func (s *ParserSuite) TestSourceDirectoryStanzaMissingArg(c *gc.C) {
+	_, err := debinterfaces.ParseSource("", "source-directory", s.expander)
+	c.Assert(err, gc.NotNil)
+	c.Check(err, gc.ErrorMatches, "missing directory")
+}
+
+func (s *ParserSuite) TestAllowStanza(c *gc.C) {
+	definition := "allow-hotplug eth0 eth1 eth2"
+	stanzas, err := debinterfaces.ParseSource("", definition, s.expander)
+	c.Assert(err, gc.IsNil)
+	c.Assert(stanzas, gc.HasLen, 1)
+	c.Assert(stanzas[0], gc.FitsTypeOf, debinterfaces.AllowStanza{})
+	allow := stanzas[0].(debinterfaces.AllowStanza)
+	c.Check(allow.Location().Filename, gc.Equals, "")
+	c.Check(allow.Location().LineNum, gc.Equals, 1)
+	c.Assert(allow.Definition(), gc.HasLen, 1)
+	c.Check(allow.Definition()[0], gc.Equals, definition)
+	c.Check(allow.DeviceNames, gc.DeepEquals, []string{"eth0", "eth1", "eth2"})
+}
+
+func (s *ParserSuite) TestAutoStanza(c *gc.C) {
+	definition := "auto eth0 eth1 eth2"
+	stanzas, err := debinterfaces.ParseSource("", definition, s.expander)
+	c.Assert(err, gc.IsNil)
+	c.Assert(stanzas, gc.HasLen, 1)
+	c.Assert(stanzas[0], gc.FitsTypeOf, debinterfaces.AutoStanza{})
+	auto := stanzas[0].(debinterfaces.AutoStanza)
+	c.Check(auto.Location().Filename, gc.Equals, "")
+	c.Check(auto.Location().LineNum, gc.Equals, 1)
+	c.Assert(auto.Definition(), gc.HasLen, 1)
+	c.Check(auto.Definition()[0], gc.Equals, definition)
+	c.Check(auto.DeviceNames, gc.DeepEquals, []string{"eth0", "eth1", "eth2"})
+}
+
+func (s *ParserSuite) TestWithIfaceStanzaAndOneOption(c *gc.C) {
+	content := `
+iface eth0 inet manual
+  # A comment.
+  address 192.168.1.254/24 `
+	stanzas, err := debinterfaces.ParseSource("", content, s.expander)
+	c.Assert(err, gc.IsNil)
+	c.Assert(stanzas, gc.HasLen, 1)
+	c.Assert(stanzas[0], gc.FitsTypeOf, debinterfaces.IfaceStanza{})
+	iface := stanzas[0].(debinterfaces.IfaceStanza)
+	c.Assert(iface.Definition(), gc.HasLen, 2)
+	c.Check(iface.Definition()[0], gc.Equals, "iface eth0 inet manual")
+	c.Check(iface.Definition()[1], gc.Equals, "address 192.168.1.254/24")
+	c.Check(iface.Location().Filename, gc.Equals, "")
+	c.Check(iface.Location().LineNum, gc.Equals, 2)
+	c.Check(iface.Options, gc.HasLen, 1)
+	c.Check(iface.Options[0], gc.Equals, "address 192.168.1.254/24")
+	c.Check(iface.HasBondMasterOption, gc.Equals, false)
+	c.Check(iface.HasBondOptions, gc.Equals, false)
+	c.Check(iface.IsAlias, gc.Equals, false)
+	c.Check(iface.IsBridged, gc.Equals, false)
+	c.Check(iface.IsVLAN, gc.Equals, false)
+}
+
+func (s *ParserSuite) TestWithIfaceStanzaAndMultipleOptions(c *gc.C) {
+	content := `
+iface eth0 inet manual
+  # A comment.
+  address 192.168.1.254/24
+  dns-nameservers 8.8.8.8
+  # Another comment.
+  dns-search ubuntu.com
+  # An ending comment`
+	stanzas, err := debinterfaces.ParseSource("", content, s.expander)
+	c.Assert(err, gc.IsNil)
+	c.Assert(stanzas, gc.HasLen, 1)
+	c.Assert(stanzas[0], gc.FitsTypeOf, debinterfaces.IfaceStanza{})
+	iface := stanzas[0].(debinterfaces.IfaceStanza)
+	c.Assert(iface.Definition(), gc.HasLen, 4)
+	c.Check(iface.Definition()[0], gc.Equals, "iface eth0 inet manual")
+	c.Check(iface.Definition()[1], gc.Equals, "address 192.168.1.254/24")
+	c.Check(iface.Definition()[2], gc.Equals, "dns-nameservers 8.8.8.8")
+	c.Check(iface.Definition()[3], gc.Equals, "dns-search ubuntu.com")
+	c.Check(iface.Location().Filename, gc.Equals, "")
+	c.Check(iface.Location().LineNum, gc.Equals, 2)
+	c.Assert(iface.Options, gc.HasLen, 3)
+	c.Check(iface.Options[0], gc.Equals, "address 192.168.1.254/24")
+	c.Check(iface.Options[1], gc.Equals, "dns-nameservers 8.8.8.8")
+	c.Check(iface.Options[2], gc.Equals, "dns-search ubuntu.com")
+	c.Check(iface.HasBondMasterOption, gc.Equals, false)
+	c.Check(iface.HasBondOptions, gc.Equals, false)
+	c.Check(iface.IsAlias, gc.Equals, false)
+	c.Check(iface.IsBridged, gc.Equals, false)
+	c.Check(iface.IsVLAN, gc.Equals, false)
+}
+
+func (s *ParserSuite) TestWithIfaceStanzaAndNoOptions(c *gc.C) {
+	content := `
+iface eth0 inet manual
+# A comment.`
+	stanzas, err := debinterfaces.ParseSource("", content, s.expander)
+	c.Assert(err, gc.IsNil)
+	c.Assert(stanzas, gc.HasLen, 1)
+	c.Assert(stanzas[0], gc.FitsTypeOf, debinterfaces.IfaceStanza{})
+	iface := stanzas[0].(debinterfaces.IfaceStanza)
+	c.Assert(iface.Definition(), gc.HasLen, 1)
+	c.Check(iface.Definition()[0], gc.Equals, "iface eth0 inet manual")
+	c.Check(iface.Location().Filename, gc.Equals, "")
+	c.Check(iface.Location().LineNum, gc.Equals, 2)
+	c.Check(iface.Options, gc.HasLen, 0)
+	c.Check(iface.HasBondMasterOption, gc.Equals, false)
+	c.Check(iface.HasBondOptions, gc.Equals, false)
+	c.Check(iface.IsAlias, gc.Equals, false)
+	c.Check(iface.IsBridged, gc.Equals, false)
+	c.Check(iface.IsVLAN, gc.Equals, false)
+}
+
+func (s *ParserSuite) TestAutoStanzaFollowedByIfaceStanza(c *gc.C) {
+	content := `
+auto eth0
+
+iface eth0 inet static
+  address 192.168.1.254/24
+  gateway 192.168.1.1`
+	stanzas, err := debinterfaces.ParseSource("", content, s.expander)
+	c.Assert(err, gc.IsNil)
+	c.Assert(stanzas, gc.HasLen, 2)
+	c.Assert(stanzas[0], gc.FitsTypeOf, debinterfaces.AutoStanza{})
+	c.Assert(stanzas[1], gc.FitsTypeOf, debinterfaces.IfaceStanza{})
+
+	auto := stanzas[0].(debinterfaces.AutoStanza)
+	c.Assert(auto.Definition(), gc.HasLen, 1)
+	c.Check(auto.Definition()[0], gc.Equals, "auto eth0")
+	c.Check(auto.Location().Filename, gc.Equals, "")
+	c.Check(auto.Location().LineNum, gc.Equals, 2)
+
+	iface := stanzas[1].(debinterfaces.IfaceStanza)
+	c.Assert(iface.Definition(), gc.HasLen, 3)
+	c.Check(iface.Definition()[0], gc.Equals, "iface eth0 inet static")
+	c.Check(iface.Definition()[1], gc.Equals, "address 192.168.1.254/24")
+	c.Check(iface.Definition()[2], gc.Equals, "gateway 192.168.1.1")
+	c.Check(iface.Location().Filename, gc.Equals, "")
+	c.Check(iface.Location().LineNum, gc.Equals, 4)
+	c.Assert(iface.Options, gc.HasLen, 2)
+	c.Check(iface.Options[0], gc.Equals, "address 192.168.1.254/24")
+	c.Check(iface.Options[1], gc.Equals, "gateway 192.168.1.1")
+	c.Check(iface.HasBondMasterOption, gc.Equals, false)
+	c.Check(iface.HasBondOptions, gc.Equals, false)
+	c.Check(iface.IsAlias, gc.Equals, false)
+	c.Check(iface.IsBridged, gc.Equals, false)
+	c.Check(iface.IsVLAN, gc.Equals, false)
+}
+
+func (s *ParserSuite) TestVLANIfaceStanza(c *gc.C) {
+	content := `
+iface eth0.100 inet static
+  address 192.168.1.254/24
+  vlan-raw-device eth1`
+	stanzas, err := debinterfaces.ParseSource("", content, s.expander)
+	c.Assert(err, gc.IsNil)
+	c.Assert(stanzas, gc.HasLen, 1)
+	c.Assert(stanzas[0], gc.FitsTypeOf, debinterfaces.IfaceStanza{})
+
+	iface := stanzas[0].(debinterfaces.IfaceStanza)
+	c.Assert(iface.Definition(), gc.HasLen, 3)
+	c.Check(iface.Definition()[0], gc.Equals, "iface eth0.100 inet static")
+	c.Check(iface.Definition()[1], gc.Equals, "address 192.168.1.254/24")
+	c.Check(iface.Definition()[2], gc.Equals, "vlan-raw-device eth1")
+	c.Check(iface.Location().Filename, gc.Equals, "")
+	c.Check(iface.Location().LineNum, gc.Equals, 2)
+	c.Assert(iface.Options, gc.HasLen, 2)
+	c.Check(iface.Options[0], gc.Equals, "address 192.168.1.254/24")
+	c.Check(iface.Options[1], gc.Equals, "vlan-raw-device eth1")
+	c.Check(iface.HasBondMasterOption, gc.Equals, false)
+	c.Check(iface.HasBondOptions, gc.Equals, false)
+	c.Check(iface.IsAlias, gc.Equals, false)
+	c.Check(iface.IsBridged, gc.Equals, false)
+	c.Check(iface.IsVLAN, gc.Equals, true)
+}
+
+func (s *ParserSuite) TestBondedIfaceStanza(c *gc.C) {
+	content := `
+auto eth0
+iface eth0 inet manual
+    bond-lacp_rate slow
+    bond-xmit_hash_policy layer2
+    bond-miimon 100
+    bond-master bond0
+    bond-mode active-backup
+
+auto eth1
+iface eth1 inet manual
+    bond-lacp_rate slow
+    bond-xmit_hash_policy layer2
+    bond-miimon 100
+    bond-master bond0
+    mtu 1500
+    bond-mode active-backup
+
+auto bond0
+iface bond0 inet dhcp
+    bond-lacp_rate slow
+    bond-xmit_hash_policy layer2
+    bond-miimon 100
+    mtu 1500
+    bond-mode active-backup
+    hwaddress 52:54:00:1c:f1:5b
+    bond-slaves none`
+	stanzas, err := debinterfaces.ParseSource("", content, s.expander)
+	c.Assert(err, gc.IsNil)
+	c.Assert(stanzas, gc.HasLen, 6)
+	c.Assert(stanzas[0], gc.FitsTypeOf, debinterfaces.AutoStanza{})
+	c.Assert(stanzas[1], gc.FitsTypeOf, debinterfaces.IfaceStanza{})
+	c.Assert(stanzas[2], gc.FitsTypeOf, debinterfaces.AutoStanza{})
+	c.Assert(stanzas[3], gc.FitsTypeOf, debinterfaces.IfaceStanza{})
+	c.Assert(stanzas[4], gc.FitsTypeOf, debinterfaces.AutoStanza{})
+	c.Assert(stanzas[5], gc.FitsTypeOf, debinterfaces.IfaceStanza{})
+
+	iface0 := stanzas[1].(debinterfaces.IfaceStanza)
+	c.Assert(iface0.Definition(), gc.HasLen, 6)
+	c.Check(iface0.Definition()[0], gc.Equals, "iface eth0 inet manual")
+	c.Check(iface0.Location().Filename, gc.Equals, "")
+	c.Check(iface0.Location().LineNum, gc.Equals, 3)
+	c.Check(iface0.Options, gc.HasLen, 5)
+	c.Check(iface0.HasBondMasterOption, gc.Equals, true)
+	c.Check(iface0.HasBondOptions, gc.Equals, true)
+	c.Check(iface0.IsAlias, gc.Equals, false)
+	c.Check(iface0.IsBridged, gc.Equals, false)
+	c.Check(iface0.IsVLAN, gc.Equals, false)
+
+	iface1 := stanzas[3].(debinterfaces.IfaceStanza)
+	c.Assert(iface1.Definition(), gc.HasLen, 7)
+	c.Check(iface1.Definition()[0], gc.Equals, "iface eth1 inet manual")
+	c.Check(iface1.Location().Filename, gc.Equals, "")
+	c.Check(iface1.Location().LineNum, gc.Equals, 11)
+	c.Check(iface1.Options, gc.HasLen, 6)
+	c.Check(iface1.HasBondMasterOption, gc.Equals, true)
+	c.Check(iface1.HasBondOptions, gc.Equals, true)
+	c.Check(iface1.IsAlias, gc.Equals, false)
+	c.Check(iface1.IsBridged, gc.Equals, false)
+	c.Check(iface1.IsVLAN, gc.Equals, false)
+
+	iface2 := stanzas[5].(debinterfaces.IfaceStanza)
+	c.Assert(iface2.Definition(), gc.HasLen, 8)
+	c.Check(iface2.Definition()[0], gc.Equals, "iface bond0 inet dhcp")
+	c.Check(iface2.Location().Filename, gc.Equals, "")
+	c.Check(iface2.Location().LineNum, gc.Equals, 20)
+	c.Check(iface2.Options, gc.HasLen, 7)
+	c.Check(iface2.HasBondOptions, gc.Equals, true)
+	c.Check(iface2.HasBondMasterOption, gc.Equals, false)
+	c.Check(iface2.IsAlias, gc.Equals, false)
+	c.Check(iface2.IsBridged, gc.Equals, false)
+	c.Check(iface2.IsVLAN, gc.Equals, false)
+}
+
+func (s *ParserSuite) TestMappingStanza(c *gc.C) {
+	content := `
+mapping eth0 eth1
+  script /path/to/get-mac-address.sh
+  map 11:22:33:44:55:66 lan
+  map AA:BB:CC:DD:EE:FF internet`
+	stanzas, err := debinterfaces.ParseSource("", content, s.expander)
+	c.Assert(err, gc.IsNil)
+	c.Assert(stanzas, gc.HasLen, 1)
+	c.Assert(stanzas[0], gc.FitsTypeOf, debinterfaces.MappingStanza{})
+
+	mapping := stanzas[0].(debinterfaces.MappingStanza)
+	c.Assert(mapping.Definition(), gc.HasLen, 4)
+	c.Check(mapping.Definition()[0], gc.Equals, "mapping eth0 eth1")
+	c.Check(mapping.Location().Filename, gc.Equals, "")
+	c.Check(mapping.Location().LineNum, gc.Equals, 2)
+	c.Check(mapping.DeviceNames, gc.DeepEquals, []string{"eth0", "eth1"})
+	c.Assert(mapping.Options, gc.HasLen, 3)
+	c.Check(mapping.Options[0], gc.Equals, "script /path/to/get-mac-address.sh")
+	c.Check(mapping.Options[1], gc.Equals, "map 11:22:33:44:55:66 lan")
+	c.Check(mapping.Options[2], gc.Equals, "map AA:BB:CC:DD:EE:FF internet")
+}
+
+func (s *ParserSuite) TestNoAutoDownStanza(c *gc.C) {
+	content := `no-auto-down eth0 eth1`
+	stanzas, err := debinterfaces.ParseSource("", content, s.expander)
+	c.Assert(err, gc.IsNil)
+	c.Assert(stanzas, gc.HasLen, 1)
+	c.Assert(stanzas[0], gc.FitsTypeOf, debinterfaces.NoAutoDownStanza{})
+
+	noautodown := stanzas[0].(debinterfaces.NoAutoDownStanza)
+	c.Assert(noautodown.Definition(), gc.HasLen, 1)
+	c.Check(noautodown.Definition()[0], gc.Equals, "no-auto-down eth0 eth1")
+	c.Check(noautodown.Location().Filename, gc.Equals, "")
+	c.Check(noautodown.Location().LineNum, gc.Equals, 1)
+	c.Check(noautodown.DeviceNames, gc.DeepEquals, []string{"eth0", "eth1"})
+}
+
+func (s *ParserSuite) TestNoScriptsStanza(c *gc.C) {
+	content := `no-scripts eth0 eth1`
+	stanzas, err := debinterfaces.ParseSource("", content, s.expander)
+	c.Assert(err, gc.IsNil)
+	c.Assert(stanzas, gc.HasLen, 1)
+	c.Assert(stanzas[0], gc.FitsTypeOf, debinterfaces.NoScriptsStanza{})
+
+	noscripts := stanzas[0].(debinterfaces.NoScriptsStanza)
+	c.Assert(noscripts.Definition(), gc.HasLen, 1)
+	c.Check(noscripts.Definition()[0], gc.Equals, "no-scripts eth0 eth1")
+	c.Check(noscripts.Location().Filename, gc.Equals, "")
+	c.Check(noscripts.Location().LineNum, gc.Equals, 1)
+	c.Check(noscripts.DeviceNames, gc.DeepEquals, []string{"eth0", "eth1"})
+}
+
+func (s *ParserSuite) TestFailParseDirectoryAsInput(c *gc.C) {
+	stanzas, err := debinterfaces.Parse("testdata/TestInputSourceStanza")
+	c.Assert(err, gc.NotNil)
+	c.Check(err, gc.ErrorMatches, ".* testdata/TestInputSourceStanza: is a directory")
+	c.Assert(stanzas, gc.IsNil)
+}
+
+func (s *ParserSuite) TestSourceStanzaNonExistentFile(c *gc.C) {
+	_, err := debinterfaces.Parse("testdata/TestInputSourceStanza/non-existent-file")
+	c.Assert(err, gc.NotNil)
+	c.Check(err, gc.ErrorMatches, ".* testdata/TestInputSourceStanza/non-existent-file: no such file or directory")
+}
+
+func (s *ParserSuite) TestSourceStanzaWhereGlobHasZeroMatches(c *gc.C) {
+	stanzas, err := debinterfaces.ParseSource("testdata/TestSourceStanzaWhereGlobHasZeroMatches/interfaces", nil, s.expander)
+	c.Assert(err, gc.IsNil)
+	c.Assert(stanzas, gc.HasLen, 1)
+	c.Assert(stanzas[0], gc.FitsTypeOf, debinterfaces.SourceStanza{})
+	src := stanzas[0].(debinterfaces.SourceStanza)
+	c.Assert(src.Sources, gc.HasLen, 0)
+	c.Assert(src.Stanzas, gc.HasLen, 0)
+}
+
+func (s *ParserSuite) TestSourceStanzaWithRelativeFilenames(c *gc.C) {
+	stanzas, err := debinterfaces.Parse("testdata/TestInputSourceStanza/interfaces")
+	c.Assert(err, gc.IsNil)
+	c.Assert(stanzas, gc.HasLen, 3)
+	c.Assert(stanzas[0], gc.FitsTypeOf, debinterfaces.AutoStanza{})
+	c.Assert(stanzas[1], gc.FitsTypeOf, debinterfaces.IfaceStanza{})
+	c.Assert(stanzas[2], gc.FitsTypeOf, debinterfaces.SourceStanza{})
+
+	c.Assert(stanzas[0].Location().Filename, gc.Equals, "testdata/TestInputSourceStanza/interfaces")
+	c.Assert(stanzas[0].Location().LineNum, gc.Equals, 5)
+
+	c.Assert(stanzas[1].Location().Filename, gc.Equals, "testdata/TestInputSourceStanza/interfaces")
+	c.Assert(stanzas[1].Location().LineNum, gc.Equals, 6)
+
+	c.Assert(stanzas[2].Location().Filename, gc.Equals, "testdata/TestInputSourceStanza/interfaces")
+	c.Assert(stanzas[2].Location().LineNum, gc.Equals, 12)
+
+	source := stanzas[2].(debinterfaces.SourceStanza)
+	c.Check(source.Path, gc.Equals, "interfaces.d/*.cfg")
+
+	c.Assert(source.Stanzas, gc.HasLen, 6)
+
+	c.Assert(source.Stanzas[0], gc.FitsTypeOf, debinterfaces.AutoStanza{})
+	c.Assert(source.Stanzas[1], gc.FitsTypeOf, debinterfaces.IfaceStanza{})
+	c.Assert(source.Stanzas[2], gc.FitsTypeOf, debinterfaces.AutoStanza{})
+	c.Assert(source.Stanzas[3], gc.FitsTypeOf, debinterfaces.IfaceStanza{})
+	c.Assert(source.Stanzas[4], gc.FitsTypeOf, debinterfaces.AutoStanza{})
+	c.Assert(source.Stanzas[5], gc.FitsTypeOf, debinterfaces.IfaceStanza{})
+
+	c.Check(source.Sources, gc.DeepEquals, []string{
+		"testdata/TestInputSourceStanza/interfaces.d/eth0.cfg",
+		"testdata/TestInputSourceStanza/interfaces.d/eth1.cfg",
+		"testdata/TestInputSourceStanza/interfaces.d/eth2.cfg",
+	})
+
+	// Note: we don't have tests for stanzas nested > 1 deep.
+
+	eth0 := source.Stanzas[1].(debinterfaces.IfaceStanza)
+	eth1 := source.Stanzas[3].(debinterfaces.IfaceStanza)
+	eth2 := source.Stanzas[5].(debinterfaces.IfaceStanza)
+
+	c.Assert(eth0.Definition(), gc.HasLen, 1)
+	c.Check(eth0.Definition()[0], gc.Equals, "iface eth0 inet dhcp")
+	c.Check(eth0.Location().Filename, gc.Equals, "testdata/TestInputSourceStanza/interfaces.d/eth0.cfg")
+	c.Check(eth0.Location().LineNum, gc.Equals, 2)
+
+	c.Assert(eth1.Definition(), gc.HasLen, 3)
+	c.Check(eth1.Definition()[0], gc.Equals, "iface eth1 inet static")
+	c.Check(eth1.Definition()[1], gc.Equals, "address 192.168.1.64")
+	c.Check(eth1.Definition()[2], gc.Equals, "dns-nameservers 192.168.1.254")
+	c.Check(eth1.Location().Filename, gc.Equals, "testdata/TestInputSourceStanza/interfaces.d/eth1.cfg")
+	c.Check(eth1.Location().LineNum, gc.Equals, 2)
+
+	c.Assert(eth2.Definition(), gc.HasLen, 1)
+	c.Check(eth2.Definition()[0], gc.Equals, "iface eth2 inet manual")
+	c.Check(eth2.Location().Filename, gc.Equals, "testdata/TestInputSourceStanza/interfaces.d/eth2.cfg")
+	c.Check(eth2.Location().LineNum, gc.Equals, 2)
+}
+
+func (s *ParserSuite) TestSourceStanzaFromFileWithStanzaErrors(c *gc.C) {
+	_, err := debinterfaces.Parse("testdata/TestInputSourceStanzaWithErrors/interfaces")
+	c.Assert(err, gc.NotNil)
+	c.Assert(err, gc.FitsTypeOf, &debinterfaces.ParseError{})
+	parseError := err.(*debinterfaces.ParseError)
+	c.Assert(parseError, gc.DeepEquals, &debinterfaces.ParseError{
+		Filename: "testdata/TestInputSourceStanzaWithErrors/interfaces.d/eth1.cfg",
+		Line:     "iface",
+		LineNum:  2,
+		Message:  "missing device name",
+	})
+}
+
+func (s *ParserSuite) TestSourceDirectoryStanzaWithRelativeFilenames(c *gc.C) {
+	stanzas, err := debinterfaces.Parse("testdata/TestInputSourceDirectoryStanza/interfaces")
+	c.Assert(err, gc.IsNil)
+	c.Assert(stanzas, gc.HasLen, 3)
+	c.Assert(stanzas[0], gc.FitsTypeOf, debinterfaces.AutoStanza{})
+	c.Assert(stanzas[1], gc.FitsTypeOf, debinterfaces.IfaceStanza{})
+	c.Assert(stanzas[2], gc.FitsTypeOf, debinterfaces.SourceDirectoryStanza{})
+
+	c.Assert(stanzas[0].Location().Filename, gc.Equals, "testdata/TestInputSourceDirectoryStanza/interfaces")
+	c.Assert(stanzas[0].Location().LineNum, gc.Equals, 1)
+
+	c.Assert(stanzas[1].Location().Filename, gc.Equals, "testdata/TestInputSourceDirectoryStanza/interfaces")
+	c.Assert(stanzas[1].Location().LineNum, gc.Equals, 2)
+
+	c.Assert(stanzas[2].Location().Filename, gc.Equals, "testdata/TestInputSourceDirectoryStanza/interfaces")
+	c.Assert(stanzas[2].Location().LineNum, gc.Equals, 4)
+
+	source := stanzas[2].(debinterfaces.SourceDirectoryStanza)
+	c.Check(source.Path, gc.Equals, "interfaces.d")
+
+	c.Assert(source.Stanzas, gc.HasLen, 2)
+
+	c.Assert(source.Stanzas[0], gc.FitsTypeOf, debinterfaces.AutoStanza{})
+	c.Assert(source.Stanzas[1], gc.FitsTypeOf, debinterfaces.IfaceStanza{})
+
+	c.Check(source.Sources, gc.DeepEquals, []string{
+		"testdata/TestInputSourceDirectoryStanza/interfaces.d/eth3",
+	})
+
+	// Note: we don't have tests for stanzas nested > 1 deep.
+
+	eth3 := source.Stanzas[1].(debinterfaces.IfaceStanza)
+	c.Assert(eth3.Definition(), gc.HasLen, 3)
+	c.Check(eth3.Definition()[0], gc.Equals, "iface eth3 inet static")
+	c.Check(eth3.Definition()[1], gc.Equals, "address 192.168.1.128")
+	c.Check(eth3.Definition()[2], gc.Equals, "dns-nameservers 192.168.1.254")
+	c.Check(eth3.Location().Filename, gc.Equals, "testdata/TestInputSourceDirectoryStanza/interfaces.d/eth3")
+	c.Check(eth3.Location().LineNum, gc.Equals, 2)
+}
+
+func (s *ParserSuite) TestSourceDirectoryStanzaFromDirectoryWithStanzaErrors(c *gc.C) {
+	_, err := debinterfaces.Parse("testdata/TestInputSourceDirectoryStanzaWithErrors/interfaces")
+	c.Assert(err, gc.NotNil)
+	c.Assert(err, gc.FitsTypeOf, &debinterfaces.ParseError{})
+	parseError := err.(*debinterfaces.ParseError)
+	c.Assert(parseError, gc.DeepEquals, &debinterfaces.ParseError{
+		Filename: "testdata/TestInputSourceDirectoryStanzaWithErrors/interfaces.d/eth3",
+		Line:     "iface",
+		LineNum:  2,
+		Message:  "missing device name",
+	})
+}
+
+func (s *ParserSuite) TestSourceStanzaWithWordExpanderError(c *gc.C) {
+	_, err := debinterfaces.ParseSource("testdata/TestInputSourceStanza/interfaces", nil, wordExpanderWithError("boom"))
+	c.Assert(err, gc.NotNil)
+	c.Assert(err, gc.FitsTypeOf, &debinterfaces.ParseError{})
+	parseError := err.(*debinterfaces.ParseError)
+	c.Assert(parseError, gc.DeepEquals, &debinterfaces.ParseError{
+		Filename: "testdata/TestInputSourceStanza/interfaces",
+		Line:     "source interfaces.d/*.cfg",
+		LineNum:  12,
+		Message:  "word expansion failed: boom",
+	})
+}
+
+func (s *ParserSuite) TestSourceDirectoryStanzaWithWordExpanderError(c *gc.C) {
+	_, err := debinterfaces.ParseSource("testdata/TestInputSourceDirectoryStanza/interfaces", nil, wordExpanderWithError("boom"))
+	c.Assert(err, gc.NotNil)
+	c.Assert(err, gc.FitsTypeOf, &debinterfaces.ParseError{})
+	parseError := err.(*debinterfaces.ParseError)
+	c.Assert(parseError, gc.DeepEquals, &debinterfaces.ParseError{
+		Filename: "testdata/TestInputSourceDirectoryStanza/interfaces",
+		Line:     "source-directory interfaces.d",
+		LineNum:  4,
+		Message:  "word expansion failed: boom",
+	})
+}
+
+func (s *ParserSuite) TestSourceStanzaWithAbsoluteFilenames(c *gc.C) {
+	_, testfile, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(testfile)
+	fullpath := fmt.Sprintf("%s/testdata/TestInputSourceStanza/interfaces.d/*.cfg", dir)
+	content := fmt.Sprintf("source %s", fullpath)
+	stanzas, err := debinterfaces.ParseSource("", content, s.expander)
+	c.Assert(err, gc.IsNil)
+	c.Assert(stanzas, gc.HasLen, 1)
+	c.Assert(stanzas[0], gc.FitsTypeOf, debinterfaces.SourceStanza{})
+
+	c.Assert(stanzas[0].Location().Filename, gc.Equals, "")
+	c.Assert(stanzas[0].Location().LineNum, gc.Equals, 1)
+
+	source := stanzas[0].(debinterfaces.SourceStanza)
+	c.Check(source.Path, gc.Equals, fullpath)
+
+	c.Assert(source.Stanzas, gc.HasLen, 6)
+
+	c.Assert(source.Stanzas[0], gc.FitsTypeOf, debinterfaces.AutoStanza{})
+	c.Assert(source.Stanzas[1], gc.FitsTypeOf, debinterfaces.IfaceStanza{})
+	c.Assert(source.Stanzas[2], gc.FitsTypeOf, debinterfaces.AutoStanza{})
+	c.Assert(source.Stanzas[3], gc.FitsTypeOf, debinterfaces.IfaceStanza{})
+	c.Assert(source.Stanzas[4], gc.FitsTypeOf, debinterfaces.AutoStanza{})
+	c.Assert(source.Stanzas[5], gc.FitsTypeOf, debinterfaces.IfaceStanza{})
+
+	c.Check(source.Sources, gc.DeepEquals, []string{
+		filepath.Join(dir, "testdata/TestInputSourceStanza/interfaces.d/eth0.cfg"),
+		filepath.Join(dir, "testdata/TestInputSourceStanza/interfaces.d/eth1.cfg"),
+		filepath.Join(dir, "testdata/TestInputSourceStanza/interfaces.d/eth2.cfg"),
+	})
+
+	// Note: we don't have tests for stanzas nested > 1 deep.
+
+	eth0 := source.Stanzas[1].(debinterfaces.IfaceStanza)
+	eth1 := source.Stanzas[3].(debinterfaces.IfaceStanza)
+	eth2 := source.Stanzas[5].(debinterfaces.IfaceStanza)
+
+	c.Assert(eth0.Definition(), gc.HasLen, 1)
+	c.Check(eth0.Definition()[0], gc.Equals, "iface eth0 inet dhcp")
+	c.Check(eth0.Location().Filename, gc.Equals, filepath.Join(dir, "testdata/TestInputSourceStanza/interfaces.d/eth0.cfg"))
+	c.Check(eth0.Location().LineNum, gc.Equals, 2)
+
+	c.Assert(eth1.Definition(), gc.HasLen, 3)
+	c.Check(eth1.Definition()[0], gc.Equals, "iface eth1 inet static")
+	c.Check(eth1.Definition()[1], gc.Equals, "address 192.168.1.64")
+	c.Check(eth1.Definition()[2], gc.Equals, "dns-nameservers 192.168.1.254")
+	c.Check(eth1.Location().Filename, gc.Equals, filepath.Join(dir, "testdata/TestInputSourceStanza/interfaces.d/eth1.cfg"))
+	c.Check(eth1.Location().LineNum, gc.Equals, 2)
+
+	c.Assert(eth2.Definition(), gc.HasLen, 1)
+	c.Check(eth2.Definition()[0], gc.Equals, "iface eth2 inet manual")
+	c.Check(eth2.Location().Filename, gc.Equals, filepath.Join(dir, "testdata/TestInputSourceStanza/interfaces.d/eth2.cfg"))
+	c.Check(eth2.Location().LineNum, gc.Equals, 2)
+}
+
+func (s *ParserSuite) TestSourceDirectoryStanzaWithAbsoluteFilenames(c *gc.C) {
+	_, testfile, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(testfile)
+	fullpath := fmt.Sprintf("%s/testdata/TestInputSourceDirectoryStanza/interfaces.d", dir)
+	content := fmt.Sprintf("source-directory %s", fullpath)
+	stanzas, err := debinterfaces.ParseSource("", content, s.expander)
+	c.Assert(err, gc.IsNil)
+	c.Assert(stanzas, gc.HasLen, 1)
+	c.Assert(stanzas[0], gc.FitsTypeOf, debinterfaces.SourceDirectoryStanza{})
+
+	c.Assert(stanzas[0].Location().Filename, gc.Equals, "")
+	c.Assert(stanzas[0].Location().LineNum, gc.Equals, 1)
+
+	source := stanzas[0].(debinterfaces.SourceDirectoryStanza)
+	c.Check(source.Path, gc.Equals, fullpath)
+
+	c.Assert(source.Stanzas, gc.HasLen, 2)
+
+	c.Assert(source.Stanzas[0], gc.FitsTypeOf, debinterfaces.AutoStanza{})
+	c.Assert(source.Stanzas[1], gc.FitsTypeOf, debinterfaces.IfaceStanza{})
+
+	c.Check(source.Sources, gc.DeepEquals, []string{
+		filepath.Join(fullpath, "eth3"),
+	})
+
+	// Note: we don't have tests for source directory stanzas nested > 1 deep.
+
+	eth3 := source.Stanzas[1].(debinterfaces.IfaceStanza)
+	c.Assert(eth3.Definition(), gc.HasLen, 3)
+	c.Check(eth3.Definition()[0], gc.Equals, "iface eth3 inet static")
+	c.Check(eth3.Definition()[1], gc.Equals, "address 192.168.1.128")
+	c.Check(eth3.Definition()[2], gc.Equals, "dns-nameservers 192.168.1.254")
+	c.Check(eth3.Location().Filename, gc.Equals, filepath.Join(fullpath, "eth3"))
+	c.Check(eth3.Location().LineNum, gc.Equals, 2)
+}
+
+func (s *ParserSuite) TestSourceStanzaWithAbsoluteNonExistentFilenames(c *gc.C) {
+	_, testfile, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(testfile)
+	fullpath := fmt.Sprintf("%s/testdata/non-existent.d/*", dir)
+	content := fmt.Sprintf("source %s", fullpath)
+	_, err := debinterfaces.ParseSource("", content, s.expander)
+	c.Assert(err, gc.IsNil)
+}
+
+func (s *ParserSuite) TestSourceDirectoryStanzaWithAbsoluteNonExistentFilenames(c *gc.C) {
+	_, testfile, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(testfile)
+	fullpath := fmt.Sprintf("%s/testdata/non-existent", dir)
+	content := fmt.Sprintf("source-directory %s", fullpath)
+	_, err := debinterfaces.ParseSource("", content, s.expander)
+	c.Assert(err, gc.NotNil)
+}
+
+func (s *ParserSuite) TestIfupdownPackageExample(c *gc.C) {
+	_, err := debinterfaces.ParseSource("testdata/ifupdown-examples", nil, s.expander)
+	c.Assert(err, gc.IsNil)
+}

--- a/network/debinterfaces/scanner.go
+++ b/network/debinterfaces/scanner.go
@@ -1,0 +1,80 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package debinterfaces
+
+import (
+	"bufio"
+	"bytes"
+	"errors"
+	"io"
+	"io/ioutil"
+	"strings"
+)
+
+type lineScanner struct {
+	filename string   // underlying source of lines[], if any
+	lines    []string // all lines; never mutated
+	line     string   // current line
+	n        int      // current index into lines[]
+	max      int      // len(lines)
+}
+
+func newScanner(filename string, src interface{}) (*lineScanner, error) {
+	if filename == "" && src == nil {
+		return nil, errors.New("filename and input is nil")
+	}
+
+	content, err := readSource(filename, src)
+
+	if err != nil {
+		return nil, err
+	}
+
+	lines := readLines(bytes.NewReader(content))
+
+	return &lineScanner{
+		filename: filename,
+		lines:    lines,
+		max:      len(lines),
+	}, nil
+}
+
+// If src != nil, readSource converts src to a []byte if possible,
+// otherwise it returns an error. If src == nil, readSource returns
+// the result of reading the file specified by filename.
+func readSource(filename string, src interface{}) ([]byte, error) {
+	if src == nil {
+		return ioutil.ReadFile(filename)
+	}
+	switch s := src.(type) {
+	case string:
+		return []byte(s), nil
+	}
+	return nil, errors.New("invalid source type")
+}
+
+func readLines(rdr io.Reader) []string {
+	lines := make([]string, 0)
+	scanner := bufio.NewScanner(rdr)
+
+	for scanner.Scan() {
+		lines = append(lines, scanner.Text())
+	}
+
+	return lines
+}
+
+func (s *lineScanner) nextLine() bool {
+	for {
+		if s.n == s.max {
+			return false
+		}
+		s.line = strings.TrimSpace(s.lines[s.n])
+		s.n++
+		if strings.HasPrefix(s.line, "#") || s.line == "" {
+			continue
+		}
+		return true
+	}
+}

--- a/network/debinterfaces/scriptrunner.go
+++ b/network/debinterfaces/scriptrunner.go
@@ -1,0 +1,53 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package debinterfaces
+
+import (
+	"time"
+
+	"github.com/juju/errors"
+	"github.com/juju/utils/clock"
+	"github.com/juju/utils/exec"
+)
+
+type scriptResult struct {
+	Stdout []byte
+	Stderr []byte
+	Code   int
+}
+
+func runCommand(command string, environ []string, clock clock.Clock, timeout time.Duration) (*scriptResult, error) {
+	cmd := exec.RunParams{
+		Commands:    command,
+		Environment: environ,
+		Clock:       clock,
+	}
+
+	err := cmd.Run()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	var cancel chan struct{}
+
+	if timeout != 0 {
+		cancel = make(chan struct{})
+		go func() {
+			<-clock.After(timeout)
+			close(cancel)
+		}()
+	}
+
+	result, err := cmd.WaitWithCancel(cancel)
+
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	return &scriptResult{
+		Stdout: result.Stdout,
+		Stderr: result.Stderr,
+		Code:   result.Code,
+	}, nil
+}

--- a/network/debinterfaces/scriptrunner_test.go
+++ b/network/debinterfaces/scriptrunner_test.go
@@ -1,0 +1,67 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package debinterfaces
+
+import (
+	"os"
+	"runtime"
+	"time"
+
+	coretesting "github.com/juju/juju/testing"
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	"github.com/juju/utils/clock"
+	gc "gopkg.in/check.v1"
+)
+
+type ScriptRunnerSuite struct {
+	testing.IsolationSuite
+}
+
+var _ = gc.Suite(&ScriptRunnerSuite{})
+
+func (s *ScriptRunnerSuite) SetUpSuite(c *gc.C) {
+	if runtime.GOOS == "windows" {
+		c.Skip("skipping ScriptRunnerSuite tests on windows")
+	}
+	s.IsolationSuite.SetUpSuite(c)
+}
+
+func (*ScriptRunnerSuite) TestScriptRunnerFails(c *gc.C) {
+	clock := testing.NewClock(coretesting.ZeroTime())
+	result, err := RunCommand("exit 1", os.Environ(), clock, 0)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result.Code, gc.Equals, 1)
+}
+
+func (*ScriptRunnerSuite) TestScriptRunnerSucceeds(c *gc.C) {
+	clock := testing.NewClock(coretesting.ZeroTime())
+	result, err := RunCommand("exit 0", os.Environ(), clock, 0)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result.Code, gc.Equals, 0)
+}
+
+func (*ScriptRunnerSuite) TestScriptRunnerCheckStdout(c *gc.C) {
+	clock := testing.NewClock(coretesting.ZeroTime())
+	result, err := RunCommand("echo -n 42", os.Environ(), clock, 0)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result.Code, gc.Equals, 0)
+	c.Check(string(result.Stdout), gc.Equals, "42")
+	c.Check(string(result.Stderr), gc.Equals, "")
+}
+
+func (*ScriptRunnerSuite) TestScriptRunnerCheckStderr(c *gc.C) {
+	clock := testing.NewClock(coretesting.ZeroTime())
+	result, err := RunCommand(">&2 echo -n 3.141", os.Environ(), clock, 0)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result.Code, gc.Equals, 0)
+	c.Check(string(result.Stdout), gc.Equals, "")
+	c.Check(string(result.Stderr), gc.Equals, "3.141")
+}
+
+func (*ScriptRunnerSuite) TestScriptRunnerTimeout(c *gc.C) {
+	_, err := RunCommand("sleep 6", os.Environ(), clock.WallClock, 500*time.Microsecond)
+	c.Assert(err, gc.NotNil)
+	c.Assert(err, gc.ErrorMatches, "command cancelled")
+}

--- a/network/debinterfaces/stanza.go
+++ b/network/debinterfaces/stanza.go
@@ -1,0 +1,122 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package debinterfaces
+
+var _ Stanza = (*stanza)(nil)
+
+// stanza implements Stanza.
+type stanza struct {
+	definition string
+	location   Location
+}
+
+// Stanza represents a network definition as described by
+// interfaces(8).
+type Stanza interface {
+	// A definition is the top-level stanza, together with any
+	// options.
+	Definition() []string
+
+	// The file and linenumber, if any, where the stanza was
+	// declared.
+	Location() Location
+}
+
+// Location represents source file and line number information
+type Location struct {
+	Filename string
+	LineNum  int
+}
+
+// AllowStanza are lines beginning with the word 'allow-*'.
+type AllowStanza struct {
+	stanza
+	DeviceNames []string
+}
+
+// AutoStanza are lines beginning with the word "auto".
+type AutoStanza struct {
+	stanza
+	DeviceNames []string
+}
+
+// IfaceStanza are lines beginning with 'iface'.
+type IfaceStanza struct {
+	stanza
+	DeviceName          string
+	HasBondMasterOption bool
+	HasBondOptions      bool
+	IsAlias             bool
+	IsBridged           bool
+	IsVLAN              bool
+	Options             []string
+}
+
+// MappingStanza are lines beginning with the word "mapping".
+type MappingStanza struct {
+	stanza
+	DeviceNames []string
+	Options     []string
+}
+
+// NoAutoDownStanza are lines beginning with "no-auto-down".
+type NoAutoDownStanza struct {
+	stanza
+	DeviceNames []string
+}
+
+// NoScriptsStanza are lines beginning with "no-scripts".
+type NoScriptsStanza struct {
+	stanza
+	DeviceNames []string
+}
+
+// SourceStanza are lines beginning with "source".
+type SourceStanza struct {
+	stanza
+	Path    string
+	Sources []string
+	Stanzas []Stanza
+}
+
+// SourceDirectoryStanza are lines beginning with "source-directory".
+type SourceDirectoryStanza struct {
+	stanza
+	Path    string
+	Sources []string
+	Stanzas []Stanza
+}
+
+func definitionWithOptions(definition string, options []string) []string {
+	result := make([]string, 1+len(options))
+	result[0] = definition
+	for i := range options {
+		result[i+1] = options[i]
+	}
+	return result
+}
+
+// Location returns the filename and line number of the first line of
+// the definition, if any.
+func (s stanza) Location() Location {
+	return s.location
+}
+
+// Definition returns all the lines that define the stanza. The
+// individual lines are trimmed of leading and trailing whitespace.
+func (s stanza) Definition() []string {
+	return []string{s.definition}
+}
+
+// Definition returns all the lines that define the stanza. The
+// individual lines are trimmed of leading and trailing whitespace.
+func (s IfaceStanza) Definition() []string {
+	return definitionWithOptions(s.definition, s.Options)
+}
+
+// Definition returns all the lines that define the stanza. The
+// individual lines are trimmed of leading and trailing whitespace.
+func (s MappingStanza) Definition() []string {
+	return definitionWithOptions(s.definition, s.Options)
+}

--- a/network/debinterfaces/testdata/TestInputSourceDirectoryStanza/interfaces
+++ b/network/debinterfaces/testdata/TestInputSourceDirectoryStanza/interfaces
@@ -1,0 +1,4 @@
+auto lo
+iface lo inet loopback
+
+source-directory interfaces.d

--- a/network/debinterfaces/testdata/TestInputSourceDirectoryStanza/interfaces.d/eth0.cfg
+++ b/network/debinterfaces/testdata/TestInputSourceDirectoryStanza/interfaces.d/eth0.cfg
@@ -1,0 +1,2 @@
+auto eth0
+iface eth0 inet dhcp

--- a/network/debinterfaces/testdata/TestInputSourceDirectoryStanza/interfaces.d/eth1.cfg
+++ b/network/debinterfaces/testdata/TestInputSourceDirectoryStanza/interfaces.d/eth1.cfg
@@ -1,0 +1,4 @@
+auto eth1
+iface eth1 inet static
+  address 192.168.1.64
+  dns-nameservers 192.168.1.254

--- a/network/debinterfaces/testdata/TestInputSourceDirectoryStanza/interfaces.d/eth2.cfg
+++ b/network/debinterfaces/testdata/TestInputSourceDirectoryStanza/interfaces.d/eth2.cfg
@@ -1,0 +1,2 @@
+auto eth2
+iface eth2 inet manual

--- a/network/debinterfaces/testdata/TestInputSourceDirectoryStanza/interfaces.d/eth3
+++ b/network/debinterfaces/testdata/TestInputSourceDirectoryStanza/interfaces.d/eth3
@@ -1,0 +1,4 @@
+auto eth3
+iface eth3 inet static
+  address 192.168.1.128
+  dns-nameservers 192.168.1.254

--- a/network/debinterfaces/testdata/TestInputSourceDirectoryStanzaWithErrors/interfaces
+++ b/network/debinterfaces/testdata/TestInputSourceDirectoryStanzaWithErrors/interfaces
@@ -1,0 +1,4 @@
+auto lo
+iface lo inet loopback
+
+source-directory interfaces.d

--- a/network/debinterfaces/testdata/TestInputSourceDirectoryStanzaWithErrors/interfaces.d/eth0.cfg
+++ b/network/debinterfaces/testdata/TestInputSourceDirectoryStanzaWithErrors/interfaces.d/eth0.cfg
@@ -1,0 +1,2 @@
+auto eth0
+iface eth0 inet dhcp

--- a/network/debinterfaces/testdata/TestInputSourceDirectoryStanzaWithErrors/interfaces.d/eth1.cfg
+++ b/network/debinterfaces/testdata/TestInputSourceDirectoryStanzaWithErrors/interfaces.d/eth1.cfg
@@ -1,0 +1,4 @@
+auto eth1
+iface eth1 inet static
+  address 192.168.1.64
+  dns-nameservers 192.168.1.254

--- a/network/debinterfaces/testdata/TestInputSourceDirectoryStanzaWithErrors/interfaces.d/eth2.cfg
+++ b/network/debinterfaces/testdata/TestInputSourceDirectoryStanzaWithErrors/interfaces.d/eth2.cfg
@@ -1,0 +1,2 @@
+auto eth2
+iface eth2 inet manual

--- a/network/debinterfaces/testdata/TestInputSourceDirectoryStanzaWithErrors/interfaces.d/eth3
+++ b/network/debinterfaces/testdata/TestInputSourceDirectoryStanzaWithErrors/interfaces.d/eth3
@@ -1,0 +1,4 @@
+auto eth3
+iface
+  address 192.168.1.128
+  dns-nameservers 192.168.1.254

--- a/network/debinterfaces/testdata/TestInputSourceStanza/interfaces
+++ b/network/debinterfaces/testdata/TestInputSourceStanza/interfaces
@@ -1,0 +1,12 @@
+# This file describes the network interfaces available on your system
+# and how to activate them. For more information, see interfaces(5).
+
+# The loopback network interface
+auto lo
+iface lo inet loopback
+
+# Source interfaces
+# Please check /etc/network/interfaces.d before changing this file
+# as interfaces may have been defined in /etc/network/interfaces.d
+# See LP: #1262951
+source interfaces.d/*.cfg

--- a/network/debinterfaces/testdata/TestInputSourceStanza/interfaces.d/eth0.cfg
+++ b/network/debinterfaces/testdata/TestInputSourceStanza/interfaces.d/eth0.cfg
@@ -1,0 +1,2 @@
+auto eth0
+iface eth0 inet dhcp

--- a/network/debinterfaces/testdata/TestInputSourceStanza/interfaces.d/eth1.cfg
+++ b/network/debinterfaces/testdata/TestInputSourceStanza/interfaces.d/eth1.cfg
@@ -1,0 +1,4 @@
+auto eth1
+iface eth1 inet static
+  address 192.168.1.64
+  dns-nameservers 192.168.1.254

--- a/network/debinterfaces/testdata/TestInputSourceStanza/interfaces.d/eth2.cfg
+++ b/network/debinterfaces/testdata/TestInputSourceStanza/interfaces.d/eth2.cfg
@@ -1,0 +1,2 @@
+auto eth2
+iface eth2 inet manual

--- a/network/debinterfaces/testdata/TestInputSourceStanza/interfaces.d/eth3
+++ b/network/debinterfaces/testdata/TestInputSourceStanza/interfaces.d/eth3
@@ -1,0 +1,4 @@
+auto eth3
+iface eth3 inet static
+  address 192.168.1.128
+  dns-nameservers 192.168.1.254

--- a/network/debinterfaces/testdata/TestInputSourceStanzaWithErrors/interfaces
+++ b/network/debinterfaces/testdata/TestInputSourceStanzaWithErrors/interfaces
@@ -1,0 +1,12 @@
+# This file describes the network interfaces available on your system
+# and how to activate them. For more information, see interfaces(5).
+
+# The loopback network interface
+auto lo
+iface lo inet loopback
+
+# Source interfaces
+# Please check /etc/network/interfaces.d before changing this file
+# as interfaces may have been defined in /etc/network/interfaces.d
+# See LP: #1262951
+source interfaces.d/*.cfg

--- a/network/debinterfaces/testdata/TestInputSourceStanzaWithErrors/interfaces.d/eth0.cfg
+++ b/network/debinterfaces/testdata/TestInputSourceStanzaWithErrors/interfaces.d/eth0.cfg
@@ -1,0 +1,2 @@
+auto eth0
+iface eth0 inet dhcp

--- a/network/debinterfaces/testdata/TestInputSourceStanzaWithErrors/interfaces.d/eth1.cfg
+++ b/network/debinterfaces/testdata/TestInputSourceStanzaWithErrors/interfaces.d/eth1.cfg
@@ -1,0 +1,4 @@
+auto eth1
+iface
+  address 192.168.1.64
+  dns-nameservers 192.168.1.254

--- a/network/debinterfaces/testdata/TestInputSourceStanzaWithErrors/interfaces.d/eth2.cfg
+++ b/network/debinterfaces/testdata/TestInputSourceStanzaWithErrors/interfaces.d/eth2.cfg
@@ -1,0 +1,2 @@
+auto eth2
+iface eth2 inet manual

--- a/network/debinterfaces/testdata/TestInputSourceStanzaWithErrors/interfaces.d/eth3
+++ b/network/debinterfaces/testdata/TestInputSourceStanzaWithErrors/interfaces.d/eth3
@@ -1,0 +1,4 @@
+auto eth3
+iface eth3 inet static
+  address 192.168.1.128
+  dns-nameservers 192.168.1.254

--- a/network/debinterfaces/testdata/TestSourceStanzaWhereGlobHasZeroMatches/interfaces
+++ b/network/debinterfaces/testdata/TestSourceStanzaWhereGlobHasZeroMatches/interfaces
@@ -1,0 +1,1 @@
+source interfaces.d/*.cfg

--- a/network/debinterfaces/testdata/ifupdown-examples
+++ b/network/debinterfaces/testdata/ifupdown-examples
@@ -1,0 +1,200 @@
+# This is a copy of the example interfaces file from the ifupdown
+# package.
+
+######################################################################
+# /etc/network/interfaces -- configuration file for ifup(8), ifdown(8)
+#
+# A "#" character in the very first column makes the rest of the line
+# be ignored. Blank lines are ignored. Lines may be indented freely.
+# A "\" character at the very end of the line indicates the next line
+# should be treated as a continuation of the current one.
+#
+# The "pre-up", "up", "down" and "post-down" options are valid for all 
+# interfaces, and may be specified multiple times. All other options
+# may only be specified once.
+#
+# See the interfaces(5) manpage for information on what options are 
+# available.
+######################################################################
+
+# The loopback interface isn't really required any longer,
+# but can be used if needed.
+#
+auto lo
+iface lo inet loopback
+
+# An example ethernet card setup: (broadcast and gateway are optional)
+#
+auto eth0
+iface eth0 inet static
+    address 192.168.0.42/24
+    gateway 192.168.0.1
+
+# A more complicated ethernet setup, with a less common netmask, and a downright
+# weird broadcast address: (the "up" lines are executed verbatim when the 
+# interface is brought up, the "down" lines when it's brought down)
+#
+auto eth0
+iface eth0 inet static
+    address 192.168.1.42/25
+    up route add -net 192.168.1.128 netmask 255.255.255.128 gw 192.168.1.2
+    up route add default gw 192.168.1.200
+    down route del default gw 192.168.1.200
+    down route del -net 192.168.1.128 netmask 255.255.255.128 gw 192.168.1.2
+
+# A more complicated ethernet setup with a single ethernet card with
+# two interfaces.
+# Note: This happens to work since ifconfig handles it that way, not because
+# ifup/down handles the ':' any differently.
+# Warning: There is a known bug if you do this, since the state will not
+# be properly defined if you try to 'ifdown eth0' when both interfaces
+# are up. The ifconfig program will not remove eth0 but it will be
+# removed from the interfaces state so you will see it up until you execute:
+# 'ifdown eth0:1 ; ifup eth0; ifdown eth0'
+# BTW, this is "bug" #193679 (it's not really a bug, it's more of a 
+# limitation)
+#
+auto eth0 eth0:1
+iface eth0 inet static
+    address 192.168.0.100/24
+    gateway 192.168.0.1
+iface eth0:1 inet static
+    address 192.168.0.200
+    netmask 255.255.255.0
+
+# Another way to accomplish this:
+#
+auto eth0
+iface eth0 inet static
+    address 192.168.0.100/24
+    gateway 192.168.0.1
+iface eth0 inet static
+    address 192.168.0.200
+    netmask 255.255.255.0
+#
+# However, when specifying multiple addresses this way, there will be no
+# way to add or remove them individually using ifup/ifdown only.
+
+# "pre-up" and "post-down" commands are also available. In addition, the
+# exit status of these commands are checked, and if any fail, configuration
+# (or deconfiguration) is aborted. So:
+#
+auto eth0
+iface eth0 inet dhcp
+    pre-up [ -f /etc/network/local-network-ok ]
+#
+# will allow you to only have eth0 brought up when the file 
+# /etc/network/local-network-ok exists.
+
+# Two ethernet interfaces, one connected to a trusted LAN, the other to
+# the untrusted Internet. If their MAC addresses get swapped (because an
+# updated kernel uses a different order when probing for network cards,
+# say), then they don't get brought up at all.
+#
+auto eth0 eth1
+iface eth0 inet static
+    address 192.168.42.1
+    netmask 255.255.255.0
+    pre-up /path/to/check-mac-address.sh eth0 11:22:33:44:55:66
+    pre-up /usr/local/sbin/enable-masq
+iface eth1 inet dhcp
+    pre-up /path/to/check-mac-address.sh eth1 AA:BB:CC:DD:EE:FF
+    pre-up /usr/local/sbin/firewall
+
+# Two ethernet interfaces, one connected to a trusted LAN, the other to
+# the untrusted Internet, identified by MAC address rather than interface
+# name:
+#
+auto eth0 eth1
+mapping eth0 eth1
+    script /path/to/get-mac-address.sh
+    map 11:22:33:44:55:66 lan
+    map AA:BB:CC:DD:EE:FF internet
+iface lan inet static
+    address 192.168.42.1
+    netmask 255.255.255.0
+    pre-up /usr/local/sbin/enable-masq $IFACE
+iface internet inet dhcp
+    pre-up /usr/local/sbin/firewall $IFACE
+
+# A PCMCIA interface for a laptop that is used in different locations:
+# (note the lack of an "auto" line for any of these)
+#
+mapping eth0
+   script /path/to/pcmcia-compat.sh
+   map home,*,*,*                  home
+   map work,*,*,00:11:22:33:44:55  work-wireless
+   map work,*,*,01:12:23:34:45:50  work-static
+#
+iface home inet dhcp
+iface work-wireless bootp
+iface work-static static
+    address 10.15.43.23
+    netmask 255.255.255.0
+    gateway 10.15.43.1
+#
+# Note, this won't work unless you specifically change the file
+# /etc/pcmcia/network to look more like:
+#
+#     if [ -r ./shared ] ; then . ./shared ; else . /etc/pcmcia/shared ; fi
+#     get_info $DEVICE
+#     case "$ACTION" in
+#         'start')
+#             /sbin/ifup $DEVICE
+#             ;;
+#         'stop')
+#             /sbin/ifdown $DEVICE
+#             ;;
+#     esac
+#     exit 0
+
+# An alternate way of doing the same thing: (in this case identifying
+# where the laptop is is done by configuring the interface as various
+# options, and seeing if a computer that is known to be on each particular
+# network will respond to pings. The various numbers here need to be chosen
+# with a great deal of care.)
+#
+mapping eth0
+   script /path/to/ping-places.sh
+   map 192.168.42.254/24 192.168.42.1 home
+   map 10.15.43.254/24 10.15.43.1 work-wireless
+   map 10.15.43.23/24 10.15.43.1 work-static
+#
+iface home inet dhcp
+iface work-wireless bootp
+iface work-static static
+    address 10.15.43.23
+    netmask 255.255.255.0
+    gateway 10.15.43.1
+#
+# Note that the ping-places script requires the iproute package installed,
+# and the same changes to /etc/pcmcia/network are required for this as for
+# the previous example.
+
+
+# Set up an interface to read all the traffic on the network. This 
+# configuration can be useful to setup Network Intrusion Detection
+# sensors in 'stealth'-type configuration. This prevents the NIDS
+# system to be a direct target in a hostile network since they have
+# no IP address on the network. Notice, however, that there have been
+# known bugs over time in sensors part of NIDS (for example see 
+# DSA-297 related to Snort) and remote buffer overflows might even be
+# triggered by network packet processing.
+# 
+auto eth0
+iface eth0 inet manual
+	up ifconfig $IFACE 0.0.0.0 up
+	up ip link set $IFACE promisc on
+	down ip link set $IFACE promisc off
+	down ifconfig $IFACE down
+
+# Set up an interface which will not be allocated an IP address by
+# ifupdown but will be configured through external programs. This
+# can be useful to setup interfaces configured through other programs,
+# like, for example, PPPOE scripts.
+#
+auto eth0
+iface eth0 inet manual
+      up ifconfig $IFACE 0.0.0.0 up
+      up /usr/local/bin/myconfigscript
+      down ifconfig $IFACE down

--- a/network/debinterfaces/wordexp.go
+++ b/network/debinterfaces/wordexp.go
@@ -1,0 +1,30 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package debinterfaces
+
+import "path/filepath"
+
+// WordExpander performs word expansion like a posix-shell.
+type WordExpander interface {
+	// Expand pattern into a slice of words, or an error if the
+	// underlying implementation failed.
+	Expand(pattern string) ([]string, error)
+}
+
+var _ WordExpander = (*globber)(nil)
+
+type globber struct{}
+
+func newWordExpander() WordExpander {
+	return &globber{}
+}
+
+func (g *globber) Expand(pattern string) ([]string, error) {
+	// The ifupdown package natively used wordexp(3). For the
+	// cases we currently need to cater for we can (probably) get
+	// away by just globbing. wordexp(3) caters for a lot of
+	// shell-style expansions but I haven't seen examples of those
+	// in all the ENI files I have seen.
+	return filepath.Glob(pattern)
+}


### PR DESCRIPTION
## Description of change

This is a Go implementation of the Python-based add-juju-bridge script
that I started in my spare some time ago. I have spent some time
tidying it up this week and the test coverage is now approaching
100% (currently 98%).

I have deliberately put this into its own package --
juju/network/debinterfaces -- so that it doesn't clash with any of the
existing bridging machinations.

This parses and handles the existing test cases with the exception of
Andrew's recent PR #6962 to handle multiple iface stanzas against a
physical interface. I guess I (and many people) were not using IPv6
that much given how long the Python logic has been around.

The juju-bridge(1) command is an example of how to drive the Go
implementation and interface. I have historically found it imperative
that you are able to give an end-user the script that Juju uses and
ask them to run it on their hardware which quite often finds new and
interesting ways that bridging fails.

I have focused much of my recent effort on the test cases and the
general logic in the package; It was only this week I created
juju-bridge(1) and as a result that has had limited exposure. Having
said that, the logic it relies on is almost identical to the way
dynamic bridging invocation is done today.

I think the Go logic is much better than the accreted wisdom (and
mess) that is in the Python script. And having "ported" it to Go
there's also a lot of cruft that could be removed from the Python
version should you not want this PR.

Good luck and sorry for the mess that comes with bridging...

Signed-off-by: Andrew McDermott <andrew.mcdermott@frobware.com>