### PR TITLE
Fix juju ssh/scp --proxy without model selected

### DIFF
--- a/cmd/juju/commands/ssh_common.go
+++ b/cmd/juju/commands/ssh_common.go
@@ -285,6 +285,7 @@ func (c *SSHCommon) setProxyCommand(options *ssh.Options) error {
 	// this extra level of checking.
 	options.SetProxyCommand(
 		juju, "ssh",
+		"--model="+c.ModelName(),
 		"--proxy=false",
 		"--no-host-key-checks",
 		"--pty=false",

--- a/cmd/juju/commands/ssh_common_test.go
+++ b/cmd/juju/commands/ssh_common_test.go
@@ -73,7 +73,10 @@ func (s *argsSpec) check(c *gc.C, output string) {
 	}
 
 	if s.withProxy {
-		expect("-o ProxyCommand juju ssh --proxy=false --no-host-key-checks " +
+		expect("-o ProxyCommand juju ssh " +
+			"--model=controller " +
+			"--proxy=false " +
+			"--no-host-key-checks " +
 			"--pty=false ubuntu@localhost -q \"nc %h %p\"")
 	}
 	expect("-o PasswordAuthentication no -o ServerAliveInterval 30")


### PR DESCRIPTION
## Description of change

The command line generated when --proxy is now specifies the selected model. This ensures that `juju ssh/scp --proxy` works when there's no model in focus (but `--model` is used).

Fixes https://bugs.launchpad.net/juju/2.1/+bug/1662732

## QA steps

Confirmed that the steps in the bug report now work.

## Documentation changes

No documentation changes required.

## Bug reference

https://bugs.launchpad.net/juju/2.1/+bug/1662732
