### PR TITLE
lxd: prefer cached images, support CentOS

### DIFF
--- a/container/lxd/lxd.go
+++ b/container/lxd/lxd.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
+	"github.com/juju/utils/arch"
 
 	"github.com/juju/juju/cloudconfig/containerinit"
 	"github.com/juju/juju/cloudconfig/instancecfg"
@@ -108,8 +109,13 @@ func (manager *containerManager) CreateContainer(
 		}
 	}
 
+	// It is only possible to provision LXD containers
+	// of the same architecture as the host.
+	hostArch := arch.HostArch()
+
 	imageName, err := manager.client.EnsureImageExists(
 		series,
+		hostArch,
 		lxdclient.DefaultImageSources,
 		func(progress string) {
 			callback(status.Provisioning, progress, nil)

--- a/container/lxd/lxd.go
+++ b/container/lxd/lxd.go
@@ -108,11 +108,13 @@ func (manager *containerManager) CreateContainer(
 		}
 	}
 
-	err = manager.client.EnsureImageExists(series,
+	imageName, err := manager.client.EnsureImageExists(
+		series,
 		lxdclient.DefaultImageSources,
 		func(progress string) {
 			callback(status.Provisioning, progress, nil)
-		})
+		},
+	)
 	if err != nil {
 		err = errors.Annotatef(err, "failed to ensure LXD image")
 		return
@@ -171,7 +173,7 @@ func (manager *containerManager) CreateContainer(
 
 	spec := lxdclient.InstanceSpec{
 		Name:     name,
-		Image:    manager.client.ImageNameForSeries(series),
+		Image:    imageName,
 		Metadata: metadata,
 		Devices:  nics,
 		Profiles: profiles,

--- a/provider/lxd/environ_broker.go
+++ b/provider/lxd/environ_broker.go
@@ -140,10 +140,6 @@ func (env *environ) newRawInstance(args environs.StartInstanceParams) (*lxdclien
 		return nil, errors.Trace(err)
 	}
 
-	series := args.InstanceConfig.Series
-	// TODO(jam): We should get this information from EnsureImageExists, or
-	// something given to us from 'raw', not assume it ourselves.
-	image := "ubuntu-" + series
 	// TODO: support args.Constraints.Arch, we'll want to map from
 
 	// Keep track of StatusCallback output so we may clean up later.
@@ -170,7 +166,9 @@ func (env *environ) newRawInstance(args environs.StartInstanceParams) (*lxdclien
 	imageCallback := func(copyProgress string) {
 		statusCallback(status.Allocating, copyProgress)
 	}
-	if err := env.raw.EnsureImageExists(series, imageSources, imageCallback); err != nil {
+	series := args.InstanceConfig.Series
+	image, err := env.raw.EnsureImageExists(series, imageSources, imageCallback)
+	if err != nil {
 		return nil, errors.Trace(err)
 	}
 	cleanupCallback() // Clean out any long line of completed download status

--- a/provider/lxd/environ_broker.go
+++ b/provider/lxd/environ_broker.go
@@ -39,13 +39,14 @@ func (env *environ) StartInstance(args environs.StartInstanceParams) (*environs.
 	series := args.Tools.OneSeries()
 	logger.Debugf("StartInstance: %q, %s", args.InstanceConfig.MachineId, series)
 
-	if err := env.finishInstanceConfig(args); err != nil {
+	arch, err := env.finishInstanceConfig(args)
+	if err != nil {
 		return nil, errors.Trace(err)
 	}
 
 	// TODO(ericsnow) Handle constraints?
 
-	raw, err := env.newRawInstance(args)
+	raw, err := env.newRawInstance(args, arch)
 	if err != nil {
 		if args.StatusCallback != nil {
 			args.StatusCallback(status.ProvisioningError, err.Error(), nil)
@@ -64,23 +65,22 @@ func (env *environ) StartInstance(args environs.StartInstanceParams) (*environs.
 	return &result, nil
 }
 
-func (env *environ) finishInstanceConfig(args environs.StartInstanceParams) error {
+func (env *environ) finishInstanceConfig(args environs.StartInstanceParams) (string, error) {
 	// TODO(natefinch): This is only correct so long as the lxd is running on
 	// the local machine.  If/when we support a remote lxd environment, we'll
 	// need to change this to match the arch of the remote machine.
-	tools, err := args.Tools.Match(tools.Filter{Arch: arch.HostArch()})
+	arch := arch.HostArch()
+	tools, err := args.Tools.Match(tools.Filter{Arch: arch})
 	if err != nil {
-		return errors.Trace(err)
+		return "", errors.Trace(err)
 	}
 	if err := args.InstanceConfig.SetTools(tools); err != nil {
-		return errors.Trace(err)
+		return "", errors.Trace(err)
 	}
-
 	if err := instancecfg.FinishInstanceConfig(args.InstanceConfig, env.ecfg.Config); err != nil {
-		return errors.Trace(err)
+		return "", errors.Trace(err)
 	}
-
-	return nil
+	return arch, nil
 }
 
 func (env *environ) getImageSources() ([]lxdclient.Remote, error) {
@@ -125,7 +125,10 @@ func (env *environ) getImageSources() ([]lxdclient.Remote, error) {
 // newRawInstance is where the new physical instance is actually
 // provisioned, relative to the provided args and spec. Info for that
 // low-level instance is returned.
-func (env *environ) newRawInstance(args environs.StartInstanceParams) (*lxdclient.Instance, error) {
+func (env *environ) newRawInstance(
+	args environs.StartInstanceParams,
+	arch string,
+) (*lxdclient.Instance, error) {
 	hostname, err := env.namespace.Hostname(args.InstanceConfig.MachineId)
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -167,7 +170,7 @@ func (env *environ) newRawInstance(args environs.StartInstanceParams) (*lxdclien
 		statusCallback(status.Allocating, copyProgress)
 	}
 	series := args.InstanceConfig.Series
-	image, err := env.raw.EnsureImageExists(series, imageSources, imageCallback)
+	image, err := env.raw.EnsureImageExists(series, arch, imageSources, imageCallback)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/provider/lxd/environ_broker_test.go
+++ b/provider/lxd/environ_broker_test.go
@@ -35,6 +35,9 @@ func (s *environBrokerSuite) TestStartInstance(c *gc.C) {
 	c.Check(result.Instance, gc.DeepEquals, s.Instance)
 	c.Check(result.Hardware, gc.DeepEquals, s.HWC)
 	c.Assert(s.StartInstArgs.InstanceConfig.AgentVersion().Arch, gc.Equals, arch.ARM64)
+
+	s.Stub.CheckCallNames(c, "EnsureImageExists", "AddInstance")
+	s.Stub.CheckCall(c, 0, "EnsureImageExists", "trusty", "arm64")
 }
 
 func (s *environBrokerSuite) TestStartInstanceNoTools(c *gc.C) {

--- a/provider/lxd/environ_raw.go
+++ b/provider/lxd/environ_raw.go
@@ -52,7 +52,7 @@ type lxdProfiles interface {
 }
 
 type lxdImages interface {
-	EnsureImageExists(series string, sources []lxdclient.Remote, copyProgressHandler func(string)) error
+	EnsureImageExists(series string, sources []lxdclient.Remote, copyProgressHandler func(string)) (string, error)
 }
 
 func newRawProvider(spec environs.CloudSpec, local bool) (*rawProvider, error) {

--- a/provider/lxd/environ_raw.go
+++ b/provider/lxd/environ_raw.go
@@ -52,7 +52,7 @@ type lxdProfiles interface {
 }
 
 type lxdImages interface {
-	EnsureImageExists(series string, sources []lxdclient.Remote, copyProgressHandler func(string)) (string, error)
+	EnsureImageExists(series, arch string, sources []lxdclient.Remote, copyProgressHandler func(string)) (string, error)
 }
 
 func newRawProvider(spec environs.CloudSpec, local bool) (*rawProvider, error) {

--- a/provider/lxd/testing_test.go
+++ b/provider/lxd/testing_test.go
@@ -8,6 +8,7 @@ package lxd
 import (
 	"net"
 	"os"
+	"path"
 
 	"github.com/juju/errors"
 	gitjujutesting "github.com/juju/testing"
@@ -505,13 +506,13 @@ func (conn *StubClient) RemoveInstances(prefix string, ids ...string) error {
 	return nil
 }
 
-func (conn *StubClient) EnsureImageExists(series string, _ []lxdclient.Remote, _ func(string)) error {
+func (conn *StubClient) EnsureImageExists(series string, _ []lxdclient.Remote, _ func(string)) (string, error) {
 	conn.AddCall("EnsureImageExists", series)
 	if err := conn.NextErr(); err != nil {
-		return errors.Trace(err)
+		return "", errors.Trace(err)
 	}
 
-	return nil
+	return path.Join("juju", series, "amd64"), nil
 }
 
 func (conn *StubClient) Addresses(name string) ([]network.Address, error) {

--- a/provider/lxd/testing_test.go
+++ b/provider/lxd/testing_test.go
@@ -506,13 +506,13 @@ func (conn *StubClient) RemoveInstances(prefix string, ids ...string) error {
 	return nil
 }
 
-func (conn *StubClient) EnsureImageExists(series string, _ []lxdclient.Remote, _ func(string)) (string, error) {
-	conn.AddCall("EnsureImageExists", series)
+func (conn *StubClient) EnsureImageExists(series, arch string, _ []lxdclient.Remote, _ func(string)) (string, error) {
+	conn.AddCall("EnsureImageExists", series, arch)
 	if err := conn.NextErr(); err != nil {
 		return "", errors.Trace(err)
 	}
 
-	return path.Join("juju", series, "amd64"), nil
+	return path.Join("juju", series, arch), nil
 }
 
 func (conn *StubClient) Addresses(name string) ([]network.Address, error) {

--- a/tools/lxdclient/client_image.go
+++ b/tools/lxdclient/client_image.go
@@ -7,16 +7,21 @@ package lxdclient
 
 import (
 	"fmt"
+	"path"
 
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
+	"github.com/juju/utils/os"
+	jujuseries "github.com/juju/utils/series"
 	"github.com/lxc/lxd"
+	"github.com/lxc/lxd/shared"
 
 	"github.com/juju/juju/utils/stringforwarder"
 )
 
 type rawImageClient interface {
 	GetAlias(string) string
+	GetImageInfo(string) (*shared.ImageInfo, error)
 }
 
 type remoteClient interface {
@@ -92,13 +97,33 @@ func (p *progressContext) copyProgress(progress string) {
 // @param copyProgressHandler: a callback function. If we have to download an
 // image, we will call this with messages indicating how much of the download
 // we have completed (and where we are downloading it from).
-func (i *imageClient) EnsureImageExists(series string, sources []Remote, copyProgressHandler func(string)) error {
+func (i *imageClient) EnsureImageExists(series string, sources []Remote, copyProgressHandler func(string)) (string, error) {
 	// TODO(jam) Find a way to test this, even though lxd.Client can't
 	// really be stubbed out because CopyImage takes one directly and pokes
 	// at private methods so we can't easily tweak it.
-	name := i.ImageNameForSeries(series)
 
-	lastErr := errors.New("image not imported!")
+	// NOTE(axw) architecture should be passed into this function, as
+	// indicated by the TODO in the function's doc comment. When it is,
+	// use get rid of this.
+	const arch = "amd64"
+
+	// First check if the image exists locally.
+	var lastErr error
+	imageName := seriesLocalAlias(series, arch)
+	target := i.raw.GetAlias(imageName)
+	if target != "" {
+		// We already have an image with the given alias,
+		// so just use that.
+		return imageName, nil
+	}
+
+	// We don't have an image locally with the juju-specific alias,
+	// so look in each of the provided remote sources for any of
+	// the expected aliases.
+	aliases, err := seriesRemoteAliases(series, arch)
+	if err != nil {
+		return "", errors.Trace(err)
+	}
 	for _, remote := range sources {
 		source, err := i.connectToSource(remote)
 		if err != nil {
@@ -106,42 +131,73 @@ func (i *imageClient) EnsureImageExists(series string, sources []Remote, copyPro
 			lastErr = err
 			continue
 		}
-
-		// TODO(jam): there are multiple possible spellings for aliases,
-		// unfortunately. cloud-images only hosts ubuntu images, and
-		// aliases them as "trusty" or "trusty/amd64" or
-		// "trusty/amd64/20160304". However, we should be more
-		// explicit. and use "ubuntu/trusty/amd64" as our default
-		// naming scheme, and only fall back for synchronization.
-		target := source.GetAlias(series)
-		if target == "" {
-			logger.Infof("no image for %s found in %s", name, source.URL())
-			// TODO(jam) Add a test that we skip sources that don't
-			// have what we are looking for
+		err = i.ensureImage(series, imageName, aliases, source, copyProgressHandler)
+		if errors.IsNotFound(err) {
 			continue
 		}
-		logger.Infof("found image from %s for %s = %s",
-			source.URL(), series, target)
-		forwarder := stringforwarder.New(copyProgressHandler)
-		defer func() {
-			dropCount := forwarder.Stop()
-			logger.Debugf("dropped %d progress messages", dropCount)
-		}()
-		adapter := &progressContext{
-			logger:  logger,
-			level:   loggo.INFO,
-			context: fmt.Sprintf("copying image for %s from %s: %%s", name, source.URL()),
-			forward: forwarder.Forward,
+		if lastErr = err; lastErr == nil {
+			break
 		}
-		err = source.CopyImage(series, i.raw, []string{name}, adapter.copyProgress)
-		return errors.Annotatef(err, "unable to get LXD image for %s", name)
 	}
-	return lastErr
+	return imageName, lastErr
 }
 
-// A common place to compute image names (aliases) based on the series
-func (i imageClient) ImageNameForSeries(series string) string {
-	// TODO(jam) Do we need 'ubuntu' in there? We only need it if "series"
-	// would collide, but all our supported series are disjoint
-	return fmt.Sprintf("ubuntu-%s", series)
+func (i *imageClient) ensureImage(
+	series, imageName string,
+	aliases []string,
+	source remoteClient,
+	copyProgressHandler func(string),
+) error {
+	// Look for an image with any of the aliases.
+	var alias, target string
+	for _, alias = range aliases {
+		if target = source.GetAlias(alias); target != "" {
+			break
+		}
+	}
+	if target == "" {
+		// TODO(jam) Add a test that we skip sources that don't
+		// have what we are looking for
+		logger.Infof("no image for %s found in %s", imageName, source.URL())
+		return errors.NotFoundf("image for %s in %s", imageName, source.URL())
+	}
+
+	logger.Infof("found image from %s for %s = %s", source.URL(), imageName, target)
+	forwarder := stringforwarder.New(copyProgressHandler)
+	defer func() {
+		dropCount := forwarder.Stop()
+		logger.Debugf("dropped %d progress messages", dropCount)
+	}()
+	adapter := &progressContext{
+		logger:  logger,
+		level:   loggo.INFO,
+		context: fmt.Sprintf("copying image for %s from %s: %%s", imageName, source.URL()),
+		forward: forwarder.Forward,
+	}
+	err := source.CopyImage(alias, i.raw, []string{imageName}, adapter.copyProgress)
+	return errors.Annotatef(err, "unable to get LXD image for %s", imageName)
+}
+
+// seriesLocalAlias returns the alias to assign to images for the
+// specified series. The alias is juju-specific, to support the
+// user supplying a customised image (e.g. CentOS with cloud-init).
+func seriesLocalAlias(series, arch string) string {
+	return fmt.Sprintf("juju/%s/%s", series, arch)
+}
+
+// seriesRemoteAliases returns the aliases to look for in remotes.
+func seriesRemoteAliases(series, arch string) ([]string, error) {
+	seriesOS, err := jujuseries.GetOSFromSeries(series)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	switch seriesOS {
+	case os.Ubuntu:
+		return []string{path.Join(series, arch)}, nil
+	case os.CentOS:
+		if series == "centos7" && arch == "amd64" {
+			return []string{"centos/7/amd64"}, nil
+		}
+	}
+	return nil, errors.NotSupportedf("series %q", series)
 }

--- a/tools/lxdclient/client_image_test.go
+++ b/tools/lxdclient/client_image_test.go
@@ -127,11 +127,11 @@ func (s *stubConnector) connectToSource(remote Remote) (remoteClient, error) {
 }
 
 func (s *imageSuite) TestEnsureImageExistsAlreadyPresent(c *gc.C) {
-	s.testEnsureImageExistsAlreadyPresent(c, "trusty", "juju/trusty/amd64")
-	s.testEnsureImageExistsAlreadyPresent(c, "centos7", "juju/centos7/amd64")
+	s.testEnsureImageExistsAlreadyPresent(c, "trusty", "ppc64el", "juju/trusty/ppc64el")
+	s.testEnsureImageExistsAlreadyPresent(c, "centos7", "ppc64el", "juju/centos7/ppc64el")
 }
 
-func (s *imageSuite) testEnsureImageExistsAlreadyPresent(c *gc.C, series, localAlias string) {
+func (s *imageSuite) testEnsureImageExistsAlreadyPresent(c *gc.C, series, arch, localAlias string) {
 	connector := MakeConnector(s.Stub, s.remoteWithTrusty)
 	raw := &stubClient{
 		stub:    s.Stub,
@@ -142,7 +142,7 @@ func (s *imageSuite) testEnsureImageExistsAlreadyPresent(c *gc.C, series, localA
 		connectToSource: connector.connectToSource,
 	}
 	s.Stub.ResetCalls()
-	image, err := client.EnsureImageExists(series, []Remote{s.remoteWithTrusty.AsRemote()}, nil)
+	image, err := client.EnsureImageExists(series, arch, []Remote{s.remoteWithTrusty.AsRemote()}, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(image, gc.Equals, localAlias)
 	s.Stub.CheckCalls(c, []testing.StubCall{
@@ -166,7 +166,7 @@ func (s *imageSuite) TestEnsureImageExistsFirstRemote(c *gc.C) {
 	}
 	remotes := []Remote{s.remoteWithTrusty.AsRemote()}
 	s.Stub.ResetCalls()
-	_, err := client.EnsureImageExists("trusty", remotes, nil)
+	_, err := client.EnsureImageExists("trusty", "amd64", remotes, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	// We didn't find it locally
 	s.Stub.CheckCalls(c, []testing.StubCall{
@@ -211,7 +211,7 @@ func (s *imageSuite) TestEnsureImageExistsUnableToConnect(c *gc.C) {
 	s.Stub.ResetCalls()
 	s.Stub.SetErrors(nil, errors.Errorf("unable-to-connect"))
 	remotes := []Remote{badRemote, s.remoteWithTrusty.AsRemote()}
-	_, err := client.EnsureImageExists("trusty", remotes, nil)
+	_, err := client.EnsureImageExists("trusty", "amd64", remotes, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	// We didn't find it locally
 	s.Stub.CheckCalls(c, []testing.StubCall{
@@ -255,7 +255,7 @@ func (s *imageSuite) TestEnsureImageExistsNotPresentInFirstRemote(c *gc.C) {
 	}
 	s.Stub.ResetCalls()
 	remotes := []Remote{s.remoteWithNothing.AsRemote(), s.remoteWithTrusty.AsRemote()}
-	_, err := client.EnsureImageExists("trusty", remotes, nil)
+	_, err := client.EnsureImageExists("trusty", "amd64", remotes, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	// We didn't find it locally
 	s.Stub.CheckCalls(c, []testing.StubCall{
@@ -309,7 +309,7 @@ func (s *imageSuite) TestEnsureImageExistsCallbackIncludesSourceURL(c *gc.C) {
 		connectToSource: connector.connectToSource,
 	}
 	remotes := []Remote{s.remoteWithTrusty.AsRemote()}
-	_, err := client.EnsureImageExists("trusty", remotes, callback)
+	_, err := client.EnsureImageExists("trusty", "amd64", remotes, callback)
 	c.Assert(err, jc.ErrorIsNil)
 	select {
 	case message := <-calls:

--- a/tools/lxdclient/client_image_test.go
+++ b/tools/lxdclient/client_image_test.go
@@ -33,7 +33,7 @@ func (s *imageSuite) SetUpTest(c *gc.C) {
 		stub: s.Stub,
 		url:  "https://match",
 		aliases: map[string]string{
-			"trusty": "trusty-alias",
+			"trusty/amd64": "trusty-fingerprint",
 		},
 	}
 	s.remoteWithNothing = &stubRemoteClient{
@@ -127,19 +127,30 @@ func (s *stubConnector) connectToSource(remote Remote) (remoteClient, error) {
 }
 
 func (s *imageSuite) TestEnsureImageExistsAlreadyPresent(c *gc.C) {
+	s.testEnsureImageExistsAlreadyPresent(c, "trusty", "juju/trusty/amd64")
+	s.testEnsureImageExistsAlreadyPresent(c, "centos7", "juju/centos7/amd64")
+}
+
+func (s *imageSuite) testEnsureImageExistsAlreadyPresent(c *gc.C, series, localAlias string) {
 	connector := MakeConnector(s.Stub, s.remoteWithTrusty)
 	raw := &stubClient{
-		stub: s.Stub,
-		Aliases: map[string]string{
-			"ubuntu-trusty": "dead-beef",
-		},
+		stub:    s.Stub,
+		Aliases: map[string]string{localAlias: "dead-beef"},
 	}
 	client := &imageClient{
 		raw:             raw,
 		connectToSource: connector.connectToSource,
 	}
-	err := client.EnsureImageExists("trusty", []Remote{s.remoteWithTrusty.AsRemote()}, nil)
+	s.Stub.ResetCalls()
+	image, err := client.EnsureImageExists(series, []Remote{s.remoteWithTrusty.AsRemote()}, nil)
 	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(image, gc.Equals, localAlias)
+	s.Stub.CheckCalls(c, []testing.StubCall{
+		{ // Check if we have the image already (we do)
+			FuncName: "GetAlias",
+			Args:     []interface{}{localAlias},
+		},
+	})
 }
 
 func (s *imageSuite) TestEnsureImageExistsFirstRemote(c *gc.C) {
@@ -155,26 +166,30 @@ func (s *imageSuite) TestEnsureImageExistsFirstRemote(c *gc.C) {
 	}
 	remotes := []Remote{s.remoteWithTrusty.AsRemote()}
 	s.Stub.ResetCalls()
-	err := client.EnsureImageExists("trusty", remotes, nil)
+	_, err := client.EnsureImageExists("trusty", remotes, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	// We didn't find it locally
 	s.Stub.CheckCalls(c, []testing.StubCall{
+		{ // Check if we have the image already (we don't)
+			FuncName: "GetAlias",
+			Args:     []interface{}{"juju/trusty/amd64"},
+		},
 		{ // We didn't so connect to the first remote
 			FuncName: "connectToSource",
 			Args:     []interface{}{"https://match"},
 		},
 		{ // And check if it has trusty (which it should)
 			FuncName: "GetAlias",
-			Args:     []interface{}{"trusty"},
+			Args:     []interface{}{"trusty/amd64"},
 		},
 		{ // So Copy the Image
 			FuncName: "CopyImage",
-			Args:     []interface{}{"trusty", []string{"ubuntu-trusty"}},
+			Args:     []interface{}{"trusty/amd64", []string{"juju/trusty/amd64"}},
 		},
 	})
 	// We've updated the aliases
 	c.Assert(raw.Aliases, gc.DeepEquals, map[string]string{
-		"ubuntu-trusty": "trusty",
+		"juju/trusty/amd64": "trusty/amd64",
 	})
 }
 
@@ -194,12 +209,16 @@ func (s *imageSuite) TestEnsureImageExistsUnableToConnect(c *gc.C) {
 		Protocol: SimplestreamsProtocol,
 	}
 	s.Stub.ResetCalls()
-	s.Stub.SetErrors(errors.Errorf("unable-to-connect"))
+	s.Stub.SetErrors(nil, errors.Errorf("unable-to-connect"))
 	remotes := []Remote{badRemote, s.remoteWithTrusty.AsRemote()}
-	err := client.EnsureImageExists("trusty", remotes, nil)
+	_, err := client.EnsureImageExists("trusty", remotes, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	// We didn't find it locally
 	s.Stub.CheckCalls(c, []testing.StubCall{
+		{ // Check if we have the image already (we don't)
+			FuncName: "GetAlias",
+			Args:     []interface{}{"juju/trusty/amd64"},
+		},
 		{ // We didn't so connect to the first remote
 			FuncName: "connectToSource",
 			Args:     []interface{}{"https://nosuch-remote.invalid"},
@@ -210,16 +229,16 @@ func (s *imageSuite) TestEnsureImageExistsUnableToConnect(c *gc.C) {
 		},
 		{ // And check if it has trusty (which it should)
 			FuncName: "GetAlias",
-			Args:     []interface{}{"trusty"},
+			Args:     []interface{}{"trusty/amd64"},
 		},
 		{ // So Copy the Image
 			FuncName: "CopyImage",
-			Args:     []interface{}{"trusty", []string{"ubuntu-trusty"}},
+			Args:     []interface{}{"trusty/amd64", []string{"juju/trusty/amd64"}},
 		},
 	})
 	// We've updated the aliases
 	c.Assert(raw.Aliases, gc.DeepEquals, map[string]string{
-		"ubuntu-trusty": "trusty",
+		"juju/trusty/amd64": "trusty/amd64",
 	})
 }
 
@@ -236,17 +255,21 @@ func (s *imageSuite) TestEnsureImageExistsNotPresentInFirstRemote(c *gc.C) {
 	}
 	s.Stub.ResetCalls()
 	remotes := []Remote{s.remoteWithNothing.AsRemote(), s.remoteWithTrusty.AsRemote()}
-	err := client.EnsureImageExists("trusty", remotes, nil)
+	_, err := client.EnsureImageExists("trusty", remotes, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	// We didn't find it locally
 	s.Stub.CheckCalls(c, []testing.StubCall{
+		{ // Lookup the alias locally
+			FuncName: "GetAlias",
+			Args:     []interface{}{"juju/trusty/amd64"},
+		},
 		{ // We didn't so connect to the first remote
 			FuncName: "connectToSource",
 			Args:     []interface{}{s.remoteWithNothing.URL()},
 		},
-		{ // Lookup the Alias
+		{ // Lookup the alias in the remote
 			FuncName: "GetAlias",
-			Args:     []interface{}{"trusty"},
+			Args:     []interface{}{"trusty/amd64"},
 		},
 		{ // It wasn't found, so connect to second and look there
 			FuncName: "connectToSource",
@@ -254,16 +277,16 @@ func (s *imageSuite) TestEnsureImageExistsNotPresentInFirstRemote(c *gc.C) {
 		},
 		{ // And check if it has trusty (which it should)
 			FuncName: "GetAlias",
-			Args:     []interface{}{"trusty"},
+			Args:     []interface{}{"trusty/amd64"},
 		},
 		{ // So Copy the Image
 			FuncName: "CopyImage",
-			Args:     []interface{}{"trusty", []string{"ubuntu-trusty"}},
+			Args:     []interface{}{"trusty/amd64", []string{"juju/trusty/amd64"}},
 		},
 	})
 	// We've updated the aliases
 	c.Assert(raw.Aliases, gc.DeepEquals, map[string]string{
-		"ubuntu-trusty": "trusty",
+		"juju/trusty/amd64": "trusty/amd64",
 	})
 }
 
@@ -286,11 +309,11 @@ func (s *imageSuite) TestEnsureImageExistsCallbackIncludesSourceURL(c *gc.C) {
 		connectToSource: connector.connectToSource,
 	}
 	remotes := []Remote{s.remoteWithTrusty.AsRemote()}
-	err := client.EnsureImageExists("trusty", remotes, callback)
+	_, err := client.EnsureImageExists("trusty", remotes, callback)
 	c.Assert(err, jc.ErrorIsNil)
 	select {
 	case message := <-calls:
-		c.Check(message, gc.Matches, "copying image for ubuntu-trusty from https://match: \\d+%")
+		c.Check(message, gc.Matches, "copying image for juju/trusty/amd64 from https://match: \\d+%")
 	case <-time.After(coretesting.LongWait):
 		// The callbacks are made asynchronously, and so may not
 		// have happened by the time EnsureImageExists exits.

--- a/tools/lxdclient/testing_test.go
+++ b/tools/lxdclient/testing_test.go
@@ -141,3 +141,11 @@ func (s *stubClient) SetContainerConfig(name, key, value string) error {
 
 	return nil
 }
+
+func (s *stubClient) GetImageInfo(imageTarget string) (*shared.ImageInfo, error) {
+	s.stub.AddCall("GetImageInfo", imageTarget)
+	if err := s.stub.NextErr(); err != nil {
+		return nil, err
+	}
+	return &shared.ImageInfo{}, nil
+}


### PR DESCRIPTION
## Description of change

We update the tools/lxdclient code to support
CentOS images if LXD knows about them. To do
this, several changes are required:

 - we give all images we use a juju-specific
   alias: juju/\<series\>/\<arch\>
 - if an image exists locally with that alias,
   we use it without consulting the remote
   sources

These changes enable a user to supply their
own image for a given series/arch pair.

## QA steps

1. go get github.com/axw/juju-lxd-centos-image-builder
2. $GOPATH/bin/juju-lxd-centos-image-builder
3. juju bootstrap localhost
4. go get github.com/axw/juju-tools
5. juju tools build 2.1-rc2.1-centos7-amd64
6. juju tools upload juju-2.1-rc2.1-centos7-amd64.tgz
7. juju add-machine --series=centos7
8. confirm centos machine comes up

Also tested existing behaviour on a non-amd64 host:

1. juju bootstrap azure
2. start a packet.net type 2A AArch64 server, manually provision it into juju
3. juju add-machine lxd:0 (where 0 is the packet.net server)
4. check that the container uses the alias "juju/xenial/arm64", and it points at the upstream xenial/arm64 image.

## Documentation changes

Maybe? We might want to link to the image builder from the docs?

## Bug reference

https://bugs.launchpad.net/juju/+bug/1495978