### PR TITLE
provider/vsphere: implement Instance.Status

### DIFF
--- a/provider/vsphere/environ_availzones_test.go
+++ b/provider/vsphere/environ_availzones_test.go
@@ -45,7 +45,7 @@ func (s *environAvailzonesSuite) TestInstanceAvailabilityZoneNames(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	vmName, err := namespace.Hostname("1")
 	c.Assert(err, jc.ErrorIsNil)
-	s.FakeInstancesWithResourcePool(client, vsphere.InstRp{Inst: vmName, Rp: "rp1"})
+	s.FakeInstances(client, vsphere.Inst{Inst: vmName, Rp: "rp1"})
 	s.FakeClient.SetPropertyProxyHandler("FakeRootFolder", vsphere.RetrieveDatacenter)
 	s.FakeAvailabilityZonesWithResourcePool(client, vsphere.ZoneRp{Zone: "z1", Rp: "rp1"}, vsphere.ZoneRp{Zone: "z2", Rp: "rp2"})
 

--- a/provider/vsphere/environ_broker_test.go
+++ b/provider/vsphere/environ_broker_test.go
@@ -39,7 +39,7 @@ func (s *environBrokerSuite) PrepareStartInstanceFakes(c *gc.C) {
 	defer closer()
 	s.FakeClient = client
 	client.SetPropertyProxyHandler("FakeDatacenter", vsphere.RetrieveDatacenterProperties)
-	s.FakeInstances(client)
+	s.FakeInstances(client /* none */)
 	s.FakeAvailabilityZones(client, "z1")
 	s.FakeAvailabilityZones(client, "z1")
 	s.FakeAvailabilityZones(client, "z1")

--- a/provider/vsphere/environ_instance_test.go
+++ b/provider/vsphere/environ_instance_test.go
@@ -40,7 +40,7 @@ func (s *environInstanceSuite) TestInstances(c *gc.C) {
 	client.SetPropertyProxyHandler("FakeDatacenter", vsphere.RetrieveDatacenterProperties)
 	vmName1 := s.machineName(c, "1")
 	vmName2 := s.machineName(c, "2")
-	s.FakeInstancesWithResourcePool(client, vsphere.InstRp{Inst: vmName1, Rp: "rp1"}, vsphere.InstRp{Inst: vmName2, Rp: "rp2"})
+	s.FakeInstances(client, vsphere.Inst{Inst: vmName1, Rp: "rp1"}, vsphere.Inst{Inst: vmName2, Rp: "rp2"})
 
 	instances, err := s.Env.Instances([]instance.Id{instance.Id(vmName1), instance.Id(vmName2)})
 
@@ -56,7 +56,7 @@ func (s *environInstanceSuite) TestInstancesNoInstances(c *gc.C) {
 	defer closer()
 	s.FakeClient = client
 	client.SetPropertyProxyHandler("FakeDatacenter", vsphere.RetrieveDatacenterProperties)
-	s.FakeInstances(client)
+	s.FakeInstances(client /* none */)
 
 	_, err = s.Env.Instances([]instance.Id{"Some other name"})
 
@@ -69,7 +69,7 @@ func (s *environInstanceSuite) TestInstancesNoMatchingInstances(c *gc.C) {
 	defer closer()
 	s.FakeClient = client
 	client.SetPropertyProxyHandler("FakeDatacenter", vsphere.RetrieveDatacenterProperties)
-	s.FakeInstancesWithResourcePool(client, vsphere.InstRp{Inst: "Some name that don't match naming convention", Rp: "rp1"})
+	s.FakeInstances(client, vsphere.Inst{Inst: "Some name that don't match naming convention", Rp: "rp1"})
 
 	_, err = s.Env.Instances([]instance.Id{instance.Id("Some other name")})
 
@@ -83,7 +83,7 @@ func (s *environInstanceSuite) TestInstancesReturnPartialInstances(c *gc.C) {
 	client.SetPropertyProxyHandler("FakeDatacenter", vsphere.RetrieveDatacenterProperties)
 	vmName1 := s.machineName(c, "1")
 	vmName2 := s.machineName(c, "2")
-	s.FakeInstancesWithResourcePool(client, vsphere.InstRp{Inst: vmName1, Rp: "rp1"}, vsphere.InstRp{Inst: "Some inst", Rp: "rp2"})
+	s.FakeInstances(client, vsphere.Inst{Inst: vmName1, Rp: "rp1"}, vsphere.Inst{Inst: "Some inst", Rp: "rp2"})
 
 	s.FakeClient = client
 	_, err = s.Env.Instances([]instance.Id{instance.Id(vmName1), instance.Id(vmName2)})

--- a/provider/vsphere/fake_methods_test.go
+++ b/provider/vsphere/fake_methods_test.go
@@ -91,24 +91,13 @@ func (s *BaseSuite) createFakeOva() []byte {
 
 }
 
-func (s *BaseSuite) FakeInstances(c *fakeClient, instName ...string) {
-	c.SetPropertyProxyHandler("FakeVmFolder", func(reqBody, resBody *methods.RetrievePropertiesBody) {
-		resBody.Res = &types.RetrievePropertiesResponse{
-			Returnval: []types.ObjectContent{},
-		}
-	})
-	c.SetPropertyProxyHandler("FakeVmFolder", func(reqBody, resBody *methods.RetrievePropertiesBody) {
-		resBody.Res = &types.RetrievePropertiesResponse{
-			Returnval: []types.ObjectContent{},
-		}
-	})
+type Inst struct {
+	Inst       string
+	Rp         string
+	PowerState string
 }
 
-type InstRp struct {
-	Inst, Rp string
-}
-
-func (s *BaseSuite) FakeInstancesWithResourcePool(c *fakeClient, instances ...InstRp) {
+func (s *BaseSuite) FakeInstances(c *fakeClient, instances ...Inst) {
 	retVal := []types.ObjectContent{}
 	for _, vm := range instances {
 		retVal = append(retVal, types.ObjectContent{
@@ -149,6 +138,7 @@ func (s *BaseSuite) FakeInstancesWithResourcePool(c *fakeClient, instances ...In
 						Value: vm.Rp,
 					}},
 					{Name: "name", Val: vm.Inst},
+					{Name: "runtime.powerState", Val: vm.PowerState},
 				},
 			}},
 		})

--- a/provider/vsphere/instance.go
+++ b/provider/vsphere/instance.go
@@ -6,6 +6,7 @@ package vsphere
 import (
 	"github.com/juju/errors"
 	"github.com/vmware/govmomi/vim25/mo"
+	"github.com/vmware/govmomi/vim25/types"
 
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/network"
@@ -34,13 +35,15 @@ func (inst *environInstance) Id() instance.Id {
 
 // Status implements instance.Instance.
 func (inst *environInstance) Status() instance.InstanceStatus {
-	// TODO(perrito666) I wont change the commented line because it was
-	// there and I have not enough knowledge about this provider
-	// but that method does not exist.
-	// return inst.base.Status()
-	return instance.InstanceStatus{
-		Status: status.Pending,
+	instanceStatus := instance.InstanceStatus{
+		Status:  status.Empty,
+		Message: string(inst.base.Runtime.PowerState),
 	}
+	switch inst.base.Runtime.PowerState {
+	case types.VirtualMachinePowerStatePoweredOn:
+		instanceStatus.Status = status.Running
+	}
+	return instanceStatus
 }
 
 // Addresses implements instance.Instance.

--- a/provider/vsphere/instance_test.go
+++ b/provider/vsphere/instance_test.go
@@ -1,0 +1,64 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package vsphere_test
+
+import (
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/instance"
+	"github.com/juju/juju/provider/vsphere"
+	"github.com/juju/juju/status"
+)
+
+type InstanceSuiteSuite struct {
+	vsphere.BaseSuite
+	namespace instance.Namespace
+}
+
+var _ = gc.Suite(&InstanceSuiteSuite{})
+
+func (s *InstanceSuiteSuite) SetUpTest(c *gc.C) {
+	s.BaseSuite.SetUpTest(c)
+	namespace, err := instance.NewNamespace(s.Env.Config().UUID())
+	c.Assert(err, jc.ErrorIsNil)
+	s.namespace = namespace
+}
+
+func (s *InstanceSuiteSuite) machineName(c *gc.C, id string) string {
+	name, err := s.namespace.Hostname(id)
+	c.Assert(err, jc.ErrorIsNil)
+	return name
+}
+
+func (s *InstanceSuiteSuite) TestInstances(c *gc.C) {
+	client, closer, err := vsphere.ExposeEnvFakeClient(s.Env)
+	c.Assert(err, jc.ErrorIsNil)
+	defer closer()
+	s.FakeClient = client
+	client.SetPropertyProxyHandler("FakeDatacenter", vsphere.RetrieveDatacenterProperties)
+	vmName1 := s.machineName(c, "1")
+	vmName2 := s.machineName(c, "2")
+	s.FakeInstances(client, vsphere.Inst{
+		Inst:       vmName1,
+		PowerState: "poweredOn",
+	}, vsphere.Inst{
+		Inst:       vmName2,
+		PowerState: "poweredOff",
+	})
+
+	instances, err := s.Env.Instances([]instance.Id{
+		instance.Id(vmName1),
+		instance.Id(vmName2),
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(instances[0].Status(), jc.DeepEquals, instance.InstanceStatus{
+		Status:  status.Running,
+		Message: "poweredOn",
+	})
+	c.Assert(instances[1].Status(), jc.DeepEquals, instance.InstanceStatus{
+		Status:  status.Empty,
+		Message: "poweredOff",
+	})
+}


### PR DESCRIPTION
## Description of change

Implement Instance.Status properly, in terms of the
VM power state. The status is "running" if the machine
is powered on. This change is required for model
migration to work with vsphere.

## QA steps

1. juju bootstrap vsphere
2. juju status -m controller --format=yaml
the machine status should be "running", with a message of "poweredOn"

## Documentation changes

No.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1679563