### PR TITLE
Enable gzip compression in the Juju GUI handlers.

### DIFF
--- a/apiserver/gui.go
+++ b/apiserver/gui.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 	"text/template"
 
+	"github.com/gorilla/handlers"
 	"github.com/juju/errors"
 	"github.com/juju/version"
 
@@ -76,7 +77,7 @@ func guiEndpoints(pattern, dataDir string, ctxt httpContext) []apihttp.Endpoint 
 	}
 	var endpoints []apihttp.Endpoint
 	add := func(pattern string, h func(*guiHandler, http.ResponseWriter, *http.Request)) {
-		handler := gr.ensureFileHandler(h)
+		handler := handlers.CompressHandler(gr.ensureFileHandler(h))
 		// TODO: We can switch from all methods to specific ones for entries
 		// where we only want to support specific request methods. However, our
 		// tests currently assert that errors come back as application/json and
@@ -360,6 +361,7 @@ func sendGUIComboFile(w io.Writer, fpath string) {
 	}
 	defer f.Close()
 	if _, err := io.Copy(w, f); err != nil {
+		logger.Infof("cannot copy combo file %q: %s", fpath, err)
 		return
 	}
 	fmt.Fprintf(w, "\n/* %s */\n", filepath.Base(fpath))

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -10,6 +10,7 @@ github.com/dustin/go-humanize	git	145fabdb1ab757076a70a886d092a3af27f66f4c	2014-
 github.com/godbus/dbus	git	32c6cc29c14570de4cf6d7e7737d68fb2d01ad15	2016-05-06T22:25:50Z
 github.com/golang/protobuf	git	4bd1920723d7b7c925de087aa32e2187708897f7	2016-11-09T07:27:36Z
 github.com/google/go-querystring	git	9235644dd9e52eeae6fa48efd539fdc351a0af53	2016-04-01T23:30:42Z
+github.com/gorilla/handlers	git	13d73096a474cac93275c679c7b8a2dc17ddba82	2017-02-24T19:39:55Z
 github.com/gorilla/schema	git	08023a0215e7fc27a9aecd8b8c50913c40019478	2016-04-26T23:15:12Z
 github.com/gorilla/websocket	git	804cb600d06b10672f2fbc0a336a7bee507a428e	2017-02-14T17:41:18Z
 github.com/gosuri/uitable	git	36ee7e946282a3fb1cfecd476ddc9b35d8847e42	2016-04-04T20:39:58Z


### PR DESCRIPTION
Enable gzip compression on embedded GUI handlers, so that clients don't have to download the GUI uncompressed files.

QA: bootstrap and run `juju gui --browser`. Log into the GUI and check that everything works as usual, and that gzip compression is enabled.
