### PR TITLE
migrations (gce): Extract zone name from URL for SetMetadata

### DIFF
--- a/provider/gce/google/conn_instance.go
+++ b/provider/gce/google/conn_instance.go
@@ -190,7 +190,9 @@ func (gce *Connection) updateInstanceMetadata(instance *compute.Instance, key, v
 	} else {
 		existingItem.Value = value
 	}
-	return errors.Trace(gce.raw.SetMetadata(gce.projectID, instance.Zone, instance.Name, metadata))
+	// The GCE API won't accept a full URL for the zone (lp:1667172).
+	zoneName := path.Base(instance.Zone)
+	return errors.Trace(gce.raw.SetMetadata(gce.projectID, zoneName, instance.Name, metadata))
 }
 
 func findMetadataItem(items []*compute.MetadataItems, key string) *compute.MetadataItems {

--- a/provider/gce/google/conn_instance_test.go
+++ b/provider/gce/google/conn_instance_test.go
@@ -326,6 +326,8 @@ func (s *connSuite) TestConnectionRemoveInstancesRemoveFailed(c *gc.C) {
 }
 
 func (s *connSuite) TestUpdateMetadataNewAttribute(c *gc.C) {
+	// Ensure we extract the name from the URL we get on the raw instance.
+	s.RawInstanceFull.Zone = "http://eels/lone/wolf/a-zone"
 	s.FakeConn.Instances = []*compute.Instance{&s.RawInstanceFull}
 
 	err := s.Conn.UpdateMetadata("business", "time", s.RawInstanceFull.Name)
@@ -348,6 +350,8 @@ func (s *connSuite) TestUpdateMetadataNewAttribute(c *gc.C) {
 }
 
 func (s *connSuite) TestUpdateMetadataExistingAttribute(c *gc.C) {
+	// Ensure we extract the name from the URL we get on the raw instance.
+	s.RawInstanceFull.Zone = "http://eels/lone/wolf/a-zone"
 	s.FakeConn.Instances = []*compute.Instance{&s.RawInstanceFull}
 
 	err := s.Conn.UpdateMetadata("eggs", "beans", s.RawInstanceFull.Name)
@@ -369,6 +373,9 @@ func (s *connSuite) TestUpdateMetadataExistingAttribute(c *gc.C) {
 }
 
 func (s *connSuite) TestUpdateMetadataMultipleInstances(c *gc.C) {
+	// Ensure we extract the name from the URL we get on the raw instance.
+	s.RawInstanceFull.Zone = "http://eels/lone/wolf/a-zone"
+
 	instance2 := s.RawInstanceFull
 	instance2.Name = "trucks"
 	instance2.Metadata = &compute.Metadata{


### PR DESCRIPTION
## Description of change

Fix the code that updates the controller tag of machines in the model - 
otherwise migrations would fail on GCE. The GCE API requires the 
unqualified zone name, so "us-central1-a" rather than:
https://www.googleapis.com/compute/v1/projects/gothic-list-89514/zones/us-central1-a
(Which is what the API gives back to us.)

## QA steps
* Bootstrap 2 GCE controllers, A and B.
* Add a model to A and deploy an application to it.
* Migrate model A:m to B.
* The migration to B should finish successfully and the model should be fully removed from A.
* Destroying controller A should leave the machines in B:m running.

## Bug reference

Fixes https://bugs.launchpad.net/juju/+bug/1667172
