### PR TITLE
provider/lxd: improve endpoint handling

### DIFF
--- a/provider/lxd/environ.go
+++ b/provider/lxd/environ.go
@@ -15,7 +15,6 @@ import (
 	"github.com/juju/juju/environs/tags"
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/provider/common"
-	"github.com/juju/juju/tools/lxdclient"
 )
 
 const bootstrapMessage = `To configure your system to better support LXD containers, please see: https://github.com/lxc/lxd/blob/master/doc/production-setup.md`
@@ -140,9 +139,6 @@ func (env *environ) Config() *config.Config {
 
 // PrepareForBootstrap implements environs.Environ.
 func (env *environ) PrepareForBootstrap(ctx environs.BootstrapContext) error {
-	if err := lxdclient.EnableHTTPSListener(env.raw); err != nil {
-		return errors.Annotate(err, "enabling HTTPS listener")
-	}
 	return nil
 }
 

--- a/provider/lxd/environ_raw.go
+++ b/provider/lxd/environ_raw.go
@@ -33,6 +33,7 @@ type lxdCerts interface {
 }
 
 type lxdConfig interface {
+	ServerAddresses() ([]string, error)
 	ServerStatus() (*lxdshared.ServerState, error)
 	SetServerConfig(k, v string) error
 	SetContainerConfig(container, key, value string) error

--- a/provider/lxd/environ_test.go
+++ b/provider/lxd/environ_test.go
@@ -149,11 +149,3 @@ func (s *environSuite) TestDestroyHostedModels(c *gc.C) {
 		{"RemoveInstances", []interface{}{"juju-", []string{machine1.Name}}},
 	})
 }
-
-func (s *environSuite) TestPrepareForBootstrap(c *gc.C) {
-	err := s.Env.PrepareForBootstrap(envtesting.BootstrapContext(c))
-	c.Assert(err, jc.ErrorIsNil)
-	s.Stub.CheckCalls(c, []gitjujutesting.StubCall{
-		{"SetServerConfig", []interface{}{"core.https_address", "[::]"}},
-	})
-}

