### PR TITLE
even when the bridge has no addresses, still use DHCP

### DIFF
--- a/apiserver/provisioner/provisioner.go
+++ b/apiserver/provisioner/provisioner.go
@@ -745,6 +745,9 @@ func (ctx *prepareOrGetContext) ProcessOneContainer(env environs.Environ, idx in
 			}
 		} else {
 			logger.Infof("host machine device %q has no addresses %v", parentDevice.Name(), parentAddrs)
+			info.ConfigType = network.ConfigDHCP
+			info.ProviderSubnetId = ""
+			info.VLANTag = 0
 		}
 
 		logger.Tracef("prepared info for container interface %q: %+v", info.InterfaceName, info)

--- a/apiserver/provisioner/provisioner.go
+++ b/apiserver/provisioner/provisioner.go
@@ -745,6 +745,8 @@ func (ctx *prepareOrGetContext) ProcessOneContainer(env environs.Environ, idx in
 			}
 		} else {
 			logger.Infof("host machine device %q has no addresses %v", parentDevice.Name(), parentAddrs)
+			// TODO(jam): 2017-02-15, have a concrete test for this case, as it
+			// seems to be the common case in the wild.
 			info.ConfigType = network.ConfigDHCP
 			info.ProviderSubnetId = ""
 			info.VLANTag = 0

--- a/apiserver/provisioner/provisioner_test.go
+++ b/apiserver/provisioner/provisioner_test.go
@@ -1393,3 +1393,14 @@ func (s *withoutControllerSuite) TestMarkMachinesForRemoval(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(removals, jc.SameContents, []string{"0", "2"})
 }
+
+// TODO(jam): 2017-02-15 We seem to be lacking most of direct unit tests around ProcessOneContainer
+// Some of the use cases we need to be testing are:
+// 1) Provider can allocate addresses, should result in a container with
+//    addresses requested from the provider, and 'static' configuration on those
+//    devices.
+// 2) Provider cannot allocate addresses, currently this should make us use
+//    'lxdbr0' and DHCP allocated addresses.
+// 3) Provider could allocate DHCP based addresses on the host device, which would let us
+//    use a bridge on the device and DHCP. (Currently not supported, but desirable for
+//    vSphere and Manual and probably LXD providers.)


### PR DESCRIPTION
## Description of change

We had a bug where we saw 'lxdbr0' exist, but it didn't have an IP address associated with it. (This is true at least on Xenial.) And our code was deciding that we should use DHCP under certain circumstances, but not under this one, and the default path was to use Static allocation.

## QA steps

```
  $ juju bootstrap lxd
  $ lxc profile edit juju-default # add 'security.privileged: true'
  $ juju deploy cs:~jameinel/ubuntu-lite-nested
```

With stock 2.1, the nested container that comes up will have an /etc/network/interfaces file with a line like:
```
  iface eth0 inet manual
```
instead of
```
  iface eth0 inet dhcp
```
With this change, the nested container will be configured to use DHCP.

## Documentation changes

Should just enable what used to work in 2.0.

## Bug reference

[lp:1664409](https://bugs.launchpad.net/juju/+bug/1664409)