### PR TITLE
2.1 into develop

### DIFF
--- a/apiserver/machine/machiner.go
+++ b/apiserver/machine/machiner.go
@@ -140,6 +140,10 @@ func (api *MachinerAPI) Jobs(args params.Entities) (params.JobsResults, error) {
 }
 
 func (api *MachinerAPI) SetObservedNetworkConfig(args params.SetMachineNetworkConfig) error {
+	// TODO(jam): 2017-03-02 This is a copy of the content of
+	// Provisioner.SetObservedNetworkConfig, either refactor the code to make them
+	// the same, or keep them in sync.
+	// https://bugs.launchpad.net/juju/+bug/1669397
 	m, err := api.getMachineForSettingNetworkConfig(args.Tag)
 	if err != nil {
 		return errors.Trace(err)
@@ -150,13 +154,13 @@ func (api *MachinerAPI) SetObservedNetworkConfig(args params.SetMachineNetworkCo
 	observedConfig := args.Config
 	logger.Tracef("observed network config of machine %q: %+v", m.Id(), observedConfig)
 	if len(observedConfig) == 0 {
-		logger.Infof("not updating machine network config: no observed network config found")
+		logger.Infof("not updating machine %q network config: no observed network config found", m.Id())
 		return nil
 	}
 
 	providerConfig, err := api.getOneMachineProviderNetworkConfig(m)
 	if errors.IsNotProvisioned(err) {
-		logger.Infof("not updating provider network config: %v", err)
+		logger.Infof("not updating machine %q network config: %v", m.Id(), err)
 		return nil
 	}
 	if err != nil {
@@ -165,7 +169,7 @@ func (api *MachinerAPI) SetObservedNetworkConfig(args params.SetMachineNetworkCo
 	finalConfig := observedConfig
 	if len(providerConfig) != 0 {
 		finalConfig = networkingcommon.MergeProviderAndObservedNetworkConfigs(providerConfig, observedConfig)
-		logger.Tracef("merged observed and provider network config: %+v", finalConfig)
+		logger.Tracef("merged observed and provider network config for machine %q: %+v", m.Id(), finalConfig)
 	}
 
 	return api.setOneMachineNetworkConfig(m, finalConfig)

--- a/container/lxd/initialisation_linux.go
+++ b/container/lxd/initialisation_linux.go
@@ -9,16 +9,19 @@ import (
 	"bytes"
 	"fmt"
 	"io/ioutil"
+	"math/rand"
 	"net"
 	"os"
 	"os/exec"
 	"strings"
 	"syscall"
+	"time"
 
 	"github.com/juju/errors"
 	"github.com/juju/utils/packaging/config"
 	"github.com/juju/utils/packaging/manager"
 	"github.com/juju/utils/proxy"
+	"github.com/juju/utils/set"
 	"github.com/lxc/lxd/shared"
 
 	"github.com/juju/juju/container"
@@ -163,10 +166,17 @@ var configureLXDBridge = func() error {
 		return errors.Trace(err)
 	}
 
+	// If LXD itself supports managing networks (added in LXD 2.3) we can allow
+	// it to do all of the network configuration.
 	if shared.StringInSlice("network", status.APIExtensions) {
 		return lxdclient.CreateDefaultBridgeInDefaultProfile(client)
 	}
+	return configureLXDBridgeForOlderLXD()
+}
 
+// configureLXDBridgeForOlderLXD is used for LXD agents that don't support the
+// Network API (pre 2.3)
+func configureLXDBridgeForOlderLXD() error {
 	f, err := os.OpenFile(lxdBridgeFile, os.O_RDWR, 0777)
 	if err != nil {
 		/* We're using an old version of LXD which doesn't have
@@ -293,6 +303,44 @@ func ensureDependencies(series string) error {
 	return err
 }
 
+// randomizedOctetRange is a variable for testing purposes.
+var randomizedOctetRange = func() []int {
+	rand.Seed(time.Now().UnixNano())
+	return rand.Perm(255)
+}
+
+// getKnownV4IPsAndCIDRs iterates all of the known Addresses on this machine
+// and groups them up into known CIDRs and IP addresses.
+func getKnownV4IPsAndCIDRs(addrFunc func() ([]net.Addr, error)) ([]net.IP, []*net.IPNet, error) {
+	addrs, err := addrFunc()
+	if err != nil {
+		return nil, nil, errors.Annotate(err, "cannot get network interface addresses")
+	}
+
+	knownIPs := []net.IP{}
+	seenIPs := set.NewStrings()
+	knownCIDRs := []*net.IPNet{}
+	seenCIDRs := set.NewStrings()
+	for _, netAddr := range addrs {
+		ip, ipNet, err := net.ParseCIDR(netAddr.String())
+		if err != nil {
+			continue
+		}
+		if ip.To4() == nil {
+			continue
+		}
+		if !seenIPs.Contains(ip.String()) {
+			knownIPs = append(knownIPs, ip)
+			seenIPs.Add(ip.String())
+		}
+		if !seenCIDRs.Contains(ipNet.String()) {
+			knownCIDRs = append(knownCIDRs, ipNet)
+			seenCIDRs.Add(ipNet.String())
+		}
+	}
+	return knownIPs, knownCIDRs, nil
+}
+
 // findNextAvailableIPv4Subnet scans the list of interfaces on the machine
 // looking for 10.0.0.0/16 networks and returns the next subnet not in
 // use, having first detected the highest subnet. The next subnet can
@@ -304,47 +352,39 @@ func ensureDependencies(series string) error {
 //
 // TODO(frobware): this only caters for IPv4 setups.
 func findNextAvailableIPv4Subnet() (string, error) {
-	_, ip10network, err := net.ParseCIDR("10.0.0.0/16")
+	knownIPs, knownCIDRs, err := getKnownV4IPsAndCIDRs(interfaceAddrs)
 	if err != nil {
 		return "", errors.Trace(err)
 	}
 
-	addrs, err := interfaceAddrs()
-	if err != nil {
-		return "", errors.Annotatef(err, "cannot get network interface addresses")
-	}
-
-	max := 0
-	usedSubnets := make(map[int]bool)
-
-	for _, address := range addrs {
-		addr, network, err := net.ParseCIDR(address.String())
+	randomized3rdSegment := randomizedOctetRange()
+	for _, i := range randomized3rdSegment {
+		// lxd randomizes the 2nd and 3rd segments, we should be fine with the
+		// 3rd only
+		ip, ip10network, err := net.ParseCIDR(fmt.Sprintf("10.0.%d.0/24", i))
 		if err != nil {
-			logger.Debugf("cannot parse address %q: %v (ignoring)", address.String(), err)
-			continue
+			return "", errors.Trace(err)
 		}
-		if !ip10network.Contains(addr) {
-			logger.Debugf("find available subnet, skipping %q", network.String())
-			continue
+
+		collides := false
+		for _, kIP := range knownIPs {
+			if ip10network.Contains(kIP) {
+				collides = true
+				break
+			}
 		}
-		subnet := int(network.IP[2])
-		usedSubnets[subnet] = true
-		if subnet > max {
-			max = subnet
+		if !collides {
+			for _, kNet := range knownCIDRs {
+				if kNet.Contains(ip) || ip10network.Contains(kNet.IP) {
+					collides = true
+					break
+				}
+			}
+		}
+		if !collides {
+			return fmt.Sprintf("%d", i), nil
 		}
 	}
-
-	if len(usedSubnets) == 0 {
-		return "0", nil
-	}
-
-	for i := 0; i < 256; i++ {
-		max = (max + 1) % 256
-		if _, inUse := usedSubnets[max]; !inUse {
-			return fmt.Sprintf("%d", max), nil
-		}
-	}
-
 	return "", errors.New("could not find unused subnet")
 }
 

--- a/container/network.go
+++ b/container/network.go
@@ -49,12 +49,3 @@ func BridgeNetworkConfig(device string, mtu int, interfaces []network.InterfaceI
 	}
 	return &NetworkConfig{BridgeNetwork, device, mtu, interfaces}
 }
-
-// PhysicalNetworkConfig returns a valid NetworkConfig to use the
-// specified device as the network device for the container. It also
-// allows passing in specific configuration for the container's
-// network interfaces and default MTU to use. If interfaces is nil the
-// default configuration is used for the respective container type.
-func PhysicalNetworkConfig(device string, mtu int, interfaces []network.InterfaceInfo) *NetworkConfig {
-	return &NetworkConfig{PhysicalNetwork, device, mtu, interfaces}
-}

--- a/state/allcollections.go
+++ b/state/allcollections.go
@@ -382,6 +382,8 @@ func allCollections() collectionSchema {
 			rawAccess: true,
 			indexes: []mgo.Index{{
 				Key: []string{"model-uuid", "globalkey", "updated"},
+			}, {
+				Key: []string{"model-uuid", "-updated"}, // used for migration
 			}},
 		},
 

--- a/worker/provisioner/broker.go
+++ b/worker/provisioner/broker.go
@@ -43,7 +43,6 @@ var resolvConf = "/etc/resolv.conf"
 func prepareOrGetContainerInterfaceInfo(
 	api APICalls,
 	machineID string,
-	bridgeDevice string,
 	allocateOrMaintain bool,
 	log loggo.Logger,
 ) ([]network.InterfaceInfo, error) {

--- a/worker/provisioner/container_initialisation.go
+++ b/worker/provisioner/container_initialisation.go
@@ -185,6 +185,20 @@ func (cs *ContainerSetup) runInitialiser(abort <-chan struct{}, containerType in
 		return errors.Trace(err)
 	}
 
+	// At this point, Initialiser likely has changed host network information,
+	// so reprobe to have an accurate view.
+	observedConfig, err := observeNetwork()
+	if err != nil {
+		return errors.Annotate(err, "cannot discover observed network config")
+	}
+	if len(observedConfig) > 0 {
+		machineTag := cs.machine.MachineTag()
+		logger.Tracef("updating observed network config for %q %s containers to %#v", machineTag, containerType, observedConfig)
+		if err := cs.provisioner.SetHostMachineNetworkConfig(machineTag, observedConfig); err != nil {
+			return errors.Trace(err)
+		}
+	}
+
 	return nil
 }
 

--- a/worker/provisioner/container_initialisation_test.go
+++ b/worker/provisioner/container_initialisation_test.go
@@ -22,7 +22,9 @@ import (
 	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/agent"
+	"github.com/juju/juju/api/common"
 	apiprovisioner "github.com/juju/juju/api/provisioner"
+	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/container"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/instance"
@@ -116,7 +118,7 @@ func (s *ContainerSetupSuite) setupContainerWorker(c *gc.C, tag names.MachineTag
 
 func (s *ContainerSetupSuite) createContainer(c *gc.C, host *state.Machine, ctype instance.ContainerType) {
 	inst := s.checkStartInstance(c, host)
-	s.setupContainerWorker(c, host.Tag().(names.MachineTag))
+	s.setupContainerWorker(c, host.MachineTag())
 
 	// make a container on the host machine
 	template := state.MachineTemplate{
@@ -140,6 +142,9 @@ func (s *ContainerSetupSuite) createContainer(c *gc.C, host *state.Machine, ctyp
 func (s *ContainerSetupSuite) assertContainerProvisionerStarted(
 	c *gc.C, host *state.Machine, ctype instance.ContainerType) {
 
+	s.PatchValue(provisioner.GetObservedNetworkConfig, func(_ common.NetworkConfigSource) ([]params.NetworkConfig, error) {
+		return nil, nil
+	})
 	// A stub worker callback to record what happens.
 	var provisionerStarted uint32
 	startProvisionerWorker := func(runner worker.Runner, containerType instance.ContainerType,
@@ -185,7 +190,7 @@ func (s *ContainerSetupSuite) TestContainerProvisionerStarted(c *gc.C) {
 	}
 }
 
-func (s *ContainerSetupSuite) TestKvmContainerUsesHostArch(c *gc.C) {
+func (s *ContainerSetupSuite) TestKvmContainerUsesTargetArch(c *gc.C) {
 	// KVM should do what it's told, and use the architecture in
 	// constraints.
 	s.PatchValue(&arch.HostArch, func() string { return arch.PPC64EL })
@@ -203,6 +208,9 @@ func (_ fakeContainerInitialiser) Initialise() error {
 
 func (s *ContainerSetupSuite) testContainerConstraintsArch(c *gc.C, containerType instance.ContainerType, expectArch string) {
 	var called uint32
+	s.PatchValue(provisioner.GetObservedNetworkConfig, func(_ common.NetworkConfigSource) ([]params.NetworkConfig, error) {
+		return nil, nil
+	})
 	s.PatchValue(provisioner.GetToolsFinder, func(*apiprovisioner.State) provisioner.ToolsFinder {
 		return toolsFinderFunc(func(v version.Number, series string, arch string) (tools.List, error) {
 			atomic.StoreUint32(&called, 1)

--- a/worker/provisioner/host_preparer.go
+++ b/worker/provisioner/host_preparer.go
@@ -96,7 +96,7 @@ func (hp *HostPreparer) Prepare(containerTag names.MachineTag) error {
 		return errors.Trace(err)
 	}
 
-	hp.logger.Debugf("Bridging %+v devices on host %q for container %q with delay=%v, acquiring lock %q",
+	hp.logger.Debugf("bridging %+v devices on host %q for container %q with delay=%v, acquiring lock %q",
 		devicesToBridge, hp.machineTag.String(), containerTag.String(), reconfigureDelay, hp.lockName)
 	releaser, err := hp.acquireLockFunc(hp.abortChan)
 	if err != nil {
@@ -119,11 +119,11 @@ func (hp *HostPreparer) Prepare(containerTag names.MachineTag) error {
 	}
 
 	if len(observedConfig) > 0 {
+		hp.logger.Debugf("updating observed network config for %q to %#v", hp.machineTag.String(), observedConfig)
 		err := hp.api.SetHostMachineNetworkConfig(hp.machineTag, observedConfig)
 		if err != nil {
 			return errors.Trace(err)
 		}
-		hp.logger.Debugf("observed network config updated")
 	}
 
 	return nil

--- a/worker/provisioner/kvm-broker.go
+++ b/worker/provisioner/kvm-broker.go
@@ -77,24 +77,24 @@ func (broker *kvmBroker) StartInstance(args environs.StartInstanceParams) (*envi
 	preparedInfo, err := prepareOrGetContainerInterfaceInfo(
 		broker.api,
 		containerMachineID,
-		bridgeDevice,
 		true, // allocate if possible, do not maintain existing.
 		kvmLogger,
 	)
 	if err != nil {
-		// It's not fatal (yet) if we couldn't pre-allocate addresses for the
-		// container.
-		logger.Warningf("failed to prepare container %q network config: %v", containerMachineID, err)
-	} else {
-		args.NetworkInfo = preparedInfo
+		return nil, errors.Trace(err)
 	}
 
-	network := container.BridgeNetworkConfig(bridgeDevice, 0, args.NetworkInfo)
-	interfaces, err := finishNetworkConfig(bridgeDevice, args.NetworkInfo)
+	// Something to fallback to if there are no devices given in args.NetworkInfo
+	// TODO(jam): 2017-02-07, this feels like something that should never need
+	// to be invoked, because either StartInstance or
+	// prepareOrGetContainerInterfaceInfo should always return a value. The
+	// test suite currently doesn't think so, and I'm hesitant to munge it too
+	// much.
+	interfaces, err := finishNetworkConfig(bridgeDevice, preparedInfo)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	network.Interfaces = interfaces
+	network := container.BridgeNetworkConfig(bridgeDevice, 0, interfaces)
 
 	// The provisioner worker will provide all tools it knows about
 	// (after applying explicitly specified constraints), which may
@@ -154,17 +154,10 @@ func (broker *kvmBroker) StartInstance(args environs.StartInstanceParams) (*envi
 func (broker *kvmBroker) MaintainInstance(args environs.StartInstanceParams) error {
 	machineID := args.InstanceConfig.MachineId
 
-	// Default to using the host network until we can configure.
-	bridgeDevice := broker.agentConfig.Value(agent.LxcBridge)
-	if bridgeDevice == "" {
-		bridgeDevice = container.DefaultKvmBridge
-	}
-
 	// There's no InterfaceInfo we expect to get below.
 	_, err := prepareOrGetContainerInterfaceInfo(
 		broker.api,
 		machineID,
-		bridgeDevice,
 		false, // maintain, do not allocate.
 		kvmLogger,
 	)

--- a/worker/provisioner/kvm-broker_test.go
+++ b/worker/provisioner/kvm-broker_test.go
@@ -243,18 +243,8 @@ func (s *kvmBrokerSuite) TestStartInstancePopulatesFallbackNetworkInfo(c *gc.C) 
 		nil, // HostChangesForContainer succeeds
 		errors.NotSupportedf("container address allocation"),
 	)
-	result, err := s.startInstance(c, broker, "1/kvm/2")
-	c.Assert(err, jc.ErrorIsNil)
-
-	c.Assert(result.NetworkInfo, jc.DeepEquals, []network.InterfaceInfo{{
-		DeviceIndex:         0,
-		InterfaceName:       "eth0",
-		InterfaceType:       network.EthernetInterface,
-		ConfigType:          network.ConfigDHCP,
-		ParentInterfaceName: "virbr0",
-		DNSServers:          network.NewAddresses("ns1.dummy", "ns2.dummy"),
-		DNSSearchDomains:    []string{"dummy", "invalid"},
-	}})
+	_, err := s.startInstance(c, broker, "1/kvm/2")
+	c.Assert(err, gc.ErrorMatches, "container address allocation not supported")
 }
 
 type kvmProvisionerSuite struct {

--- a/worker/provisioner/lxd-broker.go
+++ b/worker/provisioner/lxd-broker.go
@@ -13,7 +13,6 @@ import (
 	"github.com/juju/juju/container"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/instance"
-	"github.com/juju/juju/network"
 )
 
 var lxdLogger = loggo.GetLogger("juju.provisioner.lxd")
@@ -53,10 +52,6 @@ type lxdBroker struct {
 
 func (broker *lxdBroker) StartInstance(args environs.StartInstanceParams) (*environs.StartInstanceResult, error) {
 	containerMachineID := args.InstanceConfig.MachineId
-	bridgeDevice := broker.agentConfig.Value(agent.LxdBridge)
-	if bridgeDevice == "" {
-		bridgeDevice = network.DefaultLXDBridge
-	}
 
 	config, err := broker.api.ContainerConfig()
 	if err != nil {
@@ -72,24 +67,27 @@ func (broker *lxdBroker) StartInstance(args environs.StartInstanceParams) (*envi
 	preparedInfo, err := prepareOrGetContainerInterfaceInfo(
 		broker.api,
 		containerMachineID,
-		bridgeDevice,
 		true, // allocate if possible, do not maintain existing.
 		lxdLogger,
 	)
 	if err != nil {
-		// It's not fatal (yet) if we couldn't pre-allocate addresses for the
-		// container.
-		logger.Warningf("failed to prepare container %q network config: %v", containerMachineID, err)
-	} else {
-		args.NetworkInfo = preparedInfo
+		return nil, errors.Trace(err)
 	}
-
-	network := container.BridgeNetworkConfig(bridgeDevice, 0, args.NetworkInfo)
-	interfaces, err := finishNetworkConfig(bridgeDevice, args.NetworkInfo)
+	// Something to fallback to if there are no devices given in args.NetworkInfo
+	// TODO(jam): 2017-02-07, this feels like something that should never need
+	// to be invoked, because either StartInstance or
+	// prepareOrGetContainerInterfaceInfo should always return a value. The
+	// test suite currently doesn't think so, and I'm hesitant to munge it too
+	// much.
+	bridgeDevice := broker.agentConfig.Value(agent.LxcBridge)
+	if bridgeDevice == "" {
+		bridgeDevice = container.DefaultLxdBridge
+	}
+	interfaces, err := finishNetworkConfig(bridgeDevice, preparedInfo)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	network.Interfaces = interfaces
+	network := container.BridgeNetworkConfig(bridgeDevice, 0, interfaces)
 
 	// The provisioner worker will provide all tools it knows about
 	// (after applying explicitly specified constraints), which may
@@ -161,17 +159,10 @@ func (broker *lxdBroker) AllInstances() (result []instance.Instance, err error) 
 func (broker *lxdBroker) MaintainInstance(args environs.StartInstanceParams) error {
 	machineID := args.InstanceConfig.MachineId
 
-	// Default to using the host network until we can configure.
-	bridgeDevice := broker.agentConfig.Value(agent.LxdBridge)
-	if bridgeDevice == "" {
-		bridgeDevice = network.DefaultLXDBridge
-	}
-
 	// There's no InterfaceInfo we expect to get below.
 	_, err := prepareOrGetContainerInterfaceInfo(
 		broker.api,
 		machineID,
-		bridgeDevice,
 		false, // maintain, do not allocate.
 		lxdLogger,
 	)

--- a/worker/provisioner/lxd-broker_test.go
+++ b/worker/provisioner/lxd-broker_test.go
@@ -134,18 +134,8 @@ func (s *lxdBrokerSuite) TestStartInstancePopulatesFallbackNetworkInfo(c *gc.C) 
 		nil, // HostChangesForContainer succeeds
 		errors.NotSupportedf("container address allocation"),
 	)
-	result, err := s.startInstance(c, broker, "1/lxd/0")
-	c.Assert(err, jc.ErrorIsNil)
-
-	c.Assert(result.NetworkInfo, jc.DeepEquals, []network.InterfaceInfo{{
-		DeviceIndex:         0,
-		InterfaceName:       "eth0",
-		InterfaceType:       network.EthernetInterface,
-		ConfigType:          network.ConfigDHCP,
-		ParentInterfaceName: "lxdbr0",
-		DNSServers:          network.NewAddresses("ns1.dummy", "ns2.dummy"),
-		DNSSearchDomains:    []string{"dummy", "invalid"},
-	}})
+	_, err := s.startInstance(c, broker, "1/lxd/0")
+	c.Assert(err, gc.ErrorMatches, "container address allocation not supported")
 }
 
 func (s *lxdBrokerSuite) TestStartInstanceNoHostArchTools(c *gc.C) {


### PR DESCRIPTION
## Description of change

Merge 2.1 into develop.

This includes:
- Improvements on how we select an LXDBR0 bridge address
- Adding an index on status_history collection to avoid timeouts when it gets large.
- Fix a couple of small bugs so that we won't fall back to LXDBR0 on accident. Instead we only use LXDBR0 when we explicitly don't want to bridge to the host device.

