### PR TITLE
neutron.FilterNetwork should be a regular string, not a regexp

### DIFF
--- a/provider/openstack/networking.go
+++ b/provider/openstack/networking.go
@@ -275,7 +275,7 @@ func (n *NeutronNetworking) ResolveNetwork(name string, external bool) (string, 
 // the exact given name AND router:external boolean result.
 func networkFilter(name string, external bool) *neutron.Filter {
 	filter := neutron.NewFilter()
-	filter.Set(neutron.FilterNetwork, fmt.Sprintf("^%s$", name))
+	filter.Set(neutron.FilterNetwork, fmt.Sprintf("%s", name))
 	filter.Set(neutron.FilterRouterExternal, fmt.Sprintf("%t", external))
 	return filter
 }


### PR DESCRIPTION
## Please provide the following details to expedite Pull Request review:

----

## Description of change

Filtering in OpenStack Neutron (network) behaves differently than in Nova (compute).  For Neutron a regexp doesn't work, change the filter we're using to a simple string.

## QA steps

Bootstrap against an OpenStack cloud using the network config option.

## Documentation changes

N/A

## Bug reference

N/A
