### PR TITLE
Change /etc/network/interfaces generation method.

### DIFF
--- a/cloudconfig/containerinit/container_userdata_test.go
+++ b/cloudconfig/containerinit/container_userdata_test.go
@@ -29,23 +29,27 @@ func Test(t *stdtesting.T) {
 type UserDataSuite struct {
 	testing.BaseSuite
 
-	networkInterfacesFile       string
+	networkInterfacesPythonFile string
 	systemNetworkInterfacesFile string
 
 	fakeInterfaces []network.InterfaceInfo
 
-	expectedSampleConfig     string
-	expectedSampleUserData   string
-	expectedFallbackConfig   string
-	expectedFallbackUserData string
+	expectedSampleConfig        string
+	expectedSampleConfigWriting string
+	expectedSampleUserData      string
+	expectedFallbackConfig      string
+	expectedBaseConfig          string
+	expectedFallbackUserData    string
 }
 
 var _ = gc.Suite(&UserDataSuite{})
 
 func (s *UserDataSuite) SetUpTest(c *gc.C) {
 	s.BaseSuite.SetUpTest(c)
-	s.networkInterfacesFile = filepath.Join(c.MkDir(), "juju-interfaces")
-	s.systemNetworkInterfacesFile = filepath.Join(c.MkDir(), "system-interfaces")
+
+	networkFolder := c.MkDir()
+	s.systemNetworkInterfacesFile = filepath.Join(networkFolder, "system-interfaces")
+	s.networkInterfacesPythonFile = filepath.Join(networkFolder, "system-interfaces.py")
 	s.fakeInterfaces = []network.InterfaceInfo{{
 		InterfaceName:    "any0",
 		CIDR:             "0.1.2.0/24",
@@ -84,80 +88,139 @@ func (s *UserDataSuite) SetUpTest(c *gc.C) {
 		ConfigType:    network.ConfigManual,
 		NoAutoStart:   true,
 	}}
-	s.expectedSampleConfig = `
-auto any0 any1 any3 lo
-
-iface lo inet loopback
-  dns-nameservers ns1.invalid ns2.invalid
-  dns-search bar foo
-
-iface any0 inet static
-  address 0.1.2.3/24
-  gateway 0.1.2.1
-
-iface any1 inet static
-  address 0.2.2.4/24
-  post-up ip route add 0.5.6.0/24 via 0.2.2.1 metric 50
-  pre-down ip route del 0.5.6.0/24 via 0.2.2.1 metric 50
-
-iface any2 inet dhcp
-
-iface any3 inet dhcp
-
-iface any4 inet manual
-`
-	s.expectedSampleUserData = `
-#cloud-config
+	s.expectedSampleConfigWriting = `#cloud-config
 bootcmd:
 - install -D -m 644 /dev/null '%[1]s'
 - |-
   printf '%%s\n' '
-  auto any0 any1 any3 lo
+  auto lo {ethaa_bb_cc_dd_ee_f0} {ethaa_bb_cc_dd_ee_f1} {eth}
 
   iface lo inet loopback
     dns-nameservers ns1.invalid ns2.invalid
     dns-search bar foo
 
-  iface any0 inet static
+  iface {ethaa_bb_cc_dd_ee_f0} inet static
     address 0.1.2.3/24
     gateway 0.1.2.1
 
-  iface any1 inet static
+  iface {ethaa_bb_cc_dd_ee_f1} inet static
     address 0.2.2.4/24
     post-up ip route add 0.5.6.0/24 via 0.2.2.1 metric 50
     pre-down ip route del 0.5.6.0/24 via 0.2.2.1 metric 50
 
-  iface any2 inet dhcp
+  iface {eth} inet dhcp
 
-  iface any3 inet dhcp
+  iface {eth} inet dhcp
 
-  iface any4 inet manual
+  iface {eth} inet dhcp
   ' > '%[1]s'
-runcmd:
+`
+	s.expectedSampleConfig = `
+auto lo {ethaa_bb_cc_dd_ee_f0} {ethaa_bb_cc_dd_ee_f1} {eth}
+
+iface lo inet loopback
+  dns-nameservers ns1.invalid ns2.invalid
+  dns-search bar foo
+
+iface {ethaa_bb_cc_dd_ee_f0} inet static
+  address 0.1.2.3/24
+  gateway 0.1.2.1
+
+iface {ethaa_bb_cc_dd_ee_f1} inet static
+  address 0.2.2.4/24
+  post-up ip route add 0.5.6.0/24 via 0.2.2.1 metric 50
+  pre-down ip route del 0.5.6.0/24 via 0.2.2.1 metric 50
+
+iface {eth} inet dhcp
+
+iface {eth} inet dhcp
+
+iface {eth} inet dhcp
+`
+	s.expectedSampleUserData = `
+- install -D -m 744 /dev/null '%[2]s'
 - |-
-  if [ -f %[1]s ]; then
-      echo "stopping all interfaces"
-      ifdown -a
-      sleep 1.5
-      if ifup -a --interfaces=%[1]s; then
-          echo "ifup with %[1]s succeeded, renaming to %[2]s"
-          cp %[2]s %[2]s-orig
-          cp %[1]s %[2]s
-      else
-          echo "ifup with %[1]s failed, leaving old %[2]s alone"
-          ifup -a
-      fi
+  printf '%%s\n' 'import subprocess, re
+  from string import Formatter
+  INTERFACES_FILE="%[1]s"
+  IP_LINE = re.compile(r"^\d: (.*?):")
+  IP_HWADDR = re.compile(r".*link/ether ((\w{2}|:){11})")
+
+
+  def ip_parse(ip_output):
+      """parses the output of the ip command
+      and returns a hwaddr->nic-name dict"""
+      devices = dict()
+      print ("parsing ip command output")
+      print (ip_output)
+      for ip_line in ip_output:
+          ip_line_str = str(ip_line, '"'"'utf-8'"'"')
+          match = IP_LINE.match(ip_line_str)
+          if match is None:
+              continue
+          nic_name = match.group(1)
+          match = IP_HWADDR.match(ip_line_str)
+          if match is None:
+              continue
+          nic_hwaddr = match.group(1)
+          devices[nic_hwaddr]=nic_name
+      print("found the following devices: " + str(devices))
+      return devices
+
+  def replace_ethernets(interfaces_file, devices):
+      """check if the contents of interfaces_file contain template
+      keys corresponding to hwaddresses and replace them with
+      the proper device name"""
+      interfaces_file_descriptor = open(interfaces_file, "r")
+      interfaces = interfaces_file_descriptor.read()
+      formatter = Formatter()
+      hwaddrs = [v[1] for v in formatter.parse(interfaces) if v[1]]
+      print("found the following hwaddrs: " + str(hwaddrs))
+      device_replacements = dict()
+      for hwaddr in hwaddrs:
+          hwaddr_clean = hwaddr[3:].replace("_", ":")
+          if devices.get(hwaddr_clean, None):
+              device_replacements[hwaddr] = devices[hwaddr_clean]
+      print ("will use the values in:" + str(device_replacements))
+      print("to fix the interfaces file:")
+      print(str(interfaces))
+      formatted = interfaces.format(**device_replacements)
+      print ("into")
+      print(formatted)
+      interfaces_file_descriptor = open(interfaces_file, "w")
+      interfaces_file_descriptor.write(formatted)
+      interfaces_file_descriptor.close()
+
+  ip_output = ip_parse(subprocess.check_output(["ip", "-oneline", "link"]).splitlines())
+  replace_ethernets(INTERFACES_FILE, ip_output)
+  ' > '%[2]s'
+- |2
+
+  if [ -f /usr/bin/python ]; then
+      python /etc/network/interfaces.py
   else
-      echo "did not find %[1]s, not reconfiguring networking"
+      python3 /etc/network/interfaces.py
   fi
 `[1:]
 
-	s.expectedFallbackConfig = `
-auto eth0 lo
+	s.expectedFallbackConfig = `#cloud-config
+bootcmd:
+- install -D -m 644 /dev/null '%[1]s'
+- |-
+  printf '%%s\n' '
+  auto lo {eth}
+
+  iface lo inet loopback
+
+  iface {eth} inet dhcp
+  ' > '%[1]s'
+`
+	s.expectedBaseConfig = `
+auto lo {eth}
 
 iface lo inet loopback
 
-iface eth0 inet dhcp
+iface {eth} inet dhcp
 `
 	s.expectedFallbackUserData = `
 #cloud-config
@@ -190,7 +253,7 @@ runcmd:
   fi
 `[1:]
 
-	s.PatchValue(containerinit.NetworkInterfacesFile, s.networkInterfacesFile)
+	s.PatchValue(containerinit.NetworkInterfacesFile, s.systemNetworkInterfacesFile)
 	s.PatchValue(containerinit.SystemNetworkInterfacesFile, s.systemNetworkInterfacesFile)
 }
 
@@ -202,7 +265,7 @@ func (s *UserDataSuite) TestGenerateNetworkConfig(c *gc.C) {
 	netConfig := container.BridgeNetworkConfig("foo", 0, nil)
 	data, err = containerinit.GenerateNetworkConfig(netConfig)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(data, gc.Equals, s.expectedFallbackConfig)
+	c.Assert(data, gc.Equals, s.expectedBaseConfig)
 
 	// Test with all interface types.
 	netConfig = container.BridgeNetworkConfig("foo", 0, s.fakeInterfaces)
@@ -217,7 +280,8 @@ func (s *UserDataSuite) TestNewCloudInitConfigWithNetworksSampleConfig(c *gc.C) 
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cloudConf, gc.NotNil)
 
-	expected := fmt.Sprintf(s.expectedSampleUserData, s.networkInterfacesFile, s.systemNetworkInterfacesFile)
+	expected := fmt.Sprintf(s.expectedSampleConfigWriting, s.systemNetworkInterfacesFile)
+	expected += fmt.Sprintf(s.expectedSampleUserData, s.systemNetworkInterfacesFile, s.networkInterfacesPythonFile, s.systemNetworkInterfacesFile)
 	assertUserData(c, cloudConf, expected)
 }
 
@@ -226,7 +290,8 @@ func (s *UserDataSuite) TestNewCloudInitConfigWithNetworksFallbackConfig(c *gc.C
 	cloudConf, err := containerinit.NewCloudInitConfigWithNetworks("quantal", netConfig)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cloudConf, gc.NotNil)
-	expected := fmt.Sprintf(s.expectedFallbackUserData, s.networkInterfacesFile, s.systemNetworkInterfacesFile)
+	expected := fmt.Sprintf(s.expectedFallbackConfig, s.systemNetworkInterfacesFile, s.systemNetworkInterfacesFile)
+	expected += fmt.Sprintf(s.expectedSampleUserData, s.systemNetworkInterfacesFile, s.networkInterfacesPythonFile)
 	assertUserData(c, cloudConf, expected)
 }
 
