### PR TITLE
tools/lxdclient: add support for storage

### DIFF
--- a/tools/lxdclient/client.go
+++ b/tools/lxdclient/client.go
@@ -105,6 +105,7 @@ type Client struct {
 	*instanceClient
 	*imageClient
 	*networkClient
+	*storageClient
 	baseURL                  string
 	defaultProfileBridgeName string
 }
@@ -180,6 +181,7 @@ func Connect(cfg Config, verifyBridgeConfig bool) (*Client, error) {
 		instanceClient:           &instanceClient{raw, remoteID},
 		imageClient:              &imageClient{raw, connectToRaw},
 		networkClient:            &networkClient{raw, networkAPISupported},
+		storageClient:            &storageClient{raw, storageAPISupported},
 		baseURL:                  raw.BaseURL,
 		defaultProfileBridgeName: bridgeName,
 	}

--- a/tools/lxdclient/client_instance_test.go
+++ b/tools/lxdclient/client_instance_test.go
@@ -6,6 +6,9 @@
 package lxdclient_test
 
 import (
+	"errors"
+
+	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	lxdapi "github.com/lxc/lxd/shared/api"
 	gc "gopkg.in/check.v1"
@@ -176,4 +179,80 @@ func (s *addressesSuite) TestAddresses(c *gc.C) {
 			Scope: network.ScopeCloudLocal,
 		},
 	})
