### PR TITLE
Collect worker startup blocks on charm dir guard.

### DIFF
--- a/worker/metrics/collect/manifold.go
+++ b/worker/metrics/collect/manifold.go
@@ -125,19 +125,25 @@ func newCollect(config ManifoldConfig, context dependency.Context) (*collect, er
 
 	var agent agent.Agent
 	if err := context.Get(config.AgentName, &agent); err != nil {
-		return nil, err
+		return nil, errors.Trace(err)
 	}
 
 	var metricFactory spool.MetricFactory
 	err := context.Get(config.MetricSpoolName, &metricFactory)
 	if err != nil {
-		return nil, err
+		return nil, errors.Trace(err)
 	}
 
 	var charmdir fortress.Guest
 	err = context.Get(config.CharmDirName, &charmdir)
 	if err != nil {
-		return nil, err
+		return nil, errors.Trace(err)
+	}
+	err = charmdir.Visit(func() error {
+		return nil
+	}, context.Abort())
+	if err != nil {
+		return nil, errors.Trace(err)
 	}
 
 	agentConfig := agent.CurrentConfig()


### PR DESCRIPTION
This should smooth over a transient state in which the charm directory
has not been created yet, and the collect manifold starts up trying to
read the charm.

## Please provide the following details to expedite Pull Request review:

----

## Description of change

> Why is this change needed?

It resolves log noise due to the collect manifold trying to start before the charm directory is created:

https://bugs.launchpad.net/juju/+bug/1656258
https://bugs.launchpad.net/juju/+bug/1629819
https://bugs.launchpad.net/juju/+bug/1599269
https://bugs.launchpad.net/juju/+bug/1632006

## QA steps

> How do we verify that the change works?

If you can recreate the case which causes the log noise above, specifically, such that the charm dir does not exist when the collect manifold starts.

## Documentation changes

> Does it affect current user workflow? CLI? API?

Nah.

## Bug reference

> Does this change fix a bug? Please add a link to it.

Examples of the log noise are in the bugs listed above. This PR specifically fixes https://bugs.launchpad.net/juju/+bug/1656258.