### PR TITLE
Remove duplicated operations from remove application transaction.

### DIFF
--- a/state/application.go
+++ b/state/application.go
@@ -272,10 +272,6 @@ func (a *Application) removeOps(asserts bson.D) ([]txn.Op, error) {
 			Id:     a.doc.DocID,
 			Assert: asserts,
 			Remove: true,
-		}, {
-			C:      settingsC,
-			Id:     a.settingsKey(),
-			Remove: true,
 		},
 	}
 	// Note that appCharmDecRefOps might not catch the final decref
@@ -290,7 +286,6 @@ func (a *Application) removeOps(asserts bson.D) ([]txn.Op, error) {
 		return nil, errors.Trace(err)
 	}
 	ops = append(ops, charmOps...)
-	ops = append(ops, finalAppCharmRemoveOps(name, curl)...)
 
 	globalKey := a.globalKey()
 	ops = append(ops,

--- a/state/charm_test.go
+++ b/state/charm_test.go
@@ -256,12 +256,10 @@ func (s *CharmSuite) TestDestroyFinalUnitReference(c *gc.C) {
 	app := s.Factory.MakeApplication(c, &factory.ApplicationParams{
 		Charm: s.charm,
 	})
-	unit := s.Factory.MakeUnit(c, &factory.UnitParams{
-		Application: app,
-		SetCharmURL: true,
-	})
+	unit, err := app.AddUnit()
+	c.Assert(err, jc.ErrorIsNil)
 
-	err := app.Destroy()
+	err = app.Destroy()
 	c.Assert(err, jc.ErrorIsNil)
 	removeUnit(c, unit)
 


### PR DESCRIPTION
## Description of change

Removed redundant duplicated operations from remove application/unit transaction.

Call to appCharmDecRefOps takes care of both application settings removal operations as well as removal of charm related operations that should take affect when the final application unit is removed. In fact, the latter is properly conditionally added.

## QA steps

Internal change - if QA observes the internal transaction collection and the operations that it contains, then the transaction that removes application will no longer contain duplicate operations.

This is how it looked prior to the change, grouped by duplication not the order in transaction: http://pastebin.ubuntu.com/24332772/  

## Documentation changes

N/A, internal change.

## Bug reference

N/A, found during investigation related to the destruction of the model with an empty application (no machines or units)
