### PR TITLE
Add machine status to juju status --format=tabular

### DIFF
--- a/cmd/juju/machine/list_test.go
+++ b/cmd/juju/machine/list_test.go
@@ -122,10 +122,10 @@ func (s *MachineListCommandSuite) TestMachine(c *gc.C) {
 	context, err := testing.RunCommand(c, newMachineListCommand())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(testing.Stdout(context), gc.Equals, ""+
-		"Machine  State    DNS       Inst id              Series  AZ\n"+
-		"0        started  10.0.0.1  juju-badd06-0        trusty  us-east-1\n"+
-		"1        started  10.0.0.2  juju-badd06-1        trusty  \n"+
-		"1/lxd/0  pending  10.0.0.3  juju-badd06-1-lxd-0  trusty  \n"+
+		"Machine  State    DNS       Inst id              Series  AZ         Message\n"+
+		"0        started  10.0.0.1  juju-badd06-0        trusty  us-east-1  \n"+
+		"1        started  10.0.0.2  juju-badd06-1        trusty             \n"+
+		"1/lxd/0  pending  10.0.0.3  juju-badd06-1-lxd-0  trusty             \n"+
 		"\n")
 }
 

--- a/cmd/juju/machine/show_test.go
+++ b/cmd/juju/machine/show_test.go
@@ -116,10 +116,10 @@ func (s *MachineShowCommandSuite) TestShowTabularMachine(c *gc.C) {
 	context, err := testing.RunCommand(c, newMachineShowCommand(), "--format", "tabular", "0", "1")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(testing.Stdout(context), gc.Equals, ""+
-		"Machine  State    DNS       Inst id              Series  AZ\n"+
-		"0        started  10.0.0.1  juju-badd06-0        trusty  us-east-1\n"+
-		"1        started  10.0.0.2  juju-badd06-1        trusty  \n"+
-		"1/lxd/0  pending  10.0.0.3  juju-badd06-1-lxd-0  trusty  \n"+
+		"Machine  State    DNS       Inst id              Series  AZ         Message\n"+
+		"0        started  10.0.0.1  juju-badd06-0        trusty  us-east-1  \n"+
+		"1        started  10.0.0.2  juju-badd06-1        trusty             \n"+
+		"1/lxd/0  pending  10.0.0.3  juju-badd06-1-lxd-0  trusty             \n"+
 		"\n")
 }
 

--- a/cmd/juju/status/output_tabular.go
+++ b/cmd/juju/status/output_tabular.go
@@ -280,7 +280,7 @@ func getModelMessage(model modelStatus) string {
 
 func printMachines(tw *ansiterm.TabWriter, machines map[string]machineStatus) {
 	w := output.Wrapper{tw}
-	w.Println("Machine", "State", "DNS", "Inst id", "Series", "AZ")
+	w.Println("Machine", "State", "DNS", "Inst id", "Series", "AZ", "Message")
 	for _, name := range utils.SortStringsNaturally(stringKeysFromMap(machines)) {
 		printMachine(w, machines[name])
 	}
@@ -298,7 +298,7 @@ func printMachine(w output.Wrapper, m machineStatus) {
 	}
 	w.Print(m.Id)
 	w.PrintStatus(m.JujuStatus.Current)
-	w.Println(m.DNSName, m.InstanceId, m.Series, az)
+	w.Println(m.DNSName, m.InstanceId, m.Series, az, m.MachineStatus.Message)
 	for _, name := range utils.SortStringsNaturally(stringKeysFromMap(m.Containers)) {
 		printMachine(w, m.Containers[name])
 	}

--- a/cmd/juju/status/status_test.go
+++ b/cmd/juju/status/status_test.go
@@ -3036,8 +3036,8 @@ func (sm startMachineWithHardware) step(c *gc.C, ctx *context) {
 
 type setMachineInstanceStatus struct {
 	machineId string
-	Status status.Status
-	Message string
+	Status    status.Status
+	Message   string
 }
 
 func (sm setMachineInstanceStatus) step(c *gc.C, ctx *context) {


### PR DESCRIPTION
## Description of change
Add Machine status field (e.g. downloading LXD image) to juju status --format=tabular

## QA steps
Bootstrap controller, deploy an application and check that 'juju status --format=tabular' shows the Message for the machine (same as machine-status in format=yaml)

## Documentation changes
There is a change in CLI output

## Bug reference
https://bugs.launchpad.net/juju/+bug/1557914