### PR TITLE
If a change is no-op, then don't create a transaction.

### DIFF
--- a/state/ipaddresses_test.go
+++ b/state/ipaddresses_test.go
@@ -503,22 +503,6 @@ func (s *ipAddressesStateSuite) TestSetDevicesAddressesFailsWhenCIDRAddressMatch
 	s.assertSetDevicesAddressesFailsForArgs(c, args, expectedError)
 }
 
-func (s *ipAddressesStateSuite) TestSetDevicesAddressesFailsWhenModelNotAlive(c *gc.C) {
-	s.addNamedDeviceForMachine(c, "eth0", s.otherStateMachine)
-	otherModel, err := s.otherState.Model()
-	c.Assert(err, jc.ErrorIsNil)
-	err = otherModel.Destroy()
-	c.Assert(err, jc.ErrorIsNil)
-
-	args := state.LinkLayerDeviceAddress{
-		CIDRAddress:  "10.20.30.40/16",
-		DeviceName:   "eth0",
-		ConfigMethod: state.StaticAddress,
-	}
-	err = s.otherStateMachine.SetDevicesAddresses(args)
-	c.Assert(err, gc.ErrorMatches, `.*: model "other-model" is no longer alive`)
-}
-
 func (s *ipAddressesStateSuite) TestSetDevicesAddressesFailsWhenMachineNotAliveOrGone(c *gc.C) {
 	s.addNamedDeviceForMachine(c, "eth0", s.otherStateMachine)
 	err := s.otherStateMachine.EnsureDead()

--- a/state/ipaddresses_test.go
+++ b/state/ipaddresses_test.go
@@ -661,17 +661,19 @@ func (s *ipAddressesStateSuite) TestSetDevicesAddressesWithMultipleUpdatesOfSame
 		DNSSearchDomains: []string{"example.com", "example.org"},
 		GatewayAddress:   "0.1.2.1",
 	}, {
-		// Test deletes work for DNS settings, also change method, provider id, and gateway.
+		// Test deletes work for DNS settings, also change method, and gateway.
 		DeviceName:       "eth0",
 		ConfigMethod:     state.DynamicAddress,
 		CIDRAddress:      "0.1.2.3/24",
-		ProviderID:       "id-xxxx", // last change wins
+		ProviderID:       "id-0123", // not allowed to change ProviderID once set
 		DNSServers:       nil,
 		DNSSearchDomains: nil,
 		GatewayAddress:   "0.1.2.2",
 	}}
-	err := s.machine.SetDevicesAddresses(setArgs...)
-	c.Assert(err, jc.ErrorIsNil)
+	for _, arg := range setArgs {
+		err := s.machine.SetDevicesAddresses(arg)
+		c.Assert(err, jc.ErrorIsNil)
+	}
 	updatedAddresses, err := device.Addresses()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(updatedAddresses, gc.HasLen, len(initialAddresses))

--- a/state/linklayerdevices.go
+++ b/state/linklayerdevices.go
@@ -352,7 +352,7 @@ func insertLinkLayerDeviceDocOp(newDoc *linkLayerDeviceDoc) txn.Op {
 // ModelUUID, MachineID, and Name cannot be changed. ProviderID cannot be
 // changed once set. In all other cases newDoc values overwrites existingDoc
 // values.
-func updateLinkLayerDeviceDocOp(existingDoc, newDoc *linkLayerDeviceDoc) txn.Op {
+func updateLinkLayerDeviceDocOp(existingDoc, newDoc *linkLayerDeviceDoc) (txn.Op, bool) {
 	changes := make(bson.M)
 	if existingDoc.ProviderID == "" && newDoc.ProviderID != "" {
 		// Only allow changing the ProviderID if it was empty.
@@ -387,7 +387,7 @@ func updateLinkLayerDeviceDocOp(existingDoc, newDoc *linkLayerDeviceDoc) txn.Op 
 		Id:     existingDoc.DocID,
 		Assert: txn.DocExists,
 		Update: updates,
-	}
+	}, len(updates) > 0
 }
 
 // assertLinkLayerDeviceExistsOp returns an operation asserting the document

--- a/state/linklayerdevices_test.go
+++ b/state/linklayerdevices_test.go
@@ -154,24 +154,6 @@ func (s *linkLayerDevicesStateSuite) TestSetLinkLayerDevicesWhenMachineNotAliveO
 	s.assertSetLinkLayerDevicesFailsForArgs(c, args, `machine "0" not alive`)
 }
 
