### PR TITLE
2.1 into develop

### DIFF
--- a/state/singular_test.go
+++ b/state/singular_test.go
@@ -61,20 +61,21 @@ func (s *SingularSuite) TestExpire(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	wait := make(chan error)
 	go func() {
-		s.Clock.Advance(coretesting.ShortWait)
 		wait <- claimer.WaitUntilExpired(s.modelTag.Id())
 	}()
+
+	s.Clock.Advance(coretesting.ShortWait)
 	select {
 	case err := <-wait:
 		c.Fatalf("expired early with %v", err)
-	case <-s.Clock.After(coretesting.ShortWait):
+	case <-time.After(coretesting.ShortWait):
 	}
 
 	s.Clock.Advance(time.Hour)
 	select {
 	case err := <-wait:
 		c.Check(err, jc.ErrorIsNil)
-	case <-s.Clock.After(coretesting.LongWait):
+	case <-time.After(coretesting.LongWait):
 		c.Fatalf("never expired")
 	}
 


### PR DESCRIPTION
Bring in current 2.1 into develop. It appears the previous merges dropped the history, which means we weren't sure what stuff was actually present. This only really brings in a couple small patches. Avoiding the version change and merging a test suite fix.
