### PR TITLE
Add remote firewaller facade

### DIFF
--- a/api/apiclient.go
+++ b/api/apiclient.go
@@ -270,6 +270,25 @@ func open(
 	return st, nil
 }
 
+type NewConnectionForModelFunc func(*Info) (func(string) (Connection, error), error)
+
+// NewConnectionForModel returns a function which returns a model API
+// connection for a specified model UUID, based on the specified api info.
+// Currently, such a connection will always be to a single controller.
+func NewConnectionForModel(apiInfo *Info) (func(string) (Connection, error), error) {
+	return func(modelUUID string) (Connection, error) {
+		apiInfo.ModelTag = names.NewModelTag(modelUUID)
+		conn, err := Open(apiInfo, DialOpts{
+			Timeout:    time.Second,
+			RetryDelay: 200 * time.Millisecond,
+		})
+		if err != nil {
+			return nil, errors.Annotatef(err, "failed to open API to model %s", modelUUID)
+		}
+		return conn, nil
+	}, nil
+}
+
 // hostSwitchingTransport provides an http.RoundTripper
 // that chooses an actual RoundTripper to use
 // depending on the destination host.

--- a/api/facadeversions.go
+++ b/api/facadeversions.go
@@ -71,6 +71,7 @@ var facadeVersions = map[string]int{
 	"ProxyUpdater":                 1,
 	"Reboot":                       2,
 	"RelationUnitsWatcher":         1,
+	"RemoteFirewaller":             1,
 	"RemoteRelations":              1,
 	"Resources":                    1,
 	"ResourcesHookContext":         1,

--- a/api/remotefirewaller/package_test.go
+++ b/api/remotefirewaller/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package remotefirewaller_test
+
+import (
+	stdtesting "testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func TestAll(t *stdtesting.T) {
+	gc.TestingT(t)
+}

--- a/api/remotefirewaller/remotefirewaller.go
+++ b/api/remotefirewaller/remotefirewaller.go
@@ -1,0 +1,46 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package remotefirewaller
+
+import (
+	"github.com/juju/errors"
+
+	"github.com/juju/juju/api/base"
+	apiwatcher "github.com/juju/juju/api/watcher"
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/watcher"
+)
+
+const remoteFirewallerFacade = "RemoteFirewaller"
+
+// Client provides access to the networks api facade.
+type Client struct {
+	base.ClientFacade
+	facade base.FacadeCaller
+}
+
+// NewClient creates a new client-side Networks facade.
+func NewClient(caller base.APICallCloser) *Client {
+	frontend, backend := base.NewClientFacade(caller, remoteFirewallerFacade)
+	return &Client{ClientFacade: frontend, facade: backend}
+}
+
+// WatchSubnets returns a strings watcher that notifies of the addition,
+// removal, and lifecycle changes of subnets in the model.
+func (c *Client) WatchSubnets() (watcher.StringsWatcher, error) {
+	var result params.StringsWatchResult
+	err := c.facade.FacadeCall("WatchSubnets", nil, &result)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	if result.Error != nil {
+		return nil, errors.Trace(result.Error)
+	}
+	w := apiwatcher.NewStringsWatcher(c.facade.RawAPICaller(), result)
+	return w, nil
+}
+
+func (c *Client) Close() error {
+	return c.ClientFacade.Close()
+}

--- a/api/remotefirewaller/remotefirewaller_test.go
+++ b/api/remotefirewaller/remotefirewaller_test.go
@@ -1,0 +1,47 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package remotefirewaller_test
+
+import (
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/api/base/testing"
+	"github.com/juju/juju/api/remotefirewaller"
+	"github.com/juju/juju/apiserver/params"
+	coretesting "github.com/juju/juju/testing"
+)
+
+var _ = gc.Suite(&RemoteFirewallersSuite{})
+
+type RemoteFirewallersSuite struct {
+	coretesting.BaseSuite
+}
+
+func (s *RemoteFirewallersSuite) TestNewClient(c *gc.C) {
+	apiCaller := testing.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
+		return nil
+	})
+	client := remotefirewaller.NewClient(apiCaller)
+	c.Assert(client, gc.NotNil)
+}
+
+func (s *RemoteFirewallersSuite) TestWatchSubnets(c *gc.C) {
+	var callCount int
+	apiCaller := testing.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
+		c.Check(objType, gc.Equals, "RemoteFirewaller")
+		c.Check(version, gc.Equals, 0)
+		c.Check(id, gc.Equals, "")
+		c.Check(request, gc.Equals, "WatchSubnets")
+		c.Assert(result, gc.FitsTypeOf, &params.StringsWatchResult{})
+		*(result.(*params.StringsWatchResult)) = params.StringsWatchResult{
+			Error: &params.Error{Message: "FAIL"},
+		}
+		callCount++
+		return nil
+	})
+	client := remotefirewaller.NewClient(apiCaller)
+	_, err := client.WatchSubnets()
+	c.Check(err, gc.ErrorMatches, "FAIL")
+	c.Check(callCount, gc.Equals, 1)
+}

