### PR TITLE
Use legacy address mode for juju ssh --proxy

### DIFF
--- a/cmd/juju/commands/ssh_common.go
+++ b/cmd/juju/commands/ssh_common.go
@@ -326,7 +326,19 @@ func (c *SSHCommon) resolveTarget(target string) (*resolvedTarget, error) {
 		logger.Debugf("using legacy SSHClient API v1: no support for AllAddresses()")
 		getAddress = c.legacyAddressGetter
 	} else if c.proxy {
-		logger.Infof("proxy-ssh enabled but ignored: trying all addresses of target %q", out.entity)
+		// Ideally a reachability scan would be done from the
+		// controller's perspective but that isn't possible yet, so
+		// fall back to the legacy mode (i.e. use the instance's
+		// "private" address).
+		//
+		// This is in some ways better anyway as a both the external
+		// and internal addresses of an instance (if it has both) are
+		// likely to be accessible from the controller. With a
+		// reachability scan juju ssh could inadvertently end up using
+		// the public address when it really should be using the
+		// internal/private address.
+		logger.Debugf("proxy-ssh enabled so not doing reachability scan")
+		getAddress = c.legacyAddressGetter
 	}
 
 	return c.resolveWithRetry(*out, getAddress)
@@ -376,7 +388,7 @@ func (c *SSHCommon) resolveWithRetry(target resolvedTarget, getAddress addressGe
 
 // legacyAddressGetter returns the preferred public or private address of the
 // given entity (private when c.proxy is true), using the apiClient. Only used
-// when the SSHClient API facade v2 is not available.
+// when the SSHClient API facade v2 is not available or when proxy-ssh is set.
 func (c *SSHCommon) legacyAddressGetter(entity string) (string, error) {
 	if c.proxy {
 		return c.apiClient.PrivateAddress(entity)


### PR DESCRIPTION
## Description of change

The new reachability scan strategy was being used even when --proxy was passed. This makes no sense given that the scan happens from the client yet the SSH connection is going via the controller. This was causing juju ssh --proxy to fail in some cases.

## QA steps

```shell
$ juju bootstrap google ssh-test 
...
$ juju add-machine
created machine 0
# wait
...

# Verify connections without --proxy still work
$ JUJU_LOGGING_CONFIG="<root>=TRACE" juju ssh --debug 0  
...
[log lines about reachability scan]
...
13:31:37 TRACE juju.utils.ssh ssh_openssh.go:148 running: ssh -o "StrictHostKeyChecking yes" -o "PasswordAuthentication no" -o "ServerAliveInterval 30" -t -t -o "UserKnownHostsFile /tmp/ssh_known_hosts567340662" -i /home/menno/.local/share/juju/ssh/juju_id_rsa -i /home/menno/.ssh/id_rsa ubuntu@104.196.154.242
... (connects successfully)
# Good: direct connection to machine's public address

# Verify --proxy change
$ JUJU_LOGGING_CONFIG="<root>=TRACE" juju ssh --debug --proxy 0
...
[no log lines about reachability scan]
...
13:29:42 TRACE juju.utils.ssh ssh_openssh.go:148 running: ssh -o "StrictHostKeyChecking yes" -o "ProxyCommand /home/menno/go/bin/juju ssh --model=admin/default --proxy=false --no-host-key-checks --pty=false ubuntu@104.196.10.88 -q \"nc %h %p\"" -o "PasswordAuthentication no" -o "ServerAliveInterval 30" -t -t -o "UserKnownHostsFile /tmp/ssh_known_hosts415084587" -i /home/menno/.local/share/juju/ssh/juju_id_rsa -i /home/menno/.ssh/id_rsa ubuntu@10.142.0.3
... (connects successfully)
# Good: connection is to instance's internal address via the controller
```

## Documentation changes

N.A.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1669180