### PR TITLE
cloudconfig: pass --connect-timeout to curl

### DIFF
--- a/cloudconfig/userdatacfg_test.go
+++ b/cloudconfig/userdatacfg_test.go
@@ -395,7 +395,7 @@ chown syslog:adm /var/log/juju
 bin='/var/lib/juju/tools/1\.2\.3-quantal-amd64'
 mkdir -p \$bin
 echo 'Fetching Juju agent version.*
-curl .* --noproxy "\*" --insecure -o \$bin/tools\.tar\.gz 'https://state-addr\.testing\.invalid:54321/deadbeef-0bad-400d-8000-4b1d0d06f00d/tools/1\.2\.3-quantal-amd64'
+curl -sSfw '.*' --connect-timeout 20 --noproxy "\*" --insecure -o \$bin/tools\.tar\.gz 'https://state-addr\.testing\.invalid:54321/deadbeef-0bad-400d-8000-4b1d0d06f00d/tools/1\.2\.3-quantal-amd64'
 sha256sum \$bin/tools\.tar\.gz > \$bin/juju1\.2\.3-quantal-amd64\.sha256
 grep '1234' \$bin/juju1\.2\.3-quantal-amd64.sha256 \|\| \(echo "Tools checksum mismatch"; exit 1\)
 tar zxf \$bin/tools.tar.gz -C \$bin

--- a/cloudconfig/userdatacfg_unix.go
+++ b/cloudconfig/userdatacfg_unix.go
@@ -332,6 +332,15 @@ func (w *unixConfigure) addDownloadToolsCmds() error {
 				curlCommand += " --insecure"
 			}
 		} else {
+			// Allow up to 20 seconds for curl to make a connection. This prevents
+			// slow/broken routes from holding up others.
+			//
+			// TODO(axw) 2017-02-14 #1654943
+			// When we model spaces everywhere, we should give
+			// priority to the URLs that we know are accessible
+			// based on space overlap.
+			curlCommand += " --connect-timeout 20"
+
 			// Don't go through the proxy when downloading tools from the controllers
 			curlCommand += ` --noproxy "*"`
 


### PR DESCRIPTION
## Description of change

Pass --connect-timeout to curl, so we don't
wait too long for a given URL when downloading
agent binaries from the controller.

## QA steps

1. juju bootstrap azure
2. juju add-machine
3. observe that the machine agent comes up quicker than without the change
4. extract the curl commands from /var/log/cloud-init-output.log, run again through "time" to check that the private network URL times out in ~20 seconds.

## Documentation changes

None.

## Bug reference

Fixes https://bugs.launchpad.net/juju/+bug/1622531