### PR TITLE
juju run executes as root, not as ubuntu anymore

### DIFF
--- a/cmd/juju/commands/run.go
+++ b/cmd/juju/commands/run.go
@@ -56,7 +56,7 @@ names.  At least one target specifier is needed.
 Multiple values can be set for --machine, --application, and --unit by using
 comma separated values.
 
-If the target is a machine, the command is run as the "ubuntu" user on
+If the target is a machine, the command is run as the "root" user on
 the remote machine.
 
 If the target is an application, the command is run on all units for that


### PR DESCRIPTION
## Description of change

The help text says that `juju run` will run as "ubuntu" but it runs as "root".

## QA steps

`juju run -h`

## Documentation changes

We should make sure our web pages agree.
https://github.com/juju/docs/issues/1708

## Bug reference

[lp:1628593](https://bugs.launchpad.net/juju/+bug/1628593)
