### PR TITLE
Add CLI and facade methods for offer ACLs

### DIFF
--- a/api/applicationoffers/access_test.go
+++ b/api/applicationoffers/access_test.go
@@ -1,0 +1,191 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package applicationoffers_test
+
+import (
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/names.v2"
+
+	"github.com/juju/juju/api/applicationoffers"
+	basetesting "github.com/juju/juju/api/base/testing"
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/testing"
+)
+
+type accessSuite struct {
+	testing.BaseSuite
+}
+
+type accessFunc func(string, string, ...string) error
+
+var _ = gc.Suite(&accessSuite{})
+
+const (
+	someOffer = "hosted-mysql"
+)
+
+func accessCall(client *applicationoffers.Client, action params.OfferAction, user, access string, offerURLs ...string) error {
+	switch action {
+	case params.GrantOfferAccess:
+		return client.GrantOffer(user, access, offerURLs...)
+	case params.RevokeOfferAccess:
+		return client.RevokeOffer(user, access, offerURLs...)
+	default:
+		panic(action)
+	}
+}
+
+func (s *accessSuite) TestGrantOfferReadOnlyUser(c *gc.C) {
+	s.readOnlyUser(c, params.GrantOfferAccess)
+}
+
+func (s *accessSuite) TestRevokeOfferReadOnlyUser(c *gc.C) {
+	s.readOnlyUser(c, params.RevokeOfferAccess)
+}
+
+func checkCall(c *gc.C, objType string, id, request string) {
+	c.Check(objType, gc.Equals, "ApplicationOffers")
+	c.Check(id, gc.Equals, "")
+	c.Check(request, gc.Equals, "ModifyOfferAccess")
+}
+
+func assertRequest(c *gc.C, a interface{}) params.ModifyOfferAccessRequest {
+	req, ok := a.(params.ModifyOfferAccessRequest)
+	c.Assert(ok, jc.IsTrue, gc.Commentf("wrong request type"))
+	return req
+}
+
+func assertResponse(c *gc.C, result interface{}) *params.ErrorResults {
+	resp, ok := result.(*params.ErrorResults)
+	c.Assert(ok, jc.IsTrue, gc.Commentf("wrong response type"))
+	return resp
+}
+
+func (s *accessSuite) readOnlyUser(c *gc.C, action params.OfferAction) {
+	apiCaller := basetesting.APICallerFunc(
+		func(objType string, version int, id, request string, a, result interface{}) error {
+			checkCall(c, objType, id, request)
+
+			req := assertRequest(c, a)
+			c.Assert(req.Changes, gc.HasLen, 1)
+			c.Assert(string(req.Changes[0].Action), gc.Equals, string(action))
+			c.Assert(string(req.Changes[0].Access), gc.Equals, string(params.OfferReadAccess))
+			c.Assert(req.Changes[0].OfferTag, gc.Equals, names.NewApplicationOfferTag(someOffer).String())
+
+			resp := assertResponse(c, result)
+			*resp = params.ErrorResults{Results: []params.ErrorResult{{Error: nil}}}
+
+			return nil
+		})
+	client := applicationoffers.NewClient(apiCaller)
+	err := accessCall(client, action, "bob", "read", someOffer)
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *accessSuite) TestGrantOfferAdminUser(c *gc.C) {
+	s.adminUser(c, params.GrantOfferAccess)
+}
+
+func (s *accessSuite) TestRevokeOfferAdminUser(c *gc.C) {
+	s.adminUser(c, params.RevokeOfferAccess)
+}
+
+func (s *accessSuite) adminUser(c *gc.C, action params.OfferAction) {
+	apiCaller := basetesting.APICallerFunc(
+		func(objType string, version int, id, request string, a, result interface{}) error {
+			checkCall(c, objType, id, request)
+
+			req := assertRequest(c, a)
+			c.Assert(req.Changes, gc.HasLen, 1)
+			c.Assert(string(req.Changes[0].Action), gc.Equals, string(action))
+			c.Assert(string(req.Changes[0].Access), gc.Equals, string(params.OfferConsumeAccess))
+			c.Assert(req.Changes[0].OfferTag, gc.Equals, names.NewApplicationOfferTag(someOffer).String())
+
+			resp := assertResponse(c, result)
+			*resp = params.ErrorResults{Results: []params.ErrorResult{{Error: nil}}}
+
+			return nil
+		})
+	client := applicationoffers.NewClient(apiCaller)
+	err := accessCall(client, action, "bob", "consume", someOffer)
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *accessSuite) TestGrantThreeOffers(c *gc.C) {
+	s.threeOffers(c, params.GrantOfferAccess)
+}
+
+func (s *accessSuite) TestRevokeThreeOffers(c *gc.C) {
+	s.threeOffers(c, params.RevokeOfferAccess)
+}
+
+func (s *accessSuite) threeOffers(c *gc.C, action params.OfferAction) {
+	apiCaller := basetesting.APICallerFunc(
+		func(objType string, version int, id, request string, a, result interface{}) error {
+			checkCall(c, objType, id, request)
+
+			req := assertRequest(c, a)
+			c.Assert(req.Changes, gc.HasLen, 3)
+			for i := range req.Changes {
+				c.Assert(string(req.Changes[i].Action), gc.Equals, string(action))
+				c.Assert(string(req.Changes[i].Access), gc.Equals, string(params.OfferReadAccess))
+				c.Assert(req.Changes[i].OfferTag, gc.Equals, names.NewApplicationOfferTag(someOffer).String())
+			}
+
+			resp := assertResponse(c, result)
+			*resp = params.ErrorResults{Results: []params.ErrorResult{{Error: nil}, {Error: nil}, {Error: nil}}}
+
+			return nil
+		})
+	client := applicationoffers.NewClient(apiCaller)
+	err := accessCall(client, action, "carol", "read", someOffer, someOffer, someOffer)
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *accessSuite) TestGrantErrorResult(c *gc.C) {
+	s.errorResult(c, params.GrantOfferAccess)
+}
+
+func (s *accessSuite) TestRevokeErrorResult(c *gc.C) {
+	s.errorResult(c, params.RevokeOfferAccess)
+}
+
+func (s *accessSuite) errorResult(c *gc.C, action params.OfferAction) {
+	apiCaller := basetesting.APICallerFunc(
+		func(objType string, version int, id, request string, a, result interface{}) error {
+			checkCall(c, objType, id, request)
+
+			req := assertRequest(c, a)
+			c.Assert(req.Changes, gc.HasLen, 1)
+			c.Assert(string(req.Changes[0].Action), gc.Equals, string(action))
+			c.Assert(req.Changes[0].UserTag, gc.Equals, names.NewUserTag("aaa").String())
+			c.Assert(req.Changes[0].OfferTag, gc.Equals, names.NewApplicationOfferTag(someOffer).String())
+
+			resp := assertResponse(c, result)
+			err := &params.Error{Message: "unfortunate mishap"}
+			*resp = params.ErrorResults{Results: []params.ErrorResult{{Error: err}}}
+
+			return nil
+		})
+	client := applicationoffers.NewClient(apiCaller)
+	err := accessCall(client, action, "aaa", "consume", someOffer)
+	c.Assert(err, gc.ErrorMatches, "unfortunate mishap")
+}
+
+func (s *accessSuite) TestInvalidResultCount(c *gc.C) {
+	apiCaller := basetesting.APICallerFunc(
+		func(objType string, version int, id, request string, a, result interface{}) error {
+			checkCall(c, objType, id, request)
+			assertRequest(c, a)
+
+			resp := assertResponse(c, result)
+			*resp = params.ErrorResults{Results: nil}
+
+			return nil
+		})
+	client := applicationoffers.NewClient(apiCaller)
+	err := client.GrantOffer("bob", "consume", someOffer, someOffer)
+	c.Assert(err, gc.ErrorMatches, "expected 2 results, got 0")
+}

