### PR TITLE
apiserver/metricsmanager: Send juju-machines metrics if sla is set

### DIFF
--- a/apiserver/metricsender/metricsender.go
+++ b/apiserver/metricsender/metricsender.go
@@ -176,12 +176,13 @@ func ToWire(mb *state.MetricBatch) *wireformat.MetricBatch {
 		}
 	}
 	return &wireformat.MetricBatch{
-		UUID:        mb.UUID(),
-		ModelUUID:   mb.ModelUUID(),
-		UnitName:    mb.Unit(),
-		CharmUrl:    mb.CharmURL(),
-		Created:     mb.Created().UTC(),
-		Metrics:     metrics,
-		Credentials: mb.Credentials(),
+		UUID:           mb.UUID(),
+		ModelUUID:      mb.ModelUUID(),
+		UnitName:       mb.Unit(),
+		CharmUrl:       mb.CharmURL(),
+		Created:        mb.Created().UTC(),
+		Metrics:        metrics,
+		Credentials:    mb.Credentials(),
+		SLACredentials: mb.SLACredentials(),
 	}
 }

--- a/apiserver/metricsender/metricsender_test.go
+++ b/apiserver/metricsender/metricsender_test.go
@@ -59,13 +59,14 @@ func (s *MetricSenderSuite) TestToWire(c *gc.C) {
 		},
 	}
 	expected := &wireformat.MetricBatch{
-		UUID:        metric.UUID(),
-		ModelUUID:   metric.ModelUUID(),
-		UnitName:    metric.Unit(),
-		CharmUrl:    metric.CharmURL(),
-		Created:     metric.Created().UTC(),
-		Metrics:     metrics,
-		Credentials: metric.Credentials(),
+		UUID:           metric.UUID(),
+		ModelUUID:      metric.ModelUUID(),
+		UnitName:       metric.Unit(),
+		CharmUrl:       metric.CharmURL(),
+		Created:        metric.Created().UTC(),
+		Metrics:        metrics,
+		Credentials:    metric.Credentials(),
+		SLACredentials: metric.SLACredentials(),
 	}
 	c.Assert(result, gc.DeepEquals, expected)
 }

