### PR TITLE
discoverspaces: Get subnets when provider doesn't support space discovery

### DIFF
--- a/apiserver/common/networkingcommon/shims.go
+++ b/apiserver/common/networkingcommon/shims.go
@@ -110,7 +110,7 @@ func (s *stateShim) AllSpaces() ([]BackingSpace, error) {
 }
 
 func (s *stateShim) AddSubnet(info BackingSubnetInfo) (BackingSubnet, error) {
-	// TODO(dimitern): Add multiple AZs per subnet in state.
+	// TODO(xtian): cargo culting taking the first zone - why was this done?
 	var firstZone string
 	if len(info.AvailabilityZones) > 0 {
 		firstZone = info.AvailabilityZones[0]

--- a/apiserver/common/networkingcommon/subnets.go
+++ b/apiserver/common/networkingcommon/subnets.go
@@ -414,12 +414,16 @@ func ListSubnets(api NetworkBacking, args params.SubnetsFilters) (results params
 			)
 			continue
 		}
+		var spaceTag string
+		if subnet.SpaceName() != "" {
+			spaceTag = names.NewSpaceTag(subnet.SpaceName()).String()
+		}
 		result := params.Subnet{
 			CIDR:       subnet.CIDR(),
 			ProviderId: string(subnet.ProviderId()),
 			VLANTag:    subnet.VLANTag(),
 			Life:       subnet.Life(),
-			SpaceTag:   names.NewSpaceTag(subnet.SpaceName()).String(),
+			SpaceTag:   spaceTag,
 			Zones:      subnet.AvailabilityZones(),
 			Status:     subnet.Status(),
 		}

--- a/apiserver/common/networkingcommon/subnets.go
+++ b/apiserver/common/networkingcommon/subnets.go
@@ -414,6 +414,9 @@ func ListSubnets(api NetworkBacking, args params.SubnetsFilters) (results params
 			)
 			continue
 		}
+		// TODO(babbageclunk): make the empty string a valid space
+		// name, rather than treating blank as "doesn't have a space".
+		// lp:1672888
 		var spaceTag string
 		if subnet.SpaceName() != "" {
 			spaceTag = names.NewSpaceTag(subnet.SpaceName()).String()

--- a/apiserver/common/networkingcommon/subnets_test.go
+++ b/apiserver/common/networkingcommon/subnets_test.go
@@ -789,6 +789,26 @@ func (s *SubnetsSuite) TestListSubnetsInvalidSpaceTag(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, `"invalid" is not a valid tag`)
 }
 
