### PR TITLE
state: fix flaky tests

### DIFF
--- a/state/dump_test.go
+++ b/state/dump_test.go
@@ -7,6 +7,8 @@ import (
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils/set"
 	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/state"
 )
 
 type dumpSuite struct {
@@ -16,6 +18,10 @@ type dumpSuite struct {
 var _ = gc.Suite(&dumpSuite{})
 
 func (s *dumpSuite) TestDumpAll(c *gc.C) {
+	// Some of the state workers are responsible for creating
+	// collections, so make sure they've started before running
+	// the dump.
+	state.EnsureWorkersStarted(s.State)
 	value, err := s.State.DumpAll()
 	c.Assert(err, jc.ErrorIsNil)
 

--- a/state/export_test.go
+++ b/state/export_test.go
@@ -74,11 +74,13 @@ type (
 	BlockDevicesDoc blockDevicesDoc
 )
 
-// ensureWorkersStarted ensures that all the automatically
+// EnsureWorkersStarted ensures that all the automatically
 // started state workers are running, so that tests which
 // insert transaction hooks are less likely to have the hooks
-// run by some other worker.
-func ensureWorkersStarted(st *State) {
+// run by some other worker, and any side effects of starting
+// the workers (for example, creating collections) will have
+// taken effect.
+func EnsureWorkersStarted(st *State) {
 	// Note: we don't start the all-watcher workers, as
 	// they're started on demand anyway.
 	st.workers.txnLogWatcher()
@@ -88,22 +90,22 @@ func ensureWorkersStarted(st *State) {
 }
 
 func SetTestHooks(c *gc.C, st *State, hooks ...jujutxn.TestHook) txntesting.TransactionChecker {
-	ensureWorkersStarted(st)
+	EnsureWorkersStarted(st)
 	return txntesting.SetTestHooks(c, newRunnerForHooks(st), hooks...)
 }
 
 func SetBeforeHooks(c *gc.C, st *State, fs ...func()) txntesting.TransactionChecker {
-	ensureWorkersStarted(st)
+	EnsureWorkersStarted(st)
 	return txntesting.SetBeforeHooks(c, newRunnerForHooks(st), fs...)
 }
 
 func SetAfterHooks(c *gc.C, st *State, fs ...func()) txntesting.TransactionChecker {
-	ensureWorkersStarted(st)
+	EnsureWorkersStarted(st)
 	return txntesting.SetAfterHooks(c, newRunnerForHooks(st), fs...)
 }
 
 func SetRetryHooks(c *gc.C, st *State, block, check func()) txntesting.TransactionChecker {
-	ensureWorkersStarted(st)
+	EnsureWorkersStarted(st)
 	return txntesting.SetRetryHooks(c, newRunnerForHooks(st), block, check)
 }
 

--- a/state/state.go
+++ b/state/state.go
@@ -2155,13 +2155,14 @@ func tagForGlobalKey(key string) (string, bool) {
 // to set the internal clock for the State instance. It is named such
 // that it should be obvious if it is ever called from a non-test package.
 func (st *State) SetClockForTesting(clock clock.Clock) error {
-	st.clock = clock
 	// Need to restart the lease workers so they get the new clock.
+	// Stop them first so they don't try to use it when we're setting it.
 	st.workers.Kill()
 	err := st.workers.Wait()
 	if err != nil {
 		return errors.Trace(err)
 	}
+	st.clock = clock
 	err = st.start(st.controllerTag)
 	if err != nil {
 		return errors.Trace(err)

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -196,7 +196,7 @@ func (s *StateSuite) TestModelUUID(c *gc.C) {
 
 func (s *StateSuite) TestNoModelDocs(c *gc.C) {
 	c.Assert(s.State.EnsureModelRemoved(), gc.ErrorMatches,
-		fmt.Sprintf("found documents for model with uuid %s: 1 constraints doc, 2 leases doc, 1 modelusers doc, 1 settings doc, 1 statuses doc", s.State.ModelUUID()))
+		fmt.Sprintf(`found documents for model with uuid %s: \d+ constraints doc, \d+ leases doc, \d+ modelusers doc, \d+ settings doc, \d+ statuses doc`, s.State.ModelUUID()))
 }
 
 func (s *StateSuite) TestMongoSession(c *gc.C) {


### PR DESCRIPTION
dumpSuite.TestDumpAll and TestNoModelDocs were
failing because the state workers are now started asynchronously but
this tests was relying on their side-effects (creating
collections) taking place immediately.

Other tests relying on setting the state clock were
also failing the race detector for similar reasons.

Fixes https://bugs.launchpad.net/juju/+bug/1673544, https://bugs.launchpad.net/juju/+bug/1673552 and https://bugs.launchpad.net/juju/+bug/1673554.
