### PR TITLE
CMR: use public address for units in a CM relation

### DIFF
--- a/apiserver/uniter/uniter.go
+++ b/apiserver/uniter/uniter.go
@@ -1044,11 +1044,17 @@ func (u *UniterAPIV3) EnterScope(args params.RelationUnits) (params.ErrorResults
 		if err != nil {
 			return err
 		}
-		// Construct the settings, passing the unit's
-		// private address (we already know it).
-		privateAddress, _ := unit.PrivateAddress()
+		settingsAddress, err := relUnit.SettingsAddress()
+		if err != nil {
+			return err
+		}
+
+		// Construct the settings, passing the unit's address (we
+		// already know it). Normally this will be the private
+		// address, but if this relation is to a remote application it
+		// might be the public one.
 		settings := map[string]interface{}{
-			"private-address": privateAddress.Value,
+			"private-address": settingsAddress.Value,
 		}
 		return relUnit.EnterScope(settings)
 	}

--- a/apiserver/uniter/uniter_test.go
+++ b/apiserver/uniter/uniter_test.go
@@ -2313,38 +2313,41 @@ func (s *uniterSuite) TestPrivateAddressWithRemoteRelation(c *gc.C) {
 	})
 }
 
-// Disabling until I've added the provider-hook to do this.
-// func (s *uniterSuite) TestPrivateAddressWithRemoteRelationNoPublic(c *gc.C) {
-// 	s.makeRemoteWordpress(c)
-// 	thisUniter := s.makeMysqlUniter(c)
+func (s *uniterSuite) TestPrivateAddressWithRemoteRelationNoPublic(c *gc.C) {
+	s.makeRemoteWordpress(c)
+	thisUniter := s.makeMysqlUniter(c)
 
-// 	// Set mysql's addresses first - no public address.
-// 	err := s.machine1.SetProviderAddresses(
-// 		network.NewScopedAddress("1.2.3.4", network.ScopeCloudLocal),
-// 	)
-// 	c.Assert(err, jc.ErrorIsNil)
+	// Set mysql's addresses first - no public address.
+	err := s.machine1.SetProviderAddresses(
+		network.NewScopedAddress("1.2.3.4", network.ScopeCloudLocal),
+	)
+	c.Assert(err, jc.ErrorIsNil)
 
-// 	eps, err := s.State.InferEndpoints("mysql", "remote-wordpress")
-// 	c.Assert(err, jc.ErrorIsNil)
-// 	rel, err := s.State.AddRelation(eps...)
-// 	c.Assert(err, jc.ErrorIsNil)
+	eps, err := s.State.InferEndpoints("mysql", "remote-wordpress")
+	c.Assert(err, jc.ErrorIsNil)
+	rel, err := s.State.AddRelation(eps...)
+	c.Assert(err, jc.ErrorIsNil)
 
-// 	relUnit, err := rel.Unit(s.mysqlUnit)
-// 	c.Assert(err, jc.ErrorIsNil)
-// 	s.assertInScope(c, relUnit, false)
-// 	args := params.RelationUnits{RelationUnits: []params.RelationUnit{
-// 		{Relation: rel.Tag().String(), Unit: "unit-mysql-0"},
-// 	}}
-// 	result, err := thisUniter.EnterScope(args)
-// 	c.Assert(err, jc.ErrorIsNil)
-// 	c.Assert(result, gc.DeepEquals, params.ErrorResults{
-// 		Results: []params.ErrorResult{{
-// 			Error: &params.Error{
-// 				Message: fmt.Sprintf("no public address for unit mysql/0 in cross-model relation %s", rel),
-// 			},
-// 		}},
-// 	})
-// }
+	relUnit, err := rel.Unit(s.mysqlUnit)
+	c.Assert(err, jc.ErrorIsNil)
+	s.assertInScope(c, relUnit, false)
+	args := params.RelationUnits{RelationUnits: []params.RelationUnit{
+		{Relation: rel.Tag().String(), Unit: "unit-mysql-0"},
+	}}
+	result, err := thisUniter.EnterScope(args)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result, gc.DeepEquals, params.ErrorResults{
+		Results: []params.ErrorResult{{Error: nil}},
+	})
+
+	// Verify that we fell back to the private address.
+	s.assertInScope(c, relUnit, true)
+	readSettings, err := relUnit.ReadSettings(s.mysqlUnit.Name())
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(readSettings, gc.DeepEquals, map[string]interface{}{
+		"private-address": "1.2.3.4",
+	})
+}
 
 func (s *uniterSuite) makeMysqlUniter(c *gc.C) *uniter.UniterAPIV3 {
 	authorizer := s.authorizer

--- a/state/relation.go
+++ b/state/relation.go
@@ -352,6 +352,20 @@ func (r *Relation) RemoteUnit(unitName string) (*RelationUnit, error) {
 	return r.unit(unitName, principal, isPrincipal, checkUnitLife)
 }
 
+// IsCrossModel returns whether this relation is a cross-model
+// relation.
+func (r *Relation) IsCrossModel() (bool, error) {
+	for _, ep := range r.Endpoints() {
+		_, err := r.st.RemoteApplication(ep.ApplicationName)
+		if err == nil {
+			return true, nil
+		} else if !errors.IsNotFound(err) {
+			return false, errors.Trace(err)
+		}
+	}
+	return false, nil
+}
+
 func (r *Relation) unit(
 	unitName string,
 	principal string,

--- a/state/relationunit.go
+++ b/state/relationunit.go
@@ -15,6 +15,8 @@ import (
 	"gopkg.in/mgo.v2"
 	"gopkg.in/mgo.v2/bson"
 	"gopkg.in/mgo.v2/txn"
+
+	"github.com/juju/juju/network"
 )
 
 // RelationUnit holds information about a single unit in a relation, and
@@ -408,6 +410,37 @@ func (ru *RelationUnit) ReadSettings(uname string) (m map[string]interface{}, er
 		return nil, err
 	}
 	return node.Map(), nil
+}
+
+// SettingsAddress returns the address that should be set as
+// `private-address` in the settings for the this unit in the context
+// of this relation. Generally this will be the cloud-local address of
+// the unit, but if this is a cross-model relation then it will be the
+// public address. If this is cross-model and there's no public
+// address for the unit, return an error.
+func (ru *RelationUnit) SettingsAddress() (network.Address, error) {
+	unit, err := ru.st.Unit(ru.unitName)
+	if err != nil {
+		return network.Address{}, errors.Trace(err)
+	}
+	if crossmodel, err := ru.relation.IsCrossModel(); err != nil {
+		return network.Address{}, errors.Trace(err)
+	} else if !crossmodel {
+		return unit.PrivateAddress()
+	}
+
+	address, err := unit.PublicAddress()
+	if err != nil {
+		return network.Address{}, errors.Trace(err)
+	}
+	if address.Scope != network.ScopePublic {
+		logger.Debugf(
+			"no public address for unit %q in cross-model relation %q",
+			unit.Name(),
+			ru.relation,
+		)
+	}
+	return address, nil
 }
 
 // unitKey returns a string, based on the relation and the supplied unit name,

--- a/state/relationunit_test.go
+++ b/state/relationunit_test.go
@@ -811,6 +811,64 @@ func (s *RelationUnitSuite) assertNoScopeChange(c *gc.C, ws ...*state.RelationSc
 	}
 }
 