--- a/apiserver/applicationoffers/access_test.go
+++ b/apiserver/applicationoffers/access_test.go
@@ -1,0 +1,357 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package applicationoffers_test
+
+import (
+	"regexp"
+
+	"github.com/juju/errors"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/names.v2"
+
+	"github.com/juju/juju/apiserver/applicationoffers"
+	"github.com/juju/juju/apiserver/params"
+	jujucrossmodel "github.com/juju/juju/core/crossmodel"
+	"github.com/juju/juju/permission"
+)
+
+type offerAccessSuite struct {
+	baseSuite
+	api *applicationoffers.OffersAPI
+}
+
+var _ = gc.Suite(&offerAccessSuite{})
+
+func (s *offerAccessSuite) SetUpTest(c *gc.C) {
+	s.baseSuite.SetUpTest(c)
+	s.authorizer.Tag = names.NewUserTag("admin")
+	s.applicationOffers = &mockApplicationOffers{}
+	getApplicationOffers := func(interface{}) jujucrossmodel.ApplicationOffers {
+		return s.applicationOffers
+	}
+
+	var err error
+	s.api, err = applicationoffers.CreateOffersAPI(
+		getApplicationOffers, s.mockState, s.mockStatePool, s.authorizer,
+	)
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *offerAccessSuite) modifyAccess(
+	c *gc.C, user names.UserTag,
+	action params.OfferAction,
+	access params.OfferAccessPermission,
+	offerTag names.ApplicationOfferTag,
+) error {
+	args := params.ModifyOfferAccessRequest{
+		Changes: []params.ModifyOfferAccess{{
+			UserTag:  user.String(),
+			Action:   action,
+			Access:   access,
+			OfferTag: offerTag.String(),
+		}}}
+
+	result, err := s.api.ModifyOfferAccess(args)
+	if err != nil {
+		return err
+	}
+	return result.OneError()
+}
+
+func (s *offerAccessSuite) grant(c *gc.C, user names.UserTag, access params.OfferAccessPermission, offer string) error {
+	return s.modifyAccess(c, user, params.GrantOfferAccess, access, names.NewApplicationOfferTag(offer))
+}
+
+func (s *offerAccessSuite) revoke(c *gc.C, user names.UserTag, access params.OfferAccessPermission, offer string) error {
+	return s.modifyAccess(c, user, params.RevokeOfferAccess, access, names.NewApplicationOfferTag(offer))
+}
+
+func (s *offerAccessSuite) TestGrantMissingUserFails(c *gc.C) {
+	s.mockState.applicationOffers["someoffer"] = jujucrossmodel.ApplicationOffer{}
+
+	user := names.NewUserTag("foobar")
+	err := s.grant(c, user, params.OfferReadAccess, "someoffer")
+	expectedErr := `could not grant offer access: user "foobar" not found`
+	c.Assert(err, gc.ErrorMatches, expectedErr)
+}
+
+func (s *offerAccessSuite) TestGrantMissingOfferFails(c *gc.C) {
+	user := names.NewUserTag("foobar")
+	err := s.grant(c, user, params.OfferReadAccess, "someoffer")
+	expectedErr := `.*application offer "someoffer" not found`
+	c.Assert(err, gc.ErrorMatches, expectedErr)
+}
+
+func (s *offerAccessSuite) TestRevokeAdminLeavesReadAccess(c *gc.C) {
+	s.mockState.applicationOffers["someoffer"] = jujucrossmodel.ApplicationOffer{}
+
+	user := names.NewUserTag("foobar")
+	offer := names.NewApplicationOfferTag("someoffer")
+	s.mockState.SetUserAccess(user, offer, permission.ConsumeAccess)
+
+	err := s.revoke(c, user, params.OfferConsumeAccess, "someoffer")
+	c.Assert(err, gc.IsNil)
+
+	offerUser, err := s.mockState.UserAccess(user, offer)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(offerUser.Access, gc.Equals, permission.ReadAccess)
+}
+
+func (s *offerAccessSuite) TestRevokeReadRemovesModelUser(c *gc.C) {
+	s.mockState.applicationOffers["someoffer"] = jujucrossmodel.ApplicationOffer{}
+	s.mockState.users.Add("foobar")
+
+	user := names.NewUserTag("foobar")
+	offer := names.NewApplicationOfferTag("someoffer")
+	s.mockState.SetUserAccess(user, offer, permission.ConsumeAccess)
+
+	err := s.revoke(c, user, params.OfferReadAccess, "someoffer")
+	c.Assert(err, gc.IsNil)
+
+	_, err = s.mockState.UserAccess(user, offer)
+	c.Assert(errors.IsNotFound(err), jc.IsTrue)
+}
+
+func (s *offerAccessSuite) TestRevokeModelMissingUser(c *gc.C) {
+	s.mockState.applicationOffers["someoffer"] = jujucrossmodel.ApplicationOffer{}
+
+	user := names.NewUserTag("bob")
+	err := s.revoke(c, user, params.OfferReadAccess, "someoffer")
+	c.Assert(err, gc.ErrorMatches, `could not revoke offer access: offer user "bob" does not exist`)
+
+	offer := names.NewApplicationOfferTag("someoffer")
+	_, err = s.mockState.UserAccess(user, offer)
+	c.Assert(errors.IsNotFound(err), jc.IsTrue)
+}
+
+func (s *offerAccessSuite) TestGrantOnlyGreaterAccess(c *gc.C) {
+	s.mockState.applicationOffers["someoffer"] = jujucrossmodel.ApplicationOffer{}
+	s.mockState.users.Add("foobar")
+
+	user := names.NewUserTag("foobar")
+	err := s.grant(c, user, params.OfferReadAccess, "someoffer")
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = s.grant(c, user, params.OfferReadAccess, "someoffer")
+	c.Assert(err, gc.ErrorMatches, `user already has "read" access or greater`)
+}
+
+func (s *offerAccessSuite) assertNewUser(c *gc.C, offerUser permission.UserAccess, userTag, creatorTag names.UserTag) {
+	c.Assert(offerUser.UserTag, gc.Equals, userTag)
+	c.Assert(offerUser.CreatedBy, gc.Equals, creatorTag)
+}
+
+func (s *offerAccessSuite) assertGrantOfferAddUser(c *gc.C, user names.UserTag) {
+	s.mockState.applicationOffers["someoffer"] = jujucrossmodel.ApplicationOffer{}
+	s.mockState.users.Add("other")
+	s.mockState.users.Add(user.Name())
+
+	apiUser := names.NewUserTag("superuser-bob")
+	s.authorizer.Tag = apiUser
+
+	err := s.grant(c, user, params.OfferReadAccess, "someoffer")
+	c.Assert(err, jc.ErrorIsNil)
+
+	offer := names.NewApplicationOfferTag("someoffer")
+	offerUser, err := s.api.Backend.UserAccess(user, offer)
+	c.Assert(err, jc.ErrorIsNil)
+	s.assertNewUser(c, offerUser, user, apiUser)
+	c.Assert(offerUser.Access, gc.Equals, permission.ReadAccess)
+}
+
+func (s *offerAccessSuite) TestGrantOfferAddLocalUser(c *gc.C) {
+	s.assertGrantOfferAddUser(c, names.NewLocalUserTag("bob"))
+}
+
+func (s *offerAccessSuite) TestGrantOfferAddRemoteUser(c *gc.C) {
+	s.assertGrantOfferAddUser(c, names.NewUserTag("bob@remote"))
+}
+
+func (s *offerAccessSuite) TestGrantOfferSuperUser(c *gc.C) {
+	s.mockState.applicationOffers["someoffer"] = jujucrossmodel.ApplicationOffer{}
+	s.mockState.users.Add("other")
+
+	user := names.NewUserTag("superuser-bob")
+	s.authorizer.Tag = user
+
+	other := names.NewUserTag("other")
+	err := s.grant(c, other, params.OfferReadAccess, "someoffer")
+	c.Assert(err, jc.ErrorIsNil)
+
+	offer := names.NewApplicationOfferTag("someoffer")
+	offerUser, err := s.mockState.UserAccess(other, offer)
+	c.Assert(err, jc.ErrorIsNil)
+	s.assertNewUser(c, offerUser, other, user)
+	c.Assert(offerUser.Access, gc.Equals, permission.ReadAccess)
+}
+
+func (s *offerAccessSuite) TestGrantModelIncreaseAccess(c *gc.C) {
+	s.mockState.applicationOffers["someoffer"] = jujucrossmodel.ApplicationOffer{}
+	s.mockState.users.Add("other")
+
+	user := names.NewUserTag("other")
+	s.authorizer.Tag = user
+	s.authorizer.AdminTag = user
+
+	offer := names.NewApplicationOfferTag("someoffer")
+	s.mockState.SetUserAccess(user, offer, permission.ReadAccess)
+
+	err := s.grant(c, user, params.OfferConsumeAccess, offer.Name)
+	c.Assert(err, jc.ErrorIsNil)
+
+	offerUser, err := s.mockState.UserAccess(user, offer)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(offerUser.Access, gc.Equals, permission.ConsumeAccess)
+}
+
+func (s *offerAccessSuite) TestGrantToOfferNoAccess(c *gc.C) {
+	s.mockState.applicationOffers["someoffer"] = jujucrossmodel.ApplicationOffer{}
+	s.mockState.users.Add("other")
+
+	user := names.NewUserTag("bob@remote")
+	s.authorizer.Tag = user
+
+	other := names.NewUserTag("other@remote")
+	err := s.grant(c, other, params.OfferReadAccess, "someoffer")
+	c.Assert(err, gc.ErrorMatches, "permission denied")
+}
+
+func (s *offerAccessSuite) assertGrantToOffer(c *gc.C, userAccess permission.Access) {
+	s.mockState.applicationOffers["someoffer"] = jujucrossmodel.ApplicationOffer{}
+	s.mockState.users.Add("other")
+
+	user := names.NewUserTag("bob@remote")
+	s.authorizer.Tag = user
+
+	offer := names.NewApplicationOfferTag("someoffer")
+	s.mockState.SetUserAccess(user, offer, userAccess)
+
+	other := names.NewUserTag("other@remote")
+	err := s.grant(c, other, params.OfferReadAccess, "someoffer")
+	c.Assert(err, gc.ErrorMatches, "permission denied")
+}
+
+func (s *offerAccessSuite) TestGrantToOfferReadAccess(c *gc.C) {
+	s.assertGrantToOffer(c, permission.ReadAccess)
+}
+
+func (s *offerAccessSuite) TestGrantToOfferConsumeAccess(c *gc.C) {
+	s.assertGrantToOffer(c, permission.ConsumeAccess)
+}
+
+func (s *offerAccessSuite) TestGrantToOfferAdminAccess(c *gc.C) {
+	s.mockState.applicationOffers["someoffer"] = jujucrossmodel.ApplicationOffer{}
+	s.mockState.users.Add("other")
+
+	user := names.NewUserTag("foobar")
+	s.authorizer.Tag = user
+	s.authorizer.AdminTag = user
+	offer := names.NewApplicationOfferTag("someoffer")
+	s.mockState.SetUserAccess(user, offer, permission.AdminAccess)
+
+	other := names.NewUserTag("other")
+	err := s.grant(c, other, params.OfferReadAccess, "someoffer")
+	c.Assert(err, jc.ErrorIsNil)
+
+	offerUser, err := s.mockState.UserAccess(other, offer)
+	c.Assert(err, jc.ErrorIsNil)
+	s.assertNewUser(c, offerUser, other, user)
+	c.Assert(offerUser.Access, gc.Equals, permission.ReadAccess)
+}
+
+func (s *offerAccessSuite) TestGrantOfferInvalidUserTag(c *gc.C) {
+	for _, testParam := range []struct {
+		tag      string
+		validTag bool
+	}{{
+		tag:      "unit-foo/0",
+		validTag: true,
+	}, {
+		tag:      "application-foo",
+		validTag: true,
+	}, {
+		tag:      "relation-wordpress:db mysql:db",
+		validTag: true,
+	}, {
+		tag:      "machine-0",
+		validTag: true,
+	}, {
+		tag:      "user",
+		validTag: false,
+	}, {
+		tag:      "user-Mua^h^h^h^arh",
+		validTag: true,
+	}, {
+		tag:      "user@",
+		validTag: false,
+	}, {
+		tag:      "user@ubuntuone",
+		validTag: false,
+	}, {
+		tag:      "user@ubuntuone",
+		validTag: false,
+	}, {
+		tag:      "@ubuntuone",
+		validTag: false,
+	}, {
+		tag:      "in^valid.",
+		validTag: false,
+	}, {
+		tag:      "",
+		validTag: false,
+	},
+	} {
+		var expectedErr string
+		errPart := `could not modify offer access: "` + regexp.QuoteMeta(testParam.tag) + `" is not a valid `
+
+		if testParam.validTag {
+			// The string is a valid tag, but not a user tag.
+			expectedErr = errPart + `user tag`
+		} else {
+			// The string is not a valid tag of any kind.
+			expectedErr = errPart + `tag`
+		}
+
+		args := params.ModifyOfferAccessRequest{
+			Changes: []params.ModifyOfferAccess{{
+				UserTag:  testParam.tag,
+				Action:   params.GrantOfferAccess,
+				Access:   params.OfferReadAccess,
+				OfferTag: names.NewApplicationOfferTag("someoffer").String(),
+			}}}
+
+		result, err := s.api.ModifyOfferAccess(args)
+		c.Assert(err, jc.ErrorIsNil)
+		c.Assert(result.OneError(), gc.ErrorMatches, expectedErr)
+	}
+}
+
+func (s *offerAccessSuite) TestModifyOfferAccessEmptyArgs(c *gc.C) {
+	args := params.ModifyOfferAccessRequest{Changes: []params.ModifyOfferAccess{{}}}
+
+	result, err := s.api.ModifyOfferAccess(args)
+	c.Assert(err, jc.ErrorIsNil)
+	expectedErr := `could not modify offer access: "" offer access not valid`
+	c.Assert(result.OneError(), gc.ErrorMatches, expectedErr)
+}
+
+func (s *offerAccessSuite) TestModifyOfferAccessInvalidAction(c *gc.C) {
+	s.mockState.applicationOffers["someoffer"] = jujucrossmodel.ApplicationOffer{}
+
+	offer := names.NewApplicationOfferTag("someoffer")
+	var dance params.OfferAction = "dance"
+	args := params.ModifyOfferAccessRequest{
+		Changes: []params.ModifyOfferAccess{{
+			UserTag:  "user-user",
+			Action:   dance,
+			Access:   params.OfferReadAccess,
+			OfferTag: offer.String(),
+		}}}
+
+	result, err := s.api.ModifyOfferAccess(args)
+	c.Assert(err, jc.ErrorIsNil)
+	expectedErr := `unknown action "dance"`
+	c.Assert(result.OneError(), gc.ErrorMatches, expectedErr)
+}

