### PR TITLE
cmd/juju/storage: add remove-storage command

### DIFF
--- a/api/storage/client.go
+++ b/api/storage/client.go
@@ -147,3 +147,29 @@ func (c *Client) AddToUnit(storages []params.StorageAddParams) ([]params.ErrorRe
 	}
 	return out.Results, nil
 }
+
+// Destroy destroys specified storage entities.
+func (c *Client) Destroy(storageIds []string) ([]params.ErrorResult, error) {
+	results := params.ErrorResults{}
+	entities := make([]params.Entity, len(storageIds))
+	for i, id := range storageIds {
+		if !names.IsValidStorage(id) {
+			return nil, errors.NotValidf("storage ID %q", id)
+		}
+		entities[i] = params.Entity{Tag: names.NewStorageTag(id).String()}
+	}
+	if err := c.facade.FacadeCall(
+		"Destroy",
+		params.Entities{Entities: entities},
+		&results,
+	); err != nil {
+		return nil, errors.Trace(err)
+	}
+	if len(results.Results) != len(storageIds) {
+		return nil, errors.Errorf(
+			"expected %d result(s), got %d",
+			len(storageIds), len(results.Results),
+		)
+	}
+	return results.Results, nil
+}

--- a/api/storage/client_test.go
+++ b/api/storage/client_test.go
@@ -581,3 +581,44 @@ func (s *storageMockSuite) TestAddToUnitFacadeCallError(c *gc.C) {
 	c.Assert(errors.Cause(err), gc.ErrorMatches, msg)
 	c.Assert(found, gc.HasLen, 0)
 }
+
+func (s *storageMockSuite) TestDestroy(c *gc.C) {
+	apiCaller := basetesting.APICallerFunc(
+		func(objType string,
+			version int,
+			id, request string,
+			a, result interface{},
+		) error {
+			c.Check(objType, gc.Equals, "Storage")
+			c.Check(id, gc.Equals, "")
+			c.Check(request, gc.Equals, "Destroy")
+			c.Check(a, jc.DeepEquals, params.Entities{[]params.Entity{
+				{"storage-foo-0"},
+				{"storage-bar-1"},
+			}})
+			c.Assert(result, gc.FitsTypeOf, &params.ErrorResults{})
+			results := result.(*params.ErrorResults)
+			results.Results = []params.ErrorResult{
+				{},
+				{Error: &params.Error{Message: "baz"}},
+			}
+			return nil
+		},
+	)
+	client := storage.NewClient(apiCaller)
+	results, err := client.Destroy([]string{"foo/0", "bar/1"})
+	c.Check(err, jc.ErrorIsNil)
+	c.Assert(results, gc.HasLen, 2)
+	c.Assert(results[0].Error, gc.IsNil)
+	c.Assert(results[1].Error, jc.DeepEquals, &params.Error{Message: "baz"})
+}
+
+func (s *storageMockSuite) TestDestroyInvalidStorageId(c *gc.C) {
+	client := storage.NewClient(basetesting.APICallerFunc(
+		func(_ string, _ int, _, _ string, _, _ interface{}) error {
+			return nil
+		},
+	))
+	_, err := client.Destroy([]string{"foo/bar"})
+	c.Check(err, gc.ErrorMatches, `storage ID "foo/bar" not valid`)
+}

--- a/apiserver/common/storagecommon/mock_test.go
+++ b/apiserver/common/storagecommon/mock_test.go
@@ -76,8 +76,8 @@ func (i *fakeStorageInstance) Tag() names.Tag {
 	return i.tag
 }
 
