### PR TITLE
Changes for bug 1671265, improve checks on existing SecurityGroups to…

### DIFF
--- a/provider/openstack/firewaller.go
+++ b/provider/openstack/firewaller.go
@@ -545,92 +545,134 @@ func (c *neutronFirewaller) setUpGlobalGroup(groupName string, apiPort int) (neu
 // zeroGroup holds the zero security group.
 var zeroGroup neutron.SecurityGroupV2
 
-// ensureGroup returns the security group with name and perms.
+// ensureGroup returns the security group with name and rules.
 // If a group with name does not exist, one will be created.
-// If it exists, its permissions are set to perms.
+// If it exists, its permissions are set to rules.
 func (c *neutronFirewaller) ensureGroup(name string, rules []neutron.RuleInfoV2) (neutron.SecurityGroupV2, error) {
 	neutronClient := c.environ.neutron()
+	var group neutron.SecurityGroupV2
+
 	// First attempt to look up an existing group by name.
 	groupsFound, err := neutronClient.SecurityGroupByNameV2(name)
-	if err == nil {
-		for _, group := range groupsFound {
-			if c.verifyGroupRules(group.Rules, rules) {
-				return group, nil
-			}
+	// a list is returned, but there should be only one
+	if err == nil && len(groupsFound) == 1 {
+		group = groupsFound[0]
+	} else if err != nil && strings.Contains(err.Error(), "failed to find security group") {
+		// TODO(hml): We should use a typed error here.  SecurityGroupByNameV2
+		// doesn't currently return one for this case.
+		g, err := neutronClient.CreateSecurityGroupV2(name, "juju group")
+		if err != nil {
+			return zeroGroup, err
 		}
-	}
-	// Doesn't exist, so try and create it.
-	newGroup, err := neutronClient.CreateSecurityGroupV2(name, "juju group")
-	if err != nil {
+		group = *g
+	} else if err == nil && len(groupsFound) > 1 {
+		// TODO(hml): Add unit test for this case
+		return zeroGroup, errors.New(fmt.Sprintf("More than one security group named %s was found", name))
+	} else {
 		return zeroGroup, err
 	}
-	// The new group is created so now add the rules.
-	for _, rule := range rules {
-		rule.ParentGroupId = newGroup.Id
+
+	have := newRuleInfoSetFromRules(group.Rules)
+	want := newRuleInfoSetFromRuleInfo(rules)
+
+	// Find rules we want to delete, that we have but don't want, and
+	// delete them.
+	remove := make(ruleInfoSet)
+	for k := range have {
+		// Neutron creates 2 egress rules with any new Security Group.
+		// Keep them.
+		if _, ok := want[k]; !ok && k.Direction != "egress" {
+			remove[k] = have[k]
+		}
+	}
+	for _, ruleId := range remove {
+		if err = neutronClient.DeleteSecurityGroupRuleV2(ruleId); err != nil {
+			return zeroGroup, err
+		}
+	}
+
+	// Find rules we want to add, that we want but don't have, and add
+	// them.
+	add := make(ruleInfoSet)
+	for k := range want {
+		if _, ok := have[k]; !ok {
+			add[k] = want[k]
+		}
+	}
+	for rule, _ := range add {
+		rule.ParentGroupId = group.Id
 		// Neutron translates empty RemoteIPPrefix into
 		// 0.0.0.0/0 or ::/0 instead of ParentGroupId
 		// when EthernetType is set
 		if rule.RemoteIPPrefix == "" {
-			rule.RemoteGroupId = newGroup.Id
+			rule.RemoteGroupId = group.Id
 		}
-		groupRule, err := neutronClient.CreateSecurityGroupRuleV2(rule)
-		if err != nil {
+		if _, err := neutronClient.CreateSecurityGroupRuleV2(rule); err != nil {
 			return zeroGroup, err
 		}
-		newGroup.Rules = append(newGroup.Rules, *groupRule)
 	}
-	return *newGroup, nil
+
+	// Since we may have done a few add or delete rules, get a new
+	// copy of the security group to return containing the end
+	// list of rules.
+	groupsFound, err = neutronClient.SecurityGroupByNameV2(name)
+	if err != nil {
+		return zeroGroup, err
+	} else if len(groupsFound) > 1 {
+		// TODO(hml): Add unit test for this case
+		return zeroGroup, errors.New(fmt.Sprintf("More than one security group named %s was found after group was ensured", name))
+	}
+	return groupsFound[0], nil
 }
 
-func countIngressRules(rules []neutron.SecurityGroupRuleV2) int {
-	count := 0
-	for _, rule := range rules {
-		if rule.Direction == "ingress" {
-			count += 1
+// ruleInfoSet represents a Security Group Rule created for a Security Group.
+// The string will be the Security Group Rule Id, if the rule has previously been
+// created.
+type ruleInfoSet map[neutron.RuleInfoV2]string
+
+// newRuleSetForGroup returns a set of all of the permissions in a given
+// slice of SecurityGroupRules.  It ignores the group id, the
+// remove group id, and tenant id.  Keep the rule id to delete the rule if
+// necessary.
+func newRuleInfoSetFromRules(rules []neutron.SecurityGroupRuleV2) ruleInfoSet {
+	m := make(ruleInfoSet)
+	for _, r := range rules {
+		k := neutron.RuleInfoV2{
+			Direction:      r.Direction,
+			EthernetType:   r.EthernetType,
+			RemoteIPPrefix: r.RemoteIPPrefix,
 		}
+		if r.IPProtocol != nil {
+			k.IPProtocol = *r.IPProtocol
+		}
+		if r.PortRangeMax != nil {
+			k.PortRangeMax = *r.PortRangeMax
+		}
+		if r.PortRangeMin != nil {
+			k.PortRangeMin = *r.PortRangeMin
+		}
+		m[k] = r.Id
 	}
-	return count
+	return m
 }
 
-// verifyGroupRules verifies the group rules against the rules we're looking for.
-func (c *neutronFirewaller) verifyGroupRules(rules []neutron.SecurityGroupRuleV2, rulesToMatch []neutron.RuleInfoV2) bool {
-	if countIngressRules(rules) != len(rulesToMatch) {
-		return false
-	}
-	count := len(rulesToMatch)
-	for _, rule := range rules {
-		// This is one of the default rules created when a new
-		// Neutron Security Group is created
-		if rule.Direction == "egress" {
-			continue
+// newRuleSetForGroup returns a set of all of the permissions in a given
+// slice of RuleInfo.  It ignores the rule id, the group id, the
+// remove group id, and tenant id.
+func newRuleInfoSetFromRuleInfo(rules []neutron.RuleInfoV2) ruleInfoSet {
+	m := make(ruleInfoSet)
+	for _, r := range rules {
+		k := neutron.RuleInfoV2{
+			Direction:      r.Direction,
+			IPProtocol:     r.IPProtocol,
+			PortRangeMin:   r.PortRangeMin,
+			PortRangeMax:   r.PortRangeMax,
+			EthernetType:   r.EthernetType,
+			RemoteIPPrefix: r.RemoteIPPrefix,
 		}
-		for _, toMatch := range rulesToMatch {
-			var maxInt int
-			if rule.PortRangeMax != nil {
-				maxInt = *rule.PortRangeMax
-			} else {
-				maxInt = 0
-			}
-			var minInt int
-			if rule.PortRangeMin != nil {
-				minInt = *rule.PortRangeMin
-			} else {
-				minInt = 0
-			}
-			if rule.Direction == toMatch.Direction &&
-				rule.RemoteIPPrefix == toMatch.RemoteIPPrefix &&
-				*rule.IPProtocol == toMatch.IPProtocol &&
-				minInt == toMatch.PortRangeMin &&
-				maxInt == toMatch.PortRangeMax {
-				count -= 1
-				break
-			}
-		}
+		m[k] = ""
 	}
-	if count != 0 {
-		return false
-	}
-	return true
+	return m
 }
 
 func (c *neutronFirewaller) deleteSecurityGroups(match func(name string) bool) error {

--- a/provider/openstack/local_test.go
+++ b/provider/openstack/local_test.go
@@ -1239,6 +1239,30 @@ func (s *localServerSuite) TestImageMetadataSourceOrder(c *gc.C) {
 		"image-metadata-url", "my datasource", "keystone catalog", "default cloud images", "default ubuntu cloud images"})
 }
 
+// To compare found and expected SecurityGroupRules, convert the rules to RuleInfo, minus
+// details we can't predict such as id.
+func ruleToRuleInfo(rules []neutron.SecurityGroupRuleV2) []neutron.RuleInfoV2 {
+	ruleInfo := make([]neutron.RuleInfoV2, 0, len(rules))
+	for _, r := range rules {
+		ri := neutron.RuleInfoV2{
+			Direction:      r.Direction,
+			EthernetType:   r.EthernetType,
+			RemoteIPPrefix: r.RemoteIPPrefix,
+		}
+		if r.IPProtocol != nil {
+			ri.IPProtocol = *r.IPProtocol
+		}
+		if r.PortRangeMax != nil {
+			ri.PortRangeMax = *r.PortRangeMax
+		}
+		if r.PortRangeMin != nil {
+			ri.PortRangeMin = *r.PortRangeMin
+		}
+		ruleInfo = append(ruleInfo, ri)
+	}
+	return ruleInfo
+}
+
 // TestEnsureGroup checks that when creating a duplicate security group, the existing group is
 // returned and the existing rules have been left as is.
 func (s *localServerSuite) TestEnsureGroup(c *gc.C) {
@@ -1248,35 +1272,64 @@ func (s *localServerSuite) TestEnsureGroup(c *gc.C) {
 			IPProtocol:   "tcp",
 			PortRangeMin: 22,
 			PortRangeMax: 22,
+			EthernetType: "IPv4",
 		},
-	}
-
-	assertRule := func(group neutron.SecurityGroupV2) {
-		c.Check(len(group.Rules), gc.Equals, 3)
-		for _, r := range group.Rules {
-			// Ignore the 2 default egress rules for each new
-			// security group created by Neutron
-			if r.Direction == "egress" {
-				continue
-			}
-			c.Check(r.Direction, gc.Equals, "ingress")
-			c.Check(*r.IPProtocol, gc.Equals, "tcp")
-			c.Check(*r.PortRangeMin, gc.Equals, 22)
-			c.Check(*r.PortRangeMax, gc.Equals, 22)
-		}
 	}
 
 	group, err := openstack.EnsureGroup(s.env, "test group", rule)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(group.Name, gc.Equals, "test group")
-	assertRule(group)
+
+	// Rules created by Neutron when a new Security Group is created
+	defaultRules := []neutron.RuleInfoV2{
+		{
+			Direction:    "egress",
+			EthernetType: "IPv4",
+		},
+		{
+			Direction:    "egress",
+			EthernetType: "IPv6",
+		},
+	}
+	expectedRules := append(defaultRules, rule[0])
+	obtainedRules := ruleToRuleInfo(group.Rules)
+	c.Check(obtainedRules, jc.SameContents, expectedRules)
 	id := group.Id
-	// Do it again and check that the existing group is returned.
+
+	// Do it again and check that the existing group is returned
+	// and updated.
+	rules := []neutron.RuleInfoV2{
+		{
+			Direction:    "ingress",
+			IPProtocol:   "tcp",
+			PortRangeMin: 22,
+			PortRangeMax: 22,
+			EthernetType: "IPv4",
+		},
+		{
+			Direction:    "ingress",
+			IPProtocol:   "icmp",
+			EthernetType: "IPv6",
+		},
+	}
+	group, err = openstack.EnsureGroup(s.env, "test group", rules)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(group.Id, gc.Equals, id)
+	c.Assert(group.Name, gc.Equals, "test group")
+	c.Check(len(group.Rules), gc.Equals, 4)
+	expectedRules = append(defaultRules, rules...)
+	obtainedRulesSecondTime := ruleToRuleInfo(group.Rules)
+	c.Check(obtainedRulesSecondTime, jc.SameContents, expectedRules)
+
+	// 3rd time with same name, should be back to the orginal now
 	group, err = openstack.EnsureGroup(s.env, "test group", rule)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(group.Id, gc.Equals, id)
 	c.Assert(group.Name, gc.Equals, "test group")
-	assertRule(group)
+	expectedRules = append(defaultRules, rule[0])
+	obtainedRulesThirdTime := ruleToRuleInfo(group.Rules)
+	c.Check(obtainedRulesThirdTime, jc.SameContents, expectedRules)
+	c.Check(obtainedRulesThirdTime, jc.SameContents, obtainedRules)
 }
 
 // localHTTPSServerSuite contains tests that run against an Openstack service


### PR DESCRIPTION
## Description of change

Improve method for verifying if a Security Group already exists before creating a new one.

## QA steps

1. Install juju 2.0.3
2. Bootstrap with the openstack provider
3. Deploy a charm to the default model, (I used ghost)
4. Install juju bits with these code changes.
5. upgrade-juju on the controller model
6. upgrade-juju on the default model
7. add-unit to the charm installed in step 3.

## Documentation changes

Not that I'm aware of

## Bug reference

Allowing duplicate secgroups via neutron breaks 2.0.3 models with 2.1 controllers:
https://bugs.launchpad.net/juju/2.1/+bug/1671265