### PR TITLE
juju gui now prints the URL by default

### DIFF
--- a/cmd/juju/gui/export_test.go
+++ b/cmd/juju/gui/export_test.go
@@ -3,6 +3,14 @@
 
 package gui
 
+import (
+	"github.com/juju/cmd"
+
+	"github.com/juju/juju/api"
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/cmd/modelcmd"
+)
+
 var (
 	ClientGet      = &clientGet
 	WebbrowserOpen = &webbrowserOpen
@@ -12,3 +20,9 @@ var (
 	ClientUploadGUIArchive = &clientUploadGUIArchive
 	GUIFetchMetadata       = &guiFetchMetadata
 )
+
+func NewGUICommandForTest(getGUIVersions func(connection api.Connection) ([]params.GUIArchiveVersion, error)) cmd.Command {
+	return modelcmd.Wrap(&guiCommand{
+		getGUIVersions: getGUIVersions,
+	})
+}

--- a/cmd/juju/gui/gui.go
+++ b/cmd/juju/gui/gui.go
@@ -27,21 +27,27 @@ type guiCommand struct {
 	modelcmd.ModelCommandBase
 
 	showCreds bool
+	browser   bool
+	// Deprecated - used with --no-browser
 	noBrowser bool
 }
 
 const guiDoc = `
-Open the Juju GUI in the default browser:
+Print the Juju GUI URL:
 
 	juju gui
 
-Open the GUI and show admin credentials to use to log into it:
+Print the Juju GUI URL and show admin credential to use to log into it:
 
-	juju gui --show-credentials
+	juju gui --show-credential
 
-Do not open the browser, just output the GUI URL:
+Open the Juju GUI in the default browser:
 
-	juju gui --no-browser
+	juju gui --browser
+
+Open the GUI and show admin credential to use to log into it:
+
+	juju gui --show-credential --browser
 
 An error is returned if the Juju GUI is not available in the controller.
 `
@@ -50,7 +56,7 @@ An error is returned if the Juju GUI is not available in the controller.
 func (c *guiCommand) Info() *cmd.Info {
 	return &cmd.Info{
 		Name:    "gui",
-		Purpose: "Open the Juju GUI in the default browser.",
+		Purpose: "Print the Juju GUI URL, or open the Juju GUI in the default browser.",
 		Doc:     guiDoc,
 	}
 }
@@ -58,8 +64,10 @@ func (c *guiCommand) Info() *cmd.Info {
 // SetFlags implements the cmd.Command interface.
 func (c *guiCommand) SetFlags(f *gnuflag.FlagSet) {
 	c.ModelCommandBase.SetFlags(f)
-	f.BoolVar(&c.showCreds, "show-credentials", false, "Show admin credentials to use for logging into the Juju GUI")
-	f.BoolVar(&c.noBrowser, "no-browser", false, "Do not try to open the web browser, just print the Juju GUI URL")
+	f.BoolVar(&c.showCreds, "show-credentials", false, "DEPRECATED. Use --show-credential. Show admin credential to use for logging into the Juju GUI")
+	f.BoolVar(&c.showCreds, "show-credential", false, "Show admin credential to use for logging into the Juju GUI")
+	f.BoolVar(&c.noBrowser, "no-browser", true, "DEPRECATED. --no-browser is now the default. Use --browser to open the web browser")
+	f.BoolVar(&c.browser, "browser", false, "Open the web browser, instead of just printing the Juju GUI URL")
 }
 
 // Run implements the cmd.Command interface.
@@ -112,7 +120,7 @@ func (c *guiCommand) openBrowser(ctx *cmd.Context, rawURL string) error {
 	if err != nil {
 		return errors.Annotate(err, "cannot parse Juju GUI URL")
 	}
-	if c.noBrowser {
+	if c.noBrowser && !c.browser {
 		ctx.Infof(u.String())
 		return nil
 	}

--- a/cmd/juju/gui/gui_test.go
+++ b/cmd/juju/gui/gui_test.go
@@ -64,7 +64,7 @@ func (s *guiSuite) TestGUISuccessWithBrowser(c *gc.C) {
 		browserURL = u.String()
 		return nil
 	})
-	out, err := s.run(c)
+	out, err := s.run(c, "--browser")
 	c.Assert(err, jc.ErrorIsNil)
 	guiURL := s.guiURL(c)
 	expectOut := "Opening the Juju GUI in your browser.\nIf it does not open, open this URL:\n" + guiURL
@@ -73,7 +73,15 @@ func (s *guiSuite) TestGUISuccessWithBrowser(c *gc.C) {
 	c.Assert(browserURL, gc.Equals, guiURL)
 }
 
-func (s *guiSuite) TestGUISuccessWithCredentials(c *gc.C) {
+func (s *guiSuite) TestGUISuccessWithCredential(c *gc.C) {
+	s.patchClient(nil)
+	s.patchBrowser(nil)
+	out, err := s.run(c, "--show-credential")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(out, jc.Contains, "Username: admin\nPassword: dummy-secret")
+}
+
+func (s *guiSuite) TestGUISuccessWithCredentialsDeprecated(c *gc.C) {
 	s.patchClient(nil)
 	s.patchBrowser(nil)
 	out, err := s.run(c, "--show-credentials")
@@ -82,6 +90,14 @@ func (s *guiSuite) TestGUISuccessWithCredentials(c *gc.C) {
 }
 
 func (s *guiSuite) TestGUISuccessNoBrowser(c *gc.C) {
+	s.patchClient(nil)
+	// There is no need to patch the browser open function here.
+	out, err := s.run(c)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(out, gc.Equals, s.guiURL(c))
+}
+
+func (s *guiSuite) TestGUISuccessNoBrowserDeprecated(c *gc.C) {
 	s.patchClient(nil)
 	// There is no need to patch the browser open function here.
 	out, err := s.run(c, "--no-browser")
@@ -94,7 +110,7 @@ func (s *guiSuite) TestGUISuccessBrowserNotFound(c *gc.C) {
 	s.patchBrowser(func(u *url.URL) error {
 		return webbrowser.ErrNoBrowser
 	})
-	out, err := s.run(c)
+	out, err := s.run(c, "--browser")
 	c.Assert(err, jc.ErrorIsNil)
 	expectOut := "Open this URL in your browser:\n" + s.guiURL(c)
 	c.Assert(out, gc.Equals, expectOut)
@@ -105,7 +121,7 @@ func (s *guiSuite) TestGUIErrorBrowser(c *gc.C) {
 	s.patchBrowser(func(u *url.URL) error {
 		return errors.New("bad wolf")
 	})
-	out, err := s.run(c)
+	out, err := s.run(c, "--browser")
 	c.Assert(err, gc.ErrorMatches, "cannot open web browser: bad wolf")
 	c.Assert(out, gc.Equals, "")
 }
@@ -114,7 +130,7 @@ func (s *guiSuite) TestGUIErrorUnavailable(c *gc.C) {
 	s.patchClient(func(client *httprequest.Client, u string) error {
 		return errors.New("bad wolf")
 	})
-	out, err := s.run(c)
+	out, err := s.run(c, "--browser")
 	c.Assert(err, gc.ErrorMatches, "Juju GUI is not available: bad wolf")
 	c.Assert(out, gc.Equals, "")
 }

--- a/cmd/juju/gui/gui_test.go
+++ b/cmd/juju/gui/gui_test.go
@@ -11,9 +11,12 @@ import (
 
 	"github.com/juju/httprequest"
 	jc "github.com/juju/testing/checkers"
+	"github.com/juju/version"
 	"github.com/juju/webbrowser"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/api"
+	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/cmd/juju/gui"
 	jujutesting "github.com/juju/juju/juju/testing"
 	coretesting "github.com/juju/juju/testing"
@@ -27,7 +30,18 @@ var _ = gc.Suite(&guiSuite{})
 
 // run executes the gui command passing the given args.
 func (s *guiSuite) run(c *gc.C, args ...string) (string, error) {
-	ctx, err := coretesting.RunCommand(c, gui.NewGUICommand(), args...)
+	ctx, err := coretesting.RunCommand(c, gui.NewGUICommandForTest(
+		func(connection api.Connection) ([]params.GUIArchiveVersion, error) {
+			return []params.GUIArchiveVersion{
+				{
+					Version: version.MustParse("1.2.3"),
+					Current: false,
+				}, {
+					Version: version.MustParse("4.5.6"),
+					Current: true,
+				},
+			}, nil
+		}), args...)
 	return strings.Trim(coretesting.Stderr(ctx), "\n"), err
 }
 
@@ -64,7 +78,7 @@ func (s *guiSuite) TestGUISuccessWithBrowser(c *gc.C) {
 		browserURL = u.String()
 		return nil
 	})
-	out, err := s.run(c, "--browser")
+	out, err := s.run(c, "--browser", "--hide-credential")
 	c.Assert(err, jc.ErrorIsNil)
 	guiURL := s.guiURL(c)
 	expectOut := "Opening the Juju GUI in your browser.\nIf it does not open, open this URL:\n" + guiURL
@@ -76,33 +90,40 @@ func (s *guiSuite) TestGUISuccessWithBrowser(c *gc.C) {
 func (s *guiSuite) TestGUISuccessWithCredential(c *gc.C) {
 	s.patchClient(nil)
 	s.patchBrowser(nil)
-	out, err := s.run(c, "--show-credential")
+	out, err := s.run(c)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(out, jc.Contains, "Username: admin\nPassword: dummy-secret")
+	c.Assert(out, jc.Contains, `
+Your login credential is:
+  username: admin
+  password: dummy-secret`[1:])
 }
 
-func (s *guiSuite) TestGUISuccessWithCredentialsDeprecated(c *gc.C) {
+func (s *guiSuite) TestGUISuccessNoCredential(c *gc.C) {
 	s.patchClient(nil)
 	s.patchBrowser(nil)
-	out, err := s.run(c, "--show-credentials")
+	out, err := s.run(c, "--hide-credential")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(out, jc.Contains, "Username: admin\nPassword: dummy-secret")
+	c.Assert(out, gc.Not(jc.Contains), "Password")
 }
 
 func (s *guiSuite) TestGUISuccessNoBrowser(c *gc.C) {
 	s.patchClient(nil)
 	// There is no need to patch the browser open function here.
-	out, err := s.run(c)
+	out, err := s.run(c, "--hide-credential")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(out, gc.Equals, s.guiURL(c))
+	c.Assert(out, gc.Equals, fmt.Sprintf(`
+GUI 4.5.6 for model controller is enabled at:
+  %s`[1:], s.guiURL(c)))
 }
 
 func (s *guiSuite) TestGUISuccessNoBrowserDeprecated(c *gc.C) {
 	s.patchClient(nil)
 	// There is no need to patch the browser open function here.
-	out, err := s.run(c, "--no-browser")
+	out, err := s.run(c, "--no-browser", "--hide-credential")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(out, gc.Equals, s.guiURL(c))
+	c.Assert(out, gc.Equals, fmt.Sprintf(`
+GUI 4.5.6 for model controller is enabled at:
+  %s`[1:], s.guiURL(c)))
 }
 
 func (s *guiSuite) TestGUISuccessBrowserNotFound(c *gc.C) {
@@ -110,7 +131,7 @@ func (s *guiSuite) TestGUISuccessBrowserNotFound(c *gc.C) {
 	s.patchBrowser(func(u *url.URL) error {
 		return webbrowser.ErrNoBrowser
 	})
-	out, err := s.run(c, "--browser")
+	out, err := s.run(c, "--browser", "--hide-credential")
 	c.Assert(err, jc.ErrorIsNil)
 	expectOut := "Open this URL in your browser:\n" + s.guiURL(c)
 	c.Assert(out, gc.Equals, expectOut)


### PR DESCRIPTION
## Description of change

Invert the behaviour of the juju gui command. The command will now just print the GUI URL by default. Using --browser is needed to launch the browser.

--show-credential (singular) is used instead of --show-credentials to be consistent with the rest of Juju

## QA steps

bootstrap juju
juju gui --browser

## Documentation changes

CLI doc for juju GUI will change

## Bug reference

https://bugs.launchpad.net/juju/+bug/1631438