-func (i *fakeStorageInstance) Owner() names.Tag {
-	return i.owner
+func (i *fakeStorageInstance) Owner() (names.Tag, bool) {
+	return i.owner, i.owner != nil
 }
 
 func (i *fakeStorageInstance) Kind() state.StorageKind {

--- a/apiserver/common/storagecommon/storage.go
+++ b/apiserver/common/storagecommon/storage.go
@@ -263,7 +263,9 @@ func storageTags(
 	)
 	if storageInstance != nil {
 		storageTags[tags.JujuStorageInstance] = storageInstance.Tag().Id()
-		storageTags[tags.JujuStorageOwner] = storageInstance.Owner().Id()
+		if owner, ok := storageInstance.Owner(); ok {
+			storageTags[tags.JujuStorageOwner] = owner.Id()
+		}
 	}
 	return storageTags, nil
 }

--- a/apiserver/storage/base_test.go
+++ b/apiserver/storage/base_test.go
@@ -86,6 +86,7 @@ const (
 	addStorageForUnitCall                   = "addStorageForUnit"
 	getBlockForTypeCall                     = "getBlockForType"
 	volumeAttachmentCall                    = "volumeAttachment"
+	destroyStorageInstanceCall              = "destroyStorageInstance"
 )
 
 func (s *baseStorageSuite) constructState() *mockState {
@@ -228,6 +229,10 @@ func (s *baseStorageSuite) constructState() *mockState {
 			s.calls = append(s.calls, getBlockForTypeCall)
 			val, found := s.blocks[t]
 			return val, found, nil
+		},
+		destroyStorageInstance: func(tag names.StorageTag) error {
+			s.calls = append(s.calls, destroyStorageInstanceCall)
+			return errors.New("cannae do it")
 		},
 	}
 }

