### PR TITLE
Added default value for no_proxy

### DIFF
--- a/apiserver/provisioner/provisioner_test.go
+++ b/apiserver/provisioner/provisioner_test.go
@@ -1174,8 +1174,13 @@ func (s *withoutControllerSuite) TestContainerConfig(c *gc.C) {
 	}
 	err := s.State.UpdateModelConfig(attrs, nil, nil)
 	c.Assert(err, jc.ErrorIsNil)
-	expectedProxy := proxy.Settings{
+	expectedAPTProxy := proxy.Settings{
 		Http: "http://proxy.example.com:9000",
+	}
+
+	expectedProxy := proxy.Settings{
+		Http:    "http://proxy.example.com:9000",
+		NoProxy: "127.0.0.1,localhost,::1",
 	}
 
 	results, err := s.provisioner.ContainerConfig()
@@ -1185,7 +1190,7 @@ func (s *withoutControllerSuite) TestContainerConfig(c *gc.C) {
 	c.Check(results.AuthorizedKeys, gc.Equals, s.Environ.Config().AuthorizedKeys())
 	c.Check(results.SSLHostnameVerification, jc.IsTrue)
 	c.Check(results.Proxy, gc.DeepEquals, expectedProxy)
-	c.Check(results.AptProxy, gc.DeepEquals, expectedProxy)
+	c.Check(results.AptProxy, gc.DeepEquals, expectedAPTProxy)
 	c.Check(results.AptMirror, gc.DeepEquals, "http://example.mirror.com")
 }
 

--- a/apiserver/proxyupdater/proxyupdater.go
+++ b/apiserver/proxyupdater/proxyupdater.go
@@ -137,6 +137,10 @@ func (api *ProxyUpdaterAPI) proxyConfig() params.ProxyConfigResult {
 	noProxySet := set.NewStrings(noProxy...)
 	for _, host := range apiHostPorts {
 		for _, hp := range host {
+			if hp.Address.Scope == network.ScopeMachineLocal ||
+				hp.Address.Scope == network.ScopeLinkLocal {
+				continue
+			}
 			noProxySet.Add(hp.Address.Value)
 		}
 	}

--- a/environs/config/config.go
+++ b/environs/config/config.go
@@ -336,7 +336,7 @@ var defaultConfigValues = map[string]interface{}{
 	HTTPProxyKey:     "",
 	HTTPSProxyKey:    "",
 	FTPProxyKey:      "",
-	NoProxyKey:       "",
+	NoProxyKey:       "127.0.0.1,localhost,::1",
 	AptHTTPProxyKey:  "",
 	AptHTTPSProxyKey: "",
 	AptFTPProxyKey:   "",

--- a/environs/config/config_test.go
+++ b/environs/config/config_test.go
@@ -1062,7 +1062,7 @@ func (s *ConfigSuite) TestProxyValuesNotSet(c *gc.C) {
 	c.Assert(config.AptHTTPSProxy(), gc.Equals, "")
 	c.Assert(config.FTPProxy(), gc.Equals, "")
 	c.Assert(config.AptFTPProxy(), gc.Equals, "")
-	c.Assert(config.NoProxy(), gc.Equals, "")
+	c.Assert(config.NoProxy(), gc.Equals, "127.0.0.1,localhost,::1")
 }
 
 func (s *ConfigSuite) TestProxyConfigMap(c *gc.C) {
@@ -1098,7 +1098,7 @@ func (s *ConfigSuite) TestAptProxyConfigMap(c *gc.C) {
 	cfg, err := cfg.Apply(config.AptProxyConfigMap(proxySettings))
 	c.Assert(err, jc.ErrorIsNil)
 	// The default proxy settings should still be empty.
-	c.Assert(cfg.ProxySettings(), gc.DeepEquals, proxy.Settings{})
+	c.Assert(cfg.ProxySettings(), gc.DeepEquals, proxy.Settings{NoProxy: "127.0.0.1,localhost,::1"})
 	c.Assert(cfg.AptProxySettings(), gc.DeepEquals, proxySettings)
 }
 

--- a/state/modelconfig_test.go
+++ b/state/modelconfig_test.go
@@ -465,7 +465,7 @@ func (s *ModelConfigSourceSuite) TestUpdateModelConfigDefaults(c *gc.C) {
 			Value: "http://dummy-mirror",
 		}}}
 	expectedValues["no-proxy"] = config.AttributeDefaultValues{
-		Default: "",
+		Default: "127.0.0.1,localhost,::1",
 		Regions: []config.RegionDefaultValue{{
 			Name:  "dummy-region",
 			Value: "dummy-proxy",
@@ -520,7 +520,7 @@ func (s *ModelConfigSourceSuite) TestUpdateModelConfigRegionDefaults(c *gc.C) {
 			Value: "http://dummy-mirror",
 		}}}
 	expectedValues["no-proxy"] = config.AttributeDefaultValues{
-		Default: "",
+		Default: "127.0.0.1,localhost,::1",
 		Regions: []config.RegionDefaultValue{{
 			Name:  "dummy-region",
 			Value: "changed-proxy",
@@ -573,7 +573,7 @@ func (s *ModelConfigSourceSuite) TestUpdateModelConfigDefaultValuesUnknownRegion
 	cfg, err := s.State.ModelConfigDefaultValues()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cfg["no-proxy"], jc.DeepEquals, config.AttributeDefaultValues{
-		Default:    "",
+		Default:    "127.0.0.1,localhost,::1",
 		Controller: nil,
 		Regions: []config.RegionDefaultValue{
 			config.RegionDefaultValue{

--- a/upgrades/backend.go
+++ b/upgrades/backend.go
@@ -22,6 +22,7 @@ type StateBackend interface {
 	AddMigrationAttempt() error
 	AddLocalCharmSequences() error
 	UpdateLegacyLXDCloudCredentials(string, cloud.Credential) error
+	UpgradeNoProxyDefaults() error
 }
 
 // Model is an interface providing access to the details of a model within the
@@ -74,6 +75,10 @@ func (s stateBackend) AddLocalCharmSequences() error {
 
 func (s stateBackend) UpdateLegacyLXDCloudCredentials(endpoint string, credential cloud.Credential) error {
 	return state.UpdateLegacyLXDCloudCredentials(s.st, endpoint, credential)
+}
+
+func (s stateBackend) UpgradeNoProxyDefaults() error {
+	return state.UpgradeNoProxyDefaults(s.st)
 }
 
 type modelShim struct {


### PR DESCRIPTION
## Description of change

no_proxy configuration now has localhost values as a
default so users can eliminate them if they so require.
localhost hostname was added.

## QA steps

Bootstrap a cotnroller, and deploy a machine.
In the machine env NO_PROXY and no_proxy should contain the following values:
 * localhost
 * 127.0.0.1
 * ::1
 * the ip of the machine

Also, running `juju model-config` should yield
`no-proxy                    default  127.0.0.1,localhost,::1
`
## Bug reference

https://bugs.launchpad.net/juju/+bug/1637370