### PR TITLE
Allow removal of store charms

### DIFF
--- a/state/charm_test.go
+++ b/state/charm_test.go
@@ -151,14 +151,6 @@ func (s *CharmSuite) dummyCharm(c *gc.C, curlOverride string) state.CharmInfo {
 	return info
 }
 
-func (s *CharmSuite) TestDestroyStoreCharm(c *gc.C) {
-	info := s.dummyCharm(c, "cs:precise/dummy-2")
-	sch, err := s.State.AddCharm(info)
-	c.Assert(err, jc.ErrorIsNil)
-	err = sch.Destroy()
-	c.Assert(err, gc.ErrorMatches, "cannot destroy non-local charms")
-}
-
 func (s *CharmSuite) TestRemoveDeletesStorage(c *gc.C) {
 	// We normally don't actually set up charm storage in state
 	// tests, but we need it here.

--- a/state/charmref.go
+++ b/state/charmref.go
@@ -118,15 +118,6 @@ func finalAppCharmRemoveOps(appName string, curl *charm.URL) []txn.Op {
 
 // charmDestroyOps implements the logic of charm.Destroy.
 func charmDestroyOps(st modelBackend, curl *charm.URL) ([]txn.Op, error) {
-
-	if curl.Schema != "local" {
-		// it's not so much that it's bad to delete store
-		// charms; but we don't have a way to reinstate them
-		// once purged, so we don't allow removal in the first
-		// place.
-		return nil, errors.New("cannot destroy non-local charms")
-	}
-
 	charms, closer := st.getCollection(charmsC)
 	defer closer()
 

--- a/state/cleanup.go
+++ b/state/cleanup.go
@@ -288,10 +288,6 @@ func (st *State) cleanupCharm(charmURL string) error {
 	if err != nil {
 		return errors.Annotatef(err, "invalid charm URL %v", charmURL)
 	}
-	if curl.Schema != "local" {
-		// No cleanup necessary or possible.
-		return nil
-	}
 
 	ch, err := st.Charm(curl)
 	if errors.IsNotFound(err) {


### PR DESCRIPTION
## Description of change

Charm-store charms should be removed when they're no longer needed in 
the same way as local charms.  Otherwise the associated storage records in
 the blobstore never get removed, which means that the DB will contain every 
charm ever deployed on the controller, regardless of whether it's currently used.

It's not clear why this was prevented - the comments don't really
explain. Experimentation shows that we can reinstate removed charms if
they're subsequently deployed again. This seems like a better trade-off
- they're cached locally if there's anything using them (so adding units
doesn't require getting the charm again) but they're not kept around
forever, taking up space that isn't ever returned. (See the bug comments
for more discussion.)

## QA steps

* Bootstrap a controller with two models.
* Deploy a charm from the store (eg ubuntu) in both models.
* Remove one model.
* Check that you can still add units to the application using the charm in the other model.
* In the mongo DB you can see that there's only one record for the charm in the managedStoredResources collection: `db.managedStoredResources.find({"path": {"$regex": "charm"}}) `

## Bug reference

Part of fixing https://bugs.launchpad.net/juju/+bug/1579976
