### PR TITLE
When adding a remote relation, the remote app may already exist so lo…

### DIFF
--- a/state/remoteapplication.go
+++ b/state/remoteapplication.go
@@ -322,7 +322,7 @@ func (s *RemoteApplication) AddEndpoints(eps []charm.Relation) error {
 		}
 		for _, r := range eps {
 			if currentEndpointNames.Contains(r.Name) {
-				return errors.Errorf("conflicting endpoint %v", r.Name)
+				return errors.AlreadyExistsf("endpoint %v", r.Name)
 			}
 		}
 		return nil
@@ -341,6 +341,9 @@ func (s *RemoteApplication) AddEndpoints(eps []charm.Relation) error {
 		// model may have been destroyed.
 		if attempt > 0 {
 			if err := checkModelActive(s.st); err != nil {
+				return nil, errors.Trace(err)
+			}
+			if err = s.Refresh(); err != nil {
 				return nil, errors.Trace(err)
 			}
 			currentEndpoints, err = s.Endpoints()

--- a/state/remoteapplication.go
+++ b/state/remoteapplication.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/juju/errors"
 	jujutxn "github.com/juju/txn"
+	"github.com/juju/utils/set"
 	"gopkg.in/juju/charm.v6-unstable"
 	"gopkg.in/juju/names.v2"
 	"gopkg.in/mgo.v2"
@@ -288,6 +289,92 @@ func (s *RemoteApplication) Endpoint(relationName string) (Endpoint, error) {
 		}
 	}
 	return Endpoint{}, fmt.Errorf("remote application %q has no %q relation", s, relationName)
+}
+
+// AddEndpoints adds the specified endpoints to the remote application.
+// If an endpoint with the same name already exists, an error is returned.
+// If the endpoints change during the update, the operation is retried.
+func (s *RemoteApplication) AddEndpoints(eps []charm.Relation) error {
+	newEps := make([]remoteEndpointDoc, len(eps))
+	for i, ep := range eps {
+		newEps[i] = remoteEndpointDoc{
+			Name:      ep.Name,
+			Role:      ep.Role,
+			Interface: ep.Interface,
+			Limit:     ep.Limit,
+			Scope:     ep.Scope,
+		}
+	}
+
+	model, err := s.st.Model()
+	if err != nil {
+		return errors.Trace(err)
+	} else if model.Life() != Alive {
+		return errors.Errorf("model is no longer alive")
+	}
+
+	checkCompatibleEndpoints := func(currentEndpoints []Endpoint) error {
+		// Ensure there are no current endpoints with the same name as
+		// any of those we want to update.
+		currentEndpointNames := set.NewStrings()
+		for _, ep := range currentEndpoints {
+			currentEndpointNames.Add(ep.Name)
+		}
+		for _, r := range eps {
+			if currentEndpointNames.Contains(r.Name) {
+				return errors.Errorf("conflicting endpoint %v", r.Name)
+			}
+		}
+		return nil
+	}
+
+	currentEndpoints, err := s.Endpoints()
+	if err != nil {
+		return errors.Trace(err)
+	}
+	if err := checkCompatibleEndpoints(currentEndpoints); err != nil {
+		return err
+	}
+	applicationID := s.st.docID(s.Name())
+	buildTxn := func(attempt int) ([]txn.Op, error) {
+		// If we've tried once already and failed, check that
+		// model may have been destroyed.
+		if attempt > 0 {
+			if err := checkModelActive(s.st); err != nil {
+				return nil, errors.Trace(err)
+			}
+			currentEndpoints, err = s.Endpoints()
+			if err != nil {
+				return nil, errors.Trace(err)
+			}
+			if err := checkCompatibleEndpoints(currentEndpoints); err != nil {
+				return nil, err
+			}
+		}
+		ops := []txn.Op{
+			model.assertActiveOp(),
+			{
+				C:  remoteApplicationsC,
+				Id: applicationID,
+				Assert: bson.D{
+					{"endpoints", bson.D{{
+						"$not", bson.D{{
+							"$elemMatch", bson.D{{
+								"$in", newEps}},
+						}},
+					}}},
+				},
+				Update: bson.D{
+					{"$addToSet", bson.D{{"endpoints", bson.D{{"$each", newEps}}}}},
+				},
+			},
+		}
+		return ops, nil
+	}
+	if err := s.st.run(buildTxn); err != nil {
+		return errors.Trace(err)
+	}
+	return s.Refresh()
 }
 
 // String returns the application name.

