### PR TITLE
Replace x/net/websocket with gorilla/websocket.

### DIFF
--- a/api/apiclient.go
+++ b/api/apiclient.go
@@ -16,6 +16,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/gorilla/websocket"
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	"github.com/juju/retry"
@@ -23,7 +24,6 @@ import (
 	"github.com/juju/utils/clock"
 	"github.com/juju/utils/parallel"
 	"github.com/juju/version"
-	"golang.org/x/net/websocket"
 	"gopkg.in/juju/names.v2"
 	"gopkg.in/macaroon-bakery.v1/httpbakery"
 	"gopkg.in/macaroon.v1"
@@ -183,12 +183,12 @@ func open(
 	if clock == nil {
 		return nil, errors.NotValidf("nil clock")
 	}
-	conn, tlsConfig, err := dialAPI(info, opts)
+	dialResult, err := dialAPI(info, opts)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
 
-	client := rpc.NewConn(jsoncodec.NewWebsocket(conn), observer.None())
+	client := rpc.NewConn(jsoncodec.NewWebsocket(dialResult.conn), observer.None())
 	client.Start()
 
 	bakeryClient := opts.BakeryClient
@@ -201,29 +201,36 @@ func open(
 		httpc := *bakeryClient.Client
 		bakeryClient.Client = &httpc
 	}
-	apiHost := conn.Config().Location.Host
+	apiURL, err := url.Parse(dialResult.urlStr)
+	if err != nil {
+		// This should never happen as the url would have failed during dialAPI above.
+		// However the code paths don't allow capture of the url.URL used.
+		return nil, errors.Trace(err)
+	}
+	apiHost := apiURL.Host
+
 	// Technically when there's no CACert, we don't need this
 	// machinery, because we could just use http.DefaultTransport
 	// for everything, but it's easier just to leave it in place.
 	bakeryClient.Client.Transport = &hostSwitchingTransport{
 		primaryHost: apiHost,
-		primary:     utils.NewHttpTLSTransport(tlsConfig),
+		primary:     utils.NewHttpTLSTransport(dialResult.tlsConfig),
 		fallback:    http.DefaultTransport,
 	}
 
 	st := &state{
 		client: client,
-		conn:   conn,
+		conn:   dialResult.conn,
 		clock:  clock,
 		addr:   apiHost,
 		cookieURL: &url.URL{
 			Scheme: "https",
-			Host:   conn.Config().Location.Host,
+			Host:   apiHost,
 			Path:   "/",
 		},
 		pingerFacadeVersion: facadeVersions["Pinger"],
 		serverScheme:        "https",
-		serverRootAddress:   conn.Config().Location.Host,
+		serverRootAddress:   apiHost,
 		// We populate the username and password before
 		// login because, when doing HTTP requests, we'll want
 		// to use the same username and password for authenticating
@@ -232,13 +239,13 @@ func open(
 		password:     info.Password,
 		macaroons:    info.Macaroons,
 		nonce:        info.Nonce,
-		tlsConfig:    tlsConfig,
+		tlsConfig:    dialResult.tlsConfig,
 		bakeryClient: bakeryClient,
 		modelTag:     info.ModelTag,
 	}
 	if !info.SkipLogin {
 		if err := st.Login(info.Tag, info.Password, info.Nonce, info.Macaroons); err != nil {
-			conn.Close()
+			dialResult.conn.Close()
 			return nil, errors.Trace(err)
 		}
 	}
@@ -348,34 +355,39 @@ func (st *state) connectStream(path string, attrs url.Values, extraHeaders http.
 	// TODO(macgreagoir) IPv6. Ubuntu still always provides IPv4 loopback,
 	// and when/if this changes localhost should resolve to IPv6 loopback
 	// in any case (lp:1644009). Review.
-	cfg, err := websocket.NewConfig(target.String(), "http://localhost/")
-	if err != nil {
-		return nil, errors.Trace(err)
+
+	dialer := &websocket.Dialer{
+		Proxy:           http.ProxyFromEnvironment,
+		TLSClientConfig: st.tlsConfig,
 	}
+	var requestHeader http.Header
 	if st.tag != "" {
-		cfg.Header = utils.BasicAuthHeader(st.tag, st.password)
+		requestHeader = utils.BasicAuthHeader(st.tag, st.password)
+	} else {
+		requestHeader = make(http.Header)
 	}
+	requestHeader.Set("Origin", "http://localhost/")
 	if st.nonce != "" {
-		cfg.Header.Set(params.MachineNonceHeader, st.nonce)
+		requestHeader.Set(params.MachineNonceHeader, st.nonce)
 	}
 	// Add any cookies because they will not be sent to websocket
 	// connections by default.
-	err = st.addCookiesToHeader(cfg.Header)
+	err := st.addCookiesToHeader(requestHeader)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
 	for header, values := range extraHeaders {
 		for _, value := range values {
-			cfg.Header.Add(header, value)
+			requestHeader.Add(header, value)
 		}
 	}
 
-	cfg.TlsConfig = st.tlsConfig
-	connection, err := websocketDialConfig(cfg)
+	connection, err := websocketDial(dialer, target.String(), requestHeader)
 	if err != nil {
 		return nil, err
 	}
 	if err := readInitialStreamError(connection); err != nil {
+		connection.Close()
 		return nil, errors.Trace(err)
 	}
 	return connection, nil
@@ -383,14 +395,21 @@ func (st *state) connectStream(path string, attrs url.Values, extraHeaders http.
 
 // readInitialStreamError reads the initial error response
 // from a stream connection and returns it.
-func readInitialStreamError(conn io.Reader) error {
+func readInitialStreamError(ws base.Stream) error {
 	// We can use bufio here because the websocket guarantees that a
 	// single read will not read more than a single frame; there is
 	// no guarantee that a single read might not read less than the
 	// whole frame though, so using a single Read call is not
 	// correct. By using ReadSlice rather than ReadBytes, we
 	// guarantee that the error can't be too big (>4096 bytes).
-	line, err := bufio.NewReader(conn).ReadSlice('\n')
+	messageType, reader, err := ws.NextReader()
+	if err != nil {
+		return errors.Annotate(err, "unable to get reader")
+	}
+	if messageType != websocket.TextMessage {
+		return errors.Errorf("unexpected message type %v", messageType)
+	}
+	line, err := bufio.NewReader(reader).ReadSlice('\n')
 	if err != nil {
 		return errors.Annotate(err, "unable to read initial response")
 	}
@@ -477,20 +496,21 @@ func tagToString(tag names.Tag) string {
 	return tag.String()
 }
 
+type dialResult struct {
+	conn      *websocket.Conn
+	urlStr    string
+	tlsConfig *tls.Config
+}
+
 // dialAPI establishes a websocket connection to the RPC
 // API websocket on the API server using Info. If multiple API addresses
 // are provided in Info they will be tried concurrently - the first successful
 // connection wins.
 //
 // It also returns the TLS configuration that it has derived from the Info.
-func dialAPI(info *Info, opts DialOpts) (*websocket.Conn, *tls.Config, error) {
-	// Set opts.DialWebsocket here rather than in open because
-	// some tests call dialAPI directly.
-	if opts.DialWebsocket == nil {
-		opts.DialWebsocket = websocket.DialConfig
-	}
+func dialAPI(info *Info, opts DialOpts) (*dialResult, error) {
 	if len(info.Addrs) == 0 {
-		return nil, nil, errors.New("no API addresses to connect to")
+		return nil, errors.New("no API addresses to connect to")
 	}
 	tlsConfig := utils.SecureTLSConfig()
 	tlsConfig.InsecureSkipVerify = opts.InsecureSkipVerify
@@ -501,7 +521,7 @@ func dialAPI(info *Info, opts DialOpts) (*websocket.Conn, *tls.Config, error) {
 		tlsConfig.ServerName = "juju-apiserver"
 		certPool, err := CreateCertPool(info.CACert)
 		if err != nil {
-			return nil, nil, errors.Annotate(err, "cert pool creation failed")
+			return nil, errors.Annotate(err, "cert pool creation failed")
 		}
 		tlsConfig.RootCAs = certPool
 	} else {
@@ -510,33 +530,58 @@ func dialAPI(info *Info, opts DialOpts) (*websocket.Conn, *tls.Config, error) {
 		// name in the address will be used as usual).
 		tlsConfig.ServerName = info.SNIHostName
 	}
+
+	opts.tlsConfig = tlsConfig
+
+	// Set opts.DialWebsocket here rather than in open because
+	// some tests call dialAPI directly.
+	if opts.DialWebsocket == nil {
+		dialer := &websocketDialerAdapter{
+			&websocket.Dialer{
+				Proxy:           http.ProxyFromEnvironment,
+				TLSClientConfig: tlsConfig,
+			},
+		}
+		opts.DialWebsocket = dialer.Dial
+	}
+
 	path, err := apiPath(info.ModelTag, "/api")
 	if err != nil {
-		return nil, nil, errors.Trace(err)
+		return nil, errors.Trace(err)
 	}
-	conn, err := dialWebsocketMulti(info.Addrs, path, tlsConfig, opts)
+	conn, urlStr, err := dialWebsocketMulti(info.Addrs, path, opts)
 	if err != nil {
-		return nil, nil, errors.Trace(err)
+		return nil, errors.Trace(err)
 	}
-	logger.Infof("connection established to %q", conn.RemoteAddr())
-	return conn, tlsConfig, nil
+	logger.Infof("connection established to %q", urlStr)
+	return &dialResult{conn, urlStr, tlsConfig}, nil
+}
+
+type websocketDialerAdapter struct {
+	dialer *websocket.Dialer
+}
+
+func (a *websocketDialerAdapter) Dial(urlStr string, tlsConfig *tls.Config, requestHeader http.Header) (*websocket.Conn, *http.Response, error) {
+	// Ignore the tlsConfig because it is set on the dialer.
+	// The tls.Config is only passed through for the purpose of catpure in the tests.
+	return a.dialer.Dial(urlStr, requestHeader)
 }
 
 // dialWebsocketMulti dials a websocket with one of the provided addresses, the
 // specified URL path, TLS configuration, and dial options. Each of the
 // specified addresses will be attempted concurrently, and the first
 // successful connection will be returned.
-func dialWebsocketMulti(addrs []string, path string, tlsConfig *tls.Config, opts DialOpts) (*websocket.Conn, error) {
+func dialWebsocketMulti(addrs []string, path string, opts DialOpts) (*websocket.Conn, string, error) {
 	// Dial all addresses at reasonable intervals.
 	try := parallel.NewTry(0, nil)
 	defer try.Kill()
 	for _, addr := range addrs {
-		err := startDialWebsocket(try, addr, path, opts, tlsConfig)
+		err := startDialWebsocket(try, addr, path, opts)
 		if err == parallel.ErrStopped {
 			break
 		}
 		if err != nil {
-			return nil, errors.Trace(err)
+			return nil, "", errors.Trace(err)
 		}
 		select {
 		case <-time.After(opts.DialAddressInterval):
@@ -546,30 +591,40 @@ func dialWebsocketMulti(addrs []string, path string, tlsConfig *tls.Config, opts
 	try.Close()
 	result, err := try.Result()
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, "", errors.Trace(err)
 	}
-	return result.(*websocket.Conn), nil
+	wrapper := result.(*connWrapper)
+	return wrapper.conn, wrapper.urlStr, nil
 }
 
 // startDialWebsocket starts websocket connection to a single address
 // on the given try instance.
-func startDialWebsocket(try *parallel.Try, addr, path string, opts DialOpts, tlsConfig *tls.Config) error {
+func startDialWebsocket(try *parallel.Try, addr, path string, opts DialOpts) error {
 	// origin is required by the WebSocket API, used for "origin policy"
 	// in websockets. We pass localhost to satisfy the API; it is
 	// inconsequential to us.
-	const origin = "http://localhost/"
-	cfg, err := websocket.NewConfig("wss://"+addr+path, origin)
-	if err != nil {
-		return errors.Trace(err)
-	}
-	cfg.TlsConfig = tlsConfig
-	return try.Start(newWebsocketDialer(cfg, opts))
+	urlStr := "wss://" + addr + path
+	return try.Start(newWebsocketDialer(urlStr, opts))
+}
+
+// connWrapper contains the *websocket.Conn and the urlStr that was used
+// to connect to it. The gorilla/websocket code does not remember the URL
+// that was used to connect to it, and many internal parts of Juju assume
+// that it does.
+type connWrapper struct {
+	conn   *websocket.Conn
+	urlStr string
+}
+
+// This is defined for the parallel try to close other results.
+func (c *connWrapper) Close() error {
+	return c.conn.Close()
 }
 
 // newWebsocketDialer0 returns a function that dials the websocket represented
 // by the given configuration with the given dial options, suitable for passing
 // to utils/parallel.Try.Start.
-func newWebsocketDialer(cfg *websocket.Config, opts DialOpts) func(<-chan struct{}) (io.Closer, error) {
+func newWebsocketDialer(urlStr string, opts DialOpts) func(<-chan struct{}) (io.Closer, error) {
 	// TODO(katco): 2016-08-09: lp:1611427
 	openAttempt := utils.AttemptStrategy{
 		Total: opts.Timeout,
@@ -587,11 +642,12 @@ func newWebsocketDialer(cfg *websocket.Config, opts DialOpts) func(<-chan struct
 				return nil, parallel.ErrStopped
 			default:
 			}
-			logger.Debugf("dialing %q", cfg.Location)
-			conn, err := opts.DialWebsocket(cfg)
+			logger.Debugf("dialing %q", urlStr)
+			// Not passing through any extra header information
+			conn, _, err := opts.DialWebsocket(urlStr, opts.tlsConfig, nil)
 			if err == nil {
-				logger.Debugf("successfully dialed %q", cfg.Location)
-				return conn, nil
+				logger.Debugf("successfully dialed %q", urlStr)
+				return &connWrapper{conn, urlStr}, nil
 			}
 			if isCertErr := isX509Error(err); !a.HasNext() || isCertErr {
 				// We won't reconnect when there's an X509
@@ -612,25 +668,20 @@ func newWebsocketDialer(cfg *websocket.Config, opts DialOpts) func(<-chan struct
 // isX509Error reports whether the given websocket error
 // results from an X509 problem.
 func isX509Error(err error) bool {
-	wsErr, ok := errors.Cause(err).(*websocket.DialError)
-	if !ok {
-		return false
-	}
-	switch wsErr.Err.(type) {
-	case x509.HostnameError,
+	switch errType := err.(type) {
+	case *websocket.CloseError:
+		return errType.Code == websocket.CloseTLSHandshake
+	case x509.CertificateInvalidError,
+		x509.HostnameError,
 		x509.InsecureAlgorithmError,
 		x509.UnhandledCriticalExtension,
 		x509.UnknownAuthorityError,
 		x509.ConstraintViolationError,
 		x509.SystemRootsError:
 		return true
+	default:
+		return false
 	}
-	switch err {
-	case x509.ErrUnsupportedAlgorithm,
-		x509.IncorrectPasswordError:
-		return true
-	}
-	return false
 }
 
 type hasErrorCode interface {

--- a/api/base/caller.go
+++ b/api/base/caller.go
@@ -69,7 +69,11 @@ type ControllerStreamConnector interface {
 
 // Stream represents a streaming connection to the API.
 type Stream interface {
-	io.ReadWriteCloser
+	io.Closer
+
+	// NextReader is used to get direct access to the underlying Read methods
+	// on the websocket. Mostly just to read the initial error resonse.
+	NextReader() (messageType int, r io.Reader, err error)
 
 	// WriteJSON encodes the given value as JSON
 	// and writes it to the connection.

--- a/api/export_test.go
+++ b/api/export_test.go
@@ -4,6 +4,7 @@
 package api
 
 import (
+	"github.com/gorilla/websocket"
 	"github.com/juju/errors"
 	"github.com/juju/juju/api/base"
 	"github.com/juju/juju/network"
@@ -16,12 +17,19 @@ import (
 var (
 	CertDir             = &certDir
 	NewWebsocketDialer  = newWebsocketDialer
-	WebsocketDialConfig = &websocketDialConfig
+	WebsocketDial       = &websocketDial
 	SlideAddressToFront = slideAddressToFront
 	BestVersion         = bestVersion
 	FacadeVersions      = &facadeVersions
-	DialAPI             = dialAPI
 )
+
+func DialAPI(info *Info, opts DialOpts) (*websocket.Conn, string, error) {
+	result, err := dialAPI(info, opts)
+	if err != nil {
+		return nil, "", err
+	}
+	return result.conn, result.urlStr, nil
+}
 
 // RPCConnection defines the methods that are called on the rpc.Conn instance.
 type RPCConnection rpcConnection

--- a/api/interface.go
+++ b/api/interface.go
@@ -4,12 +4,14 @@
 package api
 
 import (
+	"crypto/tls"
+	"net/http"
 	"net/url"
 	"time"
 
+	"github.com/gorilla/websocket"
 	"github.com/juju/errors"
 	"github.com/juju/version"
-	"golang.org/x/net/websocket"
 	"gopkg.in/juju/names.v2"
 	"gopkg.in/macaroon-bakery.v1/httpbakery"
 	"gopkg.in/macaroon.v1"
@@ -149,7 +151,10 @@ type DialOpts struct {
 	// If DialWebsocket is nil, webaocket.DialConfig will be used.
 	//
 	// This field is provided for testing purposes only.
-	DialWebsocket func(cfg *websocket.Config) (*websocket.Conn, error)
+	DialWebsocket func(urlStr string, tlsConfig *tls.Config, requestHeader http.Header) (*websocket.Conn, *http.Response, error)
+
+	// Internal use only.
+	tlsConfig *tls.Config
 }
 
 // DefaultDialOpts returns a DialOpts representing the default

--- a/api/logsender/logsender_test.go
+++ b/api/logsender/logsender_test.go
@@ -5,6 +5,7 @@ package logsender_test
 
 import (
 	"errors"
+	"io"
 	"net/url"
 
 	jc "github.com/juju/testing/checkers"
@@ -106,14 +107,9 @@ func (s mockStream) ReadJSON(v interface{}) error {
 	return nil
 }
 
-func (s mockStream) Read([]byte) (int, error) {
-	s.conn.c.Errorf("Read called unexpectedly")
-	return 0, nil
-}
-
-func (s mockStream) Write([]byte) (int, error) {
-	s.conn.c.Errorf("Write called unexpectedly")
-	return 0, nil
+func (s mockStream) NextReader() (messageType int, r io.Reader, err error) {
+	s.conn.c.Errorf("NextReader called unexpectedly")
+	return 0, nil, nil
 }
 
 func (s mockStream) Close() error {

--- a/api/pubsub/pubsub_test.go
+++ b/api/pubsub/pubsub_test.go
@@ -6,6 +6,7 @@ package pubsub_test
 import (
 	"errors"
 	"fmt"
+	"io"
 	"net"
 	"net/url"
 	"time"
@@ -118,14 +119,9 @@ func (s mockStream) ReadJSON(v interface{}) error {
 	return nil
 }
 
-func (s mockStream) Read([]byte) (int, error) {
-	s.conn.c.Errorf("Read called unexpectedly")
-	return 0, nil
-}
-
-func (s mockStream) Write([]byte) (int, error) {
-	s.conn.c.Errorf("Write called unexpectedly")
-	return 0, nil
+func (s mockStream) NextReader() (messageType int, r io.Reader, err error) {
+	s.conn.c.Errorf("NextReader called unexpectedly")
+	return 0, nil, nil
 }
 
 func (s mockStream) Close() error {

--- a/api/state_macaroon_test.go
+++ b/api/state_macaroon_test.go
@@ -66,7 +66,7 @@ func (s *macaroonLoginSuite) TestUnknownUserLogin(c *gc.C) {
 
 func (s *macaroonLoginSuite) TestConnectStream(c *gc.C) {
 	catcher := urlCatcher{}
-	s.PatchValue(api.WebsocketDialConfig, catcher.recordLocation)
+	s.PatchValue(api.WebsocketDial, catcher.recordLocation)
 
 	dischargeCount := 0
 	s.DischargerLogin = func() string {
@@ -83,14 +83,15 @@ func (s *macaroonLoginSuite) TestConnectStream(c *gc.C) {
 	conn, err := s.client.ConnectStream("/path", nil)
 	c.Assert(err, gc.IsNil)
 	defer conn.Close()
-	connectURL := catcher.location
+	connectURL, err := url.Parse(catcher.location)
+	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(connectURL.Path, gc.Equals, "/model/"+s.State.ModelTag().Id()+"/path")
 	c.Assert(dischargeCount, gc.Equals, 1)
 }
 
 func (s *macaroonLoginSuite) TestConnectStreamWithoutLogin(c *gc.C) {
 	catcher := urlCatcher{}
-	s.PatchValue(api.WebsocketDialConfig, catcher.recordLocation)
+	s.PatchValue(api.WebsocketDial, catcher.recordLocation)
 
 	conn, err := s.client.ConnectStream("/path", nil)
 	c.Assert(err, gc.ErrorMatches, `cannot use ConnectStream without logging in`)
@@ -141,7 +142,7 @@ func (s *macaroonLoginSuite) TestConnectStreamWithDischargedMacaroons(c *gc.C) {
 	// wouldn't get attached to the websocket request.
 	// https://bugs.launchpad.net/juju/+bug/1650451
 	catcher := urlCatcher{}
-	s.PatchValue(api.WebsocketDialConfig, catcher.recordLocation)
+	s.PatchValue(api.WebsocketDial, catcher.recordLocation)
 
 	mac, err := macaroon.New([]byte("abc-123"), "aurora gone", "shankil butchers")
 	c.Assert(err, jc.ErrorIsNil)

--- a/apiserver/apiserver.go
+++ b/apiserver/apiserver.go
@@ -18,6 +18,7 @@ import (
 	"sync/atomic"
 
 	"github.com/bmizerany/pat"
+	"github.com/gorilla/websocket"
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	"github.com/juju/pubsub"
@@ -25,7 +26,6 @@ import (
 	"github.com/juju/utils/clock"
 	"golang.org/x/crypto/acme"
 	"golang.org/x/crypto/acme/autocert"
-	"golang.org/x/net/websocket"
 	"gopkg.in/juju/names.v2"
 	"gopkg.in/macaroon-bakery.v1/httpbakery"
 	"gopkg.in/tomb.v1"
@@ -635,21 +635,18 @@ func (srv *Server) apiHandler(w http.ResponseWriter, req *http.Request) {
 	apiObserver.Join(req, connectionID)
 	defer apiObserver.Leave()
 
-	wsServer := websocket.Server{
-		Handler: func(conn *websocket.Conn) {
-			modelUUID := req.URL.Query().Get(":modeluuid")
-			logger.Tracef("got a request for model %q", modelUUID)
-			if err := srv.serveConn(conn, modelUUID, apiObserver, req.Host); err != nil {
-				logger.Errorf("error serving RPCs: %v", err)
-			}
-		},
+	handler := func(conn *websocket.Conn) {
+		modelUUID := req.URL.Query().Get(":modeluuid")
+		logger.Tracef("got a request for model %q", modelUUID)
+		if err := srv.serveConn(conn, modelUUID, apiObserver, req.Host); err != nil {
+			logger.Errorf("error serving RPCs: %v", err)
+		}
 	}
-	wsServer.ServeHTTP(w, req)
+	websocketServer(w, req, handler)
 }
 
 func (srv *Server) serveConn(wsConn *websocket.Conn, modelUUID string, apiObserver observer.Observer, host string) error {
 	codec := jsoncodec.NewWebsocket(wsConn)
-
 	conn := rpc.NewConn(codec, apiObserver)
 
 	// Note that we don't overwrite modelUUID here because

--- a/apiserver/apiserver_test.go
+++ b/apiserver/apiserver_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net"
 
+	"github.com/juju/loggo"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils"
 	"github.com/juju/utils/clock"
@@ -34,6 +35,7 @@ type apiserverBaseSuite struct {
 
 func (s *apiserverBaseSuite) SetUpTest(c *gc.C) {
 	s.StateSuite.SetUpTest(c)
+	loggo.GetLogger("juju.apiserver").SetLogLevel(loggo.TRACE)
 	u, err := s.State.User(s.Owner)
 	c.Assert(err, jc.ErrorIsNil)
 	err = u.SetPassword(ownerPassword)

--- a/apiserver/authhttp_test.go
+++ b/apiserver/authhttp_test.go
@@ -13,11 +13,11 @@ import (
 	"net/url"
 	"os"
 
+	"github.com/gorilla/websocket"
 	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/testing/httptesting"
 	"github.com/juju/utils"
-	"golang.org/x/net/websocket"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/names.v2"
 	"gopkg.in/macaroon-bakery.v1/httpbakery"
@@ -98,28 +98,35 @@ func (s *authHTTPSuite) baseURL(c *gc.C) *url.URL {
 }
 
 func dialWebsocketFromURL(c *gc.C, server string, header http.Header) *websocket.Conn {
-	config := makeWebsocketConfigFromURL(c, server, header)
+	if header == nil {
+		header = http.Header{}
+	}
+	header.Set("Origin", "http://localhost/")
+	caCerts := x509.NewCertPool()
+	c.Assert(caCerts.AppendCertsFromPEM([]byte(testing.CACert)), jc.IsTrue)
+	tlsConfig := utils.SecureTLSConfig()
+	tlsConfig.RootCAs = caCerts
+	tlsConfig.ServerName = "anything"
 	c.Logf("dialing %v", server)
-	conn, err := websocket.DialConfig(config)
+
+	dialer := &websocket.Dialer{
+		Proxy:           http.ProxyFromEnvironment,
+		TLSClientConfig: tlsConfig,
+	}
+	conn, _, err := dialer.Dial(server, header)
 	c.Assert(err, jc.ErrorIsNil)
 	return conn
 }
 
-func makeWebsocketConfigFromURL(c *gc.C, server string, header http.Header) *websocket.Config {
-	config, err := websocket.NewConfig(server, "http://localhost/")
-	c.Assert(err, jc.ErrorIsNil)
-	config.Header = header
-	caCerts := x509.NewCertPool()
-	c.Assert(caCerts.AppendCertsFromPEM([]byte(testing.CACert)), jc.IsTrue)
-	config.TlsConfig = utils.SecureTLSConfig()
-	config.TlsConfig.RootCAs = caCerts
-	config.TlsConfig.ServerName = "anything"
-	return config
-}
-
-func assertWebsocketClosed(c *gc.C, reader *bufio.Reader) {
-	_, err := reader.ReadByte()
-	c.Assert(err, gc.Equals, io.EOF)
+func assertWebsocketClosed(c *gc.C, ws *websocket.Conn) {
+	_, _, err := ws.NextReader()
+	goodClose := []int{
+		websocket.CloseNormalClosure,
+		websocket.CloseGoingAway,
+		websocket.CloseNoStatusReceived,
+	}
+	c.Logf("%#v", err)
+	c.Assert(websocket.IsCloseError(err, goodClose...), jc.IsTrue)
 }
 
 func (s *authHTTPSuite) makeURL(c *gc.C, scheme, path string, queryParams url.Values) *url.URL {
@@ -279,16 +286,26 @@ func (s *authHTTPSuite) uploadRequest(c *gc.C, uri string, contentType, path str
 
 // assertJSONError checks the JSON encoded error returned by the log
 // and logsink APIs matches the expected value.
-func assertJSONError(c *gc.C, reader *bufio.Reader, expected string) {
-	errResult := readJSONErrorLine(c, reader)
+func assertJSONError(c *gc.C, ws *websocket.Conn, expected string) {
+	errResult := readJSONErrorLine(c, ws)
 	c.Assert(errResult.Error, gc.NotNil)
 	c.Assert(errResult.Error.Message, gc.Matches, expected)
 }
 
+// assertJSONInitialErrorNil checks the JSON encoded error returned by the log
+// and logsink APIs are nil.
+func assertJSONInitialErrorNil(c *gc.C, ws *websocket.Conn) {
+	errResult := readJSONErrorLine(c, ws)
+	c.Assert(errResult.Error, gc.IsNil)
+}
+
 // readJSONErrorLine returns the error line returned by the log and
 // logsink APIS.
-func readJSONErrorLine(c *gc.C, reader *bufio.Reader) params.ErrorResult {
-	line, err := reader.ReadSlice('\n')
+func readJSONErrorLine(c *gc.C, ws *websocket.Conn) params.ErrorResult {
+	messageType, reader, err := ws.NextReader()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(messageType, gc.Equals, websocket.TextMessage)
+	line, err := bufio.NewReader(reader).ReadSlice('\n')
 	c.Assert(err, jc.ErrorIsNil)
 	var errResult params.ErrorResult
 	err = json.Unmarshal(line, &errResult)

--- a/apiserver/debuglog_db_test.go
+++ b/apiserver/debuglog_db_test.go
@@ -4,14 +4,11 @@
 package apiserver_test
 
 import (
-	"bufio"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 
-	jc "github.com/juju/testing/checkers"
+	"github.com/gorilla/websocket"
 	"github.com/juju/utils"
-	"golang.org/x/net/websocket"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/apiserver/params"
@@ -51,10 +48,9 @@ func (s *debugLogDBSuite) TestWithHTTPS(c *gc.C) {
 func (s *debugLogDBSuite) TestNoAuth(c *gc.C) {
 	conn := s.dialWebsocketInternal(c, nil, nil)
 	defer conn.Close()
-	reader := bufio.NewReader(conn)
 
-	assertJSONError(c, reader, "no credentials provided")
-	assertWebsocketClosed(c, reader)
+	assertJSONError(c, conn, "no credentials provided")
+	assertWebsocketClosed(c, conn)
 }
 
 func (s *debugLogDBSuite) TestUnitLoginsRejected(c *gc.C) {
@@ -62,10 +58,9 @@ func (s *debugLogDBSuite) TestUnitLoginsRejected(c *gc.C) {
 	header := utils.BasicAuthHeader(u.Tag().String(), password)
 	conn := s.dialWebsocketInternal(c, nil, header)
 	defer conn.Close()
-	reader := bufio.NewReader(conn)
 
-	assertJSONError(c, reader, "tag kind unit not valid")
-	assertWebsocketClosed(c, reader)
+	assertJSONError(c, conn, "tag kind unit not valid")
+	assertWebsocketClosed(c, conn)
 }
 
 var noResultsPlease = url.Values{"maxLines": {"0"}, "noTail": {"true"}}
@@ -78,12 +73,9 @@ func (s *debugLogDBSuite) TestUserLoginsAccepted(c *gc.C) {
 	header := utils.BasicAuthHeader(u.Tag().String(), "gardener")
 	conn := s.dialWebsocketInternal(c, noResultsPlease, header)
 	defer conn.Close()
-	reader := bufio.NewReader(conn)
 
-	result := readJSONErrorLine(c, reader)
+	result := readJSONErrorLine(c, conn)
 	c.Assert(result.Error, gc.IsNil)
-	_, err := ioutil.ReadAll(reader)
-	c.Assert(err, jc.ErrorIsNil)
 }
 
 func (s *debugLogDBSuite) TestMachineLoginsAccepted(c *gc.C) {
@@ -94,27 +86,24 @@ func (s *debugLogDBSuite) TestMachineLoginsAccepted(c *gc.C) {
 	header.Add(params.MachineNonceHeader, "foo-nonce")
 	conn := s.dialWebsocketInternal(c, noResultsPlease, header)
 	defer conn.Close()
-	reader := bufio.NewReader(conn)
 
-	result := readJSONErrorLine(c, reader)
+	result := readJSONErrorLine(c, conn)
 	c.Assert(result.Error, gc.IsNil)
-	_, err := ioutil.ReadAll(reader)
-	c.Assert(err, jc.ErrorIsNil)
 }
 
-func (s *debugLogDBSuite) openWebsocket(c *gc.C, values url.Values) *bufio.Reader {
+func (s *debugLogDBSuite) openWebsocket(c *gc.C, values url.Values) *websocket.Conn {
 	conn := s.dialWebsocket(c, values)
 	s.AddCleanup(func(_ *gc.C) { conn.Close() })
-	return bufio.NewReader(conn)
+	return conn
 }
 
-func (s *debugLogDBSuite) openWebsocketCustomPath(c *gc.C, path string) *bufio.Reader {
+func (s *debugLogDBSuite) openWebsocketCustomPath(c *gc.C, path string) *websocket.Conn {
 	server := s.logURL(c, "wss", nil)
 	server.Path = path
 	header := utils.BasicAuthHeader(s.userTag.String(), s.password)
 	conn := dialWebsocketFromURL(c, server.String(), header)
 	s.AddCleanup(func(_ *gc.C) { conn.Close() })
-	return bufio.NewReader(conn)
+	return conn
 }
 
 func (s *debugLogDBSuite) logURL(c *gc.C, scheme string, queryParams url.Values) *url.URL {

--- a/apiserver/httpcontext.go
+++ b/apiserver/httpcontext.go
@@ -7,7 +7,6 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
 	"strings"
 
@@ -251,19 +250,6 @@ func (ctxt *httpContext) loginRequest(r *http.Request) (params.LoginRequest, err
 // exit.
 func (ctxt *httpContext) stop() <-chan struct{} {
 	return ctxt.srv.tomb.Dying()
-}
-
-// sendJSON writes a JSON-encoded response value
-// to the given writer along with a trailing newline.
-func sendJSON(w io.Writer, response interface{}) error {
-	body, err := json.Marshal(response)
-	if err != nil {
-		logger.Errorf("cannot marshal JSON result %#v: %v", response, err)
-		return err
-	}
-	body = append(body, '\n')
-	_, err = w.Write(body)
-	return err
 }
 
 // sendStatusAndJSON sends an HTTP status code and

--- a/apiserver/logtransfer_test.go
+++ b/apiserver/logtransfer_test.go
@@ -4,16 +4,15 @@
 package apiserver_test
 
 import (
-	"bufio"
 	"net/http"
 	"net/url"
 	"time"
 
+	"github.com/gorilla/websocket"
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils"
-	"golang.org/x/net/websocket"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/names.v2"
 	"gopkg.in/mgo.v2/bson"
@@ -75,22 +74,24 @@ func (s *logtransferSuite) dialWebsocket(c *gc.C) *websocket.Conn {
 
 func (s *logtransferSuite) dialWebsocketInternal(c *gc.C, header http.Header) *websocket.Conn {
 	server := s.logtransferURL(c, "wss").String()
-	return dialWebsocketFromURL(c, server, header)
+	conn := dialWebsocketFromURL(c, server, header)
+	s.AddCleanup(func(_ *gc.C) { conn.Close() })
+	return conn
 }
 
 func (s *logtransferSuite) TestRejectsMissingModelHeader(c *gc.C) {
 	header := utils.BasicAuthHeader(s.userTag.String(), s.password)
-	reader := s.toReader(s.dialWebsocketInternal(c, header))
-	assertJSONError(c, reader, `unknown model: ""`)
-	assertWebsocketClosed(c, reader)
+	ws := s.dialWebsocketInternal(c, header)
+	assertJSONError(c, ws, `unknown model: ""`)
+	assertWebsocketClosed(c, ws)
 }
 
 func (s *logtransferSuite) TestRejectsBadMigratingModelUUID(c *gc.C) {
 	header := utils.BasicAuthHeader(s.userTag.String(), s.password)
 	header.Add(params.MigrationModelHTTPHeader, "does-not-exist")
-	reader := s.toReader(s.dialWebsocketInternal(c, header))
-	assertJSONError(c, reader, `unknown model: "does-not-exist"`)
-	assertWebsocketClosed(c, reader)
+	ws := s.dialWebsocketInternal(c, header)
+	assertJSONError(c, ws, `unknown model: "does-not-exist"`)
+	assertWebsocketClosed(c, ws)
 }
 
 func (s *logtransferSuite) TestRejectsInvalidVersion(c *gc.C) {
@@ -100,51 +101,48 @@ func (s *logtransferSuite) TestRejectsInvalidVersion(c *gc.C) {
 	url.RawQuery = query.Encode()
 	conn := dialWebsocketFromURL(c, url.String(), s.makeAuthHeader())
 	defer conn.Close()
-	reader := bufio.NewReader(conn)
-	assertJSONError(c, reader, `^invalid jujuclientversion "blah".*`)
-	assertWebsocketClosed(c, reader)
+	assertJSONError(c, conn, `^invalid jujuclientversion "blah".*`)
+	assertWebsocketClosed(c, conn)
 }
 
 func (s *logtransferSuite) TestRejectsMachineLogins(c *gc.C) {
 	header := utils.BasicAuthHeader(s.machineTag.String(), s.machinePassword)
 	header.Add(params.MachineNonceHeader, "nonce")
-	reader := s.toReader(s.dialWebsocketInternal(c, header))
-	assertJSONError(c, reader, `tag kind machine not valid`)
-	assertWebsocketClosed(c, reader)
+	ws := s.dialWebsocketInternal(c, header)
+	assertJSONError(c, ws, `tag kind machine not valid`)
+	assertWebsocketClosed(c, ws)
 }
 
 func (s *logtransferSuite) TestRejectsBadPasword(c *gc.C) {
 	header := utils.BasicAuthHeader(s.userTag.String(), "wrong")
 	header.Add(params.MigrationModelHTTPHeader, s.State.ModelUUID())
-	reader := s.toReader(s.dialWebsocketInternal(c, header))
-	assertJSONError(c, reader, "invalid entity name or password")
-	assertWebsocketClosed(c, reader)
+	ws := s.dialWebsocketInternal(c, header)
+	assertJSONError(c, ws, "invalid entity name or password")
+	assertWebsocketClosed(c, ws)
 }
 
 func (s *logtransferSuite) TestRequiresSuperUser(c *gc.C) {
 	s.setUserAccess(c, permission.AddModelAccess)
-	reader := s.toReader(s.dialWebsocketInternal(c, s.makeAuthHeader()))
-	assertJSONError(c, reader, `not a controller admin`)
-	assertWebsocketClosed(c, reader)
+	ws := s.dialWebsocketInternal(c, s.makeAuthHeader())
+	assertJSONError(c, ws, `not a controller admin`)
+	assertWebsocketClosed(c, ws)
 }
 
 func (s *logtransferSuite) TestRequiresMigrationModeNone(c *gc.C) {
 	s.setMigrationMode(c, state.MigrationModeImporting)
-	reader := s.toReader(s.dialWebsocket(c))
-	assertJSONError(c, reader, `model migration mode is "importing" instead of ""`)
-	assertWebsocketClosed(c, reader)
+	ws := s.dialWebsocket(c)
+	assertJSONError(c, ws, `model migration mode is "importing" instead of ""`)
+	assertWebsocketClosed(c, ws)
 }
 
 func (s *logtransferSuite) TestLogging(c *gc.C) {
 	conn := s.dialWebsocket(c)
-	reader := s.toReader(conn)
 
 	// Read back the nil error, indicating that all is well.
-	errResult := readJSONErrorLine(c, reader)
-	c.Assert(errResult.Error, gc.IsNil)
+	assertJSONInitialErrorNil(c, conn)
 
 	t0 := time.Date(2015, time.June, 1, 23, 2, 1, 0, time.UTC)
-	err := websocket.JSON.Send(conn, &params.LogRecord{
+	err := conn.WriteJSON(&params.LogRecord{
 		Entity:   "machine-23",
 		Time:     t0,
 		Module:   "some.where",
@@ -155,7 +153,7 @@ func (s *logtransferSuite) TestLogging(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	t1 := time.Date(2015, time.June, 1, 23, 2, 2, 0, time.UTC)
-	err = websocket.JSON.Send(conn, &params.LogRecord{
+	err = conn.WriteJSON(&params.LogRecord{
 		Entity:   "machine-101",
 		Time:     t1,
 		Module:   "else.where",
@@ -219,17 +217,15 @@ func (s *logtransferSuite) TestLogging(c *gc.C) {
 
 func (s *logtransferSuite) TestTracksLastSentLogTime(c *gc.C) {
 	conn := s.dialWebsocket(c)
-	reader := s.toReader(conn)
 
 	// Read back the nil error, indicating that all is well.
-	errResult := readJSONErrorLine(c, reader)
-	c.Assert(errResult.Error, gc.IsNil)
+	assertJSONInitialErrorNil(c, conn)
 
 	tracker := state.NewLastSentLogTracker(s.State, s.State.ModelUUID(), "migration-logtransfer")
 	defer tracker.Close()
 
 	t0 := time.Date(2015, time.June, 1, 23, 2, 1, 0, time.UTC)
-	err := websocket.JSON.Send(conn, &params.LogRecord{
+	err := conn.WriteJSON(&params.LogRecord{
 		Entity:   "machine-23",
 		Time:     t0,
 		Module:   "some.where",
@@ -244,7 +240,7 @@ func (s *logtransferSuite) TestTracksLastSentLogTime(c *gc.C) {
 
 	// Doesn't track anything more until a log message 2 mins later.
 	t1 := t0.Add(2*time.Minute - 1*time.Nanosecond)
-	err = websocket.JSON.Send(conn, &params.LogRecord{
+	err = conn.WriteJSON(&params.LogRecord{
 		Entity:   "machine-23",
 		Time:     t1,
 		Module:   "some.where",
@@ -258,7 +254,7 @@ func (s *logtransferSuite) TestTracksLastSentLogTime(c *gc.C) {
 	assertTrackerTime(c, tracker, t0)
 
 	t2 := t1.Add(1 * time.Nanosecond)
-	err = websocket.JSON.Send(conn, &params.LogRecord{
+	err = conn.WriteJSON(&params.LogRecord{
 		Entity:   "machine-23",
 		Time:     t2,
 		Module:   "some.where",
@@ -272,7 +268,7 @@ func (s *logtransferSuite) TestTracksLastSentLogTime(c *gc.C) {
 	assertTrackerTime(c, tracker, t2)
 
 	t3 := t2.Add(1 * time.Nanosecond)
-	err = websocket.JSON.Send(conn, &params.LogRecord{
+	err = conn.WriteJSON(&params.LogRecord{
 		Entity:   "machine-23",
 		Time:     t3,
 		Module:   "some.where",
@@ -305,11 +301,6 @@ func assertTrackerTime(c *gc.C, tracker *state.LastSentLogTracker, expected time
 		}
 	}
 	c.Fatalf("tracker never set to %d - last seen was %d (err: %v)", expected.UnixNano(), timestamp, err)
-}
-
-func (s *logtransferSuite) toReader(conn *websocket.Conn) *bufio.Reader {
-	s.AddCleanup(func(_ *gc.C) { conn.Close() })
-	return bufio.NewReader(conn)
 }
 
 func (s *logtransferSuite) setUserAccess(c *gc.C, level permission.Access) {

--- a/apiserver/pubsub.go
+++ b/apiserver/pubsub.go
@@ -4,15 +4,16 @@
 package apiserver
 
 import (
-	"io"
 	"net/http"
 
+	"github.com/gorilla/websocket"
 	"github.com/juju/errors"
 	"github.com/juju/pubsub"
-	"golang.org/x/net/websocket"
+	"github.com/juju/utils/featureflag"
 
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/feature"
 	"github.com/juju/juju/state"
 )
 
@@ -60,37 +61,35 @@ func (h *pubsubHandler) authenticate(req *http.Request) error {
 
 // ServeHTTP implements the http.Handler interface.
 func (h *pubsubHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
-	server := websocket.Server{
-		Handler: func(socket *websocket.Conn) {
-			logger.Debugf("start of *pubsubHandler.ServeHTTP")
-			defer socket.Close()
+	handler := func(socket *websocket.Conn) {
+		logger.Debugf("start of *pubsubHandler.ServeHTTP")
+		defer socket.Close()
 
-			if err := h.authenticate(req); err != nil {
-				h.sendError(socket, req, err)
+		if err := h.authenticate(req); err != nil {
+			h.sendError(socket, req, err)
+			return
+		}
+
+		// If we get to here, no more errors to report, so we report a nil
+		// error.  This way the first line of the socket is always a json
+		// formatted simple error.
+		h.sendError(socket, req, nil)
+
+		messageCh := h.receiveMessages(socket)
+		for {
+			select {
+			case <-h.ctxt.stop():
 				return
-			}
-
-			// If we get to here, no more errors to report, so we report a nil
-			// error.  This way the first line of the socket is always a json
-			// formatted simple error.
-			h.sendError(socket, req, nil)
-
-			messageCh := h.receiveMessages(socket)
-			for {
-				select {
-				case <-h.ctxt.stop():
-					return
-				case m := <-messageCh:
-					logger.Tracef("topic: %q, data: %v", m.Topic, m.Data)
-					_, err := h.hub.Publish(pubsub.Topic(m.Topic), m.Data)
-					if err != nil {
-						logger.Errorf("publish failed: %v", err)
-					}
+			case m := <-messageCh:
+				logger.Tracef("topic: %q, data: %v", m.Topic, m.Data)
+				_, err := h.hub.Publish(pubsub.Topic(m.Topic), m.Data)
+				if err != nil {
+					logger.Errorf("publish failed: %v", err)
 				}
 			}
-		},
+		}
 	}
-	server.ServeHTTP(w, req)
+	websocketServer(w, req, handler)
 }
 
 func (h *pubsubHandler) receiveMessages(socket *websocket.Conn) <-chan params.PubSubMessage {
@@ -104,7 +103,7 @@ func (h *pubsubHandler) receiveMessages(socket *websocket.Conn) <-chan params.Pu
 			// Receive() blocks until data arrives but will also be
 			// unblocked when the API handler calls socket.Close as it
 			// finishes.
-			if err := websocket.JSON.Receive(socket, &m); err != nil {
+			if err := socket.ReadJSON(&m); err != nil {
 				logger.Errorf("pubsub receive error: %v", err)
 				return
 			}
@@ -122,11 +121,15 @@ func (h *pubsubHandler) receiveMessages(socket *websocket.Conn) <-chan params.Pu
 }
 
 // sendError sends a JSON-encoded error response.
-func (h *pubsubHandler) sendError(w io.Writer, req *http.Request, err error) {
-	if err != nil {
+func (h *pubsubHandler) sendError(ws *websocket.Conn, req *http.Request, err error) {
+	// There is no need to log the error for normal operators as there is nothing
+	// they can action. This is for developers.
+	if err != nil && featureflag.Enabled(feature.DeveloperMode) {
 		logger.Errorf("returning error from %s %s: %s", req.Method, req.URL.Path, errors.Details(err))
 	}
-	sendJSON(w, &params.ErrorResult{
-		Error: common.ServerError(err),
-	})
+	if sendErr := sendInitialErrorV0(ws, err); sendErr != nil {
+		logger.Errorf("closing websocket, %v", err)
+		ws.Close()
+		return
+	}
 }

--- a/apiserver/pubsub_test.go
+++ b/apiserver/pubsub_test.go
@@ -4,17 +4,16 @@
 package apiserver_test
 
 import (
-	"bufio"
 	"fmt"
 	"net/http"
 	"net/url"
 	"time"
 
+	"github.com/gorilla/websocket"
 	"github.com/juju/loggo"
 	"github.com/juju/pubsub"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils"
-	"golang.org/x/net/websocket"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/names.v2"
 
@@ -97,9 +96,8 @@ func (s *pubsubSuite) TestRejectsIncorrectNonce(c *gc.C) {
 func (s *pubsubSuite) checkAuthFails(c *gc.C, header http.Header, message string) {
 	conn := s.dialWebsocketInternal(c, header)
 	defer conn.Close()
-	reader := bufio.NewReader(conn)
-	assertJSONError(c, reader, message)
-	assertWebsocketClosed(c, reader)
+	assertJSONError(c, conn, message)
+	assertWebsocketClosed(c, conn)
 }
 
 func (s *pubsubSuite) TestMessage(c *gc.C) {
@@ -119,11 +117,9 @@ func (s *pubsubSuite) TestMessage(c *gc.C) {
 
 	conn := s.dialWebsocket(c)
 	defer conn.Close()
-	reader := bufio.NewReader(conn)
 
 	// Read back the nil error, indicating that all is well.
-	errResult := readJSONErrorLine(c, reader)
-	c.Assert(errResult.Error, gc.IsNil)
+	assertJSONInitialErrorNil(c, conn)
 
 	message1 := params.PubSubMessage{
 		Topic: "first",
@@ -131,7 +127,7 @@ func (s *pubsubSuite) TestMessage(c *gc.C) {
 			"origin":  "other",
 			"message": "first message",
 		}}
-	err = websocket.JSON.Send(conn, &message1)
+	err = conn.WriteJSON(&message1)
 	c.Assert(err, jc.ErrorIsNil)
 
 	message2 := params.PubSubMessage{
@@ -140,7 +136,7 @@ func (s *pubsubSuite) TestMessage(c *gc.C) {
 			"origin": "other",
 			"value":  false,
 		}}
-	err = websocket.JSON.Send(conn, &message2)
+	err = conn.WriteJSON(&message2)
 	c.Assert(err, jc.ErrorIsNil)
 
 	select {

--- a/apiserver/server_test.go
+++ b/apiserver/server_test.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/gorilla/websocket"
 	"github.com/juju/loggo"
 	"github.com/juju/pubsub"
 	"github.com/juju/testing"
@@ -18,7 +19,6 @@ import (
 	"github.com/juju/utils"
 	"github.com/juju/utils/cert"
 	"github.com/juju/utils/clock"
-	"golang.org/x/net/websocket"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/names.v2"
 	"gopkg.in/macaroon-bakery.v1/bakery"
@@ -268,22 +268,27 @@ func (s *serverSuite) assertAlive(c *gc.C, entity presence.Agent, expectAlive bo
 }
 
 func dialWebsocket(c *gc.C, addr, path string, tlsVersion uint16) (*websocket.Conn, error) {
-	origin := "http://localhost/"
 	url := fmt.Sprintf("wss://%s%s", addr, path)
-	config, err := websocket.NewConfig(url, origin)
-	c.Assert(err, jc.ErrorIsNil)
+	requestHeader := http.Header{"Origin": {"http://localhost/"}}
+
 	pool := x509.NewCertPool()
 	xcert, err := cert.ParseCert(coretesting.CACert)
 	c.Assert(err, jc.ErrorIsNil)
 	pool.AddCert(xcert)
-	config.TlsConfig = utils.SecureTLSConfig()
+	tlsConfig := utils.SecureTLSConfig()
 	if tlsVersion > 0 {
 		// This is for testing only. Please don't muck with the maxtlsversion in
 		// production.
-		config.TlsConfig.MaxVersion = tlsVersion
+		tlsConfig.MaxVersion = tlsVersion
 	}
-	config.TlsConfig.RootCAs = pool
-	return websocket.DialConfig(config)
+	tlsConfig.RootCAs = pool
+
+	dialer := &websocket.Dialer{
+		Proxy:           http.ProxyFromEnvironment,
+		TLSClientConfig: tlsConfig,
+	}
+	conn, _, err := dialer.Dial(url, requestHeader)
+	return conn, err
 }
 
 func (s *serverSuite) TestMinTLSVersion(c *gc.C) {
@@ -327,10 +332,10 @@ func (s *serverSuite) TestNonCompatiblePathsAre404(c *gc.C) {
 
 	// '/randompath' is not ok
 	conn, err = dialWebsocket(c, addr, "/randompath", 0)
-	// Unfortunately go.net/websocket just returns Bad Status, it doesn't
+	// Unfortunately gorilla/websocket just returns bad handshake, it doesn't
 	// give us any information (whether this was a 404 Not Found, Internal
 	// Server Error, 200 OK, etc.)
-	c.Assert(err, gc.ErrorMatches, `websocket.Dial wss://localhost:\d+/randompath: bad status`)
+	c.Assert(err, gc.ErrorMatches, `websocket: bad handshake`)
 	c.Assert(conn, gc.IsNil)
 }
 

--- a/apiserver/testing/fakeapi.go
+++ b/apiserver/testing/fakeapi.go
@@ -8,8 +8,8 @@ import (
 	"reflect"
 
 	"github.com/bmizerany/pat"
+	"github.com/gorilla/websocket"
 	"github.com/juju/utils"
-	"golang.org/x/net/websocket"
 
 	"github.com/juju/juju/apiserver/observer/fakeobserver"
 	"github.com/juju/juju/rpc"
@@ -67,12 +67,12 @@ func NewAPIServer(newRoot func(modelUUID string) interface{}) *Server {
 }
 
 func (srv *Server) serveAPI(w http.ResponseWriter, req *http.Request) {
-	wsServer := websocket.Server{
-		Handler: func(conn *websocket.Conn) {
-			srv.serveConn(conn, req.URL.Query().Get(":modeluuid"))
-		},
+	var websocketUpgrader = websocket.Upgrader{}
+	conn, err := websocketUpgrader.Upgrade(w, req, nil)
+	if err != nil {
+		return
 	}
-	wsServer.ServeHTTP(w, req)
+	srv.serveConn(conn, req.URL.Query().Get(":modeluuid"))
 }
 
 func (srv *Server) serveConn(wsConn *websocket.Conn, modelUUID string) {

--- a/apiserver/websocket.go
+++ b/apiserver/websocket.go
@@ -11,8 +11,17 @@ import (
 	"github.com/juju/juju/apiserver/params"
 )
 
+// Use a 64k frame size for the websockets while we need to deal
+// with x/net/websocket connections that don't deal with recieving
+// fragmented messages.
+const websocketFrameSize = 65536
+
 var websocketUpgrader = websocket.Upgrader{
 	CheckOrigin: func(r *http.Request) bool { return true },
+	// In order to deal with the remote side not handling message
+	// fragmentation, we default to largeish frames.
+	ReadBufferSize:  websocketFrameSize,
+	WriteBufferSize: websocketFrameSize,
 }
 
 func websocketServer(w http.ResponseWriter, req *http.Request, handler func(ws *websocket.Conn)) {

--- a/apiserver/websocket.go
+++ b/apiserver/websocket.go
@@ -1,0 +1,59 @@
+package apiserver
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/gorilla/websocket"
+	"github.com/juju/errors"
+
+	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/params"
+)
+
+var websocketUpgrader = websocket.Upgrader{
+	CheckOrigin: func(r *http.Request) bool { return true },
+}
+
+func websocketServer(w http.ResponseWriter, req *http.Request, handler func(ws *websocket.Conn)) {
+	conn, err := websocketUpgrader.Upgrade(w, req, nil)
+	if err != nil {
+		logger.Errorf("problem initiating websocket: %v", err)
+		return
+	}
+	handler(conn)
+}
+
+// sendInitialErrorV0 writes out the error as a params.ErrorResult serialized
+// with JSON with a new line character at the end.
+//
+// This is a hangover from the initial debug-log streaming endoing where the
+// client read the first line, and then just got a stream of data. We should
+// look to version the streaming endpoints to get rid of the trailing newline
+// character for message based connections, which is all of them now.
+func sendInitialErrorV0(ws *websocket.Conn, err error) error {
+	wrapped := &params.ErrorResult{
+		Error: common.ServerError(err),
+	}
+
+	body, err := json.Marshal(wrapped)
+	if err != nil {
+		errors.Annotatef(err, "cannot marshal error %#v", wrapped)
+		return err
+	}
+	body = append(body, '\n')
+
+	writer, err := ws.NextWriter(websocket.TextMessage)
+	if err != nil {
+		return errors.Annotate(err, "problem getting writer")
+	}
+	defer writer.Close()
+	_, err = writer.Write(body)
+
+	if wrapped.Error != nil {
+		// Tell the other end we are closing.
+		ws.WriteMessage(websocket.CloseMessage, []byte{})
+	}
+
+	return errors.Trace(err)
+}

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -11,7 +11,7 @@ github.com/godbus/dbus	git	32c6cc29c14570de4cf6d7e7737d68fb2d01ad15	2016-05-06T2
 github.com/golang/protobuf	git	34a5f244f1c01cdfee8e60324258cfbb97a42aec	2015-05-26T01:21:09Z
 github.com/google/go-querystring	git	9235644dd9e52eeae6fa48efd539fdc351a0af53	2016-04-01T23:30:42Z
 github.com/gorilla/schema	git	08023a0215e7fc27a9aecd8b8c50913c40019478	2016-04-26T23:15:12Z
-github.com/gorilla/websocket	git	13e4d0621caa4d77fd9aa470ef6d7ab63d1a5e41	2015-09-23T22:29:30Z
+github.com/gorilla/websocket	git	804cb600d06b10672f2fbc0a336a7bee507a428e	2017-02-14T17:41:18Z
 github.com/gosuri/uitable	git	36ee7e946282a3fb1cfecd476ddc9b35d8847e42	2016-04-04T20:39:58Z
 github.com/joyent/gocommon	git	ade826b8b54e81a779ccb29d358a45ba24b7809c	2016-03-20T19:31:33Z
 github.com/joyent/gosdc	git	2f11feadd2d9891e92296a1077c3e2e56939547d	2014-05-24T00:08:15Z

--- a/rpc/jsoncodec/conn.go
+++ b/rpc/jsoncodec/conn.go
@@ -5,30 +5,56 @@ package jsoncodec
 
 import (
 	"encoding/json"
+	"io"
 	"net"
+	"sync"
 
-	"golang.org/x/net/websocket"
+	"github.com/gorilla/websocket"
+	"github.com/juju/errors"
 )
 
 // NewWebsocket returns an rpc codec that uses the given websocket
 // connection to send and receive messages.
 func NewWebsocket(conn *websocket.Conn) *Codec {
-	return New(wsJSONConn{conn})
+	return New(&wsJSONConn{conn: conn})
 }
 
 type wsJSONConn struct {
 	conn *websocket.Conn
+	// gorilla websockets can have at most one concurrent writer, and
+	// one concurrent reader.
+	writeMutex sync.Mutex
+	readMutex  sync.Mutex
 }
 
-func (conn wsJSONConn) Send(msg interface{}) error {
-	return websocket.JSON.Send(conn.conn, msg)
+func (conn *wsJSONConn) Send(msg interface{}) error {
+	conn.writeMutex.Lock()
+	defer conn.writeMutex.Unlock()
+	return conn.conn.WriteJSON(msg)
 }
 
-func (conn wsJSONConn) Receive(msg interface{}) error {
-	return websocket.JSON.Receive(conn.conn, msg)
+func (conn *wsJSONConn) Receive(msg interface{}) error {
+	conn.readMutex.Lock()
+	defer conn.readMutex.Unlock()
+	// When receiving a message, if error has been closed from the other
+	// side, wrap with io.EOF as this is the expected error.
+	err := conn.conn.ReadJSON(msg)
+	if err != nil {
+		if websocket.IsCloseError(err,
+			websocket.CloseNormalClosure,
+			websocket.CloseGoingAway,
+			websocket.CloseNoStatusReceived) {
+			err = errors.Wrap(err, io.EOF)
+		}
+	}
+	return err
 }
 
-func (conn wsJSONConn) Close() error {
+func (conn *wsJSONConn) Close() error {
+	// Tell the other end we are closing.
+	conn.writeMutex.Lock()
+	conn.conn.WriteMessage(websocket.CloseMessage, []byte{})
+	conn.writeMutex.Unlock()
 	return conn.conn.Close()
 }
 

--- a/rpc/server.go
+++ b/rpc/server.go
@@ -341,8 +341,6 @@ func (conn *Conn) input() {
 	close(conn.dead)
 }
 
-var errRemoteClosed = errors.New("remote closed connection")
-
 // loop implements the looping part of Conn.input.
 func (conn *Conn) loop() error {
 	for {


### PR DESCRIPTION
There was a tech-board decision some time in the last two years when we were discussing websocket libraries and why we had two. The decision then was to standardise on gorilla/websocket, but nothing happened.

I'm hoping that using the more standards compliant websocket library will help with some of the leaks we are seeing. Even if they don't help right now, the new library gives the client code access to the websocket ping/pong frames, which the old library didn't. This should allow us to have better recognition when the other end goes away.

## QA steps

Deploy an old controller, make sure there are workload agents. Upgrade the controller and look at the logs. All older clients, CLI and agents should continue to work as normal. New juju CLI should work with older controller.

## Documentation changes

No user impact at all.