### PR TITLE
Add a new hook context env variable, JUJU_PRINCIPAL_UNIT

### DIFF
--- a/api/uniter/unit_test.go
+++ b/api/uniter/unit_test.go
@@ -261,10 +261,11 @@ func (s *unitSuite) TestAssignedMachine(c *gc.C) {
 	c.Assert(machineTag, gc.Equals, s.wordpressMachine.Tag())
 }
 
-func (s *unitSuite) TestIsPrincipal(c *gc.C) {
-	ok, err := s.apiUnit.IsPrincipal()
+func (s *unitSuite) TestPrincipalName(c *gc.C) {
+	unitName, ok, err := s.apiUnit.PrincipalName()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(ok, jc.IsTrue)
+	c.Assert(ok, jc.IsFalse)
+	c.Assert(unitName, gc.Equals, "")
 }
 
 func (s *unitSuite) TestHasSubordinates(c *gc.C) {

--- a/doc/charms-in-action.txt
+++ b/doc/charms-in-action.txt
@@ -105,6 +105,7 @@ following characteristics:
     with: the command line tools won't work without them).
   * $JUJU_API_ADDRESSES holds a space separated list of juju API addresses.
   * $JUJU_MODEL_NAME holds the human friendly name of the current model.
+  * $JUJU_PRINCIPAL_UNIT holds the name of the principal unit if the current unit is a subordinate.
 
 Hook tools
 ----------

--- a/worker/uniter/relation/relations.go
+++ b/worker/uniter/relation/relations.go
@@ -407,9 +407,9 @@ func (r *relations) update(remote map[int]remotestate.RelationSnapshot) error {
 			return errors.Trace(removeErr)
 		}
 	}
-	if ok, err := r.unit.IsPrincipal(); err != nil {
+	if _, ok, err := r.unit.PrincipalName(); err != nil {
 		return errors.Trace(err)
-	} else if ok {
+	} else if !ok {
 		return nil
 	}
 	// If no Alive relations remain between a subordinate unit's service

--- a/worker/uniter/runner/context/context.go
+++ b/worker/uniter/runner/context/context.go
@@ -106,6 +106,9 @@ type HookContext struct {
 	// LeadershipContext supplies several jujuc.Context methods.
 	LeadershipContext
 
+	// principal is the unitName of the principal charm.
+	principal string
+
 	// privateAddress is the cached value of the unit's private
 	// address.
 	privateAddress string
@@ -584,6 +587,7 @@ func (context *HookContext) HookVars(paths Paths) ([]string, error) {
 		"JUJU_METER_INFO="+context.meterStatus.info,
 		"JUJU_SLA="+context.slaLevel,
 		"JUJU_MACHINE_ID="+context.assignedMachineTag.Id(),
+		"JUJU_PRINCIPAL_UNIT="+context.principal,
 		"JUJU_AVAILABILITY_ZONE="+context.availabilityzone,
 	)
 	if r, err := context.HookRelation(); err == nil {

--- a/worker/uniter/runner/context/contextfactory.go
+++ b/worker/uniter/runner/context/contextfactory.go
@@ -299,6 +299,14 @@ func (f *contextFactory) updateContext(ctx *HookContext) (err error) {
 	}
 	ctx.proxySettings = modelConfig.ProxySettings()
 
+	principal, ok, err := ctx.unit.PrincipalName()
+	if err != nil {
+		return err
+	}
+	if ok {
+		ctx.principal = principal
+	}
+
 	// Calling these last, because there's a potential race: they're not guaranteed
 	// to be set in time to be needed for a hook. If they're not, we just leave them
 	// unset as we always have; this isn't great but it's about behaviour preservation.

--- a/worker/uniter/runner/context/env_test.go
+++ b/worker/uniter/runner/context/env_test.go
@@ -66,6 +66,7 @@ func (s *EnvSuite) getContext() (ctx *context.HookContext, expectVars []string) 
 		), []string{
 			"JUJU_CONTEXT_ID=some-context-id",
 			"JUJU_MODEL_UUID=model-uuid-deadbeef",
+			"JUJU_PRINCIPAL_UNIT=this-unit/123",
 			"JUJU_MODEL_NAME=some-model-name",
 			"JUJU_UNIT_NAME=this-unit/123",
 			"JUJU_METER_STATUS=PURPLE",

--- a/worker/uniter/runner/context/export_test.go
+++ b/worker/uniter/runner/context/export_test.go
@@ -158,6 +158,7 @@ func NewModelHookContext(
 		assignedMachineTag: machineTag,
 		availabilityzone:   availZone,
 		slaLevel:           slaLevel,
+		principal:          unitName,
 	}
 }
 


### PR DESCRIPTION
## Description of change
This change adds a new environment variable to the hook context, JUJU_PRINCIPAL_UNIT. Adding this addresses the bug #1568161 and allows charms with multiple relations to easily determine which unit is the principal.

## QA steps

When running with Juju containing these changes you can run 'juju debug-hook' and review the environment variable, ie:

        $ ./juju debug-hooks nrpe/0 config-changed
        root@juju-0c9ed9-0:/var/lib/juju/agents/unit-nrpe-0/charm# echo $JUJU_PRINCIPAL_UNIT
        manager/0

## Documentation changes

This affects charm authors.

## Bug reference

https://bugs.launchpad.net/juju-core/+bug/1568161
