### PR TITLE
Send controller UUID when checking charm revisions

### DIFF
--- a/apiserver/charmrevisionupdater/updater.go
+++ b/apiserver/charmrevisionupdater/updater.go
@@ -79,9 +79,9 @@ func (api *CharmRevisionUpdaterAPI) updateLatestRevisions() error {
 		}
 
 		// Then run through the handlers.
-		serviceID := info.service.ApplicationTag()
+		tag := info.application.ApplicationTag()
 		for _, handler := range handlers {
-			if err := handler.HandleLatest(serviceID, info.CharmInfo); err != nil {
+			if err := handler.HandleLatest(tag, info.CharmInfo); err != nil {
 				return err
 			}
 		}
@@ -98,19 +98,18 @@ var NewCharmStoreClient = func(st *state.State) (charmstore.Client, error) {
 
 type latestCharmInfo struct {
 	charmstore.CharmInfo
-	service *state.Application
+	application *state.Application
 }
 
 // retrieveLatestCharmInfo looks up the charm store to return the charm URLs for the
 // latest revision of the deployed charms.
 func retrieveLatestCharmInfo(st *state.State) ([]latestCharmInfo, error) {
-	// First get the uuid for the environment to use when querying the charm store.
-	env, err := st.Model()
+	model, err := st.Model()
 	if err != nil {
 		return nil, err
 	}
 
-	services, err := st.AllApplications()
+	applications, err := st.AllApplications()
 	if err != nil {
 		return nil, err
 	}
@@ -121,30 +120,27 @@ func retrieveLatestCharmInfo(st *state.State) ([]latestCharmInfo, error) {
 	}
 
 	var charms []charmstore.CharmID
-	var resultsIndexedServices []*state.Application
-	for _, service := range services {
-		curl, _ := service.CharmURL()
+	var resultsIndexedApps []*state.Application
+	for _, application := range applications {
+		curl, _ := application.CharmURL()
 		if curl.Schema == "local" {
-			// Version checking for charms from local repositories is not
-			// currently supported, since we don't yet support passing in
-			// a path to the local repo. This may change if the need arises.
 			continue
 		}
 
 		cid := charmstore.CharmID{
 			URL:     curl,
-			Channel: service.Channel(),
+			Channel: application.Channel(),
 		}
 		charms = append(charms, cid)
-		resultsIndexedServices = append(resultsIndexedServices, service)
+		resultsIndexedApps = append(resultsIndexedApps, application)
 	}
 
 	metadata := map[string]string{
-		"environment_uuid": env.UUID(),
-		"cloud":            env.Cloud(),
-		"cloud_region":     env.CloudRegion(),
+		"environment_uuid": model.UUID(),
+		"cloud":            model.Cloud(),
+		"cloud_region":     model.CloudRegion(),
 	}
-	cloud, err := st.Cloud(env.Cloud())
+	cloud, err := st.Cloud(model.Cloud())
 	if err != nil {
 		metadata["provider"] = "unknown"
 	} else {
@@ -161,10 +157,10 @@ func retrieveLatestCharmInfo(st *state.State) ([]latestCharmInfo, error) {
 			logger.Errorf("retrieving charm info for %s: %v", charms[i].URL, result.Error)
 			continue
 		}
-		service := resultsIndexedServices[i]
+		application := resultsIndexedApps[i]
 		latest = append(latest, latestCharmInfo{
-			CharmInfo: result.CharmInfo,
-			service:   service,
+			CharmInfo:   result.CharmInfo,
+			application: application,
 		})
 	}
 	return latest, nil

--- a/apiserver/charmrevisionupdater/updater.go
+++ b/apiserver/charmrevisionupdater/updater.go
@@ -126,7 +126,6 @@ func retrieveLatestCharmInfo(st *state.State) ([]latestCharmInfo, error) {
 		if curl.Schema == "local" {
 			continue
 		}
-
 		cid := charmstore.CharmID{
 			URL:     curl,
 			Channel: application.Channel(),
@@ -137,6 +136,7 @@ func retrieveLatestCharmInfo(st *state.State) ([]latestCharmInfo, error) {
 
 	metadata := map[string]string{
 		"environment_uuid": model.UUID(),
+		"controller_uuid":  st.ControllerUUID(),
 		"cloud":            model.Cloud(),
 		"cloud_region":     model.CloudRegion(),
 	}

--- a/apiserver/charmrevisionupdater/updater_test.go
+++ b/apiserver/charmrevisionupdater/updater_test.go
@@ -188,6 +188,7 @@ func (s *charmVersionSuite) TestJujuMetadataHeaderIsSent(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	expected_header := []string{
 		"environment_uuid=" + model.UUID(),
+		"controller_uuid=" + s.State.ControllerUUID(),
 		"cloud=" + model.Cloud(),
 		"cloud_region=" + model.CloudRegion(),
 		"provider=" + cloud.Type,

--- a/apiserver/charmrevisionupdater/updater_test.go
+++ b/apiserver/charmrevisionupdater/updater_test.go
@@ -109,14 +109,14 @@ func (s *charmVersionSuite) TestUpdateRevisions(c *gc.C) {
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 
 	// Update mysql version and run update again.
-	svc, err := s.State.Application("mysql")
+	app, err := s.State.Application("mysql")
 	c.Assert(err, jc.ErrorIsNil)
 	ch := s.AddCharmWithRevision(c, "mysql", 23)
 	cfg := state.SetCharmConfig{
 		Charm:      ch,
 		ForceUnits: true,
 	}
-	err = svc.SetCharm(cfg)
+	err = app.SetCharm(cfg)
 	c.Assert(err, jc.ErrorIsNil)
 
 	result, err = s.charmrevisionupdater.UpdateLatestRevisions()
@@ -182,14 +182,14 @@ func (s *charmVersionSuite) TestJujuMetadataHeaderIsSent(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.Error, gc.IsNil)
 
-	env, err := s.State.Model()
+	model, err := s.State.Model()
 	c.Assert(err, jc.ErrorIsNil)
-	cloud, err := s.State.Cloud(env.Cloud())
+	cloud, err := s.State.Cloud(model.Cloud())
 	c.Assert(err, jc.ErrorIsNil)
 	expected_header := []string{
-		"environment_uuid=" + env.UUID(),
-		"cloud=" + env.Cloud(),
-		"cloud_region=" + env.CloudRegion(),
+		"environment_uuid=" + model.UUID(),
+		"cloud=" + model.Cloud(),
+		"cloud_region=" + model.CloudRegion(),
 		"provider=" + cloud.Type,
 		"controller_version=" + version.Current.String(),
 	}

--- a/charmstore/latest.go
+++ b/charmstore/latest.go
@@ -27,6 +27,7 @@ func LatestCharmInfo(client Client, charms []CharmID, metadata map[string]string
 	revResults, err := client.LatestRevisions(charms, map[string][]string{
 		jujuMetadataHTTPHeader: []string{
 			"environment_uuid=" + metadata["environment_uuid"],
+			"controller_uuid=" + metadata["controller_uuid"],
 			"cloud=" + metadata["cloud"],
 			"cloud_region=" + metadata["cloud_region"],
 			"provider=" + metadata["provider"],

--- a/charmstore/latest_test.go
+++ b/charmstore/latest_test.go
@@ -71,6 +71,7 @@ func (s *LatestCharmInfoSuite) TestSuccess(c *gc.C) {
 
 	metadata := map[string]string{
 		"environment_uuid": "foouuid",
+		"controller_uuid":  "controlleruuid",
 		"cloud":            "foocloud",
 		"cloud_region":     "fooregion",
 		"provider":         "fooprovider",
@@ -78,7 +79,14 @@ func (s *LatestCharmInfoSuite) TestSuccess(c *gc.C) {
 	results, err := LatestCharmInfo(client, charms, metadata)
 	c.Assert(err, jc.ErrorIsNil)
 
-	header := []string{"environment_uuid=foouuid", "cloud=foocloud", "cloud_region=fooregion", "provider=fooprovider", "controller_version=" + version.Current.String()}
+	header := []string{
+		"environment_uuid=foouuid",
+		"controller_uuid=controlleruuid",
+		"cloud=foocloud",
+		"cloud_region=fooregion",
+		"provider=fooprovider",
+		"controller_version=" + version.Current.String(),
+	}
 	s.lowLevel.stableStub.CheckCall(c, 0, "Latest", params.StableChannel, []*charm.URL{spam}, map[string][]string{"Juju-Metadata": header})
 	s.lowLevel.stableStub.CheckCall(c, 1, "Latest", params.StableChannel, []*charm.URL{eggs}, map[string][]string{"Juju-Metadata": header})
 	s.lowLevel.stableStub.CheckCall(c, 2, "Latest", params.StableChannel, []*charm.URL{ham}, map[string][]string{"Juju-Metadata": header})


### PR DESCRIPTION
## Description of change

Improved usage stats.

This change also includes a drive-by fix for function and variable names which used old terminology (e.g. "service" and "environment").

## QA steps

Bootstrapped a controller with the charm revision updater worker to check every 20s instead of 24hrs. Observed that the checks still worked so no regression introduced. 

## Documentation changes

N.A.

## Bug reference

N.A.
