### PR TITLE
Make user management messages more informative

### DIFF
--- a/api/usermanager/client_test.go
+++ b/api/usermanager/client_test.go
@@ -48,7 +48,7 @@ func (s *usermanagerSuite) TestAddExistingUser(c *gc.C) {
 	s.Factory.MakeUser(c, &factory.UserParams{Name: "foobar"})
 
 	_, _, err := s.usermanager.AddUser("foobar", "Foo Bar", "password")
-	c.Assert(err, gc.ErrorMatches, "failed to create user: user already exists")
+	c.Assert(err, gc.ErrorMatches, "failed to create user: username unavailable")
 }
 
 func (s *usermanagerSuite) TestAddUserResponseError(c *gc.C) {
@@ -91,7 +91,7 @@ func (s *usermanagerSuite) TestRemoveUser(c *gc.C) {
 
 	// Assert that the user is gone.
 	_, err = s.State.User(tag)
-	c.Assert(err, jc.Satisfies, errors.IsUserNotFound)
+	c.Assert(err, gc.ErrorMatches, `user "jjam" is permanently deleted`)
 
 	err = user.Refresh()
 	c.Check(err, jc.ErrorIsNil)

--- a/apiserver/usermanager/usermanager_test.go
+++ b/apiserver/usermanager/usermanager_test.go
@@ -649,7 +649,7 @@ func (s *userManagerSuite) TestRemoveUser(c *gc.C) {
 	// Create a user to delete.
 	jjam := s.Factory.MakeUser(c, &factory.UserParams{Name: "jimmyjam"})
 
-	expectedError := fmt.Sprintf("%q user not found", jjam.Name())
+	expectedError := fmt.Sprintf("failed to delete user %q: user %q is permanently deleted", jjam.Name(), jjam.Name())
 
 	// Remove the user
 	got, err := s.usermanager.RemoveUser(params.Entities{
@@ -670,7 +670,7 @@ func (s *userManagerSuite) TestRemoveUser(c *gc.C) {
 	c.Check(got.Results, gc.HasLen, 1)
 	c.Check(got.Results[0].Error, jc.DeepEquals, &params.Error{
 		Message: expectedError,
-		Code:    "user not found",
+		Code:    "",
 	})
 	c.Assert(err, jc.ErrorIsNil)
 }

--- a/cmd/juju/user/remove_test.go
+++ b/cmd/juju/user/remove_test.go
@@ -77,10 +77,14 @@ func (s *RemoveUserCommandSuite) TestRemove(c *gc.C) {
 
 func (s *RemoveUserCommandSuite) TestRemovePrompts(c *gc.C) {
 	username := "testing"
-	expected := `
-WARNING! This command will remove the user "testing" from the "testing" controller.
+	expected := `WARNING! This command will permanently archive the user "testing" on the "testing"
+controller.
 
-Continue (y/N)? `[1:]
+This action is irreversible. If you wish to temporarily disable the
+user please use the` + " `juju disable-user` " + `command. See
+` + " `juju help disable-user` " + `for more details.
+
+Continue (y/N)? `
 	command, _ := user.NewRemoveCommandForTest(s.mockAPI, s.store)
 	ctx, _ := testing.RunCommand(c, command, username)
 	c.Assert(testing.Stdout(ctx), jc.DeepEquals, expected)

--- a/featuretests/cmd_juju_user_test.go
+++ b/featuretests/cmd_juju_user_test.go
@@ -90,9 +90,14 @@ func (s *UserSuite) TestUserEnable(c *gc.C) {
 
 func (s *UserSuite) TestRemoveUserPrompt(c *gc.C) {
 	expected := `
-WARNING! This command will remove the user "jjam" from the "kontroll" controller.
+WARNING! This command will permanently archive the user "jjam" on the "kontroll"
+controller.
 
-Continue (y/N)? `[1:]
+This action is irreversible. If you wish to temporarily disable the
+user please use the`[1:] + " `juju disable-user` " + `command. See
+` + " `juju help disable-user` " + `for more details.
+
+Continue (y/N)? `
 	_ = s.Factory.MakeUser(c, &factory.UserParams{Name: "jjam"})
 	ctx, _ := s.RunUserCommand(c, "", "remove-user", "jjam")
 	c.Assert(testing.Stdout(ctx), jc.DeepEquals, expected)

--- a/state/model.go
+++ b/state/model.go
@@ -644,11 +644,13 @@ func (m *Model) Users() ([]permission.UserAccess, error) {
 		userTag := names.NewUserTag(doc.UserName)
 		if userTag.IsLocal() {
 			_, err := m.st.User(userTag)
-			if errors.IsUserNotFound(err) {
-				continue
-			}
 			if err != nil {
-				return nil, errors.Trace(err)
+				if _, ok := err.(DeletedUserError); !ok {
+					// We ignore deleted users for now. So if it is not a
+					// DeletedUserError we return the error.
+					return nil, errors.Trace(err)
+				}
+				continue
 			}
 		}
 		mu, err := NewModelUserAccess(m.st, doc)


### PR DESCRIPTION
## Description of change

Why is this change needed?

This reworks the error messages when adding and removing users. It
essentially returns "user unavailable" rather than "not found" when
deleting and "is permanently deleted" rather than "user exists".

It also changes a bunch of gocheck asserts into checks where is made no
sense to fail the suite on the first error.


## QA steps

How do we verify that the change works?

1. Bootstrap a controller, say lxd `juju bootstrap lxd lp/1630728`
2. Add a user: 
```
$ juju add-user jjam
User "jjam" added
Please send this command to jjam:
    juju register snip...

"jjam" has not been granted access to any models. You can use "juju grant" to grant access.
```
3. Try adding it again and ensure it says unavailable rather than not found
```
juju add-user jjaM
ERROR failed to create user: username unavailable
```
4. Delete the user and verify the confirmation message is informative.
```
$ juju remove-user jjam
WARNING! This command will permanently archive the user "jjam" on the "lp/1630728_remove-user"
controller.

This action is irreversible. If you wish to temporarily disable the
user please use the `juju disable-user` command. See
 `juju help disable-user` for more details.

Continue (y/N)? y
User "jjam" removed
```
5. Try to remove the user again and ensure we have unavailable instead of not found.
```
$ juju remove-user jjam -y
ERROR failed to delete user "jjam": the user has already been permanently deleted
```
6. Try to add a user with the same name
```
$ juju add-user jjaM
ERROR failed to create user: username unavailable
```

## Documentation changes

Does it affect current user workflow? CLI? API?
It changes some output but not input.

## Bug reference

Does this change fix a bug? Please add a link to it.

Refs: https://bugs.launchpad.net/juju/+bug/1630728
