### PR TITLE
Prepare for JAAS enabled consume/relate remote apps

### DIFF
--- a/apiserver/application/application_test.go
+++ b/apiserver/application/application_test.go
@@ -2687,7 +2687,7 @@ func (s *applicationSuite) TestRemoteRelationNotFound(c *gc.C) {
 	s.AddTestingService(c, "wordpress", s.AddTestingCharm(c, "wordpress"))
 	endpoints := []string{"wordpress", "unknownmodel.unknown"}
 	_, err := s.applicationAPI.AddRelation(params.AddRelation{endpoints})
-	c.Assert(err, gc.ErrorMatches, `model "admin/unknownmodel" not found`)
+	c.Assert(err, gc.ErrorMatches, `application offer at admin/unknownmodel.unknown not found`)
 }
 
 func (s *applicationSuite) TestConsumeRejectsEndpoints(c *gc.C) {

--- a/apiserver/applicationoffers/applicationoffers_test.go
+++ b/apiserver/applicationoffers/applicationoffers_test.go
@@ -179,6 +179,7 @@ func (s *applicationOffersSuite) assertList(c *gc.C, expectedErr error) {
 		[]params.ApplicationOfferDetails{
 			{
 				ApplicationOffer: params.ApplicationOffer{
+					SourceModelTag:         "model-uuid",
 					ApplicationDescription: "description",
 					OfferName:              "hosted-db2",
 					OfferURL:               "fred/prod.hosted-db2",

--- a/apiserver/common/crossmodelcommon/crossmodel.go
+++ b/apiserver/common/crossmodelcommon/crossmodel.go
@@ -132,7 +132,7 @@ func (api *BaseAPI) ApplicationOffersFromModel(
 			return nil, errors.Trace(err)
 		}
 		offerDetails := params.ApplicationOfferDetails{
-			ApplicationOffer: makeOfferParamsFromOffer(offer, userAccess),
+			ApplicationOffer: makeOfferParamsFromOffer(offer, modelUUID, userAccess),
 			ApplicationName:  app.Name(),
 			CharmName:        curl.Name,
 			ConnectedCount:   status.ConnectionCount(),
@@ -142,8 +142,9 @@ func (api *BaseAPI) ApplicationOffersFromModel(
 	return results, nil
 }
 
-func makeOfferParamsFromOffer(offer jujucrossmodel.ApplicationOffer, access permission.Access) params.ApplicationOffer {
+func makeOfferParamsFromOffer(offer jujucrossmodel.ApplicationOffer, modelUUID string, access permission.Access) params.ApplicationOffer {
 	result := params.ApplicationOffer{
+		SourceModelTag:         names.NewModelTag(modelUUID).String(),
 		OfferName:              offer.OfferName,
 		ApplicationDescription: offer.ApplicationDescription,
 		Access:                 string(access),

--- a/apiserver/params/crossmodel.go
+++ b/apiserver/params/crossmodel.go
@@ -39,6 +39,7 @@ type OfferFilter struct {
 
 // ApplicationOffer represents an application offering from an external model.
 type ApplicationOffer struct {
+	SourceModelTag         string           `json:"source-model-tag"`
 	OfferURL               string           `json:"offer-url"`
 	OfferName              string           `json:"offer-name"`
 	ApplicationDescription string           `json:"application-description"`

--- a/apiserver/remoteendpoints/remoteendpoints_test.go
+++ b/apiserver/remoteendpoints/remoteendpoints_test.go
@@ -70,6 +70,7 @@ func (s *remoteEndpointsSuite) assertShow(c *gc.C, expected []params.Application
 func (s *remoteEndpointsSuite) TestShow(c *gc.C) {
 	expected := []params.ApplicationOfferResult{{
 		Result: params.ApplicationOffer{
+			SourceModelTag:         "model-uuid",
 			ApplicationDescription: "description",
 			OfferURL:               "fred/prod.hosted-db2",
 			OfferName:              "hosted-db2",
@@ -92,6 +93,7 @@ func (s *remoteEndpointsSuite) TestShowPermission(c *gc.C) {
 	s.authorizer.Tag = names.NewUserTag("someone")
 	expected := []params.ApplicationOfferResult{{
 		Result: params.ApplicationOffer{
+			SourceModelTag:         "model-uuid",
 			ApplicationDescription: "description",
 			OfferURL:               "fred/prod.hosted-db2",
 			OfferName:              "hosted-db2",
@@ -218,12 +220,14 @@ func (s *remoteEndpointsSuite) TestShowFoundMultiple(c *gc.C) {
 	}
 	c.Assert(results, jc.DeepEquals, []params.ApplicationOffer{
 		{
+			SourceModelTag:         "model-uuid",
 			ApplicationDescription: "description",
 			OfferName:              "hosted-" + name,
 			OfferURL:               url,
 			Access:                 "read",
 			Endpoints:              []params.RemoteEndpoint{{Name: "db"}}},
 		{
+			SourceModelTag:         "model-uuid2",
 			ApplicationDescription: "description2",
 			OfferName:              "hosted-" + name2,
 			OfferURL:               url2,
@@ -254,6 +258,7 @@ func (s *remoteEndpointsSuite) TestFind(c *gc.C) {
 	s.authorizer.Tag = names.NewUserTag("admin")
 	expected := []params.ApplicationOffer{
 		{
+			SourceModelTag:         "model-uuid",
 			ApplicationDescription: "description",
 			OfferName:              "hosted-db2",
 			OfferURL:               "fred/prod.hosted-db2",
@@ -273,6 +278,7 @@ func (s *remoteEndpointsSuite) TestFindPermission(c *gc.C) {
 	s.authorizer.Tag = names.NewUserTag("someone")
 	expected := []params.ApplicationOffer{
 		{
+			SourceModelTag:         "model-uuid",
 			ApplicationDescription: "description",
 			OfferName:              "hosted-db2",
 			OfferURL:               "fred/prod.hosted-db2",
@@ -367,6 +373,7 @@ func (s *remoteEndpointsSuite) TestFindMulti(c *gc.C) {
 	c.Assert(found, jc.DeepEquals, params.FindApplicationOffersResults{
 		[]params.ApplicationOffer{
 			{
+				SourceModelTag:         "model-uuid",
 				ApplicationDescription: "db2 description",
 				OfferName:              "hosted-db2",
 				OfferURL:               "fred/prod.hosted-db2",
@@ -374,6 +381,7 @@ func (s *remoteEndpointsSuite) TestFindMulti(c *gc.C) {
 				Endpoints:              []params.RemoteEndpoint{{Name: "db"}},
 			},
 			{
+				SourceModelTag:         "model-uuid2",
 				ApplicationDescription: "mysql description",
 				OfferName:              "hosted-mysql",
 				OfferURL:               "mary/another.hosted-mysql",
@@ -381,6 +389,7 @@ func (s *remoteEndpointsSuite) TestFindMulti(c *gc.C) {
 				Endpoints:              []params.RemoteEndpoint{{Name: "db"}},
 			},
 			{
+				SourceModelTag:         "model-uuid2",
 				ApplicationDescription: "postgresql description",
 				OfferName:              "hosted-postgresql",
 				OfferURL:               "mary/another.hosted-postgresql",


### PR DESCRIPTION
## Description of change

Clean up the apiserver code to process consume and relate to offer.
Separate methods are used to looking up offers in the same or a different controller. Only the same controller case is currently supported.

## QA steps

Smoke test CMR deployment.
