### PR TITLE
Add index for migration of status history values.

### DIFF
--- a/state/allcollections.go
+++ b/state/allcollections.go
@@ -378,6 +378,8 @@ func allCollections() collectionSchema {
 			rawAccess: true,
 			indexes: []mgo.Index{{
 				Key: []string{"model-uuid", "globalkey", "updated"},
+			}, {
+				Key: []string{"model-uuid", "-updated"}, // used for migration
 			}},
 		},
 


### PR DESCRIPTION
## Description of change

In larger controllers, the statuses history collection gets too large for simple sorting queries.

## QA steps

Tested with blahdeblah interactively in a 2.1 branch.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1668646