### PR TITLE
Drop the "persistent-storage" feature flag

### DIFF
--- a/cmd/juju/commands/main.go
+++ b/cmd/juju/commands/main.go
@@ -389,10 +389,8 @@ func registerCommands(r commandRegistry, ctx *cmd.Context) {
 	r.Register(storage.NewPoolListCommand())
 	r.Register(storage.NewShowCommand())
 	r.Register(storage.NewRemoveStorageCommandWithAPI())
-	if featureflag.Enabled(feature.PersistentStorage) {
-		r.Register(storage.NewDetachStorageCommandWithAPI())
-		r.Register(storage.NewAttachStorageCommandWithAPI())
-	}
+	r.Register(storage.NewDetachStorageCommandWithAPI())
+	r.Register(storage.NewAttachStorageCommandWithAPI())
 
 	// Manage spaces
 	r.Register(space.NewAddCommand())

--- a/cmd/juju/commands/main_test.go
+++ b/cmd/juju/commands/main_test.go
@@ -403,6 +403,7 @@ var commandNames = []string{
 	"agreements",
 	"allocate",
 	"attach",
+	"attach-storage",
 	"autoload-credentials",
 	"backups",
 	"bootstrap",
@@ -424,6 +425,7 @@ var commandNames = []string{
 	"deploy",
 	"destroy-controller",
 	"destroy-model",
+	"detach-storage",
 	"disable-command",
 	"disable-user",
 	"disabled-commands",
@@ -540,14 +542,11 @@ var commandNames = []string{
 // devFeatures are feature flags that impact registration of commands.
 var devFeatures = []string{
 	feature.CrossModelRelations,
-	feature.PersistentStorage,
 }
 
 // These are the commands that are behind the `devFeatures`.
 var commandNamesBehindFlags = set.NewStrings(
-	"attach-storage",
 	"consume",
-	"detach-storage",
 	"find-endpoints",
 	"list-offers",
 	"offer",

--- a/feature/flags.go
+++ b/feature/flags.go
@@ -39,6 +39,3 @@ const CrossModelRelations = "cross-model"
 
 // LXDStorage enables the LXD storage provider.
 const LXDStorage = "lxd-storage"
-
-// PersistentStorage enables the persistent storage feature.
-const PersistentStorage = "persistent-storage"


### PR DESCRIPTION
## Description of change

This is a feature branch that will be merged into
develop when we branch 2.2. There's no need for a
feature branch except in 2.2.

## QA steps

Without any env vars set:
```
$ juju help commands | grep tach-storage
attach-storage             Attaches existing storage to a unit.
detach-storage             Detaches storage from units.
```

## Documentation changes

None.

## Bug reference

None.