--- a/provider/lxd/provider.go
+++ b/provider/lxd/provider.go
@@ -7,6 +7,7 @@ package lxd
 
 import (
 	"net"
+	"strings"
 
 	"github.com/juju/errors"
 	"github.com/juju/jsonschema"
@@ -19,6 +20,7 @@ import (
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/provider/lxd/lxdnames"
+	"github.com/juju/juju/tools/lxdclient"
 )
 
 type environProvider struct {
@@ -101,35 +103,22 @@ func (p *environProvider) FinalizeCloud(
 	in cloud.Cloud,
 ) (cloud.Cloud, error) {
 
-	var hostAddress string
-	getHostAddress := func() (string, error) {
-		raw, err := p.newLocalRawProvider()
-		if err != nil {
-			return "", errors.Trace(err)
-		}
-		bridgeName := raw.DefaultProfileBridgeName()
-		hostAddress, err = p.interfaceAddress(bridgeName)
-		if err != nil {
-			return "", errors.Trace(err)
-		}
-		ctx.Verbosef(
-			"Resolved LXD host address on bridge %s: %s",
-			bridgeName, hostAddress,
-		)
-		return hostAddress, nil
-	}
+	var endpoint string
 	resolveEndpoint := func(ep *string) error {
 		if *ep != "" {
 			return nil
 		}
-		if hostAddress == "" {
+		if endpoint == "" {
+			// The cloud endpoint is empty, which means
+			// that we should connect to the local LXD.
 			var err error
-			hostAddress, err = getHostAddress()
+			hostAddress, err := p.getLocalHostAddress(ctx)
 			if err != nil {
 				return err
 			}
+			endpoint = hostAddress
 		}
-		*ep = hostAddress
+		*ep = endpoint
 		return nil
 	}
 
@@ -142,6 +131,48 @@ func (p *environProvider) FinalizeCloud(
 		}
 	}
 	return in, nil
+}
+
+func (p *environProvider) getLocalHostAddress(ctx environs.FinalizeCloudContext) (string, error) {
+	raw, err := p.newLocalRawProvider()
+	if err != nil {
+		return "", errors.Trace(err)
+	}
+	bridgeName := raw.DefaultProfileBridgeName()
+	hostAddress, err := p.interfaceAddress(bridgeName)
+	if err != nil {
+		return "", errors.Trace(err)
+	}
+	// LXD itself reports the host:ports that is listens on.
+	// Cross-check the address we have with the values
+	// reported by LXD.
+	if err := lxdclient.EnableHTTPSListener(raw); err != nil {
+		return "", errors.Annotate(err, "enabling HTTPS listener")
+	}
+	serverAddresses, err := raw.ServerAddresses()
+	if err != nil {
+		return "", errors.Trace(err)
+	}
+	var found bool
+	for _, addr := range serverAddresses {
+		if strings.HasPrefix(addr, hostAddress+":") {
+			hostAddress = addr
+			found = true
+			break
+		}
+	}
+	if !found {
+		return "", errors.Errorf(
+			"LXD is not listening on address %s ("+
+				"reported addresses: %s)",
+			hostAddress, serverAddresses,
+		)
+	}
+	ctx.Verbosef(
+		"Resolved LXD host address on bridge %s: %s",
+		bridgeName, hostAddress,
+	)
+	return hostAddress, nil
 }
 
 // localhostCloud is the predefined "localhost" LXD cloud. We leave the
@@ -187,9 +218,15 @@ func (p *environProvider) validateCloudSpec(spec environs.CloudSpec) (local bool
 	if spec.Credential == nil {
 		return false, errors.NotValidf("missing credential")
 	}
-	local, err := p.isLocalEndpoint(spec.Endpoint)
-	if err != nil {
-		return false, errors.Trace(err)
+	if spec.Endpoint == "" {
+		// If we're dealing with an old controller, or we're preparing
+		// a local LXD, we'll have an empty endpoint. Connect to the
+		// default Unix socket.
+		local = true
+	} else {
+		if _, err := endpointURL(spec.Endpoint); err != nil {
+			return false, errors.Trace(err)
+		}
 	}
 	switch authType := spec.Credential.AuthType(); authType {
 	case cloud.CertificateAuthType:

--- a/provider/lxd/provider_test.go
+++ b/provider/lxd/provider_test.go
@@ -106,17 +106,64 @@ func (s *providerSuite) TestFinalizeCloud(c *gc.C) {
 		Name:      "foo",
 		Type:      "lxd",
 		AuthTypes: []cloud.AuthType{cloud.CertificateAuthType},
-		Endpoint:  "1.2.3.4",
+		Endpoint:  "1.2.3.4:1234",
 		Regions: []cloud.Region{{
 			Name:     "bar",
-			Endpoint: "1.2.3.4",
+			Endpoint: "1.2.3.4:1234",
 		}},
 	})
 	ctx.CheckCallNames(c, "Verbosef")
 	ctx.CheckCall(
 		c, 0, "Verbosef", "Resolved LXD host address on bridge %s: %s",
-		[]interface{}{"test-bridge", "1.2.3.4"},
+		[]interface{}{"test-bridge", "1.2.3.4:1234"},
 	)
+
+	// Finalizing a CloudSpec with an empty endpoint involves
+	// configuring the local LXD to listen for HTTPS.
+	s.Stub.CheckCalls(c, []gitjujutesting.StubCall{
+		{"DefaultProfileBridgeName", nil},
+		{"InterfaceAddress", []interface{}{"test-bridge"}},
+		{"ServerStatus", nil},
+		{"SetServerConfig", []interface{}{"core.https_address", "[::]"}},
+		{"ServerAddresses", nil},
+	})
+}
+
+func (s *providerSuite) TestFinalizeCloudNotListening(c *gc.C) {
+	var ctx mockContext
+	s.PatchValue(&s.InterfaceAddr, "8.8.8.8")
+	_, err := s.Provider.FinalizeCloud(&ctx, cloud.Cloud{
+		Name:      "foo",
+		Type:      "lxd",
+		AuthTypes: []cloud.AuthType{cloud.CertificateAuthType},
+		Regions: []cloud.Region{{
+			Name: "bar",
+		}},
+	})
+	c.Assert(err, gc.NotNil)
+	c.Assert(err.Error(), gc.Equals,
+		`LXD is not listening on address 8.8.8.8 `+
+			`(reported addresses: [127.0.0.1:1234 1.2.3.4:1234])`)
+}
+
+func (s *providerSuite) TestFinalizeCloudAlreadyListeningHTTPS(c *gc.C) {
+	s.Client.ServerState.Config["core.https_address"] = "[::]:9999"
+	var ctx mockContext
+	_, err := s.Provider.FinalizeCloud(&ctx, cloud.Cloud{
+		Name:      "foo",
+		Type:      "lxd",
+		AuthTypes: []cloud.AuthType{cloud.CertificateAuthType},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	// The LXD is already listening on HTTPS, so there should be
+	// no SetServerConfig call.
+	s.Stub.CheckCalls(c, []gitjujutesting.StubCall{
+		{"DefaultProfileBridgeName", nil},
+		{"InterfaceAddress", []interface{}{"test-bridge"}},
+		{"ServerStatus", nil},
+		{"ServerAddresses", nil},
+	})
 }
 
 func (s *providerSuite) TestDetectRegions(c *gc.C) {
@@ -173,6 +220,16 @@ func (s *ProviderFunctionalSuite) TestPrepareConfig(c *gc.C) {
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(cfg, gc.NotNil)
+}
+
+func (s *ProviderFunctionalSuite) TestPrepareConfigUnsupportedEndpointScheme(c *gc.C) {
+	cloudSpec := lxdCloudSpec()
+	cloudSpec.Endpoint = "unix://foo"
+	_, err := s.provider.PrepareConfig(environs.PrepareConfigParams{
+		Cloud:  cloudSpec,
+		Config: s.Config,
+	})
+	c.Assert(err, gc.ErrorMatches, `validating cloud spec: invalid URL "unix://foo": only HTTPS is supported`)
 }
 
 func (s *ProviderFunctionalSuite) TestPrepareConfigUnsupportedAuthType(c *gc.C) {

--- a/tools/lxdclient/client_config.go
+++ b/tools/lxdclient/client_config.go
@@ -12,6 +12,7 @@ import (
 )
 
 type rawConfigClient interface {
+	Addresses() ([]string, error)
 	SetServerConfig(key, value string) (*lxd.Response, error)
 	SetContainerConfig(container, key, value string) error
 
@@ -50,4 +51,9 @@ func (c configClient) SetContainerConfig(container, key, value string) error {
 // ServerStatus reports the state of the server.
 func (c configClient) ServerStatus() (*shared.ServerState, error) {
 	return c.raw.ServerStatus()
+}
+
+// ServerAddresses reports the addresses that the server is listening on.
+func (c configClient) ServerAddresses() ([]string, error) {
+	return c.raw.Addresses()
 }

--- a/tools/lxdclient/utils.go
+++ b/tools/lxdclient/utils.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/juju/errors"
 	"github.com/juju/utils/series"
+	"github.com/lxc/lxd/shared"
 
 	"github.com/juju/juju/service"
 	"github.com/juju/juju/service/common"
@@ -71,17 +72,25 @@ const errIPV6NotSupported = `socket: address family not supported by protocol`
 // EnableHTTPSListener configures LXD to listen for HTTPS requests,
 // rather than only via the Unix socket.
 func EnableHTTPSListener(client interface {
+	ServerStatus() (*shared.ServerState, error)
 	SetServerConfig(k, v string) error
 }) error {
+	// First check that the server is not already listening for HTTPS.
+	state, err := client.ServerStatus()
+	if err != nil {
+		return errors.Trace(err)
+	}
+	if _, ok := state.Config["core.https_address"]; ok {
+		return nil
+	}
+
 	// Make sure the LXD service is configured to listen to local https
 	// requests, rather than only via the Unix socket.
 	// TODO: jam 2016-02-25 This tells LXD to listen on all addresses,
 	//      which does expose the LXD to outside requests. It would
 	//      probably be better to only tell LXD to listen for requests on
 	//      the loopback and LXC bridges that we are using.
-	err := client.SetServerConfig("core.https_address", "[::]")
-
-	if err != nil {
+	if err := client.SetServerConfig("core.https_address", "[::]"); err != nil {
 		// if the error hints that the problem might be a protocol unsoported
 		// such as what happens when IPV6 is disabled in kernel, we try IPV4
 		// as a fallback.

--- a/tools/lxdclient/utils_test.go
+++ b/tools/lxdclient/utils_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
+	"github.com/lxc/lxd/shared"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/tools/lxdclient"
@@ -24,30 +25,54 @@ type utilsSuite struct {
 }
 
 func (s *utilsSuite) TestEnableHTTPSListener(c *gc.C) {
-	var client mockConfigSetter
-	err := lxdclient.EnableHTTPSListener(&client)
+	client := newMockConfigSetter()
+	err := lxdclient.EnableHTTPSListener(client)
 	c.Assert(err, jc.ErrorIsNil)
-	client.CheckCall(c, 0, "SetServerConfig", "core.https_address", "[::]")
+	client.CheckCall(c, 0, "ServerStatus")
+	client.CheckCall(c, 1, "SetServerConfig", "core.https_address", "[::]")
+}
+
+func (s *utilsSuite) TestEnableHTTPSListenerAlreadyEnabled(c *gc.C) {
+	client := newMockConfigSetter()
+	client.ServerState.Config["core.https_address"] = "foo"
+	err := lxdclient.EnableHTTPSListener(client)
+	c.Assert(err, jc.ErrorIsNil)
+	client.CheckCallNames(c, "ServerStatus")
 }
 
 func (s *utilsSuite) TestEnableHTTPSListenerError(c *gc.C) {
-	var client mockConfigSetter
+	client := newMockConfigSetter()
 	client.SetErrors(errors.New("uh oh"))
-	err := lxdclient.EnableHTTPSListener(&client)
+	err := lxdclient.EnableHTTPSListener(client)
 	c.Assert(err, gc.ErrorMatches, "uh oh")
 }
 
 func (s *utilsSuite) TestEnableHTTPSListenerIPV4Fallback(c *gc.C) {
-	var client mockConfigSetter
-	client.SetErrors(errors.New("any error string added by lxd: socket: address family not supported by protocol"))
-	err := lxdclient.EnableHTTPSListener(&client)
+	client := newMockConfigSetter()
+	client.SetErrors(nil, errors.New("any error string added by lxd: socket: address family not supported by protocol"))
+	err := lxdclient.EnableHTTPSListener(client)
 	c.Assert(err, jc.ErrorIsNil)
-	client.CheckCall(c, 0, "SetServerConfig", "core.https_address", "[::]")
-	client.CheckCall(c, 1, "SetServerConfig", "core.https_address", "0.0.0.0")
+	client.CheckCall(c, 0, "ServerStatus")
+	client.CheckCall(c, 1, "SetServerConfig", "core.https_address", "[::]")
+	client.CheckCall(c, 2, "SetServerConfig", "core.https_address", "0.0.0.0")
 }
 
 type mockConfigSetter struct {
 	testing.Stub
+	ServerState *shared.ServerState
+}
+
+func newMockConfigSetter() *mockConfigSetter {
+	return &mockConfigSetter{
+		ServerState: &shared.ServerState{
+			Config: map[string]interface{}{},
+		},
+	}
+}
+
+func (m *mockConfigSetter) ServerStatus() (*shared.ServerState, error) {
+	m.MethodCall(m, "ServerStatus")
+	return m.ServerState, m.NextErr()
 }
 
 func (m *mockConfigSetter) SetServerConfig(k, v string) error {


### PR DESCRIPTION
## Description of change

We improve the cloud endpoint handling so that
users can now specify any of the following:

 - (empty) => connect to the unix socket, identify the
   bridge device used for default profile's eth0 NIC,
   and identify the IP address assigned to the bridge
   device on the host. Query LXD for the port it is
   listening on for HTTPS requests.
 - host => connect to the specified host on the default
   port (8443) over HTTPS.
 - host:port => connect to the specified host and port
   over HTTPS.
 - https://host[:port]/path => connect to the specified
   URL over HTTPS.

In the future we should also support unix://, but for
now there are too many assumptions, so we reject any
endpoint starting with unix://.

We will no longer use the unix socket just because the
endpoint is a local address. We only use the unix socket
to create certificate credentials for the local LXD,
and to configure LXD to listen on HTTPS and obtain the
appropriate endpoint for communication from within.

## QA steps

1. juju bootstrap localhost

2. (with lxd entry in clouds.yaml, endpoint set to 10.0.8.1, where 10.0.8.1 is the LXD host address on lxdbr0; LXD is not listening on HTTPS yet, there are no certs in "lxc config trust list")
juju bootstrap lxd

3. (with lxd entry in clouds.yaml, endpoint set to 10.0.8.1:8553, where 10.0.8.1 is the LXD host address on lxdbr0; LXD is configured to listen on 8553)
juju bootstrap lxd

4. (with lxd entry in clouds.yaml, endpoint set to https://10.0.8.1:8553, where 10.0.8.1 is the LXD host address on lxdbr0; LXD is configured to listen on 8553)
juju bootstrap lxd

5. (with lxd entry in clouds.yaml, endpoint set to https://10.0.8.1:8553, where 10.0.8.1 is the LXD host address on lxdbr0; LXD is configured to listen on **8443**)
juju bootstrap lxd
`ERROR Get https://10.0.8.1:8553/1.0: Unable to connect to: 10.0.8.1:8553`

6. with juju 2.0, juju bootstrap localhost; with this branch, juju destroy-controller -y localhost

## Documentation changes

We should update the LXD provider docs to describe the various endpoint formats accepted.

## Bug reference

None.