### PR TITLE
cmd/juju/storage: add detach-storage command

### DIFF
--- a/api/storage/client.go
+++ b/api/storage/client.go
@@ -173,3 +173,31 @@ func (c *Client) Destroy(storageIds []string) ([]params.ErrorResult, error) {
 	}
 	return results.Results, nil
 }
+
+// Detach detaches the specified storage entities.
+func (c *Client) Detach(storageIds []string) ([]params.ErrorResult, error) {
+	results := params.ErrorResults{}
+	args := make([]params.StorageAttachmentId, len(storageIds))
+	for i, id := range storageIds {
+		if !names.IsValidStorage(id) {
+			return nil, errors.NotValidf("storage ID %q", id)
+		}
+		args[i] = params.StorageAttachmentId{
+			StorageTag: names.NewStorageTag(id).String(),
+		}
+	}
+	if err := c.facade.FacadeCall(
+		"Detach",
+		params.StorageAttachmentIds{args},
+		&results,
+	); err != nil {
+		return nil, errors.Trace(err)
+	}
+	if len(results.Results) != len(storageIds) {
+		return nil, errors.Errorf(
+			"expected %d result(s), got %d",
+			len(storageIds), len(results.Results),
+		)
+	}
+	return results.Results, nil
+}

--- a/apiserver/storage/base_test.go
+++ b/apiserver/storage/base_test.go
@@ -86,6 +86,7 @@ const (
 	addStorageForUnitCall                   = "addStorageForUnit"
 	getBlockForTypeCall                     = "getBlockForType"
 	volumeAttachmentCall                    = "volumeAttachment"
+	destroyStorageAttachmentCall            = "destroyStorageAttachment"
 	destroyStorageInstanceCall              = "destroyStorageInstance"
 )
 
