### PR TITLE
Show model SLA owner

### DIFF
--- a/api/modelconfig/modelconfig.go
+++ b/api/modelconfig/modelconfig.go
@@ -70,9 +70,12 @@ func (c *Client) ModelUnset(keys ...string) error {
 }
 
 // SetSLALevel sets the support level for the given model.
-func (c *Client) SetSLALevel(level string, creds []byte) error {
+func (c *Client) SetSLALevel(level, owner string, creds []byte) error {
 	args := params.ModelSLA{
-		Level:       level,
+		ModelSLAInfo: params.ModelSLAInfo{
+			Level: level,
+			Owner: owner,
+		},
 		Credentials: creds,
 	}
 	return c.facade.FacadeCall("SetSLALevel", args, nil)

--- a/api/modelconfig/modelconfig_test.go
+++ b/api/modelconfig/modelconfig_test.go
@@ -140,7 +140,10 @@ func (s *modelconfigSuite) TestSetSupport(c *gc.C) {
 			c.Check(id, gc.Equals, "")
 			c.Check(request, gc.Equals, "SetSLALevel")
 			c.Check(a, jc.DeepEquals, params.ModelSLA{
-				Level:       "foobar",
+				ModelSLAInfo: params.ModelSLAInfo{
+					Level: "foobar",
+					Owner: "bob",
+				},
 				Credentials: []byte("creds"),
 			})
 			called = true
@@ -148,7 +151,7 @@ func (s *modelconfigSuite) TestSetSupport(c *gc.C) {
 		},
 	)
 	client := modelconfig.NewClient(apiCaller)
-	err := client.SetSLALevel("foobar", []byte("creds"))
+	err := client.SetSLALevel("foobar", "bob", []byte("creds"))
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(called, jc.IsTrue)
 }

--- a/api/uniter/sla_test.go
+++ b/api/uniter/sla_test.go
@@ -43,7 +43,7 @@ type slaSuite struct {
 var _ = gc.Suite(&slaSuite{})
 
 func (s *slaSuite) TestSLALevel(c *gc.C) {
-	err := s.State.SetSLA("essential", []byte("creds"))
+	err := s.State.SetSLA("essential", "bob", []byte("creds"))
 	c.Assert(err, jc.ErrorIsNil)
 
 	level, err := s.uniter.SLALevel()

--- a/api/uniter/uniter_test.go
+++ b/api/uniter/uniter_test.go
@@ -134,7 +134,7 @@ func (s *uniterSuite) patchNewState(
 }
 
 func (s *uniterSuite) TestSLALevel(c *gc.C) {
-	err := s.State.SetSLA("essential", []byte("creds"))
+	err := s.State.SetSLA("essential", "bob", []byte("creds"))
 	c.Assert(err, jc.ErrorIsNil)
 
 	level, err := s.uniter.SLALevel()

--- a/apiserver/common/modelmanagerinterface.go
+++ b/apiserver/common/modelmanagerinterface.go
@@ -84,6 +84,8 @@ type Model interface {
 	Users() ([]permission.UserAccess, error)
 	Destroy() error
 	DestroyIncludingHosted() error
+	SLALevel() string
+	SLAOwner() string
 }
 
 var _ ModelManagerBackend = (*modelManagerStateShim)(nil)

--- a/apiserver/metricsmanager/metricsmanager_test.go
+++ b/apiserver/metricsmanager/metricsmanager_test.go
@@ -217,7 +217,7 @@ func (s *metricsManagerSuite) TestLastSuccessfulNotChangedIfNothingToSend(c *gc.
 }
 
 func (s *metricsManagerSuite) TestAddJujuMachineMetrics(c *gc.C) {
-	err := s.State.SetSLA("essential", []byte("sla"))
+	err := s.State.SetSLA("essential", "bob", []byte("sla"))
 	c.Assert(err, jc.ErrorIsNil)
 	s.Factory.MakeMachine(c, nil)
 	err = s.metricsmanager.AddJujuMachineMetrics()
@@ -240,7 +240,7 @@ func (s *metricsManagerSuite) TestAddJujuMachineMetricsAddsNoMetricsWhenNoSLASet
 }
 
 func (s *metricsManagerSuite) TestAddJujuMachineMetricsDontCountContainers(c *gc.C) {
-	err := s.State.SetSLA("essential", []byte("sla"))
+	err := s.State.SetSLA("essential", "bob", []byte("sla"))
 	c.Assert(err, jc.ErrorIsNil)
 	machine := s.Factory.MakeMachine(c, nil)
 	s.Factory.MakeMachineNested(c, machine.Id(), nil)
@@ -257,7 +257,7 @@ func (s *metricsManagerSuite) TestAddJujuMachineMetricsDontCountContainers(c *gc
 }
 
 func (s *metricsManagerSuite) TestSendMetricsMachineMetrics(c *gc.C) {
-	err := s.State.SetSLA("essential", []byte("sla"))
+	err := s.State.SetSLA("essential", "bob", []byte("sla"))
 	c.Assert(err, jc.ErrorIsNil)
 	s.Factory.MakeMachine(c, nil)
 	var sender testing.MockSender

--- a/apiserver/modelconfig/backend.go
+++ b/apiserver/modelconfig/backend.go
@@ -19,7 +19,7 @@ type Backend interface {
 	ModelTag() names.ModelTag
 	ModelConfigValues() (config.ConfigValues, error)
 	UpdateModelConfig(map[string]interface{}, []string, state.ValidateConfigFunc) error
-	SetSLA(level string, credentials []byte) error
+	SetSLA(level, owner string, credentials []byte) error
 	SLALevel() (string, error)
 }
 

--- a/apiserver/modelconfig/modelconfig.go
+++ b/apiserver/modelconfig/modelconfig.go
@@ -132,7 +132,7 @@ func (c *ModelConfigAPI) SetSLALevel(args params.ModelSLA) error {
 	if err := c.checkCanWrite(); err != nil {
 		return err
 	}
-	return c.backend.SetSLA(args.Level, args.Credentials)
+	return c.backend.SetSLA(args.Level, args.Owner, args.Credentials)
 
 }
 

--- a/apiserver/modelconfig/modelconfig_test.go
+++ b/apiserver/modelconfig/modelconfig_test.go
@@ -154,7 +154,7 @@ func (s *modelconfigSuite) TestModelUnsetMissing(c *gc.C) {
 }
 
 func (s *modelconfigSuite) TestSetSupportCredentals(c *gc.C) {
-	err := s.api.SetSLALevel(params.ModelSLA{"level", []byte("foobar")})
+	err := s.api.SetSLALevel(params.ModelSLA{params.ModelSLAInfo{"level", "bob"}, []byte("foobar")})
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -201,7 +201,7 @@ func (m *mockBackend) ControllerTag() names.ControllerTag {
 	return names.NewControllerTag("deadbeef-babe-4fd2-967d-db9663db7bea")
 }
 
-func (m *mockBackend) SetSLA(level string, credentials []byte) error {
+func (m *mockBackend) SetSLA(level, owner string, credentials []byte) error {
 	return nil
 }
 

--- a/apiserver/modelmanager/modelinfo_test.go
+++ b/apiserver/modelmanager/modelinfo_test.go
@@ -186,6 +186,10 @@ func (s *modelInfoSuite) TestModelInfo(c *gc.C) {
 		}, {
 			Id: "2",
 		}},
+		SLA: &params.ModelSLAInfo{
+			Level: "essential",
+			Owner: "user",
+		},
 	})
 	s.st.CheckCalls(c, []gitjujutesting.StubCall{
 		{"ControllerTag", nil},
@@ -214,6 +218,8 @@ func (s *modelInfoSuite) TestModelInfo(c *gc.C) {
 		{"Cloud", nil},
 		{"CloudRegion", nil},
 		{"CloudCredential", nil},
+		{"SLALevel", nil},
+		{"SLAOwner", nil},
 	})
 }
 
@@ -772,6 +778,16 @@ func (m *mockModel) Destroy() error {
 func (m *mockModel) DestroyIncludingHosted() error {
 	m.MethodCall(m, "DestroyIncludingHosted")
 	return m.NextErr()
+}
+
+func (m *mockModel) SLALevel() string {
+	m.MethodCall(m, "SLALevel")
+	return "essential"
+}
+
+func (m *mockModel) SLAOwner() string {
+	m.MethodCall(m, "SLAOwner")
+	return "user"
 }
 
 type mockModelUser struct {

--- a/apiserver/modelmanager/modelmanager.go
+++ b/apiserver/modelmanager/modelmanager.go
@@ -615,6 +615,12 @@ func (m *ModelManagerAPI) getModelInfo(tag names.ModelTag) (params.ModelInfo, er
 		return params.ModelInfo{}, errors.Trace(common.ErrPerm)
 	}
 
+	// All users with access to the model can see the SLA information.
+	info.SLA = &params.ModelSLAInfo{
+		Level: model.SLALevel(),
+		Owner: model.SLAOwner(),
+	}
+
 	canSeeMachines := authorizedOwner
 	if !canSeeMachines {
 		if canSeeMachines, err = m.hasWriteAccess(tag); err != nil {

--- a/apiserver/params/model.go
+++ b/apiserver/params/model.go
@@ -75,7 +75,7 @@ type ModelUnset struct {
 // ModelSLA contains the arguments for the SetSLALevel client API
 // call.
 type ModelSLA struct {
-	Level       string `json:"level"`
+	ModelSLAInfo
 	Credentials []byte `json:"creds"`
 }
 
@@ -154,6 +154,15 @@ type ModelInfo struct {
 	// Migration contains information about the latest failed or
 	// currently-running migration. It'll be nil if there isn't one.
 	Migration *ModelMigrationStatus `json:"migration,omitempty"`
+
+	// SLA contains the information about the SLA for the model, if set.
+	SLA *ModelSLAInfo `json:"sla"`
+}
+
+// ModelSLAInfo describes the SLA info for a model.
+type ModelSLAInfo struct {
+	Level string `json:"level"`
+	Owner string `json:"owner"`
 }
 
 // ModelInfoResult holds the result of a ModelInfo call.

--- a/apiserver/uniter/uniter_test.go
+++ b/apiserver/uniter/uniter_test.go
@@ -2268,7 +2268,7 @@ func (s *uniterSuite) TestAllMachinePorts(c *gc.C) {
 }
 
 func (s *uniterSuite) TestSLALevel(c *gc.C) {
-	err := s.State.SetSLA("essential", []byte("creds"))
+	err := s.State.SetSLA("essential", "bob", []byte("creds"))
 	c.Assert(err, jc.ErrorIsNil)
 
 	result, err := s.uniter.SLALevel()

--- a/cmd/juju/common/model.go
+++ b/cmd/juju/common/model.go
@@ -28,6 +28,8 @@ type ModelInfo struct {
 	Status         ModelStatus                 `json:"status" yaml:"status"`
 	Users          map[string]ModelUserInfo    `json:"users" yaml:"users"`
 	Machines       map[string]ModelMachineInfo `json:"machines,omitempty" yaml:"machines,omitempty"`
+	SLA            string                      `json:"sla,omitempty" yaml:"sla,omitempty"`
+	SLAOwner       string                      `json:"sla-owner,omitempty" yaml:"sla-owner,omitempty"`
 }
 
 // ModelMachineInfo contains information about a machine in a model.
@@ -96,6 +98,8 @@ func ModelInfoFromParams(info params.ModelInfo, now time.Time) (ModelInfo, error
 		ProviderType:   info.ProviderType,
 		Users:          ModelUserInfoFromParams(info.Users, now),
 		Machines:       ModelMachineInfoFromParams(info.Machines),
+		SLA:            modelSLAFromParams(info.SLA),
+		SLAOwner:       modelSLAOwnerFromParams(info.SLA),
 	}, nil
 }
 
@@ -130,6 +134,20 @@ func ModelUserInfoFromParams(users []params.ModelUserInfo, now time.Time) map[st
 		output[names.NewUserTag(info.UserName).Id()] = outInfo
 	}
 	return output
+}
+
+func modelSLAFromParams(sla *params.ModelSLAInfo) string {
+	if sla == nil {
+		return ""
+	}
+	return sla.Level
+}
+
+func modelSLAOwnerFromParams(sla *params.ModelSLAInfo) string {
+	if sla == nil {
+		return ""
+	}
+	return sla.Owner
 }
 
 // OwnerQualifiedModelName returns the model name qualified with the

--- a/cmd/juju/model/show_test.go
+++ b/cmd/juju/model/show_test.go
@@ -180,6 +180,24 @@ func (s *ShowCommandSuite) TestUnrecognizedArg(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, `unrecognized args: \["whoops"\]`)
 }
 
+type showSLACommandSuite struct {
+	ShowCommandSuite
+}
+
+var _ = gc.Suite(&showSLACommandSuite{})
+
+func (s *showSLACommandSuite) SetUpTest(c *gc.C) {
+	s.ShowCommandSuite.SetUpTest(c)
+
+	s.fake.info.SLA = &params.ModelSLAInfo{
+		Level: "next",
+		Owner: "user",
+	}
+	slaOutput := s.expectedOutput["mymodel"].(attrs)
+	slaOutput["sla"] = "next"
+	slaOutput["sla-owner"] = "user"
+}
+
 func noOpRefresh(jujuclient.ClientStore, string) error {
 	return nil
 }

--- a/cmd/juju/romulus/sla/sla_test.go
+++ b/cmd/juju/romulus/sla/sla_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/juju/cmd/cmdtesting"
 	"github.com/juju/errors"
 
+	slawire "github.com/juju/romulus/wireformat/sla"
 	"github.com/juju/testing"
 	jujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
@@ -134,7 +135,7 @@ type mockapi struct {
 	macaroon *macaroon.Macaroon
 }
 
-func (m *mockapi) Authorize(modelUUID, supportLevel, budget string) (*macaroon.Macaroon, error) {
+func (m *mockapi) Authorize(modelUUID, supportLevel, budget string) (*slawire.SLAResponse, error) {
 	err := m.NextErr()
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -149,15 +150,15 @@ func (m *mockapi) Authorize(modelUUID, supportLevel, budget string) (*macaroon.M
 		return nil, errors.Trace(err)
 	}
 	m.macaroon = macaroon
-	return m.macaroon, nil
+	return &slawire.SLAResponse{Credentials: m.macaroon, Owner: "bob"}, nil
 }
 
 type mockSlaClient struct {
 	testing.Stub
 }
 
-func (m *mockSlaClient) SetSLALevel(level string, creds []byte) error {
-	m.AddCall("SetSLALevel", level, creds)
+func (m *mockSlaClient) SetSLALevel(level, owner string, creds []byte) error {
+	m.AddCall("SetSLALevel", level, owner, creds)
 	return nil
 }
 func (m *mockSlaClient) SLALevel() (string, error) {

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -21,7 +21,7 @@ github.com/juju/ansiterm	git	b99631de12cf04a906c1d4e4ec54fb86eae5863d	2016-09-07
 github.com/juju/blobstore	git	06056004b3d7b54bbb7984d830c537bad00fec21	2015-07-29T11:18:58Z
 github.com/juju/bundlechanges	git	7725027b95e0d54635e0fb11efc2debdcdf19f75	2016-12-15T16:06:52Z
 github.com/juju/cmd	git	9425a576247f348b9b40afe3b60085de63470de5	2017-03-20T01:37:09Z
-github.com/juju/description	git	0b0134bd1b5a0676537883958c55ccd1c6fafbc7	2017-03-30T02:44:27Z
+github.com/juju/description	git	50b9bb7345dcc1d0443cc137337fdb15a4296ac2	2017-04-06T03:03:04Z
 github.com/juju/errors	git	1b5e39b83d1835fa480e0c2ddefb040ee82d58b3	2015-09-16T12:56:42Z
 github.com/juju/gnuflag	git	4e76c56581859c14d9d87e1ddbe29e1c0f10195f	2016-08-09T16:52:14Z
 github.com/juju/go4	git	40d72ab9641a2a8c36a9c46a51e28367115c8e59	2016-02-22T16:32:58Z
@@ -41,7 +41,7 @@ github.com/juju/pubsub	git	f4dfa62f30adc6955341b3dd73dde7c8d9b23b9e	2017-03-31T0
 github.com/juju/replicaset	git	6b5becf2232ce76656ea765d8d915d41755a1513	2016-11-25T16:08:49Z
 github.com/juju/retry	git	62c62032529169c7ec02fa48f93349604c345e1f	2015-10-29T02:48:21Z
 github.com/juju/rfc	git	ebdbbdb950cd039a531d15cdc2ac2cbd94f068ee	2016-07-11T02:42:13Z
-github.com/juju/romulus	git	a2065b15ccbf1e93369d9e0a4bcf33f8911d8725	2017-04-05T10:19:25Z
+github.com/juju/romulus	git	cb2eb9afe5690e9639e1c8a0898ab3987b39920a	2017-04-05T14:17:21Z
 github.com/juju/schema	git	075de04f9b7d7580d60a1e12a0b3f50bb18e6998	2016-04-20T04:42:03Z
 github.com/juju/terms-client	git	9b925afd677234e4146dde3cb1a11e187cbed64e	2016-08-09T13:19:00Z
 github.com/juju/testing	git	fce9bc4ebf7a77310c262ac4884e03b778eae06a	2017-02-22T09:01:19Z

--- a/featuretests/cmd_juju_controller_test.go
+++ b/featuretests/cmd_juju_controller_test.go
@@ -134,6 +134,7 @@ models:
       cores: 0
     "1":
       cores: 2
+  sla: unsupported
 current-model: controller
 `[1:])
 }

--- a/state/migration_export.go
+++ b/state/migration_export.go
@@ -149,7 +149,7 @@ func (st *State) Export() (description.Model, error) {
 		return nil, errors.Trace(err)
 	}
 
-	export.model.SetSLA(dbModel.SLALevel(), string(dbModel.SLACredential()))
+	export.model.SetSLA(dbModel.SLALevel(), dbModel.SLAOwner(), string(dbModel.SLACredential()))
 	export.model.SetMeterStatus(dbModel.MeterStatus().Code.String(), dbModel.MeterStatus().Info)
 
 	if featureflag.Enabled(feature.StrictMigration) {

--- a/state/migration_export_test.go
+++ b/state/migration_export_test.go
@@ -235,7 +235,7 @@ func (s *MigrationExportSuite) TestModelUsers(c *gc.C) {
 }
 
 func (s *MigrationExportSuite) TestSLAs(c *gc.C) {
-	err := s.State.SetSLA("essential", []byte("creds"))
+	err := s.State.SetSLA("essential", "bob", []byte("creds"))
 	c.Assert(err, jc.ErrorIsNil)
 
 	model, err := s.State.Export()

--- a/state/migration_import.go
+++ b/state/migration_import.go
@@ -200,6 +200,7 @@ func (st *State) Import(model description.Model) (_ *Model, _ *State, err error)
 
 	if err := dbModel.SetSLA(
 		model.SLA().Level(),
+		model.SLA().Owner(),
 		[]byte(model.SLA().Credentials()),
 	); err != nil {
 		return nil, nil, errors.Trace(err)

--- a/state/migration_import_test.go
+++ b/state/migration_import_test.go
@@ -222,7 +222,7 @@ func (s *MigrationImportSuite) TestModelUsers(c *gc.C) {
 }
 
 func (s *MigrationImportSuite) TestSLA(c *gc.C) {
-	err := s.State.SetSLA("essential", []byte("creds"))
+	err := s.State.SetSLA("essential", "bob", []byte("creds"))
 	c.Assert(err, jc.ErrorIsNil)
 	newModel, newSt := s.importModel(c)
 

--- a/state/model.go
+++ b/state/model.go
@@ -129,6 +129,9 @@ type slaDoc struct {
 	// Level is the current support level set on the model.
 	Level slaLevel `bson:"level"`
 
+	// Owner is the SLA owner of the model.
+	Owner string `bson:"owner,omitempty"`
+
 	// Credentials authenticates the support level setting.
 	Credentials []byte `bson:"credentials"`
 }
@@ -674,13 +677,19 @@ func (m *Model) SLALevel() string {
 	return m.doc.SLA.Level.String()
 }
 
+// SLAOwner returns the SLA owner as a string. Note that this may differ from
+// the model owner.
+func (m *Model) SLAOwner() string {
+	return m.doc.SLA.Owner
+}
+
 // SLACredential returns the SLA credential.
 func (m *Model) SLACredential() []byte {
 	return m.doc.SLA.Credentials
 }
 
 // SetSLA sets the SLA on the model.
-func (m *Model) SetSLA(level string, credentials []byte) error {
+func (m *Model) SetSLA(level, owner string, credentials []byte) error {
 	l, err := newSLALevel(level)
 	if err != nil {
 		return errors.Trace(err)
@@ -690,6 +699,7 @@ func (m *Model) SetSLA(level string, credentials []byte) error {
 		Id: m.doc.UUID,
 		Update: bson.D{{"$set", bson.D{{"sla", slaDoc{
 			Level:       l,
+			Owner:       owner,
 			Credentials: credentials,
 		}}}}},
 	}}

--- a/state/model_test.go
+++ b/state/model_test.go
@@ -233,13 +233,14 @@ func (s *ModelSuite) TestSLA(c *gc.C) {
 	c.Assert(level, gc.Equals, "unsupported")
 	c.Assert(model.SLACredential(), gc.DeepEquals, []byte{})
 	for _, goodLevel := range []string{"unsupported", "essential", "standard", "advanced"} {
-		err = st.SetSLA(goodLevel, []byte("auth "+goodLevel))
+		err = st.SetSLA(goodLevel, "bob", []byte("auth "+goodLevel))
 		c.Assert(err, jc.ErrorIsNil)
 		c.Assert(model.Refresh(), jc.ErrorIsNil)
 		level, err = st.SLALevel()
 		c.Assert(err, jc.ErrorIsNil)
 		c.Assert(level, gc.Equals, goodLevel)
 		c.Assert(model.SLALevel(), gc.Equals, goodLevel)
+		c.Assert(model.SLAOwner(), gc.Equals, "bob")
 		c.Assert(model.SLACredential(), gc.DeepEquals, []byte("auth "+goodLevel))
 	}
 
@@ -247,10 +248,11 @@ func (s *ModelSuite) TestSLA(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(defaultLevel, gc.Equals, state.SLAUnsupported)
 
-	err = model.SetSLA("nope", []byte("auth nope"))
+	err = model.SetSLA("nope", "nobody", []byte("auth nope"))
 	c.Assert(err, gc.ErrorMatches, `.*SLA level "nope" not valid.*`)
 
 	c.Assert(model.SLALevel(), gc.Equals, "advanced")
+	c.Assert(model.SLAOwner(), gc.Equals, "bob")
 	c.Assert(model.SLACredential(), gc.DeepEquals, []byte("auth advanced"))
 	slaCreds, err := st.SLACredential()
 	c.Assert(err, jc.ErrorIsNil)

--- a/state/state.go
+++ b/state/state.go
@@ -2133,12 +2133,12 @@ func (st *State) PutAuditEntryFn() func(audit.AuditEntry) error {
 }
 
 // SetSLA sets the SLA on the current connected model.
-func (st *State) SetSLA(level string, credentials []byte) error {
+func (st *State) SetSLA(level, owner string, credentials []byte) error {
 	model, err := st.Model()
 	if err != nil {
 		return errors.Trace(err)
 	}
-	return model.SetSLA(level, credentials)
+	return model.SetSLA(level, owner, credentials)
 }
 
 // SetModelMeterStatus sets the meter status for the current connected model.

--- a/worker/uniter/runner/context/contextfactory_test.go
+++ b/worker/uniter/runner/context/contextfactory_test.go
@@ -114,7 +114,7 @@ func (s *ContextFactorySuite) testLeadershipContextWiring(c *gc.C, createContext
 }
 
 func (s *ContextFactorySuite) TestNewHookContextRetrievesSLALevel(c *gc.C) {
-	err := s.State.SetSLA("essential", []byte("creds"))
+	err := s.State.SetSLA("essential", "bob", []byte("creds"))
 	c.Assert(err, jc.ErrorIsNil)
 
 	ctx, err := s.factory.HookContext(hook.Info{Kind: hooks.ConfigChanged})


### PR DESCRIPTION
## Description of change

> Why is this change needed?

A user needs to be able to view the owner of the SLA on a model.

## QA steps

> How do we verify that the change works?

As user "bob":
```
juju add-model testmodel
juju sla essential
juju show-model testmodel
```
...
```
sla: essential
sla-owner: bob
```

## Documentation changes

> Does it affect current user workflow? CLI? API?

Yes, it makes the SLA information on a model more observable.

## Bug reference

> Does this change fix a bug? Please add a link to it.

N/A