### PR TITLE
Fixes "not valid tag" when listing models.

### DIFF
--- a/cmd/juju/controller/listmodels.go
+++ b/cmd/juju/controller/listmodels.go
@@ -212,7 +212,7 @@ func (c *modelsCommand) getModelInfo(userModels []base.UserModel) ([]params.Mode
 		return nil, errors.Trace(err)
 	}
 
-	info := make([]params.ModelInfo, len(tags))
+	info := []params.ModelInfo{}
 	for i, result := range results {
 		if result.Error != nil {
 			if params.IsCodeUnauthorized(result.Error) {
@@ -226,7 +226,7 @@ func (c *modelsCommand) getModelInfo(userModels []base.UserModel) ([]params.Mode
 				userModels[i].UUID, userModels[i].Name,
 			)
 		}
-		info[i] = *result.Result
+		info = append(info, *result.Result)
 	}
 	return info, nil
 }


### PR DESCRIPTION
## Please provide the following details to expedite Pull Request review:

----

## Description of change

A collection of models was constructed based on all controller models with predefined length. This caused issues in situations where models were not permitted to be seen by the current users or were being destroyed. With previous implementation, we'd end up with empty array elements and would fail when trying to parse model tags.

## QA steps

This is mostly timing related issue - models need to be destroyed or user permissions changed in the middle of 'juju models' call, specifically in between listing of models and iteration over the resulting collection to get model details. 
CI has a functional test that tends to hit the soft spot frequently.

All unit tests pass.

## Documentation changes

n/a

## Bug reference

The problem is hard to track but was observed in several bugs:
- https://bugs.launchpad.net/juju/+bug/1643076
- https://bugs.launchpad.net/juju/+bug/1643943
- https://bugs.launchpad.net/juju/+bug/1634926
