### PR TITLE
cmd/juju/sla: Routine cleanup, renamed internal command type and removed TODOs that were DONE

### DIFF
--- a/cmd/juju/commands/main_test.go
+++ b/cmd/juju/commands/main_test.go
@@ -521,7 +521,6 @@ var commandNames = []string{
 	"storage",
 	"storage-pools",
 	"subnets",
-	"support",
 	"switch",
 	"sync-tools",
 	"unexpose",

--- a/cmd/juju/romulus/sla/export_test.go
+++ b/cmd/juju/romulus/sla/export_test.go
@@ -13,15 +13,15 @@ import (
 
 var (
 	NewAuthorizationClient = &newAuthorizationClient
-	NewSLAClient           = &newSlaClient
+	NewSLAClient           = &newSLAClient
 	ModelId                = &modelId
 )
 
 // NewSLACommandForTest returns an slaCommand with apis provided by the given arguments
 func NewSLACommandForTest(apiRoot api.Connection, slaC slaClient, authClient authorizationClient) cmd.Command {
-	cmd := &supportCommand{
+	cmd := &slaCommand{
 		newAPIRoot:   func() (api.Connection, error) { return apiRoot, nil },
-		newSlaClient: func(api.Connection) slaClient { return slaC },
+		newSLAClient: func(api.Connection) slaClient { return slaC },
 		newAuthorizationClient: func(options ...sla.ClientOption) (authorizationClient, error) {
 			return authClient, nil
 		},

--- a/cmd/juju/romulus/sla/sla.go
+++ b/cmd/juju/romulus/sla/sla.go
@@ -34,7 +34,7 @@ type slaClient interface {
 	SLALevel() (string, error)
 }
 
-var newSlaClient = func(conn api.Connection) slaClient {
+var newSLAClient = func(conn api.Connection) slaClient {
 	return modelconfig.NewClient(conn)
 }
 
@@ -48,26 +48,24 @@ var modelId = func(conn api.Connection) string {
 	return tag.Id()
 }
 
-// TODO (mattyw) See juju/cmd/juju/storage/show.go for a better way of doing this.
-// TODO (mattyw) This should be fixed before this lands in master.
-// NewSLACommand returns a new command that is used to set sla credentials for a
+// NewSLACommand returns a new command that is used to set SLA credentials for a
 // deployed application.
 func NewSLACommand() cmd.Command {
-	slaCommand := &supportCommand{
-		newSlaClient:           newSlaClient,
+	slaCommand := &slaCommand{
+		newSLAClient:           newSLAClient,
 		newAuthorizationClient: newAuthorizationClient,
 	}
 	slaCommand.newAPIRoot = slaCommand.NewAPIRoot
 	return modelcmd.Wrap(slaCommand)
 }
 
-// supportCommand is a command-line tool for setting
+// slaCommand is a command-line tool for setting
 // Model.SLACredential for development & demonstration purposes.
-type supportCommand struct {
+type slaCommand struct {
 	modelcmd.ModelCommandBase
 
 	newAPIRoot             func() (api.Connection, error)
-	newSlaClient           func(api.Connection) slaClient
+	newSLAClient           func(api.Connection) slaClient
 	newAuthorizationClient func(options ...sla.ClientOption) (authorizationClient, error)
 
 	Level  string
@@ -75,18 +73,17 @@ type supportCommand struct {
 }
 
 // SetFlags sets additional flags for the support command.
-func (c *supportCommand) SetFlags(f *gnuflag.FlagSet) {
+func (c *slaCommand) SetFlags(f *gnuflag.FlagSet) {
 	c.ModelCommandBase.SetFlags(f)
 	f.StringVar(&c.Budget, "budget", "", "the maximum spend for the model")
 }
 
 // Info implements cmd.Command.
-func (c *supportCommand) Info() *cmd.Info {
+func (c *slaCommand) Info() *cmd.Info {
 	return &cmd.Info{
 		Name:    "sla",
-		Aliases: []string{"support"},
 		Args:    "<level>",
-		Purpose: "Set the support level for a model.",
+		Purpose: "Set the SLA level for a model.",
 		Doc: `
 Set the support level for the model, effective immediately.
 Examples:
@@ -98,7 +95,7 @@ Examples:
 }
 
 // Init implements cmd.Command.
-func (c *supportCommand) Init(args []string) error {
+func (c *slaCommand) Init(args []string) error {
 	if len(args) < 1 {
 		return nil
 	}
@@ -106,7 +103,7 @@ func (c *supportCommand) Init(args []string) error {
 	return cmd.CheckEmpty(args[1:])
 }
 
-func (c *supportCommand) requestSupportCredentials(modelUUID string) (string, []byte, error) {
+func (c *slaCommand) requestSupportCredentials(modelUUID string) (string, []byte, error) {
 	hc, err := c.BakeryClient()
 	if err != nil {
 		return "", nil, errors.Trace(err)
@@ -141,12 +138,12 @@ func displayCurrentLevel(client slaClient, ctx *cmd.Context) error {
 }
 
 // Run implements cmd.Command.
-func (c *supportCommand) Run(ctx *cmd.Context) error {
+func (c *slaCommand) Run(ctx *cmd.Context) error {
 	root, err := c.newAPIRoot()
 	if err != nil {
 		return errors.Trace(err)
 	}
-	client := c.newSlaClient(root)
+	client := c.newSLAClient(root)
 	modelId := modelId(root)
 
 	if c.Level == "" {


### PR DESCRIPTION
## Description of change

Some TODOs had been left in the code, despite them already being done. Also renamed an internal type for the sake of neatness
## QA steps

None Required. Internal code cleanup only
## Documentation changes

N/A

## Bug reference

N/A
