### PR TITLE
Allow superuser to show status of other user models (lp: 1663506)

### DIFF
--- a/apiserver/client/backend.go
+++ b/apiserver/client/backend.go
@@ -49,6 +49,7 @@ type Backend interface {
 	Application(string) (*state.Application, error)
 	ApplicationLeaders() (map[string]string, error)
 	Charm(*charm.URL) (*state.Charm, error)
+	ControllerTag() names.ControllerTag
 	EndpointsRelation(...state.Endpoint) (*state.Relation, error)
 	FindEntity(names.Tag) (state.Entity, error)
 	ForModel(tag names.ModelTag) (*state.State, error)

--- a/apiserver/client/client.go
+++ b/apiserver/client/client.go
@@ -62,22 +62,32 @@ type Client struct {
 }
 
 func (c *Client) checkCanRead() error {
+	isAdmin, err := c.api.auth.HasPermission(permission.SuperuserAccess, c.api.stateAccessor.ControllerTag())
+	if err != nil {
+		return errors.Trace(err)
+	}
+
 	canRead, err := c.api.auth.HasPermission(permission.ReadAccess, c.api.stateAccessor.ModelTag())
 	if err != nil {
 		return errors.Trace(err)
 	}
-	if !canRead {
+	if !canRead && !isAdmin {
 		return common.ErrPerm
 	}
 	return nil
 }
 
 func (c *Client) checkCanWrite() error {
+	isAdmin, err := c.api.auth.HasPermission(permission.SuperuserAccess, c.api.stateAccessor.ControllerTag())
+	if err != nil {
+		return errors.Trace(err)
+	}
+
 	canWrite, err := c.api.auth.HasPermission(permission.WriteAccess, c.api.stateAccessor.ModelTag())
 	if err != nil {
 		return errors.Trace(err)
 	}
-	if !canWrite {
+	if !canWrite && !isAdmin {
 		return common.ErrPerm
 	}
 	return nil

--- a/apiserver/client/statushistory_test.go
+++ b/apiserver/client/statushistory_test.go
@@ -232,6 +232,10 @@ func (m *mockState) ModelTag() names.ModelTag {
 	return names.NewModelTag("deadbeef-0bad-400d-8000-4b1d0d06f00d")
 }
 
+func (m *mockState) ControllerTag() names.ControllerTag {
+	return names.NewControllerTag("deadbeef-0bad-400d-8000-4b1d0d06f00d")
+}
+
 func (m *mockState) Unit(name string) (client.Unit, error) {
 	if name != "unit/0" {
 		return nil, errors.NotFoundf("%v", name)


### PR DESCRIPTION
## Description of change
Superuser can now show status for models belonging to others, given that the user should have root like privileges and it can list those models it makes sense that it can show status too.


## QA steps

Follow reproduction steps for https://bugs.launchpad.net/juju/+bug/1663506 and notice the bug is no longer present.

## Documentation changes

No, the user cli is the same

## Bug reference

https://bugs.launchpad.net/juju/+bug/1663506
