### PR TITLE
state: call db().Run{,Transaction{,For}} instead of run{,Transaction{,For}}

### DIFF
--- a/state/action.go
+++ b/state/action.go
@@ -185,7 +185,7 @@ type ActionResults struct {
 // Begin marks an action as running, and logs the time it was started.
 // It asserts that the action is currently pending.
 func (a *action) Begin() (Action, error) {
-	err := a.st.runTransaction([]txn.Op{
+	err := a.st.db().RunTransaction([]txn.Op{
 		{
 			C:      actionsC,
 			Id:     a.doc.DocId,
@@ -211,7 +211,7 @@ func (a *action) Finish(results ActionResults) (Action, error) {
 // an actionresult to capture the outcome of the action. It asserts that
 // the action is not already completed.
 func (a *action) removeAndLog(finalStatus ActionStatus, results map[string]interface{}, message string) (Action, error) {
-	err := a.st.runTransaction([]txn.Op{
+	err := a.st.db().RunTransaction([]txn.Op{
 		{
 			C:  actionsC,
 			Id: a.doc.DocId,
@@ -396,7 +396,7 @@ func (st *State) EnqueueAction(receiver names.Tag, actionName string, payload ma
 		}
 		return ops, nil
 	}
-	if err = st.run(buildTxn); err == nil {
+	if err = st.db().Run(buildTxn); err == nil {
 		return newAction(st, doc), nil
 	}
 	return nil, err

--- a/state/addmachine.go
+++ b/state/addmachine.go
@@ -177,7 +177,7 @@ func (st *State) AddMachines(templates ...MachineTemplate) (_ []*Machine, err er
 	}
 	ops = append(ops, ssOps...)
 	ops = append(ops, assertModelActiveOp(st.ModelUUID()))
-	if err := st.runTransaction(ops); err != nil {
+	if err := st.db().RunTransaction(ops); err != nil {
 		if errors.Cause(err) == txn.ErrAborted {
 			if err := checkModelActive(st); err != nil {
 				return nil, errors.Trace(err)
@@ -190,7 +190,7 @@ func (st *State) AddMachines(templates ...MachineTemplate) (_ []*Machine, err er
 
 func (st *State) addMachine(mdoc *machineDoc, ops []txn.Op) (*Machine, error) {
 	ops = append([]txn.Op{assertModelActiveOp(st.ModelUUID())}, ops...)
-	if err := st.runTransaction(ops); err != nil {
+	if err := st.db().RunTransaction(ops); err != nil {
 		if errors.Cause(err) == txn.ErrAborted {
 			if err := checkModelActive(st); err != nil {
 				return nil, errors.Trace(err)
@@ -862,7 +862,7 @@ func (st *State) EnableHA(
 		ops, change, err = st.enableHAIntentionOps(intent, currentInfo, cons, series)
 		return ops, err
 	}
-	if err := st.run(buildTxn); err != nil {
+	if err := st.db().Run(buildTxn); err != nil {
 		err = errors.Annotate(err, "failed to create new controller machines")
 		return ControllersChanges{}, err
 	}

--- a/state/address.go
+++ b/state/address.go
@@ -122,7 +122,7 @@ func (st *State) SetAPIHostPorts(netHostsPorts [][]network.HostPort) error {
 		}
 		return []txn.Op{op}, nil
 	}
-	if err := st.run(buildTxn); err != nil {
+	if err := st.db().Run(buildTxn); err != nil {
 		return errors.Annotate(err, "cannot set API addresses")
 	}
 	logger.Debugf("setting API hostPorts: %v", netHostsPorts)

--- a/state/annotations.go
+++ b/state/annotations.go
@@ -67,7 +67,7 @@ func (st *State) SetAnnotations(entity GlobalEntity, annotations map[string]stri
 		}
 		return updateAnnotations(st, entity, toUpdate, toRemove), nil
 	}
-	return st.run(buildTxn)
+	return st.db().Run(buildTxn)
 }
 
 // Annotations returns all the annotations corresponding to an entity.

--- a/state/applicationoffers.go
+++ b/state/applicationoffers.go
@@ -113,7 +113,7 @@ func (s *applicationOffers) ApplicationOffer(offerName string) (*crossmodel.Appl
 // Remove deletes the application offer for offerName immediately.
 func (s *applicationOffers) Remove(offerName string) (err error) {
 	defer errors.DeferredAnnotatef(&err, "cannot delete application offer %q", offerName)
-	err = s.st.runTransaction(s.removeOps(offerName))
+	err = s.st.db().RunTransaction(s.removeOps(offerName))
 	if err == txn.ErrAborted {
 		// Already deleted.
 		return nil
@@ -200,7 +200,7 @@ func (s *applicationOffers) AddOffer(offerArgs crossmodel.AddApplicationOfferArg
 		}
 		return ops, nil
 	}
-	err = s.st.run(buildTxn)
+	err = s.st.db().Run(buildTxn)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -269,7 +269,7 @@ func (s *applicationOffers) UpdateOffer(offerArgs crossmodel.AddApplicationOffer
 		}
 		return ops, nil
 	}
-	err = s.st.run(buildTxn)
+	err = s.st.db().Run(buildTxn)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/state/applicationofferuser.go
+++ b/state/applicationofferuser.go
@@ -49,7 +49,7 @@ func (st *State) CreateOfferAccess(offer names.ApplicationOfferTag, user names.U
 	}
 	op := createPermissionOp(applicationOfferKey(offerUUID), userGlobalKey(userAccessID(user)), access)
 
-	err = st.runTransaction([]txn.Op{op})
+	err = st.db().RunTransaction([]txn.Op{op})
 	if err == txn.ErrAborted {
 		err = errors.AlreadyExistsf("permission for user %q for offer %q", user.Id(), offer.Name)
 	}
@@ -67,7 +67,7 @@ func (st *State) UpdateOfferAccess(offer names.ApplicationOfferTag, user names.U
 	}
 	op := updatePermissionOp(applicationOfferKey(offerUUID), userGlobalKey(userAccessID(user)), access)
 
-	err = st.runTransaction([]txn.Op{op})
+	err = st.db().RunTransaction([]txn.Op{op})
 	if err == txn.ErrAborted {
 		return errors.NotFoundf("existing permissions")
 	}
@@ -82,7 +82,7 @@ func (st *State) RemoveOfferAccess(offer names.ApplicationOfferTag, user names.U
 	}
 	op := removePermissionOp(applicationOfferKey(offerUUID), userGlobalKey(userAccessID(user)))
 
-	err = st.runTransaction([]txn.Op{op})
+	err = st.db().RunTransaction([]txn.Op{op})
 	if err == txn.ErrAborted {
 		err = errors.NewNotFound(nil, fmt.Sprintf("offer user %q does not exist", user.Id()))
 	}

--- a/state/block.go
+++ b/state/block.go
@@ -266,7 +266,7 @@ func setModelBlock(st *State, t BlockType, msg string) error {
 		}
 		return createModelBlockOps(st, t, msg)
 	}
-	return st.run(buildTxn)
+	return st.db().Run(buildTxn)
 }
 
 // newBlockId returns a sequential block id for this model.
@@ -306,7 +306,7 @@ func RemoveModelBlock(st *State, t BlockType) error {
 	buildTxn := func(attempt int) ([]txn.Op, error) {
 		return RemoveModelBlockOps(st, t)
 	}
-	return st.run(buildTxn)
+	return st.db().Run(buildTxn)
 }
 
 func RemoveModelBlockOps(st *State, t BlockType) ([]txn.Op, error) {

--- a/state/charm.go
+++ b/state/charm.go
@@ -371,7 +371,7 @@ func (c *Charm) Destroy() error {
 		}
 		return ops, nil
 	}
-	if err := c.st.run(buildTxn); err != nil {
+	if err := c.st.db().Run(buildTxn); err != nil {
 		return errors.Trace(err)
 	}
 	c.doc.Life = Dying
@@ -403,7 +403,7 @@ func (c *Charm) Remove() error {
 		Id:     c.doc.URL.String(),
 		Remove: true,
 	}}
-	if err := c.st.runTransaction(removeOps); err != nil {
+	if err := c.st.db().RunTransaction(removeOps); err != nil {
 		return errors.Trace(err)
 	}
 	c.doc.Life = Dead
@@ -507,7 +507,7 @@ func (c *Charm) UpdateMacaroon(m macaroon.Slice) error {
 	if err != nil {
 		return errors.Trace(err)
 	}
-	if err := c.st.runTransaction(ops); err != nil {
+	if err := c.st.db().RunTransaction(ops); err != nil {
 		return errors.Trace(err)
 	}
 	return nil
@@ -548,7 +548,7 @@ func (st *State) AddCharm(info CharmInfo) (stch *Charm, err error) {
 		}
 		return nil, errors.AlreadyExistsf("charm %q", info.ID)
 	}
-	if err = st.run(buildTxn); err == nil {
+	if err = st.db().Run(buildTxn); err == nil {
 		return st.Charm(info.ID)
 	}
 	return nil, errors.Trace(err)
@@ -661,7 +661,7 @@ func (st *State) PrepareLocalCharmUpload(curl *charm.URL) (chosenURL *charm.URL,
 		return nil, errors.Trace(err)
 	}
 
-	if err := st.runTransaction(ops); err != nil {
+	if err := st.db().RunTransaction(ops); err != nil {
 		return nil, errors.Trace(err)
 	}
 	return allocatedURL, nil
@@ -727,7 +727,7 @@ func (st *State) PrepareStoreCharmUpload(curl *charm.URL) (*Charm, error) {
 			return nil, jujutxn.ErrNoOperations
 		}
 	}
-	if err = st.run(buildTxn); err == nil {
+	if err = st.db().Run(buildTxn); err == nil {
 		return newCharm(st, &uploadedCharm), nil
 	}
 	return nil, errors.Trace(err)
@@ -775,7 +775,7 @@ func (st *State) AddStoreCharmPlaceholder(curl *charm.URL) (err error) {
 		ops := append(deleteOps, insertOps...)
 		return ops, nil
 	}
-	return errors.Trace(st.run(buildTxn))
+	return errors.Trace(st.db().Run(buildTxn))
 }
 
 // UpdateUploadedCharm marks the given charm URL as uploaded and
@@ -800,7 +800,7 @@ func (st *State) UpdateUploadedCharm(info CharmInfo) (*Charm, error) {
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	if err := st.runTransaction(ops); err != nil {
+	if err := st.db().RunTransaction(ops); err != nil {
 		return nil, onAbort(err, ErrCharmRevisionAlreadyModified)
 	}
 	return st.Charm(info.ID)

--- a/state/cleanup.go
+++ b/state/cleanup.go
@@ -128,7 +128,7 @@ func (st *State) Cleanup() (err error) {
 			Id:     doc.DocID,
 			Remove: true,
 		}}
-		if err := st.runTransaction(ops); err != nil {
+		if err := st.db().RunTransaction(ops); err != nil {
 			return errors.Annotate(err, "cannot remove empty cleanup document")
 		}
 	}
@@ -479,7 +479,7 @@ func (st *State) cleanupForceDestroyedMachine(machineId string) error {
 	if err != nil {
 		return err
 	}
-	return st.runTransaction(removePortsOps)
+	return st.db().RunTransaction(removePortsOps)
 
 	// Note that we do *not* remove the machine entirely: we leave it for the
 	// provisioner to clean up, so that we don't end up with an unreferenced

--- a/state/cloud.go
+++ b/state/cloud.go
@@ -134,7 +134,7 @@ func (st *State) AddCloud(c cloud.Cloud) error {
 		return errors.Annotate(err, "invalid cloud")
 	}
 	ops := []txn.Op{createCloudOp(c)}
-	if err := st.runTransaction(ops); err != nil {
+	if err := st.db().RunTransaction(ops); err != nil {
 		if err == txn.ErrAborted {
 			err = errors.AlreadyExistsf("cloud %q", c.Name)
 		}

--- a/state/cloudcredentials.go
+++ b/state/cloudcredentials.go
@@ -99,7 +99,7 @@ func (st *State) UpdateCloudCredential(tag names.CloudCredentialTag, credential 
 		}
 		return ops, nil
 	}
-	if err := st.run(buildTxn); err != nil {
+	if err := st.db().Run(buildTxn); err != nil {
 		return errors.Annotate(err, "updating cloud credentials")
 	}
 	return nil
@@ -117,7 +117,7 @@ func (st *State) RemoveCloudCredential(tag names.CloudCredentialTag) error {
 		}
 		return removeCloudCredentialOps(tag), nil
 	}
-	if err := st.run(buildTxn); err != nil {
+	if err := st.db().Run(buildTxn); err != nil {
 		return errors.Annotate(err, "removing cloud credential")
 	}
 	return nil

--- a/state/constraints.go
+++ b/state/constraints.go
@@ -103,7 +103,7 @@ func readConstraints(st *State, id string) (constraints.Value, error) {
 
 func writeConstraints(st *State, id string, cons constraints.Value) error {
 	ops := []txn.Op{setConstraintsOp(st, id, cons)}
-	if err := st.runTransaction(ops); err != nil {
+	if err := st.db().RunTransaction(ops); err != nil {
 		return fmt.Errorf("cannot set constraints: %v", err)
 	}
 	return nil

--- a/state/controlleruser.go
+++ b/state/controlleruser.go
@@ -25,7 +25,7 @@ func (st *State) setControllerAccess(access permission.Access, userGlobalKey str
 	}
 	op := updatePermissionOp(controllerKey(st.ControllerUUID()), userGlobalKey, access)
 
-	err := st.runTransaction([]txn.Op{op})
+	err := st.db().RunTransaction([]txn.Op{op})
 	if err == txn.ErrAborted {
 		return errors.NotFoundf("existing permissions")
 	}
@@ -86,7 +86,7 @@ func removeControllerUserOps(controllerUUID string, user names.UserTag) []txn.Op
 // RemoveControllerUser removes a user from the database.
 func (st *State) removeControllerUser(user names.UserTag) error {
 	ops := removeControllerUserOps(st.ControllerUUID(), user)
-	err := st.runTransaction(ops)
+	err := st.db().RunTransaction(ops)
 	if err == txn.ErrAborted {
 		err = errors.NewNotFound(nil, fmt.Sprintf("controller user %q does not exist", user.Id()))
 	}

--- a/state/export_test.go
+++ b/state/export_test.go
@@ -267,7 +267,7 @@ func ConvertTagToCollectionNameAndId(st *State, tag names.Tag) (string, interfac
 }
 
 func RunTransaction(st *State, ops []txn.Op) error {
-	return st.runTransaction(ops)
+	return st.db().RunTransaction(ops)
 }
 
 // Return the PasswordSalt that goes along with the PasswordHash
@@ -375,7 +375,7 @@ func SetModelLifeDead(st *State, modelUUID string) error {
 		Id:     modelUUID,
 		Update: bson.D{{"$set", bson.D{{"life", Dead}}}},
 	}}
-	return st.runTransaction(ops)
+	return st.db().RunTransaction(ops)
 }
 
 func HostedModelCount(c *gc.C, st *State) int {
@@ -483,7 +483,7 @@ func RemoveEndpointBindingsForService(c *gc.C, app *Application) {
 	globalKey := app.globalKey()
 	removeOp := removeEndpointBindingsOp(globalKey)
 
-	txnError := app.st.runTransaction([]txn.Op{removeOp})
+	txnError := app.st.db().RunTransaction([]txn.Op{removeOp})
 	err := onAbort(txnError, nil) // ignore ErrAborted as it asserts DocExists
 	c.Assert(err, jc.ErrorIsNil)
 }
@@ -525,7 +525,7 @@ func ResetMigrationMode(c *gc.C, st *State) {
 			"$set": bson.M{"migration-mode": MigrationModeNone},
 		},
 	}}
-	err := st.runTransaction(ops)
+	err := st.db().RunTransaction(ops)
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -574,7 +574,7 @@ func PrimeUnitStatusHistory(
 		return statusSetOps(unit.st, doc, globalKey)
 	}
 
-	err := unit.st.run(buildTxn)
+	err := unit.st.db().Run(buildTxn)
 	c.Assert(err, jc.ErrorIsNil)
 }
 

--- a/state/externalcontroller.go
+++ b/state/externalcontroller.go
@@ -127,7 +127,7 @@ func (ec *externalControllers) Save(controller crossmodel.ControllerInfo, modelU
 		}
 		return ops, nil
 	}
-	if err := ec.st.run(buildTxn); err != nil {
+	if err := ec.st.db().Run(buildTxn); err != nil {
 		return nil, errors.Annotate(err, "failed to create external controllers")
 	}
 

--- a/state/filesystem.go
+++ b/state/filesystem.go
@@ -518,7 +518,7 @@ func (st *State) DetachFilesystem(machine names.MachineTag, filesystem names.Fil
 		ops := detachFilesystemOps(machine, filesystem)
 		return ops, nil
 	}
-	return st.run(buildTxn)
+	return st.db().Run(buildTxn)
 }
 
 func (st *State) filesystemVolumeAttachment(m names.MachineTag, f names.FilesystemTag) (VolumeAttachment, error) {
@@ -592,7 +592,7 @@ func (st *State) RemoveFilesystemAttachment(machine names.MachineTag, filesystem
 		}
 		return ops, nil
 	}
-	return st.run(buildTxn)
+	return st.db().Run(buildTxn)
 }
 
 func removeFilesystemAttachmentOps(st *State, m names.MachineTag, f *filesystem) ([]txn.Op, error) {
@@ -656,7 +656,7 @@ func (st *State) DestroyFilesystem(tag names.FilesystemTag) (err error) {
 		}}}
 		return destroyFilesystemOps(st, filesystem, hasNoStorageAssignment)
 	}
-	return st.run(buildTxn)
+	return st.db().Run(buildTxn)
 }
 
 func destroyFilesystemOps(st *State, f *filesystem, extraAssert bson.D) ([]txn.Op, error) {
@@ -735,7 +735,7 @@ func (st *State) RemoveFilesystem(tag names.FilesystemTag) (err error) {
 		}
 		return removeFilesystemOps(st, filesystem, isDeadDoc)
 	}
-	return st.run(buildTxn)
+	return st.db().Run(buildTxn)
 }
 
 func removeFilesystemOps(st *State, filesystem Filesystem, assert interface{}) ([]txn.Op, error) {
@@ -1013,7 +1013,7 @@ func (st *State) SetFilesystemInfo(tag names.FilesystemTag, info FilesystemInfo)
 		ops := setFilesystemInfoOps(tag, info, unsetParams)
 		return ops, nil
 	}
-	return st.run(buildTxn)
+	return st.db().Run(buildTxn)
 }
 
 func validateFilesystemInfoChange(newInfo, oldInfo FilesystemInfo) error {
@@ -1088,7 +1088,7 @@ func (st *State) SetFilesystemAttachmentInfo(
 		ops := setFilesystemAttachmentInfoOps(machineTag, filesystemTag, info, unsetParams)
 		return ops, nil
 	}
-	return st.run(buildTxn)
+	return st.db().Run(buildTxn)
 }
 
 func setFilesystemAttachmentInfoOps(

--- a/state/linklayerdevices.go
+++ b/state/linklayerdevices.go
@@ -252,7 +252,7 @@ func (dev *LinkLayerDevice) Remove() (err error) {
 		}
 		return ops, nil
 	}
-	return dev.st.run(buildTxn)
+	return dev.st.db().Run(buildTxn)
 }
 
 func (dev *LinkLayerDevice) errNoOperationsIfMissing() error {
@@ -499,5 +499,5 @@ func (dev *LinkLayerDevice) RemoveAddresses() error {
 		return errors.Trace(err)
 	}
 
-	return dev.st.runTransaction(ops)
+	return dev.st.db().RunTransaction(ops)
 }

--- a/state/linklayerdevices_ipaddresses.go
+++ b/state/linklayerdevices_ipaddresses.go
@@ -216,7 +216,7 @@ func (addr *Address) Remove() (err error) {
 		op := addr.st.networkEntityGlobalKeyRemoveOp("address", addr.ProviderID())
 		ops = append(ops, op)
 	}
-	return addr.st.runTransaction(ops)
+	return addr.st.db().RunTransaction(ops)
 }
 
 // removeIPAddressDocOpOp returns an operation to remove the ipAddressDoc

--- a/state/machine_linklayerdevices.go
+++ b/state/machine_linklayerdevices.go
@@ -113,7 +113,7 @@ func (m *Machine) RemoveAllLinkLayerDevices() error {
 		return errors.Trace(err)
 	}
 
-	return m.st.runTransaction(ops)
+	return m.st.db().RunTransaction(ops)
 }
 
 func (m *Machine) removeAllLinkLayerDevicesOps() ([]txn.Op, error) {
@@ -229,7 +229,7 @@ func (m *Machine) SetLinkLayerDevices(devicesArgs ...LinkLayerDeviceArgs) (err e
 		}
 		return append(ops, setDevicesOps...), nil
 	}
-	if err := m.st.run(buildTxn); err != nil {
+	if err := m.st.db().Run(buildTxn); err != nil {
 		return errors.Trace(err)
 	}
 	return nil
@@ -651,7 +651,7 @@ func (m *Machine) SetDevicesAddresses(devicesAddresses ...LinkLayerDeviceAddress
 		}
 		return append(ops, setAddressesOps...), nil
 	}
-	if err := m.st.run(buildTxn); err != nil {
+	if err := m.st.db().Run(buildTxn); err != nil {
 		return errors.Trace(err)
 	}
 	return nil
@@ -853,7 +853,7 @@ func (m *Machine) RemoveAllAddresses() error {
 		return errors.Trace(err)
 	}
 
-	return m.st.runTransaction(ops)
+	return m.st.db().RunTransaction(ops)
 }
 
 func (m *Machine) removeAllAddressesOps() ([]txn.Op, error) {

--- a/state/machineremovals.go
+++ b/state/machineremovals.go
@@ -59,7 +59,7 @@ func (m *Machine) MarkForRemoval() (err error) {
 		}
 		return ops, nil
 	}
-	return m.st.run(buildTxn)
+	return m.st.db().Run(buildTxn)
 }
 
 // AllMachineRemovals returns (the ids of) all of the machines that
@@ -203,5 +203,5 @@ func (st *State) CompleteMachineRemovals(ids ...string) error {
 		}
 		return ops, nil
 	}
-	return st.run(buildTxn)
+	return st.db().Run(buildTxn)
 }

--- a/state/meterstatus.go
+++ b/state/meterstatus.go
@@ -126,7 +126,7 @@ func (u *Unit) SetMeterStatus(codeStr, info string) error {
 				Update: bson.D{{"$set", bson.D{{"code", code.String()}, {"info", info}}}},
 			}}, nil
 	}
-	return errors.Annotatef(u.st.run(buildTxn), "cannot set meter state for unit %s", u.Name())
+	return errors.Annotatef(u.st.db().Run(buildTxn), "cannot set meter state for unit %s", u.Name())
 }
 
 // createMeterStatusOp returns the operation needed to create the meter status

--- a/state/metrics.go
+++ b/state/metrics.go
@@ -165,7 +165,7 @@ func (st *State) AddMetrics(batch BatchParam) (*MetricBatch, error) {
 		}}
 		return ops, nil
 	}
-	err = st.run(buildTxn)
+	err = st.db().Run(buildTxn)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -211,7 +211,7 @@ func (st *State) AddModelMetrics(batch ModelBatchParam) (*MetricBatch, error) {
 		}}
 		return ops, nil
 	}
-	err = st.run(buildTxn)
+	err = st.db().Run(buildTxn)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -436,7 +436,7 @@ func (m *MetricBatch) UniqueMetrics() []Metric {
 func (m *MetricBatch) SetSent(t time.Time) error {
 	deleteTime := t.UTC().Add(CleanupAge)
 	ops := setSentOps([]string{m.UUID()}, deleteTime)
-	if err := m.st.runTransaction(ops); err != nil {
+	if err := m.st.db().RunTransaction(ops); err != nil {
 		return errors.Annotatef(err, "cannot set metric sent for metric %q", m.UUID())
 	}
 
@@ -472,7 +472,7 @@ func setSentOps(batchUUIDs []string, deleteTime time.Time) []txn.Op {
 func (st *State) SetMetricBatchesSent(batchUUIDs []string) error {
 	deleteTime := st.clock.Now().UTC().Add(CleanupAge)
 	ops := setSentOps(batchUUIDs, deleteTime)
-	if err := st.runTransaction(ops); err != nil {
+	if err := st.db().RunTransaction(ops); err != nil {
 		return errors.Annotatef(err, "cannot set metric sent in bulk call")
 	}
 	return nil

--- a/state/metricsmanager.go
+++ b/state/metricsmanager.go
@@ -78,7 +78,7 @@ func (st *State) newMetricsManager() (*MetricsManager, error) {
 			Insert: mm.doc,
 		}}, nil
 	}
-	err := st.run(buildTxn)
+	err := st.db().Run(buildTxn)
 	if err != nil {
 		return nil, onAbort(err, errors.NotFoundf("metrics manager"))
 	}
@@ -105,7 +105,7 @@ func (m *MetricsManager) updateMetricsManager(update bson.M) error {
 		Assert: txn.DocExists,
 		Update: update,
 	}}
-	err := m.st.runTransaction(ops)
+	err := m.st.db().RunTransaction(ops)
 	if err == txn.ErrAborted {
 		err = errors.NotFoundf("metrics manager")
 	}

--- a/state/migration_import.go
+++ b/state/migration_import.go
@@ -316,7 +316,7 @@ func (i *importer) modelUsers() error {
 			permission.Access(user.Access()))...,
 		)
 	}
-	if err := i.st.runTransaction(ops); err != nil {
+	if err := i.st.db().RunTransaction(ops); err != nil {
 		return errors.Trace(err)
 	}
 	// Now set their last connection times.
@@ -409,7 +409,7 @@ func (i *importer) machine(m description.Machine) error {
 	// 5. add any ops that we may need to add the opened ports information.
 	ops = append(ops, i.machinePortsOps(m)...)
 
-	if err := i.st.runTransaction(ops); err != nil {
+	if err := i.st.db().RunTransaction(ops); err != nil {
 		return errors.Trace(err)
 	}
 
@@ -761,7 +761,7 @@ func (i *importer) application(a description.Application) error {
 
 	ops = append(ops, i.appResourceOps(a)...)
 
-	if err := i.st.runTransaction(ops); err != nil {
+	if err := i.st.db().RunTransaction(ops); err != nil {
 		return errors.Trace(err)
 	}
 
@@ -926,7 +926,7 @@ func (i *importer) unit(s description.Application, u description.Unit) error {
 		ops = append(ops, createConstraintsOp(i.st, agentGlobalKey, i.constraints(cons)))
 	}
 
-	if err := i.st.runTransaction(ops); err != nil {
+	if err := i.st.db().RunTransaction(ops); err != nil {
 		i.logger.Debugf("failed ops: %#v", ops)
 		return errors.Trace(err)
 	}
@@ -1107,7 +1107,7 @@ func (i *importer) relation(rel description.Relation) error {
 		}
 	}
 
-	if err := i.st.runTransaction(ops); err != nil {
+	if err := i.st.db().RunTransaction(ops); err != nil {
 		return errors.Trace(err)
 	}
 
@@ -1177,7 +1177,7 @@ func (i *importer) linklayerdevices() error {
 		ops = append(ops, incrementDeviceNumChildrenOp(parentDocID))
 
 	}
-	if err := i.st.runTransaction(ops); err != nil {
+	if err := i.st.db().RunTransaction(ops); err != nil {
 		return errors.Trace(err)
 	}
 	i.logger.Debugf("importing linklayerdevices succeeded")
@@ -1227,7 +1227,7 @@ func (i *importer) addLinkLayerDevice(device description.LinkLayerDevice) error 
 		id := network.Id(providerID)
 		ops = append(ops, i.st.networkEntityGlobalKeyOp("linklayerdevice", id))
 	}
-	if err := i.st.runTransaction(ops); err != nil {
+	if err := i.st.db().RunTransaction(ops); err != nil {
 		return errors.Trace(err)
 	}
 	return nil
@@ -1278,7 +1278,7 @@ func (i *importer) addSubnet(args SubnetInfo) error {
 		}
 		return ops, nil
 	}
-	err := i.st.run(buildTxn)
+	err := i.st.db().Run(buildTxn)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -1332,7 +1332,7 @@ func (i *importer) addIPAddress(addr description.IPAddress) error {
 		id := network.Id(providerID)
 		ops = append(ops, i.st.networkEntityGlobalKeyOp("address", id))
 	}
-	if err := i.st.runTransaction(ops); err != nil {
+	if err := i.st.db().RunTransaction(ops); err != nil {
 		return errors.Trace(err)
 	}
 	return nil
@@ -1427,7 +1427,7 @@ func (i *importer) addAction(action description.Action) error {
 		Insert: notificationDoc,
 	}}
 
-	if err := i.st.runTransaction(ops); err != nil {
+	if err := i.st.db().RunTransaction(ops); err != nil {
 		return errors.Trace(err)
 	}
 	return nil
@@ -1568,7 +1568,7 @@ func (i *importer) addStorageInstance(storage description.Storage) error {
 	}
 	ops = append(ops, incRefOp)
 
-	if err := i.st.runTransaction(ops); err != nil {
+	if err := i.st.db().RunTransaction(ops); err != nil {
 		return errors.Trace(err)
 	}
 	return nil
@@ -1691,7 +1691,7 @@ func (i *importer) addVolume(volume description.Volume) error {
 		ops = append(ops, i.addVolumeAttachmentOp(tag.Id(), attachment))
 	}
 
-	if err := i.st.runTransaction(ops); err != nil {
+	if err := i.st.db().RunTransaction(ops); err != nil {
 		return errors.Trace(err)
 	}
 
@@ -1783,7 +1783,7 @@ func (i *importer) addFilesystem(filesystem description.Filesystem) error {
 		ops = append(ops, i.addFilesystemAttachmentOp(tag.Id(), attachment))
 	}
 
-	if err := i.st.runTransaction(ops); err != nil {
+	if err := i.st.db().RunTransaction(ops); err != nil {
 		return errors.Trace(err)
 	}
 

--- a/state/minimumunits.go
+++ b/state/minimumunits.go
@@ -61,7 +61,7 @@ func (a *Application) SetMinUnits(minUnits int) (err error) {
 		}
 		return setMinUnitsOps(app, minUnits), nil
 	}
-	return a.st.run(buildTxn)
+	return a.st.db().Run(buildTxn)
 }
 
 // setMinUnitsOps returns the operations required to set MinUnits on the
@@ -155,7 +155,7 @@ func (a *Application) EnsureMinUnits() (err error) {
 			return err
 		}
 		// Add missing unit.
-		switch err := a.st.runTransaction(ops); err {
+		switch err := a.st.db().RunTransaction(ops); err {
 		case nil:
 			// Assign the new unit.
 			unit, err := a.st.Unit(name)

--- a/state/model.go
+++ b/state/model.go
@@ -351,7 +351,7 @@ func (st *State) NewModel(args ModelArgs) (_ *Model, _ *State, err error) {
 		assertCloudCredentialOp,
 	}
 	ops := append(prereqOps, modelOps...)
-	err = newSt.runTransaction(ops)
+	err = newSt.db().RunTransaction(ops)
 	if err == txn.ErrAborted {
 
 		// We have a  unique key restriction on the "owner" and "name" fields,
@@ -554,7 +554,7 @@ func (m *Model) SetMigrationMode(mode MigrationMode) error {
 		Assert: txn.DocExists,
 		Update: bson.D{{"$set", bson.D{{"migration-mode", mode}}}},
 	}}
-	if err := st.runTransaction(ops); err != nil {
+	if err := st.db().RunTransaction(ops); err != nil {
 		return errors.Trace(err)
 	}
 	return m.Refresh()
@@ -653,7 +653,7 @@ func (m *Model) UpdateLatestToolsVersion(ver version.Number) error {
 		Id:     m.doc.UUID,
 		Update: bson.D{{"$set", bson.D{{"available-tools", v}}}},
 	}}
-	err := m.st.runTransaction(ops)
+	err := m.st.db().RunTransaction(ops)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -710,7 +710,7 @@ func (m *Model) SetSLA(level, owner string, credentials []byte) error {
 			Credentials: credentials,
 		}}}}},
 	}}
-	err = m.st.runTransaction(ops)
+	err = m.st.db().RunTransaction(ops)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -730,7 +730,7 @@ func (m *Model) SetMeterStatus(status, info string) error {
 			Info: info,
 		}}}}},
 	}}
-	err := m.st.runTransaction(ops)
+	err := m.st.db().RunTransaction(ops)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -864,7 +864,7 @@ func (m *Model) destroy(ensureNoHostedModels bool) (err error) {
 		return ops, nil
 	}
 
-	return st.run(buildTxn)
+	return st.db().Run(buildTxn)
 }
 
 // errModelNotAlive is a signal emitted from destroyOps to indicate

--- a/state/modeluser.go
+++ b/state/modeluser.go
@@ -35,7 +35,7 @@ func (st *State) setModelAccess(access permission.Access, userGlobalKey, modelUU
 		return errors.Trace(err)
 	}
 	op := updatePermissionOp(modelKey(modelUUID), userGlobalKey, access)
-	err := st.runTransactionFor(modelUUID, []txn.Op{op})
+	err := st.db().RunTransactionFor(modelUUID, []txn.Op{op})
 	if err == txn.ErrAborted {
 		return errors.NotFoundf("existing permissions")
 	}
@@ -160,7 +160,7 @@ func removeModelUserOps(modelUUID string, user names.UserTag) []txn.Op {
 // removeModelUser removes a user from the database.
 func (st *State) removeModelUser(user names.UserTag) error {
 	ops := removeModelUserOps(st.ModelUUID(), user)
-	err := st.runTransaction(ops)
+	err := st.db().RunTransaction(ops)
 	if err == txn.ErrAborted {
 		err = errors.NewNotFound(nil, fmt.Sprintf("model user %q does not exist", user.Id()))
 	}

--- a/state/mongo.go
+++ b/state/mongo.go
@@ -26,7 +26,7 @@ func (m *environMongo) GetCollection(name string) (mongo.Collection, func()) {
 
 // RunTransaction is part of the lease.Mongo interface.
 func (m *environMongo) RunTransaction(buildTxn jujutxn.TransactionSource) error {
-	return m.state.run(buildTxn)
+	return m.state.db().Run(buildTxn)
 }
 
 // Mongo Upgrade

--- a/state/open.go
+++ b/state/open.go
@@ -383,7 +383,7 @@ func Initialize(args InitializeParams) (_ *State, err error) {
 	}
 	ops = append(ops, modelOps...)
 
-	if err := st.runTransaction(ops); err != nil {
+	if err := st.db().RunTransaction(ops); err != nil {
 		return nil, errors.Trace(err)
 	}
 	controllerTag := names.NewControllerTag(args.ControllerConfig.ControllerUUID())

--- a/state/persistence.go
+++ b/state/persistence.go
@@ -75,7 +75,7 @@ func (sp statePersistence) All(collName string, query, docs interface{}) error {
 
 // Run runs the transaction produced by the provided factory function.
 func (sp statePersistence) Run(transactions jujutxn.TransactionSource) error {
-	if err := sp.st.run(transactions); err != nil {
+	if err := sp.st.db().Run(transactions); err != nil {
 		return errors.Trace(err)
 	}
 	return nil

--- a/state/ports.go
+++ b/state/ports.go
@@ -232,7 +232,7 @@ func (p *Ports) OpenPorts(portRange PortRange) (err error) {
 		return ops, nil
 	}
 	// Run the transaction using the state transaction runner.
-	if err = p.st.run(buildTxn); err != nil {
+	if err = p.st.db().Run(buildTxn); err != nil {
 		return errors.Trace(err)
 	}
 	// Mark object as created.
@@ -303,7 +303,7 @@ func (p *Ports) ClosePorts(portRange PortRange) (err error) {
 			return setPortsDocOps(p.st, ports.doc, assert, newPorts...), nil
 		}
 	}
-	if err = p.st.run(buildTxn); err != nil {
+	if err = p.st.db().Run(buildTxn); err != nil {
 		return errors.Trace(err)
 	}
 	p.doc.Ports = newPorts
@@ -365,7 +365,7 @@ func (p *Ports) Remove() error {
 		}
 		return ports.removeOps(), nil
 	}
-	return p.st.run(buildTxn)
+	return p.st.db().Run(buildTxn)
 }
 
 // OpenedPorts returns this machine ports document for the given subnetID.

--- a/state/reboot.go
+++ b/state/reboot.go
@@ -57,7 +57,7 @@ func (m *Machine) setFlag() error {
 			Insert: &rebootDoc{Id: m.Id()},
 		},
 	}
-	err := m.st.runTransaction(ops)
+	err := m.st.db().RunTransaction(ops)
 	if err == txn.ErrAborted {
 		if err := checkModelActive(m.st); err != nil {
 			return errors.Trace(err)
@@ -88,7 +88,7 @@ func (m *Machine) clearFlag() error {
 		return nil
 	}
 	ops := []txn.Op{removeRebootDocOp(m.st, m.Id())}
-	err = m.st.runTransaction(ops)
+	err = m.st.db().RunTransaction(ops)
 	if err != nil {
 		return errors.Errorf("failed to clear reboot flag: %v", err)
 	}

--- a/state/relation.go
+++ b/state/relation.go
@@ -133,7 +133,7 @@ func (r *Relation) Destroy() (err error) {
 		}
 		return ops, nil
 	}
-	return rel.st.run(buildTxn)
+	return rel.st.db().Run(buildTxn)
 }
 
 // destroyOps returns the operations necessary to destroy the relation, and

--- a/state/relationunit.go
+++ b/state/relationunit.go
@@ -143,7 +143,7 @@ func (ru *RelationUnit) EnterScope(settings map[string]interface{}) error {
 	}
 
 	// Now run the complete transaction, or figure out why we can't.
-	if err := ru.st.runTransaction(ops); err != txn.ErrAborted {
+	if err := ru.st.db().RunTransaction(ops); err != txn.ErrAborted {
 		return err
 	}
 	if count, err := relationScopes.FindId(ruKey).Count(); err != nil {
@@ -259,7 +259,7 @@ func (ru *RelationUnit) PrepareLeaveScope() error {
 		Id:     key,
 		Update: bson.D{{"$set", bson.D{{"departing", true}}}},
 	}}
-	return ru.st.runTransaction(ops)
+	return ru.st.db().RunTransaction(ops)
 }
 
 // LeaveScope signals that the unit has left its scope in the relation.
@@ -338,7 +338,7 @@ func (ru *RelationUnit) LeaveScope() error {
 		}
 		return ops, nil
 	}
-	if err := ru.st.run(buildTxn); err != nil {
+	if err := ru.st.db().Run(buildTxn); err != nil {
 		return errors.Annotatef(err, "cannot leave scope for %s", desc)
 	}
 	return nil

--- a/state/remoteapplication.go
+++ b/state/remoteapplication.go
@@ -279,7 +279,7 @@ func (s *RemoteApplication) Destroy() (err error) {
 		}
 		return nil, jujutxn.ErrTransientFailure
 	}
-	return s.st.run(buildTxn)
+	return s.st.db().Run(buildTxn)
 }
 
 // destroyOps returns the operations required to destroy the application. If it
@@ -504,7 +504,7 @@ func (s *RemoteApplication) AddEndpoints(eps []charm.Relation) error {
 		}
 		return ops, nil
 	}
-	if err := s.st.run(buildTxn); err != nil {
+	if err := s.st.db().Run(buildTxn); err != nil {
 		return errors.Trace(err)
 	}
 	return s.Refresh()
@@ -737,7 +737,7 @@ func (st *State) AddRemoteApplication(args AddRemoteApplicationParams) (_ *Remot
 		}
 		return ops, nil
 	}
-	if err = st.run(buildTxn); err != nil {
+	if err = st.db().Run(buildTxn); err != nil {
 		return nil, errors.Trace(err)
 	}
 	return app, nil

--- a/state/remoteentities.go
+++ b/state/remoteentities.go
@@ -95,7 +95,7 @@ func (r *RemoteEntities) ExportLocalEntity(entity names.Tag) (string, error) {
 		}}
 		return aa, nil
 	}
-	if err := r.st.run(ops); err != nil {
+	if err := r.st.db().Run(ops); err != nil {
 		// Where error is AlreadyExists, we still return the
 		// token so that a second api call is not required by
 		// the caller to get the token.
@@ -116,7 +116,7 @@ func (r *RemoteEntities) ImportRemoteEntity(
 		return errors.NotValidf("empty token for %v in model %v", entity.Id(), sourceModel.Id())
 	}
 	ops := r.importRemoteEntityOps(sourceModel, entity, token)
-	err := r.st.runTransaction(ops)
+	err := r.st.db().RunTransaction(ops)
 	if err == txn.ErrAborted {
 		return errors.AlreadyExistsf(
 			"reference to %s in %s",
@@ -170,7 +170,7 @@ func (r *RemoteEntities) RemoveRemoteEntity(
 		}
 		return ops, nil
 	}
-	return r.st.run(ops)
+	return r.st.db().Run(ops)
 }
 
 // removeRemoteEntityOp returns the txn.Op to remove the remote entity

--- a/state/restore.go
+++ b/state/restore.go
@@ -115,7 +115,7 @@ func (info *RestoreInfo) SetStatus(status RestoreStatus) error {
 		}
 		return ops, nil
 	}
-	if err := info.st.run(buildTxn); err != nil {
+	if err := info.st.db().Run(buildTxn); err != nil {
 		return errors.Annotatef(err, "setting status %q", status)
 	}
 	return nil

--- a/state/spaces.go
+++ b/state/spaces.go
@@ -111,7 +111,7 @@ func (st *State) AddSpace(name string, providerId network.Id, subnets []string, 
 		})
 	}
 
-	if err := st.runTransaction(ops); err == txn.ErrAborted {
+	if err := st.db().RunTransaction(ops); err == txn.ErrAborted {
 		if _, err := st.Space(name); err == nil {
 			return nil, errors.AlreadyExistsf("space %q", name)
 		}
@@ -185,7 +185,7 @@ func (s *Space) EnsureDead() (err error) {
 		Assert: isAliveDoc,
 	}}
 
-	txnErr := s.st.runTransaction(ops)
+	txnErr := s.st.db().RunTransaction(ops)
 	if txnErr == nil {
 		s.doc.Life = Dead
 		return nil
@@ -212,7 +212,7 @@ func (s *Space) Remove() (err error) {
 		ops = append(ops, s.st.networkEntityGlobalKeyRemoveOp("space", s.ProviderId()))
 	}
 
-	txnErr := s.st.runTransaction(ops)
+	txnErr := s.st.db().RunTransaction(ops)
 	if txnErr == nil {
 		return nil
 	}

--- a/state/sshhostkeys.go
+++ b/state/sshhostkeys.go
@@ -53,7 +53,7 @@ func (st *State) SetSSHHostKeys(tag names.MachineTag, keys SSHHostKeys) error {
 	doc := sshHostKeysDoc{
 		Keys: keys,
 	}
-	err := st.runTransaction([]txn.Op{
+	err := st.db().RunTransaction([]txn.Op{
 		{
 			C:      sshHostKeysC,
 			Id:     id,

--- a/state/state.go
+++ b/state/state.go
@@ -201,7 +201,7 @@ func (st *State) removeAllModelDocs(modelAssertion bson.D) error {
 			Id:     modelUUID,
 			Assert: modelAssertion,
 		}}, ops...)
-		err = st.runTransaction(ops)
+		err = st.db().RunTransaction(ops)
 		if err != nil {
 			return errors.Trace(err)
 		}
@@ -231,7 +231,7 @@ func (st *State) removeAllModelDocs(modelAssertion bson.D) error {
 	if err != nil {
 		return errors.Trace(err)
 	}
-	err = st.runTransaction(ops)
+	err = st.db().RunTransaction(ops)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -260,7 +260,7 @@ func (st *State) removeAllModelDocs(modelAssertion bson.D) error {
 	if !st.IsController() {
 		ops = append(ops, decHostedModelCountOp())
 	}
-	return st.runTransaction(ops)
+	return st.db().RunTransaction(ops)
 }
 
 // removeAllInCollectionRaw removes all the documents from the given
@@ -698,7 +698,7 @@ func (st *State) SetModelAgentVersion(newVersion version.Number) (err error) {
 		}
 		return ops, nil
 	}
-	if err = st.run(buildTxn); err == jujutxn.ErrExcessiveContention {
+	if err = st.db().Run(buildTxn); err == jujutxn.ErrExcessiveContention {
 		// Although there is a small chance of a race here, try to
 		// return a more helpful error message in the case of an
 		// active upgradeInfo document being in place.
@@ -1277,7 +1277,7 @@ func (st *State) AddApplication(args AddApplicationArgs) (_ *Application, err er
 	// At the last moment before inserting the application, prime status history.
 	probablyUpdateStatusHistory(st, app.globalKey(), statusDoc)
 
-	if err = st.run(buildTxn); err == nil {
+	if err = st.db().Run(buildTxn); err == nil {
 		// Refresh to pick the txn-revno.
 		if err = app.Refresh(); err != nil {
 			return nil, errors.Trace(err)
@@ -1800,7 +1800,7 @@ func (st *State) AddRelation(eps ...Endpoint) (r *Relation, err error) {
 		})
 		return ops, nil
 	}
-	if err = st.run(buildTxn); err == nil {
+	if err = st.db().Run(buildTxn); err == nil {
 		return &Relation{st, *doc}, nil
 	}
 	return nil, errors.Trace(err)
@@ -2084,7 +2084,7 @@ func (st *State) SetStateServingInfo(info StateServingInfo) error {
 		Id:     stateServingInfoKey,
 		Update: bson.D{{"$set", info}},
 	}}
-	if err := st.runTransaction(ops); err != nil {
+	if err := st.db().RunTransaction(ops); err != nil {
 		return errors.Annotatef(err, "cannot set state serving info")
 	}
 	return nil
@@ -2141,7 +2141,7 @@ func (st *State) setMongoSpaceName(mongoSpaceName network.SpaceName) error {
 		}},
 	}}
 
-	return st.runTransaction(ops)
+	return st.db().RunTransaction(ops)
 }
 
 func (st *State) setMongoSpaceState(mongoSpaceState MongoSpaceStates) error {
@@ -2151,7 +2151,7 @@ func (st *State) setMongoSpaceState(mongoSpaceState MongoSpaceStates) error {
 		Update: bson.D{{"$set", bson.D{{"mongo-space-state", mongoSpaceState}}}},
 	}}
 
-	return st.runTransaction(ops)
+	return st.db().RunTransaction(ops)
 }
 
 func (st *State) networkEntityGlobalKeyOp(globalKey string, providerId network.Id) txn.Op {

--- a/state/status.go
+++ b/state/status.go
@@ -120,7 +120,7 @@ func setStatus(st *State, params setStatusParams) (err error) {
 	if params.token != nil {
 		buildTxn = buildTxnWithLeadership(buildTxn, params.token)
 	}
-	err = st.run(buildTxn)
+	err = st.db().Run(buildTxn)
 	if cause := errors.Cause(err); cause == mgo.ErrNotFound {
 		return errors.NotFoundf(params.badge)
 	}

--- a/state/storage.go
+++ b/state/storage.go
@@ -293,7 +293,7 @@ func (st *State) DestroyStorageInstance(tag names.StorageTag) (err error) {
 			return nil, errors.Trace(err)
 		}
 	}
-	return st.run(buildTxn)
+	return st.db().Run(buildTxn)
 }
 
 func (st *State) destroyStorageInstanceOps(s *storageInstance) ([]txn.Op, error) {
@@ -880,7 +880,7 @@ func (st *State) AttachStorage(storage names.StorageTag, unit names.UnitTag) (er
 		ops = append(ops, u.assertCharmOps(ch)...)
 		return ops, nil
 	}
-	return st.run(buildTxn)
+	return st.db().Run(buildTxn)
 }
 
 // attachStorageOps returns txn.Ops to attach a storage instance to the
@@ -998,7 +998,7 @@ func (st *State) DestroyUnitStorageAttachments(unit names.UnitTag) (err error) {
 		}
 		return ops, nil
 	}
-	return st.run(buildTxn)
+	return st.db().Run(buildTxn)
 }
 
 // DetachStorage ensures that the storage attachment will be
@@ -1113,7 +1113,7 @@ func (st *State) DetachStorage(storage names.StorageTag, unit names.UnitTag) (er
 		}
 		return append(ops, detachStorageOps(storage, unit)...), nil
 	}
-	return st.run(buildTxn)
+	return st.db().Run(buildTxn)
 }
 
 func detachStorageOps(storage names.StorageTag, unit names.UnitTag) []txn.Op {
@@ -1189,7 +1189,7 @@ func (st *State) RemoveStorageAttachment(storage names.StorageTag, unit names.Un
 		}
 		return ops, nil
 	}
-	return st.run(buildTxn)
+	return st.db().Run(buildTxn)
 }
 
 func removeStorageAttachmentOps(
@@ -1805,7 +1805,7 @@ func (st *State) AddStorageForUnit(
 		}
 		return st.addStorageForUnitOps(u, name, cons)
 	}
-	if err := st.run(buildTxn); err != nil {
+	if err := st.db().Run(buildTxn); err != nil {
 		return errors.Annotatef(err, "adding %q storage to %s", name, u)
 	}
 	return nil

--- a/state/subnets.go
+++ b/state/subnets.go
@@ -97,7 +97,7 @@ func (s *Subnet) EnsureDead() (err error) {
 		Assert: isAliveDoc,
 	}}
 
-	txnErr := s.st.runTransaction(ops)
+	txnErr := s.st.db().RunTransaction(ops)
 	if txnErr == nil {
 		s.doc.Life = Dead
 		return nil
@@ -126,7 +126,7 @@ func (s *Subnet) Remove() (err error) {
 		ops = append(ops, op)
 	}
 
-	txnErr := s.st.runTransaction(ops)
+	txnErr := s.st.db().RunTransaction(ops)
 	if txnErr == nil {
 		return nil
 	}
@@ -230,7 +230,7 @@ func (st *State) AddSubnet(args SubnetInfo) (subnet *Subnet, err error) {
 		}
 		return ops, nil
 	}
-	err = st.run(buildTxn)
+	err = st.db().Run(buildTxn)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/state/txns.go
+++ b/state/txns.go
@@ -23,20 +23,8 @@ func (st *State) readTxnRevno(collectionName string, id interface{}) (int64, err
 	return result.TxnRevno, errors.Trace(err)
 }
 
-func (st *State) runTransaction(ops []txn.Op) error {
-	return st.database.RunTransaction(ops)
-}
-
-func (st *State) runTransactionFor(modelUUID string, ops []txn.Op) error {
-	return st.database.RunTransactionFor(modelUUID, ops)
-}
-
 func (st *State) runRawTransaction(ops []txn.Op) error {
 	return st.database.RunRawTransaction(ops)
-}
-
-func (st *State) run(transactions jujutxn.TransactionSource) error {
-	return st.database.Run(transactions)
 }
 
 // ResumeTransactions resumes all pending transactions.

--- a/state/undertaker.go
+++ b/state/undertaker.go
@@ -52,7 +52,7 @@ func (st *State) ProcessDyingModel() (err error) {
 		return ops, nil
 	}
 
-	if err = st.run(buildTxn); err != nil {
+	if err = st.db().Run(buildTxn); err != nil {
 		return errors.Trace(err)
 	}
 	return nil

--- a/state/upgrades.go
+++ b/state/upgrades.go
@@ -384,7 +384,7 @@ func UpdateLegacyLXDCloudCredentials(
 	if err != nil {
 		return errors.Trace(err)
 	}
-	return st.runTransaction(append(cloudOps, credOps...))
+	return st.db().RunTransaction(append(cloudOps, credOps...))
 }
 
 func updateLegacyLXDCloudsOps(st *State, endpoint string) ([]txn.Op, error) {
@@ -582,7 +582,7 @@ func addNonDetachableStorageMachineId(st *State) error {
 		})
 	}
 	if len(ops) > 0 {
-		return errors.Trace(st.runTransaction(ops))
+		return errors.Trace(st.db().RunTransaction(ops))
 	}
 	return nil
 }
@@ -831,7 +831,7 @@ func addStorageInstanceConstraints(st *State) error {
 		})
 	}
 	if len(ops) > 0 {
-		return errors.Trace(st.runTransaction(ops))
+		return errors.Trace(st.db().RunTransaction(ops))
 	}
 	return nil
 }

--- a/state/user.go
+++ b/state/user.go
@@ -108,7 +108,7 @@ func (st *State) addUser(name, displayName, password, creator string, secretKey 
 		defaultControllerPermission)
 	ops = append(ops, controllerUserOps...)
 
-	err := st.runTransaction(ops)
+	err := st.db().RunTransaction(ops)
 	if err == txn.ErrAborted {
 		err = errors.Errorf("username unavailable")
 	}
@@ -149,7 +149,7 @@ func (st *State) RemoveUser(tag names.UserTag) error {
 		}}
 		return ops, nil
 	}
-	return st.run(buildTxn)
+	return st.db().Run(buildTxn)
 }
 
 func createInitialUserOps(controllerUUID string, user names.UserTag, password, salt string, dateCreated time.Time) []txn.Op {
@@ -440,7 +440,7 @@ func (u *User) SetPasswordHash(pwHash string, pwSalt string) error {
 		Assert: txn.DocExists,
 		Update: update,
 	}}
-	if err := u.st.runTransaction(ops); err != nil {
+	if err := u.st.db().RunTransaction(ops); err != nil {
 		return errors.Annotatef(err, "cannot set password of user %q", u.Name())
 	}
 	u.doc.PasswordHash = pwHash
@@ -506,7 +506,7 @@ func (u *User) setDeactivated(value bool) error {
 		Assert: txn.DocExists,
 		Update: bson.D{{"$set", bson.D{{"deactivated", value}}}},
 	}}
-	if err := u.st.runTransaction(ops); err != nil {
+	if err := u.st.db().RunTransaction(ops); err != nil {
 		if err == txn.ErrAborted {
 			err = fmt.Errorf("user no longer exists")
 		}

--- a/state/useraccess.go
+++ b/state/useraccess.go
@@ -104,7 +104,7 @@ func (st *State) addUserAccess(spec UserAccessSpec, target userAccessTarget) (pe
 	default:
 		return permission.UserAccess{}, errors.NotSupportedf("user access global key %q", target.globalKey)
 	}
-	err = st.runTransactionFor(target.uuid, ops)
+	err = st.db().RunTransactionFor(target.uuid, ops)
 	if err == txn.ErrAborted {
 		err = errors.AlreadyExistsf("user access %q", spec.User.Id())
 	}

--- a/state/volume.go
+++ b/state/volume.go
@@ -501,7 +501,7 @@ func (st *State) DetachVolume(machine names.MachineTag, volume names.VolumeTag) 
 		}
 		return detachVolumeOps(machine, volume), nil
 	}
-	return st.run(buildTxn)
+	return st.db().Run(buildTxn)
 }
 
 func (st *State) volumeFilesystemAttachment(machine names.MachineTag, volume names.VolumeTag) (FilesystemAttachment, error) {
@@ -545,7 +545,7 @@ func (st *State) RemoveVolumeAttachment(machine names.MachineTag, volume names.V
 		}
 		return removeVolumeAttachmentOps(machine, v), nil
 	}
-	return st.run(buildTxn)
+	return st.db().Run(buildTxn)
 }
 
 func removeVolumeAttachmentOps(m names.MachineTag, v *volume) []txn.Op {
@@ -657,7 +657,7 @@ func (st *State) DestroyVolume(tag names.VolumeTag) (err error) {
 		}}}
 		return destroyVolumeOps(st, volume, hasNoStorageAssignment)
 	}
