### PR TITLE
tools/lxdclient: use utils/proxy.DefaultConfig

### DIFF
--- a/tools/lxdclient/client.go
+++ b/tools/lxdclient/client.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net"
+	"net/http"
 	"net/url"
 	"os"
 	"strconv"
@@ -23,6 +24,7 @@ import (
 	"github.com/lxc/lxd/shared/api"
 
 	"github.com/juju/juju/network"
+	"github.com/juju/juju/utils/proxy"
 )
 
 var logger = loggo.GetLogger("juju.tools.lxdclient")
@@ -260,6 +262,12 @@ func newRawClient(remote Remote) (*lxd.Client, error) {
 			return nil, errors.Annotate(err, "can't connect to the local LXD server")
 		}
 		return nil, errors.Trace(err)
+	}
+
+	// Replace the proxy handler with the one managed
+	// by Juju's worker/proxyupdater.
+	if tr, ok := client.Http.Transport.(*http.Transport); ok {
+		tr.Proxy = proxy.DefaultConfig.GetProxy
 	}
 
 	if remote.Protocol != SimplestreamsProtocol {


### PR DESCRIPTION
## Description of change

Use the Juju-managed HTTP proxy configuration
when making LXD client connections, rather than
the default proxy handler that looks at the
environment variables once and only once.

As well as this, initialise the proxy config
for the client, so that $http_proxy and co. will
be picked up by the client.

## QA steps

(Address of LXD host on lxdbr0 is 10.250.243.1)

1. run an HTTP proxy, port 8080, on the LXD host; the proxy should reject attempts to proxy through to 10.250.243.1 (i.e. so if no_proxy doesn't include 10.250.243.1, the whole thing fails)
2. export no_proxy=10.250.243.1 http_proxy=http://10.250.243.1:8080 https_proxy=http://10.250.243.1:8080
3. create /tmp/config.yaml with the following contents:
```
apt-http-proxy: http://10.250.243.1:8080
apt-https-proxy: http://10.250.243.1:8080
http-proxy: http://10.250.243.1:8080
https-proxy: http://10.250.243.1:8080
no-proxy: 127.0.0.1,localhost,10.250.243.1
```
4. juju bootstrap localhost --config /tmp/config.yaml. As soon as the bootstrap container machine starts, lxc exec bash to it, and run the following:
```
ufw default deny outgoing
ufw default allow incoming
ufw allow out to 10.250.243.1
ufw enable
```
5. juju add-machine
6. ensure there's no "juju/trusty/amd64" alias: `lxc image alias delete juju/trusty/amd64` if necessary
7. juju add-machine --series=trusty

The two machines should be added successfully.

## Documentation changes

None.

## Bug reference

Fixes https://bugs.launchpad.net/juju/+bug/1642385