### PR TITLE
cmd/juju/user: consult external directory server to find out host names for public controllers

### DIFF
--- a/featuretests/cmd_juju_login_test.go
+++ b/featuretests/cmd_juju_login_test.go
@@ -63,6 +63,7 @@ func (s *cmdLoginSuite) TestLoginCommand(c *gc.C) {
 	context := s.run(c, strings.NewReader("hunter2\nhunter2\n"), "login", "test")
 	c.Assert(testing.Stdout(context), gc.Equals, "")
 	c.Assert(testing.Stderr(context), gc.Equals, `
+WARNING could not determine controller domain: Get https://api.jujucharms.com/directory/v1/controller/test: access to address "api.jujucharms.com:443" not allowed
 please enter password for test on kontroll: 
 You are now logged in to "kontroll" as "test".
 `[1:])


### PR DESCRIPTION
This allows us to set up global aliases for public controllers.