### PR TITLE
Fix catacomb worker leak.

### DIFF
--- a/worker/catacomb/catacomb.go
+++ b/worker/catacomb/catacomb.go
@@ -167,17 +167,23 @@ func (catacomb *Catacomb) add(w worker.Worker) {
 	// We must wait for _both_ goroutines to exit in
 	// arbitrary order depending on the order of the worker
 	// and the catacomb shutting down.
+	workerDone := make(chan struct{})
 	catacomb.wg.Add(2)
 	go func() {
 		defer catacomb.wg.Done()
+		defer close(workerDone)
 		if err := w.Wait(); err != nil {
 			catacomb.Kill(err)
 		}
 	}()
 	go func() {
 		defer catacomb.wg.Done()
-		<-catacomb.tomb.Dying()
-		worker.Stop(w)
+		select {
+		case <-catacomb.tomb.Dying():
+			worker.Stop(w)
+		case <-workerDone:
+			// Exit the go routine to release the worker's memory.
+		}
 	}()
 }
 


### PR DESCRIPTION
Make sure we release the worker resources when it finishes before the catacomb.

The second goroutine would wait for the catacomb to die, and then call worker.Stop.
However this meant that if the worker stopped of its own volition before the catacomb
was done, the worker memory would never be cleaned up.

## Documentation changes

None
