### PR TITLE
Use goose changes to enable keystone v3 support for authenticating with user and project domains

### DIFF
--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -79,7 +79,7 @@ google.golang.org/cloud	git	f20d6dcccb44ed49de45ae3703312cb46e627db1	2015-03-19T
 gopkg.in/amz.v3	git	18899065239e006cc73b0e66800c98c2ce4eee50	2016-10-06T07:29:34Z
 gopkg.in/check.v1	git	4f90aeace3a26ad7021961c297b22c42160c7b25	2016-01-05T16:49:36Z
 gopkg.in/errgo.v1	git	66cb46252b94c1f3d65646f54ee8043ab38d766c	2015-10-07T15:31:57Z
-gopkg.in/goose.v1	git	51ccf4fff13c89a1afb0a23873ca07bb5c12534a	2017-02-06T22:56:19Z
+gopkg.in/goose.v1	git	ac43167b647feacdd9a1e34ee81e574551bc748d	2017-02-15T01:56:23Z
 gopkg.in/ini.v1	git	776aa739ce9373377cd16f526cdf06cb4c89b40f	2016-02-22T23:24:41Z
 gopkg.in/juju/blobstore.v2	git	51fa6e26128d74e445c72d3a91af555151cc3654	2016-01-25T02:37:03Z
 gopkg.in/juju/charm.v6-unstable	git	83771c4919d6810bce5b7e63f46bea5fbfed0b93	2016-10-03T20:31:18Z

--- a/provider/openstack/credentials.go
+++ b/provider/openstack/credentials.go
@@ -19,12 +19,14 @@ import (
 )
 
 const (
-	CredAttrTenantName = "tenant-name"
-	CredAttrUserName   = "username"
-	CredAttrPassword   = "password"
-	CredAttrDomainName = "domain-name"
-	CredAttrAccessKey  = "access-key"
-	CredAttrSecretKey  = "secret-key"
+	CredAttrTenantName        = "tenant-name"
+	CredAttrUserName          = "username"
+	CredAttrPassword          = "password"
+	CredAttrDomainName        = "domain-name"
+	CredAttrProjectDomainName = "project-domain-name"
+	CredAttrUserDomainName    = "user-domain-name"
+	CredAttrAccessKey         = "access-key"
+	CredAttrSecretKey         = "secret-key"
 )
 
 type OpenstackCredentials struct{}
@@ -45,6 +47,16 @@ func (OpenstackCredentials) CredentialSchemas() map[cloud.AuthType]cloud.Credent
 			}, {
 				CredAttrDomainName, cloud.CredentialAttr{
 					Description: "The OpenStack domain name.",
+					Optional:    true,
+				},
+			}, {
+				CredAttrProjectDomainName, cloud.CredentialAttr{
+					Description: "The OpenStack project domain name.",
+					Optional:    true,
+				},
+			}, {
+				CredAttrUserDomainName, cloud.CredentialAttr{
+					Description: "The OpenStack user domain name.",
 					Optional:    true,
 				},
 			},
@@ -126,10 +138,12 @@ func (c OpenstackCredentials) detectCredential() (*cloud.Credential, string, str
 		credential = cloud.NewCredential(
 			cloud.UserPassAuthType,
 			map[string]string{
-				CredAttrUserName:   creds.User,
-				CredAttrPassword:   creds.Secrets,
-				CredAttrTenantName: creds.TenantName,
-				CredAttrDomainName: creds.DomainName,
+				CredAttrUserName:          creds.User,
+				CredAttrPassword:          creds.Secrets,
+				CredAttrTenantName:        creds.TenantName,
+				CredAttrUserDomainName:    creds.UserDomain,
+				CredAttrProjectDomainName: creds.ProjectDomain,
+				CredAttrDomainName:        creds.Domain,
 			},
 		)
 	} else {

--- a/provider/openstack/provider.go
+++ b/provider/openstack/provider.go
@@ -676,9 +676,11 @@ func newCredentials(spec environs.CloudSpec) (identity.Credentials, identity.Aut
 		// TODO(axw) we need a way of saying to use legacy auth.
 		cred.User = credAttrs[CredAttrUserName]
 		cred.Secrets = credAttrs[CredAttrPassword]
-		cred.DomainName = credAttrs[CredAttrDomainName]
+		cred.ProjectDomain = credAttrs[CredAttrProjectDomainName]
+		cred.UserDomain = credAttrs[CredAttrUserDomainName]
+		cred.Domain = credAttrs[CredAttrDomainName]
 		authMode = identity.AuthUserPass
-		if cred.DomainName != "" {
+		if cred.Domain != "" || cred.UserDomain != "" || cred.ProjectDomain != "" {
 			authMode = identity.AuthUserPassV3
 		}
 	case cloud.AccessKeyAuthType:


### PR DESCRIPTION
## Description of change

This PR builds on the change in goose PR https://github.com/go-goose/goose/pull/40
It adds support for handling user and project domains when authenticating using keystone v3. Extra credential attributes are used to store the new domain fields.

## QA steps

bootstrapped a live customer Mitaka deployment which was previously not working

## Bug reference

https://bugs.launchpad.net/goose/+bug/1543262
