### PR TITLE
2.1 into develop

### DIFF
--- a/provider/maas/constraints_test.go
+++ b/provider/maas/constraints_test.go
@@ -489,8 +489,9 @@ func (suite *environSuite) TestAcquireNodeInterfaces(c *gc.C) {
 		expectedPositives: "name-1:space=1;name-2:space=2;name-3:space=3;0:space=5",
 		expectedNegatives: "space:6",
 	}, {
-		interfaces:    []interfaceBinding{{"", "anything"}},
-		expectedError: "interface bindings cannot have empty names",
+		interfaces:        []interfaceBinding{{"", "anything"}},
+		expectedPositives: "0:space=anything;1:space=5",
+		expectedNegatives: "space:6",
 	}, {
 		interfaces:    []interfaceBinding{{"shared-db", "6"}},
 		expectedError: `negative space "bar" from constraints clashes with interface bindings`,
@@ -503,7 +504,7 @@ func (suite *environSuite) TestAcquireNodeInterfaces(c *gc.C) {
 		expectedNegatives: "space:6",
 	}, {
 		interfaces:    []interfaceBinding{{"", ""}},
-		expectedError: "interface bindings cannot have empty names",
+		expectedError: `invalid interface binding "": space provider ID is required`,
 	}, {
 		interfaces: []interfaceBinding{
 			{"valid", "ok"},
@@ -511,7 +512,7 @@ func (suite *environSuite) TestAcquireNodeInterfaces(c *gc.C) {
 			{"valid-name-empty-space", ""},
 			{"", ""},
 		},
-		expectedError: "interface bindings cannot have empty names",
+		expectedError: `invalid interface binding "valid-name-empty-space": space provider ID is required`,
 	}, {
 		interfaces:    []interfaceBinding{{"foo", ""}},
 		expectedError: `invalid interface binding "foo": space provider ID is required`,

--- a/provider/maas/maas2_test.go
+++ b/provider/maas/maas2_test.go
@@ -230,6 +230,7 @@ type fakeMachine struct {
 	interfaceSet  []gomaasapi.Interface
 	tags          []string
 	createDevice  gomaasapi.Device
+	devices       []gomaasapi.Device
 }
 
 func newFakeMachine(systemID, architecture, statusName string) *fakeMachine {
@@ -297,7 +298,21 @@ func (m *fakeMachine) Start(args gomaasapi.StartArgs) error {
 
 func (m *fakeMachine) CreateDevice(args gomaasapi.CreateMachineDeviceArgs) (gomaasapi.Device, error) {
 	m.MethodCall(m, "CreateDevice", args)
-	return m.createDevice, m.NextErr()
+	err := m.NextErr()
+	if err != nil {
+		return nil, err
+	}
+	m.devices = append(m.devices, m.createDevice)
+	return m.createDevice, nil
+}
+
+func (m *fakeMachine) Devices(args gomaasapi.DevicesArgs) ([]gomaasapi.Device, error) {
+	m.MethodCall(m, "Devices", args)
+	err := m.NextErr()
+	if err != nil {
+		return nil, err
+	}
+	return m.devices, nil
 }
 
 type fakeZone struct {


### PR DESCRIPTION
Merge 2.1 into develop including fixes for:
- Fix 'binding names must not be empty' for https://pad.lv/1671489 
- Handle 'Node with this Hostname already exists' when deploying containers: https://pad.lv/1670873
