### PR TITLE
Remove reference to "action status" in help.

### DIFF
--- a/cmd/juju/metricsdebug/collectmetrics.go
+++ b/cmd/juju/metricsdebug/collectmetrics.go
@@ -28,7 +28,7 @@ Trigger metrics collection
 
 This command waits for the metric collection to finish before returning.
 You may abort this command and it will continue to run asynchronously.
-Results may be checked by 'juju show-action-status'.
+Results may be checked  by 'juju show-action-status'.
 `
 
 const (

--- a/cmd/juju/metricsdebug/collectmetrics.go
+++ b/cmd/juju/metricsdebug/collectmetrics.go
@@ -28,7 +28,7 @@ Trigger metrics collection
 
 This command waits for the metric collection to finish before returning.
 You may abort this command and it will continue to run asynchronously.
-Results may be checked  by 'juju show-action-status'.
+Results may be checked by 'juju show-action-status'.
 `
 
 const (

--- a/cmd/juju/metricsdebug/collectmetrics.go
+++ b/cmd/juju/metricsdebug/collectmetrics.go
@@ -28,7 +28,7 @@ Trigger metrics collection
 
 This command waits for the metric collection to finish before returning.
 You may abort this command and it will continue to run asynchronously.
-Results may be checked by 'juju action status'.
+Results may be checked by 'juju show-action-status'.
 `
 
 const (


### PR DESCRIPTION
## Please provide the following details to expedite Pull Request review:

----

## Description of change

A metrics command help was directing to an old command.

## QA steps

1. run 'juju help collect-metrics'

Instead of mentioning 'juju action status' command, "juju show-action-status' should be mentioned. 

## Documentation changes

@juju/docs 
All references to 'juju action status' need to be updated to refer to 'juju show-action-status'.

## Bug reference

Fixes https://bugs.launchpad.net/juju/+bug/1666813
