### PR TITLE
add-model region selection

### DIFF
--- a/cmd/juju/controller/addmodel.go
+++ b/cmd/juju/controller/addmodel.go
@@ -333,9 +333,6 @@ func (c *addModelCommand) getCloudRegion(cloudClient CloudAPI) (cloudTag names.C
 			}
 			return names.CloudTag{}, jujucloud.Cloud{}, "", errors.Trace(err)
 		}
-	} else if len(cloud.Regions) > 0 {
-		// The first region in the list is the default.
-		cloudRegion = cloud.Regions[0].Name
 	}
 	return cloudTag, cloud, cloudRegion, nil
 }

--- a/cmd/juju/controller/addmodel_test.go
+++ b/cmd/juju/controller/addmodel_test.go
@@ -365,12 +365,12 @@ lxd
 	})
 }
 
-func (s *AddModelSuite) TestCloudDefaultRegionPassedThrough(c *gc.C) {
+func (s *AddModelSuite) TestCloudUnspecifiedRegionPassedThrough(c *gc.C) {
 	_, err := s.run(c, "test", "aws")
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Assert(s.fakeAddModelAPI.cloudName, gc.Equals, "aws")
-	c.Assert(s.fakeAddModelAPI.cloudRegion, gc.Equals, "us-east-1")
+	c.Assert(s.fakeAddModelAPI.cloudRegion, gc.Equals, "")
 }
 
 func (s *AddModelSuite) TestInvalidCloudOrRegionName(c *gc.C) {


### PR DESCRIPTION
## Please provide the following details to expedite Pull Request review:

----

What is this change?

This stops the juju client add-model command from arbitrarily picking the first region that's supported when the user doesn't specify one.

Why is this change needed?

Because the client has very little information about where a sensible place to put the new model is, and generally chooses one that's a long way from where the controllers are.

## QA steps

How do we verify that the change works?

1. Register the JAAS controller in a local juju environment.
```
juju register jimm.jujucharms.com:443
```

2. Add a model to that controller specifying the cloud, but not the region.
```
juju add-model test-region aws
```

3. Use `juju models` to see where your new model is. It should either be in us-east-1 or eu-west-1 as this is where we currently run JAAS controllers and JIMM attempts to put the model in the same region as the controller.

4. Bootstrap a new controller in the cloud and region of your choice, repeat steps 2 & 3 above this time the new model should be created 

## Documentation changes

Does it affect current user workflow? CLI? API?

No documentation changes are required

## Bug reference

Does this change fix a bug? Please add a link to it.
No
