### PR TITLE
Tweak GUI help output

### DIFF
--- a/cmd/juju/gui/gui.go
+++ b/cmd/juju/gui/gui.go
@@ -151,7 +151,7 @@ func (c *guiCommand) openBrowser(ctx *cmd.Context, rawURL string, vers *version.
 		if vers != nil {
 			versInfo = fmt.Sprintf("%v ", vers)
 		}
-		ctx.Infof("GUI %sfor model %s is enabled at:\n  %s", versInfo, c.ModelName(), u.String())
+		ctx.Infof("GUI %sis enabled at:\n  %s", versInfo, u.String())
 		return nil
 	}
 	err = webbrowserOpen(u)

--- a/cmd/juju/gui/gui_test.go
+++ b/cmd/juju/gui/gui_test.go
@@ -112,7 +112,7 @@ func (s *guiSuite) TestGUISuccessNoBrowser(c *gc.C) {
 	out, err := s.run(c, "--hide-credential")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(out, gc.Equals, fmt.Sprintf(`
-GUI 4.5.6 for model controller is enabled at:
+GUI 4.5.6 is enabled at:
   %s`[1:], s.guiURL(c)))
 }
 
@@ -122,7 +122,7 @@ func (s *guiSuite) TestGUISuccessNoBrowserDeprecated(c *gc.C) {
 	out, err := s.run(c, "--no-browser", "--hide-credential")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(out, gc.Equals, fmt.Sprintf(`
-GUI 4.5.6 for model controller is enabled at:
+GUI 4.5.6 is enabled at:
   %s`[1:], s.guiURL(c)))
 }
 


### PR DESCRIPTION
## Description of change

When Juju GUI CLI prints the URL, it includes text about the model. The URL doesn't go directly to the model so the text is tweaked.

## QA steps

bootstrap
juju gui