--- a/apiserver/applicationoffers/applicationoffers.go
+++ b/apiserver/applicationoffers/applicationoffers.go
@@ -5,6 +5,8 @@ package applicationoffers
 
 import (
 	"github.com/juju/errors"
+	"github.com/juju/txn"
+	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/common/crossmodelcommon"
@@ -12,6 +14,7 @@ import (
 	"github.com/juju/juju/apiserver/params"
 	jujucrossmodel "github.com/juju/juju/core/crossmodel"
 	"github.com/juju/juju/permission"
+	"github.com/juju/juju/state"
 )
 
 // OffersAPI implements the cross model interface and is the concrete
@@ -104,4 +107,132 @@ func (api *OffersAPI) ListApplicationOffers(filters params.OfferFilters) (params
 	}
 	result.Results = offers
 	return result, nil
+}
+
+// ModifyOfferAccess changes the application offer access granted to users.
+func (api *OffersAPI) ModifyOfferAccess(args params.ModifyOfferAccessRequest) (result params.ErrorResults, _ error) {
+	result = params.ErrorResults{
+		Results: make([]params.ErrorResult, len(args.Changes)),
+	}
+	if len(args.Changes) == 0 {
+		return result, nil
+	}
+
+	// We know we have a user.
+	apiUser, _ := api.Authorizer.GetAuthTag().(names.UserTag)
+
+	canModifyController, err := api.Authorizer.HasPermission(permission.SuperuserAccess, api.Backend.ControllerTag())
+	if err != nil {
+		return result, errors.Trace(err)
+	}
+	canModifyModel, err := api.Authorizer.HasPermission(permission.AdminAccess, api.Backend.ModelTag())
+	if err != nil {
+		return result, errors.Trace(err)
+	}
+	isAdmin := canModifyController || canModifyModel
+
+	for i, arg := range args.Changes {
+		result.Results[i].Error = common.ServerError(api.modifyOneOfferAccess(apiUser, isAdmin, arg))
+	}
+	return result, nil
+}
+
+func (api *OffersAPI) modifyOneOfferAccess(apiUser names.UserTag, isAdmin bool, arg params.ModifyOfferAccess) error {
+	offerAccess := permission.Access(arg.Access)
+	if err := permission.ValidateOfferAccess(offerAccess); err != nil {
+		return errors.Annotate(err, "could not modify offer access")
+	}
+
+	offerTag, err := names.ParseApplicationOfferTag(arg.OfferTag)
+	if err != nil {
+		return errors.Annotate(err, "could not modify offer access")
+	}
+	canModifyOffer, err := api.Authorizer.HasPermission(permission.AdminAccess, offerTag)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	canModify := isAdmin || canModifyOffer
+	if !canModify {
+		return common.ErrPerm
+	}
+
+	targetUserTag, err := names.ParseUserTag(arg.UserTag)
+	if err != nil {
+		return errors.Annotate(err, "could not modify offer access")
+	}
+	return api.changeOfferAccess(offerTag, apiUser, targetUserTag, arg.Action, offerAccess)
+}
+
+// changeOfferAccess performs the requested access grant or revoke action for the
+// specified user on the specified application offer.
+func (api *OffersAPI) changeOfferAccess(
+	offerTag names.ApplicationOfferTag,
+	apiUser, targetUserTag names.UserTag,
+	action params.OfferAction,
+	access permission.Access,
+) error {
+	_, err := api.Backend.ApplicationOffer(offerTag.Name)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	switch action {
+	case params.GrantOfferAccess:
+		return api.grantOfferAccess(offerTag, targetUserTag, apiUser, access)
+	case params.RevokeOfferAccess:
+		return api.revokeOfferAccess(offerTag, targetUserTag, apiUser, access)
+	default:
+		return errors.Errorf("unknown action %q", action)
+	}
+}
+
+func (api *OffersAPI) grantOfferAccess(offerTag names.ApplicationOfferTag, targetUserTag, apiUser names.UserTag, access permission.Access) error {
+	_, err := api.Backend.AddOfferUser(state.UserAccessSpec{User: targetUserTag, CreatedBy: apiUser, Access: access}, offerTag)
+	if errors.IsAlreadyExists(err) {
+		offerUser, err := api.Backend.UserAccess(targetUserTag, offerTag)
+		if errors.IsNotFound(err) {
+			// Conflicts with prior check, must be inconsistent state.
+			err = txn.ErrExcessiveContention
+		}
+		if err != nil {
+			return errors.Annotate(err, "could not look up offer access for user")
+		}
+
+		// Only set access if greater access is being granted.
+		if offerUser.Access.EqualOrGreaterOfferAccessThan(access) {
+			return errors.Errorf("user already has %q access or greater", access)
+		}
+		if _, err = api.Backend.SetUserAccess(offerUser.UserTag, offerUser.Object, access); err != nil {
+			return errors.Annotate(err, "could not set offer access for user")
+		}
+		return nil
+	}
+	return errors.Annotate(err, "could not grant offer access")
+}
+
+func (api *OffersAPI) revokeOfferAccess(offerTag names.ApplicationOfferTag, targetUserTag, apiUser names.UserTag, access permission.Access) error {
+	switch access {
+	case permission.ReadAccess:
+		// Revoking read access removes all access.
+		err := api.Backend.RemoveUserAccess(targetUserTag, offerTag)
+		return errors.Annotate(err, "could not revoke offer access")
+	case permission.ConsumeAccess:
+		// Revoking consume access sets read-only.
+		offerUser, err := api.Backend.UserAccess(targetUserTag, offerTag)
+		if err != nil {
+			return errors.Annotate(err, "could not look up offer access for user")
+		}
+		_, err = api.Backend.SetUserAccess(offerUser.UserTag, offerUser.Object, permission.ReadAccess)
+		return errors.Annotate(err, "could not set offer access to read-only")
+	case permission.AdminAccess:
+		// Revoking admin access sets read-consume.
+		modelUser, err := api.Backend.UserAccess(targetUserTag, offerTag)
+		if err != nil {
+			return errors.Annotate(err, "could not look up offer access for user")
+		}
+		_, err = api.Backend.SetUserAccess(modelUser.UserTag, modelUser.Object, permission.ConsumeAccess)
+		return errors.Annotate(err, "could not set offer access to read-consume")
+
+	default:
+		return errors.Errorf("don't know how to revoke %q access", access)
+	}
 }