--- a/state/remoteapplication_test.go
+++ b/state/remoteapplication_test.go
@@ -303,9 +303,6 @@ func (s *remoteApplicationSuite) TestAddEndpoints(c *gc.C) {
 	err = foo.AddEndpoints(newEps)
 	c.Assert(err, jc.ErrorIsNil)
 
-	eps, err := foo.Endpoints()
-	c.Assert(err, jc.ErrorIsNil)
-
 	var expected []state.Endpoint
 	for _, r := range origEps {
 		expected = append(expected, state.Endpoint{ApplicationName: "foo", Relation: r})
@@ -313,7 +310,16 @@ func (s *remoteApplicationSuite) TestAddEndpoints(c *gc.C) {
 	for _, r := range newEps {
 		expected = append(expected, state.Endpoint{ApplicationName: "foo", Relation: r})
 	}
-	c.Assert(eps, jc.SameContents, expected)
+
+	// Test results without and then with refresh.
+	for i := 0; i < 2; i++ {
+		eps, err := foo.Endpoints()
+		c.Assert(err, jc.ErrorIsNil)
+		c.Assert(eps, jc.SameContents, expected)
+
+		err = foo.Refresh()
+		c.Assert(err, jc.ErrorIsNil)
+	}
 }
 
 func (s *remoteApplicationSuite) TestAddEndpointsConflicting(c *gc.C) {
@@ -332,7 +338,62 @@ func (s *remoteApplicationSuite) TestAddEndpointsConflicting(c *gc.C) {
 		{Name: "ep4", Role: charm.RoleProvider, Scope: charm.ScopeGlobal, Limit: 1},
 	}
 	err = foo.AddEndpoints(newEps)
-	c.Assert(err, gc.ErrorMatches, "conflicting endpoint ep1")
+	c.Assert(err, jc.Satisfies, errors.IsAlreadyExists)
+	c.Assert(err, gc.ErrorMatches, "endpoint ep1 already exists")
+}
+
+func (s *remoteApplicationSuite) TestAddEndpointsConcurrentOneDeleted(c *gc.C) {
+	origEps := []charm.Relation{
+		{Name: "ep1", Role: charm.RoleRequirer, Scope: charm.ScopeGlobal, Limit: 1},
+		{Name: "ep2", Role: charm.RoleProvider, Scope: charm.ScopeGlobal, Limit: 1},
+	}
+	foo, err := s.State.AddRemoteApplication(state.AddRemoteApplicationParams{
+		Name: "foo", OfferName: "bar", URL: "local:/u/me/foo", SourceModel: s.State.ModelTag(),
+		Endpoints: origEps,
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	reducedEps := []charm.Relation{
+		{Name: "ep1", Role: charm.RoleRequirer, Scope: charm.ScopeGlobal, Limit: 1},
+	}
+	defer state.SetBeforeHooks(c, s.State, func() {
+		// Destroy foo and recreate with fewer endpoints to simulate
+		// endpoint removal.
+		err := foo.Destroy()
+		c.Assert(err, jc.ErrorIsNil)
+		_, err = s.State.AddRemoteApplication(state.AddRemoteApplicationParams{
+			Name: "foo", OfferName: "bar", URL: "local:/u/me/foo", SourceModel: s.State.ModelTag(),
+			Endpoints: reducedEps,
+		})
+		c.Assert(err, jc.ErrorIsNil)
+	}).Check()
+
+	newEps := []charm.Relation{
+		{Name: "ep3", Role: charm.RoleRequirer, Scope: charm.ScopeGlobal, Limit: 1},
+		{Name: "ep4", Role: charm.RoleProvider, Scope: charm.ScopeGlobal, Limit: 1},
+	}
+	err = foo.Refresh()
+	c.Assert(err, jc.ErrorIsNil)
+	err = foo.AddEndpoints(newEps)
+	c.Assert(err, jc.ErrorIsNil)
+
+	var expected []state.Endpoint
+	for _, r := range reducedEps {
+		expected = append(expected, state.Endpoint{ApplicationName: "foo", Relation: r})
+	}
+	for _, r := range newEps {
+		expected = append(expected, state.Endpoint{ApplicationName: "foo", Relation: r})
+	}
+
+	// Test results without and then with refresh.
+	for i := 0; i < 2; i++ {
+		eps, err := foo.Endpoints()
+		c.Assert(err, jc.ErrorIsNil)
+		c.Assert(eps, jc.SameContents, expected)
+
+		err = foo.Refresh()
+		c.Assert(err, jc.ErrorIsNil)
+	}
 }
 
 func (s *remoteApplicationSuite) TestAddEndpointsConcurrentConflictingOneAdded(c *gc.C) {
@@ -350,7 +411,9 @@ func (s *remoteApplicationSuite) TestAddEndpointsConcurrentConflictingOneAdded(c
 		newEps := []charm.Relation{
 			{Name: "ep3", Role: charm.RoleRequirer, Scope: charm.ScopeGlobal, Limit: 1},
 		}
-		err = foo.AddEndpoints(newEps)
+		app, err := s.State.RemoteApplication("foo")
+		c.Assert(err, jc.ErrorIsNil)
+		err = app.AddEndpoints(newEps)
 		c.Assert(err, jc.ErrorIsNil)
 	}).Check()
 
@@ -359,7 +422,8 @@ func (s *remoteApplicationSuite) TestAddEndpointsConcurrentConflictingOneAdded(c
 		{Name: "ep4", Role: charm.RoleProvider, Scope: charm.ScopeGlobal, Limit: 1},
 	}
 	err = foo.AddEndpoints(newEps)
-	c.Assert(err, gc.ErrorMatches, "conflicting endpoint ep3")
+	c.Assert(err, jc.Satisfies, errors.IsAlreadyExists)
+	c.Assert(err, gc.ErrorMatches, "endpoint ep3 already exists")
 }
 
 func (s *remoteApplicationSuite) TestAddEndpointsConcurrentDifferentOneAdded(c *gc.C) {
@@ -377,7 +441,9 @@ func (s *remoteApplicationSuite) TestAddEndpointsConcurrentDifferentOneAdded(c *
 		{Name: "ep5", Role: charm.RoleRequirer, Scope: charm.ScopeGlobal, Limit: 1},
 	}
 	defer state.SetBeforeHooks(c, s.State, func() {
-		err = foo.AddEndpoints(concurrrentEps)
+		app, err := s.State.RemoteApplication("foo")
+		c.Assert(err, jc.ErrorIsNil)
+		err = app.AddEndpoints(concurrrentEps)
 		c.Assert(err, jc.ErrorIsNil)
 	}).Check()
 
@@ -386,9 +452,6 @@ func (s *remoteApplicationSuite) TestAddEndpointsConcurrentDifferentOneAdded(c *
 		{Name: "ep4", Role: charm.RoleProvider, Scope: charm.ScopeGlobal, Limit: 1},
 	}
 	err = foo.AddEndpoints(newEps)
-	c.Assert(err, jc.ErrorIsNil)
-
-	eps, err := foo.Endpoints()
 	c.Assert(err, jc.ErrorIsNil)
 
 	var expected []state.Endpoint
@@ -401,7 +464,16 @@ func (s *remoteApplicationSuite) TestAddEndpointsConcurrentDifferentOneAdded(c *
 	for _, r := range concurrrentEps {
 		expected = append(expected, state.Endpoint{ApplicationName: "foo", Relation: r})
 	}
-	c.Assert(eps, jc.SameContents, expected)
+
+	// Test results without and then with refresh.
+	for i := 0; i < 2; i++ {
+		eps, err := foo.Endpoints()
+		c.Assert(err, jc.ErrorIsNil)
+		c.Assert(eps, jc.SameContents, expected)
+
+		err = foo.Refresh()
+		c.Assert(err, jc.ErrorIsNil)
+	}
 }
 
 func (s *remoteApplicationSuite) TestAddRemoteRelationWrongScope(c *gc.C) {


### PR DESCRIPTION
## Description of change

If an attempt is made to consume the same remote app twice, or create a remote relation where the remote app already exists from a consume step or previous relation, it now reuses that existing remote app proxy rather than failing with an already exists error.

## QA steps

bootstrap
create 2 models
deploy 2 apps
create remote relation
remove remote relation
create relation again (previously errored)
consume other model app (previously errored)