### PR TITLE
provider/vsphere: separate API-facing code

### DIFF
--- a/provider/vsphere/internal/vsphereclient/client.go
+++ b/provider/vsphere/internal/vsphereclient/client.go
@@ -1,0 +1,329 @@
+// Copyright 2015-2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package vsphereclient
+
+import (
+	"net/url"
+	"path"
+	"strings"
+
+	"github.com/juju/errors"
+	"github.com/juju/loggo"
+	"github.com/vmware/govmomi"
+	"github.com/vmware/govmomi/find"
+	"github.com/vmware/govmomi/list"
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/property"
+	"github.com/vmware/govmomi/vim25/mo"
+	"github.com/vmware/govmomi/vim25/soap"
+	"github.com/vmware/govmomi/vim25/types"
+	"golang.org/x/net/context"
+)
+
+// Client encapsulates a vSphere client, exposing the subset of
+// functionality that we require in the Juju provider.
+type Client struct {
+	client     *govmomi.Client
+	datacenter string
+	logger     loggo.Logger
+}
+
+// Dial dials a new vSphere client connection using the given URL,
+// scoped to the specified dataceter. The resulting Client's Close
+// method must be called in order to release resources allocated by
+// Dial.
+func Dial(
+	ctx context.Context,
+	u *url.URL,
+	datacenter string,
+	logger loggo.Logger,
+) (*Client, error) {
+	client, err := govmomi.NewClient(ctx, u, true)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return &Client{client, datacenter, logger}, nil
+}
+
+// Close logs out and closes the client connection.
+func (c *Client) Close(ctx context.Context) error {
+	return c.client.Logout(ctx)
+}
+
+func (c *Client) recurser() *list.Recurser {
+	return &list.Recurser{
+		Collector: property.DefaultCollector(c.client.Client),
+		All:       true,
+	}
+}
+
+func (c *Client) finder(ctx context.Context) (*find.Finder, *object.Datacenter, error) {
+	finder := find.NewFinder(c.client.Client, true)
+	datacenter, err := finder.Datacenter(ctx, c.datacenter)
+	if err != nil {
+		return nil, nil, errors.Trace(err)
+	}
+	finder.SetDatacenter(datacenter)
+	return finder, datacenter, nil
+}
+
+// RemoveVirtualMachines removes VMs matching the given path from the
+// system. The path may include wildcards, to match multiple VMs.
+func (c *Client) RemoveVirtualMachines(ctx context.Context, path string) error {
+	finder, _, err := c.finder(ctx)
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	vms, err := finder.VirtualMachineList(ctx, path)
+	if err != nil {
+		if _, ok := err.(*find.NotFoundError); ok {
+			c.logger.Debugf("no VMs matching path %q", path)
+			return nil
+		}
+		return errors.Annotatef(err, "listing VMs at %q", path)
+	}
+
+	// We run all tasks in parallel, and wait for them below.
+	var lastError error
+	tasks := make([]*object.Task, 0, len(vms)*2)
+	for _, vm := range vms {
+		c.logger.Debugf("powering off %q", vm.Name())
+		task, err := vm.PowerOff(ctx)
+		if err != nil {
+			lastError = errors.Annotatef(err, "powering off %q", vm.Name())
+			c.logger.Errorf(err.Error())
+			continue
+		}
+		tasks = append(tasks, task)
+
+		c.logger.Debugf("destroying %q", vm.Name())
+		task, err = vm.Destroy(ctx)
+		if err != nil {
+			lastError = errors.Annotatef(err, "destroying %q", vm.Name())
+			c.logger.Errorf(err.Error())
+			continue
+		}
+		tasks = append(tasks, task)
+	}
+
+	for _, task := range tasks {
+		_, err := task.WaitForResult(ctx, nil)
+		if err != nil {
+			lastError = err
+			c.logger.Errorf(err.Error())
+		}
+	}
+	return errors.Annotate(lastError, "failed to remove instances")
+}
+
+// VirtualMachines return list of all VMs in the system matching the given path.
+func (c *Client) VirtualMachines(ctx context.Context, path string) ([]*mo.VirtualMachine, error) {
+	finder, _, err := c.finder(ctx)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	items, err := finder.VirtualMachineList(ctx, path)
+	if err != nil {
+		if _, ok := err.(*find.NotFoundError); ok {
+			return nil, nil
+		}
+		return nil, errors.Annotate(err, "listing VMs")
+	}
+
+	vms := make([]*mo.VirtualMachine, len(items))
+	for i, item := range items {
+		var vm mo.VirtualMachine
+		err := c.client.RetrieveOne(ctx, item.Reference(), nil, &vm)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		vms[i] = &vm
+	}
+	return vms, nil
+}
+
+// ComputeResources retuns list of all root compute resources in the system.
+func (c *Client) ComputeResources(ctx context.Context) ([]*mo.ComputeResource, error) {
+	_, datacenter, err := c.finder(ctx)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	folders, err := datacenter.Folders(ctx)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	root := list.Element{Object: folders.HostFolder}
+	es, err := c.recurser().Recurse(ctx, root, []string{"*"})
+	if err != nil {
+		return nil, err
+	}
+
+	var cprs []*mo.ComputeResource
+	for _, e := range es {
+		switch o := e.Object.(type) {
+		case mo.ClusterComputeResource:
+			cprs = append(cprs, &o.ComputeResource)
+		case mo.ComputeResource:
+			cprs = append(cprs, &o)
+		}
+	}
+	return cprs, nil
+}
+
+// EnsureVMFolder creates the a VM folder with the given path if it doesn't
+// already exist.
+func (c *Client) EnsureVMFolder(ctx context.Context, folderPath string) error {
+	finder, datacenter, err := c.finder(ctx)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	folders, err := datacenter.Folders(ctx)
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	createFolder := func(parent *object.Folder, name string) (*object.Folder, error) {
+		folder, err := parent.CreateFolder(ctx, name)
+		if err != nil && soap.IsSoapFault(err) {
+			switch soap.ToSoapFault(err).VimFault().(type) {
+			case types.DuplicateName:
+				return finder.Folder(ctx, parent.InventoryPath+"/"+name)
+			}
+		}
+		return folder, err
+	}
+
+	parentFolder := folders.VmFolder
+	for _, name := range strings.Split(folderPath, "/") {
+		folder, err := createFolder(parentFolder, name)
+		if err != nil {
+			return errors.Annotatef(
+				err, "creating folder %q in %q",
+				name, parentFolder.InventoryPath,
+			)
+		}
+		parentFolder = folder
+	}
+	return nil
+}
+
+// DestroyVMFolder destroys a folder rooted at the datacenter's base VM folder.
+func (c *Client) DestroyVMFolder(ctx context.Context, folderPath string) error {
+	finder, datacenter, err := c.finder(ctx)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	folders, err := datacenter.Folders(ctx)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	folderPath = path.Join(folders.VmFolder.InventoryPath, folderPath)
+	folder, err := finder.Folder(ctx, folderPath)
+	if err != nil {
+		if _, ok := err.(*find.NotFoundError); ok {
+			return nil
+		}
+		return errors.Trace(err)
+	}
+
+	task, err := folder.Destroy(ctx)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	if _, err := task.WaitForResult(ctx, nil); err != nil {
+		return errors.Trace(err)
+	}
+	return nil
+}
+
+// MoveVMFolderInto moves one VM folder into another.
+func (c *Client) MoveVMFolderInto(ctx context.Context, parentPath, childPath string) error {
+	finder, datacenter, err := c.finder(ctx)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	folders, err := datacenter.Folders(ctx)
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	parentPath = path.Join(folders.VmFolder.InventoryPath, parentPath)
+	childPath = path.Join(folders.VmFolder.InventoryPath, childPath)
+	parent, err := finder.Folder(ctx, parentPath)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	child, err := finder.Folder(ctx, childPath)
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	task, err := parent.MoveInto(ctx, []types.ManagedObjectReference{child.Reference()})
+	if err != nil {
+		return errors.Trace(err)
+	}
+	if _, err := task.WaitForResult(ctx, nil); err != nil {
+		return errors.Trace(err)
+	}
+	return nil
+}
+
+// MoveVMsInto moves a set of VMs into a folder.
+func (c *Client) MoveVMsInto(
+	ctx context.Context,
+	folderPath string,
+	vms ...types.ManagedObjectReference,
+) error {
+	finder, datacenter, err := c.finder(ctx)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	folders, err := datacenter.Folders(ctx)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	folderPath = path.Join(folders.VmFolder.InventoryPath, folderPath)
+	folder, err := finder.Folder(ctx, folderPath)
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	task, err := folder.MoveInto(ctx, vms)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	if _, err := task.WaitForResult(ctx, nil); err != nil {
+		return errors.Trace(err)
+	}
+	return nil
+}
+
+// UpdateVirtualMachineExtraConfig updates the "ExtraConfig" attributes
+// of the specified virtual machine. Keys with empty values will be
+// removed from the config; existing keys that are unspecified in the
+// map will be untouched.
+func (c *Client) UpdateVirtualMachineExtraConfig(
+	ctx context.Context,
+	vmInfo *mo.VirtualMachine,
+	metadata map[string]string,
+) error {
+	var spec types.VirtualMachineConfigSpec
+	for k, v := range metadata {
+		opt := &types.OptionValue{Key: k}
+		if v != "" {
+			opt.Value = v
+		}
+		spec.ExtraConfig = append(spec.ExtraConfig, opt)
+	}
+	vm := object.NewVirtualMachine(c.client.Client, vmInfo.Reference())
+	task, err := vm.Reconfigure(ctx, spec)
+	if err != nil {
+		return errors.Annotate(err, "reconfiguring VM")
+	}
+	if _, err := task.WaitForResult(ctx, nil); err != nil {
+		return errors.Annotate(err, "reconfiguring VM")
+	}
+	return nil
+}

