### PR TITLE
Improvements to ingress address watcher

### DIFF
--- a/api/remotefirewaller/remotefirewaller.go
+++ b/api/remotefirewaller/remotefirewaller.go
@@ -26,36 +26,23 @@ func NewClient(caller base.APICallCloser) *Client {
 	return &Client{ClientFacade: frontend, facade: backend}
 }
 
-// WatchIngressAddressesForRelation returns a watcher that notifies when address from which
-// connections will originate for the relation change.
-func (c *Client) WatchIngressAddressesForRelation(remoteRelationId params.RemoteEntityId) (watcher.NotifyWatcher, error) {
+// WatchIngressAddressesForRelation returns a watcher that notifies when address, from which
+// connections will originate for the relation, change.
+// Each event contains the entire set of addresses which are required for ingress for the relation.
+func (c *Client) WatchIngressAddressesForRelation(remoteRelationId params.RemoteEntityId) (watcher.StringsWatcher, error) {
 	args := params.RemoteEntities{[]params.RemoteEntityId{remoteRelationId}}
-	var result params.NotifyWatchResult
-	err := c.facade.FacadeCall("WatchIngressAddressesForRelation", args, &result)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	if result.Error != nil {
-		return nil, errors.Trace(result.Error)
-	}
-	w := apiwatcher.NewNotifyWatcher(c.facade.RawAPICaller(), result)
-	return w, nil
-}
-
-// IngressSubnetsForRelation returns any CIDRs for which ingress is required to allow
-// the specified relation to properly function.
-func (c *Client) IngressSubnetsForRelation(remoteRelationId params.RemoteEntityId) (*params.IngressSubnetInfo, error) {
-	args := params.RemoteEntities{[]params.RemoteEntityId{remoteRelationId}}
-	var results params.IngressSubnetResults
-	err := c.facade.FacadeCall("IngressSubnetsForRelations", args, &results)
+	var results params.StringsWatchResults
+	err := c.facade.FacadeCall("WatchIngressAddressesForRelation", args, &results)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
 	if len(results.Results) != 1 {
-		return nil, errors.Errorf("expected %d result(s), got %d", 1, len(results.Results))
+		return nil, errors.Errorf("expected 1 result, got %d", len(results.Results))
 	}
-	if err := results.Results[0].Error; err != nil {
-		return nil, err
+	result := results.Results[0]
+	if result.Error != nil {
+		return nil, result.Error
 	}
-	return results.Results[0].Result, nil
+	w := apiwatcher.NewStringsWatcher(c.facade.RawAPICaller(), result)
+	return w, nil
 }

--- a/api/remotefirewaller/remotefirewaller_test.go
+++ b/api/remotefirewaller/remotefirewaller_test.go
@@ -35,31 +35,9 @@ func (s *RemoteFirewallersSuite) TestWatchIngressAddressesForRelation(c *gc.C) {
 		c.Check(id, gc.Equals, "")
 		c.Check(request, gc.Equals, "WatchIngressAddressesForRelation")
 		c.Assert(arg, gc.DeepEquals, params.RemoteEntities{Entities: []params.RemoteEntityId{remoteRelationId}})
-		c.Assert(result, gc.FitsTypeOf, &params.NotifyWatchResult{})
-		*(result.(*params.NotifyWatchResult)) = params.NotifyWatchResult{
-			Error: &params.Error{Message: "FAIL"},
-		}
-		callCount++
-		return nil
-	})
-	client := remotefirewaller.NewClient(apiCaller)
-	_, err := client.WatchIngressAddressesForRelation(remoteRelationId)
-	c.Check(err, gc.ErrorMatches, "FAIL")
-	c.Check(callCount, gc.Equals, 1)
-}
-
-func (s *RemoteFirewallersSuite) TestIngressSubnetsForRelation(c *gc.C) {
-	var callCount int
-	remoteRelationId := params.RemoteEntityId{ModelUUID: "model-uuid", Token: "token"}
-	apiCaller := testing.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
-		c.Check(objType, gc.Equals, "RemoteFirewaller")
-		c.Check(version, gc.Equals, 0)
-		c.Check(id, gc.Equals, "")
-		c.Check(request, gc.Equals, "IngressSubnetsForRelations")
-		c.Assert(arg, gc.DeepEquals, params.RemoteEntities{Entities: []params.RemoteEntityId{remoteRelationId}})
-		c.Assert(result, gc.FitsTypeOf, &params.IngressSubnetResults{})
-		*(result.(*params.IngressSubnetResults)) = params.IngressSubnetResults{
-			Results: []params.IngressSubnetResult{{
+		c.Assert(result, gc.FitsTypeOf, &params.StringsWatchResults{})
+		*(result.(*params.StringsWatchResults)) = params.StringsWatchResults{
+			Results: []params.StringsWatchResult{{
 				Error: &params.Error{Message: "FAIL"},
 			}},
 		}
@@ -67,7 +45,7 @@ func (s *RemoteFirewallersSuite) TestIngressSubnetsForRelation(c *gc.C) {
 		return nil
 	})
 	client := remotefirewaller.NewClient(apiCaller)
-	_, err := client.IngressSubnetsForRelation(remoteRelationId)
+	_, err := client.WatchIngressAddressesForRelation(remoteRelationId)
 	c.Check(err, gc.ErrorMatches, "FAIL")
 	c.Check(callCount, gc.Equals, 1)
 }

--- a/apiserver/params/crossmodel.go
+++ b/apiserver/params/crossmodel.go
@@ -365,24 +365,6 @@ type RemoteEntities struct {
 	Entities []RemoteEntityId `json:"remote-entities"`
 }
 
-// IngressSubnetInfo is the result of an IngressSubnetsForRelation call.
-type IngressSubnetInfo struct {
-	// CIDRs is the set if CIDRs which need to be allowed ingress to the application.
-	CIDRs []string `json:"cidrs,omitempty"`
-}
-
-// IngressSubnetResult holds ingress network information and an error.
-type IngressSubnetResult struct {
-	Error  *Error             `json:"error,omitempty"`
-	Result *IngressSubnetInfo `json:"result,omitempty"`
-}
-
-// IngressSubnetResults holds the result of an API call that returns
-// information about ingress networks for multiple remote relations.
-type IngressSubnetResults struct {
-	Results []IngressSubnetResult `json:"results"`
-}
-
 // ModifyModelAccessRequest holds the parameters for making grant and revoke offer calls.
 type ModifyOfferAccessRequest struct {
 	Changes []ModifyOfferAccess `json:"changes"`

--- a/apiserver/remotefirewaller/ingressaddresswatcher.go
+++ b/apiserver/remotefirewaller/ingressaddresswatcher.go
@@ -1,0 +1,181 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package remotefirewaller
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/utils/set"
+
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/network"
+	"github.com/juju/juju/state/watcher"
+	"github.com/juju/juju/worker/catacomb"
+)
+
+// IngressAddressWatcher reports changes to addresses
+// for local units in a given relation.
+// Each event contains the entire set of addresses which
+// are required for ingress for the relation.
+type IngressAddressWatcher struct {
+	catacomb catacomb.Catacomb
+
+	backend State
+	appName string
+	rel     Relation
+
+	out chan []string
+
+	// A map of known unit addresses, keyed on unit name.
+	known map[string]string
+}
+
+// NewIngressAddressWatcher creates an IngressAddressWatcher.
+func NewIngressAddressWatcher(backend State, rel Relation, appName string) (*IngressAddressWatcher, error) {
+	w := &IngressAddressWatcher{
+		backend: backend,
+		appName: appName,
+		rel:     rel,
+		known:   make(map[string]string),
+		out:     make(chan []string),
+	}
+	err := catacomb.Invoke(catacomb.Plan{
+		Site: &w.catacomb,
+		Work: w.loop,
+	})
+	return w, err
+}
+
+func (w *IngressAddressWatcher) loop() error {
+	ruw, err := w.rel.WatchUnits(w.appName)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	if err := w.catacomb.Add(ruw); err != nil {
+		return errors.Trace(err)
+	}
+
+	var (
+		sentInitial bool
+		out         chan<- []string
+	)
+	// addresses holds the current set of known addresses.
+	addresses := make(set.Strings)
+
+	for {
+		select {
+		case <-w.catacomb.Dying():
+			return w.catacomb.ErrDying()
+		case c, ok := <-ruw.Changes():
+			if !ok {
+				return watcher.EnsureErr(ruw)
+			}
+			// A unit has entered or left scope.
+			// Get the new set of addresses resulting from that
+			// change, and if different to what we know, send the change.
+			merged, err := w.mergeAddresses(addresses, c)
+			if err != nil {
+				return err
+			}
+			changed := !merged.Difference(addresses).IsEmpty() || !addresses.Difference(merged).IsEmpty()
+			if !sentInitial || changed {
+				addresses = merged
+				out = w.out
+			} else {
+				out = nil
+			}
+		case out <- formatAsCIDR(addresses.Values()):
+			sentInitial = true
+			out = nil
+		}
+	}
+}
+
+func formatAsCIDR(addresses []string) []string {
+	result := make([]string, len(addresses))
+	for i, a := range addresses {
+		result[i] = a + "/32"
+	}
+	return result
+}
+
+func (w *IngressAddressWatcher) mergeAddresses(addresses set.Strings, c params.RelationUnitsChange) (set.Strings, error) {
+	result := set.NewStrings(addresses.Values()...)
+	for name := range c.Changed {
+
+		u, err := w.backend.Unit(name)
+		if errors.IsNotFound(err) {
+			continue
+		}
+		if err != nil {
+			return result, err
+		}
+
+		// TODO - start watcher to pick up machine address changes
+		// We need to know whether to look at the public or cloud local address.
+		// For now, we'll use the public address and later if needed use a watcher
+		// parameter to look at the cloud local address.
+		addr, err := u.PublicAddress()
+		if errors.IsNotAssigned(err) {
+			logger.Debugf("unit %s is not assigned to a machine, can't get address", name)
+			continue
+		}
+		if network.IsNoAddressError(err) {
+			logger.Debugf("unit %s has no public address", name)
+			continue
+		}
+		if err != nil {
+			return result, err
+		}
+		logger.Debugf("unit %q has public address %q", name, addr.Value)
+		result.Add(addr.Value)
+		w.known[name] = addr.Value
+	}
+	for _, name := range c.Departed {
+		// If the unit is departing and we have seen its address,
+		// remove the address.
+		address := w.known[name]
+		delete(w.known, name)
+
+		// See if the address is still used by another unit.
+		inUse := false
+		for unit, addr := range w.known {
+			if name != unit && addr == address {
+				inUse = true
+				break
+			}
+		}
+		if !inUse {
+			result.Remove(address)
+		}
+	}
+	return result, nil
+}
+
+// Changes returns the event channel for this watcher.
+func (w *IngressAddressWatcher) Changes() <-chan []string {
+	return w.out
+}
+
+// Kill asks the watcher to stop without waiting for it do so.
+func (w *IngressAddressWatcher) Kill() {
+	w.catacomb.Kill(nil)
+}
+
+// Wait waits for the watcher to die and returns any
+// error encountered when it was running.
+func (w *IngressAddressWatcher) Wait() error {
+	return w.catacomb.Wait()
+}
+
+// Stop kills the watcher, then waits for it to die.
+func (w *IngressAddressWatcher) Stop() error {
+	w.Kill()
+	return w.Wait()
+}
+
+// Err returns any error encountered while the watcher
+// has been running.
+func (w *IngressAddressWatcher) Err() error {
+	return w.catacomb.Err()
+}

--- a/apiserver/remotefirewaller/ingressaddresswatcher_test.go
+++ b/apiserver/remotefirewaller/ingressaddresswatcher_test.go
@@ -1,0 +1,267 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package remotefirewaller_test
+
+import (
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/names.v2"
+
+	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/apiserver/remotefirewaller"
+	apiservertesting "github.com/juju/juju/apiserver/testing"
+	"github.com/juju/juju/network"
+	statetesting "github.com/juju/juju/state/testing"
+	coretesting "github.com/juju/juju/testing"
+)
+
+var _ = gc.Suite(&addressWatcherSuite{})
+
+type addressWatcherSuite struct {
+	coretesting.BaseSuite
+
+	resources  *common.Resources
+	authorizer *apiservertesting.FakeAuthorizer
+	st         *mockState
+	api        *remotefirewaller.FirewallerAPI
+}
+
+type nopSyncStarter struct{}
+
+func (nopSyncStarter) StartSync() {}
+
+func (s *addressWatcherSuite) SetUpTest(c *gc.C) {
+	s.BaseSuite.SetUpTest(c)
+
+	s.resources = common.NewResources()
+	s.AddCleanup(func(_ *gc.C) { s.resources.StopAll() })
+
+	s.authorizer = &apiservertesting.FakeAuthorizer{
+		Tag:        names.NewMachineTag("0"),
+		Controller: true,
+	}
+
+	s.st = newMockState(coretesting.ModelTag.Id())
+	api, err := remotefirewaller.NewRemoteFirewallerAPI(s.st, s.resources, s.authorizer)
+	c.Assert(err, jc.ErrorIsNil)
+	s.api = api
+}
+
+func (s *addressWatcherSuite) setupRelation(c *gc.C, addr string) *mockRelation {
+	rel := newMockRelation(123)
+	rel.ruwApp = "testapp"
+	s.st.relations["remote-db2:db django:db"] = rel
+	app := newMockApplication("django")
+	s.st.applications["django"] = app
+	unit := newMockUnit("django/0")
+	unit.publicAddress = network.Address{Value: addr}
+	s.st.units["django/0"] = unit
+	return rel
+}
+
+func (s *addressWatcherSuite) TestUnitEntersScope(c *gc.C) {
+	rel := s.setupRelation(c, "54.1.2.3")
+	w, err := remotefirewaller.NewIngressAddressWatcher(s.st, rel, "testapp")
+	c.Assert(err, jc.ErrorIsNil)
+	defer statetesting.AssertStop(c, w)
+	wc := statetesting.NewStringsWatcherC(c, nopSyncStarter{}, w)
+
+	rel.ruw.changes <- params.RelationUnitsChange{
+		Changed: map[string]params.UnitSettings{
+			"django/0": {},
+		},
+	}
+	wc.AssertChange("54.1.2.3/32")
+	wc.AssertNoChange()
+
+	// A not found unit doesn't trigger an event.
+	rel.ruw.changes <- params.RelationUnitsChange{
+		Changed: map[string]params.UnitSettings{
+			"unknown/0": {},
+		},
+	}
+	wc.AssertNoChange()
+}
+
+func (s *addressWatcherSuite) TestTwoUnitsEntersScope(c *gc.C) {
+	rel := s.setupRelation(c, "54.1.2.3")
+	w, err := remotefirewaller.NewIngressAddressWatcher(s.st, rel, "testapp")
+	c.Assert(err, jc.ErrorIsNil)
+	defer statetesting.AssertStop(c, w)
+	wc := statetesting.NewStringsWatcherC(c, nopSyncStarter{}, w)
+
+	unit := newMockUnit("django/1")
+	unit.publicAddress = network.Address{Value: "54.4.5.6"}
+	s.st.units["django/1"] = unit
+	rel.ruw.changes <- params.RelationUnitsChange{
+		Changed: map[string]params.UnitSettings{
+			"django/0": {},
+			"django/1": {},
+		},
+	}
+	wc.AssertChange("54.1.2.3/32", "54.4.5.6/32")
+	wc.AssertNoChange()
+}
+
+func (s *addressWatcherSuite) TestAnotherUnitsEntersScope(c *gc.C) {
+	rel := s.setupRelation(c, "54.1.2.3")
+	w, err := remotefirewaller.NewIngressAddressWatcher(s.st, rel, "testapp")
+	c.Assert(err, jc.ErrorIsNil)
+	defer statetesting.AssertStop(c, w)
+	wc := statetesting.NewStringsWatcherC(c, nopSyncStarter{}, w)
+
+	rel.ruw.changes <- params.RelationUnitsChange{
+		Changed: map[string]params.UnitSettings{
+			"django/0": {},
+		},
+	}
+	wc.AssertChange("54.1.2.3/32")
+	wc.AssertNoChange()
+
+	unit := newMockUnit("django/1")
+	unit.publicAddress = network.Address{Value: "54.4.5.6"}
+	s.st.units["django/1"] = unit
+	rel.ruw.changes <- params.RelationUnitsChange{
+		Changed: map[string]params.UnitSettings{
+			"django/1": {},
+		},
+	}
+	wc.AssertChange("54.1.2.3/32", "54.4.5.6/32")
+	wc.AssertNoChange()
+}
+
+func (s *addressWatcherSuite) TestUnitEntersScopeNoPublicAddress(c *gc.C) {
+	rel := s.setupRelation(c, "")
+	w, err := remotefirewaller.NewIngressAddressWatcher(s.st, rel, "testapp")
+	c.Assert(err, jc.ErrorIsNil)
+	defer statetesting.AssertStop(c, w)
+	wc := statetesting.NewStringsWatcherC(c, nopSyncStarter{}, w)
+
+	rel.ruw.changes <- params.RelationUnitsChange{
+		Changed: map[string]params.UnitSettings{
+			"django/0": {},
+		},
+	}
+
+	// Even though the unit has no public address,
+	// we still expect the initial event.
+	wc.AssertChange()
+	wc.AssertNoChange()
+
+	// This time no event.
+	rel.ruw.changes <- params.RelationUnitsChange{
+		Changed: map[string]params.UnitSettings{
+			"django/0": {},
+		},
+	}
+	wc.AssertNoChange()
+}
+
+func (s *addressWatcherSuite) TestUnitEntersScopeNotAssigned(c *gc.C) {
+	rel := s.setupRelation(c, "")
+	s.st.units["django/0"].assigned = false
+	w, err := remotefirewaller.NewIngressAddressWatcher(s.st, rel, "testapp")
+	c.Assert(err, jc.ErrorIsNil)
+	defer statetesting.AssertStop(c, w)
+	wc := statetesting.NewStringsWatcherC(c, nopSyncStarter{}, w)
+
+	rel.ruw.changes <- params.RelationUnitsChange{
+		Changed: map[string]params.UnitSettings{
+			"django/0": {},
+		},
+	}
+
+	// Even though the unit is not assigned,
+	// we still expect the initial event.
+	wc.AssertChange()
+	wc.AssertNoChange()
+
+	// This time no event.
+	rel.ruw.changes <- params.RelationUnitsChange{
+		Changed: map[string]params.UnitSettings{
+			"django/0": {},
+		},
+	}
+	wc.AssertNoChange()
+}
+
+func (s *addressWatcherSuite) TestUnitLeavesScopeInitial(c *gc.C) {
+	rel := s.setupRelation(c, "54.1.2.3")
+	w, err := remotefirewaller.NewIngressAddressWatcher(s.st, rel, "testapp")
+	c.Assert(err, jc.ErrorIsNil)
+	defer statetesting.AssertStop(c, w)
+	wc := statetesting.NewStringsWatcherC(c, nopSyncStarter{}, w)
+
+	rel.ruw.changes <- params.RelationUnitsChange{
+		Departed: []string{"django/0"},
+	}
+
+	// Even though the unit has not been seen via enter scope,
+	// we still expect the initial event.
+	wc.AssertChange()
+	wc.AssertNoChange()
+}
+
+func (s *addressWatcherSuite) TestUnitLeavesScope(c *gc.C) {
+	rel := s.setupRelation(c, "54.1.2.3")
+	w, err := remotefirewaller.NewIngressAddressWatcher(s.st, rel, "testapp")
+	c.Assert(err, jc.ErrorIsNil)
+	defer statetesting.AssertStop(c, w)
+	wc := statetesting.NewStringsWatcherC(c, nopSyncStarter{}, w)
+
+	unit := newMockUnit("django/1")
+	unit.publicAddress = network.Address{Value: "54.4.5.6"}
+	s.st.units["django/1"] = unit
+	rel.ruw.changes <- params.RelationUnitsChange{
+		Changed: map[string]params.UnitSettings{
+			"django/0": {},
+			"django/1": {},
+		},
+	}
+	wc.AssertChange("54.1.2.3/32", "54.4.5.6/32")
+	wc.AssertNoChange()
+
+	rel.ruw.changes <- params.RelationUnitsChange{
+		Departed: []string{"django/0"},
+	}
+
+	wc.AssertChange("54.4.5.6/32")
+	wc.AssertNoChange()
+}
+
+func (s *addressWatcherSuite) TestTwoUnitsSameAddressOneLeaves(c *gc.C) {
+	rel := s.setupRelation(c, "54.1.2.3")
+	w, err := remotefirewaller.NewIngressAddressWatcher(s.st, rel, "testapp")
+	c.Assert(err, jc.ErrorIsNil)
+	defer statetesting.AssertStop(c, w)
+	wc := statetesting.NewStringsWatcherC(c, nopSyncStarter{}, w)
+
+	unit := newMockUnit("django/1")
+	unit.publicAddress = network.Address{Value: "54.1.2.3"}
+	s.st.units["django/1"] = unit
+	rel.ruw.changes <- params.RelationUnitsChange{
+		Changed: map[string]params.UnitSettings{
+			"django/0": {},
+			"django/1": {},
+		},
+	}
+	wc.AssertChange("54.1.2.3/32")
+	wc.AssertNoChange()
+
+	// One leaves, no change.
+	rel.ruw.changes <- params.RelationUnitsChange{
+		Departed: []string{"django/0"},
+	}
+
+	wc.AssertNoChange()
+
+	// Last one leaves.
+	rel.ruw.changes <- params.RelationUnitsChange{
+		Departed: []string{"django/1"},
+	}
+
+	wc.AssertChange()
+	wc.AssertNoChange()
+}

--- a/apiserver/remotefirewaller/mock_test.go
+++ b/apiserver/remotefirewaller/mock_test.go
@@ -9,6 +9,7 @@ import (
 	"gopkg.in/juju/names.v2"
 	"gopkg.in/tomb.v1"
 
+	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/apiserver/remotefirewaller"
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/state"
@@ -19,6 +20,7 @@ type mockState struct {
 	modelUUID      string
 	remoteEntities map[names.Tag]string
 	applications   map[string]*mockApplication
+	units          map[string]*mockUnit
 	relations      map[string]*mockRelation
 	subnetsWatcher *mockStringsWatcher
 }
@@ -28,6 +30,7 @@ func newMockState(modelUUID string) *mockState {
 		modelUUID:      modelUUID,
 		relations:      make(map[string]*mockRelation),
 		applications:   make(map[string]*mockApplication),
+		units:          make(map[string]*mockUnit),
 		remoteEntities: make(map[names.Tag]string),
 		subnetsWatcher: newMockStringsWatcher(),
 	}
@@ -49,7 +52,19 @@ func (st *mockState) Application(id string) (remotefirewaller.Application, error
 	return a, nil
 }
 
-func (st *mockState) WatchSubnets() state.StringsWatcher {
+func (st *mockState) Unit(name string) (remotefirewaller.Unit, error) {
+	st.MethodCall(st, "Unit", name)
+	if err := st.NextErr(); err != nil {
+		return nil, err
+	}
+	u, ok := st.units[name]
+	if !ok {
+		return nil, errors.NotFoundf("unit %q", name)
+	}
+	return u, nil
+}
+
+func (st *mockState) WatchSubnets(func(id interface{}) bool) state.StringsWatcher {
 	st.MethodCall(st, "WatchSubnets")
 	return st.subnetsWatcher
 }
@@ -78,6 +93,11 @@ func (w *mockWatcher) Stop() error {
 	return w.Tomb.Wait()
 }
 
+func (w *mockWatcher) Err() error {
+	w.MethodCall(w, "Err")
+	return w.Tomb.Err()
+}
+
 type mockStringsWatcher struct {
 	mockWatcher
 	changes chan []string
@@ -96,8 +116,7 @@ func (w *mockStringsWatcher) Changes() <-chan []string {
 
 type mockApplication struct {
 	testing.Stub
-	name  string
-	units []*mockUnit
+	name string
 }
 
 func newMockApplication(name string) *mockApplication {
@@ -111,24 +130,19 @@ func (a *mockApplication) Name() string {
 	return a.name
 }
 
-func (a *mockApplication) AllUnits() (results []remotefirewaller.Unit, err error) {
-	a.MethodCall(a, "AllUnits")
-	for _, unit := range a.units {
-		results = append(results, unit)
-	}
-	return results, a.NextErr()
-}
-
 type mockRelation struct {
 	testing.Stub
 	id        int
 	key       string
 	endpoints []state.Endpoint
+	ruw       *mockRelationUnitsWatcher
+	ruwApp    string
 }
 
 func newMockRelation(id int) *mockRelation {
 	return &mockRelation{
-		id: id,
+		id:  id,
+		ruw: newMockRelationUnitsWatcher(),
 	}
 }
 
@@ -142,31 +156,26 @@ func (r *mockRelation) Endpoints() []state.Endpoint {
 	return r.endpoints
 }
 
-type mockUnit struct {
-	testing.Stub
-	name    string
-	address network.Address
+func (r *mockRelation) WatchUnits(applicationName string) (state.RelationUnitsWatcher, error) {
+	if r.ruwApp != applicationName {
+		return nil, errors.Errorf("unexpected app %v", applicationName)
+	}
+	return r.ruw, nil
 }
 
-func newMockUnit(name string, address network.Address) *mockUnit {
-	return &mockUnit{name: name, address: address}
+func newMockRelationUnitsWatcher() *mockRelationUnitsWatcher {
+	w := &mockRelationUnitsWatcher{changes: make(chan params.RelationUnitsChange, 1)}
+	go w.doneWhenDying()
+	return w
 }
 
-func (u *mockUnit) Name() string {
-	return u.name
+type mockRelationUnitsWatcher struct {
+	mockWatcher
+	changes chan params.RelationUnitsChange
 }
 
-func (u *mockUnit) PublicAddress() (network.Address, error) {
-	u.MethodCall(u, "PublicAddress")
-	return u.address, u.NextErr()
-}
-
-type mockSubnet struct {
-	cidr string
-}
-
-func (a *mockSubnet) CIDR() string {
-	return a.cidr
+func (w *mockRelationUnitsWatcher) Changes() <-chan params.RelationUnitsChange {
+	return w.changes
 }
 
 func (st *mockState) GetRemoteEntity(sourceModel names.ModelTag, token string) (names.Tag, error) {
@@ -192,4 +201,37 @@ func (st *mockState) KeyRelation(key string) (remotefirewaller.Relation, error) 
 		return nil, errors.NotFoundf("relation %q", key)
 	}
 	return r, nil
+}
+
+type mockUnit struct {
+	testing.Stub
+	name          string
+	assigned      bool
+	publicAddress network.Address
+}
+
+func newMockUnit(name string) *mockUnit {
+	return &mockUnit{
+		name:     name,
+		assigned: true,
+	}
+}
+
+func (u *mockUnit) Name() string {
+	u.MethodCall(u, "Name")
+	return u.name
+}
+
+func (u *mockUnit) PublicAddress() (network.Address, error) {
+	u.MethodCall(u, "PublicAddress")
+	if err := u.NextErr(); err != nil {
+		return network.Address{}, err
+	}
+	if !u.assigned {
+		return network.Address{}, errors.NotAssignedf(u.name)
+	}
+	if u.publicAddress.Value == "" {
+		return network.Address{}, network.NoAddressError("public")
+	}
+	return u.publicAddress, nil
 }

--- a/apiserver/remotefirewaller/remotefirewaller.go
+++ b/apiserver/remotefirewaller/remotefirewaller.go
@@ -8,15 +8,12 @@ import (
 
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
-	"github.com/juju/utils/set"
 	"gopkg.in/juju/charm.v6-unstable"
 	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/apiserver/params"
-	"github.com/juju/juju/network"
-	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/watcher"
 )
 
@@ -50,145 +47,119 @@ func NewRemoteFirewallerAPI(
 	}, nil
 }
 
-// stringsWatcherWrapper wraps a StringsWatcher and turns it
-// into a notify watcher.
-// TODO(wallwyworld) - this is only needed until the proper
-// backend logic is available for WatchIngressAddressesForRelation
-type stringsWatcherWrapper struct {
-	state.StringsWatcher
-	changes chan struct{}
-}
-
-func (w *stringsWatcherWrapper) Changes() <-chan struct{} {
-	return w.changes
-}
-
-func newWatcherWrapper(sw state.StringsWatcher) state.NotifyWatcher {
-	w := &stringsWatcherWrapper{
-		StringsWatcher: sw,
-		changes:        make(chan struct{}),
-	}
-	go func() {
-		for {
-			_, ok := <-w.StringsWatcher.Changes()
-			if !ok {
-				close(w.changes)
-				return
-			}
-			w.changes <- struct{}{}
-		}
-	}()
-	return w
-}
-
-// WatchIngressAddressesForRelation creates a watcher that notifies when address from which
-// connections will originate for the relation change.
-func (api *FirewallerAPI) WatchIngressAddressesForRelation(remoteEntities params.RemoteEntities) (params.NotifyWatchResult, error) {
-	var result params.NotifyWatchResult
-
-	// TODO(wallyworld) - instead of just watching subnets, we need to watch unit addresses
-	// It will depend on whether the relation can use cloud local addresses or not.
-	watch := newWatcherWrapper(api.st.WatchSubnets())
-	// Consume the initial event.
-	_, ok := <-watch.Changes()
-	if !ok {
-		return params.NotifyWatchResult{}, watcher.EnsureErr(watch)
+// WatchIngressAddressesForRelation creates a watcher that notifies when address, from which
+// connections will originate for the relation, change.
+// Each event contains the entire set of addresses which are required for ingress for the relation.
+func (api *FirewallerAPI) WatchIngressAddressesForRelation(remoteEntities params.RemoteEntities) (params.StringsWatchResults, error) {
+	results := params.StringsWatchResults{
+		make([]params.StringsWatchResult, len(remoteEntities.Entities)),
 	}
 
-	result.NotifyWatcherId = api.resources.Register(watch)
-	return result, nil
-}
-
-// IngressSubnetsForRelations returns any CIDRs for which ingress is required to allow
-// the specified relations to properly function.
-func (api *FirewallerAPI) IngressSubnetsForRelations(remoteEntities params.RemoteEntities) (params.IngressSubnetResults, error) {
-	results := params.IngressSubnetResults{
-		Results: make([]params.IngressSubnetResult, len(remoteEntities.Entities)),
-	}
-	one := func(remoteRelationId params.RemoteEntityId) (*params.IngressSubnetInfo, error) {
-		logger.Debugf("Getting ingress subnets for %+v from model %v", remoteRelationId, api.st.ModelUUID())
+	one := func(remoteRelationId params.RemoteEntityId) (id string, changes []string, _ error) {
+		logger.Debugf("Watching ingress addresses for %+v from model %v", remoteRelationId, api.st.ModelUUID())
 
 		// Load the relation details for the current token.
-		relTag, err := api.st.GetRemoteEntity(names.NewModelTag(remoteRelationId.ModelUUID), remoteRelationId.Token)
+		localEndpoint, err := api.localApplication(remoteRelationId)
 		if err != nil {
-			return nil, errors.Trace(err)
-		}
-		rel, err := api.st.KeyRelation(relTag.Id())
-		if err != nil {
-			return nil, errors.Trace(err)
+			return "", nil, errors.Trace(err)
 		}
 
-		// Gather info about the local (this model) application of the relation.
-		// We'll use the info to figure out what addresses to include.
-		var localApplication Application
-		var endpoint state.Endpoint
-		for _, ep := range rel.Endpoints() {
-			// Try looking up the info for the local application.
-			app, err := api.st.Application(ep.ApplicationName)
-			if err != nil && !errors.IsNotFound(err) {
-				return nil, errors.Trace(err)
-			} else if err == nil {
-				localApplication = app
-				endpoint = ep
-				break
-			}
-		}
-
-		var result params.IngressSubnetInfo
-		// Until networking support becomes more sophisticated, for now
-		// we only care about opening access to applications with an endpoint
-		// having the "provider" role. The assumption is that such endpoints listen
-		// to incoming connections and thus require ingress. An exception to this
-		// would be applications which accept connections onto an endpoint which
-		// has a "requirer" role.
-		// We are operating in the model hosting the "consuming" application, so check
-		// that its endpoint has the "requirer" role, meaning that we need to notify
-		// the offering model of subnets from this model required for ingress.
-		if endpoint.Role != charm.RoleRequirer {
-			return &result, errors.NotSupportedf(
-				"ingress network for application %v without requires endpoint %v", localApplication.Name(), endpoint.Name)
-		}
-
-		cidrs := set.NewStrings()
+		w, err := NewIngressAddressWatcher(api.st, localEndpoint.relation, localEndpoint.application)
 		if err != nil {
-			return nil, errors.Trace(err)
+			return "", nil, errors.Trace(err)
 		}
 
-		units, err := localApplication.AllUnits()
-		if err != nil {
-			return nil, errors.Trace(err)
+		// TODO(wallyworld) - we will need to watch subnets too, but only
+		// when we support using cloud local addresses
+		//filter := func(id interface{}) bool {
+		//	include, err := includeAsIngressSubnet(id.(string))
+		//	if err != nil {
+		//		logger.Warningf("invalid CIDR %q", id)
+		//	}
+		//	return include
+		//}
+		//w := api.st.WatchSubnets(filter)
+
+		changes, ok := <-w.Changes()
+		if !ok {
+			return "", nil, common.ServerError(watcher.EnsureErr(w))
 		}
-		for _, unit := range units {
-			address, err := unit.PublicAddress()
-			if err != nil {
-				return nil, errors.Annotatef(err, "getting public address for %q", unit.Name())
-			}
-			// TODO(wallyworld) - We only support IPv4 addresses as not all providers support IPv6.
-			if address.Type != network.IPv4Address {
-				continue
-			}
-			ip := net.ParseIP(address.Value)
-			if ip.IsLoopback() || ip.IsMulticast() {
-				continue
-			}
-			cidrs.Add(formatAsCIDR(address))
-		}
-		result.CIDRs = cidrs.SortedValues()
-		logger.Debugf("Ingress CIDRS for remote relation %v from model %v: %v", relTag, api.st.ModelUUID(), result.CIDRs)
-		return &result, nil
+		return api.resources.Register(w), changes, nil
 	}
 
 	for i, remoteRelationId := range remoteEntities.Entities {
-		networks, err := one(remoteRelationId)
+		watcherId, changes, err := one(remoteRelationId)
 		if err != nil {
 			results.Results[i].Error = common.ServerError(err)
 			continue
 		}
-		results.Results[i].Result = networks
+		results.Results[i].StringsWatcherId = watcherId
+		results.Results[i].Changes = changes
 	}
 	return results, nil
 }
 
-func formatAsCIDR(address network.Address) string {
-	return address.Value + "/32"
+type localEndpointInfo struct {
+	relation    Relation
+	application string
+	name        string
+	role        charm.RelationRole
+}
+
+func (api *FirewallerAPI) localApplication(remoteRelationId params.RemoteEntityId) (*localEndpointInfo, error) {
+	// Load the relation details for the current token.
+	relTag, err := api.st.GetRemoteEntity(names.NewModelTag(remoteRelationId.ModelUUID), remoteRelationId.Token)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	rel, err := api.st.KeyRelation(relTag.Id())
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	// Gather info about the local (this model) application of the relation.
+	// We'll use the info to figure out what addresses/subnets to include.
+	localEndpoint := localEndpointInfo{relation: rel}
+	for _, ep := range rel.Endpoints() {
+		// Try looking up the info for the local application.
+		_, err = api.st.Application(ep.ApplicationName)
+		if err != nil && !errors.IsNotFound(err) {
+			return nil, errors.Trace(err)
+		} else if err == nil {
+			localEndpoint.application = ep.ApplicationName
+			localEndpoint.name = ep.Name
+			localEndpoint.role = ep.Role
+			break
+		}
+	}
+	// Until networking support becomes more sophisticated, for now
+	// we only care about opening access to applications with an endpoint
+	// having the "provider" role. The assumption is that such endpoints listen
+	// to incoming connections and thus require ingress. An exception to this
+	// would be applications which accept connections onto an endpoint which
+	// has a "requirer" role.
+	// We are operating in the model hosting the "consuming" application, so check
+	// that its endpoint has the "requirer" role, meaning that we need to notify
+	// the offering model of subnets from this model required for ingress.
+	if localEndpoint.role != charm.RoleRequirer {
+		return nil, errors.NotSupportedf(
+			"ingress network for application %v without requires endpoint", localEndpoint.application)
+	}
+	return &localEndpoint, nil
+}
+
+// TODO(wallyworld) - this is unused until we query subnets again
+func includeAsIngressSubnet(cidr string) (bool, error) {
+	ip, _, err := net.ParseCIDR(cidr)
+	if err != nil {
+		return false, errors.Trace(err)
+	}
+	if ip.IsLoopback() || ip.IsMulticast() {
+		return false, nil
+	}
+	// TODO(wallyworld) - We only support IPv4 addresses as not all providers support IPv6.
+	if ip.To4() == nil {
+		return false, nil
+	}
+	return true, nil
 }

--- a/apiserver/remotefirewaller/remotefirewaller_test.go
+++ b/apiserver/remotefirewaller/remotefirewaller_test.go
@@ -48,28 +48,8 @@ func (s *RemoteFirewallerSuite) SetUpTest(c *gc.C) {
 }
 
 func (s *RemoteFirewallerSuite) TestWatchIngressAddressesForRelation(c *gc.C) {
-	subnetIds := []string{"1", "2"}
-	s.st.subnetsWatcher.changes <- subnetIds
-
-	result, err := s.api.WatchIngressAddressesForRelation(
-		params.RemoteEntities{Entities: []params.RemoteEntityId{{
-			ModelUUID: coretesting.ModelTag.Id(), Token: "token-db2:db django:db"}},
-		})
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(result.Error, gc.IsNil)
-	c.Assert(result.NotifyWatcherId, gc.Equals, "1")
-
-	resource := s.resources.Get("1")
-	c.Assert(resource, gc.NotNil)
-	c.Assert(resource, gc.Implements, new(state.NotifyWatcher))
-
-	s.st.CheckCalls(c, []testing.StubCall{
-		{"WatchSubnets", nil},
-	})
-}
-
-func (s *RemoteFirewallerSuite) TestIngressSubnetsForRelation(c *gc.C) {
 	db2Relation := newMockRelation(123)
+	db2Relation.ruwApp = "django"
 	db2Relation.endpoints = []state.Endpoint{
 		{
 			ApplicationName: "django",
@@ -80,56 +60,54 @@ func (s *RemoteFirewallerSuite) TestIngressSubnetsForRelation(c *gc.C) {
 				Limit:     1,
 				Scope:     charm.ScopeGlobal,
 			},
-		}, {
-			ApplicationName: "remote-db2",
-			Relation: charm.Relation{
-				Name:      "data",
-				Interface: "db2",
-				Role:      "provider",
-				Limit:     1,
-				Scope:     charm.ScopeGlobal,
-			},
 		},
 	}
 	s.st.relations["remote-db2:db django:db"] = db2Relation
-	app := newMockApplication("db2")
-	app.units = []*mockUnit{
-		{name: "django/0", address: network.NewScopedAddress("1.2.3.4", network.ScopePublic)},
-		{name: "django/1", address: network.NewScopedAddress("4.3.2.1", network.ScopePublic)},
-	}
+	app := newMockApplication("django")
 	s.st.applications["django"] = app
-
 	s.st.remoteEntities[names.NewRelationTag("remote-db2:db django:db")] = "token-db2:db django:db"
-	result, err := s.api.IngressSubnetsForRelations(
+
+	unit := newMockUnit("django/0")
+	unit.publicAddress = network.NewScopedAddress("1.2.3.4", network.ScopePublic)
+	s.st.units["django/0"] = unit
+	unit1 := newMockUnit("django/0")
+	unit1.publicAddress = network.NewScopedAddress("4.3.2.1", network.ScopePublic)
+	s.st.units["django/1"] = unit1
+
+	db2Relation.ruw.changes <- params.RelationUnitsChange{
+		Changed: map[string]params.UnitSettings{
+			"django/0": {},
+			"django/1": {},
+		},
+	}
+
+	result, err := s.api.WatchIngressAddressesForRelation(
 		params.RemoteEntities{Entities: []params.RemoteEntityId{{
 			ModelUUID: coretesting.ModelTag.Id(), Token: "token-db2:db django:db"}},
 		})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.Results, gc.HasLen, 1)
-	c.Assert(result.Results[0].Result, jc.DeepEquals, &params.IngressSubnetInfo{
-		CIDRs: []string{"1.2.3.4/32", "4.3.2.1/32"},
-	})
+	c.Assert(result.Results[0].Changes, jc.SameContents, []string{"1.2.3.4/32", "4.3.2.1/32"})
+	c.Assert(result.Results[0].Error, gc.IsNil)
+	c.Assert(result.Results[0].StringsWatcherId, gc.Equals, "1")
+
+	resource := s.resources.Get("1")
+	c.Assert(resource, gc.NotNil)
+	c.Assert(resource, gc.Implements, new(state.StringsWatcher))
 
 	s.st.CheckCalls(c, []testing.StubCall{
 		{"GetRemoteEntity", []interface{}{names.NewModelTag(coretesting.ModelTag.Id()), "token-db2:db django:db"}},
 		{"KeyRelation", []interface{}{"remote-db2:db django:db"}},
 		{"Application", []interface{}{"django"}},
+		{"Unit", []interface{}{"django/0"}},
+		{"Unit", []interface{}{"django/1"}},
 	})
 }
 
-func (s *RemoteFirewallerSuite) TestIngressSubnetsForRelationIgnoresProvider(c *gc.C) {
+func (s *RemoteFirewallerSuite) xTestWatchIngressAddressesForRelationIgnoresProvider(c *gc.C) {
 	db2Relation := newMockRelation(123)
 	db2Relation.endpoints = []state.Endpoint{
 		{
-			ApplicationName: "remote-django",
-			Relation: charm.Relation{
-				Name:      "db",
-				Interface: "db2",
-				Role:      "requirer",
-				Limit:     1,
-				Scope:     charm.ScopeGlobal,
-			},
-		}, {
 			ApplicationName: "db2",
 			Relation: charm.Relation{
 				Name:      "data",
@@ -140,20 +118,17 @@ func (s *RemoteFirewallerSuite) TestIngressSubnetsForRelationIgnoresProvider(c *
 			},
 		},
 	}
-	s.st.relations["db2:db remote-django:db"] = db2Relation
-	app := newMockApplication("db2")
-	app.units = []*mockUnit{
-		{name: "db2/0", address: network.NewScopedAddress("1.2.3.4", network.ScopePublic)},
-		{name: "db2/1", address: network.NewScopedAddress("4.3.2.1", network.ScopePublic)},
-	}
-	s.st.applications["db2"] = app
 
-	s.st.remoteEntities[names.NewRelationTag("db2:db remote-django:db")] = "token-db2:db django:db"
-	result, err := s.api.IngressSubnetsForRelations(
+	s.st.relations["remote-db2:db django:db"] = db2Relation
+	app := newMockApplication("db2")
+	s.st.applications["db2"] = app
+	s.st.remoteEntities[names.NewRelationTag("remote-db2:db django:db")] = "token-db2:db django:db"
+
+	result, err := s.api.WatchIngressAddressesForRelation(
 		params.RemoteEntities{Entities: []params.RemoteEntityId{{
 			ModelUUID: coretesting.ModelTag.Id(), Token: "token-db2:db django:db"}},
 		})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.Results, gc.HasLen, 1)
-	c.Assert(result.Results[0].Result, gc.IsNil)
+	c.Assert(result.Results[0].Error, gc.ErrorMatches, "ingress network for application db2 without requires endpoint not supported")
 }

--- a/state/cleanup.go
+++ b/state/cleanup.go
@@ -6,7 +6,10 @@ package state
 import (
 	"fmt"
 
+	"github.com/juju/utils/featureflag"
+
 	"github.com/juju/errors"
+	"github.com/juju/juju/feature"
 	"gopkg.in/juju/charm.v6-unstable"
 	"gopkg.in/juju/names.v2"
 	"gopkg.in/mgo.v2"
@@ -262,8 +265,10 @@ func (st *State) cleanupFilesystemsForDyingModel() (err error) {
 // not already Dying or Dead. It's expected to be used when a model is
 // destroyed.
 func (st *State) cleanupApplicationsForDyingModel() (err error) {
-	if err := st.removeRemoteApplicationsForDyingModel(); err != nil {
-		return err
+	if featureflag.Enabled(feature.CrossModelRelations) {
+		if err := st.removeRemoteApplicationsForDyingModel(); err != nil {
+			return err
+		}
 	}
 	return st.removeApplicationsForDyingModel()
 }

--- a/state/watcher.go
+++ b/state/watcher.go
@@ -2690,8 +2690,19 @@ func (st *State) WatchRemoteRelations() StringsWatcher {
 
 // WatchSubnets returns a StringsWatcher that notifies of changes to
 // the lifecycles of the subnets in the model.
-func (st *State) WatchSubnets() StringsWatcher {
-	return newLifecycleWatcher(st, subnetsC, nil, isLocalID(st), nil)
+func (st *State) WatchSubnets(subnetFilter func(id interface{}) bool) StringsWatcher {
+	filter := func(id interface{}) bool {
+		subnet, err := st.strictLocalID(id.(string))
+		if err != nil {
+			return false
+		}
+		if subnetFilter == nil {
+			return true
+		}
+		return subnetFilter(subnet)
+	}
+
+	return newLifecycleWatcher(st, subnetsC, nil, filter, nil)
 }
 
 // isLocalID returns a watcher filter func that rejects ids not specific

--- a/worker/catacomb/catacomb.go
+++ b/worker/catacomb/catacomb.go
@@ -198,6 +198,12 @@ func (catacomb *Catacomb) Wait() error {
 	return catacomb.tomb.Wait()
 }
 
+// Err returns the reason for the catacomb death provided via Kill
+// or Killf, or ErrStillAlive when the catacomb is still alive.
+func (catacomb *Catacomb) Err() error {
+	return catacomb.tomb.Err()
+}
+
 // Kill kills the Catacomb's internal tomb with the supplied error, or one
 // derived from it.
 //  * if it's caused by this catacomb's ErrDying, it passes on tomb.ErrDying.

--- a/worker/firewaller/firewaller_test.go
+++ b/worker/firewaller/firewaller_test.go
@@ -702,7 +702,7 @@ func (s *InstanceModeSuite) TestStartWithStateOpenPortsBroken(c *gc.C) {
 	}
 }
 
-func (s *InstanceModeSuite) assertRemoteRelation(c *gc.C, remoteCIDRs []string, expectedCIDRS []string) {
+func (s *InstanceModeSuite) assertRemoteRelation(c *gc.C, expectedCIDRS []string) {
 	// Set up another model to host one side of a remote relation.
 	otherState := s.Factory.MakeModel(c, &factory.ModelParams{Name: "other"})
 	defer otherState.Close()
@@ -766,27 +766,22 @@ func (s *InstanceModeSuite) assertRemoteRelation(c *gc.C, remoteCIDRs []string, 
 	err = re.ImportRemoteEntity(s.State.ModelTag(), otherRel.Tag(), token)
 	c.Assert(err, jc.ErrorIsNil)
 
-	// Wait for the initial ports to be opened without any explicit CIDRs.
-	s.assertPorts(c, inst, m.Id(), []network.IngressRule{
-		network.MustNewIngressRule("tcp", 3306, 3306, "0.0.0.0/0"),
+	// We should not have opened any ports yet - no unit has entered scope.
+	s.assertPorts(c, inst, m.Id(), nil)
+
+	// Add a public address to the consuming unit so the firewaller can use it.
+	wpm := otherFactory.MakeMachine(c, &factory.MachineParams{
+		Addresses: []network.Address{network.NewAddress("10.0.0.4")},
 	})
+	wpu := otherFactory.MakeUnit(c, &factory.UnitParams{Application: wp, Machine: wpm})
+	c.Assert(err, jc.ErrorIsNil)
+	relUnit, err := otherRel.Unit(wpu)
+	c.Assert(err, jc.ErrorIsNil)
 
-	if len(remoteCIDRs) > 0 {
-		// Add a public address to the consuming unit so the firewaller can use it.
-		m := otherFactory.MakeMachine(c, &factory.MachineParams{
-			Addresses: []network.Address{network.NewAddress("10.0.0.4")},
-		})
-		otherFactory.MakeUnit(c, &factory.UnitParams{Application: wp, Machine: m})
-
-		// Add subnets to the model hosting the consuming app.
-		// This will trigger the firewaller.
-		for _, cidr := range remoteCIDRs {
-			otherState.AddSubnet(state.SubnetInfo{
-				CIDR: cidr,
-			})
-			c.Assert(err, jc.ErrorIsNil)
-		}
-	}
+	// Add a unit on the consuming app and have it enter the relation scope.
+	// This will trigger the firewaller.
+	err = relUnit.EnterScope(map[string]interface{}{})
+	c.Assert(err, jc.ErrorIsNil)
 	s.assertPorts(c, inst, m.Id(), []network.IngressRule{
 		network.MustNewIngressRule("tcp", 3306, 3306, expectedCIDRS...),
 	})
@@ -794,19 +789,14 @@ func (s *InstanceModeSuite) assertRemoteRelation(c *gc.C, remoteCIDRs []string, 
 	// Check the relation ready poll time is as expected.
 	c.Assert(s.mockClock.wait, gc.Equals, 3*time.Second)
 
-	// Ports should be closed when relation dies.
-	err = rel.Destroy()
+	// Ports should be closed when unit leaves scope.
+	err = relUnit.LeaveScope()
 	c.Assert(err, jc.ErrorIsNil)
 	s.assertPorts(c, inst, m.Id(), nil)
 }
 
-func (s *InstanceModeSuite) TestRemoteRelationDefaultCIDRs(c *gc.C) {
-	// No addresses defined in remote model, to default "0.0.0.0/0" used.
-	s.assertRemoteRelation(c, nil, []string{"0.0.0.0/0"})
-}
-
 func (s *InstanceModeSuite) TestRemoteRelation(c *gc.C) {
-	s.assertRemoteRelation(c, []string{"::1/0", "10.0.0.0/24"}, []string{"10.0.0.4/32"})
+	s.assertRemoteRelation(c, []string{"10.0.0.4/32"})
 }
 
 type GlobalModeSuite struct {


### PR DESCRIPTION
## Description of change

The way the firewaller watches for ingress address changes is altered to use a stringswatcher instead of a notifywatcher. The watcher event now contains the working set of ingress addresses; there is no need for a separate api call to get the addresses, so this facade method is removed.

A new IngressAddressWatcher is added which watches for units on a given relation to enter'leave scope, and returns the set of public addresses for all units in scope. This is not used yet but will be in a subsequent PR.

## QA steps

Run up a CMR scenario on AWS.
Ensure the units can talk to each other.
Check the AWS sec group rules to ensure the expected subnets are used.
