### PR TITLE
state: fix mongo indexes/usage

### DIFF
--- a/state/allcollections.go
+++ b/state/allcollections.go
@@ -56,6 +56,11 @@ func allCollections() collectionSchema {
 			global:         true,
 			rawAccess:      true,
 			explicitCreate: &mgo.CollectionInfo{},
+			indexes: []mgo.Index{{
+				// The "s" field is used in queries
+				// by mgo/txn.Runner.ResumeAll.
+				Key: []string{"s"},
+			}},
 		},
 		txnLogC: {
 			// This collection is used by mgo/txn to record the set of documents
@@ -383,7 +388,11 @@ func allCollections() collectionSchema {
 			indexes: []mgo.Index{{
 				Key: []string{"model-uuid", "globalkey", "updated"},
 			}, {
-				Key: []string{"model-uuid", "-updated"}, // used for migration
+				// used for migration and model-specific pruning
+				Key: []string{"model-uuid", "-updated"},
+			}, {
+				// used for global pruning (after size check)
+				Key: []string{"-updated"},
 			}},
 		},
 


### PR DESCRIPTION
## Description of change

The main issue is statuseshistory: when
pruning, we are using a raw collection,
which means model-uuid is not added to
queries automatically; and we're not
adding model-uuid in what should be a
model-specific query. Because of that,
the index that includes model-uuid is
not (cannot be) used, and instead mongo
performs a full, super slow, COLLSCAN.
The fix is to add model-uuid to the query.

The juju.txns collection lacks any indexes
at all (except the default one); this is
OK except when resuming transactions,
which performs a query on the "s" field.
I have added an index for this.

## QA steps

1. juju bootstrap localhost
2. juju deploy ubuntu
3. juju debug-log
4. juju show-status-log ubuntu/0
(check /var/log/syslog on controller, make sure there are no errors/warnings)

In a production environment we added the following indexes to a 2.1.1 controller's mongod:
    logs.logs: {"e", "t"}
    juju.txns: {"s"}
    juju.statuseshistory: {"updated"}

The last one is only relevant to 2.1.1 code. This PR changes the status history pruning code to add the model-uuid to the query, which is covered by an existing index.

## Documentation changes

None.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1671258