--- a/provider/vsphere/internal/vsphereclient/client_test.go
+++ b/provider/vsphere/internal/vsphereclient/client_test.go
@@ -1,0 +1,445 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package vsphereclient
+
+import (
+	"bytes"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+
+	"github.com/juju/loggo"
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	"github.com/vmware/govmomi"
+	"github.com/vmware/govmomi/session"
+	"github.com/vmware/govmomi/vim25"
+	"github.com/vmware/govmomi/vim25/methods"
+	"github.com/vmware/govmomi/vim25/mo"
+	"github.com/vmware/govmomi/vim25/soap"
+	"github.com/vmware/govmomi/vim25/types"
+	"github.com/vmware/govmomi/vim25/xml"
+	"golang.org/x/net/context"
+	gc "gopkg.in/check.v1"
+)
+
+type clientSuite struct {
+	testing.IsolationSuite
+
+	server         *httptest.Server
+	serviceContent types.ServiceContent
+	roundTripper   mockRoundTripper
+	uploadRequests []*http.Request
+}
+
+var _ = gc.Suite(&clientSuite{})
+
+func (s *clientSuite) SetUpTest(c *gc.C) {
+	s.IsolationSuite.SetUpTest(c)
+	s.serviceContent = types.ServiceContent{
+		RootFolder: types.ManagedObjectReference{
+			Type:  "Folder",
+			Value: "FakeRootFolder",
+		},
+		OvfManager: &types.ManagedObjectReference{
+			Type:  "OvfManager",
+			Value: "FakeOvfManager",
+		},
+		SessionManager: &types.ManagedObjectReference{
+			Type:  "SessionManager",
+			Value: "FakeSessionManager",
+		},
+		PropertyCollector: types.ManagedObjectReference{
+			Type:  "PropertyCollector",
+			Value: "FakePropertyCollector",
+		},
+	}
+	s.roundTripper = mockRoundTripper{
+		collectors: make(map[string]*collector),
+	}
+	s.roundTripper.contents = map[string][]types.ObjectContent{
+		"FakeRootFolder": []types.ObjectContent{{
+			Obj: types.ManagedObjectReference{
+				Type:  "Datacenter",
+				Value: "FakeDatacenter",
+			},
+			PropSet: []types.DynamicProperty{
+				types.DynamicProperty{Name: "name", Val: "dc0"},
+			},
+		}},
+		"FakeDatacenter": []types.ObjectContent{{
+			Obj: types.ManagedObjectReference{
+				Type:  "Datacenter",
+				Value: "FakeDatacenter",
+			},
+			PropSet: []types.DynamicProperty{
+				types.DynamicProperty{Name: "name", Val: "dc0"},
+				types.DynamicProperty{Name: "hostFolder", Val: types.ManagedObjectReference{
+					Type:  "Folder",
+					Value: "FakeHostFolder",
+				}},
+				types.DynamicProperty{Name: "vmFolder", Val: types.ManagedObjectReference{
+					Type:  "Folder",
+					Value: "FakeVmFolder",
+				}},
+			},
+		}, {
+			Obj: types.ManagedObjectReference{
+				Type:  "Folder",
+				Value: "FakeVmFolder",
+			},
+			PropSet: []types.DynamicProperty{{Name: "name", Val: "vm"}},
+		}, {
+			Obj: types.ManagedObjectReference{
+				Type:  "Folder",
+				Value: "FakeHostFolder",
+			},
+			PropSet: []types.DynamicProperty{{Name: "name", Val: "vm"}},
+		}},
+		"FakeHostFolder": []types.ObjectContent{{
+			Obj: types.ManagedObjectReference{
+				Type:  "ComputeResource",
+				Value: "z0",
+			},
+			PropSet: []types.DynamicProperty{
+				{Name: "resourcePool", Val: types.ManagedObjectReference{
+					Type:  "ResourcePool",
+					Value: "FakeResourcePool1",
+				}},
+				{Name: "datastore", Val: []types.ManagedObjectReference{{
+					Type:  "Datastore",
+					Value: "FakeDatastore1",
+				}}},
+				{Name: "name", Val: "z0"},
+			},
+		}, {
+			Obj: types.ManagedObjectReference{
+				Type:  "ComputeResource",
+				Value: "z1",
+			},
+			PropSet: []types.DynamicProperty{
+				{Name: "resourcePool", Val: types.ManagedObjectReference{
+					Type:  "ResourcePool",
+					Value: "FakeResourcePool2",
+				}},
+				{Name: "datastore", Val: []types.ManagedObjectReference{{
+					Type:  "Datastore",
+					Value: "FakeDatastore2",
+				}}},
+				{Name: "name", Val: "z1"},
+			},
+		}},
+		"FakeVmFolder": []types.ObjectContent{{
+			Obj: types.ManagedObjectReference{
+				Type:  "Folder",
+				Value: "FakeControllerVmFolder",
+			},
+			PropSet: []types.DynamicProperty{
+				{Name: "name", Val: "foo"},
+			},
+		}},
+		"FakeControllerVmFolder": []types.ObjectContent{{
+			Obj: types.ManagedObjectReference{
+				Type:  "Folder",
+				Value: "FakeModelVmFolder",
+			},
+			PropSet: []types.DynamicProperty{
+				{Name: "name", Val: "bar"},
+			},
+		}},
+		"FakeModelVmFolder": []types.ObjectContent{{
+			Obj: types.ManagedObjectReference{
+				Type:  "VirtualMachine",
+				Value: "FakeVm0",
+			},
+			PropSet: []types.DynamicProperty{
+				{Name: "name", Val: "vm-0"},
+			},
+		}, {
+			Obj: types.ManagedObjectReference{
+				Type:  "VirtualMachine",
+				Value: "FakeVm1",
+			},
+			PropSet: []types.DynamicProperty{
+				{Name: "name", Val: "vm-1"},
+			},
+		}},
+		"FakeVm0": []types.ObjectContent{{
+			Obj: types.ManagedObjectReference{
+				Type:  "VirtualMachine",
+				Value: "FakeVm0",
+			},
+			PropSet: []types.DynamicProperty{
+				{Name: "name", Val: "vm-0"},
+				{
+					Name: "resourcePool",
+					Val: types.ManagedObjectReference{
+						Type:  "ResourcePool",
+						Value: "FakeResourcePool0",
+					},
+				},
+			},
+		}},
+		"FakeVm1": []types.ObjectContent{{
+			Obj: types.ManagedObjectReference{
+				Type:  "VirtualMachine",
+				Value: "FakeVm1",
+			},
+			PropSet: []types.DynamicProperty{
+				{Name: "name", Val: "vm-1"},
+				{
+					Name: "resourcePool",
+					Val: types.ManagedObjectReference{
+						Type:  "ResourcePool",
+						Value: "FakeResourcePool1",
+					},
+				},
+			},
+		}},
+	}
+
+	// Create an HTTP server to receive image uploads.
+	mux := http.NewServeMux()
+	mux.HandleFunc("/disk-device/", func(w http.ResponseWriter, r *http.Request) {
+		var buf bytes.Buffer
+		io.Copy(&buf, r.Body)
+		rcopy := *r
+		rcopy.Body = ioutil.NopCloser(&buf)
+		s.uploadRequests = append(s.uploadRequests, &rcopy)
+	})
+	s.server = httptest.NewServer(mux)
+	s.AddCleanup(func(*gc.C) {
+		s.server.Close()
+	})
+	s.roundTripper.serverURL = s.server.URL
+}
+
+func (s *clientSuite) newFakeClient(roundTripper soap.RoundTripper, dc string) *Client {
+	vimClient := &vim25.Client{
+		Client:         soap.NewClient(&url.URL{}, true),
+		ServiceContent: s.serviceContent,
+		RoundTripper:   roundTripper,
+	}
+	return &Client{
+		client: &govmomi.Client{
+			Client:         vimClient,
+			SessionManager: session.NewManager(vimClient),
+		},
+		datacenter: dc,
+		logger:     loggo.GetLogger("vsphereclient"),
+	}
+}
+
+func (s *clientSuite) TestDial(c *gc.C) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		e := xml.NewEncoder(w)
+		e.Encode(soap.Envelope{Body: methods.RetrieveServiceContentBody{
+			Res: &types.RetrieveServiceContentResponse{s.serviceContent},
+		}})
+		e.Flush()
+	})
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	url, err := url.Parse(server.URL)
+	c.Assert(err, jc.ErrorIsNil)
+
+	ctx := context.Background()
+	client, err := Dial(ctx, url, "dc", loggo.GetLogger("vsphereclient"))
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(client, gc.NotNil)
+}
+
+func (s *clientSuite) TestClose(c *gc.C) {
+	client := s.newFakeClient(&s.roundTripper, "dc0")
+	err := client.Close(context.Background())
+	c.Assert(err, jc.ErrorIsNil)
+	s.roundTripper.CheckCallNames(c, "Logout")
+}
+
+func (s *clientSuite) TestComputeResources(c *gc.C) {
+	client := s.newFakeClient(&s.roundTripper, "dc0")
+	result, err := client.ComputeResources(context.Background())
+	c.Assert(err, jc.ErrorIsNil)
+
+	s.roundTripper.CheckCalls(c, []testing.StubCall{
+		retrievePropertiesStubCall("FakeRootFolder"),
+		retrievePropertiesStubCall("FakeRootFolder"),
+		retrievePropertiesStubCall("FakeDatacenter"),
+		retrievePropertiesStubCall("FakeHostFolder"),
+	})
+
+	c.Assert(result, gc.HasLen, 2)
+	c.Assert(result[0].Name, gc.Equals, "z0")
+	c.Assert(result[1].Name, gc.Equals, "z1")
+}
+
+func (s *clientSuite) TestDestroyVMFolder(c *gc.C) {
+	client := s.newFakeClient(&s.roundTripper, "dc0")
+	err := client.DestroyVMFolder(context.Background(), "foo")
+	c.Assert(err, jc.ErrorIsNil)
+
+	s.roundTripper.CheckCalls(c, []testing.StubCall{
+		retrievePropertiesStubCall("FakeRootFolder"),
+		retrievePropertiesStubCall("FakeRootFolder"),
+		retrievePropertiesStubCall("FakeDatacenter"),
+		retrievePropertiesStubCall("FakeRootFolder"),
+		retrievePropertiesStubCall("FakeDatacenter"),
+		retrievePropertiesStubCall("FakeVmFolder"),
+		retrievePropertiesStubCall("FakeHostFolder"),
+		testing.StubCall{"Destroy_Task", nil},
+		testing.StubCall{"CreatePropertyCollector", nil},
+		testing.StubCall{"CreateFilter", nil},
+		testing.StubCall{"WaitForUpdatesEx", nil},
+	})
+}
+
+func (s *clientSuite) TestEnsureVMFolder(c *gc.C) {
+	client := s.newFakeClient(&s.roundTripper, "dc0")
+	err := client.EnsureVMFolder(context.Background(), "foo/bar")
+	c.Assert(err, jc.ErrorIsNil)
+
+	s.roundTripper.CheckCalls(c, []testing.StubCall{
+		retrievePropertiesStubCall("FakeRootFolder"),
+		retrievePropertiesStubCall("FakeRootFolder"),
+		retrievePropertiesStubCall("FakeDatacenter"),
+		testing.StubCall{"CreateFolder", nil},
+		testing.StubCall{"CreateFolder", nil},
+	})
+}
+
+func (s *clientSuite) TestMoveVMFolderInto(c *gc.C) {
+	client := s.newFakeClient(&s.roundTripper, "dc0")
+	err := client.MoveVMFolderInto(context.Background(), "foo", "foo/bar")
+	c.Assert(err, jc.ErrorIsNil)
+
+	s.roundTripper.CheckCalls(c, []testing.StubCall{
+		retrievePropertiesStubCall("FakeRootFolder"),
+		retrievePropertiesStubCall("FakeRootFolder"),
+		retrievePropertiesStubCall("FakeDatacenter"),
+		retrievePropertiesStubCall("FakeRootFolder"),
+		retrievePropertiesStubCall("FakeDatacenter"),
+		retrievePropertiesStubCall("FakeVmFolder"),
+		retrievePropertiesStubCall("FakeHostFolder"),
+		retrievePropertiesStubCall("FakeRootFolder"),
+		retrievePropertiesStubCall("FakeDatacenter"),
+		retrievePropertiesStubCall("FakeVmFolder"),
+		retrievePropertiesStubCall("FakeControllerVmFolder"),
+		retrievePropertiesStubCall("FakeHostFolder"),
+		testing.StubCall{"MoveIntoFolder_Task", nil},
+		testing.StubCall{"CreatePropertyCollector", nil},
+		testing.StubCall{"CreateFilter", nil},
+		testing.StubCall{"WaitForUpdatesEx", nil},
+	})
+}
+
+func (s *clientSuite) TestMoveVMsInto(c *gc.C) {
+	client := s.newFakeClient(&s.roundTripper, "dc0")
+	err := client.MoveVMsInto(
+		context.Background(), "foo",
+		types.ManagedObjectReference{
+			Type:  "VirtualMachine",
+			Value: "vm-0",
+		},
+		types.ManagedObjectReference{
+			Type:  "VirtualMachine",
+			Value: "vm-1",
+		},
+	)
+	c.Assert(err, jc.ErrorIsNil)
+
+	s.roundTripper.CheckCalls(c, []testing.StubCall{
+		retrievePropertiesStubCall("FakeRootFolder"),
+		retrievePropertiesStubCall("FakeRootFolder"),
+		retrievePropertiesStubCall("FakeDatacenter"),
+		retrievePropertiesStubCall("FakeRootFolder"),
+		retrievePropertiesStubCall("FakeDatacenter"),
+		retrievePropertiesStubCall("FakeVmFolder"),
+		retrievePropertiesStubCall("FakeHostFolder"),
+		testing.StubCall{"MoveIntoFolder_Task", nil},
+		testing.StubCall{"CreatePropertyCollector", nil},
+		testing.StubCall{"CreateFilter", nil},
+		testing.StubCall{"WaitForUpdatesEx", nil},
+	})
+}
+
+func (s *clientSuite) TestRemoveVirtualMachines(c *gc.C) {
+	client := s.newFakeClient(&s.roundTripper, "dc0")
+	err := client.RemoveVirtualMachines(context.Background(), "foo/bar/*")
+	c.Assert(err, jc.ErrorIsNil)
+
+	s.roundTripper.CheckCalls(c, []testing.StubCall{
+		retrievePropertiesStubCall("FakeRootFolder"),
+		retrievePropertiesStubCall("FakeRootFolder"),
+		retrievePropertiesStubCall("FakeDatacenter"),
+		retrievePropertiesStubCall("FakeVmFolder"),
+		retrievePropertiesStubCall("FakeVmFolder"),
+		retrievePropertiesStubCall("FakeControllerVmFolder"),
+		retrievePropertiesStubCall("FakeModelVmFolder"),
+		testing.StubCall{"PowerOffVM_Task", nil},
+		testing.StubCall{"Destroy_Task", nil},
+		testing.StubCall{"PowerOffVM_Task", nil},
+		testing.StubCall{"Destroy_Task", nil},
+		testing.StubCall{"CreatePropertyCollector", nil},
+		testing.StubCall{"CreateFilter", nil},
+		testing.StubCall{"WaitForUpdatesEx", nil},
+		testing.StubCall{"CreatePropertyCollector", nil},
+		testing.StubCall{"CreateFilter", nil},
+		testing.StubCall{"WaitForUpdatesEx", nil},
+		testing.StubCall{"CreatePropertyCollector", nil},
+		testing.StubCall{"CreateFilter", nil},
+		testing.StubCall{"WaitForUpdatesEx", nil},
+		testing.StubCall{"CreatePropertyCollector", nil},
+		testing.StubCall{"CreateFilter", nil},
+		testing.StubCall{"WaitForUpdatesEx", nil},
+	})
+}
+
+func (s *clientSuite) TestUpdateVirtualMachineExtraConfig(c *gc.C) {
+	client := s.newFakeClient(&s.roundTripper, "dc0")
+	var vm mo.VirtualMachine
+	vm.Self = types.ManagedObjectReference{
+		Type:  "VirtualMachine",
+		Value: "FakeVm0",
+	}
+	err := client.UpdateVirtualMachineExtraConfig(
+		context.Background(), &vm, map[string]string{
+			"k0": "v0",
+			"k1": "",
+		},
+	)
+	c.Assert(err, jc.ErrorIsNil)
+
+	s.roundTripper.CheckCallNames(c,
+		"ReconfigVM_Task",
+		"CreatePropertyCollector",
+		"CreateFilter",
+		"WaitForUpdatesEx",
+	)
+}
+
+func (s *clientSuite) TestVirtualMachines(c *gc.C) {
+	client := s.newFakeClient(&s.roundTripper, "dc0")
+	result, err := client.VirtualMachines(context.Background(), "foo/bar/*")
+	c.Assert(err, jc.ErrorIsNil)
+
+	s.roundTripper.CheckCalls(c, []testing.StubCall{
+		retrievePropertiesStubCall("FakeRootFolder"),
+		retrievePropertiesStubCall("FakeRootFolder"),
+		retrievePropertiesStubCall("FakeDatacenter"),
+		retrievePropertiesStubCall("FakeVmFolder"),
+		retrievePropertiesStubCall("FakeVmFolder"),
+		retrievePropertiesStubCall("FakeControllerVmFolder"),
+		retrievePropertiesStubCall("FakeModelVmFolder"),
+		retrievePropertiesStubCall("FakeVm0"),
+		retrievePropertiesStubCall("FakeVm1"),
+	})
+
+	c.Assert(result, gc.HasLen, 2)
+	c.Assert(result[0].Name, gc.Equals, "vm-0")
+	c.Assert(result[1].Name, gc.Equals, "vm-1")
+}

