### PR TITLE
Inform user of storage destruction/detachment in remove-{application,unit}

### DIFF
--- a/api/application/client.go
+++ b/api/application/client.go
@@ -11,8 +11,8 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	"gopkg.in/juju/charm.v6-unstable"
+	"gopkg.in/juju/names.v2"
 
-	"github.com/juju/juju/api"
 	"github.com/juju/juju/api/base"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/charmstore"
@@ -26,12 +26,12 @@ var logger = loggo.GetLogger("juju.api.application")
 // Client allows access to the service API end point.
 type Client struct {
 	base.ClientFacade
-	st     api.Connection
+	st     base.APICallCloser
 	facade base.FacadeCaller
 }
 
 // NewClient creates a new client for accessing the application api.
-func NewClient(st api.Connection) *Client {
+func NewClient(st base.APICallCloser) *Client {
 	frontend, backend := base.NewClientFacade(st, "Application")
 	return &Client{ClientFacade: frontend, st: st, facade: backend}
 }
@@ -232,18 +232,101 @@ func (c *Client) AddUnits(application string, numUnits int, placement []*instanc
 	return results.Units, err
 }
 
-// DestroyUnits decreases the number of units dedicated to an application.
-func (c *Client) DestroyUnits(unitNames ...string) error {
+// DestroyUnitsDeprecated decreases the number of units dedicated to an
+// application.
+//
+// NOTE(axw) this exists only for backwards compatibility, for API facade
+// versions 1-3; clients should prefer its successor, DestroyUnits, below.
+//
+// TODO(axw) 2017-03-16 #1673323
+// Drop this in Juju 3.0.
+func (c *Client) DestroyUnitsDeprecated(unitNames ...string) error {
 	params := params.DestroyApplicationUnits{unitNames}
 	return c.facade.FacadeCall("DestroyUnits", params, nil)
 }
 
-// Destroy destroys a given application.
-func (c *Client) Destroy(application string) error {
+// DestroyUnits decreases the number of units dedicated to one or more
+// applications.
+func (c *Client) DestroyUnits(unitNames ...string) ([]params.DestroyUnitResult, error) {
+	args := params.Entities{
+		Entities: make([]params.Entity, 0, len(unitNames)),
+	}
+	allResults := make([]params.DestroyUnitResult, len(unitNames))
+	index := make([]int, 0, len(unitNames))
+	for i, name := range unitNames {
+		if !names.IsValidUnit(name) {
+			allResults[i].Error = &params.Error{
+				Message: errors.NotValidf("unit ID %q", name).Error(),
+			}
+			continue
+		}
+		index = append(index, i)
+		args.Entities = append(args.Entities, params.Entity{
+			Tag: names.NewUnitTag(name).String(),
+		})
+	}
+	if len(args.Entities) > 0 {
+		var result params.DestroyUnitResults
+		if err := c.facade.FacadeCall("DestroyUnit", args, &result); err != nil {
+			return nil, errors.Trace(err)
+		}
+		if n := len(result.Results); n != len(args.Entities) {
+			return nil, errors.Errorf("expected %d result(s), got %d", len(args.Entities), n)
+		}
+		for i, result := range result.Results {
+			allResults[index[i]] = result
+		}
+	}
+	return allResults, nil
+}
+
+// DestroyDeprecated destroys a given application.
+//
+// NOTE(axw) this exists only for backwards compatibility,
+// for API facade versions 1-3; clients should prefer its
+// successor, DestroyApplications, below.
+//
+// TODO(axw) 2017-03-16 #1673323
+// Drop this in Juju 3.0.
+func (c *Client) DestroyDeprecated(application string) error {
 	params := params.ApplicationDestroy{
 		ApplicationName: application,
 	}
 	return c.facade.FacadeCall("Destroy", params, nil)
+}
+
+// DestroyApplications destroys the given applications.
+func (c *Client) DestroyApplications(appNames ...string) ([]params.DestroyApplicationResult, error) {
+	args := params.Entities{
+		Entities: make([]params.Entity, 0, len(appNames)),
+	}
+	allResults := make([]params.DestroyApplicationResult, len(appNames))
+	index := make([]int, 0, len(appNames))
+	for i, name := range appNames {
+		if !names.IsValidApplication(name) {
+			allResults[i].Error = &params.Error{
+				Message: errors.NotValidf("application name %q", name).Error(),
+			}
+			continue
+		}
+		index = append(index, i)
+		args.Entities = append(args.Entities, params.Entity{
+			Tag: names.NewApplicationTag(name).String(),
+		})
+	}
+	if len(args.Entities) > 0 {
+		var result params.DestroyApplicationResults
+		if err := c.facade.FacadeCall("DestroyApplication", args, &result); err != nil {
+			return nil, errors.Trace(err)
+		}
+		if n := len(result.Results); n != len(args.Entities) {
+			return nil, errors.Errorf("expected %d result(s), got %d", len(args.Entities), n)
+		}
+		for i, result := range result.Results {
+			allResults[index[i]] = result
+		}
+	}
+	return allResults, nil
 }
 
 // GetConstraints returns the constraints for the given application.

--- a/api/application/package_test.go
+++ b/api/application/package_test.go
@@ -4,11 +4,11 @@
 package application_test
 
 import (
-	stdtesting "testing"
+	"testing"
 
-	"github.com/juju/juju/testing"
+	gc "gopkg.in/check.v1"
 )
 
-func TestAll(t *stdtesting.T) {
-	testing.MgoTestPackage(t)
+func TestAll(t *testing.T) {
+	gc.TestingT(t)
 }

--- a/api/facadeversions.go
+++ b/api/facadeversions.go
@@ -17,7 +17,7 @@ var facadeVersions = map[string]int{
 	"AllModelWatcher":              2,
 	"AllWatcher":                   1,
 	"Annotations":                  2,
-	"Application":                  3,
+	"Application":                  4,
 	"ApplicationScaler":            1,
 	"Backups":                      1,
 	"Block":                        2,

--- a/api/machinemanager/machinemanager.go
+++ b/api/machinemanager/machinemanager.go
@@ -5,6 +5,7 @@ package machinemanager
 
 import (
 	"github.com/juju/errors"
+	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/api/base"
 	"github.com/juju/juju/apiserver/params"
@@ -35,4 +36,35 @@ func (client *Client) AddMachines(machineParams []params.AddMachineParams) ([]pa
 		return nil, errors.Errorf("expected %d result, got %d", len(machineParams), len(results.Machines))
 	}
 	return results.Machines, err
+}
+
+// DestroyMachines removes a given set of machines.
+func (client *Client) DestroyMachines(machines ...string) ([]params.DestroyMachineResult, error) {
+	return client.destroyMachines("DestroyMachine", machines)
+}
+
+// ForceDestroyMachines removes a given set of machines and all
+// associated units.
+func (client *Client) ForceDestroyMachines(machines ...string) ([]params.DestroyMachineResult, error) {
+	return client.destroyMachines("ForceDestroyMachine", machines)
+}
+
+func (client *Client) destroyMachines(method string, machines []string) ([]params.DestroyMachineResult, error) {
+	entities := params.Entities{
+		Entities: make([]params.Entity, len(machines)),
+	}
+	for i, machineId := range machines {
+		if !names.IsValidMachine(machineId) {
+			return nil, errors.NotValidf("machine ID %q", machineId)
+		}
+		entities.Entities[i].Tag = names.NewMachineTag(machineId).String()
+	}
+	var out params.DestroyMachineResults
+	if err := client.facade.FacadeCall(method, entities, &out); err != nil {
+		return nil, errors.Trace(err)
+	}
+	if n := len(out.Results); n != len(machines) {
+		return nil, errors.Errorf("expected %d result(s), got %d", len(machines), n)
+	}
+	return out.Results, nil
 }

--- a/apiserver/application/application.go
+++ b/apiserver/application/application.go
@@ -642,6 +642,9 @@ func (api *API) AddUnits(args params.AddApplicationUnits) (params.AddApplication
 // NOTE(axw) this exists only for backwards compatibility,
 // for API facade versions 1-3; clients should prefer its
 // successor, DestroyUnit, below.
+//
+// TODO(axw) 2017-03-16 #1673323
+// Drop this in Juju 3.0.
 func (api *API) DestroyUnits(args params.DestroyApplicationUnits) error {
 	var errs []error
 	entities := params.Entities{
@@ -719,6 +722,9 @@ func (api *API) DestroyUnit(args params.Entities) (params.DestroyUnitResults, er
 // NOTE(axw) this exists only for backwards compatibility,
 // for API facade versions 1-3; clients should prefer its
 // successor, DestroyApplication, below.
+//
+// TODO(axw) 2017-03-16 #1673323
+// Drop this in Juju 3.0.
 func (api *API) Destroy(args params.ApplicationDestroy) error {
 	if !names.IsValidApplication(args.ApplicationName) {
 		return errors.NotValidf("application name %q", args.ApplicationName)

--- a/apiserver/application/application.go
+++ b/apiserver/application/application.go
@@ -13,6 +13,7 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	"github.com/juju/utils/featureflag"
+	"github.com/juju/utils/set"
 	"gopkg.in/juju/charm.v6-unstable"
 	csparams "gopkg.in/juju/charmrepo.v2-unstable/csclient/params"
 	"gopkg.in/juju/names.v2"
@@ -35,11 +36,13 @@ func init() {
 	// TODO - version 1 is required for the legacy deployer,
 	// remove when deploy is updated.
 	common.RegisterStandardFacade("Application", 1, newAPI)
-
 	common.RegisterStandardFacade("Application", 2, newAPI)
-
 	// Version 3 adds support for cross model relations.
 	common.RegisterStandardFacade("Application", 3, newAPI)
+	// Version 4 adds the DestroyUnit and DestroyApplication
+	// methods, superseding the existing DestroyUnits and
+	// Destroy methods respectively.
+	common.RegisterStandardFacade("Application", 4, newAPI)
 }
 
 // API implements the application interface and is the concrete
@@ -57,6 +60,15 @@ type API struct {
 	// should pass a charm.Charm and charm.URL back into
 	// state wherever we pass in a state.Charm currently.
 	stateCharm func(Charm) *state.Charm
+
+	deployApplicationFunc func(backend Backend, args jjj.DeployApplicationParams) error
+}
+
+// DeployApplication is a wrapper around juju.DeployApplication, to
+// match the function signature expected by NewAPI.
+func DeployApplication(backend Backend, args jjj.DeployApplicationParams) error {
+	_, err := jjj.DeployApplication(backend, args)
+	return err
 }
 
 func newAPI(ctx facade.Context) (*API, error) {
@@ -70,6 +82,7 @@ func newAPI(ctx facade.Context) (*API, error) {
 		ctx.StatePool(),
 		blockChecker,
 		stateCharm,
+		DeployApplication,
 	)
 }
 
@@ -81,18 +94,20 @@ func NewAPI(
 	statePool *state.StatePool,
 	blockChecker BlockChecker,
 	stateCharm func(Charm) *state.Charm,
+	deployApplication func(Backend, jjj.DeployApplicationParams) error,
 ) (*API, error) {
 	if !authorizer.AuthClient() {
 		return nil, common.ErrPerm
 	}
 	dataDir := resources.Get("dataDir").(common.StringResource)
 	return &API{
-		backend:    backend,
-		authorizer: authorizer,
-		check:      blockChecker,
-		stateCharm: stateCharm,
-		statePool:  statePool,
-		dataDir:    dataDir.String(),
+		backend:               backend,
+		authorizer:            authorizer,
+		check:                 blockChecker,
+		stateCharm:            stateCharm,
+		statePool:             statePool,
+		dataDir:               dataDir.String(),
+		deployApplicationFunc: deployApplication,
 	}, nil
 }
 
@@ -156,7 +171,7 @@ func (api *API) Deploy(args params.ApplicationsDeploy) (params.ErrorResults, err
 		return result, errors.Trace(err)
 	}
 	for i, arg := range args.Applications {
-		err := deployApplication(api.backend, api.stateCharm, arg)
+		err := deployApplication(api.backend, api.stateCharm, arg, api.deployApplicationFunc)
 		result.Results[i].Error = common.ServerError(err)
 	}
 	return result, nil
@@ -169,6 +184,7 @@ func deployApplication(
 	backend Backend,
 	stateCharm func(Charm) *state.Charm,
 	args params.ApplicationDeploy,
+	deployApplicationFunc func(Backend, jjj.DeployApplicationParams) error,
 ) error {
 	curl, err := charm.ParseURL(args.CharmURL)
 	if err != nil {
@@ -210,23 +226,19 @@ func deployApplication(
 		return errors.Trace(err)
 	}
 
-	channel := csparams.Channel(args.Channel)
-
-	_, err = jjj.DeployApplication(backend,
-		jjj.DeployApplicationParams{
-			ApplicationName:  args.ApplicationName,
-			Series:           args.Series,
-			Charm:            stateCharm(ch),
-			Channel:          channel,
-			NumUnits:         args.NumUnits,
-			ConfigSettings:   settings,
-			Constraints:      args.Constraints,
-			Placement:        args.Placement,
-			Storage:          args.Storage,
-			EndpointBindings: args.EndpointBindings,
-			Resources:        args.Resources,
-		})
-	return errors.Trace(err)
+	return errors.Trace(deployApplicationFunc(backend, jjj.DeployApplicationParams{
+		ApplicationName:  args.ApplicationName,
+		Series:           args.Series,
+		Charm:            stateCharm(ch),
+		Channel:          csparams.Channel(args.Channel),
+		NumUnits:         args.NumUnits,
+		ConfigSettings:   settings,
+		Constraints:      args.Constraints,
+		Placement:        args.Placement,
+		Storage:          args.Storage,
+		EndpointBindings: args.EndpointBindings,
+		Resources:        args.Resources,
+	}))
 }
 
 // ApplicationSetSettingsStrings updates the settings for the given application,
@@ -626,58 +638,166 @@ func (api *API) AddUnits(args params.AddApplicationUnits) (params.AddApplication
 }
 
 // DestroyUnits removes a given set of application units.
+//
+// NOTE(axw) this exists only for backwards compatibility,
+// for API facade versions 1-3; clients should prefer its
+// successor, DestroyUnit, below.
 func (api *API) DestroyUnits(args params.DestroyApplicationUnits) error {
-	if err := api.checkCanWrite(); err != nil {
-		return err
+	var errs []error
+	entities := params.Entities{
+		Entities: make([]params.Entity, 0, len(args.UnitNames)),
 	}
-	if err := api.check.RemoveAllowed(); err != nil {
+	for _, unitName := range args.UnitNames {
+		if !names.IsValidUnit(unitName) {
+			errs = append(errs, errors.NotValidf("unit name %q", unitName))
+			continue
+		}
+		entities.Entities = append(entities.Entities, params.Entity{
+			Tag: names.NewUnitTag(unitName).String(),
+		})
+	}
+	results, err := api.DestroyUnit(entities)
+	if err != nil {
 		return errors.Trace(err)
 	}
-	var errs []string
-	for _, name := range args.UnitNames {
-		unit, err := api.backend.Unit(name)
-		switch {
-		case errors.IsNotFound(err):
-			err = errors.Errorf("unit %q does not exist", name)
-		case err != nil:
-		case unit.Life() != state.Alive:
-			continue
-		case unit.IsPrincipal():
-			err = unit.Destroy()
-		default:
-			err = errors.Errorf("unit %q is a subordinate", name)
-		}
-		if err != nil {
-			errs = append(errs, err.Error())
+	for _, result := range results.Results {
+		if result.Error != nil {
+			errs = append(errs, result.Error)
 		}
 	}
 	return common.DestroyErr("units", args.UnitNames, errs)
 }
 
-type appDestroy interface {
-	Destroy() (err error)
+// DestroyUnit removes a given set of application units.
+func (api *API) DestroyUnit(args params.Entities) (params.DestroyUnitResults, error) {
+	if err := api.checkCanWrite(); err != nil {
+		return params.DestroyUnitResults{}, err
+	}
+	if err := api.check.RemoveAllowed(); err != nil {
+		return params.DestroyUnitResults{}, errors.Trace(err)
+	}
+	destroyUnit := func(entity params.Entity) (*params.DestroyUnitInfo, error) {
+		unitTag, err := names.ParseUnitTag(entity.Tag)
+		if err != nil {
+			return nil, err
+		}
+		name := unitTag.Id()
+		unit, err := api.backend.Unit(name)
+		if errors.IsNotFound(err) {
+			return nil, errors.Errorf("unit %q does not exist", name)
+		} else if err != nil {
+			return nil, errors.Trace(err)
+		}
+		if !unit.IsPrincipal() {
+			return nil, errors.Errorf("unit %q is a subordinate", name)
+		}
+		var info params.DestroyUnitInfo
+		storage, err := api.unitStorage(unit, true)
+		if err != nil {
+			return nil, err
+		}
+		info.DestroyedStorage, info.DetachedStorage = classifyStorage(storage)
+		if err := unit.Destroy(); err != nil {
+			return nil, err
+		}
+		return &info, nil
+	}
+	results := make([]params.DestroyUnitResult, len(args.Entities))
+	for i, entity := range args.Entities {
+		info, err := destroyUnit(entity)
+		if err != nil {
+			results[i].Error = common.ServerError(err)
+			continue
+		}
+		results[i].Info = info
+	}
+	return params.DestroyUnitResults{results}, nil
 }
 
 // Destroy destroys a given application, local or remote.
+//
+// NOTE(axw) this exists only for backwards compatibility,
+// for API facade versions 1-3; clients should prefer its
+// successor, DestroyApplication, below.
 func (api *API) Destroy(args params.ApplicationDestroy) error {
-	if err := api.checkCanWrite(); err != nil {
-		return err
+	if !names.IsValidApplication(args.ApplicationName) {
+		return errors.NotValidf("application name %q", args.ApplicationName)
 	}
-	if err := api.check.RemoveAllowed(); err != nil {
+	entities := params.Entities{
+		Entities: []params.Entity{{
+			Tag: names.NewApplicationTag(args.ApplicationName).String(),
+		}},
+	}
+	results, err := api.DestroyApplication(entities)
+	if err != nil {
 		return errors.Trace(err)
 	}
-	var (
-		app appDestroy
-		err error
-	)
-	app, err = api.backend.RemoteApplication(args.ApplicationName)
-	if errors.IsNotFound(err) {
-		app, err = api.backend.Application(args.ApplicationName)
+	if err := results.Results[0].Error; err != nil {
+		return common.ServerError(err)
 	}
-	if err != nil {
-		return err
+	return nil
+}
+
+// DestroyApplication removes a given set of applications.
+func (api *API) DestroyApplication(args params.Entities) (params.DestroyApplicationResults, error) {
+	if err := api.checkCanWrite(); err != nil {
+		return params.DestroyApplicationResults{}, err
 	}
-	return app.Destroy()
+	if err := api.check.RemoveAllowed(); err != nil {
+		return params.DestroyApplicationResults{}, errors.Trace(err)
+	}
+	destroyRemoteApp := func(name string) error {
+		app, err := api.backend.RemoteApplication(name)
+		if err != nil {
+			return err
+		}
+		return app.Destroy()
+	}
+	destroyApp := func(entity params.Entity) (*params.DestroyApplicationInfo, error) {
+		tag, err := names.ParseApplicationTag(entity.Tag)
+		if err != nil {
+			return nil, err
+		}
+		var info params.DestroyApplicationInfo
+		if err := destroyRemoteApp(tag.Id()); !errors.IsNotFound(err) {
+			return &info, err
+		}
+		app, err := api.backend.Application(tag.Id())
+		if err != nil {
+			return nil, err
+		}
+		units, err := app.AllUnits()
+		if err != nil {
+			return nil, err
+		}
+		for _, unit := range units {
+			info.DestroyedUnits = append(
+				info.DestroyedUnits,
+				params.Entity{unit.UnitTag().String()},
+			)
+			storage, err := api.unitStorage(unit, false)
+			if err != nil {
+				return nil, err
+			}
+			destroyed, detached := classifyStorage(storage)
+			info.DestroyedStorage = append(info.DestroyedStorage, destroyed...)
+			info.DetachedStorage = append(info.DetachedStorage, detached...)
+		}
+		if err := app.Destroy(); err != nil {
+			return nil, err
+		}
+		return &info, nil
+	}
+	results := make([]params.DestroyApplicationResult, len(args.Entities))
+	for i, entity := range args.Entities {
+		info, err := destroyApp(entity)
+		if err != nil {
+			results[i].Error = common.ServerError(err)
+			continue
+		}
+		results[i].Info = info
+	}
+	return params.DestroyApplicationResults{results}, nil
 }
 
 // GetConstraints returns the constraints for a given application.
@@ -1145,4 +1265,43 @@ func (api *API) DestroyRelation(args params.DestroyRelation) error {
 		return err
 	}
 	return rel.Destroy()
+}
+
+func (api *API) unitStorage(unit Unit, unitOnly bool) ([]state.StorageInstance, error) {
+	attachments, err := api.backend.UnitStorageAttachments(unit.UnitTag())
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	instances := make([]state.StorageInstance, 0, len(attachments))
+	seen := make(set.Tags)
+	for _, attachment := range attachments {
+		storageTag := attachment.StorageInstance()
+		if seen.Contains(storageTag) {
+			continue
+		}
+		instance, err := api.backend.StorageInstance(attachment.StorageInstance())
+		if errors.IsNotFound(err) {
+			continue
+		} else if err != nil {
+			return nil, errors.Trace(err)
+		}
+		owner, hasOwner := instance.Owner()
+		if !hasOwner || (unitOnly && owner != unit.UnitTag()) {
+			continue
+		}
+		seen.Add(storageTag)
+		instances = append(instances, instance)
+	}
+	return instances, nil
+}
+
+func classifyStorage(storage []state.StorageInstance) (destroyed, detached []params.Entity) {
+	for _, storage := range storage {
+		// TODO(axw) we need to expose on StorageInstance
+		// whether or not it is detachable. Then we can
+		// decide here whether the storage will be detached
+		// or destroyed.
+		destroyed = append(destroyed, params.Entity{storage.Tag().String()})
+	}
+	return destroyed, detached
 }

--- a/apiserver/application/get_test.go
+++ b/apiserver/application/get_test.go
@@ -42,6 +42,7 @@ func (s *getSuite) SetUpTest(c *gc.C) {
 	s.serviceAPI, err = application.NewAPI(
 		backend, s.authorizer, resources, s.BackingStatePool,
 		blockChecker, application.CharmToStateCharm,
+		application.DeployApplication,
 	)
 	c.Assert(err, jc.ErrorIsNil)
 }

--- a/apiserver/client/perm_test.go
+++ b/apiserver/client/perm_test.go
@@ -122,8 +122,16 @@ func (s *permSuite) TestOperationPerm(c *gc.C) {
 		op:    opClientDestroyServiceUnits,
 		allow: []names.Tag{userAdmin, userOther},
 	}, {
+		about: "Application.DestroyUnit",
+		op:    opClientDestroyUnit,
+		allow: []names.Tag{userAdmin, userOther},
+	}, {
 		about: "Application.Destroy",
 		op:    opClientServiceDestroy,
+		allow: []names.Tag{userAdmin, userOther},
+	}, {
+		about: "Application.DestroyApplication",
+		op:    opClientDestroyApplication,
 		allow: []names.Tag{userAdmin, userOther},
 	}, {
 		about: "Application.GetConstraints",
@@ -342,18 +350,28 @@ func opClientAddServiceUnits(c *gc.C, st api.Connection, mst *state.State) (func
 }
 
 func opClientDestroyServiceUnits(c *gc.C, st api.Connection, mst *state.State) (func(), error) {
-	err := application.NewClient(st).DestroyUnits("wordpress/99")
+	err := application.NewClient(st).DestroyUnitsDeprecated("wordpress/99")
 	if err != nil && strings.HasPrefix(err.Error(), "no units were destroyed") {
 		err = nil
 	}
 	return func() {}, err
 }
 
+func opClientDestroyUnit(c *gc.C, st api.Connection, mst *state.State) (func(), error) {
+	_, err := application.NewClient(st).DestroyUnits("wordpress/99")
+	return func() {}, err
+}
+
 func opClientServiceDestroy(c *gc.C, st api.Connection, mst *state.State) (func(), error) {
-	err := application.NewClient(st).Destroy("non-existent")
+	err := application.NewClient(st).DestroyDeprecated("non-existent")
 	if params.IsCodeNotFound(err) {
 		err = nil
 	}
+	return func() {}, err
+}
+
+func opClientDestroyApplication(c *gc.C, st api.Connection, mst *state.State) (func(), error) {
+	_, err := application.NewClient(st).DestroyApplications("non-existent")
 	return func() {}, err
 }
 

--- a/apiserver/common/errors.go
+++ b/apiserver/common/errors.go
@@ -252,7 +252,7 @@ func ServerError(err error) *params.Error {
 	}
 }
 
-func DestroyErr(desc string, ids, errs []string) error {
+func DestroyErr(desc string, ids []string, errs []error) error {
 	// TODO(waigani) refactor DestroyErr to take a map of ids to errors.
 	if len(errs) == 0 {
 		return nil
@@ -262,7 +262,11 @@ func DestroyErr(desc string, ids, errs []string) error {
 		msg = "no %s were destroyed"
 	}
 	msg = fmt.Sprintf(msg, desc)
-	return errors.Errorf("%s: %s", msg, strings.Join(errs, "; "))
+	errStrings := make([]string, len(errs))
+	for i, err := range errs {
+		errStrings[i] = err.Error()
+	}
+	return errors.Errorf("%s: %s", msg, strings.Join(errStrings, "; "))
 }
 
 // RestoreError makes a best effort at converting the given error

--- a/apiserver/common/errors_test.go
+++ b/apiserver/common/errors_test.go
@@ -266,10 +266,10 @@ func (s *errorsSuite) TestUnknownModel(c *gc.C) {
 }
 
 func (s *errorsSuite) TestDestroyErr(c *gc.C) {
-	errs := []string{
-		"error one",
-		"error two",
-		"error three",
+	errs := []error{
+		errors.New("error one"),
+		errors.New("error two"),
+		errors.New("error three"),
 	}
 	ids := []string{
 		"id1",

--- a/apiserver/common/machine.go
+++ b/apiserver/common/machine.go
@@ -74,7 +74,7 @@ func DestroyMachines(st origStateInterface, force bool, ids ...string) error {
 }
 
 func destroyMachines(st stateInterface, force bool, ids ...string) error {
-	var errs []string
+	var errs []error
 	for _, id := range ids {
 		machine, err := st.Machine(id)
 		switch {
@@ -89,7 +89,7 @@ func destroyMachines(st stateInterface, force bool, ids ...string) error {
 			err = machine.Destroy()
 		}
 		if err != nil {
-			errs = append(errs, err.Error())
+			errs = append(errs, err)
 		}
 	}
 	return DestroyErr("machines", ids, errs)

--- a/apiserver/params/params.go
+++ b/apiserver/params/params.go
@@ -897,3 +897,89 @@ type MacaroonResult struct {
 	Result *macaroon.Macaroon `json:"result,omitempty"`
 	Error  *Error             `json:"error,omitempty"`
 }
+
+// DestroyMachineResults contains the results of a MachineManager.Destroy
+// API request.
+type DestroyMachineResults struct {
+	Results []DestroyMachineResult `json:"results,omitempty"`
+}
+
+// DestroyMachineResult contains one of the results of a MachineManager.Destroy
+// API request.
+type DestroyMachineResult struct {
+	Error *Error              `json:"error,omitempty"`
+	Info  *DestroyMachineInfo `json:"info,omitempty"`
+}
+
+// DestroyMachineInfo contains information related to the removal of
+// a machine.
+type DestroyMachineInfo struct {
+	// DetachedStorage is the tags of storage instances that will be
+	// detached from the machine (assigned units) as a result of
+	// destroying the machine, and will remain in the model after
+	// the machine and unit are removed.
+	DetachedStorage []Entity `json:"detached-storage,omitempty"`
+
+	// DestroyedStorage is the tags of storage instances that will be
+	// destroyed as a result of destroying the machine.
+	DestroyedStorage []Entity `json:"destroyed-storage,omitempty"`
+
+	// DestroyedStorage is the tags of units that will be destroyed
+	// as a result of destroying the machine.
+	DestroyedUnits []Entity `json:"destroyed-units,omitempty"`
+}
+
+// DestroyApplicationResults contains the results of a DestroyApplication
+// API request.
+type DestroyApplicationResults struct {
+	Results []DestroyApplicationResult `json:"results,omitempty"`
+}
+
+// DestroyApplicationResult contains one of the results of a
+// DestroyApplication API request.
+type DestroyApplicationResult struct {
+	Error *Error                  `json:"error,omitempty"`
+	Info  *DestroyApplicationInfo `json:"info,omitempty"`
+}
+
+// DestroyApplicationInfo contains information related to the removal of
+// an application.
+type DestroyApplicationInfo struct {
+	// DetachedStorage is the tags of storage instances that will be
+	// detached from the application's units, and will remain in the
+	// model after the units are removed.
+	DetachedStorage []Entity `json:"detached-storage,omitempty"`
+
+	// DestroyedStorage is the tags of storage instances that will be
+	// destroyed as a result of destroying the application.
+	DestroyedStorage []Entity `json:"destroyed-storage,omitempty"`
+
+	// DestroyedUnits is the tags of units that will be destroyed
+	// as a result of destroying the application.
+	DestroyedUnits []Entity `json:"destroyed-units,omitempty"`
+}
+
+// DestroyUnitResults contains the results of a DestroyUnit API request.
+type DestroyUnitResults struct {
+	Results []DestroyUnitResult `json:"results,omitempty"`
+}
+
+// DestroyUnitResult contains one of the results of a
+// DestroyUnit API request.
+type DestroyUnitResult struct {
+	Error *Error           `json:"error,omitempty"`
+	Info  *DestroyUnitInfo `json:"info,omitempty"`
+}
+
+// DestroyUnitInfo contains information related to the removal of
+// an application unit.
+type DestroyUnitInfo struct {
+	// DetachedStorage is the tags of storage instances that will be
+	// detached from the unit, and will remain in the model after
+	// the unit is removed.
+	DetachedStorage []Entity `json:"detached-storage,omitempty"`
+
+	// DestroyedStorage is the tags of storage instances that will be
+	// destroyed as a result of destroying the unit.
+	DestroyedStorage []Entity `json:"destroyed-storage,omitempty"`
+}

--- a/cmd/juju/application/removeapplication.go
+++ b/cmd/juju/application/removeapplication.go
@@ -27,11 +27,11 @@ func NewRemoveApplicationCommand() cmd.Command {
 // removeServiceCommand causes an existing application to be destroyed.
 type removeApplicationCommand struct {
 	modelcmd.ModelCommandBase
-	ApplicationName string
+	ApplicationNames []string
 }
 
 var helpSummaryRmApp = `
-Remove an application from the model.`[1:]
+Remove applications from the model.`[1:]
 
 var helpDetailsRmApp = `
 Removing an application will terminate any relations that application has, remove
@@ -49,7 +49,7 @@ Examples:
 func (c *removeApplicationCommand) Info() *cmd.Info {
 	return &cmd.Info{
 		Name:    "remove-application",
-		Args:    "<application>",
+		Args:    "<application> [<application>...]",
 		Purpose: helpSummaryRmApp,
 		Doc:     helpDetailsRmApp,
 	}
@@ -59,48 +59,124 @@ func (c *removeApplicationCommand) Init(args []string) error {
 	if len(args) == 0 {
 		return errors.Errorf("no application specified")
 	}
-	if !names.IsValidApplication(args[0]) {
-		return errors.Errorf("invalid application name %q", args[0])
+	for _, arg := range args {
+		if !names.IsValidApplication(arg) {
+			return errors.Errorf("invalid application name %q", arg)
+		}
 	}
-	c.ApplicationName, args = args[0], args[1:]
-	return cmd.CheckEmpty(args)
+	c.ApplicationNames = args
+	return nil
 }
 
 type removeApplicationAPI interface {
 	Close() error
-	Destroy(serviceName string) error
-	DestroyUnits(unitNames ...string) error
-	GetCharmURL(serviceName string) (*charm.URL, error)
+	DestroyApplications(appName ...string) ([]params.DestroyApplicationResult, error)
+	DestroyDeprecated(appName string) error
+	DestroyUnits(unitNames ...string) ([]params.DestroyUnitResult, error)
+	DestroyUnitsDeprecated(unitNames ...string) error
+	GetCharmURL(appName string) (*charm.URL, error)
 	ModelUUID() string
 }
 
-func (c *removeApplicationCommand) getAPI() (removeApplicationAPI, error) {
+func (c *removeApplicationCommand) getAPI() (removeApplicationAPI, int, error) {
 	root, err := c.NewAPIRoot()
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, -1, errors.Trace(err)
 	}
-	return application.NewClient(root), nil
+	version := root.BestFacadeVersion("Application")
+	return application.NewClient(root), version, nil
 }
 
 func (c *removeApplicationCommand) Run(ctx *cmd.Context) error {
-	client, err := c.getAPI()
+	client, apiVersion, err := c.getAPI()
 	if err != nil {
 		return err
 	}
 	defer client.Close()
-	err = block.ProcessBlockedError(client.Destroy(c.ApplicationName), block.BlockRemove)
-	if err != nil {
-		return err
+
+	if apiVersion < 4 {
+		return c.removeApplicationsDeprecated(ctx, client)
 	}
-	return c.removeAllocation(ctx)
+	return c.removeApplications(ctx, client)
 }
 
-func (c *removeApplicationCommand) removeAllocation(ctx *cmd.Context) error {
-	client, err := c.getAPI()
-	if err != nil {
-		return err
+// TODO(axw) 2017-03-16 #1673323
+// Drop this in Juju 3.0.
+func (c *removeApplicationCommand) removeApplicationsDeprecated(
+	ctx *cmd.Context,
+	client removeApplicationAPI,
+) error {
+	for _, name := range c.ApplicationNames {
+		err := client.DestroyDeprecated(name)
+		if err := block.ProcessBlockedError(err, block.BlockRemove); err != nil {
+			return errors.Trace(err)
+		}
+		if err := c.removeAllocation(ctx, client, name); err != nil {
+			return errors.Trace(err)
+		}
 	}
-	charmURL, err := client.GetCharmURL(c.ApplicationName)
+	return nil
+}
+
+func (c *removeApplicationCommand) removeApplications(
+	ctx *cmd.Context,
+	client removeApplicationAPI,
+) error {
+	results, err := client.DestroyApplications(c.ApplicationNames...)
+	if err := block.ProcessBlockedError(err, block.BlockRemove); err != nil {
+		return errors.Trace(err)
+	}
+	anyFailed := false
+	for i, name := range c.ApplicationNames {
+		result := results[i]
+		if result.Error != nil {
+			ctx.Infof("removing application %s failed: %s", name, result.Error)
+			anyFailed = true
+			continue
+		}
+		if err := c.removeAllocation(ctx, client, name); err != nil {
+			ctx.Infof("removing allocation for application %s failed: %s", name, result.Error)
+			anyFailed = true
+			continue
+		}
+		ctx.Infof("removing application %s", name)
+		for _, entity := range result.Info.DestroyedUnits {
+			unitTag, err := names.ParseUnitTag(entity.Tag)
+			if err != nil {
+				logger.Warningf("%s", err)
+				continue
+			}
+			ctx.Verbosef("- will remove %s", names.ReadableString(unitTag))
+		}
+		for _, entity := range result.Info.DestroyedStorage {
+			storageTag, err := names.ParseStorageTag(entity.Tag)
+			if err != nil {
+				logger.Warningf("%s", err)
+				continue
+			}
+			ctx.Infof("- will remove %s", names.ReadableString(storageTag))
+		}
+		for _, entity := range result.Info.DetachedStorage {
+			storageTag, err := names.ParseStorageTag(entity.Tag)
+			if err != nil {
+				logger.Warningf("%s", err)
+				continue
+			}
+			ctx.Infof("- will detach %s", names.ReadableString(storageTag))
+		}
+	}
+	if anyFailed {
+		return cmd.ErrSilent
+	}
+	return nil
+}
+
+func (c *removeApplicationCommand) removeAllocation(
+	ctx *cmd.Context,
+	client removeApplicationAPI,
+	applicationName string,
+) error {
+	charmURL, err := client.GetCharmURL(applicationName)
 	// Not all apps have charms, eg remote applications.
 	if params.ErrCode(err) == params.CodeNotFound {
 		return nil
@@ -132,7 +208,7 @@ func (c *removeApplicationCommand) removeAllocation(ctx *cmd.Context) error {
 	}
 	budgetClient := getBudgetAPIClient(bakeryClient)
 
-	resp, err := budgetClient.DeleteAllocation(modelUUID, c.ApplicationName)
+	resp, err := budgetClient.DeleteAllocation(modelUUID, applicationName)
 	if wireformat.IsNotAvail(err) {
 		logger.Warningf("allocation not removed: %v", err)
 	} else if err != nil {

--- a/cmd/juju/application/removeapplication_test.go
+++ b/cmd/juju/application/removeapplication_test.go
@@ -19,7 +19,6 @@ import (
 	"github.com/juju/juju/api/modelconfig"
 	"github.com/juju/juju/cmd/modelcmd"
 	jujutesting "github.com/juju/juju/juju/testing"
-	"github.com/juju/juju/rpc"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/testcharms"
 	"github.com/juju/juju/testing"
@@ -44,9 +43,8 @@ func (s *RemoveApplicationSuite) SetUpTest(c *gc.C) {
 	s.PatchValue(&getBudgetAPIClient, func(*httpbakery.Client) budgetAPIClient { return s.budgetAPIClient })
 }
 
-func runRemoveApplication(c *gc.C, args ...string) error {
-	_, err := testing.RunCommand(c, NewRemoveApplicationCommand(), args...)
-	return err
+func runRemoveApplication(c *gc.C, args ...string) (*cmd.Context, error) {
+	return testing.RunCommand(c, NewRemoveApplicationCommand(), args...)
 }
 
 func (s *RemoveApplicationSuite) setupTestApplication(c *gc.C) {
@@ -58,12 +56,31 @@ func (s *RemoveApplicationSuite) setupTestApplication(c *gc.C) {
 
 func (s *RemoveApplicationSuite) TestLocalApplication(c *gc.C) {
 	s.setupTestApplication(c)
-	err := runRemoveApplication(c, "riak")
+	ctx, err := runRemoveApplication(c, "riak")
 	c.Assert(err, jc.ErrorIsNil)
+	stderr := testing.Stderr(ctx)
+	c.Assert(stderr, gc.Equals, "removing application riak\n")
 	riak, err := s.State.Application("riak")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(riak.Life(), gc.Equals, state.Dying)
 	s.stub.CheckNoCalls(c)
+}
+
+func (s *RemoveApplicationSuite) TestInformStorageRemoved(c *gc.C) {
+	ch := testcharms.Repo.CharmArchivePath(s.CharmsPath, "storage-filesystem")
+	err := runDeploy(c, ch, "storage-filesystem", "--series", "quantal", "-n2", "--storage", "data=2,rootfs")
+	c.Assert(err, jc.ErrorIsNil)
+
+	ctx, err := runRemoveApplication(c, "storage-filesystem")
+	c.Assert(err, jc.ErrorIsNil)
+	stderr := testing.Stderr(ctx)
+	c.Assert(stderr, gc.Equals, `
+removing application storage-filesystem
+- will remove storage data/0
+- will remove storage data/1
+- will remove storage data/2
+- will remove storage data/3
+`[1:])
 }
 
 func (s *RemoveApplicationSuite) TestRemoteApplication(c *gc.C) {
@@ -76,8 +93,11 @@ func (s *RemoveApplicationSuite) TestRemoteApplication(c *gc.C) {
 	_, err = s.State.RemoteApplication("remote-app")
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = runRemoveApplication(c, "remote-app")
+	ctx, err := runRemoveApplication(c, "remote-app")
 	c.Assert(err, jc.ErrorIsNil)
+	stderr := testing.Stderr(ctx)
+	c.Assert(stderr, gc.Equals, "removing application remote-app\n")
+
 	// Removed immediately since there are no units.
 	_, err = s.State.RemoteApplication("remote-app")
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
@@ -89,7 +109,7 @@ func (s *RemoveApplicationSuite) TestRemoveLocalMetered(c *gc.C) {
 	deploy := NewDefaultDeployCommand()
 	_, err := testing.RunCommand(c, deploy, ch, "--series", "quantal")
 	c.Assert(err, jc.ErrorIsNil)
-	err = runRemoveApplication(c, "metered")
+	_, err = runRemoveApplication(c, "metered")
 	c.Assert(err, jc.ErrorIsNil)
 	riak, err := s.State.Application("metered")
 	c.Assert(err, jc.ErrorIsNil)
@@ -102,7 +122,7 @@ func (s *RemoveApplicationSuite) TestBlockRemoveService(c *gc.C) {
 
 	// block operation
 	s.BlockRemoveObject(c, "TestBlockRemoveService")
-	err := runRemoveApplication(c, "riak")
+	_, err := runRemoveApplication(c, "riak")
 	s.AssertBlocked(c, err, ".*TestBlockRemoveService.*")
 	riak, err := s.State.Application("riak")
 	c.Assert(err, jc.ErrorIsNil)
@@ -112,20 +132,20 @@ func (s *RemoveApplicationSuite) TestBlockRemoveService(c *gc.C) {
 
 func (s *RemoveApplicationSuite) TestFailure(c *gc.C) {
 	// Destroy an application that does not exist.
-	err := runRemoveApplication(c, "gargleblaster")
-	c.Assert(errors.Cause(err), gc.DeepEquals, &rpc.RequestError{
-		Message: `application "gargleblaster" not found`,
-		Code:    "not found",
-	})
+	ctx, err := runRemoveApplication(c, "gargleblaster")
+	c.Assert(err, gc.Equals, cmd.ErrSilent)
+
+	stderr := testing.Stderr(ctx)
+	c.Assert(stderr, gc.Equals, `
+removing application gargleblaster failed: application "gargleblaster" not found
+`[1:])
 	s.stub.CheckNoCalls(c)
 }
 
 func (s *RemoveApplicationSuite) TestInvalidArgs(c *gc.C) {
-	err := runRemoveApplication(c)
+	_, err := runRemoveApplication(c)
 	c.Assert(err, gc.ErrorMatches, `no application specified`)
-	err = runRemoveApplication(c, "ping", "pong")
-	c.Assert(err, gc.ErrorMatches, `unrecognized args: \["pong"\]`)
-	err = runRemoveApplication(c, "invalid:name")
+	_, err = runRemoveApplication(c, "invalid:name")
 	c.Assert(err, gc.ErrorMatches, `invalid application name "invalid:name"`)
 	s.stub.CheckNoCalls(c)
 }
@@ -178,7 +198,7 @@ func (s *RemoveCharmStoreCharmsSuite) SetUpTest(c *gc.C) {
 }
 
 func (s *RemoveCharmStoreCharmsSuite) TestRemoveAllocation(c *gc.C) {
-	err := runRemoveApplication(c, "metered")
+	_, err := runRemoveApplication(c, "metered")
 	c.Assert(err, jc.ErrorIsNil)
 	s.stub.CheckCalls(c, []jutesting.StubCall{{
 		"DeleteAllocation", []interface{}{testing.ModelTag.Id(), "metered"}}})


### PR DESCRIPTION
## Description of change

We introduce new DestroyApplication and DestroyUnit
methods to the Application facade. These supersede
the existing Destroy and DestroyUnits methods,
respectively. The new methods are bulk, and return
information relating to the entities being destroyed.

This enables us to inform the user of storage that is
destroyed, or detached and left in the model, when
removing an application or unit with the remove-application
or remove-unit commands.

We will do the same for remove-machine in a follow-up.

Also, move a few tests over to the unit test suite in
apiserver/application.

## QA steps

1. juju bootstrap localhost
2. juju deploy postgresql -n2 --storage pgdata=rootfs
3. juju remove-unit postgresql/0
should see: 
> removing unit postgresql/0
> - removing storage pgdata/0
4. juju remove-application postgresql/1 --verbose
should see: 
> removing application postgresql
> - removing unit postgresql/1
> - removing storage pgdata/1

Also tested backwards compatibility (new server & old client, and vice versa).

## Documentation changes

- The remove-application command now accepts multiple application names, and will remove them all.
- The user will be informed of removals. When removing an application, the units are only listed if the user specified --verbose (as removing an application implies the units will *all* be removed, it's probably a bit noisy to be on by default)

## Bug reference

None.