### PR TITLE
Offer display permissions

### DIFF
--- a/api/remoteendpoints/client_test.go
+++ b/api/remoteendpoints/client_test.go
@@ -34,6 +34,7 @@ func (s *crossmodelMockSuite) TestShow(c *gc.C) {
 		{Name: "log", Interface: "http", Role: charm.RoleRequirer},
 	}
 	offerName := "hosted-db2"
+	access := "consume"
 
 	called := false
 
@@ -60,6 +61,7 @@ func (s *crossmodelMockSuite) TestShow(c *gc.C) {
 						Endpoints:              endpoints,
 						OfferURL:               url,
 						OfferName:              offerName,
+						Access:                 access,
 					}},
 				}
 			}
@@ -74,7 +76,8 @@ func (s *crossmodelMockSuite) TestShow(c *gc.C) {
 		ApplicationDescription: desc,
 		Endpoints:              endpoints,
 		OfferURL:               url,
-		OfferName:              offerName})
+		OfferName:              offerName,
+		Access:                 access})
 }
 
 func (s *crossmodelMockSuite) TestShowURLError(c *gc.C) {
@@ -122,6 +125,7 @@ func (s *crossmodelMockSuite) TestShowMultiple(c *gc.C) {
 		{Name: "log", Interface: "http", Role: charm.RoleRequirer},
 	}
 	offerName := "hosted-db2"
+	access := "consume"
 
 	called := false
 
@@ -148,12 +152,14 @@ func (s *crossmodelMockSuite) TestShowMultiple(c *gc.C) {
 						Endpoints:              endpoints,
 						OfferURL:               url,
 						OfferName:              offerName,
+						Access:                 access,
 					}},
 					{Result: params.ApplicationOffer{
 						ApplicationDescription: desc,
 						Endpoints:              endpoints,
 						OfferURL:               url,
 						OfferName:              offerName,
+						Access:                 access,
 					}}}
 			}
 			return nil
@@ -213,6 +219,7 @@ func (s *crossmodelMockSuite) TestFind(c *gc.C) {
 	offerName := "hosted-db2"
 	ownerName := "owner"
 	modelName := "model"
+	access := "consume"
 	url := fmt.Sprintf("fred/model.%s", offerName)
 	endpoints := []params.RemoteEndpoint{{Name: "endPointA"}}
 	relations := []jujucrossmodel.EndpointFilterTerm{{Name: "endPointA", Interface: "http"}}
@@ -255,6 +262,7 @@ func (s *crossmodelMockSuite) TestFind(c *gc.C) {
 					OfferURL:  url,
 					OfferName: offerName,
 					Endpoints: endpoints,
+					Access:    access,
 				}
 				results.Results = []params.ApplicationOffer{offer}
 			}
@@ -269,6 +277,7 @@ func (s *crossmodelMockSuite) TestFind(c *gc.C) {
 		OfferURL:  url,
 		OfferName: offerName,
 		Endpoints: endpoints,
+		Access:    access,
 	}})
 }
 

--- a/apiserver/admin.go
+++ b/apiserver/admin.go
@@ -250,14 +250,13 @@ func (a *admin) checkUserPermissions(userTag names.UserTag, controllerOnlyLogin 
 		// no authorisation to access this model, unless the user is controller
 		// admin.
 
-		modelUser, err := a.root.state.UserAccess(userTag, a.root.state.ModelTag())
+		var err error
+		modelAccess, err = a.root.state.UserPermission(userTag, a.root.state.ModelTag())
 		if err != nil && controllerAccess != permission.SuperuserAccess {
 			return nil, errors.Wrap(err, common.ErrPerm)
 		}
 		if err != nil && controllerAccess == permission.SuperuserAccess {
 			modelAccess = permission.AdminAccess
-		} else {
-			modelAccess = modelUser.Access
 		}
 	}
 
@@ -421,14 +420,38 @@ func (f modelUserEntityFinder) FindEntity(tag names.Tag) (state.Entity, error) {
 		return f.st.FindEntity(tag)
 	}
 