--- a/provider/vsphere/internal/vsphereclient/createvm.go
+++ b/provider/vsphere/internal/vsphereclient/createvm.go
@@ -1,0 +1,357 @@
+// Copyright 2015-2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package vsphereclient
+
+import (
+	"fmt"
+	"net/url"
+	"os"
+	"path"
+	"path/filepath"
+
+	"github.com/juju/errors"
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/vim25"
+	"github.com/vmware/govmomi/vim25/mo"
+	"github.com/vmware/govmomi/vim25/progress"
+	"github.com/vmware/govmomi/vim25/soap"
+	"github.com/vmware/govmomi/vim25/types"
+	"golang.org/x/net/context"
+	tomb "gopkg.in/tomb.v1"
+
+	"github.com/juju/juju/constraints"
+)
+
+// CreateVirtualMachineParams contains the parameters required for creating
+// a new virtual machine.
+type CreateVirtualMachineParams struct {
+	// Name is the name to give the virtual machine. The VM name is used
+	// for its hostname also.
+	Name string
+
+	// Folder is the path of the VM folder, relative to the root VM folder,
+	// in which to create the VM.
+	Folder string
+
+	// OVAContentsDir is the directory containing the extracted OVA contents.
+	OVADir string
+
+	// OVF contains the OVF content.
+	OVF string
+
+	// UserData is the cloud-init user-data.
+	UserData string
+
+	// ComputeResource is the compute resource (host or cluster) to be used
+	// to create the VM.
+	ComputeResource *mo.ComputeResource
+
+	// Metadata are metadata key/value pairs to apply to the VM as
+	// "extra config".
+	Metadata map[string]string
+
+	// Constraints contains the resource constraints for the virtual machine.
+	Constraints constraints.Value
+
+	// ExternalNetwork, if set, is the name of an additional "external"
+	// network to which the VM should be connected.
+	ExternalNetwork string
+
+	// UpdateProgress is a function that should be called before/during
+	// long-running operations to provide a progress reporting.
+	UpdateProgress func(string)
+}
+
+// CreateVirtualMachine creates and powers on a new VM.
+//
+// This method imports an OVF template using the vSphere API. This process
+// comprises the following steps:
+//   1. Download the OVA archive, extract it, and load the OVF file contained
+//      within. This must have happened before CreateVirtualMachine is called.
+//   2. Call CreateImportSpec [0], which validates the OVF descriptor against
+//      the hardware supported by the host system. If the validation succeeds,
+//      the method returns a result containing:
+//        - an ImportSpec to use for importing the entity
+//        - a list of items to upload from the OVA (e.g. VMDKs)
+//   3. Prepare all necessary parameters (CPU, memory, root disk, etc.), and
+//      call the ImportVApp method [0]. This method is responsible for actually
+//      creating the VM. An HttpNfcLease [1] object is returned, which is used
+//      to signal completion of the process.
+//   4. Upload virtual disk contents (usually consists of a single VMDK file)
+//   5. Call HttpNfcLeaseComplete [0] to signal completion of uploading,
+//      completing the process of creating the virtual machine.
+//
+// [0] https://www.vmware.com/support/developer/vc-sdk/visdk41pubs/ApiReference/
+// [1] https://www.vmware.com/support/developer/vc-sdk/visdk41pubs/ApiReference/vim.HttpNfcLease.html
+func (c *Client) CreateVirtualMachine(
+	ctx context.Context,
+	args CreateVirtualMachineParams,
+) (*mo.VirtualMachine, error) {
+
+	args.UpdateProgress("creating import spec")
+	spec, err := c.createImportSpec(ctx, args)
+	if err != nil {
+		return nil, errors.Annotate(err, "creating import spec")
+	}
+
+	// Locate the folder in which to create the VM.
+	finder, datacenter, err := c.finder(ctx)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	folders, err := datacenter.Folders(ctx)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	folderPath := path.Join(folders.VmFolder.InventoryPath, args.Folder)
+	vmFolder, err := finder.Folder(ctx, folderPath)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	// Import the VApp.
+	args.UpdateProgress(fmt.Sprintf("creating VM %q", args.Name))
+	c.logger.Debugf("creating VM in folder %s", vmFolder)
+	rp := object.NewResourcePool(c.client.Client, *args.ComputeResource.ResourcePool)
+	lease, err := rp.ImportVApp(ctx, spec.ImportSpec, vmFolder, nil)
+	if err != nil {
+		return nil, errors.Annotatef(err, "failed to import vapp")
+	}
+
+	// Upload the VMDK.
+	info, err := lease.Wait(ctx)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	type uploadItem struct {
+		item types.OvfFileItem
+		url  *url.URL
+	}
+	var uploadItems []uploadItem
+	for _, device := range info.DeviceUrl {
+		for _, item := range spec.FileItem {
+			if device.ImportKey != item.DeviceId {
+				continue
+			}
+			u, err := c.client.Client.ParseURL(device.Url)
+			if err != nil {
+				return nil, errors.Trace(err)
+			}
+			uploadItems = append(uploadItems, uploadItem{
+				item: item,
+				url:  u,
+			})
+		}
+	}
+	for _, item := range uploadItems {
+		if err := uploadImage(
+			c.client.Client,
+			item.item,
+			args.OVADir,
+			item.url,
+			args.UpdateProgress,
+		); err != nil {
+			return nil, errors.Trace(err)
+		}
+	}
+	if err := lease.HttpNfcLeaseComplete(ctx); err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	// Finally, power on and return the VM.
+	args.UpdateProgress("powering on")
+	vm := object.NewVirtualMachine(c.client.Client, info.Entity)
+	task, err := vm.PowerOn(ctx)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	taskInfo, err := task.WaitForResult(ctx, nil)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	var res mo.VirtualMachine
+	if err := c.client.RetrieveOne(ctx, *taskInfo.Entity, nil, &res); err != nil {
+		return nil, errors.Trace(err)
+	}
+	return &res, nil
+}
+
+func (c *Client) createImportSpec(
+	ctx context.Context,
+	args CreateVirtualMachineParams,
+) (*types.OvfCreateImportSpecResult, error) {
+	cisp := types.OvfCreateImportSpecParams{
+		EntityName: args.Name,
+		PropertyMapping: []types.KeyValue{
+			types.KeyValue{Key: "user-data", Value: string(args.UserData)},
+			types.KeyValue{Key: "hostname", Value: string(args.Name)},
+		},
+	}
+	ovfManager := object.NewOvfManager(c.client.Client)
+	resourcePool := object.NewReference(c.client.Client, *args.ComputeResource.ResourcePool)
+	datastore := object.NewReference(c.client.Client, args.ComputeResource.Datastore[0])
+	spec, err := ovfManager.CreateImportSpec(ctx, args.OVF, resourcePool, datastore, cisp)
+	if err != nil {
+		return nil, errors.Trace(err)
+	} else if spec.Error != nil {
+		return nil, errors.New(spec.Error[0].LocalizedMessage)
+	}
+	s := &spec.ImportSpec.(*types.VirtualMachineImportSpec).ConfigSpec
+
+	// Apply resource constraints.
+	if args.Constraints.HasCpuCores() {
+		s.NumCPUs = int32(*args.Constraints.CpuCores)
+	}
+	if args.Constraints.HasMem() {
+		s.MemoryMB = int64(*args.Constraints.Mem)
+	}
+	var cpuPower int64
+	if args.Constraints.HasCpuPower() {
+		cpuPower = int64(*args.Constraints.CpuPower)
+	}
+	s.CpuAllocation = &types.ResourceAllocationInfo{
+		Limit:       cpuPower,
+		Reservation: cpuPower,
+	}
+	for _, d := range s.DeviceChange {
+		disk, ok := d.GetVirtualDeviceConfigSpec().Device.(*types.VirtualDisk)
+		if !ok {
+			continue
+		}
+		var rootDisk int64
+		if args.Constraints.RootDisk != nil {
+			rootDisk = int64(*args.Constraints.RootDisk) * 1024
+		}
+		if disk.CapacityInKB < rootDisk {
+			disk.CapacityInKB = rootDisk
+		}
+		// Set UnitNumber to -1 if it is unset in ovf file template
+		// (in this case it is parses as 0), because 0 causes an error
+		// for disk devices.
+		var unitNumber int32
+		if disk.UnitNumber != nil {
+			unitNumber = *disk.UnitNumber
+		}
+		if unitNumber == 0 {
+			unitNumber = -1
+			disk.UnitNumber = &unitNumber
+		}
+	}
+
+	// Apply metadata. Note that we do not have the ability set create or
+	// apply tags that will show up in vCenter, as that requires a separate
+	// vSphere Automation that we do not have an SDK for.
+	for k, v := range args.Metadata {
+		s.ExtraConfig = append(s.ExtraConfig, &types.OptionValue{Key: k, Value: v})
+	}
+
+	// Add the external network, if any.
+	if args.ExternalNetwork != "" {
+		s.DeviceChange = append(s.DeviceChange, &types.VirtualDeviceConfigSpec{
+			Operation: types.VirtualDeviceConfigSpecOperationAdd,
+			Device: &types.VirtualE1000{
+				VirtualEthernetCard: types.VirtualEthernetCard{
+					VirtualDevice: types.VirtualDevice{
+						Backing: &types.VirtualEthernetCardNetworkBackingInfo{
+							VirtualDeviceDeviceBackingInfo: types.VirtualDeviceDeviceBackingInfo{
+								DeviceName: args.ExternalNetwork,
+							},
+						},
+						Connectable: &types.VirtualDeviceConnectInfo{
+							StartConnected:    true,
+							AllowGuestControl: true,
+						},
+					},
+				},
+			},
+		})
+	}
+	return spec, nil
+}
+
+// uploadImage uploads an image from the given extracted OVA directory
+// to a target URL.
+func uploadImage(
+	client *vim25.Client,
+	item types.OvfFileItem,
+	ovaDir string,
+	targetURL *url.URL,
+	updateProgress func(string),
+) error {
+	sourcePath := filepath.Join(ovaDir, item.Path)
+	f, err := os.Open(sourcePath)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	defer f.Close()
+
+	// Transfer image upload progress to the UpdateProgress function.
+	progressChan := make(chan progress.Report)
+	progressSink := progressUpdater{
+		ch:     progressChan,
+		update: updateProgress,
+		action: fmt.Sprintf("uploading %s", item.Path),
+	}
+	go progressSink.loop()
+	defer progressSink.done()
+
+	opts := soap.Upload{
+		Method:        "POST",
+		Type:          "application/x-vnd.vmware-streamVmdk",
+		ContentLength: item.Size,
+		Progress:      &progressSink,
+	}
+	if err := client.Upload(f, targetURL, &opts); err != nil {
+		return errors.Annotatef(err, "uploading %s to %s", item.Path, targetURL)
+	}
+	return nil
+}
+
+type progressUpdater struct {
+	tomb   tomb.Tomb
+	ch     chan progress.Report
+	update func(string)
+	action string
+}
+
+// Sink is part of the progress.Sinker interface.
+func (u *progressUpdater) Sink() chan<- progress.Report {
+	return u.ch
+}
+
+func (u *progressUpdater) loop() {
+	defer u.tomb.Done()
+	var last float32
+	const threshold = 10 // update status every X%
+	for {
+		select {
+		case <-u.tomb.Dying():
+			u.tomb.Kill(tomb.ErrDying)
+			return
+		case report, ok := <-u.ch:
+			if !ok {
+				return
+			}
+			var message string
+			if err := report.Error(); err != nil {
+				message = fmt.Sprintf("%s: %s", u.action, err)
+			} else {
+				pc := report.Percentage()
+				if pc < 100 && (pc-last) < threshold {
+					// Don't update yet, to avoid spamming
+					// status updates.
+					continue
+				}
+				last = pc
+				message = fmt.Sprintf("%s: %.2f%% (%s)", u.action, pc, report.Detail())
+			}
+			u.update(message)
+		}
+	}
+}
+
+func (u *progressUpdater) done() {
+	u.tomb.Kill(nil)
+	u.tomb.Wait()
+}

