### PR TITLE
[api test] Wait longer for messages

### DIFF
--- a/api/pubsub/pubsub_test.go
+++ b/api/pubsub/pubsub_test.go
@@ -215,7 +215,7 @@ func (s *PubSubIntegrationSuite) TestMessages(c *gc.C) {
 	select {
 	case <-done:
 		// messages received
-	case <-time.After(coretesting.ShortWait):
+	case <-time.After(coretesting.LongWait):
 		c.Fatal("messages not received")
 	}
 	c.Assert(messages, jc.DeepEquals, []map[string]interface{}{first, second})

--- a/apiserver/pubsub_test.go
+++ b/apiserver/pubsub_test.go
@@ -141,13 +141,13 @@ func (s *pubsubSuite) TestMessage(c *gc.C) {
 
 	select {
 	case <-done:
-	case <-time.After(coretesting.ShortWait):
+	case <-time.After(coretesting.LongWait):
 		c.Fatalf("no first message")
 	}
 
 	select {
 	case <-done:
-	case <-time.After(coretesting.ShortWait):
+	case <-time.After(coretesting.LongWait):
 		c.Fatalf("no second message")
 	}
 

--- a/pubsub/centralhub/centralhub_test.go
+++ b/pubsub/centralhub/centralhub_test.go
@@ -22,7 +22,7 @@ var _ = gc.Suite(&CentralHubSuite{})
 func (*CentralHubSuite) waitForSubscribers(c *gc.C, done <-chan struct{}) {
 	select {
 	case <-done:
-	case <-time.After(testing.ShortWait):
+	case <-time.After(testing.LongWait):
 		c.Fatal("subscribers not finished")
 	}
 }


### PR DESCRIPTION
## Description of change

https://bugs.launchpad.net/juju/+bug/1669209 indicates that sometimes on windows 50ms is not long enough to wait for the messages to flow. Setting the max time to wait to LongWait. Since those timeouts indicate general failure, and are backstops, this will not slow down any successful test runs.

## QA steps

go test ./...

## Documentation changes

No change.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1669209