### PR TITLE
cmd/juju/storage: add attach-storage command

### DIFF
--- a/api/storage/client_test.go
+++ b/api/storage/client_test.go
@@ -668,3 +668,53 @@ func (s *storageMockSuite) TestDetachArityMismatch(c *gc.C) {
 	_, err := client.Detach([]string{"foo/0", "bar/1"})
 	c.Check(err, gc.ErrorMatches, `expected 2 result\(s\), got 3`)
 }
+
+func (s *storageMockSuite) TestAttach(c *gc.C) {
+	apiCaller := basetesting.APICallerFunc(
+		func(objType string,
+			version int,
+			id, request string,
+			a, result interface{},
+		) error {
+			c.Check(objType, gc.Equals, "Storage")
+			c.Check(id, gc.Equals, "")
+			c.Check(request, gc.Equals, "Attach")
+			c.Check(a, jc.DeepEquals, params.StorageAttachmentIds{[]params.StorageAttachmentId{
+				{
+					StorageTag: "storage-bar-1",
+					UnitTag:    "unit-foo-0",
+				},
+				{
+					StorageTag: "storage-baz-2",
+					UnitTag:    "unit-foo-0",
+				},
+			}})
+			c.Assert(result, gc.FitsTypeOf, &params.ErrorResults{})
+			results := result.(*params.ErrorResults)
+			results.Results = []params.ErrorResult{
+				{},
+				{Error: &params.Error{Message: "qux"}},
+			}
+			return nil
+		},
+	)
+	client := storage.NewClient(apiCaller)
+	results, err := client.Attach("foo/0", []string{"bar/1", "baz/2"})
+	c.Check(err, jc.ErrorIsNil)
+	c.Assert(results, gc.HasLen, 2)
+	c.Assert(results[0].Error, gc.IsNil)
+	c.Assert(results[1].Error, jc.DeepEquals, &params.Error{Message: "qux"})
+}
+
+func (s *storageMockSuite) TestAttachArityMismatch(c *gc.C) {
+	apiCaller := basetesting.APICallerFunc(
+		func(objType string, version int, id, request string, a, result interface{}) error {
+			results := result.(*params.ErrorResults)
+			results.Results = []params.ErrorResult{{}, {}, {}}
+			return nil
+		},
+	)
+	client := storage.NewClient(apiCaller)
+	_, err := client.Attach("foo/0", []string{"bar/1", "baz/2"})
+	c.Check(err, gc.ErrorMatches, `expected 2 result\(s\), got 3`)
+}