--- a/apiserver/allfacades.go
+++ b/apiserver/allfacades.go
@@ -58,6 +58,7 @@ import (
 	_ "github.com/juju/juju/apiserver/provisioner"
 	_ "github.com/juju/juju/apiserver/proxyupdater"
 	_ "github.com/juju/juju/apiserver/reboot"
+	_ "github.com/juju/juju/apiserver/remotefirewaller"
 	_ "github.com/juju/juju/apiserver/remoterelations"
 	_ "github.com/juju/juju/apiserver/resumer"
 	_ "github.com/juju/juju/apiserver/retrystrategy"

--- a/apiserver/remotefirewaller/mock_test.go
+++ b/apiserver/remotefirewaller/mock_test.go
@@ -1,0 +1,73 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package remotefirewaller_test
+
+import (
+	"github.com/juju/testing"
+	"gopkg.in/tomb.v1"
+
+	"github.com/juju/juju/state"
+)
+
+type mockState struct {
+	testing.Stub
+	modelUUID      string
+	subnetsWatcher *mockStringsWatcher
+}
+
+func newMockState(modelUUID string) *mockState {
+	return &mockState{
+		modelUUID:      modelUUID,
+		subnetsWatcher: newMockStringsWatcher(),
+	}
+}
+
+func (st *mockState) ModelUUID() string {
+	return st.modelUUID
+}
+
+func (st *mockState) WatchSubnets() state.StringsWatcher {
+	st.MethodCall(st, "WatchSubnets")
+	return st.subnetsWatcher
+}
+
+type mockWatcher struct {
+	testing.Stub
+	tomb.Tomb
+}
+
+func (w *mockWatcher) doneWhenDying() {
+	<-w.Tomb.Dying()
+	w.Tomb.Done()
+}
+
+func (w *mockWatcher) Kill() {
+	w.MethodCall(w, "Kill")
+	w.Tomb.Kill(nil)
+}
+
+func (w *mockWatcher) Stop() error {
+	w.MethodCall(w, "Stop")
+	if err := w.NextErr(); err != nil {
+		return err
+	}
+	w.Tomb.Kill(nil)
+	return w.Tomb.Wait()
+}
+
+type mockStringsWatcher struct {
+	mockWatcher
+	changes chan []string
+}
+
+func newMockStringsWatcher() *mockStringsWatcher {
+	w := &mockStringsWatcher{changes: make(chan []string, 1)}
+	go w.doneWhenDying()
+	return w
+}
+
+func (w *mockStringsWatcher) Changes() <-chan []string {
+	w.MethodCall(w, "Changes")
+	return w.changes
+}

--- a/apiserver/remotefirewaller/package_test.go
+++ b/apiserver/remotefirewaller/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package remotefirewaller_test
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func TestAll(t *testing.T) {
+	gc.TestingT(t)
+}

--- a/apiserver/remotefirewaller/remotefirewaller.go
+++ b/apiserver/remotefirewaller/remotefirewaller.go
@@ -1,0 +1,60 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package remotefirewaller
+
+import (
+	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/facade"
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/feature"
+	"github.com/juju/juju/state/watcher"
+)
+
+func init() {
+	common.RegisterStandardFacadeForFeature("RemoteFirewaller", 1, NewStateRemoteFirewallerAPI, feature.CrossModelRelations)
+}
+
+// FirewallerAPI provides access to the Remote Firewaller API facade.
+type FirewallerAPI struct {
+	st         State
+	resources  facade.Resources
+	authorizer facade.Authorizer
+}
+
+// NewStateRemoteFirewallerAPI creates a new server-side RemoteFirewallerAPI facade.
+func NewStateRemoteFirewallerAPI(ctx facade.Context) (*FirewallerAPI, error) {
+	return NewRemoteFirewallerAPI(stateShim{ctx.State()}, ctx.Resources(), ctx.Auth())
+}
+
+// NewRemoteFirewallerAPI creates a new server-side FirewallerAPI facade.
+func NewRemoteFirewallerAPI(
+	st State,
+	resources facade.Resources,
+	authorizer facade.Authorizer,
+) (*FirewallerAPI, error) {
+	if !authorizer.AuthController() {
+		return nil, common.ErrPerm
+	}
+	return &FirewallerAPI{
+		st:         st,
+		resources:  resources,
+		authorizer: authorizer,
+	}, nil
+}
+
+// WatchSubnets creates a strings watcher that notifies of the addition,
+// removal, and lifecycle changes of subnets in the model.
+func (f *FirewallerAPI) WatchSubnets() (params.StringsWatchResult, error) {
+	var result params.StringsWatchResult
+
+	watch := f.st.WatchSubnets()
+	// Consume the initial event and forward it to the result.
+	initial, ok := <-watch.Changes()
+	if !ok {
+		return params.StringsWatchResult{}, watcher.EnsureErr(watch)
+	}
+	result.StringsWatcherId = f.resources.Register(watch)
+	result.Changes = initial
+	return result, nil
+}

--- a/apiserver/remotefirewaller/remotefirewaller_test.go
+++ b/apiserver/remotefirewaller/remotefirewaller_test.go
@@ -1,0 +1,64 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package remotefirewaller_test
+
+import (
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/names.v2"
+
+	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/remotefirewaller"
+	apiservertesting "github.com/juju/juju/apiserver/testing"
+	"github.com/juju/juju/state"
+	coretesting "github.com/juju/juju/testing"
+)
+
+var _ = gc.Suite(&RemoteFirewallerSuite{})
+
+type RemoteFirewallerSuite struct {
+	coretesting.BaseSuite
+
+	resources  *common.Resources
+	authorizer *apiservertesting.FakeAuthorizer
+	st         *mockState
+	api        *remotefirewaller.FirewallerAPI
+}
+
+func (s *RemoteFirewallerSuite) SetUpTest(c *gc.C) {
+	s.BaseSuite.SetUpTest(c)
+
+	s.resources = common.NewResources()
+	s.AddCleanup(func(_ *gc.C) { s.resources.StopAll() })
+
+	s.authorizer = &apiservertesting.FakeAuthorizer{
+		Tag:        names.NewMachineTag("0"),
+		Controller: true,
+	}
+
+	s.st = newMockState(coretesting.ModelTag.Id())
+	api, err := remotefirewaller.NewRemoteFirewallerAPI(s.st, s.resources, s.authorizer)
+	c.Assert(err, jc.ErrorIsNil)
+	s.api = api
+}
+
+func (s *RemoteFirewallerSuite) TestWatchSubnets(c *gc.C) {
+	subnetIds := []string{"1", "2"}
+	s.st.subnetsWatcher.changes <- subnetIds
+
+	result, err := s.api.WatchSubnets()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result.Error, gc.IsNil)
+	c.Assert(result.StringsWatcherId, gc.Equals, "1")
+	c.Assert(result.Changes, jc.DeepEquals, subnetIds)
+
+	resource := s.resources.Get("1")
+	c.Assert(resource, gc.NotNil)
+	c.Assert(resource, gc.Implements, new(state.StringsWatcher))
+
+	s.st.CheckCalls(c, []testing.StubCall{
+		{"WatchSubnets", nil},
+	})
+}

