### PR TITLE
remove-machine: tell user of unit/storage changes

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -159,12 +159,26 @@ func (c *Client) ProvisioningScript(args params.ProvisioningScriptParams) (scrip
 }
 
 // DestroyMachines removes a given set of machines.
+//
+// NOTE(axw) this exists only for backwards compatibility, when MachineManager
+// facade v3 is not available. The MachineManager.DestroyMachines method should
+// be preferred.
+//
+// TODO(axw) 2017-03-16 #1673323
+// Drop this in Juju 3.0.
 func (c *Client) DestroyMachines(machines ...string) error {
 	params := params.DestroyMachines{MachineNames: machines}
 	return c.facade.FacadeCall("DestroyMachines", params, nil)
 }
 
 // ForceDestroyMachines removes a given set of machines and all associated units.
+//
+// NOTE(axw) this exists only for backwards compatibility, when MachineManager
+// facade v3 is not available. The MachineManager.ForceDestroyMachines method
+// should be preferred.
+//
+// TODO(axw) 2017-03-16 #1673323
+// Drop this in Juju 3.0.
 func (c *Client) ForceDestroyMachines(machines ...string) error {
 	params := params.DestroyMachines{Force: true, MachineNames: machines}
 	return c.facade.FacadeCall("DestroyMachines", params, nil)

--- a/api/facadeversions.go
+++ b/api/facadeversions.go
@@ -47,7 +47,7 @@ var facadeVersions = map[string]int{
 	"LogForwarding":                1,
 	"Logger":                       1,
 	"MachineActions":               1,
-	"MachineManager":               2,
+	"MachineManager":               3,
 	"MachineUndertaker":            1,
 	"Machiner":                     1,
 	"MeterStatus":                  1,

--- a/apiserver/application/application_unit_test.go
+++ b/apiserver/application/application_unit_test.go
@@ -459,7 +459,7 @@ type mockStorage struct {
 	owner names.Tag
 }
 
-func (a *mockStorage) Tag() names.Tag {
+func (a *mockStorage) StorageTag() names.StorageTag {
 	return a.tag
 }
 

--- a/apiserver/common/storage.go
+++ b/apiserver/common/storage.go
@@ -1,0 +1,50 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package common
+
+import (
+	"gopkg.in/juju/names.v2"
+
+	"github.com/juju/errors"
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/state"
+)
+
+type StorageAccessor interface {
+	StorageInstance(names.StorageTag) (state.StorageInstance, error)
+	UnitStorageAttachments(names.UnitTag) ([]state.StorageAttachment, error)
+}
+
+// UnitStorage returns the storage instances attached to the specified unit.
+func UnitStorage(st StorageAccessor, unit names.UnitTag) ([]state.StorageInstance, error) {
+	attachments, err := st.UnitStorageAttachments(unit)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	instances := make([]state.StorageInstance, 0, len(attachments))
+	for _, attachment := range attachments {
+		instance, err := st.StorageInstance(attachment.StorageInstance())
+		if errors.IsNotFound(err) {
+			continue
+		} else if err != nil {
+			return nil, errors.Trace(err)
+		}
+		instances = append(instances, instance)
+	}
+	return instances, nil
+}
+
+// ClassifyDetachedStorage classifies storage instances into those that will
+// be destroyed, and those that will be detached, when their attachment is
+// removed.
+func ClassifyDetachedStorage(storage []state.StorageInstance) (destroyed, detached []params.Entity) {
+	for _, storage := range storage {
+		// TODO(axw) we need to expose on StorageInstance
+		// whether or not it is detachable. Then we can
+		// decide here whether the storage will be detached
+		// or destroyed.
+		destroyed = append(destroyed, params.Entity{storage.StorageTag().String()})
+	}
+	return destroyed, detached
+}

--- a/apiserver/machinemanager/machinemanager.go
+++ b/apiserver/machinemanager/machinemanager.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 
 	"github.com/juju/errors"
+	"github.com/juju/utils/set"
+	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/facade"
@@ -19,6 +21,8 @@ import (
 
 func init() {
 	common.RegisterStandardFacade("MachineManager", 2, NewMachineManagerAPI)
+	// Version 3 adds DestroyMachine and ForceDestroyMachine.
+	common.RegisterStandardFacade("MachineManager", 3, NewMachineManagerAPI)
 }
 
 // MachineManagerAPI provides access to the MachineManager API facade.
@@ -51,20 +55,25 @@ func NewMachineManagerAPI(
 	}, nil
 }
 
+func (mm *MachineManagerAPI) checkCanWrite() error {
+	canWrite, err := mm.authorizer.HasPermission(permission.WriteAccess, mm.st.ModelTag())
+	if err != nil {
+		return errors.Trace(err)
+	}
+	if !canWrite {
+		return common.ErrPerm
+	}
+	return nil
+}
+
 // AddMachines adds new machines with the supplied parameters.
 func (mm *MachineManagerAPI) AddMachines(args params.AddMachines) (params.AddMachinesResults, error) {
 	results := params.AddMachinesResults{
 		Machines: make([]params.AddMachinesResult, len(args.MachineParams)),
 	}
-
-	canWrite, err := mm.authorizer.HasPermission(permission.WriteAccess, mm.st.ModelTag())
-	if err != nil {
-		return results, errors.Trace(err)
+	if err := mm.checkCanWrite(); err != nil {
+		return results, err
 	}
-	if !canWrite {
-		return results, common.ErrPerm
-	}
-
 	if err := mm.check.ChangeAllowed(); err != nil {
 		return results, errors.Trace(err)
 	}
@@ -167,4 +176,84 @@ func (mm *MachineManagerAPI) addOneMachine(p params.AddMachineParams) (*state.Ma
 		return mm.st.AddMachineInsideMachine(template, p.ParentId, p.ContainerType)
 	}
 	return mm.st.AddMachineInsideNewMachine(template, template, p.ContainerType)
+}
+
+// DestroyMachine removes a set of machines from the model.
+func (mm *MachineManagerAPI) DestroyMachine(args params.Entities) (params.DestroyMachineResults, error) {
+	return mm.destroyMachine(args, false)
+}
+
+// ForceDestroyMachine forcibly removes a set of machines from the model.
+func (mm *MachineManagerAPI) ForceDestroyMachine(args params.Entities) (params.DestroyMachineResults, error) {
+	return mm.destroyMachine(args, true)
+}
+
+func (mm *MachineManagerAPI) destroyMachine(args params.Entities, force bool) (params.DestroyMachineResults, error) {
+	if err := mm.checkCanWrite(); err != nil {
+		return params.DestroyMachineResults{}, err
+	}
+	if err := mm.check.RemoveAllowed(); err != nil {
+		return params.DestroyMachineResults{}, err
+	}
+	destroyMachine := func(entity params.Entity) (*params.DestroyMachineInfo, error) {
+		machineTag, err := names.ParseMachineTag(entity.Tag)
+		if err != nil {
+			return nil, err
+		}
+		machine, err := mm.st.Machine(machineTag.Id())
+		if err != nil {
+			return nil, err
+		}
+		var info params.DestroyMachineInfo
+		units, err := machine.Units()
+		if err != nil {
+			return nil, err
+		}
+		storageSeen := make(set.Tags)
+		for _, unit := range units {
+			info.DestroyedUnits = append(
+				info.DestroyedUnits,
+				params.Entity{unit.UnitTag().String()},
+			)
+			storage, err := common.UnitStorage(mm.st, unit.UnitTag())
+			if err != nil {
+				return nil, err
+			}
+
+			// Filter out storage we've already seen. Shared
+			// storage may be attached to multiple units.
+			var unseen []state.StorageInstance
+			for _, storage := range storage {
+				storageTag := storage.StorageTag()
+				if storageSeen.Contains(storageTag) {
+					continue
+				}
+				storageSeen.Add(storageTag)
+				unseen = append(unseen, storage)
+			}
+			storage = unseen
+
+			destroyed, detached := common.ClassifyDetachedStorage(storage)
+			info.DestroyedStorage = append(info.DestroyedStorage, destroyed...)
+			info.DetachedStorage = append(info.DetachedStorage, detached...)
+		}
+		destroy := machine.Destroy
+		if force {
+			destroy = machine.ForceDestroy
+		}
+		if err := destroy(); err != nil {
+			return nil, err
+		}
+		return &info, nil
+	}
+	results := make([]params.DestroyMachineResult, len(args.Entities))
+	for i, entity := range args.Entities {
+		info, err := destroyMachine(entity)
+		if err != nil {
+			results[i].Error = common.ServerError(err)
+			continue
+		}
+		results[i].Info = info
+	}
+	return params.DestroyMachineResults{results}, nil
 }

--- a/apiserver/machinemanager/machinemanager_test.go
+++ b/apiserver/machinemanager/machinemanager_test.go
@@ -119,6 +119,28 @@ func (s *MachineManagerSuite) TestAddMachinesStateError(c *gc.C) {
 	c.Assert(s.st.calls, gc.Equals, 1)
 }
 
+func (s *MachineManagerSuite) TestDestroyMachine(c *gc.C) {
+	results, err := s.api.DestroyMachine(params.Entities{
+		Entities: []params.Entity{{Tag: "machine-0"}},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(results, jc.DeepEquals, params.DestroyMachineResults{
+		Results: []params.DestroyMachineResult{{
+			Info: &params.DestroyMachineInfo{
+				DestroyedUnits: []params.Entity{
+					{"unit-foo-0"},
+					{"unit-foo-1"},
+					{"unit-foo-2"},
+				},
+				DestroyedStorage: []params.Entity{
+					{"storage-disks-0"},
+					{"storage-disks-1"},
+				},
+			},
+		}},
+	})
+}
+
 type mockState struct {
 	calls    int
 	machines []state.MachineTemplate
@@ -176,6 +198,24 @@ func (st *mockState) GetModel(t names.ModelTag) (machinemanager.Model, error) {
 	return &mockModel{}, nil
 }
 
+func (st *mockState) Machine(id string) (machinemanager.Machine, error) {
+	return &mockMachine{}, nil
+}
+
+func (st *mockState) StorageInstance(tag names.StorageTag) (state.StorageInstance, error) {
+	return &mockStorage{tag: tag}, nil
+}
+
+func (st *mockState) UnitStorageAttachments(tag names.UnitTag) ([]state.StorageAttachment, error) {
+	if tag.Id() == "foo/0" {
+		return []state.StorageAttachment{
+			&mockStorageAttachment{unit: tag, storage: names.NewStorageTag("disks/0")},
+			&mockStorageAttachment{unit: tag, storage: names.NewStorageTag("disks/1")},
+		}, nil
+	}
+	return nil, nil
+}
+
 type mockBlock struct {
 	state.Block
 }
@@ -198,4 +238,53 @@ func (st *mockBlock) Message() string {
 
 func (st *mockBlock) ModelUUID() string {
 	return "uuid"
+}
+
+type mockMachine struct{}
+
+func (m *mockMachine) Destroy() error {
+	return nil
+}
+
+func (m *mockMachine) ForceDestroy() error {
+	return nil
+}
+
+func (m *mockMachine) Units() ([]machinemanager.Unit, error) {
+	return []machinemanager.Unit{
+		&mockUnit{names.NewUnitTag("foo/0")},
+		&mockUnit{names.NewUnitTag("foo/1")},
+		&mockUnit{names.NewUnitTag("foo/2")},
+	}, nil
+}
+
+type mockUnit struct {
+	tag names.UnitTag
+}
+
+func (u *mockUnit) UnitTag() names.UnitTag {
+	return u.tag
+}
+
+type mockStorage struct {
+	state.StorageInstance
+	tag names.StorageTag
+}
+
+func (a *mockStorage) StorageTag() names.StorageTag {
+	return a.tag
+}
+
+type mockStorageAttachment struct {
+	state.StorageAttachment
+	unit    names.UnitTag
+	storage names.StorageTag
+}
+
+func (a *mockStorageAttachment) Unit() names.UnitTag {
+	return a.unit
+}
+
+func (a *mockStorageAttachment) StorageInstance() names.StorageTag {
+	return a.storage
 }

--- a/apiserver/machinemanager/state.go
+++ b/apiserver/machinemanager/state.go
@@ -13,6 +13,7 @@ import (
 )
 
 type stateInterface interface {
+	Machine(string) (Machine, error)
 	ModelConfig() (*config.Config, error)
 	Model() (*state.Model, error)
 	ModelTag() names.ModelTag
@@ -26,10 +27,20 @@ type stateInterface interface {
 	Clouds() (map[names.CloudTag]cloud.Cloud, error)
 	CloudCredentials(user names.UserTag, cloudName string) (map[string]cloud.Credential, error)
 	CloudCredential(tag names.CloudCredentialTag) (cloud.Credential, error)
+	StorageInstance(names.StorageTag) (state.StorageInstance, error)
+	UnitStorageAttachments(names.UnitTag) ([]state.StorageAttachment, error)
 }
 
 type stateShim struct {
 	*state.State
+}
+
+func (s stateShim) Machine(name string) (Machine, error) {
+	m, err := s.State.Machine(name)
+	if err != nil {
+		return nil, err
+	}
+	return machineShim{m}, nil
 }
 
 func (s stateShim) ModelConfig() (*config.Config, error) {
@@ -74,4 +85,34 @@ type Model interface {
 	ModelTag() names.ModelTag
 
 	Config() (*config.Config, error)
+}
+
+type Machine interface {
+	Destroy() error
+	ForceDestroy() error
+	Units() ([]Unit, error)
+}
+
+type machineShim struct {
+	*state.Machine
+}
+
+func (m machineShim) Units() ([]Unit, error) {
+	units, err := m.Machine.Units()
+	if err != nil {
+		return nil, err
+	}
+	out := make([]Unit, len(units))
+	for i, u := range units {
+		out[i] = unitShim{u}
+	}
+	return out, nil
+}
+
+type Unit interface {
+	UnitTag() names.UnitTag
+}
+
+type unitShim struct {
+	*state.Unit
 }


### PR DESCRIPTION
## Description of change

Introduce the MachineManager.(Force)DestroyMachines
methods, and use them in "juju remove-machine". We
will continue to use the existing Client facade
methods when the MachineManager facade is not new
enough.

Using the new methods, we print out the names of
units and storage that will be destroyed or detached
when removing the machine.

## QA steps

(with juju 2.0)
1. juju bootstrap localhost
(with juju from this branch)
2. juju deploy ubuntu
3. juju remove-machine 0 --force
4. juju upgrade-juju -m controller --build-agent
5. juju add-unit ubuntu
6. juju remove-machine 1
(fails, because there's a unit assigned)
7. juju remove-machine --force 1
prints out:
```
removing machine 1
- will remove unit ubuntu/1
```
8. juju deploy postgresql --storage pgdata=rootfs
9. juju remove-machine --force 2
prints out:
```
removing machine 2
- will remove unit postgresql/0
- will remove storage pgdata/0
```

## Documentation changes

Affects output of remove-machine command, so examples may need updating.

## Bug reference

None.