### PR TITLE
jujuclient: move MemStore from jujuclienttesting

### DIFF
--- a/apiserver/allfacades_test.go
+++ b/apiserver/allfacades_test.go
@@ -4,9 +4,10 @@
 package apiserver_test
 
 import (
-	"github.com/juju/juju/apiserver"
 	"github.com/juju/testing"
 	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/apiserver"
 )
 
 type AllFacadesSuite struct {

--- a/apiserver/common/modelwatcher_test.go
+++ b/apiserver/common/modelwatcher_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/environs/bootstrap"
 	"github.com/juju/juju/environs/config"
-	"github.com/juju/juju/jujuclient/jujuclienttesting"
+	"github.com/juju/juju/jujuclient"
 	"github.com/juju/juju/provider/dummy"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/testing"
@@ -102,7 +102,7 @@ func (*environWatcherSuite) TestModelConfigFetchError(c *gc.C) {
 func testingEnvConfig(c *gc.C) *config.Config {
 	env, err := bootstrap.Prepare(
 		modelcmd.BootstrapContext(testing.Context(c)),
-		jujuclienttesting.NewMemStore(),
+		jujuclient.NewMemStore(),
 		bootstrap.PrepareParams{
 			ControllerConfig: testing.FakeControllerConfig(),
 			ControllerName:   "dummycontroller",

--- a/apiserver/common/storage.go
+++ b/apiserver/common/storage.go
@@ -4,9 +4,9 @@
 package common
 
 import (
+	"github.com/juju/errors"
 	"gopkg.in/juju/names.v2"
 
-	"github.com/juju/errors"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/state"
 )

--- a/apiserver/facade/registry.go
+++ b/apiserver/facade/registry.go
@@ -10,6 +10,7 @@ import (
 	"sort"
 
 	"github.com/juju/errors"
+
 	"github.com/juju/juju/state"
 )
 

--- a/cmd/juju/action/package_test.go
+++ b/cmd/juju/action/package_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/cmd/juju/action"
 	"github.com/juju/juju/jujuclient"
-	"github.com/juju/juju/jujuclient/jujuclienttesting"
 	coretesting "github.com/juju/juju/testing"
 )
 
@@ -41,7 +40,7 @@ type BaseActionSuite struct {
 	command cmd.Command
 
 	modelFlags []string
-	store      *jujuclienttesting.MemStore
+	store      *jujuclient.MemStore
 }
 
 func (s *BaseActionSuite) SetUpTest(c *gc.C) {
@@ -49,7 +48,7 @@ func (s *BaseActionSuite) SetUpTest(c *gc.C) {
 
 	s.modelFlags = []string{"-m", "--model"}
 
-	s.store = jujuclienttesting.NewMemStore()
+	s.store = jujuclient.NewMemStore()
 	s.store.CurrentControllerName = "ctrl"
 	s.store.Accounts["ctrl"] = jujuclient.AccountDetails{
 		User: "admin",

--- a/cmd/juju/application/cmd_test.go
+++ b/cmd/juju/application/cmd_test.go
@@ -12,20 +12,19 @@ import (
 
 	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/jujuclient"
-	"github.com/juju/juju/jujuclient/jujuclienttesting"
 	coretesting "github.com/juju/juju/testing"
 )
 
 type CmdSuite struct {
 	coretesting.FakeJujuXDGDataHomeSuite
-	ControllerStore *jujuclienttesting.MemStore
+	ControllerStore *jujuclient.MemStore
 }
 
 var _ = gc.Suite(&CmdSuite{})
 
 func (s *CmdSuite) SetUpTest(c *gc.C) {
 	s.FakeJujuXDGDataHomeSuite.SetUpTest(c)
-	s.ControllerStore = jujuclienttesting.NewMemStore()
+	s.ControllerStore = jujuclient.NewMemStore()
 }
 
 var deployTests = []struct {

--- a/cmd/juju/application/consume_test.go
+++ b/cmd/juju/application/consume_test.go
@@ -12,14 +12,13 @@ import (
 
 	"github.com/juju/juju/cmd/juju/application"
 	"github.com/juju/juju/jujuclient"
-	"github.com/juju/juju/jujuclient/jujuclienttesting"
 	coretesting "github.com/juju/juju/testing"
 )
 
 type ConsumeSuite struct {
 	testing.IsolationSuite
 	mockAPI *mockConsumeAPI
-	store   *jujuclienttesting.MemStore
+	store   *jujuclient.MemStore
 }
 
 var _ = gc.Suite(&ConsumeSuite{})
@@ -31,7 +30,7 @@ func (s *ConsumeSuite) SetUpTest(c *gc.C) {
 	// Set up the current controller, and write just enough info
 	// so we don't try to refresh
 	controllerName := "test-master"
-	s.store = jujuclienttesting.NewMemStore()
+	s.store = jujuclient.NewMemStore()
 	s.store.CurrentControllerName = controllerName
 	s.store.Controllers[controllerName] = jujuclient.ControllerDetails{}
 	s.store.Models[controllerName] = &jujuclient.ControllerModels{

--- a/cmd/juju/application/upgradecharm_test.go
+++ b/cmd/juju/application/upgradecharm_test.go
@@ -36,7 +36,6 @@ import (
 	"github.com/juju/juju/environs/config"
 	jujutesting "github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/jujuclient"
-	"github.com/juju/juju/jujuclient/jujuclienttesting"
 	"github.com/juju/juju/resource/resourceadapters"
 	"github.com/juju/juju/rpc"
 	"github.com/juju/juju/state"
@@ -117,7 +116,7 @@ func (s *UpgradeCharmSuite) SetUpTest(c *gc.C) {
 	s.modelConfigGetter = mockModelConfigGetter{}
 	s.resourceLister = mockResourceLister{}
 
-	store := jujuclienttesting.NewMemStore()
+	store := jujuclient.NewMemStore()
 	store.CurrentControllerName = "foo"
 	store.Controllers["foo"] = jujuclient.ControllerDetails{}
 	store.Models["foo"] = &jujuclient.ControllerModels{

--- a/cmd/juju/backups/restore_test.go
+++ b/cmd/juju/backups/restore_test.go
@@ -20,7 +20,6 @@ import (
 	"github.com/juju/juju/environs/bootstrap"
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/jujuclient"
-	"github.com/juju/juju/jujuclient/jujuclienttesting"
 	"github.com/juju/juju/network"
 	_ "github.com/juju/juju/provider/dummy"
 	_ "github.com/juju/juju/provider/lxd"
@@ -30,7 +29,7 @@ import (
 
 type restoreSuite struct {
 	BaseBackupsSuite
-	store *jujuclienttesting.MemStore
+	store *jujuclient.MemStore
 }
 
 var _ = gc.Suite(&restoreSuite{})
@@ -50,7 +49,7 @@ func (s *restoreSuite) SetUpTest(c *gc.C) {
 	err := cloud.WritePersonalCloudMetadata(clouds)
 	c.Assert(err, jc.ErrorIsNil)
 
-	s.store = jujuclienttesting.NewMemStore()
+	s.store = jujuclient.NewMemStore()
 	s.store.Controllers["testing"] = jujuclient.ControllerDetails{
 		ControllerUUID:         "deadbeef-0bad-400d-8000-5b1d0d06f00d",
 		CACert:                 testing.CACert,

--- a/cmd/juju/cloud/addcredential_test.go
+++ b/cmd/juju/cloud/addcredential_test.go
@@ -19,7 +19,7 @@ import (
 	jujucloud "github.com/juju/juju/cloud"
 	"github.com/juju/juju/cmd/juju/cloud"
 	"github.com/juju/juju/environs"
-	"github.com/juju/juju/jujuclient/jujuclienttesting"
+	"github.com/juju/juju/jujuclient"
 	_ "github.com/juju/juju/provider/all"
 	"github.com/juju/juju/testing"
 )
@@ -27,14 +27,14 @@ import (
 type addCredentialSuite struct {
 	testing.BaseSuite
 
-	store           *jujuclienttesting.MemStore
+	store           *jujuclient.MemStore
 	schema          map[jujucloud.AuthType]jujucloud.CredentialSchema
 	authTypes       []jujucloud.AuthType
 	cloudByNameFunc func(string) (*jujucloud.Cloud, error)
 }
 
 var _ = gc.Suite(&addCredentialSuite{
-	store: jujuclienttesting.NewMemStore(),
+	store: jujuclient.NewMemStore(),
 })
 
 func (s *addCredentialSuite) SetUpSuite(c *gc.C) {

--- a/cmd/juju/cloud/defaultcredential_test.go
+++ b/cmd/juju/cloud/defaultcredential_test.go
@@ -12,7 +12,7 @@ import (
 
 	jujucloud "github.com/juju/juju/cloud"
 	"github.com/juju/juju/cmd/juju/cloud"
-	"github.com/juju/juju/jujuclient/jujuclienttesting"
+	"github.com/juju/juju/jujuclient"
 	"github.com/juju/juju/testing"
 )
 
@@ -43,7 +43,7 @@ func (s *defaultCredentialSuite) TestBadCloudName(c *gc.C) {
 }
 
 func (s *defaultCredentialSuite) assertSetDefaultCredential(c *gc.C, cloudName string) {
-	store := jujuclienttesting.NewMemStore()
+	store := jujuclient.NewMemStore()
 	store.Credentials[cloudName] = jujucloud.CloudCredential{
 		AuthCredentials: map[string]jujucloud.Credential{
 			"my-sekrets": {},

--- a/cmd/juju/cloud/defaultregion_test.go
+++ b/cmd/juju/cloud/defaultregion_test.go
@@ -13,7 +13,7 @@ import (
 
 	jujucloud "github.com/juju/juju/cloud"
 	"github.com/juju/juju/cmd/juju/cloud"
-	"github.com/juju/juju/jujuclient/jujuclienttesting"
+	"github.com/juju/juju/jujuclient"
 	"github.com/juju/juju/testing"
 )
 
@@ -43,11 +43,11 @@ func (s *defaultRegionSuite) TestBadCloudName(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, `cloud somecloud not valid`)
 }
 
-func (s *defaultRegionSuite) assertSetDefaultRegion(c *gc.C, cmd cmd.Command, store *jujuclienttesting.MemStore, cloud, errStr string) {
+func (s *defaultRegionSuite) assertSetDefaultRegion(c *gc.C, cmd cmd.Command, store *jujuclient.MemStore, cloud, errStr string) {
 	s.assertSetCustomDefaultRegion(c, cmd, store, cloud, "us-west-1", errStr)
 }
 
-func (s *defaultRegionSuite) assertSetCustomDefaultRegion(c *gc.C, cmd cmd.Command, store *jujuclienttesting.MemStore, cloud, desiredDefault, errStr string) {
+func (s *defaultRegionSuite) assertSetCustomDefaultRegion(c *gc.C, cmd cmd.Command, store *jujuclient.MemStore, cloud, desiredDefault, errStr string) {
 	ctx, err := testing.RunCommand(c, cmd, cloud, desiredDefault)
 	output := testing.Stderr(ctx)
 	output = strings.Replace(output, "\n", "", -1)
@@ -63,7 +63,7 @@ func (s *defaultRegionSuite) assertSetCustomDefaultRegion(c *gc.C, cmd cmd.Comma
 }
 
 func (s *defaultRegionSuite) TestSetDefaultRegion(c *gc.C) {
-	store := jujuclienttesting.NewMemStore()
+	store := jujuclient.NewMemStore()
 	store.Credentials["aws"] = jujucloud.CloudCredential{
 		AuthCredentials: map[string]jujucloud.Credential{
 			"one": jujucloud.Credential{},
@@ -73,7 +73,7 @@ func (s *defaultRegionSuite) TestSetDefaultRegion(c *gc.C) {
 }
 
 func (s *defaultRegionSuite) TestSetDefaultRegionBuiltIn(c *gc.C) {
-	store := jujuclienttesting.NewMemStore()
+	store := jujuclient.NewMemStore()
 	store.Credentials["localhost"] = jujucloud.CloudCredential{
 		AuthCredentials: map[string]jujucloud.Credential{
 			"one": jujucloud.Credential{},
@@ -84,7 +84,7 @@ func (s *defaultRegionSuite) TestSetDefaultRegionBuiltIn(c *gc.C) {
 }
 
 func (s *defaultRegionSuite) TestOverwriteDefaultRegion(c *gc.C) {
-	store := jujuclienttesting.NewMemStore()
+	store := jujuclient.NewMemStore()
 	store.Credentials["aws"] = jujucloud.CloudCredential{
 		AuthCredentials: map[string]jujucloud.Credential{
 			"one": jujucloud.Credential{},
@@ -95,7 +95,7 @@ func (s *defaultRegionSuite) TestOverwriteDefaultRegion(c *gc.C) {
 }
 
 func (s *defaultRegionSuite) TestCaseInsensitiveRegionSpecification(c *gc.C) {
-	store := jujuclienttesting.NewMemStore()
+	store := jujuclient.NewMemStore()
 	store.Credentials["aws"] = jujucloud.CloudCredential{
 		AuthCredentials: map[string]jujucloud.Credential{
 			"one": jujucloud.Credential{},

--- a/cmd/juju/cloud/detectcredentials_test.go
+++ b/cmd/juju/cloud/detectcredentials_test.go
@@ -17,12 +17,12 @@ import (
 	jujucloud "github.com/juju/juju/cloud"
 	"github.com/juju/juju/cmd/juju/cloud"
 	"github.com/juju/juju/environs"
-	"github.com/juju/juju/jujuclient/jujuclienttesting"
+	"github.com/juju/juju/jujuclient"
 	"github.com/juju/juju/testing"
 )
 
 type detectCredentialsSuite struct {
-	store       *jujuclienttesting.MemStore
+	store       *jujuclient.MemStore
 	aCredential jujucloud.CloudCredential
 }
 
@@ -97,7 +97,7 @@ func (s *detectCredentialsSuite) SetUpSuite(c *gc.C) {
 }
 
 func (s *detectCredentialsSuite) SetUpTest(c *gc.C) {
-	s.store = jujuclienttesting.NewMemStore()
+	s.store = jujuclient.NewMemStore()
 	s.aCredential = jujucloud.CloudCredential{}
 }
 

--- a/cmd/juju/cloud/listcredentials_test.go
+++ b/cmd/juju/cloud/listcredentials_test.go
@@ -13,13 +13,13 @@ import (
 	jujucloud "github.com/juju/juju/cloud"
 	"github.com/juju/juju/cmd/juju/cloud"
 	"github.com/juju/juju/environs"
-	"github.com/juju/juju/jujuclient/jujuclienttesting"
+	"github.com/juju/juju/jujuclient"
 	"github.com/juju/juju/testing"
 )
 
 type listCredentialsSuite struct {
 	testing.BaseSuite
-	store              *jujuclienttesting.MemStore
+	store              *jujuclient.MemStore
 	personalCloudsFunc func() (map[string]jujucloud.Cloud, error)
 	cloudByNameFunc    func(string) (*jujucloud.Cloud, error)
 }
@@ -45,7 +45,7 @@ func (s *listCredentialsSuite) SetUpSuite(c *gc.C) {
 
 func (s *listCredentialsSuite) SetUpTest(c *gc.C) {
 	s.BaseSuite.SetUpTest(c)
-	s.store = &jujuclienttesting.MemStore{
+	s.store = &jujuclient.MemStore{
 		Credentials: map[string]jujucloud.CloudCredential{
 			"aws": {
 				DefaultRegion:     "ap-southeast-2",
@@ -273,7 +273,7 @@ func (s *listCredentialsSuite) TestListCredentialsJSONFiltered(c *gc.C) {
 }
 
 func (s *listCredentialsSuite) TestListCredentialsEmpty(c *gc.C) {
-	s.store = &jujuclienttesting.MemStore{
+	s.store = &jujuclient.MemStore{
 		Credentials: map[string]jujucloud.CloudCredential{
 			"aws": {
 				AuthCredentials: map[string]jujucloud.Credential{
@@ -296,7 +296,7 @@ func (s *listCredentialsSuite) TestListCredentialsEmpty(c *gc.C) {
 }
 
 func (s *listCredentialsSuite) TestListCredentialsNone(c *gc.C) {
-	listCmd := cloud.NewListCredentialsCommandForTest(jujuclienttesting.NewMemStore(), s.personalCloudsFunc, s.cloudByNameFunc)
+	listCmd := cloud.NewListCredentialsCommandForTest(jujuclient.NewMemStore(), s.personalCloudsFunc, s.cloudByNameFunc)
 	ctx, err := testing.RunCommand(c, listCmd)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(testing.Stderr(ctx), gc.Equals, "")

--- a/cmd/juju/cloud/removecredential_test.go
+++ b/cmd/juju/cloud/removecredential_test.go
@@ -11,7 +11,7 @@ import (
 
 	jujucloud "github.com/juju/juju/cloud"
 	"github.com/juju/juju/cmd/juju/cloud"
-	"github.com/juju/juju/jujuclient/jujuclienttesting"
+	"github.com/juju/juju/jujuclient"
 	"github.com/juju/juju/testing"
 )
 
@@ -30,7 +30,7 @@ func (s *removeCredentialSuite) TestBadArgs(c *gc.C) {
 }
 
 func (s *removeCredentialSuite) TestMissingCredential(c *gc.C) {
-	store := &jujuclienttesting.MemStore{
+	store := &jujuclient.MemStore{
 		Credentials: map[string]jujucloud.CloudCredential{
 			"aws": {
 				AuthCredentials: map[string]jujucloud.Credential{
@@ -48,7 +48,7 @@ func (s *removeCredentialSuite) TestMissingCredential(c *gc.C) {
 }
 
 func (s *removeCredentialSuite) TestBadCloudName(c *gc.C) {
-	cmd := cloud.NewRemoveCredentialCommandForTest(jujuclienttesting.NewMemStore())
+	cmd := cloud.NewRemoveCredentialCommandForTest(jujuclient.NewMemStore())
 	ctx, err := testing.RunCommand(c, cmd, "somecloud", "foo")
 	c.Assert(err, jc.ErrorIsNil)
 	output := testing.Stderr(ctx)
@@ -57,7 +57,7 @@ func (s *removeCredentialSuite) TestBadCloudName(c *gc.C) {
 }
 
 func (s *removeCredentialSuite) TestRemove(c *gc.C) {
-	store := &jujuclienttesting.MemStore{
+	store := &jujuclient.MemStore{
 		Credentials: map[string]jujucloud.CloudCredential{
 			"aws": {
 				AuthCredentials: map[string]jujucloud.Credential{

--- a/cmd/juju/cloud/updatecredential_test.go
+++ b/cmd/juju/cloud/updatecredential_test.go
@@ -13,7 +13,6 @@ import (
 	jujucloud "github.com/juju/juju/cloud"
 	"github.com/juju/juju/cmd/juju/cloud"
 	"github.com/juju/juju/jujuclient"
-	"github.com/juju/juju/jujuclient/jujuclienttesting"
 	"github.com/juju/juju/testing"
 )
 
@@ -24,7 +23,7 @@ type updateCredentialSuite struct {
 var _ = gc.Suite(&updateCredentialSuite{})
 
 func (s *updateCredentialSuite) TestBadArgs(c *gc.C) {
-	store := &jujuclienttesting.MemStore{
+	store := &jujuclient.MemStore{
 		Controllers: map[string]jujuclient.ControllerDetails{
 			"controller": {},
 		},
@@ -38,7 +37,7 @@ func (s *updateCredentialSuite) TestBadArgs(c *gc.C) {
 }
 
 func (s *updateCredentialSuite) TestMissingCredential(c *gc.C) {
-	store := &jujuclienttesting.MemStore{
+	store := &jujuclient.MemStore{
 		Controllers: map[string]jujuclient.ControllerDetails{
 			"controller": {},
 		},
@@ -60,7 +59,7 @@ func (s *updateCredentialSuite) TestMissingCredential(c *gc.C) {
 }
 
 func (s *updateCredentialSuite) TestBadCloudName(c *gc.C) {
-	store := &jujuclienttesting.MemStore{
+	store := &jujuclient.MemStore{
 		Controllers: map[string]jujuclient.ControllerDetails{
 			"controller": {},
 		},
@@ -75,7 +74,7 @@ func (s *updateCredentialSuite) TestBadCloudName(c *gc.C) {
 }
 
 func (s *updateCredentialSuite) TestUpdate(c *gc.C) {
-	store := &jujuclienttesting.MemStore{
+	store := &jujuclient.MemStore{
 		Controllers: map[string]jujuclient.ControllerDetails{
 			"controller": {},
 		},

--- a/cmd/juju/commands/bootstrap_test.go
+++ b/cmd/juju/commands/bootstrap_test.go
@@ -61,7 +61,7 @@ type BootstrapSuite struct {
 	coretesting.FakeJujuXDGDataHomeSuite
 	testing.MgoSuite
 	envtesting.ToolsFixture
-	store *jujuclienttesting.MemStore
+	store *jujuclient.MemStore
 	tw    loggo.TestWriter
 }
 
@@ -114,7 +114,7 @@ func (s *BootstrapSuite) SetUpTest(c *gc.C) {
 	})
 
 	// TODO(wallyworld) - add test data when tests are improved
-	s.store = jujuclienttesting.NewMemStore()
+	s.store = jujuclient.NewMemStore()
 
 	// Write bootstrap command logs to an in-memory buffer,
 	// so we can inspect the output in tests.
@@ -216,7 +216,7 @@ func (s *BootstrapSuite) run(c *gc.C, test bootstrapTest) testing.Restorer {
 	s.tw.Clear()
 
 	var restore testing.Restorer = func() {
-		s.store = jujuclienttesting.NewMemStore()
+		s.store = jujuclient.NewMemStore()
 	}
 	bootstrapVersion := v100p64
 	if test.version != "" {
@@ -1636,7 +1636,7 @@ func (s *BootstrapSuite) TestBootstrapPrintClouds(c *gc.C) {
 		},
 	}
 	defer func() {
-		s.store = jujuclienttesting.NewMemStore()
+		s.store = jujuclient.NewMemStore()
 	}()
 
 	ctx, err := coretesting.RunCommand(c, s.newBootstrapCommand(), "--clouds")

--- a/cmd/juju/commands/migrate_test.go
+++ b/cmd/juju/commands/migrate_test.go
@@ -20,7 +20,6 @@ import (
 	"github.com/juju/juju/api/controller"
 	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/jujuclient"
-	"github.com/juju/juju/jujuclient/jujuclienttesting"
 	"github.com/juju/juju/testing"
 )
 
@@ -28,7 +27,7 @@ type MigrateSuite struct {
 	testing.FakeJujuXDGDataHomeSuite
 	api                 *fakeMigrateAPI
 	targetControllerAPI *fakeTargetControllerAPI
-	store               *jujuclienttesting.MemStore
+	store               *jujuclient.MemStore
 	password            string
 }
 
@@ -40,7 +39,7 @@ const targetControllerUUID = "beefdead-0bad-400d-8000-4b1d0d06f00d"
 func (s *MigrateSuite) SetUpTest(c *gc.C) {
 	s.FakeJujuXDGDataHomeSuite.SetUpTest(c)
 
-	s.store = jujuclienttesting.NewMemStore()
+	s.store = jujuclient.NewMemStore()
 
 	// Define the source controller in the config and set it as the default.
 	err := s.store.AddController("source", jujuclient.ControllerDetails{

--- a/cmd/juju/commands/switch_test.go
+++ b/cmd/juju/commands/switch_test.go
@@ -22,7 +22,7 @@ import (
 type SwitchSimpleSuite struct {
 	coretesting.FakeJujuXDGDataHomeSuite
 	testing.Stub
-	store     *jujuclienttesting.MemStore
+	store     *jujuclient.MemStore
 	stubStore *jujuclienttesting.StubStore
 	onRefresh func()
 }
@@ -32,7 +32,7 @@ var _ = gc.Suite(&SwitchSimpleSuite{})
 func (s *SwitchSimpleSuite) SetUpTest(c *gc.C) {
 	s.FakeJujuXDGDataHomeSuite.SetUpTest(c)
 	s.Stub.ResetCalls()
-	s.store = jujuclienttesting.NewMemStore()
+	s.store = jujuclient.NewMemStore()
 	s.stubStore = jujuclienttesting.WrapClientStore(s.store)
 	s.onRefresh = nil
 }

--- a/cmd/juju/commands/synctools_test.go
+++ b/cmd/juju/commands/synctools_test.go
@@ -23,7 +23,6 @@ import (
 	"github.com/juju/juju/environs/sync"
 	envtools "github.com/juju/juju/environs/tools"
 	"github.com/juju/juju/jujuclient"
-	"github.com/juju/juju/jujuclient/jujuclienttesting"
 	coretesting "github.com/juju/juju/testing"
 	coretools "github.com/juju/juju/tools"
 	jujuversion "github.com/juju/juju/version"
@@ -32,7 +31,7 @@ import (
 type syncToolsSuite struct {
 	coretesting.FakeJujuXDGDataHomeSuite
 	fakeSyncToolsAPI *fakeSyncToolsAPI
-	store            *jujuclienttesting.MemStore
+	store            *jujuclient.MemStore
 }
 
 var _ = gc.Suite(&syncToolsSuite{})
@@ -43,7 +42,7 @@ func (s *syncToolsSuite) SetUpTest(c *gc.C) {
 	s.PatchValue(&getSyncToolsAPI, func(c *syncToolsCommand) (syncToolsAPI, error) {
 		return s.fakeSyncToolsAPI, nil
 	})
-	s.store = jujuclienttesting.NewMemStore()
+	s.store = jujuclient.NewMemStore()
 	s.store.CurrentControllerName = "ctrl"
 	s.store.Accounts["ctrl"] = jujuclient.AccountDetails{
 		User: "admin",

--- a/cmd/juju/common/controller_test.go
+++ b/cmd/juju/common/controller_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/cmd/modelcmd"
 	cmdtesting "github.com/juju/juju/cmd/testing"
-	"github.com/juju/juju/jujuclient/jujuclienttesting"
+	"github.com/juju/juju/jujuclient"
 	"github.com/juju/juju/rpc"
 	"github.com/juju/juju/testing"
 	"github.com/juju/juju/version"
@@ -94,7 +94,7 @@ func (s *controllerSuite) TestWaitForAgentAPIReadyRetries(c *gc.C) {
 		s.mockBlockClient.numRetries = t.numRetries
 		s.mockBlockClient.retryCount = 0
 		cmd := &modelcmd.ModelCommandBase{}
-		cmd.SetClientStore(jujuclienttesting.NewMemStore())
+		cmd.SetClientStore(jujuclient.NewMemStore())
 		err := WaitForAgentInitialisation(cmdtesting.NullContext(c), cmd, "controller", "default")
 		c.Check(errors.Cause(err), gc.DeepEquals, t.err)
 		expectedRetries := t.numRetries
@@ -112,7 +112,7 @@ func (s *controllerSuite) TestWaitForAgentAPIReadyRetries(c *gc.C) {
 func (s *controllerSuite) TestWaitForAgentAPIReadyWaitsForSpaceDiscovery(c *gc.C) {
 	s.mockBlockClient.discoveringSpacesError = 2
 	cmd := &modelcmd.ModelCommandBase{}
-	cmd.SetClientStore(jujuclienttesting.NewMemStore())
+	cmd.SetClientStore(jujuclient.NewMemStore())
 	err := WaitForAgentInitialisation(cmdtesting.NullContext(c), cmd, "controller", "default")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(s.mockBlockClient.discoveringSpacesError, gc.Equals, 0)
@@ -123,7 +123,7 @@ func (s *controllerSuite) TestWaitForAgentAPIReadyRetriesWithOpenEOFErr(c *gc.C)
 	s.mockBlockClient.retryCount = 0
 	s.mockBlockClient.loginError = io.EOF
 	cmd := &modelcmd.ModelCommandBase{}
-	cmd.SetClientStore(jujuclienttesting.NewMemStore())
+	cmd.SetClientStore(jujuclient.NewMemStore())
 	err := WaitForAgentInitialisation(cmdtesting.NullContext(c), cmd, "controller", "default")
 	c.Check(err, jc.ErrorIsNil)
 
@@ -135,7 +135,7 @@ func (s *controllerSuite) TestWaitForAgentAPIReadyStopsRetriesWithOpenErr(c *gc.
 	s.mockBlockClient.retryCount = 0
 	s.mockBlockClient.loginError = errors.NewUnauthorized(nil, "")
 	cmd := &modelcmd.ModelCommandBase{}
-	cmd.SetClientStore(jujuclienttesting.NewMemStore())
+	cmd.SetClientStore(jujuclient.NewMemStore())
 	err := WaitForAgentInitialisation(cmdtesting.NullContext(c), cmd, "controller", "default")
 	c.Check(err, jc.Satisfies, errors.IsUnauthorized)
 

--- a/cmd/juju/controller/addmodel_test.go
+++ b/cmd/juju/controller/addmodel_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/juju/juju/cmd/juju/controller"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/jujuclient"
-	"github.com/juju/juju/jujuclient/jujuclienttesting"
 	_ "github.com/juju/juju/provider/ec2"
 	"github.com/juju/juju/testing"
 )
@@ -35,7 +34,7 @@ type AddModelSuite struct {
 	fakeCloudAPI         *fakeCloudAPI
 	fakeProvider         *fakeProvider
 	fakeProviderRegistry *fakeProviderRegistry
-	store                *jujuclienttesting.MemStore
+	store                *jujuclient.MemStore
 }
 
 var _ = gc.Suite(&AddModelSuite{})
@@ -69,7 +68,7 @@ func (s *AddModelSuite) SetUpTest(c *gc.C) {
 	// Set up the current controller, and write just enough info
 	// so we don't try to refresh
 	controllerName := "test-master"
-	s.store = jujuclienttesting.NewMemStore()
+	s.store = jujuclient.NewMemStore()
 	s.store.CurrentControllerName = controllerName
 	s.store.Controllers[controllerName] = jujuclient.ControllerDetails{}
 	s.store.Accounts[controllerName] = jujuclient.AccountDetails{

--- a/cmd/juju/controller/destroy_test.go
+++ b/cmd/juju/controller/destroy_test.go
@@ -23,7 +23,6 @@ import (
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/jujuclient"
-	"github.com/juju/juju/jujuclient/jujuclienttesting"
 	"github.com/juju/juju/provider/dummy"
 	"github.com/juju/juju/testing"
 )
@@ -48,7 +47,7 @@ type baseDestroySuite struct {
 	testing.FakeJujuXDGDataHomeSuite
 	api       *fakeDestroyAPI
 	clientapi *fakeDestroyAPIClient
-	store     *jujuclienttesting.MemStore
+	store     *jujuclient.MemStore
 	apierror  error
 }
 
@@ -161,7 +160,7 @@ func (s *baseDestroySuite) SetUpTest(c *gc.C) {
 	}
 	s.apierror = nil
 
-	s.store = jujuclienttesting.NewMemStore()
+	s.store = jujuclient.NewMemStore()
 	s.store.Controllers["test1"] = jujuclient.ControllerDetails{
 		APIEndpoints:   []string{"localhost"},
 		CACert:         testing.CACert,

--- a/cmd/juju/controller/enabledestroy_test.go
+++ b/cmd/juju/controller/enabledestroy_test.go
@@ -11,14 +11,13 @@ import (
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/cmd/juju/controller"
 	"github.com/juju/juju/jujuclient"
-	"github.com/juju/juju/jujuclient/jujuclienttesting"
 	"github.com/juju/juju/testing"
 )
 
 type enableDestroyControllerSuite struct {
 	baseControllerSuite
 	api   *fakeRemoveBlocksAPI
-	store *jujuclienttesting.MemStore
+	store *jujuclient.MemStore
 }
 
 var _ = gc.Suite(&enableDestroyControllerSuite{})
@@ -27,7 +26,7 @@ func (s *enableDestroyControllerSuite) SetUpTest(c *gc.C) {
 	s.baseControllerSuite.SetUpTest(c)
 
 	s.api = &fakeRemoveBlocksAPI{}
-	s.store = jujuclienttesting.NewMemStore()
+	s.store = jujuclient.NewMemStore()
 	s.store.CurrentControllerName = "fake"
 	s.store.Controllers["fake"] = jujuclient.ControllerDetails{}
 }

--- a/cmd/juju/controller/listcontrollers_test.go
+++ b/cmd/juju/controller/listcontrollers_test.go
@@ -28,7 +28,7 @@ type ListControllersSuite struct {
 var _ = gc.Suite(&ListControllersSuite{})
 
 func (s *ListControllersSuite) TestListControllersEmptyStore(c *gc.C) {
-	s.store = jujuclienttesting.NewMemStore()
+	s.store = jujuclient.NewMemStore()
 	_, err := s.runListControllers(c)
 	c.Check(errors.Cause(err), gc.Equals, modelcmd.ErrNoControllersDefined)
 }

--- a/cmd/juju/controller/listmodels_test.go
+++ b/cmd/juju/controller/listmodels_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/cmd/juju/controller"
 	"github.com/juju/juju/jujuclient"
-	"github.com/juju/juju/jujuclient/jujuclienttesting"
 	"github.com/juju/juju/status"
 	"github.com/juju/juju/testing"
 )
@@ -24,7 +23,7 @@ import (
 type ModelsSuite struct {
 	testing.FakeJujuXDGDataHomeSuite
 	api   *fakeModelMgrAPIClient
-	store *jujuclienttesting.MemStore
+	store *jujuclient.MemStore
 }
 
 var _ = gc.Suite(&ModelsSuite{})
@@ -136,7 +135,7 @@ func (s *ModelsSuite) SetUpTest(c *gc.C) {
 		models: models,
 		user:   "admin",
 	}
-	s.store = jujuclienttesting.NewMemStore()
+	s.store = jujuclient.NewMemStore()
 	s.store.CurrentControllerName = "fake"
 	s.store.Controllers["fake"] = jujuclient.ControllerDetails{}
 	s.store.Models["fake"] = &jujuclient.ControllerModels{

--- a/cmd/juju/controller/package_test.go
+++ b/cmd/juju/controller/package_test.go
@@ -10,7 +10,6 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/jujuclient"
-	"github.com/juju/juju/jujuclient/jujuclienttesting"
 	coretesting "github.com/juju/juju/testing"
 )
 
@@ -33,7 +32,7 @@ func (s *baseControllerSuite) SetUpTest(c *gc.C) {
 	s.store = nil
 }
 
-func (s *baseControllerSuite) createTestClientStore(c *gc.C) *jujuclienttesting.MemStore {
+func (s *baseControllerSuite) createTestClientStore(c *gc.C) *jujuclient.MemStore {
 	controllers, err := jujuclient.ParseControllers([]byte(s.controllersYaml))
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -43,7 +42,7 @@ func (s *baseControllerSuite) createTestClientStore(c *gc.C) *jujuclienttesting.
 	accounts, err := jujuclient.ParseAccounts([]byte(s.accountsYaml))
 	c.Assert(err, jc.ErrorIsNil)
 
-	store := jujuclienttesting.NewMemStore()
+	store := jujuclient.NewMemStore()
 	store.Controllers = controllers.Controllers
 	store.CurrentControllerName = controllers.CurrentController
 	store.Models = models

--- a/cmd/juju/controller/register_test.go
+++ b/cmd/juju/controller/register_test.go
@@ -27,14 +27,13 @@ import (
 	"github.com/juju/juju/cmd/juju/controller"
 	cmdtesting "github.com/juju/juju/cmd/testing"
 	"github.com/juju/juju/jujuclient"
-	"github.com/juju/juju/jujuclient/jujuclienttesting"
 	"github.com/juju/juju/testing"
 )
 
 type RegisterSuite struct {
 	testing.FakeJujuXDGDataHomeSuite
 	apiConnection            *mockAPIConnection
-	store                    *jujuclienttesting.MemStore
+	store                    *jujuclient.MemStore
 	apiOpenError             error
 	listModels               func(jujuclient.ClientStore, string, string) ([]base.UserModel, error)
 	listModelsControllerName string
@@ -74,7 +73,7 @@ func (s *RegisterSuite) SetUpTest(c *gc.C) {
 		return nil, nil
 	}
 
-	s.store = jujuclienttesting.NewMemStore()
+	s.store = jujuclient.NewMemStore()
 }
 
 func (s *RegisterSuite) TearDownTest(c *gc.C) {

--- a/cmd/juju/crossmodel/package_test.go
+++ b/cmd/juju/crossmodel/package_test.go
@@ -9,7 +9,6 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/jujuclient"
-	"github.com/juju/juju/jujuclient/jujuclienttesting"
 	jujutesting "github.com/juju/juju/testing"
 )
 
@@ -20,14 +19,14 @@ func TestAll(t *testing.T) {
 type BaseCrossModelSuite struct {
 	jujutesting.BaseSuite
 
-	store *jujuclienttesting.MemStore
+	store *jujuclient.MemStore
 }
 
 func (s *BaseCrossModelSuite) SetUpTest(c *gc.C) {
 	// Set up the current controller, and write just enough info
 	// so we don't try to refresh
 	controllerName := "test-master"
-	s.store = jujuclienttesting.NewMemStore()
+	s.store = jujuclient.NewMemStore()
 	s.store.CurrentControllerName = controllerName
 	s.store.Controllers[controllerName] = jujuclient.ControllerDetails{}
 	s.store.Models[controllerName] = &jujuclient.ControllerModels{

--- a/cmd/juju/model/defaultscommand_test.go
+++ b/cmd/juju/model/defaultscommand_test.go
@@ -13,20 +13,19 @@ import (
 	"github.com/juju/juju/cmd/juju/model"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/jujuclient"
-	"github.com/juju/juju/jujuclient/jujuclienttesting"
 	"github.com/juju/juju/testing"
 )
 
 type DefaultsCommandSuite struct {
 	fakeModelDefaultEnvSuite
-	store *jujuclienttesting.MemStore
+	store *jujuclient.MemStore
 }
 
 var _ = gc.Suite(&DefaultsCommandSuite{})
 
 func (s *DefaultsCommandSuite) SetUpTest(c *gc.C) {
 	s.fakeModelDefaultEnvSuite.SetUpTest(c)
-	s.store = jujuclienttesting.NewMemStore()
+	s.store = jujuclient.NewMemStore()
 	s.store.CurrentControllerName = "controller"
 	s.store.Controllers["controller"] = jujuclient.ControllerDetails{}
 }

--- a/cmd/juju/model/destroy_test.go
+++ b/cmd/juju/model/destroy_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/juju/juju/cmd/modelcmd"
 	cmdtesting "github.com/juju/juju/cmd/testing"
 	"github.com/juju/juju/jujuclient"
-	"github.com/juju/juju/jujuclient/jujuclienttesting"
 	_ "github.com/juju/juju/provider/dummy"
 	"github.com/juju/juju/testing"
 )
@@ -33,7 +32,7 @@ type DestroySuite struct {
 	configAPI       *fakeConfigAPI
 	stub            *jutesting.Stub
 	budgetAPIClient *mockBudgetAPIClient
-	store           *jujuclienttesting.MemStore
+	store           *jujuclient.MemStore
 	sleep           func(time.Duration)
 }
 
@@ -81,7 +80,7 @@ func (s *DestroySuite) SetUpTest(c *gc.C) {
 	s.configAPI = &fakeConfigAPI{}
 	s.configAPI.err = nil
 
-	s.store = jujuclienttesting.NewMemStore()
+	s.store = jujuclient.NewMemStore()
 	s.store.CurrentControllerName = "test1"
 	s.store.Controllers["test1"] = jujuclient.ControllerDetails{ControllerUUID: "test1-uuid"}
 	s.store.Models["test1"] = &jujuclient.ControllerModels{

--- a/cmd/juju/model/dump_test.go
+++ b/cmd/juju/model/dump_test.go
@@ -11,14 +11,13 @@ import (
 
 	"github.com/juju/juju/cmd/juju/model"
 	"github.com/juju/juju/jujuclient"
-	"github.com/juju/juju/jujuclient/jujuclienttesting"
 	"github.com/juju/juju/testing"
 )
 
 type DumpCommandSuite struct {
 	testing.FakeJujuXDGDataHomeSuite
 	fake  fakeDumpClient
-	store *jujuclienttesting.MemStore
+	store *jujuclient.MemStore
 }
 
 var _ = gc.Suite(&DumpCommandSuite{})
@@ -46,7 +45,7 @@ func (f *fakeDumpClient) DumpModel(model names.ModelTag) (map[string]interface{}
 func (s *DumpCommandSuite) SetUpTest(c *gc.C) {
 	s.FakeJujuXDGDataHomeSuite.SetUpTest(c)
 	s.fake.ResetCalls()
-	s.store = jujuclienttesting.NewMemStore()
+	s.store = jujuclient.NewMemStore()
 	s.store.CurrentControllerName = "testing"
 	s.store.Controllers["testing"] = jujuclient.ControllerDetails{}
 	s.store.Accounts["testing"] = jujuclient.AccountDetails{

--- a/cmd/juju/model/dumpdb_test.go
+++ b/cmd/juju/model/dumpdb_test.go
@@ -11,14 +11,13 @@ import (
 
 	"github.com/juju/juju/cmd/juju/model"
 	"github.com/juju/juju/jujuclient"
-	"github.com/juju/juju/jujuclient/jujuclienttesting"
 	"github.com/juju/juju/testing"
 )
 
 type DumpDBCommandSuite struct {
 	testing.FakeJujuXDGDataHomeSuite
 	fake  fakeDumpDBClient
-	store *jujuclienttesting.MemStore
+	store *jujuclient.MemStore
 }
 
 var _ = gc.Suite(&DumpDBCommandSuite{})
@@ -26,7 +25,7 @@ var _ = gc.Suite(&DumpDBCommandSuite{})
 func (s *DumpDBCommandSuite) SetUpTest(c *gc.C) {
 	s.FakeJujuXDGDataHomeSuite.SetUpTest(c)
 	s.fake.ResetCalls()
-	s.store = jujuclienttesting.NewMemStore()
+	s.store = jujuclient.NewMemStore()
 	s.store.CurrentControllerName = "testing"
 	s.store.Controllers["testing"] = jujuclient.ControllerDetails{}
 	s.store.Accounts["testing"] = jujuclient.AccountDetails{

--- a/cmd/juju/model/grantrevoke.go
+++ b/cmd/juju/model/grantrevoke.go
@@ -4,12 +4,13 @@
 package model
 
 import (
+	"fmt"
+
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
 	"github.com/juju/utils/featureflag"
 	"gopkg.in/juju/names.v2"
 
-	"fmt"
 	"github.com/juju/juju/api/applicationoffers"
 	"github.com/juju/juju/cmd/juju/block"
 	"github.com/juju/juju/cmd/modelcmd"

--- a/cmd/juju/model/grantrevoke_test.go
+++ b/cmd/juju/model/grantrevoke_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/juju/juju/core/crossmodel"
 	"github.com/juju/juju/feature"
 	"github.com/juju/juju/jujuclient"
-	"github.com/juju/juju/jujuclient/jujuclienttesting"
 	"github.com/juju/juju/testing"
 )
 
@@ -24,7 +23,7 @@ type grantRevokeSuite struct {
 	fakeModelAPI  *fakeModelGrantRevokeAPI
 	fakeOffersAPI *fakeOffersGrantRevokeAPI
 	cmdFactory    func(*fakeModelGrantRevokeAPI, *fakeOffersGrantRevokeAPI) cmd.Command
-	store         *jujuclienttesting.MemStore
+	store         *jujuclient.MemStore
 }
 
 const (
@@ -45,7 +44,7 @@ func (s *grantRevokeSuite) SetUpTest(c *gc.C) {
 	// so we don't try to refresh
 	controllerName := "test-master"
 
-	s.store = jujuclienttesting.NewMemStore()
+	s.store = jujuclient.NewMemStore()
 	s.store.CurrentControllerName = controllerName
 	s.store.Controllers[controllerName] = jujuclient.ControllerDetails{}
 	s.store.Accounts[controllerName] = jujuclient.AccountDetails{

--- a/cmd/juju/model/show_test.go
+++ b/cmd/juju/model/show_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/cmd/juju/model"
 	"github.com/juju/juju/jujuclient"
-	"github.com/juju/juju/jujuclient/jujuclienttesting"
 	"github.com/juju/juju/status"
 	"github.com/juju/juju/testing"
 )
@@ -24,7 +23,7 @@ import (
 type ShowCommandSuite struct {
 	testing.FakeJujuXDGDataHomeSuite
 	fake           fakeModelShowClient
-	store          *jujuclienttesting.MemStore
+	store          *jujuclient.MemStore
 	expectedOutput attrs
 }
 
@@ -126,7 +125,7 @@ func (s *ShowCommandSuite) SetUpTest(c *gc.C) {
 		},
 	}
 
-	s.store = jujuclienttesting.NewMemStore()
+	s.store = jujuclient.NewMemStore()
 	s.store.CurrentControllerName = "testing"
 	s.store.Controllers["testing"] = jujuclient.ControllerDetails{}
 	s.store.Accounts["testing"] = jujuclient.AccountDetails{

--- a/cmd/juju/romulus/allocate/allocate_test.go
+++ b/cmd/juju/romulus/allocate/allocate_test.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/juju/juju/cmd/juju/romulus/allocate"
 	"github.com/juju/juju/jujuclient"
-	"github.com/juju/juju/jujuclient/jujuclienttesting"
 	coretesting "github.com/juju/juju/testing"
 )
 
@@ -28,7 +27,7 @@ type updateAllocationSuite struct {
 
 func (s *updateAllocationSuite) SetUpTest(c *gc.C) {
 	s.FakeJujuXDGDataHomeSuite.SetUpTest(c)
-	s.store = &jujuclienttesting.MemStore{
+	s.store = &jujuclient.MemStore{
 		Controllers: map[string]jujuclient.ControllerDetails{
 			"controller": {},
 		},

--- a/cmd/juju/romulus/sla/sla_test.go
+++ b/cmd/juju/romulus/sla/sla_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/juju/cmd"
 	"github.com/juju/cmd/cmdtesting"
 	"github.com/juju/errors"
-
 	slawire "github.com/juju/romulus/wireformat/sla"
 	"github.com/juju/testing"
 	jujutesting "github.com/juju/testing"

--- a/cmd/juju/storage/package_test.go
+++ b/cmd/juju/storage/package_test.go
@@ -10,7 +10,6 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/jujuclient"
-	"github.com/juju/juju/jujuclient/jujuclienttesting"
 	jujutesting "github.com/juju/juju/testing"
 )
 
@@ -34,13 +33,13 @@ func (s *BaseStorageSuite) TearDownTest(c *gc.C) {
 
 type SubStorageSuite struct {
 	jujutesting.FakeJujuXDGDataHomeSuite
-	store *jujuclienttesting.MemStore
+	store *jujuclient.MemStore
 }
 
 func (s *SubStorageSuite) SetUpTest(c *gc.C) {
 	s.FakeJujuXDGDataHomeSuite.SetUpTest(c)
 
-	s.store = jujuclienttesting.NewMemStore()
+	s.store = jujuclient.NewMemStore()
 	s.store.CurrentControllerName = "testing"
 	s.store.Controllers["testing"] = jujuclient.ControllerDetails{}
 	s.store.Accounts["testing"] = jujuclient.AccountDetails{

--- a/cmd/juju/user/logincontroller_test.go
+++ b/cmd/juju/user/logincontroller_test.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
-	"github.com/juju/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/names.v2"
@@ -21,6 +20,7 @@ import (
 	"github.com/juju/juju/cmd/juju/user"
 	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/jujuclient"
+	"github.com/juju/juju/testing"
 )
 
 func (s *LoginCommandSuite) TestLoginFromDirectory(c *gc.C) {

--- a/cmd/juju/user/user_test.go
+++ b/cmd/juju/user/user_test.go
@@ -8,19 +8,18 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/jujuclient"
-	"github.com/juju/juju/jujuclient/jujuclienttesting"
 	"github.com/juju/juju/testing"
 )
 
 type BaseSuite struct {
 	testing.FakeJujuXDGDataHomeSuite
-	store *jujuclienttesting.MemStore
+	store *jujuclient.MemStore
 }
 
 func (s *BaseSuite) SetUpTest(c *gc.C) {
 	s.FakeJujuXDGDataHomeSuite.SetUpTest(c)
 
-	s.store = jujuclienttesting.NewMemStore()
+	s.store = jujuclient.NewMemStore()
 	s.store.CurrentControllerName = "testing"
 	s.store.Controllers["testing"] = jujuclient.ControllerDetails{
 		APIEndpoints:   []string{"0.1.2.3:12345"},

--- a/cmd/juju/user/whoami_test.go
+++ b/cmd/juju/user/whoami_test.go
@@ -30,7 +30,7 @@ There is no current controller.
 Run juju list-controllers to see available controllers.
 `[1:]
 
-	s.store = jujuclienttesting.NewMemStore()
+	s.store = jujuclient.NewMemStore()
 	s.assertWhoAmI(c)
 }
 
@@ -40,7 +40,7 @@ There is no current controller.
 Run juju list-controllers to see available controllers.
 `[1:]
 
-	s.store = &jujuclienttesting.MemStore{
+	s.store = &jujuclient.MemStore{
 		Controllers: map[string]jujuclient.ControllerDetails{
 			"controller": {},
 		},
@@ -55,7 +55,7 @@ Model:       <no-current-model>
 User:        admin
 `[1:]
 
-	s.store = &jujuclienttesting.MemStore{
+	s.store = &jujuclient.MemStore{
 		CurrentControllerName: "controller",
 		Controllers: map[string]jujuclient.ControllerDetails{
 			"controller": {},
@@ -82,7 +82,7 @@ You are not logged in to controller "controller" and model "admin/model".
 Run juju login if you want to login.
 `[1:]
 
-	s.store = &jujuclienttesting.MemStore{
+	s.store = &jujuclient.MemStore{
 		CurrentControllerName: "controller",
 		Controllers: map[string]jujuclient.ControllerDetails{
 			"controller": {},
@@ -100,7 +100,7 @@ Run juju login if you want to login.
 }
 
 func (s *WhoAmITestSuite) assertWhoAmIForUser(c *gc.C, user, format string) {
-	s.store = &jujuclienttesting.MemStore{
+	s.store = &jujuclient.MemStore{
 		CurrentControllerName: "controller",
 		Controllers: map[string]jujuclient.ControllerDetails{
 			"controller": {},

--- a/cmd/modelcmd/base_test.go
+++ b/cmd/modelcmd/base_test.go
@@ -17,13 +17,12 @@ import (
 	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/jujuclient"
-	"github.com/juju/juju/jujuclient/jujuclienttesting"
 	coretesting "github.com/juju/juju/testing"
 )
 
 type BaseCommandSuite struct {
 	testing.IsolationSuite
-	store *jujuclienttesting.MemStore
+	store *jujuclient.MemStore
 }
 
 var _ = gc.Suite(&BaseCommandSuite{})
@@ -31,7 +30,7 @@ var _ = gc.Suite(&BaseCommandSuite{})
 func (s *BaseCommandSuite) SetUpTest(c *gc.C) {
 	s.IsolationSuite.SetUpTest(c)
 
-	s.store = jujuclienttesting.NewMemStore()
+	s.store = jujuclient.NewMemStore()
 	s.store.CurrentControllerName = "foo"
 	s.store.Controllers["foo"] = jujuclient.ControllerDetails{
 		APIEndpoints: []string{"testing.invalid:1234"},
@@ -79,7 +78,7 @@ type NewGetBootstrapConfigParamsFuncSuite struct {
 var _ = gc.Suite(&NewGetBootstrapConfigParamsFuncSuite{})
 
 func (NewGetBootstrapConfigParamsFuncSuite) TestDetectCredentials(c *gc.C) {
-	clientStore := jujuclienttesting.NewMemStore()
+	clientStore := jujuclient.NewMemStore()
 	clientStore.Controllers["foo"] = jujuclient.ControllerDetails{}
 	clientStore.BootstrapConfig["foo"] = jujuclient.BootstrapConfig{
 		Cloud:               "cloud",

--- a/cmd/modelcmd/controller_test.go
+++ b/cmd/modelcmd/controller_test.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/jujuclient"
-	"github.com/juju/juju/jujuclient/jujuclienttesting"
 )
 
 type ControllerCommandSuite struct {
@@ -28,7 +27,7 @@ func (s *ControllerCommandSuite) TestControllerCommandNoneSpecified(c *gc.C) {
 }
 
 func (s *ControllerCommandSuite) TestControllerCommandInitCurrentController(c *gc.C) {
-	store := jujuclienttesting.NewMemStore()
+	store := jujuclient.NewMemStore()
 	store.CurrentControllerName = "foo"
 	store.Accounts["foo"] = jujuclient.AccountDetails{
 		User: "bar",
@@ -40,7 +39,7 @@ func (s *ControllerCommandSuite) TestControllerCommandInitCurrentController(c *g
 func (s *ControllerCommandSuite) TestControllerCommandInitExplicit(c *gc.C) {
 	// Take controller name from command line arg, and it trumps the current-
 	// controller file.
-	store := jujuclienttesting.NewMemStore()
+	store := jujuclient.NewMemStore()
 	store.CurrentControllerName = "foo"
 	store.Accounts["explicit"] = jujuclient.AccountDetails{
 		User: "bar",

--- a/cmd/modelcmd/credentials_test.go
+++ b/cmd/modelcmd/credentials_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/environs"
-	"github.com/juju/juju/jujuclient/jujuclienttesting"
+	"github.com/juju/juju/jujuclient"
 	_ "github.com/juju/juju/provider/dummy"
 	jujutesting "github.com/juju/juju/testing"
 )
@@ -70,7 +70,7 @@ func (mockProvider) FinalizeCredential(
 type credentialsSuite struct {
 	testing.IsolationSuite
 	cloud cloud.Cloud
-	store *jujuclienttesting.MemStore
+	store *jujuclient.MemStore
 }
 
 var _ = gc.Suite(&credentialsSuite{})
@@ -91,7 +91,7 @@ func (s *credentialsSuite) SetUpTest(c *gc.C) {
 	err := ioutil.WriteFile(keyFile, []byte("value"), 0600)
 	c.Assert(err, jc.ErrorIsNil)
 
-	s.store = jujuclienttesting.NewMemStore()
+	s.store = jujuclient.NewMemStore()
 	s.store.Credentials["cloud"] = cloud.CloudCredential{
 		DefaultRegion: "second-region",
 		AuthCredentials: map[string]cloud.Credential{

--- a/cmd/modelcmd/modelcommand_test.go
+++ b/cmd/modelcmd/modelcommand_test.go
@@ -18,20 +18,19 @@ import (
 	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/juju/osenv"
 	"github.com/juju/juju/jujuclient"
-	"github.com/juju/juju/jujuclient/jujuclienttesting"
 	"github.com/juju/juju/permission"
 )
 
 type ModelCommandSuite struct {
 	testing.IsolationSuite
-	store *jujuclienttesting.MemStore
+	store *jujuclient.MemStore
 }
 
 func (s *ModelCommandSuite) SetUpTest(c *gc.C) {
 	s.IsolationSuite.SetUpTest(c)
 	s.PatchEnvironment("JUJU_CLI_VERSION", "")
 
-	s.store = jujuclienttesting.NewMemStore()
+	s.store = jujuclient.NewMemStore()
 	s.store.CurrentControllerName = "foo"
 	s.store.Controllers["foo"] = jujuclient.ControllerDetails{}
 	s.store.Accounts["foo"] = jujuclient.AccountDetails{
@@ -180,7 +179,7 @@ var _ = gc.Suite(&macaroonLoginSuite{})
 
 type macaroonLoginSuite struct {
 	apitesting.MacaroonSuite
-	store          *jujuclienttesting.MemStore
+	store          *jujuclient.MemStore
 	controllerName string
 	modelName      string
 }
@@ -197,7 +196,7 @@ func (s *macaroonLoginSuite) SetUpTest(c *gc.C) {
 	modelTag := names.NewModelTag(s.State.ModelUUID())
 	apiInfo := s.APIInfo(c)
 
-	s.store = jujuclienttesting.NewMemStore()
+	s.store = jujuclient.NewMemStore()
 	s.store.Controllers[s.controllerName] = jujuclient.ControllerDetails{
 		APIEndpoints:   apiInfo.Addrs,
 		ControllerUUID: s.State.ControllerUUID(),

--- a/cmd/plugins/juju-metadata/imagemetadata_test.go
+++ b/cmd/plugins/juju-metadata/imagemetadata_test.go
@@ -19,7 +19,6 @@ import (
 	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/jujuclient"
-	"github.com/juju/juju/jujuclient/jujuclienttesting"
 	"github.com/juju/juju/provider/dummy"
 	"github.com/juju/juju/testing"
 )
@@ -28,7 +27,7 @@ type ImageMetadataSuite struct {
 	testing.FakeJujuXDGDataHomeSuite
 	environ []string
 	dir     string
-	store   *jujuclienttesting.MemStore
+	store   *jujuclient.MemStore
 }
 
 var _ = gc.Suite(&ImageMetadataSuite{})
@@ -42,7 +41,7 @@ func (s *ImageMetadataSuite) SetUpTest(c *gc.C) {
 	s.FakeJujuXDGDataHomeSuite.SetUpTest(c)
 	s.dir = c.MkDir()
 
-	s.store = jujuclienttesting.NewMemStore()
+	s.store = jujuclient.NewMemStore()
 	cacheTestEnvConfig(c, s.store)
 
 	s.PatchEnvironment("AWS_ACCESS_KEY_ID", "access")

--- a/cmd/plugins/juju-metadata/listimages_test.go
+++ b/cmd/plugins/juju-metadata/listimages_test.go
@@ -14,13 +14,12 @@ import (
 
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/jujuclient"
-	"github.com/juju/juju/jujuclient/jujuclienttesting"
 	"github.com/juju/juju/testing"
 )
 
 type BaseCloudImageMetadataSuite struct {
 	testing.FakeJujuXDGDataHomeSuite
-	store *jujuclienttesting.MemStore
+	store *jujuclient.MemStore
 }
 
 func (s *BaseCloudImageMetadataSuite) SetUpTest(c *gc.C) {
@@ -30,7 +29,7 @@ func (s *BaseCloudImageMetadataSuite) SetUpTest(c *gc.C) {
 func (s *BaseCloudImageMetadataSuite) setupBaseSuite(c *gc.C) {
 	s.FakeJujuXDGDataHomeSuite.SetUpTest(c)
 
-	s.store = jujuclienttesting.NewMemStore()
+	s.store = jujuclient.NewMemStore()
 	s.store.CurrentControllerName = "testing"
 	s.store.Controllers["testing"] = jujuclient.ControllerDetails{}
 	s.store.Accounts["testing"] = jujuclient.AccountDetails{

--- a/cmd/plugins/juju-metadata/toolsmetadata_test.go
+++ b/cmd/plugins/juju-metadata/toolsmetadata_test.go
@@ -27,7 +27,7 @@ import (
 	toolstesting "github.com/juju/juju/environs/tools/testing"
 	"github.com/juju/juju/juju/keys"
 	"github.com/juju/juju/juju/osenv"
-	"github.com/juju/juju/jujuclient/jujuclienttesting"
+	"github.com/juju/juju/jujuclient"
 	"github.com/juju/juju/provider/dummy"
 	coretesting "github.com/juju/juju/testing"
 	jujuversion "github.com/juju/juju/version"
@@ -54,7 +54,7 @@ func (s *ToolsMetadataSuite) SetUpTest(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	env, err := bootstrap.Prepare(
 		modelcmd.BootstrapContextNoVerify(coretesting.Context(c)),
-		jujuclienttesting.NewMemStore(),
+		jujuclient.NewMemStore(),
 		bootstrap.PrepareParams{
 			ControllerConfig: coretesting.FakeControllerConfig(),
 			ControllerName:   cfg.Name(),

--- a/cmd/plugins/juju-metadata/validateimagemetadata_test.go
+++ b/cmd/plugins/juju-metadata/validateimagemetadata_test.go
@@ -19,14 +19,13 @@ import (
 	"github.com/juju/juju/environs/imagemetadata"
 	"github.com/juju/juju/environs/simplestreams"
 	"github.com/juju/juju/jujuclient"
-	"github.com/juju/juju/jujuclient/jujuclienttesting"
 	coretesting "github.com/juju/juju/testing"
 )
 
 type ValidateImageMetadataSuite struct {
 	coretesting.FakeJujuXDGDataHomeSuite
 	metadataDir string
-	store       *jujuclienttesting.MemStore
+	store       *jujuclient.MemStore
 }
 
 var _ = gc.Suite(&ValidateImageMetadataSuite{})
@@ -92,7 +91,7 @@ func (s *ValidateImageMetadataSuite) makeLocalMetadata(c *gc.C, id, region, seri
 	return nil
 }
 
-func cacheTestEnvConfig(c *gc.C, store *jujuclienttesting.MemStore) {
+func cacheTestEnvConfig(c *gc.C, store *jujuclient.MemStore) {
 	ec2UUID := utils.MustNewUUID().String()
 	ec2Config, err := config.New(config.UseDefaults, map[string]interface{}{
 		"name":            "ec2",
@@ -164,7 +163,7 @@ func (s *ValidateImageMetadataSuite) SetUpTest(c *gc.C) {
 	s.FakeJujuXDGDataHomeSuite.SetUpTest(c)
 	s.metadataDir = c.MkDir()
 
-	s.store = jujuclienttesting.NewMemStore()
+	s.store = jujuclient.NewMemStore()
 	cacheTestEnvConfig(c, s.store)
 
 	s.PatchEnvironment("AWS_ACCESS_KEY_ID", "access")

--- a/cmd/plugins/juju-metadata/validatetoolsmetadata_test.go
+++ b/cmd/plugins/juju-metadata/validatetoolsmetadata_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/juju/juju/environs/filestorage"
 	"github.com/juju/juju/environs/tools"
 	"github.com/juju/juju/jujuclient"
-	"github.com/juju/juju/jujuclient/jujuclienttesting"
 	coretesting "github.com/juju/juju/testing"
 	jujuversion "github.com/juju/juju/version"
 )
@@ -24,7 +23,7 @@ import (
 type ValidateToolsMetadataSuite struct {
 	coretesting.FakeJujuXDGDataHomeSuite
 	metadataDir string
-	store       *jujuclienttesting.MemStore
+	store       *jujuclient.MemStore
 }
 
 var _ = gc.Suite(&ValidateToolsMetadataSuite{})
@@ -99,7 +98,7 @@ func (s *ValidateToolsMetadataSuite) SetUpTest(c *gc.C) {
 	s.FakeJujuXDGDataHomeSuite.SetUpTest(c)
 	s.metadataDir = c.MkDir()
 
-	s.store = jujuclienttesting.NewMemStore()
+	s.store = jujuclient.NewMemStore()
 	cacheTestEnvConfig(c, s.store)
 
 	s.PatchEnvironment("AWS_ACCESS_KEY_ID", "access")

--- a/environs/bootstrap/prepare_test.go
+++ b/environs/bootstrap/prepare_test.go
@@ -15,7 +15,6 @@ import (
 	envtesting "github.com/juju/juju/environs/testing"
 	"github.com/juju/juju/juju/keys"
 	"github.com/juju/juju/jujuclient"
-	"github.com/juju/juju/jujuclient/jujuclienttesting"
 	"github.com/juju/juju/provider/dummy"
 	"github.com/juju/juju/testing"
 )
@@ -49,7 +48,7 @@ func (*PrepareSuite) TestPrepare(c *gc.C) {
 	)
 	cfg, err := config.New(config.NoDefaults, baselineAttrs)
 	c.Assert(err, jc.ErrorIsNil)
-	controllerStore := jujuclienttesting.NewMemStore()
+	controllerStore := jujuclient.NewMemStore()
 	ctx := envtesting.BootstrapContext(c)
 	controllerCfg := controller.Config{
 		controller.ControllerUUIDKey:       testing.ControllerTag.Id(),

--- a/environs/imagemetadata_test.go
+++ b/environs/imagemetadata_test.go
@@ -16,7 +16,7 @@ import (
 	sstesting "github.com/juju/juju/environs/simplestreams/testing"
 	envtesting "github.com/juju/juju/environs/testing"
 	"github.com/juju/juju/juju/keys"
-	"github.com/juju/juju/jujuclient/jujuclienttesting"
+	"github.com/juju/juju/jujuclient"
 	"github.com/juju/juju/provider/dummy"
 	"github.com/juju/juju/testing"
 	coretesting "github.com/juju/juju/testing"
@@ -47,7 +47,7 @@ func (s *ImageMetadataSuite) env(c *gc.C, imageMetadataURL, stream string) envir
 	}
 	env, err := bootstrap.Prepare(
 		envtesting.BootstrapContext(c),
-		jujuclienttesting.NewMemStore(),
+		jujuclient.NewMemStore(),
 		bootstrap.PrepareParams{
 			ControllerConfig: testing.FakeControllerConfig(),
 			ControllerName:   attrs["name"].(string),

--- a/environs/jujutest/livetests.go
+++ b/environs/jujutest/livetests.go
@@ -37,7 +37,6 @@ import (
 	"github.com/juju/juju/juju/keys"
 	jujutesting "github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/jujuclient"
-	"github.com/juju/juju/jujuclient/jujuclienttesting"
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/provider/dummy"
 	"github.com/juju/juju/state"
@@ -109,7 +108,7 @@ type LiveTests struct {
 func (t *LiveTests) SetUpSuite(c *gc.C) {
 	t.CleanupSuite.SetUpSuite(c)
 	t.TestDataSuite.SetUpSuite(c)
-	t.ControllerStore = jujuclienttesting.NewMemStore()
+	t.ControllerStore = jujuclient.NewMemStore()
 	t.PatchValue(&keys.JujuPublicKey, sstesting.SignedMetadataPublicKey)
 }
 
@@ -937,7 +936,7 @@ func (t *LiveTests) TestBootstrapWithDefaultSeries(c *gc.C) {
 	args := t.prepareForBootstrapParams(c)
 	args.ModelConfig = dummyCfg
 	dummyenv, err := bootstrap.Prepare(envtesting.BootstrapContext(c),
-		jujuclienttesting.NewMemStore(),
+		jujuclient.NewMemStore(),
 		args,
 	)
 	c.Assert(err, jc.ErrorIsNil)

--- a/environs/jujutest/tests.go
+++ b/environs/jujutest/tests.go
@@ -21,7 +21,6 @@ import (
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/jujuclient"
-	"github.com/juju/juju/jujuclient/jujuclienttesting"
 	coretesting "github.com/juju/juju/testing"
 	jujuversion "github.com/juju/juju/version"
 )
@@ -118,7 +117,7 @@ func (t *Tests) SetUpTest(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	t.UploadFakeTools(c, stor, "released", "released")
 	t.toolsStorage = stor
-	t.ControllerStore = jujuclienttesting.NewMemStore()
+	t.ControllerStore = jujuclient.NewMemStore()
 	t.ControllerUUID = coretesting.FakeControllerConfig().ControllerUUID()
 }
 

--- a/environs/open_test.go
+++ b/environs/open_test.go
@@ -19,7 +19,6 @@ import (
 	envtools "github.com/juju/juju/environs/tools"
 	"github.com/juju/juju/juju/keys"
 	"github.com/juju/juju/jujuclient"
-	"github.com/juju/juju/jujuclient/jujuclienttesting"
 	"github.com/juju/juju/provider/dummy"
 	"github.com/juju/juju/testing"
 	jujuversion "github.com/juju/juju/version"
@@ -50,7 +49,7 @@ func (s *OpenSuite) TestNewDummyEnviron(c *gc.C) {
 	cfg, err := config.New(config.NoDefaults, dummySampleConfig())
 	c.Assert(err, jc.ErrorIsNil)
 	ctx := envtesting.BootstrapContext(c)
-	cache := jujuclienttesting.NewMemStore()
+	cache := jujuclient.NewMemStore()
 	controllerCfg := testing.FakeControllerConfig()
 	env, err := bootstrap.Prepare(ctx, cache, bootstrap.PrepareParams{
 		ControllerConfig: controllerCfg,
@@ -80,7 +79,7 @@ func (s *OpenSuite) TestNewDummyEnviron(c *gc.C) {
 }
 
 func (s *OpenSuite) TestUpdateEnvInfo(c *gc.C) {
-	store := jujuclienttesting.NewMemStore()
+	store := jujuclient.NewMemStore()
 	ctx := envtesting.BootstrapContext(c)
 	uuid := utils.MustNewUUID().String()
 	cfg, err := config.New(config.UseDefaults, map[string]interface{}{
@@ -145,7 +144,7 @@ func (*OpenSuite) TestDestroy(c *gc.C) {
 	))
 	c.Assert(err, jc.ErrorIsNil)
 
-	store := jujuclienttesting.NewMemStore()
+	store := jujuclient.NewMemStore()
 	// Prepare the environment and sanity-check that
 	// the config storage info has been made.
 	controllerCfg := testing.FakeControllerConfig()
@@ -174,7 +173,7 @@ func (*OpenSuite) TestDestroy(c *gc.C) {
 
 func (*OpenSuite) TestDestroyNotFound(c *gc.C) {
 	var env destroyControllerEnv
-	store := jujuclienttesting.NewMemStore()
+	store := jujuclient.NewMemStore()
 	err := environs.Destroy("fnord", &env, store)
 	c.Assert(err, jc.ErrorIsNil)
 	env.CheckCallNames(c) // no controller details, no call

--- a/environs/tools/tools_test.go
+++ b/environs/tools/tools_test.go
@@ -22,7 +22,7 @@ import (
 	envtools "github.com/juju/juju/environs/tools"
 	toolstesting "github.com/juju/juju/environs/tools/testing"
 	"github.com/juju/juju/juju/keys"
-	"github.com/juju/juju/jujuclient/jujuclienttesting"
+	"github.com/juju/juju/jujuclient"
 	"github.com/juju/juju/provider/dummy"
 	coretesting "github.com/juju/juju/testing"
 	coretools "github.com/juju/juju/tools"
@@ -99,7 +99,7 @@ func (s *SimpleStreamsToolsSuite) resetEnv(c *gc.C, attrs map[string]interface{}
 	dummy.Reset(c)
 	attrs = dummy.SampleConfig().Merge(attrs)
 	env, err := bootstrap.Prepare(envtesting.BootstrapContext(c),
-		jujuclienttesting.NewMemStore(),
+		jujuclient.NewMemStore(),
 		bootstrap.PrepareParams{
 			ControllerConfig: coretesting.FakeControllerConfig(),
 			ControllerName:   attrs["name"].(string),

--- a/environs/tools/urls_test.go
+++ b/environs/tools/urls_test.go
@@ -19,7 +19,7 @@ import (
 	envtesting "github.com/juju/juju/environs/testing"
 	"github.com/juju/juju/environs/tools"
 	"github.com/juju/juju/juju/keys"
-	"github.com/juju/juju/jujuclient/jujuclienttesting"
+	"github.com/juju/juju/jujuclient"
 	"github.com/juju/juju/provider/dummy"
 	"github.com/juju/juju/testing"
 	coretesting "github.com/juju/juju/testing"
@@ -45,7 +45,7 @@ func (s *URLsSuite) env(c *gc.C, toolsMetadataURL string) environs.Environ {
 		})
 	}
 	env, err := bootstrap.Prepare(envtesting.BootstrapContext(c),
-		jujuclienttesting.NewMemStore(),
+		jujuclient.NewMemStore(),
 		bootstrap.PrepareParams{
 			ControllerConfig: coretesting.FakeControllerConfig(),
 			ControllerName:   attrs["name"].(string),

--- a/juju/api_test.go
+++ b/juju/api_test.go
@@ -83,7 +83,7 @@ func (cs *NewAPIClientSuite) TearDownTest(c *gc.C) {
 func (s *NewAPIClientSuite) bootstrapModel(c *gc.C) (environs.Environ, jujuclient.ClientStore) {
 	const controllerName = "my-controller"
 
-	store := jujuclienttesting.NewMemStore()
+	store := jujuclient.NewMemStore()
 
 	ctx := envtesting.BootstrapContext(c)
 
@@ -272,8 +272,8 @@ func (s *NewAPIClientSuite) TestWithInfoAPIOpenError(c *gc.C) {
 
 // newClientStore returns a client store that contains information
 // based on the given controller name and info.
-func newClientStore(c *gc.C, controllerName string) *jujuclienttesting.MemStore {
-	store := jujuclienttesting.NewMemStore()
+func newClientStore(c *gc.C, controllerName string) *jujuclient.MemStore {
+	store := jujuclient.NewMemStore()
 	err := store.AddController(controllerName, jujuclient.ControllerDetails{
 		ControllerUUID: fakeUUID,
 		CACert:         "certificate",

--- a/jujuclient/mem.go
+++ b/jujuclient/mem.go
@@ -1,40 +1,38 @@
 // Copyright 2016 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package jujuclienttesting
+package jujuclient
 
 import (
 	"github.com/juju/errors"
 	"github.com/juju/utils/set"
 
 	"github.com/juju/juju/cloud"
-	"github.com/juju/juju/jujuclient"
 )
 
-// MemStore is an in-memory implementation of jujuclient.ClientStore,
-// intended for testing.
+// MemStore is an in-memory implementation of ClientStore.
 type MemStore struct {
-	Controllers           map[string]jujuclient.ControllerDetails
+	Controllers           map[string]ControllerDetails
 	CurrentControllerName string
-	Models                map[string]*jujuclient.ControllerModels
-	Accounts              map[string]jujuclient.AccountDetails
+	Models                map[string]*ControllerModels
+	Accounts              map[string]AccountDetails
 	Credentials           map[string]cloud.CloudCredential
-	BootstrapConfig       map[string]jujuclient.BootstrapConfig
+	BootstrapConfig       map[string]BootstrapConfig
 }
 
 func NewMemStore() *MemStore {
 	return &MemStore{
-		Controllers:     make(map[string]jujuclient.ControllerDetails),
-		Models:          make(map[string]*jujuclient.ControllerModels),
-		Accounts:        make(map[string]jujuclient.AccountDetails),
+		Controllers:     make(map[string]ControllerDetails),
+		Models:          make(map[string]*ControllerModels),
+		Accounts:        make(map[string]AccountDetails),
 		Credentials:     make(map[string]cloud.CloudCredential),
-		BootstrapConfig: make(map[string]jujuclient.BootstrapConfig),
+		BootstrapConfig: make(map[string]BootstrapConfig),
 	}
 }
 
 // AllController implements ControllerGetter.AllController
-func (c *MemStore) AllControllers() (map[string]jujuclient.ControllerDetails, error) {
-	result := make(map[string]jujuclient.ControllerDetails)
+func (c *MemStore) AllControllers() (map[string]ControllerDetails, error) {
+	result := make(map[string]ControllerDetails)
 	for name, details := range c.Controllers {
 		result[name] = details
 	}
@@ -42,8 +40,8 @@ func (c *MemStore) AllControllers() (map[string]jujuclient.ControllerDetails, er
 }
 
 // ControllerByName implements ControllerGetter.ControllerByName
-func (c *MemStore) ControllerByName(name string) (*jujuclient.ControllerDetails, error) {
-	if err := jujuclient.ValidateControllerName(name); err != nil {
+func (c *MemStore) ControllerByName(name string) (*ControllerDetails, error) {
+	if err := ValidateControllerName(name); err != nil {
 		return nil, err
 	}
 	if result, ok := c.Controllers[name]; ok {
@@ -62,7 +60,7 @@ func (c *MemStore) CurrentController() (string, error) {
 
 // SetCurrentController implements ControllerUpdater.SetCurrentController
 func (c *MemStore) SetCurrentController(name string) error {
-	if err := jujuclient.ValidateControllerName(name); err != nil {
+	if err := ValidateControllerName(name); err != nil {
 		return err
 	}
 	if _, ok := c.Controllers[name]; !ok {
@@ -73,11 +71,11 @@ func (c *MemStore) SetCurrentController(name string) error {
 }
 
 // AddController implements ControllerUpdater.AddController
-func (c *MemStore) AddController(name string, one jujuclient.ControllerDetails) error {
-	if err := jujuclient.ValidateControllerName(name); err != nil {
+func (c *MemStore) AddController(name string, one ControllerDetails) error {
+	if err := ValidateControllerName(name); err != nil {
 		return err
 	}
-	if err := jujuclient.ValidateControllerDetails(one); err != nil {
+	if err := ValidateControllerDetails(one); err != nil {
 		return err
 	}
 
@@ -96,11 +94,11 @@ func (c *MemStore) AddController(name string, one jujuclient.ControllerDetails) 
 }
 
 // UpdateController implements ControllerUpdater.UpdateController
-func (c *MemStore) UpdateController(name string, one jujuclient.ControllerDetails) error {
-	if err := jujuclient.ValidateControllerName(name); err != nil {
+func (c *MemStore) UpdateController(name string, one ControllerDetails) error {
+	if err := ValidateControllerName(name); err != nil {
 		return err
 	}
-	if err := jujuclient.ValidateControllerDetails(one); err != nil {
+	if err := ValidateControllerDetails(one); err != nil {
 		return err
 	}
 
@@ -125,7 +123,7 @@ func (c *MemStore) UpdateController(name string, one jujuclient.ControllerDetail
 
 // RemoveController implements ControllerRemover.RemoveController
 func (c *MemStore) RemoveController(name string) error {
-	if err := jujuclient.ValidateControllerName(name); err != nil {
+	if err := ValidateControllerName(name); err != nil {
 		return err
 	}
 	names := set.NewStrings(name)
@@ -149,20 +147,20 @@ func (c *MemStore) RemoveController(name string) error {
 }
 
 // UpdateModel implements ModelUpdater.
-func (c *MemStore) UpdateModel(controller, model string, details jujuclient.ModelDetails) error {
-	if err := jujuclient.ValidateControllerName(controller); err != nil {
+func (c *MemStore) UpdateModel(controller, model string, details ModelDetails) error {
+	if err := ValidateControllerName(controller); err != nil {
 		return err
 	}
-	if err := jujuclient.ValidateModelName(model); err != nil {
+	if err := ValidateModelName(model); err != nil {
 		return err
 	}
-	if err := jujuclient.ValidateModelDetails(details); err != nil {
+	if err := ValidateModelDetails(details); err != nil {
 		return err
 	}
 	controllerModels, ok := c.Models[controller]
 	if !ok {
-		controllerModels = &jujuclient.ControllerModels{
-			Models: make(map[string]jujuclient.ModelDetails),
+		controllerModels = &ControllerModels{
+			Models: make(map[string]ModelDetails),
 		}
 		c.Models[controller] = controllerModels
 	}
@@ -172,10 +170,10 @@ func (c *MemStore) UpdateModel(controller, model string, details jujuclient.Mode
 
 // SetCurrentModel implements ModelUpdater.
 func (c *MemStore) SetCurrentModel(controllerName, modelName string) error {
-	if err := jujuclient.ValidateControllerName(controllerName); err != nil {
+	if err := ValidateControllerName(controllerName); err != nil {
 		return errors.Trace(err)
 	}
-	if err := jujuclient.ValidateModelName(modelName); err != nil {
+	if err := ValidateModelName(modelName); err != nil {
 		return errors.Trace(err)
 	}
 	controllerModels, ok := c.Models[controllerName]
@@ -191,10 +189,10 @@ func (c *MemStore) SetCurrentModel(controllerName, modelName string) error {
 
 // RemoveModel implements ModelRemover.
 func (c *MemStore) RemoveModel(controller, model string) error {
-	if err := jujuclient.ValidateControllerName(controller); err != nil {
+	if err := ValidateControllerName(controller); err != nil {
 		return err
 	}
-	if err := jujuclient.ValidateModelName(model); err != nil {
+	if err := ValidateModelName(model); err != nil {
 		return err
 	}
 	controllerModels, ok := c.Models[controller]
@@ -212,8 +210,8 @@ func (c *MemStore) RemoveModel(controller, model string) error {
 }
 
 // AllModels implements ModelGetter.
-func (c *MemStore) AllModels(controller string) (map[string]jujuclient.ModelDetails, error) {
-	if err := jujuclient.ValidateControllerName(controller); err != nil {
+func (c *MemStore) AllModels(controller string) (map[string]ModelDetails, error) {
+	if err := ValidateControllerName(controller); err != nil {
 		return nil, err
 	}
 	controllerModels, ok := c.Models[controller]
@@ -225,7 +223,7 @@ func (c *MemStore) AllModels(controller string) (map[string]jujuclient.ModelDeta
 
 // CurrentModel implements ModelGetter.
 func (c *MemStore) CurrentModel(controller string) (string, error) {
-	if err := jujuclient.ValidateControllerName(controller); err != nil {
+	if err := ValidateControllerName(controller); err != nil {
 		return "", err
 	}
 	controllerModels, ok := c.Models[controller]
@@ -239,11 +237,11 @@ func (c *MemStore) CurrentModel(controller string) (string, error) {
 }
 
 // ModelByName implements ModelGetter.
-func (c *MemStore) ModelByName(controller, model string) (*jujuclient.ModelDetails, error) {
-	if err := jujuclient.ValidateControllerName(controller); err != nil {
+func (c *MemStore) ModelByName(controller, model string) (*ModelDetails, error) {
+	if err := ValidateControllerName(controller); err != nil {
 		return nil, err
 	}
-	if err := jujuclient.ValidateModelName(model); err != nil {
+	if err := ValidateModelName(model); err != nil {
 		return nil, err
 	}
 	controllerModels, ok := c.Models[controller]
@@ -258,11 +256,11 @@ func (c *MemStore) ModelByName(controller, model string) (*jujuclient.ModelDetai
 }
 
 // UpdateAccount implements AccountUpdater.
-func (c *MemStore) UpdateAccount(controllerName string, details jujuclient.AccountDetails) error {
-	if err := jujuclient.ValidateControllerName(controllerName); err != nil {
+func (c *MemStore) UpdateAccount(controllerName string, details AccountDetails) error {
+	if err := ValidateControllerName(controllerName); err != nil {
 		return err
 	}
-	if err := jujuclient.ValidateAccountDetails(details); err != nil {
+	if err := ValidateAccountDetails(details); err != nil {
 		return err
 	}
 	oldDetails := c.Accounts[controllerName]
@@ -275,8 +273,8 @@ func (c *MemStore) UpdateAccount(controllerName string, details jujuclient.Accou
 }
 
 // AccountDetails implements AccountGetter.
-func (c *MemStore) AccountDetails(controllerName string) (*jujuclient.AccountDetails, error) {
-	if err := jujuclient.ValidateControllerName(controllerName); err != nil {
+func (c *MemStore) AccountDetails(controllerName string) (*AccountDetails, error) {
+	if err := ValidateControllerName(controllerName); err != nil {
 		return nil, err
 	}
 	details, ok := c.Accounts[controllerName]
@@ -288,7 +286,7 @@ func (c *MemStore) AccountDetails(controllerName string) (*jujuclient.AccountDet
 
 // RemoveAccount implements AccountRemover.
 func (c *MemStore) RemoveAccount(controllerName string) error {
-	if err := jujuclient.ValidateControllerName(controllerName); err != nil {
+	if err := ValidateControllerName(controllerName); err != nil {
 		return err
 	}
 	if _, ok := c.Accounts[controllerName]; !ok {
@@ -326,11 +324,11 @@ func (c *MemStore) AllCredentials() (map[string]cloud.CloudCredential, error) {
 }
 
 // UpdateBootstrapConfig implements BootstrapConfigUpdater.
-func (c *MemStore) UpdateBootstrapConfig(controllerName string, cfg jujuclient.BootstrapConfig) error {
-	if err := jujuclient.ValidateControllerName(controllerName); err != nil {
+func (c *MemStore) UpdateBootstrapConfig(controllerName string, cfg BootstrapConfig) error {
+	if err := ValidateControllerName(controllerName); err != nil {
 		return err
 	}
-	if err := jujuclient.ValidateBootstrapConfig(cfg); err != nil {
+	if err := ValidateBootstrapConfig(cfg); err != nil {
 		return err
 	}
 	c.BootstrapConfig[controllerName] = cfg
@@ -339,7 +337,7 @@ func (c *MemStore) UpdateBootstrapConfig(controllerName string, cfg jujuclient.B
 }
 
 // BootstrapConfigForController implements BootstrapConfigGetter.
-func (c *MemStore) BootstrapConfigForController(controllerName string) (*jujuclient.BootstrapConfig, error) {
+func (c *MemStore) BootstrapConfigForController(controllerName string) (*BootstrapConfig, error) {
 	if cfg, ok := c.BootstrapConfig[controllerName]; ok {
 		return &cfg, nil
 	}

--- a/provider/dummy/config_test.go
+++ b/provider/dummy/config_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/juju/juju/environs/bootstrap"
 	"github.com/juju/juju/environs/config"
 	envtesting "github.com/juju/juju/environs/testing"
-	"github.com/juju/juju/jujuclient/jujuclienttesting"
+	"github.com/juju/juju/jujuclient"
 	"github.com/juju/juju/provider/dummy"
 	"github.com/juju/juju/testing"
 )
@@ -69,7 +69,7 @@ func (s *ConfigSuite) TestFirewallMode(c *gc.C) {
 		}
 		ctx := envtesting.BootstrapContext(c)
 		env, err := bootstrap.Prepare(
-			ctx, jujuclienttesting.NewMemStore(),
+			ctx, jujuclient.NewMemStore(),
 			bootstrap.PrepareParams{
 				ControllerConfig: testing.FakeControllerConfig(),
 				ControllerName:   cfg.Name(),

--- a/provider/ec2/local_test.go
+++ b/provider/ec2/local_test.go
@@ -41,7 +41,7 @@ import (
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/juju/keys"
 	"github.com/juju/juju/juju/testing"
-	"github.com/juju/juju/jujuclient/jujuclienttesting"
+	"github.com/juju/juju/jujuclient"
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/provider/common"
 	"github.com/juju/juju/provider/ec2"
@@ -1726,7 +1726,7 @@ func (t *localNonUSEastSuite) SetUpTest(c *gc.C) {
 
 	env, err := bootstrap.Prepare(
 		envtesting.BootstrapContext(c),
-		jujuclienttesting.NewMemStore(),
+		jujuclient.NewMemStore(),
 		bootstrap.PrepareParams{
 			ControllerConfig: coretesting.FakeControllerConfig(),
 			ModelConfig:      localConfigAttrs,

--- a/provider/openstack/local_test.go
+++ b/provider/openstack/local_test.go
@@ -54,7 +54,7 @@ import (
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/juju/keys"
 	"github.com/juju/juju/juju/testing"
-	"github.com/juju/juju/jujuclient/jujuclienttesting"
+	"github.com/juju/juju/jujuclient"
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/provider/common"
 	"github.com/juju/juju/provider/openstack"
@@ -1468,7 +1468,7 @@ func (s *localHTTPSServerSuite) SetUpTest(c *gc.C) {
 	var err error
 	s.env, err = bootstrap.Prepare(
 		envtesting.BootstrapContext(c),
-		jujuclienttesting.NewMemStore(),
+		jujuclient.NewMemStore(),
 		prepareParams(attrs, s.cred),
 	)
 	c.Assert(err, jc.ErrorIsNil)
@@ -2269,7 +2269,7 @@ func (s *noSwiftSuite) SetUpTest(c *gc.C) {
 
 	env, err := bootstrap.Prepare(
 		envtesting.BootstrapContext(c),
-		jujuclienttesting.NewMemStore(),
+		jujuclient.NewMemStore(),
 		prepareParams(attrs, s.cred),
 	)
 	c.Assert(err, jc.ErrorIsNil)

--- a/state/assign_test.go
+++ b/state/assign_test.go
@@ -8,7 +8,7 @@ import (
 	"runtime"
 	"sort"
 	"strconv"
-	"time" // Only used to Sleep().
+	"time"
 
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/txn"

--- a/state/cleanup.go
+++ b/state/cleanup.go
@@ -6,15 +6,15 @@ package state
 import (
 	"fmt"
 
-	"github.com/juju/utils/featureflag"
-
 	"github.com/juju/errors"
-	"github.com/juju/juju/feature"
+	"github.com/juju/utils/featureflag"
 	"gopkg.in/juju/charm.v6-unstable"
 	"gopkg.in/juju/names.v2"
 	"gopkg.in/mgo.v2"
 	"gopkg.in/mgo.v2/bson"
 	"gopkg.in/mgo.v2/txn"
+
+	"github.com/juju/juju/feature"
 )
 
 type cleanupKind string

--- a/state/lease/fixture_test.go
+++ b/state/lease/fixture_test.go
@@ -5,7 +5,7 @@ package lease_test
 
 import (
 	"fmt"
-	"time" // Only used for time types and Parse().
+	"time"
 
 	jujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"

--- a/state/upgrade.go
+++ b/state/upgrade.go
@@ -40,13 +40,14 @@ import (
 	"time"
 
 	"github.com/juju/errors"
-	"github.com/juju/juju/status"
 	jujutxn "github.com/juju/txn"
 	"github.com/juju/utils/set"
 	"github.com/juju/version"
 	"gopkg.in/mgo.v2"
 	"gopkg.in/mgo.v2/bson"
 	"gopkg.in/mgo.v2/txn"
+
+	"github.com/juju/juju/status"
 )
 
 // UpgradeStatus describes the states an upgrade operation may be in.


### PR DESCRIPTION
The MemStore is useful for external programs that don't
want to use the disk-based store, and isn't directly
concerned with testing, so move it into the
jujuclient package.

This also means that test packages that want to use
MemStore don't need to depend on jujuclienttesting.

Also sort import statements canonically where they're
not.

This change is purely mechanical - no externally visible changes.