### PR TITLE
Tweak output of cmr list and find, better find query support

### DIFF
--- a/api/remoteendpoints/client.go
+++ b/api/remoteendpoints/client.go
@@ -64,6 +64,7 @@ func (c *Client) FindApplicationOffers(filters ...crossmodel.ApplicationOfferFil
 		filterTerm := params.OfferFilter{
 			OfferName: f.OfferName,
 			ModelName: f.ModelName,
+			OwnerName: f.OwnerName,
 		}
 		filterTerm.Endpoints = make([]params.EndpointFilterAttributes, len(f.Endpoints))
 		for i, ep := range f.Endpoints {

--- a/api/remoteendpoints/client_test.go
+++ b/api/remoteendpoints/client_test.go
@@ -211,11 +211,15 @@ func (s *crossmodelMockSuite) TestShowFacadeCallError(c *gc.C) {
 
 func (s *crossmodelMockSuite) TestFind(c *gc.C) {
 	offerName := "hosted-db2"
+	ownerName := "owner"
+	modelName := "model"
 	url := fmt.Sprintf("fred/model.%s", offerName)
 	endpoints := []params.RemoteEndpoint{{Name: "endPointA"}}
 	relations := []jujucrossmodel.EndpointFilterTerm{{Name: "endPointA", Interface: "http"}}
 
 	filter := jujucrossmodel.ApplicationOfferFilter{
+		OwnerName: ownerName,
+		ModelName: modelName,
 		OfferName: offerName,
 		Endpoints: relations,
 	}
@@ -236,6 +240,8 @@ func (s *crossmodelMockSuite) TestFind(c *gc.C) {
 			c.Assert(ok, jc.IsTrue)
 			c.Assert(args.Filters, gc.HasLen, 1)
 			c.Assert(args.Filters[0], jc.DeepEquals, params.OfferFilter{
+				OwnerName:       filter.OwnerName,
+				ModelName:       filter.ModelName,
 				OfferName:       filter.OfferName,
 				ApplicationName: filter.ApplicationName,
 				Endpoints: []params.EndpointFilterAttributes{{

--- a/apiserver/common/crossmodelcommon/crossmodel.go
+++ b/apiserver/common/crossmodelcommon/crossmodel.go
@@ -37,10 +37,10 @@ func (api *BaseAPI) CheckPermission(backend Backend, perm permission.Access) err
 }
 
 // ModelForName looks up the model details for the named model.
-func (api *BaseAPI) ModelForName(modelName, userName string) (Model, bool, error) {
+func (api *BaseAPI) ModelForName(modelName, ownerName string) (Model, bool, error) {
 	user := api.Authorizer.GetAuthTag().(names.UserTag)
-	if userName != "" {
-		user = names.NewUserTag(userName)
+	if ownerName == "" {
+		ownerName = user.Name()
 	}
 	var model Model
 	models, err := api.Backend.ModelsForUser(user)
@@ -48,7 +48,7 @@ func (api *BaseAPI) ModelForName(modelName, userName string) (Model, bool, error
 		return nil, false, err
 	}
 	for _, m := range models {
-		if m.Model().Name() == modelName {
+		if m.Model().Name() == modelName && m.Model().Owner().Name() == ownerName {
 			model = m.Model()
 			break
 		}
@@ -148,7 +148,7 @@ func (api *BaseAPI) getModelFilters(filters params.OfferFilters) (
 		if f.ModelName != "" {
 			if modelUUID, ok = modelUUIDs[f.ModelName]; !ok {
 				var err error
-				model, ok, err := api.ModelForName(f.ModelName, "")
+				model, ok, err := api.ModelForName(f.ModelName, f.OwnerName)
 				if err != nil {
 					return nil, nil, errors.Trace(err)
 				}

--- a/apiserver/params/crossmodel.go
+++ b/apiserver/params/crossmodel.go
@@ -23,7 +23,12 @@ type OfferFilters struct {
 
 // OfferFilter is used to query offers.
 type OfferFilter struct {
-	ModelName              string                     `json:"model-name"`
+	// OwnerName is the owner of the model hosting the offer.
+	OwnerName string `json:"owner-name"`
+
+	// ModelName is the name of the model hosting the offer.
+	ModelName string `json:"model-name"`
+
 	OfferName              string                     `json:"offer-name"`
 	ApplicationName        string                     `json:"application-name"`
 	ApplicationDescription string                     `json:"application-description"`

--- a/cmd/juju/application/addrelation.go
+++ b/cmd/juju/application/addrelation.go
@@ -117,9 +117,6 @@ func (c *addRelationCommand) Run(ctx *cmd.Context) error {
 	if params.IsCodeUnauthorized(err) {
 		common.PermissionsMessage(ctx.Stderr, "add a relation")
 	}
-	if err == nil && c.remoteEndpoint != "" {
-		ctx.Infof("Note: this beta version of Juju has automatically exposed the endpoint at %s to enable cross model communications", c.remoteEndpoint)
-	}
 	return block.ProcessBlockedError(err, block.BlockChange)
 }
 

--- a/cmd/juju/crossmodel/find_test.go
+++ b/cmd/juju/crossmodel/find_test.go
@@ -40,9 +40,16 @@ func (s *findSuite) runFind(c *gc.C, args ...string) (*cmd.Context, error) {
 
 func (s *findSuite) TestFindNoArgs(c *gc.C) {
 	s.mockAPI.c = c
-	s.mockAPI.expectedFilter = &jujucrossmodel.ApplicationOfferFilter{ModelName: "test"}
-	s.mockAPI.expectedModelName = "model"
-	s.assertFindError(c, []string{}, "at least one filter term must be specified, try specifying a model name")
+	s.mockAPI.expectedFilter = &jujucrossmodel.ApplicationOfferFilter{}
+	s.assertFind(
+		c,
+		[]string{},
+		`
+URL                   Interfaces
+fred/test.hosted-db2  http:db2, http:log
+
+`[1:],
+	)
 }
 
 func (s *findSuite) TestFindDuplicateUrl(c *gc.C) {
@@ -57,6 +64,7 @@ func (s *findSuite) TestNoResults(c *gc.C) {
 	s.mockAPI.c = c
 	s.mockAPI.expectedModelName = "none"
 	s.mockAPI.expectedFilter = &jujucrossmodel.ApplicationOfferFilter{
+		OwnerName: "bob",
 		ModelName: "none",
 	}
 	s.mockAPI.results = []params.ApplicationOffer{}
@@ -72,6 +80,7 @@ func (s *findSuite) TestSimpleFilter(c *gc.C) {
 	s.mockAPI.expectedModelName = "model"
 	s.mockAPI.expectedFilter = &jujucrossmodel.ApplicationOfferFilter{
 		OfferName: "hosted-db2",
+		OwnerName: "fred",
 		ModelName: "model",
 	}
 	s.mockAPI.expectedModelName = "model"
@@ -89,6 +98,7 @@ fred/model.hosted-db2  http:db2, http:log
 func (s *findSuite) TestEndpointFilter(c *gc.C) {
 	s.mockAPI.c = c
 	s.mockAPI.expectedFilter = &jujucrossmodel.ApplicationOfferFilter{
+		OwnerName: "fred",
 		ModelName: "model",
 		Endpoints: []jujucrossmodel.EndpointFilterTerm{{
 			Interface: "mysql",

--- a/cmd/juju/crossmodel/list_test.go
+++ b/cmd/juju/crossmodel/list_test.go
@@ -66,7 +66,7 @@ func (s *ListSuite) TestListFormatError(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, ".*failed to format.*")
 }
 
-func (s *ListSuite) TestListDirectories(c *gc.C) {
+func (s *ListSuite) TestList(c *gc.C) {
 	// Insert in random order to check sorting.
 	s.applications = append(s.applications, model.ApplicationOfferDetailsResult{Result: s.createOfferItem("zdiff-db2", "differentstore", 33)})
 	s.applications = append(s.applications, model.ApplicationOfferDetailsResult{Result: s.createOfferItem("adiff-db2", "vendor", 23)})
@@ -76,18 +76,13 @@ func (s *ListSuite) TestListDirectories(c *gc.C) {
 		nil,
 		// Default format is tabular
 		`
-differentstore
-Application  Charm  Connected  Store           URL                                  Endpoint  Interface  Role
-zdiff-db2    db2    33         differentstore  differentstore:fred/model.zdiff-db2  log       http       provider
-                                                                                    mysql     db2        requirer
-myctrl
-Application  Charm  Connected  Store   URL                           Endpoint  Interface  Role
-hosted-db2   db2    0          myctrl  myctrl:fred/model.hosted-db2  log       http       provider
-                                                                     mysql     db2        requirer
-vendor
-Application  Charm  Connected  Store   URL                          Endpoint  Interface  Role
-adiff-db2    db2    23         vendor  vendor:fred/model.adiff-db2  log       http       provider
-                                                                    mysql     db2        requirer
+Application     Charm  Connected  Store           URL                                  Endpoint  Interface  Role
+app-zdiff-db2   db2    33         differentstore  differentstore:fred/model.zdiff-db2  log       http       provider
+                                                                                       mysql     db2        requirer
+app-hosted-db2  db2    0          myctrl          myctrl:fred/model.hosted-db2         log       http       provider
+                                                                                       mysql     db2        requirer
+app-adiff-db2   db2    23         vendor          vendor:fred/model.adiff-db2          log       http       provider
+                                                                                       mysql     db2        requirer
 
 `[1:],
 		"",
@@ -102,10 +97,9 @@ func (s *ListSuite) TestListWithErrors(c *gc.C) {
 		c,
 		nil,
 		`
-myctrl
-Application  Charm  Connected  Store   URL                           Endpoint  Interface  Role
-hosted-db2   db2    0          myctrl  myctrl:fred/model.hosted-db2  log       http       provider
-                                                                     mysql     db2        requirer
+Application     Charm  Connected  Store   URL                           Endpoint  Interface  Role
+app-hosted-db2  db2    0          myctrl  myctrl:fred/model.hosted-db2  log       http       provider
+                                                                        mysql     db2        requirer
 
 `[1:],
 		msg,
@@ -121,14 +115,14 @@ func (s *ListSuite) TestListYAML(c *gc.C) {
 		c,
 		[]string{"--format", "yaml"},
 		`
-myctrl:
-  hosted-db2:
-    charm: db2
-    url: myctrl:fred/model.hosted-db2
-    endpoints:
-      mysql:
-        interface: db2
-        role: requirer
+hosted-db2:
+  store: myctrl
+  charm: db2
+  url: myctrl:fred/model.hosted-db2
+  endpoints:
+    mysql:
+      interface: db2
+      role: requirer
 `[1:],
 		"",
 	)
@@ -136,11 +130,12 @@ myctrl:
 
 func (s *ListSuite) createOfferItem(name, store string, count int) *model.ApplicationOfferDetails {
 	return &model.ApplicationOfferDetails{
-		OfferName:      name,
-		OfferURL:       fmt.Sprintf("%s:%s.%s", store, "fred/model", name),
-		CharmName:      "db2",
-		Endpoints:      s.endpoints,
-		ConnectedCount: count,
+		ApplicationName: "app-" + name,
+		OfferName:       name,
+		OfferURL:        fmt.Sprintf("%s:%s.%s", store, "fred/model", name),
+		CharmName:       "db2",
+		Endpoints:       s.endpoints,
+		ConnectedCount:  count,
 	}
 }
 

--- a/cmd/juju/crossmodel/listformatter.go
+++ b/cmd/juju/crossmodel/listformatter.go
@@ -13,66 +13,62 @@ import (
 	"github.com/juju/juju/cmd/output"
 )
 
-// formatListTabular returns a tabular summary of remote applications or
+// formatListTabular returns a tabular summary of remote application offers or
 // errors out if parameter is not of expected type.
 func formatListTabular(writer io.Writer, value interface{}) error {
-	endpoints, ok := value.(map[string]directoryApplications)
+	offers, ok := value.(offeredApplications)
 	if !ok {
-		return errors.Errorf("expected value of type %T, got %T", endpoints, value)
+		return errors.Errorf("expected value of type %T, got %T", offers, value)
 	}
-	return formatListEndpointsTabular(writer, endpoints)
+	return formatListEndpointsTabular(writer, offers)
 }
 
+type offerItems []ListOfferItem
+
 // formatListEndpointsTabular returns a tabular summary of listed applications' endpoints.
-func formatListEndpointsTabular(writer io.Writer, all map[string]directoryApplications) error {
+func formatListEndpointsTabular(writer io.Writer, offers offeredApplications) error {
 	tw := output.TabWriter(writer)
 	w := output.Wrapper{tw}
 
-	// Ensure directories are sorted alphabetically.
-	directories := []string{}
-	for name, _ := range all {
-		directories = append(directories, name)
+	// Sort offers by source then application name.
+	allOffers := offerItems{}
+	for _, offer := range offers {
+		allOffers = append(allOffers, offer)
 	}
-	sort.Strings(directories)
+	sort.Sort(allOffers)
 
-	for _, directory := range directories {
-		w.Println(directory)
-		w.Println("Application", "Charm", "Connected", "Store", "URL", "Endpoint", "Interface", "Role")
-
-		// Sort application names alphabetically.
-		applications := all[directory]
-		applicationNames := []string{}
-		for name, _ := range applications {
-			applicationNames = append(applicationNames, name)
+	w.Println("Application", "Charm", "Connected", "Store", "URL", "Endpoint", "Interface", "Role")
+	for _, offer := range allOffers {
+		// Sort endpoints alphabetically.
+		endpoints := []string{}
+		for endpoint, _ := range offer.Endpoints {
+			endpoints = append(endpoints, endpoint)
 		}
-		sort.Strings(applicationNames)
+		sort.Strings(endpoints)
 
-		for _, name := range applicationNames {
-			application := applications[name]
+		for i, endpointName := range endpoints {
 
-			// Sort endpoints alphabetically.
-			endpoints := []string{}
-			for endpoint, _ := range application.Endpoints {
-				endpoints = append(endpoints, endpoint)
+			endpoint := offer.Endpoints[endpointName]
+			if i == 0 {
+				// As there is some information about offer and its endpoints,
+				// only display offer information once when the first endpoint is displayed.
+				w.Println(offer.ApplicationName, offer.CharmName, fmt.Sprint(offer.UsersCount), offer.Source, offer.Location, endpointName, endpoint.Interface, endpoint.Role)
+				continue
 			}
-			sort.Strings(endpoints)
-
-			for i, endpointName := range endpoints {
-
-				endpoint := application.Endpoints[endpointName]
-				if i == 0 {
-					// As there is some information about application and its endpoints,
-					// only display application information once
-					// when the first endpoint is  displayed.
-					w.Println(name, application.CharmName, fmt.Sprint(application.UsersCount), directory, application.Location, endpointName, endpoint.Interface, endpoint.Role)
-					continue
-				}
-				// Subsequent lines only need to display endpoint information.
-				// This will display less noise.
-				w.Println("", "", "", "", "", endpointName, endpoint.Interface, endpoint.Role)
-			}
+			// Subsequent lines only need to display endpoint information.
+			// This will display less noise.
+			w.Println("", "", "", "", "", endpointName, endpoint.Interface, endpoint.Role)
 		}
 	}
 	tw.Flush()
 	return nil
+}
+
+func (o offerItems) Len() int      { return len(o) }
+func (o offerItems) Swap(i, j int) { o[i], o[j] = o[j], o[i] }
+func (o offerItems) Less(i, j int) bool {
+	if o[i].Source == o[j].Source {
+		return o[i].ApplicationName < o[j].ApplicationName
+	}
+	return o[i].Source < o[j].Source
 }

--- a/core/crossmodel/interface.go
+++ b/core/crossmodel/interface.go
@@ -54,7 +54,10 @@ func (s *ApplicationOffer) String() string {
 // ApplicationOfferFilter is used to query applications offered
 // by this model.
 type ApplicationOfferFilter struct {
-	// OfferName is the name of the model hosting the offer.
+	// OwnerName is the owner of the model hosting the offer.
+	OwnerName string
+
+	// ModelName is the name of the model hosting the offer.
 	ModelName string
 
 	// OfferName is the name of the offer.


### PR DESCRIPTION
## Description of change

The output of the cmr list and find commands is tweaked for readability.
Also, the find endpoints api is fixed so that it requires the model owner to be specified, as distinct from the user making the query. It also supports queries across all models on a controller, so long as only one filter term is specified.

## QA steps

bootstrap
create offers
run show-endpoints, find-endpoints, list-offers
