### PR TITLE
Don't leave charm files sitting in the cache

### DIFF
--- a/apiserver/application/application_test.go
+++ b/apiserver/application/application_test.go
@@ -6,6 +6,7 @@ package application_test
 import (
 	"fmt"
 	"io"
+	"io/ioutil"
 	"regexp"
 	"sync"
 	"time"
@@ -339,6 +340,11 @@ func (s *applicationSuite) TestApplicationDeploy(c *gc.C) {
 	units, err := svc.AllUnits()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(units, gc.HasLen, 1)
+
+	// Check that the charm cache dir is cleared out.
+	files, err := ioutil.ReadDir(charmrepo.CacheDir)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(files, gc.HasLen, 0)
 }
 
 func (s *applicationSuite) TestApplicationDeployWithInvalidPlacement(c *gc.C) {

--- a/apiserver/application/application_test.go
+++ b/apiserver/application/application_test.go
@@ -42,7 +42,7 @@ import (
 	jujuversion "github.com/juju/juju/version"
 )
 
-type serviceSuite struct {
+type applicationSuite struct {
 	jujutesting.JujuConnSuite
 	apiservertesting.CharmStoreSuite
 	commontesting.BlockHelper
@@ -53,19 +53,19 @@ type serviceSuite struct {
 	offersApiFactory *mockApplicationOffersFactory
 }
 
-var _ = gc.Suite(&serviceSuite{})
+var _ = gc.Suite(&applicationSuite{})
 
-func (s *serviceSuite) SetUpSuite(c *gc.C) {
+func (s *applicationSuite) SetUpSuite(c *gc.C) {
 	s.CharmStoreSuite.SetUpSuite(c)
 	s.JujuConnSuite.SetUpSuite(c)
 }
 
-func (s *serviceSuite) TearDownSuite(c *gc.C) {
+func (s *applicationSuite) TearDownSuite(c *gc.C) {
 	s.CharmStoreSuite.TearDownSuite(c)
 	s.JujuConnSuite.TearDownSuite(c)
 }
 
-func (s *serviceSuite) SetUpTest(c *gc.C) {
+func (s *applicationSuite) SetUpTest(c *gc.C) {
 	s.JujuConnSuite.SetUpTest(c)
 	s.CharmStoreSuite.Session = s.JujuConnSuite.Session
 	s.CharmStoreSuite.SetUpTest(c)
@@ -90,12 +90,12 @@ func (s *serviceSuite) SetUpTest(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 }
 
-func (s *serviceSuite) TearDownTest(c *gc.C) {
+func (s *applicationSuite) TearDownTest(c *gc.C) {
 	s.CharmStoreSuite.TearDownTest(c)
 	s.JujuConnSuite.TearDownTest(c)
 }
 
-func (s *serviceSuite) TestSetMetricCredentials(c *gc.C) {
+func (s *applicationSuite) TestSetMetricCredentials(c *gc.C) {
 	charm := s.Factory.MakeCharm(c, &factory.CharmParams{Name: "wordpress"})
 	wordpress := s.Factory.MakeApplication(c, &factory.ApplicationParams{
 		Charm: charm,
@@ -166,7 +166,7 @@ func (s *serviceSuite) TestSetMetricCredentials(c *gc.C) {
 	}
 }
 
-func (s *serviceSuite) TestCompatibleSettingsParsing(c *gc.C) {
+func (s *applicationSuite) TestCompatibleSettingsParsing(c *gc.C) {
 	// Test the exported settings parsing in a compatible way.
 	s.AddTestingService(c, "dummy", s.AddTestingCharm(c, "dummy"))
 	svc, err := s.State.Application("dummy")
@@ -195,7 +195,7 @@ func (s *serviceSuite) TestCompatibleSettingsParsing(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, `unknown option "yummy"`)
 }
 
-func (s *serviceSuite) TestServiceDeployWithStorage(c *gc.C) {
+func (s *applicationSuite) TestApplicationDeployWithStorage(c *gc.C) {
 	curl, ch := s.UploadCharm(c, "utopic/storage-block-10", "storage-block")
 	err := application.AddCharmWithAuthorization(s.State, params.AddCharmWithAuthorization{
 		URL: curl.String(),
@@ -241,7 +241,7 @@ func (s *serviceSuite) TestServiceDeployWithStorage(c *gc.C) {
 	})
 }
 
-func (s *serviceSuite) TestMinJujuVersionTooHigh(c *gc.C) {
+func (s *applicationSuite) TestMinJujuVersionTooHigh(c *gc.C) {
 	curl, _ := s.UploadCharm(c, "quantal/minjujuversion-0", "minjujuversion")
 	err := application.AddCharmWithAuthorization(s.State, params.AddCharmWithAuthorization{
 		URL: curl.String(),
@@ -250,7 +250,7 @@ func (s *serviceSuite) TestMinJujuVersionTooHigh(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, regexp.QuoteMeta(match))
 }
 
-func (s *serviceSuite) TestServiceDeployWithInvalidStoragePool(c *gc.C) {
+func (s *applicationSuite) TestApplicationDeployWithInvalidStoragePool(c *gc.C) {
 	curl, _ := s.UploadCharm(c, "utopic/storage-block-0", "storage-block")
 	err := application.AddCharmWithAuthorization(s.State, params.AddCharmWithAuthorization{
 		URL: curl.String(),
@@ -280,7 +280,7 @@ func (s *serviceSuite) TestServiceDeployWithInvalidStoragePool(c *gc.C) {
 	c.Assert(results.Results[0].Error, gc.ErrorMatches, `.* pool "foo" not found`)
 }
 
-func (s *serviceSuite) TestServiceDeployDefaultFilesystemStorage(c *gc.C) {
+func (s *applicationSuite) TestApplicationDeployDefaultFilesystemStorage(c *gc.C) {
 	curl, ch := s.UploadCharm(c, "trusty/storage-filesystem-1", "storage-filesystem")
 	err := application.AddCharmWithAuthorization(s.State, params.AddCharmWithAuthorization{
 		URL: curl.String(),
@@ -312,7 +312,7 @@ func (s *serviceSuite) TestServiceDeployDefaultFilesystemStorage(c *gc.C) {
 	})
 }
 
-func (s *serviceSuite) TestServiceDeploy(c *gc.C) {
+func (s *applicationSuite) TestApplicationDeploy(c *gc.C) {
 	curl, ch := s.UploadCharm(c, "precise/dummy-42", "dummy")
 	err := application.AddCharmWithAuthorization(s.State, params.AddCharmWithAuthorization{
 		URL: curl.String(),
@@ -341,7 +341,7 @@ func (s *serviceSuite) TestServiceDeploy(c *gc.C) {
 	c.Assert(units, gc.HasLen, 1)
 }
 
-func (s *serviceSuite) TestServiceDeployWithInvalidPlacement(c *gc.C) {
+func (s *applicationSuite) TestApplicationDeployWithInvalidPlacement(c *gc.C) {
 	curl, _ := s.UploadCharm(c, "precise/dummy-42", "dummy")
 	err := application.AddCharmWithAuthorization(s.State, params.AddCharmWithAuthorization{
 		URL: curl.String(),
@@ -366,7 +366,7 @@ func (s *serviceSuite) TestServiceDeployWithInvalidPlacement(c *gc.C) {
 	c.Assert(results.Results[0].Error.Error(), gc.Matches, ".* invalid placement is invalid")
 }
 
-func (s *serviceSuite) testClientServicesDeployWithBindings(c *gc.C, endpointBindings, expected map[string]string) {
+func (s *applicationSuite) testClientApplicationsDeployWithBindings(c *gc.C, endpointBindings, expected map[string]string) {
 	curl, _ := s.UploadCharm(c, "utopic/riak-42", "riak")
 	err := application.AddCharmWithAuthorization(s.State, params.AddCharmWithAuthorization{
 		URL: curl.String(),
@@ -397,7 +397,7 @@ func (s *serviceSuite) testClientServicesDeployWithBindings(c *gc.C, endpointBin
 	c.Assert(retrievedBindings, jc.DeepEquals, expected)
 }
 
-func (s *serviceSuite) TestClientServicesDeployWithBindings(c *gc.C) {
+func (s *applicationSuite) TestClientApplicationsDeployWithBindings(c *gc.C) {
 	s.State.AddSpace("a-space", "", nil, true)
 	expected := map[string]string{
 		"endpoint": "a-space",
@@ -405,16 +405,16 @@ func (s *serviceSuite) TestClientServicesDeployWithBindings(c *gc.C) {
 		"admin":    "",
 	}
 	endpointBindings := map[string]string{"endpoint": "a-space"}
-	s.testClientServicesDeployWithBindings(c, endpointBindings, expected)
+	s.testClientApplicationsDeployWithBindings(c, endpointBindings, expected)
 }
 
-func (s *serviceSuite) TestClientServicesDeployWithDefaultBindings(c *gc.C) {
+func (s *applicationSuite) TestClientApplicationsDeployWithDefaultBindings(c *gc.C) {
 	expected := map[string]string{
 		"endpoint": "",
 		"ring":     "",
 		"admin":    "",
 	}
-	s.testClientServicesDeployWithBindings(c, nil, expected)
+	s.testClientApplicationsDeployWithBindings(c, nil, expected)
 }
 
 // TODO(wallyworld) - the following charm tests have been moved from the apiserver/client
@@ -422,7 +422,7 @@ func (s *serviceSuite) TestClientServicesDeployWithDefaultBindings(c *gc.C) {
 // written to use the api client instead of the apiserver logic. They need to be rewritten and
 // feature tests added.
 
-func (s *serviceSuite) TestAddCharm(c *gc.C) {
+func (s *applicationSuite) TestAddCharm(c *gc.C) {
 	var blobs blobs
 	s.PatchValue(application.NewStateStorage, func(uuid string, session *mgo.Session) statestorage.Storage {
 		storage := statestorage.NewStorage(uuid, session)
@@ -470,7 +470,7 @@ func (s *serviceSuite) TestAddCharm(c *gc.C) {
 	s.assertUploaded(c, storage, sch.StoragePath(), sch.BundleSha256())
 }
 
-func (s *serviceSuite) TestAddCharmWithAuthorization(c *gc.C) {
+func (s *applicationSuite) TestAddCharmWithAuthorization(c *gc.C) {
 	// Upload a new charm to the charm store.
 	curl, _ := s.UploadCharm(c, "cs:~restricted/precise/wordpress-3", "wordpress")
 
@@ -512,7 +512,7 @@ func (s *serviceSuite) TestAddCharmWithAuthorization(c *gc.C) {
 	c.Assert(err, gc.IsNil)
 }
 
-func (s *serviceSuite) TestAddCharmConcurrently(c *gc.C) {
+func (s *applicationSuite) TestAddCharmConcurrently(c *gc.C) {
 	c.Skip("see lp:1596960 -- bad test for bad code")
 
 	var putBarrier sync.WaitGroup
@@ -567,7 +567,7 @@ func (s *serviceSuite) TestAddCharmConcurrently(c *gc.C) {
 	s.assertUploaded(c, storage, sch.StoragePath(), sch.BundleSha256())
 }
 
-func (s *serviceSuite) assertUploaded(c *gc.C, storage statestorage.Storage, storagePath, expectedSHA256 string) {
+func (s *applicationSuite) assertUploaded(c *gc.C, storage statestorage.Storage, storagePath, expectedSHA256 string) {
 	reader, _, err := storage.Get(storagePath)
 	c.Assert(err, jc.ErrorIsNil)
 	defer reader.Close()
@@ -576,7 +576,7 @@ func (s *serviceSuite) assertUploaded(c *gc.C, storage statestorage.Storage, sto
 	c.Assert(downloadedSHA256, gc.Equals, expectedSHA256)
 }
 
-func (s *serviceSuite) TestAddCharmOverwritesPlaceholders(c *gc.C) {
+func (s *applicationSuite) TestAddCharmOverwritesPlaceholders(c *gc.C) {
 	client := s.APIState.Client()
 	curl, _ := s.UploadCharm(c, "trusty/wordpress-42", "wordpress")
 
@@ -599,7 +599,7 @@ func (s *serviceSuite) TestAddCharmOverwritesPlaceholders(c *gc.C) {
 	c.Assert(sch.IsUploaded(), jc.IsTrue)
 }
 
-func (s *serviceSuite) TestServiceGetCharmURL(c *gc.C) {
+func (s *applicationSuite) TestApplicationGetCharmURL(c *gc.C) {
 	s.AddTestingService(c, "wordpress", s.AddTestingCharm(c, "wordpress"))
 	result, err := s.applicationAPI.GetCharmURL(params.ApplicationGet{"wordpress"})
 	c.Assert(err, jc.ErrorIsNil)
@@ -607,7 +607,7 @@ func (s *serviceSuite) TestServiceGetCharmURL(c *gc.C) {
 	c.Assert(result.Result, gc.Equals, "local:quantal/wordpress-3")
 }
 
-func (s *serviceSuite) TestServiceSetCharm(c *gc.C) {
+func (s *applicationSuite) TestApplicationSetCharm(c *gc.C) {
 	curl, _ := s.UploadCharm(c, "precise/dummy-0", "dummy")
 	err := application.AddCharmWithAuthorization(s.State, params.AddCharmWithAuthorization{
 		URL: curl.String(),
@@ -642,7 +642,7 @@ func (s *serviceSuite) TestServiceSetCharm(c *gc.C) {
 	c.Assert(force, jc.IsFalse)
 }
 
-func (s *serviceSuite) setupServiceSetCharm(c *gc.C) {
+func (s *applicationSuite) setupApplicationSetCharm(c *gc.C) {
 	curl, _ := s.UploadCharm(c, "precise/dummy-0", "dummy")
 	err := application.AddCharmWithAuthorization(s.State, params.AddCharmWithAuthorization{
 		URL: curl.String(),
@@ -664,7 +664,7 @@ func (s *serviceSuite) setupServiceSetCharm(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 }
 
-func (s *serviceSuite) assertServiceSetCharm(c *gc.C, forceUnits bool) {
+func (s *applicationSuite) assertApplicationSetCharm(c *gc.C, forceUnits bool) {
 	err := s.applicationAPI.SetCharm(params.ApplicationSetCharm{
 		ApplicationName: "application",
 		CharmURL:        "cs:~who/precise/wordpress-3",
@@ -679,7 +679,7 @@ func (s *serviceSuite) assertServiceSetCharm(c *gc.C, forceUnits bool) {
 	c.Assert(charm.URL().String(), gc.Equals, "cs:~who/precise/wordpress-3")
 }
 
-func (s *serviceSuite) assertServiceSetCharmBlocked(c *gc.C, msg string) {
+func (s *applicationSuite) assertApplicationSetCharmBlocked(c *gc.C, msg string) {
 	err := s.applicationAPI.SetCharm(params.ApplicationSetCharm{
 		ApplicationName: "application",
 		CharmURL:        "cs:~who/precise/wordpress-3",
@@ -687,25 +687,25 @@ func (s *serviceSuite) assertServiceSetCharmBlocked(c *gc.C, msg string) {
 	s.AssertBlocked(c, err, msg)
 }
 
-func (s *serviceSuite) TestBlockDestroyServiceSetCharm(c *gc.C) {
-	s.setupServiceSetCharm(c)
-	s.BlockDestroyModel(c, "TestBlockDestroyServiceSetCharm")
-	s.assertServiceSetCharm(c, false)
+func (s *applicationSuite) TestBlockDestroyApplicationSetCharm(c *gc.C) {
+	s.setupApplicationSetCharm(c)
+	s.BlockDestroyModel(c, "TestBlockDestroyApplicationSetCharm")
+	s.assertApplicationSetCharm(c, false)
 }
 
-func (s *serviceSuite) TestBlockRemoveServiceSetCharm(c *gc.C) {
-	s.setupServiceSetCharm(c)
-	s.BlockRemoveObject(c, "TestBlockRemoveServiceSetCharm")
-	s.assertServiceSetCharm(c, false)
+func (s *applicationSuite) TestBlockRemoveApplicationSetCharm(c *gc.C) {
+	s.setupApplicationSetCharm(c)
+	s.BlockRemoveObject(c, "TestBlockRemoveApplicationSetCharm")
+	s.assertApplicationSetCharm(c, false)
 }
 
-func (s *serviceSuite) TestBlockChangesServiceSetCharm(c *gc.C) {
-	s.setupServiceSetCharm(c)
-	s.BlockAllChanges(c, "TestBlockChangesServiceSetCharm")
-	s.assertServiceSetCharmBlocked(c, "TestBlockChangesServiceSetCharm")
+func (s *applicationSuite) TestBlockChangesApplicationSetCharm(c *gc.C) {
+	s.setupApplicationSetCharm(c)
+	s.BlockAllChanges(c, "TestBlockChangesApplicationSetCharm")
+	s.assertApplicationSetCharmBlocked(c, "TestBlockChangesApplicationSetCharm")
 }
 
-func (s *serviceSuite) TestServiceSetCharmForceUnits(c *gc.C) {
+func (s *applicationSuite) TestApplicationSetCharmForceUnits(c *gc.C) {
 	curl, _ := s.UploadCharm(c, "precise/dummy-0", "dummy")
 	err := application.AddCharmWithAuthorization(s.State, params.AddCharmWithAuthorization{
 		URL: curl.String(),
@@ -741,28 +741,28 @@ func (s *serviceSuite) TestServiceSetCharmForceUnits(c *gc.C) {
 	c.Assert(force, jc.IsTrue)
 }
 
-func (s *serviceSuite) TestBlockServiceSetCharmForce(c *gc.C) {
-	s.setupServiceSetCharm(c)
+func (s *applicationSuite) TestBlockApplicationSetCharmForce(c *gc.C) {
+	s.setupApplicationSetCharm(c)
 
 	// block all changes
-	s.BlockAllChanges(c, "TestBlockServiceSetCharmForce")
-	s.BlockRemoveObject(c, "TestBlockServiceSetCharmForce")
-	s.BlockDestroyModel(c, "TestBlockServiceSetCharmForce")
+	s.BlockAllChanges(c, "TestBlockApplicationSetCharmForce")
+	s.BlockRemoveObject(c, "TestBlockApplicationSetCharmForce")
+	s.BlockDestroyModel(c, "TestBlockApplicationSetCharmForce")
 
-	s.assertServiceSetCharm(c, true)
+	s.assertApplicationSetCharm(c, true)
 }
 
-func (s *serviceSuite) TestServiceSetCharmInvalidService(c *gc.C) {
+func (s *applicationSuite) TestApplicationSetCharmInvalidApplication(c *gc.C) {
 	err := s.applicationAPI.SetCharm(params.ApplicationSetCharm{
-		ApplicationName: "badservice",
+		ApplicationName: "badapplication",
 		CharmURL:        "cs:precise/wordpress-3",
 		ForceSeries:     true,
 		ForceUnits:      true,
 	})
-	c.Assert(err, gc.ErrorMatches, `application "badservice" not found`)
+	c.Assert(err, gc.ErrorMatches, `application "badapplication" not found`)
 }
 
-func (s *serviceSuite) TestServiceAddCharmErrors(c *gc.C) {
+func (s *applicationSuite) TestApplicationAddCharmErrors(c *gc.C) {
 	for url, expect := range map[string]string{
 		"wordpress":                   "charm URL must include revision",
 		"cs:wordpress":                "charm URL must include revision",
@@ -777,7 +777,7 @@ func (s *serviceSuite) TestServiceAddCharmErrors(c *gc.C) {
 	}
 }
 
-func (s *serviceSuite) TestServiceSetCharmLegacy(c *gc.C) {
+func (s *applicationSuite) TestApplicationSetCharmLegacy(c *gc.C) {
 	curl, _ := s.UploadCharm(c, "precise/dummy-0", "dummy")
 	err := application.AddCharmWithAuthorization(s.State, params.AddCharmWithAuthorization{
 		URL: curl.String(),
@@ -807,7 +807,7 @@ func (s *serviceSuite) TestServiceSetCharmLegacy(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, `cannot upgrade application "application" to charm "cs:~who/trusty/dummy-1": cannot change an application's series`)
 }
 
-func (s *serviceSuite) TestServiceSetCharmUnsupportedSeries(c *gc.C) {
+func (s *applicationSuite) TestApplicationSetCharmUnsupportedSeries(c *gc.C) {
 	curl, _ := s.UploadCharmMultiSeries(c, "~who/multi-series", "multi-series")
 	err := application.AddCharmWithAuthorization(s.State, params.AddCharmWithAuthorization{
 		URL: curl.String(),
@@ -835,7 +835,7 @@ func (s *serviceSuite) TestServiceSetCharmUnsupportedSeries(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, `cannot upgrade application "application" to charm "cs:~who/multi-series-1": only these series are supported: trusty, wily`)
 }
 
-func (s *serviceSuite) assertServiceSetCharmSeries(c *gc.C, upgradeCharm, series string) {
+func (s *applicationSuite) assertApplicationSetCharmSeries(c *gc.C, upgradeCharm, series string) {
 	curl, _ := s.UploadCharmMultiSeries(c, "~who/multi-series", "multi-series")
 	err := application.AddCharmWithAuthorization(s.State, params.AddCharmWithAuthorization{
 		URL: curl.String(),
@@ -874,15 +874,15 @@ func (s *serviceSuite) assertServiceSetCharmSeries(c *gc.C, upgradeCharm, series
 	c.Assert(ch.URL().String(), gc.Equals, "cs:~who/"+url+"-0")
 }
 
-func (s *serviceSuite) TestServiceSetCharmUnsupportedSeriesForce(c *gc.C) {
-	s.assertServiceSetCharmSeries(c, "multi-series2", "")
+func (s *applicationSuite) TestApplicationSetCharmUnsupportedSeriesForce(c *gc.C) {
+	s.assertApplicationSetCharmSeries(c, "multi-series2", "")
 }
 
-func (s *serviceSuite) TestServiceSetCharmNoExplicitSupportedSeries(c *gc.C) {
-	s.assertServiceSetCharmSeries(c, "dummy", "precise")
+func (s *applicationSuite) TestApplicationSetCharmNoExplicitSupportedSeries(c *gc.C) {
+	s.assertApplicationSetCharmSeries(c, "dummy", "precise")
 }
 
-func (s *serviceSuite) TestServiceSetCharmWrongOS(c *gc.C) {
+func (s *applicationSuite) TestApplicationSetCharmWrongOS(c *gc.C) {
 	curl, _ := s.UploadCharmMultiSeries(c, "~who/multi-series", "multi-series")
 	err := application.AddCharmWithAuthorization(s.State, params.AddCharmWithAuthorization{
 		URL: curl.String(),
@@ -922,7 +922,7 @@ func (s *testModeCharmRepo) WithTestMode() charmrepo.Interface {
 	return s.CharmStore.WithTestMode()
 }
 
-func (s *serviceSuite) TestSpecializeStoreOnDeployServiceSetCharmAndAddCharm(c *gc.C) {
+func (s *applicationSuite) TestSpecializeStoreOnDeployApplicationSetCharmAndAddCharm(c *gc.C) {
 	repo := &testModeCharmRepo{}
 	s.PatchValue(&csclient.ServerURL, s.Srv.URL)
 	newCharmStoreRepo := application.NewCharmStoreRepo
@@ -934,7 +934,7 @@ func (s *serviceSuite) TestSpecializeStoreOnDeployServiceSetCharmAndAddCharm(c *
 	err := s.State.UpdateModelConfig(attrs, nil, nil)
 	c.Assert(err, jc.ErrorIsNil)
 
-	// Check that the store's test mode is enabled when calling service Deploy.
+	// Check that the store's test mode is enabled when calling application Deploy.
 	curl, _ := s.UploadCharm(c, "trusty/dummy-1", "dummy")
 	err = application.AddCharmWithAuthorization(s.State, params.AddCharmWithAuthorization{
 		URL: curl.String(),
@@ -966,7 +966,7 @@ func (s *serviceSuite) TestSpecializeStoreOnDeployServiceSetCharmAndAddCharm(c *
 	c.Assert(repo.testMode, jc.IsTrue)
 }
 
-func (s *serviceSuite) setupServiceDeploy(c *gc.C, args string) (*charm.URL, charm.Charm, constraints.Value) {
+func (s *applicationSuite) setupApplicationDeploy(c *gc.C, args string) (*charm.URL, charm.Charm, constraints.Value) {
 	curl, ch := s.UploadCharm(c, "precise/dummy-42", "dummy")
 	err := application.AddCharmWithAuthorization(s.State, params.AddCharmWithAuthorization{
 		URL: curl.String(),
@@ -976,7 +976,7 @@ func (s *serviceSuite) setupServiceDeploy(c *gc.C, args string) (*charm.URL, cha
 	return curl, ch, cons
 }
 
-func (s *serviceSuite) assertServiceDeployPrincipal(c *gc.C, curl *charm.URL, ch charm.Charm, mem4g constraints.Value) {
+func (s *applicationSuite) assertApplicationDeployPrincipal(c *gc.C, curl *charm.URL, ch charm.Charm, mem4g constraints.Value) {
 	results, err := s.applicationAPI.Deploy(params.ApplicationsDeploy{
 		Applications: []params.ApplicationDeploy{{
 			CharmURL:        curl.String(),
@@ -990,7 +990,7 @@ func (s *serviceSuite) assertServiceDeployPrincipal(c *gc.C, curl *charm.URL, ch
 	apiservertesting.AssertPrincipalServiceDeployed(c, s.State, "application", curl, false, ch, mem4g)
 }
 
-func (s *serviceSuite) assertServiceDeployPrincipalBlocked(c *gc.C, msg string, curl *charm.URL, mem4g constraints.Value) {
+func (s *applicationSuite) assertApplicationDeployPrincipalBlocked(c *gc.C, msg string, curl *charm.URL, mem4g constraints.Value) {
 	_, err := s.applicationAPI.Deploy(params.ApplicationsDeploy{
 		Applications: []params.ApplicationDeploy{{
 			CharmURL:        curl.String(),
@@ -1001,25 +1001,25 @@ func (s *serviceSuite) assertServiceDeployPrincipalBlocked(c *gc.C, msg string, 
 	s.AssertBlocked(c, err, msg)
 }
 
-func (s *serviceSuite) TestBlockDestroyServiceDeployPrincipal(c *gc.C) {
-	curl, bundle, cons := s.setupServiceDeploy(c, "mem=4G")
-	s.BlockDestroyModel(c, "TestBlockDestroyServiceDeployPrincipal")
-	s.assertServiceDeployPrincipal(c, curl, bundle, cons)
+func (s *applicationSuite) TestBlockDestroyApplicationDeployPrincipal(c *gc.C) {
+	curl, bundle, cons := s.setupApplicationDeploy(c, "mem=4G")
+	s.BlockDestroyModel(c, "TestBlockDestroyApplicationDeployPrincipal")
+	s.assertApplicationDeployPrincipal(c, curl, bundle, cons)
 }
 
-func (s *serviceSuite) TestBlockRemoveServiceDeployPrincipal(c *gc.C) {
-	curl, bundle, cons := s.setupServiceDeploy(c, "mem=4G")
-	s.BlockRemoveObject(c, "TestBlockRemoveServiceDeployPrincipal")
-	s.assertServiceDeployPrincipal(c, curl, bundle, cons)
+func (s *applicationSuite) TestBlockRemoveApplicationDeployPrincipal(c *gc.C) {
+	curl, bundle, cons := s.setupApplicationDeploy(c, "mem=4G")
+	s.BlockRemoveObject(c, "TestBlockRemoveApplicationDeployPrincipal")
+	s.assertApplicationDeployPrincipal(c, curl, bundle, cons)
 }
 
-func (s *serviceSuite) TestBlockChangesServiceDeployPrincipal(c *gc.C) {
-	curl, _, cons := s.setupServiceDeploy(c, "mem=4G")
-	s.BlockAllChanges(c, "TestBlockChangesServiceDeployPrincipal")
-	s.assertServiceDeployPrincipalBlocked(c, "TestBlockChangesServiceDeployPrincipal", curl, cons)
+func (s *applicationSuite) TestBlockChangesApplicationDeployPrincipal(c *gc.C) {
+	curl, _, cons := s.setupApplicationDeploy(c, "mem=4G")
+	s.BlockAllChanges(c, "TestBlockChangesApplicationDeployPrincipal")
+	s.assertApplicationDeployPrincipalBlocked(c, "TestBlockChangesApplicationDeployPrincipal", curl, cons)
 }
 
-func (s *serviceSuite) TestServiceDeploySubordinate(c *gc.C) {
+func (s *applicationSuite) TestApplicationDeploySubordinate(c *gc.C) {
 	curl, ch := s.UploadCharm(c, "utopic/logging-47", "logging")
 	err := application.AddCharmWithAuthorization(s.State, params.AddCharmWithAuthorization{
 		URL: curl.String(),
@@ -1048,7 +1048,7 @@ func (s *serviceSuite) TestServiceDeploySubordinate(c *gc.C) {
 	c.Assert(units, gc.HasLen, 0)
 }
 
-func (s *serviceSuite) TestServiceDeployConfig(c *gc.C) {
+func (s *applicationSuite) TestApplicationDeployConfig(c *gc.C) {
 	curl, _ := s.UploadCharm(c, "precise/dummy-0", "dummy")
 	err := application.AddCharmWithAuthorization(s.State, params.AddCharmWithAuthorization{
 		URL: curl.String(),
@@ -1072,7 +1072,7 @@ func (s *serviceSuite) TestServiceDeployConfig(c *gc.C) {
 	c.Assert(settings, gc.DeepEquals, charm.Settings{"username": "fred"})
 }
 
-func (s *serviceSuite) TestServiceDeployConfigError(c *gc.C) {
+func (s *applicationSuite) TestApplicationDeployConfigError(c *gc.C) {
 	// TODO(fwereade): test Config/ConfigYAML handling directly on srvClient.
 	// Can't be done cleanly until it's extracted similarly to Machiner.
 	curl, _ := s.UploadCharm(c, "precise/dummy-0", "dummy")
@@ -1094,7 +1094,7 @@ func (s *serviceSuite) TestServiceDeployConfigError(c *gc.C) {
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 }
 
-func (s *serviceSuite) TestServiceDeployToMachine(c *gc.C) {
+func (s *applicationSuite) TestApplicationDeployToMachine(c *gc.C) {
 	curl, ch := s.UploadCharm(c, "precise/dummy-0", "dummy")
 	err := application.AddCharmWithAuthorization(s.State, params.AddCharmWithAuthorization{
 		URL: curl.String(),
@@ -1136,7 +1136,7 @@ func (s *serviceSuite) TestServiceDeployToMachine(c *gc.C) {
 	c.Assert(mid, gc.Equals, machine.Id())
 }
 
-func (s *serviceSuite) TestServiceDeployToMachineNotFound(c *gc.C) {
+func (s *applicationSuite) TestApplicationDeployToMachineNotFound(c *gc.C) {
 	results, err := s.applicationAPI.Deploy(params.ApplicationsDeploy{
 		Applications: []params.ApplicationDeploy{{
 			CharmURL:        "cs:precise/application-name-1",
@@ -1152,7 +1152,7 @@ func (s *serviceSuite) TestServiceDeployToMachineNotFound(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, `application "application-name" not found`)
 }
 
-func (s *serviceSuite) deployServiceForUpdateTests(c *gc.C) {
+func (s *applicationSuite) deployApplicationForUpdateTests(c *gc.C) {
 	curl, _ := s.UploadCharm(c, "precise/dummy-1", "dummy")
 	err := application.AddCharmWithAuthorization(s.State, params.AddCharmWithAuthorization{
 		URL: curl.String(),
@@ -1169,8 +1169,8 @@ func (s *serviceSuite) deployServiceForUpdateTests(c *gc.C) {
 	c.Assert(results.Results[0].Error, gc.IsNil)
 }
 
-func (s *serviceSuite) checkClientServiceUpdateSetCharm(c *gc.C, forceCharmURL bool) {
-	s.deployServiceForUpdateTests(c)
+func (s *applicationSuite) checkClientApplicationUpdateSetCharm(c *gc.C, forceCharmURL bool) {
+	s.deployApplicationForUpdateTests(c)
 	curl, _ := s.UploadCharm(c, "precise/wordpress-3", "wordpress")
 	err := application.AddCharmWithAuthorization(s.State, params.AddCharmWithAuthorization{
 		URL: curl.String(),
@@ -1195,22 +1195,22 @@ func (s *serviceSuite) checkClientServiceUpdateSetCharm(c *gc.C, forceCharmURL b
 	c.Assert(force, gc.Equals, forceCharmURL)
 }
 
-func (s *serviceSuite) TestServiceUpdateSetCharm(c *gc.C) {
-	s.checkClientServiceUpdateSetCharm(c, false)
+func (s *applicationSuite) TestApplicationUpdateSetCharm(c *gc.C) {
+	s.checkClientApplicationUpdateSetCharm(c, false)
 }
 
-func (s *serviceSuite) TestBlockDestroyServiceUpdate(c *gc.C) {
-	s.BlockDestroyModel(c, "TestBlockDestroyServiceUpdate")
-	s.checkClientServiceUpdateSetCharm(c, false)
+func (s *applicationSuite) TestBlockDestroyApplicationUpdate(c *gc.C) {
+	s.BlockDestroyModel(c, "TestBlockDestroyApplicationUpdate")
+	s.checkClientApplicationUpdateSetCharm(c, false)
 }
 
-func (s *serviceSuite) TestBlockRemoveServiceUpdate(c *gc.C) {
-	s.BlockRemoveObject(c, "TestBlockRemoveServiceUpdate")
-	s.checkClientServiceUpdateSetCharm(c, false)
+func (s *applicationSuite) TestBlockRemoveApplicationUpdate(c *gc.C) {
+	s.BlockRemoveObject(c, "TestBlockRemoveApplicationUpdate")
+	s.checkClientApplicationUpdateSetCharm(c, false)
 }
 
-func (s *serviceSuite) setupServiceUpdate(c *gc.C) string {
-	s.deployServiceForUpdateTests(c)
+func (s *applicationSuite) setupApplicationUpdate(c *gc.C) string {
+	s.deployApplicationForUpdateTests(c)
 	curl, _ := s.UploadCharm(c, "precise/wordpress-3", "wordpress")
 	err := application.AddCharmWithAuthorization(s.State, params.AddCharmWithAuthorization{
 		URL: curl.String(),
@@ -1219,9 +1219,9 @@ func (s *serviceSuite) setupServiceUpdate(c *gc.C) string {
 	return curl.String()
 }
 
-func (s *serviceSuite) TestBlockChangeServiceUpdate(c *gc.C) {
-	curl := s.setupServiceUpdate(c)
-	s.BlockAllChanges(c, "TestBlockChangeServiceUpdate")
+func (s *applicationSuite) TestBlockChangeApplicationUpdate(c *gc.C) {
+	curl := s.setupApplicationUpdate(c)
+	s.BlockAllChanges(c, "TestBlockChangeApplicationUpdate")
 	// Update the charm for the application.
 	args := params.ApplicationUpdate{
 		ApplicationName: "application",
@@ -1229,20 +1229,20 @@ func (s *serviceSuite) TestBlockChangeServiceUpdate(c *gc.C) {
 		ForceCharmURL:   false,
 	}
 	err := s.applicationAPI.Update(args)
-	s.AssertBlocked(c, err, "TestBlockChangeServiceUpdate")
+	s.AssertBlocked(c, err, "TestBlockChangeApplicationUpdate")
 }
 
-func (s *serviceSuite) TestServiceUpdateForceSetCharm(c *gc.C) {
-	s.checkClientServiceUpdateSetCharm(c, true)
+func (s *applicationSuite) TestApplicationUpdateForceSetCharm(c *gc.C) {
+	s.checkClientApplicationUpdateSetCharm(c, true)
 }
 
-func (s *serviceSuite) TestBlockServiceUpdateForced(c *gc.C) {
-	curl := s.setupServiceUpdate(c)
+func (s *applicationSuite) TestBlockApplicationUpdateForced(c *gc.C) {
+	curl := s.setupApplicationUpdate(c)
 
 	// block all changes. Force should ignore block :)
-	s.BlockAllChanges(c, "TestBlockServiceUpdateForced")
-	s.BlockDestroyModel(c, "TestBlockServiceUpdateForced")
-	s.BlockRemoveObject(c, "TestBlockServiceUpdateForced")
+	s.BlockAllChanges(c, "TestBlockApplicationUpdateForced")
+	s.BlockDestroyModel(c, "TestBlockApplicationUpdateForced")
+	s.BlockRemoveObject(c, "TestBlockApplicationUpdateForced")
 
 	// Update the charm for the application.
 	args := params.ApplicationUpdate{
@@ -1262,7 +1262,7 @@ func (s *serviceSuite) TestBlockServiceUpdateForced(c *gc.C) {
 	c.Assert(force, jc.IsTrue)
 }
 
-func (s *serviceSuite) TestServiceUpdateSetCharmNotFound(c *gc.C) {
+func (s *applicationSuite) TestApplicationUpdateSetCharmNotFound(c *gc.C) {
 	s.AddTestingService(c, "wordpress", s.AddTestingCharm(c, "wordpress"))
 	args := params.ApplicationUpdate{
 		ApplicationName: "wordpress",
@@ -1272,7 +1272,7 @@ func (s *serviceSuite) TestServiceUpdateSetCharmNotFound(c *gc.C) {
 	c.Check(err, gc.ErrorMatches, `charm "cs:precise/wordpress-999999" not found`)
 }
 
-func (s *serviceSuite) TestServiceUpdateSetMinUnits(c *gc.C) {
+func (s *applicationSuite) TestApplicationUpdateSetMinUnits(c *gc.C) {
 	application := s.AddTestingService(c, "dummy", s.AddTestingCharm(c, "dummy"))
 
 	// Set minimum units for the application.
@@ -1289,7 +1289,7 @@ func (s *serviceSuite) TestServiceUpdateSetMinUnits(c *gc.C) {
 	c.Assert(application.MinUnits(), gc.Equals, minUnits)
 }
 
-func (s *serviceSuite) TestServiceUpdateSetMinUnitsError(c *gc.C) {
+func (s *applicationSuite) TestApplicationUpdateSetMinUnitsError(c *gc.C) {
 	application := s.AddTestingService(c, "dummy", s.AddTestingCharm(c, "dummy"))
 
 	// Set a negative minimum number of units for the application.
@@ -1307,7 +1307,7 @@ func (s *serviceSuite) TestServiceUpdateSetMinUnitsError(c *gc.C) {
 	c.Assert(application.MinUnits(), gc.Equals, 0)
 }
 
-func (s *serviceSuite) TestServiceUpdateSetSettingsStrings(c *gc.C) {
+func (s *applicationSuite) TestApplicationUpdateSetSettingsStrings(c *gc.C) {
 	application := s.AddTestingService(c, "dummy", s.AddTestingCharm(c, "dummy"))
 
 	// Update settings for the application.
@@ -1325,7 +1325,7 @@ func (s *serviceSuite) TestServiceUpdateSetSettingsStrings(c *gc.C) {
 	c.Assert(obtained, gc.DeepEquals, expected)
 }
 
-func (s *serviceSuite) TestServiceUpdateSetSettingsYAML(c *gc.C) {
+func (s *applicationSuite) TestApplicationUpdateSetSettingsYAML(c *gc.C) {
 	application := s.AddTestingService(c, "dummy", s.AddTestingCharm(c, "dummy"))
 
 	// Update settings for the application.
@@ -1343,7 +1343,7 @@ func (s *serviceSuite) TestServiceUpdateSetSettingsYAML(c *gc.C) {
 	c.Assert(obtained, gc.DeepEquals, expected)
 }
 
-func (s *serviceSuite) TestClientServiceUpdateSetSettingsGetYAML(c *gc.C) {
+func (s *applicationSuite) TestClientApplicationUpdateSetSettingsGetYAML(c *gc.C) {
 	application := s.AddTestingService(c, "dummy", s.AddTestingCharm(c, "dummy"))
 
 	// Update settings for the application.
@@ -1361,7 +1361,7 @@ func (s *serviceSuite) TestClientServiceUpdateSetSettingsGetYAML(c *gc.C) {
 	c.Assert(obtained, gc.DeepEquals, expected)
 }
 
-func (s *serviceSuite) TestServiceUpdateSetConstraints(c *gc.C) {
+func (s *applicationSuite) TestApplicationUpdateSetConstraints(c *gc.C) {
 	application := s.AddTestingService(c, "dummy", s.AddTestingCharm(c, "dummy"))
 
 	// Update constraints for the application.
@@ -1380,15 +1380,15 @@ func (s *serviceSuite) TestServiceUpdateSetConstraints(c *gc.C) {
 	c.Assert(obtained, gc.DeepEquals, cons)
 }
 
-func (s *serviceSuite) TestServiceUpdateAllParams(c *gc.C) {
-	s.deployServiceForUpdateTests(c)
+func (s *applicationSuite) TestApplicationUpdateAllParams(c *gc.C) {
+	s.deployApplicationForUpdateTests(c)
 	curl, _ := s.UploadCharm(c, "precise/wordpress-3", "wordpress")
 	err := application.AddCharmWithAuthorization(s.State, params.AddCharmWithAuthorization{
 		URL: curl.String(),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
-	// Update all the service attributes.
+	// Update all the application attributes.
 	minUnits := 3
 	cons, err := constraints.Parse("mem=4096", "cores=2")
 	c.Assert(err, jc.ErrorIsNil)
@@ -1404,7 +1404,7 @@ func (s *serviceSuite) TestServiceUpdateAllParams(c *gc.C) {
 	err = s.applicationAPI.Update(args)
 	c.Assert(err, jc.ErrorIsNil)
 
-	// Ensure the service has been correctly updated.
+	// Ensure the application has been correctly updated.
 	application, err := s.State.Application("application")
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -1430,7 +1430,7 @@ func (s *serviceSuite) TestServiceUpdateAllParams(c *gc.C) {
 	c.Assert(obtainedConstraints, gc.DeepEquals, cons)
 }
 
-func (s *serviceSuite) TestServiceUpdateNoParams(c *gc.C) {
+func (s *applicationSuite) TestApplicationUpdateNoParams(c *gc.C) {
 	s.AddTestingService(c, "wordpress", s.AddTestingCharm(c, "wordpress"))
 
 	// Calling Update with no parameters set is a no-op.
@@ -1439,22 +1439,22 @@ func (s *serviceSuite) TestServiceUpdateNoParams(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 }
 
-func (s *serviceSuite) TestServiceUpdateNoService(c *gc.C) {
+func (s *applicationSuite) TestApplicationUpdateNoApplication(c *gc.C) {
 	err := s.applicationAPI.Update(params.ApplicationUpdate{})
 	c.Assert(err, gc.ErrorMatches, `"" is not a valid application name`)
 }
 
-func (s *serviceSuite) TestServiceUpdateInvalidService(c *gc.C) {
-	args := params.ApplicationUpdate{ApplicationName: "no-such-service"}
+func (s *applicationSuite) TestApplicationUpdateInvalidApplication(c *gc.C) {
+	args := params.ApplicationUpdate{ApplicationName: "no-such-application"}
 	err := s.applicationAPI.Update(args)
-	c.Assert(err, gc.ErrorMatches, `application "no-such-service" not found`)
+	c.Assert(err, gc.ErrorMatches, `application "no-such-application" not found`)
 }
 
 var (
 	validSetTestValue = "a value with spaces\nand newline\nand UTF-8 characters: \U0001F604 / \U0001F44D"
 )
 
-func (s *serviceSuite) TestServiceSet(c *gc.C) {
+func (s *applicationSuite) TestApplicationSet(c *gc.C) {
 	dummy := s.AddTestingService(c, "dummy", s.AddTestingCharm(c, "dummy"))
 
 	err := s.applicationAPI.Set(params.ApplicationSet{ApplicationName: "dummy", Options: map[string]string{
@@ -1482,7 +1482,7 @@ func (s *serviceSuite) TestServiceSet(c *gc.C) {
 	})
 }
 
-func (s *serviceSuite) assertServiceSetBlocked(c *gc.C, dummy *state.Application, msg string) {
+func (s *applicationSuite) assertApplicationSetBlocked(c *gc.C, dummy *state.Application, msg string) {
 	err := s.applicationAPI.Set(params.ApplicationSet{
 		ApplicationName: "dummy",
 		Options: map[string]string{
@@ -1491,7 +1491,7 @@ func (s *serviceSuite) assertServiceSetBlocked(c *gc.C, dummy *state.Application
 	s.AssertBlocked(c, err, msg)
 }
 
-func (s *serviceSuite) assertServiceSet(c *gc.C, dummy *state.Application) {
+func (s *applicationSuite) assertApplicationSet(c *gc.C, dummy *state.Application) {
 	err := s.applicationAPI.Set(params.ApplicationSet{
 		ApplicationName: "dummy",
 		Options: map[string]string{
@@ -1506,25 +1506,25 @@ func (s *serviceSuite) assertServiceSet(c *gc.C, dummy *state.Application) {
 	})
 }
 
-func (s *serviceSuite) TestBlockDestroyServiceSet(c *gc.C) {
+func (s *applicationSuite) TestBlockDestroyApplicationSet(c *gc.C) {
 	dummy := s.AddTestingService(c, "dummy", s.AddTestingCharm(c, "dummy"))
-	s.BlockDestroyModel(c, "TestBlockDestroyServiceSet")
-	s.assertServiceSet(c, dummy)
+	s.BlockDestroyModel(c, "TestBlockDestroyApplicationSet")
+	s.assertApplicationSet(c, dummy)
 }
 
-func (s *serviceSuite) TestBlockRemoveServiceSet(c *gc.C) {
+func (s *applicationSuite) TestBlockRemoveApplicationSet(c *gc.C) {
 	dummy := s.AddTestingService(c, "dummy", s.AddTestingCharm(c, "dummy"))
-	s.BlockRemoveObject(c, "TestBlockRemoveServiceSet")
-	s.assertServiceSet(c, dummy)
+	s.BlockRemoveObject(c, "TestBlockRemoveApplicationSet")
+	s.assertApplicationSet(c, dummy)
 }
 
-func (s *serviceSuite) TestBlockChangesServiceSet(c *gc.C) {
+func (s *applicationSuite) TestBlockChangesApplicationSet(c *gc.C) {
 	dummy := s.AddTestingService(c, "dummy", s.AddTestingCharm(c, "dummy"))
-	s.BlockAllChanges(c, "TestBlockChangesServiceSet")
-	s.assertServiceSetBlocked(c, dummy, "TestBlockChangesServiceSet")
+	s.BlockAllChanges(c, "TestBlockChangesApplicationSet")
+	s.assertApplicationSetBlocked(c, dummy, "TestBlockChangesApplicationSet")
 }
 
-func (s *serviceSuite) TestServerUnset(c *gc.C) {
+func (s *applicationSuite) TestServerUnset(c *gc.C) {
 	dummy := s.AddTestingService(c, "dummy", s.AddTestingCharm(c, "dummy"))
 
 	err := s.applicationAPI.Set(params.ApplicationSet{ApplicationName: "dummy", Options: map[string]string{
@@ -1548,7 +1548,7 @@ func (s *serviceSuite) TestServerUnset(c *gc.C) {
 	})
 }
 
-func (s *serviceSuite) setupServerUnsetBlocked(c *gc.C) *state.Application {
+func (s *applicationSuite) setupServerUnsetBlocked(c *gc.C) *state.Application {
 	dummy := s.AddTestingService(c, "dummy", s.AddTestingCharm(c, "dummy"))
 
 	err := s.applicationAPI.Set(params.ApplicationSet{
@@ -1567,7 +1567,7 @@ func (s *serviceSuite) setupServerUnsetBlocked(c *gc.C) *state.Application {
 	return dummy
 }
 
-func (s *serviceSuite) assertServerUnset(c *gc.C, dummy *state.Application) {
+func (s *applicationSuite) assertServerUnset(c *gc.C, dummy *state.Application) {
 	err := s.applicationAPI.Unset(params.ApplicationUnset{
 		ApplicationName: "dummy",
 		Options:         []string{"username"},
@@ -1580,7 +1580,7 @@ func (s *serviceSuite) assertServerUnset(c *gc.C, dummy *state.Application) {
 	})
 }
 
-func (s *serviceSuite) assertServerUnsetBlocked(c *gc.C, dummy *state.Application, msg string) {
+func (s *applicationSuite) assertServerUnsetBlocked(c *gc.C, dummy *state.Application, msg string) {
 	err := s.applicationAPI.Unset(params.ApplicationUnset{
 		ApplicationName: "dummy",
 		Options:         []string{"username"},
@@ -1588,30 +1588,30 @@ func (s *serviceSuite) assertServerUnsetBlocked(c *gc.C, dummy *state.Applicatio
 	s.AssertBlocked(c, err, msg)
 }
 
-func (s *serviceSuite) TestBlockDestroyServerUnset(c *gc.C) {
+func (s *applicationSuite) TestBlockDestroyServerUnset(c *gc.C) {
 	dummy := s.setupServerUnsetBlocked(c)
 	s.BlockDestroyModel(c, "TestBlockDestroyServerUnset")
 	s.assertServerUnset(c, dummy)
 }
 
-func (s *serviceSuite) TestBlockRemoveServerUnset(c *gc.C) {
+func (s *applicationSuite) TestBlockRemoveServerUnset(c *gc.C) {
 	dummy := s.setupServerUnsetBlocked(c)
 	s.BlockRemoveObject(c, "TestBlockRemoveServerUnset")
 	s.assertServerUnset(c, dummy)
 }
 
-func (s *serviceSuite) TestBlockChangesServerUnset(c *gc.C) {
+func (s *applicationSuite) TestBlockChangesServerUnset(c *gc.C) {
 	dummy := s.setupServerUnsetBlocked(c)
 	s.BlockAllChanges(c, "TestBlockChangesServerUnset")
 	s.assertServerUnsetBlocked(c, dummy, "TestBlockChangesServerUnset")
 }
 
-var clientAddServiceUnitsTests = []struct {
-	about    string
-	service  string // if not set, defaults to 'dummy'
-	expected []string
-	to       string
-	err      string
+var clientAddApplicationUnitsTests = []struct {
+	about       string
+	application string // if not set, defaults to 'dummy'
+	expected    []string
+	to          string
+	err         string
 }{
 	{
 		about:    "returns unit names",
@@ -1629,22 +1629,22 @@ var clientAddServiceUnitsTests = []struct {
 		to:       "0",
 	},
 	{
-		about:   "unknown application name",
-		service: "unknown-service",
-		err:     `application "unknown-service" not found`,
+		about:       "unknown application name",
+		application: "unknown-application",
+		err:         `application "unknown-application" not found`,
 	},
 }
 
-func (s *serviceSuite) TestClientAddServiceUnits(c *gc.C) {
+func (s *applicationSuite) TestClientAddApplicationUnits(c *gc.C) {
 	s.AddTestingService(c, "dummy", s.AddTestingCharm(c, "dummy"))
-	for i, t := range clientAddServiceUnitsTests {
+	for i, t := range clientAddApplicationUnitsTests {
 		c.Logf("test %d. %s", i, t.about)
-		serviceName := t.service
-		if serviceName == "" {
-			serviceName = "dummy"
+		applicationName := t.application
+		if applicationName == "" {
+			applicationName = "dummy"
 		}
 		args := params.AddApplicationUnits{
-			ApplicationName: serviceName,
+			ApplicationName: applicationName,
 			NumUnits:        len(t.expected),
 		}
 		if t.to != "" {
@@ -1666,7 +1666,7 @@ func (s *serviceSuite) TestClientAddServiceUnits(c *gc.C) {
 	c.Assert(assignedMachine, gc.Equals, "0")
 }
 
-func (s *serviceSuite) TestAddServiceUnitsToNewContainer(c *gc.C) {
+func (s *applicationSuite) TestAddApplicationUnitsToNewContainer(c *gc.C) {
 	svc := s.AddTestingService(c, "dummy", s.AddTestingCharm(c, "dummy"))
 	machine, err := s.State.AddMachine("quantal", state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)
@@ -1685,13 +1685,13 @@ func (s *serviceSuite) TestAddServiceUnitsToNewContainer(c *gc.C) {
 	c.Assert(mid, gc.Equals, machine.Id()+"/lxd/0")
 }
 
-var addServiceUnitTests = []struct {
-	about      string
-	service    string // if not set, defaults to 'dummy'
-	expected   []string
-	machineIds []string
-	placement  []*instance.Placement
-	err        string
+var addApplicationUnitTests = []struct {
+	about       string
+	application string // if not set, defaults to 'dummy'
+	expected    []string
+	machineIds  []string
+	placement   []*instance.Placement
+	err         string
 }{
 	{
 		about:      "valid placement directives",
@@ -1711,19 +1711,19 @@ var addServiceUnitTests = []struct {
 	},
 }
 
-func (s *serviceSuite) TestAddServiceUnits(c *gc.C) {
+func (s *applicationSuite) TestAddApplicationUnits(c *gc.C) {
 	s.AddTestingService(c, "dummy", s.AddTestingCharm(c, "dummy"))
 	// Add a machine for the units to be placed on.
 	_, err := s.State.AddMachine("quantal", state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)
-	for i, t := range addServiceUnitTests {
+	for i, t := range addApplicationUnitTests {
 		c.Logf("test %d. %s", i, t.about)
-		serviceName := t.service
-		if serviceName == "" {
-			serviceName = "dummy"
+		applicationName := t.application
+		if applicationName == "" {
+			applicationName = "dummy"
 		}
 		result, err := s.applicationAPI.AddUnits(params.AddApplicationUnits{
-			ApplicationName: serviceName,
+			ApplicationName: applicationName,
 			NumUnits:        len(t.expected),
 			Placement:       t.placement,
 		})
@@ -1743,7 +1743,7 @@ func (s *serviceSuite) TestAddServiceUnits(c *gc.C) {
 	}
 }
 
-func (s *serviceSuite) assertAddServiceUnits(c *gc.C) {
+func (s *applicationSuite) assertAddApplicationUnits(c *gc.C) {
 	result, err := s.applicationAPI.AddUnits(params.AddApplicationUnits{
 		ApplicationName: "dummy",
 		NumUnits:        3,
@@ -1759,7 +1759,7 @@ func (s *serviceSuite) assertAddServiceUnits(c *gc.C) {
 	c.Assert(assignedMachine, gc.Equals, "0")
 }
 
-func (s *serviceSuite) TestServiceCharmRelations(c *gc.C) {
+func (s *applicationSuite) TestApplicationCharmRelations(c *gc.C) {
 	s.AddTestingService(c, "wordpress", s.AddTestingCharm(c, "wordpress"))
 	s.AddTestingService(c, "logging", s.AddTestingCharm(c, "logging"))
 	eps, err := s.State.InferEndpoints("logging", "wordpress")
@@ -1777,7 +1777,7 @@ func (s *serviceSuite) TestServiceCharmRelations(c *gc.C) {
 	})
 }
 
-func (s *serviceSuite) assertAddServiceUnitsBlocked(c *gc.C, msg string) {
+func (s *applicationSuite) assertAddApplicationUnitsBlocked(c *gc.C, msg string) {
 	_, err := s.applicationAPI.AddUnits(params.AddApplicationUnits{
 		ApplicationName: "dummy",
 		NumUnits:        3,
@@ -1785,25 +1785,25 @@ func (s *serviceSuite) assertAddServiceUnitsBlocked(c *gc.C, msg string) {
 	s.AssertBlocked(c, err, msg)
 }
 
-func (s *serviceSuite) TestBlockDestroyAddServiceUnits(c *gc.C) {
+func (s *applicationSuite) TestBlockDestroyAddApplicationUnits(c *gc.C) {
 	s.AddTestingService(c, "dummy", s.AddTestingCharm(c, "dummy"))
-	s.BlockDestroyModel(c, "TestBlockDestroyAddServiceUnits")
-	s.assertAddServiceUnits(c)
+	s.BlockDestroyModel(c, "TestBlockDestroyAddApplicationUnits")
+	s.assertAddApplicationUnits(c)
 }
 
-func (s *serviceSuite) TestBlockRemoveAddServiceUnits(c *gc.C) {
+func (s *applicationSuite) TestBlockRemoveAddApplicationUnits(c *gc.C) {
 	s.AddTestingService(c, "dummy", s.AddTestingCharm(c, "dummy"))
-	s.BlockRemoveObject(c, "TestBlockRemoveAddServiceUnits")
-	s.assertAddServiceUnits(c)
+	s.BlockRemoveObject(c, "TestBlockRemoveAddApplicationUnits")
+	s.assertAddApplicationUnits(c)
 }
 
-func (s *serviceSuite) TestBlockChangeAddServiceUnits(c *gc.C) {
+func (s *applicationSuite) TestBlockChangeAddApplicationUnits(c *gc.C) {
 	s.AddTestingService(c, "dummy", s.AddTestingCharm(c, "dummy"))
-	s.BlockAllChanges(c, "TestBlockChangeAddServiceUnits")
-	s.assertAddServiceUnitsBlocked(c, "TestBlockChangeAddServiceUnits")
+	s.BlockAllChanges(c, "TestBlockChangeAddApplicationUnits")
+	s.assertAddApplicationUnitsBlocked(c, "TestBlockChangeAddApplicationUnits")
 }
 
-func (s *serviceSuite) TestAddUnitToMachineNotFound(c *gc.C) {
+func (s *applicationSuite) TestAddUnitToMachineNotFound(c *gc.C) {
 	s.AddTestingService(c, "dummy", s.AddTestingCharm(c, "dummy"))
 	_, err := s.applicationAPI.AddUnits(params.AddApplicationUnits{
 		ApplicationName: "dummy",
@@ -1813,38 +1813,38 @@ func (s *serviceSuite) TestAddUnitToMachineNotFound(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, `adding new machine to host unit "dummy/0": machine 42 not found`)
 }
 
-func (s *serviceSuite) TestServiceExpose(c *gc.C) {
+func (s *applicationSuite) TestApplicationExpose(c *gc.C) {
 	charm := s.AddTestingCharm(c, "dummy")
-	serviceNames := []string{"dummy-service", "exposed-service"}
-	svcs := make([]*state.Application, len(serviceNames))
+	applicationNames := []string{"dummy-application", "exposed-application"}
+	svcs := make([]*state.Application, len(applicationNames))
 	var err error
-	for i, name := range serviceNames {
+	for i, name := range applicationNames {
 		svcs[i] = s.AddTestingService(c, name, charm)
 		c.Assert(svcs[i].IsExposed(), jc.IsFalse)
 	}
 	err = svcs[1].SetExposed()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(svcs[1].IsExposed(), jc.IsTrue)
-	for i, t := range serviceExposeTests {
+	for i, t := range applicationExposeTests {
 		c.Logf("test %d. %s", i, t.about)
-		err = s.applicationAPI.Expose(params.ApplicationExpose{t.service})
+		err = s.applicationAPI.Expose(params.ApplicationExpose{t.application})
 		if t.err != "" {
 			c.Assert(err, gc.ErrorMatches, t.err)
 		} else {
 			c.Assert(err, jc.ErrorIsNil)
-			application, err := s.State.Application(t.service)
+			application, err := s.State.Application(t.application)
 			c.Assert(err, jc.ErrorIsNil)
 			c.Assert(application.IsExposed(), gc.Equals, t.exposed)
 		}
 	}
 }
 
-func (s *serviceSuite) setupServiceExpose(c *gc.C) {
+func (s *applicationSuite) setupApplicationExpose(c *gc.C) {
 	charm := s.AddTestingCharm(c, "dummy")
-	serviceNames := []string{"dummy-service", "exposed-service"}
-	svcs := make([]*state.Application, len(serviceNames))
+	applicationNames := []string{"dummy-application", "exposed-application"}
+	svcs := make([]*state.Application, len(applicationNames))
 	var err error
-	for i, name := range serviceNames {
+	for i, name := range applicationNames {
 		svcs[i] = s.AddTestingService(c, name, charm)
 		c.Assert(svcs[i].IsExposed(), jc.IsFalse)
 	}
@@ -1853,106 +1853,106 @@ func (s *serviceSuite) setupServiceExpose(c *gc.C) {
 	c.Assert(svcs[1].IsExposed(), jc.IsTrue)
 }
 
-var serviceExposeTests = []struct {
-	about   string
-	service string
-	err     string
-	exposed bool
+var applicationExposeTests = []struct {
+	about       string
+	application string
+	err         string
+	exposed     bool
 }{
 	{
-		about:   "unknown application name",
-		service: "unknown-service",
-		err:     `application "unknown-service" not found`,
+		about:       "unknown application name",
+		application: "unknown-application",
+		err:         `application "unknown-application" not found`,
 	},
 	{
-		about:   "expose a service",
-		service: "dummy-service",
-		exposed: true,
+		about:       "expose a application",
+		application: "dummy-application",
+		exposed:     true,
 	},
 	{
-		about:   "expose an already exposed service",
-		service: "exposed-service",
-		exposed: true,
+		about:       "expose an already exposed application",
+		application: "exposed-application",
+		exposed:     true,
 	},
 }
 
-func (s *serviceSuite) assertServiceExpose(c *gc.C) {
-	for i, t := range serviceExposeTests {
+func (s *applicationSuite) assertApplicationExpose(c *gc.C) {
+	for i, t := range applicationExposeTests {
 		c.Logf("test %d. %s", i, t.about)
-		err := s.applicationAPI.Expose(params.ApplicationExpose{t.service})
+		err := s.applicationAPI.Expose(params.ApplicationExpose{t.application})
 		if t.err != "" {
 			c.Assert(err, gc.ErrorMatches, t.err)
 		} else {
 			c.Assert(err, jc.ErrorIsNil)
-			application, err := s.State.Application(t.service)
+			application, err := s.State.Application(t.application)
 			c.Assert(err, jc.ErrorIsNil)
 			c.Assert(application.IsExposed(), gc.Equals, t.exposed)
 		}
 	}
 }
 
-func (s *serviceSuite) assertServiceExposeBlocked(c *gc.C, msg string) {
-	for i, t := range serviceExposeTests {
+func (s *applicationSuite) assertApplicationExposeBlocked(c *gc.C, msg string) {
+	for i, t := range applicationExposeTests {
 		c.Logf("test %d. %s", i, t.about)
-		err := s.applicationAPI.Expose(params.ApplicationExpose{t.service})
+		err := s.applicationAPI.Expose(params.ApplicationExpose{t.application})
 		s.AssertBlocked(c, err, msg)
 	}
 }
 
-func (s *serviceSuite) TestBlockDestroyServiceExpose(c *gc.C) {
-	s.setupServiceExpose(c)
-	s.BlockDestroyModel(c, "TestBlockDestroyServiceExpose")
-	s.assertServiceExpose(c)
+func (s *applicationSuite) TestBlockDestroyApplicationExpose(c *gc.C) {
+	s.setupApplicationExpose(c)
+	s.BlockDestroyModel(c, "TestBlockDestroyApplicationExpose")
+	s.assertApplicationExpose(c)
 }
 
-func (s *serviceSuite) TestBlockRemoveServiceExpose(c *gc.C) {
-	s.setupServiceExpose(c)
-	s.BlockRemoveObject(c, "TestBlockRemoveServiceExpose")
-	s.assertServiceExpose(c)
+func (s *applicationSuite) TestBlockRemoveApplicationExpose(c *gc.C) {
+	s.setupApplicationExpose(c)
+	s.BlockRemoveObject(c, "TestBlockRemoveApplicationExpose")
+	s.assertApplicationExpose(c)
 }
 
-func (s *serviceSuite) TestBlockChangesServiceExpose(c *gc.C) {
-	s.setupServiceExpose(c)
-	s.BlockAllChanges(c, "TestBlockChangesServiceExpose")
-	s.assertServiceExposeBlocked(c, "TestBlockChangesServiceExpose")
+func (s *applicationSuite) TestBlockChangesApplicationExpose(c *gc.C) {
+	s.setupApplicationExpose(c)
+	s.BlockAllChanges(c, "TestBlockChangesApplicationExpose")
+	s.assertApplicationExposeBlocked(c, "TestBlockChangesApplicationExpose")
 }
 
-var serviceUnexposeTests = []struct {
-	about    string
-	service  string
-	err      string
-	initial  bool
-	expected bool
+var applicationUnexposeTests = []struct {
+	about       string
+	application string
+	err         string
+	initial     bool
+	expected    bool
 }{
 	{
-		about:   "unknown application name",
-		service: "unknown-service",
-		err:     `application "unknown-service" not found`,
+		about:       "unknown application name",
+		application: "unknown-application",
+		err:         `application "unknown-application" not found`,
 	},
 	{
-		about:    "unexpose a service",
-		service:  "dummy-service",
-		initial:  true,
-		expected: false,
+		about:       "unexpose a application",
+		application: "dummy-application",
+		initial:     true,
+		expected:    false,
 	},
 	{
-		about:    "unexpose an already unexposed service",
-		service:  "dummy-service",
-		initial:  false,
-		expected: false,
+		about:       "unexpose an already unexposed application",
+		application: "dummy-application",
+		initial:     false,
+		expected:    false,
 	},
 }
 
-func (s *serviceSuite) TestServiceUnexpose(c *gc.C) {
+func (s *applicationSuite) TestApplicationUnexpose(c *gc.C) {
 	charm := s.AddTestingCharm(c, "dummy")
-	for i, t := range serviceUnexposeTests {
+	for i, t := range applicationUnexposeTests {
 		c.Logf("test %d. %s", i, t.about)
-		svc := s.AddTestingService(c, "dummy-service", charm)
+		svc := s.AddTestingService(c, "dummy-application", charm)
 		if t.initial {
 			svc.SetExposed()
 		}
 		c.Assert(svc.IsExposed(), gc.Equals, t.initial)
-		err := s.applicationAPI.Unexpose(params.ApplicationUnexpose{t.service})
+		err := s.applicationAPI.Unexpose(params.ApplicationUnexpose{t.application})
 		if t.err == "" {
 			c.Assert(err, jc.ErrorIsNil)
 			svc.Refresh()
@@ -1965,16 +1965,16 @@ func (s *serviceSuite) TestServiceUnexpose(c *gc.C) {
 	}
 }
 
-func (s *serviceSuite) setupServiceUnexpose(c *gc.C) *state.Application {
+func (s *applicationSuite) setupApplicationUnexpose(c *gc.C) *state.Application {
 	charm := s.AddTestingCharm(c, "dummy")
-	svc := s.AddTestingService(c, "dummy-service", charm)
+	svc := s.AddTestingService(c, "dummy-application", charm)
 	svc.SetExposed()
 	c.Assert(svc.IsExposed(), gc.Equals, true)
 	return svc
 }
 
-func (s *serviceSuite) assertServiceUnexpose(c *gc.C, svc *state.Application) {
-	err := s.applicationAPI.Unexpose(params.ApplicationUnexpose{"dummy-service"})
+func (s *applicationSuite) assertApplicationUnexpose(c *gc.C, svc *state.Application) {
+	err := s.applicationAPI.Unexpose(params.ApplicationUnexpose{"dummy-application"})
 	c.Assert(err, jc.ErrorIsNil)
 	svc.Refresh()
 	c.Assert(svc.IsExposed(), gc.Equals, false)
@@ -1982,57 +1982,57 @@ func (s *serviceSuite) assertServiceUnexpose(c *gc.C, svc *state.Application) {
 	c.Assert(err, jc.ErrorIsNil)
 }
 
-func (s *serviceSuite) assertServiceUnexposeBlocked(c *gc.C, svc *state.Application, msg string) {
-	err := s.applicationAPI.Unexpose(params.ApplicationUnexpose{"dummy-service"})
+func (s *applicationSuite) assertApplicationUnexposeBlocked(c *gc.C, svc *state.Application, msg string) {
+	err := s.applicationAPI.Unexpose(params.ApplicationUnexpose{"dummy-application"})
 	s.AssertBlocked(c, err, msg)
 	err = svc.Destroy()
 	c.Assert(err, jc.ErrorIsNil)
 }
 
-func (s *serviceSuite) TestBlockDestroyServiceUnexpose(c *gc.C) {
-	svc := s.setupServiceUnexpose(c)
-	s.BlockDestroyModel(c, "TestBlockDestroyServiceUnexpose")
-	s.assertServiceUnexpose(c, svc)
+func (s *applicationSuite) TestBlockDestroyApplicationUnexpose(c *gc.C) {
+	svc := s.setupApplicationUnexpose(c)
+	s.BlockDestroyModel(c, "TestBlockDestroyApplicationUnexpose")
+	s.assertApplicationUnexpose(c, svc)
 }
 
-func (s *serviceSuite) TestBlockRemoveServiceUnexpose(c *gc.C) {
-	svc := s.setupServiceUnexpose(c)
-	s.BlockRemoveObject(c, "TestBlockRemoveServiceUnexpose")
-	s.assertServiceUnexpose(c, svc)
+func (s *applicationSuite) TestBlockRemoveApplicationUnexpose(c *gc.C) {
+	svc := s.setupApplicationUnexpose(c)
+	s.BlockRemoveObject(c, "TestBlockRemoveApplicationUnexpose")
+	s.assertApplicationUnexpose(c, svc)
 }
 
-func (s *serviceSuite) TestBlockChangesServiceUnexpose(c *gc.C) {
-	svc := s.setupServiceUnexpose(c)
-	s.BlockAllChanges(c, "TestBlockChangesServiceUnexpose")
-	s.assertServiceUnexposeBlocked(c, svc, "TestBlockChangesServiceUnexpose")
+func (s *applicationSuite) TestBlockChangesApplicationUnexpose(c *gc.C) {
+	svc := s.setupApplicationUnexpose(c)
+	s.BlockAllChanges(c, "TestBlockChangesApplicationUnexpose")
+	s.assertApplicationUnexposeBlocked(c, svc, "TestBlockChangesApplicationUnexpose")
 }
 
-var serviceDestroyTests = []struct {
-	about   string
-	service string
-	err     string
+var applicationDestroyTests = []struct {
+	about       string
+	application string
+	err         string
 }{
 	{
-		about:   "unknown application name",
-		service: "unknown-service",
-		err:     `application "unknown-service" not found`,
+		about:       "unknown application name",
+		application: "unknown-application",
+		err:         `application "unknown-application" not found`,
 	},
 	{
-		about:   "destroy a service",
-		service: "dummy-service",
+		about:       "destroy a application",
+		application: "dummy-application",
 	},
 	{
-		about:   "destroy an already destroyed service",
-		service: "dummy-service",
-		err:     `application "dummy-service" not found`,
+		about:       "destroy an already destroyed application",
+		application: "dummy-application",
+		err:         `application "dummy-application" not found`,
 	},
 }
 
-func (s *serviceSuite) TestServiceDestroy(c *gc.C) {
-	s.AddTestingService(c, "dummy-service", s.AddTestingCharm(c, "dummy"))
-	for i, t := range serviceDestroyTests {
+func (s *applicationSuite) TestApplicationDestroy(c *gc.C) {
+	s.AddTestingService(c, "dummy-application", s.AddTestingCharm(c, "dummy"))
+	for i, t := range applicationDestroyTests {
 		c.Logf("test %d. %s", i, t.about)
-		err := s.applicationAPI.Destroy(params.ApplicationDestroy{t.service})
+		err := s.applicationAPI.Destroy(params.ApplicationDestroy{t.application})
 		if t.err != "" {
 			c.Assert(err, gc.ErrorMatches, t.err)
 		} else {
@@ -2040,14 +2040,14 @@ func (s *serviceSuite) TestServiceDestroy(c *gc.C) {
 		}
 	}
 
-	// Now do Destroy on a service with units. Destroy will
-	// cause the service to be not-Alive, but will not remove its
+	// Now do Destroy on an application with units. Destroy will
+	// cause the application to be not-Alive, but will not remove its
 	// document.
 	s.AddTestingService(c, "wordpress", s.AddTestingCharm(c, "wordpress"))
-	serviceName := "wordpress"
-	application, err := s.State.Application(serviceName)
+	applicationName := "wordpress"
+	application, err := s.State.Application(applicationName)
 	c.Assert(err, jc.ErrorIsNil)
-	err = s.applicationAPI.Destroy(params.ApplicationDestroy{serviceName})
+	err = s.applicationAPI.Destroy(params.ApplicationDestroy{applicationName})
 	c.Assert(err, jc.ErrorIsNil)
 	err = application.Refresh()
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
@@ -2059,22 +2059,22 @@ func assertLife(c *gc.C, entity state.Living, life state.Life) {
 	c.Assert(entity.Life(), gc.Equals, life)
 }
 
-func (s *serviceSuite) TestBlockServiceDestroy(c *gc.C) {
-	s.AddTestingService(c, "dummy-service", s.AddTestingCharm(c, "dummy"))
+func (s *applicationSuite) TestBlockApplicationDestroy(c *gc.C) {
+	s.AddTestingService(c, "dummy-application", s.AddTestingCharm(c, "dummy"))
 
 	// block remove-objects
-	s.BlockRemoveObject(c, "TestBlockServiceDestroy")
-	err := s.applicationAPI.Destroy(params.ApplicationDestroy{"dummy-service"})
-	s.AssertBlocked(c, err, "TestBlockServiceDestroy")
+	s.BlockRemoveObject(c, "TestBlockApplicationDestroy")
+	err := s.applicationAPI.Destroy(params.ApplicationDestroy{"dummy-application"})
+	s.AssertBlocked(c, err, "TestBlockApplicationDestroy")
 	// Tests may have invalid application names.
-	application, err := s.State.Application("dummy-service")
+	application, err := s.State.Application("dummy-application")
 	if err == nil {
-		// For valid application names, check that service is alive :-)
+		// For valid application names, check that application is alive :-)
 		assertLife(c, application, state.Alive)
 	}
 }
 
-func (s *serviceSuite) TestDestroyPrincipalUnits(c *gc.C) {
+func (s *applicationSuite) TestDestroyPrincipalUnits(c *gc.C) {
 	wordpress := s.AddTestingService(c, "wordpress", s.AddTestingCharm(c, "wordpress"))
 	units := make([]*state.Unit, 5)
 	for i := range units {
@@ -2095,7 +2095,7 @@ func (s *serviceSuite) TestDestroyPrincipalUnits(c *gc.C) {
 	s.assertDestroyPrincipalUnits(c, units)
 }
 
-func (s *serviceSuite) TestDestroySubordinateUnits(c *gc.C) {
+func (s *applicationSuite) TestDestroySubordinateUnits(c *gc.C) {
 	wordpress := s.AddTestingService(c, "wordpress", s.AddTestingCharm(c, "wordpress"))
 	wordpress0, err := wordpress.AddUnit()
 	c.Assert(err, jc.ErrorIsNil)
@@ -2121,7 +2121,7 @@ func (s *serviceSuite) TestDestroySubordinateUnits(c *gc.C) {
 	s.assertDestroySubordinateUnits(c, wordpress0, logging0)
 }
 
-func (s *serviceSuite) assertDestroyPrincipalUnits(c *gc.C, units []*state.Unit) {
+func (s *applicationSuite) assertDestroyPrincipalUnits(c *gc.C, units []*state.Unit) {
 	// Destroy 2 of them; check they become Dying.
 	err := s.applicationAPI.DestroyUnits(params.DestroyApplicationUnits{
 		UnitNames: []string{"wordpress/0", "wordpress/1"},
@@ -2159,7 +2159,7 @@ func (s *serviceSuite) assertDestroyPrincipalUnits(c *gc.C, units []*state.Unit)
 	assertLife(c, units[4], state.Dying)
 }
 
-func (s *serviceSuite) setupDestroyPrincipalUnits(c *gc.C) []*state.Unit {
+func (s *applicationSuite) setupDestroyPrincipalUnits(c *gc.C) []*state.Unit {
 	units := make([]*state.Unit, 5)
 	wordpress := s.AddTestingService(c, "wordpress", s.AddTestingCharm(c, "wordpress"))
 	for i := range units {
@@ -2180,7 +2180,7 @@ func (s *serviceSuite) setupDestroyPrincipalUnits(c *gc.C) []*state.Unit {
 	return units
 }
 
-func (s *serviceSuite) assertBlockedErrorAndLiveliness(
+func (s *applicationSuite) assertBlockedErrorAndLiveliness(
 	c *gc.C,
 	err error,
 	msg string,
@@ -2196,7 +2196,7 @@ func (s *serviceSuite) assertBlockedErrorAndLiveliness(
 	assertLife(c, living4, state.Alive)
 }
 
-func (s *serviceSuite) TestBlockChangesDestroyPrincipalUnits(c *gc.C) {
+func (s *applicationSuite) TestBlockChangesDestroyPrincipalUnits(c *gc.C) {
 	units := s.setupDestroyPrincipalUnits(c)
 	s.BlockAllChanges(c, "TestBlockChangesDestroyPrincipalUnits")
 	err := s.applicationAPI.DestroyUnits(params.DestroyApplicationUnits{
@@ -2205,7 +2205,7 @@ func (s *serviceSuite) TestBlockChangesDestroyPrincipalUnits(c *gc.C) {
 	s.assertBlockedErrorAndLiveliness(c, err, "TestBlockChangesDestroyPrincipalUnits", units[0], units[1], units[2], units[3])
 }
 
-func (s *serviceSuite) TestBlockRemoveDestroyPrincipalUnits(c *gc.C) {
+func (s *applicationSuite) TestBlockRemoveDestroyPrincipalUnits(c *gc.C) {
 	units := s.setupDestroyPrincipalUnits(c)
 	s.BlockRemoveObject(c, "TestBlockRemoveDestroyPrincipalUnits")
 	err := s.applicationAPI.DestroyUnits(params.DestroyApplicationUnits{
@@ -2214,7 +2214,7 @@ func (s *serviceSuite) TestBlockRemoveDestroyPrincipalUnits(c *gc.C) {
 	s.assertBlockedErrorAndLiveliness(c, err, "TestBlockRemoveDestroyPrincipalUnits", units[0], units[1], units[2], units[3])
 }
 
-func (s *serviceSuite) TestBlockDestroyDestroyPrincipalUnits(c *gc.C) {
+func (s *applicationSuite) TestBlockDestroyDestroyPrincipalUnits(c *gc.C) {
 	units := s.setupDestroyPrincipalUnits(c)
 	s.BlockDestroyModel(c, "TestBlockDestroyDestroyPrincipalUnits")
 	err := s.applicationAPI.DestroyUnits(params.DestroyApplicationUnits{
@@ -2225,7 +2225,7 @@ func (s *serviceSuite) TestBlockDestroyDestroyPrincipalUnits(c *gc.C) {
 	assertLife(c, units[1], state.Dying)
 }
 
-func (s *serviceSuite) assertDestroySubordinateUnits(c *gc.C, wordpress0, logging0 *state.Unit) {
+func (s *applicationSuite) assertDestroySubordinateUnits(c *gc.C, wordpress0, logging0 *state.Unit) {
 	// Try to destroy the principal and the subordinate together; check it warns
 	// about the subordinate, but destroys the one it can. (The principal unit
 	// agent will be responsible for destroying the subordinate.)
@@ -2237,7 +2237,7 @@ func (s *serviceSuite) assertDestroySubordinateUnits(c *gc.C, wordpress0, loggin
 	assertLife(c, logging0, state.Alive)
 }
 
-func (s *serviceSuite) TestBlockRemoveDestroySubordinateUnits(c *gc.C) {
+func (s *applicationSuite) TestBlockRemoveDestroySubordinateUnits(c *gc.C) {
 	wordpress := s.AddTestingService(c, "wordpress", s.AddTestingCharm(c, "wordpress"))
 	wordpress0, err := wordpress.AddUnit()
 	c.Assert(err, jc.ErrorIsNil)
@@ -2272,7 +2272,7 @@ func (s *serviceSuite) TestBlockRemoveDestroySubordinateUnits(c *gc.C) {
 	assertLife(c, rel, state.Alive)
 }
 
-func (s *serviceSuite) TestBlockChangesDestroySubordinateUnits(c *gc.C) {
+func (s *applicationSuite) TestBlockChangesDestroySubordinateUnits(c *gc.C) {
 	wordpress := s.AddTestingService(c, "wordpress", s.AddTestingCharm(c, "wordpress"))
 	wordpress0, err := wordpress.AddUnit()
 	c.Assert(err, jc.ErrorIsNil)
@@ -2307,7 +2307,7 @@ func (s *serviceSuite) TestBlockChangesDestroySubordinateUnits(c *gc.C) {
 	assertLife(c, rel, state.Alive)
 }
 
-func (s *serviceSuite) TestBlockDestroyDestroySubordinateUnits(c *gc.C) {
+func (s *applicationSuite) TestBlockDestroyDestroySubordinateUnits(c *gc.C) {
 	wordpress := s.AddTestingService(c, "wordpress", s.AddTestingCharm(c, "wordpress"))
 	wordpress0, err := wordpress.AddUnit()
 	c.Assert(err, jc.ErrorIsNil)
@@ -2334,7 +2334,7 @@ func (s *serviceSuite) TestBlockDestroyDestroySubordinateUnits(c *gc.C) {
 	s.assertDestroySubordinateUnits(c, wordpress0, logging0)
 }
 
-func (s *serviceSuite) TestClientSetServiceConstraints(c *gc.C) {
+func (s *applicationSuite) TestClientSetApplicationConstraints(c *gc.C) {
 	application := s.AddTestingService(c, "dummy", s.AddTestingCharm(c, "dummy"))
 
 	// Update constraints for the application.
@@ -2349,7 +2349,7 @@ func (s *serviceSuite) TestClientSetServiceConstraints(c *gc.C) {
 	c.Assert(obtained, gc.DeepEquals, cons)
 }
 
-func (s *serviceSuite) setupSetServiceConstraints(c *gc.C) (*state.Application, constraints.Value) {
+func (s *applicationSuite) setupSetApplicationConstraints(c *gc.C) (*state.Application, constraints.Value) {
 	application := s.AddTestingService(c, "dummy", s.AddTestingCharm(c, "dummy"))
 	// Update constraints for the application.
 	cons, err := constraints.Parse("mem=4096", "cores=2")
@@ -2357,7 +2357,7 @@ func (s *serviceSuite) setupSetServiceConstraints(c *gc.C) (*state.Application, 
 	return application, cons
 }
 
-func (s *serviceSuite) assertSetServiceConstraints(c *gc.C, application *state.Application, cons constraints.Value) {
+func (s *applicationSuite) assertSetApplicationConstraints(c *gc.C, application *state.Application, cons constraints.Value) {
 	err := s.applicationAPI.SetConstraints(params.SetConstraints{ApplicationName: "dummy", Constraints: cons})
 	c.Assert(err, jc.ErrorIsNil)
 	// Ensure the constraints have been correctly updated.
@@ -2366,30 +2366,30 @@ func (s *serviceSuite) assertSetServiceConstraints(c *gc.C, application *state.A
 	c.Assert(obtained, gc.DeepEquals, cons)
 }
 
-func (s *serviceSuite) assertSetServiceConstraintsBlocked(c *gc.C, msg string, service *state.Application, cons constraints.Value) {
+func (s *applicationSuite) assertSetApplicationConstraintsBlocked(c *gc.C, msg string, application *state.Application, cons constraints.Value) {
 	err := s.applicationAPI.SetConstraints(params.SetConstraints{ApplicationName: "dummy", Constraints: cons})
 	s.AssertBlocked(c, err, msg)
 }
 
-func (s *serviceSuite) TestBlockDestroySetServiceConstraints(c *gc.C) {
-	svc, cons := s.setupSetServiceConstraints(c)
-	s.BlockDestroyModel(c, "TestBlockDestroySetServiceConstraints")
-	s.assertSetServiceConstraints(c, svc, cons)
+func (s *applicationSuite) TestBlockDestroySetApplicationConstraints(c *gc.C) {
+	svc, cons := s.setupSetApplicationConstraints(c)
+	s.BlockDestroyModel(c, "TestBlockDestroySetApplicationConstraints")
+	s.assertSetApplicationConstraints(c, svc, cons)
 }
 
-func (s *serviceSuite) TestBlockRemoveSetServiceConstraints(c *gc.C) {
-	svc, cons := s.setupSetServiceConstraints(c)
-	s.BlockRemoveObject(c, "TestBlockRemoveSetServiceConstraints")
-	s.assertSetServiceConstraints(c, svc, cons)
+func (s *applicationSuite) TestBlockRemoveSetApplicationConstraints(c *gc.C) {
+	svc, cons := s.setupSetApplicationConstraints(c)
+	s.BlockRemoveObject(c, "TestBlockRemoveSetApplicationConstraints")
+	s.assertSetApplicationConstraints(c, svc, cons)
 }
 
-func (s *serviceSuite) TestBlockChangesSetServiceConstraints(c *gc.C) {
-	svc, cons := s.setupSetServiceConstraints(c)
-	s.BlockAllChanges(c, "TestBlockChangesSetServiceConstraints")
-	s.assertSetServiceConstraintsBlocked(c, "TestBlockChangesSetServiceConstraints", svc, cons)
+func (s *applicationSuite) TestBlockChangesSetApplicationConstraints(c *gc.C) {
+	svc, cons := s.setupSetApplicationConstraints(c)
+	s.BlockAllChanges(c, "TestBlockChangesSetApplicationConstraints")
+	s.assertSetApplicationConstraintsBlocked(c, "TestBlockChangesSetApplicationConstraints", svc, cons)
 }
 
-func (s *serviceSuite) TestClientGetServiceConstraints(c *gc.C) {
+func (s *applicationSuite) TestClientGetApplicationConstraints(c *gc.C) {
 	application := s.AddTestingService(c, "dummy", s.AddTestingCharm(c, "dummy"))
 
 	// Set constraints for the application.
@@ -2404,7 +2404,7 @@ func (s *serviceSuite) TestClientGetServiceConstraints(c *gc.C) {
 	c.Assert(result.Constraints, gc.DeepEquals, cons)
 }
 
-func (s *serviceSuite) checkEndpoints(c *gc.C, mysqlAppName string, endpoints map[string]params.CharmRelation) {
+func (s *applicationSuite) checkEndpoints(c *gc.C, mysqlAppName string, endpoints map[string]params.CharmRelation) {
 	c.Assert(endpoints["wordpress"], gc.DeepEquals, params.CharmRelation{
 		Name:      "db",
 		Role:      "requirer",
@@ -2423,7 +2423,7 @@ func (s *serviceSuite) checkEndpoints(c *gc.C, mysqlAppName string, endpoints ma
 	})
 }
 
-func (s *serviceSuite) setupRelationScenario(c *gc.C) {
+func (s *applicationSuite) setupRelationScenario(c *gc.C) {
 	s.AddTestingService(c, "wordpress", s.AddTestingCharm(c, "wordpress"))
 	s.AddTestingService(c, "logging", s.AddTestingCharm(c, "logging"))
 	eps, err := s.State.InferEndpoints("logging", "wordpress")
@@ -2432,7 +2432,7 @@ func (s *serviceSuite) setupRelationScenario(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 }
 
-func (s *serviceSuite) assertAddRelation(c *gc.C, endpoints []string) {
+func (s *applicationSuite) assertAddRelation(c *gc.C, endpoints []string) {
 	s.setupRelationScenario(c)
 	res, err := s.applicationAPI.AddRelation(params.AddRelation{Endpoints: endpoints})
 	c.Assert(err, jc.ErrorIsNil)
@@ -2461,43 +2461,43 @@ func (s *serviceSuite) assertAddRelation(c *gc.C, endpoints []string) {
 	c.Assert(len(rels), gc.Equals, 1)
 }
 
-func (s *serviceSuite) TestSuccessfullyAddRelation(c *gc.C) {
+func (s *applicationSuite) TestSuccessfullyAddRelation(c *gc.C) {
 	endpoints := []string{"wordpress", "mysql"}
 	s.assertAddRelation(c, endpoints)
 }
 
-func (s *serviceSuite) TestBlockDestroyAddRelation(c *gc.C) {
+func (s *applicationSuite) TestBlockDestroyAddRelation(c *gc.C) {
 	s.BlockDestroyModel(c, "TestBlockDestroyAddRelation")
 	s.assertAddRelation(c, []string{"wordpress", "mysql"})
 }
-func (s *serviceSuite) TestBlockRemoveAddRelation(c *gc.C) {
+func (s *applicationSuite) TestBlockRemoveAddRelation(c *gc.C) {
 	s.BlockRemoveObject(c, "TestBlockRemoveAddRelation")
 	s.assertAddRelation(c, []string{"wordpress", "mysql"})
 }
 
-func (s *serviceSuite) TestBlockChangesAddRelation(c *gc.C) {
+func (s *applicationSuite) TestBlockChangesAddRelation(c *gc.C) {
 	s.AddTestingService(c, "wordpress", s.AddTestingCharm(c, "wordpress"))
 	s.BlockAllChanges(c, "TestBlockChangesAddRelation")
 	_, err := s.applicationAPI.AddRelation(params.AddRelation{Endpoints: []string{"wordpress", "mysql"}})
 	s.AssertBlocked(c, err, "TestBlockChangesAddRelation")
 }
 
-func (s *serviceSuite) TestSuccessfullyAddRelationSwapped(c *gc.C) {
-	// Show that the order of the services listed in the AddRelation call
-	// does not matter.  This is a repeat of the previous test with the service
+func (s *applicationSuite) TestSuccessfullyAddRelationSwapped(c *gc.C) {
+	// Show that the order of the applications listed in the AddRelation call
+	// does not matter.  This is a repeat of the previous test with the application
 	// names swapped.
 	endpoints := []string{"mysql", "wordpress"}
 	s.assertAddRelation(c, endpoints)
 }
 
-func (s *serviceSuite) TestCallWithOnlyOneEndpoint(c *gc.C) {
+func (s *applicationSuite) TestCallWithOnlyOneEndpoint(c *gc.C) {
 	s.AddTestingService(c, "wordpress", s.AddTestingCharm(c, "wordpress"))
 	endpoints := []string{"wordpress"}
 	_, err := s.applicationAPI.AddRelation(params.AddRelation{Endpoints: endpoints})
 	c.Assert(err, gc.ErrorMatches, "no relations found")
 }
 
-func (s *serviceSuite) TestCallWithOneEndpointTooMany(c *gc.C) {
+func (s *applicationSuite) TestCallWithOneEndpointTooMany(c *gc.C) {
 	s.AddTestingService(c, "wordpress", s.AddTestingCharm(c, "wordpress"))
 	s.AddTestingService(c, "logging", s.AddTestingCharm(c, "logging"))
 	endpoints := []string{"wordpress", "mysql", "logging"}
@@ -2505,7 +2505,7 @@ func (s *serviceSuite) TestCallWithOneEndpointTooMany(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, "cannot relate 3 endpoints")
 }
 
-func (s *serviceSuite) TestAddAlreadyAddedRelation(c *gc.C) {
+func (s *applicationSuite) TestAddAlreadyAddedRelation(c *gc.C) {
 	s.AddTestingService(c, "wordpress", s.AddTestingCharm(c, "wordpress"))
 	// Add a relation between wordpress and mysql.
 	endpoints := []string{"wordpress", "mysql"}
@@ -2558,26 +2558,26 @@ func remoteOffers() []params.ApplicationOffer {
 	}
 }
 
-func (s *serviceSuite) TestSuccessfullyAddRemoteRelation(c *gc.C) {
+func (s *applicationSuite) TestSuccessfullyAddRemoteRelation(c *gc.C) {
 	s.offersApiFactory.offers = remoteOffers()
 	endpoints := []string{"wordpress", "local:/u/me/prod/hosted-mysql"}
 	s.assertAddRelation(c, endpoints)
 }
 
-func (s *serviceSuite) TestSuccessfullyAddRemoteRelationWithRelName(c *gc.C) {
+func (s *applicationSuite) TestSuccessfullyAddRemoteRelationWithRelName(c *gc.C) {
 	s.offersApiFactory.offers = remoteOffers()
 	endpoints := []string{"wordpress", "local:/u/me/prod/hosted-mysql:server"}
 	s.assertAddRelation(c, endpoints)
 }
 
-func (s *serviceSuite) TestAddRemoteRelationOnlyOneEndpoint(c *gc.C) {
+func (s *applicationSuite) TestAddRemoteRelationOnlyOneEndpoint(c *gc.C) {
 	s.offersApiFactory.offers = remoteOffers()
 	endpoints := []string{"local:/u/me/prod/hosted-mysql"}
 	_, err := s.applicationAPI.AddRelation(params.AddRelation{endpoints})
 	c.Assert(err, gc.ErrorMatches, "no relations found")
 }
 
-func (s *serviceSuite) TestAlreadyAddedRemoteRelation(c *gc.C) {
+func (s *applicationSuite) TestAlreadyAddedRemoteRelation(c *gc.C) {
 	s.offersApiFactory.offers = remoteOffers()
 	// Add a relation between wordpress and mysql.
 	endpoints := []string{"wordpress", "local:/u/me/prod/hosted-mysql"}
@@ -2588,7 +2588,7 @@ func (s *serviceSuite) TestAlreadyAddedRemoteRelation(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, `cannot add relation "wordpress:db hosted-mysql:server": relation wordpress:db hosted-mysql:server already exists`)
 }
 
-func (s *serviceSuite) TestRemoteRelationInvalidEndpoint(c *gc.C) {
+func (s *applicationSuite) TestRemoteRelationInvalidEndpoint(c *gc.C) {
 	s.offersApiFactory.offers = remoteOffers()
 	s.AddTestingService(c, "wordpress", s.AddTestingCharm(c, "wordpress"))
 	endpoints := []string{"wordpress", "local:/u/me/prod/hosted-mysql:nope"}
@@ -2596,7 +2596,7 @@ func (s *serviceSuite) TestRemoteRelationInvalidEndpoint(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, `remote application "hosted-mysql" has no "nope" relation`)
 }
 
-func (s *serviceSuite) TestRemoteRelationNoMatchingEndpoint(c *gc.C) {
+func (s *applicationSuite) TestRemoteRelationNoMatchingEndpoint(c *gc.C) {
 	s.offersApiFactory.offers = []params.ApplicationOffer{
 		{
 			ApplicationURL:  "local:/u/me/prod/hosted-mysql",
@@ -2618,14 +2618,14 @@ func (s *serviceSuite) TestRemoteRelationNoMatchingEndpoint(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, "no relations found")
 }
 
-func (s *serviceSuite) TestRemoteRelationServiceNotFound(c *gc.C) {
+func (s *applicationSuite) TestRemoteRelationApplicationNotFound(c *gc.C) {
 	s.AddTestingService(c, "wordpress", s.AddTestingCharm(c, "wordpress"))
 	endpoints := []string{"wordpress", "local:/u/me/prod/unknown"}
 	_, err := s.applicationAPI.AddRelation(params.AddRelation{endpoints})
 	c.Assert(err, gc.ErrorMatches, `application offer "local:/u/me/prod/unknown" not found`)
 }
 
-func (s *serviceSuite) setupDestroyRelationScenario(c *gc.C, endpoints []string) *state.Relation {
+func (s *applicationSuite) setupDestroyRelationScenario(c *gc.C, endpoints []string) *state.Relation {
 	s.AddTestingService(c, "wordpress", s.AddTestingCharm(c, "wordpress"))
 	// Add a relation between the endpoints.
 	eps, err := s.State.InferEndpoints(endpoints...)
@@ -2635,41 +2635,41 @@ func (s *serviceSuite) setupDestroyRelationScenario(c *gc.C, endpoints []string)
 	return relation
 }
 
-func (s *serviceSuite) assertDestroyRelation(c *gc.C, endpoints []string) {
+func (s *applicationSuite) assertDestroyRelation(c *gc.C, endpoints []string) {
 	s.assertDestroyRelationSuccess(
 		c,
 		s.setupDestroyRelationScenario(c, endpoints),
 		endpoints)
 }
 
-func (s *serviceSuite) assertDestroyRelationSuccess(c *gc.C, relation *state.Relation, endpoints []string) {
+func (s *applicationSuite) assertDestroyRelationSuccess(c *gc.C, relation *state.Relation, endpoints []string) {
 	err := s.applicationAPI.DestroyRelation(params.DestroyRelation{Endpoints: endpoints})
 	c.Assert(err, jc.ErrorIsNil)
 	// Show that the relation was removed.
 	c.Assert(relation.Refresh(), jc.Satisfies, errors.IsNotFound)
 }
 
-func (s *serviceSuite) TestSuccessfulDestroyRelation(c *gc.C) {
+func (s *applicationSuite) TestSuccessfulDestroyRelation(c *gc.C) {
 	endpoints := []string{"wordpress", "mysql"}
 	s.assertDestroyRelation(c, endpoints)
 }
 
-func (s *serviceSuite) TestSuccessfullyDestroyRelationSwapped(c *gc.C) {
-	// Show that the order of the services listed in the DestroyRelation call
-	// does not matter.  This is a repeat of the previous test with the service
+func (s *applicationSuite) TestSuccessfullyDestroyRelationSwapped(c *gc.C) {
+	// Show that the order of the applications listed in the DestroyRelation call
+	// does not matter.  This is a repeat of the previous test with the application
 	// names swapped.
 	endpoints := []string{"mysql", "wordpress"}
 	s.assertDestroyRelation(c, endpoints)
 }
 
-func (s *serviceSuite) TestNoRelation(c *gc.C) {
+func (s *applicationSuite) TestNoRelation(c *gc.C) {
 	s.AddTestingService(c, "wordpress", s.AddTestingCharm(c, "wordpress"))
 	endpoints := []string{"wordpress", "mysql"}
 	err := s.applicationAPI.DestroyRelation(params.DestroyRelation{Endpoints: endpoints})
 	c.Assert(err, gc.ErrorMatches, `relation "wordpress:db mysql:server" not found`)
 }
 
-func (s *serviceSuite) TestAttemptDestroyingNonExistentRelation(c *gc.C) {
+func (s *applicationSuite) TestAttemptDestroyingNonExistentRelation(c *gc.C) {
 	s.AddTestingService(c, "wordpress", s.AddTestingCharm(c, "wordpress"))
 	s.AddTestingService(c, "riak", s.AddTestingCharm(c, "riak"))
 	endpoints := []string{"riak", "wordpress"}
@@ -2677,14 +2677,14 @@ func (s *serviceSuite) TestAttemptDestroyingNonExistentRelation(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, "no relations found")
 }
 
-func (s *serviceSuite) TestAttemptDestroyingWithOnlyOneEndpoint(c *gc.C) {
+func (s *applicationSuite) TestAttemptDestroyingWithOnlyOneEndpoint(c *gc.C) {
 	s.AddTestingService(c, "wordpress", s.AddTestingCharm(c, "wordpress"))
 	endpoints := []string{"wordpress"}
 	err := s.applicationAPI.DestroyRelation(params.DestroyRelation{Endpoints: endpoints})
 	c.Assert(err, gc.ErrorMatches, "no relations found")
 }
 
-func (s *serviceSuite) TestAttemptDestroyingPeerRelation(c *gc.C) {
+func (s *applicationSuite) TestAttemptDestroyingPeerRelation(c *gc.C) {
 	s.AddTestingService(c, "wordpress", s.AddTestingCharm(c, "wordpress"))
 	s.AddTestingService(c, "riak", s.AddTestingCharm(c, "riak"))
 
@@ -2693,7 +2693,7 @@ func (s *serviceSuite) TestAttemptDestroyingPeerRelation(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, `cannot destroy relation "riak:ring": is a peer relation`)
 }
 
-func (s *serviceSuite) TestAttemptDestroyingAlreadyDestroyedRelation(c *gc.C) {
+func (s *applicationSuite) TestAttemptDestroyingAlreadyDestroyedRelation(c *gc.C) {
 	s.AddTestingService(c, "wordpress", s.AddTestingCharm(c, "wordpress"))
 
 	// Add a relation between wordpress and mysql.
@@ -2712,7 +2712,7 @@ func (s *serviceSuite) TestAttemptDestroyingAlreadyDestroyedRelation(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, `relation "wordpress:db mysql:server" not found`)
 }
 
-func (s *serviceSuite) TestBlockRemoveDestroyRelation(c *gc.C) {
+func (s *applicationSuite) TestBlockRemoveDestroyRelation(c *gc.C) {
 	endpoints := []string{"wordpress", "mysql"}
 	relation := s.setupDestroyRelationScenario(c, endpoints)
 	// block remove-objects
@@ -2722,7 +2722,7 @@ func (s *serviceSuite) TestBlockRemoveDestroyRelation(c *gc.C) {
 	assertLife(c, relation, state.Alive)
 }
 
-func (s *serviceSuite) TestBlockChangeDestroyRelation(c *gc.C) {
+func (s *applicationSuite) TestBlockChangeDestroyRelation(c *gc.C) {
 	endpoints := []string{"wordpress", "mysql"}
 	relation := s.setupDestroyRelationScenario(c, endpoints)
 	s.BlockAllChanges(c, "TestBlockChangeDestroyRelation")
@@ -2731,7 +2731,7 @@ func (s *serviceSuite) TestBlockChangeDestroyRelation(c *gc.C) {
 	assertLife(c, relation, state.Alive)
 }
 
-func (s *serviceSuite) TestBlockDestroyDestroyRelation(c *gc.C) {
+func (s *applicationSuite) TestBlockDestroyDestroyRelation(c *gc.C) {
 	s.BlockDestroyModel(c, "TestBlockDestroyDestroyRelation")
 	endpoints := []string{"wordpress", "mysql"}
 	s.assertDestroyRelation(c, endpoints)

--- a/apiserver/application/charmstore.go
+++ b/apiserver/application/charmstore.go
@@ -93,6 +93,11 @@ func AddCharmWithAuthorization(st *state.State, args params.AddCharmWithAuthoriz
 	if !ok {
 		return errors.Errorf("expected a charm archive, got %T", downloadedCharm)
 	}
+
+	// Clean up the downloaded charm - we don't need to cache it in
+	// the filesystem as well as in blob storage.
+	defer os.Remove(downloadedBundle.Path)
+
 	archive, err := os.Open(downloadedBundle.Path)
 	if err != nil {
 		return errors.Annotate(err, "cannot read downloaded charm")


### PR DESCRIPTION
## Description of change

When the charmrepo downloads charm archives it stores them in a cache directory. On the controller this is unnecessary, since the archive is loaded into the blobstore (which is available to all of the controllers in HA, rather than just the one that downloaded the charm initially). Additionally, if a controller had had a large number of models that had been migrated away or otherwise removed, the charms used by those models would still be taking up space on the filesystem.

Remove the charm from the cache once it's been stored.

A cleaner way to do this would be to have the cache dir be an attribute of the CharmStore. The store would get a Cleanup method that would be called when the archive is finished with and would delete the charm dir. Then the controller code wouldn't set a cache dir at all - it would just be a temp directory, and would be removed when the charm was finished with. I haven't done that yet because I want to talk to @rogpeppe about what would work for other places that use the charm store.

Also includes a driveby to rename service to application in the apiserver/application unit tests.

## QA steps
* Bootstrap a controller and add a model
* Deploy ubuntu
* Check that the charm cache directory (/var/lib/juju/charmcache) is empty on the controller.

## Bug reference

Part of the fix for https://bugs.launchpad.net/juju/+bug/1579976