### PR TITLE
cloudconfig: attempt agent downloads in parallel

### DIFF
--- a/cloudconfig/download_parallel.go
+++ b/cloudconfig/download_parallel.go
@@ -1,0 +1,78 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package cloudconfig
+
+// Generated code - do not edit.
+
+const DownloadParallelScript = `from __future__ import print_function
+
+import argparse
+import shutil
+import ssl
+import sys
+import threading
+
+
+try:
+    import queue
+    from urllib.request import build_opener, HTTPSHandler, ProxyHandler
+except ImportError:
+    import Queue as queue
+    from urllib2 import build_opener, HTTPSHandler, ProxyHandler
+
+
+def main(args):
+    ctx = ssl.create_default_context()
+    if args.insecure:
+        ctx.check_hostname = False
+        ctx.verify_mode = ssl.CERT_NONE
+
+    q = queue.Queue()
+    for u in args.urls:
+        t = threading.Thread(target=try_download, args=(u, ctx, args.noproxy, q))
+        t.daemon = True
+        t.start()
+
+    failed = []
+    for u in args.urls:
+        u, result = q.get()
+        if isinstance(result, Exception):
+            failed.append((u, result))
+            continue
+        print('downloading {} to {}'.format(u, args.output), file=sys.stderr)
+        with open(args.output, 'wb') as fout:
+            shutil.copyfileobj(result, fout)
+            result.close()
+        sys.exit(0)
+
+    for (u, exception) in failed:
+        print('failed to download {}: {}'.format(u, exception), file=sys.stderr)
+    sys.exit(1)
+
+
+def try_download(url, ctx, noproxy, q):
+    try:
+        handlers = []
+        if noproxy:
+            handlers.append(ProxyHandler({}))
+        handlers.append(HTTPSHandler(context=ctx))
+        opener = build_opener(*handlers)
+        resp = opener.open(url)
+        q.put((url, resp))
+    except Exception as e:
+        q.put((url, e))
+
+
+def arg_parser():
+    parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+    parser.add_argument('-o', dest="output", help="path to store file", type=str, required=True)
+    parser.add_argument('--insecure', dest="insecure", help="disable cert validation and host checking", action="store_true", default=False)
+    parser.add_argument('--noproxy', dest="noproxy", help="disable proxying of requests", action="store_true", default=False)
+    parser.add_argument('urls', nargs='+')
+    return parser
+
+
+if __name__ == '__main__':
+    main(arg_parser().parse_args())
+`

--- a/cloudconfig/unixuserdatafiles/download_parallel.py
+++ b/cloudconfig/unixuserdatafiles/download_parallel.py
@@ -1,0 +1,70 @@
+from __future__ import print_function
+
+import argparse
+import shutil
+import ssl
+import sys
+import threading
+
+
+try:
+    import queue
+    from urllib.request import build_opener, HTTPSHandler, ProxyHandler
+except ImportError:
+    import Queue as queue
+    from urllib2 import build_opener, HTTPSHandler, ProxyHandler
+
+
+def main(args):
+    ctx = ssl.create_default_context()
+    if args.insecure:
+        ctx.check_hostname = False
+        ctx.verify_mode = ssl.CERT_NONE
+
+    q = queue.Queue()
+    for u in args.urls:
+        t = threading.Thread(target=try_download, args=(u, ctx, args.noproxy, q))
+        t.daemon = True
+        t.start()
+
+    failed = []
+    for u in args.urls:
+        u, result = q.get()
+        if isinstance(result, Exception):
+            failed.append((u, result))
+            continue
+        print('downloading {} to {}'.format(u, args.output), file=sys.stderr)
+        with open(args.output, 'wb') as fout:
+            shutil.copyfileobj(result, fout)
+            result.close()
+        sys.exit(0)
+
+    for (u, exception) in failed:
+        print('failed to download {}: {}'.format(u, exception), file=sys.stderr)
+    sys.exit(1)
+
+
+def try_download(url, ctx, noproxy, q):
+    try:
+        handlers = []
+        if noproxy:
+            handlers.append(ProxyHandler({}))
+        handlers.append(HTTPSHandler(context=ctx))
+        opener = build_opener(*handlers)
+        resp = opener.open(url)
+        q.put((url, resp))
+    except Exception as e:
+        q.put((url, e))
+
+
+def arg_parser():
+    parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+    parser.add_argument('-o', dest="output", help="path to store file", type=str, required=True)
+    parser.add_argument('--insecure', dest="insecure", help="disable cert validation and host checking", action="store_true", default=False)
+    parser.add_argument('--noproxy', dest="noproxy", help="disable proxying of requests", action="store_true", default=False)
+    parser.add_argument('urls', nargs='+')
+    return parser
+
+
+if __name__ == '__main__':
+    main(arg_parser().parse_args())

--- a/cloudconfig/userdatacfg_test.go
+++ b/cloudconfig/userdatacfg_test.go
@@ -337,8 +337,11 @@ mkdir -p /var/log/juju
 chown syslog:adm /var/log/juju
 bin='/var/lib/juju/tools/1\.2\.3-precise-amd64'
 mkdir -p \$bin
+install -D -m 644 /dev/null '/var/lib/juju/tools/1\.2\.3-precise-amd64/download\.py'
+printf '%s\\n' '.*' > '/var/lib/juju/tools/1\.2\.3-precise-amd64/download\.py'
+python=\$\(which python3 \|\| which python\)
 echo 'Fetching Juju agent version.*
