### PR TITLE
Status history pruning age and size is configurable

### DIFF
--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -1124,15 +1124,10 @@ func (a *MachineAgent) startModelWorkers(controllerUUID, modelUUID string) (work
 		RunFlagDuration:             time.Minute,
 		CharmRevisionUpdateInterval: 24 * time.Hour,
 		InstPollerAggregationDelay:  3 * time.Second,
-		// TODO(perrito666) the status history pruning numbers need
-		// to be adjusting, after collecting user data from large install
-		// bases, to numbers allowing a rich and useful back history.
-		StatusHistoryPrunerMaxHistoryTime: 336 * time.Hour, // 2 weeks
-		StatusHistoryPrunerMaxHistoryMB:   5120,            // 5G
-		StatusHistoryPrunerInterval:       5 * time.Minute,
-		SpacesImportedGate:                a.discoverSpacesComplete,
-		NewEnvironFunc:                    newEnvirons,
-		NewMigrationMaster:                migrationmaster.NewWorker,
+		StatusHistoryPrunerInterval: 5 * time.Minute,
+		SpacesImportedGate:          a.discoverSpacesComplete,
+		NewEnvironFunc:              newEnvirons,
+		NewMigrationMaster:          migrationmaster.NewWorker,
 	})
 	if err := dependency.Install(engine, manifolds); err != nil {
 		if err := worker.Stop(engine); err != nil {

--- a/cmd/jujud/agent/model/manifolds.go
+++ b/cmd/jujud/agent/model/manifolds.go
@@ -84,9 +84,7 @@ type ManifoldsConfig struct {
 
 	// StatusHistoryPruner* values control status-history pruning
 	// behaviour.
-	StatusHistoryPrunerMaxHistoryTime time.Duration
-	StatusHistoryPrunerMaxHistoryMB   uint
-	StatusHistoryPrunerInterval       time.Duration
+	StatusHistoryPrunerInterval time.Duration
 
 	// SpacesImportedGate will be unlocked when spaces are known to
 	// have been imported.
@@ -289,10 +287,11 @@ func Manifolds(config ManifoldsConfig) dependency.Manifolds {
 			APICallerName: apiCallerName,
 		})),
 		statusHistoryPrunerName: ifNotMigrating(statushistorypruner.Manifold(statushistorypruner.ManifoldConfig{
-			APICallerName:  apiCallerName,
-			MaxHistoryTime: config.StatusHistoryPrunerMaxHistoryTime,
-			MaxHistoryMB:   config.StatusHistoryPrunerMaxHistoryMB,
-			PruneInterval:  config.StatusHistoryPrunerInterval,
+			APICallerName: apiCallerName,
+			EnvironName:   environTrackerName,
+			NewWorker:     statushistorypruner.New,
+			NewFacade:     statushistorypruner.NewFacade,
+			PruneInterval: config.StatusHistoryPrunerInterval,
 			// TODO(fwereade): 2016-03-17 lp:1558657
 			NewTimer: jworker.NewTimer,
 		})),

--- a/cmd/jujud/agent/util_test.go
+++ b/cmd/jujud/agent/util_test.go
@@ -565,7 +565,7 @@ type minModelWorkersEnviron struct {
 
 func (e *minModelWorkersEnviron) Config() *config.Config {
 	attrs := coretesting.FakeConfig()
-	cfg, err := config.New(config.NoDefaults, attrs)
+	cfg, err := config.New(config.UseDefaults, attrs)
 	if err != nil {
 		panic(err)
 	}

--- a/controller/config.go
+++ b/controller/config.go
@@ -75,9 +75,9 @@ const (
 	// MaxLogsAge is the maximum age for log entries, ef "72h"
 	MaxLogsAge = "max-logs-age"
 
-	// MaxLogSize is the maximum size the log collection can grow to
+	// MaxLogsSize is the maximum size the log collection can grow to
 	// before it is pruned, eg "4M"
-	MaxLogSize = "max-logs-size"
+	MaxLogsSize = "max-logs-size"
 
 	// Attribute Defaults
 
@@ -120,7 +120,7 @@ var ControllerOnlyConfigAttributes = []string{
 	SetNUMAControlPolicyKey,
 	StatePort,
 	MongoMemoryProfile,
-	MaxLogSize,
+	MaxLogsSize,
 	MaxLogsAge,
 }
 
@@ -295,7 +295,7 @@ func (c Config) MaxLogsAge() time.Duration {
 // can grow to before being pruned.
 func (c Config) MaxLogSizeMB() int {
 	// Value has already been validated.
-	val, _ := utils.ParseSize(c.mustString(MaxLogSize))
+	val, _ := utils.ParseSize(c.mustString(MaxLogsSize))
 	return int(val)
 }
 
@@ -346,7 +346,7 @@ func Validate(c Config) error {
 		}
 	}
 
-	if v, ok := c[MaxLogSize].(string); ok {
+	if v, ok := c[MaxLogsSize].(string); ok {
 		if _, err := utils.ParseSize(v); err != nil {
 			return errors.Annotate(err, "invalid max logs size in configuration")
 		}
@@ -373,7 +373,7 @@ var configChecker = schema.FieldMap(schema.Fields{
 	AllowModelAccessKey:     schema.Bool(),
 	MongoMemoryProfile:      schema.String(),
 	MaxLogsAge:              schema.String(),
-	MaxLogSize:              schema.String(),
+	MaxLogsSize:             schema.String(),
 }, schema.Defaults{
 	APIPort:                 DefaultAPIPort,
 	AuditingEnabled:         DefaultAuditingEnabled,
@@ -386,5 +386,5 @@ var configChecker = schema.FieldMap(schema.Fields{
 	AllowModelAccessKey:     schema.Omit,
 	MongoMemoryProfile:      schema.Omit,
 	MaxLogsAge:              fmt.Sprintf("%vh", DefaultMaxLogsAgeDays*24),
-	MaxLogSize:              fmt.Sprintf("%vM", DefaultMaxLogCollectionMB),
+	MaxLogsSize:             fmt.Sprintf("%vM", DefaultMaxLogCollectionMB),
 })

--- a/environs/config/config.go
+++ b/environs/config/config.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
@@ -139,6 +140,14 @@ const (
 	// ExtraInfoKey is the key for arbitrary user specified string data that
 	// is stored against the model.
 	ExtraInfoKey = "extra-info"
+
+	// MaxStatusHistoryAge is the maximum age of status history values
+	// to keep when pruning, ef "72h"
+	MaxStatusHistoryAge = "max-status-history-age"
+
+	// MaxStatusHistorySize is the maximum size the status history
+	// collection can grow to before it is pruned, eg "5M"
+	MaxStatusHistorySize = "max-status-history-size"
 
 	//
 	// Deprecated Settings Attributes
@@ -288,6 +297,14 @@ func New(withDefaults Defaulting, attrs map[string]interface{}) (*Config, error)
 	return c, nil
 }
 
+const (
+	// DefaultStatusHistoryAge is the default value for MaxStatusHistoryAge.
+	DefaultStatusHistoryAge = "336h" // 2 weeks
+
+	// DefaultStatusHistorySize is the default value for MaxStatusHistorySize.
+	DefaultStatusHistorySize = "5G"
+)
+
 var defaultConfigValues = map[string]interface{}{
 	// Network.
 	"firewall-mode":              FwInstance,
@@ -345,6 +362,10 @@ var defaultConfigValues = map[string]interface{}{
 	AptFTPProxyKey:   "",
 	AptNoProxyKey:    "127.0.0.1,localhost,::1",
 	"apt-mirror":     "",
+
+	// Status history settings
+	MaxStatusHistoryAge:  DefaultStatusHistoryAge,
+	MaxStatusHistorySize: DefaultStatusHistorySize,
 }
 
 // ConfigDefaults returns the config default values
@@ -480,6 +501,18 @@ func Validate(cfg, old *Config) error {
 	// Ensure the resource tags have the expected k=v format.
 	if _, err := cfg.resourceTags(); err != nil {
 		return errors.Annotate(err, "validating resource tags")
+	}
+
+	if v, ok := cfg.defined[MaxStatusHistoryAge].(string); ok {
+		if _, err := time.ParseDuration(v); err != nil {
+			return errors.Annotate(err, "invalid max status history age in model configuration")
+		}
+	}
+
+	if v, ok := cfg.defined[MaxStatusHistorySize].(string); ok {
+		if _, err := utils.ParseSize(v); err != nil {
+			return errors.Annotate(err, "invalid max status history size in model configuration")
+		}
 	}
 
 	// Check the immutable config values.  These can't change
@@ -903,6 +936,22 @@ func (c *Config) resourceTags() (map[string]string, error) {
 	return v, nil
 }
 
+// MaxStatusHistoryAge is the maximum age of status history entries
+// before being pruned.
+func (c *Config) MaxStatusHistoryAge() time.Duration {
+	// Value has already been validated.
+	val, _ := time.ParseDuration(c.mustString(MaxStatusHistoryAge))
+	return val
+}
+
+// MaxStatusHistorySizeMB is the maximum size in MiB which the status history
+// collection can grow to before being pruned.
+func (c *Config) MaxStatusHistorySizeMB() uint {
+	// Value has already been validated.
+	val, _ := utils.ParseSize(c.mustString(MaxStatusHistorySize))
+	return uint(val)
+}
+
 // UnknownAttrs returns a copy of the raw configuration attributes
 // that are supposedly specific to the environment type. They could
 // also be wrong attributes, though. Only the specific environment
@@ -1008,6 +1057,8 @@ var alwaysOptional = schema.Defaults{
 	"test-mode":                  schema.Omit,
 	TransmitVendorMetricsKey:     schema.Omit,
 	NetBondReconfigureDelayKey:   schema.Omit,
+	MaxStatusHistoryAge:          schema.Omit,
+	MaxStatusHistorySize:         schema.Omit,
 }
 
 func allowEmpty(attr string) bool {
@@ -1377,6 +1428,16 @@ data of the store. (default false)`,
 	NetBondReconfigureDelayKey: {
 		Description: "The amount of time in seconds to sleep between ifdown and ifup when bridging",
 		Type:        environschema.Tint,
+		Group:       environschema.EnvironGroup,
+	},
+	MaxStatusHistoryAge: {
+		Description: "The maximum age for status history entries before they are pruned, in human-readable time format",
+		Type:        environschema.Tstring,
+		Group:       environschema.EnvironGroup,
+	},
+	MaxStatusHistorySize: {
+		Description: "The maximum size for the status history collection, in human-readable memory format",
+		Type:        environschema.Tstring,
 		Group:       environschema.EnvironGroup,
 	},
 }

--- a/environs/config/config_test.go
+++ b/environs/config/config_test.go
@@ -1103,6 +1103,21 @@ func (s *ConfigSuite) TestAptProxyConfigMap(c *gc.C) {
 	c.Assert(cfg.AptProxySettings(), gc.DeepEquals, proxySettings)
 }
 
+func (s *ConfigSuite) TestStatusHistoryConfigDefaults(c *gc.C) {
+	cfg := newTestConfig(c, testing.Attrs{})
+	c.Assert(cfg.MaxStatusHistoryAge(), gc.Equals, 336*time.Hour)
+	c.Assert(cfg.MaxStatusHistorySizeMB(), gc.Equals, uint(5120))
+}
+
+func (s *ConfigSuite) TestStatusHistoryConfigValues(c *gc.C) {
+	cfg := newTestConfig(c, testing.Attrs{
+		"max-status-history-size": "8G",
+		"max-status-history-age":  "96h",
+	})
+	c.Assert(cfg.MaxStatusHistoryAge(), gc.Equals, 96*time.Hour)
+	c.Assert(cfg.MaxStatusHistorySizeMB(), gc.Equals, uint(8192))
+}
+
 func (s *ConfigSuite) TestSchemaNoExtra(c *gc.C) {
 	schema, err := config.Schema(nil)
 	c.Assert(err, gc.IsNil)

--- a/state/upgrades.go
+++ b/state/upgrades.go
@@ -642,19 +642,16 @@ func AddControllerLogPruneSettings(st *State) error {
 	defer closer()
 	var doc settingsDoc
 	if err := coll.FindId(controllerSettingsGlobalKey).One(&doc); err != nil {
-		return nil
+		if err == mgo.ErrNotFound {
+			return nil
+		}
+		return errors.Trace(err)
 	}
 
 	var ops []txn.Op
-	settingsChanged := false
-	if _, ok := doc.Settings[controller.MaxLogsAge]; !ok {
-		settingsChanged = true
-		doc.Settings[controller.MaxLogsAge] = fmt.Sprintf("%vh", controller.DefaultMaxLogsAgeDays*24)
-	}
-	if _, ok := doc.Settings[controller.MaxLogSize]; !ok {
-		settingsChanged = true
-		doc.Settings[controller.MaxLogSize] = fmt.Sprintf("%vM", controller.DefaultMaxLogCollectionMB)
-	}
+	settingsChanged := maybeUpdateSettings(doc.Settings, controller.MaxLogsAge, fmt.Sprintf("%vh", controller.DefaultMaxLogsAgeDays*24))
+	settingsChanged =
+		maybeUpdateSettings(doc.Settings, controller.MaxLogsSize, fmt.Sprintf("%vM", controller.DefaultMaxLogCollectionMB)) || settingsChanged
 	if settingsChanged {
 		ops = append(ops, txn.Op{
 			C:      controllersC,
@@ -662,6 +659,52 @@ func AddControllerLogPruneSettings(st *State) error {
 			Assert: txn.DocExists,
 			Update: bson.M{"$set": bson.M{"settings": doc.Settings}},
 		})
+	}
+	if len(ops) > 0 {
+		return errors.Trace(st.runRawTransaction(ops))
+	}
+	return nil
+}
+
+func maybeUpdateSettings(settings map[string]interface{}, key string, value interface{}) bool {
+	if _, ok := settings[key]; !ok {
+		settings[key] = value
+		return true
+	}
+	return false
+}
+
+// AddStatusHistoryPruneSettings adds the model settings
+// to control log pruning if they are missing.
+func AddStatusHistoryPruneSettings(st *State) error {
+	coll, closer := st.getRawCollection(settingsC)
+	defer closer()
+
+	models, err := st.AllModels()
+	if err != nil {
+		return errors.Trace(err)
+	}
+	var ids []string
+	for _, m := range models {
+		ids = append(ids, m.UUID()+":e")
+	}
+
+	iter := coll.Find(bson.M{"_id": bson.M{"$in": ids}}).Iter()
+	var ops []txn.Op
+	var doc settingsDoc
+	for iter.Next(&doc) {
+		settingsChanged :=
+			maybeUpdateSettings(doc.Settings, config.MaxStatusHistoryAge, config.DefaultStatusHistoryAge)
+		settingsChanged =
+			maybeUpdateSettings(doc.Settings, config.MaxStatusHistorySize, config.DefaultStatusHistorySize) || settingsChanged
+		if settingsChanged {
+			ops = append(ops, txn.Op{
+				C:      settingsC,
+				Id:     doc.DocID,
+				Assert: txn.DocExists,
+				Update: bson.M{"$set": bson.M{"settings": doc.Settings}},
+			})
+		}
 	}
 	if len(ops) > 0 {
 		return errors.Trace(st.runRawTransaction(ops))

--- a/state/upgrades_test.go
+++ b/state/upgrades_test.go
@@ -5,14 +5,18 @@ package state
 
 import (
 	"reflect"
+	"sort"
 	"time"
 
 	jc "github.com/juju/testing/checkers"
+	"github.com/juju/utils"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/mgo.v2"
 	"gopkg.in/mgo.v2/bson"
 
 	"github.com/juju/juju/cloud"
+	"github.com/juju/juju/storage/provider"
+	"github.com/juju/juju/testing"
 )
 
 type upgradesSuite struct {
@@ -323,6 +327,7 @@ func (s *upgradesSuite) assertUpgradedData(c *gc.C, upgrade func(*State) error, 
 				doc := d
 				delete(doc, "txn-queue")
 				delete(doc, "txn-revno")
+				delete(doc, "version")
 				docs[i] = doc
 			}
 			c.Assert(docs, jc.DeepEquals, expect.expected)
@@ -931,9 +936,14 @@ func (s *upgradesSuite) TestAddControllerLogPruneSettingsKeepExisting(c *gc.C) {
 	err = settingsColl.Insert(bson.M{
 		"_id": "controllerSettings",
 		"settings": bson.M{
+			"key":           "value",
 			"max-logs-age":  "96h",
 			"max-logs-size": "5G",
 		},
+	}, bson.M{
+		"_id": "someothersettingshouldnotbetouched",
+		// non-controller data: should not be touched
+		"settings": bson.M{"key": "value"},
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -941,10 +951,15 @@ func (s *upgradesSuite) TestAddControllerLogPruneSettingsKeepExisting(c *gc.C) {
 		{
 			"_id": "controllerSettings",
 			"settings": bson.M{
+				"key":           "value",
 				"max-logs-age":  "96h",
 				"max-logs-size": "5G",
 			},
-		}}
+		}, {
+			"_id":      "someothersettingshouldnotbetouched",
+			"settings": bson.M{"key": "value"},
+		},
+	}
 
 	s.assertUpgradedData(c, AddControllerLogPruneSettings,
 		expectUpgradedData{settingsColl, expectedSettings},
@@ -958,7 +973,11 @@ func (s *upgradesSuite) TestAddControllerLogPruneSettings(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	err = settingsColl.Insert(bson.M{
 		"_id":      "controllerSettings",
-		"settings": bson.M{},
+		"settings": bson.M{"key": "value"},
+	}, bson.M{
+		"_id": "someothersettingshouldnotbetouched",
+		// non-controller data: should not be touched
+		"settings": bson.M{"key": "value"},
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -966,12 +985,101 @@ func (s *upgradesSuite) TestAddControllerLogPruneSettings(c *gc.C) {
 		{
 			"_id": "controllerSettings",
 			"settings": bson.M{
+				"key":           "value",
 				"max-logs-age":  "72h",
 				"max-logs-size": "4096M",
 			},
-		}}
+		}, {
+			"_id":      "someothersettingshouldnotbetouched",
+			"settings": bson.M{"key": "value"},
+		},
+	}
 
 	s.assertUpgradedData(c, AddControllerLogPruneSettings,
 		expectUpgradedData{settingsColl, expectedSettings},
 	)
+}
+
+func (s *upgradesSuite) makeModel(c *gc.C, name string, attr testing.Attrs) *State {
+	uuid := utils.MustNewUUID()
+	cfg := testing.CustomModelConfig(c, testing.Attrs{
+		"name": name,
+		"uuid": uuid.String(),
+	}.Merge(attr))
+	m, err := s.state.Model()
+	c.Assert(err, jc.ErrorIsNil)
+	_, st, err := s.state.NewModel(ModelArgs{
+		CloudName:   "dummy",
+		CloudRegion: "dummy-region",
+		Config:      cfg,
+		Owner:       m.Owner(),
+		StorageProviderRegistry: provider.CommonStorageProviders(),
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	return st
+}
+
+func (s *upgradesSuite) TestAddStatusHistoryPruneSettings(c *gc.C) {
+	settingsColl, settingsCloser := s.state.getRawCollection(settingsC)
+	defer settingsCloser()
+	_, err := settingsColl.RemoveAll(nil)
+	c.Assert(err, jc.ErrorIsNil)
+
+	m1 := s.makeModel(c, "m1", testing.Attrs{
+		"max-status-history-age":  "96h",
+		"max-status-history-size": "4G",
+	})
+	defer m1.Close()
+
+	m2 := s.makeModel(c, "m2", testing.Attrs{})
+	defer m2.Close()
+
+	err = settingsColl.Insert(bson.M{
+		"_id": "someothersettingshouldnotbetouched",
+		// non-model setting: should not be touched
+		"settings": bson.M{"key": "value"},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	cfg1, err := m1.ModelConfig()
+	c.Assert(err, jc.ErrorIsNil)
+	expected1 := cfg1.AllAttrs()
+	expected1["resource-tags"] = ""
+
+	cfg2, err := m2.ModelConfig()
+	c.Assert(err, jc.ErrorIsNil)
+	expected2 := cfg2.AllAttrs()
+	expected2["max-status-history-age"] = "336h"
+	expected2["max-status-history-size"] = "5G"
+	expected2["resource-tags"] = ""
+
+	expectedSettings := bsonMById{
+		{
+			"_id":        m1.ModelUUID() + ":e",
+			"settings":   bson.M(expected1),
+			"model-uuid": m1.ModelUUID(),
+		}, {
+			"_id":        m2.ModelUUID() + ":e",
+			"settings":   bson.M(expected2),
+			"model-uuid": m2.ModelUUID(),
+		}, {
+			"_id":      "someothersettingshouldnotbetouched",
+			"settings": bson.M{"key": "value"},
+		},
+	}
+	sort.Sort(expectedSettings)
+
+	s.assertUpgradedData(c, AddStatusHistoryPruneSettings,
+		expectUpgradedData{settingsColl, expectedSettings},
+	)
+}
+
+type bsonMById []bson.M
+
+func (x bsonMById) Len() int { return len(x) }
+
+func (x bsonMById) Swap(i, j int) { x[i], x[j] = x[j], x[i] }
+
+func (x bsonMById) Less(i, j int) bool {
+	return x[i]["_id"].(string) < x[j]["_id"].(string)
 }

--- a/upgrades/backend.go
+++ b/upgrades/backend.go
@@ -28,6 +28,7 @@ type StateBackend interface {
 	AddNonDetachableStorageMachineId() error
 	RemoveNilValueApplicationSettings() error
 	AddControllerLogPruneSettings() error
+	AddStatusHistoryPruneSettings() error
 }
 
 // Model is an interface providing access to the details of a model within the
@@ -100,6 +101,10 @@ func (s stateBackend) RemoveNilValueApplicationSettings() error {
 
 func (s stateBackend) AddControllerLogPruneSettings() error {
 	return state.AddControllerLogPruneSettings(s.st)
+}
+
+func (s stateBackend) AddStatusHistoryPruneSettings() error {
+	return state.AddStatusHistoryPruneSettings(s.st)
 }
 
 type modelShim struct {

--- a/upgrades/steps_22.go
+++ b/upgrades/steps_22.go
@@ -32,6 +32,13 @@ func stateStepsFor22() []Step {
 				return context.State().AddControllerLogPruneSettings()
 			},
 		},
+		&upgradeStep{
+			description: "add status history pruning config settings",
+			targets:     []Target{DatabaseMaster},
+			run: func(context Context) error {
+				return context.State().AddStatusHistoryPruneSettings()
+			},
+		},
 	}
 }
 

--- a/upgrades/steps_22_test.go
+++ b/upgrades/steps_22_test.go
@@ -59,3 +59,9 @@ func (s *steps22Suite) TestAddControllerLogPruneSettings(c *gc.C) {
 	// Logic for step itself is tested in state package.
 	c.Assert(step.Targets(), jc.DeepEquals, []upgrades.Target{upgrades.DatabaseMaster})
 }
+
+func (s *steps22Suite) TestAddStatusHistoryPruneSettings(c *gc.C) {
+	step := findStateStep(c, v220, "add status history pruning config settings")
+	// Logic for step itself is tested in state package.
+	c.Assert(step.Targets(), jc.DeepEquals, []upgrades.Target{upgrades.DatabaseMaster})
+}

--- a/worker/statushistorypruner/manifold.go
+++ b/worker/statushistorypruner/manifold.go
@@ -10,7 +10,7 @@ import (
 	"gopkg.in/juju/worker.v1"
 
 	"github.com/juju/juju/api/base"
-	"github.com/juju/juju/api/statushistory"
+	"github.com/juju/juju/environs"
 	jworker "github.com/juju/juju/worker"
 	"github.com/juju/juju/worker/dependency"
 )
@@ -18,10 +18,11 @@ import (
 // ManifoldConfig describes the resources and configuration on which the
 // statushistorypruner worker depends.
 type ManifoldConfig struct {
-	APICallerName  string
-	MaxHistoryTime time.Duration
-	MaxHistoryMB   uint
-	PruneInterval  time.Duration
+	APICallerName string
+	EnvironName   string
+	PruneInterval time.Duration
+	NewWorker     func(Config) (worker.Worker, error)
+	NewFacade     func(base.APICaller) Facade
 	// TODO(fwereade): 2016-03-17 lp:1558657
 	NewTimer jworker.NewTimerFunc
 }
@@ -29,26 +30,55 @@ type ManifoldConfig struct {
 // Manifold returns a Manifold that encapsulates the statushistorypruner worker.
 func Manifold(config ManifoldConfig) dependency.Manifold {
 	return dependency.Manifold{
-		Inputs: []string{config.APICallerName},
-		Start: func(context dependency.Context) (worker.Worker, error) {
-			var apiCaller base.APICaller
-			if err := context.Get(config.APICallerName, &apiCaller); err != nil {
-				return nil, errors.Trace(err)
-			}
-
-			facade := statushistory.NewFacade(apiCaller)
-			prunerConfig := Config{
-				Facade:         facade,
-				MaxHistoryTime: config.MaxHistoryTime,
-				MaxHistoryMB:   config.MaxHistoryMB,
-				PruneInterval:  config.PruneInterval,
-				NewTimer:       config.NewTimer,
-			}
-			w, err := New(prunerConfig)
-			if err != nil {
-				return nil, errors.Trace(err)
-			}
-			return w, nil
-		},
+		Inputs: []string{config.APICallerName, config.EnvironName},
+		Start:  config.start,
 	}
+}
+
+// start is a StartFunc for a Worker manifold.
+func (config ManifoldConfig) start(context dependency.Context) (worker.Worker, error) {
+	if err := config.Validate(); err != nil {
+		return nil, errors.Trace(err)
+	}
+	var apiCaller base.APICaller
+	if err := context.Get(config.APICallerName, &apiCaller); err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	var environ environs.Environ
+	if err := context.Get(config.EnvironName, &environ); err != nil {
+		return nil, errors.Trace(err)
+	}
+	cfg := environ.Config()
+
+	facade := config.NewFacade(apiCaller)
+	prunerConfig := Config{
+		Facade:         facade,
+		MaxHistoryTime: cfg.MaxStatusHistoryAge(),
+		MaxHistoryMB:   cfg.MaxStatusHistorySizeMB(),
+		PruneInterval:  config.PruneInterval,
+		NewTimer:       config.NewTimer,
+	}
+	w, err := config.NewWorker(prunerConfig)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return w, nil
+}
+
+// Validate is called by start to check for bad configuration.
+func (config ManifoldConfig) Validate() error {
+	if config.APICallerName == "" {
+		return errors.NotValidf("empty APICallerName")
+	}
+	if config.EnvironName == "" {
+		return errors.NotValidf("empty EnvironName")
+	}
+	if config.NewWorker == nil {
+		return errors.NotValidf("nil NewWorker")
+	}
+	if config.NewFacade == nil {
+		return errors.NotValidf("nil NewFacade")
+	}
+	return nil
 }

--- a/worker/statushistorypruner/manifold_test.go
+++ b/worker/statushistorypruner/manifold_test.go
@@ -1,0 +1,125 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package statushistorypruner_test
+
+import (
+	"time"
+
+	"github.com/juju/errors"
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/worker.v1"
+
+	"github.com/juju/juju/api/base"
+	"github.com/juju/juju/environs"
+	"github.com/juju/juju/environs/config"
+	coretesting "github.com/juju/juju/testing"
+	"github.com/juju/juju/worker/dependency"
+	"github.com/juju/juju/worker/statushistorypruner"
+)
+
+type ManifoldSuite struct {
+	testing.IsolationSuite
+}
+
+var _ = gc.Suite(&ManifoldSuite{})
+
+func (s *ManifoldSuite) TestStatusHistoryConfig(c *gc.C) {
+	ctx := &mockDependencyContext{
+		env: &mockEnviron{
+			config: coretesting.CustomModelConfig(c, coretesting.Attrs{
+				"max-status-history-age":  "96h",
+				"max-status-history-size": "4G",
+			}),
+		},
+	}
+
+	manifold := statushistorypruner.Manifold(statushistorypruner.ManifoldConfig{
+		APICallerName: "api-caller",
+		EnvironName:   "environ",
+		NewWorker: func(cfg statushistorypruner.Config) (worker.Worker, error) {
+			c.Assert(cfg.MaxHistoryTime, gc.Equals, 96*time.Hour)
+			c.Assert(cfg.MaxHistoryMB, gc.Equals, uint(4096))
+			return nil, dependency.ErrUninstall
+		},
+		NewFacade: func(caller base.APICaller) statushistorypruner.Facade {
+			return nil
+		},
+	})
+	_, err := manifold.Start(ctx)
+	c.Assert(errors.Cause(err), gc.Equals, dependency.ErrUninstall)
+}
+
+type mockDependencyContext struct {
+	dependency.Context
+	env *mockEnviron
+}
+
+func (m *mockDependencyContext) Get(name string, out interface{}) error {
+	if name == "environ" {
+		*(out.(*environs.Environ)) = m.env
+	}
+	return nil
+}
+
+type mockEnviron struct {
+	environs.Environ
+	config *config.Config
+}
+
+func (e *mockEnviron) Config() *config.Config {
+	return e.config
+}
+
+type ManifoldConfigSuite struct {
+	testing.IsolationSuite
+	config statushistorypruner.ManifoldConfig
+}
+
+var _ = gc.Suite(&ManifoldConfigSuite{})
+
+func (s *ManifoldConfigSuite) SetUpTest(c *gc.C) {
+	s.IsolationSuite.SetUpTest(c)
+	s.config = s.validConfig()
+}
+
+func (s *ManifoldConfigSuite) validConfig() statushistorypruner.ManifoldConfig {
+	return statushistorypruner.ManifoldConfig{
+		APICallerName: "api-caller",
+		EnvironName:   "environ",
+		NewWorker:     func(statushistorypruner.Config) (worker.Worker, error) { return nil, nil },
+		NewFacade:     func(caller base.APICaller) statushistorypruner.Facade { return nil },
+	}
+}
+
+func (s *ManifoldConfigSuite) TestValid(c *gc.C) {
+	c.Check(s.config.Validate(), jc.ErrorIsNil)
+}
+
+func (s *ManifoldConfigSuite) TestMissingAPICallerName(c *gc.C) {
+	s.config.APICallerName = ""
+	s.checkNotValid(c, "empty APICallerName not valid")
+}
+
+func (s *ManifoldConfigSuite) TestMissingEnvironName(c *gc.C) {
+	s.config.EnvironName = ""
+	s.checkNotValid(c, "empty EnvironName not valid")
+}
+
+func (s *ManifoldConfigSuite) TestMissingNewWorker(c *gc.C) {
+	s.config.NewWorker = nil
+	s.checkNotValid(c, "nil NewWorker not valid")
+}
+
+func (s *ManifoldConfigSuite) TestMissingNewFacade(c *gc.C) {
+	s.config.NewFacade = nil
+	s.checkNotValid(c, "nil NewFacade not valid")
+}
+
+func (s *ManifoldConfigSuite) checkNotValid(c *gc.C, expect string) {
+	err := s.config.Validate()
+	c.Check(err, gc.ErrorMatches, expect)
+	c.Check(err, jc.Satisfies, errors.IsNotValid)
+}

--- a/worker/statushistorypruner/worker.go
+++ b/worker/statushistorypruner/worker.go
@@ -9,6 +9,8 @@ import (
 	"github.com/juju/errors"
 	"gopkg.in/juju/worker.v1"
 
+	"github.com/juju/juju/api/base"
+	"github.com/juju/juju/api/statushistory"
 	jworker "github.com/juju/juju/worker"
 )
 
@@ -59,4 +61,9 @@ func New(conf Config) (worker.Worker, error) {
 	}
 
 	return jworker.NewPeriodicWorker(doPruning, conf.PruneInterval, conf.NewTimer), nil
+}
+
+// NewFacade returns a new status history facade.
+func NewFacade(caller base.APICaller) Facade {
+	return statushistory.NewFacade(caller)
 }


### PR DESCRIPTION
## Description of change

We add 2 new model config parameters
- max-status-history-age
- max-status-history-size

These control how status history records are removed during pruning; the age and the max size of the collection holding the records.

The status history pruning worker manifold is also improved, plus tests are added.

There are also fixes to tests for the previously landed code to control log pruning.

Still todo - the pruning worker does not react to changes in the pruning config.

## QA steps

bootstrap
juju model-config, verify that default status history pruning params are shown

bootstrap with values set via --config
juju model-config, verify that the specified status history pruning params are shown

bootstrap beta2
upgrade
juju model-config, verify that default status history pruning params are shown

## Documentation changes

There are 2 new model config attributes:
- max-status-history-age
"The maximum age for status history entries before they are pruned, in human-readable time format"

- max-status-history-size
"The maximum size for the status history collection, in human-readable memory format"

## Bug reference

http://pad.lv/1681352
