### PR TITLE
remotefirewaller API: Watch machine addresses

### DIFF
--- a/apiserver/remotefirewaller/ingressaddresswatcher.go
+++ b/apiserver/remotefirewaller/ingressaddresswatcher.go
@@ -134,7 +134,7 @@ func (w *IngressAddressWatcher) loop() error {
 				addressSet.Add(addr)
 			}
 			changed = false
-			addresses = addressSet.Values()
+			addresses = formatAsCIDR(addressSet.Values())
 			out = w.out
 		}
 
@@ -142,7 +142,7 @@ func (w *IngressAddressWatcher) loop() error {
 		case <-w.catacomb.Dying():
 			return w.catacomb.ErrDying()
 		// Send initial event or subsequent changes.
-		case out <- formatAsCIDR(addresses):
+		case out <- addresses:
 			sentInitial = true
 			out = nil
 		case c, ok := <-ruw.Changes():

--- a/apiserver/remotefirewaller/ingressaddresswatcher.go
+++ b/apiserver/remotefirewaller/ingressaddresswatcher.go
@@ -6,6 +6,7 @@ package remotefirewaller
 import (
 	"github.com/juju/errors"
 	"github.com/juju/utils/set"
+	"gopkg.in/juju/worker.v1"
 
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/network"
@@ -26,6 +27,18 @@ type IngressAddressWatcher struct {
 
 	out chan []string
 
+	// Channel for machineAddressWatchers to report individual machine
+	// updates.
+	addressChanges  chan string
+	addressWatchers map[string]*machineAddressWatcher
+
+	// A map of unit names by machine id.
+	machineToUnits map[string]set.Strings
+	// A map of machine id by unit name - this is needed because we
+	// might not be able to retrieve the machine name when a unit
+	// leaves scope if it's been completely removed by the time we look.
+	unitToMachine map[string]string
+
 	// A map of known unit addresses, keyed on unit name.
 	known map[string]string
 }
@@ -33,11 +46,15 @@ type IngressAddressWatcher struct {
 // NewIngressAddressWatcher creates an IngressAddressWatcher.
 func NewIngressAddressWatcher(backend State, rel Relation, appName string) (*IngressAddressWatcher, error) {
 	w := &IngressAddressWatcher{
-		backend: backend,
-		appName: appName,
-		rel:     rel,
-		known:   make(map[string]string),
-		out:     make(chan []string),
+		backend:         backend,
+		appName:         appName,
+		rel:             rel,
+		known:           make(map[string]string),
+		out:             make(chan []string),
+		addressChanges:  make(chan string),
+		addressWatchers: make(map[string]*machineAddressWatcher),
+		machineToUnits:  make(map[string]set.Strings),
+		unitToMachine:   make(map[string]string),
 	}
 	err := catacomb.Invoke(catacomb.Plan{
 		Site: &w.catacomb,
@@ -61,16 +78,21 @@ func (w *IngressAddressWatcher) initial() (set.Strings, error) {
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
-		if inScope {
-			addr, ok, err := w.unitAddress(u)
-			if err != nil {
-				return nil, errors.Trace(err)
-			}
-			if !ok {
-				continue
-			}
+		if !inScope {
+			continue
+		}
+
+		addr, ok, err := w.unitAddress(u)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		if ok {
 			result.Add(addr)
 		}
+		if err := w.trackUnit(u); err != nil {
+			return nil, errors.Trace(err)
+		}
+
 	}
 	return result, nil
 }
@@ -102,6 +124,7 @@ func (w *IngressAddressWatcher) loop() error {
 	}
 	out = w.out
 	for {
+		newAddresses := addresses
 		select {
 		case <-w.catacomb.Dying():
 			return w.catacomb.ErrDying()
@@ -116,19 +139,38 @@ func (w *IngressAddressWatcher) loop() error {
 			// A unit has entered or left scope.
 			// Get the new set of addresses resulting from that
 			// change, and if different to what we know, send the change.
-			merged, err := w.mergeAddresses(addresses, c)
+			newAddresses, err = w.mergeAddresses(addresses, c)
 			if err != nil {
 				return err
 			}
-			changed := !merged.Difference(addresses).IsEmpty() || !addresses.Difference(merged).IsEmpty()
-			if !sentInitial || changed {
-				addresses = merged
-				out = w.out
-			} else {
-				out = nil
+		case machineId, ok := <-w.addressChanges:
+			if !ok {
+				return errors.Errorf("address changes channel unexpectedly closed")
+			}
+			changed, err := w.machineAddressChanged(machineId)
+			if err != nil {
+				return errors.Trace(err)
+			}
+			if changed {
+				newAddresses = set.NewStrings()
+				for _, addr := range w.known {
+					newAddresses.Add(addr)
+				}
 			}
 		}
+
+		changed := areDifferent(newAddresses, addresses)
+		if !sentInitial || changed {
+			addresses = newAddresses
+			out = w.out
+		} else {
+			out = nil
+		}
 	}
+}
+
+func areDifferent(s1, s2 set.Strings) bool {
+	return !s1.Difference(s2).IsEmpty() || !s2.Difference(s1).IsEmpty()
 }
 
 func formatAsCIDR(addresses []string) []string {
@@ -168,7 +210,10 @@ func (w *IngressAddressWatcher) mergeAddresses(addresses set.Strings, c params.R
 			return result, err
 		}
 
-		// TODO - start watcher to pick up machine address changes
+		if err := w.trackUnit(u); err != nil {
+			return result, errors.Trace(err)
+		}
+
 		// We need to know whether to look at the public or cloud local address.
 		// For now, we'll use the public address and later if needed use a watcher
 		// parameter to look at the cloud local address.
@@ -183,6 +228,9 @@ func (w *IngressAddressWatcher) mergeAddresses(addresses set.Strings, c params.R
 		w.known[name] = addr
 	}
 	for _, name := range c.Departed {
+		if err := w.untrackUnit(name); err != nil {
+			return result, errors.Trace(err)
+		}
 		// If the unit is departing and we have seen its address,
 		// remove the address.
 		address := w.known[name]
@@ -201,6 +249,110 @@ func (w *IngressAddressWatcher) mergeAddresses(addresses set.Strings, c params.R
 		}
 	}
 	return result, nil
+}
+
+func (w *IngressAddressWatcher) trackUnit(unit Unit) error {
+	machine, err := w.assignedMachine(unit)
+	if errors.IsNotAssigned(err) {
+		logger.Errorf("unit %q entered scope without a machine assigned - addresses will not be tracked", unit)
+		return nil
+	}
+	if err != nil {
+		return errors.Trace(err)
+	}
+	if units, ok := w.machineToUnits[machine.Id()]; !ok {
+		w.machineToUnits[machine.Id()] = set.NewStrings(unit.Name())
+	} else {
+		units.Add(unit.Name())
+	}
+	if _, ok := w.addressWatchers[machine.Id()]; ok {
+		// We're already watching this machine.
+		return nil
+	}
+	addressWatcher, err := newMachineAddressWatcher(machine, w.addressChanges)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	err = w.catacomb.Add(addressWatcher)
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	w.addressWatchers[machine.Id()] = addressWatcher
+	w.unitToMachine[unit.Name()] = machine.Id()
+	return nil
+}
+
+func (w *IngressAddressWatcher) untrackUnit(unitName string) error {
+	machineId, ok := w.unitToMachine[unitName]
+	if !ok {
+		logger.Errorf("missing machine id for unit %q", unitName)
+		return nil
+	}
+	units, ok := w.machineToUnits[machineId]
+	if !ok {
+		// This shouldn't happen.
+		return errors.Errorf("missing unit-set for machine %q (hosting unit %q)", machineId, unitName)
+	}
+	units.Remove(unitName)
+	if units.Size() > 0 {
+		// No need to stop the watcher - there are still units on the
+		// machine.
+		return nil
+	}
+
+	// Clean up this machine's watcher and units entries.
+	watcher, ok := w.addressWatchers[machineId]
+	if !ok {
+		return errors.Errorf("missing watcher for machine %q (hosting unit %q)", machineId, unitName)
+	}
+	err := worker.Stop(watcher)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	delete(w.addressWatchers, machineId)
+	delete(w.machineToUnits, machineId)
+	delete(w.unitToMachine, unitName)
+	return nil
+}
+
+func (w *IngressAddressWatcher) assignedMachine(unit Unit) (Machine, error) {
+	machineId, err := unit.AssignedMachineId()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	machine, err := w.backend.Machine(machineId)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return machine, nil
+}
+
+func (w *IngressAddressWatcher) machineAddressChanged(machineId string) (bool, error) {
+	unitNames, ok := w.machineToUnits[machineId]
+	if !ok {
+		return false, errors.Errorf("missing unit-set for machine %q", machineId)
+	}
+	changed := false
+	for unitName := range unitNames {
+		unit, err := w.backend.Unit(unitName)
+		if errors.IsNotFound(err) {
+			continue
+		}
+		if err != nil {
+			return false, errors.Trace(err)
+		}
+		address, _, err := w.unitAddress(unit)
+		if err != nil {
+			return false, errors.Trace(err)
+		}
+		existingAddress := w.known[unitName]
+		if existingAddress != address {
+			w.known[unitName] = address
+			changed = true
+		}
+	}
+	return changed, nil
 }
 
 // Changes returns the event channel for this watcher.
@@ -229,4 +381,48 @@ func (w *IngressAddressWatcher) Stop() error {
 // has been running.
 func (w *IngressAddressWatcher) Err() error {
 	return w.catacomb.Err()
+}
+
+func newMachineAddressWatcher(machine Machine, dest chan<- string) (*machineAddressWatcher, error) {
+	w := &machineAddressWatcher{
+		machine: machine,
+		dest:    dest,
+	}
+	err := catacomb.Invoke(catacomb.Plan{
+		Site: &w.catacomb,
+		Work: w.loop,
+	})
+	return w, errors.Trace(err)
+}
+
+// machineAddressWatcher watches for machine address changes and
+// notifies the dest channel when it sees them. It isn't a watcher in
+// the strict sense since it doesn't have a Changes method.
+type machineAddressWatcher struct {
+	catacomb catacomb.Catacomb
+	machine  Machine
+	dest     chan<- string
+}
+
+func (w *machineAddressWatcher) loop() error {
+	aw := w.machine.WatchAddresses()
+	if err := w.catacomb.Add(aw); err != nil {
+		return errors.Trace(err)
+	}
+	for {
+		select {
+		case <-w.catacomb.Dying():
+			return w.catacomb.ErrDying()
+		case <-aw.Changes():
+			w.dest <- w.machine.Id()
+		}
+	}
+}
+
+func (w *machineAddressWatcher) Kill() {
+	w.catacomb.Kill(nil)
+}
+
+func (w *machineAddressWatcher) Wait() error {
+	return w.catacomb.Wait()
 }

--- a/apiserver/remotefirewaller/ingressaddresswatcher_test.go
+++ b/apiserver/remotefirewaller/ingressaddresswatcher_test.go
@@ -56,10 +56,12 @@ func (s *addressWatcherSuite) setupRelation(c *gc.C, addr string) *mockRelation 
 	s.st.relations["remote-db2:db django:db"] = rel
 	unit := newMockUnit("django/0")
 	unit.publicAddress = network.Address{Value: addr}
+	unit.machineId = "0"
 	s.st.units["django/0"] = unit
 	app := newMockApplication("django")
 	app.units = []*mockUnit{unit}
 	s.st.applications["django"] = app
+	s.st.machines["0"] = newMockMachine("0")
 	return rel
 }
 
@@ -112,7 +114,9 @@ func (s *addressWatcherSuite) TestTwoUnitsEntersScope(c *gc.C) {
 
 	unit := newMockUnit("django/1")
 	unit.publicAddress = network.Address{Value: "54.4.5.6"}
+	unit.machineId = "1"
 	s.st.units["django/1"] = unit
+	s.st.machines["1"] = newMockMachine("1")
 
 	// Initial event.
 	wc.AssertChange()
@@ -149,7 +153,9 @@ func (s *addressWatcherSuite) TestAnotherUnitsEntersScope(c *gc.C) {
 
 	unit := newMockUnit("django/1")
 	unit.publicAddress = network.Address{Value: "54.4.5.6"}
+	unit.machineId = "1"
 	s.st.units["django/1"] = unit
+	s.st.machines["1"] = newMockMachine("1")
 	rel.ruw.changes <- params.RelationUnitsChange{
 		Changed: map[string]params.UnitSettings{
 			"django/1": {},
@@ -240,7 +246,9 @@ func (s *addressWatcherSuite) TestUnitLeavesScope(c *gc.C) {
 
 	unit := newMockUnit("django/1")
 	unit.publicAddress = network.Address{Value: "54.4.5.6"}
+	unit.machineId = "1"
 	s.st.units["django/1"] = unit
+	s.st.machines["1"] = newMockMachine("1")
 
 	// Initial event.
 	wc.AssertChange()
@@ -272,6 +280,7 @@ func (s *addressWatcherSuite) TestTwoUnitsSameAddressOneLeaves(c *gc.C) {
 
 	unit := newMockUnit("django/1")
 	unit.publicAddress = network.Address{Value: "54.1.2.3"}
+	unit.machineId = "0"
 	s.st.units["django/1"] = unit
 
 	// Initial event.
@@ -300,5 +309,64 @@ func (s *addressWatcherSuite) TestTwoUnitsSameAddressOneLeaves(c *gc.C) {
 	}
 
 	wc.AssertChange()
+	wc.AssertNoChange()
+}
+
+func (s *addressWatcherSuite) TestSeesMachineAddressChanges(c *gc.C) {
+	rel := s.setupRelation(c, "2.3.4.5")
+	s.st.relations["remote-db2:db django:db"].inScope = set.NewStrings("django/0")
+	w, err := remotefirewaller.NewIngressAddressWatcher(s.st, rel, "django")
+	c.Assert(err, jc.ErrorIsNil)
+	defer statetesting.AssertStop(c, w)
+	wc := statetesting.NewStringsWatcherC(c, nopSyncStarter{}, w)
+
+	wc.AssertChange("2.3.4.5/32")
+	wc.AssertNoChange()
+
+	s.st.units["django/0"].publicAddress = network.Address{Value: "5.4.3.3"}
+	s.st.machines["0"].watcher.changes <- struct{}{}
+
+	wc.AssertChange("5.4.3.3/32")
+	wc.AssertNoChange()
+}
+
+func (s *addressWatcherSuite) TestHandlesMachineAddressChangesWithNoEffect(c *gc.C) {
+	rel := s.setupRelation(c, "2.3.4.5")
+	s.st.relations["remote-db2:db django:db"].inScope = set.NewStrings("django/0")
+	w, err := remotefirewaller.NewIngressAddressWatcher(s.st, rel, "django")
+	c.Assert(err, jc.ErrorIsNil)
+	defer statetesting.AssertStop(c, w)
+	wc := statetesting.NewStringsWatcherC(c, nopSyncStarter{}, w)
+
+	wc.AssertChange("2.3.4.5/32")
+	wc.AssertNoChange()
+
+	// Public address for the unit stays the same (maybe some other address changed).
+	s.st.machines["0"].watcher.changes <- struct{}{}
+
+	wc.AssertNoChange()
+}
+
+func (s *addressWatcherSuite) TestHandlesUnitGoneWhenMachineAddressChanges(c *gc.C) {
+	rel := s.setupRelation(c, "2.3.4.5")
+	unit := newMockUnit("django/1")
+	unit.publicAddress = network.Address{Value: "2.3.4.5"}
+	unit.machineId = "0"
+	s.st.units["django/1"] = unit
+
+	s.st.relations["remote-db2:db django:db"].inScope = set.NewStrings("django/0", "django/1")
+	w, err := remotefirewaller.NewIngressAddressWatcher(s.st, rel, "django")
+	c.Assert(err, jc.ErrorIsNil)
+	defer statetesting.AssertStop(c, w)
+	wc := statetesting.NewStringsWatcherC(c, nopSyncStarter{}, w)
+
+	wc.AssertChange("2.3.4.5/32")
+	wc.AssertNoChange()
+
+	delete(s.st.units, "django/1")
+	s.st.units["django/0"].publicAddress = network.Address{Value: "6.7.8.9"}
+	s.st.machines["0"].watcher.changes <- struct{}{}
+
+	wc.AssertChange("6.7.8.9/32")
 	wc.AssertNoChange()
 }

--- a/apiserver/remotefirewaller/mock_test.go
+++ b/apiserver/remotefirewaller/mock_test.go
@@ -281,7 +281,7 @@ func (u *mockUnit) AssignedMachineId() (string, error) {
 type mockMachine struct {
 	testing.Stub
 	id      string
-	watcher *mockAddressesWatcher
+	watcher *mockAddressWatcher
 }
 
 func newMockMachine(id string) *mockMachine {
@@ -296,23 +296,23 @@ func (m *mockMachine) Id() string {
 func (m *mockMachine) WatchAddresses() state.NotifyWatcher {
 	m.MethodCall(m, "WatchAddresses")
 	if m.watcher == nil {
-		m.watcher = newMockAddressesWatcher()
+		m.watcher = newMockAddressWatcher()
 	}
 	return m.watcher
 }
 
-type mockAddressesWatcher struct {
+type mockAddressWatcher struct {
 	mockWatcher
 	changes chan struct{}
 }
 
-func newMockAddressesWatcher() *mockAddressesWatcher {
-	w := &mockAddressesWatcher{changes: make(chan struct{}, 1)}
+func newMockAddressWatcher() *mockAddressWatcher {
+	w := &mockAddressWatcher{changes: make(chan struct{}, 1)}
 	go w.doneWhenDying()
 	return w
 }
 
-func (w *mockAddressesWatcher) Changes() <-chan struct{} {
+func (w *mockAddressWatcher) Changes() <-chan struct{} {
 	w.MethodCall(w, "Changes")
 	return w.changes
 }

--- a/apiserver/remotefirewaller/remotefirewaller_test.go
+++ b/apiserver/remotefirewaller/remotefirewaller_test.go
@@ -69,10 +69,14 @@ func (s *RemoteFirewallerSuite) TestWatchIngressAddressesForRelation(c *gc.C) {
 
 	unit := newMockUnit("django/0")
 	unit.publicAddress = network.NewScopedAddress("1.2.3.4", network.ScopePublic)
+	unit.machineId = "0"
 	s.st.units["django/0"] = unit
-	unit1 := newMockUnit("django/0")
+	unit1 := newMockUnit("django/1")
 	unit1.publicAddress = network.NewScopedAddress("4.3.2.1", network.ScopePublic)
+	unit1.machineId = "1"
 	s.st.units["django/1"] = unit1
+	s.st.machines["0"] = newMockMachine("0")
+	s.st.machines["1"] = newMockMachine("1")
 	app := newMockApplication("django")
 	app.units = []*mockUnit{unit, unit1}
 	s.st.applications["django"] = app
@@ -96,6 +100,8 @@ func (s *RemoteFirewallerSuite) TestWatchIngressAddressesForRelation(c *gc.C) {
 		{"KeyRelation", []interface{}{"remote-db2:db django:db"}},
 		{"Application", []interface{}{"django"}},
 		{"Application", []interface{}{"django"}},
+		{"Machine", []interface{}{"0"}},
+		{"Machine", []interface{}{"1"}},
 	})
 }
 

--- a/apiserver/remotefirewaller/state.go
+++ b/apiserver/remotefirewaller/state.go
@@ -25,6 +25,8 @@ type State interface {
 	Application(string) (Application, error)
 
 	Unit(string) (Unit, error)
+
+	Machine(string) (Machine, error)
 }
 
 type stateShim struct {
@@ -93,8 +95,18 @@ func (a applicationShim) AllUnits() (results []Unit, err error) {
 type Unit interface {
 	Name() string
 	PublicAddress() (network.Address, error)
+	AssignedMachineId() (string, error)
 }
 
 func (st stateShim) Unit(name string) (Unit, error) {
 	return st.State.Unit(name)
+}
+
+type Machine interface {
+	Id() string
+	WatchAddresses() state.NotifyWatcher
+}
+
+func (st stateShim) Machine(id string) (Machine, error) {
+	return st.State.Machine(id)
 }


### PR DESCRIPTION
## Description of change

The `IngressAddressWatcher` will now signal when a unit's address changes, as well as when units enter or leave the scope of the relation. This means that cross-model relations will still work when addresses change.

## QA steps

Smoke test CMR deployment. Then have a machine's public address change in the consuming model (I'm not sure how to do this). The offering model's firewall ingress rules should be updated to match the new public addresses of the consuming units.
