### PR TITLE
Add controller config to control log pruning

### DIFF
--- a/agent/agentbootstrap/bootstrap_test.go
+++ b/agent/agentbootstrap/bootstrap_test.go
@@ -222,6 +222,8 @@ LXC_BRIDGE="ignored"`[1:])
 		"state-port":              1234,
 		"api-port":                17777,
 		"set-numa-control-policy": false,
+		"max-logs-age":            "72h",
+		"max-logs-size":           "4G",
 	})
 
 	// Check that controller model configuration has been added, and

--- a/cmd/juju/backups/restore_test.go
+++ b/cmd/juju/backups/restore_test.go
@@ -236,6 +236,8 @@ func (s *restoreSuite) TestRestoreReboostrapWritesUpdatedControllerInfo(c *gc.C)
 			"state-port":              1234,
 			"api-port":                17777,
 			"set-numa-control-policy": false,
+			"max-logs-age":            "72h",
+			"max-logs-size":           "4G",
 		})
 		boostrapped = true
 		return nil

--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -985,6 +985,11 @@ func (a *MachineAgent) startStateWorkers(
 		return nil, errors.Trace(err)
 	}
 
+	controllerConfig, err := st.ControllerConfig()
+	if err != nil {
+		return nil, errors.Annotate(err, "cannot fetch the controller config")
+	}
+
 	for _, job := range m.Jobs() {
 		switch job {
 		case state.JobHostUnits:
@@ -1077,7 +1082,10 @@ func (a *MachineAgent) startStateWorkers(
 			})
 
 			a.startWorkerAfterUpgrade(singularRunner, "dblogpruner", func() (worker.Worker, error) {
-				return dblogpruner.New(st, dblogpruner.NewLogPruneParams()), nil
+				return dblogpruner.New(st, dblogpruner.NewLogPruneParams(
+					controllerConfig.MaxLogsAge(),
+					controllerConfig.MaxLogSizeMB(),
+				)), nil
 			})
 
 			a.startWorkerAfterUpgrade(singularRunner, "txnpruner", func() (worker.Worker, error) {

--- a/cmd/jujud/agent/machine_test.go
+++ b/cmd/jujud/agent/machine_test.go
@@ -437,7 +437,7 @@ func (s *MachineSuite) TestManageModelRunsPeergrouper(c *gc.C) {
 	started.assertTriggered(c, "peergrouperworker to start")
 }
 
-func (s *MachineSuite) TestManageModelRunsDbLogPrunerIfFeatureFlagEnabled(c *gc.C) {
+func (s *MachineSuite) TestManageModelRunsDbLogPruner(c *gc.C) {
 	m, _, _ := s.primeAgent(c, state.JobManageModel)
 	a := s.newAgent(c, m)
 	defer func() { c.Check(a.Stop(), jc.ErrorIsNil) }()

--- a/controller/config.go
+++ b/controller/config.go
@@ -4,10 +4,11 @@
 package controller
 
 import (
+	"fmt"
 	"net/url"
+	"time"
 
 	"github.com/juju/errors"
-	"github.com/juju/loggo"
 	"github.com/juju/schema"
 	"github.com/juju/utils"
 	utilscert "github.com/juju/utils/cert"
@@ -15,8 +16,6 @@ import (
 
 	"github.com/juju/juju/cert"
 )
-
-var logger = loggo.GetLogger("juju.controller")
 
 const (
 	// MongoProfLow represents the most conservative mongo memory profile.
@@ -73,6 +72,13 @@ const (
 	// detault
 	MongoMemoryProfile = "mongo-memory-profile"
 
+	// MaxLogsAge is the maximum age for log entries, ef "72h"
+	MaxLogsAge = "max-logs-age"
+
+	// MaxLogSize is the maximum size the log collection can grow to
+	// before it is pruned, eg "4M"
+	MaxLogSize = "max-logs-size"
+
 	// Attribute Defaults
 
 	// DefaultAuditingEnabled contains the default value for the
@@ -91,6 +97,13 @@ const (
 
 	// DefaultMongoMemoryProfile is the default profile used by mongo.
 	DefaultMongoMemoryProfile = MongoProfLow
+
+	// DefaultMaxLogsAgeDays is the maximum age in days of log entries.
+	DefaultMaxLogsAgeDays = 3
+
+	// DefaultMaxLogCollectionMB is the maximum size the log collection can
+	// grow to before being pruned.
+	DefaultMaxLogCollectionMB = 4 * 1024 // 4 GB
 )
 
 // ControllerOnlyConfigAttributes are attributes which are only relevant
@@ -107,6 +120,8 @@ var ControllerOnlyConfigAttributes = []string{
 	SetNUMAControlPolicyKey,
 	StatePort,
 	MongoMemoryProfile,
+	MaxLogSize,
+	MaxLogsAge,
 }
 
 // ControllerOnlyAttribute returns true if the specified attribute name
@@ -269,6 +284,21 @@ func (c Config) AllowModelAccess() bool {
 	return value
 }
 
+// MaxLogsAge is the maximum age of log entries before they are pruned.
+func (c Config) MaxLogsAge() time.Duration {
+	// Value has already been validated.
+	val, _ := time.ParseDuration(c.mustString(MaxLogsAge))
+	return val
+}
+
+// MaxLogSizeMB is the maximum size in MiB which the log collection
+// can grow to before being pruned.
+func (c Config) MaxLogSizeMB() int {
+	// Value has already been validated.
+	val, _ := utils.ParseSize(c.mustString(MaxLogSize))
+	return int(val)
+}
+
 // Validate ensures that config is a valid configuration.
 func Validate(c Config) error {
 	if v, ok := c[IdentityPublicKey].(string); ok {
@@ -310,6 +340,18 @@ func Validate(c Config) error {
 		}
 	}
 
+	if v, ok := c[MaxLogsAge].(string); ok {
+		if _, err := time.ParseDuration(v); err != nil {
+			return errors.Annotate(err, "invalid logs prune interval in configuration")
+		}
+	}
+
+	if v, ok := c[MaxLogSize].(string); ok {
+		if _, err := utils.ParseSize(v); err != nil {
+			return errors.Annotate(err, "invalid max logs size in configuration")
+		}
+	}
+
 	return nil
 }
 
@@ -330,6 +372,8 @@ var configChecker = schema.FieldMap(schema.Fields{
 	AutocertDNSNameKey:      schema.String(),
 	AllowModelAccessKey:     schema.Bool(),
 	MongoMemoryProfile:      schema.String(),
+	MaxLogsAge:              schema.String(),
+	MaxLogSize:              schema.String(),
 }, schema.Defaults{
 	APIPort:                 DefaultAPIPort,
 	AuditingEnabled:         DefaultAuditingEnabled,
@@ -341,4 +385,6 @@ var configChecker = schema.FieldMap(schema.Fields{
 	AutocertDNSNameKey:      schema.Omit,
 	AllowModelAccessKey:     schema.Omit,
 	MongoMemoryProfile:      schema.Omit,
+	MaxLogsAge:              fmt.Sprintf("%vh", DefaultMaxLogsAgeDays*24),
+	MaxLogSize:              fmt.Sprintf("%vM", DefaultMaxLogCollectionMB),
 })

--- a/controller/config_test.go
+++ b/controller/config_test.go
@@ -147,8 +147,8 @@ func (s *ConfigSuite) TestLogConfigValues(c *gc.C) {
 		testing.ControllerTag.Id(),
 		testing.CACert,
 		map[string]interface{}{
-			"max-logs-size":       "8G",
-			"max-logs-age": "96h",
+			"max-logs-size": "8G",
+			"max-logs-age":  "96h",
 		},
 	)
 	c.Assert(err, jc.ErrorIsNil)

--- a/controller/config_test.go
+++ b/controller/config_test.go
@@ -134,3 +134,24 @@ func (s *ConfigSuite) TestValidate(c *gc.C) {
 		}
 	}
 }
+
+func (s *ConfigSuite) TestLogConfigDefaults(c *gc.C) {
+	cfg, err := controller.NewConfig(testing.ControllerTag.Id(), testing.CACert, nil)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(cfg.MaxLogsAge(), gc.Equals, 72*time.Hour)
+	c.Assert(cfg.MaxLogSizeMB(), gc.Equals, 4096)
+}
+
+func (s *ConfigSuite) TestLogConfigValues(c *gc.C) {
+	cfg, err := controller.NewConfig(
+		testing.ControllerTag.Id(),
+		testing.CACert,
+		map[string]interface{}{
+			"max-logs-size":       "8G",
+			"max-logs-age": "96h",
+		},
+	)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(cfg.MaxLogsAge(), gc.Equals, 96*time.Hour)
+	c.Assert(cfg.MaxLogSizeMB(), gc.Equals, 8192)
+}

--- a/state/upgrades_test.go
+++ b/state/upgrades_test.go
@@ -922,3 +922,56 @@ func (s *upgradesSuite) TestRemoveNilValueApplicationSettings(c *gc.C) {
 		expectUpgradedData{settingsColl, expectedSettings},
 	)
 }
+
+func (s *upgradesSuite) TestAddControllerLogPruneSettingsKeepExisting(c *gc.C) {
+	settingsColl, settingsCloser := s.state.getRawCollection(controllersC)
+	defer settingsCloser()
+	_, err := settingsColl.RemoveAll(nil)
+	c.Assert(err, jc.ErrorIsNil)
+	err = settingsColl.Insert(bson.M{
+		"_id": "controllerSettings",
+		"settings": bson.M{
+			"max-logs-age":  "96h",
+			"max-logs-size": "5G",
+		},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	expectedSettings := []bson.M{
+		{
+			"_id": "controllerSettings",
+			"settings": bson.M{
+				"max-logs-age":  "96h",
+				"max-logs-size": "5G",
+			},
+		}}
+
+	s.assertUpgradedData(c, AddControllerLogPruneSettings,
+		expectUpgradedData{settingsColl, expectedSettings},
+	)
+}
+
+func (s *upgradesSuite) TestAddControllerLogPruneSettings(c *gc.C) {
+	settingsColl, settingsCloser := s.state.getRawCollection(controllersC)
+	defer settingsCloser()
+	_, err := settingsColl.RemoveAll(nil)
+	c.Assert(err, jc.ErrorIsNil)
+	err = settingsColl.Insert(bson.M{
+		"_id":      "controllerSettings",
+		"settings": bson.M{},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	expectedSettings := []bson.M{
+		{
+			"_id": "controllerSettings",
+			"settings": bson.M{
+				"max-logs-age":  "72h",
+				"max-logs-size": "4096M",
+			},
+		}}
+
+	s.assertUpgradedData(c, AddControllerLogPruneSettings,
+		expectUpgradedData{settingsColl, expectedSettings},
+	)
+}

--- a/testing/environ.go
+++ b/testing/environ.go
@@ -47,6 +47,8 @@ func FakeControllerConfig() controller.Config {
 		"state-port":              1234,
 		"api-port":                17777,
 		"set-numa-control-policy": false,
+		"max-logs-age":            "72h",
+		"max-logs-size":           "4G",
 	}
 }
 

--- a/upgrades/backend.go
+++ b/upgrades/backend.go
@@ -27,6 +27,7 @@ type StateBackend interface {
 	UpgradeNoProxyDefaults() error
 	AddNonDetachableStorageMachineId() error
 	RemoveNilValueApplicationSettings() error
+	AddControllerLogPruneSettings() error
 }
 
 // Model is an interface providing access to the details of a model within the
@@ -95,6 +96,10 @@ func (s stateBackend) AddNonDetachableStorageMachineId() error {
 
 func (s stateBackend) RemoveNilValueApplicationSettings() error {
 	return state.RemoveNilValueApplicationSettings(s.st)
+}
+
+func (s stateBackend) AddControllerLogPruneSettings() error {
+	return state.AddControllerLogPruneSettings(s.st)
 }
 
 type modelShim struct {

--- a/upgrades/steps_22.go
+++ b/upgrades/steps_22.go
@@ -25,6 +25,13 @@ func stateStepsFor22() []Step {
 				return context.State().RemoveNilValueApplicationSettings()
 			},
 		},
+		&upgradeStep{
+			description: "add controller log pruning config settings",
+			targets:     []Target{DatabaseMaster},
+			run: func(context Context) error {
+				return context.State().AddControllerLogPruneSettings()
+			},
+		},
 	}
 }
 

--- a/upgrades/steps_22_test.go
+++ b/upgrades/steps_22_test.go
@@ -53,3 +53,9 @@ func (s *steps22Suite) TestMeterStatusFile(c *gc.C) {
 	check()
 	check() // Check OK when file not present.
 }
+
+func (s *steps22Suite) TestAddControllerLogPruneSettings(c *gc.C) {
+	step := findStateStep(c, v220, "add controller log pruning config settings")
+	// Logic for step itself is tested in state package.
+	c.Assert(step.Targets(), jc.DeepEquals, []upgrades.Target{upgrades.DatabaseMaster})
+}

--- a/worker/dblogpruner/worker.go
+++ b/worker/dblogpruner/worker.go
@@ -21,16 +21,14 @@ type LogPruneParams struct {
 	PruneInterval   time.Duration
 }
 
-const DefaultMaxLogAge = 3 * 24 * time.Hour // 3 days
-const DefaultMaxCollectionMB = 4 * 1024     // 4 GB
 const DefaultPruneInterval = 5 * time.Minute
 
 // NewLogPruneParams returns a LogPruneParams initialised with default
 // values.
-func NewLogPruneParams() *LogPruneParams {
+func NewLogPruneParams(maxLogAge time.Duration, maxCollectionMB int) *LogPruneParams {
 	return &LogPruneParams{
-		MaxLogAge:       DefaultMaxLogAge,
-		MaxCollectionMB: DefaultMaxCollectionMB,
+		MaxLogAge:       maxLogAge,
+		MaxCollectionMB: maxCollectionMB,
 		PruneInterval:   DefaultPruneInterval,
 	}
 }


### PR DESCRIPTION
## Description of change

Add 2 controller config attributes to control log pruning behaviour:

max-logs-size
specified as a parsable string eg "400M" or "5G"
the max size the log collection is allowed to grow to

max-logs-age
specified as a time duration eg 72h
the maximum age of log entries before they are pruned

## QA steps

Add a cloud with the log config entries specified to be quite small.
Bootstrap
Check controller config is correctly set
Check that the pruning occurs as expected for the configured age/size
## Documentation changes

Documentation needs to change to describe the new controller config items.

## Bug reference

http://pad.lv/1566545
