### PR TITLE
Remove reference to 'juju help placement'.

### DIFF
--- a/cmd/juju/machine/add.go
+++ b/cmd/juju/machine/add.go
@@ -61,7 +61,6 @@ It is possible to override or augment constraints by passing provider-specific
 "placement directives" as an argument; these give the provider additional
 information about how to allocate the machine. For example, one can direct the
 MAAS provider to acquire a particular node by specifying its hostname.
-For more information on placement directives, see "juju help placement".
 
 Examples:
    juju add-machine                      (starts a new machine)


### PR DESCRIPTION
## Description of change

Removed reference to redundant 'juju help placement'. All information that this help topic contained is now comprehensively covered in add-machine help.

## QA steps

Run 'juju help add-machine'. There should be no instructions to run 'juju help placement'.

## Documentation changes
N/A

## Bug reference

https://bugs.launchpad.net/juju/+bug/1669851
