### PR TITLE
Add a new hook context env variable, JUJU_PRINCIPAL_UNIT

### DIFF
--- a/api/uniter/unit.go
+++ b/api/uniter/unit.go
@@ -304,29 +304,30 @@ func (u *Unit) AssignedMachine() (names.MachineTag, error) {
 	return names.ParseMachineTag(result.Result)
 }
 
-// IsPrincipal returns whether the unit is deployed in its own container,
-// and can therefore have subordinate services deployed alongside it.
+// PrincipalUnit returns whether the the principal unit name as well
+// as whether the current unit is principal, and can therefore have
+// subordinate services deployed alongside it.
 //
 // NOTE: This differs from state.Unit.IsPrincipal() by returning an
 // error as well, because it needs to make an API call.
-func (u *Unit) IsPrincipal() (bool, error) {
+func (u *Unit) PrincipalUnit() (bool, string, error) {
 	var results params.StringBoolResults
 	args := params.Entities{
 		Entities: []params.Entity{{Tag: u.tag.String()}},
 	}
 	err := u.st.facade.FacadeCall("GetPrincipal", args, &results)
 	if err != nil {
-		return false, err
+		return false, "", err
 	}
 	if len(results.Results) != 1 {
-		return false, fmt.Errorf("expected 1 result, got %d", len(results.Results))
+		return false, "", fmt.Errorf("expected 1 result, got %d", len(results.Results))
 	}
 	result := results.Results[0]
 	if result.Error != nil {
-		return false, result.Error
+		return false, "", result.Error
 	}
 	// GetPrincipal returns false when the unit is subordinate.
-	return !result.Ok, nil
+	return !result.Ok, result.Result, nil
 }
 
 // HasSubordinates returns the tags of any subordinate units.

--- a/api/uniter/unit_test.go
+++ b/api/uniter/unit_test.go
@@ -261,10 +261,11 @@ func (s *unitSuite) TestAssignedMachine(c *gc.C) {
 	c.Assert(machineTag, gc.Equals, s.wordpressMachine.Tag())
 }
 
-func (s *unitSuite) TestIsPrincipal(c *gc.C) {
-	ok, err := s.apiUnit.IsPrincipal()
+func (s *unitSuite) TestPrincipalUnit(c *gc.C) {
+	ok, unitName, err := s.apiUnit.PrincipalUnit()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(ok, jc.IsTrue)
+	c.Assert(unitName, gc.Equals, s.apiUnit.Name())
 }
 
 func (s *unitSuite) TestHasSubordinates(c *gc.C) {

--- a/apiserver/uniter/uniter_test.go
+++ b/apiserver/uniter/uniter_test.go
@@ -591,7 +591,7 @@ func (s *uniterSuite) TestGetPrincipal(c *gc.C) {
 	c.Assert(result, gc.DeepEquals, params.StringBoolResults{
 		Results: []params.StringBoolResult{
 			{Error: apiservertesting.ErrUnauthorized},
-			{Result: "", Ok: false, Error: nil},
+			{Result: "wordpress/0", Ok: false, Error: nil},
 			{Error: apiservertesting.ErrUnauthorized},
 			{Error: apiservertesting.ErrUnauthorized},
 		},

--- a/doc/charms-in-action.txt
+++ b/doc/charms-in-action.txt
@@ -105,6 +105,7 @@ following characteristics:
     with: the command line tools won't work without them).
   * $JUJU_API_ADDRESSES holds a space separated list of juju API addresses.
   * $JUJU_MODEL_NAME holds the human friendly name of the current model.
+  * $JUJU_PRINCIPAL_UNIT holds the name of the principal unit.
 
 Hook tools
 ----------

--- a/worker/uniter/relation/relations.go
+++ b/worker/uniter/relation/relations.go
@@ -407,7 +407,7 @@ func (r *relations) update(remote map[int]remotestate.RelationSnapshot) error {
 			return errors.Trace(removeErr)
 		}
 	}
-	if ok, err := r.unit.IsPrincipal(); err != nil {
+	if ok, _, err := r.unit.PrincipalUnit(); err != nil {
 		return errors.Trace(err)
 	} else if ok {
 		return nil

--- a/worker/uniter/runner/context/context.go
+++ b/worker/uniter/runner/context/context.go
@@ -106,6 +106,9 @@ type HookContext struct {
 	// LeadershipContext supplies several jujuc.Context methods.
 	LeadershipContext
 
+	// principle is the unitName of the principal charm.
+	principal string
+
 	// privateAddress is the cached value of the unit's private
 	// address.
 	privateAddress string
@@ -384,6 +387,19 @@ func (ctx *HookContext) ResetExecutionSetUnitStatus() {
 	ctx.hasRunStatusSet = false
 }
 
+// PrincipalUnit will return the principal unit name and set the environment
+// variable JUJU_PRINCIPAL_UNIT.
+func (ctx *HookContext) PrincipalUnit() (string, error) {
+	if ctx.principal == "" {
+		_, principal, err := ctx.unit.PrincipalUnit()
+		if err != nil {
+			return "", err
+		}
+		ctx.principal = principal
+	}
+	return ctx.principal, nil
+}
+
 func (ctx *HookContext) PublicAddress() (string, error) {
 	if ctx.publicAddress == "" {
 		return "", errors.NotFoundf("public address")
@@ -580,6 +596,7 @@ func (context *HookContext) HookVars(paths Paths) ([]string, error) {
 		"JUJU_METER_STATUS="+context.meterStatus.code,
 		"JUJU_METER_INFO="+context.meterStatus.info,
 		"JUJU_MACHINE_ID="+context.assignedMachineTag.Id(),
+		"JUJU_PRINCIPAL_UNIT="+context.principal,
 		"JUJU_AVAILABILITY_ZONE="+context.availabilityzone,
 	)
 	if r, err := context.HookRelation(); err == nil {

--- a/worker/uniter/runner/context/contextfactory.go
+++ b/worker/uniter/runner/context/contextfactory.go
@@ -291,6 +291,10 @@ func (f *contextFactory) updateContext(ctx *HookContext) (err error) {
 	}
 	ctx.proxySettings = modelConfig.ProxySettings()
 
+	if _, err := ctx.PrincipalUnit(); err != nil {
+		return err
+	}
+
 	// Calling these last, because there's a potential race: they're not guaranteed
 	// to be set in time to be needed for a hook. If they're not, we just leave them
 	// unset as we always have; this isn't great but it's about behaviour preservation.

--- a/worker/uniter/runner/context/env_test.go
+++ b/worker/uniter/runner/context/env_test.go
@@ -65,6 +65,7 @@ func (s *EnvSuite) getContext() (ctx *context.HookContext, expectVars []string) 
 		), []string{
 			"JUJU_CONTEXT_ID=some-context-id",
 			"JUJU_MODEL_UUID=model-uuid-deadbeef",
+			"JUJU_PRINCIPAL_UNIT=",
 			"JUJU_MODEL_NAME=some-model-name",
 			"JUJU_UNIT_NAME=this-unit/123",
 			"JUJU_METER_STATUS=PURPLE",


### PR DESCRIPTION
## Description of change
This change adds a new environment variable to the hook context, JUJU_PRINCIPAL_UNIT. Adding this addresses the bug #1568161 and allows charms with multiple relations to easily determine which unit is the principal.

## QA steps

When running with Juju containing these changes you can run 'juju debug-hook' and review the environment variable, ie:

        $ ./juju debug-hooks nrpe/0 config-changed
        root@juju-0c9ed9-0:/var/lib/juju/agents/unit-nrpe-0/charm# echo $JUJU_PRINCIPAL_UNIT
        manager/0

## Documentation changes

This affects charm authors.

## Bug reference

https://bugs.launchpad.net/juju-core/+bug/1568161
