### PR TITLE
`juju show-budget` doesn't resolve model names

### DIFF
--- a/cmd/juju/romulus/showbudget/export_test.go
+++ b/cmd/juju/romulus/showbudget/export_test.go
@@ -9,16 +9,7 @@ import (
 
 var (
 	NewBudgetAPIClient = &newBudgetAPIClient
-	NewAPIClient       = &newAPIClient
 )
-
-// APIClientFnc returns a function that returns the provided APIClient
-// and can be used to patch the NewAPIClient variable in tests
-func NewAPIClientFnc(api APIClient) func(*showBudgetCommand) (APIClient, error) {
-	return func(*showBudgetCommand) (APIClient, error) {
-		return api, nil
-	}
-}
 
 // BudgetAPIClientFnc returns a function that returns the provided budgetAPIClient
 // and can be used to patch the NewBudgetAPIClient variable for tests.

--- a/cmd/juju/romulus/showbudget/show_budget.go
+++ b/cmd/juju/romulus/showbudget/show_budget.go
@@ -17,7 +17,6 @@ import (
 	"gopkg.in/juju/names.v2"
 	"gopkg.in/macaroon-bakery.v1/httpbakery"
 
-	"github.com/juju/juju/api/modelmanager"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/cmd/modelcmd"
 )
@@ -86,39 +85,8 @@ func (c *showBudgetCommand) Run(ctx *cmd.Context) error {
 	if err != nil {
 		return errors.Annotate(err, "failed to retrieve the budget")
 	}
-	c.resolveModelNames(budget)
 	err = c.out.Write(ctx, budget)
 	return errors.Trace(err)
-}
-
-// resolveModelNames is a best-effort method to resolve model names - if we
-// encounter any error, we do not issue an error.
-func (c *showBudgetCommand) resolveModelNames(budget *wireformat.BudgetWithAllocations) {
-	models := make([]names.ModelTag, len(budget.Allocations))
-	for i, allocation := range budget.Allocations {
-		models[i] = names.NewModelTag(allocation.Model)
-	}
-	client, err := newAPIClient(c)
-	if err != nil {
-		logger.Warningf("failed to open the API client: %v", err)
-		return
-	}
-	modelInfoSlice, err := client.ModelInfo(models)
-	if err != nil {
-		logger.Debugf("failed to retrieve model info: %v", err)
-		return
-	}
-	for j, info := range modelInfoSlice {
-		if info.Error != nil {
-			logger.Debugf("failed to get info for model %q: %v", models[j], info.Error)
-			continue
-		}
-		for i, allocation := range budget.Allocations {
-			if info.Result.UUID == allocation.Model {
-				budget.Allocations[i].Model = info.Result.Name
-			}
-		}
-	}
 }
 
 // formatTabular returns a tabular view of available budgets.
@@ -145,16 +113,6 @@ func formatTabular(writer io.Writer, value interface{}) error {
 	table.AddRow("Unallocated", "", b.Total.Unallocated, "")
 	fmt.Fprint(writer, table)
 	return nil
-}
-
-var newAPIClient = newAPIClientImpl
-
-func newAPIClientImpl(c *showBudgetCommand) (APIClient, error) {
-	root, err := c.NewControllerAPIRoot()
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	return modelmanager.NewClient(root), nil
 }
 
 type APIClient interface {

--- a/cmd/juju/romulus/showbudget/show_budget_test.go
+++ b/cmd/juju/romulus/showbudget/show_budget_test.go
@@ -33,18 +33,16 @@ func (s *showBudgetSuite) SetUpTest(c *gc.C) {
 	s.mockBudgetAPI = &mockBudgetAPI{s.stub}
 	s.mockAPI = &mockAPI{s.stub}
 	s.PatchValue(showbudget.NewBudgetAPIClient, showbudget.BudgetAPIClientFnc(s.mockBudgetAPI))
-	s.PatchValue(showbudget.NewAPIClient, showbudget.NewAPIClientFnc(s.mockAPI))
 }
 
 func (s *showBudgetSuite) TestShowBudgetCommand(c *gc.C) {
 	tests := []struct {
-		about      string
-		args       []string
-		err        string
-		budget     string
-		apierr     string
-		resolveerr string
-		output     string
+		about  string
+		args   []string
+		err    string
+		budget string
+		apierr string
+		output string
 	}{{
 		about: "missing argument",
 		err:   `missing arguments`,
@@ -61,20 +59,6 @@ func (s *showBudgetSuite) TestShowBudgetCommand(c *gc.C) {
 		about:  "all ok",
 		args:   []string{"personal"},
 		budget: "personal",
-		output: "" +
-			"Model      \tSpent\tAllocated\t       By\tUsage\n" +
-			"model.joe  \t500  \t     1200\t user.joe\t42%  \n" +
-			"model.jess \t600  \t     1000\tuser.jess\t60%  \n" +
-			"uuid3      \t10   \t      100\t user.bob\t10%  \n" +
-			"           \t     \t         \t         \n" +
-			"Total      \t1110 \t     2300\t         \t48%  \n" +
-			"Budget     \t     \t     4000\t         \n" +
-			"Unallocated\t     \t     1700\t         \n",
-	}, {
-		about:      "resolve error",
-		args:       []string{"personal"},
-		budget:     "personal",
-		resolveerr: "test error",
 		output: "" +
 			"Model      \tSpent\tAllocated\t       By\tUsage\n" +
 			"uuid1      \t500  \t     1200\t user.joe\t42%  \n" +
@@ -97,11 +81,6 @@ func (s *showBudgetSuite) TestShowBudgetCommand(c *gc.C) {
 		} else {
 			errs = append(errs, nil)
 		}
-		if test.resolveerr != "" {
-			errs = append(errs, errors.New(test.resolveerr))
-		} else {
-			errs = append(errs, nil)
-		}
 		s.mockAPI.SetErrors(errs...)
 
 		showBudget := showbudget.NewShowBudgetCommand()
@@ -111,7 +90,6 @@ func (s *showBudgetSuite) TestShowBudgetCommand(c *gc.C) {
 			c.Assert(err, jc.ErrorIsNil)
 			s.stub.CheckCalls(c, []testing.StubCall{
 				{"GetBudget", []interface{}{test.budget}},
-				{"ModelInfo", []interface{}{[]names.ModelTag{names.NewModelTag("uuid1"), names.NewModelTag("uuid2"), names.NewModelTag("uuid3")}}},
 			})
 			output := cmdtesting.Stdout(ctx)
 			c.Assert(output, gc.Equals, test.output)
@@ -126,23 +104,7 @@ type mockAPI struct {
 }
 
 func (api *mockAPI) ModelInfo(tags []names.ModelTag) ([]params.ModelInfoResult, error) {
-	api.AddCall("ModelInfo", tags)
-	return []params.ModelInfoResult{{
-		Result: &params.ModelInfo{
-			Name: "model.jess",
-			UUID: "uuid2",
-		},
-	}, {
-		Result: &params.ModelInfo{
-			Name: "model.joe",
-			UUID: "uuid1",
-		},
-	}, {
-		Error: &params.Error{
-			Message: "not found",
-		},
-	},
-	}, api.NextErr()
+	return nil, api.NextErr()
 }
 
 type mockBudgetAPI struct {


### PR DESCRIPTION
## Description of change

> Why is this change needed?

It's inappropriate to resolve model UUIDs to names in the context of a connection to a single controller or model. This needs to be done across all models that the user's Juju client knows about locally. See https://bugs.launchpad.net/juju/+bug/1636635

Resolving the model UUID to name currently panics with recent refactoring to modelcmd wrapping. Instead of trying to fix an already broken implementation, I've decided to remove the brokenness. Will follow up with a solution to resolve model names across controllers.   

## QA steps

> How do we verify that the change works?

`juju show-budget` will not panic and will display all model allocations, but with model UUIDs. This isn't optimal, but at least is correct and can be improved upon.

## Documentation changes

> Does it affect current user workflow? CLI? API?

None other than explained above.

## Bug reference

> Does this change fix a bug? Please add a link to it.

N/A