-func (s *linkLayerDevicesStateSuite) TestSetLinkLayerDevicesWhenModelNotAlive(c *gc.C) {
-	otherModel, err := s.otherState.Model()
-	c.Assert(err, jc.ErrorIsNil)
-	err = otherModel.Destroy()
-	c.Assert(err, jc.ErrorIsNil)
-
-	args := state.LinkLayerDeviceArgs{
-		Name: "eth0",
-		Type: state.EthernetDevice,
-	}
-	err = s.otherStateMachine.SetLinkLayerDevices(args)
-	expectedError := fmt.Sprintf(
-		"cannot set link-layer devices to machine %q: model %q is no longer alive",
-		s.otherStateMachine.Id(), otherModel.Name(),
-	)
-	c.Assert(err, gc.ErrorMatches, expectedError)
-}
-
 func (s *linkLayerDevicesStateSuite) TestSetLinkLayerDevicesWithMissingParentSameMachine(c *gc.C) {
 	args := state.LinkLayerDeviceArgs{
 		Name:       "eth0",

--- a/state/linklayerdevices_test.go
+++ b/state/linklayerdevices_test.go
@@ -608,6 +608,17 @@ func (s *linkLayerDevicesStateSuite) TestLinkLayerDeviceRemoveRemovesProviderID(
 	c.Assert(err, jc.ErrorIsNil)
 }
 
+func (s *linkLayerDevicesStateSuite) TestSetLinkLayerDevicesNoop(c *gc.C) {
+	args := state.LinkLayerDeviceArgs{
+		Name: "foo",
+		Type: state.EthernetDevice,
+	}
+	err := s.machine.SetLinkLayerDevices(args)
+	c.Assert(err, jc.ErrorIsNil)
+	err = s.machine.SetLinkLayerDevices(args)
+	c.Assert(err, jc.ErrorIsNil)
+}
+
 func (s *linkLayerDevicesStateSuite) removeDeviceAndAssertSuccess(c *gc.C, givenDevice *state.LinkLayerDevice) {
 	err := givenDevice.Remove()
 	c.Assert(err, jc.ErrorIsNil)

--- a/state/linklayerdevices_test.go
+++ b/state/linklayerdevices_test.go
@@ -146,12 +146,12 @@ func (s *linkLayerDevicesStateSuite) TestSetLinkLayerDevicesWhenMachineNotAliveO
 		Name: "eth0",
 		Type: state.EthernetDevice,
 	}
-	s.assertSetLinkLayerDevicesFailsForArgs(c, args, "machine not found or not alive")
+	s.assertSetLinkLayerDevicesFailsForArgs(c, args, `machine "0" not alive`)
 
 	err = s.machine.Remove()
 	c.Assert(err, jc.ErrorIsNil)
 
-	s.assertSetLinkLayerDevicesFailsForArgs(c, args, "machine not found or not alive")
+	s.assertSetLinkLayerDevicesFailsForArgs(c, args, `machine "0" not alive`)
 }
 
 func (s *linkLayerDevicesStateSuite) TestSetLinkLayerDevicesWhenModelNotAlive(c *gc.C) {
@@ -1333,7 +1333,7 @@ func (s *linkLayerDevicesStateSuite) TestSetLinkLayerDevicesToContainerWhenConta
 		c.Assert(err, jc.ErrorIsNil)
 	}
 
-	s.assertSetLinkLayerDevicesToContainerFailsWithBeforeHook(c, beforeHook, `.*machine not found or not alive`)
+	s.assertSetLinkLayerDevicesToContainerFailsWithBeforeHook(c, beforeHook, `.*machine "0/lxd/0" not alive`)
 }
 
 func (s *linkLayerDevicesStateSuite) assertSetLinkLayerDevicesToContainerFailsWithBeforeHook(c *gc.C, beforeHook func(), expectedError string) {

--- a/state/machine_linklayerdevices.go
+++ b/state/machine_linklayerdevices.go
@@ -187,13 +187,13 @@ func (m *Machine) SetLinkLayerDevices(devicesArgs ...LinkLayerDeviceArgs) (err e
 			return nil, errors.Trace(err)
 		}
 
+		if err := checkModelActive(m.st); err != nil {
+			return nil, errors.Trace(err)
+		}
+		if err := m.isStillAlive(); err != nil {
+			return nil, errors.Trace(err)
+		}
 		if attempt > 0 {
-			if err := checkModelActive(m.st); err != nil {
-				return nil, errors.Trace(err)
-			}
-			if err := m.isStillAlive(); err != nil {
-				return nil, errors.Trace(err)
-			}
 			allIds, err := m.st.allProviderIDsForLinkLayerDevices()
 			if err != nil {
 				return nil, errors.Trace(err)
@@ -610,13 +610,13 @@ func (m *Machine) SetDevicesAddresses(devicesAddresses ...LinkLayerDeviceAddress
 			return nil, errors.Trace(err)
 		}
 
+		if err := checkModelActive(m.st); err != nil {
+			return nil, errors.Trace(err)
+		}
+		if err := m.isStillAlive(); err != nil {
+			return nil, errors.Trace(err)
+		}
 		if attempt > 0 {
-			if err := checkModelActive(m.st); err != nil {
-				return nil, errors.Trace(err)
-			}
-			if err := m.isStillAlive(); err != nil {
-				return nil, errors.Trace(err)
-			}
 			allIds, err := m.st.allProviderIDsForAddresses()
 			if err != nil {
 				return nil, errors.Trace(err)

--- a/state/machine_linklayerdevices.go
+++ b/state/machine_linklayerdevices.go
@@ -188,9 +188,6 @@ func (m *Machine) SetLinkLayerDevices(devicesArgs ...LinkLayerDeviceArgs) (err e
 			return nil, errors.Trace(err)
 		}
 
-		if err := checkModelActive(m.st); err != nil {
-			return nil, errors.Trace(err)
-		}
 		if m.doc.Life != Alive {
 			return nil, errors.Errorf("machine %q not alive", m.doc.Id)
 		}
@@ -615,9 +612,6 @@ func (m *Machine) SetDevicesAddresses(devicesAddresses ...LinkLayerDeviceAddress
 			return nil, errors.Trace(err)
 		}
 
-		if err := checkModelActive(m.st); err != nil {
-			return nil, errors.Trace(err)
-		}
 		if err := m.isStillAlive(); err != nil {
 			return nil, errors.Trace(err)
 		}

--- a/state/machine_linklayerdevices.go
+++ b/state/machine_linklayerdevices.go
@@ -649,7 +649,7 @@ func (m *Machine) SetDevicesAddresses(devicesAddresses ...LinkLayerDeviceAddress
 			// no actual address changes to be queued, so no need to create an op that just asserts
 			// the machine is alive
 			// TODO(jam) 2017-03-30: consider raising a 'nothing-to-do' error that gets trapped and just returned as 'nil' outside the loop
-			logger.Debugf("no changes to Devices Addresses for machine %q", m.Id())
+			logger.Debugf("no changes to DevicesAddresses for machine %q", m.Id())
 			return nil, errNoChanges
 		}
 		return append(ops, setAddressesOps...), nil

--- a/state/machine_linklayerdevices.go
+++ b/state/machine_linklayerdevices.go
@@ -648,7 +648,6 @@ func (m *Machine) SetDevicesAddresses(devicesAddresses ...LinkLayerDeviceAddress
 		if len(setAddressesOps) == 0 {
 			// no actual address changes to be queued, so no need to create an op that just asserts
 			// the machine is alive
-			// TODO(jam) 2017-03-30: consider raising a 'nothing-to-do' error that gets trapped and just returned as 'nil' outside the loop
 			logger.Debugf("no changes to DevicesAddresses for machine %q", m.Id())
 			return nil, errNoChanges
 		}

--- a/state/machine_linklayerdevices.go
+++ b/state/machine_linklayerdevices.go
@@ -9,8 +9,8 @@ import (
 	"net"
 
 	"github.com/juju/errors"
-	"github.com/juju/utils/set"
 	jujutxn "github.com/juju/txn"
+	"github.com/juju/utils/set"
 	"gopkg.in/mgo.v2"
 	"gopkg.in/mgo.v2/bson"
 	"gopkg.in/mgo.v2/txn"


### PR DESCRIPTION
## Description of change

Change SetLinkLayerDevices and SetDevicesAddresses so that both of them check if there are actually any changes to be done, and only if we'll actually change something do we create a transaction.

## QA steps

```
  $ juju bootstrap lxd --debug
  $ juju add-machine
  $ juju ssh 0
  $$ sudo service jujud-machine-0 restart
```
```
  $ juju ssh -m controller 0
  $ dialmgo
  $ db.txns.find({"o.c": {"$in": ["linklayerdevices", "ip.addresses"]}}).sort({"_id": -1}).limit(5).pretty()
```
```
  $ juju debug-log -m controller --include machine-0 -include-module juju.state
```
monitor the transaction log, it should not be filling up with transactions that are ultimately just asserting that a bunch of devices still exist. The debug-log should also include lines like:
```
  DEBUG juju.state no changes to LinkLayerDevices for machine "0"
  DEBUG juju.state no changes to DevicesAddresses for machine "0"
```

```
  db.txns.find({"o.c": {$exists: 0}}).pretty()
```
should return no documents. Before the last commit we were creating transactions that affected no collections, which was a bit silly.

## Documentation changes

None.

## Bug reference

[lp:1677619](https://bugs.launchpad.net/juju/+bug/1677619)
[lp:1676427](https://bugs.launchpad.net/juju/+bug/1676427)