### PR TITLE
Using gogland and Windows more files should be ignored

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,4 +15,6 @@ stage/
 .emacs.desktop
 .emacs.desktop.lock
 *.test
+*.test.exe
 *.sw[nop]
+.idea/


### PR DESCRIPTION
## Description of change

Just ignore some files that don't belong in version control.
I saw that we already had some stuff like emacs and vim files, and I've been playing around with Gogland on multiple platforms so might as well exclude the '.idea' directory as well.
I also saw that 'test' executables are flagged as ignored, but on Windows they have a different extension, so I added those as well.

## QA steps

```git status``` inside a tree on Windows.

## Documentation changes

No

## Bug reference

None