### PR TITLE
provider/vsphere: cache OVA contents on controller

### DIFF
--- a/provider/vsphere/config_test.go
+++ b/provider/vsphere/config_test.go
@@ -61,7 +61,7 @@ var _ = gc.Suite(&ConfigSuite{})
 func (s *ConfigSuite) SetUpTest(c *gc.C) {
 	s.BaseSuite.SetUpTest(c)
 	s.config = fakeConfig(c)
-	s.provider = vsphere.NewEnvironProvider(nil)
+	s.provider = vsphere.NewEnvironProvider(vsphere.EnvironProviderConfig{})
 }
 
 // configTestSpec defines a subtest to run in a table driven test.

--- a/provider/vsphere/environ.go
+++ b/provider/vsphere/environ.go
@@ -29,9 +29,6 @@ type environ struct {
 
 	lock sync.Mutex // lock protects access the following fields.
 	ecfg *environConfig
-
-	archLock               sync.Mutex
-	supportedArchitectures []string
 }
 
 func newEnviron(

--- a/provider/vsphere/environ_policy.go
+++ b/provider/vsphere/environ_policy.go
@@ -4,13 +4,9 @@
 package vsphere
 
 import (
-	"github.com/juju/errors"
-	"github.com/juju/utils/set"
+	"github.com/juju/utils/arch"
 
 	"github.com/juju/juju/constraints"
-	"github.com/juju/juju/environs"
-	"github.com/juju/juju/environs/imagemetadata"
-	"github.com/juju/juju/environs/simplestreams"
 )
 
 // PrecheckInstance is part of the environs.Environ interface.
@@ -29,46 +25,6 @@ func (env *sessionEnviron) PrecheckInstance(series string, cons constraints.Valu
 	return err
 }
 
-// supportedArchitectures returns the image architectures which can
-// be hosted by this environment.
-func (env *environ) allSupportedArchitectures() ([]string, error) {
-	env.archLock.Lock()
-	defer env.archLock.Unlock()
-
-	if env.supportedArchitectures != nil {
-		return env.supportedArchitectures, nil
-	}
-
-	archList, err := env.lookupArchitectures()
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	env.supportedArchitectures = archList
-	return archList, nil
-}
-
-func (env *environ) lookupArchitectures() ([]string, error) {
-	// Create a filter to get all images for the correct stream.
-	imageConstraint := imagemetadata.NewImageConstraint(simplestreams.LookupParams{
-		Stream: env.Config().ImageStream(),
-	})
-	sources, err := environs.ImageMetadataSources(env)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	matchingImages, err := imageMetadataFetch(sources, imageConstraint)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-
-	var arches = set.NewStrings()
-	for _, im := range matchingImages {
-		arches.Add(im.Arch)
-	}
-
-	return arches.Values(), nil
-}
-
 var unsupportedConstraints = []string{
 	constraints.Tags,
 	constraints.VirtType,
@@ -79,11 +35,8 @@ var unsupportedConstraints = []string{
 func (env *environ) ConstraintsValidator() (constraints.Validator, error) {
 	validator := constraints.NewValidator()
 	validator.RegisterUnsupported(unsupportedConstraints)
-
-	supportedArches, err := env.allSupportedArchitectures()
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	validator.RegisterVocabulary(constraints.Arch, supportedArches)
+	validator.RegisterVocabulary(constraints.Arch, []string{
+		arch.AMD64, arch.I386,
+	})
 	return validator, nil
 }

--- a/provider/vsphere/init.go
+++ b/provider/vsphere/init.go
@@ -5,7 +5,10 @@ package vsphere
 
 import (
 	"net/url"
+	"time"
 
+	"github.com/juju/mutex"
+	"github.com/juju/utils/clock"
 	"golang.org/x/net/context"
 
 	"github.com/juju/juju/environs"
@@ -20,5 +23,13 @@ func init() {
 	dial := func(ctx context.Context, u *url.URL, dc string) (Client, error) {
 		return vsphereclient.Dial(ctx, u, dc, logger)
 	}
-	environs.RegisterProvider(providerType, NewEnvironProvider(dial))
+	environs.RegisterProvider(providerType, NewEnvironProvider(EnvironProviderConfig{
+		Dial:        dial,
+		OVACacheDir: "/var/cache/juju/vsphere/ova",
+		OVACacheLocker: NewMutexCacheLocker(mutex.Spec{
+			Name:  "juju-vsphere",
+			Clock: clock.WallClock,
+			Delay: 5 * time.Second,
+		}),
+	}))
 }

--- a/provider/vsphere/internal/vsphereclient/createvm.go
+++ b/provider/vsphere/internal/vsphereclient/createvm.go
@@ -303,7 +303,7 @@ func uploadImage(
 		Progress:      &progressSink,
 	}
 	if err := client.Upload(f, targetURL, &opts); err != nil {
-		return errors.Annotatef(err, "uploading %s to %s", item.Path, targetURL)
+		return errors.Annotatef(err, "uploading %s to %s", filepath.Base(item.Path), targetURL)
 	}
 	return nil
 }

--- a/provider/vsphere/ova_utils.go
+++ b/provider/vsphere/ova_utils.go
@@ -5,6 +5,8 @@ package vsphere
 
 import (
 	"archive/tar"
+	"crypto/sha256"
+	"fmt"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -12,72 +14,156 @@ import (
 	"path/filepath"
 
 	"github.com/juju/errors"
+	"github.com/juju/mutex"
 )
 
-func downloadOva(basePath, url string) (string, error) {
-	logger.Debugf("Downloading ova file from url: %s", url)
-	resp, err := http.Get(url)
+// CacheLocker is an interface that may be used for locking
+// an OVA cache directory.
+type CacheLocker interface {
+	// Lock locks the OVA cache directory for concurrent access,
+	// and returns a function to release the lock or an error.
+	Lock() (func(), error)
+}
+
+type mutexCacheLocker struct {
+	spec mutex.Spec
+}
+
+// NewMutexCacheLocker returns an implemenation of CacheLocker
+// based on juju/mutex, using the given mutex.Spec.
+func NewMutexCacheLocker(spec mutex.Spec) CacheLocker {
+	return mutexCacheLocker{spec: spec}
+}
+
+// Lock is part of the CacheLocker interface.
+func (l mutexCacheLocker) Lock() (func(), error) {
+	releaser, err := mutex.Acquire(l.spec)
 	if err != nil {
-		return "", errors.Trace(err)
+		return nil, err
+	}
+	return releaser.Release, nil
+}
+
+// downloadOVA downloads and extracts the OVA identified by the
+// given image metadata into the specified directory. We store
+// the extracted OVA in the directory <basedir>/<series>/<arch>/<sha256>.
+// If that directory already exists, we'll use it as-is; otherwise
+// we delete all existing subdirectories of <basedir>/<series>/<arch>
+// (to remove older images), and then download and extract into
+// the target directory.
+func downloadOVA(
+	basedir, series string,
+	img *OvaFileMetadata,
+	updateProgress func(string),
+) (ovaDir string, ovfPath string, _ error) {
+	seriesDir := filepath.Join(basedir, series)
+	archDir := filepath.Join(seriesDir, img.Arch)
+	ovaDir = filepath.Join(archDir, img.Sha256)
+	if _, err := os.Stat(ovaDir); err == nil {
+		// The directory exists, which means we have previously
+		// successfully downloaded and extracted the OVA. We create
+		// the target directory atomically at the end of the process.
+		logger.Debugf("OVA file previously extracted to %s", ovaDir)
+		ovfPath, err := findOVF(ovaDir)
+		if err != nil {
+			return "", "", errors.Trace(err)
+		}
+		return ovaDir, ovfPath, nil
+	}
+
+	// Remove any existing <series>/<arch> directories, so we don't
+	// accumulate old images.
+	if err := os.RemoveAll(archDir); err != nil {
+		return "", "", errors.Trace(err)
+	}
+
+	// Tacking on a ".tmp" suffix ensures that tempdir:
+	//  - is within the same filesystem as ovaDir, makingthe
+	//    final rename atomic
+	//  - will be removed by a subsequent RemoveAll (above)
+	//    in the event of failure
+	tempdir := ovaDir + ".tmp"
+	if err := os.MkdirAll(tempdir, 0755); err != nil {
+		return "", "", errors.Trace(err)
+	}
+	defer os.RemoveAll(tempdir)
+
+	updateProgress(fmt.Sprintf("downloading %s", img.URL))
+	logger.Debugf("downloading OVA file from %s", img.URL)
+	resp, err := http.Get(img.URL)
+	if err != nil {
+		return "", "", errors.Trace(err)
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
-		return "", errors.Errorf("can't download ova file from url: %s, status: %d", url, resp.StatusCode)
+		return "", "", errors.Errorf("downloading %s (status: %d)", img.URL, resp.StatusCode)
 	}
 
-	ovfFilePath, err := extractOva(basePath, resp.Body)
+	logger.Debugf("extracting OVA to path: %s", ovaDir)
+	hash := sha256.New()
+	reader := io.TeeReader(resp.Body, hash)
+	ovfFilename, err := extractOVA(tempdir, reader)
 	if err != nil {
-		return "", errors.Trace(err)
+		return "", "", errors.Trace(err)
 	}
-	file, err := os.Open(ovfFilePath)
-	defer file.Close()
-	if err != nil {
-		return "", errors.Trace(err)
+	// Read any trailing data so we compute the hash correctly.
+	if _, err := io.Copy(ioutil.Discard, reader); err != nil {
+		return "", "", errors.Trace(err)
 	}
-	bytes, err := ioutil.ReadAll(file)
-	if err != nil {
-		return "", errors.Trace(err)
+	if img.Sha256 != fmt.Sprintf("%x", hash.Sum(nil)) {
+		return "", "", errors.Errorf("hash mismatch")
 	}
-	return string(bytes), nil
+	if err := os.Rename(tempdir, ovaDir); err != nil {
+		return "", "", errors.Trace(err)
+	}
+	logger.Debugf("OVA extracted successfully to %s", ovaDir)
+	return ovaDir, filepath.Join(ovaDir, ovfFilename), nil
 }
 
-func extractOva(basePath string, body io.Reader) (string, error) {
-	logger.Debugf("Extracting OVA to path: %s", basePath)
+func extractOVA(dir string, body io.Reader) (string, error) {
 	tarBallReader := tar.NewReader(body)
-	var ovfFileName string
-
+	var ovfFilename string
 	for {
 		header, err := tarBallReader.Next()
-		if err != nil {
-			if err == io.EOF {
-				break
-			}
+		if err == io.EOF {
+			break
+		} else if err != nil {
 			return "", errors.Trace(err)
 		}
-		filename := header.Name
+		logger.Debugf("writing file %s", header.Name)
+		if filepath.Ext(header.Name) == ".ovf" {
+			ovfFilename = header.Name
+		}
+		writer, err := os.Create(filepath.Join(dir, header.Name))
+		if err != nil {
+			return "", errors.Trace(err)
+		}
+		_, err = io.Copy(writer, tarBallReader)
+		writer.Close() // close whether Copy failed or not
+		if err != nil {
+			return "", errors.Trace(err)
+		}
+	}
+	if ovfFilename == "" {
+		return "", errors.NotFoundf(".ovf file")
+	}
+	return ovfFilename, nil
+}
+
+func findOVF(dirpath string) (string, error) {
+	dir, err := os.Open(dirpath)
+	if err != nil {
+		return "", err
+	}
+	info, err := dir.Readdir(-1)
+	if err != nil {
+		return "", err
+	}
+	for _, info := range info {
+		filename := info.Name()
 		if filepath.Ext(filename) == ".ovf" {
-			ovfFileName = filename
-		}
-		logger.Debugf("Writing file %s", filename)
-		err = func() error {
-			writer, err := os.Create(filepath.Join(basePath, filename))
-			defer writer.Close()
-			if err != nil {
-				return errors.Trace(err)
-			}
-			_, err = io.Copy(writer, tarBallReader)
-			if err != nil {
-				return errors.Trace(err)
-			}
-			return nil
-		}()
-		if err != nil {
-			return "", errors.Trace(err)
+			return filepath.Join(dirpath, filename), nil
 		}
 	}
-	if ovfFileName == "" {
-		return "", errors.Errorf("no ovf file found in the archive")
-	}
-	logger.Debugf("OVA extracted successfully to %s", basePath)
-	return filepath.Join(basePath, ovfFileName), nil
+	return "", errors.NotFoundf(".ovf file")
 }

--- a/provider/vsphere/provider.go
+++ b/provider/vsphere/provider.go
@@ -20,13 +20,34 @@ var logger = loggo.GetLogger("juju.provider.vmware")
 
 type environProvider struct {
 	environProviderCredentials
-	dial DialFunc
+	dial           DialFunc
+	ovaCacheDir    string
+	ovaCacheLocker CacheLocker
+}
+
+// EnvironProviderConfig contains configuration for the EnvironProvider.
+type EnvironProviderConfig struct {
+	// Dial is a function used for dialing connections to vCenter/ESXi.
+	Dial DialFunc
+
+	// OVACacheDir is a directory in which OVA contents are cached,
+	// to speed up VM creation. This is only used within the controller,
+	// and not on the bootstrap client.
+	OVACacheDir string
+
+	// OVACacheLocker is a CacheLocker used for synchronising access
+	// to the OVACacheDir. This should be a machine-wide lock.
+	OVACacheLocker CacheLocker
 }
 
 // NewEnvironProvider returns a new environs.EnvironProvider that will
 // dial vSphere connectons with the given dial function.
-func NewEnvironProvider(dial DialFunc) environs.EnvironProvider {
-	return &environProvider{dial: dial}
+func NewEnvironProvider(config EnvironProviderConfig) environs.EnvironProvider {
+	return &environProvider{
+		dial:           config.Dial,
+		ovaCacheDir:    config.OVACacheDir,
+		ovaCacheLocker: config.OVACacheLocker,
+	}
 }
 
 // Open implements environs.EnvironProvider.


### PR DESCRIPTION
## Description of change

When starting an instance, cache the OVA contents
on the controller's disk, and reuse if it already
exists. This can provide a substantial speedup
when starting multiple VMs.

We must use a system-wide mutex to prevent the
provisioners of separate models from trampling on
each other.

## QA steps

1. juju bootstrap vsphere
2. juju deploy canonical-kubernetes
3. juju add-model foo
4. juju deploy ubuntu

Should all deploy successfully, and without downloading the image multiple times.

## Documentation changes

None.

## Bug reference

Fixes https://bugs.launchpad.net/juju/+bug/1681640