+func (s *RelationUnitSuite) TestSettingsAddress(c *gc.C) {
+	prr := newProReqRelation(c, &s.ConnSuite, charm.ScopeGlobal)
+	err := prr.pu0.AssignToNewMachine()
+	c.Assert(err, jc.ErrorIsNil)
+	id, err := prr.pu0.AssignedMachineId()
+	c.Assert(err, jc.ErrorIsNil)
+	machine, err := s.State.Machine(id)
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = machine.SetProviderAddresses(
+		network.NewScopedAddress("1.2.3.4", network.ScopeCloudLocal),
+		network.NewScopedAddress("4.3.2.1", network.ScopePublic),
+	)
+
+	address, err := prr.pru0.SettingsAddress()
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Assert(address, gc.DeepEquals, network.NewScopedAddress("1.2.3.4", network.ScopeCloudLocal))
+}
+
+func (s *RelationUnitSuite) TestSettingsAddressRemoteRelation(c *gc.C) {
+	prr := newRemoteProReqRelation(c, &s.ConnSuite)
+	err := prr.ru0.AssignToNewMachine()
+	c.Assert(err, jc.ErrorIsNil)
+	id, err := prr.ru0.AssignedMachineId()
+	c.Assert(err, jc.ErrorIsNil)
+	machine, err := s.State.Machine(id)
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = machine.SetProviderAddresses(
+		network.NewScopedAddress("1.2.3.4", network.ScopeCloudLocal),
+		network.NewScopedAddress("4.3.2.1", network.ScopePublic),
+	)
+
+	address, err := prr.rru0.SettingsAddress()
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Assert(address, gc.DeepEquals, network.NewScopedAddress("4.3.2.1", network.ScopePublic))
+}
+
+func (s *RelationUnitSuite) TestSettingsAddressRemoteRelationNoPublicAddr(c *gc.C) {
+	prr := newRemoteProReqRelation(c, &s.ConnSuite)
+	err := prr.ru0.AssignToNewMachine()
+	c.Assert(err, jc.ErrorIsNil)
+	id, err := prr.ru0.AssignedMachineId()
+	c.Assert(err, jc.ErrorIsNil)
+	machine, err := s.State.Machine(id)
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = machine.SetProviderAddresses(
+		network.NewScopedAddress("1.2.3.4", network.ScopeCloudLocal),
+	)
+
+	address, err := prr.rru0.SettingsAddress()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(address, gc.DeepEquals, network.NewScopedAddress("1.2.3.4", network.ScopeCloudLocal))
+}
+
 type PeerRelation struct {
 	rel                *state.Relation
 	app                *state.Application
@@ -931,6 +989,7 @@ type RemoteProReqRelation struct {
 	psvc                   *state.RemoteApplication
 	rsvc                   *state.Application
 	pru0, pru1, rru0, rru1 *state.RelationUnit
+	ru0, ru1               *state.Unit
 }
 
 func newRemoteProReqRelation(c *gc.C, s *ConnSuite) *RemoteProReqRelation {
@@ -954,8 +1013,8 @@ func newRemoteProReqRelation(c *gc.C, s *ConnSuite) *RemoteProReqRelation {
 	prr := &RemoteProReqRelation{rel: rel, psvc: psvc, rsvc: rsvc}
 	prr.pru0 = addRemoteRU(c, rel, "mysql/0")
 	prr.pru1 = addRemoteRU(c, rel, "mysql/1")
-	_, prr.rru0 = addRU(c, rsvc, rel, nil)
-	_, prr.rru1 = addRU(c, rsvc, rel, nil)
+	prr.ru0, prr.rru0 = addRU(c, rsvc, rel, nil)
+	prr.ru1, prr.rru1 = addRU(c, rsvc, rel, nil)
 	return prr
 }
 


### PR DESCRIPTION
## Description of change

To ensure that we can establish connections between the units in different models in a cross-model relation, change the Uniter.EnterScope API method to report the public address for each unit in the (unfortunately-named) `private-address` setting. This means that we aren't limited to the offering and consuming model having the same tenant/VPC/network. In the future we'll use the model subnets to short-circuit connections when we can, but this lowest-common-denominator technique will work for Azure and GCE right now.

Update `RemoteFirewaller` to report the public addresses of the units (as /32 CIDRs) that need to be firewall accessible. There'll be a follow-up PR soon to change the watcher to watch the corresponding units instead of the model subnets as it does now.

## QA steps

* Bootstrap on a cloud that firewalls (like Azure or GCE).
* Create two models a and b, deploy mysql to a and wordpress to b.
* Create an offer for mysql in a.
* Relate b:wordpress to the offer.
* Expose b:wordpress.
* Verify that you can visit the wordpress public address and it works.
* Check the controller logs for `juju.apiserver.remotefirewaller` - it should report that it's adding the public 
IP of wordpress (as a /32 CIDR) to the ingress rules for mysql.

