### PR TITLE
Added JUJU_SLA environment variable to the hook context.

### DIFF
--- a/api/facadeversions.go
+++ b/api/facadeversions.go
@@ -87,7 +87,7 @@ var facadeVersions = map[string]int{
 	"Subnets":                      2,
 	"Undertaker":                   1,
 	"UnitAssigner":                 1,
-	"Uniter":                       4,
+	"Uniter":                       5,
 	"Upgrader":                     1,
 	"UserManager":                  1,
 	"VolumeAttachmentsWatcher":     2,

--- a/api/uniter/export_test.go
+++ b/api/uniter/export_test.go
@@ -42,3 +42,5 @@ func PatchUnitFacadeCall(p testing.Patcher, u *Unit, respFunc func(request strin
 func CreateUnit(st *State, tag names.UnitTag) *Unit {
 	return &Unit{st, tag, params.Alive}
 }
+
+var NewStateV4 = newStateForVersionFn(4)

--- a/api/uniter/sla_test.go
+++ b/api/uniter/sla_test.go
@@ -1,0 +1,52 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package uniter_test
+
+import (
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/names.v2"
+
+	"github.com/juju/juju/api/base/testing"
+	"github.com/juju/juju/api/uniter"
+)
+
+type slaSuiteV4 struct {
+	uniterSuite
+}
+
+var _ = gc.Suite(&slaSuiteV4{})
+
+func (s *slaSuiteV4) SetUpTest(c *gc.C) {
+	s.uniterSuite.SetUpTest(c)
+	s.PatchValue(&uniter.NewState, uniter.NewStateV4)
+}
+
+func (s *slaSuiteV4) TestSLALevelOldFacadeVersion(c *gc.C) {
+	apiCaller := testing.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
+		return nil
+	})
+	st := uniter.NewState(apiCaller, names.NewUnitTag("wordpress/0"))
+	level, err := st.SLALevel()
+	c.Assert(err, jc.ErrorIsNil)
+
+	// testing.APICallerFunc declared the BestFacadeVersion to be 0: that is why we
+	// expect "unsupported", because we are talking to an old apiserver.
+	c.Assert(level, gc.Equals, "unsupported")
+}
+
+type slaSuite struct {
+	uniterSuite
+}
+
+var _ = gc.Suite(&slaSuite{})
+
+func (s *slaSuite) TestSLALevel(c *gc.C) {
+	err := s.State.SetSLA("essential", []byte("creds"))
+	c.Assert(err, jc.ErrorIsNil)
+
+	level, err := s.uniter.SLALevel()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(level, gc.Equals, "essential")
+}

--- a/api/uniter/storage_test.go
+++ b/api/uniter/storage_test.go
@@ -30,7 +30,7 @@ func (s *storageSuite) TestUnitStorageAttachments(c *gc.C) {
 	var called bool
 	apiCaller := testing.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
 		c.Check(objType, gc.Equals, "Uniter")
-		c.Check(version, gc.Equals, 4)
+		c.Check(version, gc.Equals, 5)
 		c.Check(id, gc.Equals, "")
 		c.Check(request, gc.Equals, "UnitStorageAttachments")
 		c.Check(arg, gc.DeepEquals, params.Entities{
@@ -57,7 +57,7 @@ func (s *storageSuite) TestDestroyUnitStorageAttachments(c *gc.C) {
 	var called bool
 	apiCaller := testing.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
 		c.Check(objType, gc.Equals, "Uniter")
-		c.Check(version, gc.Equals, 4)
+		c.Check(version, gc.Equals, 5)
 		c.Check(id, gc.Equals, "")
 		c.Check(request, gc.Equals, "DestroyUnitStorageAttachments")
 		c.Check(arg, gc.DeepEquals, params.Entities{
@@ -103,7 +103,7 @@ func (s *storageSuite) TestWatchUnitStorageAttachments(c *gc.C) {
 	var called bool
 	apiCaller := testing.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
 		c.Check(objType, gc.Equals, "Uniter")
-		c.Check(version, gc.Equals, 4)
+		c.Check(version, gc.Equals, 5)
 		c.Check(id, gc.Equals, "")
 		c.Check(request, gc.Equals, "WatchUnitStorageAttachments")
 		c.Check(arg, gc.DeepEquals, params.Entities{
@@ -129,7 +129,7 @@ func (s *storageSuite) TestWatchStorageAttachments(c *gc.C) {
 	var called bool
 	apiCaller := testing.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
 		c.Check(objType, gc.Equals, "Uniter")
-		c.Check(version, gc.Equals, 4)
+		c.Check(version, gc.Equals, 5)
 		c.Check(id, gc.Equals, "")
 		c.Check(request, gc.Equals, "WatchStorageAttachments")
 		c.Check(arg, gc.DeepEquals, params.StorageAttachmentIds{
@@ -166,7 +166,7 @@ func (s *storageSuite) TestStorageAttachments(c *gc.C) {
 	var called bool
 	apiCaller := testing.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
 		c.Check(objType, gc.Equals, "Uniter")
-		c.Check(version, gc.Equals, 4)
+		c.Check(version, gc.Equals, 5)
 		c.Check(id, gc.Equals, "")
 		c.Check(request, gc.Equals, "StorageAttachments")
 		c.Check(arg, gc.DeepEquals, params.StorageAttachmentIds{
@@ -195,7 +195,7 @@ func (s *storageSuite) TestStorageAttachments(c *gc.C) {
 func (s *storageSuite) TestStorageAttachmentLife(c *gc.C) {
 	apiCaller := testing.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
 		c.Check(objType, gc.Equals, "Uniter")
-		c.Check(version, gc.Equals, 4)
+		c.Check(version, gc.Equals, 5)
 		c.Check(id, gc.Equals, "")
 		c.Check(request, gc.Equals, "StorageAttachmentLife")
 		c.Check(arg, gc.DeepEquals, params.StorageAttachmentIds{
@@ -225,7 +225,7 @@ func (s *storageSuite) TestStorageAttachmentLife(c *gc.C) {
 func (s *storageSuite) TestRemoveStorageAttachment(c *gc.C) {
 	apiCaller := testing.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
 		c.Check(objType, gc.Equals, "Uniter")
-		c.Check(version, gc.Equals, 4)
+		c.Check(version, gc.Equals, 5)
 		c.Check(id, gc.Equals, "")
 		c.Check(request, gc.Equals, "RemoveStorageAttachments")
 		c.Check(arg, gc.DeepEquals, params.StorageAttachmentIds{

--- a/api/uniter/uniter.go
+++ b/api/uniter/uniter.go
@@ -69,12 +69,12 @@ func newStateForVersionFn(version int) func(base.APICaller, names.UnitTag) *Stat
 	}
 }
 
-// newStateV4 creates a new client-side Uniter facade, version 4.
-var newStateV4 = newStateForVersionFn(4)
+// newStateV5 creates a new client-side Uniter facade, version 5.
+var newStateV5 = newStateForVersionFn(5)
 
 // NewState creates a new client-side Uniter facade.
 // Defined like this to allow patching during tests.
-var NewState = newStateV4
+var NewState = newStateV5
 
 // BestAPIVersion returns the API version that we were able to
 // determine is supported by both the client and the API Server.
@@ -389,4 +389,20 @@ func ErrIfNotVersionFn(minVersion int, bestAPIVersion int) func(string) error {
 		}
 		return errors.NotImplementedf("%s(...) requires v%d+", fnName, minVersion)
 	}
+}
+
+// SLALevel returns the SLA level set on the model.
+func (st *State) SLALevel() (string, error) {
+	if st.BestAPIVersion() < 5 {
+		return "unsupported", nil
+	}
+	var result params.StringResult
+	err := st.facade.FacadeCall("SLALevel", nil, &result)
+	if err != nil {
+		return "", errors.Trace(err)
+	}
+	if err := result.Error; err != nil {
+		return "", errors.Trace(err)
+	}
+	return result.Result, nil
 }

--- a/api/uniter/uniter_test.go
+++ b/api/uniter/uniter_test.go
@@ -132,3 +132,12 @@ func (s *uniterSuite) patchNewState(
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(s.uniter, gc.NotNil)
 }
+
+func (s *uniterSuite) TestSLALevel(c *gc.C) {
+	err := s.State.SetSLA("essential", []byte("creds"))
+	c.Assert(err, jc.ErrorIsNil)
+
+	level, err := s.uniter.SLALevel()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(level, gc.Equals, "essential")
+}

--- a/api/uniter/unitstorage_test.go
+++ b/api/uniter/unitstorage_test.go
@@ -42,7 +42,7 @@ func (s *unitStorageSuite) TestAddUnitStorage(c *gc.C) {
 
 	apiCaller := basetesting.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
 		c.Assert(objType, gc.Equals, "Uniter")
-		c.Assert(version, gc.Equals, 4)
+		c.Assert(version, gc.Equals, 5)
 		c.Assert(id, gc.Equals, "")
 		c.Assert(request, gc.Equals, "AddUnitStorage")
 		c.Assert(arg, gc.DeepEquals, expected)
@@ -75,7 +75,7 @@ func (s *unitStorageSuite) TestAddUnitStorageError(c *gc.C) {
 	msg := "yoink"
 	apiCaller := basetesting.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
 		c.Assert(objType, gc.Equals, "Uniter")
-		c.Assert(version, gc.Equals, 4)
+		c.Assert(version, gc.Equals, 5)
 		c.Assert(id, gc.Equals, "")
 		c.Assert(request, gc.Equals, "AddUnitStorage")
 		c.Assert(arg, gc.DeepEquals, expected)

--- a/apiserver/uniter/uniter.go
+++ b/apiserver/uniter/uniter.go
@@ -28,7 +28,10 @@ import (
 var logger = loggo.GetLogger("juju.apiserver.uniter")
 
 func init() {
-	common.RegisterStandardFacade("Uniter", 4, NewUniterAPIV4)
+	common.RegisterStandardFacade("Uniter", 4, NewUniterAPI)
+
+	// Version 5 introduces the SLA levels.
+	common.RegisterStandardFacade("Uniter", 5, NewUniterAPI)
 }
 
 // UniterAPIV3 implements the API version 3, used by the uniter worker.
@@ -53,8 +56,8 @@ type UniterAPIV3 struct {
 	StorageAPI
 }
 
-// NewUniterAPIV4 creates a new instance of the Uniter API, version 3.
-func NewUniterAPIV4(st *state.State, resources facade.Resources, authorizer facade.Authorizer) (*UniterAPIV3, error) {
+// NewUniterAPI creates a new instance of the Uniter API.
+func NewUniterAPI(st *state.State, resources facade.Resources, authorizer facade.Authorizer) (*UniterAPIV3, error) {
 	if !authorizer.AuthUnitAgent() {
 		return nil, common.ErrPerm
 	}
@@ -1684,4 +1687,14 @@ func (u *UniterAPIV3) getOneNetworkConfig(canAccess common.AuthFunc, unitTagArg,
 	}
 
 	return results, nil
+}
+
+// SLALevel returns the model's SLA level.
+func (u *UniterAPIV3) SLALevel() (params.StringResult, error) {
+	result := params.StringResult{}
+	sla, err := u.st.SLALevel()
+	if err == nil {
+		result.Result = sla
+	}
+	return result, err
 }

--- a/worker/uniter/relation/relations_test.go
+++ b/worker/uniter/relation/relations_test.go
@@ -78,7 +78,7 @@ func mockAPICaller(c *gc.C, callNumber *int32, apiCalls ...apiCall) apitesting.A
 			c.Check(index < len(apiCalls), jc.IsTrue)
 			call := apiCalls[index]
 			c.Logf("request %d, %s", index, request)
-			c.Check(version, gc.Equals, 4)
+			c.Check(version, gc.Equals, 5)
 			c.Check(id, gc.Equals, "")
 			c.Check(request, gc.Equals, call.request)
 			c.Check(arg, jc.DeepEquals, call.args)

--- a/worker/uniter/runner/context/context.go
+++ b/worker/uniter/runner/context/context.go
@@ -207,6 +207,9 @@ type HookContext struct {
 
 	componentDir   func(string) string
 	componentFuncs map[string]ComponentFunc
+
+	//  slaLevel contains the current SLA level.
+	slaLevel string
 }
 
 // Component implements jujuc.Context.
@@ -579,6 +582,7 @@ func (context *HookContext) HookVars(paths Paths) ([]string, error) {
 		"JUJU_API_ADDRESSES="+strings.Join(context.apiAddrs, " "),
 		"JUJU_METER_STATUS="+context.meterStatus.code,
 		"JUJU_METER_INFO="+context.meterStatus.info,
+		"JUJU_SLA="+context.slaLevel,
 		"JUJU_MACHINE_ID="+context.assignedMachineTag.Id(),
 		"JUJU_AVAILABILITY_ZONE="+context.availabilityzone,
 	)

--- a/worker/uniter/runner/context/env_test.go
+++ b/worker/uniter/runner/context/env_test.go
@@ -53,6 +53,7 @@ func (s *EnvSuite) getContext() (ctx *context.HookContext, expectVars []string) 
 			"this-unit/123",
 			"PURPLE",
 			"proceed with care",
+			"essential",
 			"some-zone",
 			[]string{"he.re:12345", "the.re:23456"},
 			proxy.Settings{
@@ -69,6 +70,7 @@ func (s *EnvSuite) getContext() (ctx *context.HookContext, expectVars []string) 
 			"JUJU_UNIT_NAME=this-unit/123",
 			"JUJU_METER_STATUS=PURPLE",
 			"JUJU_METER_INFO=proceed with care",
+			"JUJU_SLA=essential",
 			"JUJU_API_ADDRESSES=he.re:12345 the.re:23456",
 			"JUJU_MACHINE_ID=42",
 			"JUJU_AVAILABILITY_ZONE=some-zone",

--- a/worker/uniter/runner/context/export_test.go
+++ b/worker/uniter/runner/context/export_test.go
@@ -139,7 +139,7 @@ func StorageAddConstraints(ctx *HookContext) map[string][]params.StorageConstrai
 // NewModelHookContext exists purely to set the fields used in rs.
 // The returned value is not otherwise valid.
 func NewModelHookContext(
-	id, modelUUID, envName, unitName, meterCode, meterInfo, availZone string,
+	id, modelUUID, envName, unitName, meterCode, meterInfo, slaLevel, availZone string,
 	apiAddresses []string, proxySettings proxy.Settings,
 	machineTag names.MachineTag,
 ) *HookContext {
@@ -157,6 +157,7 @@ func NewModelHookContext(
 		relationId:         -1,
 		assignedMachineTag: machineTag,
 		availabilityzone:   availZone,
+		slaLevel:           slaLevel,
 	}
 }
 
@@ -183,4 +184,8 @@ func CachedSettings(cf0 ContextFactory, relId int, unitName string) (params.Sett
 	cf := cf0.(*contextFactory)
 	settings, found := cf.relationCaches[relId].members[unitName]
 	return settings, found
+}
+
+func (ctx *HookContext) SLALevel() string {
+	return ctx.slaLevel
 }

--- a/worker/uniter/runner/factory_test.go
+++ b/worker/uniter/runner/factory_test.go
@@ -160,15 +160,15 @@ func (s *FactorySuite) TestNewHookRunnerWithStorage(c *gc.C) {
 	uniter, err := st.Uniter()
 	c.Assert(err, jc.ErrorIsNil)
 
-	contextFactory, err := context.NewContextFactory(
-		uniter,
-		unit.Tag().(names.UnitTag),
-		runnertesting.FakeTracker{},
-		s.getRelationInfos,
-		s.storage,
-		s.paths,
-		testing.NewClock(time.Time{}),
-	)
+	contextFactory, err := context.NewContextFactory(context.FactoryConfig{
+		State:            uniter,
+		UnitTag:          unit.Tag().(names.UnitTag),
+		Tracker:          runnertesting.FakeTracker{},
+		GetRelationInfos: s.getRelationInfos,
+		Storage:          s.storage,
+		Paths:            s.paths,
+		Clock:            testing.NewClock(time.Time{}),
+	})
 	c.Assert(err, jc.ErrorIsNil)
 	factory, err := runner.NewFactory(
 		uniter,

--- a/worker/uniter/runner/util_test.go
+++ b/worker/uniter/runner/util_test.go
@@ -98,15 +98,15 @@ func (s *ContextSuite) SetUpTest(c *gc.C) {
 	s.AddContextRelation(c, "db0")
 	s.AddContextRelation(c, "db1")
 
-	s.contextFactory, err = context.NewContextFactory(
-		s.uniter,
-		s.unit.Tag().(names.UnitTag),
-		runnertesting.FakeTracker{},
-		s.getRelationInfos,
-		s.storage,
-		s.paths,
-		jujutesting.NewClock(time.Time{}),
-	)
+	s.contextFactory, err = context.NewContextFactory(context.FactoryConfig{
+		State:            s.uniter,
+		UnitTag:          s.unit.Tag().(names.UnitTag),
+		Tracker:          runnertesting.FakeTracker{},
+		GetRelationInfos: s.getRelationInfos,
+		Storage:          s.storage,
+		Paths:            s.paths,
+		Clock:            jujutesting.NewClock(time.Time{}),
+	})
 	c.Assert(err, jc.ErrorIsNil)
 
 	factory, err := runner.NewFactory(

--- a/worker/uniter/uniter.go
+++ b/worker/uniter/uniter.go
@@ -459,9 +459,15 @@ func (u *Uniter) init(unitTag names.UnitTag) (err error) {
 	if err != nil {
 		return errors.Annotatef(err, "cannot create deployer")
 	}
-	contextFactory, err := context.NewContextFactory(
-		u.st, unitTag, u.leadershipTracker, u.relations.GetInfo, u.storage, u.paths, u.clock,
-	)
+	contextFactory, err := context.NewContextFactory(context.FactoryConfig{
+		State:            u.st,
+		UnitTag:          unitTag,
+		Tracker:          u.leadershipTracker,
+		GetRelationInfos: u.relations.GetInfo,
+		Storage:          u.storage,
+		Paths:            u.paths,
+		Clock:            u.clock,
+	})
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Description of change

This adds the JUJU_SLA environment variable to the hook context so that charm authors can see the current SLA level for the model.

## QA steps

1. go install ./...
2. bootstrap (juju bootstrap lxd test --build-agent)
3. deploy a service (e.g. juju deploy ubuntu)
4. juju sla advanced (ask @cmars for instructions)
5. run debug-hooks on the deployed unit (e.g. juju debug-hooks/0)
6. trigger a hook (e.g. juju config ubuntu hostname=test-hostname)
7. in debug-hooks check that the JUJU_SLA environment is set to "advanced"

## Documentation changes

The new JUJU_SLA environment variable needs to be documented. Speak to @cmars for details

## Bug reference

n/a