### PR TITLE
all: sort imports canonically

### DIFF
--- a/api/authentication/visitor.go
+++ b/api/authentication/visitor.go
@@ -9,7 +9,6 @@ import (
 	"net/url"
 
 	"github.com/juju/errors"
-
 	"gopkg.in/macaroon-bakery.v1/httpbakery"
 )
 

--- a/api/authentication/visitor_test.go
+++ b/api/authentication/visitor_test.go
@@ -9,11 +9,12 @@ import (
 	"net/http/httptest"
 	"net/url"
 
-	"github.com/juju/juju/api/authentication"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/macaroon-bakery.v1/httpbakery"
+
+	"github.com/juju/juju/api/authentication"
 )
 
 type VisitorSuite struct {

--- a/api/certpool_test.go
+++ b/api/certpool_test.go
@@ -10,12 +10,12 @@ import (
 	"strings"
 	"time"
 
-	"github.com/juju/juju/cert"
 	"github.com/juju/loggo"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/api"
+	"github.com/juju/juju/cert"
 	"github.com/juju/juju/testing"
 )
 

--- a/api/cloud/cloud.go
+++ b/api/cloud/cloud.go
@@ -4,9 +4,9 @@
 package cloud
 
 import (
+	"github.com/juju/errors"
 	"gopkg.in/juju/names.v2"
 
-	"github.com/juju/errors"
 	"github.com/juju/juju/api/base"
 	"github.com/juju/juju/apiserver/params"
 	jujucloud "github.com/juju/juju/cloud"

--- a/api/controller/controller_test.go
+++ b/api/controller/controller_test.go
@@ -7,7 +7,9 @@ import (
 	"encoding/json"
 	"errors"
 
+	jujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
+	"github.com/juju/utils"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/names.v2"
 	"gopkg.in/macaroon.v1"
@@ -17,8 +19,6 @@ import (
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/environs"
-	jujutesting "github.com/juju/testing"
-	"github.com/juju/utils"
 )
 
 type Suite struct {

--- a/api/export_test.go
+++ b/api/export_test.go
@@ -6,12 +6,13 @@ package api
 import (
 	"github.com/gorilla/websocket"
 	"github.com/juju/errors"
-	"github.com/juju/juju/api/base"
-	"github.com/juju/juju/network"
 	"github.com/juju/utils/clock"
 	"gopkg.in/juju/names.v2"
 	"gopkg.in/macaroon-bakery.v1/httpbakery"
 	"gopkg.in/macaroon.v1"
+
+	"github.com/juju/juju/api/base"
+	"github.com/juju/juju/network"
 )
 
 var (

--- a/api/interface.go
+++ b/api/interface.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/gorilla/websocket"
 	"github.com/juju/errors"
+	"github.com/juju/utils/set"
 	"github.com/juju/version"
 	"gopkg.in/juju/names.v2"
 	"gopkg.in/macaroon-bakery.v1/httpbakery"
@@ -27,7 +28,6 @@ import (
 	"github.com/juju/juju/api/uniter"
 	"github.com/juju/juju/api/upgrader"
 	"github.com/juju/juju/network"
-	"github.com/juju/utils/set"
 )
 
 // Info encapsulates information about a server holding juju state and

--- a/api/logfwd/lastsent_test.go
+++ b/api/logfwd/lastsent_test.go
@@ -4,6 +4,8 @@
 package logfwd_test
 
 import (
+	"time"
+
 	"github.com/juju/errors"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
@@ -14,7 +16,6 @@ import (
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/state"
-	"time"
 )
 
 type LastSentSuite struct {

--- a/api/machineactions/machineactions.go
+++ b/api/machineactions/machineactions.go
@@ -8,11 +8,12 @@ package machineactions
 
 import (
 	"github.com/juju/errors"
+	"gopkg.in/juju/names.v2"
+
 	"github.com/juju/juju/api/base"
 	apiwatcher "github.com/juju/juju/api/watcher"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/watcher"
-	"gopkg.in/juju/names.v2"
 )
 
 type Client struct {

--- a/api/proxyupdater/proxyupdater.go
+++ b/api/proxyupdater/proxyupdater.go
@@ -7,12 +7,13 @@ import (
 	"fmt"
 
 	"github.com/juju/errors"
+	"github.com/juju/utils/proxy"
+	"gopkg.in/juju/names.v2"
+
 	"github.com/juju/juju/api/base"
 	apiwatcher "github.com/juju/juju/api/watcher"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/watcher"
-	"github.com/juju/utils/proxy"
-	"gopkg.in/juju/names.v2"
 )
 
 const proxyUpdaterFacade = "ProxyUpdater"

--- a/api/proxyupdater/proxyupdater_test.go
+++ b/api/proxyupdater/proxyupdater_test.go
@@ -7,6 +7,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils/proxy"
 	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/api/base"
 	apitesting "github.com/juju/juju/api/base/testing"
@@ -14,7 +15,6 @@ import (
 	"github.com/juju/juju/apiserver/params"
 	coretesting "github.com/juju/juju/testing"
 	"github.com/juju/juju/watcher"
-	"gopkg.in/juju/names.v2"
 )
 
 type ProxyUpdaterSuite struct {

--- a/apiserver/applicationscaler/facade.go
+++ b/apiserver/applicationscaler/facade.go
@@ -5,12 +5,13 @@ package applicationscaler
 
 import (
 	"github.com/juju/errors"
+	"gopkg.in/juju/names.v2"
+
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/watcher"
-	"gopkg.in/juju/names.v2"
 )
 
 // Backend exposes functionality required by Facade.

--- a/apiserver/backups/shim.go
+++ b/apiserver/backups/shim.go
@@ -5,6 +5,7 @@ package backups
 
 import (
 	"github.com/juju/errors"
+
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/state"

--- a/apiserver/block/state.go
+++ b/apiserver/block/state.go
@@ -4,8 +4,9 @@
 package block
 
 import (
-	"github.com/juju/juju/state"
 	names "gopkg.in/juju/names.v2"
+
+	"github.com/juju/juju/state"
 )
 
 type blockAccess interface {

--- a/apiserver/cert_test.go
+++ b/apiserver/cert_test.go
@@ -8,13 +8,13 @@ import (
 	"runtime"
 	"time"
 
-	"github.com/juju/juju/cert"
 	"github.com/juju/loggo"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/api"
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/cert"
 	coretesting "github.com/juju/juju/testing"
 )
 

--- a/apiserver/cloud/cloud_test.go
+++ b/apiserver/cloud/cloud_test.go
@@ -4,12 +4,12 @@
 package cloud_test
 
 import (
+	"github.com/juju/errors"
 	gitjujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/names.v2"
 
-	"github.com/juju/errors"
 	cloudfacade "github.com/juju/juju/apiserver/cloud"
 	"github.com/juju/juju/apiserver/params"
 	apiservertesting "github.com/juju/juju/apiserver/testing"

--- a/apiserver/common/instancetypes.go
+++ b/apiserver/common/instancetypes.go
@@ -5,6 +5,7 @@ package common
 
 import (
 	"github.com/juju/errors"
+
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/constraints"
 	"github.com/juju/juju/environs"

--- a/apiserver/common/modelstatus.go
+++ b/apiserver/common/modelstatus.go
@@ -4,9 +4,8 @@
 package common
 
 import (
-	"gopkg.in/juju/names.v2"
-
 	"github.com/juju/errors"
+	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/apiserver/params"

--- a/apiserver/common/modeluser.go
+++ b/apiserver/common/modeluser.go
@@ -6,9 +6,8 @@ package common
 import (
 	"time"
 
-	"gopkg.in/juju/names.v2"
-
 	"github.com/juju/errors"
+	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/permission"

--- a/apiserver/discoverspaces/discoverspaces.go
+++ b/apiserver/discoverspaces/discoverspaces.go
@@ -5,6 +5,7 @@ package discoverspaces
 
 import (
 	"github.com/juju/errors"
+
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/common/networkingcommon"
 	"github.com/juju/juju/apiserver/facade"

--- a/apiserver/hostkeyreporter/shim.go
+++ b/apiserver/hostkeyreporter/shim.go
@@ -5,6 +5,7 @@ package hostkeyreporter
 
 import (
 	"github.com/juju/errors"
+
 	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/state"
 )

--- a/apiserver/httpattachment/attachment.go
+++ b/apiserver/httpattachment/attachment.go
@@ -17,6 +17,7 @@ import (
 	"strings"
 
 	"github.com/juju/errors"
+
 	"github.com/juju/juju/apiserver/params"
 )
 

--- a/apiserver/imagemanager/state.go
+++ b/apiserver/imagemanager/state.go
@@ -4,9 +4,10 @@
 package imagemanager
 
 import (
+	names "gopkg.in/juju/names.v2"
+
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/imagestorage"
-	names "gopkg.in/juju/names.v2"
 )
 
 type stateInterface interface {

--- a/apiserver/imagemetadata/state.go
+++ b/apiserver/imagemetadata/state.go
@@ -4,10 +4,11 @@
 package imagemetadata
 
 import (
+	names "gopkg.in/juju/names.v2"
+
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/cloudimagemetadata"
-	names "gopkg.in/juju/names.v2"
 )
 
 type metadataAcess interface {

--- a/apiserver/introspection.go
+++ b/apiserver/introspection.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 
 	"github.com/juju/errors"
+
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/permission"

--- a/apiserver/machineactions/machineactions.go
+++ b/apiserver/machineactions/machineactions.go
@@ -7,11 +7,12 @@
 package machineactions
 
 import (
+	"gopkg.in/juju/names.v2"
+
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/state"
-	"gopkg.in/juju/names.v2"
 )
 
 type Backend interface {

--- a/apiserver/machineactions/shim.go
+++ b/apiserver/machineactions/shim.go
@@ -5,11 +5,12 @@
 package machineactions
 
 import (
+	"gopkg.in/juju/names.v2"
+
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/state"
-	"gopkg.in/juju/names.v2"
 )
 
 func init() {

--- a/apiserver/machinemanager/state.go
+++ b/apiserver/machinemanager/state.go
@@ -4,11 +4,12 @@
 package machinemanager
 
 import (
+	names "gopkg.in/juju/names.v2"
+
 	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/state"
-	names "gopkg.in/juju/names.v2"
 )
 
 type stateInterface interface {

--- a/apiserver/metricsender/metricsender_test.go
+++ b/apiserver/metricsender/metricsender_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	wireformat "github.com/juju/romulus/wireformat/metrics"
+	jujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils/clock"
 	gc "gopkg.in/check.v1"
@@ -17,7 +18,6 @@ import (
 	jujujutesting "github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/testing/factory"
-	jujutesting "github.com/juju/testing"
 )
 
 type MetricSenderSuite struct {

--- a/apiserver/metricsender/testing/mocksender.go
+++ b/apiserver/metricsender/testing/mocksender.go
@@ -6,10 +6,10 @@ package testing
 import (
 	"fmt"
 
-	"github.com/juju/juju/state"
-
 	wireformat "github.com/juju/romulus/wireformat/metrics"
 	"github.com/juju/utils"
+
+	"github.com/juju/juju/state"
 )
 
 // MockSender implements the metric sender interface.

--- a/apiserver/metricsmanager/metricsmanager_test.go
+++ b/apiserver/metricsmanager/metricsmanager_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/juju/errors"
+	jujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/names.v2"
@@ -20,7 +21,6 @@ import (
 	jujujutesting "github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/testing/factory"
-	jujutesting "github.com/juju/testing"
 )
 
 type metricsManagerSuite struct {

--- a/apiserver/migrationmaster/backend.go
+++ b/apiserver/migrationmaster/backend.go
@@ -4,11 +4,11 @@
 package migrationmaster
 
 import (
+	"github.com/juju/version"
 	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/migration"
 	"github.com/juju/juju/state"
-	"github.com/juju/version"
 )
 
 // Backend defines the state functionality required by the

--- a/apiserver/migrationmaster/shim.go
+++ b/apiserver/migrationmaster/shim.go
@@ -5,11 +5,12 @@ package migrationmaster
 
 import (
 	"github.com/juju/errors"
+	"github.com/juju/version"
+	"gopkg.in/juju/names.v2"
+
 	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/migration"
 	"github.com/juju/juju/state"
-	"github.com/juju/version"
-	"gopkg.in/juju/names.v2"
 )
 
 // newAPIForRegistration exists to provide the required signature for

--- a/apiserver/modelconfig/backend.go
+++ b/apiserver/modelconfig/backend.go
@@ -4,10 +4,11 @@
 package modelconfig
 
 import (
+	names "gopkg.in/juju/names.v2"
+
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/state"
-	names "gopkg.in/juju/names.v2"
 )
 
 // Backend contains the state.State methods used in this package,

--- a/apiserver/modelmanager/export_test.go
+++ b/apiserver/modelmanager/export_test.go
@@ -5,7 +5,6 @@ package modelmanager
 
 import (
 	gc "gopkg.in/check.v1"
-
 	"gopkg.in/juju/names.v2"
 )
 

--- a/apiserver/modelmanager/modelmanager_test.go
+++ b/apiserver/modelmanager/modelmanager_test.go
@@ -15,6 +15,8 @@ import (
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/names.v2"
 
+	// Register the providers for the field check test
+	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/modelmanager"
 	"github.com/juju/juju/apiserver/params"
 	apiservertesting "github.com/juju/juju/apiserver/testing"
@@ -23,11 +25,6 @@ import (
 	"github.com/juju/juju/environs/config"
 	jujutesting "github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/permission"
-	"github.com/juju/juju/state/stateenvirons"
-	"github.com/juju/juju/status"
-	jujuversion "github.com/juju/juju/version"
-	// Register the providers for the field check test
-	"github.com/juju/juju/apiserver/common"
 	_ "github.com/juju/juju/provider/azure"
 	"github.com/juju/juju/provider/dummy"
 	_ "github.com/juju/juju/provider/ec2"
@@ -35,8 +32,11 @@ import (
 	_ "github.com/juju/juju/provider/maas"
 	_ "github.com/juju/juju/provider/openstack"
 	"github.com/juju/juju/state"
+	"github.com/juju/juju/state/stateenvirons"
+	"github.com/juju/juju/status"
 	coretesting "github.com/juju/juju/testing"
 	"github.com/juju/juju/testing/factory"
+	jujuversion "github.com/juju/juju/version"
 )
 
 func createArgs(owner names.UserTag) params.ModelCreateArgs {

--- a/apiserver/observer/fakeobserver/instance.go
+++ b/apiserver/observer/fakeobserver/instance.go
@@ -6,13 +6,12 @@ package fakeobserver
 import (
 	"net/http"
 	"runtime"
-
-	"gopkg.in/juju/names.v2"
-
 	"strings"
 
-	"github.com/juju/juju/rpc"
 	"github.com/juju/testing"
+	"gopkg.in/juju/names.v2"
+
+	"github.com/juju/juju/rpc"
 )
 
 // Instance is a fake Observer used for testing.

--- a/apiserver/observer/metricobserver/metricobserver.go
+++ b/apiserver/observer/metricobserver/metricobserver.go
@@ -8,11 +8,10 @@ import (
 	"strconv"
 	"time"
 
-	"gopkg.in/juju/names.v2"
-
 	"github.com/juju/errors"
 	"github.com/juju/utils/clock"
 	"github.com/prometheus/client_golang/prometheus"
+	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/apiserver/observer"
 	"github.com/juju/juju/rpc"

--- a/apiserver/observer/observer.go
+++ b/apiserver/observer/observer.go
@@ -7,8 +7,9 @@ import (
 	"net/http"
 	"sync"
 
-	"github.com/juju/juju/rpc"
 	"gopkg.in/juju/names.v2"
+
+	"github.com/juju/juju/rpc"
 )
 
 // Observer defines a type which will observe API server events as

--- a/apiserver/observer/request_notifier.go
+++ b/apiserver/observer/request_notifier.go
@@ -6,10 +6,9 @@ import (
 	"net/http"
 	"time"
 
-	"gopkg.in/juju/names.v2"
-
 	"github.com/juju/loggo"
 	"github.com/juju/utils/clock"
+	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/rpc"
 	"github.com/juju/juju/rpc/jsoncodec"

--- a/apiserver/presence/pinger.go
+++ b/apiserver/presence/pinger.go
@@ -8,11 +8,12 @@ import (
 	"time"
 
 	"github.com/juju/errors"
-	"github.com/juju/juju/worker"
-	"github.com/juju/juju/worker/catacomb"
 	"github.com/juju/loggo"
 	"github.com/juju/utils/clock"
 	"gopkg.in/juju/names.v2"
+
+	"github.com/juju/juju/worker"
+	"github.com/juju/juju/worker/catacomb"
 )
 
 // Pinger exposes some methods implemented by state/presence.Pinger.

--- a/apiserver/provisioner/container_test.go
+++ b/apiserver/provisioner/container_test.go
@@ -5,7 +5,6 @@ package provisioner_test
 
 import (
 	jc "github.com/juju/testing/checkers"
-
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/apiserver/params"

--- a/apiserver/proxyupdater/proxyupdater.go
+++ b/apiserver/proxyupdater/proxyupdater.go
@@ -6,6 +6,10 @@ package proxyupdater
 import (
 	"strings"
 
+	"github.com/juju/utils/proxy"
+	"github.com/juju/utils/set"
+	"gopkg.in/juju/names.v2"
+
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/apiserver/params"
@@ -13,9 +17,6 @@ import (
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/watcher"
-	"github.com/juju/utils/proxy"
-	"github.com/juju/utils/set"
-	"gopkg.in/juju/names.v2"
 )
 
 // Backend defines the state methods this facade needs, so they can be

--- a/apiserver/proxyupdater/proxyupdater_test.go
+++ b/apiserver/proxyupdater/proxyupdater_test.go
@@ -6,6 +6,7 @@ package proxyupdater_test
 import (
 	"time"
 
+	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/names.v2"
@@ -19,7 +20,6 @@ import (
 	"github.com/juju/juju/state"
 	coretesting "github.com/juju/juju/testing"
 	"github.com/juju/juju/worker/workertest"
-	"github.com/juju/testing"
 )
 
 type ProxyUpdaterSuite struct {

--- a/apiserver/remoterelations/state.go
+++ b/apiserver/remoterelations/state.go
@@ -4,9 +4,9 @@
 package remoterelations
 
 import (
+	"github.com/juju/errors"
 	"gopkg.in/juju/names.v2"
 
-	"github.com/juju/errors"
 	"github.com/juju/juju/core/crossmodel"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/status"

--- a/apiserver/testing/stub_network.go
+++ b/apiserver/testing/stub_network.go
@@ -8,6 +8,12 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/juju/testing"
+	"github.com/juju/utils"
+	"github.com/juju/utils/set"
+	gc "gopkg.in/check.v1"
+	names "gopkg.in/juju/names.v2"
+
 	"github.com/juju/juju/apiserver/common/networkingcommon"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/environs"
@@ -16,11 +22,6 @@ import (
 	"github.com/juju/juju/network"
 	providercommon "github.com/juju/juju/provider/common"
 	coretesting "github.com/juju/juju/testing"
-	"github.com/juju/testing"
-	"github.com/juju/utils"
-	"github.com/juju/utils/set"
-	gc "gopkg.in/check.v1"
-	names "gopkg.in/juju/names.v2"
 )
 
 type StubNetwork struct {

--- a/audit/auditlogfile.go
+++ b/audit/auditlogfile.go
@@ -4,13 +4,13 @@
 package audit
 
 import (
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
 	"strings"
 	"time"
 
-	"fmt"
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	"github.com/juju/utils"

--- a/audit/auditlogfile_test.go
+++ b/audit/auditlogfile_test.go
@@ -10,12 +10,12 @@ import (
 	"runtime"
 	"time"
 
+	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/audit"
 	coretesting "github.com/juju/juju/testing"
-	"github.com/juju/testing"
 )
 
 type auditLogFileSuite struct {

--- a/cloudconfig/cloudinit/cloudinit_centos.go
+++ b/cloudconfig/cloudinit/cloudinit_centos.go
@@ -8,12 +8,13 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/juju/juju/feature"
 	"github.com/juju/utils/featureflag"
 	"github.com/juju/utils/packaging"
 	"github.com/juju/utils/packaging/config"
 	"github.com/juju/utils/proxy"
 	"gopkg.in/yaml.v2"
+
+	"github.com/juju/juju/feature"
 )
 
 // centOSCloudConfig is the cloudconfig type specific to CentOS machines.

--- a/cloudconfig/providerinit/renderers/common.go
+++ b/cloudconfig/providerinit/renderers/common.go
@@ -8,9 +8,10 @@ import (
 	"encoding/base64"
 	"fmt"
 
+	"github.com/juju/utils"
+
 	"github.com/juju/juju/cloudconfig"
 	"github.com/juju/juju/cloudconfig/cloudinit"
-	"github.com/juju/utils"
 )
 
 // ToBase64 just transforms whatever userdata it gets to base64 format

--- a/cmd/juju/application/config.go
+++ b/cmd/juju/application/config.go
@@ -13,13 +13,13 @@ import (
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
 	"github.com/juju/gnuflag"
+	"github.com/juju/utils/keyvalues"
 
 	"github.com/juju/juju/api/application"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/cmd/juju/block"
 	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/cmd/output"
-	"github.com/juju/utils/keyvalues"
 )
 
 const maxValueSize = 5242880 // Max size for a config file.

--- a/cmd/juju/application/removeapplication_test.go
+++ b/cmd/juju/application/removeapplication_test.go
@@ -6,9 +6,11 @@ package application
 import (
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
+	jutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/charmrepo.v2-unstable"
+	"gopkg.in/juju/names.v2"
 	"gopkg.in/macaroon-bakery.v1/httpbakery"
 
 	"github.com/juju/juju/api/annotations"
@@ -21,8 +23,6 @@ import (
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/testcharms"
 	"github.com/juju/juju/testing"
-	jutesting "github.com/juju/testing"
-	"gopkg.in/juju/names.v2"
 )
 
 type RemoveApplicationSuite struct {

--- a/cmd/juju/application/upgradecharm_test.go
+++ b/cmd/juju/application/upgradecharm_test.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"strings"
 
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
@@ -25,8 +26,6 @@ import (
 	charmstore "gopkg.in/juju/charmstore.v5-unstable"
 	"gopkg.in/macaroon-bakery.v1/httpbakery"
 	macaroon "gopkg.in/macaroon.v1"
-
-	"strings"
 
 	"github.com/juju/juju/api"
 	"github.com/juju/juju/api/application"

--- a/cmd/juju/cloud/add.go
+++ b/cmd/juju/cloud/add.go
@@ -8,11 +8,10 @@ import (
 	"sort"
 	"strings"
 
-	"gopkg.in/yaml.v2"
-
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
 	"github.com/juju/gnuflag"
+	"gopkg.in/yaml.v2"
 
 	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/cmd/juju/common"

--- a/cmd/juju/cloud/defaultregion_test.go
+++ b/cmd/juju/cloud/defaultregion_test.go
@@ -7,10 +7,10 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/juju/cmd"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
-	"github.com/juju/cmd"
 	jujucloud "github.com/juju/juju/cloud"
 	"github.com/juju/juju/cmd/juju/cloud"
 	"github.com/juju/juju/jujuclient/jujuclienttesting"

--- a/cmd/juju/cloud/listcredentials_test.go
+++ b/cmd/juju/cloud/listcredentials_test.go
@@ -6,10 +6,10 @@ package cloud_test
 import (
 	"strings"
 
+	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
-	"github.com/juju/errors"
 	jujucloud "github.com/juju/juju/cloud"
 	"github.com/juju/juju/cmd/juju/cloud"
 	"github.com/juju/juju/environs"

--- a/cmd/juju/commands/bootstrap_interactive.go
+++ b/cmd/juju/commands/bootstrap_interactive.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/juju/errors"
+
 	jujucloud "github.com/juju/juju/cloud"
 	"github.com/juju/juju/cmd/juju/common"
 	"github.com/juju/juju/cmd/juju/interact"

--- a/cmd/juju/commands/cmd_test.go
+++ b/cmd/juju/commands/cmd_test.go
@@ -4,9 +4,8 @@
 package commands
 
 import (
-	gc "gopkg.in/check.v1"
-
 	"github.com/juju/testing"
+	gc "gopkg.in/check.v1"
 
 	cmdtesting "github.com/juju/juju/cmd/testing"
 	coretesting "github.com/juju/juju/testing"

--- a/cmd/juju/commands/main.go
+++ b/cmd/juju/commands/main.go
@@ -20,6 +20,8 @@ import (
 	"github.com/juju/utils/series"
 	"github.com/juju/version"
 
+	// Import the providers.
+	cloudfile "github.com/juju/juju/cloud"
 	jujucmd "github.com/juju/juju/cmd"
 	"github.com/juju/juju/cmd/juju/action"
 	"github.com/juju/juju/cmd/juju/application"
@@ -46,11 +48,9 @@ import (
 	"github.com/juju/juju/juju"
 	"github.com/juju/juju/juju/osenv"
 	"github.com/juju/juju/jujuclient"
+	_ "github.com/juju/juju/provider/all"
 	"github.com/juju/juju/utils/proxy"
 	jujuversion "github.com/juju/juju/version"
-	// Import the providers.
-	cloudfile "github.com/juju/juju/cloud"
-	_ "github.com/juju/juju/provider/all"
 )
 
 var logger = loggo.GetLogger("juju.cmd.juju.commands")

--- a/cmd/juju/common/authkeys.go
+++ b/cmd/juju/common/authkeys.go
@@ -11,10 +11,11 @@ import (
 
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
-	"github.com/juju/juju/environs/config"
 	"github.com/juju/schema"
 	"github.com/juju/utils"
 	"github.com/juju/utils/ssh"
+
+	"github.com/juju/juju/environs/config"
 )
 
 var ErrNoAuthorizedKeys = errors.New("no public ssh keys found")

--- a/cmd/juju/common/controller.go
+++ b/cmd/juju/common/controller.go
@@ -12,6 +12,7 @@ import (
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
 	"github.com/juju/utils"
+	"github.com/juju/version"
 
 	"github.com/juju/juju/api/block"
 	"github.com/juju/juju/apiserver/params"
@@ -22,7 +23,6 @@ import (
 	"github.com/juju/juju/juju"
 	"github.com/juju/juju/jujuclient"
 	"github.com/juju/juju/network"
-	"github.com/juju/version"
 )
 
 var allInstances = func(environ environs.Environ) ([]instance.Instance, error) {

--- a/cmd/juju/common/flags.go
+++ b/cmd/juju/common/flags.go
@@ -10,9 +10,10 @@ import (
 
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
-	"github.com/juju/juju/constraints"
 	"github.com/juju/utils"
 	"gopkg.in/yaml.v2"
+
+	"github.com/juju/juju/constraints"
 )
 
 // ConfigFlag records k=v attributes from command arguments

--- a/cmd/juju/common/model.go
+++ b/cmd/juju/common/model.go
@@ -8,9 +8,10 @@ import (
 	"time"
 
 	"github.com/juju/errors"
+	"gopkg.in/juju/names.v2"
+
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/status"
-	"gopkg.in/juju/names.v2"
 )
 
 // ModelInfo contains information about a model.

--- a/cmd/juju/controller/getconfig_test.go
+++ b/cmd/juju/controller/getconfig_test.go
@@ -7,10 +7,10 @@ import (
 	"strings"
 
 	"github.com/juju/cmd"
+	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
-	"github.com/juju/errors"
 	"github.com/juju/juju/cmd/juju/controller"
 	jujucontroller "github.com/juju/juju/controller"
 	"github.com/juju/juju/testing"

--- a/cmd/juju/controller/killstatus.go
+++ b/cmd/juju/controller/killstatus.go
@@ -9,9 +9,10 @@ import (
 
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
-	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/utils/clock"
 	"gopkg.in/juju/names.v2"
+
+	"github.com/juju/juju/apiserver/params"
 )
 
 type ctrData struct {

--- a/cmd/juju/controller/mock_test.go
+++ b/cmd/juju/controller/mock_test.go
@@ -4,8 +4,9 @@
 package controller_test
 
 import (
-	"github.com/juju/juju/api"
 	"gopkg.in/juju/names.v2"
+
+	"github.com/juju/juju/api"
 )
 
 // mockAPIConnection implements just enough of the api.Connection interface

--- a/cmd/juju/crossmodel/findformatter.go
+++ b/cmd/juju/crossmodel/findformatter.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/juju/errors"
+
 	"github.com/juju/juju/cmd/output"
 )
 

--- a/cmd/juju/crossmodel/listformatter.go
+++ b/cmd/juju/crossmodel/listformatter.go
@@ -9,6 +9,7 @@ import (
 	"sort"
 
 	"github.com/juju/errors"
+
 	"github.com/juju/juju/cmd/output"
 )
 

--- a/cmd/juju/crossmodel/showformatter.go
+++ b/cmd/juju/crossmodel/showformatter.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/juju/errors"
+
 	"github.com/juju/juju/cmd/output"
 )
 

--- a/cmd/juju/interact/pollster.go
+++ b/cmd/juju/interact/pollster.go
@@ -15,11 +15,10 @@ import (
 	"strconv"
 	"strings"
 
-	"golang.org/x/crypto/ssh/terminal"
-
 	"github.com/juju/errors"
 	"github.com/juju/jsonschema"
 	"github.com/juju/utils/set"
+	"golang.org/x/crypto/ssh/terminal"
 )
 
 // Pollster is used to ask multiple questions of the user using a standard

--- a/cmd/juju/model/defaultscommand.go
+++ b/cmd/juju/model/defaultscommand.go
@@ -9,12 +9,11 @@ import (
 	"sort"
 	"strings"
 
-	"gopkg.in/juju/names.v2"
-
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
 	"github.com/juju/gnuflag"
 	"github.com/juju/utils/keyvalues"
+	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/api"
 	"github.com/juju/juju/api/base"

--- a/cmd/juju/romulus/agree/agree.go
+++ b/cmd/juju/romulus/agree/agree.go
@@ -14,10 +14,11 @@ import (
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
 	"github.com/juju/gnuflag"
-	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/terms-client/api"
 	"github.com/juju/terms-client/api/wireformat"
 	"gopkg.in/juju/charm.v6-unstable"
+
+	"github.com/juju/juju/cmd/modelcmd"
 )
 
 var (

--- a/cmd/juju/romulus/allocate/allocate.go
+++ b/cmd/juju/romulus/allocate/allocate.go
@@ -11,11 +11,11 @@ import (
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
 	"github.com/juju/gnuflag"
-	"github.com/juju/juju/cmd/modelcmd"
+	api "github.com/juju/romulus/api/budget"
 	"github.com/juju/utils"
 	"gopkg.in/macaroon-bakery.v1/httpbakery"
 
-	api "github.com/juju/romulus/api/budget"
+	"github.com/juju/juju/cmd/modelcmd"
 )
 
 var budgetWithLimitRe = regexp.MustCompile(`^[a-zA-Z0-9\-]+:[0-9]+$`)

--- a/cmd/juju/romulus/allocate/export_test.go
+++ b/cmd/juju/romulus/allocate/export_test.go
@@ -5,6 +5,7 @@ package allocate
 
 import (
 	"github.com/juju/cmd"
+
 	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/jujuclient"
 )

--- a/cmd/juju/romulus/createbudget/createbudget.go
+++ b/cmd/juju/romulus/createbudget/createbudget.go
@@ -9,10 +9,10 @@ import (
 
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
-	"github.com/juju/juju/cmd/modelcmd"
+	api "github.com/juju/romulus/api/budget"
 	"gopkg.in/macaroon-bakery.v1/httpbakery"
 
-	api "github.com/juju/romulus/api/budget"
+	"github.com/juju/juju/cmd/modelcmd"
 )
 
 type createBudgetCommand struct {

--- a/cmd/juju/romulus/listagreements/listagreements.go
+++ b/cmd/juju/romulus/listagreements/listagreements.go
@@ -10,10 +10,11 @@ import (
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
 	"github.com/juju/gnuflag"
-	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/terms-client/api"
 	"github.com/juju/terms-client/api/wireformat"
 	"gopkg.in/macaroon-bakery.v1/httpbakery"
+
+	"github.com/juju/juju/cmd/modelcmd"
 )
 
 var (

--- a/cmd/juju/romulus/listbudgets/list-budgets.go
+++ b/cmd/juju/romulus/listbudgets/list-budgets.go
@@ -12,11 +12,11 @@ import (
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
 	"github.com/juju/gnuflag"
-	"github.com/juju/juju/cmd/modelcmd"
-	"gopkg.in/macaroon-bakery.v1/httpbakery"
-
 	api "github.com/juju/romulus/api/budget"
 	wireformat "github.com/juju/romulus/wireformat/budget"
+	"gopkg.in/macaroon-bakery.v1/httpbakery"
+
+	"github.com/juju/juju/cmd/modelcmd"
 )
 
 // NewListBudgetsCommand returns a new command that is used

--- a/cmd/juju/romulus/setbudget/setbudget.go
+++ b/cmd/juju/romulus/setbudget/setbudget.go
@@ -9,10 +9,10 @@ import (
 
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
-	"github.com/juju/juju/cmd/modelcmd"
+	api "github.com/juju/romulus/api/budget"
 	"gopkg.in/macaroon-bakery.v1/httpbakery"
 
-	api "github.com/juju/romulus/api/budget"
+	"github.com/juju/juju/cmd/modelcmd"
 )
 
 type setBudgetCommand struct {

--- a/cmd/juju/romulus/setplan/set_plan.go
+++ b/cmd/juju/romulus/setplan/set_plan.go
@@ -11,12 +11,12 @@ import (
 
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
-	"github.com/juju/juju/api/application"
-	"github.com/juju/juju/cmd/modelcmd"
+	api "github.com/juju/romulus/api/plan"
 	"gopkg.in/juju/names.v2"
 	"gopkg.in/macaroon.v1"
 
-	api "github.com/juju/romulus/api/plan"
+	"github.com/juju/juju/api/application"
+	"github.com/juju/juju/cmd/modelcmd"
 )
 
 // authorizationClient defines the interface of an api client that

--- a/cmd/juju/romulus/showbudget/show_budget.go
+++ b/cmd/juju/romulus/showbudget/show_budget.go
@@ -12,15 +12,15 @@ import (
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
 	"github.com/juju/gnuflag"
-	"github.com/juju/juju/api/modelmanager"
-	"github.com/juju/juju/apiserver/params"
-	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/loggo"
+	api "github.com/juju/romulus/api/budget"
+	wireformat "github.com/juju/romulus/wireformat/budget"
 	"gopkg.in/juju/names.v2"
 	"gopkg.in/macaroon-bakery.v1/httpbakery"
 
-	api "github.com/juju/romulus/api/budget"
-	wireformat "github.com/juju/romulus/wireformat/budget"
+	"github.com/juju/juju/api/modelmanager"
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/cmd/modelcmd"
 )
 
 var logger = loggo.GetLogger("romulus.cmd.showbudget")

--- a/cmd/juju/romulus/updateallocation/export_test.go
+++ b/cmd/juju/romulus/updateallocation/export_test.go
@@ -5,6 +5,7 @@ package updateallocation
 
 import (
 	"github.com/juju/cmd"
+
 	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/jujuclient"
 )

--- a/cmd/juju/romulus/updateallocation/updateallocation.go
+++ b/cmd/juju/romulus/updateallocation/updateallocation.go
@@ -10,10 +10,10 @@ import (
 
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
-	"github.com/juju/juju/cmd/modelcmd"
+	api "github.com/juju/romulus/api/budget"
 	"gopkg.in/macaroon-bakery.v1/httpbakery"
 
-	api "github.com/juju/romulus/api/budget"
+	"github.com/juju/juju/cmd/modelcmd"
 )
 
 type updateAllocationCommand struct {

--- a/cmd/juju/space/list_test.go
+++ b/cmd/juju/space/list_test.go
@@ -7,9 +7,8 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
-	"strings"
-
 	"regexp"
+	"strings"
 
 	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"

--- a/cmd/juju/space/remove_test.go
+++ b/cmd/juju/space/remove_test.go
@@ -5,11 +5,11 @@ package space_test
 
 import (
 	"github.com/juju/errors"
-	"github.com/juju/juju/feature"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/cmd/juju/space"
+	"github.com/juju/juju/feature"
 	coretesting "github.com/juju/juju/testing"
 )
 

--- a/cmd/juju/storage/filesystemlistformatters.go
+++ b/cmd/juju/storage/filesystemlistformatters.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/dustin/go-humanize"
+
 	"github.com/juju/juju/cmd/output"
 )
 

--- a/cmd/juju/storage/listformatters.go
+++ b/cmd/juju/storage/listformatters.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/dustin/go-humanize"
+
 	"github.com/juju/juju/cmd/output"
 )
 

--- a/cmd/juju/storage/poollistformatters.go
+++ b/cmd/juju/storage/poollistformatters.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/juju/errors"
+
 	"github.com/juju/juju/cmd/output"
 )
 

--- a/cmd/juju/storage/volumelistformatters.go
+++ b/cmd/juju/storage/volumelistformatters.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/dustin/go-humanize"
+
 	"github.com/juju/juju/cmd/output"
 )
 

--- a/cmd/juju/subnet/add.go
+++ b/cmd/juju/subnet/add.go
@@ -8,12 +8,12 @@ import (
 
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
-	"github.com/juju/juju/network"
 	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/cmd/juju/common"
 	"github.com/juju/juju/cmd/modelcmd"
+	"github.com/juju/juju/network"
 )
 
 // NewAddCommand returns a command used to add an existing subnet to Juju.

--- a/cmd/juju/subnet/create.go
+++ b/cmd/juju/subnet/create.go
@@ -6,10 +6,9 @@ package subnet
 import (
 	"strings"
 
-	"github.com/juju/gnuflag"
-
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
+	"github.com/juju/gnuflag"
 	"github.com/juju/utils/set"
 	"gopkg.in/juju/names.v2"
 

--- a/cmd/juju/subnet/list.go
+++ b/cmd/juju/subnet/list.go
@@ -7,13 +7,12 @@ import (
 	"net"
 	"strings"
 
-	"github.com/juju/gnuflag"
-
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
-	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/gnuflag"
 	"gopkg.in/juju/names.v2"
 
+	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/cmd/output"
 )

--- a/cmd/juju/user/remove.go
+++ b/cmd/juju/user/remove.go
@@ -11,8 +11,8 @@ import (
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
 	"github.com/juju/gnuflag"
-	"github.com/juju/juju/apiserver/params"
 
+	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/cmd/juju/block"
 	"github.com/juju/juju/cmd/modelcmd"
 )

--- a/cmd/juju/user/remove_test.go
+++ b/cmd/juju/user/remove_test.go
@@ -4,10 +4,11 @@ package user_test
 
 import (
 	"github.com/juju/cmd"
-	"github.com/juju/juju/cmd/juju/user"
-	"github.com/juju/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/cmd/juju/user"
+	"github.com/juju/juju/testing"
 )
 
 type RemoveUserCommandSuite struct {

--- a/cmd/jujud/agent/introspection.go
+++ b/cmd/jujud/agent/introspection.go
@@ -7,10 +7,9 @@ import (
 	"os"
 	"runtime"
 
-	names "gopkg.in/juju/names.v2"
-
 	"github.com/juju/errors"
 	"github.com/prometheus/client_golang/prometheus"
+	names "gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/agent"
 	"github.com/juju/juju/worker"

--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -22,6 +22,7 @@ import (
 	"github.com/juju/pubsub"
 	"github.com/juju/replicaset"
 	"github.com/juju/utils"
+	utilscert "github.com/juju/utils/cert"
 	"github.com/juju/utils/clock"
 	"github.com/juju/utils/featureflag"
 	"github.com/juju/utils/series"
@@ -96,7 +97,6 @@ import (
 	"github.com/juju/juju/worker/singular"
 	"github.com/juju/juju/worker/txnpruner"
 	"github.com/juju/juju/worker/upgradesteps"
-	utilscert "github.com/juju/utils/cert"
 )
 
 var (

--- a/cmd/jujud/agent/machine/manifolds.go
+++ b/cmd/jujud/agent/machine/manifolds.go
@@ -9,8 +9,10 @@ import (
 
 	"github.com/juju/errors"
 	"github.com/juju/pubsub"
+	"github.com/juju/utils/clock"
 	"github.com/juju/utils/proxy"
 	"github.com/juju/utils/voyeur"
+	"github.com/juju/version"
 	"github.com/prometheus/client_golang/prometheus"
 
 	coreagent "github.com/juju/juju/agent"
@@ -54,8 +56,6 @@ import (
 	"github.com/juju/juju/worker/toolsversionchecker"
 	"github.com/juju/juju/worker/upgrader"
 	"github.com/juju/juju/worker/upgradesteps"
-	"github.com/juju/utils/clock"
-	"github.com/juju/version"
 )
 
 // ManifoldsConfig allows specialisation of the result of Manifolds.

--- a/cmd/jujud/agent/model/agent_test.go
+++ b/cmd/jujud/agent/model/agent_test.go
@@ -4,11 +4,10 @@
 package model_test
 
 import (
-	gc "gopkg.in/check.v1"
-
 	"github.com/juju/errors"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/agent"

--- a/cmd/jujud/agent/model/manifolds.go
+++ b/cmd/jujud/agent/model/manifolds.go
@@ -6,12 +6,12 @@ package model
 import (
 	"time"
 
-	"github.com/juju/juju/api"
 	"github.com/juju/utils/clock"
 	"github.com/juju/utils/featureflag"
 	"github.com/juju/utils/voyeur"
 
 	coreagent "github.com/juju/juju/agent"
+	"github.com/juju/juju/api"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/cmd/jujud/agent/engine"
 	"github.com/juju/juju/core/life"

--- a/cmd/jujud/main.go
+++ b/cmd/jujud/main.go
@@ -26,9 +26,9 @@ import (
 	components "github.com/juju/juju/component/all"
 	"github.com/juju/juju/juju/names"
 	"github.com/juju/juju/juju/sockets"
-	"github.com/juju/juju/upgrades"
 	// Import the providers.
 	_ "github.com/juju/juju/provider/all"
+	"github.com/juju/juju/upgrades"
 	"github.com/juju/juju/utils/proxy"
 	"github.com/juju/juju/worker/logsender"
 	"github.com/juju/juju/worker/uniter/runner/jujuc"

--- a/cmd/jujud/run.go
+++ b/cmd/jujud/run.go
@@ -16,13 +16,13 @@ import (
 	"github.com/juju/mutex"
 	"github.com/juju/utils/clock"
 	"github.com/juju/utils/exec"
+	jujuos "github.com/juju/utils/os"
 	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/agent"
 	cmdutil "github.com/juju/juju/cmd/jujud/util"
 	"github.com/juju/juju/juju/sockets"
 	"github.com/juju/juju/worker/uniter"
-	jujuos "github.com/juju/utils/os"
 )
 
 type RunCommand struct {

--- a/cmd/jujud/run_test.go
+++ b/cmd/jujud/run_test.go
@@ -18,13 +18,13 @@ import (
 	"github.com/juju/utils"
 	"github.com/juju/utils/clock"
 	"github.com/juju/utils/exec"
+	jujuos "github.com/juju/utils/os"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/names.v2"
 
 	cmdutil "github.com/juju/juju/cmd/jujud/util"
 	"github.com/juju/juju/testing"
 	"github.com/juju/juju/worker/uniter"
-	jujuos "github.com/juju/utils/os"
 )
 
 const testLockName = "juju-run-test"

--- a/cmd/modelcmd/apicontext.go
+++ b/cmd/modelcmd/apicontext.go
@@ -6,6 +6,7 @@ package modelcmd
 import (
 	"os"
 
+	"github.com/juju/cmd"
 	"github.com/juju/errors"
 	"github.com/juju/gnuflag"
 	"github.com/juju/idmclient/ussologin"
@@ -13,7 +14,6 @@ import (
 	"gopkg.in/juju/environschema.v1/form"
 	"gopkg.in/macaroon-bakery.v1/httpbakery"
 
-	"github.com/juju/cmd"
 	"github.com/juju/juju/jujuclient"
 )
 

--- a/cmd/modelcmd/base_test.go
+++ b/cmd/modelcmd/base_test.go
@@ -6,11 +6,10 @@ package modelcmd_test
 import (
 	"strings"
 
-	gc "gopkg.in/check.v1"
-
 	"github.com/juju/errors"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/api"
 	"github.com/juju/juju/apiserver/params"

--- a/cmd/modelcmd/credentials_test.go
+++ b/cmd/modelcmd/credentials_test.go
@@ -5,12 +5,11 @@ package modelcmd_test
 
 import (
 	"fmt"
+	"io/ioutil"
+	"path/filepath"
 
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
-
-	"io/ioutil"
-	"path/filepath"
 
 	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/cmd/modelcmd"

--- a/cmd/output/output.go
+++ b/cmd/output/output.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/juju/ansiterm"
 	"github.com/juju/cmd"
+
 	"github.com/juju/juju/status"
 )
 

--- a/cmd/plugins/juju-metadata/listformatter.go
+++ b/cmd/plugins/juju-metadata/listformatter.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/juju/errors"
+
 	"github.com/juju/juju/cmd/output"
 )
 

--- a/cmd/testing/prompt_test.go
+++ b/cmd/testing/prompt_test.go
@@ -10,11 +10,11 @@ import (
 	"strings"
 
 	"github.com/juju/errors"
+	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
 	cmdtesting "github.com/juju/juju/cmd/testing"
-	"github.com/juju/testing"
 )
 
 type prompterSuite struct {

--- a/container/kvm/container_internal_test.go
+++ b/container/kvm/container_internal_test.go
@@ -4,10 +4,10 @@
 package kvm
 
 import (
+	"github.com/juju/testing"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/network"
-	"github.com/juju/testing"
 )
 
 // gocheck boilerplate.

--- a/container/kvm/initialisation_internal_test.go
+++ b/container/kvm/initialisation_internal_test.go
@@ -8,10 +8,9 @@ import (
 	"io/ioutil"
 	"os"
 
-	gc "gopkg.in/check.v1"
-
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
 )
 
 // gocheck boilerplate.

--- a/container/kvm/libvirt/domainxml_internal_test.go
+++ b/container/kvm/libvirt/domainxml_internal_test.go
@@ -4,10 +4,9 @@
 package libvirt
 
 import (
-	gc "gopkg.in/check.v1"
-
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
 )
 
 // gocheck boilerplate.

--- a/container/kvm/libvirt/domainxml_test.go
+++ b/container/kvm/libvirt/domainxml_test.go
@@ -6,13 +6,12 @@ package libvirt_test
 import (
 	"encoding/xml"
 
-	gc "gopkg.in/check.v1"
-
 	"github.com/juju/errors"
 	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
 
 	. "github.com/juju/juju/container/kvm/libvirt"
-	jc "github.com/juju/testing/checkers"
 )
 
 // gocheck boilerplate.

--- a/container/kvm/package_test.go
+++ b/container/kvm/package_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	"github.com/juju/utils/arch"
-
 	gc "gopkg.in/check.v1"
 )
 

--- a/container/kvm/sync_internal_test.go
+++ b/container/kvm/sync_internal_test.go
@@ -13,12 +13,12 @@ import (
 	"strings"
 	"time"
 
-	gc "gopkg.in/check.v1"
-
 	"github.com/juju/errors"
-	"github.com/juju/juju/environs/imagedownloads"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/environs/imagedownloads"
 )
 
 // syncInternalSuite is gocheck boilerplate.

--- a/container/kvm/sync_test.go
+++ b/container/kvm/sync_test.go
@@ -6,14 +6,13 @@ package kvm_test
 import (
 	"net/http"
 
-	gc "gopkg.in/check.v1"
-
 	"github.com/juju/errors"
-	"github.com/juju/juju/environs/imagedownloads"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
 
 	. "github.com/juju/juju/container/kvm"
+	"github.com/juju/juju/environs/imagedownloads"
 )
 
 // cacheSuite is gocheck boilerplate.

--- a/container/kvm/wrappedcmds.go
+++ b/container/kvm/wrappedcmds.go
@@ -24,12 +24,11 @@ import (
 	"regexp"
 	"strings"
 
-	"gopkg.in/yaml.v2"
-
 	"github.com/juju/errors"
 	"github.com/juju/utils"
 	"github.com/juju/utils/arch"
 	"github.com/juju/utils/series"
+	"gopkg.in/yaml.v2"
 
 	"github.com/juju/juju/container/kvm/libvirt"
 	"github.com/juju/juju/juju/paths"

--- a/container/kvm/wrappedcmds_internal_test.go
+++ b/container/kvm/wrappedcmds_internal_test.go
@@ -9,11 +9,11 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/container/kvm/libvirt"
-	"github.com/juju/testing"
-	jc "github.com/juju/testing/checkers"
 )
 
 type libvirtInternalSuite struct {

--- a/environs/bootstrap/bootstrap_test.go
+++ b/environs/bootstrap/bootstrap_test.go
@@ -16,7 +16,6 @@ import (
 	"time"
 
 	"github.com/juju/errors"
-	"github.com/juju/juju/cloud"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils/arch"
 	utilscert "github.com/juju/utils/cert"
@@ -27,6 +26,7 @@ import (
 
 	"github.com/juju/juju/api"
 	"github.com/juju/juju/cert"
+	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/cloudconfig/instancecfg"
 	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/constraints"

--- a/environs/bootstrap/config.go
+++ b/environs/bootstrap/config.go
@@ -14,10 +14,10 @@ import (
 	"time"
 
 	"github.com/juju/errors"
-	"github.com/juju/juju/cert"
 	"github.com/juju/schema"
 	"github.com/juju/utils"
 
+	"github.com/juju/juju/cert"
 	"github.com/juju/juju/juju/osenv"
 )
 

--- a/environs/config/authkeys_test.go
+++ b/environs/config/authkeys_test.go
@@ -4,10 +4,10 @@
 package config_test
 
 import (
+	"github.com/juju/testing"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/environs/config"
-	"github.com/juju/testing"
 )
 
 type AuthKeysSuite struct {

--- a/environs/imagedownloads/simplestreams_test.go
+++ b/environs/imagedownloads/simplestreams_test.go
@@ -9,15 +9,13 @@ import (
 	"net/http/httptest"
 	"strings"
 
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
-	"github.com/juju/testing"
-
+	. "github.com/juju/juju/environs/imagedownloads"
 	"github.com/juju/juju/environs/imagemetadata"
 	"github.com/juju/juju/environs/simplestreams"
-	jc "github.com/juju/testing/checkers"
-
-	. "github.com/juju/juju/environs/imagedownloads"
 )
 
 type Suite struct {

--- a/environs/imagemetadata/simplestreams.go
+++ b/environs/imagemetadata/simplestreams.go
@@ -11,11 +11,11 @@ import (
 	"sort"
 
 	"github.com/juju/utils"
+	"github.com/juju/utils/arch"
+	"github.com/juju/utils/series"
 
 	"github.com/juju/juju/environs/simplestreams"
 	"github.com/juju/juju/juju/keys"
-	"github.com/juju/utils/arch"
-	"github.com/juju/utils/series"
 )
 
 func init() {

--- a/environs/manual/addresses_test.go
+++ b/environs/manual/addresses_test.go
@@ -7,12 +7,12 @@ package manual_test
 import (
 	"errors"
 
-	"github.com/juju/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/environs/manual"
 	"github.com/juju/juju/network"
+	"github.com/juju/juju/testing"
 )
 
 const (

--- a/environs/networking.go
+++ b/environs/networking.go
@@ -4,9 +4,9 @@
 package environs
 
 import (
+	"github.com/juju/errors"
 	"gopkg.in/juju/names.v2"
 
-	"github.com/juju/errors"
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/network"
 )

--- a/featuretests/bakerystorage_test.go
+++ b/featuretests/bakerystorage_test.go
@@ -6,14 +6,15 @@ package featuretests
 import (
 	"time"
 
-	"github.com/juju/juju/mongo"
-	"github.com/juju/juju/state/bakerystorage"
 	gitjujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/macaroon-bakery.v1/bakery"
 	"gopkg.in/macaroon.v1"
 	"gopkg.in/mgo.v2"
+
+	"github.com/juju/juju/mongo"
+	"github.com/juju/juju/state/bakerystorage"
 )
 
 // This suite is not about a feature tests per se, but tests the integration

--- a/featuretests/storage_test.go
+++ b/featuretests/storage_test.go
@@ -7,12 +7,12 @@ import (
 	"strings"
 
 	"github.com/juju/cmd"
+	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/names.v2"
 
-	"github.com/juju/errors"
 	jujucmd "github.com/juju/juju/cmd/juju/commands"
 	jujutesting "github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/provider/dummy"

--- a/featuretests/upgrade_test.go
+++ b/featuretests/upgrade_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/juju/utils/arch"
 	pacman "github.com/juju/utils/packaging/manager"
 	"github.com/juju/utils/series"
+	"github.com/juju/version"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/names.v2"
 
@@ -39,7 +40,6 @@ import (
 	"github.com/juju/juju/worker/logsender"
 	"github.com/juju/juju/worker/upgrader"
 	"github.com/juju/juju/worker/upgradesteps"
-	"github.com/juju/version"
 )
 
 const (

--- a/juju/home.go
+++ b/juju/home.go
@@ -4,11 +4,11 @@
 package juju
 
 import (
-	"github.com/juju/juju/juju/osenv"
-
 	"github.com/juju/errors"
 	"github.com/juju/utils/ssh"
 	"gopkg.in/juju/charmrepo.v2-unstable"
+
+	"github.com/juju/juju/juju/osenv"
 )
 
 // InitJujuXDGDataHome initializes the charm cache, environs/config and utils/ssh packages

--- a/juju/mock_test.go
+++ b/juju/mock_test.go
@@ -6,12 +6,12 @@ package juju_test
 import (
 	"net"
 
+	"github.com/juju/version"
 	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/api"
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/testing"
-	"github.com/juju/version"
 )
 
 type mockAPIState struct {

--- a/juju/sockets/sockets_windows.go
+++ b/juju/sockets/sockets_windows.go
@@ -8,7 +8,6 @@ import (
 	"net/rpc"
 
 	"github.com/juju/errors"
-
 	"gopkg.in/natefinch/npipe.v2"
 )
 

--- a/jujuclient/credentialsfile_test.go
+++ b/jujuclient/credentialsfile_test.go
@@ -6,10 +6,10 @@ package jujuclient_test
 import (
 	"io/ioutil"
 
+	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
-	"github.com/juju/errors"
 	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/juju/osenv"
 	"github.com/juju/juju/jujuclient"

--- a/mongo/internal_test.go
+++ b/mongo/internal_test.go
@@ -10,10 +10,10 @@ import (
 	"os"
 	"time"
 
-	coretesting "github.com/juju/juju/testing"
-
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
+
+	coretesting "github.com/juju/juju/testing"
 )
 
 type MongoVersionSuite struct {

--- a/mongo/utils/data_cleansing_test.go
+++ b/mongo/utils/data_cleansing_test.go
@@ -4,9 +4,10 @@
 package utils_test
 
 import (
-	"github.com/juju/juju/mongo/utils"
 	"github.com/juju/testing"
 	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/mongo/utils"
 )
 
 type dataCleansingSuite struct {

--- a/network/bridge_test.go
+++ b/network/bridge_test.go
@@ -8,10 +8,11 @@ import (
 	"runtime"
 	"time"
 
-	"github.com/juju/juju/network"
 	"github.com/juju/testing"
 	"github.com/juju/utils/clock"
 	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/network"
 )
 
 // A note regarding the use of clock.WallClock in these unit tests.

--- a/network/devicenames_test.go
+++ b/network/devicenames_test.go
@@ -4,10 +4,10 @@
 package network_test
 
 import (
+	"github.com/juju/testing"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/network"
-	"github.com/juju/testing"
 )
 
 type DeviceNamesSuite struct {

--- a/network/scriptrunner_test.go
+++ b/network/scriptrunner_test.go
@@ -8,12 +8,13 @@ import (
 	"runtime"
 	"time"
 
-	"github.com/juju/juju/network"
-	coretesting "github.com/juju/juju/testing"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils/clock"
 	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/network"
+	coretesting "github.com/juju/juju/testing"
 )
 
 type ScriptRunnerSuite struct {

--- a/payload/status/output_tabular.go
+++ b/payload/status/output_tabular.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/juju/errors"
+
 	"github.com/juju/juju/cmd/output"
 )
 

--- a/provider/azure/environ_test.go
+++ b/provider/azure/environ_test.go
@@ -25,6 +25,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils"
 	"github.com/juju/utils/arch"
+	"github.com/juju/version"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/names.v2"
 
@@ -47,7 +48,6 @@ import (
 	"github.com/juju/juju/provider/azure/internal/azuretesting"
 	"github.com/juju/juju/testing"
 	"github.com/juju/juju/tools"
-	"github.com/juju/version"
 )
 
 const storageAccountName = "juju400d80004b1d0d06f00d"

--- a/provider/azure/instance.go
+++ b/provider/azure/instance.go
@@ -11,12 +11,12 @@ import (
 	"github.com/Azure/azure-sdk-for-go/arm/network"
 	"github.com/Azure/go-autorest/autorest"
 	"github.com/Azure/go-autorest/autorest/to"
-
 	"github.com/juju/errors"
+	"gopkg.in/juju/names.v2"
+
 	"github.com/juju/juju/instance"
 	jujunetwork "github.com/juju/juju/network"
 	"github.com/juju/juju/status"
-	"gopkg.in/juju/names.v2"
 )
 
 type azureInstance struct {

--- a/provider/azure/internal/errorutils/errors.go
+++ b/provider/azure/internal/errorutils/errors.go
@@ -4,10 +4,9 @@
 package errorutils
 
 import (
-	"github.com/juju/errors"
-
 	"github.com/Azure/go-autorest/autorest"
 	"github.com/Azure/go-autorest/autorest/azure"
+	"github.com/juju/errors"
 )
 
 // ServiceError returns the *azure.ServiceError underlying the

--- a/provider/azure/upgrades_test.go
+++ b/provider/azure/upgrades_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/arm/storage"
 	"github.com/Azure/go-autorest/autorest/to"
 	jc "github.com/juju/testing/checkers"
+	"github.com/juju/version"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/environs"
@@ -19,7 +20,6 @@ import (
 	"github.com/juju/juju/provider/azure/internal/armtemplates"
 	"github.com/juju/juju/provider/azure/internal/azuretesting"
 	"github.com/juju/juju/testing"
-	"github.com/juju/version"
 )
 
 type environUpgradeSuite struct {

--- a/provider/cloudsigma/config_test.go
+++ b/provider/cloudsigma/config_test.go
@@ -4,9 +4,9 @@
 package cloudsigma
 
 import (
+	"github.com/altoros/gosigma/mock"
 	gc "gopkg.in/check.v1"
 
-	"github.com/altoros/gosigma/mock"
 	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/config"

--- a/provider/cloudsigma/credentials.go
+++ b/provider/cloudsigma/credentials.go
@@ -5,6 +5,7 @@ package cloudsigma
 
 import (
 	"github.com/juju/errors"
+
 	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/environs"
 )

--- a/provider/common/disk_test.go
+++ b/provider/common/disk_test.go
@@ -4,8 +4,9 @@
 package common_test
 
 import (
-	"github.com/juju/juju/provider/common"
 	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/provider/common"
 )
 
 type DiskSuite struct{}

--- a/provider/dummy/environs_whitebox_test.go
+++ b/provider/dummy/environs_whitebox_test.go
@@ -5,7 +5,6 @@ package dummy
 
 import (
 	// stdtesting "testing"
-
 	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"

--- a/provider/gce/google/ruleset.go
+++ b/provider/gce/google/ruleset.go
@@ -6,10 +6,10 @@ package google
 import (
 	"crypto/sha256"
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/juju/juju/network"
-	"sort"
 )
 
 // RuleSet is used to manipulate port ranges

--- a/provider/gce/instancetypes.go
+++ b/provider/gce/instancetypes.go
@@ -4,8 +4,9 @@
 package gce
 
 import (
-	"github.com/juju/juju/environs/instances"
 	"github.com/juju/utils/arch"
+
+	"github.com/juju/juju/environs/instances"
 )
 
 var (

--- a/provider/joyent/environ_firewall.go
+++ b/provider/joyent/environ_firewall.go
@@ -10,8 +10,8 @@ import (
 	"strings"
 
 	"github.com/joyent/gosdc/cloudapi"
-
 	"github.com/juju/errors"
+
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/network"
 )

--- a/provider/joyent/instance_information.go
+++ b/provider/joyent/instance_information.go
@@ -5,6 +5,7 @@ package joyent
 
 import (
 	"github.com/juju/errors"
+
 	"github.com/juju/juju/constraints"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/instances"

--- a/provider/joyent/userdata_test.go
+++ b/provider/joyent/userdata_test.go
@@ -6,12 +6,12 @@ package joyent_test
 
 import (
 	jc "github.com/juju/testing/checkers"
+	"github.com/juju/utils/os"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/cloudconfig/cloudinit/cloudinittest"
 	"github.com/juju/juju/provider/joyent"
 	"github.com/juju/juju/testing"
-	"github.com/juju/utils/os"
 )
 
 type UserdataSuite struct {

--- a/provider/lxd/testing_test.go
+++ b/provider/lxd/testing_test.go
@@ -14,6 +14,7 @@ import (
 	gitjujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils/arch"
+	"github.com/juju/version"
 	"github.com/lxc/lxd/shared/api"
 	gc "gopkg.in/check.v1"
 
@@ -29,7 +30,6 @@ import (
 	"github.com/juju/juju/testing"
 	coretools "github.com/juju/juju/tools"
 	"github.com/juju/juju/tools/lxdclient"
-	"github.com/juju/version"
 )
 
 // Ensure LXD provider supports the expected interfaces.

--- a/provider/maas/environ_test.go
+++ b/provider/maas/environ_test.go
@@ -9,12 +9,12 @@ import (
 	"net/http/httptest"
 	stdtesting "testing"
 
+	"github.com/juju/errors"
 	"github.com/juju/gomaasapi"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils/set"
 	gc "gopkg.in/check.v1"
 
-	"github.com/juju/errors"
 	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/config"

--- a/provider/maas/environprovider_test.go
+++ b/provider/maas/environprovider_test.go
@@ -13,7 +13,6 @@ import (
 	"strings"
 
 	"github.com/juju/gomaasapi"
-
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils"
 	"github.com/juju/utils/set"

--- a/provider/maas/instance_information.go
+++ b/provider/maas/instance_information.go
@@ -5,6 +5,7 @@ package maas
 
 import (
 	"github.com/juju/errors"
+
 	"github.com/juju/juju/constraints"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/instances"

--- a/provider/openstack/legacy_networking.go
+++ b/provider/openstack/legacy_networking.go
@@ -4,9 +4,10 @@
 package openstack
 
 import (
-	"github.com/juju/juju/instance"
 	"github.com/juju/utils"
 	"gopkg.in/goose.v1/nova"
+
+	"github.com/juju/juju/instance"
 )
 
 // LegacyNovaNetworking is an implementation of Networking that uses the legacy

--- a/provider/openstack/provider.go
+++ b/provider/openstack/provider.go
@@ -16,6 +16,7 @@ import (
 	"github.com/juju/jsonschema"
 	"github.com/juju/loggo"
 	"github.com/juju/utils"
+	"github.com/juju/utils/clock"
 	"github.com/juju/version"
 	"gopkg.in/goose.v1/cinder"
 	"gopkg.in/goose.v1/client"
@@ -40,7 +41,6 @@ import (
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/status"
 	"github.com/juju/juju/tools"
-	"github.com/juju/utils/clock"
 )
 
 var logger = loggo.GetLogger("juju.provider.openstack")

--- a/provider/rackspace/environ.go
+++ b/provider/rackspace/environ.go
@@ -9,13 +9,13 @@ import (
 	"time"
 
 	"github.com/juju/errors"
+	jujuos "github.com/juju/utils/os"
+	"github.com/juju/utils/series"
+	"github.com/juju/utils/ssh"
 
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/provider/common"
-	jujuos "github.com/juju/utils/os"
-	"github.com/juju/utils/series"
-	"github.com/juju/utils/ssh"
 )
 
 type environ struct {

--- a/provider/rackspace/environ_test.go
+++ b/provider/rackspace/environ_test.go
@@ -7,9 +7,11 @@ import (
 	"io"
 	"os"
 
+	"github.com/juju/errors"
+	"github.com/juju/utils/ssh"
+	"github.com/juju/version"
 	gc "gopkg.in/check.v1"
 
-	"github.com/juju/errors"
 	"github.com/juju/juju/cloudconfig/instancecfg"
 	"github.com/juju/juju/constraints"
 	"github.com/juju/juju/environs"
@@ -23,8 +25,6 @@ import (
 	"github.com/juju/juju/storage"
 	"github.com/juju/juju/testing"
 	"github.com/juju/juju/tools"
-	"github.com/juju/utils/ssh"
-	"github.com/juju/version"
 )
 
 type environSuite struct {

--- a/provider/rackspace/flavors.go
+++ b/provider/rackspace/flavors.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 
 	"github.com/juju/loggo"
-
 	"gopkg.in/goose.v1/nova"
 )
 

--- a/provider/rackspace/init.go
+++ b/provider/rackspace/init.go
@@ -4,10 +4,11 @@
 package rackspace
 
 import (
-	"github.com/juju/juju/environs"
-	"github.com/juju/juju/provider/openstack"
 	"gopkg.in/goose.v1/client"
 	"gopkg.in/goose.v1/identity"
+
+	"github.com/juju/juju/environs"
+	"github.com/juju/juju/provider/openstack"
 )
 
 const (

--- a/provider/rackspace/provider.go
+++ b/provider/rackspace/provider.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/juju/errors"
 	"github.com/juju/jsonschema"
+
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/config"
 )

--- a/provider/rackspace/provider_test.go
+++ b/provider/rackspace/provider_test.go
@@ -4,11 +4,11 @@
 package rackspace_test
 
 import (
+	"github.com/juju/errors"
 	"github.com/juju/jsonschema"
 	"github.com/juju/testing"
 	gc "gopkg.in/check.v1"
 
-	"github.com/juju/errors"
 	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/config"

--- a/provider/vsphere/userdata.go
+++ b/provider/vsphere/userdata.go
@@ -6,10 +6,10 @@ package vsphere
 
 import (
 	"github.com/juju/errors"
+	jujuos "github.com/juju/utils/os"
 
 	"github.com/juju/juju/cloudconfig/cloudinit"
 	"github.com/juju/juju/cloudconfig/providerinit/renderers"
-	jujuos "github.com/juju/utils/os"
 )
 
 type VsphereRenderer struct{}

--- a/resource/cmd/formatter.go
+++ b/resource/cmd/formatter.go
@@ -8,11 +8,11 @@ import (
 	"strconv"
 	"strings"
 
-	charmresource "gopkg.in/juju/charm.v6-unstable/resource"
-
 	"github.com/juju/errors"
-	"github.com/juju/juju/resource"
+	charmresource "gopkg.in/juju/charm.v6-unstable/resource"
 	"gopkg.in/juju/names.v2"
+
+	"github.com/juju/juju/resource"
 )
 
 type charmResourcesFormatter struct {

--- a/resource/cmd/list_charm_resources_test.go
+++ b/resource/cmd/list_charm_resources_test.go
@@ -7,12 +7,13 @@ import (
 	"strings"
 
 	jujucmd "github.com/juju/cmd"
-	"github.com/juju/juju/charmstore"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/charm.v6-unstable"
 	charmresource "gopkg.in/juju/charm.v6-unstable/resource"
+
+	"github.com/juju/juju/charmstore"
 )
 
 var _ = gc.Suite(&ListCharmSuite{})

--- a/resource/cmd/output_tabular.go
+++ b/resource/cmd/output_tabular.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/juju/ansiterm"
 	"github.com/juju/errors"
+
 	"github.com/juju/juju/cmd/output"
 )
 

--- a/resource/cmd/stub_test.go
+++ b/resource/cmd/stub_test.go
@@ -7,9 +7,10 @@ import (
 	"io"
 
 	"github.com/juju/errors"
-	"github.com/juju/juju/charmstore"
 	"github.com/juju/testing"
 	charmresource "gopkg.in/juju/charm.v6-unstable/resource"
+
+	"github.com/juju/juju/charmstore"
 )
 
 type stubCharmStore struct {

--- a/resource/context/cmd/get.go
+++ b/resource/context/cmd/get.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
+
 	"github.com/juju/juju/worker/uniter/runner/jujuc"
 )
 

--- a/resource/state/resource_test.go
+++ b/resource/state/resource_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
+	"github.com/juju/utils/clock"
 	gc "gopkg.in/check.v1"
 	charmresource "gopkg.in/juju/charm.v6-unstable/resource"
 	"gopkg.in/juju/names.v2"
@@ -20,7 +21,6 @@ import (
 
 	"github.com/juju/juju/resource"
 	"github.com/juju/juju/resource/resourcetesting"
-	"github.com/juju/utils/clock"
 )
 
 var _ = gc.Suite(&ResourceSuite{})

--- a/state/backups/metadata.go
+++ b/state/backups/metadata.go
@@ -13,9 +13,10 @@ import (
 	"time"
 
 	"github.com/juju/errors"
-	jujuversion "github.com/juju/juju/version"
 	"github.com/juju/utils/filestorage"
 	"github.com/juju/version"
+
+	jujuversion "github.com/juju/juju/version"
 )
 
 // checksumFormat identifies how to interpret the checksum for a backup

--- a/state/backups/storage.go
+++ b/state/backups/storage.go
@@ -9,9 +9,6 @@ import (
 	"time"
 
 	"github.com/juju/errors"
-	"github.com/juju/juju/controller"
-	"github.com/juju/juju/environs/config"
-	"github.com/juju/juju/state"
 	jujutxn "github.com/juju/txn"
 	"github.com/juju/utils/filestorage"
 	"github.com/juju/version"
@@ -20,6 +17,10 @@ import (
 	"gopkg.in/mgo.v2"
 	"gopkg.in/mgo.v2/bson"
 	"gopkg.in/mgo.v2/txn"
+
+	"github.com/juju/juju/controller"
+	"github.com/juju/juju/environs/config"
+	"github.com/juju/juju/state"
 )
 
 // backupIDTimstamp is used to format the timestamp from a backup

--- a/state/binarystorage/binarystorage.go
+++ b/state/binarystorage/binarystorage.go
@@ -8,13 +8,14 @@ import (
 	"io"
 
 	"github.com/juju/errors"
-	"github.com/juju/juju/mongo"
 	"github.com/juju/loggo"
 	jujutxn "github.com/juju/txn"
 	"gopkg.in/juju/blobstore.v2"
 	"gopkg.in/mgo.v2"
 	"gopkg.in/mgo.v2/bson"
 	"gopkg.in/mgo.v2/txn"
+
+	"github.com/juju/juju/mongo"
 )
 
 var logger = loggo.GetLogger("juju.state.binarystorage")

--- a/state/internal/audit/audit.go
+++ b/state/internal/audit/audit.go
@@ -5,10 +5,9 @@ package audit
 
 import (
 	"github.com/juju/errors"
-
-	"github.com/juju/juju/audit"
 	"github.com/juju/version"
 
+	"github.com/juju/juju/audit"
 	"github.com/juju/juju/mongo/utils"
 )
 

--- a/state/presence/presence.go
+++ b/state/presence/presence.go
@@ -14,12 +14,13 @@ import (
 	"time"
 
 	"github.com/juju/errors"
-	"github.com/juju/juju/worker"
 	"github.com/juju/loggo"
 	"gopkg.in/juju/names.v2"
 	"gopkg.in/mgo.v2"
 	"gopkg.in/mgo.v2/bson"
 	"gopkg.in/tomb.v1"
+
+	"github.com/juju/juju/worker"
 )
 
 var logger = loggo.GetLogger("juju.state.presence")

--- a/state/refcounts_ns.go
+++ b/state/refcounts_ns.go
@@ -5,10 +5,11 @@ package state
 
 import (
 	"github.com/juju/errors"
-	"github.com/juju/juju/mongo"
 	"gopkg.in/mgo.v2"
 	"gopkg.in/mgo.v2/bson"
 	"gopkg.in/mgo.v2/txn"
+
+	"github.com/juju/juju/mongo"
 )
 
 // refcountDoc holds a reference count. Refcounts are important to juju

--- a/state/sequence.go
+++ b/state/sequence.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 
 	"github.com/juju/errors"
-
 	"gopkg.in/mgo.v2"
 	"gopkg.in/mgo.v2/bson"
 )

--- a/state/sequence_internal_test.go
+++ b/state/sequence_internal_test.go
@@ -6,9 +6,8 @@ package state
 import (
 	"github.com/juju/errors"
 	"github.com/juju/testing"
-	gc "gopkg.in/check.v1"
-
 	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
 )
 
 var _ = gc.Suite(&sequenceMinSuite{})

--- a/state/state.go
+++ b/state/state.go
@@ -20,6 +20,7 @@ import (
 	jujutxn "github.com/juju/txn"
 	"github.com/juju/utils"
 	"github.com/juju/utils/clock"
+	"github.com/juju/utils/clock/monotonic"
 	"github.com/juju/utils/featureflag"
 	"github.com/juju/utils/os"
 	"github.com/juju/utils/series"
@@ -47,7 +48,6 @@ import (
 	"github.com/juju/juju/state/workers"
 	"github.com/juju/juju/status"
 	jujuversion "github.com/juju/juju/version"
-	"github.com/juju/utils/clock/monotonic"
 )
 
 var logger = loggo.GetLogger("juju.state")

--- a/state/status_unitagent_test.go
+++ b/state/status_unitagent_test.go
@@ -4,12 +4,12 @@
 package state_test
 
 import (
+	"fmt"
 	"time" // Only used for time types.
 
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
-	"fmt"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/status"
 	"github.com/juju/juju/testing"

--- a/state/upgrades_test.go
+++ b/state/upgrades_test.go
@@ -7,11 +7,12 @@ import (
 	"reflect"
 	"time"
 
-	"github.com/juju/juju/cloud"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/mgo.v2"
 	"gopkg.in/mgo.v2/bson"
+
+	"github.com/juju/juju/cloud"
 )
 
 type upgradesSuite struct {

--- a/state/watcher/watcher.go
+++ b/state/watcher/watcher.go
@@ -11,11 +11,12 @@ import (
 	"time"
 
 	"github.com/juju/errors"
-	"github.com/juju/juju/worker"
 	"github.com/juju/loggo"
 	"gopkg.in/mgo.v2"
 	"gopkg.in/mgo.v2/bson"
 	"gopkg.in/tomb.v1"
+
+	"github.com/juju/juju/worker"
 )
 
 var logger = loggo.GetLogger("juju.state.watcher")

--- a/status/status_test.go
+++ b/status/status_test.go
@@ -6,9 +6,10 @@ package status_test
 import (
 	"time"
 
-	"github.com/juju/juju/status"
 	"github.com/juju/testing"
 	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/status"
 )
 
 type statusHistorySuite struct {

--- a/storage/poolmanager/interface.go
+++ b/storage/poolmanager/interface.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/juju/errors"
+
 	"github.com/juju/juju/storage"
 )
 

--- a/testing/factory/factory.go
+++ b/testing/factory/factory.go
@@ -14,6 +14,7 @@ import (
 	"github.com/juju/utils"
 	"github.com/juju/utils/arch"
 	"github.com/juju/utils/series"
+	"github.com/juju/version"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/charm.v6-unstable"
 	"gopkg.in/juju/names.v2"
@@ -29,7 +30,6 @@ import (
 	"github.com/juju/juju/testcharms"
 	"github.com/juju/juju/testing"
 	jujuversion "github.com/juju/juju/version"
-	"github.com/juju/version"
 )
 
 const (

--- a/testing/roundtripper_test.go
+++ b/testing/roundtripper_test.go
@@ -8,9 +8,10 @@ import (
 	"net/http"
 	"net/url"
 
-	"github.com/juju/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/testing"
 )
 
 type metadataSuite struct{}

--- a/tools/lxdclient/instance_test.go
+++ b/tools/lxdclient/instance_test.go
@@ -12,11 +12,11 @@ import (
 
 	jc "github.com/juju/testing/checkers"
 	lxdapi "github.com/lxc/lxd/shared/api"
+	"github.com/lxc/lxd/shared/osarch"
 	gc "gopkg.in/check.v1"
 
 	jujutesting "github.com/juju/juju/testing"
 	"github.com/juju/juju/tools/lxdclient"
-	"github.com/lxc/lxd/shared/osarch"
 )
 
 type instanceSuite struct {

--- a/upgrades/operations.go
+++ b/upgrades/operations.go
@@ -4,8 +4,9 @@
 package upgrades
 
 import (
-	jujuversion "github.com/juju/juju/version"
 	"github.com/juju/version"
+
+	jujuversion "github.com/juju/juju/version"
 )
 
 // stateUpgradeOperations returns an ordered slice of sets of

--- a/utils/proxy/proxyconfig_test.go
+++ b/utils/proxy/proxyconfig_test.go
@@ -7,9 +7,8 @@ import (
 	"net/http"
 
 	jc "github.com/juju/testing/checkers"
-	gc "gopkg.in/check.v1"
-
 	"github.com/juju/utils/proxy"
+	gc "gopkg.in/check.v1"
 
 	proxyconfig "github.com/juju/juju/utils/proxy"
 )

--- a/version/version_test.go
+++ b/version/version_test.go
@@ -7,7 +7,6 @@ import (
 	"runtime"
 
 	semversion "github.com/juju/version"
-
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/testing"

--- a/worker/applicationscaler/manifold.go
+++ b/worker/applicationscaler/manifold.go
@@ -5,6 +5,7 @@ package applicationscaler
 
 import (
 	"github.com/juju/errors"
+
 	"github.com/juju/juju/api/base"
 	"github.com/juju/juju/cmd/jujud/agent/engine"
 	"github.com/juju/juju/worker"

--- a/worker/catacomb/catacomb.go
+++ b/worker/catacomb/catacomb.go
@@ -6,6 +6,7 @@ package catacomb
 import (
 	"fmt"
 	"runtime/debug"
+	"strings"
 	"sync"
 	"sync/atomic"
 
@@ -13,7 +14,6 @@ import (
 	"gopkg.in/tomb.v1"
 
 	"github.com/juju/juju/worker"
-	"strings"
 )
 
 // Catacomb is a variant of tomb.Tomb with its own internal goroutine, designed

--- a/worker/dependency/testing/stub.go
+++ b/worker/dependency/testing/stub.go
@@ -7,6 +7,7 @@ import (
 	"reflect"
 
 	"github.com/juju/errors"
+
 	"github.com/juju/juju/worker/dependency"
 )
 

--- a/worker/diskmanager/manifold_test.go
+++ b/worker/diskmanager/manifold_test.go
@@ -4,13 +4,13 @@
 package diskmanager_test
 
 import (
-	apidiskmanager "github.com/juju/juju/api/diskmanager"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/agent"
 	basetesting "github.com/juju/juju/api/base/testing"
+	apidiskmanager "github.com/juju/juju/api/diskmanager"
 	"github.com/juju/juju/state/multiwatcher"
 	coretesting "github.com/juju/juju/testing"
 	"github.com/juju/juju/worker"

--- a/worker/identityfilewriter/manifold_test.go
+++ b/worker/identityfilewriter/manifold_test.go
@@ -4,7 +4,6 @@
 package identityfilewriter_test
 
 import (
-	"github.com/juju/juju/worker/dependency"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
@@ -16,6 +15,7 @@ import (
 	"github.com/juju/juju/cmd/jujud/agent/engine/enginetest"
 	"github.com/juju/juju/state/multiwatcher"
 	"github.com/juju/juju/worker"
+	"github.com/juju/juju/worker/dependency"
 	"github.com/juju/juju/worker/identityfilewriter"
 )
 

--- a/worker/introspection/socket_test.go
+++ b/worker/introspection/socket_test.go
@@ -18,12 +18,11 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	gc "gopkg.in/check.v1"
 
+	// Bring in the state package for the tracker profile.
+	_ "github.com/juju/juju/state"
 	"github.com/juju/juju/worker"
 	"github.com/juju/juju/worker/introspection"
 	"github.com/juju/juju/worker/workertest"
-
-	// Bring in the state package for the tracker profile.
-	_ "github.com/juju/juju/state"
 )
 
 type suite struct {

--- a/worker/lifeflag/validate_test.go
+++ b/worker/lifeflag/validate_test.go
@@ -5,10 +5,11 @@ package lifeflag_test
 
 import (
 	"github.com/juju/errors"
-	"github.com/juju/juju/worker/lifeflag"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/worker/lifeflag"
 )
 
 type ValidateSuite struct {

--- a/worker/logsender/logsendermetrics/logsendermetrics.go
+++ b/worker/logsender/logsendermetrics/logsendermetrics.go
@@ -4,8 +4,9 @@
 package logsendermetrics
 
 import (
-	"github.com/juju/juju/worker/logsender"
 	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/juju/juju/worker/logsender"
 )
 
 var (

--- a/worker/machineactions/fixture_test.go
+++ b/worker/machineactions/fixture_test.go
@@ -7,13 +7,14 @@ package machineactions_test
 import (
 	"errors"
 
+	"github.com/juju/testing"
+	"gopkg.in/juju/names.v2"
+
 	"github.com/juju/juju/api/machineactions"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/watcher"
 	"github.com/juju/juju/worker"
 	"github.com/juju/juju/worker/workertest"
-	"github.com/juju/testing"
-	"gopkg.in/juju/names.v2"
 )
 
 var actionNotFoundErr = errors.New("action not found")

--- a/worker/machineactions/handleactions_test.go
+++ b/worker/machineactions/handleactions_test.go
@@ -8,12 +8,13 @@ import (
 	"strings"
 
 	"github.com/juju/errors"
-	"github.com/juju/juju/core/actions"
-	"github.com/juju/juju/worker/machineactions"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils/exec"
 	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/core/actions"
+	"github.com/juju/juju/worker/machineactions"
 )
 
 type HandleSuite struct {

--- a/worker/machineactions/manifold.go
+++ b/worker/machineactions/manifold.go
@@ -6,12 +6,13 @@ package machineactions
 
 import (
 	"github.com/juju/errors"
+	"gopkg.in/juju/names.v2"
+
 	"github.com/juju/juju/agent"
 	"github.com/juju/juju/api/base"
 	"github.com/juju/juju/cmd/jujud/agent/engine"
 	"github.com/juju/juju/worker"
 	"github.com/juju/juju/worker/dependency"
-	"gopkg.in/juju/names.v2"
 )
 
 // ManifoldConfig describes the dependencies of a machine action runner.

--- a/worker/machineactions/worker.go
+++ b/worker/machineactions/worker.go
@@ -6,12 +6,13 @@ package machineactions
 
 import (
 	"github.com/juju/errors"
+	"github.com/juju/loggo"
+	"gopkg.in/juju/names.v2"
+
 	"github.com/juju/juju/api/machineactions"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/watcher"
 	"github.com/juju/juju/worker"
-	"github.com/juju/loggo"
-	"gopkg.in/juju/names.v2"
 )
 
 var logger = loggo.GetLogger("juju.worker.machineactions")

--- a/worker/machineactions/worker_test.go
+++ b/worker/machineactions/worker_test.go
@@ -6,13 +6,14 @@ package machineactions_test
 
 import (
 	"github.com/juju/errors"
-	"github.com/juju/juju/apiserver/params"
-	"github.com/juju/juju/worker/machineactions"
-	"github.com/juju/juju/worker/workertest"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/names.v2"
+
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/worker/machineactions"
+	"github.com/juju/juju/worker/workertest"
 )
 
 type WorkerSuite struct {

--- a/worker/machiner/manifold.go
+++ b/worker/machiner/manifold.go
@@ -5,6 +5,7 @@ package machiner
 
 import (
 	"github.com/juju/errors"
+	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/agent"
 	apiagent "github.com/juju/juju/api/agent"
@@ -13,7 +14,6 @@ import (
 	"github.com/juju/juju/cmd/jujud/agent/engine"
 	"github.com/juju/juju/worker"
 	"github.com/juju/juju/worker/dependency"
-	"gopkg.in/juju/names.v2"
 )
 
 // ManifoldConfig defines the names of the manifolds on which a

--- a/worker/metrics/sender/manifold_test.go
+++ b/worker/metrics/sender/manifold_test.go
@@ -9,12 +9,12 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/juju/httprequest"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/names.v2"
 
-	"github.com/juju/httprequest"
 	"github.com/juju/juju/agent"
 	"github.com/juju/juju/api/base"
 	"github.com/juju/juju/api/metricsadder"

--- a/worker/migrationmaster/shim.go
+++ b/worker/migrationmaster/shim.go
@@ -5,6 +5,7 @@ package migrationmaster
 
 import (
 	"github.com/juju/errors"
+
 	"github.com/juju/juju/api/base"
 	"github.com/juju/juju/api/migrationmaster"
 	"github.com/juju/juju/api/watcher"

--- a/worker/migrationminion/manifold.go
+++ b/worker/migrationminion/manifold.go
@@ -5,6 +5,7 @@ package migrationminion
 
 import (
 	"github.com/juju/errors"
+
 	"github.com/juju/juju/agent"
 	"github.com/juju/juju/api"
 	"github.com/juju/juju/api/base"

--- a/worker/migrationminion/validate_test.go
+++ b/worker/migrationminion/validate_test.go
@@ -5,14 +5,15 @@ package migrationminion_test
 
 import (
 	"github.com/juju/errors"
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
 	"github.com/juju/juju/agent"
 	"github.com/juju/juju/api"
 	"github.com/juju/juju/api/base"
 	"github.com/juju/juju/worker/fortress"
 	"github.com/juju/juju/worker/migrationminion"
-	"github.com/juju/testing"
-	jc "github.com/juju/testing/checkers"
-	gc "gopkg.in/check.v1"
 )
 
 type ValidateSuite struct {

--- a/worker/mongoupgrader/worker.go
+++ b/worker/mongoupgrader/worker.go
@@ -8,11 +8,11 @@ import (
 	"strconv"
 
 	"github.com/juju/errors"
+	"github.com/juju/replicaset"
 
 	"github.com/juju/juju/mongo"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/worker"
-	"github.com/juju/replicaset"
 )
 
 // StopMongo represents a function that can issue a stop

--- a/worker/provisioner/provisioner_task.go
+++ b/worker/provisioner/provisioner_task.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/juju/errors"
 	"github.com/juju/utils"
+	"github.com/juju/version"
 	"gopkg.in/juju/names.v2"
 
 	apiprovisioner "github.com/juju/juju/api/provisioner"
@@ -34,7 +35,6 @@ import (
 	"github.com/juju/juju/worker"
 	"github.com/juju/juju/worker/catacomb"
 	"github.com/juju/juju/wrench"
-	"github.com/juju/version"
 )
 
 type ProvisionerTask interface {

--- a/worker/resumer/resumer.go
+++ b/worker/resumer/resumer.go
@@ -7,9 +7,10 @@ import (
 	"time"
 
 	"github.com/juju/errors"
-	"github.com/juju/juju/worker/catacomb"
 	"github.com/juju/loggo"
 	"github.com/juju/utils/clock"
+
+	"github.com/juju/juju/worker/catacomb"
 )
 
 var logger = loggo.GetLogger("juju.worker.resumer")

--- a/worker/retrystrategy/worker.go
+++ b/worker/retrystrategy/worker.go
@@ -6,10 +6,11 @@ package retrystrategy
 
 import (
 	"github.com/juju/errors"
+	"gopkg.in/juju/names.v2"
+
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/watcher"
 	"github.com/juju/juju/worker"
-	"gopkg.in/juju/names.v2"
 )
 
 // Facade defines the capabilities required by the worker from the API.

--- a/worker/singular/flag.go
+++ b/worker/singular/flag.go
@@ -7,9 +7,10 @@ import (
 	"time"
 
 	"github.com/juju/errors"
+	"github.com/juju/utils/clock"
+
 	"github.com/juju/juju/core/lease"
 	"github.com/juju/juju/worker/catacomb"
-	"github.com/juju/utils/clock"
 )
 
 // Facade exposes the capabilities required by a FlagWorker.

--- a/worker/singular/manifold.go
+++ b/worker/singular/manifold.go
@@ -7,13 +7,14 @@ import (
 	"time"
 
 	"github.com/juju/errors"
+	"github.com/juju/utils/clock"
+	"gopkg.in/juju/names.v2"
+
 	"github.com/juju/juju/agent"
 	"github.com/juju/juju/api/base"
 	"github.com/juju/juju/cmd/jujud/agent/engine"
 	"github.com/juju/juju/worker"
 	"github.com/juju/juju/worker/dependency"
-	"github.com/juju/utils/clock"
-	"gopkg.in/juju/names.v2"
 )
 
 // ManifoldConfig holds the information necessary to run a FlagWorker in

--- a/worker/stateconfigwatcher/manifold_test.go
+++ b/worker/stateconfigwatcher/manifold_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils/voyeur"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/names.v2"
@@ -19,7 +20,6 @@ import (
 	"github.com/juju/juju/worker/dependency"
 	dt "github.com/juju/juju/worker/dependency/testing"
 	"github.com/juju/juju/worker/stateconfigwatcher"
-	jc "github.com/juju/testing/checkers"
 )
 
 type ManifoldSuite struct {

--- a/worker/storageprovisioner/config.go
+++ b/worker/storageprovisioner/config.go
@@ -5,9 +5,10 @@ package storageprovisioner
 
 import (
 	"github.com/juju/errors"
-	"github.com/juju/juju/storage"
 	"github.com/juju/utils/clock"
 	"gopkg.in/juju/names.v2"
+
+	"github.com/juju/juju/storage"
 )
 
 // Config holds configuration and dependencies for a storageprovisioner worker.

--- a/worker/toolsversionchecker/manifold.go
+++ b/worker/toolsversionchecker/manifold.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/juju/errors"
+	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/agent"
 	apiagent "github.com/juju/juju/api/agent"
@@ -16,7 +17,6 @@ import (
 	"github.com/juju/juju/state/multiwatcher"
 	"github.com/juju/juju/worker"
 	"github.com/juju/juju/worker/dependency"
-	"gopkg.in/juju/names.v2"
 )
 
 // ManifoldConfig defines the names of the manifolds on which a Manifold will depend.

--- a/worker/undertaker/manifold.go
+++ b/worker/undertaker/manifold.go
@@ -5,6 +5,7 @@ package undertaker
 
 import (
 	"github.com/juju/errors"
+
 	"github.com/juju/juju/api/base"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/worker"

--- a/worker/unitassigner/unitassigner.go
+++ b/worker/unitassigner/unitassigner.go
@@ -5,12 +5,13 @@ package unitassigner
 
 import (
 	"github.com/juju/errors"
+	"github.com/juju/loggo"
+	"gopkg.in/juju/names.v2"
+
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/status"
 	"github.com/juju/juju/watcher"
 	"github.com/juju/juju/worker"
-	"github.com/juju/loggo"
-	"gopkg.in/juju/names.v2"
 )
 
 var logger = loggo.GetLogger("juju.worker.unitassigner")

--- a/worker/uniter/runlistener.go
+++ b/worker/uniter/runlistener.go
@@ -11,10 +11,9 @@ import (
 	"net/rpc"
 	"sync"
 
-	"gopkg.in/tomb.v1"
-
 	"github.com/juju/errors"
 	"github.com/juju/utils/exec"
+	"gopkg.in/tomb.v1"
 
 	"github.com/juju/juju/juju/sockets"
 	"github.com/juju/juju/worker"

--- a/worker/uniter/runner/args.go
+++ b/worker/uniter/runner/args.go
@@ -10,8 +10,9 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/juju/juju/worker/uniter/runner/context"
 	jujuos "github.com/juju/utils/os"
+
+	"github.com/juju/juju/worker/uniter/runner/context"
 )
 
 var windowsSuffixOrder = []string{

--- a/worker/uniter/runner/context/env_test.go
+++ b/worker/uniter/runner/context/env_test.go
@@ -12,12 +12,12 @@ import (
 	envtesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils/keyvalues"
+	jujuos "github.com/juju/utils/os"
 	"github.com/juju/utils/proxy"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/worker/uniter/runner/context"
-	jujuos "github.com/juju/utils/os"
 )
 
 type EnvSuite struct {

--- a/worker/uniter/runner/jujuc/errors_test.go
+++ b/worker/uniter/runner/jujuc/errors_test.go
@@ -4,9 +4,8 @@
 package jujuc_test
 
 import (
-	gc "gopkg.in/check.v1"
-
 	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/testing"
 	"github.com/juju/juju/worker/uniter/runner/jujuc"

--- a/worker/uniter/runner/runner.go
+++ b/worker/uniter/runner/runner.go
@@ -17,12 +17,12 @@ import (
 	"github.com/juju/loggo"
 	"github.com/juju/utils/clock"
 	utilexec "github.com/juju/utils/exec"
+	jujuos "github.com/juju/utils/os"
 
 	"github.com/juju/juju/core/actions"
 	"github.com/juju/juju/worker/uniter/runner/context"
 	"github.com/juju/juju/worker/uniter/runner/debug"
 	"github.com/juju/juju/worker/uniter/runner/jujuc"
-	jujuos "github.com/juju/utils/os"
 )
 
 var logger = loggo.GetLogger("juju.worker.uniter.runner")

--- a/worker/uniter/uniter.go
+++ b/worker/uniter/uniter.go
@@ -15,6 +15,7 @@ import (
 	"github.com/juju/utils"
 	"github.com/juju/utils/clock"
 	"github.com/juju/utils/exec"
+	jujuos "github.com/juju/utils/os"
 	corecharm "gopkg.in/juju/charm.v6-unstable"
 	"gopkg.in/juju/names.v2"
 
@@ -38,7 +39,6 @@ import (
 	"github.com/juju/juju/worker/uniter/runner/context"
 	"github.com/juju/juju/worker/uniter/runner/jujuc"
 	"github.com/juju/juju/worker/uniter/storage"
-	jujuos "github.com/juju/utils/os"
 )
 
 var logger = loggo.GetLogger("juju.worker.uniter")

--- a/worker/upgrader/manifold.go
+++ b/worker/upgrader/manifold.go
@@ -5,6 +5,7 @@ package upgrader
 
 import (
 	"github.com/juju/errors"
+	"github.com/juju/version"
 
 	"github.com/juju/juju/agent"
 	"github.com/juju/juju/api/base"
@@ -12,7 +13,6 @@ import (
 	"github.com/juju/juju/worker"
 	"github.com/juju/juju/worker/dependency"
 	"github.com/juju/juju/worker/gate"
-	"github.com/juju/version"
 )
 
 // ManifoldConfig defines the names of the manifolds on which a

--- a/worker/upgradesteps/worker.go
+++ b/worker/upgradesteps/worker.go
@@ -10,6 +10,7 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	"github.com/juju/utils"
+	"github.com/juju/version"
 	"gopkg.in/juju/names.v2"
 	"gopkg.in/tomb.v1"
 
@@ -26,7 +27,6 @@ import (
 	"github.com/juju/juju/worker"
 	"github.com/juju/juju/worker/gate"
 	"github.com/juju/juju/wrench"
-	"github.com/juju/version"
 )
 
 var logger = loggo.GetLogger("juju.worker.upgradesteps")

--- a/worker/upgradesteps/worker_test.go
+++ b/worker/upgradesteps/worker_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/juju/utils/arch"
 	"github.com/juju/utils/clock"
 	"github.com/juju/utils/series"
+	"github.com/juju/version"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/names.v2"
 
@@ -34,7 +35,6 @@ import (
 	jujuversion "github.com/juju/juju/version"
 	"github.com/juju/juju/worker"
 	"github.com/juju/juju/worker/gate"
-	"github.com/juju/version"
 )
 
 // TODO(mjs) - these tests are too tightly coupled to the


### PR DESCRIPTION
all: sort imports canonically

This PR is entirely automatically generated - it
contains just the changes made by doing:

    sortimports ./...

in the root of the juju repo. (see github.com/rogpeppe/sortimports
for the implementation of the sortimports tool)