+func (s *SubnetsSuite) TestListSubnetsBlankSpaceTag(c *gc.C) {
+	args := params.SubnetsFilters{}
+	apiservertesting.BackingInstance.Subnets = []networkingcommon.BackingSubnet{
+		&apiservertesting.FakeSubnet{Info: networkingcommon.BackingSubnetInfo{
+			CIDR:              "10.0.10.0/24",
+			ProviderId:        "1",
+			AvailabilityZones: []string{"zone1"},
+			SpaceName:         "",
+		}},
+	}
+	results, err := networkingcommon.ListSubnets(apiservertesting.BackingInstance, args)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(results, gc.DeepEquals, params.ListSubnetsResults{Results: []params.Subnet{{
+		CIDR:       "10.0.10.0/24",
+		ProviderId: "1",
+		SpaceTag:   "",
+		Zones:      []string{"zone1"},
+	}}})
+}
+
 func (s *SubnetsSuite) TestListSubnetsAllSubnetError(c *gc.C) {
 	boom := errors.New("no subnets for you")
 	apiservertesting.BackingInstance.SetErrors(boom)

--- a/apiserver/discoverspaces/discoverspaces.go
+++ b/apiserver/discoverspaces/discoverspaces.go
@@ -5,35 +5,40 @@ package discoverspaces
 
 import (
 	"github.com/juju/errors"
+	"github.com/juju/utils/set"
+	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/common/networkingcommon"
 	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/network"
 	"github.com/juju/juju/state"
 )
 
 func init() {
-	common.RegisterStandardFacade("DiscoverSpaces", 2, NewDiscoverSpacesAPI)
+	common.RegisterStandardFacade("DiscoverSpaces", 2, NewAPI)
 }
 
-// DiscoverSpacesAPI implements the API used by the discoverspaces worker.
-type DiscoverSpacesAPI struct {
+// API implements the API used by the discoverspaces worker.
+type API struct {
 	st         networkingcommon.NetworkBacking
 	resources  facade.Resources
 	authorizer facade.Authorizer
 }
 
-// NewDiscoverSpacesAPI creates a new instance of the DiscoverSpaces API.
-func NewDiscoverSpacesAPI(st *state.State, resources facade.Resources, authorizer facade.Authorizer) (*DiscoverSpacesAPI, error) {
-	return NewDiscoverSpacesAPIWithBacking(networkingcommon.NewStateShim(st), resources, authorizer)
+// NewAPI creates a new instance of the DiscoverSpaces API.
+func NewAPI(st *state.State, resources facade.Resources, authorizer facade.Authorizer) (*API, error) {
+	return NewAPIWithBacking(networkingcommon.NewStateShim(st), resources, authorizer)
 }
 
-func NewDiscoverSpacesAPIWithBacking(st networkingcommon.NetworkBacking, resources facade.Resources, authorizer facade.Authorizer) (*DiscoverSpacesAPI, error) {
+// NewAPIWithBacking creates an API instance from the given network
+// backing (primarily useful from tests).
+func NewAPIWithBacking(st networkingcommon.NetworkBacking, resources facade.Resources, authorizer facade.Authorizer) (*API, error) {
 	if !authorizer.AuthController() {
 		return nil, common.ErrPerm
 	}
-	return &DiscoverSpacesAPI{
+	return &API{
 		st:         st,
 		authorizer: authorizer,
 		resources:  resources,
@@ -41,7 +46,7 @@ func NewDiscoverSpacesAPIWithBacking(st networkingcommon.NetworkBacking, resourc
 }
 
 // ModelConfig returns the current model's configuration.
-func (api *DiscoverSpacesAPI) ModelConfig() (params.ModelConfigResult, error) {
+func (api *API) ModelConfig() (params.ModelConfigResult, error) {
 	result := params.ModelConfigResult{}
 
 	config, err := api.st.ModelConfig()
@@ -57,12 +62,12 @@ func (api *DiscoverSpacesAPI) ModelConfig() (params.ModelConfigResult, error) {
 
 // CreateSpaces creates a new Juju network space, associating the
 // specified subnets with it (optional; can be empty).
-func (api *DiscoverSpacesAPI) CreateSpaces(args params.CreateSpacesParams) (results params.ErrorResults, err error) {
+func (api *API) CreateSpaces(args params.CreateSpacesParams) (results params.ErrorResults, err error) {
 	return networkingcommon.CreateSpaces(api.st, args)
 }
 
 // ListSpaces lists all the available spaces and their associated subnets.
-func (api *DiscoverSpacesAPI) ListSpaces() (results params.DiscoverSpacesResults, err error) {
+func (api *API) ListSpaces() (results params.DiscoverSpacesResults, err error) {
 	spaces, err := api.st.AllSpaces()
 	if err != nil {
 		return results, errors.Trace(err)
@@ -91,13 +96,62 @@ func (api *DiscoverSpacesAPI) ListSpaces() (results params.DiscoverSpacesResults
 	return results, nil
 }
 
-// AddSubnets is defined on the API interface.
-func (api *DiscoverSpacesAPI) AddSubnets(args params.AddSubnetsParams) (params.ErrorResults, error) {
-	return networkingcommon.AddSubnets(api.st, args)
+// AddSubnets adds the passed subnet info to the backing store.
+func (api *API) AddSubnets(args params.AddSubnetsParams) (params.ErrorResults, error) {
+	var empty params.ErrorResults
+	if len(args.Subnets) == 0 {
+		return empty, nil
+	}
+	spaces, err := api.st.AllSpaces()
+	if err != nil {
+		return empty, errors.Trace(err)
+	}
+	spaceNames := set.NewStrings()
+	for _, space := range spaces {
+		spaceNames.Add(space.Name())
+	}
+
+	addOneSubnet := func(arg params.AddSubnetParams) error {
+		if arg.SubnetProviderId == "" {
+			return errors.Trace(errors.New("SubnetProviderId is required"))
+		}
+		spaceName := ""
+		if arg.SpaceTag != "" {
+			spaceTag, err := names.ParseSpaceTag(arg.SpaceTag)
+			if err != nil {
+				return errors.Annotate(err, "SpaceTag is invalid")
+			}
+			spaceName = spaceTag.Id()
+			if !spaceNames.Contains(spaceName) {
+				return errors.NotFoundf("space %q", spaceName)
+			}
+		}
+		if arg.SubnetTag == "" {
+			return errors.New("SubnetTag is required")
+		}
+		subnetTag, err := names.ParseSubnetTag(arg.SubnetTag)
+		if err != nil {
+			return errors.Annotate(err, "SubnetTag is invalid")
+		}
+		_, err = api.st.AddSubnet(networkingcommon.BackingSubnetInfo{
+			ProviderId:        network.Id(arg.SubnetProviderId),
+			CIDR:              subnetTag.Id(),
+			VLANTag:           arg.VLANTag,
+			AvailabilityZones: arg.Zones,
+			SpaceName:         spaceName,
+		})
+		return errors.Trace(err)
+	}
+
+	results := make([]params.ErrorResult, len(args.Subnets))
+	for i, arg := range args.Subnets {
+		results[i].Error = common.ServerError(addOneSubnet(arg))
+	}
+	return params.ErrorResults{Results: results}, nil
 }
 
 // ListSubnets lists all the available subnets or only those matching
 // all given optional filters.
-func (api *DiscoverSpacesAPI) ListSubnets(args params.SubnetsFilters) (results params.ListSubnetsResults, err error) {
+func (api *API) ListSubnets(args params.SubnetsFilters) (results params.ListSubnetsResults, err error) {
 	return networkingcommon.ListSubnets(api.st, args)
 }

--- a/apiserver/params/network.go
+++ b/apiserver/params/network.go
@@ -580,6 +580,7 @@ type AddSubnetParams struct {
 	SubnetTag        string   `json:"subnet-tag,omitempty"`
 	SubnetProviderId string   `json:"subnet-provider-id,omitempty"`
 	SpaceTag         string   `json:"space-tag"`
+	VLANTag          int      `json:"vlan-tag,omitempty"`
 	Zones            []string `json:"zones,omitempty"`
 }
 

--- a/apiserver/testing/stub_network.go
+++ b/apiserver/testing/stub_network.go
@@ -164,7 +164,7 @@ func (f *FakeSpace) Subnets() (bs []networkingcommon.BackingSubnet, err error) {
 			AvailabilityZones: zones,
 			Status:            status,
 		}
-		outputSubnets = append(outputSubnets, &FakeSubnet{info: backing})
+		outputSubnets = append(outputSubnets, &FakeSubnet{Info: backing})
 	}
 
 	return outputSubnets, nil
@@ -289,42 +289,42 @@ func (f *FakeZone) GoString() string {
 
 // FakeSubnet implements networkingcommon.BackingSubnet for testing.
 type FakeSubnet struct {
-	info networkingcommon.BackingSubnetInfo
+	Info networkingcommon.BackingSubnetInfo
 }
 
 var _ networkingcommon.BackingSubnet = (*FakeSubnet)(nil)
 
 // GoString implements fmt.GoStringer.
 func (f *FakeSubnet) GoString() string {
-	return fmt.Sprintf("&FakeSubnet{%#v}", f.info)
+	return fmt.Sprintf("&FakeSubnet{%#v}", f.Info)
 }
 
 func (f *FakeSubnet) Status() string {
-	return f.info.Status
+	return f.Info.Status
 }
 
 func (f *FakeSubnet) CIDR() string {
-	return f.info.CIDR
+	return f.Info.CIDR
 }
 
 func (f *FakeSubnet) AvailabilityZones() []string {
-	return f.info.AvailabilityZones
+	return f.Info.AvailabilityZones
 }
 
 func (f *FakeSubnet) ProviderId() network.Id {
-	return f.info.ProviderId
+	return f.Info.ProviderId
 }
 
 func (f *FakeSubnet) VLANTag() int {
-	return f.info.VLANTag
+	return f.Info.VLANTag
 }
 
 func (f *FakeSubnet) SpaceName() string {
-	return f.info.SpaceName
+	return f.Info.SpaceName
 }
 
 func (f *FakeSubnet) Life() params.Life {
-	return f.info.Life
+	return f.Info.Life
 }
 
 // ResetStub resets all recorded calls and errors of the given stub.
@@ -504,7 +504,7 @@ func (sb *StubBacking) AddSubnet(subnetInfo networkingcommon.BackingSubnetInfo) 
 	if err := sb.NextErr(); err != nil {
 		return nil, err
 	}
-	fs := &FakeSubnet{info: subnetInfo}
+	fs := &FakeSubnet{Info: subnetInfo}
 	sb.Subnets = append(sb.Subnets, fs)
 	return fs, nil
 }

--- a/cmd/juju/subnet/list.go
+++ b/cmd/juju/subnet/list.go
@@ -128,12 +128,14 @@ func (c *listCommand) Run(ctx *cmd.Context) error {
 			} else if ip.To16() != nil {
 				subResult.Type = typeIPv6
 			}
-			// Space must be valid, but verify anyway.
-			spaceTag, err := names.ParseSpaceTag(sub.SpaceTag)
-			if err != nil {
-				return errors.Annotatef(err, "subnet %q has invalid space", sub.CIDR)
+			if sub.SpaceTag != "" {
+				// Space must be valid, but verify anyway.
+				spaceTag, err := names.ParseSpaceTag(sub.SpaceTag)
+				if err != nil {
+					return errors.Annotatef(err, "subnet %q has invalid space", sub.CIDR)
+				}
+				subResult.Space = spaceTag.Id()
 			}
-			subResult.Space = spaceTag.Id()
 
 			// Display correct status according to the life cycle value.
 			switch sub.Life {

--- a/cmd/juju/subnet/list_test.go
+++ b/cmd/juju/subnet/list_test.go
@@ -330,3 +330,23 @@ func (s *ListSuite) TestRunWhenASubnetHasInvalidSpaceFails(c *gc.C) {
 	s.api.CheckCallNames(c, "ListSubnets", "Close")
 	s.api.CheckCall(c, 0, "ListSubnets", nil, "")
 }
+
+func (s *ListSuite) TestRunWhenSubnetHasBlankSpace(c *gc.C) {
+	s.api.Subnets = s.api.Subnets[0:1]
+	s.api.Subnets[0].SpaceTag = ""
+
+	expectedYAML := `
+subnets:
+  10.20.0.0/24:
+    type: ipv4
+    provider-id: subnet-foo
+    status: in-use
+    space: ""
+    zones:
+    - zone1
+    - zone2
+`[1:]
+	s.AssertRunSucceeds(c, "", expectedYAML)
+	s.api.CheckCallNames(c, "ListSubnets", "Close")
+	s.api.CheckCall(c, 0, "ListSubnets", nil, "")
+}

--- a/worker/discoverspaces/config_test.go
+++ b/worker/discoverspaces/config_test.go
@@ -20,18 +20,18 @@ var _ = gc.Suite(&ConfigSuite{})
 
 func (*ConfigSuite) TestAllSet(c *gc.C) {
 	config := discoverspaces.Config{
-		Facade:   fakeFacade{},
-		Environ:  fakeEnviron{},
+		Facade:   &fakeFacade{},
+		Environ:  &fakeEnviron{},
 		NewName:  fakeNewName,
-		Unlocker: fakeUnlocker{},
+		Unlocker: &fakeUnlocker{},
 	}
 	checkConfigValid(c, config)
 }
 
 func (*ConfigSuite) TestNilUnlocker(c *gc.C) {
 	config := discoverspaces.Config{
-		Facade:  fakeFacade{},
-		Environ: fakeEnviron{},
+		Facade:  &fakeFacade{},
+		Environ: &fakeEnviron{},
 		NewName: fakeNewName,
 	}
 	checkConfigValid(c, config)
@@ -43,7 +43,7 @@ func checkConfigValid(c *gc.C, config discoverspaces.Config) {
 
 func (*ConfigSuite) TestNilFacade(c *gc.C) {
 	config := discoverspaces.Config{
-		Environ: fakeEnviron{},
+		Environ: &fakeEnviron{},
 		NewName: fakeNewName,
 	}
 	checkAlwaysInvalid(c, config, "nil Facade not valid")
@@ -51,7 +51,7 @@ func (*ConfigSuite) TestNilFacade(c *gc.C) {
 
 func (*ConfigSuite) TestNilEnviron(c *gc.C) {
 	config := discoverspaces.Config{
-		Facade:  fakeFacade{},
+		Facade:  &fakeFacade{},
 		NewName: fakeNewName,
 	}
 	checkAlwaysInvalid(c, config, "nil Environ not valid")
@@ -59,8 +59,8 @@ func (*ConfigSuite) TestNilEnviron(c *gc.C) {
 
 func (*ConfigSuite) TestNilNewName(c *gc.C) {
 	config := discoverspaces.Config{
-		Facade:  fakeFacade{},
-		Environ: fakeEnviron{},
+		Facade:  &fakeFacade{},
+		Environ: &fakeEnviron{},
 	}
 	checkAlwaysInvalid(c, config, "nil NewName not valid")
 }

--- a/worker/discoverspaces/discoverspaces.go
+++ b/worker/discoverspaces/discoverspaces.go
@@ -332,7 +332,9 @@ func collectMissingSubnets(
 		}
 		addArgs.Subnets = append(addArgs.Subnets, params.AddSubnetParams{
 			SubnetProviderId: string(subnet.ProviderId),
+			SubnetTag:        names.NewSubnetTag(subnet.CIDR).String(),
 			SpaceTag:         spaceTag,
+			VLANTag:          subnet.VLANTag,
 			Zones:            zones,
 		})
 	}

--- a/worker/discoverspaces/fake_test.go
+++ b/worker/discoverspaces/fake_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/juju/juju/api/base"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/environs"
+	"github.com/juju/juju/instance"
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/worker/gate"
 )
@@ -62,6 +63,7 @@ type fakeEnviron struct {
 	stub           *testing.Stub
 	spaceDiscovery bool
 	spaces         []network.SpaceInfo
+	subnets        []network.SubnetInfo
 }
 
 func (e *fakeEnviron) SupportsSpaceDiscovery() (bool, error) {
@@ -72,6 +74,11 @@ func (e *fakeEnviron) SupportsSpaceDiscovery() (bool, error) {
 func (e *fakeEnviron) Spaces() ([]network.SpaceInfo, error) {
 	e.stub.AddCall("Spaces")
 	return e.spaces, e.stub.NextErr()
+}
+
+func (e *fakeEnviron) Subnets(inst instance.Id, subnetIds []network.Id) ([]network.SubnetInfo, error) {
+	e.stub.AddCall("Subnets", inst, subnetIds)
+	return e.subnets, e.stub.NextErr()
 }
 
 func fakeNewName(_ string, _ set.Strings) string {

--- a/worker/discoverspaces/fake_test.go
+++ b/worker/discoverspaces/fake_test.go
@@ -4,12 +4,14 @@
 package discoverspaces_test
 
 import (
+	"github.com/juju/testing"
 	"github.com/juju/utils/set"
 	worker "gopkg.in/juju/worker.v1"
 
 	"github.com/juju/juju/api/base"
+	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/environs"
-	"github.com/juju/juju/worker/discoverspaces"
+	"github.com/juju/juju/network"
 	"github.com/juju/juju/worker/gate"
 )
 
@@ -22,11 +24,54 @@ type fakeAPICaller struct {
 }
 
 type fakeFacade struct {
-	discoverspaces.Facade
+	stub *testing.Stub
+
+	createSpaces params.ErrorResults
+	addSubnets   params.ErrorResults
+	listSpaces   params.DiscoverSpacesResults
+	listSubnets  params.ListSubnetsResults
+}
+
+func (f *fakeFacade) CreateSpaces(args params.CreateSpacesParams) (params.ErrorResults, error) {
+	f.stub.AddCall("CreateSpaces", args)
+	return f.createSpaces, f.stub.NextErr()
+}
+
+func (f *fakeFacade) AddSubnets(args params.AddSubnetsParams) (params.ErrorResults, error) {
+	f.stub.AddCall("AddSubnets", args)
+	return f.addSubnets, f.stub.NextErr()
+}
+
+func (f *fakeFacade) ListSpaces() (params.DiscoverSpacesResults, error) {
+	f.stub.AddCall("ListSpaces")
+	return f.listSpaces, f.stub.NextErr()
+}
+
+func (f *fakeFacade) ListSubnets(args params.SubnetsFilters) (params.ListSubnetsResults, error) {
+	f.stub.AddCall("ListSubnets", args)
+	return f.listSubnets, f.stub.NextErr()
+}
+
+type fakeNoNetworkEnviron struct {
+	environs.Environ
 }
 
 type fakeEnviron struct {
 	environs.NetworkingEnviron
+
+	stub           *testing.Stub
+	spaceDiscovery bool
+	spaces         []network.SpaceInfo
+}
+
+func (e *fakeEnviron) SupportsSpaceDiscovery() (bool, error) {
+	e.stub.AddCall("SupportsSpaceDiscovery")
+	return e.spaceDiscovery, e.stub.NextErr()
+}
+
+func (e *fakeEnviron) Spaces() ([]network.SpaceInfo, error) {
+	e.stub.AddCall("Spaces")
+	return e.spaces, e.stub.NextErr()
 }
 
 func fakeNewName(_ string, _ set.Strings) string {

--- a/worker/discoverspaces/worker_test.go
+++ b/worker/discoverspaces/worker_test.go
@@ -4,23 +4,17 @@
 package discoverspaces_test
 
 import (
-	"sync/atomic"
 	"time"
 
+	"github.com/juju/errors"
+	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
-	"gopkg.in/juju/names.v2"
 	worker "gopkg.in/juju/worker.v1"
 
-	"github.com/juju/juju/api"
-	apidiscoverspaces "github.com/juju/juju/api/discoverspaces"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/environs"
-	"github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/network"
-	"github.com/juju/juju/provider/dummy"
-	"github.com/juju/juju/state"
-	"github.com/juju/juju/state/stateenvirons"
 	coretesting "github.com/juju/juju/testing"
 	"github.com/juju/juju/worker/discoverspaces"
 	"github.com/juju/juju/worker/gate"
@@ -28,73 +22,30 @@ import (
 )
 
 type WorkerSuite struct {
-	// TODO(fwereade): we *really* should not be using
-	// JujuConnSuite in new code.
-	testing.JujuConnSuite
-
-	APIConnection api.Connection
-	API           *checkingFacade
-
-	numCreateSpaceCalls uint32
-	numAddSubnetsCalls  uint32
-}
-
-type checkingFacade struct {
-	apidiscoverspaces.API
-
-	createSpacesCallback func()
-	addSubnetsCallback   func()
-}
-
-func (cf *checkingFacade) CreateSpaces(args params.CreateSpacesParams) (results params.ErrorResults, err error) {
-	if cf.createSpacesCallback != nil {
-		cf.createSpacesCallback()
-	}
-	return cf.API.CreateSpaces(args)
-}
-
-func (cf *checkingFacade) AddSubnets(args params.AddSubnetsParams) (params.ErrorResults, error) {
-	if cf.addSubnetsCallback != nil {
-		cf.addSubnetsCallback()
-	}
-	return cf.API.AddSubnets(args)
+	coretesting.BaseSuite
+	facade          fakeFacade
+	environ         fakeEnviron
+	selectedEnviron environs.Environ
 }
 
 var _ = gc.Suite(&WorkerSuite{})
 
 func (s *WorkerSuite) SetUpTest(c *gc.C) {
-	s.JujuConnSuite.SetUpTest(c)
-
-	// Unbreak dummy provider methods.
-	s.AssertConfigParameterUpdated(c, "broken", "")
-
-	s.APIConnection, _ = s.OpenAPIAsNewMachine(c, state.JobManageModel)
-
-	realAPI := s.APIConnection.DiscoverSpaces()
-	s.API = &checkingFacade{
-		API: *realAPI,
-		createSpacesCallback: func() {
-			atomic.AddUint32(&s.numCreateSpaceCalls, 1)
-		},
-		addSubnetsCallback: func() {
-			atomic.AddUint32(&s.numAddSubnetsCalls, 1)
-		},
+	s.BaseSuite.SetUpTest(c)
+	s.facade = fakeFacade{stub: &testing.Stub{}}
+	s.environ = fakeEnviron{
+		stub:           &testing.Stub{},
+		spaceDiscovery: true,
 	}
-}
-
-func (s *WorkerSuite) TearDownTest(c *gc.C) {
-	if s.APIConnection != nil {
-		c.Check(s.APIConnection.Close(), jc.ErrorIsNil)
-	}
-	s.JujuConnSuite.TearDownTest(c)
+	s.selectedEnviron = &s.environ
 }
 
 func (s *WorkerSuite) TestSupportsSpaceDiscoveryBroken(c *gc.C) {
-	s.AssertConfigParameterUpdated(c, "broken", "SupportsSpaceDiscovery")
+	s.environ.stub.SetErrors(errors.New("SupportsSpaceDiscovery is broken"))
 
 	worker, lock := s.startWorker(c)
 	err := workertest.CheckKilled(c, worker)
-	c.Assert(err, gc.ErrorMatches, "dummy.SupportsSpaceDiscovery is broken")
+	c.Assert(err, gc.ErrorMatches, "SupportsSpaceDiscovery is broken")
 
 	select {
 	case <-time.After(coretesting.ShortWait):
@@ -104,12 +55,10 @@ func (s *WorkerSuite) TestSupportsSpaceDiscoveryBroken(c *gc.C) {
 }
 
 func (s *WorkerSuite) TestSpacesBroken(c *gc.C) {
-	dummy.SetSupportsSpaceDiscovery(true)
-	s.AssertConfigParameterUpdated(c, "broken", "Spaces")
-
+	s.environ.stub.SetErrors(nil, errors.New("Spaces am broken"))
 	worker, lock := s.startWorker(c)
 	err := workertest.CheckKilled(c, worker)
-	c.Assert(err, gc.ErrorMatches, "dummy.Spaces is broken")
+	c.Assert(err, gc.ErrorMatches, "Spaces am broken")
 
 	select {
 	case <-time.After(coretesting.ShortWait):
@@ -119,83 +68,186 @@ func (s *WorkerSuite) TestSpacesBroken(c *gc.C) {
 }
 
 func (s *WorkerSuite) TestWorkerSupportsNetworkingFalse(c *gc.C) {
-	// We set SupportsSpaceDiscovery to true so that spaces *would* be
-	// discovered if networking was supported. So we know that if they're
-	// discovered it must be because networking is not supported.
-	dummy.SetSupportsSpaceDiscovery(true)
-
-	// TODO(fwereade): monkey-patching remote packages is even worse
-	// than monkey-patching local packages, please don't do it.
-	noNetworking := func(environs.Environ) (environs.NetworkingEnviron, bool) {
-		return nil, false
-	}
-	s.PatchValue(&environs.SupportsNetworking, noNetworking)
-
+	s.selectedEnviron = &fakeNoNetworkEnviron{}
 	s.unlockCheck(c, s.assertDiscoveredNoSpaces)
 }
 
 func (s *WorkerSuite) TestWorkerSupportsSpaceDiscoveryFalse(c *gc.C) {
+	s.environ.spaceDiscovery = false
 	s.unlockCheck(c, s.assertDiscoveredNoSpaces)
 }
 
-func (s *WorkerSuite) TestWorkerDiscoversSpaces(c *gc.C) {
-	dummy.SetSupportsSpaceDiscovery(true)
-	s.unlockCheck(c, func(*gc.C) {
-		s.assertDiscoveredSpaces(c)
-		s.assertNumCalls(c, 1, 1)
-	})
+func (s *WorkerSuite) cannedSpaces() []network.SpaceInfo {
+	return []network.SpaceInfo{{
+		Name:       "foo",
+		ProviderId: network.Id("0"),
+		Subnets: []network.SubnetInfo{{
+			ProviderId:        network.Id("1"),
+			CIDR:              "192.168.1.0/24",
+			AvailabilityZones: []string{"zone1"},
+		}, {
+			ProviderId:        network.Id("2"),
+			CIDR:              "192.168.2.0/24",
+			AvailabilityZones: []string{"zone1"},
+		}},
+	}, {
+		Name:       "Another foo 99!",
+		ProviderId: network.Id("1"),
+		Subnets: []network.SubnetInfo{{
+			ProviderId:        network.Id("3"),
+			CIDR:              "192.168.3.0/24",
+			AvailabilityZones: []string{"zone1"},
+		}},
+	}, {
+		Name:       "foo-",
+		ProviderId: network.Id("2"),
+		Subnets: []network.SubnetInfo{{
+			ProviderId:        network.Id("4"),
+			CIDR:              "192.168.4.0/24",
+			AvailabilityZones: []string{"zone1"},
+		}},
+	}, {
+		Name:       "---",
+		ProviderId: network.Id("3"),
+		Subnets: []network.SubnetInfo{{
+			ProviderId:        network.Id("5"),
+			CIDR:              "192.168.5.0/24",
+			AvailabilityZones: []string{"zone1"},
+		}},
+	}}
 }
 
-func (s *WorkerSuite) TestWorkerIdempotent(c *gc.C) {
-	dummy.SetSupportsSpaceDiscovery(true)
-	s.unlockCheck(c, s.assertDiscoveredSpaces)
+func makeErrorResults(errors ...*params.Error) params.ErrorResults {
+	results := make([]params.ErrorResult, len(errors))
+	for i, err := range errors {
+		results[i].Error = err
+	}
+	return params.ErrorResults{Results: results}
+}
+
+func (s *WorkerSuite) TestWorkerDiscoversSpaces(c *gc.C) {
+	s.environ.spaces = s.cannedSpaces()
+	s.facade.createSpaces = makeErrorResults(nil, nil, nil, nil)
+	s.facade.addSubnets = makeErrorResults(nil, nil, nil, nil, nil)
+	// The facade reports there aren't any spaces or subnets already.
 	s.unlockCheck(c, func(*gc.C) {
-		s.assertDiscoveredSpaces(c)
-		s.assertNumCalls(c, 2, 2)
+		stub := s.facade.stub
+		stub.CheckCallNames(c, "ListSpaces", "ListSubnets", "CreateSpaces", "AddSubnets")
+		stub.CheckCall(c, 2, "CreateSpaces", params.CreateSpacesParams{
+			Spaces: []params.CreateSpaceParams{{
+				Public:     false,
+				SpaceTag:   "space-foo",
+				ProviderId: "0",
+			}, {
+				Public:     false,
+				SpaceTag:   "space-another-foo-99",
+				ProviderId: "1",
+			}, {
+				Public:     false,
+				SpaceTag:   "space-foo-2",
+				ProviderId: "2",
+			}, {
+				Public:     false,
+				SpaceTag:   "space-empty",
+				ProviderId: "3",
+			}},
+		})
+		stub.CheckCall(c, 3, "AddSubnets", params.AddSubnetsParams{
+			Subnets: []params.AddSubnetParams{{
+				SubnetProviderId: "1",
+				SpaceTag:         "space-foo",
+				Zones:            []string{"zone1"},
+			}, {
+				SubnetProviderId: "2",
+				SpaceTag:         "space-foo",
+				Zones:            []string{"zone1"},
+			}, {
+				SubnetProviderId: "3",
+				SpaceTag:         "space-another-foo-99",
+				Zones:            []string{"zone1"},
+			}, {
+				SubnetProviderId: "4",
+				SpaceTag:         "space-foo-2",
+				Zones:            []string{"zone1"},
+			}, {
+				SubnetProviderId: "5",
+				SpaceTag:         "space-empty",
+				Zones:            []string{"zone1"},
+			}},
+		})
 	})
 }
 
 func (s *WorkerSuite) TestWorkerIgnoresExistingSpacesAndSubnets(c *gc.C) {
-	dummy.SetSupportsSpaceDiscovery(true)
-	spaceTag := names.NewSpaceTag("foo")
-	args := params.CreateSpacesParams{
-		Spaces: []params.CreateSpaceParams{{
-			Public:     false,
-			SpaceTag:   spaceTag.String(),
-			ProviderId: "foo",
-		}}}
-	result, err := s.API.CreateSpaces(args)
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(result.Results, gc.HasLen, 1)
-	c.Assert(result.Results[0].Error, gc.IsNil)
+	s.environ.spaces = s.cannedSpaces()
+	// Indicate that we already know about some of those spaces and
+	// subnets.
+	s.facade.listSpaces = params.DiscoverSpacesResults{Results: []params.ProviderSpace{
+		{ProviderId: "0", Name: "foo"},
+		{ProviderId: "1"},
+		{ProviderId: "3"},
+	}}
+	s.facade.listSubnets = params.ListSubnetsResults{Results: []params.Subnet{
+		{ProviderId: "1"},
+		{ProviderId: "3"},
+		{ProviderId: "5"},
+	}}
+	s.facade.createSpaces = makeErrorResults(nil)
+	s.facade.addSubnets = makeErrorResults(nil, nil)
+	s.unlockCheck(c, func(*gc.C) {
+		stub := s.facade.stub
+		// We only create the new ones.
+		stub.CheckCallNames(c, "ListSpaces", "ListSubnets", "CreateSpaces", "AddSubnets")
+		stub.CheckCall(c, 2, "CreateSpaces", params.CreateSpacesParams{
+			Spaces: []params.CreateSpaceParams{{
+				Public:     false,
+				SpaceTag:   "space-foo-2",
+				ProviderId: "2",
+			}},
+		})
+		stub.CheckCall(c, 3, "AddSubnets", params.AddSubnetsParams{
+			Subnets: []params.AddSubnetParams{{
+				SubnetProviderId: "2",
+				SpaceTag:         "space-foo",
+				Zones:            []string{"zone1"},
+			}, {
+				SubnetProviderId: "4",
+				SpaceTag:         "space-foo-2",
+				Zones:            []string{"zone1"},
+			}},
+		})
+	})
+}
 
-	subnetArgs := params.AddSubnetsParams{
-		Subnets: []params.AddSubnetParams{{
-			SubnetProviderId: "1",
-			SpaceTag:         spaceTag.String(),
-			Zones:            []string{"zone1"},
-		}}}
-	subnetResult, err := s.API.AddSubnets(subnetArgs)
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(subnetResult.Results, gc.HasLen, 1)
-	c.Assert(subnetResult.Results[0].Error, gc.IsNil)
-
-	s.unlockCheck(c, func(c *gc.C) {
-		spaces, err := s.State.AllSpaces()
-		c.Assert(err, jc.ErrorIsNil)
-		c.Assert(spaces, gc.HasLen, 5)
+func (s *WorkerSuite) TestWorkerIdempotent(c *gc.C) {
+	s.environ.spaces = s.cannedSpaces()
+	// Indicate that we already know about all of those spaces and
+	// subnets.
+	s.facade.listSpaces = params.DiscoverSpacesResults{Results: []params.ProviderSpace{
+		{ProviderId: "0"},
+		{ProviderId: "1"},
+		{ProviderId: "2"},
+		{ProviderId: "3"},
+	}}
+	s.facade.listSubnets = params.ListSubnetsResults{Results: []params.Subnet{
+		{ProviderId: "1"},
+		{ProviderId: "2"},
+		{ProviderId: "3"},
+		{ProviderId: "4"},
+		{ProviderId: "5"},
+	}}
+	s.unlockCheck(c, func(*gc.C) {
+		stub := s.facade.stub
+		// We don't create any more.
+		stub.CheckCallNames(c, "ListSpaces", "ListSubnets")
 	})
 }
 
 func (s *WorkerSuite) startWorker(c *gc.C) (worker.Worker, gate.Lock) {
-	// create fresh environ to see any injected broken-ness
-	environ, err := stateenvirons.GetNewEnvironFunc(environs.New)(s.State)
-	c.Assert(err, jc.ErrorIsNil)
-
 	lock := gate.NewLock()
 	worker, err := discoverspaces.NewWorker(discoverspaces.Config{
-		Facade:   s.API,
-		Environ:  environ,
+		Facade:   &s.facade,
+		Environ:  s.selectedEnviron,
 		NewName:  network.ConvertSpaceName,
 		Unlocker: lock,
 	})
@@ -216,75 +268,9 @@ func (s *WorkerSuite) unlockCheck(c *gc.C, check func(c *gc.C)) {
 }
 
 func (s *WorkerSuite) assertDiscoveredNoSpaces(c *gc.C) {
-	spaces, err := s.State.AllSpaces()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Check(spaces, gc.HasLen, 0)
-}
-
-func (s *WorkerSuite) assertDiscoveredSpaces(c *gc.C) {
-	spaces, err := s.State.AllSpaces()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(spaces, gc.HasLen, 4)
-	expectedSpaces := []network.SpaceInfo{{
-		Name:       "foo",
-		ProviderId: network.Id("0"),
-		Subnets: []network.SubnetInfo{{
-			ProviderId:        network.Id("1"),
-			CIDR:              "192.168.1.0/24",
-			AvailabilityZones: []string{"zone1"},
-		}, {
-			ProviderId:        network.Id("2"),
-			CIDR:              "192.168.2.0/24",
-			AvailabilityZones: []string{"zone1"},
-		}}}, {
-		Name:       "another-foo-99",
-		ProviderId: network.Id("1"),
-		Subnets: []network.SubnetInfo{{
-			ProviderId:        network.Id("3"),
-			CIDR:              "192.168.3.0/24",
-			AvailabilityZones: []string{"zone1"},
-		}}}, {
-		Name:       "foo-2",
-		ProviderId: network.Id("2"),
-		Subnets: []network.SubnetInfo{{
-			ProviderId:        network.Id("4"),
-			CIDR:              "192.168.4.0/24",
-			AvailabilityZones: []string{"zone1"},
-		}}}, {
-		Name:       "empty",
-		ProviderId: network.Id("3"),
-		Subnets: []network.SubnetInfo{{
-			ProviderId:        network.Id("5"),
-			CIDR:              "192.168.5.0/24",
-			AvailabilityZones: []string{"zone1"},
-		}}}}
-	expectedSpaceMap := make(map[string]network.SpaceInfo)
-	for _, space := range expectedSpaces {
-		expectedSpaceMap[space.Name] = space
-	}
-	for _, space := range spaces {
-		expected, ok := expectedSpaceMap[space.Name()]
-		if !c.Check(ok, jc.IsTrue) {
-			continue
-		}
-		c.Check(space.ProviderId(), gc.Equals, expected.ProviderId)
-		subnets, err := space.Subnets()
-		if !c.Check(err, jc.ErrorIsNil) {
-			continue
-		}
-		if !c.Check(len(subnets), gc.Equals, len(expected.Subnets)) {
-			continue
-		}
-		for i, subnet := range subnets {
-			expectedSubnet := expected.Subnets[i]
-			c.Check(subnet.ProviderId(), gc.Equals, expectedSubnet.ProviderId)
-			c.Check([]string{subnet.AvailabilityZone()}, jc.DeepEquals, expectedSubnet.AvailabilityZones)
-			c.Check(subnet.CIDR(), gc.Equals, expectedSubnet.CIDR)
+	for _, call := range s.facade.stub.Calls() {
+		if call.FuncName == "CreateSpaces" {
+			c.Fatalf("created some spaces: %#v", call.Args)
 		}
 	}
-}
-
-func (s *WorkerSuite) assertNumCalls(c *gc.C, expectedNumCreateSpaceCalls, expectedNumAddSubnetsCalls int) {
-	c.Check(atomic.LoadUint32(&s.numCreateSpaceCalls), gc.Equals, uint32(expectedNumCreateSpaceCalls))
-	c.Check(atomic.LoadUint32(&s.numAddSubnetsCalls), gc.Equals, uint32(expectedNumAddSubnetsCalls))
 }

--- a/worker/discoverspaces/worker_test.go
+++ b/worker/discoverspaces/worker_test.go
@@ -85,6 +85,7 @@ func (s *WorkerSuite) cannedSubnets() []network.SubnetInfo {
 	}, {
 		ProviderId:        network.Id("3"),
 		CIDR:              "192.168.3.0/24",
+		VLANTag:           50,
 		AvailabilityZones: []string{"zone1"},
 	}, {
 		ProviderId:        network.Id("4"),
@@ -107,18 +108,24 @@ func (s *WorkerSuite) TestWorkerNoSpaceDiscoveryOnlySubnets(c *gc.C) {
 		stub.CheckCall(c, 1, "AddSubnets", params.AddSubnetsParams{
 			Subnets: []params.AddSubnetParams{{
 				SubnetProviderId: "1",
+				SubnetTag:        "subnet-192.168.1.0/24",
 				Zones:            []string{"zone1"},
 			}, {
 				SubnetProviderId: "2",
+				SubnetTag:        "subnet-192.168.2.0/24",
 				Zones:            []string{"zone1"},
 			}, {
 				SubnetProviderId: "3",
+				SubnetTag:        "subnet-192.168.3.0/24",
+				VLANTag:          50,
 				Zones:            []string{"zone1"},
 			}, {
 				SubnetProviderId: "4",
+				SubnetTag:        "subnet-192.168.4.0/24",
 				Zones:            []string{"zone1"},
 			}, {
 				SubnetProviderId: "5",
+				SubnetTag:        "subnet-192.168.5.0/24",
 				Zones:            []string{"zone1"},
 			}},
 		})
@@ -155,6 +162,7 @@ func (s *WorkerSuite) cannedSpaces() []network.SpaceInfo {
 			ProviderId:        network.Id("4"),
 			CIDR:              "192.168.4.0/24",
 			AvailabilityZones: []string{"zone1"},
+			VLANTag:           3,
 		}},
 	}, {
 		Name:       "---",
@@ -205,22 +213,28 @@ func (s *WorkerSuite) TestWorkerDiscoversSpaces(c *gc.C) {
 		stub.CheckCall(c, 3, "AddSubnets", params.AddSubnetsParams{
 			Subnets: []params.AddSubnetParams{{
 				SubnetProviderId: "1",
+				SubnetTag:        "subnet-192.168.1.0/24",
 				SpaceTag:         "space-foo",
 				Zones:            []string{"zone1"},
 			}, {
 				SubnetProviderId: "2",
+				SubnetTag:        "subnet-192.168.2.0/24",
 				SpaceTag:         "space-foo",
 				Zones:            []string{"zone1"},
 			}, {
 				SubnetProviderId: "3",
+				SubnetTag:        "subnet-192.168.3.0/24",
 				SpaceTag:         "space-another-foo-99",
 				Zones:            []string{"zone1"},
 			}, {
 				SubnetProviderId: "4",
+				SubnetTag:        "subnet-192.168.4.0/24",
 				SpaceTag:         "space-foo-2",
+				VLANTag:          3,
 				Zones:            []string{"zone1"},
 			}, {
 				SubnetProviderId: "5",
+				SubnetTag:        "subnet-192.168.5.0/24",
 				SpaceTag:         "space-empty",
 				Zones:            []string{"zone1"},
 			}},
@@ -258,11 +272,14 @@ func (s *WorkerSuite) TestWorkerIgnoresExistingSpacesAndSubnets(c *gc.C) {
 		stub.CheckCall(c, 3, "AddSubnets", params.AddSubnetsParams{
 			Subnets: []params.AddSubnetParams{{
 				SubnetProviderId: "2",
+				SubnetTag:        "subnet-192.168.2.0/24",
 				SpaceTag:         "space-foo",
 				Zones:            []string{"zone1"},
 			}, {
 				SubnetProviderId: "4",
+				SubnetTag:        "subnet-192.168.4.0/24",
 				SpaceTag:         "space-foo-2",
+				VLANTag:          3,
 				Zones:            []string{"zone1"},
 			}},
 		})


### PR DESCRIPTION
## Description of change

At the moment we only get subnets from the provider if it supports space discovery, but it would be useful to have them for providers that support networking (even if we don't have them tagged with a space). That will allow us to use them to set up ingress rules when a cross-model relation is created.

Change the discover spaces worker to collect subnets (with no associated spaces) if the provider doesn't support space discovery. Also change the AddSubnets API call to allow subnets without a space, and change the ListSubnets API method and command to handle empty space.

Rewrite the worker tests to not use `JujuConnSuite`.

## QA steps

* Bootstrap on AWS. 
* Run `juju subnets` to verify that subnets have been imported in by the discoverspaces worker - they'll come back with a blank space tag.
