### PR TITLE
The firewaller creates ingress rules for remote applications

### DIFF
--- a/api/firewaller/firewaller.go
+++ b/api/firewaller/firewaller.go
@@ -117,3 +117,16 @@ func (st *State) WatchOpenedPorts() (watcher.StringsWatcher, error) {
 	w := apiwatcher.NewStringsWatcher(st.facade.RawAPICaller(), result)
 	return w, nil
 }
+
+// Relation provides access to methods of a state.Relation through the
+// facade.
+func (st *State) Relation(tag names.RelationTag) (*Relation, error) {
+	life, err := st.life(tag)
+	if err != nil {
+		return nil, err
+	}
+	return &Relation{
+		tag:  tag,
+		life: life,
+	}, nil
+}

--- a/api/firewaller/firewaller_test.go
+++ b/api/firewaller/firewaller_test.go
@@ -25,6 +25,7 @@ type firewallerSuite struct {
 	application *state.Application
 	charm       *state.Charm
 	units       []*state.Unit
+	relations   []*state.Relation
 
 	firewaller *firewaller.State
 }
@@ -67,6 +68,15 @@ func (s *firewallerSuite) SetUpTest(c *gc.C) {
 		err = s.units[i].AssignToMachine(s.machines[i])
 		c.Check(err, jc.ErrorIsNil)
 	}
+
+	// Create a relation.
+	s.AddTestingService(c, "mysql", s.AddTestingCharm(c, "mysql"))
+	eps, err := s.State.InferEndpoints("wordpress", "mysql")
+	c.Assert(err, jc.ErrorIsNil)
+
+	s.relations = make([]*state.Relation, 1)
+	s.relations[0], err = s.State.AddRelation(eps...)
+	c.Assert(err, jc.ErrorIsNil)
 
 	// Create the firewaller API facade.
 	s.firewaller = firewaller.NewState(s.st)

--- a/api/firewaller/relation.go
+++ b/api/firewaller/relation.go
@@ -1,0 +1,26 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package firewaller
+
+import (
+	"gopkg.in/juju/names.v2"
+
+	"github.com/juju/juju/apiserver/params"
+)
+
+// Relation represents a juju relation as seen by the firewaller worker.
+type Relation struct {
+	tag  names.RelationTag
+	life params.Life
+}
+
+// Tag returns the relation tag.
+func (r *Relation) Tag() names.RelationTag {
+	return r.tag
+}
+
+// Life returns the relation's life cycle value.
+func (r *Relation) Life() params.Life {
+	return r.life
+}

--- a/api/firewaller/relation_test.go
+++ b/api/firewaller/relation_test.go
@@ -1,0 +1,51 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package firewaller_test
+
+import (
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/names.v2"
+
+	"github.com/juju/juju/api/firewaller"
+	"github.com/juju/juju/apiserver/params"
+)
+
+type relationSuite struct {
+	firewallerSuite
+
+	apiRelation *firewaller.Relation
+}
+
+var _ = gc.Suite(&relationSuite{})
+
+func (s *relationSuite) SetUpTest(c *gc.C) {
+	s.firewallerSuite.SetUpTest(c)
+
+	var err error
+	s.apiRelation, err = s.firewaller.Relation(s.relations[0].Tag().(names.RelationTag))
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *relationSuite) TearDownTest(c *gc.C) {
+	s.firewallerSuite.TearDownTest(c)
+}
+
+func (s *relationSuite) TestRelation(c *gc.C) {
+	_, err := s.firewaller.Relation(names.NewRelationTag("foo:db bar:db"))
+	c.Assert(err, gc.ErrorMatches, `relation "foo:db bar:db" not found`)
+	c.Assert(err, jc.Satisfies, params.IsCodeNotFound)
+
+	apiRelation0, err := s.firewaller.Relation(s.relations[0].Tag().(names.RelationTag))
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(apiRelation0, gc.NotNil)
+}
+
+func (s *relationSuite) TestTag(c *gc.C) {
+	c.Assert(s.apiRelation.Tag(), gc.Equals, names.NewRelationTag(s.relations[0].String()))
+}
+
+func (s *relationSuite) TestLife(c *gc.C) {
+	c.Assert(s.apiRelation.Life(), gc.Equals, params.Alive)
+}

