### PR TITLE
upgrade to the latest juju/txn.

### DIFF
--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -45,7 +45,7 @@ github.com/juju/romulus	git	bc81f6e2d6a3b1698de8358a368b7bc4a23374dd	2017-03-31T
 github.com/juju/schema	git	075de04f9b7d7580d60a1e12a0b3f50bb18e6998	2016-04-20T04:42:03Z
 github.com/juju/terms-client	git	9b925afd677234e4146dde3cb1a11e187cbed64e	2016-08-09T13:19:00Z
 github.com/juju/testing	git	fce9bc4ebf7a77310c262ac4884e03b778eae06a	2017-02-22T09:01:19Z
-github.com/juju/txn	git	aeb0c962db9bb5ae5705d7466e500ed8926b0f53	2017-04-11T03:58:11Z
+github.com/juju/txn	git	42e03dbca6a4f5333d92daae67228c032a109aad	2017-04-11T10:02:47Z
 github.com/juju/usso	git	68a59c96c178fbbad65926e7f93db50a2cd14f33	2016-04-01T10:44:24Z
 github.com/juju/utils	git	6a26b0e1230eeaad6d2321bb63700da1b1116c2b	2017-03-17T14:03:37Z
 github.com/juju/version	git	1f41e27e54f21acccf9b2dddae063a782a8a7ceb	2016-10-31T05:19:06Z

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -45,7 +45,7 @@ github.com/juju/romulus	git	bc81f6e2d6a3b1698de8358a368b7bc4a23374dd	2017-03-31T
 github.com/juju/schema	git	075de04f9b7d7580d60a1e12a0b3f50bb18e6998	2016-04-20T04:42:03Z
 github.com/juju/terms-client	git	9b925afd677234e4146dde3cb1a11e187cbed64e	2016-08-09T13:19:00Z
 github.com/juju/testing	git	fce9bc4ebf7a77310c262ac4884e03b778eae06a	2017-02-22T09:01:19Z
-github.com/juju/txn	git	b0486f90a44540ef9a5cfc9f3fad904832e954fe	2017-03-31T02:42:25Z
+github.com/juju/txn	git	aeb0c962db9bb5ae5705d7466e500ed8926b0f53	2017-04-11T03:58:11Z
 github.com/juju/usso	git	68a59c96c178fbbad65926e7f93db50a2cd14f33	2016-04-01T10:44:24Z
 github.com/juju/utils	git	6a26b0e1230eeaad6d2321bb63700da1b1116c2b	2017-03-17T14:03:37Z
 github.com/juju/version	git	1f41e27e54f21acccf9b2dddae063a782a8a7ceb	2016-10-31T05:19:06Z