--- a/provider/vsphere/internal/vsphereclient/createvm_test.go
+++ b/provider/vsphere/internal/vsphereclient/createvm_test.go
@@ -1,0 +1,57 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package vsphereclient
+
+import (
+	"io/ioutil"
+	"path/filepath"
+
+	jc "github.com/juju/testing/checkers"
+	"github.com/vmware/govmomi/vim25/mo"
+	"github.com/vmware/govmomi/vim25/types"
+	"golang.org/x/net/context"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/constraints"
+)
+
+func (s *clientSuite) TestCreateVirtualMachine(c *gc.C) {
+	ovaDir := c.MkDir()
+	err := ioutil.WriteFile(
+		filepath.Join(ovaDir, "ubuntu-14.04-server-cloudimg-amd64.vmdk"),
+		[]byte("image-contents"),
+		0644,
+	)
+	c.Assert(err, jc.ErrorIsNil)
+
+	client := s.newFakeClient(&s.roundTripper, "dc0")
+	args := CreateVirtualMachineParams{
+		Name:     "vm-0",
+		Folder:   "foo",
+		OVADir:   ovaDir,
+		OVF:      "bar",
+		UserData: "baz",
+		ComputeResource: &mo.ComputeResource{
+			ResourcePool: &types.ManagedObjectReference{
+				Type:  "ResourcePool",
+				Value: "FakeResourcePool1",
+			},
+			Datastore: []types.ManagedObjectReference{{
+				Type:  "Datastore",
+				Value: "FakeDatastore1",
+			}},
+		},
+		Metadata:        map[string]string{"k": "v"},
+		Constraints:     constraints.Value{},
+		ExternalNetwork: "arpa",
+		UpdateProgress:  func(string) {},
+	}
+	_, err = client.CreateVirtualMachine(context.Background(), args)
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Assert(s.uploadRequests, gc.HasLen, 1)
+	contents, err := ioutil.ReadAll(s.uploadRequests[0].Body)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(string(contents), gc.Equals, "image-contents")
+}

