### PR TITLE
Allow empty interface names for binding as well as constraints.

### DIFF
--- a/provider/maas/constraints_test.go
+++ b/provider/maas/constraints_test.go
@@ -489,8 +489,9 @@ func (suite *environSuite) TestAcquireNodeInterfaces(c *gc.C) {
 		expectedPositives: "name-1:space=1;name-2:space=2;name-3:space=3;0:space=5",
 		expectedNegatives: "space:6",
 	}, {
-		interfaces:    []interfaceBinding{{"", "anything"}},
-		expectedError: "interface bindings cannot have empty names",
+		interfaces:        []interfaceBinding{{"", "anything"}},
+		expectedPositives: "0:space=anything;1:space=5",
+		expectedNegatives: "space:6",
 	}, {
 		interfaces:    []interfaceBinding{{"shared-db", "6"}},
 		expectedError: `negative space "bar" from constraints clashes with interface bindings`,
@@ -503,7 +504,7 @@ func (suite *environSuite) TestAcquireNodeInterfaces(c *gc.C) {
 		expectedNegatives: "space:6",
 	}, {
 		interfaces:    []interfaceBinding{{"", ""}},
-		expectedError: "interface bindings cannot have empty names",
+		expectedError: `invalid interface binding "": space provider ID is required`,
 	}, {
 		interfaces: []interfaceBinding{
 			{"valid", "ok"},
@@ -511,7 +512,7 @@ func (suite *environSuite) TestAcquireNodeInterfaces(c *gc.C) {
 			{"valid-name-empty-space", ""},
 			{"", ""},
 		},
-		expectedError: "interface bindings cannot have empty names",
+		expectedError: `invalid interface binding "valid-name-empty-space": space provider ID is required`,
 	}, {
 		interfaces:    []interfaceBinding{{"foo", ""}},
 		expectedError: `invalid interface binding "foo": space provider ID is required`,

--- a/provider/maas/maas2_environ_whitebox_test.go
+++ b/provider/maas/maas2_environ_whitebox_test.go
@@ -529,7 +529,7 @@ func (suite *maas2EnvironSuite) TestAcquireNodeInterfaces(c *gc.C) {
 	cons := constraints.Value{
 		Spaces: stringslicep("foo", "^bar"),
 	}
-	// In the tests below "space:5" means foo, "space:6" means bar.
+	// In the tests below Space 2 means foo, Space 3 means bar.
 	for i, test := range []struct {
 		interfaces        []interfaceBinding
 		expectedPositives []gomaasapi.InterfaceSpec
@@ -553,8 +553,9 @@ func (suite *maas2EnvironSuite) TestAcquireNodeInterfaces(c *gc.C) {
 		expectedPositives: []gomaasapi.InterfaceSpec{{"name-1", "7"}, {"name-2", "8"}, {"name-3", "9"}, {"0", "2"}},
 		expectedNegatives: []string{"3"},
 	}, {
-		interfaces:    []interfaceBinding{{"", "anything"}},
-		expectedError: "interface bindings cannot have empty names",
+		interfaces:        []interfaceBinding{{"", "anything"}},
+		expectedPositives: []gomaasapi.InterfaceSpec{{"0", "anything"}, {"1", "2"}},
+		expectedNegatives: []string{"3"},
 	}, {
 		interfaces:    []interfaceBinding{{"shared-db", "3"}},
 		expectedError: `negative space "bar" from constraints clashes with interface bindings`,
@@ -567,7 +568,7 @@ func (suite *maas2EnvironSuite) TestAcquireNodeInterfaces(c *gc.C) {
 		expectedNegatives: []string{"3"},
 	}, {
 		interfaces:    []interfaceBinding{{"", ""}},
-		expectedError: "interface bindings cannot have empty names",
+		expectedError: `invalid interface binding "": space provider ID is required`,
 	}, {
 		interfaces: []interfaceBinding{
 			{"valid", "ok"},
@@ -575,7 +576,7 @@ func (suite *maas2EnvironSuite) TestAcquireNodeInterfaces(c *gc.C) {
 			{"valid-name-empty-space", ""},
 			{"", ""},
 		},
-		expectedError: "interface bindings cannot have empty names",
+		expectedError: `invalid interface binding "valid-name-empty-space": space provider ID is required`,
 	}, {
 		interfaces:    []interfaceBinding{{"foo", ""}},
 		expectedError: `invalid interface binding "foo": space provider ID is required`,


### PR DESCRIPTION
Addresses bug #1671489 where 'juju deploy app --bind space' was failing
because space was tracked as part of an empty binding name. We supported
that for '--constraints space=foo' so just do the same for empty
binding names.

## QA steps

```
  $ juju bootstrap maas
  $ juju deploy ubuntu --bind space-0
```

Without this patch, it fails to provision a machine with:
 cannot run instances: cannot run instance: interface bindings cannot
        have empty names

With this patch, it should find an appropriate machine that is in space-0. (tested live on guimaas)

## Documentation changes

No, it was supposed to be something we already supported, and the docs already reflect this.

## Bug reference

[lp:1671489](https://bugs.launchpad.net/juju/+bug/1671489)