### PR TITLE
Add --no-switch to juju bootstrap and add-model

### DIFF
--- a/cmd/juju/commands/bootstrap_test.go
+++ b/cmd/juju/commands/bootstrap_test.go
@@ -512,6 +512,15 @@ func (s *BootstrapSuite) TestBootstrapSetsCurrentModel(c *gc.C) {
 	c.Assert(modelName, gc.Equals, "admin/default")
 }
 
+func (s *BootstrapSuite) TestNoSwitch(c *gc.C) {
+	s.setupAutoUploadTest(c, "1.8.3", "raring")
+
+	_, err := coretesting.RunCommand(c, s.newBootstrapCommand(), "dummy", "devcontroller", "--no-switch")
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Assert(s.store.CurrentControllerName, gc.Equals, "")
+}
+
 func (s *BootstrapSuite) TestBootstrapSetsControllerDetails(c *gc.C) {
 	s.setupAutoUploadTest(c, "1.8.3", "raring")
 

--- a/cmd/juju/commands/bootstrap_test.go
+++ b/cmd/juju/commands/bootstrap_test.go
@@ -515,7 +515,7 @@ func (s *BootstrapSuite) TestBootstrapSetsCurrentModel(c *gc.C) {
 func (s *BootstrapSuite) TestNoSwitch(c *gc.C) {
 	s.setupAutoUploadTest(c, "1.8.3", "raring")
 
-	_, err := coretesting.RunCommand(c, s.newBootstrapCommand(), "dummy", "devcontroller", "--no-switch")
+	_, err := cmdtesting.RunCommand(c, s.newBootstrapCommand(), "dummy", "devcontroller", "--no-switch")
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Assert(s.store.CurrentControllerName, gc.Equals, "")

--- a/cmd/juju/controller/addmodel.go
+++ b/cmd/juju/controller/addmodel.go
@@ -54,6 +54,7 @@ type addModelCommand struct {
 	CredentialName string
 	CloudRegion    string
 	Config         common.ConfigFlag
+	noSwitch       bool
 }
 
 const addModelHelpDoc = `
@@ -115,6 +116,8 @@ func (c *addModelCommand) SetFlags(f *gnuflag.FlagSet) {
 	f.StringVar(&c.Owner, "owner", "", "The owner of the new model if not the current user")
 	f.StringVar(&c.CredentialName, "credential", "", "Credential used to add the model")
 	f.Var(&c.Config, "config", "Path to YAML model configuration file or individual options (--config config.yaml [--config key=value ...])")
+	f.BoolVar(&c.noSwitch, "S", false, "Do not switch to the newly created controller")
+	f.BoolVar(&c.noSwitch, "no-switch", false, "")
 }
 
 func (c *addModelCommand) Init(args []string) error {
@@ -234,8 +237,10 @@ func (c *addModelCommand) Run(ctx *cmd.Context) error {
 		}); err != nil {
 			return errors.Trace(err)
 		}
-		if err := store.SetCurrentModel(controllerName, c.Name); err != nil {
-			return errors.Trace(err)
+		if !c.noSwitch {
+			if err := store.SetCurrentModel(controllerName, c.Name); err != nil {
+				return errors.Trace(err)
+			}
 		}
 	}
 


### PR DESCRIPTION
## Description of change

When performing operations in a script or in parallel the automatic switching to new controllers and models can lead to surprises and unwanted actions. `juju bootstrap` and `juju add-model` now take a `-S` / `--no-switch` flag to suppress this behaviour.

## QA steps

```
# bootstrap with --no-switch works but doesn't select new controller
$ juju bootstrap dev devx --no-switch
Creating Juju controller "devx" on dev
...
Initial model "default" added.
$ juju switch
dev:admin/k3

# conventional bootstrap works as before
$ juju bootstrap dev devy            
Creating Juju controller "devy" on dev
...
Initial model "default" added.
$ juju switch
devy:admin/default

# add-model with --no-switch works but doesn't select the new model
$ juju add-model --no-switch frog
Using credential 'localhost' cached in controller
Added 'frog' model with credential 'localhost' for user 'admin'
$ juju switch
devy:admin/default

# conventional add-model works as before
$ juju add-model dog
Using credential 'localhost' cached in controller
Added 'dog' model with credential 'localhost' for user 'admin'
$ juju switch
devy:admin/dog
```

## Documentation changes

Perhaps worth mentioning but this is fairly minor.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1618234
