### PR TITLE
Initialise default proxy config from environment

### DIFF
--- a/cmd/jujud/main.go
+++ b/cmd/jujud/main.go
@@ -17,6 +17,7 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	"github.com/juju/utils/exec"
+	proxyutils "github.com/juju/utils/proxy"
 
 	"github.com/juju/juju/agent"
 	jujucmd "github.com/juju/juju/cmd"
@@ -140,6 +141,9 @@ func jujuDMain(args []string, ctx *cmd.Context) (code int, err error) {
 
 	// Set the default transport to use the in-process proxy
 	// configuration.
+	if err := proxy.DefaultConfig.Set(proxyutils.DetectProxies()); err != nil {
+		return 1, errors.Trace(err)
+	}
 	if err := proxy.DefaultConfig.InstallInDefaultTransport(); err != nil {
 		return 1, errors.Trace(err)
 	}


### PR DESCRIPTION
## Description of change

The proxy info is set into the environment by cloud-init for the
bootstrap, so we need to load it here so that we have the correct values
for requests made during bootstrapping. before the proxyupdater is running. 

## QA steps

* bootstrap with proxy settings
* ensure that initial web requests made during bootstrap go via the proxy

## Bug reference

Referenced from this comment: https://bugs.launchpad.net/juju/+bug/1633788/comments/30
Part of fixing: https://bugs.launchpad.net/juju/2.1/+bug/1654591