### PR TITLE
Concrete testing shows that its actually UnexpectedError.

### DIFF
--- a/provider/maas/maas2_environ_whitebox_test.go
+++ b/provider/maas/maas2_environ_whitebox_test.go
@@ -1156,7 +1156,8 @@ func (suite *maas2EnvironSuite) TestAllocateContainerAddressesNoStaticRoutesAPI(
 		StatusCode:  http.StatusNotFound,
 		BodyMessage: body,
 	}
-	staticRoutesErr := errors.Annotatef(notFound, "ServerError: %v (%s)", http.StatusNotFound, body)
+	wrap1 := errors.Annotatef(notFound, "ServerError: 404 NOT FOUND (%s)", body)
+	staticRoutesErr := gomaasapi.NewUnexpectedError(wrap1)
 	var env *maasEnviron
 	controller := &fakeController{
 		Stub: &testing.Stub{},


### PR DESCRIPTION
The content of the error is a ServerError with the values we were
checking, but it has been wrapped in an UnexpectedError which doesn't
seem to make the original error available.

## Description of change

MAAS 2.0 doesn't support static-routes, and I misunderstood the error we were getting. We get a ServerError *wrapped* by a UnexpectedError, and errors.Wrap doesn't let you get to the original error.

## QA steps

Against a MAAS 2.0 controller:
```
  $ juju bootstrap
  $ juju switch controller
  $ juju add-machine lxd:0
  $ juju status
  $ juju ssh 0/lxd/0
```
Without this patch we get an error and the 'fallback to lxdbr0' code kicks in and you get an unreachable container.

## Documentation changes

No, as 2.1 didn't ship with this bug.

## Bug reference

[lp:1668359](https://pad.lv/1668359)