### PR TITLE
Add support for propagating remote relation removal

### DIFF
--- a/api/remoterelations/remoterelations_test.go
+++ b/api/remoterelations/remoterelations_test.go
@@ -374,8 +374,8 @@ func (s *remoteRelationsSuite) TestImportRemoteEntity(c *gc.C) {
 		c.Check(version, gc.Equals, 0)
 		c.Check(id, gc.Equals, "")
 		c.Check(request, gc.Equals, "ImportRemoteEntities")
-		c.Check(arg, gc.DeepEquals, params.ImportEntityArgs{
-			Args: []params.ImportEntityArg{{ModelTag: coretesting.ModelTag.String(), Tag: "application-app", Token: "token"}}})
+		c.Check(arg, gc.DeepEquals, params.RemoteEntityArgs{
+			Args: []params.RemoteEntityArg{{ModelTag: coretesting.ModelTag.String(), Tag: "application-app", Token: "token"}}})
 		c.Assert(result, gc.FitsTypeOf, &params.ErrorResults{})
 		*(result.(*params.ErrorResults)) = params.ErrorResults{
 			Results: []params.ErrorResult{{
@@ -403,6 +403,45 @@ func (s *remoteRelationsSuite) TestImportRemoteEntityCount(c *gc.C) {
 	})
 	client := remoterelations.NewClient(apiCaller)
 	err := client.ImportRemoteEntity(coretesting.ModelTag.Id(), names.NewApplicationTag("app"), "token")
+	c.Check(err, gc.ErrorMatches, `expected 1 result, got 2`)
+}
+
+func (s *remoteRelationsSuite) TestRemoveRemoteEntity(c *gc.C) {
+	var callCount int
+	apiCaller := testing.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
+		c.Check(objType, gc.Equals, "RemoteRelations")
+		c.Check(version, gc.Equals, 0)
+		c.Check(id, gc.Equals, "")
+		c.Check(request, gc.Equals, "RemoveRemoteEntities")
+		c.Check(arg, gc.DeepEquals, params.RemoteEntityArgs{
+			Args: []params.RemoteEntityArg{{ModelTag: coretesting.ModelTag.String(), Tag: "application-app"}}})
+		c.Assert(result, gc.FitsTypeOf, &params.ErrorResults{})
+		*(result.(*params.ErrorResults)) = params.ErrorResults{
+			Results: []params.ErrorResult{{
+				Error: &params.Error{Message: "FAIL"},
+			}},
+		}
+		callCount++
+		return nil
+	})
+	client := remoterelations.NewClient(apiCaller)
+	err := client.RemoveRemoteEntity(coretesting.ModelTag.Id(), names.NewApplicationTag("app"))
+	c.Check(err, gc.ErrorMatches, "FAIL")
+	c.Check(callCount, gc.Equals, 1)
+}
+
+func (s *remoteRelationsSuite) TestRemoveRemoteEntityCount(c *gc.C) {
+	apiCaller := testing.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
+		*(result.(*params.ErrorResults)) = params.ErrorResults{
+			Results: []params.ErrorResult{
+				{Error: &params.Error{Message: "FAIL"}},
+				{Error: &params.Error{Message: "FAIL"}},
+			},
+		}
+		return nil
+	})
+	client := remoterelations.NewClient(apiCaller)
+	err := client.RemoveRemoteEntity(coretesting.ModelTag.Id(), names.NewApplicationTag("app"))
 	c.Check(err, gc.ErrorMatches, `expected 1 result, got 2`)
 }
 

--- a/apiserver/params/crossmodel.go
+++ b/apiserver/params/crossmodel.go
@@ -318,21 +318,21 @@ type GetTokenArg struct {
 	Tag string `json:"tag"`
 }
 
