### PR TITLE
Added SLA to juju status output.

### DIFF
--- a/apiserver/client/api_test.go
+++ b/apiserver/client/api_test.go
@@ -176,6 +176,7 @@ var scenarioStatus = &params.FullStatus{
 			Status: "available",
 			Data:   map[string]interface{}{},
 		},
+		SLA: "unsupported",
 	},
 	Machines: map[string]params.MachineStatus{
 		"0": {

--- a/apiserver/client/status.go
+++ b/apiserver/client/status.go
@@ -340,6 +340,8 @@ func (c *Client) modelStatus() (params.ModelStatusInfo, error) {
 		return params.ModelStatusInfo{}, errors.Annotate(err, "cannot obtain model status info")
 	}
 
+	info.SLA = m.SLALevel()
+
 	info.ModelStatus = params.DetailedStatus{
 		Status: status.Status.String(),
 		Info:   status.Message,

--- a/apiserver/client/status_test.go
+++ b/apiserver/client/status_test.go
@@ -42,11 +42,13 @@ func (s *statusSuite) addMachine(c *gc.C) *state.Machine {
 
 func (s *statusSuite) TestFullStatus(c *gc.C) {
 	machine := s.addMachine(c)
+	s.State.SetSLA("essential", "test-user", []byte(""))
 	client := s.APIState.Client()
 	status, err := client.Status(nil)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(status.Model.Name, gc.Equals, "controller")
 	c.Check(status.Model.CloudTag, gc.Equals, "cloud-dummy")
+	c.Check(status.Model.SLA, gc.Equals, "essential")
 	c.Check(status.Applications, gc.HasLen, 0)
 	c.Check(status.RemoteApplications, gc.HasLen, 0)
 	c.Check(status.Machines, gc.HasLen, 1)

--- a/apiserver/params/status.go
+++ b/apiserver/params/status.go
@@ -37,6 +37,7 @@ type ModelStatusInfo struct {
 	AvailableVersion string         `json:"available-version"`
 	ModelStatus      DetailedStatus `json:"model-status"`
 	MeterStatus      MeterStatus    `json:"meter-status"`
+	SLA              string         `json:"sla"`
 }
 
 // NetworkInterfaceStatus holds a /etc/network/interfaces-type data and the

--- a/cmd/juju/status/formatted.go
+++ b/cmd/juju/status/formatted.go
@@ -38,6 +38,7 @@ type modelStatus struct {
 	AvailableVersion string             `json:"upgrade-available,omitempty" yaml:"upgrade-available,omitempty"`
 	Status           statusInfoContents `json:"model-status,omitempty" yaml:"model-status,omitempty"`
 	MeterStatus      *meterStatus       `json:"meter-status,omitempty" yaml:"meter-status,omitempty"`
+	SLA              string             `json:"sla,omitempty" yaml:"sla,omitempty"`
 }
 
 type networkInterface struct {

--- a/cmd/juju/status/formatter.go
+++ b/cmd/juju/status/formatter.go
@@ -59,6 +59,7 @@ func (sf *statusFormatter) format() (formattedStatus, error) {
 			Version:          sf.status.Model.Version,
 			AvailableVersion: sf.status.Model.AvailableVersion,
 			Status:           sf.getStatusInfoContents(sf.status.Model.ModelStatus),
+			SLA:              sf.status.Model.SLA,
 		},
 		Machines:           make(map[string]machineStatus),
 		Applications:       make(map[string]applicationStatus),

--- a/cmd/juju/status/output_tabular.go
+++ b/cmd/juju/status/output_tabular.go
@@ -115,6 +115,10 @@ func FormatTabular(writer io.Writer, forceColor bool, value interface{}) error {
 		header = append(header, "Notes")
 		values = append(values, message)
 	}
+	if fs.Model.SLA != "" {
+		header = append(header, "SLA")
+		values = append(values, fs.Model.SLA)
+	}
 
 	// The first set of headers don't use outputHeaders because it adds the blank line.
 	p(header...)

--- a/cmd/juju/status/status_test.go
+++ b/cmd/juju/status/status_test.go
@@ -168,6 +168,7 @@ var (
 			"current": "available",
 			"since":   "01 Apr 15 01:23+10:00",
 		},
+		"sla": "unsupported",
 	}
 
 	machine0 = M{
@@ -2577,6 +2578,7 @@ var statusTests = []testCase{
 						"current": "available",
 						"since":   "01 Apr 15 01:23+10:00",
 					},
+					"sla": "unsupported",
 				},
 				"machines":     M{},
 				"applications": M{},
@@ -2876,6 +2878,30 @@ var statusTests = []testCase{
 						"color":   "RED",
 						"message": "status message",
 					},
+					"sla": "unsupported",
+				},
+				"machines":     M{},
+				"applications": M{},
+			},
+		},
+	),
+	test( // 25
+		"set sla on the model",
+		setSLA{"advanced"},
+		expect{
+			"set sla on the model",
+			M{
+				"model": M{
+					"name":       "controller",
+					"controller": "kontroll",
+					"cloud":      "dummy",
+					"region":     "dummy-region",
+					"version":    "1.2.3",
+					"model-status": M{
+						"current": "available",
+						"since":   "01 Apr 15 01:23+10:00",
+					},
+					"sla": "advanced",
 				},
 				"machines":     M{},
 				"applications": M{},
@@ -2949,6 +2975,15 @@ func wordpressCharm(extras M) M {
 }
 
 // TODO(dfc) test failing components by destructively mutating the state under the hood
+
+type setSLA struct {
+	level string
+}
+
+func (s setSLA) step(c *gc.C, ctx *context) {
+	err := ctx.st.SetSLA(s.level, "test-user", []byte(""))
+	c.Assert(err, jc.ErrorIsNil)
+}
 
 type addMachine struct {
 	machineId string
@@ -3659,6 +3694,7 @@ func (s *StatusSuite) TestMigrationInProgress(c *gc.C) {
 				"since":   "01 Apr 15 01:23+10:00",
 				"message": "migrating: foo bar",
 			},
+			"sla": "unsupported",
 		},
 		"machines":     M{},
 		"applications": M{},
@@ -3686,8 +3722,8 @@ func (s *StatusSuite) TestMigrationInProgress(c *gc.C) {
 
 func (s *StatusSuite) TestMigrationInProgressTabular(c *gc.C) {
 	expected := `
-Model   Controller  Cloud/Region        Version  Notes
-hosted  kontroll    dummy/dummy-region  1.2.3    migrating: foo bar
+Model   Controller  Cloud/Region        Version  Notes               SLA
+hosted  kontroll    dummy/dummy-region  1.2.3    migrating: foo bar  unsupported
 
 App  Version  Status  Scale  Charm  Store  Rev  OS  Notes
 
@@ -3707,8 +3743,8 @@ Machine  State  DNS  Inst id  Series  AZ  Message
 
 func (s *StatusSuite) TestMigrationInProgressAndUpgradeAvailable(c *gc.C) {
 	expected := `
-Model   Controller  Cloud/Region        Version  Notes
-hosted  kontroll    dummy/dummy-region  1.2.3    migrating: foo bar
+Model   Controller  Cloud/Region        Version  Notes               SLA
+hosted  kontroll    dummy/dummy-region  1.2.3    migrating: foo bar  unsupported
 
 App  Version  Status  Scale  Charm  Store  Rev  OS  Notes
 
@@ -3997,8 +4033,8 @@ func (s *StatusSuite) testStatusWithFormatTabular(c *gc.C, useFeatureFlag bool) 
 	c.Check(code, gc.Equals, 0)
 	c.Check(string(stderr), gc.Equals, "")
 	expected := `
-Model       Controller  Cloud/Region        Version  Notes
-controller  kontroll    dummy/dummy-region  1.2.3    upgrade available: 1.2.4
+Model       Controller  Cloud/Region        Version  Notes                     SLA
+controller  kontroll    dummy/dummy-region  1.2.3    upgrade available: 1.2.4  unsupported
 
 SAAS name    Status   Store  URL
 hosted-riak  unknown  local  me/model.riak
@@ -4330,6 +4366,7 @@ func (s *StatusSuite) TestFilterToContainer(c *gc.C) {
 		"  model-status:\n" +
 		"    current: available\n" +
 		"    since: 01 Apr 15 01:23+10:00\n" +
+		"  sla: unsupported\n" +
 		"machines:\n" +
 		"  \"0\":\n" +
 		"    juju-status:\n" +
@@ -4635,6 +4672,7 @@ var statusTimeTest = test(
 					"current": "available",
 					"since":   "01 Apr 15 01:23+10:00",
 				},
+				"sla": "unsupported",
 			},
 			"machines": M{
 				"0": machine0,


### PR DESCRIPTION
## Description of change

Exposes model's SLA level in juju status output

## QA steps

1. bootstrap a controller
2. add a model
3. run "juju status" -> it should show SLA level as "unsupported"
3. use "juju sla" to set the desired SLA level on the controller
4. run "juju status" -> it should show model's SLA that you just set.

## Documentation changes

Please contact @cmars for more details.

## Bug reference

N/A