### PR TITLE
Only use not dead and not imported models for user.

### DIFF
--- a/state/modeluser.go
+++ b/state/modeluser.go
@@ -236,12 +236,14 @@ func (st *State) ModelsForUser(user names.UserTag) ([]*UserModel, error) {
 	var result []*UserModel
 	for _, doc := range userSlice {
 		modelTag := names.NewModelTag(doc.ObjectUUID)
-		env, err := st.GetModel(modelTag)
+		model, err := st.GetModel(modelTag)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
 
-		result = append(result, &UserModel{Model: env, User: user})
+		if model.Life() != Dead && model.MigrationMode() != MigrationModeImporting {
+			result = append(result, &UserModel{Model: model, User: user})
+		}
 	}
 
 	return result, nil

--- a/state/modeluser_test.go
+++ b/state/modeluser_test.go
@@ -391,6 +391,34 @@ func (s *ModelUserSuite) TestModelsForUser(c *gc.C) {
 	c.Assert(st.Close(), jc.ErrorIsNil)
 }
 
+func (s *ModelUserSuite) TestDeadModelsForUser(c *gc.C) {
+	user := s.Factory.MakeUser(c, nil)
+	models, err := s.State.ModelsForUser(user.UserTag())
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(models, gc.HasLen, 1)
+	c.Assert(models[0].UUID(), gc.Equals, s.State.ModelUUID())
+
+	err = state.SetModelLifeDead(s.State, models[0].UUID())
+	c.Assert(err, jc.ErrorIsNil)
+	models, err = s.State.ModelsForUser(user.UserTag())
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(models, gc.HasLen, 0)
+}
+
+func (s *ModelUserSuite) TestImportingModelsForUser(c *gc.C) {
+	user := s.Factory.MakeUser(c, nil)
+	models, err := s.State.ModelsForUser(user.UserTag())
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(models, gc.HasLen, 1)
+	c.Assert(models[0].UUID(), gc.Equals, s.State.ModelUUID())
+
+	err = models[0].SetMigrationMode(state.MigrationModeImporting)
+	c.Assert(err, jc.ErrorIsNil)
+	models, err = s.State.ModelsForUser(user.UserTag())
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(models, gc.HasLen, 0)
+}
+
 func (s *ModelUserSuite) newEnvWithOwner(c *gc.C, name string, owner names.UserTag) *state.Model {
 	// Don't use the factory to call MakeModel because it may at some
 	// time in the future be modified to do additional things.  Instead call


### PR DESCRIPTION
## Description of change

List model was listing models that were marked as Dead. This caused unpredictable behavior of client side when model details were being retrieved. It also does not make sense for us to list models that are being imported during model migration. 

## QA steps

As per functional QA  test described in the linked bug, imported models are dead models should not appear in model list for a user.

## Documentation changes

@juju/docs Model Migration and Listing of Models documentation may need to be clarified to explicit call out that model lists will not have models that are dead or that are being imported.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1667333
https://bugs.launchpad.net/juju/+bug/1613960
