### PR TITLE
localhost lost as a builtin cloud from cmd.

### DIFF
--- a/cmd/juju/cloud/regions.go
+++ b/cmd/juju/cloud/regions.go
@@ -73,7 +73,7 @@ func (c *listRegionsCommand) Init(args []string) error {
 
 // Run implements Command.Run.
 func (c *listRegionsCommand) Run(ctxt *cmd.Context) error {
-	cloud, err := common.AnyCloudByName(c.cloudName)
+	cloud, err := common.CloudByName(c.cloudName)
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/cmd/juju/cloud/regions.go
+++ b/cmd/juju/cloud/regions.go
@@ -12,7 +12,7 @@ import (
 	"github.com/juju/gnuflag"
 	"gopkg.in/yaml.v2"
 
-	"github.com/juju/juju/cloud"
+	"github.com/juju/juju/cmd/juju/common"
 	"github.com/juju/juju/cmd/output"
 )
 
@@ -73,9 +73,9 @@ func (c *listRegionsCommand) Init(args []string) error {
 
 // Run implements Command.Run.
 func (c *listRegionsCommand) Run(ctxt *cmd.Context) error {
-	cloud, err := cloud.CloudByName(c.cloudName)
+	cloud, err := common.AnyCloudByName(c.cloudName)
 	if err != nil {
-		return err
+		return errors.Trace(err)
 	}
 
 	if len(cloud.Regions) == 0 {

--- a/cmd/juju/cloud/regions_test.go
+++ b/cmd/juju/cloud/regions_test.go
@@ -53,6 +53,13 @@ sa-east-1
 `[1:])
 }
 
+func (s *regionsSuite) TestListRegionsBuiltInCloud(c *gc.C) {
+	ctx, err := testing.RunCommand(c, cloud.NewListRegionsCommand(), "localhost")
+	c.Assert(err, jc.ErrorIsNil)
+	out := testing.Stdout(ctx)
+	c.Assert(out, jc.DeepEquals, "localhost\n\n")
+}
+
 func (s *regionsSuite) TestListRegionsYaml(c *gc.C) {
 	ctx, err := testing.RunCommand(c, cloud.NewListRegionsCommand(), "aws", "--format", "yaml")
 	c.Assert(err, jc.ErrorIsNil)

--- a/cmd/juju/commands/bootstrap.go
+++ b/cmd/juju/commands/bootstrap.go
@@ -1006,7 +1006,7 @@ func (c *bootstrapCommand) runInteractive(ctx *cmd.Context) error {
 	if err != nil {
 		return errors.Trace(err)
 	}
-	cloud, err := common.AnyCloudByName(c.Cloud)
+	cloud, err := common.CloudByName(c.Cloud)
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/cmd/juju/commands/bootstrap.go
+++ b/cmd/juju/commands/bootstrap.go
@@ -1006,7 +1006,7 @@ func (c *bootstrapCommand) runInteractive(ctx *cmd.Context) error {
 	if err != nil {
 		return errors.Trace(err)
 	}
-	cloud, err := jujucloud.CloudByName(c.Cloud)
+	cloud, err := common.AnyCloudByName(c.Cloud)
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/cmd/juju/commands/bootstrap_clouds.go
+++ b/cmd/juju/commands/bootstrap_clouds.go
@@ -123,7 +123,7 @@ listed is the default. Add more clouds with ‘juju add-cloud’.
 }
 
 func printCloudRegions(ctx *cmd.Context, cloudName string) error {
-	cloud, err := common.AnyCloudByName(cloudName)
+	cloud, err := common.CloudByName(cloudName)
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/cmd/juju/commands/bootstrap_clouds.go
+++ b/cmd/juju/commands/bootstrap_clouds.go
@@ -123,9 +123,9 @@ listed is the default. Add more clouds with ‘juju add-cloud’.
 }
 
 func printCloudRegions(ctx *cmd.Context, cloudName string) error {
-	cloud, err := jujucloud.CloudByName(cloudName)
+	cloud, err := common.AnyCloudByName(cloudName)
 	if err != nil {
-		return err
+		return errors.Trace(err)
 	}
 	fmt.Fprintf(ctx.Stdout, "Showing regions for %s:\n", cloudName)
 	for _, region := range cloud.Regions {

--- a/cmd/juju/common/cloud.go
+++ b/cmd/juju/common/cloud.go
@@ -93,3 +93,27 @@ func BuiltInClouds() (map[string]jujucloud.Cloud, error) {
 	}
 	return allClouds, nil
 }
+
+// AnyCloudByName returns a cloud for given name
+// regardless of whether it's public, private or builtin cloud.
+// Since this method caters for builtin clouds, unlike cloud.CloudByName,
+// it should be used in cmd.
+func AnyCloudByName(cloudName string) (*jujucloud.Cloud, error) {
+	cloud, err := jujucloud.CloudByName(cloudName)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			// Check built in clouds like localhost (lxd).
+			builtinClouds, err := BuiltInClouds()
+			if err != nil {
+				return nil, errors.Trace(err)
+			}
+			aCloud, found := builtinClouds[cloudName]
+			if !found {
+				return nil, errors.NotFoundf("cloud %s", cloudName)
+			}
+			return &aCloud, nil
+		}
+		return nil, errors.Trace(err)
+	}
+	return cloud, nil
+}

--- a/cmd/juju/common/cloud.go
+++ b/cmd/juju/common/cloud.go
@@ -94,11 +94,11 @@ func BuiltInClouds() (map[string]jujucloud.Cloud, error) {
 	return allClouds, nil
 }
 
-// AnyCloudByName returns a cloud for given name
+// CloudByName returns a cloud for given name
 // regardless of whether it's public, private or builtin cloud.
-// Since this method caters for builtin clouds, unlike cloud.CloudByName,
-// it should be used in cmd.
-func AnyCloudByName(cloudName string) (*jujucloud.Cloud, error) {
+// Not to be confused with cloud.CloudByName which does not cater
+// for built-in clouds like localhost.
+func CloudByName(cloudName string) (*jujucloud.Cloud, error) {
 	cloud, err := jujucloud.CloudByName(cloudName)
 	if err != nil {
 		if errors.IsNotFound(err) {


### PR DESCRIPTION
## Description of change

Juju caters for 3 categories of clouds - public, private and built-in. Some command could not recognise built-in clouds.

## QA steps

SCENARIO 1: interactively bootstrap with a built-in cloud
1. 'juju bootstrap'
2. Select localhost as a cloud (either by pressing ENTER or typing it in)
3. Bootstrap proceeds as expected without throwing "unknown cloud" error

SCENARIO 2: List regions for a built-in cloud
1. 'juju regions localhost'
2. Presented with a list of correct regions without throwing "unknown cloud" error

## Documentation changes
n/a

## Bug reference

https://bugs.launchpad.net/juju/+bug/1665056
