### PR TITLE
Handle 'Node with this Hostname already exists'.

### DIFF
--- a/provider/maas/environ.go
+++ b/provider/maas/environ.go
@@ -2259,8 +2259,8 @@ func (env *maasEnviron) allocateContainerAddresses2(hostInstanceID instance.Id, 
 			logger.Debugf("found MAAS device for container %q, using existing device", deviceName)
 			device = maybeDevices[0]
 		} else if len(maybeDevices) > 1 {
-			logger.Warningf("found too many MAAS devices (%d) for container %q", len(maybeDevices), deviceName)
-			return errors.Errorf("found more than one MAAS device (%d) for container %q", len(maybeDevices), deviceName)
+			logger.Warningf("found more than 1 MAAS devices (%d) for container %q", len(maybeDevices), deviceName)
+			return nil, errors.Errorf("found more than 1 MAAS device (%d) for container %q", len(maybeDevices), deviceName)
 		} else {
 			logger.Debugf("no existing MAAS devices for container %q, creating", deviceName)
 		}
@@ -2275,8 +2275,6 @@ func (env *maasEnviron) allocateContainerAddresses2(hostInstanceID instance.Id, 
 		}
 		device, err = machine.CreateDevice(createDeviceArgs)
 		if err != nil {
-			// TODO(jam): I believe MAAS is returning "Hostname already exists" if
-			// we tried to create the container earlier, we should instead lookup the device
 			return nil, errors.Trace(err)
 		}
 	}

