### PR TITLE
state: clean up machine-bound storage properly

### DIFF
--- a/api/watcher/watcher_test.go
+++ b/api/watcher/watcher_test.go
@@ -178,7 +178,7 @@ func (s *watcherSuite) TestWatchMachineStorage(c *gc.C) {
 	f.MakeMachine(c, &factory.MachineParams{
 		Volumes: []state.MachineVolumeParams{{
 			Volume: state.VolumeParams{
-				Pool: "environscoped",
+				Pool: "modelscoped",
 				Size: 1024,
 			},
 		}},

--- a/apiserver/application/application_test.go
+++ b/apiserver/application/application_test.go
@@ -210,7 +210,7 @@ func (s *serviceSuite) TestServiceDeployWithStorage(c *gc.C) {
 		"data": {
 			Count: 1,
 			Size:  1024,
-			Pool:  "environscoped-block",
+			Pool:  "modelscoped-block",
 		},
 	}
 
@@ -236,7 +236,7 @@ func (s *serviceSuite) TestServiceDeployWithStorage(c *gc.C) {
 		"data": {
 			Count: 1,
 			Size:  1024,
-			Pool:  "environscoped-block",
+			Pool:  "modelscoped-block",
 		},
 		"allecto": {
 			Count: 0,

--- a/apiserver/provisioner/provisioninginfo_test.go
+++ b/apiserver/provisioner/provisioninginfo_test.go
@@ -275,7 +275,7 @@ func (s *withoutControllerSuite) TestStorageProviderFallbackToType(c *gc.C) {
 		Jobs:      []state.MachineJob{state.JobHostUnits},
 		Placement: "valid",
 		Volumes: []state.MachineVolumeParams{
-			{Volume: state.VolumeParams{Size: 1000, Pool: "environscoped"}},
+			{Volume: state.VolumeParams{Size: 1000, Pool: "modelscoped"}},
 			{Volume: state.VolumeParams{Size: 1000, Pool: "static"}},
 		},
 	}

--- a/apiserver/storageprovisioner/storageprovisioner_test.go
+++ b/apiserver/storageprovisioner/storageprovisioner_test.go
@@ -76,10 +76,10 @@ func (s *provisionerSuite) setupVolumes(c *gc.C) {
 		InstanceId: instance.Id("inst-id"),
 		Volumes: []state.MachineVolumeParams{
 			{Volume: state.VolumeParams{Pool: "machinescoped", Size: 1024}},
-			{Volume: state.VolumeParams{Pool: "environscoped", Size: 2048}},
-			{Volume: state.VolumeParams{Pool: "environscoped", Size: 4096}},
+			{Volume: state.VolumeParams{Pool: "modelscoped", Size: 2048}},
+			{Volume: state.VolumeParams{Pool: "modelscoped", Size: 4096}},
 			{
-				Volume: state.VolumeParams{Pool: "environscoped", Size: 4096},
+				Volume: state.VolumeParams{Pool: "modelscoped", Size: 4096},
 				Attachment: state.VolumeAttachmentParams{
 					ReadOnly: true,
 				},
@@ -111,7 +111,7 @@ func (s *provisionerSuite) setupVolumes(c *gc.C) {
 		Series: "quantal",
 		Jobs:   []state.MachineJob{state.JobHostUnits},
 		Volumes: []state.MachineVolumeParams{
-			{Volume: state.VolumeParams{Pool: "environscoped", Size: 2048}},
+			{Volume: state.VolumeParams{Pool: "modelscoped", Size: 2048}},
 		},
 	})
 	c.Assert(err, jc.ErrorIsNil)
@@ -127,9 +127,9 @@ func (s *provisionerSuite) setupFilesystems(c *gc.C) {
 				ReadOnly: true,
 			},
 		}, {
-			Filesystem: state.FilesystemParams{Pool: "environscoped", Size: 2048},
+			Filesystem: state.FilesystemParams{Pool: "modelscoped", Size: 2048},
 		}, {
-			Filesystem: state.FilesystemParams{Pool: "environscoped", Size: 4096},
+			Filesystem: state.FilesystemParams{Pool: "modelscoped", Size: 4096},
 		}},
 	})
 
@@ -155,7 +155,7 @@ func (s *provisionerSuite) setupFilesystems(c *gc.C) {
 		Series: "quantal",
 		Jobs:   []state.MachineJob{state.JobHostUnits},
 		Filesystems: []state.MachineFilesystemParams{{
-			Filesystem: state.FilesystemParams{Pool: "environscoped", Size: 2048},
+			Filesystem: state.FilesystemParams{Pool: "modelscoped", Size: 2048},
 		}},
 	})
 	c.Assert(err, jc.ErrorIsNil)
@@ -370,7 +370,7 @@ func (s *provisionerSuite) TestVolumeParams(c *gc.C) {
 			{Result: params.VolumeParams{
 				VolumeTag: "volume-1",
 				Size:      2048,
-				Provider:  "environscoped",
+				Provider:  "modelscoped",
 				Tags: map[string]string{
 					tags.JujuController: testing.ControllerTag.Id(),
 					tags.JujuModel:      testing.ModelTag.Id(),
@@ -378,14 +378,14 @@ func (s *provisionerSuite) TestVolumeParams(c *gc.C) {
 				Attachment: &params.VolumeAttachmentParams{
 					MachineTag: "machine-0",
 					VolumeTag:  "volume-1",
-					Provider:   "environscoped",
+					Provider:   "modelscoped",
 					InstanceId: "inst-id",
 				},
 			}},
 			{Result: params.VolumeParams{
 				VolumeTag: "volume-3",
 				Size:      4096,
-				Provider:  "environscoped",
+				Provider:  "modelscoped",
 				Tags: map[string]string{
 					tags.JujuController: testing.ControllerTag.Id(),
 					tags.JujuModel:      testing.ModelTag.Id(),
@@ -393,7 +393,7 @@ func (s *provisionerSuite) TestVolumeParams(c *gc.C) {
 				Attachment: &params.VolumeAttachmentParams{
 					MachineTag: "machine-0",
 					VolumeTag:  "volume-3",
-					Provider:   "environscoped",
+					Provider:   "modelscoped",
 					InstanceId: "inst-id",
 					ReadOnly:   true,
 				},
@@ -429,7 +429,7 @@ func (s *provisionerSuite) TestFilesystemParams(c *gc.C) {
 			{Result: params.FilesystemParams{
 				FilesystemTag: "filesystem-1",
 				Size:          2048,
-				Provider:      "environscoped",
+				Provider:      "modelscoped",
 				Tags: map[string]string{
 					tags.JujuController: testing.ControllerTag.Id(),
 					tags.JujuModel:      testing.ModelTag.Id(),
@@ -492,20 +492,20 @@ func (s *provisionerSuite) TestVolumeAttachmentParams(c *gc.C) {
 				MachineTag: "machine-0",
 				VolumeTag:  "volume-1",
 				InstanceId: "inst-id",
-				Provider:   "environscoped",
+				Provider:   "modelscoped",
 			}},
 			{Result: params.VolumeAttachmentParams{
 				MachineTag: "machine-0",
 				VolumeTag:  "volume-3",
 				InstanceId: "inst-id",
 				VolumeId:   "xyz",
-				Provider:   "environscoped",
+				Provider:   "modelscoped",
 				ReadOnly:   true,
 			}},
 			{Result: params.VolumeAttachmentParams{
 				MachineTag: "machine-2",
 				VolumeTag:  "volume-4",
-				Provider:   "environscoped",
+				Provider:   "modelscoped",
 			}},
 			{Error: &params.Error{Message: "permission denied", Code: "unauthorized access"}},
 		},
@@ -562,13 +562,13 @@ func (s *provisionerSuite) TestFilesystemAttachmentParams(c *gc.C) {
 				FilesystemTag: "filesystem-1",
 				InstanceId:    "inst-id",
 				FilesystemId:  "fsid",
-				Provider:      "environscoped",
+				Provider:      "modelscoped",
 				MountPoint:    "/in/the/place",
 			}},
 			{Result: params.FilesystemAttachmentParams{
 				MachineTag:    "machine-2",
 				FilesystemTag: "filesystem-3",
-				Provider:      "environscoped",
+				Provider:      "modelscoped",
 			}},
 			{Error: &params.Error{Message: "permission denied", Code: "unauthorized access"}},
 		},
@@ -1087,7 +1087,7 @@ func (s *provisionerSuite) TestRemoveVolumesMachineAgent(c *gc.C) {
 		{"volume-invalid"}, {"machine-0"},
 	}}
 
-	err := s.State.DetachVolume(names.NewMachineTag("0"), names.NewVolumeTag("0/0"))
+	err := s.State.DestroyVolume(names.NewVolumeTag("0/0"))
 	c.Assert(err, jc.ErrorIsNil)
 	err = s.State.RemoveVolumeAttachment(names.NewMachineTag("0"), names.NewVolumeTag("0/0"))
 	c.Assert(err, jc.ErrorIsNil)
@@ -1115,11 +1115,9 @@ func (s *provisionerSuite) TestRemoveFilesystemsMachineAgent(c *gc.C) {
 		{"filesystem-invalid"}, {"machine-0"},
 	}}
 
-	err := s.State.DetachFilesystem(names.NewMachineTag("0"), names.NewFilesystemTag("0/0"))
+	err := s.State.DestroyFilesystem(names.NewFilesystemTag("0/0"))
 	c.Assert(err, jc.ErrorIsNil)
 	err = s.State.RemoveFilesystemAttachment(names.NewMachineTag("0"), names.NewFilesystemTag("0/0"))
-	c.Assert(err, jc.ErrorIsNil)
-	err = s.State.DestroyFilesystem(names.NewFilesystemTag("0/0"))
 	c.Assert(err, jc.ErrorIsNil)
 
 	result, err := s.api.Remove(args)

--- a/featuretests/storage_test.go
+++ b/featuretests/storage_test.go
@@ -236,14 +236,14 @@ block:
   provider: loop
   attrs:
     it: works
-environscoped:
-  provider: environscoped
-environscoped-block:
-  provider: environscoped-block
 loop:
   provider: loop
 machinescoped:
   provider: machinescoped
+modelscoped:
+  provider: modelscoped
+modelscoped-block:
+  provider: modelscoped-block
 rootfs:
   provider: rootfs
 static:
@@ -258,15 +258,15 @@ func (s *cmdStorageSuite) TestListPoolsTabular(c *gc.C) {
 	stdout, _, err := runPoolList(c)
 	c.Assert(err, jc.ErrorIsNil)
 	expected := `
-Name                 Provider             Attrs
-block                loop                 it=works
-environscoped        environscoped        
-environscoped-block  environscoped-block  
-loop                 loop                 
-machinescoped        machinescoped        
-rootfs               rootfs               
-static               static               
-tmpfs                tmpfs                
+Name               Provider           Attrs
+block              loop               it=works
+loop               loop               
+machinescoped      machinescoped      
+modelscoped        modelscoped        
+modelscoped-block  modelscoped-block  
+rootfs             rootfs             
+static             static             
+tmpfs              tmpfs              
 
 `[1:]
 	c.Assert(stdout, gc.Equals, expected)
@@ -340,7 +340,7 @@ block:
 }
 
 func (s *cmdStorageSuite) TestListPoolsProviderAndNotName(c *gc.C) {
-	stdout, _, err := runPoolList(c, "--name", "fluff", "--provider", "environscoped")
+	stdout, _, err := runPoolList(c, "--name", "fluff", "--provider", "modelscoped")
 	c.Assert(err, jc.ErrorIsNil)
 	// there is no pool that matches this name AND type
 	c.Assert(stdout, gc.Equals, "")
@@ -545,7 +545,7 @@ func (s *cmdStorageSuite) TestStorageAddToUnitStorageDoesntExist(c *gc.C) {
 
 func (s *cmdStorageSuite) TestStorageAddToUnitHasVolumes(c *gc.C) {
 	// Reproducing Bug1462146
-	u := createUnitWithFileSystemStorage(c, &s.JujuConnSuite, "environscoped-block")
+	u := createUnitWithFileSystemStorage(c, &s.JujuConnSuite, "modelscoped-block")
 	instancesBefore, err := s.State.AllStorageInstances()
 	c.Assert(err, jc.ErrorIsNil)
 	s.assertStorageExist(c, instancesBefore, "data")
@@ -571,7 +571,7 @@ Machine  Unit                  Storage  Id  Provider Id  Device  Size  State    
 `[1:])
 	c.Assert(testing.Stderr(context), gc.Equals, "")
 
-	context, err = runAddToUnit(c, u, "data=environscoped-block,1G")
+	context, err = runAddToUnit(c, u, "data=modelscoped-block,1G")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(testing.Stdout(context), gc.Equals, "added \"data\"\n")
 	c.Assert(testing.Stderr(context), gc.Equals, "")

--- a/provider/dummy/storage.go
+++ b/provider/dummy/storage.go
@@ -4,10 +4,10 @@
 package dummy
 
 import (
-	"github.com/juju/juju/state/testing"
 	"github.com/juju/juju/storage"
+	dummystorage "github.com/juju/juju/storage/provider/dummy"
 )
 
 func StorageProviders() storage.ProviderRegistry {
-	return testing.StorageProviders()
+	return dummystorage.StorageProviders()
 }

--- a/state/allcollections.go
+++ b/state/allcollections.go
@@ -295,6 +295,8 @@ func allCollections() collectionSchema {
 		filesystemsC: {
 			indexes: []mgo.Index{{
 				Key: []string{"model-uuid", "storageid"},
+			}, {
+				Key: []string{"model-uuid", "machineid"},
 			}},
 		},
 		filesystemAttachmentsC: {},
@@ -313,6 +315,8 @@ func allCollections() collectionSchema {
 		volumesC: {
 			indexes: []mgo.Index{{
 				Key: []string{"model-uuid", "storageid"},
+			}, {
+				Key: []string{"model-uuid", "machineid"},
 			}},
 		},
 		volumeAttachmentsC: {},

--- a/state/cleanup.go
+++ b/state/cleanup.go
@@ -541,6 +541,12 @@ func cleanupDyingMachineResources(m *Machine) error {
 		return errors.Annotate(err, "getting machine volume attachments")
 	}
 	for _, va := range volumeAttachments {
+		if detachable, err := isDetachableVolumeTag(m.st, va.Volume()); err != nil {
+			return errors.Trace(err)
+		} else if !detachable {
+			// Non-detachable volumes will be removed along with the machine.
+			continue
+		}
 		if err := m.st.DetachVolume(va.Machine(), va.Volume()); err != nil {
 			if IsContainsFilesystem(err) {
 				// The volume will be destroyed when the
@@ -556,6 +562,12 @@ func cleanupDyingMachineResources(m *Machine) error {
 		return errors.Annotate(err, "getting machine filesystem attachments")
 	}
 	for _, fsa := range filesystemAttachments {
+		if detachable, err := isDetachableFilesystemTag(m.st, fsa.Filesystem()); err != nil {
+			return errors.Trace(err)
+		} else if !detachable {
+			// Non-detachable filesystems will be removed along with the machine.
+			continue
+		}
 		if err := m.st.DetachFilesystem(fsa.Machine(), fsa.Filesystem()); err != nil {
 			return errors.Trace(err)
 		}

--- a/state/filesystem.go
+++ b/state/filesystem.go
@@ -98,19 +98,22 @@ type filesystemAttachment struct {
 
 // filesystemDoc records information about a filesystem in the model.
 type filesystemDoc struct {
-	DocID        string `bson:"_id"`
-	FilesystemId string `bson:"filesystemid"`
-	ModelUUID    string `bson:"model-uuid"`
-	Life         Life   `bson:"life"`
-	StorageId    string `bson:"storageid,omitempty"`
-	VolumeId     string `bson:"volumeid,omitempty"`
-	// TODO(axw) 2015-06-22 #1467379
-	// upgrade step to set "attachmentcount" and "binding"
-	// for 1.24 models.
+	DocID           string            `bson:"_id"`
+	FilesystemId    string            `bson:"filesystemid"`
+	ModelUUID       string            `bson:"model-uuid"`
+	Life            Life              `bson:"life"`
+	StorageId       string            `bson:"storageid,omitempty"`
+	VolumeId        string            `bson:"volumeid,omitempty"`
 	AttachmentCount int               `bson:"attachmentcount"`
 	Binding         string            `bson:"binding,omitempty"`
 	Info            *FilesystemInfo   `bson:"info,omitempty"`
 	Params          *FilesystemParams `bson:"params,omitempty"`
+
+	// MachineId is the ID of the machine that a non-detachable
+	// volume is initially attached to. We use this to identify
+	// the volume as being non-detachable, and to determine
+	// which volumes must be removed along with said machine.
+	MachineId string `bson:"machineid,omitempty"`
 }
 
 // filesystemAttachmentDoc records information about a filesystem attachment.
@@ -439,67 +442,92 @@ func (st *State) filesystemAttachments(query bson.D) ([]FilesystemAttachment, er
 // removeMachineFilesystemsOps returns txn.Ops to remove non-persistent filesystems
 // attached to the specified machine. This is used when the given machine is
 // being removed from state.
-func (st *State) removeMachineFilesystemsOps(machine names.MachineTag) ([]txn.Op, error) {
-	attachments, err := st.MachineFilesystemAttachments(machine)
+func (st *State) removeMachineFilesystemsOps(m *Machine) ([]txn.Op, error) {
+	// A machine cannot transition to Dead if it has any detachable storage
+	// attached, so any attachments are for machine-bound storage.
+	//
+	// Even if a filesystem is "non-detachable", there still exist filesystem
+	// attachments, and they may be removed independently of the filesystem.
+	// For example, the user may request that the filesystem be destroyed.
+	// This will cause the filesystem to become Dying, and the attachment
+	// to be Dying, then Dead, and finally removed. Only once the attachment
+	// is removed will the filesystem transition to Dead and then be removed.
+	// Therefore, there may be filesystems that are bound, but not attached,
+	// to the machine.
+	machineFilesystems, err := st.filesystems(bson.D{{"machineid", m.Id()}})
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	ops := make([]txn.Op, 0, len(attachments))
-	for _, a := range attachments {
-		filesystemTag := a.Filesystem()
-		// When removing the machine, there should only remain
-		// non-persistent storage. This will be implicitly
-		// removed when the machine is removed, so we do not
-		// use removeFilesystemAttachmentOps or removeFilesystemOps,
-		// which track and update related documents.
+	ops := make([]txn.Op, 0, 2*len(machineFilesystems)+len(m.doc.Filesystems))
+	for _, filesystemId := range m.doc.Filesystems {
 		ops = append(ops, txn.Op{
 			C:      filesystemAttachmentsC,
-			Id:     filesystemAttachmentId(machine.Id(), filesystemTag.Id()),
+			Id:     filesystemAttachmentId(m.Id(), filesystemId),
 			Assert: txn.DocExists,
 			Remove: true,
 		})
-		canRemove, err := isFilesystemInherentlyMachineBound(st, filesystemTag)
-		if err != nil {
-			return nil, errors.Trace(err)
-		}
-		if !canRemove {
-			return nil, errors.Errorf("machine has non-machine bound filesystem %v", filesystemTag.Id())
-		}
+	}
+	for _, v := range machineFilesystems {
+		filesystemId := v.Tag().Id()
 		ops = append(ops,
 			txn.Op{
 				C:      filesystemsC,
-				Id:     filesystemTag.Id(),
+				Id:     filesystemId,
 				Assert: txn.DocExists,
 				Remove: true,
 			},
-			removeModelFilesystemRefOp(st, filesystemTag.Id()),
+			removeModelFilesystemRefOp(st, filesystemId),
 		)
 	}
 	return ops, nil
 }
 
-// isFilesystemInherentlyMachineBound reports whether or not the filesystem
-// with the specified tag is inherently bound to the lifetime of the machine,
-// and will be removed along with it, leaving no resources dangling.
-func isFilesystemInherentlyMachineBound(st *State, tag names.FilesystemTag) (bool, error) {
-	// TODO(axw) when we have support for persistent filesystems,
-	// e.g. NFS shares, then we need to check the filesystem info
-	// to decide whether or not to remove.
-	return true, nil
+// isDetachableFilesystemTag reports whether or not the filesystem with the
+// specified tag is detachable.
+func isDetachableFilesystemTag(st *State, tag names.FilesystemTag) (bool, error) {
+	f, err := st.filesystemByTag(tag)
+	if err != nil {
+		return false, errors.Trace(err)
+	}
+	return f.detachable(), nil
 }
 
-// isFilesystemParamsInherentlyMachineBound reports whether or not the given
-// filesystem params will create a filesystem inherently bound to the lifetime
-// of a machine, and will be removed along with it, leaving no resources dangling.
-func isFilesystemParamsInherentlyMachineBound(st *State, params FilesystemParams) (bool, error) {
-	// TODO(axw) when we have support for persistent filesystems,
-	// e.g. NFS shares, then we need to check the filesystem info
-	// to decide whether or not to remove.
+// detachable reports whether or not the filesystem is detachable.
+func (f *filesystem) detachable() bool {
+	return f.doc.MachineId == ""
+}
+
+// isDetachableFilesystemPool reports whether or not the given
+// storage pool will create a filesystem that is not inherently
+// bound to a machine, and therefore can be detached.
+func isDetachableFilesystemPool(st *State, pool string) (bool, error) {
+	_, provider, err := poolStorageProvider(st, pool)
+	if err != nil {
+		return false, errors.Trace(err)
+	}
+	if provider.Scope() == storage.ScopeMachine {
+		// Any storage created by a machine cannot be detached from
+		// the machine, and must be destroyed along with it.
+		return false, nil
+	}
+	if !provider.Dynamic() {
+		// The storage provider only accomodates provisioning storage
+		// statically along with the machine. Such storage is bound
+		// to the machine.
+		return false, nil
+	}
+	if !provider.Supports(storage.StorageKindFilesystem) {
+		// TODO(axw) remove this when volume-backed filesystems
+		// inherit the scope of the volume. For now, volume-backed
+		// filesystems are always machine-scoped.
+		return false, nil
+	}
 	return true, nil
 }
 
 // DetachFilesystem marks the filesystem attachment identified by the specified machine
-// and filesystem tags as Dying, if it is Alive.
+// and filesystem tags as Dying, if it is Alive. DetachFilesystem will fail for
+// inherently machine-bound filesystems.
 func (st *State) DetachFilesystem(machine names.MachineTag, filesystem names.FilesystemTag) (err error) {
 	defer errors.DeferredAnnotatef(&err, "detaching filesystem %s from machine %s", filesystem.Id(), machine.Id())
 	buildTxn := func(attempt int) ([]txn.Op, error) {
@@ -509,6 +537,13 @@ func (st *State) DetachFilesystem(machine names.MachineTag, filesystem names.Fil
 		}
 		if fsa.Life() != Alive {
 			return nil, jujutxn.ErrNoOperations
+		}
+		detachable, err := isDetachableFilesystemTag(st, filesystem)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		if !detachable {
+			return nil, errors.New("filesystem is not detachable")
 		}
 		ops := detachFilesystemOps(machine, filesystem)
 		return ops, nil
@@ -561,16 +596,26 @@ func (st *State) RemoveFilesystemAttachment(machine names.MachineTag, filesystem
 			return nil, errors.Trace(err)
 		}
 		ops := removeFilesystemAttachmentOps(machine, f)
-		// If the filesystem is backed by a volume, the volume
-		// attachment can and should be destroyed once the
-		// filesystem attachment is removed.
 		volumeAttachment, err := st.filesystemVolumeAttachment(machine, filesystem)
 		if err != nil {
 			if errors.Cause(err) != ErrNoBackingVolume && !errors.IsNotFound(err) {
 				return nil, errors.Trace(err)
 			}
-		} else if volumeAttachment.Life() == Alive {
-			ops = append(ops, detachVolumeOps(machine, volumeAttachment.Volume())...)
+		} else {
+			// The filesystem is backed by a volume. Since the
+			// filesystem has been detached, we should now
+			// detach the volume as well if it is detachable.
+			// If the volume is not detachable, we'll just
+			// destroy it along with the filesystem.
+			volume := volumeAttachment.Volume()
+			detachableVolume, err := isDetachableVolumeTag(st, volume)
+			if err != nil {
+				return nil, errors.Trace(err)
+			}
+			if detachableVolume {
+				volOps := detachVolumeOps(machine, volume)
+				ops = append(ops, volOps...)
+			}
 		}
 		return ops, nil
 	}
@@ -620,12 +665,12 @@ func (st *State) DestroyFilesystem(tag names.FilesystemTag) (err error) {
 			{{"storageid", ""}},
 			{{"storageid", bson.D{{"$exists", false}}}},
 		}}}
-		return destroyFilesystemOps(st, filesystem, hasNoStorageAssignment), nil
+		return destroyFilesystemOps(st, filesystem, hasNoStorageAssignment)
 	}
 	return st.run(buildTxn)
 }
 
-func destroyFilesystemOps(st *State, f *filesystem, extraAssert bson.D) []txn.Op {
+func destroyFilesystemOps(st *State, f *filesystem, extraAssert bson.D) ([]txn.Op, error) {
 	baseAssert := append(isAliveDoc, extraAssert...)
 	if f.doc.AttachmentCount == 0 {
 		hasNoAttachments := bson.D{{"attachmentcount", 0}}
@@ -634,16 +679,42 @@ func destroyFilesystemOps(st *State, f *filesystem, extraAssert bson.D) []txn.Op
 			Id:     f.doc.FilesystemId,
 			Assert: append(hasNoAttachments, baseAssert...),
 			Update: bson.D{{"$set", bson.D{{"life", Dead}}}},
-		}}
+		}}, nil
 	}
 	hasAttachments := bson.D{{"attachmentcount", bson.D{{"$gt", 0}}}}
-	cleanupOp := newCleanupOp(cleanupAttachmentsForDyingFilesystem, f.doc.FilesystemId)
-	return []txn.Op{{
+	ops := []txn.Op{{
 		C:      filesystemsC,
 		Id:     f.doc.FilesystemId,
 		Assert: append(hasAttachments, baseAssert...),
 		Update: bson.D{{"$set", bson.D{{"life", Dying}}}},
-	}, cleanupOp}
+	}}
+	if !f.detachable() {
+		// This filesystem cannot be directly detached, so we do
+		// not issue a cleanup. Since there can (should!) be only
+		// one attachment for the lifetime of the filesystem, we
+		// can look it up and destroy it along with the filesystem.
+		attachments, err := st.FilesystemAttachments(f.FilesystemTag())
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		if len(attachments) != 1 {
+			return nil, errors.Errorf(
+				"expected 1 attachment, found %d",
+				len(attachments),
+			)
+		}
+		detachOps := detachFilesystemOps(
+			attachments[0].Machine(),
+			f.FilesystemTag(),
+		)
+		ops = append(ops, detachOps...)
+	} else {
+		ops = append(ops, newCleanupOp(
+			cleanupAttachmentsForDyingFilesystem,
+			f.doc.FilesystemId,
+		))
+	}
+	return ops, nil
 }
 
 // RemoveFilesystem removes the filesystem from state. RemoveFilesystem will
@@ -680,7 +751,8 @@ func removeFilesystemOps(st *State, filesystem Filesystem) ([]txn.Op, error) {
 	}
 	// If the filesystem is backed by a volume, the volume should
 	// be destroyed once the filesystem is removed if it is bound
-	// to the filesystem.
+	// to the filesystem. The volume must not be destroyed before
+	// the filesystem is removed.
 	volumeTag, err := filesystem.Volume()
 	if err == nil {
 		volume, err := st.volumeByTag(volumeTag)
@@ -688,7 +760,11 @@ func removeFilesystemOps(st *State, filesystem Filesystem) ([]txn.Op, error) {
 			return nil, errors.Trace(err)
 		}
 		if volume.LifeBinding() == filesystem.Tag() {
-			ops = append(ops, destroyVolumeOps(st, volume, nil)...)
+			volOps, err := destroyVolumeOps(st, volume, nil)
+			if err != nil {
+				return nil, errors.Trace(err)
+			}
+			ops = append(ops, volOps...)
 		}
 	} else if err != ErrNoBackingVolume {
 		return nil, errors.Trace(err)
@@ -745,6 +821,18 @@ func (st *State) addFilesystemOps(params FilesystemParams, machineId string) ([]
 	if err != nil {
 		return nil, names.FilesystemTag{}, names.VolumeTag{}, errors.Trace(err)
 	}
+	detachable, err := isDetachableFilesystemPool(st, params.Pool)
+	if err != nil {
+		return nil, names.FilesystemTag{}, names.VolumeTag{}, errors.Trace(err)
+	}
+	if params.binding == nil {
+		if detachable {
+			params.binding = st.ModelTag()
+		} else {
+			params.binding = names.NewMachineTag(machineId)
+		}
+	}
+	origMachineId := machineId
 	machineId, err = st.validateFilesystemParams(params, machineId)
 	if err != nil {
 		return nil, names.FilesystemTag{}, names.VolumeTag{}, errors.Annotate(err, "validating filesystem params")
@@ -793,6 +881,9 @@ func (st *State) addFilesystemOps(params FilesystemParams, machineId string) ([]
 		// Every filesystem is created with one attachment.
 		AttachmentCount: 1,
 	}
+	if !detachable {
+		doc.MachineId = origMachineId
+	}
 	ops = append(ops, st.newFilesystemOps(doc, status)...)
 	return ops, filesystemTag, volumeTag, nil
 }
@@ -825,17 +916,6 @@ func (st *State) filesystemParamsWithDefaults(params FilesystemParams, machineId
 			return FilesystemParams{}, errors.Annotate(err, "getting default filesystem storage pool")
 		}
 		params.Pool = poolName
-	}
-	if params.binding == nil {
-		machineBound, err := isFilesystemParamsInherentlyMachineBound(st, params)
-		if err != nil {
-			return FilesystemParams{}, errors.Trace(err)
-		}
-		if machineBound {
-			params.binding = names.NewMachineTag(machineId)
-		} else {
-			params.binding = st.ModelTag()
-		}
 	}
 	return params, nil
 }

--- a/state/internal_test.go
+++ b/state/internal_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/juju/juju/mongo"
 	"github.com/juju/juju/mongo/mongotest"
 	"github.com/juju/juju/storage"
-	"github.com/juju/juju/storage/provider"
+	"github.com/juju/juju/storage/provider/dummy"
 	"github.com/juju/juju/testing"
 )
 
@@ -72,7 +72,7 @@ func (s *internalStateSuite) SetUpTest(c *gc.C) {
 			CloudRegion:             "dummy-region",
 			Owner:                   s.owner,
 			Config:                  modelCfg,
-			StorageProviderRegistry: provider.CommonStorageProviders(),
+			StorageProviderRegistry: dummy.StorageProviders(),
 		},
 		Cloud: cloud.Cloud{
 			Name:      "dummy",
@@ -111,7 +111,7 @@ func (s *internalStateSuite) newState(c *gc.C) *State {
 		CloudRegion: "dummy-region",
 		Config:      cfg,
 		Owner:       s.owner,
-		StorageProviderRegistry: storage.StaticProviderRegistry{},
+		StorageProviderRegistry: dummy.StorageProviders(),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	s.AddCleanup(func(*gc.C) { st.Close() })
@@ -137,7 +137,7 @@ func (internalStatePolicy) InstanceDistributor() (instance.Distributor, error) {
 }
 
 func (internalStatePolicy) StorageProviderRegistry() (storage.ProviderRegistry, error) {
-	return provider.CommonStorageProviders(), nil
+	return dummy.StorageProviders(), nil
 }
 
 func (internalStatePolicy) ProviderConfigSchemaSource() (config.ConfigSchemaSource, error) {

--- a/state/machine.go
+++ b/state/machine.go
@@ -729,7 +729,7 @@ func (original *Machine) advanceLifecycle(life Life) (err error) {
 
 		if life == Dead {
 			// A machine may not become Dead until it has no more
-			// attachments to inherently machine-bound storage.
+			// attachments to detachable storage.
 			storageAsserts, err := m.assertNoPersistentStorage()
 			if err != nil {
 				return nil, errors.Trace(err)
@@ -754,21 +754,21 @@ func (m *Machine) assertNoPersistentStorage() (bson.D, error) {
 	attachments := make(set.Tags)
 	for _, v := range m.doc.Volumes {
 		tag := names.NewVolumeTag(v)
-		machineBound, err := isVolumeInherentlyMachineBound(m.st, tag)
+		detachable, err := isDetachableVolumeTag(m.st, tag)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
-		if !machineBound {
+		if detachable {
 			attachments.Add(tag)
 		}
 	}
 	for _, f := range m.doc.Filesystems {
 		tag := names.NewFilesystemTag(f)
-		machineBound, err := isFilesystemInherentlyMachineBound(m.st, tag)
+		detachable, err := isDetachableFilesystemTag(m.st, tag)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
-		if !machineBound {
+		if detachable {
 			attachments.Add(tag)
 		}
 	}
@@ -861,11 +861,11 @@ func (m *Machine) removeOps() ([]txn.Op, error) {
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	filesystemOps, err := m.st.removeMachineFilesystemsOps(m.MachineTag())
+	filesystemOps, err := m.st.removeMachineFilesystemsOps(m)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	volumeOps, err := m.st.removeMachineVolumesOps(m.MachineTag())
+	volumeOps, err := m.st.removeMachineVolumesOps(m)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/state/migration_import.go
+++ b/state/migration_import.go
@@ -1385,6 +1385,9 @@ func (i *importer) constraints(cons description.Constraints) constraints.Value {
 }
 
 func (i *importer) storage() error {
+	if err := i.storagePools(); err != nil {
+		return errors.Annotate(err, "storage pools")
+	}
 	if err := i.storageInstances(); err != nil {
 		return errors.Annotate(err, "storage instances")
 	}
@@ -1393,9 +1396,6 @@ func (i *importer) storage() error {
 	}
 	if err := i.filesystems(); err != nil {
 		return errors.Annotate(err, "filesystems")
-	}
-	if err := i.storagePools(); err != nil {
-		return errors.Annotate(err, "storage pools")
 	}
 	return nil
 }
@@ -1507,6 +1507,11 @@ func (i *importer) addVolume(volume description.Volume) error {
 		Info:            info,
 		AttachmentCount: len(attachments),
 	}
+	if detachable, err := isDetachableVolumePool(i.st, volume.Pool()); err != nil {
+		return errors.Trace(err)
+	} else if !detachable && len(attachments) == 1 {
+		doc.MachineId = attachments[0].Machine().Id()
+	}
 	status := i.makeStatusDoc(volume.Status())
 	ops := i.st.newVolumeOps(doc, status)
 
@@ -1602,6 +1607,11 @@ func (i *importer) addFilesystem(filesystem description.Filesystem) error {
 		Params:          params,
 		Info:            info,
 		AttachmentCount: len(attachments),
+	}
+	if detachable, err := isDetachableFilesystemPool(i.st, filesystem.Pool()); err != nil {
+		return errors.Trace(err)
+	} else if !detachable && len(attachments) == 1 {
+		doc.MachineId = attachments[0].Machine().Id()
 	}
 	status := i.makeStatusDoc(filesystem.Status())
 	ops := i.st.newFilesystemOps(doc, status)

--- a/state/migration_internal_test.go
+++ b/state/migration_internal_test.go
@@ -677,6 +677,7 @@ func (s *MigrationSuite) TestVolumeDocFields(c *gc.C) {
 		"ModelUUID",
 		"DocID",
 		"Life",
+		"MachineId", // recreated from pool properties
 	)
 	migrated := set.NewStrings(
 		"Name",
@@ -719,6 +720,7 @@ func (s *MigrationSuite) TestFilesystemDocFields(c *gc.C) {
 		"ModelUUID",
 		"DocID",
 		"Life",
+		"MachineId", // recreated from pool properties
 	)
 	migrated := set.NewStrings(
 		"FilesystemId",

--- a/state/model_test.go
+++ b/state/model_test.go
@@ -673,7 +673,7 @@ func (s *ModelSuite) TestProcessDyingModelWithVolumeBackedFilesystems(c *gc.C) {
 		Jobs:   []state.MachineJob{state.JobHostUnits},
 		Filesystems: []state.MachineFilesystemParams{{
 			Filesystem: state.FilesystemParams{
-				Pool: "environscoped-block",
+				Pool: "modelscoped-block",
 				Size: 123,
 			},
 		}},
@@ -685,7 +685,7 @@ func (s *ModelSuite) TestProcessDyingModelWithVolumeBackedFilesystems(c *gc.C) {
 	c.Assert(filesystems, gc.HasLen, 1)
 
 	c.Assert(model.Destroy(), jc.ErrorIsNil)
-	err = st.DetachFilesystem(machine.MachineTag(), names.NewFilesystemTag("0/0"))
+	err = st.DestroyFilesystem(names.NewFilesystemTag("0/0"))
 	c.Assert(err, jc.ErrorIsNil)
 	err = st.RemoveFilesystemAttachment(machine.MachineTag(), names.NewFilesystemTag("0/0"))
 	c.Assert(err, jc.ErrorIsNil)
@@ -714,7 +714,7 @@ func (s *ModelSuite) TestProcessDyingModelWithVolumes(c *gc.C) {
 		Jobs:   []state.MachineJob{state.JobHostUnits},
 		Volumes: []state.MachineVolumeParams{{
 			Volume: state.VolumeParams{
-				Pool: "environscoped",
+				Pool: "modelscoped",
 				Size: 123,
 			},
 		}},

--- a/state/status_filesystem_test.go
+++ b/state/status_filesystem_test.go
@@ -28,7 +28,7 @@ func (s *FilesystemStatusSuite) SetUpTest(c *gc.C) {
 		Jobs:   []state.MachineJob{state.JobHostUnits},
 		Filesystems: []state.MachineFilesystemParams{{
 			Filesystem: state.FilesystemParams{
-				Pool: "environscoped", Size: 1024,
+				Pool: "modelscoped", Size: 1024,
 			},
 		}},
 	})

--- a/state/status_volume_test.go
+++ b/state/status_volume_test.go
@@ -28,7 +28,7 @@ func (s *VolumeStatusSuite) SetUpTest(c *gc.C) {
 		Jobs:   []state.MachineJob{state.JobHostUnits},
 		Volumes: []state.MachineVolumeParams{{
 			Volume: state.VolumeParams{
-				Pool: "environscoped", Size: 1024,
+				Pool: "modelscoped", Size: 1024,
 			},
 		}},
 	})

--- a/state/storage.go
+++ b/state/storage.go
@@ -320,7 +320,11 @@ func removeStorageInstanceOps(
 			volumesC, volume.Tag().Id(),
 		))
 		if volume.LifeBinding() == tag {
-			ops = append(ops, destroyVolumeOps(st, volume, nil)...)
+			volOps, err := destroyVolumeOps(st, volume, nil)
+			if err != nil {
+				return nil, errors.Trace(err)
+			}
+			ops = append(ops, volOps...)
 		}
 	} else if !errors.IsNotFound(err) {
 		return nil, errors.Trace(err)
@@ -331,7 +335,11 @@ func removeStorageInstanceOps(
 			filesystemsC, filesystem.Tag().Id(),
 		))
 		if filesystem.LifeBinding() == tag {
-			ops = append(ops, destroyFilesystemOps(st, filesystem, nil)...)
+			fsOps, err := destroyFilesystemOps(st, filesystem, nil)
+			if err != nil {
+				return nil, errors.Trace(err)
+			}
+			ops = append(ops, fsOps...)
 		}
 	} else if !errors.IsNotFound(err) {
 		return nil, errors.Trace(err)

--- a/state/storage_test.go
+++ b/state/storage_test.go
@@ -38,7 +38,7 @@ func (s *StorageStateSuiteBase) SetUpTest(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Create a pool that creates persistent block devices.
-	_, err = pm.Create("persistent-block", "environscoped-block", map[string]interface{}{
+	_, err = pm.Create("persistent-block", "modelscoped-block", map[string]interface{}{
 		"persistent": true,
 	})
 	c.Assert(err, jc.ErrorIsNil)
@@ -97,7 +97,7 @@ storage:
 
 func (s *StorageStateSuiteBase) setupMixedScopeStorageService(c *gc.C, kind string) *state.Application {
 	storageCons := map[string]state.StorageConstraints{
-		"multi1to10": makeStorageCons("environscoped", 1024, 1),
+		"multi1to10": makeStorageCons("modelscoped", 1024, 1),
 		"multi2up":   makeStorageCons("machinescoped", 2048, 2),
 	}
 	ch := s.AddTestingCharm(c, "storage-"+kind+"2")

--- a/state/testing/conn.go
+++ b/state/testing/conn.go
@@ -15,8 +15,6 @@ import (
 	"github.com/juju/juju/mongo"
 	"github.com/juju/juju/mongo/mongotest"
 	"github.com/juju/juju/state"
-	"github.com/juju/juju/storage"
-	"github.com/juju/juju/storage/provider"
 	dummystorage "github.com/juju/juju/storage/provider/dummy"
 	"github.com/juju/juju/testing"
 )
@@ -65,7 +63,7 @@ func InitializeWithArgs(c *gc.C, args InitializeArgs) *state.State {
 			CloudRegion: "dummy-region",
 			Config:      args.InitialConfig,
 			Owner:       args.Owner,
-			StorageProviderRegistry: StorageProviders(),
+			StorageProviderRegistry: dummystorage.StorageProviders(),
 		},
 		ControllerInheritedConfig: args.ControllerInheritedConfig,
 		Cloud: cloud.Cloud{
@@ -100,32 +98,6 @@ func InitializeWithArgs(c *gc.C, args InitializeArgs) *state.State {
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	return st
-}
-
-func StorageProviders() storage.ProviderRegistry {
-	return storage.ChainedProviderRegistry{
-		storage.StaticProviderRegistry{
-			map[storage.ProviderType]storage.Provider{
-				"static": &dummystorage.StorageProvider{IsDynamic: false},
-				"environscoped": &dummystorage.StorageProvider{
-					StorageScope: storage.ScopeEnviron,
-					IsDynamic:    true,
-				},
-				"environscoped-block": &dummystorage.StorageProvider{
-					StorageScope: storage.ScopeEnviron,
-					IsDynamic:    true,
-					SupportsFunc: func(k storage.StorageKind) bool {
-						return k == storage.StorageKindBlock
-					},
-				},
-				"machinescoped": &dummystorage.StorageProvider{
-					StorageScope: storage.ScopeMachine,
-					IsDynamic:    true,
-				},
-			},
-		},
-		provider.CommonStorageProviders(),
-	}
 }
 
 // NewMongoInfo returns information suitable for

--- a/state/upgrades_test.go
+++ b/state/upgrades_test.go
@@ -730,3 +730,133 @@ func (s *upgradesSuite) TestUpgradeNoProxy(c *gc.C) {
 		expectUpgradedData{settingsColl, expectedSettings},
 	)
 }
+
+func (s *upgradesSuite) TestAddNonDetachableStorageMachineId(c *gc.C) {
+	volumesColl, volumesCloser := s.state.getRawCollection(volumesC)
+	defer volumesCloser()
+	volumeAttachmentsColl, volumeAttachmentsCloser := s.state.getRawCollection(volumeAttachmentsC)
+	defer volumeAttachmentsCloser()
+
+	filesystemsColl, filesystemsCloser := s.state.getRawCollection(filesystemsC)
+	defer filesystemsCloser()
+	filesystemAttachmentsColl, filesystemAttachmentsCloser := s.state.getRawCollection(filesystemAttachmentsC)
+	defer filesystemAttachmentsCloser()
+
+	uuid := s.state.ModelUUID()
+
+	err := volumesColl.Insert(bson.M{
+		"_id":        uuid + ":0",
+		"name":       "0",
+		"model-uuid": uuid,
+		"machineid":  "42",
+	}, bson.M{
+		"_id":        uuid + ":1",
+		"name":       "1",
+		"model-uuid": uuid,
+		"info": bson.M{
+			"pool": "modelscoped",
+		},
+	}, bson.M{
+		"_id":        uuid + ":2",
+		"name":       "2",
+		"model-uuid": uuid,
+		"params": bson.M{
+			"pool": "static",
+		},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = volumeAttachmentsColl.Insert(bson.M{
+		"_id":        uuid + ":123:2",
+		"model-uuid": uuid,
+		"machineid":  "123",
+		"volumeid":   "2",
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = filesystemsColl.Insert(bson.M{
+		"_id":          uuid + ":0",
+		"filesystemid": "0",
+		"model-uuid":   uuid,
+		"machineid":    "42",
+	}, bson.M{
+		"_id":          uuid + ":1",
+		"filesystemid": "1",
+		"model-uuid":   uuid,
+		"info": bson.M{
+			"pool": "modelscoped",
+		},
+	}, bson.M{
+		"_id":          uuid + ":2",
+		"filesystemid": "2",
+		"model-uuid":   uuid,
+		"params": bson.M{
+			"pool": "static",
+		},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = filesystemAttachmentsColl.Insert(bson.M{
+		"_id":          uuid + ":123:2",
+		"model-uuid":   uuid,
+		"machineid":    "123",
+		"filesystemid": "2",
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	// We expect that:
+	//  - volume-0 and filesystem-0 are unchanged, since they
+	//    already have machineid fields
+	//  - volume-1 and filesystem-1 are unchanged, since they
+	//    are detachable
+	//  - volume-2's and filesystem-2's machineid fields are
+	//    set to 123, the machine to which they are inherently
+	//    bound
+	expectedVolumes := []bson.M{{
+		"_id":        uuid + ":0",
+		"name":       "0",
+		"model-uuid": uuid,
+		"machineid":  "42",
+	}, {
+		"_id":        uuid + ":1",
+		"name":       "1",
+		"model-uuid": uuid,
+		"info": bson.M{
+			"pool": "modelscoped",
+		},
+	}, {
+		"_id":        uuid + ":2",
+		"name":       "2",
+		"model-uuid": uuid,
+		"params": bson.M{
+			"pool": "static",
+		},
+		"machineid": "123",
+	}}
+	expectedFilesystems := []bson.M{{
+		"_id":          uuid + ":0",
+		"filesystemid": "0",
+		"model-uuid":   uuid,
+		"machineid":    "42",
+	}, {
+		"_id":          uuid + ":1",
+		"filesystemid": "1",
+		"model-uuid":   uuid,
+		"info": bson.M{
+			"pool": "modelscoped",
+		},
+	}, {
+		"_id":          uuid + ":2",
+		"filesystemid": "2",
+		"model-uuid":   uuid,
+		"params": bson.M{
+			"pool": "static",
+		},
+		"machineid": "123",
+	}}
+
+	s.assertUpgradedData(c, AddNonDetachableStorageMachineId,
+		expectUpgradedData{volumesColl, expectedVolumes},
+		expectUpgradedData{filesystemsColl, expectedFilesystems},
+	)
+}

--- a/state/volume.go
+++ b/state/volume.go
@@ -91,6 +91,12 @@ type volumeDoc struct {
 	Binding         string        `bson:"binding,omitempty"`
 	Info            *VolumeInfo   `bson:"info,omitempty"`
 	Params          *VolumeParams `bson:"params,omitempty"`
+
+	// MachineId is the ID of the machine that a non-detachable
+	// volume is initially attached to. We use this to identify
+	// the volume as being non-detachable, and to determine
+	// which volumes must be removed along with said machine.
+	MachineId string `bson:"machineid,omitempty"`
 }
 
 // volumeAttachmentDoc records information about a volume attachment.
@@ -404,78 +410,76 @@ func IsContainsFilesystem(err error) bool {
 }
 
 // removeMachineVolumesOps returns txn.Ops to remove non-persistent volumes
-// attached to the specified machine. This is used when the given machine is
-// being removed from state.
-func (st *State) removeMachineVolumesOps(machine names.MachineTag) ([]txn.Op, error) {
-	attachments, err := st.MachineVolumeAttachments(machine)
+// bound or attached to the specified machine. This is used when the given
+// machine is being removed from state.
+func (st *State) removeMachineVolumesOps(m *Machine) ([]txn.Op, error) {
+	// A machine cannot transition to Dead if it has any detachable storage
+	// attached, so any attachments are for machine-bound storage.
+	//
+	// Even if a volume is "non-detachable", there still exist volume
+	// attachments, and they may be removed independently of the volume.
+	// For example, the user may request that the volume be destroyed.
+	// This will cause the volume to become Dying, and the attachment to
+	// be Dying, then Dead, and finally removed. Only once the attachment
+	// is removed will the volume transition to Dead and then be removed.
+	// Therefore, there may be volumes that are bound, but not attached,
+	// to the machine.
+
+	machineVolumes, err := st.volumes(bson.D{{"machineid", m.Id()}})
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	ops := make([]txn.Op, 0, len(attachments))
-	for _, a := range attachments {
-		volumeTag := a.Volume()
-		// When removing the machine, there should only remain
-		// non-persistent storage. This will be implicitly
-		// removed when the machine is removed, so we do not
-		// use removeVolumeAttachmentOps or removeVolumeOps,
-		// which track and update related documents.
+	ops := make([]txn.Op, 0, 2*len(machineVolumes)+len(m.doc.Volumes))
+	for _, volumeId := range m.doc.Volumes {
 		ops = append(ops, txn.Op{
 			C:      volumeAttachmentsC,
-			Id:     volumeAttachmentId(machine.Id(), volumeTag.Id()),
+			Id:     volumeAttachmentId(m.Id(), volumeId),
 			Assert: txn.DocExists,
 			Remove: true,
 		})
-		canRemove, err := isVolumeInherentlyMachineBound(st, volumeTag)
-		if err != nil {
-			return nil, errors.Trace(err)
-		}
-		if !canRemove {
-			return nil, errors.Errorf("machine has non-machine bound volume %v", volumeTag.Id())
-		}
+	}
+	for _, v := range machineVolumes {
+		volumeId := v.Tag().Id()
 		ops = append(ops,
 			txn.Op{
 				C:      volumesC,
-				Id:     volumeTag.Id(),
+				Id:     volumeId,
 				Assert: txn.DocExists,
 				Remove: true,
 			},
-			removeModelVolumeRefOp(st, volumeTag.Id()),
+			removeModelVolumeRefOp(st, volumeId),
 		)
 	}
 	return ops, nil
 }
 
-// isVolumeInherentlyMachineBound reports whether or not the volume with the
-// specified tag is inherently bound to the lifetime of the machine, and will
-// be removed along with it, leaving no resources dangling.
-func isVolumeInherentlyMachineBound(st *State, tag names.VolumeTag) (bool, error) {
-	volume, err := st.Volume(tag)
+// isDetachableVolumeTag reports whether or not the volume with the specified
+// tag is detachable.
+func isDetachableVolumeTag(st *State, tag names.VolumeTag) (bool, error) {
+	volume, err := st.volumeByTag(tag)
 	if err != nil {
 		return false, errors.Trace(err)
 	}
-	volumeInfo, err := volume.Info()
-	if errors.IsNotProvisioned(err) {
-		params, _ := volume.Params()
-		return isVolumeParamsInherentlyMachineBound(st, params)
-	} else if err != nil {
-		return false, errors.Trace(err)
-	}
-	// If volume does not outlive machine it can be removed.
-	return !volumeInfo.Persistent, nil
+	return volume.detachable(), nil
 }
 
-// isVolumeParamsInherentlyMachineBound reports whether or not the given volume
-// params will create a volume inherently bound to the lifetime of a machine,
-// and will be removed along with it, leaving no resources dangling.
-func isVolumeParamsInherentlyMachineBound(st *State, params VolumeParams) (bool, error) {
-	_, provider, err := poolStorageProvider(st, params.Pool)
+// detachable reports whether or not the volume is detachable.
+func (v *volume) detachable() bool {
+	return v.doc.MachineId == ""
+}
+
+// isDetachableVolumePool reports whether or not the given storage
+// pool will create a volume that is not inherently bound to a machine,
+// and therefore can be detached.
+func isDetachableVolumePool(st *State, pool string) (bool, error) {
+	_, provider, err := poolStorageProvider(st, pool)
 	if err != nil {
 		return false, errors.Trace(err)
 	}
 	if provider.Scope() == storage.ScopeMachine {
-		// Any storage created by a machine must be destroyed
-		// along with the machine.
-		return true, nil
+		// Any storage created by a machine cannot be detached from
+		// the machine, and must be destroyed along with it.
+		return false, nil
 	}
 	if provider.Dynamic() {
 		// NOTE(axw) In theory, we don't know ahead of time
@@ -487,16 +491,17 @@ func isVolumeParamsInherentlyMachineBound(st *State, params VolumeParams) (bool,
 		// TODO(axw) get rid of the Persistent field from Volume
 		// and Filesystem. We only need to care whether the
 		// storage is dynamic and model-scoped.
-		return false, nil
+		return true, nil
 	}
 	// Volume is static, so it will be tied to the machine.
-	return true, nil
+	return false, nil
 }
 
 // DetachVolume marks the volume attachment identified by the specified machine
 // and volume tags as Dying, if it is Alive. DetachVolume will fail with a
 // IsContainsFilesystem error if the volume contains an attached filesystem; the
-// filesystem attachment must be removed first.
+// filesystem attachment must be removed first. DetachVolume will fail for
+// inherently machine-bound volumes.
 func (st *State) DetachVolume(machine names.MachineTag, volume names.VolumeTag) (err error) {
 	defer errors.DeferredAnnotatef(&err, "detaching volume %s from machine %s", volume.Id(), machine.Id())
 	// If the volume is backing a filesystem, the volume cannot be detached
@@ -513,6 +518,13 @@ func (st *State) DetachVolume(machine names.MachineTag, volume names.VolumeTag) 
 		}
 		if va.Life() != Alive {
 			return nil, jujutxn.ErrNoOperations
+		}
+		detachable, err := isDetachableVolumeTag(st, volume)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		if !detachable {
+			return nil, errors.New("volume is not detachable")
 		}
 		return detachVolumeOps(machine, volume), nil
 	}
@@ -680,12 +692,12 @@ func (st *State) DestroyVolume(tag names.VolumeTag) (err error) {
 			{{"storageid", ""}},
 			{{"storageid", bson.D{{"$exists", false}}}},
 		}}}
-		return destroyVolumeOps(st, volume, hasNoStorageAssignment), nil
+		return destroyVolumeOps(st, volume, hasNoStorageAssignment)
 	}
 	return st.run(buildTxn)
 }
 
-func destroyVolumeOps(st *State, v *volume, extraAssert bson.D) []txn.Op {
+func destroyVolumeOps(st *State, v *volume, extraAssert bson.D) ([]txn.Op, error) {
 	baseAssert := append(isAliveDoc, extraAssert...)
 	if v.doc.AttachmentCount == 0 {
 		hasNoAttachments := bson.D{{"attachmentcount", 0}}
@@ -694,16 +706,42 @@ func destroyVolumeOps(st *State, v *volume, extraAssert bson.D) []txn.Op {
 			Id:     v.doc.Name,
 			Assert: append(hasNoAttachments, baseAssert...),
 			Update: bson.D{{"$set", bson.D{{"life", Dead}}}},
-		}}
+		}}, nil
 	}
-	cleanupOp := newCleanupOp(cleanupAttachmentsForDyingVolume, v.doc.Name)
 	hasAttachments := bson.D{{"attachmentcount", bson.D{{"$gt", 0}}}}
-	return []txn.Op{{
+	ops := []txn.Op{{
 		C:      volumesC,
 		Id:     v.doc.Name,
 		Assert: append(hasAttachments, baseAssert...),
 		Update: bson.D{{"$set", bson.D{{"life", Dying}}}},
-	}, cleanupOp}
+	}}
+	if !v.detachable() {
+		// This volume cannot be directly detached, so we do not
+		// issue a cleanup. Since there can (should!) be only one
+		// attachment for the lifetime of the filesystem, we can
+		// look it up and destroy it along with the filesystem.
+		attachments, err := st.VolumeAttachments(v.VolumeTag())
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		if len(attachments) != 1 {
+			return nil, errors.Errorf(
+				"expected 1 attachment, found %d",
+				len(attachments),
+			)
+		}
+		detachOps := detachVolumeOps(
+			attachments[0].Machine(),
+			v.VolumeTag(),
+		)
+		ops = append(ops, detachOps...)
+	} else {
+		ops = append(ops, newCleanupOp(
+			cleanupAttachmentsForDyingVolume,
+			v.doc.Name,
+		))
+	}
+	return ops, nil
 }
 
 // RemoveVolume removes the volume from state. RemoveVolume will fail if
@@ -759,6 +797,18 @@ func (st *State) addVolumeOps(params VolumeParams, machineId string) ([]txn.Op, 
 	if err != nil {
 		return nil, names.VolumeTag{}, errors.Trace(err)
 	}
+	detachable, err := isDetachableVolumePool(st, params.Pool)
+	if err != nil {
+		return nil, names.VolumeTag{}, errors.Trace(err)
+	}
+	if params.binding == nil {
+		if detachable {
+			params.binding = st.ModelTag()
+		} else {
+			params.binding = names.NewMachineTag(machineId)
+		}
+	}
+	origMachineId := machineId
 	machineId, err = st.validateVolumeParams(params, machineId)
 	if err != nil {
 		return nil, names.VolumeTag{}, errors.Annotate(err, "validating volume params")
@@ -778,6 +828,9 @@ func (st *State) addVolumeOps(params VolumeParams, machineId string) ([]txn.Op, 
 		Params:    &params,
 		// Every volume is created with one attachment.
 		AttachmentCount: 1,
+	}
+	if !detachable {
+		doc.MachineId = origMachineId
 	}
 	return st.newVolumeOps(doc, status), names.NewVolumeTag(name), nil
 }
@@ -811,17 +864,6 @@ func (st *State) volumeParamsWithDefaults(params VolumeParams, machineId string)
 			return VolumeParams{}, errors.Annotate(err, "getting default block storage pool")
 		}
 		params.Pool = poolName
-	}
-	if params.binding == nil {
-		machineBound, err := isVolumeParamsInherentlyMachineBound(st, params)
-		if err != nil {
-			return VolumeParams{}, errors.Trace(err)
-		}
-		if machineBound {
-			params.binding = names.NewMachineTag(machineId)
-		} else {
-			params.binding = st.ModelTag()
-		}
 	}
 	return params, nil
 }

--- a/storage/provider/dummy/common.go
+++ b/storage/provider/dummy/common.go
@@ -1,0 +1,37 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package dummy
+
+import (
+	"github.com/juju/juju/storage"
+	"github.com/juju/juju/storage/provider"
+)
+
+// StorageProviders returns a provider registry with some
+// well-defined dummy storage providers.
+func StorageProviders() storage.ProviderRegistry {
+	return storage.ChainedProviderRegistry{
+		storage.StaticProviderRegistry{
+			map[storage.ProviderType]storage.Provider{
+				"static": &StorageProvider{IsDynamic: false},
+				"modelscoped": &StorageProvider{
+					StorageScope: storage.ScopeEnviron,
+					IsDynamic:    true,
+				},
+				"modelscoped-block": &StorageProvider{
+					StorageScope: storage.ScopeEnviron,
+					IsDynamic:    true,
+					SupportsFunc: func(k storage.StorageKind) bool {
+						return k == storage.StorageKindBlock
+					},
+				},
+				"machinescoped": &StorageProvider{
+					StorageScope: storage.ScopeMachine,
+					IsDynamic:    true,
+				},
+			},
+		},
+		provider.CommonStorageProviders(),
+	}
+}

--- a/upgrades/backend.go
+++ b/upgrades/backend.go
@@ -23,6 +23,7 @@ type StateBackend interface {
 	AddLocalCharmSequences() error
 	UpdateLegacyLXDCloudCredentials(string, cloud.Credential) error
 	UpgradeNoProxyDefaults() error
+	AddNonDetachableStorageMachineId() error
 }
 
 // Model is an interface providing access to the details of a model within the
@@ -79,6 +80,10 @@ func (s stateBackend) UpdateLegacyLXDCloudCredentials(endpoint string, credentia
 
 func (s stateBackend) UpgradeNoProxyDefaults() error {
 	return state.UpgradeNoProxyDefaults(s.st)
+}
+
+func (s stateBackend) AddNonDetachableStorageMachineId() error {
+	return state.AddNonDetachableStorageMachineId(s.st)
 }
 
 type modelShim struct {

--- a/upgrades/operations.go
+++ b/upgrades/operations.go
@@ -20,6 +20,7 @@ var stateUpgradeOperations = func() []Operation {
 	steps := []Operation{
 		upgradeToVersion{version.MustParse("2.0.0"), stateStepsFor20()},
 		upgradeToVersion{version.MustParse("2.1.0"), stateStepsFor21()},
+		upgradeToVersion{version.MustParse("2.2.0"), stateStepsFor22()},
 	}
 	return steps
 }

--- a/upgrades/steps_22.go
+++ b/upgrades/steps_22.go
@@ -1,0 +1,17 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package upgrades
+
+// stateStepsFor22 returns upgrade steps for Juju 2.2 that manipulate state directly.
+func stateStepsFor22() []Step {
+	return []Step{
+		&upgradeStep{
+			description: "add machineid to non-detachable storage docs",
+			targets:     []Target{DatabaseMaster},
+			run: func(context Context) error {
+				return context.State().AddNonDetachableStorageMachineId()
+			},
+		},
+	}
+}

--- a/upgrades/steps_22_test.go
+++ b/upgrades/steps_22_test.go
@@ -1,0 +1,27 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package upgrades_test
+
+import (
+	jc "github.com/juju/testing/checkers"
+	"github.com/juju/version"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/testing"
+	"github.com/juju/juju/upgrades"
+)
+
+var v220 = version.MustParse("2.2.0")
+
+type steps22Suite struct {
+	testing.BaseSuite
+}
+
+var _ = gc.Suite(&steps22Suite{})
+
+func (s *steps22Suite) TestAddNonDetachableStorageMachineId(c *gc.C) {
+	step := findStateStep(c, v220, "add machineid to non-detachable storage docs")
+	// Logic for step itself is tested in state package.
+	c.Assert(step.Targets(), jc.DeepEquals, []upgrades.Target{upgrades.DatabaseMaster})
+}

--- a/upgrades/upgrade_test.go
+++ b/upgrades/upgrade_test.go
@@ -714,6 +714,7 @@ func (s *upgradeSuite) TestStateUpgradeOperationsVersions(c *gc.C) {
 	c.Assert(versions, gc.DeepEquals, []string{
 		"2.0.0",
 		"2.1.0",
+		"2.2.0",
 	})
 }
 

--- a/worker/uniter/runner/context/unitStorage_test.go
+++ b/worker/uniter/runner/context/unitStorage_test.go
@@ -138,7 +138,7 @@ func setupTestStorageSupport(c *gc.C, s *state.State) {
 	poolManager := poolmanager.New(stsetts, dummy.StorageProviders())
 	_, err := poolManager.Create(testPool, provider.LoopProviderType, map[string]interface{}{"it": "works"})
 	c.Assert(err, jc.ErrorIsNil)
-	_, err = poolManager.Create(testPersistentPool, "environscoped", map[string]interface{}{"persistent": true})
+	_, err = poolManager.Create(testPersistentPool, "modelscoped", map[string]interface{}{"persistent": true})
 	c.Assert(err, jc.ErrorIsNil)
 }
 


### PR DESCRIPTION
## Description of change

We were previously relying on a combination of kludges to
get non-detachable machine storage to be removed along
with a machine. Due to recent changes to expose more of
storage (i.e.g for removal and detachment, etc.), machine
storage stopped getting removed along with the machine.

For "non-detachable" storage, the one-and-only attachment
may still be destroyed and removed independently of the
volume/filesystem. For example, if you destroy a unit on
a machine, and the unit has a "loop" volume, then the
volume will be marked Dying when the unit is destroyed.
That will cascade and mark the volume attachment as
Dying; the volume will be detached, at which point the
volume attachment is removed from the model. At this
point there is no association remaining between the machine
and the volume.

To fix this, we now record the ID of the machine to which
a volume or filesystem is inherently bound (if it is at all)
on the volume/filesystem document. We can then immediately
identify all volumes/filesystems that are inherently bound to
a machine when the machine is to be removed from state,
and remove them as well. We also use this to identify whether
the storage is detachable in various parts.

## QA steps

**SCENARIO 1**
1. juju bootstrap localhost
2. juju deploy postgresql --storage pgdata=rootfs
(wait for unit to become idle)
3. juju remove-application postgresql
(wait for unit to be removed)
4. confirm there is no storage remaining

**SCENARIO 2**
As above, but migrate the model to another controller
between steps 2 and 3.

**SCENARIO 3**
Run the "assess_storage.py" test from juju-ci-tools.

## Documentation changes

None.

## Bug reference

https://bugs.launchpad.net/bugs/1667883