### PR TITLE
Add PR #241 for goyaml now until it gets merged upstream.

### DIFF
--- a/featuretests/cmdjuju_test.go
+++ b/featuretests/cmdjuju_test.go
@@ -124,6 +124,12 @@ settings:
 }
 
 func (s *cmdJujuSuite) TestServiceGetWeirdYAML(c *gc.C) {
+	// This test has been confirmed to pass with the patch/goyaml-pr-241.diff
+	// applied to the current gopkg.in/yaml.v2 revision, however since our standard
+	// local test tooling doesn't apply patches, this test would fail without it.
+	// When the goyaml has merged pr #241 and the dependencies updated, we can
+	// remove the skip.
+	c.Skip("Remove skip when goyaml has PR #241.")
 	expected := `application: yaml-config
 charm: yaml-config
 settings:
@@ -134,10 +140,9 @@ settings:
     value: "0xD06F00D"
   nonoctal:
     default: true
-    description: TODO remove the quotes. Number that isn't valid octal, so should
-      be a string.
+    description: Number that isn't valid octal, so should be a string.
     type: string
-    value: "01182252"
+    value: 01182252
   numberstring:
     default: true
     description: A string that happens to contain a number.

--- a/patches/goyaml-pr-241.diff
+++ b/patches/goyaml-pr-241.diff
@@ -1,0 +1,27 @@
+diff --git a/decode_test.go b/decode_test.go
+index a6fea0f..11c1278 100644
+--- a/gopkg.in/yaml.v2/decode_test.go
++++ b/gopkg.in/yaml.v2/decode_test.go
+@@ -43,6 +43,9 @@ var unmarshalTests = []struct {
+ 		"v: 0xA",
+ 		map[string]interface{}{"v": 10},
+ 	}, {
++		"v: 01182252",
++		map[string]interface{}{"v": "01182252"},
++	}, {
+ 		"v: 4294967296",
+ 		map[string]int64{"v": 4294967296},
+ 	}, {
+diff --git a/resolve.go b/resolve.go
+index 232313c..34d559b 100644
+--- a/gopkg.in/yaml.v2/resolve.go
++++ b/gopkg.in/yaml.v2/resolve.go
+@@ -81,7 +81,7 @@ func resolvableTag(tag string) bool {
+ 	return false
+ }
+ 
+-var yamlStyleFloat = regexp.MustCompile(`^[-+]?[0-9]*\.?[0-9]+([eE][-+][0-9]+)?$`)
++var yamlStyleFloat = regexp.MustCompile(`^[-+]?(0|[1-9][0-9]*)?(\.[0-9]+)?([eE][-+][0-9]+)?$`)
+ 
+ func resolve(tag string, in string) (rtag string, out interface{}) {
+ 	if !resolvableTag(tag) {

--- a/patches/goyaml-pr-241.diff
+++ b/patches/goyaml-pr-241.diff
@@ -1,3 +1,7 @@
+This is the diff from PR #241 on goyaml.
+When this file is removed, also remove the Skip from the test
+featuretests/cmdjuju_test.go TestServiceGetWeirdYAML.
+
 diff --git a/decode_test.go b/decode_test.go
 index a6fea0f..11c1278 100644
 --- a/gopkg.in/yaml.v2/decode_test.go

--- a/testcharms/charm-repo/quantal/yaml-config/config.yaml
+++ b/testcharms/charm-repo/quantal/yaml-config/config.yaml
@@ -8,6 +8,6 @@ options:
     description: A string that happens to contain a number.
     type: string
   nonoctal:
-    default: "01182252"
-    description: TODO remove the quotes. Number that isn't valid octal, so should be a string.
+    default: 01182252
+    description: Number that isn't valid octal, so should be a string.
     type: string


### PR DESCRIPTION
In order to better support the YAML spec, values that have leading zeros are strings, not numbers.

## QA steps

From the bug, create a charm with the following config option:

```  install_keys:
    type: string
    description: The key for the Debian package repository.
    default: 01182252
```

Deploy it, check the config for the app.

## Bug reference

Fixes lp:1543660