### PR TITLE
Merge "user-domain" feature branch into develop.

### DIFF
--- a/cmd/juju/commands/migrate.go
+++ b/cmd/juju/commands/migrate.go
@@ -206,5 +206,5 @@ func (c *migrateCommand) getTargetControllerMacaroons() ([]macaroon.Slice, error
 		return nil, errors.Annotate(err, "connecting to target controller")
 	}
 	defer api.Close()
-	return httpbakery.MacaroonsForURL(apiContext.Jar, api.CookieURL()), nil
+	return httpbakery.MacaroonsForURL(apiContext.CookieJar(), api.CookieURL()), nil
 }

--- a/cmd/juju/controller/destroy.go
+++ b/cmd/juju/controller/destroy.go
@@ -300,7 +300,7 @@ func (c *destroyCommandBase) Init(args []string) error {
 	case 0:
 		return errors.New("no controller specified")
 	case 1:
-		return c.SetControllerName(args[0])
+		return c.SetControllerName(args[0], false)
 	default:
 		return cmd.CheckEmpty(args[1:])
 	}

--- a/cmd/juju/controller/mock_test.go
+++ b/cmd/juju/controller/mock_test.go
@@ -12,6 +12,8 @@ import (
 // mockAPIConnection implements just enough of the api.Connection interface
 // to satisfy the methods used by the register command.
 type mockAPIConnection struct {
+	// This will be nil - it's just there to satisfy the api.Connection
+	// interface methods not explicitly defined by mockAPIConnection.
 	api.Connection
 
 	// addr is returned by Addr.

--- a/cmd/juju/controller/register.go
+++ b/cmd/juju/controller/register.go
@@ -501,7 +501,7 @@ func (c *registerCommand) secretKeyLogin(addrs []string, request params.SecretKe
 	}
 	httpReq.Header.Set("Content-Type", "application/json")
 	httpClient := utils.GetNonValidatingHTTPClient()
-	httpClient.Jar = apiContext.Jar
+	httpClient.Jar = apiContext.CookieJar()
 	httpResp, err := httpClient.Do(httpReq)
 	if err != nil {
 		return nil, errors.Trace(err)

--- a/cmd/juju/user/export_test.go
+++ b/cmd/juju/user/export_test.go
@@ -13,6 +13,15 @@ import (
 	"github.com/juju/juju/jujuclient"
 )
 
+var (
+	APIOpen          = &apiOpen
+	ListModels       = &listModels
+	NewAPIConnection = &newAPIConnection
+	LoginClientStore = &loginClientStore
+)
+
+const NoModelsMessage = noModelsMessage
+
 type AddCommand struct {
 	*addCommand
 }
@@ -71,17 +80,6 @@ func NewChangePasswordCommandForTest(
 	}
 	c.SetClientStore(store)
 	return modelcmd.WrapController(c), &ChangePasswordCommand{c}
-}
-
-// NewLoginCommand returns a LoginCommand with the api
-// and writer provided as specified.
-func NewLoginCommandForTest(
-	newLoginAPI func(juju.NewAPIConnectionParams) (LoginAPI, ConnectionAPI, error),
-	store jujuclient.ClientStore,
-) (cmd.Command, *LoginCommand) {
-	c := &loginCommand{newLoginAPI: newLoginAPI}
-	c.SetClientStore(store)
-	return modelcmd.WrapController(c), &LoginCommand{c}
 }
 
 // NewLogoutCommand returns a LogoutCommand with the api

--- a/cmd/juju/user/login.go
+++ b/cmd/juju/user/login.go
@@ -5,99 +5,157 @@ package user
 
 import (
 	"fmt"
+	"net/http"
+	"os"
+	"strings"
 
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
+	"github.com/juju/gnuflag"
+	"github.com/juju/httprequest"
+	"github.com/juju/utils/set"
 	"gopkg.in/juju/names.v2"
 
-	"github.com/juju/juju/api/usermanager"
+	"github.com/juju/juju/api"
+	apibase "github.com/juju/juju/api/base"
+	"github.com/juju/juju/api/modelmanager"
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/cmd/juju/common"
 	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/juju"
 	"github.com/juju/juju/jujuclient"
 )
 
 const loginDoc = `
+By default, the juju login command logs the user into a public
+controller. If the controller is already known it can be specified
+by name. Alternatively, the host name of a public controller can be
+specified. The -c flag can be used to specify a name for the controller
+when a host name is provided.
+
+If the -u flag is provided, the juju login command will attempt to log
+into a controller as a local user. In this case, the -c flag names the
+controller to log in to.
+
 After login, a token ("macaroon") will become active. It has an expiration
 time of 24 hours. Upon expiration, no further Juju commands can be issued
 and the user will be prompted to log in again.
 
 Examples:
 
-    juju login bob
+    juju login somepubliccontroller
+    juju login jimm.jujucharms.com
+    juju login -u bob
 
 See also:
     disable-user
     enable-user
     logout
-
 `
+
+// Functions defined as variables so they can be overridden in tests.
+var (
+	apiOpen          = (*modelcmd.JujuCommandBase).APIOpen
+	newAPIConnection = juju.NewAPIConnection
+	listModels       = func(c *modelcmd.ControllerCommandBase, userName string) ([]apibase.UserModel, error) {
+		api, err := c.NewAPIRoot()
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		defer api.Close()
+		mm := modelmanager.NewClient(api)
+		return mm.ListModels(userName)
+	}
+	// loginClientStore is used as the client store. When it is nil,
+	// the default client store will be used.
+	loginClientStore jujuclient.ClientStore
+)
 
 // NewLoginCommand returns a new cmd.Command to handle "juju login".
 func NewLoginCommand() cmd.Command {
-	return modelcmd.WrapController(&loginCommand{
-		newLoginAPI: func(args juju.NewAPIConnectionParams) (LoginAPI, ConnectionAPI, error) {
-			api, err := juju.NewAPIConnection(args)
-			if err != nil {
-				return nil, nil, errors.Trace(err)
-			}
-			return usermanager.NewClient(api), api, nil
-		},
-	})
+	var c loginCommand
+	c.SetClientStore(loginClientStore)
+	return modelcmd.WrapController(&c, modelcmd.WrapControllerSkipControllerFlags)
 }
 
 // loginCommand changes the password for a user.
 type loginCommand struct {
 	modelcmd.ControllerCommandBase
-	newLoginAPI func(juju.NewAPIConnectionParams) (LoginAPI, ConnectionAPI, error)
-	User        string
+	userOrDomain string
+	forceUser    bool
+
+	// controllerName holds the name of the current controller.
+	// We define this and the --controller flag here because
+	// the controller does not necessarily exist when the command
+	// is executed.
+	controllerName string
+
+	// onRunError is executed if non-nil if there is an error at the end
+	// of the Run method.
+	onRunError func()
 }
 
 // Info implements Command.Info.
 func (c *loginCommand) Info() *cmd.Info {
 	return &cmd.Info{
 		Name:    "login",
-		Args:    "[username]",
+		Args:    "[username|domain]",
 		Purpose: "Logs a user in to a controller.",
 		Doc:     loginDoc,
 	}
 }
 
+func (c *loginCommand) SetFlags(fset *gnuflag.FlagSet) {
+	c.ControllerCommandBase.SetFlags(fset)
+	fset.StringVar(&c.controllerName, "c", "", "Controller to operate in")
+	fset.StringVar(&c.controllerName, "controller", "", "")
+	fset.BoolVar(&c.forceUser, "u", false, "log into the current controller as a local user")
+	fset.BoolVar(&c.forceUser, "user", false, "")
+}
+
 // Init implements Command.Init.
 func (c *loginCommand) Init(args []string) error {
 	var err error
-	c.User, err = cmd.ZeroOrOneArgs(args)
+	c.userOrDomain, err = cmd.ZeroOrOneArgs(args)
 	if err != nil {
 		return errors.Trace(err)
 	}
 	return nil
 }
 
-// LoginAPI provides the API methods that the login command uses.
-type LoginAPI interface {
-	Close() error
-}
-
-// ConnectionAPI provides relevant API methods off the underlying connection.
-type ConnectionAPI interface {
-	AuthTag() names.Tag
-	ControllerAccess() string
-}
-
 // Run implements Command.Run.
 func (c *loginCommand) Run(ctx *cmd.Context) error {
-	controllerName := c.ControllerName()
+	err := c.run(ctx)
+	if err != nil && c.onRunError != nil {
+		c.onRunError()
+	}
+	return err
+}
+
+var errNotControllerLogin = errors.New("not a controller login")
+
+func (c *loginCommand) run(ctx *cmd.Context) error {
 	store := c.ClientStore()
+	if !c.forceUser {
+		if err := c.controllerLogin(ctx, store); err != nil {
+			return errors.Trace(err)
+		}
+		return nil
+	}
+	user := c.userOrDomain
+	// Set the controller name as if this is a normal controller command.
+	if err := c.SetControllerName(c.controllerName, true); err != nil {
+		return errors.Trace(err)
+	}
+	controllerName := c.ControllerName()
 	accountDetails, err := store.AccountDetails(controllerName)
 	if err != nil && !errors.IsNotFound(err) {
 		return errors.Trace(err)
 	}
-
-	user := c.User
 	if user == "" && accountDetails == nil {
-		// The username has not been specified, and there
-		// is no current account. See if the user can log
-		// in with macaroons.
+		// The username has not been specified, and there is no
+		// current account. See if the user can log in with
+		// macaroons.
 		args, err := c.NewAPIConnectionParams(
 			store, controllerName, "",
 			&jujuclient.AccountDetails{},
@@ -105,10 +163,10 @@ func (c *loginCommand) Run(ctx *cmd.Context) error {
 		if err != nil {
 			return errors.Trace(err)
 		}
-		api, conn, err := c.newLoginAPI(args)
+		conn, err := newAPIConnection(args)
 		if err == nil {
 			authTag := conn.AuthTag()
-			api.Close()
+			conn.Close()
 			ctx.Infof("You are now logged in to %q as %q.", controllerName, authTag.Id())
 			return nil
 		}
@@ -143,8 +201,7 @@ func (c *loginCommand) Run(ctx *cmd.Context) error {
 	if accountDetails != nil && accountDetails.User != userTag.Id() {
 		return errors.New(`already logged in
 
-Run "juju logout" first before attempting to log in as a different user.
-`)
+Run "juju logout" first before attempting to log in as a different user.`)
 	}
 
 	// Log in without specifying a password in the account details. This
@@ -157,11 +214,11 @@ Run "juju logout" first before attempting to log in as a different user.
 	if err != nil {
 		return errors.Trace(err)
 	}
-	api, conn, err := c.newLoginAPI(params)
+	conn, err := newAPIConnection(params)
 	if err != nil {
 		return errors.Annotate(err, "creating API connection")
 	}
-	defer api.Close()
+	defer conn.Close()
 
 	accountDetails.LastKnownAccess = conn.ControllerAccess()
 	if err := store.UpdateAccount(controllerName, *accountDetails); err != nil {
@@ -169,4 +226,251 @@ Run "juju logout" first before attempting to log in as a different user.
 	}
 	ctx.Infof("You are now logged in to %q as %q.", controllerName, userTag.Id())
 	return nil
+}
+
+func (c *loginCommand) controllerLogin(ctx *cmd.Context, store jujuclient.ClientStore) error {
+	controllerHost := c.userOrDomain
+	if !strings.Contains(controllerHost, ".") {
+		// TODO(rog) provide a way of avoiding this external network access.
+		controllerHost1, err := c.getKnownControllerDomain(controllerHost)
+		if errors.IsNotFound(err) {
+			return errors.Errorf("%q is not a known public controller", controllerHost)
+		}
+		if err != nil {
+			return errors.Annotatef(err, "could not determine controller domain")
+		}
+		controllerHost = controllerHost1
+	}
+	if c.controllerName == "" {
+		// No explicitly specified controller name, so
+		// derive it from the domain.
+		if strings.Contains(c.userOrDomain, ":") {
+			return errors.Errorf("cannot use %q as controller name - use -c flag to choose a different one", c.userOrDomain)
+		}
+		c.controllerName = c.userOrDomain
+	}
+	store = modelcmd.QualifyingClientStore{store}
+	controllerDetails, accountDetails, err := c.publicControllerDetails(controllerHost)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	if err := c.updateController(
+		store,
+		c.controllerName,
+		controllerDetails,
+		accountDetails,
+	); err != nil {
+		return errors.Trace(err)
+	}
+	if err := c.SetControllerName(c.controllerName, false); err != nil {
+		return errors.Annotatef(err, "cannot set controller name")
+	}
+	// Log into the controller to verify the credentials, and
+	// list the models available.
+	models, err := listModels(&c.ControllerCommandBase, accountDetails.User)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	for _, model := range models {
+		owner := names.NewUserTag(model.Owner)
+		if err := store.UpdateModel(
+			c.controllerName,
+			jujuclient.JoinOwnerModelName(owner, model.Name),
+			jujuclient.ModelDetails{model.UUID},
+		); err != nil {
+			return errors.Annotate(err, "storing model details")
+		}
+	}
+	if err := store.SetCurrentController(c.controllerName); err != nil {
+		return errors.Trace(err)
+	}
+
+	fmt.Fprintf(
+		ctx.Stderr, "Welcome, %s. You are now logged into %q.\n",
+		friendlyUserName(accountDetails.User), c.controllerName,
+	)
+	return c.maybeSetCurrentModel(ctx, store, c.controllerName, accountDetails.User, models)
+}
+
+// publicControllerDetails returns controller and account details to be registered
+// for the given public controller host name.
+func (c *loginCommand) publicControllerDetails(host string) (jujuclient.ControllerDetails, jujuclient.AccountDetails, error) {
+	fail := func(err error) (jujuclient.ControllerDetails, jujuclient.AccountDetails, error) {
+		return jujuclient.ControllerDetails{}, jujuclient.AccountDetails{}, err
+	}
+	apiAddr := host
+	if !strings.Contains(apiAddr, ":") {
+		apiAddr += ":443"
+	}
+	// Make a direct API connection because we don't yet know the
+	// controller UUID so can't store the thus-incomplete controller
+	// details to make a conventional connection.
+	//
+	// Unfortunately this means we'll connect twice to the controller
+	// but it's probably best to go through the conventional path the
+	// second time.
+	bclient, err := c.BakeryClient()
+	if err != nil {
+		return fail(errors.Trace(err))
+	}
+	dialOpts := api.DefaultDialOpts()
+	dialOpts.BakeryClient = bclient
+	conn, err := apiOpen(&c.JujuCommandBase, &api.Info{
+		Addrs: []string{apiAddr},
+	}, dialOpts)
+	if err != nil {
+		return fail(errors.Trace(err))
+	}
+	defer conn.Close()
+	user, ok := conn.AuthTag().(names.UserTag)
+	if !ok {
+		return fail(errors.Errorf("logged in as %v, not a user", conn.AuthTag()))
+	}
+	// If we get to here, then we have a cached macaroon for the registered
+	// user. If we encounter an error after here, we need to clear it.
+	c.onRunError = func() {
+		if err := c.ClearControllerMacaroons([]string{apiAddr}); err != nil {
+			logger.Errorf("failed to clear macaroon: %v", err)
+		}
+	}
+	return jujuclient.ControllerDetails{
+			APIEndpoints:   []string{apiAddr},
+			ControllerUUID: conn.ControllerTag().Id(),
+		}, jujuclient.AccountDetails{
+			User:            user.Id(),
+			LastKnownAccess: conn.ControllerAccess(),
+		}, nil
+}
+
+// updateController updates the controller and account details in the given client store,
+// using the given controller name and adding the controller if necessary.
+func (c *loginCommand) updateController(
+	store jujuclient.ClientStore,
+	controllerName string,
+	controllerDetails jujuclient.ControllerDetails,
+	accountDetails jujuclient.AccountDetails,
+) error {
+	// Check that the same controller isn't already stored, so that we
+	// can avoid needlessly asking for a controller name in that case.
+	all, err := store.AllControllers()
+	if err != nil {
+		return errors.Trace(err)
+	}
+	for name, ctl := range all {
+		if ctl.ControllerUUID == controllerDetails.ControllerUUID {
+			// TODO(rogpeppe) lp#1614010 Succeed but override the account details in this case?
+			return errors.Errorf("controller is already registered as %q", name)
+		}
+	}
+	if err := store.AddController(controllerName, controllerDetails); err != nil {
+		return errors.Trace(err)
+	}
+	if err := store.UpdateAccount(controllerName, accountDetails); err != nil {
+		return errors.Annotatef(err, "cannot update account information: %v", err)
+	}
+	return nil
+}
+
+const noModelsMessage = `
+There are no models available. You can add models with
+"juju add-model", or you can ask an administrator or owner
+of a model to grant access to that model with "juju grant".
+`
+
+func (c *loginCommand) maybeSetCurrentModel(ctx *cmd.Context, store jujuclient.ClientStore, controllerName, userName string, models []apibase.UserModel) error {
+	if len(models) == 0 {
+		fmt.Fprint(ctx.Stderr, noModelsMessage)
+		return nil
+	}
+
+	// If we get to here, there is at least one model.
+	if len(models) == 1 {
+		// There is exactly one model shared,
+		// so set it as the current model.
+		model := models[0]
+		owner := names.NewUserTag(model.Owner)
+		modelName := jujuclient.JoinOwnerModelName(owner, model.Name)
+		err := store.SetCurrentModel(controllerName, modelName)
+		if err != nil {
+			return errors.Trace(err)
+		}
+		fmt.Fprintf(ctx.Stderr, "\nCurrent model set to %q.\n", modelName)
+		return nil
+	}
+	fmt.Fprintf(ctx.Stderr, `
+There are %d models available. Use "juju switch" to select
+one of them:
+`, len(models))
+	user := names.NewUserTag(userName)
+	ownerModelNames := make(set.Strings)
+	otherModelNames := make(set.Strings)
+	for _, model := range models {
+		if model.Owner == userName {
+			ownerModelNames.Add(model.Name)
+			continue
+		}
+		owner := names.NewUserTag(model.Owner)
+		modelName := common.OwnerQualifiedModelName(model.Name, owner, user)
+		otherModelNames.Add(modelName)
+	}
+	for _, modelName := range ownerModelNames.SortedValues() {
+		fmt.Fprintf(ctx.Stderr, "  - juju switch %s\n", modelName)
+	}
+	for _, modelName := range otherModelNames.SortedValues() {
+		fmt.Fprintf(ctx.Stderr, "  - juju switch %s\n", modelName)
+	}
+	return nil
+}
+
+type controllerDomainResponse struct {
+	Host string `json:"host"`
+}
+
+const defaultJujuDirectory = "https://api.jujucharms.com/directory"
+
+// getKnownControllerDomain returns the list of known
+// controller domain aliases.
+func (c *loginCommand) getKnownControllerDomain(name string) (string, error) {
+	if strings.Contains(name, ".") || strings.Contains(name, ":") {
+		return "", errors.NotFoundf("controller %q", name)
+	}
+	baseURL := defaultJujuDirectory
+	if u := os.Getenv("JUJU_DIRECTORY"); u != "" {
+		baseURL = u
+	}
+	client, err := c.BakeryClient()
+	if err != nil {
+		return "", errors.Trace(err)
+	}
+	req, err := http.NewRequest("GET", baseURL+"/v1/controller/"+name, nil)
+	if err != nil {
+		return "", errors.Trace(err)
+	}
+	httpResp, err := client.Do(req)
+	if err != nil {
+		return "", errors.Trace(err)
+	}
+	defer httpResp.Body.Close()
+	if httpResp.StatusCode != http.StatusOK {
+		if httpResp.StatusCode == http.StatusNotFound {
+			return "", errors.NotFoundf("controller %q", name)
+		}
+		return "", errors.Errorf("unexpected HTTP response %q", httpResp.Status)
+	}
+	var resp controllerDomainResponse
+	if err := httprequest.UnmarshalJSONResponse(httpResp, &resp); err != nil {
+		return "", errors.Trace(err)
+	}
+	if resp.Host == "" {
+		return "", errors.Errorf("no host field found in response")
+	}
+	return resp.Host, nil
+}
+
+func friendlyUserName(user string) string {
+	u := names.NewUserTag(user)
+	if u.IsLocal() {
+		return u.Name()
+	}
+	return u.Id()
 }

--- a/cmd/juju/user/logincontroller_test.go
+++ b/cmd/juju/user/logincontroller_test.go
@@ -1,0 +1,238 @@
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package user_test
+
+import (
+	"bytes"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"strings"
+
+	"github.com/juju/cmd"
+	"github.com/juju/errors"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/names.v2"
+
+	"github.com/juju/juju/api"
+	"github.com/juju/juju/api/base"
+	"github.com/juju/juju/cmd/juju/user"
+	"github.com/juju/juju/cmd/modelcmd"
+	"github.com/juju/juju/jujuclient"
+)
+
+// LoginControllerSuite tests the functionality of the login command
+// that logs into controllers rather than choosing a user name.
+// Most of the tests come from cmd/juju/controller/register_test.go - eventually
+// that command will be deleted.
+type LoginControllerSuite struct {
+	BaseSuite
+	apiConnection      *loginMockAPI
+	listModels         func(jujuclient.ClientStore, string, string) ([]base.UserModel, error)
+	listModelsUserName string
+	server             *httptest.Server
+	httpHandler        http.Handler
+}
+
+var _ = gc.Suite(&LoginControllerSuite{})
+
+func (s *LoginControllerSuite) SetUpTest(c *gc.C) {
+	s.BaseSuite.SetUpTest(c)
+
+	s.httpHandler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
+	s.server = httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		s.httpHandler.ServeHTTP(w, r)
+	}))
+
+	serverURL, err := url.Parse(s.server.URL)
+	c.Assert(err, jc.ErrorIsNil)
+	s.apiConnection = &loginMockAPI{
+		controllerTag: names.NewControllerTag(mockControllerUUID),
+		addr:          serverURL.Host,
+	}
+	s.listModelsUserName = ""
+	s.PatchValue(user.ListModels, func(_ *modelcmd.ControllerCommandBase, userName string) ([]base.UserModel, error) {
+		s.listModelsUserName = userName
+		return nil, nil
+	})
+	s.PatchValue(user.APIOpen, func(c *modelcmd.JujuCommandBase, info *api.Info, opts api.DialOpts) (api.Connection, error) {
+		return s.apiConnection, nil
+	})
+	s.PatchValue(user.LoginClientStore, s.store)
+	s.PatchEnvironment("JUJU_DIRECTORY", "http://0.1.2.3/directory")
+}
+
+func (s *LoginControllerSuite) TearDownTest(c *gc.C) {
+	s.server.Close()
+	s.FakeJujuXDGDataHomeSuite.TearDownTest(c)
+}
+
+func (s *LoginControllerSuite) TestLoginFromDirectory(c *gc.C) {
+	dirSrv := serveDirectory(map[string]string{
+		"bighost": "bighost.jujucharms.com:443",
+	})
+	defer dirSrv.Close()
+	os.Setenv("JUJU_DIRECTORY", dirSrv.URL)
+	s.apiConnection.authTag = names.NewUserTag("bob@external")
+	s.apiConnection.controllerAccess = "login"
+	stdout, stderr, code := s.run(c, "bighost")
+	c.Check(stderr, gc.Equals, `
+Welcome, bob@external. You are now logged into "bighost".
+`[1:]+user.NoModelsMessage)
+	c.Check(stdout, gc.Equals, "")
+	c.Assert(code, gc.Equals, 0)
+
+	// The controller and account details should be recorded with
+	// the specified controller name and user
+	// name from the auth tag.
+
+	controller, err := s.store.ControllerByName("bighost")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(controller, jc.DeepEquals, &jujuclient.ControllerDetails{
+		ControllerUUID: mockControllerUUID,
+		APIEndpoints:   []string{"bighost.jujucharms.com:443"},
+	})
+	account, err := s.store.AccountDetails("bighost")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(account, jc.DeepEquals, &jujuclient.AccountDetails{
+		User:            "bob@external",
+		LastKnownAccess: "login",
+	})
+}
+
+func (s *LoginControllerSuite) TestLoginPublicHostname(c *gc.C) {
+	s.apiConnection.authTag = names.NewUserTag("bob@external")
+	s.apiConnection.controllerAccess = "login"
+	stdout, stderr, code := s.run(c, "0.1.2.3")
+	c.Check(stderr, gc.Equals, `
+Welcome, bob@external. You are now logged into "0.1.2.3".
+`[1:]+user.NoModelsMessage)
+	c.Check(stdout, gc.Equals, "")
+	c.Assert(code, gc.Equals, 0)
+
+	// The controller and account details should be recorded with
+	// the specified controller name and user
+	// name from the auth tag.
+	controller, err := s.store.ControllerByName("0.1.2.3")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(controller, jc.DeepEquals, &jujuclient.ControllerDetails{
+		ControllerUUID: mockControllerUUID,
+		APIEndpoints:   []string{"0.1.2.3:443"},
+	})
+	account, err := s.store.AccountDetails("0.1.2.3")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(account, jc.DeepEquals, &jujuclient.AccountDetails{
+		User:            "bob@external",
+		LastKnownAccess: "login",
+	})
+}
+
+func (s *LoginControllerSuite) TestRegisterPublicHostnameWithPort(c *gc.C) {
+	s.apiConnection.authTag = names.NewUserTag("bob@external")
+	s.apiConnection.controllerAccess = "login"
+	stdout, stderr, code := s.run(c, "0.1.2.3:5678")
+	c.Check(stdout, gc.Equals, "")
+	c.Check(stderr, gc.Equals, "error: cannot use \"0.1.2.3:5678\" as controller name - use -c flag to choose a different one\n")
+	c.Check(code, gc.Equals, 1)
+}
+
+func (s *LoginControllerSuite) TestRegisterPublicHostnameWithPortAndControllerFlag(c *gc.C) {
+	s.apiConnection.authTag = names.NewUserTag("bob@external")
+	s.apiConnection.controllerAccess = "login"
+	stdout, stderr, code := s.run(c, "-c", "foo", "0.1.2.3:5678")
+	c.Check(stdout, gc.Equals, "")
+	c.Check(stderr, gc.Equals, `
+Welcome, bob@external. You are now logged into "foo".
+`[1:]+user.NoModelsMessage)
+	c.Check(stdout, gc.Equals, "")
+	c.Assert(code, gc.Equals, 0)
+
+	// The controller and account details should be recorded with
+	// the specified controller name and user
+	// name from the auth tag.
+	controller, err := s.store.ControllerByName("foo")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(controller, jc.DeepEquals, &jujuclient.ControllerDetails{
+		ControllerUUID: mockControllerUUID,
+		APIEndpoints:   []string{"0.1.2.3:5678"},
+	})
+}
+
+func (s *LoginControllerSuite) TestRegisterPublicAPIOpenError(c *gc.C) {
+	srv := serveDirectory(map[string]string{"bighost": "https://0.1.2.3/directory"})
+	defer srv.Close()
+	os.Setenv("JUJU_DIRECTORY", srv.URL)
+	*user.APIOpen = func(c *modelcmd.JujuCommandBase, info *api.Info, opts api.DialOpts) (api.Connection, error) {
+		return nil, errors.New("open failed")
+	}
+	stdout, stderr, code := s.run(c, "bighost")
+	c.Check(stdout, gc.Equals, "")
+	c.Check(stderr, gc.Matches, `error: open failed\n`)
+	c.Check(code, gc.Equals, 1)
+}
+
+func (s *LoginControllerSuite) run(c *gc.C, args ...string) (stdout, stderr string, errCode int) {
+	c.Logf("in LoginControllerSuite.run")
+	var stdoutBuf, stderrBuf bytes.Buffer
+	ctxt := &cmd.Context{
+		Dir:    c.MkDir(),
+		Stdin:  strings.NewReader(""),
+		Stdout: &stdoutBuf,
+		Stderr: &stderrBuf,
+	}
+	exitCode := cmd.Main(user.NewLoginCommand(), ctxt, args)
+	return stdoutBuf.String(), stderrBuf.String(), exitCode
+}
+
+// loginMockAPIConnection implements just enough of the api.Connection interface
+// to satisfy the methods used by the login command.
+type loginMockAPI struct {
+	// This will be nil - it's just there to satisfy the api.Connection
+	// interface methods not explicitly defined by loginMockAPIConnection.
+	api.Connection
+
+	// addr is returned by Addr.
+	addr string
+
+	// controllerTag is returned by ControllerTag.
+	controllerTag names.ControllerTag
+
+	// authTag is returned by AuthTag.
+	authTag names.Tag
+
+	// controllerAccess is returned by ControllerAccess.
+	controllerAccess string
+}
+
+func (*loginMockAPI) Close() error {
+	return nil
+}
+
+func (m *loginMockAPI) ControllerTag() names.ControllerTag {
+	return m.controllerTag
+}
+
+func (m *loginMockAPI) AuthTag() names.Tag {
+	return m.authTag
+}
+
+func (m *loginMockAPI) ControllerAccess() string {
+	return m.controllerAccess
+}
+
+const mockControllerUUID = "df136476-12e9-11e4-8a70-b2227cce2b54"
+
+func serveDirectory(dir map[string]string) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		name := strings.TrimPrefix(req.URL.Path, "/v1/controller/")
+		if name == req.URL.Path || dir[name] == "" {
+			http.NotFound(w, req)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintf(w, `{"host":%q}`, dir[name])
+	}))
+}

--- a/cmd/modelcmd/apicontext.go
+++ b/cmd/modelcmd/apicontext.go
@@ -4,6 +4,8 @@
 package modelcmd
 
 import (
+	"net/http"
+	"net/url"
 	"os"
 
 	"github.com/juju/cmd"
@@ -20,8 +22,10 @@ import (
 // APIContext holds the context required for making connections to
 // APIs used by juju.
 type APIContext struct {
-	Jar            *cookiejar.Jar
-	WebPageVisitor httpbakery.Visitor
+	// jar holds the internal version of the cookie jar - it has
+	// methods that clients should not use, such as Save.
+	jar            *domainCookieJar
+	webPageVisitor httpbakery.Visitor
 }
 
 // AuthOpts holds flags relating to authentication.
@@ -46,11 +50,19 @@ func (o *AuthOpts) SetFlags(f *gnuflag.FlagSet) {
 // This function is provided for use by commands that cannot use
 // JujuCommandBase. Most clients should use that instead.
 func NewAPIContext(ctxt *cmd.Context, opts *AuthOpts) (*APIContext, error) {
-	jar, err := cookiejar.New(&cookiejar.Options{
+	jar0, err := cookiejar.New(&cookiejar.Options{
 		Filename: cookieFile(),
 	})
 	if err != nil {
 		return nil, errors.Trace(err)
+	}
+	// The JUJU_USER_DOMAIN environment variable specifies
+	// the preferred user domain when discharging third party caveats.
+	// We set up a cookie jar that will send it to all sites because
+	// we don't know where the third party might be.
+	jar := &domainCookieJar{
+		Jar:    jar0,
+		domain: os.Getenv("JUJU_USER_DOMAIN"),
 	}
 	var visitors []httpbakery.Visitor
 	if ctxt != nil && opts != nil && opts.NoBrowser {
@@ -62,19 +74,24 @@ func NewAPIContext(ctxt *cmd.Context, opts *AuthOpts) (*APIContext, error) {
 	} else {
 		visitors = append(visitors, httpbakery.WebBrowserVisitor)
 	}
-	webPageVisitor := httpbakery.NewMultiVisitor(visitors...)
 	return &APIContext{
-		Jar:            jar,
-		WebPageVisitor: webPageVisitor,
+		jar:            jar,
+		webPageVisitor: httpbakery.NewMultiVisitor(visitors...),
 	}, nil
+}
+
+// CookieJar returns the cookie jar used to make
+// HTTP requests.
+func (ctx *APIContext) CookieJar() http.CookieJar {
+	return ctx.jar
 }
 
 // NewBakeryClient returns a new httpbakery.Client, using the API context's
 // persistent cookie jar and web page visitor.
 func (ctx *APIContext) NewBakeryClient() *httpbakery.Client {
 	client := httpbakery.NewClient()
-	client.Jar = ctx.Jar
-	client.WebPageVisitor = ctx.WebPageVisitor
+	client.Jar = ctx.jar
+	client.WebPageVisitor = ctx.webPageVisitor
 	return client
 }
 
@@ -91,8 +108,37 @@ func cookieFile() string {
 // Close closes the API context, saving any cookies to the
 // persistent cookie jar.
 func (ctxt *APIContext) Close() error {
-	if err := ctxt.Jar.Save(); err != nil {
+	if err := ctxt.jar.Save(); err != nil {
 		return errors.Annotatef(err, "cannot save cookie jar")
 	}
 	return nil
+}
+
+const domainCookieName = "domain"
+
+// domainCookieJar implements a variant of CookieJar that
+// always includes a domain cookie regardless of the site.
+type domainCookieJar struct {
+	*cookiejar.Jar
+	// domain holds the value of the domain cookie.
+	domain string
+}
+
+// Cookies implements http.CookieJar.Cookies by
+// adding the domain cookie when the domain is non-empty.
+func (j *domainCookieJar) Cookies(u *url.URL) []*http.Cookie {
+	cookies := j.Jar.Cookies(u)
+	if j.domain == "" {
+		return cookies
+	}
+	// Allow the site to override if it wants to.
+	for _, c := range cookies {
+		if c.Name == domainCookieName {
+			return cookies
+		}
+	}
+	return append(cookies, &http.Cookie{
+		Name:  domainCookieName,
+		Value: j.domain,
+	})
 }

--- a/cmd/modelcmd/apicontext_test.go
+++ b/cmd/modelcmd/apicontext_test.go
@@ -1,0 +1,92 @@
+package modelcmd_test
+
+import (
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/macaroon-bakery.v1/httpbakery"
+
+	"github.com/juju/juju/cmd/modelcmd"
+)
+
+type APIContextSuite struct {
+	testing.IsolationSuite
+}
+
+func (s *APIContextSuite) SetUpTest(c *gc.C) {
+	s.IsolationSuite.SetUpTest(c)
+	testing.MakeFakeHome(c)
+}
+
+var _ = gc.Suite(&APIContextSuite{})
+
+func (s *APIContextSuite) TestNewAPIContext(c *gc.C) {
+	ctx, err := modelcmd.NewAPIContext(nil, nil)
+	c.Assert(err, jc.ErrorIsNil)
+
+	handler := func(w http.ResponseWriter, req *http.Request) {
+		// Set a cookie so we can check that cookies are
+		// saved.
+		http.SetCookie(w, &http.Cookie{
+			Name:   "cook",
+			Value:  "val",
+			MaxAge: 1000,
+		})
+		w.Write([]byte("hello"))
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		handler(w, req)
+	}))
+	defer srv.Close()
+	// Check that we can use the client.
+	assertClientGet(c, ctx.NewBakeryClient(), srv.URL, "hello")
+
+	// Close the context, which should save the cookies.
+	err = ctx.Close()
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Make another APIContext which should
+	// get the cookies just saved.
+	ctx, err = modelcmd.NewAPIContext(nil, nil)
+	c.Assert(err, jc.ErrorIsNil)
+
+	handler = func(w http.ResponseWriter, req *http.Request) {
+		c.Check(req.Cookies(), jc.DeepEquals, []*http.Cookie{{
+			Name:  "cook",
+			Value: "val",
+		}})
+		w.Write([]byte("goodbye"))
+	}
+	assertClientGet(c, ctx.NewBakeryClient(), srv.URL, "goodbye")
+}
+
+func (s *APIContextSuite) TestDomainCookie(c *gc.C) {
+	s.PatchEnvironment("JUJU_USER_DOMAIN", "something")
+	ctx, err := modelcmd.NewAPIContext(nil, nil)
+	c.Assert(err, jc.ErrorIsNil)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		c.Check(req.Cookies(), jc.DeepEquals, []*http.Cookie{{
+			Name:  "domain",
+			Value: "something",
+		}})
+		w.Write([]byte("hello"))
+	}))
+	defer srv.Close()
+	// Check that we can use the client.
+	assertClientGet(c, ctx.NewBakeryClient(), srv.URL, "hello")
+}
+
+func assertClientGet(c *gc.C, client *httpbakery.Client, url string, expectBody string) {
+	req, err := http.NewRequest("GET", url, nil)
+	c.Assert(err, jc.ErrorIsNil)
+	resp, err := client.Do(req)
+	c.Assert(err, jc.ErrorIsNil)
+	defer resp.Body.Close()
+	c.Assert(resp.StatusCode, gc.Equals, http.StatusOK)
+	data, _ := ioutil.ReadAll(resp.Body)
+	c.Assert(string(data), gc.Equals, expectBody)
+}

--- a/cmd/modelcmd/base.go
+++ b/cmd/modelcmd/base.go
@@ -285,10 +285,7 @@ func (c *JujuCommandBase) ClearControllerMacaroons(endpoints []string) error {
 		return errors.Trace(err)
 	}
 	for _, s := range endpoints {
-		apictx.Jar.RemoveAllHost(s)
-	}
-	if err := apictx.Jar.Save(); err != nil {
-		return errors.Annotate(err, "can't remove cached authentication cookie")
+		apictx.jar.RemoveAllHost(s)
 	}
 	return nil
 }

--- a/cmd/modelcmd/base_test.go
+++ b/cmd/modelcmd/base_test.go
@@ -22,14 +22,14 @@ import (
 )
 
 type BaseCommandSuite struct {
-	coretesting.FakeJujuXDGDataHomeSuite
+	testing.IsolationSuite
 	store *jujuclienttesting.MemStore
 }
 
 var _ = gc.Suite(&BaseCommandSuite{})
 
 func (s *BaseCommandSuite) SetUpTest(c *gc.C) {
-	s.FakeJujuXDGDataHomeSuite.SetUpTest(c)
+	s.IsolationSuite.SetUpTest(c)
 
 	s.store = jujuclienttesting.NewMemStore()
 	s.store.CurrentControllerName = "foo"

--- a/cmd/modelcmd/controller_test.go
+++ b/cmd/modelcmd/controller_test.go
@@ -7,17 +7,17 @@ import (
 	"github.com/juju/cmd"
 	"github.com/juju/cmd/cmdtesting"
 	"github.com/juju/errors"
+	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/jujuclient"
 	"github.com/juju/juju/jujuclient/jujuclienttesting"
-	"github.com/juju/juju/testing"
 )
 
 type ControllerCommandSuite struct {
-	testing.FakeJujuXDGDataHomeSuite
+	testing.IsolationSuite
 }
 
 var _ = gc.Suite(&ControllerCommandSuite{})

--- a/cmd/modelcmd/credentials_test.go
+++ b/cmd/modelcmd/credentials_test.go
@@ -8,6 +8,7 @@ import (
 	"io/ioutil"
 	"path/filepath"
 
+	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
@@ -16,7 +17,7 @@ import (
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/jujuclient/jujuclienttesting"
 	_ "github.com/juju/juju/provider/dummy"
-	"github.com/juju/juju/testing"
+	jujutesting "github.com/juju/juju/testing"
 )
 
 func init() {
@@ -67,7 +68,7 @@ func (mockProvider) FinalizeCredential(
 }
 
 type credentialsSuite struct {
-	testing.FakeJujuXDGDataHomeSuite
+	testing.IsolationSuite
 	cloud cloud.Cloud
 	store *jujuclienttesting.MemStore
 }
@@ -75,7 +76,7 @@ type credentialsSuite struct {
 var _ = gc.Suite(&credentialsSuite{})
 
 func (s *credentialsSuite) SetUpTest(c *gc.C) {
-	s.FakeJujuXDGDataHomeSuite.SetUpTest(c)
+	s.IsolationSuite.SetUpTest(c)
 	s.cloud = cloud.Cloud{
 		Name: "cloud",
 		Type: "fake",
@@ -108,7 +109,7 @@ func (s *credentialsSuite) SetUpTest(c *gc.C) {
 
 func (s *credentialsSuite) assertGetCredentials(c *gc.C, cred, region string) {
 	credential, credentialName, regionName, err := modelcmd.GetCredentials(
-		testing.Context(c), s.store, modelcmd.GetCredentialsParams{
+		jujutesting.Context(c), s.store, modelcmd.GetCredentialsParams{
 			Cloud:          s.cloud,
 			CloudRegion:    region,
 			CredentialName: cred,

--- a/cmd/modelcmd/modelcommand_test.go
+++ b/cmd/modelcmd/modelcommand_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/juju/cmd"
 	"github.com/juju/cmd/cmdtesting"
+	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/names.v2"
@@ -19,16 +20,15 @@ import (
 	"github.com/juju/juju/jujuclient"
 	"github.com/juju/juju/jujuclient/jujuclienttesting"
 	"github.com/juju/juju/permission"
-	"github.com/juju/juju/testing"
 )
 
 type ModelCommandSuite struct {
-	testing.FakeJujuXDGDataHomeSuite
+	testing.IsolationSuite
 	store *jujuclienttesting.MemStore
 }
 
 func (s *ModelCommandSuite) SetUpTest(c *gc.C) {
-	s.FakeJujuXDGDataHomeSuite.SetUpTest(c)
+	s.IsolationSuite.SetUpTest(c)
 	s.PatchEnvironment("JUJU_CLI_VERSION", "")
 
 	s.store = jujuclienttesting.NewMemStore()

--- a/featuretests/cmd_juju_login_test.go
+++ b/featuretests/cmd_juju_login_test.go
@@ -60,7 +60,7 @@ func (s *cmdLoginSuite) TestLoginCommand(c *gc.C) {
 	s.changeUserPassword(c, "admin", "hunter2")
 	s.run(c, nil, "logout")
 
-	context := s.run(c, strings.NewReader("hunter2\nhunter2\n"), "login", "test")
+	context := s.run(c, strings.NewReader("hunter2\nhunter2\n"), "login", "test", "-u")
 	c.Assert(testing.Stdout(context), gc.Equals, "")
 	c.Assert(testing.Stderr(context), gc.Equals, `
 please enter password for test on kontroll: 


### PR DESCRIPTION
This adds the capability to specify a required user
domain for users, and alters the juju login command
so that it knows about public controllers.