-	modelUser, controllerUser, err := common.UserAccess(f.st, utag)
-	if err != nil {
+	modelUser, err := f.st.UserAccess(utag, f.st.ModelTag())
+	if err != nil && !errors.IsNotFound(err) {
 		return nil, errors.Trace(err)
 	}
+	// No model user found, so see if the user has been granted
+	// access to the controller.
+	if permission.IsEmptyUserAccess(modelUser) {
+		controllerUser, err := state.ControllerAccess(f.st, utag)
+		if err != nil && !errors.IsNotFound(err) {
+			return nil, errors.Trace(err)
+		}
+		// TODO(perrito666) remove the following section about everyone group
+		// when groups are implemented, this accounts only for the lack of a local
+		// ControllerUser when logging in from an external user that has not been granted
+		// permissions on the controller but there are permissions for the special
+		// everyone group.
+		if permission.IsEmptyUserAccess(controllerUser) && !utag.IsLocal() {
+			everyoneTag := names.NewUserTag(common.EveryoneTagName)
+			controllerUser, err = f.st.UserAccess(everyoneTag, f.st.ControllerTag())
+			if err != nil && !errors.IsNotFound(err) {
+				return nil, errors.Annotatef(err, "obtaining ControllerUser for everyone group")
+			}
+		}
+		if permission.IsEmptyUserAccess(controllerUser) {
+			return nil, errors.NotFoundf("model or controller user")
+		}
+	}
+
 	u := &modelUserEntity{
-		st:             f.st,
-		modelUser:      modelUser,
-		controllerUser: controllerUser,
+		st:        f.st,
+		modelUser: modelUser,
+		tag:       utag,
 	}
 	if utag.IsLocal() {
 		user, err := f.st.User(utag)
@@ -450,9 +473,9 @@ var _ loginEntity = &modelUserEntity{}
 type modelUserEntity struct {
 	st *state.State
 
-	controllerUser permission.UserAccess
-	modelUser      permission.UserAccess
-	user           *state.User
+	modelUser permission.UserAccess
+	user      *state.User
+	tag       names.Tag
 }
 
 // Refresh implements state.Authenticator.Refresh.
@@ -482,14 +505,7 @@ func (u *modelUserEntity) PasswordValid(pass string) bool {
 
 // Tag implements state.Entity.Tag.
 func (u *modelUserEntity) Tag() names.Tag {
-	if u.user != nil {
-		return u.user.UserTag()
-	}
-	if !permission.IsEmptyUserAccess(u.modelUser) {
-		return u.modelUser.UserTag
-	}
-	return u.controllerUser.UserTag
-
+	return u.tag
 }
 
 // LastLogin implements loginEntity.LastLogin.

--- a/apiserver/application/application_test.go
+++ b/apiserver/application/application_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/juju/juju/core/crossmodel"
 	"github.com/juju/juju/instance"
 	jujutesting "github.com/juju/juju/juju/testing"
+	"github.com/juju/juju/permission"
 	"github.com/juju/juju/state"
 	statestorage "github.com/juju/juju/state/storage"
 	"github.com/juju/juju/status"
@@ -48,7 +49,7 @@ type applicationSuite struct {
 
 	applicationAPI *application.API
 	application    *state.Application
-	authorizer     apiservertesting.FakeAuthorizer
+	authorizer     *apiservertesting.FakeAuthorizer
 	otherModel     *state.State
 }
 
@@ -76,7 +77,7 @@ func (s *applicationSuite) SetUpTest(c *gc.C) {
 
 	s.application = s.Factory.MakeApplication(c, nil)
 
-	s.authorizer = apiservertesting.FakeAuthorizer{
+	s.authorizer = &apiservertesting.FakeAuthorizer{
 		Tag: s.AdminUserTag(c),
 	}
 	var err error
@@ -2736,6 +2737,39 @@ func (s *applicationSuite) TestConsumeLocalAlreadyExists(c *gc.C) {
 		Message: `cannot add remote application "mysql": local application with same name already exists`,
 		Code:    "already exists",
 	})
+}
+
+func (s *applicationSuite) TestConsumeNoPermission(c *gc.C) {
+	s.setupOtherModelOffer(c)
+
+	s.authorizer.Tag = names.NewUserTag("someone")
+	results, err := s.applicationAPI.Consume(params.ConsumeApplicationArgs{
+		Args: []params.ConsumeApplicationArg{
+			{ApplicationURL: "admin/othermodel.hosted-mysql"},
+		},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(results.Results, gc.HasLen, 1)
+	c.Assert(results.Results[0].Error, gc.ErrorMatches, ".*permission denied.*")
+}
+
+func (s *applicationSuite) TestConsumeWithPermission(c *gc.C) {
+	s.setupOtherModelOffer(c)
+
+	_, err := s.otherModel.AddUser("someone", "spmeone", "secret", "admin")
+	c.Assert(err, jc.ErrorIsNil)
+	apiUser := names.NewUserTag("someone")
+	err = s.otherModel.CreateOfferAccess(
+		names.NewApplicationOfferTag("hosted-mysql"), apiUser, permission.ConsumeAccess)
+	s.authorizer.Tag = apiUser
+	results, err := s.applicationAPI.Consume(params.ConsumeApplicationArgs{
+		Args: []params.ConsumeApplicationArg{
+			{ApplicationURL: "admin/othermodel.hosted-mysql"},
+		},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(results.Results, gc.HasLen, 1)
+	c.Assert(results.Results[0].Error, gc.IsNil)
 }
 
 func (s *applicationSuite) TestConsumingAndAddingRelation(c *gc.C) {

--- a/apiserver/application/backend.go
+++ b/apiserver/application/backend.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/juju/juju/constraints"
 	"github.com/juju/juju/instance"
+	"github.com/juju/juju/permission"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/storage"
 )
@@ -35,6 +36,7 @@ type Backend interface {
 	NewStorage() storage.Storage
 	StorageInstance(names.StorageTag) (state.StorageInstance, error)
 	UnitStorageAttachments(names.UnitTag) ([]state.StorageAttachment, error)
+	GetOfferAccess(offer names.ApplicationOfferTag, user names.UserTag) (permission.Access, error)
 }
 
 // BlockChecker defines the block-checking functionality required by

--- a/apiserver/applicationoffers/applicationoffers_test.go
+++ b/apiserver/applicationoffers/applicationoffers_test.go
@@ -183,6 +183,7 @@ func (s *applicationOffersSuite) assertList(c *gc.C, expectedErr error) {
 					OfferName:              "hosted-db2",
 					OfferURL:               "fred/prod.hosted-db2",
 					Endpoints:              []params.RemoteEndpoint{{Name: "db"}},
+					Access:                 "admin",
 				},
 				CharmName:      "db2",
 				ConnectedCount: 5,

--- a/apiserver/applicationoffers/base_test.go
+++ b/apiserver/applicationoffers/base_test.go
@@ -80,8 +80,5 @@ func (s *baseSuite) setupOffers(c *gc.C, filterAppName string) {
 		"test": &mockApplication{charm: ch, curl: charm.MustParseURL("db2-2")},
 	}
 	s.mockState.model = &mockModel{uuid: "uuid", name: "prod", owner: "fred"}
-	s.mockState.usermodels = []crossmodelcommon.UserModel{
-		&mockUserModel{model: s.mockState.model},
-	}
 	s.mockState.connStatus = &mockConnectionStatus{count: 5}
 }

--- a/apiserver/applicationoffers/mock_test.go
+++ b/apiserver/applicationoffers/mock_test.go
@@ -77,14 +77,6 @@ func (m *mockModel) Owner() names.UserTag {
 	return names.NewUserTag(m.owner)
 }
 
-type mockUserModel struct {
-	model crossmodelcommon.Model
-}
-
-func (m *mockUserModel) Model() crossmodelcommon.Model {
-	return m.model
-}
-
 type mockCharm struct {
 	meta *charm.Meta
 }
@@ -127,7 +119,6 @@ type offerAccess struct {
 type mockState struct {
 	modelUUID         string
 	model             crossmodelcommon.Model
-	usermodels        []crossmodelcommon.UserModel
 	users             set.Strings
 	applications      map[string]crossmodelcommon.Application
 	applicationOffers map[string]jujucrossmodel.ApplicationOffer
@@ -167,8 +158,8 @@ func (m *mockState) ModelTag() names.ModelTag {
 	return names.NewModelTag(m.modelUUID)
 }
 
-func (m *mockState) ModelsForUser(user names.UserTag) ([]crossmodelcommon.UserModel, error) {
-	return m.usermodels, nil
+func (m *mockState) AllModels() ([]crossmodelcommon.Model, error) {
+	return []crossmodelcommon.Model{m.model}, nil
 }
 
 func (m *mockState) RemoteConnectionStatus(offerName string) (crossmodelcommon.RemoteConnectionStatus, error) {

--- a/apiserver/common/permissions.go
+++ b/apiserver/common/permissions.go
@@ -4,67 +4,37 @@
 package common
 
 import (
-	"strings"
-
 	"github.com/juju/errors"
 	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/permission"
-	"github.com/juju/juju/state"
 )
 
 // EveryoneTagName represents a special group that encompasses
 // all external users.
 const EveryoneTagName = "everyone@external"
 
-// UserAccess returns the access the user has on the model state
-// and the host controller.
-func UserAccess(st *state.State, utag names.UserTag) (modelUser, controllerUser permission.UserAccess, err error) {
-	var none permission.UserAccess
-	modelUser, err = st.UserAccess(utag, st.ModelTag())
-	if err != nil && !errors.IsNotFound(err) {
-		return none, none, errors.Trace(err)
-	}
-
-	controllerUser, err = state.ControllerAccess(st, utag)
-	if err != nil && !errors.IsNotFound(err) {
-		return none, none, errors.Trace(err)
-	}
-
-	// TODO(perrito666) remove the following section about everyone group
-	// when groups are implemented, this accounts only for the lack of a local
-	// ControllerUser when logging in from an external user that has not been granted
-	// permissions on the controller but there are permissions for the special
-	// everyone group.
-	if !utag.IsLocal() {
-		controllerUser, err = maybeUseGroupPermission(st.UserAccess, controllerUser, st.ControllerTag(), utag)
-		if err != nil {
-			return none, none, errors.Annotatef(err, "obtaining ControllerUser for everyone group")
-		}
-	}
-
-	if permission.IsEmptyUserAccess(modelUser) &&
-		permission.IsEmptyUserAccess(controllerUser) {
-		return none, none, errors.NotFoundf("model or controller user")
-	}
-	return modelUser, controllerUser, nil
-}
+type userAccessFunc func(names.UserTag, names.Tag) (permission.Access, error)
 
 // HasPermission returns true if the specified user has the specified
 // permission on target.
-func HasPermission(userGetter userAccessFunc, utag names.Tag,
-	requestedPermission permission.Access, target names.Tag) (bool, error) {
-
-	validForKind := false
-	switch requestedPermission {
-	case permission.LoginAccess, permission.AddModelAccess, permission.SuperuserAccess:
-		validForKind = target.Kind() == names.ControllerTagKind
-	case permission.ReadAccess, permission.WriteAccess, permission.AdminAccess:
-		validForKind = target.Kind() == names.ModelTagKind
+func HasPermission(
+	accessGetter userAccessFunc, utag names.Tag,
+	requestedPermission permission.Access, target names.Tag,
+) (bool, error) {
+	var validate func(permission.Access) error
+	switch target.Kind() {
+	case names.ControllerTagKind:
+		validate = permission.ValidateControllerAccess
+	case names.ModelTagKind:
+		validate = permission.ValidateModelAccess
+	case names.ApplicationOfferTagKind:
+		validate = permission.ValidateOfferAccess
+	default:
+		return false, nil
 	}
-
-	if !validForKind {
+	if err := validate(requestedPermission); err != nil {
 		return false, nil
 	}
 
@@ -74,85 +44,47 @@ func HasPermission(userGetter userAccessFunc, utag names.Tag,
 		return false, nil
 	}
 
-	user, err := userGetter(userTag, target)
+	userAccess, err := GetPermission(accessGetter, userTag, target)
 	if err != nil && !errors.IsNotFound(err) {
 		return false, errors.Annotatef(err, "while obtaining %s user", target.Kind())
 	}
-	// there is a special case for external users, a group called everyone@external
-	if target.Kind() == names.ControllerTagKind && !userTag.IsLocal() {
-		controllerTag, ok := target.(names.ControllerTag)
-		if !ok {
-			return false, errors.NotValidf("controller tag")
-		}
-
-		// TODO(perrito666) remove the following section about everyone group
-		// when groups are implemented, this accounts only for the lack of a local
-		// ControllerUser when logging in from an external user that has not been granted
-		// permissions on the controller but there are permissions for the special
-		// everyone group.
-		user, err = maybeUseGroupPermission(userGetter, user, controllerTag, userTag)
-		if err != nil {
-			return false, errors.Trace(err)
-		}
-		if permission.IsEmptyUserAccess(user) {
-			return false, nil
-		}
-	}
 	// returning this kind of information would be too much information to reveal too.
-	if errors.IsNotFound(err) {
+	if errors.IsNotFound(err) || userAccess == permission.NoAccess {
 		return false, nil
 	}
-	modelPermission := user.Access.EqualOrGreaterModelAccessThan(requestedPermission) && target.Kind() == names.ModelTagKind
-	controllerPermission := user.Access.EqualOrGreaterControllerAccessThan(requestedPermission) && target.Kind() == names.ControllerTagKind
-	if !controllerPermission && !modelPermission {
+
+	modelPermission := userAccess.EqualOrGreaterModelAccessThan(requestedPermission) && target.Kind() == names.ModelTagKind
+	controllerPermission := userAccess.EqualOrGreaterControllerAccessThan(requestedPermission) && target.Kind() == names.ControllerTagKind
+	offerPermission := userAccess.EqualOrGreaterOfferAccessThan(requestedPermission) && target.Kind() == names.ApplicationOfferTagKind
+	if !controllerPermission && !modelPermission && !offerPermission {
 		return false, nil
 	}
 	return true, nil
 }
 
-// maybeUseGroupPermission returns a permission.UserAccess updated
-// with the group permissions that apply to it if higher than
-// current.
-// If the passed UserAccess is empty (controller user lacks permissions)
-// but the group is not, a stand-in will be created to hold the group
-// permissions.
-func maybeUseGroupPermission(
-	userGetter userAccessFunc,
-	externalUser permission.UserAccess,
-	controllerTag names.ControllerTag,
-	userTag names.UserTag,
-) (permission.UserAccess, error) {
-
-	everyoneTag := names.NewUserTag(EveryoneTagName)
-	everyone, err := userGetter(everyoneTag, controllerTag)
-	if errors.IsNotFound(err) {
-		return externalUser, nil
+// GetPermission returns the permission a user has on te specified target.
+func GetPermission(accessGetter userAccessFunc, userTag names.UserTag, target names.Tag) (permission.Access, error) {
+	userAccess, err := accessGetter(userTag, target)
+	if err != nil && !errors.IsNotFound(err) {
+		return permission.NoAccess, errors.Annotatef(err, "while obtaining %s user", target.Kind())
 	}
-	if err != nil {
-		return permission.UserAccess{}, errors.Trace(err)
+	// there is a special case for external users, a group called everyone@external
+	if !userTag.IsLocal() {
+		// TODO(perrito666) remove the following section about everyone group
+		// when groups are implemented.
+		everyoneTag := names.NewUserTag(EveryoneTagName)
+		everyoneAccess, err := accessGetter(everyoneTag, target)
+		if err != nil && !errors.IsNotFound(err) {
+			return permission.NoAccess, errors.Trace(err)
+		}
+		if userAccess == permission.NoAccess && everyoneAccess != permission.NoAccess {
+			userAccess = everyoneAccess
+		}
+		if everyoneAccess.EqualOrGreaterControllerAccessThan(userAccess) {
+			userAccess = everyoneAccess
+		}
 	}
-	if permission.IsEmptyUserAccess(externalUser) &&
-		!permission.IsEmptyUserAccess(everyone) {
-		externalUser = newControllerUserFromGroup(everyone, userTag)
-	}
-
-	if everyone.Access.EqualOrGreaterControllerAccessThan(externalUser.Access) {
-		externalUser.Access = everyone.Access
-	}
-	return externalUser, nil
-}
-
-type userAccessFunc func(names.UserTag, names.Tag) (permission.UserAccess, error)
-
-// newControllerUserFromGroup returns a permission.UserAccess that serves
-// as a stand-in for a user that has group access but no explicit user
-// access.
-func newControllerUserFromGroup(everyoneAccess permission.UserAccess,
-	userTag names.UserTag) permission.UserAccess {
-	everyoneAccess.UserTag = userTag
-	everyoneAccess.UserID = strings.ToLower(userTag.Id())
-	everyoneAccess.UserName = userTag.Id()
-	return everyoneAccess
+	return userAccess, nil
 }
 
 // HasModelAdmin reports whether or not a user has admin access to the specified model.

--- a/apiserver/controller/controller.go
+++ b/apiserver/controller/controller.go
@@ -348,13 +348,13 @@ func (c *ControllerAPI) GetControllerAccess(req params.Entities) (params.UserAcc
 			results.Results[i].Error = common.ServerError(common.ErrPerm)
 			continue
 		}
-		accessInfo, err := c.state.UserAccess(userTag, c.state.ControllerTag())
+		access, err := c.state.UserPermission(userTag, c.state.ControllerTag())
 		if err != nil {
 			results.Results[i].Error = common.ServerError(err)
 			continue
 		}
 		results.Results[i].Result = &params.UserAccess{
-			Access:  string(accessInfo.Access),
+			Access:  string(access),
 			UserTag: userTag.String()}
 	}
 	return results, nil

--- a/apiserver/introspection.go
+++ b/apiserver/introspection.go
@@ -43,7 +43,7 @@ func (h introspectionHandler) checkAuth(r *http.Request) error {
 	// access these endpoints.
 
 	ok, err := common.HasPermission(
-		st.UserAccess,
+		st.UserPermission,
 		entity.Tag(),
 		permission.SuperuserAccess,
 		st.ControllerTag(),
@@ -60,7 +60,7 @@ func (h introspectionHandler) checkAuth(r *http.Request) error {
 		return errors.Trace(err)
 	}
 	ok, err = common.HasPermission(
-		st.UserAccess,
+		st.UserPermission,
 		entity.Tag(),
 		permission.ReadAccess,
 		controllerModel.ModelTag(),

--- a/apiserver/keymanager/keymanager.go
+++ b/apiserver/keymanager/keymanager.go
@@ -78,7 +78,7 @@ func (api *KeyManagerAPI) checkCanRead(sshUser string) error {
 		return common.ErrPerm
 	}
 	ok, err := common.HasPermission(
-		api.state.UserAccess,
+		api.state.UserPermission,
 		*api.apiUser,
 		permission.ReadAccess,
 		api.state.ModelTag(),

--- a/apiserver/params/crossmodel.go
+++ b/apiserver/params/crossmodel.go
@@ -43,6 +43,7 @@ type ApplicationOffer struct {
 	OfferName              string           `json:"offer-name"`
 	ApplicationDescription string           `json:"application-description"`
 	Endpoints              []RemoteEndpoint `json:"endpoints"`
+	Access                 string           `json:"access"`
 }
 
 // ApplicationOfferDetails represents an application offering,

--- a/apiserver/remoteendpoints/base_test.go
+++ b/apiserver/remoteendpoints/base_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/juju/juju/apiserver/common/crossmodelcommon"
 	"github.com/juju/juju/apiserver/testing"
 	jujucrossmodel "github.com/juju/juju/core/crossmodel"
+	"github.com/juju/juju/permission"
 )
 
 const (
@@ -35,7 +36,10 @@ func (s *baseSuite) SetUpTest(c *gc.C) {
 		AdminTag: names.NewUserTag("admin"),
 	}
 
-	s.mockState = &mockState{modelUUID: "uuid"}
+	s.mockState = &mockState{
+		modelUUID:   "uuid",
+		offerAccess: make(map[names.ApplicationOfferTag]permission.Access),
+	}
 	s.mockStatePool = &mockStatePool{map[string]crossmodelcommon.Backend{s.mockState.modelUUID: s.mockState}}
 }
 

--- a/apiserver/remoteendpoints/base_test.go
+++ b/apiserver/remoteendpoints/base_test.go
@@ -63,8 +63,5 @@ func (s *baseSuite) setupOffers(c *gc.C, filterAppName string) {
 		"test": &mockApplication{charm: ch, curl: charm.MustParseURL("db2-2")},
 	}
 	s.mockState.model = &mockModel{uuid: "uuid", name: "prod", owner: "fred"}
-	s.mockState.usermodels = []crossmodelcommon.UserModel{
-		&mockUserModel{model: s.mockState.model},
-	}
 	s.mockState.connStatus = &mockConnectionStatus{count: 5}
 }

--- a/apiserver/remoteendpoints/mock_test.go
+++ b/apiserver/remoteendpoints/mock_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/juju/juju/apiserver/common/crossmodelcommon"
 	jujucrossmodel "github.com/juju/juju/core/crossmodel"
+	"github.com/juju/juju/testing"
 )
 
 const (
@@ -94,7 +95,7 @@ type mockState struct {
 	crossmodelcommon.Backend
 	modelUUID    string
 	model        crossmodelcommon.Model
-	usermodels   []crossmodelcommon.UserModel
+	allmodels    []crossmodelcommon.Model
 	applications map[string]crossmodelcommon.Application
 	connStatus   crossmodelcommon.RemoteConnectionStatus
 }
@@ -119,8 +120,15 @@ func (m *mockState) ModelTag() names.ModelTag {
 	return names.NewModelTag(m.modelUUID)
 }
 
-func (m *mockState) ModelsForUser(user names.UserTag) ([]crossmodelcommon.UserModel, error) {
-	return m.usermodels, nil
+func (m *mockState) ControllerTag() names.ControllerTag {
+	return testing.ControllerTag
+}
+
+func (m *mockState) AllModels() ([]crossmodelcommon.Model, error) {
+	if len(m.allmodels) > 0 {
+		return m.allmodels, nil
+	}
+	return []crossmodelcommon.Model{m.model}, nil
 }
 
 func (m *mockState) RemoteConnectionStatus(offerName string) (crossmodelcommon.RemoteConnectionStatus, error) {

--- a/apiserver/remoteendpoints/mock_test.go
+++ b/apiserver/remoteendpoints/mock_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/juju/juju/apiserver/common/crossmodelcommon"
 	jujucrossmodel "github.com/juju/juju/core/crossmodel"
+	"github.com/juju/juju/permission"
 	"github.com/juju/juju/testing"
 )
 
@@ -98,6 +99,7 @@ type mockState struct {
 	allmodels    []crossmodelcommon.Model
 	applications map[string]crossmodelcommon.Application
 	connStatus   crossmodelcommon.RemoteConnectionStatus
+	offerAccess  map[names.ApplicationOfferTag]permission.Access
 }
 
 func (m *mockState) Application(name string) (crossmodelcommon.Application, error) {
@@ -129,6 +131,14 @@ func (m *mockState) AllModels() ([]crossmodelcommon.Model, error) {
 		return m.allmodels, nil
 	}
 	return []crossmodelcommon.Model{m.model}, nil
+}
+
+func (m *mockState) GetOfferAccess(offer names.ApplicationOfferTag, user names.UserTag) (permission.Access, error) {
+	access, ok := m.offerAccess[offer]
+	if !ok {
+		return permission.NoAccess, errors.NotFoundf("access for %q", offer)
+	}
+	return access, nil
 }
 
 func (m *mockState) RemoteConnectionStatus(offerName string) (crossmodelcommon.RemoteConnectionStatus, error) {

--- a/apiserver/remoteendpoints/remoteendpoints_test.go
+++ b/apiserver/remoteendpoints/remoteendpoints_test.go
@@ -40,16 +40,13 @@ func (s *remoteEndpointsSuite) SetUpTest(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 }
 
-func (s *remoteEndpointsSuite) assertShow(c *gc.C, expectedErr error) {
+func (s *remoteEndpointsSuite) assertShow(c *gc.C, expected []params.ApplicationOfferResult) {
 	applicationName := "test"
-	offerName := "hosted-test"
-	url := "fred/prod.hosted-db2"
-
-	filter := params.ApplicationURLs{[]string{url}}
+	filter := params.ApplicationURLs{[]string{"fred/prod.hosted-db2"}}
 	anOffer := jujucrossmodel.ApplicationOffer{
 		ApplicationName:        applicationName,
 		ApplicationDescription: "description",
-		OfferName:              offerName,
+		OfferName:              "hosted-db2",
 		Endpoints:              map[string]charm.Relation{"db": {Name: "db"}},
 	}
 
@@ -61,36 +58,43 @@ func (s *remoteEndpointsSuite) assertShow(c *gc.C, expectedErr error) {
 		applicationName: &mockApplication{charm: ch, curl: charm.MustParseURL("db2-2")},
 	}
 	s.mockState.model = &mockModel{uuid: "uuid", name: "prod", owner: "fred"}
-	s.mockState.usermodels = []crossmodelcommon.UserModel{
-		&mockUserModel{model: s.mockState.model},
-	}
 	s.mockState.connStatus = &mockConnectionStatus{count: 5}
 
 	found, err := s.api.ApplicationOffers(filter)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(found.Results, gc.HasLen, 1)
-	result := found.Results[0]
-	if expectedErr != nil {
-		c.Assert(errors.Cause(result.Error), gc.ErrorMatches, expectedErr.Error())
-		return
-	}
-	c.Assert(result.Error, gc.IsNil)
-	c.Assert(result.Result, jc.DeepEquals, params.ApplicationOffer{
-		ApplicationDescription: "description",
-		OfferURL:               url,
-		OfferName:              offerName,
-		Endpoints:              []params.RemoteEndpoint{{Name: "db"}}},
-	)
+	c.Assert(found.Results, jc.DeepEquals, expected)
 	s.applicationOffers.CheckCallNames(c, listOffersBackendCall)
 }
 
 func (s *remoteEndpointsSuite) TestShow(c *gc.C) {
-	s.assertShow(c, nil)
+	expected := []params.ApplicationOfferResult{{
+		Result: params.ApplicationOffer{
+			ApplicationDescription: "description",
+			OfferURL:               "fred/prod.hosted-db2",
+			OfferName:              "hosted-db2",
+			Endpoints:              []params.RemoteEndpoint{{Name: "db"}}},
+	}}
+	s.assertShow(c, expected)
+}
+
+func (s *remoteEndpointsSuite) TestShowNoPermission(c *gc.C) {
+	s.authorizer.Tag = names.NewUserTag("someone")
+	expected := []params.ApplicationOfferResult{{
+		Error: common.ServerError(errors.NotFoundf("application offer %q", "hosted-db2")),
+	}}
+	s.assertShow(c, expected)
 }
 
 func (s *remoteEndpointsSuite) TestShowPermission(c *gc.C) {
-	s.authorizer.Tag = names.NewUserTag("someone")
-	s.assertShow(c, common.ErrPerm)
+	s.authorizer.Tag = names.NewUserTag("read-applicationoffer-hosted-db2")
+	expected := []params.ApplicationOfferResult{{
+		Result: params.ApplicationOffer{
+			ApplicationDescription: "description",
+			OfferURL:               "fred/prod.hosted-db2",
+			OfferName:              "hosted-db2",
+			Endpoints:              []params.RemoteEndpoint{{Name: "db"}}},
+	}}
+	s.assertShow(c, expected)
 }
 
 func (s *remoteEndpointsSuite) TestShowError(c *gc.C) {
@@ -102,9 +106,6 @@ func (s *remoteEndpointsSuite) TestShowError(c *gc.C) {
 		return nil, errors.New(msg)
 	}
 	s.mockState.model = &mockModel{uuid: "uuid", name: "prod", owner: "fred"}
-	s.mockState.usermodels = []crossmodelcommon.UserModel{
-		&mockUserModel{model: s.mockState.model},
-	}
 
 	result, err := s.api.ApplicationOffers(filter)
 	c.Assert(err, jc.ErrorIsNil)
@@ -121,9 +122,6 @@ func (s *remoteEndpointsSuite) TestShowNotFound(c *gc.C) {
 		return nil, nil
 	}
 	s.mockState.model = &mockModel{uuid: "uuid", name: "prod", owner: "fred"}
-	s.mockState.usermodels = []crossmodelcommon.UserModel{
-		&mockUserModel{model: s.mockState.model},
-	}
 
 	found, err := s.api.ApplicationOffers(filter)
 	c.Assert(err, jc.ErrorIsNil)
@@ -140,9 +138,9 @@ func (s *remoteEndpointsSuite) TestShowErrorMsgMultipleURLs(c *gc.C) {
 		return nil, nil
 	}
 	s.mockState.model = &mockModel{uuid: "uuid", name: "prod", owner: "fred"}
-	s.mockState.usermodels = []crossmodelcommon.UserModel{
-		&mockUserModel{model: s.mockState.model},
-		&mockUserModel{model: &mockModel{uuid: "uuid2", name: "test", owner: "fred"}},
+	s.mockState.allmodels = []crossmodelcommon.Model{
+		s.mockState.model,
+		&mockModel{uuid: "uuid2", name: "test", owner: "fred"},
 	}
 	anotherState := &mockState{modelUUID: "uuid2"}
 	s.mockStatePool.st["uuid2"] = anotherState
@@ -188,9 +186,9 @@ func (s *remoteEndpointsSuite) TestShowFoundMultiple(c *gc.C) {
 		"test": &mockApplication{charm: ch, curl: charm.MustParseURL("db2-2")},
 	}
 	s.mockState.model = &mockModel{uuid: "uuid", name: "prod", owner: "fred"}
-	s.mockState.usermodels = []crossmodelcommon.UserModel{
-		&mockUserModel{model: s.mockState.model},
-		&mockUserModel{model: &mockModel{uuid: "uuid2", name: "test", owner: "mary"}},
+	s.mockState.allmodels = []crossmodelcommon.Model{
+		s.mockState.model,
+		&mockModel{uuid: "uuid2", name: "test", owner: "mary"},
 	}
 	s.mockState.connStatus = &mockConnectionStatus{count: 5}
 
@@ -223,8 +221,7 @@ func (s *remoteEndpointsSuite) TestShowFoundMultiple(c *gc.C) {
 	s.applicationOffers.CheckCallNames(c, listOffersBackendCall, listOffersBackendCall)
 }
 
-func (s *remoteEndpointsSuite) assertFind(c *gc.C, expectedErr error) {
-	s.setupOffers(c, "")
+func (s *remoteEndpointsSuite) assertFind(c *gc.C, expected []params.ApplicationOffer) {
 	filter := params.OfferFilters{
 		Filters: []params.OfferFilter{
 			{
@@ -233,29 +230,40 @@ func (s *remoteEndpointsSuite) assertFind(c *gc.C, expectedErr error) {
 		},
 	}
 	found, err := s.api.FindApplicationOffers(filter)
-	if expectedErr != nil {
-		c.Assert(errors.Cause(err), gc.ErrorMatches, expectedErr.Error())
-		return
-	}
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(found, jc.DeepEquals, params.FindApplicationOffersResults{
-		[]params.ApplicationOffer{
-			{
-				ApplicationDescription: "description",
-				OfferName:              "hosted-db2",
-				OfferURL:               "fred/prod.hosted-db2",
-				Endpoints:              []params.RemoteEndpoint{{Name: "db"}}}},
+		Results: expected,
 	})
 	s.applicationOffers.CheckCallNames(c, listOffersBackendCall)
 }
 
 func (s *remoteEndpointsSuite) TestFind(c *gc.C) {
-	s.assertFind(c, nil)
+	s.setupOffers(c, "")
+	expected := []params.ApplicationOffer{
+		{
+			ApplicationDescription: "description",
+			OfferName:              "hosted-db2",
+			OfferURL:               "fred/prod.hosted-db2",
+			Endpoints:              []params.RemoteEndpoint{{Name: "db"}}}}
+	s.assertFind(c, expected)
+}
+
+func (s *remoteEndpointsSuite) TestFindNoPermission(c *gc.C) {
+	s.setupOffers(c, "")
+	s.authorizer.Tag = names.NewUserTag("someone")
+	s.assertFind(c, []params.ApplicationOffer{})
 }
 
 func (s *remoteEndpointsSuite) TestFindPermission(c *gc.C) {
-	s.authorizer.Tag = names.NewUserTag("someone")
-	s.assertFind(c, common.ErrPerm)
+	s.setupOffers(c, "")
+	s.authorizer.Tag = names.NewUserTag("read-applicationoffer-hosted-db2")
+	expected := []params.ApplicationOffer{
+		{
+			ApplicationDescription: "description",
+			OfferName:              "hosted-db2",
+			OfferURL:               "fred/prod.hosted-db2",
+			Endpoints:              []params.RemoteEndpoint{{Name: "db"}}}}
+	s.assertFind(c, expected)
 }
 
 func (s *remoteEndpointsSuite) TestFindMulti(c *gc.C) {
@@ -306,14 +314,11 @@ func (s *remoteEndpointsSuite) TestFindMulti(c *gc.C) {
 		"postgresql": &mockApplication{charm: ch, curl: charm.MustParseURL("postgresql-2")},
 	}
 	anotherState.model = &mockModel{uuid: "uuid2", name: "another", owner: "mary"}
-	anotherState.usermodels = []crossmodelcommon.UserModel{
-		&mockUserModel{model: anotherState.model},
-	}
 	anotherState.connStatus = &mockConnectionStatus{count: 15}
 
-	s.mockState.usermodels = []crossmodelcommon.UserModel{
-		&mockUserModel{model: s.mockState.model},
-		&mockUserModel{model: anotherState.model},
+	s.mockState.allmodels = []crossmodelcommon.Model{
+		s.mockState.model,
+		anotherState.model,
 	}
 
 	filter := params.OfferFilters{
@@ -376,6 +381,7 @@ func (s *remoteEndpointsSuite) TestFindError(c *gc.C) {
 	s.applicationOffers.listOffers = func(filters ...jujucrossmodel.ApplicationOfferFilter) ([]jujucrossmodel.ApplicationOffer, error) {
 		return nil, errors.New(msg)
 	}
+	s.mockState.model = &mockModel{uuid: "uuid", name: "prod", owner: "fred"}
 
 	_, err := s.api.FindApplicationOffers(filter)
 	c.Assert(err, gc.ErrorMatches, fmt.Sprintf(".*%v.*", msg))

--- a/apiserver/root.go
+++ b/apiserver/root.go
@@ -385,12 +385,12 @@ func (r *apiHandler) GetAuthEntity() state.Entity {
 
 // HasPermission returns true if the logged in user can perform <operation> on <target>.
 func (r *apiHandler) HasPermission(operation permission.Access, target names.Tag) (bool, error) {
-	return common.HasPermission(r.state.UserAccess, r.entity.Tag(), operation, target)
+	return common.HasPermission(r.state.UserPermission, r.entity.Tag(), operation, target)
 }
 
 // UserHasPermission returns true if the passed in user can perform <operation> on <target>.
 func (r *apiHandler) UserHasPermission(user names.UserTag, operation permission.Access, target names.Tag) (bool, error) {
-	return common.HasPermission(r.state.UserAccess, user, operation, target)
+	return common.HasPermission(r.state.UserPermission, user, operation, target)
 }
 
 // DescribeFacades returns the list of available Facades and their Versions

--- a/apiserver/server_test.go
+++ b/apiserver/server_test.go
@@ -460,9 +460,9 @@ func (s *serverSuite) bootstrapHasPermissionTest(c *gc.C) (*state.User, names.Co
 
 	ctag, err := names.ParseControllerTag("controller-" + s.State.ControllerUUID())
 	c.Assert(err, jc.ErrorIsNil)
-	cu, err := s.State.UserAccess(user, ctag)
+	access, err := s.State.UserPermission(user, ctag)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(cu.Access, gc.Equals, permission.LoginAccess)
+	c.Assert(access, gc.Equals, permission.LoginAccess)
 	return u, ctag
 }
 

--- a/apiserver/testing/fakeauthorizer.go
+++ b/apiserver/testing/fakeauthorizer.go
@@ -88,6 +88,8 @@ func nameBasedHasPermission(name string, operation permission.Access, target nam
 		perm = permission.AdminAccess
 	case strings.HasPrefix(name, string(permission.WriteAccess)):
 		perm = permission.WriteAccess
+	case strings.HasPrefix(name, string(permission.ConsumeAccess)):
+		perm = permission.ConsumeAccess
 	case strings.HasPrefix(name, string(permission.ReadAccess)):
 		perm = permission.ReadAccess
 	default:
@@ -100,17 +102,14 @@ func nameBasedHasPermission(name string, operation permission.Access, target nam
 	if len(name) == 0 {
 		return operation == perm
 	}
-	if target.Kind() != names.ModelTagKind {
+	if name[0] == '-' {
+		name = name[1:]
+	}
+	targetTag, err := names.ParseTag(name)
+	if err != nil {
 		return false
 	}
-	if names.IsValidModel(name) {
-		newTarget, err := names.ParseModelTag(name)
-		if err != nil {
-			return false
-		}
-		return operation == perm && newTarget == target.(names.ModelTag)
-	}
-	return false
+	return operation == perm && targetTag.String() == target.String()
 }
 
 // ConnectedModel returns the UUID of the model the current client is

--- a/apiserver/usermanager/usermanager.go
+++ b/apiserver/usermanager/usermanager.go
@@ -268,9 +268,9 @@ func (api *UserManagerAPI) UserInfo(request params.UserInfoRequest) (params.User
 
 	var accessForUser = func(userTag names.UserTag, result *params.UserInfoResult) {
 		// Lookup the access the specified user has to the controller.
-		_, controllerUserAccess, err := common.UserAccess(api.state, userTag)
+		access, err := common.GetPermission(api.state.UserPermission, userTag, api.state.ControllerTag())
 		if err == nil {
-			result.Result.Access = string(controllerUserAccess.Access)
+			result.Result.Access = string(access)
 		} else if err != nil && !errors.IsNotFound(err) {
 			result.Result = nil
 			result.Error = common.ServerError(err)

--- a/apiserver/usermanager/usermanager_test.go
+++ b/apiserver/usermanager/usermanager_test.go
@@ -341,6 +341,10 @@ func (s *userManagerSuite) TestUserInfo(c *gc.C) {
 		s.State, s.AdminUserTag(c), names.NewUserTag("fred@external"),
 		params.GrantControllerAccess, permission.AddModelAccess)
 	c.Assert(err, jc.ErrorIsNil)
+	err = controller.ChangeControllerAccess(
+		s.State, s.AdminUserTag(c), names.NewUserTag("everyone@external"),
+		params.GrantControllerAccess, permission.AddModelAccess)
+	c.Assert(err, jc.ErrorIsNil)
 
 	args := params.UserInfoRequest{
 		Entities: []params.Entity{
@@ -352,6 +356,8 @@ func (s *userManagerSuite) TestUserInfo(c *gc.C) {
 				Tag: names.NewLocalUserTag("ellie").String(),
 			}, {
 				Tag: names.NewUserTag("fred@external").String(),
+			}, {
+				Tag: names.NewUserTag("mary@external").String(),
 			}, {
 				Tag: "not-a-tag",
 			},
@@ -388,6 +394,11 @@ func (s *userManagerSuite) TestUserInfo(c *gc.C) {
 		}, {
 			info: &params.UserInfo{
 				Username: "fred@external",
+				Access:   "add-model",
+			},
+		}, {
+			info: &params.UserInfo{
+				Username: "mary@external",
 				Access:   "add-model",
 			},
 		}, {

--- a/cmd/juju/application/consume.go
+++ b/cmd/juju/application/consume.go
@@ -73,6 +73,14 @@ func (c *consumeCommand) Init(args []string) error {
 	if url.HasEndpoint() {
 		return errors.Errorf("remote application %q shouldn't include endpoint", c.remoteApplication)
 	}
+	if url.User == "" {
+		details, err := c.ClientStore().AccountDetails(c.ControllerName())
+		if err != nil {
+			return errors.Trace(err)
+		}
+		url.User = details.User
+		c.remoteApplication = url.Path()
+	}
 	if len(args) > 1 {
 		if !names.IsValidApplication(args[1]) {
 			return errors.Errorf("invalid application name %q", args[1])

--- a/cmd/juju/application/consume_test.go
+++ b/cmd/juju/application/consume_test.go
@@ -11,12 +11,15 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/cmd/juju/application"
+	"github.com/juju/juju/jujuclient"
+	"github.com/juju/juju/jujuclient/jujuclienttesting"
 	coretesting "github.com/juju/juju/testing"
 )
 
 type ConsumeSuite struct {
 	testing.IsolationSuite
 	mockAPI *mockConsumeAPI
+	store   *jujuclienttesting.MemStore
 }
 
 var _ = gc.Suite(&ConsumeSuite{})
@@ -24,10 +27,27 @@ var _ = gc.Suite(&ConsumeSuite{})
 func (s *ConsumeSuite) SetUpTest(c *gc.C) {
 	s.IsolationSuite.SetUpTest(c)
 	s.mockAPI = &mockConsumeAPI{Stub: &testing.Stub{}}
+
+	// Set up the current controller, and write just enough info
+	// so we don't try to refresh
+	controllerName := "test-master"
+	s.store = jujuclienttesting.NewMemStore()
+	s.store.CurrentControllerName = controllerName
+	s.store.Controllers[controllerName] = jujuclient.ControllerDetails{}
+	s.store.Models[controllerName] = &jujuclient.ControllerModels{
+		CurrentModel: "fred/test",
+		Models: map[string]jujuclient.ModelDetails{
+			"bob/test": {"test-uuid"},
+			"bob/prod": {"prod-uuid"},
+		},
+	}
+	s.store.Accounts[controllerName] = jujuclient.AccountDetails{
+		User: "bob",
+	}
 }
 
 func (s *ConsumeSuite) runConsume(c *gc.C, args ...string) (*cmd.Context, error) {
-	return coretesting.RunCommand(c, application.NewConsumeCommandForTest(s.mockAPI), args...)
+	return coretesting.RunCommand(c, application.NewConsumeCommandForTest(s.store, s.mockAPI), args...)
 }
 
 func (s *ConsumeSuite) TestNoArguments(c *gc.C) {
@@ -65,10 +85,10 @@ func (s *ConsumeSuite) TestSuccessModelDotApplication(c *gc.C) {
 	ctx, err := s.runConsume(c, "booster.uke")
 	c.Assert(err, jc.ErrorIsNil)
 	s.mockAPI.CheckCalls(c, []testing.StubCall{
-		{"Consume", []interface{}{"booster.uke", ""}},
+		{"Consume", []interface{}{"bob/booster.uke", ""}},
 		{"Close", nil},
 	})
-	c.Assert(coretesting.Stderr(ctx), gc.Equals, "Added booster.uke as mary-weep\n")
+	c.Assert(coretesting.Stderr(ctx), gc.Equals, "Added bob/booster.uke as mary-weep\n")
 }
 
 func (s *ConsumeSuite) TestSuccessModelDotApplicationWithAlias(c *gc.C) {
@@ -76,10 +96,10 @@ func (s *ConsumeSuite) TestSuccessModelDotApplicationWithAlias(c *gc.C) {
 	ctx, err := s.runConsume(c, "booster.uke", "alias")
 	c.Assert(err, jc.ErrorIsNil)
 	s.mockAPI.CheckCalls(c, []testing.StubCall{
-		{"Consume", []interface{}{"booster.uke", "alias"}},
+		{"Consume", []interface{}{"bob/booster.uke", "alias"}},
 		{"Close", nil},
 	})
-	c.Assert(coretesting.Stderr(ctx), gc.Equals, "Added booster.uke as mary-weep\n")
+	c.Assert(coretesting.Stderr(ctx), gc.Equals, "Added bob/booster.uke as mary-weep\n")
 }
 
 type mockConsumeAPI struct {

--- a/cmd/juju/application/export_test.go
+++ b/cmd/juju/application/export_test.go
@@ -70,8 +70,10 @@ func NewRemoveRelationCommandForTest(api ApplicationDestroyRelationAPI) cmd.Comm
 }
 
 // NewConsumeCommandForTest returns a ConsumeCommand with the specified api.
-func NewConsumeCommandForTest(api applicationConsumeAPI) cmd.Command {
-	return modelcmd.Wrap(&consumeCommand{api: api})
+func NewConsumeCommandForTest(store jujuclient.ClientStore, api applicationConsumeAPI) cmd.Command {
+	c := &consumeCommand{api: api}
+	c.SetClientStore(store)
+	return modelcmd.Wrap(c)
 }
 
 type Patcher interface {

--- a/cmd/juju/crossmodel/find.go
+++ b/cmd/juju/crossmodel/find.go
@@ -161,22 +161,28 @@ type FindAPI interface {
 	FindApplicationOffers(filters ...crossmodel.ApplicationOfferFilter) ([]params.ApplicationOffer, error)
 }
 
-// RemoteApplicationResult defines the serialization behaviour of remote application.
+// ApplicationOfferResult defines the serialization behaviour of an application offer.
 // This is used in map-style yaml output where remote application URL is the key.
-type RemoteApplicationResult struct {
+type ApplicationOfferResult struct {
+	// Access is the level of access the user has on the offer.
+	Access string `yaml:"access" json:"access"`
+
 	// Endpoints is the list of offered application endpoints.
 	Endpoints map[string]RemoteEndpoint `yaml:"endpoints" json:"endpoints"`
 }
 
 // convertFoundOffers takes any number of api-formatted remote applications and
 // creates a collection of ui-formatted applications.
-func convertFoundOffers(services ...params.ApplicationOffer) (map[string]RemoteApplicationResult, error) {
+func convertFoundOffers(services ...params.ApplicationOffer) (map[string]ApplicationOfferResult, error) {
 	if len(services) == 0 {
 		return nil, nil
 	}
-	output := make(map[string]RemoteApplicationResult, len(services))
+	output := make(map[string]ApplicationOfferResult, len(services))
 	for _, one := range services {
-		app := RemoteApplicationResult{Endpoints: convertRemoteEndpoints(one.Endpoints...)}
+		app := ApplicationOfferResult{
+			Access:    one.Access,
+			Endpoints: convertRemoteEndpoints(one.Endpoints...),
+		}
 		output[one.OfferURL] = app
 	}
 	return output, nil

--- a/cmd/juju/crossmodel/find_test.go
+++ b/cmd/juju/crossmodel/find_test.go
@@ -45,8 +45,8 @@ func (s *findSuite) TestFindNoArgs(c *gc.C) {
 		c,
 		[]string{},
 		`
-URL                   Interfaces
-fred/test.hosted-db2  http:db2, http:log
+URL                   Access   Interfaces
+fred/test.hosted-db2  consume  http:db2, http:log
 
 `[1:],
 	)
@@ -88,8 +88,8 @@ func (s *findSuite) TestSimpleFilter(c *gc.C) {
 		c,
 		[]string{"--format", "tabular", "--url", "fred/model.hosted-db2"},
 		`
-URL                    Interfaces
-fred/model.hosted-db2  http:db2, http:log
+URL                    Access   Interfaces
+fred/model.hosted-db2  consume  http:db2, http:log
 
 `[1:],
 	)
@@ -110,8 +110,8 @@ func (s *findSuite) TestEndpointFilter(c *gc.C) {
 		c,
 		[]string{"--format", "tabular", "--url", "fred/model", "--endpoint", "db", "--interface", "mysql"},
 		`
-URL                    Interfaces
-fred/model.hosted-db2  http:db2, http:log
+URL                    Access   Interfaces
+fred/model.hosted-db2  consume  http:db2, http:log
 
 `[1:],
 	)
@@ -129,6 +129,7 @@ func (s *findSuite) TestFindYaml(c *gc.C) {
 		[]string{"fred/model.hosted-db2", "--format", "yaml"},
 		`
 fred/model.hosted-db2:
+  access: consume
   endpoints:
     db2:
       interface: http
@@ -146,8 +147,8 @@ func (s *findSuite) TestFindTabular(c *gc.C) {
 		c,
 		[]string{"fred/model.hosted-db2", "--format", "tabular"},
 		`
-URL                    Interfaces
-fred/model.hosted-db2  http:db2, http:log
+URL                    Access   Interfaces
+fred/model.hosted-db2  consume  http:db2, http:log
 
 `[1:],
 	)
@@ -197,5 +198,6 @@ func (s mockFindAPI) FindApplicationOffers(filters ...jujucrossmodel.Application
 			{Name: "log", Interface: "http", Role: charm.RoleProvider},
 			{Name: "db2", Interface: "http", Role: charm.RoleRequirer},
 		},
+		Access: "consume",
 	}}, nil
 }

--- a/cmd/juju/crossmodel/findformatter.go
+++ b/cmd/juju/crossmodel/findformatter.go
@@ -17,7 +17,7 @@ import (
 // formatFindTabular returns a tabular summary of remote applications or
 // errors out if parameter is not of expected type.
 func formatFindTabular(writer io.Writer, value interface{}) error {
-	endpoints, ok := value.(map[string]RemoteApplicationResult)
+	endpoints, ok := value.(map[string]ApplicationOfferResult)
 	if !ok {
 		return errors.Errorf("expected value of type %T, got %T", endpoints, value)
 	}
@@ -25,10 +25,10 @@ func formatFindTabular(writer io.Writer, value interface{}) error {
 }
 
 // formatFoundEndpointsTabular returns a tabular summary of offered applications' endpoints.
-func formatFoundEndpointsTabular(writer io.Writer, all map[string]RemoteApplicationResult) error {
+func formatFoundEndpointsTabular(writer io.Writer, all map[string]ApplicationOfferResult) error {
 	tw := output.TabWriter(writer)
 	w := output.Wrapper{tw}
-	w.Println("URL", "Interfaces")
+	w.Println("URL", "Access", "Interfaces")
 
 	for url, one := range all {
 		applicationURL := url
@@ -38,7 +38,7 @@ func formatFoundEndpointsTabular(writer io.Writer, all map[string]RemoteApplicat
 			interfaces = append(interfaces, fmt.Sprintf("%s:%s", ep.Interface, name))
 		}
 		sort.Strings(interfaces)
-		w.Println(applicationURL, strings.Join(interfaces, ", "))
+		w.Println(applicationURL, one.Access, strings.Join(interfaces, ", "))
 	}
 	tw.Flush()
 

--- a/cmd/juju/crossmodel/show.go
+++ b/cmd/juju/crossmodel/show.go
@@ -114,9 +114,12 @@ type ShowAPI interface {
 	ApplicationOffer(url string) (params.ApplicationOffer, error)
 }
 
-// ShowRemoteApplication defines the serialization behaviour of remote application.
+// ShowOfferedApplication defines the serialization behaviour of an application offer.
 // This is used in map-style yaml output where remote application name is the key.
-type ShowRemoteApplication struct {
+type ShowOfferedApplication struct {
+	// Access is the level of access the user has on the offer.
+	Access string `yaml:"access" json:"access"`
+
 	// Endpoints list of offered application endpoints.
 	Endpoints map[string]RemoteEndpoint `yaml:"endpoints" json:"endpoints"`
 
@@ -126,13 +129,16 @@ type ShowRemoteApplication struct {
 
 // convertOffers takes any number of api-formatted remote applications and
 // creates a collection of ui-formatted offers.
-func convertOffers(offers ...params.ApplicationOffer) (map[string]ShowRemoteApplication, error) {
+func convertOffers(offers ...params.ApplicationOffer) (map[string]ShowOfferedApplication, error) {
 	if len(offers) == 0 {
 		return nil, nil
 	}
-	output := make(map[string]ShowRemoteApplication, len(offers))
+	output := make(map[string]ShowOfferedApplication, len(offers))
 	for _, one := range offers {
-		app := ShowRemoteApplication{Endpoints: convertRemoteEndpoints(one.Endpoints...)}
+		app := ShowOfferedApplication{
+			Access:    one.Access,
+			Endpoints: convertRemoteEndpoints(one.Endpoints...),
+		}
 		if one.ApplicationDescription != "" {
 			app.Description = one.ApplicationDescription
 		}

--- a/cmd/juju/crossmodel/show_test.go
+++ b/cmd/juju/crossmodel/show_test.go
@@ -57,6 +57,7 @@ func (s *showSuite) TestShowYaml(c *gc.C) {
 		[]string{"fred/model.db2", "--format", "yaml"},
 		`
 fred/model.db2:
+  access: consume
   endpoints:
     db2:
       interface: http
@@ -74,9 +75,9 @@ func (s *showSuite) TestShowTabular(c *gc.C) {
 		c,
 		[]string{"fred/model.db2", "--format", "tabular"},
 		`
-Application URL  Description                                 Endpoint  Interface  Role
-fred/model.db2   IBM DB2 Express Server Edition is an entry  db2       http       requirer
-                 level database system                       log       http       provider
+URL             Access   Description                                 Endpoint  Interface  Role
+fred/model.db2  consume  IBM DB2 Express Server Edition is an entry  db2       http       requirer
+                         level database system                       log       http       provider
 
 `[1:],
 	)
@@ -88,12 +89,12 @@ func (s *showSuite) TestShowTabularExactly180Desc(c *gc.C) {
 		c,
 		[]string{"fred/model.db2", "--format", "tabular"},
 		`
-Application URL  Description                                   Endpoint  Interface  Role
-fred/model.db2   IBM DB2 Express Server Edition is an entry    db2       http       requirer
-                 level database systemIBM DB2 Express Server   log       http       provider
-                 Edition is an entry level database systemIBM                       
-                 DB2 Express Server Edition is an entry level                       
-                 dat                                                                
+URL             Access   Description                                   Endpoint  Interface  Role
+fred/model.db2  consume  IBM DB2 Express Server Edition is an entry    db2       http       requirer
+                         level database systemIBM DB2 Express Server   log       http       provider
+                         Edition is an entry level database systemIBM                       
+                         DB2 Express Server Edition is an entry level                       
+                         dat                                                                
 
 `[1:],
 	)
@@ -105,12 +106,12 @@ func (s *showSuite) TestShowTabularMoreThan180Desc(c *gc.C) {
 		c,
 		[]string{"fred/model.db2", "--format", "tabular"},
 		`
-Application URL  Description                                   Endpoint  Interface  Role
-fred/model.db2   IBM DB2 Express Server Edition is an entry    db2       http       requirer
-                 level database systemIBM DB2 Express Server   log       http       provider
-                 Edition is an entry level database systemIBM                       
-                 DB2 Express Server Edition is an entry level                       
-                 ...                                                                
+URL             Access   Description                                   Endpoint  Interface  Role
+fred/model.db2  consume  IBM DB2 Express Server Edition is an entry    db2       http       requirer
+                         level database systemIBM DB2 Express Server   log       http       provider
+                         Edition is an entry level database systemIBM                       
+                         DB2 Express Server Edition is an entry level                       
+                         ...                                                                
 
 `[1:],
 	)
@@ -150,5 +151,6 @@ func (s mockShowAPI) ApplicationOffer(url string) (params.ApplicationOffer, erro
 			{Name: "log", Interface: "http", Role: charm.RoleProvider},
 			{Name: "db2", Interface: "http", Role: charm.RoleRequirer},
 		},
+		Access: "consume",
 	}, nil
 }

--- a/cmd/juju/crossmodel/showformatter.go
+++ b/cmd/juju/crossmodel/showformatter.go
@@ -25,7 +25,7 @@ const (
 // formatShowTabular returns a tabular summary of remote applications or
 // errors out if parameter is not of expected type.
 func formatShowTabular(writer io.Writer, value interface{}) error {
-	endpoints, ok := value.(map[string]ShowRemoteApplication)
+	endpoints, ok := value.(map[string]ShowOfferedApplication)
 	if !ok {
 		return errors.Errorf("expected value of type %T, got %T", endpoints, value)
 	}
@@ -33,21 +33,22 @@ func formatShowTabular(writer io.Writer, value interface{}) error {
 }
 
 // formatOfferedEndpointsTabular returns a tabular summary of offered applications' endpoints.
-func formatOfferedEndpointsTabular(writer io.Writer, all map[string]ShowRemoteApplication) error {
+func formatOfferedEndpointsTabular(writer io.Writer, all map[string]ShowOfferedApplication) error {
 	tw := output.TabWriter(writer)
 	w := output.Wrapper{tw}
 
-	w.Println("Application URL", "Description", "Endpoint", "Interface", "Role")
+	w.Println("URL", "Access", "Description", "Endpoint", "Interface", "Role")
 
 	for name, one := range all {
-		applicationName := name
-		applicationDesc := one.Description
+		offerName := name
+		offerAccess := one.Access
+		offerDesc := one.Description
 
 		// truncate long description for now.
-		if len(applicationDesc) > maxColumnLength {
-			applicationDesc = fmt.Sprintf("%v%v", applicationDesc[:maxFieldLength], truncatedSuffix)
+		if len(offerDesc) > maxColumnLength {
+			offerDesc = fmt.Sprintf("%v%v", offerDesc[:maxFieldLength], truncatedSuffix)
 		}
-		descLines := breakLines(applicationDesc)
+		descLines := breakLines(offerDesc)
 
 		// Find the maximum amount of iterations required:
 		// it will be either endpoints or description lines length
@@ -62,9 +63,10 @@ func formatOfferedEndpointsTabular(writer io.Writer, all map[string]ShowRemoteAp
 		for i := 0; i < maxIterations; i++ {
 			descLine := descAt(descLines, i)
 			name, endpoint := endpointAt(one.Endpoints, names, i)
-			w.Println(applicationName, descLine, name, endpoint.Interface, endpoint.Role)
+			w.Println(offerName, offerAccess, descLine, name, endpoint.Interface, endpoint.Role)
 			// Only print once.
-			applicationName = ""
+			offerName = ""
+			offerAccess = ""
 		}
 	}
 	tw.Flush()

--- a/cmd/juju/model/grantrevoke_test.go
+++ b/cmd/juju/model/grantrevoke_test.go
@@ -80,12 +80,20 @@ func (s *grantRevokeSuite) TestPassesModelValues(c *gc.C) {
 }
 
 func (s *grantRevokeSuite) TestPassesOfferValues(c *gc.C) {
-	user := "sam"
 	offers := []string{"bob/foo.hosted-mysql", "bob/bar.mysql", "bob/baz.hosted-db2"}
 	_, err := s.run(c, "sam", "read", offers[0], offers[1], offers[2])
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(s.fakeOffersAPI.user, jc.DeepEquals, user)
+	c.Assert(s.fakeOffersAPI.user, jc.DeepEquals, "sam")
 	c.Assert(s.fakeOffersAPI.offerURLs, jc.SameContents, []string{"hosted-mysql", "mysql", "hosted-db2"})
+	c.Assert(s.fakeOffersAPI.access, gc.Equals, "read")
+}
+
+func (s *grantRevokeSuite) TestPassesOfferWithDefaultModelUser(c *gc.C) {
+	offer := "foo.hosted-mysql"
+	_, err := s.run(c, "sam", "read", offer)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(s.fakeOffersAPI.user, jc.DeepEquals, "sam")
+	c.Assert(s.fakeOffersAPI.offerURLs, jc.SameContents, []string{"hosted-mysql"})
 	c.Assert(s.fakeOffersAPI.access, gc.Equals, "read")
 }
 

--- a/state/applicationofferuser_test.go
+++ b/state/applicationofferuser_test.go
@@ -37,17 +37,22 @@ func (s *ApplicationOfferUserSuite) makeOffer(c *gc.C, access permission.Access)
 			Name: "validusername",
 		})
 	offerTag := names.NewApplicationOfferTag("someoffer")
+
+	// Initially no access.
+	_, err = s.State.GetOfferAccess(offerTag, user.UserTag())
+	c.Assert(err, jc.Satisfies, errors.IsNotFound)
+
 	err = s.State.CreateOfferAccess(offerTag, user.UserTag(), access)
 	c.Assert(err, jc.ErrorIsNil)
 	return offerTag, user.UserTag()
 }
 
-func (s *ApplicationOfferUserSuite) assertAddOffer(c *gc.C, access permission.Access) {
-	offerTag, user := s.makeOffer(c, access)
+func (s *ApplicationOfferUserSuite) assertAddOffer(c *gc.C, wantedAccess permission.Access) {
+	offerTag, user := s.makeOffer(c, wantedAccess)
 
 	access, err := s.State.GetOfferAccess(offerTag, user)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(access, gc.Equals, access)
+	c.Assert(access, gc.Equals, wantedAccess)
 
 	// Creator of offer has admin.
 	access, err = s.State.GetOfferAccess(offerTag, names.NewUserTag("test-admin"))

--- a/state/useraccess.go
+++ b/state/useraccess.go
@@ -140,6 +140,22 @@ func NewControllerUserAccess(st *State, userDoc userAccessDoc) (permission.UserA
 	return newUserAccess(perm, userDoc, names.NewControllerTag(userDoc.ObjectUUID)), nil
 }
 
+// UserPermission returns the access permission for the passed subject and target.
+func (st *State) UserPermission(subject names.UserTag, target names.Tag) (permission.Access, error) {
+	switch target.Kind() {
+	case names.ModelTagKind, names.ControllerTagKind:
+		access, err := st.UserAccess(subject, target)
+		if err != nil {
+			return "", errors.Trace(err)
+		}
+		return access.Access, nil
+	case names.ApplicationOfferTagKind:
+		return st.GetOfferAccess(target.(names.ApplicationOfferTag), subject)
+	default:
+		return "", errors.NotValidf("%q as a target", target.Kind())
+	}
+}
+
 func newUserAccess(perm *userPermission, userDoc userAccessDoc, object names.Tag) permission.UserAccess {
 	return permission.UserAccess{
 		UserID:      userDoc.ID,


### PR DESCRIPTION

## Description of change

This PR builds on https://github.com/juju/juju/pull/7167
Please only review the second commit https://github.com/wallyworld/juju/commit/6f26818d07323b4ee5227d1b96f8faf94071803b
(Show offer permission in CLI output)

We now show the application offer permission a user has when running juju find-endpoints of show-endpoints.

## QA steps

`$juju find-endpoints 
URL                     Access   Interfaces
admin/controller.mysql  read     mysql:db
admin/controller.foo    consume  mysql:db

$juju show-endpoints admin/controller.mysql
URL                     Access   Description                                    Endpoint  Interface  Role
admin/controller.mysql  consume  MySQL is a fast, stable and true multi-user,   db        mysql      provider
                                 multi-threaded SQL database server. SQL                             
                                 (Structured Query Language) is the most                             
                                 popular database query language in the world.                       
                                 The ma...`
