### PR TITLE
state: Model migration for sla and meter status

### DIFF
--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -20,7 +20,7 @@ github.com/juju/ansiterm	git	b99631de12cf04a906c1d4e4ec54fb86eae5863d	2016-09-07
 github.com/juju/blobstore	git	06056004b3d7b54bbb7984d830c537bad00fec21	2015-07-29T11:18:58Z
 github.com/juju/bundlechanges	git	7725027b95e0d54635e0fb11efc2debdcdf19f75	2016-12-15T16:06:52Z
 github.com/juju/cmd	git	9425a576247f348b9b40afe3b60085de63470de5	2017-03-20T01:37:09Z
-github.com/juju/description	git	d3742c23561884cd7d759ef7142340af1d22cab0	2017-03-20T07:46:40Z
+github.com/juju/description	git	76acbf13a755236ebeb415c4bc9bbd6b88f0c66a	2017-03-22T22:45:04Z
 github.com/juju/errors	git	1b5e39b83d1835fa480e0c2ddefb040ee82d58b3	2015-09-16T12:56:42Z
 github.com/juju/gnuflag	git	4e76c56581859c14d9d87e1ddbe29e1c0f10195f	2016-08-09T16:52:14Z
 github.com/juju/go4	git	40d72ab9641a2a8c36a9c46a51e28367115c8e59	2016-02-22T16:32:58Z

--- a/state/migration_export.go
+++ b/state/migration_export.go
@@ -143,6 +143,8 @@ func (st *State) Export() (description.Model, error) {
 		return nil, errors.Trace(err)
 	}
 
+	export.model.SetSLA(dbModel.SLALevel(), dbModel.SLACredential())
+
 	export.logExtras()
 
 	return export.model, nil

--- a/state/migration_export.go
+++ b/state/migration_export.go
@@ -143,7 +143,8 @@ func (st *State) Export() (description.Model, error) {
 		return nil, errors.Trace(err)
 	}
 
-	export.model.SetSLA(dbModel.SLALevel(), dbModel.SLACredential())
+	export.model.SetSLA(dbModel.SLALevel(), string(dbModel.SLACredential()))
+	export.model.SetMeterStatus(dbModel.MeterStatus().Code.String(), dbModel.MeterStatus().Info)
 
 	export.logExtras()
 

--- a/state/migration_export_test.go
+++ b/state/migration_export_test.go
@@ -238,7 +238,20 @@ func (s *MigrationExportSuite) TestSLAs(c *gc.C) {
 	sla := model.SLA()
 
 	c.Assert(sla.Level(), gc.Equals, "essential")
-	c.Assert(sla.Credentials(), jc.DeepEquals, []byte("creds"))
+	c.Assert(sla.Credentials(), gc.DeepEquals, "creds")
+}
+
+func (s *MigrationExportSuite) TestMeterStatus(c *gc.C) {
+	err := s.State.SetModelMeterStatus("RED", "red info message")
+	c.Assert(err, jc.ErrorIsNil)
+
+	model, err := s.State.Export()
+	c.Assert(err, jc.ErrorIsNil)
+
+	sla := model.MeterStatus()
+
+	c.Assert(sla.Code(), gc.Equals, "RED")
+	c.Assert(sla.Info(), gc.Equals, "red info message")
 }
 
 func (s *MigrationExportSuite) TestMachines(c *gc.C) {

--- a/state/migration_export_test.go
+++ b/state/migration_export_test.go
@@ -228,6 +228,19 @@ func (s *MigrationExportSuite) TestModelUsers(c *gc.C) {
 	c.Assert(exportedBob.Access(), gc.Equals, "read")
 }
 
+func (s *MigrationExportSuite) TestSLAs(c *gc.C) {
+	err := s.State.SetSLA("essential", []byte("creds"))
+	c.Assert(err, jc.ErrorIsNil)
+
+	model, err := s.State.Export()
+	c.Assert(err, jc.ErrorIsNil)
+
+	sla := model.SLA()
+
+	c.Assert(sla.Level(), gc.Equals, "essential")
+	c.Assert(sla.Credentials(), jc.DeepEquals, []byte("creds"))
+}
+
 func (s *MigrationExportSuite) TestMachines(c *gc.C) {
 	s.assertMachinesMigrated(c, constraints.MustParse("arch=amd64 mem=8G"))
 }

--- a/state/migration_import.go
+++ b/state/migration_import.go
@@ -190,6 +190,10 @@ func (st *State) Import(model description.Model) (_ *Model, _ *State, err error)
 
 	// Update the sequences to match that the source.
 
+	if err := dbModel.SetSLA(model.SLA().Level(), model.SLA().Credentials()); err != nil {
+		return nil, nil, errors.Trace(err)
+	}
+
 	logger.Debugf("import success")
 	return dbModel, newSt, nil
 }

