### PR TITLE
Add support for apt-no-proxy option

### DIFF
--- a/apiserver/provisioner/provisioner_test.go
+++ b/apiserver/provisioner/provisioner_test.go
@@ -1175,7 +1175,8 @@ func (s *withoutControllerSuite) TestContainerConfig(c *gc.C) {
 	err := s.State.UpdateModelConfig(attrs, nil, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	expectedAPTProxy := proxy.Settings{
-		Http: "http://proxy.example.com:9000",
+		Http:    "http://proxy.example.com:9000",
+		NoProxy: "127.0.0.1,localhost,::1",
 	}
 
 	expectedProxy := proxy.Settings{

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -46,7 +46,7 @@ github.com/juju/terms-client	git	9b925afd677234e4146dde3cb1a11e187cbed64e	2016-0
 github.com/juju/testing	git	fce9bc4ebf7a77310c262ac4884e03b778eae06a	2017-02-22T09:01:19Z
 github.com/juju/txn	git	28898197906200d603394d8e4ce537436529f1c5	2016-11-16T04:07:55Z
 github.com/juju/usso	git	68a59c96c178fbbad65926e7f93db50a2cd14f33	2016-04-01T10:44:24Z
-github.com/juju/utils	git	9f8aeb9b09e2d8c769be8317ccfa23f7eec62c26	2017-02-15T08:19:00Z
+github.com/juju/utils	git	6a26b0e1230eeaad6d2321bb63700da1b1116c2b	2017-03-17T14:03:37Z
 github.com/juju/version	git	1f41e27e54f21acccf9b2dddae063a782a8a7ceb	2016-10-31T05:19:06Z
 github.com/juju/webbrowser	git	54b8c57083b4afb7dc75da7f13e2967b2606a507	2016-03-09T14:36:29Z
 github.com/juju/xml	git	eb759a627588d35166bc505fceb51b88500e291e	2015-04-13T13:11:21Z

--- a/environs/config/config.go
+++ b/environs/config/config.go
@@ -84,6 +84,9 @@ const (
 	// FTPProxyKey stores the key for this setting.
 	FTPProxyKey = "ftp-proxy"
 
+	// NoProxyKey stores the key for this setting.
+	NoProxyKey = "no-proxy"
+
 	// AptHTTPProxyKey stores the key for this setting.
 	AptHTTPProxyKey = "apt-http-proxy"
 
@@ -93,8 +96,8 @@ const (
 	// AptFTPProxyKey stores the key for this setting.
 	AptFTPProxyKey = "apt-ftp-proxy"
 
-	// NoProxyKey stores the key for this setting.
-	NoProxyKey = "no-proxy"
+	// AptNoProxyKey stores the key for this setting.
+	AptNoProxyKey = "apt-no-proxy"
 
 	// NetBondReconfigureDelay is the key to pass when bridging
 	// the network for containers.
@@ -340,6 +343,7 @@ var defaultConfigValues = map[string]interface{}{
 	AptHTTPProxyKey:  "",
 	AptHTTPSProxyKey: "",
 	AptFTPProxyKey:   "",
+	AptNoProxyKey:    "127.0.0.1,localhost,::1",
 	"apt-mirror":     "",
 }
 
@@ -640,9 +644,10 @@ func addSchemeIfMissing(defaultScheme string, url string) string {
 // AptProxySettings returns all three proxy settings; http, https and ftp.
 func (c *Config) AptProxySettings() proxy.Settings {
 	return proxy.Settings{
-		Http:  c.AptHTTPProxy(),
-		Https: c.AptHTTPSProxy(),
-		Ftp:   c.AptFTPProxy(),
+		Http:    c.AptHTTPProxy(),
+		Https:   c.AptHTTPSProxy(),
+		Ftp:     c.AptFTPProxy(),
+		NoProxy: c.AptNoProxy(),
 	}
 }
 
@@ -662,6 +667,11 @@ func (c *Config) AptHTTPSProxy() string {
 // Falls back to the default ftp-proxy if not specified.
 func (c *Config) AptFTPProxy() string {
 	return addSchemeIfMissing("ftp", c.getWithFallback(AptFTPProxyKey, FTPProxyKey))
+}
+
+// AptNoProxy returns the 'apt-no proxy' for the environment.
+func (c *Config) AptNoProxy() string {
+	return c.asString(AptNoProxyKey)
 }
 
 // AptMirror sets the apt mirror for the environment.
@@ -978,6 +988,7 @@ var alwaysOptional = schema.Defaults{
 	AptHTTPProxyKey:              schema.Omit,
 	AptHTTPSProxyKey:             schema.Omit,
 	AptFTPProxyKey:               schema.Omit,
+	AptNoProxyKey:                schema.Omit,
 	"apt-mirror":                 schema.Omit,
 	AgentStreamKey:               schema.Omit,
 	ResourceTagsKey:              schema.Omit,
@@ -1104,6 +1115,7 @@ func AptProxyConfigMap(proxySettings proxy.Settings) map[string]interface{} {
 	addIfNotEmpty(settings, AptHTTPProxyKey, proxySettings.Http)
 	addIfNotEmpty(settings, AptHTTPSProxyKey, proxySettings.Https)
 	addIfNotEmpty(settings, AptFTPProxyKey, proxySettings.Ftp)
+	addIfNotEmpty(settings, AptNoProxyKey, proxySettings.NoProxy)
 	return settings
 }
 
@@ -1166,6 +1178,11 @@ var configSchema = environschema.Fields{
 	AptHTTPSProxyKey: {
 		// TODO document acceptable format
 		Description: "The APT HTTPS proxy for the model",
+		Type:        environschema.Tstring,
+		Group:       environschema.EnvironGroup,
+	},
+	AptNoProxyKey: {
+		Description: "List of domain addresses not to be proxied for APT (comma-separated)",
 		Type:        environschema.Tstring,
 		Group:       environschema.EnvironGroup,
 	},

--- a/environs/config/config.go
+++ b/environs/config/config.go
@@ -620,7 +620,7 @@ func (c *Config) FTPProxy() string {
 	return c.asString(FTPProxyKey)
 }
 
-// NoProxy returns the 'no proxy' for the environment.
+// NoProxy returns the 'no-proxy' for the environment.
 func (c *Config) NoProxy() string {
 	return c.asString(NoProxyKey)
 }
@@ -669,7 +669,7 @@ func (c *Config) AptFTPProxy() string {
 	return addSchemeIfMissing("ftp", c.getWithFallback(AptFTPProxyKey, FTPProxyKey))
 }
 
-// AptNoProxy returns the 'apt-no proxy' for the environment.
+// AptNoProxy returns the 'apt-no-proxy' for the environment.
 func (c *Config) AptNoProxy() string {
 	return c.asString(AptNoProxyKey)
 }

--- a/environs/config/config_test.go
+++ b/environs/config/config_test.go
@@ -1078,12 +1078,12 @@ func (s *ConfigSuite) TestProxyConfigMap(c *gc.C) {
 		Http:    "http://http proxy",
 		Https:   "https://https proxy",
 		Ftp:     "ftp://ftp proxy",
-		NoProxy: "",
+		NoProxy: "127.0.0.1,localhost,::1",
 	}
 	cfg, err := cfg.Apply(config.ProxyConfigMap(proxySettings))
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cfg.ProxySettings(), gc.DeepEquals, proxySettings)
-	// Apt proxy settings always include the scheme. NoProxy is empty.
+	// Apt proxy settings always include the scheme. NoProxy is set to system defaults.
 	c.Assert(cfg.AptProxySettings(), gc.DeepEquals, expectedProxySettings)
 }
 
@@ -1091,9 +1091,10 @@ func (s *ConfigSuite) TestAptProxyConfigMap(c *gc.C) {
 	s.addJujuFiles(c)
 	cfg := newTestConfig(c, testing.Attrs{})
 	proxySettings := proxy.Settings{
-		Http:  "http://httpproxy",
-		Https: "https://httpsproxy",
-		Ftp:   "ftp://ftpproxy",
+		Http:    "http://httpproxy",
+		Https:   "https://httpsproxy",
+		Ftp:     "ftp://ftpproxy",
+		NoProxy: "noproxyhost1,noproxyhost2",
 	}
 	cfg, err := cfg.Apply(config.AptProxyConfigMap(proxySettings))
 	c.Assert(err, jc.ErrorIsNil)


### PR DESCRIPTION
## Description of change
Add support for apt-no-proxy - disable proxy for apt for selected hosts.

## QA steps
1. juju model-config apt-no-proxy=h1,h2,h3
2. deploy unit
3. verify that /etc/apt/apt.config.d/95-juju-proxy-settings contains Apt::<protocol>::"<host>" "DIRECT"; lines for protocols in http, https, ftp and host in h1, h2 h3

## Documentation changes
This option has to be documented in juju/docs

## Bug reference
https://bugs.launchpad.net/juju/+bug/1466951