### PR TITLE
provider/vsphere: handle "NotFoundError"

### DIFF
--- a/provider/vsphere/client.go
+++ b/provider/vsphere/client.go
@@ -210,7 +210,10 @@ func (c *client) Instances(prefix string) ([]*mo.VirtualMachine, error) {
 	}
 	items, err := finder.VirtualMachineList(context.TODO(), "*")
 	if err != nil {
-		return nil, errors.Trace(err)
+		if _, ok := err.(*find.NotFoundError); ok {
+			return nil, nil
+		}
+		return nil, errors.Annotate(err, "listing VMs")
 	}
 
 	var vms []*mo.VirtualMachine

--- a/provider/vsphere/environ_instance_test.go
+++ b/provider/vsphere/environ_instance_test.go
@@ -52,7 +52,20 @@ func (s *environInstanceSuite) TestInstances(c *gc.C) {
 	c.Assert(string(instances[1].Id()), gc.Equals, vmName2)
 }
 
-func (s *environInstanceSuite) TestInstancesReturnNoInstances(c *gc.C) {
+func (s *environInstanceSuite) TestInstancesNoInstances(c *gc.C) {
+	client, closer, err := vsphere.ExposeEnvFakeClient(s.Env)
+	c.Assert(err, jc.ErrorIsNil)
+	defer closer()
+	s.FakeClient = client
+	client.SetPropertyProxyHandler("FakeDatacenter", vsphere.RetrieveDatacenterProperties)
+	s.FakeInstances(client)
+
+	_, err = s.Env.Instances([]instance.Id{"Some other name"})
+
+	c.Assert(err, gc.Equals, environs.ErrNoInstances)
+}
+
+func (s *environInstanceSuite) TestInstancesNoMatchingInstances(c *gc.C) {
 	client, closer, err := vsphere.ExposeEnvFakeClient(s.Env)
 	c.Assert(err, jc.ErrorIsNil)
 	defer closer()


### PR DESCRIPTION
## Description of change

When calling the Finder.VirtualMachineList method,
handle NotFoundError. This error is returned if
no matching virtual machines can be found, which
is a legitimate scenario for Juju.

## QA steps

1. destroy aor move all existing VMs into folders
2. juju bootstrap vsphere

## Documentation changes

None.

## Bug reference

Fixes https://bugs.launchpad.net/juju/+bug/1669483