### PR TITLE
Bug 1654144: Call Neutron ListNetworksV2() with a filter to find better

### DIFF
--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -86,7 +86,7 @@ google.golang.org/cloud	git	f20d6dcccb44ed49de45ae3703312cb46e627db1	2015-03-19T
 gopkg.in/amz.v3	git	8c3190dff075bf5442c9eedbf8f8ed6144a099e7	2016-12-15T13:08:49Z
 gopkg.in/check.v1	git	4f90aeace3a26ad7021961c297b22c42160c7b25	2016-01-05T16:49:36Z
 gopkg.in/errgo.v1	git	442357a80af5c6bf9b6d51ae791a39c3421004f3	2016-12-22T12:58:16Z
-gopkg.in/goose.v1	git	ac43167b647feacdd9a1e34ee81e574551bc748d	2017-02-15T01:56:23Z
+gopkg.in/goose.v1	git	3228e4f367c3d48545d0615ca00baf11c9bda375	2017-04-06T01:46:06Z
 gopkg.in/ini.v1	git	776aa739ce9373377cd16f526cdf06cb4c89b40f	2016-02-22T23:24:41Z
 gopkg.in/juju/blobstore.v2	git	51fa6e26128d74e445c72d3a91af555151cc3654	2016-01-25T02:37:03Z
 gopkg.in/juju/charm.v6-unstable	git	83771c4919d6810bce5b7e63f46bea5fbfed0b93	2016-10-03T20:31:18Z

--- a/provider/openstack/export_test.go
+++ b/provider/openstack/export_test.go
@@ -514,8 +514,8 @@ func GetNovaClient(e environs.Environ) *nova.Client {
 }
 
 // ResolveNetwork exposes environ helper function resolveNetwork for testing
