### PR TITLE
2.1 minimal fix for bug #1664437

### DIFF
--- a/worker/provisioner/container_initialisation.go
+++ b/worker/provisioner/container_initialisation.go
@@ -210,8 +210,8 @@ func (cs *ContainerSetup) prepareHost(containerTag names.MachineTag, log loggo.L
 		return errors.Trace(err)
 	}
 
-	log.Debugf("Bridging %+v devices on host %q with delay=%v, acquiring lock %q",
-		devicesToBridge, cs.machine.MachineTag().String(), reconfigureDelay, cs.initLockName)
+	log.Debugf("Bridging %+v devices on host %q for container %q with delay=%v, acquiring lock %q",
+		devicesToBridge, cs.machine.MachineTag().String(), containerTag.String(), reconfigureDelay, cs.initLockName)
 	// TODO(jam): 2017-02-08 figure out how to thread catacomb.Dying() into
 	// this function, so that we can stop trying to acquire the lock if we are
 	// stopping.
@@ -219,7 +219,7 @@ func (cs *ContainerSetup) prepareHost(containerTag names.MachineTag, log loggo.L
 	if err != nil {
 		return errors.Annotatef(err, "failed to acquire lock %q for bridging", cs.initLockName)
 	}
-	defer log.Debugf("releasing lock %q for bridging", cs.initLockName)
+	defer log.Debugf("releasing lock %q for bridging machine %q for container %q", cs.initLockName, cs.machine.MachineTag().String(), containerTag.String())
 	defer releaser.Release()
 	err = bridger.Bridge(devicesToBridge, reconfigureDelay)
 	if err != nil {
@@ -265,20 +265,18 @@ func (cs *ContainerSetup) getContainerArtifacts(
 		return nil, nil, nil, err
 	}
 
-	bridger, err := network.DefaultEtcNetworkInterfacesBridger(activateBridgesTimeout, instancecfg.DefaultBridgePrefix, systemNetworkInterfacesFile)
-	if err != nil {
-		return nil, nil, nil, err
-	}
-
 	switch containerType {
 	case instance.KVM:
 		initialiser = kvm.NewContainerInitialiser()
-		broker, err = NewKvmBroker(
-			bridger,
-			cs.machine.MachineTag(),
+		manager, err := kvm.NewContainerManager(managerConfig)
+		if err != nil {
+			return nil, nil, nil, err
+		}
+		broker, err = NewKVMBroker(
+			cs.prepareHost,
 			cs.provisioner,
+			manager,
 			cs.config,
-			managerConfig,
 		)
 		if err != nil {
 			logger.Errorf("failed to create new kvm broker")


### PR DESCRIPTION
The KVM broker was updated to allow using the preferred 'prepareHost',
but we didn't actually start calling the new function.

## Description of change

In the field they noticed that if you are creating KVM and LXD containers at the same time, the end up racing to bridge the network interfaces. It is possible for KVM to be bringing the interfaces down at the same time that LXD is trying to introspect the machine for what devices are available.

The full fix should include updating all of the test suite so we get rid of the old function that was causing this problem, and preferably a test that we actually do grab the lock. I'm not sure if that test is easy to write, but the fallback only exists for the test suite at this point, and we just need to get rid of that.

## QA steps

```
  $ juju deploy bundle-with-kvm-and-lxd.yaml
```
You should see entries in the log file that indicate KVM is grabbing the lock and releasing it, as is LXD but never are they both running:
```
  juju.network bridge.go:70 bridgescript command=/usr/bin/python2 - --interfaces-to-bridge
```
at the same time.

## Documentation changes

Doesn't affect the actual workflow.

## Bug reference

[lp:1664437](https://bugs.launchpad.net/juju/+bug/1664437)