### PR TITLE
state,apiserver, cmd/status: Add MeterStatus to the model

### DIFF
--- a/api/metricsdebug/client_test.go
+++ b/api/metricsdebug/client_test.go
@@ -397,7 +397,7 @@ func (s *metricsdebugSuite) TestSetMeterStatus(c *gc.C) {
 		tag:   testUnit1.Tag().String(),
 		code:  "WRONG",
 		info:  "test",
-		err:   "invalid meter status \"NOT AVAILABLE\"",
+		err:   "meter status \"NOT AVAILABLE\" not valid",
 	}, {
 		about: "not such service",
 		tag:   "application-missing",

--- a/apiserver/client/status.go
+++ b/apiserver/client/status.go
@@ -346,6 +346,10 @@ func (c *Client) modelStatus() (params.ModelStatusInfo, error) {
 		Since:  status.Since,
 		Data:   status.Data,
 	}
+	ms := m.MeterStatus()
+	if isColorStatus(ms.Code) {
+		info.MeterStatus = params.MeterStatus{Color: ms.Code.String(), Message: ms.Info}
+	}
 
 	return info, nil
 }

--- a/apiserver/common/modeldestroy.go
+++ b/apiserver/common/modeldestroy.go
@@ -17,7 +17,13 @@ var sendMetrics = func(st metricsender.ModelBackend) error {
 		return errors.Annotatef(err, "failed to get model config for %s", st.ModelTag())
 	}
 
-	err = metricsender.SendMetrics(st, metricsender.DefaultMetricSender(), clock.WallClock, metricsender.DefaultMaxBatchesPerSend(), cfg.TransmitVendorMetrics())
+	err = metricsender.SendMetrics(
+		st,
+		metricsender.DefaultMetricSender(),
+		clock.WallClock,
+		metricsender.DefaultMaxBatchesPerSend(),
+		cfg.TransmitVendorMetrics(),
+	)
 	return errors.Trace(err)
 }
 

