### PR TITLE
state: fix SingularSuite.TestExpire

### DIFF
--- a/state/singular_test.go
+++ b/state/singular_test.go
@@ -61,20 +61,21 @@ func (s *SingularSuite) TestExpire(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	wait := make(chan error)
 	go func() {
-		s.Clock.Advance(coretesting.ShortWait)
 		wait <- claimer.WaitUntilExpired(s.modelTag.Id())
 	}()
+
+	s.Clock.Advance(coretesting.ShortWait)
 	select {
 	case err := <-wait:
 		c.Fatalf("expired early with %v", err)
-	case <-s.Clock.After(coretesting.ShortWait):
+	case <-time.After(coretesting.ShortWait):
 	}
 
 	s.Clock.Advance(time.Hour)
 	select {
 	case err := <-wait:
 		c.Check(err, jc.ErrorIsNil)
-	case <-s.Clock.After(coretesting.LongWait):
+	case <-time.After(coretesting.LongWait):
 		c.Fatalf("never expired")
 	}
 


### PR DESCRIPTION
## Description of change

The test code was erroneously using the test clock for
timeouts, when it should be using the system clock. The
tests would mostly succeed because the test clock was
advanced asynchronously, and the first select would
choose the second case because it was already waiting
on the (test) clock. If the clock was advanced first,
the select would block forever.

## QA steps

Run the SingularSuite.TestExpire test in a loop of 1000. Consistently failed somewhere within that 1000 before (typically within a few hundred attempts). Cannot the reproduce failure with changes.

## Documentation changes

None.

## Bug reference

Fixes https://bugs.launchpad.net/juju/+bug/1625768