### PR TITLE
Use random seed for lxd ips

### DIFF
--- a/container/lxd/initialisation_linux.go
+++ b/container/lxd/initialisation_linux.go
@@ -379,6 +379,7 @@ func findNextAvailableIPv4Subnet() (string, error) {
 		}
 		if !collides {
 			return fmt.Sprintf("%d", i), nil
+
 		}
 	}
 	return "", errors.New("could not find unused subnet")

--- a/container/lxd/initialisation_linux.go
+++ b/container/lxd/initialisation_linux.go
@@ -15,6 +15,7 @@ import (
 	"os/exec"
 	"strings"
 	"syscall"
+	"time"
 
 	"github.com/juju/errors"
 	"github.com/juju/utils/packaging/config"
@@ -303,7 +304,10 @@ func ensureDependencies(series string) error {
 }
 
 // randomizedOctetRange is a variable for testing purposes.
-var randomizedOctetRange = func() []int { return rand.Perm(255) }
+var randomizedOctetRange = func() []int {
+	rand.Seed(time.Now().UnixNano())
+	return rand.Perm(255)
+}
 
 // getKnownV4IPsAndCIDRs iterates all of the known Addresses on this machine
 // and groups them up into known CIDRs and IP addresses.
@@ -379,7 +383,6 @@ func findNextAvailableIPv4Subnet() (string, error) {
 		}
 		if !collides {
 			return fmt.Sprintf("%d", i), nil
-
 		}
 	}
 	return "", errors.New("could not find unused subnet")


### PR DESCRIPTION
## Description of change

The method that chooses LXD IPs was using an unseeded random which produces deterministic results.
A time based seed was added.

## QA steps

Bootstrap a couple of times and ipv4 subnets for containers should differ.