--- a/apiserver/storage/mock_test.go
+++ b/apiserver/storage/mock_test.go
@@ -62,6 +62,7 @@ type mockState struct {
 	addStorageForUnit                   func(u names.UnitTag, name string, cons state.StorageConstraints) error
 	getBlockForType                     func(t state.BlockType) (state.Block, bool, error)
 	blockDevices                        func(names.MachineTag) ([]state.BlockDeviceInfo, error)
+	destroyStorageInstance              func(names.StorageTag) error
 }
 
 func (st *mockState) StorageInstance(s names.StorageTag) (state.StorageInstance, error) {
@@ -165,6 +166,10 @@ func (st *mockState) BlockDevices(m names.MachineTag) ([]state.BlockDeviceInfo, 
 		return st.blockDevices(m)
 	}
 	return []state.BlockDeviceInfo{}, nil
+}
+
+func (st *mockState) DestroyStorageInstance(tag names.StorageTag) error {
+	return st.destroyStorageInstance(tag)
 }
 
 type mockNotifyWatcher struct {
@@ -282,8 +287,8 @@ func (m *mockStorageInstance) Kind() state.StorageKind {
 	return m.kind
 }
 
-func (m *mockStorageInstance) Owner() names.Tag {
-	return m.owner
+func (m *mockStorageInstance) Owner() (names.Tag, bool) {
+	return m.owner, m.owner != nil
 }
 
 func (m *mockStorageInstance) Tag() names.Tag {
@@ -308,7 +313,7 @@ func (m *mockStorageAttachment) StorageInstance() names.StorageTag {
 }
 
 func (m *mockStorageAttachment) Unit() names.UnitTag {
-	return m.storage.Owner().(names.UnitTag)
+	return m.storage.owner.(names.UnitTag)
 }
 
 type mockVolumeAttachment struct {

--- a/apiserver/storage/shim.go
+++ b/apiserver/storage/shim.go
@@ -113,6 +113,9 @@ type storageAccess interface {
 
 	// GetBlockForType is required to block operations.
 	GetBlockForType(t state.BlockType) (state.Block, bool, error)
+
+	// DestroyStorageInstance destroys the storage instance with the specified tag.
+	DestroyStorageInstance(names.StorageTag) error
 }
 
 var getState = func(st *state.State) storageAccess {

--- a/apiserver/storage/storage_test.go
+++ b/apiserver/storage/storage_test.go
@@ -317,3 +317,25 @@ func (s *storageSuite) TestShowStorageInvalidId(c *gc.C) {
 	c.Assert(found.Results, gc.HasLen, 1)
 	s.assertInstanceInfoError(c, found.Results[0], params.StorageDetailsResult{}, `"foo" is not a valid tag`)
 }
+
+func (s *storageSuite) TestDestroy(c *gc.C) {
+	results, err := s.api.Destroy(params.Entities{Entities: []params.Entity{
+		{Tag: "storage-foo-0"},
+		{Tag: "volume-0"},
+		{Tag: "filesystem-1-2"},
+		{Tag: "machine-0"},
+	}})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(results.Results, gc.HasLen, 4)
+	c.Assert(results.Results, jc.DeepEquals, []params.ErrorResult{
+		{Error: &params.Error{Message: "cannae do it"}},
+		{Error: &params.Error{Message: `tag kind "volume" not valid`}},
+		{Error: &params.Error{Message: `tag kind "filesystem" not valid`}},
+		{Error: &params.Error{Message: `tag kind "machine" not valid`}},
+	})
+	s.assertCalls(c, []string{
+		getBlockForTypeCall, // Remove
+		getBlockForTypeCall, // Change
+		destroyStorageInstanceCall,
+	})
+}

--- a/apiserver/uniter/storage.go
+++ b/apiserver/uniter/storage.go
@@ -181,9 +181,13 @@ func (s *StorageAPI) fromStateStorageAttachment(stateStorageAttachment state.Sto
 	if err != nil {
 		return params.StorageAttachment{}, err
 	}
+	var ownerTag string
+	if owner, ok := stateStorageInstance.Owner(); ok {
+		ownerTag = owner.String()
+	}
 	return params.StorageAttachment{
 		stateStorageAttachment.StorageInstance().String(),
-		stateStorageInstance.Owner().String(),
+		ownerTag,
 		stateStorageAttachment.Unit().String(),
 		params.StorageKind(stateStorageInstance.Kind()),
 		info.Location,

--- a/cmd/juju/commands/main.go
+++ b/cmd/juju/commands/main.go
@@ -388,6 +388,7 @@ func registerCommands(r commandRegistry, ctx *cmd.Context) {
 	r.Register(storage.NewPoolCreateCommand())
 	r.Register(storage.NewPoolListCommand())
 	r.Register(storage.NewShowCommand())
+	r.Register(storage.NewRemoveStorageCommandWithAPI())
 
 	// Manage spaces
 	r.Register(space.NewAddCommand())

--- a/cmd/juju/commands/main_test.go
+++ b/cmd/juju/commands/main_test.go
@@ -480,6 +480,7 @@ var commandNames = []string{
 	"remove-machine",
 	"remove-relation",
 	"remove-ssh-key",
+	"remove-storage",
 	"remove-unit",
 	"resolved",
 	"restore-backup",

--- a/cmd/juju/storage/remove.go
+++ b/cmd/juju/storage/remove.go
@@ -1,0 +1,116 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package storage
+
+import (
+	"github.com/juju/cmd"
+	"github.com/juju/errors"
+
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/cmd/juju/common"
+	"github.com/juju/juju/cmd/modelcmd"
+)
+
+// NewRemoveStorageCommandWithAPI returns a command
+// used to remove storage from the model.
+func NewRemoveStorageCommandWithAPI() cmd.Command {
+	cmd := &removeStorageCommand{}
+	cmd.newEntityDestroyerCloser = func() (EntityDestroyerCloser, error) {
+		return cmd.NewStorageAPI()
+	}
+	return modelcmd.Wrap(cmd)
+}
+
+// NewRemoveStorageCommand returns a command
+// used to remove storage from the model.
+func NewRemoveStorageCommand(new NewEntityDestroyerCloserFunc) cmd.Command {
+	cmd := &removeStorageCommand{}
+	cmd.newEntityDestroyerCloser = new
+	return modelcmd.Wrap(cmd)
+}
+
+const (
+	removeStorageCommandDoc = `
+Removes storage from the model. Specify one or more
+storage IDs, as output by "juju storage".
+
+Examples:
+    juju remove-storage pgdata/0
+`
+	removeStorageCommandArgs = `<storage> [<storage> ...]`
+)
+
+type removeStorageCommand struct {
+	StorageCommandBase
+	newEntityDestroyerCloser NewEntityDestroyerCloserFunc
+	storageIds               []string
+}
+
+// Info implements Command.Info.
+func (c *removeStorageCommand) Info() *cmd.Info {
+	return &cmd.Info{
+		Name:    "remove-storage",
+		Purpose: "Removes storage from the model.",
+		Doc:     removeStorageCommandDoc,
+		Args:    removeStorageCommandArgs,
+	}
+}
+
+// Init implements Command.Init.
+func (c *removeStorageCommand) Init(args []string) error {
+	if len(args) < 1 {
+		return errors.New("remove-storage requires at least one storage ID")
+	}
+	c.storageIds = args
+	return nil
+}
+
+// Run implements Command.Run.
+func (c *removeStorageCommand) Run(ctx *cmd.Context) error {
+	destroyer, err := c.newEntityDestroyerCloser()
+	if err != nil {
+		return errors.Trace(err)
+	}
+	defer destroyer.Close()
+
+	results, err := destroyer.Destroy(c.storageIds)
+	if err != nil {
+		if params.IsCodeUnauthorized(err) {
+			common.PermissionsMessage(ctx.Stderr, "remove storage")
+		}
+		return err
+	}
+	for i, result := range results {
+		if result.Error == nil {
+			ctx.Infof("removing %s", c.storageIds[i])
+		}
+	}
+	anyFailed := false
+	for i, result := range results {
+		if result.Error != nil {
+			ctx.Infof("failed to remove %s: %s", c.storageIds[i], result.Error)
+			anyFailed = true
+		}
+	}
+	if anyFailed {
+		return cmd.ErrSilent
+	}
+	return nil
+}
+
+// NewEntityDestroyerCloserFunc is the type of a function that returns an
+// EntityDestroyerCloser.
+type NewEntityDestroyerCloserFunc func() (EntityDestroyerCloser, error)
+
+// EntityDestroyerCloser extends EntityDestroyer with a Closer method.
+type EntityDestroyerCloser interface {
+	EntityDestroyer
+	Close() error
+}
+
+// EntityDestroyer defines an interface for destroying storage instances
+// with the specified IDs.
+type EntityDestroyer interface {
+	Destroy([]string) ([]params.ErrorResult, error)
+}

--- a/cmd/juju/storage/remove_test.go
+++ b/cmd/juju/storage/remove_test.go
@@ -1,0 +1,95 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package storage_test
+
+import (
+	"github.com/juju/cmd"
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/cmd/juju/storage"
+	coretesting "github.com/juju/juju/testing"
+)
+
+type RemoveStorageSuite struct {
+	testing.IsolationSuite
+}
+
+var _ = gc.Suite(&RemoveStorageSuite{})
+
+func (s *RemoveStorageSuite) TestRemoveStorage(c *gc.C) {
+	fake := fakeEntityDestroyer{results: []params.ErrorResult{
+		{},
+		{},
+	}}
+	cmd := storage.NewRemoveStorageCommand(fake.new)
+	ctx, err := coretesting.RunCommand(c, cmd, "pgdata/0", "pgdata/1")
+	c.Assert(err, jc.ErrorIsNil)
+	fake.CheckCallNames(c, "NewEntityDestroyerCloser", "Destroy", "Close")
+	fake.CheckCall(c, 1, "Destroy", []string{"pgdata/0", "pgdata/1"})
+	c.Assert(coretesting.Stderr(ctx), gc.Equals, `
+removing pgdata/0
+removing pgdata/1
+`[1:])
+}
+
+func (s *RemoveStorageSuite) TestRemoveStorageError(c *gc.C) {
+	fake := fakeEntityDestroyer{results: []params.ErrorResult{
+		{Error: &params.Error{Message: "foo"}},
+		{Error: &params.Error{Message: "bar"}},
+	}}
+	removeCmd := storage.NewRemoveStorageCommand(fake.new)
+	ctx, err := coretesting.RunCommand(c, removeCmd, "pgdata/0", "pgdata/1")
+	stderr := coretesting.Stderr(ctx)
+	c.Assert(stderr, gc.Equals, `failed to remove pgdata/0: foo
+failed to remove pgdata/1: bar
+`)
+	c.Assert(err, gc.Equals, cmd.ErrSilent)
+}
+
+func (s *RemoveStorageSuite) TestRemoveStorageUnauthorizedError(c *gc.C) {
+	var fake fakeEntityDestroyer
+	fake.SetErrors(nil, &params.Error{Code: params.CodeUnauthorized, Message: "nope"})
+	cmd := storage.NewRemoveStorageCommand(fake.new)
+	ctx, err := coretesting.RunCommand(c, cmd, "pgdata/0")
+	c.Assert(err, gc.ErrorMatches, "nope")
+	c.Assert(coretesting.Stderr(ctx), gc.Equals, `
+You do not have permission to remove storage.
+You may ask an administrator to grant you access with "juju grant".
+
+`)
+}
+
+func (s *RemoveStorageSuite) TestRemoveStorageInitErrors(c *gc.C) {
+	s.testRemoveStorageInitError(c, []string{}, "remove-storage requires at least one storage ID")
+}
+
+func (s *RemoveStorageSuite) testRemoveStorageInitError(c *gc.C, args []string, expect string) {
+	var fake fakeEntityDestroyer
+	cmd := storage.NewRemoveStorageCommand(fake.new)
+	_, err := coretesting.RunCommand(c, cmd, args...)
+	c.Assert(err, gc.ErrorMatches, expect)
+}
+
+type fakeEntityDestroyer struct {
+	testing.Stub
+	results []params.ErrorResult
+}
+
+func (f *fakeEntityDestroyer) new() (storage.EntityDestroyerCloser, error) {
+	f.MethodCall(f, "NewEntityDestroyerCloser")
+	return f, f.NextErr()
+}
+
+func (f *fakeEntityDestroyer) Close() error {
+	f.MethodCall(f, "Close")
+	return f.NextErr()
+}
+
+func (f *fakeEntityDestroyer) Destroy(ids []string) ([]params.ErrorResult, error) {
+	f.MethodCall(f, "Destroy", ids)
+	return f.results, f.NextErr()
+}

--- a/state/cleanup.go
+++ b/state/cleanup.go
@@ -228,7 +228,11 @@ func (st *State) cleanupVolumesForDyingModel() (err error) {
 	}
 	for _, v := range volumes {
 		err := st.DestroyVolume(v.VolumeTag())
-		if err != nil && !IsContainsFilesystem(err) {
+		if errors.IsNotFound(err) {
+			continue
+		} else if IsContainsFilesystem(err) {
+			continue
+		} else if err != nil {
 			return errors.Trace(err)
 		}
 	}
@@ -245,7 +249,9 @@ func (st *State) cleanupFilesystemsForDyingModel() (err error) {
 	}
 	for _, fs := range filesystems {
 		err := st.DestroyFilesystem(fs.FilesystemTag())
-		if err != nil {
+		if errors.IsNotFound(err) {
+			continue
+		} else if err != nil {
 			return errors.Trace(err)
 		}
 	}

--- a/state/migration_export.go
+++ b/state/migration_export.go
@@ -1630,10 +1630,14 @@ func (e *exporter) storageInstances() error {
 }
 
 func (e *exporter) addStorage(instance *storageInstance, attachments []names.UnitTag) error {
+	owner, ok := instance.Owner()
+	if !ok {
+		owner = nil
+	}
 	args := description.StorageArgs{
 		Tag:         instance.StorageTag(),
 		Kind:        instance.Kind().String(),
-		Owner:       instance.Owner(),
+		Owner:       owner,
 		Name:        instance.StorageName(),
 		Attachments: attachments,
 	}

--- a/state/storage_test.go
+++ b/state/storage_test.go
@@ -546,7 +546,9 @@ func (s *StorageStateSuite) TestAllStorageInstances(c *gc.C) {
 	for _, one := range all {
 		c.Assert(one.Kind(), gc.DeepEquals, state.StorageKindBlock)
 		c.Assert(nameSet.Contains(one.StorageName()), jc.IsTrue)
-		c.Assert(ownerSet.Contains(one.Owner().String()), jc.IsTrue)
+		owner, ok := one.Owner()
+		c.Assert(ok, jc.IsTrue)
+		c.Assert(ownerSet.Contains(owner.String()), jc.IsTrue)
 	}
 }
 
@@ -733,6 +735,12 @@ func (s *StorageStateSuite) TestConcurrentDestroyStorageInstance(c *gc.C) {
 	si, err := s.State.StorageInstance(storageTag)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(si.Life(), gc.Equals, state.Dying)
+}
+
+func (s *StorageStateSuite) TestDestroyStorageInstanceNotFound(c *gc.C) {
+	err := s.State.DestroyStorageInstance(names.NewStorageTag("foo/0"))
+	c.Assert(err, gc.ErrorMatches, `cannot destroy storage "foo/0": storage instance "foo/0" not found`)
+	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 }
 
 func (s *StorageStateSuite) TestWatchStorageAttachments(c *gc.C) {

--- a/state/unit.go
+++ b/state/unit.go
@@ -1785,7 +1785,7 @@ func unitMachineStorageParams(u *Unit) (*machineStorageParams, error) {
 	volumeAttachments := make(map[names.VolumeTag]VolumeAttachmentParams)
 	filesystemAttachments := make(map[names.FilesystemTag]FilesystemAttachmentParams)
 	for _, storageAttachment := range storageAttachments {
-		storage, err := u.st.StorageInstance(storageAttachment.StorageInstance())
+		storage, err := u.st.storageInstance(storageAttachment.StorageInstance())
 		if err != nil {
 			return nil, errors.Annotatef(err, "getting storage instance")
 		}
@@ -1825,7 +1825,7 @@ func machineStorageParamsForStorageInstance(
 	unit names.UnitTag,
 	series string,
 	allCons map[string]StorageConstraints,
-	storage StorageInstance,
+	storage *storageInstance,
 ) (*machineStorageParams, error) {
 
 	charmStorage := charmMeta.Storage[storage.StorageName()]
@@ -1840,7 +1840,7 @@ func machineStorageParamsForStorageInstance(
 		volumeAttachmentParams := VolumeAttachmentParams{
 			charmStorage.ReadOnly,
 		}
-		if unit == storage.Owner() {
+		if unit == storage.maybeOwner() {
 			// The storage instance is owned by the unit, so we'll need
 			// to create a volume.
 			cons := allCons[storage.StorageName()]
@@ -1879,7 +1879,7 @@ func machineStorageParamsForStorageInstance(
 			location,
 			charmStorage.ReadOnly,
 		}
-		if unit == storage.Owner() {
+		if unit == storage.maybeOwner() {
 			// The storage instance is owned by the unit, so we'll need
 			// to create a filesystem.
 			cons := allCons[storage.StorageName()]


### PR DESCRIPTION
## Description of change

Add the remove-storage command. This command takes
one or more storage instance, filesystem, or volume
IDs, and destroys the corresponding entities. If
a storage instance is specified (e.g. "pgdata/0"),
then the associated volume/filesystem will also be
destroyed.

To disambiguate volume and filesystem IDs, the
user must specify those IDs prefixed with the
entity type, e.g. filesystem-0, volume-0.

## QA steps

1. juju bootstrap aws
2. juju deploy postgresql --storage pgdata=ebs (wait for unit to become idle)
3. juju remove-storage pgdata/0
4. observe "pgdata-storage-detaching" hook run on postgresql/0
5. observe pgdata/0 is removed
6. observe volume 0 is detached, destroyed and removed

## Documentation changes

Yes, docs needed describing the new remove-storage command.