### PR TITLE
subnets: store ProviderNetworkId in state and display it

### DIFF
--- a/apiserver/common/networkingcommon/shims.go
+++ b/apiserver/common/networkingcommon/shims.go
@@ -17,7 +17,6 @@ import (
 
 // subnetShim forwards and adapts state.Subnets methods to BackingSubnet.
 type subnetShim struct {
-	BackingSubnet
 	subnet *state.Subnet
 }
 
@@ -27,6 +26,10 @@ func (s *subnetShim) CIDR() string {
 
 func (s *subnetShim) VLANTag() int {
 	return s.subnet.VLANTag()
+}
+
+func (s *subnetShim) ProviderNetworkId() network.Id {
+	return s.subnet.ProviderNetworkId()
 }
 
 func (s *subnetShim) ProviderId() network.Id {
@@ -56,7 +59,6 @@ func (s *subnetShim) SpaceName() string {
 
 // spaceShim forwards and adapts state.Space methods to BackingSpace.
 type spaceShim struct {
-	BackingSpace
 	space *state.Space
 }
 
@@ -110,7 +112,8 @@ func (s *stateShim) AllSpaces() ([]BackingSpace, error) {
 }
 
 func (s *stateShim) AddSubnet(info BackingSubnetInfo) (BackingSubnet, error) {
-	// TODO(xtian): cargo culting taking the first zone - why was this done?
+	// TODO(babbageclunk): we only take the first zone because
+	// state.Subnet currently only stores one.
 	var firstZone string
 	if len(info.AvailabilityZones) > 0 {
 		firstZone = info.AvailabilityZones[0]

--- a/apiserver/common/networkingcommon/shims.go
+++ b/apiserver/common/networkingcommon/shims.go
@@ -116,11 +116,12 @@ func (s *stateShim) AddSubnet(info BackingSubnetInfo) (BackingSubnet, error) {
 		firstZone = info.AvailabilityZones[0]
 	}
 	_, err := s.st.AddSubnet(state.SubnetInfo{
-		CIDR:             info.CIDR,
-		VLANTag:          info.VLANTag,
-		ProviderId:       info.ProviderId,
-		AvailabilityZone: firstZone,
-		SpaceName:        info.SpaceName,
+		CIDR:              info.CIDR,
+		VLANTag:           info.VLANTag,
+		ProviderId:        info.ProviderId,
+		ProviderNetworkId: info.ProviderNetworkId,
+		AvailabilityZone:  firstZone,
+		SpaceName:         info.SpaceName,
 	})
 	return nil, err // Drop the first result, as it's unused.
 }

--- a/apiserver/common/networkingcommon/subnets.go
+++ b/apiserver/common/networkingcommon/subnets.go
@@ -349,6 +349,7 @@ func addOneSubnet(api NetworkBacking, args params.AddSubnetParams, cache *addSub
 	// Try adding the subnet.
 	backingInfo := BackingSubnetInfo{
 		ProviderId:        subnetInfo.ProviderId,
+		ProviderNetworkId: subnetInfo.ProviderNetworkId,
 		CIDR:              subnetInfo.CIDR,
 		VLANTag:           subnetInfo.VLANTag,
 		AvailabilityZones: zones,
@@ -422,13 +423,14 @@ func ListSubnets(api NetworkBacking, args params.SubnetsFilters) (results params
 			spaceTag = names.NewSpaceTag(subnet.SpaceName()).String()
 		}
 		result := params.Subnet{
-			CIDR:       subnet.CIDR(),
-			ProviderId: string(subnet.ProviderId()),
-			VLANTag:    subnet.VLANTag(),
-			Life:       subnet.Life(),
-			SpaceTag:   spaceTag,
-			Zones:      subnet.AvailabilityZones(),
-			Status:     subnet.Status(),
+			CIDR:              subnet.CIDR(),
+			ProviderId:        string(subnet.ProviderId()),
+			ProviderNetworkId: string(subnet.ProviderNetworkId()),
+			VLANTag:           subnet.VLANTag(),
+			Life:              subnet.Life(),
+			SpaceTag:          spaceTag,
+			Zones:             subnet.AvailabilityZones(),
+			Status:            subnet.Status(),
 		}
 		results.Results = append(results.Results, result)
 	}

--- a/apiserver/common/networkingcommon/subnets_test.go
+++ b/apiserver/common/networkingcommon/subnets_test.go
@@ -483,18 +483,21 @@ func (s *SubnetsSuite) TestAddSubnetsParamsCombinations(c *gc.C) {
 	}
 	expectedBackingInfos := []networkingcommon.BackingSubnetInfo{{
 		ProviderId:        "sn-ipv6",
+		ProviderNetworkId: "",
 		CIDR:              "2001:db8::/32",
 		VLANTag:           0,
 		AvailabilityZones: []string{"zone1"},
 		SpaceName:         "dmz",
 	}, {
 		ProviderId:        "vlan-42",
+		ProviderNetworkId: "",
 		CIDR:              "10.30.1.0/24",
 		VLANTag:           42,
 		AvailabilityZones: []string{"zone3"},
 		SpaceName:         "private",
 	}, {
 		ProviderId:        "sn-zadf00d",
+		ProviderNetworkId: "godspeed",
 		CIDR:              "10.10.0.0/24",
 		VLANTag:           0,
 		AvailabilityZones: []string{"zone1"},
@@ -740,21 +743,23 @@ func (s *SubnetsSuite) TestAddSubnetsWhenNetworkingEnvironNotSupported(c *gc.C) 
 
 func (s *SubnetsSuite) TestListSubnetsAndFiltering(c *gc.C) {
 	expected := []params.Subnet{{
-		CIDR:       "10.10.0.0/24",
-		ProviderId: "sn-zadf00d",
-		VLANTag:    0,
-		Life:       "",
-		SpaceTag:   "space-private",
-		Zones:      []string{"zone1"},
-		Status:     "",
+		CIDR:              "10.10.0.0/24",
+		ProviderId:        "sn-zadf00d",
+		ProviderNetworkId: "godspeed",
+		VLANTag:           0,
+		Life:              "",
+		SpaceTag:          "space-private",
+		Zones:             []string{"zone1"},
+		Status:            "",
 	}, {
-		CIDR:       "2001:db8::/32",
-		ProviderId: "sn-ipv6",
-		VLANTag:    0,
-		Life:       "",
-		SpaceTag:   "space-dmz",
-		Zones:      []string{"zone1", "zone3"},
-		Status:     "",
+		CIDR:              "2001:db8::/32",
+		ProviderId:        "sn-ipv6",
+		ProviderNetworkId: "",
+		VLANTag:           0,
+		Life:              "",
+		SpaceTag:          "space-dmz",
+		Zones:             []string{"zone1", "zone3"},
+		Status:            "",
 	}}
 	// No filtering.
 	args := params.SubnetsFilters{}

--- a/apiserver/common/networkingcommon/types.go
+++ b/apiserver/common/networkingcommon/types.go
@@ -26,6 +26,7 @@ type BackingSubnet interface {
 	CIDR() string
 	VLANTag() int
 	ProviderId() network.Id
+	ProviderNetworkId() network.Id
 	AvailabilityZones() []string
 	Status() string
 	SpaceName() string
@@ -41,8 +42,6 @@ type BackingSubnet interface {
 // * subnetDoc.AvailabilityZone becomes subnetDoc.AvailabilityZones,
 //   adding an upgrade step to migrate existing non empty zones on
 //   subnet docs. Also change state.Subnet.AvailabilityZone to
-// * add subnetDoc.SpaceName - no upgrade step needed, as it will only
-//   be used for new space-aware subnets.
 // * Subnets need a reference count to calculate Status.
 // * ensure EC2 and MAAS providers accept empty IDs as Subnets() args
 //   and return all subnets, including the AvailabilityZones (for EC2;
@@ -50,6 +49,11 @@ type BackingSubnet interface {
 type BackingSubnetInfo struct {
 	// ProviderId is a provider-specific network id. This may be empty.
 	ProviderId network.Id
+
+	// ProviderNetworkId is the id of the network containing this
+	// subnet from the provider's perspective. It can be empty if the
+	// provider doesn't support distinct networks.
+	ProviderNetworkId network.Id
 
 	// CIDR of the network, in 123.45.67.89/24 format.
 	CIDR string

--- a/apiserver/common/networkingcommon/types.go
+++ b/apiserver/common/networkingcommon/types.go
@@ -90,14 +90,6 @@ type BackingSpace interface {
 
 	// ProviderId returns the network ID of the provider
 	ProviderId() network.Id
-
-	// Zones returns a list of availability zone(s) that this
-	// space is in. It can be empty if the provider does not support
-	// availability zones.
-	Zones() []string
-
-	// Life returns the lifecycle state of the space
-	Life() params.Life
 }
 
 // Backing defines the methods needed by the API facade to store and

--- a/apiserver/discoverspaces/discoverspaces.go
+++ b/apiserver/discoverspaces/discoverspaces.go
@@ -131,6 +131,7 @@ func (api *API) AddSubnets(args params.AddSubnetsParams) (params.ErrorResults, e
 		}
 		_, err = api.st.AddSubnet(networkingcommon.BackingSubnetInfo{
 			ProviderId:        network.Id(arg.SubnetProviderId),
+			ProviderNetworkId: network.Id(arg.ProviderNetworkId),
 			CIDR:              subnetTag.Id(),
 			VLANTag:           arg.VLANTag,
 			AvailabilityZones: arg.Zones,

--- a/apiserver/discoverspaces/discoverspaces_test.go
+++ b/apiserver/discoverspaces/discoverspaces_test.go
@@ -178,11 +178,12 @@ func (s *DiscoverSpacesSuite) TestAddSubnetsParamsCombinations(c *gc.C) {
 		SpaceTag:         "space-thing",
 	}, {
 		// Successful - ipv6
-		SubnetProviderId: "sn-ipv6",
-		SubnetTag:        "subnet-2001:db8::/32",
-		VLANTag:          0,
-		Zones:            []string{"a", "b", "c"},
-		SpaceTag:         "space-dmz",
+		SubnetProviderId:  "sn-ipv6",
+		ProviderNetworkId: "antennas",
+		SubnetTag:         "subnet-2001:db8::/32",
+		VLANTag:           0,
+		Zones:             []string{"a", "b", "c"},
+		SpaceTag:          "space-dmz",
 	}, {
 		// Successful - no zones
 		SubnetProviderId: "sn-no-zone",
@@ -214,18 +215,21 @@ func (s *DiscoverSpacesSuite) TestAddSubnetsParamsCombinations(c *gc.C) {
 	}
 	expectedBackingInfos := []networkingcommon.BackingSubnetInfo{{
 		ProviderId:        "sn-ipv6",
+		ProviderNetworkId: "antennas",
 		CIDR:              "2001:db8::/32",
 		VLANTag:           0,
 		AvailabilityZones: []string{"a", "b", "c"},
 		SpaceName:         "dmz",
 	}, {
 		ProviderId:        "sn-no-zone",
+		ProviderNetworkId: "",
 		CIDR:              "10.10.10.0/24",
 		VLANTag:           3,
 		AvailabilityZones: nil,
 		SpaceName:         "dmz",
 	}, {
 		ProviderId:        "sn-no-space",
+		ProviderNetworkId: "",
 		CIDR:              "10.10.10.0/24",
 		VLANTag:           3,
 		AvailabilityZones: []string{"a", "b", "c"},

--- a/apiserver/params/network.go
+++ b/apiserver/params/network.go
@@ -19,6 +19,11 @@ type Subnet struct {
 	// ProviderId is the provider-specific subnet ID (if applicable).
 	ProviderId string `json:"provider-id,omitempty"`
 
+	// ProviderNetworkId is the id of the network containing this
+	// subnet from the provider's perspective. It can be empty if the
+	// provider doesn't support distinct networks.
+	ProviderNetworkId string `json:"provider-network-id,omitempty"`
+
 	// VLANTag needs to be between 1 and 4094 for VLANs and 0 for
 	// normal networks. It's defined by IEEE 802.1Q standard.
 	VLANTag int `json:"vlan-tag"`
@@ -577,11 +582,12 @@ type AddSubnetsParams struct {
 // SubnetProviderId must be set, but not both. Zones can be empty if
 // they can be discovered
 type AddSubnetParams struct {
-	SubnetTag        string   `json:"subnet-tag,omitempty"`
-	SubnetProviderId string   `json:"subnet-provider-id,omitempty"`
-	SpaceTag         string   `json:"space-tag"`
-	VLANTag          int      `json:"vlan-tag,omitempty"`
-	Zones            []string `json:"zones,omitempty"`
+	SubnetTag         string   `json:"subnet-tag,omitempty"`
+	SubnetProviderId  string   `json:"subnet-provider-id,omitempty"`
+	ProviderNetworkId string   `json:"provider-network-id,omitempty"`
+	SpaceTag          string   `json:"space-tag"`
+	VLANTag           int      `json:"vlan-tag,omitempty"`
+	Zones             []string `json:"zones,omitempty"`
 }
 
 // CreateSubnetsParams holds the arguments of CreateSubnets API call.

--- a/apiserver/subnets/subnets_test.go
+++ b/apiserver/subnets/subnets_test.go
@@ -535,18 +535,21 @@ func (s *SubnetsSuite) TestAddSubnetsParamsCombinations(c *gc.C) {
 	}
 	expectedBackingInfos := []networkingcommon.BackingSubnetInfo{{
 		ProviderId:        "sn-ipv6",
+		ProviderNetworkId: "",
 		CIDR:              "2001:db8::/32",
 		VLANTag:           0,
 		AvailabilityZones: []string{"zone1"},
 		SpaceName:         "dmz",
 	}, {
 		ProviderId:        "vlan-42",
+		ProviderNetworkId: "",
 		CIDR:              "10.30.1.0/24",
 		VLANTag:           42,
 		AvailabilityZones: []string{"zone3"},
 		SpaceName:         "private",
 	}, {
 		ProviderId:        "sn-zadf00d",
+		ProviderNetworkId: "godspeed",
 		CIDR:              "10.10.0.0/24",
 		VLANTag:           0,
 		AvailabilityZones: []string{"zone1"},
@@ -792,21 +795,23 @@ func (s *SubnetsSuite) TestAddSubnetsWhenNetworkingEnvironNotSupported(c *gc.C) 
 
 func (s *SubnetsSuite) TestListSubnetsAndFiltering(c *gc.C) {
 	expected := []params.Subnet{{
-		CIDR:       "10.10.0.0/24",
-		ProviderId: "sn-zadf00d",
-		VLANTag:    0,
-		Life:       "",
-		SpaceTag:   "space-private",
-		Zones:      []string{"zone1"},
-		Status:     "",
+		CIDR:              "10.10.0.0/24",
+		ProviderId:        "sn-zadf00d",
+		ProviderNetworkId: "godspeed",
+		VLANTag:           0,
+		Life:              "",
+		SpaceTag:          "space-private",
+		Zones:             []string{"zone1"},
+		Status:            "",
 	}, {
-		CIDR:       "2001:db8::/32",
-		ProviderId: "sn-ipv6",
-		VLANTag:    0,
-		Life:       "",
-		SpaceTag:   "space-dmz",
-		Zones:      []string{"zone1", "zone3"},
-		Status:     "",
+		CIDR:              "2001:db8::/32",
+		ProviderId:        "sn-ipv6",
+		ProviderNetworkId: "",
+		VLANTag:           0,
+		Life:              "",
+		SpaceTag:          "space-dmz",
+		Zones:             []string{"zone1", "zone3"},
+		Status:            "",
 	}}
 	// No filtering.
 	args := params.SubnetsFilters{}

--- a/apiserver/testing/stub_network.go
+++ b/apiserver/testing/stub_network.go
@@ -65,6 +65,7 @@ func (s StubNetwork) SetUpSuite(c *gc.C) {
 	ProviderInstance.Subnets = []network.SubnetInfo{{
 		CIDR:              "10.10.0.0/24",
 		ProviderId:        "sn-zadf00d",
+		ProviderNetworkId: "godspeed",
 		AvailabilityZones: []string{"zone1"},
 	}, {
 		CIDR:              "2001:db8::/32",
@@ -315,6 +316,10 @@ func (f *FakeSubnet) ProviderId() network.Id {
 	return f.Info.ProviderId
 }
 
+func (f *FakeSubnet) ProviderNetworkId() network.Id {
+	return f.Info.ProviderNetworkId
+}
+
 func (f *FakeSubnet) VLANTag() int {
 	return f.Info.VLANTag
 }
@@ -411,12 +416,14 @@ func (sb *StubBacking) SetUp(c *gc.C, envName string, withZones, withSpaces, wit
 		info0 := networkingcommon.BackingSubnetInfo{
 			CIDR:              ProviderInstance.Subnets[0].CIDR,
 			ProviderId:        ProviderInstance.Subnets[0].ProviderId,
+			ProviderNetworkId: ProviderInstance.Subnets[0].ProviderNetworkId,
 			AvailabilityZones: ProviderInstance.Subnets[0].AvailabilityZones,
 			SpaceName:         "private",
 		}
 		info1 := networkingcommon.BackingSubnetInfo{
 			CIDR:              ProviderInstance.Subnets[1].CIDR,
 			ProviderId:        ProviderInstance.Subnets[1].ProviderId,
+			ProviderNetworkId: ProviderInstance.Subnets[1].ProviderNetworkId,
 			AvailabilityZones: ProviderInstance.Subnets[1].AvailabilityZones,
 			SpaceName:         "dmz",
 		}

--- a/cmd/juju/subnet/list.go
+++ b/cmd/juju/subnet/list.go
@@ -116,8 +116,9 @@ func (c *listCommand) Run(ctx *cmd.Context) error {
 		}
 		for _, sub := range subnets {
 			subResult := formattedSubnet{
-				ProviderId: sub.ProviderId,
-				Zones:      sub.Zones,
+				ProviderId:        sub.ProviderId,
+				ProviderNetworkId: sub.ProviderNetworkId,
+				Zones:             sub.Zones,
 			}
 
 			// Use the CIDR to determine the subnet type.
@@ -165,9 +166,10 @@ type formattedList struct {
 }
 
 type formattedSubnet struct {
-	Type       string   `json:"type" yaml:"type"`
-	ProviderId string   `json:"provider-id,omitempty" yaml:"provider-id,omitempty"`
-	Status     string   `json:"status,omitempty" yaml:"status,omitempty"`
-	Space      string   `json:"space" yaml:"space"`
-	Zones      []string `json:"zones" yaml:"zones"`
+	Type              string   `json:"type" yaml:"type"`
+	ProviderId        string   `json:"provider-id,omitempty" yaml:"provider-id,omitempty"`
+	ProviderNetworkId string   `json:"provider-network-id,omitempty" yaml:"provider-network-id,omitempty"`
+	Status            string   `json:"status,omitempty" yaml:"status,omitempty"`
+	Space             string   `json:"space" yaml:"space"`
+	Zones             []string `json:"zones" yaml:"zones"`
 }

--- a/cmd/juju/subnet/list_test.go
+++ b/cmd/juju/subnet/list_test.go
@@ -123,6 +123,7 @@ subnets:
   2001:db8::/32:
     type: ipv6
     provider-id: subnet-bar
+    provider-network-id: network-yay
     status: terminating
     space: dmz
     zones:
@@ -145,6 +146,7 @@ subnets:
 		`"2001:db8::/32":{` +
 		`"type":"ipv6",` +
 		`"provider-id":"subnet-bar",` +
+		`"provider-network-id":"network-yay",` +
 		`"status":"terminating",` +
 		`"space":"dmz",` +
 		`"zones":["zone2"]}}}

--- a/cmd/juju/subnet/package_test.go
+++ b/cmd/juju/subnet/package_test.go
@@ -128,11 +128,12 @@ func NewStubAPI() *StubAPI {
 		Zones:      []string{"zone1", "zone2"},
 	}, {
 		// IPv6 subnet.
-		CIDR:       "2001:db8::/32",
-		ProviderId: "subnet-bar",
-		Life:       params.Dying,
-		SpaceTag:   "space-dmz",
-		Zones:      []string{"zone2"},
+		CIDR:              "2001:db8::/32",
+		ProviderId:        "subnet-bar",
+		ProviderNetworkId: "network-yay",
+		Life:              params.Dying,
+		SpaceTag:          "space-dmz",
+		Zones:             []string{"zone2"},
 	}, {
 		// IPv4 VLAN subnet.
 		CIDR:     "10.10.0.0/16",

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -20,7 +20,7 @@ github.com/juju/ansiterm	git	b99631de12cf04a906c1d4e4ec54fb86eae5863d	2016-09-07
 github.com/juju/blobstore	git	06056004b3d7b54bbb7984d830c537bad00fec21	2015-07-29T11:18:58Z
 github.com/juju/bundlechanges	git	7725027b95e0d54635e0fb11efc2debdcdf19f75	2016-12-15T16:06:52Z
 github.com/juju/cmd	git	9425a576247f348b9b40afe3b60085de63470de5	2017-03-20T01:37:09Z
-github.com/juju/description	git	76acbf13a755236ebeb415c4bc9bbd6b88f0c66a	2017-03-22T22:45:04Z
+github.com/juju/description	git	390c59b260dba9dd880fee7eba31d5cf2a0294c1	2017-03-26T22:17:51Z
 github.com/juju/errors	git	1b5e39b83d1835fa480e0c2ddefb040ee82d58b3	2015-09-16T12:56:42Z
 github.com/juju/gnuflag	git	4e76c56581859c14d9d87e1ddbe29e1c0f10195f	2016-08-09T16:52:14Z
 github.com/juju/go4	git	40d72ab9641a2a8c36a9c46a51e28367115c8e59	2016-02-22T16:32:58Z

--- a/state/migration_export.go
+++ b/state/migration_export.go
@@ -902,11 +902,12 @@ func (e *exporter) subnets() error {
 
 	for _, subnet := range subnets {
 		e.model.AddSubnet(description.SubnetArgs{
-			CIDR:             subnet.CIDR(),
-			ProviderId:       string(subnet.ProviderId()),
-			VLANTag:          subnet.VLANTag(),
-			AvailabilityZone: subnet.AvailabilityZone(),
-			SpaceName:        subnet.SpaceName(),
+			CIDR:              subnet.CIDR(),
+			ProviderId:        string(subnet.ProviderId()),
+			ProviderNetworkId: string(subnet.ProviderNetworkId()),
+			VLANTag:           subnet.VLANTag(),
+			AvailabilityZone:  subnet.AvailabilityZone(),
+			SpaceName:         subnet.SpaceName(),
 		})
 	}
 	return nil

--- a/state/migration_export_test.go
+++ b/state/migration_export_test.go
@@ -647,11 +647,12 @@ func (s *MigrationExportSuite) TestLinkLayerDevices(c *gc.C) {
 
 func (s *MigrationExportSuite) TestSubnets(c *gc.C) {
 	_, err := s.State.AddSubnet(state.SubnetInfo{
-		CIDR:             "10.0.0.0/24",
-		ProviderId:       network.Id("foo"),
-		VLANTag:          64,
-		AvailabilityZone: "bar",
-		SpaceName:        "bam",
+		CIDR:              "10.0.0.0/24",
+		ProviderId:        network.Id("foo"),
+		ProviderNetworkId: network.Id("rust"),
+		VLANTag:           64,
+		AvailabilityZone:  "bar",
+		SpaceName:         "bam",
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	_, err = s.State.AddSpace("bam", "", nil, true)
@@ -665,6 +666,7 @@ func (s *MigrationExportSuite) TestSubnets(c *gc.C) {
 	subnet := subnets[0]
 	c.Assert(subnet.CIDR(), gc.Equals, "10.0.0.0/24")
 	c.Assert(subnet.ProviderId(), gc.Equals, "foo")
+	c.Assert(subnet.ProviderNetworkId(), gc.Equals, "rust")
 	c.Assert(subnet.VLANTag(), gc.Equals, 64)
 	c.Assert(subnet.AvailabilityZone(), gc.Equals, "bar")
 	c.Assert(subnet.SpaceName(), gc.Equals, "bam")

--- a/state/migration_import.go
+++ b/state/migration_import.go
@@ -1159,11 +1159,12 @@ func (i *importer) subnets() error {
 	i.logger.Debugf("importing subnets")
 	for _, subnet := range i.model.Subnets() {
 		err := i.addSubnet(SubnetInfo{
-			CIDR:             subnet.CIDR(),
-			ProviderId:       network.Id(subnet.ProviderId()),
-			VLANTag:          subnet.VLANTag(),
-			AvailabilityZone: subnet.AvailabilityZone(),
-			SpaceName:        subnet.SpaceName(),
+			CIDR:              subnet.CIDR(),
+			ProviderId:        network.Id(subnet.ProviderId()),
+			ProviderNetworkId: network.Id(subnet.ProviderNetworkId()),
+			VLANTag:           subnet.VLANTag(),
+			AvailabilityZone:  subnet.AvailabilityZone(),
+			SpaceName:         subnet.SpaceName(),
 		})
 		if err != nil {
 			return errors.Trace(err)

--- a/state/migration_import_test.go
+++ b/state/migration_import_test.go
@@ -775,11 +775,12 @@ func (s *MigrationImportSuite) TestLinkLayerDeviceMigratesReferences(c *gc.C) {
 
 func (s *MigrationImportSuite) TestSubnets(c *gc.C) {
 	original, err := s.State.AddSubnet(state.SubnetInfo{
-		CIDR:             "10.0.0.0/24",
-		ProviderId:       network.Id("foo"),
-		VLANTag:          64,
-		AvailabilityZone: "bar",
-		SpaceName:        "bam",
+		CIDR:              "10.0.0.0/24",
+		ProviderId:        network.Id("foo"),
+		ProviderNetworkId: network.Id("elm"),
+		VLANTag:           64,
+		AvailabilityZone:  "bar",
+		SpaceName:         "bam",
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	_, err = s.State.AddSpace("bam", "", nil, true)
@@ -792,6 +793,7 @@ func (s *MigrationImportSuite) TestSubnets(c *gc.C) {
 
 	c.Assert(subnet.CIDR(), gc.Equals, "10.0.0.0/24")
 	c.Assert(subnet.ProviderId(), gc.Equals, network.Id("foo"))
+	c.Assert(subnet.ProviderNetworkId(), gc.Equals, network.Id("elm"))
 	c.Assert(subnet.VLANTag(), gc.Equals, 64)
 	c.Assert(subnet.AvailabilityZone(), gc.Equals, "bar")
 	c.Assert(subnet.SpaceName(), gc.Equals, "bam")

--- a/state/migration_internal_test.go
+++ b/state/migration_internal_test.go
@@ -604,6 +604,7 @@ func (s *MigrationSuite) TestSubnetDocFields(c *gc.C) {
 		"SpaceName",
 		"ProviderId",
 		"AvailabilityZone",
+		"ProviderNetworkId",
 	)
 	s.AssertExportedFields(c, subnetDoc{}, migrated.Union(ignored))
 }

--- a/state/subnets_test.go
+++ b/state/subnets_test.go
@@ -21,11 +21,12 @@ var _ = gc.Suite(&SubnetSuite{})
 
 func (s *SubnetSuite) TestAddSubnetSucceedsWithFullyPopulatedInfo(c *gc.C) {
 	subnetInfo := state.SubnetInfo{
-		ProviderId:       "foo",
-		CIDR:             "192.168.1.0/24",
-		VLANTag:          79,
-		AvailabilityZone: "Timbuktu",
-		SpaceName:        "foo",
+		ProviderId:        "foo",
+		CIDR:              "192.168.1.0/24",
+		VLANTag:           79,
+		AvailabilityZone:  "Timbuktu",
+		SpaceName:         "foo",
+		ProviderNetworkId: "wildbirds",
 	}
 
 	subnet, err := s.State.AddSubnet(subnetInfo)
@@ -46,6 +47,7 @@ func (s *SubnetSuite) assertSubnetMatchesInfo(c *gc.C, subnet *state.Subnet, inf
 	c.Assert(subnet.String(), gc.Equals, info.CIDR)
 	c.Assert(subnet.GoString(), gc.Equals, info.CIDR)
 	c.Assert(subnet.SpaceName(), gc.Equals, info.SpaceName)
+	c.Assert(subnet.ProviderNetworkId(), gc.Equals, info.ProviderNetworkId)
 }
 
 func (s *SubnetSuite) TestAddSubnetFailsWithEmptyCIDR(c *gc.C) {

--- a/worker/discoverspaces/discoverspaces.go
+++ b/worker/discoverspaces/discoverspaces.go
@@ -331,11 +331,12 @@ func collectMissingSubnets(
 			zones = []string{"default"}
 		}
 		addArgs.Subnets = append(addArgs.Subnets, params.AddSubnetParams{
-			SubnetProviderId: string(subnet.ProviderId),
-			SubnetTag:        names.NewSubnetTag(subnet.CIDR).String(),
-			SpaceTag:         spaceTag,
-			VLANTag:          subnet.VLANTag,
-			Zones:            zones,
+			SubnetProviderId:  string(subnet.ProviderId),
+			ProviderNetworkId: string(subnet.ProviderNetworkId),
+			SubnetTag:         names.NewSubnetTag(subnet.CIDR).String(),
+			SpaceTag:          spaceTag,
+			VLANTag:           subnet.VLANTag,
+			Zones:             zones,
 		})
 	}
 }

--- a/worker/discoverspaces/worker_test.go
+++ b/worker/discoverspaces/worker_test.go
@@ -75,24 +75,29 @@ func (s *WorkerSuite) TestWorkerSupportsNetworkingFalse(c *gc.C) {
 
 func (s *WorkerSuite) cannedSubnets() []network.SubnetInfo {
 	return []network.SubnetInfo{{
-		ProviderId:        network.Id("1"),
+		ProviderId:        "1",
+		ProviderNetworkId: "swans",
 		CIDR:              "192.168.1.0/24",
 		AvailabilityZones: []string{"zone1"},
 	}, {
-		ProviderId:        network.Id("2"),
+		ProviderId:        "2",
+		ProviderNetworkId: "swans",
 		CIDR:              "192.168.2.0/24",
 		AvailabilityZones: []string{"zone1"},
 	}, {
-		ProviderId:        network.Id("3"),
+		ProviderId:        "3",
+		ProviderNetworkId: "liars",
 		CIDR:              "192.168.3.0/24",
 		VLANTag:           50,
 		AvailabilityZones: []string{"zone1"},
 	}, {
-		ProviderId:        network.Id("4"),
+		ProviderId:        "4",
+		ProviderNetworkId: "liars",
 		CIDR:              "192.168.4.0/24",
 		AvailabilityZones: []string{"zone1"},
 	}, {
-		ProviderId:        network.Id("5"),
+		ProviderId:        "5",
+		ProviderNetworkId: "hdu",
 		CIDR:              "192.168.5.0/24",
 		AvailabilityZones: []string{"zone1"},
 	}}
@@ -107,26 +112,31 @@ func (s *WorkerSuite) TestWorkerNoSpaceDiscoveryOnlySubnets(c *gc.C) {
 		stub.CheckCallNames(c, "ListSubnets", "AddSubnets")
 		stub.CheckCall(c, 1, "AddSubnets", params.AddSubnetsParams{
 			Subnets: []params.AddSubnetParams{{
-				SubnetProviderId: "1",
-				SubnetTag:        "subnet-192.168.1.0/24",
-				Zones:            []string{"zone1"},
+				SubnetProviderId:  "1",
+				ProviderNetworkId: "swans",
+				SubnetTag:         "subnet-192.168.1.0/24",
+				Zones:             []string{"zone1"},
 			}, {
-				SubnetProviderId: "2",
-				SubnetTag:        "subnet-192.168.2.0/24",
-				Zones:            []string{"zone1"},
+				SubnetProviderId:  "2",
+				ProviderNetworkId: "swans",
+				SubnetTag:         "subnet-192.168.2.0/24",
+				Zones:             []string{"zone1"},
 			}, {
-				SubnetProviderId: "3",
-				SubnetTag:        "subnet-192.168.3.0/24",
-				VLANTag:          50,
-				Zones:            []string{"zone1"},
+				SubnetProviderId:  "3",
+				ProviderNetworkId: "liars",
+				SubnetTag:         "subnet-192.168.3.0/24",
+				VLANTag:           50,
+				Zones:             []string{"zone1"},
 			}, {
-				SubnetProviderId: "4",
-				SubnetTag:        "subnet-192.168.4.0/24",
-				Zones:            []string{"zone1"},
+				SubnetProviderId:  "4",
+				ProviderNetworkId: "liars",
+				SubnetTag:         "subnet-192.168.4.0/24",
+				Zones:             []string{"zone1"},
 			}, {
-				SubnetProviderId: "5",
-				SubnetTag:        "subnet-192.168.5.0/24",
-				Zones:            []string{"zone1"},
+				SubnetProviderId:  "5",
+				ProviderNetworkId: "hdu",
+				SubnetTag:         "subnet-192.168.5.0/24",
+				Zones:             []string{"zone1"},
 			}},
 		})
 		s.environ.stub.CheckCallNames(c, "SupportsSpaceDiscovery", "Subnets")
@@ -140,10 +150,12 @@ func (s *WorkerSuite) cannedSpaces() []network.SpaceInfo {
 		ProviderId: network.Id("0"),
 		Subnets: []network.SubnetInfo{{
 			ProviderId:        network.Id("1"),
+			ProviderNetworkId: "swans",
 			CIDR:              "192.168.1.0/24",
 			AvailabilityZones: []string{"zone1"},
 		}, {
 			ProviderId:        network.Id("2"),
+			ProviderNetworkId: "swans",
 			CIDR:              "192.168.2.0/24",
 			AvailabilityZones: []string{"zone1"},
 		}},
@@ -152,6 +164,7 @@ func (s *WorkerSuite) cannedSpaces() []network.SpaceInfo {
 		ProviderId: network.Id("1"),
 		Subnets: []network.SubnetInfo{{
 			ProviderId:        network.Id("3"),
+			ProviderNetworkId: "liars",
 			CIDR:              "192.168.3.0/24",
 			AvailabilityZones: []string{"zone1"},
 		}},
@@ -160,6 +173,7 @@ func (s *WorkerSuite) cannedSpaces() []network.SpaceInfo {
 		ProviderId: network.Id("2"),
 		Subnets: []network.SubnetInfo{{
 			ProviderId:        network.Id("4"),
+			ProviderNetworkId: "liars",
 			CIDR:              "192.168.4.0/24",
 			AvailabilityZones: []string{"zone1"},
 			VLANTag:           3,
@@ -169,6 +183,7 @@ func (s *WorkerSuite) cannedSpaces() []network.SpaceInfo {
 		ProviderId: network.Id("3"),
 		Subnets: []network.SubnetInfo{{
 			ProviderId:        network.Id("5"),
+			ProviderNetworkId: "hdu",
 			CIDR:              "192.168.5.0/24",
 			AvailabilityZones: []string{"zone1"},
 		}},
@@ -212,31 +227,36 @@ func (s *WorkerSuite) TestWorkerDiscoversSpaces(c *gc.C) {
 		})
 		stub.CheckCall(c, 3, "AddSubnets", params.AddSubnetsParams{
 			Subnets: []params.AddSubnetParams{{
-				SubnetProviderId: "1",
-				SubnetTag:        "subnet-192.168.1.0/24",
-				SpaceTag:         "space-foo",
-				Zones:            []string{"zone1"},
+				SubnetProviderId:  "1",
+				ProviderNetworkId: "swans",
+				SubnetTag:         "subnet-192.168.1.0/24",
+				SpaceTag:          "space-foo",
+				Zones:             []string{"zone1"},
 			}, {
-				SubnetProviderId: "2",
-				SubnetTag:        "subnet-192.168.2.0/24",
-				SpaceTag:         "space-foo",
-				Zones:            []string{"zone1"},
+				SubnetProviderId:  "2",
+				ProviderNetworkId: "swans",
+				SubnetTag:         "subnet-192.168.2.0/24",
+				SpaceTag:          "space-foo",
+				Zones:             []string{"zone1"},
 			}, {
-				SubnetProviderId: "3",
-				SubnetTag:        "subnet-192.168.3.0/24",
-				SpaceTag:         "space-another-foo-99",
-				Zones:            []string{"zone1"},
+				SubnetProviderId:  "3",
+				ProviderNetworkId: "liars",
+				SubnetTag:         "subnet-192.168.3.0/24",
+				SpaceTag:          "space-another-foo-99",
+				Zones:             []string{"zone1"},
 			}, {
-				SubnetProviderId: "4",
-				SubnetTag:        "subnet-192.168.4.0/24",
-				SpaceTag:         "space-foo-2",
-				VLANTag:          3,
-				Zones:            []string{"zone1"},
+				SubnetProviderId:  "4",
+				ProviderNetworkId: "liars",
+				SubnetTag:         "subnet-192.168.4.0/24",
+				SpaceTag:          "space-foo-2",
+				VLANTag:           3,
+				Zones:             []string{"zone1"},
 			}, {
-				SubnetProviderId: "5",
-				SubnetTag:        "subnet-192.168.5.0/24",
-				SpaceTag:         "space-empty",
-				Zones:            []string{"zone1"},
+				SubnetProviderId:  "5",
+				ProviderNetworkId: "hdu",
+				SubnetTag:         "subnet-192.168.5.0/24",
+				SpaceTag:          "space-empty",
+				Zones:             []string{"zone1"},
 			}},
 		})
 	})
@@ -271,16 +291,18 @@ func (s *WorkerSuite) TestWorkerIgnoresExistingSpacesAndSubnets(c *gc.C) {
 		})
 		stub.CheckCall(c, 3, "AddSubnets", params.AddSubnetsParams{
 			Subnets: []params.AddSubnetParams{{
-				SubnetProviderId: "2",
-				SubnetTag:        "subnet-192.168.2.0/24",
-				SpaceTag:         "space-foo",
-				Zones:            []string{"zone1"},
+				SubnetProviderId:  "2",
+				ProviderNetworkId: "swans",
+				SubnetTag:         "subnet-192.168.2.0/24",
+				SpaceTag:          "space-foo",
+				Zones:             []string{"zone1"},
 			}, {
-				SubnetProviderId: "4",
-				SubnetTag:        "subnet-192.168.4.0/24",
-				SpaceTag:         "space-foo-2",
-				VLANTag:          3,
-				Zones:            []string{"zone1"},
+				SubnetProviderId:  "4",
+				ProviderNetworkId: "liars",
+				SubnetTag:         "subnet-192.168.4.0/24",
+				SpaceTag:          "space-foo-2",
+				VLANTag:           3,
+				Zones:             []string{"zone1"},
 			}},
 		})
 	})


### PR DESCRIPTION
## Description of change

The GCE provider reports the id of the network for subnets that it finds. This information is potentially useful (for example to distinguish between subnets with overlapping ranges that are actually on different networks), so we should keep track of it in the database and display it.

Includes a driveby fix to remove the embedded interfaces from the shims in `apiserver/networkingcommon` - they just masked possible errors with unimplemented interface methods.

## QA steps
Bootstrap a controller on GCE against a project with subnets (it needs to have more than just a legacy network). Run `juju subnets` - the name of the network should be reported (as `provider-network-id`) against each subnet.
