### PR TITLE
Show progress for kvm containers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,4 +15,6 @@ stage/
 .emacs.desktop
 .emacs.desktop.lock
 *.test
+*.test.exe
 *.sw[nop]
+.idea/

--- a/container/kvm/container.go
+++ b/container/kvm/container.go
@@ -56,10 +56,7 @@ func (c *kvmContainer) Start(params StartParams) error {
 	logger.Debugf("synchronise images for %s %s %s", sp.arch, sp.series, params.ImageDownloadURL)
 	var callback ProgressCallback
 	if params.StatusCallback != nil {
-		callback = func(url string, cur, total uint64) {
-			percent := (float64(cur) * 100.0) / float64(total)
-			mb := cur / (1024 * 1024)
-			msg := fmt.Sprintf("copying %s %dMB %.1f%%", url, mb, percent)
+		callback = func(msg string) {
 			params.StatusCallback(status.Provisioning, msg, nil)
 		}
 	}

--- a/container/kvm/container.go
+++ b/container/kvm/container.go
@@ -14,6 +14,7 @@ import (
 	"github.com/juju/juju/environs/imagedownloads"
 	"github.com/juju/juju/environs/simplestreams"
 	"github.com/juju/juju/network"
+	"github.com/juju/juju/status"
 )
 
 type kvmContainer struct {
@@ -53,7 +54,16 @@ func (c *kvmContainer) Start(params StartParams) error {
 		srcFunc: srcFunc,
 	}
 	logger.Debugf("synchronise images for %s %s %s", sp.arch, sp.series, params.ImageDownloadURL)
-	if err := Sync(sp, nil); err != nil {
+	var callback ProgressCallback
+	if params.StatusCallback != nil {
+		callback = func(url string, cur, total uint64) {
+			percent := (float64(cur) * 100.0) / float64(total)
+			mb := cur / (1024 * 1024)
+			msg := fmt.Sprintf("copying %s %dMB %.1f%%", url, mb, percent)
+			params.StatusCallback(status.Provisioning, msg, nil)
+		}
+	}
+	if err := Sync(sp, nil, callback); err != nil {
 		if !errors.IsAlreadyExists(err) {
 			return errors.Trace(err)
 		}
@@ -74,6 +84,9 @@ func (c *kvmContainer) Start(params StartParams) error {
 		}
 	}
 	logger.Debugf("create the machine %s", c.name)
+	if params.StatusCallback != nil {
+		params.StatusCallback(status.Provisioning, "Creating instance", nil)
+	}
 	if err := CreateMachine(CreateMachineParams{
 		Hostname:      c.name,
 		Series:        params.Series,
@@ -88,6 +101,9 @@ func (c *kvmContainer) Start(params StartParams) error {
 	}
 
 	logger.Debugf("Set machine %s to autostart", c.name)
+	if params.StatusCallback != nil {
+		params.StatusCallback(status.Provisioning, "Starting instance", nil)
+	}
 	return AutostartMachine(c)
 }
 

--- a/container/kvm/interface.go
+++ b/container/kvm/interface.go
@@ -5,6 +5,7 @@ package kvm
 
 import (
 	"github.com/juju/juju/container"
+	"github.com/juju/juju/status"
 )
 
 // StartParams is a simple parameter struct for Container.Start.
@@ -17,6 +18,7 @@ type StartParams struct {
 	CpuCores         uint64
 	RootDisk         uint64 // GB
 	ImageDownloadURL string
+	StatusCallback   func(status status.Status, info string, data map[string]interface{}) error
 }
 
 // Container represents a virtualized container instance and provides

--- a/container/kvm/kvm.go
+++ b/container/kvm/kvm.go
@@ -166,6 +166,7 @@ func (manager *containerManager) CreateContainer(
 	startParams.Series = series
 	startParams.Network = networkConfig
 	startParams.UserDataFile = userDataFilename
+	startParams.StatusCallback = callback
 
 	// If the Simplestream requested is anything but released, update
 	// our StartParams to request it.
@@ -181,13 +182,14 @@ func (manager *containerManager) CreateContainer(
 		return nil, nil, errors.Annotate(err, "failed to parse hardware")
 	}
 
-	callback(status.Allocating, "Creating container; it might take some time", nil)
+	callback(status.Provisioning, "Creating container; it might take some time", nil)
 	logger.Tracef("create the container, constraints: %v", cons)
 	if err := kvmContainer.Start(startParams); err != nil {
 		err = errors.Annotate(err, "kvm container creation failed")
 		return nil, nil, err
 	}
 	logger.Tracef("kvm container created")
+	callback(status.Running, "Container started", nil)
 	return &kvmInstance{kvmContainer, name}, &hardware, nil
 }
 

--- a/container/kvm/sync.go
+++ b/container/kvm/sync.go
@@ -14,6 +14,7 @@ import (
 	"path/filepath"
 	"time"
 
+	humanize "github.com/dustin/go-humanize"
 	"github.com/juju/errors"
 	"github.com/juju/utils/clock"
 	"github.com/juju/utils/series"
@@ -120,6 +121,8 @@ type ProgressCallback func(message string)
 // Sync updates the local cached images by reading the simplestreams data and
 // caching if an image matching the contrainsts doesn't exist. It retrieves
 // metadata information from Oner and updates local cache via Fetcher.
+// A ProgressCallback can optionally be passed which will get update messages
+// as data is copied.
 func Sync(o Oner, f Fetcher, progress ProgressCallback) error {
 	md, err := o.One()
 	if err != nil {
@@ -196,7 +199,8 @@ func (p *progressWriter) Write(content []byte) (n int, err error) {
 			percent := (float64(p.total) * 100.0) / float64(p.maxBytes)
 			intPercent := int(percent + 0.5)
 			if p.lastPercent != intPercent {
-				p.callback(fmt.Sprintf("copying %s %d%% (%s)", p.url, intPercent, toBPS(p.total, elapsed.Seconds())))
+				bps := uint64((float64(p.total) / elapsed.Seconds()) + 0.5)
+				p.callback(fmt.Sprintf("copying %s %d%% (%s/s)", p.url, intPercent, humanize.Bytes(bps)))
 				p.lastPercent = intPercent
 			}
 		}

--- a/container/kvm/sync.go
+++ b/container/kvm/sync.go
@@ -196,7 +196,7 @@ func (p *progressWriter) Write(content []byte) (n int, err error) {
 			percent := (float64(p.total) * 100.0) / float64(p.maxBytes)
 			intPercent := int(percent + 0.5)
 			if p.lastPercent != intPercent {
-				p.callback(fmt.Sprintf("copying %s %d%% %s", p.url, intPercent, toBPS(p.total, elapsed.Seconds())))
+				p.callback(fmt.Sprintf("copying %s %d%% (%s)", p.url, intPercent, toBPS(p.total, elapsed.Seconds())))
 				p.lastPercent = intPercent
 			}
 		}

--- a/container/kvm/sync_internal_test.go
+++ b/container/kvm/sync_internal_test.go
@@ -325,8 +325,6 @@ func (s *progressWriterSuite) TestOnlyPercentChanges(c *gc.C) {
 	now := clock.Now()
 	writer.startTime = &now
 	for i := 0; i < 2048; i++ {
-		// We tick every 1ms and add 50kiB each time, which is
-		// 50*1024 *1000/ 1024/1024  = 48.8MiB/s
 		clock.Advance(time.Millisecond)
 		n, err := writer.Write(content)
 		c.Assert(err, jc.ErrorIsNil)
@@ -334,7 +332,9 @@ func (s *progressWriterSuite) TestOnlyPercentChanges(c *gc.C) {
 	}
 	expectedCB := []string{}
 	for i := 1; i <= 100; i++ {
-		expectedCB = append(expectedCB, fmt.Sprintf("copying http://host/path %d%% 48.8MB/s", i))
+		// We tick every 1ms and add 50kiB each time, which is
+		// 50*1024 *1000/ 1024/1024  = 48.8MiB/s
+		expectedCB = append(expectedCB, fmt.Sprintf("copying http://host/path %d%% (48.8MB/s)", i))
 	}
 	// There are 2048 calls to Write, but there should only be 100 calls to progress update
 	c.Check(len(cbLog), gc.Equals, 100)

--- a/container/kvm/sync_internal_test.go
+++ b/container/kvm/sync_internal_test.go
@@ -49,7 +49,7 @@ func (syncInternalSuite) TestFetcher(c *gc.C) {
 		}
 	}()
 
-	fetcher, err := newDefaultFetcher(md, pathfinder)
+	fetcher, err := newDefaultFetcher(md, pathfinder, nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	// setup a fake command runner.
@@ -87,7 +87,7 @@ func (syncInternalSuite) TestFetcherWriteFails(c *gc.C) {
 		}
 	}()
 
-	fetcher, err := newDefaultFetcher(md, pathfinder)
+	fetcher, err := newDefaultFetcher(md, pathfinder, nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	// setup a fake command runner.
@@ -124,7 +124,7 @@ func (syncInternalSuite) TestFetcherInvalidSHA(c *gc.C) {
 		}
 	}()
 
-	fetcher, err := newDefaultFetcher(md, pathfinder)
+	fetcher, err := newDefaultFetcher(md, pathfinder, nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	err = fetcher.Fetch()
@@ -151,7 +151,7 @@ func (syncInternalSuite) TestFetcherNotFound(c *gc.C) {
 		}
 	}()
 
-	fetcher, err := newDefaultFetcher(md, pathfinder)
+	fetcher, err := newDefaultFetcher(md, pathfinder, nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	err = fetcher.Fetch()

--- a/container/kvm/sync_internal_test.go
+++ b/container/kvm/sync_internal_test.go
@@ -265,36 +265,6 @@ func (fs fakeFS) Open(name string) (http.File, error) {
 	return &fakeFile{ReadSeeker: strings.NewReader(f.contents), fi: f, path: name}, nil
 }
 
-type bpsSuite struct {
-	testing.IsolationSuite
-}
-
-var _ = gc.Suite(&bpsSuite{})
-
-func (s *bpsSuite) TestMultipleMagnitudes(c *gc.C) {
-	var tests = []struct {
-		count    uint64
-		secs     float64
-		expected string
-	}{
-		{1000, 1.0, "1000.0B/s"}, // B/s
-		{1000, 0.5, "2000.0B/s"},
-		{1000, 0.3, "3333.3B/s"},
-		{1000, 0.1, "9.8kB/s"}, // in kiB/s
-		{10000, 0.1, "97.7kB/s"},
-		{100000, 0.1, "976.6kB/s"},
-		{1000000, 0.1, "9765.6kB/s"},
-		{2000000, 0.1, "19.1MB/s"}, // in MiB/s
-		{50000000, 0.1, "476.8MB/s"},
-		{500000000, 0.1, "4768.4MB/s"},
-		{8000000000, 0.1, "74.5GB/s"}, // in GiB/s
-	}
-	for i, t := range tests {
-		c.Logf("test %d", i)
-		c.Check(toBPS(t.count, t.secs), gc.Equals, t.expected)
-	}
-}
-
 type progressWriterSuite struct {
 	testing.IsolationSuite
 }
@@ -333,8 +303,8 @@ func (s *progressWriterSuite) TestOnlyPercentChanges(c *gc.C) {
 	expectedCB := []string{}
 	for i := 1; i <= 100; i++ {
 		// We tick every 1ms and add 50kiB each time, which is
-		// 50*1024 *1000/ 1024/1024  = 48.8MiB/s
-		expectedCB = append(expectedCB, fmt.Sprintf("copying http://host/path %d%% (48.8MB/s)", i))
+		// 50*1024 *1000/ 1000/1000  = 51MB/s
+		expectedCB = append(expectedCB, fmt.Sprintf("copying http://host/path %d%% (51MB/s)", i))
 	}
 	// There are 2048 calls to Write, but there should only be 100 calls to progress update
 	c.Check(len(cbLog), gc.Equals, 100)

--- a/container/kvm/sync_test.go
+++ b/container/kvm/sync_test.go
@@ -27,7 +27,7 @@ var _ = gc.Suite(&cacheSuite{})
 func (cacheSuite) TestSyncOnerErrors(c *gc.C) {
 	o := fakeParams{FakeData: nil, Err: errors.New("oner failed")}
 	u := fakeFetcher{}
-	got := Sync(o, u)
+	got := Sync(o, u, nil)
 	c.Assert(got, gc.ErrorMatches, "oner failed")
 }
 
@@ -36,21 +36,21 @@ func (cacheSuite) TestSyncOnerExists(c *gc.C) {
 		FakeData: nil,
 		Err:      errors.AlreadyExistsf("exists")}
 	u := fakeFetcher{}
-	got := Sync(o, u)
+	got := Sync(o, u, nil)
 	c.Assert(got, jc.ErrorIsNil)
 }
 
 func (cacheSuite) TestSyncUpdaterErrors(c *gc.C) {
 	o := fakeParams{FakeData: &imagedownloads.Metadata{}, Err: nil}
 	u := fakeFetcher{Err: errors.New("updater failed")}
-	got := Sync(o, u)
+	got := Sync(o, u, nil)
 	c.Assert(got, gc.ErrorMatches, "updater failed")
 }
 
 func (cacheSuite) TestSyncSucceeds(c *gc.C) {
 	o := fakeParams{FakeData: &imagedownloads.Metadata{}}
 	u := fakeFetcher{}
-	got := Sync(o, u)
+	got := Sync(o, u, nil)
 	c.Assert(got, jc.ErrorIsNil)
 }
 

--- a/container/kvm/wrappedcmds_test.go
+++ b/container/kvm/wrappedcmds_test.go
@@ -66,7 +66,7 @@ func (s *LibVertSuite) TestSyncImagesUtilizesSimpleStreamsSource(c *gc.C) {
 		srcFunc: func() simplestreams.DataSource { return imagedownloads.NewDataSource(source) },
 		success: true,
 	}
-	err := Sync(p, fakeFetcher{})
+	err := Sync(p, fakeFetcher{}, nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	url, err := p.sourceURL()


### PR DESCRIPTION
## Description of change

KVM containers were only showing "Starting container, this might take a while". But not giving any sense for what it was actually doing. This makes it slightly better by giving a progress message (number of bytes copied, progress %) while the container is being started, and then changing the final message to indicate the machine is running.

## QA steps

```
  $ juju bootstrap maas
  $ juju switch controller
  $ juju add-machine kvm:0
  $ juju status
  $ watch juju show-machine 0
```

Without this patch, there would only be a message:
```
        instance-id: juju-3cab08-0-kvm-1
        machine-status:
          current: allocating
          message: Creating container; it might take some time
```

With this patch, you should see messages like:
```
 copying http://cloud-images.ubuntu.com/server/releases/trusty/release-20170307/ubuntu-14.04-server-cloudimg-amd64-disk1.img 5% 1.4MB/s
```
And a final status of:
```
        machine-status:
          current: running
          message: Container started
          since: 19 Mar 2017 16:25:39+04:00
```

this matches the LXD container status.  The progress message should be pretty close, and the final status is the same.

## Documentation changes

This *is* user visible, but as it is informative, I don't think it needs documentation changes.

## Bug reference

[lp:1674074](https://bugs.launchpad.net/juju/+bug/1674074)