### PR TITLE
Logsink leak fix

### DIFF
--- a/api/logsender/logsender.go
+++ b/api/logsender/logsender.go
@@ -40,6 +40,8 @@ func NewAPI(connector base.StreamConnector) *API {
 func (api *API) LogWriter() (LogWriter, error) {
 	attrs := make(url.Values)
 	attrs.Set("jujuclientversion", version.Current.String())
+	// Version 1 does ping/pong handling.
+	attrs.Set("version", "1")
 	conn, err := api.connector.ConnectStream("/logsink", attrs)
 	if err != nil {
 		return nil, errors.Annotatef(err, "cannot connect to /logsink")

--- a/api/logsender/logsender_test.go
+++ b/api/logsender/logsender_test.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"io"
 	"net/url"
+	"time"
 
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
@@ -83,6 +84,7 @@ func (c *mockConnector) ConnectStream(path string, values url.Values) (base.Stre
 	c.c.Assert(path, gc.Equals, "/logsink")
 	c.c.Assert(values, jc.DeepEquals, url.Values{
 		"jujuclientversion": []string{version.Current.String()},
+		"version":           []string{"1"},
 	})
 	if c.connectError != nil {
 		return nil, c.connectError
@@ -108,7 +110,9 @@ func (s mockStream) ReadJSON(v interface{}) error {
 }
 
 func (s mockStream) NextReader() (messageType int, r io.Reader, err error) {
-	s.conn.c.Errorf("NextReader called unexpectedly")
+	// NextReader is now called by the read loop thread.
+	// So just wait a bit and return so it doesn't sit in a very tight loop.
+	time.Sleep(time.Millisecond)
 	return 0, nil, nil
 }
 

--- a/api/pubsub/pubsub.go
+++ b/api/pubsub/pubsub.go
@@ -37,11 +37,24 @@ func (api *API) OpenMessageWriter() (MessageWriter, error) {
 	if err != nil {
 		return nil, errors.Annotatef(err, "cannot connect to /pubsub")
 	}
-	return &writer{conn}, nil
+	messageWriter := &writer{conn}
+	go messageWriter.readLoop()
+	return messageWriter, nil
 }
 
 type writer struct {
 	conn base.Stream
+}
+
+// readLoop is necessary for the client to process websocket control messages.
+// Close() is safe to call concurrently.
+func (w *writer) readLoop() {
+	for {
+		if _, _, err := w.conn.NextReader(); err != nil {
+			w.conn.Close()
+			break
+		}
+	}
 }
 
 func (w *writer) ForwardMessage(m *params.PubSubMessage) error {

--- a/api/pubsub/pubsub_test.go
+++ b/api/pubsub/pubsub_test.go
@@ -120,7 +120,9 @@ func (s mockStream) ReadJSON(v interface{}) error {
 }
 
 func (s mockStream) NextReader() (messageType int, r io.Reader, err error) {
-	s.conn.c.Errorf("NextReader called unexpectedly")
+	// NextReader is now called by the read loop thread.
+	// So just wait a bit and return so it doesn't sit in a very tight loop.
+	time.Sleep(time.Millisecond)
 	return 0, nil, nil
 }
 

--- a/apiserver/logsink.go
+++ b/apiserver/logsink.go
@@ -167,6 +167,9 @@ type logSinkHandler struct {
 // libraries use time.Now() to determine whether or not to send errors, so
 // using a testing clock here isn't going to work. So we rely on manual
 // testing, and what is defined as good practice by the library authors.
+//
+// Now, in theory, we should be using this ping/pong across all the websockets,
+// but that is a little outside the scope of this piece of work.
 
 const (
 	// pongDelay is how long the server will wait for a pong to be sent

--- a/apiserver/logsink.go
+++ b/apiserver/logsink.go
@@ -174,11 +174,14 @@ type logSinkHandler struct {
 const (
 	// pongDelay is how long the server will wait for a pong to be sent
 	// before the websocket is considered broken.
-	pongDelay = 60 * time.Second
+	pongDelay = 90 * time.Second
 
 	// pingPeriod is how often ping messages are sent. This should be shorter
-	// than the pongDelay, but not by too much.
-	pingPeriod = (pongDelay * 9) / 10
+	// than the pongDelay, but not by too much. The difference here allows
+	// the remote endpoint 30 seconds to respond to the ping as a ping is sent
+	// every 60s, and when a pong is recieved the read deadline is advanced
+	// another 90s.
+	pingPeriod = 60 * time.Second
 
 	// writeWait is how long the write call can take before it errors out.
 	writeWait = 10 * time.Second

--- a/apiserver/logsink.go
+++ b/apiserver/logsink.go
@@ -154,7 +154,7 @@ type logSinkHandler struct {
 	fileLogger  io.Writer
 }
 
-// Since the logsink only recieves messages, it is possible for the other end
+// Since the logsink only receives messages, it is possible for the other end
 // to disappear without the server noticing. To fix this, we use the
 // underlying websocket control messages ping/pong. Periodically the server
 // writes a ping, and the other end replies with a pong. Now the tricky bit is
@@ -179,7 +179,7 @@ const (
 	// pingPeriod is how often ping messages are sent. This should be shorter
 	// than the pongDelay, but not by too much. The difference here allows
 	// the remote endpoint 30 seconds to respond to the ping as a ping is sent
-	// every 60s, and when a pong is recieved the read deadline is advanced
+	// every 60s, and when a pong is received the read deadline is advanced
 	// another 90s.
 	pingPeriod = 60 * time.Second
 
@@ -215,13 +215,11 @@ func (h *logSinkHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		// formatted simple error.
 		h.sendError(socket, req, nil)
 
-		// Older versions did not respond to ping control messages, so don't try.
-		doPingPong := endpointVersion > 0
-
-		// Here we configure the ping/pong handling for the websocket so
-		// the server can notice when the client goes away.
+		// Here we configure the ping/pong handling for the websocket so the
+		// server can notice when the client goes away. Older versions did not
+		// respond to ping control messages, so don't try.
 		var tickChannel <-chan time.Time
-		if doPingPong {
+		if endpointVersion > 0 {
 			socket.SetReadDeadline(time.Now().Add(pongDelay))
 			socket.SetPongHandler(func(string) error {
 				logger.Tracef("pong logsink %p", socket)
@@ -320,7 +318,7 @@ func (h *logSinkHandler) receiveLogs(socket *websocket.Conn, endpointVersion int
 				return
 			case logCh <- m:
 				// If the remote end does not support ping/pong, we bump
-				// the read deadline everytime a message is recieved.
+				// the read deadline everytime a message is received.
 				if endpointVersion == 0 {
 					socket.SetReadDeadline(time.Now().Add(vZeroDelay))
 				}

--- a/apiserver/logsink.go
+++ b/apiserver/logsink.go
@@ -182,6 +182,10 @@ const (
 
 	// writeWait is how long the write call can take before it errors out.
 	writeWait = 10 * time.Second
+
+	// For endpoints that don't support ping/pong (i.e. agents prior to 2.2-beta1)
+	// we will time out their connections after six hours of inactivity.
+	vZeroDelay = 6 * time.Hour
 )
 
 // ServeHTTP implements the http.Handler interface.
@@ -194,6 +198,12 @@ func (h *logSinkHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 			h.sendError(socket, req, err)
 			return
 		}
+		endpointVersion, err := h.getVersion(req)
+		if err != nil {
+			h.sendError(socket, req, err)
+			return
+		}
+
 		strategy.Start()
 		defer strategy.Stop()
 
@@ -202,28 +212,39 @@ func (h *logSinkHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		// formatted simple error.
 		h.sendError(socket, req, nil)
 
+		// Older versions did not respond to ping control messages, so don't try.
+		doPingPong := endpointVersion > 0
+
 		// Here we configure the ping/pong handling for the websocket so
 		// the server can notice when the client goes away.
-		socket.SetReadDeadline(time.Now().Add(pongDelay))
-		socket.SetPongHandler(func(string) error {
+		var tickChannel <-chan time.Time
+		if doPingPong {
 			socket.SetReadDeadline(time.Now().Add(pongDelay))
-			return nil
-		})
-		ticker := time.NewTicker(pingPeriod)
-		defer ticker.Stop()
+			socket.SetPongHandler(func(string) error {
+				logger.Tracef("pong logsink %p", socket)
+				socket.SetReadDeadline(time.Now().Add(pongDelay))
+				return nil
+			})
+			ticker := time.NewTicker(pingPeriod)
+			defer ticker.Stop()
+			tickChannel = ticker.C
+		} else {
+			socket.SetReadDeadline(time.Now().Add(vZeroDelay))
+		}
 
-		logCh := h.receiveLogs(socket)
+		logCh := h.receiveLogs(socket, endpointVersion)
 		for {
 			select {
 			case <-h.ctxt.stop():
 				return
-			case <-ticker.C:
+			case <-tickChannel:
 				deadline := time.Now().Add(writeWait)
+				logger.Tracef("ping logsink %p", socket)
 				if err := socket.WriteControl(websocket.PingMessage, []byte{}, deadline); err != nil {
 					// This error is expected if the other end goes away. By
 					// returning we clean up the strategy and close the socket
 					// through the defer calls.
-					logger.Tracef("failed to write ping: %s", err)
+					logger.Debugf("failed to write ping: %s", err)
 					return
 				}
 			case m, ok := <-logCh:
@@ -240,6 +261,18 @@ func (h *logSinkHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	websocketServer(w, req, handler)
 }
 
+func (h *logSinkHandler) getVersion(req *http.Request) (int, error) {
+	verStr := req.URL.Query().Get("version")
+	switch verStr {
+	case "":
+		return 0, nil
+	case "1":
+		return 1, nil
+	default:
+		return 0, errors.Errorf("unknown version %q", verStr)
+	}
+}
+
 func jujuClientVersionFromReq(req *http.Request) (version.Number, error) {
 	verStr := req.URL.Query().Get("jujuclientversion")
 	if verStr == "" {
@@ -252,7 +285,7 @@ func jujuClientVersionFromReq(req *http.Request) (version.Number, error) {
 	return ver, nil
 }
 
-func (h *logSinkHandler) receiveLogs(socket *websocket.Conn) <-chan params.LogRecord {
+func (h *logSinkHandler) receiveLogs(socket *websocket.Conn, endpointVersion int) <-chan params.LogRecord {
 	logCh := make(chan params.LogRecord)
 
 	go func() {
@@ -269,7 +302,7 @@ func (h *logSinkHandler) receiveLogs(socket *websocket.Conn) <-chan params.LogRe
 				if websocket.IsUnexpectedCloseError(err, websocket.CloseNormalClosure, websocket.CloseGoingAway) {
 					logger.Debugf("logsink receive error: %v", err)
 				} else {
-					logger.Debugf("disconnected")
+					logger.Debugf("disconnected, %p", socket)
 				}
 				// Try to tell the other end we are closing. If the other end
 				// has already disconnected from us, this will fail, but we don't
@@ -283,6 +316,11 @@ func (h *logSinkHandler) receiveLogs(socket *websocket.Conn) <-chan params.LogRe
 			case <-h.ctxt.stop():
 				return
 			case logCh <- m:
+				// If the remote end does not support ping/pong, we bump
+				// the read deadline everytime a message is recieved.
+				if endpointVersion == 0 {
+					socket.SetReadDeadline(time.Now().Add(vZeroDelay))
+				}
 			}
 		}
 	}()


### PR DESCRIPTION
## Description of change

Adding ping/pong websocket control messages to the logsink and pubsub API server endpoints.
Previously when a model was destroyed it was possible for the logsink endpoint not to notice. This change adds the ping/pong contorl messages supported in the underlying websocket protocol for this purpose.

## QA steps

This was hard to reproduce on the LXD provider due to the fact that they all share the same kernel and the OS is obviously cleaning some things up in a much nicer manner than using remote providers. However using iptables we are able to simulate a machine going away.

bootstrap lxd
deploy ubuntu
ssh into the ubuntu/0 machine

Run:
sudo iptables -I OUTPUT -p tcp --dport 17070 -j DROP
sudo iptables -I INPUT -p tcp --sport 17070 -j DROP

wait until the machine is shown as missing on status, then run

sudo iptables -D INPUT -p tcp --sport 17070 -j DROP
sudo iptables -D OUTPUT -p tcp --dport 17070 -j DROP

to reestablish connection.

Then destroy the model.
On the apiserver, run juju-statepool-report, and there should be no models.

## Documentation changes

If there are models from 2.1.x or ealier in the 2.2 controller, the remote endpoint that the log sender worker is talking to will time out after six hours of inactivity. This may mean some additional errors showing up in the 2.1 model's logs for the "logsender". The 2.1 agent will reconnect to send the logs. The remote timeout is necessary due to the older agents not responding to the ping websocket control messages, and in order to not have the 2.2 controller leak under certain circumstances it is better to have the occasional error recorded against older models. There is no loss of log messages.

## Bug reference

http://pad.lv/1649719
http://pad.lv/1581069