--- a/api/remoterelations/remoterelations.go
+++ b/api/remoterelations/remoterelations.go
@@ -151,6 +151,24 @@ func (c *Client) Relations(keys []string) ([]params.RemoteRelationResult, error)
 	return results.Results, nil
 }
 
+// IngressSubnetsForRelation returns any CIDRs for which ingress is required to allow
+// the specified relation to properly function.
+func (c *Client) IngressSubnetsForRelation(key string) (*params.IngressSubnetInfo, error) {
+	args := params.Entities{Entities: []params.Entity{{Tag: names.NewRelationTag(key).String()}}}
+	var results params.IngressSubnetResults
+	err := c.facade.FacadeCall("IngressSubnetsForRelation", args, &results)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	if len(results.Results) != 1 {
+		return nil, errors.Errorf("expected %d result(s), got %d", 1, len(results.Results))
+	}
+	if err := results.Results[0].Error; err != nil {
+		return nil, err
+	}
+	return results.Results[0].Result, nil
+}
+
 // RemoteApplications returns the current state of the remote applications with
 // the specified names in the local model.
 func (c *Client) RemoteApplications(applications []string) ([]params.RemoteApplicationResult, error) {

--- a/api/remoterelations/remoterelations_test.go
+++ b/api/remoterelations/remoterelations_test.go
@@ -28,6 +28,29 @@ func (s *remoteRelationsSuite) TestNewClient(c *gc.C) {
 	c.Assert(client, gc.NotNil)
 }
 
+func (s *remoteRelationsSuite) TestIngressSubnetsForRelation(c *gc.C) {
+	var callCount int
+	apiCaller := testing.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
+		c.Check(objType, gc.Equals, "RemoteRelations")
+		c.Check(version, gc.Equals, 0)
+		c.Check(id, gc.Equals, "")
+		c.Check(request, gc.Equals, "IngressSubnetsForRelation")
+		c.Assert(arg, gc.DeepEquals, params.Entities{Entities: []params.Entity{{Tag: "relation-db2.db#django.db"}}})
+		c.Assert(result, gc.FitsTypeOf, &params.IngressSubnetResults{})
+		*(result.(*params.IngressSubnetResults)) = params.IngressSubnetResults{
+			Results: []params.IngressSubnetResult{{
+				Error: &params.Error{Message: "FAIL"},
+			}},
+		}
+		callCount++
+		return nil
+	})
+	client := remoterelations.NewClient(apiCaller)
+	_, err := client.IngressSubnetsForRelation("db2:db django:db")
+	c.Check(err, gc.ErrorMatches, "FAIL")
+	c.Check(callCount, gc.Equals, 1)
+}
+
 func (s *remoteRelationsSuite) TestWatchRemoteApplications(c *gc.C) {
 	var callCount int
 	apiCaller := testing.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {

--- a/apiserver/application/application.go
+++ b/apiserver/application/application.go
@@ -726,7 +726,6 @@ func (api *API) AddRelation(args params.AddRelation) (params.AddRelationResults,
 	}
 
 	endpoints := make([]string, len(args.Endpoints))
-	var offer *offeredApplication
 	// We may have a remote application passed in as the endpoint spec.
 	// We'll iterate the endpoints to check.
 	for i, ep := range args.Endpoints {
@@ -753,7 +752,7 @@ func (api *API) AddRelation(args params.AddRelation) (params.AddRelationResults,
 		}
 		// Save the remote application details into state.
 		// TODO(wallyworld) - allow app name to be aliased
-		remoteApp, sourceModel, err := api.processRemoteApplication(*url, url.ApplicationName)
+		remoteApp, err := api.processRemoteApplication(*url, url.ApplicationName)
 		if err != nil {
 			return params.AddRelationResults{}, errors.Trace(err)
 		}
@@ -762,11 +761,6 @@ func (api *API) AddRelation(args params.AddRelation) (params.AddRelationResults,
 		endpoints[i] = remoteApp.Name()
 		if relName != "" {
 			endpoints[i] = remoteApp.Name() + ":" + relName
-		}
-		// Record details of the offering application for later use.
-		offer = &offeredApplication{
-			offerName:   url.ApplicationName,
-			sourceModel: sourceModel,
 		}
 	}
 
@@ -777,51 +771,6 @@ func (api *API) AddRelation(args params.AddRelation) (params.AddRelationResults,
 	rel, err := api.backend.AddRelation(inEps...)
 	if err != nil {
 		return params.AddRelationResults{}, errors.Trace(err)
-	}
-
-	// For remote applications, we need to ensure the offering application
-	// is exposed to the models which consume it, and vice versa.
-	// There can only be one remote application in a relation.
-	// If we have added a relation via a URL, we already have the offer details.
-	// But we may have added a relation to a consumed application so we
-	// need to check the endpoint application names to see if there's a
-	// consumed application we are relating to.
-	if offer == nil {
-		for _, ep := range inEps {
-			app, err := api.backend.RemoteApplication(ep.ApplicationName)
-			if errors.IsNotFound(err) {
-				continue
-			}
-			if err != nil {
-				return params.AddRelationResults{}, errors.Trace(err)
-			}
-			// Record details of the offering application for later use.
-			offer = &offeredApplication{
-				offerName:   app.OfferName(),
-				sourceModel: app.SourceModel(),
-			}
-			break
-		}
-	}
-	if offer != nil {
-		// Expose the offering app.
-		if err := api.exposeOfferedApplication(offer); err != nil {
-			return params.AddRelationResults{}, errors.Trace(err)
-		}
-		// Expose the consuming app.
-		for _, ep := range inEps {
-			app, err := api.backend.Application(ep.ApplicationName)
-			if errors.IsNotFound(err) {
-				continue
-			}
-			if err != nil {
-				return params.AddRelationResults{}, errors.Trace(err)
-			}
-			// TODO(wallyworld) - we want to only expose to the offering model, not the world
-			if err := app.SetExposed(); err != nil {
-				return params.AddRelationResults{}, errors.Trace(err)
-			}
-		}
 	}
 
 	outEps := make(map[string]params.CharmRelation)
@@ -842,48 +791,22 @@ func (api *API) AddRelation(args params.AddRelation) (params.AddRelationResults,
 	return params.AddRelationResults{Endpoints: outEps}, nil
 }
 
-type offeredApplication struct {
-	sourceModel names.ModelTag
-	offerName   string
-}
-
-// exposeOfferedApplication ensures that the remote applications in this model
-// can reach the offered application in another model.
-func (api *API) exposeOfferedApplication(offer *offeredApplication) error {
-	app, st, err := api.sameControllerOfferedApplication(offer.sourceModel, offer.offerName)
-	// TODO(wallyworld) - we don't yet map offer name to application
-	// but this is only mandatory for offer URLs which are deprecated for now.
-	if errors.IsNotFound(err) {
-		return nil
-	}
-	if err != nil {
-		return errors.Trace(err)
-	}
-	defer st.Close()
-
-	// TODO(wallyworld) - we want to only expose to the consuming model, not the world
-	if err := app.SetExposed(); err != nil {
-		return errors.Trace(err)
-	}
-	return nil
-}
-
 // processRemoteApplication takes a remote application URL and retrieves or confirms the the details
 // of the application and endpoint. These details are saved to the state model so relations to
 // the remote application can be created.
-func (api *API) processRemoteApplication(url jujucrossmodel.ApplicationURL, alias string) (*state.RemoteApplication, names.ModelTag, error) {
+func (api *API) processRemoteApplication(url jujucrossmodel.ApplicationURL, alias string) (*state.RemoteApplication, error) {
 	// The application URL is either for an application in another model on this controller,
 	// or is for an application offer contained in a directory.
 	if url.Directory == "" {
 		if url.ModelName == "" {
-			return nil, names.ModelTag{}, errors.Errorf("missing model name in URL %q", url.String())
+			return nil, errors.Errorf("missing model name in URL %q", url.String())
 		}
 		return api.processSameControllerRemoteApplication(url, alias)
 	}
 
 	offersAPI, err := api.applicationOffersAPIFactory.ApplicationOffers(url.Directory)
 	if err != nil {
-		return nil, names.ModelTag{}, errors.Trace(err)
+		return nil, errors.Trace(err)
 	}
 	offers, err := offersAPI.ListOffers(params.OfferFilters{
 		Directory: url.Directory,
@@ -894,21 +817,21 @@ func (api *API) processRemoteApplication(url jujucrossmodel.ApplicationURL, alia
 		},
 	})
 	if err != nil || offers.Error != nil {
-		return nil, names.ModelTag{}, errors.Trace(err)
+		return nil, errors.Trace(err)
 	}
 	// The offers query succeeded but there were no offers matching the URL.
 	if len(offers.Offers) == 0 {
-		return nil, names.ModelTag{}, errors.NotFoundf("application offer %q", url.String())
+		return nil, errors.NotFoundf("application offer %q", url.String())
 	}
 
 	// Create a remote application entry in the model for the consumed service.
 	offer := offers.Offers[0]
 	sourceModelTag, err := names.ParseModelTag(offer.SourceModelTag)
 	if err != nil {
-		return nil, names.ModelTag{}, errors.Trace(err)
+		return nil, errors.Trace(err)
 	}
 	remoteApp, err := api.saveRemoteApplication(sourceModelTag, url.ApplicationName, url.ApplicationName, url.String(), offer.Endpoints)
-	return remoteApp, sourceModelTag, err
+	return remoteApp, err
 }
 
 func (api *API) sameControllerSourceModel(userName, modelName string) (names.ModelTag, error) {
@@ -935,7 +858,7 @@ func (api *API) sameControllerSourceModel(userName, modelName string) (names.Mod
 
 // processSameControllerRemoteApplication handles the case where we have an application
 // from another model on the same controller.
-func (api *API) processSameControllerRemoteApplication(url jujucrossmodel.ApplicationURL, alias string) (*state.RemoteApplication, names.ModelTag, error) {
+func (api *API) processSameControllerRemoteApplication(url jujucrossmodel.ApplicationURL, alias string) (*state.RemoteApplication, error) {
 	// The user name is either specified in URL, or else we default to
 	// the logged in user.
 	userName := url.User
@@ -945,17 +868,17 @@ func (api *API) processSameControllerRemoteApplication(url jujucrossmodel.Applic
 	// To relate to an application in another model, the user needs at least write permission.
 	sourceModelTag, err := api.sameControllerSourceModel(userName, url.ModelName)
 	if err != nil {
-		return nil, names.ModelTag{}, errors.Trace(err)
+		return nil, errors.Trace(err)
 	}
 	app, closer, err := api.sameControllerOfferedApplication(sourceModelTag, url.ApplicationName)
 	if err != nil {
-		return nil, names.ModelTag{}, errors.Trace(err)
+		return nil, errors.Trace(err)
 	}
 	defer closer.Close()
 
 	eps, err := app.Endpoints()
 	if err != nil {
-		return nil, names.ModelTag{}, errors.Trace(err)
+		return nil, errors.Trace(err)
 	}
 	endpoints := make([]params.RemoteEndpoint, len(eps))
 	for i, ep := range eps {
@@ -972,7 +895,7 @@ func (api *API) processSameControllerRemoteApplication(url jujucrossmodel.Applic
 		appName = url.ApplicationName
 	}
 	remoteApp, err := api.saveRemoteApplication(sourceModelTag, appName, url.ApplicationName, url.String(), endpoints)
-	return remoteApp, sourceModelTag, err
+	return remoteApp, err
 }
 
 // sameControllerOfferedApplication looks the specified model on the same controller
@@ -1205,7 +1128,7 @@ func (api *API) consumeOne(possibleURL, alias string) (string, error) {
 	if url.HasEndpoint() {
 		return "", errors.Errorf("remote application %q shouldn't include endpoint", url)
 	}
-	remoteApp, _, err := api.processRemoteApplication(*url, alias)
+	remoteApp, err := api.processRemoteApplication(*url, alias)
 	if err != nil {
 		return "", errors.Trace(err)
 	}

--- a/apiserver/application/application_test.go
+++ b/apiserver/application/application_test.go
@@ -2609,19 +2609,13 @@ func (s *serviceSuite) addTestingCharmOtherModel(c *gc.C, name string) *state.Ch
 }
 
 func (s *serviceSuite) TestSuccessfullyAddRemoteRelationOtherModel(c *gc.C) {
-	mysql, err := s.otherModel.AddApplication(state.AddApplicationArgs{
+	_, err := s.otherModel.AddApplication(state.AddApplicationArgs{
 		Name:  "othermysql",
 		Charm: s.addTestingCharmOtherModel(c, "mysql"),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	endpoints := []string{"wordpress", "othermodel.othermysql"}
 	s.assertAddRelation(c, endpoints)
-	err = mysql.Refresh()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(mysql.IsExposed(), jc.IsTrue)
-	wp, err := s.State.Application("wordpress")
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(wp.IsExposed(), jc.IsTrue)
 }
 
 func (s *serviceSuite) TestSuccessfullyAddRemoteRelationWithRelName(c *gc.C) {
@@ -2631,19 +2625,13 @@ func (s *serviceSuite) TestSuccessfullyAddRemoteRelationWithRelName(c *gc.C) {
 }
 
 func (s *serviceSuite) TestSuccessfullyAddRemoteRelationOtherModelWithRelName(c *gc.C) {
-	mysql, err := s.otherModel.AddApplication(state.AddApplicationArgs{
+	_, err := s.otherModel.AddApplication(state.AddApplicationArgs{
 		Name:  "othermysql",
 		Charm: s.addTestingCharmOtherModel(c, "mysql"),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	endpoints := []string{"wordpress", "othermodel.othermysql:server"}
 	s.assertAddRelation(c, endpoints)
-	err = mysql.Refresh()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(mysql.IsExposed(), jc.IsTrue)
-	wp, err := s.State.Application("wordpress")
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(wp.IsExposed(), jc.IsTrue)
 }
 
 func (s *serviceSuite) TestAddRemoteRelationOnlyOneEndpoint(c *gc.C) {
@@ -2701,7 +2689,7 @@ func (s *serviceSuite) TestRemoteRelationInvalidEndpoint(c *gc.C) {
 }
 
 func (s *serviceSuite) TestRemoteRelationInvalidEndpointOtherModel(c *gc.C) {
-	mysql, err := s.otherModel.AddApplication(state.AddApplicationArgs{
+	_, err := s.otherModel.AddApplication(state.AddApplicationArgs{
 		Name:  "othermysql",
 		Charm: s.addTestingCharmOtherModel(c, "mysql"),
 	})
@@ -2710,12 +2698,6 @@ func (s *serviceSuite) TestRemoteRelationInvalidEndpointOtherModel(c *gc.C) {
 	endpoints := []string{"wordpress", "othermodel.othermysql:nope"}
 	_, err = s.applicationAPI.AddRelation(params.AddRelation{endpoints})
 	c.Assert(err, gc.ErrorMatches, `remote application "othermysql" has no "nope" relation`)
-	err = mysql.Refresh()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(mysql.IsExposed(), jc.IsFalse)
-	wp, err := s.State.Application("wordpress")
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(wp.IsExposed(), jc.IsFalse)
 }
 
 func (s *serviceSuite) TestRemoteRelationNoMatchingEndpoint(c *gc.C) {
@@ -2741,7 +2723,7 @@ func (s *serviceSuite) TestRemoteRelationNoMatchingEndpoint(c *gc.C) {
 }
 
 func (s *serviceSuite) TestRemoteRelationNoMatchingEndpointOtherModel(c *gc.C) {
-	mysql, err := s.otherModel.AddApplication(state.AddApplicationArgs{
+	_, err := s.otherModel.AddApplication(state.AddApplicationArgs{
 		Name:  "dummy",
 		Charm: s.addTestingCharmOtherModel(c, "dummy"),
 	})
@@ -2750,12 +2732,6 @@ func (s *serviceSuite) TestRemoteRelationNoMatchingEndpointOtherModel(c *gc.C) {
 	endpoints := []string{"wordpress", "othermodel.dummy"}
 	_, err = s.applicationAPI.AddRelation(params.AddRelation{endpoints})
 	c.Assert(err, gc.ErrorMatches, "no relations found")
-	err = mysql.Refresh()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(mysql.IsExposed(), jc.IsFalse)
-	wp, err := s.State.Application("wordpress")
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(wp.IsExposed(), jc.IsFalse)
 }
 
 func (s *serviceSuite) TestRemoteRelationApplicationOfferNotFound(c *gc.C) {

--- a/apiserver/firewaller/firewaller.go
+++ b/apiserver/firewaller/firewaller.go
@@ -56,12 +56,13 @@ func NewFirewallerAPI(
 	accessUnit := common.AuthFuncForTagKind(names.UnitTagKind)
 	accessApplication := common.AuthFuncForTagKind(names.ApplicationTagKind)
 	accessMachine := common.AuthFuncForTagKind(names.MachineTagKind)
-	accessUnitApplicationOrMachine := common.AuthAny(accessUnit, accessApplication, accessMachine)
+	accessRelation := common.AuthFuncForTagKind(names.RelationTagKind)
+	accessUnitApplicationOrMachineOrRelation := common.AuthAny(accessUnit, accessApplication, accessMachine, accessRelation)
 
 	// Life() is supported for units, applications or machines.
 	lifeGetter := common.NewLifeGetter(
 		st,
-		accessUnitApplicationOrMachine,
+		accessUnitApplicationOrMachineOrRelation,
 	)
 	// ModelConfig() and WatchForModelConfigChanges() are allowed
 	// with unrestriced access.

--- a/apiserver/firewaller/firewaller_base_test.go
+++ b/apiserver/firewaller/firewaller_base_test.go
@@ -24,10 +24,11 @@ import (
 type firewallerBaseSuite struct {
 	testing.JujuConnSuite
 
-	machines []*state.Machine
-	service  *state.Application
-	charm    *state.Charm
-	units    []*state.Unit
+	machines  []*state.Machine
+	service   *state.Application
+	charm     *state.Charm
+	units     []*state.Unit
+	relations []*state.Relation
 
 	authorizer apiservertesting.FakeAuthorizer
 	resources  *common.Resources
@@ -58,6 +59,15 @@ func (s *firewallerBaseSuite) setUpTest(c *gc.C) {
 		c.Check(err, jc.ErrorIsNil)
 		s.units = append(s.units, unit)
 	}
+
+	// Create a relation.
+	s.AddTestingService(c, "mysql", s.AddTestingCharm(c, "mysql"))
+	eps, err := s.State.InferEndpoints("wordpress", "mysql")
+	c.Assert(err, jc.ErrorIsNil)
+
+	s.relations = make([]*state.Relation, 1)
+	s.relations[0], err = s.State.AddRelation(eps...)
+	c.Assert(err, jc.ErrorIsNil)
 
 	// Create a FakeAuthorizer so we can check permissions,
 	// set up assuming we logged in as the environment manager.
@@ -101,6 +111,7 @@ func (s *firewallerBaseSuite) testLife(
 		{Tag: s.machines[0].Tag().String()},
 		{Tag: s.machines[1].Tag().String()},
 		{Tag: s.machines[2].Tag().String()},
+		{Tag: s.relations[0].Tag().String()},
 	}})
 	result, err := facade.Life(args)
 	c.Assert(err, jc.ErrorIsNil)
@@ -108,6 +119,7 @@ func (s *firewallerBaseSuite) testLife(
 		Results: []params.LifeResult{
 			{Life: "alive"},
 			{Life: "dead"},
+			{Life: "alive"},
 			{Life: "alive"},
 			{Error: apiservertesting.NotFoundError("machine 42")},
 			{Error: apiservertesting.NotFoundError(`unit "foo/0"`)},

--- a/apiserver/params/crossmodel.go
+++ b/apiserver/params/crossmodel.go
@@ -266,6 +266,7 @@ type RemoteRelation struct {
 	ApplicationName    string         `json:"application-name"`
 	Endpoint           RemoteEndpoint `json:"endpoint"`
 	RemoteEndpointName string         `json:"remote-endpoint-name"`
+	SourceModelUUID    string         `json:"source-model-uuid"`
 }
 
 // RemoteRelationResult holds a remote relation and an error.
@@ -471,4 +472,25 @@ type ConsumeApplicationResult struct {
 // ConsumeApplicationResults is the result of a Consume call.
 type ConsumeApplicationResults struct {
 	Results []ConsumeApplicationResult `json:"results"`
+}
+
+// IngressSubnetInfo is the result of an IngressSubnetsForRelation call.
+type IngressSubnetInfo struct {
+	// ApplicationName is the name of the local application.
+	ApplicationName string `json:"application-name"`
+
+	// CIDRs is the set if CIDRs which need to be allowed ingress to the application.
+	CIDRs []string `json:"cidrs,omitempty"`
+}
+
+// IngressSubnetResult holds ingress network information and an error.
+type IngressSubnetResult struct {
+	Error  *Error             `json:"error,omitempty"`
+	Result *IngressSubnetInfo `json:"result,omitempty"`
+}
+
+// IngressSubnetResults holds the result of an API call that returns
+// information about ingress networks for multiple remote relations.
+type IngressSubnetResults struct {
+	Results []IngressSubnetResult `json:"results"`
 }

--- a/apiserver/remoterelations/mock_test.go
+++ b/apiserver/remoterelations/mock_test.go
@@ -20,6 +20,14 @@ import (
 	coretesting "github.com/juju/juju/testing"
 )
 
+type mockStatePool struct {
+	st *mockState
+}
+
+func (st *mockStatePool) Get(modelUUID string) (remoterelations.RemoteRelationsState, func(), error) {
+	return st.st, func() {}, nil
+}
+
 type mockState struct {
 	testing.Stub
 	relations                    map[string]*mockRelation
@@ -29,6 +37,7 @@ type mockState struct {
 	remoteRelationsWatcher       *mockStringsWatcher
 	applicationRelationsWatchers map[string]*mockStringsWatcher
 	remoteEntities               map[names.Tag]string
+	subnets                      []remoterelations.Subnet
 }
 
 func newMockState() *mockState {
@@ -53,6 +62,11 @@ func (st *mockState) ListOffers(filter ...crossmodel.OfferedApplicationFilter) (
 
 func (st *mockState) ModelUUID() string {
 	return coretesting.ModelTag.Id()
+}
+
+func (st *mockState) AllSubnets() ([]remoterelations.Subnet, error) {
+	st.MethodCall(st, "AllSubnets")
+	return st.subnets, nil
 }
 
 func (st *mockState) AddRelation(eps ...state.Endpoint) (remoterelations.Relation, error) {
@@ -479,4 +493,12 @@ func (u *mockRelationUnit) ReplaceSettings(settings map[string]interface{}) erro
 		u.settings[k] = v
 	}
 	return nil
+}
+
+type mockSubnet struct {
+	cidr string
+}
+
+func (a *mockSubnet) CIDR() string {
+	return a.cidr
 }

--- a/apiserver/remoterelations/remoterelations_test.go
+++ b/apiserver/remoterelations/remoterelations_test.go
@@ -41,7 +41,8 @@ func (s *remoteRelationsSuite) SetUpTest(c *gc.C) {
 	}
 
 	s.st = newMockState()
-	api, err := remoterelations.NewRemoteRelationsAPI(s.st, s.resources, s.authorizer)
+	pool := &mockStatePool{s.st}
+	api, err := remoterelations.NewRemoteRelationsAPI(s.st, pool, s.resources, s.authorizer)
 	c.Assert(err, jc.ErrorIsNil)
 	s.api = api
 }
@@ -350,6 +351,7 @@ func (s *remoteRelationsSuite) TestRelations(c *gc.C) {
 			Key:                "db2:db django:db",
 			RemoteEndpointName: "data",
 			ApplicationName:    "django",
+			SourceModelUUID:    "model-uuid",
 			Endpoint: params.RemoteEndpoint{
 				Name:      "db",
 				Role:      "provides",
@@ -407,4 +409,54 @@ func (s *remoteRelationsSuite) TestRegisterRemoteRelations(c *gc.C) {
 func (s *remoteRelationsSuite) TestRegisterRemoteRelationsIdempotent(c *gc.C) {
 	s.assertRegisterRemoteRelations(c)
 	s.assertRegisterRemoteRelations(c)
+}
+
+func (s *remoteRelationsSuite) TestIngressSubnetsForRelation(c *gc.C) {
+	db2Relation := newMockRelation(123)
+	db2Relation.endpoints = []state.Endpoint{
+		{
+			ApplicationName: "django",
+			Relation: charm.Relation{
+				Name:      "db",
+				Interface: "db2",
+				Role:      "requirer",
+				Limit:     1,
+				Scope:     charm.ScopeGlobal,
+			},
+		}, {
+			ApplicationName: "db2",
+			Relation: charm.Relation{
+				Name:      "data",
+				Interface: "db2",
+				Role:      "provider",
+				Limit:     1,
+				Scope:     charm.ScopeGlobal,
+			},
+		},
+	}
+	s.st.relations["db2:db django:db"] = db2Relation
+	app := newMockApplication("db2")
+	s.st.applications["db2"] = app
+	remoteApp := newMockRemoteApplication("django", "url")
+	s.st.remoteApplications["django"] = remoteApp
+	s.st.subnets = []remoterelations.Subnet{
+		&mockSubnet{"10.0.0.0/24"},
+		&mockSubnet{"127.0.0.0/0"},
+		&mockSubnet{"::1/0"},
+	}
+	result, err := s.api.IngressSubnetsForRelation(params.Entities{Entities: []params.Entity{{Tag: "relation-db2.db#django.db"}}})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result.Results, gc.HasLen, 1)
+	c.Assert(result.Results[0].Result, jc.DeepEquals, &params.IngressSubnetInfo{
+		ApplicationName: "db2",
+		CIDRs:           []string{"10.0.0.0/24"},
+	})
+
+	s.st.CheckCalls(c, []testing.StubCall{
+		{"KeyRelation", []interface{}{"db2:db django:db"}},
+		{"RemoteApplication", []interface{}{"django"}},
+		{"RemoteApplication", []interface{}{"db2"}},
+		{"Application", []interface{}{"db2"}},
+		{"AllSubnets", nil},
+	})
 }

--- a/state/watcher.go
+++ b/state/watcher.go
@@ -491,6 +491,11 @@ func (w *lifecycleWatcher) initial() (set.Strings, error) {
 	var doc lifeDoc
 	iter := coll.Find(w.members).Select(lifeFields).Iter()
 	for iter.Next(&doc) {
+		// If no members criteria is specified, use the filter
+		// to reject any unsuitable initial elements.
+		if w.members == nil && w.filter != nil && !w.filter(doc.Id) {
+			continue
+		}
 		id := w.st.localID(doc.Id)
 		ids.Add(id)
 		if doc.Life != Dead {

--- a/worker/firewaller/manifold.go
+++ b/worker/firewaller/manifold.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/juju/juju/api/base"
 	"github.com/juju/juju/api/firewaller"
+	"github.com/juju/juju/api/remoterelations"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/worker"
@@ -48,8 +49,9 @@ func Manifold(cfg ManifoldConfig) dependency.Manifold {
 
 // manifoldStart creates a firewaller worker, given a base.APICaller.
 func manifoldStart(env environs.Environ, apiCaller base.APICaller, firewallMode string) (worker.Worker, error) {
-	api := firewaller.NewState(apiCaller)
-	w, err := NewFirewaller(env, api, firewallMode)
+	firewallerApi := firewaller.NewState(apiCaller)
+	remoteRelationsApi := remoterelations.NewClient(apiCaller)
+	w, err := NewFirewaller(env, firewallerApi, firewallMode, remoteRelationsApi)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}


### PR DESCRIPTION
## Description of change

The firewaller is updated to allow ingress from remote models so that remote relations can function.
Core components:
- new RemoteRelations facade method IngressSubnetsForRelation
- fix to state lifecycle watcher to properly filter members on initialisation
- remove the automatic expose to the world behaviour from add relation api
- update firewaller to listen to remote relations

The watcher fix to to plug a hole where the initial watcher elements are not properly filtered because only the member query was being used, not the filter method.

When a relation is added, the add relation API no longer needs to open the applications to the world as the firewaller now takes care of ingress management.

The firewaller is not complete - it reacts to new remote relations but the necessary network updates in the model may not have been completed. So the firewaller will fall back to using 0.0.0.0/0. A follow up will add a watcher to the firewaller to handle things better.

The IngressSubnetsForRelation API for now just returns all CIDRs from the source model. The next step will be to only return CIDRs from machines hosting units of the remote application. And then next step will be to uses the spaces model to return only CIDRs to which the remote endpoints are bound.

The firewaller fallback to 0.0.0.0/0 is also needed because only AWS and MAAS currently implement the environ NetworkInterface. Azure, GCE, Openstack need updating before the fallback can be dropped.

## QA steps

bootstrap aws
deploy mediawiki and mysql in separate models
relate mediawiki and mysql
check the mysql security group to see that it allows ingress from 0.0.0.0/0

