### PR TITLE
Check provided auth type is valid for the cloud.

### DIFF
--- a/cmd/juju/cloud/addcredential_test.go
+++ b/cmd/juju/cloud/addcredential_test.go
@@ -130,6 +130,7 @@ func (s *addCredentialSuite) TestAddFromFileExisting(c *gc.C) {
 }
 
 func (s *addCredentialSuite) TestAddFromFileExistingReplace(c *gc.C) {
+	s.authTypes = []jujucloud.AuthType{jujucloud.UserPassAuthType, jujucloud.AccessKeyAuthType}
 	s.store.Credentials = map[string]jujucloud.CloudCredential{
 		"somecloud": {
 			AuthCredentials: map[string]jujucloud.Credential{
@@ -152,6 +153,7 @@ func (s *addCredentialSuite) TestAddFromFileExistingReplace(c *gc.C) {
 }
 
 func (s *addCredentialSuite) TestAddNewFromFile(c *gc.C) {
+	s.authTypes = []jujucloud.AuthType{jujucloud.AccessKeyAuthType}
 	sourceFile := s.createTestCredentialData(c)
 	_, err := s.run(c, nil, "somecloud", "-f", sourceFile)
 	c.Assert(err, jc.ErrorIsNil)

--- a/cmd/juju/cloud/addcredential_test.go
+++ b/cmd/juju/cloud/addcredential_test.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"io/ioutil"
 	"path/filepath"
+	"regexp"
 	"strings"
 
 	"github.com/juju/cmd"
@@ -92,16 +93,20 @@ func (s *addCredentialSuite) TestNoCredentialsRequired(c *gc.C) {
 }
 
 func (s *addCredentialSuite) createTestCredentialData(c *gc.C) string {
+	return s.createTestCredentialDataWithAuthType(c, "access-key")
+}
+
+func (s *addCredentialSuite) createTestCredentialDataWithAuthType(c *gc.C, authType string) string {
 	dir := c.MkDir()
 	credsFile := filepath.Join(dir, "cred.yaml")
-	data := `
+	data := fmt.Sprintf(`
 credentials:
   somecloud:
     me:
-      auth-type: access-key
+      auth-type: %v
       access-key: <key>
       secret-key: <secret>
-`[1:]
+`[1:], authType)
 	err := ioutil.WriteFile(credsFile, []byte(data), 0600)
 	c.Assert(err, jc.ErrorIsNil)
 	return credsFile
@@ -159,6 +164,14 @@ func (s *addCredentialSuite) TestAddNewFromFile(c *gc.C) {
 				})},
 		},
 	})
+}
+
+func (s *addCredentialSuite) TestAddInvalidAuth(c *gc.C) {
+	s.authTypes = []jujucloud.AuthType{jujucloud.AccessKeyAuthType}
+	sourceFile := s.createTestCredentialDataWithAuthType(c, "invalid auth")
+	_, err := s.run(c, nil, "somecloud", "-f", sourceFile)
+	c.Assert(err, gc.ErrorMatches,
+		regexp.QuoteMeta(`credential "me" contains invalid auth type "invalid auth", valid auth types for cloud "somecloud" are [access-key]`))
 }
 
 // TODO(wallyworld) - these tests should also validate that the prompts and messages are as expected.

--- a/cmd/juju/cloud/addcredential_test.go
+++ b/cmd/juju/cloud/addcredential_test.go
@@ -174,6 +174,14 @@ func (s *addCredentialSuite) TestAddInvalidAuth(c *gc.C) {
 		regexp.QuoteMeta(`credential "me" contains invalid auth type "invalid auth", valid auth types for cloud "somecloud" are [access-key]`))
 }
 
+func (s *addCredentialSuite) TestAddCloudUnsupportedAuth(c *gc.C) {
+	s.authTypes = []jujucloud.AuthType{jujucloud.AccessKeyAuthType}
+	sourceFile := s.createTestCredentialDataWithAuthType(c, fmt.Sprintf("%v", jujucloud.JSONFileAuthType))
+	_, err := s.run(c, nil, "somecloud", "-f", sourceFile)
+	c.Assert(err, gc.ErrorMatches,
+		regexp.QuoteMeta(`credential "me" contains invalid auth type "jsonfile", valid auth types for cloud "somecloud" are [access-key]`))
+}
+
 // TODO(wallyworld) - these tests should also validate that the prompts and messages are as expected.
 
 func (s *addCredentialSuite) assertAddUserpassCredential(c *gc.C, input string, expected *jujucloud.Credential) {


### PR DESCRIPTION
## Description of change

When adding credentials, provided auth types need to be valid for a given cloud.

## QA steps

1. add cloud with some auth type
2. add credential using -f where file contains either mistyped or an auth type not listed for the cloud
3. Add cloud command should error out.

## Bug reference
https://bugs.launchpad.net/juju/+bug/1590239
