### PR TITLE
Asterisk default budget

### DIFF
--- a/cmd/juju/romulus/listbudgets/list-budgets.go
+++ b/cmd/juju/romulus/listbudgets/list-budgets.go
@@ -97,7 +97,11 @@ func formatTabular(writer io.Writer, value interface{}) error {
 
 	table.AddRow("Budget", "Monthly", "Allocated", "Available", "Spent")
 	for _, budgetEntry := range b.Budgets {
-		table.AddRow(budgetEntry.Budget, budgetEntry.Limit, budgetEntry.Allocated, budgetEntry.Available, budgetEntry.Consumed)
+		suffix := ""
+		if budgetEntry.Default {
+			suffix = "*"
+		}
+		table.AddRow(budgetEntry.Budget+suffix, budgetEntry.Limit, budgetEntry.Allocated, budgetEntry.Available, budgetEntry.Consumed)
 	}
 	table.AddRow("Total", b.Total.Limit, b.Total.Allocated, b.Total.Available, b.Total.Consumed)
 	table.AddRow("", "", "", "", "")

--- a/cmd/juju/romulus/listbudgets/list-budgets_test.go
+++ b/cmd/juju/romulus/listbudgets/list-budgets_test.go
@@ -54,6 +54,7 @@ func (s *listBudgetsSuite) TestListBudgetsOutput(c *gc.C) {
 				Unallocated: "20",
 				Available:   "45",
 				Consumed:    "5",
+				Default:     true,
 			},
 			budget.BudgetSummary{
 				Owner:       "bob",
@@ -86,7 +87,7 @@ func (s *listBudgetsSuite) TestListBudgetsOutput(c *gc.C) {
 	// Expected command output. Make sure budgets are sorted alphabetically.
 	expected := "" +
 		"Budget       \tMonthly\tAllocated\tAvailable\tSpent\n" +
-		"personal     \t     50\t       30\t       45\t    5\n" +
+		"personal*    \t     50\t       30\t       45\t    5\n" +
 		"team         \t     50\t       10\t       40\t   10\n" +
 		"work         \t    200\t      100\t      150\t   50\n" +
 		"Total        \t    300\t      140\t      235\t   65\n" +

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -41,7 +41,7 @@ github.com/juju/pubsub	git	f4dfa62f30adc6955341b3dd73dde7c8d9b23b9e	2017-03-31T0
 github.com/juju/replicaset	git	6b5becf2232ce76656ea765d8d915d41755a1513	2016-11-25T16:08:49Z
 github.com/juju/retry	git	62c62032529169c7ec02fa48f93349604c345e1f	2015-10-29T02:48:21Z
 github.com/juju/rfc	git	ebdbbdb950cd039a531d15cdc2ac2cbd94f068ee	2016-07-11T02:42:13Z
-github.com/juju/romulus	git	bc81f6e2d6a3b1698de8358a368b7bc4a23374dd	2017-03-31T15:19:32Z
+github.com/juju/romulus	git	a2065b15ccbf1e93369d9e0a4bcf33f8911d8725	2017-04-05T10:19:25Z
 github.com/juju/schema	git	075de04f9b7d7580d60a1e12a0b3f50bb18e6998	2016-04-20T04:42:03Z
 github.com/juju/terms-client	git	9b925afd677234e4146dde3cb1a11e187cbed64e	2016-08-09T13:19:00Z
 github.com/juju/testing	git	fce9bc4ebf7a77310c262ac4884e03b778eae06a	2017-02-22T09:01:19Z


### PR DESCRIPTION
## Description of change

> Why is this change needed?

So that the user can see which budget is the default when not specified.

## QA steps

> How do we verify that the change works?

In the tabular output from `juju budgets`, the default budget will have an asterisk next to it. In the JSON output, it will have a `default: true` attribute.

## Documentation changes

> Does it affect current user workflow? CLI? API?

This is a minor UX improvement to make the output more intuitive. It does not change the user workflow.

## Bug reference

> Does this change fix a bug? Please add a link to it.

N/A