--- a/apiserver/storage/base_test.go
+++ b/apiserver/storage/base_test.go
@@ -5,6 +5,7 @@ package storage_test
 
 import (
 	"github.com/juju/errors"
+	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/names.v2"
@@ -12,7 +13,7 @@ import (
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/apiserver/storage"
-	"github.com/juju/juju/apiserver/testing"
+	apiservertesting "github.com/juju/juju/apiserver/testing"
 	"github.com/juju/juju/state"
 	jujustorage "github.com/juju/juju/storage"
 	coretesting "github.com/juju/juju/testing"
@@ -22,7 +23,7 @@ type baseStorageSuite struct {
 	coretesting.BaseSuite
 
 	resources  *common.Resources
-	authorizer testing.FakeAuthorizer
+	authorizer apiservertesting.FakeAuthorizer
 
 	api   *storage.API
 	state *mockState
@@ -38,7 +39,7 @@ type baseStorageSuite struct {
 	filesystemTag        names.FilesystemTag
 	filesystem           *mockFilesystem
 	filesystemAttachment *mockFilesystemAttachment
-	calls                []string
+	stub                 testing.Stub
 
 	registry    jujustorage.StaticProviderRegistry
 	poolManager *mockPoolManager
@@ -50,8 +51,8 @@ type baseStorageSuite struct {
 func (s *baseStorageSuite) SetUpTest(c *gc.C) {
 	s.BaseSuite.SetUpTest(c)
 	s.resources = common.NewResources()
-	s.authorizer = testing.FakeAuthorizer{Tag: names.NewUserTag("admin"), Controller: true}
-	s.calls = []string{}
+	s.authorizer = apiservertesting.FakeAuthorizer{Tag: names.NewUserTag("admin"), Controller: true}
+	s.stub.ResetCalls()
 	s.state = s.constructState()
 
 	s.registry = jujustorage.StaticProviderRegistry{map[jujustorage.ProviderType]jujustorage.Provider{}}
@@ -63,8 +64,9 @@ func (s *baseStorageSuite) SetUpTest(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 }
 
+// TODO(axw) get rid of assertCalls, use stub directly everywhere.
 func (s *baseStorageSuite) assertCalls(c *gc.C, expectedCalls []string) {
-	c.Assert(s.calls, jc.SameContents, expectedCalls)
+	s.stub.CheckCallNames(c, expectedCalls...)
 }
 
 const (
@@ -129,117 +131,117 @@ func (s *baseStorageSuite) constructState() *mockState {
 	s.blocks = make(map[state.BlockType]state.Block)
 	return &mockState{
 		allStorageInstances: func() ([]state.StorageInstance, error) {
-			s.calls = append(s.calls, allStorageInstancesCall)
+			s.stub.AddCall(allStorageInstancesCall)
 			return []state.StorageInstance{s.storageInstance}, nil
 		},
 		storageInstance: func(sTag names.StorageTag) (state.StorageInstance, error) {
-			s.calls = append(s.calls, storageInstanceCall)
+			s.stub.AddCall(storageInstanceCall, sTag)
 			if sTag == s.storageTag {
 				return s.storageInstance, nil
 			}
 			return nil, errors.NotFoundf("%s", names.ReadableString(sTag))
 		},
 		storageInstanceAttachments: func(tag names.StorageTag) ([]state.StorageAttachment, error) {
-			s.calls = append(s.calls, storageInstanceAttachmentsCall)
+			s.stub.AddCall(storageInstanceAttachmentsCall, tag)
 			if tag == s.storageTag {
 				return []state.StorageAttachment{storageInstanceAttachment}, nil
 			}
 			return []state.StorageAttachment{}, nil
 		},
 		storageInstanceFilesystem: func(sTag names.StorageTag) (state.Filesystem, error) {
-			s.calls = append(s.calls, storageInstanceFilesystemCall)
+			s.stub.AddCall(storageInstanceFilesystemCall)
 			if sTag == s.storageTag {
 				return s.filesystem, nil
 			}
 			return nil, errors.NotFoundf("%s", names.ReadableString(sTag))
 		},
 		storageInstanceFilesystemAttachment: func(m names.MachineTag, f names.FilesystemTag) (state.FilesystemAttachment, error) {
-			s.calls = append(s.calls, storageInstanceFilesystemAttachmentCall)
+			s.stub.AddCall(storageInstanceFilesystemAttachmentCall)
 			if m == s.machineTag && f == s.filesystemTag {
 				return s.filesystemAttachment, nil
 			}
 			return nil, errors.NotFoundf("filesystem attachment %s:%s", m, f)
 		},
 		storageInstanceVolume: func(t names.StorageTag) (state.Volume, error) {
-			s.calls = append(s.calls, storageInstanceVolumeCall)
+			s.stub.AddCall(storageInstanceVolumeCall)
 			if t == s.storageTag {
 				return s.volume, nil
 			}
 			return nil, errors.NotFoundf("%s", names.ReadableString(t))
 		},
 		volumeAttachment: func(names.MachineTag, names.VolumeTag) (state.VolumeAttachment, error) {
-			s.calls = append(s.calls, volumeAttachmentCall)
+			s.stub.AddCall(volumeAttachmentCall)
 			return s.volumeAttachment, nil
 		},
 		unitAssignedMachine: func(u names.UnitTag) (names.MachineTag, error) {
-			s.calls = append(s.calls, unitAssignedMachineCall)
+			s.stub.AddCall(unitAssignedMachineCall)
 			if u == s.unitTag {
 				return s.machineTag, nil
 			}
 			return names.MachineTag{}, errors.NotFoundf("%s", names.ReadableString(u))
 		},
 		volume: func(tag names.VolumeTag) (state.Volume, error) {
-			s.calls = append(s.calls, volumeCall)
+			s.stub.AddCall(volumeCall)
 			if tag == s.volumeTag {
 				return s.volume, nil
 			}
 			return nil, errors.NotFoundf("%s", names.ReadableString(tag))
 		},
 		machineVolumeAttachments: func(machine names.MachineTag) ([]state.VolumeAttachment, error) {
-			s.calls = append(s.calls, machineVolumeAttachmentsCall)
+			s.stub.AddCall(machineVolumeAttachmentsCall)
 			if machine == s.machineTag {
 				return []state.VolumeAttachment{s.volumeAttachment}, nil
 			}
 			return nil, nil
 		},
 		volumeAttachments: func(volume names.VolumeTag) ([]state.VolumeAttachment, error) {
-			s.calls = append(s.calls, volumeAttachmentsCall)
+			s.stub.AddCall(volumeAttachmentsCall)
 			if volume == s.volumeTag {
 				return []state.VolumeAttachment{s.volumeAttachment}, nil
 			}
 			return nil, nil
 		},
 		allVolumes: func() ([]state.Volume, error) {
-			s.calls = append(s.calls, allVolumesCall)
+			s.stub.AddCall(allVolumesCall)
 			return []state.Volume{s.volume}, nil
 		},
 		filesystem: func(tag names.FilesystemTag) (state.Filesystem, error) {
-			s.calls = append(s.calls, filesystemCall)
+			s.stub.AddCall(filesystemCall)
 			if tag == s.filesystemTag {
 				return s.filesystem, nil
 			}
 			return nil, errors.NotFoundf("%s", names.ReadableString(tag))
 		},
 		machineFilesystemAttachments: func(machine names.MachineTag) ([]state.FilesystemAttachment, error) {
-			s.calls = append(s.calls, machineFilesystemAttachmentsCall)
+			s.stub.AddCall(machineFilesystemAttachmentsCall)
 			if machine == s.machineTag {
 				return []state.FilesystemAttachment{s.filesystemAttachment}, nil
 			}
 			return nil, nil
 		},
 		filesystemAttachments: func(filesystem names.FilesystemTag) ([]state.FilesystemAttachment, error) {
-			s.calls = append(s.calls, filesystemAttachmentsCall)
+			s.stub.AddCall(filesystemAttachmentsCall)
 			if filesystem == s.filesystemTag {
 				return []state.FilesystemAttachment{s.filesystemAttachment}, nil
 			}
 			return nil, nil
 		},
 		allFilesystems: func() ([]state.Filesystem, error) {
-			s.calls = append(s.calls, allFilesystemsCall)
+			s.stub.AddCall(allFilesystemsCall)
 			return []state.Filesystem{s.filesystem}, nil
 		},
 		modelName: "storagetest",
 		addStorageForUnit: func(u names.UnitTag, name string, cons state.StorageConstraints) error {
-			s.calls = append(s.calls, addStorageForUnitCall)
+			s.stub.AddCall(addStorageForUnitCall)
 			return nil
 		},
 		getBlockForType: func(t state.BlockType) (state.Block, bool, error) {
-			s.calls = append(s.calls, getBlockForTypeCall)
+			s.stub.AddCall(getBlockForTypeCall, t)
 			val, found := s.blocks[t]
 			return val, found, nil
 		},
 		destroyStorageAttachment: func(storage names.StorageTag, unit names.UnitTag) error {
-			s.calls = append(s.calls, destroyStorageAttachmentCall)
+			s.stub.AddCall(destroyStorageAttachmentCall, storage, unit)
 			if storage == s.storageTag && unit == s.unitTag {
 				return nil
 			}
@@ -250,7 +252,7 @@ func (s *baseStorageSuite) constructState() *mockState {
 			)
 		},
 		destroyStorageInstance: func(tag names.StorageTag) error {
-			s.calls = append(s.calls, destroyStorageInstanceCall)
+			s.stub.AddCall(destroyStorageInstanceCall)
 			return errors.New("cannae do it")
 		},
 	}

--- a/apiserver/storage/storageadd_test.go
+++ b/apiserver/storage/storageadd_test.go
@@ -90,7 +90,7 @@ func (s *storageAddSuite) TestStorageAddUnitInvalidName(c *gc.C) {
 func (s *storageAddSuite) TestStorageAddUnitStateError(c *gc.C) {
 	msg := "add test directive error"
 	s.state.addStorageForUnit = func(u names.UnitTag, name string, cons state.StorageConstraints) error {
-		s.calls = append(s.calls, addStorageForUnitCall)
+		s.stub.AddCall(addStorageForUnitCall)
 		return errors.Errorf(msg)
 	}
 
@@ -119,7 +119,7 @@ func (s *storageAddSuite) TestStorageAddUnitResultOrder(c *gc.C) {
 	}
 	msg := "storage name missing error"
 	s.state.addStorageForUnit = func(u names.UnitTag, name string, cons state.StorageConstraints) error {
-		s.calls = append(s.calls, addStorageForUnitCall)
+		s.stub.AddCall(addStorageForUnitCall)
 		if name == "" {
 			return errors.Errorf(msg)
 		}
@@ -142,7 +142,7 @@ func (s *storageAddSuite) TestStorageAddUnitResultOrder(c *gc.C) {
 func (s *storageAddSuite) TestStorageAddUnitNotFoundErr(c *gc.C) {
 	msg := "sanity"
 	s.state.addStorageForUnit = func(u names.UnitTag, name string, cons state.StorageConstraints) error {
-		s.calls = append(s.calls, addStorageForUnitCall)
+		s.stub.AddCall(addStorageForUnitCall)
 		return errors.NotFoundf(msg)
 	}
 

--- a/cmd/juju/commands/main.go
+++ b/cmd/juju/commands/main.go
@@ -384,6 +384,7 @@ func registerCommands(r commandRegistry, ctx *cmd.Context) {
 
 	// Manage storage
 	r.Register(storage.NewAddCommand())
+	r.Register(storage.NewAttachStorageCommandWithAPI())
 	r.Register(storage.NewListCommand())
 	r.Register(storage.NewPoolCreateCommand())
 	r.Register(storage.NewPoolListCommand())

--- a/cmd/juju/commands/main_test.go
+++ b/cmd/juju/commands/main_test.go
@@ -402,6 +402,7 @@ var commandNames = []string{
 	"agree",
 	"agreements",
 	"allocate",
+	"attach-storage",
 	"autoload-credentials",
 	"backups",
 	"bootstrap",

--- a/cmd/juju/storage/attach.go
+++ b/cmd/juju/storage/attach.go
@@ -1,0 +1,120 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package storage
+
+import (
+	"github.com/juju/cmd"
+	"github.com/juju/errors"
+
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/cmd/juju/common"
+	"github.com/juju/juju/cmd/modelcmd"
+)
+
+// NewAttachStorageCommandWithAPI returns a command
+// used to attach storage to application units.
+func NewAttachStorageCommandWithAPI() cmd.Command {
+	cmd := &attachStorageCommand{}
+	cmd.newEntityAttacherCloser = func() (EntityAttacherCloser, error) {
+		return cmd.NewStorageAPI()
+	}
+	return modelcmd.Wrap(cmd)
+}
+
+// NewAttachStorageCommand returns a command used to
+// attach storage to application units.
+func NewAttachStorageCommand(new NewEntityAttacherCloserFunc) cmd.Command {
+	cmd := &attachStorageCommand{}
+	cmd.newEntityAttacherCloser = new
+	return modelcmd.Wrap(cmd)
+}
+
+const (
+	attachStorageCommandDoc = `
+Attach existing storage to a unit. Specify a unit
+and one or more storage IDs to attach to it.
+
+Examples:
+    juju attach-storage postgresq/1 pgdata/0
+`
+
+	attachStorageCommandArgs = `<unit> <storage> [<storage> ...]`
+)
+
+// attachStorageCommand adds unit storage instances dynamically.
+type attachStorageCommand struct {
+	StorageCommandBase
+	newEntityAttacherCloser NewEntityAttacherCloserFunc
+	unitId                  string
+	storageIds              []string
+}
+
+// Init implements Command.Init.
+func (c *attachStorageCommand) Init(args []string) error {
+	if len(args) < 2 {
+		return errors.New("attach-storage requires a unit ID and at least one storage ID")
+	}
+	c.unitId = args[0]
+	c.storageIds = args[1:]
+	return nil
+}
+
+// Info implements Command.Info.
+func (c *attachStorageCommand) Info() *cmd.Info {
+	return &cmd.Info{
+		Name:    "attach-storage",
+		Purpose: "Attaches existing storage to a unit.",
+		Doc:     attachStorageCommandDoc,
+		Args:    attachStorageCommandArgs,
+	}
+}
+
+// Run implements Command.Run.
+func (c *attachStorageCommand) Run(ctx *cmd.Context) error {
+	attacher, err := c.newEntityAttacherCloser()
+	if err != nil {
+		return err
+	}
+	defer attacher.Close()
+
+	results, err := attacher.Attach(c.unitId, c.storageIds)
+	if err != nil {
+		if params.IsCodeUnauthorized(err) {
+			common.PermissionsMessage(ctx.Stderr, "attach storage")
+		}
+		return errors.Trace(err)
+	}
+	for i, result := range results {
+		if result.Error == nil {
+			ctx.Infof("attaching %s to %s", c.storageIds[i], c.unitId)
+		}
+	}
+	var anyFailed bool
+	for i, result := range results {
+		if result.Error != nil {
+			ctx.Infof("failed to attach %s to %s: %s", c.storageIds[i], c.unitId, result.Error)
+			anyFailed = true
+		}
+	}
+	if anyFailed {
+		return cmd.ErrSilent
+	}
+	return nil
+}
+
+// NewEntityAttacherCloser is the type of a function that returns an
+// EntityAttacherCloser.
+type NewEntityAttacherCloserFunc func() (EntityAttacherCloser, error)
+
+// EntityAttacherCloser extends EntityAttacher with a Closer method.
+type EntityAttacherCloser interface {
+	EntityAttacher
+	Close() error
+}
+
+// EntityAttacher defines an interface for attaching storage with the
+// specified IDs to a unit.
+type EntityAttacher interface {
+	Attach(string, []string) ([]params.ErrorResult, error)
+}

--- a/cmd/juju/storage/attach_test.go
+++ b/cmd/juju/storage/attach_test.go
@@ -1,0 +1,95 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package storage_test
+
+import (
+	"github.com/juju/cmd"
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/cmd/juju/storage"
+	coretesting "github.com/juju/juju/testing"
+)
+
+type AttachStorageSuite struct {
+	testing.IsolationSuite
+}
+
+var _ = gc.Suite(&AttachStorageSuite{})
+
+func (s *AttachStorageSuite) TestAttach(c *gc.C) {
+	fake := fakeEntityAttacher{results: []params.ErrorResult{
+		{},
+		{},
+	}}
+	cmd := storage.NewAttachStorageCommand(fake.new)
+	ctx, err := coretesting.RunCommand(c, cmd, "foo/0", "bar/1", "baz/2")
+	c.Assert(err, jc.ErrorIsNil)
+	fake.CheckCallNames(c, "NewEntityAttacherCloser", "Attach", "Close")
+	fake.CheckCall(c, 1, "Attach", "foo/0", []string{"bar/1", "baz/2"})
+	c.Assert(coretesting.Stderr(ctx), gc.Equals, `
+attaching bar/1 to foo/0
+attaching baz/2 to foo/0
+`[1:])
+}
+
+func (s *AttachStorageSuite) TestAttachError(c *gc.C) {
+	fake := fakeEntityAttacher{results: []params.ErrorResult{
+		{Error: &params.Error{Message: "foo"}},
+		{Error: &params.Error{Message: "bar"}},
+	}}
+	attachCmd := storage.NewAttachStorageCommand(fake.new)
+	ctx, err := coretesting.RunCommand(c, attachCmd, "baz/0", "qux/1", "quux/2")
+	stderr := coretesting.Stderr(ctx)
+	c.Assert(stderr, gc.Equals, `failed to attach qux/1 to baz/0: foo
+failed to attach quux/2 to baz/0: bar
+`)
+	c.Assert(err, gc.Equals, cmd.ErrSilent)
+}
+
+func (s *AttachStorageSuite) TestAttachUnauthorizedError(c *gc.C) {
+	var fake fakeEntityAttacher
+	fake.SetErrors(nil, &params.Error{Code: params.CodeUnauthorized, Message: "nope"})
+	cmd := storage.NewAttachStorageCommand(fake.new)
+	ctx, err := coretesting.RunCommand(c, cmd, "foo/0", "bar/1")
+	c.Assert(err, gc.ErrorMatches, "nope")
+	c.Assert(coretesting.Stderr(ctx), gc.Equals, `
+You do not have permission to attach storage.
+You may ask an administrator to grant you access with "juju grant".
+
+`)
+}
+
+func (s *AttachStorageSuite) TestAttachInitErrors(c *gc.C) {
+	s.testAttachInitError(c, []string{}, "attach-storage requires a unit ID and at least one storage ID")
+	s.testAttachInitError(c, []string{"unit/0"}, "attach-storage requires a unit ID and at least one storage ID")
+}
+
+func (s *AttachStorageSuite) testAttachInitError(c *gc.C, args []string, expect string) {
+	cmd := storage.NewAttachStorageCommand(nil)
+	_, err := coretesting.RunCommand(c, cmd, args...)
+	c.Assert(err, gc.ErrorMatches, expect)
+}
+
+type fakeEntityAttacher struct {
+	testing.Stub
+	results []params.ErrorResult
+}
+
+func (f *fakeEntityAttacher) new() (storage.EntityAttacherCloser, error) {
+	f.MethodCall(f, "NewEntityAttacherCloser")
+	return f, f.NextErr()
+}
+
+func (f *fakeEntityAttacher) Close() error {
+	f.MethodCall(f, "Close")
+	return f.NextErr()
+}
+
+func (f *fakeEntityAttacher) Attach(unitId string, storageIds []string) ([]params.ErrorResult, error) {
+	f.MethodCall(f, "Attach", unitId, storageIds)
+	return f.results, f.NextErr()
+}


### PR DESCRIPTION
## Description of change

Add the "attach-storage" command, along with
client and backend-scaffolding additions.

Attaching storage is not currently possible
in state, so the API server backend will
return a "not implemented" error.

## QA steps

1. juju bootstrap localhost
2. juju deploy postgresql
3. juju attach-storage postgresql/0 pgdata/0
(should fail with "attaching storage not implemented")

## Documentation changes

Yes, we'll need to document this command. Probably best to hold off until the backend is completed, and it actually works.

## Bug reference

None.