### PR TITLE
apiserver/client: Fixed capitalisation in meter status message

### DIFF
--- a/apiserver/client/status.go
+++ b/apiserver/client/status.go
@@ -350,7 +350,7 @@ func (c *Client) modelStatus() (params.ModelStatusInfo, error) {
 	}
 	ms := m.MeterStatus()
 	if isColorStatus(ms.Code) {
-		info.MeterStatus = params.MeterStatus{Color: ms.Code.String(), Message: ms.Info}
+		info.MeterStatus = params.MeterStatus{Color: strings.ToLower(ms.Code.String()), Message: ms.Info}
 	}
 
 	return info, nil

--- a/apiserver/client/status_test.go
+++ b/apiserver/client/status_test.go
@@ -135,6 +135,18 @@ var testUnits = []struct {
 }, {},
 }
 
+func (s *statusUnitTestSuite) TestModelMeterStatus(c *gc.C) {
+	s.State.SetModelMeterStatus("RED", "thing")
+
+	client := s.APIState.Client()
+	status, err := client.Status(nil)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(status, gc.NotNil)
+	modelMeterStatus := status.Model.MeterStatus
+	c.Assert(modelMeterStatus.Color, gc.Equals, "red")
+	c.Assert(modelMeterStatus.Message, gc.Equals, "thing")
+}
+
 func (s *statusUnitTestSuite) TestMeterStatus(c *gc.C) {
 	meteredCharm := s.Factory.MakeCharm(c, &factory.CharmParams{Name: "metered", URL: "cs:quantal/metered"})
 	service := s.Factory.MakeApplication(c, &factory.ApplicationParams{Charm: meteredCharm})

--- a/cmd/juju/romulus/allocate/allocate.go
+++ b/cmd/juju/romulus/allocate/allocate.go
@@ -44,7 +44,7 @@ Updates an existing allocation for a model.
 
 Examples:
     # Sets the allocation for the current model to 10.
-    juju update-allocation 10
+    juju allocation 10
 `
 
 // Info implements cmd.Command.Info.

--- a/cmd/juju/status/output_tabular.go
+++ b/cmd/juju/status/output_tabular.go
@@ -229,7 +229,7 @@ func FormatTabular(writer io.Writer, forceColor bool, value interface{}) error {
 	}
 
 	if metering {
-		outputHeaders("Meter", "Status", "Message")
+		outputHeaders("Entity", "Meter status", "Message")
 		if fs.Model.MeterStatus != nil {
 			w.Print("model")
 			outputColor := fromMeterStatusColor(fs.Model.MeterStatus.Color)

--- a/cmd/juju/status/status_test.go
+++ b/cmd/juju/status/status_test.go
@@ -2876,7 +2876,7 @@ var statusTests = []testCase{
 						"since":   "01 Apr 15 01:23+10:00",
 					},
 					"meter-status": M{
-						"color":   "RED",
+						"color":   "red",
 						"message": "status message",
 					},
 					"sla": "unsupported",
@@ -4209,9 +4209,9 @@ func (s *StatusSuite) TestFormatTabularMetering(c *gc.C) {
 		"foo/0                                                   \n"+
 		"foo/1                                                   \n"+
 		"\n"+
-		"Meter  Status   Message\n"+
-		"foo/0  strange  warning: stable strangelets  \n"+
-		"foo/1  up       things are looking up        \n"+
+		"Entity  Meter status  Message\n"+
+		"foo/0   strange       warning: stable strangelets  \n"+
+		"foo/1   up            things are looking up        \n"+
 		"\n"+
 		"Machine  State  DNS  Inst id  Series  AZ  Message\n")
 }


### PR DESCRIPTION
## Description of change
This branch contains 2 cosmetic improvements for meter status in juju status:

1. juju status was displaying inconsistent capitlisation for model and unit meter status.
2. the header meter status header had 3 components: [Meter,Status,Message]. This was wrong. The output header now has the following 3 components: [Entity, Meter Status, Message]
## QA steps

```
juju bootstrap
juju sla essential
juju status
confirm new header and meter status shows "green" rather than "GREEN"
```
## Documentation changes

Any docs referencing the old format need to be updated

## Bug reference

n/a