### PR TITLE
BUG 1677425: Gracefully handle NetworkInterfaces() returning NotSuppo…

### DIFF
--- a/apiserver/common/networkingcommon/networkconfigapi.go
+++ b/apiserver/common/networkingcommon/networkconfigapi.go
@@ -53,7 +53,12 @@ func (api *NetworkConfigAPI) getOneMachineProviderNetworkConfig(m *state.Machine
 	}
 
 	interfaceInfos, err := netEnviron.NetworkInterfaces(instId)
-	if err != nil {
+	if errors.IsNotSupported(err) {
+		// It's possible to have a networking environ, but not support
+		// NetworkInterfaces().  In leiu of adding SupportsNetworkInterfaces():
+		logger.Infof("provider network interfaces not supported: %v", err)
+		return nil, nil
+	} else if err != nil {
 		return nil, errors.Annotatef(err, "cannot get network interfaces of %q", instId)
 	}
 	if len(interfaceInfos) == 0 {

--- a/provider/openstack/networking.go
+++ b/provider/openstack/networking.go
@@ -312,8 +312,8 @@ func (n *NeutronNetworking) Subnets(instId instance.Id, subnetIds []network.Id) 
 
 	if instId != instance.UnknownId {
 		// TODO(hml): 2017-03-20
-		// Implment Subnets() for case where instId is specified
-		return nil, errors.NotImplementedf("neutron subnets with instance Id")
+		// Implement Subnets() for case where instId is specified
+		return nil, errors.NotSupportedf("neutron subnets with instance Id")
 	} else {
 		neutron := n.env.neutron()
 		subnets, err := neutron.ListSubnetsV2()
@@ -345,5 +345,5 @@ func (n *NeutronNetworking) Subnets(instId instance.Id, subnetIds []network.Id) 
 }
 
 func (n *NeutronNetworking) NetworkInterfaces(instId instance.Id) ([]network.InterfaceInfo, error) {
-	return nil, errors.NotImplementedf("neutron network interfaces")
+	return nil, errors.NotSupportedf("neutron network interfaces")
 }


### PR DESCRIPTION
…rted

## Please provide the following details to expedite Pull Request review:

----

## Description of change

Fix for Bug 1675799, gracefully handle NetworkInterface() returning NotSupported
when a Network Environ is available.

## QA steps

1. juju bootstrap to a rackspace or openstack cloud.
2. juju add-machine
3. let machine deploy and install 
4. juju add-machine lxd:0
4. wait for container to start
5. juju remove-machine 0/lxd/0
6. lxd machine should be removed.

## Documentation changes

no

## Bug reference

https://bugs.launchpad.net/juju/+bug/1677425
