### PR TITLE
Upgrade step for applications with nil value settings.

### DIFF
--- a/state/unit.go
+++ b/state/unit.go
@@ -130,9 +130,7 @@ func (u *Unit) ConfigSettings() (charm.Settings, error) {
 	}
 	result := chrm.Config().DefaultSettings()
 	for name, value := range settings.Map() {
-		if value != nil {
-			result[name] = value
-		}
+		result[name] = value
 	}
 	return result, nil
 }

--- a/state/unit_test.go
+++ b/state/unit_test.go
@@ -71,22 +71,6 @@ func (s *UnitSuite) TestConfigSettingsIncludeDefaults(c *gc.C) {
 	c.Assert(settings, gc.DeepEquals, charm.Settings{"blog-title": "My Title"})
 }
 
-func (s *UnitSuite) TestConfigSettingsNilTrumpedByDefaults(c *gc.C) {
-	err := s.unit.SetCharmURL(s.charm.URL())
-	c.Assert(err, jc.ErrorIsNil)
-
-	// Should never happen again; was happening because of lp#1667199
-	settings := state.GetApplicationSettings(s.State, s.service)
-	settings.Set("blog-title", nil)
-	_, err = settings.Write()
-	c.Assert(err, jc.ErrorIsNil)
-
-	unitSettings, err := s.unit.ConfigSettings()
-	c.Assert(err, jc.ErrorIsNil)
-
-	c.Assert(unitSettings, gc.DeepEquals, charm.Settings{"blog-title": "My Title"})
-}
-
 func (s *UnitSuite) TestConfigSettingsReflectService(c *gc.C) {
 	err := s.service.UpdateConfigSettings(charm.Settings{"blog-title": "no title"})
 	c.Assert(err, jc.ErrorIsNil)

--- a/upgrades/backend.go
+++ b/upgrades/backend.go
@@ -5,6 +5,7 @@ package upgrades
 
 import (
 	"github.com/juju/errors"
+
 	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/config"
@@ -24,6 +25,7 @@ type StateBackend interface {
 	UpdateLegacyLXDCloudCredentials(string, cloud.Credential) error
 	UpgradeNoProxyDefaults() error
 	AddNonDetachableStorageMachineId() error
+	RemoveNilValueApplicationSettings() error
 }
 
 // Model is an interface providing access to the details of a model within the
@@ -84,6 +86,10 @@ func (s stateBackend) UpgradeNoProxyDefaults() error {
 
 func (s stateBackend) AddNonDetachableStorageMachineId() error {
 	return state.AddNonDetachableStorageMachineId(s.st)
+}
+
+func (s stateBackend) RemoveNilValueApplicationSettings() error {
+	return state.RemoveNilValueApplicationSettings(s.st)
 }
 
 type modelShim struct {

--- a/upgrades/steps_22.go
+++ b/upgrades/steps_22.go
@@ -13,5 +13,12 @@ func stateStepsFor22() []Step {
 				return context.State().AddNonDetachableStorageMachineId()
 			},
 		},
+		&upgradeStep{
+			description: "remove application config settings with nil value",
+			targets:     []Target{DatabaseMaster},
+			run: func(context Context) error {
+				return context.State().RemoveNilValueApplicationSettings()
+			},
+		},
 	}
 }


### PR DESCRIPTION
## Description of change

A regression from Juju 1.25 introduced a possibility of deploying application with custom config settings with nil values. 
This PR ensures that going forward, these applications settings are stripped during the upgrade to 2.2.x

## QA steps

1. bootstrap in Juju 2.0.x or 2.1.x
2. deploy application with custom config where some settings are nil
3. upgrade to Juju 2.2.x
4. Applications should not have settings with nil values in the database


## Bug reference

Fallow-up to a fix for https://bugs.launchpad.net/bugs/1667199
