### PR TITLE
provider/openstack: Don't update volume tags when storage is unsupported

### DIFF
--- a/provider/openstack/provider.go
+++ b/provider/openstack/provider.go
@@ -1290,20 +1290,6 @@ func (e *Environ) AdoptResources(controllerUUID string, fromVersion version.Numb
 	if err != nil {
 		return errors.Trace(err)
 	}
-	cinder, err := e.cinderProvider()
-	if err != nil {
-		return errors.Trace(err)
-	}
-	// TODO(axw): fix the storage API.
-	volumeSource, err := cinder.VolumeSource(nil)
-	if err != nil {
-		return errors.Trace(err)
-	}
-	volumeIds, err := volumeSource.ListVolumes()
-	if err != nil {
-		return errors.Trace(err)
-	}
-
 	for _, instance := range instances {
 		err := e.TagInstance(instance.Id(), controllerTag)
 		if err != nil {
@@ -1312,13 +1298,11 @@ func (e *Environ) AdoptResources(controllerUUID string, fromVersion version.Numb
 		}
 	}
 
-	for _, volumeId := range volumeIds {
-		_, err := cinder.storageAdapter.SetVolumeMetadata(volumeId, controllerTag)
-		if err != nil {
-			logger.Errorf("error updating controller tag for volume %s: %v", volumeId, err)
-			failed = append(failed, volumeId)
-		}
+	failedVolumes, err := e.adoptVolumes(controllerTag)
+	if err != nil {
+		return errors.Trace(err)
 	}
+	failed = append(failed, failedVolumes...)
 
 	err = e.firewaller.UpdateGroupController(controllerUUID)
 	if err != nil {
@@ -1328,6 +1312,36 @@ func (e *Environ) AdoptResources(controllerUUID string, fromVersion version.Numb
 		return errors.Errorf("error updating controller tag for some resources: %v", failed)
 	}
 	return nil
+}
+
+func (e *Environ) adoptVolumes(controllerTag map[string]string) ([]string, error) {
+	cinder, err := e.cinderProvider()
+	if errors.IsNotSupported(err) {
+		logger.Debugf("volumes not supported: not transferring ownership for volumes")
+		return nil, nil
+	}
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	// TODO(axw): fix the storage API.
+	volumeSource, err := cinder.VolumeSource(nil)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	volumeIds, err := volumeSource.ListVolumes()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	var failed []string
+	for _, volumeId := range volumeIds {
+		_, err := cinder.storageAdapter.SetVolumeMetadata(volumeId, controllerTag)
+		if err != nil {
+			logger.Errorf("error updating controller tag for volume %s: %v", volumeId, err)
+			failed = append(failed, volumeId)
+		}
+	}
+	return failed, nil
 }
 
 // AllInstances returns all instances in this environment.


### PR DESCRIPTION
## Description of change

In nova-lxd, storage isn't supported, so ownership transfer would fail during migration when we tried to get volumes to update their controller tags. Detect the not-supported error and skip updating volumes in that case.

## QA steps

* Bootstrap 2 controllers (A and B) on a nova-lxd Openstack cloud.
* Add a model m to A.
* Deploy a minimal charm to m.
* Migrate m from A to B.
* The migration (and in particular the ownership transfer) should complete successfully.
* Destroy controller A.
* The model m (now running under controller B) should be unaffected.

## Bug reference

Fixes https://bugs.launchpad.net/juju/+bug/1677225
