### PR TITLE
Transaction pruning improvments

### DIFF
--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -44,7 +44,7 @@ github.com/juju/romulus	git	181593a92f0f9cd88556a267beceedfb560ee715	2017-03-16T
 github.com/juju/schema	git	075de04f9b7d7580d60a1e12a0b3f50bb18e6998	2016-04-20T04:42:03Z
 github.com/juju/terms-client	git	9b925afd677234e4146dde3cb1a11e187cbed64e	2016-08-09T13:19:00Z
 github.com/juju/testing	git	fce9bc4ebf7a77310c262ac4884e03b778eae06a	2017-02-22T09:01:19Z
-github.com/juju/txn	git	28898197906200d603394d8e4ce537436529f1c5	2016-11-16T04:07:55Z
+github.com/juju/txn	git	b0486f90a44540ef9a5cfc9f3fad904832e954fe	2017-03-31T02:42:25Z
 github.com/juju/usso	git	68a59c96c178fbbad65926e7f93db50a2cd14f33	2016-04-01T10:44:24Z
 github.com/juju/utils	git	6a26b0e1230eeaad6d2321bb63700da1b1116c2b	2017-03-17T14:03:37Z
 github.com/juju/version	git	1f41e27e54f21acccf9b2dddae063a782a8a7ceb	2016-10-31T05:19:06Z

--- a/state/txns.go
+++ b/state/txns.go
@@ -52,8 +52,8 @@ func (st *State) ResumeTransactions() error {
 func (st *State) MaybePruneTransactions() error {
 	runner, closer := st.database.TransactionRunner()
 	defer closer()
-	// Prune txns only when txn count has doubled since last prune.
-	return runner.MaybePruneTransactions(2.0)
+	// Prune txns when txn count has increased by 10% since last prune.
+	return runner.MaybePruneTransactions(1.1)
 }
 
 type multiModelRunner struct {


### PR DESCRIPTION
## Description of change

Two parts:

1. Update to newest juju/txn to pull in the improved txn pruning algorithm.

2. Prune transactions after 10% growth. Previously we would only prune after 2x growth which wasn't aggressive enough and made the prune process impact system resources much more
when it did run. Now that the pruning process is much more efficient running it more often is ok.

## QA steps

* Bootstrap a system with the txnpruner worker hacked to run every 20s instead of every 2 hours. 
* Generate transactions by deploying and relating applications
* Observed that the pruner ran when it was supposed and did the right things:
```
$ juju debug-log -m controller --include-module juju.txn
```

## Documentation changes

N.A. (internal only)

## Bug reference

https://bugs.launchpad.net/juju/+bug/1676427