### PR TITLE
WIP: Model meter status

### DIFF
--- a/apiserver/common/modeldestroy.go
+++ b/apiserver/common/modeldestroy.go
@@ -16,7 +16,6 @@ var sendMetrics = func(st metricsender.ModelBackend) error {
 	if err != nil {
 		return errors.Annotatef(err, "failed to get model config for %s", st.ModelTag())
 	}
-
 	err = metricsender.SendMetrics(st, metricsender.DefaultMetricSender(), clock.WallClock, metricsender.DefaultMaxBatchesPerSend(), cfg.TransmitVendorMetrics())
 	return errors.Trace(err)
 }

--- a/apiserver/common/modelmanagerinterface.go
+++ b/apiserver/common/modelmanagerinterface.go
@@ -60,6 +60,7 @@ type ModelManagerBackend interface {
 	LatestMigration() (state.ModelMigration, error)
 	DumpAll() (map[string]interface{}, error)
 	Close() error
+	SetMeterStatus(codeStr, info string) error
 }
 
 // Model defines methods provided by a state.Model instance.

--- a/apiserver/metricsender/metricsender.go
+++ b/apiserver/metricsender/metricsender.go
@@ -35,16 +35,9 @@ func handleResponse(mm *state.MetricsManager, st ModelBackend, response wireform
 		if err != nil {
 			logger.Errorf("failed to set sent on metrics %v", err)
 		}
-		for unitName, status := range envResp.UnitStatuses {
-			unit, err := st.Unit(unitName)
-			if err != nil {
-				logger.Errorf("failed to retrieve unit %q: %v", unitName, err)
-				continue
-			}
-			err = unit.SetMeterStatus(status.Status, status.Info)
-			if err != nil {
-				logger.Errorf("failed to set unit %q meter status to %v: %v", unitName, status, err)
-			}
+		err = st.SetMeterStatus(envResp.ModelStatus.Status, envResp.ModelStatus.Info)
+		if err != nil {
+			logger.Errorf("failed to set model meter status to %v: %v", envResp.ModelStatus.Status, err)
 		}
 	}
 	if response.NewGracePeriod > 0 && response.NewGracePeriod != mm.GracePeriod() {

--- a/apiserver/metricsender/sender_test.go
+++ b/apiserver/metricsender/sender_test.go
@@ -125,7 +125,7 @@ func testHandler(c *gc.C, batches chan<- wireformat.MetricBatch, statusMap Statu
 
 			if statusMap != nil {
 				unitName, status, info := statusMap(batch.UnitName)
-				resp.SetStatus(batch.ModelUUID, unitName, status, info)
+				resp.SetUnitStatus(batch.ModelUUID, unitName, status, info)
 			}
 
 			select {

--- a/apiserver/metricsender/stateinterface.go
+++ b/apiserver/metricsender/stateinterface.go
@@ -31,4 +31,5 @@ type ModelBackend interface {
 	Unit(name string) (*state.Unit, error)
 	ModelTag() names.ModelTag
 	ModelConfig() (*config.Config, error)
+	SetMeterStatus(codeStr, info string) error
 }

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -40,7 +40,7 @@ github.com/juju/pubsub	git	9dcaca7eb4340dbf685aa7b3ad4cc4f8691a33d4	2016-07-28T0
 github.com/juju/replicaset	git	6b5becf2232ce76656ea765d8d915d41755a1513	2016-11-25T16:08:49Z
 github.com/juju/retry	git	62c62032529169c7ec02fa48f93349604c345e1f	2015-10-29T02:48:21Z
 github.com/juju/rfc	git	ebdbbdb950cd039a531d15cdc2ac2cbd94f068ee	2016-07-11T02:42:13Z
-github.com/juju/romulus	git	bf7827fa2f360ab762c134766ff1d4fff959ea03	2016-08-17T23:29:48Z
+github.com/juju/romulus	git	433001071a128525f712cfa41ced4a2ef5c1d836	2017-03-09T17:09:27Z
 github.com/juju/schema	git	075de04f9b7d7580d60a1e12a0b3f50bb18e6998	2016-04-20T04:42:03Z
 github.com/juju/terms-client	git	9b925afd677234e4146dde3cb1a11e187cbed64e	2016-08-09T13:19:00Z
 github.com/juju/testing	git	fce9bc4ebf7a77310c262ac4884e03b778eae06a	2017-02-22T09:01:19Z

--- a/state/state.go
+++ b/state/state.go
@@ -2163,6 +2163,15 @@ func (st *State) PutAuditEntryFn() func(audit.AuditEntry) error {
 	return stateaudit.PutAuditEntryFn(auditingC, insert)
 }
 
+// SetMeterStatus sets the meter status on the current connected model.
+func (st *State) SetMeterStatus(codeStr, info string) error {
+	m, err := st.Model()
+	if err != nil {
+		return errors.Trace(err)
+	}
+	return errors.Trace(m.SetMeterStatus(codeStr, info))
+}
+
 var tagPrefix = map[byte]string{
 	'm': names.MachineTagKind + "-",
 	'a': names.ApplicationTagKind + "-",


### PR DESCRIPTION
## Description of change

/v3/metrics API can now set the meter status on an entire model. This is different from the metricsmanager, which also sets model meter status, but only on the basis of connectivity.

## QA steps

1. Arrange for the /v3/metrics response to set a model's meter status to a given response.
2. Confirm that the units in that model receive the meter status setting in their hook execution context.

## Documentation changes

@juju/docs should ask @cmars about this.

## Bug reference

None.