--- a/apiserver/applicationoffers/base_test.go
+++ b/apiserver/applicationoffers/base_test.go
@@ -5,6 +5,7 @@ package applicationoffers_test
 
 import (
 	jc "github.com/juju/testing/checkers"
+	"github.com/juju/utils/set"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/charm.v6-unstable"
 	"gopkg.in/juju/names.v2"
@@ -36,7 +37,12 @@ func (s *baseSuite) SetUpTest(c *gc.C) {
 		AdminTag: names.NewUserTag("admin"),
 	}
 
-	s.mockState = &mockState{modelUUID: "uuid"}
+	s.mockState = &mockState{
+		modelUUID:         "uuid",
+		users:             set.NewStrings(),
+		applicationOffers: make(map[string]jujucrossmodel.ApplicationOffer),
+		accessPerms:       make(map[accessEntity]accessRecord),
+	}
 	s.mockStatePool = &mockStatePool{map[string]crossmodelcommon.Backend{s.mockState.modelUUID: s.mockState}}
 }
 

--- a/apiserver/params/crossmodel.go
+++ b/apiserver/params/crossmodel.go
@@ -381,3 +381,35 @@ type IngressSubnetResult struct {
 type IngressSubnetResults struct {
 	Results []IngressSubnetResult `json:"results"`
 }
+
+// ModifyModelAccessRequest holds the parameters for making grant and revoke offer calls.
+type ModifyOfferAccessRequest struct {
+	Changes []ModifyOfferAccess `json:"changes"`
+}
+
+// ModifyOfferAccess contains parameters to grant and revoke access to an offer.
+type ModifyOfferAccess struct {
+	UserTag  string                `json:"user-tag"`
+	Action   OfferAction           `json:"action"`
+	Access   OfferAccessPermission `json:"access"`
+	OfferTag string                `json:"offer-tag"`
+}
+
+// OfferAction is an action that can be performed on an offer.
+type OfferAction string
+
+// Actions that can be preformed on an offer.
+const (
+	GrantOfferAccess  OfferAction = "grant"
+	RevokeOfferAccess OfferAction = "revoke"
+)
+
+// OfferAccessPermission defines a type for an access permission on an offer.
+type OfferAccessPermission string
+
+// Access permissions that may be set on an offer.
+const (
+	OfferAdminAccess   OfferAccessPermission = "admin"
+	OfferConsumeAccess OfferAccessPermission = "consume"
+	OfferReadAccess    OfferAccessPermission = "read"
+)

--- a/cmd/juju/model/export_test.go
+++ b/cmd/juju/model/export_test.go
@@ -93,18 +93,20 @@ type RevokeCommand struct {
 }
 
 // NewGrantCommandForTest returns a GrantCommand with the api provided as specified.
-func NewGrantCommandForTest(api GrantModelAPI, store jujuclient.ClientStore) (cmd.Command, *GrantCommand) {
+func NewGrantCommandForTest(modelsApi GrantModelAPI, offersAPI GrantOfferAPI, store jujuclient.ClientStore) (cmd.Command, *GrantCommand) {
 	cmd := &grantCommand{
-		api: api,
+		modelsApi: modelsApi,
+		offersApi: offersAPI,
 	}
 	cmd.SetClientStore(store)
 	return modelcmd.WrapController(cmd), &GrantCommand{cmd}
 }
 
 // NewRevokeCommandForTest returns an revokeCommand with the api provided as specified.
-func NewRevokeCommandForTest(api RevokeModelAPI, store jujuclient.ClientStore) (cmd.Command, *RevokeCommand) {
+func NewRevokeCommandForTest(modelsApi RevokeModelAPI, offersAPI RevokeOfferAPI, store jujuclient.ClientStore) (cmd.Command, *RevokeCommand) {
 	cmd := &revokeCommand{
-		api: api,
+		modelsApi: modelsApi,
+		offersApi: offersAPI,
 	}
 	cmd.SetClientStore(store)
 	return modelcmd.WrapController(cmd), &RevokeCommand{cmd}

--- a/cmd/juju/model/grantrevoke.go
+++ b/cmd/juju/model/grantrevoke.go
@@ -6,14 +6,18 @@ package model
 import (
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
+	"gopkg.in/juju/names.v2"
 
+	"github.com/juju/juju/api/applicationoffers"
 	"github.com/juju/juju/cmd/juju/block"
 	"github.com/juju/juju/cmd/modelcmd"
+	"github.com/juju/juju/core/crossmodel"
+	"github.com/juju/juju/jujuclient"
 	"github.com/juju/juju/permission"
 )
 
 var usageGrantSummary = `
-Grants access level to a Juju user for a model or controller.`[1:]
+Grants access level to a Juju user for a model, controller, or aplication offer.`[1:]
 
 var usageGrantDetails = `
 By default, the controller is the current controller.
@@ -31,6 +35,11 @@ Valid access levels for controllers are:
     add-model
     superuser
 
+Valid access levels for application offers are:
+    read
+    consume
+    admin
+
 Examples:
 Grant user 'joe' 'read' access to model 'mymodel':
 
@@ -47,6 +56,18 @@ Grant user 'sam' 'read' access to models 'model1' and 'model2':
 Grant user 'maria' 'add-model' access to the controller:
 
     juju grant maria add-model
+
+Grant user 'joe' 'read' access to application offer 'fred/prod.hosted-mysql':
+
+    juju grant joe read fred/prod.hosted-mysql
+
+Grant user 'jim' 'consume' access to application offer 'fred/prod.hosted-mysql':
+
+    juju grant jim consume fred/prod.hosted-mysql
+
+Grant user 'sam' 'read' access to application offers 'fred/prod.hosted-mysql' and 'mary/test.hosted-mysql':
+
+    juju grant sam read fred/prod.hosted-mysql mary/test.hosted-mysql
 
 See also: 
     revoke
@@ -75,6 +96,14 @@ Revoke 'add-model' access from user 'maria' to the controller:
 
     juju revoke maria add-model
 
+Revoke 'read' (and 'write') access from user 'joe' for application offer 'fred/prod.hosted-mysql':
+
+    juju revoke joe read fred/prod.hosted-mysql
+
+Revoke 'consume' access from user 'sam' for models 'fred/prod.hosted-mysql' and 'mary/test.hosted-mysql':
+
+    juju revoke sam consume fred/prod.hosted-mysql mary/test.hosted-mysql
+
 See also: 
     grant`[1:]
 
@@ -83,6 +112,7 @@ type accessCommand struct {
 
 	User       string
 	ModelNames []string
+	OfferURLs  []*crossmodel.ApplicationURL
 	Access     string
 }
 
@@ -97,19 +127,40 @@ func (c *accessCommand) Init(args []string) error {
 	}
 
 	c.User = args[0]
-	c.ModelNames = args[2:]
 	c.Access = args[1]
+
+	// The remaining args are either model names or offer names.
+	for _, arg := range args[2:] {
+		if names.IsValidModelName(arg) {
+			c.ModelNames = append(c.ModelNames, arg)
+		} else {
+			url, err := crossmodel.ParseApplicationURL(arg)
+			if err != nil {
+				return err
+			}
+			c.OfferURLs = append(c.OfferURLs, url)
+		}
+	}
+	if len(c.ModelNames) > 0 && len(c.OfferURLs) > 0 {
+		return errors.New("either specify model names or offer URLs but not both")
+	}
+
 	// Special case for backwards compatibility.
 	if c.Access == "addmodel" {
 		c.Access = "add-model"
 	}
-	if len(c.ModelNames) > 0 {
+	if len(c.ModelNames) > 0 || len(c.OfferURLs) > 0 {
 		if err := permission.ValidateControllerAccess(permission.Access(c.Access)); err == nil {
 			return errors.Errorf("You have specified a controller access permission %q.\n"+
-				"If you intended to change controller access, do not specify any model names.\n"+
+				"If you intended to change controller access, do not specify any model names or offer URLs.\n"+
 				"See 'juju help grant'.", c.Access)
 		}
+	}
+	if len(c.ModelNames) > 0 {
 		return permission.ValidateModelAccess(permission.Access(c.Access))
+	}
+	if len(c.OfferURLs) > 0 {
+		return permission.ValidateOfferAccess(permission.Access(c.Access))
 	}
 	if err := permission.ValidateModelAccess(permission.Access(c.Access)); err == nil {
 		return errors.Errorf("You have specified a model access permission %q.\n"+
@@ -127,28 +178,40 @@ func NewGrantCommand() cmd.Command {
 // grantCommand represents the command to grant a user access to one or more models.
 type grantCommand struct {
 	accessCommand
-	api GrantModelAPI
+	modelsApi GrantModelAPI
+	offersApi GrantOfferAPI
 }
 
 // Info implements Command.Info.
 func (c *grantCommand) Info() *cmd.Info {
 	return &cmd.Info{
 		Name:    "grant",
-		Args:    "<user name> <permission> [<model name> ...]",
+		Args:    "<user name> <permission> [<model name> ... | <offer url> ...]",
 		Purpose: usageGrantSummary,
 		Doc:     usageGrantDetails,
 	}
 }
 
 func (c *grantCommand) getModelAPI() (GrantModelAPI, error) {
-	if c.api != nil {
-		return c.api, nil
+	if c.modelsApi != nil {
+		return c.modelsApi, nil
 	}
 	return c.NewModelManagerAPIClient()
 }
 
 func (c *grantCommand) getControllerAPI() (GrantControllerAPI, error) {
 	return c.NewControllerAPIClient()
+}
+
+func (c *grantCommand) getOfferAPI(modelName string) (GrantOfferAPI, error) {
+	if c.offersApi != nil {
+		return c.offersApi, nil
+	}
+	root, err := c.NewModelAPIRoot(modelName)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return applicationoffers.NewClient(root), nil
 }
 
 // GrantModelAPI defines the API functions used by the grant command.
@@ -163,10 +226,19 @@ type GrantControllerAPI interface {
 	GrantController(user, access string) error
 }
 
+// GrantOfferAPI defines the API functions used by the grant command.
+type GrantOfferAPI interface {
+	Close() error
+	GrantOffer(user, access string, offers ...string) error
+}
+
 // Run implements cmd.Command.
 func (c *grantCommand) Run(ctx *cmd.Context) error {
 	if len(c.ModelNames) > 0 {
 		return c.runForModel()
+	}
+	if len(c.OfferURLs) > 0 {
+		return c.runForOffers()
 	}
 	return c.runForController()
 }
@@ -195,6 +267,24 @@ func (c *grantCommand) runForModel() error {
 	return block.ProcessBlockedError(client.GrantModel(c.User, c.Access, models...), block.BlockChange)
 }
 
+func (c *grantCommand) runForOffers() error {
+	// For each model, process the grants.
+	offersForModel := offersForModel(c.OfferURLs)
+	for model, urls := range offersForModel {
+		client, err := c.getOfferAPI(model)
+		if err != nil {
+			return err
+		}
+		defer client.Close()
+
+		err = client.GrantOffer(c.User, c.Access, urls...)
+		if err != nil {
+			return block.ProcessBlockedError(err, block.BlockChange)
+		}
+	}
+	return nil
+}
+
 // NewRevokeCommand returns a new revoke command.
 func NewRevokeCommand() cmd.Command {
 	return modelcmd.WrapController(&revokeCommand{})
@@ -203,7 +293,8 @@ func NewRevokeCommand() cmd.Command {
 // revokeCommand revokes a user's access to models.
 type revokeCommand struct {
 	accessCommand
-	api RevokeModelAPI
+	modelsApi RevokeModelAPI
+	offersApi RevokeOfferAPI
 }
 
 // Info implements cmd.Command.
@@ -217,14 +308,25 @@ func (c *revokeCommand) Info() *cmd.Info {
 }
 
 func (c *revokeCommand) getModelAPI() (RevokeModelAPI, error) {
-	if c.api != nil {
-		return c.api, nil
+	if c.modelsApi != nil {
+		return c.modelsApi, nil
 	}
 	return c.NewModelManagerAPIClient()
 }
 
 func (c *revokeCommand) getControllerAPI() (RevokeControllerAPI, error) {
 	return c.NewControllerAPIClient()
+}
+
+func (c *revokeCommand) getOfferAPI(modelName string) (RevokeOfferAPI, error) {
+	if c.offersApi != nil {
+		return c.offersApi, nil
+	}
+	root, err := c.NewModelAPIRoot(modelName)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return applicationoffers.NewClient(root), nil
 }
 
 // RevokeModelAPI defines the API functions used by the revoke command.
@@ -239,10 +341,19 @@ type RevokeControllerAPI interface {
 	RevokeController(user, access string) error
 }
 
+// RevokeOfferAPI defines the API functions used by the revoke command.
+type RevokeOfferAPI interface {
+	Close() error
+	RevokeOffer(user, access string, offers ...string) error
+}
+
 // Run implements cmd.Command.
 func (c *revokeCommand) Run(ctx *cmd.Context) error {
 	if len(c.ModelNames) > 0 {
 		return c.runForModel()
+	}
+	if len(c.OfferURLs) > 0 {
+		return c.runForOffers()
 	}
 	return c.runForController()
 }
@@ -269,4 +380,34 @@ func (c *revokeCommand) runForModel() error {
 		return err
 	}
 	return block.ProcessBlockedError(client.RevokeModel(c.User, c.Access, models...), block.BlockChange)
+}
+
+// offersForModel group the offer URLs per model.
+func offersForModel(offerURLs []*crossmodel.ApplicationURL) map[string][]string {
+	offersForModel := make(map[string][]string)
+	for _, url := range offerURLs {
+		fullName := jujuclient.JoinOwnerModelName(names.NewUserTag(url.User), url.ModelName)
+		offers := offersForModel[fullName]
+		offers = append(offers, url.ApplicationName)
+		offersForModel[fullName] = offers
+	}
+	return offersForModel
+}
+
+func (c *revokeCommand) runForOffers() error {
+	// For each model, process the grant.
+	offersForModel := offersForModel(c.OfferURLs)
+	for model, urls := range offersForModel {
+		client, err := c.getOfferAPI(model)
+		if err != nil {
+			return err
+		}
+		defer client.Close()
+
+		err = client.RevokeOffer(c.User, c.Access, urls...)
+		if err != nil {
+			return block.ProcessBlockedError(err, block.BlockChange)
+		}
+	}
+	return nil
 }

--- a/cmd/juju/model/grantrevoke_test.go
+++ b/cmd/juju/model/grantrevoke_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/cmd/juju/model"
 	"github.com/juju/juju/core/crossmodel"
+	"github.com/juju/juju/feature"
 	"github.com/juju/juju/jujuclient"
 	"github.com/juju/juju/jujuclient/jujuclienttesting"
 	"github.com/juju/juju/testing"
@@ -35,6 +36,7 @@ const (
 )
 
 func (s *grantRevokeSuite) SetUpTest(c *gc.C) {
+	s.SetInitialFeatureFlags(feature.CrossModelRelations)
 	s.FakeJujuXDGDataHomeSuite.SetUpTest(c)
 	s.fakeModelAPI = &fakeModelGrantRevokeAPI{}
 	s.fakeOffersAPI = &fakeOffersGrantRevokeAPI{}

--- a/core/crossmodel/interface.go
+++ b/core/crossmodel/interface.go
@@ -98,6 +98,9 @@ type ApplicationOffers interface {
 	// UpdateOffer replaces an existing offer at the same URL.
 	UpdateOffer(offer AddApplicationOfferArgs) (*ApplicationOffer, error)
 
+	// ApplicationOffer returns the named application offer.
+	ApplicationOffer(offerName string) (*ApplicationOffer, error)
+
 	// ListOffers returns the offers satisfying the specified filter.
 	ListOffers(filter ...ApplicationOfferFilter) ([]ApplicationOffer, error)
 

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -94,7 +94,7 @@ gopkg.in/juju/charmrepo.v2-unstable	git	e79aa298df89ea887c9bffec46063c24bfb730f7
 gopkg.in/juju/charmstore.v5-unstable	git	fd1eef3002fc6b6daff5e97efab6f5056d22dcc7	2016-09-16T10:09:07Z
 gopkg.in/juju/environschema.v1	git	7359fc7857abe2b11b5b3e23811a9c64cb6b01e0	2015-11-04T11:58:10Z
 gopkg.in/juju/jujusvg.v2	git	d82160011935ef79fc7aca84aba2c6f74700fe75	2016-06-09T10:52:15Z
-gopkg.in/juju/names.v2	git	742440955ac975739eee6f1fe10a21ffc07b3071	2017-03-22T06:40:53Z
+gopkg.in/juju/names.v2	git	8869b97720a9675a8ffbdd506a8f4b72bf720517	2017-03-24T04:25:04Z
 gopkg.in/juju/worker.v1	git	6965b9d826717287bb002e02d1fd4d079978083e	2017-03-08T00:24:58Z
 gopkg.in/macaroon-bakery.v1	git	469b44e6f1f9479e115c8ae879ef80695be624d5	2016-06-22T12:14:21Z
 gopkg.in/macaroon.v1	git	ab3940c6c16510a850e1c2dd628b919f0f3f1464	2015-01-21T11:42:31Z

--- a/permission/access.go
+++ b/permission/access.go
@@ -24,6 +24,9 @@ const (
 	// WriteAccess allows a user to make changes to a permission subject.
 	WriteAccess Access = "write"
 
+	// ConsumeAccess allows a user to consume a permission subject.
+	ConsumeAccess Access = "consume"
+
 	// AdminAccess allows a user full control over the subject.
 	AdminAccess Access = "admin"
 
@@ -57,6 +60,16 @@ func ValidateModelAccess(access Access) error {
 		return nil
 	}
 	return errors.NotValidf("%q model access", access)
+}
+
+// ValidateOfferAccess returns error if the passed access is not a valid
+// offer access level.
+func ValidateOfferAccess(access Access) error {
+	switch access {
+	case ReadAccess, ConsumeAccess, AdminAccess:
+		return nil
+	}
+	return errors.NotValidf("%q offer access", access)
 }
 
 //ValidateControllerAccess returns error if the passed access is not a valid
@@ -133,6 +146,41 @@ func (a Access) EqualOrGreaterControllerAccessThan(access Access) bool {
 // greater than the passed in access level.
 func (a Access) GreaterControllerAccessThan(access Access) bool {
 	v1, v2 := a.controllerValue(), access.controllerValue()
+	if v1 < 0 || v2 < 0 {
+		return false
+	}
+	return v1 > v2
+}
+
+func (a Access) offerValue() int {
+	switch a {
+	case NoAccess:
+		return 0
+	case ReadAccess:
+		return 1
+	case ConsumeAccess:
+		return 2
+	case AdminAccess:
+		return 3
+	default:
+		return -1
+	}
+}
+
+// EqualOrGreaterOfferAccessThan returns true if the current access is
+// equal or greater than the passed in access level.
+func (a Access) EqualOrGreaterOfferAccessThan(access Access) bool {
+	v1, v2 := a.offerValue(), access.offerValue()
+	if v1 < 0 || v2 < 0 {
+		return false
+	}
+	return v1 >= v2
+}
+
+// GreaterOfferAccessThan returns true if the current access is
+// greater than the passed in access level.
+func (a Access) GreaterOfferAccessThan(access Access) bool {
+	v1, v2 := a.offerValue(), access.offerValue()
 	if v1 < 0 || v2 < 0 {
 		return false
 	}

--- a/state/applicationoffers.go
+++ b/state/applicationoffers.go
@@ -76,6 +76,15 @@ func (s *applicationOffers) offerForName(offerName string) (*applicationOfferDoc
 	return &doc, nil
 }
 
+// ApplicationOffer returns the named application offer.
+func (s *applicationOffers) ApplicationOffer(offerName string) (*crossmodel.ApplicationOffer, error) {
+	offerDoc, err := s.offerForName(offerName)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return s.makeApplicationOffer(*offerDoc)
+}
+
 // Remove deletes the application offer for offerName immediately.
 func (s *applicationOffers) Remove(offerName string) (err error) {
 	defer errors.DeferredAnnotatef(&err, "cannot delete application offer %q", offerName)

--- a/state/applicationoffers_test.go
+++ b/state/applicationoffers_test.go
@@ -126,6 +126,14 @@ func (s *applicationOffersSuite) createOffer(c *gc.C, name, description string) 
 	return *offer
 }
 
+func (s *applicationOffersSuite) TestApplicationOffer(c *gc.C) {
+	sd := state.NewApplicationOffers(s.State)
+	expectedOffer := s.createDefaultOffer(c)
+	offer, err := sd.ApplicationOffer("hosted-mysql")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(*offer, jc.DeepEquals, expectedOffer)
+}
+
 func (s *applicationOffersSuite) TestListOffersAll(c *gc.C) {
 	sd := state.NewApplicationOffers(s.State)
 	offer := s.createDefaultOffer(c)


### PR DESCRIPTION
## Description of change

The grant/revoke CLI is extended to be able to act on application offers.
The applicationoffers facade gets new methods to accept requests to modify offer ACLs.
The new ACLs for offers are read, consume, admin.
This PR uses mocks for the state side of things - a followup PR will fill that in as well as use the ACLs to gate operations on offers.
The work borrows heavily from what was done for model ACLs.

## QA steps

Basic smoke testing - no functional user changes till the next PR.
