### PR TITLE
Revert allocation deletion on model destroy

### DIFF
--- a/cmd/juju/model/destroy_test.go
+++ b/cmd/juju/model/destroy_test.go
@@ -198,19 +198,24 @@ func (s *DestroySuite) TestDestroyWithSupportedSLA(c *gc.C) {
 	s.configAPI.slaLevel = "standard"
 	_, err := s.runDestroyCommand(c, "test2", "-y")
 	c.Assert(err, jc.ErrorIsNil)
-	s.stub.CheckCalls(c, []jutesting.StubCall{{
-		"DeleteAllocation", []interface{}{"test2-uuid"},
-	}})
+	// TODO(cmars): fix DeleteAllocation on model destroy
+	//s.stub.CheckCalls(c, []jutesting.StubCall{{
+	//	"DeleteAllocation", []interface{}{"test2-uuid"},
+	//}})
+	s.stub.CheckNoCalls(c)
 }
 
 func (s *DestroySuite) TestDestroyWithSupportedSLAFailure(c *gc.C) {
 	s.configAPI.slaLevel = "standard"
 	s.stub.SetErrors(errors.New("bah"))
 	_, err := s.runDestroyCommand(c, "test2", "-y")
-	c.Assert(err, gc.ErrorMatches, `bah`)
-	s.stub.CheckCalls(c, []jutesting.StubCall{{
-		"DeleteAllocation", []interface{}{"test2-uuid"},
-	}})
+	// TODO(cmars): fix DeleteAllocation on model destroy
+	//c.Assert(err, gc.ErrorMatches, `bah`)
+	//s.stub.CheckCalls(c, []jutesting.StubCall{{
+	//	"DeleteAllocation", []interface{}{"test2-uuid"},
+	//}})
+	c.Assert(err, jc.ErrorIsNil)
+	s.stub.CheckNoCalls(c)
 }
 
 func (s *DestroySuite) resetModel(c *gc.C) {


### PR DESCRIPTION
Fixes LP:#1675214

This is a temporary fix that addresses the regression. For 2.2, we'll
followup with a more robust solution to allocation deletion on model
destroy.

## Description of change

> Why is this change needed?

Fixes LP:#1675214

## QA steps

> How do we verify that the change works?

The failing test linked in that bug should now pass.

## Documentation changes

> Does it affect current user workflow? CLI? API?

No.

## Bug reference

> Does this change fix a bug? Please add a link to it.

https://bugs.launchpad.net/juju/+bug/1675214