--- a/apiserver/common/modelmanagerinterface.go
+++ b/apiserver/common/modelmanagerinterface.go
@@ -9,7 +9,6 @@ import (
 	"github.com/juju/description"
 	"gopkg.in/juju/names.v2"
 
-	"github.com/juju/juju/apiserver/metricsender"
 	"github.com/juju/juju/controller"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/config"
@@ -26,7 +25,6 @@ type ModelManagerBackend interface {
 	APIHostPortsGetter
 	ToolsStorageGetter
 	BlockGetter
-	metricsender.MetricsSenderBackend
 	state.CloudAccessor
 
 	ModelUUID() string
@@ -61,6 +59,14 @@ type ModelManagerBackend interface {
 	LatestMigration() (state.ModelMigration, error)
 	DumpAll() (map[string]interface{}, error)
 	Close() error
+
+	// Methods required by the metricsender package.
+	MetricsManager() (*state.MetricsManager, error)
+	MetricsToSend(batchSize int) ([]*state.MetricBatch, error)
+	SetMetricBatchesSent(batchUUIDs []string) error
+	CountOfUnsentMetrics() (int, error)
+	CountOfSentMetrics() (int, error)
+	CleanupOldMetrics() error
 }
 
 // Model defines methods provided by a state.Model instance.

--- a/apiserver/common/modelmanagerinterface.go
+++ b/apiserver/common/modelmanagerinterface.go
@@ -56,6 +56,7 @@ type ModelManagerBackend interface {
 	ControllerTag() names.ControllerTag
 	Export() (description.Model, error)
 	SetUserAccess(subject names.UserTag, target names.Tag, access permission.Access) (permission.UserAccess, error)
+	SetModelMeterStatus(string, string) error
 	LastModelConnection(user names.UserTag) (time.Time, error)
 	LatestMigration() (state.ModelMigration, error)
 	DumpAll() (map[string]interface{}, error)

--- a/apiserver/metricsdebug/metricsdebug_test.go
+++ b/apiserver/metricsdebug/metricsdebug_test.go
@@ -138,7 +138,7 @@ func (s *metricsDebugSuite) TestSetMeterStatus(c *gc.C) {
 		},
 		assert: func(c *gc.C, results params.ErrorResults) {
 			err := results.OneError()
-			c.Assert(err, gc.DeepEquals, &params.Error{Message: "invalid meter status \"NOT AVAILABLE\""})
+			c.Assert(err, gc.DeepEquals, &params.Error{Message: "meter status \"NOT AVAILABLE\" not valid"})
 		},
 	}, {
 		about: "not such application",

--- a/apiserver/metricsender/metricsender.go
+++ b/apiserver/metricsender/metricsender.go
@@ -46,6 +46,13 @@ func handleResponse(mm *state.MetricsManager, st ModelBackend, response wireform
 				logger.Errorf("failed to set unit %q meter status to %v: %v", unitName, status, err)
 			}
 		}
+		err = st.SetModelMeterStatus(
+			envResp.ModelStatus.Status,
+			envResp.ModelStatus.Info,
+		)
+		if err != nil {
+			logger.Errorf("failed to set the model meter status: %v", err)
+		}
 	}
 	if response.NewGracePeriod > 0 && response.NewGracePeriod != mm.GracePeriod() {
 		err := mm.SetGracePeriod(response.NewGracePeriod)

--- a/apiserver/metricsender/metricsender_test.go
+++ b/apiserver/metricsender/metricsender_test.go
@@ -93,6 +93,23 @@ func (s *MetricSenderSuite) TestSendMetrics(c *gc.C) {
 	c.Assert(sent2.Sent(), jc.IsTrue)
 }
 
+func (s *MetricSenderSuite) TestSendingHandlesModelMeterStatus(c *gc.C) {
+	var sender testing.MockSender
+	now := time.Now()
+	s.Factory.MakeMetric(c, &factory.MetricParams{Unit: s.credUnit, Time: &now})
+	s.Factory.MakeMetric(c, &factory.MetricParams{Unit: s.meteredUnit, Time: &now})
+	s.Factory.MakeMetric(c, &factory.MetricParams{Unit: s.credUnit, Sent: true, Time: &now})
+	err := metricsender.SendMetrics(s.State, &sender, s.clock, 10, true)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(sender.Data, gc.HasLen, 1)
+	c.Assert(sender.Data[0], gc.HasLen, 2)
+
+	meterStatus, err := s.State.ModelMeterStatus()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(meterStatus.Code.String(), gc.Equals, "RED")
+	c.Assert(meterStatus.Info, gc.Equals, "mocked response")
+}
+
 // TestSendMetricsAbort creates 7 unsent metrics and
 // checks that the sending stops when no more batches are ack'ed.
 func (s *MetricSenderSuite) TestSendMetricsAbort(c *gc.C) {

--- a/apiserver/metricsender/stateinterface.go
+++ b/apiserver/metricsender/stateinterface.go
@@ -31,4 +31,5 @@ type ModelBackend interface {
 	Unit(name string) (*state.Unit, error)
 	ModelTag() names.ModelTag
 	ModelConfig() (*config.Config, error)
+	SetModelMeterStatus(string, string) error
 }

--- a/apiserver/metricsender/stateinterface.go
+++ b/apiserver/metricsender/stateinterface.go
@@ -12,21 +12,14 @@ import (
 	"github.com/juju/juju/state"
 )
 
-// MetricsSenderBackend defines methods provided by a state
-// instance used by the metrics sender apiserver implementation.
-// All the interface methods are defined directly on state.State
-// and are reproduced here for use in tests.
-type MetricsSenderBackend interface {
+// ModelBackend contains methods that are used by the metrics sender.
+type ModelBackend interface {
 	MetricsManager() (*state.MetricsManager, error)
 	MetricsToSend(batchSize int) ([]*state.MetricBatch, error)
 	SetMetricBatchesSent(batchUUIDs []string) error
 	CountOfUnsentMetrics() (int, error)
 	CountOfSentMetrics() (int, error)
-}
-
-// ModelBackend contains additional methods that are used by the metrics sender.
-type ModelBackend interface {
-	MetricsSenderBackend
+	CleanupOldMetrics() error
 
 	Unit(name string) (*state.Unit, error)
 	ModelTag() names.ModelTag

--- a/apiserver/metricsender/testing/mocksender.go
+++ b/apiserver/metricsender/testing/mocksender.go
@@ -35,6 +35,7 @@ func (m *MockSender) Send(d []*wireformat.MetricBatch) (*wireformat.Response, er
 			}
 		}
 		envResponses.Ack(batch.ModelUUID, batch.UUID)
+		envResponses.SetModelStatus(batch.ModelUUID, "RED", "mocked response")
 	}
 	return &wireformat.Response{
 		UUID:         respUUID.String(),

--- a/apiserver/modelmanager/modelinfo_test.go
+++ b/apiserver/modelmanager/modelinfo_test.go
@@ -615,6 +615,11 @@ func (st *mockState) LatestMigration() (state.ModelMigration, error) {
 	return st.migration, st.NextErr()
 }
 
+func (st *mockState) SetModelMeterStatus(level, message string) error {
+	st.MethodCall(st, "SetModelMeterStatus", level, message)
+	return st.NextErr()
+}
+
 type mockBlock struct {
 	state.Block
 	t state.BlockType

--- a/apiserver/modelmanager/modelinfo_test.go
+++ b/apiserver/modelmanager/modelinfo_test.go
@@ -16,7 +16,6 @@ import (
 	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/apiserver/common"
-	"github.com/juju/juju/apiserver/metricsender"
 	"github.com/juju/juju/apiserver/modelmanager"
 	"github.com/juju/juju/apiserver/params"
 	apiservertesting "github.com/juju/juju/apiserver/testing"
@@ -345,6 +344,16 @@ type unitRetriever interface {
 	Unit(name string) (*state.Unit, error)
 }
 
+// metricSender defines methods required by the metricsender package.
+type metricSender interface {
+	MetricsManager() (*state.MetricsManager, error)
+	MetricsToSend(batchSize int) ([]*state.MetricBatch, error)
+	SetMetricBatchesSent(batchUUIDs []string) error
+	CountOfUnsentMetrics() (int, error)
+	CountOfSentMetrics() (int, error)
+	CleanupOldMetrics() error
+}
+
 type mockState struct {
 	gitjujutesting.Stub
 
@@ -352,7 +361,7 @@ type mockState struct {
 	common.APIHostPortsGetter
 	common.ToolsStorageGetter
 	common.BlockGetter
-	metricsender.MetricsSenderBackend
+	metricSender
 	unitRetriever
 
 	modelUUID       string

--- a/apiserver/params/status.go
+++ b/apiserver/params/status.go
@@ -36,6 +36,7 @@ type ModelStatusInfo struct {
 	Version          string         `json:"version"`
 	AvailableVersion string         `json:"available-version"`
 	ModelStatus      DetailedStatus `json:"model-status"`
+	MeterStatus      MeterStatus    `json:"meter-status"`
 }
 
 // NetworkInterfaceStatus holds a /etc/network/interfaces-type data and the

--- a/cmd/juju/status/formatted.go
+++ b/cmd/juju/status/formatted.go
@@ -37,6 +37,7 @@ type modelStatus struct {
 	Version          string             `json:"version" yaml:"version"`
 	AvailableVersion string             `json:"upgrade-available,omitempty" yaml:"upgrade-available,omitempty"`
 	Status           statusInfoContents `json:"model-status,omitempty" yaml:"model-status,omitempty"`
+	MeterStatus      *meterStatus       `json:"meter-status,omitempty" yaml:"meter-status,omitempty"`
 }
 
 type networkInterface struct {

--- a/cmd/juju/status/formatter.go
+++ b/cmd/juju/status/formatter.go
@@ -59,6 +59,10 @@ func (sf *statusFormatter) format() (formattedStatus, error) {
 			Version:          sf.status.Model.Version,
 			AvailableVersion: sf.status.Model.AvailableVersion,
 			Status:           sf.getStatusInfoContents(sf.status.Model.ModelStatus),
+			MeterStatus: &meterStatus{
+				Color:   sf.status.Model.MeterStatus.Color,
+				Message: sf.status.Model.MeterStatus.Message,
+			},
 		},
 		Machines:           make(map[string]machineStatus),
 		Applications:       make(map[string]applicationStatus),

--- a/cmd/juju/status/formatter.go
+++ b/cmd/juju/status/formatter.go
@@ -59,14 +59,16 @@ func (sf *statusFormatter) format() (formattedStatus, error) {
 			Version:          sf.status.Model.Version,
 			AvailableVersion: sf.status.Model.AvailableVersion,
 			Status:           sf.getStatusInfoContents(sf.status.Model.ModelStatus),
-			MeterStatus: &meterStatus{
-				Color:   sf.status.Model.MeterStatus.Color,
-				Message: sf.status.Model.MeterStatus.Message,
-			},
 		},
 		Machines:           make(map[string]machineStatus),
 		Applications:       make(map[string]applicationStatus),
 		RemoteApplications: make(map[string]remoteApplicationStatus),
+	}
+	if sf.status.Model.MeterStatus.Color != "" {
+		out.Model.MeterStatus = &meterStatus{
+			Color:   sf.status.Model.MeterStatus.Color,
+			Message: sf.status.Model.MeterStatus.Message,
+		}
 	}
 	for k, m := range sf.status.Machines {
 		out.Machines[k] = sf.formatMachine(m)

--- a/cmd/juju/status/output_tabular.go
+++ b/cmd/juju/status/output_tabular.go
@@ -106,6 +106,8 @@ func FormatTabular(writer io.Writer, forceColor bool, value interface{}) error {
 		cloudRegion += "/" + fs.Model.CloudRegion
 	}
 
+	metering := fs.Model.MeterStatus != nil
+
 	header := []interface{}{"Model", "Controller", "Cloud/Region", "Version"}
 	values := []interface{}{fs.Model.Name, fs.Model.Controller, cloudRegion, fs.Model.Version}
 	message := getModelMessage(fs.Model)
@@ -142,7 +144,6 @@ func FormatTabular(writer io.Writer, forceColor bool, value interface{}) error {
 	}
 
 	units := make(map[string]unitStatus)
-	metering := false
 	relations := newRelationFormatter()
 	outputHeaders("App", "Version", "Status", "Scale", "Charm", "Store", "Rev", "OS", "Notes")
 	tw.SetColumnAlignRight(3)
@@ -225,6 +226,13 @@ func FormatTabular(writer io.Writer, forceColor bool, value interface{}) error {
 
 	if metering {
 		outputHeaders("Meter", "Status", "Message")
+		if fs.Model.MeterStatus != nil {
+			w.Print("model")
+			outputColor := fromMeterStatusColor(fs.Model.MeterStatus.Color)
+			w.PrintColor(outputColor, fs.Model.MeterStatus.Color)
+			w.PrintColor(outputColor, fs.Model.MeterStatus.Message)
+			w.Println()
+		}
 		for _, name := range utils.SortStringsNaturally(stringKeysFromMap(units)) {
 			u := units[name]
 			if u.MeterStatus != nil {

--- a/cmd/juju/status/status_test.go
+++ b/cmd/juju/status/status_test.go
@@ -2852,6 +2852,32 @@ var statusTests = []testCase{
 			},
 		},
 	),
+	test( // 24
+		"set meter status on the model",
+		setModelMeterStatus{"RED", "status message"},
+		expect{
+			"simulate just the two services and a bootstrap node",
+			M{
+				"model": M{
+					"name":       "controller",
+					"controller": "kontroll",
+					"cloud":      "dummy",
+					"region":     "dummy-region",
+					"version":    "1.2.3",
+					"model-status": M{
+						"current": "available",
+						"since":   "01 Apr 15 01:23+10:00",
+					},
+					"meter-status": M{
+						"color":   "RED",
+						"message": "status message",
+					},
+				},
+				"machines":     M{},
+				"applications": M{},
+			},
+		},
+	),
 }
 
 func mysqlCharm(extras M) M {
@@ -3282,6 +3308,18 @@ func (s setUnitMeterStatus) step(c *gc.C, ctx *context) {
 	u, err := ctx.st.Unit(s.unitName)
 	c.Assert(err, jc.ErrorIsNil)
 	err = u.SetMeterStatus(s.color, s.message)
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+type setModelMeterStatus struct {
+	color   string
+	message string
+}
+
+func (s setModelMeterStatus) step(c *gc.C, ctx *context) {
+	m, err := ctx.st.Model()
+	c.Assert(err, jc.ErrorIsNil)
+	err = m.SetMeterStatus(s.color, s.message)
 	c.Assert(err, jc.ErrorIsNil)
 }
 

--- a/state/meterstatus.go
+++ b/state/meterstatus.go
@@ -82,7 +82,7 @@ func isValidMeterStatusCode(codeStr string) (MeterStatusCode, error) {
 	case MeterGreen, MeterAmber, MeterRed:
 		return code, nil
 	default:
-		return MeterNotAvailable, errors.Errorf("invalid meter status %q", codeStr)
+		return MeterNotAvailable, errors.NotValidf("meter status %q", codeStr)
 	}
 }
 

--- a/state/meterstatus.go
+++ b/state/meterstatus.go
@@ -76,13 +76,21 @@ type meterStatusDoc struct {
 	Info      string `bson:"info"`
 }
 
-// SetMeterStatus sets the meter status for the unit.
-func (u *Unit) SetMeterStatus(codeStr, info string) error {
+func isValidMeterStatusCode(codeStr string) (MeterStatusCode, error) {
 	code := MeterStatusFromString(codeStr)
 	switch code {
 	case MeterGreen, MeterAmber, MeterRed:
+		return code, nil
 	default:
-		return errors.Errorf("invalid meter status %q", code)
+		return MeterNotAvailable, errors.Errorf("invalid meter status %q", codeStr)
+	}
+}
+
+// SetMeterStatus sets the meter status for the unit.
+func (u *Unit) SetMeterStatus(codeStr, info string) error {
+	code, err := isValidMeterStatusCode(codeStr)
+	if err != nil {
+		return errors.Trace(err)
 	}
 	meterDoc, err := u.getMeterStatusDoc()
 	if err != nil {

--- a/state/meterstatus_test.go
+++ b/state/meterstatus_test.go
@@ -57,13 +57,13 @@ func (s *MeterStateSuite) TestMeterStatusIncludesModelUUID(c *gc.C) {
 
 func (s *MeterStateSuite) TestSetMeterStatusIncorrect(c *gc.C) {
 	err := s.unit.SetMeterStatus("NOT SET", "Additional information.")
-	c.Assert(err, gc.ErrorMatches, `invalid meter status "NOT SET"`)
+	c.Assert(err, gc.ErrorMatches, `meter status "NOT SET" not valid`)
 	status, err := s.unit.GetMeterStatus()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(status.Code, gc.Equals, state.MeterNotSet)
 
 	err = s.unit.SetMeterStatus("this-is-not-a-valid-status", "Additional information.")
-	c.Assert(err, gc.ErrorMatches, `invalid meter status "this-is-not-a-valid-status"`)
+	c.Assert(err, gc.ErrorMatches, `meter status "this-is-not-a-valid-status" not valid`)
 	status, err = s.unit.GetMeterStatus()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(status.Code, gc.Equals, state.MeterNotSet)

--- a/state/meterstatus_test.go
+++ b/state/meterstatus_test.go
@@ -63,7 +63,7 @@ func (s *MeterStateSuite) TestSetMeterStatusIncorrect(c *gc.C) {
 	c.Assert(status.Code, gc.Equals, state.MeterNotSet)
 
 	err = s.unit.SetMeterStatus("this-is-not-a-valid-status", "Additional information.")
-	c.Assert(err, gc.ErrorMatches, `invalid meter status "NOT AVAILABLE"`)
+	c.Assert(err, gc.ErrorMatches, `invalid meter status "this-is-not-a-valid-status"`)
 	status, err = s.unit.GetMeterStatus()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(status.Code, gc.Equals, state.MeterNotSet)

--- a/state/migration_export_test.go
+++ b/state/migration_export_test.go
@@ -228,19 +228,6 @@ func (s *MigrationExportSuite) TestModelUsers(c *gc.C) {
 	c.Assert(exportedBob.Access(), gc.Equals, "read")
 }
 
-func (s *MigrationExportSuite) TestSLAs(c *gc.C) {
-	err := s.State.SetSLA("essential", []byte("creds"))
-	c.Assert(err, jc.ErrorIsNil)
-
-	model, err := s.State.Export()
-	c.Assert(err, jc.ErrorIsNil)
-
-	sla := model.SLA()
-
-	c.Assert(sla.Level, gc.Equals, "essential")
-	c.Assert(sla.Creds, jc.DeepEquals, []byte("creds"))
-}
-
 func (s *MigrationExportSuite) TestMachines(c *gc.C) {
 	s.assertMachinesMigrated(c, constraints.MustParse("arch=amd64 mem=8G"))
 }

--- a/state/migration_export_test.go
+++ b/state/migration_export_test.go
@@ -228,6 +228,19 @@ func (s *MigrationExportSuite) TestModelUsers(c *gc.C) {
 	c.Assert(exportedBob.Access(), gc.Equals, "read")
 }
 
+func (s *MigrationExportSuite) TestSLAs(c *gc.C) {
+	err := s.State.SetSLA("essential", []byte("creds"))
+	c.Assert(err, jc.ErrorIsNil)
+
+	model, err := s.State.Export()
+	c.Assert(err, jc.ErrorIsNil)
+
+	sla := model.SLA()
+
+	c.Assert(sla.Level, gc.Equals, "essential")
+	c.Assert(sla.Creds, jc.DeepEquals, []byte("creds"))
+}
+
 func (s *MigrationExportSuite) TestMachines(c *gc.C) {
 	s.assertMachinesMigrated(c, constraints.MustParse("arch=amd64 mem=8G"))
 }

--- a/state/migration_internal_test.go
+++ b/state/migration_internal_test.go
@@ -227,6 +227,8 @@ func (s *MigrationSuite) TestModelDocFields(c *gc.C) {
 		"CloudRegion",
 		"CloudCredential",
 		"LatestAvailableTools",
+		"SLA",
+		"MeterStatus",
 	)
 	s.AssertExportedFields(c, modelDoc{}, fields)
 }
@@ -827,7 +829,6 @@ func (s *MigrationSuite) TestEndpointBindingFields(c *gc.C) {
 }
 
 func (s *MigrationSuite) AssertExportedFields(c *gc.C, doc interface{}, fields set.Strings) {
-	c.Skip("NEED TO FIX BEFORE LANDING")
 	expected := testing.GetExportedFields(doc)
 	unknown := expected.Difference(fields)
 	removed := fields.Difference(expected)

--- a/state/model_test.go
+++ b/state/model_test.go
@@ -288,7 +288,7 @@ func (s *ModelSuite) TestMeterStatus(c *gc.C) {
 	}
 
 	err = model.SetMeterStatus("PURPLE", "foobar")
-	c.Assert(err, gc.ErrorMatches, `invalid meter status "PURPLE"`)
+	c.Assert(err, gc.ErrorMatches, `meter status "PURPLE" not valid`)
 
 	c.Assert(ms.Code, gc.Equals, state.MeterAmber)
 	c.Assert(ms.Info, gc.Equals, "info setting 2")

--- a/state/model_test.go
+++ b/state/model_test.go
@@ -257,6 +257,43 @@ func (s *ModelSuite) TestSLA(c *gc.C) {
 	c.Assert(slaCreds, gc.DeepEquals, []byte("auth advanced"))
 }
 
+func (s *ModelSuite) TestMeterStatus(c *gc.C) {
+	cfg, _ := s.createTestModelConfig(c)
+	owner := names.NewUserTag("test@remote")
+
+	model, st, err := s.State.NewModel(state.ModelArgs{
+		CloudName:   "dummy",
+		CloudRegion: "dummy-region",
+		Config:      cfg,
+		Owner:       owner,
+		StorageProviderRegistry: storage.StaticProviderRegistry{},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	defer st.Close()
+
+	ms, err := st.ModelMeterStatus()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(ms.Code, gc.Equals, state.MeterNotAvailable)
+	c.Assert(ms.Info, gc.Equals, "")
+
+	for i, validStatus := range []string{"RED", "GREEN", "AMBER"} {
+		info := fmt.Sprintf("info setting %d", i)
+		err = st.SetModelMeterStatus(validStatus, info)
+		c.Assert(err, jc.ErrorIsNil)
+		c.Assert(model.Refresh(), jc.ErrorIsNil)
+		ms, err = st.ModelMeterStatus()
+		c.Assert(err, jc.ErrorIsNil)
+		c.Assert(ms.Code.String(), gc.Equals, validStatus)
+		c.Assert(ms.Info, gc.Equals, info)
+	}
+
+	err = model.SetMeterStatus("PURPLE", "foobar")
+	c.Assert(err, gc.ErrorMatches, `invalid meter status "PURPLE"`)
+
+	c.Assert(ms.Code, gc.Equals, state.MeterAmber)
+	c.Assert(ms.Info, gc.Equals, "info setting 2")
+}
+
 func (s *ModelSuite) TestControllerModel(c *gc.C) {
 	model, err := s.State.ControllerModel()
 	c.Assert(err, jc.ErrorIsNil)

--- a/state/state.go
+++ b/state/state.go
@@ -2172,6 +2172,22 @@ func (st *State) SetSLA(level string, credentials []byte) error {
 	return model.SetSLA(level, credentials)
 }
 
+func (st *State) SetModelMeterStatus(status, info string) error {
+	model, err := st.Model()
+	if err != nil {
+		return errors.Trace(err)
+	}
+	return model.SetMeterStatus(status, info)
+}
+
+func (st *State) ModelMeterStatus() (MeterStatus, error) {
+	model, err := st.Model()
+	if err != nil {
+		return MeterStatus{MeterNotAvailable, ""}, errors.Trace(err)
+	}
+	return model.MeterStatus(), nil
+}
+
 // SLALevel returns the SLA level of the current connected model.
 func (st *State) SLALevel() (string, error) {
 	model, err := st.Model()

--- a/state/state.go
+++ b/state/state.go
@@ -2172,6 +2172,7 @@ func (st *State) SetSLA(level string, credentials []byte) error {
 	return model.SetSLA(level, credentials)
 }
 
+// SetModelMeterStatus sets the meter status for the current connected model.
 func (st *State) SetModelMeterStatus(status, info string) error {
 	model, err := st.Model()
 	if err != nil {
@@ -2180,6 +2181,7 @@ func (st *State) SetModelMeterStatus(status, info string) error {
 	return model.SetMeterStatus(status, info)
 }
 
+// ModelMeterStatus returns the meter status for the current connected model.
 func (st *State) ModelMeterStatus() (MeterStatus, error) {
 	model, err := st.Model()
 	if err != nil {

--- a/state/upgrades_test.go
+++ b/state/upgrades_test.go
@@ -100,9 +100,6 @@ func (s *upgradesSuite) TestStripLocalUserDomainModels(c *gc.C) {
 	delete(initialModel, "txn-revno")
 	initialModel["owner"] = "test-admin"
 
-	// TODO (mattyw, cmars) We need to confirm that setting sla and meter-status in this test
-	// in this way is correct.
-	// Put another way - we need to ensure we're testing correct behaviour here.
 	expected := []bson.M{{
 		"_id":              "0000-dead-beaf-0001",
 		"owner":            "user-admin",

--- a/state/upgrades_test.go
+++ b/state/upgrades_test.go
@@ -100,7 +100,7 @@ func (s *upgradesSuite) TestStripLocalUserDomainModels(c *gc.C) {
 	delete(initialModel, "txn-revno")
 	initialModel["owner"] = "test-admin"
 
-	// TODO (mattyw, cmars) We need to confirm that setting sla in this test
+	// TODO (mattyw, cmars) We need to confirm that setting sla and meter-status in this test
 	// in this way is correct.
 	// Put another way - we need to ensure we're testing correct behaviour here.
 	expected := []bson.M{{
@@ -114,6 +114,7 @@ func (s *upgradesSuite) TestStripLocalUserDomainModels(c *gc.C) {
 		"life":             0,
 		"migration-mode":   "",
 		"sla":              bson.M{"level": "", "credentials": []uint8{}},
+		"meter-status":     bson.M{"code": "", "info": ""},
 	}, {
 		"_id":              "0000-dead-beaf-0002",
 		"owner":            "user-mary@external",
@@ -125,6 +126,7 @@ func (s *upgradesSuite) TestStripLocalUserDomainModels(c *gc.C) {
 		"life":             0,
 		"migration-mode":   "",
 		"sla":              bson.M{"level": "", "credentials": []uint8{}},
+		"meter-status":     bson.M{"code": "", "info": ""},
 	},
 		initialModel,
 	}


### PR DESCRIPTION
## Description of change

With SLAs operating at the conceptual level of models each model now has the concept of a meter status, this is the same concept as the existing unit meter status.

## QA steps

```bash
juju bootstrap
juju status # No meter status should be reported
# Do something to make the model meter status go red
juju status
# Output should look something like http://paste.ubuntu.com/24196065/
```

## Documentation changes

How users react to meter status on models needs to be documented. This feature is just one of the features under the umbrella of SLAs
## Bug reference

n/a