### PR TITLE
Put {attach,detach}-storage behind feature flag

### DIFF
--- a/cmd/juju/commands/main.go
+++ b/cmd/juju/commands/main.go
@@ -384,13 +384,15 @@ func registerCommands(r commandRegistry, ctx *cmd.Context) {
 
 	// Manage storage
 	r.Register(storage.NewAddCommand())
-	r.Register(storage.NewAttachStorageCommandWithAPI())
 	r.Register(storage.NewListCommand())
 	r.Register(storage.NewPoolCreateCommand())
 	r.Register(storage.NewPoolListCommand())
 	r.Register(storage.NewShowCommand())
-	r.Register(storage.NewDetachStorageCommandWithAPI())
 	r.Register(storage.NewRemoveStorageCommandWithAPI())
+	if featureflag.Enabled(feature.PersistentStorage) {
+		r.Register(storage.NewDetachStorageCommandWithAPI())
+		r.Register(storage.NewAttachStorageCommandWithAPI())
+	}
 
 	// Manage spaces
 	r.Register(space.NewAddCommand())

--- a/cmd/juju/commands/main_test.go
+++ b/cmd/juju/commands/main_test.go
@@ -402,7 +402,6 @@ var commandNames = []string{
 	"agree",
 	"agreements",
 	"allocate",
-	"attach-storage",
 	"autoload-credentials",
 	"backups",
 	"bootstrap",
@@ -421,7 +420,6 @@ var commandNames = []string{
 	"controller-config",
 	"debug-hooks",
 	"debug-log",
-	"detach-storage",
 	"remove-user",
 	"deploy",
 	"destroy-controller",
@@ -534,11 +532,16 @@ var commandNames = []string{
 }
 
 // devFeatures are feature flags that impact registration of commands.
-var devFeatures = []string{feature.CrossModelRelations}
+var devFeatures = []string{
+	feature.CrossModelRelations,
+	feature.PersistentStorage,
+}
 
 // These are the commands that are behind the `devFeatures`.
 var commandNamesBehindFlags = set.NewStrings(
+	"attach-storage",
 	"consume",
+	"detach-storage",
 	"find-endpoints",
 	"list-offers",
 	"offer",

--- a/feature/flags.go
+++ b/feature/flags.go
@@ -39,3 +39,6 @@ const CrossModelRelations = "cross-model"
 
 // LXDStorage enables the LXD storage provider.
 const LXDStorage = "lxd-storage"
+
+// PersistentStorage enables the persistent storage feature.
+const PersistentStorage = "persistent-storage"


### PR DESCRIPTION
## Description of change

Introduce the "persistent-storage" feature flag,
and put the attach-storage and detach-storage
commands behind it. The remove-storage command
is complete, and so has not been put behind the
flag. We'll remove the feature flag in develop
once 2.2 has branched.

## QA steps

1. juju detach-storage -h
`ERROR unrecognized command: juju detach-storage`
2. juju attach-storage -h
`ERROR unrecognized command: juju attach-storage`
3. export JUJU_DEV_FEATURE_FLAGS=provider-storage
4. juju detach-storage -h
```
Usage: juju detach-storage [options] <storage> [<storage> ...]
...
```
5. juju attach-storage -h
```
Usage: juju attach-storage [options] <unit> <storage> [<storage> ...]
...
```

## Documentation changes

No, these commands are not yet documented.

## Bug reference

None.