### PR TITLE
Include remote applications in model dump

### DIFF
--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -20,7 +20,7 @@ github.com/juju/ansiterm	git	b99631de12cf04a906c1d4e4ec54fb86eae5863d	2016-09-07
 github.com/juju/blobstore	git	06056004b3d7b54bbb7984d830c537bad00fec21	2015-07-29T11:18:58Z
 github.com/juju/bundlechanges	git	7725027b95e0d54635e0fb11efc2debdcdf19f75	2016-12-15T16:06:52Z
 github.com/juju/cmd	git	0f05ac592d6925a1b8ca0f77524d3348fafa66cc	2017-02-07T03:13:09Z
-github.com/juju/description	git	4a15eb10a592c58ceace8c44cf9e5f33ed357c41	2017-02-22T23:01:32Z
+github.com/juju/description	git	6686f4133b987f246cf3b7d7307862235c9d0c6f	2017-02-28T20:28:14Z
 github.com/juju/errors	git	1b5e39b83d1835fa480e0c2ddefb040ee82d58b3	2015-09-16T12:56:42Z
 github.com/juju/gnuflag	git	4e76c56581859c14d9d87e1ddbe29e1c0f10195f	2016-08-09T16:52:14Z
 github.com/juju/go4	git	40d72ab9641a2a8c36a9c46a51e28367115c8e59	2016-02-22T16:32:58Z

--- a/state/migration_export_test.go
+++ b/state/migration_export_test.go
@@ -1120,3 +1120,62 @@ func (s *MigrationExportSuite) newResource(c *gc.C, appName, name string, revisi
 	res.Revision = revision
 	return res
 }
+
+func (s *MigrationExportSuite) TestRemoteApplications(c *gc.C) {
+	_, err := s.State.AddRemoteApplication(state.AddRemoteApplicationParams{
+		Name:        "gravy-rainbow",
+		URL:         "local:/u/me/rainbow",
+		SourceModel: s.State.ModelTag(),
+		Token:       "charisma",
+		Endpoints: []charm.Relation{{
+			Interface: "mysql",
+			Name:      "db",
+			Role:      charm.RoleProvider,
+			Scope:     charm.ScopeGlobal,
+		}, {
+			Interface: "mysql-root",
+			Name:      "db-admin",
+			Limit:     5,
+			Role:      charm.RoleProvider,
+			Scope:     charm.ScopeGlobal,
+		}, {
+			Interface: "logging",
+			Name:      "logging",
+			Role:      charm.RoleProvider,
+			Scope:     charm.ScopeGlobal,
+		}},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	model, err := s.State.Export()
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Assert(model.RemoteApplications(), gc.HasLen, 1)
+	app := model.RemoteApplications()[0]
+	c.Check(app.Tag(), gc.Equals, names.NewApplicationTag("gravy-rainbow"))
+	c.Check(app.Name(), gc.Equals, "gravy-rainbow")
+	c.Check(app.OfferName(), gc.Equals, "")
+	c.Check(app.URL(), gc.Equals, "local:/u/me/rainbow")
+	c.Check(app.SourceModelTag(), gc.Equals, s.State.ModelTag())
+	c.Check(app.Registered(), jc.IsFalse)
+
+	c.Assert(app.Endpoints(), gc.HasLen, 3)
+	ep := app.Endpoints()[0]
+	c.Check(ep.Name(), gc.Equals, "db")
+	c.Check(ep.Interface(), gc.Equals, "mysql")
+	c.Check(ep.Limit(), gc.Equals, 0)
+	c.Check(ep.Role(), gc.Equals, "provider")
+	c.Check(ep.Scope(), gc.Equals, "global")
+	ep = app.Endpoints()[1]
+	c.Check(ep.Name(), gc.Equals, "db-admin")
+	c.Check(ep.Interface(), gc.Equals, "mysql-root")
+	c.Check(ep.Limit(), gc.Equals, 5)
+	c.Check(ep.Role(), gc.Equals, "provider")
+	c.Check(ep.Scope(), gc.Equals, "global")
+	ep = app.Endpoints()[2]
+	c.Check(ep.Name(), gc.Equals, "logging")
+	c.Check(ep.Interface(), gc.Equals, "logging")
+	c.Check(ep.Limit(), gc.Equals, 0)
+	c.Check(ep.Role(), gc.Equals, "provider")
+	c.Check(ep.Scope(), gc.Equals, "global")
+}

--- a/state/migration_import.go
+++ b/state/migration_import.go
@@ -54,6 +54,9 @@ func (st *State) Import(model description.Model) (_ *Model, _ *State, err error)
 	}
 
 	if len(model.RemoteApplications()) != 0 {
+		// Cross-model relations are currently limited to models on
+		// the same controller, while migration is for getting the
+		// model to a new controller.
 		return nil, nil, errors.New("can't import models with remote applications")
 	}
 

--- a/state/migration_import.go
+++ b/state/migration_import.go
@@ -53,6 +53,10 @@ func (st *State) Import(model description.Model) (_ *Model, _ *State, err error)
 		return nil, nil, errors.Trace(err)
 	}
 
