### PR TITLE
add model default region

### DIFF
--- a/cmd/juju/controller/addmodel.go
+++ b/cmd/juju/controller/addmodel.go
@@ -204,15 +204,23 @@ func (c *addModelCommand) Run(ctx *cmd.Context) error {
 		}
 	}
 
-	// If the user has specified a credential, then we will upload it if
-	// it doesn't already exist in the controller, and it exists locally.
-	//
-	// If no credential is specified, but there is exactly one on the
-	// client, then we use that; otherwise we attempt to detect one from
-	// the environment.
-	credentialTag, err := c.maybeUploadCredential(ctx, cloudClient, cloudTag, cloudRegion, cloud, modelOwner)
+	// Find a credential to use with the new model.
+	credential, credentialTag, cloudRegion, err := c.findCredential(ctx, cloudClient, &findCredentialParams{
+		cloudTag:    cloudTag,
+		cloudRegion: cloudRegion,
+		cloud:       cloud,
+		modelOwner:  modelOwner,
+	})
 	if err != nil {
 		return errors.Trace(err)
+	}
+
+	// Upload the credential if it was found locally.
+	if credential != nil {
+		ctx.Infof("Uploading credential '%s' to controller", credentialTag.Id())
+		if err := cloudClient.UpdateCredential(credentialTag, *credential); err != nil {
+			return errors.Trace(err)
+		}
 	}
 
 	addModelClient := c.newAddModelAPI(api)
