### PR TITLE
Fixes regression for application settings with nil values.

### DIFF
--- a/state/application.go
+++ b/state/application.go
@@ -1727,9 +1727,7 @@ type addApplicationOpsArgs struct {
 // applications collection, along with all the associated expected other application
 // entries. This method is used by both the *State.AddApplication method and the
 // migration import code.
-func addApplicationOps(st *State, args addApplicationOpsArgs) ([]txn.Op, error) {
-	app := newApplication(st, args.applicationDoc)
-
+func addApplicationOps(st *State, app *Application, args addApplicationOpsArgs) ([]txn.Op, error) {
 	charmRefOps, err := appCharmIncRefOps(st, args.applicationDoc.Name, args.applicationDoc.CharmURL, true)
 	if err != nil {
 		return nil, errors.Trace(err)

--- a/state/export_test.go
+++ b/state/export_test.go
@@ -636,3 +636,9 @@ func AssertNoCleanups(c *gc.C, st *State, kind cleanupKind) {
 		}
 	}
 }
+
+// GetApplicationSettings allows access to settings collection for a
+// given application.
+func GetApplicationSettings(st *State, app *Application) *Settings {
+	return newSettings(st, settingsC, app.settingsKey())
+}

--- a/state/migration_import.go
+++ b/state/migration_import.go
@@ -697,7 +697,14 @@ func (i *importer) application(a description.Application) error {
 	statusDoc := i.makeStatusDoc(status)
 	// TODO: update never set malarky... maybe...
 
-	ops, err := addApplicationOps(i.st, addApplicationOpsArgs{
+	// When creating the settings, we ignore nils.  In other circumstances, nil
+	// means to delete the value (reset to default), so creating with nil should
+	// mean to use the default, i.e. don't set the value.
+	// There may have existed some applications with settings that contained
+	// nil values, see lp#1667199. When importing, we want these stripped.
+	removeNils(a.Settings())
+
+	ops, err := addApplicationOps(i.st, app, addApplicationOpsArgs{
 		applicationDoc:     appDoc,
 		statusDoc:          statusDoc,
 		constraints:        i.constraints(a.Constraints()),

--- a/state/unit.go
+++ b/state/unit.go
@@ -130,7 +130,9 @@ func (u *Unit) ConfigSettings() (charm.Settings, error) {
 	}
 	result := chrm.Config().DefaultSettings()
 	for name, value := range settings.Map() {
-		result[name] = value
+		if value != nil {
+			result[name] = value
+		}
 	}
 	return result, nil
 }

--- a/state/unit_test.go
+++ b/state/unit_test.go
@@ -71,6 +71,22 @@ func (s *UnitSuite) TestConfigSettingsIncludeDefaults(c *gc.C) {
 	c.Assert(settings, gc.DeepEquals, charm.Settings{"blog-title": "My Title"})
 }
 
+func (s *UnitSuite) TestConfigSettingsNilTrumpedByDefaults(c *gc.C) {
+	err := s.unit.SetCharmURL(s.charm.URL())
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Should never happen again; was happening because of lp#1667199
+	settings := state.GetApplicationSettings(s.State, s.service)
+	settings.Set("blog-title", nil)
+	_, err = settings.Write()
+	c.Assert(err, jc.ErrorIsNil)
+
+	unitSettings, err := s.unit.ConfigSettings()
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Assert(unitSettings, gc.DeepEquals, charm.Settings{"blog-title": "My Title"})
+}
+
 func (s *UnitSuite) TestConfigSettingsReflectService(c *gc.C) {
 	err := s.service.UpdateConfigSettings(charm.Settings{"blog-title": "no title"})
 	c.Assert(err, jc.ErrorIsNil)


### PR DESCRIPTION
## Description of change

With the move to Juju 2.x a regression in behavior was introduced:
a user could deploy an application with custom config where setting values are nil. This is an undesirable behavior as nil values have special meaning on settings update - we delete them.

The fallout from this was that when we read application settings, especially as a result of "config-get", these settings were omitted altogether instead of falling back to charm default values.

This PR does 3 things:
1. Re-introduce lost removal of settings with nil values when an application is added.
2. During migration import, remove application settings with nil values to ensure that in new world application only has settings that actually overwrite charm default values.
3. When reading unit settings, which are essentially application settings, allow charm default values to overwrite nil values.

## QA steps
(as per bug linked below)
1. bootstrap a controller
2. deploy an application with custom config where some settings have nil values. I've used cs:trusty/apache2-20 application with config.yaml:
apache2:
    ssl_cert: 
    ssl_certlocation: 
    ssl_key: 
    ssl_keylocation: 
    ssl_chain: 
    ssl_chainlocation: 
3. Verify that config-get has these settings in the list with default values. 'juju run --application apache2 "config-get"'
4. I have also logged into MongoDB on the controller and verified that settings collection does not have these settings for apache2 application. 

## Documentation changes

@juju/docs It may be worthwhile to call out that in order to overwrite charm settings default an empty string should be used, not nil.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1667199
