### PR TITLE
cmd/juju/user: implement controller login

### DIFF
--- a/cmd/juju/controller/destroy.go
+++ b/cmd/juju/controller/destroy.go
@@ -300,7 +300,7 @@ func (c *destroyCommandBase) Init(args []string) error {
 	case 0:
 		return errors.New("no controller specified")
 	case 1:
-		return c.SetControllerName(args[0])
+		return c.SetControllerName(args[0], false)
 	default:
 		return cmd.CheckEmpty(args[1:])
 	}

--- a/cmd/juju/controller/mock_test.go
+++ b/cmd/juju/controller/mock_test.go
@@ -11,6 +11,8 @@ import (
 // mockAPIConnection implements just enough of the api.Connection interface
 // to satisfy the methods used by the register command.
 type mockAPIConnection struct {
+	// This will be nil - it's just there to satisfy the api.Connection
+	// interface methods not explicitly defined by mockAPIConnection.
 	api.Connection
 
 	// addr is returned by Addr.

--- a/cmd/juju/user/export_test.go
+++ b/cmd/juju/user/export_test.go
@@ -13,6 +13,15 @@ import (
 	"github.com/juju/juju/jujuclient"
 )
 
+var (
+	APIOpen          = &apiOpen
+	ListModels       = &listModels
+	NewAPIConnection = &newAPIConnection
+	LoginClientStore = &loginClientStore
+)
+
+const NoModelsMessage = noModelsMessage
+
 type AddCommand struct {
 	*addCommand
 }
@@ -71,17 +80,6 @@ func NewChangePasswordCommandForTest(
 	}
 	c.SetClientStore(store)
 	return modelcmd.WrapController(c), &ChangePasswordCommand{c}
-}
-
-// NewLoginCommand returns a LoginCommand with the api
-// and writer provided as specified.
-func NewLoginCommandForTest(
-	newLoginAPI func(juju.NewAPIConnectionParams) (LoginAPI, ConnectionAPI, error),
-	store jujuclient.ClientStore,
-) (cmd.Command, *LoginCommand) {
-	c := &loginCommand{newLoginAPI: newLoginAPI}
-	c.SetClientStore(store)
-	return modelcmd.WrapController(c), &LoginCommand{c}
 }
 
 // NewLogoutCommand returns a LogoutCommand with the api

--- a/cmd/juju/user/login.go
+++ b/cmd/juju/user/login.go
@@ -5,19 +5,34 @@ package user
 
 import (
 	"fmt"
+	"os"
+	"strings"
 
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
+	"github.com/juju/gnuflag"
+	"github.com/juju/utils/keyvalues"
+	"github.com/juju/utils/set"
 	"gopkg.in/juju/names.v2"
 
-	"github.com/juju/juju/api/usermanager"
+	"github.com/juju/juju/api"
+	apibase "github.com/juju/juju/api/base"
+	"github.com/juju/juju/api/modelmanager"
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/cmd/juju/common"
 	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/juju"
 	"github.com/juju/juju/jujuclient"
 )
 
 const loginDoc = `
+When a known domain is specified instead of a username or the
+--host flag is specified the user is logged into
+the controller associated with the given domain and the controller is registered
+using the domain name (the -c flag can be used to choose a different controller
+name). If a different controller is already registered with the same name,
+it is an error.
+
 After login, a token ("macaroon") will become active. It has an expiration
 time of 24 hours. Upon expiration, no further Juju commands can be issued
 and the user will be prompted to log in again.
@@ -31,73 +46,116 @@ See also:
     enable-user
     logout
 
+Currently, the JUJU_PUBLIC_CONTROLLERS environment variable
+is used to set the currently known public controllers.
+For example:
+
+	export JUJU_PUBLIC_CONTROLLERS="foo=foo.com"
+
+will cause juju login to interpret "juju login foo" the same
+as "juju login --host foo.com".
 `
+
+// Functions defined as variables so they can be overridden in tests.
+var (
+	apiOpen          = (*modelcmd.JujuCommandBase).APIOpen
+	newAPIConnection = juju.NewAPIConnection
+	listModels       = func(c *modelcmd.ControllerCommandBase, userName string) ([]apibase.UserModel, error) {
+		api, err := c.NewAPIRoot()
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		defer api.Close()
+		mm := modelmanager.NewClient(api)
+		return mm.ListModels(userName)
+	}
+	// loginClientStore is used as the client store. When it is nil,
+	// the default client store will be used.
+	loginClientStore jujuclient.ClientStore
+)
 
 // NewLoginCommand returns a new cmd.Command to handle "juju login".
 func NewLoginCommand() cmd.Command {
-	return modelcmd.WrapController(&loginCommand{
-		newLoginAPI: func(args juju.NewAPIConnectionParams) (LoginAPI, ConnectionAPI, error) {
-			api, err := juju.NewAPIConnection(args)
-			if err != nil {
-				return nil, nil, errors.Trace(err)
-			}
-			return usermanager.NewClient(api), api, nil
-		},
-	})
+	var c loginCommand
+	c.SetClientStore(loginClientStore)
+	return modelcmd.WrapController(&c, modelcmd.WrapControllerSkipControllerFlags)
 }
 
 // loginCommand changes the password for a user.
 type loginCommand struct {
 	modelcmd.ControllerCommandBase
-	newLoginAPI func(juju.NewAPIConnectionParams) (LoginAPI, ConnectionAPI, error)
-	User        string
+	userOrDomain string
+	forceHost    bool
+
+	// controllerName holds the name of the current controller.
+	// We define this and the --controller flag here because
+	// the controller does not necessarily exist when the command
+	// is executed.
+	controllerName string
+
+	// onRunError is executed if non-nil if there is an error at the end
+	// of the Run method.
+	onRunError func()
 }
 
 // Info implements Command.Info.
 func (c *loginCommand) Info() *cmd.Info {
 	return &cmd.Info{
 		Name:    "login",
-		Args:    "[username]",
+		Args:    "[username|domain]",
 		Purpose: "Logs a user in to a controller.",
 		Doc:     loginDoc,
 	}
 }
 
+func (c *loginCommand) SetFlags(fset *gnuflag.FlagSet) {
+	c.ControllerCommandBase.SetFlags(fset)
+	fset.StringVar(&c.controllerName, "c", "", "Controller to operate in")
+	fset.StringVar(&c.controllerName, "controller", "", "")
+	fset.BoolVar(&c.forceHost, "host", false, "force the domain argument to be treated as the host name of a controller")
+}
+
 // Init implements Command.Init.
 func (c *loginCommand) Init(args []string) error {
 	var err error
-	c.User, err = cmd.ZeroOrOneArgs(args)
+	c.userOrDomain, err = cmd.ZeroOrOneArgs(args)
 	if err != nil {
 		return errors.Trace(err)
 	}
 	return nil
 }
 
-// LoginAPI provides the API methods that the login command uses.
-type LoginAPI interface {
-	Close() error
-}
-
-// ConnectionAPI provides relevant API methods off the underlying connection.
-type ConnectionAPI interface {
-	AuthTag() names.Tag
-	ControllerAccess() string
-}
-
 // Run implements Command.Run.
 func (c *loginCommand) Run(ctx *cmd.Context) error {
-	controllerName := c.ControllerName()
+	err := c.run(ctx)
+	if err != nil && c.onRunError != nil {
+		c.onRunError()
+	}
+	return err
+}
+
+var errNotControllerLogin = errors.New("not a controller login")
+
+func (c *loginCommand) run(ctx *cmd.Context) error {
 	store := c.ClientStore()
+	err := c.controllerLogin(ctx, store)
+	if errors.Cause(err) != errNotControllerLogin {
+		return errors.Trace(err)
+	}
+	user := c.userOrDomain
+	// Set the controller name as if this is a normal controller command.
+	if err := c.SetControllerName(c.controllerName, true); err != nil {
+		return errors.Trace(err)
+	}
+	controllerName := c.ControllerName()
 	accountDetails, err := store.AccountDetails(controllerName)
 	if err != nil && !errors.IsNotFound(err) {
 		return errors.Trace(err)
 	}
-
-	user := c.User
 	if user == "" && accountDetails == nil {
-		// The username has not been specified, and there
-		// is no current account. See if the user can log
-		// in with macaroons.
+		// The username has not been specified, and there is no
+		// current account. See if the user can log in with
+		// macaroons.
 		args, err := c.NewAPIConnectionParams(
 			store, controllerName, "",
 			&jujuclient.AccountDetails{},
@@ -105,10 +163,10 @@ func (c *loginCommand) Run(ctx *cmd.Context) error {
 		if err != nil {
 			return errors.Trace(err)
 		}
-		api, conn, err := c.newLoginAPI(args)
+		conn, err := newAPIConnection(args)
 		if err == nil {
 			authTag := conn.AuthTag()
-			api.Close()
+			conn.Close()
 			ctx.Infof("You are now logged in to %q as %q.", controllerName, authTag.Id())
 			return nil
 		}
@@ -143,8 +201,7 @@ func (c *loginCommand) Run(ctx *cmd.Context) error {
 	if accountDetails != nil && accountDetails.User != userTag.Id() {
 		return errors.New(`already logged in
 
-Run "juju logout" first before attempting to log in as a different user.
-`)
+Run "juju logout" first before attempting to log in as a different user.`)
 	}
 
 	// Log in without specifying a password in the account details. This
@@ -157,11 +214,11 @@ Run "juju logout" first before attempting to log in as a different user.
 	if err != nil {
 		return errors.Trace(err)
 	}
-	api, conn, err := c.newLoginAPI(params)
+	conn, err := newAPIConnection(params)
 	if err != nil {
 		return errors.Annotate(err, "creating API connection")
 	}
-	defer api.Close()
+	defer conn.Close()
 
 	accountDetails.LastKnownAccess = conn.ControllerAccess()
 	if err := store.UpdateAccount(controllerName, *accountDetails); err != nil {
@@ -169,4 +226,214 @@ Run "juju logout" first before attempting to log in as a different user.
 	}
 	ctx.Infof("You are now logged in to %q as %q.", controllerName, userTag.Id())
 	return nil
+}
+
+func (c *loginCommand) controllerLogin(ctx *cmd.Context, store jujuclient.ClientStore) error {
+	knownDomains, err := c.getKnownControllerDomains()
+	if err != nil {
+		// TODO(rogpeppe) perhaps this shouldn't be fatal.
+		return errors.Trace(err)
+	}
+	controllerHost := knownDomains[c.userOrDomain]
+	if controllerHost == "" {
+		if !c.forceHost {
+			return errNotControllerLogin
+		}
+		controllerHost = c.userOrDomain
+	}
+	if c.controllerName == "" {
+		// No explicitly specified controller name, so
+		// derive it from the domain.
+		if strings.Contains(c.userOrDomain, ":") {
+			return errors.Errorf("cannot use %q as controller name - use -c flag to choose a different one", c.userOrDomain)
+		}
+		c.controllerName = c.userOrDomain
+	}
+	store = modelcmd.QualifyingClientStore{store}
+	controllerDetails, accountDetails, err := c.publicControllerDetails(controllerHost)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	if err := c.updateController(
+		store,
+		c.controllerName,
+		controllerDetails,
+		accountDetails,
+	); err != nil {
+		return errors.Trace(err)
+	}
+	// Log into the controller to verify the credentials, and
+	// list the models available.
+	models, err := listModels(&c.ControllerCommandBase, accountDetails.User)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	for _, model := range models {
+		owner := names.NewUserTag(model.Owner)
+		if err := store.UpdateModel(
+			c.controllerName,
+			jujuclient.JoinOwnerModelName(owner, model.Name),
+			jujuclient.ModelDetails{model.UUID},
+		); err != nil {
+			return errors.Annotate(err, "storing model details")
+		}
+	}
+	if err := store.SetCurrentController(c.controllerName); err != nil {
+		return errors.Trace(err)
+	}
+
+	fmt.Fprintf(
+		ctx.Stderr, "Welcome, %s. You are now logged into %q.\n",
+		friendlyUserName(accountDetails.User), c.controllerName,
+	)
+	return c.maybeSetCurrentModel(ctx, store, c.controllerName, accountDetails.User, models)
+}
+
+// publicControllerDetails returns controller and account details to be registered
+// for the given public controller host name.
+func (c *loginCommand) publicControllerDetails(host string) (jujuclient.ControllerDetails, jujuclient.AccountDetails, error) {
+	fail := func(err error) (jujuclient.ControllerDetails, jujuclient.AccountDetails, error) {
+		return jujuclient.ControllerDetails{}, jujuclient.AccountDetails{}, err
+	}
+	apiAddr := host
+	if !strings.Contains(apiAddr, ":") {
+		apiAddr += ":443"
+	}
+	// Make a direct API connection because we don't yet know the
+	// controller UUID so can't store the thus-incomplete controller
+	// details to make a conventional connection.
+	//
+	// Unfortunately this means we'll connect twice to the controller
+	// but it's probably best to go through the conventional path the
+	// second time.
+	bclient, err := c.BakeryClient()
+	if err != nil {
+		return fail(errors.Trace(err))
+	}
+	dialOpts := api.DefaultDialOpts()
+	dialOpts.BakeryClient = bclient
+	conn, err := apiOpen(&c.JujuCommandBase, &api.Info{
+		Addrs: []string{apiAddr},
+	}, dialOpts)
+	if err != nil {
+		return fail(errors.Trace(err))
+	}
+	defer conn.Close()
+	user, ok := conn.AuthTag().(names.UserTag)
+	if !ok {
+		return fail(errors.Errorf("logged in as %v, not a user", conn.AuthTag()))
+	}
+	// If we get to here, then we have a cached macaroon for the registered
+	// user. If we encounter an error after here, we need to clear it.
+	c.onRunError = func() {
+		if err := c.ClearControllerMacaroons([]string{apiAddr}); err != nil {
+			logger.Errorf("failed to clear macaroon: %v", err)
+		}
+	}
+	return jujuclient.ControllerDetails{
+			APIEndpoints:   []string{apiAddr},
+			ControllerUUID: conn.ControllerTag().Id(),
+		}, jujuclient.AccountDetails{
+			User:            user.Id(),
+			LastKnownAccess: conn.ControllerAccess(),
+		}, nil
+}
+
+// updateController updates the controller and account details in the given client store,
+// using the given controller name and adding the controller if necessary.
+func (c *loginCommand) updateController(
+	store jujuclient.ClientStore,
+	controllerName string,
+	controllerDetails jujuclient.ControllerDetails,
+	accountDetails jujuclient.AccountDetails,
+) error {
+	// Check that the same controller isn't already stored, so that we
+	// can avoid needlessly asking for a controller name in that case.
+	all, err := store.AllControllers()
+	if err != nil {
+		return errors.Trace(err)
+	}
+	for name, ctl := range all {
+		if ctl.ControllerUUID == controllerDetails.ControllerUUID {
+			// TODO(rogpeppe) lp#1614010 Succeed but override the account details in this case?
+			return errors.Errorf("controller is already registered as %q", name)
+		}
+	}
+	if err := store.AddController(controllerName, controllerDetails); err != nil {
+		return errors.Trace(err)
+	}
+	if err := store.UpdateAccount(controllerName, accountDetails); err != nil {
+		return errors.Annotatef(err, "cannot update account information: %v", err)
+	}
+	return nil
+}
+
+const noModelsMessage = `
+There are no models available. You can add models with
+"juju add-model", or you can ask an administrator or owner
+of a model to grant access to that model with "juju grant".
+`
+
+func (c *loginCommand) maybeSetCurrentModel(ctx *cmd.Context, store jujuclient.ClientStore, controllerName, userName string, models []apibase.UserModel) error {
+	if len(models) == 0 {
+		fmt.Fprint(ctx.Stderr, noModelsMessage)
+		return nil
+	}
+
+	// If we get to here, there is at least one model.
+	if len(models) == 1 {
+		// There is exactly one model shared,
+		// so set it as the current model.
+		model := models[0]
+		owner := names.NewUserTag(model.Owner)
+		modelName := jujuclient.JoinOwnerModelName(owner, model.Name)
+		err := store.SetCurrentModel(controllerName, modelName)
+		if err != nil {
+			return errors.Trace(err)
+		}
+		fmt.Fprintf(ctx.Stderr, "\nCurrent model set to %q.\n", modelName)
+		return nil
+	}
+	fmt.Fprintf(ctx.Stderr, `
+There are %d models available. Use "juju switch" to select
+one of them:
+`, len(models))
+	user := names.NewUserTag(userName)
+	ownerModelNames := make(set.Strings)
+	otherModelNames := make(set.Strings)
+	for _, model := range models {
+		if model.Owner == userName {
+			ownerModelNames.Add(model.Name)
+			continue
+		}
+		owner := names.NewUserTag(model.Owner)
+		modelName := common.OwnerQualifiedModelName(model.Name, owner, user)
+		otherModelNames.Add(modelName)
+	}
+	for _, modelName := range ownerModelNames.SortedValues() {
+		fmt.Fprintf(ctx.Stderr, "  - juju switch %s\n", modelName)
+	}
+	for _, modelName := range otherModelNames.SortedValues() {
+		fmt.Fprintf(ctx.Stderr, "  - juju switch %s\n", modelName)
+	}
+	return nil
+}
+
+// getKnownControllerDomains returns the list of known
+// controller domain aliases.
+func (c *loginCommand) getKnownControllerDomains() (map[string]string, error) {
+	controllers := os.Getenv("JUJU_PUBLIC_CONTROLLERS")
+	m, err := keyvalues.Parse(strings.Fields(controllers), false)
+	if err != nil {
+		return nil, errors.Annotatef(err, "bad value for JUJU_PUBLIC_CONTROLLERS")
+	}
+	return m, nil
+}
+
+func friendlyUserName(user string) string {
+	u := names.NewUserTag(user)
+	if u.IsLocal() {
+		return u.Name()
+	}
+	return u.Id()
 }

--- a/cmd/juju/user/login_test.go
+++ b/cmd/juju/user/login_test.go
@@ -4,101 +4,86 @@
 package user_test
 
 import (
+	"bytes"
 	"strings"
 
 	"github.com/juju/cmd"
+	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/names.v2"
 
+	"github.com/juju/juju/api"
+	apibase "github.com/juju/juju/api/base"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/cmd/juju/user"
+	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/juju"
 	"github.com/juju/juju/jujuclient"
-	coretesting "github.com/juju/juju/testing"
 )
 
 type LoginCommandSuite struct {
 	BaseSuite
-	mockAPI  *mockLoginAPI
-	loginErr error
+	mockAPI *loginMockAPI
+
+	// apiConnectionParams is set when the mock newAPIConnection
+	// implementation installed by SetUpTest is called.
+	apiConnectionParams juju.NewAPIConnectionParams
 }
 
 var _ = gc.Suite(&LoginCommandSuite{})
 
 func (s *LoginCommandSuite) SetUpTest(c *gc.C) {
 	s.BaseSuite.SetUpTest(c)
-	s.mockAPI = &mockLoginAPI{}
-	s.loginErr = nil
-}
-
-func (s *LoginCommandSuite) run(c *gc.C, stdin string, args ...string) (*cmd.Context, juju.NewAPIConnectionParams, error) {
-	var argsOut juju.NewAPIConnectionParams
-	cmd, _ := user.NewLoginCommandForTest(func(args juju.NewAPIConnectionParams) (user.LoginAPI, user.ConnectionAPI, error) {
-		argsOut = args
+	s.mockAPI = &loginMockAPI{
+		authTag:          names.NewUserTag("user@external"),
+		controllerAccess: "superuser",
+	}
+	s.apiConnectionParams = juju.NewAPIConnectionParams{}
+	s.PatchValue(user.NewAPIConnection, func(p juju.NewAPIConnectionParams) (api.Connection, error) {
 		// The account details are modified in place, so take a copy.
-		accountDetails := *argsOut.AccountDetails
-		argsOut.AccountDetails = &accountDetails
-		if s.loginErr != nil {
-			err := s.loginErr
-			s.loginErr = nil
-			return nil, nil, err
-		}
-		return s.mockAPI, s.mockAPI, nil
-	}, s.store)
-	ctx := coretesting.Context(c)
-	if stdin == "" {
-		stdin = "sekrit\n"
-	}
-	ctx.Stdin = strings.NewReader(stdin)
-	err := coretesting.InitCommand(cmd, args)
-	if err != nil {
-		return nil, argsOut, err
-	}
-	err = cmd.Run(ctx)
-	return ctx, argsOut, err
+		accountDetails := *p.AccountDetails
+		p.AccountDetails = &accountDetails
+		s.apiConnectionParams = p
+		return s.mockAPI, nil
+	})
+	s.PatchValue(user.ListModels, func(_ *modelcmd.ControllerCommandBase, userName string) ([]apibase.UserModel, error) {
+		return nil, errors.New("unexpected call to ListModels")
+	})
+	s.PatchValue(user.APIOpen, func(c *modelcmd.JujuCommandBase, info *api.Info, opts api.DialOpts) (api.Connection, error) {
+		return nil, errors.New("unexpected call to apiOpen")
+	})
+	s.PatchValue(user.LoginClientStore, s.store)
 }
 
-func (s *LoginCommandSuite) TestInit(c *gc.C) {
+func (s *LoginCommandSuite) TestInitError(c *gc.C) {
 	for i, test := range []struct {
-		args        []string
-		user        string
-		errorString string
-	}{
-		{
-		// no args is fine
-		}, {
-			args: []string{"foobar"},
-			user: "foobar",
-		}, {
-			args:        []string{"--foobar"},
-			errorString: "flag provided but not defined: --foobar",
-		}, {
-			args:        []string{"foobar", "extra"},
-			errorString: `unrecognized args: \["extra"\]`,
-		},
-	} {
+		args   []string
+		stderr string
+	}{{
+		args:   []string{"--foobar"},
+		stderr: `error: flag provided but not defined: --foobar\n`,
+	}, {
+		args:   []string{"foobar", "extra"},
+		stderr: `error: unrecognized args: \["extra"\]\n`,
+	}} {
 		c.Logf("test %d", i)
-		wrappedCommand, command := user.NewLoginCommandForTest(nil, s.store)
-		err := coretesting.InitCommand(wrappedCommand, test.args)
-		if test.errorString == "" {
-			c.Check(command.User, gc.Equals, test.user)
-		} else {
-			c.Check(err, gc.ErrorMatches, test.errorString)
-		}
+		stdout, stderr, code := runLogin(c, "", test.args...)
+		c.Check(stdout, gc.Equals, "")
+		c.Check(stderr, gc.Matches, test.stderr)
+		c.Assert(code, gc.Equals, 2)
 	}
 }
 
 func (s *LoginCommandSuite) TestLogin(c *gc.C) {
-	context, args, err := s.run(c, "current-user\nsekrit\n")
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(coretesting.Stdout(context), gc.Equals, "")
-	c.Assert(coretesting.Stderr(context), gc.Equals, `
+	stdout, stderr, code := runLogin(c, "current-user\nsekrit\n")
+	c.Check(stdout, gc.Equals, "")
+	c.Check(stderr, gc.Equals, `
 username: You are now logged in to "testing" as "current-user".
-`[1:],
-	)
+`[1:])
+	c.Assert(code, gc.Equals, 0)
 	s.assertStorePassword(c, "current-user", "", "superuser")
-	c.Assert(args.AccountDetails, jc.DeepEquals, &jujuclient.AccountDetails{
+	c.Assert(s.apiConnectionParams.AccountDetails, jc.DeepEquals, &jujuclient.AccountDetails{
 		User: "current-user",
 	})
 }
@@ -106,68 +91,79 @@ username: You are now logged in to "testing" as "current-user".
 func (s *LoginCommandSuite) TestLoginNewUser(c *gc.C) {
 	err := s.store.RemoveAccount("testing")
 	c.Assert(err, jc.ErrorIsNil)
-	context, args, err := s.run(c, "", "new-user")
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(coretesting.Stdout(context), gc.Equals, "")
-	c.Assert(coretesting.Stderr(context), gc.Equals, `
+	stdout, stderr, code := runLogin(c, "sekrit\n", "new-user")
+	c.Check(stdout, gc.Equals, "")
+	c.Check(stderr, gc.Equals, `
 You are now logged in to "testing" as "new-user".
-`[1:],
-	)
+`[1:])
+	c.Assert(code, gc.Equals, 0)
 	s.assertStorePassword(c, "new-user", "", "superuser")
-	c.Assert(args.AccountDetails, jc.DeepEquals, &jujuclient.AccountDetails{
+	c.Assert(s.apiConnectionParams.AccountDetails, jc.DeepEquals, &jujuclient.AccountDetails{
 		User: "new-user",
 	})
 }
 
 func (s *LoginCommandSuite) TestLoginAlreadyLoggedInSameUser(c *gc.C) {
-	_, _, err := s.run(c, "", "current-user")
-	c.Assert(err, jc.ErrorIsNil)
+	stdout, stderr, code := runLogin(c, "", "current-user")
+	c.Check(stdout, gc.Equals, "")
+	c.Check(stderr, gc.Equals, `You are now logged in to "testing" as "current-user".
+`)
+	c.Assert(code, gc.Equals, 0)
 }
 
 func (s *LoginCommandSuite) TestLoginAlreadyLoggedInDifferentUser(c *gc.C) {
-	_, _, err := s.run(c, "", "other-user")
-	c.Assert(err, gc.ErrorMatches, `already logged in
+	stdout, stderr, code := runLogin(c, "sekrit\n", "other-user")
+	c.Check(stdout, gc.Equals, "")
+	c.Check(stderr, gc.Equals, `
+error: already logged in
 
 Run "juju logout" first before attempting to log in as a different user.
-`)
+`[1:])
+	c.Assert(code, gc.Equals, 1)
 }
 
 func (s *LoginCommandSuite) TestLoginWithMacaroons(c *gc.C) {
 	err := s.store.RemoveAccount("testing")
 	c.Assert(err, jc.ErrorIsNil)
-	context, args, err := s.run(c, "")
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(coretesting.Stdout(context), gc.Equals, "")
-	c.Assert(coretesting.Stderr(context), gc.Equals, `
+	stdout, stderr, code := runLogin(c, "")
+	c.Check(stderr, gc.Equals, `
 You are now logged in to "testing" as "user@external".
-`[1:],
-	)
-	c.Assert(args.AccountDetails, jc.DeepEquals, &jujuclient.AccountDetails{})
+`[1:])
+	c.Check(stdout, gc.Equals, ``)
+	c.Assert(code, gc.Equals, 0)
+	c.Assert(s.apiConnectionParams.AccountDetails, jc.DeepEquals, &jujuclient.AccountDetails{})
 }
 
 func (s *LoginCommandSuite) TestLoginWithMacaroonsNotSupported(c *gc.C) {
 	err := s.store.RemoveAccount("testing")
 	c.Assert(err, jc.ErrorIsNil)
-	s.loginErr = &params.Error{Code: params.CodeNoCreds, Message: "barf"}
-	context, _, err := s.run(c, "new-user\nsekrit\n")
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(coretesting.Stdout(context), gc.Equals, "")
-	c.Assert(coretesting.Stderr(context), gc.Equals, `
+	*user.NewAPIConnection = func(p juju.NewAPIConnectionParams) (api.Connection, error) {
+		if !c.Check(p.AccountDetails, gc.NotNil) {
+			return nil, errors.New("no account details")
+		}
+		if p.AccountDetails.User == "" && p.AccountDetails.Password == "" {
+			return nil, &params.Error{Code: params.CodeNoCreds, Message: "barf"}
+		}
+		c.Check(p.AccountDetails.User, gc.Equals, "new-user")
+		return s.mockAPI, nil
+	}
+	stdout, stderr, code := runLogin(c, "new-user\nsekrit\n")
+	c.Check(stdout, gc.Equals, ``)
+	c.Check(stderr, gc.Equals, `
 username: You are now logged in to "testing" as "new-user".
-`[1:],
-	)
+`[1:])
+	c.Assert(code, gc.Equals, 0)
 }
 
-type mockLoginAPI struct{}
-
-func (*mockLoginAPI) Close() error {
-	return nil
-}
-
-func (*mockLoginAPI) AuthTag() names.Tag {
-	return names.NewUserTag("user@external")
-}
-
-func (*mockLoginAPI) ControllerAccess() string {
-	return "superuser"
+func runLogin(c *gc.C, stdin string, args ...string) (stdout, stderr string, errCode int) {
+	c.Logf("in LoginControllerSuite.run")
+	var stdoutBuf, stderrBuf bytes.Buffer
+	ctxt := &cmd.Context{
+		Dir:    c.MkDir(),
+		Stdin:  strings.NewReader(stdin),
+		Stdout: &stdoutBuf,
+		Stderr: &stderrBuf,
+	}
+	exitCode := cmd.Main(user.NewLoginCommand(), ctxt, args)
+	return stdoutBuf.String(), stderrBuf.String(), exitCode
 }

--- a/cmd/juju/user/logincontroller_test.go
+++ b/cmd/juju/user/logincontroller_test.go
@@ -1,0 +1,218 @@
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package user_test
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"strings"
+
+	"github.com/juju/cmd"
+	"github.com/juju/errors"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/names.v2"
+
+	"github.com/juju/juju/api"
+	"github.com/juju/juju/api/base"
+	"github.com/juju/juju/cmd/juju/user"
+	"github.com/juju/juju/cmd/modelcmd"
+	"github.com/juju/juju/jujuclient"
+)
+
+// LoginControllerSuite tests the functionality of the login command
+// that logs into controllers rather than choosing a user name.
+// Most of the tests come from cmd/juju/controller/register_test.go - eventually
+// that command will be deleted.
+type LoginControllerSuite struct {
+	BaseSuite
+	apiConnection      *loginMockAPI
+	listModels         func(jujuclient.ClientStore, string, string) ([]base.UserModel, error)
+	listModelsUserName string
+	server             *httptest.Server
+	httpHandler        http.Handler
+}
+
+var _ = gc.Suite(&LoginControllerSuite{})
+
+func (s *LoginControllerSuite) SetUpTest(c *gc.C) {
+	s.BaseSuite.SetUpTest(c)
+
+	s.httpHandler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
+	s.server = httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		s.httpHandler.ServeHTTP(w, r)
+	}))
+
+	serverURL, err := url.Parse(s.server.URL)
+	c.Assert(err, jc.ErrorIsNil)
+	s.apiConnection = &loginMockAPI{
+		controllerTag: names.NewControllerTag(mockControllerUUID),
+		addr:          serverURL.Host,
+	}
+	s.listModelsUserName = ""
+	s.PatchValue(user.ListModels, func(_ *modelcmd.ControllerCommandBase, userName string) ([]base.UserModel, error) {
+		s.listModelsUserName = userName
+		return nil, nil
+	})
+	s.PatchValue(user.APIOpen, func(c *modelcmd.JujuCommandBase, info *api.Info, opts api.DialOpts) (api.Connection, error) {
+		return s.apiConnection, nil
+	})
+	s.PatchValue(user.LoginClientStore, s.store)
+}
+
+func (s *LoginControllerSuite) TearDownTest(c *gc.C) {
+	s.server.Close()
+	s.FakeJujuXDGDataHomeSuite.TearDownTest(c)
+}
+
+func (s *LoginControllerSuite) TestRegisterPublic(c *gc.C) {
+	os.Setenv("JUJU_PUBLIC_CONTROLLERS", "bighost=bighost.jujucharms.com")
+	s.apiConnection.authTag = names.NewUserTag("bob@external")
+	s.apiConnection.controllerAccess = "login"
+	stdout, stderr, code := s.run(c, "bighost")
+	c.Check(stderr, gc.Equals, `
+Welcome, bob@external. You are now logged into "bighost".
+`[1:]+user.NoModelsMessage)
+	c.Check(stdout, gc.Equals, "")
+	c.Assert(code, gc.Equals, 0)
+
+	// The controller and account details should be recorded with
+	// the specified controller name and user
+	// name from the auth tag.
+
+	controller, err := s.store.ControllerByName("bighost")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(controller, jc.DeepEquals, &jujuclient.ControllerDetails{
+		ControllerUUID: mockControllerUUID,
+		APIEndpoints:   []string{"bighost.jujucharms.com:443"},
+	})
+	account, err := s.store.AccountDetails("bighost")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(account, jc.DeepEquals, &jujuclient.AccountDetails{
+		User:            "bob@external",
+		LastKnownAccess: "login",
+	})
+}
+
+func (s *LoginControllerSuite) TestRegisterPublicHostname(c *gc.C) {
+	s.apiConnection.authTag = names.NewUserTag("bob@external")
+	s.apiConnection.controllerAccess = "login"
+	stdout, stderr, code := s.run(c, "--host", "0.1.2.3")
+	c.Check(stderr, gc.Equals, `
+Welcome, bob@external. You are now logged into "0.1.2.3".
+`[1:]+user.NoModelsMessage)
+	c.Check(stdout, gc.Equals, "")
+	c.Assert(code, gc.Equals, 0)
+
+	// The controller and account details should be recorded with
+	// the specified controller name and user
+	// name from the auth tag.
+	controller, err := s.store.ControllerByName("0.1.2.3")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(controller, jc.DeepEquals, &jujuclient.ControllerDetails{
+		ControllerUUID: mockControllerUUID,
+		APIEndpoints:   []string{"0.1.2.3:443"},
+	})
+	account, err := s.store.AccountDetails("0.1.2.3")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(account, jc.DeepEquals, &jujuclient.AccountDetails{
+		User:            "bob@external",
+		LastKnownAccess: "login",
+	})
+}
+
+func (s *LoginControllerSuite) TestRegisterPublicHostnameWithPort(c *gc.C) {
+	s.apiConnection.authTag = names.NewUserTag("bob@external")
+	s.apiConnection.controllerAccess = "login"
+	stdout, stderr, code := s.run(c, "--host", "0.1.2.3:5678")
+	c.Check(stdout, gc.Equals, "")
+	c.Check(stderr, gc.Equals, "error: cannot use \"0.1.2.3:5678\" as controller name - use -c flag to choose a different one\n")
+	c.Check(code, gc.Equals, 1)
+}
+
+func (s *LoginControllerSuite) TestRegisterPublicHostnameWithPortAndControllerFlag(c *gc.C) {
+	s.apiConnection.authTag = names.NewUserTag("bob@external")
+	s.apiConnection.controllerAccess = "login"
+	stdout, stderr, code := s.run(c, "-c", "foo", "--host", "0.1.2.3:5678")
+	c.Check(stdout, gc.Equals, "")
+	c.Check(stderr, gc.Equals, `
+Welcome, bob@external. You are now logged into "foo".
+`[1:]+user.NoModelsMessage)
+	c.Check(stdout, gc.Equals, "")
+	c.Assert(code, gc.Equals, 0)
+
+	// The controller and account details should be recorded with
+	// the specified controller name and user
+	// name from the auth tag.
+	controller, err := s.store.ControllerByName("foo")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(controller, jc.DeepEquals, &jujuclient.ControllerDetails{
+		ControllerUUID: mockControllerUUID,
+		APIEndpoints:   []string{"0.1.2.3:5678"},
+	})
+}
+
+func (s *LoginControllerSuite) TestRegisterPublicAPIOpenError(c *gc.C) {
+	os.Setenv("JUJU_PUBLIC_CONTROLLERS", "bighost=bighost.jujucharms.com")
+	*user.APIOpen = func(c *modelcmd.JujuCommandBase, info *api.Info, opts api.DialOpts) (api.Connection, error) {
+		return nil, errors.New("open failed")
+	}
+	stdout, stderr, code := s.run(c, "bighost")
+	c.Check(stdout, gc.Equals, "")
+	c.Check(stderr, gc.Matches, `error: open failed\n`)
+	c.Check(code, gc.Equals, 1)
+}
+
+func (s *LoginControllerSuite) run(c *gc.C, args ...string) (stdout, stderr string, errCode int) {
+	c.Logf("in LoginControllerSuite.run")
+	var stdoutBuf, stderrBuf bytes.Buffer
+	ctxt := &cmd.Context{
+		Dir:    c.MkDir(),
+		Stdin:  strings.NewReader(""),
+		Stdout: &stdoutBuf,
+		Stderr: &stderrBuf,
+	}
+	exitCode := cmd.Main(user.NewLoginCommand(), ctxt, args)
+	return stdoutBuf.String(), stderrBuf.String(), exitCode
+}
+
+// loginMockAPIConnection implements just enough of the api.Connection interface
+// to satisfy the methods used by the login command.
+type loginMockAPI struct {
+	// This will be nil - it's just there to satisfy the api.Connection
+	// interface methods not explicitly defined by loginMockAPIConnection.
+	api.Connection
+
+	// addr is returned by Addr.
+	addr string
+
+	// controllerTag is returned by ControllerTag.
+	controllerTag names.ControllerTag
+
+	// authTag is returned by AuthTag.
+	authTag names.Tag
+
+	// controllerAccess is returned by ControllerAccess.
+	controllerAccess string
+}
+
+func (*loginMockAPI) Close() error {
+	return nil
+}
+
+func (m *loginMockAPI) ControllerTag() names.ControllerTag {
+	return m.controllerTag
+}
+
+func (m *loginMockAPI) AuthTag() names.Tag {
+	return m.authTag
+}
+
+func (m *loginMockAPI) ControllerAccess() string {
+	return m.controllerAccess
+}
+
+const mockControllerUUID = "df136476-12e9-11e4-8a70-b2227cce2b54"


### PR DESCRIPTION
This is the first stage of a process that will eventually
deprecate juju register in favour of juju login.

Much of the new code in juju login is copied from
juju register.

To QA, try "juju login --host some-public-controller-address",
which should do the same thing as "juju register some-public-controller-address".
You could also try changing the table in getKnownControllerDomains
and doing "juju login some-alias".