--- a/state/migration_import.go
+++ b/state/migration_import.go
@@ -190,8 +190,17 @@ func (st *State) Import(model description.Model) (_ *Model, _ *State, err error)
 
 	// Update the sequences to match that the source.
 
-	if err := dbModel.SetSLA(model.SLA().Level(), model.SLA().Credentials()); err != nil {
+	if err := dbModel.SetSLA(
+		model.SLA().Level(),
+		[]byte(model.SLA().Credentials()),
+	); err != nil {
 		return nil, nil, errors.Trace(err)
+	}
+
+	if model.MeterStatus().Code() != MeterNotAvailable.String() {
+		if err := dbModel.SetMeterStatus(model.MeterStatus().Code(), model.MeterStatus().Info()); err != nil {
+			return nil, nil, errors.Trace(err)
+		}
 	}
 
 	logger.Debugf("import success")

--- a/state/migration_import_test.go
+++ b/state/migration_import_test.go
@@ -225,6 +225,20 @@ func (s *MigrationImportSuite) TestSLA(c *gc.C) {
 	c.Assert(creds, jc.DeepEquals, []byte("creds"))
 }
 
+func (s *MigrationImportSuite) TestMeterStatus(c *gc.C) {
+	err := s.State.SetModelMeterStatus("RED", "info message")
+	c.Assert(err, jc.ErrorIsNil)
+	newModel, newSt := s.importModel(c)
+
+	ms := newModel.MeterStatus()
+	c.Assert(ms.Code.String(), gc.Equals, "RED")
+	c.Assert(ms.Info, gc.Equals, "info message")
+	ms, err = newSt.ModelMeterStatus()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(ms.Code.String(), gc.Equals, "RED")
+	c.Assert(ms.Info, gc.Equals, "info message")
+}
+
 func (s *MigrationImportSuite) AssertMachineEqual(c *gc.C, newMachine, oldMachine *state.Machine) {
 	c.Assert(newMachine.Id(), gc.Equals, oldMachine.Id())
 	c.Assert(newMachine.Principals(), jc.DeepEquals, oldMachine.Principals())

--- a/state/migration_import_test.go
+++ b/state/migration_import_test.go
@@ -210,6 +210,21 @@ func (s *MigrationImportSuite) TestModelUsers(c *gc.C) {
 	c.Assert(allUsers, gc.HasLen, 3)
 }
 
+func (s *MigrationImportSuite) TestSLA(c *gc.C) {
+	err := s.State.SetSLA("essential", []byte("creds"))
+	c.Assert(err, jc.ErrorIsNil)
+	newModel, newSt := s.importModel(c)
+
+	c.Assert(newModel.SLALevel(), gc.Equals, "essential")
+	c.Assert(newModel.SLACredential(), jc.DeepEquals, []byte("creds"))
+	level, err := newSt.SLALevel()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(level, gc.Equals, "essential")
+	creds, err := newSt.SLACredential()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(creds, jc.DeepEquals, []byte("creds"))
+}
+
 func (s *MigrationImportSuite) AssertMachineEqual(c *gc.C, newMachine, oldMachine *state.Machine) {
 	c.Assert(newMachine.Id(), gc.Equals, oldMachine.Id())
 	c.Assert(newMachine.Principals(), jc.DeepEquals, oldMachine.Principals())


### PR DESCRIPTION
Also depends on https://github.com/juju/description/pull/5

## Description of change

Adds model migration for slas and meter status.
## QA steps

```
juju bootstrap
juju sla essential
# Do model migration
juju sla
essential
```
## Documentation changes

The SLA feature needs documenting. The model migration support is part of that feature, however it should be invisible to the user
## Bug reference

n/a