### PR TITLE
Update tests for new error formatting.

### DIFF
--- a/cmd/juju/application/config_test.go
+++ b/cmd/juju/application/config_test.go
@@ -141,7 +141,7 @@ func (s *configCommandSuite) TestGetConfigKeyNotFound(c *gc.C) {
 	ctx := coretesting.Context(c)
 	code := cmd.Main(application.NewConfigCommandForTest(s.fake), ctx, []string{"dummy-application", "invalid"})
 	c.Check(code, gc.Equals, 1)
-	c.Assert(ctx.Stderr.(*bytes.Buffer).String(), gc.Equals, "error: key \"invalid\" not found in \"dummy-application\" application settings.\n")
+	c.Assert(ctx.Stderr.(*bytes.Buffer).String(), gc.Equals, "ERROR key \"invalid\" not found in \"dummy-application\" application settings.\n")
 	c.Assert(ctx.Stdout.(*bytes.Buffer).String(), gc.Equals, "")
 }
 
@@ -231,24 +231,24 @@ func (s *configCommandSuite) TestSetSameValue(c *gc.C) {
 
 func (s *configCommandSuite) TestSetOptionFail(c *gc.C) {
 	s.assertSetFail(c, s.dir, []string{"foo", "bar"},
-		"error: can only retrieve a single value, or all values\n")
-	s.assertSetFail(c, s.dir, []string{"=bar"}, "error: expected \"key=value\", got \"=bar\"\n")
+		"ERROR can only retrieve a single value, or all values\n")
+	s.assertSetFail(c, s.dir, []string{"=bar"}, "ERROR expected \"key=value\", got \"=bar\"\n")
 	s.assertSetFail(c, s.dir, []string{
 		"username=@missing.txt",
-	}, "error: cannot read option from file \"missing.txt\": .* "+utils.NoSuchFileErrRegexp+"\n")
+	}, "ERROR cannot read option from file \"missing.txt\": .* "+utils.NoSuchFileErrRegexp+"\n")
 	s.assertSetFail(c, s.dir, []string{
 		"username=@big.txt",
-	}, "error: size of option file is larger than 5M\n")
+	}, "ERROR size of option file is larger than 5M\n")
 	s.assertSetFail(c, s.dir, []string{
 		"username=@invalid.txt",
-	}, "error: value for option \"username\" contains non-UTF-8 sequences\n")
+	}, "ERROR value for option \"username\" contains non-UTF-8 sequences\n")
 }
 
 func (s *configCommandSuite) TestSetConfig(c *gc.C) {
 	s.assertSetFail(c, s.dir, []string{
 		"--file",
 		"missing.yaml",
-	}, "error.* "+utils.NoSuchFileErrRegexp+"\n")
+	}, "ERROR.* "+utils.NoSuchFileErrRegexp+"\n")
 
 	ctx := coretesting.ContextForDir(c, s.dir)
 	code := cmd.Main(application.NewConfigCommandForTest(s.fake), ctx, []string{

--- a/cmd/juju/commands/main_test.go
+++ b/cmd/juju/commands/main_test.go
@@ -102,17 +102,17 @@ func (s *MainSuite) TestRunMain(c *gc.C) {
 		summary: "unknown option before command",
 		args:    []string{"--cheese", "bootstrap"},
 		code:    2,
-		out:     "error: flag provided but not defined: --cheese\n",
+		out:     "ERROR flag provided but not defined: --cheese\n",
 	}, {
 		summary: "unknown option after command",
 		args:    []string{"bootstrap", "--cheese"},
 		code:    2,
-		out:     "error: flag provided but not defined: --cheese\n",
+		out:     "ERROR flag provided but not defined: --cheese\n",
 	}, {
 		summary: "known option, but specified before command",
 		args:    []string{"--model", "blah", "bootstrap"},
 		code:    2,
-		out:     "error: flag provided but not defined: --model\n",
+		out:     "ERROR flag provided but not defined: --model\n",
 	}, {
 		summary: "juju sync-tools registered properly",
 		args:    []string{"sync-tools", "--help"},

--- a/cmd/juju/status/status_test.go
+++ b/cmd/juju/status/status_test.go
@@ -4134,7 +4134,7 @@ func (s *StatusSuite) TestStatusWithNilStatusAPI(c *gc.C) {
 
 	code, _, stderr := runStatus(c, "--format", "tabular")
 	c.Check(code, gc.Equals, 1)
-	c.Check(string(stderr), gc.Equals, "error: unable to obtain the current status\n")
+	c.Check(string(stderr), gc.Equals, "ERROR unable to obtain the current status\n")
 }
 
 func (s *StatusSuite) TestFormatTabularMetering(c *gc.C) {

--- a/cmd/juju/user/login_test.go
+++ b/cmd/juju/user/login_test.go
@@ -63,10 +63,10 @@ func (s *LoginCommandSuite) TestInitError(c *gc.C) {
 		stderr string
 	}{{
 		args:   []string{"--foobar"},
-		stderr: `error: flag provided but not defined: --foobar\n`,
+		stderr: `ERROR flag provided but not defined: --foobar\n`,
 	}, {
 		args:   []string{"foobar", "extra"},
-		stderr: `error: unrecognized args: \["extra"\]\n`,
+		stderr: `ERROR unrecognized args: \["extra"\]\n`,
 	}} {
 		c.Logf("test %d", i)
 		stdout, stderr, code := runLogin(c, "", test.args...)
@@ -163,7 +163,7 @@ func (s *LoginCommandSuite) TestLoginWithNonExistentController(c *gc.C) {
 	stdout, stderr, code := runLogin(c, "", "-c", "something")
 	c.Assert(code, gc.Equals, 1)
 	c.Check(stdout, gc.Equals, "")
-	c.Check(stderr, gc.Matches, `error: controller "something" does not exist\n`)
+	c.Check(stderr, gc.Matches, `ERROR controller "something" does not exist\n`)
 }
 
 func (s *LoginCommandSuite) TestLoginWithNoCurrentController(c *gc.C) {
@@ -171,14 +171,14 @@ func (s *LoginCommandSuite) TestLoginWithNoCurrentController(c *gc.C) {
 	stdout, stderr, code := runLogin(c, "")
 	c.Assert(code, gc.Equals, 1)
 	c.Check(stdout, gc.Equals, "")
-	c.Check(stderr, gc.Matches, `error: no current controller\n`)
+	c.Check(stderr, gc.Matches, `ERROR no current controller\n`)
 }
 
 func (s *LoginCommandSuite) TestLoginAlreadyLoggedInDifferentUser(c *gc.C) {
 	stdout, stderr, code := runLogin(c, "", "-u", "other-user")
 	c.Check(stdout, gc.Equals, "")
 	c.Check(stderr, gc.Equals, `
-error: cannot log into controller "testing": already logged in as current-user.
+ERROR cannot log into controller "testing": already logged in as current-user.
 
 Run "juju logout" first before attempting to log in as a different user.
 `[1:])

--- a/cmd/juju/user/logincontroller_test.go
+++ b/cmd/juju/user/logincontroller_test.go
@@ -94,7 +94,7 @@ func (s *LoginCommandSuite) TestRegisterPublicHostnameWithPort(c *gc.C) {
 	s.apiConnection.controllerAccess = "login"
 	stdout, stderr, code := s.run(c, "0.1.2.3:5678")
 	c.Check(stdout, gc.Equals, "")
-	c.Check(stderr, gc.Equals, "error: cannot use \"0.1.2.3:5678\" as a controller name - use -c flag to choose a different one\n")
+	c.Check(stderr, gc.Equals, "ERROR cannot use \"0.1.2.3:5678\" as a controller name - use -c flag to choose a different one\n")
 	c.Check(code, gc.Equals, 1)
 }
 
@@ -129,7 +129,7 @@ func (s *LoginCommandSuite) TestRegisterPublicAPIOpenError(c *gc.C) {
 	}
 	stdout, stderr, code := s.run(c, "bighost")
 	c.Check(stdout, gc.Equals, "")
-	c.Check(stderr, gc.Matches, `error: cannot log into "bighost": open failed\n`)
+	c.Check(stderr, gc.Matches, `ERROR cannot log into "bighost": open failed\n`)
 	c.Check(code, gc.Equals, 1)
 }
 
@@ -145,7 +145,7 @@ func (s *LoginCommandSuite) TestRegisterPublicControllerMismatch(c *gc.C) {
 	stdout, stderr, code := s.run(c, "-c", "other", "bighost")
 	c.Check(stdout, gc.Equals, "")
 	c.Check(stderr, gc.Matches, `
-error: controller at "bighost" does not match existing controller.
+ERROR controller at "bighost" does not match existing controller.
 Please choose a different controller name with the -c flag, or
 use "juju unregister other" to remove the existing controller\.
 `[1:])

--- a/cmd/jujud/main.go
+++ b/cmd/jujud/main.go
@@ -206,7 +206,7 @@ func Main(args []string) int {
 
 	ctx, err := cmd.DefaultContext()
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		logger.Errorf("error: %v\n", err)
 		os.Exit(exit_err)
 	}
 
@@ -230,7 +230,7 @@ func Main(args []string) int {
 		code, err = jujuCMain(commandName, ctx, args)
 	}
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		logger.Errorf("%v\n", err)
 	}
 	return code
 }

--- a/cmd/jujud/main_test.go
+++ b/cmd/jujud/main_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/juju/juju/juju/names"
 	coretesting "github.com/juju/juju/testing"
 	"github.com/juju/juju/worker/uniter/runner/jujuc"
+	"github.com/juju/loggo"
 )
 
 var caCertFile string
@@ -84,7 +85,7 @@ func checkMessage(c *gc.C, msg string, cmd ...string) {
 	c.Logf(string(output))
 	c.Assert(err, gc.ErrorMatches, "exit status 2")
 	lines := strings.Split(string(output), "\n")
-	c.Assert(lines[len(lines)-2], gc.Equals, "error: "+msg)
+	c.Assert(lines[len(lines)-2], jc.Contains, msg)
 }
 
 func (s *MainSuite) TestParseErrors(c *gc.C) {
@@ -212,6 +213,7 @@ func osDependentSockPath(c *gc.C) string {
 }
 
 func (s *JujuCMainSuite) SetUpSuite(c *gc.C) {
+	loggo.DefaultContext().AddWriter("default", cmd.NewWarningWriter(os.Stderr))
 	factory := func(contextId, cmdName string) (cmd.Command, error) {
 		if contextId != "bill" {
 			return nil, fmt.Errorf("bad context: %s", contextId)
@@ -241,14 +243,14 @@ var argsTests = []struct {
 	code   int
 	output string
 }{
-	{[]string{"jujuc", "whatever"}, 2, jujudDoc + "error: jujuc should not be called directly\n"},
+	{[]string{"jujuc", "whatever"}, 2, "jujuc should not be called directly\n"},
 	{[]string{"remote"}, 0, "success!\n"},
 	{[]string{"/path/to/remote"}, 0, "success!\n"},
 	{[]string{"remote", "--help"}, 0, expectUsage},
-	{[]string{"unknown"}, 1, "error: bad request: bad command: unknown\n"},
-	{[]string{"remote", "--error", "borken"}, 1, "error: borken\n"},
-	{[]string{"remote", "--unknown"}, 2, "error: flag provided but not defined: --unknown\n"},
-	{[]string{"remote", "unwanted"}, 2, `error: unrecognized args: ["unwanted"]` + "\n"},
+	{[]string{"unknown"}, 1, "bad request: bad command: unknown\n"},
+	{[]string{"remote", "--error", "borken"}, 1, "borken\n"},
+	{[]string{"remote", "--unknown"}, 2, "flag provided but not defined: --unknown\n"},
+	{[]string{"remote", "unwanted"}, 2, `unrecognized args: ["unwanted"]` + "\n"},
 }
 
 func (s *JujuCMainSuite) TestArgs(c *gc.C) {
@@ -258,7 +260,8 @@ func (s *JujuCMainSuite) TestArgs(c *gc.C) {
 	for _, t := range argsTests {
 		c.Log(t.args)
 		output := run(c, s.sockPath, "bill", t.code, nil, t.args...)
-		c.Assert(output, gc.Equals, t.output)
+		c.Assert(output, jc.Contains, t.output)
+
 	}
 }
 
@@ -267,7 +270,7 @@ func (s *JujuCMainSuite) TestNoClientId(c *gc.C) {
 		c.Skip("issue 1403084: test panics on CryptAcquireContext on windows")
 	}
 	output := run(c, s.sockPath, "", 1, nil, "remote")
-	c.Assert(output, gc.Equals, "error: JUJU_CONTEXT_ID not set\n")
+	c.Assert(output, jc.Contains, "JUJU_CONTEXT_ID not set\n")
 }
 
 func (s *JujuCMainSuite) TestBadClientId(c *gc.C) {
@@ -275,7 +278,7 @@ func (s *JujuCMainSuite) TestBadClientId(c *gc.C) {
 		c.Skip("issue 1403084: test panics on CryptAcquireContext on windows")
 	}
 	output := run(c, s.sockPath, "ben", 1, nil, "remote")
-	c.Assert(output, gc.Equals, "error: bad request: bad context: ben\n")
+	c.Assert(output, jc.Contains, "bad request: bad context: ben\n")
 }
 
 func (s *JujuCMainSuite) TestNoSockPath(c *gc.C) {
@@ -283,7 +286,7 @@ func (s *JujuCMainSuite) TestNoSockPath(c *gc.C) {
 		c.Skip("issue 1403084: test panics on CryptAcquireContext on windows")
 	}
 	output := run(c, "", "bill", 1, nil, "remote")
-	c.Assert(output, gc.Equals, "error: JUJU_AGENT_SOCKET not set\n")
+	c.Assert(output, jc.Contains, "JUJU_AGENT_SOCKET not set\n")
 }
 
 func (s *JujuCMainSuite) TestBadSockPath(c *gc.C) {
@@ -292,7 +295,7 @@ func (s *JujuCMainSuite) TestBadSockPath(c *gc.C) {
 	}
 	badSock := filepath.Join(c.MkDir(), "bad.sock")
 	output := run(c, badSock, "bill", 1, nil, "remote")
-	err := fmt.Sprintf("error: dial unix %s: .*\n", badSock)
+	err := fmt.Sprintf("^.* dial unix %s: .*\n", badSock)
 	c.Assert(output, gc.Matches, err)
 }
 

--- a/cmd/plugins/juju-metadata/toolsmetadata_test.go
+++ b/cmd/plugins/juju-metadata/toolsmetadata_test.go
@@ -297,7 +297,7 @@ func (s *ToolsMetadataSuite) TestNoTools(c *gc.C) {
 	stdout := ctx.Stdout.(*bytes.Buffer).String()
 	c.Assert(stdout, gc.Matches, ".*Finding tools in .*\n")
 	stderr := ctx.Stderr.(*bytes.Buffer).String()
-	c.Assert(stderr, gc.Matches, "error: no tools available\n")
+	c.Assert(stderr, gc.Matches, "ERROR no tools available\n")
 }
 
 func (s *ToolsMetadataSuite) TestPatchLevels(c *gc.C) {

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -20,7 +20,7 @@ github.com/joyent/gosign	git	0da0d5f1342065321c97812b1f4ac0c2b0bab56c	2014-05-24
 github.com/juju/ansiterm	git	b99631de12cf04a906c1d4e4ec54fb86eae5863d	2016-09-07T23:45:32Z
 github.com/juju/blobstore	git	06056004b3d7b54bbb7984d830c537bad00fec21	2015-07-29T11:18:58Z
 github.com/juju/bundlechanges	git	7725027b95e0d54635e0fb11efc2debdcdf19f75	2016-12-15T16:06:52Z
-github.com/juju/cmd	git	9425a576247f348b9b40afe3b60085de63470de5	2017-03-20T01:37:09Z
+github.com/juju/cmd	git	bd2e5f58d3dd312dfc8845beef36f23f4e4f5cd4	2017-03-29T20:57:14Z
 github.com/juju/description	git	0b0134bd1b5a0676537883958c55ccd1c6fafbc7	2017-03-30T02:44:27Z
 github.com/juju/errors	git	1b5e39b83d1835fa480e0c2ddefb040ee82d58b3	2015-09-16T12:56:42Z
 github.com/juju/gnuflag	git	4e76c56581859c14d9d87e1ddbe29e1c0f10195f	2016-08-09T16:52:14Z

--- a/worker/uniter/runner/jujuc/action-fail_test.go
+++ b/worker/uniter/runner/jujuc/action-fail_test.go
@@ -69,7 +69,7 @@ func (s *ActionFailSuite) TestActionFail(c *gc.C) {
 	}, {
 		summary: "extra arguments are an error, leaving the action not failed",
 		command: []string{"a failure message", "something else"},
-		errMsg:  "error: unrecognized args: [\"something else\"]\n",
+		errMsg:  "ERROR unrecognized args: [\"something else\"]\n",
 		code:    2,
 	}}
 
@@ -94,7 +94,7 @@ func (s *ActionFailSuite) TestNonActionSetActionFailedFails(c *gc.C) {
 	ctx := testing.Context(c)
 	code := cmd.Main(com, ctx, []string{"oops"})
 	c.Check(code, gc.Equals, 1)
-	c.Check(bufferString(ctx.Stderr), gc.Equals, "error: not running an action\n")
+	c.Check(bufferString(ctx.Stderr), gc.Equals, "ERROR not running an action\n")
 	c.Check(bufferString(ctx.Stdout), gc.Equals, "")
 }
 

--- a/worker/uniter/runner/jujuc/action-get_test.go
+++ b/worker/uniter/runner/jujuc/action-get_test.go
@@ -46,7 +46,7 @@ func (s *ActionGetSuite) TestNonActionRunFail(c *gc.C) {
 	code := cmd.Main(com, ctx, []string{})
 	c.Check(code, gc.Equals, 1)
 	c.Check(bufferString(ctx.Stdout), gc.Equals, "")
-	expect := fmt.Sprintf(`(\n)*error: %s\n`, "ActionParams queried from non-Action hook context")
+	expect := fmt.Sprintf(`(\n)*ERROR %s\n`, "ActionParams queried from non-Action hook context")
 	c.Check(bufferString(ctx.Stderr), gc.Matches, expect)
 }
 
@@ -262,7 +262,7 @@ func (s *ActionGetSuite) TestActionGet(c *gc.C) {
 			c.Check(bufferString(ctx.Stderr), gc.Equals, "")
 		} else {
 			c.Check(bufferString(ctx.Stdout), gc.Equals, "")
-			expect := fmt.Sprintf(`(\n)*error: %s\n`, t.errMsg)
+			expect := fmt.Sprintf(`(\n)*ERROR %s\n`, t.errMsg)
 			c.Check(bufferString(ctx.Stderr), gc.Matches, expect)
 		}
 	}

--- a/worker/uniter/runner/jujuc/action-set_test.go
+++ b/worker/uniter/runner/jujuc/action-set_test.go
@@ -50,7 +50,7 @@ func (s *ActionSetSuite) TestActionSetOnNonActionContextFails(c *gc.C) {
 	code := cmd.Main(com, ctx, []string{"oops=nope"})
 	c.Check(code, gc.Equals, 1)
 	c.Check(bufferString(ctx.Stdout), gc.Equals, "")
-	expect := fmt.Sprintf(`(\n)*error: %s\n`, "not running an action")
+	expect := fmt.Sprintf(`(\n)*ERROR %s\n`, "not running an action")
 	c.Check(bufferString(ctx.Stderr), gc.Matches, expect)
 }
 
@@ -64,12 +64,12 @@ func (s *ActionSetSuite) TestActionSet(c *gc.C) {
 	}{{
 		summary: "bare value(s) are an Init error",
 		command: []string{"result"},
-		errMsg:  "error: argument \"result\" must be of the form key...=value\n",
+		errMsg:  "ERROR argument \"result\" must be of the form key...=value\n",
 		code:    2,
 	}, {
 		summary: "invalid keys are an error",
 		command: []string{"result-Value=5"},
-		errMsg:  "error: key \"result-Value\" must start and end with lowercase alphanumeric, and contain only lowercase alphanumeric, hyphens and periods\n",
+		errMsg:  "ERROR key \"result-Value\" must start and end with lowercase alphanumeric, and contain only lowercase alphanumeric, hyphens and periods\n",
 		code:    2,
 	}, {
 		summary: "empty values are not an error",

--- a/worker/uniter/runner/jujuc/add-metric_test.go
+++ b/worker/uniter/runner/jujuc/add-metric_test.go
@@ -61,7 +61,7 @@ func (s *AddMetricSuite) TestAddMetric(c *gc.C) {
 			true,
 			2,
 			"",
-			"error: no metrics specified\n",
+			"ERROR no metrics specified\n",
 			nil,
 		}, {
 			"invalid argument format",
@@ -69,7 +69,7 @@ func (s *AddMetricSuite) TestAddMetric(c *gc.C) {
 			true,
 			2,
 			"",
-			"error: expected \"key=value\", got \"key\"\n",
+			"ERROR expected \"key=value\", got \"key\"\n",
 			nil,
 		}, {
 			"invalid argument format",
@@ -77,7 +77,7 @@ func (s *AddMetricSuite) TestAddMetric(c *gc.C) {
 			true,
 			2,
 			"",
-			"error: expected \"key=value\", got \"=key\"\n",
+			"ERROR expected \"key=value\", got \"=key\"\n",
 			nil,
 		}, {
 			"invalid argument format, whitespace key",
@@ -85,7 +85,7 @@ func (s *AddMetricSuite) TestAddMetric(c *gc.C) {
 			true,
 			2,
 			"",
-			"error: expected \"key=value\", got \"=value\"\n",
+			"ERROR expected \"key=value\", got \"=value\"\n",
 			nil,
 		}, {
 			"invalid argument format, whitespace key and value",
@@ -93,7 +93,7 @@ func (s *AddMetricSuite) TestAddMetric(c *gc.C) {
 			true,
 			2,
 			"",
-			"error: expected \"key=value\", got \"=\"\n",
+			"ERROR expected \"key=value\", got \"=\"\n",
 			nil,
 		}, {
 			"invalid argument format, whitespace value",
@@ -101,7 +101,7 @@ func (s *AddMetricSuite) TestAddMetric(c *gc.C) {
 			true,
 			2,
 			"",
-			"error: expected \"key=value\", got \"key=\"\n",
+			"ERROR expected \"key=value\", got \"key=\"\n",
 			nil,
 		}, {
 			"multiple metrics",
@@ -117,7 +117,7 @@ func (s *AddMetricSuite) TestAddMetric(c *gc.C) {
 			true,
 			2,
 			"",
-			"error: key \"key\" specified more than once\n",
+			"ERROR key \"key\" specified more than once\n",
 			nil,
 		}, {
 			"newline in metric value",
@@ -133,7 +133,7 @@ func (s *AddMetricSuite) TestAddMetric(c *gc.C) {
 			false,
 			1,
 			"",
-			"error: cannot record metric: metrics disabled\n",
+			"ERROR cannot record metric: metrics disabled\n",
 			nil,
 		}, {
 			"cannot add builtin metric",
@@ -141,7 +141,7 @@ func (s *AddMetricSuite) TestAddMetric(c *gc.C) {
 			true,
 			1,
 			"",
-			"error: juju-key uses a reserved prefix\n",
+			"ERROR juju-key uses a reserved prefix\n",
 			nil,
 		}}
 	for i, t := range testCases {

--- a/worker/uniter/runner/jujuc/application-version-set_test.go
+++ b/worker/uniter/runner/jujuc/application-version-set_test.go
@@ -34,7 +34,7 @@ func (s *ApplicationVersionSetSuite) TestApplicationVersionSetNoArguments(c *gc.
 	code := cmd.Main(com, ctx, nil)
 	c.Check(code, gc.Equals, 2)
 	c.Check(bufferString(ctx.Stdout), gc.Equals, "")
-	c.Check(bufferString(ctx.Stderr), gc.Equals, "error: no version specified\n")
+	c.Check(bufferString(ctx.Stderr), gc.Equals, "ERROR no version specified\n")
 	c.Check(hctx.info.Version.WorkloadVersion, gc.Equals, "")
 }
 
@@ -54,7 +54,7 @@ func (s *ApplicationVersionSetSuite) TestApplicationVersionSetError(c *gc.C) {
 	code := cmd.Main(com, ctx, []string{"cannae"})
 	c.Check(code, gc.Equals, 1)
 	c.Check(bufferString(ctx.Stdout), gc.Equals, "")
-	c.Check(bufferString(ctx.Stderr), gc.Equals, "error: uh oh spaghettio\n")
+	c.Check(bufferString(ctx.Stderr), gc.Equals, "ERROR uh oh spaghettio\n")
 	c.Check(hctx.info.Version.WorkloadVersion, gc.Equals, "")
 }
 

--- a/worker/uniter/runner/jujuc/config-get_test.go
+++ b/worker/uniter/runner/jujuc/config-get_test.go
@@ -179,5 +179,5 @@ func (s *ConfigGetSuite) TestAllPlusKey(c *gc.C) {
 	ctx := testing.Context(c)
 	code := cmd.Main(com, ctx, []string{"--all", "--format", "json", "monsters"})
 	c.Assert(code, gc.Equals, 2)
-	c.Assert(bufferString(ctx.Stderr), gc.Equals, "error: cannot use argument --all together with key \"monsters\"\n")
+	c.Assert(bufferString(ctx.Stderr), gc.Equals, "ERROR cannot use argument --all together with key \"monsters\"\n")
 }

--- a/worker/uniter/runner/jujuc/is-leader_test.go
+++ b/worker/uniter/runner/jujuc/is-leader_test.go
@@ -40,7 +40,7 @@ func (s *isLeaderSuite) TestFormatError(c *gc.C) {
 	code := cmd.Main(command, runContext, []string{"--format", "bad"})
 	c.Check(code, gc.Equals, 2)
 	c.Check(bufferString(runContext.Stdout), gc.Equals, "")
-	c.Check(bufferString(runContext.Stderr), gc.Equals, `error: invalid value "bad" for flag --format: unknown format "bad"`+"\n")
+	c.Check(bufferString(runContext.Stderr), gc.Equals, `ERROR invalid value "bad" for flag --format: unknown format "bad"`+"\n")
 }
 
 func (s *isLeaderSuite) TestIsLeaderError(c *gc.C) {
@@ -52,7 +52,7 @@ func (s *isLeaderSuite) TestIsLeaderError(c *gc.C) {
 	c.Check(code, gc.Equals, 1)
 	c.Check(jujucContext.called, jc.IsTrue)
 	c.Check(bufferString(runContext.Stdout), gc.Equals, "")
-	c.Check(bufferString(runContext.Stderr), gc.Equals, "error: leadership status unknown: pow\n")
+	c.Check(bufferString(runContext.Stderr), gc.Equals, "ERROR leadership status unknown: pow\n")
 }
 
 func (s *isLeaderSuite) TestFormatDefaultYes(c *gc.C) {

--- a/worker/uniter/runner/jujuc/juju-log_test.go
+++ b/worker/uniter/runner/jujuc/juju-log_test.go
@@ -5,10 +5,7 @@
 package jujuc_test
 
 import (
-	"fmt"
-
 	"github.com/juju/cmd"
-	"github.com/juju/loggo"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
@@ -21,59 +18,6 @@ type JujuLogSuite struct {
 }
 
 var _ = gc.Suite(&JujuLogSuite{})
-
-func assertLogs(c *gc.C, ctx jujuc.Context, writer *loggo.TestWriter, unitname, badge string) {
-	msg1 := "the chickens"
-	msg2 := "are 110% AWESOME"
-	com, err := jujuc.NewCommand(ctx, cmdString("juju-log"))
-	c.Assert(err, jc.ErrorIsNil)
-	for _, t := range []struct {
-		args  []string
-		level loggo.Level
-	}{
-		{
-			level: loggo.INFO,
-		}, {
-			args:  []string{"--debug"},
-			level: loggo.DEBUG,
-		}, {
-			args:  []string{"--log-level", "TRACE"},
-			level: loggo.TRACE,
-		}, {
-			args:  []string{"--log-level", "info"},
-			level: loggo.INFO,
-		}, {
-			args:  []string{"--log-level", "WaRnInG"},
-			level: loggo.WARNING,
-		}, {
-			args:  []string{"--log-level", "error"},
-			level: loggo.ERROR,
-		},
-	} {
-		writer.Clear()
-		c.Assert(err, jc.ErrorIsNil)
-
-		args := append(t.args, msg1, msg2)
-		code := cmd.Main(com, &cmd.Context{}, args)
-		c.Assert(code, gc.Equals, 0)
-		log := writer.Log()
-		c.Assert(log, gc.HasLen, 1)
-		c.Assert(log[0].Level, gc.Equals, t.level)
-		c.Assert(log[0].Module, gc.Equals, fmt.Sprintf("unit.%s.juju-log", unitname))
-		c.Assert(log[0].Message, gc.Equals, fmt.Sprintf("%s%s %s", badge, msg1, msg2))
-	}
-}
-
-func (s *JujuLogSuite) TestBadges(c *gc.C) {
-	tw := &loggo.TestWriter{}
-	_, err := loggo.ReplaceDefaultWriter(tw)
-	loggo.GetLogger("unit").SetLogLevel(loggo.TRACE)
-	c.Assert(err, jc.ErrorIsNil)
-	hctx, _ := s.newHookContext(-1, "")
-	assertLogs(c, hctx, tw, "u/0", "")
-	hctx, _ = s.newHookContext(1, "u/1")
-	assertLogs(c, hctx, tw, "u/0", "peer1:1: ")
-}
 
 func (s *JujuLogSuite) newJujuLogCommand(c *gc.C) cmd.Command {
 	ctx, _ := s.newHookContext(-1, "")

--- a/worker/uniter/runner/jujuc/leader-get_test.go
+++ b/worker/uniter/runner/jujuc/leader-get_test.go
@@ -52,7 +52,7 @@ func (s *leaderGetSuite) TestFormatError(c *gc.C) {
 	code := cmd.Main(s.command, runContext, []string{"--format", "bad"})
 	c.Check(code, gc.Equals, 2)
 	c.Check(bufferString(runContext.Stdout), gc.Equals, "")
-	c.Check(bufferString(runContext.Stderr), gc.Equals, `error: invalid value "bad" for flag --format: unknown format "bad"`+"\n")
+	c.Check(bufferString(runContext.Stderr), gc.Equals, `ERROR invalid value "bad" for flag --format: unknown format "bad"`+"\n")
 }
 
 func (s *leaderGetSuite) TestSettingsError(c *gc.C) {
@@ -64,7 +64,7 @@ func (s *leaderGetSuite) TestSettingsError(c *gc.C) {
 	c.Check(code, gc.Equals, 1)
 	c.Check(jujucContext.called, jc.IsTrue)
 	c.Check(bufferString(runContext.Stdout), gc.Equals, "")
-	c.Check(bufferString(runContext.Stderr), gc.Equals, "error: cannot read leadership settings: zap\n")
+	c.Check(bufferString(runContext.Stderr), gc.Equals, "ERROR cannot read leadership settings: zap\n")
 }
 
 func (s *leaderGetSuite) TestSettingsFormatDefaultMissingKey(c *gc.C) {

--- a/worker/uniter/runner/jujuc/leader-set_test.go
+++ b/worker/uniter/runner/jujuc/leader-set_test.go
@@ -78,7 +78,7 @@ func (s *leaderSetSuite) TestWriteError(c *gc.C) {
 	c.Check(code, gc.Equals, 1)
 	c.Check(jujucContext.gotSettings, jc.DeepEquals, map[string]string{"foo": "bar"})
 	c.Check(bufferString(runContext.Stdout), gc.Equals, "")
-	c.Check(bufferString(runContext.Stderr), gc.Equals, "error: cannot write leadership settings: splat\n")
+	c.Check(bufferString(runContext.Stderr), gc.Equals, "ERROR cannot write leadership settings: splat\n")
 }
 
 type leaderSetContext struct {

--- a/worker/uniter/runner/jujuc/network-get_test.go
+++ b/worker/uniter/runner/jujuc/network-get_test.go
@@ -103,7 +103,7 @@ func (s *NetworkGetSuite) TestNetworkGet(c *gc.C) {
 			c.Check(bufferString(ctx.Stdout), gc.Equals, expect)
 		} else {
 			c.Check(bufferString(ctx.Stdout), gc.Equals, "")
-			expect := fmt.Sprintf(`(.|\n)*error: %s\n`, t.out)
+			expect := fmt.Sprintf(`(.|\n)*ERROR %s\n`, t.out)
 			c.Check(bufferString(ctx.Stderr), gc.Matches, expect)
 		}
 	}

--- a/worker/uniter/runner/jujuc/reboot_test.go
+++ b/worker/uniter/runner/jujuc/reboot_test.go
@@ -107,5 +107,5 @@ func (s *JujuRebootSuite) TestRebootInActions(c *gc.C) {
 	cmdCtx := testing.Context(c)
 	code := cmd.Main(com, cmdCtx, nil)
 	c.Check(code, gc.Equals, 1)
-	c.Assert(testing.Stderr(cmdCtx), gc.Equals, "error: juju-reboot is not supported when running an action.\n")
+	c.Assert(testing.Stderr(cmdCtx), gc.Equals, "ERROR juju-reboot is not supported when running an action.\n")
 }

--- a/worker/uniter/runner/jujuc/relation-get_test.go
+++ b/worker/uniter/runner/jujuc/relation-get_test.go
@@ -158,7 +158,7 @@ func (s *RelationGetSuite) TestRelationGet(c *gc.C) {
 			c.Check(bufferString(ctx.Stdout), gc.Equals, expect)
 		} else {
 			c.Check(bufferString(ctx.Stdout), gc.Equals, "")
-			expect := fmt.Sprintf(`(.|\n)*error: %s\n`, t.out)
+			expect := fmt.Sprintf(`(.|\n)*ERROR %s\n`, t.out)
 			c.Check(bufferString(ctx.Stderr), gc.Matches, expect)
 		}
 	}

--- a/worker/uniter/runner/jujuc/relation-ids_test.go
+++ b/worker/uniter/runner/jujuc/relation-ids_test.go
@@ -43,7 +43,7 @@ var relationIdsTests = []struct {
 		summary: "no default, no name",
 		relid:   -1,
 		code:    2,
-		out:     "(.|\n)*error: no relation name specified\n",
+		out:     "(.|\n)*ERROR no relation name specified\n",
 	}, {
 		summary: "default name",
 		relid:   1,

--- a/worker/uniter/runner/jujuc/relation-list_test.go
+++ b/worker/uniter/runner/jujuc/relation-list_test.go
@@ -129,7 +129,7 @@ func (s *RelationListSuite) TestRelationList(c *gc.C) {
 			c.Check(bufferString(ctx.Stdout), gc.Equals, expect)
 		} else {
 			c.Check(bufferString(ctx.Stdout), gc.Equals, "")
-			expect := fmt.Sprintf(`(.|\n)*error: %s\n`, t.out)
+			expect := fmt.Sprintf(`(.|\n)*ERROR %s\n`, t.out)
 			c.Check(bufferString(ctx.Stderr), gc.Matches, expect)
 		}
 	}

--- a/worker/uniter/runner/jujuc/server_test.go
+++ b/worker/uniter/runner/jujuc/server_test.go
@@ -232,13 +232,13 @@ func (s *ServerSuite) AssertBadCommand(c *gc.C, args []string, code int) exec.Ex
 func (s *ServerSuite) TestParseError(c *gc.C) {
 	resp := s.AssertBadCommand(c, []string{"remote", "--cheese"}, 2)
 	c.Assert(string(resp.Stdout), gc.Equals, "")
-	c.Assert(string(resp.Stderr), gc.Equals, "error: flag provided but not defined: --cheese\n")
+	c.Assert(string(resp.Stderr), gc.Equals, "ERROR flag provided but not defined: --cheese\n")
 }
 
 func (s *ServerSuite) TestBrokenCommand(c *gc.C) {
 	resp := s.AssertBadCommand(c, []string{"remote", "--value", "error"}, 1)
 	c.Assert(string(resp.Stdout), gc.Equals, "")
-	c.Assert(string(resp.Stderr), gc.Equals, "error: blam\n")
+	c.Assert(string(resp.Stderr), gc.Equals, "ERROR blam\n")
 }
 
 type NewCommandSuite struct {


### PR DESCRIPTION
## Description of change

juju/cmd now formats logger messages (including errors) with the badge (log level) prefixed to the message in all capitals. This commit updates tests to reflect this change.

## QA steps

The QA steps for this change are found in PR https://github.com/juju/juju/pull/7145. The test were missed since the juju/cmd respository was not updated in that PR. This updates the dependency and fixes the tests and error messages where necessary.

## Documentation changes

N/A

## Bug reference

See:  https://github.com/juju/juju/pull/7145