### PR TITLE
cmd/juju/storage: revise storage tabular format

### DIFF
--- a/api/storage/client_test.go
+++ b/api/storage/client_test.go
@@ -313,9 +313,9 @@ func (s *storageMockSuite) TestListVolumes(c *gc.C) {
 
 			details := params.VolumeDetails{
 				VolumeTag: "volume-0",
-				MachineAttachments: map[string]params.VolumeAttachmentInfo{
-					"machine-0": params.VolumeAttachmentInfo{},
-					"machine-1": params.VolumeAttachmentInfo{},
+				MachineAttachments: map[string]params.VolumeAttachmentDetails{
+					"machine-0": {},
+					"machine-1": {},
 				},
 			}
 			results.Results = []params.VolumeDetailsListResult{{
@@ -333,9 +333,9 @@ func (s *storageMockSuite) TestListVolumes(c *gc.C) {
 	for i := 0; i < 2; i++ {
 		c.Assert(found[i].Result, jc.DeepEquals, []params.VolumeDetails{{
 			VolumeTag: "volume-0",
-			MachineAttachments: map[string]params.VolumeAttachmentInfo{
-				"machine-0": params.VolumeAttachmentInfo{},
-				"machine-1": params.VolumeAttachmentInfo{},
+			MachineAttachments: map[string]params.VolumeAttachmentDetails{
+				"machine-0": {},
+				"machine-1": {},
 			},
 		}})
 	}
@@ -406,10 +406,12 @@ func (s *storageMockSuite) TestListFilesystems(c *gc.C) {
 		Status: params.EntityStatus{
 			Status: "attached",
 		},
-		MachineAttachments: map[string]params.FilesystemAttachmentInfo{
-			"0": params.FilesystemAttachmentInfo{
-				MountPoint: "/mnt/kinabalu",
-				ReadOnly:   false,
+		MachineAttachments: map[string]params.FilesystemAttachmentDetails{
+			"0": params.FilesystemAttachmentDetails{
+				FilesystemAttachmentInfo: params.FilesystemAttachmentInfo{
+					MountPoint: "/mnt/kinabalu",
+					ReadOnly:   false,
+				},
 			},
 		},
 	}

--- a/apiserver/common/storagecommon/filesystems.go
+++ b/apiserver/common/storagecommon/filesystems.go
@@ -120,6 +120,7 @@ func FilesystemFromState(f state.Filesystem) (params.Filesystem, error) {
 func FilesystemInfoFromState(info state.FilesystemInfo) params.FilesystemInfo {
 	return params.FilesystemInfo{
 		info.FilesystemId,
+		info.Pool,
 		info.Size,
 	}
 }

--- a/apiserver/common/storagecommon/storage.go
+++ b/apiserver/common/storagecommon/storage.go
@@ -91,7 +91,13 @@ func volumeStorageAttachmentInfo(
 ) (*storage.StorageAttachmentInfo, error) {
 	storageTag := storageInstance.StorageTag()
 	volume, err := st.StorageInstanceVolume(storageTag)
-	if err != nil {
+	if errors.IsNotFound(err) {
+		// If the unit of the storage attachment is not
+		// assigned to a machine, there will be no volume
+		// yet. Handle this gracefully by saying that the
+		// volume is not yet provisioned.
+		return nil, errors.NotProvisionedf("volume for storage %q", storageTag.Id())
+	} else if err != nil {
 		return nil, errors.Annotate(err, "getting volume")
 	}
 	volumeInfo, err := volume.Info()
@@ -143,7 +149,13 @@ func filesystemStorageAttachmentInfo(
 ) (*storage.StorageAttachmentInfo, error) {
 	storageTag := storageInstance.StorageTag()
 	filesystem, err := st.StorageInstanceFilesystem(storageTag)
-	if err != nil {
+	if errors.IsNotFound(err) {
+		// If the unit of the storage attachment is not
+		// assigned to a machine, there will be no filesystem
+		// yet. Handle this gracefully by saying that the
+		// filesystem is not yet provisioned.
+		return nil, errors.NotProvisionedf("filesystem for storage %q", storageTag.Id())
+	} else if err != nil {
 		return nil, errors.Annotate(err, "getting filesystem")
 	}
 	filesystemAttachment, err := st.FilesystemAttachment(machineTag, filesystem.FilesystemTag())

--- a/apiserver/common/storagecommon/storage_test.go
+++ b/apiserver/common/storagecommon/storage_test.go
@@ -149,6 +149,15 @@ func (s *storageAttachmentInfoSuite) TestStorageAttachmentInfoNoBlockDevice(c *g
 	s.st.CheckCallNames(c, "StorageInstance", "StorageInstanceVolume", "VolumeAttachment", "BlockDevices")
 }
 
+func (s *storageAttachmentInfoSuite) TestStorageAttachmentInfoVolumeNotFound(c *gc.C) {
+	s.st.storageInstanceVolume = func(tag names.StorageTag) (state.Volume, error) {
+		return nil, errors.NotFoundf("volume for storage %s", tag.Id())
+	}
+	_, err := storagecommon.StorageAttachmentInfo(s.st, s.storageAttachment, s.machineTag)
+	c.Assert(err, jc.Satisfies, errors.IsNotProvisioned)
+	s.st.CheckCallNames(c, "StorageInstance", "StorageInstanceVolume")
+}
+
 type watchStorageAttachmentSuite struct {
 	storageTag               names.StorageTag
 	machineTag               names.MachineTag

--- a/apiserver/common/storagecommon/volumes.go
+++ b/apiserver/common/storagecommon/volumes.go
@@ -139,6 +139,7 @@ func VolumeInfoFromState(info state.VolumeInfo) params.VolumeInfo {
 	return params.VolumeInfo{
 		info.VolumeId,
 		info.HardwareId,
+		info.Pool,
 		info.Size,
 		info.Persistent,
 	}

--- a/apiserver/params/storage.go
+++ b/apiserver/params/storage.go
@@ -404,6 +404,11 @@ type StorageDetails struct {
 	// Status contains the status of the storage instance.
 	Status EntityStatus `json:"status"`
 
+	// Life contains the lifecycle state of the storage.
+	// Old versions of the API do not populate this field,
+	// so it may be omitted.
+	Life Life `json:"life,omitempty"`
+
 	// Persistent reports whether or not the underlying volume or
 	// filesystem is persistent; i.e. whether or not it outlives
 	// the machine that it is attached to.
@@ -462,6 +467,11 @@ type StorageAttachmentDetails struct {
 	// Location holds location (mount point/device path) of
 	// the attached storage.
 	Location string `json:"location,omitempty"`
+
+	// Life contains the lifecycle state of the storage attachment.
+	// Old versions of the API do not populate this field, so it may
+	// be omitted.
+	Life Life `json:"life,omitempty"`
 }
 
 // StoragePool holds data for a pool instance.
@@ -547,16 +557,33 @@ type VolumeDetails struct {
 	// Info contains information about the volume.
 	Info VolumeInfo `json:"info"`
 
+	// Life contains the lifecycle state of the volume.
+	// Old versions of the API do not populate this field,
+	// so it may be omitted.
+	Life Life `json:"life,omitempty"`
+
 	// Status contains the status of the volume.
 	Status EntityStatus `json:"status"`
 
 	// MachineAttachments contains a mapping from
 	// machine tag to volume attachment information.
-	MachineAttachments map[string]VolumeAttachmentInfo `json:"machine-attachments,omitempty"`
+	MachineAttachments map[string]VolumeAttachmentDetails `json:"machine-attachments,omitempty"`
 
 	// Storage contains details about the storage instance
 	// that the volume is assigned to, if any.
 	Storage *StorageDetails `json:"storage,omitempty"`
+}
+
+// VolumeAttachmentDetails describes a volume attachment.
+type VolumeAttachmentDetails struct {
+	// NOTE(axw) for backwards-compatibility, this must not be given a
+	// json tag. This ensures that we collapse VolumeAttachmentInfo.
+	VolumeAttachmentInfo
+
+	// Life contains the lifecycle state of the volume attachment.
+	// Old versions of the API do not populate this field, so it
+	// may be omitted.
+	Life Life `json:"life,omitempty"`
 }
 
 // VolumeDetailsResult contains details about a volume, its attachments or
@@ -603,16 +630,33 @@ type FilesystemDetails struct {
 	// Info contains information about the filesystem.
 	Info FilesystemInfo `json:"info"`
 
+	// Life contains the lifecycle state of the filesystem.
+	// Old versions of the API do not populate this field,
+	// so it may be omitted.
+	Life Life `json:"life,omitempty"`
+
 	// Status contains the status of the filesystem.
 	Status EntityStatus `json:"status"`
 
 	// MachineAttachments contains a mapping from
 	// machine tag to filesystem attachment information.
-	MachineAttachments map[string]FilesystemAttachmentInfo `json:"machine-attachments,omitempty"`
+	MachineAttachments map[string]FilesystemAttachmentDetails `json:"machine-attachments,omitempty"`
 
 	// Storage contains details about the storage instance
 	// that the volume is assigned to, if any.
 	Storage *StorageDetails `json:"storage,omitempty"`
+}
+
+// FilesystemAttachmentDetails describes a filesystem attachment.
+type FilesystemAttachmentDetails struct {
+	// NOTE(axw) for backwards-compatibility, this must not be given a
+	// json tag. This ensures that we collapse FilesystemAttachmentInfo.
+	FilesystemAttachmentInfo
+
+	// Life contains the lifecycle state of the filesystem attachment.
+	// Old versions of the API do not populate this field, so it may
+	// be omitted.
+	Life Life `json:"life,omitempty"`
 }
 
 // FilesystemDetailsResult contains details about a filesystem, its attachments or

--- a/apiserver/params/storage.go
+++ b/apiserver/params/storage.go
@@ -172,6 +172,11 @@ type Volume struct {
 type VolumeInfo struct {
 	VolumeId   string `json:"volume-id"`
 	HardwareId string `json:"hardware-id,omitempty"`
+	// Pool is the name of the storage pool used to
+	// allocate the volume. Juju controllers older
+	// than 2.2 do not populate this field, so it may
+	// be omitted.
+	Pool string `json:"pool,omitempty"`
 	// Size is the size of the volume in MiB.
 	Size       uint64 `json:"size"`
 	Persistent bool   `json:"persistent"`
@@ -293,6 +298,11 @@ type Filesystem struct {
 // Filesystem describes a storage filesystem in the model.
 type FilesystemInfo struct {
 	FilesystemId string `json:"filesystem-id"`
+	// Pool is the name of the storage pool used to
+	// allocate the filesystem. Juju controllers older
+	// than 2.2 do not populate this field, so it may
+	// be omitted.
+	Pool string `json:"pool"`
 	// Size is the size of the filesystem in MiB.
 	Size uint64 `json:"size"`
 }
@@ -405,8 +415,8 @@ type StorageDetails struct {
 	Status EntityStatus `json:"status"`
 
 	// Life contains the lifecycle state of the storage.
-	// Old versions of the API do not populate this field,
-	// so it may be omitted.
+	// Juju controllers older than 2.2 do not populate this
+	// field, so it may be omitted.
 	Life Life `json:"life,omitempty"`
 
 	// Persistent reports whether or not the underlying volume or
@@ -469,8 +479,8 @@ type StorageAttachmentDetails struct {
 	Location string `json:"location,omitempty"`
 
 	// Life contains the lifecycle state of the storage attachment.
-	// Old versions of the API do not populate this field, so it may
-	// be omitted.
+	// Juju controllers older than 2.2 do not populate this
+	// field, so it may be omitted.
 	Life Life `json:"life,omitempty"`
 }
 
@@ -558,8 +568,8 @@ type VolumeDetails struct {
 	Info VolumeInfo `json:"info"`
 
 	// Life contains the lifecycle state of the volume.
-	// Old versions of the API do not populate this field,
-	// so it may be omitted.
+	// Juju controllers older than 2.2 do not populate this
+	// field, so it may be omitted.
 	Life Life `json:"life,omitempty"`
 
 	// Status contains the status of the volume.
@@ -578,11 +588,15 @@ type VolumeDetails struct {
 type VolumeAttachmentDetails struct {
 	// NOTE(axw) for backwards-compatibility, this must not be given a
 	// json tag. This ensures that we collapse VolumeAttachmentInfo.
+	//
+	// TODO(axw) when we can break backwards-compatibility (Juju 3.0),
+	// give this a field name of "info", like we have in VolumeDetails
+	// above.
 	VolumeAttachmentInfo
 
 	// Life contains the lifecycle state of the volume attachment.
-	// Old versions of the API do not populate this field, so it
-	// may be omitted.
+	// Juju controllers older than 2.2 do not populate this
+	// field, so it may be omitted.
 	Life Life `json:"life,omitempty"`
 }
 
@@ -631,8 +645,8 @@ type FilesystemDetails struct {
 	Info FilesystemInfo `json:"info"`
 
 	// Life contains the lifecycle state of the filesystem.
-	// Old versions of the API do not populate this field,
-	// so it may be omitted.
+	// Juju controllers older than 2.2 do not populate this
+	// field, so it may be omitted.
 	Life Life `json:"life,omitempty"`
 
 	// Status contains the status of the filesystem.
@@ -651,11 +665,15 @@ type FilesystemDetails struct {
 type FilesystemAttachmentDetails struct {
 	// NOTE(axw) for backwards-compatibility, this must not be given a
 	// json tag. This ensures that we collapse FilesystemAttachmentInfo.
+	//
+	// TODO(axw) when we can break backwards-compatibility (Juju 3.0),
+	// give this a field name of "info", like we have in FilesystemDetails
+	// above.
 	FilesystemAttachmentInfo
 
 	// Life contains the lifecycle state of the filesystem attachment.
-	// Old versions of the API do not populate this field, so it may
-	// be omitted.
+	// Juju controllers older than 2.2 do not populate this
+	// field, so it may be omitted.
 	Life Life `json:"life,omitempty"`
 }
 

--- a/apiserver/storage/base_test.go
+++ b/apiserver/storage/base_test.go
@@ -97,9 +97,13 @@ func (s *baseStorageSuite) constructState() *mockState {
 		kind:       state.StorageKindFilesystem,
 		owner:      s.unitTag,
 		storageTag: s.storageTag,
+		life:       state.Dying,
 	}
 
-	storageInstanceAttachment := &mockStorageAttachment{storage: s.storageInstance}
+	storageInstanceAttachment := &mockStorageAttachment{
+		storage: s.storageInstance,
+		life:    state.Alive,
+	}
 
 	s.machineTag = names.NewMachineTag("66")
 	s.filesystemTag = names.NewFilesystemTag("104")
@@ -107,15 +111,18 @@ func (s *baseStorageSuite) constructState() *mockState {
 	s.filesystem = &mockFilesystem{
 		tag:     s.filesystemTag,
 		storage: &s.storageTag,
+		life:    state.Alive,
 	}
 	s.filesystemAttachment = &mockFilesystemAttachment{
 		filesystem: s.filesystemTag,
 		machine:    s.machineTag,
+		life:       state.Dead,
 	}
 	s.volume = &mockVolume{tag: s.volumeTag, storage: &s.storageTag}
 	s.volumeAttachment = &mockVolumeAttachment{
 		VolumeTag:  s.volumeTag,
 		MachineTag: s.machineTag,
+		life:       state.Alive,
 	}
 
 	s.blocks = make(map[state.BlockType]state.Block)

--- a/apiserver/storage/filesystemlist_test.go
+++ b/apiserver/storage/filesystemlist_test.go
@@ -21,16 +21,20 @@ var _ = gc.Suite(&filesystemSuite{})
 func (s *filesystemSuite) expectedFilesystemDetails() params.FilesystemDetails {
 	return params.FilesystemDetails{
 		FilesystemTag: s.filesystemTag.String(),
+		Life:          "alive",
 		Status: params.EntityStatus{
 			Status: "attached",
 		},
-		MachineAttachments: map[string]params.FilesystemAttachmentInfo{
-			s.machineTag.String(): params.FilesystemAttachmentInfo{},
+		MachineAttachments: map[string]params.FilesystemAttachmentDetails{
+			s.machineTag.String(): params.FilesystemAttachmentDetails{
+				Life: "dead",
+			},
 		},
 		Storage: &params.StorageDetails{
 			StorageTag: "storage-data-0",
 			OwnerTag:   "unit-mysql-0",
 			Kind:       params.StorageKindFilesystem,
+			Life:       "dying",
 			Status: params.EntityStatus{
 				Status: "attached",
 			},
@@ -39,6 +43,7 @@ func (s *filesystemSuite) expectedFilesystemDetails() params.FilesystemDetails {
 					StorageTag: "storage-data-0",
 					UnitTag:    "unit-mysql-0",
 					MachineTag: "machine-66",
+					Life:       "alive",
 				},
 			},
 		},
@@ -120,9 +125,12 @@ func (s *filesystemSuite) TestListFilesystemsAttachmentInfo(c *gc.C) {
 		ReadOnly:   true,
 	}
 	expected := s.expectedFilesystemDetails()
-	expected.MachineAttachments[s.machineTag.String()] = params.FilesystemAttachmentInfo{
-		MountPoint: "/tmp",
-		ReadOnly:   true,
+	expected.MachineAttachments[s.machineTag.String()] = params.FilesystemAttachmentDetails{
+		FilesystemAttachmentInfo: params.FilesystemAttachmentInfo{
+			MountPoint: "/tmp",
+			ReadOnly:   true,
+		},
+		Life: "dead",
 	}
 	expectedStorageAttachmentDetails := expected.Storage.Attachments["unit-mysql-0"]
 	expectedStorageAttachmentDetails.Location = "/tmp"

--- a/apiserver/storage/mock_test.go
+++ b/apiserver/storage/mock_test.go
@@ -186,6 +186,7 @@ type mockVolume struct {
 	tag     names.VolumeTag
 	storage *names.StorageTag
 	info    *state.VolumeInfo
+	life    state.Life
 }
 
 func (m *mockVolume) StorageInstance() (names.StorageTag, error) {
@@ -213,6 +214,10 @@ func (m *mockVolume) Info() (state.VolumeInfo, error) {
 	return state.VolumeInfo{}, errors.NotProvisionedf("%v", m.tag)
 }
 
+func (m *mockVolume) Life() state.Life {
+	return m.life
+}
+
 func (m *mockVolume) Status() (status.StatusInfo, error) {
 	return status.StatusInfo{Status: status.Attached}, nil
 }
@@ -223,6 +228,7 @@ type mockFilesystem struct {
 	storage *names.StorageTag
 	volume  *names.VolumeTag
 	info    *state.FilesystemInfo
+	life    state.Life
 }
 
 func (m *mockFilesystem) Storage() (names.StorageTag, error) {
@@ -250,6 +256,10 @@ func (m *mockFilesystem) Info() (state.FilesystemInfo, error) {
 	return state.FilesystemInfo{}, errors.NotProvisionedf("filesystem")
 }
 
+func (m *mockFilesystem) Life() state.Life {
+	return m.life
+}
+
 func (m *mockFilesystem) Status() (status.StatusInfo, error) {
 	return status.StatusInfo{Status: status.Attached}, nil
 }
@@ -259,6 +269,7 @@ type mockFilesystemAttachment struct {
 	filesystem names.FilesystemTag
 	machine    names.MachineTag
 	info       *state.FilesystemAttachmentInfo
+	life       state.Life
 }
 
 func (m *mockFilesystemAttachment) Filesystem() names.FilesystemTag {
@@ -276,11 +287,16 @@ func (m *mockFilesystemAttachment) Info() (state.FilesystemAttachmentInfo, error
 	return state.FilesystemAttachmentInfo{}, errors.NotProvisionedf("filesystem attachment")
 }
 
+func (m *mockFilesystemAttachment) Life() state.Life {
+	return m.life
+}
+
 type mockStorageInstance struct {
 	state.StorageInstance
 	kind       state.StorageKind
 	owner      names.Tag
 	storageTag names.Tag
+	life       state.Life
 }
 
 func (m *mockStorageInstance) Kind() state.StorageKind {
@@ -303,9 +319,14 @@ func (m *mockStorageInstance) CharmURL() *charm.URL {
 	panic("not implemented for test")
 }
 
+func (m *mockStorageInstance) Life() state.Life {
+	return m.life
+}
+
 type mockStorageAttachment struct {
 	state.StorageAttachment
 	storage *mockStorageInstance
+	life    state.Life
 }
 
 func (m *mockStorageAttachment) StorageInstance() names.StorageTag {
@@ -316,10 +337,15 @@ func (m *mockStorageAttachment) Unit() names.UnitTag {
 	return m.storage.owner.(names.UnitTag)
 }
 
+func (m *mockStorageAttachment) Life() state.Life {
+	return m.life
+}
+
 type mockVolumeAttachment struct {
 	VolumeTag  names.VolumeTag
 	MachineTag names.MachineTag
 	info       *state.VolumeAttachmentInfo
+	life       state.Life
 }
 
 func (va *mockVolumeAttachment) Volume() names.VolumeTag {
@@ -331,7 +357,7 @@ func (va *mockVolumeAttachment) Machine() names.MachineTag {
 }
 
 func (va *mockVolumeAttachment) Life() state.Life {
-	panic("not implemented for test")
+	return va.life
 }
 
 func (va *mockVolumeAttachment) Info() (state.VolumeAttachmentInfo, error) {

--- a/apiserver/storage/storage.go
+++ b/apiserver/storage/storage.go
@@ -191,6 +191,7 @@ func createStorageDetails(st storageAccess, si state.StorageInstance) (*params.S
 				a.Unit().String(),
 				machineTag.String(),
 				location,
+				params.Life(a.Life().String()),
 			}
 			storageAttachmentDetails[a.Unit().String()] = details
 		}
@@ -205,6 +206,7 @@ func createStorageDetails(st storageAccess, si state.StorageInstance) (*params.S
 		StorageTag:  si.Tag().String(),
 		OwnerTag:    ownerTag,
 		Kind:        params.StorageKind(si.Kind()),
+		Life:        params.Life(si.Life().String()),
 		Status:      common.EntityStatusFromState(status),
 		Persistent:  persistent,
 		Attachments: storageAttachmentDetails,
@@ -478,6 +480,7 @@ func createVolumeDetails(
 
 	details := &params.VolumeDetails{
 		VolumeTag: v.VolumeTag().String(),
+		Life:      params.Life(v.Life().String()),
 	}
 
 	if info, err := v.Info(); err == nil {
@@ -485,14 +488,17 @@ func createVolumeDetails(
 	}
 
 	if len(attachments) > 0 {
-		details.MachineAttachments = make(map[string]params.VolumeAttachmentInfo, len(attachments))
+		details.MachineAttachments = make(map[string]params.VolumeAttachmentDetails, len(attachments))
 		for _, attachment := range attachments {
-			stateInfo, err := attachment.Info()
-			var info params.VolumeAttachmentInfo
-			if err == nil {
-				info = storagecommon.VolumeAttachmentInfoFromState(stateInfo)
+			attDetails := params.VolumeAttachmentDetails{
+				Life: params.Life(attachment.Life().String()),
 			}
-			details.MachineAttachments[attachment.Machine().String()] = info
+			if stateInfo, err := attachment.Info(); err == nil {
+				attDetails.VolumeAttachmentInfo = storagecommon.VolumeAttachmentInfoFromState(
+					stateInfo,
+				)
+			}
+			details.MachineAttachments[attachment.Machine().String()] = attDetails
 		}
 	}
 
@@ -626,6 +632,7 @@ func createFilesystemDetails(
 
 	details := &params.FilesystemDetails{
 		FilesystemTag: f.FilesystemTag().String(),
+		Life:          params.Life(f.Life().String()),
 	}
 
 	if volumeTag, err := f.Volume(); err == nil {
@@ -637,14 +644,17 @@ func createFilesystemDetails(
 	}
 
 	if len(attachments) > 0 {
-		details.MachineAttachments = make(map[string]params.FilesystemAttachmentInfo, len(attachments))
+		details.MachineAttachments = make(map[string]params.FilesystemAttachmentDetails, len(attachments))
 		for _, attachment := range attachments {
-			stateInfo, err := attachment.Info()
-			var info params.FilesystemAttachmentInfo
-			if err == nil {
-				info = storagecommon.FilesystemAttachmentInfoFromState(stateInfo)
+			attDetails := params.FilesystemAttachmentDetails{
+				Life: params.Life(attachment.Life().String()),
 			}
-			details.MachineAttachments[attachment.Machine().String()] = info
+			if stateInfo, err := attachment.Info(); err == nil {
+				attDetails.FilesystemAttachmentInfo = storagecommon.FilesystemAttachmentInfoFromState(
+					stateInfo,
+				)
+			}
+			details.MachineAttachments[attachment.Machine().String()] = attDetails
 		}
 	}
 

--- a/apiserver/storage/storage.go
+++ b/apiserver/storage/storage.go
@@ -187,11 +187,11 @@ func createStorageDetails(st storageAccess, si state.StorageInstance) (*params.S
 				return nil, errors.Trace(err)
 			}
 			details := params.StorageAttachmentDetails{
-				a.StorageInstance().String(),
-				a.Unit().String(),
-				machineTag.String(),
-				location,
-				params.Life(a.Life().String()),
+				StorageTag: a.StorageInstance().String(),
+				UnitTag:    a.Unit().String(),
+				MachineTag: machineTag.String(),
+				Location:   location,
+				Life:       params.Life(a.Life().String()),
 			}
 			storageAttachmentDetails[a.Unit().String()] = details
 		}

--- a/apiserver/storage/storage_test.go
+++ b/apiserver/storage/storage_test.go
@@ -237,6 +237,7 @@ func (s *storageSuite) createTestStorageDetails() params.StorageDetails {
 		StorageTag: s.storageTag.String(),
 		OwnerTag:   s.unitTag.String(),
 		Kind:       params.StorageKindFilesystem,
+		Life:       "dying",
 		Status: params.EntityStatus{
 			Status: "attached",
 		},
@@ -246,6 +247,7 @@ func (s *storageSuite) createTestStorageDetails() params.StorageDetails {
 				s.unitTag.String(),
 				s.machineTag.String(),
 				"", // location
+				"alive",
 			},
 		},
 	}
@@ -293,6 +295,7 @@ func (s *storageSuite) TestShowStorage(c *gc.C) {
 		StorageTag: s.storageTag.String(),
 		OwnerTag:   s.unitTag.String(),
 		Kind:       params.StorageKindFilesystem,
+		Life:       "dying",
 		Status: params.EntityStatus{
 			Status: "attached",
 		},
@@ -302,6 +305,7 @@ func (s *storageSuite) TestShowStorage(c *gc.C) {
 				s.unitTag.String(),
 				s.machineTag.String(),
 				"",
+				"alive",
 			},
 		},
 	}

--- a/apiserver/storage/volumelist_test.go
+++ b/apiserver/storage/volumelist_test.go
@@ -25,16 +25,20 @@ var _ = gc.Suite(&volumeSuite{})
 func (s *volumeSuite) expectedVolumeDetails() params.VolumeDetails {
 	return params.VolumeDetails{
 		VolumeTag: s.volumeTag.String(),
+		Life:      "alive",
 		Status: params.EntityStatus{
 			Status: "attached",
 		},
-		MachineAttachments: map[string]params.VolumeAttachmentInfo{
-			s.machineTag.String(): params.VolumeAttachmentInfo{},
+		MachineAttachments: map[string]params.VolumeAttachmentDetails{
+			s.machineTag.String(): params.VolumeAttachmentDetails{
+				Life: "alive",
+			},
 		},
 		Storage: &params.StorageDetails{
 			StorageTag: "storage-data-0",
 			OwnerTag:   "unit-mysql-0",
 			Kind:       params.StorageKindFilesystem,
+			Life:       "dying",
 			Status: params.EntityStatus{
 				Status: "attached",
 			},
@@ -43,6 +47,7 @@ func (s *volumeSuite) expectedVolumeDetails() params.VolumeDetails {
 					StorageTag: "storage-data-0",
 					UnitTag:    "unit-mysql-0",
 					MachineTag: "machine-66",
+					Life:       "alive",
 				},
 			},
 		},
@@ -132,9 +137,12 @@ func (s *volumeSuite) TestListVolumesAttachmentInfo(c *gc.C) {
 		ReadOnly:   true,
 	}
 	expected := s.expectedVolumeDetails()
-	expected.MachineAttachments[s.machineTag.String()] = params.VolumeAttachmentInfo{
-		DeviceName: "xvdf1",
-		ReadOnly:   true,
+	expected.MachineAttachments[s.machineTag.String()] = params.VolumeAttachmentDetails{
+		VolumeAttachmentInfo: params.VolumeAttachmentInfo{
+			DeviceName: "xvdf1",
+			ReadOnly:   true,
+		},
+		Life: "alive",
 	}
 	found, err := s.api.ListVolumes(params.VolumeFilters{[]params.VolumeFilter{{}}})
 	c.Assert(err, jc.ErrorIsNil)
@@ -152,8 +160,11 @@ func (s *volumeSuite) TestListVolumesStorageLocationNoBlockDevice(c *gc.C) {
 	expected := s.expectedVolumeDetails()
 	expected.Storage.Kind = params.StorageKindBlock
 	expected.Storage.Status.Status = status.Attached
-	expected.MachineAttachments[s.machineTag.String()] = params.VolumeAttachmentInfo{
-		ReadOnly: true,
+	expected.MachineAttachments[s.machineTag.String()] = params.VolumeAttachmentDetails{
+		VolumeAttachmentInfo: params.VolumeAttachmentInfo{
+			ReadOnly: true,
+		},
+		Life: "alive",
 	}
 	found, err := s.api.ListVolumes(params.VolumeFilters{[]params.VolumeFilter{{}}})
 	c.Assert(err, jc.ErrorIsNil)
@@ -181,9 +192,12 @@ func (s *volumeSuite) TestListVolumesStorageLocationBlockDevicePath(c *gc.C) {
 	storageAttachmentDetails := expected.Storage.Attachments["unit-mysql-0"]
 	storageAttachmentDetails.Location = filepath.FromSlash("/dev/sdd")
 	expected.Storage.Attachments["unit-mysql-0"] = storageAttachmentDetails
-	expected.MachineAttachments[s.machineTag.String()] = params.VolumeAttachmentInfo{
-		BusAddress: "bus-addr",
-		ReadOnly:   true,
+	expected.MachineAttachments[s.machineTag.String()] = params.VolumeAttachmentDetails{
+		VolumeAttachmentInfo: params.VolumeAttachmentInfo{
+			BusAddress: "bus-addr",
+			ReadOnly:   true,
+		},
+		Life: "alive",
 	}
 	found, err := s.api.ListVolumes(params.VolumeFilters{[]params.VolumeFilter{{}}})
 	c.Assert(err, jc.ErrorIsNil)

--- a/apiserver/storageprovisioner/storageprovisioner_test.go
+++ b/apiserver/storageprovisioner/storageprovisioner_test.go
@@ -178,6 +178,7 @@ func (s *provisionerSuite) TestVolumesMachine(c *gc.C) {
 					HardwareId: "123",
 					Size:       1024,
 					Persistent: true,
+					Pool:       "machinescoped",
 				},
 			}},
 			{Error: &params.Error{Message: "permission denied", Code: "unauthorized access"}},
@@ -209,6 +210,7 @@ func (s *provisionerSuite) TestVolumesEnviron(c *gc.C) {
 					VolumeId:   "def",
 					HardwareId: "456",
 					Size:       4096,
+					Pool:       "modelscoped",
 				},
 			}},
 			{Error: &params.Error{Message: "permission denied", Code: "unauthorized access"}},
@@ -244,6 +246,7 @@ func (s *provisionerSuite) TestFilesystems(c *gc.C) {
 				Info: params.FilesystemInfo{
 					FilesystemId: "def",
 					Size:         4096,
+					Pool:         "modelscoped",
 				},
 			}},
 			{Error: &params.Error{Message: "permission denied", Code: "unauthorized access"}},

--- a/cmd/juju/storage/filesystem.go
+++ b/cmd/juju/storage/filesystem.go
@@ -34,6 +34,9 @@ type FilesystemInfo struct {
 	// Attachments is the set of entities attached to the filesystem.
 	Attachments *FilesystemAttachments
 
+	// Pool is the name of the storage pool that the filesystem came from.
+	Pool string `yaml:"pool,omitempty" json:"pool,omitempty"`
+
 	// from params.FilesystemInfo
 	Size uint64 `yaml:"size" json:"size"`
 
@@ -100,6 +103,7 @@ func createFilesystemInfo(details params.FilesystemDetails) (names.FilesystemTag
 
 	var info FilesystemInfo
 	info.ProviderFilesystemId = details.Info.FilesystemId
+	info.Pool = details.Info.Pool
 	info.Size = details.Info.Size
 	info.Life = string(details.Life)
 	info.Status = EntityStatus{

--- a/cmd/juju/storage/filesystem.go
+++ b/cmd/juju/storage/filesystem.go
@@ -25,17 +25,20 @@ type FilesystemInfo struct {
 	ProviderFilesystemId string `yaml:"provider-id,omitempty" json:"provider-id,omitempty"`
 
 	// Volume is the ID of the volume that the filesystem is backed by, if any.
-	Volume string
+	Volume string `yaml:"volume,omitempty" json:"volume,omitempty"`
 
 	// Storage is the ID of the storage instance that the filesystem is
 	// assigned to, if any.
-	Storage string
+	Storage string `yaml:"storage,omitempty" json:"storage,omitempty"`
 
 	// Attachments is the set of entities attached to the filesystem.
 	Attachments *FilesystemAttachments
 
 	// from params.FilesystemInfo
 	Size uint64 `yaml:"size" json:"size"`
+
+	// Life is the lifecycle state of the filesystem.
+	Life string `yaml:"life,omitempty" json:"life,omitempty"`
 
 	// from params.FilesystemInfo.
 	Status EntityStatus `yaml:"status,omitempty" json:"status,omitempty"`
@@ -49,6 +52,7 @@ type FilesystemAttachments struct {
 type MachineFilesystemAttachment struct {
 	MountPoint string `yaml:"mount-point" json:"mount-point"`
 	ReadOnly   bool   `yaml:"read-only" json:"read-only"`
+	Life       string `yaml:"life,omitempty" json:"life,omitempty"`
 }
 
 // generateListFilesystemOutput returns a map filesystem IDs to filesystem info
@@ -97,6 +101,7 @@ func createFilesystemInfo(details params.FilesystemDetails) (names.FilesystemTag
 	var info FilesystemInfo
 	info.ProviderFilesystemId = details.Info.FilesystemId
 	info.Size = details.Info.Size
+	info.Life = string(details.Life)
 	info.Status = EntityStatus{
 		details.Status.Status,
 		details.Status.Info,
@@ -122,6 +127,7 @@ func createFilesystemInfo(details params.FilesystemDetails) (names.FilesystemTag
 			machineAttachments[machineId] = MachineFilesystemAttachment{
 				attachment.MountPoint,
 				attachment.ReadOnly,
+				string(attachment.Life),
 			}
 		}
 		info.Attachments = &FilesystemAttachments{

--- a/cmd/juju/storage/list.go
+++ b/cmd/juju/storage/list.go
@@ -160,10 +160,17 @@ func formatListTabular(writer io.Writer, value interface{}) error {
 	combined := value.(combinedStorage)
 	var newline bool
 	if len(combined.StorageInstances) > 0 {
-		if err := formatStorageListTabular(writer, combined.StorageInstances); err != nil {
+		// If we're listing storage in tabular format, we combine all
+		// of the information into a list of "storage".
+		if err := formatStorageListTabular(
+			writer,
+			combined.StorageInstances,
+			combined.Filesystems,
+			combined.Volumes,
+		); err != nil {
 			return err
 		}
-		newline = true
+		return nil
 	}
 	if len(combined.Filesystems) > 0 {
 		if newline {

--- a/cmd/juju/storage/list_test.go
+++ b/cmd/juju/storage/list_test.go
@@ -41,11 +41,11 @@ func (s *ListSuite) TestList(c *gc.C) {
 		// Default format is tabular
 		`
 \[Storage\]
-Unit          Id           Pool      Provider id                 Size    Status    Message
-postgresql/0  db-dir/1100                                                attached  
-transcode/0   db-dir/1000                                                pending   creating volume
-transcode/0   shared-fs/0  radiance  provider-supplied-volume-4  1.0GiB  attached  
-transcode/1   shared-fs/0  radiance  provider-supplied-volume-4  1.0GiB  attached  
+Unit          Id           Type        Pool      Provider id                 Size    Status    Message
+postgresql/0  db-dir/1100  block                                                     attached  
+transcode/0   db-dir/1000  block                                                     pending   creating volume
+transcode/0   shared-fs/0  filesystem  radiance  provider-supplied-volume-4  1.0GiB  attached  
+transcode/1   shared-fs/0  filesystem  radiance  provider-supplied-volume-4  1.0GiB  attached  
 
 `[1:])
 }
@@ -58,11 +58,11 @@ func (s *ListSuite) TestListNoPool(c *gc.C) {
 		// Default format is tabular
 		`
 \[Storage\]
-Unit          Id           Provider id                 Size    Status    Message
-postgresql/0  db-dir/1100                                      attached  
-transcode/0   db-dir/1000                                      pending   creating volume
-transcode/0   shared-fs/0  provider-supplied-volume-4  1.0GiB  attached  
-transcode/1   shared-fs/0  provider-supplied-volume-4  1.0GiB  attached  
+Unit          Id           Type        Provider id                 Size    Status    Message
+postgresql/0  db-dir/1100  block                                           attached  
+transcode/0   db-dir/1000  block                                           pending   creating volume
+transcode/0   shared-fs/0  filesystem  provider-supplied-volume-4  1.0GiB  attached  
+transcode/1   shared-fs/0  filesystem  provider-supplied-volume-4  1.0GiB  attached  
 
 `[1:])
 }

--- a/cmd/juju/storage/list_test.go
+++ b/cmd/juju/storage/list_test.go
@@ -126,8 +126,6 @@ filesystems:
       since: .*
   "1":
     provider-id: provider-supplied-filesystem-1
-    volume: ""
-    storage: ""
     attachments:
       machines:
         "0":
@@ -140,8 +138,6 @@ filesystems:
       since: .*
   "2":
     provider-id: provider-supplied-filesystem-2
-    volume: ""
-    storage: ""
     attachments:
       machines:
         "1":
@@ -152,8 +148,6 @@ filesystems:
       current: attached
       since: .*
   "3":
-    volume: ""
-    storage: ""
     attachments:
       machines:
         "1":
@@ -165,7 +159,6 @@ filesystems:
       since: .*
   "4":
     provider-id: provider-supplied-filesystem-4
-    volume: ""
     storage: shared-fs/0
     attachments:
       machines:

--- a/cmd/juju/storage/listformatters.go
+++ b/cmd/juju/storage/listformatters.go
@@ -48,7 +48,7 @@ func formatStorageListTabular(
 		}
 	}
 
-	w.Print("Unit", "Id")
+	w.Print("Unit", "Id", "Type")
 	if len(storagePool) > 0 {
 		// Older versions of Juju do not include
 		// the pool name in the storage details.
@@ -71,7 +71,7 @@ func formatStorageListTabular(
 			}
 			continue
 		}
-		for unitId, a := range storageInfo.Attachments.Units {
+		for unitId := range storageInfo.Attachments.Units {
 			byStorage := byUnit[unitId]
 			if byStorage == nil {
 				byStorage = make(map[string]storageAttachmentInfo)
@@ -80,7 +80,7 @@ func formatStorageListTabular(
 			byStorage[storageId] = storageAttachmentInfo{
 				storageId: storageId,
 				unitId:    unitId,
-				location:  a.Location,
+				kind:      storageInfo.Kind,
 				status:    storageInfo.Status,
 			}
 		}
@@ -110,6 +110,7 @@ func formatStorageListTabular(
 			}
 			w.Print(info.unitId)
 			w.Print(info.storageId)
+			w.Print(info.kind)
 			if len(storagePool) > 0 {
 				w.Print(storagePool[info.storageId])
 			}
@@ -129,7 +130,7 @@ func formatStorageListTabular(
 type storageAttachmentInfo struct {
 	storageId string
 	unitId    string
-	location  string
+	kind      string
 	status    EntityStatus
 }
 

--- a/cmd/juju/storage/listformatters.go
+++ b/cmd/juju/storage/listformatters.go
@@ -4,26 +4,58 @@
 package storage
 
 import (
-	"fmt"
 	"io"
 	"sort"
 	"strconv"
 	"strings"
 
+	"github.com/dustin/go-humanize"
 	"github.com/juju/juju/cmd/output"
 )
 
 // formatListTabular writes a tabular summary of storage instances.
-func formatStorageListTabular(writer io.Writer, storageInfo map[string]StorageInfo) error {
+func formatStorageListTabular(
+	writer io.Writer,
+	storageInfo map[string]StorageInfo,
+	filesystems map[string]FilesystemInfo,
+	volumes map[string]VolumeInfo,
+) error {
 	tw := output.TabWriter(writer)
-	p := func(values ...interface{}) {
-		for _, v := range values {
-			fmt.Fprintf(tw, "%v\t", v)
+	w := output.Wrapper{tw}
+	w.Println("[Storage]")
+
+	storageProviderId := make(map[string]string)
+	storageSize := make(map[string]uint64)
+	storagePool := make(map[string]string)
+	for _, f := range filesystems {
+		if f.Pool != "" {
+			storagePool[f.Storage] = f.Pool
 		}
-		fmt.Fprintln(tw)
+		storageProviderId[f.Storage] = f.ProviderFilesystemId
+		storageSize[f.Storage] = f.Size
 	}
-	p("[Storage]")
-	p("Unit\tId\tLocation\tStatus\tMessage")
+	for _, v := range volumes {
+		// This will intentionally override the provider ID
+		// and pool for a volume-backed filesystem.
+		if v.Pool != "" {
+			storagePool[v.Storage] = v.Pool
+		}
+		storageProviderId[v.Storage] = v.ProviderVolumeId
+		// For size, we want to use the size of the fileystem
+		// rather than the volume.
+		if _, ok := storageSize[v.Storage]; !ok {
+			storageSize[v.Storage] = v.Size
+		}
+	}
+
+	w.Print("Unit", "Id")
+	if len(storagePool) > 0 {
+		// Older versions of Juju do not include
+		// the pool name in the storage details.
+		// We omit the column in that case.
+		w.Print("Pool")
+	}
+	w.Println("Provider id", "Size", "Status", "Message")
 
 	byUnit := make(map[string]map[string]storageAttachmentInfo)
 	for storageId, storageInfo := range storageInfo {
@@ -34,10 +66,8 @@ func formatStorageListTabular(writer io.Writer, storageInfo map[string]StorageIn
 				byUnit[""] = byStorage
 			}
 			byStorage[storageId] = storageAttachmentInfo{
-				storageId:  storageId,
-				kind:       storageInfo.Kind,
-				persistent: storageInfo.Persistent,
-				status:     storageInfo.Status,
+				storageId: storageId,
+				status:    storageInfo.Status,
 			}
 			continue
 		}
@@ -48,12 +78,10 @@ func formatStorageListTabular(writer io.Writer, storageInfo map[string]StorageIn
 				byUnit[unitId] = byStorage
 			}
 			byStorage[storageId] = storageAttachmentInfo{
-				storageId:  storageId,
-				unitId:     unitId,
-				kind:       storageInfo.Kind,
-				persistent: storageInfo.Persistent,
-				location:   a.Location,
-				status:     storageInfo.Status,
+				storageId: storageId,
+				unitId:    unitId,
+				location:  a.Location,
+				status:    storageInfo.Status,
 			}
 		}
 	}
@@ -76,7 +104,21 @@ func formatStorageListTabular(writer io.Writer, storageInfo map[string]StorageIn
 
 		for _, storageId := range storageIds {
 			info := byStorage[storageId]
-			p(info.unitId, info.storageId, info.location, info.status.Current, info.status.Message)
+			var sizeStr string
+			if size := storageSize[storageId]; size > 0 {
+				sizeStr = humanize.IBytes(size * humanize.MiByte)
+			}
+			w.Print(info.unitId)
+			w.Print(info.storageId)
+			if len(storagePool) > 0 {
+				w.Print(storagePool[info.storageId])
+			}
+			w.Print(
+				storageProviderId[info.storageId],
+				sizeStr,
+			)
+			w.PrintStatus(info.status.Current)
+			w.Println(info.status.Message)
 		}
 	}
 	tw.Flush()
@@ -85,12 +127,10 @@ func formatStorageListTabular(writer io.Writer, storageInfo map[string]StorageIn
 }
 
 type storageAttachmentInfo struct {
-	storageId  string
-	unitId     string
-	kind       string
-	persistent bool
-	location   string
-	status     EntityStatus
+	storageId string
+	unitId    string
+	location  string
+	status    EntityStatus
 }
 
 type slashSeparatedIds []string

--- a/cmd/juju/storage/storage.go
+++ b/cmd/juju/storage/storage.go
@@ -35,6 +35,7 @@ func (c *StorageCommandBase) NewStorageAPI() (*storage.Client, error) {
 // StorageInfo defines the serialization behaviour of the storage information.
 type StorageInfo struct {
 	Kind        string              `yaml:"kind" json:"kind"`
+	Life        string              `yaml:"life,omitempty" json:"life,omitempty"`
 	Status      EntityStatus        `yaml:"status" json:"status"`
 	Persistent  bool                `yaml:"persistent" json:"persistent"`
 	Attachments *StorageAttachments `yaml:"attachments" json:"attachments"`
@@ -57,6 +58,9 @@ type UnitStorageAttachment struct {
 
 	// Location is the location of the storage attachment.
 	Location string `yaml:"location,omitempty" json:"location,omitempty"`
+
+	// Life is the lifecycle state of the storage attachment.
+	Life string `yaml:"life,omitempty" json:"life,omitempty"`
 
 	// TODO(axw) per-unit status when we have it in state.
 }
@@ -86,6 +90,7 @@ func createStorageInfo(details params.StorageDetails) (names.StorageTag, Storage
 
 	info := StorageInfo{
 		Kind: details.Kind.String(),
+		Life: string(details.Life),
 		Status: EntityStatus{
 			details.Status.Status,
 			details.Status.Info,
@@ -113,6 +118,7 @@ func createStorageInfo(details params.StorageDetails) (names.StorageTag, Storage
 			unitStorageAttachments[unitTag.Id()] = UnitStorageAttachment{
 				machineId,
 				attachmentDetails.Location,
+				string(attachmentDetails.Life),
 			}
 		}
 		info.Attachments = &StorageAttachments{unitStorageAttachments}

--- a/cmd/juju/storage/volume.go
+++ b/cmd/juju/storage/volume.go
@@ -36,6 +36,9 @@ type VolumeInfo struct {
 	// from params.Volume
 	Persistent bool `yaml:"persistent" json:"persistent"`
 
+	// Life is the lifecycle state of the volume.
+	Life string `yaml:"life,omitempty" json:"life,omitempty"`
+
 	// from params.Volume
 	Status EntityStatus `yaml:"status,omitempty" json:"status,omitempty"`
 }
@@ -56,6 +59,7 @@ type MachineVolumeAttachment struct {
 	DeviceLink string `yaml:"device-link,omitempty" json:"device-link,omitempty"`
 	BusAddress string `yaml:"bus-address,omitempty" json:"bus-address,omitempty"`
 	ReadOnly   bool   `yaml:"read-only" json:"read-only"`
+	Life       string `yaml:"life,omitempty" json:"life,omitempty"`
 	// TODO(axw) add machine volume attachment status when we have it
 }
 
@@ -114,6 +118,7 @@ func createVolumeInfo(details params.VolumeDetails) (names.VolumeTag, VolumeInfo
 	info.HardwareId = details.Info.HardwareId
 	info.Size = details.Info.Size
 	info.Persistent = details.Info.Persistent
+	info.Life = string(details.Life)
 	info.Status = EntityStatus{
 		details.Status.Status,
 		details.Status.Info,
@@ -133,6 +138,7 @@ func createVolumeInfo(details params.VolumeDetails) (names.VolumeTag, VolumeInfo
 				attachment.DeviceLink,
 				attachment.BusAddress,
 				attachment.ReadOnly,
+				string(attachment.Life),
 			}
 		}
 		info.Attachments = &VolumeAttachments{

--- a/cmd/juju/storage/volume.go
+++ b/cmd/juju/storage/volume.go
@@ -27,6 +27,9 @@ type VolumeInfo struct {
 	// Attachments is the set of entities attached to the volume.
 	Attachments *VolumeAttachments `yaml:"attachments,omitempty" json:"attachments,omitempty"`
 
+	// Pool is the name of the storage pool that the volume came from.
+	Pool string `yaml:"pool,omitempty" json:"pool,omitempty"`
+
 	// from params.Volume
 	HardwareId string `yaml:"hardware-id,omitempty" json:"hardware-id,omitempty"`
 
@@ -116,6 +119,7 @@ func createVolumeInfo(details params.VolumeDetails) (names.VolumeTag, VolumeInfo
 	var info VolumeInfo
 	info.ProviderVolumeId = details.Info.VolumeId
 	info.HardwareId = details.Info.HardwareId
+	info.Pool = details.Info.Pool
 	info.Size = details.Info.Size
 	info.Persistent = details.Info.Persistent
 	info.Life = string(details.Life)

--- a/cmd/juju/storage/volumelist_test.go
+++ b/cmd/juju/storage/volumelist_test.go
@@ -73,7 +73,8 @@ func (s *ListSuite) TestVolumeListJSON(c *gc.C) {
 
 func (s *ListSuite) TestVolumeListWithErrorResults(c *gc.C) {
 	s.mockAPI.listVolumes = func([]string) ([]params.VolumeDetailsListResult, error) {
-		results, _ := mockListAPI{}.ListVolumes(nil)
+		var emptyMockAPI mockListAPI
+		results, _ := emptyMockAPI.ListVolumes(nil)
 		results = append(results, params.VolumeDetailsListResult{
 			Error: &params.Error{Message: "bad"},
 		})
@@ -106,7 +107,8 @@ func (s *ListSuite) TestVolumeListTabular(c *gc.C) {
 	// Do it again, reversing the results returned by the API.
 	// We should get everything sorted in the appropriate order.
 	s.mockAPI.listVolumes = func([]string) ([]params.VolumeDetailsListResult, error) {
-		results, _ := mockListAPI{}.ListVolumes(nil)
+		var emptyMockAPI mockListAPI
+		results, _ := emptyMockAPI.ListVolumes(nil)
 		n := len(results)
 		for i := 0; i < n/2; i++ {
 			results[i], results[n-i-1] = results[n-i-1], results[i]
@@ -169,7 +171,7 @@ func (s *ListSuite) assertUserFacingVolumeOutput(c *gc.C, context *cmd.Context, 
 	c.Assert(obtainedErr, gc.Equals, expectedErr)
 }
 
-func (s mockListAPI) ListVolumes(machines []string) ([]params.VolumeDetailsListResult, error) {
+func (s *mockListAPI) ListVolumes(machines []string) ([]params.VolumeDetailsListResult, error) {
 	if s.listVolumes != nil {
 		return s.listVolumes(machines)
 	}
@@ -181,18 +183,24 @@ func (s mockListAPI) ListVolumes(machines []string) ([]params.VolumeDetailsListR
 			VolumeTag: "volume-0-0",
 			Info: params.VolumeInfo{
 				VolumeId: "provider-supplied-volume-0-0",
+				Pool:     "radiance",
 				Size:     512,
 			},
+			Life:   "alive",
 			Status: createTestStatus(status.Attached, ""),
-			MachineAttachments: map[string]params.VolumeAttachmentInfo{
-				"machine-0": params.VolumeAttachmentInfo{
-					DeviceName: "loop0",
+			MachineAttachments: map[string]params.VolumeAttachmentDetails{
+				"machine-0": {
+					Life: "alive",
+					VolumeAttachmentInfo: params.VolumeAttachmentInfo{
+						DeviceName: "loop0",
+					},
 				},
 			},
 			Storage: &params.StorageDetails{
 				StorageTag: "storage-db-dir-1001",
 				OwnerTag:   "unit-abc-0",
 				Kind:       params.StorageKindBlock,
+				Life:       "alive",
 				Status:     createTestStatus(status.Attached, ""),
 				Attachments: map[string]params.StorageAttachmentDetails{
 					"unit-abc-0": params.StorageAttachmentDetails{
@@ -215,8 +223,8 @@ func (s mockListAPI) ListVolumes(machines []string) ([]params.VolumeDetailsListR
 				Size:       2048,
 			},
 			Status: createTestStatus(status.Attaching, "failed to attach, will retry"),
-			MachineAttachments: map[string]params.VolumeAttachmentInfo{
-				"machine-0": params.VolumeAttachmentInfo{},
+			MachineAttachments: map[string]params.VolumeAttachmentDetails{
+				"machine-0": {},
 			},
 		},
 		// volume 3 is due to be attached to machine 1, but is not
@@ -227,8 +235,8 @@ func (s mockListAPI) ListVolumes(machines []string) ([]params.VolumeDetailsListR
 				Size: 42,
 			},
 			Status: createTestStatus(status.Pending, ""),
-			MachineAttachments: map[string]params.VolumeAttachmentInfo{
-				"machine-1": params.VolumeAttachmentInfo{},
+			MachineAttachments: map[string]params.VolumeAttachmentDetails{
+				"machine-1": {},
 			},
 		},
 		// volume 2 is due to be attached to machine 1, but is not
@@ -240,9 +248,11 @@ func (s mockListAPI) ListVolumes(machines []string) ([]params.VolumeDetailsListR
 				Size:     3,
 			},
 			Status: createTestStatus(status.Attached, ""),
-			MachineAttachments: map[string]params.VolumeAttachmentInfo{
-				"machine-1": params.VolumeAttachmentInfo{
-					DeviceName: "xvdf1",
+			MachineAttachments: map[string]params.VolumeAttachmentDetails{
+				"machine-1": {
+					VolumeAttachmentInfo: params.VolumeAttachmentInfo{
+						DeviceName: "xvdf1",
+					},
 				},
 			},
 		},
@@ -256,14 +266,18 @@ func (s mockListAPI) ListVolumes(machines []string) ([]params.VolumeDetailsListR
 				Size:       1024,
 			},
 			Status: createTestStatus(status.Attached, ""),
-			MachineAttachments: map[string]params.VolumeAttachmentInfo{
-				"machine-0": params.VolumeAttachmentInfo{
-					DeviceName: "xvdf2",
-					ReadOnly:   true,
+			MachineAttachments: map[string]params.VolumeAttachmentDetails{
+				"machine-0": {
+					VolumeAttachmentInfo: params.VolumeAttachmentInfo{
+						DeviceName: "xvdf2",
+						ReadOnly:   true,
+					},
 				},
-				"machine-1": params.VolumeAttachmentInfo{
-					DeviceName: "xvdf3",
-					ReadOnly:   true,
+				"machine-1": {
+					VolumeAttachmentInfo: params.VolumeAttachmentInfo{
+						DeviceName: "xvdf3",
+						ReadOnly:   true,
+					},
 				},
 			},
 			Storage: &params.StorageDetails{
@@ -288,6 +302,14 @@ func (s mockListAPI) ListVolumes(machines []string) ([]params.VolumeDetailsListR
 			},
 		},
 	}}}
+	if s.omitPool {
+		for _, result := range results {
+			for i, details := range result.Result {
+				details.Info.Pool = ""
+				result.Result[i] = details
+			}
+		}
+	}
 	return results, nil
 }
 

--- a/cmd/output/output.go
+++ b/cmd/output/output.go
@@ -96,6 +96,8 @@ var statusColors = map[status.Status]*ansiterm.Context{
 	status.Idle:      GoodHighlight,
 	status.Started:   GoodHighlight,
 	status.Executing: GoodHighlight,
+	status.Attaching: GoodHighlight,
+	status.Attached:  GoodHighlight,
 	// busy
 	status.Allocating:  WarningHighlight,
 	status.Lost:        WarningHighlight,
@@ -104,6 +106,8 @@ var statusColors = map[status.Status]*ansiterm.Context{
 	status.Rebooting:   WarningHighlight,
 	status.Stopped:     WarningHighlight,
 	status.Unknown:     WarningHighlight,
+	status.Detaching:   WarningHighlight,
+	status.Detached:    WarningHighlight,
 	// bad
 	status.Blocked: ErrorHighlight,
 	status.Down:    ErrorHighlight,

--- a/featuretests/storage_test.go
+++ b/featuretests/storage_test.go
@@ -85,6 +85,7 @@ func (s *cmdStorageSuite) TestStorageShow(c *gc.C) {
 	expected := `
 data/0:
   kind: block
+  life: alive
   status:
     current: pending
     since: .*
@@ -93,6 +94,7 @@ data/0:
     units:
       storage-block/0:
         machine: "0"
+        life: alive
 `[1:]
 	context, err := runJujuCommand(c, "show-storage", "data/0")
 	c.Assert(err, jc.ErrorIsNil)
@@ -169,6 +171,7 @@ func (s *cmdStorageSuite) TestStoragePersistentProvisioned(c *gc.C) {
 	expected := `
 data/0:
   kind: block
+  life: alive
   status:
     current: pending
     since: .*
@@ -177,6 +180,7 @@ data/0:
     units:
       storage-block/0:
         machine: "0"
+        life: alive
 `[1:]
 	context, err := runJujuCommand(c, "show-storage", "data/0")
 	c.Assert(err, jc.ErrorIsNil)
@@ -191,6 +195,7 @@ func (s *cmdStorageSuite) TestStoragePersistentUnprovisioned(c *gc.C) {
 	expected := `
 data/0:
   kind: block
+  life: alive
   status:
     current: pending
     since: .*
@@ -199,6 +204,7 @@ data/0:
     units:
       storage-block/0:
         machine: "0"
+        life: alive
 `[1:]
 	context, err := runJujuCommand(c, "show-storage", "data/0")
 	c.Assert(err, jc.ErrorIsNil)

--- a/featuretests/storage_test.go
+++ b/featuretests/storage_test.go
@@ -128,8 +128,8 @@ func (s *cmdStorageSuite) TestStorageList(c *gc.C) {
 
 	expected := `
 [Storage]
-Unit             Id      Provider id  Size  Status   Message
-storage-block/0  data/0                     pending  
+Unit             Id      Type   Provider id  Size  Status   Message
+storage-block/0  data/0  block                     pending  
 
 `[1:]
 	runList(c, expected)
@@ -142,8 +142,8 @@ func (s *cmdStorageSuite) TestStorageListPersistent(c *gc.C) {
 	// will be persistent until it has been provisioned.
 	expected := `
 [Storage]
-Unit             Id      Provider id  Size  Status   Message
-storage-block/0  data/0                     pending  
+Unit             Id      Type   Provider id  Size  Status   Message
+storage-block/0  data/0  block                     pending  
 
 `[1:]
 	runList(c, expected)
@@ -555,8 +555,8 @@ func (s *cmdStorageSuite) TestStorageAddToUnitHasVolumes(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(testing.Stdout(context), gc.Equals, `
 [Storage]
-Unit                  Id      Provider id  Size  Status   Message
-storage-filesystem/0  data/0                     pending  
+Unit                  Id      Type        Provider id  Size  Status   Message
+storage-filesystem/0  data/0  filesystem                     pending  
 
 `[1:])
 	c.Assert(testing.Stderr(context), gc.Equals, "")
@@ -578,9 +578,9 @@ storage-filesystem/0  data/0                     pending
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(testing.Stdout(context), gc.Equals, `
 [Storage]
-Unit                  Id      Provider id  Size  Status   Message
-storage-filesystem/0  data/0                     pending  
-storage-filesystem/0  data/1                     pending  
+Unit                  Id      Type        Provider id  Size  Status   Message
+storage-filesystem/0  data/0  filesystem                     pending  
+storage-filesystem/0  data/1  filesystem                     pending  
 
 `[1:])
 	c.Assert(testing.Stderr(context), gc.Equals, "")

--- a/featuretests/storage_test.go
+++ b/featuretests/storage_test.go
@@ -127,13 +127,9 @@ func (s *cmdStorageSuite) TestStorageList(c *gc.C) {
 	createUnitWithStorage(c, &s.JujuConnSuite, testPool)
 
 	expected := `
-[Storage]        
-Unit             Id      Location  Status   Message  
-storage-block/0  data/0            pending           
-
-[Volumes]
-Machine  Unit             Storage  Id   Provider Id  Device  Size  State    Message
-0        storage-block/0  data/0   0/0                             pending  
+[Storage]
+Unit             Id      Provider id  Size  Status   Message
+storage-block/0  data/0                     pending  
 
 `[1:]
 	runList(c, expected)
@@ -145,13 +141,9 @@ func (s *cmdStorageSuite) TestStorageListPersistent(c *gc.C) {
 	// There are currently no guarantees about whether storage
 	// will be persistent until it has been provisioned.
 	expected := `
-[Storage]        
-Unit             Id      Location  Status   Message  
-storage-block/0  data/0            pending           
-
-[Volumes]
-Machine  Unit             Storage  Id   Provider Id  Device  Size  State    Message
-0        storage-block/0  data/0   0/0                             pending  
+[Storage]
+Unit             Id      Provider id  Size  Status   Message
+storage-block/0  data/0                     pending  
 
 `[1:]
 	runList(c, expected)
@@ -562,17 +554,9 @@ func (s *cmdStorageSuite) TestStorageAddToUnitHasVolumes(c *gc.C) {
 	context, err := runJujuCommand(c, "storage")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(testing.Stdout(context), gc.Equals, `
-[Storage]             
-Unit                  Id      Location  Status   Message  
-storage-filesystem/0  data/0            pending           
-
-[Filesystems]
-Machine  Unit                  Storage  Id   Volume  Provider id  Mountpoint  Size  State    Message
-0        storage-filesystem/0  data/0   0/0  0                                      pending  
-
-[Volumes]
-Machine  Unit                  Storage  Id  Provider Id  Device  Size  State    Message
-0        storage-filesystem/0  data/0   0                              pending  
+[Storage]
+Unit                  Id      Provider id  Size  Status   Message
+storage-filesystem/0  data/0                     pending  
 
 `[1:])
 	c.Assert(testing.Stderr(context), gc.Equals, "")
@@ -593,20 +577,10 @@ Machine  Unit                  Storage  Id  Provider Id  Device  Size  State    
 	context, err = runJujuCommand(c, "list-storage")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(testing.Stdout(context), gc.Equals, `
-[Storage]             
-Unit                  Id      Location  Status   Message  
-storage-filesystem/0  data/0            pending           
-storage-filesystem/0  data/1            pending           
-
-[Filesystems]
-Machine  Unit                  Storage  Id   Volume  Provider id  Mountpoint  Size  State    Message
-0        storage-filesystem/0  data/0   0/0  0                                      pending  
-0        storage-filesystem/0  data/1   0/1  1                                      pending  
-
-[Volumes]
-Machine  Unit                  Storage  Id  Provider Id  Device  Size  State    Message
-0        storage-filesystem/0  data/0   0                              pending  
-0        storage-filesystem/0  data/1   1                              pending  
+[Storage]
+Unit                  Id      Provider id  Size  Status   Message
+storage-filesystem/0  data/0                     pending  
+storage-filesystem/0  data/1                     pending  
 
 `[1:])
 	c.Assert(testing.Stderr(context), gc.Equals, "")

--- a/worker/provisioner/provisioner_task.go
+++ b/worker/provisioner/provisioner_task.go
@@ -812,6 +812,7 @@ func volumesToAPIserver(volumes []storage.Volume) []params.Volume {
 			params.VolumeInfo{
 				v.VolumeId,
 				v.HardwareId,
+				"", // pool
 				v.Size,
 				v.Persistent,
 			},

--- a/worker/storageprovisioner/filesystem_ops.go
+++ b/worker/storageprovisioner/filesystem_ops.go
@@ -469,6 +469,7 @@ func filesystemsFromStorage(in []storage.Filesystem) []params.Filesystem {
 			"",
 			params.FilesystemInfo{
 				f.FilesystemId,
+				"", // pool
 				f.Size,
 			},
 		}

--- a/worker/storageprovisioner/volume_events.go
+++ b/worker/storageprovisioner/volume_events.go
@@ -390,6 +390,7 @@ func volumesFromStorage(in []storage.Volume) []params.Volume {
 			params.VolumeInfo{
 				v.VolumeId,
 				v.HardwareId,
+				"", // pool
 				v.Size,
 				v.Persistent,
 			},


### PR DESCRIPTION
## Description of change

Instead of having storage, volumes and filesystems,
we go back to having just "storage". It is not
helpful to separate storage from volume/filesystem;
instead, we add more information from the machine
storage to the unit storage entry.

New fields added to volume/filesystem/storage:
include "life" in the storage, volume, filesystem
details in YAML/JSON output. This can be useful for
debugging. Included the pool name in volume and
filesystem info. The pool name is useful for users
to see what class of storage is attached to a unit.

Also: fix a bug that would cause "juju storage" to
fail when a storage instance has no associated
volume or filesystem. This will be the case up
until the storage instance's attached unit is assigned
to a machine.

## QA steps

SCENARIO 1
1. juju bootstrap
2. juju deploy postgresql --storage pgdata=1G
3. juju storage --format=yaml
check that the storage includes life fields, status is colourised

The colour for status should be yellow for "detaching", "detached", and green for "attaching", "attached".

SCENARIO 2
same as scenario 1, but use juju 2.0 client in step 3
(check that it can handle the new fields.)

SCENARIO 3
same as scenario 1, but use juju 2.0 client in steps 1-2
(check that juju storage works, but the "Pool" column is omitted.)

## Documentation changes

The tabular format of "juju storage" has been updated. If there are any examples in the documentation, we should update them to match.

## Bug reference

None.