--- a/state/txns.go
+++ b/state/txns.go
@@ -53,7 +53,11 @@ func (st *State) MaybePruneTransactions() error {
 	runner, closer := st.database.TransactionRunner()
 	defer closer()
 	// Prune txns when txn count has increased by 10% since last prune.
-	return runner.MaybePruneTransactions(1.1)
+	return runner.MaybePruneTransactions(jujutxn.PruneOptions{
+		PruneFactor: 1.1,
+		MinNewTransactions: 1000,
+		MaxNewTransactions: 100000,
+	})
 }
 
 type multiModelRunner struct {
@@ -99,8 +103,8 @@ func (r *multiModelRunner) ResumeTransactions() error {
 }
 
 // MaybePruneTransactions is part of the jujutxn.Runner interface.
-func (r *multiModelRunner) MaybePruneTransactions(pruneFactor float32) error {
-	return r.rawRunner.MaybePruneTransactions(pruneFactor)
+func (r *multiModelRunner) MaybePruneTransactions(opts jujutxn.PruneOptions) error {
+	return r.rawRunner.MaybePruneTransactions(opts)
 }
 
 // updateOps modifies the Insert and Update fields in a slice of

--- a/state/txns.go
+++ b/state/txns.go
@@ -54,7 +54,7 @@ func (st *State) MaybePruneTransactions() error {
 	defer closer()
 	// Prune txns when txn count has increased by 10% since last prune.
 	return runner.MaybePruneTransactions(jujutxn.PruneOptions{
-		PruneFactor: 1.1,
+		PruneFactor:        1.1,
 		MinNewTransactions: 1000,
 		MaxNewTransactions: 100000,
 	})

--- a/state/txns_test.go
+++ b/state/txns_test.go
@@ -453,14 +453,18 @@ func (s *MultiModelRunnerSuite) TestResumeTransactionsWithError(c *gc.C) {
 }
 
 func (s *MultiModelRunnerSuite) TestMaybePruneTransactions(c *gc.C) {
-	err := s.multiModelRunner.MaybePruneTransactions(2.0)
+	err := s.multiModelRunner.MaybePruneTransactions(jujutxn.PruneOptions{
+		PruneFactor: 2.0,
+	})
 	c.Check(err, jc.ErrorIsNil)
 	c.Check(s.testRunner.pruneTransactionsCalled, jc.IsTrue)
 }
 
 func (s *MultiModelRunnerSuite) TestMaybePruneTransactionsWithError(c *gc.C) {
 	s.testRunner.pruneTransactionsErr = errors.New("boom")
-	err := s.multiModelRunner.MaybePruneTransactions(2.0)
+	err := s.multiModelRunner.MaybePruneTransactions(jujutxn.PruneOptions{
+		PruneFactor: 2.0,
+	})
 	c.Check(err, gc.ErrorMatches, "boom")
 }
 
@@ -495,7 +499,7 @@ func (r *recordingRunner) ResumeTransactions() error {
 	return r.resumeTransactionsErr
 }
 
-func (r *recordingRunner) MaybePruneTransactions(float32) error {
+func (r *recordingRunner) MaybePruneTransactions(_ jujutxn.PruneOptions) error {
 	r.pruneTransactionsCalled = true
 	return r.pruneTransactionsErr
 }


### PR DESCRIPTION
## Description of change

This brings in a lot of improvements to how we do live pruning.
If the number of transactions is high, it uses a database table
to prune instead of loading everything into memory. When possible,
it uses the more efficient $out aggregation pipeline to generate
that table rather than loading the values into the client.
It walks all documents to find completed transactions and remove
them from the txn-queue, rather than leaving them as referenced and
thus 'unremovable'.
It also removes items from txns.stash that have no more txn references,
keeping that collection from growing out of bounds.
The queries for finding documents that need to be touched have been
given filters to allow skipping most documents that have already
been processed. If necessary, we can start adding indexes to speed
up that query, but currently following up a prune with another prune
on a large production database only takes <200ms.

## QA steps

```
  $ juju bootstrap
  $ juju debug-log -m controller --include-machine machine-0 --include-module juju.txn
  $ juju deploy, relate, update, delete
```

You should be able to do a lot of changes, and after 2 hrs the transaction pruner should run and report that it has decided to do a pruning sweep (current logic is to do it after 1000 transactions that haven't been pruned).

You can also use this patch to make it trigger far more often:
```
diff --git a/cmd/jujud/agent/machine.go b/cmd/jujud/agent/machine.go
index ea61107..5e0402c 100644
--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -1081,7 +1081,7 @@ func (a *MachineAgent) startStateWorkers(
                        })

                        a.startWorkerAfterUpgrade(singularRunner, "txnpruner", func() (worker.Worker, error) {
-                               return txnpruner.New(st, time.Hour*2, clock.WallClock), nil
+                               return txnpruner.New(st, time.Second*20, clock.WallClock), nil
                        })
                default:
                        return nil, errors.Errorf("unknown job type %q", job)
diff --git a/state/txns.go b/state/txns.go
index fa9190d..4d4a48c 100644
--- a/state/txns.go
+++ b/state/txns.go
@@ -55,7 +55,7 @@ func (st *State) MaybePruneTransactions() error {
        // Prune txns when txn count has increased by 10% since last prune.
        return runner.MaybePruneTransactions(jujutxn.PruneOptions{
                PruneFactor: 1.1,
-               MinNewTransactions: 1000,
+               MinNewTransactions: 10,
                MaxNewTransactions: 100000,
        })
 }
```

The net result is that on-average the txns collection and txns.stash collections should both stay nearly empty.

## Documentation changes

It should not be visible externally except for improved interactions with the controller (that doesn't have extra cruft, etc.)

## Bug reference

[lp:1678587](https://bugs.launchpad.net/juju/+bug/1678587)
[lp:1676427](https://bugs.launchpad.net/juju/+bug/1676427)