### PR TITLE
state/metrics: Add concept of saving a model metric

### DIFF
--- a/state/metrics_test.go
+++ b/state/metrics_test.go
@@ -94,6 +94,44 @@ func (s *MetricSuite) TestAddMetric(c *gc.C) {
 	c.Assert(metric.Time.Equal(now), jc.IsTrue)
 }
 
+func (s *MetricSuite) TestAddModelMetricMetric(c *gc.C) {
+	now := s.State.NowToTheSecond()
+	modelUUID := s.State.ModelUUID()
+	m := state.Metric{"pings", "5", now}
+	metricBatch, err := s.State.AddModelMetrics(
+		state.ModelBatchParam{
+			UUID:    utils.MustNewUUID().String(),
+			Created: now,
+			Metrics: []state.Metric{m},
+		},
+	)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(metricBatch.Unit(), gc.Equals, "")
+	c.Assert(metricBatch.ModelUUID(), gc.Equals, modelUUID)
+	c.Assert(metricBatch.CharmURL(), gc.Equals, "")
+	c.Assert(metricBatch.Sent(), jc.IsFalse)
+	c.Assert(metricBatch.Created(), gc.Equals, now)
+	c.Assert(metricBatch.Metrics(), gc.HasLen, 1)
+
+	metric := metricBatch.Metrics()[0]
+	c.Assert(metric.Key, gc.Equals, "pings")
+	c.Assert(metric.Value, gc.Equals, "5")
+	c.Assert(metric.Time.Equal(now), jc.IsTrue)
+
+	tosend, err := s.State.MetricsToSend(1)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(tosend, gc.HasLen, 1)
+	saved := tosend[0]
+	c.Assert(saved.Unit(), gc.Equals, "")
+	c.Assert(metricBatch.CharmURL(), gc.Equals, "")
+	c.Assert(saved.Sent(), jc.IsFalse)
+	c.Assert(saved.Metrics(), gc.HasLen, 1)
+	metric = saved.Metrics()[0]
+	c.Assert(metric.Key, gc.Equals, "pings")
+	c.Assert(metric.Value, gc.Equals, "5")
+	c.Assert(metric.Time.Equal(now), jc.IsTrue)
+}
+
 func (s *MetricSuite) TestAddMetricNonExistentUnit(c *gc.C) {
 	removeUnit(c, s.unit)
 	now := s.State.NowToTheSecond()

--- a/state/model_test.go
+++ b/state/model_test.go
@@ -252,6 +252,9 @@ func (s *ModelSuite) TestSLA(c *gc.C) {
 
 	c.Assert(model.SLALevel(), gc.Equals, "advanced")
 	c.Assert(model.SLACredential(), gc.DeepEquals, []byte("auth advanced"))
+	slaCreds, err := st.SLACredential()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(slaCreds, gc.DeepEquals, []byte("auth advanced"))
 }
 
 func (s *ModelSuite) TestControllerModel(c *gc.C) {

--- a/state/state.go
+++ b/state/state.go
@@ -2181,6 +2181,15 @@ func (st *State) SLALevel() (string, error) {
 	return model.SLALevel(), nil
 }
 
+// SLACredential returns the SLA credential of the current connected model.
+func (st *State) SLACredential() ([]byte, error) {
+	model, err := st.Model()
+	if err != nil {
+		return []byte{}, errors.Trace(err)
+	}
+	return model.SLACredential(), nil
+}
+
 var tagPrefix = map[byte]string{
 	'm': names.MachineTagKind + "-",
 	'a': names.ApplicationTagKind + "-",


### PR DESCRIPTION
## Description of change

In an upcoming pr we will add support for machines and models being able to record metrics. This pr adds the supporting functions in state

## QA steps

As this is an internal change only there is nothing to QA. That will occur in a follow up

## Documentation changes

The presence of model metrics might be something we wish to document. But how and why is not decided yet

## Bug reference

n/a