--- a/apiserver/remotefirewaller/state.go
+++ b/apiserver/remotefirewaller/state.go
@@ -1,0 +1,24 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package remotefirewaller
+
+import (
+	"github.com/juju/juju/state"
+)
+
+// State provides the subset of global state required by the
+// remote firewaller facade.
+type State interface {
+	// ModelUUID returns the model UUID for the model
+	// controlled by this state instance.
+	ModelUUID() string
+
+	// WatchSubnets returns a StringsWatcher that notifies of changes to
+	// the lifecycles of the subnets in the model.
+	WatchSubnets() state.StringsWatcher
+}
+
+type stateShim struct {
+	*state.State
+}

--- a/cmd/jujud/agent/model/manifolds.go
+++ b/cmd/jujud/agent/model/manifolds.go
@@ -250,8 +250,14 @@ func Manifolds(config ManifoldsConfig) dependency.Manifolds {
 			Scope:         modelTag,
 		})),
 		firewallerName: ifNotMigrating(firewaller.Manifold(firewaller.ManifoldConfig{
-			APICallerName: apiCallerName,
-			EnvironName:   environTrackerName,
+			AgentName:          agentName,
+			APICallerName:      apiCallerName,
+			EnvironName:        environTrackerName,
+			NewAPIConnForModel: api.NewConnectionForModel,
+
+			NewFirewallerWorker:      firewaller.NewWorker,
+			NewFirewallerFacade:      firewaller.NewFirewallerFacade,
+			NewRemoteRelationsFacade: firewaller.NewRemoteRelationsFacade,
 		})),
 		unitAssignerName: ifNotMigrating(unitassigner.Manifold(unitassigner.ManifoldConfig{
 			APICallerName: apiCallerName,
@@ -299,7 +305,7 @@ func Manifolds(config ManifoldsConfig) dependency.Manifolds {
 		result[remoteRelationsName] = ifNotMigrating(remoterelations.Manifold(remoterelations.ManifoldConfig{
 			AgentName:                agentName,
 			APICallerName:            apiCallerName,
-			APIOpen:                  api.Open,
+			NewAPIConnForModel:       api.NewConnectionForModel,
 			NewRemoteRelationsFacade: remoterelations.NewRemoteRelationsFacade,
 			NewWorker:                remoterelations.NewWorker,
 		}))

--- a/state/watcher.go
+++ b/state/watcher.go
@@ -2789,3 +2789,9 @@ func (st *State) WatchRemoteRelations() StringsWatcher {
 	}
 	return newLifecycleWatcher(st, relationsC, nil, filter, tr)
 }
+
+// WatchSubnets returns a StringsWatcher that notifies of changes to
+// the lifecycles of the subnets in the model.
+func (st *State) WatchSubnets() StringsWatcher {
+	return newLifecycleWatcher(st, subnetsC, nil, isLocalID(st), nil)
+}

--- a/worker/firewaller/manifold.go
+++ b/worker/firewaller/manifold.go
@@ -6,8 +6,9 @@ package firewaller
 import (
 	"github.com/juju/errors"
 
+	"github.com/juju/juju/agent"
+	"github.com/juju/juju/api"
 	"github.com/juju/juju/api/base"
-	"github.com/juju/juju/api/firewaller"
 	"github.com/juju/juju/api/remoterelations"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/config"
@@ -17,41 +18,107 @@ import (
 
 // ManifoldConfig describes the resources used by the firewaller worker.
 type ManifoldConfig struct {
+	AgentName     string
 	APICallerName string
 	EnvironName   string
+
+	NewAPIConnForModel       api.NewConnectionForModelFunc
+	NewRemoteRelationsFacade func(base.APICaller) (*remoterelations.Client, error)
+	NewFirewallerFacade      func(base.APICaller) (FirewallerAPI, error)
+	NewFirewallerWorker      func(Config) (worker.Worker, error)
 }
 
 // Manifold returns a Manifold that encapsulates the firewaller worker.
 func Manifold(cfg ManifoldConfig) dependency.Manifold {
 	return dependency.Manifold{
 		Inputs: []string{
+			cfg.AgentName,
 			cfg.APICallerName,
 			cfg.EnvironName,
 		},
-		Start: func(context dependency.Context) (worker.Worker, error) {
-			var apiCaller base.APICaller
-			if err := context.Get(cfg.APICallerName, &apiCaller); err != nil {
-				return nil, errors.Trace(err)
-			}
-			var environ environs.Environ
-			if err := context.Get(cfg.EnvironName, &environ); err != nil {
-				return nil, errors.Trace(err)
-			}
-			mode := environ.Config().FirewallMode()
-			if mode == config.FwNone {
-				logger.Infof("stopping firewaller (not required)")
-				return nil, dependency.ErrUninstall
-			}
-			return manifoldStart(environ, apiCaller, mode)
-		},
+		Start: cfg.start,
 	}
 }
 
-// manifoldStart creates a firewaller worker, given a base.APICaller.
-func manifoldStart(env environs.Environ, apiCaller base.APICaller, firewallMode string) (worker.Worker, error) {
-	firewallerApi := firewaller.NewState(apiCaller)
-	remoteRelationsApi := remoterelations.NewClient(apiCaller)
-	w, err := NewFirewaller(env, firewallerApi, firewallMode, remoteRelationsApi)
+// Validate is called by start to check for bad configuration.
+func (cfg ManifoldConfig) Validate() error {
+	if cfg.AgentName == "" {
+		return errors.NotValidf("empty AgentName")
+	}
+	if cfg.APICallerName == "" {
+		return errors.NotValidf("empty APICallerName")
+	}
+	if cfg.EnvironName == "" {
+		return errors.NotValidf("empty EnvironName")
+	}
+	if cfg.NewAPIConnForModel == nil {
+		return errors.NotValidf("nil NewAPIConnForModel")
+	}
+	if cfg.NewRemoteRelationsFacade == nil {
+		return errors.NotValidf("nil NewRemoteRelationsFacade")
+	}
+	if cfg.NewFirewallerFacade == nil {
+		return errors.NotValidf("nil NewFirewallerFacade")
+	}
+	if cfg.NewFirewallerWorker == nil {
+		return errors.NotValidf("nil NewFirewallerWorker")
+	}
+	return nil
+}
+
+// start is a StartFunc for a Worker manifold.
+func (cfg ManifoldConfig) start(context dependency.Context) (worker.Worker, error) {
+	if err := cfg.Validate(); err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	var agent agent.Agent
+	if err := context.Get(cfg.AgentName, &agent); err != nil {
+		return nil, errors.Trace(err)
+	}
+	var apiConn api.Connection
+	if err := context.Get(cfg.APICallerName, &apiConn); err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	var environ environs.Environ
+	if err := context.Get(cfg.EnvironName, &environ); err != nil {
+		return nil, errors.Trace(err)
+	}
+	mode := environ.Config().FirewallMode()
+	if mode == config.FwNone {
+		logger.Infof("stopping firewaller (not required)")
+		return nil, dependency.ErrUninstall
+	}
+
+	agentConf := agent.CurrentConfig()
+	apiInfo, ok := agentConf.APIInfo()
+	if !ok {
+		return nil, errors.New("no API connection details")
+	}
+	apiConnForModelFunc, err := cfg.NewAPIConnForModel(apiInfo)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	firewallerAPI, err := cfg.NewFirewallerFacade(apiConn)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	remoteRelationsAPI, err := cfg.NewRemoteRelationsFacade(apiConn)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	w, err := cfg.NewFirewallerWorker(Config{
+		ModelUUID:          agent.CurrentConfig().Model().Id(),
+		RemoteRelationsApi: remoteRelationsAPI,
+		FirewallerAPI:      firewallerAPI,
+		EnvironFirewaller:  environ,
+		EnvironInstances:   environ,
+		Mode:               mode,
+		NewRemoteFirewallerAPIFunc: remoteFirewallerAPIFunc(apiConnForModelFunc),
+	})
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/worker/firewaller/manifold_test.go
+++ b/worker/firewaller/manifold_test.go
@@ -4,12 +4,18 @@
 package firewaller_test
 
 import (
+	"github.com/juju/errors"
 	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/api"
+	"github.com/juju/juju/api/base"
+	"github.com/juju/juju/api/remoterelations"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/config"
 	coretesting "github.com/juju/juju/testing"
+	"github.com/juju/juju/worker"
 	"github.com/juju/juju/worker/dependency"
 	"github.com/juju/juju/worker/firewaller"
 )
@@ -30,8 +36,13 @@ func (s *ManifoldSuite) TestManifoldFirewallModeNone(c *gc.C) {
 	}
 
 	manifold := firewaller.Manifold(firewaller.ManifoldConfig{
-		APICallerName: "api-caller",
-		EnvironName:   "environ",
+		AgentName:                "agent",
+		APICallerName:            "api-caller",
+		EnvironName:              "environ",
+		NewAPIConnForModel:       func(*api.Info) (func(string) (api.Connection, error), error) { return nil, nil },
+		NewFirewallerFacade:      func(base.APICaller) (firewaller.FirewallerAPI, error) { return nil, nil },
+		NewFirewallerWorker:      func(firewaller.Config) (worker.Worker, error) { return nil, nil },
+		NewRemoteRelationsFacade: func(base.APICaller) (*remoterelations.Client, error) { return nil, nil },
 	})
 	_, err := manifold.Start(ctx)
 	c.Assert(err, gc.Equals, dependency.ErrUninstall)
@@ -56,4 +67,73 @@ type mockEnviron struct {
 
 func (e *mockEnviron) Config() *config.Config {
 	return e.config
+}
+
+type ManifoldConfigSuite struct {
+	testing.IsolationSuite
+	config firewaller.ManifoldConfig
+}
+
+var _ = gc.Suite(&ManifoldConfigSuite{})
+
+func (s *ManifoldConfigSuite) SetUpTest(c *gc.C) {
+	s.IsolationSuite.SetUpTest(c)
+	s.config = s.validConfig()
+}
+
+func (s *ManifoldConfigSuite) validConfig() firewaller.ManifoldConfig {
+	return firewaller.ManifoldConfig{
+		AgentName:                "agent",
+		APICallerName:            "api-caller",
+		EnvironName:              "environ",
+		NewAPIConnForModel:       func(*api.Info) (func(string) (api.Connection, error), error) { return nil, nil },
+		NewFirewallerFacade:      func(base.APICaller) (firewaller.FirewallerAPI, error) { return nil, nil },
+		NewFirewallerWorker:      func(firewaller.Config) (worker.Worker, error) { return nil, nil },
+		NewRemoteRelationsFacade: func(base.APICaller) (*remoterelations.Client, error) { return nil, nil },
+	}
+}
+
+func (s *ManifoldConfigSuite) TestValid(c *gc.C) {
+	c.Check(s.config.Validate(), jc.ErrorIsNil)
+}
+
+func (s *ManifoldConfigSuite) TestMissingAgentName(c *gc.C) {
+	s.config.AgentName = ""
+	s.checkNotValid(c, "empty AgentName not valid")
+}
+
+func (s *ManifoldConfigSuite) TestMissingAPICallerName(c *gc.C) {
+	s.config.APICallerName = ""
+	s.checkNotValid(c, "empty APICallerName not valid")
+}
+
+func (s *ManifoldConfigSuite) TestMissingEnvironName(c *gc.C) {
+	s.config.EnvironName = ""
+	s.checkNotValid(c, "empty EnvironName not valid")
+}
+
+func (s *ManifoldConfigSuite) TestMissingNewFirewallerFacade(c *gc.C) {
+	s.config.NewFirewallerFacade = nil
+	s.checkNotValid(c, "nil NewFirewallerFacade not valid")
+}
+
+func (s *ManifoldConfigSuite) TestMissingNewFirewallerWorker(c *gc.C) {
+	s.config.NewFirewallerWorker = nil
+	s.checkNotValid(c, "nil NewFirewallerWorker not valid")
+}
+
+func (s *ManifoldConfigSuite) TestMissingNewAPIConnForModel(c *gc.C) {
+	s.config.NewAPIConnForModel = nil
+	s.checkNotValid(c, "nil NewAPIConnForModel not valid")
+}
+
+func (s *ManifoldConfigSuite) TestMissingNewRemoteRelationsFacade(c *gc.C) {
+	s.config.NewRemoteRelationsFacade = nil
+	s.checkNotValid(c, "nil NewRemoteRelationsFacade not valid")
+}
+
+func (s *ManifoldConfigSuite) checkNotValid(c *gc.C, expect string) {
+	err := s.config.Validate()
+	c.Check(err, gc.ErrorMatches, expect)
+	c.Check(err, jc.Satisfies, errors.IsNotValid)
 }

--- a/worker/firewaller/shim.go
+++ b/worker/firewaller/shim.go
@@ -1,0 +1,64 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package firewaller
+
+import (
+	"io"
+
+	"github.com/juju/errors"
+
+	"github.com/juju/juju/api"
+	"github.com/juju/juju/api/base"
+	"github.com/juju/juju/api/firewaller"
+	"github.com/juju/juju/api/remotefirewaller"
+	"github.com/juju/juju/api/remoterelations"
+	"github.com/juju/juju/worker"
+)
+
+// NewRemoteRelationsFacade creates a remote relations API facade.
+func NewRemoteRelationsFacade(apiCaller base.APICaller) (*remoterelations.Client, error) {
+	facade := remoterelations.NewClient(apiCaller)
+	return facade, nil
+}
+
+// NewFirewallerFacade creates a firewaller API facade.
+func NewFirewallerFacade(apiCaller base.APICaller) (FirewallerAPI, error) {
+	facade := firewaller.NewState(apiCaller)
+	return facade, nil
+}
+
+// NewWorker creates a firewaller worker.
+func NewWorker(cfg Config) (worker.Worker, error) {
+	w, err := NewFirewaller(cfg)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return w, nil
+}
+
+// remoteFirewallerAPIFunc returns a function that
+// can be used be construct instances which provide a
+// remote firewaller API facade for a given (remote) model.
+// For now we use a facade on the same controller.
+func remoteFirewallerAPIFunc(
+	apiConnForModelFunc func(string) (api.Connection, error),
+) func(string) (RemoteFirewallerAPICloser, error) {
+	return func(modelUUID string) (RemoteFirewallerAPICloser, error) {
+		conn, err := apiConnForModelFunc(modelUUID)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		facade := remotefirewaller.NewClient(conn)
+		return &firewallerAPICloser{facade, conn}, nil
+	}
+}
+
+type firewallerAPICloser struct {
+	RemoteFirewallerAPI
+	conn io.Closer
+}
+
+func (p *firewallerAPICloser) Close() error {
+	return p.conn.Close()
+}

--- a/worker/remoterelations/manifold_test.go
+++ b/worker/remoterelations/manifold_test.go
@@ -31,7 +31,7 @@ func (s *ManifoldConfigSuite) validConfig() remoterelations.ManifoldConfig {
 	return remoterelations.ManifoldConfig{
 		AgentName:                "agent",
 		APICallerName:            "api-caller",
-		APIOpen:                  func(*api.Info, api.DialOpts) (api.Connection, error) { return nil, nil },
+		NewAPIConnForModel:       func(*api.Info) (func(string) (api.Connection, error), error) { return nil, nil },
 		NewRemoteRelationsFacade: func(base.APICaller) (remoterelations.RemoteRelationsFacade, error) { return nil, nil },
 		NewWorker:                func(remoterelations.Config) (worker.Worker, error) { return nil, nil },
 	}
@@ -61,9 +61,9 @@ func (s *ManifoldConfigSuite) TestMissingNewWorker(c *gc.C) {
 	s.checkNotValid(c, "nil NewWorker not valid")
 }
 
-func (s *ManifoldConfigSuite) TestMissingAPIOpen(c *gc.C) {
-	s.config.APIOpen = nil
-	s.checkNotValid(c, "nil APIOpen not valid")
+func (s *ManifoldConfigSuite) TestMissingNewAPIConnForModel(c *gc.C) {
+	s.config.NewAPIConnForModel = nil
+	s.checkNotValid(c, "nil NewAPIConnForModel not valid")
 }
 
 func (s *ManifoldConfigSuite) checkNotValid(c *gc.C, expect string) {

--- a/worker/remoterelations/shim.go
+++ b/worker/remoterelations/shim.go
@@ -5,12 +5,9 @@ package remoterelations
 
 import (
 	"io"
-	"time"
 
 	"github.com/juju/errors"
-	"gopkg.in/juju/names.v2"
 
-	"github.com/juju/juju/agent"
 	"github.com/juju/juju/api"
 	"github.com/juju/juju/api/base"
 	"github.com/juju/juju/api/remoterelations"
@@ -28,28 +25,6 @@ func NewWorker(config Config) (worker.Worker, error) {
 		return nil, errors.Trace(err)
 	}
 	return w, nil
-}
-
-func apiConnForModelFunc(
-	a agent.Agent,
-	apiOpen func(*api.Info, api.DialOpts) (api.Connection, error),
-) (func(string) (api.Connection, error), error) {
-	agentConf := a.CurrentConfig()
-	apiInfo, ok := agentConf.APIInfo()
-	if !ok {
-		return nil, errors.New("no API connection details")
-	}
-	return func(modelUUID string) (api.Connection, error) {
-		apiInfo.ModelTag = names.NewModelTag(modelUUID)
-		conn, err := apiOpen(apiInfo, api.DialOpts{
-			Timeout:    time.Second,
-			RetryDelay: 200 * time.Millisecond,
-		})
-		if err != nil {
-			return nil, errors.Annotate(err, "failed to open API to remote model")
-		}
-		return conn, nil
-	}, nil
 }
 
 // relationChangePublisherForModelFunc returns a function that


### PR DESCRIPTION
## Description of change

This PR adds a new remote firewaller facade. The facade will be used by the firewaller worker and provides firewall/network related functionality against a different (remote) model, where a cross model application is hosted and a relation established.

The only method currently is WatchSubnets() which notifies of changes to subnets in a remote model. The next PR will move the IngressSubnetsForRelation() method off the remote relation facade and onto this new remote firewaller facade.

The worker uses a helper method to construct a remote firewaller facade to access a given model - the remote relations worker uses the same methodology so some code to manage the underlying API connection itself was extracted to a helper. At the moment, the result is a facade pointing to a model on the same controller, but in future will be used to allow cross controller interactions transparent to the worker.

The PR includes all the components of the facade - api, apiserver, state functionality. The firewaller worker manifold was restructured to allow tests to be updated later to plug in mocks etc (as part of the work to plug in the remote firewaller facade).

## QA steps

bootstrap aws
create 2 models and deploy an app to each
relate the apps across models
expose the app
check the ports

