### PR TITLE
apiserver Client.ModelInfo: only require read permissions

### DIFF
--- a/apiserver/client/client.go
+++ b/apiserver/client/client.go
@@ -441,7 +441,7 @@ func (c *Client) DestroyMachines(args params.DestroyMachines) error {
 
 // ModelInfo returns information about the current model.
 func (c *Client) ModelInfo() (params.ModelInfo, error) {
-	if err := c.checkCanWrite(); err != nil {
+	if err := c.checkCanRead(); err != nil {
 		return params.ModelInfo{}, err
 	}
 	state := c.api.stateAccessor

--- a/apiserver/client/client_test.go
+++ b/apiserver/client/client_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/juju/juju/agent"
 	"github.com/juju/juju/apiserver/client"
 	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/apiserver/modelconfig"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/apiserver/testing"
@@ -61,11 +62,7 @@ func (s *serverSuite) SetUpTest(c *gc.C) {
 	s.client = s.clientForState(c, s.State)
 }
 
-func (s *serverSuite) clientForState(c *gc.C, st *state.State) *client.Client {
-	auth := testing.FakeAuthorizer{
-		Tag:        s.AdminUserTag(c),
-		Controller: true,
-	}
+func (s *serverSuite) authClientForState(c *gc.C, st *state.State, auth facade.Authorizer) *client.Client {
 	urlGetter := common.NewToolsURLGetter(st.ModelUUID(), st)
 	configGetter := stateenvirons.EnvironConfigGetter{st}
 	statusSetter := common.NewStatusSetter(st, common.AuthAlways())
@@ -93,6 +90,13 @@ func (s *serverSuite) clientForState(c *gc.C, st *state.State) *client.Client {
 	return apiserverClient
 }
 
+func (s *serverSuite) clientForState(c *gc.C, st *state.State) *client.Client {
+	return s.authClientForState(c, st, testing.FakeAuthorizer{
+		Tag:        s.AdminUserTag(c),
+		Controller: true,
+	})
+}
+
 func (s *serverSuite) setAgentPresence(c *gc.C, machineId string) *presence.Pinger {
 	m, err := s.State.Machine(machineId)
 	c.Assert(err, jc.ErrorIsNil)
@@ -111,7 +115,12 @@ func (s *serverSuite) TestModelInfo(c *gc.C) {
 	model, err := s.State.Model()
 	c.Assert(err, jc.ErrorIsNil)
 	conf, _ := s.State.ModelConfig()
-	info, err := s.client.ModelInfo()
+	// Model info is available to read-only users.
+	client := s.authClientForState(c, s.State, testing.FakeAuthorizer{
+		Tag:        names.NewUserTag("read"),
+		Controller: true,
+	})
+	info, err := client.ModelInfo()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(info.DefaultSeries, gc.Equals, config.PreferredSeries(conf))
 	c.Assert(info.CloudRegion, gc.Equals, model.CloudRegion())


### PR DESCRIPTION
The call does not change the model, so read perms are enough.
The GUI expects a user with read perms to be able to retrieve info about the currently connected model.

QA:
- share one model to another user with read permissions only;
- run "juju gui" to open up the GUI on your browser, and log in as the read-only user;
- ensure no errors are printed in the JS console and the model name is visible on the GUI breadcrumb.