### PR TITLE
Don't rely on environment vars for proxy settings

### DIFF
--- a/cmd/jujud/agent/machine/manifolds.go
+++ b/cmd/jujud/agent/machine/manifolds.go
@@ -19,6 +19,7 @@ import (
 	"github.com/juju/juju/cmd/jujud/agent/engine"
 	"github.com/juju/juju/container/lxd"
 	"github.com/juju/juju/state"
+	proxyconfig "github.com/juju/juju/utils/proxy"
 	"github.com/juju/juju/worker"
 	"github.com/juju/juju/worker/agent"
 	"github.com/juju/juju/worker/apiaddressupdater"
@@ -359,10 +360,11 @@ func Manifolds(config ManifoldsConfig) dependency.Manifolds {
 		// The proxy config updater is a leaf worker that sets http/https/apt/etc
 		// proxy settings.
 		proxyConfigUpdater: ifNotMigrating(proxyupdater.Manifold(proxyupdater.ManifoldConfig{
-			AgentName:      agentName,
-			APICallerName:  apiCallerName,
-			WorkerFunc:     proxyupdater.NewWorker,
-			ExternalUpdate: externalUpdateProxyFunc,
+			AgentName:       agentName,
+			APICallerName:   apiCallerName,
+			WorkerFunc:      proxyupdater.NewWorker,
+			ExternalUpdate:  externalUpdateProxyFunc,
+			InProcessUpdate: proxyconfig.DefaultConfig.Set,
 		})),
 
 		// The api address updater is a leaf worker that rewrites agent config

--- a/cmd/jujud/agent/unit/manifolds.go
+++ b/cmd/jujud/agent/unit/manifolds.go
@@ -16,6 +16,7 @@ import (
 	"github.com/juju/juju/api/base"
 	msapi "github.com/juju/juju/api/meterstatus"
 	"github.com/juju/juju/cmd/jujud/agent/engine"
+	"github.com/juju/juju/utils/proxy"
 	"github.com/juju/juju/worker"
 	"github.com/juju/juju/worker/agent"
 	"github.com/juju/juju/worker/apiaddressupdater"
@@ -183,9 +184,10 @@ func Manifolds(config ManifoldsConfig) dependency.Manifolds {
 		// coincidence. Probably we ought to be making components that might
 		// need proxy config into explicit dependencies of the proxy updater...
 		proxyConfigUpdaterName: ifNotMigrating(proxyupdater.Manifold(proxyupdater.ManifoldConfig{
-			AgentName:     agentName,
-			APICallerName: apiCallerName,
-			WorkerFunc:    proxyupdater.NewWorker,
+			AgentName:       agentName,
+			APICallerName:   apiCallerName,
+			WorkerFunc:      proxyupdater.NewWorker,
+			InProcessUpdate: proxy.DefaultConfig.Set,
 		})),
 
 		// The charmdir resource coordinates whether the charm directory is

--- a/cmd/jujud/main.go
+++ b/cmd/jujud/main.go
@@ -27,6 +27,7 @@ import (
 	"github.com/juju/juju/juju/sockets"
 	// Import the providers.
 	_ "github.com/juju/juju/provider/all"
+	"github.com/juju/juju/utils/proxy"
 	"github.com/juju/juju/worker/logsender"
 	"github.com/juju/juju/worker/uniter/runner/jujuc"
 )
@@ -134,6 +135,12 @@ func jujuDMain(args []string, ctx *cmd.Context) (code int, err error) {
 	defer logger.Debugf("jujud complete, code %d, err %v", code, err)
 	bufferedLogger, err := logsender.InstallBufferedLogWriter(1048576)
 	if err != nil {
+		return 1, errors.Trace(err)
+	}
+
+	// Set the default transport to use the in-process proxy
+	// configuration.
+	if err := proxy.DefaultConfig.InstallInDefaultTransport(); err != nil {
 		return 1, errors.Trace(err)
 	}
 

--- a/utils/proxy/package_test.go
+++ b/utils/proxy/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package proxy
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func TestPackage(t *testing.T) {
+	gc.TestingT(t)
+}

--- a/utils/proxy/proxyconfig.go
+++ b/utils/proxy/proxyconfig.go
@@ -1,0 +1,172 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package proxy
+
+import (
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+
+	"github.com/juju/errors"
+	proxyutils "github.com/juju/utils/proxy"
+)
+
+// ProxyConfig stores the proxy settings that should be used for web
+// requests made from this process.
+type ProxyConfig struct {
+	mu          sync.Mutex
+	http, https *url.URL
+	noProxy     string
+}
+
+// Set updates the stored settings to the new ones passed in.
+func (pc *ProxyConfig) Set(newSettings proxyutils.Settings) error {
+	pc.mu.Lock()
+	defer pc.mu.Unlock()
+	httpUrl, err := tolerantParse(newSettings.Http)
+	if err != nil {
+		return errors.Annotate(err, "http proxy")
+	}
+	httpsUrl, err := tolerantParse(newSettings.Https)
+	if err != nil {
+		return errors.Annotate(err, "https proxy")
+	}
+	pc.http = httpUrl
+	pc.https = httpsUrl
+	pc.noProxy = newSettings.NoProxy
+	return nil
+}
+
+// GetProxy returns the URL of the proxy to use for a given request as
+// indicated by the proxy settings. It behaves the same as the
+// net/http.ProxyFromEnvironment function, except that it uses the
+// stored settings rather than pulling the configuration from
+// environment variables. (The implementation is copied from
+// net/http.ProxyFromEnvironment.)
+func (pc *ProxyConfig) GetProxy(req *http.Request) (*url.URL, error) {
+	pc.mu.Lock()
+	defer pc.mu.Unlock()
+
+	var proxy *url.URL
+	if req.URL.Scheme == "https" {
+		proxy = pc.https
+	}
+	if proxy == nil {
+		proxy = pc.http
+	}
+	if proxy == nil {
+		return nil, nil
+	}
+	if !pc.useProxy(canonicalAddr(req.URL)) {
+		return nil, nil
+	}
+	return proxy, nil
+}
+
+// useProxy reports whether requests to addr should use a proxy,
+// according to the NO_PROXY or no_proxy environment variable.
+// addr is always a canonicalAddr with a host and port.
+func (pc *ProxyConfig) useProxy(addr string) bool {
+	if len(addr) == 0 {
+		return true
+	}
+	host, _, err := net.SplitHostPort(addr)
+	if err != nil {
+		return false
+	}
+	if host == "localhost" {
+		return false
+	}
+	if ip := net.ParseIP(host); ip != nil {
+		if ip.IsLoopback() {
+			return false
+		}
+	}
+
+	if pc.noProxy == "*" {
+		return false
+	}
+
+	addr = strings.ToLower(strings.TrimSpace(addr))
+	if hasPort(addr) {
+		addr = addr[:strings.LastIndex(addr, ":")]
+	}
+
+	for _, p := range strings.Split(pc.noProxy, ",") {
+		p = strings.ToLower(strings.TrimSpace(p))
+		if len(p) == 0 {
+			continue
+		}
+		if hasPort(p) {
+			p = p[:strings.LastIndex(p, ":")]
+		}
+		if addr == p {
+			return false
+		}
+		if p[0] == '.' && (strings.HasSuffix(addr, p) || addr == p[1:]) {
+			// no_proxy ".foo.com" matches "bar.foo.com" or "foo.com"
+			return false
+		}
+		if p[0] != '.' && strings.HasSuffix(addr, p) && addr[len(addr)-len(p)-1] == '.' {
+			// no_proxy "foo.com" matches "bar.foo.com"
+			return false
+		}
+	}
+	return true
+}
+
+// InstallInDefaultTransport sets the proxy resolution used by the
+// default HTTP transport to use the proxy details stored in this
+// ProxyConfig. Requests made without an explicit transport will
+// respect these proxy settings.
+func (pc *ProxyConfig) InstallInDefaultTransport() error {
+	transport, ok := http.DefaultTransport.(*http.Transport)
+	if !ok {
+		return errors.Errorf("http.DefaultTransport was %T instead of *http.Transport", http.DefaultTransport)
+	}
+	transport.Proxy = pc.GetProxy
+	return nil
+}
+
+var DefaultConfig = ProxyConfig{}
+
+func tolerantParse(value string) (*url.URL, error) {
+	if value == "" {
+		return nil, nil
+	}
+	proxyURL, err := url.Parse(value)
+	if err != nil || !strings.HasPrefix(proxyURL.Scheme, "http") {
+		// proxy was bogus. Try prepending "http://" to it and
+		// see if that parses correctly. If not, we fall
+		// through and complain about the original one.
+		if proxyURL, err := url.Parse("http://" + value); err == nil {
+			return proxyURL, nil
+		}
+	}
+	if err != nil {
+		return nil, errors.Errorf("invalid proxy address %q: %v", value, err)
+	}
+	return proxyURL, nil
+}
+
+// Internal utilities copied from net/http/transport.go
+var portMap = map[string]string{
+	"http":  "80",
+	"https": "443",
+}
+
+// canonicalAddr returns url.Host but always with a ":port" suffix
+func canonicalAddr(url *url.URL) string {
+	addr := url.Host
+	if !hasPort(addr) {
+		return addr + ":" + portMap[url.Scheme]
+	}
+	return addr
+}
+
+// Given a string of the form "host", "host:port", or "[ipv6::address]:port",
+// return true if the string includes a port.
+func hasPort(s string) bool { return strings.LastIndex(s, ":") > strings.LastIndex(s, "]") }

--- a/utils/proxy/proxyconfig.go
+++ b/utils/proxy/proxyconfig.go
@@ -67,8 +67,9 @@ func (pc *ProxyConfig) GetProxy(req *http.Request) (*url.URL, error) {
 }
 
 // useProxy reports whether requests to addr should use a proxy,
-// according to the NO_PROXY or no_proxy environment variable.
+// according to the NoProxy value of the proxy setting.
 // addr is always a canonicalAddr with a host and port.
+// (Implementation copied from net/http.useProxy.)
 func (pc *ProxyConfig) useProxy(addr string) bool {
 	if len(addr) == 0 {
 		return true
@@ -162,7 +163,7 @@ var portMap = map[string]string{
 func canonicalAddr(url *url.URL) string {
 	addr := url.Host
 	if !hasPort(addr) {
-		return addr + ":" + portMap[url.Scheme]
+		return net.JoinHostPort(addr, portMap[url.Scheme])
 	}
 	return addr
 }

--- a/utils/proxy/proxyconfig_test.go
+++ b/utils/proxy/proxyconfig_test.go
@@ -1,0 +1,113 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package proxy_test
+
+import (
+	"net/http"
+
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/utils/proxy"
+
+	proxyconfig "github.com/juju/juju/utils/proxy"
+)
+
+type Suite struct{}
+
+var _ = gc.Suite(&Suite{})
+
+func checkProxy(c *gc.C, settings proxy.Settings, requestURL, expectedURL string) {
+	pc := proxyconfig.ProxyConfig{}
+	c.Assert(pc.Set(settings), jc.ErrorIsNil)
+	req, err := http.NewRequest("GET", requestURL, nil)
+	c.Assert(err, jc.ErrorIsNil)
+	proxyURL, err := pc.GetProxy(req)
+	c.Assert(err, jc.ErrorIsNil)
+	if expectedURL == "" {
+		c.Check(proxyURL, gc.IsNil)
+	} else {
+		c.Assert(proxyURL, gc.Not(gc.IsNil))
+		c.Check(proxyURL.String(), gc.Equals, expectedURL)
+	}
+}
+
+var (
+	normal = proxy.Settings{
+		Http:    "http://http.proxy",
+		Https:   "https://https.proxy",
+		NoProxy: ".foo.com,bar.com,10.0.0.1:3333",
+	}
+	noProxy = proxy.Settings{
+		Http:    "http://http.proxy",
+		NoProxy: "*",
+	}
+)
+
+func (s *Suite) TestGetProxy(c *gc.C) {
+	checkProxy(c, normal, "https://perfect.crime", "https://https.proxy")
+	checkProxy(c, normal, "decemberists.com", "http://http.proxy")
+	checkProxy(c, normal, "2001:db8:85a3::8a2e:370:7334", "http://http.proxy")
+	checkProxy(c, proxy.Settings{}, "https://sufjan.stevens", "")
+	checkProxy(c, normal, "http://adz.foo.com:80", "")
+	checkProxy(c, normal, "http://adz.bar.com", "")
+	checkProxy(c, normal, "http://localhost", "")
+	checkProxy(c, normal, "http://127.0.0.1", "")
+	checkProxy(c, normal, "http://[::1]:8000", "")
+	checkProxy(c, normal, "http://10.0.0.1", "")
+	checkProxy(c, normal, "http://10.0.0.1:1996", "")
+	checkProxy(c, normal, "http://10.23.45.67:80", "http://http.proxy")
+	checkProxy(c, noProxy, "decemberists.com", "")
+	checkProxy(c, proxy.Settings{Http: "grizzly.bear"}, "veckatimest.com", "http://grizzly.bear")
+}
+
+func (s *Suite) TestSetBadUrl(c *gc.C) {
+	pc := proxyconfig.ProxyConfig{}
+	err := pc.Set(proxy.Settings{
+		Https: "http://badurl%gg",
+	})
+	c.Assert(err, gc.ErrorMatches, `https proxy: invalid proxy address "http://badurl%gg": .*$`)
+	err = pc.Set(proxy.Settings{
+		Http: "http://badurl%gg",
+	})
+	c.Assert(err, gc.ErrorMatches, `http proxy: invalid proxy address "http://badurl%gg": .*$`)
+}
+
+func (s *Suite) TestInstallError(c *gc.C) {
+	type fakeRoundTripper struct {
+		http.RoundTripper
+	}
+	// PatchValue doesn't work for this for some reflection/type
+	// reason.
+	oldTransport := http.DefaultTransport
+	http.DefaultTransport = &fakeRoundTripper{}
+	defer func() {
+		http.DefaultTransport = oldTransport
+	}()
+
+	pc := proxyconfig.ProxyConfig{}
+	err := pc.InstallInDefaultTransport()
+	c.Assert(err, gc.ErrorMatches, `http.DefaultTransport was \*proxy_test\.fakeRoundTripper instead of \*http\.Transport`)
+}
+
+func (s *Suite) TestInstall(c *gc.C) {
+	oldTransport := http.DefaultTransport
+	defer func() {
+		http.DefaultTransport = oldTransport
+	}()
+
+	pc := proxyconfig.ProxyConfig{}
+	pc.Set(normal)
+	pc.InstallInDefaultTransport()
+
+	transport, ok := http.DefaultTransport.(*http.Transport)
+	c.Assert(ok, jc.IsTrue)
+
+	req, err := http.NewRequest("GET", "https://risky.biz", nil)
+	c.Assert(err, jc.ErrorIsNil)
+	proxyURL, err := transport.Proxy(req)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(proxyURL, gc.Not(gc.IsNil))
+	c.Assert(proxyURL.String(), gc.Equals, "https://https.proxy")
+}

--- a/worker/proxyupdater/manifold.go
+++ b/worker/proxyupdater/manifold.go
@@ -16,10 +16,11 @@ import (
 
 // ManifoldConfig defines the names of the manifolds on which a Manifold will depend.
 type ManifoldConfig struct {
-	AgentName      string
-	APICallerName  string
-	WorkerFunc     func(Config) (worker.Worker, error)
-	ExternalUpdate func(proxy.Settings) error
+	AgentName       string
+	APICallerName   string
+	WorkerFunc      func(Config) (worker.Worker, error)
+	ExternalUpdate  func(proxy.Settings) error
+	InProcessUpdate func(proxy.Settings) error
 }
 
 // Manifold returns a dependency manifold that runs a proxy updater worker,
@@ -33,6 +34,9 @@ func Manifold(config ManifoldConfig) dependency.Manifold {
 		Start: func(context dependency.Context) (worker.Worker, error) {
 			if config.WorkerFunc == nil {
 				return nil, errors.NotValidf("missing WorkerFunc")
+			}
+			if config.InProcessUpdate == nil {
+				return nil, errors.NotValidf("missing InProcessUpdate")
 			}
 			var agent agent.Agent
 			if err := context.Get(config.AgentName, &agent); err != nil {
@@ -49,11 +53,12 @@ func Manifold(config ManifoldConfig) dependency.Manifold {
 				return nil, err
 			}
 			w, err := config.WorkerFunc(Config{
-				Directory:      "/home/ubuntu",
-				RegistryPath:   `HKCU:\Software\Microsoft\Windows\CurrentVersion\Internet Settings`,
-				Filename:       ".juju-proxy",
-				API:            proxyAPI,
-				ExternalUpdate: config.ExternalUpdate,
+				Directory:       "/home/ubuntu",
+				RegistryPath:    `HKCU:\Software\Microsoft\Windows\CurrentVersion\Internet Settings`,
+				Filename:        ".juju-proxy",
+				API:             proxyAPI,
+				ExternalUpdate:  config.ExternalUpdate,
+				InProcessUpdate: config.InProcessUpdate,
 			})
 			if err != nil {
 				return nil, errors.Trace(err)

--- a/worker/proxyupdater/manifold_test.go
+++ b/worker/proxyupdater/manifold_test.go
@@ -27,8 +27,11 @@ type ManifoldSuite struct {
 
 var _ = gc.Suite(&ManifoldSuite{})
 
-func OtherUpdate(proxy.Settings) error {
-	return nil
+func MakeUpdateFunc(name string) func(proxy.Settings) error {
+	// So we can tell the difference between update funcs.
+	return func(proxy.Settings) error {
+		return errors.New(name)
+	}
 }
 
 func (s *ManifoldSuite) SetUpTest(c *gc.C) {
@@ -43,7 +46,8 @@ func (s *ManifoldSuite) SetUpTest(c *gc.C) {
 			}
 			return &dummyWorker{config: cfg}, nil
 		},
-		ExternalUpdate: OtherUpdate,
+		ExternalUpdate:  MakeUpdateFunc("external"),
+		InProcessUpdate: MakeUpdateFunc("in-process"),
 	}
 }
 
@@ -61,6 +65,14 @@ func (s *ManifoldSuite) TestWorkerFuncMissing(c *gc.C) {
 	worker, err := s.manifold().Start(context)
 	c.Check(worker, gc.IsNil)
 	c.Check(err, gc.ErrorMatches, "missing WorkerFunc not valid")
+}
+
+func (s *ManifoldSuite) TestInProcessUpdateMissing(c *gc.C) {
+	s.config.InProcessUpdate = nil
+	context := dt.StubContext(nil, nil)
+	worker, err := s.manifold().Start(context)
+	c.Check(worker, gc.IsNil)
+	c.Check(err, gc.ErrorMatches, "missing InProcessUpdate not valid")
 }
 
 func (s *ManifoldSuite) TestStartAgentMissing(c *gc.C) {
@@ -110,8 +122,10 @@ func (s *ManifoldSuite) TestStartSuccess(c *gc.C) {
 	c.Check(dummy.config.RegistryPath, gc.Equals, `HKCU:\Software\Microsoft\Windows\CurrentVersion\Internet Settings`)
 	c.Check(dummy.config.Filename, gc.Equals, ".juju-proxy")
 	c.Check(dummy.config.API, gc.NotNil)
-	// Checking function equality is problematic.
-	c.Check(dummy.config.ExternalUpdate, gc.NotNil)
+	// Checking function equality is problematic, use the errors they
+	// return.
+	c.Check(dummy.config.ExternalUpdate(proxy.Settings{}), gc.ErrorMatches, "external")
+	c.Check(dummy.config.InProcessUpdate(proxy.Settings{}), gc.ErrorMatches, "in-process")
 }
 
 type dummyAgent struct {

--- a/worker/proxyupdater/proxyupdater.go
+++ b/worker/proxyupdater/proxyupdater.go
@@ -27,11 +27,12 @@ var (
 )
 
 type Config struct {
-	Directory      string
-	RegistryPath   string
-	Filename       string
-	API            API
-	ExternalUpdate func(proxyutils.Settings) error
+	Directory       string
+	RegistryPath    string
+	Filename        string
+	API             API
+	ExternalUpdate  func(proxyutils.Settings) error
+	InProcessUpdate func(proxyutils.Settings) error
 }
 
 // API is an interface that is provided to New
@@ -147,6 +148,9 @@ func (w *proxyWorker) writeEnvironment() error {
 
 func (w *proxyWorker) handleProxyValues(proxySettings proxyutils.Settings) {
 	proxySettings.SetEnvironmentValues()
+	if err := w.config.InProcessUpdate(proxySettings); err != nil {
+		logger.Errorf("error updating in-process proxy settings: %v", err)
+	}
 	if proxySettings != w.proxy || w.first {
 		logger.Debugf("new proxy settings %#v", proxySettings)
 		w.proxy = proxySettings

--- a/worker/proxyupdater/proxyupdater_test.go
+++ b/worker/proxyupdater/proxyupdater_test.go
@@ -123,7 +123,7 @@ func (s *ProxyUpdaterSuite) waitProxySettings(c *gc.C, expected proxy.Settings) 
 			if c.Check(inProcSettings, gc.Equals, expected) {
 				gotInProc = true
 			}
-		case <-time.After(10 * time.Millisecond):
+		case <-time.After(coretesting.ShortWait):
 			envSettings = proxy.DetectProxies()
 			if envSettings == expected {
 				gotEnv = true

--- a/worker/proxyupdater/proxyupdater_test.go
+++ b/worker/proxyupdater/proxyupdater_test.go
@@ -11,6 +11,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/juju/errors"
+	"github.com/juju/loggo"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils/packaging/commands"
 	pacconfig "github.com/juju/utils/packaging/config"
@@ -32,6 +34,7 @@ type ProxyUpdaterSuite struct {
 	api              *fakeAPI
 	proxyFile        string
 	detectedSettings proxy.Settings
+	inProcSettings   chan proxy.Settings
 	config           proxyupdater.Config
 }
 
@@ -78,10 +81,21 @@ func (s *ProxyUpdaterSuite) SetUpTest(c *gc.C) {
 	s.BaseSuite.SetUpTest(c)
 	s.api = NewFakeAPI()
 
+	// Make buffer large for tests that never look at the settings.
+	s.inProcSettings = make(chan proxy.Settings, 1000)
+
 	s.config = proxyupdater.Config{
 		Directory: c.MkDir(),
 		Filename:  "juju-proxy-settings",
 		API:       s.api,
+		InProcessUpdate: func(newSettings proxyutils.Settings) error {
+			select {
+			case s.inProcSettings <- newSettings:
+			case <-time.After(coretesting.LongWait):
+				panic("couldn't send settings on inProcSettings channel")
+			}
+			return nil
+		},
 	}
 	s.PatchValue(&pacconfig.AptProxyConfigFile, path.Join(s.config.Directory, "juju-apt-proxy"))
 	s.proxyFile = path.Join(s.config.Directory, s.config.Filename)
@@ -96,21 +110,32 @@ func (s *ProxyUpdaterSuite) TearDownTest(c *gc.C) {
 
 func (s *ProxyUpdaterSuite) waitProxySettings(c *gc.C, expected proxy.Settings) {
 	maxWait := time.After(coretesting.LongWait)
+	var (
+		inProcSettings, envSettings proxy.Settings
+		gotInProc, gotEnv           bool
+	)
 	for {
 		select {
 		case <-maxWait:
 			c.Fatalf("timeout while waiting for proxy settings to change")
 			return
-		case <-time.After(10 * time.Millisecond):
-			obtained := proxy.DetectProxies()
-			if obtained != expected {
-				if obtained != s.detectedSettings {
-					c.Logf("proxy settings are \n%#v, should be \n%#v, still waiting", obtained, expected)
-				}
-				s.detectedSettings = obtained
-				continue
+		case inProcSettings = <-s.inProcSettings:
+			if c.Check(inProcSettings, gc.Equals, expected) {
+				gotInProc = true
 			}
-			return
+		case <-time.After(10 * time.Millisecond):
+			envSettings = proxy.DetectProxies()
+			if envSettings == expected {
+				gotEnv = true
+			} else {
+				if envSettings != s.detectedSettings {
+					c.Logf("proxy settings are \n%#v, should be \n%#v, still waiting", envSettings, expected)
+				}
+				s.detectedSettings = envSettings
+			}
+		}
+		if gotEnv && gotInProc {
+			break
 		}
 	}
 }
@@ -241,4 +266,39 @@ func (s *ProxyUpdaterSuite) TestExternalFuncCalled(c *gc.C) {
 	}
 
 	c.Assert(externalSettings, jc.DeepEquals, proxySettings)
+}
+
+func (s *ProxyUpdaterSuite) TestErrorSettingInProcessLogs(c *gc.C) {
+	proxySettings, _ := s.updateConfig(c)
+
+	s.config.InProcessUpdate = func(newSettings proxy.Settings) error {
+		select {
+		case s.inProcSettings <- newSettings:
+		case <-time.After(coretesting.LongWait):
+			panic("couldn't send settings on inProcSettings channel")
+		}
+		return errors.New("gone daddy gone")
+	}
+
+	var logWriter loggo.TestWriter
+	c.Assert(loggo.RegisterWriter("proxyupdater-tests", &logWriter), jc.ErrorIsNil)
+	defer func() {
+		loggo.RemoveWriter("proxyupdater-tests")
+		logWriter.Clear()
+	}()
+
+	updater, err := proxyupdater.NewWorker(s.config)
+	c.Assert(err, jc.ErrorIsNil)
+	s.waitProxySettings(c, proxySettings)
+	workertest.CleanKill(c, updater)
+
+	var foundMessage bool
+	expectedMessage := "error updating in-process proxy settings: gone daddy gone"
+	for _, entry := range logWriter.Log() {
+		if entry.Level == loggo.ERROR && strings.Contains(entry.Message, expectedMessage) {
+			foundMessage = true
+			break
+		}
+	}
+	c.Assert(foundMessage, jc.IsTrue)
 }


### PR DESCRIPTION
## Description of change

At the moment we update environment variables with the proxy settings,
intending for them to apply to web requests made from the running
process (like charm downloads). Unfortunately the built-in
implementation that reads proxy info from the environment only reads the
variables once - if a request has already been made the variable will
have been read and subsequent changes won't be seen.

Instead, store proxy settings in a package variable and configure the process's 
default transport so it will use the values from there. Change the proxy updater
to update those config settings as well as the other places it currently sets - we 
want any processes started by jujud to still get the right values in their env.

The proxy selection code was adapted from the stdlib function 
`net/http.ProxyFromEnvironment`.

## QA steps
* Run a proxy (like [tinyproxy](https://tinyproxy.github.io/)) and check that you can see requests that it handles.
* Bootstrap a controller and add a model.
* Deploy a charm to the model - the charm download shouldn't go via the proxy.
* Update the controller proxy settings to point to the proxy.
* Deploy another different charm that uses resources (like [mattermost](https://jujucharms.com/u/cmars/mattermost/)) - the download of the charm and resources should go via the proxy.

## Bug reference

Fixes https://bugs.launchpad.net/juju/2.1/+bug/1654591
