### PR TITLE
cmd/juju/user: refactor login command

### DIFF
--- a/cmd/juju/user/add_test.go
+++ b/cmd/juju/user/add_test.go
@@ -88,7 +88,7 @@ func (s *UserAddCommandSuite) TestAddUserWithUsername(c *gc.C) {
 	expected := `
 User "foobar" added
 Please send this command to foobar:
-    juju register MEYTBmZvb2JhcjAREw8xMjcuMC4wLjE6MTIzNDUEIFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYEwd0ZXN0aW5n
+    juju register MEQTBmZvb2JhcjAPEw0wLjEuMi4zOjEyMzQ1BCBYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWBMHdGVzdGluZwAA
 
 "foobar" has not been granted access to any models. You can use "juju grant" to grant access.
 `[1:]
@@ -104,7 +104,7 @@ func (s *UserAddCommandSuite) TestAddUserWithUsernameAndDisplayname(c *gc.C) {
 	expected := `
 User "Foo Bar (foobar)" added
 Please send this command to foobar:
-    juju register MEYTBmZvb2JhcjAREw8xMjcuMC4wLjE6MTIzNDUEIFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYEwd0ZXN0aW5n
+    juju register MEQTBmZvb2JhcjAPEw0wLjEuMi4zOjEyMzQ1BCBYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWBMHdGVzdGluZwAA
 
 "Foo Bar (foobar)" has not been granted access to any models. You can use "juju grant" to grant access.
 `[1:]

--- a/cmd/juju/user/user_test.go
+++ b/cmd/juju/user/user_test.go
@@ -23,7 +23,7 @@ func (s *BaseSuite) SetUpTest(c *gc.C) {
 	s.store = jujuclienttesting.NewMemStore()
 	s.store.CurrentControllerName = "testing"
 	s.store.Controllers["testing"] = jujuclient.ControllerDetails{
-		APIEndpoints:   []string{"127.0.0.1:12345"},
+		APIEndpoints:   []string{"0.1.2.3:12345"},
 		CACert:         testing.CACert,
 		ControllerUUID: testing.ControllerTag.Id(),
 	}

--- a/featuretests/cmd_juju_login_test.go
+++ b/featuretests/cmd_juju_login_test.go
@@ -60,11 +60,13 @@ func (s *cmdLoginSuite) TestLoginCommand(c *gc.C) {
 	s.changeUserPassword(c, "admin", "hunter2")
 	s.run(c, nil, "logout")
 
-	context := s.run(c, strings.NewReader("hunter2\nhunter2\n"), "login", "test", "-u")
+	context := s.run(c, strings.NewReader("hunter2\nhunter2\n"), "login", "-u", "test")
 	c.Assert(testing.Stdout(context), gc.Equals, "")
 	c.Assert(testing.Stderr(context), gc.Equals, `
 please enter password for test on kontroll: 
-You are now logged in to "kontroll" as "test".
+Welcome, test. You are now logged into "kontroll".
+
+Current model set to "admin/controller".
 `[1:])
 
 	// We should have a macaroon, but no password, in the client store.

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -195,8 +195,10 @@ func (s *StateSuite) TestModelUUID(c *gc.C) {
 }
 
 func (s *StateSuite) TestNoModelDocs(c *gc.C) {
+	// For example:
+	// found documents for model with uuid 7bfe98b6-7282-48d4-8e37-9b90fb3da4f1: 1 constraints doc, 1 modelusers doc, 1 settings doc, 1 statuses doc
 	c.Assert(s.State.EnsureModelRemoved(), gc.ErrorMatches,
-		fmt.Sprintf(`found documents for model with uuid %s: \d+ constraints doc, \d+ leases doc, \d+ modelusers doc, \d+ settings doc, \d+ statuses doc`, s.State.ModelUUID()))
+		fmt.Sprintf(`found documents for model with uuid %s: (\d+ [a-z]+ doc, )*\d+ [a-z]+ doc`, s.State.ModelUUID()))
 }
 
 func (s *StateSuite) TestMongoSession(c *gc.C) {


### PR DESCRIPTION
We integrate the two kinds of login, so local user login
is orthogonal to whether you're logging into a public controller.

Logging into a controller is now idempotent - no message
will be printed unless the account or controller have changed.

The -u (--user) flag now takes the username as its argument,
so the argument to juju login is always now the controller domain.

Also add a few tests for existing untested behaviour and integrate
the two login test suites (but left them in two separate files for now
so that the diff looks better).

To QA, try "juju login" with as many different combinations as possible.
