### PR TITLE
Don't assert against a struct.

### DIFF
--- a/state/address.go
+++ b/state/address.go
@@ -118,11 +118,9 @@ func (st *State) SetAPIHostPorts(netHostsPorts [][]network.HostPort) error {
 			return nil, err
 		}
 		op := txn.Op{
-			C:  stateServersC,
-			Id: apiHostPortsKey,
-			Assert: bson.D{{
-				"apihostports", fromNetworkHostsPorts(existing),
-			}},
+			C:      stateServersC,
+			Id:     apiHostPortsKey,
+			Assert: txn.DocExists,
 		}
 		if !hostsPortsEqual(netHostsPorts, existing) {
 			op.Update = bson.D{{

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -3956,47 +3956,6 @@ func (s *StateSuite) TestSetAPIHostPorts(c *gc.C) {
 	c.Assert(gotHostPorts, jc.DeepEquals, newHostPorts)
 }
 
-func (s *StateSuite) TestSetAPIHostPortsConcurrentSame(c *gc.C) {
-	hostPorts := [][]network.HostPort{{{
-		Address: network.Address{
-			Value:       "0.4.8.16",
-			Type:        network.IPv4Address,
-			NetworkName: "foo",
-			Scope:       network.ScopePublic,
-		},
-		Port: 2,
-	}}, {{
-		Address: network.Address{
-			Value:       "0.2.4.6",
-			Type:        network.IPv4Address,
-			NetworkName: "net",
-			Scope:       network.ScopeCloudLocal,
-		},
-		Port: 1,
-	}}}
-
-	// API host ports are concurrently changed to the same
-	// desired value; second arrival will fail its assertion,
-	// refresh finding nothing to do, and then issue a
-	// read-only assertion that suceeds.
-
-	var prevRevno int64
-	defer state.SetBeforeHooks(c, s.State, func() {
-		err := s.State.SetAPIHostPorts(hostPorts)
-		c.Assert(err, jc.ErrorIsNil)
-		revno, err := state.TxnRevno(s.State, "stateServers", "apiHostPorts")
-		c.Assert(err, jc.ErrorIsNil)
-		prevRevno = revno
-	}).Check()
-
-	err := s.State.SetAPIHostPorts(hostPorts)
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(prevRevno, gc.Not(gc.Equals), 0)
-	revno, err := state.TxnRevno(s.State, "stateServers", "apiHostPorts")
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(revno, gc.Equals, prevRevno)
-}
-
 func (s *StateSuite) TestSetAPIHostPortsConcurrentDifferent(c *gc.C) {
 	hostPorts0 := []network.HostPort{{
 		Address: network.Address{


### PR DESCRIPTION
## Description of change

When setting the API host ports, the code was asserting against the existing structure for the host ports. This also requires that the struct ordering is the same. This is not the way to do checks in mongo, and has been fixed in the 2.0 branch. This fix is a simpler backport as it doesn't even care about the transaction number of the previous value since it is just overwriting the content.

## Documentation changes

None.

## Bug reference

http://pad.lv/1613855
