### PR TITLE
state/presence: Make beings docs smaller

### DIFF
--- a/state/presence/presence.go
+++ b/state/presence/presence.go
@@ -384,21 +384,23 @@ func (w *Watcher) findAllBeings() (map[int64]beingInfo, error) {
 	session := w.beings.Database.Session.Copy()
 	defer session.Close()
 
+	beingInfos := make(map[int64]beingInfo)
 	beingsC := w.beings.With(session)
+
 	t0 := time.Now()
-	beings := make([]beingInfo, 0)
-	err := beingsC.Find(bson.M{
+	iter := beingsC.Find(bson.M{
 		"_id": bson.M{"$regex": bson.RegEx{"^" + w.modelUUID, ""}},
-	}).All(&beings)
-	if err != nil {
-		return nil, err
-	}
-	dt := time.Now().Sub(t0)
-	logger.Debugf("[%s] loaded %d beings in %s", w.modelUUID[:6], len(beings), dt)
-	beingInfos := make(map[int64]beingInfo, len(beings))
-	for _, being := range beings {
+	}).Batch(1600).Iter()
+	var being beingInfo
+	for iter.Next(&being) {
 		beingInfos[being.Seq] = being
 	}
+	if err := iter.Close(); err != nil {
+		return nil, errors.Annotate(err, "reading all beings")
+	}
+
+	dt := time.Now().Sub(t0)
+	logger.Debugf("[%s] loaded %d beings in %s", w.modelUUID[:6], len(beingInfos), dt)
 	return beingInfos, nil
 }
 


### PR DESCRIPTION
## Description of change

There is no need to stored the model-uuid separately as it's already
in the _id prefix. The query on model-uuid can be replaced with a
prefix match on _id (this uses the index on _id).

Given that many beings documents are created this as a significant
impact on disk space usage.

## QA steps

Bootstrapped a controller with a few units and models and confirmed that presence still functions. Confirmed new log message works like this:

```
$ juju model-config -m controller logging-config="<root>=INFO;juju=DEBUG;unit=DEBUG;juju.state.presence=TRACE"
$ juju debug-log --include-module juju.state.presence --replay -m controller
machine-0: 17:37:04 TRACE juju.state.presence [1004c4] loaded 0 beings in 409.522µs
...
machine-0: 17:37:24 TRACE juju.state.presence [5e88ac] loaded 5 beings in 879.482µs
...
machine-0: 17:37:24 TRACE juju.state.presence [5e88ac] loaded 5 beings in 3.432866ms
...
```

## Documentation changes

N.A. (internal only)

## Bug reference

Contributes to fixing https://bugs.launchpad.net/juju/+bug/1454661