-	return st.run(buildTxn)
+	return st.db().Run(buildTxn)
 }
 
 func destroyVolumeOps(st *State, v *volume, extraAssert bson.D) ([]txn.Op, error) {
@@ -732,7 +732,7 @@ func (st *State) RemoveVolume(tag names.VolumeTag) (err error) {
 			removeStatusOp(st, volumeGlobalKey(tag.Id())),
 		}, nil
 	}
-	return st.run(buildTxn)
+	return st.db().Run(buildTxn)
 }
 
 // newVolumeName returns a unique volume name.
@@ -952,7 +952,7 @@ func (st *State) setVolumeAttachmentInfo(
 		)
 		return ops, nil
 	}
-	return st.run(buildTxn)
+	return st.db().Run(buildTxn)
 }
 
 func setVolumeAttachmentInfoOps(machine names.MachineTag, volume names.VolumeTag, info VolumeAttachmentInfo, unsetParams bool) []txn.Op {
@@ -1019,7 +1019,7 @@ func (st *State) SetVolumeInfo(tag names.VolumeTag, info VolumeInfo) (err error)
 		ops = append(ops, setVolumeInfoOps(tag, info, unsetParams)...)
 		return ops, nil
 	}
-	return st.run(buildTxn)
+	return st.db().Run(buildTxn)
 }
 
 func validateVolumeInfoChange(newInfo, oldInfo VolumeInfo) error {


### PR DESCRIPTION
This removes unnecessary indirection and makes it easier to refactor
code to take a modelBackend interface.

No functional change.