### PR TITLE
provider/vsphere: use domain terminology

### DIFF
--- a/cmd/juju/cloud/add_test.go
+++ b/cmd/juju/cloud/add_test.go
@@ -418,17 +418,18 @@ func (*addSuite) TestInteractiveVSphere(c *gc.C) {
 	err := testing.InitCommand(command, nil)
 	c.Assert(err, jc.ErrorIsNil)
 
+	var stdout bytes.Buffer
 	ctx := &cmd.Context{
-		Stdout: ioutil.Discard,
+		Stdout: &stdout,
 		Stderr: ioutil.Discard,
 		Stdin: strings.NewReader("" +
 			/* Select cloud type: */ "vsphere\n" +
 			/* Enter a name for the cloud: */ "mvs\n" +
-			/* Enter the controller's hostname or IP address: */ "192.168.1.6\n" +
-			/* Enter region name: */ "foo\n" +
-			/* Enter another region? (Y/n): */ "y\n" +
-			/* Enter region name: */ "bar\n" +
-			/* Enter another region? (Y/n): */ "n\n",
+			/* Enter the vCenter address or URL: */ "192.168.1.6\n" +
+			/* Enter datacenter name: */ "foo\n" +
+			/* Enter another datacenter? (Y/n): */ "y\n" +
+			/* Enter datacenter name: */ "bar\n" +
+			/* Enter another datacenter? (Y/n): */ "n\n",
 		),
 	}
 
@@ -436,6 +437,15 @@ func (*addSuite) TestInteractiveVSphere(c *gc.C) {
 	c.Check(err, jc.ErrorIsNil)
 
 	c.Check(numCallsToWrite(), gc.Equals, 1)
+	c.Check(stdout.String(), gc.Matches, "(.|\n)*"+`
+Select cloud type: 
+Enter a name for your vsphere cloud: 
+Enter the vCenter address or URL: 
+Enter datacenter name: 
+Enter another datacenter\? \(Y/n\): 
+Enter datacenter name: 
+Enter another datacenter\? \(Y/n\): 
+`[1:]+"(.|\n)*")
 }
 
 func (*addSuite) TestInteractiveExistingNameOverride(c *gc.C) {

--- a/provider/vsphere/provider.go
+++ b/provider/vsphere/provider.go
@@ -42,7 +42,7 @@ var cloudSchema = &jsonschema.Schema{
 	Order:    []string{cloud.EndpointKey, cloud.AuthTypesKey, cloud.RegionsKey},
 	Properties: map[string]*jsonschema.Schema{
 		cloud.EndpointKey: {
-			Singular: "the API endpoint url for the cloud",
+			Singular: "the vCenter address or URL",
 			Type:     []jsonschema.Type{jsonschema.StringType},
 			Format:   jsonschema.FormatURI,
 		},
@@ -53,8 +53,8 @@ var cloudSchema = &jsonschema.Schema{
 		},
 		cloud.RegionsKey: {
 			Type:     []jsonschema.Type{jsonschema.ObjectType},
-			Singular: "region",
-			Plural:   "regions",
+			Singular: "datacenter",
+			Plural:   "datacenters",
 			AdditionalProperties: &jsonschema.Schema{
 				Type:          []jsonschema.Type{jsonschema.ObjectType},
 				MaxProperties: jsonschema.Int(0),


### PR DESCRIPTION
## Description of change

When interactively adding a vsphere cloud,
use "vCenter address or URL" instead of
"the API endpoint url for the cloud"; and
"datacenter" instead of "region".

## QA steps

1. juju add-cloud
2. enter "vsphere", follow prompts

you should be asked for "the vCenter address or URL" (endpoint) and "datacenter name" (region)

## Documentation changes

If we include output of "juju add-cloud" in docs, yes. Else, no.

## Bug reference

Fixes https://bugs.launchpad.net/juju/+bug/1649647