### PR TITLE
provider/maas: Allow including the MAAS api version in the cloud endpoint

### DIFF
--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -28,7 +28,7 @@ github.com/juju/go4	git	40d72ab9641a2a8c36a9c46a51e28367115c8e59	2016-02-22T16:3
 github.com/juju/gojsonpointer	git	afe8b77aa08f272b49e01b82de78510c11f61500	2015-02-04T19:46:29Z
 github.com/juju/gojsonreference	git	f0d24ac5ee330baa21721cdff56d45e4ee42628e	2015-02-04T19:46:33Z
 github.com/juju/gojsonschema	git	e1ad140384f254c82f89450d9a7c8dd38a632838	2015-03-12T17:00:16Z
-github.com/juju/gomaasapi	git	cfbc096bd45f276c17a391efc4db710b60ae3ad7	2017-02-27T07:51:07Z
+github.com/juju/gomaasapi	git	4eddf584006b5410c4febe1731109aaf5b8f17f6	2017-04-04T00:56:18Z
 github.com/juju/httpprof	git	14bf14c307672fd2456bdbf35d19cf0ccd3cf565	2014-12-17T16:00:36Z
 github.com/juju/httprequest	git	266fd1e9debf09c037a63f074d099a2da4559ece	2016-10-06T15:09:09Z
 github.com/juju/idmclient	git	4dc25171f675da4206b71695d3fd80e519ad05c1	2017-02-09T16:27:49Z

--- a/provider/maas/constraints_test.go
+++ b/provider/maas/constraints_test.go
@@ -355,7 +355,7 @@ func (suite *environSuite) TestAcquireNodePassedAgentName(c *gc.C) {
 
 func (suite *environSuite) TestAcquireNodePassesPositiveAndNegativeTags(c *gc.C) {
 	env := suite.makeEnviron()
-	suite.testMAASObject.TestServer.NewNode(`{"system_id": "node0"}`)
+	suite.testMAASObject.TestServer.NewNode(`{"system_id": "node0", "tag_names": "tag1,tag3"}`)
 
 	_, err := env.acquireNode(
 		"", "",

--- a/provider/maas/environ.go
+++ b/provider/maas/environ.go
@@ -280,7 +280,12 @@ func (env *maasEnviron) SetConfig(cfg *config.Config) error {
 	switch {
 	case gomaasapi.IsUnsupportedVersionError(err):
 		apiVersion = apiVersion1
-		authClient, err := gomaasapi.NewAuthenticatedClient(maasServer, maasOAuth, apiVersion1)
+		_, _, includesVersion := gomaasapi.SplitVersionedURL(maasServer)
+		versionURL := maasServer
+		if !includesVersion {
+			versionURL = gomaasapi.AddAPIVersionToURL(maasServer, apiVersion1)
+		}
+		authClient, err := gomaasapi.NewAuthenticatedClient(versionURL, maasOAuth)
 		if err != nil {
 			return errors.Trace(err)
 		}

--- a/provider/maas/environprovider.go
+++ b/provider/maas/environprovider.go
@@ -74,13 +74,22 @@ func (p MaasEnvironProvider) CloudSchema() *jsonschema.Schema {
 
 // Ping tests the connection to the cloud, to verify the endpoint is valid.
 func (p MaasEnvironProvider) Ping(endpoint string) error {
-	err := p.checkMaas(endpoint, apiVersion2)
-	if err == nil {
-		return nil
-	}
-	err = p.checkMaas(endpoint, apiVersion1)
-	if err == nil {
-		return nil
+	base, version, includesVersion := gomaasapi.SplitVersionedURL(endpoint)
+	if includesVersion {
+		err := p.checkMaas(base, version)
+		if err == nil {
+			return nil
+		}
+	} else {
+		// No version info in the endpoint - try both in preference order.
+		err := p.checkMaas(endpoint, apiVersion2)
+		if err == nil {
+			return nil
+		}
+		err = p.checkMaas(endpoint, apiVersion1)
+		if err == nil {
+			return nil
+		}
 	}
 	return errors.Errorf("No MAAS server running at %s", endpoint)
 }


### PR DESCRIPTION
## Description of change

This allows users to specify the MAAS endpoint including the version indicator (e.g. `http://maas.server/MAAS/api/2.0/`). When the version is included it will prevent the usual version probing that we do to decide which API version should be used. One benefit of this is that we won't mistake a connectivity problem for a version mismatch.

Updates the gomaasapi dependency, and fixes a maas constraint test that was broken by a change to the gomaasapi test server (it now supports positive tag filtering).

## QA steps

For both MAAS 1.9 and MAAS 2.1
* Add a MAAS cloud to juju using add-cloud interactively.
* Specify the endpoint including the `/api/2.0/`or `/api/1.0/` components.
* Adding the cloud should succeed (this includes doing a connectivity test of the endpoint).
* Add a credential to the new cloud.
* Bootstrap on that cloud - the controller should come up successfully.

## Documentation changes

I'm not sure whether we want to call out the possibility of specifying the version in the endpoint - it seems more like a troubleshooting tool than the preferred method of specifying the MAAS api.

## Bug reference

Fixes https://bugs.launchpad.net/juju/+bug/1675485
