### PR TITLE
environs: drop Environ.BootstrapMessage method

### DIFF
--- a/environs/interface.go
+++ b/environs/interface.go
@@ -253,10 +253,6 @@ type Environ interface {
 	// architecture.
 	Bootstrap(ctx BootstrapContext, params BootstrapParams) (*BootstrapResult, error)
 
-	// BootstrapMessage optionally provides a message to be displayed to
-	// the user at bootstrap time.
-	BootstrapMessage() string
-
 	// Create creates the environment for a new hosted model.
 	//
 	// This will be called before any workers begin operating on the

--- a/provider/azure/environ.go
+++ b/provider/azure/environ.go
@@ -234,11 +234,6 @@ func (env *azureEnviron) Bootstrap(
 	return result, nil
 }
 
-// BootstrapMessage is part of the Environ interface.
-func (env *azureEnviron) BootstrapMessage() string {
-	return ""
-}
-
 // initResourceGroup creates a resource group for this environment.
 func (env *azureEnviron) initResourceGroup(controllerUUID string, controller bool) error {
 	resourceGroupsClient := resources.GroupsClient{env.resources}

--- a/provider/cloudsigma/environ.go
+++ b/provider/cloudsigma/environ.go
@@ -94,11 +94,6 @@ func (env *environ) Bootstrap(ctx environs.BootstrapContext, params environs.Boo
 	return common.Bootstrap(ctx, env, params)
 }
 
-// BootstrapMessage is part of the Environ interface.
-func (env *environ) BootstrapMessage() string {
-	return ""
-}
-
 // ControllerInstances is part of the Environ interface.
 func (e *environ) ControllerInstances(controllerUUID string) ([]instance.Id, error) {
 	return e.client.getControllerIds()

--- a/provider/common/bootstrap.go
+++ b/provider/common/bootstrap.go
@@ -133,11 +133,6 @@ func BootstrapInstance(ctx environs.BootstrapContext, env environs.Environ, args
 	}
 	maybeSetBridge(instanceConfig)
 
-	bootstrapMsg := env.BootstrapMessage()
-	if bootstrapMsg != "" {
-		ctx.Infof(bootstrapMsg)
-	}
-
 	cloudRegion := args.CloudName
 	if args.CloudRegion != "" {
 		cloudRegion += "/" + args.CloudRegion

--- a/provider/common/bootstrap_test.go
+++ b/provider/common/bootstrap_test.go
@@ -4,10 +4,8 @@
 package common_test
 
 import (
-	"bytes"
 	"fmt"
 	"os"
-	"strings"
 	"time"
 
 	"github.com/juju/errors"
@@ -235,10 +233,6 @@ func (s *BootstrapSuite) TestSuccess(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.Arch, gc.Equals, "ppc64el") // based on hardware characteristics
 	c.Assert(result.Series, gc.Equals, config.PreferredSeries(mocksConfig))
-	output := inner.Stderr.(*bytes.Buffer)
-	lines := strings.Split(output.String(), "\n")
-	c.Assert(len(lines), jc.GreaterThan, 1)
-	c.Assert(lines[0], gc.Equals, "Some message")
 }
 
 type neverRefreshes struct {

--- a/provider/common/mock_test.go
+++ b/provider/common/mock_test.go
@@ -46,10 +46,6 @@ func (env *mockEnviron) AllInstances() ([]instance.Instance, error) {
 	return env.allInstances()
 }
 
-func (env *mockEnviron) BootstrapMessage() string {
-	return "Some message"
-}
-
 func (env *mockEnviron) StartInstance(args environs.StartInstanceParams) (*environs.StartInstanceResult, error) {
 	inst, hw, networkInfo, err := env.startInstance(
 		args.Placement,

--- a/provider/dummy/environs.go
+++ b/provider/dummy/environs.go
@@ -851,11 +851,6 @@ func (e *environ) Bootstrap(ctx environs.BootstrapContext, args environs.Bootstr
 	return bsResult, nil
 }
 
-// BootstrapMessage is part of the Environ interface.
-func (e *environ) BootstrapMessage() string {
-	return ""
-}
-
 func (e *environ) ControllerInstances(controllerUUID string) ([]instance.Id, error) {
 	estate, err := e.state()
 	if err != nil {

--- a/provider/ec2/environ.go
+++ b/provider/ec2/environ.go
@@ -134,11 +134,6 @@ func (e *environ) Bootstrap(ctx environs.BootstrapContext, args environs.Bootstr
 	return common.Bootstrap(ctx, e, args)
 }
 
-// BootstrapMessage is part of the Environ interface.
-func (e *environ) BootstrapMessage() string {
-	return ""
-}
-
 // SupportsSpaces is specified on environs.Networking.
 func (e *environ) SupportsSpaces() (bool, error) {
 	return true, nil

--- a/provider/gce/environ.go
+++ b/provider/gce/environ.go
@@ -205,11 +205,6 @@ func (env *environ) Bootstrap(ctx environs.BootstrapContext, params environs.Boo
 	return bootstrap(ctx, env, params)
 }
 
-// BootstrapMessage is part of the Environ interface.
-func (env *environ) BootstrapMessage() string {
-	return ""
-}
-
 // Destroy shuts down all known machines and destroys the rest of the
 // known environment.
 func (env *environ) Destroy() error {

--- a/provider/joyent/environ.go
+++ b/provider/joyent/environ.go
@@ -114,11 +114,6 @@ func (env *joyentEnviron) Bootstrap(ctx environs.BootstrapContext, args environs
 	return common.Bootstrap(ctx, env, args)
 }
 
-// BootstrapMessage is part of the Environ interface.
-func (env *joyentEnviron) BootstrapMessage() string {
-	return ""
-}
-
 func (env *joyentEnviron) ControllerInstances(controllerUUID string) ([]instance.Id, error) {
 	instanceIds := []instance.Id{}
 

--- a/provider/lxd/environ.go
+++ b/provider/lxd/environ.go
@@ -149,12 +149,8 @@ func (env *environ) Create(environs.CreateParams) error {
 
 // Bootstrap implements environs.Environ.
 func (env *environ) Bootstrap(ctx environs.BootstrapContext, params environs.BootstrapParams) (*environs.BootstrapResult, error) {
+	ctx.Infof("%s", bootstrapMessage)
 	return env.base.BootstrapEnv(ctx, params)
-}
-
-// BootstrapMessage is part of the Environ interface.
-func (env *environ) BootstrapMessage() string {
-	return bootstrapMessage
 }
 
 // Destroy shuts down all known machines and destroys the rest of the

--- a/provider/lxd/environ_test.go
+++ b/provider/lxd/environ_test.go
@@ -11,6 +11,7 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/cloudconfig/instancecfg"
+	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/environs"
 	envtesting "github.com/juju/juju/environs/testing"
 	"github.com/juju/juju/provider/common"
@@ -65,17 +66,20 @@ func (s *environSuite) TestBootstrapOkay(c *gc.C) {
 		},
 	}
 
-	ctx := envtesting.BootstrapContext(c)
+	ctx := coretesting.Context(c)
 	params := environs.BootstrapParams{
 		ControllerConfig: coretesting.FakeControllerConfig(),
 	}
-	result, err := s.Env.Bootstrap(ctx, params)
+	result, err := s.Env.Bootstrap(modelcmd.BootstrapContext(ctx), params)
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Check(result.Arch, gc.Equals, "amd64")
 	c.Check(result.Series, gc.Equals, "trusty")
 	// We don't check bsFinalizer because functions cannot be compared.
 	c.Check(result.Finalize, gc.NotNil)
+
+	out := coretesting.Stderr(ctx)
+	c.Assert(out, gc.Equals, "To configure your system to better support LXD containers, please see: https://github.com/lxc/lxd/blob/master/doc/production-setup.md\n")
 }
 
 func (s *environSuite) TestBootstrapAPI(c *gc.C) {

--- a/provider/maas/environ.go
+++ b/provider/maas/environ.go
@@ -194,11 +194,6 @@ func (env *maasEnviron) Bootstrap(ctx environs.BootstrapContext, args environs.B
 	return bsResult, nil
 }
 
-// BootstrapMessage is part of the Environ interface.
-func (env *maasEnviron) BootstrapMessage() string {
-	return ""
-}
-
 // ControllerInstances is specified in the Environ interface.
 func (env *maasEnviron) ControllerInstances(controllerUUID string) ([]instance.Id, error) {
 	if !env.usingMAAS2() {

--- a/provider/manual/environ.go
+++ b/provider/manual/environ.go
@@ -130,11 +130,6 @@ func (e *manualEnviron) Bootstrap(ctx environs.BootstrapContext, args environs.B
 	return result, nil
 }
 
-// BootstrapMessage is part of the Environ interface.
-func (e *manualEnviron) BootstrapMessage() string {
-	return ""
-}
-
 // ControllerInstances is specified in the Environ interface.
 func (e *manualEnviron) ControllerInstances(controllerUUID string) ([]instance.Id, error) {
 	if !isRunningController() {

--- a/provider/openstack/provider.go
+++ b/provider/openstack/provider.go
@@ -652,11 +652,6 @@ func (e *Environ) supportsNeutron() bool {
 	return ok
 }
 
-// BootstrapMessage is part of the Environ interface.
-func (e *Environ) BootstrapMessage() string {
-	return ""
-}
-
 func (e *Environ) ControllerInstances(controllerUUID string) ([]instance.Id, error) {
 	// Find all instances tagged with tags.JujuIsController.
 	instances, err := e.allControllerManagedInstances(controllerUUID, e.ecfg().useFloatingIP())

--- a/provider/rackspace/environ.go
+++ b/provider/rackspace/environ.go
@@ -30,11 +30,6 @@ func (e environ) Bootstrap(ctx environs.BootstrapContext, params environs.Bootst
 	return bootstrap(ctx, e, params)
 }
 
-// BootstrapMessage is part of the Environ interface.
-func (e environ) BootstrapMessage() string {
-	return ""
-}
-
 var waitSSH = common.WaitSSH
 
 // StartInstance implements environs.Environ.

--- a/provider/rackspace/environ_test.go
+++ b/provider/rackspace/environ_test.go
@@ -125,10 +125,6 @@ func (e *fakeEnviron) Bootstrap(ctx environs.BootstrapContext, params environs.B
 	return nil, nil
 }
 
-func (e *fakeEnviron) BootstrapMessage() string {
-	return ""
-}
-
 func (e *fakeEnviron) StartInstance(args environs.StartInstanceParams) (*environs.StartInstanceResult, error) {
 	e.Push("StartInstance", args)
 	return &environs.StartInstanceResult{

--- a/provider/vsphere/environ.go
+++ b/provider/vsphere/environ.go
@@ -114,11 +114,6 @@ func (env *environ) Bootstrap(ctx environs.BootstrapContext, params environs.Boo
 	return Bootstrap(ctx, env, params)
 }
 
-// BootstrapMessage is part of the Environ interface.
-func (env *environ) BootstrapMessage() string {
-	return ""
-}
-
 //this variable is exported, because it has to be rewritten in external unit tests
 var DestroyEnv = common.Destroy
 


### PR DESCRIPTION
## Description of change

The Environ.BootstrapMessage method was added
as a means of logging a message at bootstrap
time in the LXD provider. The added method is
redundant, as we already pass context to the
Bootstrap method, which the provider can use
to show messages to the user.

We drop the BootstrapMessage method, and update
the LXD provider to use the bootstrap context
to display its message.

## QA steps

1. juju bootstrap localhost
2. confirm message is displayed

## Documentation changes

None

## Bug reference

None