--- a/provider/vsphere/internal/vsphereclient/mock_test.go
+++ b/provider/vsphere/internal/vsphereclient/mock_test.go
@@ -1,0 +1,200 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package vsphereclient
+
+import (
+	"github.com/juju/loggo"
+	"github.com/juju/testing"
+	"github.com/juju/utils"
+	"github.com/pkg/errors"
+	"github.com/vmware/govmomi/vim25/methods"
+	"github.com/vmware/govmomi/vim25/soap"
+	"github.com/vmware/govmomi/vim25/types"
+	"golang.org/x/net/context"
+)
+
+var logger = loggo.GetLogger("vsphereclient")
+
+type mockRoundTripper struct {
+	testing.Stub
+
+	serverURL  string
+	roundTrip  func(ctx context.Context, req, res soap.HasFault) error
+	contents   map[string][]types.ObjectContent
+	collectors map[string]*collector
+}
+
+func (r *mockRoundTripper) RoundTrip(ctx context.Context, req, res soap.HasFault) error {
+	if err := r.NextErr(); err != nil {
+		return err
+	}
+
+	if r.roundTrip != nil {
+		return r.roundTrip(ctx, req, res)
+	}
+
+	lease := types.ManagedObjectReference{
+		Type:  "Lease",
+		Value: "FakeLease",
+	}
+	reconfigVMTask := types.ManagedObjectReference{
+		Type:  "Task",
+		Value: "ReconfigVMTask",
+	}
+	destroyTask := types.ManagedObjectReference{
+		Type:  "Task",
+		Value: "DestroyTask",
+	}
+	moveIntoFolderTask := types.ManagedObjectReference{
+		Type:  "Task",
+		Value: "MoveIntoFolder",
+	}
+	powerOffVMTask := types.ManagedObjectReference{
+		Type:  "Task",
+		Value: "PowerOffVM",
+	}
+	powerOnVMTask := types.ManagedObjectReference{
+		Type:  "Task",
+		Value: "PowerOnVM",
+	}
+
+	switch res := res.(type) {
+	case *methods.RetrievePropertiesBody:
+		req := req.(*methods.RetrievePropertiesBody).Req
+		res.Res = r.retrieveProperties(req)
+	case *methods.LogoutBody:
+		r.MethodCall(r, "Logout")
+		res.Res = &types.LogoutResponse{}
+	case *methods.ReconfigVM_TaskBody:
+		r.MethodCall(r, "ReconfigVM_Task")
+		res.Res = &types.ReconfigVM_TaskResponse{reconfigVMTask}
+	case *methods.Destroy_TaskBody:
+		r.MethodCall(r, "Destroy_Task")
+		res.Res = &types.Destroy_TaskResponse{destroyTask}
+	case *methods.MoveIntoFolder_TaskBody:
+		r.MethodCall(r, "MoveIntoFolder_Task")
+		res.Res = &types.MoveIntoFolder_TaskResponse{moveIntoFolderTask}
+	case *methods.PowerOffVM_TaskBody:
+		r.MethodCall(r, "PowerOffVM_Task")
+		res.Res = &types.PowerOffVM_TaskResponse{powerOffVMTask}
+	case *methods.PowerOnVM_TaskBody:
+		r.MethodCall(r, "PowerOnVM_Task")
+		res.Res = &types.PowerOnVM_TaskResponse{powerOnVMTask}
+	case *methods.CreateFolderBody:
+		r.MethodCall(r, "CreateFolder")
+		res.Res = &types.CreateFolderResponse{}
+	case *methods.CreateImportSpecBody:
+		r.MethodCall(r, "CreateImportSpec")
+		res.Res = &types.CreateImportSpecResponse{
+			types.OvfCreateImportSpecResult{
+				FileItem: []types.OvfFileItem{
+					types.OvfFileItem{
+						DeviceId: "key1",
+						Path:     "ubuntu-14.04-server-cloudimg-amd64.vmdk",
+					},
+				},
+				ImportSpec: &types.VirtualMachineImportSpec{},
+			},
+		}
+	case *methods.ImportVAppBody:
+		res.Res = &types.ImportVAppResponse{lease}
+	case *methods.CreatePropertyCollectorBody:
+		r.MethodCall(r, "CreatePropertyCollector")
+		uuid := utils.MustNewUUID().String()
+		r.collectors[uuid] = &collector{}
+		res.Res = &types.CreatePropertyCollectorResponse{
+			Returnval: types.ManagedObjectReference{
+				Type:  "PropertyCollector",
+				Value: uuid,
+			},
+		}
+	case *methods.CreateFilterBody:
+		r.MethodCall(r, "CreateFilter")
+		req := req.(*methods.CreateFilterBody).Req
+		r.collectors[req.This.Value].filter = req.Spec
+		res.Res = &types.CreateFilterResponse{
+			Returnval: req.Spec.ObjectSet[0].Obj,
+		}
+	case *methods.HttpNfcLeaseCompleteBody:
+		req := req.(*methods.HttpNfcLeaseCompleteBody).Req
+		delete(r.collectors, req.This.Value)
+		res.Res = &types.HttpNfcLeaseCompleteResponse{}
+	case *methods.WaitForUpdatesExBody:
+		r.MethodCall(r, "WaitForUpdatesEx")
+		req := req.(*methods.WaitForUpdatesExBody).Req
+		collector := r.collectors[req.This.Value]
+
+		var changes []types.PropertyChange
+		if collector.filter.ObjectSet[0].Obj == lease {
+			changes = []types.PropertyChange{{
+				Name: "info",
+				Val: types.HttpNfcLeaseInfo{
+					DeviceUrl: []types.HttpNfcLeaseDeviceUrl{
+						types.HttpNfcLeaseDeviceUrl{
+							ImportKey: "key1",
+							Url:       r.serverURL + "/disk-device/",
+						},
+					},
+				},
+			}, {
+				Name: "state",
+				Val:  types.HttpNfcLeaseStateReady,
+			}}
+		} else {
+			changes = []types.PropertyChange{{
+				Name: "info",
+				Op:   types.PropertyChangeOpAssign,
+				Val: types.TaskInfo{
+					Entity: &types.ManagedObjectReference{},
+					State:  types.TaskInfoStateSuccess,
+				},
+			}}
+		}
+		res.Res = &types.WaitForUpdatesExResponse{
+			Returnval: &types.UpdateSet{
+				FilterSet: []types.PropertyFilterUpdate{{
+					ObjectSet: []types.ObjectUpdate{{
+						Obj:       collector.filter.ObjectSet[0].Obj,
+						ChangeSet: changes,
+					}},
+				}},
+			},
+		}
+
+	default:
+		return errors.Errorf("unknown type %T", res)
+	}
+	return nil
+}
+
+func (r *mockRoundTripper) retrieveProperties(req *types.RetrieveProperties) *types.RetrievePropertiesResponse {
+	spec := req.SpecSet[0]
+	obj := spec.ObjectSet[0].Obj.Value
+	r.MethodCall(r, "RetrieveProperties", obj)
+	logger.Debugf("RetrieveProperties for %s", obj)
+	var contents []types.ObjectContent
+	for _, content := range r.contents[obj] {
+		var match bool
+		for _, prop := range spec.PropSet {
+			if prop.Type == content.Obj.Type {
+				match = true
+				break
+			}
+		}
+		if match {
+			contents = append(contents, content)
+		}
+	}
+	return &types.RetrievePropertiesResponse{contents}
+}
+
+func retrievePropertiesStubCall(obj string) testing.StubCall {
+	return testing.StubCall{
+		"RetrieveProperties", []interface{}{obj},
+	}
+}
+
+type collector struct {
+	filter types.PropertyFilterSpec
+}

--- a/provider/vsphere/internal/vsphereclient/package_test.go
+++ b/provider/vsphere/internal/vsphereclient/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package vsphereclient_test
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func TestPackage(t *testing.T) {
+	gc.TestingT(t)
+}


### PR DESCRIPTION
## Description of change

Introduce a new internal package, internal/vsphereclient,
under the vsphere provider. This package exposes a
simplified Virtual Infrastructure API client, containing
only the bits we need in Juju.

A follow up will refactor the provider further to use
this package's Client type, rather than using
govmomi.Client directly. This will enable us to improve
the test coverage of the provider without exposing the
inner workings of the VI SDK.

Note that this code is unused in this PR. It will be
used in the follow-up.

## QA steps

None (code is not used yet).

## Documentation changes

None.

## Bug reference

None.