### PR TITLE
Romulus dependency update.

### DIFF
--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -41,7 +41,7 @@ github.com/juju/pubsub	git	f4dfa62f30adc6955341b3dd73dde7c8d9b23b9e	2017-03-31T0
 github.com/juju/replicaset	git	6b5becf2232ce76656ea765d8d915d41755a1513	2016-11-25T16:08:49Z
 github.com/juju/retry	git	62c62032529169c7ec02fa48f93349604c345e1f	2015-10-29T02:48:21Z
 github.com/juju/rfc	git	ebdbbdb950cd039a531d15cdc2ac2cbd94f068ee	2016-07-11T02:42:13Z
-github.com/juju/romulus	git	181593a92f0f9cd88556a267beceedfb560ee715	2017-03-16T16:17:25Z
+github.com/juju/romulus	git	bc81f6e2d6a3b1698de8358a368b7bc4a23374dd	2017-03-31T15:19:32Z
 github.com/juju/schema	git	075de04f9b7d7580d60a1e12a0b3f50bb18e6998	2016-04-20T04:42:03Z
 github.com/juju/terms-client	git	9b925afd677234e4146dde3cb1a11e187cbed64e	2016-08-09T13:19:00Z
 github.com/juju/testing	git	fce9bc4ebf7a77310c262ac4884e03b778eae06a	2017-02-22T09:01:19Z


### PR DESCRIPTION
## Description of change

This PR updates the romulus dependency to a more recent version. The change is needed to decode error responses in a more user-friendly way.

## QA steps

Tests pass (no regressions). Romulus commands (such as `sla`) will output the `error` message given by the service in an `{error: "..."}` JSON response, if it is available. See https://github.com/juju/romulus/pull/67 for details.

## Documentation changes

No external changes.

## Bug reference

None
