### PR TITLE
Add permisisons to crossmodel facade apis

### DIFF
--- a/apiserver/crossmodel/base_test.go
+++ b/apiserver/crossmodel/base_test.go
@@ -22,7 +22,7 @@ const (
 
 type baseCrossmodelSuite struct {
 	resources  *common.Resources
-	authorizer testing.FakeAuthorizer
+	authorizer *testing.FakeAuthorizer
 
 	api *crossmodel.API
 
@@ -42,7 +42,10 @@ func (s *baseCrossmodelSuite) addApplication(c *gc.C, name string) jujucrossmode
 
 func (s *baseCrossmodelSuite) SetUpTest(c *gc.C) {
 	s.resources = common.NewResources()
-	s.authorizer = testing.FakeAuthorizer{Tag: names.NewUserTag("testuser"), Controller: true}
+	s.authorizer = &testing.FakeAuthorizer{
+		Tag:      names.NewUserTag("read"),
+		AdminTag: names.NewUserTag("admin"),
+	}
 
 	s.applicationOffers = &mockApplicationOffers{}
 

--- a/apiserver/crossmodel/mock_test.go
+++ b/apiserver/crossmodel/mock_test.go
@@ -131,6 +131,10 @@ func (m *mockState) ModelUUID() string {
 	return m.modelUUID
 }
 
+func (m *mockState) ModelTag() names.ModelTag {
+	return names.NewModelTag(m.modelUUID)
+}
+
 func (m *mockState) ModelsForUser(user names.UserTag) ([]crossmodel.UserModel, error) {
 	return m.usermodels, nil
 }

--- a/apiserver/crossmodel/state.go
+++ b/apiserver/crossmodel/state.go
@@ -41,6 +41,7 @@ type Backend interface {
 	Application(name string) (Application, error)
 	Model() (Model, error)
 	ModelUUID() string
+	ModelTag() names.ModelTag
 	ModelsForUser(user names.UserTag) ([]UserModel, error)
 	RemoteConnectionStatus(offerName string) (RemoteConnectionStatus, error)
 }

--- a/core/crossmodel/applicationurl.go
+++ b/core/crossmodel/applicationurl.go
@@ -149,3 +149,12 @@ func parseApplicationURLParts(urlStr string, allowIncomplete bool) (*Application
 	}
 	return &result, nil
 }
+
+// MakeURL constructs an application URL from the specified components.
+func MakeURL(user, model, application, controller string) string {
+	base := fmt.Sprintf("%s/%s.%s", user, model, application)
+	if controller == "" {
+		return base
+	}
+	return fmt.Sprintf("%s:%s", controller, base)
+}

--- a/core/crossmodel/applicationurl_test.go
+++ b/core/crossmodel/applicationurl_test.go
@@ -162,3 +162,10 @@ func (s *ApplicationURLSuite) TestHasEndpoint(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(url.HasEndpoint(), jc.IsFalse)
 }
+
+func (s *ApplicationURLSuite) TestMakeURL(c *gc.C) {
+	url := crossmodel.MakeURL("user", "model", "app", "")
+	c.Assert(url, gc.Equals, "user/model.app")
+	url = crossmodel.MakeURL("user", "model", "app", "ctrl")
+	c.Assert(url, gc.Equals, "ctrl:user/model.app")
+}

--- a/state/applicationoffers.go
+++ b/state/applicationoffers.go
@@ -128,6 +128,10 @@ func (s *applicationOffers) AddOffer(offerArgs crossmodel.AddApplicationOfferArg
 	}
 
 	doc := s.makeApplicationOfferDoc(offerArgs)
+	result, err := s.makeApplicationOffer(doc)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	buildTxn := func(attempt int) ([]txn.Op, error) {
 		// If we've tried once already and failed, check that
 		// environment may have been destroyed.
@@ -155,7 +159,7 @@ func (s *applicationOffers) AddOffer(offerArgs crossmodel.AddApplicationOfferArg
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	return s.makeApplicationOffer(doc)
+	return result, nil
 }
 
 // UpdateOffer replaces an existing offer at the same URL.


### PR DESCRIPTION
## Please provide the following details to expedite Pull Request review:

----

## Description of change

The crossmodel facade has permission checks added so that:
offer -> admin access
list -> admin access
show -> read access
find -> read access

Also fix a bug in state where an error adding an offer would create part of the offer and fail the next time.
And improve the offer command by printing info after it runs.

## QA steps

create CMR offers, list, show, find etc