@@ -143,7 +144,7 @@ func (s *baseStorageSuite) constructState() *mockState {
 			if tag == s.storageTag {
 				return []state.StorageAttachment{storageInstanceAttachment}, nil
 			}
-			return nil, errors.NotFoundf("%s", names.ReadableString(tag))
+			return []state.StorageAttachment{}, nil
 		},
 		storageInstanceFilesystem: func(sTag names.StorageTag) (state.Filesystem, error) {
 			s.calls = append(s.calls, storageInstanceFilesystemCall)
@@ -236,6 +237,17 @@ func (s *baseStorageSuite) constructState() *mockState {
 			s.calls = append(s.calls, getBlockForTypeCall)
 			val, found := s.blocks[t]
 			return val, found, nil
+		},
+		destroyStorageAttachment: func(storage names.StorageTag, unit names.UnitTag) error {
+			s.calls = append(s.calls, destroyStorageAttachmentCall)
+			if storage == s.storageTag && unit == s.unitTag {
+				return nil
+			}
+			return errors.NotFoundf(
+				"attachment of %s to %s",
+				names.ReadableString(storage),
+				names.ReadableString(unit),
+			)
 		},
 		destroyStorageInstance: func(tag names.StorageTag) error {
 			s.calls = append(s.calls, destroyStorageInstanceCall)

--- a/apiserver/storage/mock_test.go
+++ b/apiserver/storage/mock_test.go
@@ -63,6 +63,7 @@ type mockState struct {
 	getBlockForType                     func(t state.BlockType) (state.Block, bool, error)
 	blockDevices                        func(names.MachineTag) ([]state.BlockDeviceInfo, error)
 	destroyStorageInstance              func(names.StorageTag) error
+	destroyStorageAttachment            func(names.StorageTag, names.UnitTag) error
 }
 
 func (st *mockState) StorageInstance(s names.StorageTag) (state.StorageInstance, error) {
@@ -166,6 +167,10 @@ func (st *mockState) BlockDevices(m names.MachineTag) ([]state.BlockDeviceInfo, 
 		return st.blockDevices(m)
 	}
 	return []state.BlockDeviceInfo{}, nil
+}
+
+func (st *mockState) DestroyStorageAttachment(storage names.StorageTag, unit names.UnitTag) error {
+	return st.destroyStorageAttachment(storage, unit)
 }
 
 func (st *mockState) DestroyStorageInstance(tag names.StorageTag) error {

--- a/apiserver/storage/shim.go
+++ b/apiserver/storage/shim.go
@@ -114,6 +114,10 @@ type storageAccess interface {
 	// GetBlockForType is required to block operations.
 	GetBlockForType(t state.BlockType) (state.Block, bool, error)
 
+	// DestroyStorageAttachment detaches the storage instance with the
+	// specified tag from the unit with the specified tag.
+	DestroyStorageAttachment(names.StorageTag, names.UnitTag) error
+
 	// DestroyStorageInstance destroys the storage instance with the specified tag.
 	DestroyStorageInstance(names.StorageTag) error
 }

--- a/apiserver/storage/storage.go
+++ b/apiserver/storage/storage.go
@@ -756,3 +756,69 @@ func (a *API) Destroy(args params.Entities) (params.ErrorResults, error) {
 	}
 	return params.ErrorResults{result}, nil
 }
+
+// Detach sets the specified storage attachments to Dying, unless they are
+// already Dying or Dead. Any associated, persistent storage will remain
+// alive.
+func (a *API) Detach(args params.StorageAttachmentIds) (params.ErrorResults, error) {
+	if err := a.checkCanWrite(); err != nil {
+		return params.ErrorResults{}, errors.Trace(err)
+	}
+
+	blockChecker := common.NewBlockChecker(a.storage)
+	if err := blockChecker.ChangeAllowed(); err != nil {
+		return params.ErrorResults{}, errors.Trace(err)
+	}
+
+	detachOne := func(arg params.StorageAttachmentId) error {
+		storageTag, err := names.ParseStorageTag(arg.StorageTag)
+		if err != nil {
+			return err
+		}
+		var unitTag names.UnitTag
+		if arg.UnitTag != "" {
+			var err error
+			unitTag, err = names.ParseUnitTag(arg.UnitTag)
+			if err != nil {
+				return err
+			}
+		}
+		return a.detachStorage(storageTag, unitTag)
+	}
+
+	result := make([]params.ErrorResult, len(args.Ids))
+	for i, arg := range args.Ids {
+		result[i].Error = common.ServerError(detachOne(arg))
+	}
+	return params.ErrorResults{result}, nil
+}
+
+func (api *API) detachStorage(storageTag names.StorageTag, unitTag names.UnitTag) error {
+	if unitTag != (names.UnitTag{}) {
+		// The caller has specified a unit explicitly. Do
+		// not filter out "not found" errors in this case.
+		return api.storage.DestroyStorageAttachment(storageTag, unitTag)
+	}
+	attachments, err := api.storage.StorageAttachments(storageTag)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	if len(attachments) == 0 {
+		// No attachments: check if the storage exists at all.
+		if _, err := api.storage.StorageInstance(storageTag); err != nil {
+			return errors.Trace(err)
+		}
+	}
+	for _, a := range attachments {
+		if a.Life() != state.Alive {
+			continue
+		}
+		err := api.storage.DestroyStorageAttachment(storageTag, a.Unit())
+		if err != nil && !errors.IsNotFound(err) {
+			// We only care about NotFound errors if
+			// the user specified a unit explicitly.
+			return errors.Trace(err)
+		}
+	}
+	return nil
+}

--- a/apiserver/storage/storage_test.go
+++ b/apiserver/storage/storage_test.go
@@ -343,3 +343,94 @@ func (s *storageSuite) TestDestroy(c *gc.C) {
 		destroyStorageInstanceCall,
 	})
 }
