### PR TITLE
dependencies.tsv: update github.com/juju/testing

### DIFF
--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -44,7 +44,7 @@ github.com/juju/rfc	git	ebdbbdb950cd039a531d15cdc2ac2cbd94f068ee	2016-07-11T02:4
 github.com/juju/romulus	git	bf7827fa2f360ab762c134766ff1d4fff959ea03	2016-08-17T23:29:48Z
 github.com/juju/schema	git	075de04f9b7d7580d60a1e12a0b3f50bb18e6998	2016-04-20T04:42:03Z
 github.com/juju/terms-client	git	9b925afd677234e4146dde3cb1a11e187cbed64e	2016-08-09T13:19:00Z
-github.com/juju/testing	git	5ea77166c8c6a8f56f258565288c4714aa399283	2016-11-24T00:43:14Z
+github.com/juju/testing	git	44f495fbd6d645be114105945fdf75c9e7648b67	2017-02-14T22:39:22Z
 github.com/juju/txn	git	28898197906200d603394d8e4ce537436529f1c5	2016-11-16T04:07:55Z
 github.com/juju/usso	git	68a59c96c178fbbad65926e7f93db50a2cd14f33	2016-04-01T10:44:24Z
 github.com/juju/utils	git	c42a5b184ca1fe8d21ea96b1edacf280ed7032c9	2017-02-14T00:59:05Z


### PR DESCRIPTION
## Description of change

Disabled mgo debugging/logging by default, which cuts out
a significant amount of mgo call overhead.

## QA steps

Run the tests. Before change, state tests take ~350s on my laptop; after change, ~250s.

## Documentation changes

None.

## Bug reference

Hopefully fixes https://bugs.launchpad.net/juju/+bug/1625768