### PR TITLE
Adjust precedence of apt proxy settings conf file

### DIFF
--- a/cloudconfig/userdatacfg_test.go
+++ b/cloudconfig/userdatacfg_test.go
@@ -1144,7 +1144,7 @@ func (s *cloudinitSuite) TestAptProxyWritten(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	cmds := cloudcfg.BootCmds()
-	expected := "printf '%s\\n' 'Acquire::http::Proxy \"http://user@10.0.0.1\";' > /etc/apt/apt.conf.d/42-juju-proxy-settings"
+	expected := "printf '%s\\n' 'Acquire::http::Proxy \"http://user@10.0.0.1\";' > /etc/apt/apt.conf.d/95-juju-proxy-settings"
 	c.Assert(cmds, jc.DeepEquals, []string{expected})
 }
 

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -47,7 +47,7 @@ github.com/juju/terms-client	git	9b925afd677234e4146dde3cb1a11e187cbed64e	2016-0
 github.com/juju/testing	git	5ea77166c8c6a8f56f258565288c4714aa399283	2016-11-24T00:43:14Z
 github.com/juju/txn	git	28898197906200d603394d8e4ce537436529f1c5	2016-11-16T04:07:55Z
 github.com/juju/usso	git	68a59c96c178fbbad65926e7f93db50a2cd14f33	2016-04-01T10:44:24Z
-github.com/juju/utils	git	2c7a521b0a6ba1b4d0c29a1670a1d92bbdc23610	2017-02-08T11:46:50Z
+github.com/juju/utils	git	c42a5b184ca1fe8d21ea96b1edacf280ed7032c9	2017-02-14T00:59:05Z
 github.com/juju/version	git	1f41e27e54f21acccf9b2dddae063a782a8a7ceb	2016-10-31T05:19:06Z
 github.com/juju/webbrowser	git	54b8c57083b4afb7dc75da7f13e2967b2606a507	2016-03-09T14:36:29Z
 github.com/juju/xml	git	eb759a627588d35166bc505fceb51b88500e291e	2015-04-13T13:11:21Z


### PR DESCRIPTION
## Description of change

Change the precedence of the juju apt proxy conf file so that it will override any settings from MAAS/curtain.
Implement the suggestion in https://bugs.launchpad.net/juju/+bug/1490480/comments/1

## QA steps

bootstrap LXD with apt proxy settings and ensure 
/etc/apt/apt.conf.d/95-juju-proxy-settings
exists and has the expected contents

Needs to be tested live on a MAAS setup exhibiting the issue. 

## Bug reference

https://bugs.launchpad.net/juju/+bug/1490480
