### PR TITLE
Make DebugHook test more reliable on busy machines

### DIFF
--- a/worker/uniter/runner/debug/server_test.go
+++ b/worker/uniter/runner/debug/server_test.go
@@ -154,7 +154,7 @@ func (s *DebugHooksServerSuite) TestRunHook(c *gc.C) {
 	// and also create the .pid file. We'll populate it with
 	// an invalid PID; this will cause the server process to
 	// exit cleanly (as if the PID were real and no longer running).
-	cmd := exec.Command("flock", s.ctx.ClientExitFileLock(), "-c", "sleep 5s")
+	cmd := exec.Command("flock", s.ctx.ClientExitFileLock(), "-c", "sleep 10s")
 	c.Assert(cmd.Start(), gc.IsNil)
 	defer cmd.Process.Kill() // kill flock
 


### PR DESCRIPTION
## Description of change

TestRunHook was regularly failing on test hosts with an error indicating
that the flock process was being killed by a timer before we managed to
get the debug directory. It passes reliably on a (relatively unloaded)
dev machine, but I could simulate a heavier load by adding a delay in
the goroutine the test starts and get similarly flaky behaviour.

Increase the timeout of the flock command to match the timeout of the
select loop below it - this should make the failures much less likely.

## Bug reference

Hopefullly fixes https://bugs.launchpad.net/juju/+bug/1612747