### PR TITLE
Remove cloud references from file if last credential is removed.

### DIFF
--- a/cmd/juju/cloud/defaultregion_test.go
+++ b/cmd/juju/cloud/defaultregion_test.go
@@ -64,12 +64,20 @@ func (s *defaultRegionSuite) assertSetCustomDefaultRegion(c *gc.C, cmd cmd.Comma
 
 func (s *defaultRegionSuite) TestSetDefaultRegion(c *gc.C) {
 	store := jujuclienttesting.NewMemStore()
+	store.Credentials["aws"] = jujucloud.CloudCredential{
+		AuthCredentials: map[string]jujucloud.Credential{
+			"one": jujucloud.Credential{},
+		}}
 	cmd := cloud.NewSetDefaultRegionCommandForTest(store)
 	s.assertSetDefaultRegion(c, cmd, store, "aws", "")
 }
 
 func (s *defaultRegionSuite) TestSetDefaultRegionBuiltIn(c *gc.C) {
 	store := jujuclienttesting.NewMemStore()
+	store.Credentials["localhost"] = jujucloud.CloudCredential{
+		AuthCredentials: map[string]jujucloud.Credential{
+			"one": jujucloud.Credential{},
+		}}
 	cmd := cloud.NewSetDefaultRegionCommandForTest(store)
 	// Cloud 'localhost' is of type lxd.
 	s.assertSetCustomDefaultRegion(c, cmd, store, "localhost", "localhost", "")
@@ -77,14 +85,22 @@ func (s *defaultRegionSuite) TestSetDefaultRegionBuiltIn(c *gc.C) {
 
 func (s *defaultRegionSuite) TestOverwriteDefaultRegion(c *gc.C) {
 	store := jujuclienttesting.NewMemStore()
-	store.Credentials["aws"] = jujucloud.CloudCredential{DefaultRegion: "us-east-1"}
+	store.Credentials["aws"] = jujucloud.CloudCredential{
+		AuthCredentials: map[string]jujucloud.Credential{
+			"one": jujucloud.Credential{},
+		},
+		DefaultRegion: "us-east-1"}
 	cmd := cloud.NewSetDefaultRegionCommandForTest(store)
 	s.assertSetDefaultRegion(c, cmd, store, "aws", "")
 }
 
 func (s *defaultRegionSuite) TestCaseInsensitiveRegionSpecification(c *gc.C) {
 	store := jujuclienttesting.NewMemStore()
-	store.Credentials["aws"] = jujucloud.CloudCredential{DefaultRegion: "us-east-1"}
+	store.Credentials["aws"] = jujucloud.CloudCredential{
+		AuthCredentials: map[string]jujucloud.Credential{
+			"one": jujucloud.Credential{},
+		},
+		DefaultRegion: "us-east-1"}
 
 	cmd := cloud.NewSetDefaultRegionCommandForTest(store)
 	_, err := testing.RunCommand(c, cmd, "aws", "us-WEST-1")

--- a/jujuclient/credentials_test.go
+++ b/jujuclient/credentials_test.go
@@ -108,7 +108,6 @@ func (s *CredentialsSuite) TestUpdateCredentialRemovesCloudWhenNoCredentialLeft(
 	c.Assert(err, jc.ErrorIsNil)
 
 	_, exists := creds[s.cloudName]
-	c.Assert(creds[s.cloudName].AuthCredentials, gc.HasLen, 0)
 	c.Assert(exists, jc.IsFalse)
 }
 

--- a/jujuclient/credentials_test.go
+++ b/jujuclient/credentials_test.go
@@ -93,6 +93,25 @@ func (s *CredentialsSuite) TestUpdateCredentialRemovesDefaultIfNecessary(c *gc.C
 	c.Assert(creds[s.cloudName].DefaultCredential, gc.Equals, "")
 }
 
+func (s *CredentialsSuite) TestUpdateCredentialRemovesCloudWhenNoCredentialLeft(c *gc.C) {
+	s.cloudName = firstTestCloudName(c)
+
+	store := jujuclient.NewFileCredentialStore()
+	err := store.UpdateCredential(s.cloudName, s.credentials)
+	c.Assert(err, jc.ErrorIsNil)
+
+	// delete all
+	err = store.UpdateCredential(s.cloudName, cloud.CloudCredential{})
+	c.Assert(err, jc.ErrorIsNil)
+
+	creds, err := store.AllCredentials()
+	c.Assert(err, jc.ErrorIsNil)
+
+	_, exists := creds[s.cloudName]
+	c.Assert(creds[s.cloudName].AuthCredentials, gc.HasLen, 0)
+	c.Assert(exists, jc.IsFalse)
+}
+
 func (s *CredentialsSuite) assertCredentialsNotExists(c *gc.C) {
 	all := writeTestCredentialsFile(c)
 	_, exists := all[s.cloudName]

--- a/jujuclient/file.go
+++ b/jujuclient/file.go
@@ -627,12 +627,9 @@ func (s *store) UpdateCredential(cloudName string, details cloud.CloudCredential
 			details.DefaultCredential = ""
 		}
 	}
-
-	all[cloudName] = details
-
-	// If cloud has no credentials now, delete cloud references from
-	// credentials file as well.
-	if len(all[cloudName].AuthCredentials) == 0 {
+	if len(details.AuthCredentials) > 0 {
+		all[cloudName] = details
+	} else {
 		delete(all, cloudName)
 	}
 

--- a/jujuclient/file.go
+++ b/jujuclient/file.go
@@ -629,6 +629,13 @@ func (s *store) UpdateCredential(cloudName string, details cloud.CloudCredential
 	}
 
 	all[cloudName] = details
+
+	// If cloud has no credentials now, delete cloud references from
+	// credentials file as well.
+	if len(all[cloudName].AuthCredentials) == 0 {
+		delete(all, cloudName)
+	}
+
 	return WriteCredentialsFile(all)
 }
 

--- a/jujuclient/jujuclienttesting/mem.go
+++ b/jujuclient/jujuclienttesting/mem.go
@@ -300,10 +300,9 @@ func (c *MemStore) RemoveAccount(controllerName string) error {
 
 // UpdateCredential implements CredentialsUpdater.
 func (c *MemStore) UpdateCredential(cloudName string, details cloud.CloudCredential) error {
-	c.Credentials[cloudName] = details
-	// If cloud has no credentials now, delete cloud references from
-	// credentials file as well.
-	if len(c.Credentials[cloudName]) == 0 {
+	if len(details.AuthCredentials) > 0 {
+		c.Credentials[cloudName] = details
+	} else {
 		delete(c.Credentials, cloudName)
 	}
 	return nil

--- a/jujuclient/jujuclienttesting/mem.go
+++ b/jujuclient/jujuclienttesting/mem.go
@@ -301,6 +301,11 @@ func (c *MemStore) RemoveAccount(controllerName string) error {
 // UpdateCredential implements CredentialsUpdater.
 func (c *MemStore) UpdateCredential(cloudName string, details cloud.CloudCredential) error {
 	c.Credentials[cloudName] = details
+	// If cloud has no credentials now, delete cloud references from
+	// credentials file as well.
+	if len(c.Credentials[cloudName]) == 0 {
+		delete(c.Credentials, cloudName)
+	}
 	return nil
 }
 


### PR DESCRIPTION
## Please provide the following details to expedite Pull Request review:

----

## Description of change

When remove credential deletes last credential for a cloud, there is no need to keep reference for a cloud in credentials.yaml file.
In fact, it causes confusion as per the bug.

## QA steps

1. add cloud
2. add credential for it
3. remove cloud
4. remove credential for the removed cloud
Success criteria: 
a. listing credentials does not show message to re-run with --show-secrets flag
b. listing credential with --show-secrets does not list the cloud
c. credentials.yaml does not reference delete cloud

## Documentation changes

No documentation changes are needed.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1590237