-// ImportEntityArgs holds the arguments to an ImportRemoteEntity API call.
-type ImportEntityArgs struct {
-	Args []ImportEntityArg
+// RemoteEntityArgs holds the arguments to an API call dealing with remote entities.
+type RemoteEntityArgs struct {
+	Args []RemoteEntityArg
 }
 
-// ImportEntityArg holds the model, entity and token to be imported.
-type ImportEntityArg struct {
+// RemoteEntityArg holds the model, entity and token to be operated on.
+type RemoteEntityArg struct {
 	// ModelTag is the tag of the model hosting the entity.
 	ModelTag string `json:"model-tag"`
 
-	// Tag is the tag of the entity for which are importing the token.
+	// Tag is the tag of the entity.
 	Tag string `json:"tag"`
 
-	// Token is the token of the entity to be imported.
-	Token string `json:"token"`
+	// Token is the token of the entity.
+	Token string `json:"token,omitempty"`
 }
 
 // RemoteApplicationResult holds a remote application and an error.

--- a/apiserver/remoterelations/mock_test.go
+++ b/apiserver/remoterelations/mock_test.go
@@ -95,6 +95,15 @@ func (st *mockState) ImportRemoteEntity(sourceModel names.ModelTag, entity names
 	return nil
 }
 
+func (st *mockState) RemoveRemoteEntity(sourceModel names.ModelTag, entity names.Tag) error {
+	st.MethodCall(st, "RemoveRemoteEntity", sourceModel, entity)
+	if err := st.NextErr(); err != nil {
+		return err
+	}
+	delete(st.remoteEntities, entity)
+	return nil
+}
+
 func (st *mockState) ExportLocalEntity(entity names.Tag) (string, error) {
 	st.MethodCall(st, "ExportLocalEntity", entity)
 	if err := st.NextErr(); err != nil {

--- a/apiserver/remoterelations/remoterelations_test.go
+++ b/apiserver/remoterelations/remoterelations_test.go
@@ -210,8 +210,8 @@ func (s *remoteRelationsSuite) TestWatchLocalRelationUnits(c *gc.C) {
 }
 
 func (s *remoteRelationsSuite) TestImportRemoteEntities(c *gc.C) {
-	result, err := s.api.ImportRemoteEntities(params.ImportEntityArgs{
-		Args: []params.ImportEntityArg{
+	result, err := s.api.ImportRemoteEntities(params.RemoteEntityArgs{
+		Args: []params.RemoteEntityArg{
 			{ModelTag: coretesting.ModelTag.String(), Tag: "application-django", Token: "token"},
 		}})
 	c.Assert(err, jc.ErrorIsNil)
@@ -223,13 +223,13 @@ func (s *remoteRelationsSuite) TestImportRemoteEntities(c *gc.C) {
 }
 
 func (s *remoteRelationsSuite) TestImportRemoteEntitiesTwice(c *gc.C) {
-	_, err := s.api.ImportRemoteEntities(params.ImportEntityArgs{
-		Args: []params.ImportEntityArg{
+	_, err := s.api.ImportRemoteEntities(params.RemoteEntityArgs{
+		Args: []params.RemoteEntityArg{
 			{ModelTag: coretesting.ModelTag.String(), Tag: "application-django", Token: "token"},
 		}})
 	c.Assert(err, jc.ErrorIsNil)
-	result, err := s.api.ImportRemoteEntities(params.ImportEntityArgs{
-		Args: []params.ImportEntityArg{
+	result, err := s.api.ImportRemoteEntities(params.RemoteEntityArgs{
+		Args: []params.RemoteEntityArg{
 			{ModelTag: coretesting.ModelTag.String(), Tag: "application-django", Token: "token"},
 		}})
 	c.Assert(err, jc.ErrorIsNil)
@@ -239,6 +239,19 @@ func (s *remoteRelationsSuite) TestImportRemoteEntitiesTwice(c *gc.C) {
 	s.st.CheckCalls(c, []testing.StubCall{
 		{"ImportRemoteEntity", []interface{}{coretesting.ModelTag, names.ApplicationTag{Name: "django"}, "token"}},
 		{"ImportRemoteEntity", []interface{}{coretesting.ModelTag, names.ApplicationTag{Name: "django"}, "token"}},
+	})
+}
+
+func (s *remoteRelationsSuite) TestRemoveRemoteEntities(c *gc.C) {
+	result, err := s.api.RemoveRemoteEntities(params.RemoteEntityArgs{
+		Args: []params.RemoteEntityArg{
+			{ModelTag: coretesting.ModelTag.String(), Tag: "application-django"},
+		}})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result.Results, gc.HasLen, 1)
+	c.Assert(result.Results[0], jc.DeepEquals, params.ErrorResult{})
+	s.st.CheckCalls(c, []testing.StubCall{
+		{"RemoveRemoteEntity", []interface{}{coretesting.ModelTag, names.ApplicationTag{Name: "django"}}},
 	})
 }
 

--- a/apiserver/remoterelations/state.go
+++ b/apiserver/remoterelations/state.go
@@ -75,6 +75,9 @@ type RemoteRelationsState interface {
 	// with the specified opaque token.
 	ImportRemoteEntity(sourceModel names.ModelTag, entity names.Tag, token string) error
 
+	// RemoveRemoteEntity removes the specified entity from the remote entities collection.
+	RemoveRemoteEntity(sourceModel names.ModelTag, entity names.Tag) error
+
 	// GetToken returns the token associated with the entity with the given tag
 	// and model.
 	GetToken(names.ModelTag, names.Tag) (string, error)
@@ -167,6 +170,11 @@ type RemoteApplication interface {
 
 	// Status returns the status of the remote application.
 	Status() (status.StatusInfo, error)
+
+	// Destroy ensures that this remote application reference and all its relations
+	// will be removed at some point; if no relation involving the
+	// application has any units in scope, they are all removed immediately.
+	Destroy() error
 }
 
 // Application represents the state of a application hosted in the local model.
@@ -215,6 +223,11 @@ func (st stateShim) GetRemoteEntity(model names.ModelTag, token string) (names.T
 func (st stateShim) ImportRemoteEntity(model names.ModelTag, entity names.Tag, token string) error {
 	r := st.State.RemoteEntities()
 	return r.ImportRemoteEntity(model, entity, token)
+}
+
+func (st stateShim) RemoveRemoteEntity(model names.ModelTag, entity names.Tag) error {
+	r := st.State.RemoteEntities()
+	return r.RemoveRemoteEntity(model, entity)
 }
 
 func (st stateShim) GetToken(model names.ModelTag, entity names.Tag) (string, error) {

--- a/provider/dummy/environs.go
+++ b/provider/dummy/environs.go
@@ -1576,9 +1576,16 @@ func (inst *dummyInstance) OpenPorts(machineId string, rules []network.IngressRu
 			r.SourceCIDRs = []string{"0.0.0.0/0"}
 		}
 		found := false
-		for _, rule := range inst.rules {
+		for i, rule := range inst.rules {
+			if r.PortRange == rule.PortRange {
+				ruleCopy := r
+				inst.rules[i] = ruleCopy
+				found = true
+				break
+			}
 			if r.String() == rule.String() {
 				found = true
+				break
 			}
 		}
 		if !found {

--- a/state/remoteentities.go
+++ b/state/remoteentities.go
@@ -157,6 +157,7 @@ func (r *RemoteEntities) RemoveRemoteEntity(
 	ops := func(attempt int) ([]txn.Op, error) {
 		token, err := r.GetToken(sourceModel, entity)
 		if errors.IsNotFound(err) {
+			logger.Debugf("remote entity %v from %v in model %v not found", entity, sourceModel, r.st.ModelUUID())
 			return nil, jujutxn.ErrNoOperations
 		}
 		ops := []txn.Op{r.removeRemoteEntityOp(sourceModel, entity)}

--- a/worker/firewaller/firewaller_test.go
+++ b/worker/firewaller/firewaller_test.go
@@ -803,10 +803,6 @@ func (s *InstanceModeSuite) TestRemoteRelation(c *gc.C) {
 	s.assertRemoteRelation(c, []string{"::1/0", "10.0.0.0/24"}, []string{"10.0.0.0/24"})
 }
 
-func (s *InstanceModeSuite) TestRemoveRemoteRelation(c *gc.C) {
-	// TODO(wallyworld) - implement once firewaller is fixed
-}
-
 type GlobalModeSuite struct {
 	firewallerBaseSuite
 }

--- a/worker/remoterelations/mock_test.go
+++ b/worker/remoterelations/mock_test.go
@@ -130,6 +130,14 @@ func (m *mockRelationsFacade) ImportRemoteEntity(sourceModelUUID string, entity 
 	return nil
 }
 
+func (m *mockRelationsFacade) RemoveRemoteEntity(sourceModelUUID string, entity names.Tag) error {
+	m.stub.MethodCall(m, "RemoveRemoteEntity", sourceModelUUID, entity)
+	if err := m.stub.NextErr(); err != nil {
+		return err
+	}
+	return nil
+}
+
 func (m *mockRelationsFacade) GetToken(modelUUID string, entity names.Tag) (string, error) {
 	m.stub.MethodCall(m, "GetToken", modelUUID, entity)
 	if err := m.stub.NextErr(); err != nil {

--- a/worker/remoterelations/remoterelations_test.go
+++ b/worker/remoterelations/remoterelations_test.go
@@ -205,6 +205,19 @@ func (s *remoteRelationsSuite) TestRemoteRelationsDead(c *gc.C) {
 	c.Assert(unitsWatcher.killed(), jc.IsTrue)
 	expected := []jujutesting.StubCall{
 		{"Relations", []interface{}{[]string{"db2:db django:db"}}},
+		{"GetToken", []interface{}{"model-uuid", names.NewRelationTag("db2:db django:db")}},
+		{"RemoveRemoteEntity", []interface{}{"model-uuid", names.NewRelationTag("db2:db django:db")}},
+		{"PublishLocalRelationChange", []interface{}{
+			params.RemoteRelationChangeEvent{
+				Life: params.Dead,
+				ApplicationId: params.RemoteEntityId{
+					ModelUUID: "model-uuid",
+					Token:     "token-django"},
+				RelationId: params.RemoteEntityId{
+					ModelUUID: "model-uuid",
+					Token:     "token-db2:db django:db"},
+			},
+		}},
 	}
 	s.waitForWorkerStubCalls(c, expected)
 }
@@ -228,6 +241,19 @@ func (s *remoteRelationsSuite) TestRemoteRelationsRemoved(c *gc.C) {
 	c.Assert(unitsWatcher.killed(), jc.IsTrue)
 	expected := []jujutesting.StubCall{
 		{"Relations", []interface{}{[]string{"db2:db django:db"}}},
+		{"GetToken", []interface{}{"model-uuid", names.NewRelationTag("db2:db django:db")}},
+		{"RemoveRemoteEntity", []interface{}{"model-uuid", names.NewRelationTag("db2:db django:db")}},
+		{"PublishLocalRelationChange", []interface{}{
+			params.RemoteRelationChangeEvent{
+				Life: params.Dead,
+				ApplicationId: params.RemoteEntityId{
+					ModelUUID: "model-uuid",
+					Token:     "token-django"},
+				RelationId: params.RemoteEntityId{
+					ModelUUID: "model-uuid",
+					Token:     "token-db2:db django:db"},
+			},
+		}},
 	}
 	s.waitForWorkerStubCalls(c, expected)
 }


### PR DESCRIPTION
## Description of change

When a remote relation is removed, that change is now propagated to the other remote model.
New apis are added to the remote relations facade:
- unregisterrelations
- removeremoteentities

Also as a drive by, include stack trace in catacomb errors to make test errors easier to diagnose.

## QA steps

bootstrap
create 2 models
deploy apps and relate across models
remove-relation in consuming model
check debug logs to see relation in both models be removed

repeat above but destroy in offering model

