### PR TITLE
api/base/testing: simplify API call checkers

### DIFF
--- a/api/cleaner/cleaner_test.go
+++ b/api/cleaner/cleaner_test.go
@@ -25,25 +25,24 @@ var _ = gc.Suite(&CleanerSuite{})
 
 type TestCommon struct {
 	apiCaller base.APICaller
-	apiArgs   apitesting.CheckArgs
 	called    chan struct{}
 	api       *cleaner.API
 }
 
 // Init returns a new, initialised instance of TestCommon.
-func Init(c *gc.C, method string, expectArgs, useResults interface{}, err error) (t *TestCommon) {
+func Init(c *gc.C, facade, method string, expectArgs, useResults interface{}, err error) (t *TestCommon) {
 	t = &TestCommon{}
-	t.apiArgs = apitesting.CheckArgs{
-		Facade:        "Cleaner",
+	caller := apitesting.APICallChecker(c, apitesting.APICall{
+		Facade:        facade,
 		VersionIsZero: true,
 		IdIsEmpty:     true,
 		Method:        method,
 		Args:          expectArgs,
 		Results:       useResults,
-	}
-
+		Error:         err,
+	})
 	t.called = make(chan struct{}, 100)
-	t.apiCaller = apitesting.NotifyingCheckingAPICaller(c, &t.apiArgs, t.called, err)
+	t.apiCaller = apitesting.NotifyingAPICaller(c, t.called, caller)
 	t.api = cleaner.NewAPI(t.apiCaller)
 
 	c.Check(t.api, gc.NotNil)
@@ -63,18 +62,20 @@ func AssertNumReceives(c *gc.C, watched chan struct{}, expected uint32) {
 			c.Errorf("timeout while waiting for a call")
 		}
 	}
-
-	time.Sleep(coretesting.ShortWait)
-	c.Assert(receives, gc.Equals, expected)
+	select {
+	case <-watched:
+		c.Fatalf("unexpected event received")
+	case <-time.After(coretesting.ShortWait):
+	}
 }
 
 func (s *CleanerSuite) TestNewAPI(c *gc.C) {
-	Init(c, "", nil, nil, nil)
+	Init(c, "Cleaner", "", nil, nil, nil)
 }
 
 func (s *CleanerSuite) TestWatchCleanups(c *gc.C) {
-	t := Init(c, "", nil, nil, nil)
-	t.apiArgs.Facade = "" // Multiple facades are called, so we can't check this.
+	// Multiple facades are called, so pass an empty string for the facade.
+	t := Init(c, "", "", nil, nil, nil)
 	m, err := t.api.WatchCleanups()
 	AssertNumReceives(c, t.called, 2)
 	c.Assert(err, jc.ErrorIsNil)
@@ -82,14 +83,14 @@ func (s *CleanerSuite) TestWatchCleanups(c *gc.C) {
 }
 
 func (s *CleanerSuite) TestCleanup(c *gc.C) {
-	t := Init(c, "Cleanup", nil, nil, nil)
+	t := Init(c, "Cleaner", "Cleanup", nil, nil, nil)
 	err := t.api.Cleanup()
 	AssertNumReceives(c, t.called, 1)
 	c.Assert(err, jc.ErrorIsNil)
 }
 
 func (s *CleanerSuite) TestWatchCleanupsFailFacadeCall(c *gc.C) {
-	t := Init(c, "WatchCleanups", nil, nil, errors.New("client error!"))
+	t := Init(c, "Cleaner", "WatchCleanups", nil, nil, errors.New("client error!"))
 	m, err := t.api.WatchCleanups()
 	c.Assert(err, gc.ErrorMatches, "client error!")
 	AssertNumReceives(c, t.called, 1)
@@ -103,7 +104,7 @@ func (s *CleanerSuite) TestWatchCleanupsFailFacadeResult(c *gc.C) {
 	p := params.NotifyWatchResult{
 		Error: &e,
 	}
-	t := Init(c, "WatchCleanups", nil, p, nil)
+	t := Init(c, "Cleaner", "WatchCleanups", nil, p, nil)
 	m, err := t.api.WatchCleanups()
 	AssertNumReceives(c, t.called, 1)
 	c.Assert(err, gc.ErrorMatches, e.Message)

--- a/api/discoverspaces/discoverspaces_test.go
+++ b/api/discoverspaces/discoverspaces_test.go
@@ -9,7 +9,6 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
-	"github.com/juju/juju/api/base"
 	apitesting "github.com/juju/juju/api/base/testing"
 	"github.com/juju/juju/api/discoverspaces"
 	"github.com/juju/juju/apiserver/params"
@@ -24,39 +23,37 @@ type DiscoverSpacesSuite struct {
 var _ = gc.Suite(&DiscoverSpacesSuite{})
 
 func (s *DiscoverSpacesSuite) TestNewAPI(c *gc.C) {
-	var called int
-	apiCaller := clientErrorAPICaller(c, "ListSpaces", nil, &called)
+	apiCaller := clientErrorAPICaller(c, "ListSpaces", nil)
 	api := discoverspaces.NewAPI(apiCaller)
 	c.Check(api, gc.NotNil)
-	c.Check(called, gc.Equals, 0)
+	c.Check(apiCaller.CallCount, gc.Equals, 0)
 
 	// Make a call so that an error will be returned.
 	_, err := api.ListSpaces()
 	c.Assert(err, gc.ErrorMatches, "client error!")
-	c.Assert(called, gc.Equals, 1)
+	c.Assert(apiCaller.CallCount, gc.Equals, 1)
 }
 
-func clientErrorAPICaller(c *gc.C, method string, expectArgs interface{}, numCalls *int) base.APICaller {
-	args := &apitesting.CheckArgs{
+func clientErrorAPICaller(c *gc.C, method string, expectArgs interface{}) *apitesting.CallChecker {
+	return apitesting.APICallChecker(c, apitesting.APICall{
 		Facade:        "DiscoverSpaces",
 		VersionIsZero: true,
 		IdIsEmpty:     true,
 		Method:        method,
 		Args:          expectArgs,
-	}
-	return apitesting.CheckingAPICaller(c, args, numCalls, errors.New("client error!"))
+		Error:         errors.New("client error!"),
+	})
 }
 
-func successAPICaller(c *gc.C, method string, expectArgs, useResults interface{}, numCalls *int) base.APICaller {
-	args := &apitesting.CheckArgs{
+func successAPICaller(c *gc.C, method string, expectArgs, useResults interface{}) *apitesting.CallChecker {
+	return apitesting.APICallChecker(c, apitesting.APICall{
 		Facade:        "DiscoverSpaces",
 		VersionIsZero: true,
 		IdIsEmpty:     true,
 		Method:        method,
 		Args:          expectArgs,
 		Results:       useResults,
-	}
-	return apitesting.CheckingAPICaller(c, args, numCalls, nil)
+	})
 }
 
 func (s *DiscoverSpacesSuite) TestNewAPIWithNilCaller(c *gc.C) {
@@ -65,65 +62,61 @@ func (s *DiscoverSpacesSuite) TestNewAPIWithNilCaller(c *gc.C) {
 }
 
 func (s *DiscoverSpacesSuite) TestListSpaces(c *gc.C) {
-	var called int
 	expectedResult := params.DiscoverSpacesResults{
 		Results: []params.ProviderSpace{{Name: "foobar"}},
 	}
-	apiCaller := successAPICaller(c, "ListSpaces", nil, expectedResult, &called)
+	apiCaller := successAPICaller(c, "ListSpaces", nil, expectedResult)
 	api := discoverspaces.NewAPI(apiCaller)
 
 	result, err := api.ListSpaces()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, jc.DeepEquals, expectedResult)
-	c.Assert(called, gc.Equals, 1)
+	c.Assert(apiCaller.CallCount, gc.Equals, 1)
 }
 
 func (s *DiscoverSpacesSuite) TestAddSubnets(c *gc.C) {
-	var called int
 	expectedResult := params.ErrorResults{
 		Results: []params.ErrorResult{{}},
 	}
 	expectedArgs := params.AddSubnetsParams{
 		Subnets: []params.AddSubnetParams{{SubnetTag: "foo"}},
 	}
-	apiCaller := successAPICaller(c, "AddSubnets", expectedArgs, expectedResult, &called)
+	apiCaller := successAPICaller(c, "AddSubnets", expectedArgs, expectedResult)
 	api := discoverspaces.NewAPI(apiCaller)
 
 	result, err := api.AddSubnets(expectedArgs)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, jc.DeepEquals, expectedResult)
-	c.Assert(called, gc.Equals, 1)
+	c.Assert(apiCaller.CallCount, gc.Equals, 1)
 }
 
 func (s *DiscoverSpacesSuite) TestCreateSpaces(c *gc.C) {
-	var called int
 	expectedResult := params.ErrorResults{
 		Results: []params.ErrorResult{{}},
 	}
 	expectedArgs := params.CreateSpacesParams{
 		Spaces: []params.CreateSpaceParams{{SpaceTag: "foo"}},
 	}
-	apiCaller := successAPICaller(c, "CreateSpaces", expectedArgs, expectedResult, &called)
+	apiCaller := successAPICaller(c, "CreateSpaces", expectedArgs, expectedResult)
 	api := discoverspaces.NewAPI(apiCaller)
 
 	result, err := api.CreateSpaces(expectedArgs)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, jc.DeepEquals, expectedResult)
-	c.Assert(called, gc.Equals, 1)
+	c.Assert(apiCaller.CallCount, gc.Equals, 1)
 }
 
 func (s *DiscoverSpacesSuite) TestModelConfig(c *gc.C) {
-	var called int
 	cfg, err := config.New(config.UseDefaults, coretesting.FakeConfig())
 	c.Assert(err, jc.ErrorIsNil)
 	expectedResult := params.ModelConfigResult{
 		Config: cfg.AllAttrs(),
 	}
-	apiCaller := successAPICaller(c, "ModelConfig", nil, expectedResult, &called)
+	apiCaller := successAPICaller(c, "ModelConfig", nil, expectedResult)
 	api := discoverspaces.NewAPI(apiCaller)
 
 	result, err := api.ModelConfig()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, jc.DeepEquals, cfg)
-	c.Assert(called, gc.Equals, 1)
+	c.Assert(apiCaller.CallCount, gc.Equals, 1)
 }

--- a/api/instancepoller/machine_test.go
+++ b/api/instancepoller/machine_test.go
@@ -142,19 +142,17 @@ func (s *MachineSuite) TestTooManyResultsServerError(c *gc.C) {
 }
 
 func (s *MachineSuite) TestRefreshSuccess(c *gc.C) {
-	var called int
 	results := params.LifeResults{
 		Results: []params.LifeResult{{Life: params.Dying}},
 	}
-	apiCaller := successAPICaller(c, "Life", entitiesArgs, results, &called)
+	apiCaller := successAPICaller(c, "Life", entitiesArgs, results)
 	machine := instancepoller.NewMachine(apiCaller, s.tag, params.Alive)
 	c.Check(machine.Refresh(), jc.ErrorIsNil)
 	c.Check(machine.Life(), gc.Equals, params.Dying)
-	c.Check(called, gc.Equals, 1)
+	c.Check(apiCaller.CallCount, gc.Equals, 1)
 }
 
 func (s *MachineSuite) TestStatusSuccess(c *gc.C) {
-	var called int
 	now := time.Now()
 	expectStatus := params.StatusResult{
 		Status: "foo",
@@ -170,57 +168,53 @@ func (s *MachineSuite) TestStatusSuccess(c *gc.C) {
 		Since: &now,
 	}
 	results := params.StatusResults{Results: []params.StatusResult{expectStatus}}
-	apiCaller := successAPICaller(c, "Status", entitiesArgs, results, &called)
+	apiCaller := successAPICaller(c, "Status", entitiesArgs, results)
 	machine := instancepoller.NewMachine(apiCaller, s.tag, params.Alive)
 	status, err := machine.Status()
 	c.Check(err, jc.ErrorIsNil)
 	c.Check(status, jc.DeepEquals, expectStatus)
-	c.Check(called, gc.Equals, 1)
+	c.Check(apiCaller.CallCount, gc.Equals, 1)
 }
 
 func (s *MachineSuite) TestIsManualSuccess(c *gc.C) {
-	var called int
 	results := params.BoolResults{
 		Results: []params.BoolResult{{Result: true}},
 	}
-	apiCaller := successAPICaller(c, "AreManuallyProvisioned", entitiesArgs, results, &called)
+	apiCaller := successAPICaller(c, "AreManuallyProvisioned", entitiesArgs, results)
 	machine := instancepoller.NewMachine(apiCaller, s.tag, params.Alive)
 	isManual, err := machine.IsManual()
 	c.Check(err, jc.ErrorIsNil)
 	c.Check(isManual, jc.IsTrue)
-	c.Check(called, gc.Equals, 1)
+	c.Check(apiCaller.CallCount, gc.Equals, 1)
 }
 
 func (s *MachineSuite) TestInstanceIdSuccess(c *gc.C) {
-	var called int
 	results := params.StringResults{
 		Results: []params.StringResult{{Result: "i-foo"}},
 	}
-	apiCaller := successAPICaller(c, "InstanceId", entitiesArgs, results, &called)
+	apiCaller := successAPICaller(c, "InstanceId", entitiesArgs, results)
 	machine := instancepoller.NewMachine(apiCaller, s.tag, params.Alive)
 	instId, err := machine.InstanceId()
 	c.Check(err, jc.ErrorIsNil)
 	c.Check(instId, gc.Equals, instance.Id("i-foo"))
-	c.Check(called, gc.Equals, 1)
+	c.Check(apiCaller.CallCount, gc.Equals, 1)
 }
 
 func (s *MachineSuite) TestInstanceStatusSuccess(c *gc.C) {
-	var called int
 	results := params.StatusResults{
 		Results: []params.StatusResult{{
 			Status: status.Provisioning.String(),
 		}},
 	}
-	apiCaller := successAPICaller(c, "InstanceStatus", entitiesArgs, results, &called)
+	apiCaller := successAPICaller(c, "InstanceStatus", entitiesArgs, results)
 	machine := instancepoller.NewMachine(apiCaller, s.tag, params.Alive)
 	statusResult, err := machine.InstanceStatus()
 	c.Check(err, jc.ErrorIsNil)
 	c.Check(statusResult.Status, gc.DeepEquals, status.Provisioning.String())
-	c.Check(called, gc.Equals, 1)
+	c.Check(apiCaller.CallCount, gc.Equals, 1)
 }
 
 func (s *MachineSuite) TestSetInstanceStatusSuccess(c *gc.C) {
-	var called int
 	expectArgs := params.SetStatus{
 		Entities: []params.EntityStatusArgs{{
 			Tag:    "machine-42",
@@ -229,30 +223,28 @@ func (s *MachineSuite) TestSetInstanceStatusSuccess(c *gc.C) {
 	results := params.ErrorResults{
 		Results: []params.ErrorResult{{Error: nil}},
 	}
-	apiCaller := successAPICaller(c, "SetInstanceStatus", expectArgs, results, &called)
+	apiCaller := successAPICaller(c, "SetInstanceStatus", expectArgs, results)
 	machine := instancepoller.NewMachine(apiCaller, s.tag, params.Alive)
 	err := machine.SetInstanceStatus("RUNNING", "", nil)
 	c.Check(err, jc.ErrorIsNil)
-	c.Check(called, gc.Equals, 1)
+	c.Check(apiCaller.CallCount, gc.Equals, 1)
 }
 
 func (s *MachineSuite) TestProviderAddressesSuccess(c *gc.C) {
-	var called int
 	addresses := network.NewAddresses("2001:db8::1", "0.1.2.3")
 	results := params.MachineAddressesResults{
 		Results: []params.MachineAddressesResult{{
 			Addresses: params.FromNetworkAddresses(addresses...),
 		}}}
-	apiCaller := successAPICaller(c, "ProviderAddresses", entitiesArgs, results, &called)
+	apiCaller := successAPICaller(c, "ProviderAddresses", entitiesArgs, results)
 	machine := instancepoller.NewMachine(apiCaller, s.tag, params.Alive)
 	addrs, err := machine.ProviderAddresses()
 	c.Check(err, jc.ErrorIsNil)
 	c.Check(addrs, jc.DeepEquals, addresses)
-	c.Check(called, gc.Equals, 1)
+	c.Check(apiCaller.CallCount, gc.Equals, 1)
 }
 
 func (s *MachineSuite) TestSetProviderAddressesSuccess(c *gc.C) {
-	var called int
 	addresses := network.NewAddresses("2001:db8::1", "0.1.2.3")
 	expectArgs := params.SetMachinesAddresses{
 		MachineAddresses: []params.MachineAddresses{{
@@ -262,27 +254,25 @@ func (s *MachineSuite) TestSetProviderAddressesSuccess(c *gc.C) {
 	results := params.ErrorResults{
 		Results: []params.ErrorResult{{Error: nil}},
 	}
-	apiCaller := successAPICaller(c, "SetProviderAddresses", expectArgs, results, &called)
+	apiCaller := successAPICaller(c, "SetProviderAddresses", expectArgs, results)
 	machine := instancepoller.NewMachine(apiCaller, s.tag, params.Alive)
 	err := machine.SetProviderAddresses(addresses...)
 	c.Check(err, jc.ErrorIsNil)
-	c.Check(called, gc.Equals, 1)
+	c.Check(apiCaller.CallCount, gc.Equals, 1)
 }
 
 func (s *MachineSuite) CheckClientError(c *gc.C, wf methodWrapper) {
-	var called int
-	apiCaller := clientErrorAPICaller(c, "", nil, &called)
+	apiCaller := clientErrorAPICaller(c, "", nil)
 	machine := instancepoller.NewMachine(apiCaller, s.tag, params.Alive)
 	c.Check(wf(machine), gc.ErrorMatches, "client error!")
-	c.Check(called, gc.Equals, 1)
+	c.Check(apiCaller.CallCount, gc.Equals, 1)
 }
 
 func (s *MachineSuite) CheckServerError(c *gc.C, wf methodWrapper, expectErr string, serverResults interface{}) {
-	var called int
-	apiCaller := successAPICaller(c, "", nil, serverResults, &called)
+	apiCaller := successAPICaller(c, "", nil, serverResults)
 	machine := instancepoller.NewMachine(apiCaller, s.tag, params.Alive)
 	c.Check(wf(machine), gc.ErrorMatches, expectErr)
-	c.Check(called, gc.Equals, 1)
+	c.Check(apiCaller.CallCount, gc.Equals, 1)
 }
 
 var entitiesArgs = params.Entities{


### PR DESCRIPTION
With the upcoming changes to command mocking, we're going to be
using API call checkers quite a bit more, so simplify the API
and make it a little more general. Specifically, we

- integrate CheckingAPICallerMultiArgs and CheckingAPICaller into one
- make NotifyingCheckingAPICaller just do notification
on an APICaller implementation without mixing that with the checking
logic
- make the error return a part of an individual call rather
than separate.
- include the call count in the returned APICaller implementation
rather than a separate argument.

QA No regressions.