### PR TITLE
SLA term required error

### DIFF
--- a/cmd/juju/application/deploy.go
+++ b/cmd/juju/application/deploy.go
@@ -936,9 +936,8 @@ func (c *DeployCommand) charmStoreCharm() (deployFn, error) {
 		// Store the charm in the controller
 		curl, csMac, err := addCharmFromURL(apiRoot, storeCharmOrBundleURL, channel)
 		if err != nil {
-			if err1, ok := errors.Cause(err).(*termsRequiredError); ok {
-				terms := strings.Join(err1.Terms, " ")
-				return errors.Errorf(`Declined: please agree to the following terms %s. Try: "juju agree %s"`, terms, terms)
+			if termErr, ok := errors.Cause(err).(*common.TermsRequiredError); ok {
+				return errors.Trace(termErr.UserErr())
 			}
 			return errors.Annotatef(err, "storing charm for URL %q", storeCharmOrBundleURL)
 		}

--- a/cmd/juju/application/deploy_test.go
+++ b/cmd/juju/application/deploy_test.go
@@ -630,7 +630,7 @@ func (s *DeployCharmStoreSuite) TestDeployWithTermsNotSigned(c *gc.C) {
 	}
 	testcharms.UploadCharm(c, s.client, "quantal/terms1-1", "terms1")
 	_, err := runDeployCommand(c, "quantal/terms1")
-	expectedError := `Declined: please agree to the following terms term/1 term/2. Try: "juju agree term/1 term/2"`
+	expectedError := `Declined: some terms require agreement. Try: "juju agree term/1 term/2"`
 	c.Assert(err, gc.ErrorMatches, expectedError)
 }
 

--- a/cmd/juju/application/store.go
+++ b/cmd/juju/application/store.go
@@ -7,9 +7,7 @@
 package application
 
 import (
-	"fmt"
 	"net/url"
-	"strings"
 
 	"github.com/juju/errors"
 	"gopkg.in/juju/charm.v6-unstable"
@@ -19,33 +17,9 @@ import (
 	"gopkg.in/macaroon.v1"
 
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/cmd/juju/common"
 	"github.com/juju/juju/environs/config"
 )
-
-// maybeTermsAgreementError returns err as a *termsAgreementError
-// if it has a "terms agreement required" error code, otherwise
-// it returns err unchanged.
-func maybeTermsAgreementError(err error) error {
-	const code = "term agreement required"
-	e, ok := errors.Cause(err).(*httpbakery.DischargeError)
-	if !ok || e.Reason == nil || e.Reason.Code != code {
-		return err
-	}
-	magicMarker := code + ":"
-	index := strings.LastIndex(e.Reason.Message, magicMarker)
-	if index == -1 {
-		return err
-	}
-	return &termsRequiredError{strings.Fields(e.Reason.Message[index+len(magicMarker):])}
-}
-
-type termsRequiredError struct {
-	Terms []string
-}
-
-func (e *termsRequiredError) Error() string {
-	return fmt.Sprintf("please agree to terms %q", strings.Join(e.Terms, " "))
-}
 
 func isSeriesSupported(requestedSeries string, supportedSeries []string) bool {
 	for _, series := range supportedSeries {
@@ -118,7 +92,7 @@ func addCharmFromURL(client CharmAdder, curl *charm.URL, channel csparams.Channe
 		}
 		m, err := client.AuthorizeCharmstoreEntity(curl)
 		if err != nil {
-			return nil, nil, maybeTermsAgreementError(err)
+			return nil, nil, common.MaybeTermsAgreementError(err)
 		}
 		if err := client.AddCharmWithAuthorization(curl, channel, m); err != nil {
 			return nil, nil, errors.Trace(err)

--- a/cmd/juju/application/upgradecharm.go
+++ b/cmd/juju/application/upgradecharm.go
@@ -6,7 +6,6 @@ package application
 import (
 	"fmt"
 	"os"
-	"strings"
 
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
@@ -26,6 +25,7 @@ import (
 	"github.com/juju/juju/api/modelconfig"
 	"github.com/juju/juju/charmstore"
 	"github.com/juju/juju/cmd/juju/block"
+	"github.com/juju/juju/cmd/juju/common"
 	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/resource"
@@ -299,15 +299,8 @@ func (c *upgradeCharmCommand) Run(ctx *cmd.Context) error {
 	charmRepo := c.getCharmStore(bakeryClient, modelConfig)
 	chID, csMac, err := c.addCharm(charmAdder, charmRepo, modelConfig, oldURL, newRef)
 	if err != nil {
-		if termsErr, ok := errors.Cause(err).(*termsRequiredError); ok {
-			terms := strings.Join(termsErr.Terms, " ")
-			return errors.Wrap(
-				termsErr,
-				errors.Errorf(
-					`Declined: please agree to the following terms %s. Try: "juju agree %[1]s"`,
-					terms,
-				),
-			)
+		if termErr, ok := errors.Cause(err).(*common.TermsRequiredError); ok {
+			return errors.Trace(termErr.UserErr())
 		}
 		return block.ProcessBlockedError(err, block.BlockChange)
 	}

--- a/cmd/juju/application/upgradecharm_test.go
+++ b/cmd/juju/application/upgradecharm_test.go
@@ -664,7 +664,7 @@ func (s *UpgradeCharmCharmStoreStateSuite) TestUpgradeWithTermsNotSigned(c *gc.C
 		Message: "term agreement required: term/1 term/2",
 		Code:    "term agreement required",
 	}
-	expectedError := `Declined: please agree to the following terms term/1 term/2. Try: "juju agree term/1 term/2"`
+	expectedError := `Declined: some terms require agreement. Try: "juju agree term/1 term/2"`
 	err = runUpgradeCharm(c, "terms1")
 	c.Assert(err, gc.ErrorMatches, expectedError)
 }

--- a/cmd/juju/common/errors.go
+++ b/cmd/juju/common/errors.go
@@ -6,6 +6,10 @@ package common
 import (
 	"fmt"
 	"io"
+	"strings"
+
+	"github.com/juju/errors"
+	"gopkg.in/macaroon-bakery.v1/httpbakery"
 )
 
 func PermissionsMessage(writer io.Writer, command string) {
@@ -18,4 +22,39 @@ func PermissionsMessage(writer io.Writer, command string) {
 		command = "complete this operation"
 	}
 	fmt.Fprintf(writer, "\n%s\n%s\n\n", fmt.Sprintf(perm, command), grant)
+}
+
+// MaybeTermsAgreementError returns err as a *TermsAgreementError
+// if it has a "terms agreement required" error code, otherwise
+// it returns err unchanged.
+func MaybeTermsAgreementError(err error) error {
+	const code = "term agreement required"
+	e, ok := errors.Cause(err).(*httpbakery.DischargeError)
+	if !ok || e.Reason == nil || e.Reason.Code != code {
+		return err
+	}
+	magicMarker := code + ":"
+	index := strings.LastIndex(e.Reason.Message, magicMarker)
+	if index == -1 {
+		return err
+	}
+	return &TermsRequiredError{strings.Fields(e.Reason.Message[index+len(magicMarker):])}
+}
+
+// TermsRequiredError is an error returned when agreement to terms is required.
+type TermsRequiredError struct {
+	Terms []string
+}
+
+// Error implements error.
+func (e *TermsRequiredError) Error() string {
+	return fmt.Sprintf("please agree to terms %q", strings.Join(e.Terms, " "))
+}
+
+// UserErr returns an error containing a user-friendly message describing how
+// to agree to required terms.
+func (e *TermsRequiredError) UserErr() error {
+	terms := strings.Join(e.Terms, " ")
+	return errors.Wrap(e,
+		errors.Errorf(`Declined: some terms require agreement. Try: "juju agree %s"`, terms))
 }

--- a/cmd/juju/common/errors_test.go
+++ b/cmd/juju/common/errors_test.go
@@ -1,0 +1,72 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package common_test
+
+import (
+	"bytes"
+
+	"github.com/juju/errors"
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/macaroon-bakery.v1/httpbakery"
+
+	"github.com/juju/juju/cmd/juju/common"
+)
+
+type errorsSuite struct {
+	testing.IsolationSuite
+}
+
+var _ = gc.Suite(&errorsSuite{})
+
+func (s *errorsSuite) TestTermsRequiredPassThru(c *gc.C) {
+	err := errors.New("nothing about terms")
+	c.Assert(err, gc.Equals, common.MaybeTermsAgreementError(err))
+}
+
+func (s *errorsSuite) TestBakeryNonTerms(c *gc.C) {
+	err := &httpbakery.DischargeError{Reason: &httpbakery.Error{
+		Code: "bad cookie",
+	}}
+	c.Assert(err, gc.Equals, common.MaybeTermsAgreementError(err))
+	err = &httpbakery.DischargeError{Reason: &httpbakery.Error{
+		Code:    "term agreement required",
+		Message: "but terms not specified in message",
+	}}
+	c.Assert(err, gc.Equals, common.MaybeTermsAgreementError(err))
+}
+
+func (s *errorsSuite) TestSingleTermRequired(c *gc.C) {
+	err := &httpbakery.DischargeError{Reason: &httpbakery.Error{
+		Code:    "term agreement required",
+		Message: "term agreement required: foo/1",
+	}}
+	termErr, ok := common.MaybeTermsAgreementError(err).(*common.TermsRequiredError)
+	c.Assert(ok, jc.IsTrue, gc.Commentf("failed to match common.TermsRequiredError"))
+	c.Assert(termErr, gc.ErrorMatches, `.*please agree to terms "foo/1".*`)
+	c.Assert(termErr.UserErr(), gc.ErrorMatches,
+		`.*Declined: some terms require agreement. Try: "juju agree foo/1".*`)
+}
+
+func (s *errorsSuite) TestMultipleTermsRequired(c *gc.C) {
+	err := &httpbakery.DischargeError{Reason: &httpbakery.Error{
+		Code:    "term agreement required",
+		Message: "term agreement required: foo/1 bar/2",
+	}}
+	termErr, ok := common.MaybeTermsAgreementError(err).(*common.TermsRequiredError)
+	c.Assert(ok, jc.IsTrue, gc.Commentf("failed to match common.TermsRequiredError"))
+	c.Assert(termErr, gc.ErrorMatches, `.*please agree to terms "foo/1 bar/2".*`)
+	c.Assert(termErr.UserErr(), gc.ErrorMatches,
+		`.*Declined: some terms require agreement. Try: "juju agree foo/1 bar/2".*`)
+}
+
+func (s *errorsSuite) TestPermissionsMessage(c *gc.C) {
+	var buf bytes.Buffer
+	common.PermissionsMessage(&buf, "bork")
+	c.Assert(buf.String(), jc.Contains, `You do not have permission to bork.`)
+	buf.Reset()
+	common.PermissionsMessage(&buf, "")
+	c.Assert(buf.String(), jc.Contains, `You do not have permission to complete this operation.`)
+}

--- a/cmd/juju/romulus/sla/sla.go
+++ b/cmd/juju/romulus/sla/sla.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/juju/juju/api"
 	"github.com/juju/juju/api/modelconfig"
+	"github.com/juju/juju/cmd/juju/common"
 	"github.com/juju/juju/cmd/modelcmd"
 )
 
@@ -115,6 +116,10 @@ func (c *supportCommand) requestSupportCredentials(modelUUID string) ([]byte, er
 	}
 	m, err := authClient.Authorize(modelUUID, c.Level, c.Budget)
 	if err != nil {
+		err = common.MaybeTermsAgreementError(err)
+		if termErr, ok := errors.Cause(err).(*common.TermsRequiredError); ok {
+			return nil, errors.Trace(termErr.UserErr())
+		}
 		return nil, errors.Trace(err)
 	}
 	ms := macaroon.Slice{m}


### PR DESCRIPTION
## Description of change

> Why is this change needed?

The current error message displayed when agreement to SLA terms is terrible, something like:
`ERROR cannot get discharge from "http://10.232.205.30/terms": third party refused discharge: term agreement required:`

This change consolidates "term agreement required" error handling so that the error message is handled consistently across several commands including `juju sla`.

## QA steps

> How do we verify that the change works?

`juju sla essential` on a new model without having agreed to the required SLA terms would produce a nice error message:
`Declined: please agree to the following terms term/1. Try: "juju agree term/1"`

No regressions in this existing error message for other affected commands: `deploy`, `upgradecharm`.

Contact @cmars for assistance with setup issues for end-to-end testing.

## Documentation changes

> Does it affect current user workflow? CLI? API?

Not really. It only changes a new command.

## Bug reference

> Does this change fix a bug? Please add a link to it.

N/A