### PR TITLE
state: Database and modelBackend refactoring

### DIFF
--- a/state/backend.go
+++ b/state/backend.go
@@ -6,36 +6,17 @@ package state
 import (
 	"github.com/juju/errors"
 
-	"github.com/juju/juju/mongo"
+	"github.com/juju/juju/state/workers"
 )
 
 // modelBackend collects together some useful internal state methods for
 // accessing mongo and mapping local and global ids to one another.
-//
-// Its primary purpose is to insulate watcher implementations from the
-// other features of state (specifically, to deny access to the .workers
-// field and prevent a class of bug in which it tries to use two
-// different underlying TxnWatchers), but it's probably also useful
-// elsewhere.
 type modelBackend interface {
 	docID(string) string
 	localID(string) string
 	strictLocalID(string) (string, error)
-	getCollection(name string) (mongo.Collection, func())
-	getCollectionFor(modelUUID, name string) (mongo.Collection, func())
-}
-
-// isLocalID returns a watcher filter func that rejects ids not specific
-// to the supplied modelBackend.
-func isLocalID(st modelBackend) func(interface{}) bool {
-	return func(id interface{}) bool {
-		key, ok := id.(string)
-		if !ok {
-			return false
-		}
-		_, err := st.strictLocalID(key)
-		return err == nil
-	}
+	db() Database
+	txnLogWatcher() workers.TxnLogWatcher
 }
 
 // docID generates a globally unique id value
@@ -66,21 +47,4 @@ func (st *State) strictLocalID(ID string) (string, error) {
 		return "", errors.Errorf("unexpected id: %#v", ID)
 	}
 	return localID, nil
-}
-
-// getCollection fetches a named collection using a new session if the
-// database has previously been logged in to. It returns the
-// collection and a closer function for the session.
-//
-// If the collection stores documents for multiple models, the
-// returned collection will automatically perform model
-// filtering where possible. See modelStateCollection below.
-// XXX to go
-func (st *State) getCollection(name string) (mongo.Collection, func()) {
-	return st.database.GetCollection(name)
-}
-
-// XXX to go
-func (st *State) getCollectionFor(modelUUID, name string) (mongo.Collection, func()) {
-	return st.database.GetCollectionFor(modelUUID, name)
 }

