### PR TITLE
cmd/cmdtesting: rename from cmd/testing

### DIFF
--- a/apiserver/common/modelwatcher_test.go
+++ b/apiserver/common/modelwatcher_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/params"
 	apiservertesting "github.com/juju/juju/apiserver/testing"
+	"github.com/juju/juju/cmd/cmdtesting"
 	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/environs/bootstrap"
 	"github.com/juju/juju/environs/config"
@@ -101,7 +102,7 @@ func (*environWatcherSuite) TestModelConfigFetchError(c *gc.C) {
 
 func testingEnvConfig(c *gc.C) *config.Config {
 	env, err := bootstrap.Prepare(
-		modelcmd.BootstrapContext(testing.Context(c)),
+		modelcmd.BootstrapContext(cmdtesting.Context(c)),
 		jujuclient.NewMemStore(),
 		bootstrap.PrepareParams{
 			ControllerConfig: testing.FakeControllerConfig(),

--- a/cmd/cmdtesting/cmd.go
+++ b/cmd/cmdtesting/cmd.go
@@ -1,7 +1,7 @@
 // Copyright 2013 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package testing
+package cmdtesting
 
 import (
 	"bytes"

--- a/cmd/cmdtesting/package_test.go
+++ b/cmd/cmdtesting/package_test.go
@@ -1,7 +1,7 @@
 // Copyright 2016 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package testing_test
+package cmdtesting_test
 
 import (
 	"testing"

--- a/cmd/cmdtesting/prompt.go
+++ b/cmd/cmdtesting/prompt.go
@@ -1,7 +1,7 @@
 // Copyright 2016 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package testing
+package cmdtesting
 
 import (
 	"io"

--- a/cmd/cmdtesting/prompt_test.go
+++ b/cmd/cmdtesting/prompt_test.go
@@ -1,7 +1,7 @@
 // Copyright 2016 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package testing_test
+package cmdtesting_test
 
 import (
 	"fmt"
@@ -14,7 +14,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
-	cmdtesting "github.com/juju/juju/cmd/testing"
+	"github.com/juju/juju/cmd/cmdtesting"
 )
 
 type prompterSuite struct {

--- a/cmd/cmdtesting/testing.go
+++ b/cmd/cmdtesting/testing.go
@@ -1,41 +1,20 @@
 // Copyright 2014 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package testing
+package cmdtesting
 
 import (
 	"bytes"
-	"flag"
 	"fmt"
 	"io"
-	"os"
-	"os/exec"
 
 	"github.com/juju/cmd"
 	"github.com/juju/gnuflag"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
-	"github.com/juju/juju/juju/osenv"
 	"github.com/juju/juju/provider/dummy"
-	coretesting "github.com/juju/juju/testing"
 )
-
-// FlagRunMain is used to indicate that the -run-main flag was used.
-var FlagRunMain = flag.Bool("run-main", false, "Run the application's main function for recursive testing")
-
-// BadRun is used to run a command, check the exit code, and return the output.
-func BadRun(c *gc.C, exit int, args ...string) string {
-	localArgs := append([]string{"-test.run", "TestRunMain", "-run-main", "--"}, args...)
-	ps := exec.Command(os.Args[0], localArgs...)
-	ps.Env = append(os.Environ(), osenv.JujuXDGDataHomeEnvKey+"="+osenv.JujuXDGDataHome())
-	output, err := ps.CombinedOutput()
-	c.Logf("command output: %q", output)
-	if exit != 0 {
-		c.Assert(err, gc.ErrorMatches, fmt.Sprintf("exit status %d", exit))
-	}
-	return string(output)
-}
 
 // HelpText returns a command's formatted help text.
 func HelpText(command cmd.Command, name string) string {
@@ -73,9 +52,9 @@ func NullContext(c *gc.C) *cmd.Context {
 	return ctx
 }
 
-// RunCommand runs the command and returns channels holding the
+// RunCommandWithDummyProvider runs the command and returns channels holding the
 // command's operations and errors.
-func RunCommand(ctx *cmd.Context, com cmd.Command, args ...string) (opc chan dummy.Operation, errc chan error) {
+func RunCommandWithDummyProvider(ctx *cmd.Context, com cmd.Command, args ...string) (opc chan dummy.Operation, errc chan error) {
 	if ctx == nil {
 		panic("ctx == nil")
 	}
@@ -92,7 +71,7 @@ func RunCommand(ctx *cmd.Context, com cmd.Command, args ...string) (opc chan dum
 			close(opc)
 		}()
 
-		if err := coretesting.InitCommand(com, args); err != nil {
+		if err := InitCommand(com, args); err != nil {
 			errc <- err
 			return
 		}

--- a/cmd/juju/action/list_test.go
+++ b/cmd/juju/action/list_test.go
@@ -15,9 +15,9 @@ import (
 	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/cmd/cmdtesting"
 	"github.com/juju/juju/cmd/juju/action"
 	"github.com/juju/juju/state"
-	"github.com/juju/juju/testing"
 )
 
 type ListSuite struct {
@@ -74,7 +74,7 @@ func (s *ListSuite) TestInit(c *gc.C) {
 				t.should, strings.Join(t.args, " "))
 			s.wrappedCommand, s.command = action.NewListCommandForTest(s.store)
 			args := append([]string{modelFlag, "admin"}, t.args...)
-			err := testing.InitCommand(s.wrappedCommand, args)
+			err := cmdtesting.InitCommand(s.wrappedCommand, args)
 			if t.expectedErr == "" {
 				c.Check(err, jc.ErrorIsNil)
 				c.Check(s.command.ApplicationTag(), gc.Equals, t.expectedSvc)
@@ -140,7 +140,7 @@ snapshot        Take a snapshot of the database.
 
 				args := append([]string{modelFlag, "admin"}, t.withArgs...)
 				s.wrappedCommand, s.command = action.NewListCommandForTest(s.store)
-				ctx, err := testing.RunCommand(c, s.wrappedCommand, args...)
+				ctx, err := cmdtesting.RunCommand(c, s.wrappedCommand, args...)
 
 				if t.expectedErr != "" || t.withAPIErr != "" {
 					c.Check(err, gc.ErrorMatches, t.expectedErr)
@@ -150,9 +150,9 @@ snapshot        Take a snapshot of the database.
 					if t.expectFullSchema {
 						checkFullSchema(c, t.withCharmActions, result)
 					} else if t.expectNoResults {
-						c.Check(testing.Stderr(ctx), gc.Matches, t.expectMessage)
+						c.Check(cmdtesting.Stderr(ctx), gc.Matches, t.expectMessage)
 					} else {
-						c.Check(testing.Stdout(ctx), gc.Equals, simpleOutput)
+						c.Check(cmdtesting.Stdout(ctx), gc.Equals, simpleOutput)
 					}
 				}
 

--- a/cmd/juju/action/package_test.go
+++ b/cmd/juju/action/package_test.go
@@ -15,6 +15,7 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/cmd/cmdtesting"
 	"github.com/juju/juju/cmd/juju/action"
 	"github.com/juju/juju/jujuclient"
 	coretesting "github.com/juju/juju/testing"
@@ -109,7 +110,7 @@ func tagsForIdPrefix(prefix string, tags ...string) params.FindTagsResults {
 // setupValueFile creates a file containing one value for testing.
 // cf. cmd/juju/set_test.go
 func setupValueFile(c *gc.C, dir, filename, value string) string {
-	ctx := coretesting.ContextForDir(c, dir)
+	ctx := cmdtesting.ContextForDir(c, dir)
 	path := ctx.AbsPath(filename)
 	content := []byte(value)
 	err := ioutil.WriteFile(path, content, 0666)

--- a/cmd/juju/action/run_test.go
+++ b/cmd/juju/action/run_test.go
@@ -17,8 +17,8 @@ import (
 
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/cmd/cmdtesting"
 	"github.com/juju/juju/cmd/juju/action"
-	"github.com/juju/juju/testing"
 )
 
 var (
@@ -166,7 +166,7 @@ func (s *RunSuite) TestInit(c *gc.C) {
 			c.Logf("test %d: should %s:\n$ juju run-action %s\n", i,
 				t.should, strings.Join(t.args, " "))
 			args := append([]string{modelFlag, "admin"}, t.args...)
-			err := testing.InitCommand(wrappedCommand, args)
+			err := cmdtesting.InitCommand(wrappedCommand, args)
 			if t.expectError == "" {
 				c.Check(command.UnitTag(), gc.Equals, t.expectUnit)
 				c.Check(command.ActionName(), gc.Equals, t.expectAction)
@@ -367,7 +367,7 @@ func (s *RunSuite) TestRun(c *gc.C) {
 
 				wrappedCommand, _ := action.NewRunCommandForTest(s.store)
 				args := append([]string{modelFlag, "admin"}, t.withArgs...)
-				ctx, err := testing.RunCommand(c, wrappedCommand, args...)
+				ctx, err := cmdtesting.RunCommand(c, wrappedCommand, args...)
 
 				if t.expectedErr != "" || t.withAPIErr != "" {
 					c.Check(err, gc.ErrorMatches, t.expectedErr)

--- a/cmd/juju/action/showoutput_test.go
+++ b/cmd/juju/action/showoutput_test.go
@@ -13,8 +13,8 @@ import (
 
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/cmd/cmdtesting"
 	"github.com/juju/juju/cmd/juju/action"
-	"github.com/juju/juju/testing"
 )
 
 type ShowOutputSuite struct {
@@ -48,7 +48,7 @@ func (s *ShowOutputSuite) TestInit(c *gc.C) {
 				t.should, strings.Join(t.args, " "))
 			cmd, _ := action.NewShowOutputCommandForTest(s.store)
 			args := append([]string{modelFlag, "admin"}, t.args...)
-			err := testing.InitCommand(cmd, args)
+			err := cmdtesting.InitCommand(cmd, args)
 			if t.expectError != "" {
 				c.Check(err, gc.ErrorMatches, t.expectError)
 			}
@@ -298,7 +298,7 @@ func testRunHelper(c *gc.C, s *ShowOutputSuite, client *fakeAPIClient, expectedE
 		args = append(args, "--wait", wait)
 	}
 	cmd, _ := action.NewShowOutputCommandForTest(s.store)
-	ctx, err := testing.RunCommand(c, cmd, args...)
+	ctx, err := cmdtesting.RunCommand(c, cmd, args...)
 	if expectedErr != "" {
 		c.Check(err, gc.ErrorMatches, expectedErr)
 	} else {

--- a/cmd/juju/action/status_test.go
+++ b/cmd/juju/action/status_test.go
@@ -12,8 +12,8 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/cmd/cmdtesting"
 	"github.com/juju/juju/cmd/juju/action"
-	"github.com/juju/juju/testing"
 )
 
 type StatusSuite struct {
@@ -106,7 +106,7 @@ func (s *StatusSuite) runTestCase(c *gc.C, tc statusTestCase) {
 
 		s.subcommand, _ = action.NewStatusCommandForTest(s.store)
 		args := append([]string{modelFlag, "admin"}, tc.args...)
-		ctx, err := testing.RunCommand(c, s.subcommand, args...)
+		ctx, err := cmdtesting.RunCommand(c, s.subcommand, args...)
 		if tc.expectError == "" {
 			c.Assert(err, jc.ErrorIsNil)
 		} else {

--- a/cmd/juju/application/addrelation_test.go
+++ b/cmd/juju/application/addrelation_test.go
@@ -13,7 +13,8 @@ import (
 
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/params"
-	coretesting "github.com/juju/juju/testing"
+	"github.com/juju/juju/cmd/cmdtesting"
+	jtesting "github.com/juju/juju/testing"
 )
 
 type AddRelationSuite struct {
@@ -34,7 +35,7 @@ func (s *AddRelationSuite) SetUpTest(c *gc.C) {
 var _ = gc.Suite(&AddRelationSuite{})
 
 func (s *AddRelationSuite) runAddRelation(c *gc.C, args ...string) error {
-	_, err := coretesting.RunCommand(c, NewAddRelationCommandForTest(s.mockAPI), args...)
+	_, err := cmdtesting.RunCommand(c, NewAddRelationCommandForTest(s.mockAPI), args...)
 	return err
 }
 
@@ -71,7 +72,7 @@ func (s *AddRelationSuite) TestAddRelationFail(c *gc.C) {
 func (s *AddRelationSuite) TestAddRelationBlocked(c *gc.C) {
 	s.mockAPI.SetErrors(common.OperationBlockedError("TestBlockAddRelation"))
 	err := s.runAddRelation(c, "application1", "application2")
-	coretesting.AssertOperationWasBlocked(c, err, ".*TestBlockAddRelation.*")
+	jtesting.AssertOperationWasBlocked(c, err, ".*TestBlockAddRelation.*")
 	s.mockAPI.CheckCall(c, 0, "AddRelation", []string{"application1", "application2"})
 	s.mockAPI.CheckCall(c, 1, "Close")
 }
@@ -81,8 +82,8 @@ func (s *AddRelationSuite) TestAddRelationUnauthorizedMentionsJujuGrant(c *gc.C)
 		Message: "permission denied",
 		Code:    params.CodeUnauthorized,
 	})
-	ctx, _ := coretesting.RunCommand(c, NewAddRelationCommandForTest(s.mockAPI), "application1", "application2")
-	errString := strings.Replace(coretesting.Stderr(ctx), "\n", " ", -1)
+	ctx, _ := cmdtesting.RunCommand(c, NewAddRelationCommandForTest(s.mockAPI), "application1", "application2")
+	errString := strings.Replace(cmdtesting.Stderr(ctx), "\n", " ", -1)
 	c.Assert(errString, gc.Matches, `.*juju grant.*`)
 }
 

--- a/cmd/juju/application/addremoterelation_test.go
+++ b/cmd/juju/application/addremoterelation_test.go
@@ -12,10 +12,10 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/cmd/cmdtesting"
 	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/feature"
 	jujutesting "github.com/juju/juju/juju/testing"
-	"github.com/juju/juju/testing"
 )
 
 const endpointSeparator = ":"
@@ -69,7 +69,7 @@ func (s *AddRemoteRelationSuiteNewAPI) TestAddRelationClientRetrievalFailure(c *
 		return nil, errors.New(msg)
 	}
 
-	_, err := testing.RunCommand(c, modelcmd.Wrap(addRelationCmd), "othermodel.applicationname2", "applicationname")
+	_, err := cmdtesting.RunCommand(c, modelcmd.Wrap(addRelationCmd), "othermodel.applicationname2", "applicationname")
 	c.Assert(err, gc.ErrorMatches, msg)
 }
 
@@ -166,7 +166,7 @@ func (s *baseAddRemoteRelationSuite) runAddRelation(c *gc.C, args ...string) err
 	addRelationCmd.newAPIFunc = func() (ApplicationAddRelationAPI, error) {
 		return s.mockAPI, nil
 	}
-	_, err := testing.RunCommand(c, modelcmd.Wrap(addRelationCmd), args...)
+	_, err := cmdtesting.RunCommand(c, modelcmd.Wrap(addRelationCmd), args...)
 	return err
 }
 

--- a/cmd/juju/application/addunit_test.go
+++ b/cmd/juju/application/addunit_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/cmd/cmdtesting"
 	"github.com/juju/juju/cmd/juju/application"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/instance"
@@ -90,13 +91,13 @@ var initAddUnitErrorTests = []struct {
 func (s *AddUnitSuite) TestInitErrors(c *gc.C) {
 	for i, t := range initAddUnitErrorTests {
 		c.Logf("test %d", i)
-		err := testing.InitCommand(application.NewAddUnitCommandForTest(s.fake), t.args)
+		err := cmdtesting.InitCommand(application.NewAddUnitCommandForTest(s.fake), t.args)
 		c.Check(err, gc.ErrorMatches, t.err)
 	}
 }
 
 func (s *AddUnitSuite) runAddUnit(c *gc.C, args ...string) error {
-	_, err := testing.RunCommand(c, application.NewAddUnitCommandForTest(s.fake), args...)
+	_, err := cmdtesting.RunCommand(c, application.NewAddUnitCommandForTest(s.fake), args...)
 	return err
 }
 
@@ -141,8 +142,8 @@ func (s *AddUnitSuite) TestUnauthorizedMentionsJujuGrant(c *gc.C) {
 		Message: "permission denied",
 		Code:    params.CodeUnauthorized,
 	}
-	ctx, _ := testing.RunCommand(c, application.NewAddUnitCommandForTest(s.fake), "some-application-name")
-	errString := strings.Replace(testing.Stderr(ctx), "\n", " ", -1)
+	ctx, _ := cmdtesting.RunCommand(c, application.NewAddUnitCommandForTest(s.fake), "some-application-name")
+	errString := strings.Replace(cmdtesting.Stderr(ctx), "\n", " ", -1)
 	c.Assert(errString, gc.Matches, `.*juju grant.*`)
 }
 

--- a/cmd/juju/application/bundle_test.go
+++ b/cmd/juju/application/bundle_test.go
@@ -17,6 +17,7 @@ import (
 	"gopkg.in/juju/charmrepo.v2-unstable/csclient"
 
 	"github.com/juju/juju/api"
+	"github.com/juju/juju/cmd/cmdtesting"
 	"github.com/juju/juju/constraints"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/multiwatcher"
@@ -34,8 +35,8 @@ import (
 // charm or bundle. The deployment output and error are returned.
 func runDeployCommand(c *gc.C, id string, args ...string) (string, error) {
 	args = append([]string{id}, args...)
-	ctx, err := coretesting.RunCommand(c, NewDefaultDeployCommand(), args...)
-	return strings.Trim(coretesting.Stderr(ctx), "\n"), err
+	ctx, err := cmdtesting.RunCommand(c, NewDefaultDeployCommand(), args...)
+	return strings.Trim(cmdtesting.Stderr(ctx), "\n"), err
 }
 
 func (s *BundleDeployCharmStoreSuite) TestDeployBundleNotFoundCharmStore(c *gc.C) {

--- a/cmd/juju/application/cmd_test.go
+++ b/cmd/juju/application/cmd_test.go
@@ -10,6 +10,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/cmd/cmdtesting"
 	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/jujuclient"
 	coretesting "github.com/juju/juju/testing"
@@ -60,7 +61,7 @@ func initExpectations(com *DeployCommand, store jujuclient.ClientStore) {
 func initDeployCommand(store jujuclient.ClientStore, args ...string) (*DeployCommand, error) {
 	com := &DeployCommand{}
 	com.SetClientStore(store)
-	return com, coretesting.InitCommand(modelcmd.Wrap(com), args)
+	return com, cmdtesting.InitCommand(modelcmd.Wrap(com), args)
 }
 
 func (s *CmdSuite) TestDeployCommandInit(c *gc.C) {
@@ -77,7 +78,7 @@ func (s *CmdSuite) TestDeployCommandInit(c *gc.C) {
 	}
 
 	// test relative --config path
-	ctx := coretesting.Context(c)
+	ctx := cmdtesting.Context(c)
 	expected := []byte("test: data")
 	path := ctx.AbsPath("testconfig.yaml")
 	file, err := os.Create(path)
@@ -107,7 +108,7 @@ func (s *CmdSuite) TestDeployCommandInit(c *gc.C) {
 
 func initExposeCommand(args ...string) (*exposeCommand, error) {
 	com := &exposeCommand{}
-	return com, coretesting.InitCommand(modelcmd.Wrap(com), args)
+	return com, cmdtesting.InitCommand(modelcmd.Wrap(com), args)
 }
 
 func (*CmdSuite) TestExposeCommandInit(c *gc.C) {
@@ -120,7 +121,7 @@ func (*CmdSuite) TestExposeCommandInit(c *gc.C) {
 
 func initUnexposeCommand(args ...string) (*unexposeCommand, error) {
 	com := &unexposeCommand{}
-	return com, coretesting.InitCommand(modelcmd.Wrap(com), args)
+	return com, cmdtesting.InitCommand(modelcmd.Wrap(com), args)
 }
 
 func (*CmdSuite) TestUnexposeCommandInit(c *gc.C) {
@@ -133,7 +134,7 @@ func (*CmdSuite) TestUnexposeCommandInit(c *gc.C) {
 
 func initRemoveUnitCommand(args ...string) (cmd.Command, error) {
 	com := NewRemoveUnitCommand()
-	return com, coretesting.InitCommand(com, args)
+	return com, cmdtesting.InitCommand(com, args)
 }
 
 func (*CmdSuite) TestRemoveUnitCommandInit(c *gc.C) {

--- a/cmd/juju/application/config_test.go
+++ b/cmd/juju/application/config_test.go
@@ -16,6 +16,7 @@ import (
 	goyaml "gopkg.in/yaml.v2"
 
 	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/cmd/cmdtesting"
 	"github.com/juju/juju/cmd/juju/application"
 	coretesting "github.com/juju/juju/testing"
 )
@@ -91,25 +92,25 @@ func (s *configCommandSuite) SetUpTest(c *gc.C) {
 
 func (s *configCommandSuite) TestGetCommandInit(c *gc.C) {
 	// missing args
-	err := coretesting.InitCommand(application.NewConfigCommandForTest(s.fake), []string{})
+	err := cmdtesting.InitCommand(application.NewConfigCommandForTest(s.fake), []string{})
 	c.Assert(err, gc.ErrorMatches, "no application name specified")
 }
 
 func (s *configCommandSuite) TestGetCommandInitWithApplication(c *gc.C) {
-	err := coretesting.InitCommand(application.NewConfigCommandForTest(s.fake), []string{"app"})
+	err := cmdtesting.InitCommand(application.NewConfigCommandForTest(s.fake), []string{"app"})
 	// everything ok
 	c.Assert(err, jc.ErrorIsNil)
 }
 
 func (s *configCommandSuite) TestGetCommandInitWithKey(c *gc.C) {
-	err := coretesting.InitCommand(application.NewConfigCommandForTest(s.fake), []string{"app", "key"})
+	err := cmdtesting.InitCommand(application.NewConfigCommandForTest(s.fake), []string{"app", "key"})
 	// everything ok
 	c.Assert(err, jc.ErrorIsNil)
 }
 
 func (s *configCommandSuite) TestGetConfig(c *gc.C) {
 	for _, t := range getTests {
-		ctx := coretesting.Context(c)
+		ctx := cmdtesting.Context(c)
 		code := cmd.Main(application.NewConfigCommandForTest(s.fake), ctx, []string{t.application})
 		c.Check(code, gc.Equals, 0)
 		c.Assert(ctx.Stderr.(*bytes.Buffer).String(), gc.Equals, "")
@@ -130,7 +131,7 @@ func (s *configCommandSuite) TestGetConfig(c *gc.C) {
 }
 
 func (s *configCommandSuite) TestGetConfigKey(c *gc.C) {
-	ctx := coretesting.Context(c)
+	ctx := cmdtesting.Context(c)
 	code := cmd.Main(application.NewConfigCommandForTest(s.fake), ctx, []string{"dummy-application", "title"})
 	c.Check(code, gc.Equals, 0)
 	c.Assert(ctx.Stderr.(*bytes.Buffer).String(), gc.Equals, "")
@@ -138,7 +139,7 @@ func (s *configCommandSuite) TestGetConfigKey(c *gc.C) {
 }
 
 func (s *configCommandSuite) TestGetConfigKeyNotFound(c *gc.C) {
-	ctx := coretesting.Context(c)
+	ctx := cmdtesting.Context(c)
 	code := cmd.Main(application.NewConfigCommandForTest(s.fake), ctx, []string{"dummy-application", "invalid"})
 	c.Check(code, gc.Equals, 1)
 	c.Assert(ctx.Stderr.(*bytes.Buffer).String(), gc.Equals, "ERROR key \"invalid\" not found in \"dummy-application\" application settings.\n")
@@ -147,39 +148,39 @@ func (s *configCommandSuite) TestGetConfigKeyNotFound(c *gc.C) {
 
 func (s *configCommandSuite) TestSetCommandInit(c *gc.C) {
 	// missing args
-	err := coretesting.InitCommand(application.NewConfigCommandForTest(s.fake), []string{})
+	err := cmdtesting.InitCommand(application.NewConfigCommandForTest(s.fake), []string{})
 	c.Assert(err, gc.ErrorMatches, "no application name specified")
 
 	// missing application name
-	err = coretesting.InitCommand(application.NewConfigCommandForTest(s.fake), []string{"name=foo"})
+	err = cmdtesting.InitCommand(application.NewConfigCommandForTest(s.fake), []string{"name=foo"})
 	c.Assert(err, gc.ErrorMatches, "no application name specified")
 
 	// --file path, but no application
-	err = coretesting.InitCommand(application.NewConfigCommandForTest(s.fake), []string{"--file", "testconfig.yaml"})
+	err = cmdtesting.InitCommand(application.NewConfigCommandForTest(s.fake), []string{"--file", "testconfig.yaml"})
 	c.Assert(err, gc.ErrorMatches, "no application name specified")
 
 	// --file and options specified
-	err = coretesting.InitCommand(application.NewConfigCommandForTest(s.fake), []string{"application", "--file", "testconfig.yaml", "bees="})
+	err = cmdtesting.InitCommand(application.NewConfigCommandForTest(s.fake), []string{"application", "--file", "testconfig.yaml", "bees="})
 	c.Assert(err, gc.ErrorMatches, "cannot specify --file and key=value arguments simultaneously")
 
 	// --reset and no config name provided
-	err = coretesting.InitCommand(application.NewConfigCommandForTest(s.fake), []string{"application", "--reset"})
+	err = cmdtesting.InitCommand(application.NewConfigCommandForTest(s.fake), []string{"application", "--reset"})
 	c.Assert(err, gc.ErrorMatches, "flag needs an argument: --reset")
 
 	// cannot set and retrieve simultaneously
-	err = coretesting.InitCommand(application.NewConfigCommandForTest(s.fake), []string{"application", "get", "set=value"})
+	err = cmdtesting.InitCommand(application.NewConfigCommandForTest(s.fake), []string{"application", "get", "set=value"})
 	c.Assert(err, gc.ErrorMatches, "cannot set and retrieve values simultaneously")
 
 	// cannot reset and get simultaneously
-	err = coretesting.InitCommand(application.NewConfigCommandForTest(s.fake), []string{"application", "--reset", "reset", "get"})
+	err = cmdtesting.InitCommand(application.NewConfigCommandForTest(s.fake), []string{"application", "--reset", "reset", "get"})
 	c.Assert(err, gc.ErrorMatches, "cannot reset and retrieve values simultaneously")
 
 	// invalid reset keys
-	err = coretesting.InitCommand(application.NewConfigCommandForTest(s.fake), []string{"application", "--reset", "reset,bad=key"})
+	err = cmdtesting.InitCommand(application.NewConfigCommandForTest(s.fake), []string{"application", "--reset", "reset,bad=key"})
 	c.Assert(err, gc.ErrorMatches, `--reset accepts a comma delimited set of keys "a,b,c", received: "bad=key"`)
 
 	// init too many args fails
-	err = coretesting.InitCommand(application.NewConfigCommandForTest(s.fake), []string{"application", "key", "another"})
+	err = cmdtesting.InitCommand(application.NewConfigCommandForTest(s.fake), []string{"application", "key", "another"})
 	c.Assert(err, gc.ErrorMatches, "can only retrieve a single value, or all values")
 
 }
@@ -250,7 +251,7 @@ func (s *configCommandSuite) TestSetConfig(c *gc.C) {
 		"missing.yaml",
 	}, "ERROR.* "+utils.NoSuchFileErrRegexp+"\n")
 
-	ctx := coretesting.ContextForDir(c, s.dir)
+	ctx := cmdtesting.ContextForDir(c, s.dir)
 	code := cmd.Main(application.NewConfigCommandForTest(s.fake), ctx, []string{
 		"dummy-application",
 		"--file",
@@ -262,7 +263,7 @@ func (s *configCommandSuite) TestSetConfig(c *gc.C) {
 
 func (s *configCommandSuite) TestSetFromStdin(c *gc.C) {
 	s.fake = &fakeApplicationAPI{name: "dummy-application"}
-	ctx := coretesting.Context(c)
+	ctx := cmdtesting.Context(c)
 	ctx.Stdin = strings.NewReader("settings:\n  username:\n  value: world\n")
 	code := cmd.Main(application.NewConfigCommandForTest(s.fake), ctx, []string{
 		"dummy-application",
@@ -286,7 +287,7 @@ func (s *configCommandSuite) TestResetConfigToDefault(c *gc.C) {
 func (s *configCommandSuite) TestBlockSetConfig(c *gc.C) {
 	// Block operation
 	s.fake.err = common.OperationBlockedError("TestBlockSetConfig")
-	ctx := coretesting.ContextForDir(c, s.dir)
+	ctx := cmdtesting.ContextForDir(c, s.dir)
 	code := cmd.Main(application.NewConfigCommandForTest(s.fake), ctx, []string{
 		"dummy-application",
 		"--file",
@@ -299,21 +300,21 @@ func (s *configCommandSuite) TestBlockSetConfig(c *gc.C) {
 
 // assertSetSuccess sets configuration options and checks the expected settings.
 func (s *configCommandSuite) assertSetSuccess(c *gc.C, dir string, args []string, expect map[string]interface{}) {
-	ctx := coretesting.ContextForDir(c, dir)
+	ctx := cmdtesting.ContextForDir(c, dir)
 	code := cmd.Main(application.NewConfigCommandForTest(s.fake), ctx, append([]string{"dummy-application"}, args...))
 	c.Assert(code, gc.Equals, 0)
 }
 
 // assertSetFail sets configuration options and checks the expected error.
 func (s *configCommandSuite) assertSetFail(c *gc.C, dir string, args []string, err string) {
-	ctx := coretesting.ContextForDir(c, dir)
+	ctx := cmdtesting.ContextForDir(c, dir)
 	code := cmd.Main(application.NewConfigCommandForTest(s.fake), ctx, append([]string{"dummy-application"}, args...))
 	c.Check(code, gc.Not(gc.Equals), 0)
 	c.Assert(ctx.Stderr.(*bytes.Buffer).String(), gc.Matches, err)
 }
 
 func (s *configCommandSuite) assertSetWarning(c *gc.C, dir string, args []string, w string) {
-	ctx := coretesting.ContextForDir(c, dir)
+	ctx := cmdtesting.ContextForDir(c, dir)
 	code := cmd.Main(application.NewConfigCommandForTest(s.fake), ctx, append([]string{"dummy-application"}, args...))
 	c.Check(code, gc.Equals, 0)
 
@@ -323,7 +324,7 @@ func (s *configCommandSuite) assertSetWarning(c *gc.C, dir string, args []string
 // setupValueFile creates a file containing one value for testing
 // set with name=@filename.
 func setupValueFile(c *gc.C, dir, filename, value string) string {
-	ctx := coretesting.ContextForDir(c, dir)
+	ctx := cmdtesting.ContextForDir(c, dir)
 	path := ctx.AbsPath(filename)
 	content := []byte(value)
 	err := ioutil.WriteFile(path, content, 0666)
@@ -334,7 +335,7 @@ func setupValueFile(c *gc.C, dir, filename, value string) string {
 // setupBigFile creates a too big file for testing
 // set with name=@filename.
 func setupBigFile(c *gc.C, dir string) string {
-	ctx := coretesting.ContextForDir(c, dir)
+	ctx := cmdtesting.ContextForDir(c, dir)
 	path := ctx.AbsPath("big.txt")
 	file, err := os.Create(path)
 	c.Assert(err, jc.ErrorIsNil)
@@ -353,7 +354,7 @@ func setupBigFile(c *gc.C, dir string) string {
 // setupConfigFile creates a configuration file for testing set
 // with the --file argument specifying a configuration file.
 func setupConfigFile(c *gc.C, dir string) string {
-	ctx := coretesting.ContextForDir(c, dir)
+	ctx := cmdtesting.ContextForDir(c, dir)
 	path := ctx.AbsPath("testconfig.yaml")
 	content := []byte(yamlConfigValue)
 	err := ioutil.WriteFile(path, content, 0666)

--- a/cmd/juju/application/constraints_test.go
+++ b/cmd/juju/application/constraints_test.go
@@ -7,6 +7,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/cmd/cmdtesting"
 	"github.com/juju/juju/cmd/juju/application"
 	"github.com/juju/juju/testing"
 )
@@ -41,7 +42,7 @@ func (s *ServiceConstraintsCommandsSuite) TestSetInit(c *gc.C) {
 			args: []string{"mysql", "cpu-power=250"},
 		},
 	} {
-		err := testing.InitCommand(application.NewServiceSetConstraintsCommand(), test.args)
+		err := cmdtesting.InitCommand(application.NewServiceSetConstraintsCommand(), test.args)
 		if test.err == "" {
 			c.Check(err, jc.ErrorIsNil)
 		} else {
@@ -71,7 +72,7 @@ func (s *ServiceConstraintsCommandsSuite) TestGetInit(c *gc.C) {
 			args: []string{"mysql"},
 		},
 	} {
-		err := testing.InitCommand(application.NewServiceGetConstraintsCommand(), test.args)
+		err := cmdtesting.InitCommand(application.NewServiceGetConstraintsCommand(), test.args)
 		if test.err == "" {
 			c.Check(err, jc.ErrorIsNil)
 		} else {

--- a/cmd/juju/application/consume_test.go
+++ b/cmd/juju/application/consume_test.go
@@ -10,9 +10,9 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/cmd/cmdtesting"
 	"github.com/juju/juju/cmd/juju/application"
 	"github.com/juju/juju/jujuclient"
-	coretesting "github.com/juju/juju/testing"
 )
 
 type ConsumeSuite struct {
@@ -46,7 +46,7 @@ func (s *ConsumeSuite) SetUpTest(c *gc.C) {
 }
 
 func (s *ConsumeSuite) runConsume(c *gc.C, args ...string) (*cmd.Context, error) {
-	return coretesting.RunCommand(c, application.NewConsumeCommandForTest(s.store, s.mockAPI), args...)
+	return cmdtesting.RunCommand(c, application.NewConsumeCommandForTest(s.store, s.mockAPI), args...)
 }
 
 func (s *ConsumeSuite) TestNoArguments(c *gc.C) {
@@ -87,7 +87,7 @@ func (s *ConsumeSuite) TestSuccessModelDotApplication(c *gc.C) {
 		{"Consume", []interface{}{"bob/booster.uke", ""}},
 		{"Close", nil},
 	})
-	c.Assert(coretesting.Stderr(ctx), gc.Equals, "Added bob/booster.uke as mary-weep\n")
+	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "Added bob/booster.uke as mary-weep\n")
 }
 
 func (s *ConsumeSuite) TestSuccessModelDotApplicationWithAlias(c *gc.C) {
@@ -98,7 +98,7 @@ func (s *ConsumeSuite) TestSuccessModelDotApplicationWithAlias(c *gc.C) {
 		{"Consume", []interface{}{"bob/booster.uke", "alias"}},
 		{"Close", nil},
 	})
-	c.Assert(coretesting.Stderr(ctx), gc.Equals, "Added bob/booster.uke as mary-weep\n")
+	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "Added bob/booster.uke as mary-weep\n")
 }
 
 type mockConsumeAPI struct {

--- a/cmd/juju/application/deploy_test.go
+++ b/cmd/juju/application/deploy_test.go
@@ -40,6 +40,7 @@ import (
 	"github.com/juju/juju/api/charms"
 	"github.com/juju/juju/apiserver/params"
 	jjcharmstore "github.com/juju/juju/charmstore"
+	"github.com/juju/juju/cmd/cmdtesting"
 	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/constraints"
 	"github.com/juju/juju/environs/config"
@@ -48,7 +49,6 @@ import (
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/testcharms"
 	coretesting "github.com/juju/juju/testing"
-	jtesting "github.com/juju/juju/testing"
 )
 
 type DeploySuite struct {
@@ -66,7 +66,7 @@ func (s *DeploySuite) SetUpTest(c *gc.C) {
 }
 
 func runDeploy(c *gc.C, args ...string) error {
-	_, err := coretesting.RunCommand(c, NewDefaultDeployCommand(), args...)
+	_, err := cmdtesting.RunCommand(c, NewDefaultDeployCommand(), args...)
 	return err
 }
 
@@ -98,7 +98,7 @@ var initErrorTests = []struct {
 func (s *DeploySuite) TestInitErrors(c *gc.C) {
 	for i, t := range initErrorTests {
 		c.Logf("test %d", i)
-		err := coretesting.InitCommand(NewDefaultDeployCommand(), t.args)
+		err := cmdtesting.InitCommand(NewDefaultDeployCommand(), t.args)
 		c.Assert(err, gc.ErrorMatches, t.err)
 	}
 }
@@ -295,7 +295,7 @@ func (s *DeploySuite) TestResources(c *gc.C) {
 	d := DeployCommand{}
 	args := []string{ch, "--resource", res1, "--resource", res2, "--series", "quantal"}
 
-	err = coretesting.InitCommand(modelcmd.Wrap(&d), args)
+	err = cmdtesting.InitCommand(modelcmd.Wrap(&d), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(d.Resources, gc.DeepEquals, map[string]string{
 		"foo": foopath,
@@ -507,7 +507,7 @@ func (s *DeployLocalSuite) SetUpTest(c *gc.C) {
 // setupConfigFile creates a configuration file for testing set
 // with the --config argument specifying a configuration file.
 func setupConfigFile(c *gc.C, dir string) string {
-	ctx := coretesting.ContextForDir(c, dir)
+	ctx := cmdtesting.ContextForDir(c, dir)
 	path := ctx.AbsPath("testconfig.yaml")
 	content := []byte("dummy-application:\n  skill-level: 9000\n  username: admin001\n\n")
 	err := ioutil.WriteFile(path, content, 0666)
@@ -596,7 +596,7 @@ func (s *DeployCharmStoreSuite) TestDeployAuthorization(c *gc.C) {
 		if test.readPermUser != "" {
 			s.changeReadPerm(c, url, test.readPermUser)
 		}
-		_, err := coretesting.RunCommand(c, NewDefaultDeployCommand(), test.deployURL, fmt.Sprintf("wordpress%d", i))
+		_, err := cmdtesting.RunCommand(c, NewDefaultDeployCommand(), test.deployURL, fmt.Sprintf("wordpress%d", i))
 		if test.expectError != "" {
 			c.Check(err, gc.ErrorMatches, test.expectError)
 			continue
@@ -907,7 +907,7 @@ func (s *DeployCharmStoreSuite) TestAddMetricCredentials(c *gc.C) {
 			return fakeAPI, nil
 		},
 	}
-	_, err = coretesting.RunCommand(c, modelcmd.Wrap(deploy), "cs:quantal/metered-1", "--plan", "someplan")
+	_, err = cmdtesting.RunCommand(c, modelcmd.Wrap(deploy), "cs:quantal/metered-1", "--plan", "someplan")
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Check(setMetricCredentialsCall(), gc.Equals, 1)
@@ -954,7 +954,7 @@ func (s *DeployCharmStoreSuite) TestAddMetricCredentialsDefaultPlan(c *gc.C) {
 			return fakeAPI, nil
 		},
 	}
-	_, err = coretesting.RunCommand(c, modelcmd.Wrap(deploy), "cs:quantal/metered-1")
+	_, err = cmdtesting.RunCommand(c, modelcmd.Wrap(deploy), "cs:quantal/metered-1")
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Check(setMetricCredentialsCall(), gc.Equals, 1)
@@ -995,7 +995,7 @@ func (s *DeployCharmStoreSuite) TestSetMetricCredentialsNotCalledForUnmeteredCha
 		},
 	}
 
-	_, err = coretesting.RunCommand(c, modelcmd.Wrap(deploy), "cs:quantal/dummy-1")
+	_, err = cmdtesting.RunCommand(c, modelcmd.Wrap(deploy), "cs:quantal/dummy-1")
 	c.Assert(err, jc.ErrorIsNil)
 
 	for _, call := range fakeAPI.Calls() {
@@ -1044,7 +1044,7 @@ summary: summary
 		},
 	}
 
-	_, err = coretesting.RunCommand(c, modelcmd.Wrap(deploy), url.String())
+	_, err = cmdtesting.RunCommand(c, modelcmd.Wrap(deploy), url.String())
 	c.Assert(err, jc.ErrorIsNil)
 	stub.CheckNoCalls(c)
 }
@@ -1088,7 +1088,7 @@ summary: summary
 		},
 	}
 
-	_, err = coretesting.RunCommand(c, modelcmd.Wrap(deploy), url.String(), "--plan", "someplan")
+	_, err = cmdtesting.RunCommand(c, modelcmd.Wrap(deploy), url.String(), "--plan", "someplan")
 	c.Assert(err, jc.ErrorIsNil)
 	stub.CheckCalls(c, []jujutesting.StubCall{{
 		"Authorize", []interface{}{metricRegistrationPost{
@@ -1165,7 +1165,7 @@ func (s *DeployCharmStoreSuite) TestDeployCharmsEndpointNotImplemented(c *gc.C) 
 			return fakeAPI, nil
 		},
 	}
-	_, err = coretesting.RunCommand(c, modelcmd.Wrap(deploy), "cs:quantal/metered-1", "--plan", "someplan")
+	_, err = cmdtesting.RunCommand(c, modelcmd.Wrap(deploy), "cs:quantal/metered-1", "--plan", "someplan")
 
 	c.Check(err, gc.ErrorMatches, "IsMetered")
 }
@@ -1262,10 +1262,10 @@ func (s *DeployUnitTestSuite) TestDeployLocalCharm_GivesCorrectUserMessage(c *gc
 	cmd := NewDeployCommand(func() (DeployAPI, error) {
 		return fakeAPI, nil
 	}, nil)
-	context, err := jtesting.RunCommand(c, cmd, charmDir.Path, "--series", "trusty")
+	context, err := cmdtesting.RunCommand(c, cmd, charmDir.Path, "--series", "trusty")
 	c.Assert(err, jc.ErrorIsNil)
 
-	c.Check(jtesting.Stderr(context), gc.Equals, `Deploying charm "local:trusty/dummy-1".`+"\n")
+	c.Check(cmdtesting.Stderr(context), gc.Equals, `Deploying charm "local:trusty/dummy-1".`+"\n")
 }
 
 func (s *DeployUnitTestSuite) TestAddMetricCredentialsDefaultForUnmeteredCharm(c *gc.C) {
@@ -1285,7 +1285,7 @@ func (s *DeployUnitTestSuite) TestAddMetricCredentialsDefaultForUnmeteredCharm(c
 	deployCmd := NewDeployCommand(func() (DeployAPI, error) {
 		return fakeAPI, nil
 	}, nil)
-	_, err := coretesting.RunCommand(c, deployCmd, charmDir.Path, "--series", "trusty")
+	_, err := cmdtesting.RunCommand(c, deployCmd, charmDir.Path, "--series", "trusty")
 	c.Assert(err, jc.ErrorIsNil)
 
 	// We never attempt to set metric credentials
@@ -1312,10 +1312,10 @@ func (s *DeployUnitTestSuite) TestRedeployLocalCharm_SucceedsWhenDeployed(c *gc.
 	deployCmd := NewDeployCommand(func() (DeployAPI, error) {
 		return fakeAPI, nil
 	}, nil)
-	context, err := jtesting.RunCommand(c, deployCmd, dummyURL.String())
+	context, err := cmdtesting.RunCommand(c, deployCmd, dummyURL.String())
 	c.Assert(err, jc.ErrorIsNil)
 
-	c.Check(jtesting.Stderr(context), gc.Equals, ""+
+	c.Check(cmdtesting.Stderr(context), gc.Equals, ""+
 		`Located charm "local:trusty/dummy-0".`+"\n"+
 		`Deploying charm "local:trusty/dummy-0".`+"\n",
 	)
@@ -1372,10 +1372,10 @@ func (s *DeployUnitTestSuite) TestDeployBundle_OutputsCorrectMessage(c *gc.C) {
 	deployCmd := NewDeployCommand(func() (DeployAPI, error) {
 		return fakeAPI, nil
 	}, nil)
-	context, err := jtesting.RunCommand(c, deployCmd, "cs:bundle/wordpress-simple")
+	context, err := cmdtesting.RunCommand(c, deployCmd, "cs:bundle/wordpress-simple")
 	c.Assert(err, jc.ErrorIsNil)
 
-	c.Check(jtesting.Stderr(context), gc.Equals, ""+
+	c.Check(cmdtesting.Stderr(context), gc.Equals, ""+
 		`Located bundle "cs:bundle/wordpress-simple"`+"\n"+
 		`Deploying charm "cs:mysql"`+"\n"+
 		`Deploying charm "cs:wordpress"`+"\n"+

--- a/cmd/juju/application/expose_test.go
+++ b/cmd/juju/application/expose_test.go
@@ -9,6 +9,7 @@ import (
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/charm.v6-unstable"
 
+	"github.com/juju/juju/cmd/cmdtesting"
 	jujutesting "github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/rpc"
 	"github.com/juju/juju/testcharms"
@@ -30,7 +31,7 @@ func (s *ExposeSuite) SetUpTest(c *gc.C) {
 var _ = gc.Suite(&ExposeSuite{})
 
 func runExpose(c *gc.C, args ...string) error {
-	_, err := testing.RunCommand(c, NewExposeCommand(), args...)
+	_, err := cmdtesting.RunCommand(c, NewExposeCommand(), args...)
 	return err
 }
 

--- a/cmd/juju/application/register_test.go
+++ b/cmd/juju/application/register_test.go
@@ -17,7 +17,7 @@ import (
 
 	apicharms "github.com/juju/juju/api/charms"
 	"github.com/juju/juju/charmstore"
-	coretesting "github.com/juju/juju/testing"
+	"github.com/juju/juju/cmd/cmdtesting"
 )
 
 var _ = gc.Suite(&registrationSuite{})
@@ -47,7 +47,7 @@ func (s *registrationSuite) SetUpTest(c *gc.C) {
 		RegisterURL:    s.server.URL,
 		IncreaseBudget: 100,
 	}
-	s.ctx = coretesting.Context(c)
+	s.ctx = cmdtesting.Context(c)
 }
 
 func (s *registrationSuite) TearDownTest(c *gc.C) {
@@ -751,7 +751,7 @@ func (s *noPlanRegistrationSuite) SetUpTest(c *gc.C) {
 		RegisterURL:    s.server.URL,
 		IncreaseBudget: 100,
 	}
-	s.ctx = coretesting.Context(c)
+	s.ctx = cmdtesting.Context(c)
 }
 
 func (s *noPlanRegistrationSuite) TearDownTest(c *gc.C) {

--- a/cmd/juju/application/removeapplication_test.go
+++ b/cmd/juju/application/removeapplication_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/juju/juju/api/application"
 	"github.com/juju/juju/api/charms"
 	"github.com/juju/juju/api/modelconfig"
+	"github.com/juju/juju/cmd/cmdtesting"
 	"github.com/juju/juju/cmd/modelcmd"
 	jujutesting "github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/state"
@@ -37,7 +38,7 @@ func (s *RemoveApplicationSuite) SetUpTest(c *gc.C) {
 }
 
 func runRemoveApplication(c *gc.C, args ...string) (*cmd.Context, error) {
-	return testing.RunCommand(c, NewRemoveApplicationCommand(), args...)
+	return cmdtesting.RunCommand(c, NewRemoveApplicationCommand(), args...)
 }
 
 func (s *RemoveApplicationSuite) setupTestApplication(c *gc.C) {
@@ -51,7 +52,7 @@ func (s *RemoveApplicationSuite) TestLocalApplication(c *gc.C) {
 	s.setupTestApplication(c)
 	ctx, err := runRemoveApplication(c, "riak")
 	c.Assert(err, jc.ErrorIsNil)
-	stderr := testing.Stderr(ctx)
+	stderr := cmdtesting.Stderr(ctx)
 	c.Assert(stderr, gc.Equals, "removing application riak\n")
 	riak, err := s.State.Application("riak")
 	c.Assert(err, jc.ErrorIsNil)
@@ -65,7 +66,7 @@ func (s *RemoveApplicationSuite) TestInformStorageRemoved(c *gc.C) {
 
 	ctx, err := runRemoveApplication(c, "storage-filesystem")
 	c.Assert(err, jc.ErrorIsNil)
-	stderr := testing.Stderr(ctx)
+	stderr := cmdtesting.Stderr(ctx)
 	c.Assert(stderr, gc.Equals, `
 removing application storage-filesystem
 - will remove storage data/0
@@ -87,7 +88,7 @@ func (s *RemoveApplicationSuite) TestRemoteApplication(c *gc.C) {
 
 	ctx, err := runRemoveApplication(c, "remote-app")
 	c.Assert(err, jc.ErrorIsNil)
-	stderr := testing.Stderr(ctx)
+	stderr := cmdtesting.Stderr(ctx)
 	c.Assert(stderr, gc.Equals, "removing application remote-app\n")
 
 	// Removed immediately since there are no units.
@@ -98,7 +99,7 @@ func (s *RemoveApplicationSuite) TestRemoteApplication(c *gc.C) {
 func (s *RemoveApplicationSuite) TestRemoveLocalMetered(c *gc.C) {
 	ch := testcharms.Repo.CharmArchivePath(s.CharmsPath, "metered")
 	deploy := NewDefaultDeployCommand()
-	_, err := testing.RunCommand(c, deploy, ch, "--series", "quantal")
+	_, err := cmdtesting.RunCommand(c, deploy, ch, "--series", "quantal")
 	c.Assert(err, jc.ErrorIsNil)
 	_, err = runRemoveApplication(c, "metered")
 	c.Assert(err, jc.ErrorIsNil)
@@ -124,7 +125,7 @@ func (s *RemoveApplicationSuite) TestFailure(c *gc.C) {
 	ctx, err := runRemoveApplication(c, "gargleblaster")
 	c.Assert(err, gc.Equals, cmd.ErrSilent)
 
-	stderr := testing.Stderr(ctx)
+	stderr := cmdtesting.Stderr(ctx)
 	c.Assert(stderr, gc.Equals, `
 removing application gargleblaster failed: application "gargleblaster" not found
 `[1:])
@@ -147,7 +148,7 @@ var _ = gc.Suite(&RemoveCharmStoreCharmsSuite{})
 func (s *RemoveCharmStoreCharmsSuite) SetUpTest(c *gc.C) {
 	s.charmStoreSuite.SetUpTest(c)
 
-	s.ctx = testing.Context(c)
+	s.ctx = cmdtesting.Context(c)
 
 	testcharms.UploadCharm(c, s.client, "cs:quantal/metered-1", "metered")
 	deployCmd := &DeployCommand{}
@@ -174,7 +175,7 @@ func (s *RemoveCharmStoreCharmsSuite) SetUpTest(c *gc.C) {
 		}, nil
 	}
 
-	_, err := testing.RunCommand(c, cmd, "cs:quantal/metered-1")
+	_, err := cmdtesting.RunCommand(c, cmd, "cs:quantal/metered-1")
 	c.Assert(err, jc.ErrorIsNil)
 
 }

--- a/cmd/juju/application/removerelation_test.go
+++ b/cmd/juju/application/removerelation_test.go
@@ -10,6 +10,7 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/cmd/cmdtesting"
 	coretesting "github.com/juju/juju/testing"
 )
 
@@ -29,7 +30,7 @@ func (s *RemoveRelationSuite) SetUpTest(c *gc.C) {
 var _ = gc.Suite(&RemoveRelationSuite{})
 
 func (s *RemoveRelationSuite) runRemoveRelation(c *gc.C, args ...string) error {
-	_, err := coretesting.RunCommand(c, NewRemoveRelationCommandForTest(s.mockAPI), args...)
+	_, err := cmdtesting.RunCommand(c, NewRemoveRelationCommandForTest(s.mockAPI), args...)
 	return err
 }
 

--- a/cmd/juju/application/removeunit_test.go
+++ b/cmd/juju/application/removeunit_test.go
@@ -12,6 +12,7 @@ import (
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/charm.v6-unstable"
 
+	"github.com/juju/juju/cmd/cmdtesting"
 	jujutesting "github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/testcharms"
@@ -33,7 +34,7 @@ func (s *RemoveUnitSuite) SetUpTest(c *gc.C) {
 var _ = gc.Suite(&RemoveUnitSuite{})
 
 func runRemoveUnit(c *gc.C, args ...string) (*cmd.Context, error) {
-	return testing.RunCommand(c, NewRemoveUnitCommand(), args...)
+	return cmdtesting.RunCommand(c, NewRemoveUnitCommand(), args...)
 }
 
 func (s *RemoveUnitSuite) setupUnitForRemove(c *gc.C) *state.Application {
@@ -50,7 +51,7 @@ func (s *RemoveUnitSuite) TestRemoveUnit(c *gc.C) {
 
 	ctx, err := runRemoveUnit(c, "dummy/0", "dummy/1", "dummy/2", "sillybilly/17")
 	c.Assert(err, gc.Equals, cmd.ErrSilent)
-	stderr := testing.Stderr(ctx)
+	stderr := cmdtesting.Stderr(ctx)
 	c.Assert(stderr, gc.Equals, `
 removing unit dummy/0
 removing unit dummy/1
@@ -72,7 +73,7 @@ func (s *RemoveUnitSuite) TestRemoveUnitInformsStorageRemoval(c *gc.C) {
 
 	ctx, err := runRemoveUnit(c, "storage-filesystem/0")
 	c.Assert(err, jc.ErrorIsNil)
-	stderr := testing.Stderr(ctx)
+	stderr := cmdtesting.Stderr(ctx)
 	c.Assert(stderr, gc.Equals, `
 removing unit storage-filesystem/0
 - will remove storage data/0

--- a/cmd/juju/application/unexpose_test.go
+++ b/cmd/juju/application/unexpose_test.go
@@ -9,6 +9,7 @@ import (
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/charm.v6-unstable"
 
+	"github.com/juju/juju/cmd/cmdtesting"
 	jujutesting "github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/rpc"
 	"github.com/juju/juju/testcharms"
@@ -30,7 +31,7 @@ func (s *UnexposeSuite) SetUpTest(c *gc.C) {
 var _ = gc.Suite(&UnexposeSuite{})
 
 func runUnexpose(c *gc.C, args ...string) error {
-	_, err := testing.RunCommand(c, NewUnexposeCommand(), args...)
+	_, err := cmdtesting.RunCommand(c, NewUnexposeCommand(), args...)
 	return err
 }
 

--- a/cmd/juju/application/upgradecharm_resources_test.go
+++ b/cmd/juju/application/upgradecharm_resources_test.go
@@ -20,6 +20,7 @@ import (
 	"gopkg.in/juju/charmrepo.v2-unstable/csclient"
 	"gopkg.in/juju/charmstore.v5-unstable"
 
+	"github.com/juju/juju/cmd/cmdtesting"
 	"github.com/juju/juju/cmd/juju/application"
 	"github.com/juju/juju/component/all"
 	"github.com/juju/juju/constraints"
@@ -27,7 +28,6 @@ import (
 	"github.com/juju/juju/resource"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/testcharms"
-	"github.com/juju/juju/testing"
 )
 
 type UpgradeCharmResourceSuite struct {
@@ -45,7 +45,7 @@ func (s *UpgradeCharmResourceSuite) SetUpTest(c *gc.C) {
 	s.RepoSuite.SetUpTest(c)
 	chPath := testcharms.Repo.ClonedDirPath(s.CharmsPath, "riak")
 
-	_, err := testing.RunCommand(c, application.NewDefaultDeployCommand(), chPath, "riak", "--series", "quantal")
+	_, err := cmdtesting.RunCommand(c, application.NewDefaultDeployCommand(), chPath, "riak", "--series", "quantal")
 	c.Assert(err, jc.ErrorIsNil)
 	riak, err := s.State.Application("riak")
 	c.Assert(err, jc.ErrorIsNil)
@@ -87,7 +87,7 @@ resources:
 	err = ioutil.WriteFile(resourceFile, data, 0644)
 	c.Assert(err, jc.ErrorIsNil)
 
-	_, err = testing.RunCommand(c, application.NewUpgradeCharmCommand(),
+	_, err = cmdtesting.RunCommand(c, application.NewUpgradeCharmCommand(),
 		"riak", "--path="+myriakPath.Path, "--resource", "data="+resourceFile)
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -193,9 +193,9 @@ func (s *UpgradeCharmStoreResourceSuite) TestDeployStarsaySuccess(c *gc.C) {
 	err := ioutil.WriteFile(resourceFile, []byte(resourceContent), 0644)
 	c.Assert(err, jc.ErrorIsNil)
 
-	ctx, err := testing.RunCommand(c, application.NewDefaultDeployCommand(), "trusty/starsay", "--resource", "upload-resource="+resourceFile)
+	ctx, err := cmdtesting.RunCommand(c, application.NewDefaultDeployCommand(), "trusty/starsay", "--resource", "upload-resource="+resourceFile)
 	c.Assert(err, jc.ErrorIsNil)
-	output := testing.Stderr(ctx)
+	output := cmdtesting.Stderr(ctx)
 
 	expectedOutput := `Located charm "cs:trusty/starsay-1".
 Deploying charm "cs:trusty/starsay-1".
@@ -279,7 +279,7 @@ Deploying charm "cs:trusty/starsay-1".
 
 	testcharms.UploadCharm(c, s.client, "trusty/starsay-2", "starsay")
 
-	_, err = testing.RunCommand(c, application.NewUpgradeCharmCommand(), "starsay")
+	_, err = cmdtesting.RunCommand(c, application.NewUpgradeCharmCommand(), "starsay")
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.assertServicesDeployed(c, map[string]serviceInfo{

--- a/cmd/juju/application/upgradecharm_test.go
+++ b/cmd/juju/application/upgradecharm_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/juju/juju/api/base"
 	"github.com/juju/juju/api/charms"
 	jujucharmstore "github.com/juju/juju/charmstore"
+	"github.com/juju/juju/cmd/cmdtesting"
 	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/environs/config"
 	jujutesting "github.com/juju/juju/juju/testing"
@@ -160,7 +161,7 @@ func (s *UpgradeCharmSuite) SetUpTest(c *gc.C) {
 }
 
 func (s *UpgradeCharmSuite) runUpgradeCharm(c *gc.C, args ...string) (*cmd.Context, error) {
-	return coretesting.RunCommand(c, s.cmd, args...)
+	return cmdtesting.RunCommand(c, s.cmd, args...)
 }
 
 func (s *UpgradeCharmSuite) TestStorageConstraints(c *gc.C) {
@@ -258,7 +259,7 @@ func (s *UpgradeCharmErrorsStateSuite) SetUpTest(c *gc.C) {
 var _ = gc.Suite(&UpgradeCharmErrorsStateSuite{})
 
 func runUpgradeCharm(c *gc.C, args ...string) error {
-	_, err := coretesting.RunCommand(c, NewUpgradeCharmCommand(), args...)
+	_, err := cmdtesting.RunCommand(c, NewUpgradeCharmCommand(), args...)
 	return err
 }
 
@@ -463,7 +464,7 @@ func (s *UpgradeCharmSuccessStateSuite) TestInitWithResources(c *gc.C) {
 	d := upgradeCharmCommand{}
 	args := []string{"dummy", "--resource", res1, "--resource", res2}
 
-	err = coretesting.InitCommand(modelcmd.Wrap(&d), args)
+	err = cmdtesting.InitCommand(modelcmd.Wrap(&d), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(d.Resources, gc.DeepEquals, map[string]string{
 		"foo": foopath,

--- a/cmd/juju/backups/create_test.go
+++ b/cmd/juju/backups/create_test.go
@@ -12,8 +12,8 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/cmd/cmdtesting"
 	"github.com/juju/juju/cmd/juju/backups"
-	"github.com/juju/juju/testing"
 )
 
 type createSuite struct {
@@ -67,7 +67,7 @@ func (s *createSuite) checkDownload(c *gc.C, ctx *cmd.Context) {
 
 func (s *createSuite) TestNoArgs(c *gc.C) {
 	client := s.BaseBackupsSuite.setDownload()
-	_, err := testing.RunCommand(c, s.wrappedCommand, "--quiet")
+	_, err := cmdtesting.RunCommand(c, s.wrappedCommand, "--quiet")
 	c.Assert(err, jc.ErrorIsNil)
 
 	client.Check(c, s.metaresult.ID, "", "Create", "Download")
@@ -75,7 +75,7 @@ func (s *createSuite) TestNoArgs(c *gc.C) {
 
 func (s *createSuite) TestDefaultDownload(c *gc.C) {
 	s.setDownload()
-	ctx, err := testing.RunCommand(c, s.wrappedCommand, "--quiet", "--filename", s.defaultFilename)
+	ctx, err := cmdtesting.RunCommand(c, s.wrappedCommand, "--quiet", "--filename", s.defaultFilename)
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.checkDownload(c, ctx)
@@ -85,7 +85,7 @@ func (s *createSuite) TestDefaultDownload(c *gc.C) {
 
 func (s *createSuite) TestQuiet(c *gc.C) {
 	client := s.BaseBackupsSuite.setDownload()
-	ctx, err := testing.RunCommand(c, s.wrappedCommand, "--quiet")
+	ctx, err := cmdtesting.RunCommand(c, s.wrappedCommand, "--quiet")
 	c.Assert(err, jc.ErrorIsNil)
 
 	client.Check(c, s.metaresult.ID, "", "Create", "Download")
@@ -99,7 +99,7 @@ func (s *createSuite) TestQuiet(c *gc.C) {
 
 func (s *createSuite) TestNotes(c *gc.C) {
 	client := s.BaseBackupsSuite.setDownload()
-	_, err := testing.RunCommand(c, s.wrappedCommand, "spam", "--quiet")
+	_, err := cmdtesting.RunCommand(c, s.wrappedCommand, "spam", "--quiet")
 	c.Assert(err, jc.ErrorIsNil)
 
 	client.Check(c, s.metaresult.ID, "spam", "Create", "Download")
@@ -107,7 +107,7 @@ func (s *createSuite) TestNotes(c *gc.C) {
 
 func (s *createSuite) TestFilename(c *gc.C) {
 	client := s.setDownload()
-	ctx, err := testing.RunCommand(c, s.wrappedCommand, "--filename", "backup.tgz", "--quiet")
+	ctx, err := cmdtesting.RunCommand(c, s.wrappedCommand, "--filename", "backup.tgz", "--quiet")
 	c.Assert(err, jc.ErrorIsNil)
 
 	client.Check(c, s.metaresult.ID, "", "Create", "Download")
@@ -117,7 +117,7 @@ func (s *createSuite) TestFilename(c *gc.C) {
 
 func (s *createSuite) TestNoDownload(c *gc.C) {
 	client := s.setSuccess()
-	ctx, err := testing.RunCommand(c, s.wrappedCommand, "--no-download")
+	ctx, err := cmdtesting.RunCommand(c, s.wrappedCommand, "--no-download")
 	c.Assert(err, jc.ErrorIsNil)
 
 	client.Check(c, "", "", "Create")
@@ -128,14 +128,14 @@ func (s *createSuite) TestNoDownload(c *gc.C) {
 
 func (s *createSuite) TestFilenameAndNoDownload(c *gc.C) {
 	s.setSuccess()
-	_, err := testing.RunCommand(c, s.wrappedCommand, "--no-download", "--filename", "backup.tgz")
+	_, err := cmdtesting.RunCommand(c, s.wrappedCommand, "--no-download", "--filename", "backup.tgz")
 
 	c.Check(err, gc.ErrorMatches, "cannot mix --no-download and --filename")
 }
 
 func (s *createSuite) TestError(c *gc.C) {
 	s.setFailure("failed!")
-	_, err := testing.RunCommand(c, s.wrappedCommand)
+	_, err := cmdtesting.RunCommand(c, s.wrappedCommand)
 
 	c.Check(errors.Cause(err), gc.ErrorMatches, "failed!")
 }

--- a/cmd/juju/backups/download_test.go
+++ b/cmd/juju/backups/download_test.go
@@ -9,8 +9,8 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/cmd/cmdtesting"
 	"github.com/juju/juju/cmd/juju/backups"
-	"github.com/juju/juju/testing"
 )
 
 type downloadSuite struct {
@@ -48,7 +48,7 @@ func (s *downloadSuite) setSuccess() *fakeAPIClient {
 
 func (s *downloadSuite) TestOkay(c *gc.C) {
 	s.setSuccess()
-	ctx, err := testing.RunCommand(c, s.wrappedCommand, s.metaresult.ID)
+	ctx, err := cmdtesting.RunCommand(c, s.wrappedCommand, s.metaresult.ID)
 	c.Check(err, jc.ErrorIsNil)
 
 	s.filename = "juju-backup-" + s.metaresult.ID + ".tar.gz"
@@ -58,7 +58,7 @@ func (s *downloadSuite) TestOkay(c *gc.C) {
 
 func (s *downloadSuite) TestFilename(c *gc.C) {
 	s.setSuccess()
-	ctx, err := testing.RunCommand(c, s.wrappedCommand, s.metaresult.ID, "--filename", "backup.tar.gz")
+	ctx, err := cmdtesting.RunCommand(c, s.wrappedCommand, s.metaresult.ID, "--filename", "backup.tar.gz")
 	c.Check(err, jc.ErrorIsNil)
 
 	s.filename = "backup.tar.gz"
@@ -68,6 +68,6 @@ func (s *downloadSuite) TestFilename(c *gc.C) {
 
 func (s *downloadSuite) TestError(c *gc.C) {
 	s.setFailure("failed!")
-	_, err := testing.RunCommand(c, s.wrappedCommand, s.metaresult.ID)
+	_, err := cmdtesting.RunCommand(c, s.wrappedCommand, s.metaresult.ID)
 	c.Check(errors.Cause(err), gc.ErrorMatches, "failed!")
 }

--- a/cmd/juju/backups/list_test.go
+++ b/cmd/juju/backups/list_test.go
@@ -5,13 +5,12 @@ package backups_test
 
 import (
 	"github.com/juju/cmd"
-	"github.com/juju/cmd/cmdtesting"
 	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/cmd/cmdtesting"
 	"github.com/juju/juju/cmd/juju/backups"
-	"github.com/juju/juju/testing"
 )
 
 type listSuite struct {
@@ -29,7 +28,7 @@ func (s *listSuite) SetUpTest(c *gc.C) {
 func (s *listSuite) TestOkay(c *gc.C) {
 	s.setSuccess()
 	ctx := cmdtesting.Context(c)
-	ctx, err := testing.RunCommand(c, s.subcommand, []string{"--verbose"}...)
+	ctx, err := cmdtesting.RunCommand(c, s.subcommand, []string{"--verbose"}...)
 	c.Assert(err, jc.ErrorIsNil)
 
 	out := MetaResultString
@@ -38,7 +37,7 @@ func (s *listSuite) TestOkay(c *gc.C) {
 
 func (s *listSuite) TestBrief(c *gc.C) {
 	s.setSuccess()
-	ctx, err := testing.RunCommand(c, s.subcommand)
+	ctx, err := cmdtesting.RunCommand(c, s.subcommand)
 	c.Assert(err, jc.ErrorIsNil)
 	out := s.metaresult.ID + "\n"
 	s.checkStd(c, ctx, out, "")
@@ -46,6 +45,6 @@ func (s *listSuite) TestBrief(c *gc.C) {
 
 func (s *listSuite) TestError(c *gc.C) {
 	s.setFailure("failed!")
-	_, err := testing.RunCommand(c, s.subcommand)
+	_, err := cmdtesting.RunCommand(c, s.subcommand)
 	c.Check(errors.Cause(err), gc.ErrorMatches, "failed!")
 }

--- a/cmd/juju/backups/remove_test.go
+++ b/cmd/juju/backups/remove_test.go
@@ -9,8 +9,8 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/cmd/cmdtesting"
 	"github.com/juju/juju/cmd/juju/backups"
-	"github.com/juju/juju/testing"
 )
 
 type removeSuite struct {
@@ -27,7 +27,7 @@ func (s *removeSuite) SetUpTest(c *gc.C) {
 
 func (s *removeSuite) TestOkay(c *gc.C) {
 	s.setSuccess()
-	ctx, err := testing.RunCommand(c, s.command, "spam")
+	ctx, err := cmdtesting.RunCommand(c, s.command, "spam")
 	c.Check(err, jc.ErrorIsNil)
 
 	out := "successfully removed: spam\n"
@@ -36,6 +36,6 @@ func (s *removeSuite) TestOkay(c *gc.C) {
 
 func (s *removeSuite) TestError(c *gc.C) {
 	s.setFailure("failed!")
-	_, err := testing.RunCommand(c, s.command, "spam")
+	_, err := cmdtesting.RunCommand(c, s.command, "spam")
 	c.Check(errors.Cause(err), gc.ErrorMatches, "failed!")
 }

--- a/cmd/juju/backups/restore_test.go
+++ b/cmd/juju/backups/restore_test.go
@@ -14,6 +14,7 @@ import (
 	apibackups "github.com/juju/juju/api/backups"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/cloud"
+	"github.com/juju/juju/cmd/cmdtesting"
 	"github.com/juju/juju/cmd/juju/backups"
 	"github.com/juju/juju/controller"
 	"github.com/juju/juju/environs"
@@ -95,13 +96,13 @@ func (s *restoreSuite) SetUpTest(c *gc.C) {
 
 func (s *restoreSuite) TestRestoreArgs(c *gc.C) {
 	s.command = backups.NewRestoreCommandForTest(s.store, nil, nil, nil, nil)
-	_, err := testing.RunCommand(c, s.command, "restore")
+	_, err := cmdtesting.RunCommand(c, s.command, "restore")
 	c.Assert(err, gc.ErrorMatches, "you must specify either a file or a backup id.")
 
-	_, err = testing.RunCommand(c, s.command, "restore", "--id", "anid", "--file", "afile")
+	_, err = cmdtesting.RunCommand(c, s.command, "restore", "--id", "anid", "--file", "afile")
 	c.Assert(err, gc.ErrorMatches, "you must specify either a file or a backup id but not both.")
 
-	_, err = testing.RunCommand(c, s.command, "restore", "--id", "anid", "-b")
+	_, err = cmdtesting.RunCommand(c, s.command, "restore", "--id", "anid", "-b")
 	c.Assert(err, gc.ErrorMatches, "it is not possible to rebootstrap and restore from an id.")
 }
 
@@ -136,7 +137,7 @@ func (s *restoreSuite) TestRestoreReboostrapControllerExists(c *gc.C) {
 		backups.GetEnvironFunc(fakeEnv),
 		backups.GetRebootstrapParamsFunc("mycloud"),
 	)
-	_, err := testing.RunCommand(c, s.command, "restore", "--file", "afile", "-b")
+	_, err := cmdtesting.RunCommand(c, s.command, "restore", "--file", "afile", "-b")
 	c.Assert(err, gc.ErrorMatches, ".*still seems to exist.*")
 }
 
@@ -156,7 +157,7 @@ func (s *restoreSuite) TestRestoreReboostrapNoControllers(c *gc.C) {
 		return errors.New("failed to bootstrap new controller")
 	})
 
-	_, err := testing.RunCommand(c, s.command, "restore", "--file", "afile", "-b")
+	_, err := cmdtesting.RunCommand(c, s.command, "restore", "--file", "afile", "-b")
 	c.Assert(err, gc.ErrorMatches, ".*failed to bootstrap new controller")
 }
 
@@ -177,7 +178,7 @@ func (s *restoreSuite) TestRestoreReboostrapReadsMetadata(c *gc.C) {
 		return errors.New("failed to bootstrap new controller")
 	})
 
-	_, err := testing.RunCommand(c, s.command, "restore", "-m", "testing:test1", "--file", "afile", "-b")
+	_, err := cmdtesting.RunCommand(c, s.command, "restore", "-m", "testing:test1", "--file", "afile", "-b")
 	c.Assert(err, gc.ErrorMatches, ".*failed to bootstrap new controller")
 }
 
@@ -200,7 +201,7 @@ func (s *restoreSuite) TestFailedRestoreReboostrapMaintainsControllerInfo(c *gc.
 		return nil
 	})
 
-	_, err := testing.RunCommand(c, s.command, "restore", "-m", "testing:test1", "--file", "afile", "-b")
+	_, err := cmdtesting.RunCommand(c, s.command, "restore", "-m", "testing:test1", "--file", "afile", "-b")
 	c.Assert(err, gc.ErrorMatches, "failed")
 	// The details below are as per what was done in test setup, so no changes.
 	c.Assert(s.store.Controllers["testing"], jc.DeepEquals, jujuclient.ControllerDetails{
@@ -244,7 +245,7 @@ func (s *restoreSuite) TestRestoreReboostrapWritesUpdatedControllerInfo(c *gc.C)
 		return &i
 	}
 
-	_, err := testing.RunCommand(c, s.command, "restore", "-m", "testing:test1", "--file", "afile", "-b")
+	_, err := cmdtesting.RunCommand(c, s.command, "restore", "-m", "testing:test1", "--file", "afile", "-b")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(boostrapped, jc.IsTrue)
 	c.Assert(s.store.Controllers["testing"], jc.DeepEquals, jujuclient.ControllerDetails{
@@ -288,7 +289,7 @@ func (s *restoreSuite) TestRestoreReboostrapBuiltInProvider(c *gc.C) {
 		return nil
 	})
 
-	_, err := testing.RunCommand(c, s.command, "restore", "-m", "testing:test1", "--file", "afile", "-b")
+	_, err := cmdtesting.RunCommand(c, s.command, "restore", "-m", "testing:test1", "--file", "afile", "-b")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(boostrapped, jc.IsTrue)
 }

--- a/cmd/juju/backups/show_test.go
+++ b/cmd/juju/backups/show_test.go
@@ -9,8 +9,8 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/cmd/cmdtesting"
 	"github.com/juju/juju/cmd/juju/backups"
-	"github.com/juju/juju/testing"
 )
 
 type showSuite struct {
@@ -27,7 +27,7 @@ func (s *showSuite) SetUpTest(c *gc.C) {
 
 func (s *showSuite) TestOkay(c *gc.C) {
 	s.setSuccess()
-	ctx, err := testing.RunCommand(c, s.subcommand, s.metaresult.ID)
+	ctx, err := cmdtesting.RunCommand(c, s.subcommand, s.metaresult.ID)
 	c.Check(err, jc.ErrorIsNil)
 
 	out := MetaResultString
@@ -36,6 +36,6 @@ func (s *showSuite) TestOkay(c *gc.C) {
 
 func (s *showSuite) TestError(c *gc.C) {
 	s.setFailure("failed!")
-	_, err := testing.RunCommand(c, s.subcommand, s.metaresult.ID)
+	_, err := cmdtesting.RunCommand(c, s.subcommand, s.metaresult.ID)
 	c.Check(errors.Cause(err), gc.ErrorMatches, "failed!")
 }

--- a/cmd/juju/backups/upload_test.go
+++ b/cmd/juju/backups/upload_test.go
@@ -13,8 +13,8 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/cmd/cmdtesting"
 	"github.com/juju/juju/cmd/juju/backups"
-	"github.com/juju/juju/testing"
 )
 
 type uploadSuite struct {
@@ -72,7 +72,7 @@ func (s *uploadSuite) createArchive(c *gc.C) {
 func (s *uploadSuite) TestOkay(c *gc.C) {
 	s.createArchive(c)
 	s.setSuccess()
-	ctx, err := testing.RunCommand(c, s.command, s.filename)
+	ctx, err := cmdtesting.RunCommand(c, s.command, s.filename)
 	c.Check(err, jc.ErrorIsNil)
 
 	out := MetaResultString
@@ -81,13 +81,13 @@ func (s *uploadSuite) TestOkay(c *gc.C) {
 
 func (s *uploadSuite) TestFileMissing(c *gc.C) {
 	s.setSuccess()
-	_, err := testing.RunCommand(c, s.command, s.filename)
+	_, err := cmdtesting.RunCommand(c, s.command, s.filename)
 	c.Check(os.IsNotExist(errors.Cause(err)), jc.IsTrue)
 }
 
 func (s *uploadSuite) TestError(c *gc.C) {
 	s.createArchive(c)
 	s.setFailure("failed!")
-	_, err := testing.RunCommand(c, s.command, s.filename)
+	_, err := cmdtesting.RunCommand(c, s.command, s.filename)
 	c.Check(errors.Cause(err), gc.ErrorMatches, "failed!")
 }

--- a/cmd/juju/block/disablecommand_test.go
+++ b/cmd/juju/block/disablecommand_test.go
@@ -8,6 +8,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/cmd/cmdtesting"
 	"github.com/juju/juju/cmd/juju/block"
 	"github.com/juju/juju/testing"
 )
@@ -39,7 +40,7 @@ func (s *disableCommandSuite) TestInit(c *gc.C) {
 		},
 	} {
 		cmd := block.NewDisableCommand()
-		err := testing.InitCommand(cmd, test.args)
+		err := cmdtesting.InitCommand(cmd, test.args)
 		if test.err == "" {
 			c.Check(err, jc.ErrorIsNil)
 		} else {
@@ -50,7 +51,7 @@ func (s *disableCommandSuite) TestInit(c *gc.C) {
 
 func (s *disableCommandSuite) TestRunGetAPIError(c *gc.C) {
 	cmd := block.NewDisableCommandForTest(nil, errors.New("boom"))
-	_, err := testing.RunCommand(c, cmd, "all")
+	_, err := cmdtesting.RunCommand(c, cmd, "all")
 	c.Assert(err.Error(), gc.Equals, "cannot connect to the API: boom")
 }
 
@@ -74,7 +75,7 @@ func (s *disableCommandSuite) TestRun(c *gc.C) {
 	}} {
 		mockClient := &mockBlockClient{}
 		cmd := block.NewDisableCommandForTest(mockClient, nil)
-		_, err := testing.RunCommand(c, cmd, test.args...)
+		_, err := cmdtesting.RunCommand(c, cmd, test.args...)
 		c.Check(err, jc.ErrorIsNil)
 		c.Check(mockClient.blockType, gc.Equals, test.type_)
 		c.Check(mockClient.message, gc.Equals, test.message)
@@ -84,7 +85,7 @@ func (s *disableCommandSuite) TestRun(c *gc.C) {
 func (s *disableCommandSuite) TestRunError(c *gc.C) {
 	mockClient := &mockBlockClient{err: errors.New("boom")}
 	cmd := block.NewDisableCommandForTest(mockClient, nil)
-	_, err := testing.RunCommand(c, cmd, "all")
+	_, err := cmdtesting.RunCommand(c, cmd, "all")
 	c.Check(err, gc.ErrorMatches, "boom")
 }
 

--- a/cmd/juju/block/enablecommand_test.go
+++ b/cmd/juju/block/enablecommand_test.go
@@ -9,6 +9,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/cmd/cmdtesting"
 	"github.com/juju/juju/cmd/juju/block"
 	"github.com/juju/juju/testing"
 )
@@ -41,7 +42,7 @@ func (s *enableCommandSuite) TestInit(c *gc.C) {
 		},
 	} {
 		cmd := block.NewEnableCommand()
-		err := testing.InitCommand(cmd, test.args)
+		err := cmdtesting.InitCommand(cmd, test.args)
 		if test.err == "" {
 			c.Check(err, jc.ErrorIsNil)
 		} else {
@@ -52,7 +53,7 @@ func (s *enableCommandSuite) TestInit(c *gc.C) {
 
 func (s *enableCommandSuite) TestRunGetAPIError(c *gc.C) {
 	cmd := block.NewEnableCommandForTest(nil, errors.New("boom"))
-	_, err := testing.RunCommand(c, cmd, "all")
+	_, err := cmdtesting.RunCommand(c, cmd, "all")
 	c.Assert(err.Error(), gc.Equals, "cannot connect to the API: boom")
 }
 
@@ -72,7 +73,7 @@ func (s *enableCommandSuite) TestRun(c *gc.C) {
 	}} {
 		mockClient := &mockUnblockClient{}
 		cmd := block.NewEnableCommandForTest(mockClient, nil)
-		_, err := testing.RunCommand(c, cmd, test.args...)
+		_, err := cmdtesting.RunCommand(c, cmd, test.args...)
 		c.Check(err, jc.ErrorIsNil)
 		c.Check(mockClient.blockType, gc.Equals, test.type_)
 	}
@@ -81,7 +82,7 @@ func (s *enableCommandSuite) TestRun(c *gc.C) {
 func (s *enableCommandSuite) TestRunError(c *gc.C) {
 	mockClient := &mockUnblockClient{err: errors.New("boom")}
 	cmd := block.NewEnableCommandForTest(mockClient, nil)
-	_, err := testing.RunCommand(c, cmd, "all")
+	_, err := cmdtesting.RunCommand(c, cmd, "all")
 	c.Check(err, gc.ErrorMatches, "boom")
 }
 

--- a/cmd/juju/block/list_test.go
+++ b/cmd/juju/block/list_test.go
@@ -10,6 +10,7 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/cmd/cmdtesting"
 	"github.com/juju/juju/cmd/juju/block"
 	"github.com/juju/juju/testing"
 )
@@ -22,21 +23,21 @@ type listCommandSuite struct {
 
 func (s *listCommandSuite) TestInit(c *gc.C) {
 	cmd := block.NewListCommand()
-	err := testing.InitCommand(cmd, nil)
+	err := cmdtesting.InitCommand(cmd, nil)
 	c.Check(err, jc.ErrorIsNil)
 
-	err = testing.InitCommand(cmd, []string{"anything"})
+	err = cmdtesting.InitCommand(cmd, []string{"anything"})
 	c.Check(err.Error(), gc.Equals, `unrecognized args: ["anything"]`)
 }
 
 func (s *listCommandSuite) TestListEmpty(c *gc.C) {
-	ctx, err := testing.RunCommand(c, block.NewListCommandForTest(&mockListClient{}, nil))
+	ctx, err := cmdtesting.RunCommand(c, block.NewListCommandForTest(&mockListClient{}, nil))
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(testing.Stderr(ctx), gc.Equals, "No commands are currently disabled.\n")
+	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "No commands are currently disabled.\n")
 }
 
 func (s *listCommandSuite) TestListError(c *gc.C) {
-	_, err := testing.RunCommand(c, block.NewListCommandForTest(
+	_, err := cmdtesting.RunCommand(c, block.NewListCommandForTest(
 		&mockListClient{err: errors.New("boom")}, nil))
 	c.Assert(err, gc.ErrorMatches, "boom")
 }
@@ -75,10 +76,10 @@ func (s *listCommandSuite) mock() *mockListClient {
 
 func (s *listCommandSuite) TestList(c *gc.C) {
 	cmd := block.NewListCommandForTest(s.mock(), nil)
-	ctx, err := testing.RunCommand(c, cmd)
+	ctx, err := cmdtesting.RunCommand(c, cmd)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(testing.Stderr(ctx), gc.Equals, "")
-	c.Assert(testing.Stdout(ctx), gc.Equals, ""+
+	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "")
+	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, ""+
 		"Disabled commands  Message\n"+
 		"destroy-model      Sysadmins in control.\n"+
 		"all                just temporary\n"+
@@ -88,9 +89,9 @@ func (s *listCommandSuite) TestList(c *gc.C) {
 
 func (s *listCommandSuite) TestListYAML(c *gc.C) {
 	cmd := block.NewListCommandForTest(s.mock(), nil)
-	ctx, err := testing.RunCommand(c, cmd, "--format", "yaml")
+	ctx, err := cmdtesting.RunCommand(c, cmd, "--format", "yaml")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(testing.Stdout(ctx), gc.Equals, ""+
+	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, ""+
 		"- command-set: destroy-model\n"+
 		"  message: Sysadmins in control.\n"+
 		"- command-set: all\n"+
@@ -99,26 +100,26 @@ func (s *listCommandSuite) TestListYAML(c *gc.C) {
 }
 
 func (s *listCommandSuite) TestListJSONEmpty(c *gc.C) {
-	ctx, err := testing.RunCommand(c, block.NewListCommandForTest(&mockListClient{}, nil), "--format", "json")
+	ctx, err := cmdtesting.RunCommand(c, block.NewListCommandForTest(&mockListClient{}, nil), "--format", "json")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(testing.Stdout(ctx), gc.Equals, "[]\n")
+	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, "[]\n")
 }
 
 func (s *listCommandSuite) TestListJSON(c *gc.C) {
 	cmd := block.NewListCommandForTest(s.mock(), nil)
-	ctx, err := testing.RunCommand(c, cmd, "--format", "json")
+	ctx, err := cmdtesting.RunCommand(c, cmd, "--format", "json")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(testing.Stdout(ctx), gc.Equals, ""+
+	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, ""+
 		`[{"command-set":"destroy-model","message":"Sysadmins in control."},`+
 		`{"command-set":"all","message":"just temporary"}]`+"\n")
 }
 
 func (s *listCommandSuite) TestListAll(c *gc.C) {
 	cmd := block.NewListCommandForTest(s.mock(), nil)
-	ctx, err := testing.RunCommand(c, cmd, "--all")
+	ctx, err := cmdtesting.RunCommand(c, cmd, "--all")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(testing.Stderr(ctx), gc.Equals, "")
-	c.Assert(testing.Stdout(ctx), gc.Equals, ""+
+	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "")
+	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, ""+
 		"Name        Model UUID   Owner             Disabled commands\n"+
 		"controller  fake-uuid-1  admin             destroy-model, remove-object\n"+
 		"model-a     fake-uuid-2  bob@external      all\n"+
@@ -128,9 +129,9 @@ func (s *listCommandSuite) TestListAll(c *gc.C) {
 
 func (s *listCommandSuite) TestListAllYAML(c *gc.C) {
 	cmd := block.NewListCommandForTest(s.mock(), nil)
-	ctx, err := testing.RunCommand(c, cmd, "--format", "yaml", "--all")
+	ctx, err := cmdtesting.RunCommand(c, cmd, "--format", "yaml", "--all")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(testing.Stdout(ctx), gc.Equals, ""+
+	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, ""+
 		"- name: controller\n"+
 		"  model-uuid: fake-uuid-1\n"+
 		"  owner: admin\n"+
@@ -152,9 +153,9 @@ func (s *listCommandSuite) TestListAllYAML(c *gc.C) {
 
 func (s *listCommandSuite) TestListAllJSON(c *gc.C) {
 	cmd := block.NewListCommandForTest(s.mock(), nil)
-	ctx, err := testing.RunCommand(c, cmd, "--format", "json", "--all")
+	ctx, err := cmdtesting.RunCommand(c, cmd, "--format", "json", "--all")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(testing.Stdout(ctx), gc.Equals, "["+
+	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, "["+
 		`{"name":"controller","model-uuid":"fake-uuid-1","owner":"admin","disabled-commands":["destroy-model","remove-object"]},`+
 		`{"name":"model-a","model-uuid":"fake-uuid-2","owner":"bob@external","disabled-commands":["all"]},`+
 		`{"name":"model-b","model-uuid":"fake-uuid-3","owner":"charlie@external","disabled-commands":["all","destroy-model"]}`+

--- a/cmd/juju/cachedimages/list_test.go
+++ b/cmd/juju/cachedimages/list_test.go
@@ -11,6 +11,7 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/cmd/cmdtesting"
 	"github.com/juju/juju/cmd/juju/cachedimages"
 	"github.com/juju/juju/testing"
 )
@@ -53,19 +54,19 @@ func (s *listImagesCommandSuite) SetUpTest(c *gc.C) {
 }
 
 func runListCommand(c *gc.C, args ...string) (*cmd.Context, error) {
-	return testing.RunCommand(c, cachedimages.NewListCommandForTest(), args...)
+	return cmdtesting.RunCommand(c, cachedimages.NewListCommandForTest(), args...)
 }
 
 func (*listImagesCommandSuite) TestListImagesNone(c *gc.C) {
 	context, err := runListCommand(c, "--kind", "kvm")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(testing.Stderr(context), gc.Equals, "No images to display.\n")
+	c.Assert(cmdtesting.Stderr(context), gc.Equals, "No images to display.\n")
 }
 
 func (*listImagesCommandSuite) TestListImagesFormatJson(c *gc.C) {
 	context, err := runListCommand(c, "--format", "json", "--kind", "lxd", "--series", "trusty", "--arch", "amd64")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(testing.Stdout(context), gc.Equals, "Cached images:\n["+
+	c.Assert(cmdtesting.Stdout(context), gc.Equals, "Cached images:\n["+
 		`{"kind":"lxd","series":"trusty","arch":"amd64","source-url":"http://image","created":"Thu, 01 Jan 2015 00:00:00 UTC"}`+
 		"]\n")
 }
@@ -73,7 +74,7 @@ func (*listImagesCommandSuite) TestListImagesFormatJson(c *gc.C) {
 func (*listImagesCommandSuite) TestListImagesFormatYaml(c *gc.C) {
 	context, err := runListCommand(c, "--format", "yaml", "--kind", "lxd", "--series", "trusty", "--arch", "amd64")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(testing.Stdout(context), gc.Equals, "Cached images:\n"+
+	c.Assert(cmdtesting.Stdout(context), gc.Equals, "Cached images:\n"+
 		"- kind: lxd\n"+
 		"  series: trusty\n"+
 		"  arch: amd64\n"+

--- a/cmd/juju/cachedimages/remove_test.go
+++ b/cmd/juju/cachedimages/remove_test.go
@@ -8,6 +8,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/cmd/cmdtesting"
 	"github.com/juju/juju/cmd/juju/cachedimages"
 	"github.com/juju/juju/testing"
 )
@@ -45,7 +46,7 @@ func (s *removeImageCommandSuite) SetUpTest(c *gc.C) {
 }
 
 func runRemoveCommand(c *gc.C, args ...string) (*cmd.Context, error) {
-	return testing.RunCommand(c, cachedimages.NewRemoveCommandForTest(), args...)
+	return cmdtesting.RunCommand(c, cachedimages.NewRemoveCommandForTest(), args...)
 }
 
 func (s *removeImageCommandSuite) TestRemoveImage(c *gc.C) {

--- a/cmd/juju/cloud/add_test.go
+++ b/cmd/juju/cloud/add_test.go
@@ -18,9 +18,9 @@ import (
 	gc "gopkg.in/check.v1"
 
 	cloudfile "github.com/juju/juju/cloud"
+	"github.com/juju/juju/cmd/cmdtesting"
 	"github.com/juju/juju/cmd/juju/cloud"
 	"github.com/juju/juju/environs"
-	"github.com/juju/juju/testing"
 )
 
 type addSuite struct {
@@ -64,7 +64,7 @@ func (f *fakeCloudMetadataStore) ParseOneCloud(data []byte) (cloudfile.Cloud, er
 }
 
 func (s *addSuite) TestAddBadArgs(c *gc.C) {
-	_, err := testing.RunCommand(c, cloud.NewAddCloudCommand(nil), "cloud", "cloud.yaml", "extra")
+	_, err := cmdtesting.RunCommand(c, cloud.NewAddCloudCommand(nil), "cloud", "cloud.yaml", "extra")
 	c.Assert(err, gc.ErrorMatches, `unrecognized args: \["extra"\]`)
 }
 
@@ -133,7 +133,7 @@ func (*addSuite) TestAddBadFilename(c *gc.C) {
 	fake.Call("ParseCloudMetadataFile", "somefile.yaml").Returns(map[string]cloudfile.Cloud{}, badFileErr)
 
 	addCmd := cloud.NewAddCloudCommand(fake)
-	_, err := testing.RunCommand(c, addCmd, "cloud", "somefile.yaml")
+	_, err := cmdtesting.RunCommand(c, addCmd, "cloud", "somefile.yaml")
 	c.Check(err, gc.Equals, badFileErr)
 }
 
@@ -142,7 +142,7 @@ func (*addSuite) TestAddBadCloudName(c *gc.C) {
 	fake.Call("ParseCloudMetadataFile", "testFile").Returns(map[string]cloudfile.Cloud{}, nil)
 
 	addCmd := cloud.NewAddCloudCommand(fake)
-	_, err := testing.RunCommand(c, addCmd, "cloud", "testFile")
+	_, err := cmdtesting.RunCommand(c, addCmd, "cloud", "testFile")
 	c.Assert(err, gc.ErrorMatches, `cloud "cloud" not found in file .*`)
 }
 
@@ -152,7 +152,7 @@ func (*addSuite) TestAddExisting(c *gc.C) {
 	fake.Call("PublicCloudMetadata", []string(nil)).Returns(map[string]cloudfile.Cloud{}, false, nil)
 	fake.Call("PersonalCloudMetadata").Returns(homestackMetadata(), nil)
 
-	_, err := testing.RunCommand(c, cloud.NewAddCloudCommand(fake), "homestack", "fake.yaml")
+	_, err := cmdtesting.RunCommand(c, cloud.NewAddCloudCommand(fake), "homestack", "fake.yaml")
 	c.Assert(err, gc.ErrorMatches, `"homestack" already exists; use --replace to replace this existing cloud`)
 }
 
@@ -162,7 +162,7 @@ func (*addSuite) TestAddExistingReplace(c *gc.C) {
 	fake.Call("PersonalCloudMetadata").Returns(homestackMetadata(), nil)
 	numCallsToWrite := fake.Call("WritePersonalCloudMetadata", homestackMetadata()).Returns(nil)
 
-	_, err := testing.RunCommand(c, cloud.NewAddCloudCommand(fake), "homestack", "fake.yaml", "--replace")
+	_, err := cmdtesting.RunCommand(c, cloud.NewAddCloudCommand(fake), "homestack", "fake.yaml", "--replace")
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Check(numCallsToWrite(), gc.Equals, 1)
@@ -174,7 +174,7 @@ func (*addSuite) TestAddExistingPublic(c *gc.C) {
 	fake.Call("PublicCloudMetadata", []string(nil)).Returns(awsMetadata(), false, nil)
 	fake.Call("PersonalCloudMetadata").Returns(map[string]cloudfile.Cloud{}, nil)
 
-	_, err := testing.RunCommand(c, cloud.NewAddCloudCommand(fake), "aws", "fake.yaml")
+	_, err := cmdtesting.RunCommand(c, cloud.NewAddCloudCommand(fake), "aws", "fake.yaml")
 	c.Assert(err, gc.ErrorMatches, `"aws" is the name of a public cloud; use --replace to override this definition`)
 }
 
@@ -184,7 +184,7 @@ func (*addSuite) TestAddExistingBuiltin(c *gc.C) {
 	fake.Call("PublicCloudMetadata", []string(nil)).Returns(map[string]cloudfile.Cloud{}, false, nil)
 	fake.Call("PersonalCloudMetadata").Returns(map[string]cloudfile.Cloud{}, nil)
 
-	_, err := testing.RunCommand(c, cloud.NewAddCloudCommand(fake), "localhost", "fake.yaml")
+	_, err := cmdtesting.RunCommand(c, cloud.NewAddCloudCommand(fake), "localhost", "fake.yaml")
 	c.Assert(err, gc.ErrorMatches, `"localhost" is the name of a built-in cloud; use --replace to override this definition`)
 }
 
@@ -195,7 +195,7 @@ func (*addSuite) TestAddExistingPublicReplace(c *gc.C) {
 	fake.Call("PersonalCloudMetadata").Returns(map[string]cloudfile.Cloud{}, nil)
 	writeCall := fake.Call("WritePersonalCloudMetadata", awsMetadata()).Returns(nil)
 
-	_, err := testing.RunCommand(c, cloud.NewAddCloudCommand(fake), "aws", "fake.yaml", "--replace")
+	_, err := cmdtesting.RunCommand(c, cloud.NewAddCloudCommand(fake), "aws", "fake.yaml", "--replace")
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Check(writeCall(), gc.Equals, 1)
@@ -208,7 +208,7 @@ func (*addSuite) TestAddNew(c *gc.C) {
 	fake.Call("PersonalCloudMetadata").Returns(map[string]cloudfile.Cloud{}, nil)
 	numCallsToWrite := fake.Call("WritePersonalCloudMetadata", garageMAASMetadata()).Returns(nil)
 
-	_, err := testing.RunCommand(c, cloud.NewAddCloudCommand(fake), "garage-maas", "fake.yaml")
+	_, err := cmdtesting.RunCommand(c, cloud.NewAddCloudCommand(fake), "garage-maas", "fake.yaml")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(numCallsToWrite(), gc.Equals, 1)
 }
@@ -224,13 +224,13 @@ func (*addSuite) TestAddNewInvalidAuthType(c *gc.C) {
 	fileClouds := map[string]cloudfile.Cloud{"fakecloud": fakeCloud}
 	fake.Call("ParseCloudMetadataFile", "fake.yaml").Returns(fileClouds, nil)
 
-	_, err := testing.RunCommand(c, cloud.NewAddCloudCommand(fake), "fakecloud", "fake.yaml")
+	_, err := cmdtesting.RunCommand(c, cloud.NewAddCloudCommand(fake), "fakecloud", "fake.yaml")
 	c.Assert(err, gc.ErrorMatches, regexp.QuoteMeta(`auth type "user-pass" not supported`))
 }
 
 func (*addSuite) TestInteractive(c *gc.C) {
 	command := cloud.NewAddCloudCommand(nil)
-	err := testing.InitCommand(command, nil)
+	err := cmdtesting.InitCommand(command, nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	out := &bytes.Buffer{}
@@ -287,7 +287,7 @@ func (*addSuite) TestInteractiveOpenstack(c *gc.C) {
 	command.Ping = func(environs.EnvironProvider, string) error {
 		return nil
 	}
-	err := testing.InitCommand(command, nil)
+	err := cmdtesting.InitCommand(command, nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	ctx := &cmd.Context{
@@ -328,7 +328,7 @@ func (*addSuite) TestInteractiveMaas(c *gc.C) {
 	command.Ping = func(environs.EnvironProvider, string) error {
 		return nil
 	}
-	err := testing.InitCommand(command, nil)
+	err := cmdtesting.InitCommand(command, nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	ctx := &cmd.Context{
@@ -361,7 +361,7 @@ func (*addSuite) TestInteractiveManual(c *gc.C) {
 	command.Ping = func(environs.EnvironProvider, string) error {
 		return nil
 	}
-	err := testing.InitCommand(command, nil)
+	err := cmdtesting.InitCommand(command, nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	ctx := &cmd.Context{
@@ -415,7 +415,7 @@ func (*addSuite) TestInteractiveVSphere(c *gc.C) {
 	command.Ping = func(environs.EnvironProvider, string) error {
 		return nil
 	}
-	err := testing.InitCommand(command, nil)
+	err := cmdtesting.InitCommand(command, nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	var stdout bytes.Buffer
@@ -463,7 +463,7 @@ func (*addSuite) TestInteractiveExistingNameOverride(c *gc.C) {
 	command.Ping = func(environs.EnvironProvider, string) error {
 		return nil
 	}
-	err := testing.InitCommand(command, nil)
+	err := cmdtesting.InitCommand(command, nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	ctx := &cmd.Context{
@@ -503,7 +503,7 @@ func (*addSuite) TestInteractiveExistingNameNoOverride(c *gc.C) {
 	command.Ping = func(environs.EnvironProvider, string) error {
 		return nil
 	}
-	err := testing.InitCommand(command, nil)
+	err := cmdtesting.InitCommand(command, nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	var out bytes.Buffer
@@ -553,7 +553,7 @@ func (*addSuite) TestInteractiveAddCloud_PromptForNameIsCorrect(c *gc.C) {
 func (*addSuite) TestSpecifyingCloudFileThroughFlag_CorrectlySetsMemberVar(c *gc.C) {
 	command := cloud.NewAddCloudCommand(nil)
 	runCmd := func() {
-		testing.RunCommand(c, command, "garage-maas", "-f", "fake.yaml")
+		cmdtesting.RunCommand(c, command, "garage-maas", "-f", "fake.yaml")
 	}
 	c.Assert(runCmd, gc.PanicMatches, "runtime error: invalid memory address or nil pointer dereference")
 	c.Check(command.CloudFile, gc.Equals, "fake.yaml")
@@ -561,6 +561,6 @@ func (*addSuite) TestSpecifyingCloudFileThroughFlag_CorrectlySetsMemberVar(c *gc
 
 func (*addSuite) TestSpecifyingCloudFileThroughFlagAndArgument_Errors(c *gc.C) {
 	command := cloud.NewAddCloudCommand(nil)
-	_, err := testing.RunCommand(c, command, "garage-maas", "-f", "fake.yaml", "foo.yaml")
+	_, err := cmdtesting.RunCommand(c, command, "garage-maas", "-f", "fake.yaml", "foo.yaml")
 	c.Check(err, gc.ErrorMatches, "cannot specify cloud file with flag and argument")
 }

--- a/cmd/juju/cloud/addcredential_test.go
+++ b/cmd/juju/cloud/addcredential_test.go
@@ -17,6 +17,7 @@ import (
 	gc "gopkg.in/check.v1"
 
 	jujucloud "github.com/juju/juju/cloud"
+	"github.com/juju/juju/cmd/cmdtesting"
 	"github.com/juju/juju/cmd/juju/cloud"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/jujuclient"
@@ -60,11 +61,11 @@ func (s *addCredentialSuite) SetUpTest(c *gc.C) {
 
 func (s *addCredentialSuite) run(c *gc.C, stdin io.Reader, args ...string) (*cmd.Context, error) {
 	addCmd := cloud.NewAddCredentialCommandForTest(s.store, s.cloudByNameFunc)
-	err := testing.InitCommand(addCmd, args)
+	err := cmdtesting.InitCommand(addCmd, args)
 	if err != nil {
 		return nil, err
 	}
-	ctx := testing.Context(c)
+	ctx := cmdtesting.Context(c)
 	ctx.Stdin = stdin
 	return ctx, addCmd.Run(ctx)
 }
@@ -245,7 +246,7 @@ func (s *addCredentialSuite) TestAddCredentialInteractive(c *gc.C) {
 	// there's an extra line return after Using auth-type because the rest get a
 	// second line return from the user hitting return when they enter a value
 	// (which is not shown here), but that one does not.
-	c.Assert(testing.Stdout(ctx), gc.Equals, `
+	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, `
 Enter credential name: 
 Using auth-type "interactive".
 
@@ -300,9 +301,9 @@ func (s *addCredentialSuite) assertAddFileCredential(c *gc.C, input, fileKey str
 
 	stdin := strings.NewReader(fmt.Sprintf(input, filename))
 	addCmd := cloud.NewAddCredentialCommandForTest(s.store, s.cloudByNameFunc)
-	err = testing.InitCommand(addCmd, []string{"somecloud"})
+	err = cmdtesting.InitCommand(addCmd, []string{"somecloud"})
 	c.Assert(err, jc.ErrorIsNil)
-	ctx := testing.ContextForDir(c, dir)
+	ctx := cmdtesting.ContextForDir(c, dir)
 	ctx.Stdin = stdin
 	err = addCmd.Run(ctx)
 	c.Assert(err, jc.ErrorIsNil)

--- a/cmd/juju/cloud/defaultcredential_test.go
+++ b/cmd/juju/cloud/defaultcredential_test.go
@@ -11,6 +11,7 @@ import (
 	gc "gopkg.in/check.v1"
 
 	jujucloud "github.com/juju/juju/cloud"
+	"github.com/juju/juju/cmd/cmdtesting"
 	"github.com/juju/juju/cmd/juju/cloud"
 	"github.com/juju/juju/jujuclient"
 	"github.com/juju/juju/testing"
@@ -24,21 +25,21 @@ var _ = gc.Suite(&defaultCredentialSuite{})
 
 func (s *defaultCredentialSuite) TestBadArgs(c *gc.C) {
 	cmd := cloud.NewSetDefaultCredentialCommand()
-	_, err := testing.RunCommand(c, cmd)
+	_, err := cmdtesting.RunCommand(c, cmd)
 	c.Assert(err, gc.ErrorMatches, "Usage: juju set-default-credential <cloud-name> <credential-name>")
-	_, err = testing.RunCommand(c, cmd, "cloud", "credential", "extra")
+	_, err = cmdtesting.RunCommand(c, cmd, "cloud", "credential", "extra")
 	c.Assert(err, gc.ErrorMatches, `unrecognized args: \["extra"\]`)
 }
 
 func (s *defaultCredentialSuite) TestBadCredential(c *gc.C) {
 	cmd := cloud.NewSetDefaultCredentialCommand()
-	_, err := testing.RunCommand(c, cmd, "aws", "foo")
+	_, err := cmdtesting.RunCommand(c, cmd, "aws", "foo")
 	c.Assert(err, gc.ErrorMatches, `credential "foo" for cloud aws not valid`)
 }
 
 func (s *defaultCredentialSuite) TestBadCloudName(c *gc.C) {
 	cmd := cloud.NewSetDefaultCredentialCommand()
-	_, err := testing.RunCommand(c, cmd, "somecloud", "us-west-1")
+	_, err := cmdtesting.RunCommand(c, cmd, "somecloud", "us-west-1")
 	c.Assert(err, gc.ErrorMatches, `cloud somecloud not valid`)
 }
 
@@ -50,9 +51,9 @@ func (s *defaultCredentialSuite) assertSetDefaultCredential(c *gc.C, cloudName s
 		},
 	}
 	cmd := cloud.NewSetDefaultCredentialCommandForTest(store)
-	ctx, err := testing.RunCommand(c, cmd, cloudName, "my-sekrets")
+	ctx, err := cmdtesting.RunCommand(c, cmd, cloudName, "my-sekrets")
 	c.Assert(err, jc.ErrorIsNil)
-	output := testing.Stderr(ctx)
+	output := cmdtesting.Stderr(ctx)
 	output = strings.Replace(output, "\n", "", -1)
 	c.Assert(output, gc.Equals, fmt.Sprintf(`Default credential for %s set to "my-sekrets".`, cloudName))
 	c.Assert(store.Credentials[cloudName].DefaultCredential, gc.Equals, "my-sekrets")

--- a/cmd/juju/cloud/defaultregion_test.go
+++ b/cmd/juju/cloud/defaultregion_test.go
@@ -12,6 +12,7 @@ import (
 	gc "gopkg.in/check.v1"
 
 	jujucloud "github.com/juju/juju/cloud"
+	"github.com/juju/juju/cmd/cmdtesting"
 	"github.com/juju/juju/cmd/juju/cloud"
 	"github.com/juju/juju/jujuclient"
 	"github.com/juju/juju/testing"
@@ -25,21 +26,21 @@ var _ = gc.Suite(&defaultRegionSuite{})
 
 func (s *defaultRegionSuite) TestBadArgs(c *gc.C) {
 	cmd := cloud.NewSetDefaultRegionCommand()
-	_, err := testing.RunCommand(c, cmd)
+	_, err := cmdtesting.RunCommand(c, cmd)
 	c.Assert(err, gc.ErrorMatches, "Usage: juju set-default-region <cloud-name> <region>")
-	_, err = testing.RunCommand(c, cmd, "cloud", "region", "extra")
+	_, err = cmdtesting.RunCommand(c, cmd, "cloud", "region", "extra")
 	c.Assert(err, gc.ErrorMatches, `unrecognized args: \["extra"\]`)
 }
 
 func (s *defaultRegionSuite) TestBadRegion(c *gc.C) {
 	cmd := cloud.NewSetDefaultRegionCommand()
-	_, err := testing.RunCommand(c, cmd, "aws", "foo")
+	_, err := cmdtesting.RunCommand(c, cmd, "aws", "foo")
 	c.Assert(err, gc.ErrorMatches, `region "foo" for cloud aws not valid, valid regions are .*`)
 }
 
 func (s *defaultRegionSuite) TestBadCloudName(c *gc.C) {
 	cmd := cloud.NewSetDefaultRegionCommand()
-	_, err := testing.RunCommand(c, cmd, "somecloud", "us-west-1")
+	_, err := cmdtesting.RunCommand(c, cmd, "somecloud", "us-west-1")
 	c.Assert(err, gc.ErrorMatches, `cloud somecloud not valid`)
 }
 
@@ -48,8 +49,8 @@ func (s *defaultRegionSuite) assertSetDefaultRegion(c *gc.C, cmd cmd.Command, st
 }
 
 func (s *defaultRegionSuite) assertSetCustomDefaultRegion(c *gc.C, cmd cmd.Command, store *jujuclient.MemStore, cloud, desiredDefault, errStr string) {
-	ctx, err := testing.RunCommand(c, cmd, cloud, desiredDefault)
-	output := testing.Stderr(ctx)
+	ctx, err := cmdtesting.RunCommand(c, cmd, cloud, desiredDefault)
+	output := cmdtesting.Stderr(ctx)
 	output = strings.Replace(output, "\n", "", -1)
 	if errStr != "" {
 		c.Assert(err, gc.ErrorMatches, errStr)
@@ -103,7 +104,7 @@ func (s *defaultRegionSuite) TestCaseInsensitiveRegionSpecification(c *gc.C) {
 		DefaultRegion: "us-east-1"}
 
 	cmd := cloud.NewSetDefaultRegionCommandForTest(store)
-	_, err := testing.RunCommand(c, cmd, "aws", "us-WEST-1")
+	_, err := cmdtesting.RunCommand(c, cmd, "aws", "us-WEST-1")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(store.Credentials["aws"].DefaultRegion, gc.Equals, "us-west-1")
 }

--- a/cmd/juju/cloud/detectcredentials_test.go
+++ b/cmd/juju/cloud/detectcredentials_test.go
@@ -15,10 +15,10 @@ import (
 	gc "gopkg.in/check.v1"
 
 	jujucloud "github.com/juju/juju/cloud"
+	"github.com/juju/juju/cmd/cmdtesting"
 	"github.com/juju/juju/cmd/juju/cloud"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/jujuclient"
-	"github.com/juju/juju/testing"
 )
 
 type detectCredentialsSuite struct {
@@ -115,9 +115,9 @@ func (s *detectCredentialsSuite) run(c *gc.C, stdin io.Reader, clouds map[string
 		return nil, errors.NotFoundf("cloud %s", cloudName)
 	}
 	command := cloud.NewDetectCredentialsCommandForTest(s.store, registeredProvidersFunc, allCloudsFunc, cloudByNameFunc)
-	err := testing.InitCommand(command, nil)
+	err := cmdtesting.InitCommand(command, nil)
 	c.Assert(err, jc.ErrorIsNil)
-	ctx := testing.Context(c)
+	ctx := cmdtesting.Context(c)
 	ctx.Stdin = stdin
 	return ctx, command.Run(ctx)
 }
@@ -152,7 +152,7 @@ func (s *detectCredentialsSuite) assertDetectCredential(c *gc.C, cloudName, expe
 		}
 		c.Assert(s.store.Credentials["test-cloud"], jc.DeepEquals, s.aCredential)
 	} else {
-		output := strings.Replace(testing.Stderr(ctx), "\n", "", -1)
+		output := strings.Replace(cmdtesting.Stderr(ctx), "\n", "", -1)
 		c.Assert(output, gc.Matches, ".*"+regexp.QuoteMeta(errText)+".*")
 	}
 }
@@ -200,7 +200,7 @@ func (s *detectCredentialsSuite) TestNewDetectCredentialNoneFound(c *gc.C) {
 	stdin := strings.NewReader("")
 	ctx, err := s.run(c, stdin, nil)
 	c.Assert(err, jc.ErrorIsNil)
-	output := strings.Replace(testing.Stderr(ctx), "\n", "", -1)
+	output := strings.Replace(cmdtesting.Stderr(ctx), "\n", "", -1)
 	c.Assert(output, gc.Matches, ".*No cloud credentials found.*")
 	c.Assert(s.store.Credentials, gc.HasLen, 0)
 }
@@ -216,7 +216,7 @@ func (s *detectCredentialsSuite) TestDetectCredentialInvalidChoice(c *gc.C) {
 	stdin := strings.NewReader("3\nQ\n")
 	ctx, err := s.run(c, stdin, nil)
 	c.Assert(err, jc.ErrorIsNil)
-	output := strings.Replace(testing.Stderr(ctx), "\n", "", -1)
+	output := strings.Replace(cmdtesting.Stderr(ctx), "\n", "", -1)
 	c.Assert(output, gc.Matches, ".*Invalid choice, enter a number between 1 and 2.*")
 	c.Assert(s.store.Credentials, gc.HasLen, 0)
 }

--- a/cmd/juju/cloud/list_test.go
+++ b/cmd/juju/cloud/list_test.go
@@ -11,6 +11,7 @@ import (
 	gc "gopkg.in/check.v1"
 
 	jujucloud "github.com/juju/juju/cloud"
+	"github.com/juju/juju/cmd/cmdtesting"
 	"github.com/juju/juju/cmd/juju/cloud"
 	"github.com/juju/juju/juju/osenv"
 	_ "github.com/juju/juju/provider/all"
@@ -24,9 +25,9 @@ type listSuite struct {
 var _ = gc.Suite(&listSuite{})
 
 func (s *listSuite) TestListPublic(c *gc.C) {
-	ctx, err := testing.RunCommand(c, cloud.NewListCloudsCommand())
+	ctx, err := cmdtesting.RunCommand(c, cloud.NewListCloudsCommand())
 	c.Assert(err, jc.ErrorIsNil)
-	out := testing.Stdout(ctx)
+	out := cmdtesting.Stdout(ctx)
 	out = strings.Replace(out, "\n", "", -1)
 	// Just check couple of snippets of the output to make sure it looks ok.
 	c.Assert(out, gc.Matches, `.*aws-china[ ]*1[ ]*cn-north-1[ ]*ec2.*`)
@@ -49,9 +50,9 @@ clouds:
 	err := ioutil.WriteFile(osenv.JujuXDGDataHomePath("clouds.yaml"), []byte(data), 0600)
 	c.Assert(err, jc.ErrorIsNil)
 
-	ctx, err := testing.RunCommand(c, cloud.NewListCloudsCommand())
+	ctx, err := cmdtesting.RunCommand(c, cloud.NewListCloudsCommand())
 	c.Assert(err, jc.ErrorIsNil)
-	out := testing.Stdout(ctx)
+	out := cmdtesting.Stdout(ctx)
 	out = strings.Replace(out, "\n", "", -1)
 	// Just check a snippet of the output to make sure it looks ok.
 	// local clouds are last.
@@ -70,9 +71,9 @@ clouds:
 	err := ioutil.WriteFile(osenv.JujuXDGDataHomePath("clouds.yaml"), []byte(data), 0600)
 	c.Assert(err, jc.ErrorIsNil)
 
-	ctx, err := testing.RunCommand(c, cloud.NewListCloudsCommand(), "--format", "yaml")
+	ctx, err := cmdtesting.RunCommand(c, cloud.NewListCloudsCommand(), "--format", "yaml")
 	c.Assert(err, jc.ErrorIsNil)
-	out := testing.Stdout(ctx)
+	out := cmdtesting.Stdout(ctx)
 	out = strings.Replace(out, "\n", "", -1)
 	// Just check a snippet of the output to make sure it looks ok.
 	// local clouds are last.
@@ -81,27 +82,27 @@ clouds:
 }
 
 func (s *listSuite) TestListYAML(c *gc.C) {
-	ctx, err := testing.RunCommand(c, cloud.NewListCloudsCommand(), "--format", "yaml")
+	ctx, err := cmdtesting.RunCommand(c, cloud.NewListCloudsCommand(), "--format", "yaml")
 	c.Assert(err, jc.ErrorIsNil)
-	out := testing.Stdout(ctx)
+	out := cmdtesting.Stdout(ctx)
 	out = strings.Replace(out, "\n", "", -1)
 	// Just check a snippet of the output to make sure it looks ok.
 	c.Assert(out, gc.Matches, `.*aws:[ ]*defined: public[ ]*type: ec2[ ]*description: Amazon Web Services[ ]*auth-types: \[access-key\].*`)
 }
 
 func (s *listSuite) TestListJSON(c *gc.C) {
-	ctx, err := testing.RunCommand(c, cloud.NewListCloudsCommand(), "--format", "json")
+	ctx, err := cmdtesting.RunCommand(c, cloud.NewListCloudsCommand(), "--format", "json")
 	c.Assert(err, jc.ErrorIsNil)
-	out := testing.Stdout(ctx)
+	out := cmdtesting.Stdout(ctx)
 	out = strings.Replace(out, "\n", "", -1)
 	// Just check a snippet of the output to make sure it looks ok.
 	c.Assert(out, gc.Matches, `.*{"aws":{"defined":"public","type":"ec2","description":"Amazon Web Services","auth-types":\["access-key"\].*`)
 }
 
 func (s *listSuite) TestListPreservesRegionOrder(c *gc.C) {
-	ctx, err := testing.RunCommand(c, cloud.NewListCloudsCommand(), "--format", "yaml")
+	ctx, err := cmdtesting.RunCommand(c, cloud.NewListCloudsCommand(), "--format", "yaml")
 	c.Assert(err, jc.ErrorIsNil)
-	lines := strings.Split(testing.Stdout(ctx), "\n")
+	lines := strings.Split(cmdtesting.Stdout(ctx), "\n")
 	withClouds := "clouds:\n  " + strings.Join(lines, "\n  ")
 
 	parsedClouds, err := jujucloud.ParseCloudMetadata([]byte(withClouds))

--- a/cmd/juju/cloud/listcredentials_test.go
+++ b/cmd/juju/cloud/listcredentials_test.go
@@ -11,6 +11,7 @@ import (
 	gc "gopkg.in/check.v1"
 
 	jujucloud "github.com/juju/juju/cloud"
+	"github.com/juju/juju/cmd/cmdtesting"
 	"github.com/juju/juju/cmd/juju/cloud"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/jujuclient"
@@ -297,28 +298,28 @@ func (s *listCredentialsSuite) TestListCredentialsEmpty(c *gc.C) {
 
 func (s *listCredentialsSuite) TestListCredentialsNone(c *gc.C) {
 	listCmd := cloud.NewListCredentialsCommandForTest(jujuclient.NewMemStore(), s.personalCloudsFunc, s.cloudByNameFunc)
-	ctx, err := testing.RunCommand(c, listCmd)
+	ctx, err := cmdtesting.RunCommand(c, listCmd)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(testing.Stderr(ctx), gc.Equals, "")
-	out := strings.Replace(testing.Stdout(ctx), "\n", "", -1)
+	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "")
+	out := strings.Replace(cmdtesting.Stdout(ctx), "\n", "", -1)
 	c.Assert(out, gc.Equals, "No credentials to display.")
 
-	ctx, err = testing.RunCommand(c, listCmd, "--format", "yaml")
+	ctx, err = cmdtesting.RunCommand(c, listCmd, "--format", "yaml")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(testing.Stderr(ctx), gc.Equals, "")
-	out = strings.Replace(testing.Stdout(ctx), "\n", "", -1)
+	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "")
+	out = strings.Replace(cmdtesting.Stdout(ctx), "\n", "", -1)
 	c.Assert(out, gc.Equals, "credentials: {}")
 
-	ctx, err = testing.RunCommand(c, listCmd, "--format", "json")
+	ctx, err = cmdtesting.RunCommand(c, listCmd, "--format", "json")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(testing.Stderr(ctx), gc.Equals, "")
-	out = strings.Replace(testing.Stdout(ctx), "\n", "", -1)
+	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "")
+	out = strings.Replace(cmdtesting.Stdout(ctx), "\n", "", -1)
 	c.Assert(out, gc.Equals, `{"credentials":{}}`)
 }
 
 func (s *listCredentialsSuite) listCredentials(c *gc.C, args ...string) string {
-	ctx, err := testing.RunCommand(c, cloud.NewListCredentialsCommandForTest(s.store, s.personalCloudsFunc, s.cloudByNameFunc), args...)
+	ctx, err := cmdtesting.RunCommand(c, cloud.NewListCredentialsCommandForTest(s.store, s.personalCloudsFunc, s.cloudByNameFunc), args...)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(testing.Stderr(ctx), gc.Equals, "")
-	return testing.Stdout(ctx)
+	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "")
+	return cmdtesting.Stdout(ctx)
 }

--- a/cmd/juju/cloud/regions_test.go
+++ b/cmd/juju/cloud/regions_test.go
@@ -9,6 +9,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/cmd/cmdtesting"
 	"github.com/juju/juju/cmd/juju/cloud"
 	_ "github.com/juju/juju/provider/all"
 	"github.com/juju/juju/testing"
@@ -21,19 +22,19 @@ type regionsSuite struct {
 var _ = gc.Suite(&regionsSuite{})
 
 func (s *regionsSuite) TestListRegionsInvalidCloud(c *gc.C) {
-	_, err := testing.RunCommand(c, cloud.NewListRegionsCommand(), "invalid")
+	_, err := cmdtesting.RunCommand(c, cloud.NewListRegionsCommand(), "invalid")
 	c.Assert(err, gc.ErrorMatches, "cloud invalid not found")
 }
 
 func (s *regionsSuite) TestListRegionsInvalidArgs(c *gc.C) {
-	_, err := testing.RunCommand(c, cloud.NewListRegionsCommand(), "aws", "another")
+	_, err := cmdtesting.RunCommand(c, cloud.NewListRegionsCommand(), "aws", "another")
 	c.Assert(err, gc.ErrorMatches, `unrecognized args: \["another"\]`)
 }
 
 func (s *regionsSuite) TestListRegions(c *gc.C) {
-	ctx, err := testing.RunCommand(c, cloud.NewListRegionsCommand(), "aws")
+	ctx, err := cmdtesting.RunCommand(c, cloud.NewListRegionsCommand(), "aws")
 	c.Assert(err, jc.ErrorIsNil)
-	out := testing.Stdout(ctx)
+	out := cmdtesting.Stdout(ctx)
 	c.Assert(out, jc.DeepEquals, `
 us-east-1
 us-east-2
@@ -54,16 +55,16 @@ sa-east-1
 }
 
 func (s *regionsSuite) TestListRegionsBuiltInCloud(c *gc.C) {
-	ctx, err := testing.RunCommand(c, cloud.NewListRegionsCommand(), "localhost")
+	ctx, err := cmdtesting.RunCommand(c, cloud.NewListRegionsCommand(), "localhost")
 	c.Assert(err, jc.ErrorIsNil)
-	out := testing.Stdout(ctx)
+	out := cmdtesting.Stdout(ctx)
 	c.Assert(out, jc.DeepEquals, "localhost\n\n")
 }
 
 func (s *regionsSuite) TestListRegionsYaml(c *gc.C) {
-	ctx, err := testing.RunCommand(c, cloud.NewListRegionsCommand(), "aws", "--format", "yaml")
+	ctx, err := cmdtesting.RunCommand(c, cloud.NewListRegionsCommand(), "aws", "--format", "yaml")
 	c.Assert(err, jc.ErrorIsNil)
-	out := testing.Stdout(ctx)
+	out := cmdtesting.Stdout(ctx)
 	c.Assert(out, jc.DeepEquals, `
 us-east-1:
   endpoint: https://ec2.us-east-1.amazonaws.com
@@ -97,9 +98,9 @@ sa-east-1:
 }
 
 func (s *regionsSuite) TestListGCERegions(c *gc.C) {
-	ctx, err := testing.RunCommand(c, cloud.NewListRegionsCommand(), "google")
+	ctx, err := cmdtesting.RunCommand(c, cloud.NewListRegionsCommand(), "google")
 	c.Assert(err, jc.ErrorIsNil)
-	out := testing.Stdout(ctx)
+	out := cmdtesting.Stdout(ctx)
 	c.Assert(out, jc.DeepEquals, `
 us-east1
 us-central1
@@ -112,9 +113,9 @@ asia-northeast1
 }
 
 func (s *regionsSuite) TestListGCERegionsYaml(c *gc.C) {
-	ctx, err := testing.RunCommand(c, cloud.NewListRegionsCommand(), "google", "--format", "yaml")
+	ctx, err := cmdtesting.RunCommand(c, cloud.NewListRegionsCommand(), "google", "--format", "yaml")
 	c.Assert(err, jc.ErrorIsNil)
-	out := testing.Stdout(ctx)
+	out := cmdtesting.Stdout(ctx)
 	c.Assert(out, jc.DeepEquals, `
 us-east1:
   endpoint: https://www.googleapis.com
@@ -138,9 +139,9 @@ type regionDetails struct {
 }
 
 func (s *regionsSuite) TestListRegionsJson(c *gc.C) {
-	ctx, err := testing.RunCommand(c, cloud.NewListRegionsCommand(), "azure", "--format", "json")
+	ctx, err := cmdtesting.RunCommand(c, cloud.NewListRegionsCommand(), "azure", "--format", "json")
 	c.Assert(err, jc.ErrorIsNil)
-	out := testing.Stdout(ctx)
+	out := cmdtesting.Stdout(ctx)
 	var data map[string]regionDetails
 	err = json.Unmarshal([]byte(out), &data)
 	c.Assert(err, jc.ErrorIsNil)

--- a/cmd/juju/cloud/remove_test.go
+++ b/cmd/juju/cloud/remove_test.go
@@ -10,6 +10,7 @@ import (
 	gc "gopkg.in/check.v1"
 
 	jujucloud "github.com/juju/juju/cloud"
+	"github.com/juju/juju/cmd/cmdtesting"
 	"github.com/juju/juju/cmd/juju/cloud"
 	"github.com/juju/juju/juju/osenv"
 	"github.com/juju/juju/testing"
@@ -23,17 +24,17 @@ var _ = gc.Suite(&removeSuite{})
 
 func (s *removeSuite) TestRemoveBadArgs(c *gc.C) {
 	cmd := cloud.NewRemoveCloudCommand()
-	_, err := testing.RunCommand(c, cmd)
+	_, err := cmdtesting.RunCommand(c, cmd)
 	c.Assert(err, gc.ErrorMatches, "Usage: juju remove-cloud <cloud name>")
-	_, err = testing.RunCommand(c, cmd, "cloud", "extra")
+	_, err = cmdtesting.RunCommand(c, cmd, "cloud", "extra")
 	c.Assert(err, gc.ErrorMatches, `unrecognized args: \["extra"\]`)
 }
 
 func (s *removeSuite) TestRemoveNotFound(c *gc.C) {
 	cmd := cloud.NewRemoveCloudCommand()
-	ctx, err := testing.RunCommand(c, cmd, "fnord")
+	ctx, err := cmdtesting.RunCommand(c, cmd, "fnord")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(testing.Stderr(ctx), gc.Equals, "No personal cloud called \"fnord\" exists\n")
+	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "No personal cloud called \"fnord\" exists\n")
 }
 
 func (s *removeSuite) createTestCloudData(c *gc.C) {
@@ -63,17 +64,17 @@ clouds:
 func (s *removeSuite) TestRemoveCloud(c *gc.C) {
 	s.createTestCloudData(c)
 	assertPersonalClouds(c, "homestack", "homestack2")
-	ctx, err := testing.RunCommand(c, cloud.NewRemoveCloudCommand(), "homestack")
+	ctx, err := cmdtesting.RunCommand(c, cloud.NewRemoveCloudCommand(), "homestack")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(testing.Stderr(ctx), gc.Equals, "Removed details of personal cloud \"homestack\"\n")
+	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "Removed details of personal cloud \"homestack\"\n")
 	assertPersonalClouds(c, "homestack2")
 }
 
 func (s *removeSuite) TestCannotRemovePublicCloud(c *gc.C) {
 	s.createTestCloudData(c)
-	ctx, err := testing.RunCommand(c, cloud.NewRemoveCloudCommand(), "prodstack")
+	ctx, err := cmdtesting.RunCommand(c, cloud.NewRemoveCloudCommand(), "prodstack")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(testing.Stderr(ctx), gc.Equals, "No personal cloud called \"prodstack\" exists\n")
+	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "No personal cloud called \"prodstack\" exists\n")
 }
 
 func assertPersonalClouds(c *gc.C, names ...string) {

--- a/cmd/juju/cloud/removecredential_test.go
+++ b/cmd/juju/cloud/removecredential_test.go
@@ -10,6 +10,7 @@ import (
 	gc "gopkg.in/check.v1"
 
 	jujucloud "github.com/juju/juju/cloud"
+	"github.com/juju/juju/cmd/cmdtesting"
 	"github.com/juju/juju/cmd/juju/cloud"
 	"github.com/juju/juju/jujuclient"
 	"github.com/juju/juju/testing"
@@ -23,9 +24,9 @@ var _ = gc.Suite(&removeCredentialSuite{})
 
 func (s *removeCredentialSuite) TestBadArgs(c *gc.C) {
 	cmd := cloud.NewRemoveCredentialCommand()
-	_, err := testing.RunCommand(c, cmd)
+	_, err := cmdtesting.RunCommand(c, cmd)
 	c.Assert(err, gc.ErrorMatches, "Usage: juju remove-credential <cloud-name> <credential-name>")
-	_, err = testing.RunCommand(c, cmd, "cloud", "credential", "extra")
+	_, err = cmdtesting.RunCommand(c, cmd, "cloud", "credential", "extra")
 	c.Assert(err, gc.ErrorMatches, `unrecognized args: \["extra"\]`)
 }
 
@@ -40,18 +41,18 @@ func (s *removeCredentialSuite) TestMissingCredential(c *gc.C) {
 		},
 	}
 	cmd := cloud.NewRemoveCredentialCommandForTest(store)
-	ctx, err := testing.RunCommand(c, cmd, "aws", "foo")
+	ctx, err := cmdtesting.RunCommand(c, cmd, "aws", "foo")
 	c.Assert(err, jc.ErrorIsNil)
-	output := testing.Stderr(ctx)
+	output := cmdtesting.Stderr(ctx)
 	output = strings.Replace(output, "\n", "", -1)
 	c.Assert(output, gc.Equals, `No credential called "foo" exists for cloud "aws"`)
 }
 
 func (s *removeCredentialSuite) TestBadCloudName(c *gc.C) {
 	cmd := cloud.NewRemoveCredentialCommandForTest(jujuclient.NewMemStore())
-	ctx, err := testing.RunCommand(c, cmd, "somecloud", "foo")
+	ctx, err := cmdtesting.RunCommand(c, cmd, "somecloud", "foo")
 	c.Assert(err, jc.ErrorIsNil)
-	output := testing.Stderr(ctx)
+	output := cmdtesting.Stderr(ctx)
 	output = strings.Replace(output, "\n", "", -1)
 	c.Assert(output, gc.Equals, `No credentials exist for cloud "somecloud"`)
 }
@@ -68,9 +69,9 @@ func (s *removeCredentialSuite) TestRemove(c *gc.C) {
 		},
 	}
 	cmd := cloud.NewRemoveCredentialCommandForTest(store)
-	ctx, err := testing.RunCommand(c, cmd, "aws", "my-credential")
+	ctx, err := cmdtesting.RunCommand(c, cmd, "aws", "my-credential")
 	c.Assert(err, jc.ErrorIsNil)
-	output := testing.Stderr(ctx)
+	output := cmdtesting.Stderr(ctx)
 	output = strings.Replace(output, "\n", "", -1)
 	c.Assert(output, gc.Equals, `Credential "my-credential" for cloud "aws" has been deleted.`)
 	_, stillThere := store.Credentials["aws"].AuthCredentials["my-credential"]

--- a/cmd/juju/cloud/show_test.go
+++ b/cmd/juju/cloud/show_test.go
@@ -9,6 +9,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/cmd/cmdtesting"
 	"github.com/juju/juju/cmd/juju/cloud"
 	"github.com/juju/juju/juju/osenv"
 	_ "github.com/juju/juju/provider/all"
@@ -22,14 +23,14 @@ type showSuite struct {
 var _ = gc.Suite(&showSuite{})
 
 func (s *showSuite) TestShowBadArgs(c *gc.C) {
-	_, err := testing.RunCommand(c, cloud.NewShowCloudCommand())
+	_, err := cmdtesting.RunCommand(c, cloud.NewShowCloudCommand())
 	c.Assert(err, gc.ErrorMatches, "no cloud specified")
 }
 
 func (s *showSuite) TestShow(c *gc.C) {
-	ctx, err := testing.RunCommand(c, cloud.NewShowCloudCommand(), "aws-china")
+	ctx, err := cmdtesting.RunCommand(c, cloud.NewShowCloudCommand(), "aws-china")
 	c.Assert(err, jc.ErrorIsNil)
-	out := testing.Stdout(ctx)
+	out := cmdtesting.Stdout(ctx)
 	c.Assert(out, gc.Equals, `
 defined: public
 type: ec2
@@ -57,9 +58,9 @@ clouds:
 `[1:]
 	err := ioutil.WriteFile(osenv.JujuXDGDataHomePath("clouds.yaml"), []byte(data), 0600)
 
-	ctx, err := testing.RunCommand(c, cloud.NewShowCloudCommand(), "homestack")
+	ctx, err := cmdtesting.RunCommand(c, cloud.NewShowCloudCommand(), "homestack")
 	c.Assert(err, jc.ErrorIsNil)
-	out := testing.Stdout(ctx)
+	out := cmdtesting.Stdout(ctx)
 	c.Assert(out, gc.Equals, `
 defined: local
 type: openstack
@@ -91,9 +92,9 @@ clouds:
 `[1:]
 	err := ioutil.WriteFile(osenv.JujuXDGDataHomePath("clouds.yaml"), []byte(data), 0600)
 
-	ctx, err := testing.RunCommand(c, cloud.NewShowCloudCommand(), "homestack")
+	ctx, err := cmdtesting.RunCommand(c, cloud.NewShowCloudCommand(), "homestack")
 	c.Assert(err, jc.ErrorIsNil)
-	out := testing.Stdout(ctx)
+	out := cmdtesting.Stdout(ctx)
 	c.Assert(out, gc.Equals, `
 defined: local
 type: openstack

--- a/cmd/juju/cloud/updateclouds_test.go
+++ b/cmd/juju/cloud/updateclouds_test.go
@@ -16,6 +16,7 @@ import (
 	gc "gopkg.in/check.v1"
 
 	jujucloud "github.com/juju/juju/cloud"
+	"github.com/juju/juju/cmd/cmdtesting"
 	"github.com/juju/juju/cmd/juju/cloud"
 	sstesting "github.com/juju/juju/environs/simplestreams/testing"
 	"github.com/juju/juju/testing"
@@ -64,20 +65,20 @@ func (s *updateCloudsSuite) setupTestServer(c *gc.C, serverContent string) *http
 
 func (s *updateCloudsSuite) TestBadArgs(c *gc.C) {
 	updateCmd := cloud.NewUpdateCloudsCommandForTest("")
-	_, err := testing.RunCommand(c, updateCmd, "extra")
+	_, err := cmdtesting.RunCommand(c, updateCmd, "extra")
 	c.Assert(err, gc.ErrorMatches, `unrecognized args: \["extra"\]`)
 }
 
 func (s *updateCloudsSuite) run(c *gc.C, url, errMsg string) string {
 	updateCmd := cloud.NewUpdateCloudsCommandForTest(url)
-	out, err := testing.RunCommand(c, updateCmd)
+	out, err := cmdtesting.RunCommand(c, updateCmd)
 	if errMsg == "" {
 		c.Assert(err, jc.ErrorIsNil)
 	} else {
 		errString := strings.Replace(err.Error(), "\n", "", -1)
 		c.Assert(errString, gc.Matches, errMsg)
 	}
-	return testing.Stderr(out)
+	return cmdtesting.Stderr(out)
 }
 
 func (s *updateCloudsSuite) Test404(c *gc.C) {

--- a/cmd/juju/cloud/updatecredential_test.go
+++ b/cmd/juju/cloud/updatecredential_test.go
@@ -11,6 +11,7 @@ import (
 	"gopkg.in/juju/names.v2"
 
 	jujucloud "github.com/juju/juju/cloud"
+	"github.com/juju/juju/cmd/cmdtesting"
 	"github.com/juju/juju/cmd/juju/cloud"
 	"github.com/juju/juju/jujuclient"
 	"github.com/juju/juju/testing"
@@ -30,9 +31,9 @@ func (s *updateCredentialSuite) TestBadArgs(c *gc.C) {
 		CurrentControllerName: "controller",
 	}
 	cmd := cloud.NewUpdateCredentialCommandForTest(store, nil)
-	_, err := testing.RunCommand(c, cmd)
+	_, err := cmdtesting.RunCommand(c, cmd)
 	c.Assert(err, gc.ErrorMatches, "Usage: juju update-credential <cloud-name> <credential-name>")
-	_, err = testing.RunCommand(c, cmd, "cloud", "credential", "extra")
+	_, err = cmdtesting.RunCommand(c, cmd, "cloud", "credential", "extra")
 	c.Assert(err, gc.ErrorMatches, `unrecognized args: \["extra"\]`)
 }
 
@@ -51,9 +52,9 @@ func (s *updateCredentialSuite) TestMissingCredential(c *gc.C) {
 		},
 	}
 	cmd := cloud.NewUpdateCredentialCommandForTest(store, nil)
-	ctx, err := testing.RunCommand(c, cmd, "aws", "foo")
+	ctx, err := cmdtesting.RunCommand(c, cmd, "aws", "foo")
 	c.Assert(err, jc.ErrorIsNil)
-	output := testing.Stderr(ctx)
+	output := cmdtesting.Stderr(ctx)
 	output = strings.Replace(output, "\n", "", -1)
 	c.Assert(output, gc.Equals, `No credential called "foo" exists for cloud "aws"`)
 }
@@ -66,9 +67,9 @@ func (s *updateCredentialSuite) TestBadCloudName(c *gc.C) {
 		CurrentControllerName: "controller",
 	}
 	cmd := cloud.NewUpdateCredentialCommandForTest(store, nil)
-	ctx, err := testing.RunCommand(c, cmd, "somecloud", "foo")
+	ctx, err := cmdtesting.RunCommand(c, cmd, "somecloud", "foo")
 	c.Assert(err, jc.ErrorIsNil)
-	output := testing.Stderr(ctx)
+	output := cmdtesting.Stderr(ctx)
 	output = strings.Replace(output, "\n", "", -1)
 	c.Assert(output, gc.Equals, `No credentials exist for cloud "somecloud"`)
 }
@@ -95,9 +96,9 @@ func (s *updateCredentialSuite) TestUpdate(c *gc.C) {
 	}
 	fake := &fakeUpdateCredentialAPI{}
 	cmd := cloud.NewUpdateCredentialCommandForTest(store, fake)
-	ctx, err := testing.RunCommand(c, cmd, "aws", "my-credential")
+	ctx, err := cmdtesting.RunCommand(c, cmd, "aws", "my-credential")
 	c.Assert(err, jc.ErrorIsNil)
-	output := testing.Stderr(ctx)
+	output := cmdtesting.Stderr(ctx)
 	output = strings.Replace(output, "\n", "", -1)
 	c.Assert(output, gc.Equals, `Updated credential "my-credential" for user "admin@local" on cloud "aws".`)
 	c.Assert(fake.creds, jc.DeepEquals, map[names.CloudCredentialTag]jujucloud.Credential{

--- a/cmd/juju/commands/bootstrap_interactive_test.go
+++ b/cmd/juju/commands/bootstrap_interactive_test.go
@@ -14,7 +14,7 @@ import (
 	gc "gopkg.in/check.v1"
 
 	jujucloud "github.com/juju/juju/cloud"
-	jujutesting "github.com/juju/juju/testing"
+	"github.com/juju/juju/cmd/cmdtesting"
 	"github.com/juju/juju/version"
 )
 
@@ -26,14 +26,14 @@ var _ = gc.Suite(BSInteractSuite{})
 
 func (BSInteractSuite) TestInitEmpty(c *gc.C) {
 	cmd := &bootstrapCommand{}
-	err := jujutesting.InitCommand(cmd, nil)
+	err := cmdtesting.InitCommand(cmd, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cmd.interactive, jc.IsTrue)
 }
 
 func (BSInteractSuite) TestInitBuildAgent(c *gc.C) {
 	cmd := &bootstrapCommand{}
-	err := jujutesting.InitCommand(cmd, []string{"--build-agent"})
+	err := cmdtesting.InitCommand(cmd, []string{"--build-agent"})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cmd.interactive, jc.IsTrue)
 	c.Assert(cmd.BuildAgent, jc.IsTrue)
@@ -41,28 +41,28 @@ func (BSInteractSuite) TestInitBuildAgent(c *gc.C) {
 
 func (BSInteractSuite) TestInitArg(c *gc.C) {
 	cmd := &bootstrapCommand{}
-	err := jujutesting.InitCommand(cmd, []string{"foo"})
+	err := cmdtesting.InitCommand(cmd, []string{"foo"})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cmd.interactive, jc.IsFalse)
 }
 
 func (BSInteractSuite) TestInitTwoArgs(c *gc.C) {
 	cmd := &bootstrapCommand{}
-	err := jujutesting.InitCommand(cmd, []string{"foo", "bar"})
+	err := cmdtesting.InitCommand(cmd, []string{"foo", "bar"})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cmd.interactive, jc.IsFalse)
 }
 
 func (BSInteractSuite) TestInitInfoOnlyFlag(c *gc.C) {
 	cmd := &bootstrapCommand{}
-	err := jujutesting.InitCommand(cmd, []string{"--clouds"})
+	err := cmdtesting.InitCommand(cmd, []string{"--clouds"})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cmd.interactive, jc.IsFalse)
 }
 
 func (BSInteractSuite) TestInitVariousFlags(c *gc.C) {
 	cmd := &bootstrapCommand{}
-	err := jujutesting.InitCommand(cmd, []string{"--keep-broken", "--agent-version", version.Current.String()})
+	err := cmdtesting.InitCommand(cmd, []string{"--keep-broken", "--agent-version", version.Current.String()})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cmd.interactive, jc.IsTrue)
 }

--- a/cmd/juju/commands/bootstrap_test.go
+++ b/cmd/juju/commands/bootstrap_test.go
@@ -29,8 +29,8 @@ import (
 
 	"github.com/juju/juju/cert"
 	"github.com/juju/juju/cloud"
+	"github.com/juju/juju/cmd/cmdtesting"
 	"github.com/juju/juju/cmd/modelcmd"
-	cmdtesting "github.com/juju/juju/cmd/testing"
 	"github.com/juju/juju/constraints"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/bootstrap"
@@ -245,7 +245,7 @@ func (s *BootstrapSuite) run(c *gc.C, test bootstrapTest) testing.Restorer {
 		cloudName, controllerName,
 		"--config", "default-series=raring",
 	}, test.args...)
-	opc, errc := cmdtesting.RunCommand(cmdtesting.NullContext(c), s.newBootstrapCommand(), args...)
+	opc, errc := cmdtesting.RunCommandWithDummyProvider(cmdtesting.NullContext(c), s.newBootstrapCommand(), args...)
 	var err error
 	select {
 	case err = <-errc:
@@ -441,7 +441,7 @@ var bootstrapTests = []bootstrapTest{{
 }}
 
 func (s *BootstrapSuite) TestRunCloudNameUnknown(c *gc.C) {
-	_, err := coretesting.RunCommand(c, s.newBootstrapCommand(), "unknown", "my-controller")
+	_, err := cmdtesting.RunCommand(c, s.newBootstrapCommand(), "unknown", "my-controller")
 	c.Check(err, gc.ErrorMatches, `unknown cloud "unknown", please try "juju update-clouds"`)
 }
 
@@ -469,17 +469,17 @@ func (s *BootstrapSuite) TestBootstrapTwice(c *gc.C) {
 	const controllerName = "dev"
 	s.setupAutoUploadTest(c, "1.8.3", "raring")
 
-	_, err := coretesting.RunCommand(c, s.newBootstrapCommand(), "dummy", controllerName, "--auto-upgrade")
+	_, err := cmdtesting.RunCommand(c, s.newBootstrapCommand(), "dummy", controllerName, "--auto-upgrade")
 	c.Assert(err, jc.ErrorIsNil)
 
-	_, err = coretesting.RunCommand(c, s.newBootstrapCommand(), "dummy", controllerName, "--auto-upgrade")
+	_, err = cmdtesting.RunCommand(c, s.newBootstrapCommand(), "dummy", controllerName, "--auto-upgrade")
 	c.Assert(err, gc.ErrorMatches, `controller "dev" already exists`)
 }
 
 func (s *BootstrapSuite) TestBootstrapDefaultControllerName(c *gc.C) {
 	s.setupAutoUploadTest(c, "1.8.3", "raring")
 
-	_, err := coretesting.RunCommand(c, s.newBootstrapCommand(), "dummy-cloud/region-1", "--auto-upgrade")
+	_, err := cmdtesting.RunCommand(c, s.newBootstrapCommand(), "dummy-cloud/region-1", "--auto-upgrade")
 	c.Assert(err, jc.ErrorIsNil)
 	currentController := s.store.CurrentControllerName
 	c.Assert(currentController, gc.Equals, "dummy-cloud-region-1")
@@ -493,7 +493,7 @@ func (s *BootstrapSuite) TestBootstrapDefaultControllerName(c *gc.C) {
 func (s *BootstrapSuite) TestBootstrapDefaultControllerNameNoRegions(c *gc.C) {
 	s.setupAutoUploadTest(c, "1.8.3", "raring")
 
-	_, err := coretesting.RunCommand(c, s.newBootstrapCommand(), "no-cloud-regions", "--auto-upgrade")
+	_, err := cmdtesting.RunCommand(c, s.newBootstrapCommand(), "no-cloud-regions", "--auto-upgrade")
 	c.Assert(err, jc.ErrorIsNil)
 	currentController := s.store.CurrentControllerName
 	c.Assert(currentController, gc.Equals, "no-cloud-regions")
@@ -502,7 +502,7 @@ func (s *BootstrapSuite) TestBootstrapDefaultControllerNameNoRegions(c *gc.C) {
 func (s *BootstrapSuite) TestBootstrapSetsCurrentModel(c *gc.C) {
 	s.setupAutoUploadTest(c, "1.8.3", "raring")
 
-	_, err := coretesting.RunCommand(c, s.newBootstrapCommand(), "dummy", "devcontroller", "--auto-upgrade")
+	_, err := cmdtesting.RunCommand(c, s.newBootstrapCommand(), "dummy", "devcontroller", "--auto-upgrade")
 	c.Assert(err, jc.ErrorIsNil)
 	currentController := s.store.CurrentControllerName
 	c.Assert(currentController, gc.Equals, "devcontroller")
@@ -514,7 +514,7 @@ func (s *BootstrapSuite) TestBootstrapSetsCurrentModel(c *gc.C) {
 func (s *BootstrapSuite) TestBootstrapSetsControllerDetails(c *gc.C) {
 	s.setupAutoUploadTest(c, "1.8.3", "raring")
 
-	_, err := coretesting.RunCommand(c, s.newBootstrapCommand(), "dummy", "devcontroller", "--auto-upgrade")
+	_, err := cmdtesting.RunCommand(c, s.newBootstrapCommand(), "dummy", "devcontroller", "--auto-upgrade")
 	c.Assert(err, jc.ErrorIsNil)
 	currentController := s.store.CurrentControllerName
 	c.Assert(currentController, gc.Equals, "devcontroller")
@@ -533,7 +533,7 @@ func (s *BootstrapSuite) TestBootstrapDefaultModel(c *gc.C) {
 		return &bootstrap
 	})
 
-	coretesting.RunCommand(
+	cmdtesting.RunCommand(
 		c, s.newBootstrapCommand(),
 		"dummy", "devcontroller",
 		"--auto-upgrade",
@@ -552,7 +552,7 @@ func (s *BootstrapSuite) TestBootstrapTimeout(c *gc.C) {
 	s.PatchValue(&getBootstrapFuncs, func() BootstrapInterface {
 		return &bootstrap
 	})
-	coretesting.RunCommand(
+	cmdtesting.RunCommand(
 		c, s.newBootstrapCommand(), "dummy", "devcontroller", "--auto-upgrade",
 		"--config", "bootstrap-timeout=99",
 	)
@@ -570,7 +570,7 @@ func (s *BootstrapSuite) TestBootstrapDefaultConfigStripsProcessedAttributes(c *
 	fakeSSHFile := filepath.Join(c.MkDir(), "ssh")
 	err := ioutil.WriteFile(fakeSSHFile, []byte("ssh-key"), 0600)
 	c.Assert(err, jc.ErrorIsNil)
-	coretesting.RunCommand(
+	cmdtesting.RunCommand(
 		c, s.newBootstrapCommand(),
 		"dummy", "devcontroller",
 		"--auto-upgrade",
@@ -588,7 +588,7 @@ func (s *BootstrapSuite) TestBootstrapModelDefaultConfig(c *gc.C) {
 		return &bootstrap
 	})
 
-	coretesting.RunCommand(
+	cmdtesting.RunCommand(
 		c, s.newBootstrapCommand(),
 		"dummy", "devcontroller",
 		"--model-default", "network=foo",
@@ -614,7 +614,7 @@ func (s *BootstrapSuite) TestBootstrapDefaultConfigStripsInheritedAttributes(c *
 	fakeSSHFile := filepath.Join(c.MkDir(), "ssh")
 	err := ioutil.WriteFile(fakeSSHFile, []byte("ssh-key"), 0600)
 	c.Assert(err, jc.ErrorIsNil)
-	coretesting.RunCommand(
+	cmdtesting.RunCommand(
 		c, s.newBootstrapCommand(),
 		"dummy", "devcontroller",
 		"--auto-upgrade",
@@ -668,7 +668,7 @@ func (s *BootstrapSuite) TestBootstrapAttributesInheritedOverDefaults(c *gc.C) {
 	s.patchVersionAndSeries(c, "raring")
 
 	bootstrapCmd := bootstrapCommand{}
-	ctx := coretesting.Context(c)
+	ctx := cmdtesting.Context(c)
 
 	// The OpenStack provider has a default of "use-floating-ip": false, so we
 	// use that to test against.
@@ -705,7 +705,7 @@ func (s *BootstrapSuite) TestBootstrapAttributesCLIOverDefaults(c *gc.C) {
 	s.patchVersionAndSeries(c, "raring")
 
 	bootstrapCmd := bootstrapCommand{}
-	ctx := coretesting.Context(c)
+	ctx := cmdtesting.Context(c)
 
 	// The OpenStack provider has a default of "use-floating-ip": false, so we
 	// use that to test against.
@@ -740,7 +740,7 @@ func (s *BootstrapSuite) TestBootstrapAttributesCLIOverInherited(c *gc.C) {
 	s.patchVersionAndSeries(c, "raring")
 
 	bootstrapCmd := bootstrapCommand{}
-	ctx := coretesting.Context(c)
+	ctx := cmdtesting.Context(c)
 
 	// The OpenStack provider has a default of "use-floating-ip": false, so we
 	// use that to test against.
@@ -777,7 +777,7 @@ func (s *BootstrapSuite) TestBootstrapWithGUI(c *gc.C) {
 	s.PatchValue(&getBootstrapFuncs, func() BootstrapInterface {
 		return &bootstrap
 	})
-	coretesting.RunCommand(c, s.newBootstrapCommandWrapper(false), "dummy", "devcontroller")
+	cmdtesting.RunCommand(c, s.newBootstrapCommandWrapper(false), "dummy", "devcontroller")
 	c.Assert(bootstrap.args.GUIDataSourceBaseURL, gc.Equals, gui.DefaultBaseURL)
 }
 
@@ -790,7 +790,7 @@ func (s *BootstrapSuite) TestBootstrapWithCustomizedGUI(c *gc.C) {
 		return &bootstrap
 	})
 
-	coretesting.RunCommand(c, s.newBootstrapCommandWrapper(false), "dummy", "devcontroller")
+	cmdtesting.RunCommand(c, s.newBootstrapCommandWrapper(false), "dummy", "devcontroller")
 	c.Assert(bootstrap.args.GUIDataSourceBaseURL, gc.Equals, "https://1.2.3.4/gui/streams")
 }
 
@@ -801,7 +801,7 @@ func (s *BootstrapSuite) TestBootstrapWithoutGUI(c *gc.C) {
 	s.PatchValue(&getBootstrapFuncs, func() BootstrapInterface {
 		return &bootstrap
 	})
-	coretesting.RunCommand(c, s.newBootstrapCommandWrapper(false), "dummy", "devcontroller", "--no-gui")
+	cmdtesting.RunCommand(c, s.newBootstrapCommandWrapper(false), "dummy", "devcontroller", "--no-gui")
 	c.Assert(bootstrap.args.GUIDataSourceBaseURL, gc.Equals, "")
 }
 
@@ -824,7 +824,7 @@ func (s *BootstrapSuite) TestBootstrapPropagatesStoreErrors(c *gc.C) {
 	cmd := &bootstrapCommand{}
 	cmd.SetClientStore(store)
 	wrapped := modelcmd.Wrap(cmd, modelcmd.WrapSkipModelFlags, modelcmd.WrapSkipDefaultModel)
-	_, err := coretesting.RunCommand(c, wrapped, "dummy", controllerName, "--auto-upgrade")
+	_, err := cmdtesting.RunCommand(c, wrapped, "dummy", controllerName, "--auto-upgrade")
 	store.CheckCallNames(c, "CredentialForCloud")
 	c.Assert(err, gc.ErrorMatches, `loading credentials: oh noes`)
 }
@@ -847,8 +847,8 @@ func (s *BootstrapSuite) TestBootstrapFailToPrepareDiesGracefully(c *gc.C) {
 		return nil, errors.New("mock-prepare")
 	})
 
-	ctx := coretesting.Context(c)
-	_, errc := cmdtesting.RunCommand(
+	ctx := cmdtesting.Context(c)
+	_, errc := cmdtesting.RunCommandWithDummyProvider(
 		ctx, s.newBootstrapCommand(),
 		"dummy", "devcontroller",
 	)
@@ -914,7 +914,7 @@ func (s *BootstrapSuite) TestBootstrapErrorRestoresOldMetadata(c *gc.C) {
 		user:           "fred",
 	}
 	s.writeControllerModelAccountInfo(c, &ctx)
-	_, err := coretesting.RunCommand(c, s.newBootstrapCommand(), "dummy", "devcontroller", "--auto-upgrade")
+	_, err := cmdtesting.RunCommand(c, s.newBootstrapCommand(), "dummy", "devcontroller", "--auto-upgrade")
 	c.Assert(err, gc.ErrorMatches, "mock-prepare")
 
 	currentController := s.store.CurrentControllerName
@@ -938,8 +938,8 @@ func (s *BootstrapSuite) TestBootstrapAlreadyExists(c *gc.C) {
 	}
 	s.writeControllerModelAccountInfo(c, &cmaCtx)
 
-	ctx := coretesting.Context(c)
-	_, errc := cmdtesting.RunCommand(ctx, s.newBootstrapCommand(), "dummy", controllerName, "--auto-upgrade")
+	ctx := cmdtesting.Context(c)
+	_, errc := cmdtesting.RunCommandWithDummyProvider(ctx, s.newBootstrapCommand(), "dummy", controllerName, "--auto-upgrade")
 	err := <-errc
 	c.Assert(err, jc.Satisfies, errors.IsAlreadyExists)
 	c.Assert(err, gc.ErrorMatches, fmt.Sprintf(`controller %q already exists`, controllerName))
@@ -963,13 +963,13 @@ func (s *BootstrapSuite) TestInvalidLocalSource(c *gc.C) {
 	// Bootstrap the controller with an invalid source.
 	// The command will look for prepackaged agent binaries
 	// in the source, and then fall back to building.
-	ctx, err := coretesting.RunCommand(
+	ctx, err := cmdtesting.RunCommand(
 		c, s.newBootstrapCommand(), "--metadata-source", c.MkDir(),
 		"dummy", "devcontroller",
 	)
 	c.Check(err, gc.Equals, cmd.ErrSilent)
 
-	stderr := coretesting.Stderr(ctx)
+	stderr := cmdtesting.Stderr(ctx)
 	c.Check(stderr, gc.Matches,
 		"(.|\n)*Looking for packaged Juju agent version 1\\.2\\.0 for amd64\n"+
 			"No packaged binary found, preparing local Juju agent binary(.|\n)*",
@@ -1012,7 +1012,7 @@ func (s *BootstrapSuite) TestBootstrapCalledWithMetadataDir(c *gc.C) {
 		return &bootstrap
 	})
 
-	coretesting.RunCommand(
+	cmdtesting.RunCommand(
 		c, s.newBootstrapCommand(),
 		"--metadata-source", sourceDir, "--constraints", "mem=4G",
 		"dummy-cloud/region-1", "devcontroller",
@@ -1033,7 +1033,7 @@ func (s *BootstrapSuite) checkBootstrapWithVersion(c *gc.C, vers, expect string)
 	num.Major = 2
 	num.Minor = 3
 	s.PatchValue(&jujuversion.Current, num)
-	coretesting.RunCommand(
+	cmdtesting.RunCommand(
 		c, s.newBootstrapCommand(),
 		"--agent-version", vers,
 		"dummy-cloud/region-1", "devcontroller",
@@ -1058,7 +1058,7 @@ func (s *BootstrapSuite) TestBootstrapWithAutoUpgrade(c *gc.C) {
 	s.PatchValue(&getBootstrapFuncs, func() BootstrapInterface {
 		return &bootstrap
 	})
-	coretesting.RunCommand(
+	cmdtesting.RunCommand(
 		c, s.newBootstrapCommand(),
 		"--auto-upgrade",
 		"dummy-cloud/region-1", "devcontroller",
@@ -1075,14 +1075,14 @@ func (s *BootstrapSuite) TestAutoSyncLocalSource(c *gc.C) {
 	// Bootstrap the controller with the valid source.
 	// The bootstrapping has to show no error, because the tools
 	// are automatically synchronized.
-	_, err := coretesting.RunCommand(
+	_, err := cmdtesting.RunCommand(
 		c, s.newBootstrapCommand(), "--metadata-source", sourceDir,
 		"dummy-cloud/region-1", "devcontroller", "--config", "default-series=trusty",
 	)
 	c.Assert(err, jc.ErrorIsNil)
 
 	bootstrapConfig, params, err := modelcmd.NewGetBootstrapConfigParamsFunc(
-		coretesting.Context(c), s.store, environs.GlobalProviderRegistry(),
+		cmdtesting.Context(c), s.store, environs.GlobalProviderRegistry(),
 	)("devcontroller")
 	c.Assert(err, jc.ErrorIsNil)
 	provider, err := environs.Provider(bootstrapConfig.CloudType)
@@ -1107,9 +1107,9 @@ func (s *BootstrapSuite) TestInteractiveBootstrap(c *gc.C) {
 	//s.patchVersionAndSeries(c, "raring")
 
 	cmd := s.newBootstrapCommand()
-	err := coretesting.InitCommand(cmd, nil)
+	err := cmdtesting.InitCommand(cmd, nil)
 	c.Assert(err, jc.ErrorIsNil)
-	ctx := coretesting.Context(c)
+	ctx := cmdtesting.Context(c)
 	out := bytes.Buffer{}
 	ctx.Stdin = strings.NewReader(`
 dummy-cloud
@@ -1154,7 +1154,7 @@ func (s *BootstrapSuite) TestAutoUploadAfterFailedSync(c *gc.C) {
 	s.setupAutoUploadTest(c, "1.7.3", "quantal")
 	// Run command and check for that upload has been run for tools matching
 	// the current juju version.
-	opc, errc := cmdtesting.RunCommand(
+	opc, errc := cmdtesting.RunCommandWithDummyProvider(
 		cmdtesting.NullContext(c), s.newBootstrapCommand(),
 		"dummy-cloud/region-1", "devcontroller",
 		"--config", "default-series=raring",
@@ -1175,7 +1175,7 @@ func (s *BootstrapSuite) TestAutoUploadAfterFailedSync(c *gc.C) {
 func (s *BootstrapSuite) TestMissingToolsError(c *gc.C) {
 	s.setupAutoUploadTest(c, "1.8.3", "precise")
 
-	_, err := coretesting.RunCommand(c, s.newBootstrapCommand(),
+	_, err := cmdtesting.RunCommand(c, s.newBootstrapCommand(),
 		"dummy-cloud/region-1", "devcontroller",
 		"--config", "default-series=raring", "--agent-version=1.8.4",
 	)
@@ -1195,7 +1195,7 @@ func (s *BootstrapSuite) TestMissingToolsUploadFailedError(c *gc.C) {
 	s.setupAutoUploadTest(c, "1.7.3", "precise")
 	s.PatchValue(&sync.BuildAgentTarball, BuildAgentTarballAlwaysFails)
 
-	ctx, err := coretesting.RunCommand(
+	ctx, err := cmdtesting.RunCommand(
 		c, s.newBootstrapCommand(),
 		"dummy-cloud/region-1", "devcontroller",
 		"--config", "default-series=raring",
@@ -1203,7 +1203,7 @@ func (s *BootstrapSuite) TestMissingToolsUploadFailedError(c *gc.C) {
 		"--auto-upgrade", "--agent-version=1.7.3",
 	)
 
-	c.Check(coretesting.Stderr(ctx), gc.Equals, `
+	c.Check(cmdtesting.Stderr(ctx), gc.Equals, `
 Creating Juju controller "devcontroller" on dummy-cloud/region-1
 Looking for packaged Juju agent version 1.7.3 for amd64
 No packaged binary found, preparing local Juju agent binary
@@ -1218,7 +1218,7 @@ No packaged binary found, preparing local Juju agent binary
 func (s *BootstrapSuite) TestBootstrapDestroy(c *gc.C) {
 	s.setupAutoUploadTest(c, "1.7.3", "quantal")
 
-	opc, errc := cmdtesting.RunCommand(
+	opc, errc := cmdtesting.RunCommandWithDummyProvider(
 		cmdtesting.NullContext(c), s.newBootstrapCommand(),
 		"dummy-cloud/region-1", "devcontroller",
 		"--config", "broken=Bootstrap Destroy",
@@ -1257,8 +1257,8 @@ func (s *BootstrapSuite) TestBootstrapDestroy(c *gc.C) {
 func (s *BootstrapSuite) TestBootstrapKeepBroken(c *gc.C) {
 	s.setupAutoUploadTest(c, "1.7.3", "quantal")
 
-	ctx := coretesting.Context(c)
-	opc, errc := cmdtesting.RunCommand(ctx, s.newBootstrapCommand(),
+	ctx := cmdtesting.Context(c)
+	opc, errc := cmdtesting.RunCommandWithDummyProvider(ctx, s.newBootstrapCommand(),
 		"--keep-broken",
 		"dummy-cloud/region-1", "devcontroller",
 		"--config", "broken=Bootstrap Destroy",
@@ -1287,69 +1287,69 @@ func (s *BootstrapSuite) TestBootstrapKeepBroken(c *gc.C) {
 			break
 		}
 	}
-	stderr := strings.Replace(coretesting.Stderr(ctx), "\n", " ", -1)
+	stderr := strings.Replace(cmdtesting.Stderr(ctx), "\n", " ", -1)
 	c.Assert(stderr, gc.Matches, `.*See .*juju kill\-controller.*`)
 }
 
 func (s *BootstrapSuite) TestBootstrapUnknownCloudOrProvider(c *gc.C) {
 	s.patchVersionAndSeries(c, "raring")
-	_, err := coretesting.RunCommand(c, s.newBootstrapCommand(), "no-such-provider", "ctrl")
+	_, err := cmdtesting.RunCommand(c, s.newBootstrapCommand(), "no-such-provider", "ctrl")
 	c.Assert(err, gc.ErrorMatches, `unknown cloud "no-such-provider", please try "juju update-clouds"`)
 }
 
 func (s *BootstrapSuite) TestBootstrapProviderNoRegionDetection(c *gc.C) {
 	s.patchVersionAndSeries(c, "raring")
-	_, err := coretesting.RunCommand(c, s.newBootstrapCommand(), "no-cloud-region-detection", "ctrl")
+	_, err := cmdtesting.RunCommand(c, s.newBootstrapCommand(), "no-cloud-region-detection", "ctrl")
 	c.Assert(err, gc.ErrorMatches, `unknown cloud "no-cloud-region-detection", please try "juju update-clouds"`)
 }
 
 func (s *BootstrapSuite) TestBootstrapProviderNoRegions(c *gc.C) {
-	ctx, err := coretesting.RunCommand(
+	ctx, err := cmdtesting.RunCommand(
 		c, s.newBootstrapCommand(), "no-cloud-regions", "ctrl",
 		"--config", "default-series=precise",
 	)
-	c.Check(coretesting.Stderr(ctx), gc.Matches, "Creating Juju controller \"ctrl\" on no-cloud-regions(.|\n)*")
+	c.Check(cmdtesting.Stderr(ctx), gc.Matches, "Creating Juju controller \"ctrl\" on no-cloud-regions(.|\n)*")
 	c.Assert(err, jc.ErrorIsNil)
 }
 
 func (s *BootstrapSuite) TestBootstrapCloudNoRegions(c *gc.C) {
 	resetJujuXDGDataHome(c)
-	ctx, err := coretesting.RunCommand(
+	ctx, err := cmdtesting.RunCommand(
 		c, s.newBootstrapCommand(), "dummy-cloud-without-regions", "ctrl",
 		"--config", "default-series=precise",
 	)
-	c.Check(coretesting.Stderr(ctx), gc.Matches, "Creating Juju controller \"ctrl\" on dummy-cloud-without-regions(.|\n)*")
+	c.Check(cmdtesting.Stderr(ctx), gc.Matches, "Creating Juju controller \"ctrl\" on dummy-cloud-without-regions(.|\n)*")
 	c.Assert(err, jc.ErrorIsNil)
 }
 
 func (s *BootstrapSuite) TestBootstrapCloudNoRegionsOneSpecified(c *gc.C) {
 	resetJujuXDGDataHome(c)
-	ctx, err := coretesting.RunCommand(
+	ctx, err := cmdtesting.RunCommand(
 		c, s.newBootstrapCommand(), "dummy-cloud-without-regions/my-region", "ctrl",
 		"--config", "default-series=precise",
 	)
-	c.Check(coretesting.Stderr(ctx), gc.Matches,
+	c.Check(cmdtesting.Stderr(ctx), gc.Matches,
 		"region \"my-region\" not found \\(expected one of \\[\\]\\)\n\n.*\n")
 	c.Assert(err, gc.Equals, cmd.ErrSilent)
 }
 
 func (s *BootstrapSuite) TestBootstrapProviderNoCredentials(c *gc.C) {
 	s.patchVersionAndSeries(c, "raring")
-	_, err := coretesting.RunCommand(c, s.newBootstrapCommand(), "no-credentials", "ctrl")
+	_, err := cmdtesting.RunCommand(c, s.newBootstrapCommand(), "no-credentials", "ctrl")
 	c.Assert(err, gc.ErrorMatches, `detecting credentials for "no-credentials" cloud provider: credentials not found`)
 }
 
 func (s *BootstrapSuite) TestBootstrapProviderManyDetectedCredentials(c *gc.C) {
 	s.patchVersionAndSeries(c, "raring")
-	_, err := coretesting.RunCommand(c, s.newBootstrapCommand(), "many-credentials", "ctrl")
+	_, err := cmdtesting.RunCommand(c, s.newBootstrapCommand(), "many-credentials", "ctrl")
 	c.Assert(err, gc.ErrorMatches, ambiguousDetectedCredentialError.Error())
 }
 
 func (s *BootstrapSuite) TestBootstrapProviderDetectRegionsInvalid(c *gc.C) {
 	s.patchVersionAndSeries(c, "raring")
-	ctx, err := coretesting.RunCommand(c, s.newBootstrapCommand(), "dummy/not-dummy", "ctrl")
+	ctx, err := cmdtesting.RunCommand(c, s.newBootstrapCommand(), "dummy/not-dummy", "ctrl")
 	c.Assert(err, gc.Equals, cmd.ErrSilent)
-	stderr := strings.Replace(coretesting.Stderr(ctx), "\n", "", -1)
+	stderr := strings.Replace(cmdtesting.Stderr(ctx), "\n", "", -1)
 	c.Assert(stderr, gc.Matches, `region "not-dummy" not found \(expected one of \["dummy"\]\)Specify an alternative region, or try "juju update-clouds".`)
 }
 
@@ -1365,7 +1365,7 @@ func (s *BootstrapSuite) TestBootstrapProviderManyCredentialsCloudNoAuthTypes(c 
 			AuthCredentials: map[string]cloud.Credential{"one": cloud.NewCredential("one", nil)},
 		},
 	}
-	coretesting.RunCommand(c, s.newBootstrapCommand(),
+	cmdtesting.RunCommand(c, s.newBootstrapCommand(),
 		"many-credentials-no-auth-types", "ctrl",
 		"--credential", "one",
 	)
@@ -1387,7 +1387,7 @@ func (s *BootstrapSuite) TestManyAvailableCredentialsNoneSpecified(c *gc.C) {
 			},
 		},
 	}
-	_, err := coretesting.RunCommand(c, s.newBootstrapCommand(), "dummy", "ctrl")
+	_, err := cmdtesting.RunCommand(c, s.newBootstrapCommand(), "dummy", "ctrl")
 	msg := strings.Replace(err.Error(), "\n", "", -1)
 	c.Assert(msg, gc.Matches, "more than one credential is available.*")
 }
@@ -1417,7 +1417,7 @@ func (s *BootstrapSuite) TestBootstrapProviderDetectCloud(c *gc.C) {
 	})
 
 	s.patchVersionAndSeries(c, "raring")
-	coretesting.RunCommand(c, s.newBootstrapCommand(), "bruce", "ctrl")
+	cmdtesting.RunCommand(c, s.newBootstrapCommand(), "bruce", "ctrl")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(bootstrap.args.CloudRegion, gc.Equals, "gazza")
 	c.Assert(bootstrap.args.CloudCredentialName, gc.Equals, "default")
@@ -1441,7 +1441,7 @@ func (s *BootstrapSuite) TestBootstrapProviderDetectRegions(c *gc.C) {
 	})
 
 	s.patchVersionAndSeries(c, "raring")
-	coretesting.RunCommand(c, s.newBootstrapCommand(), "dummy", "ctrl")
+	cmdtesting.RunCommand(c, s.newBootstrapCommand(), "dummy", "ctrl")
 	c.Assert(bootstrap.args.CloudRegion, gc.Equals, "bruce")
 	c.Assert(bootstrap.args.CloudCredentialName, gc.Equals, "default")
 	sort.Sort(bootstrap.args.Cloud.AuthTypes)
@@ -1465,7 +1465,7 @@ func (s *BootstrapSuite) TestBootstrapProviderDetectNoRegions(c *gc.C) {
 	})
 
 	s.patchVersionAndSeries(c, "raring")
-	coretesting.RunCommand(c, s.newBootstrapCommand(), "dummy", "ctrl")
+	cmdtesting.RunCommand(c, s.newBootstrapCommand(), "dummy", "ctrl")
 	c.Assert(bootstrap.args.CloudRegion, gc.Equals, "")
 	sort.Sort(bootstrap.args.Cloud.AuthTypes)
 	c.Assert(bootstrap.args.Cloud, jc.DeepEquals, cloud.Cloud{
@@ -1493,7 +1493,7 @@ func (s *BootstrapSuite) TestBootstrapProviderFinalizeCloud(c *gc.C) {
 	})
 
 	s.patchVersionAndSeries(c, "raring")
-	coretesting.RunCommand(c, s.newBootstrapCommand(), "dummy", "ctrl")
+	cmdtesting.RunCommand(c, s.newBootstrapCommand(), "dummy", "ctrl")
 	c.Assert(bootstrap.args.Cloud, jc.DeepEquals, cloud.Cloud{
 		Name:      "override",
 		Type:      "dummy",
@@ -1514,7 +1514,7 @@ func (s *BootstrapSuite) TestBootstrapProviderCaseInsensitiveRegionCheck(c *gc.C
 		return nil, errors.New("mock-prepare")
 	})
 
-	_, err := coretesting.RunCommand(c, s.newBootstrapCommand(), "dummy/DUMMY", "ctrl")
+	_, err := cmdtesting.RunCommand(c, s.newBootstrapCommand(), "dummy/DUMMY", "ctrl")
 	c.Assert(err, gc.ErrorMatches, "mock-prepare")
 	c.Assert(prepareParams.Cloud.Region, gc.Equals, "dummy")
 }
@@ -1526,7 +1526,7 @@ func (s *BootstrapSuite) TestBootstrapConfigFile(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.patchVersionAndSeries(c, "raring")
-	_, err = coretesting.RunCommand(
+	_, err = cmdtesting.RunCommand(
 		c, s.newBootstrapCommand(), "dummy", "ctrl",
 		"--config", configFile,
 	)
@@ -1546,7 +1546,7 @@ func (s *BootstrapSuite) TestBootstrapMultipleConfigFiles(c *gc.C) {
 	), 0644)
 
 	s.setupAutoUploadTest(c, "1.8.3", "raring")
-	_, err = coretesting.RunCommand(
+	_, err = cmdtesting.RunCommand(
 		c, s.newBootstrapCommand(), "dummy", "ctrl",
 		"--auto-upgrade",
 		// the second config file should replace attributes
@@ -1568,7 +1568,7 @@ func (s *BootstrapSuite) TestBootstrapConfigFileAndAdHoc(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.setupAutoUploadTest(c, "1.8.3", "raring")
-	_, err = coretesting.RunCommand(
+	_, err = cmdtesting.RunCommand(
 		c, s.newBootstrapCommand(), "dummy", "ctrl",
 		"--auto-upgrade",
 		// Configuration specified on the command line overrides
@@ -1585,7 +1585,7 @@ func (s *BootstrapSuite) TestBootstrapAutocertDNSNameDefaultPort(c *gc.C) {
 	s.PatchValue(&getBootstrapFuncs, func() BootstrapInterface {
 		return &bootstrap
 	})
-	coretesting.RunCommand(
+	cmdtesting.RunCommand(
 		c, s.newBootstrapCommand(), "dummy", "ctrl",
 		"--config", "autocert-dns-name=foo.example",
 	)
@@ -1598,7 +1598,7 @@ func (s *BootstrapSuite) TestBootstrapAutocertDNSNameExplicitAPIPort(c *gc.C) {
 	s.PatchValue(&getBootstrapFuncs, func() BootstrapInterface {
 		return &bootstrap
 	})
-	coretesting.RunCommand(
+	cmdtesting.RunCommand(
 		c, s.newBootstrapCommand(), "dummy", "ctrl",
 		"--config", "autocert-dns-name=foo.example",
 		"--config", "api-port=12345",
@@ -1608,7 +1608,7 @@ func (s *BootstrapSuite) TestBootstrapAutocertDNSNameExplicitAPIPort(c *gc.C) {
 
 func (s *BootstrapSuite) TestBootstrapCloudConfigAndAdHoc(c *gc.C) {
 	s.patchVersionAndSeries(c, "raring")
-	_, err := coretesting.RunCommand(
+	_, err := cmdtesting.RunCommand(
 		c, s.newBootstrapCommand(), "dummy-cloud-with-config", "ctrl",
 		"--auto-upgrade",
 		// Configuration specified on the command line overrides
@@ -1639,9 +1639,9 @@ func (s *BootstrapSuite) TestBootstrapPrintClouds(c *gc.C) {
 		s.store = jujuclient.NewMemStore()
 	}()
 
-	ctx, err := coretesting.RunCommand(c, s.newBootstrapCommand(), "--clouds")
+	ctx, err := cmdtesting.RunCommand(c, s.newBootstrapCommand(), "--clouds")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(coretesting.Stdout(ctx), jc.DeepEquals, `
+	c.Assert(cmdtesting.Stdout(ctx), jc.DeepEquals, `
 You can bootstrap on these clouds. See ‘--regions <cloud>’ for all regions.
 Cloud                           Credentials  Default Region
 aws                             fred         us-west-1
@@ -1668,9 +1668,9 @@ listed is the default. Add more clouds with ‘juju add-cloud’.
 
 func (s *BootstrapSuite) TestBootstrapPrintCloudRegions(c *gc.C) {
 	resetJujuXDGDataHome(c)
-	ctx, err := coretesting.RunCommand(c, s.newBootstrapCommand(), "--regions", "aws")
+	ctx, err := cmdtesting.RunCommand(c, s.newBootstrapCommand(), "--regions", "aws")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(coretesting.Stdout(ctx), jc.DeepEquals, `
+	c.Assert(cmdtesting.Stdout(ctx), jc.DeepEquals, `
 Showing regions for aws:
 us-east-1
 us-east-2
@@ -1691,7 +1691,7 @@ sa-east-1
 
 func (s *BootstrapSuite) TestBootstrapPrintCloudRegionsNoSuchCloud(c *gc.C) {
 	resetJujuXDGDataHome(c)
-	_, err := coretesting.RunCommand(c, s.newBootstrapCommand(), "--regions", "foo")
+	_, err := cmdtesting.RunCommand(c, s.newBootstrapCommand(), "--regions", "foo")
 	c.Assert(err, gc.ErrorMatches, "cloud foo not found")
 }
 
@@ -1724,7 +1724,7 @@ func (s *BootstrapSuite) TestBootstrapSetsControllerOnBase(c *gc.C) {
 		}()
 		com := s.newBootstrapCommand()
 		args := []string{"dummy", controllerName, "--auto-upgrade"}
-		if err := coretesting.InitCommand(com, args); err != nil {
+		if err := cmdtesting.InitCommand(com, args); err != nil {
 			errc <- err
 			return
 		}

--- a/cmd/juju/commands/cmd_test.go
+++ b/cmd/juju/commands/cmd_test.go
@@ -4,17 +4,21 @@
 package commands
 
 import (
+	"flag"
+	"fmt"
+	"os"
+	"os/exec"
+	stdtesting "testing"
+
 	"github.com/juju/testing"
 	gc "gopkg.in/check.v1"
 
-	cmdtesting "github.com/juju/juju/cmd/testing"
-	coretesting "github.com/juju/juju/testing"
+	"github.com/juju/juju/cmd/cmdtesting"
+	"github.com/juju/juju/juju/osenv"
 )
 
-func badrun(c *gc.C, exit int, args ...string) string {
-	args = append([]string{"juju"}, args...)
-	return cmdtesting.BadRun(c, exit, args...)
-}
+// flagRunMain is used to indicate that the -run-main flag was used.
+var flagRunMain = flag.Bool("run-main", false, "Run the application's main function for recursive testing")
 
 type CmdSuite struct {
 	testing.IsolationSuite
@@ -24,7 +28,7 @@ var _ = gc.Suite(&CmdSuite{})
 
 func initSSHCommand(args ...string) (*sshCommand, error) {
 	com := &sshCommand{}
-	return com, coretesting.InitCommand(com, args)
+	return com, cmdtesting.InitCommand(com, args)
 }
 
 func (*CmdSuite) TestSSHCommandInit(c *gc.C) {
@@ -35,7 +39,7 @@ func (*CmdSuite) TestSSHCommandInit(c *gc.C) {
 
 func initSCPCommand(args ...string) (*scpCommand, error) {
 	com := &scpCommand{}
-	return com, coretesting.InitCommand(com, args)
+	return com, cmdtesting.InitCommand(com, args)
 }
 
 func (*CmdSuite) TestSCPCommandInit(c *gc.C) {
@@ -46,4 +50,25 @@ func (*CmdSuite) TestSCPCommandInit(c *gc.C) {
 	// not enough args
 	_, err = initSCPCommand("mysql/0:foo")
 	c.Assert(err, gc.ErrorMatches, "at least two arguments required")
+}
+
+// Reentrancy point for testing (something as close as possible to) the juju
+// tool itself.
+func TestRunMain(t *stdtesting.T) {
+	if *flagRunMain {
+		os.Exit(Main(flag.Args()))
+	}
+}
+
+// badrun is used to run a command, check the exit code, and return the output.
+func badrun(c *gc.C, exit int, args ...string) string {
+	localArgs := append([]string{"-test.run", "TestRunMain", "-run-main", "--", "juju"}, args...)
+	ps := exec.Command(os.Args[0], localArgs...)
+	ps.Env = append(os.Environ(), osenv.JujuXDGDataHomeEnvKey+"="+osenv.JujuXDGDataHome())
+	output, err := ps.CombinedOutput()
+	c.Logf("command output: %q", output)
+	if exit != 0 {
+		c.Assert(err, gc.ErrorMatches, fmt.Sprintf("exit status %d", exit))
+	}
+	return string(output)
 }

--- a/cmd/juju/commands/debughooks_test.go
+++ b/cmd/juju/commands/debughooks_test.go
@@ -9,8 +9,8 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/cmd/cmdtesting"
 	jujussh "github.com/juju/juju/network/ssh"
-	coretesting "github.com/juju/juju/testing"
 )
 
 var _ = gc.Suite(&DebugHooksSuite{})
@@ -135,13 +135,13 @@ func (s *DebugHooksSuite) TestDebugHooksCommand(c *gc.C) {
 		s.setHostChecker(t.hostChecker)
 		s.setForceAPIv1(t.forceAPIv1)
 
-		ctx, err := coretesting.RunCommand(c, newDebugHooksCommand(s.hostChecker), t.args...)
+		ctx, err := cmdtesting.RunCommand(c, newDebugHooksCommand(s.hostChecker), t.args...)
 		if t.error != "" {
 			c.Check(err, gc.ErrorMatches, t.error)
 		} else {
 			c.Check(err, jc.ErrorIsNil)
 			if t.expected != nil {
-				t.expected.check(c, coretesting.Stdout(ctx))
+				t.expected.check(c, cmdtesting.Stdout(ctx))
 			}
 		}
 	}

--- a/cmd/juju/commands/debuglog_test.go
+++ b/cmd/juju/commands/debuglog_test.go
@@ -11,6 +11,7 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/api/common"
+	"github.com/juju/juju/cmd/cmdtesting"
 	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/testing"
 )
@@ -90,7 +91,7 @@ func (s *DebugLogSuite) TestArgParsing(c *gc.C) {
 	} {
 		c.Logf("test %v", i)
 		command := &debugLogCommand{}
-		err := testing.InitCommand(modelcmd.Wrap(command), test.args)
+		err := cmdtesting.InitCommand(modelcmd.Wrap(command), test.args)
 		if test.errMatch == "" {
 			c.Check(err, jc.ErrorIsNil)
 			c.Check(command.params, jc.DeepEquals, test.expected)
@@ -105,7 +106,7 @@ func (s *DebugLogSuite) TestParamsPassed(c *gc.C) {
 	s.PatchValue(&getDebugLogAPI, func(_ *debugLogCommand) (DebugLogAPI, error) {
 		return fake, nil
 	})
-	_, err := testing.RunCommand(c, newDebugLogCommand(),
+	_, err := cmdtesting.RunCommand(c, newDebugLogCommand(),
 		"-i", "machine-1*", "-x", "machine-1-lxd-1",
 		"--include-module=juju.provisioner",
 		"--lines=500",
@@ -141,9 +142,9 @@ func (s *DebugLogSuite) TestLogOutput(c *gc.C) {
 	checkOutput := func(args ...string) {
 		count := len(args)
 		args, expected := args[:count-1], args[count-1]
-		ctx, err := testing.RunCommand(c, newDebugLogCommandTZ(tz), args...)
+		ctx, err := cmdtesting.RunCommand(c, newDebugLogCommandTZ(tz), args...)
 		c.Check(err, jc.ErrorIsNil)
-		c.Check(testing.Stdout(ctx), gc.Equals, expected)
+		c.Check(cmdtesting.Stdout(ctx), gc.Equals, expected)
 
 	}
 	checkOutput(

--- a/cmd/juju/commands/enableha_test.go
+++ b/cmd/juju/commands/enableha_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/cmd/cmdtesting"
 	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/constraints"
 	"github.com/juju/juju/instance"
@@ -98,13 +99,13 @@ var _ = gc.Suite(&EnableHASuite{})
 
 func (s *EnableHASuite) runEnableHA(c *gc.C, args ...string) (*cmd.Context, error) {
 	command := &enableHACommand{newHAClientFunc: func() (MakeHAClient, error) { return s.fake, nil }}
-	return coretesting.RunCommand(c, modelcmd.WrapController(command), args...)
+	return cmdtesting.RunCommand(c, modelcmd.WrapController(command), args...)
 }
 
 func (s *EnableHASuite) TestEnableHA(c *gc.C) {
 	ctx, err := s.runEnableHA(c, "-n", "1")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(coretesting.Stdout(ctx), gc.Equals, "\n")
+	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, "\n")
 
 	c.Assert(s.fake.numControllers, gc.Equals, 1)
 	c.Assert(&s.fake.cons, jc.Satisfies, constraints.IsEmpty)
@@ -159,7 +160,7 @@ func (s *EnableHASuite) TestEnableHAWithFive(c *gc.C) {
 	// Also test with -n 5 to validate numbers other than 1 and 3
 	ctx, err := s.runEnableHA(c, "-n", "5")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(coretesting.Stdout(ctx), gc.Equals,
+	c.Assert(cmdtesting.Stdout(ctx), gc.Equals,
 		"maintaining machines: 0\n"+
 			"adding machines: 1, 2, 3, 4\n\n")
 
@@ -171,7 +172,7 @@ func (s *EnableHASuite) TestEnableHAWithFive(c *gc.C) {
 func (s *EnableHASuite) TestEnableHAWithConstraints(c *gc.C) {
 	ctx, err := s.runEnableHA(c, "--constraints", "mem=4G", "-n", "3")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(coretesting.Stdout(ctx), gc.Equals,
+	c.Assert(cmdtesting.Stdout(ctx), gc.Equals,
 		"maintaining machines: 0\n"+
 			"adding machines: 1, 2\n\n")
 
@@ -184,7 +185,7 @@ func (s *EnableHASuite) TestEnableHAWithConstraints(c *gc.C) {
 func (s *EnableHASuite) TestEnableHAWithPlacement(c *gc.C) {
 	ctx, err := s.runEnableHA(c, "--to", "valid", "-n", "3")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(coretesting.Stdout(ctx), gc.Equals,
+	c.Assert(cmdtesting.Stdout(ctx), gc.Equals,
 		"maintaining machines: 0\n"+
 			"adding machines: 1, 2\n\n")
 
@@ -209,7 +210,7 @@ func (s *EnableHASuite) TestEnableHAAllows0(c *gc.C) {
 	// then use the default number of 3.
 	ctx, err := s.runEnableHA(c, "-n", "0")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(coretesting.Stdout(ctx), gc.Equals,
+	c.Assert(cmdtesting.Stdout(ctx), gc.Equals,
 		"maintaining machines: 0\n"+
 			"adding machines: 1, 2\n\n")
 
@@ -223,7 +224,7 @@ func (s *EnableHASuite) TestEnableHADefaultsTo0(c *gc.C) {
 	// API.  The API will then use the default number of 3.
 	ctx, err := s.runEnableHA(c)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(coretesting.Stdout(ctx), gc.Equals,
+	c.Assert(cmdtesting.Stdout(ctx), gc.Equals,
 		"maintaining machines: 0\n"+
 			"adding machines: 1, 2\n\n")
 
@@ -236,11 +237,11 @@ func (s *EnableHASuite) TestEnableHAEndToEnd(c *gc.C) {
 	s.Factory.MakeMachine(c, &factory.MachineParams{
 		Jobs: []state.MachineJob{state.JobManageModel},
 	})
-	ctx, err := coretesting.RunCommand(c, newEnableHACommand(), "-n", "3")
+	ctx, err := cmdtesting.RunCommand(c, newEnableHACommand(), "-n", "3")
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Machine 0 is demoted because it hasn't reported its presence
-	c.Assert(coretesting.Stdout(ctx), gc.Equals,
+	c.Assert(cmdtesting.Stdout(ctx), gc.Equals,
 		"adding machines: 1, 2, 3\n"+
 			"demoting machines: 0\n\n")
 }
@@ -248,7 +249,7 @@ func (s *EnableHASuite) TestEnableHAEndToEnd(c *gc.C) {
 func (s *EnableHASuite) TestEnableHAToExisting(c *gc.C) {
 	ctx, err := s.runEnableHA(c, "--to", "1,2")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Check(coretesting.Stdout(ctx), gc.Equals, `
+	c.Check(cmdtesting.Stdout(ctx), gc.Equals, `
 maintaining machines: 0
 converting machines: 1, 2
 
@@ -264,5 +265,5 @@ func (s *EnableHASuite) TestEnableHADisallowsSeries(c *gc.C) {
 	// inadvertantly added back.
 	ctx, err := s.runEnableHA(c, "-n", "0", "--series", "xenian")
 	c.Assert(err, gc.ErrorMatches, "flag provided but not defined: --series")
-	c.Assert(coretesting.Stdout(ctx), gc.Equals, "")
+	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, "")
 }

--- a/cmd/juju/commands/machine_test.go
+++ b/cmd/juju/commands/machine_test.go
@@ -8,9 +8,9 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/cmd/cmdtesting"
 	jujutesting "github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/state"
-	"github.com/juju/juju/testing"
 )
 
 // MachineSuite tests the connectivity of all the machine subcommands. These
@@ -24,9 +24,9 @@ type MachineSuite struct {
 var _ = gc.Suite(&MachineSuite{})
 
 func (s *MachineSuite) RunCommand(c *gc.C, args ...string) (*cmd.Context, error) {
-	context := testing.Context(c)
+	context := cmdtesting.Context(c)
 	juju := NewJujuCommand(context)
-	if err := testing.InitCommand(juju, args); err != nil {
+	if err := cmdtesting.InitCommand(juju, args); err != nil {
 		return context, err
 	}
 	return context, juju.Run(context)
@@ -38,7 +38,7 @@ func (s *MachineSuite) TestMachineAdd(c *gc.C) {
 	count := len(machines)
 
 	ctx, err := s.RunCommand(c, "add-machine")
-	c.Assert(testing.Stderr(ctx), jc.Contains, `created machine`)
+	c.Assert(cmdtesting.Stderr(ctx), jc.Contains, `created machine`)
 
 	machines, err = s.State.AllMachines()
 	c.Assert(err, jc.ErrorIsNil)
@@ -49,7 +49,7 @@ func (s *MachineSuite) TestMachineRemove(c *gc.C) {
 	machine := s.Factory.MakeMachine(c, nil)
 
 	ctx, err := s.RunCommand(c, "remove-machine", machine.Id())
-	c.Assert(testing.Stdout(ctx), gc.Equals, "")
+	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, "")
 
 	err = machine.Refresh()
 	c.Assert(err, jc.ErrorIsNil)

--- a/cmd/juju/commands/main_test.go
+++ b/cmd/juju/commands/main_test.go
@@ -22,10 +22,10 @@ import (
 	"github.com/juju/version"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/cmd/cmdtesting"
 	"github.com/juju/juju/cmd/juju/application"
 	"github.com/juju/juju/cmd/juju/cloud"
 	"github.com/juju/juju/cmd/modelcmd"
-	cmdtesting "github.com/juju/juju/cmd/testing"
 	"github.com/juju/juju/feature"
 	"github.com/juju/juju/juju/osenv"
 	_ "github.com/juju/juju/provider/dummy"
@@ -656,7 +656,7 @@ func (s *MainSuite) TestRegisterCommands(c *gc.C) {
 
 	registry := &stubRegistry{stub: stub}
 	registry.names = append(registry.names, "help", "version") // implicit
-	registerCommands(registry, testing.Context(c))
+	registerCommands(registry, cmdtesting.Context(c))
 	sort.Strings(registry.names)
 
 	expected := make([]string, len(commandNames))
@@ -684,7 +684,7 @@ func (r *commands) RegisterSuperAlias(name, super, forName string, check cmd.Dep
 
 func (s *MainSuite) TestModelCommands(c *gc.C) {
 	var commands commands
-	registerCommands(&commands, testing.Context(c))
+	registerCommands(&commands, cmdtesting.Context(c))
 	// There should not be any ModelCommands registered.
 	// ModelCommands must be wrapped using modelcmd.Wrap.
 	for _, cmd := range commands {
@@ -707,7 +707,7 @@ func (s *MainSuite) TestAllCommandsPurpose(c *gc.C) {
 	// - Makes the Doc content either start like a sentence, or start
 	//   godoc-like by using the command's name in lowercase.
 	var commands commands
-	registerCommands(&commands, testing.Context(c))
+	registerCommands(&commands, cmdtesting.Context(c))
 	for _, cmd := range commands {
 		info := cmd.Info()
 		purpose := strings.TrimSpace(info.Purpose)

--- a/cmd/juju/commands/migrate_test.go
+++ b/cmd/juju/commands/migrate_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/juju/juju/api"
 	"github.com/juju/juju/api/base"
 	"github.com/juju/juju/api/controller"
+	"github.com/juju/juju/cmd/cmdtesting"
 	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/jujuclient"
 	"github.com/juju/juju/testing"
@@ -142,7 +143,7 @@ func (s *MigrateSuite) TestSuccess(c *gc.C) {
 	ctx, err := s.makeAndRun(c, "model", "target")
 	c.Assert(err, jc.ErrorIsNil)
 
-	c.Check(testing.Stderr(ctx), gc.Matches, "Migration started with ID \"uuid:0\"\n")
+	c.Check(cmdtesting.Stderr(ctx), gc.Matches, "Migration started with ID \"uuid:0\"\n")
 	c.Check(s.api.specSeen, jc.DeepEquals, &controller.MigrationSpec{
 		ModelUUID:            modelUUID,
 		TargetControllerUUID: targetControllerUUID,
@@ -163,7 +164,7 @@ func (s *MigrateSuite) TestSuccessMacaroons(c *gc.C) {
 	ctx, err := s.makeAndRun(c, "model", "target")
 	c.Assert(err, jc.ErrorIsNil)
 
-	c.Check(testing.Stderr(ctx), gc.Matches, "Migration started with ID \"uuid:0\"\n")
+	c.Check(cmdtesting.Stderr(ctx), gc.Matches, "Migration started with ID \"uuid:0\"\n")
 	c.Check(s.api.specSeen, jc.DeepEquals, &controller.MigrationSpec{
 		ModelUUID:            modelUUID,
 		TargetControllerUUID: targetControllerUUID,
@@ -191,7 +192,7 @@ func (s *MigrateSuite) TestMultipleModelMatch(c *gc.C) {
 		"Multiple potential matches found, please specify owner to disambiguate:\n" +
 		"  alpha/production\n" +
 		"  omega/production\n"
-	c.Check(testing.Stderr(ctx), gc.Equals, expected)
+	c.Check(cmdtesting.Stderr(ctx), gc.Equals, expected)
 	c.Check(s.api.specSeen, gc.IsNil) // API shouldn't have been called
 }
 
@@ -199,7 +200,7 @@ func (s *MigrateSuite) TestSpecifyOwner(c *gc.C) {
 	ctx, err := s.makeAndRun(c, "omega/production", "target")
 	c.Assert(err, jc.ErrorIsNil)
 
-	c.Check(testing.Stderr(ctx), gc.Matches, "Migration started with ID \"uuid:0\"\n")
+	c.Check(cmdtesting.Stderr(ctx), gc.Matches, "Migration started with ID \"uuid:0\"\n")
 	c.Check(s.api.specSeen.ModelUUID, gc.Equals, "prod-2-uuid")
 }
 
@@ -225,7 +226,7 @@ func (s *MigrateSuite) makeCommand() *migrateCommand {
 }
 
 func (s *MigrateSuite) run(c *gc.C, cmd *migrateCommand, args ...string) (*cmd.Context, error) {
-	return testing.RunCommand(c, modelcmd.WrapController(cmd), args...)
+	return cmdtesting.RunCommand(c, modelcmd.WrapController(cmd), args...)
 }
 
 type fakeMigrateAPI struct {

--- a/cmd/juju/commands/package_test.go
+++ b/cmd/juju/commands/package_test.go
@@ -4,13 +4,9 @@
 package commands_test
 
 import (
-	"flag"
-	"os"
 	"runtime"
 	stdtesting "testing"
 
-	"github.com/juju/juju/cmd/juju/commands"
-	cmdtesting "github.com/juju/juju/cmd/testing"
 	"github.com/juju/juju/component/all"
 	_ "github.com/juju/juju/provider/dummy"
 	"github.com/juju/juju/testing"
@@ -27,12 +23,4 @@ func TestPackage(t *stdtesting.T) {
 		t.Skipf("skipping package for %v/%v, see http://pad.lv/1425569", runtime.GOOS, runtime.GOARCH)
 	}
 	testing.MgoTestPackage(t)
-}
-
-// Reentrancy point for testing (something as close as possible to) the juju
-// tool itself.
-func TestRunMain(t *stdtesting.T) {
-	if *cmdtesting.FlagRunMain {
-		os.Exit(commands.Main(flag.Args()))
-	}
 }

--- a/cmd/juju/commands/plugin_test.go
+++ b/cmd/juju/commands/plugin_test.go
@@ -17,6 +17,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/cmd/cmdtesting"
 	"github.com/juju/juju/jujuclient"
 	"github.com/juju/juju/testing"
 )
@@ -73,21 +74,21 @@ func (suite *PluginSuite) TestFindPluginsIgnoreNotExec(c *gc.C) {
 
 func (suite *PluginSuite) TestRunPluginExising(c *gc.C) {
 	suite.makeWorkingPlugin("foo", 0755)
-	ctx := testing.Context(c)
+	ctx := cmdtesting.Context(c)
 	err := RunPlugin(ctx, "foo", []string{"some params"})
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(testing.Stdout(ctx), gc.Equals, "foo some params\n")
-	c.Assert(testing.Stderr(ctx), gc.Equals, "")
+	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, "foo some params\n")
+	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "")
 }
 
 func (suite *PluginSuite) TestRunPluginWithFailing(c *gc.C) {
 	suite.makeFailingPlugin("foo", 2)
-	ctx := testing.Context(c)
+	ctx := cmdtesting.Context(c)
 	err := RunPlugin(ctx, "foo", []string{"some params"})
 	c.Assert(err, gc.ErrorMatches, "subprocess encountered error code 2")
 	c.Assert(err, jc.Satisfies, cmd.IsRcPassthroughError)
-	c.Assert(testing.Stdout(ctx), gc.Equals, "failing\n")
-	c.Assert(testing.Stderr(ctx), gc.Equals, "")
+	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, "failing\n")
+	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "")
 }
 
 func (suite *PluginSuite) TestGatherDescriptionsInParallel(c *gc.C) {

--- a/cmd/juju/commands/resolved_test.go
+++ b/cmd/juju/commands/resolved_test.go
@@ -9,6 +9,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/cmd/cmdtesting"
 	"github.com/juju/juju/cmd/juju/application"
 	jujutesting "github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/state"
@@ -32,12 +33,12 @@ func (s *ResolvedSuite) SetUpTest(c *gc.C) {
 var _ = gc.Suite(&ResolvedSuite{})
 
 func runResolved(c *gc.C, args []string) error {
-	_, err := testing.RunCommand(c, newResolvedCommand(), args...)
+	_, err := cmdtesting.RunCommand(c, newResolvedCommand(), args...)
 	return err
 }
 
 func runDeploy(c *gc.C, args ...string) error {
-	_, err := testing.RunCommand(c, application.NewDefaultDeployCommand(), args...)
+	_, err := cmdtesting.RunCommand(c, application.NewDefaultDeployCommand(), args...)
 	return err
 }
 

--- a/cmd/juju/commands/run_test.go
+++ b/cmd/juju/commands/run_test.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/cmd/cmdtesting"
 	"github.com/juju/juju/cmd/juju/action"
 	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/testing"
@@ -121,7 +122,7 @@ func (*RunSuite) TestTargetArgParsing(c *gc.C) {
 		c.Log(fmt.Sprintf("%v: %s", i, test.message))
 		cmd := &runCommand{}
 		runCmd := modelcmd.Wrap(cmd)
-		testing.TestInit(c, runCmd, test.args, test.errMatch)
+		cmdtesting.TestInit(c, runCmd, test.args, test.errMatch)
 		if test.errMatch == "" {
 			c.Check(cmd.all, gc.Equals, test.all)
 			c.Check(cmd.machines, gc.DeepEquals, test.machines)
@@ -158,7 +159,7 @@ func (*RunSuite) TestTimeoutArgParsing(c *gc.C) {
 		c.Log(fmt.Sprintf("%v: %s", i, test.message))
 		cmd := &runCommand{}
 		runCmd := modelcmd.Wrap(cmd)
-		testing.TestInit(c, runCmd, test.args, test.errMatch)
+		cmdtesting.TestInit(c, runCmd, test.args, test.errMatch)
 		if test.errMatch == "" {
 			c.Check(cmd.timeout, gc.Equals, test.timeout)
 		}
@@ -265,19 +266,19 @@ func (s *RunSuite) TestRunForMachineAndUnit(c *gc.C) {
 	err := cmd.FormatJson(buff, unformatted)
 	c.Assert(err, jc.ErrorIsNil)
 
-	context, err := testing.RunCommand(c, newTestRunCommand(&mockClock{}),
+	context, err := cmdtesting.RunCommand(c, newTestRunCommand(&mockClock{}),
 		"--format=json", "--machine=0", "--unit=unit/0", "hostname",
 	)
 	c.Assert(err, jc.ErrorIsNil)
 
-	c.Check(testing.Stdout(context), gc.Equals, buff.String())
+	c.Check(cmdtesting.Stdout(context), gc.Equals, buff.String())
 }
 
 func (s *RunSuite) TestBlockRunForMachineAndUnit(c *gc.C) {
 	mock := s.setupMockAPI()
 	// Block operation
 	mock.block = true
-	_, err := testing.RunCommand(c, newTestRunCommand(&mockClock{}),
+	_, err := cmdtesting.RunCommand(c, newTestRunCommand(&mockClock{}),
 		"--format=json", "--machine=0", "--unit=unit/0", "hostname",
 	)
 	testing.AssertOperationWasBlocked(c, err, ".*To enable changes.*")
@@ -325,11 +326,11 @@ func (s *RunSuite) TestAllMachines(c *gc.C) {
 	err := cmd.FormatJson(buff, unformatted)
 	c.Assert(err, jc.ErrorIsNil)
 
-	context, err := testing.RunCommand(c, newTestRunCommand(&mockClock{}), "--format=json", "--all", "hostname")
+	context, err := cmdtesting.RunCommand(c, newTestRunCommand(&mockClock{}), "--format=json", "--all", "hostname")
 	c.Assert(err, jc.ErrorIsNil)
 
-	c.Check(testing.Stdout(context), gc.Equals, buff.String())
-	c.Check(testing.Stderr(context), gc.Equals, "")
+	c.Check(cmdtesting.Stdout(context), gc.Equals, buff.String())
+	c.Check(cmdtesting.Stderr(context), gc.Equals, "")
 }
 
 func (s *RunSuite) TestTimeout(c *gc.C) {
@@ -369,14 +370,14 @@ func (s *RunSuite) TestTimeout(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	var clock mockClock
-	context, err := testing.RunCommand(
+	context, err := cmdtesting.RunCommand(
 		c, newTestRunCommand(&clock),
 		"--format=json", "--all", "hostname", "--timeout", "99s",
 	)
 	c.Assert(err, gc.ErrorMatches, "timed out waiting for results from: machine 1, machine 2")
 
-	c.Check(testing.Stdout(context), gc.Equals, buf.String())
-	c.Check(testing.Stderr(context), gc.Equals, "")
+	c.Check(cmdtesting.Stdout(context), gc.Equals, buf.String())
+	c.Check(cmdtesting.Stderr(context), gc.Equals, "")
 	clock.CheckCalls(c, []gitjujutesting.StubCall{
 		{"After", []interface{}{99 * time.Second}},
 		{"After", []interface{}{1 * time.Second}},
@@ -420,7 +421,7 @@ func (s *RunSuite) TestBlockAllMachines(c *gc.C) {
 	mock := s.setupMockAPI()
 	// Block operation
 	mock.block = true
-	_, err := testing.RunCommand(c, newTestRunCommand(&mockClock{}), "--format=json", "--all", "hostname")
+	_, err := cmdtesting.RunCommand(c, newTestRunCommand(&mockClock{}), "--format=json", "--all", "hostname")
 	testing.AssertOperationWasBlocked(c, err, ".*To enable changes.*")
 }
 
@@ -479,14 +480,14 @@ func (s *RunSuite) TestSingleResponse(c *gc.C) {
 			args = append(args, "--format", test.format)
 		}
 		args = append(args, "--all", "ignored")
-		context, err := testing.RunCommand(c, newTestRunCommand(&mockClock{}), args...)
+		context, err := cmdtesting.RunCommand(c, newTestRunCommand(&mockClock{}), args...)
 		if test.errorMatch != "" {
 			c.Check(err, gc.ErrorMatches, test.errorMatch)
 		} else {
 			c.Check(err, jc.ErrorIsNil)
 		}
-		c.Check(testing.Stdout(context), gc.Equals, test.stdout)
-		c.Check(testing.Stderr(context), gc.Equals, test.stderr)
+		c.Check(cmdtesting.Stdout(context), gc.Equals, test.stdout)
+		c.Check(cmdtesting.Stderr(context), gc.Equals, test.stderr)
 	}
 }
 

--- a/cmd/juju/commands/scp_unix_test.go
+++ b/cmd/juju/commands/scp_unix_test.go
@@ -12,8 +12,8 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/cmd/cmdtesting"
 	jujussh "github.com/juju/juju/network/ssh"
-	coretesting "github.com/juju/juju/testing"
 )
 
 var _ = gc.Suite(&SCPSuite{})
@@ -220,7 +220,7 @@ func (s *SCPSuite) TestSCPCommand(c *gc.C) {
 		s.setHostChecker(t.hostChecker)
 		s.setForceAPIv1(t.forceAPIv1)
 
-		ctx, err := coretesting.RunCommand(c, newSCPCommand(s.hostChecker), t.args...)
+		ctx, err := cmdtesting.RunCommand(c, newSCPCommand(s.hostChecker), t.args...)
 		if t.error != "" {
 			c.Check(err, gc.ErrorMatches, t.error)
 		} else {
@@ -228,8 +228,8 @@ func (s *SCPSuite) TestSCPCommand(c *gc.C) {
 			// we suppress stdout from scp, so get the scp args used
 			// from the "scp.args" file that the fake scp executable
 			// installed by SSHCommonSuite generates.
-			c.Check(coretesting.Stderr(ctx), gc.Equals, "")
-			c.Check(coretesting.Stdout(ctx), gc.Equals, "")
+			c.Check(cmdtesting.Stderr(ctx), gc.Equals, "")
+			c.Check(cmdtesting.Stdout(ctx), gc.Equals, "")
 			actual, err := ioutil.ReadFile(filepath.Join(s.binDir, "scp.args"))
 			c.Assert(err, jc.ErrorIsNil)
 			t.expected.check(c, string(actual))

--- a/cmd/juju/commands/ssh_unix_test.go
+++ b/cmd/juju/commands/ssh_unix_test.go
@@ -15,8 +15,8 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/apiserver"
+	"github.com/juju/juju/cmd/cmdtesting"
 	jujussh "github.com/juju/juju/network/ssh"
-	coretesting "github.com/juju/juju/testing"
 )
 
 type SSHSuite struct {
@@ -179,13 +179,13 @@ func (s *SSHSuite) TestSSHCommand(c *gc.C) {
 		s.setHostChecker(t.hostChecker)
 		s.setForceAPIv1(t.forceAPIv1)
 
-		ctx, err := coretesting.RunCommand(c, newSSHCommand(s.hostChecker), t.args...)
+		ctx, err := cmdtesting.RunCommand(c, newSSHCommand(s.hostChecker), t.args...)
 		if t.expectedErr != "" {
 			c.Check(err, gc.ErrorMatches, t.expectedErr)
 		} else {
 			c.Check(err, jc.ErrorIsNil)
-			c.Check(coretesting.Stderr(ctx), gc.Equals, "")
-			stdout := coretesting.Stdout(ctx)
+			c.Check(cmdtesting.Stderr(ctx), gc.Equals, "")
+			stdout := cmdtesting.Stdout(ctx)
 			t.expected.check(c, stdout)
 		}
 	}
@@ -200,9 +200,9 @@ func (s *SSHSuite) TestSSHCommandModelConfigProxySSH(c *gc.C) {
 
 	s.setForceAPIv1(true)
 
-	ctx, err := coretesting.RunCommand(c, newSSHCommand(s.hostChecker), "0")
+	ctx, err := cmdtesting.RunCommand(c, newSSHCommand(s.hostChecker), "0")
 	c.Check(err, jc.ErrorIsNil)
-	c.Check(coretesting.Stderr(ctx), gc.Equals, "")
+	c.Check(cmdtesting.Stderr(ctx), gc.Equals, "")
 	expectedArgs := argsSpec{
 		hostKeyChecking: "yes",
 		knownHosts:      "0",
@@ -210,14 +210,14 @@ func (s *SSHSuite) TestSSHCommandModelConfigProxySSH(c *gc.C) {
 		withProxy:       true,
 		args:            "ubuntu@0.private", // as set by setAddresses()
 	}
-	expectedArgs.check(c, coretesting.Stdout(ctx))
+	expectedArgs.check(c, cmdtesting.Stdout(ctx))
 
 	s.setForceAPIv1(false)
-	ctx, err = coretesting.RunCommand(c, newSSHCommand(s.hostChecker), "0")
+	ctx, err = cmdtesting.RunCommand(c, newSSHCommand(s.hostChecker), "0")
 	c.Check(err, jc.ErrorIsNil)
-	c.Check(coretesting.Stderr(ctx), gc.Equals, "")
+	c.Check(cmdtesting.Stderr(ctx), gc.Equals, "")
 	expectedArgs.argsMatch = `ubuntu@0.(public|private|1\.2\.3)` // can be any of the 3 with api v2.
-	expectedArgs.check(c, coretesting.Stdout(ctx))
+	expectedArgs.check(c, cmdtesting.Stdout(ctx))
 
 }
 
@@ -287,7 +287,7 @@ func (s *SSHSuite) testSSHCommandHostAddressRetry(c *gc.C, proxy bool) {
 	// Ensure that the ssh command waits for a public (private with proxy=true)
 	// address, or the attempt strategy's Done method returns false.
 	args := []string{"--proxy=" + fmt.Sprint(proxy), "0"}
-	_, err := coretesting.RunCommand(c, newSSHCommand(s.hostChecker), args...)
+	_, err := cmdtesting.RunCommand(c, newSSHCommand(s.hostChecker), args...)
 	c.Assert(err, gc.ErrorMatches, `no .+ address\(es\)`)
 	c.Assert(called, gc.Equals, 2)
 
@@ -306,7 +306,7 @@ func (s *SSHSuite) testSSHCommandHostAddressRetry(c *gc.C, proxy bool) {
 		return true
 	}
 
-	_, err = coretesting.RunCommand(c, newSSHCommand(s.hostChecker), args...)
+	_, err = cmdtesting.RunCommand(c, newSSHCommand(s.hostChecker), args...)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(called, gc.Equals, 2)
 }

--- a/cmd/juju/commands/sshkeys_test.go
+++ b/cmd/juju/commands/sshkeys_test.go
@@ -13,6 +13,7 @@ import (
 
 	keymanagerserver "github.com/juju/juju/apiserver/keymanager"
 	keymanagertesting "github.com/juju/juju/apiserver/keymanager/testing"
+	"github.com/juju/juju/cmd/cmdtesting"
 	"github.com/juju/juju/juju/osenv"
 	jujutesting "github.com/juju/juju/juju/testing"
 	coretesting "github.com/juju/juju/testing"
@@ -94,9 +95,9 @@ func (s *ListKeysSuite) TestListKeys(c *gc.C) {
 	key2 := sshtesting.ValidKeyTwo.Key + " another@host"
 	s.setAuthorizedKeys(c, key1, key2)
 
-	context, err := coretesting.RunCommand(c, NewListKeysCommand())
+	context, err := cmdtesting.RunCommand(c, NewListKeysCommand())
 	c.Assert(err, jc.ErrorIsNil)
-	output := strings.TrimSpace(coretesting.Stdout(context))
+	output := strings.TrimSpace(cmdtesting.Stdout(context))
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(output, gc.Matches, "Keys used in model: controller\n.*\\(user@host\\)\n.*\\(another@host\\)")
 }
@@ -106,15 +107,15 @@ func (s *ListKeysSuite) TestListFullKeys(c *gc.C) {
 	key2 := sshtesting.ValidKeyTwo.Key + " another@host"
 	s.setAuthorizedKeys(c, key1, key2)
 
-	context, err := coretesting.RunCommand(c, NewListKeysCommand(), "--full")
+	context, err := cmdtesting.RunCommand(c, NewListKeysCommand(), "--full")
 	c.Assert(err, jc.ErrorIsNil)
-	output := strings.TrimSpace(coretesting.Stdout(context))
+	output := strings.TrimSpace(cmdtesting.Stdout(context))
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(output, gc.Matches, "Keys used in model: controller\n.*user@host\n.*another@host")
 }
 
 func (s *ListKeysSuite) TestTooManyArgs(c *gc.C) {
-	_, err := coretesting.RunCommand(c, NewListKeysCommand(), "foo")
+	_, err := cmdtesting.RunCommand(c, NewListKeysCommand(), "foo")
 	c.Assert(err, gc.ErrorMatches, `unrecognized args: \["foo"\]`)
 }
 
@@ -129,9 +130,9 @@ func (s *AddKeySuite) TestAddKey(c *gc.C) {
 	s.setAuthorizedKeys(c, key1)
 
 	key2 := sshtesting.ValidKeyTwo.Key + " another@host"
-	context, err := coretesting.RunCommand(c, NewAddKeysCommand(), key2, "invalid-key")
+	context, err := cmdtesting.RunCommand(c, NewAddKeysCommand(), key2, "invalid-key")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(coretesting.Stderr(context), gc.Matches, `cannot add key "invalid-key".*\n`)
+	c.Assert(cmdtesting.Stderr(context), gc.Matches, `cannot add key "invalid-key".*\n`)
 	s.assertEnvironKeys(c, key1, key2)
 }
 
@@ -142,7 +143,7 @@ func (s *AddKeySuite) TestBlockAddKey(c *gc.C) {
 	key2 := sshtesting.ValidKeyTwo.Key + " another@host"
 	// Block operation
 	s.BlockAllChanges(c, "TestBlockAddKey")
-	_, err := coretesting.RunCommand(c, NewAddKeysCommand(), key2, "invalid-key")
+	_, err := cmdtesting.RunCommand(c, NewAddKeysCommand(), key2, "invalid-key")
 	coretesting.AssertOperationWasBlocked(c, err, ".*TestBlockAddKey.*")
 }
 
@@ -157,10 +158,10 @@ func (s *RemoveKeySuite) TestRemoveKeys(c *gc.C) {
 	key2 := sshtesting.ValidKeyTwo.Key + " another@host"
 	s.setAuthorizedKeys(c, key1, key2)
 
-	context, err := coretesting.RunCommand(c, NewRemoveKeysCommand(),
+	context, err := cmdtesting.RunCommand(c, NewRemoveKeysCommand(),
 		sshtesting.ValidKeyTwo.Fingerprint, "invalid-key")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(coretesting.Stderr(context), gc.Matches, `cannot remove key id "invalid-key".*\n`)
+	c.Assert(cmdtesting.Stderr(context), gc.Matches, `cannot remove key id "invalid-key".*\n`)
 	s.assertEnvironKeys(c, key1)
 }
 
@@ -171,7 +172,7 @@ func (s *RemoveKeySuite) TestBlockRemoveKeys(c *gc.C) {
 
 	// Block operation
 	s.BlockAllChanges(c, "TestBlockRemoveKeys")
-	_, err := coretesting.RunCommand(c, NewRemoveKeysCommand(),
+	_, err := cmdtesting.RunCommand(c, NewRemoveKeysCommand(),
 		sshtesting.ValidKeyTwo.Fingerprint, "invalid-key")
 	coretesting.AssertOperationWasBlocked(c, err, ".*TestBlockRemoveKeys.*")
 }
@@ -191,9 +192,9 @@ func (s *ImportKeySuite) TestImportKeys(c *gc.C) {
 	key1 := sshtesting.ValidKeyOne.Key + " user@host"
 	s.setAuthorizedKeys(c, key1)
 
-	context, err := coretesting.RunCommand(c, NewImportKeysCommand(), "lp:validuser", "lp:invalid-key")
+	context, err := cmdtesting.RunCommand(c, NewImportKeysCommand(), "lp:validuser", "lp:invalid-key")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(coretesting.Stderr(context), gc.Matches, `cannot import key id "lp:invalid-key".*\n`)
+	c.Assert(cmdtesting.Stderr(context), gc.Matches, `cannot import key id "lp:invalid-key".*\n`)
 	s.assertEnvironKeys(c, key1, sshtesting.ValidKeyThree.Key)
 }
 
@@ -203,6 +204,6 @@ func (s *ImportKeySuite) TestBlockImportKeys(c *gc.C) {
 
 	// Block operation
 	s.BlockAllChanges(c, "TestBlockImportKeys")
-	_, err := coretesting.RunCommand(c, NewImportKeysCommand(), "lp:validuser", "lp:invalid-key")
+	_, err := cmdtesting.RunCommand(c, NewImportKeysCommand(), "lp:validuser", "lp:invalid-key")
 	coretesting.AssertOperationWasBlocked(c, err, ".*TestBlockImportKeys.*")
 }

--- a/cmd/juju/commands/switch_test.go
+++ b/cmd/juju/commands/switch_test.go
@@ -12,6 +12,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/cmd/cmdtesting"
 	"github.com/juju/juju/cmd/modelcmd"
 	_ "github.com/juju/juju/juju"
 	"github.com/juju/juju/jujuclient"
@@ -50,7 +51,7 @@ func (s *SwitchSimpleSuite) run(c *gc.C, args ...string) (*cmd.Context, error) {
 		Store:         s.stubStore,
 		RefreshModels: s.refreshModels,
 	}
-	return coretesting.RunCommand(c, modelcmd.WrapBase(cmd), args...)
+	return cmdtesting.RunCommand(c, modelcmd.WrapBase(cmd), args...)
 }
 
 func (s *SwitchSimpleSuite) TestNoArgs(c *gc.C) {
@@ -63,7 +64,7 @@ func (s *SwitchSimpleSuite) TestNoArgsCurrentController(c *gc.C) {
 	s.store.CurrentControllerName = "a-controller"
 	ctx, err := s.run(c)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(coretesting.Stdout(ctx), gc.Equals, "a-controller\n")
+	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, "a-controller\n")
 }
 
 func (s *SwitchSimpleSuite) TestUnknownControllerNameReturnsError(c *gc.C) {
@@ -82,14 +83,14 @@ func (s *SwitchSimpleSuite) TestNoArgsCurrentModel(c *gc.C) {
 	}
 	ctx, err := s.run(c)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(coretesting.Stdout(ctx), gc.Equals, "a-controller:admin/mymodel\n")
+	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, "a-controller:admin/mymodel\n")
 }
 
 func (s *SwitchSimpleSuite) TestSwitchWritesCurrentController(c *gc.C) {
 	s.addController(c, "a-controller")
 	context, err := s.run(c, "a-controller")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(coretesting.Stderr(context), gc.Equals, " -> a-controller (controller)\n")
+	c.Assert(cmdtesting.Stderr(context), gc.Equals, " -> a-controller (controller)\n")
 	s.stubStore.CheckCalls(c, []testing.StubCall{
 		{"CurrentController", nil},
 		{"ControllerByName", []interface{}{"a-controller"}},
@@ -103,7 +104,7 @@ func (s *SwitchSimpleSuite) TestSwitchWithCurrentController(c *gc.C) {
 	s.addController(c, "new")
 	context, err := s.run(c, "new")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(coretesting.Stderr(context), gc.Equals, "old (controller) -> new (controller)\n")
+	c.Assert(cmdtesting.Stderr(context), gc.Equals, "old (controller) -> new (controller)\n")
 }
 
 func (s *SwitchSimpleSuite) TestSwitchLocalControllerWithCurrent(c *gc.C) {
@@ -111,7 +112,7 @@ func (s *SwitchSimpleSuite) TestSwitchLocalControllerWithCurrent(c *gc.C) {
 	s.addController(c, "new")
 	context, err := s.run(c, "new")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(coretesting.Stderr(context), gc.Equals, "old (controller) -> new (controller)\n")
+	c.Assert(cmdtesting.Stderr(context), gc.Equals, "old (controller) -> new (controller)\n")
 }
 
 func (s *SwitchSimpleSuite) TestSwitchSameController(c *gc.C) {
@@ -119,7 +120,7 @@ func (s *SwitchSimpleSuite) TestSwitchSameController(c *gc.C) {
 	s.addController(c, "same")
 	context, err := s.run(c, "same")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(coretesting.Stderr(context), gc.Equals, "same (controller) (no change)\n")
+	c.Assert(cmdtesting.Stderr(context), gc.Equals, "same (controller) (no change)\n")
 	s.stubStore.CheckCalls(c, []testing.StubCall{
 		{"CurrentController", nil},
 		{"CurrentModel", []interface{}{"same"}},
@@ -135,7 +136,7 @@ func (s *SwitchSimpleSuite) TestSwitchControllerToModel(c *gc.C) {
 	}
 	context, err := s.run(c, "mymodel")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(coretesting.Stderr(context), gc.Equals, "ctrl (controller) -> ctrl:admin/mymodel\n")
+	c.Assert(cmdtesting.Stderr(context), gc.Equals, "ctrl (controller) -> ctrl:admin/mymodel\n")
 	s.stubStore.CheckCalls(c, []testing.StubCall{
 		{"CurrentController", nil},
 		{"CurrentModel", []interface{}{"ctrl"}},
@@ -154,7 +155,7 @@ func (s *SwitchSimpleSuite) TestSwitchControllerToModelDifferentController(c *gc
 	}
 	context, err := s.run(c, "new:mymodel")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(coretesting.Stderr(context), gc.Equals, "old (controller) -> new:admin/mymodel\n")
+	c.Assert(cmdtesting.Stderr(context), gc.Equals, "old (controller) -> new:admin/mymodel\n")
 	s.stubStore.CheckCalls(c, []testing.StubCall{
 		{"CurrentController", nil},
 		{"CurrentModel", []interface{}{"old"}},
@@ -175,7 +176,7 @@ func (s *SwitchSimpleSuite) TestSwitchLocalControllerToModelDifferentController(
 	}
 	context, err := s.run(c, "new:mymodel")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(coretesting.Stderr(context), gc.Equals, "old (controller) -> new:admin/mymodel\n")
+	c.Assert(cmdtesting.Stderr(context), gc.Equals, "old (controller) -> new:admin/mymodel\n")
 	s.stubStore.CheckCalls(c, []testing.StubCall{
 		{"CurrentController", nil},
 		{"CurrentModel", []interface{}{"old"}},
@@ -197,7 +198,7 @@ func (s *SwitchSimpleSuite) TestSwitchControllerToDifferentControllerCurrentMode
 	}
 	context, err := s.run(c, "new:mymodel")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(coretesting.Stderr(context), gc.Equals, "old (controller) -> new:admin/mymodel\n")
+	c.Assert(cmdtesting.Stderr(context), gc.Equals, "old (controller) -> new:admin/mymodel\n")
 	s.stubStore.CheckCalls(c, []testing.StubCall{
 		{"CurrentController", nil},
 		{"CurrentModel", []interface{}{"old"}},
@@ -221,7 +222,7 @@ func (s *SwitchSimpleSuite) TestSwitchToModelDifferentOwner(c *gc.C) {
 	}
 	context, err := s.run(c, "bianca/mymodel")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(coretesting.Stderr(context), gc.Equals, "same:admin/mymodel -> same:bianca/mymodel\n")
+	c.Assert(cmdtesting.Stderr(context), gc.Equals, "same:admin/mymodel -> same:bianca/mymodel\n")
 	c.Assert(s.store.Models["same"].CurrentModel, gc.Equals, "bianca/mymodel")
 }
 
@@ -244,7 +245,7 @@ func (s *SwitchSimpleSuite) TestSwitchUnknownCurrentControllerRefreshModels(c *g
 	}
 	ctx, err := s.run(c, "unknown")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(coretesting.Stderr(ctx), gc.Equals, "ctrl (controller) -> ctrl:admin/unknown\n")
+	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "ctrl (controller) -> ctrl:admin/unknown\n")
 	s.CheckCallNames(c, "RefreshModels")
 }
 

--- a/cmd/juju/commands/synctools_test.go
+++ b/cmd/juju/commands/synctools_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/cmd/cmdtesting"
 	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/environs/sync"
 	envtools "github.com/juju/juju/environs/tools"
@@ -57,7 +58,7 @@ func (s *syncToolsSuite) Reset(c *gc.C) {
 func (s *syncToolsSuite) runSyncToolsCommand(c *gc.C, args ...string) (*cmd.Context, error) {
 	cmd := &syncToolsCommand{}
 	cmd.SetClientStore(s.store)
-	return coretesting.RunCommand(c, modelcmd.Wrap(cmd), args...)
+	return cmdtesting.RunCommand(c, modelcmd.Wrap(cmd), args...)
 }
 
 var syncToolsCommandTests = []struct {

--- a/cmd/juju/common/authkeys_test.go
+++ b/cmd/juju/common/authkeys_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/juju/utils/ssh"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/cmd/cmdtesting"
 	"github.com/juju/juju/cmd/juju/common"
 	"github.com/juju/juju/testing"
 )
@@ -43,7 +44,7 @@ func (s *AuthKeysSuite) SetUpTest(c *gc.C) {
 }
 
 func (s *AuthKeysSuite) TestReadAuthorizedKeysErrors(c *gc.C) {
-	ctx := testing.Context(c)
+	ctx := cmdtesting.Context(c)
 	_, err := common.ReadAuthorizedKeys(ctx, "")
 	c.Assert(err, gc.ErrorMatches, "no public ssh keys found")
 	c.Assert(err, gc.Equals, common.ErrNoAuthorizedKeys)
@@ -58,7 +59,7 @@ func writeFile(c *gc.C, filename string, contents string) {
 }
 
 func (s *AuthKeysSuite) TestReadAuthorizedKeys(c *gc.C) {
-	ctx := testing.Context(c)
+	ctx := cmdtesting.Context(c)
 	writeFile(c, filepath.Join(s.dotssh, "id_rsa.pub"), "id_rsa")
 	writeFile(c, filepath.Join(s.dotssh, "identity.pub"), "identity")
 	writeFile(c, filepath.Join(s.dotssh, "test.pub"), "test")
@@ -71,7 +72,7 @@ func (s *AuthKeysSuite) TestReadAuthorizedKeys(c *gc.C) {
 }
 
 func (s *AuthKeysSuite) TestReadAuthorizedKeysClientKeys(c *gc.C) {
-	ctx := testing.Context(c)
+	ctx := cmdtesting.Context(c)
 	keydir := filepath.Join(s.dotssh, "juju")
 	err := ssh.LoadClientKeys(keydir) // auto-generates a key pair
 	c.Assert(err, jc.ErrorIsNil)
@@ -96,7 +97,7 @@ func (s *AuthKeysSuite) TestReadAuthorizedKeysClientKeys(c *gc.C) {
 
 func (s *AuthKeysSuite) TestFinalizeAuthorizedKeysNoop(c *gc.C) {
 	attrs := map[string]interface{}{"authorized-keys": "meep"}
-	err := common.FinalizeAuthorizedKeys(testing.Context(c), attrs)
+	err := common.FinalizeAuthorizedKeys(cmdtesting.Context(c), attrs)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(attrs, jc.DeepEquals, map[string]interface{}{"authorized-keys": "meep"})
 }
@@ -104,7 +105,7 @@ func (s *AuthKeysSuite) TestFinalizeAuthorizedKeysNoop(c *gc.C) {
 func (s *AuthKeysSuite) TestFinalizeAuthorizedKeysPath(c *gc.C) {
 	writeFile(c, filepath.Join(s.dotssh, "whatever"), "meep")
 	attrs := map[string]interface{}{"authorized-keys-path": "whatever"}
-	err := common.FinalizeAuthorizedKeys(testing.Context(c), attrs)
+	err := common.FinalizeAuthorizedKeys(cmdtesting.Context(c), attrs)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(attrs, jc.DeepEquals, map[string]interface{}{"authorized-keys": "meep\n"})
 }
@@ -112,13 +113,13 @@ func (s *AuthKeysSuite) TestFinalizeAuthorizedKeysPath(c *gc.C) {
 func (s *AuthKeysSuite) TestFinalizeAuthorizedKeysDefault(c *gc.C) {
 	writeFile(c, filepath.Join(s.dotssh, "id_rsa.pub"), "meep")
 	attrs := map[string]interface{}{}
-	err := common.FinalizeAuthorizedKeys(testing.Context(c), attrs)
+	err := common.FinalizeAuthorizedKeys(cmdtesting.Context(c), attrs)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(attrs, jc.DeepEquals, map[string]interface{}{"authorized-keys": "meep\n"})
 }
 
 func (s *AuthKeysSuite) TestFinalizeAuthorizedKeysConflict(c *gc.C) {
 	attrs := map[string]interface{}{"authorized-keys": "foo", "authorized-keys-path": "bar"}
-	err := common.FinalizeAuthorizedKeys(testing.Context(c), attrs)
+	err := common.FinalizeAuthorizedKeys(cmdtesting.Context(c), attrs)
 	c.Assert(err, gc.ErrorMatches, `"authorized-keys" and "authorized-keys-path" may not both be specified`)
 }

--- a/cmd/juju/common/controller_test.go
+++ b/cmd/juju/common/controller_test.go
@@ -12,8 +12,8 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/cmd/cmdtesting"
 	"github.com/juju/juju/cmd/modelcmd"
-	cmdtesting "github.com/juju/juju/cmd/testing"
 	"github.com/juju/juju/jujuclient"
 	"github.com/juju/juju/rpc"
 	"github.com/juju/juju/testing"

--- a/cmd/juju/common/flags_test.go
+++ b/cmd/juju/common/flags_test.go
@@ -12,6 +12,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/cmd/cmdtesting"
 	"github.com/juju/juju/testing"
 )
 
@@ -79,7 +80,7 @@ func (*FlagsSuite) TestConfigFlagReadAttrsErrors(c *gc.C) {
 
 	var f ConfigFlag
 	f.files = append(f.files, configFile)
-	ctx := testing.Context(c)
+	ctx := cmdtesting.Context(c)
 	attrs, err := f.ReadAttrs(ctx)
 	c.Assert(errors.Cause(err), jc.Satisfies, os.IsNotExist)
 	c.Assert(attrs, gc.IsNil)
@@ -91,7 +92,7 @@ func assertConfigFlag(c *gc.C, f ConfigFlag, files []string, attrs map[string]in
 }
 
 func assertConfigFlagReadAttrs(c *gc.C, f ConfigFlag, expect map[string]interface{}) {
-	ctx := testing.Context(c)
+	ctx := cmdtesting.Context(c)
 	attrs, err := f.ReadAttrs(ctx)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(attrs, jc.DeepEquals, expect)

--- a/cmd/juju/controller/addmodel_test.go
+++ b/cmd/juju/controller/addmodel_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/juju/juju/api/base"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/cloud"
+	"github.com/juju/juju/cmd/cmdtesting"
 	"github.com/juju/juju/cmd/juju/controller"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/jujuclient"
@@ -100,7 +101,7 @@ func (s *AddModelSuite) run(c *gc.C, args ...string) (*cmd.Context, error) {
 		s.store,
 		s.fakeProviderRegistry,
 	)
-	return testing.RunCommand(c, command, args...)
+	return cmdtesting.RunCommand(c, command, args...)
 }
 
 func (s *AddModelSuite) TestInit(c *gc.C) {
@@ -155,7 +156,7 @@ func (s *AddModelSuite) TestInit(c *gc.C) {
 	} {
 		c.Logf("test %d", i)
 		wrappedCommand, command := controller.NewAddModelCommandForTest(nil, nil, nil, s.store, nil)
-		err := testing.InitCommand(wrappedCommand, test.args)
+		err := cmdtesting.InitCommand(wrappedCommand, test.args)
 		if test.err != "" {
 			c.Assert(err, gc.ErrorMatches, test.err)
 			continue
@@ -199,7 +200,7 @@ func (s *AddModelSuite) TestAddModelUnauthorizedMentionsJujuGrant(c *gc.C) {
 		Code:    params.CodeUnauthorized,
 	}
 	ctx, _ := s.run(c, "test")
-	errString := strings.Replace(testing.Stderr(ctx), "\n", " ", -1)
+	errString := strings.Replace(cmdtesting.Stderr(ctx), "\n", " ", -1)
 	c.Assert(errString, gc.Matches, `.*juju grant.*`)
 }
 

--- a/cmd/juju/controller/destroy_test.go
+++ b/cmd/juju/controller/destroy_test.go
@@ -17,9 +17,9 @@ import (
 	"github.com/juju/juju/api/base"
 	apicontroller "github.com/juju/juju/api/controller"
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/cmd/cmdtesting"
 	"github.com/juju/juju/cmd/juju/controller"
 	"github.com/juju/juju/cmd/modelcmd"
-	cmdtesting "github.com/juju/juju/cmd/testing"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/jujuclient"
@@ -231,7 +231,7 @@ func (s *baseDestroySuite) SetUpTest(c *gc.C) {
 }
 
 func (s *DestroySuite) runDestroyCommand(c *gc.C, args ...string) (*cmd.Context, error) {
-	return testing.RunCommand(c, s.newDestroyCommand(), args...)
+	return cmdtesting.RunCommand(c, s.newDestroyCommand(), args...)
 }
 
 func (s *DestroySuite) newDestroyCommand() cmd.Command {
@@ -385,40 +385,40 @@ func (s *DestroySuite) resetController(c *gc.C) {
 
 func (s *DestroySuite) TestDestroyCommandConfirmation(c *gc.C) {
 	var stdin, stdout bytes.Buffer
-	ctx := testing.Context(c)
+	ctx := cmdtesting.Context(c)
 	ctx.Stdout = &stdout
 	ctx.Stdin = &stdin
 
 	// Ensure confirmation is requested if "-y" is not specified.
 	stdin.WriteString("n")
-	_, errc := cmdtesting.RunCommand(ctx, s.newDestroyCommand(), "test1")
+	_, errc := cmdtesting.RunCommandWithDummyProvider(ctx, s.newDestroyCommand(), "test1")
 	select {
 	case err := <-errc:
 		c.Check(err, gc.ErrorMatches, "controller destruction aborted")
 	case <-time.After(testing.LongWait):
 		c.Fatalf("command took too long")
 	}
-	c.Check(testing.Stdout(ctx), gc.Matches, "WARNING!.*test1(.|\n)*")
+	c.Check(cmdtesting.Stdout(ctx), gc.Matches, "WARNING!.*test1(.|\n)*")
 	checkControllerExistsInStore(c, "test1", s.store)
 
 	// EOF on stdin: equivalent to answering no.
 	stdin.Reset()
 	stdout.Reset()
-	_, errc = cmdtesting.RunCommand(ctx, s.newDestroyCommand(), "test1")
+	_, errc = cmdtesting.RunCommandWithDummyProvider(ctx, s.newDestroyCommand(), "test1")
 	select {
 	case err := <-errc:
 		c.Check(err, gc.ErrorMatches, "controller destruction aborted")
 	case <-time.After(testing.LongWait):
 		c.Fatalf("command took too long")
 	}
-	c.Check(testing.Stdout(ctx), gc.Matches, "WARNING!.*test1(.|\n)*")
+	c.Check(cmdtesting.Stdout(ctx), gc.Matches, "WARNING!.*test1(.|\n)*")
 	checkControllerExistsInStore(c, "test1", s.store)
 
 	for _, answer := range []string{"y", "Y", "yes", "YES"} {
 		stdin.Reset()
 		stdout.Reset()
 		stdin.WriteString(answer)
-		_, errc = cmdtesting.RunCommand(ctx, s.newDestroyCommand(), "test1")
+		_, errc = cmdtesting.RunCommandWithDummyProvider(ctx, s.newDestroyCommand(), "test1")
 		select {
 		case err := <-errc:
 			c.Check(err, jc.ErrorIsNil)
@@ -474,9 +474,9 @@ func (s *DestroySuite) TestDestroyReturnsBlocks(c *gc.C) {
 		},
 	}
 	ctx, _ := s.runDestroyCommand(c, "test1", "-y", "--destroy-all-models")
-	c.Assert(testing.Stderr(ctx), gc.Equals, "Destroying controller\n"+
+	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "Destroying controller\n"+
 		"Name   Model UUID                            Owner   Disabled commands\n"+
 		"test1  1871299e-1370-4f3e-83ab-1849ed7b1076  cheryl  destroy-model\n"+
 		"test2  c59d0e3b-2bd7-4867-b1b9-f1ef8a0bb004  bob     all, destroy-model\n")
-	c.Assert(testing.Stdout(ctx), gc.Equals, "")
+	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, "")
 }

--- a/cmd/juju/controller/enabledestroy_test.go
+++ b/cmd/juju/controller/enabledestroy_test.go
@@ -9,9 +9,9 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/cmd/cmdtesting"
 	"github.com/juju/juju/cmd/juju/controller"
 	"github.com/juju/juju/jujuclient"
-	"github.com/juju/juju/testing"
 )
 
 type enableDestroyControllerSuite struct {
@@ -36,20 +36,20 @@ func (s *enableDestroyControllerSuite) newCommand() cmd.Command {
 }
 
 func (s *enableDestroyControllerSuite) TestRemove(c *gc.C) {
-	_, err := testing.RunCommand(c, s.newCommand())
+	_, err := cmdtesting.RunCommand(c, s.newCommand())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(s.api.called, jc.IsTrue)
 }
 
 func (s *enableDestroyControllerSuite) TestUnrecognizedArg(c *gc.C) {
-	_, err := testing.RunCommand(c, s.newCommand(), "whoops")
+	_, err := cmdtesting.RunCommand(c, s.newCommand(), "whoops")
 	c.Assert(err, gc.ErrorMatches, `unrecognized args: \["whoops"\]`)
 	c.Assert(s.api.called, jc.IsFalse)
 }
 
 func (s *enableDestroyControllerSuite) TestEnvironmentsError(c *gc.C) {
 	s.api.err = common.ErrPerm
-	_, err := testing.RunCommand(c, s.newCommand())
+	_, err := cmdtesting.RunCommand(c, s.newCommand())
 	c.Assert(err, gc.ErrorMatches, "permission denied")
 }
 

--- a/cmd/juju/controller/getconfig_test.go
+++ b/cmd/juju/controller/getconfig_test.go
@@ -11,9 +11,9 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/cmd/cmdtesting"
 	"github.com/juju/juju/cmd/juju/controller"
 	jujucontroller "github.com/juju/juju/controller"
-	"github.com/juju/juju/testing"
 )
 
 type GetConfigSuite struct {
@@ -29,17 +29,17 @@ func (s *GetConfigSuite) SetUpTest(c *gc.C) {
 
 func (s *GetConfigSuite) run(c *gc.C, args ...string) (*cmd.Context, error) {
 	command := controller.NewGetConfigCommandForTest(&fakeControllerAPI{}, s.store)
-	return testing.RunCommand(c, command, args...)
+	return cmdtesting.RunCommand(c, command, args...)
 }
 
 func (s *GetConfigSuite) TestInit(c *gc.C) {
 	// zero or one args is fine.
-	err := testing.InitCommand(controller.NewGetConfigCommandForTest(&fakeControllerAPI{}, s.store), nil)
+	err := cmdtesting.InitCommand(controller.NewGetConfigCommandForTest(&fakeControllerAPI{}, s.store), nil)
 	c.Check(err, jc.ErrorIsNil)
-	err = testing.InitCommand(controller.NewGetConfigCommandForTest(&fakeControllerAPI{}, s.store), []string{"one"})
+	err = cmdtesting.InitCommand(controller.NewGetConfigCommandForTest(&fakeControllerAPI{}, s.store), []string{"one"})
 	c.Check(err, jc.ErrorIsNil)
 	// More than one is not allowed.
-	err = testing.InitCommand(controller.NewGetConfigCommandForTest(&fakeControllerAPI{}, s.store), []string{"one", "two"})
+	err = cmdtesting.InitCommand(controller.NewGetConfigCommandForTest(&fakeControllerAPI{}, s.store), []string{"one", "two"})
 	c.Check(err, gc.ErrorMatches, `unrecognized args: \["two"\]`)
 }
 
@@ -47,7 +47,7 @@ func (s *GetConfigSuite) TestSingleValue(c *gc.C) {
 	context, err := s.run(c, "ca-cert")
 	c.Assert(err, jc.ErrorIsNil)
 
-	output := strings.TrimSpace(testing.Stdout(context))
+	output := strings.TrimSpace(cmdtesting.Stdout(context))
 	c.Assert(output, gc.Equals, "multi\nline")
 }
 
@@ -55,7 +55,7 @@ func (s *GetConfigSuite) TestSingleValueJSON(c *gc.C) {
 	context, err := s.run(c, "--format=json", "controller-uuid")
 	c.Assert(err, jc.ErrorIsNil)
 
-	output := strings.TrimSpace(testing.Stdout(context))
+	output := strings.TrimSpace(cmdtesting.Stdout(context))
 	c.Assert(output, gc.Equals, `"uuid"`)
 }
 
@@ -63,7 +63,7 @@ func (s *GetConfigSuite) TestAllValues(c *gc.C) {
 	context, err := s.run(c)
 	c.Assert(err, jc.ErrorIsNil)
 
-	output := strings.TrimSpace(testing.Stdout(context))
+	output := strings.TrimSpace(cmdtesting.Stdout(context))
 	expected := `
 Attribute  Value
 api-port   1234
@@ -78,14 +78,14 @@ func (s *GetConfigSuite) TestAllValuesJSON(c *gc.C) {
 	context, err := s.run(c, "--format=json")
 	c.Assert(err, jc.ErrorIsNil)
 
-	output := strings.TrimSpace(testing.Stdout(context))
+	output := strings.TrimSpace(cmdtesting.Stdout(context))
 	expected := `{"api-port":1234,"ca-cert":"multi\nline","controller-uuid":"uuid"}`
 	c.Assert(output, gc.Equals, expected)
 }
 
 func (s *GetConfigSuite) TestError(c *gc.C) {
 	command := controller.NewGetConfigCommandForTest(&fakeControllerAPI{err: errors.New("error")}, s.store)
-	_, err := testing.RunCommand(c, command)
+	_, err := cmdtesting.RunCommand(c, command)
 	c.Assert(err, gc.ErrorMatches, "error")
 }
 

--- a/cmd/juju/controller/kill_test.go
+++ b/cmd/juju/controller/kill_test.go
@@ -19,9 +19,9 @@ import (
 	"github.com/juju/juju/api/base"
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/cmd/cmdtesting"
 	"github.com/juju/juju/cmd/juju/controller"
 	"github.com/juju/juju/cmd/modelcmd"
-	cmdtesting "github.com/juju/juju/cmd/testing"
 	"github.com/juju/juju/jujuclient"
 	_ "github.com/juju/juju/provider/dummy"
 	coretesting "github.com/juju/juju/testing"
@@ -41,7 +41,7 @@ func (s *KillSuite) SetUpTest(c *gc.C) {
 }
 
 func (s *KillSuite) runKillCommand(c *gc.C, args ...string) (*cmd.Context, error) {
-	return coretesting.RunCommand(c, s.newKillCommand(), args...)
+	return cmdtesting.RunCommand(c, s.newKillCommand(), args...)
 }
 
 func (s *KillSuite) newKillCommand() cmd.Command {
@@ -91,7 +91,7 @@ func (s *KillSuite) TestKillDurationFlags(c *gc.C) {
 		c.Logf("duration test %d", i)
 		wrapped, inner := s.newKillCommandBoth()
 		args := append([]string{"test1"}, test.args...)
-		err := coretesting.InitCommand(wrapped, args)
+		err := cmdtesting.InitCommand(wrapped, args)
 		if test.err == "" {
 			c.Check(err, jc.ErrorIsNil)
 			c.Check(controller.KillTimeout(c, inner), gc.Equals, test.expected)
@@ -104,13 +104,13 @@ func (s *KillSuite) TestKillDurationFlags(c *gc.C) {
 func (s *KillSuite) TestKillWaitForModels_AllGood(c *gc.C) {
 	s.resetAPIModels(c)
 	wrapped, inner := s.newKillCommandBoth()
-	err := coretesting.InitCommand(wrapped, []string{"test1", "--timeout=1m"})
+	err := cmdtesting.InitCommand(wrapped, []string{"test1", "--timeout=1m"})
 	c.Assert(err, jc.ErrorIsNil)
 
-	ctx := coretesting.Context(c)
+	ctx := cmdtesting.Context(c)
 	err = controller.KillWaitForModels(inner, ctx, s.api, test1UUID)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(coretesting.Stderr(ctx), gc.Equals, "All hosted models reclaimed, cleaning up controller machines\n")
+	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "All hosted models reclaimed, cleaning up controller machines\n")
 }
 
 func (s *KillSuite) TestKillWaitForModels_ActuallyWaits(c *gc.C) {
@@ -123,10 +123,10 @@ func (s *KillSuite) TestKillWaitForModels_ActuallyWaits(c *gc.C) {
 		ServiceCount:       2,
 	})
 	wrapped, inner := s.newKillCommandBoth()
-	err := coretesting.InitCommand(wrapped, []string{"test1", "--timeout=1m"})
+	err := cmdtesting.InitCommand(wrapped, []string{"test1", "--timeout=1m"})
 	c.Assert(err, jc.ErrorIsNil)
 
-	ctx := coretesting.Context(c)
+	ctx := cmdtesting.Context(c)
 	result := make(chan error)
 	go func() {
 		err := controller.KillWaitForModels(inner, ctx, s.api, test1UUID)
@@ -157,7 +157,7 @@ func (s *KillSuite) TestKillWaitForModels_ActuallyWaits(c *gc.C) {
 		"Waiting on 1 model, 1 machine\n" +
 		"All hosted models reclaimed, cleaning up controller machines\n"
 
-	c.Assert(coretesting.Stderr(ctx), gc.Equals, expect)
+	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, expect)
 }
 
 func (s *KillSuite) TestKillWaitForModels_WaitsForControllerMachines(c *gc.C) {
@@ -173,10 +173,10 @@ func (s *KillSuite) TestKillWaitForModels_WaitsForControllerMachines(c *gc.C) {
 	s.clock.Advance(5 * time.Second)
 
 	wrapped, inner := s.newKillCommandBoth()
-	err := coretesting.InitCommand(wrapped, []string{"test1", "--timeout=1m"})
+	err := cmdtesting.InitCommand(wrapped, []string{"test1", "--timeout=1m"})
 	c.Assert(err, jc.ErrorIsNil)
 
-	ctx := coretesting.Context(c)
+	ctx := cmdtesting.Context(c)
 	result := make(chan error)
 	go func() {
 		err := controller.KillWaitForModels(inner, ctx, s.api, test1UUID)
@@ -212,7 +212,7 @@ func (s *KillSuite) TestKillWaitForModels_WaitsForControllerMachines(c *gc.C) {
 		"Waiting on 0 model, 1 machine\n" +
 		"All hosted models reclaimed, cleaning up controller machines\n"
 
-	c.Assert(coretesting.Stderr(ctx), gc.Equals, expect)
+	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, expect)
 }
 
 func (s *KillSuite) TestKillWaitForModels_TimeoutResetsWithChange(c *gc.C) {
@@ -225,10 +225,10 @@ func (s *KillSuite) TestKillWaitForModels_TimeoutResetsWithChange(c *gc.C) {
 		ServiceCount:       2,
 	})
 	wrapped, inner := s.newKillCommandBoth()
-	err := coretesting.InitCommand(wrapped, []string{"test1", "--timeout=20s"})
+	err := cmdtesting.InitCommand(wrapped, []string{"test1", "--timeout=20s"})
 	c.Assert(err, jc.ErrorIsNil)
 
-	ctx := coretesting.Context(c)
+	ctx := cmdtesting.Context(c)
 	result := make(chan error)
 	go func() {
 		err := controller.KillWaitForModels(inner, ctx, s.api, test1UUID)
@@ -263,7 +263,7 @@ func (s *KillSuite) TestKillWaitForModels_TimeoutResetsWithChange(c *gc.C) {
 		"Waiting on 1 model, 1 machine, will kill machines directly in 20s\n" +
 		"All hosted models reclaimed, cleaning up controller machines\n"
 
-	c.Assert(coretesting.Stderr(ctx), gc.Equals, expect)
+	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, expect)
 }
 
 func (s *KillSuite) TestKillWaitForModels_TimeoutWithNoChange(c *gc.C) {
@@ -276,10 +276,10 @@ func (s *KillSuite) TestKillWaitForModels_TimeoutWithNoChange(c *gc.C) {
 		ServiceCount:       2,
 	})
 	wrapped, inner := s.newKillCommandBoth()
-	err := coretesting.InitCommand(wrapped, []string{"test1", "--timeout=1m"})
+	err := cmdtesting.InitCommand(wrapped, []string{"test1", "--timeout=1m"})
 	c.Assert(err, jc.ErrorIsNil)
 
-	ctx := coretesting.Context(c)
+	ctx := cmdtesting.Context(c)
 	result := make(chan error)
 	go func() {
 		err := controller.KillWaitForModels(inner, ctx, s.api, test1UUID)
@@ -311,7 +311,7 @@ func (s *KillSuite) TestKillWaitForModels_TimeoutWithNoChange(c *gc.C) {
 		"Waiting on 1 model, 2 machines, 2 applications, will kill machines directly in 10s\n" +
 		"Waiting on 1 model, 2 machines, 2 applications, will kill machines directly in 5s\n"
 
-	c.Assert(coretesting.Stderr(ctx), gc.Equals, expect)
+	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, expect)
 }
 
 func (s *KillSuite) resetAPIModels(c *gc.C) {
@@ -370,7 +370,7 @@ func (s *KillSuite) TestKillCannotConnectToAPISucceeds(c *gc.C) {
 	s.apierror = errors.New("connection refused")
 	ctx, err := s.runKillCommand(c, "test1", "-y")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Check(coretesting.Stderr(ctx), jc.Contains, "Unable to open API: connection refused")
+	c.Check(cmdtesting.Stderr(ctx), jc.Contains, "Unable to open API: connection refused")
 	checkControllerRemovedFromStore(c, "test1", s.store)
 }
 
@@ -405,7 +405,7 @@ func (s *KillSuite) TestKillDestroysControllerWithAPIError(c *gc.C) {
 	s.api.SetErrors(errors.New("some destroy error"))
 	ctx, err := s.runKillCommand(c, "test1", "-y")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Check(coretesting.Stderr(ctx), jc.Contains, "Unable to destroy controller through the API: some destroy error\nDestroying through provider")
+	c.Check(cmdtesting.Stderr(ctx), jc.Contains, "Unable to destroy controller through the API: some destroy error\nDestroying through provider")
 	c.Assert(s.api.destroyAll, jc.IsTrue)
 	checkControllerRemovedFromStore(c, "test1", s.store)
 }
@@ -419,19 +419,19 @@ func (s *KillSuite) TestKillCommandConfirmation(c *gc.C) {
 
 	// Ensure confirmation is requested if "-y" is not specified.
 	stdin.WriteString("n")
-	_, errc := cmdtesting.RunCommand(ctx, s.newKillCommand(), "test1")
+	_, errc := cmdtesting.RunCommandWithDummyProvider(ctx, s.newKillCommand(), "test1")
 	select {
 	case err := <-errc:
 		c.Check(err, gc.ErrorMatches, "controller destruction aborted")
 	case <-time.After(coretesting.LongWait):
 		c.Fatalf("command took too long")
 	}
-	c.Check(coretesting.Stdout(ctx), gc.Matches, "WARNING!.*test1(.|\n)*")
+	c.Check(cmdtesting.Stdout(ctx), gc.Matches, "WARNING!.*test1(.|\n)*")
 	checkControllerExistsInStore(c, "test1", s.store)
 }
 
 func (s *KillSuite) TestKillCommandControllerAlias(c *gc.C) {
-	_, err := coretesting.RunCommand(c, s.newKillCommand(), "test1", "-y")
+	_, err := cmdtesting.RunCommand(c, s.newKillCommand(), "test1", "-y")
 	c.Assert(err, jc.ErrorIsNil)
 	checkControllerRemovedFromStore(c, "test1:test1", s.store)
 }
@@ -441,7 +441,7 @@ func (s *KillSuite) TestKillAPIPermErrFails(c *gc.C) {
 		return nil, common.ErrPerm
 	}
 	cmd, _ := controller.NewKillCommandForTest(nil, nil, s.store, nil, clock.WallClock, modelcmd.OpenFunc(testDialer))
-	_, err := coretesting.RunCommand(c, cmd, "test1", "-y")
+	_, err := cmdtesting.RunCommand(c, cmd, "test1", "-y")
 	c.Assert(err, gc.ErrorMatches, "cannot destroy controller: permission denied")
 	checkControllerExistsInStore(c, "test1", s.store)
 }
@@ -457,9 +457,9 @@ func (s *KillSuite) TestKillEarlyAPIConnectionTimeout(c *gc.C) {
 	}
 
 	cmd, _ := controller.NewKillCommandForTest(nil, nil, s.store, nil, clock, modelcmd.OpenFunc(testDialer))
-	ctx, err := coretesting.RunCommand(c, cmd, "test1", "-y")
+	ctx, err := cmdtesting.RunCommand(c, cmd, "test1", "-y")
 	c.Check(err, jc.ErrorIsNil)
-	c.Check(coretesting.Stderr(ctx), jc.Contains, "Unable to open API: open connection timed out")
+	c.Check(cmdtesting.Stderr(ctx), jc.Contains, "Unable to open API: open connection timed out")
 	checkControllerRemovedFromStore(c, "test1", s.store)
 	// Check that we were actually told to wait for 10s.
 	c.Assert(clock.wait, gc.Equals, 10*time.Second)

--- a/cmd/juju/controller/listcontrollers_test.go
+++ b/cmd/juju/controller/listcontrollers_test.go
@@ -13,11 +13,11 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/api/base"
+	"github.com/juju/juju/cmd/cmdtesting"
 	"github.com/juju/juju/cmd/juju/controller"
 	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/jujuclient"
 	"github.com/juju/juju/jujuclient/jujuclienttesting"
-	"github.com/juju/juju/testing"
 )
 
 type ListControllersSuite struct {
@@ -261,7 +261,7 @@ another controller that you have been given access to using "juju register".
 }
 
 func (s *ListControllersSuite) runListControllers(c *gc.C, args ...string) (*cmd.Context, error) {
-	return testing.RunCommand(c, controller.NewListControllersCommandForTest(s.store, s.api), args...)
+	return cmdtesting.RunCommand(c, controller.NewListControllersCommandForTest(s.store, s.api), args...)
 }
 
 func (s *ListControllersSuite) assertListControllersFailed(c *gc.C, args ...string) {
@@ -272,7 +272,7 @@ func (s *ListControllersSuite) assertListControllersFailed(c *gc.C, args ...stri
 func (s *ListControllersSuite) assertListControllers(c *gc.C, args ...string) string {
 	context, err := s.runListControllers(c, args...)
 	c.Assert(err, jc.ErrorIsNil)
-	output := testing.Stdout(context)
+	output := cmdtesting.Stdout(context)
 	if s.expectedOutput != "" {
 		c.Assert(output, gc.Equals, s.expectedOutput)
 	}

--- a/cmd/juju/controller/listmodels_test.go
+++ b/cmd/juju/controller/listmodels_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/juju/juju/api/base"
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/cmd/cmdtesting"
 	"github.com/juju/juju/cmd/juju/controller"
 	"github.com/juju/juju/jujuclient"
 	"github.com/juju/juju/status"
@@ -152,10 +153,10 @@ func (s *ModelsSuite) newCommand() cmd.Command {
 }
 
 func (s *ModelsSuite) TestModelsOwner(c *gc.C) {
-	context, err := testing.RunCommand(c, s.newCommand())
+	context, err := cmdtesting.RunCommand(c, s.newCommand())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(s.api.user, gc.Equals, "admin")
-	c.Assert(testing.Stdout(context), gc.Equals, ""+
+	c.Assert(cmdtesting.Stdout(context), gc.Equals, ""+
 		"Controller: fake\n"+
 		"\n"+
 		"Model                        Cloud/Region  Status      Access  Last connection\n"+
@@ -166,10 +167,10 @@ func (s *ModelsSuite) TestModelsOwner(c *gc.C) {
 }
 
 func (s *ModelsSuite) TestModelsNonOwner(c *gc.C) {
-	context, err := testing.RunCommand(c, s.newCommand(), "--user", "bob")
+	context, err := cmdtesting.RunCommand(c, s.newCommand(), "--user", "bob")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(s.api.user, gc.Equals, "bob")
-	c.Assert(testing.Stdout(context), gc.Equals, ""+
+	c.Assert(cmdtesting.Stdout(context), gc.Equals, ""+
 		"Controller: fake\n"+
 		"\n"+
 		"Model                        Cloud/Region  Status      Access  Last connection\n"+
@@ -180,10 +181,10 @@ func (s *ModelsSuite) TestModelsNonOwner(c *gc.C) {
 }
 
 func (s *ModelsSuite) TestAllModels(c *gc.C) {
-	context, err := testing.RunCommand(c, s.newCommand(), "--all")
+	context, err := cmdtesting.RunCommand(c, s.newCommand(), "--all")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(s.api.all, jc.IsTrue)
-	c.Assert(testing.Stdout(context), gc.Equals, ""+
+	c.Assert(cmdtesting.Stdout(context), gc.Equals, ""+
 		"Controller: fake\n"+
 		"\n"+
 		"Model                        Cloud/Region  Status      Access  Last connection\n"+
@@ -195,9 +196,9 @@ func (s *ModelsSuite) TestAllModels(c *gc.C) {
 
 func (s *ModelsSuite) TestAllModelsNoneCurrent(c *gc.C) {
 	delete(s.store.Models, "fake")
-	context, err := testing.RunCommand(c, s.newCommand())
+	context, err := cmdtesting.RunCommand(c, s.newCommand())
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(testing.Stdout(context), gc.Equals, ""+
+	c.Assert(cmdtesting.Stdout(context), gc.Equals, ""+
 		"Controller: fake\n"+
 		"\n"+
 		"Model                        Cloud/Region  Status      Access  Last connection\n"+
@@ -209,10 +210,10 @@ func (s *ModelsSuite) TestAllModelsNoneCurrent(c *gc.C) {
 
 func (s *ModelsSuite) TestModelsUUID(c *gc.C) {
 	s.api.inclMachines = true
-	context, err := testing.RunCommand(c, s.newCommand(), "--uuid")
+	context, err := cmdtesting.RunCommand(c, s.newCommand(), "--uuid")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(s.api.user, gc.Equals, "admin")
-	c.Assert(testing.Stdout(context), gc.Equals, ""+
+	c.Assert(cmdtesting.Stdout(context), gc.Equals, ""+
 		"Controller: fake\n"+
 		"\n"+
 		"Model                        UUID              Cloud/Region  Status      Machines  Cores  Access  Last connection\n"+
@@ -224,10 +225,10 @@ func (s *ModelsSuite) TestModelsUUID(c *gc.C) {
 
 func (s *ModelsSuite) TestModelsMachineInfo(c *gc.C) {
 	s.api.inclMachines = true
-	context, err := testing.RunCommand(c, s.newCommand())
+	context, err := cmdtesting.RunCommand(c, s.newCommand())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(s.api.user, gc.Equals, "admin")
-	c.Assert(testing.Stdout(context), gc.Equals, ""+
+	c.Assert(cmdtesting.Stdout(context), gc.Equals, ""+
 		"Controller: fake\n"+
 		"\n"+
 		"Model                        Cloud/Region  Status      Machines  Cores  Access  Last connection\n"+
@@ -239,9 +240,9 @@ func (s *ModelsSuite) TestModelsMachineInfo(c *gc.C) {
 
 func (s *ModelsSuite) TestAllModelsWithOneUnauthorised(c *gc.C) {
 	s.api.denyAccess = true
-	context, err := testing.RunCommand(c, s.newCommand())
+	context, err := cmdtesting.RunCommand(c, s.newCommand())
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(testing.Stdout(context), gc.Equals, ""+
+	c.Assert(cmdtesting.Stdout(context), gc.Equals, ""+
 		"Controller: fake\n"+
 		"\n"+
 		"Model                 Cloud/Region  Status  Access  Last connection\n"+
@@ -251,12 +252,12 @@ func (s *ModelsSuite) TestAllModelsWithOneUnauthorised(c *gc.C) {
 }
 
 func (s *ModelsSuite) TestUnrecognizedArg(c *gc.C) {
-	_, err := testing.RunCommand(c, s.newCommand(), "whoops")
+	_, err := cmdtesting.RunCommand(c, s.newCommand(), "whoops")
 	c.Assert(err, gc.ErrorMatches, `unrecognized args: \["whoops"\]`)
 }
 
 func (s *ModelsSuite) TestModelsError(c *gc.C) {
 	s.api.err = common.ErrPerm
-	_, err := testing.RunCommand(c, s.newCommand())
+	_, err := cmdtesting.RunCommand(c, s.newCommand())
 	c.Assert(err, gc.ErrorMatches, "cannot list models: permission denied")
 }

--- a/cmd/juju/controller/register_test.go
+++ b/cmd/juju/controller/register_test.go
@@ -24,8 +24,8 @@ import (
 	"github.com/juju/juju/api"
 	"github.com/juju/juju/api/base"
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/cmd/cmdtesting"
 	"github.com/juju/juju/cmd/juju/controller"
-	cmdtesting "github.com/juju/juju/cmd/testing"
 	"github.com/juju/juju/jujuclient"
 	"github.com/juju/juju/testing"
 )
@@ -84,14 +84,14 @@ func (s *RegisterSuite) TearDownTest(c *gc.C) {
 func (s *RegisterSuite) TestInit(c *gc.C) {
 	registerCommand := controller.NewRegisterCommandForTest(nil, nil, nil)
 
-	err := testing.InitCommand(registerCommand, []string{})
+	err := cmdtesting.InitCommand(registerCommand, []string{})
 	c.Assert(err, gc.ErrorMatches, "registration data missing")
 
-	err = testing.InitCommand(registerCommand, []string{"foo"})
+	err = cmdtesting.InitCommand(registerCommand, []string{"foo"})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(registerCommand.Arg, gc.Equals, "foo")
 
-	err = testing.InitCommand(registerCommand, []string{"foo", "bar"})
+	err = cmdtesting.InitCommand(registerCommand, []string{"foo", "bar"})
 	c.Assert(err, gc.ErrorMatches, `unrecognized args: \["bar"\]`)
 }
 
@@ -575,7 +575,7 @@ func (s *RegisterSuite) run(c *gc.C, stdio io.ReadWriter, args ...string) error 
 	}
 
 	command := controller.NewRegisterCommandForTest(s.apiOpen, s.listModels, s.store)
-	err := testing.InitCommand(command, args)
+	err := cmdtesting.InitCommand(command, args)
 	c.Assert(err, jc.ErrorIsNil)
 	return command.Run(&cmd.Context{
 		Dir:    c.MkDir(),

--- a/cmd/juju/controller/showcontroller_test.go
+++ b/cmd/juju/controller/showcontroller_test.go
@@ -13,11 +13,11 @@ import (
 	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/api/base"
+	"github.com/juju/juju/cmd/cmdtesting"
 	"github.com/juju/juju/cmd/juju/controller"
 	"github.com/juju/juju/jujuclient"
 	"github.com/juju/juju/jujuclient/jujuclienttesting"
 	"github.com/juju/juju/permission"
-	"github.com/juju/juju/testing"
 )
 
 type ShowControllerSuite struct {
@@ -325,7 +325,7 @@ func (s *ShowControllerSuite) TestShowControllerUnrecognizedOptionFlag(c *gc.C) 
 }
 
 func (s *ShowControllerSuite) runShowController(c *gc.C, args ...string) (*cmd.Context, error) {
-	return testing.RunCommand(c, controller.NewShowControllerCommandForTest(s.store, s.api), args...)
+	return cmdtesting.RunCommand(c, controller.NewShowControllerCommandForTest(s.store, s.api), args...)
 }
 
 func (s *ShowControllerSuite) assertShowControllerFailed(c *gc.C, args ...string) {
@@ -336,7 +336,7 @@ func (s *ShowControllerSuite) assertShowControllerFailed(c *gc.C, args ...string
 func (s *ShowControllerSuite) assertShowController(c *gc.C, args ...string) {
 	context, err := s.runShowController(c, args...)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(testing.Stdout(context), gc.Equals, s.expectedOutput)
+	c.Assert(cmdtesting.Stdout(context), gc.Equals, s.expectedOutput)
 }
 
 type fakeController struct {

--- a/cmd/juju/crossmodel/find_test.go
+++ b/cmd/juju/crossmodel/find_test.go
@@ -13,9 +13,9 @@ import (
 	"gopkg.in/juju/charm.v6-unstable"
 
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/cmd/cmdtesting"
 	"github.com/juju/juju/cmd/juju/crossmodel"
 	jujucrossmodel "github.com/juju/juju/core/crossmodel"
-	"github.com/juju/juju/testing"
 )
 
 type findSuite struct {
@@ -35,7 +35,7 @@ func (s *findSuite) SetUpTest(c *gc.C) {
 }
 
 func (s *findSuite) runFind(c *gc.C, args ...string) (*cmd.Context, error) {
-	return testing.RunCommand(c, crossmodel.NewFindEndpointsCommandForTest(s.store, s.mockAPI), args...)
+	return cmdtesting.RunCommand(c, crossmodel.NewFindEndpointsCommandForTest(s.store, s.mockAPI), args...)
 }
 
 func (s *findSuite) TestFindNoArgs(c *gc.C) {
@@ -158,7 +158,7 @@ func (s *findSuite) assertFind(c *gc.C, args []string, expected string) {
 	context, err := s.runFind(c, args...)
 	c.Assert(err, jc.ErrorIsNil)
 
-	obtained := testing.Stdout(context)
+	obtained := cmdtesting.Stdout(context)
 	c.Assert(obtained, gc.Matches, expected)
 }
 

--- a/cmd/juju/crossmodel/list_test.go
+++ b/cmd/juju/crossmodel/list_test.go
@@ -13,9 +13,9 @@ import (
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/charm.v6-unstable"
 
+	"github.com/juju/juju/cmd/cmdtesting"
 	"github.com/juju/juju/cmd/juju/crossmodel"
 	model "github.com/juju/juju/core/crossmodel"
-	"github.com/juju/juju/testing"
 )
 
 type ListSuite struct {
@@ -140,17 +140,17 @@ func (s *ListSuite) createOfferItem(name, store string, count int) *model.Applic
 }
 
 func (s *ListSuite) runList(c *gc.C, args []string) (*cmd.Context, error) {
-	return testing.RunCommand(c, crossmodel.NewListEndpointsCommandForTest(s.store, s.mockAPI), args...)
+	return cmdtesting.RunCommand(c, crossmodel.NewListEndpointsCommandForTest(s.store, s.mockAPI), args...)
 }
 
 func (s *ListSuite) assertValidList(c *gc.C, args []string, expectedValid, expectedErr string) {
 	context, err := s.runList(c, args)
 	c.Assert(err, jc.ErrorIsNil)
 
-	obtainedErr := strings.Replace(testing.Stderr(context), "\n", "", -1)
+	obtainedErr := strings.Replace(cmdtesting.Stderr(context), "\n", "", -1)
 	c.Assert(obtainedErr, gc.Matches, expectedErr)
 
-	obtainedValid := testing.Stdout(context)
+	obtainedValid := cmdtesting.Stdout(context)
 	c.Assert(obtainedValid, gc.Matches, expectedValid)
 }
 

--- a/cmd/juju/crossmodel/offer_test.go
+++ b/cmd/juju/crossmodel/offer_test.go
@@ -11,8 +11,8 @@ import (
 
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/cmd/cmdtesting"
 	"github.com/juju/juju/cmd/juju/crossmodel"
-	"github.com/juju/juju/testing"
 )
 
 type offerSuite struct {
@@ -60,7 +60,7 @@ func (s *offerSuite) assertOfferErrorOutput(c *gc.C, expected string) {
 }
 
 func (s *offerSuite) runOffer(c *gc.C, args ...string) (*cmd.Context, error) {
-	return testing.RunCommand(c, crossmodel.NewOfferCommandForTest(s.store, s.mockAPI), args...)
+	return cmdtesting.RunCommand(c, crossmodel.NewOfferCommandForTest(s.store, s.mockAPI), args...)
 }
 
 func (s *offerSuite) TestOfferCallErred(c *gc.C) {

--- a/cmd/juju/crossmodel/show_test.go
+++ b/cmd/juju/crossmodel/show_test.go
@@ -11,8 +11,8 @@ import (
 	"gopkg.in/juju/charm.v6-unstable"
 
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/cmd/cmdtesting"
 	"github.com/juju/juju/cmd/juju/crossmodel"
-	"github.com/juju/juju/testing"
 )
 
 type showSuite struct {
@@ -31,7 +31,7 @@ func (s *showSuite) SetUpTest(c *gc.C) {
 }
 
 func (s *showSuite) runShow(c *gc.C, args ...string) (*cmd.Context, error) {
-	return testing.RunCommand(c, crossmodel.NewShowEndpointsCommandForTest(s.store, s.mockAPI), args...)
+	return cmdtesting.RunCommand(c, crossmodel.NewShowEndpointsCommandForTest(s.store, s.mockAPI), args...)
 }
 
 func (s *showSuite) TestShowNoUrl(c *gc.C) {
@@ -121,7 +121,7 @@ func (s *showSuite) assertShow(c *gc.C, args []string, expected string) {
 	context, err := s.runShow(c, args...)
 	c.Assert(err, jc.ErrorIsNil)
 
-	obtained := testing.Stdout(context)
+	obtained := cmdtesting.Stdout(context)
 	c.Assert(obtained, gc.Matches, expected)
 }
 

--- a/cmd/juju/gui/gui_test.go
+++ b/cmd/juju/gui/gui_test.go
@@ -17,9 +17,9 @@ import (
 
 	"github.com/juju/juju/api"
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/cmd/cmdtesting"
 	"github.com/juju/juju/cmd/juju/gui"
 	jujutesting "github.com/juju/juju/juju/testing"
-	coretesting "github.com/juju/juju/testing"
 )
 
 type guiSuite struct {
@@ -30,7 +30,7 @@ var _ = gc.Suite(&guiSuite{})
 
 // run executes the gui command passing the given args.
 func (s *guiSuite) run(c *gc.C, args ...string) (string, error) {
-	ctx, err := coretesting.RunCommand(c, gui.NewGUICommandForTest(
+	ctx, err := cmdtesting.RunCommand(c, gui.NewGUICommandForTest(
 		func(connection api.Connection) ([]params.GUIArchiveVersion, error) {
 			return []params.GUIArchiveVersion{
 				{
@@ -42,7 +42,7 @@ func (s *guiSuite) run(c *gc.C, args ...string) (string, error) {
 				},
 			}, nil
 		}), args...)
-	return strings.Trim(coretesting.Stderr(ctx), "\n"), err
+	return strings.Trim(cmdtesting.Stderr(ctx), "\n"), err
 }
 
 func (s *guiSuite) patchClient(f func(*httprequest.Client, string) error) {

--- a/cmd/juju/gui/upgradegui_test.go
+++ b/cmd/juju/gui/upgradegui_test.go
@@ -23,11 +23,11 @@ import (
 
 	"github.com/juju/juju/api/controller"
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/cmd/cmdtesting"
 	"github.com/juju/juju/cmd/juju/gui"
 	envgui "github.com/juju/juju/environs/gui"
 	"github.com/juju/juju/environs/simplestreams"
 	jujutesting "github.com/juju/juju/juju/testing"
-	coretesting "github.com/juju/juju/testing"
 )
 
 type upgradeGUISuite struct {
@@ -38,8 +38,8 @@ var _ = gc.Suite(&upgradeGUISuite{})
 
 // run executes the upgrade-gui command passing the given args.
 func (s *upgradeGUISuite) run(c *gc.C, args ...string) (string, error) {
-	ctx, err := coretesting.RunCommand(c, gui.NewUpgradeGUICommand(), args...)
-	return strings.Trim(coretesting.Stderr(ctx), "\n"), err
+	ctx, err := cmdtesting.RunCommand(c, gui.NewUpgradeGUICommand(), args...)
+	return strings.Trim(cmdtesting.Stderr(ctx), "\n"), err
 }
 
 // calledFunc is returned by the patch* methods below, and when called reports

--- a/cmd/juju/machine/add_test.go
+++ b/cmd/juju/machine/add_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/cmd/cmdtesting"
 	"github.com/juju/juju/cmd/juju/machine"
 	"github.com/juju/juju/environs/manual"
 	"github.com/juju/juju/provider/dummy"
@@ -93,7 +94,7 @@ func (s *AddMachineSuite) TestInit(c *gc.C) {
 	} {
 		c.Logf("test %d", i)
 		wrappedCommand, addCmd := machine.NewAddCommandForTest(s.fakeAddMachine, s.fakeAddMachine, s.fakeMachineManager)
-		err := testing.InitCommand(wrappedCommand, test.args)
+		err := cmdtesting.InitCommand(wrappedCommand, test.args)
 		if test.errorString == "" {
 			c.Check(err, jc.ErrorIsNil)
 			c.Check(addCmd.Series, gc.Equals, test.series)
@@ -112,13 +113,13 @@ func (s *AddMachineSuite) TestInit(c *gc.C) {
 
 func (s *AddMachineSuite) run(c *gc.C, args ...string) (*cmd.Context, error) {
 	add, _ := machine.NewAddCommandForTest(s.fakeAddMachine, s.fakeAddMachine, s.fakeMachineManager)
-	return testing.RunCommand(c, add, args...)
+	return cmdtesting.RunCommand(c, add, args...)
 }
 
 func (s *AddMachineSuite) TestAddMachine(c *gc.C) {
 	context, err := s.run(c)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(testing.Stderr(context), gc.Equals, "created machine 0\n")
+	c.Assert(cmdtesting.Stderr(context), gc.Equals, "created machine 0\n")
 
 	c.Assert(s.fakeAddMachine.args, gc.HasLen, 1)
 	param := s.fakeAddMachine.args[0]
@@ -133,7 +134,7 @@ func (s *AddMachineSuite) TestAddMachineUnauthorizedMentionsJujuGrant(c *gc.C) {
 		Code:    params.CodeUnauthorized,
 	}
 	ctx, _ := s.run(c)
-	errString := strings.Replace(testing.Stderr(ctx), "\n", " ", -1)
+	errString := strings.Replace(cmdtesting.Stderr(ctx), "\n", " ", -1)
 	c.Assert(errString, gc.Matches, `.*juju grant.*`)
 }
 
@@ -143,7 +144,7 @@ func (s *AddMachineSuite) TestSSHPlacement(c *gc.C) {
 	})
 	context, err := s.run(c, "ssh:10.1.2.3")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(testing.Stderr(context), gc.Equals, "created machine 42\n")
+	c.Assert(cmdtesting.Stderr(context), gc.Equals, "created machine 42\n")
 }
 
 func (s *AddMachineSuite) TestSSHPlacementError(c *gc.C) {
@@ -152,7 +153,7 @@ func (s *AddMachineSuite) TestSSHPlacementError(c *gc.C) {
 	})
 	context, err := s.run(c, "ssh:10.1.2.3")
 	c.Assert(err, gc.ErrorMatches, "failed to initialize warp core")
-	c.Assert(testing.Stderr(context), gc.Equals, "")
+	c.Assert(cmdtesting.Stderr(context), gc.Equals, "")
 }
 
 func (s *AddMachineSuite) TestParamsPassedOn(c *gc.C) {
@@ -183,7 +184,7 @@ failed to create 2 machines
 `
 	context, err := s.run(c, "-n", "3")
 	c.Assert(err, gc.ErrorMatches, "something went wrong, something went wrong")
-	c.Assert(testing.Stderr(context), gc.Equals, expectedOutput)
+	c.Assert(cmdtesting.Stderr(context), gc.Equals, expectedOutput)
 }
 
 func (s *AddMachineSuite) TestBlockedError(c *gc.C) {

--- a/cmd/juju/machine/list_test.go
+++ b/cmd/juju/machine/list_test.go
@@ -9,6 +9,7 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/cmd/cmdtesting"
 	"github.com/juju/juju/cmd/juju/machine"
 	"github.com/juju/juju/testing"
 )
@@ -119,9 +120,9 @@ func (s *MachineListCommandSuite) SetUpTest(c *gc.C) {
 }
 
 func (s *MachineListCommandSuite) TestMachine(c *gc.C) {
-	context, err := testing.RunCommand(c, newMachineListCommand())
+	context, err := cmdtesting.RunCommand(c, newMachineListCommand())
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(testing.Stdout(context), gc.Equals, ""+
+	c.Assert(cmdtesting.Stdout(context), gc.Equals, ""+
 		"Machine  State    DNS       Inst id              Series  AZ         Message\n"+
 		"0        started  10.0.0.1  juju-badd06-0        trusty  us-east-1  \n"+
 		"1        started  10.0.0.2  juju-badd06-1        trusty             \n"+
@@ -130,9 +131,9 @@ func (s *MachineListCommandSuite) TestMachine(c *gc.C) {
 }
 
 func (s *MachineListCommandSuite) TestListMachineYaml(c *gc.C) {
-	context, err := testing.RunCommand(c, newMachineListCommand(), "--format", "yaml")
+	context, err := cmdtesting.RunCommand(c, newMachineListCommand(), "--format", "yaml")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(testing.Stdout(context), gc.Equals, ""+
+	c.Assert(cmdtesting.Stdout(context), gc.Equals, ""+
 		"model: dummyenv\n"+
 		"machines:\n"+
 		"  \"0\":\n"+
@@ -189,13 +190,13 @@ func (s *MachineListCommandSuite) TestListMachineYaml(c *gc.C) {
 }
 
 func (s *MachineListCommandSuite) TestListMachineJson(c *gc.C) {
-	context, err := testing.RunCommand(c, newMachineListCommand(), "--format", "json")
+	context, err := cmdtesting.RunCommand(c, newMachineListCommand(), "--format", "json")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(testing.Stdout(context), gc.Equals, ""+
+	c.Assert(cmdtesting.Stdout(context), gc.Equals, ""+
 		"{\"model\":\"dummyenv\",\"machines\":{\"0\":{\"juju-status\":{\"current\":\"started\"},\"dns-name\":\"10.0.0.1\",\"ip-addresses\":[\"10.0.0.1\",\"10.0.1.1\"],\"instance-id\":\"juju-badd06-0\",\"machine-status\":{},\"series\":\"trusty\",\"network-interfaces\":{\"eth0\":{\"ip-addresses\":[\"10.0.0.1\",\"10.0.1.1\"],\"mac-address\":\"aa:bb:cc:dd:ee:ff\",\"is-up\":true}},\"constraints\":\"mem=3584M\",\"hardware\":\"availability-zone=us-east-1\"},\"1\":{\"juju-status\":{\"current\":\"started\"},\"dns-name\":\"10.0.0.2\",\"ip-addresses\":[\"10.0.0.2\",\"10.0.1.2\"],\"instance-id\":\"juju-badd06-1\",\"machine-status\":{},\"series\":\"trusty\",\"network-interfaces\":{\"eth0\":{\"ip-addresses\":[\"10.0.0.2\",\"10.0.1.2\"],\"mac-address\":\"aa:bb:cc:dd:ee:ff\",\"is-up\":true}},\"containers\":{\"1/lxd/0\":{\"juju-status\":{\"current\":\"pending\"},\"dns-name\":\"10.0.0.3\",\"ip-addresses\":[\"10.0.0.3\",\"10.0.1.3\"],\"instance-id\":\"juju-badd06-1-lxd-0\",\"machine-status\":{},\"series\":\"trusty\",\"network-interfaces\":{\"eth0\":{\"ip-addresses\":[\"10.0.0.3\",\"10.0.1.3\"],\"mac-address\":\"aa:bb:cc:dd:ee:ff\",\"is-up\":true}}}}}}}\n")
 }
 
 func (s *MachineListCommandSuite) TestListMachineArgsError(c *gc.C) {
-	_, err := testing.RunCommand(c, newMachineListCommand(), "0")
+	_, err := cmdtesting.RunCommand(c, newMachineListCommand(), "0")
 	c.Assert(err, gc.ErrorMatches, `unrecognized args: \["0"\]`)
 }

--- a/cmd/juju/machine/remove_test.go
+++ b/cmd/juju/machine/remove_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/cmd/cmdtesting"
 	"github.com/juju/juju/cmd/juju/machine"
 	"github.com/juju/juju/testing"
 )
@@ -28,7 +29,7 @@ func (s *RemoveMachineSuite) SetUpTest(c *gc.C) {
 
 func (s *RemoveMachineSuite) run(c *gc.C, args ...string) (*cmd.Context, error) {
 	remove, _ := machine.NewRemoveCommandForTest(s.fake)
-	return testing.RunCommand(c, remove, args...)
+	return cmdtesting.RunCommand(c, remove, args...)
 }
 
 func (s *RemoveMachineSuite) TestInit(c *gc.C) {
@@ -64,7 +65,7 @@ func (s *RemoveMachineSuite) TestInit(c *gc.C) {
 	} {
 		c.Logf("test %d", i)
 		wrappedCommand, removeCmd := machine.NewRemoveCommandForTest(s.fake)
-		err := testing.InitCommand(wrappedCommand, test.args)
+		err := cmdtesting.InitCommand(wrappedCommand, test.args)
 		if test.errorString == "" {
 			c.Check(err, jc.ErrorIsNil)
 			c.Check(removeCmd.Force, gc.Equals, test.force)
@@ -96,7 +97,7 @@ func (s *RemoveMachineSuite) TestRemoveOutput(c *gc.C) {
 	}}
 	ctx, err := s.run(c, "1", "2/lxd/1")
 	c.Assert(err, gc.Equals, cmd.ErrSilent)
-	stderr := testing.Stderr(ctx)
+	stderr := cmdtesting.Stderr(ctx)
 	c.Assert(stderr, gc.Equals, `
 removing machine 1 failed: oy vey
 removing machine 2/lxd/1

--- a/cmd/juju/machine/show_test.go
+++ b/cmd/juju/machine/show_test.go
@@ -8,6 +8,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/cmd/cmdtesting"
 	"github.com/juju/juju/cmd/juju/machine"
 	"github.com/juju/juju/testing"
 )
@@ -27,10 +28,10 @@ func (s *MachineShowCommandSuite) SetUpTest(c *gc.C) {
 }
 
 func (s *MachineShowCommandSuite) TestShowMachine(c *gc.C) {
-	context, err := testing.RunCommand(c, newMachineShowCommand())
+	context, err := cmdtesting.RunCommand(c, newMachineShowCommand())
 	c.Assert(err, jc.ErrorIsNil)
 	// TODO(macgreagoir) Spaces in dummyenv?
-	c.Assert(testing.Stdout(context), gc.Equals, ""+
+	c.Assert(cmdtesting.Stdout(context), gc.Equals, ""+
 		"model: dummyenv\n"+
 		"machines:\n"+
 		"  \"0\":\n"+
@@ -86,10 +87,10 @@ func (s *MachineShowCommandSuite) TestShowMachine(c *gc.C) {
 		"            is-up: true\n")
 }
 func (s *MachineShowCommandSuite) TestShowSingleMachine(c *gc.C) {
-	context, err := testing.RunCommand(c, newMachineShowCommand(), "0")
+	context, err := cmdtesting.RunCommand(c, newMachineShowCommand(), "0")
 	c.Assert(err, jc.ErrorIsNil)
 	// TODO(macgreagoir) Spaces in dummyenv?
-	c.Assert(testing.Stdout(context), gc.Equals, ""+
+	c.Assert(cmdtesting.Stdout(context), gc.Equals, ""+
 		"model: dummyenv\n"+
 		"machines:\n"+
 		"  \"0\":\n"+
@@ -113,9 +114,9 @@ func (s *MachineShowCommandSuite) TestShowSingleMachine(c *gc.C) {
 }
 
 func (s *MachineShowCommandSuite) TestShowTabularMachine(c *gc.C) {
-	context, err := testing.RunCommand(c, newMachineShowCommand(), "--format", "tabular", "0", "1")
+	context, err := cmdtesting.RunCommand(c, newMachineShowCommand(), "--format", "tabular", "0", "1")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(testing.Stdout(context), gc.Equals, ""+
+	c.Assert(cmdtesting.Stdout(context), gc.Equals, ""+
 		"Machine  State    DNS       Inst id              Series  AZ         Message\n"+
 		"0        started  10.0.0.1  juju-badd06-0        trusty  us-east-1  \n"+
 		"1        started  10.0.0.2  juju-badd06-1        trusty             \n"+
@@ -124,9 +125,9 @@ func (s *MachineShowCommandSuite) TestShowTabularMachine(c *gc.C) {
 }
 
 func (s *MachineShowCommandSuite) TestShowJsonMachine(c *gc.C) {
-	context, err := testing.RunCommand(c, newMachineShowCommand(), "--format", "json", "0", "1")
+	context, err := cmdtesting.RunCommand(c, newMachineShowCommand(), "--format", "json", "0", "1")
 	c.Assert(err, jc.ErrorIsNil)
 	// TODO(macgreagoir) Spaces in dummyenv?
-	c.Assert(testing.Stdout(context), gc.Equals, ""+
+	c.Assert(cmdtesting.Stdout(context), gc.Equals, ""+
 		"{\"model\":\"dummyenv\",\"machines\":{\"0\":{\"juju-status\":{\"current\":\"started\"},\"dns-name\":\"10.0.0.1\",\"ip-addresses\":[\"10.0.0.1\",\"10.0.1.1\"],\"instance-id\":\"juju-badd06-0\",\"machine-status\":{},\"series\":\"trusty\",\"network-interfaces\":{\"eth0\":{\"ip-addresses\":[\"10.0.0.1\",\"10.0.1.1\"],\"mac-address\":\"aa:bb:cc:dd:ee:ff\",\"is-up\":true}},\"constraints\":\"mem=3584M\",\"hardware\":\"availability-zone=us-east-1\"},\"1\":{\"juju-status\":{\"current\":\"started\"},\"dns-name\":\"10.0.0.2\",\"ip-addresses\":[\"10.0.0.2\",\"10.0.1.2\"],\"instance-id\":\"juju-badd06-1\",\"machine-status\":{},\"series\":\"trusty\",\"network-interfaces\":{\"eth0\":{\"ip-addresses\":[\"10.0.0.2\",\"10.0.1.2\"],\"mac-address\":\"aa:bb:cc:dd:ee:ff\",\"is-up\":true}},\"containers\":{\"1/lxd/0\":{\"juju-status\":{\"current\":\"pending\"},\"dns-name\":\"10.0.0.3\",\"ip-addresses\":[\"10.0.0.3\",\"10.0.1.3\"],\"instance-id\":\"juju-badd06-1-lxd-0\",\"machine-status\":{},\"series\":\"trusty\",\"network-interfaces\":{\"eth0\":{\"ip-addresses\":[\"10.0.0.3\",\"10.0.1.3\"],\"mac-address\":\"aa:bb:cc:dd:ee:ff\",\"is-up\":true}}}}}}}\n")
 }

--- a/cmd/juju/metricsdebug/collectmetrics_test.go
+++ b/cmd/juju/metricsdebug/collectmetrics_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/juju/juju/api"
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/cmd/cmdtesting"
 	"github.com/juju/juju/cmd/juju/action"
 	"github.com/juju/juju/cmd/juju/metricsdebug"
 	"github.com/juju/juju/cmd/modelcmd"
@@ -309,12 +310,12 @@ func (s *collectMetricsSuite) TestCollectMetrics(c *gc.C) {
 			runClient.results = test.results
 		}
 		metricsdebug.PatchGetActionResult(s.PatchValue, test.actionMap)
-		ctx, err := coretesting.RunCommand(c, metricsdebug.NewCollectMetricsCommand(), test.args...)
+		ctx, err := cmdtesting.RunCommand(c, metricsdebug.NewCollectMetricsCommand(), test.args...)
 		if test.err != "" {
 			c.Assert(err, gc.ErrorMatches, test.err)
 		} else {
 			c.Assert(err, jc.ErrorIsNil)
-			c.Assert(coretesting.Stdout(ctx), gc.Matches, test.stdout)
+			c.Assert(cmdtesting.Stdout(ctx), gc.Matches, test.stdout)
 		}
 	}
 }
@@ -326,7 +327,7 @@ func (s *collectMetricsSuite) TestCollectMetricsFailsOnNonLocalCharm(c *gc.C) {
 	s.PatchValue(metricsdebug.NewAPIConn, noConn)
 	s.PatchValue(metricsdebug.NewRunClient, metricsdebug.NewRunClientFnc(runClient))
 	s.PatchValue(metricsdebug.NewServiceClient, metricsdebug.NewServiceClientFnc(serviceClient))
-	_, err := coretesting.RunCommand(c, metricsdebug.NewCollectMetricsCommand(), "foobar")
+	_, err := cmdtesting.RunCommand(c, metricsdebug.NewCollectMetricsCommand(), "foobar")
 	c.Assert(err, gc.ErrorMatches, `"foobar" is not a local charm`)
 	runClient.CheckCallNames(c, "Close")
 }

--- a/cmd/juju/metricsdebug/metrics_test.go
+++ b/cmd/juju/metricsdebug/metrics_test.go
@@ -7,13 +7,13 @@ import (
 	stdtesting "testing"
 	"time"
 
-	"github.com/juju/cmd/cmdtesting"
 	"github.com/juju/errors"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/cmd/cmdtesting"
 	"github.com/juju/juju/cmd/juju/metricsdebug"
 	"github.com/juju/juju/cmd/modelcmd"
 	coretesting "github.com/juju/juju/testing"
@@ -71,7 +71,7 @@ func (s *metricsSuite) TestSort(c *gc.C) {
 		Value: "15.0",
 		Time:  time.Date(2016, 8, 22, 12, 02, 04, 0, time.UTC),
 	}}
-	ctx, err := coretesting.RunCommand(c, metricsdebug.New(), "metered/0")
+	ctx, err := cmdtesting.RunCommand(c, metricsdebug.New(), "metered/0")
 	c.Assert(err, jc.ErrorIsNil)
 	s.client.CheckCall(c, 0, "GetMetrics", []string{"unit-metered-0"})
 	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, `UNIT          	           TIMESTAMP	METRIC	VALUE
@@ -93,7 +93,7 @@ func (s *metricsSuite) TestDefaultTabulatFormat(c *gc.C) {
 		Value: "5.0",
 		Time:  time.Date(2016, 8, 22, 12, 02, 03, 0, time.UTC),
 	}}
-	ctx, err := coretesting.RunCommand(c, metricsdebug.New(), "metered/0")
+	ctx, err := cmdtesting.RunCommand(c, metricsdebug.New(), "metered/0")
 	c.Assert(err, jc.ErrorIsNil)
 	s.client.CheckCall(c, 0, "GetMetrics", []string{"unit-metered-0"})
 	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, `UNIT          	           TIMESTAMP	METRIC	VALUE
@@ -114,7 +114,7 @@ func (s *metricsSuite) TestJSONFormat(c *gc.C) {
 		Value: "15.0",
 		Time:  time.Date(2016, 8, 22, 12, 02, 04, 0, time.UTC),
 	}}
-	ctx, err := coretesting.RunCommand(c, metricsdebug.New(), "metered", "--format", "json")
+	ctx, err := cmdtesting.RunCommand(c, metricsdebug.New(), "metered", "--format", "json")
 	c.Assert(err, jc.ErrorIsNil)
 	s.client.CheckCall(c, 0, "GetMetrics", []string{"application-metered"})
 	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, `[{"unit":"unit-metered-0","timestamp":"2016-08-22T12:02:03Z","metric":"pings","value":"5.0"},{"unit":"unit-metered-0","timestamp":"2016-08-22T12:02:04Z","metric":"pongs","value":"15.0"}]
@@ -133,7 +133,7 @@ func (s *metricsSuite) TestYAMLFormat(c *gc.C) {
 		Value: "15.0",
 		Time:  time.Date(2016, 8, 22, 12, 02, 04, 0, time.UTC),
 	}}
-	ctx, err := coretesting.RunCommand(c, metricsdebug.New(), "metered", "--format", "yaml")
+	ctx, err := cmdtesting.RunCommand(c, metricsdebug.New(), "metered", "--format", "yaml")
 	c.Assert(err, jc.ErrorIsNil)
 	s.client.CheckCall(c, 0, "GetMetrics", []string{"application-metered"})
 	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, `- unit: unit-metered-0
@@ -148,28 +148,28 @@ func (s *metricsSuite) TestYAMLFormat(c *gc.C) {
 }
 
 func (s *metricsSuite) TestAll(c *gc.C) {
-	_, err := coretesting.RunCommand(c, metricsdebug.New(), "--all")
+	_, err := cmdtesting.RunCommand(c, metricsdebug.New(), "--all")
 	c.Assert(err, jc.ErrorIsNil)
 	s.client.CheckCall(c, 0, "GetMetrics", []string(nil))
 }
 
 func (s *metricsSuite) TestAllWithExtraArgs(c *gc.C) {
-	_, err := coretesting.RunCommand(c, metricsdebug.New(), "--all", "metered")
+	_, err := cmdtesting.RunCommand(c, metricsdebug.New(), "--all", "metered")
 	c.Assert(err, gc.ErrorMatches, "cannot use --all with additional entities")
 }
 
 func (s *metricsSuite) TestInvalidUnitName(c *gc.C) {
-	_, err := coretesting.RunCommand(c, metricsdebug.New(), "metered-/0")
+	_, err := cmdtesting.RunCommand(c, metricsdebug.New(), "metered-/0")
 	c.Assert(err, gc.ErrorMatches, `"metered-/0" is not a valid unit or application`)
 }
 
 func (s *metricsSuite) TestAPIClientError(c *gc.C) {
 	s.client.SetErrors(errors.New("a silly error"))
-	_, err := coretesting.RunCommand(c, metricsdebug.New(), "metered/0")
+	_, err := cmdtesting.RunCommand(c, metricsdebug.New(), "metered/0")
 	c.Assert(err, gc.ErrorMatches, `a silly error`)
 }
 
 func (s *metricsSuite) TestNoArgs(c *gc.C) {
-	_, err := coretesting.RunCommand(c, metricsdebug.New())
+	_, err := cmdtesting.RunCommand(c, metricsdebug.New())
 	c.Assert(err, gc.ErrorMatches, "you need to specify at least one unit or application")
 }

--- a/cmd/juju/model/configcommand_test.go
+++ b/cmd/juju/model/configcommand_test.go
@@ -11,6 +11,7 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/cmd/cmdtesting"
 	"github.com/juju/juju/cmd/juju/model"
 	"github.com/juju/juju/testing"
 )
@@ -23,7 +24,7 @@ var _ = gc.Suite(&ConfigCommandSuite{})
 
 func (s *ConfigCommandSuite) run(c *gc.C, args ...string) (*cmd.Context, error) {
 	command := model.NewConfigCommandForTest(s.fake)
-	return testing.RunCommand(c, command, args...)
+	return cmdtesting.RunCommand(c, command, args...)
 }
 
 func (s *ConfigCommandSuite) TestInit(c *gc.C) {
@@ -84,7 +85,7 @@ func (s *ConfigCommandSuite) TestInit(c *gc.C) {
 	} {
 		c.Logf("test %d: %s", i, test.desc)
 		cmd := model.NewConfigCommandForTest(s.fake)
-		err := testing.InitCommand(cmd, test.args)
+		err := cmdtesting.InitCommand(cmd, test.args)
 		if test.nilErr {
 			c.Check(err, jc.ErrorIsNil)
 			continue
@@ -99,7 +100,7 @@ func (s *ConfigCommandSuite) TestSingleValue(c *gc.C) {
 	context, err := s.run(c, "special")
 	c.Assert(err, jc.ErrorIsNil)
 
-	output := testing.Stdout(context)
+	output := cmdtesting.Stdout(context)
 	c.Assert(output, gc.Equals, "multi\nline\n")
 }
 
@@ -119,7 +120,7 @@ func (s *ConfigCommandSuite) TestGetUnknownValue(c *gc.C) {
 	context, err := s.run(c, "unknown")
 	c.Assert(err, gc.ErrorMatches, `key "unknown" not found in {<nil> ""} model.`)
 
-	output := testing.Stdout(context)
+	output := cmdtesting.Stdout(context)
 	c.Assert(output, gc.Equals, "")
 }
 
@@ -128,7 +129,7 @@ func (s *ConfigCommandSuite) TestSingleValueJSON(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	want := "{\"special\":{\"Value\":\"special value\",\"Source\":\"model\"}}\n"
-	output := testing.Stdout(context)
+	output := cmdtesting.Stdout(context)
 	c.Assert(output, gc.Equals, want)
 }
 
@@ -141,7 +142,7 @@ func (s *ConfigCommandSuite) TestSingleValueYAML(c *gc.C) {
 		"  value: special value\n" +
 		"  source: model\n"
 
-	output := testing.Stdout(context)
+	output := cmdtesting.Stdout(context)
 	c.Assert(output, gc.Equals, want)
 }
 
@@ -149,7 +150,7 @@ func (s *ConfigCommandSuite) TestAllValuesYAML(c *gc.C) {
 	context, err := s.run(c, "--format=yaml")
 	c.Assert(err, jc.ErrorIsNil)
 
-	output := testing.Stdout(context)
+	output := cmdtesting.Stdout(context)
 	expected := "" +
 		"running:\n" +
 		"  value: true\n" +
@@ -164,7 +165,7 @@ func (s *ConfigCommandSuite) TestAllValuesJSON(c *gc.C) {
 	context, err := s.run(c, "--format=json")
 	c.Assert(err, jc.ErrorIsNil)
 
-	output := testing.Stdout(context)
+	output := cmdtesting.Stdout(context)
 	expected := `{"running":{"Value":true,"Source":"model"},"special":{"Value":"special value","Source":"model"}}` + "\n"
 	c.Assert(output, gc.Equals, expected)
 }
@@ -173,7 +174,7 @@ func (s *ConfigCommandSuite) TestAllValuesTabular(c *gc.C) {
 	context, err := s.run(c)
 	c.Assert(err, jc.ErrorIsNil)
 
-	output := testing.Stdout(context)
+	output := cmdtesting.Stdout(context)
 	expected := "" +
 		"Attribute  From   Value\n" +
 		"running    model  true\n" +

--- a/cmd/juju/model/constraints_test.go
+++ b/cmd/juju/model/constraints_test.go
@@ -7,6 +7,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/cmd/cmdtesting"
 	"github.com/juju/juju/cmd/juju/model"
 	"github.com/juju/juju/testing"
 )
@@ -32,7 +33,7 @@ func (s *ModelConstraintsCommandsSuite) TestSetInit(c *gc.C) {
 			args: []string{"cpu-power=250"},
 		},
 	} {
-		err := testing.InitCommand(model.NewModelSetConstraintsCommand(), test.args)
+		err := cmdtesting.InitCommand(model.NewModelSetConstraintsCommand(), test.args)
 		if test.err == "" {
 			c.Check(err, jc.ErrorIsNil)
 		} else {
@@ -56,7 +57,7 @@ func (s *ModelConstraintsCommandsSuite) TestGetInit(c *gc.C) {
 			args: []string{},
 		},
 	} {
-		err := testing.InitCommand(model.NewModelGetConstraintsCommand(), test.args)
+		err := cmdtesting.InitCommand(model.NewModelGetConstraintsCommand(), test.args)
 		if test.err == "" {
 			c.Check(err, jc.ErrorIsNil)
 		} else {

--- a/cmd/juju/model/defaultscommand_test.go
+++ b/cmd/juju/model/defaultscommand_test.go
@@ -10,6 +10,7 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/cmd/cmdtesting"
 	"github.com/juju/juju/cmd/juju/model"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/jujuclient"
@@ -32,7 +33,7 @@ func (s *DefaultsCommandSuite) SetUpTest(c *gc.C) {
 
 func (s *DefaultsCommandSuite) run(c *gc.C, args ...string) (*cmd.Context, error) {
 	command := model.NewDefaultsCommandForTest(s.fakeAPIRoot, s.fakeDefaultsAPI, s.fakeCloudAPI, s.store)
-	return testing.RunCommand(c, command, args...)
+	return cmdtesting.RunCommand(c, command, args...)
 }
 
 func (s *DefaultsCommandSuite) TestDefaultsInit(c *gc.C) {
@@ -218,7 +219,7 @@ func (s *DefaultsCommandSuite) TestDefaultsInit(c *gc.C) {
 	} {
 		c.Logf("test %d: %s", i, test.description)
 		cmd := model.NewDefaultsCommandForTest(s.fakeAPIRoot, s.fakeDefaultsAPI, s.fakeCloudAPI, s.store)
-		err := testing.InitCommand(cmd, test.args)
+		err := cmdtesting.InitCommand(cmd, test.args)
 		if test.nilErr {
 			c.Check(err, jc.ErrorIsNil)
 			continue
@@ -232,7 +233,7 @@ func (s *DefaultsCommandSuite) TestResetUnknownValueLogs(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	expected := `key "weird" is not defined in the known model configuration: possible misspelling`
 	c.Check(c.GetTestLog(), jc.Contains, expected)
-	c.Check(testing.Stdout(ctx), jc.DeepEquals, "")
+	c.Check(cmdtesting.Stdout(ctx), jc.DeepEquals, "")
 }
 
 func (s *DefaultsCommandSuite) TestResetAttr(c *gc.C) {
@@ -247,7 +248,7 @@ func (s *DefaultsCommandSuite) TestResetAttr(c *gc.C) {
 			Value: "another-value",
 		}}},
 	})
-	c.Check(testing.Stdout(ctx), jc.DeepEquals, "")
+	c.Check(cmdtesting.Stdout(ctx), jc.DeepEquals, "")
 }
 
 func (s *DefaultsCommandSuite) TestResetRegionAttr(c *gc.C) {
@@ -262,7 +263,7 @@ func (s *DefaultsCommandSuite) TestResetRegionAttr(c *gc.C) {
 			Value: "another-value",
 		}}},
 	})
-	c.Check(testing.Stdout(ctx), jc.DeepEquals, "")
+	c.Check(cmdtesting.Stdout(ctx), jc.DeepEquals, "")
 }
 
 func (s *DefaultsCommandSuite) TestResetBlockedError(c *gc.C) {
@@ -327,7 +328,7 @@ func (s *DefaultsCommandSuite) TestGetSingleValue(c *gc.C) {
 	context, err := s.run(c, "attr2")
 	c.Assert(err, jc.ErrorIsNil)
 
-	output := strings.TrimSpace(testing.Stdout(context))
+	output := strings.TrimSpace(cmdtesting.Stdout(context))
 	expected := "" +
 		"Attribute         Default        Controller\n" +
 		"attr2             -              bar\n" +
@@ -340,7 +341,7 @@ func (s *DefaultsCommandSuite) TestGetSingleValueJSON(c *gc.C) {
 	context, err := s.run(c, "--format=json", "attr2")
 	c.Assert(err, jc.ErrorIsNil)
 
-	output := strings.TrimSpace(testing.Stdout(context))
+	output := strings.TrimSpace(cmdtesting.Stdout(context))
 	c.Assert(output, gc.Equals,
 		`{"attr2":{"controller":"bar","regions":[{"name":"dummy-region","value":"dummy-value"},{"name":"another-region","value":"another-value"}]}}`)
 }
@@ -349,7 +350,7 @@ func (s *DefaultsCommandSuite) TestGetAllValuesYAML(c *gc.C) {
 	context, err := s.run(c, "--format=yaml")
 	c.Assert(err, jc.ErrorIsNil)
 
-	output := strings.TrimSpace(testing.Stdout(context))
+	output := strings.TrimSpace(cmdtesting.Stdout(context))
 	expected := "" +
 		"attr:\n" +
 		"  default: foo\n" +
@@ -367,7 +368,7 @@ func (s *DefaultsCommandSuite) TestGetAllValuesJSON(c *gc.C) {
 	context, err := s.run(c, "--format=json")
 	c.Assert(err, jc.ErrorIsNil)
 
-	output := strings.TrimSpace(testing.Stdout(context))
+	output := strings.TrimSpace(cmdtesting.Stdout(context))
 	expected := `{"attr":{"default":"foo"},"attr2":{"controller":"bar","regions":[{"name":"dummy-region","value":"dummy-value"},{"name":"another-region","value":"another-value"}]}}`
 	c.Assert(output, gc.Equals, expected)
 }
@@ -376,7 +377,7 @@ func (s *DefaultsCommandSuite) TestGetAllValuesTabular(c *gc.C) {
 	context, err := s.run(c)
 	c.Assert(err, jc.ErrorIsNil)
 
-	output := strings.TrimSpace(testing.Stdout(context))
+	output := strings.TrimSpace(cmdtesting.Stdout(context))
 	expected := "" +
 		"Attribute         Default        Controller\n" +
 		"attr              foo            -\n" +
@@ -390,7 +391,7 @@ func (s *DefaultsCommandSuite) TestGetRegionValuesTabular(c *gc.C) {
 	context, err := s.run(c, "dummy-region")
 	c.Assert(err, jc.ErrorIsNil)
 
-	output := strings.TrimSpace(testing.Stdout(context))
+	output := strings.TrimSpace(cmdtesting.Stdout(context))
 	expected := "" +
 		"Attribute       Default      Controller\n" +
 		"attr2           -            bar\n" +
@@ -403,11 +404,11 @@ func (s *DefaultsCommandSuite) TestGetRegionNoValuesTabular(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	ctx, err := s.run(c, "dummy-region")
 	c.Assert(err, gc.ErrorMatches, `there are no default model values in region "dummy-region"`)
-	c.Assert(testing.Stdout(ctx), gc.Equals, "")
+	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, "")
 }
 
 func (s *DefaultsCommandSuite) TestGetRegionOneArgNoValuesTabular(c *gc.C) {
 	ctx, err := s.run(c, "dummy-region", "attr")
 	c.Assert(err, gc.ErrorMatches, `there are no default model values for "attr" in region "dummy-region"`)
-	c.Assert(testing.Stdout(ctx), gc.Equals, "")
+	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, "")
 }

--- a/cmd/juju/model/dump_test.go
+++ b/cmd/juju/model/dump_test.go
@@ -9,6 +9,7 @@ import (
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/names.v2"
 
+	"github.com/juju/juju/cmd/cmdtesting"
 	"github.com/juju/juju/cmd/juju/model"
 	"github.com/juju/juju/jujuclient"
 	"github.com/juju/juju/testing"
@@ -59,13 +60,13 @@ func (s *DumpCommandSuite) SetUpTest(c *gc.C) {
 }
 
 func (s *DumpCommandSuite) TestDump(c *gc.C) {
-	ctx, err := testing.RunCommand(c, model.NewDumpCommandForTest(&s.fake, s.store))
+	ctx, err := cmdtesting.RunCommand(c, model.NewDumpCommandForTest(&s.fake, s.store))
 	c.Assert(err, jc.ErrorIsNil)
 	s.fake.CheckCalls(c, []gitjujutesting.StubCall{
 		{"DumpModel", []interface{}{testing.ModelTag}},
 		{"Close", nil},
 	})
 
-	out := testing.Stdout(ctx)
+	out := cmdtesting.Stdout(ctx)
 	c.Assert(out, gc.Equals, "model-uuid: fake uuid\n")
 }

--- a/cmd/juju/model/dumpdb_test.go
+++ b/cmd/juju/model/dumpdb_test.go
@@ -9,6 +9,7 @@ import (
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/names.v2"
 
+	"github.com/juju/juju/cmd/cmdtesting"
 	"github.com/juju/juju/cmd/juju/model"
 	"github.com/juju/juju/jujuclient"
 	"github.com/juju/juju/testing"
@@ -39,14 +40,14 @@ func (s *DumpDBCommandSuite) SetUpTest(c *gc.C) {
 }
 
 func (s *DumpDBCommandSuite) TestDumpDB(c *gc.C) {
-	ctx, err := testing.RunCommand(c, model.NewDumpDBCommandForTest(&s.fake, s.store))
+	ctx, err := cmdtesting.RunCommand(c, model.NewDumpDBCommandForTest(&s.fake, s.store))
 	c.Assert(err, jc.ErrorIsNil)
 	s.fake.CheckCalls(c, []gitjujutesting.StubCall{
 		{"DumpModelDB", []interface{}{testing.ModelTag}},
 		{"Close", nil},
 	})
 
-	out := testing.Stdout(ctx)
+	out := cmdtesting.Stdout(ctx)
 	c.Assert(out, gc.Equals, `all-others: heaps of data
 models:
   name: testing

--- a/cmd/juju/model/grantrevoke_test.go
+++ b/cmd/juju/model/grantrevoke_test.go
@@ -11,6 +11,7 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/cmd/cmdtesting"
 	"github.com/juju/juju/cmd/juju/model"
 	"github.com/juju/juju/core/crossmodel"
 	"github.com/juju/juju/feature"
@@ -65,7 +66,7 @@ func (s *grantRevokeSuite) SetUpTest(c *gc.C) {
 
 func (s *grantRevokeSuite) run(c *gc.C, args ...string) (*cmd.Context, error) {
 	command := s.cmdFactory(s.fakeModelAPI, s.fakeOffersAPI)
-	return testing.RunCommand(c, command, args...)
+	return cmdtesting.RunCommand(c, command, args...)
 }
 
 func (s *grantRevokeSuite) TestPassesModelValues(c *gc.C) {
@@ -127,24 +128,24 @@ func (s *grantSuite) SetUpTest(c *gc.C) {
 
 func (s *grantSuite) TestInitModels(c *gc.C) {
 	wrappedCmd, grantCmd := model.NewGrantCommandForTest(nil, nil, s.store)
-	err := testing.InitCommand(wrappedCmd, []string{})
+	err := cmdtesting.InitCommand(wrappedCmd, []string{})
 	c.Assert(err, gc.ErrorMatches, "no user specified")
 
-	err = testing.InitCommand(wrappedCmd, []string{"bob", "read", "model1", "model2"})
+	err = cmdtesting.InitCommand(wrappedCmd, []string{"bob", "read", "model1", "model2"})
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Assert(grantCmd.User, gc.Equals, "bob")
 	c.Assert(grantCmd.ModelNames, jc.DeepEquals, []string{"model1", "model2"})
 	c.Assert(grantCmd.OfferURLs, gc.HasLen, 0)
 
-	err = testing.InitCommand(wrappedCmd, []string{})
+	err = cmdtesting.InitCommand(wrappedCmd, []string{})
 	c.Assert(err, gc.ErrorMatches, `no user specified`)
 }
 
 func (s *grantSuite) TestInitOffers(c *gc.C) {
 	wrappedCmd, grantCmd := model.NewGrantCommandForTest(nil, nil, s.store)
 
-	err := testing.InitCommand(wrappedCmd, []string{"bob", "read", "fred/model.offer1", "mary/model.offer2"})
+	err := cmdtesting.InitCommand(wrappedCmd, []string{"bob", "read", "fred/model.offer1", "mary/model.offer2"})
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Assert(grantCmd.User, gc.Equals, "bob")
@@ -161,11 +162,11 @@ func (s *grantSuite) TestInitOffers(c *gc.C) {
 func (s *grantSuite) TestInitGrantAddModel(c *gc.C) {
 	wrappedCmd, grantCmd := model.NewGrantCommandForTest(nil, nil, s.store)
 	// The documented case, add-model.
-	err := testing.InitCommand(wrappedCmd, []string{"bob", "add-model"})
+	err := cmdtesting.InitCommand(wrappedCmd, []string{"bob", "add-model"})
 	c.Check(err, jc.ErrorIsNil)
 
 	// The backwards-compatible case, addmodel.
-	err = testing.InitCommand(wrappedCmd, []string{"bob", "addmodel"})
+	err = cmdtesting.InitCommand(wrappedCmd, []string{"bob", "addmodel"})
 	c.Check(err, jc.ErrorIsNil)
 	c.Assert(grantCmd.Access, gc.Equals, "add-model")
 }
@@ -186,16 +187,16 @@ func (s *revokeSuite) SetUpTest(c *gc.C) {
 
 func (s *revokeSuite) TestInit(c *gc.C) {
 	wrappedCmd, revokeCmd := model.NewRevokeCommandForTest(nil, nil, s.store)
-	err := testing.InitCommand(wrappedCmd, []string{})
+	err := cmdtesting.InitCommand(wrappedCmd, []string{})
 	c.Assert(err, gc.ErrorMatches, "no user specified")
 
-	err = testing.InitCommand(wrappedCmd, []string{"bob", "read", "model1", "model2"})
+	err = cmdtesting.InitCommand(wrappedCmd, []string{"bob", "read", "model1", "model2"})
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Assert(revokeCmd.User, gc.Equals, "bob")
 	c.Assert(revokeCmd.ModelNames, jc.DeepEquals, []string{"model1", "model2"})
 
-	err = testing.InitCommand(wrappedCmd, []string{})
+	err = cmdtesting.InitCommand(wrappedCmd, []string{})
 	c.Assert(err, gc.ErrorMatches, `no user specified`)
 
 }
@@ -205,32 +206,32 @@ func (s *revokeSuite) TestInit(c *gc.C) {
 func (s *grantSuite) TestInitRevokeAddModel(c *gc.C) {
 	wrappedCmd, revokeCmd := model.NewRevokeCommandForTest(nil, nil, s.store)
 	// The documented case, add-model.
-	err := testing.InitCommand(wrappedCmd, []string{"bob", "add-model"})
+	err := cmdtesting.InitCommand(wrappedCmd, []string{"bob", "add-model"})
 	c.Check(err, jc.ErrorIsNil)
 
 	// The backwards-compatible case, addmodel.
-	err = testing.InitCommand(wrappedCmd, []string{"bob", "addmodel"})
+	err = cmdtesting.InitCommand(wrappedCmd, []string{"bob", "addmodel"})
 	c.Check(err, jc.ErrorIsNil)
 	c.Assert(revokeCmd.Access, gc.Equals, "add-model")
 }
 
 func (s *grantSuite) TestModelAccessForController(c *gc.C) {
 	wrappedCmd, _ := model.NewRevokeCommandForTest(nil, nil, s.store)
-	err := testing.InitCommand(wrappedCmd, []string{"bob", "write"})
+	err := cmdtesting.InitCommand(wrappedCmd, []string{"bob", "write"})
 	msg := strings.Replace(err.Error(), "\n", "", -1)
 	c.Check(msg, gc.Matches, `You have specified a model access permission "write".*`)
 }
 
 func (s *grantSuite) TestControllerAccessForModel(c *gc.C) {
 	wrappedCmd, _ := model.NewRevokeCommandForTest(nil, nil, s.store)
-	err := testing.InitCommand(wrappedCmd, []string{"bob", "superuser", "default"})
+	err := cmdtesting.InitCommand(wrappedCmd, []string{"bob", "superuser", "default"})
 	msg := strings.Replace(err.Error(), "\n", "", -1)
 	c.Check(msg, gc.Matches, `You have specified a controller access permission "superuser".*`)
 }
 
 func (s *grantSuite) TestControllerAccessForOffer(c *gc.C) {
 	wrappedCmd, _ := model.NewRevokeCommandForTest(nil, nil, s.store)
-	err := testing.InitCommand(wrappedCmd, []string{"bob", "superuser", "fred/default.mysql"})
+	err := cmdtesting.InitCommand(wrappedCmd, []string{"bob", "superuser", "fred/default.mysql"})
 	msg := strings.Replace(err.Error(), "\n", "", -1)
 	c.Check(msg, gc.Matches, `You have specified a controller access permission "superuser".*`)
 }

--- a/cmd/juju/model/retryprovisioning_test.go
+++ b/cmd/juju/model/retryprovisioning_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/cmd/cmdtesting"
 	"github.com/juju/juju/cmd/juju/model"
 	"github.com/juju/juju/testing"
 )
@@ -123,13 +124,13 @@ func (s *retryProvisioningSuite) TestRetryProvisioning(c *gc.C) {
 	for i, t := range resolvedMachineTests {
 		c.Logf("test %d: %v", i, t.args)
 		command := model.NewRetryProvisioningCommandForTest(s.fake)
-		context, err := testing.RunCommand(c, command, t.args...)
+		context, err := cmdtesting.RunCommand(c, command, t.args...)
 		if t.err != "" {
 			c.Check(err, gc.ErrorMatches, t.err)
 			continue
 		}
 		c.Check(err, jc.ErrorIsNil)
-		output := testing.Stderr(context)
+		output := cmdtesting.Stderr(context)
 		stripped := strings.Replace(output, "\n", "", -1)
 		c.Check(stripped, gc.Equals, t.stdErr)
 		if t.args[0] == "0" {
@@ -146,7 +147,7 @@ func (s *retryProvisioningSuite) TestBlockRetryProvisioning(c *gc.C) {
 
 	for i, t := range resolvedMachineTests {
 		c.Logf("test %d: %v", i, t.args)
-		_, err := testing.RunCommand(c, command, t.args...)
+		_, err := cmdtesting.RunCommand(c, command, t.args...)
 		if t.err != "" {
 			c.Check(err, gc.ErrorMatches, t.err)
 			continue

--- a/cmd/juju/model/show_test.go
+++ b/cmd/juju/model/show_test.go
@@ -14,6 +14,7 @@ import (
 	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/cmd/cmdtesting"
 	"github.com/juju/juju/cmd/juju/model"
 	"github.com/juju/juju/jujuclient"
 	"github.com/juju/juju/status"
@@ -143,7 +144,7 @@ func (s *ShowCommandSuite) newShowCommand() cmd.Command {
 }
 
 func (s *ShowCommandSuite) TestShow(c *gc.C) {
-	_, err := testing.RunCommand(c, s.newShowCommand())
+	_, err := cmdtesting.RunCommand(c, s.newShowCommand())
 	c.Assert(err, jc.ErrorIsNil)
 	s.fake.CheckCalls(c, []gitjujutesting.StubCall{
 		{"ModelInfo", []interface{}{[]names.ModelTag{testing.ModelTag}}},
@@ -157,25 +158,25 @@ func (s *ShowCommandSuite) TestShowUnknownCallsRefresh(c *gc.C) {
 		called = true
 		return nil
 	}
-	_, err := testing.RunCommand(c, model.NewShowCommandForTest(&s.fake, refresh, s.store), "unknown")
+	_, err := cmdtesting.RunCommand(c, model.NewShowCommandForTest(&s.fake, refresh, s.store), "unknown")
 	c.Check(called, jc.IsTrue)
 	c.Check(err, jc.Satisfies, errors.IsNotFound)
 }
 
 func (s *ShowCommandSuite) TestShowFormatYaml(c *gc.C) {
-	ctx, err := testing.RunCommand(c, s.newShowCommand(), "--format", "yaml")
+	ctx, err := cmdtesting.RunCommand(c, s.newShowCommand(), "--format", "yaml")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(testing.Stdout(ctx), jc.YAMLEquals, s.expectedOutput)
+	c.Assert(cmdtesting.Stdout(ctx), jc.YAMLEquals, s.expectedOutput)
 }
 
 func (s *ShowCommandSuite) TestShowFormatJson(c *gc.C) {
-	ctx, err := testing.RunCommand(c, s.newShowCommand(), "--format", "json")
+	ctx, err := cmdtesting.RunCommand(c, s.newShowCommand(), "--format", "json")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(testing.Stdout(ctx), jc.JSONEquals, s.expectedOutput)
+	c.Assert(cmdtesting.Stdout(ctx), jc.JSONEquals, s.expectedOutput)
 }
 
 func (s *ShowCommandSuite) TestUnrecognizedArg(c *gc.C) {
-	_, err := testing.RunCommand(c, s.newShowCommand(), "admin", "whoops")
+	_, err := cmdtesting.RunCommand(c, s.newShowCommand(), "admin", "whoops")
 	c.Assert(err, gc.ErrorMatches, `unrecognized args: \["whoops"\]`)
 }
 

--- a/cmd/juju/romulus/agree/agree_test.go
+++ b/cmd/juju/romulus/agree/agree_test.go
@@ -8,13 +8,13 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/juju/cmd/cmdtesting"
 	"github.com/juju/terms-client/api"
 	"github.com/juju/terms-client/api/wireformat"
 	jujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/cmd/cmdtesting"
 	"github.com/juju/juju/cmd/juju/romulus/agree"
 	coretesting "github.com/juju/juju/testing"
 )

--- a/cmd/juju/romulus/allocate/allocate_test.go
+++ b/cmd/juju/romulus/allocate/allocate_test.go
@@ -5,12 +5,12 @@ package allocate_test
 
 import (
 	"github.com/juju/cmd"
-	"github.com/juju/cmd/cmdtesting"
 	"github.com/juju/errors"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/cmd/cmdtesting"
 	"github.com/juju/juju/cmd/juju/romulus/allocate"
 	"github.com/juju/juju/jujuclient"
 	coretesting "github.com/juju/juju/testing"

--- a/cmd/juju/romulus/createbudget/createbudget_test.go
+++ b/cmd/juju/romulus/createbudget/createbudget_test.go
@@ -4,12 +4,12 @@
 package createbudget_test
 
 import (
-	"github.com/juju/cmd/cmdtesting"
 	"github.com/juju/errors"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/cmd/cmdtesting"
 	"github.com/juju/juju/cmd/juju/romulus/createbudget"
 	coretesting "github.com/juju/juju/testing"
 )

--- a/cmd/juju/romulus/listagreements/listagreements_test.go
+++ b/cmd/juju/romulus/listagreements/listagreements_test.go
@@ -7,13 +7,13 @@ import (
 	"errors"
 	"time"
 
-	"github.com/juju/cmd/cmdtesting"
 	"github.com/juju/terms-client/api/wireformat"
 	jujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/macaroon-bakery.v1/httpbakery"
 
+	"github.com/juju/juju/cmd/cmdtesting"
 	"github.com/juju/juju/cmd/juju/romulus/listagreements"
 	coretesting "github.com/juju/juju/testing"
 )

--- a/cmd/juju/romulus/listbudgets/list-budgets_test.go
+++ b/cmd/juju/romulus/listbudgets/list-budgets_test.go
@@ -4,13 +4,13 @@
 package listbudgets_test
 
 import (
-	"github.com/juju/cmd/cmdtesting"
 	"github.com/juju/errors"
 	"github.com/juju/romulus/wireformat/budget"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/cmd/cmdtesting"
 	"github.com/juju/juju/cmd/juju/romulus/listbudgets"
 	coretesting "github.com/juju/juju/testing"
 )

--- a/cmd/juju/romulus/listplans/list_plans_test.go
+++ b/cmd/juju/romulus/listplans/list_plans_test.go
@@ -6,7 +6,6 @@ package listplans_test
 import (
 	"time"
 
-	"github.com/juju/cmd/cmdtesting"
 	api "github.com/juju/romulus/api/plan"
 	wireformat "github.com/juju/romulus/wireformat/plan"
 	"github.com/juju/testing"
@@ -14,6 +13,7 @@ import (
 	gc "gopkg.in/check.v1"
 	"gopkg.in/macaroon-bakery.v1/httpbakery"
 
+	"github.com/juju/juju/cmd/cmdtesting"
 	"github.com/juju/juju/cmd/juju/romulus/listplans"
 	coretesting "github.com/juju/juju/testing"
 )

--- a/cmd/juju/romulus/setbudget/setbudget_test.go
+++ b/cmd/juju/romulus/setbudget/setbudget_test.go
@@ -4,12 +4,12 @@
 package setbudget_test
 
 import (
-	"github.com/juju/cmd/cmdtesting"
 	"github.com/juju/errors"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/cmd/cmdtesting"
 	"github.com/juju/juju/cmd/juju/romulus/setbudget"
 	coretesting "github.com/juju/juju/testing"
 )

--- a/cmd/juju/romulus/setplan/set_plan_test.go
+++ b/cmd/juju/romulus/setplan/set_plan_test.go
@@ -9,7 +9,6 @@ import (
 	"net/url"
 	stdtesting "testing"
 
-	"github.com/juju/cmd/cmdtesting"
 	"github.com/juju/errors"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
@@ -19,6 +18,7 @@ import (
 	"gopkg.in/macaroon-bakery.v1/bakery/checkers"
 	"gopkg.in/macaroon.v1"
 
+	"github.com/juju/juju/cmd/cmdtesting"
 	"github.com/juju/juju/cmd/juju/romulus/setplan"
 	jjjtesting "github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/state"

--- a/cmd/juju/romulus/showbudget/show_budget_test.go
+++ b/cmd/juju/romulus/showbudget/show_budget_test.go
@@ -4,7 +4,6 @@
 package showbudget_test
 
 import (
-	"github.com/juju/cmd/cmdtesting"
 	"github.com/juju/errors"
 	"github.com/juju/romulus/wireformat/budget"
 	"github.com/juju/testing"
@@ -13,6 +12,7 @@ import (
 	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/cmd/cmdtesting"
 	"github.com/juju/juju/cmd/juju/romulus/showbudget"
 	coretesting "github.com/juju/juju/testing"
 )

--- a/cmd/juju/romulus/sla/sla_test.go
+++ b/cmd/juju/romulus/sla/sla_test.go
@@ -7,7 +7,6 @@ import (
 	stdtesting "testing"
 
 	"github.com/juju/cmd"
-	"github.com/juju/cmd/cmdtesting"
 	"github.com/juju/errors"
 	slawire "github.com/juju/romulus/wireformat/sla"
 	"github.com/juju/testing"
@@ -21,6 +20,7 @@ import (
 	"gopkg.in/macaroon.v1"
 
 	"github.com/juju/juju/api"
+	"github.com/juju/juju/cmd/cmdtesting"
 	"github.com/juju/juju/cmd/juju/romulus/sla"
 )
 

--- a/cmd/juju/setmeterstatus/setmeterstatus_test.go
+++ b/cmd/juju/setmeterstatus/setmeterstatus_test.go
@@ -10,6 +10,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/cmd/cmdtesting"
 	"github.com/juju/juju/cmd/juju/setmeterstatus"
 	"github.com/juju/juju/cmd/modelcmd"
 	jujutesting "github.com/juju/juju/juju/testing"
@@ -45,7 +46,7 @@ func (s *SetMeterStatusSuite) TestUnit(c *gc.C) {
 	s.PatchValue(setmeterstatus.NewClient, func(_ modelcmd.ModelCommandBase) (setmeterstatus.SetMeterStatusClient, error) {
 		return &client, nil
 	})
-	_, err := coretesting.RunCommand(c, setmeterstatus.New(), "metered/0", "RED")
+	_, err := cmdtesting.RunCommand(c, setmeterstatus.New(), "metered/0", "RED")
 	c.Assert(err, jc.ErrorIsNil)
 	client.CheckCall(c, 0, "SetMeterStatus", "unit-metered-0", "RED", "")
 }
@@ -55,7 +56,7 @@ func (s *SetMeterStatusSuite) TestService(c *gc.C) {
 	s.PatchValue(setmeterstatus.NewClient, func(_ modelcmd.ModelCommandBase) (setmeterstatus.SetMeterStatusClient, error) {
 		return &client, nil
 	})
-	_, err := coretesting.RunCommand(c, setmeterstatus.New(), "metered", "RED")
+	_, err := cmdtesting.RunCommand(c, setmeterstatus.New(), "metered", "RED")
 	c.Assert(err, jc.ErrorIsNil)
 	client.CheckCall(c, 0, "SetMeterStatus", "application-metered", "RED", "")
 }
@@ -65,7 +66,7 @@ func (s *SetMeterStatusSuite) TestNotValidServiceOrUnit(c *gc.C) {
 	s.PatchValue(setmeterstatus.NewClient, func(_ modelcmd.ModelCommandBase) (setmeterstatus.SetMeterStatusClient, error) {
 		return &client, nil
 	})
-	_, err := coretesting.RunCommand(c, setmeterstatus.New(), "!!!!!!", "RED")
+	_, err := cmdtesting.RunCommand(c, setmeterstatus.New(), "!!!!!!", "RED")
 	c.Assert(err, gc.ErrorMatches, `"!!!!!!" is not a valid unit or application`)
 }
 
@@ -76,7 +77,7 @@ type DebugMetricsCommandSuite struct {
 var _ = gc.Suite(&DebugMetricsCommandSuite{})
 
 func (s *DebugMetricsCommandSuite) TestDebugNoArgs(c *gc.C) {
-	_, err := coretesting.RunCommand(c, setmeterstatus.New())
+	_, err := cmdtesting.RunCommand(c, setmeterstatus.New())
 	c.Assert(err, gc.ErrorMatches, `you need to specify an entity \(application or unit\) and a status`)
 }
 
@@ -84,7 +85,7 @@ func (s *DebugMetricsCommandSuite) TestUnits(c *gc.C) {
 	charm := s.Factory.MakeCharm(c, &factory.CharmParams{Name: "mysql", URL: "local:quantal/mysql-1"})
 	service := s.Factory.MakeApplication(c, &factory.ApplicationParams{Charm: charm})
 	unit := s.Factory.MakeUnit(c, &factory.UnitParams{Application: service, SetCharmURL: true})
-	_, err := coretesting.RunCommand(c, setmeterstatus.New(), unit.Name(), "RED", "--info", "foobar")
+	_, err := cmdtesting.RunCommand(c, setmeterstatus.New(), unit.Name(), "RED", "--info", "foobar")
 	c.Assert(err, jc.ErrorIsNil)
 	status, err := unit.GetMeterStatus()
 	c.Assert(err, jc.ErrorIsNil)
@@ -99,7 +100,7 @@ func (s *DebugMetricsCommandSuite) TestService(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	unit1, err := service.AddUnit()
 	c.Assert(err, jc.ErrorIsNil)
-	_, err = coretesting.RunCommand(c, setmeterstatus.New(), "mysql", "RED", "--info", "foobar")
+	_, err = cmdtesting.RunCommand(c, setmeterstatus.New(), "mysql", "RED", "--info", "foobar")
 	c.Assert(err, jc.ErrorIsNil)
 	status, err := unit0.GetMeterStatus()
 	c.Assert(err, jc.ErrorIsNil)

--- a/cmd/juju/space/list_test.go
+++ b/cmd/juju/space/list_test.go
@@ -14,8 +14,8 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/cmd/cmdtesting"
 	"github.com/juju/juju/cmd/juju/space"
-	coretesting "github.com/juju/juju/testing"
 )
 
 type ListSuite struct {
@@ -75,7 +75,7 @@ func (s *ListSuite) TestInit(c *gc.C) {
 		// since we're not running the command no need to use
 		// modelcmd.Wrap().
 		wrappedCommand, command := space.NewListCommandForTest(s.api)
-		err := coretesting.InitCommand(wrappedCommand, test.args)
+		err := cmdtesting.InitCommand(wrappedCommand, test.args)
 		if test.expectErr != "" {
 			c.Check(err, gc.ErrorMatches, test.expectErr)
 		} else {

--- a/cmd/juju/space/package_test.go
+++ b/cmd/juju/space/package_test.go
@@ -14,6 +14,7 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/cmd/cmdtesting"
 	"github.com/juju/juju/cmd/juju/space"
 	"github.com/juju/juju/feature"
 	coretesting "github.com/juju/juju/testing"
@@ -74,9 +75,9 @@ func (s *BaseSpaceSuite) RunCommand(c *gc.C, args ...string) (string, string, er
 	if s.command == nil {
 		panic("subcommand is nil")
 	}
-	ctx, err := coretesting.RunCommand(c, s.command, args...)
+	ctx, err := cmdtesting.RunCommand(c, s.command, args...)
 	if ctx != nil {
-		return coretesting.Stdout(ctx), coretesting.Stderr(ctx), err
+		return cmdtesting.Stdout(ctx), cmdtesting.Stderr(ctx), err
 	}
 	return "", "", err
 }

--- a/cmd/juju/space/remove_test.go
+++ b/cmd/juju/space/remove_test.go
@@ -8,9 +8,9 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/cmd/cmdtesting"
 	"github.com/juju/juju/cmd/juju/space"
 	"github.com/juju/juju/feature"
-	coretesting "github.com/juju/juju/testing"
 )
 
 type RemoveSuite struct {
@@ -54,7 +54,7 @@ func (s *RemoveSuite) TestInit(c *gc.C) {
 		// since we're not running the command no need to use
 		// modelcmd.Wrap().
 		wrappedCommand, command := space.NewRemoveCommandForTest(s.api)
-		err := coretesting.InitCommand(wrappedCommand, test.args)
+		err := cmdtesting.InitCommand(wrappedCommand, test.args)
 		if test.expectErr != "" {
 			prefixedErr := "invalid arguments specified: " + test.expectErr
 			c.Check(err, gc.ErrorMatches, prefixedErr)

--- a/cmd/juju/space/rename_test.go
+++ b/cmd/juju/space/rename_test.go
@@ -8,9 +8,9 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/cmd/cmdtesting"
 	"github.com/juju/juju/cmd/juju/space"
 	"github.com/juju/juju/feature"
-	coretesting "github.com/juju/juju/testing"
 )
 
 type RenameSuite struct {
@@ -79,7 +79,7 @@ func (s *RenameSuite) TestInit(c *gc.C) {
 		// since we're not running the command no need to use
 		// modelcmd.Wrap().
 		wrappedCommand, command := space.NewRenameCommandForTest(s.api) // surely can use s.command??
-		err := coretesting.InitCommand(wrappedCommand, test.args)
+		err := cmdtesting.InitCommand(wrappedCommand, test.args)
 		if test.expectErr != "" {
 			prefixedErr := "invalid arguments specified: " + test.expectErr
 			c.Check(err, gc.ErrorMatches, prefixedErr)

--- a/cmd/juju/status/status_test.go
+++ b/cmd/juju/status/status_test.go
@@ -23,6 +23,7 @@ import (
 	goyaml "gopkg.in/yaml.v2"
 
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/cmd/cmdtesting"
 	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/constraints"
 	"github.com/juju/juju/core/migration"
@@ -47,7 +48,7 @@ var (
 )
 
 func runStatus(c *gc.C, args ...string) (code int, stdout, stderr []byte) {
-	ctx := coretesting.Context(c)
+	ctx := cmdtesting.Context(c)
 	code = cmd.Main(NewStatusCommand(), ctx, args)
 	stdout = ctx.Stdout.(*bytes.Buffer).Bytes()
 	stderr = ctx.Stderr.(*bytes.Buffer).Bytes()
@@ -4605,7 +4606,7 @@ func (s *StatusSuite) TestSummaryStatusWithUnresolvableDns(c *gc.C) {
 
 func initStatusCommand(args ...string) (*statusCommand, error) {
 	com := &statusCommand{}
-	return com, coretesting.InitCommand(modelcmd.Wrap(com), args)
+	return com, cmdtesting.InitCommand(modelcmd.Wrap(com), args)
 }
 
 var statusInitTests = []struct {

--- a/cmd/juju/storage/add_test.go
+++ b/cmd/juju/storage/add_test.go
@@ -14,9 +14,9 @@ import (
 
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/cmd/cmdtesting"
 	"github.com/juju/juju/cmd/juju/storage"
 	_ "github.com/juju/juju/provider/dummy"
-	"github.com/juju/juju/testing"
 )
 
 type addSuite struct {
@@ -233,7 +233,7 @@ func (s *addSuite) TestUnauthorizedMentionsJujuGrant(c *gc.C) {
 	}
 
 	ctx, _ := s.runAdd(c, s.args...)
-	errString := strings.Replace(testing.Stderr(ctx), "\n", " ", -1)
+	errString := strings.Replace(cmdtesting.Stderr(ctx), "\n", " ", -1)
 	c.Assert(errString, gc.Matches, `.*juju grant.*`)
 }
 
@@ -251,15 +251,15 @@ func (s *addSuite) assertAddErrorOutput(c *gc.C, expected string, expectedOut, e
 }
 
 func (s *addSuite) assertExpectedOutput(c *gc.C, context *cmd.Context, expectedOut, expectedErr string) {
-	obtainedErr := testing.Stderr(context)
+	obtainedErr := cmdtesting.Stderr(context)
 	c.Assert(obtainedErr, gc.Equals, expectedErr)
 
-	obtainedValid := testing.Stdout(context)
+	obtainedValid := cmdtesting.Stdout(context)
 	c.Assert(obtainedValid, gc.Equals, expectedOut)
 }
 
 func (s *addSuite) runAdd(c *gc.C, args ...string) (*cmd.Context, error) {
-	return testing.RunCommand(c, storage.NewAddCommandForTest(s.mockAPI, s.store), args...)
+	return cmdtesting.RunCommand(c, storage.NewAddCommandForTest(s.mockAPI, s.store), args...)
 }
 
 func visibleErrorMessage(errMsg string) string {

--- a/cmd/juju/storage/attach_test.go
+++ b/cmd/juju/storage/attach_test.go
@@ -10,8 +10,8 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/cmd/cmdtesting"
 	"github.com/juju/juju/cmd/juju/storage"
-	coretesting "github.com/juju/juju/testing"
 )
 
 type AttachStorageSuite struct {
@@ -26,11 +26,11 @@ func (s *AttachStorageSuite) TestAttach(c *gc.C) {
 		{},
 	}}
 	cmd := storage.NewAttachStorageCommand(fake.new)
-	ctx, err := coretesting.RunCommand(c, cmd, "foo/0", "bar/1", "baz/2")
+	ctx, err := cmdtesting.RunCommand(c, cmd, "foo/0", "bar/1", "baz/2")
 	c.Assert(err, jc.ErrorIsNil)
 	fake.CheckCallNames(c, "NewEntityAttacherCloser", "Attach", "Close")
 	fake.CheckCall(c, 1, "Attach", "foo/0", []string{"bar/1", "baz/2"})
-	c.Assert(coretesting.Stderr(ctx), gc.Equals, `
+	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, `
 attaching bar/1 to foo/0
 attaching baz/2 to foo/0
 `[1:])
@@ -42,8 +42,8 @@ func (s *AttachStorageSuite) TestAttachError(c *gc.C) {
 		{Error: &params.Error{Message: "bar"}},
 	}}
 	attachCmd := storage.NewAttachStorageCommand(fake.new)
-	ctx, err := coretesting.RunCommand(c, attachCmd, "baz/0", "qux/1", "quux/2")
-	stderr := coretesting.Stderr(ctx)
+	ctx, err := cmdtesting.RunCommand(c, attachCmd, "baz/0", "qux/1", "quux/2")
+	stderr := cmdtesting.Stderr(ctx)
 	c.Assert(stderr, gc.Equals, `failed to attach qux/1 to baz/0: foo
 failed to attach quux/2 to baz/0: bar
 `)
@@ -54,9 +54,9 @@ func (s *AttachStorageSuite) TestAttachUnauthorizedError(c *gc.C) {
 	var fake fakeEntityAttacher
 	fake.SetErrors(nil, &params.Error{Code: params.CodeUnauthorized, Message: "nope"})
 	cmd := storage.NewAttachStorageCommand(fake.new)
-	ctx, err := coretesting.RunCommand(c, cmd, "foo/0", "bar/1")
+	ctx, err := cmdtesting.RunCommand(c, cmd, "foo/0", "bar/1")
 	c.Assert(err, gc.ErrorMatches, "nope")
-	c.Assert(coretesting.Stderr(ctx), gc.Equals, `
+	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, `
 You do not have permission to attach storage.
 You may ask an administrator to grant you access with "juju grant".
 
@@ -70,7 +70,7 @@ func (s *AttachStorageSuite) TestAttachInitErrors(c *gc.C) {
 
 func (s *AttachStorageSuite) testAttachInitError(c *gc.C, args []string, expect string) {
 	cmd := storage.NewAttachStorageCommand(nil)
-	_, err := coretesting.RunCommand(c, cmd, args...)
+	_, err := cmdtesting.RunCommand(c, cmd, args...)
 	c.Assert(err, gc.ErrorMatches, expect)
 }
 

--- a/cmd/juju/storage/detach_test.go
+++ b/cmd/juju/storage/detach_test.go
@@ -10,8 +10,8 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/cmd/cmdtesting"
 	"github.com/juju/juju/cmd/juju/storage"
-	coretesting "github.com/juju/juju/testing"
 )
 
 type DetachStorageSuite struct {
@@ -26,11 +26,11 @@ func (s *DetachStorageSuite) TestDetach(c *gc.C) {
 		{},
 	}}
 	cmd := storage.NewDetachStorageCommand(fake.new)
-	ctx, err := coretesting.RunCommand(c, cmd, "foo/0", "bar/1")
+	ctx, err := cmdtesting.RunCommand(c, cmd, "foo/0", "bar/1")
 	c.Assert(err, jc.ErrorIsNil)
 	fake.CheckCallNames(c, "NewEntityDetacherCloser", "Detach", "Close")
 	fake.CheckCall(c, 1, "Detach", []string{"foo/0", "bar/1"})
-	c.Assert(coretesting.Stderr(ctx), gc.Equals, `
+	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, `
 detaching foo/0
 detaching bar/1
 `[1:])
@@ -42,8 +42,8 @@ func (s *DetachStorageSuite) TestDetachError(c *gc.C) {
 		{Error: &params.Error{Message: "bar"}},
 	}}
 	detachCmd := storage.NewDetachStorageCommand(fake.new)
-	ctx, err := coretesting.RunCommand(c, detachCmd, "baz/0", "qux/1")
-	stderr := coretesting.Stderr(ctx)
+	ctx, err := cmdtesting.RunCommand(c, detachCmd, "baz/0", "qux/1")
+	stderr := cmdtesting.Stderr(ctx)
 	c.Assert(stderr, gc.Equals, `failed to detach baz/0: foo
 failed to detach qux/1: bar
 `)
@@ -54,9 +54,9 @@ func (s *DetachStorageSuite) TestDetachUnauthorizedError(c *gc.C) {
 	var fake fakeEntityDetacher
 	fake.SetErrors(nil, &params.Error{Code: params.CodeUnauthorized, Message: "nope"})
 	cmd := storage.NewDetachStorageCommand(fake.new)
-	ctx, err := coretesting.RunCommand(c, cmd, "foo/0")
+	ctx, err := cmdtesting.RunCommand(c, cmd, "foo/0")
 	c.Assert(err, gc.ErrorMatches, "nope")
-	c.Assert(coretesting.Stderr(ctx), gc.Equals, `
+	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, `
 You do not have permission to detach storage.
 You may ask an administrator to grant you access with "juju grant".
 
@@ -69,7 +69,7 @@ func (s *DetachStorageSuite) TestDetachInitErrors(c *gc.C) {
 
 func (s *DetachStorageSuite) testDetachInitError(c *gc.C, args []string, expect string) {
 	cmd := storage.NewDetachStorageCommand(nil)
-	_, err := coretesting.RunCommand(c, cmd, args...)
+	_, err := cmdtesting.RunCommand(c, cmd, args...)
 	c.Assert(err, gc.ErrorMatches, expect)
 }
 

--- a/cmd/juju/storage/filesystemlist_test.go
+++ b/cmd/juju/storage/filesystemlist_test.go
@@ -13,9 +13,9 @@ import (
 	goyaml "gopkg.in/yaml.v2"
 
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/cmd/cmdtesting"
 	"github.com/juju/juju/cmd/juju/storage"
 	"github.com/juju/juju/status"
-	"github.com/juju/juju/testing"
 )
 
 func (s *ListSuite) TestFilesystemListEmpty(c *gc.C) {
@@ -123,13 +123,13 @@ func (s *ListSuite) assertUnmarshalledOutput(c *gc.C, unmarshal unmarshaller, ex
 	var result struct {
 		Filesystems map[string]storage.FilesystemInfo
 	}
-	err = unmarshal([]byte(testing.Stdout(context)), &result)
+	err = unmarshal([]byte(cmdtesting.Stdout(context)), &result)
 	c.Assert(err, jc.ErrorIsNil)
 
 	expected := s.expect(c, nil)
 	c.Assert(result.Filesystems, jc.DeepEquals, expected)
 
-	obtainedErr := testing.Stderr(context)
+	obtainedErr := cmdtesting.Stderr(context)
 	c.Assert(obtainedErr, gc.Equals, expectedErr)
 }
 
@@ -157,15 +157,15 @@ func (s *ListSuite) assertValidFilesystemList(c *gc.C, args []string, expectedOu
 }
 
 func (s *ListSuite) runFilesystemList(c *gc.C, args ...string) (*cmd.Context, error) {
-	return testing.RunCommand(c,
+	return cmdtesting.RunCommand(c,
 		storage.NewListCommandForTest(s.mockAPI, s.store), append(args, "--filesystem")...)
 }
 
 func (s *ListSuite) assertUserFacingOutput(c *gc.C, context *cmd.Context, expectedOut, expectedErr string) {
-	obtainedOut := testing.Stdout(context)
+	obtainedOut := cmdtesting.Stdout(context)
 	c.Assert(obtainedOut, gc.Equals, expectedOut)
 
-	obtainedErr := testing.Stderr(context)
+	obtainedErr := cmdtesting.Stderr(context)
 	c.Assert(obtainedErr, gc.Equals, expectedErr)
 }
 

--- a/cmd/juju/storage/list_test.go
+++ b/cmd/juju/storage/list_test.go
@@ -11,10 +11,10 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/cmd/cmdtesting"
 	"github.com/juju/juju/cmd/juju/storage"
 	_ "github.com/juju/juju/provider/dummy"
 	"github.com/juju/juju/status"
-	"github.com/juju/juju/testing"
 )
 
 type ListSuite struct {
@@ -31,7 +31,7 @@ func (s *ListSuite) SetUpTest(c *gc.C) {
 }
 
 func (s *ListSuite) runList(c *gc.C, args []string) (*cmd.Context, error) {
-	return testing.RunCommand(c, storage.NewListCommandForTest(s.mockAPI, s.store), args...)
+	return cmdtesting.RunCommand(c, storage.NewListCommandForTest(s.mockAPI, s.store), args...)
 }
 
 func (s *ListSuite) TestList(c *gc.C) {
@@ -280,9 +280,9 @@ func (s *ListSuite) TestListError(c *gc.C) {
 	s.mockAPI.listErrors = true
 	context, err := s.runList(c, nil)
 	c.Assert(err, gc.ErrorMatches, "list fails")
-	stderr := testing.Stderr(context)
+	stderr := cmdtesting.Stderr(context)
 	c.Assert(stderr, gc.Equals, "")
-	stdout := testing.Stdout(context)
+	stdout := cmdtesting.Stdout(context)
 	c.Assert(stdout, gc.Equals, "")
 }
 
@@ -290,10 +290,10 @@ func (s *ListSuite) assertValidList(c *gc.C, args []string, expectedValid string
 	context, err := s.runList(c, args)
 	c.Assert(err, jc.ErrorIsNil)
 
-	obtainedErr := testing.Stderr(context)
+	obtainedErr := cmdtesting.Stderr(context)
 	c.Assert(obtainedErr, gc.Equals, "")
 
-	obtainedValid := testing.Stdout(context)
+	obtainedValid := cmdtesting.Stdout(context)
 	c.Assert(obtainedValid, gc.Matches, expectedValid)
 }
 

--- a/cmd/juju/storage/poolcreate_test.go
+++ b/cmd/juju/storage/poolcreate_test.go
@@ -8,9 +8,9 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/cmd/cmdtesting"
 	"github.com/juju/juju/cmd/juju/storage"
 	_ "github.com/juju/juju/provider/dummy"
-	"github.com/juju/juju/testing"
 )
 
 type PoolCreateSuite struct {
@@ -27,7 +27,7 @@ func (s *PoolCreateSuite) SetUpTest(c *gc.C) {
 }
 
 func (s *PoolCreateSuite) runPoolCreate(c *gc.C, args []string) (*cmd.Context, error) {
-	return testing.RunCommand(c, storage.NewPoolCreateCommandForTest(s.mockAPI, s.store), args...)
+	return cmdtesting.RunCommand(c, storage.NewPoolCreateCommandForTest(s.mockAPI, s.store), args...)
 }
 
 func (s *PoolCreateSuite) TestPoolCreateOneArg(c *gc.C) {

--- a/cmd/juju/storage/poollist_test.go
+++ b/cmd/juju/storage/poollist_test.go
@@ -14,9 +14,9 @@ import (
 	goyaml "gopkg.in/yaml.v2"
 
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/cmd/cmdtesting"
 	"github.com/juju/juju/cmd/juju/storage"
 	_ "github.com/juju/juju/provider/dummy"
-	"github.com/juju/juju/testing"
 )
 
 type poolListSuite struct {
@@ -36,7 +36,7 @@ func (s *poolListSuite) SetUpTest(c *gc.C) {
 
 func (s *poolListSuite) runPoolList(c *gc.C, args []string) (*cmd.Context, error) {
 	args = append(args, []string{"-m", "admin"}...)
-	return testing.RunCommand(c, storage.NewPoolListCommandForTest(s.mockAPI, s.store), args...)
+	return cmdtesting.RunCommand(c, storage.NewPoolListCommandForTest(s.mockAPI, s.store), args...)
 }
 
 func (s *poolListSuite) TestPoolListEmpty(c *gc.C) {
@@ -164,7 +164,7 @@ func (s *poolListSuite) assertValidList(c *gc.C, args []string, expected string)
 	context, err := s.runPoolList(c, args)
 	c.Assert(err, jc.ErrorIsNil)
 
-	obtained := testing.Stdout(context)
+	obtained := cmdtesting.Stdout(context)
 	c.Assert(obtained, gc.Equals, expected)
 }
 

--- a/cmd/juju/storage/remove_test.go
+++ b/cmd/juju/storage/remove_test.go
@@ -10,8 +10,8 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/cmd/cmdtesting"
 	"github.com/juju/juju/cmd/juju/storage"
-	coretesting "github.com/juju/juju/testing"
 )
 
 type RemoveStorageSuite struct {
@@ -26,11 +26,11 @@ func (s *RemoveStorageSuite) TestRemoveStorage(c *gc.C) {
 		{},
 	}}
 	cmd := storage.NewRemoveStorageCommand(fake.new)
-	ctx, err := coretesting.RunCommand(c, cmd, "pgdata/0", "pgdata/1")
+	ctx, err := cmdtesting.RunCommand(c, cmd, "pgdata/0", "pgdata/1")
 	c.Assert(err, jc.ErrorIsNil)
 	fake.CheckCallNames(c, "NewEntityDestroyerCloser", "Destroy", "Close")
 	fake.CheckCall(c, 1, "Destroy", []string{"pgdata/0", "pgdata/1"})
-	c.Assert(coretesting.Stderr(ctx), gc.Equals, `
+	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, `
 removing pgdata/0
 removing pgdata/1
 `[1:])
@@ -42,8 +42,8 @@ func (s *RemoveStorageSuite) TestRemoveStorageError(c *gc.C) {
 		{Error: &params.Error{Message: "bar"}},
 	}}
 	removeCmd := storage.NewRemoveStorageCommand(fake.new)
-	ctx, err := coretesting.RunCommand(c, removeCmd, "pgdata/0", "pgdata/1")
-	stderr := coretesting.Stderr(ctx)
+	ctx, err := cmdtesting.RunCommand(c, removeCmd, "pgdata/0", "pgdata/1")
+	stderr := cmdtesting.Stderr(ctx)
 	c.Assert(stderr, gc.Equals, `failed to remove pgdata/0: foo
 failed to remove pgdata/1: bar
 `)
@@ -54,9 +54,9 @@ func (s *RemoveStorageSuite) TestRemoveStorageUnauthorizedError(c *gc.C) {
 	var fake fakeEntityDestroyer
 	fake.SetErrors(nil, &params.Error{Code: params.CodeUnauthorized, Message: "nope"})
 	cmd := storage.NewRemoveStorageCommand(fake.new)
-	ctx, err := coretesting.RunCommand(c, cmd, "pgdata/0")
+	ctx, err := cmdtesting.RunCommand(c, cmd, "pgdata/0")
 	c.Assert(err, gc.ErrorMatches, "nope")
-	c.Assert(coretesting.Stderr(ctx), gc.Equals, `
+	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, `
 You do not have permission to remove storage.
 You may ask an administrator to grant you access with "juju grant".
 
@@ -70,7 +70,7 @@ func (s *RemoveStorageSuite) TestRemoveStorageInitErrors(c *gc.C) {
 func (s *RemoveStorageSuite) testRemoveStorageInitError(c *gc.C, args []string, expect string) {
 	var fake fakeEntityDestroyer
 	cmd := storage.NewRemoveStorageCommand(fake.new)
-	_, err := coretesting.RunCommand(c, cmd, args...)
+	_, err := cmdtesting.RunCommand(c, cmd, args...)
 	c.Assert(err, gc.ErrorMatches, expect)
 }
 

--- a/cmd/juju/storage/show_test.go
+++ b/cmd/juju/storage/show_test.go
@@ -13,9 +13,9 @@ import (
 	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/cmd/cmdtesting"
 	"github.com/juju/juju/cmd/juju/storage"
 	_ "github.com/juju/juju/provider/dummy"
-	"github.com/juju/juju/testing"
 )
 
 // epoch is the time we use for "since" in statuses. The time
@@ -38,7 +38,7 @@ func (s *ShowSuite) SetUpTest(c *gc.C) {
 }
 
 func (s *ShowSuite) runShow(c *gc.C, args []string) (*cmd.Context, error) {
-	return testing.RunCommand(c, storage.NewShowCommandForTest(s.mockAPI, s.store), args...)
+	return cmdtesting.RunCommand(c, storage.NewShowCommandForTest(s.mockAPI, s.store), args...)
 }
 
 func (s *ShowSuite) TestShowNoMatch(c *gc.C) {
@@ -126,7 +126,7 @@ func (s *ShowSuite) assertValidShow(c *gc.C, args []string, expected string) {
 	context, err := s.runShow(c, args)
 	c.Assert(err, jc.ErrorIsNil)
 
-	obtained := testing.Stdout(context)
+	obtained := cmdtesting.Stdout(context)
 	c.Assert(obtained, gc.Matches, expected)
 }
 

--- a/cmd/juju/storage/volumelist_test.go
+++ b/cmd/juju/storage/volumelist_test.go
@@ -14,9 +14,9 @@ import (
 	goyaml "gopkg.in/yaml.v2"
 
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/cmd/cmdtesting"
 	"github.com/juju/juju/cmd/juju/storage"
 	"github.com/juju/juju/status"
-	"github.com/juju/juju/testing"
 )
 
 func (s *ListSuite) TestVolumeListEmpty(c *gc.C) {
@@ -125,13 +125,13 @@ func (s *ListSuite) assertUnmarshalledVolumeOutput(c *gc.C, unmarshal unmarshall
 	var result struct {
 		Volumes map[string]storage.VolumeInfo
 	}
-	err = unmarshal([]byte(testing.Stdout(context)), &result)
+	err = unmarshal([]byte(cmdtesting.Stdout(context)), &result)
 	c.Assert(err, jc.ErrorIsNil)
 
 	expected := s.expectVolume(c, nil)
 	c.Assert(result.Volumes, jc.DeepEquals, expected)
 
-	obtainedErr := testing.Stderr(context)
+	obtainedErr := cmdtesting.Stderr(context)
 	c.Assert(obtainedErr, gc.Equals, expectedErr)
 }
 
@@ -159,15 +159,15 @@ func (s *ListSuite) assertValidVolumeList(c *gc.C, args []string, expectedOut st
 }
 
 func (s *ListSuite) runVolumeList(c *gc.C, args ...string) (*cmd.Context, error) {
-	return testing.RunCommand(c,
+	return cmdtesting.RunCommand(c,
 		storage.NewListCommandForTest(s.mockAPI, s.store), append(args, "--volume")...)
 }
 
 func (s *ListSuite) assertUserFacingVolumeOutput(c *gc.C, context *cmd.Context, expectedOut, expectedErr string) {
-	obtainedOut := testing.Stdout(context)
+	obtainedOut := cmdtesting.Stdout(context)
 	c.Assert(obtainedOut, gc.Equals, expectedOut)
 
-	obtainedErr := testing.Stderr(context)
+	obtainedErr := cmdtesting.Stderr(context)
 	c.Assert(obtainedErr, gc.Equals, expectedErr)
 }
 

--- a/cmd/juju/subnet/add_test.go
+++ b/cmd/juju/subnet/add_test.go
@@ -13,9 +13,9 @@ import (
 	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/cmd/cmdtesting"
 	"github.com/juju/juju/cmd/juju/subnet"
 	"github.com/juju/juju/network"
-	coretesting "github.com/juju/juju/testing"
 )
 
 type AddSuite struct {
@@ -96,7 +96,7 @@ func (s *AddSuite) TestInit(c *gc.C) {
 		// since we're not running the command no need to use
 		// modelcmd.Wrap().
 		wrappedCommand, command := subnet.NewAddCommandForTest(s.api)
-		err := coretesting.InitCommand(wrappedCommand, test.args)
+		err := cmdtesting.InitCommand(wrappedCommand, test.args)
 		if test.expectErr != "" {
 			prefixedErr := "invalid arguments specified: " + test.expectErr
 			c.Check(err, gc.ErrorMatches, prefixedErr)

--- a/cmd/juju/subnet/create_test.go
+++ b/cmd/juju/subnet/create_test.go
@@ -9,9 +9,9 @@ import (
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/names.v2"
 
+	"github.com/juju/juju/cmd/cmdtesting"
 	"github.com/juju/juju/cmd/juju/subnet"
 	"github.com/juju/juju/feature"
-	coretesting "github.com/juju/juju/testing"
 )
 
 type CreateSuite struct {
@@ -126,7 +126,7 @@ func (s *CreateSuite) TestInit(c *gc.C) {
 		// since we're not running the command no need to use
 		// modelcmd.Wrap().
 		wrappedCommand, command := subnet.NewCreateCommandForTest(s.api)
-		err := coretesting.InitCommand(wrappedCommand, test.args)
+		err := cmdtesting.InitCommand(wrappedCommand, test.args)
 		if test.expectErr != "" {
 			c.Check(err, gc.ErrorMatches, test.expectErr)
 		} else {

--- a/cmd/juju/subnet/list_test.go
+++ b/cmd/juju/subnet/list_test.go
@@ -13,8 +13,8 @@ import (
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/names.v2"
 
+	"github.com/juju/juju/cmd/cmdtesting"
 	"github.com/juju/juju/cmd/juju/subnet"
-	coretesting "github.com/juju/juju/testing"
 )
 
 type ListSuite struct {
@@ -87,7 +87,7 @@ func (s *ListSuite) TestInit(c *gc.C) {
 		// since we're not running the command no need to use
 		// modelcmd.Wrap().
 		wrappedCommand, command := subnet.NewListCommandForTest(s.api)
-		err := coretesting.InitCommand(wrappedCommand, test.args)
+		err := cmdtesting.InitCommand(wrappedCommand, test.args)
 		if test.expectErr != "" {
 			c.Check(err, gc.ErrorMatches, test.expectErr)
 		} else {

--- a/cmd/juju/subnet/package_test.go
+++ b/cmd/juju/subnet/package_test.go
@@ -14,6 +14,7 @@ import (
 	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/cmd/cmdtesting"
 	"github.com/juju/juju/cmd/juju/subnet"
 	"github.com/juju/juju/feature"
 	"github.com/juju/juju/network"
@@ -70,9 +71,9 @@ func (s *BaseSubnetSuite) RunCommand(c *gc.C, args ...string) (string, string, e
 	if s.command == nil {
 		panic("command is nil")
 	}
-	ctx, err := coretesting.RunCommand(c, s.command, args...)
+	ctx, err := cmdtesting.RunCommand(c, s.command, args...)
 	if ctx != nil {
-		return coretesting.Stdout(ctx), coretesting.Stderr(ctx), err
+		return cmdtesting.Stdout(ctx), cmdtesting.Stderr(ctx), err
 	}
 	return "", "", err
 }

--- a/cmd/juju/subnet/remove_test.go
+++ b/cmd/juju/subnet/remove_test.go
@@ -9,9 +9,9 @@ import (
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/names.v2"
 
+	"github.com/juju/juju/cmd/cmdtesting"
 	"github.com/juju/juju/cmd/juju/subnet"
 	"github.com/juju/juju/feature"
-	coretesting "github.com/juju/juju/testing"
 )
 
 type RemoveSuite struct {
@@ -55,7 +55,7 @@ func (s *RemoveSuite) TestInit(c *gc.C) {
 		// since we're not running the command no need to use
 		// modelcmd.Wrap().
 		wrappedCommand, command := subnet.NewRemoveCommandForTest(s.api)
-		err := coretesting.InitCommand(wrappedCommand, test.args)
+		err := cmdtesting.InitCommand(wrappedCommand, test.args)
 		if test.expectErr != "" {
 			c.Check(err, gc.ErrorMatches, test.expectErr)
 		} else {

--- a/cmd/juju/user/add_test.go
+++ b/cmd/juju/user/add_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/juju/juju/api/base"
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/cmd/cmdtesting"
 	"github.com/juju/juju/cmd/juju/user"
 	"github.com/juju/juju/testing"
 )
@@ -36,7 +37,7 @@ func (s *UserAddCommandSuite) SetUpTest(c *gc.C) {
 
 func (s *UserAddCommandSuite) run(c *gc.C, args ...string) (*cmd.Context, error) {
 	addCommand, _ := user.NewAddCommandForTest(s.mockAPI, s.store, &mockModelAPI{})
-	return testing.RunCommand(c, addCommand, args...)
+	return cmdtesting.RunCommand(c, addCommand, args...)
 }
 
 func (s *UserAddCommandSuite) TestInit(c *gc.C) {
@@ -69,7 +70,7 @@ func (s *UserAddCommandSuite) TestInit(c *gc.C) {
 	}} {
 		c.Logf("test %d (%q)", i, test.args)
 		wrappedCommand, command := user.NewAddCommandForTest(s.mockAPI, s.store, &mockModelAPI{})
-		err := testing.InitCommand(wrappedCommand, test.args)
+		err := cmdtesting.InitCommand(wrappedCommand, test.args)
 		if test.errorString == "" {
 			c.Check(err, jc.ErrorIsNil)
 			c.Check(command.User, gc.Equals, test.user)
@@ -92,8 +93,8 @@ Please send this command to foobar:
 
 "foobar" has not been granted access to any models. You can use "juju grant" to grant access.
 `[1:]
-	c.Assert(testing.Stdout(context), gc.Equals, expected)
-	c.Assert(testing.Stderr(context), gc.Equals, "")
+	c.Assert(cmdtesting.Stdout(context), gc.Equals, expected)
+	c.Assert(cmdtesting.Stderr(context), gc.Equals, "")
 }
 
 func (s *UserAddCommandSuite) TestAddUserWithUsernameAndDisplayname(c *gc.C) {
@@ -108,8 +109,8 @@ Please send this command to foobar:
 
 "Foo Bar (foobar)" has not been granted access to any models. You can use "juju grant" to grant access.
 `[1:]
-	c.Assert(testing.Stdout(context), gc.Equals, expected)
-	c.Assert(testing.Stderr(context), gc.Equals, "")
+	c.Assert(cmdtesting.Stdout(context), gc.Equals, expected)
+	c.Assert(cmdtesting.Stderr(context), gc.Equals, "")
 }
 
 func (s *UserAddCommandSuite) TestUserRegistrationString(c *gc.C) {
@@ -118,7 +119,7 @@ func (s *UserAddCommandSuite) TestUserRegistrationString(c *gc.C) {
 		s.mockAPI.secretKey = []byte(strings.Repeat("X", 32+i))
 		context, err := s.run(c, "foobar", "Foo Bar")
 		c.Assert(err, jc.ErrorIsNil)
-		lines := strings.Split(testing.Stdout(context), "\n")
+		lines := strings.Split(cmdtesting.Stdout(context), "\n")
 		c.Assert(lines, gc.HasLen, 6)
 		c.Assert(lines[2], gc.Matches, `^\s+juju register [A-Za-z0-9]+$`)
 	}
@@ -153,7 +154,7 @@ func (s *UserAddCommandSuite) TestAddUserUnauthorizedMentionsJujuGrant(c *gc.C) 
 		Code:    params.CodeUnauthorized,
 	}
 	ctx, _ := s.run(c, "foobar")
-	errString := strings.Replace(testing.Stderr(ctx), "\n", " ", -1)
+	errString := strings.Replace(cmdtesting.Stderr(ctx), "\n", " ", -1)
 	c.Assert(errString, gc.Matches, `.*juju grant.*`)
 }
 

--- a/cmd/juju/user/change_password_test.go
+++ b/cmd/juju/user/change_password_test.go
@@ -13,10 +13,10 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/api"
+	"github.com/juju/juju/cmd/cmdtesting"
 	"github.com/juju/juju/cmd/juju/user"
 	"github.com/juju/juju/juju"
 	"github.com/juju/juju/jujuclient"
-	coretesting "github.com/juju/juju/testing"
 )
 
 type ChangePasswordCommandSuite struct {
@@ -42,9 +42,9 @@ func (s *ChangePasswordCommandSuite) run(c *gc.C, args ...string) (*cmd.Context,
 	changePasswordCommand, _ := user.NewChangePasswordCommandForTest(
 		newAPIConnection, s.mockAPI, s.store,
 	)
-	ctx := coretesting.Context(c)
+	ctx := cmdtesting.Context(c)
 	ctx.Stdin = strings.NewReader("sekrit\nsekrit\n")
-	err := coretesting.InitCommand(changePasswordCommand, args)
+	err := cmdtesting.InitCommand(changePasswordCommand, args)
 	if err != nil {
 		return ctx, nil, err
 	}
@@ -72,7 +72,7 @@ func (s *ChangePasswordCommandSuite) TestInit(c *gc.C) {
 	} {
 		c.Logf("test %d", i)
 		wrappedCommand, command := user.NewChangePasswordCommandForTest(nil, nil, s.store)
-		err := coretesting.InitCommand(wrappedCommand, test.args)
+		err := cmdtesting.InitCommand(wrappedCommand, test.args)
 		if test.errorString == "" {
 			c.Check(command.User, gc.Equals, test.user)
 		} else {
@@ -89,8 +89,8 @@ func (s *ChangePasswordCommandSuite) TestChangePassword(c *gc.C) {
 	context, args, err := s.run(c)
 	c.Assert(err, jc.ErrorIsNil)
 	s.assertAPICalls(c, "current-user", "sekrit")
-	c.Assert(coretesting.Stdout(context), gc.Equals, "")
-	c.Assert(coretesting.Stderr(context), gc.Equals, `
+	c.Assert(cmdtesting.Stdout(context), gc.Equals, "")
+	c.Assert(cmdtesting.Stderr(context), gc.Equals, `
 new password: 
 type new password again: 
 Your password has been updated.

--- a/cmd/juju/user/disenable_test.go
+++ b/cmd/juju/user/disenable_test.go
@@ -8,8 +8,8 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/cmd/cmdtesting"
 	"github.com/juju/juju/cmd/juju/user"
-	"github.com/juju/juju/testing"
 )
 
 type DisableUserSuite struct {
@@ -47,7 +47,7 @@ func (s *DisableUserSuite) testInit(c *gc.C, wrappedCommand cmd.Command, command
 		},
 	} {
 		c.Logf("test %d, args %v", i, test.args)
-		err := testing.InitCommand(wrappedCommand, test.args)
+		err := cmdtesting.InitCommand(wrappedCommand, test.args)
 		if test.errMatch == "" {
 			c.Assert(err, jc.ErrorIsNil)
 			c.Assert(command.User, gc.Equals, test.user)
@@ -67,7 +67,7 @@ func (s *DisableUserSuite) TestInit(c *gc.C) {
 func (s *DisableUserSuite) TestDisable(c *gc.C) {
 	username := "testing"
 	disableCommand, _ := user.NewDisableCommandForTest(s.mock, s.store)
-	_, err := testing.RunCommand(c, disableCommand, username)
+	_, err := cmdtesting.RunCommand(c, disableCommand, username)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(s.mock.disable, gc.Equals, username)
 }
@@ -75,7 +75,7 @@ func (s *DisableUserSuite) TestDisable(c *gc.C) {
 func (s *DisableUserSuite) TestEnable(c *gc.C) {
 	username := "testing"
 	enableCommand, _ := user.NewEnableCommandForTest(s.mock, s.store)
-	_, err := testing.RunCommand(c, enableCommand, username)
+	_, err := cmdtesting.RunCommand(c, enableCommand, username)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(s.mock.enable, gc.Equals, username)
 }

--- a/cmd/juju/user/info_test.go
+++ b/cmd/juju/user/info_test.go
@@ -14,8 +14,8 @@ import (
 	"github.com/juju/juju/api/usermanager"
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/cmd/cmdtesting"
 	"github.com/juju/juju/cmd/juju/user"
-	"github.com/juju/juju/testing"
 )
 
 var logger = loggo.GetLogger("juju.cmd.user.test")
@@ -69,9 +69,9 @@ func (*fakeUserInfoAPI) UserInfo(usernames []string, all usermanager.IncludeDisa
 }
 
 func (s *UserInfoCommandSuite) TestUserInfo(c *gc.C) {
-	context, err := testing.RunCommand(c, s.NewShowUserCommand())
+	context, err := cmdtesting.RunCommand(c, s.NewShowUserCommand())
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(testing.Stdout(context), gc.Equals, `user-name: current-user
+	c.Assert(cmdtesting.Stdout(context), gc.Equals, `user-name: current-user
 access: add-model
 date-created: 1981-02-27
 last-connection: 2014-01-01
@@ -79,9 +79,9 @@ last-connection: 2014-01-01
 }
 
 func (s *UserInfoCommandSuite) TestUserInfoExactTime(c *gc.C) {
-	context, err := testing.RunCommand(c, s.NewShowUserCommand(), "--exact-time")
+	context, err := cmdtesting.RunCommand(c, s.NewShowUserCommand(), "--exact-time")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(testing.Stdout(context), gc.Equals, `user-name: current-user
+	c.Assert(cmdtesting.Stdout(context), gc.Equals, `user-name: current-user
 access: add-model
 date-created: 1981-02-27 16:10:05 +0000 UTC
 last-connection: 2014-01-01 00:00:00 +0000 UTC
@@ -89,9 +89,9 @@ last-connection: 2014-01-01 00:00:00 +0000 UTC
 }
 
 func (s *UserInfoCommandSuite) TestUserInfoWithUsername(c *gc.C) {
-	context, err := testing.RunCommand(c, s.NewShowUserCommand(), "foobar")
+	context, err := cmdtesting.RunCommand(c, s.NewShowUserCommand(), "foobar")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(testing.Stdout(context), gc.Equals, `user-name: foobar
+	c.Assert(cmdtesting.Stdout(context), gc.Equals, `user-name: foobar
 display-name: Foo Bar
 access: login
 date-created: 1981-02-27
@@ -100,39 +100,39 @@ last-connection: 2014-01-01
 }
 
 func (s *UserInfoCommandSuite) TestUserInfoExternalUser(c *gc.C) {
-	context, err := testing.RunCommand(c, s.NewShowUserCommand(), "fred@external")
+	context, err := cmdtesting.RunCommand(c, s.NewShowUserCommand(), "fred@external")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(testing.Stdout(context), gc.Equals, `user-name: fred@external
+	c.Assert(cmdtesting.Stdout(context), gc.Equals, `user-name: fred@external
 display-name: Fred External
 access: add-model
 `)
 }
 
 func (s *UserInfoCommandSuite) TestUserInfoUserDoesNotExist(c *gc.C) {
-	_, err := testing.RunCommand(c, s.NewShowUserCommand(), "barfoo")
+	_, err := cmdtesting.RunCommand(c, s.NewShowUserCommand(), "barfoo")
 	c.Assert(err, gc.ErrorMatches, "permission denied")
 }
 
 func (s *UserInfoCommandSuite) TestUserInfoFormatJson(c *gc.C) {
-	context, err := testing.RunCommand(c, s.NewShowUserCommand(), "--format", "json")
+	context, err := cmdtesting.RunCommand(c, s.NewShowUserCommand(), "--format", "json")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(testing.Stdout(context), gc.Equals, `
+	c.Assert(cmdtesting.Stdout(context), gc.Equals, `
 {"user-name":"current-user","access":"add-model","date-created":"1981-02-27","last-connection":"2014-01-01"}
 `[1:])
 }
 
 func (s *UserInfoCommandSuite) TestUserInfoFormatJsonWithUsername(c *gc.C) {
-	context, err := testing.RunCommand(c, s.NewShowUserCommand(), "foobar", "--format", "json")
+	context, err := cmdtesting.RunCommand(c, s.NewShowUserCommand(), "foobar", "--format", "json")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(testing.Stdout(context), gc.Equals, `
+	c.Assert(cmdtesting.Stdout(context), gc.Equals, `
 {"user-name":"foobar","display-name":"Foo Bar","access":"login","date-created":"1981-02-27","last-connection":"2014-01-01"}
 `[1:])
 }
 
 func (s *UserInfoCommandSuite) TestUserInfoFormatYaml(c *gc.C) {
-	context, err := testing.RunCommand(c, s.NewShowUserCommand(), "--format", "yaml")
+	context, err := cmdtesting.RunCommand(c, s.NewShowUserCommand(), "--format", "yaml")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(testing.Stdout(context), gc.Equals, `user-name: current-user
+	c.Assert(cmdtesting.Stdout(context), gc.Equals, `user-name: current-user
 access: add-model
 date-created: 1981-02-27
 last-connection: 2014-01-01
@@ -140,6 +140,6 @@ last-connection: 2014-01-01
 }
 
 func (s *UserInfoCommandSuite) TestTooManyArgs(c *gc.C) {
-	_, err := testing.RunCommand(c, s.NewShowUserCommand(), "username", "whoops")
+	_, err := cmdtesting.RunCommand(c, s.NewShowUserCommand(), "username", "whoops")
 	c.Assert(err, gc.ErrorMatches, `unrecognized args: \["whoops"\]`)
 }

--- a/cmd/juju/user/list_test.go
+++ b/cmd/juju/user/list_test.go
@@ -14,9 +14,9 @@ import (
 
 	"github.com/juju/juju/api/usermanager"
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/cmd/cmdtesting"
 	"github.com/juju/juju/cmd/juju/user"
 	"github.com/juju/juju/jujuclient"
-	"github.com/juju/juju/testing"
 )
 
 // All of the functionality of the UserInfo api call is contained elsewhere.
@@ -123,9 +123,9 @@ func (s *UserListCommandSuite) SetUpTest(c *gc.C) {
 }
 
 func (s *UserListCommandSuite) TestUserInfo(c *gc.C) {
-	context, err := testing.RunCommand(c, s.newUserListCommand())
+	context, err := cmdtesting.RunCommand(c, s.newUserListCommand())
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(testing.Stdout(context), gc.Equals, ""+
+	c.Assert(cmdtesting.Stdout(context), gc.Equals, ""+
 		"Controller: testing\n\n"+
 		"Name     Display name    Access     Date created  Last connection\n"+
 		"adam*    Adam Zulu       login      2012-10-08    2014-01-01\n"+
@@ -135,9 +135,9 @@ func (s *UserListCommandSuite) TestUserInfo(c *gc.C) {
 }
 
 func (s *UserListCommandSuite) TestUserInfoWithDisabled(c *gc.C) {
-	context, err := testing.RunCommand(c, s.newUserListCommand(), "--all")
+	context, err := cmdtesting.RunCommand(c, s.newUserListCommand(), "--all")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(testing.Stdout(context), gc.Equals, ""+
+	c.Assert(cmdtesting.Stdout(context), gc.Equals, ""+
 		"Controller: testing\n\n"+
 		"Name     Display name    Access     Date created  Last connection\n"+
 		"adam*    Adam Zulu       login      2012-10-08    2014-01-01\n"+
@@ -148,9 +148,9 @@ func (s *UserListCommandSuite) TestUserInfoWithDisabled(c *gc.C) {
 }
 
 func (s *UserListCommandSuite) TestUserInfoExactTime(c *gc.C) {
-	context, err := testing.RunCommand(c, s.newUserListCommand(), "--exact-time")
+	context, err := cmdtesting.RunCommand(c, s.newUserListCommand(), "--exact-time")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(testing.Stdout(context), gc.Equals, ""+
+	c.Assert(cmdtesting.Stdout(context), gc.Equals, ""+
 		"Controller: testing\n\n"+
 		"Name     Display name    Access     Date created                   Last connection\n"+
 		"adam*    Adam Zulu       login      2012-10-08 00:00:00 +0000 UTC  2014-01-01 00:00:00 +0000 UTC\n"+
@@ -160,9 +160,9 @@ func (s *UserListCommandSuite) TestUserInfoExactTime(c *gc.C) {
 }
 
 func (s *UserListCommandSuite) TestUserInfoFormatJson(c *gc.C) {
-	context, err := testing.RunCommand(c, s.newUserListCommand(), "--format", "json")
+	context, err := cmdtesting.RunCommand(c, s.newUserListCommand(), "--format", "json")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(testing.Stdout(context), gc.Equals, "["+
+	c.Assert(cmdtesting.Stdout(context), gc.Equals, "["+
 		`{"user-name":"adam","display-name":"Adam Zulu","access":"login","date-created":"2012-10-08","last-connection":"2014-01-01"},`+
 		`{"user-name":"barbara","display-name":"Barbara Yellow","access":"add-model","date-created":"2013-05-02","last-connection":"just now"},`+
 		`{"user-name":"charlie","display-name":"Charlie Xavier","access":"superuser","date-created":"6 hours ago","last-connection":"never connected"}`+
@@ -170,9 +170,9 @@ func (s *UserListCommandSuite) TestUserInfoFormatJson(c *gc.C) {
 }
 
 func (s *UserListCommandSuite) TestUserInfoFormatYaml(c *gc.C) {
-	context, err := testing.RunCommand(c, s.newUserListCommand(), "--format", "yaml")
+	context, err := cmdtesting.RunCommand(c, s.newUserListCommand(), "--format", "yaml")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(testing.Stdout(context), gc.Equals, ""+
+	c.Assert(cmdtesting.Stdout(context), gc.Equals, ""+
 		"- user-name: adam\n"+
 		"  display-name: Adam Zulu\n"+
 		"  access: login\n"+
@@ -191,9 +191,9 @@ func (s *UserListCommandSuite) TestUserInfoFormatYaml(c *gc.C) {
 }
 
 func (s *UserListCommandSuite) TestModelUsers(c *gc.C) {
-	context, err := testing.RunCommand(c, s.newUserListCommand(), "admin")
+	context, err := cmdtesting.RunCommand(c, s.newUserListCommand(), "admin")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(testing.Stdout(context), gc.Equals, ""+
+	c.Assert(cmdtesting.Stdout(context), gc.Equals, ""+
 		"Name                Display name  Access  Last connection\n"+
 		"adam*               Adam          read    2015-03-01\n"+
 		"admin                             write   2015-03-20\n"+
@@ -202,9 +202,9 @@ func (s *UserListCommandSuite) TestModelUsers(c *gc.C) {
 }
 
 func (s *UserListCommandSuite) TestModelUsersFormatJson(c *gc.C) {
-	context, err := testing.RunCommand(c, s.newUserListCommand(), "admin", "--format", "json")
+	context, err := cmdtesting.RunCommand(c, s.newUserListCommand(), "admin", "--format", "json")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(testing.Stdout(context), gc.Equals, "{"+
+	c.Assert(cmdtesting.Stdout(context), gc.Equals, "{"+
 		`"adam":{"display-name":"Adam","access":"read","last-connection":"2015-03-01"},`+
 		`"admin":{"access":"write","last-connection":"2015-03-20"},`+
 		`"charlie@ubuntu.com":{"display-name":"Charlie","access":"read","last-connection":"never connected"}`+
@@ -212,9 +212,9 @@ func (s *UserListCommandSuite) TestModelUsersFormatJson(c *gc.C) {
 }
 
 func (s *UserListCommandSuite) TestModelUsersInfoFormatYaml(c *gc.C) {
-	context, err := testing.RunCommand(c, s.newUserListCommand(), "admin", "--format", "yaml")
+	context, err := cmdtesting.RunCommand(c, s.newUserListCommand(), "admin", "--format", "yaml")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(testing.Stdout(context), gc.Equals, ""+
+	c.Assert(cmdtesting.Stdout(context), gc.Equals, ""+
 		"adam:\n"+
 		"  display-name: Adam\n"+
 		"  access: read\n"+
@@ -229,6 +229,6 @@ func (s *UserListCommandSuite) TestModelUsersInfoFormatYaml(c *gc.C) {
 }
 
 func (s *UserListCommandSuite) TestTooManyArgs(c *gc.C) {
-	_, err := testing.RunCommand(c, s.newUserListCommand(), "model", "whoops")
+	_, err := cmdtesting.RunCommand(c, s.newUserListCommand(), "model", "whoops")
 	c.Assert(err, gc.ErrorMatches, `unrecognized args: \["whoops"\]`)
 }

--- a/cmd/juju/user/logout_test.go
+++ b/cmd/juju/user/logout_test.go
@@ -15,8 +15,8 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/cmd/cmdtesting"
 	"github.com/juju/juju/cmd/juju/user"
-	coretesting "github.com/juju/juju/testing"
 )
 
 type LogoutCommandSuite struct {
@@ -31,7 +31,7 @@ func (s *LogoutCommandSuite) SetUpTest(c *gc.C) {
 
 func (s *LogoutCommandSuite) run(c *gc.C, args ...string) (*cmd.Context, error) {
 	cmd, _ := user.NewLogoutCommandForTest(s.store)
-	return coretesting.RunCommand(c, cmd, args...)
+	return cmdtesting.RunCommand(c, cmd, args...)
 }
 
 func (s *LogoutCommandSuite) TestInit(c *gc.C) {
@@ -51,7 +51,7 @@ func (s *LogoutCommandSuite) TestInit(c *gc.C) {
 	} {
 		c.Logf("test %d", i)
 		wrappedCommand, _ := user.NewLogoutCommandForTest(s.store)
-		err := coretesting.InitCommand(wrappedCommand, test.args)
+		err := cmdtesting.InitCommand(wrappedCommand, test.args)
 		if test.errorString == "" {
 			c.Check(err, jc.ErrorIsNil)
 		} else {
@@ -88,8 +88,8 @@ func (s *LogoutCommandSuite) TestLogout(c *gc.C) {
 	s.setPassword(c, "testing", "")
 	ctx, err := s.run(c)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(coretesting.Stdout(ctx), gc.Equals, "")
-	c.Assert(coretesting.Stderr(ctx), gc.Equals, `
+	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, "")
+	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, `
 Logged out. You are no longer logged into any controllers.
 `[1:],
 	)
@@ -123,8 +123,8 @@ func (s *LogoutCommandSuite) TestLogoutCount(c *gc.C) {
 	for i, controller := range controllers {
 		ctx, err := s.run(c, "-c", controller)
 		c.Assert(err, jc.ErrorIsNil)
-		c.Assert(coretesting.Stdout(ctx), gc.Equals, "")
-		c.Assert(coretesting.Stderr(ctx), gc.Equals, expected[i])
+		c.Assert(cmdtesting.Stdout(ctx), gc.Equals, "")
+		c.Assert(cmdtesting.Stderr(ctx), gc.Equals, expected[i])
 	}
 }
 
@@ -158,8 +158,8 @@ func (s *LogoutCommandSuite) TestLogoutNotLoggedIn(c *gc.C) {
 	delete(s.store.Accounts, "testing")
 	ctx, err := s.run(c)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(coretesting.Stdout(ctx), gc.Equals, "")
-	c.Assert(coretesting.Stderr(ctx), gc.Equals, `
+	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, "")
+	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, `
 Logged out. You are no longer logged into any controllers.
 `[1:],
 	)

--- a/cmd/juju/user/remove_test.go
+++ b/cmd/juju/user/remove_test.go
@@ -7,8 +7,8 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/cmd/cmdtesting"
 	"github.com/juju/juju/cmd/juju/user"
-	"github.com/juju/juju/testing"
 )
 
 type RemoveUserCommandSuite struct {
@@ -36,7 +36,7 @@ func (m *mockRemoveUserAPI) RemoveUser(username string) error {
 
 func (s *RemoveUserCommandSuite) run(c *gc.C, name string) (*cmd.Context, error) {
 	removeCommand, _ := user.NewRemoveCommandForTest(s.mockAPI, s.store)
-	return testing.RunCommand(c, removeCommand, name)
+	return cmdtesting.RunCommand(c, removeCommand, name)
 }
 
 func (s *RemoveUserCommandSuite) TestInit(c *gc.C) {
@@ -57,7 +57,7 @@ func (s *RemoveUserCommandSuite) TestInit(c *gc.C) {
 	}}
 	for _, test := range table {
 		wrappedCommand, command := user.NewRemoveCommandForTest(s.mockAPI, s.store)
-		err := testing.InitCommand(wrappedCommand, test.args)
+		err := cmdtesting.InitCommand(wrappedCommand, test.args)
 		c.Check(command.ConfirmDelete, jc.DeepEquals, test.confirm)
 		if test.errorString == "" {
 			c.Check(err, jc.ErrorIsNil)
@@ -70,7 +70,7 @@ func (s *RemoveUserCommandSuite) TestInit(c *gc.C) {
 func (s *RemoveUserCommandSuite) TestRemove(c *gc.C) {
 	username := "testing"
 	command, _ := user.NewRemoveCommandForTest(s.mockAPI, s.store)
-	_, err := testing.RunCommand(c, command, "-y", username)
+	_, err := cmdtesting.RunCommand(c, command, "-y", username)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(s.mockAPI.username, gc.Equals, username)
 
@@ -87,7 +87,7 @@ user please use the` + " `juju disable-user` " + `command. See
 
 Continue (y/N)? `
 	command, _ := user.NewRemoveCommandForTest(s.mockAPI, s.store)
-	ctx, _ := testing.RunCommand(c, command, username)
-	c.Assert(testing.Stdout(ctx), jc.DeepEquals, expected)
+	ctx, _ := cmdtesting.RunCommand(c, command, username)
+	c.Assert(cmdtesting.Stdout(ctx), jc.DeepEquals, expected)
 
 }

--- a/cmd/juju/user/whoami_test.go
+++ b/cmd/juju/user/whoami_test.go
@@ -9,6 +9,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/cmd/cmdtesting"
 	"github.com/juju/juju/cmd/juju/user"
 	"github.com/juju/juju/jujuclient"
 	"github.com/juju/juju/jujuclient/jujuclienttesting"
@@ -167,7 +168,7 @@ func (s *WhoAmITestSuite) TestFromStoreErr(c *gc.C) {
 }
 
 func (s *WhoAmITestSuite) runWhoAmI(c *gc.C, args ...string) (*cmd.Context, error) {
-	return testing.RunCommand(c, user.NewWhoAmICommandForTest(s.store), args...)
+	return cmdtesting.RunCommand(c, user.NewWhoAmICommandForTest(s.store), args...)
 }
 
 func (s *WhoAmITestSuite) assertWhoAmIFailed(c *gc.C, args ...string) {
@@ -178,9 +179,9 @@ func (s *WhoAmITestSuite) assertWhoAmIFailed(c *gc.C, args ...string) {
 func (s *WhoAmITestSuite) assertWhoAmI(c *gc.C, args ...string) string {
 	context, err := s.runWhoAmI(c, args...)
 	c.Assert(err, jc.ErrorIsNil)
-	output := testing.Stdout(context)
+	output := cmdtesting.Stdout(context)
 	if output == "" {
-		output = testing.Stderr(context)
+		output = cmdtesting.Stderr(context)
 	}
 	if s.expectedOutput != "" {
 		c.Assert(output, gc.Equals, s.expectedOutput)

--- a/cmd/jujud/agent/agent_test.go
+++ b/cmd/jujud/agent/agent_test.go
@@ -10,13 +10,13 @@ import (
 	gc "gopkg.in/check.v1"
 	worker "gopkg.in/juju/worker.v1"
 
+	"github.com/juju/juju/cmd/cmdtesting"
 	"github.com/juju/juju/cmd/jujud/agent/agenttest"
 	cmdutil "github.com/juju/juju/cmd/jujud/util"
 	imagetesting "github.com/juju/juju/environs/imagemetadata/testing"
 	"github.com/juju/juju/juju/paths"
 	"github.com/juju/juju/mongo"
 	"github.com/juju/juju/network"
-	coretesting "github.com/juju/juju/testing"
 	"github.com/juju/juju/worker/proxyupdater"
 )
 
@@ -27,18 +27,18 @@ type acCreator func() (cmd.Command, AgentConf)
 // command pre-parsed, with any mandatory flags added.
 func CheckAgentCommand(c *gc.C, create acCreator, args []string) cmd.Command {
 	com, conf := create()
-	err := coretesting.InitCommand(com, args)
+	err := cmdtesting.InitCommand(com, args)
 	dataDir, err := paths.DataDir(series.MustHostSeries())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(conf.DataDir(), gc.Equals, dataDir)
 	badArgs := append(args, "--data-dir", "")
 	com, _ = create()
-	err = coretesting.InitCommand(com, badArgs)
+	err = cmdtesting.InitCommand(com, badArgs)
 	c.Assert(err, gc.ErrorMatches, "--data-dir option must be set")
 
 	args = append(args, "--data-dir", "jd")
 	com, conf = create()
-	c.Assert(coretesting.InitCommand(com, args), gc.IsNil)
+	c.Assert(cmdtesting.InitCommand(com, args), gc.IsNil)
 	c.Assert(conf.DataDir(), gc.Equals, "jd")
 	return com
 }
@@ -49,7 +49,7 @@ func ParseAgentCommand(ac cmd.Command, args []string) error {
 	common := []string{
 		"--data-dir", "jd",
 	}
-	return coretesting.InitCommand(ac, append(common, args...))
+	return cmdtesting.InitCommand(ac, append(common, args...))
 }
 
 // AgentSuite is a fixture to be used by agent test suites.

--- a/cmd/jujud/agent/agenttest/agent.go
+++ b/cmd/jujud/agent/agenttest/agent.go
@@ -22,6 +22,7 @@ import (
 	"github.com/juju/juju/agent"
 	agenttools "github.com/juju/juju/agent/tools"
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/cmd/cmdtesting"
 	cmdutil "github.com/juju/juju/cmd/jujud/util"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/filestorage"
@@ -241,7 +242,7 @@ func (s *AgentSuite) primeAPIHostPorts(c *gc.C) {
 // arguments as provided.
 func (s *AgentSuite) InitAgent(c *gc.C, a cmd.Command, args ...string) {
 	args = append([]string{"--data-dir", s.DataDir()}, args...)
-	err := coretesting.InitCommand(a, args)
+	err := cmdtesting.InitCommand(a, args)
 	c.Assert(err, jc.ErrorIsNil)
 }
 

--- a/cmd/jujud/agent/machine_test.go
+++ b/cmd/jujud/agent/machine_test.go
@@ -13,7 +13,6 @@ import (
 	"time"
 
 	"github.com/juju/cmd"
-	"github.com/juju/cmd/cmdtesting"
 	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils"
@@ -38,6 +37,7 @@ import (
 	"github.com/juju/juju/api/imagemetadata"
 	apimachiner "github.com/juju/juju/api/machiner"
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/cmd/cmdtesting"
 	"github.com/juju/juju/cmd/jujud/agent/model"
 	"github.com/juju/juju/core/migration"
 	"github.com/juju/juju/environs"

--- a/cmd/jujud/agent/unit_test.go
+++ b/cmd/jujud/agent/unit_test.go
@@ -12,7 +12,6 @@ import (
 	"time"
 
 	"github.com/juju/cmd"
-	"github.com/juju/cmd/cmdtesting"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils/arch"
 	"github.com/juju/utils/series"
@@ -23,6 +22,7 @@ import (
 
 	"github.com/juju/juju/agent"
 	agenttools "github.com/juju/juju/agent/tools"
+	"github.com/juju/juju/cmd/cmdtesting"
 	"github.com/juju/juju/cmd/jujud/agent/agenttest"
 	envtesting "github.com/juju/juju/environs/testing"
 	"github.com/juju/juju/network"
@@ -95,7 +95,7 @@ func (s *UnitSuite) newBufferedLogWriter() *logsender.BufferedLogWriter {
 func (s *UnitSuite) TestParseSuccess(c *gc.C) {
 	a, err := NewUnitAgent(nil, s.newBufferedLogWriter())
 	c.Assert(err, jc.ErrorIsNil)
-	err = coretesting.InitCommand(a, []string{
+	err = cmdtesting.InitCommand(a, []string{
 		"--data-dir", "jd",
 		"--unit-name", "w0rd-pre55/1",
 		"--log-to-stderr",
@@ -108,7 +108,7 @@ func (s *UnitSuite) TestParseSuccess(c *gc.C) {
 func (s *UnitSuite) TestParseMissing(c *gc.C) {
 	uc, err := NewUnitAgent(nil, s.newBufferedLogWriter())
 	c.Assert(err, jc.ErrorIsNil)
-	err = coretesting.InitCommand(uc, []string{
+	err = cmdtesting.InitCommand(uc, []string{
 		"--data-dir", "jc",
 	})
 
@@ -126,7 +126,7 @@ func (s *UnitSuite) TestParseNonsense(c *gc.C) {
 		a, err := NewUnitAgent(nil, s.newBufferedLogWriter())
 		c.Assert(err, jc.ErrorIsNil)
 
-		err = coretesting.InitCommand(a, append(args, "--data-dir", "jc"))
+		err = cmdtesting.InitCommand(a, append(args, "--data-dir", "jc"))
 		c.Check(err, gc.ErrorMatches, `--unit-name option expects "<application>/<n>" argument`)
 	}
 }
@@ -135,7 +135,7 @@ func (s *UnitSuite) TestParseUnknown(c *gc.C) {
 	a, err := NewUnitAgent(nil, s.newBufferedLogWriter())
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = coretesting.InitCommand(a, []string{
+	err = cmdtesting.InitCommand(a, []string{
 		"--unit-name", "wordpress/1",
 		"thundering typhoons",
 	})

--- a/cmd/jujud/bootstrap_test.go
+++ b/cmd/jujud/bootstrap_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/cloudconfig/instancecfg"
+	"github.com/juju/juju/cmd/cmdtesting"
 	"github.com/juju/juju/cmd/jujud/agent/agenttest"
 	cmdutil "github.com/juju/juju/cmd/jujud/util"
 	"github.com/juju/juju/cmd/modelcmd"
@@ -335,7 +336,7 @@ func (s *BootstrapSuite) initBootstrapCommand(c *gc.C, jobs []multiwatcher.Machi
 		args = []string{s.bootstrapParamsFile}
 	}
 	cmd = NewBootstrapCommand()
-	err = testing.InitCommand(cmd, append([]string{"--data-dir", s.dataDir}, args...))
+	err = cmdtesting.InitCommand(cmd, append([]string{"--data-dir", s.dataDir}, args...))
 	return machineConf, cmd, err
 }
 

--- a/cmd/jujud/main_test.go
+++ b/cmd/jujud/main_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/juju/cmd"
 	"github.com/juju/gnuflag"
+	"github.com/juju/loggo"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
@@ -26,7 +27,6 @@ import (
 	"github.com/juju/juju/juju/names"
 	coretesting "github.com/juju/juju/testing"
 	"github.com/juju/juju/worker/uniter/runner/jujuc"
-	"github.com/juju/loggo"
 )
 
 var caCertFile string

--- a/cmd/modelcmd/base_test.go
+++ b/cmd/modelcmd/base_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/juju/juju/api"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/cloud"
+	"github.com/juju/juju/cmd/cmdtesting"
 	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/jujuclient"
@@ -92,7 +93,7 @@ func (NewGetBootstrapConfigParamsFuncSuite) TestDetectCredentials(c *gc.C) {
 	var registry mockProviderRegistry
 
 	f := modelcmd.NewGetBootstrapConfigParamsFunc(
-		coretesting.Context(c),
+		cmdtesting.Context(c),
 		clientStore,
 		&registry,
 	)

--- a/cmd/modelcmd/controller_test.go
+++ b/cmd/modelcmd/controller_test.go
@@ -5,12 +5,12 @@ package modelcmd_test
 
 import (
 	"github.com/juju/cmd"
-	"github.com/juju/cmd/cmdtesting"
 	"github.com/juju/errors"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/cmd/cmdtesting"
 	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/jujuclient"
 )

--- a/cmd/modelcmd/credentials_test.go
+++ b/cmd/modelcmd/credentials_test.go
@@ -13,11 +13,11 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/cloud"
+	"github.com/juju/juju/cmd/cmdtesting"
 	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/jujuclient"
 	_ "github.com/juju/juju/provider/dummy"
-	jujutesting "github.com/juju/juju/testing"
 )
 
 func init() {
@@ -109,7 +109,7 @@ func (s *credentialsSuite) SetUpTest(c *gc.C) {
 
 func (s *credentialsSuite) assertGetCredentials(c *gc.C, cred, region string) {
 	credential, credentialName, regionName, err := modelcmd.GetCredentials(
-		jujutesting.Context(c), s.store, modelcmd.GetCredentialsParams{
+		cmdtesting.Context(c), s.store, modelcmd.GetCredentialsParams{
 			Cloud:          s.cloud,
 			CloudRegion:    region,
 			CredentialName: cred,

--- a/cmd/modelcmd/modelcommand_test.go
+++ b/cmd/modelcmd/modelcommand_test.go
@@ -8,13 +8,13 @@ import (
 	"os"
 
 	"github.com/juju/cmd"
-	"github.com/juju/cmd/cmdtesting"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/names.v2"
 
 	apitesting "github.com/juju/juju/api/testing"
+	"github.com/juju/juju/cmd/cmdtesting"
 	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/juju/osenv"
 	"github.com/juju/juju/jujuclient"

--- a/cmd/plugins/juju-metadata/addimage_test.go
+++ b/cmd/plugins/juju-metadata/addimage_test.go
@@ -13,7 +13,7 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/apiserver/params"
-	"github.com/juju/juju/testing"
+	"github.com/juju/juju/cmd/cmdtesting"
 )
 
 type addImageSuite struct {
@@ -132,7 +132,7 @@ func (s *addImageSuite) assertValidAddImageMetadata(c *gc.C, m params.CloudImage
 }
 
 func runAddImageMetadata(c *gc.C, args ...string) (*cmd.Context, error) {
-	return testing.RunCommand(c, newAddImageMetadataCommand(), args...)
+	return cmdtesting.RunCommand(c, newAddImageMetadataCommand(), args...)
 }
 
 func (s *addImageSuite) assertAddImageMetadataErr(c *gc.C, m params.CloudImageMetadata, msg string) {

--- a/cmd/plugins/juju-metadata/deleteimage_test.go
+++ b/cmd/plugins/juju-metadata/deleteimage_test.go
@@ -9,8 +9,8 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/cmd/cmdtesting"
 	"github.com/juju/juju/cmd/modelcmd"
-	"github.com/juju/juju/testing"
 )
 
 const deleteTestId = "tst12345"
@@ -66,7 +66,7 @@ func (s *deleteImageSuite) runDeleteImageMetadata(c *gc.C, args ...string) error
 	}
 	deleteCmd := modelcmd.Wrap(tstDelete)
 
-	_, err := testing.RunCommand(c, deleteCmd, args...)
+	_, err := cmdtesting.RunCommand(c, deleteCmd, args...)
 	return err
 }
 

--- a/cmd/plugins/juju-metadata/imagemetadata_test.go
+++ b/cmd/plugins/juju-metadata/imagemetadata_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/juju/utils/series"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/cmd/cmdtesting"
 	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/jujuclient"
@@ -51,7 +52,7 @@ func (s *ImageMetadataSuite) SetUpTest(c *gc.C) {
 func runImageMetadata(c *gc.C, store jujuclient.ClientStore, args ...string) (*cmd.Context, error) {
 	cmd := &imageMetadataCommand{}
 	cmd.SetClientStore(store)
-	return testing.RunCommand(c, modelcmd.Wrap(cmd), args...)
+	return cmdtesting.RunCommand(c, modelcmd.Wrap(cmd), args...)
 }
 
 var seriesVersions map[string]string = map[string]string{
@@ -122,7 +123,7 @@ func (s *ImageMetadataSuite) TestImageMetadataFilesNoEnv(c *gc.C) {
 		"-s", "raring", "--virt-type=pv", "--storage=root",
 	)
 	c.Assert(err, jc.ErrorIsNil)
-	out := testing.Stdout(ctx)
+	out := cmdtesting.Stdout(ctx)
 	expected := expectedMetadata{
 		series:   "raring",
 		arch:     "arch",
@@ -137,7 +138,7 @@ func (s *ImageMetadataSuite) TestImageMetadataFilesDefaultArch(c *gc.C) {
 		"-d", s.dir, "-i", "1234", "-r", "region", "-u", "endpoint", "-s", "raring",
 	)
 	c.Assert(err, jc.ErrorIsNil)
-	out := testing.Stdout(ctx)
+	out := cmdtesting.Stdout(ctx)
 	expected := expectedMetadata{
 		series: "raring",
 		arch:   "amd64",
@@ -166,7 +167,7 @@ func (s *ImageMetadataSuite) TestImageMetadataFilesLatestLts(c *gc.C) {
 		"-d", s.dir, "-i", "1234", "-r", "region", "-a", "arch", "-u", "endpoint",
 	)
 	c.Assert(err, jc.ErrorIsNil)
-	out := testing.Stdout(ctx)
+	out := cmdtesting.Stdout(ctx)
 	expected := expectedMetadata{
 		series: series.LatestLts(),
 		arch:   "arch",
@@ -179,7 +180,7 @@ func (s *ImageMetadataSuite) TestImageMetadataFilesUsingEnv(c *gc.C) {
 		"-d", s.dir, "-m", "ec2-controller:ec2", "-i", "1234", "--virt-type=pv", "--storage=root",
 	)
 	c.Assert(err, jc.ErrorIsNil)
-	out := testing.Stdout(ctx)
+	out := cmdtesting.Stdout(ctx)
 	expected := expectedMetadata{
 		series:   "precise",
 		arch:     "amd64",
@@ -196,7 +197,7 @@ func (s *ImageMetadataSuite) TestImageMetadataFilesUsingEnvWithRegionOverride(c 
 		"-d", s.dir, "-m", "ec2-controller:ec2", "-r", "us-west-1", "-u", "https://ec2.us-west-1.amazonaws.com", "-i", "1234",
 	)
 	c.Assert(err, jc.ErrorIsNil)
-	out := testing.Stdout(ctx)
+	out := cmdtesting.Stdout(ctx)
 	expected := expectedMetadata{
 		series:   "precise",
 		arch:     "amd64",
@@ -211,7 +212,7 @@ func (s *ImageMetadataSuite) TestImageMetadataFilesUsingEnvWithNoHasRegion(c *gc
 		"-d", s.dir, "-m", "azure-controller:azure", "-r", "region", "-u", "endpoint", "-i", "1234",
 	)
 	c.Assert(err, jc.ErrorIsNil)
-	out := testing.Stdout(ctx)
+	out := cmdtesting.Stdout(ctx)
 	expected := expectedMetadata{
 		series:   "raring",
 		arch:     "amd64",

--- a/cmd/plugins/juju-metadata/listimages_test.go
+++ b/cmd/plugins/juju-metadata/listimages_test.go
@@ -13,6 +13,7 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/cmd/cmdtesting"
 	"github.com/juju/juju/jujuclient"
 	"github.com/juju/juju/testing"
 )
@@ -57,7 +58,7 @@ func (s *ListSuite) SetUpTest(c *gc.C) {
 }
 
 func runList(c *gc.C, args []string) (*cmd.Context, error) {
-	return testing.RunCommand(c, newListImagesCommand(), args...)
+	return cmdtesting.RunCommand(c, newListImagesCommand(), args...)
 }
 
 func (s *ListSuite) TestListDefault(c *gc.C) {
@@ -244,10 +245,10 @@ func (s *ListSuite) assertValidList(c *gc.C, expectedValid, expectedErr string, 
 	context, err := runList(c, args)
 	c.Assert(err, jc.ErrorIsNil)
 
-	obtainedErr := testing.Stderr(context)
+	obtainedErr := cmdtesting.Stderr(context)
 	c.Assert(obtainedErr, gc.Matches, expectedErr)
 
-	obtainedValid := testing.Stdout(context)
+	obtainedValid := cmdtesting.Stdout(context)
 	c.Assert(obtainedValid, gc.Matches, expectedValid)
 }
 

--- a/cmd/plugins/juju-metadata/signmetadata_test.go
+++ b/cmd/plugins/juju-metadata/signmetadata_test.go
@@ -15,6 +15,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/cmd/cmdtesting"
 	"github.com/juju/juju/environs/simplestreams"
 	sstesting "github.com/juju/juju/environs/simplestreams/testing"
 	coretesting "github.com/juju/juju/testing"
@@ -81,7 +82,7 @@ func (s *SignMetadataSuite) TestSignMetadata(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	setupJsonFiles(c, topLevel)
 
-	ctx := coretesting.Context(c)
+	ctx := cmdtesting.Context(c)
 	code := cmd.Main(
 		newSignMetadataCommand(), ctx, []string{"-d", topLevel, "-k", keyfile, "-p", sstesting.PrivateKeyPassphrase})
 	c.Assert(code, gc.Equals, 0)
@@ -91,7 +92,7 @@ func (s *SignMetadataSuite) TestSignMetadata(c *gc.C) {
 }
 
 func runSignMetadata(c *gc.C, args ...string) error {
-	_, err := coretesting.RunCommand(c, newSignMetadataCommand(), args...)
+	_, err := cmdtesting.RunCommand(c, newSignMetadataCommand(), args...)
 	return err
 }
 

--- a/cmd/plugins/juju-metadata/toolsmetadata_test.go
+++ b/cmd/plugins/juju-metadata/toolsmetadata_test.go
@@ -19,6 +19,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/cmd/cmdtesting"
 	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/bootstrap"
@@ -53,7 +54,7 @@ func (s *ToolsMetadataSuite) SetUpTest(c *gc.C) {
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	env, err := bootstrap.Prepare(
-		modelcmd.BootstrapContextNoVerify(coretesting.Context(c)),
+		modelcmd.BootstrapContextNoVerify(cmdtesting.Context(c)),
 		jujuclient.NewMemStore(),
 		bootstrap.PrepareParams{
 			ControllerConfig: coretesting.FakeControllerConfig(),
@@ -120,7 +121,7 @@ var expectedOutputDirectoryTemplate = expectedOutputCommon + `
 func (s *ToolsMetadataSuite) TestGenerateToDirectory(c *gc.C) {
 	metadataDir := c.MkDir()
 	toolstesting.MakeTools(c, metadataDir, "released", versionStrings)
-	ctx := coretesting.Context(c)
+	ctx := cmdtesting.Context(c)
 	code := cmd.Main(newToolsMetadataCommand(), ctx, []string{"-d", metadataDir})
 	c.Check(code, gc.Equals, 0)
 	output := ctx.Stdout.(*bytes.Buffer).String()
@@ -145,7 +146,7 @@ func (s *ToolsMetadataSuite) TestGenerateToDirectory(c *gc.C) {
 func (s *ToolsMetadataSuite) TestGenerateStream(c *gc.C) {
 	metadataDir := c.MkDir()
 	toolstesting.MakeTools(c, metadataDir, "proposed", versionStrings)
-	ctx := coretesting.Context(c)
+	ctx := cmdtesting.Context(c)
 	code := cmd.Main(newToolsMetadataCommand(), ctx, []string{"-d", metadataDir, "--stream", "proposed"})
 	c.Assert(code, gc.Equals, 0)
 	output := ctx.Stdout.(*bytes.Buffer).String()
@@ -165,7 +166,7 @@ func (s *ToolsMetadataSuite) TestGenerateMultipleStreams(c *gc.C) {
 	toolstesting.MakeTools(c, metadataDir, "proposed", versionStrings)
 	toolstesting.MakeTools(c, metadataDir, "released", currentVersionStrings)
 
-	ctx := coretesting.Context(c)
+	ctx := cmdtesting.Context(c)
 	code := cmd.Main(newToolsMetadataCommand(), ctx, []string{"-d", metadataDir, "--stream", "proposed"})
 	c.Assert(code, gc.Equals, 0)
 	code = cmd.Main(newToolsMetadataCommand(), ctx, []string{"-d", metadataDir, "--stream", "released"})
@@ -205,7 +206,7 @@ func (s *ToolsMetadataSuite) TestGenerateDeleteExisting(c *gc.C) {
 	toolstesting.MakeTools(c, metadataDir, "proposed", versionStrings)
 	toolstesting.MakeTools(c, metadataDir, "released", currentVersionStrings)
 
-	ctx := coretesting.Context(c)
+	ctx := cmdtesting.Context(c)
 	code := cmd.Main(newToolsMetadataCommand(), ctx, []string{"-d", metadataDir, "--stream", "proposed"})
 	c.Assert(code, gc.Equals, 0)
 	code = cmd.Main(newToolsMetadataCommand(), ctx, []string{"-d", metadataDir, "--stream", "released"})
@@ -246,7 +247,7 @@ func (s *ToolsMetadataSuite) TestGenerateWithPublicFallback(c *gc.C) {
 	toolstesting.MakeToolsWithCheckSum(c, s.publicStorageDir, "released", versionStrings)
 
 	// Run the command with no local metadata.
-	ctx := coretesting.Context(c)
+	ctx := cmdtesting.Context(c)
 	metadataDir := c.MkDir()
 	code := cmd.Main(newToolsMetadataCommand(), ctx, []string{"-d", metadataDir, "--stream", "released"})
 	c.Assert(code, gc.Equals, 0)
@@ -264,7 +265,7 @@ func (s *ToolsMetadataSuite) TestGenerateWithMirrors(c *gc.C) {
 
 	metadataDir := c.MkDir()
 	toolstesting.MakeTools(c, metadataDir, "released", versionStrings)
-	ctx := coretesting.Context(c)
+	ctx := cmdtesting.Context(c)
 	code := cmd.Main(newToolsMetadataCommand(), ctx, []string{"--public", "-d", metadataDir, "--stream", "released"})
 	c.Assert(code, gc.Equals, 0)
 	output := ctx.Stdout.(*bytes.Buffer).String()
@@ -291,7 +292,7 @@ func (s *ToolsMetadataSuite) TestNoTools(c *gc.C) {
 	if runtime.GOOS == "windows" {
 		c.Skip("Skipping on windows, test only set up for Linux tools")
 	}
-	ctx := coretesting.Context(c)
+	ctx := cmdtesting.Context(c)
 	code := cmd.Main(newToolsMetadataCommand(), ctx, nil)
 	c.Assert(code, gc.Equals, 1)
 	stdout := ctx.Stdout.(*bytes.Buffer).String()
@@ -312,7 +313,7 @@ func (s *ToolsMetadataSuite) TestPatchLevels(c *gc.C) {
 	}
 	metadataDir := osenv.JujuXDGDataHomeDir() // default metadata dir
 	toolstesting.MakeTools(c, metadataDir, "released", versionStrings)
-	ctx := coretesting.Context(c)
+	ctx := cmdtesting.Context(c)
 	code := cmd.Main(newToolsMetadataCommand(), ctx, []string{"--stream", "released"})
 	c.Assert(code, gc.Equals, 0)
 	output := ctx.Stdout.(*bytes.Buffer).String()

--- a/cmd/plugins/juju-metadata/validateimagemetadata_test.go
+++ b/cmd/plugins/juju-metadata/validateimagemetadata_test.go
@@ -13,6 +13,7 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/cloud"
+	"github.com/juju/juju/cmd/cmdtesting"
 	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/environs/filestorage"
@@ -33,7 +34,7 @@ var _ = gc.Suite(&ValidateImageMetadataSuite{})
 func runValidateImageMetadata(c *gc.C, store jujuclient.ClientStore, args ...string) (*cmd.Context, error) {
 	cmd := &validateImageMetadataCommand{}
 	cmd.SetClientStore(store)
-	return coretesting.RunCommand(c, modelcmd.Wrap(cmd), args...)
+	return cmdtesting.RunCommand(c, modelcmd.Wrap(cmd), args...)
 }
 
 var validateInitImageErrorTests = []struct {
@@ -55,7 +56,7 @@ var validateInitImageErrorTests = []struct {
 func (s *ValidateImageMetadataSuite) TestInitErrors(c *gc.C) {
 	for i, t := range validateInitImageErrorTests {
 		c.Logf("test %d", i)
-		err := coretesting.InitCommand(newValidateImageMetadataCommand(), t.args)
+		err := cmdtesting.InitCommand(newValidateImageMetadataCommand(), t.args)
 		c.Check(err, gc.ErrorMatches, t.err)
 	}
 }
@@ -188,8 +189,8 @@ func (s *ValidateImageMetadataSuite) assertEc2LocalMetadataUsingEnvironment(c *g
 	s.setupEc2LocalMetadata(c, "us-east-1", stream)
 	ctx, err := runValidateImageMetadata(c, s.store, "-m", "ec2-controller:ec2", "-d", s.metadataDir, "--stream", stream)
 	c.Assert(err, jc.ErrorIsNil)
-	stdout := coretesting.Stdout(ctx)
-	stderr := coretesting.Stderr(ctx)
+	stdout := cmdtesting.Stdout(ctx)
+	stderr := cmdtesting.Stderr(ctx)
 	strippedOut := strings.Replace(stdout, "\n", "", -1)
 	c.Check(strippedOut, gc.Matches,
 		`ImageIds:.*"1234".*Region:.*us-east-1.*Resolve Metadata:.*source: local metadata directory.*`,
@@ -220,7 +221,7 @@ func (s *ValidateImageMetadataSuite) TestEc2LocalMetadataWithManualParams(c *gc.
 		"-u", "https://ec2.us-west-1.amazonaws.com", "-d", s.metadataDir,
 	)
 	c.Assert(err, jc.ErrorIsNil)
-	errOut := coretesting.Stdout(ctx)
+	errOut := cmdtesting.Stdout(ctx)
 	strippedOut := strings.Replace(errOut, "\n", "", -1)
 	c.Check(
 		strippedOut, gc.Matches,
@@ -248,7 +249,7 @@ func (s *ValidateImageMetadataSuite) TestOpenstackLocalMetadataWithManualParams(
 		"-u", "some-auth-url", "-d", s.metadataDir,
 	)
 	c.Assert(err, jc.ErrorIsNil)
-	errOut := coretesting.Stdout(ctx)
+	errOut := cmdtesting.Stdout(ctx)
 	strippedOut := strings.Replace(errOut, "\n", "", -1)
 	c.Check(
 		strippedOut, gc.Matches,

--- a/cmd/plugins/juju-metadata/validatetoolsmetadata_test.go
+++ b/cmd/plugins/juju-metadata/validatetoolsmetadata_test.go
@@ -12,6 +12,7 @@ import (
 	"gopkg.in/amz.v3/aws"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/cmd/cmdtesting"
 	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/environs/filestorage"
 	"github.com/juju/juju/environs/tools"
@@ -31,7 +32,7 @@ var _ = gc.Suite(&ValidateToolsMetadataSuite{})
 func runValidateToolsMetadata(c *gc.C, store jujuclient.ClientStore, args ...string) (*cmd.Context, error) {
 	cmd := &validateToolsMetadataCommand{}
 	cmd.SetClientStore(store)
-	return coretesting.RunCommand(c, modelcmd.Wrap(cmd), args...)
+	return cmdtesting.RunCommand(c, modelcmd.Wrap(cmd), args...)
 }
 
 var validateInitToolsErrorTests = []struct {
@@ -61,7 +62,7 @@ func (s *ValidateToolsMetadataSuite) TestInitErrors(c *gc.C) {
 		c.Logf("test %d", i)
 		cmd := &validateToolsMetadataCommand{}
 		cmd.SetClientStore(s.store)
-		err := coretesting.InitCommand(modelcmd.Wrap(cmd), t.args)
+		err := cmdtesting.InitCommand(modelcmd.Wrap(cmd), t.args)
 		c.Check(err, gc.ErrorMatches, t.err)
 	}
 }
@@ -123,7 +124,7 @@ func (s *ValidateToolsMetadataSuite) TestEc2LocalMetadataUsingEnvironment(c *gc.
 	s.setupEc2LocalMetadata(c, "us-east-1")
 	ctx, err := runValidateToolsMetadata(c, s.store, "-m", "ec2-controller:ec2", "-j", "1.11.4", "-d", s.metadataDir)
 	c.Assert(err, jc.ErrorIsNil)
-	errOut := coretesting.Stdout(ctx)
+	errOut := cmdtesting.Stdout(ctx)
 	strippedOut := strings.Replace(errOut, "\n", "", -1)
 	c.Assert(strippedOut, gc.Matches, `Matching Tools Versions:.*Resolve Metadata.*`)
 }
@@ -144,7 +145,7 @@ func (s *ValidateToolsMetadataSuite) TestEc2LocalMetadataWithManualParams(c *gc.
 		"-u", "https://ec2.us-west-1.amazonaws.com", "-d", s.metadataDir,
 	)
 	c.Assert(err, jc.ErrorIsNil)
-	errOut := coretesting.Stdout(ctx)
+	errOut := cmdtesting.Stdout(ctx)
 	strippedOut := strings.Replace(errOut, "\n", "", -1)
 	c.Check(strippedOut, gc.Matches, `Matching Tools Versions:.*Resolve Metadata.*`)
 }
@@ -170,7 +171,7 @@ func (s *ValidateToolsMetadataSuite) TestOpenstackLocalMetadataWithManualParams(
 		"-u", "some-auth-url", "-d", s.metadataDir,
 	)
 	c.Assert(err, jc.ErrorIsNil)
-	errOut := coretesting.Stdout(ctx)
+	errOut := cmdtesting.Stdout(ctx)
 	strippedOut := strings.Replace(errOut, "\n", "", -1)
 	c.Check(strippedOut, gc.Matches, `Matching Tools Versions:.*Resolve Metadata.*`)
 }
@@ -196,7 +197,7 @@ func (s *ValidateToolsMetadataSuite) TestDefaultVersion(c *gc.C) {
 		"-u", "some-auth-url", "-d", s.metadataDir,
 	)
 	c.Assert(err, jc.ErrorIsNil)
-	errOut := coretesting.Stdout(ctx)
+	errOut := cmdtesting.Stdout(ctx)
 	strippedOut := strings.Replace(errOut, "\n", "", -1)
 	c.Check(strippedOut, gc.Matches, `Matching Tools Versions:.*Resolve Metadata.*`)
 }
@@ -208,7 +209,7 @@ func (s *ValidateToolsMetadataSuite) TestStream(c *gc.C) {
 		"-u", "some-auth-url", "-d", s.metadataDir, "--stream", "proposed",
 	)
 	c.Assert(err, jc.ErrorIsNil)
-	errOut := coretesting.Stdout(ctx)
+	errOut := cmdtesting.Stdout(ctx)
 	strippedOut := strings.Replace(errOut, "\n", "", -1)
 	c.Check(strippedOut, gc.Matches, `Matching Tools Versions:.*Resolve Metadata.*`)
 }
@@ -220,7 +221,7 @@ func (s *ValidateToolsMetadataSuite) TestMajorVersionMatch(c *gc.C) {
 		"-u", "some-auth-url", "-d", s.metadataDir, "--majorminor-version", "1",
 	)
 	c.Assert(err, jc.ErrorIsNil)
-	errOut := coretesting.Stdout(ctx)
+	errOut := cmdtesting.Stdout(ctx)
 	strippedOut := strings.Replace(errOut, "\n", "", -1)
 	c.Check(strippedOut, gc.Matches, `Matching Tools Versions:.*Resolve Metadata.*`)
 }
@@ -232,7 +233,7 @@ func (s *ValidateToolsMetadataSuite) TestMajorMinorVersionMatch(c *gc.C) {
 		"-u", "some-auth-url", "-d", s.metadataDir, "--majorminor-version", "1.12",
 	)
 	c.Assert(err, jc.ErrorIsNil)
-	errOut := coretesting.Stdout(ctx)
+	errOut := cmdtesting.Stdout(ctx)
 	strippedOut := strings.Replace(errOut, "\n", "", -1)
 	c.Check(strippedOut, gc.Matches, `Matching Tools Versions:.*Resolve Metadata.*`)
 }
@@ -243,7 +244,7 @@ func (s *ValidateToolsMetadataSuite) TestJustDirectory(c *gc.C) {
 		"-s", "raring", "-d", s.metadataDir,
 	)
 	c.Assert(err, jc.ErrorIsNil)
-	errOut := coretesting.Stdout(ctx)
+	errOut := cmdtesting.Stdout(ctx)
 	strippedOut := strings.Replace(errOut, "\n", "", -1)
 	c.Check(strippedOut, gc.Matches, `Matching Tools Versions:.*Resolve Metadata.*`)
 }

--- a/environs/bootstrap/bootstrap_test.go
+++ b/environs/bootstrap/bootstrap_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/juju/juju/cert"
 	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/cloudconfig/instancecfg"
+	"github.com/juju/juju/cmd/cmdtesting"
 	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/constraints"
 	"github.com/juju/juju/environs"
@@ -699,7 +700,7 @@ func (s *bootstrapSuite) TestBootstrapGUISuccessRemote(c *gc.C) {
 		}}, nil
 	})
 	env := newEnviron("foo", useDefaultKeys, nil)
-	ctx := coretesting.Context(c)
+	ctx := cmdtesting.Context(c)
 	err := bootstrap.Bootstrap(modelcmd.BootstrapContext(ctx), env, bootstrap.BootstrapParams{
 		ControllerConfig:     coretesting.FakeControllerConfig(),
 		AdminSecret:          "admin-secret",
@@ -707,7 +708,7 @@ func (s *bootstrapSuite) TestBootstrapGUISuccessRemote(c *gc.C) {
 		GUIDataSourceBaseURL: "https://1.2.3.4/gui/sources",
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(coretesting.Stderr(ctx), jc.Contains, "Fetching Juju GUI 2.0.42\n")
+	c.Assert(cmdtesting.Stderr(ctx), jc.Contains, "Fetching Juju GUI 2.0.42\n")
 
 	// The most recent GUI release info has been stored.
 	c.Assert(env.instanceConfig.Bootstrap.GUI.URL, gc.Equals, "https://1.2.3.4/juju-gui-2.0.42.tar.bz2")
@@ -720,14 +721,14 @@ func (s *bootstrapSuite) TestBootstrapGUISuccessLocal(c *gc.C) {
 	path := makeGUIArchive(c, "jujugui-2.2.0")
 	s.PatchEnvironment("JUJU_GUI", path)
 	env := newEnviron("foo", useDefaultKeys, nil)
-	ctx := coretesting.Context(c)
+	ctx := cmdtesting.Context(c)
 	err := bootstrap.Bootstrap(modelcmd.BootstrapContext(ctx), env, bootstrap.BootstrapParams{
 		ControllerConfig: coretesting.FakeControllerConfig(),
 		AdminSecret:      "admin-secret",
 		CAPrivateKey:     coretesting.CAKey,
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(coretesting.Stderr(ctx), jc.Contains, "Fetching Juju GUI 2.2.0 from local archive\n")
+	c.Assert(cmdtesting.Stderr(ctx), jc.Contains, "Fetching Juju GUI 2.2.0 from local archive\n")
 
 	// Check GUI URL and version.
 	c.Assert(env.instanceConfig.Bootstrap.GUI.URL, gc.Equals, "file://"+path)
@@ -750,14 +751,14 @@ func (s *bootstrapSuite) TestBootstrapGUISuccessLocal(c *gc.C) {
 
 func (s *bootstrapSuite) TestBootstrapGUISuccessNoGUI(c *gc.C) {
 	env := newEnviron("foo", useDefaultKeys, nil)
-	ctx := coretesting.Context(c)
+	ctx := cmdtesting.Context(c)
 	err := bootstrap.Bootstrap(modelcmd.BootstrapContext(ctx), env, bootstrap.BootstrapParams{
 		ControllerConfig: coretesting.FakeControllerConfig(),
 		AdminSecret:      "admin-secret",
 		CAPrivateKey:     coretesting.CAKey,
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(coretesting.Stderr(ctx), jc.Contains, "Juju GUI installation has been disabled\n")
+	c.Assert(cmdtesting.Stderr(ctx), jc.Contains, "Juju GUI installation has been disabled\n")
 	c.Assert(env.instanceConfig.Bootstrap.GUI, gc.IsNil)
 }
 
@@ -766,7 +767,7 @@ func (s *bootstrapSuite) TestBootstrapGUINoStreams(c *gc.C) {
 		return nil, nil
 	})
 	env := newEnviron("foo", useDefaultKeys, nil)
-	ctx := coretesting.Context(c)
+	ctx := cmdtesting.Context(c)
 	err := bootstrap.Bootstrap(modelcmd.BootstrapContext(ctx), env, bootstrap.BootstrapParams{
 		ControllerConfig:     coretesting.FakeControllerConfig(),
 		AdminSecret:          "admin-secret",
@@ -774,7 +775,7 @@ func (s *bootstrapSuite) TestBootstrapGUINoStreams(c *gc.C) {
 		GUIDataSourceBaseURL: "https://1.2.3.4/gui/sources",
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(coretesting.Stderr(ctx), jc.Contains, "No available Juju GUI archives found\n")
+	c.Assert(cmdtesting.Stderr(ctx), jc.Contains, "No available Juju GUI archives found\n")
 	c.Assert(env.instanceConfig.Bootstrap.GUI, gc.IsNil)
 }
 
@@ -783,7 +784,7 @@ func (s *bootstrapSuite) TestBootstrapGUIStreamsFailure(c *gc.C) {
 		return nil, errors.New("bad wolf")
 	})
 	env := newEnviron("foo", useDefaultKeys, nil)
-	ctx := coretesting.Context(c)
+	ctx := cmdtesting.Context(c)
 	err := bootstrap.Bootstrap(modelcmd.BootstrapContext(ctx), env, bootstrap.BootstrapParams{
 		ControllerConfig:     coretesting.FakeControllerConfig(),
 		AdminSecret:          "admin-secret",
@@ -791,21 +792,21 @@ func (s *bootstrapSuite) TestBootstrapGUIStreamsFailure(c *gc.C) {
 		GUIDataSourceBaseURL: "https://1.2.3.4/gui/sources",
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(coretesting.Stderr(ctx), jc.Contains, "Unable to fetch Juju GUI info: bad wolf\n")
+	c.Assert(cmdtesting.Stderr(ctx), jc.Contains, "Unable to fetch Juju GUI info: bad wolf\n")
 	c.Assert(env.instanceConfig.Bootstrap.GUI, gc.IsNil)
 }
 
 func (s *bootstrapSuite) TestBootstrapGUIErrorNotFound(c *gc.C) {
 	s.PatchEnvironment("JUJU_GUI", "/no/such/file")
 	env := newEnviron("foo", useDefaultKeys, nil)
-	ctx := coretesting.Context(c)
+	ctx := cmdtesting.Context(c)
 	err := bootstrap.Bootstrap(modelcmd.BootstrapContext(ctx), env, bootstrap.BootstrapParams{
 		ControllerConfig: coretesting.FakeControllerConfig(),
 		AdminSecret:      "admin-secret",
 		CAPrivateKey:     coretesting.CAKey,
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(coretesting.Stderr(ctx), jc.Contains, `Cannot use Juju GUI at "/no/such/file": cannot open Juju GUI archive:`)
+	c.Assert(cmdtesting.Stderr(ctx), jc.Contains, `Cannot use Juju GUI at "/no/such/file": cannot open Juju GUI archive:`)
 }
 
 func (s *bootstrapSuite) TestBootstrapGUIErrorInvalidArchive(c *gc.C) {
@@ -814,42 +815,42 @@ func (s *bootstrapSuite) TestBootstrapGUIErrorInvalidArchive(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	s.PatchEnvironment("JUJU_GUI", path)
 	env := newEnviron("foo", useDefaultKeys, nil)
-	ctx := coretesting.Context(c)
+	ctx := cmdtesting.Context(c)
 	err = bootstrap.Bootstrap(modelcmd.BootstrapContext(ctx), env, bootstrap.BootstrapParams{
 		ControllerConfig: coretesting.FakeControllerConfig(),
 		AdminSecret:      "admin-secret",
 		CAPrivateKey:     coretesting.CAKey,
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(coretesting.Stderr(ctx), jc.Contains, fmt.Sprintf("Cannot use Juju GUI at %q: cannot read Juju GUI archive", path))
+	c.Assert(cmdtesting.Stderr(ctx), jc.Contains, fmt.Sprintf("Cannot use Juju GUI at %q: cannot read Juju GUI archive", path))
 }
 
 func (s *bootstrapSuite) TestBootstrapGUIErrorInvalidVersion(c *gc.C) {
 	path := makeGUIArchive(c, "jujugui-invalid")
 	s.PatchEnvironment("JUJU_GUI", path)
 	env := newEnviron("foo", useDefaultKeys, nil)
-	ctx := coretesting.Context(c)
+	ctx := cmdtesting.Context(c)
 	err := bootstrap.Bootstrap(modelcmd.BootstrapContext(ctx), env, bootstrap.BootstrapParams{
 		ControllerConfig: coretesting.FakeControllerConfig(),
 		AdminSecret:      "admin-secret",
 		CAPrivateKey:     coretesting.CAKey,
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(coretesting.Stderr(ctx), jc.Contains, fmt.Sprintf(`Cannot use Juju GUI at %q: cannot parse version "invalid"`, path))
+	c.Assert(cmdtesting.Stderr(ctx), jc.Contains, fmt.Sprintf(`Cannot use Juju GUI at %q: cannot parse version "invalid"`, path))
 }
 
 func (s *bootstrapSuite) TestBootstrapGUIErrorUnexpectedArchive(c *gc.C) {
 	path := makeGUIArchive(c, "not-a-gui")
 	s.PatchEnvironment("JUJU_GUI", path)
 	env := newEnviron("foo", useDefaultKeys, nil)
-	ctx := coretesting.Context(c)
+	ctx := cmdtesting.Context(c)
 	err := bootstrap.Bootstrap(modelcmd.BootstrapContext(ctx), env, bootstrap.BootstrapParams{
 		ControllerConfig: coretesting.FakeControllerConfig(),
 		AdminSecret:      "admin-secret",
 		CAPrivateKey:     coretesting.CAKey,
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(coretesting.Stderr(ctx), jc.Contains, fmt.Sprintf("Cannot use Juju GUI at %q: cannot find Juju GUI version", path))
+	c.Assert(cmdtesting.Stderr(ctx), jc.Contains, fmt.Sprintf("Cannot use Juju GUI at %q: cannot find Juju GUI version", path))
 }
 
 func makeGUIArchive(c *gc.C, dir string) string {

--- a/environs/testing/bootstrap.go
+++ b/environs/testing/bootstrap.go
@@ -10,11 +10,11 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/cloudconfig/instancecfg"
+	"github.com/juju/juju/cmd/cmdtesting"
 	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/provider/common"
-	coretesting "github.com/juju/juju/testing"
 )
 
 var logger = loggo.GetLogger("juju.environs.testing")
@@ -39,5 +39,5 @@ func DisableFinishBootstrap() func() {
 
 // BootstrapContext creates a simple bootstrap execution context.
 func BootstrapContext(c *gc.C) environs.BootstrapContext {
-	return modelcmd.BootstrapContext(coretesting.Context(c))
+	return modelcmd.BootstrapContext(cmdtesting.Context(c))
 }

--- a/featuretests/application_config_test.go
+++ b/featuretests/application_config_test.go
@@ -15,10 +15,10 @@ import (
 	"gopkg.in/yaml.v2"
 
 	"github.com/juju/juju/api/uniter"
+	"github.com/juju/juju/cmd/cmdtesting"
 	"github.com/juju/juju/cmd/juju/application"
 	jujutesting "github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/state"
-	"github.com/juju/juju/testing"
 )
 
 type ApplicationConfigSuite struct {
@@ -86,9 +86,9 @@ func (s *ApplicationConfigSuite) SetUpTest(c *gc.C) {
 }
 
 func (s *ApplicationConfigSuite) configCommandOutput(c *gc.C, args ...string) string {
-	context, err := testing.RunCommand(c, application.NewConfigCommand(), args...)
+	context, err := cmdtesting.RunCommand(c, application.NewConfigCommand(), args...)
 	c.Assert(err, jc.ErrorIsNil)
-	return testing.Stdout(context)
+	return cmdtesting.Stdout(context)
 }
 
 func (s *ApplicationConfigSuite) getHookOutput(c *gc.C) charm.Settings {

--- a/featuretests/cmd_juju_controller_test.go
+++ b/featuretests/cmd_juju_controller_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/juju/juju/api"
 	"github.com/juju/juju/api/base"
 	"github.com/juju/juju/api/modelmanager"
+	"github.com/juju/juju/cmd/cmdtesting"
 	"github.com/juju/juju/cmd/juju/commands"
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/juju"
@@ -36,9 +37,9 @@ type cmdControllerSuite struct {
 }
 
 func (s *cmdControllerSuite) run(c *gc.C, args ...string) *cmd.Context {
-	context := testing.Context(c)
+	context := cmdtesting.Context(c)
 	command := commands.NewJujuCommand(context)
-	c.Assert(testing.InitCommand(command, args), jc.ErrorIsNil)
+	c.Assert(cmdtesting.InitCommand(command, args), jc.ErrorIsNil)
 	c.Assert(command.Run(context), jc.ErrorIsNil)
 	loggo.RemoveWriter("warning")
 	return context
@@ -78,13 +79,13 @@ Controller  Model       User   Access     Cloud/Region        Models  Machines  
 kontroll*   controller  admin  superuser  dummy/dummy-region       -         -   -  (unknown)  
 
 `[1:]
-	c.Assert(testing.Stdout(context), gc.Equals, expectedOutput)
+	c.Assert(cmdtesting.Stdout(context), gc.Equals, expectedOutput)
 }
 
 func (s *cmdControllerSuite) TestCreateModelAdminUser(c *gc.C) {
 	s.createModelAdminUser(c, "new-model", false)
 	context := s.run(c, "list-models")
-	c.Assert(testing.Stdout(context), gc.Equals, ""+
+	c.Assert(cmdtesting.Stdout(context), gc.Equals, ""+
 		"Controller: kontroll\n"+
 		"\n"+
 		"Model        Cloud/Region        Status     Access  Last connection\n"+
@@ -96,7 +97,7 @@ func (s *cmdControllerSuite) TestCreateModelAdminUser(c *gc.C) {
 func (s *cmdControllerSuite) TestAddModelNormalUser(c *gc.C) {
 	s.createModelNormalUser(c, "new-model", false)
 	context := s.run(c, "list-models", "--all")
-	c.Assert(testing.Stdout(context), gc.Equals, ""+
+	c.Assert(cmdtesting.Stdout(context), gc.Equals, ""+
 		"Controller: kontroll\n"+
 		"\n"+
 		"Model              Cloud/Region        Status     Access  Last connection\n"+
@@ -110,7 +111,7 @@ func (s *cmdControllerSuite) TestListModelsYAML(c *gc.C) {
 	two := uint64(2)
 	s.Factory.MakeMachine(c, &factory.MachineParams{Characteristics: &instance.HardwareCharacteristics{CpuCores: &two}})
 	context := s.run(c, "list-models", "--format=yaml")
-	c.Assert(testing.Stdout(context), gc.Matches, `
+	c.Assert(cmdtesting.Stdout(context), gc.Matches, `
 models:
 - name: controller
   model-uuid: deadbeef-0bad-400d-8000-4b1d0d06f00d
@@ -160,7 +161,7 @@ func (s *cmdControllerSuite) TestListDeadModels(c *gc.C) {
 	// Dead models still show up in the list. It's a lie to pretend they
 	// don't exist, and they will go away quickly.
 	context := s.run(c, "list-models")
-	c.Assert(testing.Stdout(context), gc.Equals, ""+
+	c.Assert(cmdtesting.Stdout(context), gc.Equals, ""+
 		"Controller: kontroll\n"+
 		"\n"+
 		"Model        Cloud/Region        Status      Access  Last connection\n"+
@@ -187,8 +188,8 @@ func (s *cmdControllerSuite) testAddModel(c *gc.C, args ...string) {
 		"--config", "controller=false",
 	)
 	context := s.run(c, args...)
-	c.Check(testing.Stdout(context), gc.Equals, "")
-	c.Check(testing.Stderr(context), gc.Equals, `
+	c.Check(cmdtesting.Stdout(context), gc.Equals, "")
+	c.Check(cmdtesting.Stderr(context), gc.Equals, `
 Added 'new-model' model on dummy/dummy-region with credential 'cred' for user 'admin'
 `[1:])
 
@@ -364,5 +365,5 @@ func (s *cmdControllerSuite) TestGetControllerConfigYAML(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	cfgYaml, err := yaml.Marshal(controllerCfg)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(testing.Stdout(context), gc.Equals, string(cfgYaml))
+	c.Assert(cmdtesting.Stdout(context), gc.Equals, string(cfgYaml))
 }

--- a/featuretests/cmd_juju_credential_test.go
+++ b/featuretests/cmd_juju_credential_test.go
@@ -13,10 +13,10 @@ import (
 	apicloud "github.com/juju/juju/api/cloud"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/cloud"
+	"github.com/juju/juju/cmd/cmdtesting"
 	"github.com/juju/juju/cmd/juju/commands"
 	jujutesting "github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/jujuclient"
-	"github.com/juju/juju/testing"
 )
 
 type cmdCredentialSuite struct {
@@ -24,9 +24,9 @@ type cmdCredentialSuite struct {
 }
 
 func (s *cmdCredentialSuite) run(c *gc.C, args ...string) *cmd.Context {
-	context := testing.Context(c)
+	context := cmdtesting.Context(c)
 	command := commands.NewJujuCommand(context)
-	c.Assert(testing.InitCommand(command, args), jc.ErrorIsNil)
+	c.Assert(cmdtesting.InitCommand(command, args), jc.ErrorIsNil)
 	c.Assert(command.Run(context), jc.ErrorIsNil)
 	loggo.RemoveWriter("warning")
 	return context

--- a/featuretests/cmd_juju_crossmodel_test.go
+++ b/featuretests/cmd_juju_crossmodel_test.go
@@ -16,6 +16,7 @@ import (
 	"gopkg.in/juju/charmrepo.v2-unstable"
 	"gopkg.in/juju/names.v2"
 
+	"github.com/juju/juju/cmd/cmdtesting"
 	"github.com/juju/juju/cmd/juju/commands"
 	"github.com/juju/juju/cmd/juju/crossmodel"
 	"github.com/juju/juju/cmd/juju/model"
@@ -24,7 +25,6 @@ import (
 	"github.com/juju/juju/permission"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/testcharms"
-	"github.com/juju/juju/testing"
 	"github.com/juju/juju/testing/factory"
 )
 
@@ -38,13 +38,13 @@ func (s *crossmodelSuite) TestListEndpoints(c *gc.C) {
 	ch = s.AddTestingCharm(c, "varnish")
 	s.AddTestingService(c, "varnishservice", ch)
 
-	_, err := testing.RunCommand(c, crossmodel.NewOfferCommand(), "riakservice:endpoint", "riak")
+	_, err := cmdtesting.RunCommand(c, crossmodel.NewOfferCommand(), "riakservice:endpoint", "riak")
 	c.Assert(err, jc.ErrorIsNil)
-	_, err = testing.RunCommand(c, crossmodel.NewOfferCommand(), "varnishservice:webcache", "varnish")
+	_, err = cmdtesting.RunCommand(c, crossmodel.NewOfferCommand(), "varnishservice:webcache", "varnish")
 	c.Assert(err, jc.ErrorIsNil)
 
 	// TODO(wallyworld) - list with filters when supported
-	ctx, err := testing.RunCommand(c, crossmodel.NewListEndpointsCommand(),
+	ctx, err := cmdtesting.RunCommand(c, crossmodel.NewListEndpointsCommand(),
 		"--format", "yaml")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(ctx.Stdout.(*bytes.Buffer).String(), gc.Equals, `
@@ -73,15 +73,15 @@ func (s *crossmodelSuite) TestShow(c *gc.C) {
 	ch = s.AddTestingCharm(c, "varnish")
 	s.AddTestingService(c, "varnishservice", ch)
 
-	_, err := testing.RunCommand(c, crossmodel.NewOfferCommand(),
+	_, err := cmdtesting.RunCommand(c, crossmodel.NewOfferCommand(),
 		"riakservice:endpoint", "riak")
 	c.Assert(err, jc.ErrorIsNil)
-	_, err = testing.RunCommand(c, crossmodel.NewOfferCommand(),
+	_, err = cmdtesting.RunCommand(c, crossmodel.NewOfferCommand(),
 		"varnishservice:webcache", "varnish")
 	c.Assert(err, jc.ErrorIsNil)
 
 	// TODO(wallyworld) - list with filters when supported
-	ctx, err := testing.RunCommand(c, crossmodel.NewShowOfferedEndpointCommand(),
+	ctx, err := cmdtesting.RunCommand(c, crossmodel.NewShowOfferedEndpointCommand(),
 		"admin/controller.varnish", "--format", "yaml")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(ctx.Stdout.(*bytes.Buffer).String(), gc.Equals, `
@@ -98,7 +98,7 @@ admin/controller.varnish:
 func (s *crossmodelSuite) TestShowOtherModel(c *gc.C) {
 	s.addOtherModelApplication(c)
 
-	ctx, err := testing.RunCommand(c, crossmodel.NewShowOfferedEndpointCommand(),
+	ctx, err := cmdtesting.RunCommand(c, crossmodel.NewShowOfferedEndpointCommand(),
 		"otheruser/othermodel.hosted-mysql", "--format", "yaml")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(ctx.Stdout.(*bytes.Buffer).String(), gc.Equals, `
@@ -117,16 +117,16 @@ func (s *crossmodelSuite) setupOffers(c *gc.C) {
 	ch = s.AddTestingCharm(c, "varnish")
 	s.AddTestingService(c, "varnishservice", ch)
 
-	_, err := testing.RunCommand(c, crossmodel.NewOfferCommand(),
+	_, err := cmdtesting.RunCommand(c, crossmodel.NewOfferCommand(),
 		"riakservice:endpoint", "riak")
 	c.Assert(err, jc.ErrorIsNil)
-	_, err = testing.RunCommand(c, crossmodel.NewOfferCommand(),
+	_, err = cmdtesting.RunCommand(c, crossmodel.NewOfferCommand(),
 		"varnishservice:webcache", "varnish")
 	c.Assert(err, jc.ErrorIsNil)
 }
 func (s *crossmodelSuite) TestFind(c *gc.C) {
 	s.setupOffers(c)
-	ctx, err := testing.RunCommand(c, crossmodel.NewFindEndpointsCommand(),
+	ctx, err := cmdtesting.RunCommand(c, crossmodel.NewFindEndpointsCommand(),
 		"admin/controller", "--format", "yaml")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(ctx.Stdout.(*bytes.Buffer).String(), gc.Equals, `
@@ -148,7 +148,7 @@ admin/controller.varnish:
 func (s *crossmodelSuite) TestFindOtherModel(c *gc.C) {
 	s.addOtherModelApplication(c)
 
-	ctx, err := testing.RunCommand(c, crossmodel.NewFindEndpointsCommand(),
+	ctx, err := cmdtesting.RunCommand(c, crossmodel.NewFindEndpointsCommand(),
 		"otheruser/othermodel", "--format", "yaml")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(ctx.Stdout.(*bytes.Buffer).String(), gc.Equals, `
@@ -165,7 +165,7 @@ func (s *crossmodelSuite) TestFindAllModels(c *gc.C) {
 	s.setupOffers(c)
 	s.addOtherModelApplication(c)
 
-	ctx, err := testing.RunCommand(c, crossmodel.NewFindEndpointsCommand(), "kontroll:", "--format", "yaml")
+	ctx, err := cmdtesting.RunCommand(c, crossmodel.NewFindEndpointsCommand(), "kontroll:", "--format", "yaml")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(ctx.Stdout.(*bytes.Buffer).String(), gc.Equals, `
 admin/controller.riak:
@@ -197,7 +197,7 @@ func (s *crossmodelSuite) TestAddRelationFromURL(c *gc.C) {
 	ch = s.AddTestingCharm(c, "mysql")
 	s.AddTestingService(c, "mysql", ch)
 
-	_, err := testing.RunCommand(c, crossmodel.NewOfferCommand(),
+	_, err := cmdtesting.RunCommand(c, crossmodel.NewOfferCommand(),
 		"mysql:server", "me/model.hosted-mysql")
 	c.Assert(err, jc.ErrorIsNil)
 	_, err = runJujuCommand(c, "add-relation", "wordpress", "me/model.hosted-mysql")
@@ -320,12 +320,12 @@ func (s *crossmodelSuite) addOtherModelApplication(c *gc.C) *state.State {
 }
 
 func (s *crossmodelSuite) runJujuCommndWithStdin(c *gc.C, stdin io.Reader, args ...string) {
-	context := testing.Context(c)
+	context := cmdtesting.Context(c)
 	if stdin != nil {
 		context.Stdin = stdin
 	}
 	command := commands.NewJujuCommand(context)
-	c.Assert(testing.InitCommand(command, args), jc.ErrorIsNil)
+	c.Assert(cmdtesting.InitCommand(command, args), jc.ErrorIsNil)
 	loggo.RemoveWriter("warning") // remove logger added by main command
 	err := command.Run(context)
 	c.Assert(err, jc.ErrorIsNil, gc.Commentf("stdout: %q; stderr: %q", context.Stdout, context.Stderr))
@@ -363,7 +363,7 @@ func (s *crossmodelSuite) TestAddRelationSameControllerPermissionDenied(c *gc.C)
 	s.loginTestUser(c)
 	context, err := runJujuCommand(c, "add-relation", "-m", "admin/controller", "wordpress", "otheruser/othermodel.hosted-mysql")
 	c.Assert(err, gc.NotNil)
-	c.Assert(testing.Stderr(context), jc.Contains, "You do not have permission to add a relation")
+	c.Assert(cmdtesting.Stderr(context), jc.Contains, "You do not have permission to add a relation")
 }
 
 func (s *crossmodelSuite) TestAddRelationSameControllerPermissionAllowed(c *gc.C) {
@@ -385,16 +385,16 @@ func (s *crossmodelSuite) TestFindOffersWithPermission(c *gc.C) {
 	s.addOtherModelApplication(c)
 	s.createTestUser(c)
 	s.loginTestUser(c)
-	ctx, err := testing.RunCommand(c, crossmodel.NewFindEndpointsCommand(),
+	ctx, err := cmdtesting.RunCommand(c, crossmodel.NewFindEndpointsCommand(),
 		"otheruser/othermodel", "--format", "yaml")
 	c.Assert(err, gc.ErrorMatches, ".*no matching application offers found.*")
 
 	s.loginAdminUser(c)
-	_, err = testing.RunCommand(c, model.NewGrantCommand(), "test", "read", "otheruser/othermodel.hosted-mysql")
+	_, err = cmdtesting.RunCommand(c, model.NewGrantCommand(), "test", "read", "otheruser/othermodel.hosted-mysql")
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.loginTestUser(c)
-	ctx, err = testing.RunCommand(c, crossmodel.NewFindEndpointsCommand(),
+	ctx, err = cmdtesting.RunCommand(c, crossmodel.NewFindEndpointsCommand(),
 		"otheruser/othermodel", "--format", "yaml")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(ctx.Stdout.(*bytes.Buffer).String(), gc.Equals, `
@@ -411,7 +411,7 @@ func (s *crossmodelSuite) assertOfferGrant(c *gc.C) {
 	ch := s.AddTestingCharm(c, "riak")
 	s.AddTestingService(c, "riakservice", ch)
 
-	_, err := testing.RunCommand(c, crossmodel.NewOfferCommand(), "riakservice:endpoint", "riak")
+	_, err := cmdtesting.RunCommand(c, crossmodel.NewOfferCommand(), "riakservice:endpoint", "riak")
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Check the default access levels.
@@ -426,7 +426,7 @@ func (s *crossmodelSuite) assertOfferGrant(c *gc.C) {
 
 	// Grant consume access.
 	s.Factory.MakeUser(c, &factory.UserParams{Name: "bob"})
-	_, err = testing.RunCommand(c, model.NewGrantCommand(), "bob", "consume", "admin/controller.riak")
+	_, err = cmdtesting.RunCommand(c, model.NewGrantCommand(), "bob", "consume", "admin/controller.riak")
 	c.Assert(err, jc.ErrorIsNil)
 	access, err = s.State.GetOfferAccess(offerTag, names.NewUserTag("bob"))
 	c.Assert(err, jc.ErrorIsNil)
@@ -443,7 +443,7 @@ func (s *crossmodelSuite) TestOfferRevoke(c *gc.C) {
 	offerTag := names.NewApplicationOfferTag("riak")
 
 	// Revoke consume access.
-	_, err := testing.RunCommand(c, model.NewRevokeCommand(), "bob", "consume", "admin/controller.riak")
+	_, err := cmdtesting.RunCommand(c, model.NewRevokeCommand(), "bob", "consume", "admin/controller.riak")
 	c.Assert(err, jc.ErrorIsNil)
 	access, err := s.State.GetOfferAccess(offerTag, names.NewUserTag("bob"))
 	c.Assert(err, jc.ErrorIsNil)

--- a/featuretests/cmd_juju_dumplogs_test.go
+++ b/featuretests/cmd_juju_dumplogs_test.go
@@ -15,10 +15,10 @@ import (
 	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/agent"
+	"github.com/juju/juju/cmd/cmdtesting"
 	"github.com/juju/juju/cmd/jujud/agent/agenttest"
 	"github.com/juju/juju/cmd/jujud/dumplogs"
 	"github.com/juju/juju/state"
-	"github.com/juju/juju/testing"
 	"github.com/juju/juju/testing/factory"
 	"github.com/juju/juju/version"
 )
@@ -61,7 +61,7 @@ func (s *dumpLogsCommandSuite) TestRun(c *gc.C) {
 
 	// Run the juju-dumplogs command
 	command := dumplogs.NewCommand()
-	context, err := testing.RunCommand(c, command, "--data-dir", s.DataDir())
+	context, err := cmdtesting.RunCommand(c, command, "--data-dir", s.DataDir())
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Check the log file for each environment

--- a/featuretests/cmd_juju_login_test.go
+++ b/featuretests/cmd_juju_login_test.go
@@ -13,11 +13,11 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/cmd/cmdtesting"
 	"github.com/juju/juju/cmd/juju/commands"
 	"github.com/juju/juju/juju/osenv"
 	jujutesting "github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/jujuclient"
-	"github.com/juju/juju/testing"
 )
 
 type cmdLoginSuite struct {
@@ -30,12 +30,12 @@ func (s *cmdLoginSuite) SetUpTest(c *gc.C) {
 }
 
 func (s *cmdLoginSuite) run(c *gc.C, stdin io.Reader, args ...string) *cmd.Context {
-	context := testing.Context(c)
+	context := cmdtesting.Context(c)
 	if stdin != nil {
 		context.Stdin = stdin
 	}
 	command := commands.NewJujuCommand(context)
-	c.Assert(testing.InitCommand(command, args), jc.ErrorIsNil)
+	c.Assert(cmdtesting.InitCommand(command, args), jc.ErrorIsNil)
 	err := command.Run(context)
 	c.Assert(err, jc.ErrorIsNil, gc.Commentf("stdout: %q; stderr: %q", context.Stdout, context.Stderr))
 	loggo.RemoveWriter("warning") // remove logger added by main command
@@ -61,8 +61,8 @@ func (s *cmdLoginSuite) TestLoginCommand(c *gc.C) {
 	s.run(c, nil, "logout")
 
 	context := s.run(c, strings.NewReader("hunter2\nhunter2\n"), "login", "-u", "test")
-	c.Assert(testing.Stdout(context), gc.Equals, "")
-	c.Assert(testing.Stderr(context), gc.Equals, `
+	c.Assert(cmdtesting.Stdout(context), gc.Equals, "")
+	c.Assert(cmdtesting.Stderr(context), gc.Equals, `
 please enter password for test on kontroll: 
 Welcome, test. You are now logged into "kontroll".
 

--- a/featuretests/cmd_juju_metrics.go
+++ b/featuretests/cmd_juju_metrics.go
@@ -7,14 +7,13 @@ import (
 	"time"
 
 	"github.com/gosuri/uitable"
-	"github.com/juju/cmd/cmdtesting"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/cmd/cmdtesting"
 	"github.com/juju/juju/cmd/juju/metricsdebug"
 	jujutesting "github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/state"
-	coretesting "github.com/juju/juju/testing"
 	"github.com/juju/juju/testing/factory"
 )
 
@@ -25,7 +24,7 @@ type cmdMetricsCommandSuite struct {
 var _ = gc.Suite(&cmdMetricsCommandSuite{})
 
 func (s *cmdMetricsCommandSuite) TestDebugNoArgs(c *gc.C) {
-	_, err := coretesting.RunCommand(c, metricsdebug.New())
+	_, err := cmdtesting.RunCommand(c, metricsdebug.New())
 	c.Assert(err, gc.ErrorMatches, "you need to specify at least one unit or application")
 }
 
@@ -61,7 +60,7 @@ func (s *cmdMetricsCommandSuite) TestUnits(c *gc.C) {
 	metricB := state.Metric{"pings", "10.5", newTime2}
 	s.Factory.MakeMetric(c, &factory.MetricParams{Unit: unit, Metrics: []state.Metric{metricA}})
 	s.Factory.MakeMetric(c, &factory.MetricParams{Unit: unit2, Metrics: []state.Metric{metricA, metricB}})
-	ctx, err := coretesting.RunCommand(c, metricsdebug.New(), "metered/1")
+	ctx, err := cmdtesting.RunCommand(c, metricsdebug.New(), "metered/1")
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Assert(cmdtesting.Stdout(ctx), gc.Equals,
@@ -72,7 +71,7 @@ func (s *cmdMetricsCommandSuite) TestUnits(c *gc.C) {
 			Value:     "10.5",
 		}),
 	)
-	ctx, err = coretesting.RunCommand(c, metricsdebug.New(), "metered/0")
+	ctx, err = cmdtesting.RunCommand(c, metricsdebug.New(), "metered/0")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cmdtesting.Stdout(ctx), gc.Equals,
 		formatTabular(metric{
@@ -95,7 +94,7 @@ func (s *cmdMetricsCommandSuite) TestAll(c *gc.C) {
 	metricB := state.Metric{"pings", "10.5", newTime2}
 	s.Factory.MakeMetric(c, &factory.MetricParams{Unit: unit, Metrics: []state.Metric{metricA}})
 	s.Factory.MakeMetric(c, &factory.MetricParams{Unit: unit2, Metrics: []state.Metric{metricA, metricB}})
-	ctx, err := coretesting.RunCommand(c, metricsdebug.New(), "--all")
+	ctx, err := cmdtesting.RunCommand(c, metricsdebug.New(), "--all")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cmdtesting.Stdout(ctx), gc.Equals,
 		formatTabular([]metric{{
@@ -123,7 +122,7 @@ func (s *cmdMetricsCommandSuite) TestFormatJSON(c *gc.C) {
 	metricB := state.Metric{"pings", "10.5", newTime2}
 	s.Factory.MakeMetric(c, &factory.MetricParams{Unit: unit, Metrics: []state.Metric{metricA}})
 	s.Factory.MakeMetric(c, &factory.MetricParams{Unit: unit2, Metrics: []state.Metric{metricA, metricB}})
-	ctx, err := coretesting.RunCommand(c, metricsdebug.New(), "metered/1", "--format", "json")
+	ctx, err := cmdtesting.RunCommand(c, metricsdebug.New(), "metered/1", "--format", "json")
 	c.Assert(err, jc.ErrorIsNil)
 	expectedOutput := []metric{{
 		Unit:      unit2.Name(),
@@ -145,7 +144,7 @@ func (s *cmdMetricsCommandSuite) TestFormatYAML(c *gc.C) {
 	metricB := state.Metric{"pings", "10.5", newTime2}
 	s.Factory.MakeMetric(c, &factory.MetricParams{Unit: unit, Metrics: []state.Metric{metricA}})
 	s.Factory.MakeMetric(c, &factory.MetricParams{Unit: unit2, Metrics: []state.Metric{metricA, metricB}})
-	ctx, err := coretesting.RunCommand(c, metricsdebug.New(), "metered/1", "--format", "yaml")
+	ctx, err := cmdtesting.RunCommand(c, metricsdebug.New(), "metered/1", "--format", "yaml")
 	c.Assert(err, jc.ErrorIsNil)
 	expectedOutput := []metric{{
 		Unit:      unit2.Name(),
@@ -160,7 +159,7 @@ func (s *cmdMetricsCommandSuite) TestNoMetrics(c *gc.C) {
 	meteredCharm := s.Factory.MakeCharm(c, &factory.CharmParams{Name: "metered", URL: "local:quantal/metered-1"})
 	meteredService := s.Factory.MakeApplication(c, &factory.ApplicationParams{Charm: meteredCharm})
 	s.Factory.MakeUnit(c, &factory.UnitParams{Application: meteredService, SetCharmURL: true})
-	ctx, err := coretesting.RunCommand(c, metricsdebug.New(), "metered")
+	ctx, err := cmdtesting.RunCommand(c, metricsdebug.New(), "metered")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, "")
 }

--- a/featuretests/cmd_juju_model_test.go
+++ b/featuretests/cmd_juju_model_test.go
@@ -15,6 +15,7 @@ import (
 	"gopkg.in/juju/names.v2"
 	"gopkg.in/yaml.v2"
 
+	"github.com/juju/juju/cmd/cmdtesting"
 	"github.com/juju/juju/cmd/juju/commands"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/config"
@@ -22,7 +23,6 @@ import (
 	jujutesting "github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/permission"
 	"github.com/juju/juju/state"
-	"github.com/juju/juju/testing"
 	"github.com/juju/juju/testing/factory"
 )
 
@@ -35,9 +35,9 @@ func (s *cmdModelSuite) SetUpTest(c *gc.C) {
 }
 
 func (s *cmdModelSuite) run(c *gc.C, args ...string) *cmd.Context {
-	context := testing.Context(c)
+	context := cmdtesting.Context(c)
 	jujuCmd := commands.NewJujuCommand(context)
-	err := testing.InitCommand(jujuCmd, args)
+	err := cmdtesting.InitCommand(jujuCmd, args)
 	c.Assert(err, jc.ErrorIsNil)
 	err = jujuCmd.Run(context)
 	c.Assert(err, jc.ErrorIsNil)
@@ -47,7 +47,7 @@ func (s *cmdModelSuite) run(c *gc.C, args ...string) *cmd.Context {
 func (s *cmdModelSuite) TestGrantModelCmdStack(c *gc.C) {
 	username := "bar@ubuntuone"
 	context := s.run(c, "grant", username, "read", "controller")
-	obtained := strings.Replace(testing.Stdout(context), "\n", "", -1)
+	obtained := strings.Replace(cmdtesting.Stdout(context), "\n", "", -1)
 	expected := ""
 	c.Assert(obtained, gc.Equals, expected)
 
@@ -74,7 +74,7 @@ func (s *cmdModelSuite) TestRevokeModelCmdStack(c *gc.C) {
 
 	// Then test that the unshare command stack is hooked up
 	context := s.run(c, "revoke", username, "read", "controller")
-	obtained := strings.Replace(testing.Stdout(context), "\n", "", -1)
+	obtained := strings.Replace(cmdtesting.Stdout(context), "\n", "", -1)
 	expected := ""
 	c.Assert(obtained, gc.Equals, expected)
 
@@ -100,7 +100,7 @@ func (s *cmdModelSuite) TestModelUsersCmd(c *gc.C) {
 
 	context = s.run(c, "list-users", "controller")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(testing.Stdout(context), gc.Equals, ""+
+	c.Assert(cmdtesting.Stdout(context), gc.Equals, ""+
 		"Name           Display name  Access  Last connection\n"+
 		"admin*         admin         admin   just now\n"+
 		"bar@ubuntuone                read    never connected\n"+
@@ -113,7 +113,7 @@ func (s *cmdModelSuite) TestModelConfigGet(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	context := s.run(c, "model-config", "special")
-	c.Assert(testing.Stdout(context), gc.Equals, "known\n")
+	c.Assert(cmdtesting.Stdout(context), gc.Equals, "known\n")
 }
 
 func (s *cmdModelSuite) TestModelConfigSet(c *gc.C) {
@@ -134,7 +134,7 @@ func (s *cmdModelSuite) TestModelDefaultsGet(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	context := s.run(c, "model-defaults", "special")
-	c.Assert(testing.Stdout(context), gc.Equals, `
+	c.Assert(cmdtesting.Stdout(context), gc.Equals, `
 Attribute  Default  Controller
 special    -        known
 
@@ -146,7 +146,7 @@ func (s *cmdModelSuite) TestModelDefaultsGetRegion(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	context := s.run(c, "model-defaults", "dummy-region", "special")
-	c.Assert(testing.Stdout(context), gc.Equals, `
+	c.Assert(cmdtesting.Stdout(context), gc.Equals, `
 Attribute       Default  Controller
 special         -        -
   dummy-region  known    -
@@ -200,7 +200,7 @@ func (s *cmdModelSuite) TestRetryProvisioning(c *gc.C) {
 		Jobs: []state.MachineJob{state.JobManageModel},
 	})
 	ctx := s.run(c, "retry-provisioning", "0")
-	output := testing.Stderr(ctx)
+	output := cmdtesting.Stderr(ctx)
 	stripped := strings.Replace(output, "\n", "", -1)
 	c.Check(stripped, gc.Equals, `machine 0 is not in an error state`)
 }
@@ -211,7 +211,7 @@ func (s *cmdModelSuite) TestDumpModel(c *gc.C) {
 		Jobs: []state.MachineJob{state.JobManageModel},
 	})
 	ctx := s.run(c, "dump-model")
-	output := testing.Stdout(ctx)
+	output := cmdtesting.Stdout(ctx)
 	// The output is yaml formatted output that is a model description.
 	model, err := description.Deserialize([]byte(output))
 	c.Assert(err, jc.ErrorIsNil)
@@ -224,7 +224,7 @@ func (s *cmdModelSuite) TestDumpModelDB(c *gc.C) {
 		Jobs: []state.MachineJob{state.JobManageModel},
 	})
 	ctx := s.run(c, "dump-db")
-	output := testing.Stdout(ctx)
+	output := cmdtesting.Stdout(ctx)
 	// The output is map of collection names to documents.
 	// Defaults to yaml output.
 	var valueMap map[string]interface{}

--- a/featuretests/cmd_juju_register_test.go
+++ b/featuretests/cmd_juju_register_test.go
@@ -15,11 +15,10 @@ import (
 	"gopkg.in/macaroon-bakery.v1/httpbakery"
 
 	"github.com/juju/juju/api"
+	"github.com/juju/juju/cmd/cmdtesting"
 	"github.com/juju/juju/cmd/juju/commands"
-	cmdtesting "github.com/juju/juju/cmd/testing"
 	"github.com/juju/juju/juju"
 	jujutesting "github.com/juju/juju/juju/testing"
-	"github.com/juju/juju/testing"
 )
 
 type cmdRegistrationSuite struct {
@@ -31,8 +30,8 @@ func (s *cmdRegistrationSuite) TestAddUserAndRegister(c *gc.C) {
 	// that is printed out.
 
 	context := run(c, nil, "add-user", "bob", "Bob Dobbs")
-	c.Check(testing.Stderr(context), gc.Equals, "")
-	stdout := testing.Stdout(context)
+	c.Check(cmdtesting.Stderr(context), gc.Equals, "")
+	stdout := cmdtesting.Stdout(context)
 	expectPat := `
 User "Bob Dobbs \(bob\)" added
 Please send this command to bob:
@@ -95,7 +94,7 @@ There are no models available. (.|\n)*
 
 // run runs a juju command with the given arguments.
 // If stdio is given, it will be used for all input and output
-// to the command; otherwise testing.Context will be used.
+// to the command; otherwise cmdtesting.Context will be used.
 //
 // It returns the context used to run the command.
 func run(c *gc.C, stdio io.ReadWriter, args ...string) *cmd.Context {
@@ -108,10 +107,10 @@ func run(c *gc.C, stdio io.ReadWriter, args ...string) *cmd.Context {
 			Stderr: stdio,
 		}
 	} else {
-		context = testing.Context(c)
+		context = cmdtesting.Context(c)
 	}
 	command := commands.NewJujuCommand(context)
-	c.Assert(testing.InitCommand(command, args), jc.ErrorIsNil)
+	c.Assert(cmdtesting.InitCommand(command, args), jc.ErrorIsNil)
 	err := command.Run(context)
 	c.Assert(err, jc.ErrorIsNil, gc.Commentf("stderr: %q", context.Stderr))
 	loggo.RemoveWriter("warning") // remove logger added by main command

--- a/featuretests/cmd_juju_space_test.go
+++ b/featuretests/cmd_juju_space_test.go
@@ -11,11 +11,11 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/cmd/cmdtesting"
 	jujutesting "github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/provider/dummy"
 	"github.com/juju/juju/state"
-	"github.com/juju/juju/testing"
 )
 
 type cmdSpaceSuite struct {
@@ -68,8 +68,8 @@ func (s *cmdSpaceSuite) Run(c *gc.C, args ...string) (string, string, error) {
 	context, err := runJujuCommand(c, args...)
 	stdout, stderr := "", ""
 	if context != nil {
-		stdout = testing.Stdout(context)
-		stderr = testing.Stderr(context)
+		stdout = cmdtesting.Stdout(context)
+		stderr = cmdtesting.Stderr(context)
 	}
 	return stdout, stderr, err
 }
@@ -97,8 +97,8 @@ func (s *cmdSpaceSuite) RunList(c *gc.C, expectedError string, args ...string) {
 }
 
 func (s *cmdSpaceSuite) AssertOutput(c *gc.C, context *cmd.Context, expectedOut, expectedErr string) {
-	c.Assert(testing.Stdout(context), gc.Equals, expectedOut)
-	c.Assert(testing.Stderr(context), gc.Equals, expectedErr)
+	c.Assert(cmdtesting.Stdout(context), gc.Equals, expectedOut)
+	c.Assert(cmdtesting.Stderr(context), gc.Equals, expectedErr)
 }
 
 func (s *cmdSpaceSuite) TestSpaceCreateNotSupported(c *gc.C) {

--- a/featuretests/cmd_juju_subnet_test.go
+++ b/featuretests/cmd_juju_subnet_test.go
@@ -8,10 +8,10 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/cmd/cmdtesting"
 	jujutesting "github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/state"
-	"github.com/juju/juju/testing"
 )
 
 type cmdSubnetSuite struct {
@@ -50,8 +50,8 @@ func (s *cmdSubnetSuite) RunAdd(c *gc.C, expectedError string, args ...string) (
 	ctx, err := runJujuCommand(c, cmdArgs...)
 	stdout, stderr := "", ""
 	if ctx != nil {
-		stdout = testing.Stdout(ctx)
-		stderr = testing.Stderr(ctx)
+		stdout = cmdtesting.Stdout(ctx)
+		stderr = cmdtesting.Stderr(ctx)
 	}
 	if expectedError != "" {
 		c.Assert(err, gc.NotNil)
@@ -61,8 +61,8 @@ func (s *cmdSubnetSuite) RunAdd(c *gc.C, expectedError string, args ...string) (
 }
 
 func (s *cmdSubnetSuite) AssertOutput(c *gc.C, context *cmd.Context, expectedOut, expectedErr string) {
-	c.Assert(testing.Stdout(context), gc.Equals, expectedOut)
-	c.Assert(testing.Stderr(context), gc.Equals, expectedErr)
+	c.Assert(cmdtesting.Stdout(context), gc.Equals, expectedOut)
+	c.Assert(cmdtesting.Stderr(context), gc.Equals, expectedErr)
 }
 
 func (s *cmdSubnetSuite) TestSubnetAddNoArguments(c *gc.C) {
@@ -169,8 +169,8 @@ func (s *cmdSubnetSuite) TestSubnetListResultsWithFilters(c *gc.C) {
 		expectedSuccess,
 		"subnets", "--zone", "zone1", "--space", "myspace",
 	)
-	c.Assert(testing.Stderr(context), gc.Equals, "") // no stderr expected
-	stdout := testing.Stdout(context)
+	c.Assert(cmdtesting.Stderr(context), gc.Equals, "") // no stderr expected
+	stdout := cmdtesting.Stdout(context)
 	c.Assert(stdout, jc.Contains, "subnets:")
 	c.Assert(stdout, jc.Contains, "10.10.0.0/16:")
 	c.Assert(stdout, jc.Contains, "space: myspace")

--- a/featuretests/cmd_juju_user_test.go
+++ b/featuretests/cmd_juju_user_test.go
@@ -12,9 +12,9 @@ import (
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/names.v2"
 
+	"github.com/juju/juju/cmd/cmdtesting"
 	"github.com/juju/juju/cmd/juju/commands"
 	jujutesting "github.com/juju/juju/juju/testing"
-	"github.com/juju/juju/testing"
 	"github.com/juju/juju/testing/factory"
 )
 
@@ -29,12 +29,12 @@ type UserSuite struct {
 var _ = gc.Suite(&UserSuite{})
 
 func (s *UserSuite) RunUserCommand(c *gc.C, stdin string, args ...string) (*cmd.Context, error) {
-	context := testing.Context(c)
+	context := cmdtesting.Context(c)
 	if stdin != "" {
 		context.Stdin = strings.NewReader(stdin)
 	}
 	jujuCmd := commands.NewJujuCommand(context)
-	err := testing.InitCommand(jujuCmd, args)
+	err := cmdtesting.InitCommand(jujuCmd, args)
 	c.Assert(err, jc.ErrorIsNil)
 	err = jujuCmd.Run(context)
 	return context, err
@@ -43,7 +43,7 @@ func (s *UserSuite) RunUserCommand(c *gc.C, stdin string, args ...string) (*cmd.
 func (s *UserSuite) TestUserAdd(c *gc.C) {
 	ctx, err := s.RunUserCommand(c, "", "add-user", "test")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(testing.Stdout(ctx), jc.HasPrefix, `User "test" added`)
+	c.Assert(cmdtesting.Stdout(ctx), jc.HasPrefix, `User "test" added`)
 	user, err := s.State.User(names.NewLocalUserTag("test"))
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(user.IsDisabled(), jc.IsFalse)
@@ -67,7 +67,7 @@ func (s *UserSuite) TestUserInfo(c *gc.C) {
 	c.Assert(user.PasswordValid("dummy-secret"), jc.IsTrue)
 	ctx, err := s.RunUserCommand(c, "", "show-user")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(testing.Stdout(ctx), jc.Contains, "user-name: admin")
+	c.Assert(cmdtesting.Stdout(ctx), jc.Contains, "user-name: admin")
 }
 
 func (s *UserSuite) TestUserDisable(c *gc.C) {
@@ -100,7 +100,7 @@ user please use the`[1:] + " `juju disable-user` " + `command. See
 Continue (y/N)? `
 	_ = s.Factory.MakeUser(c, &factory.UserParams{Name: "jjam"})
 	ctx, _ := s.RunUserCommand(c, "", "remove-user", "jjam")
-	c.Assert(testing.Stdout(ctx), jc.DeepEquals, expected)
+	c.Assert(cmdtesting.Stdout(ctx), jc.DeepEquals, expected)
 }
 
 func (s *UserSuite) TestRemoveUser(c *gc.C) {
@@ -132,5 +132,5 @@ Name\s+Display name\s+Access\s+Date created\s+Last connection
 admin.*\s+admin\s+superuser\s+%s\s+%s
 
 `[1:], periodPattern, periodPattern)
-	c.Assert(testing.Stdout(ctx), gc.Matches, expected)
+	c.Assert(cmdtesting.Stdout(ctx), gc.Matches, expected)
 }

--- a/featuretests/cmdjuju_test.go
+++ b/featuretests/cmdjuju_test.go
@@ -8,13 +8,13 @@ import (
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/charm.v6-unstable"
 
+	"github.com/juju/juju/cmd/cmdtesting"
 	"github.com/juju/juju/cmd/juju/application"
 	"github.com/juju/juju/cmd/juju/model"
 	"github.com/juju/juju/constraints"
 	"github.com/juju/juju/instance"
 	jujutesting "github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/state"
-	"github.com/juju/juju/testing"
 )
 
 // cmdJujuSuite tests the connectivity of juju commands.  These tests
@@ -30,7 +30,7 @@ func uint64p(val uint64) *uint64 {
 }
 
 func (s *cmdJujuSuite) TestSetConstraints(c *gc.C) {
-	_, err := testing.RunCommand(c, model.NewModelSetConstraintsCommand(), "mem=4G", "cpu-power=250")
+	_, err := cmdtesting.RunCommand(c, model.NewModelSetConstraintsCommand(), "mem=4G", "cpu-power=250")
 	c.Assert(err, jc.ErrorIsNil)
 
 	cons, err := s.State.ModelConstraints()
@@ -46,16 +46,16 @@ func (s *cmdJujuSuite) TestGetConstraints(c *gc.C) {
 	err := svc.SetConstraints(constraints.Value{CpuCores: uint64p(64)})
 	c.Assert(err, jc.ErrorIsNil)
 
-	context, err := testing.RunCommand(c, application.NewServiceGetConstraintsCommand(), "svc")
-	c.Assert(testing.Stdout(context), gc.Equals, "cores=64\n")
-	c.Assert(testing.Stderr(context), gc.Equals, "")
+	context, err := cmdtesting.RunCommand(c, application.NewServiceGetConstraintsCommand(), "svc")
+	c.Assert(cmdtesting.Stdout(context), gc.Equals, "cores=64\n")
+	c.Assert(cmdtesting.Stderr(context), gc.Equals, "")
 }
 
 func (s *cmdJujuSuite) TestServiceSet(c *gc.C) {
 	ch := s.AddTestingCharm(c, "dummy")
 	svc := s.AddTestingService(c, "dummy-service", ch)
 
-	_, err := testing.RunCommand(c, application.NewConfigCommand(), "dummy-service",
+	_, err := cmdtesting.RunCommand(c, application.NewConfigCommand(), "dummy-service",
 		"username=hello", "outlook=hello@world.tld")
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -81,7 +81,7 @@ func (s *cmdJujuSuite) TestServiceUnset(c *gc.C) {
 	err := svc.UpdateConfigSettings(settings)
 	c.Assert(err, jc.ErrorIsNil)
 
-	_, err = testing.RunCommand(c, application.NewConfigCommand(), "dummy-service", "--reset", "username")
+	_, err = cmdtesting.RunCommand(c, application.NewConfigCommand(), "dummy-service", "--reset", "username")
 	c.Assert(err, jc.ErrorIsNil)
 
 	expect := charm.Settings{
@@ -118,9 +118,9 @@ settings:
 	ch := s.AddTestingCharm(c, "dummy")
 	s.AddTestingService(c, "dummy-service", ch)
 
-	context, err := testing.RunCommand(c, application.NewConfigCommand(), "dummy-service")
+	context, err := cmdtesting.RunCommand(c, application.NewConfigCommand(), "dummy-service")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(testing.Stdout(context), jc.DeepEquals, expected)
+	c.Assert(cmdtesting.Stdout(context), jc.DeepEquals, expected)
 }
 
 func (s *cmdJujuSuite) TestServiceGetWeirdYAML(c *gc.C) {
@@ -152,9 +152,9 @@ settings:
 	ch := s.AddTestingCharm(c, "yaml-config")
 	s.AddTestingService(c, "yaml-config", ch)
 
-	context, err := testing.RunCommand(c, application.NewConfigCommand(), "yaml-config")
+	context, err := cmdtesting.RunCommand(c, application.NewConfigCommand(), "yaml-config")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(testing.Stdout(context), jc.DeepEquals, expected)
+	c.Assert(cmdtesting.Stdout(context), jc.DeepEquals, expected)
 }
 
 func (s *cmdJujuSuite) TestServiceAddUnitExistingContainer(c *gc.C) {
@@ -170,7 +170,7 @@ func (s *cmdJujuSuite) TestServiceAddUnitExistingContainer(c *gc.C) {
 	container, err := s.State.AddMachineInsideMachine(template, machine.Id(), instance.LXD)
 	c.Assert(err, jc.ErrorIsNil)
 
-	_, err = testing.RunCommand(c, application.NewAddUnitCommand(), "some-application-name",
+	_, err = cmdtesting.RunCommand(c, application.NewAddUnitCommand(), "some-application-name",
 		"--to", container.Id())
 	c.Assert(err, jc.ErrorIsNil)
 

--- a/featuretests/package_test.go
+++ b/featuretests/package_test.go
@@ -13,6 +13,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/cmd/cmdtesting"
 	jujucmd "github.com/juju/juju/cmd/juju/commands"
 	"github.com/juju/juju/component/all"
 	coretesting "github.com/juju/juju/testing"
@@ -72,9 +73,9 @@ func runCommand(c *gc.C, args ...string) (*cmd.Context, error) {
 	// return an error if we attempt to run two commands in the
 	// same test.
 	loggo.ResetWriters()
-	ctx := coretesting.Context(c)
+	ctx := cmdtesting.Context(c)
 	command := jujucmd.NewJujuCommand(ctx)
-	return coretesting.RunCommand(c, command, args...)
+	return cmdtesting.RunCommand(c, command, args...)
 }
 
 func runCommandExpectSuccess(c *gc.C, command string, args ...string) {
@@ -85,5 +86,5 @@ func runCommandExpectSuccess(c *gc.C, command string, args ...string) {
 func runCommandExpectFailure(c *gc.C, command, expectedError string, args ...string) {
 	context, err := runCommand(c, append([]string{command}, args...)...)
 	c.Assert(err, gc.ErrorMatches, "cmd: error out silently")
-	c.Assert(coretesting.Stderr(context), jc.Contains, expectedError)
+	c.Assert(cmdtesting.Stderr(context), jc.Contains, expectedError)
 }

--- a/featuretests/storage_test.go
+++ b/featuretests/storage_test.go
@@ -13,13 +13,13 @@ import (
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/names.v2"
 
+	"github.com/juju/juju/cmd/cmdtesting"
 	jujucmd "github.com/juju/juju/cmd/juju/commands"
 	jujutesting "github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/provider/dummy"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/storage/poolmanager"
 	"github.com/juju/juju/storage/provider"
-	"github.com/juju/juju/testing"
 )
 
 const (
@@ -67,7 +67,7 @@ func runShow(c *gc.C, expectedError string, args ...string) {
 		c.Assert(err, jc.ErrorIsNil)
 	} else {
 		c.Assert(err, gc.NotNil)
-		c.Assert(testing.Stderr(context), jc.Contains, expectedError)
+		c.Assert(cmdtesting.Stderr(context), jc.Contains, expectedError)
 	}
 }
 
@@ -98,7 +98,7 @@ data/0:
 `[1:]
 	context, err := runJujuCommand(c, "show-storage", "data/0")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(testing.Stdout(context), gc.Matches, expected)
+	c.Assert(cmdtesting.Stdout(context), gc.Matches, expected)
 }
 
 func (s *cmdStorageSuite) TestStorageShowOneInvalid(c *gc.C) {
@@ -116,7 +116,7 @@ func runList(c *gc.C, expectedOutput string, args ...string) {
 	cmdArgs := append([]string{"list-storage"}, args...)
 	context, err := runJujuCommand(c, cmdArgs...)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(testing.Stdout(context), gc.Equals, expectedOutput)
+	c.Assert(cmdtesting.Stdout(context), gc.Equals, expectedOutput)
 }
 
 func (s *cmdStorageSuite) TestStorageListEmpty(c *gc.C) {
@@ -176,7 +176,7 @@ data/0:
 `[1:]
 	context, err := runJujuCommand(c, "show-storage", "data/0")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(testing.Stdout(context), gc.Matches, expected)
+	c.Assert(cmdtesting.Stdout(context), gc.Matches, expected)
 }
 
 func (s *cmdStorageSuite) TestStoragePersistentUnprovisioned(c *gc.C) {
@@ -200,7 +200,7 @@ data/0:
 `[1:]
 	context, err := runJujuCommand(c, "show-storage", "data/0")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(testing.Stdout(context), gc.Matches, expected)
+	c.Assert(cmdtesting.Stdout(context), gc.Matches, expected)
 }
 
 func runJujuCommand(c *gc.C, args ...string) (*cmd.Context, error) {
@@ -212,7 +212,7 @@ func runJujuCommand(c *gc.C, args ...string) (*cmd.Context, error) {
 	ctx, err := cmd.DefaultContext()
 	c.Assert(err, jc.ErrorIsNil)
 	command := jujucmd.NewJujuCommand(ctx)
-	return testing.RunCommand(c, command, args...)
+	return cmdtesting.RunCommand(c, command, args...)
 }
 
 func runPoolList(c *gc.C, args ...string) (string, string, error) {
@@ -220,8 +220,8 @@ func runPoolList(c *gc.C, args ...string) (string, string, error) {
 	ctx, err := runJujuCommand(c, cmdArgs...)
 	stdout, stderr := "", ""
 	if ctx != nil {
-		stdout = testing.Stdout(ctx)
-		stderr = testing.Stderr(ctx)
+		stdout = cmdtesting.Stdout(ctx)
+		stderr = cmdtesting.Stderr(ctx)
 	}
 	return stdout, stderr, err
 }
@@ -362,8 +362,8 @@ func runPoolCreate(c *gc.C, args ...string) (string, string, error) {
 	ctx, err := runJujuCommand(c, cmdArgs...)
 	stdout, stderr := "", ""
 	if ctx != nil {
-		stdout = testing.Stdout(ctx)
-		stderr = testing.Stderr(ctx)
+		stdout = cmdtesting.Stdout(ctx)
+		stderr = cmdtesting.Stderr(ctx)
 	}
 	return stdout, stderr, err
 
@@ -435,7 +435,7 @@ func assertPoolExists(c *gc.C, st *state.State, pname, provider, attr string) {
 func runVolumeList(c *gc.C, args ...string) (string, string, error) {
 	cmdArgs := append([]string{"list-storage", "--volume"}, args...)
 	ctx, err := runJujuCommand(c, cmdArgs...)
-	return testing.Stdout(ctx), testing.Stderr(ctx), err
+	return cmdtesting.Stdout(ctx), cmdtesting.Stderr(ctx), err
 }
 
 func (s *cmdStorageSuite) TestListVolumeInvalidMachine(c *gc.C) {
@@ -472,8 +472,8 @@ func (s *cmdStorageSuite) TestStorageAddToUnitSuccess(c *gc.C) {
 
 	context, err := runAddToUnit(c, u, "allecto=1")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(testing.Stdout(context), gc.Equals, "added \"allecto\"\n")
-	c.Assert(testing.Stderr(context), gc.Equals, "")
+	c.Assert(cmdtesting.Stdout(context), gc.Equals, "added \"allecto\"\n")
+	c.Assert(cmdtesting.Stderr(context), gc.Equals, "")
 
 	instancesAfter, err := s.State.AllStorageInstances()
 	c.Assert(err, jc.ErrorIsNil)
@@ -498,23 +498,23 @@ func (s *cmdStorageSuite) assertStorageExist(c *gc.C,
 func (s *cmdStorageSuite) TestStorageAddToUnitUnitDoesntExist(c *gc.C) {
 	context, err := runAddToUnit(c, "fluffyunit/0", "allecto=1")
 	c.Assert(errors.Cause(err), gc.ErrorMatches, "cmd: error out silently")
-	c.Assert(testing.Stdout(context), gc.Equals, "")
-	c.Assert(testing.Stderr(context), gc.Equals, "failed to add \"allecto\": unit \"fluffyunit/0\" not found\n")
+	c.Assert(cmdtesting.Stdout(context), gc.Equals, "")
+	c.Assert(cmdtesting.Stderr(context), gc.Equals, "failed to add \"allecto\": unit \"fluffyunit/0\" not found\n")
 }
 
 func (s *cmdStorageSuite) TestStorageAddToUnitCollapseUnitErrors(c *gc.C) {
 	context, err := runAddToUnit(c, "fluffyunit/0", "allecto=1", "trial=1")
 	c.Assert(errors.Cause(err), gc.ErrorMatches, "cmd: error out silently")
-	c.Assert(testing.Stdout(context), gc.Equals, "")
-	c.Assert(testing.Stderr(context), gc.Equals, "unit \"fluffyunit/0\" not found\n")
+	c.Assert(cmdtesting.Stdout(context), gc.Equals, "")
+	c.Assert(cmdtesting.Stderr(context), gc.Equals, "unit \"fluffyunit/0\" not found\n")
 }
 
 func (s *cmdStorageSuite) TestStorageAddToUnitInvalidUnitName(c *gc.C) {
 	cmdArgs := append([]string{"add-storage"}, "fluffyunit-0", "allecto=1")
 	context, err := runJujuCommand(c, cmdArgs...)
 	c.Assert(err, gc.ErrorMatches, `unit name "fluffyunit-0" not valid`)
-	c.Assert(testing.Stdout(context), gc.Equals, "")
-	c.Assert(testing.Stderr(context), gc.Equals, "error: unit name \"fluffyunit-0\" not valid\n")
+	c.Assert(cmdtesting.Stdout(context), gc.Equals, "")
+	c.Assert(cmdtesting.Stderr(context), gc.Equals, "error: unit name \"fluffyunit-0\" not valid\n")
 }
 
 func (s *cmdStorageSuite) TestStorageAddToUnitStorageDoesntExist(c *gc.C) {
@@ -527,8 +527,8 @@ func (s *cmdStorageSuite) TestStorageAddToUnitStorageDoesntExist(c *gc.C) {
 
 	context, err := runAddToUnit(c, u, "nonstorage=1")
 	c.Assert(errors.Cause(err), gc.ErrorMatches, "cmd: error out silently")
-	c.Assert(testing.Stdout(context), gc.Equals, "")
-	c.Assert(testing.Stderr(context), gc.Equals,
+	c.Assert(cmdtesting.Stdout(context), gc.Equals, "")
+	c.Assert(cmdtesting.Stderr(context), gc.Equals,
 		`failed to add "nonstorage": adding "nonstorage" storage to storage-block/0: charm storage "nonstorage" not found`+"\n",
 	)
 
@@ -553,18 +553,18 @@ func (s *cmdStorageSuite) TestStorageAddToUnitHasVolumes(c *gc.C) {
 
 	context, err := runJujuCommand(c, "storage")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(testing.Stdout(context), gc.Equals, `
+	c.Assert(cmdtesting.Stdout(context), gc.Equals, `
 [Storage]
 Unit                  Id      Type        Provider id  Size  Status   Message
 storage-filesystem/0  data/0  filesystem                     pending  
 
 `[1:])
-	c.Assert(testing.Stderr(context), gc.Equals, "")
+	c.Assert(cmdtesting.Stderr(context), gc.Equals, "")
 
 	context, err = runAddToUnit(c, u, "data=modelscoped-block,1G")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(testing.Stdout(context), gc.Equals, "added \"data\"\n")
-	c.Assert(testing.Stderr(context), gc.Equals, "")
+	c.Assert(cmdtesting.Stdout(context), gc.Equals, "added \"data\"\n")
+	c.Assert(cmdtesting.Stderr(context), gc.Equals, "")
 
 	instancesAfter, err := s.State.AllStorageInstances()
 	c.Assert(err, jc.ErrorIsNil)
@@ -576,14 +576,14 @@ storage-filesystem/0  data/0  filesystem                     pending
 
 	context, err = runJujuCommand(c, "list-storage")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(testing.Stdout(context), gc.Equals, `
+	c.Assert(cmdtesting.Stdout(context), gc.Equals, `
 [Storage]
 Unit                  Id      Type        Provider id  Size  Status   Message
 storage-filesystem/0  data/0  filesystem                     pending  
 storage-filesystem/0  data/1  filesystem                     pending  
 
 `[1:])
-	c.Assert(testing.Stderr(context), gc.Equals, "")
+	c.Assert(cmdtesting.Stderr(context), gc.Equals, "")
 }
 
 func createUnitWithFileSystemStorage(c *gc.C, s *jujutesting.JujuConnSuite, poolName string) string {

--- a/juju/testing/conn.go
+++ b/juju/testing/conn.go
@@ -29,6 +29,7 @@ import (
 	"github.com/juju/juju/api"
 	"github.com/juju/juju/cert"
 	"github.com/juju/juju/cloud"
+	"github.com/juju/juju/cmd/cmdtesting"
 	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/controller"
 	"github.com/juju/juju/environs"
@@ -321,7 +322,7 @@ func (s *JujuConnSuite) setUpConn(c *gc.C) {
 	cfg, err := config.New(config.UseDefaults, (map[string]interface{})(s.sampleConfig()))
 	c.Assert(err, jc.ErrorIsNil)
 
-	ctx := testing.Context(c)
+	ctx := cmdtesting.Context(c)
 	s.ControllerConfig = testing.FakeControllerConfig()
 	for key, value := range s.ControllerConfigAttrs {
 		s.ControllerConfig[key] = value

--- a/payload/context/status-set_test.go
+++ b/payload/context/status-set_test.go
@@ -12,9 +12,9 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/cmd/cmdtesting"
 	"github.com/juju/juju/payload"
 	"github.com/juju/juju/payload/context"
-	coretesting "github.com/juju/juju/testing"
 )
 
 type statusSetSuite struct {
@@ -34,7 +34,7 @@ func (s *statusSetSuite) SetUpTest(c *gc.C) {
 
 	s.stub = &testing.Stub{}
 	s.compCtx = &stubSetStatusContext{stub: s.stub}
-	s.ctx = coretesting.Context(c)
+	s.ctx = cmdtesting.Context(c)
 
 	cmd, err := context.NewStatusSetCmd(s)
 	c.Assert(err, jc.ErrorIsNil)

--- a/payload/context/unregister_test.go
+++ b/payload/context/unregister_test.go
@@ -12,9 +12,9 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/cmd/cmdtesting"
 	"github.com/juju/juju/payload"
 	"github.com/juju/juju/payload/context"
-	coretesting "github.com/juju/juju/testing"
 )
 
 type unregisterSuite struct {
@@ -32,7 +32,7 @@ func (s *unregisterSuite) SetUpTest(c *gc.C) {
 
 	s.stub = &testing.Stub{}
 	s.compCtx = &stubUnregisterContext{stub: s.stub}
-	s.ctx = coretesting.Context(c)
+	s.ctx = cmdtesting.Context(c)
 }
 
 func (s *unregisterSuite) Component(name string) (context.Component, error) {

--- a/payload/status/list_test.go
+++ b/payload/status/list_test.go
@@ -13,9 +13,9 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/cmd/cmdtesting"
 	"github.com/juju/juju/payload"
 	"github.com/juju/juju/payload/status"
-	coretesting "github.com/juju/juju/testing"
 )
 
 var _ = gc.Suite(&listSuite{})
@@ -210,7 +210,7 @@ another-application/1  2        eggs           running  docker  ideggs
 }
 
 func runList(c *gc.C, command *status.ListCommand, args ...string) (int, string, string) {
-	ctx := coretesting.Context(c)
+	ctx := cmdtesting.Context(c)
 	code := cmd.Main(command, ctx, args)
 	stdout := ctx.Stdout.(*bytes.Buffer).Bytes()
 	stderr := ctx.Stderr.(*bytes.Buffer).Bytes()

--- a/provider/azure/credentials_test.go
+++ b/provider/azure/credentials_test.go
@@ -15,10 +15,10 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/cloud"
+	"github.com/juju/juju/cmd/cmdtesting"
 	"github.com/juju/juju/environs"
 	envtesting "github.com/juju/juju/environs/testing"
 	"github.com/juju/juju/provider/azure"
-	coretesting "github.com/juju/juju/testing"
 )
 
 type credentialsSuite struct {
@@ -69,7 +69,7 @@ func (s *credentialsSuite) TestDetectCredentials(c *gc.C) {
 
 func (s *credentialsSuite) TestFinalizeCredentialInteractive(c *gc.C) {
 	in := cloud.NewCredential("interactive", map[string]string{"subscription-id": "subscription"})
-	ctx := coretesting.Context(c)
+	ctx := cmdtesting.Context(c)
 	out, err := s.provider.FinalizeCredential(ctx, environs.FinalizeCredentialParams{
 		Credential:            in,
 		CloudEndpoint:         "https://arm.invalid",
@@ -94,7 +94,7 @@ func (s *credentialsSuite) TestFinalizeCredentialInteractive(c *gc.C) {
 func (s *credentialsSuite) TestFinalizeCredentialInteractiveError(c *gc.C) {
 	in := cloud.NewCredential("interactive", map[string]string{"subscription-id": "subscription"})
 	s.interactiveCreateServicePrincipalCreator.SetErrors(errors.New("blargh"))
-	ctx := coretesting.Context(c)
+	ctx := cmdtesting.Context(c)
 	_, err := s.provider.FinalizeCredential(ctx, environs.FinalizeCredentialParams{
 		Credential:            in,
 		CloudEndpoint:         "https://arm.invalid",

--- a/provider/lxd/credentials_test.go
+++ b/provider/lxd/credentials_test.go
@@ -15,6 +15,7 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/cloud"
+	"github.com/juju/juju/cmd/cmdtesting"
 	"github.com/juju/juju/environs"
 	envtesting "github.com/juju/juju/environs/testing"
 	"github.com/juju/juju/juju/osenv"
@@ -128,7 +129,7 @@ func (s *credentialsSuite) TestDetectCredentialsGeneratesCert(c *gc.C) {
 
 func (s *credentialsSuite) TestFinalizeCredentialLocal(c *gc.C) {
 	cert, _ := s.TestingCert(c)
-	out, err := s.Provider.FinalizeCredential(coretesting.Context(c), environs.FinalizeCredentialParams{
+	out, err := s.Provider.FinalizeCredential(cmdtesting.Context(c), environs.FinalizeCredentialParams{
 		CloudEndpoint: "1.2.3.4",
 		Credential: cloud.NewCredential(cloud.CertificateAuthType, map[string]string{
 			"client-cert": string(cert.CertPEM),
@@ -154,7 +155,7 @@ func (s *credentialsSuite) TestFinalizeCredentialLocal(c *gc.C) {
 func (s *credentialsSuite) TestFinalizeCredentialLocalAddCert(c *gc.C) {
 	s.Stub.SetErrors(errors.NotFoundf("certificate"))
 	cert, _ := s.TestingCert(c)
-	out, err := s.Provider.FinalizeCredential(coretesting.Context(c), environs.FinalizeCredentialParams{
+	out, err := s.Provider.FinalizeCredential(cmdtesting.Context(c), environs.FinalizeCredentialParams{
 		CloudEndpoint: "", // skips host lookup
 		Credential: cloud.NewCredential(cloud.CertificateAuthType, map[string]string{
 			"client-cert": string(cert.CertPEM),
@@ -185,7 +186,7 @@ func (s *credentialsSuite) TestFinalizeCredentialLocalAddCertAlreadyThere(c *gc.
 		errors.New("UNIQUE constraint failed: certificates.fingerprint"),
 	)
 	cert, _ := s.TestingCert(c)
-	out, err := s.Provider.FinalizeCredential(coretesting.Context(c), environs.FinalizeCredentialParams{
+	out, err := s.Provider.FinalizeCredential(cmdtesting.Context(c), environs.FinalizeCredentialParams{
 		CloudEndpoint: "", // skips host lookup
 		Credential: cloud.NewCredential(cloud.CertificateAuthType, map[string]string{
 			"client-cert": string(cert.CertPEM),
@@ -218,7 +219,7 @@ func (s *credentialsSuite) TestFinalizeCredentialLocalAddCertFatal(c *gc.C) {
 		errors.NotFoundf("certificate"),
 	)
 	cert, _ := s.TestingCert(c)
-	_, err := s.Provider.FinalizeCredential(coretesting.Context(c), environs.FinalizeCredentialParams{
+	_, err := s.Provider.FinalizeCredential(cmdtesting.Context(c), environs.FinalizeCredentialParams{
 		CloudEndpoint: "", // skips host lookup
 		Credential: cloud.NewCredential(cloud.CertificateAuthType, map[string]string{
 			"client-cert": string(cert.CertPEM),
@@ -236,7 +237,7 @@ func (s *credentialsSuite) TestFinalizeCredentialNonLocal(c *gc.C) {
 		"client-cert": "foo",
 		"client-key":  "bar",
 	})
-	_, err := s.Provider.FinalizeCredential(coretesting.Context(c), environs.FinalizeCredentialParams{
+	_, err := s.Provider.FinalizeCredential(cmdtesting.Context(c), environs.FinalizeCredentialParams{
 		CloudEndpoint: "8.8.8.8",
 		Credential:    in,
 	})
@@ -258,7 +259,7 @@ func (s *credentialsSuite) TestFinalizeCredentialLocalInteractive(c *gc.C) {
 	s.writeFile(c, filepath.Join(home, ".config/lxc/client.crt"), string(cert.CertPEM))
 	s.writeFile(c, filepath.Join(home, ".config/lxc/client.key"), string(cert.KeyPEM))
 
-	ctx := coretesting.Context(c)
+	ctx := cmdtesting.Context(c)
 	out, err := s.Provider.FinalizeCredential(ctx, environs.FinalizeCredentialParams{
 		CloudEndpoint: "1.2.3.4",
 		Credential:    cloud.NewCredential("interactive", map[string]string{}),
@@ -289,7 +290,7 @@ func (s *credentialsSuite) TestFinalizeCredentialNonLocalInteractive(c *gc.C) {
 	// Patch the interface addresses for the calling machine, so
 	// it appears that we're not on the LXD server host.
 	s.PatchValue(&s.InterfaceAddrs, []net.Addr{&net.IPNet{IP: net.ParseIP("8.8.8.8")}})
-	_, err := s.Provider.FinalizeCredential(coretesting.Context(c), environs.FinalizeCredentialParams{
+	_, err := s.Provider.FinalizeCredential(cmdtesting.Context(c), environs.FinalizeCredentialParams{
 		CloudEndpoint: "8.8.8.8",
 		Credential:    cloud.NewCredential("interactive", map[string]string{}),
 	})

--- a/provider/lxd/environ_test.go
+++ b/provider/lxd/environ_test.go
@@ -11,6 +11,7 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/cloudconfig/instancecfg"
+	"github.com/juju/juju/cmd/cmdtesting"
 	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/environs"
 	envtesting "github.com/juju/juju/environs/testing"
@@ -66,7 +67,7 @@ func (s *environSuite) TestBootstrapOkay(c *gc.C) {
 		},
 	}
 
-	ctx := coretesting.Context(c)
+	ctx := cmdtesting.Context(c)
 	params := environs.BootstrapParams{
 		ControllerConfig: coretesting.FakeControllerConfig(),
 	}
@@ -78,7 +79,7 @@ func (s *environSuite) TestBootstrapOkay(c *gc.C) {
 	// We don't check bsFinalizer because functions cannot be compared.
 	c.Check(result.Finalize, gc.NotNil)
 
-	out := coretesting.Stderr(ctx)
+	out := cmdtesting.Stderr(ctx)
 	c.Assert(out, gc.Equals, "To configure your system to better support LXD containers, please see: https://github.com/lxc/lxd/blob/master/doc/production-setup.md\n")
 }
 

--- a/resource/cmd/export_test.go
+++ b/resource/cmd/export_test.go
@@ -1,0 +1,21 @@
+package cmd
+
+func ListCharmResourcesCommandChannel(c *ListCharmResourcesCommand) string {
+	return c.channel
+}
+
+func ShowServiceCommandTarget(c *ShowServiceCommand) string {
+	return c.target
+}
+
+func UploadCommandResourceFile(c *UploadCommand) (service, name, filename string) {
+	return c.resourceFile.service,
+		c.resourceFile.name,
+		c.resourceFile.filename
+}
+
+func UploadCommandService(c *UploadCommand) string {
+	return c.service
+}
+
+var FormatServiceResources = formatServiceResources

--- a/resource/cmd/formatted.go
+++ b/resource/cmd/formatted.go
@@ -42,11 +42,9 @@ type FormattedSvcResource struct {
 	Timestamp     time.Time `json:"timestamp,omitempty" yaml:"timestamp,omitempty"`
 	Username      string    `json:"username,omitempty" yaml:"username,omitempty"`
 
-	// These fields are not exported so they won't be serialized, since they are
-	// specific to the tabular output.
-	combinedRevision string
-	usedYesNo        string
-	combinedOrigin   string
+	CombinedRevision string `json:"-"`
+	UsedYesNo        string `json:"-"`
+	CombinedOrigin   string `json:"-"`
 }
 
 // FormattedUnitResource holds the formatted representation of a resource's info.
@@ -59,9 +57,8 @@ type FormattedDetailResource struct {
 	Unit        FormattedSvcResource `json:"unit" yaml:"unit"`
 	Expected    FormattedSvcResource `json:"expected" yaml:"expected"`
 	Progress    int64                `json:"progress,omitempty" yaml:"progress,omitempty"`
-	unitNumber  int
-	progress    string
-	revProgress string
+	UnitNumber  int                  `json:"-"`
+	RevProgress string               `json:"-"`
 }
 
 // FormattedServiceDetails is the data for the tabular output for juju resources

--- a/resource/cmd/formatter.go
+++ b/resource/cmd/formatter.go
@@ -71,9 +71,9 @@ func FormatSvcResource(res resource.Resource) FormattedSvcResource {
 		Used:             used,
 		Timestamp:        res.Timestamp,
 		Username:         res.Username,
-		combinedRevision: combinedRevision(res),
-		combinedOrigin:   combinedOrigin(used, res),
-		usedYesNo:        usedYesNo(used),
+		CombinedRevision: combinedRevision(res),
+		CombinedOrigin:   combinedOrigin(used, res),
+		UsedYesNo:        usedYesNo(used),
 	}
 }
 
@@ -131,24 +131,23 @@ func FormatDetailResource(tag names.UnitTag, svc, unit resource.Resource, progre
 	progressStr := ""
 	fUnit := FormatSvcResource(unit)
 	expected := FormatSvcResource(svc)
-	revProgress := expected.combinedRevision
+	revProgress := expected.CombinedRevision
 	if progress >= 0 {
 		progressStr = "100%"
 		if expected.Size > 0 {
 			progressStr = fmt.Sprintf("%.f%%", float64(progress)*100.0/float64(expected.Size))
 		}
-		if fUnit.combinedRevision != expected.combinedRevision {
-			revProgress = fmt.Sprintf("%s (fetching: %s)", expected.combinedRevision, progressStr)
+		if fUnit.CombinedRevision != expected.CombinedRevision {
+			revProgress = fmt.Sprintf("%s (fetching: %s)", expected.CombinedRevision, progressStr)
 		}
 	}
 	return FormattedDetailResource{
 		UnitID:      tag.Id(),
-		unitNumber:  unitNum,
+		UnitNumber:  unitNum,
 		Unit:        fUnit,
 		Expected:    expected,
 		Progress:    progress,
-		progress:    progressStr,
-		revProgress: revProgress,
+		RevProgress: revProgress,
 	}, nil
 }
 

--- a/resource/cmd/formatter_test.go
+++ b/resource/cmd/formatter_test.go
@@ -1,7 +1,7 @@
 // Copyright 2015 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package cmd
+package cmd_test
 
 import (
 	"strings"
@@ -14,6 +14,7 @@ import (
 	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/resource"
+	resourcecmd "github.com/juju/juju/resource/cmd"
 )
 
 var _ = gc.Suite(&CharmFormatterSuite{})
@@ -26,9 +27,9 @@ func (s *CharmFormatterSuite) TestFormatCharmResource(c *gc.C) {
 	res := charmRes(c, "spam", ".tgz", "X", "spamspamspam")
 	res.Revision = 5
 
-	formatted := FormatCharmResource(res)
+	formatted := resourcecmd.FormatCharmResource(res)
 
-	c.Check(formatted, jc.DeepEquals, FormattedCharmResource{
+	c.Check(formatted, jc.DeepEquals, resourcecmd.FormattedCharmResource{
 		Name:        "spam",
 		Type:        "file",
 		Path:        "spam.tgz",
@@ -68,8 +69,8 @@ func (s *SvcFormatterSuite) TestFormatSvcResource(c *gc.C) {
 		ApplicationID: "a-application",
 	}
 
-	f := FormatSvcResource(r)
-	c.Assert(f, gc.Equals, FormattedSvcResource{
+	f := resourcecmd.FormatSvcResource(r)
+	c.Assert(f, gc.Equals, resourcecmd.FormattedSvcResource{
 		ID:               "a-application/website",
 		ApplicationID:    "a-application",
 		Name:             r.Name,
@@ -83,9 +84,9 @@ func (s *SvcFormatterSuite) TestFormatSvcResource(c *gc.C) {
 		Description:      r.Description,
 		Timestamp:        r.Timestamp,
 		Username:         r.Username,
-		combinedRevision: "5",
-		usedYesNo:        "yes",
-		combinedOrigin:   "charmstore",
+		CombinedRevision: "5",
+		UsedYesNo:        "yes",
+		CombinedOrigin:   "charmstore",
 	})
 
 }
@@ -94,7 +95,7 @@ func (s *SvcFormatterSuite) TestNotUsed(c *gc.C) {
 	r := resource.Resource{
 		Timestamp: time.Time{},
 	}
-	f := FormatSvcResource(r)
+	f := resourcecmd.FormatSvcResource(r)
 	c.Assert(f.Used, jc.IsFalse)
 }
 
@@ -102,7 +103,7 @@ func (s *SvcFormatterSuite) TestUsed(c *gc.C) {
 	r := resource.Resource{
 		Timestamp: time.Now(),
 	}
-	f := FormatSvcResource(r)
+	f := resourcecmd.FormatSvcResource(r)
 	c.Assert(f.Used, jc.IsTrue)
 }
 
@@ -115,8 +116,8 @@ func (s *SvcFormatterSuite) TestOriginUploadDeployed(c *gc.C) {
 		Username:  "bill",
 		Timestamp: time.Now(),
 	}
-	f := FormatSvcResource(r)
-	c.Assert(f.combinedOrigin, gc.Equals, "bill")
+	f := resourcecmd.FormatSvcResource(r)
+	c.Assert(f.CombinedOrigin, gc.Equals, "bill")
 }
 
 func (s *SvcFormatterSuite) TestInitialOriginUpload(c *gc.C) {
@@ -125,8 +126,8 @@ func (s *SvcFormatterSuite) TestInitialOriginUpload(c *gc.C) {
 			Origin: charmresource.OriginUpload,
 		},
 	}
-	f := FormatSvcResource(r)
-	c.Assert(f.combinedOrigin, gc.Equals, "upload")
+	f := resourcecmd.FormatSvcResource(r)
+	c.Assert(f.CombinedOrigin, gc.Equals, "upload")
 }
 
 var _ = gc.Suite(&DetailFormatterSuite{})
@@ -181,17 +182,16 @@ func (s *DetailFormatterSuite) TestFormatDetail(c *gc.C) {
 	}
 	tag := names.NewUnitTag("a-application/55")
 
-	d, err := FormatDetailResource(tag, svc, unit, 8)
+	d, err := resourcecmd.FormatDetailResource(tag, svc, unit, 8)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(d, gc.Equals,
-		FormattedDetailResource{
-			unitNumber:  55,
+		resourcecmd.FormattedDetailResource{
+			UnitNumber:  55,
 			UnitID:      "a-application/55",
-			Expected:    FormatSvcResource(svc),
+			Expected:    resourcecmd.FormatSvcResource(svc),
 			Progress:    8,
-			progress:    "80%",
-			revProgress: "5 (fetching: 80%)",
-			Unit:        FormatSvcResource(unit),
+			RevProgress: "5 (fetching: 80%)",
+			Unit:        resourcecmd.FormatSvcResource(unit),
 		},
 	)
 }
@@ -222,17 +222,16 @@ func (s *DetailFormatterSuite) TestFormatDetailEmpty(c *gc.C) {
 	unit := resource.Resource{}
 	tag := names.NewUnitTag("a-application/55")
 
-	d, err := FormatDetailResource(tag, svc, unit, 0)
+	d, err := resourcecmd.FormatDetailResource(tag, svc, unit, 0)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(d, gc.Equals,
-		FormattedDetailResource{
-			unitNumber:  55,
+		resourcecmd.FormattedDetailResource{
+			UnitNumber:  55,
 			UnitID:      "a-application/55",
-			Expected:    FormatSvcResource(svc),
+			Expected:    resourcecmd.FormatSvcResource(svc),
 			Progress:    0,
-			progress:    "0%",
-			revProgress: "5 (fetching: 0%)",
-			Unit:        FormatSvcResource(unit),
+			RevProgress: "5 (fetching: 0%)",
+			Unit:        resourcecmd.FormatSvcResource(unit),
 		},
 	)
 }

--- a/resource/cmd/list_charm_resources_test.go
+++ b/resource/cmd/list_charm_resources_test.go
@@ -1,7 +1,7 @@
 // Copyright 2015 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package cmd
+package cmd_test
 
 import (
 	"strings"
@@ -14,6 +14,7 @@ import (
 	charmresource "gopkg.in/juju/charm.v6-unstable/resource"
 
 	"github.com/juju/juju/charmstore"
+	resourcecmd "github.com/juju/juju/resource/cmd"
 )
 
 var _ = gc.Suite(&ListCharmSuite{})
@@ -33,7 +34,7 @@ func (s *ListCharmSuite) SetUpTest(c *gc.C) {
 }
 
 func (s *ListCharmSuite) TestInfo(c *gc.C) {
-	var command ListCharmResourcesCommand
+	var command resourcecmd.ListCharmResourcesCommand
 	info := command.Info()
 
 	c.Check(info, jc.DeepEquals, &jujucmd.Info{
@@ -68,7 +69,7 @@ func (s *ListCharmSuite) TestOkay(c *gc.C) {
 	resources[0].Revision = 2
 	s.client.ReturnListResources = [][]charmresource.Resource{resources}
 
-	command := NewListCharmResourcesCommand()
+	command := resourcecmd.NewListCharmResourcesCommand()
 	command.ResourceLister = s.client
 	code, stdout, stderr := runCmd(c, command, "cs:a-charm")
 	c.Check(code, gc.Equals, 0)
@@ -94,7 +95,7 @@ music     1
 func (s *ListCharmSuite) TestNoResources(c *gc.C) {
 	s.client.ReturnListResources = [][]charmresource.Resource{{}}
 
-	command := NewListCharmResourcesCommand()
+	command := resourcecmd.NewListCharmResourcesCommand()
 	command.ResourceLister = s.client
 	code, stdout, stderr := runCmd(c, command, "cs:a-charm")
 	c.Check(code, gc.Equals, 0)
@@ -166,7 +167,7 @@ music     1
 	}
 	for format, expected := range formats {
 		c.Logf("checking format %q", format)
-		command := NewListCharmResourcesCommand()
+		command := resourcecmd.NewListCharmResourcesCommand()
 		command.ResourceLister = s.client
 		args := []string{
 			"--format", format,
@@ -190,7 +191,7 @@ func (s *ListCharmSuite) TestChannelFlag(c *gc.C) {
 		charmRes(c, "music", ".mp3", "mp3 of your backing vocals", string(fp2.Bytes())),
 	}
 	s.client.ReturnListResources = [][]charmresource.Resource{resources}
-	command := NewListCharmResourcesCommand()
+	command := resourcecmd.NewListCharmResourcesCommand()
 	command.ResourceLister = s.client
 
 	code, _, stderr := runCmd(c, command,
@@ -200,5 +201,5 @@ func (s *ListCharmSuite) TestChannelFlag(c *gc.C) {
 
 	c.Check(code, gc.Equals, 0)
 	c.Check(stderr, gc.Equals, "")
-	c.Check(command.channel, gc.Equals, "development")
+	c.Check(resourcecmd.ListCharmResourcesCommandChannel(command), gc.Equals, "development")
 }

--- a/resource/cmd/output_tabular.go
+++ b/resource/cmd/output_tabular.go
@@ -75,8 +75,8 @@ func formatServiceTabular(writer io.Writer, info FormattedServiceInfo) {
 		// the column headers must be kept in sync with these.
 		fmt.Fprintf(tw, "%v\t%v\t%v\n",
 			r.Name,
-			r.combinedOrigin,
-			r.combinedRevision,
+			r.CombinedOrigin,
+			r.CombinedRevision,
 		)
 	}
 
@@ -121,7 +121,7 @@ func formatUnitTabular(writer io.Writer, resources []FormattedUnitResource) {
 		// the column headers must be kept in sync with these.
 		fmt.Fprintf(tw, "%v\t%v\n",
 			r.Name,
-			r.combinedRevision,
+			r.CombinedRevision,
 		)
 	}
 	tw.Flush()
@@ -142,10 +142,10 @@ func formatServiceDetailTabular(writer io.Writer, resources FormattedServiceDeta
 
 	for _, r := range resources.Resources {
 		fmt.Fprintf(tw, "%v\t%v\t%v\t%v\n",
-			r.unitNumber,
+			r.UnitNumber,
 			r.Expected.Name,
-			r.Unit.combinedRevision,
-			r.revProgress,
+			r.Unit.CombinedRevision,
+			r.RevProgress,
 		)
 	}
 	tw.Flush()
@@ -169,8 +169,8 @@ func formatUnitDetailTabular(writer io.Writer, resources FormattedUnitDetails) {
 	for _, r := range resources {
 		fmt.Fprintf(tw, "%v\t%v\t%v\n",
 			r.Expected.Name,
-			r.Unit.combinedRevision,
-			r.revProgress,
+			r.Unit.CombinedRevision,
+			r.RevProgress,
 		)
 	}
 	tw.Flush()
@@ -182,8 +182,8 @@ func (b byUnitID) Len() int      { return len(b) }
 func (b byUnitID) Swap(i, j int) { b[i], b[j] = b[j], b[i] }
 
 func (b byUnitID) Less(i, j int) bool {
-	if b[i].unitNumber != b[j].unitNumber {
-		return b[i].unitNumber < b[j].unitNumber
+	if b[i].UnitNumber != b[j].UnitNumber {
+		return b[i].UnitNumber < b[j].UnitNumber
 	}
 	return b[i].Expected.Name < b[j].Expected.Name
 }

--- a/resource/cmd/output_tabular_test.go
+++ b/resource/cmd/output_tabular_test.go
@@ -1,7 +1,7 @@
 // Copyright 2015 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package cmd
+package cmd_test
 
 import (
 	"bytes"
@@ -13,6 +13,7 @@ import (
 	charmresource "gopkg.in/juju/charm.v6-unstable/resource"
 
 	"github.com/juju/juju/resource"
+	resourcecmd "github.com/juju/juju/resource/cmd"
 )
 
 var _ = gc.Suite(&CharmTabularSuite{})
@@ -23,14 +24,14 @@ type CharmTabularSuite struct {
 
 func (s *CharmTabularSuite) formatTabular(c *gc.C, value interface{}) string {
 	out := &bytes.Buffer{}
-	err := FormatCharmTabular(out, value)
+	err := resourcecmd.FormatCharmTabular(out, value)
 	c.Assert(err, jc.ErrorIsNil)
 	return out.String()
 }
 
 func (s *CharmTabularSuite) TestFormatCharmTabularOkay(c *gc.C) {
 	res := charmRes(c, "spam", ".tgz", "...", "")
-	formatted := []FormattedCharmResource{FormatCharmResource(res)}
+	formatted := []resourcecmd.FormattedCharmResource{resourcecmd.FormatCharmResource(res)}
 
 	data := s.formatTabular(c, formatted)
 	c.Check(data, gc.Equals, `
@@ -41,7 +42,7 @@ spam      1
 
 func (s *CharmTabularSuite) TestFormatCharmTabularMinimal(c *gc.C) {
 	res := charmRes(c, "spam", "", "", "")
-	formatted := []FormattedCharmResource{FormatCharmResource(res)}
+	formatted := []resourcecmd.FormattedCharmResource{resourcecmd.FormatCharmResource(res)}
 
 	data := s.formatTabular(c, formatted)
 	c.Check(data, gc.Equals, `
@@ -53,7 +54,7 @@ spam      1
 func (s *CharmTabularSuite) TestFormatCharmTabularUpload(c *gc.C) {
 	res := charmRes(c, "spam", "", "", "")
 	res.Origin = charmresource.OriginUpload
-	formatted := []FormattedCharmResource{FormatCharmResource(res)}
+	formatted := []resourcecmd.FormattedCharmResource{resourcecmd.FormatCharmResource(res)}
 
 	data := s.formatTabular(c, formatted)
 	c.Check(data, gc.Equals, `
@@ -63,12 +64,12 @@ spam      1
 }
 
 func (s *CharmTabularSuite) TestFormatCharmTabularMulti(c *gc.C) {
-	formatted := []FormattedCharmResource{
-		FormatCharmResource(charmRes(c, "spam", ".tgz", "spamspamspamspam", "")),
-		FormatCharmResource(charmRes(c, "eggs", "", "...", "")),
-		FormatCharmResource(charmRes(c, "somethingbig", ".zip", "", "")),
-		FormatCharmResource(charmRes(c, "song", ".mp3", "your favorite", "")),
-		FormatCharmResource(charmRes(c, "avatar", ".png", "your picture", "")),
+	formatted := []resourcecmd.FormattedCharmResource{
+		resourcecmd.FormatCharmResource(charmRes(c, "spam", ".tgz", "spamspamspamspam", "")),
+		resourcecmd.FormatCharmResource(charmRes(c, "eggs", "", "...", "")),
+		resourcecmd.FormatCharmResource(charmRes(c, "somethingbig", ".zip", "", "")),
+		resourcecmd.FormatCharmResource(charmRes(c, "song", ".mp3", "your favorite", "")),
+		resourcecmd.FormatCharmResource(charmRes(c, "avatar", ".png", "your picture", "")),
 	}
 	formatted[1].Revision = 2
 
@@ -85,7 +86,7 @@ avatar        1
 
 func (s *CharmTabularSuite) TestFormatCharmTabularBadValue(c *gc.C) {
 	bogus := "should have been something else"
-	err := FormatCharmTabular(nil, bogus)
+	err := resourcecmd.FormatCharmTabular(nil, bogus)
 	c.Check(err, gc.ErrorMatches, `expected value of type .*`)
 }
 
@@ -97,7 +98,7 @@ type SvcTabularSuite struct {
 
 func (s *SvcTabularSuite) formatTabular(c *gc.C, value interface{}) string {
 	out := &bytes.Buffer{}
-	err := FormatSvcTabular(out, value)
+	err := resourcecmd.FormatSvcTabular(out, value)
 	c.Assert(err, jc.ErrorIsNil)
 	return out.String()
 }
@@ -116,8 +117,8 @@ func (s *SvcTabularSuite) TestFormatServiceOkay(c *gc.C) {
 		Timestamp: time.Now(),
 	}
 
-	formatted := FormattedServiceInfo{
-		Resources: []FormattedSvcResource{FormatSvcResource(res)},
+	formatted := resourcecmd.FormattedServiceInfo{
+		Resources: []resourcecmd.FormattedSvcResource{resourcecmd.FormatSvcResource(res)},
 	}
 
 	data := s.formatTabular(c, formatted)
@@ -142,8 +143,8 @@ func (s *SvcTabularSuite) TestFormatUnitOkay(c *gc.C) {
 		Timestamp: time.Now(),
 	}
 
-	formatted := []FormattedUnitResource{
-		FormattedUnitResource(FormatSvcResource(res)),
+	formatted := []resourcecmd.FormattedUnitResource{
+		resourcecmd.FormattedUnitResource(resourcecmd.FormatSvcResource(res)),
 	}
 
 	data := s.formatTabular(c, formatted)
@@ -242,7 +243,7 @@ func (s *SvcTabularSuite) TestFormatSvcTabularMulti(c *gc.C) {
 		},
 	}
 
-	formatted, err := formatServiceResources(resource.ServiceResources{
+	formatted, err := resourcecmd.FormatServiceResources(resource.ServiceResources{
 		Resources:           res,
 		CharmStoreResources: charmResources,
 	})
@@ -266,31 +267,30 @@ openjdk   10
 
 func (s *SvcTabularSuite) TestFormatSvcTabularBadValue(c *gc.C) {
 	bogus := "should have been something else"
-	err := FormatSvcTabular(nil, bogus)
+	err := resourcecmd.FormatSvcTabular(nil, bogus)
 	c.Check(err, gc.ErrorMatches, `unexpected type for data: string`)
 }
 
 func (s *SvcTabularSuite) TestFormatServiceDetailsOkay(c *gc.C) {
 	res := charmRes(c, "spam", ".tgz", "...", "")
-	updates := []FormattedCharmResource{FormatCharmResource(res)}
+	updates := []resourcecmd.FormattedCharmResource{resourcecmd.FormatCharmResource(res)}
 
-	data := FormattedServiceDetails{
-		Resources: []FormattedDetailResource{
+	data := resourcecmd.FormattedServiceDetails{
+		Resources: []resourcecmd.FormattedDetailResource{
 			{
 				UnitID:      "svc/10",
-				unitNumber:  10,
+				UnitNumber:  10,
 				Unit:        fakeFmtSvcRes("data", "1"),
 				Expected:    fakeFmtSvcRes("data", "1"),
 				Progress:    17,
-				progress:    "17%",
-				revProgress: "combRev1 (fetching: 17%)",
+				RevProgress: "combRev1 (fetching: 17%)",
 			},
 			{
 				UnitID:      "svc/5",
-				unitNumber:  5,
+				UnitNumber:  5,
 				Unit:        fakeFmtSvcRes("config", "2"),
 				Expected:    fakeFmtSvcRes("config", "3"),
-				revProgress: "combRev3",
+				RevProgress: "combRev3",
 			},
 		},
 		Updates: updates,
@@ -310,22 +310,21 @@ spam      1
 }
 
 func (s *SvcTabularSuite) TestFormatUnitDetailsOkay(c *gc.C) {
-	data := FormattedUnitDetails{
+	data := resourcecmd.FormattedUnitDetails{
 		{
 			UnitID:      "svc/10",
-			unitNumber:  10,
+			UnitNumber:  10,
 			Unit:        fakeFmtSvcRes("data", "1"),
 			Expected:    fakeFmtSvcRes("data", "1"),
-			revProgress: "combRev1",
+			RevProgress: "combRev1",
 		},
 		{
 			UnitID:      "svc/10",
-			unitNumber:  10,
+			UnitNumber:  10,
 			Unit:        fakeFmtSvcRes("config", "2"),
 			Expected:    fakeFmtSvcRes("config", "3"),
 			Progress:    91,
-			progress:    "91%",
-			revProgress: "combRev3 (fetching: 91%)",
+			RevProgress: "combRev3 (fetching: 91%)",
 		},
 	}
 
@@ -338,8 +337,8 @@ data      combRev1  combRev1
 `[1:])
 }
 
-func fakeFmtSvcRes(name, suffix string) FormattedSvcResource {
-	return FormattedSvcResource{
+func fakeFmtSvcRes(name, suffix string) resourcecmd.FormattedSvcResource {
+	return resourcecmd.FormattedSvcResource{
 		ID:               "ID" + suffix,
 		ApplicationID:    "svc",
 		Name:             name,
@@ -353,8 +352,8 @@ func fakeFmtSvcRes(name, suffix string) FormattedSvcResource {
 		Used:             true,
 		Timestamp:        time.Date(2012, 12, 12, 12, 12, 12, 0, time.UTC),
 		Username:         "Username" + suffix,
-		combinedRevision: "combRev" + suffix,
-		usedYesNo:        "usedYesNo" + suffix,
-		combinedOrigin:   "combOrig" + suffix,
+		CombinedRevision: "combRev" + suffix,
+		UsedYesNo:        "usedYesNo" + suffix,
+		CombinedOrigin:   "combOrig" + suffix,
 	}
 }

--- a/resource/cmd/package_test.go
+++ b/resource/cmd/package_test.go
@@ -1,7 +1,7 @@
 // Copyright 2015 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package cmd
+package cmd_test
 
 import (
 	"testing"

--- a/resource/cmd/show_service_test.go
+++ b/resource/cmd/show_service_test.go
@@ -1,7 +1,7 @@
 // Copyright 2015 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package cmd
+package cmd_test
 
 import (
 	"time"
@@ -15,6 +15,7 @@ import (
 	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/resource"
+	resourcecmd "github.com/juju/juju/resource/cmd"
 )
 
 var _ = gc.Suite(&ShowServiceSuite{})
@@ -36,28 +37,28 @@ func (s *ShowServiceSuite) SetUpTest(c *gc.C) {
 }
 
 func (*ShowServiceSuite) TestInitEmpty(c *gc.C) {
-	s := ShowServiceCommand{}
+	s := resourcecmd.ShowServiceCommand{}
 
 	err := s.Init([]string{})
 	c.Assert(err, jc.Satisfies, errors.IsBadRequest)
 }
 
 func (*ShowServiceSuite) TestInitGood(c *gc.C) {
-	s := ShowServiceCommand{}
+	s := resourcecmd.ShowServiceCommand{}
 	err := s.Init([]string{"foo"})
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(s.target, gc.Equals, "foo")
+	c.Assert(resourcecmd.ShowServiceCommandTarget(&s), gc.Equals, "foo")
 }
 
 func (*ShowServiceSuite) TestInitTooManyArgs(c *gc.C) {
-	s := ShowServiceCommand{}
+	s := resourcecmd.ShowServiceCommand{}
 
 	err := s.Init([]string{"foo", "bar"})
 	c.Assert(err, jc.Satisfies, errors.IsBadRequest)
 }
 
 func (s *ShowServiceSuite) TestInfo(c *gc.C) {
-	var command ShowServiceCommand
+	var command resourcecmd.ShowServiceCommand
 	info := command.Info()
 
 	c.Check(info, jc.DeepEquals, &jujucmd.Info{
@@ -163,11 +164,9 @@ func (s *ShowServiceSuite) TestRun(c *gc.C) {
 	}
 	s.stubDeps.client.ReturnResources = data
 
-	cmd := &ShowServiceCommand{
-		deps: ShowServiceDeps{
-			NewClient: s.stubDeps.NewClient,
-		},
-	}
+	cmd := resourcecmd.NewShowServiceCommand(resourcecmd.ShowServiceDeps{
+		NewClient: s.stubDeps.NewClient,
+	})
 
 	code, stdout, stderr := runCmd(c, cmd, "svc")
 	c.Check(code, gc.Equals, 0)
@@ -226,11 +225,9 @@ func (s *ShowServiceSuite) TestRunUnit(c *gc.C) {
 	}}
 	s.stubDeps.client.ReturnResources = data
 
-	cmd := &ShowServiceCommand{
-		deps: ShowServiceDeps{
-			NewClient: s.stubDeps.NewClient,
-		},
-	}
+	cmd := resourcecmd.NewShowServiceCommand(resourcecmd.ShowServiceDeps{
+		NewClient: s.stubDeps.NewClient,
+	})
 
 	code, stdout, stderr := runCmd(c, cmd, "svc/0")
 	c.Assert(code, gc.Equals, 0)
@@ -390,11 +387,9 @@ func (s *ShowServiceSuite) TestRunDetails(c *gc.C) {
 	}}
 	s.stubDeps.client.ReturnResources = data
 
-	cmd := &ShowServiceCommand{
-		deps: ShowServiceDeps{
-			NewClient: s.stubDeps.NewClient,
-		},
-	}
+	cmd := resourcecmd.NewShowServiceCommand(resourcecmd.ShowServiceDeps{
+		NewClient: s.stubDeps.NewClient,
+	})
 
 	code, stdout, stderr := runCmd(c, cmd, "svc", "--details")
 	c.Check(code, gc.Equals, 0)
@@ -530,11 +525,9 @@ func (s *ShowServiceSuite) TestRunUnitDetails(c *gc.C) {
 	}}
 	s.stubDeps.client.ReturnResources = data
 
-	cmd := &ShowServiceCommand{
-		deps: ShowServiceDeps{
-			NewClient: s.stubDeps.NewClient,
-		},
-	}
+	cmd := resourcecmd.NewShowServiceCommand(resourcecmd.ShowServiceDeps{
+		NewClient: s.stubDeps.NewClient,
+	})
 
 	code, stdout, stderr := runCmd(c, cmd, "svc/10", "--details")
 	c.Assert(code, gc.Equals, 0)
@@ -557,7 +550,7 @@ type stubShowServiceDeps struct {
 	client *stubServiceClient
 }
 
-func (s *stubShowServiceDeps) NewClient(c *ShowServiceCommand) (ShowServiceClient, error) {
+func (s *stubShowServiceDeps) NewClient(c *resourcecmd.ShowServiceCommand) (resourcecmd.ShowServiceClient, error) {
 	s.stub.AddCall("NewClient", c)
 	if err := s.stub.NextErr(); err != nil {
 		return nil, errors.Trace(err)

--- a/resource/cmd/stub_test.go
+++ b/resource/cmd/stub_test.go
@@ -1,7 +1,7 @@
 // Copyright 2015 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package cmd
+package cmd_test
 
 import (
 	"io"

--- a/resource/cmd/upload_test.go
+++ b/resource/cmd/upload_test.go
@@ -1,7 +1,7 @@
 // Copyright 2015 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package cmd
+package cmd_test
 
 import (
 	jujucmd "github.com/juju/cmd"
@@ -9,6 +9,8 @@ import (
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
+
+	resourcecmd "github.com/juju/juju/resource/cmd"
 )
 
 var _ = gc.Suite(&UploadSuite{})
@@ -31,61 +33,60 @@ func (s *UploadSuite) SetUpTest(c *gc.C) {
 }
 
 func (*UploadSuite) TestInitEmpty(c *gc.C) {
-	var u UploadCommand
+	var u resourcecmd.UploadCommand
 
 	err := u.Init([]string{})
 	c.Assert(err, jc.Satisfies, errors.IsBadRequest)
 }
 
 func (*UploadSuite) TestInitOneArg(c *gc.C) {
-	var u UploadCommand
+	var u resourcecmd.UploadCommand
 	err := u.Init([]string{"foo"})
 	c.Assert(err, jc.Satisfies, errors.IsBadRequest)
 }
 
 func (*UploadSuite) TestInitJustName(c *gc.C) {
-	var u UploadCommand
+	var u resourcecmd.UploadCommand
 
 	err := u.Init([]string{"foo", "bar"})
 	c.Assert(err, jc.Satisfies, errors.IsNotValid)
 }
 
 func (*UploadSuite) TestInitNoName(c *gc.C) {
-	var u UploadCommand
+	var u resourcecmd.UploadCommand
 
 	err := u.Init([]string{"foo", "=foobar"})
 	c.Assert(errors.Cause(err), jc.Satisfies, errors.IsNotValid)
 }
 
 func (*UploadSuite) TestInitNoPath(c *gc.C) {
-	var u UploadCommand
+	var u resourcecmd.UploadCommand
 
 	err := u.Init([]string{"foo", "foobar="})
 	c.Assert(errors.Cause(err), jc.Satisfies, errors.IsNotValid)
 }
 
 func (*UploadSuite) TestInitGood(c *gc.C) {
-	var u UploadCommand
+	var u resourcecmd.UploadCommand
 
 	err := u.Init([]string{"foo", "bar=baz"})
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(u.resourceFile, gc.DeepEquals, resourceFile{
-		service:  "foo",
-		name:     "bar",
-		filename: "baz",
-	})
-	c.Assert(u.service, gc.Equals, "foo")
+	svc, name, filename := resourcecmd.UploadCommandResourceFile(&u)
+	c.Assert(svc, gc.Equals, "foo")
+	c.Assert(name, gc.Equals, "bar")
+	c.Assert(filename, gc.Equals, "baz")
+	c.Assert(resourcecmd.UploadCommandService(&u), gc.Equals, "foo")
 }
 
 func (*UploadSuite) TestInitTwoResources(c *gc.C) {
-	var u UploadCommand
+	var u resourcecmd.UploadCommand
 
 	err := u.Init([]string{"foo", "bar=baz", "fizz=buzz"})
 	c.Assert(err, jc.Satisfies, errors.IsBadRequest)
 }
 
 func (s *UploadSuite) TestInfo(c *gc.C) {
-	var command UploadCommand
+	var command resourcecmd.UploadCommand
 	info := command.Info()
 
 	c.Check(info, jc.DeepEquals, &jujucmd.Info{
@@ -102,20 +103,15 @@ used as a resource for an application.
 func (s *UploadSuite) TestRun(c *gc.C) {
 	file := &stubFile{stub: s.stub}
 	s.stubDeps.file = file
-	u := UploadCommand{
-		deps: UploadDeps{
-			NewClient:    s.stubDeps.NewClient,
-			OpenResource: s.stubDeps.OpenResource,
-		},
-		resourceFile: resourceFile{
-			service:  "svc",
-			name:     "foo",
-			filename: "bar",
-		},
-		service: "svc",
-	}
+	u := resourcecmd.NewUploadCommand(resourcecmd.UploadDeps{
+		NewClient:    s.stubDeps.NewClient,
+		OpenResource: s.stubDeps.OpenResource,
+	},
+	)
+	err := u.Init([]string{"svc", "foo=bar"})
+	c.Assert(err, jc.ErrorIsNil)
 
-	err := u.Run(nil)
+	err = u.Run(nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.stub.CheckCallNames(c,
@@ -131,11 +127,11 @@ func (s *UploadSuite) TestRun(c *gc.C) {
 
 type stubUploadDeps struct {
 	stub   *testing.Stub
-	file   ReadSeekCloser
-	client UploadClient
+	file   resourcecmd.ReadSeekCloser
+	client resourcecmd.UploadClient
 }
 
-func (s *stubUploadDeps) NewClient(c *UploadCommand) (UploadClient, error) {
+func (s *stubUploadDeps) NewClient(c *resourcecmd.UploadCommand) (resourcecmd.UploadClient, error) {
 	s.stub.AddCall("NewClient", c)
 	if err := s.stub.NextErr(); err != nil {
 		return nil, errors.Trace(err)
@@ -144,7 +140,7 @@ func (s *stubUploadDeps) NewClient(c *UploadCommand) (UploadClient, error) {
 	return s.client, nil
 }
 
-func (s *stubUploadDeps) OpenResource(path string) (ReadSeekCloser, error) {
+func (s *stubUploadDeps) OpenResource(path string) (resourcecmd.ReadSeekCloser, error) {
 	s.stub.AddCall("OpenResource", path)
 	if err := s.stub.NextErr(); err != nil {
 		return nil, errors.Trace(err)

--- a/resource/cmd/util_test.go
+++ b/resource/cmd/util_test.go
@@ -1,7 +1,7 @@
 // Copyright 2015 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package cmd
+package cmd_test
 
 import (
 	"bytes"
@@ -12,7 +12,7 @@ import (
 	gc "gopkg.in/check.v1"
 	charmresource "gopkg.in/juju/charm.v6-unstable/resource"
 
-	coretesting "github.com/juju/juju/testing"
+	"github.com/juju/juju/cmd/cmdtesting"
 )
 
 func charmRes(c *gc.C, name, suffix, description, content string) charmresource.Resource {
@@ -57,7 +57,7 @@ func newCharmResources(c *gc.C, names ...string) []charmresource.Resource {
 }
 
 func runCmd(c *gc.C, command jujucmd.Command, args ...string) (code int, stdout string, stderr string) {
-	ctx := coretesting.Context(c)
+	ctx := cmdtesting.Context(c)
 	code = jujucmd.Main(command, ctx, args)
 	stdout = string(ctx.Stdout.(*bytes.Buffer).Bytes())
 	stderr = string(ctx.Stderr.(*bytes.Buffer).Bytes())

--- a/resource/context/cmd/get_test.go
+++ b/resource/context/cmd/get_test.go
@@ -9,7 +9,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
-	coretesting "github.com/juju/juju/testing"
+	"github.com/juju/juju/cmd/cmdtesting"
 )
 
 var _ = gc.Suite(&GetCmdSuite{})
@@ -68,15 +68,15 @@ func (s *GetCmdSuite) TestRunOkay(c *gc.C) {
 	}
 	const expected = "/var/lib/juju/agents/unit-foo-1/resources/spam/a-file.tgz"
 	s.hctx.ReturnDownload = expected
-	ctx := coretesting.Context(c)
+	ctx := cmdtesting.Context(c)
 
 	err := getCmd.Run(ctx)
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.stub.CheckCallNames(c, "Download")
 	s.stub.CheckCall(c, 0, "Download", "spam")
-	c.Check(coretesting.Stdout(ctx), gc.Equals, expected)
-	c.Check(coretesting.Stderr(ctx), gc.Equals, "")
+	c.Check(cmdtesting.Stdout(ctx), gc.Equals, expected)
+	c.Check(cmdtesting.Stderr(ctx), gc.Equals, "")
 }
 
 func (s *GetCmdSuite) TestRunDownloadFailure(c *gc.C) {
@@ -86,12 +86,12 @@ func (s *GetCmdSuite) TestRunDownloadFailure(c *gc.C) {
 	}
 	failure := errors.New("<failure>")
 	s.stub.SetErrors(failure)
-	ctx := coretesting.Context(c)
+	ctx := cmdtesting.Context(c)
 
 	err := getCmd.Run(ctx)
 
 	s.stub.CheckCallNames(c, "Download")
 	c.Check(errors.Cause(err), gc.Equals, failure)
-	c.Check(coretesting.Stdout(ctx), gc.Equals, "")
-	c.Check(coretesting.Stderr(ctx), gc.Equals, "")
+	c.Check(cmdtesting.Stdout(ctx), gc.Equals, "")
+	c.Check(cmdtesting.Stderr(ctx), gc.Equals, "")
 }

--- a/worker/uniter/runner/jujuc/action-fail_test.go
+++ b/worker/uniter/runner/jujuc/action-fail_test.go
@@ -10,7 +10,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
-	"github.com/juju/juju/testing"
+	"github.com/juju/juju/cmd/cmdtesting"
 	"github.com/juju/juju/worker/uniter/runner/jujuc"
 )
 
@@ -78,7 +78,7 @@ func (s *ActionFailSuite) TestActionFail(c *gc.C) {
 		hctx := &actionFailContext{}
 		com, err := jujuc.NewCommand(hctx, cmdString("action-fail"))
 		c.Assert(err, jc.ErrorIsNil)
-		ctx := testing.Context(c)
+		ctx := cmdtesting.Context(c)
 		code := cmd.Main(com, ctx, t.command)
 		c.Check(code, gc.Equals, t.code)
 		c.Check(bufferString(ctx.Stderr), gc.Equals, t.errMsg)
@@ -91,7 +91,7 @@ func (s *ActionFailSuite) TestNonActionSetActionFailedFails(c *gc.C) {
 	hctx := &nonActionFailContext{}
 	com, err := jujuc.NewCommand(hctx, cmdString("action-fail"))
 	c.Assert(err, jc.ErrorIsNil)
-	ctx := testing.Context(c)
+	ctx := cmdtesting.Context(c)
 	code := cmd.Main(com, ctx, []string{"oops"})
 	c.Check(code, gc.Equals, 1)
 	c.Check(bufferString(ctx.Stderr), gc.Equals, "ERROR not running an action\n")
@@ -102,7 +102,7 @@ func (s *ActionFailSuite) TestHelp(c *gc.C) {
 	hctx, _ := s.NewHookContext()
 	com, err := jujuc.NewCommand(hctx, cmdString("action-fail"))
 	c.Assert(err, jc.ErrorIsNil)
-	ctx := testing.Context(c)
+	ctx := cmdtesting.Context(c)
 	code := cmd.Main(com, ctx, []string{"--help"})
 	c.Assert(code, gc.Equals, 0)
 	c.Assert(bufferString(ctx.Stdout), gc.Equals, `Usage: action-fail ["<failure message>"]

--- a/worker/uniter/runner/jujuc/action-get_test.go
+++ b/worker/uniter/runner/jujuc/action-get_test.go
@@ -11,7 +11,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
-	"github.com/juju/juju/testing"
+	"github.com/juju/juju/cmd/cmdtesting"
 	"github.com/juju/juju/worker/uniter/runner/jujuc"
 )
 
@@ -42,7 +42,7 @@ func (s *ActionGetSuite) TestNonActionRunFail(c *gc.C) {
 	hctx := &nonActionContext{}
 	com, err := jujuc.NewCommand(hctx, cmdString("action-get"))
 	c.Assert(err, jc.ErrorIsNil)
-	ctx := testing.Context(c)
+	ctx := cmdtesting.Context(c)
 	code := cmd.Main(com, ctx, []string{})
 	c.Check(code, gc.Equals, 1)
 	c.Check(bufferString(ctx.Stdout), gc.Equals, "")
@@ -254,7 +254,7 @@ func (s *ActionGetSuite) TestActionGet(c *gc.C) {
 		hctx.actionParams = t.actionParams
 		com, err := jujuc.NewCommand(hctx, cmdString("action-get"))
 		c.Assert(err, jc.ErrorIsNil)
-		ctx := testing.Context(c)
+		ctx := cmdtesting.Context(c)
 		code := cmd.Main(com, ctx, t.args)
 		c.Check(code, gc.Equals, t.code)
 		if code == 0 {
@@ -272,7 +272,7 @@ func (s *ActionGetSuite) TestHelp(c *gc.C) {
 	hctx := &actionGetContext{}
 	com, err := jujuc.NewCommand(hctx, cmdString("action-get"))
 	c.Assert(err, jc.ErrorIsNil)
-	ctx := testing.Context(c)
+	ctx := cmdtesting.Context(c)
 	code := cmd.Main(com, ctx, []string{"--help"})
 	c.Assert(code, gc.Equals, 0)
 	c.Assert(bufferString(ctx.Stdout), gc.Equals, `Usage: action-get [options] [<key>[.<key>.<key>...]]

--- a/worker/uniter/runner/jujuc/action-set_test.go
+++ b/worker/uniter/runner/jujuc/action-set_test.go
@@ -10,7 +10,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
-	"github.com/juju/juju/testing"
+	"github.com/juju/juju/cmd/cmdtesting"
 	"github.com/juju/juju/worker/uniter/runner/jujuc"
 )
 
@@ -46,7 +46,7 @@ func (s *ActionSetSuite) TestActionSetOnNonActionContextFails(c *gc.C) {
 	hctx := &nonActionSettingContext{}
 	com, err := jujuc.NewCommand(hctx, cmdString("action-set"))
 	c.Assert(err, jc.ErrorIsNil)
-	ctx := testing.Context(c)
+	ctx := cmdtesting.Context(c)
 	code := cmd.Main(com, ctx, []string{"oops=nope"})
 	c.Check(code, gc.Equals, 1)
 	c.Check(bufferString(ctx.Stdout), gc.Equals, "")
@@ -127,7 +127,7 @@ func (s *ActionSetSuite) TestActionSet(c *gc.C) {
 		hctx := &actionSettingContext{}
 		com, err := jujuc.NewCommand(hctx, cmdString("action-set"))
 		c.Assert(err, jc.ErrorIsNil)
-		ctx := testing.Context(c)
+		ctx := cmdtesting.Context(c)
 		c.Logf("  command list: %#v", t.command)
 		code := cmd.Main(com, ctx, t.command)
 		c.Check(code, gc.Equals, t.code)
@@ -140,7 +140,7 @@ func (s *ActionSetSuite) TestHelp(c *gc.C) {
 	hctx := &actionSettingContext{}
 	com, err := jujuc.NewCommand(hctx, cmdString("action-set"))
 	c.Assert(err, jc.ErrorIsNil)
-	ctx := testing.Context(c)
+	ctx := cmdtesting.Context(c)
 	code := cmd.Main(com, ctx, []string{"--help"})
 	c.Assert(code, gc.Equals, 0)
 	c.Assert(bufferString(ctx.Stdout), gc.Equals, `Usage: action-set <key>=<value> [<key>=<value> ...]

--- a/worker/uniter/runner/jujuc/add-metric_test.go
+++ b/worker/uniter/runner/jujuc/add-metric_test.go
@@ -11,7 +11,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
-	"github.com/juju/juju/testing"
+	"github.com/juju/juju/cmd/cmdtesting"
 	"github.com/juju/juju/worker/uniter/runner/jujuc"
 )
 
@@ -25,7 +25,7 @@ func (s *AddMetricSuite) TestHelp(c *gc.C) {
 	hctx := s.GetHookContext(c, -1, "")
 	com, err := jujuc.NewCommand(hctx, cmdString("add-metric"))
 	c.Assert(err, jc.ErrorIsNil)
-	ctx := testing.Context(c)
+	ctx := cmdtesting.Context(c)
 	code := cmd.Main(com, ctx, []string{"--help"})
 	c.Assert(code, gc.Equals, 0)
 	c.Assert(bufferString(ctx.Stdout), gc.Equals, `
@@ -150,7 +150,7 @@ func (s *AddMetricSuite) TestAddMetric(c *gc.C) {
 		hctx.canAddMetrics = t.canAddMetrics
 		com, err := jujuc.NewCommand(hctx, cmdString(t.cmd[0]))
 		c.Assert(err, jc.ErrorIsNil)
-		ctx := testing.Context(c)
+		ctx := cmdtesting.Context(c)
 		ret := cmd.Main(com, ctx, t.cmd[1:])
 		c.Check(ret, gc.Equals, t.result)
 		c.Check(bufferString(ctx.Stdout), gc.Equals, t.stdout)

--- a/worker/uniter/runner/jujuc/application-version-set_test.go
+++ b/worker/uniter/runner/jujuc/application-version-set_test.go
@@ -9,7 +9,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
-	"github.com/juju/juju/testing"
+	"github.com/juju/juju/cmd/cmdtesting"
 	"github.com/juju/juju/worker/uniter/runner/jujuc"
 )
 
@@ -30,7 +30,7 @@ func (s *ApplicationVersionSetSuite) createCommand(c *gc.C, err error) (*Context
 
 func (s *ApplicationVersionSetSuite) TestApplicationVersionSetNoArguments(c *gc.C) {
 	hctx, com := s.createCommand(c, nil)
-	ctx := testing.Context(c)
+	ctx := cmdtesting.Context(c)
 	code := cmd.Main(com, ctx, nil)
 	c.Check(code, gc.Equals, 2)
 	c.Check(bufferString(ctx.Stdout), gc.Equals, "")
@@ -40,7 +40,7 @@ func (s *ApplicationVersionSetSuite) TestApplicationVersionSetNoArguments(c *gc.
 
 func (s *ApplicationVersionSetSuite) TestApplicationVersionSetWithArguments(c *gc.C) {
 	hctx, com := s.createCommand(c, nil)
-	ctx := testing.Context(c)
+	ctx := cmdtesting.Context(c)
 	code := cmd.Main(com, ctx, []string{"dia de los muertos"})
 	c.Check(code, gc.Equals, 0)
 	c.Check(bufferString(ctx.Stdout), gc.Equals, "")
@@ -50,7 +50,7 @@ func (s *ApplicationVersionSetSuite) TestApplicationVersionSetWithArguments(c *g
 
 func (s *ApplicationVersionSetSuite) TestApplicationVersionSetError(c *gc.C) {
 	hctx, com := s.createCommand(c, errors.New("uh oh spaghettio"))
-	ctx := testing.Context(c)
+	ctx := cmdtesting.Context(c)
 	code := cmd.Main(com, ctx, []string{"cannae"})
 	c.Check(code, gc.Equals, 1)
 	c.Check(bufferString(ctx.Stdout), gc.Equals, "")
@@ -76,7 +76,7 @@ output for the application.
 `[1:]
 
 	_, com := s.createCommand(c, nil)
-	ctx := testing.Context(c)
+	ctx := cmdtesting.Context(c)
 	code := cmd.Main(com, ctx, []string{"--help"})
 	c.Check(code, gc.Equals, 0)
 

--- a/worker/uniter/runner/jujuc/config-get_test.go
+++ b/worker/uniter/runner/jujuc/config-get_test.go
@@ -14,7 +14,7 @@ import (
 	gc "gopkg.in/check.v1"
 	goyaml "gopkg.in/yaml.v2"
 
-	"github.com/juju/juju/testing"
+	"github.com/juju/juju/cmd/cmdtesting"
 	"github.com/juju/juju/worker/uniter/runner/jujuc"
 )
 
@@ -45,7 +45,7 @@ func (s *ConfigGetSuite) TestOutputFormatKey(c *gc.C) {
 		hctx := s.GetHookContext(c, -1, "")
 		com, err := jujuc.NewCommand(hctx, cmdString("config-get"))
 		c.Assert(err, jc.ErrorIsNil)
-		ctx := testing.Context(c)
+		ctx := cmdtesting.Context(c)
 		code := cmd.Main(com, ctx, t.args)
 		c.Check(code, gc.Equals, 0)
 		c.Check(bufferString(ctx.Stderr), gc.Equals, "")
@@ -107,7 +107,7 @@ func (s *ConfigGetSuite) TestOutputFormatAll(c *gc.C) {
 		hctx := s.GetHookContext(c, -1, "")
 		com, err := jujuc.NewCommand(hctx, cmdString("config-get"))
 		c.Assert(err, jc.ErrorIsNil)
-		ctx := testing.Context(c)
+		ctx := cmdtesting.Context(c)
 		code := cmd.Main(com, ctx, t.args)
 		c.Assert(code, gc.Equals, 0)
 		c.Assert(bufferString(ctx.Stderr), gc.Equals, "")
@@ -127,7 +127,7 @@ func (s *ConfigGetSuite) TestHelp(c *gc.C) {
 	hctx := s.GetHookContext(c, -1, "")
 	com, err := jujuc.NewCommand(hctx, cmdString("config-get"))
 	c.Assert(err, jc.ErrorIsNil)
-	ctx := testing.Context(c)
+	ctx := cmdtesting.Context(c)
 	code := cmd.Main(com, ctx, []string{"--help"})
 	c.Assert(code, gc.Equals, 0)
 	c.Assert(bufferString(ctx.Stdout), gc.Equals, `Usage: config-get [options] [<key>]
@@ -155,7 +155,7 @@ func (s *ConfigGetSuite) TestOutputPath(c *gc.C) {
 	hctx := s.GetHookContext(c, -1, "")
 	com, err := jujuc.NewCommand(hctx, cmdString("config-get"))
 	c.Assert(err, jc.ErrorIsNil)
-	ctx := testing.Context(c)
+	ctx := cmdtesting.Context(c)
 	code := cmd.Main(com, ctx, []string{"--output", "some-file", "monsters"})
 	c.Assert(code, gc.Equals, 0)
 	c.Assert(bufferString(ctx.Stderr), gc.Equals, "")
@@ -169,14 +169,14 @@ func (s *ConfigGetSuite) TestUnknownArg(c *gc.C) {
 	hctx := s.GetHookContext(c, -1, "")
 	com, err := jujuc.NewCommand(hctx, cmdString("config-get"))
 	c.Assert(err, jc.ErrorIsNil)
-	testing.TestInit(c, com, []string{"multiple", "keys"}, `unrecognized args: \["keys"\]`)
+	cmdtesting.TestInit(c, com, []string{"multiple", "keys"}, `unrecognized args: \["keys"\]`)
 }
 
 func (s *ConfigGetSuite) TestAllPlusKey(c *gc.C) {
 	hctx := s.GetHookContext(c, -1, "")
 	com, err := jujuc.NewCommand(hctx, cmdString("config-get"))
 	c.Assert(err, jc.ErrorIsNil)
-	ctx := testing.Context(c)
+	ctx := cmdtesting.Context(c)
 	code := cmd.Main(com, ctx, []string{"--all", "--format", "json", "monsters"})
 	c.Assert(code, gc.Equals, 2)
 	c.Assert(bufferString(ctx.Stderr), gc.Equals, "ERROR cannot use argument --all together with key \"monsters\"\n")

--- a/worker/uniter/runner/jujuc/is-leader_test.go
+++ b/worker/uniter/runner/jujuc/is-leader_test.go
@@ -9,6 +9,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/cmd/cmdtesting"
 	"github.com/juju/juju/testing"
 	"github.com/juju/juju/worker/uniter/runner/jujuc"
 )
@@ -36,7 +37,7 @@ func (s *isLeaderSuite) TestInitSuccess(c *gc.C) {
 func (s *isLeaderSuite) TestFormatError(c *gc.C) {
 	command, err := jujuc.NewIsLeaderCommand(nil)
 	c.Assert(err, jc.ErrorIsNil)
-	runContext := testing.Context(c)
+	runContext := cmdtesting.Context(c)
 	code := cmd.Main(command, runContext, []string{"--format", "bad"})
 	c.Check(code, gc.Equals, 2)
 	c.Check(bufferString(runContext.Stdout), gc.Equals, "")
@@ -47,7 +48,7 @@ func (s *isLeaderSuite) TestIsLeaderError(c *gc.C) {
 	jujucContext := &isLeaderContext{err: errors.New("pow")}
 	command, err := jujuc.NewIsLeaderCommand(jujucContext)
 	c.Assert(err, jc.ErrorIsNil)
-	runContext := testing.Context(c)
+	runContext := cmdtesting.Context(c)
 	code := cmd.Main(command, runContext, nil)
 	c.Check(code, gc.Equals, 1)
 	c.Check(jujucContext.called, jc.IsTrue)
@@ -91,7 +92,7 @@ func (s *isLeaderSuite) testOutput(c *gc.C, leader bool, args []string, expect s
 	jujucContext := &isLeaderContext{leader: leader}
 	command, err := jujuc.NewIsLeaderCommand(jujucContext)
 	c.Assert(err, jc.ErrorIsNil)
-	runContext := testing.Context(c)
+	runContext := cmdtesting.Context(c)
 	code := cmd.Main(command, runContext, args)
 	c.Check(code, gc.Equals, 0)
 	c.Check(jujucContext.called, jc.IsTrue)
@@ -103,7 +104,7 @@ func (s *isLeaderSuite) testParseOutput(c *gc.C, leader bool, args []string, che
 	jujucContext := &isLeaderContext{leader: leader}
 	command, err := jujuc.NewIsLeaderCommand(jujucContext)
 	c.Assert(err, jc.ErrorIsNil)
-	runContext := testing.Context(c)
+	runContext := cmdtesting.Context(c)
 	code := cmd.Main(command, runContext, args)
 	c.Check(code, gc.Equals, 0)
 	c.Check(jujucContext.called, jc.IsTrue)

--- a/worker/uniter/runner/jujuc/juju-log_test.go
+++ b/worker/uniter/runner/jujuc/juju-log_test.go
@@ -9,7 +9,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
-	"github.com/juju/juju/testing"
+	"github.com/juju/juju/cmd/cmdtesting"
 	"github.com/juju/juju/worker/uniter/runner/jujuc"
 )
 
@@ -28,28 +28,28 @@ func (s *JujuLogSuite) newJujuLogCommand(c *gc.C) cmd.Command {
 
 func (s *JujuLogSuite) TestRequiresMessage(c *gc.C) {
 	com := s.newJujuLogCommand(c)
-	testing.TestInit(c, com, nil, "no message specified")
+	cmdtesting.TestInit(c, com, nil, "no message specified")
 }
 
 func (s *JujuLogSuite) TestLogInitMissingLevel(c *gc.C) {
 	com := s.newJujuLogCommand(c)
-	testing.TestInit(c, com, []string{"-l"}, "flag needs an argument.*")
+	cmdtesting.TestInit(c, com, []string{"-l"}, "flag needs an argument.*")
 
 	com = s.newJujuLogCommand(c)
-	testing.TestInit(c, com, []string{"--log-level"}, "flag needs an argument.*")
+	cmdtesting.TestInit(c, com, []string{"--log-level"}, "flag needs an argument.*")
 }
 
 func (s *JujuLogSuite) TestLogInitMissingMessage(c *gc.C) {
 	com := s.newJujuLogCommand(c)
-	testing.TestInit(c, com, []string{"-l", "FATAL"}, "no message specified")
+	cmdtesting.TestInit(c, com, []string{"-l", "FATAL"}, "no message specified")
 
 	com = s.newJujuLogCommand(c)
-	testing.TestInit(c, com, []string{"--log-level", "FATAL"}, "no message specified")
+	cmdtesting.TestInit(c, com, []string{"--log-level", "FATAL"}, "no message specified")
 }
 
 func (s *JujuLogSuite) TestLogDeprecation(c *gc.C) {
 	com := s.newJujuLogCommand(c)
-	ctx, err := testing.RunCommand(c, com, "--format", "foo", "msg")
+	ctx, err := cmdtesting.RunCommand(c, com, "--format", "foo", "msg")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(testing.Stderr(ctx), gc.Equals, "--format flag deprecated for command \"juju-log\"")
+	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "--format flag deprecated for command \"juju-log\"")
 }

--- a/worker/uniter/runner/jujuc/leader-get_test.go
+++ b/worker/uniter/runner/jujuc/leader-get_test.go
@@ -9,6 +9,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/cmd/cmdtesting"
 	"github.com/juju/juju/testing"
 	"github.com/juju/juju/worker/uniter/runner/jujuc"
 )
@@ -48,7 +49,7 @@ func (s *leaderGetSuite) TestInitEmpty(c *gc.C) {
 }
 
 func (s *leaderGetSuite) TestFormatError(c *gc.C) {
-	runContext := testing.Context(c)
+	runContext := cmdtesting.Context(c)
 	code := cmd.Main(s.command, runContext, []string{"--format", "bad"})
 	c.Check(code, gc.Equals, 2)
 	c.Check(bufferString(runContext.Stdout), gc.Equals, "")
@@ -59,7 +60,7 @@ func (s *leaderGetSuite) TestSettingsError(c *gc.C) {
 	jujucContext := newLeaderGetContext(errors.New("zap"))
 	command, err := jujuc.NewLeaderGetCommand(jujucContext)
 	c.Assert(err, jc.ErrorIsNil)
-	runContext := testing.Context(c)
+	runContext := cmdtesting.Context(c)
 	code := cmd.Main(command, runContext, nil)
 	c.Check(code, gc.Equals, 1)
 	c.Check(jujucContext.called, jc.IsTrue)
@@ -139,7 +140,7 @@ func (s *leaderGetSuite) testParseOutput(c *gc.C, args []string, checker gc.Chec
 	jujucContext := newLeaderGetContext(nil)
 	command, err := jujuc.NewLeaderGetCommand(jujucContext)
 	c.Assert(err, jc.ErrorIsNil)
-	runContext := testing.Context(c)
+	runContext := cmdtesting.Context(c)
 	code := cmd.Main(command, runContext, args)
 	c.Check(code, gc.Equals, 0)
 	c.Check(jujucContext.called, jc.IsTrue)

--- a/worker/uniter/runner/jujuc/leader-set_test.go
+++ b/worker/uniter/runner/jujuc/leader-set_test.go
@@ -10,7 +10,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
-	"github.com/juju/juju/testing"
+	"github.com/juju/juju/cmd/cmdtesting"
 	"github.com/juju/juju/worker/uniter/runner/jujuc"
 )
 
@@ -46,7 +46,7 @@ func (s *leaderSetSuite) TestWriteEmpty(c *gc.C) {
 	jujucContext := &leaderSetContext{}
 	command, err := jujuc.NewLeaderSetCommand(jujucContext)
 	c.Assert(err, jc.ErrorIsNil)
-	runContext := testing.Context(c)
+	runContext := cmdtesting.Context(c)
 	code := cmd.Main(command, runContext, nil)
 	c.Check(code, gc.Equals, 0)
 	c.Check(jujucContext.gotSettings, jc.DeepEquals, map[string]string{})
@@ -58,7 +58,7 @@ func (s *leaderSetSuite) TestWriteValues(c *gc.C) {
 	jujucContext := &leaderSetContext{}
 	command, err := jujuc.NewLeaderSetCommand(jujucContext)
 	c.Assert(err, jc.ErrorIsNil)
-	runContext := testing.Context(c)
+	runContext := cmdtesting.Context(c)
 	code := cmd.Main(command, runContext, []string{"foo=bar", "baz=qux"})
 	c.Check(code, gc.Equals, 0)
 	c.Check(jujucContext.gotSettings, jc.DeepEquals, map[string]string{
@@ -73,7 +73,7 @@ func (s *leaderSetSuite) TestWriteError(c *gc.C) {
 	jujucContext := &leaderSetContext{err: errors.New("splat")}
 	command, err := jujuc.NewLeaderSetCommand(jujucContext)
 	c.Assert(err, jc.ErrorIsNil)
-	runContext := testing.Context(c)
+	runContext := cmdtesting.Context(c)
 	code := cmd.Main(command, runContext, []string{"foo=bar"})
 	c.Check(code, gc.Equals, 1)
 	c.Check(jujucContext.gotSettings, jc.DeepEquals, map[string]string{"foo": "bar"})

--- a/worker/uniter/runner/jujuc/network-get_test.go
+++ b/worker/uniter/runner/jujuc/network-get_test.go
@@ -11,7 +11,7 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/apiserver/params"
-	"github.com/juju/juju/testing"
+	"github.com/juju/juju/cmd/cmdtesting"
 	"github.com/juju/juju/worker/uniter/runner/jujuc"
 )
 
@@ -91,7 +91,7 @@ func (s *NetworkGetSuite) TestNetworkGet(c *gc.C) {
 	}} {
 		c.Logf("test %d: %s", i, t.summary)
 		com := s.createCommand(c)
-		ctx := testing.Context(c)
+		ctx := cmdtesting.Context(c)
 		code := cmd.Main(com, ctx, t.args)
 		c.Check(code, gc.Equals, t.code)
 		if code == 0 {
@@ -132,7 +132,7 @@ the IP address the local unit should advertise as its endpoint to its peers.
 `[1:]
 
 	com := s.createCommand(c)
-	ctx := testing.Context(c)
+	ctx := cmdtesting.Context(c)
 	code := cmd.Main(com, ctx, []string{"--help"})
 	c.Check(code, gc.Equals, 0)
 

--- a/worker/uniter/runner/jujuc/opened-ports_test.go
+++ b/worker/uniter/runner/jujuc/opened-ports_test.go
@@ -10,8 +10,8 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/cmd/cmdtesting"
 	"github.com/juju/juju/network"
-	"github.com/juju/juju/testing"
 	"github.com/juju/juju/worker/uniter/runner/jujuc"
 )
 
@@ -62,7 +62,7 @@ func (s *OpenedPortsSuite) TestBadArgs(c *gc.C) {
 	hctx := s.GetHookContext(c, -1, "")
 	com, err := jujuc.NewCommand(hctx, cmdString("opened-ports"))
 	c.Assert(err, jc.ErrorIsNil)
-	err = testing.InitCommand(com, []string{"foo"})
+	err = cmdtesting.InitCommand(com, []string{"foo"})
 	c.Assert(err, gc.ErrorMatches, `unrecognized args: \["foo"\]`)
 }
 
@@ -70,7 +70,7 @@ func (s *OpenedPortsSuite) TestHelp(c *gc.C) {
 	hctx := s.GetHookContext(c, -1, "")
 	openedPorts, err := jujuc.NewCommand(hctx, cmdString("opened-ports"))
 	c.Assert(err, jc.ErrorIsNil)
-	flags := testing.NewFlagSet()
+	flags := cmdtesting.NewFlagSet()
 	c.Assert(string(openedPorts.Info().Help(flags)), gc.Equals, `
 Usage: opened-ports
 
@@ -95,7 +95,7 @@ func (s *OpenedPortsSuite) getContextAndOpenPorts(c *gc.C) *Context {
 func (s *OpenedPortsSuite) runCommand(c *gc.C, hctx *Context, args ...string) (stdout, stderr string) {
 	com, err := jujuc.NewCommand(hctx, cmdString("opened-ports"))
 	c.Assert(err, jc.ErrorIsNil)
-	ctx := testing.Context(c)
+	ctx := cmdtesting.Context(c)
 	code := cmd.Main(com, ctx, args)
 	c.Assert(code, gc.Equals, 0)
 	return bufferString(ctx.Stdout), bufferString(ctx.Stderr)

--- a/worker/uniter/runner/jujuc/ports_test.go
+++ b/worker/uniter/runner/jujuc/ports_test.go
@@ -12,8 +12,8 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/cmd/cmdtesting"
 	"github.com/juju/juju/network"
-	"github.com/juju/juju/testing"
 	"github.com/juju/juju/worker/uniter/runner/jujuc"
 )
 
@@ -73,7 +73,7 @@ func (s *PortsSuite) TestOpenClose(c *gc.C) {
 	for _, t := range portsTests {
 		com, err := jujuc.NewCommand(hctx, cmdString(t.cmd[0]))
 		c.Assert(err, jc.ErrorIsNil)
-		ctx := testing.Context(c)
+		ctx := cmdtesting.Context(c)
 		code := cmd.Main(com, ctx, t.cmd[1:])
 		c.Assert(code, gc.Equals, 0)
 		c.Assert(bufferString(ctx.Stdout), gc.Equals, "")
@@ -107,7 +107,7 @@ func (s *PortsSuite) TestBadArgs(c *gc.C) {
 			hctx := s.GetHookContext(c, -1, "")
 			com, err := jujuc.NewCommand(hctx, cmdString(name))
 			c.Assert(err, jc.ErrorIsNil)
-			err = testing.InitCommand(com, t.args)
+			err = cmdtesting.InitCommand(com, t.args)
 			c.Assert(err, gc.ErrorMatches, t.err)
 		}
 	}
@@ -117,7 +117,7 @@ func (s *PortsSuite) TestHelp(c *gc.C) {
 	hctx := s.GetHookContext(c, -1, "")
 	open, err := jujuc.NewCommand(hctx, cmdString("open-port"))
 	c.Assert(err, jc.ErrorIsNil)
-	flags := testing.NewFlagSet()
+	flags := cmdtesting.NewFlagSet()
 	c.Assert(string(open.Info().Help(flags)), gc.Equals, `
 Usage: open-port <port>[/<protocol>] or <from>-<to>[/<protocol>]
 
@@ -153,10 +153,10 @@ func (s *PortsSuite) TestOpenCloseDeprecation(c *gc.C) {
 		name := t.cmd[0]
 		com, err := jujuc.NewCommand(hctx, cmdString(name))
 		c.Assert(err, jc.ErrorIsNil)
-		ctx := testing.Context(c)
+		ctx := cmdtesting.Context(c)
 		code := cmd.Main(com, ctx, t.cmd[1:])
 		c.Assert(code, gc.Equals, 0)
-		c.Assert(testing.Stdout(ctx), gc.Equals, "")
-		c.Assert(testing.Stderr(ctx), gc.Equals, "--format flag deprecated for command \""+name+"\"")
+		c.Assert(cmdtesting.Stdout(ctx), gc.Equals, "")
+		c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "--format flag deprecated for command \""+name+"\"")
 	}
 }

--- a/worker/uniter/runner/jujuc/reboot_test.go
+++ b/worker/uniter/runner/jujuc/reboot_test.go
@@ -10,7 +10,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
-	"github.com/juju/juju/testing"
+	"github.com/juju/juju/cmd/cmdtesting"
 	"github.com/juju/juju/worker/uniter/runner/jujuc"
 )
 
@@ -93,7 +93,7 @@ func (s *JujuRebootSuite) TestJujuRebootCommand(c *gc.C) {
 		hctx.rebootPriority = t.hctx.rebootPriority
 		com, err := jujuc.NewCommand(hctx, cmdString("juju-reboot"))
 		c.Assert(err, jc.ErrorIsNil)
-		ctx := testing.Context(c)
+		ctx := cmdtesting.Context(c)
 		code := cmd.Main(com, ctx, t.args)
 		c.Check(code, gc.Equals, t.code)
 		c.Check(hctx.rebootPriority, gc.Equals, t.priority)
@@ -104,8 +104,8 @@ func (s *JujuRebootSuite) TestRebootInActions(c *gc.C) {
 	jujucCtx := &actionGetContext{}
 	com, err := jujuc.NewCommand(jujucCtx, cmdString("juju-reboot"))
 	c.Assert(err, jc.ErrorIsNil)
-	cmdCtx := testing.Context(c)
+	cmdCtx := cmdtesting.Context(c)
 	code := cmd.Main(com, cmdCtx, nil)
 	c.Check(code, gc.Equals, 1)
-	c.Assert(testing.Stderr(cmdCtx), gc.Equals, "ERROR juju-reboot is not supported when running an action.\n")
+	c.Assert(cmdtesting.Stderr(cmdCtx), gc.Equals, "ERROR juju-reboot is not supported when running an action.\n")
 }

--- a/worker/uniter/runner/jujuc/relation-get_test.go
+++ b/worker/uniter/runner/jujuc/relation-get_test.go
@@ -13,7 +13,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
-	"github.com/juju/juju/testing"
+	"github.com/juju/juju/cmd/cmdtesting"
 	"github.com/juju/juju/worker/uniter/runner/jujuc"
 	jujuctesting "github.com/juju/juju/worker/uniter/runner/jujuc/testing"
 )
@@ -146,7 +146,7 @@ func (s *RelationGetSuite) TestRelationGet(c *gc.C) {
 		hctx, _ := s.newHookContext(t.relid, t.unit)
 		com, err := jujuc.NewCommand(hctx, cmdString("relation-get"))
 		c.Assert(err, jc.ErrorIsNil)
-		ctx := testing.Context(c)
+		ctx := cmdtesting.Context(c)
 		code := cmd.Main(com, ctx, t.args)
 		c.Check(code, gc.Equals, t.code)
 		if code == 0 {
@@ -202,7 +202,7 @@ func (s *RelationGetSuite) TestRelationGetFormat(c *gc.C) {
 			hctx, _ := s.newHookContext(t.relid, t.unit)
 			com, err := jujuc.NewCommand(hctx, cmdString("relation-get"))
 			c.Assert(err, jc.ErrorIsNil)
-			ctx := testing.Context(c)
+			ctx := cmdtesting.Context(c)
 			args := append(t.args, "--format", format)
 			code := cmd.Main(com, ctx, args)
 			c.Check(code, gc.Equals, 0)
@@ -265,7 +265,7 @@ func (s *RelationGetSuite) TestHelp(c *gc.C) {
 		hctx, _ := s.newHookContext(t.relid, t.unit)
 		com, err := jujuc.NewCommand(hctx, cmdString("relation-get"))
 		c.Assert(err, jc.ErrorIsNil)
-		ctx := testing.Context(c)
+		ctx := cmdtesting.Context(c)
 		code := cmd.Main(com, ctx, []string{"--help"})
 		c.Assert(code, gc.Equals, 0)
 		unitHelp := ""
@@ -282,7 +282,7 @@ func (s *RelationGetSuite) TestOutputPath(c *gc.C) {
 	hctx, _ := s.newHookContext(1, "m/0")
 	com, err := jujuc.NewCommand(hctx, cmdString("relation-get"))
 	c.Assert(err, jc.ErrorIsNil)
-	ctx := testing.Context(c)
+	ctx := cmdtesting.Context(c)
 	code := cmd.Main(com, ctx, []string{"--output", "some-file", "pew"})
 	c.Assert(code, gc.Equals, 0)
 	c.Assert(bufferString(ctx.Stderr), gc.Equals, "")

--- a/worker/uniter/runner/jujuc/relation-ids_test.go
+++ b/worker/uniter/runner/jujuc/relation-ids_test.go
@@ -11,7 +11,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
-	"github.com/juju/juju/testing"
+	"github.com/juju/juju/cmd/cmdtesting"
 	"github.com/juju/juju/worker/uniter/runner/jujuc"
 )
 
@@ -106,7 +106,7 @@ func (s *RelationIdsSuite) TestRelationIds(c *gc.C) {
 		hctx, _ := s.newHookContext(t.relid, "")
 		com, err := jujuc.NewCommand(hctx, cmdString("relation-ids"))
 		c.Assert(err, jc.ErrorIsNil)
-		ctx := testing.Context(c)
+		ctx := cmdtesting.Context(c)
 		code := cmd.Main(com, ctx, t.args)
 		c.Assert(code, gc.Equals, t.code)
 		if code == 0 {
@@ -148,7 +148,7 @@ Options:
 		hctx, _ := s.newHookContext(relid, "")
 		com, err := jujuc.NewCommand(hctx, cmdString("relation-ids"))
 		c.Assert(err, jc.ErrorIsNil)
-		ctx := testing.Context(c)
+		ctx := cmdtesting.Context(c)
 		code := cmd.Main(com, ctx, []string{"--help"})
 		c.Assert(code, gc.Equals, 0)
 		expect := fmt.Sprintf(template, t.usage, t.doc)

--- a/worker/uniter/runner/jujuc/relation-list_test.go
+++ b/worker/uniter/runner/jujuc/relation-list_test.go
@@ -11,7 +11,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
-	"github.com/juju/juju/testing"
+	"github.com/juju/juju/cmd/cmdtesting"
 	"github.com/juju/juju/worker/uniter/runner/jujuc"
 )
 
@@ -116,7 +116,7 @@ func (s *RelationListSuite) TestRelationList(c *gc.C) {
 		c.Logf("%#v %#v", info.rels[t.relid], t.members1)
 		com, err := jujuc.NewCommand(hctx, cmdString("relation-list"))
 		c.Assert(err, jc.ErrorIsNil)
-		ctx := testing.Context(c)
+		ctx := cmdtesting.Context(c)
 		code := cmd.Main(com, ctx, t.args)
 		c.Logf(bufferString(ctx.Stderr))
 		c.Assert(code, gc.Equals, t.code)
@@ -161,7 +161,7 @@ Options:
 		hctx, _ := s.newHookContext(relid, "")
 		com, err := jujuc.NewCommand(hctx, cmdString("relation-list"))
 		c.Assert(err, jc.ErrorIsNil)
-		ctx := testing.Context(c)
+		ctx := cmdtesting.Context(c)
 		code := cmd.Main(com, ctx, []string{"--help"})
 		c.Assert(code, gc.Equals, 0)
 		expect := fmt.Sprintf(template, t.usage, t.doc)

--- a/worker/uniter/runner/jujuc/relation-set_test.go
+++ b/worker/uniter/runner/jujuc/relation-set_test.go
@@ -14,7 +14,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
-	"github.com/juju/juju/testing"
+	"github.com/juju/juju/cmd/cmdtesting"
 	"github.com/juju/juju/worker/uniter/runner/jujuc"
 	jujuctesting "github.com/juju/juju/worker/uniter/runner/jujuc/testing"
 )
@@ -36,7 +36,7 @@ func (s *RelationSetSuite) TestHelp(c *gc.C) {
 		hctx, _ := s.newHookContext(t.relid, "")
 		com, err := jujuc.NewCommand(hctx, cmdString("relation-set"))
 		c.Assert(err, jc.ErrorIsNil)
-		ctx := testing.Context(c)
+		ctx := cmdtesting.Context(c)
 		code := cmd.Main(com, ctx, []string{"--help"})
 		c.Assert(code, gc.Equals, 0)
 		c.Assert(bufferString(ctx.Stdout), gc.Equals, fmt.Sprintf(`
@@ -106,7 +106,7 @@ func (t relationSetInitTest) init(c *gc.C, s *RelationSetSuite) (cmd.Command, []
 	com, err := jujuc.NewCommand(hctx, cmdString("relation-set"))
 	c.Assert(err, jc.ErrorIsNil)
 
-	ctx := testing.Context(c)
+	ctx := cmdtesting.Context(c)
 
 	// Adjust the args and context for the filename.
 	filename, i := t.filename()
@@ -322,7 +322,7 @@ func (s *RelationSetSuite) TestInit(c *gc.C) {
 		t.log(c, i)
 		com, args, ctx := t.init(c, s)
 
-		err := testing.InitCommand(com, args)
+		err := cmdtesting.InitCommand(com, args)
 		if err == nil {
 			err = jujuc.HandleSettingsFile(com.(*jujuc.RelationSetCommand), ctx)
 		}
@@ -363,7 +363,7 @@ func (s *RelationSetSuite) TestRun(c *gc.C) {
 		rset := com.(*jujuc.RelationSetCommand)
 		rset.RelationId = 1
 		rset.Settings = t.change
-		ctx := testing.Context(c)
+		ctx := cmdtesting.Context(c)
 		err = com.Run(ctx)
 		c.Assert(err, jc.ErrorIsNil)
 
@@ -378,9 +378,9 @@ func (s *RelationSetSuite) TestRunDeprecationWarning(c *gc.C) {
 	com, _ := jujuc.NewCommand(hctx, cmdString("relation-set"))
 
 	// The rel= is needed to make this a valid command.
-	ctx, err := testing.RunCommand(c, com, "--format", "foo", "rel=")
+	ctx, err := cmdtesting.RunCommand(c, com, "--format", "foo", "rel=")
 
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(testing.Stdout(ctx), gc.Equals, "")
-	c.Assert(testing.Stderr(ctx), gc.Equals, "--format flag deprecated for command \"relation-set\"")
+	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, "")
+	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "--format flag deprecated for command \"relation-set\"")
 }

--- a/worker/uniter/runner/jujuc/status-get_test.go
+++ b/worker/uniter/runner/jujuc/status-get_test.go
@@ -13,7 +13,7 @@ import (
 	gc "gopkg.in/check.v1"
 	goyaml "gopkg.in/yaml.v2"
 
-	"github.com/juju/juju/testing"
+	"github.com/juju/juju/cmd/cmdtesting"
 	"github.com/juju/juju/worker/uniter/runner/jujuc"
 )
 
@@ -74,7 +74,7 @@ func (s *statusGetSuite) TestOutputFormatJustStatus(c *gc.C) {
 		setFakeStatus(hctx)
 		com, err := jujuc.NewCommand(hctx, cmdString("status-get"))
 		c.Assert(err, jc.ErrorIsNil)
-		ctx := testing.Context(c)
+		ctx := cmdtesting.Context(c)
 		code := cmd.Main(com, ctx, t.args)
 		c.Assert(code, gc.Equals, 0)
 		c.Assert(bufferString(ctx.Stderr), gc.Equals, "")
@@ -99,7 +99,7 @@ func (s *statusGetSuite) TestHelp(c *gc.C) {
 	hctx := s.GetStatusHookContext(c)
 	com, err := jujuc.NewCommand(hctx, cmdString("status-get"))
 	c.Assert(err, jc.ErrorIsNil)
-	ctx := testing.Context(c)
+	ctx := cmdtesting.Context(c)
 	code := cmd.Main(com, ctx, []string{"--help"})
 	c.Assert(code, gc.Equals, 0)
 	expectedHelp := "" +
@@ -131,7 +131,7 @@ func (s *statusGetSuite) TestOutputPath(c *gc.C) {
 	setFakeStatus(hctx)
 	com, err := jujuc.NewCommand(hctx, cmdString("status-get"))
 	c.Assert(err, jc.ErrorIsNil)
-	ctx := testing.Context(c)
+	ctx := cmdtesting.Context(c)
 	code := cmd.Main(com, ctx, []string{"--format", "json", "--output", "some-file", "--include-data"})
 	c.Assert(code, gc.Equals, 0)
 	c.Assert(bufferString(ctx.Stderr), gc.Equals, "")
@@ -162,7 +162,7 @@ func (s *statusGetSuite) TestServiceStatus(c *gc.C) {
 	setFakeServiceStatus(hctx)
 	com, err := jujuc.NewCommand(hctx, cmdString("status-get"))
 	c.Assert(err, jc.ErrorIsNil)
-	ctx := testing.Context(c)
+	ctx := cmdtesting.Context(c)
 	code := cmd.Main(com, ctx, []string{"--format", "json", "--include-data", "--application"})
 	c.Assert(code, gc.Equals, 0)
 

--- a/worker/uniter/runner/jujuc/status-set_test.go
+++ b/worker/uniter/runner/jujuc/status-set_test.go
@@ -8,7 +8,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
-	"github.com/juju/juju/testing"
+	"github.com/juju/juju/cmd/cmdtesting"
 	"github.com/juju/juju/worker/uniter/runner/jujuc"
 )
 
@@ -40,7 +40,7 @@ func (s *statusSetSuite) TestStatusSetInit(c *gc.C) {
 		hctx := s.GetStatusHookContext(c)
 		com, err := jujuc.NewCommand(hctx, cmdString("status-set"))
 		c.Assert(err, jc.ErrorIsNil)
-		testing.TestInit(c, com, t.args, t.err)
+		cmdtesting.TestInit(c, com, t.args, t.err)
 	}
 }
 
@@ -48,7 +48,7 @@ func (s *statusSetSuite) TestHelp(c *gc.C) {
 	hctx := s.GetStatusHookContext(c)
 	com, err := jujuc.NewCommand(hctx, cmdString("status-set"))
 	c.Assert(err, jc.ErrorIsNil)
-	ctx := testing.Context(c)
+	ctx := cmdtesting.Context(c)
 	code := cmd.Main(com, ctx, []string{"--help"})
 	c.Assert(code, gc.Equals, 0)
 	expectedHelp := "" +
@@ -79,7 +79,7 @@ func (s *statusSetSuite) TestStatus(c *gc.C) {
 		hctx := s.GetStatusHookContext(c)
 		com, err := jujuc.NewCommand(hctx, cmdString("status-set"))
 		c.Assert(err, jc.ErrorIsNil)
-		ctx := testing.Context(c)
+		ctx := cmdtesting.Context(c)
 		code := cmd.Main(com, ctx, args)
 		c.Assert(code, gc.Equals, 0)
 		c.Assert(bufferString(ctx.Stderr), gc.Equals, "")
@@ -101,7 +101,7 @@ func (s *statusSetSuite) TestServiceStatus(c *gc.C) {
 		hctx := s.GetStatusHookContext(c)
 		com, err := jujuc.NewCommand(hctx, cmdString("status-set"))
 		c.Assert(err, jc.ErrorIsNil)
-		ctx := testing.Context(c)
+		ctx := cmdtesting.Context(c)
 		code := cmd.Main(com, ctx, args)
 		c.Assert(code, gc.Equals, 0)
 		c.Assert(bufferString(ctx.Stderr), gc.Equals, "")

--- a/worker/uniter/runner/jujuc/storage-add_test.go
+++ b/worker/uniter/runner/jujuc/storage-add_test.go
@@ -8,7 +8,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
-	"github.com/juju/juju/testing"
+	"github.com/juju/juju/cmd/cmdtesting"
 	"github.com/juju/juju/worker/uniter/runner/jujuc"
 )
 
@@ -32,7 +32,7 @@ func (s *storageAddSuite) getStorageUnitAddCommand(c *gc.C) cmd.Command {
 
 func (s *storageAddSuite) TestHelp(c *gc.C) {
 	com := s.getStorageUnitAddCommand(c)
-	ctx := testing.Context(c)
+	ctx := cmdtesting.Context(c)
 	code := cmd.Main(com, ctx, []string{"--help"})
 	c.Assert(code, gc.Equals, 0)
 	help := `
@@ -72,7 +72,7 @@ func (s *storageAddSuite) TestStorageAddInit(c *gc.C) {
 	for i, t := range tests {
 		c.Logf("test %d: %#v", i, t.args)
 		com := s.getStorageUnitAddCommand(c)
-		testing.TestInit(c, com, t.args, t.err)
+		cmdtesting.TestInit(c, com, t.args, t.err)
 	}
 }
 
@@ -85,7 +85,7 @@ func (s *storageAddSuite) TestAddUnitStorage(c *gc.C) {
 	for i, t := range tests {
 		c.Logf("test %d: %#v", i, t.args)
 		com := s.getStorageUnitAddCommand(c)
-		ctx := testing.Context(c)
+		ctx := cmdtesting.Context(c)
 		code := cmd.Main(com, ctx, t.args)
 		c.Assert(code, gc.Equals, t.code)
 		s.assertOutput(c, ctx, "", t.err)

--- a/worker/uniter/runner/jujuc/storage-get_test.go
+++ b/worker/uniter/runner/jujuc/storage-get_test.go
@@ -13,7 +13,7 @@ import (
 	gc "gopkg.in/check.v1"
 	goyaml "gopkg.in/yaml.v2"
 
-	"github.com/juju/juju/testing"
+	"github.com/juju/juju/cmd/cmdtesting"
 	"github.com/juju/juju/worker/uniter/runner/jujuc"
 )
 
@@ -40,7 +40,7 @@ func (s *storageGetSuite) TestOutputFormatKey(c *gc.C) {
 		hctx, _ := s.newHookContext()
 		com, err := jujuc.NewCommand(hctx, cmdString("storage-get"))
 		c.Assert(err, jc.ErrorIsNil)
-		ctx := testing.Context(c)
+		ctx := cmdtesting.Context(c)
 		code := cmd.Main(com, ctx, t.args)
 		c.Assert(code, gc.Equals, 0)
 		c.Assert(bufferString(ctx.Stderr), gc.Equals, "")
@@ -65,7 +65,7 @@ func (s *storageGetSuite) TestHelp(c *gc.C) {
 	hctx, _ := s.newHookContext()
 	com, err := jujuc.NewCommand(hctx, cmdString("storage-get"))
 	c.Assert(err, jc.ErrorIsNil)
-	ctx := testing.Context(c)
+	ctx := cmdtesting.Context(c)
 	code := cmd.Main(com, ctx, []string{"--help"})
 	c.Assert(code, gc.Equals, 0)
 	c.Assert(bufferString(ctx.Stdout), gc.Equals, `Usage: storage-get [options] [<key>]
@@ -91,7 +91,7 @@ func (s *storageGetSuite) TestOutputPath(c *gc.C) {
 	hctx, _ := s.newHookContext()
 	com, err := jujuc.NewCommand(hctx, cmdString("storage-get"))
 	c.Assert(err, jc.ErrorIsNil)
-	ctx := testing.Context(c)
+	ctx := cmdtesting.Context(c)
 	code := cmd.Main(com, ctx, []string{"--format", "yaml", "--output", "some-file", "-s", "data/0"})
 	c.Assert(code, gc.Equals, 0)
 	c.Assert(bufferString(ctx.Stderr), gc.Equals, "")

--- a/worker/uniter/runner/jujuc/storage-list_test.go
+++ b/worker/uniter/runner/jujuc/storage-list_test.go
@@ -11,7 +11,7 @@ import (
 	gc "gopkg.in/check.v1"
 	goyaml "gopkg.in/yaml.v2"
 
-	"github.com/juju/juju/testing"
+	"github.com/juju/juju/cmd/cmdtesting"
 	"github.com/juju/juju/worker/uniter/runner/jujuc"
 	jujuctesting "github.com/juju/juju/worker/uniter/runner/jujuc/testing"
 )
@@ -78,7 +78,7 @@ func (s *storageListSuite) testOutputFormat(c *gc.C, args []string, format int, 
 	hctx := s.newHookContext()
 	com, err := jujuc.NewCommand(hctx, cmdString("storage-list"))
 	c.Assert(err, jc.ErrorIsNil)
-	ctx := testing.Context(c)
+	ctx := cmdtesting.Context(c)
 	code := cmd.Main(com, ctx, args)
 	c.Assert(code, gc.Equals, 0)
 	c.Assert(bufferString(ctx.Stderr), gc.Equals, "")
@@ -102,7 +102,7 @@ func (s *storageListSuite) TestHelp(c *gc.C) {
 	hctx := s.newHookContext()
 	com, err := jujuc.NewCommand(hctx, cmdString("storage-list"))
 	c.Assert(err, jc.ErrorIsNil)
-	ctx := testing.Context(c)
+	ctx := cmdtesting.Context(c)
 	code := cmd.Main(com, ctx, []string{"--help"})
 	c.Assert(code, gc.Equals, 0)
 	c.Assert(bufferString(ctx.Stdout), gc.Equals, `Usage: storage-list [options] [<storage-name>]

--- a/worker/uniter/runner/jujuc/unit-get_test.go
+++ b/worker/uniter/runner/jujuc/unit-get_test.go
@@ -12,7 +12,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
-	"github.com/juju/juju/testing"
+	"github.com/juju/juju/cmd/cmdtesting"
 	"github.com/juju/juju/worker/uniter/runner/jujuc"
 )
 
@@ -44,7 +44,7 @@ func (s *UnitGetSuite) createCommand(c *gc.C) cmd.Command {
 func (s *UnitGetSuite) TestOutputFormat(c *gc.C) {
 	for _, t := range unitGetTests {
 		com := s.createCommand(c)
-		ctx := testing.Context(c)
+		ctx := cmdtesting.Context(c)
 		code := cmd.Main(com, ctx, t.args)
 		c.Check(code, gc.Equals, 0)
 		c.Check(bufferString(ctx.Stderr), gc.Equals, "")
@@ -54,7 +54,7 @@ func (s *UnitGetSuite) TestOutputFormat(c *gc.C) {
 
 func (s *UnitGetSuite) TestHelp(c *gc.C) {
 	com := s.createCommand(c)
-	ctx := testing.Context(c)
+	ctx := cmdtesting.Context(c)
 	code := cmd.Main(com, ctx, []string{"--help"})
 	c.Assert(code, gc.Equals, 0)
 	c.Assert(bufferString(ctx.Stdout), gc.Equals, `Usage: unit-get [options] <setting>
@@ -73,7 +73,7 @@ Options:
 
 func (s *UnitGetSuite) TestOutputPath(c *gc.C) {
 	com := s.createCommand(c)
-	ctx := testing.Context(c)
+	ctx := cmdtesting.Context(c)
 	code := cmd.Main(com, ctx, []string{"--output", "some-file", "private-address"})
 	c.Assert(code, gc.Equals, 0)
 	c.Assert(bufferString(ctx.Stderr), gc.Equals, "")
@@ -85,12 +85,12 @@ func (s *UnitGetSuite) TestOutputPath(c *gc.C) {
 
 func (s *UnitGetSuite) TestUnknownSetting(c *gc.C) {
 	com := s.createCommand(c)
-	err := testing.InitCommand(com, []string{"protected-address"})
+	err := cmdtesting.InitCommand(com, []string{"protected-address"})
 	c.Assert(err, gc.ErrorMatches, `unknown setting "protected-address"`)
 }
 
 func (s *UnitGetSuite) TestUnknownArg(c *gc.C) {
 	com := s.createCommand(c)
-	err := testing.InitCommand(com, []string{"private-address", "blah"})
+	err := cmdtesting.InitCommand(com, []string{"private-address", "blah"})
 	c.Assert(err, gc.ErrorMatches, `unrecognized args: \["blah"\]`)
 }


### PR DESCRIPTION
Also move the command testing helpers from
the top level testing package.

This is because we don't want to add a cmd/modelcmd
dependency to juju/testing, but having cmd testing
helpers in one place seems like a Good Thing.

Left for the future: use the almost-identical github.com/juju/cmd/cmdtesting
throughout.

We rename the RunCommand that was currently in cmd/testing
to RunCommandWithDummyProvider to avoid the name clash.

We also needed to make the resource/cmd tests external because of
a dubious-looking import cycle caused by this import cycle:

    package github.com/juju/juju/resource/cmd (test)
	imports github.com/juju/juju/cmd/cmdtesting
	imports github.com/juju/juju/provider/dummy
	imports github.com/juju/juju/apiserver
	imports github.com/juju/juju/resource/resourceadapters
	imports github.com/juju/juju/resource/cmd

The apiserver package should really not import any cmd packages,
but that can be fixed some other day.

QA: no regressions.
