### PR TITLE
provider/vsphere: organise VMs in folders

### DIFF
--- a/environs/interface.go
+++ b/environs/interface.go
@@ -400,7 +400,15 @@ type InstanceTypesFetcher interface {
 type Upgrader interface {
 	// UpgradeOperations returns a list of UpgradeOperations for upgrading
 	// an Environ.
-	UpgradeOperations() []UpgradeOperation
+	UpgradeOperations(UpgradeOperationsParams) []UpgradeOperation
+}
+
+// UpgradeOperationsParams contains the parameters for
+// Upgrader.UpgradeOperations.
+type UpgradeOperationsParams struct {
+	// ControllerUUID is the UUID of the controller to be that contains
+	// the Environ that is to be upgraded.
+	ControllerUUID string
 }
 
 // UpgradeOperation contains a target agent version and sequence of upgrade

--- a/provider/azure/upgrades.go
+++ b/provider/azure/upgrades.go
@@ -16,7 +16,7 @@ import (
 )
 
 // UpgradeOperations is part of the upgrades.OperationSource interface.
-func (env *azureEnviron) UpgradeOperations() []environs.UpgradeOperation {
+func (env *azureEnviron) UpgradeOperations(environs.UpgradeOperationsParams) []environs.UpgradeOperation {
 	return []environs.UpgradeOperation{{
 		version.MustParse("2.2-alpha1"),
 		[]environs.UpgradeStep{

--- a/provider/azure/upgrades_test.go
+++ b/provider/azure/upgrades_test.go
@@ -52,7 +52,7 @@ func (s *environUpgradeSuite) TestEnvironImplementsUpgrader(c *gc.C) {
 
 func (s *environUpgradeSuite) TestEnvironUpgradeOperations(c *gc.C) {
 	upgrader := s.env.(environs.Upgrader)
-	ops := upgrader.UpgradeOperations()
+	ops := upgrader.UpgradeOperations(environs.UpgradeOperationsParams{})
 	c.Assert(ops, gc.HasLen, 1)
 	c.Assert(ops[0].TargetVersion, gc.Equals, version.MustParse("2.2-alpha1"))
 	c.Assert(ops[0].Steps, gc.HasLen, 1)
@@ -61,7 +61,7 @@ func (s *environUpgradeSuite) TestEnvironUpgradeOperations(c *gc.C) {
 
 func (s *environUpgradeSuite) TestEnvironUpgradeOperationCreateCommonDeployment(c *gc.C) {
 	upgrader := s.env.(environs.Upgrader)
-	op0 := upgrader.UpgradeOperations()[0]
+	op0 := upgrader.UpgradeOperations(environs.UpgradeOperationsParams{})[0]
 
 	// The existing NSG has two rules: one for Juju API traffic,
 	// and an application-specific rule. Only the latter should
@@ -200,6 +200,6 @@ func (s *environUpgradeSuite) TestEnvironUpgradeOperationCreateCommonDeploymentC
 	vmListSender.PathPattern = ".*/virtualMachines"
 	s.sender = append(s.sender, vmListSender)
 
-	op0 := upgrader.UpgradeOperations()[0]
+	op0 := upgrader.UpgradeOperations(environs.UpgradeOperationsParams{})[0]
 	c.Assert(op0.Steps[0].Run(), jc.ErrorIsNil)
 }

--- a/provider/vsphere/environ_broker_test.go
+++ b/provider/vsphere/environ_broker_test.go
@@ -104,12 +104,10 @@ func (s *environBrokerSuite) TestStartInstance(c *gc.C) {
 	createVMArgs.Constraints = constraints.Value{}
 	createVMArgs.UpdateProgress = nil
 	c.Assert(createVMArgs, jc.DeepEquals, vsphereclient.CreateVirtualMachineParams{
-		Name: "juju-f75cba-0",
-		OVF:  "FakeOvfContent",
-		Metadata: map[string]string{
-			"juju_controller_uuid_key": "deadbeef-1bad-500d-9000-4b1d0d06f00d",
-			"juju_is_controller_key":   "juju_is_controller_value",
-		},
+		Name:            "juju-f75cba-0",
+		Folder:          `Juju Controller (deadbeef-1bad-500d-9000-4b1d0d06f00d)/Model "testenv" (2d02eeac-9dbb-11e4-89d3-123b93f75cba)`,
+		OVF:             "FakeOvfContent",
+		Metadata:        startInstArgs.InstanceConfig.Tags,
 		ComputeResource: s.client.computeResources[0],
 	})
 }
@@ -284,7 +282,10 @@ func (s *environBrokerSuite) TestStopInstances(c *gc.C) {
 
 	// NOTE(axw) we must use SameContents, not DeepEquals, because
 	// we run the RemoveVirtualMachines calls concurrently.
-	c.Assert(paths, jc.SameContents, []string{`vm-0`, `vm-1`})
+	c.Assert(paths, jc.SameContents, []string{
+		`Juju Controller (*)/Model "testenv" (2d02eeac-9dbb-11e4-89d3-123b93f75cba)/vm-0`,
+		`Juju Controller (*)/Model "testenv" (2d02eeac-9dbb-11e4-89d3-123b93f75cba)/vm-1`,
+	})
 }
 
 func (s *environBrokerSuite) TestStopInstancesOneFailure(c *gc.C) {

--- a/provider/vsphere/environ_test.go
+++ b/provider/vsphere/environ_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/version"
+	"golang.org/x/net/context"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/environs"
@@ -35,7 +36,16 @@ func (s *environSuite) TestBootstrap(c *gc.C) {
 	})
 	c.Assert(err, gc.ErrorMatches, "Bootstrap called")
 
-	s.dialStub.CheckNoCalls(c)
+	// We dial a connection before calling calling Bootstrap,
+	// in order to create the VM folder.
+	s.dialStub.CheckCallNames(c, "Dial")
+	s.client.CheckCallNames(c, "EnsureVMFolder", "Close")
+	ensureVMFolderCall := s.client.Calls()[0]
+	c.Assert(ensureVMFolderCall.Args, gc.HasLen, 2)
+	c.Assert(ensureVMFolderCall.Args[0], gc.Implements, new(context.Context))
+	c.Assert(ensureVMFolderCall.Args[1], gc.Equals,
+		`Juju Controller (deadbeef-1bad-500d-9000-4b1d0d06f00d)/Model "testenv" (2d02eeac-9dbb-11e4-89d3-123b93f75cba)`,
+	)
 }
 
 func (s *environSuite) TestDestroy(c *gc.C) {
@@ -48,7 +58,13 @@ func (s *environSuite) TestDestroy(c *gc.C) {
 	err := s.env.Destroy()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(destroyCalled, jc.IsTrue)
-	s.client.CheckCallNames(c, "Close")
+	s.client.CheckCallNames(c, "DestroyVMFolder", "Close")
+	destroyVMFolderCall := s.client.Calls()[0]
+	c.Assert(destroyVMFolderCall.Args, gc.HasLen, 2)
+	c.Assert(destroyVMFolderCall.Args[0], gc.Implements, new(context.Context))
+	c.Assert(destroyVMFolderCall.Args[1], gc.Equals,
+		`Juju Controller (*)/Model "testenv" (2d02eeac-9dbb-11e4-89d3-123b93f75cba)`,
+	)
 }
 
 func (s *environSuite) TestDestroyController(c *gc.C) {
@@ -61,14 +77,43 @@ func (s *environSuite) TestDestroyController(c *gc.C) {
 	err := s.env.DestroyController("foo")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(destroyCalled, jc.IsTrue)
-	s.client.CheckCallNames(c, "Close")
+
+	s.dialStub.CheckCallNames(c, "Dial")
+	s.client.CheckCallNames(c, "DestroyVMFolder", "RemoveVirtualMachines", "DestroyVMFolder", "Close")
+
+	destroyModelVMFolderCall := s.client.Calls()[0]
+	c.Assert(destroyModelVMFolderCall.Args, gc.HasLen, 2)
+	c.Assert(destroyModelVMFolderCall.Args[0], gc.Implements, new(context.Context))
+	c.Assert(destroyModelVMFolderCall.Args[1], gc.Equals,
+		`Juju Controller (*)/Model "testenv" (2d02eeac-9dbb-11e4-89d3-123b93f75cba)`,
+	)
+
+	removeVirtualMachinesCall := s.client.Calls()[1]
+	c.Assert(removeVirtualMachinesCall.Args, gc.HasLen, 2)
+	c.Assert(removeVirtualMachinesCall.Args[0], gc.Implements, new(context.Context))
+	c.Assert(removeVirtualMachinesCall.Args[1], gc.Equals,
+		`Juju Controller (foo)/Model "*" (*)/*`,
+	)
+
+	destroyControllerVMFolderCall := s.client.Calls()[2]
+	c.Assert(destroyControllerVMFolderCall.Args, gc.HasLen, 2)
+	c.Assert(destroyControllerVMFolderCall.Args[0], gc.Implements, new(context.Context))
+	c.Assert(destroyControllerVMFolderCall.Args[1], gc.Equals, `Juju Controller (foo)`)
 }
 
 func (s *environSuite) TestAdoptResources(c *gc.C) {
 	err := s.env.AdoptResources("foo", version.Number{})
 	c.Assert(err, jc.ErrorIsNil)
 
-	s.dialStub.CheckNoCalls(c)
+	s.dialStub.CheckCallNames(c, "Dial")
+	s.client.CheckCallNames(c, "MoveVMFolderInto", "Close")
+	moveVMFolderIntoCall := s.client.Calls()[0]
+	c.Assert(moveVMFolderIntoCall.Args, gc.HasLen, 3)
+	c.Assert(moveVMFolderIntoCall.Args[0], gc.Implements, new(context.Context))
+	c.Assert(moveVMFolderIntoCall.Args[1], gc.Equals, `Juju Controller (foo)`)
+	c.Assert(moveVMFolderIntoCall.Args[2], gc.Equals,
+		`Juju Controller (*)/Model "testenv" (2d02eeac-9dbb-11e4-89d3-123b93f75cba)`,
+	)
 }
 
 func (s *environSuite) TestPrepareForBootstrap(c *gc.C) {

--- a/provider/vsphere/instance_test.go
+++ b/provider/vsphere/instance_test.go
@@ -102,11 +102,7 @@ func (s *InstanceSuite) TestInstanceAddresses(c *gc.C) {
 func (s *InstanceSuite) TestControllerInstances(c *gc.C) {
 	s.client.virtualMachines = []*mo.VirtualMachine{
 		buildVM("inst-0").vm(),
-		buildVM("inst-1").extraConfig(
-			"juju_is_controller_key", "juju_is_controller_value",
-		).extraConfig(
-			"juju_controller_uuid_key", "foo",
-		).vm(),
+		buildVM("inst-1").extraConfig("juju-is-controller", "true").vm(),
 	}
 	ids, err := s.env.ControllerInstances("foo")
 	c.Assert(err, jc.ErrorIsNil)

--- a/provider/vsphere/internal/vsphereclient/client.go
+++ b/provider/vsphere/internal/vsphereclient/client.go
@@ -311,10 +311,7 @@ func (c *Client) UpdateVirtualMachineExtraConfig(
 ) error {
 	var spec types.VirtualMachineConfigSpec
 	for k, v := range metadata {
-		opt := &types.OptionValue{Key: k}
-		if v != "" {
-			opt.Value = v
-		}
+		opt := &types.OptionValue{Key: k, Value: v}
 		spec.ExtraConfig = append(spec.ExtraConfig, opt)
 	}
 	vm := object.NewVirtualMachine(c.client.Client, vmInfo.Reference())

--- a/provider/vsphere/upgrades.go
+++ b/provider/vsphere/upgrades.go
@@ -1,0 +1,125 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package vsphere
+
+import (
+	"path"
+
+	"github.com/juju/errors"
+	"github.com/juju/version"
+	"github.com/vmware/govmomi/vim25/types"
+
+	"github.com/juju/juju/environs"
+	"github.com/juju/juju/environs/tags"
+)
+
+// UpgradeOperations is part of the upgrades.OperationSource interface.
+func (env *environ) UpgradeOperations(args environs.UpgradeOperationsParams) []environs.UpgradeOperation {
+	return []environs.UpgradeOperation{{
+		version.MustParse("2.2-beta3"),
+		[]environs.UpgradeStep{
+			extraConfigUpgradeStep{env, args.ControllerUUID},
+			modelFoldersUpgradeStep{env, args.ControllerUUID},
+		},
+	}}
+}
+
+// extraConfigUpgradeStep moves top-level VMs into a model-specific
+// VM folder.
+type extraConfigUpgradeStep struct {
+	env            *environ
+	controllerUUID string
+}
+
+// Description is part of the environs.UpgradeStep interface.
+func (extraConfigUpgradeStep) Description() string {
+	return "Update ExtraConfig properties with standard Juju tags"
+}
+
+// Run is part of the environs.UpgradeStep interface.
+func (step extraConfigUpgradeStep) Run() error {
+	const (
+		legacyControllerTag   = "juju_controller_uuid_key"
+		legacyIsControllerTag = "juju_is_controller_key"
+	)
+	controllerUUID := step.controllerUUID
+	return step.env.withSession(func(env *sessionEnviron) error {
+		vms, err := env.client.VirtualMachines(env.ctx, env.namespace.Prefix()+"*")
+		if err != nil || len(vms) == 0 {
+			return err
+		}
+		for _, vm := range vms {
+			update := false
+			isController := false
+			for _, opt := range vm.Config.ExtraConfig {
+				value := opt.GetOptionValue()
+				switch value.Key {
+				case legacyControllerTag:
+					update = true
+				case legacyIsControllerTag:
+					isController = true
+				}
+			}
+			if !update {
+				continue
+			}
+			metadata := map[string]string{
+				tags.JujuController: controllerUUID,
+				tags.JujuModel:      env.Config().UUID(),
+			}
+			if isController {
+				metadata[tags.JujuIsController] = "true"
+			}
+			if err := env.client.UpdateVirtualMachineExtraConfig(
+				env.ctx, vm, metadata,
+			); err != nil {
+				return errors.Annotatef(err, "updating VM %s", vm.Name)
+			}
+		}
+		return nil
+	})
+}
+
+// modelFoldersUpgradeStep moves top-level VMs into a model-specific
+// VM folder.
+type modelFoldersUpgradeStep struct {
+	env            *environ
+	controllerUUID string
+}
+
+// Description is part of the environs.UpgradeStep interface.
+func (modelFoldersUpgradeStep) Description() string {
+	return "Move VMs into controller/model folders"
+}
+
+// Run is part of the environs.UpgradeStep interface.
+func (step modelFoldersUpgradeStep) Run() error {
+	controllerUUID := step.controllerUUID
+	return step.env.withSession(func(env *sessionEnviron) error {
+		// We must create the folder even if there are no VMs in the model.
+		modelFolderPath := path.Join(
+			controllerFolderName(controllerUUID),
+			env.modelFolderName(),
+		)
+		if err := env.client.EnsureVMFolder(env.ctx, modelFolderPath); err != nil {
+			return errors.Annotate(err, "creating model folder")
+		}
+
+		// List all instances at the top level with the model UUID,
+		// and move them into the folder.
+		vms, err := env.client.VirtualMachines(env.ctx, env.namespace.Prefix()+"*")
+		if err != nil || len(vms) == 0 {
+			return err
+		}
+		refs := make([]types.ManagedObjectReference, len(vms))
+		for i, vm := range vms {
+			logger.Debugf("moving VM %q into %q", vm.Name, modelFolderPath)
+			refs[i] = vm.Reference()
+		}
+		if err := env.client.MoveVMsInto(env.ctx, modelFolderPath, refs...); err != nil {
+			return errors.Annotate(err, "moving VMs into model folder")
+		}
+		return nil
+	})
+}

--- a/provider/vsphere/upgrades_test.go
+++ b/provider/vsphere/upgrades_test.go
@@ -1,0 +1,92 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package vsphere_test
+
+import (
+	jc "github.com/juju/testing/checkers"
+	"github.com/juju/version"
+	"github.com/vmware/govmomi/vim25/mo"
+	"github.com/vmware/govmomi/vim25/types"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/environs"
+)
+
+type environUpgradeSuite struct {
+	EnvironFixture
+}
+
+var _ = gc.Suite(&environUpgradeSuite{})
+
+func (s *environUpgradeSuite) TestEnvironImplementsUpgrader(c *gc.C) {
+	c.Assert(s.env, gc.Implements, new(environs.Upgrader))
+}
+
+func (s *environUpgradeSuite) TestEnvironUpgradeOperations(c *gc.C) {
+	upgrader := s.env.(environs.Upgrader)
+	ops := upgrader.UpgradeOperations(environs.UpgradeOperationsParams{})
+	c.Assert(ops, gc.HasLen, 1)
+	c.Assert(ops[0].TargetVersion, gc.Equals, version.MustParse("2.2-beta3"))
+	c.Assert(ops[0].Steps, gc.HasLen, 2)
+	c.Assert(ops[0].Steps[0].Description(), gc.Equals, "Update ExtraConfig properties with standard Juju tags")
+	c.Assert(ops[0].Steps[1].Description(), gc.Equals, "Move VMs into controller/model folders")
+}
+
+func (s *environUpgradeSuite) TestEnvironUpgradeOperationUpdateExtraConfig(c *gc.C) {
+	upgrader := s.env.(environs.Upgrader)
+	step := upgrader.UpgradeOperations(environs.UpgradeOperationsParams{
+		ControllerUUID: "foo",
+	})[0].Steps[0]
+
+	vm1 := buildVM("vm-1").extraConfig("juju_controller_uuid_key", "old").vm()
+	vm2 := buildVM("vm-1").extraConfig("juju_controller_uuid_key", "old").extraConfig("juju_is_controller_key", "yep").vm()
+	vm3 := buildVM("vm-2").vm()
+	s.client.virtualMachines = []*mo.VirtualMachine{vm1, vm2, vm3}
+
+	err := step.Run()
+	c.Assert(err, jc.ErrorIsNil)
+
+	s.client.CheckCallNames(c, "VirtualMachines", "UpdateVirtualMachineExtraConfig", "UpdateVirtualMachineExtraConfig", "Close")
+
+	updateCall1 := s.client.Calls()[1]
+	c.Assert(updateCall1.Args[1], gc.Equals, vm1)
+	c.Assert(updateCall1.Args[2], jc.DeepEquals, map[string]string{
+		"juju-controller-uuid": "foo",
+		"juju-model-uuid":      "2d02eeac-9dbb-11e4-89d3-123b93f75cba",
+	})
+
+	updateCall2 := s.client.Calls()[2]
+	c.Assert(updateCall2.Args[1], gc.Equals, vm2)
+	c.Assert(updateCall2.Args[2], jc.DeepEquals, map[string]string{
+		"juju-controller-uuid": "foo",
+		"juju-model-uuid":      "2d02eeac-9dbb-11e4-89d3-123b93f75cba",
+		"juju-is-controller":   "true",
+	})
+}
+
+func (s *environUpgradeSuite) TestEnvironUpgradeOperationModelFolders(c *gc.C) {
+	upgrader := s.env.(environs.Upgrader)
+	step := upgrader.UpgradeOperations(environs.UpgradeOperationsParams{
+		ControllerUUID: "foo",
+	})[0].Steps[1]
+
+	vm1 := buildVM("vm-1").vm()
+	vm2 := buildVM("vm-2").vm()
+	vm3 := buildVM("vm-3").vm()
+	s.client.virtualMachines = []*mo.VirtualMachine{vm1, vm2, vm3}
+
+	err := step.Run()
+	c.Assert(err, jc.ErrorIsNil)
+
+	s.client.CheckCallNames(c, "EnsureVMFolder", "VirtualMachines", "MoveVMsInto", "Close")
+	ensureVMFolderCall := s.client.Calls()[0]
+	moveVMsIntoCall := s.client.Calls()[2]
+	c.Assert(ensureVMFolderCall.Args[1], gc.Equals,
+		`Juju Controller (foo)/Model "testenv" (2d02eeac-9dbb-11e4-89d3-123b93f75cba)`)
+	c.Assert(moveVMsIntoCall.Args[1], gc.Equals,
+		`Juju Controller (foo)/Model "testenv" (2d02eeac-9dbb-11e4-89d3-123b93f75cba)`)
+	c.Assert(moveVMsIntoCall.Args[2], jc.DeepEquals,
+		[]types.ManagedObjectReference{vm1.Reference(), vm2.Reference(), vm3.Reference()},
+	)
+}

--- a/upgrades/backend.go
+++ b/upgrades/backend.go
@@ -16,6 +16,7 @@ import (
 // StateBackend provides an interface for upgrading the global state database.
 type StateBackend interface {
 	AllModels() ([]Model, error)
+	ControllerUUID() string
 
 	StripLocalUserDomain() error
 	RenameAddModelPermission() error
@@ -54,6 +55,10 @@ func (s stateBackend) AllModels() ([]Model, error) {
 		out[i] = &modelShim{s.st, m}
 	}
 	return out, nil
+}
+
+func (s stateBackend) ControllerUUID() string {
+	return s.st.ControllerUUID()
 }
 
 func (s stateBackend) StripLocalUserDomain() error {

--- a/upgrades/environ.go
+++ b/upgrades/environ.go
@@ -30,7 +30,10 @@ func newEnvironUpgradeOpsIterator(from version.Number, context Context) (*opsIte
 			return nil, errors.Trace(err)
 		}
 		if env, ok := env.(environs.Upgrader); ok {
-			envUpgradeOps = append(envUpgradeOps, env.UpgradeOperations()...)
+			args := environs.UpgradeOperationsParams{
+				ControllerUUID: st.ControllerUUID(),
+			}
+			envUpgradeOps = append(envUpgradeOps, env.UpgradeOperations(args)...)
 		}
 	}
 	ops := make([]Operation, len(envUpgradeOps))

--- a/upgrades/upgrade_test.go
+++ b/upgrades/upgrade_test.go
@@ -228,6 +228,11 @@ func (mock *mockStateBackend) AllModels() ([]upgrades.Model, error) {
 	return mock.models, mock.NextErr()
 }
 
+func (mock *mockStateBackend) ControllerUUID() string {
+	mock.MethodCall(mock, "ControllerUUID")
+	return "a-b-c-d"
+}
+
 type mockModel struct {
 	testing.Stub
 	config    *config.Config
@@ -250,8 +255,8 @@ type mockUpgradeableEnviron struct {
 	ops []environs.UpgradeOperation
 }
 
-func (m *mockUpgradeableEnviron) UpgradeOperations() []environs.UpgradeOperation {
-	m.MethodCall(m, "UpgradeOperations")
+func (m *mockUpgradeableEnviron) UpgradeOperations(args environs.UpgradeOperationsParams) []environs.UpgradeOperation {
+	m.MethodCall(m, "UpgradeOperations", args)
 	return m.ops
 }
 
@@ -690,7 +695,7 @@ func (s *upgradeSuite) TestEnvironUpgradeOperations(c *gc.C) {
 	err := upgrades.PerformUpgrade(fromVers, targets(upgrades.DatabaseMaster), ctx)
 	c.Assert(err, jc.ErrorIsNil)
 
-	state.CheckCallNames(c, "AllModels")
+	state.CheckCallNames(c, "AllModels", "ControllerUUID")
 	model0.CheckCallNames(c, "Config", "CloudSpec")
 	model1.CheckCallNames(c, "Config", "CloudSpec")
 	newEnvironStub.CheckCallNames(c, "NewEnviron", "NewEnviron")


### PR DESCRIPTION
## Description of change

The main change in this branch is to organise
vCenter/ESXi VMs into folders. We create a
folder per controller, containing folders for
each model within that controller. The model
folders contain the VMs.

This change enables us to properly support
kill-controller, so that hosted model resources
are cleaned up even when the controller is
not available.

We also start using the standard instance tags
as VM metadata ("extra config"), and use them
for identifying controller instances.

Upgrade steps are included to move VMs into
folders, and to update VM metadata.

## QA steps

SCENARIO 1
1. juju bootstrap vsphere a
2. juju add-model foo
2. juju deploy ubuntu
3. juju bootstrap vsphere b
4. juju switch a:foo
5. juju migrate foo b
(check that it migrates)
6. juju kill-controller -y a
(check that only the controller machine for a is destroyed, along with the folders for controller a)
7. juju switch b
8. juju ssh -m controller 0 "sudo service jujud-machine-0 stop"
9. juju kill-controller -y b -t0
(check that all Juju-related VMs are destroyed, along with the folders for controller b)

SCENARIO 2

1. (with juju 2.2-beta2) juju bootstrap vsphere

2. (with juju from this branch) juju upgrade-juju -m controller --build-agent
(check that VMs are moved into folders, and govc vm.info -json shows that the extra config is updated)

## Documentation changes

None.

## Bug reference

Sorta fixes https://bugs.launchpad.net/bugs/1677325