### PR TITLE
Skip TestUniterUpgradeOverwrite on s390x for now due to intermittant

### DIFF
--- a/testing/base.go
+++ b/testing/base.go
@@ -94,6 +94,13 @@ func SkipIfI386(c *gc.C, bugID string) {
 	}
 }
 
+// SkipIfS390X skips the test if the arch is S390X.
+func SkipIfS390X(c *gc.C, bugID string) {
+	if arch.NormaliseArch(runtime.GOARCH) == arch.S390X {
+		c.Skip(fmt.Sprintf("Test disabled on S390X until fixed - see bug %s", bugID))
+	}
+}
+
 // SkipIfWindowsBug skips the test if the OS is Windows.
 func SkipIfWindowsBug(c *gc.C, bugID string) {
 	if runtime.GOOS == "windows" {

--- a/worker/uniter/uniter_test.go
+++ b/worker/uniter/uniter_test.go
@@ -738,9 +738,9 @@ resources:
 
 func (s *UniterSuite) TestUniterUpgradeOverwrite(c *gc.C) {
 	//TODO(bogdanteleaga): Fix this on windows
-	if runtime.GOOS == "windows" {
-		c.Skip("bug 1403084: currently does not work on windows")
-	}
+	coretesting.SkipIfWindowsBug(c, "lp:1403084")
+	//TODO(hml): Fix this on S390X, intermittent there.
+	coretesting.SkipIfS390X(c, "lp:1534637")
 	makeTest := func(description string, content, extraChecks ft.Entries) uniterTest {
 		return ut(description,
 			createCharm{


### PR DESCRIPTION
failures like seen in Bug 1534637.  Add SkipIfS390X method.

## Please provide the following details to expedite Pull Request review:

----

## Description of change

Bad results on s390x are intermittent and difficult to reproduce.  Skipping the test on that platform for
now.

## QA steps

Ran TestUniterUpgradeOverwrite on s390x-slave from package tarball.

## Documentation changes

N/A

## Bug reference

https://bugs.launchpad.net/juju-core/+bug/1534637
