### PR TITLE
Show budget resolve model names

### DIFF
--- a/cmd/juju/romulus/showbudget/export_test.go
+++ b/cmd/juju/romulus/showbudget/export_test.go
@@ -9,6 +9,7 @@ import (
 
 var (
 	NewBudgetAPIClient = &newBudgetAPIClient
+	NewJujuclientStore = &newJujuclientStore
 )
 
 // BudgetAPIClientFnc returns a function that returns the provided budgetAPIClient


### PR DESCRIPTION
## Description of change

> Why is this change needed?

So that `juju show-budget` can resolve model names.

## QA steps

> How do we verify that the change works?

`juju show-budget` will show model names instead of UUIDs if the client knows them.

## Documentation changes

> Does it affect current user workflow? CLI? API?

Improve the UX of `juju show-budget`. Contact @cmars for more info.

## Bug reference

> Does this change fix a bug? Please add a link to it.

https://bugs.launchpad.net/juju/+bug/1636635