### PR TITLE
provider/vsphere: set VM hostname

### DIFF
--- a/cloudconfig/cloudinit/cloudinit.go
+++ b/cloudconfig/cloudinit/cloudinit.go
@@ -341,6 +341,15 @@ func (cfg *cloudConfig) DisableRoot() bool {
 	return disable
 }
 
+// ManageEtcHosts enables or disables management of /etc/hosts.
+func (cfg *cloudConfig) ManageEtcHosts(manage bool) {
+	if manage {
+		cfg.SetAttr("manage_etc_hosts", true)
+	} else {
+		cfg.UnsetAttr("manage_etc_hosts")
+	}
+}
+
 // AddRunTextFile is defined on the WrittenFilesConfig interface.
 func (cfg *cloudConfig) AddRunTextFile(filename, contents string, perm uint) {
 	cfg.AddScripts(addFileCmds(filename, []byte(contents), perm, false)...)

--- a/cloudconfig/cloudinit/cloudinit_test.go
+++ b/cloudconfig/cloudinit/cloudinit_test.go
@@ -360,8 +360,13 @@ var ctests = []struct {
 			0644,
 		)
 	},
-},
-}
+}, {
+	"ManageEtcHosts",
+	map[string]interface{}{"manage_etc_hosts": true},
+	func(cfg cloudinit.CloudConfig) {
+		cfg.ManageEtcHosts(true)
+	},
+}}
 
 func (S) TestOutput(c *gc.C) {
 	for i, t := range ctests {

--- a/cloudconfig/cloudinit/interface.go
+++ b/cloudconfig/cloudinit/interface.go
@@ -53,6 +53,7 @@ type CloudConfig interface {
 	WrittenFilesConfig
 	RenderConfig
 	AdvancedPackagingConfig
+	HostnameConfig
 }
 
 // SystemUpdateConfig is the interface for managing all system update options.
@@ -380,6 +381,12 @@ type UsersConfig interface {
 	// UnsetUsers unsets any users set in the config, meaning the default
 	// user specified in the image cloud config will be used.
 	UnsetUsers()
+}
+
+// HostnameConfig is the interface for managing the hostname.
+type HostnameConfig interface {
+	// ManageEtcHosts enables or disables management of /etc/hosts.
+	ManageEtcHosts(manage bool)
 }
 
 // New returns a new Config with no options set.

--- a/provider/vsphere/environ_broker.go
+++ b/provider/vsphere/environ_broker.go
@@ -86,6 +86,10 @@ func (env *environ) newRawInstance(args environs.StartInstanceParams, img *OvaFi
 	}
 	cloudcfg.AddPackage("open-vm-tools")
 	cloudcfg.AddPackage("iptables-persistent")
+
+	// Make sure the hostname is resolvable by adding it to /etc/hosts.
+	cloudcfg.ManageEtcHosts(true)
+
 	userData, err := providerinit.ComposeUserData(args.InstanceConfig, cloudcfg, VsphereRenderer{})
 	if err != nil {
 		return nil, nil, errors.Annotate(err, "cannot make user data")

--- a/provider/vsphere/fake_methods_test.go
+++ b/provider/vsphere/fake_methods_test.go
@@ -295,6 +295,16 @@ func (s *BaseSuite) FakeCreateInstance(c *fakeClient, serverURL string, checker 
 func (s *BaseSuite) FakeImportOvf(c *fakeClient, serverURL string, checker *gc.C) {
 	c.SetPropertyProxyHandler("FakeDatacenter", RetrieveDatacenterProperties)
 	c.SetProxyHandler("CreateImportSpec", func(req, res soap.HasFault) {
+		// Check that the expected keys are passed to CreateImportSpec.
+		reqBody := req.(*methods.CreateImportSpecBody)
+		var propertyKeys []string
+		for _, kv := range reqBody.Req.Cisp.PropertyMapping {
+			propertyKeys = append(propertyKeys, kv.Key)
+		}
+		checker.Assert(propertyKeys, jc.SameContents, []string{
+			"public-keys", "user-data", "hostname",
+		})
+
 		resBody := res.(*methods.CreateImportSpecBody)
 		resBody.Res = &types.CreateImportSpecResponse{
 			Returnval: types.OvfCreateImportSpecResult{

--- a/provider/vsphere/ova_import_manager.go
+++ b/provider/vsphere/ova_import_manager.go
@@ -81,6 +81,7 @@ func (m *ovaImportManager) importOva(ecfg *environConfig, instSpec *instanceSpec
 		PropertyMapping: []types.KeyValue{
 			types.KeyValue{Key: "public-keys", Value: instSpec.sshKey},
 			types.KeyValue{Key: "user-data", Value: string(instSpec.userData)},
+			types.KeyValue{Key: "hostname", Value: string(instSpec.machineID)},
 		},
 	}
 


### PR DESCRIPTION
## Description of change

Set the VM hostname to the same as the instance ID.
If we don't set the hostname, the default name from
the OVF ("ubuntuguest") is used.

## QA steps

1. juju bootstrap vsphere
2. juju add-machine
3. check the two VMs (controller machine-0, default model machine-0) have the same hostname as their reported instance IDs

## Documentation changes

None.

## Bug reference

(Partially?) Fixes https://bugs.launchpad.net/juju/+bug/1669072