### PR TITLE
Modify subnet watcher used by firewaller worker

### DIFF
--- a/api/remotefirewaller/remotefirewaller.go
+++ b/api/remotefirewaller/remotefirewaller.go
@@ -26,18 +26,19 @@ func NewClient(caller base.APICallCloser) *Client {
 	return &Client{ClientFacade: frontend, facade: backend}
 }
 
-// WatchSubnets returns a strings watcher that notifies of the addition,
-// removal, and lifecycle changes of subnets in the model.
-func (c *Client) WatchSubnets() (watcher.StringsWatcher, error) {
-	var result params.StringsWatchResult
-	err := c.facade.FacadeCall("WatchSubnets", nil, &result)
+// WatchIngressAddressesForRelation returns a watcher that notifies when address from which
+// connections will originate for the relation change.
+func (c *Client) WatchIngressAddressesForRelation(remoteRelationId params.RemoteEntityId) (watcher.NotifyWatcher, error) {
+	args := params.RemoteEntities{[]params.RemoteEntityId{remoteRelationId}}
+	var result params.NotifyWatchResult
+	err := c.facade.FacadeCall("WatchIngressAddressesForRelation", args, &result)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
 	if result.Error != nil {
 		return nil, errors.Trace(result.Error)
 	}
-	w := apiwatcher.NewStringsWatcher(c.facade.RawAPICaller(), result)
+	w := apiwatcher.NewNotifyWatcher(c.facade.RawAPICaller(), result)
 	return w, nil
 }
 

--- a/api/remotefirewaller/remotefirewaller_test.go
+++ b/api/remotefirewaller/remotefirewaller_test.go
@@ -26,22 +26,24 @@ func (s *RemoteFirewallersSuite) TestNewClient(c *gc.C) {
 	c.Assert(client, gc.NotNil)
 }
 
-func (s *RemoteFirewallersSuite) TestWatchSubnets(c *gc.C) {
+func (s *RemoteFirewallersSuite) TestWatchIngressAddressesForRelation(c *gc.C) {
 	var callCount int
+	remoteRelationId := params.RemoteEntityId{ModelUUID: "model-uuid", Token: "token"}
 	apiCaller := testing.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
 		c.Check(objType, gc.Equals, "RemoteFirewaller")
 		c.Check(version, gc.Equals, 0)
 		c.Check(id, gc.Equals, "")
-		c.Check(request, gc.Equals, "WatchSubnets")
-		c.Assert(result, gc.FitsTypeOf, &params.StringsWatchResult{})
-		*(result.(*params.StringsWatchResult)) = params.StringsWatchResult{
+		c.Check(request, gc.Equals, "WatchIngressAddressesForRelation")
+		c.Assert(arg, gc.DeepEquals, params.RemoteEntities{Entities: []params.RemoteEntityId{remoteRelationId}})
+		c.Assert(result, gc.FitsTypeOf, &params.NotifyWatchResult{})
+		*(result.(*params.NotifyWatchResult)) = params.NotifyWatchResult{
 			Error: &params.Error{Message: "FAIL"},
 		}
 		callCount++
 		return nil
 	})
 	client := remotefirewaller.NewClient(apiCaller)
-	_, err := client.WatchSubnets()
+	_, err := client.WatchIngressAddressesForRelation(remoteRelationId)
 	c.Check(err, gc.ErrorMatches, "FAIL")
 	c.Check(callCount, gc.Equals, 1)
 }

--- a/apiserver/remotefirewaller/remotefirewaller_test.go
+++ b/apiserver/remotefirewaller/remotefirewaller_test.go
@@ -46,19 +46,21 @@ func (s *RemoteFirewallerSuite) SetUpTest(c *gc.C) {
 	s.api = api
 }
 
-func (s *RemoteFirewallerSuite) TestWatchSubnets(c *gc.C) {
+func (s *RemoteFirewallerSuite) TestWatchIngressAddressesForRelation(c *gc.C) {
 	subnetIds := []string{"1", "2"}
 	s.st.subnetsWatcher.changes <- subnetIds
 
-	result, err := s.api.WatchSubnets()
+	result, err := s.api.WatchIngressAddressesForRelation(
+		params.RemoteEntities{Entities: []params.RemoteEntityId{{
+			ModelUUID: coretesting.ModelTag.Id(), Token: "token-db2:db django:db"}},
+		})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.Error, gc.IsNil)
-	c.Assert(result.StringsWatcherId, gc.Equals, "1")
-	c.Assert(result.Changes, jc.DeepEquals, subnetIds)
+	c.Assert(result.NotifyWatcherId, gc.Equals, "1")
 
 	resource := s.resources.Get("1")
 	c.Assert(resource, gc.NotNil)
-	c.Assert(resource, gc.Implements, new(state.StringsWatcher))
+	c.Assert(resource, gc.Implements, new(state.NotifyWatcher))
 
 	s.st.CheckCalls(c, []testing.StubCall{
 		{"WatchSubnets", nil},

--- a/worker/firewaller/firewaller.go
+++ b/worker/firewaller/firewaller.go
@@ -39,7 +39,7 @@ type FirewallerAPI interface {
 // RemoteFirewallerAPI exposes remote firewaller functionality to a worker.
 type RemoteFirewallerAPI interface {
 	IngressSubnetsForRelation(id params.RemoteEntityId) (*params.IngressSubnetInfo, error)
-	WatchSubnets() (watcher.StringsWatcher, error)
+	WatchIngressAddressesForRelation(id params.RemoteEntityId) (watcher.NotifyWatcher, error)
 }
 
 // RemoteFirewallerAPICloser implements RemoteFirewallerAPI
@@ -1225,30 +1225,34 @@ func (rd *remoteRelationData) watchLoop() error {
 	}
 	defer facade.Close()
 
-	subnetsWatcher, err := facade.WatchSubnets()
+	// First, wait for relation to become ready.
+	for rd.remoteRelationId == nil {
+		select {
+		case <-rd.catacomb.Dying():
+			return rd.catacomb.ErrDying()
+		case remoteRelationId := <-rd.relationReady:
+			rd.remoteRelationId = &remoteRelationId
+			logger.Infof("relation %v is ready", remoteRelationId)
+		}
+	}
+
+	// Now watch for updates to ingress addresses.
+	addressWatcher, err := facade.WatchIngressAddressesForRelation(*rd.remoteRelationId)
 	if err != nil {
 		return errors.Trace(err)
 	}
-
 	for {
+		if err := rd.updateNetworks(facade, *rd.remoteRelationId); err != nil {
+			return errors.Trace(err)
+		}
 		select {
 		case <-rd.catacomb.Dying():
 			// We stop the watcher here as it is tied to the remote facade
 			// which is closed as soon as we return.
-			worker.Stop(subnetsWatcher)
+			worker.Stop(addressWatcher)
 			return rd.catacomb.ErrDying()
-		case <-subnetsWatcher.Changes():
-			if rd.remoteRelationId == nil {
-				// relation not ready yet.
-				continue
-			}
-			logger.Debugf("subnets changed in model %v", rd.remoteModelUUID)
-		case remoteRelationId := <-rd.relationReady:
-			rd.remoteRelationId = &remoteRelationId
-			logger.Debugf("relation %v is ready", remoteRelationId)
-		}
-		if err := rd.updateNetworks(facade, *rd.remoteRelationId); err != nil {
-			return errors.Trace(err)
+		case <-addressWatcher.Changes():
+			logger.Debugf("relation ingress addresses for %v changed in model %v", *rd.remoteRelationId, rd.remoteModelUUID)
 		}
 	}
 }


### PR DESCRIPTION

## Description of change

The remote firewaller WatchSubnets() API is renamed to WatchIngressAddressesForRelation() and now uses a notify watcher and not a strings watcher.

Followup work is need to fill out the new backend implementation.

## QA steps

Smoke test a CMR deployment.