--- a/state/backend.go
+++ b/state/backend.go
@@ -75,15 +75,12 @@ func (st *State) strictLocalID(ID string) (string, error) {
 // If the collection stores documents for multiple models, the
 // returned collection will automatically perform model
 // filtering where possible. See modelStateCollection below.
+// XXX to go
 func (st *State) getCollection(name string) (mongo.Collection, func()) {
 	return st.database.GetCollection(name)
 }
 
+// XXX to go
 func (st *State) getCollectionFor(modelUUID, name string) (mongo.Collection, func()) {
-	database, dbcloser := st.database.CopyForModel(modelUUID)
-	collection, closer := database.GetCollection(name)
-	return collection, func() {
-		closer()
-		dbcloser()
-	}
+	return st.database.GetCollectionFor(modelUUID, name)
 }

--- a/state/charm.go
+++ b/state/charm.go
@@ -154,8 +154,8 @@ func insertPendingCharmOps(st *State, curl *charm.URL) ([]txn.Op, error) {
 // insertAnyCharmOps returns the txn operations necessary to insert the supplied
 // charm document.
 func insertAnyCharmOps(st modelBackend, cdoc *charmDoc) ([]txn.Op, error) {
-
-	charms, closer := st.getCollection(charmsC)
+	db := st.db()
+	charms, closer := db.GetCollection(charmsC)
 	defer closer()
 
 	life, err := nsLife.read(charms, cdoc.DocID)
@@ -175,7 +175,7 @@ func insertAnyCharmOps(st modelBackend, cdoc *charmDoc) ([]txn.Op, error) {
 		Insert: cdoc,
 	}
 
-	refcounts, closer := st.getCollection(refcountsC)
+	refcounts, closer := db.GetCollection(refcountsC)
 	defer closer()
 
 	charmKey := charmGlobalKey(cdoc.URL)

--- a/state/database.go
+++ b/state/database.go
@@ -51,6 +51,12 @@ type Database interface {
 	// model specified. As for GetCollection, a closer is also returned.
 	GetCollectionFor(modelUUID, name string) (mongo.Collection, SessionCloser)
 
+	// GetRawCollection returns the named mgo Collection. As no
+	// automatic model filtering is performed by the returned
+	// collection it should be rarely used. GetCollection() should be
+	// used in almost all cases.
+	GetRawCollection(name string) (*mgo.Collection, SessionCloser)
+
 	// TransactionRunner() returns a runner responsible for making changes to
 	// the database, and a func that must be called when the runner is no longer
 	// needed. The returned Runner might or might not have its own session,
@@ -300,6 +306,12 @@ func (db *database) GetCollectionFor(modelUUID, name string) (mongo.Collection, 
 		closer()
 		dbcloser()
 	}
+}
+
+// GetRawCollection is part of the Database interface.
+func (db *database) GetRawCollection(name string) (*mgo.Collection, SessionCloser) {
+	collection, closer := db.GetCollection(name)
+	return collection.Writeable().Underlying(), closer
 }
 
 // TransactionRunner is part of the Database interface.

--- a/state/database.go
+++ b/state/database.go
@@ -47,6 +47,10 @@ type Database interface {
 	// see modelStateCollection.
 	GetCollection(name string) (mongo.Collection, SessionCloser)
 
+	// GetCollecitonFor returns the named Collection, scoped for the
+	// model specified. As for GetCollection, a closer is also returned.
+	GetCollectionFor(modelUUID, name string) (mongo.Collection, SessionCloser)
+
 	// TransactionRunner() returns a runner responsible for making changes to
 	// the database, and a func that must be called when the runner is no longer
 	// needed. The returned Runner might or might not have its own session,
@@ -57,6 +61,26 @@ type Database interface {
 	// non-global collections; and it will ensure that non-global documents can
 	// only be inserted while the corresponding model is still Alive.
 	TransactionRunner() (jujutxn.Runner, SessionCloser)
+
+	// RunTransaction is a convenience method for running a single
+	// transaction.
+	RunTransaction(ops []txn.Op) error
+
+	// RunTransaction is a convenience method for running a single
+	// transaction for the model specified.
+	RunTransactionFor(modelUUID string, ops []txn.Op) error
+
+	// RunRawTransaction is a convenience method that will run a
+	// single transaction using a "raw" transaction runner that won't
+	// perform model filtering.
+	RunRawTransaction(ops []txn.Op) error
+
+	// Run is a convenience method running a transaction using a
+	// transaction building function.
+	Run(transactions jujutxn.TransactionSource) error
+
+	// RunFor is like Run but runs the transaction for the model specified.
+	RunFor(modelUUID string, transactions jujutxn.TransactionSource) error
 
 	// Schema returns the schema used to load the database. The returned schema
 	// is not a copy and must not be modified.
@@ -268,6 +292,16 @@ func (db *database) GetCollection(name string) (collection mongo.Collection, clo
 	return collection, closer
 }
 
+// GetCollectionFor is part of the Database interface.
+func (db *database) GetCollectionFor(modelUUID, name string) (mongo.Collection, SessionCloser) {
+	newDb, dbcloser := db.CopyForModel(modelUUID)
+	collection, closer := newDb.GetCollection(name)
+	return collection, func() {
+		closer()
+		dbcloser()
+	}
+}
+
 // TransactionRunner is part of the Database interface.
 func (db *database) TransactionRunner() (runner jujutxn.Runner, closer SessionCloser) {
 	runner = db.runner
@@ -299,6 +333,48 @@ func (db *database) TransactionRunner() (runner jujutxn.Runner, closer SessionCl
 		modelUUID: db.modelUUID,
 		schema:    db.schema,
 	}, closer
+}
+
+// RunTransaction is part of the Database interface.
+func (db *database) RunTransaction(ops []txn.Op) error {
+	runner, closer := db.TransactionRunner()
+	defer closer()
+	return runner.RunTransaction(ops)
+}
+
+// RunTransactionFor is part of the Database interface.
+func (db *database) RunTransactionFor(modelUUID string, ops []txn.Op) error {
+	newDB, dbcloser := db.CopyForModel(modelUUID)
+	defer dbcloser()
+	runner, closer := newDB.TransactionRunner()
+	defer closer()
+	return runner.RunTransaction(ops)
+}
+
+// RunRawTransaction is part of the Database interface.
+func (db *database) RunRawTransaction(ops []txn.Op) error {
+	runner, closer := db.TransactionRunner()
+	defer closer()
+	if multiRunner, ok := runner.(*multiModelRunner); ok {
+		runner = multiRunner.rawRunner
+	}
+	return runner.RunTransaction(ops)
+}
+
+// Run is part of the Database interface.
+func (db *database) Run(transactions jujutxn.TransactionSource) error {
+	runner, closer := db.TransactionRunner()
+	defer closer()
+	return runner.Run(transactions)
+}
+
+// RunFor is part of the Database interface.
+func (db *database) RunFor(modelUUID string, transactions jujutxn.TransactionSource) error {
+	newDB, dbcloser := db.CopyForModel(modelUUID)
+	defer dbcloser()
+	runner, closer := newDB.TransactionRunner()
+	defer closer()
+	return runner.Run(transactions)
 }
 
 // Schema is part of the Database interface.

--- a/state/settings.go
+++ b/state/settings.go
@@ -292,7 +292,7 @@ func readSettingsDoc(st modelBackend, collection, key string) (*settingsDoc, err
 // readSettingsDocInto reads the settings doc with the given key
 // into the provided output structure.
 func readSettingsDocInto(st modelBackend, collection, key string, out interface{}) error {
-	settings, closer := st.getCollection(collection)
+	settings, closer := st.db().GetCollection(collection)
 	defer closer()
 
 	err := settings.FindId(key).One(out)

--- a/state/settings.go
+++ b/state/settings.go
@@ -93,7 +93,8 @@ func (ics itemChangeSlice) Swap(i, j int)      { ics[i], ics[j] = ics[j], ics[i]
 // A Settings manages changes to settings as a delta in memory and merges
 // them back in the database when explicitly requested.
 type Settings struct {
-	st         *State
+	backend    modelBackend
+	db         Database // For convenience
 	collection string
 	key        string
 
@@ -206,7 +207,7 @@ func (s *Settings) settingsUpdateOps() ([]ItemChange, []txn.Op) {
 }
 
 func (s *Settings) write(ops []txn.Op) error {
-	err := s.st.runTransaction(ops)
+	err := s.db.RunTransaction(ops)
 	if err == txn.ErrAborted {
 		return errors.NotFoundf("settings")
 	}
@@ -229,9 +230,10 @@ func (s *Settings) Write() ([]ItemChange, error) {
 	return changes, nil
 }
 
-func newSettings(st *State, collection, key string) *Settings {
+func newSettings(backend modelBackend, collection, key string) *Settings {
 	return &Settings{
-		st:         st,
+		backend:    backend,
+		db:         backend.db(),
 		collection: collection,
 		key:        key,
 		core:       make(map[string]interface{}),
@@ -265,7 +267,7 @@ func copyMap(in map[string]interface{}, replace func(string) string) (out map[st
 
 // Read (re)reads the node data into c.
 func (s *Settings) Read() error {
-	doc, err := readSettingsDoc(s.st, s.collection, s.key)
+	doc, err := readSettingsDoc(s.backend, s.collection, s.key)
 	if errors.IsNotFound(err) {
 		s.disk = nil
 		s.core = make(map[string]interface{})
@@ -308,8 +310,8 @@ func (st *State) ReadSettings(collection, key string) (*Settings, error) {
 }
 
 // readSettings returns the Settings for key.
-func readSettings(st *State, collection, key string) (*Settings, error) {
-	s := newSettings(st, collection, key)
+func readSettings(backend modelBackend, collection, key string) (*Settings, error) {
+	s := newSettings(backend, collection, key)
 	if err := s.Read(); err != nil {
 		return nil, err
 	}
@@ -331,11 +333,11 @@ func createSettingsOp(collection, key string, values map[string]interface{}) txn
 }
 
 // createSettings writes an initial config node.
-func createSettings(st *State, collection, key string, values map[string]interface{}) (*Settings, error) {
-	s := newSettings(st, collection, key)
+func createSettings(backend modelBackend, collection, key string, values map[string]interface{}) (*Settings, error) {
+	s := newSettings(backend, collection, key)
 	s.core = copyMap(values, nil)
 	ops := []txn.Op{createSettingsOp(collection, key, values)}
-	err := s.st.runTransaction(ops)
+	err := s.db.RunTransaction(ops)
 	if err == txn.ErrAborted {
 		return nil, errSettingsExist
 	}
@@ -346,8 +348,8 @@ func createSettings(st *State, collection, key string, values map[string]interfa
 }
 
 // removeSettings removes the Settings for key.
-func removeSettings(st *State, collection, key string) error {
-	err := st.runTransaction([]txn.Op{removeSettingsOp(collection, key)})
+func removeSettings(backend modelBackend, collection, key string) error {
+	err := backend.db().RunTransaction([]txn.Op{removeSettingsOp(collection, key)})
 	if err == txn.ErrAborted {
 		return errors.NotFoundf("settings")
 	} else if err != nil {
@@ -366,18 +368,18 @@ func removeSettingsOp(collection, key string) txn.Op {
 }
 
 // listSettings returns all the settings with the specified key prefix.
-func listSettings(st *State, collection, keyPrefix string) (map[string]map[string]interface{}, error) {
-	settings, closer := st.getRawCollection(collection)
+func listSettings(backend modelBackend, collection, keyPrefix string) (map[string]map[string]interface{}, error) {
+	settings, closer := backend.db().GetRawCollection(collection)
 	defer closer()
 
 	var matchingSettings []settingsDoc
-	findExpr := fmt.Sprintf("^%s.*$", st.docID(keyPrefix))
+	findExpr := fmt.Sprintf("^%s.*$", backend.docID(keyPrefix))
 	if err := settings.Find(bson.D{{"_id", bson.D{{"$regex", findExpr}}}}).All(&matchingSettings); err != nil {
 		return nil, err
 	}
 	result := make(map[string]map[string]interface{})
 	for i := range matchingSettings {
-		result[st.localID(matchingSettings[i].DocID)] = matchingSettings[i].Settings
+		result[backend.localID(matchingSettings[i].DocID)] = matchingSettings[i].Settings
 	}
 	return result, nil
 }
@@ -386,8 +388,8 @@ func listSettings(st *State, collection, keyPrefix string) (map[string]map[strin
 // replaces it with the supplied values, and a function that should be called on
 // txn failure to determine whether this operation failed (due to a concurrent
 // settings change).
-func replaceSettingsOp(st *State, collection, key string, values map[string]interface{}) (txn.Op, func() (bool, error), error) {
-	s, err := readSettings(st, collection, key)
+func replaceSettingsOp(backend modelBackend, collection, key string, values map[string]interface{}) (txn.Op, func() (bool, error), error) {
+	s, err := readSettings(backend, collection, key)
 	if err != nil {
 		return txn.Op{}, nil, err
 	}
@@ -401,7 +403,7 @@ func replaceSettingsOp(st *State, collection, key string, values map[string]inte
 	op := s.assertUnchangedOp()
 	op.Update = setUnsetUpdateSettings(bson.M(newValues), deletes)
 	assertFailed := func() (bool, error) {
-		latest, err := readSettings(st, collection, key)
+		latest, err := readSettings(backend, collection, key)
 		if err != nil {
 			return false, err
 		}
@@ -453,24 +455,24 @@ func setUnsetUpdateSettings(set, unset bson.M) bson.D {
 
 // StateSettings is used to expose various settings APIs outside of the state package.
 type StateSettings struct {
-	st         *State
+	backend    modelBackend
 	collection string
 }
 
-// NewStateSettings creates a StateSettings from state.
-func NewStateSettings(st *State) *StateSettings {
-	return &StateSettings{st, settingsC}
+// NewStateSettings creates a StateSettings from a modelBackend (e.g. State).
+func NewStateSettings(backend *State) *StateSettings {
+	return &StateSettings{backend, settingsC}
 }
 
 // CreateSettings exposes createSettings on state for use outside the state package.
 func (s *StateSettings) CreateSettings(key string, settings map[string]interface{}) error {
-	_, err := createSettings(s.st, s.collection, key, settings)
+	_, err := createSettings(s.backend, s.collection, key, settings)
 	return err
 }
 
 // ReadSettings exposes readSettings on state for use outside the state package.
 func (s *StateSettings) ReadSettings(key string) (map[string]interface{}, error) {
-	if settings, err := readSettings(s.st, s.collection, key); err != nil {
+	if settings, err := readSettings(s.backend, s.collection, key); err != nil {
 		return nil, err
 	} else {
 		return settings.Map(), nil
@@ -479,10 +481,10 @@ func (s *StateSettings) ReadSettings(key string) (map[string]interface{}, error)
 
 // RemoveSettings exposes removeSettings on state for use outside the state package.
 func (s *StateSettings) RemoveSettings(key string) error {
-	return removeSettings(s.st, s.collection, key)
+	return removeSettings(s.backend, s.collection, key)
 }
 
 // ListSettings exposes listSettings on state for use outside the state package.
 func (s *StateSettings) ListSettings(keyPrefix string) (map[string]map[string]interface{}, error) {
-	return listSettings(s.st, s.collection, keyPrefix)
+	return listSettings(s.backend, s.collection, keyPrefix)
 }

--- a/state/settings_test.go
+++ b/state/settings_test.go
@@ -224,7 +224,7 @@ func (s *SettingsSuite) TestReplaceSettingsEscape(c *gc.C) {
 	rop, settingsChanged, err := replaceSettingsOp(s.state, s.collection, s.key, options)
 	c.Assert(err, jc.ErrorIsNil)
 	ops := []txn.Op{rop}
-	err = node.st.runTransaction(ops)
+	err = node.db.RunTransaction(ops)
 	c.Assert(err, jc.ErrorIsNil)
 
 	changed, err := settingsChanged()

--- a/state/state.go
+++ b/state/state.go
@@ -2189,7 +2189,7 @@ func (st *State) SetClockForTesting(clock clock.Clock) error {
 // getCollection delegates to the State's underlying Database.  It
 // returns the collection and a closer function for the session.
 //
-// TODO(mjs) - this should eventually go in favour of using using the
+// TODO(mjs) - this should eventually go in favour of using the
 // Database directly.
 func (st *State) getCollection(name string) (mongo.Collection, func()) {
 	return st.database.GetCollection(name)
@@ -2198,7 +2198,7 @@ func (st *State) getCollection(name string) (mongo.Collection, func()) {
 // getCollectionFor delegates to the State's underlying Database.  It
 // returns the collection and a closer function for the session.
 //
-// TODO(mjs) - this should eventually go in favour of using using the
+// TODO(mjs) - this should eventually go in favour of using the
 // Database directly.
 func (st *State) getCollectionFor(modelUUID, name string) (mongo.Collection, func()) {
 	return st.database.GetCollectionFor(modelUUID, name)

--- a/state/state.go
+++ b/state/state.go
@@ -523,6 +523,18 @@ func (st *State) newDB() (Database, func()) {
 	return st.database.Copy()
 }
 
+// db returns the Database instance used by the State. It is part of
+// the modelBackend interface.
+func (st *State) db() Database {
+	return st.database
+}
+
+// txnLogWatcher returns the TxnLogWatcher for the State. It is part
+// of the modelBackend interface.
+func (st *State) txnLogWatcher() workers.TxnLogWatcher {
+	return st.workers.TxnLogWatcher()
+}
+
 // Ping probes the state's database connection to ensure
 // that it is still alive.
 func (st *State) Ping() error {
@@ -2172,4 +2184,22 @@ func (st *State) SetClockForTesting(clock clock.Clock) error {
 		return errors.Trace(err)
 	}
 	return nil
+}
+
+// getCollection delegates to the State's underlying Database.  It
+// returns the collection and a closer function for the session.
+//
+// TODO(mjs) - this should eventually go in favour of using using the
+// Database directly.
+func (st *State) getCollection(name string) (mongo.Collection, func()) {
+	return st.database.GetCollection(name)
+}
+
+// getCollectionFor delegates to the State's underlying Database.  It
+// returns the collection and a closer function for the session.
+//
+// TODO(mjs) - this should eventually go in favour of using using the
+// Database directly.
+func (st *State) getCollectionFor(modelUUID, name string) (mongo.Collection, func()) {
+	return st.database.GetCollectionFor(modelUUID, name)
 }

--- a/state/txns.go
+++ b/state/txns.go
@@ -10,7 +10,6 @@ import (
 	"gopkg.in/mgo.v2/txn"
 )
 
-// readTxnRevno is a convenience method delegating to the state's Database.
 func (st *State) readTxnRevno(collectionName string, id interface{}) (int64, error) {
 	collection, closer := st.database.GetCollection(collectionName)
 	defer closer()
@@ -22,50 +21,24 @@ func (st *State) readTxnRevno(collectionName string, id interface{}) (int64, err
 	return result.TxnRevno, errors.Trace(err)
 }
 
-// runTransaction is a convenience method delegating to the state's Database.
 func (st *State) runTransaction(ops []txn.Op) error {
-	runner, closer := st.database.TransactionRunner()
-	defer closer()
-	return runner.RunTransaction(ops)
+	return st.database.RunTransaction(ops)
 }
 
-// runTransaction is a convenience method delegating to the state's Database
-// for the model with the given modelUUID.
 func (st *State) runTransactionFor(modelUUID string, ops []txn.Op) error {
-	database, dbcloser := st.database.CopyForModel(modelUUID)
-	defer dbcloser()
-	runner, closer := database.TransactionRunner()
-	defer closer()
-	return runner.RunTransaction(ops)
+	return st.database.RunTransactionFor(modelUUID, ops)
 }
 
-// runRawTransaction is a convenience method that will run a single
-// transaction using a "raw" transaction runner that won't perform
-// model filtering.
 func (st *State) runRawTransaction(ops []txn.Op) error {
-	runner, closer := st.database.TransactionRunner()
-	defer closer()
-	if multiRunner, ok := runner.(*multiModelRunner); ok {
-		runner = multiRunner.rawRunner
-	}
-	return runner.RunTransaction(ops)
+	return st.database.RunRawTransaction(ops)
 }
 
-// run is a convenience method delegating to the state's Database.
 func (st *State) run(transactions jujutxn.TransactionSource) error {
-	runner, closer := st.database.TransactionRunner()
-	defer closer()
-	return runner.Run(transactions)
+	return st.database.Run(transactions)
 }
 
-// runForModel is a convenience method that delegates to a Database for a different
-// modelUUID.
 func (st *State) runForModel(modelUUID string, transactions jujutxn.TransactionSource) error {
-	database, dbcloser := st.database.CopyForModel(modelUUID)
-	defer dbcloser()
-	runner, closer := database.TransactionRunner()
-	defer closer()
-	return runner.Run(transactions)
+	return st.database.RunFor(modelUUID, transactions)
 }
 
 // ResumeTransactions resumes all pending transactions.

--- a/state/watcher.go
+++ b/state/watcher.go
@@ -89,16 +89,18 @@ type RelationUnitsWatcher interface {
 // of the embedder (and also to restrict the width of the interface by
 // which they can access the rest of State, by storing st as a
 // modelBackend).
-func newCommonWatcher(st *State) commonWatcher {
+func newCommonWatcher(backend modelBackend) commonWatcher {
 	return commonWatcher{
-		st:      st,
-		watcher: st.workers.TxnLogWatcher(),
+		backend: backend,
+		db:      backend.db(),
+		watcher: backend.txnLogWatcher(),
 	}
 }
 
 // commonWatcher is part of all client watchers.
 type commonWatcher struct {
-	st      modelBackend
+	backend modelBackend
+	db      Database
 	watcher workers.TxnLogWatcher
 	tomb    tomb.Tomb
 }
@@ -496,7 +498,7 @@ func (w *lifecycleWatcher) initial() (set.Strings, error) {
 		if w.members == nil && w.filter != nil && !w.filter(doc.Id) {
 			continue
 		}
-		id := w.st.localID(doc.Id)
+		id := w.backend.localID(doc.Id)
 		ids.Add(id)
 		if doc.Life != Dead {
 			w.life[id] = doc.Life
@@ -518,7 +520,7 @@ func (w *lifecycleWatcher) merge(ids set.Strings, updates map[interface{}]bool) 
 			if exists {
 				changed = append(changed, docID)
 			} else {
-				latest[w.st.localID(docID)] = Dead
+				latest[w.backend.localID(docID)] = Dead
 			}
 		default:
 			return errors.Errorf("id is not of type string, got %T", docID)
@@ -532,7 +534,7 @@ func (w *lifecycleWatcher) merge(ids set.Strings, updates map[interface{}]bool) 
 	iter := coll.Find(bson.D{{"_id", bson.D{{"$in", changed}}}}).Select(lifeFields).Iter()
 	var doc lifeDoc
 	for iter.Next(&doc) {
-		latest[w.st.localID(doc.Id)] = doc.Life
+		latest[w.backend.localID(doc.Id)] = doc.Life
 	}
 	if err := iter.Close(); err != nil {
 		return err
@@ -647,7 +649,7 @@ func (st *State) WatchMinUnits() StringsWatcher {
 func (w *minUnitsWatcher) initial() (set.Strings, error) {
 	applicationnames := make(set.Strings)
 	var doc minUnitsDoc
-	newMinUnits, closer := w.st.getCollection(minUnitsC)
+	newMinUnits, closer := w.db.GetCollection(minUnitsC)
 	defer closer()
 
 	iter := newMinUnits.Find(nil).Iter()
@@ -659,14 +661,14 @@ func (w *minUnitsWatcher) initial() (set.Strings, error) {
 }
 
 func (w *minUnitsWatcher) merge(applicationnames set.Strings, change watcher.Change) error {
-	applicationname := w.st.localID(change.Id.(string))
+	applicationname := w.backend.localID(change.Id.(string))
 	if change.Revno == -1 {
 		delete(w.known, applicationname)
 		applicationnames.Remove(applicationname)
 		return nil
 	}
 	doc := minUnitsDoc{}
-	newMinUnits, closer := w.st.getCollection(minUnitsC)
+	newMinUnits, closer := w.db.GetCollection(minUnitsC)
 	defer closer()
 	if err := newMinUnits.FindId(change.Id).One(&doc); err != nil {
 		return err
@@ -681,7 +683,7 @@ func (w *minUnitsWatcher) merge(applicationnames set.Strings, change watcher.Cha
 
 func (w *minUnitsWatcher) loop() (err error) {
 	ch := make(chan watcher.Change)
-	w.watcher.WatchCollectionWithFilter(minUnitsC, ch, isLocalID(w.st))
+	w.watcher.WatchCollectionWithFilter(minUnitsC, ch, isLocalID(w.backend))
 	defer w.watcher.UnwatchCollection(minUnitsC, ch)
 	applicationnames, err := w.initial()
 	if err != nil {
@@ -804,7 +806,7 @@ func (w *RelationScopeWatcher) Changes() <-chan *RelationScopeChange {
 
 // initialInfo returns an uncommitted scopeInfo with the current set of units.
 func (w *RelationScopeWatcher) initialInfo() (info *scopeInfo, err error) {
-	relationScopes, closer := w.st.getCollection(relationScopesC)
+	relationScopes, closer := w.db.GetCollection(relationScopesC)
 	defer closer()
 
 	docs := []relationScopeDoc{}
@@ -832,7 +834,7 @@ func (w *RelationScopeWatcher) initialInfo() (info *scopeInfo, err error) {
 // document to be read, and whether it's treated as added or removed depends
 // on the value of the document's Departing field.
 func (w *RelationScopeWatcher) mergeChanges(info *scopeInfo, ids map[interface{}]bool) error {
-	relationScopes, closer := w.st.getCollection(relationScopesC)
+	relationScopes, closer := w.db.GetCollection(relationScopesC)
 	defer closer()
 
 	var existIds []string
@@ -842,7 +844,7 @@ func (w *RelationScopeWatcher) mergeChanges(info *scopeInfo, ids map[interface{}
 			if exists {
 				existIds = append(existIds, id)
 			} else {
-				key, err := w.st.strictLocalID(id)
+				key, err := w.backend.strictLocalID(id)
 				if err != nil {
 					return errors.Trace(err)
 				}
@@ -870,7 +872,7 @@ func (w *RelationScopeWatcher) mergeChanges(info *scopeInfo, ids map[interface{}
 
 func (w *RelationScopeWatcher) loop() error {
 	in := make(chan watcher.Change)
-	fullPrefix := w.st.docID(w.prefix)
+	fullPrefix := w.backend.docID(w.prefix)
 	filter := func(id interface{}) bool {
 		return strings.HasPrefix(id.(string), fullPrefix)
 	}
@@ -993,7 +995,7 @@ func (w *relationUnitsWatcher) mergeSettings(changes *params.RelationUnitsChange
 		TxnRevno int64 `bson:"txn-revno"`
 		Version  int64 `bson:"version"`
 	}
-	if err := readSettingsDocInto(w.st, settingsC, key, &doc); err != nil {
+	if err := readSettingsDocInto(w.backend, settingsC, key, &doc); err != nil {
 		return -1, err
 	}
 	setRelationUnitChangeVersion(changes, key, doc.Version)
@@ -1006,7 +1008,7 @@ func (w *relationUnitsWatcher) mergeSettings(changes *params.RelationUnitsChange
 func (w *relationUnitsWatcher) mergeScope(changes *params.RelationUnitsChange, c *RelationScopeChange) error {
 	for _, name := range c.Entered {
 		key := w.sw.prefix + name
-		docID := w.st.docID(key)
+		docID := w.backend.docID(key)
 		revno, err := w.mergeSettings(changes, key)
 		if err != nil {
 			return err
@@ -1017,7 +1019,7 @@ func (w *relationUnitsWatcher) mergeScope(changes *params.RelationUnitsChange, c
 	}
 	for _, name := range c.Left {
 		key := w.sw.prefix + name
-		docID := w.st.docID(key)
+		docID := w.backend.docID(key)
 		changes.Departed = append(changes.Departed, name)
 		if changes.Changed != nil {
 			delete(changes.Changed, name)
@@ -1177,7 +1179,7 @@ func (w *unitsWatcher) initial() ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	newUnits, closer := w.st.getCollection(unitsC)
+	newUnits, closer := w.db.GetCollection(unitsC)
 	defer closer()
 	query := bson.D{{"name", bson.D{{"$in", initialNames}}}}
 	docs := []lifeWatchDoc{}
@@ -1186,7 +1188,7 @@ func (w *unitsWatcher) initial() ([]string, error) {
 	}
 	changes := []string{}
 	for _, doc := range docs {
-		unitName, err := w.st.strictLocalID(doc.Id)
+		unitName, err := w.backend.strictLocalID(doc.Id)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
@@ -1222,7 +1224,7 @@ func (w *unitsWatcher) update(changes []string) ([]string, error) {
 			changes = append(changes, name)
 		}
 		delete(w.life, name)
-		w.watcher.Unwatch(unitsC, w.st.docID(name), w.in)
+		w.watcher.Unwatch(unitsC, w.backend.docID(name), w.in)
 	}
 	return changes, nil
 }
@@ -1230,10 +1232,10 @@ func (w *unitsWatcher) update(changes []string) ([]string, error) {
 // merge adds to and returns changes, such that it contains the supplied unit
 // name if that unit is unknown and non-Dead, or has changed lifecycle status.
 func (w *unitsWatcher) merge(changes []string, name string) ([]string, error) {
-	units, closer := w.st.getCollection(unitsC)
+	units, closer := w.db.GetCollection(unitsC)
 	defer closer()
 
-	unitDocID := w.st.docID(name)
+	unitDocID := w.backend.docID(name)
 	doc := lifeWatchDoc{}
 	err := units.FindId(unitDocID).Select(lifeWatchFields).One(&doc)
 	gone := false
@@ -1264,7 +1266,7 @@ func (w *unitsWatcher) merge(changes []string, name string) ([]string, error) {
 }
 
 func (w *unitsWatcher) loop(coll, id string) error {
-	collection, closer := w.st.getCollection(coll)
+	collection, closer := w.db.GetCollection(coll)
 	revno, err := getTxnRevno(collection, id)
 	closer()
 	if err != nil {
@@ -1275,14 +1277,14 @@ func (w *unitsWatcher) loop(coll, id string) error {
 	defer func() {
 		w.watcher.Unwatch(coll, id, w.in)
 		for name := range w.life {
-			w.watcher.Unwatch(unitsC, w.st.docID(name), w.in)
+			w.watcher.Unwatch(unitsC, w.backend.docID(name), w.in)
 		}
 	}()
 	changes, err := w.initial()
 	if err != nil {
 		return err
 	}
-	rootLocalID := w.st.localID(id)
+	rootLocalID := w.backend.localID(id)
 	out := w.out
 	for {
 		select {
@@ -1291,7 +1293,7 @@ func (w *unitsWatcher) loop(coll, id string) error {
 		case <-w.tomb.Dying():
 			return tomb.ErrDying
 		case c := <-w.in:
-			localID := w.st.localID(c.Id.(string))
+			localID := w.backend.localID(c.Id.(string))
 			if localID == rootLocalID {
 				changes, err = w.update(changes)
 			} else {
@@ -1487,7 +1489,7 @@ func getTxnRevno(coll mongo.Collection, id interface{}) (int64, error) {
 func (w *docWatcher) loop(docKeys []docKey) error {
 	in := make(chan watcher.Change)
 	for _, k := range docKeys {
-		coll, closer := w.st.getCollection(k.coll)
+		coll, closer := w.db.GetCollection(k.coll)
 		txnRevno, err := getTxnRevno(coll, k.docId)
 		closer()
 		if err != nil {
@@ -1578,7 +1580,7 @@ func (w *machineUnitsWatcher) updateMachine(pending []string) (new []string, err
 
 func (w *machineUnitsWatcher) merge(pending []string, unitName string) (new []string, err error) {
 	doc := unitDoc{}
-	newUnits, closer := w.st.getCollection(unitsC)
+	newUnits, closer := w.db.GetCollection(unitsC)
 	defer closer()
 	err = newUnits.FindId(unitName).One(&doc)
 	if err != nil && err != mgo.ErrNotFound {
@@ -1589,14 +1591,14 @@ func (w *machineUnitsWatcher) merge(pending []string, unitName string) (new []st
 		// Unit was removed or unassigned from w.machine.
 		if known {
 			delete(w.known, unitName)
-			w.watcher.Unwatch(unitsC, w.st.docID(unitName), w.in)
+			w.watcher.Unwatch(unitsC, w.backend.docID(unitName), w.in)
 			if life != Dead && !hasString(pending, unitName) {
 				pending = append(pending, unitName)
 			}
 			for _, subunitName := range doc.Subordinates {
 				if sublife, subknown := w.known[subunitName]; subknown {
 					delete(w.known, subunitName)
-					w.watcher.Unwatch(unitsC, w.st.docID(subunitName), w.in)
+					w.watcher.Unwatch(unitsC, w.backend.docID(subunitName), w.in)
 					if sublife != Dead && !hasString(pending, subunitName) {
 						pending = append(pending, subunitName)
 					}
@@ -1626,11 +1628,11 @@ func (w *machineUnitsWatcher) merge(pending []string, unitName string) (new []st
 func (w *machineUnitsWatcher) loop() error {
 	defer func() {
 		for unit := range w.known {
-			w.watcher.Unwatch(unitsC, w.st.docID(unit), w.in)
+			w.watcher.Unwatch(unitsC, w.backend.docID(unit), w.in)
 		}
 	}()
 
-	machines, closer := w.st.getCollection(machinesC)
+	machines, closer := w.db.GetCollection(machinesC)
 	revno, err := getTxnRevno(machines, w.machine.doc.DocID)
 	closer()
 	if err != nil {
@@ -1659,7 +1661,7 @@ func (w *machineUnitsWatcher) loop() error {
 				out = w.out
 			}
 		case c := <-w.in:
-			changes, err = w.merge(changes, w.st.localID(c.Id.(string)))
+			changes, err = w.merge(changes, w.backend.localID(c.Id.(string)))
 			if err != nil {
 				return err
 			}
@@ -1711,7 +1713,7 @@ func (w *machineAddressesWatcher) Changes() <-chan struct{} {
 }
 
 func (w *machineAddressesWatcher) loop() error {
-	machines, closer := w.st.getCollection(machinesC)
+	machines, closer := w.db.GetCollection(machinesC)
 	revno, err := getTxnRevno(machines, w.machine.doc.DocID)
 	closer()
 	if err != nil {
@@ -1801,7 +1803,7 @@ func (w *actionStatusWatcher) loop() error {
 		in      <-chan watcher.Change = w.source
 		out     chan<- []string       = w.sink
 	)
-	w.watcher.WatchCollectionWithFilter(actionsC, w.source, isLocalID(w.st))
+	w.watcher.WatchCollectionWithFilter(actionsC, w.source, isLocalID(w.backend))
 	defer w.watcher.UnwatchCollection(actionsC, w.source)
 
 	changes, err := w.initial()
@@ -1847,16 +1849,16 @@ func (w *actionStatusWatcher) initial() ([]string, error) {
 func (w *actionStatusWatcher) matchingIds(ids ...string) ([]string, error) {
 	watchLogger.Tracef("actionStatusWatcher matchingIds() ids:'%+v'", ids)
 
-	coll, closer := w.st.getCollection(actionsC)
+	coll, closer := w.db.GetCollection(actionsC)
 	defer closer()
 
-	idFilter := localIdInCollectionOp(w.st, ids...)
+	idFilter := localIdInCollectionOp(w.backend, ids...)
 	query := bson.D{{"$and", []bson.D{idFilter, w.receiverFilter, w.statusFilter}}}
 	iter := coll.Find(query).Iter()
 	var found []string
 	var doc actionDoc
 	for iter.Next(&doc) {
-		found = append(found, w.st.localID(doc.DocId))
+		found = append(found, w.backend.localID(doc.DocId))
 	}
 	watchLogger.Debugf("actionStatusWatcher matchingIds() ids:'%+v', found:'%+v'", ids, found)
 	return found, iter.Close()
@@ -1873,7 +1875,7 @@ func (w *actionStatusWatcher) filterAndMergeIds(changes *[]string, updates map[i
 	for id, exists := range updates {
 		switch id := id.(type) {
 		case string:
-			localId := w.st.localID(id)
+			localId := w.backend.localID(id)
 			chIx, idAlreadyInChangeset := indexOf(localId, *changes)
 			if exists {
 				if !idAlreadyInChangeset {
@@ -2087,14 +2089,14 @@ func (w *collectionWatcher) initial() ([]string, error) {
 	var doc struct {
 		DocId string `bson:"_id"`
 	}
-	coll, closer := w.st.getCollection(w.col)
+	coll, closer := w.db.GetCollection(w.col)
 	defer closer()
 	iter := coll.Find(nil).Iter()
 	for iter.Next(&doc) {
 		if w.filter == nil || w.filter(doc.DocId) {
 			id := doc.DocId
 			if !w.colWCfg.global {
-				id = w.st.localID(id)
+				id = w.backend.localID(id)
 			}
 			if w.idconv != nil {
 				id = w.idconv(id)
@@ -2114,7 +2116,7 @@ func (w *collectionWatcher) initial() ([]string, error) {
 // Additionally, mergeIds strips the model UUID prefix from the id
 // before emitting it through the watcher.
 func (w *collectionWatcher) mergeIds(changes *[]string, updates map[interface{}]bool) error {
-	return mergeIds(w.st, changes, updates, w.convertId)
+	return mergeIds(w.backend, changes, updates, w.convertId)
 }
 
 func (w *collectionWatcher) convertId(id string) (string, error) {
@@ -2122,7 +2124,7 @@ func (w *collectionWatcher) convertId(id string) (string, error) {
 		// Strip off the env UUID prefix.
 		// We only expect ids for a single model.
 		var err error
-		id, err = w.st.strictLocalID(id)
+		id, err = w.backend.strictLocalID(id)
 		if err != nil {
 			return "", errors.Trace(err)
 		}
@@ -2304,14 +2306,14 @@ func (w *openedPortsWatcher) transformID(globalKey string) (string, error) {
 }
 
 func (w *openedPortsWatcher) initial() (set.Strings, error) {
-	ports, closer := w.st.getCollection(openedPortsC)
+	ports, closer := w.db.GetCollection(openedPortsC)
 	defer closer()
 
 	portDocs := set.NewStrings()
 	var doc portsDoc
 	iter := ports.Find(nil).Select(bson.D{{"_id", 1}, {"txn-revno", 1}}).Iter()
 	for iter.Next(&doc) {
-		id, err := w.st.strictLocalID(doc.DocID)
+		id, err := w.backend.strictLocalID(doc.DocID)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
@@ -2333,7 +2335,7 @@ func (w *openedPortsWatcher) loop() error {
 	if err != nil {
 		return errors.Trace(err)
 	}
-	w.watcher.WatchCollectionWithFilter(openedPortsC, in, isLocalID(w.st))
+	w.watcher.WatchCollectionWithFilter(openedPortsC, in, isLocalID(w.backend))
 	defer w.watcher.UnwatchCollection(openedPortsC, in)
 
 	out := w.out
@@ -2362,7 +2364,7 @@ func (w *openedPortsWatcher) merge(ids set.Strings, change watcher.Change) error
 	if !ok {
 		return errors.Errorf("id %v is not of type string, got %T", id, id)
 	}
-	localID, err := w.st.strictLocalID(id)
+	localID, err := w.backend.strictLocalID(id)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -2376,7 +2378,7 @@ func (w *openedPortsWatcher) merge(ids set.Strings, change watcher.Change) error
 		}
 		return nil
 	}
-	openedPorts, closer := w.st.getCollection(openedPortsC)
+	openedPorts, closer := w.db.GetCollection(openedPortsC)
 	currentRevno, err := getTxnRevno(openedPorts, id)
 	closer()
 	if err != nil {
@@ -2445,8 +2447,8 @@ func (w *blockDevicesWatcher) Changes() <-chan struct{} {
 }
 
 func (w *blockDevicesWatcher) loop() error {
-	docID := w.st.docID(w.machineId)
-	coll, closer := w.st.getCollection(blockDevicesC)
+	docID := w.backend.docID(w.machineId)
+	coll, closer := w.db.GetCollection(blockDevicesC)
 	revno, err := getTxnRevno(coll, docID)
 	closer()
 	if err != nil {
@@ -2455,7 +2457,7 @@ func (w *blockDevicesWatcher) loop() error {
 	changes := make(chan watcher.Change)
 	w.watcher.Watch(blockDevicesC, docID, revno, changes)
 	defer w.watcher.Unwatch(blockDevicesC, docID, changes)
-	blockDevices, err := getBlockDevices(w.st, w.machineId)
+	blockDevices, err := getBlockDevices(w.db, w.machineId)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -2467,7 +2469,7 @@ func (w *blockDevicesWatcher) loop() error {
 		case <-w.tomb.Dying():
 			return tomb.ErrDying
 		case <-changes:
-			newBlockDevices, err := getBlockDevices(w.st, w.machineId)
+			newBlockDevices, err := getBlockDevices(w.db, w.machineId)
 			if err != nil {
 				return errors.Trace(err)
 			}
@@ -2516,7 +2518,7 @@ func (w *migrationActiveWatcher) Changes() <-chan struct{} {
 }
 
 func (w *migrationActiveWatcher) loop() error {
-	collection, closer := w.st.getCollection(w.collName)
+	collection, closer := w.db.GetCollection(w.collName)
 	revno, err := getTxnRevno(collection, w.id)
 	closer()
 	if err != nil {
@@ -2663,7 +2665,7 @@ func (w *offeredApplicationsWatcher) initial() (set.Strings, error) {
 		ApplicationURL string `bson:"application-url"`
 		TxnRevno       int64  `bson:"txn-revno"`
 	}
-	offeredCollection, closer := w.st.getCollection(applicationOffersC)
+	offeredCollection, closer := w.db.GetCollection(applicationOffersC)
 	defer closer()
 
 	iter := offeredCollection.Find(nil).Iter()
@@ -2675,7 +2677,7 @@ func (w *offeredApplicationsWatcher) initial() (set.Strings, error) {
 }
 
 func (w *offeredApplicationsWatcher) merge(applicationURLs set.Strings, change watcher.Change) error {
-	applicationURL := w.st.localID(change.Id.(string))
+	applicationURL := w.backend.localID(change.Id.(string))
 	if change.Revno == -1 {
 		delete(w.known, applicationURL)
 		applicationURLs.Remove(applicationURL)
@@ -2684,7 +2686,7 @@ func (w *offeredApplicationsWatcher) merge(applicationURLs set.Strings, change w
 	var revnoDoc struct {
 		TxnRevno int64 `bson:"txn-revno"`
 	}
-	offeredCollection, closer := w.st.getCollection(applicationOffersC)
+	offeredCollection, closer := w.db.GetCollection(applicationOffersC)
 	defer closer()
 	if err := offeredCollection.FindId(change.Id).One(&revnoDoc); err != nil {
 		return err
@@ -2699,7 +2701,7 @@ func (w *offeredApplicationsWatcher) merge(applicationURLs set.Strings, change w
 
 func (w *offeredApplicationsWatcher) loop() (err error) {
 	ch := make(chan watcher.Change)
-	w.watcher.WatchCollectionWithFilter(applicationOffersC, ch, isLocalID(w.st))
+	w.watcher.WatchCollectionWithFilter(applicationOffersC, ch, isLocalID(w.backend))
 	defer w.watcher.UnwatchCollection(applicationOffersC, ch)
 	offers, err := w.initial()
 	if err != nil {
@@ -2747,7 +2749,7 @@ func (st *State) WatchRemoteRelations() StringsWatcher {
 		}
 
 		// Gather the remote app names.
-		remoteApps, closer := st.getCollection(remoteApplicationsC)
+		remoteApps, closer := st.db().GetCollection(remoteApplicationsC)
 		defer closer()
 
 		type remoteAppDoc struct {
@@ -2766,7 +2768,7 @@ func (st *State) WatchRemoteRelations() StringsWatcher {
 		}
 
 		// Run a query to pickup any relations to those remote apps.
-		relations, closer := st.getCollection(relationsC)
+		relations, closer := st.db().GetCollection(relationsC)
 		defer closer()
 
 		query := bson.D{
@@ -2794,4 +2796,17 @@ func (st *State) WatchRemoteRelations() StringsWatcher {
 // the lifecycles of the subnets in the model.
 func (st *State) WatchSubnets() StringsWatcher {
 	return newLifecycleWatcher(st, subnetsC, nil, isLocalID(st), nil)
+}
+
+// isLocalID returns a watcher filter func that rejects ids not specific
+// to the supplied modelBackend.
+func isLocalID(st modelBackend) func(interface{}) bool {
+	return func(id interface{}) bool {
+		key, ok := id.(string)
+		if !ok {
+			return false
+		}
+		_, err := st.strictLocalID(key)
+		return err == nil
+	}
 }


### PR DESCRIPTION
## Description of change

In order to support new State-like types (coming soon) and allow them to leverage existing functionality in the state package, some low level txn functionality which was on State has been moved onto Database. Additionally the modelBackend interface has been extended to allow it to be used more widely, providing access to the underlying Database.

The state settings and watcher implementations are now completely based on modelBackend instead of State, allowing alternative State types to use these areas too.

## QA steps

This change shouldn't affect external behaviour. Unit tests still pass and a simple bootstrap, deploy, destroy check was undertaken to ensure basic functionality is still OK.

## Documentation changes

Not required - no used visible changes.

## Bug reference

N.A.
