### PR TITLE
cmd/juju/user: set controller name properly

### DIFF
--- a/cmd/juju/user/login_test.go
+++ b/cmd/juju/user/login_test.go
@@ -76,7 +76,7 @@ func (s *LoginCommandSuite) TestInitError(c *gc.C) {
 }
 
 func (s *LoginCommandSuite) TestLogin(c *gc.C) {
-	stdout, stderr, code := runLogin(c, "current-user\nsekrit\n")
+	stdout, stderr, code := runLogin(c, "current-user\nsekrit\n", "-u")
 	c.Check(stdout, gc.Equals, "")
 	c.Check(stderr, gc.Equals, `
 username: You are now logged in to "testing" as "current-user".
@@ -91,7 +91,7 @@ username: You are now logged in to "testing" as "current-user".
 func (s *LoginCommandSuite) TestLoginNewUser(c *gc.C) {
 	err := s.store.RemoveAccount("testing")
 	c.Assert(err, jc.ErrorIsNil)
-	stdout, stderr, code := runLogin(c, "sekrit\n", "new-user")
+	stdout, stderr, code := runLogin(c, "sekrit\n", "new-user", "-u")
 	c.Check(stdout, gc.Equals, "")
 	c.Check(stderr, gc.Equals, `
 You are now logged in to "testing" as "new-user".
@@ -104,7 +104,7 @@ You are now logged in to "testing" as "new-user".
 }
 
 func (s *LoginCommandSuite) TestLoginAlreadyLoggedInSameUser(c *gc.C) {
-	stdout, stderr, code := runLogin(c, "", "current-user")
+	stdout, stderr, code := runLogin(c, "", "current-user", "-u")
 	c.Check(stdout, gc.Equals, "")
 	c.Check(stderr, gc.Equals, `You are now logged in to "testing" as "current-user".
 `)
@@ -112,7 +112,7 @@ func (s *LoginCommandSuite) TestLoginAlreadyLoggedInSameUser(c *gc.C) {
 }
 
 func (s *LoginCommandSuite) TestLoginAlreadyLoggedInDifferentUser(c *gc.C) {
-	stdout, stderr, code := runLogin(c, "sekrit\n", "other-user")
+	stdout, stderr, code := runLogin(c, "sekrit\n", "-u", "other-user")
 	c.Check(stdout, gc.Equals, "")
 	c.Check(stderr, gc.Equals, `
 error: already logged in
@@ -125,7 +125,7 @@ Run "juju logout" first before attempting to log in as a different user.
 func (s *LoginCommandSuite) TestLoginWithMacaroons(c *gc.C) {
 	err := s.store.RemoveAccount("testing")
 	c.Assert(err, jc.ErrorIsNil)
-	stdout, stderr, code := runLogin(c, "")
+	stdout, stderr, code := runLogin(c, "", "-u")
 	c.Check(stderr, gc.Equals, `
 You are now logged in to "testing" as "user@external".
 `[1:])
@@ -147,7 +147,7 @@ func (s *LoginCommandSuite) TestLoginWithMacaroonsNotSupported(c *gc.C) {
 		c.Check(p.AccountDetails.User, gc.Equals, "new-user")
 		return s.mockAPI, nil
 	}
-	stdout, stderr, code := runLogin(c, "new-user\nsekrit\n")
+	stdout, stderr, code := runLogin(c, "new-user\nsekrit\n", "-u")
 	c.Check(stdout, gc.Equals, ``)
 	c.Check(stderr, gc.Equals, `
 username: You are now logged in to "testing" as "new-user".

--- a/cmd/juju/user/logincontroller_test.go
+++ b/cmd/juju/user/logincontroller_test.go
@@ -70,7 +70,7 @@ func (s *LoginControllerSuite) TearDownTest(c *gc.C) {
 	s.FakeJujuXDGDataHomeSuite.TearDownTest(c)
 }
 
-func (s *LoginControllerSuite) TestRegisterPublic(c *gc.C) {
+func (s *LoginControllerSuite) TestLoginFromDirectory(c *gc.C) {
 	dirSrv := serveDirectory(map[string]string{
 		"bighost": "bighost.jujucharms.com:443",
 	})
@@ -103,10 +103,10 @@ Welcome, bob@external. You are now logged into "bighost".
 	})
 }
 
-func (s *LoginControllerSuite) TestRegisterPublicHostname(c *gc.C) {
+func (s *LoginControllerSuite) TestLoginPublicHostname(c *gc.C) {
 	s.apiConnection.authTag = names.NewUserTag("bob@external")
 	s.apiConnection.controllerAccess = "login"
-	stdout, stderr, code := s.run(c, "--host", "0.1.2.3")
+	stdout, stderr, code := s.run(c, "0.1.2.3")
 	c.Check(stderr, gc.Equals, `
 Welcome, bob@external. You are now logged into "0.1.2.3".
 `[1:]+user.NoModelsMessage)
@@ -133,7 +133,7 @@ Welcome, bob@external. You are now logged into "0.1.2.3".
 func (s *LoginControllerSuite) TestRegisterPublicHostnameWithPort(c *gc.C) {
 	s.apiConnection.authTag = names.NewUserTag("bob@external")
 	s.apiConnection.controllerAccess = "login"
-	stdout, stderr, code := s.run(c, "--host", "0.1.2.3:5678")
+	stdout, stderr, code := s.run(c, "0.1.2.3:5678")
 	c.Check(stdout, gc.Equals, "")
 	c.Check(stderr, gc.Equals, "error: cannot use \"0.1.2.3:5678\" as controller name - use -c flag to choose a different one\n")
 	c.Check(code, gc.Equals, 1)
@@ -142,7 +142,7 @@ func (s *LoginControllerSuite) TestRegisterPublicHostnameWithPort(c *gc.C) {
 func (s *LoginControllerSuite) TestRegisterPublicHostnameWithPortAndControllerFlag(c *gc.C) {
 	s.apiConnection.authTag = names.NewUserTag("bob@external")
 	s.apiConnection.controllerAccess = "login"
-	stdout, stderr, code := s.run(c, "-c", "foo", "--host", "0.1.2.3:5678")
+	stdout, stderr, code := s.run(c, "-c", "foo", "0.1.2.3:5678")
 	c.Check(stdout, gc.Equals, "")
 	c.Check(stderr, gc.Equals, `
 Welcome, bob@external. You are now logged into "foo".

--- a/featuretests/cmd_juju_login_test.go
+++ b/featuretests/cmd_juju_login_test.go
@@ -60,10 +60,9 @@ func (s *cmdLoginSuite) TestLoginCommand(c *gc.C) {
 	s.changeUserPassword(c, "admin", "hunter2")
 	s.run(c, nil, "logout")
 
-	context := s.run(c, strings.NewReader("hunter2\nhunter2\n"), "login", "test")
+	context := s.run(c, strings.NewReader("hunter2\nhunter2\n"), "login", "test", "-u")
 	c.Assert(testing.Stdout(context), gc.Equals, "")
 	c.Assert(testing.Stderr(context), gc.Equals, `
-WARNING could not determine controller domain: Get https://api.jujucharms.com/directory/v1/controller/test: access to address "api.jujucharms.com:443" not allowed
 please enter password for test on kontroll: 
 You are now logged in to "kontroll" as "test".
 `[1:])


### PR DESCRIPTION
Because the controller wasn't being set, the ListControllers
call was failing. The tests still passed because the ListControllers
call was entirely mocked.

Also make a backwardly incompatible change so that the old
"juju login $user" behaviour is no longer the default - to log in as
a user, the "--user" (or "-u") flag is required.
