### PR TITLE
Change subnet choosing algoritm for lxd

### DIFF
--- a/container/lxd/initialisation_test.go
+++ b/container/lxd/initialisation_test.go
@@ -83,6 +83,12 @@ func (s *InitialiserSuite) SetUpTest(c *gc.C) {
 	s.PatchValue(&getLXDConfigSetter, func() (configSetter, error) {
 		return &mockConfigSetter{}, nil
 	})
+	nonRandomizedOctetRange := func() []int {
+		// chosen by fair dice roll
+		// guaranteed to be random
+		return []int{4, 5}
+	}
+	s.PatchValue(&randomizedOctetRange, nonRandomizedOctetRange)
 	// Fake the lxc executable for all the tests.
 	testing.PatchExecutableAsEchoArgs(c, s, "lxc")
 	testing.PatchExecutableAsEchoArgs(c, s, "lxd")
@@ -262,7 +268,7 @@ func (s *InitialiserSuite) TestFindAvailableSubnetWithNoAddresses(c *gc.C) {
 	})
 	subnet, err := findNextAvailableIPv4Subnet()
 	c.Assert(err, gc.IsNil)
-	c.Assert(subnet, gc.Equals, "0")
+	c.Assert(subnet, gc.Equals, "4")
 }
 
 func (s *InitialiserSuite) TestFindAvailableSubnetWithIPv6Only(c *gc.C) {
@@ -271,7 +277,7 @@ func (s *InitialiserSuite) TestFindAvailableSubnetWithIPv6Only(c *gc.C) {
 	})
 	subnet, err := findNextAvailableIPv4Subnet()
 	c.Assert(err, gc.IsNil)
-	c.Assert(subnet, gc.Equals, "0")
+	c.Assert(subnet, gc.Equals, "4")
 }
 
 func (s *InitialiserSuite) TestFindAvailableSubnetWithIPv4OnlyAndNo10xSubnet(c *gc.C) {
@@ -280,7 +286,7 @@ func (s *InitialiserSuite) TestFindAvailableSubnetWithIPv4OnlyAndNo10xSubnet(c *
 	})
 	subnet, err := findNextAvailableIPv4Subnet()
 	c.Assert(err, gc.IsNil)
-	c.Assert(subnet, gc.Equals, "0")
+	c.Assert(subnet, gc.Equals, "4")
 }
 
 func (s *InitialiserSuite) TestFindAvailableSubnetWithInvalidCIDR(c *gc.C) {
@@ -291,7 +297,7 @@ func (s *InitialiserSuite) TestFindAvailableSubnetWithInvalidCIDR(c *gc.C) {
 	})
 	subnet, err := findNextAvailableIPv4Subnet()
 	c.Assert(err, gc.IsNil)
-	c.Assert(subnet, gc.Equals, "6")
+	c.Assert(subnet, gc.Equals, "4")
 }
 
 func (s *InitialiserSuite) TestFindAvailableSubnetWithIPv4AndExisting10xNetwork(c *gc.C) {
@@ -300,7 +306,7 @@ func (s *InitialiserSuite) TestFindAvailableSubnetWithIPv4AndExisting10xNetwork(
 	})
 	subnet, err := findNextAvailableIPv4Subnet()
 	c.Assert(err, gc.IsNil)
-	c.Assert(subnet, gc.Equals, "1")
+	c.Assert(subnet, gc.Equals, "4")
 }
 
 func (s *InitialiserSuite) TestFindAvailableSubnetWithExisting10xNetworks(c *gc.C) {
@@ -318,7 +324,7 @@ func (s *InitialiserSuite) TestFindAvailableSubnetUpperBoundInUse(c *gc.C) {
 	})
 	subnet, err := findNextAvailableIPv4Subnet()
 	c.Assert(err, gc.IsNil)
-	c.Assert(subnet, gc.Equals, "0")
+	c.Assert(subnet, gc.Equals, "4")
 }
 
 func (s *InitialiserSuite) TestFindAvailableSubnetUpperBoundAndLowerBoundInUse(c *gc.C) {
@@ -327,7 +333,7 @@ func (s *InitialiserSuite) TestFindAvailableSubnetUpperBoundAndLowerBoundInUse(c
 	})
 	subnet, err := findNextAvailableIPv4Subnet()
 	c.Assert(err, gc.IsNil)
-	c.Assert(subnet, gc.Equals, "1")
+	c.Assert(subnet, gc.Equals, "4")
 }
 
 func (s *InitialiserSuite) TestFindAvailableSubnetWithFull10xSubnet(c *gc.C) {
@@ -450,17 +456,17 @@ func (s *InitialiserSuite) TestBridgeConfigurationWithInterfacesError(c *gc.C) {
 
 func (s *InitialiserSuite) TestBridgeConfigurationWithNewSubnet(c *gc.C) {
 	s.PatchValue(&interfaceAddrs, func() ([]net.Addr, error) {
-		return testAddresses(c, "10.0.4.1/24")
+		return testAddresses(c, "10.0.2.1/24")
 	})
 
 	expectedValues := map[string]string{
 		"USE_LXD_BRIDGE":      "true",
 		"EXISTING_BRIDGE":     "",
 		"LXD_BRIDGE":          "lxdbr0",
-		"LXD_IPV4_ADDR":       "10.0.5.1",
+		"LXD_IPV4_ADDR":       "10.0.4.1",
 		"LXD_IPV4_NETMASK":    "255.255.255.0",
-		"LXD_IPV4_NETWORK":    "10.0.5.1/24",
-		"LXD_IPV4_DHCP_RANGE": "10.0.5.2,10.0.5.254",
+		"LXD_IPV4_NETWORK":    "10.0.4.1/24",
+		"LXD_IPV4_DHCP_RANGE": "10.0.4.2,10.0.4.254",
 		"LXD_IPV4_DHCP_MAX":   "253",
 		"LXD_IPV4_NAT":        "true",
 		"LXD_IPV6_PROXY":      "false",
@@ -469,5 +475,5 @@ func (s *InitialiserSuite) TestBridgeConfigurationWithNewSubnet(c *gc.C) {
 	result, err := bridgeConfiguration(`LXD_IPV4_ADDR=""`)
 	c.Assert(err, gc.IsNil)
 	actualValues := parseLXDBridgeConfigValues(result)
-	c.Assert(expectedValues, gc.DeepEquals, actualValues)
+	c.Assert(actualValues, gc.DeepEquals, expectedValues)
 }


### PR DESCRIPTION
## Description of change

In order to address lxd network overlapping, the same algoritm used by lxd to pick subnets is now used for juju too.

## QA steps

deploy lxd workloads in different machines and the containers should be in significantly different /24 networks, to be accurate, the second octet is chosen at random so should vary the most.

## Bug reference

Juju 2.0.3 fails to deploy LXD container lxdbr0 overlapping subnets
https://bugs.launchpad.net/juju/+bug/1665648
