### PR TITLE
Add support for new gui urls

### DIFF
--- a/apiserver/apiserver.go
+++ b/apiserver/apiserver.go
@@ -482,7 +482,9 @@ func (srv *Server) endpoints() []apihttp.Endpoint {
 	)
 	add("/model/:modeluuid/api", mainAPIHandler)
 
-	endpoints = append(endpoints, guiEndpoints("/gui/:modeluuid/", srv.dataDir, httpCtxt)...)
+	// GUI now supports URLs without the model uuid, just the user/model.
+	endpoints = append(endpoints, guiEndpoints(guiURLPathPrefix+"u/:user/:modelname/", srv.dataDir, httpCtxt)...)
+	endpoints = append(endpoints, guiEndpoints(guiURLPathPrefix+":modeluuid/", srv.dataDir, httpCtxt)...)
 	add("/gui-archive", &guiArchiveHandler{
 		ctxt: httpCtxt,
 	})

--- a/apiserver/httpcontext.go
+++ b/apiserver/httpcontext.go
@@ -30,13 +30,44 @@ type httpContext struct {
 	srv *Server
 }
 
+// modelUUIDFromRequest returns the uuid of the model based on path elements
+// in the request, and a boolean indicating if the model uuid were included directly.
+// A request either has the modeluuid directly in the path, or the path is
+// u/user/modelname and we need to look up the model uuid.
+func (ctxt *httpContext) modelUUIDFromRequest(r *http.Request) (string, bool, error) {
+	uuid := r.URL.Query().Get(":modeluuid")
+	if uuid != "" {
+		return uuid, true, nil
+	}
+
+	user := r.URL.Query().Get(":user")
+	model := r.URL.Query().Get(":modelname")
+	if user == "" || model == "" {
+		return "", false, nil
+	}
+	models, err := ctxt.srv.state.ModelsForUser(names.NewUserTag(user))
+	if err != nil {
+		return "", false, errors.Trace(err)
+	}
+	for _, m := range models {
+		if m.Name() == model {
+			return m.UUID(), false, nil
+		}
+	}
+	return "", false, errors.NotFoundf("model %s/%s", user, model)
+}
+
 // stateForRequestUnauthenticated returns a state instance appropriate for
 // using for the model implicit in the given request
 // without checking any authentication information.
 func (ctxt *httpContext) stateForRequestUnauthenticated(r *http.Request) (*state.State, func(), error) {
-	modelUUID, err := validateModelUUID(validateArgs{
+	modelUUID, _, err := ctxt.modelUUIDFromRequest(r)
+	if err != nil {
+		return nil, nil, errors.Trace(err)
+	}
+	modelUUID, err = validateModelUUID(validateArgs{
 		statePool:           ctxt.srv.statePool,
-		modelUUID:           r.URL.Query().Get(":modeluuid"),
+		modelUUID:           modelUUID,
 		strict:              ctxt.strictValidation,
 		controllerModelOnly: ctxt.controllerModelOnly,
 	})


### PR DESCRIPTION
## Description of change

The GUI us moving to a new URL scheme
https://<controller>:17070/gui/u/user/model

We need to support that plus there's a login redirect bug that is fixed.
The existing modelUUID URLs are still used to serve static content. It's just the user navigable URLs that are changed.

## QA steps

bootstrap juju 2.1
$ juju gui
Use the url and credentials printed to log into the GUI.
Logout
Login again and ensure that works

boostrap juju 2.0
$ juju gui
Check that the UUID baded URL is printed and works.

## Bug reference

https://github.com/juju/juju-gui/issues/2430