--- a/provider/maas/environ.go
+++ b/provider/maas/environ.go
@@ -2246,15 +2246,39 @@ func (env *maasEnviron) allocateContainerAddresses2(hostInstanceID instance.Id, 
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	createDeviceArgs := gomaasapi.CreateMachineDeviceArgs{
-		Hostname:      deviceName,
-		MACAddress:    primaryMACAddress,
-		Subnet:        subnet, // can be nil
-		InterfaceName: primaryNICName,
+	// Check to see if we've already tried to allocate information for this device:
+	devicesArgs := gomaasapi.DevicesArgs{
+		Hostname: []string{deviceName},
 	}
-	device, err := machine.CreateDevice(createDeviceArgs)
+	var device gomaasapi.Device
+	maybeDevices, err := machine.Devices(devicesArgs)
 	if err != nil {
-		return nil, errors.Trace(err)
+		logger.Warningf("error while trying to lookup %q: %v", deviceName, err)
+	} else {
+		if len(maybeDevices) == 1 {
+			logger.Debugf("found MAAS device for container %q, using existing device", deviceName)
+			device = maybeDevices[0]
+		} else if len(maybeDevices) > 1 {
+			logger.Warningf("found too many MAAS devices (%d) for container %q", len(maybeDevices), deviceName)
+			return errors.Errorf("found more than one MAAS device (%d) for container %q", len(maybeDevices), deviceName)
+		} else {
+			logger.Debugf("no existing MAAS devices for container %q, creating", deviceName)
+		}
+	}
+	if device == nil {
+		// The device didn't already exist, so we Create it.
+		createDeviceArgs := gomaasapi.CreateMachineDeviceArgs{
+			Hostname:      deviceName,
+			MACAddress:    primaryMACAddress,
+			Subnet:        subnet, // can be nil
+			InterfaceName: primaryNICName,
+		}
+		device, err = machine.CreateDevice(createDeviceArgs)
+		if err != nil {
+			// TODO(jam): I believe MAAS is returning "Hostname already exists" if
+			// we tried to create the container earlier, we should instead lookup the device
+			return nil, errors.Trace(err)
+		}
 	}
 	interface_set := device.InterfaceSet()
 	if len(interface_set) != 1 {

--- a/provider/maas/maas2_environ_whitebox_test.go
+++ b/provider/maas/maas2_environ_whitebox_test.go
@@ -1547,7 +1547,7 @@ func (suite *maas2EnvironSuite) TestAllocateContainerAddressesCreateDevicerror(c
 		Stub:     &testing.Stub{},
 		systemID: "1",
 	}
-	machine.SetErrors(errors.New("boom"))
+	machine.SetErrors(nil, errors.New("boom"))
 	controller := &fakeController{
 		machines: []gomaasapi.Machine{machine},
 		spaces: []gomaasapi.Space{
@@ -1566,16 +1566,15 @@ func (suite *maas2EnvironSuite) TestAllocateContainerAddressesCreateDevicerror(c
 	ignored := names.NewMachineTag("1/lxd/0")
 	_, err := env.AllocateContainerAddresses(instance.Id("1"), ignored, prepared)
 	c.Assert(err, gc.ErrorMatches, "boom")
-	args := getArgs(c, machine.Calls())
-	maasArgs, ok := args.(gomaasapi.CreateMachineDeviceArgs)
-	c.Assert(ok, jc.IsTrue)
-	expected := gomaasapi.CreateMachineDeviceArgs{
+	machine.CheckCall(c, 0, "Devices", gomaasapi.DevicesArgs{
+		Hostname: []string{"juju-06f00d-1-lxd-0"},
+	})
+	machine.CheckCall(c, 1, "CreateDevice", gomaasapi.CreateMachineDeviceArgs{
 		Hostname:      "juju-06f00d-1-lxd-0",
 		Subnet:        subnet,
 		MACAddress:    "DEADBEEF",
 		InterfaceName: "eth0",
-	}
-	c.Assert(maasArgs, jc.DeepEquals, expected)
+	})
 }
 
 func (suite *maas2EnvironSuite) TestAllocateContainerAddressesSubnetMissing(c *gc.C) {

--- a/provider/maas/maas2_test.go
+++ b/provider/maas/maas2_test.go
@@ -230,6 +230,7 @@ type fakeMachine struct {
 	interfaceSet  []gomaasapi.Interface
 	tags          []string
 	createDevice  gomaasapi.Device
+	devices       []gomaasapi.Device
 }
 
 func newFakeMachine(systemID, architecture, statusName string) *fakeMachine {
@@ -297,7 +298,21 @@ func (m *fakeMachine) Start(args gomaasapi.StartArgs) error {
 
 func (m *fakeMachine) CreateDevice(args gomaasapi.CreateMachineDeviceArgs) (gomaasapi.Device, error) {
 	m.MethodCall(m, "CreateDevice", args)
-	return m.createDevice, m.NextErr()
+	err := m.NextErr()
+	if err != nil {
+		return nil, err
+	}
+	m.devices = append(m.devices, m.createDevice)
+	return m.createDevice, nil
+}
+
+func (m *fakeMachine) Devices(args gomaasapi.DevicesArgs) ([]gomaasapi.Device, error) {
+	m.MethodCall(m, "Devices", args)
+	err := m.NextErr()
+	if err != nil {
+		return nil, err
+	}
+	return m.devices, nil
 }
 
 type fakeZone struct {


### PR DESCRIPTION
If we have a failure to actually start an LXD (or KVM) container, then
we would mark it as in error, but would retry the provisioning after a
10s delay. However, we should not try to CreateDevice() again in MAAS,
(or we should be Delete()ing the device). The way we were doing it was
causing us to Create the device twice, which was why MAAS was giving an
error the second time.

This was tested on a live MAAS by injecting a failure just before
broker.manager.CreateContainer. Which should cause us to fail to
provision the container with that specific error, rather than failing
with Hostname already exists.

## QA steps

You need some way to cause CreateContainer to fail. In my testing I used:
```
diff --git a/worker/provisioner/lxd-broker.go b/worker/provisioner/lxd-broker.go
index c8cc50f..749e378 100644
--- a/worker/provisioner/lxd-broker.go
+++ b/worker/provisioner/lxd-broker.go
@@ -120,6 +120,7 @@ func (broker *lxdBroker) StartInstance(args environs.StartInstanceParams) (*envi
        }

        storageConfig := &container.StorageConfig{}
+       return nil, errors.Errorf("boom, lxd shall not pass")
        inst, hardware, err := broker.manager.CreateContainer(
                args.InstanceConfig, args.Constraints,
                series, network, storageConfig, args.StatusCallback,
```

At which point you should be able to do:
```
  $ juju bootstrap maas
  $ juju switch controller
  $ juju add-machine lxd:0
```
And it should fail to provision the container, with the error "boom, lxd shall not pass", rather than the error "Node with this Hostname already exists".

## Documentation changes

No.

## Bug reference

[lp:1670873](https://bugs.launchpad.net/juju/+bug/1670873)
