### PR TITLE
MaaS 2.0 issues a 404 when requesting static-routes.

### DIFF
--- a/provider/maas/environ.go
+++ b/provider/maas/environ.go
@@ -2188,8 +2188,11 @@ func (env *maasEnviron) allocateContainerAddresses2(hostInstanceID instance.Id, 
 		// "version": "2.1.3+bzr5573-0ubuntu1", "subversion": "16.04.1"}
 		// TODO(jam) 2017-02-28 Is there a better test for this? The full error we were creating was:
 		// failed to prepare container "0/lxd/1" network config: unable to look up static-routes: unexpected: ServerError: 404 NOT FOUND (Unknown API endpoint: /MAAS/api/2.0/static-routes/.)
-		// ServerError and 404 look like something maybe we could use?
-		if strings.Contains(err.Error(), "Unknown API endpoint: /MAAS/api/2.0/static-routes/") {
+		// We don't check the full string, because the MAAS server may not be strictly hosted at /MAAS (though that is the default).
+		serverError, ok := gomaasapi.GetServerError(err)
+		if ok && serverError.StatusCode == http.StatusNotFound &&
+			strings.Contains(err.Error(), "Unknown API endpoint:") &&
+			strings.Contains(err.Error(), "/api/2.0/static-routes/") {
 			staticRoutes = nil
 		} else {
 			return nil, errors.Annotate(err, "unable to look up static-routes")

--- a/provider/maas/maas2_environ_whitebox_test.go
+++ b/provider/maas/maas2_environ_whitebox_test.go
@@ -1088,6 +1088,204 @@ func (suite *maas2EnvironSuite) TestAllocateContainerAddressesSingleNic(c *gc.C)
 	c.Assert(result, jc.DeepEquals, expected)
 }
 
+func (suite *maas2EnvironSuite) TestAllocateContainerAddressesNoStaticRoutesAPI(c *gc.C) {
+	// MAAS 2.0 doesn't have support for static routes, and generates an Error
+	vlan1 := fakeVLAN{
+		id:  5001,
+		mtu: 1500,
+	}
+	subnet1 := fakeSubnet{
+		id:         3,
+		space:      "freckles",
+		vlan:       vlan1,
+		gateway:    "10.20.19.2",
+		cidr:       "10.20.19.0/24",
+		dnsServers: []string{"10.20.19.2", "10.20.19.3"},
+	}
+
+	interfaces := []gomaasapi.Interface{
+		&fakeInterface{
+			id:         91,
+			name:       "eth0",
+			type_:      "physical",
+			enabled:    true,
+			macAddress: "52:54:00:70:9b:fe",
+			vlan:       vlan1,
+			links: []gomaasapi.Link{
+				&fakeLink{
+					id:        436,
+					subnet:    &subnet1,
+					ipAddress: "10.20.19.103",
+					mode:      "static",
+				},
+			},
+			parents:  []string{},
+			children: []string{"eth0.100", "eth0.250", "eth0.50"},
+		},
+	}
+	// This will be returned by the fakeController when we call CreateDevice
+	deviceInterfaces := []gomaasapi.Interface{
+		&fakeInterface{
+			id:         93,
+			name:       "eth0",
+			type_:      "physical",
+			enabled:    true,
+			macAddress: "53:54:00:70:9b:ff",
+			vlan:       vlan1,
+			links: []gomaasapi.Link{
+				&fakeLink{
+					id:        480,
+					subnet:    &subnet1,
+					ipAddress: "10.20.19.104",
+					mode:      "static",
+				},
+			},
+			parents:  []string{},
+			children: []string{},
+		},
+	}
+	device := &fakeDevice{
+		interfaceSet: deviceInterfaces,
+		systemID:     "foo",
+	}
+	// MAAS 2.0 gives us this kind of error back, I'm not sure of the conten of
+	// the Headers or BodyMessage, but it is a 404 with a particular error
+	// string that we've seen.
+	body := "Unknown API endpoint: /MAAS/api/2.0/static-routes/."
+	notFound := gomaasapi.ServerError{
+		StatusCode:  http.StatusNotFound,
+		BodyMessage: body,
+	}
+	staticRoutesErr := errors.Annotatef(notFound, "ServerError: %v (%s)", http.StatusNotFound, body)
+	var env *maasEnviron
+	controller := &fakeController{
+		Stub: &testing.Stub{},
+		machines: []gomaasapi.Machine{&fakeMachine{
+			Stub:         &testing.Stub{},
+			systemID:     "1",
+			architecture: arch.HostArch(),
+			interfaceSet: interfaces,
+			createDevice: device,
+		}},
+		spaces: []gomaasapi.Space{
+			fakeSpace{
+				name:    "freckles",
+				id:      4567,
+				subnets: []gomaasapi.Subnet{subnet1},
+			},
+		},
+		devices:           []gomaasapi.Device{device},
+		staticRoutesError: staticRoutesErr,
+	}
+	suite.injectController(controller)
+	suite.setupFakeTools(c)
+	env = suite.makeEnviron(c, nil)
+
+	prepared := []network.InterfaceInfo{{
+		MACAddress:    "52:54:00:70:9b:fe",
+		CIDR:          "10.20.19.0/24",
+		InterfaceName: "eth0",
+	}}
+	ignored := names.NewMachineTag("1/lxd/0")
+	result, err := env.AllocateContainerAddresses(instance.Id("1"), ignored, prepared)
+	c.Assert(err, jc.ErrorIsNil)
+	expected := []network.InterfaceInfo{{
+		DeviceIndex:       0,
+		MACAddress:        "53:54:00:70:9b:ff",
+		CIDR:              "10.20.19.0/24",
+		ProviderId:        "93",
+		ProviderSubnetId:  "3",
+		VLANTag:           0,
+		ProviderVLANId:    "5001",
+		ProviderAddressId: "480",
+		InterfaceName:     "eth0",
+		InterfaceType:     "ethernet",
+		ConfigType:        "static",
+		Address:           network.NewAddressOnSpace("freckles", "10.20.19.104"),
+		DNSServers:        network.NewAddressesOnSpace("freckles", "10.20.19.2", "10.20.19.3"),
+		MTU:               1500,
+		GatewayAddress:    network.NewAddressOnSpace("freckles", "10.20.19.2"),
+		Routes:            []network.Route{},
+	}}
+	c.Assert(result, jc.DeepEquals, expected)
+}
+
+func (suite *maas2EnvironSuite) TestAllocateContainerAddressesStaticRoutesDenied(c *gc.C) {
+	// I don't have a specific error that we've triggered, but we want to make
+	// sure that we don't suppress all error responses from MAAS just because
+	// we know we want to skip 404
+	vlan1 := fakeVLAN{
+		id:  5001,
+		mtu: 1500,
+	}
+	subnet1 := fakeSubnet{
+		id:         3,
+		space:      "freckles",
+		vlan:       vlan1,
+		gateway:    "10.20.19.2",
+		cidr:       "10.20.19.0/24",
+		dnsServers: []string{"10.20.19.2", "10.20.19.3"},
+	}
+
+	interfaces := []gomaasapi.Interface{
+		&fakeInterface{
+			id:         91,
+			name:       "eth0",
+			type_:      "physical",
+			enabled:    true,
+			macAddress: "52:54:00:70:9b:fe",
+			vlan:       vlan1,
+			links: []gomaasapi.Link{
+				&fakeLink{
+					id:        436,
+					subnet:    &subnet1,
+					ipAddress: "10.20.19.103",
+					mode:      "static",
+				},
+			},
+			parents:  []string{},
+			children: []string{"eth0.100", "eth0.250", "eth0.50"},
+		},
+	}
+	body := "I have failed you"
+	internalError := gomaasapi.ServerError{
+		StatusCode:  http.StatusInternalServerError,
+		BodyMessage: body,
+	}
+	staticRoutesErr := errors.Annotatef(internalError, "ServerError: %v (%s)", http.StatusInternalServerError, body)
+	var env *maasEnviron
+	controller := &fakeController{
+		Stub: &testing.Stub{},
+		machines: []gomaasapi.Machine{&fakeMachine{
+			Stub:         &testing.Stub{},
+			systemID:     "1",
+			architecture: arch.HostArch(),
+			interfaceSet: interfaces,
+		}},
+		spaces: []gomaasapi.Space{
+			fakeSpace{
+				name:    "freckles",
+				id:      4567,
+				subnets: []gomaasapi.Subnet{subnet1},
+			},
+		},
+		staticRoutesError: staticRoutesErr,
+	}
+	suite.injectController(controller)
+	suite.setupFakeTools(c)
+	env = suite.makeEnviron(c, nil)
+
+	prepared := []network.InterfaceInfo{{
+		MACAddress:    "52:54:00:70:9b:fe",
+		CIDR:          "10.20.19.0/24",
+		InterfaceName: "eth0",
+	}}
+	ignored := names.NewMachineTag("1/lxd/0")
+	_, err := env.AllocateContainerAddresses(instance.Id("1"), ignored, prepared)
+	c.Assert(err, gc.NotNil)
+	c.Assert(err, gc.ErrorMatches, ".*ServerError: 500 \\(I have failed you\\).*")
+}
+
 func (suite *maas2EnvironSuite) TestAllocateContainerAddressesDualNic(c *gc.C) {
 	vlan1 := fakeVLAN{
 		id:  5001,


### PR DESCRIPTION
It seems static-routes is only in 2.1+ but isn't reported in the API version,
nor in the 'capabilities' list.

## Description of change

MAAS 2.1 implemented a new API (static-routes), that we wanted to propagate into containers. However, MAAS 2.0 does not have that API, but we don't have a way to tell the API isn't available based on the API version, nor on the capabilities tags. So instead we try the API, and handle getting a 404 back.

## QA steps

We have a functional test that tests we can create containers and get access to them on MAAS 2.0.

To test directly "juju bootstrap" onto a MAAS 2.0 machine, and "juju add-machine -m controller lxd:0". That container should be on the host's network, instead of on lxdbr0, and there shouldn't be this error in the log file:
2017-02-27 17:55:22 WARNING juju.provisioner lxd-broker.go:82 failed to prepare container "0/lxd/1" network config: unable to look up static-routes: unexpected: ServerError: 404 NOT FOUND (Unknown API endpoint: /MAAS/api/2.0/static-routes/.)

## Documentation changes

No.

## Bug reference

[lp:1668359](https://bugs.launchpad.net/juju/+bug/1668359)
