### PR TITLE
Remove allocation when a model with a supported SLA is being destroyed.

### DIFF
--- a/cmd/juju/model/destroy.go
+++ b/cmd/juju/model/destroy.go
@@ -231,7 +231,6 @@ func (c *destroyCommand) Run(ctx *cmd.Context) error {
 		if err != nil {
 			ctx.Warningf("model allocation not removed: %v", err)
 		}
-		return nil
 	}
 
 	return nil

--- a/cmd/juju/model/destroy.go
+++ b/cmd/juju/model/destroy.go
@@ -226,25 +226,32 @@ func (c *destroyCommand) Run(ctx *cmd.Context) error {
 	}
 
 	// Check if the model has an sla auth.
-	if !slaIsSet {
+	if slaIsSet {
+		err = c.removeModelAllocation(modelDetails.ModelUUID)
+		if err != nil {
+			ctx.Warningf("model allocation not removed: %v", err)
+		}
 		return nil
 	}
 
+	return nil
+}
+
+func (c *destroyCommand) removeModelAllocation(uuid string) error {
 	bakeryClient, err := c.BakeryClient()
 	if err != nil {
-		ctx.Warningf("could not remove model allocation: %v", err)
+		return errors.Trace(err)
 	}
 
 	budgetClient := getBudgetAPIClient(bakeryClient)
 
-	resp, err := budgetClient.DeleteAllocation(modelDetails.ModelUUID)
+	resp, err := budgetClient.DeleteAllocation(uuid)
 	if err != nil {
-		ctx.Warningf("allocation not removed: %v", err)
+		return errors.Trace(err)
 	}
 	if resp != "" {
 		logger.Infof(resp)
 	}
-
 	return nil
 }
 

--- a/cmd/juju/model/destroy_test.go
+++ b/cmd/juju/model/destroy_test.go
@@ -197,24 +197,19 @@ func (s *DestroySuite) TestDestroyWithSupportedSLA(c *gc.C) {
 	s.configAPI.slaLevel = "standard"
 	_, err := s.runDestroyCommand(c, "test2", "-y")
 	c.Assert(err, jc.ErrorIsNil)
-	// TODO(cmars): fix DeleteAllocation on model destroy
-	//s.stub.CheckCalls(c, []jutesting.StubCall{{
-	//	"DeleteAllocation", []interface{}{"test2-uuid"},
-	//}})
-	s.stub.CheckNoCalls(c)
+	s.stub.CheckCalls(c, []jutesting.StubCall{{
+		"DeleteAllocation", []interface{}{"test2-uuid"},
+	}})
 }
 
 func (s *DestroySuite) TestDestroyWithSupportedSLAFailure(c *gc.C) {
 	s.configAPI.slaLevel = "standard"
 	s.stub.SetErrors(errors.New("bah"))
 	_, err := s.runDestroyCommand(c, "test2", "-y")
-	// TODO(cmars): fix DeleteAllocation on model destroy
-	//c.Assert(err, gc.ErrorMatches, `bah`)
-	//s.stub.CheckCalls(c, []jutesting.StubCall{{
-	//	"DeleteAllocation", []interface{}{"test2-uuid"},
-	//}})
 	c.Assert(err, jc.ErrorIsNil)
-	s.stub.CheckNoCalls(c)
+	s.stub.CheckCalls(c, []jutesting.StubCall{{
+		"DeleteAllocation", []interface{}{"test2-uuid"},
+	}})
 }
 
 func (s *DestroySuite) resetModel(c *gc.C) {


### PR DESCRIPTION
## Description of change

This change is needed to fix the juju support for model SLAs.

## QA steps

Model creation and destruction should work as before.

## Documentation changes

Contact @cmars for questions regarding this feature.