-func ResolveNetwork(e environs.Environ, networkName string) (string, error) {
-	return e.(*Environ).networking.ResolveNetwork(networkName)
+func ResolveNetwork(e environs.Environ, networkName string, external bool) (string, error) {
+	return e.(*Environ).networking.ResolveNetwork(networkName, external)
 }
 
 var PortsToRuleInfo = rulesToRuleInfo

--- a/provider/openstack/legacy_networking.go
+++ b/provider/openstack/legacy_networking.go
@@ -59,7 +59,8 @@ func (*LegacyNovaNetworking) DefaultNetworks() ([]nova.ServerNetworks, error) {
 }
 
 // ResolveNetwork is part of the Networking interface.
-func (n *LegacyNovaNetworking) ResolveNetwork(name string) (string, error) {
+func (n *LegacyNovaNetworking) ResolveNetwork(name string, external bool) (string, error) {
+	// Ignore external, it's a Neutron concept.
 	if utils.IsValidUUIDString(name) {
 		return name, nil
 	}

--- a/provider/openstack/local_test.go
+++ b/provider/openstack/local_test.go
@@ -1651,7 +1651,7 @@ func (s *localServerSuite) TestAllInstancesIgnoresOtherMachines(c *gc.C) {
 
 func (s *localServerSuite) TestResolveNetworkUUID(c *gc.C) {
 	var sampleUUID = "f81d4fae-7dec-11d0-a765-00a0c91e6bf6"
-	networkId, err := openstack.ResolveNetwork(s.env, sampleUUID)
+	networkId, err := openstack.ResolveNetwork(s.env, sampleUUID, false)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(networkId, gc.Equals, sampleUUID)
 }
@@ -1660,14 +1660,17 @@ func (s *localServerSuite) TestResolveNetworkLabel(c *gc.C) {
 	// For now this test has to cheat and use knowledge of goose internals
 	var networkLabel = "net"
 	var expectNetworkId = "1"
-	networkId, err := openstack.ResolveNetwork(s.env, networkLabel)
+	networkId, err := openstack.ResolveNetwork(s.env, networkLabel, false)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(networkId, gc.Equals, expectNetworkId)
 }
 
 func (s *localServerSuite) TestResolveNetworkNotPresent(c *gc.C) {
 	var notPresentNetwork = "no-network-with-this-label"
-	networkId, err := openstack.ResolveNetwork(s.env, notPresentNetwork)
+	networkId, err := openstack.ResolveNetwork(s.env, notPresentNetwork, false)
+	c.Check(networkId, gc.Equals, "")
+	c.Assert(err, gc.ErrorMatches, `no networks exist with label "no-network-with-this-label"`)
+	networkId, err = openstack.ResolveNetwork(s.env, notPresentNetwork, true)
 	c.Check(networkId, gc.Equals, "")
 	c.Assert(err, gc.ErrorMatches, `no networks exist with label "no-network-with-this-label"`)
 }

--- a/provider/openstack/networking.go
+++ b/provider/openstack/networking.go
@@ -4,6 +4,7 @@
 package openstack
 
 import (
+	"fmt"
 	"net"
 	"sync"
 
@@ -29,8 +30,9 @@ type Networking interface {
 	DefaultNetworks() ([]nova.ServerNetworks, error)
 
 	// ResolveNetwork takes either a network ID or label
+	// with a string to specify whether the network is external
 	// and returns the corresponding network ID.
-	ResolveNetwork(string) (string, error)
+	ResolveNetwork(string, bool) (string, error)
 
 	// Subnets returns basic information about subnets known
 	// by OpenStack for the environment.
@@ -102,11 +104,11 @@ func (n *switchingNetworking) DefaultNetworks() ([]nova.ServerNetworks, error) {
 }
 
 // ResolveNetwork is part of the Networking interface.
-func (n *switchingNetworking) ResolveNetwork(name string) (string, error) {
+func (n *switchingNetworking) ResolveNetwork(name string, external bool) (string, error) {
 	if err := n.initNetworking(); err != nil {
 		return "", errors.Trace(err)
 	}
-	return n.networking.ResolveNetwork(name)
+	return n.networking.ResolveNetwork(name, external)
 }
 
 // Subnets is part of the Networking interface.
@@ -202,6 +204,14 @@ func (n *NeutronNetworking) AllocatePublicIP(instId instance.Id) (*string, error
 	return nil, lastErr
 }
 
+// externalNetworkFilter returns a neutron.Filter to match Neutron Networks with
+// router:external = true.
+func externalNetworkFilter() *neutron.Filter {
+	filter := neutron.NewFilter()
+	filter.Set(neutron.FilterRouterExternal, "true")
+	return filter
+}
+
 // getExternalNeutronNetworksByAZ returns all external networks within the
 // given availability zone. If azName is empty, return all external networks.
 func getExternalNeutronNetworksByAZ(e *Environ, azName string) ([]string, error) {
@@ -209,7 +219,7 @@ func getExternalNeutronNetworksByAZ(e *Environ, azName string) ([]string, error)
 	externalNetwork := e.ecfg().externalNetwork()
 	if externalNetwork != "" {
 		// the config specified an external network, try it first.
-		netId, err := resolveNeutronNetwork(neutron, externalNetwork)
+		netId, err := resolveNeutronNetwork(neutron, externalNetwork, true)
 		if err != nil {
 			logger.Debugf("external network %s not found, search for one", externalNetwork)
 		} else {
@@ -228,18 +238,20 @@ func getExternalNeutronNetworksByAZ(e *Environ, azName string) ([]string, error)
 		}
 	}
 	// Find all external networks in availability zone
-	networks, err := neutron.ListNetworksV2()
+	networks, err := neutron.ListNetworksV2(externalNetworkFilter())
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
 	netIds := make([]string, 0)
 	for _, network := range networks {
-		if network.External == true {
-			for _, netAZ := range network.AvailabilityZones {
-				if azName == netAZ {
-					netIds = append(netIds, network.Id)
-					break
-				}
+		// TODO (hml): OpenStack Compute and Network AZs have no direct relation,
+		// though they can be named the same.  The default AZ is named "nova" in
+		// either case. It's possible that a compute AZ was configured but not a
+		// network one.  Need to account for this.
+		for _, netAZ := range network.AvailabilityZones {
+			if azName == netAZ {
+				netIds = append(netIds, network.Id)
+				break
 			}
 		}
 	}
@@ -255,23 +267,30 @@ func (n *NeutronNetworking) DefaultNetworks() ([]nova.ServerNetworks, error) {
 }
 
 // ResolveNetwork is part of the Networking interface.
-func (n *NeutronNetworking) ResolveNetwork(name string) (string, error) {
-	return resolveNeutronNetwork(n.env.neutron(), name)
+func (n *NeutronNetworking) ResolveNetwork(name string, external bool) (string, error) {
+	return resolveNeutronNetwork(n.env.neutron(), name, external)
 }
 
-func resolveNeutronNetwork(neutron *neutron.Client, name string) (string, error) {
+// networkFilter returns a neutron.Filter to match Neutron Networks with
+// the exact given name AND router:external boolean result.
+func networkFilter(name string, external bool) *neutron.Filter {
+	filter := neutron.NewFilter()
+	filter.Set(neutron.FilterNetwork, fmt.Sprintf("^%s$", name))
+	filter.Set(neutron.FilterRouterExternal, fmt.Sprintf("%t", external))
+	return filter
+}
+
+func resolveNeutronNetwork(neutron *neutron.Client, name string, external bool) (string, error) {
 	if utils.IsValidUUIDString(name) {
 		return name, nil
 	}
-	var networkIds []string
-	networks, err := neutron.ListNetworksV2()
+	networks, err := neutron.ListNetworksV2(networkFilter(name, external))
 	if err != nil {
 		return "", err
 	}
+	var networkIds []string
 	for _, network := range networks {
-		if network.Name == name {
-			networkIds = append(networkIds, network.Id)
-		}
+		networkIds = append(networkIds, network.Id)
 	}
 	return processResolveNetworkIds(name, networkIds)
 }

--- a/provider/openstack/provider.go
+++ b/provider/openstack/provider.go
@@ -1009,7 +1009,7 @@ func (e *Environ) StartInstance(args environs.StartInstanceParams) (*environs.St
 	}
 	usingNetwork := e.ecfg().network()
 	if usingNetwork != "" {
-		networkId, err := e.networking.ResolveNetwork(usingNetwork)
+		networkId, err := e.networking.ResolveNetwork(usingNetwork, false)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
find External Networks.

## Please provide the following details to expedite Pull Request review:

----

## Description of change

There is an implementation of the OpenStack API which only returns external networks if the 
related filter is used in the API call.  Updating the OpenStack Provider code to use the new
filtering ability for ListNetworksV2() being added to goose with: https://github.com/go-goose/goose/pull/41

For the specific OpenStack in question, there are two caveats, this will not resolve the case where
--external-network is specified at bootstrap time nor will it work with Nova networking.

Also updating resolveNeutronNetwork() to use the new filtering in ListNetworksV2() with 
regards to network names.

## QA steps

Bootstrap with an OpenStack Cloud using Neutron Networking.  There should be no change to behavior.  This fix will require verification by the originating party.

## Documentation changes

N/A

## Bug reference

https://bugs.launchpad.net/juju/+bug/1654144
