### PR TITLE
state: call db().GetCollection{,For} instead of getCollection{,For}

### DIFF
--- a/state/action.go
+++ b/state/action.go
@@ -276,7 +276,7 @@ var ensureActionMarker = ensureSuffixFn(actionMarker)
 // Action returns an Action by Id, which is a UUID.
 func (st *State) Action(id string) (Action, error) {
 	actionLogger.Tracef("Action() %q", id)
-	actions, closer := st.getCollection(actionsC)
+	actions, closer := st.db().GetCollection(actionsC)
 	defer closer()
 
 	doc := actionDoc{}
@@ -294,7 +294,7 @@ func (st *State) Action(id string) (Action, error) {
 // AllActions returns all Actions.
 func (st *State) AllActions() ([]Action, error) {
 	actionLogger.Tracef("AllActions()")
-	actions, closer := st.getCollection(actionsC)
+	actions, closer := st.db().GetCollection(actionsC)
 	defer closer()
 
 	results := []Action{}
@@ -323,7 +323,7 @@ func (st *State) FindActionTagsByPrefix(prefix string) []names.ActionTag {
 		Id string `bson:"_id"`
 	}
 
-	actions, closer := st.getCollection(actionsC)
+	actions, closer := st.db().GetCollection(actionsC)
 	defer closer()
 
 	iter := actions.Find(bson.D{{"_id", bson.D{{"$regex", "^" + st.docID(prefix)}}}}).Iter()
@@ -344,7 +344,7 @@ func (st *State) FindActionsByName(name string) ([]Action, error) {
 	var results []Action
 	var doc actionDoc
 
-	actions, closer := st.getCollection(actionsC)
+	actions, closer := st.db().GetCollection(actionsC)
 	defer closer()
 
 	iter := actions.Find(bson.D{{"name", name}}).Iter()
@@ -412,7 +412,7 @@ func (st *State) matchingActionsByReceiverId(id string) ([]Action, error) {
 	var doc actionDoc
 	var actions []Action
 
-	actionsCollection, closer := st.getCollection(actionsC)
+	actionsCollection, closer := st.db().GetCollection(actionsC)
 	defer closer()
 
 	iter := actionsCollection.Find(bson.D{{"receiver", id}}).Iter()
@@ -453,7 +453,7 @@ func (st *State) matchingActionsByReceiverAndStatus(tag names.Tag, statusConditi
 	var doc actionDoc
 	var actions []Action
 
-	actionsCollection, closer := st.getCollection(actionsC)
+	actionsCollection, closer := st.db().GetCollection(actionsC)
 	defer closer()
 
 	sel := append(bson.D{{"receiver", tag.Id()}}, statusCondition...)

--- a/state/address.go
+++ b/state/address.go
@@ -40,7 +40,7 @@ func (st *State) controllerAddresses() ([]string, error) {
 	}
 	var allAddresses []addressMachine
 	// TODO(rog) 2013/10/14 index machines on jobs.
-	machines, closer := ssState.getCollection(machinesC)
+	machines, closer := ssState.db().GetCollection(machinesC)
 	defer closer()
 	err = machines.Find(bson.D{{"jobs", JobManageModel}}).All(&allAddresses)
 	if err != nil {
@@ -111,7 +111,7 @@ type apiHostPortsDoc struct {
 // SetAPIHostPorts sets the addresses of the API server instances.
 // Each server is represented by one element in the top level slice.
 func (st *State) SetAPIHostPorts(netHostsPorts [][]network.HostPort) error {
-	controllers, closer := st.getCollection(controllersC)
+	controllers, closer := st.db().GetCollection(controllersC)
 	defer closer()
 	doc := apiHostPortsDoc{
 		APIHostPorts: fromNetworkHostsPorts(netHostsPorts),
@@ -149,7 +149,7 @@ func (st *State) SetAPIHostPorts(netHostsPorts [][]network.HostPort) error {
 // APIHostPorts returns the API addresses as set by SetAPIHostPorts.
 func (st *State) APIHostPorts() ([][]network.HostPort, error) {
 	var doc apiHostPortsDoc
-	controllers, closer := st.getCollection(controllersC)
+	controllers, closer := st.db().GetCollection(controllersC)
 	defer closer()
 	err := controllers.Find(bson.D{{"_id", apiHostPortsKey}}).One(&doc)
 	if err != nil {

--- a/state/allwatcher.go
+++ b/state/allwatcher.go
@@ -1140,7 +1140,7 @@ func (b *allWatcherStateBacking) Changed(all *multiwatcherStore, change watcher.
 	if !ok {
 		return errors.Errorf("unknown collection %q in fetch request", change.C)
 	}
-	col, closer := b.st.getCollection(c.name)
+	col, closer := b.st.db().GetCollection(c.name)
 	defer closer()
 	doc := reflect.New(c.docType).Interface().(backingEntityDoc)
 
@@ -1264,7 +1264,7 @@ func (b *allModelWatcherStateBacking) Changed(all *multiwatcherStore, change wat
 	}
 	defer releaser()
 
-	col, closer := st.getCollection(c.name)
+	col, closer := st.db().GetCollection(c.name)
 	defer closer()
 
 	// TODO - see TODOs in allWatcherStateBacking.Changed()

--- a/state/annotations.go
+++ b/state/annotations.go
@@ -54,7 +54,7 @@ func (st *State) SetAnnotations(entity GlobalEntity, annotations map[string]stri
 	// annotations in the meantime, we consider that worthy of an error
 	// (will be fixed when new entities can never share names with old ones).
 	buildTxn := func(attempt int) ([]txn.Op, error) {
-		annotations, closer := st.getCollection(annotationsC)
+		annotations, closer := st.db().GetCollection(annotationsC)
 		defer closer()
 		if count, err := annotations.FindId(entity.globalKey()).Count(); err != nil {
 			return nil, err
@@ -73,7 +73,7 @@ func (st *State) SetAnnotations(entity GlobalEntity, annotations map[string]stri
 // Annotations returns all the annotations corresponding to an entity.
 func (st *State) Annotations(entity GlobalEntity) (map[string]string, error) {
 	doc := new(annotatorDoc)
-	annotations, closer := st.getCollection(annotationsC)
+	annotations, closer := st.db().GetCollection(annotationsC)
 	defer closer()
 	err := annotations.FindId(entity.globalKey()).One(doc)
 	if err == mgo.ErrNotFound {

--- a/state/application.go
+++ b/state/application.go
@@ -1000,7 +1000,7 @@ func (a *Application) String() string {
 // state. It returns an error that satisfies errors.IsNotFound if the
 // application has been removed.
 func (a *Application) Refresh() error {
-	applications, closer := a.st.getCollection(applicationsC)
+	applications, closer := a.st.db().GetCollection(applicationsC)
 	defer closer()
 
 	err := applications.FindId(a.doc.DocID).One(&a.doc)
@@ -1320,7 +1320,7 @@ func (a *Application) AllUnits() (units []*Unit, err error) {
 }
 
 func allUnits(st *State, application string) (units []*Unit, err error) {
-	unitsCollection, closer := st.getCollection(unitsC)
+	unitsCollection, closer := st.db().GetCollection(unitsC)
 	defer closer()
 
 	docs := []unitDoc{}
@@ -1341,7 +1341,7 @@ func (a *Application) Relations() (relations []*Relation, err error) {
 
 func applicationRelations(st *State, name string) (relations []*Relation, err error) {
 	defer errors.DeferredAnnotatef(&err, "can't get relations for application %q", name)
-	relationsCollection, closer := st.getCollection(relationsC)
+	relationsCollection, closer := st.db().GetCollection(relationsC)
 	defer closer()
 
 	docs := []relationDoc{}
@@ -1604,7 +1604,7 @@ func (a *Application) StorageConstraints() (map[string]StorageConstraints, error
 // If no status is recorded, then there are no unit leaders and the
 // status is derived from the unit status values.
 func (a *Application) Status() (status.StatusInfo, error) {
-	statuses, closer := a.st.getCollection(statusesC)
+	statuses, closer := a.st.db().GetCollection(statusesC)
 	defer closer()
 	query := statuses.Find(bson.D{{"_id", a.globalKey()}, {"neverset", true}})
 	if count, err := query.Count(); err != nil {

--- a/state/applicationoffers.go
+++ b/state/applicationoffers.go
@@ -87,7 +87,7 @@ func applicationOfferUUID(st *State, offerName string) (string, error) {
 }
 
 func (s *applicationOffers) offerForName(offerName string) (*applicationOfferDoc, error) {
-	applicationOffersCollection, closer := s.st.getCollection(applicationOffersC)
+	applicationOffersCollection, closer := s.st.db().GetCollection(applicationOffersC)
 	defer closer()
 
 	var doc applicationOfferDoc
@@ -308,7 +308,7 @@ func (s *applicationOffers) makeFilterTerm(filterTerm crossmodel.ApplicationOffe
 
 // ListOffers returns the application offers matching any one of the filter terms.
 func (s *applicationOffers) ListOffers(filter ...crossmodel.ApplicationOfferFilter) ([]crossmodel.ApplicationOffer, error) {
-	applicationOffersCollection, closer := s.st.getCollection(applicationOffersC)
+	applicationOffersCollection, closer := s.st.db().GetCollection(applicationOffersC)
 	defer closer()
 
 	// TODO(wallyworld) - add support for filtering on endpoints

--- a/state/autocertcache.go
+++ b/state/autocertcache.go
@@ -68,6 +68,6 @@ func (cache autocertCache) Delete(ctx context.Context, name string) error {
 }
 
 func (cache autocertCache) coll() (mongo.WriteCollection, func()) {
-	coll, closer := cache.st.getCollection(autocertCacheC)
+	coll, closer := cache.st.db().GetCollection(autocertCacheC)
 	return coll.Writeable(), closer
 }

--- a/state/bakerystorage.go
+++ b/state/bakerystorage.go
@@ -15,7 +15,7 @@ import (
 func (st *State) NewBakeryStorage() (bakerystorage.ExpirableStorage, error) {
 	return bakerystorage.New(bakerystorage.Config{
 		GetCollection: func() (mongo.Collection, func()) {
-			return st.getCollection(bakeryStorageItemsC)
+			return st.db().GetCollection(bakeryStorageItemsC)
 		},
 	})
 }

--- a/state/block.go
+++ b/state/block.go
@@ -175,7 +175,7 @@ func (st *State) SwitchBlockOff(t BlockType) error {
 //     found -> block, true, nil
 //     error -> nil, false, err
 func (st *State) GetBlockForType(t BlockType) (Block, bool, error) {
-	all, closer := st.getCollection(blocksC)
+	all, closer := st.db().GetCollection(blocksC)
 	defer closer()
 
 	doc := blockDoc{}
@@ -193,7 +193,7 @@ func (st *State) GetBlockForType(t BlockType) (Block, bool, error) {
 
 // AllBlocks returns all blocks in the model.
 func (st *State) AllBlocks() ([]Block, error) {
-	blocksCollection, closer := st.getCollection(blocksC)
+	blocksCollection, closer := st.db().GetCollection(blocksC)
 	defer closer()
 
 	var bdocs []blockDoc

--- a/state/charm.go
+++ b/state/charm.go
@@ -195,7 +195,7 @@ func updateCharmOps(
 	st *State, info CharmInfo, assert bson.D,
 ) ([]txn.Op, error) {
 
-	charms, closer := st.getCollection(charmsC)
+	charms, closer := st.db().GetCollection(charmsC)
 	defer closer()
 
 	charmKey := info.ID.String()
@@ -269,7 +269,7 @@ func deleteOldPlaceholderCharmsOps(st *State, charms mongo.Collection, curl *cha
 		return nil, errors.Trace(err)
 	}
 
-	refcounts, closer := st.getCollection(refcountsC)
+	refcounts, closer := st.db().GetCollection(refcountsC)
 	defer closer()
 
 	var ops []txn.Op
@@ -516,7 +516,7 @@ func (c *Charm) UpdateMacaroon(m macaroon.Slice) error {
 // AddCharm adds the ch charm with curl to the state.
 // On success the newly added charm state is returned.
 func (st *State) AddCharm(info CharmInfo) (stch *Charm, err error) {
-	charms, closer := st.getCollection(charmsC)
+	charms, closer := st.db().GetCollection(charmsC)
 	defer closer()
 
 	if err := validateCharmVersion(info.Charm); err != nil {
@@ -570,7 +570,7 @@ func validateCharmVersion(ch hasMeta) error {
 
 // AllCharms returns all charms in state.
 func (st *State) AllCharms() ([]*Charm, error) {
-	charmsCollection, closer := st.getCollection(charmsC)
+	charmsCollection, closer := st.db().GetCollection(charmsC)
 	defer closer()
 	var cdoc charmDoc
 	var charms []*Charm
@@ -585,7 +585,7 @@ func (st *State) AllCharms() ([]*Charm, error) {
 // Charm returns the charm with the given URL. Charms pending upload
 // to storage and placeholders are never returned.
 func (st *State) Charm(curl *charm.URL) (*Charm, error) {
-	charms, closer := st.getCollection(charmsC)
+	charms, closer := st.db().GetCollection(charmsC)
 	defer closer()
 
 	cdoc := &charmDoc{}
@@ -611,7 +611,7 @@ func (st *State) Charm(curl *charm.URL) (*Charm, error) {
 // LatestPlaceholderCharm returns the latest charm described by the
 // given URL but which is not yet deployed.
 func (st *State) LatestPlaceholderCharm(curl *charm.URL) (*Charm, error) {
-	charms, closer := st.getCollection(charmsC)
+	charms, closer := st.db().GetCollection(charmsC)
 	defer closer()
 
 	noRevURL := curl.WithRevision(-1)
@@ -695,7 +695,7 @@ func (st *State) PrepareStoreCharmUpload(curl *charm.URL) (*Charm, error) {
 		return nil, errors.Errorf("expected charm URL with revision, got %q", curl)
 	}
 
-	charms, closer := st.getCollection(charmsC)
+	charms, closer := st.db().GetCollection(charmsC)
 	defer closer()
 
 	var (
@@ -749,7 +749,7 @@ func (st *State) AddStoreCharmPlaceholder(curl *charm.URL) (err error) {
 	if curl.Revision < 0 {
 		return errors.Errorf("expected charm URL with revision, got %q", curl)
 	}
-	charms, closer := st.getCollection(charmsC)
+	charms, closer := st.db().GetCollection(charmsC)
 	defer closer()
 
 	buildTxn := func(attempt int) ([]txn.Op, error) {
@@ -781,7 +781,7 @@ func (st *State) AddStoreCharmPlaceholder(curl *charm.URL) (err error) {
 // UpdateUploadedCharm marks the given charm URL as uploaded and
 // updates the rest of its data, returning it as *state.Charm.
 func (st *State) UpdateUploadedCharm(info CharmInfo) (*Charm, error) {
-	charms, closer := st.getCollection(charmsC)
+	charms, closer := st.db().GetCollection(charmsC)
 	defer closer()
 
 	doc := &charmDoc{}

--- a/state/cleanup.go
+++ b/state/cleanup.go
@@ -64,7 +64,7 @@ func newCleanupOp(kind cleanupKind, prefix string) txn.Op {
 
 // NeedsCleanup returns true if documents previously marked for removal exist.
 func (st *State) NeedsCleanup() (bool, error) {
-	cleanups, closer := st.getCollection(cleanupsC)
+	cleanups, closer := st.db().GetCollection(cleanupsC)
 	defer closer()
 	count, err := cleanups.Count()
 	if err != nil {
@@ -78,7 +78,7 @@ func (st *State) NeedsCleanup() (bool, error) {
 // of the system.
 func (st *State) Cleanup() (err error) {
 	var doc cleanupDoc
-	cleanups, closer := st.getCollection(cleanupsC)
+	cleanups, closer := st.db().GetCollection(cleanupsC)
 	defer closer()
 	iter := cleanups.Find(nil).Iter()
 	defer closeIter(iter, &err, "reading cleanup document")
@@ -278,7 +278,7 @@ func (st *State) removeApplicationsForDyingModel() (err error) {
 	// applications added to it. But we do have to remove the applications
 	// themselves via individual transactions, because they could be in any
 	// state at all.
-	applications, closer := st.getCollection(applicationsC)
+	applications, closer := st.db().GetCollection(applicationsC)
 	defer closer()
 	application := Application{st: st}
 	sel := bson.D{{"life", Alive}}
@@ -296,7 +296,7 @@ func (st *State) removeRemoteApplicationsForDyingModel() (err error) {
 	// This won't miss remote applications, because a Dying model cannot have
 	// applications added to it. But we do have to remove the applications themselves
 	// via individual transactions, because they could be in any state at all.
-	remoteApps, closer := st.getCollection(remoteApplicationsC)
+	remoteApps, closer := st.db().GetCollection(remoteApplicationsC)
 	defer closer()
 	remoteApp := RemoteApplication{st: st}
 	sel := bson.D{{"life", Alive}}
@@ -317,7 +317,7 @@ func (st *State) cleanupUnitsForDyingApplication(applicationname string) (err er
 	// This won't miss units, because a Dying application cannot have units
 	// added to it. But we do have to remove the units themselves via
 	// individual transactions, because they could be in any state at all.
-	units, closer := st.getCollection(unitsC)
+	units, closer := st.db().GetCollection(unitsC)
 	defer closer()
 
 	unit := Unit{st: st}
@@ -633,7 +633,7 @@ func (st *State) cleanupAttachmentsForDyingStorage(storageId string) (err error)
 	// have attachments added to it. But we do have to remove the attachments
 	// themselves via individual transactions, because they could be in
 	// any state at all.
-	coll, closer := st.getCollection(storageAttachmentsC)
+	coll, closer := st.db().GetCollection(storageAttachmentsC)
 	defer closer()
 
 	var doc storageAttachmentDoc
@@ -659,7 +659,7 @@ func (st *State) cleanupAttachmentsForDyingVolume(volumeId string) (err error) {
 	// attachments added to it. But we do have to remove the attachments
 	// themselves via individual transactions, because they could be in
 	// any state at all.
-	coll, closer := st.getCollection(volumeAttachmentsC)
+	coll, closer := st.db().GetCollection(volumeAttachmentsC)
 	defer closer()
 
 	var doc volumeAttachmentDoc
@@ -685,7 +685,7 @@ func (st *State) cleanupAttachmentsForDyingFilesystem(filesystemId string) (err 
 	// attachments added to it. But we do have to remove the attachments
 	// themselves via individual transactions, because they could be in
 	// any state at all.
-	coll, closer := st.getCollection(filesystemAttachmentsC)
+	coll, closer := st.db().GetCollection(filesystemAttachmentsC)
 	defer closer()
 
 	var doc filesystemAttachmentDoc

--- a/state/cloud.go
+++ b/state/cloud.go
@@ -100,7 +100,7 @@ func (d cloudDoc) toCloud() cloud.Cloud {
 
 // Clouds returns the definitions for all clouds in the controller.
 func (st *State) Clouds() (map[names.CloudTag]cloud.Cloud, error) {
-	coll, cleanup := st.getCollection(cloudsC)
+	coll, cleanup := st.db().GetCollection(cloudsC)
 	defer cleanup()
 
 	var doc cloudDoc
@@ -117,7 +117,7 @@ func (st *State) Clouds() (map[names.CloudTag]cloud.Cloud, error) {
 
 // Cloud returns the controller's cloud definition.
 func (st *State) Cloud(name string) (cloud.Cloud, error) {
-	coll, cleanup := st.getCollection(cloudsC)
+	coll, cleanup := st.db().GetCollection(cloudsC)
 	defer cleanup()
 
 	var doc cloudDoc

--- a/state/cloudcredentials.go
+++ b/state/cloudcredentials.go
@@ -30,7 +30,7 @@ type cloudCredentialDoc struct {
 
 // CloudCredential returns the cloud credential for the given tag.
 func (st *State) CloudCredential(tag names.CloudCredentialTag) (cloud.Credential, error) {
-	coll, cleanup := st.getCollection(cloudCredentialsC)
+	coll, cleanup := st.db().GetCollection(cloudCredentialsC)
 	defer cleanup()
 
 	var doc cloudCredentialDoc
@@ -50,7 +50,7 @@ func (st *State) CloudCredential(tag names.CloudCredentialTag) (cloud.Credential
 // CloudCredentials returns the user's cloud credentials for a given cloud,
 // keyed by credential name.
 func (st *State) CloudCredentials(user names.UserTag, cloudName string) (map[string]cloud.Credential, error) {
-	coll, cleanup := st.getCollection(cloudCredentialsC)
+	coll, cleanup := st.db().GetCollection(cloudCredentialsC)
 	defer cleanup()
 
 	var doc cloudCredentialDoc

--- a/state/collection.go
+++ b/state/collection.go
@@ -13,8 +13,7 @@ import (
 
 // getRawCollection returns the named mgo Collection. As no automatic
 // model filtering is performed by the returned collection it
-// should be rarely used. getCollection() should be used in almost all
-// cases.
+// should be rarely used.
 func (st *State) getRawCollection(name string) (*mgo.Collection, func()) {
 	collection, closer := st.database.GetCollection(name)
 	return collection.Writeable().Underlying(), closer

--- a/state/constraints.go
+++ b/state/constraints.go
@@ -89,7 +89,7 @@ func removeConstraintsOp(st *State, id string) txn.Op {
 }
 
 func readConstraints(st *State, id string) (constraints.Value, error) {
-	constraintsCollection, closer := st.getCollection(constraintsC)
+	constraintsCollection, closer := st.db().GetCollection(constraintsC)
 	defer closer()
 
 	doc := constraintsDoc{}

--- a/state/controlleruser.go
+++ b/state/controlleruser.go
@@ -35,7 +35,7 @@ func (st *State) setControllerAccess(access permission.Access, userGlobalKey str
 // controllerUser a model userAccessDoc.
 func (st *State) controllerUser(user names.UserTag) (userAccessDoc, error) {
 	controllerUser := userAccessDoc{}
-	controllerUsers, closer := st.getCollection(controllerUsersC)
+	controllerUsers, closer := st.db().GetCollection(controllerUsersC)
 	defer closer()
 
 	username := strings.ToLower(user.Id())

--- a/state/dump.go
+++ b/state/dump.go
@@ -31,7 +31,7 @@ func (st *State) DumpAll() (map[string]interface{}, error) {
 }
 
 func getModelDoc(st *State) (map[string]interface{}, error) {
-	coll, closer := st.getCollection(modelsC)
+	coll, closer := st.db().GetCollection(modelsC)
 	defer closer()
 
 	var doc map[string]interface{}
@@ -43,7 +43,7 @@ func getModelDoc(st *State) (map[string]interface{}, error) {
 }
 
 func getAllModelDocs(st *State, collectionName string) ([]map[string]interface{}, error) {
-	coll, closer := st.getCollection(collectionName)
+	coll, closer := st.db().GetCollection(collectionName)
 	defer closer()
 
 	var (

--- a/state/endpoint_bindings.go
+++ b/state/endpoint_bindings.go
@@ -214,7 +214,7 @@ func removeEndpointBindingsOp(key string) txn.Op {
 // readEndpointBindings returns the stored bindings and TxnRevno for the given
 // service global key, or an error satisfying errors.IsNotFound() otherwise.
 func readEndpointBindings(st *State, key string) (map[string]string, int64, error) {
-	endpointBindings, closer := st.getCollection(endpointBindingsC)
+	endpointBindings, closer := st.db().GetCollection(endpointBindingsC)
 	defer closer()
 
 	var doc endpointBindingsDoc

--- a/state/export_test.go
+++ b/state/export_test.go
@@ -138,7 +138,7 @@ func (doc *MachineDoc) String() string {
 }
 
 func ServiceSettingsRefCount(st *State, appName string, curl *charm.URL) (int, error) {
-	refcounts, closer := st.getCollection(refcountsC)
+	refcounts, closer := st.db().GetCollection(refcountsC)
 	defer closer()
 
 	key := applicationSettingsKey(appName, curl)
@@ -271,7 +271,7 @@ func TxnRevno(st *State, collName string, id interface{}) (int64, error) {
 	var doc struct {
 		TxnRevno int64 `bson:"txn-revno"`
 	}
-	coll, closer := st.getCollection(collName)
+	coll, closer := st.db().GetCollection(collName)
 	defer closer()
 	err := coll.FindId(id).One(&doc)
 	if err != nil {
@@ -283,7 +283,7 @@ func TxnRevno(st *State, collName string, id interface{}) (int64, error) {
 // MinUnitsRevno returns the Revno of the minUnits document
 // associated with the given application name.
 func MinUnitsRevno(st *State, applicationname string) (int, error) {
-	minUnitsCollection, closer := st.getCollection(minUnitsC)
+	minUnitsCollection, closer := st.db().GetCollection(minUnitsC)
 	defer closer()
 	var doc minUnitsDoc
 	if err := minUnitsCollection.FindId(applicationname).One(&doc); err != nil {
@@ -326,7 +326,7 @@ func NewActionStatusWatcher(st *State, receivers []ActionReceiver, statuses ...A
 }
 
 func GetAllUpgradeInfos(st *State) ([]*UpgradeInfo, error) {
-	upgradeInfos, closer := st.getCollection(upgradeInfoC)
+	upgradeInfos, closer := st.db().GetCollection(upgradeInfoC)
 	defer closer()
 
 	var out []*UpgradeInfo
@@ -363,7 +363,7 @@ func GetUnitModelUUID(unit *Unit) string {
 }
 
 func GetCollection(st *State, name string) (mongo.Collection, func()) {
-	return st.getCollection(name)
+	return st.db().GetCollection(name)
 }
 
 func GetRawCollection(st *State, name string) (*mgo.Collection, func()) {
@@ -571,7 +571,7 @@ func PrimeUnitStatusHistory(
 ) {
 	globalKey := unit.globalKey()
 
-	history, closer := unit.st.getCollection(statusesHistoryC)
+	history, closer := unit.st.db().GetCollection(statusesHistoryC)
 	defer closer()
 	historyW := history.Writeable()
 
@@ -645,7 +645,7 @@ func IsBlobStored(c *gc.C, st *State, storagePath string) bool {
 // of a given kind scheduled.
 func AssertNoCleanupsWithKind(c *gc.C, st *State, kind cleanupKind) {
 	var docs []cleanupDoc
-	cleanups, closer := st.getCollection(cleanupsC)
+	cleanups, closer := st.db().GetCollection(cleanupsC)
 	defer closer()
 	err := cleanups.Find(nil).All(&docs)
 	c.Assert(err, jc.ErrorIsNil)
@@ -659,7 +659,7 @@ func AssertNoCleanupsWithKind(c *gc.C, st *State, kind cleanupKind) {
 // AssertNoCleanups checks that there are no cleanups scheduled.
 func AssertNoCleanups(c *gc.C, st *State) {
 	var docs []cleanupDoc
-	cleanups, closer := st.getCollection(cleanupsC)
+	cleanups, closer := st.db().GetCollection(cleanupsC)
 	defer closer()
 	err := cleanups.Find(nil).All(&docs)
 	c.Assert(err, jc.ErrorIsNil)

--- a/state/filesystem.go
+++ b/state/filesystem.go
@@ -306,7 +306,7 @@ func (st *State) VolumeFilesystem(tag names.VolumeTag) (Filesystem, error) {
 }
 
 func (st *State) filesystems(query interface{}) ([]*filesystem, error) {
-	coll, cleanup := st.getCollection(filesystemsC)
+	coll, cleanup := st.db().GetCollection(filesystemsC)
 	defer cleanup()
 
 	var fDocs []filesystemDoc
@@ -326,7 +326,7 @@ func (st *State) filesystems(query interface{}) ([]*filesystem, error) {
 }
 
 func (st *State) filesystem(query bson.D, description string) (*filesystem, error) {
-	coll, cleanup := st.getCollection(filesystemsC)
+	coll, cleanup := st.db().GetCollection(filesystemsC)
 	defer cleanup()
 
 	f := filesystem{st: st}
@@ -345,7 +345,7 @@ func (st *State) filesystem(query bson.D, description string) (*filesystem, erro
 // FilesystemAttachment returns the FilesystemAttachment corresponding to
 // the specified filesystem and machine.
 func (st *State) FilesystemAttachment(machine names.MachineTag, filesystem names.FilesystemTag) (FilesystemAttachment, error) {
-	coll, cleanup := st.getCollection(filesystemAttachmentsC)
+	coll, cleanup := st.db().GetCollection(filesystemAttachmentsC)
 	defer cleanup()
 
 	var att filesystemAttachment
@@ -379,7 +379,7 @@ func (st *State) MachineFilesystemAttachments(machine names.MachineTag) ([]Files
 }
 
 func (st *State) filesystemAttachments(query bson.D) ([]FilesystemAttachment, error) {
-	coll, cleanup := st.getCollection(filesystemAttachmentsC)
+	coll, cleanup := st.db().GetCollection(filesystemAttachmentsC)
 	defer cleanup()
 
 	var docs []filesystemAttachmentDoc

--- a/state/gui.go
+++ b/state/gui.go
@@ -30,7 +30,7 @@ func (st *State) GUISetVersion(vers version.Number) error {
 	}
 
 	// Set the current version.
-	settings, closer := st.getCollection(guisettingsC)
+	settings, closer := st.db().GetCollection(guisettingsC)
 	defer closer()
 	if _, err = settings.Writeable().Upsert(nil, bson.D{{"current-version", vers}}); err != nil {
 		return errors.Annotate(err, "cannot set current GUI version")
@@ -40,7 +40,7 @@ func (st *State) GUISetVersion(vers version.Number) error {
 
 // GUIVersion returns the Juju GUI version currently served by the controller.
 func (st *State) GUIVersion() (vers version.Number, err error) {
-	settings, closer := st.getCollection(guisettingsC)
+	settings, closer := st.db().GetCollection(guisettingsC)
 	defer closer()
 
 	// Retrieve the settings document.

--- a/state/life.go
+++ b/state/life.go
@@ -62,7 +62,7 @@ type AgentLiving interface {
 }
 
 func isAlive(st *State, collName string, id interface{}) (bool, error) {
-	coll, closer := st.getCollection(collName)
+	coll, closer := st.db().GetCollection(collName)
 	defer closer()
 	return isAliveWithSession(coll, id)
 }
@@ -73,7 +73,7 @@ func isAliveWithSession(coll mongo.Collection, id interface{}) (bool, error) {
 }
 
 func isNotDead(st *State, collName string, id interface{}) (bool, error) {
-	coll, closer := st.getCollection(collName)
+	coll, closer := st.db().GetCollection(collName)
 	defer closer()
 	return isNotDeadWithSession(coll, id)
 }

--- a/state/linklayerdevices.go
+++ b/state/linklayerdevices.go
@@ -102,7 +102,7 @@ func newLinkLayerDevice(st *State, doc linkLayerDeviceDoc) *LinkLayerDevice {
 
 // AllLinkLayerDevices returns all link layer devices in the model.
 func (st *State) AllLinkLayerDevices() (devices []*LinkLayerDevice, err error) {
-	devicesCollection, closer := st.getCollection(linkLayerDevicesC)
+	devicesCollection, closer := st.db().GetCollection(linkLayerDevicesC)
 	defer closer()
 
 	sdocs := []linkLayerDeviceDoc{}

--- a/state/linklayerdevices_ipaddresses.go
+++ b/state/linklayerdevices_ipaddresses.go
@@ -338,7 +338,7 @@ func (st *State) removeMatchingIPAddressesDocOps(findQuery bson.D) ([]txn.Op, er
 }
 
 func (st *State) forEachIPAddressDoc(findQuery bson.D, callbackFunc func(resultDoc *ipAddressDoc)) error {
-	addresses, closer := st.getCollection(ipAddressesC)
+	addresses, closer := st.db().GetCollection(ipAddressesC)
 	defer closer()
 
 	query := addresses.Find(findQuery)
@@ -354,7 +354,7 @@ func (st *State) forEachIPAddressDoc(findQuery bson.D, callbackFunc func(resultD
 
 // AllIPAddresses returns all ip addresses in the model.
 func (st *State) AllIPAddresses() (addresses []*Address, err error) {
-	addressesCollection, closer := st.getCollection(ipAddressesC)
+	addressesCollection, closer := st.db().GetCollection(ipAddressesC)
 	defer closer()
 
 	sdocs := []ipAddressDoc{}

--- a/state/linklayerdevices_refs.go
+++ b/state/linklayerdevices_refs.go
@@ -59,7 +59,7 @@ func removeLinkLayerDevicesRefsOp(linkLayerDeviceDocID string) txn.Op {
 // linkLayerDeviceDocID. If the linkLayerDevicesRefsDoc is missing, no error and
 // -1 children are returned.
 func getParentDeviceNumChildrenRefs(st *State, linkLayerDeviceDocID string) (int, error) {
-	devicesRefs, closer := st.getCollection(linkLayerDevicesRefsC)
+	devicesRefs, closer := st.db().GetCollection(linkLayerDevicesRefsC)
 	defer closer()
 
 	var doc linkLayerDevicesRefsDoc

--- a/state/machine.go
+++ b/state/machine.go
@@ -239,7 +239,7 @@ func (m *Machine) HardwareCharacteristics() (*instance.HardwareCharacteristics, 
 }
 
 func getInstanceData(st *State, id string) (instanceData, error) {
-	instanceDataCollection, closer := st.getCollection(instanceDataC)
+	instanceDataCollection, closer := st.db().GetCollection(instanceDataC)
 	defer closer()
 
 	var instData instanceData
@@ -514,7 +514,7 @@ func IsHasAssignedUnitsError(err error) bool {
 // Containers returns the container ids belonging to a parent machine.
 // TODO(wallyworld): move this method to a service
 func (m *Machine) Containers() ([]string, error) {
-	containerRefs, closer := m.st.getCollection(containerRefsC)
+	containerRefs, closer := m.st.db().GetCollection(containerRefsC)
 	defer closer()
 
 	var mc machineContainers
@@ -1042,7 +1042,7 @@ func (m *Machine) AvailabilityZone() (string, error) {
 // Units returns all the units that have been assigned to the machine.
 func (m *Machine) Units() (units []*Unit, err error) {
 	defer errors.DeferredAnnotatef(&err, "cannot get units assigned to machine %v", m)
-	unitsCollection, closer := m.st.getCollection(unitsC)
+	unitsCollection, closer := m.st.db().GetCollection(unitsC)
 	defer closer()
 
 	pudocs := []unitDoc{}

--- a/state/machine_linklayerdevices.go
+++ b/state/machine_linklayerdevices.go
@@ -27,7 +27,7 @@ const defaultSpaceName = "default"
 // error satisfying errors.IsNotFound() is returned when no such device exists
 // on the machine.
 func (m *Machine) LinkLayerDevice(name string) (*LinkLayerDevice, error) {
-	linkLayerDevices, closer := m.st.getCollection(linkLayerDevicesC)
+	linkLayerDevices, closer := m.st.db().GetCollection(linkLayerDevicesC)
 	defer closer()
 
 	linkLayerDeviceDocID := m.linkLayerDeviceDocIDFromName(name)
@@ -69,7 +69,7 @@ func (m *Machine) AllLinkLayerDevices() ([]*LinkLayerDevice, error) {
 }
 
 func (m *Machine) forEachLinkLayerDeviceDoc(docFieldsToSelect bson.D, callbackFunc func(resultDoc *linkLayerDeviceDoc)) error {
-	linkLayerDevices, closer := m.st.getCollection(linkLayerDevicesC)
+	linkLayerDevices, closer := m.st.db().GetCollection(linkLayerDevicesC)
 	defer closer()
 
 	query := linkLayerDevices.Find(bson.D{{"machine-id", m.doc.Id}})
@@ -244,7 +244,7 @@ func (st *State) allProviderIDsForAddresses() (set.Strings, error) {
 }
 
 func (st *State) allProviderIDsForEntity(entityName string) (set.Strings, error) {
-	idCollection, closer := st.getCollection(providerIDsC)
+	idCollection, closer := st.db().GetCollection(providerIDsC)
 	defer closer()
 
 	allProviderIDs := set.NewStrings()
@@ -449,7 +449,7 @@ func (m *Machine) assertAliveOp() txn.Op {
 }
 
 func (m *Machine) setDevicesFromDocsOps(newDocs []linkLayerDeviceDoc) ([]txn.Op, error) {
-	devices, closer := m.st.getCollection(linkLayerDevicesC)
+	devices, closer := m.st.db().GetCollection(linkLayerDevicesC)
 	defer closer()
 
 	var ops []txn.Op
@@ -772,7 +772,7 @@ func (m *Machine) verifySubnetAlive(subnet *Subnet) error {
 }
 
 func (m *Machine) setDevicesAddressesFromDocsOps(newDocs []ipAddressDoc) ([]txn.Op, error) {
-	addresses, closer := m.st.getCollection(ipAddressesC)
+	addresses, closer := m.st.db().GetCollection(ipAddressesC)
 	defer closer()
 
 	var ops []txn.Op

--- a/state/machineremovals.go
+++ b/state/machineremovals.go
@@ -65,7 +65,7 @@ func (m *Machine) MarkForRemoval() (err error) {
 // AllMachineRemovals returns (the ids of) all of the machines that
 // need to be removed but need provider-level cleanup.
 func (st *State) AllMachineRemovals() ([]string, error) {
-	removals, close := st.getCollection(machineRemovalsC)
+	removals, close := st.db().GetCollection(machineRemovalsC)
 	defer close()
 
 	var docs []machineRemovalDoc
@@ -81,7 +81,7 @@ func (st *State) AllMachineRemovals() ([]string, error) {
 }
 
 func (st *State) allMachinesMatching(query bson.D) ([]*Machine, error) {
-	machines, close := st.getCollection(machinesC)
+	machines, close := st.db().GetCollection(machinesC)
 	defer close()
 
 	var docs []machineDoc

--- a/state/meterstatus.go
+++ b/state/meterstatus.go
@@ -182,7 +182,7 @@ func combineMeterStatus(a, b MeterStatus) MeterStatus {
 }
 
 func (u *Unit) getMeterStatusDoc() (*meterStatusDoc, error) {
-	meterStatuses, closer := u.st.getCollection(meterStatusC)
+	meterStatuses, closer := u.st.db().GetCollection(meterStatusC)
 	defer closer()
 	var status meterStatusDoc
 	err := meterStatuses.FindId(u.globalMeterStatusKey()).One(&status)

--- a/state/metrics.go
+++ b/state/metrics.go
@@ -224,7 +224,7 @@ func (st *State) AddModelMetrics(batch ModelBatchParam) (*MetricBatch, error) {
 //                  it needs to be modified to restrict the scope of the values it
 //                  returns if it is to be used outside of tests.
 func (st *State) AllMetricBatches() ([]MetricBatch, error) {
-	c, closer := st.getCollection(metricsC)
+	c, closer := st.db().GetCollection(metricsC)
 	defer closer()
 	docs := []metricBatchDoc{}
 	err := c.Find(nil).All(&docs)
@@ -239,7 +239,7 @@ func (st *State) AllMetricBatches() ([]MetricBatch, error) {
 }
 
 func (st *State) queryMetricBatches(query bson.M) ([]MetricBatch, error) {
-	c, closer := st.getCollection(metricsC)
+	c, closer := st.db().GetCollection(metricsC)
 	defer closer()
 	docs := []metricBatchDoc{}
 	err := c.Find(query).Sort("created").All(&docs)
@@ -286,7 +286,7 @@ func (st *State) MetricBatchesForApplication(application string) ([]MetricBatch,
 
 // MetricBatch returns the metric batch with the given id.
 func (st *State) MetricBatch(id string) (*MetricBatch, error) {
-	c, closer := st.getCollection(metricsC)
+	c, closer := st.db().GetCollection(metricsC)
 	defer closer()
 	doc := metricBatchDoc{}
 	err := c.Find(bson.M{"_id": id}).One(&doc)
@@ -303,7 +303,7 @@ func (st *State) MetricBatch(id string) (*MetricBatch, error) {
 // and have been sent. Any metrics it finds are deleted.
 func (st *State) CleanupOldMetrics() error {
 	now := st.clock.Now()
-	metrics, closer := st.getCollection(metricsC)
+	metrics, closer := st.db().GetCollection(metricsC)
 	defer closer()
 	// Nothing else in the system will interact with sent metrics, and nothing needs
 	// to watch them either; so in this instance it's safe to do an end run around the
@@ -325,7 +325,7 @@ func (st *State) CleanupOldMetrics() error {
 // to the collector
 func (st *State) MetricsToSend(batchSize int) ([]*MetricBatch, error) {
 	var docs []metricBatchDoc
-	c, closer := st.getCollection(metricsC)
+	c, closer := st.db().GetCollection(metricsC)
 	defer closer()
 
 	q := bson.M{
@@ -349,7 +349,7 @@ func (st *State) MetricsToSend(batchSize int) ([]*MetricBatch, error) {
 // CountOfUnsentMetrics returns the number of metrics that
 // haven't been sent to the collection service.
 func (st *State) CountOfUnsentMetrics() (int, error) {
-	c, closer := st.getCollection(metricsC)
+	c, closer := st.db().GetCollection(metricsC)
 	defer closer()
 	return c.Find(bson.M{
 		"model-uuid": st.ModelUUID(),
@@ -361,7 +361,7 @@ func (st *State) CountOfUnsentMetrics() (int, error) {
 // have been sent to the collection service and have not
 // been removed by the cleanup worker.
 func (st *State) CountOfSentMetrics() (int, error) {
-	c, closer := st.getCollection(metricsC)
+	c, closer := st.db().GetCollection(metricsC)
 	defer closer()
 	return c.Find(bson.M{
 		"model-uuid": st.ModelUUID(),

--- a/state/metricsmanager.go
+++ b/state/metricsmanager.go
@@ -86,7 +86,7 @@ func (st *State) newMetricsManager() (*MetricsManager, error) {
 }
 
 func (st *State) getMetricsManager() (*MetricsManager, error) {
-	coll, closer := st.getCollection(metricsManagerC)
+	coll, closer := st.db().GetCollection(metricsManagerC)
 	defer closer()
 	var doc metricsManagerDoc
 	err := coll.FindId(metricsManagerKey).One(&doc)

--- a/state/migration_export.go
+++ b/state/migration_export.go
@@ -179,7 +179,7 @@ type exporter struct {
 }
 
 func (e *exporter) sequences() error {
-	sequences, closer := e.st.getCollection(sequenceC)
+	sequences, closer := e.st.db().GetCollection(sequenceC)
 	defer closer()
 
 	var docs []sequenceDoc
@@ -194,7 +194,7 @@ func (e *exporter) sequences() error {
 }
 
 func (e *exporter) readBlocks() (map[string]string, error) {
-	blocks, closer := e.st.getCollection(blocksC)
+	blocks, closer := e.st.db().GetCollection(blocksC)
 	defer closer()
 
 	var docs []blockDoc
@@ -264,7 +264,7 @@ func (e *exporter) machines() error {
 	}
 
 	// Read all the open ports documents.
-	openedPorts, closer := e.st.getCollection(openedPortsC)
+	openedPorts, closer := e.st.db().GetCollection(openedPortsC)
 	defer closer()
 	var portsData []portsDoc
 	if err := openedPorts.Find(nil).All(&portsData); err != nil {
@@ -301,7 +301,7 @@ func (e *exporter) machines() error {
 }
 
 func (e *exporter) loadMachineInstanceData() (map[string]instanceData, error) {
-	instanceDataCollection, closer := e.st.getCollection(instanceDataC)
+	instanceDataCollection, closer := e.st.db().GetCollection(instanceDataC)
 	defer closer()
 
 	var instData []instanceData
@@ -317,7 +317,7 @@ func (e *exporter) loadMachineInstanceData() (map[string]instanceData, error) {
 }
 
 func (e *exporter) loadMachineBlockDevices() (map[string][]BlockDeviceInfo, error) {
-	coll, closer := e.st.getCollection(blockDevicesC)
+	coll, closer := e.st.db().GetCollection(blockDevicesC)
 	defer closer()
 
 	var deviceData []blockDevicesDoc
@@ -564,7 +564,7 @@ func (e *exporter) applications() error {
 }
 
 func (e *exporter) readAllStorageConstraints() error {
-	coll, closer := e.st.getCollection(storageConstraintsC)
+	coll, closer := e.st.db().GetCollection(storageConstraintsC)
 	defer closer()
 
 	storageConstraints := make(map[string]storageConstraintsDoc)
@@ -1050,7 +1050,7 @@ func (e *exporter) actions() error {
 }
 
 func (e *exporter) readAllRelationScopes() (set.Strings, error) {
-	relationScopes, closer := e.st.getCollection(relationScopesC)
+	relationScopes, closer := e.st.db().GetCollection(relationScopesC)
 	defer closer()
 
 	docs := []relationScopeDoc{}
@@ -1068,7 +1068,7 @@ func (e *exporter) readAllRelationScopes() (set.Strings, error) {
 }
 
 func (e *exporter) readAllUnits() (map[string][]*Unit, error) {
-	unitsCollection, closer := e.st.getCollection(unitsC)
+	unitsCollection, closer := e.st.db().GetCollection(unitsC)
 	defer closer()
 
 	docs := []unitDoc{}
@@ -1086,7 +1086,7 @@ func (e *exporter) readAllUnits() (map[string][]*Unit, error) {
 }
 
 func (e *exporter) readAllEndpointBindings() (map[string]bindingsMap, error) {
-	bindings, closer := e.st.getCollection(endpointBindingsC)
+	bindings, closer := e.st.db().GetCollection(endpointBindingsC)
 	defer closer()
 
 	docs := []endpointBindingsDoc{}
@@ -1103,7 +1103,7 @@ func (e *exporter) readAllEndpointBindings() (map[string]bindingsMap, error) {
 }
 
 func (e *exporter) readAllMeterStatus() (map[string]*meterStatusDoc, error) {
-	meterStatuses, closer := e.st.getCollection(meterStatusC)
+	meterStatuses, closer := e.st.db().GetCollection(meterStatusC)
 	defer closer()
 
 	docs := []meterStatusDoc{}
@@ -1120,7 +1120,7 @@ func (e *exporter) readAllMeterStatus() (map[string]*meterStatusDoc, error) {
 }
 
 func (e *exporter) readLastConnectionTimes() (map[string]time.Time, error) {
-	lastConnections, closer := e.st.getCollection(modelUserLastConnectionC)
+	lastConnections, closer := e.st.db().GetCollection(modelUserLastConnectionC)
 	defer closer()
 
 	var docs []modelUserLastConnectionDoc
@@ -1136,7 +1136,7 @@ func (e *exporter) readLastConnectionTimes() (map[string]time.Time, error) {
 }
 
 func (e *exporter) readAllAnnotations() error {
-	annotations, closer := e.st.getCollection(annotationsC)
+	annotations, closer := e.st.db().GetCollection(annotationsC)
 	defer closer()
 
 	var docs []annotatorDoc
@@ -1153,7 +1153,7 @@ func (e *exporter) readAllAnnotations() error {
 }
 
 func (e *exporter) readAllConstraints() error {
-	constraintsCollection, closer := e.st.getCollection(constraintsC)
+	constraintsCollection, closer := e.st.db().GetCollection(constraintsC)
 	defer closer()
 
 	// Since the constraintsDoc doesn't include any global key or _id
@@ -1191,7 +1191,7 @@ func (e *exporter) getAnnotations(key string) map[string]string {
 }
 
 func (e *exporter) readAllSettings() error {
-	settings, closer := e.st.getCollection(settingsC)
+	settings, closer := e.st.db().GetCollection(settingsC)
 	defer closer()
 
 	var docs []settingsDoc
@@ -1208,7 +1208,7 @@ func (e *exporter) readAllSettings() error {
 }
 
 func (e *exporter) readAllStatuses() error {
-	statuses, closer := e.st.getCollection(statusesC)
+	statuses, closer := e.st.db().GetCollection(statusesC)
 	defer closer()
 
 	var docs []bson.M
@@ -1232,7 +1232,7 @@ func (e *exporter) readAllStatuses() error {
 }
 
 func (e *exporter) readAllStatusHistory() error {
-	statuses, closer := e.st.getCollection(statusesHistoryC)
+	statuses, closer := e.st.db().GetCollection(statusesHistoryC)
 	defer closer()
 
 	count := 0
@@ -1457,7 +1457,7 @@ func (e *exporter) storage() error {
 }
 
 func (e *exporter) volumes() error {
-	coll, closer := e.st.getCollection(volumesC)
+	coll, closer := e.st.db().GetCollection(volumesC)
 	defer closer()
 
 	attachments, err := e.readVolumeAttachments()
@@ -1546,7 +1546,7 @@ func (e *exporter) addVolume(vol *volume, volAttachments []volumeAttachmentDoc) 
 }
 
 func (e *exporter) readVolumeAttachments() (map[string][]volumeAttachmentDoc, error) {
-	coll, closer := e.st.getCollection(volumeAttachmentsC)
+	coll, closer := e.st.db().GetCollection(volumeAttachmentsC)
 	defer closer()
 
 	result := make(map[string][]volumeAttachmentDoc)
@@ -1566,7 +1566,7 @@ func (e *exporter) readVolumeAttachments() (map[string][]volumeAttachmentDoc, er
 }
 
 func (e *exporter) filesystems() error {
-	coll, closer := e.st.getCollection(filesystemsC)
+	coll, closer := e.st.db().GetCollection(filesystemsC)
 	defer closer()
 
 	attachments, err := e.readFilesystemAttachments()
@@ -1649,7 +1649,7 @@ func (e *exporter) addFilesystem(fs *filesystem, fsAttachments []filesystemAttac
 }
 
 func (e *exporter) readFilesystemAttachments() (map[string][]filesystemAttachmentDoc, error) {
-	coll, closer := e.st.getCollection(filesystemAttachmentsC)
+	coll, closer := e.st.db().GetCollection(filesystemAttachmentsC)
 	defer closer()
 
 	result := make(map[string][]filesystemAttachmentDoc)
@@ -1669,7 +1669,7 @@ func (e *exporter) readFilesystemAttachments() (map[string][]filesystemAttachmen
 }
 
 func (e *exporter) storageInstances() error {
-	coll, closer := e.st.getCollection(storageInstancesC)
+	coll, closer := e.st.db().GetCollection(storageInstancesC)
 	defer closer()
 
 	attachments, err := e.readStorageAttachments()
@@ -1709,7 +1709,7 @@ func (e *exporter) addStorage(instance *storageInstance, attachments []names.Uni
 }
 
 func (e *exporter) readStorageAttachments() (map[string][]names.UnitTag, error) {
-	coll, closer := e.st.getCollection(storageAttachmentsC)
+	coll, closer := e.st.db().GetCollection(storageAttachmentsC)
 	defer closer()
 
 	result := make(map[string][]names.UnitTag)

--- a/state/migration_import.go
+++ b/state/migration_import.go
@@ -281,7 +281,7 @@ func (i *importer) sequences() error {
 		return nil
 	}
 
-	sequences, closer := i.st.getCollection(sequenceC)
+	sequences, closer := i.st.db().GetCollection(sequenceC)
 	defer closer()
 
 	if err := sequences.Writeable().Insert(docs...); err != nil {
@@ -680,7 +680,7 @@ func (i *importer) applications() error {
 }
 
 func (i *importer) loadUnits() error {
-	unitsCollection, closer := i.st.getCollection(unitsC)
+	unitsCollection, closer := i.st.db().GetCollection(unitsC)
 	defer closer()
 
 	docs := []unitDoc{}
@@ -1382,7 +1382,7 @@ func (i *importer) importStatusHistory(globalKey string, history []description.S
 		return nil
 	}
 
-	statusHistory, closer := i.st.getCollection(statusesHistoryC)
+	statusHistory, closer := i.st.db().GetCollection(statusesHistoryC)
 	defer closer()
 
 	if err := statusHistory.Writeable().Insert(docs...); err != nil {
@@ -1492,7 +1492,7 @@ func (i *importer) addStorageInstance(storage description.Storage) error {
 		Insert: doc,
 	})
 
-	refcounts, closer := i.st.getCollection(refcountsC)
+	refcounts, closer := i.st.db().GetCollection(refcountsC)
 	defer closer()
 	storageRefcountKey := entityStorageRefcountKey(owner, storage.Name())
 	incRefOp, err := nsRefcounts.CreateOrIncRefOp(refcounts, storageRefcountKey, 1)

--- a/state/minimumunits.go
+++ b/state/minimumunits.go
@@ -183,7 +183,7 @@ func (a *Application) EnsureMinUnits() (err error) {
 
 // aliveUnitsCount returns the number a alive units for the application.
 func aliveUnitsCount(app *Application) (int, error) {
-	units, closer := app.st.getCollection(unitsC)
+	units, closer := app.st.db().GetCollection(unitsC)
 	defer closer()
 
 	query := bson.D{{"application", app.doc.Name}, {"life", Alive}}

--- a/state/model.go
+++ b/state/model.go
@@ -179,7 +179,7 @@ func (st *State) Model() (*Model, error) {
 
 // GetModel looks for the model identified by the uuid passed in.
 func (st *State) GetModel(tag names.ModelTag) (*Model, error) {
-	models, closer := st.getCollection(modelsC)
+	models, closer := st.db().GetCollection(modelsC)
 	defer closer()
 
 	model := &Model{st: st}
@@ -191,7 +191,7 @@ func (st *State) GetModel(tag names.ModelTag) (*Model, error) {
 
 // AllModels returns all the models in the system.
 func (st *State) AllModels() ([]*Model, error) {
-	models, closer := st.getCollection(modelsC)
+	models, closer := st.db().GetCollection(modelsC)
 	defer closer()
 
 	var modelDocs []modelDoc
@@ -355,7 +355,7 @@ func (st *State) NewModel(args ModelArgs) (_ *Model, _ *State, err error) {
 		// the same "owner" and "name" in the collection. If the txn is
 		// aborted, check if it is due to the unique key restriction.
 		name := args.Config.Name()
-		models, closer := st.getCollection(modelsC)
+		models, closer := st.db().GetCollection(modelsC)
 		defer closer()
 		envCount, countErr := models.Find(bson.D{
 			{"owner", owner.Id()},
@@ -745,7 +745,7 @@ func (m *Model) globalKey() string {
 }
 
 func (m *Model) Refresh() error {
-	models, closer := m.st.getCollection(modelsC)
+	models, closer := m.st.db().GetCollection(modelsC)
 	defer closer()
 	return m.refresh(models.FindId(m.UUID()))
 }
@@ -763,7 +763,7 @@ func (m *Model) Users() ([]permission.UserAccess, error) {
 	if m.st.ModelUUID() != m.UUID() {
 		return nil, errors.New("cannot lookup model users outside the current model")
 	}
-	coll, closer := m.st.getCollection(modelUsersC)
+	coll, closer := m.st.db().GetCollection(modelUsersC)
 	defer closer()
 
 	var userDocs []userAccessDoc
@@ -1030,7 +1030,7 @@ func (m *Model) checkEmpty() error {
 	}
 	defer closeState()
 
-	modelEntityRefs, closer := st.getCollection(modelEntityRefsC)
+	modelEntityRefs, closer := st.db().GetCollection(modelEntityRefsC)
 	defer closer()
 
 	var doc modelEntityRefsDoc
@@ -1177,7 +1177,7 @@ func HostedModelCountOp(amount int) txn.Op {
 
 func hostedModelCount(st *State) (int, error) {
 	var doc hostedModelCountDoc
-	controllers, closer := st.getCollection(controllersC)
+	controllers, closer := st.db().GetCollection(controllersC)
 	defer closer()
 
 	if err := controllers.Find(bson.D{{"_id", hostedModelCountKey}}).One(&doc); err != nil {

--- a/state/modeluser.go
+++ b/state/modeluser.go
@@ -83,7 +83,7 @@ func (st *State) UpdateLastModelConnection(user names.UserTag) error {
 }
 
 func (st *State) updateLastModelConnection(user names.UserTag, when time.Time) error {
-	lastConnections, closer := st.getCollection(modelUserLastConnectionC)
+	lastConnections, closer := st.db().GetCollection(modelUserLastConnectionC)
 	defer closer()
 
 	lastConnectionsW := lastConnections.Writeable()
@@ -106,7 +106,7 @@ func (st *State) updateLastModelConnection(user names.UserTag, when time.Time) e
 // ModelUser a model userAccessDoc.
 func (st *State) modelUser(modelUUID string, user names.UserTag) (userAccessDoc, error) {
 	modelUser := userAccessDoc{}
-	modelUsers, closer := st.getCollectionFor(modelUUID, modelUsersC)
+	modelUsers, closer := st.db().GetCollectionFor(modelUUID, modelUsersC)
 	defer closer()
 
 	username := strings.ToLower(user.Id())

--- a/state/mongo.go
+++ b/state/mongo.go
@@ -21,7 +21,7 @@ type environMongo struct {
 
 // GetCollection is part of the lease.Mongo interface.
 func (m *environMongo) GetCollection(name string) (mongo.Collection, func()) {
-	return m.state.getCollection(name)
+	return m.state.db().GetCollection(name)
 }
 
 // RunTransaction is part of the lease.Mongo interface.

--- a/state/persistence.go
+++ b/state/persistence.go
@@ -53,7 +53,7 @@ func (st *State) newPersistence() Persistence {
 
 // One gets the identified document from the collection.
 func (sp statePersistence) One(collName, id string, doc interface{}) error {
-	coll, closeColl := sp.st.getCollection(collName)
+	coll, closeColl := sp.st.db().GetCollection(collName)
 	defer closeColl()
 
 	err := coll.FindId(id).One(doc)
@@ -68,7 +68,7 @@ func (sp statePersistence) One(collName, id string, doc interface{}) error {
 
 // All gets all documents from the collection matching the query.
 func (sp statePersistence) All(collName string, query, docs interface{}) error {
-	coll, closeColl := sp.st.getCollection(collName)
+	coll, closeColl := sp.st.db().GetCollection(collName)
 	defer closeColl()
 
 	if err := coll.Find(query).All(docs); err != nil {

--- a/state/ports.go
+++ b/state/ports.go
@@ -335,7 +335,7 @@ func (p *Ports) PortsForUnit(unitName string) []PortRange {
 
 // Refresh refreshes the port document from state.
 func (p *Ports) Refresh() error {
-	openedPorts, closer := p.st.getCollection(openedPortsC)
+	openedPorts, closer := p.st.db().GetCollection(openedPortsC)
 	defer closer()
 
 	err := openedPorts.FindId(p.doc.DocID).One(&p.doc)
@@ -391,7 +391,7 @@ func (m *Machine) OpenedPorts(subnetID string) (*Ports, error) {
 // AllPorts returns all opened ports for this machine (on all
 // networks).
 func (m *Machine) AllPorts() ([]*Ports, error) {
-	openedPorts, closer := m.st.getCollection(openedPortsC)
+	openedPorts, closer := m.st.db().GetCollection(openedPortsC)
 	defer closer()
 
 	docs := []portsDoc{}
@@ -531,7 +531,7 @@ func removePortsForUnitOps(st *State, unit *Unit) ([]txn.Op, error) {
 
 // getPorts returns the ports document for the specified machine and subnet.
 func getPorts(st *State, machineID, subnetID string) (*Ports, error) {
-	openedPorts, closer := st.getCollection(openedPortsC)
+	openedPorts, closer := st.db().GetCollection(openedPortsC)
 	defer closer()
 
 	var doc portsDoc

--- a/state/reboot.go
+++ b/state/reboot.go
@@ -79,7 +79,7 @@ func removeRebootDocOp(st *State, machineId string) txn.Op {
 }
 
 func (m *Machine) clearFlag() error {
-	reboot, closer := m.st.getCollection(rebootC)
+	reboot, closer := m.st.db().GetCollection(rebootC)
 	defer closer()
 
 	docID := m.doc.DocID
@@ -107,7 +107,7 @@ func (m *Machine) SetRebootFlag(flag bool) error {
 
 // GetRebootFlag returns the reboot flag for this machine.
 func (m *Machine) GetRebootFlag() (bool, error) {
-	rebootCol, closer := m.st.getCollection(rebootC)
+	rebootCol, closer := m.st.db().GetCollection(rebootC)
 	defer closer()
 
 	count, err := rebootCol.FindId(m.doc.DocID).Count()
@@ -133,7 +133,7 @@ func (m *Machine) machinesToCareAboutRebootsFor() []string {
 // If we are a container, and our parent needs to reboot, this should return:
 // ShouldShutdown
 func (m *Machine) ShouldRebootOrShutdown() (RebootAction, error) {
-	rebootCol, closer := m.st.getCollection(rebootC)
+	rebootCol, closer := m.st.db().GetCollection(rebootC)
 	defer closer()
 
 	machines := m.machinesToCareAboutRebootsFor()

--- a/state/relation.go
+++ b/state/relation.go
@@ -70,7 +70,7 @@ func (r *Relation) Tag() names.Tag {
 // state. It returns an error that satisfies errors.IsNotFound if the
 // relation has been removed.
 func (r *Relation) Refresh() error {
-	relations, closer := r.st.getCollection(relationsC)
+	relations, closer := r.st.db().GetCollection(relationsC)
 	defer closer()
 
 	doc := relationDoc{}
@@ -219,7 +219,7 @@ func (r *Relation) removeLocalEndpointOps(ep Endpoint, departingUnitName string)
 		asserts = append(hasRelation, cannotDieYet...)
 	} else {
 		// This service may require immediate removal.
-		applications, closer := r.st.getCollection(applicationsC)
+		applications, closer := r.st.db().GetCollection(applicationsC)
 		defer closer()
 
 		svc := &Application{st: r.st}
@@ -256,7 +256,7 @@ func (r *Relation) removeRemoteEndpointOps(ep Endpoint, unitDying bool) ([]txn.O
 		asserts = append(hasRelation, isAliveDoc...)
 	} else {
 		// The remote application may require immediate removal.
-		services, closer := r.st.getCollection(remoteApplicationsC)
+		services, closer := r.st.db().GetCollection(remoteApplicationsC)
 		defer closer()
 
 		svc := &RemoteApplication{st: r.st}

--- a/state/relationunit.go
+++ b/state/relationunit.go
@@ -206,7 +206,7 @@ func (ru *RelationUnit) EnterScope(settings map[string]interface{}) error {
 // exists and is Alive, its name will be returned as well; if one exists
 // but is not Alive, ErrCannotEnterScopeYet is returned.
 func (ru *RelationUnit) subordinateOps() ([]txn.Op, string, error) {
-	units, closer := ru.st.getCollection(unitsC)
+	units, closer := ru.st.db().GetCollection(unitsC)
 	defer closer()
 
 	if !ru.isPrincipal || ru.endpoint.Scope != charm.ScopeContainer {
@@ -245,7 +245,7 @@ func (ru *RelationUnit) subordinateOps() ([]txn.Op, string, error) {
 // but does not *actually* leave the scope, to avoid triggering relation
 // cleanup.
 func (ru *RelationUnit) PrepareLeaveScope() error {
-	relationScopes, closer := ru.st.getCollection(relationScopesC)
+	relationScopes, closer := ru.st.db().GetCollection(relationScopesC)
 	defer closer()
 
 	key := ru.key()
@@ -268,7 +268,7 @@ func (ru *RelationUnit) PrepareLeaveScope() error {
 // leaves, it is removed immediately. It is not an error to leave a scope
 // that the unit is not, or never was, a member of.
 func (ru *RelationUnit) LeaveScope() error {
-	relationScopes, closer := ru.st.getCollection(relationScopesC)
+	relationScopes, closer := ru.st.db().GetCollection(relationScopesC)
 	defer closer()
 
 	key := ru.key()
@@ -358,7 +358,7 @@ func (ru *RelationUnit) Joined() (bool, error) {
 // inScope returns whether a scope document exists satisfying the supplied
 // selector.
 func (ru *RelationUnit) inScope(sel bson.D) (bool, error) {
-	relationScopes, closer := ru.st.getCollection(relationScopesC)
+	relationScopes, closer := ru.st.db().GetCollection(relationScopesC)
 	defer closer()
 
 	sel = append(sel, bson.D{{"_id", ru.key()}}...)

--- a/state/remoteapplication.go
+++ b/state/remoteapplication.go
@@ -389,7 +389,7 @@ func (s *RemoteApplication) String() string {
 // state. It returns an error that satisfies errors.IsNotFound if the
 // application has been removed.
 func (s *RemoteApplication) Refresh() error {
-	applications, closer := s.st.getCollection(remoteApplicationsC)
+	applications, closer := s.st.db().GetCollection(remoteApplicationsC)
 	defer closer()
 
 	err := applications.FindId(s.doc.DocID).One(&s.doc)
@@ -556,7 +556,7 @@ func (st *State) RemoteApplication(name string) (_ *RemoteApplication, err error
 		return nil, errors.NotValidf("remote application name %q", name)
 	}
 
-	applications, closer := st.getCollection(remoteApplicationsC)
+	applications, closer := st.db().GetCollection(remoteApplicationsC)
 	defer closer()
 
 	appDoc := &remoteApplicationDoc{}
@@ -572,7 +572,7 @@ func (st *State) RemoteApplication(name string) (_ *RemoteApplication, err error
 
 // RemoteApplicationByToken returns a remote application state by token.
 func (st *State) RemoteApplicationByToken(token string) (_ *RemoteApplication, err error) {
-	apps, closer := st.getCollection(remoteApplicationsC)
+	apps, closer := st.db().GetCollection(remoteApplicationsC)
 	defer closer()
 
 	appDoc := &remoteApplicationDoc{}
@@ -588,7 +588,7 @@ func (st *State) RemoteApplicationByToken(token string) (_ *RemoteApplication, e
 
 // AllRemoteApplications returns all the remote applications used by the model.
 func (st *State) AllRemoteApplications() (applications []*RemoteApplication, err error) {
-	applicationsCollection, closer := st.getCollection(remoteApplicationsC)
+	applicationsCollection, closer := st.db().GetCollection(remoteApplicationsC)
 	defer closer()
 
 	appDocs := []remoteApplicationDoc{}
@@ -604,7 +604,7 @@ func (st *State) AllRemoteApplications() (applications []*RemoteApplication, err
 
 // RemoteConnectionStatus returns summary information about connections to the specified offer.
 func (st *State) RemoteConnectionStatus(offerName string) (*RemoteConnectionStatus, error) {
-	applicationsCollection, closer := st.getCollection(remoteApplicationsC)
+	applicationsCollection, closer := st.db().GetCollection(remoteApplicationsC)
 	defer closer()
 
 	count, err := applicationsCollection.Find(bson.D{{"offer-name", offerName}}).Count()

--- a/state/remoteentities.go
+++ b/state/remoteentities.go
@@ -188,7 +188,7 @@ func (r *RemoteEntities) removeRemoteEntityOp(
 // GetToken returns the token associated with the entity with the given tag
 // and model.
 func (r *RemoteEntities) GetToken(sourceModel names.ModelTag, entity names.Tag) (string, error) {
-	remoteEntities, closer := r.st.getCollection(remoteEntitiesC)
+	remoteEntities, closer := r.st.db().GetCollection(remoteEntitiesC)
 	defer closer()
 
 	var doc remoteEntityDoc
@@ -213,7 +213,7 @@ func (r *RemoteEntities) GetToken(sourceModel names.ModelTag, entity names.Tag) 
 // GetRemoteEntity returns the tag of the entity associated with the given
 // token and model.
 func (r *RemoteEntities) GetRemoteEntity(sourceModel names.ModelTag, token string) (names.Tag, error) {
-	remoteEntities, closer := r.st.getCollection(remoteEntitiesC)
+	remoteEntities, closer := r.st.db().GetCollection(remoteEntitiesC)
 	defer closer()
 
 	var doc remoteEntityDoc
@@ -241,7 +241,7 @@ func (r *RemoteEntities) docID(sourceModel names.ModelTag, entity names.Tag) str
 }
 
 func (r *RemoteEntities) tokenExists(token string) (bool, error) {
-	tokens, closer := r.st.getCollection(tokensC)
+	tokens, closer := r.st.db().GetCollection(tokensC)
 	defer closer()
 	n, err := tokens.FindId(token).Count()
 	if err != nil {

--- a/state/restore.go
+++ b/state/restore.go
@@ -63,7 +63,7 @@ type RestoreInfo struct {
 
 // Status returns the current Restore doc status
 func (info *RestoreInfo) Status() (RestoreStatus, error) {
-	restoreInfo, closer := info.st.getCollection(restoreInfoC)
+	restoreInfo, closer := info.st.db().GetCollection(restoreInfoC)
 	defer closer()
 
 	var doc struct {

--- a/state/sequence.go
+++ b/state/sequence.go
@@ -21,7 +21,7 @@ type sequenceDoc struct {
 // sequence safely increments a database backed sequence, returning
 // the next value.
 func (st *State) sequence(name string) (int, error) {
-	sequences, closer := st.getCollection(sequenceC)
+	sequences, closer := st.db().GetCollection(sequenceC)
 	defer closer()
 	query := sequences.FindId(name)
 	inc := mgo.Change{

--- a/state/settings_test.go
+++ b/state/settings_test.go
@@ -83,7 +83,7 @@ func (s *SettingsSuite) TestUpdateWithWrite(c *gc.C) {
 	var mgoData struct {
 		Settings settingsMap
 	}
-	settings, closer := s.state.getCollection(settingsC)
+	settings, closer := s.state.db().GetCollection(settingsC)
 	defer closer()
 	err = settings.FindId(s.key).One(&mgoData)
 	c.Assert(err, jc.ErrorIsNil)
@@ -168,7 +168,7 @@ func (s *SettingsSuite) TestSetItem(c *gc.C) {
 	var mgoData struct {
 		Settings settingsMap
 	}
-	settings, closer := s.state.getCollection(settingsC)
+	settings, closer := s.state.db().GetCollection(settingsC)
 	defer closer()
 	err = settings.FindId(s.key).One(&mgoData)
 	c.Assert(err, jc.ErrorIsNil)
@@ -196,7 +196,7 @@ func (s *SettingsSuite) TestSetItemEscape(c *gc.C) {
 	var mgoData struct {
 		Settings map[string]interface{}
 	}
-	settings, closer := s.state.getCollection(settingsC)
+	settings, closer := s.state.db().GetCollection(settingsC)
 	defer closer()
 	err = settings.FindId(s.key).One(&mgoData)
 	c.Assert(err, jc.ErrorIsNil)
@@ -236,7 +236,7 @@ func (s *SettingsSuite) TestReplaceSettingsEscape(c *gc.C) {
 	var mgoData struct {
 		Settings map[string]interface{}
 	}
-	settings, closer := s.state.getCollection(settingsC)
+	settings, closer := s.state.db().GetCollection(settingsC)
 	defer closer()
 	err = settings.FindId(s.key).One(&mgoData)
 	c.Assert(err, jc.ErrorIsNil)
@@ -257,7 +257,7 @@ func (s *SettingsSuite) TestcreateSettingsEscape(c *gc.C) {
 	var mgoData struct {
 		Settings map[string]interface{}
 	}
-	settings, closer := s.state.getCollection(settingsC)
+	settings, closer := s.state.db().GetCollection(settingsC)
 	defer closer()
 
 	err = settings.FindId(s.key).One(&mgoData)
@@ -416,7 +416,7 @@ func (s *SettingsSuite) TestMultipleWritesAreStable(c *gc.C) {
 	var mgoData struct {
 		Settings map[string]interface{}
 	}
-	settings, closer := s.state.getCollection(settingsC)
+	settings, closer := s.state.db().GetCollection(settingsC)
 	defer closer()
 	err = settings.FindId(s.key).One(&mgoData)
 	c.Assert(err, jc.ErrorIsNil)

--- a/state/spaces.go
+++ b/state/spaces.go
@@ -57,7 +57,7 @@ func (s *Space) Subnets() (results []*Subnet, err error) {
 	defer errors.DeferredAnnotatef(&err, "cannot fetch subnets")
 	name := s.Name()
 
-	subnetsCollection, closer := s.st.getCollection(subnetsC)
+	subnetsCollection, closer := s.st.db().GetCollection(subnetsC)
 	defer closer()
 
 	var doc subnetDoc
@@ -137,7 +137,7 @@ func (st *State) AddSpace(name string, providerId network.Id, subnets []string, 
 // is returned if the space doesn't exist or if there was a problem accessing
 // its information.
 func (st *State) Space(name string) (*Space, error) {
-	spaces, closer := st.getCollection(spacesC)
+	spaces, closer := st.db().GetCollection(spacesC)
 	defer closer()
 
 	var doc spaceDoc
@@ -153,7 +153,7 @@ func (st *State) Space(name string) (*Space, error) {
 
 // AllSpaces returns all spaces for the model.
 func (st *State) AllSpaces() ([]*Space, error) {
-	spacesCollection, closer := st.getCollection(spacesC)
+	spacesCollection, closer := st.db().GetCollection(spacesC)
 	defer closer()
 
 	docs := []spaceDoc{}
@@ -223,7 +223,7 @@ func (s *Space) Remove() (err error) {
 // returns an error that satisfies errors.IsNotFound if the Space has been
 // removed.
 func (s *Space) Refresh() error {
-	spaces, closer := s.st.getCollection(spacesC)
+	spaces, closer := s.st.db().GetCollection(spacesC)
 	defer closer()
 
 	var doc spaceDoc

--- a/state/sshhostkeys.go
+++ b/state/sshhostkeys.go
@@ -32,7 +32,7 @@ type sshHostKeysDoc struct {
 // NOTE: Currently only machines are supported. This can be
 // generalised to take other tag types later, if and when we need it.
 func (st *State) GetSSHHostKeys(tag names.MachineTag) (SSHHostKeys, error) {
-	coll, closer := st.getCollection(sshHostKeysC)
+	coll, closer := st.db().GetCollection(sshHostKeysC)
 	defer closer()
 
 	var doc sshHostKeysDoc

--- a/state/state.go
+++ b/state/state.go
@@ -260,7 +260,7 @@ func (st *State) removeAllModelDocs(modelAssertion bson.D) error {
 // removeAllInCollectionRaw removes all the documents from the given
 // named collection.
 func (st *State) removeAllInCollectionRaw(name string) error {
-	coll, closer := st.getCollection(name)
+	coll, closer := st.db().GetCollection(name)
 	defer closer()
 	_, err := coll.Writeable().RemoveAll(nil)
 	return errors.Trace(err)
@@ -275,7 +275,7 @@ func (st *State) removeAllInCollectionOps(name string) ([]txn.Op, error) {
 // removeInCollectionOps generates operations to remove all documents
 // from the named collection matching a specific selector.
 func (st *State) removeInCollectionOps(name string, sel interface{}) ([]txn.Op, error) {
-	coll, closer := st.getCollection(name)
+	coll, closer := st.db().GetCollection(name)
 	defer closer()
 
 	var ids []bson.M
@@ -457,7 +457,7 @@ func (st *State) EnsureModelRemoved() error {
 		if info.global {
 			continue
 		}
-		coll, closer := st.getCollection(name)
+		coll, closer := st.db().GetCollection(name)
 		defer closer()
 		n, err := coll.Find(nil).Count()
 		if err != nil {
@@ -591,7 +591,7 @@ func (st *State) checkCanUpgrade(currentVersion, newVersion string) error {
 	}}}
 	var agentTags []string
 	for _, name := range []string{machinesC, unitsC} {
-		collection, closer := st.getCollection(name)
+		collection, closer := st.db().GetCollection(name)
 		defer closer()
 		var doc struct {
 			DocID string `bson:"_id"`
@@ -727,7 +727,7 @@ func (st *State) allMachines(machinesCollection mongo.Collection) ([]*Machine, e
 // AllMachines returns all machines in the model
 // ordered by id.
 func (st *State) AllMachines() ([]*Machine, error) {
-	machinesCollection, closer := st.getCollection(machinesC)
+	machinesCollection, closer := st.db().GetCollection(machinesC)
 	defer closer()
 	return st.allMachines(machinesCollection)
 }
@@ -735,7 +735,7 @@ func (st *State) AllMachines() ([]*Machine, error) {
 // AllMachinesFor returns all machines for the model represented
 // by the given modeluuid
 func (st *State) AllMachinesFor(modelUUID string) ([]*Machine, error) {
-	machinesCollection, closer := st.getCollectionFor(modelUUID, machinesC)
+	machinesCollection, closer := st.db().GetCollectionFor(modelUUID, machinesC)
 	defer closer()
 	return st.allMachines(machinesCollection)
 }
@@ -800,7 +800,7 @@ func (st *State) Machine(id string) (*Machine, error) {
 }
 
 func (st *State) getMachineDoc(id string) (*machineDoc, error) {
-	machinesCollection, closer := st.getCollection(machinesC)
+	machinesCollection, closer := st.db().GetCollection(machinesC)
 	defer closer()
 
 	var err error
@@ -1271,7 +1271,7 @@ func (st *State) AllUnitAssignments() ([]UnitAssignment, error) {
 }
 
 func (st *State) unitAssignments(query bson.D) ([]UnitAssignment, error) {
-	col, close := st.getCollection(assignUnitC)
+	col, close := st.db().GetCollection(assignUnitC)
 	defer close()
 
 	var docs []assignUnitDoc
@@ -1419,7 +1419,7 @@ func (st *State) addMachineWithPlacement(unit *Unit, placement *instance.Placeme
 
 // Application returns a application state by name.
 func (st *State) Application(name string) (_ *Application, err error) {
-	applications, closer := st.getCollection(applicationsC)
+	applications, closer := st.db().GetCollection(applicationsC)
 	defer closer()
 
 	if !names.IsValidApplication(name) {
@@ -1438,7 +1438,7 @@ func (st *State) Application(name string) (_ *Application, err error) {
 
 // AllApplications returns all deployed applications in the model.
 func (st *State) AllApplications() (applications []*Application, err error) {
-	applicationsCollection, closer := st.getCollection(applicationsC)
+	applicationsCollection, closer := st.db().GetCollection(applicationsC)
 	defer closer()
 
 	sdocs := []applicationDoc{}
@@ -1752,7 +1752,7 @@ func (st *State) EndpointsRelation(endpoints ...Endpoint) (*Relation, error) {
 // KeyRelation returns the existing relation with the given key (which can
 // be derived unambiguously from the relation's endpoints).
 func (st *State) KeyRelation(key string) (*Relation, error) {
-	relations, closer := st.getCollection(relationsC)
+	relations, closer := st.db().GetCollection(relationsC)
 	defer closer()
 
 	doc := relationDoc{}
@@ -1768,7 +1768,7 @@ func (st *State) KeyRelation(key string) (*Relation, error) {
 
 // Relation returns the existing relation with the given id.
 func (st *State) Relation(id int) (*Relation, error) {
-	relations, closer := st.getCollection(relationsC)
+	relations, closer := st.db().GetCollection(relationsC)
 	defer closer()
 
 	doc := relationDoc{}
@@ -1784,7 +1784,7 @@ func (st *State) Relation(id int) (*Relation, error) {
 
 // AllRelations returns all relations in the model ordered by id.
 func (st *State) AllRelations() (relations []*Relation, err error) {
-	relationsCollection, closer := st.getCollection(relationsC)
+	relationsCollection, closer := st.db().GetCollection(relationsC)
 	defer closer()
 
 	docs := relationDocSlice{}
@@ -1812,7 +1812,7 @@ func (st *State) Unit(name string) (*Unit, error) {
 	if !names.IsValidUnit(name) {
 		return nil, errors.Errorf("%q is not a valid unit name", name)
 	}
-	units, closer := st.getCollection(unitsC)
+	units, closer := st.db().GetCollection(unitsC)
 	defer closer()
 
 	doc := unitDoc{}
@@ -1976,7 +1976,7 @@ const stateServingInfoKey = "stateServingInfo"
 
 // StateServingInfo returns information for running a controller machine
 func (st *State) StateServingInfo() (StateServingInfo, error) {
-	controllers, closer := st.getCollection(controllersC)
+	controllers, closer := st.db().GetCollection(controllersC)
 	defer closer()
 
 	var info StateServingInfo
@@ -2122,7 +2122,7 @@ func (st *State) networkEntityGlobalKey(globalKey string, providerId network.Id)
 // audit.AuditEntry instances to the database.
 func (st *State) PutAuditEntryFn() func(audit.AuditEntry) error {
 	insert := func(collectionName string, docs ...interface{}) error {
-		collection, closeCollection := st.getCollection(collectionName)
+		collection, closeCollection := st.db().GetCollection(collectionName)
 		defer closeCollection()
 
 		writeableCollection := collection.Writeable()
@@ -2213,22 +2213,4 @@ func (st *State) SetClockForTesting(clock clock.Clock) error {
 		return errors.Trace(err)
 	}
 	return nil
-}
-
-// getCollection delegates to the State's underlying Database.  It
-// returns the collection and a closer function for the session.
-//
-// TODO(mjs) - this should eventually go in favour of using the
-// Database directly.
-func (st *State) getCollection(name string) (mongo.Collection, func()) {
-	return st.database.GetCollection(name)
-}
-
-// getCollectionFor delegates to the State's underlying Database.  It
-// returns the collection and a closer function for the session.
-//
-// TODO(mjs) - this should eventually go in favour of using the
-// Database directly.
-func (st *State) getCollectionFor(modelUUID, name string) (mongo.Collection, func()) {
-	return st.database.GetCollectionFor(modelUUID, name)
 }

--- a/state/status.go
+++ b/state/status.go
@@ -51,7 +51,7 @@ func unixNanoToTime(i int64) *time.Time {
 // is not found, a NotFoundError referencing badge will be returned.
 func getStatus(st *State, globalKey, badge string) (_ status.StatusInfo, err error) {
 	defer errors.DeferredAnnotatef(&err, "cannot get status")
-	statuses, closer := st.getCollection(statusesC)
+	statuses, closer := st.db().GetCollection(statusesC)
 	defer closer()
 
 	var doc statusDoc
@@ -183,7 +183,7 @@ func probablyUpdateStatusHistory(st *State, globalKey string, doc statusDoc) {
 		Updated:    doc.Updated,
 		GlobalKey:  globalKey,
 	}
-	history, closer := st.getCollection(statusesHistoryC)
+	history, closer := st.db().GetCollection(statusesHistoryC)
 	defer closer()
 	historyW := history.Writeable()
 	if err := historyW.Insert(historyDoc); err != nil {
@@ -241,7 +241,7 @@ func statusHistory(args *statusHistoryArgs) ([]status.StatusInfo, error) {
 	if err := args.filter.Validate(); err != nil {
 		return nil, errors.Annotate(err, "validating arguments")
 	}
-	statusHistory, closer := args.st.getCollection(statusesHistoryC)
+	statusHistory, closer := args.st.db().GetCollection(statusesHistoryC)
 	defer closer()
 
 	var results []status.StatusInfo

--- a/state/storage.go
+++ b/state/storage.go
@@ -213,7 +213,7 @@ func (st *State) StorageInstance(tag names.StorageTag) (StorageInstance, error) 
 }
 
 func (st *State) storageInstance(tag names.StorageTag) (*storageInstance, error) {
-	storageInstances, cleanup := st.getCollection(storageInstancesC)
+	storageInstances, cleanup := st.db().GetCollection(storageInstancesC)
 	defer cleanup()
 
 	s := storageInstance{st: st}
@@ -229,7 +229,7 @@ func (st *State) storageInstance(tag names.StorageTag) (*storageInstance, error)
 // AllStorageInstances lists all storage instances currently in state
 // for this Juju model.
 func (st *State) AllStorageInstances() (storageInstances []StorageInstance, err error) {
-	storageCollection, closer := st.getCollection(storageInstancesC)
+	storageCollection, closer := st.db().GetCollection(storageInstancesC)
 	defer closer()
 
 	sdocs := []storageInstanceDoc{}
@@ -495,7 +495,7 @@ func validateStorageCountChange(
 // should be called when creating a shared storage instance, or when
 // attaching a non-shared storage instance to a unit.
 func increfEntityStorageOp(st *State, owner names.Tag, storageName string, n int) (txn.Op, error) {
-	refcounts, closer := st.getCollection(refcountsC)
+	refcounts, closer := st.db().GetCollection(refcountsC)
 	defer closer()
 	storageRefcountKey := entityStorageRefcountKey(owner, storageName)
 	incRefOp, err := nsRefcounts.CreateOrIncRefOp(refcounts, storageRefcountKey, n)
@@ -507,7 +507,7 @@ func increfEntityStorageOp(st *State, owner names.Tag, storageName string, n int
 // should be called when removing a shared storage instance, or when
 // detaching a non-shared storage instance from a unit.
 func decrefEntityStorageOp(st *State, owner names.Tag, storageName string) (txn.Op, error) {
-	refcounts, closer := st.getCollection(refcountsC)
+	refcounts, closer := st.db().GetCollection(refcountsC)
 	defer closer()
 	storageRefcountKey := entityStorageRefcountKey(owner, storageName)
 	decRefOp, _, err := nsRefcounts.DyingDecRefOp(refcounts, storageRefcountKey)
@@ -759,7 +759,7 @@ func (st *State) UnitStorageAttachments(unit names.UnitTag) ([]StorageAttachment
 }
 
 func (st *State) storageAttachments(query bson.D) ([]StorageAttachment, error) {
-	coll, closer := st.getCollection(storageAttachmentsC)
+	coll, closer := st.db().GetCollection(storageAttachmentsC)
 	defer closer()
 
 	var docs []storageAttachmentDoc
@@ -783,7 +783,7 @@ func (st *State) StorageAttachment(storage names.StorageTag, unit names.UnitTag)
 }
 
 func (st *State) storageAttachment(storage names.StorageTag, unit names.UnitTag) (*storageAttachment, error) {
-	coll, closer := st.getCollection(storageAttachmentsC)
+	coll, closer := st.db().GetCollection(storageAttachmentsC)
 	defer closer()
 	var s storageAttachment
 	err := coll.FindId(storageAttachmentId(unit.Id(), storage.Id())).One(&s.doc)
@@ -1116,7 +1116,7 @@ func (st *State) detachStorageMachineAttachmentOps(si *storageInstance, unitTag 
 // removeStorageInstancesOps returns the transaction operations to remove all
 // storage instances owned by the specified entity.
 func removeStorageInstancesOps(st *State, owner names.Tag) ([]txn.Op, error) {
-	coll, closer := st.getCollection(storageInstancesC)
+	coll, closer := st.db().GetCollection(storageInstancesC)
 	defer closer()
 
 	var docs []storageInstanceDoc
@@ -1186,7 +1186,7 @@ func removeStorageConstraintsOp(key string) txn.Op {
 }
 
 func readStorageConstraints(st *State, key string) (map[string]StorageConstraints, error) {
-	coll, closer := st.getCollection(storageConstraintsC)
+	coll, closer := st.db().GetCollection(storageConstraintsC)
 	defer closer()
 
 	var doc storageConstraintsDoc
@@ -1652,7 +1652,7 @@ func (st *State) addUnitStorageOps(
 }
 
 func (st *State) countEntityStorageInstances(owner names.Tag, name string) (txn.Op, int, error) {
-	refcounts, closer := st.getCollection(refcountsC)
+	refcounts, closer := st.db().GetCollection(refcountsC)
 	defer closer()
 	key := entityStorageRefcountKey(owner, name)
 	return nsRefcounts.CurrentOp(refcounts, key)

--- a/state/subnets.go
+++ b/state/subnets.go
@@ -189,7 +189,7 @@ func (s *Subnet) Validate() error {
 // state. It an error that satisfies errors.IsNotFound if the Subnet has
 // been removed.
 func (s *Subnet) Refresh() error {
-	subnets, closer := s.st.getCollection(subnetsC)
+	subnets, closer := s.st.db().GetCollection(subnetsC)
 	defer closer()
 
 	err := subnets.FindId(s.doc.DocID).One(&s.doc)
@@ -287,7 +287,7 @@ func (st *State) addSubnetOps(args SubnetInfo) []txn.Op {
 
 // Subnet returns the subnet specified by the cidr.
 func (st *State) Subnet(cidr string) (*Subnet, error) {
-	subnets, closer := st.getCollection(subnetsC)
+	subnets, closer := st.db().GetCollection(subnetsC)
 	defer closer()
 
 	doc := &subnetDoc{}
@@ -303,7 +303,7 @@ func (st *State) Subnet(cidr string) (*Subnet, error) {
 
 // AllSubnets returns all known subnets in the model.
 func (st *State) AllSubnets() (subnets []*Subnet, err error) {
-	subnetsCollection, closer := st.getCollection(subnetsC)
+	subnetsCollection, closer := st.db().GetCollection(subnetsC)
 	defer closer()
 
 	docs := []subnetDoc{}

--- a/state/unit.go
+++ b/state/unit.go
@@ -346,7 +346,7 @@ func (u *Unit) Destroy() (err error) {
 }
 
 func (u *Unit) eraseHistory() error {
-	history, closer := u.st.getCollection(statusesHistoryC)
+	history, closer := u.st.db().GetCollection(statusesHistoryC)
 	defer closer()
 	historyW := history.Writeable()
 
@@ -807,7 +807,7 @@ func (u *Unit) AvailabilityZone() (string, error) {
 // state. It an error that satisfies errors.IsNotFound if the unit has
 // been removed.
 func (u *Unit) Refresh() error {
-	units, closer := u.st.getCollection(unitsC)
+	units, closer := u.st.db().GetCollection(unitsC)
 	defer closer()
 
 	err := units.FindId(u.doc.DocID).One(&u.doc)
@@ -1253,7 +1253,7 @@ func (u *Unit) AssignedMachineId() (id string, err error) {
 		return u.doc.MachineId, nil
 	}
 
-	units, closer := u.st.getCollection(unitsC)
+	units, closer := u.st.db().GetCollection(unitsC)
 	defer closer()
 
 	pudoc := unitDoc{}
@@ -1660,7 +1660,7 @@ func (u *Unit) AssignToNewMachineOrContainer() (err error) {
 	if err != nil {
 		return err
 	}
-	machinesCollection, closer := u.st.getCollection(machinesC)
+	machinesCollection, closer := u.st.db().GetCollection(machinesC)
 	defer closer()
 	var host machineDoc
 	if err := machinesCollection.Find(query).One(&host); err == mgo.ErrNotFound {
@@ -2130,7 +2130,7 @@ func (u *Unit) assignToCleanMaybeEmptyMachineOps(requireEmpty bool) (_ *Machine,
 	// instances for those that are provisioned. Instances
 	// will be distributed across in preference to
 	// unprovisioned machines.
-	machinesCollection, closer := u.st.getCollection(machinesC)
+	machinesCollection, closer := u.st.db().GetCollection(machinesC)
 	defer closer()
 	var mdocs []*machineDoc
 	if err := machinesCollection.Find(query).All(&mdocs); err != nil {

--- a/state/upgrade.go
+++ b/state/upgrade.go
@@ -541,7 +541,7 @@ func (st *State) AbortCurrentUpgrade() error {
 
 func currentUpgradeInfoDoc(st *State) (*upgradeInfoDoc, error) {
 	var doc upgradeInfoDoc
-	upgradeInfo, closer := st.getCollection(upgradeInfoC)
+	upgradeInfo, closer := st.db().GetCollection(upgradeInfoC)
 	defer closer()
 	if err := upgradeInfo.FindId(currentUpgradeId).One(&doc); err == mgo.ErrNotFound {
 		return nil, errors.NotFoundf("current upgrade info")

--- a/state/upgrades.go
+++ b/state/upgrades.go
@@ -25,7 +25,7 @@ var upgradesLogger = loggo.GetLogger("juju.state.upgrade")
 // runForAllModelStates will run runner function for every model passing a state
 // for that model.
 func runForAllModelStates(st *State, runner func(st *State) error) error {
-	models, closer := st.getCollection(modelsC)
+	models, closer := st.db().GetCollection(modelsC)
 	defer closer()
 
 	var modelDocs []bson.M

--- a/state/user.go
+++ b/state/user.go
@@ -32,7 +32,7 @@ func userGlobalKey(userID string) string {
 }
 
 func (st *State) checkUserExists(name string) (bool, error) {
-	users, closer := st.getCollection(usersC)
+	users, closer := st.db().GetCollection(usersC)
 	defer closer()
 
 	var count int
@@ -185,7 +185,7 @@ func createInitialUserOps(controllerUUID string, user names.UserTag, password, s
 // getUser fetches information about the user with the
 // given name into the provided userDoc.
 func (st *State) getUser(name string, udoc *userDoc) error {
-	users, closer := st.getCollection(usersC)
+	users, closer := st.db().GetCollection(usersC)
 	defer closer()
 
 	name = strings.ToLower(name)
@@ -224,7 +224,7 @@ func (st *State) User(tag names.UserTag) (*User, error) {
 func (st *State) AllUsers(includeDeactivated bool) ([]*User, error) {
 	var result []*User
 
-	users, closer := st.getCollection(usersC)
+	users, closer := st.db().GetCollection(usersC)
 	defer closer()
 
 	var query bson.D
@@ -379,7 +379,7 @@ func (u *User) UpdateLastLogin() (err error) {
 	if err := u.ensureNotDeleted(); err != nil {
 		return errors.Annotate(err, "cannot update last login")
 	}
-	lastLogins, closer := u.st.getCollection(userLastLoginC)
+	lastLogins, closer := u.st.db().GetCollection(userLastLoginC)
 	defer closer()
 
 	lastLoginsW := lastLogins.Writeable()

--- a/state/userpermission.go
+++ b/state/userpermission.go
@@ -42,7 +42,7 @@ func accessToString(a permission.Access) string {
 // userPermission returns a Permission for the given Subject and User.
 func (st *State) userPermission(objectGlobalKey, subjectGlobalKey string) (*userPermission, error) {
 	result := &userPermission{}
-	permissions, closer := st.getCollection(permissionsC)
+	permissions, closer := st.db().GetCollection(permissionsC)
 	defer closer()
 
 	id := permissionID(objectGlobalKey, subjectGlobalKey)
@@ -57,7 +57,7 @@ func (st *State) userPermission(objectGlobalKey, subjectGlobalKey string) (*user
 func (st *State) controllerUserPermission(objectGlobalKey, subjectGlobalKey string) (*userPermission, error) {
 	result := &userPermission{}
 
-	permissions, closer := st.getCollection(permissionsC)
+	permissions, closer := st.db().GetCollection(permissionsC)
 	defer closer()
 
 	id := permissionID(objectGlobalKey, subjectGlobalKey)

--- a/state/volume.go
+++ b/state/volume.go
@@ -241,7 +241,7 @@ func (st *State) Volume(tag names.VolumeTag) (Volume, error) {
 }
 
 func (st *State) volumes(query interface{}) ([]*volume, error) {
-	coll, cleanup := st.getCollection(volumesC)
+	coll, cleanup := st.db().GetCollection(volumesC)
 	defer cleanup()
 
 	var docs []volumeDoc
@@ -302,7 +302,7 @@ func (st *State) StorageInstanceVolume(tag names.StorageTag) (Volume, error) {
 // VolumeAttachment returns the VolumeAttachment corresponding to
 // the specified volume and machine.
 func (st *State) VolumeAttachment(machine names.MachineTag, volume names.VolumeTag) (VolumeAttachment, error) {
-	coll, cleanup := st.getCollection(volumeAttachmentsC)
+	coll, cleanup := st.db().GetCollection(volumeAttachmentsC)
 	defer cleanup()
 
 	var att volumeAttachment
@@ -336,7 +336,7 @@ func (st *State) VolumeAttachments(volume names.VolumeTag) ([]VolumeAttachment, 
 }
 
 func (st *State) volumeAttachments(query bson.D) ([]VolumeAttachment, error) {
-	coll, cleanup := st.getCollection(volumeAttachmentsC)
+	coll, cleanup := st.db().GetCollection(volumeAttachmentsC)
 	defer cleanup()
 
 	var docs []volumeAttachmentDoc


### PR DESCRIPTION
This removes unnecessary indirection and makes it easier to refactor
code to take a modelBackend interface.

No functional change.