@@ -412,98 +420,151 @@ more than one credential is available. List credentials with:
 and then run the add-model command again with the --credential flag.`[1:],
 )
 
-func (c *addModelCommand) maybeUploadCredential(
-	ctx *cmd.Context,
-	cloudClient CloudAPI,
-	cloudTag names.CloudTag,
-	cloudRegion string,
-	cloud jujucloud.Cloud,
-	modelOwner string,
-) (names.CloudCredentialTag, error) {
+type findCredentialParams struct {
+	cloudTag    names.CloudTag
+	cloud       jujucloud.Cloud
+	cloudRegion string
+	modelOwner  string
+}
 
+// findCredential finds a suitable credential to use for the new model.
+// The credential will first be searched for locally and then on the
+// controller. If a credential is found locally then it's value will be
+// returned as the first return value. If it is found on the controller
+// this will be nil as there is no need to upload it in that case.
+func (c *addModelCommand) findCredential(ctx *cmd.Context, cloudClient CloudAPI, p *findCredentialParams) (_ *jujucloud.Credential, _ names.CloudCredentialTag, cloudRegion string, _ error) {
+	if c.CredentialName == "" {
+		return c.findUnspecifiedCredential(ctx, cloudClient, p)
+	}
+	return c.findSpecifiedCredential(ctx, cloudClient, p)
+}
+
+func (c *addModelCommand) findUnspecifiedCredential(ctx *cmd.Context, cloudClient CloudAPI, p *findCredentialParams) (_ *jujucloud.Credential, _ names.CloudCredentialTag, cloudRegion string, _ error) {
+	fail := func(err error) (*jujucloud.Credential, names.CloudCredentialTag, string, error) {
+		return nil, names.CloudCredentialTag{}, "", err
+	}
 	// If the user has not specified a credential, and the cloud advertises
 	// itself as supporting the "empty" auth-type, then return immediately.
-	if c.CredentialName == "" {
-		for _, authType := range cloud.AuthTypes {
-			if authType == jujucloud.EmptyAuthType {
-				return names.CloudCredentialTag{}, nil
-			}
+	for _, authType := range p.cloud.AuthTypes {
+		if authType == jujucloud.EmptyAuthType {
+			return nil, names.CloudCredentialTag{}, p.cloudRegion, nil
 		}
 	}
 
-	// Check if the credential is already in the controller.
-	modelOwnerTag := names.NewUserTag(modelOwner)
-	credentialTags, err := cloudClient.UserCredentials(modelOwnerTag, cloudTag)
+	// No credential has been specified, so see if there is one already on the controller we can use.
+	modelOwnerTag := names.NewUserTag(p.modelOwner)
+	credentialTags, err := cloudClient.UserCredentials(modelOwnerTag, p.cloudTag)
 	if err != nil {
-		return names.CloudCredentialTag{}, errors.Trace(err)
+		return fail(errors.Trace(err))
 	}
-	if c.CredentialName != "" {
+	var credentialTag names.CloudCredentialTag
+	if len(credentialTags) == 1 {
+		credentialTag = credentialTags[0]
+	}
+
+	if (credentialTag != names.CloudCredentialTag{}) {
+		// If the controller already has a credential, see if
+		// there is a local version that has an associated
+		// region.
+		credential, _, cloudRegion, err := c.findLocalCredential(ctx, p, credentialTag.Name())
+		if err == nil || errors.IsNotFound(err) {
+			// If there is a credential in the controller use it even if we don't have a local version.
+			return credential, credentialTag, cloudRegion, nil
+		}
+		if err != nil {
+			return fail(errors.Trace(err))
+		}
+	}
+	// There is not a default credential on the controller (either
+	// there are no credentials, or there is more than one). Look for
+	// a local credential we might use.
+	credential, credentialName, cloudRegion, err := c.findLocalCredential(ctx, p, "")
+	if err != nil {
+		return fail(errors.Trace(err))
+	}
+	// We've got a local credential to use.
+	credentialTag, err = common.ResolveCloudCredentialTag(
+		modelOwnerTag, p.cloudTag, credentialName,
+	)
+	if err != nil {
+		return fail(errors.Trace(err))
+	}
+	return credential, credentialTag, cloudRegion, nil
+}
+
+func (c *addModelCommand) findSpecifiedCredential(ctx *cmd.Context, cloudClient CloudAPI, p *findCredentialParams) (_ *jujucloud.Credential, _ names.CloudCredentialTag, cloudRegion string, _ error) {
+	fail := func(err error) (*jujucloud.Credential, names.CloudCredentialTag, string, error) {
+		return nil, names.CloudCredentialTag{}, "", err
+	}
+	// Look for a local credential with the specified name
+	credential, credentialName, cloudRegion, err := c.findLocalCredential(ctx, p, c.CredentialName)
+	if err != nil {
+		return fail(errors.Trace(err))
+	}
+	if credential != nil {
+		// We found a local credential with the specified name.
+		modelOwnerTag := names.NewUserTag(p.modelOwner)
 		credentialTag, err := common.ResolveCloudCredentialTag(
-			modelOwnerTag, cloudTag, c.CredentialName,
+			modelOwnerTag, p.cloudTag, credentialName,
 		)
 		if err != nil {
-			return names.CloudCredentialTag{}, errors.Trace(err)
+			return fail(errors.Trace(err))
 		}
-		credentialId := credentialTag.Id()
-		for _, tag := range credentialTags {
-			if tag.Id() != credentialId {
-				continue
-			}
-			ctx.Infof("Using credential '%s' cached in controller", c.CredentialName)
-			return credentialTag, nil
-		}
-		if credentialTag.Owner().Id() != modelOwner {
-			// Another user's credential was specified, so
-			// we cannot automatically upload.
-			return names.CloudCredentialTag{}, errors.NotFoundf(
-				"credential '%s'", c.CredentialName,
-			)
-		}
+		return credential, credentialTag, cloudRegion, nil
 	}
 
-	// The user has either not specified a credential, or if they have, it
-	// is not cached in the controller, and isn't qualified with another
-	// user name.
-
-	if c.CredentialName == "" && len(credentialTags) == 1 {
-		tag := credentialTags[0]
-		ctx.Infof("Using credential '%s' cached in controller", tag.Name())
-		return tag, nil
-	}
-
-	// Upload the credential from the client, if it exists locally.
-	provider, err := c.providerRegistry.Provider(cloud.Type)
+	// There was no local credential with that name, check the controller
+	modelOwnerTag := names.NewUserTag(p.modelOwner)
+	credentialTags, err := cloudClient.UserCredentials(modelOwnerTag, p.cloudTag)
 	if err != nil {
-		return names.CloudCredentialTag{}, errors.Trace(err)
+		return fail(errors.Trace(err))
 	}
-	credential, credentialName, _, _, err := common.GetOrDetectCredential(
+	credentialTag, err := common.ResolveCloudCredentialTag(
+		modelOwnerTag, p.cloudTag, c.CredentialName,
+	)
+	if err != nil {
+		return fail(errors.Trace(err))
+	}
+	credentialId := credentialTag.Id()
+	for _, tag := range credentialTags {
+		if tag.Id() != credentialId {
+			continue
+		}
+		ctx.Infof("Using credential '%s' cached in controller", c.CredentialName)
+		return nil, credentialTag, "", nil
+	}
+	// Cannot find a credential with the correct name
+	return fail(errors.NotFoundf("credential '%s'", c.CredentialName))
+}
+
+func (c *addModelCommand) findLocalCredential(ctx *cmd.Context, p *findCredentialParams, name string) (_ *jujucloud.Credential, credentialName, cloudRegion string, _ error) {
+	fail := func(err error) (*jujucloud.Credential, string, string, error) {
+		return nil, "", "", err
+	}
+	provider, err := c.providerRegistry.Provider(p.cloud.Type)
+	if err != nil {
+		return fail(errors.Trace(err))
+	}
+	credential, credentialName, cloudRegion, _, err := common.GetOrDetectCredential(
 		ctx, c.ClientStore(), provider, modelcmd.GetCredentialsParams{
-			Cloud:          cloud,
-			CloudRegion:    cloudRegion,
-			CredentialName: c.CredentialName,
+			Cloud:          p.cloud,
+			CloudRegion:    p.cloudRegion,
+			CredentialName: name,
 		},
 	)
+	if err == nil {
+		return credential, credentialName, cloudRegion, nil
+	}
+	if errors.IsNotFound(err) {
+		return nil, "", "", nil
+	}
 	switch errors.Cause(err) {
-	case nil:
 	case modelcmd.ErrMultipleCredentials:
-		return names.CloudCredentialTag{}, ambiguousCredentialError
+		return fail(ambiguousCredentialError)
 	case common.ErrMultipleDetectedCredentials:
-		return names.CloudCredentialTag{}, ambiguousDetectedCredentialError
-	default:
-		return names.CloudCredentialTag{}, errors.Trace(err)
+		return fail(ambiguousDetectedCredentialError)
 	}
-
-	credentialTag, err := common.ResolveCloudCredentialTag(
-		modelOwnerTag, cloudTag, credentialName,
-	)
-	if err != nil {
-		return names.CloudCredentialTag{}, errors.Trace(err)
-	}
-	ctx.Infof("Uploading credential '%s' to controller", credentialTag.Id())
-	if err := cloudClient.UpdateCredential(credentialTag, *credential); err != nil {
-		return names.CloudCredentialTag{}, errors.Trace(err)
-	}
-	return credentialTag, nil
+	return fail(errors.Trace(err))
 }
 
 func (c *addModelCommand) getConfigValues(ctx *cmd.Context) (map[string]interface{}, error) {

--- a/cmd/modelcmd/credentials.go
+++ b/cmd/modelcmd/credentials.go
@@ -53,15 +53,9 @@ func GetCredentials(
 	if err != nil {
 		return nil, "", "", errors.Trace(err)
 	}
-
 	regionName = args.CloudRegion
 	if regionName == "" {
 		regionName = defaultRegion
-		if regionName == "" && len(args.Cloud.Regions) > 0 {
-			// No region was specified, use the first region
-			// in the list.
-			regionName = args.Cloud.Regions[0].Name
-		}
 	}
 
 	cloudEndpoint := args.Cloud.Endpoint

--- a/cmd/modelcmd/credentials_test.go
+++ b/cmd/modelcmd/credentials_test.go
@@ -119,9 +119,6 @@ func (s *credentialsSuite) assertGetCredentials(c *gc.C, cred, region string) {
 	expectedRegion := region
 	if expectedRegion == "" {
 		expectedRegion = s.store.Credentials["cloud"].DefaultRegion
-		if expectedRegion == "" && len(s.cloud.Regions) > 0 {
-			expectedRegion = "first-region"
-		}
 	}
 	c.Assert(regionName, gc.Equals, expectedRegion)
 	c.Assert(credentialName, gc.Equals, cred)


### PR DESCRIPTION
## Please provide the following details to expedite Pull Request review:

----

## Description of change

This change ensures that if set-default-region has been used to configure a default regions for a cloud and none is specified on the command line, the default region is used with add-model.

## QA steps

Ensure you're registered with JAAS and switched to the JAAS controller.
```
juju add-model test-model-001 aws
```
Make sure the model is created in an arbitrary region
```
juju set-default-region aws <a different region>
```
```
juju add-model test-model-002 aws
```
This time the model should be created in the specified default region.

## Documentation changes

This changes the behavior of `add-model`, such that if the region is not specified on the command line the default region from a previous `set-default-region` will be used if it has been set.

## Bug reference
No specific bugs changed.
