### PR TITLE
Moved install hook message to agent.

### DIFF
--- a/worker/uniter/operation/runhook.go
+++ b/worker/uniter/operation/runhook.go
@@ -133,10 +133,7 @@ func (rh *runHook) beforeHook() error {
 	var err error
 	switch rh.info.Kind {
 	case hooks.Install:
-		err = rh.runner.Context().SetUnitStatus(jujuc.StatusInfo{
-			Status: string(status.Maintenance),
-			Info:   status.MessageInstallingCharm,
-		})
+		err = rh.callbacks.SetExecutingStatus(status.MessageInstallingCharm)
 	case hooks.Stop:
 		err = rh.runner.Context().SetUnitStatus(jujuc.StatusInfo{
 			Status: string(status.Maintenance),

--- a/worker/uniter/operation/util_test.go
+++ b/worker/uniter/operation/util_test.go
@@ -152,6 +152,7 @@ type PrepareHookCallbacks struct {
 	operation.Callbacks
 	*MockPrepareHook
 	executingMessage string
+	executingQueue   []string
 }
 
 func (cb *PrepareHookCallbacks) PrepareHook(hookInfo hook.Info) (string, error) {
@@ -159,6 +160,7 @@ func (cb *PrepareHookCallbacks) PrepareHook(hookInfo hook.Info) (string, error) 
 }
 
 func (cb *PrepareHookCallbacks) SetExecutingStatus(message string) error {
+	cb.executingQueue = append(cb.executingQueue, message)
 	cb.executingMessage = message
 	return nil
 }

--- a/worker/uniter/uniter_test.go
+++ b/worker/uniter/uniter_test.go
@@ -319,11 +319,6 @@ func (s *UniterSuite) TestUniterStartHook(c *gc.C) {
 			waitUnitAgent{
 				status: status.Idle,
 			},
-			waitUnitAgent{
-				statusGetter: unitStatusGetter,
-				status:       status.Maintenance,
-				info:         "installing charm software",
-			},
 			waitHooks{"config-changed"},
 			verifyRunning{},
 		), ut(
@@ -856,12 +851,6 @@ func (s *UniterSuite) TestUniterErrorStateUnforcedUpgrade(c *gc.C) {
 			waitUnitAgent{
 				status: status.Idle,
 				charm:  1,
-			},
-			waitUnitAgent{
-				statusGetter: unitStatusGetter,
-				status:       status.Maintenance,
-				info:         "installing charm software",
-				charm:        1,
 			},
 			waitHooks{"upgrade-charm", "config-changed"},
 			verifyCharm{revision: 1},
@@ -1498,11 +1487,6 @@ func (s *UniterSuite) TestActionEvents(c *gc.C) {
 			verifyWaiting{},
 			resolveError{state.ResolvedNoHooks},
 			waitUnitAgent{status: status.Idle},
-			waitUnitAgent{
-				statusGetter: unitStatusGetter,
-				status:       status.Maintenance,
-				info:         "installing charm software",
-			},
 		),
 	})
 }


### PR DESCRIPTION
## Description of change

With this change, juju will no longer override workload statuses from charms while still informing about charm activities.

## QA steps

Deploy a charm and see that the "installing charm software" status is now part of juju-status in yaml format.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1597481