@@ -278,55 +343,6 @@ func (s *UserDataSuite) TestCloudInitUserDataNoNetworkConfig(c *gc.C) {
 	linesToMatch := CloudInitDataExcludingOutputSection(string(data))
 
 	c.Assert(strings.Join(linesToMatch, "\n"), gc.Equals, "#cloud-config")
-}
-
-func (s *UserDataSuite) TestCloudInitUserDataFallbackConfig(c *gc.C) {
-	instanceConfig, err := containertesting.MockMachineConfig("1/lxd/0")
-	c.Assert(err, jc.ErrorIsNil)
-	networkConfig := container.BridgeNetworkConfig("foo", 0, nil)
-	data, err := containerinit.CloudInitUserData(instanceConfig, networkConfig)
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(data, gc.NotNil)
-
-	linesToMatch := CloudInitDataExcludingOutputSection(string(data))
-
-	expected := fmt.Sprintf(s.expectedFallbackUserData, s.networkInterfacesFile, s.systemNetworkInterfacesFile)
-	var expectedLinesToMatch []string
-
-	for _, line := range strings.Split(expected, "\n") {
-		if strings.HasPrefix(line, "runcmd:") {
-			break
-		}
-		expectedLinesToMatch = append(expectedLinesToMatch, line)
-	}
-
-	c.Assert(strings.Join(linesToMatch, "\n")+"\n", gc.Equals, strings.Join(expectedLinesToMatch, "\n")+"\n")
-}
-
-func (s *UserDataSuite) TestCloudInitUserDataFallbackConfigWithContainerHostname(c *gc.C) {
-	instanceConfig, err := containertesting.MockMachineConfig("1/lxd/0")
-	instanceConfig.MachineContainerHostname = "lxdhostname"
-	c.Assert(err, jc.ErrorIsNil)
-	networkConfig := container.BridgeNetworkConfig("foo", 0, nil)
-	data, err := containerinit.CloudInitUserData(instanceConfig, networkConfig)
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(data, gc.NotNil)
-
-	linesToMatch := CloudInitDataExcludingOutputSection(string(data))
-
-	expected := fmt.Sprintf(s.expectedFallbackUserData, s.networkInterfacesFile, s.systemNetworkInterfacesFile)
-	var expectedLinesToMatch []string
-
-	for _, line := range strings.Split(expected, "\n") {
-		if strings.HasPrefix(line, "runcmd:") {
-			break
-		}
-		expectedLinesToMatch = append(expectedLinesToMatch, line)
-	}
-
-	expectedLinesToMatch = append(expectedLinesToMatch, "hostname: lxdhostname")
-
-	c.Assert(strings.Join(linesToMatch, "\n")+"\n", gc.Equals, strings.Join(expectedLinesToMatch, "\n")+"\n")
 }
 
 func assertUserData(c *gc.C, cloudConf cloudinit.CloudConfig, expected string) {


### PR DESCRIPTION
## Please provide the following details to expedite Pull Request review:

## Description of change

/e/n/i is now generated using a basic template and a python
script that fills the template based on information obtained
from `ip` command. This new approach removes dependency from
interface names that are, in newer ubuntu releases, decided on
boot time.

## QA steps

Bootstrap juju and add-machine for a kvm of the latest ubuntu version, there should be a /e/n/i file comprising all the interfaces with their correct names.

## Documentation changes

no

## Bug reference

https://bugs.launchpad.net/juju/+bug/1666198
