### PR TITLE
2.1.2 empty binding update 1671428

### DIFF
--- a/state/application_test.go
+++ b/state/application_test.go
@@ -199,6 +199,7 @@ func (s *ApplicationSuite) TestSetCharmUpdatesBindings(c *gc.C) {
 		Name:  "yoursql",
 		Charm: oldCharm,
 		EndpointBindings: map[string]string{
+			"":       "db",
 			"server": "db",
 			"client": "client",
 		}})
@@ -212,13 +213,14 @@ func (s *ApplicationSuite) TestSetCharmUpdatesBindings(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(updatedBindings, jc.DeepEquals, map[string]string{
 		// Existing bindings are preserved.
+		"":        "db",
 		"server":  "db",
 		"client":  "client",
-		"cluster": "", // inherited from defaults in AddService.
-		// New endpoints use empty defaults.
-		"foo":  "",
-		"baz":  "",
-		"just": "",
+		"cluster": "db", // inherited from defaults in AddService.
+		// New endpoints use defaults.
+		"foo":  "db",
+		"baz":  "db",
+		"just": "db",
 	})
 }
 


### PR DESCRIPTION
## Description of change

When using a default binding (juju deploy --bind foo) we are creating a record with a key of "". Trying to update that key using the dotted syntax causes an invalid TXN to be created, which triggers during any "upgrade-charm" action. However, we were already setting all of the values in the binding. Also, the check that was trying to skip updating bindings when they don't change was invalid. Now we properly update bindings, and even do an even better thing and use the 'default' value for any new bindings that a charm starts to declare.

## QA steps

```
  $ juju bootstrap maas
  $ juju deploy cs:~jameinel/ubuntu-lite-5 ul --bind space-0
  $ juju upgrade-charm ul
```

With 2.1.1 that gets into a bad state with failures like:
```
The update path 'bindings.' contains an empty field name, which is not allowed.
```

With this patch, upgrade-charm succeeds.

## Documentation changes

No.

## Bug reference

[lp:1671428](https://bugs.launchpad.net/juju/+bug/1671428)