### PR TITLE
provider/lxd: experimental LXD storage provider

### DIFF
--- a/feature/flags.go
+++ b/feature/flags.go
@@ -39,3 +39,6 @@ const DeveloperMode = "developer-mode"
 
 // CrossModelRelations allows cross model relations functionality.
 const CrossModelRelations = "cross-model"
+
+// LXDStorage enables the LXD storage provider.
+const LXDStorage = "lxd-storage"

--- a/provider/lxd/environ_raw.go
+++ b/provider/lxd/environ_raw.go
@@ -21,6 +21,7 @@ type rawProvider struct {
 	lxdInstances
 	lxdProfiles
 	lxdImages
+	lxdStorage
 	common.Firewaller
 
 	remote lxdclient.Remote
@@ -44,6 +45,8 @@ type lxdInstances interface {
 	AddInstance(lxdclient.InstanceSpec) (*lxdclient.Instance, error)
 	RemoveInstances(string, ...string) error
 	Addresses(string) ([]network.Address, error)
+	AttachDisk(string, string, lxdclient.DiskDevice) error
+	RemoveDevice(string, string) error
 }
 
 type lxdProfiles interface {
@@ -54,6 +57,13 @@ type lxdProfiles interface {
 
 type lxdImages interface {
 	EnsureImageExists(series, arch string, sources []lxdclient.Remote, copyProgressHandler func(string)) (string, error)
+}
+
+type lxdStorage interface {
+	StorageSupported() bool
+	VolumeCreate(pool, volume string, config map[string]string) error
+	VolumeDelete(pool, volume string) error
+	VolumeList(pool string) ([]lxdapi.StorageVolume, error)
 }
 
 func newRawProvider(spec environs.CloudSpec, local bool) (*rawProvider, error) {
@@ -87,6 +97,7 @@ func newRawProviderFromConfig(config lxdclient.Config) (*rawProvider, error) {
 		lxdInstances: client,
 		lxdProfiles:  client,
 		lxdImages:    client,
+		lxdStorage:   client,
 		Firewaller:   common.NewFirewaller(),
 		remote:       config.Remote,
 	}, nil

--- a/provider/lxd/storage.go
+++ b/provider/lxd/storage.go
@@ -1,22 +1,428 @@
-// Copyright 2016 Canonical Ltd.
+// Copyright 2017 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
-
-// +build go1.3
 
 package lxd
 
 import (
-	"github.com/juju/errors"
+	"fmt"
+	"net/http"
+	"strings"
 
+	"github.com/juju/errors"
+	"github.com/juju/schema"
+	"github.com/juju/utils/featureflag"
+	"github.com/juju/utils/set"
+	"github.com/lxc/lxd"
+	"github.com/lxc/lxd/shared/api"
+	"gopkg.in/juju/names.v2"
+
+	"github.com/juju/juju/environs"
+	"github.com/juju/juju/feature"
+	"github.com/juju/juju/instance"
 	"github.com/juju/juju/storage"
+	"github.com/juju/juju/tools/lxdclient"
 )
 
+const (
+	lxdStorageProviderType = "lxd"
+
+	// attrLXDStorageDriver is the attribute name for the
+	// storage pool's LXD storage driver. This is the only
+	// predefined storage attribute; all others are passed
+	// on to LXD directly.
+	attrLXDStorageDriver = "driver"
+)
+
+func (env *environ) storageSupported() bool {
+	return featureflag.Enabled(feature.LXDStorage) && env.raw.StorageSupported()
+}
+
 // StorageProviderTypes implements storage.ProviderRegistry.
-func (*environ) StorageProviderTypes() ([]storage.ProviderType, error) {
-	return nil, nil
+func (env *environ) StorageProviderTypes() ([]storage.ProviderType, error) {
+	var types []storage.ProviderType
+	if env.storageSupported() {
+		types = append(types, lxdStorageProviderType)
+	}
+	return types, nil
 }
 
 // StorageProvider implements storage.ProviderRegistry.
-func (*environ) StorageProvider(t storage.ProviderType) (storage.Provider, error) {
+func (env *environ) StorageProvider(t storage.ProviderType) (storage.Provider, error) {
+	if env.storageSupported() && t == lxdStorageProviderType {
+		return &lxdStorageProvider{env}, nil
+	}
 	return nil, errors.NotFoundf("storage provider %q", t)
+}
+
+// lxdStorageProvider is a storage provider for LXD volumes, exposed to Juju as
+// filesystems.
+type lxdStorageProvider struct {
+	env *environ
+}
+
+var _ storage.Provider = (*lxdStorageProvider)(nil)
+
+var lxdStorageConfigFields = schema.Fields{
+	attrLXDStorageDriver: schema.OneOf(
+		schema.Const("zfs"),
+		schema.Const("dir"),
+		schema.Const("btrfs"),
+		schema.Const("lvm"),
+	),
+	// TODO(axw) copy the rest of the schema from LXD code.
+	// Ideally LXD would export the schema over the API, and
+	// we would expose it.
+}
+
+var lxdStorageConfigChecker = schema.FieldMap(
+	lxdStorageConfigFields,
+	schema.Defaults{
+		attrLXDStorageDriver: "dir",
+	},
+)
+
+type lxdStorageConfig struct {
+	pool   string
+	driver string
+}
+
+func newLXDStorageConfig(pool string, attrs map[string]interface{}) (*lxdStorageConfig, error) {
+	coerced, err := lxdStorageConfigChecker.Coerce(attrs, nil)
+	if err != nil {
+		return nil, errors.Annotate(err, "validating Azure storage config")
+	}
+	attrs = coerced.(map[string]interface{})
+	driver := attrs[attrLXDStorageDriver].(string)
+	lxdStorageConfig := &lxdStorageConfig{
+		// TODO(axw) the LXD pool name should probably come from
+		// an attribute of the Juju storage pool, rather than the
+		// Juju storage pool name directly.
+		pool:   pool,
+		driver: driver,
+		// TODO(axw) other things
+	}
+	return lxdStorageConfig, nil
+}
+
+// ValidateConfig is part of the Provider interface.
+func (e *lxdStorageProvider) ValidateConfig(cfg *storage.Config) error {
+	_, err := newLXDStorageConfig(cfg.Name(), cfg.Attrs())
+	// TODO(axw) sanity check values.
+	return errors.Trace(err)
+}
+
+// Supports is part of the Provider interface.
+func (e *lxdStorageProvider) Supports(k storage.StorageKind) bool {
+	return k == storage.StorageKindFilesystem
+}
+
+// Scope is part of the Provider interface.
+func (e *lxdStorageProvider) Scope() storage.Scope {
+	return storage.ScopeEnviron
+}
+
+// Dynamic is part of the Provider interface.
+func (e *lxdStorageProvider) Dynamic() bool {
+	return true
+}
+
+// DefaultPools is part of the Provider interface.
+func (e *lxdStorageProvider) DefaultPools() []*storage.Config {
+	// TODO(axw) other ones
+	zfsPool, _ := storage.NewConfig("lxd-zfs", lxdStorageProviderType, map[string]interface{}{
+		attrLXDStorageDriver: "zfs",
+	})
+	return []*storage.Config{zfsPool}
+}
+
+// VolumeSource is part of the Provider interface.
+func (e *lxdStorageProvider) VolumeSource(cfg *storage.Config) (storage.VolumeSource, error) {
+	return nil, errors.NotSupportedf("volumes")
+}
+
+// FilesystemSource is part of the Provider interface.
+func (e *lxdStorageProvider) FilesystemSource(cfg *storage.Config) (storage.FilesystemSource, error) {
+	lxdStorageConfig, err := newLXDStorageConfig(cfg.Name(), cfg.Attrs())
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return &lxdFilesystemSource{e.env, lxdStorageConfig}, nil
+}
+
+type lxdFilesystemSource struct {
+	env *environ
+	cfg *lxdStorageConfig
+}
+
+// CreateFilesystems is specified on the storage.FilesystemSource interface.
+func (s *lxdFilesystemSource) CreateFilesystems(args []storage.FilesystemParams) (_ []storage.CreateFilesystemsResult, err error) {
+	results := make([]storage.CreateFilesystemsResult, len(args))
+	for i, arg := range args {
+		if err := s.ValidateFilesystemParams(arg); err != nil {
+			results[i].Error = err
+			continue
+		}
+		filesystem, err := s.createFilesystem(arg)
+		if err != nil {
+			results[i].Error = err
+			continue
+		}
+		results[i].Filesystem = filesystem
+	}
+	return results, nil
+}
+
+func (s *lxdFilesystemSource) createFilesystem(
+	arg storage.FilesystemParams,
+) (*storage.Filesystem, error) {
+
+	// TODO(axw) the filesystem ID needs to be something
+	// unique, since the storage pool could potentially be
+	// used by something other than Juju.
+	volumeName := arg.Tag.String()
+	filesystemId := fmt.Sprintf("%s:%s", s.cfg.pool, volumeName)
+
+	config := map[string]string{
+	// TODO(axw) for the "dir" driver, the size attribute is rejected
+	// by LXD. Ideally LXD would be able to tell us the total size of
+	// the filesystem on which the directory was created, though.
+	//"size": ...,
+	}
+	for k, v := range arg.ResourceTags {
+		config["user."+k] = v
+	}
+
+	// TODO(axw) ensure pool exists
+
+	if err := s.env.raw.VolumeCreate(s.cfg.pool, volumeName, config); err != nil {
+		return nil, errors.Trace(err)
+	}
+	// TODO(axw) handle BadRequest, checking if the volume already exists.
+
+	filesystem := storage.Filesystem{
+		arg.Tag,
+		names.VolumeTag{},
+		storage.FilesystemInfo{
+			FilesystemId: filesystemId,
+			Size:         arg.Size,
+		},
+	}
+	return &filesystem, nil
+}
+
+func (s *lxdFilesystemSource) filesystemId(v api.StorageVolume) string {
+	return fmt.Sprintf("%s:%s", s.cfg.pool, v.Name)
+}
+
+// parseFilesystemId parses the given filesystem ID, returning the underlying
+// LXD volume name for this source's LXD storage pool.
+func (s *lxdFilesystemSource) parseFilesystemId(id string) (string, error) {
+	prefix := s.cfg.pool + ":"
+	if !strings.HasPrefix(id, prefix) {
+		return "", errors.NotValidf("filesystem ID %q", id)
+	}
+	return id[len(prefix):], nil
+}
+
+// ListFilesystems is specified on the storage.FilesystemSource interface.
+func (s *lxdFilesystemSource) ListFilesystems() ([]string, error) {
+	volumes, err := s.env.raw.VolumeList(s.cfg.pool)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	ids := make([]string, len(volumes))
+	for i, v := range volumes {
+		// TODO(axw) filter volumes?
+		ids[i] = s.filesystemId(v)
+	}
+	return ids, nil
+}
+
+// DescribeFilesystems is specified on the storage.FilesystemSource interface.
+func (s *lxdFilesystemSource) DescribeFilesystems(filesystemIds []string) ([]storage.DescribeFilesystemsResult, error) {
+	volumes, err := s.env.raw.VolumeList(s.cfg.pool)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	results := make([]storage.DescribeFilesystemsResult, len(filesystemIds))
+	for i, id := range filesystemIds {
+		var found bool
+		for _, v := range volumes {
+			if id != s.filesystemId(v) {
+				continue
+			}
+			// TODO(axw) extract size from properties
+			results[i].FilesystemInfo = &storage.FilesystemInfo{
+				FilesystemId: id,
+			}
+			found = true
+		}
+		if !found {
+			results[i].Error = errors.NotFoundf("filesystem %q", id)
+		}
+	}
+	return results, nil
+}
+
+// DestroyFilesystems is specified on the storage.FilesystemSource interface.
+func (s *lxdFilesystemSource) DestroyFilesystems(filesystemIds []string) ([]error, error) {
+	results := make([]error, len(filesystemIds))
+	for i, filesystemId := range filesystemIds {
+		results[i] = s.destroyFilesystem(filesystemId)
+	}
+	return results, nil
+}
+
+func (s *lxdFilesystemSource) destroyFilesystem(filesystemId string) error {
+	volumeName, err := s.parseFilesystemId(filesystemId)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	err = s.env.raw.VolumeDelete(s.cfg.pool, volumeName)
+	if err != nil && err != lxd.LXDErrors[http.StatusNotFound] {
+		return errors.Trace(err)
+	}
+	return nil
+}
+
+// ValidateFilesystemParams is specified on the storage.FilesystemSource interface.
+func (s *lxdFilesystemSource) ValidateFilesystemParams(params storage.FilesystemParams) error {
+	// TODO(axw) sanity check params
+	return nil
+}
+
+// AttachFilesystems is specified on the storage.FilesystemSource interface.
+func (s *lxdFilesystemSource) AttachFilesystems(args []storage.FilesystemAttachmentParams) ([]storage.AttachFilesystemsResult, error) {
+	var instanceIds []instance.Id
+	instanceIdsSeen := make(set.Strings)
+	for _, arg := range args {
+		if instanceIdsSeen.Contains(string(arg.InstanceId)) {
+			continue
+		}
+		instanceIdsSeen.Add(string(arg.InstanceId))
+		instanceIds = append(instanceIds, arg.InstanceId)
+	}
+	instances, err := s.env.Instances(instanceIds)
+	switch err {
+	case nil, environs.ErrPartialInstances, environs.ErrNoInstances:
+	default:
+		return nil, errors.Trace(err)
+	}
+
+	results := make([]storage.AttachFilesystemsResult, len(args))
+	for i, arg := range args {
+		var inst *environInstance
+		for i, instanceId := range instanceIds {
+			if instanceId != arg.InstanceId {
+				continue
+			}
+			if instances[i] != nil {
+				inst = instances[i].(*environInstance)
+			}
+			break
+		}
+		attachment, err := s.attachFilesystem(arg, inst)
+		if err != nil {
+			results[i].Error = errors.Annotatef(
+				err, "attaching %s to %s",
+				names.ReadableString(arg.Filesystem),
+				names.ReadableString(arg.Machine),
+			)
+			continue
+		}
+		results[i].FilesystemAttachment = attachment
+	}
+	return results, nil
+}
+
+func (s *lxdFilesystemSource) attachFilesystem(
+	arg storage.FilesystemAttachmentParams,
+	inst *environInstance,
+) (*storage.FilesystemAttachment, error) {
+
+	if inst == nil {
+		return nil, errors.NotFoundf("instance %q", arg.InstanceId)
+	}
+
+	volumeName, err := s.parseFilesystemId(arg.FilesystemId)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	disks := inst.raw.Disks()
+	deviceName := arg.Filesystem.String()
+	if _, ok := disks[deviceName]; !ok {
+		disk := lxdclient.DiskDevice{
+			Path:     arg.Path,
+			Source:   volumeName,
+			Pool:     s.cfg.pool,
+			ReadOnly: arg.ReadOnly,
+		}
+		if err := s.env.raw.AttachDisk(inst.raw.Name, deviceName, disk); err != nil {
+			return nil, errors.Trace(err)
+		}
+	}
+
+	filesystemAttachment := storage.FilesystemAttachment{
+		arg.Filesystem,
+		arg.Machine,
+		storage.FilesystemAttachmentInfo{
+			Path:     arg.Path,
+			ReadOnly: arg.ReadOnly,
+		},
+	}
+	return &filesystemAttachment, nil
+}
+
+// DetachFilesystems is specified on the storage.FilesystemSource interface.
+func (s *lxdFilesystemSource) DetachFilesystems(args []storage.FilesystemAttachmentParams) ([]error, error) {
+	var instanceIds []instance.Id
+	instanceIdsSeen := make(set.Strings)
+	for _, arg := range args {
+		if instanceIdsSeen.Contains(string(arg.InstanceId)) {
+			continue
+		}
+		instanceIdsSeen.Add(string(arg.InstanceId))
+		instanceIds = append(instanceIds, arg.InstanceId)
+	}
+	instances, err := s.env.Instances(instanceIds)
+	switch err {
+	case nil, environs.ErrPartialInstances, environs.ErrNoInstances:
+	default:
+		return nil, errors.Trace(err)
+	}
+
+	results := make([]error, len(args))
+	for i, arg := range args {
+		var inst *environInstance
+		for i, instanceId := range instanceIds {
+			if instanceId != arg.InstanceId {
+				continue
+			}
+			if instances[i] != nil {
+				inst = instances[i].(*environInstance)
+			}
+			break
+		}
+		if inst != nil {
+			err := s.detachFilesystem(arg, inst)
+			results[i] = errors.Annotatef(
+				err, "detaching %s",
+				names.ReadableString(arg.Filesystem),
+			)
+		}
+	}
+	return results, nil
+}
+
+func (s *lxdFilesystemSource) detachFilesystem(
+	arg storage.FilesystemAttachmentParams,
+	inst *environInstance,
+) error {
+	devices := inst.raw.Disks()
+	deviceName := arg.Filesystem.String()
+	if _, ok := devices[deviceName]; !ok {
+		return nil
+	}
+	return s.env.raw.RemoveDevice(inst.raw.Name, deviceName)
 }

--- a/provider/lxd/storage_test.go
+++ b/provider/lxd/storage_test.go
@@ -1,0 +1,268 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package lxd_test
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/names.v2"
+
+	"github.com/juju/juju/provider/lxd"
+	"github.com/juju/juju/storage"
+	"github.com/juju/juju/tools/lxdclient"
+)
+
+type storageSuite struct {
+	lxd.BaseSuite
+
+	provider storage.Provider
+}
+
+var _ = gc.Suite(&storageSuite{})
+
+func (s *storageSuite) SetUpTest(c *gc.C) {
+	s.SetInitialFeatureFlags("lxd-storage")
+	s.BaseSuite.SetUpTest(c)
+	s.Client.StorageIsSupported = true
+
+	provider, err := s.Env.StorageProvider("lxd")
+	c.Assert(err, jc.ErrorIsNil)
+	s.provider = provider
+	s.Stub.ResetCalls()
+}
+
+func (s *storageSuite) filesystemSource(c *gc.C, pool string) storage.FilesystemSource {
+	storageConfig, err := storage.NewConfig(pool, "lxd", nil)
+	c.Assert(err, jc.ErrorIsNil)
+	filesystemSource, err := s.provider.FilesystemSource(storageConfig)
+	c.Assert(err, jc.ErrorIsNil)
+	return filesystemSource
+}
+
+func (s *storageSuite) TestStorageProviderTypes(c *gc.C) {
+	s.Client.StorageIsSupported = false
+	types, err := s.Env.StorageProviderTypes()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(types, gc.HasLen, 0)
+
+	s.Client.StorageIsSupported = true
+	types, err = s.Env.StorageProviderTypes()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(types, jc.DeepEquals, []storage.ProviderType{"lxd"})
+
+	s.SetFeatureFlags( /*none*/ )
+	types, err = s.Env.StorageProviderTypes()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(types, gc.HasLen, 0)
+}
+
+func (s *storageSuite) TestVolumeSource(c *gc.C) {
+	_, err := s.provider.VolumeSource(nil)
+	c.Assert(err, gc.ErrorMatches, "volumes not supported")
+	c.Assert(err, jc.Satisfies, errors.IsNotSupported)
+}
+
+func (s *storageSuite) TestFilesystemSource(c *gc.C) {
+	s.filesystemSource(c, "pool")
+}
+
+func (s *storageSuite) TestSupports(c *gc.C) {
+	c.Assert(s.provider.Supports(storage.StorageKindBlock), jc.IsFalse)
+	c.Assert(s.provider.Supports(storage.StorageKindFilesystem), jc.IsTrue)
+}
+
+func (s *storageSuite) TestDynamic(c *gc.C) {
+	c.Assert(s.provider.Dynamic(), jc.IsTrue)
+}
+
+func (s *storageSuite) TestScope(c *gc.C) {
+	c.Assert(s.provider.Scope(), gc.Equals, storage.ScopeEnviron)
+}
+
+func (s *storageSuite) TestCreateFilesystems(c *gc.C) {
+	source := s.filesystemSource(c, "radiance")
+	results, err := source.CreateFilesystems([]storage.FilesystemParams{{
+		Tag:      names.NewFilesystemTag("0"),
+		Provider: "lxd",
+		Size:     1024,
+		ResourceTags: map[string]string{
+			"key": "value",
+		},
+	}})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(results, gc.HasLen, 1)
+	c.Assert(results[0].Error, jc.ErrorIsNil)
+	c.Assert(results[0].Filesystem, jc.DeepEquals, &storage.Filesystem{
+		names.NewFilesystemTag("0"),
+		names.VolumeTag{},
+		storage.FilesystemInfo{
+			FilesystemId: "radiance:filesystem-0",
+			Size:         1024,
+		},
+	})
+
+	s.Stub.CheckCallNames(c, "VolumeCreate")
+	s.Stub.CheckCall(c, 0, "VolumeCreate", "radiance", "filesystem-0", map[string]string{
+		"user.key": "value",
+	})
+}
+
+func (s *storageSuite) TestDestroyFilesystems(c *gc.C) {
+	s.Stub.SetErrors(nil, errors.New("boom"))
+	source := s.filesystemSource(c, "pool")
+	results, err := source.DestroyFilesystems([]string{
+		"notmypool:filesystem-0",
+		"pool:filesystem-0",
+		"pool:filesystem-1",
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(results, gc.HasLen, 3)
+	c.Assert(results[0], gc.ErrorMatches, `filesystem ID "notmypool:filesystem-0" not valid`)
+	c.Assert(results[1], jc.ErrorIsNil)
+	c.Assert(results[2], gc.ErrorMatches, "boom")
+
+	s.Stub.CheckCalls(c, []testing.StubCall{
+		{"VolumeDelete", []interface{}{"pool", "filesystem-0"}},
+		{"VolumeDelete", []interface{}{"pool", "filesystem-1"}},
+	})
+}
+
+func (s *storageSuite) TestAttachFilesystems(c *gc.C) {
+	raw := s.NewRawInstance(c, "inst-0")
+	raw.Devices = map[string]map[string]string{
+		"filesystem-1": map[string]string{
+			"type":     "disk",
+			"source":   "filesystem-1",
+			"pool":     "pool",
+			"path":     "/mnt/path",
+			"readonly": "true",
+		},
+	}
+	s.Client.Insts = []lxdclient.Instance{*raw}
+
+	source := s.filesystemSource(c, "pool")
+	results, err := source.AttachFilesystems([]storage.FilesystemAttachmentParams{{
+		AttachmentParams: storage.AttachmentParams{
+			Provider:   "lxd",
+			Machine:    names.NewMachineTag("123"),
+			InstanceId: "inst-0",
+			ReadOnly:   true,
+		},
+		Filesystem:   names.NewFilesystemTag("0"),
+		FilesystemId: "pool:filesystem-0",
+		Path:         "/mnt/path",
+	}, {
+		AttachmentParams: storage.AttachmentParams{
+			Provider:   "lxd",
+			Machine:    names.NewMachineTag("123"),
+			InstanceId: "inst-0",
+			ReadOnly:   true,
+		},
+		Filesystem:   names.NewFilesystemTag("1"),
+		FilesystemId: "pool:filesystem-1",
+		Path:         "/mnt/socio",
+	}, {
+		AttachmentParams: storage.AttachmentParams{
+			Provider:   "lxd",
+			Machine:    names.NewMachineTag("42"),
+			InstanceId: "inst-42",
+		},
+		Filesystem:   names.NewFilesystemTag("2"),
+		FilesystemId: "pool:filesystem-2",
+		Path:         "/mnt/psycho",
+	}})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(results, gc.HasLen, 3)
+	c.Assert(results[0].Error, jc.ErrorIsNil)
+	c.Assert(results[0].FilesystemAttachment, jc.DeepEquals, &storage.FilesystemAttachment{
+		names.NewFilesystemTag("0"),
+		names.NewMachineTag("123"),
+		storage.FilesystemAttachmentInfo{
+			Path:     "/mnt/path",
+			ReadOnly: true,
+		},
+	})
+	c.Assert(results[1].Error, jc.ErrorIsNil)
+	c.Assert(results[1].FilesystemAttachment, jc.DeepEquals, &storage.FilesystemAttachment{
+		names.NewFilesystemTag("1"),
+		names.NewMachineTag("123"),
+		storage.FilesystemAttachmentInfo{
+			Path:     "/mnt/socio",
+			ReadOnly: true,
+		},
+	})
+	c.Assert(
+		results[2].Error,
+		gc.ErrorMatches,
+		`attaching filesystem 2 to machine 42: instance "inst-42" not found`,
+	)
+
+	s.Stub.CheckCalls(c, []testing.StubCall{{
+		"Instances",
+		[]interface{}{"juju-f75cba-", []string{"Starting", "Started", "Running", "Stopping", "Stopped"}},
+	}, {
+		"AttachDisk",
+		[]interface{}{"inst-0", "filesystem-0", lxdclient.DiskDevice{
+			Path:     "/mnt/path",
+			Source:   "filesystem-0",
+			Pool:     "pool",
+			ReadOnly: true,
+		}},
+	}})
+}
+
+func (s *storageSuite) TestDetachFilesystems(c *gc.C) {
+	raw := s.NewRawInstance(c, "inst-0")
+	raw.Devices = map[string]map[string]string{
+		"filesystem-0": map[string]string{
+			"type":     "disk",
+			"source":   "filesystem-0",
+			"pool":     "pool",
+			"path":     "/mnt/path",
+			"readonly": "true",
+		},
+	}
+	s.Client.Insts = []lxdclient.Instance{*raw}
+
+	source := s.filesystemSource(c, "pool")
+	results, err := source.DetachFilesystems([]storage.FilesystemAttachmentParams{{
+		AttachmentParams: storage.AttachmentParams{
+			Provider:   "lxd",
+			Machine:    names.NewMachineTag("123"),
+			InstanceId: "inst-0",
+		},
+		Filesystem:   names.NewFilesystemTag("0"),
+		FilesystemId: "pool:filesystem-0",
+	}, {
+		AttachmentParams: storage.AttachmentParams{
+			Provider:   "lxd",
+			Machine:    names.NewMachineTag("123"),
+			InstanceId: "inst-0",
+		},
+		Filesystem:   names.NewFilesystemTag("1"),
+		FilesystemId: "pool:filesystem-1",
+	}, {
+		AttachmentParams: storage.AttachmentParams{
+			Provider:   "lxd",
+			Machine:    names.NewMachineTag("42"),
+			InstanceId: "inst-42",
+		},
+		Filesystem:   names.NewFilesystemTag("2"),
+		FilesystemId: "pool:filesystem-2",
+	}})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(results, gc.HasLen, 3)
+	c.Assert(results[0], jc.ErrorIsNil)
+	c.Assert(results[1], jc.ErrorIsNil)
+	c.Assert(results[2], jc.ErrorIsNil)
+
+	s.Stub.CheckCalls(c, []testing.StubCall{{
+		"Instances",
+		[]interface{}{"juju-f75cba-", []string{"Starting", "Started", "Running", "Stopping", "Stopped"}},
+	}, {
+		"RemoveDevice", []interface{}{"inst-0", "filesystem-0"},
+	}})
+}


### PR DESCRIPTION
## Description of change

Introduce a new "lxd" storage provider that is
enabled with the "lxd-storage" feature flag.
This storage provider requires the storage
feature available in LXD 2.9+.

The first commit in this PR is from https://github.com/juju/juju/pull/7026, and should be reviewed there.

## QA steps

First create a storage pool in LXD called "lxd".

1. juju bootstrap localhost
2. juju deploy postgresql --pgdata=lxd
Fails with: `ERROR cannot add application "storagetest": pool "lxd" not found` because the feature flag is not set.
3. juju destroy-controller -y localhost

4. export JUJU_DEV_FEATURE_FLAGS=lxd-storage
5. juju bootstrap localhost
6. juju deploy postgresql --pgdata=lxd

Verify there's a volume in the "lxd" LXD storage pool, it's attached to the container, and mounted at the path shown in "juju storage".

## Documentation changes

Not yet. This is experimental, and subject to change.

## Bug reference

None.