--- a/apiserver/metricsmanager/metricsmanager.go
+++ b/apiserver/metricsmanager/metricsmanager.go
@@ -6,8 +6,11 @@
 package metricsmanager
 
 import (
+	"fmt"
+
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
+	"github.com/juju/utils"
 	"github.com/juju/utils/clock"
 	"gopkg.in/juju/names.v2"
 
@@ -15,6 +18,7 @@ import (
 	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/apiserver/metricsender"
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/instance"
 	"github.com/juju/juju/state"
 )
 
@@ -128,8 +132,49 @@ func (api *MetricsManagerAPI) CleanupOldMetrics(args params.Entities) (params.Er
 	return result, nil
 }
 
+// AddJujuMachineMetrics adds a metric that counts the number of
+// non-container machines in the current model.
+func (api *MetricsManagerAPI) AddJujuMachineMetrics() error {
+	sla, err := api.state.SLACredential()
+	if err != nil {
+		return errors.Trace(err)
+	}
+	if len(sla) == 0 {
+		return nil
+	}
+	allMachines, err := api.state.AllMachines()
+	if err != nil {
+		return errors.Trace(err)
+	}
+	machineCount := 0
+	for _, machine := range allMachines {
+		ct := machine.ContainerType()
+		if ct == instance.NONE || ct == "" {
+			machineCount++
+		}
+	}
+	t := clock.WallClock.Now()
+	metricUUID, err := utils.NewUUID()
+	if err != nil {
+		return errors.Trace(err)
+	}
+	_, err = api.state.AddModelMetrics(state.ModelBatchParam{
+		UUID:    metricUUID.String(),
+		Created: t,
+		Metrics: []state.Metric{{
+			Key:   "juju-machines",
+			Value: fmt.Sprintf("%d", machineCount),
+			Time:  t,
+		}},
+	})
+	return err
+}
+
 // SendMetrics will send any unsent metrics onto the metric collection service.
 func (api *MetricsManagerAPI) SendMetrics(args params.Entities) (params.ErrorResults, error) {
+	if err := api.AddJujuMachineMetrics(); err != nil {
+		logger.Warningf("failed to add juju-machines metrics: %v", err)
+	}
 	result := params.ErrorResults{
 		Results: make([]params.ErrorResult, len(args.Entities)),
 	}

--- a/apiserver/metricsmanager/metricsmanager_test.go
+++ b/apiserver/metricsmanager/metricsmanager_test.go
@@ -215,3 +215,66 @@ func (s *metricsManagerSuite) TestLastSuccessfulNotChangedIfNothingToSend(c *gc.
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(mm.LastSuccessfulSend().Equal(time.Time{}), jc.IsTrue)
 }
+
+func (s *metricsManagerSuite) TestAddJujuMachineMetrics(c *gc.C) {
+	err := s.State.SetSLA("essential", []byte("sla"))
+	c.Assert(err, jc.ErrorIsNil)
+	s.Factory.MakeMachine(c, nil)
+	err = s.metricsmanager.AddJujuMachineMetrics()
+	c.Assert(err, jc.ErrorIsNil)
+	metrics, err := s.State.MetricsToSend(10)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(metrics, gc.HasLen, 1)
+	c.Assert(metrics[0].Metrics()[0].Key, gc.Equals, "juju-machines")
+	c.Assert(metrics[0].Metrics()[0].Value, gc.Equals, "2")
+	c.Assert(metrics[0].SLACredentials(), gc.DeepEquals, []byte("sla"))
+}
+
+func (s *metricsManagerSuite) TestAddJujuMachineMetricsAddsNoMetricsWhenNoSLASet(c *gc.C) {
+	s.Factory.MakeMachine(c, nil)
+	err := s.metricsmanager.AddJujuMachineMetrics()
+	c.Assert(err, jc.ErrorIsNil)
+	metrics, err := s.State.MetricsToSend(10)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(metrics, gc.HasLen, 0)
+}
+
+func (s *metricsManagerSuite) TestAddJujuMachineMetricsDontCountContainers(c *gc.C) {
+	err := s.State.SetSLA("essential", []byte("sla"))
+	c.Assert(err, jc.ErrorIsNil)
+	machine := s.Factory.MakeMachine(c, nil)
+	s.Factory.MakeMachineNested(c, machine.Id(), nil)
+	err = s.metricsmanager.AddJujuMachineMetrics()
+	c.Assert(err, jc.ErrorIsNil)
+	metrics, err := s.State.MetricsToSend(10)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(metrics, gc.HasLen, 1)
+	c.Assert(metrics[0].Metrics()[0].Key, gc.Equals, "juju-machines")
+	// Even though we add two machines - one nested (i.e. container) we only
+	// count non-container machine.
+	c.Assert(metrics[0].Metrics()[0].Value, gc.Equals, "2")
+	c.Assert(metrics[0].SLACredentials(), gc.DeepEquals, []byte("sla"))
+}
+
+func (s *metricsManagerSuite) TestSendMetricsMachineMetrics(c *gc.C) {
+	err := s.State.SetSLA("essential", []byte("sla"))
+	c.Assert(err, jc.ErrorIsNil)
+	s.Factory.MakeMachine(c, nil)
+	var sender testing.MockSender
+	metricsmanager.PatchSender(&sender)
+	args := params.Entities{Entities: []params.Entity{
+		{s.State.ModelTag().String()},
+	}}
+	result, err := s.metricsmanager.SendMetrics(args)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result.Results, gc.HasLen, 1)
+	c.Assert(result.Results[0], gc.DeepEquals, params.ErrorResult{Error: nil})
+	c.Assert(sender.Data, gc.HasLen, 1)
+	c.Assert(sender.Data[0], gc.HasLen, 1)
+	c.Assert(sender.Data[0][0].Metrics[0].Key, gc.Equals, "juju-machines")
+	c.Assert(sender.Data[0][0].SLACredentials, gc.DeepEquals, []byte("sla"))
+	ms, err := s.State.AllMetricBatches()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(ms, gc.HasLen, 1)
+	c.Assert(ms[0].Sent(), jc.IsTrue)
+}

--- a/state/metrics.go
+++ b/state/metrics.go
@@ -450,6 +450,11 @@ func (m *MetricBatch) Credentials() []byte {
 	return m.doc.Credentials
 }
 
+// SLACredentials returns any sla credentials associated with the metric batch.
+func (m *MetricBatch) SLACredentials() []byte {
+	return m.doc.SLACredentials
+}
+
 func setSentOps(batchUUIDs []string, deleteTime time.Time) []txn.Op {
 	ops := make([]txn.Op, len(batchUUIDs))
 	for i, u := range batchUUIDs {


### PR DESCRIPTION
## Description of change

Adds the sending of "juju-machines" metrics if an sla has been set on the model
## QA steps
```
# bootstrap a new model
juju sla essential
juju deploy ubuntu
# wait for the unit to come up
juju metrics --all
UNIT               TIMESTAMP                   METRIC                VALUE
                       2017-03-16T12:50:00Z    juju-machines       1
```
## Documentation changes

There are no ui changes as a result of this change. But the sla scheme in general needs documenting
## Bug reference
n/a