### PR TITLE
Increment juju to 2.1.3

### DIFF
--- a/scripts/win-installer/setup.iss
+++ b/scripts/win-installer/setup.iss
@@ -2,7 +2,7 @@
 ; SEE THE DOCUMENTATION FOR DETAILS ON CREATING INNO SETUP SCRIPT FILES!
 
 #define MyAppName "Juju"
-#define MyAppVersion "2.1.2"
+#define MyAppVersion "2.1.3"
 #define MyAppPublisher "Canonical, Ltd"
 #define MyAppURL "http://jujucharms.com/"
 #define MyAppExeName "juju.exe"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: juju
-version: 2.1.2
+version: 2.1.3
 summary: juju client
 description: Through the use of charms, juju provides you with shareable, re-usable, and repeatable expressions of devops best practices.
 confinement: classic

--- a/version/version.go
+++ b/version/version.go
@@ -19,7 +19,7 @@ import (
 // The presence and format of this constant is very important.
 // The debian/rules build recipe uses this value for the version
 // number of the release package.
-const version = "2.1.2"
+const version = "2.1.3"
 
 // The version that we switched over from old style numbering to new style.
 var switchOverVersion = semversion.MustParse("1.19.9")


### PR DESCRIPTION
Increment the 2.1 branch version to 2.1.3. We do not intend to release a 2.1 again

Why is this change needed?

## QA steps

juju version will show 2.1.3
the windows installer and snap will be tested in CI

## Documentation changes

None

## Bug reference

None
