### PR TITLE
Update romulus commands with proper wrapping.

### DIFF
--- a/cmd/juju/romulus/agree/agree.go
+++ b/cmd/juju/romulus/agree/agree.go
@@ -48,7 +48,7 @@ Examples:
 // NewAgreeCommand returns a new command that can be
 // used to create user agreements.
 func NewAgreeCommand() cmd.Command {
-	return &agreeCommand{}
+	return modelcmd.WrapBase(&agreeCommand{})
 }
 
 type term struct {
@@ -102,7 +102,7 @@ func (c *agreeCommand) Init(args []string) error {
 	if len(c.terms) == 0 {
 		return errors.New("must specify a valid term revision")
 	}
-	return nil
+	return c.JujuCommandBase.Init([]string{})
 }
 
 // Run implements Command.Run.

--- a/cmd/juju/romulus/allocate/allocate.go
+++ b/cmd/juju/romulus/allocate/allocate.go
@@ -16,18 +16,18 @@ import (
 	"github.com/juju/juju/cmd/modelcmd"
 )
 
-type updateAllocationCommand struct {
+type allocateCommand struct {
 	modelcmd.ModelCommandBase
 	api   apiClient
 	Value string
 }
 
-// NewUpdateAllocationCommand returns a new updateAllocationCommand.
-func NewUpdateAllocationCommand() modelcmd.ModelCommand {
-	return &updateAllocationCommand{}
+// NewAllocateCommand returns a new allocateCommand.
+func NewAllocateCommand() cmd.Command {
+	return modelcmd.Wrap(&allocateCommand{})
 }
 
-func (c *updateAllocationCommand) newAPIClient(bakery *httpbakery.Client) (apiClient, error) {
+func (c *allocateCommand) newAPIClient(bakery *httpbakery.Client) (apiClient, error) {
 	if c.api != nil {
 		return c.api, nil
 	}
@@ -44,11 +44,11 @@ Updates an existing allocation for a model.
 
 Examples:
     # Sets the allocation for the current model to 10.
-    juju allocation 10
+    juju allocate 10
 `
 
 // Info implements cmd.Command.Info.
-func (c *updateAllocationCommand) Info() *cmd.Info {
+func (c *allocateCommand) Info() *cmd.Info {
 	return &cmd.Info{
 		Name:    "allocate",
 		Args:    "<value>",
@@ -58,7 +58,7 @@ func (c *updateAllocationCommand) Info() *cmd.Info {
 }
 
 // Init implements cmd.Command.Init.
-func (c *updateAllocationCommand) Init(args []string) error {
+func (c *allocateCommand) Init(args []string) error {
 	if len(args) < 1 {
 		return errors.New("value required")
 	}
@@ -66,10 +66,11 @@ func (c *updateAllocationCommand) Init(args []string) error {
 	if _, err := strconv.ParseInt(c.Value, 10, 32); err != nil {
 		return errors.New("value needs to be a whole number")
 	}
-	return cmd.CheckEmpty(args[1:])
+
+	return c.ModelCommandBase.Init(args[1:])
 }
 
-func (c *updateAllocationCommand) modelUUID() (string, error) {
+func (c *allocateCommand) modelUUID() (string, error) {
 	model, err := c.ClientStore().ModelByName(c.ControllerName(), c.ModelName())
 	if err != nil {
 		return "", errors.Trace(err)
@@ -78,7 +79,7 @@ func (c *updateAllocationCommand) modelUUID() (string, error) {
 }
 
 // Run implements cmd.Command.Run and contains most of the setbudget logic.
-func (c *updateAllocationCommand) Run(ctx *cmd.Context) error {
+func (c *allocateCommand) Run(ctx *cmd.Context) error {
 	modelUUID, err := c.modelUUID()
 	if err != nil {
 		return errors.Annotate(err, "failed to get model uuid")

--- a/cmd/juju/romulus/allocate/allocate_test.go
+++ b/cmd/juju/romulus/allocate/allocate_test.go
@@ -16,16 +16,16 @@ import (
 	coretesting "github.com/juju/juju/testing"
 )
 
-var _ = gc.Suite(&updateAllocationSuite{})
+var _ = gc.Suite(&allocateSuite{})
 
-type updateAllocationSuite struct {
+type allocateSuite struct {
 	coretesting.FakeJujuXDGDataHomeSuite
 	stub    *testing.Stub
 	mockAPI *mockapi
 	store   jujuclient.ClientStore
 }
 
-func (s *updateAllocationSuite) SetUpTest(c *gc.C) {
+func (s *allocateSuite) SetUpTest(c *gc.C) {
 	s.FakeJujuXDGDataHomeSuite.SetUpTest(c)
 	s.store = &jujuclient.MemStore{
 		Controllers: map[string]jujuclient.ControllerDetails{
@@ -49,14 +49,14 @@ func (s *updateAllocationSuite) SetUpTest(c *gc.C) {
 	s.mockAPI = newMockAPI(s.stub)
 }
 
-func (s *updateAllocationSuite) run(c *gc.C, args ...string) (*cmd.Context, error) {
-	updateAlloc := allocate.NewUpdateAllocateCommandForTest(s.mockAPI, s.store)
+func (s *allocateSuite) run(c *gc.C, args ...string) (*cmd.Context, error) {
+	updateAlloc := allocate.NewAllocateCommandForTest(s.mockAPI, s.store)
 	a := []string{"-m", "controller:model"}
 	a = append(a, args...)
 	return cmdtesting.RunCommand(c, updateAlloc, a...)
 }
 
-func (s *updateAllocationSuite) TestUpdateAllocation(c *gc.C) {
+func (s *allocateSuite) TestUpdateAllocation(c *gc.C) {
 	s.mockAPI.resp = "allocation set to 5"
 	ctx, err := s.run(c, "5")
 	c.Assert(err, jc.ErrorIsNil)
@@ -64,14 +64,14 @@ func (s *updateAllocationSuite) TestUpdateAllocation(c *gc.C) {
 	s.mockAPI.CheckCall(c, 0, "UpdateAllocation", "model-uuid", "5")
 }
 
-func (s *updateAllocationSuite) TestUpdateAllocationAPIError(c *gc.C) {
+func (s *allocateSuite) TestUpdateAllocationAPIError(c *gc.C) {
 	s.stub.SetErrors(errors.New("something failed"))
 	_, err := s.run(c, "5")
 	c.Assert(err, gc.ErrorMatches, "failed to update the allocation: something failed")
 	s.mockAPI.CheckCall(c, 0, "UpdateAllocation", "model-uuid", "5")
 }
 
-func (s *updateAllocationSuite) TestUpdateAllocationErrors(c *gc.C) {
+func (s *allocateSuite) TestUpdateAllocationErrors(c *gc.C) {
 	tests := []struct {
 		about         string
 		args          []string

--- a/cmd/juju/romulus/allocate/export_test.go
+++ b/cmd/juju/romulus/allocate/export_test.go
@@ -10,8 +10,8 @@ import (
 	"github.com/juju/juju/jujuclient"
 )
 
-func NewUpdateAllocateCommandForTest(api apiClient, store jujuclient.ClientStore) cmd.Command {
-	c := &updateAllocationCommand{api: api}
+func NewAllocateCommandForTest(api apiClient, store jujuclient.ClientStore) cmd.Command {
+	c := &allocateCommand{api: api}
 	c.SetClientStore(store)
 	return modelcmd.Wrap(c)
 }

--- a/cmd/juju/romulus/commands/commands.go
+++ b/cmd/juju/romulus/commands/commands.go
@@ -17,7 +17,6 @@ import (
 	"github.com/juju/juju/cmd/juju/romulus/setplan"
 	"github.com/juju/juju/cmd/juju/romulus/showbudget"
 	"github.com/juju/juju/cmd/juju/romulus/sla"
-	"github.com/juju/juju/cmd/modelcmd"
 )
 
 type commandRegister interface {
@@ -27,23 +26,14 @@ type commandRegister interface {
 // RegisterAll registers all romulus commands with the
 // provided command registry.
 func RegisterAll(r commandRegister) {
-	register := func(c cmd.Command) {
-		switch c := c.(type) {
-		case modelcmd.CommandBase:
-			r.Register(modelcmd.WrapBase(c))
-		default:
-			r.Register(c)
-		}
-
-	}
-	register(agree.NewAgreeCommand())
-	register(listagreements.NewListAgreementsCommand())
-	register(allocate.NewUpdateAllocationCommand())
-	register(listbudgets.NewListBudgetsCommand())
-	register(createbudget.NewCreateBudgetCommand())
-	register(listplans.NewListPlansCommand())
-	register(setbudget.NewSetBudgetCommand())
-	register(setplan.NewSetPlanCommand())
-	register(showbudget.NewShowBudgetCommand())
-	register(sla.NewSLACommand())
+	r.Register(agree.NewAgreeCommand())
+	r.Register(listagreements.NewListAgreementsCommand())
+	r.Register(allocate.NewAllocateCommand())
+	r.Register(listbudgets.NewListBudgetsCommand())
+	r.Register(createbudget.NewCreateBudgetCommand())
+	r.Register(listplans.NewListPlansCommand())
+	r.Register(setbudget.NewSetBudgetCommand())
+	r.Register(setplan.NewSetPlanCommand())
+	r.Register(showbudget.NewShowBudgetCommand())
+	r.Register(sla.NewSLACommand())
 }

--- a/cmd/juju/romulus/createbudget/createbudget.go
+++ b/cmd/juju/romulus/createbudget/createbudget.go
@@ -23,7 +23,7 @@ type createBudgetCommand struct {
 
 // NewCreateBudgetCommand returns a new createBudgetCommand
 func NewCreateBudgetCommand() cmd.Command {
-	return &createBudgetCommand{}
+	return modelcmd.WrapBase(&createBudgetCommand{})
 }
 
 const doc = `
@@ -52,7 +52,7 @@ func (c *createBudgetCommand) Init(args []string) error {
 	if _, err := strconv.ParseInt(c.Value, 10, 32); err != nil {
 		return errors.New("budget value needs to be a whole number")
 	}
-	return cmd.CheckEmpty(args[2:])
+	return c.JujuCommandBase.Init(args[2:])
 }
 
 // Run implements cmd.Command.Run and has most of the logic for the run command.

--- a/cmd/juju/romulus/listagreements/listagreements.go
+++ b/cmd/juju/romulus/listagreements/listagreements.go
@@ -35,8 +35,8 @@ List terms the user has agreed to.
 
 // NewListAgreementsCommand returns a new command that can be
 // used to list agreements a user has made.
-func NewListAgreementsCommand() *listAgreementsCommand {
-	return &listAgreementsCommand{}
+func NewListAgreementsCommand() cmd.Command {
+	return modelcmd.WrapBase(&listAgreementsCommand{})
 }
 
 type term struct {

--- a/cmd/juju/romulus/listbudgets/list-budgets.go
+++ b/cmd/juju/romulus/listbudgets/list-budgets.go
@@ -21,8 +21,8 @@ import (
 
 // NewListBudgetsCommand returns a new command that is used
 // to list budgets a user has access to.
-func NewListBudgetsCommand() modelcmd.CommandBase {
-	return &listBudgetsCommand{}
+func NewListBudgetsCommand() cmd.Command {
+	return modelcmd.WrapBase(&listBudgetsCommand{})
 }
 
 type listBudgetsCommand struct {

--- a/cmd/juju/romulus/listplans/list_plans.go
+++ b/cmd/juju/romulus/listplans/list_plans.go
@@ -54,10 +54,10 @@ type ListPlansCommand struct {
 }
 
 // NewListPlansCommand creates a new ListPlansCommand.
-func NewListPlansCommand() modelcmd.CommandBase {
-	return &ListPlansCommand{
+func NewListPlansCommand() cmd.Command {
+	return modelcmd.WrapBase(&ListPlansCommand{
 		CharmResolver: rcmd.NewCharmStoreResolver(),
-	}
+	})
 }
 
 // Info implements Command.Info.
@@ -81,7 +81,7 @@ func (c *ListPlansCommand) Init(args []string) error {
 		return errors.Errorf("unknown command line arguments: " + strings.Join(args, ","))
 	}
 	c.CharmURL = charmURL
-	return nil
+	return c.JujuCommandBase.Init(args)
 }
 
 // SetFlags implements Command.SetFlags.

--- a/cmd/juju/romulus/setbudget/setbudget.go
+++ b/cmd/juju/romulus/setbudget/setbudget.go
@@ -23,7 +23,7 @@ type setBudgetCommand struct {
 
 // NewSetBudgetCommand returns a new setBudgetCommand.
 func NewSetBudgetCommand() cmd.Command {
-	return &setBudgetCommand{}
+	return modelcmd.WrapBase(&setBudgetCommand{})
 }
 
 const doc = `
@@ -53,7 +53,7 @@ func (c *setBudgetCommand) Init(args []string) error {
 	if _, err := strconv.ParseInt(c.Value, 10, 32); err != nil {
 		return errors.New("budget value needs to be a whole number")
 	}
-	return cmd.CheckEmpty(args[2:])
+	return c.JujuCommandBase.Init(args[2:])
 }
 
 // Run implements cmd.Command.Run and contains most of the setbudget logic.

--- a/cmd/juju/romulus/showbudget/show_budget.go
+++ b/cmd/juju/romulus/showbudget/show_budget.go
@@ -25,12 +25,12 @@ var logger = loggo.GetLogger("romulus.cmd.showbudget")
 
 // NewShowBudgetCommand returns a new command that is used
 // to show details of the specified wireformat.
-func NewShowBudgetCommand() modelcmd.CommandBase {
-	return &showBudgetCommand{}
+func NewShowBudgetCommand() cmd.Command {
+	return modelcmd.WrapBase(&showBudgetCommand{})
 }
 
 type showBudgetCommand struct {
-	modelcmd.ModelCommandBase
+	modelcmd.JujuCommandBase
 
 	out    cmd.Output
 	budget string
@@ -60,12 +60,12 @@ func (c *showBudgetCommand) Init(args []string) error {
 	}
 	c.budget, args = args[0], args[1:]
 
-	return cmd.CheckEmpty(args)
+	return c.JujuCommandBase.Init(args)
 }
 
 // SetFlags implements cmd.Command.SetFlags.
 func (c *showBudgetCommand) SetFlags(f *gnuflag.FlagSet) {
-	c.ModelCommandBase.SetFlags(f)
+	c.JujuCommandBase.SetFlags(f)
 	c.out.AddFlags(f, "tabular", map[string]cmd.Formatter{
 		"tabular": formatTabular,
 		"json":    cmd.FormatJson,

--- a/cmd/juju/romulus/sla/sla.go
+++ b/cmd/juju/romulus/sla/sla.go
@@ -100,7 +100,7 @@ func (c *slaCommand) Init(args []string) error {
 		return nil
 	}
 	c.Level = args[0]
-	return cmd.CheckEmpty(args[1:])
+	return c.ModelCommandBase.Init(args[1:])
 }
 
 func (c *slaCommand) requestSupportCredentials(modelUUID string) (string, []byte, error) {


### PR DESCRIPTION

## Description of change

This change fixes a bug in the ```juju allocate``` command, which due to incorrect wrapping and initialization would cause the command to segfault.

## QA steps

```juju allocate 0``` should not segfault

## Documentation changes

no changes

## Bug reference

None