+	if len(model.RemoteApplications()) != 0 {
+		return nil, nil, errors.New("can't import models with remote applications")
+	}
+
 	// Create the model.
 	cfg, err := config.New(config.NoDefaults, model.Config())
 	if err != nil {

--- a/state/migration_import_test.go
+++ b/state/migration_import_test.go
@@ -1120,7 +1120,8 @@ func (s *MigrationImportSuite) TestPayloads(c *gc.C) {
 
 func (s *MigrationImportSuite) TestRemoteApplications(c *gc.C) {
 	// For now we want to prevent importing models that have remote
-	// applications.
+	// applications - cross-model relations don't support relations
+	// with the models in different controllers.
 	_, err := s.State.AddRemoteApplication(state.AddRemoteApplicationParams{
 		Name:        "gravy-rainbow",
 		URL:         "local:/u/me/rainbow",

--- a/state/migration_import_test.go
+++ b/state/migration_import_test.go
@@ -1118,6 +1118,47 @@ func (s *MigrationImportSuite) TestPayloads(c *gc.C) {
 	c.Check(payload.Machine, gc.Equals, machineID)
 }
 
+func (s *MigrationImportSuite) TestRemoteApplications(c *gc.C) {
+	// For now we want to prevent importing models that have remote
+	// applications.
+	_, err := s.State.AddRemoteApplication(state.AddRemoteApplicationParams{
+		Name:        "gravy-rainbow",
+		URL:         "local:/u/me/rainbow",
+		SourceModel: s.State.ModelTag(),
+		Token:       "charisma",
+		Endpoints: []charm.Relation{{
+			Interface: "mysql",
+			Name:      "db",
+			Role:      charm.RoleProvider,
+			Scope:     charm.ScopeGlobal,
+		}, {
+			Interface: "mysql-root",
+			Name:      "db-admin",
+			Limit:     5,
+			Role:      charm.RoleProvider,
+			Scope:     charm.ScopeGlobal,
+		}, {
+			Interface: "logging",
+			Name:      "logging",
+			Role:      charm.RoleProvider,
+			Scope:     charm.ScopeGlobal,
+		}},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	out, err := s.State.Export()
+	c.Assert(err, jc.ErrorIsNil)
+
+	uuid := utils.MustNewUUID().String()
+	in := newModel(out, uuid, "new")
+
+	_, newSt, err := s.State.Import(in)
+	if err == nil {
+		defer newSt.Close()
+	}
+	c.Assert(err, gc.ErrorMatches, "can't import models with remote applications")
+}
+
 // newModel replaces the uuid and name of the config attributes so we
 // can use all the other data to validate imports. An owner and name of the
 // model are unique together in a controller.


### PR DESCRIPTION
## Description of change

This means that we can see remote applications in the dump-model output. At the moment we don't support importing models with remote applications - that requires a lot of other changes to work correctly.

Uses the new RemoteApplication and RemoteEndpoint added to the description in https://github.com/juju/description/pull/1

## QA steps

* Bootstrap a controller and add two models
* Deploy wordpress to one model and mysql to the other and relate them.
* Run `juju dump-model` on each model and verify that the YAML includes the remote application information.
