### PR TITLE
Fix multi-series local charm upgrade

### DIFF
--- a/cmd/juju/application/upgradecharm_test.go
+++ b/cmd/juju/application/upgradecharm_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/juju/juju/api/application"
 	"github.com/juju/juju/api/base"
 	"github.com/juju/juju/api/charms"
+	"github.com/juju/juju/apiserver/params"
 	jujucharmstore "github.com/juju/juju/charmstore"
 	"github.com/juju/juju/cmd/cmdtesting"
 	"github.com/juju/juju/cmd/modelcmd"
@@ -167,8 +168,8 @@ func (s *UpgradeCharmSuite) runUpgradeCharm(c *gc.C, args ...string) (*cmd.Conte
 func (s *UpgradeCharmSuite) TestStorageConstraints(c *gc.C) {
 	_, err := s.runUpgradeCharm(c, "foo", "--storage", "bar=baz")
 	c.Assert(err, jc.ErrorIsNil)
-	s.charmUpgradeClient.CheckCallNames(c, "GetCharmURL", "SetCharm")
-	s.charmUpgradeClient.CheckCall(c, 1, "SetCharm", application.SetCharmConfig{
+	s.charmUpgradeClient.CheckCallNames(c, "GetCharmURL", "Get", "SetCharm")
+	s.charmUpgradeClient.CheckCall(c, 2, "SetCharm", application.SetCharmConfig{
 		ApplicationName: "foo",
 		CharmID: jujucharmstore.CharmID{
 			URL:     s.resolvedCharmURL,
@@ -203,8 +204,8 @@ func (s *UpgradeCharmSuite) TestConfigSettings(c *gc.C) {
 
 	_, err = s.runUpgradeCharm(c, "foo", "--config", configFile)
 	c.Assert(err, jc.ErrorIsNil)
-	s.charmUpgradeClient.CheckCallNames(c, "GetCharmURL", "SetCharm")
-	s.charmUpgradeClient.CheckCall(c, 1, "SetCharm", application.SetCharmConfig{
+	s.charmUpgradeClient.CheckCallNames(c, "GetCharmURL", "Get", "SetCharm")
+	s.charmUpgradeClient.CheckCall(c, 2, "SetCharm", application.SetCharmConfig{
 		ApplicationName: "foo",
 		CharmID: jujucharmstore.CharmID{
 			URL:     s.resolvedCharmURL,
@@ -728,6 +729,11 @@ func (m *mockCharmUpgradeClient) GetCharmURL(applicationName string) (*charm.URL
 func (m *mockCharmUpgradeClient) SetCharm(cfg application.SetCharmConfig) error {
 	m.MethodCall(m, "SetCharm", cfg)
 	return m.NextErr()
+}
+
+func (m *mockCharmUpgradeClient) Get(applicationName string) (*params.ApplicationGetResults, error) {
+	m.MethodCall(m, "Get", applicationName)
+	return &params.ApplicationGetResults{}, m.NextErr()
 }
 
 type mockModelConfigGetter struct {


### PR DESCRIPTION
## Description of change

With a deployed mutli-series charm from the charm store, attempts to upgrade that charm's application from a local repository fail with the following error:

```bash
ERROR cannot upgrade application <application name> to charm <local charm url>: cannot change an application's series
```

This happens since the upgrading from a multi-series charm (having no series in its URL) is dependent on the order of series found in the local charm's `metadata.yml` file. The upgrade command attempts to upgrade to the first series found in the file.  

## QA steps

Deploy the ubuntu charm from the charm store (the ubuntu charm is a multi-series charm having no series specified in its URL) with the series `trusty` defined at the command line.

```bash
juju deploy ubuntu --series trusty
``` 

Download the ubuntu charm form the charm store

```bash
wget https://api.jujucharms.com/charmstore/v5/ubuntu-10/archive
```

Unzip the archive into a folder named ubuntu (this is your local charm from which to upgrade)

```bash
unzip archive -d ubuntu
```

Upgrade the deployed ubuntu application
```
juju upgrade-charm ubuntu --path ./ubuntu
```

You will either see the error specified above or you have applied the fix in this PR and should see the command select the appropriate series and complete the upgrade successfully.

## Documentation changes

N/A

## Bug reference

[lp#1673122](https://bugs.launchpad.net/juju/+bug/1673122)