+
+func (s *storageSuite) TestDetach(c *gc.C) {
+	results, err := s.api.Detach(params.StorageAttachmentIds{[]params.StorageAttachmentId{
+		{StorageTag: "storage-data-0", UnitTag: "unit-mysql-0"},
+		{StorageTag: "storage-data-0", UnitTag: ""},
+		{StorageTag: "volume-0", UnitTag: "unit-bar-0"},
+		{StorageTag: "filesystem-1-2", UnitTag: "unit-bar-0"},
+		{StorageTag: "machine-0", UnitTag: "unit-bar-0"},
+		{StorageTag: "storage-foo-0", UnitTag: "application-bar"},
+	}})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(results.Results, gc.HasLen, 6)
+	c.Assert(results.Results, jc.DeepEquals, []params.ErrorResult{
+		{Error: nil},
+		{Error: nil},
+		{Error: &params.Error{Message: `"volume-0" is not a valid storage tag`}},
+		{Error: &params.Error{Message: `"filesystem-1-2" is not a valid storage tag`}},
+		{Error: &params.Error{Message: `"machine-0" is not a valid storage tag`}},
+		{Error: &params.Error{Message: `"application-bar" is not a valid unit tag`}},
+	})
+	s.assertCalls(c, []string{
+		getBlockForTypeCall, // Change
+		destroyStorageAttachmentCall,
+		storageInstanceAttachmentsCall,
+		destroyStorageAttachmentCall,
+	})
+}
+
+func (s *storageSuite) TestDetachSpecifiedNotFound(c *gc.C) {
+	results, err := s.api.Detach(params.StorageAttachmentIds{[]params.StorageAttachmentId{
+		{StorageTag: "storage-data-0", UnitTag: "unit-foo-42"},
+	}})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(results.Results, gc.HasLen, 1)
+	c.Assert(results.Results, jc.DeepEquals, []params.ErrorResult{
+		{Error: &params.Error{
+			Code:    params.CodeNotFound,
+			Message: "attachment of storage data/0 to unit foo/42 not found",
+		}},
+	})
+	s.assertCalls(c, []string{
+		getBlockForTypeCall, // Change
+		destroyStorageAttachmentCall,
+	})
+}
+
+func (s *storageSuite) TestDetachAttachmentNotFoundConcurrent(c *gc.C) {
+	// Simulate:
+	//  1. call StorageAttachments, and receive
+	//     a list of alive attachments
+	//  2. attachment is concurrently destroyed
+	//     and removed by another process
+	s.state.destroyStorageAttachment = func(sTag names.StorageTag, uTag names.UnitTag) error {
+		s.calls = append(s.calls, destroyStorageAttachmentCall)
+		return errors.NotFoundf(
+			"attachment of %s to %s",
+			names.ReadableString(sTag),
+			names.ReadableString(uTag),
+		)
+	}
+	results, err := s.api.Detach(params.StorageAttachmentIds{[]params.StorageAttachmentId{
+		{StorageTag: "storage-data-0"},
+	}})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(results.Results, gc.HasLen, 1)
+	c.Assert(results.Results, jc.DeepEquals, []params.ErrorResult{{}})
+	s.assertCalls(c, []string{
+		getBlockForTypeCall, // Change
+		storageInstanceAttachmentsCall,
+		destroyStorageAttachmentCall,
+	})
+}
+
+func (s *storageSuite) TestDetachNoAttachmentsStorageNotFound(c *gc.C) {
+	results, err := s.api.Detach(params.StorageAttachmentIds{[]params.StorageAttachmentId{
+		{StorageTag: "storage-foo-42"},
+	}})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(results.Results, gc.HasLen, 1)
+	c.Assert(results.Results, jc.DeepEquals, []params.ErrorResult{
+		{Error: &params.Error{
+			Code:    params.CodeNotFound,
+			Message: "storage foo/42 not found",
+		}},
+	})
+	s.assertCalls(c, []string{
+		getBlockForTypeCall, // Change
+		storageInstanceAttachmentsCall,
+		storageInstanceCall,
+	})
+}

