### PR TITLE
run-action --wait

### DIFF
--- a/cmd/juju/action/run.go
+++ b/cmd/juju/action/run.go
@@ -1,4 +1,4 @@
-// Copyright 2014, 2015 Canonical Ltd.
+// Copyright 2014-2017 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
 package action
@@ -34,8 +34,7 @@ type runCommand struct {
 	actionName   string
 	paramsYAML   cmd.FileVar
 	parseStrings bool
-	wait         bool
-	timeout      time.Duration
+	wait         waitFlag
 	out          cmd.Output
 	args         [][]string
 }
@@ -58,6 +57,16 @@ If --params is passed, along with key.key...=value explicit arguments, the
 explicit arguments will override the parameter file.
 
 Examples:
+
+$ juju run-action mysql/3 backup --wait
+action-id: <ID>
+result:
+  status: success
+  file:
+    size: 873.2
+    units: GB
+    name: foo.sql
+
 
 $ juju run-action mysql/3 backup 
 action: <ID>
@@ -118,9 +127,7 @@ func (c *runCommand) SetFlags(f *gnuflag.FlagSet) {
 	c.out.AddFlags(f, "yaml", output.DefaultFormatters)
 	f.Var(&c.paramsYAML, "params", "Path to yaml-formatted params file")
 	f.BoolVar(&c.parseStrings, "string-args", false, "Use raw string values of CLI args")
-	f.BoolVar(&c.wait, "wait", false, "Wait for results")
-	f.DurationVar(&c.timeout, "timeout", time.Duration(0),
-		"Timeout waiting for results")
+	f.Var(&c.wait, "wait", "Wait for results, with optional timeout")
 }
 
 func (c *runCommand) Info() *cmd.Info {
@@ -266,7 +273,7 @@ func (c *runCommand) Run(ctx *cmd.Context) error {
 		return err
 	}
 
-	if !c.wait && c.timeout.Nanoseconds() <= 0 {
+	if !c.wait.forever && c.wait.d.Nanoseconds() <= 0 {
 		// Immediate return. This is the default, although rarely
 		// what cli users want. We should consider changing this
 		// default with Juju 3.0.
@@ -275,12 +282,12 @@ func (c *runCommand) Run(ctx *cmd.Context) error {
 	}
 
 	var wait *time.Timer
-	if c.timeout.Nanoseconds() <= 0 {
+	if c.wait.d.Nanoseconds() <= 0 {
 		// Indefinite wait. Discard the tick.
 		wait = time.NewTimer(0 * time.Second)
 		_ = <-wait.C
 	} else {
-		wait = time.NewTimer(c.timeout)
+		wait = time.NewTimer(c.wait.d)
 	}
 
 	result, err = GetActionResult(api, tag.Id(), wait)

--- a/cmd/juju/action/waitflag.go
+++ b/cmd/juju/action/waitflag.go
@@ -1,0 +1,47 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package action
+
+import (
+	"time"
+)
+
+// A gnuflag.Value for the --wait command line argument. If called
+// as a boolean  with no arguments, the forever flag is set to true.
+// If called  with an argument, d is set to the result of
+// time.ParseDuration().
+// eg:
+//   --wait
+//   --wait=10s
+type waitFlag struct {
+	forever bool
+	d       time.Duration
+}
+
+func (f *waitFlag) Set(s string) error {
+	if s == "true" {
+		f.forever = true
+		return nil
+	}
+	v, err := time.ParseDuration(s)
+	if err != nil {
+		return err
+	}
+	f.d = v
+	return nil
+}
+
+func (f *waitFlag) String() string {
+	if f.forever {
+		return "true"
+	}
+	if f.d == 0 {
+		return ""
+	}
+	return f.d.String()
+}
+
+func (f *waitFlag) IsBoolFlag() bool {
+	return true
+}


### PR DESCRIPTION
## Description of change

Actions will remain generally unused until the command line user experience is better than the alternatives 'juju run' or 'juju ssh'. This branch adds a --wait option to the 'run-action', allowing run-action it to be effectively used from the command line, rather than the current cumbersome approach of needing to run two separate commands and cutting and pasting the action-id between them. ~A --timeout option was also added, as in many automation situations we can't wait indefinitely for a result and should terminate and flag the error. The timeout was not combined with the '--wait' flag, as this would have made the most common use case of 'juju run-action --wait' to wait indefinitely to  become more cumbersome and require a timeout to be specified like 'juju run-action --wait=-1s'.~

https://bugs.launchpad.net/bugs/1445066 for history.

## QA steps

The following should two commands should return the same action results. The second (new) invocation method will have an additional action-id key in the results.

```
juju run-action unit/1 some-action
juju show-action-output <action-id> --wait=0
```

```
juju run-action unit/1 some-action --wait
```

Similarly, the following will behave equivalently (1ns timeout should always trigger timeout):

```
juju run-action unit/1 some-action
juju show-action-output <action-id> --wait=1ns
```

```
juju run-action unit/1 some-action --wait=1ns
```

## Documentation changes

Existing documentation needs to be adjusted, ideally preferring the new --wait example. Command line examples using the  run-action/show-action-output sequence are cumbersome and put people off.

## Bug reference

https://bugs.launchpad.net/bugs/1445066

