### PR TITLE
cmd/juju/storage: add binding/life to details

### DIFF
--- a/api/storage/client_test.go
+++ b/api/storage/client_test.go
@@ -313,9 +313,9 @@ func (s *storageMockSuite) TestListVolumes(c *gc.C) {
 
 			details := params.VolumeDetails{
 				VolumeTag: "volume-0",
-				MachineAttachments: map[string]params.VolumeAttachmentInfo{
-					"machine-0": params.VolumeAttachmentInfo{},
-					"machine-1": params.VolumeAttachmentInfo{},
+				MachineAttachments: map[string]params.VolumeAttachmentDetails{
+					"machine-0": {},
+					"machine-1": {},
 				},
 			}
 			results.Results = []params.VolumeDetailsListResult{{
@@ -333,9 +333,9 @@ func (s *storageMockSuite) TestListVolumes(c *gc.C) {
 	for i := 0; i < 2; i++ {
 		c.Assert(found[i].Result, jc.DeepEquals, []params.VolumeDetails{{
 			VolumeTag: "volume-0",
-			MachineAttachments: map[string]params.VolumeAttachmentInfo{
-				"machine-0": params.VolumeAttachmentInfo{},
-				"machine-1": params.VolumeAttachmentInfo{},
+			MachineAttachments: map[string]params.VolumeAttachmentDetails{
+				"machine-0": {},
+				"machine-1": {},
 			},
 		}})
 	}
@@ -406,10 +406,12 @@ func (s *storageMockSuite) TestListFilesystems(c *gc.C) {
 		Status: params.EntityStatus{
 			Status: "attached",
 		},
-		MachineAttachments: map[string]params.FilesystemAttachmentInfo{
-			"0": params.FilesystemAttachmentInfo{
-				MountPoint: "/mnt/kinabalu",
-				ReadOnly:   false,
+		MachineAttachments: map[string]params.FilesystemAttachmentDetails{
+			"0": params.FilesystemAttachmentDetails{
+				FilesystemAttachmentInfo: params.FilesystemAttachmentInfo{
+					MountPoint: "/mnt/kinabalu",
+					ReadOnly:   false,
+				},
 			},
 		},
 	}

--- a/apiserver/params/storage.go
+++ b/apiserver/params/storage.go
@@ -404,6 +404,11 @@ type StorageDetails struct {
 	// Status contains the status of the storage instance.
 	Status EntityStatus `json:"status"`
 
+	// Life contains the lifecycle state of the storage.
+	// Old versions of the API do not populate this field,
+	// so it may be omitted.
+	Life Life `json:"life,omitempty"`
+
 	// Persistent reports whether or not the underlying volume or
 	// filesystem is persistent; i.e. whether or not it outlives
 	// the machine that it is attached to.
@@ -462,6 +467,11 @@ type StorageAttachmentDetails struct {
 	// Location holds location (mount point/device path) of
 	// the attached storage.
 	Location string `json:"location,omitempty"`
+
+	// Life contains the lifecycle state of the storage attachment.
+	// Old versions of the API do not populate this field, so it may
+	// be omitted.
+	Life Life `json:"life,omitempty"`
 }
 
 // StoragePool holds data for a pool instance.
@@ -551,16 +561,33 @@ type VolumeDetails struct {
 	// Info contains information about the volume.
 	Info VolumeInfo `json:"info"`
 
+	// Life contains the lifecycle state of the volume.
+	// Old versions of the API do not populate this field,
+	// so it may be omitted.
+	Life Life `json:"life,omitempty"`
+
 	// Status contains the status of the volume.
 	Status EntityStatus `json:"status"`
 
 	// MachineAttachments contains a mapping from
 	// machine tag to volume attachment information.
-	MachineAttachments map[string]VolumeAttachmentInfo `json:"machine-attachments,omitempty"`
+	MachineAttachments map[string]VolumeAttachmentDetails `json:"machine-attachments,omitempty"`
 
 	// Storage contains details about the storage instance
 	// that the volume is assigned to, if any.
 	Storage *StorageDetails `json:"storage,omitempty"`
+}
+
+// VolumeAttachmentDetails describes a volume attachment.
+type VolumeAttachmentDetails struct {
+	// NOTE(axw) for backwards-compatibility, this must not be given a
+	// json tag. This ensures that we collapse VolumeAttachmentInfo.
+	VolumeAttachmentInfo
+
+	// Life contains the lifecycle state of the volume attachment.
+	// Old versions of the API do not populate this field, so it
+	// may be omitted.
+	Life Life `json:"life,omitempty"`
 }
 
 // VolumeDetailsResult contains details about a volume, its attachments or
@@ -611,16 +638,33 @@ type FilesystemDetails struct {
 	// Info contains information about the filesystem.
 	Info FilesystemInfo `json:"info"`
 
+	// Life contains the lifecycle state of the filesystem.
+	// Old versions of the API do not populate this field,
+	// so it may be omitted.
+	Life Life `json:"life,omitempty"`
+
 	// Status contains the status of the filesystem.
 	Status EntityStatus `json:"status"`
 
 	// MachineAttachments contains a mapping from
 	// machine tag to filesystem attachment information.
-	MachineAttachments map[string]FilesystemAttachmentInfo `json:"machine-attachments,omitempty"`
+	MachineAttachments map[string]FilesystemAttachmentDetails `json:"machine-attachments,omitempty"`
 
 	// Storage contains details about the storage instance
 	// that the volume is assigned to, if any.
 	Storage *StorageDetails `json:"storage,omitempty"`
+}
+
+// FilesystemAttachmentDetails describes a filesystem attachment.
+type FilesystemAttachmentDetails struct {
+	// NOTE(axw) for backwards-compatibility, this must not be given a
+	// json tag. This ensures that we collapse FilesystemAttachmentInfo.
+	FilesystemAttachmentInfo
+
+	// Life contains the lifecycle state of the filesystem attachment.
+	// Old versions of the API do not populate this field, so it may
+	// be omitted.
+	Life Life `json:"life,omitempty"`
 }
 
 // FilesystemDetailsResult contains details about a filesystem, its attachments or

--- a/apiserver/params/storage.go
+++ b/apiserver/params/storage.go
@@ -544,6 +544,10 @@ type VolumeDetails struct {
 	// VolumeTag is the tag for the volume.
 	VolumeTag string `json:"volume-tag"`
 
+	// BindingTag is the tag of an entity to which the
+	// volume's lifetime is bound.
+	BindingTag string `json:"binding-tag,omitempty"`
+
 	// Info contains information about the volume.
 	Info VolumeInfo `json:"info"`
 
@@ -599,6 +603,10 @@ type FilesystemDetails struct {
 	// VolumeTag is the tag for the volume backing the
 	// filesystem, if any.
 	VolumeTag string `json:"volume-tag,omitempty"`
+
+	// BindingTag is the tag of an entity to which the
+	// filesystem's lifetime is bound.
+	BindingTag string `json:"binding-tag,omitempty"`
 
 	// Info contains information about the filesystem.
 	Info FilesystemInfo `json:"info"`

--- a/apiserver/storage/base_test.go
+++ b/apiserver/storage/base_test.go
@@ -96,9 +96,13 @@ func (s *baseStorageSuite) constructState() *mockState {
 		kind:       state.StorageKindFilesystem,
 		owner:      s.unitTag,
 		storageTag: s.storageTag,
+		life:       state.Dying,
 	}
 
-	storageInstanceAttachment := &mockStorageAttachment{storage: s.storageInstance}
+	storageInstanceAttachment := &mockStorageAttachment{
+		storage: s.storageInstance,
+		life:    state.Alive,
+	}
 
 	s.machineTag = names.NewMachineTag("66")
 	s.filesystemTag = names.NewFilesystemTag("104")
@@ -106,15 +110,18 @@ func (s *baseStorageSuite) constructState() *mockState {
 	s.filesystem = &mockFilesystem{
 		tag:     s.filesystemTag,
 		storage: &s.storageTag,
+		life:    state.Alive,
 	}
 	s.filesystemAttachment = &mockFilesystemAttachment{
 		filesystem: s.filesystemTag,
 		machine:    s.machineTag,
+		life:       state.Dead,
 	}
 	s.volume = &mockVolume{tag: s.volumeTag, storage: &s.storageTag}
 	s.volumeAttachment = &mockVolumeAttachment{
 		VolumeTag:  s.volumeTag,
 		MachineTag: s.machineTag,
+		life:       state.Alive,
 	}
 
 	s.blocks = make(map[state.BlockType]state.Block)

--- a/apiserver/storage/filesystemlist_test.go
+++ b/apiserver/storage/filesystemlist_test.go
@@ -21,16 +21,20 @@ var _ = gc.Suite(&filesystemSuite{})
 func (s *filesystemSuite) expectedFilesystemDetails() params.FilesystemDetails {
 	return params.FilesystemDetails{
 		FilesystemTag: s.filesystemTag.String(),
+		Life:          "alive",
 		Status: params.EntityStatus{
 			Status: "attached",
 		},
-		MachineAttachments: map[string]params.FilesystemAttachmentInfo{
-			s.machineTag.String(): params.FilesystemAttachmentInfo{},
+		MachineAttachments: map[string]params.FilesystemAttachmentDetails{
+			s.machineTag.String(): params.FilesystemAttachmentDetails{
+				Life: "dead",
+			},
 		},
 		Storage: &params.StorageDetails{
 			StorageTag: "storage-data-0",
 			OwnerTag:   "unit-mysql-0",
 			Kind:       params.StorageKindFilesystem,
+			Life:       "dying",
 			Status: params.EntityStatus{
 				Status: "attached",
 			},
@@ -39,6 +43,7 @@ func (s *filesystemSuite) expectedFilesystemDetails() params.FilesystemDetails {
 					StorageTag: "storage-data-0",
 					UnitTag:    "unit-mysql-0",
 					MachineTag: "machine-66",
+					Life:       "alive",
 				},
 			},
 		},
@@ -120,9 +125,12 @@ func (s *filesystemSuite) TestListFilesystemsAttachmentInfo(c *gc.C) {
 		ReadOnly:   true,
 	}
 	expected := s.expectedFilesystemDetails()
-	expected.MachineAttachments[s.machineTag.String()] = params.FilesystemAttachmentInfo{
-		MountPoint: "/tmp",
-		ReadOnly:   true,
+	expected.MachineAttachments[s.machineTag.String()] = params.FilesystemAttachmentDetails{
+		FilesystemAttachmentInfo: params.FilesystemAttachmentInfo{
+			MountPoint: "/tmp",
+			ReadOnly:   true,
+		},
+		Life: "dead",
 	}
 	expectedStorageAttachmentDetails := expected.Storage.Attachments["unit-mysql-0"]
 	expectedStorageAttachmentDetails.Location = "/tmp"

--- a/apiserver/storage/mock_test.go
+++ b/apiserver/storage/mock_test.go
@@ -181,6 +181,8 @@ type mockVolume struct {
 	tag     names.VolumeTag
 	storage *names.StorageTag
 	info    *state.VolumeInfo
+	life    state.Life
+	binding names.Tag
 }
 
 func (m *mockVolume) StorageInstance() (names.StorageTag, error) {
@@ -208,6 +210,14 @@ func (m *mockVolume) Info() (state.VolumeInfo, error) {
 	return state.VolumeInfo{}, errors.NotProvisionedf("%v", m.tag)
 }
 
+func (m *mockVolume) LifeBinding() names.Tag {
+	return m.binding
+}
+
+func (m *mockVolume) Life() state.Life {
+	return m.life
+}
+
 func (m *mockVolume) Status() (status.StatusInfo, error) {
 	return status.StatusInfo{Status: status.Attached}, nil
 }
@@ -218,6 +228,8 @@ type mockFilesystem struct {
 	storage *names.StorageTag
 	volume  *names.VolumeTag
 	info    *state.FilesystemInfo
+	life    state.Life
+	binding names.Tag
 }
 
 func (m *mockFilesystem) Storage() (names.StorageTag, error) {
@@ -245,6 +257,14 @@ func (m *mockFilesystem) Info() (state.FilesystemInfo, error) {
 	return state.FilesystemInfo{}, errors.NotProvisionedf("filesystem")
 }
 
+func (m *mockFilesystem) LifeBinding() names.Tag {
+	return m.binding
+}
+
+func (m *mockFilesystem) Life() state.Life {
+	return m.life
+}
+
 func (m *mockFilesystem) Status() (status.StatusInfo, error) {
 	return status.StatusInfo{Status: status.Attached}, nil
 }
@@ -254,6 +274,7 @@ type mockFilesystemAttachment struct {
 	filesystem names.FilesystemTag
 	machine    names.MachineTag
 	info       *state.FilesystemAttachmentInfo
+	life       state.Life
 }
 
 func (m *mockFilesystemAttachment) Filesystem() names.FilesystemTag {
@@ -271,11 +292,16 @@ func (m *mockFilesystemAttachment) Info() (state.FilesystemAttachmentInfo, error
 	return state.FilesystemAttachmentInfo{}, errors.NotProvisionedf("filesystem attachment")
 }
 
+func (m *mockFilesystemAttachment) Life() state.Life {
+	return m.life
+}
+
 type mockStorageInstance struct {
 	state.StorageInstance
 	kind       state.StorageKind
 	owner      names.Tag
 	storageTag names.Tag
+	life       state.Life
 }
 
 func (m *mockStorageInstance) Kind() state.StorageKind {
@@ -298,9 +324,14 @@ func (m *mockStorageInstance) CharmURL() *charm.URL {
 	panic("not implemented for test")
 }
 
+func (m *mockStorageInstance) Life() state.Life {
+	return m.life
+}
+
 type mockStorageAttachment struct {
 	state.StorageAttachment
 	storage *mockStorageInstance
+	life    state.Life
 }
 
 func (m *mockStorageAttachment) StorageInstance() names.StorageTag {
@@ -311,10 +342,15 @@ func (m *mockStorageAttachment) Unit() names.UnitTag {
 	return m.storage.Owner().(names.UnitTag)
 }
 
+func (m *mockStorageAttachment) Life() state.Life {
+	return m.life
+}
+
 type mockVolumeAttachment struct {
 	VolumeTag  names.VolumeTag
 	MachineTag names.MachineTag
 	info       *state.VolumeAttachmentInfo
+	life       state.Life
 }
 
 func (va *mockVolumeAttachment) Volume() names.VolumeTag {
@@ -326,7 +362,7 @@ func (va *mockVolumeAttachment) Machine() names.MachineTag {
 }
 
 func (va *mockVolumeAttachment) Life() state.Life {
-	panic("not implemented for test")
+	return va.life
 }
 
 func (va *mockVolumeAttachment) Info() (state.VolumeAttachmentInfo, error) {

--- a/apiserver/storage/storage.go
+++ b/apiserver/storage/storage.go
@@ -474,9 +474,11 @@ func createVolumeDetails(
 ) (*params.VolumeDetails, error) {
 
 	details := &params.VolumeDetails{
-		VolumeTag:  v.VolumeTag().String(),
-		BindingTag: v.LifeBinding().String(),
-		Life:       params.Life(v.Life().String()),
+		VolumeTag: v.VolumeTag().String(),
+		Life:      params.Life(v.Life().String()),
+	}
+	if binding := v.LifeBinding(); binding != nil {
+		details.BindingTag = binding.String()
 	}
 
 	if info, err := v.Info(); err == nil {
@@ -628,8 +630,10 @@ func createFilesystemDetails(
 
 	details := &params.FilesystemDetails{
 		FilesystemTag: f.FilesystemTag().String(),
-		BindingTag:    f.LifeBinding().String(),
 		Life:          params.Life(f.Life().String()),
+	}
+	if binding := f.LifeBinding(); binding != nil {
+		details.BindingTag = binding.String()
 	}
 
 	if volumeTag, err := f.Volume(); err == nil {

--- a/apiserver/storage/storage.go
+++ b/apiserver/storage/storage.go
@@ -49,6 +49,7 @@ func NewAPI(
 		authorizer:  authorizer,
 	}, nil
 }
+
 func (api *API) checkCanRead() error {
 	canRead, err := api.authorizer.HasPermission(permission.ReadAccess, api.storage.ModelTag())
 	if err != nil {
@@ -471,7 +472,8 @@ func createVolumeDetails(
 ) (*params.VolumeDetails, error) {
 
 	details := &params.VolumeDetails{
-		VolumeTag: v.VolumeTag().String(),
+		VolumeTag:  v.VolumeTag().String(),
+		BindingTag: v.LifeBinding().String(),
 	}
 
 	if info, err := v.Info(); err == nil {
@@ -620,6 +622,7 @@ func createFilesystemDetails(
 
 	details := &params.FilesystemDetails{
 		FilesystemTag: f.FilesystemTag().String(),
+		BindingTag:    f.LifeBinding().String(),
 	}
 
 	if volumeTag, err := f.Volume(); err == nil {

--- a/apiserver/storage/storage.go
+++ b/apiserver/storage/storage.go
@@ -191,6 +191,7 @@ func createStorageDetails(st storageAccess, si state.StorageInstance) (*params.S
 				a.Unit().String(),
 				machineTag.String(),
 				location,
+				params.Life(a.Life().String()),
 			}
 			storageAttachmentDetails[a.Unit().String()] = details
 		}
@@ -200,6 +201,7 @@ func createStorageDetails(st storageAccess, si state.StorageInstance) (*params.S
 		StorageTag:  si.Tag().String(),
 		OwnerTag:    si.Owner().String(),
 		Kind:        params.StorageKind(si.Kind()),
+		Life:        params.Life(si.Life().String()),
 		Status:      common.EntityStatusFromState(status),
 		Persistent:  persistent,
 		Attachments: storageAttachmentDetails,
@@ -474,6 +476,7 @@ func createVolumeDetails(
 	details := &params.VolumeDetails{
 		VolumeTag:  v.VolumeTag().String(),
 		BindingTag: v.LifeBinding().String(),
+		Life:       params.Life(v.Life().String()),
 	}
 
 	if info, err := v.Info(); err == nil {
@@ -481,14 +484,17 @@ func createVolumeDetails(
 	}
 
 	if len(attachments) > 0 {
-		details.MachineAttachments = make(map[string]params.VolumeAttachmentInfo, len(attachments))
+		details.MachineAttachments = make(map[string]params.VolumeAttachmentDetails, len(attachments))
 		for _, attachment := range attachments {
-			stateInfo, err := attachment.Info()
-			var info params.VolumeAttachmentInfo
-			if err == nil {
-				info = storagecommon.VolumeAttachmentInfoFromState(stateInfo)
+			attDetails := params.VolumeAttachmentDetails{
+				Life: params.Life(attachment.Life().String()),
 			}
-			details.MachineAttachments[attachment.Machine().String()] = info
+			if stateInfo, err := attachment.Info(); err == nil {
+				attDetails.VolumeAttachmentInfo = storagecommon.VolumeAttachmentInfoFromState(
+					stateInfo,
+				)
+			}
+			details.MachineAttachments[attachment.Machine().String()] = attDetails
 		}
 	}
 
@@ -623,6 +629,7 @@ func createFilesystemDetails(
 	details := &params.FilesystemDetails{
 		FilesystemTag: f.FilesystemTag().String(),
 		BindingTag:    f.LifeBinding().String(),
+		Life:          params.Life(f.Life().String()),
 	}
 
 	if volumeTag, err := f.Volume(); err == nil {
@@ -634,14 +641,17 @@ func createFilesystemDetails(
 	}
 
 	if len(attachments) > 0 {
-		details.MachineAttachments = make(map[string]params.FilesystemAttachmentInfo, len(attachments))
+		details.MachineAttachments = make(map[string]params.FilesystemAttachmentDetails, len(attachments))
 		for _, attachment := range attachments {
-			stateInfo, err := attachment.Info()
-			var info params.FilesystemAttachmentInfo
-			if err == nil {
-				info = storagecommon.FilesystemAttachmentInfoFromState(stateInfo)
+			attDetails := params.FilesystemAttachmentDetails{
+				Life: params.Life(attachment.Life().String()),
 			}
-			details.MachineAttachments[attachment.Machine().String()] = info
+			if stateInfo, err := attachment.Info(); err == nil {
+				attDetails.FilesystemAttachmentInfo = storagecommon.FilesystemAttachmentInfoFromState(
+					stateInfo,
+				)
+			}
+			details.MachineAttachments[attachment.Machine().String()] = attDetails
 		}
 	}
 

--- a/apiserver/storage/storage_test.go
+++ b/apiserver/storage/storage_test.go
@@ -237,6 +237,7 @@ func (s *storageSuite) createTestStorageDetails() params.StorageDetails {
 		StorageTag: s.storageTag.String(),
 		OwnerTag:   s.unitTag.String(),
 		Kind:       params.StorageKindFilesystem,
+		Life:       "dying",
 		Status: params.EntityStatus{
 			Status: "attached",
 		},
@@ -246,6 +247,7 @@ func (s *storageSuite) createTestStorageDetails() params.StorageDetails {
 				s.unitTag.String(),
 				s.machineTag.String(),
 				"", // location
+				"alive",
 			},
 		},
 	}
@@ -293,6 +295,7 @@ func (s *storageSuite) TestShowStorage(c *gc.C) {
 		StorageTag: s.storageTag.String(),
 		OwnerTag:   s.unitTag.String(),
 		Kind:       params.StorageKindFilesystem,
+		Life:       "dying",
 		Status: params.EntityStatus{
 			Status: "attached",
 		},
@@ -302,6 +305,7 @@ func (s *storageSuite) TestShowStorage(c *gc.C) {
 				s.unitTag.String(),
 				s.machineTag.String(),
 				"",
+				"alive",
 			},
 		},
 	}

--- a/apiserver/storage/volumelist_test.go
+++ b/apiserver/storage/volumelist_test.go
@@ -25,16 +25,20 @@ var _ = gc.Suite(&volumeSuite{})
 func (s *volumeSuite) expectedVolumeDetails() params.VolumeDetails {
 	return params.VolumeDetails{
 		VolumeTag: s.volumeTag.String(),
+		Life:      "alive",
 		Status: params.EntityStatus{
 			Status: "attached",
 		},
-		MachineAttachments: map[string]params.VolumeAttachmentInfo{
-			s.machineTag.String(): params.VolumeAttachmentInfo{},
+		MachineAttachments: map[string]params.VolumeAttachmentDetails{
+			s.machineTag.String(): params.VolumeAttachmentDetails{
+				Life: "alive",
+			},
 		},
 		Storage: &params.StorageDetails{
 			StorageTag: "storage-data-0",
 			OwnerTag:   "unit-mysql-0",
 			Kind:       params.StorageKindFilesystem,
+			Life:       "dying",
 			Status: params.EntityStatus{
 				Status: "attached",
 			},
@@ -43,6 +47,7 @@ func (s *volumeSuite) expectedVolumeDetails() params.VolumeDetails {
 					StorageTag: "storage-data-0",
 					UnitTag:    "unit-mysql-0",
 					MachineTag: "machine-66",
+					Life:       "alive",
 				},
 			},
 		},
@@ -132,9 +137,12 @@ func (s *volumeSuite) TestListVolumesAttachmentInfo(c *gc.C) {
 		ReadOnly:   true,
 	}
 	expected := s.expectedVolumeDetails()
-	expected.MachineAttachments[s.machineTag.String()] = params.VolumeAttachmentInfo{
-		DeviceName: "xvdf1",
-		ReadOnly:   true,
+	expected.MachineAttachments[s.machineTag.String()] = params.VolumeAttachmentDetails{
+		VolumeAttachmentInfo: params.VolumeAttachmentInfo{
+			DeviceName: "xvdf1",
+			ReadOnly:   true,
+		},
+		Life: "alive",
 	}
 	found, err := s.api.ListVolumes(params.VolumeFilters{[]params.VolumeFilter{{}}})
 	c.Assert(err, jc.ErrorIsNil)
@@ -152,8 +160,11 @@ func (s *volumeSuite) TestListVolumesStorageLocationNoBlockDevice(c *gc.C) {
 	expected := s.expectedVolumeDetails()
 	expected.Storage.Kind = params.StorageKindBlock
 	expected.Storage.Status.Status = status.Attached
-	expected.MachineAttachments[s.machineTag.String()] = params.VolumeAttachmentInfo{
-		ReadOnly: true,
+	expected.MachineAttachments[s.machineTag.String()] = params.VolumeAttachmentDetails{
+		VolumeAttachmentInfo: params.VolumeAttachmentInfo{
+			ReadOnly: true,
+		},
+		Life: "alive",
 	}
 	found, err := s.api.ListVolumes(params.VolumeFilters{[]params.VolumeFilter{{}}})
 	c.Assert(err, jc.ErrorIsNil)
@@ -181,9 +192,12 @@ func (s *volumeSuite) TestListVolumesStorageLocationBlockDevicePath(c *gc.C) {
 	storageAttachmentDetails := expected.Storage.Attachments["unit-mysql-0"]
 	storageAttachmentDetails.Location = filepath.FromSlash("/dev/sdd")
 	expected.Storage.Attachments["unit-mysql-0"] = storageAttachmentDetails
-	expected.MachineAttachments[s.machineTag.String()] = params.VolumeAttachmentInfo{
-		BusAddress: "bus-addr",
-		ReadOnly:   true,
+	expected.MachineAttachments[s.machineTag.String()] = params.VolumeAttachmentDetails{
+		VolumeAttachmentInfo: params.VolumeAttachmentInfo{
+			BusAddress: "bus-addr",
+			ReadOnly:   true,
+		},
+		Life: "alive",
 	}
 	found, err := s.api.ListVolumes(params.VolumeFilters{[]params.VolumeFilter{{}}})
 	c.Assert(err, jc.ErrorIsNil)

--- a/cmd/juju/storage/filesystem.go
+++ b/cmd/juju/storage/filesystem.go
@@ -42,6 +42,9 @@ type FilesystemInfo struct {
 	// from params.FilesystemInfo
 	Size uint64 `yaml:"size" json:"size"`
 
+	// Life is the lifecycle state of the filesystem.
+	Life string `yaml:"life,omitempty" json:"life,omitempty"`
+
 	// from params.FilesystemInfo.
 	Status EntityStatus `yaml:"status,omitempty" json:"status,omitempty"`
 }
@@ -54,6 +57,7 @@ type FilesystemAttachments struct {
 type MachineFilesystemAttachment struct {
 	MountPoint string `yaml:"mount-point" json:"mount-point"`
 	ReadOnly   bool   `yaml:"read-only" json:"read-only"`
+	Life       string `yaml:"life,omitempty" json:"life,omitempty"`
 }
 
 // generateListFilesystemOutput returns a map filesystem IDs to filesystem info
@@ -102,6 +106,7 @@ func createFilesystemInfo(details params.FilesystemDetails) (names.FilesystemTag
 	var info FilesystemInfo
 	info.ProviderFilesystemId = details.Info.FilesystemId
 	info.Size = details.Info.Size
+	info.Life = string(details.Life)
 	info.Status = EntityStatus{
 		details.Status.Status,
 		details.Status.Info,
@@ -127,6 +132,7 @@ func createFilesystemInfo(details params.FilesystemDetails) (names.FilesystemTag
 			machineAttachments[machineId] = MachineFilesystemAttachment{
 				attachment.MountPoint,
 				attachment.ReadOnly,
+				string(attachment.Life),
 			}
 		}
 		info.Attachments = &FilesystemAttachments{

--- a/cmd/juju/storage/list_test.go
+++ b/cmd/juju/storage/list_test.go
@@ -126,8 +126,6 @@ filesystems:
       since: .*
   "1":
     provider-id: provider-supplied-filesystem-1
-    volume: ""
-    storage: ""
     attachments:
       machines:
         "0":
@@ -140,8 +138,6 @@ filesystems:
       since: .*
   "2":
     provider-id: provider-supplied-filesystem-2
-    volume: ""
-    storage: ""
     attachments:
       machines:
         "1":
@@ -152,8 +148,6 @@ filesystems:
       current: attached
       since: .*
   "3":
-    volume: ""
-    storage: ""
     attachments:
       machines:
         "1":
@@ -165,7 +159,6 @@ filesystems:
       since: .*
   "4":
     provider-id: provider-supplied-filesystem-4
-    volume: ""
     storage: shared-fs/0
     attachments:
       machines:
@@ -190,6 +183,7 @@ volumes:
   0/0:
     provider-id: provider-supplied-volume-0-0
     storage: db-dir/1001
+    binding: unit
     attachments:
       machines:
         "0":
@@ -206,6 +200,7 @@ volumes:
       since: .*
   "1":
     provider-id: provider-supplied-volume-1
+    binding: machine
     attachments:
       machines:
         "0":
@@ -242,6 +237,7 @@ volumes:
   "4":
     provider-id: provider-supplied-volume-4
     storage: shared-fs/0
+    binding: application
     attachments:
       machines:
         "0":

--- a/cmd/juju/storage/show_test.go
+++ b/cmd/juju/storage/show_test.go
@@ -168,6 +168,7 @@ func (s mockShowAPI) StorageDetails(tags []names.StorageTag) ([]params.StorageDe
 		} else {
 			all[i].Result = &params.StorageDetails{
 				StorageTag: tag.String(),
+				OwnerTag:   "unit-postgresql-0",
 				Kind:       params.StorageKindBlock,
 				Status: params.EntityStatus{
 					Status: "pending",

--- a/cmd/juju/storage/storage.go
+++ b/cmd/juju/storage/storage.go
@@ -35,6 +35,7 @@ func (c *StorageCommandBase) NewStorageAPI() (*storage.Client, error) {
 // StorageInfo defines the serialization behaviour of the storage information.
 type StorageInfo struct {
 	Kind        string              `yaml:"kind" json:"kind"`
+	Life        string              `yaml:"life,omitempty" json:"life,omitempty"`
 	Status      EntityStatus        `yaml:"status" json:"status"`
 	Persistent  bool                `yaml:"persistent" json:"persistent"`
 	Attachments *StorageAttachments `yaml:"attachments" json:"attachments"`
@@ -57,6 +58,9 @@ type UnitStorageAttachment struct {
 
 	// Location is the location of the storage attachment.
 	Location string `yaml:"location,omitempty" json:"location,omitempty"`
+
+	// Life is the lifecycle state of the storage attachment.
+	Life string `yaml:"life,omitempty" json:"life,omitempty"`
 
 	// TODO(axw) per-unit status when we have it in state.
 }
@@ -95,6 +99,7 @@ func createStorageInfo(details params.StorageDetails) (names.StorageTag, names.T
 
 	info := StorageInfo{
 		Kind: details.Kind.String(),
+		Life: string(details.Life),
 		Status: EntityStatus{
 			details.Status.Status,
 			details.Status.Info,
@@ -122,6 +127,7 @@ func createStorageInfo(details params.StorageDetails) (names.StorageTag, names.T
 			unitStorageAttachments[unitTag.Id()] = UnitStorageAttachment{
 				machineId,
 				attachmentDetails.Location,
+				string(attachmentDetails.Life),
 			}
 		}
 		info.Attachments = &StorageAttachments{unitStorageAttachments}

--- a/cmd/juju/storage/volume.go
+++ b/cmd/juju/storage/volume.go
@@ -41,6 +41,9 @@ type VolumeInfo struct {
 	// from params.Volume
 	Persistent bool `yaml:"persistent" json:"persistent"`
 
+	// Life is the lifecycle state of the volume.
+	Life string `yaml:"life,omitempty" json:"life,omitempty"`
+
 	// from params.Volume
 	Status EntityStatus `yaml:"status,omitempty" json:"status,omitempty"`
 }
@@ -61,6 +64,7 @@ type MachineVolumeAttachment struct {
 	DeviceLink string `yaml:"device-link,omitempty" json:"device-link,omitempty"`
 	BusAddress string `yaml:"bus-address,omitempty" json:"bus-address,omitempty"`
 	ReadOnly   bool   `yaml:"read-only" json:"read-only"`
+	Life       string `yaml:"life,omitempty" json:"life,omitempty"`
 	// TODO(axw) add machine volume attachment status when we have it
 }
 
@@ -119,6 +123,7 @@ func createVolumeInfo(details params.VolumeDetails) (names.VolumeTag, VolumeInfo
 	info.HardwareId = details.Info.HardwareId
 	info.Size = details.Info.Size
 	info.Persistent = details.Info.Persistent
+	info.Life = string(details.Life)
 	info.Status = EntityStatus{
 		details.Status.Status,
 		details.Status.Info,
@@ -138,6 +143,7 @@ func createVolumeInfo(details params.VolumeDetails) (names.VolumeTag, VolumeInfo
 				attachment.DeviceLink,
 				attachment.BusAddress,
 				attachment.ReadOnly,
+				string(attachment.Life),
 			}
 		}
 		info.Attachments = &VolumeAttachments{

--- a/cmd/juju/storage/volumelist_test.go
+++ b/cmd/juju/storage/volumelist_test.go
@@ -178,7 +178,8 @@ func (s mockListAPI) ListVolumes(machines []string) ([]params.VolumeDetailsListR
 		// storage db-dir/1001, which is attached to unit
 		// abc/0.
 		{
-			VolumeTag: "volume-0-0",
+			VolumeTag:  "volume-0-0",
+			BindingTag: "storage-db-dir-1001",
 			Info: params.VolumeInfo{
 				VolumeId: "provider-supplied-volume-0-0",
 				Size:     512,
@@ -207,7 +208,8 @@ func (s mockListAPI) ListVolumes(machines []string) ([]params.VolumeDetailsListR
 		// volume 1 is attaching to machine 0, but is not assigned
 		// to any storage.
 		{
-			VolumeTag: "volume-1",
+			VolumeTag:  "volume-1",
+			BindingTag: "machine-0",
 			Info: params.VolumeInfo{
 				VolumeId:   "provider-supplied-volume-1",
 				HardwareId: "serial blah blah",
@@ -249,7 +251,8 @@ func (s mockListAPI) ListVolumes(machines []string) ([]params.VolumeDetailsListR
 		// volume 4 is attached to machines 0 and 1, and is assigned
 		// to shared storage.
 		{
-			VolumeTag: "volume-4",
+			VolumeTag:  "volume-4",
+			BindingTag: "storage-shared-fs-0",
 			Info: params.VolumeInfo{
 				VolumeId:   "provider-supplied-volume-4",
 				Persistent: true,

--- a/featuretests/storage_test.go
+++ b/featuretests/storage_test.go
@@ -85,6 +85,7 @@ func (s *cmdStorageSuite) TestStorageShow(c *gc.C) {
 	expected := `
 data/0:
   kind: block
+  life: alive
   status:
     current: pending
     since: .*
@@ -93,6 +94,7 @@ data/0:
     units:
       storage-block/0:
         machine: "0"
+        life: alive
 `[1:]
 	context, err := runJujuCommand(c, "show-storage", "data/0")
 	c.Assert(err, jc.ErrorIsNil)
@@ -169,6 +171,7 @@ func (s *cmdStorageSuite) TestStoragePersistentProvisioned(c *gc.C) {
 	expected := `
 data/0:
   kind: block
+  life: alive
   status:
     current: pending
     since: .*
@@ -177,6 +180,7 @@ data/0:
     units:
       storage-block/0:
         machine: "0"
+        life: alive
 `[1:]
 	context, err := runJujuCommand(c, "show-storage", "data/0")
 	c.Assert(err, jc.ErrorIsNil)
@@ -191,6 +195,7 @@ func (s *cmdStorageSuite) TestStoragePersistentUnprovisioned(c *gc.C) {
 	expected := `
 data/0:
   kind: block
+  life: alive
   status:
     current: pending
     since: .*
@@ -199,6 +204,7 @@ data/0:
     units:
       storage-block/0:
         machine: "0"
+        life: alive
 `[1:]
 	context, err := runJujuCommand(c, "show-storage", "data/0")
 	c.Assert(err, jc.ErrorIsNil)


### PR DESCRIPTION
## Description of change

When displaying the details of storage in YAML or
JSON format, include the binding and life of the entity.
The binding will be simplified to the kind of the entity,
which is "model", "machine", "application", or "unit". 

## QA steps

1. juju bootstrap
2. juju deploy postgresql --storage pgdata=1G
3. juju storage --format=yaml
check that the storage includes life and binding fields

## Documentation changes

This is primarily for debugging, does not need documentation at present.

## Bug reference

None.