--- a/cmd/juju/commands/main.go
+++ b/cmd/juju/commands/main.go
@@ -388,6 +388,7 @@ func registerCommands(r commandRegistry, ctx *cmd.Context) {
 	r.Register(storage.NewPoolCreateCommand())
 	r.Register(storage.NewPoolListCommand())
 	r.Register(storage.NewShowCommand())
+	r.Register(storage.NewDetachStorageCommandWithAPI())
 	r.Register(storage.NewRemoveStorageCommandWithAPI())
 
 	// Manage spaces

--- a/cmd/juju/commands/main_test.go
+++ b/cmd/juju/commands/main_test.go
@@ -420,6 +420,7 @@ var commandNames = []string{
 	"controller-config",
 	"debug-hooks",
 	"debug-log",
+	"detach-storage",
 	"remove-user",
 	"deploy",
 	"destroy-controller",

--- a/cmd/juju/storage/detach.go
+++ b/cmd/juju/storage/detach.go
@@ -1,0 +1,119 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package storage
+
+import (
+	"github.com/juju/cmd"
+	"github.com/juju/errors"
+
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/cmd/juju/common"
+	"github.com/juju/juju/cmd/modelcmd"
+)
+
+// NewDetachStorageCommandWithAPI returns a command
+// used to detach storage from application units.
+func NewDetachStorageCommandWithAPI() cmd.Command {
+	cmd := &detachStorageCommand{}
+	cmd.newEntityDetacherCloser = func() (EntityDetacherCloser, error) {
+		return cmd.NewStorageAPI()
+	}
+	return modelcmd.Wrap(cmd)
+}
+
+// NewDetachStorageCommand returns a command used to
+// detach storage from application units.
+func NewDetachStorageCommand(new NewEntityDetacherCloserFunc) cmd.Command {
+	cmd := &detachStorageCommand{}
+	cmd.newEntityDetacherCloser = new
+	return modelcmd.Wrap(cmd)
+}
+
+const (
+	detachStorageCommandDoc = `
+Detaches storage from units. Specify one or more unit/application storage IDs,
+as output by "juju storage". The storage will remain in the model until it is
+removed by an operator.
+
+Examples:
+    juju detach-storage pgdata/0
+`
+
+	detachStorageCommandArgs = `<storage> [<storage> ...]`
+)
+
+// detachStorageCommand detaches storage instances.
+type detachStorageCommand struct {
+	StorageCommandBase
+	newEntityDetacherCloser NewEntityDetacherCloserFunc
+	storageIds              []string
+}
+
+// Init implements Command.Init.
+func (c *detachStorageCommand) Init(args []string) error {
+	if len(args) < 1 {
+		return errors.New("detach-storage requires at least one storage ID")
+	}
+	c.storageIds = args
+	return nil
+}
+
+// Info implements Command.Info.
+func (c *detachStorageCommand) Info() *cmd.Info {
+	return &cmd.Info{
+		Name:    "detach-storage",
+		Purpose: "Detaches storage from units.",
+		Doc:     detachStorageCommandDoc,
+		Args:    detachStorageCommandArgs,
+	}
+}
+
+// Run implements Command.Run.
+func (c *detachStorageCommand) Run(ctx *cmd.Context) error {
+	detacher, err := c.newEntityDetacherCloser()
+	if err != nil {
+		return errors.Trace(err)
+	}
+	defer detacher.Close()
+
+	results, err := detacher.Detach(c.storageIds)
+	if err != nil {
+		if params.IsCodeUnauthorized(err) {
+			common.PermissionsMessage(ctx.Stderr, "detach storage")
+		}
+		return err
+	}
+	for i, result := range results {
+		if result.Error == nil {
+			ctx.Infof("detaching %s", c.storageIds[i])
+		}
+	}
+	anyFailed := false
+	for i, result := range results {
+		if result.Error != nil {
+			ctx.Infof("failed to detach %s: %s", c.storageIds[i], result.Error)
+			anyFailed = true
+		}
+	}
+	if anyFailed {
+		return cmd.ErrSilent
+	}
+	return nil
+}
+
+// NewEntityDetacherCloser is the type of a function that returns an
+// EntityDetacherCloser.
+type NewEntityDetacherCloserFunc func() (EntityDetacherCloser, error)
+
+// EntityDetacherCloser extends EntityDetacher with a Closer method.
+type EntityDetacherCloser interface {
+	EntityDetacher
+	Close() error
+}
+
+// EntityDetacher defines an interface for detaching storage with the
+// specified IDs.
+type EntityDetacher interface {
+	Detach([]string) ([]params.ErrorResult, error)
+}

--- a/cmd/juju/storage/detach_test.go
+++ b/cmd/juju/storage/detach_test.go
@@ -1,0 +1,94 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package storage_test
+
+import (
+	"github.com/juju/cmd"
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/cmd/juju/storage"
+	coretesting "github.com/juju/juju/testing"
+)
+
+type DetachStorageSuite struct {
+	testing.IsolationSuite
+}
+
+var _ = gc.Suite(&DetachStorageSuite{})
+
+func (s *DetachStorageSuite) TestDetach(c *gc.C) {
+	fake := fakeEntityDetacher{results: []params.ErrorResult{
+		{},
+		{},
+	}}
+	cmd := storage.NewDetachStorageCommand(fake.new)
+	ctx, err := coretesting.RunCommand(c, cmd, "foo/0", "bar/1")
+	c.Assert(err, jc.ErrorIsNil)
+	fake.CheckCallNames(c, "NewEntityDetacherCloser", "Detach", "Close")
+	fake.CheckCall(c, 1, "Detach", []string{"foo/0", "bar/1"})
+	c.Assert(coretesting.Stderr(ctx), gc.Equals, `
+detaching foo/0
+detaching bar/1
+`[1:])
+}
+
+func (s *DetachStorageSuite) TestDetachError(c *gc.C) {
+	fake := fakeEntityDetacher{results: []params.ErrorResult{
+		{Error: &params.Error{Message: "foo"}},
+		{Error: &params.Error{Message: "bar"}},
+	}}
+	detachCmd := storage.NewDetachStorageCommand(fake.new)
+	ctx, err := coretesting.RunCommand(c, detachCmd, "baz/0", "qux/1")
+	stderr := coretesting.Stderr(ctx)
+	c.Assert(stderr, gc.Equals, `failed to detach baz/0: foo
+failed to detach qux/1: bar
+`)
+	c.Assert(err, gc.Equals, cmd.ErrSilent)
+}
+
+func (s *DetachStorageSuite) TestDetachUnauthorizedError(c *gc.C) {
+	var fake fakeEntityDetacher
+	fake.SetErrors(nil, &params.Error{Code: params.CodeUnauthorized, Message: "nope"})
+	cmd := storage.NewDetachStorageCommand(fake.new)
+	ctx, err := coretesting.RunCommand(c, cmd, "foo/0")
+	c.Assert(err, gc.ErrorMatches, "nope")
+	c.Assert(coretesting.Stderr(ctx), gc.Equals, `
+You do not have permission to detach storage.
+You may ask an administrator to grant you access with "juju grant".
+
+`)
+}
+
+func (s *DetachStorageSuite) TestDetachInitErrors(c *gc.C) {
+	s.testDetachInitError(c, []string{}, "detach-storage requires at least one storage ID")
+}
+
+func (s *DetachStorageSuite) testDetachInitError(c *gc.C, args []string, expect string) {
+	cmd := storage.NewDetachStorageCommand(nil)
+	_, err := coretesting.RunCommand(c, cmd, args...)
+	c.Assert(err, gc.ErrorMatches, expect)
+}
+
+type fakeEntityDetacher struct {
+	testing.Stub
+	results []params.ErrorResult
+}
+
+func (f *fakeEntityDetacher) new() (storage.EntityDetacherCloser, error) {
+	f.MethodCall(f, "NewEntityDetacherCloser")
+	return f, f.NextErr()
+}
+
+func (f *fakeEntityDetacher) Close() error {
+	f.MethodCall(f, "Close")
+	return f.NextErr()
+}
+
+func (f *fakeEntityDetacher) Detach(ids []string) ([]params.ErrorResult, error) {
+	f.MethodCall(f, "Detach", ids)
+	return f.results, f.NextErr()
+}

--- a/cmd/juju/storage/list.go
+++ b/cmd/juju/storage/list.go
@@ -42,7 +42,7 @@ type listCommand struct {
 func (c *listCommand) Info() *cmd.Info {
 	return &cmd.Info{
 		Name:    "storage",
-		Args:    "<machineID> ...",
+		Args:    "<filesystem|volume> ...",
 		Purpose: "Lists storage details.",
 		Doc:     listCommandDoc,
 		Aliases: []string{"list-storage"},


### PR DESCRIPTION
## Description of change

Add the "detach-storage" command, along with
client and backend additions.

Detaching storage currently still causes it
to be destroyed. Additional changes will be
made to have storage instances detachable.

## QA steps

1. juju bootstrap localhost
2. juju deploy postgresql --storage pgdata=rootfs
(wait for postgresql/0 to become idle)
3. juju detach-storage pgdata/0
(observe that storage is detached, and then destroyed)

## Documentation changes

Yes, we should document the new "detach-storage" command. The *expected* behaviour of detach-storage is that it should trigger the "storage-detaching" hook in the unit that the storage is attached to, then cause the storage to be detached from the unit's machine, but leave the storage in the model so it can be attached to another unit later. At the moment, the storage is destroyed as well as detached.

## Bug reference

None.