### PR TITLE
state: check constraints when destroying storage

### DIFF
--- a/apiserver/storage/base_test.go
+++ b/apiserver/storage/base_test.go
@@ -88,7 +88,7 @@ const (
 	addStorageForUnitCall                   = "addStorageForUnit"
 	getBlockForTypeCall                     = "getBlockForType"
 	volumeAttachmentCall                    = "volumeAttachment"
-	destroyStorageAttachmentCall            = "destroyStorageAttachment"
+	detachStorageCall                       = "detachStorage"
 	destroyStorageInstanceCall              = "destroyStorageInstance"
 )
 
@@ -240,8 +240,8 @@ func (s *baseStorageSuite) constructState() *mockState {
 			val, found := s.blocks[t]
 			return val, found, nil
 		},
-		destroyStorageAttachment: func(storage names.StorageTag, unit names.UnitTag) error {
-			s.stub.AddCall(destroyStorageAttachmentCall, storage, unit)
+		detachStorage: func(storage names.StorageTag, unit names.UnitTag) error {
+			s.stub.AddCall(detachStorageCall, storage, unit)
 			if storage == s.storageTag && unit == s.unitTag {
 				return nil
 			}

--- a/apiserver/storage/mock_test.go
+++ b/apiserver/storage/mock_test.go
@@ -63,7 +63,7 @@ type mockState struct {
 	getBlockForType                     func(t state.BlockType) (state.Block, bool, error)
 	blockDevices                        func(names.MachineTag) ([]state.BlockDeviceInfo, error)
 	destroyStorageInstance              func(names.StorageTag) error
-	destroyStorageAttachment            func(names.StorageTag, names.UnitTag) error
+	detachStorage                       func(names.StorageTag, names.UnitTag) error
 }
 
 func (st *mockState) StorageInstance(s names.StorageTag) (state.StorageInstance, error) {
@@ -169,8 +169,8 @@ func (st *mockState) BlockDevices(m names.MachineTag) ([]state.BlockDeviceInfo, 
 	return []state.BlockDeviceInfo{}, nil
 }
 
-func (st *mockState) DestroyStorageAttachment(storage names.StorageTag, unit names.UnitTag) error {
-	return st.destroyStorageAttachment(storage, unit)
+func (st *mockState) DetachStorage(storage names.StorageTag, unit names.UnitTag) error {
+	return st.detachStorage(storage, unit)
 }
 
 func (st *mockState) DestroyStorageInstance(tag names.StorageTag) error {

--- a/apiserver/storage/shim.go
+++ b/apiserver/storage/shim.go
@@ -114,9 +114,9 @@ type storageAccess interface {
 	// GetBlockForType is required to block operations.
 	GetBlockForType(t state.BlockType) (state.Block, bool, error)
 
-	// DestroyStorageAttachment detaches the storage instance with the
+	// DetachStorage detaches the storage instance with the
 	// specified tag from the unit with the specified tag.
-	DestroyStorageAttachment(names.StorageTag, names.UnitTag) error
+	DetachStorage(names.StorageTag, names.UnitTag) error
 
 	// DestroyStorageInstance destroys the storage instance with the specified tag.
 	DestroyStorageInstance(names.StorageTag) error

--- a/apiserver/storage/storage.go
+++ b/apiserver/storage/storage.go
@@ -797,7 +797,7 @@ func (api *API) detachStorage(storageTag names.StorageTag, unitTag names.UnitTag
 	if unitTag != (names.UnitTag{}) {
 		// The caller has specified a unit explicitly. Do
 		// not filter out "not found" errors in this case.
-		return api.storage.DestroyStorageAttachment(storageTag, unitTag)
+		return api.storage.DetachStorage(storageTag, unitTag)
 	}
 	attachments, err := api.storage.StorageAttachments(storageTag)
 	if err != nil {
@@ -813,7 +813,7 @@ func (api *API) detachStorage(storageTag names.StorageTag, unitTag names.UnitTag
 		if a.Life() != state.Alive {
 			continue
 		}
-		err := api.storage.DestroyStorageAttachment(storageTag, a.Unit())
+		err := api.storage.DetachStorage(storageTag, a.Unit())
 		if err != nil && !errors.IsNotFound(err) {
 			// We only care about NotFound errors if
 			// the user specified a unit explicitly.

--- a/apiserver/storage/storage_test.go
+++ b/apiserver/storage/storage_test.go
@@ -366,15 +366,15 @@ func (s *storageSuite) TestDetach(c *gc.C) {
 	})
 	s.assertCalls(c, []string{
 		getBlockForTypeCall, // Change
-		destroyStorageAttachmentCall,
+		detachStorageCall,
 		storageInstanceAttachmentsCall,
-		destroyStorageAttachmentCall,
+		detachStorageCall,
 	})
 	s.stub.CheckCalls(c, []testing.StubCall{
 		{getBlockForTypeCall, []interface{}{state.ChangeBlock}},
-		{destroyStorageAttachmentCall, []interface{}{s.storageTag, s.unitTag}},
+		{detachStorageCall, []interface{}{s.storageTag, s.unitTag}},
 		{storageInstanceAttachmentsCall, []interface{}{s.storageTag}},
-		{destroyStorageAttachmentCall, []interface{}{s.storageTag, s.unitTag}},
+		{detachStorageCall, []interface{}{s.storageTag, s.unitTag}},
 	})
 }
 
@@ -392,11 +392,11 @@ func (s *storageSuite) TestDetachSpecifiedNotFound(c *gc.C) {
 	})
 	s.assertCalls(c, []string{
 		getBlockForTypeCall, // Change
-		destroyStorageAttachmentCall,
+		detachStorageCall,
 	})
 	s.stub.CheckCalls(c, []testing.StubCall{
 		{getBlockForTypeCall, []interface{}{state.ChangeBlock}},
-		{destroyStorageAttachmentCall, []interface{}{
+		{detachStorageCall, []interface{}{
 			s.storageTag,
 			names.NewUnitTag("foo/42"),
 		}},
@@ -409,8 +409,8 @@ func (s *storageSuite) TestDetachAttachmentNotFoundConcurrent(c *gc.C) {
 	//     a list of alive attachments
 	//  2. attachment is concurrently destroyed
 	//     and removed by another process
-	s.state.destroyStorageAttachment = func(sTag names.StorageTag, uTag names.UnitTag) error {
-		s.stub.AddCall(destroyStorageAttachmentCall, sTag, uTag)
+	s.state.detachStorage = func(sTag names.StorageTag, uTag names.UnitTag) error {
+		s.stub.AddCall(detachStorageCall, sTag, uTag)
 		return errors.NotFoundf(
 			"attachment of %s to %s",
 			names.ReadableString(sTag),
@@ -426,12 +426,12 @@ func (s *storageSuite) TestDetachAttachmentNotFoundConcurrent(c *gc.C) {
 	s.assertCalls(c, []string{
 		getBlockForTypeCall, // Change
 		storageInstanceAttachmentsCall,
-		destroyStorageAttachmentCall,
+		detachStorageCall,
 	})
 	s.stub.CheckCalls(c, []testing.StubCall{
 		{getBlockForTypeCall, []interface{}{state.ChangeBlock}},
 		{storageInstanceAttachmentsCall, []interface{}{s.storageTag}},
-		{destroyStorageAttachmentCall, []interface{}{s.storageTag, s.unitTag}},
+		{detachStorageCall, []interface{}{s.storageTag, s.unitTag}},
 	})
 }
 

--- a/featuretests/storage_test.go
+++ b/featuretests/storage_test.go
@@ -529,7 +529,7 @@ func (s *cmdStorageSuite) TestStorageAddToUnitStorageDoesntExist(c *gc.C) {
 	c.Assert(errors.Cause(err), gc.ErrorMatches, "cmd: error out silently")
 	c.Assert(testing.Stdout(context), gc.Equals, "")
 	c.Assert(testing.Stderr(context), gc.Equals,
-		`failed to add "nonstorage": adding storage to unit storage-block/0: charm storage "nonstorage" not found`+"\n",
+		`failed to add "nonstorage": adding "nonstorage" storage to storage-block/0: charm storage "nonstorage" not found`+"\n",
 	)
 
 	instancesAfter, err := s.State.AllStorageInstances()

--- a/state/application_test.go
+++ b/state/application_test.go
@@ -1794,7 +1794,7 @@ func (s *ApplicationSuite) TestDestroyWithPlaceholderResources(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	// No cleanup required for placeholder resources.
-	state.AssertNoCleanups(c, s.State, state.CleanupKindResourceBlob)
+	state.AssertNoCleanupsWithKind(c, s.State, state.CleanupKindResourceBlob)
 }
 
 func (s *ApplicationSuite) TestReadUnitWithChangingState(c *gc.C) {

--- a/state/cleanup.go
+++ b/state/cleanup.go
@@ -399,7 +399,7 @@ func (st *State) cleanupUnitStorageAttachments(unitTag names.UnitTag, remove boo
 	}
 	for _, storageAttachment := range storageAttachments {
 		storageTag := storageAttachment.StorageInstance()
-		err := st.DestroyStorageAttachment(storageTag, unitTag)
+		err := st.DetachStorage(storageTag, unitTag)
 		if errors.IsNotFound(err) {
 			continue
 		} else if err != nil {
@@ -637,7 +637,7 @@ func (st *State) cleanupAttachmentsForDyingStorage(storageId string) (err error)
 	defer closeIter(iter, &err, "reading storage attachment document")
 	for iter.Next(&doc) {
 		unitTag := names.NewUnitTag(doc.Unit)
-		if err := st.DestroyStorageAttachment(storageTag, unitTag); err != nil {
+		if err := st.DetachStorage(storageTag, unitTag); err != nil {
 			return errors.Annotate(err, "destroying storage attachment")
 		}
 	}

--- a/state/cleanup_test.go
+++ b/state/cleanup_test.go
@@ -609,7 +609,7 @@ func (s *CleanupSuite) TestCleanupStorageAttachments(c *gc.C) {
 func (s *CleanupSuite) TestCleanupStorageInstances(c *gc.C) {
 	ch := s.AddTestingCharm(c, "storage-block")
 	storage := map[string]state.StorageConstraints{
-		"data": makeStorageCons("loop", 1024, 1),
+		"allecto": makeStorageCons("modelscoped-block", 1024, 1),
 	}
 	application := s.AddTestingServiceWithStorage(c, "storage-block", ch, storage)
 	u, err := application.AddUnit()
@@ -619,7 +619,7 @@ func (s *CleanupSuite) TestCleanupStorageInstances(c *gc.C) {
 	s.assertDoesNotNeedCleanup(c)
 
 	// this tag matches the storage instance created for the unit above.
-	storageTag := names.NewStorageTag("data/0")
+	storageTag := names.NewStorageTag("allecto/0")
 
 	si, err := s.State.StorageInstance(storageTag)
 	c.Assert(err, jc.ErrorIsNil)
@@ -631,17 +631,15 @@ func (s *CleanupSuite) TestCleanupStorageInstances(c *gc.C) {
 	si, err = s.State.StorageInstance(storageTag)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(si.Life(), gc.Equals, state.Dying)
-	sa, err := s.State.UnitStorageAttachments(u.UnitTag())
+	sa, err := s.State.StorageAttachment(storageTag, u.UnitTag())
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(sa, gc.HasLen, 1)
-	c.Assert(sa[0].Life(), gc.Equals, state.Alive)
+	c.Assert(sa.Life(), gc.Equals, state.Alive)
 	s.assertCleanupRuns(c)
 
 	// After running the cleanup, the attachment should be dying.
-	sa, err = s.State.UnitStorageAttachments(u.UnitTag())
+	sa, err = s.State.StorageAttachment(storageTag, u.UnitTag())
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(sa, gc.HasLen, 1)
-	c.Assert(sa[0].Life(), gc.Equals, state.Dying)
+	c.Assert(sa.Life(), gc.Equals, state.Dying)
 
 	// check no cleanups
 	s.assertDoesNotNeedCleanup(c)
@@ -745,9 +743,7 @@ func (s *CleanupSuite) assertNeedsCleanup(c *gc.C) {
 }
 
 func (s *CleanupSuite) assertDoesNotNeedCleanup(c *gc.C) {
-	actual, err := s.State.NeedsCleanup()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(actual, jc.IsFalse)
+	state.AssertNoCleanups(c, s.State)
 }
 
 // assertCleanupCount is useful because certain cleanups cause other cleanups

--- a/state/export_test.go
+++ b/state/export_test.go
@@ -622,9 +622,9 @@ func IsBlobStored(c *gc.C, st *State, storagePath string) bool {
 	return true
 }
 
-// AssertNoCleanups checks that there are no cleanups scheduled of a
-// given kind.
-func AssertNoCleanups(c *gc.C, st *State, kind cleanupKind) {
+// AssertNoCleanupsWithKind checks that there are no cleanups
+// of a given kind scheduled.
+func AssertNoCleanupsWithKind(c *gc.C, st *State, kind cleanupKind) {
 	var docs []cleanupDoc
 	cleanups, closer := st.getCollection(cleanupsC)
 	defer closer()
@@ -634,6 +634,18 @@ func AssertNoCleanups(c *gc.C, st *State, kind cleanupKind) {
 		if doc.Kind == kind {
 			c.Fatalf("found cleanup of kind %q", kind)
 		}
+	}
+}
+
+// AssertNoCleanups checks that there are no cleanups scheduled.
+func AssertNoCleanups(c *gc.C, st *State) {
+	var docs []cleanupDoc
+	cleanups, closer := st.getCollection(cleanupsC)
+	defer closer()
+	err := cleanups.Find(nil).All(&docs)
+	c.Assert(err, jc.ErrorIsNil)
+	if len(docs) > 0 {
+		c.Fatalf("unexpected cleanups: %+v", docs)
 	}
 }
 

--- a/state/filesystem_test.go
+++ b/state/filesystem_test.go
@@ -465,7 +465,7 @@ func (s *FilesystemStateSuite) TestRemoveStorageInstanceDestroysAndUnassignsFile
 
 	err := s.State.DestroyStorageInstance(storageTag)
 	c.Assert(err, jc.ErrorIsNil)
-	err = s.State.DestroyStorageAttachment(storageTag, unitTag)
+	err = s.State.DetachStorage(storageTag, unitTag)
 	c.Assert(err, jc.ErrorIsNil)
 
 	// The storage instance and attachment are dying, but not yet

--- a/state/filesystem_test.go
+++ b/state/filesystem_test.go
@@ -36,7 +36,7 @@ func (s *FilesystemStateSuite) TestAddServiceNoPoolNoDefault(c *gc.C) {
 
 func (s *FilesystemStateSuite) TestAddServiceNoPoolNoDefaultWithUnits(c *gc.C) {
 	// no pool specified, no default configured: use rootfs, add a unit during
-	// service deploy.
+	// app deploy.
 	s.testAddServiceDefaultPool(c, "rootfs", 1)
 }
 
@@ -164,8 +164,8 @@ func (s *FilesystemStateSuite) addUnitWithFilesystem(c *gc.C, pool string, withV
 	storage := map[string]state.StorageConstraints{
 		"data": makeStorageCons(pool, 1024, 1),
 	}
-	service := s.AddTestingServiceWithStorage(c, "storage-filesystem", ch, storage)
-	unit, err := service.AddUnit()
+	app := s.AddTestingServiceWithStorage(c, "storage-filesystem", ch, storage)
+	unit, err := app.AddUnit()
 	c.Assert(err, jc.ErrorIsNil)
 	err = s.State.AssignUnit(unit, state.AssignCleanEmpty)
 	c.Assert(err, jc.ErrorIsNil)
@@ -308,9 +308,9 @@ func (s *FilesystemStateSuite) TestVolumeBackedFilesystemScope(c *gc.C) {
 }
 
 func (s *FilesystemStateSuite) TestWatchModelFilesystems(c *gc.C) {
-	service := s.setupMixedScopeStorageService(c, "filesystem")
+	app := s.setupMixedScopeStorageApplication(c, "filesystem")
 	addUnit := func() {
-		u, err := service.AddUnit()
+		u, err := app.AddUnit()
 		c.Assert(err, jc.ErrorIsNil)
 		err = s.State.AssignUnit(u, state.AssignCleanEmpty)
 		c.Assert(err, jc.ErrorIsNil)
@@ -332,9 +332,9 @@ func (s *FilesystemStateSuite) TestWatchModelFilesystems(c *gc.C) {
 }
 
 func (s *FilesystemStateSuite) TestWatchEnvironFilesystemAttachments(c *gc.C) {
-	service := s.setupMixedScopeStorageService(c, "filesystem")
+	app := s.setupMixedScopeStorageApplication(c, "filesystem")
 	addUnit := func() {
-		u, err := service.AddUnit()
+		u, err := app.AddUnit()
 		c.Assert(err, jc.ErrorIsNil)
 		err = s.State.AssignUnit(u, state.AssignCleanEmpty)
 		c.Assert(err, jc.ErrorIsNil)
@@ -356,9 +356,9 @@ func (s *FilesystemStateSuite) TestWatchEnvironFilesystemAttachments(c *gc.C) {
 }
 
 func (s *FilesystemStateSuite) TestWatchMachineFilesystems(c *gc.C) {
-	service := s.setupMixedScopeStorageService(c, "filesystem")
+	app := s.setupMixedScopeStorageApplication(c, "filesystem")
 	addUnit := func() {
-		u, err := service.AddUnit()
+		u, err := app.AddUnit()
 		c.Assert(err, jc.ErrorIsNil)
 		err = s.State.AssignUnit(u, state.AssignCleanEmpty)
 		c.Assert(err, jc.ErrorIsNil)
@@ -380,12 +380,10 @@ func (s *FilesystemStateSuite) TestWatchMachineFilesystems(c *gc.C) {
 }
 
 func (s *FilesystemStateSuite) TestWatchMachineFilesystemAttachments(c *gc.C) {
-	service := s.setupMixedScopeStorageService(
-		c, "filesystem", "machinescoped", "modelscoped",
-	)
+	app := s.setupMixedScopeStorageApplication(c, "filesystem", "machinescoped", "modelscoped")
 	addUnit := func(to *state.Machine) (u *state.Unit, m *state.Machine) {
 		var err error
-		u, err = service.AddUnit()
+		u, err = app.AddUnit()
 		c.Assert(err, jc.ErrorIsNil)
 		if to != nil {
 			err = u.AssignToMachine(to)
@@ -876,8 +874,8 @@ func (s *FilesystemStateSuite) testFilesystemAttachmentParams(
 		"data": makeStorageCons("rootfs", 1024, 1),
 	}
 
-	service := s.AddTestingServiceWithStorage(c, "storage-filesystem", ch, storage)
-	unit, err := service.AddUnit()
+	app := s.AddTestingServiceWithStorage(c, "storage-filesystem", ch, storage)
+	unit, err := app.AddUnit()
 	c.Assert(err, jc.ErrorIsNil)
 	err = s.State.AssignUnit(unit, state.AssignCleanEmpty)
 	c.Assert(err, jc.ErrorIsNil)
@@ -926,8 +924,8 @@ func (s *FilesystemStateSuite) testFilesystemAttachmentParamsConcurrent(c *gc.C,
 			CountMax: 1,
 			Location: location,
 		}, rev)
-		service := s.AddTestingServiceWithStorage(c, applicationname, ch, storage)
-		unit, err := service.AddUnit()
+		app := s.AddTestingServiceWithStorage(c, applicationname, ch, storage)
+		unit, err := app.AddUnit()
 		c.Assert(err, jc.ErrorIsNil)
 		return unit.AssignToMachine(machine)
 	}
@@ -956,8 +954,8 @@ func (s *FilesystemStateSuite) TestFilesystemAttachmentParamsConcurrentRemove(c 
 		CountMax: 1,
 		Location: "/not/in/srv",
 	})
-	service := s.AddTestingService(c, "storage-filesystem", ch)
-	unit, err := service.AddUnit()
+	app := s.AddTestingService(c, "storage-filesystem", ch)
+	unit, err := app.AddUnit()
 	c.Assert(err, jc.ErrorIsNil)
 
 	defer state.SetBeforeHooks(c, s.State, func() {
@@ -981,8 +979,8 @@ func (s *FilesystemStateSuite) TestFilesystemAttachmentParamsLocationStorageDir(
 		CountMax: 1,
 		Location: "/var/lib/juju/storage",
 	})
-	service := s.AddTestingService(c, "storage-filesystem", ch)
-	unit, err := service.AddUnit()
+	app := s.AddTestingService(c, "storage-filesystem", ch)
+	unit, err := app.AddUnit()
 	c.Assert(err, jc.ErrorIsNil)
 	err = s.State.AssignUnit(unit, state.AssignCleanEmpty)
 	c.Assert(err, gc.ErrorMatches, `cannot assign unit \"storage-filesystem/0\" to machine: `+

--- a/state/storage.go
+++ b/state/storage.go
@@ -673,7 +673,7 @@ func (st *State) storageAttachment(storage names.StorageTag, unit names.UnitTag)
 	return &s, nil
 }
 
-// DestroyStorageAttachment ensures that the existing storage attachments of
+// DetachStorage ensures that the existing storage attachments of
 // the specified unit are removed at some point.
 func (st *State) DestroyUnitStorageAttachments(unit names.UnitTag) (err error) {
 	defer errors.DeferredAnnotatef(&err, "cannot destroy unit %s storage attachments", unit.Id())
@@ -699,9 +699,9 @@ func (st *State) DestroyUnitStorageAttachments(unit names.UnitTag) (err error) {
 	return st.run(buildTxn)
 }
 
-// DestroyStorageAttachment ensures that the storage attachment will be
+// DetachStorage ensures that the storage attachment will be
 // removed at some point.
-func (st *State) DestroyStorageAttachment(storage names.StorageTag, unit names.UnitTag) (err error) {
+func (st *State) DetachStorage(storage names.StorageTag, unit names.UnitTag) (err error) {
 	defer errors.DeferredAnnotatef(&err, "cannot destroy storage attachment %s:%s", storage.Id(), unit.Id())
 	buildTxn := func(attempt int) ([]txn.Op, error) {
 		s, err := st.storageAttachment(storage, unit)

--- a/state/storage.go
+++ b/state/storage.go
@@ -277,8 +277,24 @@ func (st *State) destroyStorageInstanceOps(s *storageInstance) ([]txn.Op, error)
 		// remove the storage instance immediately.
 		hasNoAttachments := bson.D{{"attachmentcount", 0}}
 		assert := append(hasNoAttachments, isAliveDoc...)
-		return removeStorageInstanceOps(st, s.maybeOwner(), s.StorageTag(), assert)
+		return removeStorageInstanceOps(s, assert)
 	}
+
+	// Check that removing the storage from its owner (if any) is permitted.
+	owner := s.maybeOwner()
+	var validateRemoveOps []txn.Op
+	var ownerAssert bson.DocElem
+	if owner != nil {
+		var err error
+		validateRemoveOps, err = validateRemoveOwnerStorageInstanceOps(s)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		ownerAssert = bson.DocElem{"owner", owner.String()}
+	} else {
+		ownerAssert = bson.DocElem{"owner", bson.D{{"$exists", false}}}
+	}
+
 	// There are still attachments: the storage instance will be removed
 	// when the last attachment is removed. We schedule a cleanup to destroy
 	// attachments.
@@ -289,37 +305,51 @@ func (st *State) destroyStorageInstanceOps(s *storageInstance) ([]txn.Op, error)
 	update := bson.D{{"$set", bson.D{{"life", Dying}}}}
 	ops := []txn.Op{
 		newCleanupOp(cleanupAttachmentsForDyingStorage, s.doc.Id),
-		{
-			C:      storageInstancesC,
-			Id:     s.doc.Id,
-			Assert: notLastRefs,
-			Update: update,
-		},
 	}
+	ops = append(ops, validateRemoveOps...)
+	ops = append(ops, txn.Op{
+		C:      storageInstancesC,
+		Id:     s.doc.Id,
+		Assert: append(notLastRefs, ownerAssert),
+		Update: update,
+	})
 	return ops, nil
 }
 
 // removeStorageInstanceOps removes the storage instance with the given
 // tag from state, if the specified assertions hold true.
 func removeStorageInstanceOps(
-	st *State,
-	owner names.Tag,
-	tag names.StorageTag,
+	si *storageInstance,
 	assert bson.D,
 ) ([]txn.Op, error) {
 
+	// Remove the storage instance document, ensuring the owner does not
+	// change from what's passed in.
+	owner := si.maybeOwner()
+	var ownerAssert bson.DocElem
+	if owner != nil {
+		ownerAssert = bson.DocElem{"owner", owner.String()}
+	} else {
+		ownerAssert = bson.DocElem{"owner", bson.D{{"$exists", false}}}
+	}
 	ops := []txn.Op{{
 		C:      storageInstancesC,
-		Id:     tag.Id(),
-		Assert: assert,
+		Id:     si.doc.Id,
+		Assert: append(assert, ownerAssert),
 		Remove: true,
 	}}
 	if owner != nil {
-		storageName, err := names.StorageName(tag.Id())
+		// Ensure that removing the storage will not violate the
+		// owner's charm storage requirements.
+		validateRemoveOps, err := validateRemoveOwnerStorageInstanceOps(si)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
-		decrefOp, err := decrefEntityStorageOp(st, owner, storageName)
+		ops = append(ops, validateRemoveOps...)
+
+		// Decrement the owner's count for the storage name, freeing
+		// up a slot for a new storage instance to be attached.
+		decrefOp, err := decrefEntityStorageOp(si.st, owner, si.StorageName())
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
@@ -330,7 +360,7 @@ func removeStorageInstanceOps(
 		return txn.Op{
 			C:      c,
 			Id:     id,
-			Assert: bson.D{{"storageid", tag.Id()}},
+			Assert: bson.D{{"storageid", si.doc.Id}},
 			Update: bson.D{{"$unset", bson.D{{"storageid", nil}}}},
 		}
 	}
@@ -339,12 +369,12 @@ func removeStorageInstanceOps(
 	// reference to avoid a dangling pointer while the volume/filesystem
 	// is being destroyed.
 	var haveFilesystem bool
-	filesystem, err := st.storageInstanceFilesystem(tag)
+	filesystem, err := si.st.storageInstanceFilesystem(si.StorageTag())
 	if err == nil {
 		ops = append(ops, machineStorageOp(
 			filesystemsC, filesystem.Tag().Id(),
 		))
-		fsOps, err := destroyFilesystemOps(st, filesystem, nil)
+		fsOps, err := destroyFilesystemOps(si.st, filesystem, nil)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
@@ -353,7 +383,7 @@ func removeStorageInstanceOps(
 	} else if !errors.IsNotFound(err) {
 		return nil, errors.Trace(err)
 	}
-	volume, err := st.storageInstanceVolume(tag)
+	volume, err := si.st.storageInstanceVolume(si.StorageTag())
 	if err == nil {
 		ops = append(ops, machineStorageOp(
 			volumesC, volume.Tag().Id(),
@@ -363,7 +393,7 @@ func removeStorageInstanceOps(
 		// this case, we want to destroy only the filesystem; when
 		// the filesystem is removed, the volume will be destroyed.
 		if !haveFilesystem {
-			volOps, err := destroyVolumeOps(st, volume, nil)
+			volOps, err := destroyVolumeOps(si.st, volume, nil)
 			if err != nil {
 				return nil, errors.Trace(err)
 			}
@@ -374,6 +404,102 @@ func removeStorageInstanceOps(
 	}
 
 	return ops, nil
+}
+
+// validateRemoveOwnerStorageInstanceOps checks that the given storage
+// instance can be removed from its current owner, returning txn.Ops to
+// ensure the same in a transaction. If the owner is not alive, then charm
+// storage requirements are ignored.
+func validateRemoveOwnerStorageInstanceOps(si *storageInstance) ([]txn.Op, error) {
+	var ops []txn.Op
+	var charmMeta *charm.Meta
+	owner := si.maybeOwner()
+	switch owner.Kind() {
+	case names.ApplicationTagKind:
+		app, err := si.st.Application(owner.Id())
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		if app.Life() != Alive {
+			return nil, nil
+		}
+		ch, _, err := app.Charm()
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		charmMeta = ch.Meta()
+		ops = append(ops, txn.Op{
+			C:  applicationsC,
+			Id: app.Name(),
+			Assert: bson.D{
+				{"life", Alive},
+				{"charmurl", ch.URL},
+			},
+		})
+	case names.UnitTagKind:
+		u, err := si.st.Unit(owner.Id())
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		if u.Life() != Alive {
+			return nil, nil
+		}
+		ch, err := u.charm()
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		charmMeta = ch.Meta()
+		ops = append(ops, txn.Op{
+			C:      unitsC,
+			Id:     u.doc.Name,
+			Assert: bson.D{{"life", Alive}},
+		})
+		ops = append(ops, u.assertCharmOps(ch)...)
+	default:
+		return nil, errors.Errorf(
+			"invalid storage owner %s",
+			names.ReadableString(owner),
+		)
+	}
+	_, currentCountOp, err := validateStorageCountChange(
+		si.st, owner, si.StorageName(), -1, charmMeta,
+	)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	ops = append(ops, currentCountOp)
+	return ops, nil
+}
+
+// validateStorageCountChange validates the desired storage count change,
+// and returns the current storage count, and a txn.Op that ensures the
+// current storage count does not change before the transaction is executed.
+func validateStorageCountChange(
+	st *State, owner names.Tag,
+	storageName string, n int,
+	charmMeta *charm.Meta,
+) (current int, _ txn.Op, _ error) {
+	currentCountOp, currentCount, err := st.countEntityStorageInstances(owner, storageName)
+	if err != nil {
+		return -1, txn.Op{}, errors.Trace(err)
+	}
+	charmStorage := charmMeta.Storage[storageName]
+	if err := validateCharmStorageCountChange(charmStorage, currentCount, n); err != nil {
+		return -1, txn.Op{}, errors.Trace(err)
+	}
+	return currentCount, currentCountOp, nil
+}
+
+// increfEntityStorageOp returns a txn.Op that increments the reference
+// count for a storage instance for a given application or unit. This
+// should be called when creating a shared storage instance, or when
+// attaching a non-shared storage instance to a unit.
+func increfEntityStorageOp(st *State, owner names.Tag, storageName string, n int) (txn.Op, error) {
+	refcounts, closer := st.getCollection(refcountsC)
+	defer closer()
+	storageRefcountKey := entityStorageRefcountKey(owner, storageName)
+	incRefOp, err := nsRefcounts.CreateOrIncRefOp(refcounts, storageRefcountKey, n)
+	return incRefOp, errors.Trace(err)
 }
 
 // decrefEntityStorageOp returns a txn.Op that decrements the reference
@@ -469,9 +595,6 @@ func createStorageOps(
 		})
 	}
 
-	refcounts, closer := st.getCollection(refcountsC)
-	defer closer()
-
 	ops = make([]txn.Op, 0, len(templates)*3)
 	for _, t := range templates {
 		owner := entityTag.String()
@@ -489,8 +612,7 @@ func createStorageOps(
 		// instance we create. We'll use the reference counts to ensure
 		// we don't exceed limits when adding storage, and for
 		// maintaining model integrity during charm upgrades.
-		storageRefcountKey := entityStorageRefcountKey(entityTag, t.storageName)
-		incRefOp, err := nsRefcounts.CreateOrIncRefOp(refcounts, storageRefcountKey, int(t.cons.Count))
+		incRefOp, err := increfEntityStorageOp(st, entityTag, t.storageName, int(t.cons.Count))
 		if err != nil {
 			return nil, -1, errors.Trace(err)
 		}
@@ -687,7 +809,7 @@ func (st *State) DestroyUnitStorageAttachments(unit names.UnitTag) (err error) {
 			if attachment.Life() != Alive {
 				continue
 			}
-			ops = append(ops, destroyStorageAttachmentOps(
+			ops = append(ops, detachStorageOps(
 				attachment.StorageInstance(), unit,
 			)...)
 		}
@@ -713,12 +835,37 @@ func (st *State) DetachStorage(storage names.StorageTag, unit names.UnitTag) (er
 		if s.doc.Life == Dying {
 			return nil, jujutxn.ErrNoOperations
 		}
-		return destroyStorageAttachmentOps(storage, unit), nil
+		si, err := st.storageInstance(storage)
+		if err != nil {
+			return nil, jujutxn.ErrNoOperations
+		}
+		var ops []txn.Op
+		var ownerAssert bson.DocElem
+		switch owner := si.maybeOwner(); owner {
+		case nil:
+			ownerAssert = bson.DocElem{"owner", bson.D{{"$exists", false}}}
+		case unit:
+			validateRemoveOps, err := validateRemoveOwnerStorageInstanceOps(si)
+			if err != nil {
+				return nil, errors.Trace(err)
+			}
+			ops = append(ops, validateRemoveOps...)
+			fallthrough
+		default:
+			ownerAssert = bson.DocElem{"owner", si.doc.Owner}
+		}
+		ops = append(ops, txn.Op{
+			C:      storageInstancesC,
+			Id:     si.doc.Id,
+			Assert: bson.D{ownerAssert},
+		})
+		ops = append(ops, detachStorageOps(storage, unit)...)
+		return ops, nil
 	}
 	return st.run(buildTxn)
 }
 
-func destroyStorageAttachmentOps(storage names.StorageTag, unit names.UnitTag) []txn.Op {
+func detachStorageOps(storage names.StorageTag, unit names.UnitTag) []txn.Op {
 	ops := []txn.Op{{
 		C:      storageAttachmentsC,
 		Id:     storageAttachmentId(unit.Id(), storage.Id()),
@@ -776,6 +923,7 @@ func removeStorageAttachmentOps(
 		Assert: txn.DocExists,
 		Update: bson.D{{"$inc", bson.D{{"storageattachmentcount", -1}}}},
 	}}
+	var siAssert interface{}
 	siUpdate := bson.D{{"$inc", bson.D{{"attachmentcount", -1}}}}
 	if si.doc.AttachmentCount == 1 {
 		var hasLastRef bson.D
@@ -784,6 +932,15 @@ func removeStorageAttachmentOps(
 			// can be added to the instance, so it can be removed.
 			hasLastRef = bson.D{{"life", Dying}, {"attachmentcount", 1}}
 		} else if si.doc.Owner == names.NewUnitTag(s.doc.Unit).String() {
+			// Ensure that removing the storage will not violate the
+			// unit's charm storage requirements.
+			siAssert = bson.D{{"owner", si.doc.Owner}}
+			validateRemoveOps, err := validateRemoveOwnerStorageInstanceOps(si)
+			if err != nil {
+				return nil, errors.Trace(err)
+			}
+			ops = append(ops, validateRemoveOps...)
+
 			// TODO(axw) if the storage instance is Alive, and is owned by
 			// the unit, disown the storage and decrement the refcount for
 			// the storage name on the unit. This will allow the user to
@@ -794,9 +951,7 @@ func removeStorageAttachmentOps(
 			// TODO(axw) we should only remove the storage instance
 			// when the last attachment is removed if the instance
 			// is dying.
-			siOps, err := removeStorageInstanceOps(
-				st, si.maybeOwner(), si.StorageTag(), hasLastRef,
-			)
+			siOps, err := removeStorageInstanceOps(si, hasLastRef)
 			if err != nil {
 				return nil, errors.Trace(err)
 			}
@@ -806,6 +961,7 @@ func removeStorageAttachmentOps(
 	decrefOp := txn.Op{
 		C:      storageInstancesC,
 		Id:     si.doc.Id,
+		Assert: siAssert,
 		Update: siUpdate,
 	}
 	if si.doc.Life == Alive {
@@ -827,7 +983,134 @@ func removeStorageAttachmentOps(
 		}
 	}
 	ops = append(ops, decrefOp)
+
+	// If the storage instance has an associated volume or
+	// filesystem, and the unit is assigned to a machine,
+	// detach the volume/filesystem too.
+	machineOps, err := st.detachStorageMachineAttachmentOps(si, s.Unit())
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	ops = append(ops, machineOps...)
+
 	return ops, nil
+}
+
+func (st *State) detachStorageMachineAttachmentOps(si *storageInstance, unitTag names.UnitTag) ([]txn.Op, error) {
+	unit, err := st.Unit(unitTag.Id())
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	machineId, err := unit.AssignedMachineId()
+	if errors.IsNotAssigned(err) {
+		return []txn.Op{unit.noAssignedMachineOp()}, nil
+	} else if err != nil {
+		return nil, errors.Trace(err)
+	}
+	machineTag := names.NewMachineTag(machineId)
+
+	switch si.Kind() {
+	case StorageKindBlock:
+		volume, err := st.storageInstanceVolume(si.StorageTag())
+		if errors.IsNotFound(err) {
+			// The volume has already been removed, so must have
+			// already been detached.
+			logger.Debugf("%s", err)
+			return nil, nil
+		} else if err != nil {
+			return nil, errors.Trace(err)
+		} else if !volume.detachable() {
+			// Non-detachable volumes are left attached to the
+			// machine, since the only other option is to destroy
+			// them. The user can remove them explicitly, or else
+			// leave them to be removed along with the machine.
+			logger.Debugf(
+				"%s for %s is non-detachable",
+				names.ReadableString(volume.Tag()),
+				names.ReadableString(si.StorageTag()),
+			)
+			return nil, nil
+		} else if volume.Life() != Alive {
+			// The volume is not alive, so either is already
+			// or will soon be detached.
+			logger.Debugf(
+				"%s is %s",
+				names.ReadableString(volume.Tag()),
+				volume.Life(),
+			)
+			return nil, nil
+		}
+		att, err := st.VolumeAttachment(machineTag, volume.VolumeTag())
+		if errors.IsNotFound(err) {
+			// Since the storage attachment is Dying, it is not
+			// possible to create a volume attachment for the
+			// machine, associated with the same storage.
+			logger.Debugf("%s", err)
+			return nil, nil
+		} else if err != nil {
+			return nil, errors.Trace(err)
+		}
+		if att.Life() != Alive {
+			logger.Debugf(
+				"%s is detaching from %s",
+				names.ReadableString(volume.Tag()),
+				names.ReadableString(machineTag),
+			)
+			return nil, nil
+		}
+		return detachVolumeOps(machineTag, volume.VolumeTag()), nil
+
+	case StorageKindFilesystem:
+		filesystem, err := st.storageInstanceFilesystem(si.StorageTag())
+		if errors.IsNotFound(err) {
+			// The filesystem has already been removed, so must
+			// have already been detached.
+			logger.Debugf("%s", err)
+			return nil, nil
+		} else if err != nil {
+			return nil, errors.Trace(err)
+		} else if !filesystem.detachable() {
+			// Non-detachable filesystems are left attached to the
+			// machine, since the only other option is to destroy
+			// them. The user can remove them explicitly, or else
+			// leave them to be removed along with the machine.
+			logger.Debugf(
+				"%s for %s is non-detachable",
+				names.ReadableString(filesystem.Tag()),
+				names.ReadableString(si.StorageTag()),
+			)
+			return nil, nil
+		} else if filesystem.Life() != Alive {
+			logger.Debugf(
+				"%s is %s",
+				names.ReadableString(filesystem.Tag()),
+				filesystem.Life(),
+			)
+			return nil, nil
+		}
+		att, err := st.FilesystemAttachment(machineTag, filesystem.FilesystemTag())
+		if errors.IsNotFound(err) {
+			// Since the storage attachment is Dying, it is not
+			// possible to create a volume attachment for the
+			// machine, associated with the same storage.
+			logger.Debugf("%s", err)
+			return nil, nil
+		} else if err != nil {
+			return nil, errors.Trace(err)
+		}
+		if att.Life() != Alive {
+			logger.Debugf(
+				"%s is detaching from %s",
+				names.ReadableString(filesystem.Tag()),
+				names.ReadableString(machineTag),
+			)
+			return nil, nil
+		}
+		return detachFilesystemOps(machineTag, filesystem.FilesystemTag()), nil
+
+	default:
+		return nil, errors.Errorf("unknown storage type %q", si.Kind())
+	}
 }
 
 // removeStorageInstancesOps returns the transaction operations to remove all
@@ -843,8 +1126,8 @@ func removeStorageInstancesOps(st *State, owner names.Tag) ([]txn.Op, error) {
 	}
 	ops := make([]txn.Op, 0, len(docs))
 	for _, doc := range docs {
-		tag := names.NewStorageTag(doc.Id)
-		storageInstanceOps, err := removeStorageInstanceOps(st, owner, tag, nil)
+		si := &storageInstance{st, doc}
+		storageInstanceOps, err := removeStorageInstanceOps(si, nil)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
@@ -960,17 +1243,8 @@ func validateStorageConstraintsAgainstCharm(
 				charmMeta.Name, name,
 			)
 		}
-		if cons.Count < uint64(charmStorage.CountMin) {
-			return errors.Errorf(
-				"charm %q store %q: %d instances required, %d specified",
-				charmMeta.Name, name, charmStorage.CountMin, cons.Count,
-			)
-		}
-		if charmStorage.CountMax >= 0 && cons.Count > uint64(charmStorage.CountMax) {
-			return errors.Errorf(
-				"charm %q store %q: at most %d instances supported, %d specified",
-				charmMeta.Name, name, charmStorage.CountMax, cons.Count,
-			)
+		if err := validateCharmStorageCount(charmStorage, cons.Count); err != nil {
+			return errors.Annotatef(err, "charm %q store %q", charmMeta.Name, name)
 		}
 		if charmStorage.MinimumSize > 0 && cons.Size < charmStorage.MinimumSize {
 			return errors.Errorf(
@@ -984,6 +1258,61 @@ func validateStorageConstraintsAgainstCharm(
 		if err := validateStoragePool(st, cons.Pool, kind, nil); err != nil {
 			return err
 		}
+	}
+	return nil
+}
+
+func validateCharmStorageCountChange(charmStorage charm.Storage, current, n int) error {
+	action := "attach"
+	absn := n
+	if n < 0 {
+		action = "detach"
+		absn = -absn
+	}
+	gerund := action + "ing"
+	pluralise := ""
+	if absn != 1 {
+		pluralise = "s"
+	}
+
+	count := uint64(current + n)
+	if charmStorage.CountMin == 1 && charmStorage.CountMax == 1 && count != 1 {
+		return errors.Errorf("cannot %s, storage is singular", action)
+	}
+	if count < uint64(charmStorage.CountMin) {
+		return errors.Errorf(
+			"%s %d storage instance%s brings the total to %d, "+
+				"which is less than the minimum of %d",
+			gerund, absn, pluralise, count,
+			charmStorage.CountMin,
+		)
+	}
+	if charmStorage.CountMax >= 0 && count > uint64(charmStorage.CountMax) {
+		return errors.Errorf(
+			"%s %d storage instance%s brings the total to %d, "+
+				"exceeding the maximum of %d",
+			gerund, absn, pluralise, count,
+			charmStorage.CountMax,
+		)
+	}
+	return nil
+}
+
+func validateCharmStorageCount(charmStorage charm.Storage, count uint64) error {
+	if charmStorage.CountMin == 1 && charmStorage.CountMax == 1 && count != 1 {
+		return errors.Errorf("storage is singular, %d specified", count)
+	}
+	if count < uint64(charmStorage.CountMin) {
+		return errors.Errorf(
+			"%d instances required, %d specified",
+			charmStorage.CountMin, count,
+		)
+	}
+	if charmStorage.CountMax >= 0 && count > uint64(charmStorage.CountMax) {
+		return errors.Errorf(
+			"at most %d instances supported, %d specified",
+			charmStorage.CountMax, count,
+		)
 	}
 	return nil
 }
@@ -1197,7 +1526,7 @@ func (st *State) AddStorageForUnit(
 		return st.addStorageForUnitOps(u, name, cons)
 	}
 	if err := st.run(buildTxn); err != nil {
-		return errors.Annotatef(err, "adding storage to unit %s", u)
+		return errors.Annotatef(err, "adding %q storage to %s", name, u)
 	}
 	return nil
 }
@@ -1212,29 +1541,10 @@ func (st *State) addStorageForUnitOps(
 		return nil, unitNotAliveErr
 	}
 
-	// Storage addition is based on the charm metadata, so make sure that
-	// the charm URL for the unit or application does not change during
-	// the transaction. If the unit does not have a charm URL set yet,
-	// then we use the application's charm URL.
-	ops := []txn.Op{{
-		C:      unitsC,
-		Id:     u.doc.Name,
-		Assert: bson.D{{"charmurl", u.doc.CharmURL}},
-	}}
-	curl, ok := u.CharmURL()
-	if !ok {
-		a, err := u.Application()
-		if err != nil {
-			return nil, errors.Annotatef(err, "getting application for unit %v", u.doc.Name)
-		}
-		curl = a.doc.CharmURL
-		ops = append(ops, txn.Op{
-			C:      applicationsC,
-			Id:     a.doc.Name,
-			Assert: bson.D{{"charmurl", curl}},
-		})
-	}
-	ch, err := st.Charm(curl)
+	// Storage addition is based on the charm metadata; u.charm()
+	// returns txn.Ops that ensure the charm URL does not change
+	// during the transaction.
+	ch, err := u.charm()
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -1243,6 +1553,7 @@ func (st *State) addStorageForUnitOps(
 	if !ok {
 		return nil, errors.NotFoundf("charm storage %q", storageName)
 	}
+	ops := u.assertCharmOps(ch)
 
 	// Populate missing configuration parameters with default values.
 	modelConfig, err := st.ModelConfig()
@@ -1285,20 +1596,32 @@ func (st *State) addUnitStorageOps(
 	cons StorageConstraints,
 	countMin int,
 ) ([]txn.Op, error) {
-	currentCountOp, currentCount, err := st.countEntityStorageInstances(u.Tag(), storageName)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	ops := []txn.Op{currentCountOp}
-	if countMin >= 0 {
+	var ops []txn.Op
+
+	consTotal := cons
+	if countMin < 0 {
+		// Validate that the requested number of storage
+		// instances can be added to the unit.
+		currentCount, currentCountOp, err := validateStorageCountChange(
+			st, u.Tag(), storageName, int(cons.Count), charmMeta,
+		)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		ops = append(ops, currentCountOp)
+		consTotal.Count += uint64(currentCount)
+	} else {
+		currentCountOp, currentCount, err := st.countEntityStorageInstances(u.Tag(), storageName)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		ops = append(ops, currentCountOp)
 		if currentCount >= countMin {
 			return ops, nil
 		}
-		cons.Count = uint64(countMin - currentCount)
+		cons.Count = uint64(countMin)
 	}
 
-	consTotal := cons
-	consTotal.Count += uint64(currentCount)
 	if err := validateStorageConstraintsAgainstCharm(st,
 		map[string]StorageConstraints{storageName: consTotal},
 		charmMeta,

--- a/state/storage_dynamicadd_test.go
+++ b/state/storage_dynamicadd_test.go
@@ -128,7 +128,9 @@ func (s *storageAddSuite) TestAddStorageMultipleCalls(c *gc.C) {
 	// Should not succeed as the number of storages after
 	// this call would be 11 whereas our upper limit is 10 here.
 	err = s.State.AddStorageForUnit(s.unitTag, "multi1to10", makeStorageCons("loop-pool", 1024, 6))
-	c.Assert(err, gc.ErrorMatches, `.*charm "storage-block2" store "multi1to10": at most 10 instances supported, 11 specified.*`)
+	c.Assert(err, gc.ErrorMatches,
+		`adding "multi1to10" storage to storage-block2/0: `+
+			`attaching 6 storage instances brings the total to 11, exceeding the maximum of 10`)
 	s.assertStorageCount(c, s.originalStorageCount+2)
 	s.assertVolumeCount(c, s.originalVolumeCount+2)
 	s.assertFileSystemCount(c, s.originalFilesystemCount)
@@ -146,7 +148,7 @@ func (s *storageAddSuite) TestAddStorageToDyingUnitFails(c *gc.C) {
 	}).Check()
 
 	err := s.State.AddStorageForUnit(s.unitTag, "multi1to10", makeStorageCons("loop-pool", 1024, 1))
-	c.Assert(err, gc.ErrorMatches, `adding storage to unit storage-block2/0: unit is not alive`)
+	c.Assert(err, gc.ErrorMatches, `adding "multi1to10" storage to storage-block2/0: unit is not alive`)
 
 	s.assertStorageCount(c, s.originalStorageCount)
 }
@@ -156,7 +158,7 @@ func (s *storageAddSuite) TestAddStorageExceedCount(c *gc.C) {
 	s.assertStorageCount(c, 1)
 
 	err := s.State.AddStorageForUnit(u.UnitTag(), "data", makeStorageCons("loop-pool", 1024, 1))
-	c.Assert(err, gc.ErrorMatches, `.*charm "storage-block" store "data": at most 1 instances supported, 2 specified.*`)
+	c.Assert(err, gc.ErrorMatches, `adding "data" storage to storage-block/0: cannot attach, storage is singular`)
 	s.assertStorageCount(c, 1)
 	s.assertVolumeCount(c, 0)
 	s.assertFileSystemCount(c, 0)
@@ -287,7 +289,9 @@ func (s *storageAddSuite) TestAddStorageConcurrentlyExceedCount(c *gc.C) {
 	}
 	defer state.SetBeforeHooks(c, s.State, addStorage).Check()
 	err := s.State.AddStorageForUnit(s.unitTag, "multi1to10", state.StorageConstraints{Count: uint64(count)})
-	c.Assert(err, gc.ErrorMatches, `.*charm "storage-block2" store "multi1to10": at most 10 instances supported, 15 specified.*`)
+	c.Assert(err, gc.ErrorMatches,
+		`adding "multi1to10" storage to storage-block2/0: `+
+			`attaching 6 storage instances brings the total to 15, exceeding the maximum of 10`)
 
 	// Only "count" number of instances should have been added.
 	s.assertStorageCount(c, s.originalStorageCount+count)
@@ -337,7 +341,7 @@ func (s *storageAddSuite) TestAddStorageStatic(c *gc.C) {
 		u.UnitTag(), "data",
 		makeStorageCons("static", 1024, 1),
 	)
-	c.Assert(err, gc.ErrorMatches, "adding storage to unit storage-filesystem/0: "+
+	c.Assert(err, gc.ErrorMatches, `adding "data" storage to storage-filesystem/0: `+
 		"creating machine storage for storage data/1: "+
 		`"static" storage provider does not support dynamic storage`)
 	s.assertStorageCount(c, 1)    // no change

--- a/state/storage_test.go
+++ b/state/storage_test.go
@@ -239,7 +239,7 @@ func (s *StorageStateSuiteBase) obliterateUnitStorage(c *gc.C, tag names.UnitTag
 	attachments, err := s.State.UnitStorageAttachments(tag)
 	c.Assert(err, jc.ErrorIsNil)
 	for _, a := range attachments {
-		err = s.State.DestroyStorageAttachment(a.StorageInstance(), a.Unit())
+		err = s.State.DetachStorage(a.StorageInstance(), a.Unit())
 		c.Assert(err, jc.ErrorIsNil)
 		err = s.State.RemoveStorageAttachment(a.StorageInstance(), a.Unit())
 		c.Assert(err, jc.ErrorIsNil)
@@ -595,7 +595,7 @@ func (s *StorageStateSuite) TestUnitEnsureDead(c *gc.C) {
 		c.Assert(err, gc.ErrorMatches, "unit has storage attachments")
 	}
 	assertUnitEnsureDeadError()
-	err = s.State.DestroyStorageAttachment(storageTag, u.UnitTag())
+	err = s.State.DetachStorage(storageTag, u.UnitTag())
 	c.Assert(err, jc.ErrorIsNil)
 	assertUnitEnsureDeadError()
 	err = s.State.DestroyStorageInstance(storageTag)
@@ -619,7 +619,7 @@ func (s *StorageStateSuite) TestRemoveStorageAttachmentsRemovesDyingInstance(c *
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(si.Life(), gc.Equals, state.Dying)
 
-	err = s.State.DestroyStorageAttachment(storageTag, u.UnitTag())
+	err = s.State.DetachStorage(storageTag, u.UnitTag())
 	c.Assert(err, jc.ErrorIsNil)
 	err = s.State.RemoveStorageAttachment(storageTag, u.UnitTag())
 	c.Assert(err, jc.ErrorIsNil)
@@ -637,7 +637,7 @@ func (s *StorageStateSuite) TestRemoveStorageAttachmentsRemovesUnitOwnedInstance
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(si.Life(), gc.Equals, state.Alive)
 
-	err = s.State.DestroyStorageAttachment(storageTag, u.UnitTag())
+	err = s.State.DetachStorage(storageTag, u.UnitTag())
 	c.Assert(err, jc.ErrorIsNil)
 	err = s.State.RemoveStorageAttachment(storageTag, u.UnitTag())
 	c.Assert(err, jc.ErrorIsNil)
@@ -649,7 +649,7 @@ func (s *StorageStateSuite) TestConcurrentDestroyStorageInstanceRemoveStorageAtt
 	_, u, storageTag := s.setupSingleStorage(c, "block", "loop-pool")
 
 	defer state.SetBeforeHooks(c, s.State, func() {
-		err := s.State.DestroyStorageAttachment(storageTag, u.UnitTag())
+		err := s.State.DetachStorage(storageTag, u.UnitTag())
 		c.Assert(err, jc.ErrorIsNil)
 		err = s.State.RemoveStorageAttachment(storageTag, u.UnitTag())
 		c.Assert(err, jc.ErrorIsNil)
@@ -672,7 +672,7 @@ func (s *StorageStateSuite) TestConcurrentRemoveStorageAttachment(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	destroy := func() {
-		err = s.State.DestroyStorageAttachment(storageTag, u.UnitTag())
+		err = s.State.DetachStorage(storageTag, u.UnitTag())
 		c.Assert(err, jc.ErrorIsNil)
 	}
 	remove := func() {
@@ -713,7 +713,7 @@ func (s *StorageStateSuite) TestConcurrentDestroyInstanceRemoveStorageAttachment
 	// Removing the attachment should check that there are no concurrent
 	// changes to the storage instance's life, and recompute operations
 	// if it does.
-	err := s.State.DestroyStorageAttachment(storageTag, u.UnitTag())
+	err := s.State.DetachStorage(storageTag, u.UnitTag())
 	c.Assert(err, jc.ErrorIsNil)
 	err = s.State.RemoveStorageAttachment(storageTag, u.UnitTag())
 	c.Assert(err, jc.ErrorIsNil)
@@ -759,7 +759,7 @@ func (s *StorageStateSuite) TestWatchStorageAttachments(c *gc.C) {
 	wc.AssertChange("multi1to10/0", "multi2up/1", "multi2up/2")
 	wc.AssertNoChange()
 
-	err = s.State.DestroyStorageAttachment(names.NewStorageTag("multi2up/1"), u.UnitTag())
+	err = s.State.DetachStorage(names.NewStorageTag("multi2up/1"), u.UnitTag())
 	c.Assert(err, jc.ErrorIsNil)
 	wc.AssertChange("multi2up/1")
 	wc.AssertNoChange()
@@ -773,7 +773,7 @@ func (s *StorageStateSuite) TestWatchStorageAttachment(c *gc.C) {
 	wc := testing.NewNotifyWatcherC(c, s.State, w)
 	wc.AssertOneChange()
 
-	err := s.State.DestroyStorageAttachment(storageTag, u.UnitTag())
+	err := s.State.DetachStorage(storageTag, u.UnitTag())
 	c.Assert(err, jc.ErrorIsNil)
 	wc.AssertOneChange()
 

--- a/state/storage_test.go
+++ b/state/storage_test.go
@@ -51,11 +51,11 @@ func (s *StorageStateSuiteBase) setupSingleStorage(c *gc.C, kind, pool string) (
 	storage := map[string]state.StorageConstraints{
 		"data": makeStorageCons(pool, 1024, 1),
 	}
-	service := s.AddTestingServiceWithStorage(c, "storage-"+kind, ch, storage)
-	unit, err := service.AddUnit()
+	app := s.AddTestingServiceWithStorage(c, "storage-"+kind, ch, storage)
+	unit, err := app.AddUnit()
 	c.Assert(err, jc.ErrorIsNil)
 	storageTag := names.NewStorageTag("data/0")
-	return service, unit, storageTag
+	return app, unit, storageTag
 }
 
 func (s *StorageStateSuiteBase) setupSingleStorageDetachable(c *gc.C) (*state.Application, *state.Unit, names.StorageTag) {
@@ -112,7 +112,7 @@ storage:
 	return ch
 }
 
-func (s *StorageStateSuiteBase) setupMixedScopeStorageService(
+func (s *StorageStateSuiteBase) setupMixedScopeStorageApplication(
 	c *gc.C, kind string, pools ...string,
 ) *state.Application {
 	pool0 := "modelscoped"
@@ -434,9 +434,9 @@ func (s *StorageStateSuite) assertAddServiceStorageConstraintsDefaults(c *gc.C, 
 		c.Assert(err, jc.ErrorIsNil)
 	}
 	ch := s.AddTestingCharm(c, "storage-block")
-	service, err := s.State.AddApplication(state.AddApplicationArgs{Name: "storage-block2", Charm: ch, Storage: cons})
+	app, err := s.State.AddApplication(state.AddApplicationArgs{Name: "storage-block2", Charm: ch, Storage: cons})
 	c.Assert(err, jc.ErrorIsNil)
-	savedCons, err := service.StorageConstraints()
+	savedCons, err := app.StorageConstraints()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(savedCons, jc.DeepEquals, expect)
 	// TODO(wallyworld) - test pool name stored in data model
@@ -506,9 +506,9 @@ func (s *StorageStateSuite) TestAddServiceStorageConstraintsDefaultSizeFromCharm
 		"multi2up":   makeStorageCons("loop", 2048, 2),
 	}
 	ch := s.AddTestingCharm(c, "storage-block2")
-	service, err := s.State.AddApplication(state.AddApplicationArgs{Name: "storage-block2", Charm: ch, Storage: storageCons})
+	app, err := s.State.AddApplication(state.AddApplicationArgs{Name: "storage-block2", Charm: ch, Storage: storageCons})
 	c.Assert(err, jc.ErrorIsNil)
-	savedCons, err := service.StorageConstraints()
+	savedCons, err := app.StorageConstraints()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(savedCons, jc.DeepEquals, expectedCons)
 }
@@ -535,16 +535,16 @@ func (s *StorageStateSuite) assertStorageUnitsAdded(c *gc.C) {
 	}, nil, nil)
 	c.Assert(err, jc.ErrorIsNil)
 
-	// Each unit added to the service will create storage instances
-	// to satisfy the service's storage constraints.
+	// Each unit added to the application will create storage instances
+	// to satisfy the application's storage constraints.
 	ch := s.AddTestingCharm(c, "storage-block2")
 	storage := map[string]state.StorageConstraints{
 		"multi1to10": makeStorageCons("", 1024, 1),
 		"multi2up":   makeStorageCons("loop-pool", 2048, 2),
 	}
-	service := s.AddTestingServiceWithStorage(c, "storage-block2", ch, storage)
+	app := s.AddTestingServiceWithStorage(c, "storage-block2", ch, storage)
 	for i := 0; i < 2; i++ {
-		u, err := service.AddUnit()
+		u, err := app.AddUnit()
 		c.Assert(err, jc.ErrorIsNil)
 		storageAttachments, err := s.State.UnitStorageAttachments(u.UnitTag())
 		c.Assert(err, jc.ErrorIsNil)
@@ -792,8 +792,8 @@ func (s *StorageStateSuite) TestWatchStorageAttachments(c *gc.C) {
 		"multi1to10": makeStorageCons("loop-pool", 1024, 2),
 		"multi2up":   makeStorageCons("loop-pool", 2048, 2),
 	}
-	service := s.AddTestingServiceWithStorage(c, "storage-block2", ch, storage)
-	u, err := service.AddUnit()
+	app := s.AddTestingServiceWithStorage(c, "storage-block2", ch, storage)
+	u, err := app.AddUnit()
 	c.Assert(err, jc.ErrorIsNil)
 
 	w := s.State.WatchStorageAttachments(u.UnitTag())
@@ -828,8 +828,8 @@ func (s *StorageStateSuite) TestWatchStorageAttachment(c *gc.C) {
 }
 
 func (s *StorageStateSuite) TestDestroyUnitStorageAttachments(c *gc.C) {
-	service := s.setupMixedScopeStorageService(c, "block")
-	u, err := service.AddUnit()
+	app := s.setupMixedScopeStorageApplication(c, "block")
+	u, err := app.AddUnit()
 	c.Assert(err, jc.ErrorIsNil)
 	err = u.Destroy()
 	c.Assert(err, jc.ErrorIsNil)

--- a/state/volume_test.go
+++ b/state/volume_test.go
@@ -92,9 +92,9 @@ func (s *VolumeStateSuite) TestAddServiceNoUserDefaultPool(c *gc.C) {
 	storage := map[string]state.StorageConstraints{
 		"data": makeStorageCons("", 1024, 1),
 	}
-	service, err := s.State.AddApplication(state.AddApplicationArgs{Name: "storage-block", Charm: ch, Storage: storage})
+	app, err := s.State.AddApplication(state.AddApplicationArgs{Name: "storage-block", Charm: ch, Storage: storage})
 	c.Assert(err, jc.ErrorIsNil)
-	cons, err := service.StorageConstraints()
+	cons, err := app.StorageConstraints()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cons, jc.DeepEquals, map[string]state.StorageConstraints{
 		"data": state.StorageConstraints{
@@ -124,8 +124,8 @@ func (s *VolumeStateSuite) TestAddServiceDefaultPool(c *gc.C) {
 	storage := map[string]state.StorageConstraints{
 		"data": makeStorageCons("", 1024, 1),
 	}
-	service := s.AddTestingServiceWithStorage(c, "storage-block", ch, storage)
-	cons, err := service.StorageConstraints()
+	app := s.AddTestingServiceWithStorage(c, "storage-block", ch, storage)
+	cons, err := app.StorageConstraints()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cons, jc.DeepEquals, map[string]state.StorageConstraints{
 		"data": state.StorageConstraints{
@@ -272,9 +272,9 @@ func (s *VolumeStateSuite) TestWatchVolumeAttachment(c *gc.C) {
 }
 
 func (s *VolumeStateSuite) TestWatchModelVolumes(c *gc.C) {
-	service := s.setupMixedScopeStorageService(c, "block")
+	app := s.setupMixedScopeStorageApplication(c, "block")
 	addUnit := func() {
-		u, err := service.AddUnit()
+		u, err := app.AddUnit()
 		c.Assert(err, jc.ErrorIsNil)
 		err = s.State.AssignUnit(u, state.AssignCleanEmpty)
 		c.Assert(err, jc.ErrorIsNil)
@@ -313,9 +313,9 @@ func (s *VolumeStateSuite) TestWatchModelVolumes(c *gc.C) {
 }
 
 func (s *VolumeStateSuite) TestWatchEnvironVolumeAttachments(c *gc.C) {
-	service := s.setupMixedScopeStorageService(c, "block")
+	app := s.setupMixedScopeStorageApplication(c, "block")
 	addUnit := func() {
-		u, err := service.AddUnit()
+		u, err := app.AddUnit()
 		c.Assert(err, jc.ErrorIsNil)
 		err = s.State.AssignUnit(u, state.AssignCleanEmpty)
 		c.Assert(err, jc.ErrorIsNil)
@@ -344,11 +344,9 @@ func (s *VolumeStateSuite) TestWatchEnvironVolumeAttachments(c *gc.C) {
 }
 
 func (s *VolumeStateSuite) TestWatchMachineVolumes(c *gc.C) {
-	service := s.setupMixedScopeStorageService(
-		c, "block", "machinescoped", "modelscoped",
-	)
+	app := s.setupMixedScopeStorageApplication(c, "block", "machinescoped", "modelscoped")
 	addUnit := func() {
-		u, err := service.AddUnit()
+		u, err := app.AddUnit()
 		c.Assert(err, jc.ErrorIsNil)
 		err = s.State.AssignUnit(u, state.AssignCleanEmpty)
 		c.Assert(err, jc.ErrorIsNil)
@@ -386,12 +384,10 @@ func (s *VolumeStateSuite) TestWatchMachineVolumes(c *gc.C) {
 }
 
 func (s *VolumeStateSuite) TestWatchMachineVolumeAttachments(c *gc.C) {
-	service := s.setupMixedScopeStorageService(
-		c, "block", "machinescoped", "modelscoped",
-	)
+	app := s.setupMixedScopeStorageApplication(c, "block", "machinescoped", "modelscoped")
 	addUnit := func(to *state.Machine) (u *state.Unit, m *state.Machine) {
 		var err error
-		u, err = service.AddUnit()
+		u, err = app.AddUnit()
 		c.Assert(err, jc.ErrorIsNil)
 		if to != nil {
 			err = u.AssignToMachine(to)

--- a/state/volume_test.go
+++ b/state/volume_test.go
@@ -517,7 +517,7 @@ func (s *VolumeStateSuite) TestRemoveStorageInstanceDestroysAndUnassignsVolume(c
 
 	err = s.State.DestroyStorageInstance(storageTag)
 	c.Assert(err, jc.ErrorIsNil)
-	err = s.State.DestroyStorageAttachment(storageTag, u.UnitTag())
+	err = s.State.DetachStorage(storageTag, u.UnitTag())
 	c.Assert(err, jc.ErrorIsNil)
 
 	// The storage instance and attachment are dying, but not yet
@@ -918,7 +918,7 @@ func removeStorageInstance(c *gc.C, st *state.State, storageTag names.StorageTag
 	attachments, err := st.StorageAttachments(storageTag)
 	c.Assert(err, jc.ErrorIsNil)
 	for _, a := range attachments {
-		err = st.DestroyStorageAttachment(storageTag, a.Unit())
+		err = st.DetachStorage(storageTag, a.Unit())
 		c.Assert(err, jc.ErrorIsNil)
 		err = st.RemoveStorageAttachment(storageTag, a.Unit())
 		c.Assert(err, jc.ErrorIsNil)

--- a/worker/uniter/uniter_test.go
+++ b/worker/uniter/uniter_test.go
@@ -1833,8 +1833,17 @@ func (s *UniterSuite) TestStorage(c *gc.C) {
 			err := f.Close()
 			c.Assert(err, jc.ErrorIsNil)
 		}()
-		_, err = io.WriteString(f, "storage:\n  wp-content:\n    type: filesystem\n")
+		_, err = io.WriteString(f, `
+storage:
+  wp-content:
+    type: filesystem
+    multiple:
+      range: 0-
+`[1:])
 		c.Assert(err, jc.ErrorIsNil)
+	}
+	storageConstraints := map[string]state.StorageConstraints{
+		"wp-content": {Count: 1},
 	}
 	s.runUniterTests(c, []uniterTest{
 		ut(
@@ -1842,7 +1851,7 @@ func (s *UniterSuite) TestStorage(c *gc.C) {
 			createCharm{customize: appendStorageMetadata},
 			serveCharm{},
 			ensureStateWorker{},
-			createServiceAndUnit{},
+			createServiceAndUnit{storage: storageConstraints},
 			provisionStorage{},
 			startUniter{},
 			waitAddresses{},
@@ -1853,7 +1862,7 @@ func (s *UniterSuite) TestStorage(c *gc.C) {
 			createCharm{customize: appendStorageMetadata},
 			serveCharm{},
 			ensureStateWorker{},
-			createServiceAndUnit{},
+			createServiceAndUnit{storage: storageConstraints},
 			provisionStorage{},
 			startUniter{},
 			waitAddresses{},
@@ -1870,7 +1879,7 @@ func (s *UniterSuite) TestStorage(c *gc.C) {
 			createCharm{customize: appendStorageMetadata},
 			serveCharm{},
 			ensureStateWorker{},
-			createServiceAndUnit{},
+			createServiceAndUnit{storage: storageConstraints},
 			// provision and destroy the storage before the uniter starts,
 			// to ensure it never sees the storage as attached
 			provisionStorage{},
@@ -1887,7 +1896,7 @@ func (s *UniterSuite) TestStorage(c *gc.C) {
 			createCharm{customize: appendStorageMetadata},
 			serveCharm{},
 			ensureStateWorker{},
-			createServiceAndUnit{},
+			createServiceAndUnit{storage: storageConstraints},
 			startUniter{},
 			// no hooks should be run, as storage isn't provisioned
 			waitHooks{},
@@ -1899,7 +1908,7 @@ func (s *UniterSuite) TestStorage(c *gc.C) {
 			createCharm{customize: appendStorageMetadata},
 			serveCharm{},
 			ensureStateWorker{},
-			createServiceAndUnit{},
+			createServiceAndUnit{storage: storageConstraints},
 			unitDying,
 			startUniter{},
 			// no hooks should be run, and unit agent should terminate

--- a/worker/uniter/util_test.go
+++ b/worker/uniter/util_test.go
@@ -407,6 +407,7 @@ func (s serveCharm) step(c *gc.C, ctx *context) {
 
 type createServiceAndUnit struct {
 	serviceName string
+	storage     map[string]state.StorageConstraints
 }
 
 func (csau createServiceAndUnit) step(c *gc.C, ctx *context) {
@@ -415,7 +416,7 @@ func (csau createServiceAndUnit) step(c *gc.C, ctx *context) {
 	}
 	sch, err := ctx.st.Charm(curl(0))
 	c.Assert(err, jc.ErrorIsNil)
-	svc := ctx.s.AddTestingService(c, csau.serviceName, sch)
+	svc := ctx.s.AddTestingServiceWithStorage(c, csau.serviceName, sch, csau.storage)
 	unit, err := svc.AddUnit()
 	c.Assert(err, jc.ErrorIsNil)
 

--- a/worker/uniter/util_test.go
+++ b/worker/uniter/util_test.go
@@ -1769,7 +1769,7 @@ func (s destroyStorageAttachment) step(c *gc.C, ctx *context) {
 	storageAttachments, err := ctx.st.UnitStorageAttachments(ctx.unit.UnitTag())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(storageAttachments, gc.HasLen, 1)
-	err = ctx.st.DestroyStorageAttachment(
+	err = ctx.st.DetachStorage(
 		storageAttachments[0].StorageInstance(),
 		ctx.unit.UnitTag(),
 	)


### PR DESCRIPTION
## Description of change

When detaching or destroying storage, ensure that
doing so does not violate the minimum storage
requirements of the owner (unit or application).
The minimum storage requirements are ignored when
the owner is dying, to allow storage to be cleanly
detached during unit destruction.

Also: rename DestroyStorageAttachment to
DetachStorage, to better match what we have with
volumes and filesystems. An AttachStorage method
will be added in a future PR.

## QA steps

1. export JUJU_DEV_FEATURE_FLAGS=lxd-storage
2. juju bootstrap localhost
3. juju deploy /path/to/storagetest --storage fs=lxd # [0]
(wait for unit to become idle)
4. juju remove-storage fs/0
(should fail, saying that the storage is singular)
5. juju detach-storage fs/0
(should fail, saying that the storage is singular)
6. juju destroy-controller -y localhost --destroy-all-models

[0] The storagetest charm's metadata.yaml is as follows:
```yaml
name: storagetest
summary: ...
maintainer: Andrew Wilkins <andrew.wilkins@canonical.com>
description: ...
series: [xenial]
storage:
  fs:
    type: filesystem
```

## Documentation changes

None.

## Bug reference

None.