### PR TITLE
Fix for Bug 1675799

### DIFF
--- a/provider/openstack/export_test.go
+++ b/provider/openstack/export_test.go
@@ -474,6 +474,24 @@ func EnsureGroup(e environs.Environ, name string, rules []neutron.RuleInfoV2) (n
 	return switching.fw.(*neutronFirewaller).ensureGroup(name, rules)
 }
 
+func MachineGroupRegexp(e environs.Environ, machineId string) string {
+	switching := e.(*Environ).firewaller.(*switchingFirewaller)
+	return switching.fw.(*neutronFirewaller).machineGroupRegexp(machineId)
+}
+
+func MachineGroupName(e environs.Environ, controllerUUID, machineId string) string {
+	switching := e.(*Environ).firewaller.(*switchingFirewaller)
+	return switching.fw.(*neutronFirewaller).machineGroupName(controllerUUID, machineId)
+}
+
+func MatchingGroup(e environs.Environ, nameRegExp string) (neutron.SecurityGroupV2, error) {
+	switching := e.(*Environ).firewaller.(*switchingFirewaller)
+	if err := switching.initFirewaller(); err != nil {
+		return neutron.SecurityGroupV2{}, err
+	}
+	return switching.fw.(*neutronFirewaller).matchingGroup(nameRegExp)
+}
+
 // ImageMetadataStorage returns a Storage object pointing where the goose
 // infrastructure sets up its keystone entry for image metadata
 func ImageMetadataStorage(e environs.Environ) envstorage.Storage {

--- a/provider/openstack/firewaller.go
+++ b/provider/openstack/firewaller.go
@@ -434,7 +434,8 @@ func (c *firewallerBase) globalGroupRegexp() string {
 }
 
 func (c *firewallerBase) machineGroupRegexp(machineId string) string {
-	return fmt.Sprintf("%s-%s", c.jujuGroupRegexp(), machineId)
+	// we are only looking to match 1 machine
+	return fmt.Sprintf("%s-%s$", c.jujuGroupRegexp(), machineId)
 }
 
 type neutronFirewaller struct {
@@ -800,8 +801,11 @@ func (c *neutronFirewaller) matchingGroup(nameRegExp string) (neutron.SecurityGr
 			matchingGroups = append(matchingGroups, group)
 		}
 	}
-	if len(matchingGroups) != 1 {
+	numMatching := len(matchingGroups)
+	if numMatching == 0 {
 		return neutron.SecurityGroupV2{}, errors.NotFoundf("security groups matching %q", nameRegExp)
+	} else if numMatching > 1 {
+		return neutron.SecurityGroupV2{}, errors.New(fmt.Sprintf("%d security groups found matching %q, expected 1", numMatching, nameRegExp))
 	}
 	return matchingGroups[0], nil
 }

--- a/provider/openstack/legacy_firewaller.go
+++ b/provider/openstack/legacy_firewaller.go
@@ -4,6 +4,7 @@
 package openstack
 
 import (
+	"fmt"
 	"regexp"
 
 	"github.com/juju/errors"
@@ -246,8 +247,11 @@ func (c *legacyNovaFirewaller) matchingGroup(nameRegExp string) (nova.SecurityGr
 			matchingGroups = append(matchingGroups, group)
 		}
 	}
-	if len(matchingGroups) != 1 {
+	numMatching := len(matchingGroups)
+	if numMatching == 0 {
 		return nova.SecurityGroup{}, errors.NotFoundf("security groups matching %q", nameRegExp)
+	} else if numMatching > 1 {
+		return nova.SecurityGroup{}, errors.New(fmt.Sprintf("%d security groups found matching %q, expected 1", numMatching, nameRegExp))
 	}
 	return matchingGroups[0], nil
 }


### PR DESCRIPTION
matchingGroup() should return only 1 group, even if a controller has 10 or more machines.
Adding related unit test and updated error messaging.

## Please provide the following details to expedite Pull Request review:

----

## Description of change

Resolved issue where regular expression for matching a machine's security group in the OpenStack provider did not account for finding unique machine numbers when the number was higher than 9.  

Added a unit test to verify results of matchingGroup() with machine numbers known to cause confusion.

Updated error messaging in matchingGroup() in case more than 1 security group is still found to 
differentiate between none found and more than 1 found.

## QA steps

1. bootstrap OpenStack
2. juju deploy -n 12 ghost
3. juju expose ghost
4. No error messages like the following should be found in the machine0.log on the controller:
2017-03-24 13:34:57 ERROR juju.worker.dependency engine.go:547 "firewaller" manifold worker returned unexpected error: security groups matching "juju-.*-deb718c6-2a6d-4df9-880f-7c8665a3570a-1" not found
2017-03-24 13:34:58 ERROR juju.worker.dependency engine.go:547 "firewaller" manifold worker returned unexpected error: cannot respond to units changes for "machine-1": security groups matching "juju-.*-d3ab9c43-dcbc-48b6-8efa-25fa800f73fb-1" not found

## Documentation changes

No

## Bug reference

https://bugs.launchpad.net/juju/+bug/1675799
