### PR TITLE
Require consume acls on an offer when consuming or relating to it

### DIFF
--- a/apiserver/admin.go
+++ b/apiserver/admin.go
@@ -250,14 +250,13 @@ func (a *admin) checkUserPermissions(userTag names.UserTag, controllerOnlyLogin 
 		// no authorisation to access this model, unless the user is controller
 		// admin.
 
-		modelUser, err := a.root.state.UserAccess(userTag, a.root.state.ModelTag())
+		var err error
+		modelAccess, err = a.root.state.UserPermission(userTag, a.root.state.ModelTag())
 		if err != nil && controllerAccess != permission.SuperuserAccess {
 			return nil, errors.Wrap(err, common.ErrPerm)
 		}
 		if err != nil && controllerAccess == permission.SuperuserAccess {
 			modelAccess = permission.AdminAccess
-		} else {
-			modelAccess = modelUser.Access
 		}
 	}
 
@@ -421,14 +420,38 @@ func (f modelUserEntityFinder) FindEntity(tag names.Tag) (state.Entity, error) {
 		return f.st.FindEntity(tag)
 	}
 
-	modelUser, controllerUser, err := common.UserAccess(f.st, utag)
-	if err != nil {
+	modelUser, err := f.st.UserAccess(utag, f.st.ModelTag())
+	if err != nil && !errors.IsNotFound(err) {
 		return nil, errors.Trace(err)
 	}
+	// No model user found, so see if the user has been granted
+	// access to the controller.
+	if permission.IsEmptyUserAccess(modelUser) {
+		controllerUser, err := state.ControllerAccess(f.st, utag)
+		if err != nil && !errors.IsNotFound(err) {
+			return nil, errors.Trace(err)
+		}
+		// TODO(perrito666) remove the following section about everyone group
+		// when groups are implemented, this accounts only for the lack of a local
+		// ControllerUser when logging in from an external user that has not been granted
+		// permissions on the controller but there are permissions for the special
+		// everyone group.
+		if permission.IsEmptyUserAccess(controllerUser) && !utag.IsLocal() {
+			everyoneTag := names.NewUserTag(common.EveryoneTagName)
+			controllerUser, err = f.st.UserAccess(everyoneTag, f.st.ControllerTag())
+			if err != nil && !errors.IsNotFound(err) {
+				return nil, errors.Annotatef(err, "obtaining ControllerUser for everyone group")
+			}
+		}
+		if permission.IsEmptyUserAccess(controllerUser) {
+			return nil, errors.NotFoundf("model or controller user")
+		}
+	}
+
 	u := &modelUserEntity{
-		st:             f.st,
-		modelUser:      modelUser,
-		controllerUser: controllerUser,
+		st:        f.st,
+		modelUser: modelUser,
+		tag:       utag,
 	}
 	if utag.IsLocal() {
 		user, err := f.st.User(utag)
@@ -450,9 +473,9 @@ var _ loginEntity = &modelUserEntity{}
 type modelUserEntity struct {
 	st *state.State
 
-	controllerUser permission.UserAccess
-	modelUser      permission.UserAccess
-	user           *state.User
+	modelUser permission.UserAccess
+	user      *state.User
+	tag       names.Tag
 }
 
 // Refresh implements state.Authenticator.Refresh.
@@ -482,14 +505,7 @@ func (u *modelUserEntity) PasswordValid(pass string) bool {
 
 // Tag implements state.Entity.Tag.
 func (u *modelUserEntity) Tag() names.Tag {
-	if u.user != nil {
-		return u.user.UserTag()
-	}
-	if !permission.IsEmptyUserAccess(u.modelUser) {
-		return u.modelUser.UserTag
-	}
-	return u.controllerUser.UserTag
-
+	return u.tag
 }
 
 // LastLogin implements loginEntity.LastLogin.

--- a/apiserver/application/backend.go
+++ b/apiserver/application/backend.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/juju/juju/constraints"
 	"github.com/juju/juju/instance"
+	"github.com/juju/juju/permission"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/storage"
 )
@@ -35,6 +36,7 @@ type Backend interface {
 	NewStorage() storage.Storage
 	StorageInstance(names.StorageTag) (state.StorageInstance, error)
 	UnitStorageAttachments(names.UnitTag) ([]state.StorageAttachment, error)
+	GetOfferAccess(offer names.ApplicationOfferTag, user names.UserTag) (permission.Access, error)
 }
 
 // BlockChecker defines the block-checking functionality required by

--- a/apiserver/applicationoffers/base_test.go
+++ b/apiserver/applicationoffers/base_test.go
@@ -80,8 +80,5 @@ func (s *baseSuite) setupOffers(c *gc.C, filterAppName string) {
 		"test": &mockApplication{charm: ch, curl: charm.MustParseURL("db2-2")},
 	}
 	s.mockState.model = &mockModel{uuid: "uuid", name: "prod", owner: "fred"}
-	s.mockState.usermodels = []crossmodelcommon.UserModel{
-		&mockUserModel{model: s.mockState.model},
-	}
 	s.mockState.connStatus = &mockConnectionStatus{count: 5}
 }

--- a/apiserver/applicationoffers/mock_test.go
+++ b/apiserver/applicationoffers/mock_test.go
@@ -77,14 +77,6 @@ func (m *mockModel) Owner() names.UserTag {
 	return names.NewUserTag(m.owner)
 }
 
-type mockUserModel struct {
-	model crossmodelcommon.Model
-}
-
-func (m *mockUserModel) Model() crossmodelcommon.Model {
-	return m.model
-}
-
 type mockCharm struct {
 	meta *charm.Meta
 }
@@ -127,7 +119,6 @@ type offerAccess struct {
 type mockState struct {
 	modelUUID         string
 	model             crossmodelcommon.Model
-	usermodels        []crossmodelcommon.UserModel
 	users             set.Strings
 	applications      map[string]crossmodelcommon.Application
 	applicationOffers map[string]jujucrossmodel.ApplicationOffer
@@ -167,8 +158,8 @@ func (m *mockState) ModelTag() names.ModelTag {
 	return names.NewModelTag(m.modelUUID)
 }
 
-func (m *mockState) ModelsForUser(user names.UserTag) ([]crossmodelcommon.UserModel, error) {
-	return m.usermodels, nil
+func (m *mockState) AllModels() ([]crossmodelcommon.Model, error) {
+	return []crossmodelcommon.Model{m.model}, nil
 }
 
 func (m *mockState) RemoteConnectionStatus(offerName string) (crossmodelcommon.RemoteConnectionStatus, error) {

--- a/apiserver/common/crossmodelcommon/crossmodel.go
+++ b/apiserver/common/crossmodelcommon/crossmodel.go
@@ -24,9 +24,27 @@ type BaseAPI struct {
 	StatePool            StatePool
 }
 
-// CheckPermission ensures that the logged in user holds the given permission on a model.
-func (api *BaseAPI) CheckPermission(backend Backend, perm permission.Access) error {
-	allowed, err := api.Authorizer.HasPermission(perm, api.Backend.ModelTag())
+// CheckPermission ensures that the logged in user holds the given permission on an entity.
+func (api *BaseAPI) CheckPermission(tag names.Tag, perm permission.Access) error {
+	allowed, err := api.Authorizer.HasPermission(perm, tag)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	if !allowed {
+		return common.ErrPerm
+	}
+	return nil
+}
+
+// CheckAdmin ensures that the logged in user is a model or controller admin.
+func (api *BaseAPI) CheckAdmin(backend Backend) error {
+	allowed, err := api.Authorizer.HasPermission(permission.AdminAccess, backend.ModelTag())
+	if err != nil {
+		return errors.Trace(err)
+	}
+	if !allowed {
+		allowed, err = api.Authorizer.HasPermission(permission.SuperuserAccess, backend.ControllerTag())
+	}
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -43,13 +61,13 @@ func (api *BaseAPI) ModelForName(modelName, ownerName string) (Model, bool, erro
 		ownerName = user.Name()
 	}
 	var model Model
-	models, err := api.Backend.ModelsForUser(user)
+	models, err := api.Backend.AllModels()
 	if err != nil {
 		return nil, false, err
 	}
 	for _, m := range models {
-		if m.Model().Name() == modelName && m.Model().Owner().Name() == ownerName {
-			model = m.Model()
+		if m.Name() == modelName && m.Owner().Name() == ownerName {
+			model = m
 			break
 		}
 	}
@@ -59,7 +77,7 @@ func (api *BaseAPI) ModelForName(modelName, ownerName string) (Model, bool, erro
 // ApplicationOffersFromModel gets details about remote applications that match given filters.
 func (api *BaseAPI) ApplicationOffersFromModel(
 	modelUUID string,
-	requiredPerm permission.Access,
+	requireAdmin bool,
 	filters ...jujucrossmodel.ApplicationOfferFilter,
 ) ([]params.ApplicationOfferDetails, error) {
 	backend := api.Backend
@@ -71,7 +89,15 @@ func (api *BaseAPI) ApplicationOffersFromModel(
 		backend = st
 		defer releaser()
 	}
-	if err := api.CheckPermission(backend, requiredPerm); err != nil {
+	// If requireAdmin is true, the user must be a controller superuser
+	// or model admin to proceed.
+	isAdmin := false
+	err := api.CheckAdmin(backend)
+	if err != nil && err != common.ErrPerm {
+		return nil, errors.Trace(err)
+	}
+	isAdmin = err == nil
+	if requireAdmin && !isAdmin {
 		return nil, common.ServerError(err)
 	}
 
@@ -82,6 +108,17 @@ func (api *BaseAPI) ApplicationOffersFromModel(
 
 	var results []params.ApplicationOfferDetails
 	for _, offer := range offers {
+		// If the user is not a model admin, they need at least read
+		// access on an offer to see it.
+		if !isAdmin {
+			permErr := api.CheckPermission(names.NewApplicationOfferTag(offer.OfferName), permission.ReadAccess)
+			if permErr == common.ErrPerm {
+				continue
+			}
+			if permErr != nil {
+				return nil, errors.Trace(permErr)
+			}
+		}
 		app, err := backend.Application(offer.ApplicationName)
 		if err != nil {
 			return nil, errors.Trace(err)
@@ -174,7 +211,7 @@ func (api *BaseAPI) getModelFilters(filters params.OfferFilters) (
 // GetApplicationOffersDetails gets details about remote applications that match given filter.
 func (api *BaseAPI) GetApplicationOffersDetails(
 	filters params.OfferFilters,
-	requiredPerm permission.Access,
+	requireAdmin bool,
 ) ([]params.ApplicationOfferDetails, error) {
 	// Gather all the filter details for doing a query for each model.
 	models, filtersPerModel, err := api.getModelFilters(filters)
@@ -203,7 +240,7 @@ func (api *BaseAPI) GetApplicationOffersDetails(
 	var result []params.ApplicationOfferDetails
 	for _, modelUUID := range allUUIDs {
 		filters := filtersPerModel[modelUUID]
-		offers, err := api.ApplicationOffersFromModel(modelUUID, requiredPerm, filters...)
+		offers, err := api.ApplicationOffersFromModel(modelUUID, requireAdmin, filters...)
 		if err != nil {
 			return nil, common.ServerError(errors.Trace(err))
 		}

--- a/apiserver/common/permissions.go
+++ b/apiserver/common/permissions.go
@@ -4,67 +4,37 @@
 package common
 
 import (
-	"strings"
-
 	"github.com/juju/errors"
 	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/permission"
-	"github.com/juju/juju/state"
 )
 
 // EveryoneTagName represents a special group that encompasses
 // all external users.
 const EveryoneTagName = "everyone@external"
 
-// UserAccess returns the access the user has on the model state
-// and the host controller.
-func UserAccess(st *state.State, utag names.UserTag) (modelUser, controllerUser permission.UserAccess, err error) {
-	var none permission.UserAccess
-	modelUser, err = st.UserAccess(utag, st.ModelTag())
-	if err != nil && !errors.IsNotFound(err) {
-		return none, none, errors.Trace(err)
-	}
-
-	controllerUser, err = state.ControllerAccess(st, utag)
-	if err != nil && !errors.IsNotFound(err) {
-		return none, none, errors.Trace(err)
-	}
-
-	// TODO(perrito666) remove the following section about everyone group
-	// when groups are implemented, this accounts only for the lack of a local
-	// ControllerUser when logging in from an external user that has not been granted
-	// permissions on the controller but there are permissions for the special
-	// everyone group.
-	if !utag.IsLocal() {
-		controllerUser, err = maybeUseGroupPermission(st.UserAccess, controllerUser, st.ControllerTag(), utag)
-		if err != nil {
-			return none, none, errors.Annotatef(err, "obtaining ControllerUser for everyone group")
-		}
-	}
-
-	if permission.IsEmptyUserAccess(modelUser) &&
-		permission.IsEmptyUserAccess(controllerUser) {
-		return none, none, errors.NotFoundf("model or controller user")
-	}
-	return modelUser, controllerUser, nil
-}
+type userAccessFunc func(names.UserTag, names.Tag) (permission.Access, error)
 
 // HasPermission returns true if the specified user has the specified
 // permission on target.
-func HasPermission(userGetter userAccessFunc, utag names.Tag,
-	requestedPermission permission.Access, target names.Tag) (bool, error) {
-
-	validForKind := false
-	switch requestedPermission {
-	case permission.LoginAccess, permission.AddModelAccess, permission.SuperuserAccess:
-		validForKind = target.Kind() == names.ControllerTagKind
-	case permission.ReadAccess, permission.WriteAccess, permission.AdminAccess:
-		validForKind = target.Kind() == names.ModelTagKind
+func HasPermission(
+	accessGetter userAccessFunc, utag names.Tag,
+	requestedPermission permission.Access, target names.Tag,
+) (bool, error) {
+	var validate func(permission.Access) error
+	switch target.Kind() {
+	case names.ControllerTagKind:
+		validate = permission.ValidateControllerAccess
+	case names.ModelTagKind:
+		validate = permission.ValidateModelAccess
+	case names.ApplicationOfferTagKind:
+		validate = permission.ValidateOfferAccess
+	default:
+		return false, nil
 	}
-
-	if !validForKind {
+	if err := validate(requestedPermission); err != nil {
 		return false, nil
 	}
 
@@ -74,85 +44,47 @@ func HasPermission(userGetter userAccessFunc, utag names.Tag,
 		return false, nil
 	}
 
-	user, err := userGetter(userTag, target)
+	userAccess, err := GetPermission(accessGetter, userTag, target)
 	if err != nil && !errors.IsNotFound(err) {
 		return false, errors.Annotatef(err, "while obtaining %s user", target.Kind())
 	}
-	// there is a special case for external users, a group called everyone@external
-	if target.Kind() == names.ControllerTagKind && !userTag.IsLocal() {
-		controllerTag, ok := target.(names.ControllerTag)
-		if !ok {
-			return false, errors.NotValidf("controller tag")
-		}
-
-		// TODO(perrito666) remove the following section about everyone group
-		// when groups are implemented, this accounts only for the lack of a local
-		// ControllerUser when logging in from an external user that has not been granted
-		// permissions on the controller but there are permissions for the special
-		// everyone group.
-		user, err = maybeUseGroupPermission(userGetter, user, controllerTag, userTag)
-		if err != nil {
-			return false, errors.Trace(err)
-		}
-		if permission.IsEmptyUserAccess(user) {
-			return false, nil
-		}
-	}
 	// returning this kind of information would be too much information to reveal too.
-	if errors.IsNotFound(err) {
+	if errors.IsNotFound(err) || userAccess == permission.NoAccess {
 		return false, nil
 	}
-	modelPermission := user.Access.EqualOrGreaterModelAccessThan(requestedPermission) && target.Kind() == names.ModelTagKind
-	controllerPermission := user.Access.EqualOrGreaterControllerAccessThan(requestedPermission) && target.Kind() == names.ControllerTagKind
-	if !controllerPermission && !modelPermission {
+
+	modelPermission := userAccess.EqualOrGreaterModelAccessThan(requestedPermission) && target.Kind() == names.ModelTagKind
+	controllerPermission := userAccess.EqualOrGreaterControllerAccessThan(requestedPermission) && target.Kind() == names.ControllerTagKind
+	offerPermission := userAccess.EqualOrGreaterOfferAccessThan(requestedPermission) && target.Kind() == names.ApplicationOfferTagKind
+	if !controllerPermission && !modelPermission && !offerPermission {
 		return false, nil
 	}
 	return true, nil
 }
 
-// maybeUseGroupPermission returns a permission.UserAccess updated
-// with the group permissions that apply to it if higher than
-// current.
-// If the passed UserAccess is empty (controller user lacks permissions)
-// but the group is not, a stand-in will be created to hold the group
-// permissions.
-func maybeUseGroupPermission(
-	userGetter userAccessFunc,
-	externalUser permission.UserAccess,
-	controllerTag names.ControllerTag,
-	userTag names.UserTag,
-) (permission.UserAccess, error) {
-
-	everyoneTag := names.NewUserTag(EveryoneTagName)
-	everyone, err := userGetter(everyoneTag, controllerTag)
-	if errors.IsNotFound(err) {
-		return externalUser, nil
+// GetPermission returns the permission a user has on the specified target.
+func GetPermission(accessGetter userAccessFunc, userTag names.UserTag, target names.Tag) (permission.Access, error) {
+	userAccess, err := accessGetter(userTag, target)
+	if err != nil && !errors.IsNotFound(err) {
+		return permission.NoAccess, errors.Annotatef(err, "while obtaining %s user", target.Kind())
 	}
-	if err != nil {
-		return permission.UserAccess{}, errors.Trace(err)
+	// there is a special case for external users, a group called everyone@external
+	if !userTag.IsLocal() {
+		// TODO(perrito666) remove the following section about everyone group
+		// when groups are implemented.
+		everyoneTag := names.NewUserTag(EveryoneTagName)
+		everyoneAccess, err := accessGetter(everyoneTag, target)
+		if err != nil && !errors.IsNotFound(err) {
+			return permission.NoAccess, errors.Trace(err)
+		}
+		if userAccess == permission.NoAccess && everyoneAccess != permission.NoAccess {
+			userAccess = everyoneAccess
+		}
+		if everyoneAccess.EqualOrGreaterControllerAccessThan(userAccess) {
+			userAccess = everyoneAccess
+		}
 	}
-	if permission.IsEmptyUserAccess(externalUser) &&
-		!permission.IsEmptyUserAccess(everyone) {
-		externalUser = newControllerUserFromGroup(everyone, userTag)
-	}
-
-	if everyone.Access.EqualOrGreaterControllerAccessThan(externalUser.Access) {
-		externalUser.Access = everyone.Access
-	}
-	return externalUser, nil
-}
-
-type userAccessFunc func(names.UserTag, names.Tag) (permission.UserAccess, error)
-
-// newControllerUserFromGroup returns a permission.UserAccess that serves
-// as a stand-in for a user that has group access but no explicit user
-// access.
-func newControllerUserFromGroup(everyoneAccess permission.UserAccess,
-	userTag names.UserTag) permission.UserAccess {
-	everyoneAccess.UserTag = userTag
-	everyoneAccess.UserID = strings.ToLower(userTag.Id())
-	everyoneAccess.UserName = userTag.Id()
-	return everyoneAccess
+	return userAccess, nil
 }
 
 // HasModelAdmin reports whether or not a user has admin access to the specified model.

--- a/apiserver/controller/controller.go
+++ b/apiserver/controller/controller.go
@@ -348,13 +348,13 @@ func (c *ControllerAPI) GetControllerAccess(req params.Entities) (params.UserAcc
 			results.Results[i].Error = common.ServerError(common.ErrPerm)
 			continue
 		}
-		accessInfo, err := c.state.UserAccess(userTag, c.state.ControllerTag())
+		access, err := c.state.UserPermission(userTag, c.state.ControllerTag())
 		if err != nil {
 			results.Results[i].Error = common.ServerError(err)
 			continue
 		}
 		results.Results[i].Result = &params.UserAccess{
-			Access:  string(accessInfo.Access),
+			Access:  string(access),
 			UserTag: userTag.String()}
 	}
 	return results, nil

--- a/apiserver/introspection.go
+++ b/apiserver/introspection.go
@@ -43,7 +43,7 @@ func (h introspectionHandler) checkAuth(r *http.Request) error {
 	// access these endpoints.
 
 	ok, err := common.HasPermission(
-		st.UserAccess,
+		st.UserPermission,
 		entity.Tag(),
 		permission.SuperuserAccess,
 		st.ControllerTag(),
@@ -60,7 +60,7 @@ func (h introspectionHandler) checkAuth(r *http.Request) error {
 		return errors.Trace(err)
 	}
 	ok, err = common.HasPermission(
-		st.UserAccess,
+		st.UserPermission,
 		entity.Tag(),
 		permission.ReadAccess,
 		controllerModel.ModelTag(),

--- a/apiserver/keymanager/keymanager.go
+++ b/apiserver/keymanager/keymanager.go
@@ -78,7 +78,7 @@ func (api *KeyManagerAPI) checkCanRead(sshUser string) error {
 		return common.ErrPerm
 	}
 	ok, err := common.HasPermission(
-		api.state.UserAccess,
+		api.state.UserPermission,
 		*api.apiUser,
 		permission.ReadAccess,
 		api.state.ModelTag(),

--- a/apiserver/remoteendpoints/base_test.go
+++ b/apiserver/remoteendpoints/base_test.go
@@ -63,8 +63,5 @@ func (s *baseSuite) setupOffers(c *gc.C, filterAppName string) {
 		"test": &mockApplication{charm: ch, curl: charm.MustParseURL("db2-2")},
 	}
 	s.mockState.model = &mockModel{uuid: "uuid", name: "prod", owner: "fred"}
-	s.mockState.usermodels = []crossmodelcommon.UserModel{
-		&mockUserModel{model: s.mockState.model},
-	}
 	s.mockState.connStatus = &mockConnectionStatus{count: 5}
 }

--- a/apiserver/remoteendpoints/mock_test.go
+++ b/apiserver/remoteendpoints/mock_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/juju/juju/apiserver/common/crossmodelcommon"
 	jujucrossmodel "github.com/juju/juju/core/crossmodel"
+	"github.com/juju/juju/testing"
 )
 
 const (
@@ -94,7 +95,7 @@ type mockState struct {
 	crossmodelcommon.Backend
 	modelUUID    string
 	model        crossmodelcommon.Model
-	usermodels   []crossmodelcommon.UserModel
+	allmodels    []crossmodelcommon.Model
 	applications map[string]crossmodelcommon.Application
 	connStatus   crossmodelcommon.RemoteConnectionStatus
 }
@@ -119,8 +120,15 @@ func (m *mockState) ModelTag() names.ModelTag {
 	return names.NewModelTag(m.modelUUID)
 }
 
-func (m *mockState) ModelsForUser(user names.UserTag) ([]crossmodelcommon.UserModel, error) {
-	return m.usermodels, nil
+func (m *mockState) ControllerTag() names.ControllerTag {
+	return testing.ControllerTag
+}
+
+func (m *mockState) AllModels() ([]crossmodelcommon.Model, error) {
+	if len(m.allmodels) > 0 {
+		return m.allmodels, nil
+	}
+	return []crossmodelcommon.Model{m.model}, nil
 }
 
 func (m *mockState) RemoteConnectionStatus(offerName string) (crossmodelcommon.RemoteConnectionStatus, error) {

--- a/apiserver/remoteendpoints/remoteendpoints_test.go
+++ b/apiserver/remoteendpoints/remoteendpoints_test.go
@@ -40,16 +40,13 @@ func (s *remoteEndpointsSuite) SetUpTest(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 }
 
-func (s *remoteEndpointsSuite) assertShow(c *gc.C, expectedErr error) {
+func (s *remoteEndpointsSuite) assertShow(c *gc.C, expected []params.ApplicationOfferResult) {
 	applicationName := "test"
-	offerName := "hosted-test"
-	url := "fred/prod.hosted-db2"
-
-	filter := params.ApplicationURLs{[]string{url}}
+	filter := params.ApplicationURLs{[]string{"fred/prod.hosted-db2"}}
 	anOffer := jujucrossmodel.ApplicationOffer{
 		ApplicationName:        applicationName,
 		ApplicationDescription: "description",
-		OfferName:              offerName,
+		OfferName:              "hosted-db2",
 		Endpoints:              map[string]charm.Relation{"db": {Name: "db"}},
 	}
 
@@ -61,36 +58,43 @@ func (s *remoteEndpointsSuite) assertShow(c *gc.C, expectedErr error) {
 		applicationName: &mockApplication{charm: ch, curl: charm.MustParseURL("db2-2")},
 	}
 	s.mockState.model = &mockModel{uuid: "uuid", name: "prod", owner: "fred"}
-	s.mockState.usermodels = []crossmodelcommon.UserModel{
-		&mockUserModel{model: s.mockState.model},
-	}
 	s.mockState.connStatus = &mockConnectionStatus{count: 5}
 
 	found, err := s.api.ApplicationOffers(filter)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(found.Results, gc.HasLen, 1)
-	result := found.Results[0]
-	if expectedErr != nil {
-		c.Assert(errors.Cause(result.Error), gc.ErrorMatches, expectedErr.Error())
-		return
-	}
-	c.Assert(result.Error, gc.IsNil)
-	c.Assert(result.Result, jc.DeepEquals, params.ApplicationOffer{
-		ApplicationDescription: "description",
-		OfferURL:               url,
-		OfferName:              offerName,
-		Endpoints:              []params.RemoteEndpoint{{Name: "db"}}},
-	)
+	c.Assert(found.Results, jc.DeepEquals, expected)
 	s.applicationOffers.CheckCallNames(c, listOffersBackendCall)
 }
 
 func (s *remoteEndpointsSuite) TestShow(c *gc.C) {
-	s.assertShow(c, nil)
+	expected := []params.ApplicationOfferResult{{
+		Result: params.ApplicationOffer{
+			ApplicationDescription: "description",
+			OfferURL:               "fred/prod.hosted-db2",
+			OfferName:              "hosted-db2",
+			Endpoints:              []params.RemoteEndpoint{{Name: "db"}}},
+	}}
+	s.assertShow(c, expected)
+}
+
+func (s *remoteEndpointsSuite) TestShowNoPermission(c *gc.C) {
+	s.authorizer.Tag = names.NewUserTag("someone")
+	expected := []params.ApplicationOfferResult{{
+		Error: common.ServerError(errors.NotFoundf("application offer %q", "hosted-db2")),
+	}}
+	s.assertShow(c, expected)
 }
 
 func (s *remoteEndpointsSuite) TestShowPermission(c *gc.C) {
-	s.authorizer.Tag = names.NewUserTag("someone")
-	s.assertShow(c, common.ErrPerm)
+	s.authorizer.Tag = names.NewUserTag("read-applicationoffer-hosted-db2")
+	expected := []params.ApplicationOfferResult{{
+		Result: params.ApplicationOffer{
+			ApplicationDescription: "description",
+			OfferURL:               "fred/prod.hosted-db2",
+			OfferName:              "hosted-db2",
+			Endpoints:              []params.RemoteEndpoint{{Name: "db"}}},
+	}}
+	s.assertShow(c, expected)
 }
 
 func (s *remoteEndpointsSuite) TestShowError(c *gc.C) {
@@ -102,9 +106,6 @@ func (s *remoteEndpointsSuite) TestShowError(c *gc.C) {
 		return nil, errors.New(msg)
 	}
 	s.mockState.model = &mockModel{uuid: "uuid", name: "prod", owner: "fred"}
-	s.mockState.usermodels = []crossmodelcommon.UserModel{
-		&mockUserModel{model: s.mockState.model},
-	}
 
 	result, err := s.api.ApplicationOffers(filter)
 	c.Assert(err, jc.ErrorIsNil)
@@ -121,9 +122,6 @@ func (s *remoteEndpointsSuite) TestShowNotFound(c *gc.C) {
 		return nil, nil
 	}
 	s.mockState.model = &mockModel{uuid: "uuid", name: "prod", owner: "fred"}
-	s.mockState.usermodels = []crossmodelcommon.UserModel{
-		&mockUserModel{model: s.mockState.model},
-	}
 
 	found, err := s.api.ApplicationOffers(filter)
 	c.Assert(err, jc.ErrorIsNil)
@@ -140,9 +138,9 @@ func (s *remoteEndpointsSuite) TestShowErrorMsgMultipleURLs(c *gc.C) {
 		return nil, nil
 	}
 	s.mockState.model = &mockModel{uuid: "uuid", name: "prod", owner: "fred"}
-	s.mockState.usermodels = []crossmodelcommon.UserModel{
-		&mockUserModel{model: s.mockState.model},
-		&mockUserModel{model: &mockModel{uuid: "uuid2", name: "test", owner: "fred"}},
+	s.mockState.allmodels = []crossmodelcommon.Model{
+		s.mockState.model,
+		&mockModel{uuid: "uuid2", name: "test", owner: "fred"},
 	}
 	anotherState := &mockState{modelUUID: "uuid2"}
 	s.mockStatePool.st["uuid2"] = anotherState
@@ -188,9 +186,9 @@ func (s *remoteEndpointsSuite) TestShowFoundMultiple(c *gc.C) {
 		"test": &mockApplication{charm: ch, curl: charm.MustParseURL("db2-2")},
 	}
 	s.mockState.model = &mockModel{uuid: "uuid", name: "prod", owner: "fred"}
-	s.mockState.usermodels = []crossmodelcommon.UserModel{
-		&mockUserModel{model: s.mockState.model},
-		&mockUserModel{model: &mockModel{uuid: "uuid2", name: "test", owner: "mary"}},
+	s.mockState.allmodels = []crossmodelcommon.Model{
+		s.mockState.model,
+		&mockModel{uuid: "uuid2", name: "test", owner: "mary"},
 	}
 	s.mockState.connStatus = &mockConnectionStatus{count: 5}
 
@@ -223,8 +221,7 @@ func (s *remoteEndpointsSuite) TestShowFoundMultiple(c *gc.C) {
 	s.applicationOffers.CheckCallNames(c, listOffersBackendCall, listOffersBackendCall)
 }
 
-func (s *remoteEndpointsSuite) assertFind(c *gc.C, expectedErr error) {
-	s.setupOffers(c, "")
+func (s *remoteEndpointsSuite) assertFind(c *gc.C, expected []params.ApplicationOffer) {
 	filter := params.OfferFilters{
 		Filters: []params.OfferFilter{
 			{
@@ -233,29 +230,40 @@ func (s *remoteEndpointsSuite) assertFind(c *gc.C, expectedErr error) {
 		},
 	}
 	found, err := s.api.FindApplicationOffers(filter)
-	if expectedErr != nil {
-		c.Assert(errors.Cause(err), gc.ErrorMatches, expectedErr.Error())
-		return
-	}
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(found, jc.DeepEquals, params.FindApplicationOffersResults{
-		[]params.ApplicationOffer{
-			{
-				ApplicationDescription: "description",
-				OfferName:              "hosted-db2",
-				OfferURL:               "fred/prod.hosted-db2",
-				Endpoints:              []params.RemoteEndpoint{{Name: "db"}}}},
+		Results: expected,
 	})
 	s.applicationOffers.CheckCallNames(c, listOffersBackendCall)
 }
 
 func (s *remoteEndpointsSuite) TestFind(c *gc.C) {
-	s.assertFind(c, nil)
+	s.setupOffers(c, "")
+	expected := []params.ApplicationOffer{
+		{
+			ApplicationDescription: "description",
+			OfferName:              "hosted-db2",
+			OfferURL:               "fred/prod.hosted-db2",
+			Endpoints:              []params.RemoteEndpoint{{Name: "db"}}}}
+	s.assertFind(c, expected)
+}
+
+func (s *remoteEndpointsSuite) TestFindNoPermission(c *gc.C) {
+	s.setupOffers(c, "")
+	s.authorizer.Tag = names.NewUserTag("someone")
+	s.assertFind(c, []params.ApplicationOffer{})
 }
 
 func (s *remoteEndpointsSuite) TestFindPermission(c *gc.C) {
-	s.authorizer.Tag = names.NewUserTag("someone")
-	s.assertFind(c, common.ErrPerm)
+	s.setupOffers(c, "")
+	s.authorizer.Tag = names.NewUserTag("read-applicationoffer-hosted-db2")
+	expected := []params.ApplicationOffer{
+		{
+			ApplicationDescription: "description",
+			OfferName:              "hosted-db2",
+			OfferURL:               "fred/prod.hosted-db2",
+			Endpoints:              []params.RemoteEndpoint{{Name: "db"}}}}
+	s.assertFind(c, expected)
 }
 
 func (s *remoteEndpointsSuite) TestFindMulti(c *gc.C) {
@@ -306,14 +314,11 @@ func (s *remoteEndpointsSuite) TestFindMulti(c *gc.C) {
 		"postgresql": &mockApplication{charm: ch, curl: charm.MustParseURL("postgresql-2")},
 	}
 	anotherState.model = &mockModel{uuid: "uuid2", name: "another", owner: "mary"}
-	anotherState.usermodels = []crossmodelcommon.UserModel{
-		&mockUserModel{model: anotherState.model},
-	}
 	anotherState.connStatus = &mockConnectionStatus{count: 15}
 
-	s.mockState.usermodels = []crossmodelcommon.UserModel{
-		&mockUserModel{model: s.mockState.model},
-		&mockUserModel{model: anotherState.model},
+	s.mockState.allmodels = []crossmodelcommon.Model{
+		s.mockState.model,
+		anotherState.model,
 	}
 
 	filter := params.OfferFilters{
@@ -376,6 +381,7 @@ func (s *remoteEndpointsSuite) TestFindError(c *gc.C) {
 	s.applicationOffers.listOffers = func(filters ...jujucrossmodel.ApplicationOfferFilter) ([]jujucrossmodel.ApplicationOffer, error) {
 		return nil, errors.New(msg)
 	}
+	s.mockState.model = &mockModel{uuid: "uuid", name: "prod", owner: "fred"}
 
 	_, err := s.api.FindApplicationOffers(filter)
 	c.Assert(err, gc.ErrorMatches, fmt.Sprintf(".*%v.*", msg))

--- a/apiserver/root.go
+++ b/apiserver/root.go
@@ -385,12 +385,12 @@ func (r *apiHandler) GetAuthEntity() state.Entity {
 
 // HasPermission returns true if the logged in user can perform <operation> on <target>.
 func (r *apiHandler) HasPermission(operation permission.Access, target names.Tag) (bool, error) {
-	return common.HasPermission(r.state.UserAccess, r.entity.Tag(), operation, target)
+	return common.HasPermission(r.state.UserPermission, r.entity.Tag(), operation, target)
 }
 
 // UserHasPermission returns true if the passed in user can perform <operation> on <target>.
 func (r *apiHandler) UserHasPermission(user names.UserTag, operation permission.Access, target names.Tag) (bool, error) {
-	return common.HasPermission(r.state.UserAccess, user, operation, target)
+	return common.HasPermission(r.state.UserPermission, user, operation, target)
 }
 
 // DescribeFacades returns the list of available Facades and their Versions

--- a/apiserver/server_test.go
+++ b/apiserver/server_test.go
@@ -460,9 +460,9 @@ func (s *serverSuite) bootstrapHasPermissionTest(c *gc.C) (*state.User, names.Co
 
 	ctag, err := names.ParseControllerTag("controller-" + s.State.ControllerUUID())
 	c.Assert(err, jc.ErrorIsNil)
-	cu, err := s.State.UserAccess(user, ctag)
+	access, err := s.State.UserPermission(user, ctag)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(cu.Access, gc.Equals, permission.LoginAccess)
+	c.Assert(access, gc.Equals, permission.LoginAccess)
 	return u, ctag
 }
 

--- a/apiserver/testing/fakeauthorizer.go
+++ b/apiserver/testing/fakeauthorizer.go
@@ -88,6 +88,8 @@ func nameBasedHasPermission(name string, operation permission.Access, target nam
 		perm = permission.AdminAccess
 	case strings.HasPrefix(name, string(permission.WriteAccess)):
 		perm = permission.WriteAccess
+	case strings.HasPrefix(name, string(permission.ConsumeAccess)):
+		perm = permission.ConsumeAccess
 	case strings.HasPrefix(name, string(permission.ReadAccess)):
 		perm = permission.ReadAccess
 	default:
@@ -100,17 +102,14 @@ func nameBasedHasPermission(name string, operation permission.Access, target nam
 	if len(name) == 0 {
 		return operation == perm
 	}
-	if target.Kind() != names.ModelTagKind {
+	if name[0] == '-' {
+		name = name[1:]
+	}
+	targetTag, err := names.ParseTag(name)
+	if err != nil {
 		return false
 	}
-	if names.IsValidModel(name) {
-		newTarget, err := names.ParseModelTag(name)
-		if err != nil {
-			return false
-		}
-		return operation == perm && newTarget == target.(names.ModelTag)
-	}
-	return false
+	return operation == perm && targetTag.String() == target.String()
 }
 
 // ConnectedModel returns the UUID of the model the current client is

--- a/apiserver/usermanager/usermanager.go
+++ b/apiserver/usermanager/usermanager.go
@@ -268,9 +268,9 @@ func (api *UserManagerAPI) UserInfo(request params.UserInfoRequest) (params.User
 
 	var accessForUser = func(userTag names.UserTag, result *params.UserInfoResult) {
 		// Lookup the access the specified user has to the controller.
-		_, controllerUserAccess, err := common.UserAccess(api.state, userTag)
+		access, err := common.GetPermission(api.state.UserPermission, userTag, api.state.ControllerTag())
 		if err == nil {
-			result.Result.Access = string(controllerUserAccess.Access)
+			result.Result.Access = string(access)
 		} else if err != nil && !errors.IsNotFound(err) {
 			result.Result = nil
 			result.Error = common.ServerError(err)

--- a/apiserver/usermanager/usermanager_test.go
+++ b/apiserver/usermanager/usermanager_test.go
@@ -341,6 +341,10 @@ func (s *userManagerSuite) TestUserInfo(c *gc.C) {
 		s.State, s.AdminUserTag(c), names.NewUserTag("fred@external"),
 		params.GrantControllerAccess, permission.AddModelAccess)
 	c.Assert(err, jc.ErrorIsNil)
+	err = controller.ChangeControllerAccess(
+		s.State, s.AdminUserTag(c), names.NewUserTag("everyone@external"),
+		params.GrantControllerAccess, permission.AddModelAccess)
+	c.Assert(err, jc.ErrorIsNil)
 
 	args := params.UserInfoRequest{
 		Entities: []params.Entity{
@@ -352,6 +356,8 @@ func (s *userManagerSuite) TestUserInfo(c *gc.C) {
 				Tag: names.NewLocalUserTag("ellie").String(),
 			}, {
 				Tag: names.NewUserTag("fred@external").String(),
+			}, {
+				Tag: names.NewUserTag("mary@external").String(),
 			}, {
 				Tag: "not-a-tag",
 			},
@@ -388,6 +394,11 @@ func (s *userManagerSuite) TestUserInfo(c *gc.C) {
 		}, {
 			info: &params.UserInfo{
 				Username: "fred@external",
+				Access:   "add-model",
+			},
+		}, {
+			info: &params.UserInfo{
+				Username: "mary@external",
 				Access:   "add-model",
 			},
 		}, {

--- a/cmd/juju/model/grantrevoke_test.go
+++ b/cmd/juju/model/grantrevoke_test.go
@@ -80,12 +80,20 @@ func (s *grantRevokeSuite) TestPassesModelValues(c *gc.C) {
 }
 
 func (s *grantRevokeSuite) TestPassesOfferValues(c *gc.C) {
-	user := "sam"
 	offers := []string{"bob/foo.hosted-mysql", "bob/bar.mysql", "bob/baz.hosted-db2"}
 	_, err := s.run(c, "sam", "read", offers[0], offers[1], offers[2])
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(s.fakeOffersAPI.user, jc.DeepEquals, user)
+	c.Assert(s.fakeOffersAPI.user, jc.DeepEquals, "sam")
 	c.Assert(s.fakeOffersAPI.offerURLs, jc.SameContents, []string{"hosted-mysql", "mysql", "hosted-db2"})
+	c.Assert(s.fakeOffersAPI.access, gc.Equals, "read")
+}
+
+func (s *grantRevokeSuite) TestPassesOfferWithDefaultModelUser(c *gc.C) {
+	offer := "foo.hosted-mysql"
+	_, err := s.run(c, "sam", "read", offer)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(s.fakeOffersAPI.user, jc.DeepEquals, "sam")
+	c.Assert(s.fakeOffersAPI.offerURLs, jc.SameContents, []string{"hosted-mysql"})
 	c.Assert(s.fakeOffersAPI.access, gc.Equals, "read")
 }
 

--- a/state/remoteapplication.go
+++ b/state/remoteapplication.go
@@ -90,7 +90,7 @@ func (s *RemoteApplication) Name() string {
 	return s.doc.Name
 }
 
-// OfferName returns the name on te offering side.
+// OfferName returns the name on the offering side.
 func (s *RemoteApplication) OfferName() string {
 	return s.doc.OfferName
 }

--- a/state/useraccess.go
+++ b/state/useraccess.go
@@ -140,6 +140,22 @@ func NewControllerUserAccess(st *State, userDoc userAccessDoc) (permission.UserA
 	return newUserAccess(perm, userDoc, names.NewControllerTag(userDoc.ObjectUUID)), nil
 }
 
+// UserPermission returns the access permission for the passed subject and target.
+func (st *State) UserPermission(subject names.UserTag, target names.Tag) (permission.Access, error) {
+	switch target.Kind() {
+	case names.ModelTagKind, names.ControllerTagKind:
+		access, err := st.UserAccess(subject, target)
+		if err != nil {
+			return "", errors.Trace(err)
+		}
+		return access.Access, nil
+	case names.ApplicationOfferTagKind:
+		return st.GetOfferAccess(target.(names.ApplicationOfferTag), subject)
+	default:
+		return "", errors.NotValidf("%q as a target", target.Kind())
+	}
+}
+
 func newUserAccess(perm *userPermission, userDoc userAccessDoc, object names.Tag) permission.UserAccess {
 	return permission.UserAccess{
 		UserID:      userDoc.ID,


### PR DESCRIPTION
## Description of change

When consuming or relating to a remote offer, the user needs to have consume access on the offer. They don't need an specific model access, just access to the offer.

Includes a drive by fix for juju grant command to properly handle models when feature flag is off.

The fake authenticator is improved to handle arbitrary permission checks.
The facade authenticator HasPermission implementation is simplified to no longer loads a user access struct. This struct is not relevant to permissions other than model or controller. It is not only used in one place, where user login info is required. The change means that we now support permissions on entities other than model or controller, eg application offer.

## QA steps

New feature tests are added.
Also tested live.
bootstrap
create new user "bob"
add model, give "bob" write access
deploy mysql in a different model
as bob, log in to controller
deploy mediawiki into bob's model
relate to admin's mysql -> permission denied
as admin, give bob consume permission on offer
as bob, do relate again, success
