### PR TITLE
state: prepare for persistent storage

### DIFF
--- a/state/cleanup.go
+++ b/state/cleanup.go
@@ -31,6 +31,8 @@ const (
 	cleanupAttachmentsForDyingFilesystem cleanupKind = "filesystemAttachments"
 	cleanupModelsForDyingController      cleanupKind = "models"
 	cleanupMachinesForDyingModel         cleanupKind = "modelMachines"
+	cleanupVolumesForDyingModel          cleanupKind = "modelVolumes"
+	cleanupFilesystemsForDyingModel      cleanupKind = "modelFilesystems"
 )
 
 // cleanupDoc originally represented a set of documents that should be
@@ -107,6 +109,10 @@ func (st *State) Cleanup() (err error) {
 			err = st.cleanupModelsForDyingController()
 		case cleanupMachinesForDyingModel:
 			err = st.cleanupMachinesForDyingModel()
+		case cleanupVolumesForDyingModel:
+			err = st.cleanupVolumesForDyingModel()
+		case cleanupFilesystemsForDyingModel:
+			err = st.cleanupFilesystemsForDyingModel()
 		default:
 			handler, ok := cleanupHandlers[doc.Kind]
 			if !ok {
@@ -212,7 +218,41 @@ func (st *State) cleanupMachinesForDyingModel() (err error) {
 	return nil
 }
 
-// cleanupServicesForDyingModel sets all services to Dying, if they are
+// cleanupVolumesForDyingModel sets all persistent volumes to Dying,
+// if they are not already Dying or Dead. It's expected to be used when
+// a model is destroyed.
+func (st *State) cleanupVolumesForDyingModel() (err error) {
+	volumes, err := st.AllVolumes()
+	if err != nil {
+		return errors.Trace(err)
+	}
+	for _, v := range volumes {
+		err := st.DestroyVolume(v.VolumeTag())
+		if err != nil && !IsContainsFilesystem(err) {
+			return errors.Trace(err)
+		}
+	}
+	return nil
+}
+
+// cleanupFilesystemsForDyingModel sets all persistent filesystems to
+// Dying, if they are not already Dying or Dead. It's expected to be used
+// when a model is destroyed.
+func (st *State) cleanupFilesystemsForDyingModel() (err error) {
+	filesystems, err := st.AllFilesystems()
+	if err != nil {
+		return errors.Trace(err)
+	}
+	for _, fs := range filesystems {
+		err := st.DestroyFilesystem(fs.FilesystemTag())
+		if err != nil {
+			return errors.Trace(err)
+		}
+	}
+	return nil
+}
+
+// cleanupApplicationsForDyingModel sets all applications to Dying, if they are
 // not already Dying or Dead. It's expected to be used when a model is
 // destroyed.
 func (st *State) cleanupApplicationsForDyingModel() (err error) {
@@ -224,8 +264,9 @@ func (st *State) cleanupApplicationsForDyingModel() (err error) {
 
 func (st *State) removeApplicationsForDyingModel() (err error) {
 	// This won't miss applications, because a Dying model cannot have
-	// applications added to it. But we do have to remove the applications themselves
-	// via individual transactions, because they could be in any state at all.
+	// applications added to it. But we do have to remove the applications
+	// themselves via individual transactions, because they could be in any
+	// state at all.
 	applications, closer := st.getCollection(applicationsC)
 	defer closer()
 	application := Application{st: st}
@@ -260,11 +301,11 @@ func (st *State) removeRemoteApplicationsForDyingModel() (err error) {
 
 // cleanupUnitsForDyingApplication sets all units with the given prefix to Dying,
 // if they are not already Dying or Dead. It's expected to be used when a
-// service is destroyed.
+// application is destroyed.
 func (st *State) cleanupUnitsForDyingApplication(applicationname string) (err error) {
-	// This won't miss units, because a Dying service cannot have units added
-	// to it. But we do have to remove the units themselves via individual
-	// transactions, because they could be in any state at all.
+	// This won't miss units, because a Dying application cannot have units
+	// added to it. But we do have to remove the units themselves via
+	// individual transactions, because they could be in any state at all.
 	units, closer := st.getCollection(unitsC)
 	defer closer()
 

--- a/state/model_test.go
+++ b/state/model_test.go
@@ -576,16 +576,16 @@ func (s *ModelSuite) TestDestroyModelEmpty(c *gc.C) {
 }
 
 func (s *ModelSuite) TestProcessDyingServerEnvironTransitionDyingToDead(c *gc.C) {
-	s.assertDyingEnvironTransitionDyingToDead(c, s.State)
+	s.assertDyingModelTransitionDyingToDead(c, s.State)
 }
 
 func (s *ModelSuite) TestProcessDyingHostedEnvironTransitionDyingToDead(c *gc.C) {
 	st := s.Factory.MakeModel(c, nil)
 	defer st.Close()
-	s.assertDyingEnvironTransitionDyingToDead(c, st)
+	s.assertDyingModelTransitionDyingToDead(c, st)
 }
 
-func (s *ModelSuite) assertDyingEnvironTransitionDyingToDead(c *gc.C, st *state.State) {
+func (s *ModelSuite) assertDyingModelTransitionDyingToDead(c *gc.C, st *state.State) {
 	// Add a service to prevent the model from transitioning directly to Dead.
 	// Add the service before getting the Model, otherwise we'll have to run
 	// the transaction twice, and hit the hook point too early.
@@ -612,7 +612,7 @@ func (s *ModelSuite) assertDyingEnvironTransitionDyingToDead(c *gc.C, st *state.
 	c.Assert(env.Destroy(), jc.ErrorIsNil)
 }
 
-func (s *ModelSuite) TestProcessDyingEnvironWithMachinesAndServicesNoOp(c *gc.C) {
+func (s *ModelSuite) TestProcessDyingModelWithMachinesAndServicesNoOp(c *gc.C) {
 	st := s.Factory.MakeModel(c, nil)
 	defer st.Close()
 
@@ -659,6 +659,84 @@ func (s *ModelSuite) TestProcessDyingEnvironWithMachinesAndServicesNoOp(c *gc.C)
 
 	c.Assert(env.Refresh(), jc.ErrorIsNil)
 	c.Assert(env.Destroy(), jc.ErrorIsNil)
+}
+
+func (s *ModelSuite) TestProcessDyingModelWithVolumeBackedFilesystems(c *gc.C) {
+	st := s.Factory.MakeModel(c, nil)
+	defer st.Close()
+
+	model, err := st.Model()
+	c.Assert(err, jc.ErrorIsNil)
+
+	machine, err := st.AddOneMachine(state.MachineTemplate{
+		Series: "quantal",
+		Jobs:   []state.MachineJob{state.JobHostUnits},
+		Filesystems: []state.MachineFilesystemParams{{
+			Filesystem: state.FilesystemParams{
+				Pool: "environscoped-block",
+				Size: 123,
+			},
+		}},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	filesystems, err := st.AllFilesystems()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(filesystems, gc.HasLen, 1)
+
+	c.Assert(model.Destroy(), jc.ErrorIsNil)
+	err = st.DetachFilesystem(machine.MachineTag(), names.NewFilesystemTag("0/0"))
+	c.Assert(err, jc.ErrorIsNil)
+	err = st.RemoveFilesystemAttachment(machine.MachineTag(), names.NewFilesystemTag("0/0"))
+	c.Assert(err, jc.ErrorIsNil)
+	err = st.DetachVolume(machine.MachineTag(), names.NewVolumeTag("0"))
+	c.Assert(err, jc.ErrorIsNil)
+	err = st.RemoveVolumeAttachment(machine.MachineTag(), names.NewVolumeTag("0"))
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(machine.EnsureDead(), jc.ErrorIsNil)
+	c.Assert(machine.Remove(), jc.ErrorIsNil)
+
+	// The filesystem will be gone, but the volume is persistent and should
+	// not have been removed.
+	err = st.ProcessDyingModel()
+	c.Assert(err, gc.ErrorMatches, `model not empty, found 1 volume\(s\)`)
+}
+
+func (s *ModelSuite) TestProcessDyingModelWithVolumes(c *gc.C) {
+	st := s.Factory.MakeModel(c, nil)
+	defer st.Close()
+
+	model, err := st.Model()
+	c.Assert(err, jc.ErrorIsNil)
+
+	machine, err := st.AddOneMachine(state.MachineTemplate{
+		Series: "quantal",
+		Jobs:   []state.MachineJob{state.JobHostUnits},
+		Volumes: []state.MachineVolumeParams{{
+			Volume: state.VolumeParams{
+				Pool: "environscoped",
+				Size: 123,
+			},
+		}},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	volumes, err := st.AllVolumes()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(volumes, gc.HasLen, 1)
+
+	c.Assert(model.Destroy(), jc.ErrorIsNil)
+	err = st.DetachVolume(machine.MachineTag(), names.NewVolumeTag("0"))
+	c.Assert(err, jc.ErrorIsNil)
+	err = st.RemoveVolumeAttachment(machine.MachineTag(), names.NewVolumeTag("0"))
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(machine.EnsureDead(), jc.ErrorIsNil)
+	c.Assert(machine.Remove(), jc.ErrorIsNil)
+
+	// The volume is persistent and should not have been removed along with
+	// the machine it was attached to.
+	err = st.ProcessDyingModel()
+	c.Assert(err, gc.ErrorMatches, `model not empty, found 1 volume\(s\)`)
 }
 
 func (s *ModelSuite) TestProcessDyingControllerEnvironWithHostedEnvsNoOp(c *gc.C) {

--- a/state/storage.go
+++ b/state/storage.go
@@ -307,7 +307,7 @@ func removeStorageInstanceOps(
 			C:      c,
 			Id:     id,
 			Assert: bson.D{{"storageid", tag.Id()}},
-			Update: bson.D{{"$set", bson.D{{"storageid", ""}}}},
+			Update: bson.D{{"$unset", bson.D{{"storageid", nil}}}},
 		}
 	}
 
@@ -320,7 +320,7 @@ func removeStorageInstanceOps(
 			volumesC, volume.Tag().Id(),
 		))
 		if volume.LifeBinding() == tag {
-			ops = append(ops, destroyVolumeOps(st, volume)...)
+			ops = append(ops, destroyVolumeOps(st, volume, nil)...)
 		}
 	} else if !errors.IsNotFound(err) {
 		return nil, errors.Trace(err)
@@ -331,13 +331,13 @@ func removeStorageInstanceOps(
 			filesystemsC, filesystem.Tag().Id(),
 		))
 		if filesystem.LifeBinding() == tag {
-			ops = append(ops, destroyFilesystemOps(st, filesystem)...)
+			ops = append(ops, destroyFilesystemOps(st, filesystem, nil)...)
 		}
 	} else if !errors.IsNotFound(err) {
 		return nil, errors.Trace(err)
 	}
 
-	// Decrement the charm storage reference count.
+	// Decrement the storage reference count.
 	refcounts, closer := st.getCollection(refcountsC)
 	defer closer()
 	storageName, err := names.StorageName(tag.Id())

--- a/state/unit.go
+++ b/state/unit.go
@@ -1396,14 +1396,14 @@ func validateDynamicMachineStorageParams(m *Machine, params *machineStorageParam
 func machineStoragePools(st *State, params *machineStorageParams) (set.Strings, error) {
 	pools := make(set.Strings)
 	for _, v := range params.volumes {
-		v, err := st.volumeParamsWithDefaults(v.Volume)
+		v, err := st.volumeParamsWithDefaults(v.Volume, "")
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
 		pools.Add(v.Pool)
 	}
 	for _, f := range params.filesystems {
-		f, err := st.filesystemParamsWithDefaults(f.Filesystem)
+		f, err := st.filesystemParamsWithDefaults(f.Filesystem, "")
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
@@ -1846,6 +1846,9 @@ func machineStorageParamsForStorageInstance(
 			cons := allCons[storage.StorageName()]
 			volumeParams := VolumeParams{
 				storage: storage.StorageTag(),
+				// TODO(axw) when we have commands for removing
+				// floating storage, drop the binding so that
+				// storage is persistent by default.
 				binding: storage.StorageTag(),
 				Pool:    cons.Pool,
 				Size:    cons.Size,
@@ -1882,6 +1885,9 @@ func machineStorageParamsForStorageInstance(
 			cons := allCons[storage.StorageName()]
 			filesystemParams := FilesystemParams{
 				storage: storage.StorageTag(),
+				// TODO(axw) when we have commands for removing
+				// floating storage, drop the binding so that
+				// storage is persistent by default.
 				binding: storage.StorageTag(),
 				Pool:    cons.Pool,
 				Size:    cons.Size,

--- a/state/volume.go
+++ b/state/volume.go
@@ -151,8 +151,6 @@ func (v *volume) validate() error {
 		}
 		switch tag.(type) {
 		case names.ModelTag:
-			// TODO(axw) support binding to model
-			return errors.NotSupportedf("binding to model")
 		case names.MachineTag:
 		case names.FilesystemTag:
 		case names.StorageTag:
@@ -434,12 +432,15 @@ func (st *State) removeMachineVolumesOps(machine names.MachineTag) ([]txn.Op, er
 		if !canRemove {
 			return nil, errors.Errorf("machine has non-machine bound volume %v", volumeTag.Id())
 		}
-		ops = append(ops, txn.Op{
-			C:      volumesC,
-			Id:     volumeTag.Id(),
-			Assert: txn.DocExists,
-			Remove: true,
-		})
+		ops = append(ops,
+			txn.Op{
+				C:      volumesC,
+				Id:     volumeTag.Id(),
+				Assert: txn.DocExists,
+				Remove: true,
+			},
+			removeModelVolumeRefOp(st, volumeTag.Id()),
+		)
 	}
 	return ops, nil
 }
@@ -455,30 +456,41 @@ func isVolumeInherentlyMachineBound(st *State, tag names.VolumeTag) (bool, error
 	volumeInfo, err := volume.Info()
 	if errors.IsNotProvisioned(err) {
 		params, _ := volume.Params()
-		_, provider, err := poolStorageProvider(st, params.Pool)
-		if err != nil {
-			return false, errors.Trace(err)
-		}
-		if provider.Scope() == storage.ScopeMachine {
-			// Any storage created by a machine must be destroyed
-			// along with the machine.
-			return true, nil
-		}
-		if provider.Dynamic() {
-			// We don't know ahead of time whether the storage
-			// will be Persistent, so we assume it will be, and
-			// rely on the environment-level storage provisioner
-			// to clean up.
-			return false, nil
-		}
-		// Volume is static, so even if it is provisioned, it will
-		// be tied to the machine.
-		return true, nil
+		return isVolumeParamsInherentlyMachineBound(st, params)
 	} else if err != nil {
 		return false, errors.Trace(err)
 	}
 	// If volume does not outlive machine it can be removed.
 	return !volumeInfo.Persistent, nil
+}
+
+// isVolumeParamsInherentlyMachineBound reports whether or not the given volume
+// params will create a volume inherently bound to the lifetime of a machine,
+// and will be removed along with it, leaving no resources dangling.
+func isVolumeParamsInherentlyMachineBound(st *State, params VolumeParams) (bool, error) {
+	_, provider, err := poolStorageProvider(st, params.Pool)
+	if err != nil {
+		return false, errors.Trace(err)
+	}
+	if provider.Scope() == storage.ScopeMachine {
+		// Any storage created by a machine must be destroyed
+		// along with the machine.
+		return true, nil
+	}
+	if provider.Dynamic() {
+		// NOTE(axw) In theory, we don't know ahead of time
+		// whether the storage will be Persistent, as the model
+		// allows for a dynamic storage provider to create non-
+		// persistent storage. None of the storage providers do
+		// this, so we assume it will be persistent for now.
+		//
+		// TODO(axw) get rid of the Persistent field from Volume
+		// and Filesystem. We only need to care whether the
+		// storage is dynamic and model-scoped.
+		return false, nil
+	}
+	// Volume is static, so it will be tied to the machine.
+	return true, nil
 }
 
 // DetachVolume marks the volume attachment identified by the specified machine
@@ -655,21 +667,32 @@ func (st *State) DestroyVolume(tag names.VolumeTag) (err error) {
 		} else if err != nil {
 			return nil, errors.Trace(err)
 		}
+		if volume.doc.StorageId != "" {
+			return nil, errors.Errorf(
+				"volume is assigned to %s",
+				names.ReadableString(names.NewStorageTag(volume.doc.StorageId)),
+			)
+		}
 		if volume.Life() != Alive {
 			return nil, jujutxn.ErrNoOperations
 		}
-		return destroyVolumeOps(st, volume), nil
+		hasNoStorageAssignment := bson.D{{"$or", []bson.D{
+			{{"storageid", ""}},
+			{{"storageid", bson.D{{"$exists", false}}}},
+		}}}
+		return destroyVolumeOps(st, volume, hasNoStorageAssignment), nil
 	}
 	return st.run(buildTxn)
 }
 
-func destroyVolumeOps(st *State, v *volume) []txn.Op {
+func destroyVolumeOps(st *State, v *volume, extraAssert bson.D) []txn.Op {
+	baseAssert := append(isAliveDoc, extraAssert...)
 	if v.doc.AttachmentCount == 0 {
 		hasNoAttachments := bson.D{{"attachmentcount", 0}}
 		return []txn.Op{{
 			C:      volumesC,
 			Id:     v.doc.Name,
-			Assert: append(hasNoAttachments, isAliveDoc...),
+			Assert: append(hasNoAttachments, baseAssert...),
 			Update: bson.D{{"$set", bson.D{{"life", Dead}}}},
 		}}
 	}
@@ -678,7 +701,7 @@ func destroyVolumeOps(st *State, v *volume) []txn.Op {
 	return []txn.Op{{
 		C:      volumesC,
 		Id:     v.doc.Name,
-		Assert: append(hasAttachments, isAliveDoc...),
+		Assert: append(hasAttachments, baseAssert...),
 		Update: bson.D{{"$set", bson.D{{"life", Dying}}}},
 	}, cleanupOp}
 }
@@ -704,6 +727,7 @@ func (st *State) RemoveVolume(tag names.VolumeTag) (err error) {
 				Assert: txn.DocExists,
 				Remove: true,
 			},
+			removeModelVolumeRefOp(st, tag.Id()),
 			removeStatusOp(st, volumeGlobalKey(tag.Id())),
 		}, nil
 	}
@@ -731,10 +755,7 @@ func newVolumeName(st *State, machineId string) (string, error) {
 // provider is machine-scoped, then the volume will be scoped to that
 // machine.
 func (st *State) addVolumeOps(params VolumeParams, machineId string) ([]txn.Op, names.VolumeTag, error) {
-	if params.binding == nil {
-		params.binding = names.NewMachineTag(machineId)
-	}
-	params, err := st.volumeParamsWithDefaults(params)
+	params, err := st.volumeParamsWithDefaults(params, machineId)
 	if err != nil {
 		return nil, names.VolumeTag{}, errors.Trace(err)
 	}
@@ -770,27 +791,38 @@ func (st *State) newVolumeOps(doc volumeDoc, status statusDoc) []txn.Op {
 			Assert: txn.DocMissing,
 			Insert: &doc,
 		},
+		addModelVolumeRefOp(st, doc.Name),
 	}
 }
 
-func (st *State) volumeParamsWithDefaults(params VolumeParams) (VolumeParams, error) {
-	if params.Pool != "" {
-		return params, nil
+func (st *State) volumeParamsWithDefaults(params VolumeParams, machineId string) (VolumeParams, error) {
+	if params.Pool == "" {
+		modelConfig, err := st.ModelConfig()
+		if err != nil {
+			return VolumeParams{}, errors.Trace(err)
+		}
+		cons := StorageConstraints{
+			Pool:  params.Pool,
+			Size:  params.Size,
+			Count: 1,
+		}
+		poolName, err := defaultStoragePool(modelConfig, storage.StorageKindBlock, cons)
+		if err != nil {
+			return VolumeParams{}, errors.Annotate(err, "getting default block storage pool")
+		}
+		params.Pool = poolName
 	}
-	envConfig, err := st.ModelConfig()
-	if err != nil {
-		return VolumeParams{}, errors.Trace(err)
+	if params.binding == nil {
+		machineBound, err := isVolumeParamsInherentlyMachineBound(st, params)
+		if err != nil {
+			return VolumeParams{}, errors.Trace(err)
+		}
+		if machineBound {
+			params.binding = names.NewMachineTag(machineId)
+		} else {
+			params.binding = st.ModelTag()
+		}
 	}
-	cons := StorageConstraints{
-		Pool:  params.Pool,
-		Size:  params.Size,
-		Count: 1,
-	}
-	poolName, err := defaultStoragePool(envConfig, storage.StorageKindBlock, cons)
-	if err != nil {
-		return VolumeParams{}, errors.Annotate(err, "getting default block storage pool")
-	}
-	params.Pool = poolName
 	return params, nil
 }
 

--- a/state/volume_test.go
+++ b/state/volume_test.go
@@ -292,7 +292,12 @@ func (s *VolumeStateSuite) TestWatchModelVolumes(c *gc.C) {
 	wc.AssertChangeInSingleEvent("3")
 	wc.AssertNoChange()
 
-	err := s.State.DestroyVolume(names.NewVolumeTag("0"))
+	volume, err := s.State.Volume(names.NewVolumeTag("0"))
+	c.Assert(err, jc.ErrorIsNil)
+	storageTag, err := volume.StorageInstance()
+	c.Assert(err, jc.ErrorIsNil)
+	removeStorageInstance(c, s.State, storageTag)
+	err = s.State.DestroyVolume(names.NewVolumeTag("0"))
 	c.Assert(err, jc.ErrorIsNil)
 	wc.AssertChangeInSingleEvent("0") // dying
 	wc.AssertNoChange()
@@ -359,7 +364,12 @@ func (s *VolumeStateSuite) TestWatchMachineVolumes(c *gc.C) {
 	// no change, since we're only interested in the one machine.
 	wc.AssertNoChange()
 
-	err := s.State.DestroyVolume(names.NewVolumeTag("0/1"))
+	volume, err := s.State.Volume(names.NewVolumeTag("0/1"))
+	c.Assert(err, jc.ErrorIsNil)
+	storageTag, err := volume.StorageInstance()
+	c.Assert(err, jc.ErrorIsNil)
+	removeStorageInstance(c, s.State, storageTag)
+	err = s.State.DestroyVolume(volume.VolumeTag())
 	c.Assert(err, jc.ErrorIsNil)
 	wc.AssertChangeInSingleEvent("0/1") // dying
 	wc.AssertNoChange()
@@ -480,7 +490,7 @@ func (s *VolumeStateSuite) assertCreateVolumes(c *gc.C) (_ *state.Machine, all, 
 	volume2 := s.volume(c, names.NewVolumeTag("0/1"))
 	volume3 := s.volume(c, names.NewVolumeTag("2"))
 
-	c.Assert(volume1.LifeBinding(), gc.Equals, machine.MachineTag())
+	c.Assert(volume1.LifeBinding(), gc.Equals, s.State.ModelTag())
 	c.Assert(volume2.LifeBinding(), gc.Equals, machine.MachineTag())
 	c.Assert(volume3.LifeBinding(), gc.Equals, machine.MachineTag())
 
@@ -561,6 +571,19 @@ func (s *VolumeStateSuite) TestDestroyVolume(c *gc.C) {
 	}
 	defer state.SetBeforeHooks(c, s.State, assertDestroy).Check()
 	assertDestroy()
+}
+
+func (s *VolumeStateSuite) TestDestroyVolumeStorageAssigned(c *gc.C) {
+	volume, _ := s.setupStorageVolumeAttachment(c)
+	storageTag, err := volume.StorageInstance()
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = s.State.DestroyVolume(volume.VolumeTag())
+	c.Assert(err, gc.ErrorMatches, "destroying volume 0/0: volume is assigned to storage data/0")
+
+	removeStorageInstance(c, s.State, storageTag)
+	err = s.State.DestroyVolume(volume.VolumeTag())
+	c.Assert(err, jc.ErrorIsNil)
 }
 
 func (s *VolumeStateSuite) TestDestroyVolumeNoAttachments(c *gc.C) {
@@ -809,7 +832,7 @@ func (s *VolumeStateSuite) TestEnsureMachineDeadRemoveVolumeConcurrently(c *gc.C
 	c.Assert(err, jc.ErrorIsNil)
 }
 
-func (s *VolumeStateSuite) TestVolumeBindingMachine(c *gc.C) {
+func (s *VolumeStateSuite) TestVolumeBindingModel(c *gc.C) {
 	machine, err := s.State.AddOneMachine(state.MachineTemplate{
 		Series: "quantal",
 		Jobs:   []state.MachineJob{state.JobHostUnits},
@@ -819,9 +842,35 @@ func (s *VolumeStateSuite) TestVolumeBindingMachine(c *gc.C) {
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
-	// Volumes created unassigned to a storage instance are
-	// bound to the initially attached machine.
+	// Model-scoped volumes created unassigned to a storage instance are
+	// bound to the model.
 	volume := s.volume(c, names.NewVolumeTag("0"))
+	c.Assert(volume.LifeBinding(), gc.Equals, s.State.ModelTag())
+	c.Assert(volume.Life(), gc.Equals, state.Alive)
+
+	// Detaching the volume from the machine should not cause it to be
+	// destroyed.
+	err = s.State.DetachVolume(machine.MachineTag(), volume.VolumeTag())
+	c.Assert(err, jc.ErrorIsNil)
+	err = s.State.RemoveVolumeAttachment(machine.MachineTag(), volume.VolumeTag())
+	c.Assert(err, jc.ErrorIsNil)
+	volume = s.volume(c, volume.VolumeTag())
+	c.Assert(volume.Life(), gc.Equals, state.Alive)
+}
+
+func (s *VolumeStateSuite) TestVolumeBindingMachine(c *gc.C) {
+	machine, err := s.State.AddOneMachine(state.MachineTemplate{
+		Series: "quantal",
+		Jobs:   []state.MachineJob{state.JobHostUnits},
+		Volumes: []state.MachineVolumeParams{{
+			Volume: state.VolumeParams{Pool: "loop", Size: 1024},
+		}},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Machine-scoped volumes created unassigned to a storage instance are
+	// bound to the machine.
+	volume := s.volume(c, names.NewVolumeTag("0/0"))
 	c.Assert(volume.LifeBinding(), gc.Equals, machine.Tag())
 	c.Assert(volume.Life(), gc.Equals, state.Alive)
 
@@ -831,44 +880,67 @@ func (s *VolumeStateSuite) TestVolumeBindingMachine(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	volume = s.volume(c, volume.VolumeTag())
 	c.Assert(volume.Life(), gc.Equals, state.Dead)
-
-	// TODO(axw) when we can assign storage to an existing volume, we
-	// should test that a machine-bound volume is not destroyed when
-	// its assigned storage instance is removed.
 }
 
 func (s *VolumeStateSuite) TestVolumeBindingStorage(c *gc.C) {
 	// Volumes created assigned to a storage instance are bound
-	// to the storage instance.
-	volume, _ := s.setupVolumeAttachment(c)
+	// to the machine/model, and not the storage. i.e. storage
+	// is persistent by default.
+	volume, machine := s.setupStorageVolumeAttachment(c)
 	storageTag, err := volume.StorageInstance()
 	c.Assert(err, jc.ErrorIsNil)
+
+	// TODO(axw) when we switch the default binding from storage
+	// to machine/model, delete the following line and drop the
+	// "if false".
 	c.Assert(volume.LifeBinding(), gc.Equals, storageTag)
+	if false {
+		c.Assert(volume.LifeBinding(), gc.Equals, machine.Tag())
 
-	err = s.State.DestroyStorageInstance(storageTag)
-	c.Assert(err, jc.ErrorIsNil)
-	attachments, err := s.State.StorageAttachments(storageTag)
-	c.Assert(err, jc.ErrorIsNil)
-	for _, a := range attachments {
-		err = s.State.DestroyStorageAttachment(storageTag, a.Unit())
-		c.Assert(err, jc.ErrorIsNil)
-		err = s.State.RemoveStorageAttachment(storageTag, a.Unit())
-		c.Assert(err, jc.ErrorIsNil)
+		// The volume should remain Alive when the storage is removed.
+		removeStorageInstance(c, s.State, storageTag)
+		volume = s.volume(c, volume.VolumeTag())
+		c.Assert(volume.Life(), gc.Equals, state.Alive)
 	}
-
-	// The storage instance should be removed,
-	// and the volume should be Dying.
-	_, err = s.State.StorageInstance(storageTag)
-	c.Assert(err, jc.Satisfies, errors.IsNotFound)
-	volume = s.volume(c, volume.VolumeTag())
-	c.Assert(volume.Life(), gc.Equals, state.Dying)
 }
 
-func (s *VolumeStateSuite) setupVolumeAttachment(c *gc.C) (state.Volume, *state.Machine) {
+func (s *VolumeStateSuite) setupStorageVolumeAttachment(c *gc.C) (state.Volume, *state.Machine) {
 	_, u, storageTag := s.setupSingleStorage(c, "block", "loop-pool")
 	err := s.State.AssignUnit(u, state.AssignCleanEmpty)
 	c.Assert(err, jc.ErrorIsNil)
 	assignedMachineId, err := u.AssignedMachineId()
 	c.Assert(err, jc.ErrorIsNil)
 	return s.storageInstanceVolume(c, storageTag), s.machine(c, assignedMachineId)
+}
+
+func (s *VolumeStateSuite) setupVolumeAttachment(c *gc.C) (state.Volume, *state.Machine) {
+	machine, err := s.State.AddOneMachine(state.MachineTemplate{
+		Series: "quantal",
+		Jobs:   []state.MachineJob{state.JobHostUnits},
+		Volumes: []state.MachineVolumeParams{{
+			Volume: state.VolumeParams{Pool: "loop", Size: 1024},
+		}},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	volumeAttachments, err := s.State.MachineVolumeAttachments(machine.MachineTag())
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(volumeAttachments, gc.HasLen, 1)
+	volume, err := s.State.Volume(volumeAttachments[0].Volume())
+	c.Assert(err, jc.ErrorIsNil)
+	return volume, machine
+}
+
+func removeStorageInstance(c *gc.C, st *state.State, storageTag names.StorageTag) {
+	err := st.DestroyStorageInstance(storageTag)
+	c.Assert(err, jc.ErrorIsNil)
+	attachments, err := st.StorageAttachments(storageTag)
+	c.Assert(err, jc.ErrorIsNil)
+	for _, a := range attachments {
+		err = st.DestroyStorageAttachment(storageTag, a.Unit())
+		c.Assert(err, jc.ErrorIsNil)
+		err = st.RemoveStorageAttachment(storageTag, a.Unit())
+		c.Assert(err, jc.ErrorIsNil)
+	}
+	_, err = st.StorageInstance(storageTag)
+	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 }

--- a/storage/provider/managedfs.go
+++ b/storage/provider/managedfs.go
@@ -50,9 +50,10 @@ func NewManagedFilesystemSource(
 
 // ValidateFilesystemParams is defined on storage.FilesystemSource.
 func (s *managedFilesystemSource) ValidateFilesystemParams(arg storage.FilesystemParams) error {
-	if _, err := s.backingVolumeBlockDevice(arg.Volume); err != nil {
-		return errors.Trace(err)
-	}
+	// NOTE(axw) the parameters may be for destroying a filesystem, which
+	// may be called when the backing volume is detached from the machine.
+	// We must not perform any validation here that would fail if the
+	// volume is detached.
 	return nil
 }
 


### PR DESCRIPTION
## Description of change

We make various changes to the state package
to allow for volumes and filesystems to be
bound to a model, rather than only machine
or storage instance. We continue to bind
the storage to storage instances; we will
later flip the switch when commands for
detaching, attaching, and removing storage
have been introduced.

This is the minimal change. Volume-backed
filesystems are currently always considered
machine-scoped, which leads to undesirable
behaviour: the filesystem cannot be detached
from the machine it is initially attached to
(or doing so will cause the volume to be
destroyed). We will need to make further
changes so that volume-backed filesystems
are not scoped or bound to a single machine.

This is based on https://github.com/juju/juju/pull/6795,
with a couple of small fixes to the assertions; and
until we have commands for destroying storage, we
continue to bind machine storage to the storage
instance.

## QA steps

1. juju bootstrap localhost
2. juju deploy a charm with rootfs storage
3. juju remove-unit
4. ensure the machine storage is also removed