### PR TITLE
Configure basic log writer on program start and otherwise fix incosistent error handling.

### DIFF
--- a/cmd/juju/commands/main_test.go
+++ b/cmd/juju/commands/main_test.go
@@ -144,9 +144,9 @@ func (s *MainSuite) TestActualRunJujuArgOrder(c *gc.C) {
 	s.PatchEnvironment(osenv.JujuModelEnvKey, "current")
 	logpath := filepath.Join(c.MkDir(), "log")
 	tests := [][]string{
-		{"--log-file", logpath, "--debug", "controllers"}, // global flags before
-		{"controllers", "--log-file", logpath, "--debug"}, // after
-		{"--log-file", logpath, "controllers", "--debug"}, // mixed
+		{"--log-file", logpath, "--debug", "help"}, // global flags before
+		{"help", "--log-file", logpath, "--debug"}, // after
+		{"--log-file", logpath, "help", "--debug"}, // mixed
 	}
 	for i, test := range tests {
 		c.Logf("test %d: %v", i, test)

--- a/cmd/juju/controller/listcontrollers.go
+++ b/cmd/juju/controller/listcontrollers.go
@@ -83,8 +83,7 @@ func (c *listControllersCommand) Run(ctx *cmd.Context) error {
 		return errors.Annotate(err, "failed to list controllers")
 	}
 	if len(controllers) == 0 && c.out.Name() == "tabular" {
-		ctx.Infof("%s", modelcmd.ErrNoControllersDefined)
-		return nil
+		return errors.Trace(modelcmd.ErrNoControllersDefined)
 	}
 	if c.refresh && len(controllers) > 0 {
 		var wg sync.WaitGroup

--- a/cmd/juju/main.go
+++ b/cmd/juju/main.go
@@ -6,6 +6,7 @@ package main
 import (
 	"os"
 
+	"github.com/juju/cmd"
 	"github.com/juju/loggo"
 
 	"github.com/juju/juju/cmd/juju/commands"
@@ -24,5 +25,9 @@ func init() {
 }
 
 func main() {
+	_, err := loggo.ReplaceDefaultWriter(cmd.NewWarningWriter(os.Stderr))
+	if err != nil {
+		panic(err)
+	}
 	os.Exit(commands.Main(os.Args))
 }


### PR DESCRIPTION
## Description of change

This PR is intended to make error messages more consistent. It does so in two ways:

- It sets a standard logging configuration at program start
- Errors listing controllers were being reported at the `INFO` level and the program exited with a success status code. Since this behavior differs from how other errors are handled it has been corrected.

## QA steps

In general, any command that is run that results in an error should be displayed in the following format:

`ERROR <specific error message>`

That is, the error message should be preceded by the word "ERROR" in all capitals as show above. Also, all errors should cause the command to exit with an appropriate error exit code.

### Specific QA examples: 

#### consistent error messaging fixes

run the command:

`juju-2.0 add-credential`

You should see the following output:

`ERROR Usage: juju add-credential <cloud-name> [-f <credentials.yaml>]`

#### consistent exit code fix

run the command:

`juju-2.0 controllers`

You should see the following output:

```
ERROR No controllers registered.

Please either create a new controller using "juju bootstrap" or connect to
another controller that you have been given access to using "juju register".
```

run the command:

`echo $?`

You should se the following output:

`1`

This signifies that the the command failed because there are no registered controllers and thus the command exits with a failure exit code. (Before this PR it exited signifying success)

Please see the launch pad bug that is referenced below for more cases. 

## Documentation changes

N/A

## Bug reference

[lp#1631476](https://bugs.launchpad.net/juju/+bug/1631476)