-curl .* '.*' --retry 10 -o \$bin/tools\.tar\.gz 'http://foo\.com/tools/released/juju1\.2\.3-precise-amd64\.tgz'
+\$python .*/download\.py -o \$bin/tools\.tar\.gz 'http://foo\.com/tools/released/juju1\.2\.3-precise-amd64\.tgz'
 sha256sum \$bin/tools\.tar\.gz > \$bin/juju1\.2\.3-precise-amd64\.sha256
 grep '1234' \$bin/juju1\.2\.3-precise-amd64.sha256 \|\| \(echo "Tools checksum mismatch"; exit 1\)
 tar zxf \$bin/tools.tar.gz -C \$bin
@@ -365,7 +368,8 @@ rm \$bin/tools\.tar\.gz && rm \$bin/juju1\.2\.3-precise-amd64\.sha256
 		inexactMatch: true,
 		expectScripts: `
 bin='/var/lib/juju/tools/1\.2\.3-raring-amd64'
-curl .* '.*' --retry 10 -o \$bin/tools\.tar\.gz 'http://foo\.com/tools/released/juju1\.2\.3-raring-amd64\.tgz'
+python=\$\(which python3 || which python\)
+\$python .*/download\.py -o \$bin/tools\.tar\.gz 'http://foo\.com/tools/released/juju1\.2\.3-raring-amd64\.tgz'
 sha256sum \$bin/tools\.tar\.gz > \$bin/juju1\.2\.3-raring-amd64\.sha256
 grep '1234' \$bin/juju1\.2\.3-raring-amd64.sha256 \|\| \(echo "Tools checksum mismatch"; exit 1\)
 printf %s '{"version":"1\.2\.3-raring-amd64","url":"http://foo\.com/tools/released/juju1\.2\.3-raring-amd64\.tgz","sha256":"1234","size":10}' > \$bin/downloaded-tools\.txt
@@ -394,8 +398,11 @@ mkdir -p /var/log/juju
 chown syslog:adm /var/log/juju
 bin='/var/lib/juju/tools/1\.2\.3-quantal-amd64'
 mkdir -p \$bin
+install -D -m 644 /dev/null '/var/lib/juju/tools/1\.2\.3-quantal-amd64/download\.py'
+printf '%s\\n' '.*' > '/var/lib/juju/tools/1\.2\.3-quantal-amd64/download\.py'
+python=\$\(which python3 || which python\)
 echo 'Fetching Juju agent version.*
-curl .* --noproxy "\*" --insecure -o \$bin/tools\.tar\.gz 'https://state-addr\.testing\.invalid:54321/deadbeef-0bad-400d-8000-4b1d0d06f00d/tools/1\.2\.3-quantal-amd64'
+\$python .*/download\.py --noproxy --insecure -o \$bin/tools\.tar\.gz 'https://state-addr\.testing\.invalid:54321/deadbeef-0bad-400d-8000-4b1d0d06f00d/tools/1\.2\.3-quantal-amd64'
 sha256sum \$bin/tools\.tar\.gz > \$bin/juju1\.2\.3-quantal-amd64\.sha256
 grep '1234' \$bin/juju1\.2\.3-quantal-amd64.sha256 \|\| \(echo "Tools checksum mismatch"; exit 1\)
 tar zxf \$bin/tools.tar.gz -C \$bin
@@ -460,7 +467,7 @@ start jujud-machine-2-lxd-1
 		}),
 		inexactMatch: true,
 		expectScripts: `
-curl .* --noproxy "\*" --insecure -o \$bin/tools\.tar\.gz 'https://state-addr\.testing\.invalid:54321/deadbeef-0bad-400d-8000-4b1d0d06f00d/tools/1\.2\.3-quantal-amd64'
+\$python .*/download\.py --noproxy --insecure -o \$bin/tools\.tar\.gz 'https://state-addr\.testing\.invalid:54321/deadbeef-0bad-400d-8000-4b1d0d06f00d/tools/1\.2\.3-quantal-amd64'
 `,
 	},
 
@@ -1283,16 +1290,8 @@ func (*cloudinitSuite) TestToolsDownloadCommand(c *gc.C) {
 	expected := `
 n=1
 while true; do
-
-    printf "Attempt $n to download tools from %s...\n" 'a'
-    download 'a' && echo "Tools downloaded successfully." && break
-
-    printf "Attempt $n to download tools from %s...\n" 'b'
-    download 'b' && echo "Tools downloaded successfully." && break
-
-    printf "Attempt $n to download tools from %s...\n" 'c'
-    download 'c' && echo "Tools downloaded successfully." && break
-
+    echo "Attempt $n to download agent..."
+    download 'a' 'b' 'c' && echo "Agent downloaded successfully." && break
     echo "Download failed, retrying in 15s"
     sleep 15
     n=$((n+1))


### PR DESCRIPTION
## Description of change

We introduce a Python script to attempt downloading
agent binary URLs in parallel, and use it in the
cloud-init scripts run on Linux. The first URL
for which we get a response will be downloaded.

Attempting the URLs in series leads to poor agent
startup times in Azure, where the agents cannot
communicate with the controller over the private
network. The cloud-init script was prioritising the
private network when attempting URLs, and that
would cause a significant delay before the public
Internet address/URL was attempted.

NOTE: once upon a time we used aria2c, which makes
this trivial. Unfortunately that was ruled out as an
option as it is in universe, not main.

## QA steps

1. juju bootstrap azure
2. (in default model) juju add-machine
3. wait for the machine to get an IP address, and "juju ssh ubuntu@<that IP>". Tail /var/log/cloud-init-output.log and check that the agent download step doesn't take long.

Also, manually tested the script with both python 2 and python 3, using --noproxy and without specifying --insecure for servers with certs signed by un/trusted CA.

## Documentation changes

None.

## Bug reference

Fixes https://bugs.launchpad.net/juju/+bug/1622531