+}
+
+type devicesSuite struct {
+	lxdclient.BaseSuite
+}
+
+var _ = gc.Suite(&devicesSuite{})
+
+func (s *devicesSuite) TestAttachDisk(c *gc.C) {
+	client := lxdclient.NewInstanceClient(s.Client)
+	err := client.AttachDisk("instance", "device", lxdclient.DiskDevice{
+		Source: "source-value",
+		Path:   "path-value",
+		Pool:   "pool-value",
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	s.Stub.CheckCalls(c, []testing.StubCall{
+		{"ContainerDeviceAdd", []interface{}{"instance", "device", "disk", []string{
+			"path=path-value", "source=source-value", "pool=pool-value",
+		}}},
+		{"WaitForSuccess", []interface{}{""}},
+	})
+}
+
+func (s *devicesSuite) TestAttachDiskReadOnly(c *gc.C) {
+	client := lxdclient.NewInstanceClient(s.Client)
+	err := client.AttachDisk("instance", "device", lxdclient.DiskDevice{
+		Source:   "source-value",
+		Path:     "path-value",
+		ReadOnly: true,
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	s.Stub.CheckCall(c, 0, "ContainerDeviceAdd", "instance", "device", "disk", []string{
+		"path=path-value", "source=source-value", "readonly=true",
+	})
+}
+
+func (s *devicesSuite) TestAttachDiskSyncError(c *gc.C) {
+	s.Stub.SetErrors(errors.New("sync error"))
+	client := lxdclient.NewInstanceClient(s.Client)
+	err := client.AttachDisk("instance", "device", lxdclient.DiskDevice{})
+	c.Assert(err, gc.ErrorMatches, "sync error")
+}
+
+func (s *devicesSuite) TestAttachDiskAsyncError(c *gc.C) {
+	s.Stub.SetErrors(nil, errors.New("async error"))
+	client := lxdclient.NewInstanceClient(s.Client)
+	err := client.AttachDisk("instance", "device", lxdclient.DiskDevice{})
+	c.Assert(err, gc.ErrorMatches, "async error")
+}
+
+func (s *devicesSuite) TestRemoveDevice(c *gc.C) {
+	client := lxdclient.NewInstanceClient(s.Client)
+	err := client.RemoveDevice("instance", "device")
+	c.Assert(err, jc.ErrorIsNil)
+
+	s.Stub.CheckCalls(c, []testing.StubCall{
+		{"ContainerDeviceDelete", []interface{}{"instance", "device"}},
+		{"WaitForSuccess", []interface{}{""}},
+	})
+}
+
+func (s *devicesSuite) TestRemoveDeviceSyncError(c *gc.C) {
+	s.Stub.SetErrors(errors.New("sync error"))
+	client := lxdclient.NewInstanceClient(s.Client)
+	err := client.RemoveDevice("instance", "device")
+	c.Assert(err, gc.ErrorMatches, "sync error")
+}
+
+func (s *devicesSuite) TestRemoveDeviceAsyncError(c *gc.C) {
+	s.Stub.SetErrors(nil, errors.New("async error"))
+	client := lxdclient.NewInstanceClient(s.Client)
+	err := client.RemoveDevice("instance", "device")
+	c.Assert(err, gc.ErrorMatches, "async error")
 }

--- a/tools/lxdclient/client_storage.go
+++ b/tools/lxdclient/client_storage.go
@@ -1,0 +1,62 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+// +build go1.3
+
+package lxdclient
+
+import (
+	"github.com/juju/errors"
+	"github.com/lxc/lxd/shared/api"
+)
+
+type rawStorageClient interface {
+	StoragePoolVolumeTypeCreate(pool string, volume string, volumeType string, config map[string]string) error
+	StoragePoolVolumeTypeDelete(pool string, volume string, volumeType string) error
+	StoragePoolVolumesList(pool string) ([]api.StorageVolume, error)
+}
+
+type storageClient struct {
+	raw       rawStorageClient
+	supported bool
+}
+
+// StorageSupported reports whether or not storage is supported by the LXD remote.
+func (c *storageClient) StorageSupported() bool {
+	return c.supported
+}
+
+// VolumeCreate creates a volume in a storage pool.
+func (c *storageClient) VolumeCreate(pool, volume string, config map[string]string) error {
+	if !c.supported {
+		return errors.NotSupportedf("storage API on this remote")
+	}
+	return c.raw.StoragePoolVolumeTypeCreate(pool, volume, "custom", config)
+}
+
+// VolumeDelete deletes a volume from a storage pool.
+func (c *storageClient) VolumeDelete(pool, volume string) error {
+	if !c.supported {
+		return errors.NotSupportedf("storage API on this remote")
+	}
+	return c.raw.StoragePoolVolumeTypeDelete(pool, volume, "custom")
+}
+
+// VolumeList lists volumes in a storage pool, excluding any non-custom type
+// volumes.
+func (c *storageClient) VolumeList(pool string) ([]api.StorageVolume, error) {
+	if !c.supported {
+		return nil, errors.NotSupportedf("storage API on this remote")
+	}
+	all, err := c.raw.StoragePoolVolumesList(pool)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	custom := make([]api.StorageVolume, 0, len(all))
+	for _, v := range all {
+		if v.Type == "custom" {
+			custom = append(custom, v)
+		}
+	}
+	return custom, nil
+}

--- a/tools/lxdclient/client_storage_test.go
+++ b/tools/lxdclient/client_storage_test.go
@@ -1,0 +1,130 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+// +build go1.3
+
+package lxdclient_test
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	"github.com/lxc/lxd/shared/api"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/tools/lxdclient"
+)
+
+type StorageClientSuite struct {
+	testing.IsolationSuite
+
+	raw *mockRawStorageClient
+}
+
+var _ = gc.Suite(&StorageClientSuite{})
+
+func (s *StorageClientSuite) SetUpTest(c *gc.C) {
+	s.IsolationSuite.SetUpTest(c)
+
+	s.raw = &mockRawStorageClient{}
+}
+
+func (s *StorageClientSuite) TestStorageSupported(c *gc.C) {
+	client := lxdclient.NewStorageClient(s.raw, true)
+	c.Assert(client.StorageSupported(), jc.IsTrue)
+}
+
+func (s *StorageClientSuite) TestStorageNotSupported(c *gc.C) {
+	client := lxdclient.NewStorageClient(s.raw, false)
+	c.Assert(client.StorageSupported(), jc.IsFalse)
+
+	err := client.VolumeCreate("pool", "volume", nil)
+	c.Assert(err, jc.Satisfies, errors.IsNotSupported)
+
+	err = client.VolumeDelete("pool", "volume")
+	c.Assert(err, jc.Satisfies, errors.IsNotSupported)
+
+	_, err = client.VolumeList("pool")
+	c.Assert(err, jc.Satisfies, errors.IsNotSupported)
+}
+
+func (s *StorageClientSuite) TestVolumeCreate(c *gc.C) {
+	client := lxdclient.NewStorageClient(s.raw, true)
+	cfg := map[string]string{"foo": "bar"}
+	err := client.VolumeCreate("pool", "volume", cfg)
+	c.Assert(err, jc.ErrorIsNil)
+	s.raw.CheckCallNames(c, "StoragePoolVolumeTypeCreate")
+	s.raw.CheckCall(c, 0, "StoragePoolVolumeTypeCreate", "pool", "volume", "custom", cfg)
+}
+
+func (s *StorageClientSuite) TestVolumeCreateError(c *gc.C) {
+	s.raw.SetErrors(errors.New("burp"))
+	client := lxdclient.NewStorageClient(s.raw, true)
+	err := client.VolumeCreate("pool", "volume", nil)
+	c.Assert(err, gc.ErrorMatches, "burp")
+}
+
+func (s *StorageClientSuite) TestVolumeDelete(c *gc.C) {
+	client := lxdclient.NewStorageClient(s.raw, true)
+	err := client.VolumeDelete("pool", "volume")
+	c.Assert(err, jc.ErrorIsNil)
+	s.raw.CheckCallNames(c, "StoragePoolVolumeTypeDelete")
+	s.raw.CheckCall(c, 0, "StoragePoolVolumeTypeDelete", "pool", "volume", "custom")
+}
+
+func (s *StorageClientSuite) TestVolumeDeleteError(c *gc.C) {
+	s.raw.SetErrors(errors.New("burp"))
+	client := lxdclient.NewStorageClient(s.raw, true)
+	err := client.VolumeDelete("pool", "volume")
+	c.Assert(err, gc.ErrorMatches, "burp")
+}
+
+func (s *StorageClientSuite) TestVolumeList(c *gc.C) {
+	client := lxdclient.NewStorageClient(s.raw, true)
+	s.raw.volumes = []api.StorageVolume{{
+		Type: "custom",
+		StorageVolumePut: api.StorageVolumePut{
+			Name: "foo",
+		},
+	}, {
+		Type: "not-custom",
+		StorageVolumePut: api.StorageVolumePut{
+			Name: "bar",
+		},
+	}}
+	list, err := client.VolumeList("pool")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(list, jc.DeepEquals, s.raw.volumes[:1])
+	s.raw.CheckCallNames(c, "StoragePoolVolumeTypeList")
+	s.raw.CheckCall(c, 0, "StoragePoolVolumeTypeList", "pool")
+}
+
+func (s *StorageClientSuite) TestVolumeListError(c *gc.C) {
+	s.raw.SetErrors(errors.New("burp"))
+	client := lxdclient.NewStorageClient(s.raw, true)
+	_, err := client.VolumeList("pool")
+	c.Assert(err, gc.ErrorMatches, "burp")
+}
+
+type mockRawStorageClient struct {
+	testing.Stub
+	volumes []api.StorageVolume
+}
+
+func (c *mockRawStorageClient) StoragePoolVolumeTypeCreate(pool string, volume string, volumeType string, config map[string]string) error {
+	c.MethodCall(c, "StoragePoolVolumeTypeCreate", pool, volume, volumeType, config)
+	return c.NextErr()
+}
+
+func (c *mockRawStorageClient) StoragePoolVolumeTypeDelete(pool string, volume string, volumeType string) error {
+	c.MethodCall(c, "StoragePoolVolumeTypeDelete", pool, volume, volumeType)
+	return c.NextErr()
+}
+
+func (c *mockRawStorageClient) StoragePoolVolumesList(pool string) ([]api.StorageVolume, error) {
+	c.MethodCall(c, "StoragePoolVolumeTypeList", pool)
+	if err := c.NextErr(); err != nil {
+		return nil, err
+	}
+	return c.volumes, nil
+}

--- a/tools/lxdclient/export_test.go
+++ b/tools/lxdclient/export_test.go
@@ -11,12 +11,22 @@ import (
 
 var NewInstanceSummary = newInstanceSummary
 
-type RawInstanceClient rawInstanceClient
+type (
+	RawInstanceClient rawInstanceClient
+	RawStorageClient  rawStorageClient
+)
 
 func NewInstanceClient(raw RawInstanceClient) *instanceClient {
 	return &instanceClient{
 		raw:    rawInstanceClient(raw),
 		remote: "",
+	}
+}
+
+func NewStorageClient(raw RawStorageClient, supported bool) *storageClient {
+	return &storageClient{
+		raw:       raw,
+		supported: supported,
 	}
 }
 

--- a/tools/lxdclient/instance_test.go
+++ b/tools/lxdclient/instance_test.go
@@ -33,7 +33,24 @@ var templateContainerInfo = lxdapi.Container{
 			"limits.memory":  "256MB",
 			"user.something": "something value",
 		},
-		Devices:   nil,
+		Devices: map[string]map[string]string{
+			"disk0": {
+				"type":   "disk",
+				"source": "disk0",
+				"path":   "/mnt/disk0",
+				"pool":   "radiance",
+			},
+			"disk1": {
+				"type":     "disk",
+				"source":   "/tmp/disk1",
+				"path":     "/mnt/disk1",
+				"readonly": "true",
+			},
+			"fun": {
+				"type": "unix-char",
+				"path": "/dev/mem",
+			},
+		},
 		Ephemeral: false,
 		Profiles:  []string{""},
 	},
@@ -118,5 +135,24 @@ func (*instanceSuite) TestNamespaceMetadata(c *gc.C) {
 	c.Assert(sum.Metadata, gc.DeepEquals, map[string]string{
 		"foo": "bar",
 		"baz": "boo",
+	})
+}
+
+func (*instanceSuite) TestDisks(c *gc.C) {
+	summary := lxdclient.NewInstanceSummary(&templateContainerInfo)
+	inst := lxdclient.NewInstance(summary, nil)
+
+	disks := inst.Disks()
+	c.Assert(disks, jc.DeepEquals, map[string]lxdclient.DiskDevice{
+		"disk0": {
+			Source: "disk0",
+			Path:   "/mnt/disk0",
+			Pool:   "radiance",
+		},
+		"disk1": {
+			Source:   "/tmp/disk1",
+			Path:     "/mnt/disk1",
+			ReadOnly: true,
+		},
 	})
 }

--- a/tools/lxdclient/testing_test.go
+++ b/tools/lxdclient/testing_test.go
@@ -7,6 +7,7 @@ package lxdclient
 
 import (
 	"crypto/x509"
+	"io"
 	"runtime"
 
 	"github.com/juju/errors"
@@ -106,8 +107,8 @@ func (s *stubClient) GetAlias(alias string) string {
 	return s.Aliases[alias]
 }
 
-func (s *stubClient) Init(name, remote, image string, profiles *[]string, ephem bool) (*api.Response, error) {
-	s.stub.AddCall("AddInstance", name, remote, image, profiles, ephem)
+func (s *stubClient) Init(name, remote, image string, profiles *[]string, config map[string]string, devices map[string]map[string]string, ephem bool) (*api.Response, error) {
+	s.stub.AddCall("Init", name, remote, image, profiles, config, devices, ephem)
 	if err := s.stub.NextErr(); err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -148,4 +149,36 @@ func (s *stubClient) GetImageInfo(imageTarget string) (*api.Image, error) {
 		return nil, err
 	}
 	return &api.Image{}, nil
+}
+
+func (s *stubClient) ContainerDeviceAdd(container, devname, devtype string, props []string) (*api.Response, error) {
+	s.stub.AddCall("ContainerDeviceAdd", container, devname, devtype, props)
+	if err := s.stub.NextErr(); err != nil {
+		return nil, err
+	}
+	return &api.Response{}, nil
+}
+
+func (s *stubClient) ContainerDeviceDelete(container, devname string) (*api.Response, error) {
+	s.stub.AddCall("ContainerDeviceDelete", container, devname)
+	if err := s.stub.NextErr(); err != nil {
+		return nil, err
+	}
+	return &api.Response{}, nil
+}
+
+func (s *stubClient) ContainerInfo(name string) (*api.Container, error) {
+	s.stub.AddCall("ContainerInfo", name)
+	if err := s.stub.NextErr(); err != nil {
+		return nil, err
+	}
+	return &api.Container{}, nil
+}
+
+func (s *stubClient) PushFile(container, path string, gid int, uid int, mode string, buf io.ReadSeeker) error {
+	s.stub.AddCall("PushFile", container, path, gid, uid, mode, buf)
+	if err := s.stub.NextErr(); err != nil {
+		return err
+	}
+	return nil
 }


### PR DESCRIPTION
## Description of change

Add support for managing storage volumes,
and attaching/detaching them to/from
containers. This is required so that we can
implement a LXD storage provider.

## QA steps

No functional changes, so just smoke test:
```
juju bootstrap localhost
```

## Documentation changes

None

## Bug reference

None