### PR TITLE
Properly reuse existing devices 1782338

### DIFF
--- a/provider/maas/devices.go
+++ b/provider/maas/devices.go
@@ -552,8 +552,8 @@ func validateExistingDevice(netInfo []network.InterfaceInfo, device gomaasapi.De
 // checkForExistingDevice checks to see if we've already registered a device
 // with this name, and if its information is appropriately populated. If we
 // have, then we just return the existing interface info. If we find it, but
-// it doesn't match, then we ask MAAS to remove it. And request that we
-// create it again.
+// it doesn't match, then we ask MAAS to remove it, which should cause the
+// calling code to create it again.
 func (env *maasEnviron) checkForExistingDevice(params deviceCreatorParams) (gomaasapi.Device, error) {
 	devicesArgs := gomaasapi.DevicesArgs{
 		Hostname: []string{params.Name},
@@ -561,7 +561,7 @@ func (env *maasEnviron) checkForExistingDevice(params deviceCreatorParams) (goma
 	maybeDevices, err := params.Machine.Devices(devicesArgs)
 	if err != nil {
 		logger.Warningf("error while trying to lookup %q: %v", params.Name, err)
-		// treated as not fatal, since we'll try to create it
+		// not considered fatal, since we'll attempt to create the device if we didn't find it
 		return nil, nil
 	}
 	if len(maybeDevices) == 0 {

--- a/provider/maas/devices.go
+++ b/provider/maas/devices.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"net/url"
 	"path"
+	"strings"
 	"strconv"
 
 	"github.com/juju/errors"
@@ -244,16 +245,9 @@ func (env *maasEnviron) deviceInterfaceInfo(deviceID instance.Id, nameToParentNa
 	return interfaceInfo, nil
 }
 
-func (env *maasEnviron) deviceInterfaceInfo2(deviceID string, nameToParentName map[string]string, subnetToStaticRoutes map[string][]gomaasapi.StaticRoute) ([]network.InterfaceInfo, error) {
-	args := gomaasapi.DevicesArgs{SystemIDs: []string{deviceID}}
-	devices, err := env.maasController.Devices(args)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	if len(devices) != 1 {
-		return nil, errors.Errorf("unexpected response requesting device %v: %v", deviceID, devices)
-	}
-	interfaces := devices[0].InterfaceSet()
+func (env *maasEnviron) deviceInterfaceInfo2(device gomaasapi.Device, nameToParentName map[string]string, subnetToStaticRoutes map[string][]gomaasapi.StaticRoute) ([]network.InterfaceInfo, error) {
+	deviceID := device.SystemID()
+	interfaces := device.InterfaceSet()
 
 	interfaceInfo := make([]network.InterfaceInfo, 0, len(interfaces))
 	for _, nic := range interfaces {
@@ -323,4 +317,221 @@ func (env *maasEnviron) deviceInterfaceInfo2(deviceID string, nameToParentName m
 	}
 	logger.Debugf("device %q has interface info: %+v", deviceID, interfaceInfo)
 	return interfaceInfo, nil
+}
+
+type deviceCreatorParams struct {
+	Name                 string
+	Subnet               gomaasapi.Subnet // may be nil
+	PrimaryMACAddress    string
+	PrimaryNICName       string
+	DesiredInterfaceInfo []network.InterfaceInfo
+	CIDRToMAASSubnet     map[string]gomaasapi.Subnet
+	CIDRToStaticRoutes   map[string][]gomaasapi.StaticRoute
+	Machine              gomaasapi.Machine
+}
+
+func (env *maasEnviron) createAndPopulateDevice(params deviceCreatorParams) (gomaasapi.Device, error) {
+	createDeviceArgs := gomaasapi.CreateMachineDeviceArgs{
+		Hostname:      params.Name,
+		MACAddress:    params.PrimaryMACAddress,
+		Subnet:        params.Subnet, // can be nil
+		InterfaceName: params.PrimaryNICName,
+	}
+	device, err := params.Machine.CreateDevice(createDeviceArgs)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	interface_set := device.InterfaceSet()
+	if len(interface_set) != 1 {
+		// Shouldn't be possible as machine.CreateDevice always
+		// returns a device with one interface.
+		names := make([]string, len(interface_set))
+		for i, iface := range interface_set {
+			names[i] = iface.Name()
+		}
+		return nil, errors.Errorf("unexpected number of interfaces "+
+			"in response from creating device: %v", names)
+	}
+	primaryNIC := interface_set[0]
+	primaryNICVLAN := primaryNIC.VLAN()
+
+	// Populate the rest of the desired interfaces on this device
+	for _, nic := range params.DesiredInterfaceInfo {
+		if nic.InterfaceName == params.PrimaryNICName {
+			// already handled in CreateDevice
+			continue
+		}
+		// We have to register an extra interface for this container
+		// (aka 'device'), and then link that device to the desired
+		// subnet so that it can acquire an IP address from MAAS.
+		createArgs := gomaasapi.CreateInterfaceArgs{
+			Name:       nic.InterfaceName,
+			MTU:        nic.MTU,
+			MACAddress: nic.MACAddress,
+		}
+
+		subnet, knownSubnet := params.CIDRToMAASSubnet[nic.CIDR]
+		if !knownSubnet {
+			logger.Warningf("NIC %v has no subnet - setting to manual and using 'primaryNIC' VLAN %d", nic.InterfaceName, primaryNICVLAN.ID())
+			createArgs.VLAN = primaryNICVLAN
+		} else {
+			createArgs.VLAN = subnet.VLAN()
+			logger.Infof("linking NIC %v to subnet %v - using static IP", nic.InterfaceName, subnet.CIDR())
+		}
+
+		createdNIC, err := device.CreateInterface(createArgs)
+		if err != nil {
+			return nil, errors.Annotate(err, "creating device interface")
+		}
+		logger.Debugf("created device interface: %+v", createdNIC)
+
+		if !knownSubnet {
+			// If we didn't request an explicit subnet, then we
+			// don't need to link the device to that subnet
+			continue
+		}
+
+		linkArgs := gomaasapi.LinkSubnetArgs{
+			Mode:   gomaasapi.LinkModeStatic,
+			Subnet: subnet,
+		}
+
+		if err := createdNIC.LinkSubnet(linkArgs); err != nil {
+			logger.Warningf("linking NIC %v to subnet %v failed: %v", nic.InterfaceName, subnet.CIDR(), err)
+		} else {
+			logger.Debugf("linked device interface to subnet: %+v", createdNIC)
+		}
+	}
+	return device, nil
+}
+
+func (env *maasEnviron) lookupSubnets() (map[string]gomaasapi.Subnet, error) {
+	subnetCIDRToSubnet := make(map[string]gomaasapi.Subnet)
+	spaces, err := env.maasController.Spaces()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	for _, space := range spaces {
+		for _, subnet := range space.Subnets() {
+			subnetCIDRToSubnet[subnet.CIDR()] = subnet
+		}
+	}
+	return subnetCIDRToSubnet, nil
+}
+func (env *maasEnviron) lookupStaticRoutes() (map[string][]gomaasapi.StaticRoute, error) {
+	// map from the source subnet (what subnet is the device in), to what
+	// static routes should be used.
+	subnetToStaticRoutes := make(map[string][]gomaasapi.StaticRoute)
+	staticRoutes, err := env.maasController.StaticRoutes()
+	if err != nil {
+		// MAAS 2.0 does not support static-routes, and will return a 404. MAAS
+		// does not report support for static-routes in its capabilities, nor
+		// does it have a different API version between 2.1 and 2.0. So we make
+		// the attempt, and treat a 404 as not having any configured static
+		// routes.
+		// gomaaasapi wraps a ServerError in an UnexpectedError, so we need to
+		// dig to make sure we have the right cause:
+		handled := false
+		if gomaasapi.IsUnexpectedError(err) {
+			msg := err.Error()
+			if strings.Contains(msg, "404") &&
+				strings.Contains(msg, "Unknown API endpoint:") &&
+				strings.Contains(msg, "/static-routes/") {
+				logger.Debugf("static-routes not supported: %v", err)
+				handled = true
+				staticRoutes = nil
+			} else {
+				logger.Warningf("looking up static routes generated IsUnexpectedError, but didn't match: %q %#v", msg, err)
+			}
+		} else {
+			logger.Warningf("not IsUnexpectedError: %#v", err)
+		}
+		if !handled {
+			logger.Warningf("error looking up static-routes: %v", err)
+			return nil, errors.Annotate(err, "unable to look up static-routes")
+		}
+	}
+	for _, route := range staticRoutes {
+		source := route.Source()
+		sourceCIDR := source.CIDR()
+		subnetToStaticRoutes[sourceCIDR] = append(subnetToStaticRoutes[sourceCIDR], route)
+	}
+	logger.Debugf("found static routes: %# v", subnetToStaticRoutes)
+	return subnetToStaticRoutes, nil
+}
+
+func (env *maasEnviron) prepareDeviceDetails(name string, machine gomaasapi.Machine, preparedInfo []network.InterfaceInfo) (deviceCreatorParams, error) {
+	var zeroParams deviceCreatorParams
+
+	subnetCIDRToSubnet, err := env.lookupSubnets()
+	if err != nil {
+		return zeroParams, errors.Trace(err)
+	}
+	subnetToStaticRoutes, err := env.lookupStaticRoutes()
+	if err != nil {
+		return zeroParams, errors.Trace(err)
+	}
+	params := deviceCreatorParams{
+		// Containers always use 'eth0' as their primary NIC
+		// XXX(jam) 2017-04-13: Except we *don't* do that for KVM containers running Xenial
+		Name:                 name,
+		Machine:              machine,
+		PrimaryNICName:       "eth0",
+		DesiredInterfaceInfo: preparedInfo,
+		CIDRToMAASSubnet:     subnetCIDRToSubnet,
+		CIDRToStaticRoutes:   subnetToStaticRoutes,
+	}
+
+	var primaryNICInfo network.InterfaceInfo
+	for _, nic := range preparedInfo {
+		if nic.InterfaceName == params.PrimaryNICName {
+			primaryNICInfo = nic
+			break
+		}
+	}
+	if primaryNICInfo.InterfaceName == "" {
+		return zeroParams, errors.Errorf("cannot find primary interface for container")
+	}
+	logger.Debugf("primary device NIC prepared info: %+v", primaryNICInfo)
+
+	primaryNICSubnetCIDR := primaryNICInfo.CIDR
+	subnet, hasSubnet := subnetCIDRToSubnet[primaryNICSubnetCIDR]
+	if hasSubnet {
+		params.Subnet = subnet
+	} else {
+		logger.Debugf("primary device NIC %q has no linked subnet - leaving unconfigured", primaryNICInfo.InterfaceName)
+	}
+	params.PrimaryMACAddress = primaryNICInfo.MACAddress
+	return params, nil
+}
+
+// checkForExistingDevice checks to see if we've already registered a device
+// with this name, and if its information is appropriately populated. If we
+// have, then we just return the existing interface info. If we find it, but
+// it doesn't match, then we ask MAAS to remove it. And request that we
+// create it again.
+func (env *maasEnviron) checkForExistingDevice(params deviceCreatorParams) (gomaasapi.Device, error) {
+	devicesArgs := gomaasapi.DevicesArgs{
+		Hostname: []string{params.Name},
+	}
+	maybeDevices, err := params.Machine.Devices(devicesArgs)
+	if err != nil {
+		logger.Warningf("error while trying to lookup %q: %v", params.Name, err)
+		// treated as not fatal, since we'll try to create it
+		return nil, nil
+	}
+	if len(maybeDevices) == 0 {
+		logger.Debugf("no existing MAAS devices for container %q, creating", params.Name)
+		return nil, nil
+	}
+	if len(maybeDevices) > 1 {
+		logger.Warningf("found more than 1 MAAS devices (%d) for container %q", len(maybeDevices),
+			params.Name)
+		return nil, errors.Errorf("found more than 1 MAAS device (%d) for container %q",
+			len(maybeDevices), params.Name)
+	}
+	logger.Debugf("found MAAS device for container %q, "+"using existing device", params.Name)
+	device := maybeDevices[0]
+	// Now validate that this device has the right interfaces
+	return device, nil
 }

--- a/provider/maas/environ.go
+++ b/provider/maas/environ.go
@@ -2161,75 +2161,6 @@ func (env *maasEnviron) allocateContainerAddresses1(hostInstanceID instance.Id, 
 }
 
 func (env *maasEnviron) allocateContainerAddresses2(hostInstanceID instance.Id, containerTag names.MachineTag, preparedInfo []network.InterfaceInfo) ([]network.InterfaceInfo, error) {
-	subnetCIDRToSubnet := make(map[string]gomaasapi.Subnet)
-	spaces, err := env.maasController.Spaces()
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	for _, space := range spaces {
-		for _, subnet := range space.Subnets() {
-			subnetCIDRToSubnet[subnet.CIDR()] = subnet
-		}
-	}
-	// map from the source subnet (what subnet is the device in), to what
-	// static routes should be used.
-	subnetToStaticRoutes := make(map[string][]gomaasapi.StaticRoute)
-	staticRoutes, err := env.maasController.StaticRoutes()
-	if err != nil {
-		// MAAS 2.0 does not support static-routes, and will return a 404. MAAS
-		// does not report support for static-routes in its capabilities, nor
-		// does it have a different API version between 2.1 and 2.0. So we make
-		// the attempt, and treat a 404 as not having any configured static
-		// routes.
-		// gomaaasapi wraps a ServerError in an UnexpectedError, so we need to
-		// dig to make sure we have the right cause:
-		handled := false
-		if gomaasapi.IsUnexpectedError(err) {
-			msg := err.Error()
-			if strings.Contains(msg, "404") &&
-				strings.Contains(msg, "Unknown API endpoint:") &&
-				strings.Contains(msg, "/static-routes/") {
-				logger.Debugf("static-routes not supported: %v", err)
-				handled = true
-				staticRoutes = nil
-			} else {
-				logger.Warningf("IsUnexpectedError, but didn't match: %q %#v", msg, err)
-			}
-		} else {
-			logger.Warningf("not IsUnexpectedError: %#v", err)
-		}
-		if !handled {
-			logger.Warningf("error looking up static-routes: %v", err)
-			return nil, errors.Annotate(err, "unable to look up static-routes")
-		}
-	}
-	for _, route := range staticRoutes {
-		source := route.Source()
-		sourceCIDR := source.CIDR()
-		subnetToStaticRoutes[sourceCIDR] = append(subnetToStaticRoutes[sourceCIDR], route)
-	}
-	logger.Debugf("found static routes: %# v", subnetToStaticRoutes)
-
-	// Containers always use 'eth0' as their primary NIC
-	var primaryNICInfo network.InterfaceInfo
-	primaryNICName := "eth0"
-	for _, nic := range preparedInfo {
-		if nic.InterfaceName == primaryNICName {
-			primaryNICInfo = nic
-			break
-		}
-	}
-	if primaryNICInfo.InterfaceName == "" {
-		return nil, errors.Errorf("cannot find primary interface for container")
-	}
-	logger.Debugf("primary device NIC prepared info: %+v", primaryNICInfo)
-
-	primaryNICSubnetCIDR := primaryNICInfo.CIDR
-	subnet, hasSubnet := subnetCIDRToSubnet[primaryNICSubnetCIDR]
-	if !hasSubnet {
-		logger.Debugf("primary device NIC %q has no linked subnet - leaving unconfigured", primaryNICInfo.InterfaceName)
-	}
-	primaryMACAddress := primaryNICInfo.MACAddress
 	args := gomaasapi.MachinesArgs{
 		AgentName: env.uuid,
 		SystemIDs: []string{string(hostInstanceID)},
@@ -2246,95 +2177,35 @@ func (env *maasEnviron) allocateContainerAddresses2(hostInstanceID instance.Id, 
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	// Check to see if we've already tried to allocate information for this device:
-	devicesArgs := gomaasapi.DevicesArgs{
-		Hostname: []string{deviceName},
-	}
-	var device gomaasapi.Device
-	maybeDevices, err := machine.Devices(devicesArgs)
+	params, err := env.prepareDeviceDetails(deviceName, machine, preparedInfo)
 	if err != nil {
-		logger.Warningf("error while trying to lookup %q: %v", deviceName, err)
-	} else {
-		if len(maybeDevices) == 1 {
-			logger.Debugf("found MAAS device for container %q, using existing device", deviceName)
-			device = maybeDevices[0]
-		} else if len(maybeDevices) > 1 {
-			logger.Warningf("found more than 1 MAAS devices (%d) for container %q", len(maybeDevices), deviceName)
-			return nil, errors.Errorf("found more than 1 MAAS device (%d) for container %q", len(maybeDevices), deviceName)
-		} else {
-			logger.Debugf("no existing MAAS devices for container %q, creating", deviceName)
-		}
+		return nil, errors.Trace(err)
+	}
+
+	// Check to see if we've already tried to allocate information for this device:
+	device, err := env.checkForExistingDevice(params)
+	if err != nil {
+		return nil, errors.Trace(err)
 	}
 	if device == nil {
-		// The device didn't already exist, so we Create it.
-		createDeviceArgs := gomaasapi.CreateMachineDeviceArgs{
-			Hostname:      deviceName,
-			MACAddress:    primaryMACAddress,
-			Subnet:        subnet, // can be nil
-			InterfaceName: primaryNICName,
-		}
-		device, err = machine.CreateDevice(createDeviceArgs)
+		device, err = env.createAndPopulateDevice(params)
 		if err != nil {
-			return nil, errors.Trace(err)
+			return nil, errors.Annotatef(err,
+				"failed to create MAAS device for %q",
+				params.Name)
 		}
 	}
-	interface_set := device.InterfaceSet()
-	if len(interface_set) != 1 {
-		// Shouldn't be possible as machine.CreateDevice always returns us
-		// one interface.
-		return nil, errors.Errorf("unexpected number of interfaces in response from creating device: %v", interface_set)
-	}
-	primaryNICVLAN := interface_set[0].VLAN()
 
+	// TODO(jam): the old code used to reload the device from its SystemID()
 	nameToParentName := make(map[string]string)
 	for _, nic := range preparedInfo {
 		nameToParentName[nic.InterfaceName] = nic.ParentInterfaceName
-		if nic.InterfaceName != primaryNICName {
-			createArgs := gomaasapi.CreateInterfaceArgs{
-				Name:       nic.InterfaceName,
-				MTU:        nic.MTU,
-				MACAddress: nic.MACAddress,
-			}
-
-			subnet, knownSubnet := subnetCIDRToSubnet[nic.CIDR]
-			if !knownSubnet {
-				logger.Warningf("NIC %v has no subnet - setting to manual and using 'primaryNIC' VLAN %d", nic.InterfaceName, primaryNICVLAN.ID())
-				createArgs.VLAN = primaryNICVLAN
-			} else {
-				createArgs.VLAN = subnet.VLAN()
-				logger.Infof("linking NIC %v to subnet %v - using static IP", nic.InterfaceName, subnet.CIDR())
-			}
-
-			createdNIC, err := device.CreateInterface(createArgs)
-			if err != nil {
-				return nil, errors.Annotate(err, "creating device interface")
-			}
-			logger.Debugf("created device interface: %+v", createdNIC)
-
-			if !knownSubnet {
-				continue
-			}
-
-			linkArgs := gomaasapi.LinkSubnetArgs{
-				Mode:   gomaasapi.LinkModeStatic,
-				Subnet: subnet,
-			}
-
-			if err := createdNIC.LinkSubnet(linkArgs); err != nil {
-				logger.Warningf("linking NIC %v to subnet %v failed: %v", nic.InterfaceName, subnet.CIDR(), err)
-			} else {
-				logger.Debugf("linked device interface to subnet: %+v", createdNIC)
-			}
-		}
 	}
-
-	finalInterfaces, err := env.deviceInterfaceInfo2(device.SystemID(), nameToParentName, subnetToStaticRoutes)
+	interfaces, err := env.deviceInterfaceInfo2(device, nameToParentName, params.CIDRToStaticRoutes)
 	if err != nil {
 		return nil, errors.Annotate(err, "cannot get device interfaces")
 	}
-	logger.Debugf("allocated device interfaces: %+v", finalInterfaces)
-
-	return finalInterfaces, nil
+	return interfaces, nil
 }
 
 func (env *maasEnviron) ReleaseContainerAddresses(interfaces []network.ProviderInterfaceInfo) error {

--- a/provider/maas/environprovider_test.go
+++ b/provider/maas/environprovider_test.go
@@ -146,6 +146,7 @@ func (suite *EnvironProviderSuite) testMAASServerFromEndpoint(c *gc.C, endpoint 
 // up at the end of the test calling this method.
 func createTempFile(c *gc.C, content []byte) string {
 	file, err := ioutil.TempFile(c.MkDir(), "")
+	defer file.Close()
 	c.Assert(err, jc.ErrorIsNil)
 	filename := file.Name()
 	err = ioutil.WriteFile(filename, content, 0644)

--- a/provider/maas/maas2_environ_whitebox_test.go
+++ b/provider/maas/maas2_environ_whitebox_test.go
@@ -1541,14 +1541,14 @@ func getArgs(c *gc.C, calls []testing.StubCall) interface{} {
 	return args[0]
 }
 
-func (suite *maas2EnvironSuite) TestAllocateContainerAddressesCreateDevicerror(c *gc.C) {
+func (suite *maas2EnvironSuite) TestAllocateContainerAddressesCreateDeviceError(c *gc.C) {
 	subnet := makeFakeSubnet(3)
 	var env *maasEnviron
 	machine := &fakeMachine{
 		Stub:     &testing.Stub{},
 		systemID: "1",
 	}
-	machine.SetErrors(nil, errors.New("boom"))
+	machine.SetErrors(nil, errors.New("bad device call"))
 	controller := &fakeController{
 		machines: []gomaasapi.Machine{machine},
 		spaces: []gomaasapi.Space{
@@ -1566,7 +1566,7 @@ func (suite *maas2EnvironSuite) TestAllocateContainerAddressesCreateDevicerror(c
 	}
 	ignored := names.NewMachineTag("1/lxd/0")
 	_, err := env.AllocateContainerAddresses(instance.Id("1"), ignored, prepared)
-	c.Assert(err, gc.ErrorMatches, "boom")
+	c.Assert(err, gc.ErrorMatches, `failed to create MAAS device for "juju-06f00d-1-lxd-0": bad device call`)
 	machine.CheckCall(c, 0, "Devices", gomaasapi.DevicesArgs{
 		Hostname: []string{"juju-06f00d-1-lxd-0"},
 	})

--- a/provider/maas/maas2_environ_whitebox_test.go
+++ b/provider/maas/maas2_environ_whitebox_test.go
@@ -1486,12 +1486,25 @@ func (suite *maas2EnvironSuite) assertAllocateContainerAddressesFails(c *gc.C, c
 }
 
 func (suite *maas2EnvironSuite) TestAllocateContainerAddressesSpacesError(c *gc.C) {
-	controller := &fakeController{spacesError: errors.New("boom")}
+	machine := &fakeMachine{
+		Stub:     &testing.Stub{},
+		systemID: "1",
+	}
+	controller := &fakeController{
+		machines:    []gomaasapi.Machine{machine},
+		spacesError: errors.New("boom"),
+	}
 	suite.assertAllocateContainerAddressesFails(c, controller, nil, "boom")
 }
 
 func (suite *maas2EnvironSuite) TestAllocateContainerAddressesPrimaryInterfaceMissing(c *gc.C) {
-	controller := &fakeController{}
+	machine := &fakeMachine{
+		Stub:     &testing.Stub{},
+		systemID: "1",
+	}
+	controller := &fakeController{
+		machines: []gomaasapi.Machine{machine},
+	}
 	suite.assertAllocateContainerAddressesFails(c, controller, nil, "cannot find primary interface for container")
 }
 
@@ -1706,7 +1719,7 @@ func (suite *maas2EnvironSuite) TestAllocateContainerAddressesCreateInterfaceErr
 	}
 	ignored := names.NewMachineTag("1/lxd/0")
 	_, err := env.AllocateContainerAddresses(instance.Id("1"), ignored, prepared)
-	c.Assert(err, gc.ErrorMatches, "creating device interface: boom")
+	c.Assert(err, gc.ErrorMatches, `failed to create MAAS device for "juju-06f00d-1-lxd-0": creating device interface: boom`)
 	args := getArgs(c, device.Calls())
 	maasArgs, ok := args.(gomaasapi.CreateInterfaceArgs)
 	c.Assert(ok, jc.IsTrue)

--- a/provider/maas/maas2_environ_whitebox_test.go
+++ b/provider/maas/maas2_environ_whitebox_test.go
@@ -910,7 +910,7 @@ func (suite *maas2EnvironSuite) TestStartInstanceNetworkInterfaces(c *gc.C) {
 		MTU:               1500,
 		GatewayAddress:    network.NewAddressOnSpace("default", "10.20.19.2"),
 	}, {
-		DeviceIndex:       0,
+		DeviceIndex:       1,
 		MACAddress:        "52:54:00:70:9b:fe",
 		CIDR:              "10.20.19.0/24",
 		ProviderId:        "91",
@@ -1145,7 +1145,9 @@ func (suite *maas2EnvironSuite) TestAllocateContainerAddressesNoStaticRoutesAPI(
 			children: []string{},
 		},
 	}
+	stub := &testing.Stub{}
 	device := &fakeDevice{
+		Stub:         stub,
 		interfaceSet: deviceInterfaces,
 		systemID:     "foo",
 	}
@@ -1161,9 +1163,9 @@ func (suite *maas2EnvironSuite) TestAllocateContainerAddressesNoStaticRoutesAPI(
 	staticRoutesErr := gomaasapi.NewUnexpectedError(wrap1)
 	var env *maasEnviron
 	controller := &fakeController{
-		Stub: &testing.Stub{},
+		Stub: stub,
 		machines: []gomaasapi.Machine{&fakeMachine{
-			Stub:         &testing.Stub{},
+			Stub:         stub,
 			systemID:     "1",
 			architecture: arch.HostArch(),
 			interfaceSet: interfaces,
@@ -1448,7 +1450,7 @@ func (suite *maas2EnvironSuite) TestAllocateContainerAddressesDualNic(c *gc.C) {
 		MTU:               1500,
 		GatewayAddress:    network.NewAddressOnSpace("freckles", "10.20.19.2"),
 	}, {
-		DeviceIndex:       0,
+		DeviceIndex:       1,
 		MACAddress:        "52:54:00:70:9b:f4",
 		CIDR:              "192.168.1.0/24",
 		ProviderId:        "94",
@@ -1661,6 +1663,7 @@ func (suite *maas2EnvironSuite) TestAllocateContainerAddressesSubnetMissing(c *g
 	allocated, err := env.AllocateContainerAddresses(instance.Id("1"), ignored, prepared)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(allocated, jc.DeepEquals, []network.InterfaceInfo{{
+		DeviceIndex:    0,
 		MACAddress:     "53:54:00:70:9b:ff",
 		ProviderId:     "93",
 		ProviderVLANId: "0",
@@ -1672,6 +1675,7 @@ func (suite *maas2EnvironSuite) TestAllocateContainerAddressesSubnetMissing(c *g
 		ConfigType:     "manual",
 		MTU:            1500,
 	}, {
+		DeviceIndex:    1,
 		MACAddress:     "53:54:00:70:9b:f1",
 		ProviderId:     "94",
 		ProviderVLANId: "0",
@@ -1771,6 +1775,7 @@ func (suite *maas2EnvironSuite) TestAllocateContainerAddressesLinkSubnetError(c 
 	allocated, err := env.AllocateContainerAddresses(instance.Id("1"), ignored, prepared)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(allocated, jc.DeepEquals, []network.InterfaceInfo{{
+		DeviceIndex:      0,
 		CIDR:             "",
 		ProviderId:       "0",
 		ProviderSubnetId: "",
@@ -1783,6 +1788,7 @@ func (suite *maas2EnvironSuite) TestAllocateContainerAddressesLinkSubnetError(c 
 		Disabled:         true,
 		NoAutoStart:      true,
 	}, {
+		DeviceIndex:      1,
 		CIDR:             "",
 		ProviderId:       "0",
 		ProviderSubnetId: "",
@@ -1805,6 +1811,7 @@ func (suite *maas2EnvironSuite) TestAllocateContainerAddressesLinkSubnetError(c 
 	}
 	c.Assert(maasArgs, jc.DeepEquals, expected)
 }
+
 func (suite *maas2EnvironSuite) TestStorageReturnsStorage(c *gc.C) {
 	controller := newFakeController()
 	env := suite.makeEnviron(c, controller)
@@ -1817,6 +1824,334 @@ func (suite *maas2EnvironSuite) TestStorageReturnsStorage(c *gc.C) {
 	// Its environment pointer refers back to its environment.
 	c.Check(specificStorage.environ, gc.Equals, env)
 	c.Check(specificStorage.maasController, gc.Equals, controller)
+}
+
+func (suite *maas2EnvironSuite) TestAllocateContainerReuseExistingDevice(c *gc.C) {
+	stub := &testing.Stub{}
+	vlan1 := fakeVLAN{
+		id:  5001,
+		mtu: 1500,
+	}
+	subnet1 := fakeSubnet{
+		id:         3,
+		space:      "space-1",
+		vlan:       vlan1,
+		gateway:    "10.20.19.2",
+		cidr:       "10.20.19.0/24",
+		dnsServers: []string{"10.20.19.2", "10.20.19.3"},
+	}
+	interfaces := []gomaasapi.Interface{
+		&fakeInterface{
+			id:         91,
+			name:       "eth0",
+			type_:      "physical",
+			enabled:    true,
+			macAddress: "52:54:00:70:9b:fe",
+			vlan:       vlan1,
+			links: []gomaasapi.Link{
+				&fakeLink{
+					id:        436,
+					subnet:    &subnet1,
+					ipAddress: "10.20.19.103",
+					mode:      "static",
+				},
+			},
+			parents: []string{},
+		},
+	}
+	deviceInterfaces := []gomaasapi.Interface{
+		&fakeInterface{
+			id:         93,
+			name:       "eth0",
+			type_:      "physical",
+			enabled:    true,
+			macAddress: "53:54:00:70:9b:ff",
+			vlan:       vlan1,
+			links: []gomaasapi.Link{
+				&fakeLink{
+					id:        480,
+					subnet:    &subnet1,
+					ipAddress: "10.20.19.105",
+					mode:      "static",
+				},
+			},
+			parents: []string{},
+		},
+	}
+	var env *maasEnviron
+	device := &fakeDevice{
+		Stub:         stub,
+		interfaceSet: deviceInterfaces,
+		systemID:     "foo",
+	}
+	controller := &fakeController{
+		Stub: stub,
+		machines: []gomaasapi.Machine{&fakeMachine{
+			Stub:         stub,
+			systemID:     "1",
+			architecture: arch.HostArch(),
+			interfaceSet: interfaces,
+			// Instead of having createDevice return it, Devices()
+			// returns it from the beginning
+			createDevice: nil,
+			devices:      []gomaasapi.Device{device},
+		}},
+		spaces: []gomaasapi.Space{
+			fakeSpace{
+				name:    "space-1",
+				id:      4567,
+				subnets: []gomaasapi.Subnet{subnet1},
+			},
+		},
+		devices: []gomaasapi.Device{device},
+	}
+	suite.injectController(controller)
+	suite.setupFakeTools(c)
+	env = suite.makeEnviron(c, nil)
+
+	prepared := []network.InterfaceInfo{{
+		MACAddress:    "53:54:00:70:9b:ff",
+		CIDR:          "10.20.19.0/24",
+		InterfaceName: "eth0",
+	}}
+	containerTag := names.NewMachineTag("1/lxd/0")
+	result, err := env.AllocateContainerAddresses(instance.Id("1"), containerTag, prepared)
+	c.Assert(err, jc.ErrorIsNil)
+	expected := []network.InterfaceInfo{{
+		DeviceIndex:       0,
+		MACAddress:        "53:54:00:70:9b:ff",
+		CIDR:              "10.20.19.0/24",
+		ProviderId:        "93",
+		ProviderSubnetId:  "3",
+		VLANTag:           0,
+		ProviderVLANId:    "5001",
+		ProviderAddressId: "480",
+		InterfaceName:     "eth0",
+		InterfaceType:     "ethernet",
+		ConfigType:        "static",
+		Address:           network.NewAddressOnSpace("space-1", "10.20.19.105"),
+		DNSServers:        network.NewAddressesOnSpace("space-1", "10.20.19.2", "10.20.19.3"),
+		MTU:               1500,
+		GatewayAddress:    network.NewAddressOnSpace("space-1", "10.20.19.2"),
+		Routes:            []network.Route{},
+	}}
+	c.Assert(result, jc.DeepEquals, expected)
+}
+
+func (suite *maas2EnvironSuite) TestAllocateContainerRefusesReuseInvalidNIC(c *gc.C) {
+	vlan1 := fakeVLAN{
+		id:  5001,
+		mtu: 1500,
+	}
+	vlan2 := fakeVLAN{
+		id:  5002,
+		mtu: 1500,
+	}
+	subnet1 := fakeSubnet{
+		id:         3,
+		space:      "freckles",
+		vlan:       vlan1,
+		gateway:    "10.20.19.2",
+		cidr:       "10.20.19.0/24",
+		dnsServers: []string{"10.20.19.2", "10.20.19.3"},
+	}
+	subnet2 := fakeSubnet{
+		id:         4,
+		space:      "freckles",
+		vlan:       vlan2,
+		gateway:    "192.168.1.1",
+		cidr:       "192.168.1.0/24",
+		dnsServers: []string{"192.168.1.2"},
+	}
+	subnet3 := fakeSubnet{
+		id:         5,
+		space:      "freckles",
+		vlan:       vlan2,
+		gateway:    "192.168.1.1",
+		cidr:       "192.168.2.0/24",
+		dnsServers: []string{"192.168.1.2"},
+	}
+	interfaces := []gomaasapi.Interface{
+		&fakeInterface{
+			id:         91,
+			name:       "eth0",
+			type_:      "physical",
+			enabled:    true,
+			macAddress: "52:54:00:70:9b:fe",
+			vlan:       vlan1,
+			links: []gomaasapi.Link{
+				&fakeLink{
+					id:        436,
+					subnet:    &subnet1,
+					ipAddress: "10.20.19.103",
+					mode:      "static",
+				},
+			},
+			parents: []string{},
+		},
+		&fakeInterface{
+			id:         92,
+			name:       "eth1",
+			type_:      "physical",
+			enabled:    true,
+			macAddress: "52:54:00:70:9b:ff",
+			vlan:       vlan2,
+			links: []gomaasapi.Link{
+				&fakeLink{
+					id:        437,
+					subnet:    &subnet2,
+					ipAddress: "192.168.1.100",
+					mode:      "static",
+				},
+			},
+			parents: []string{},
+		},
+	}
+	badDeviceInterfaces := []gomaasapi.Interface{
+		&fakeInterface{
+			id:         93,
+			name:       "eth0",
+			type_:      "physical",
+			enabled:    true,
+			macAddress: "53:54:00:70:88:aa",
+			vlan:       vlan1,
+			links: []gomaasapi.Link{
+				&fakeLink{
+					id:        480,
+					subnet:    &subnet1,
+					ipAddress: "10.20.19.105",
+					mode:      "static",
+				},
+			},
+			parents: []string{},
+		},
+		// This interface is linked to the wrong subnet
+		&fakeInterface{
+			id:         94,
+			name:       "eth1",
+			type_:      "physical",
+			enabled:    true,
+			macAddress: "53:54:00:70:88:bb",
+			vlan:       vlan1,
+			links: []gomaasapi.Link{
+				&fakeLink{
+					id:        481,
+					subnet:    &subnet3,
+					ipAddress: "192.168.2.100",
+					mode:      "static",
+				},
+			},
+			parents: []string{},
+		},
+	}
+	goodSecondInterface := &fakeInterface{
+		id:         94,
+		name:       "eth1",
+		type_:      "physical",
+		enabled:    true,
+		macAddress: "53:54:00:70:88:bb",
+		vlan:       vlan2,
+		links: []gomaasapi.Link{
+			&fakeLink{
+				id:        481,
+				subnet:    &subnet2,
+				ipAddress: "192.168.1.101",
+				mode:      "static",
+			},
+		},
+		parents: []string{},
+	}
+	goodDeviceInterfaces := []gomaasapi.Interface{
+		badDeviceInterfaces[0],
+	}
+	var env *maasEnviron
+	stub := &testing.Stub{}
+	badDevice := &fakeDevice{
+		Stub:         stub,
+		interfaceSet: badDeviceInterfaces,
+		systemID:     "foo",
+	}
+	goodDevice := &fakeDevice{
+		Stub:         stub,
+		interfaceSet: goodDeviceInterfaces,
+		systemID:     "foo",
+		interface_:   goodSecondInterface,
+	}
+	machine := &fakeMachine{
+		Stub:         stub,
+		systemID:     "1",
+		architecture: arch.HostArch(),
+		interfaceSet: interfaces,
+		createDevice: goodDevice,
+		// Devices will first list the bad device, and then
+		// createDevice will create the right one
+		devices: []gomaasapi.Device{badDevice},
+	}
+	badDevice.deleteCB = func() { machine.devices = machine.devices[:0] }
+	controller := &fakeController{
+		Stub:     stub,
+		machines: []gomaasapi.Machine{machine},
+		spaces: []gomaasapi.Space{
+			fakeSpace{
+				name:    "space-1",
+				id:      4567,
+				subnets: []gomaasapi.Subnet{subnet1},
+			},
+		},
+		// devices:      []gomaasapi.Device{device},
+	}
+	suite.injectController(controller)
+	suite.setupFakeTools(c)
+	env = suite.makeEnviron(c, nil)
+
+	prepared := []network.InterfaceInfo{{
+		MACAddress:    "53:54:00:70:88:aa",
+		CIDR:          "10.20.19.0/24",
+		InterfaceName: "eth0",
+	}, {
+		MACAddress:    "53:54:00:70:88:bb",
+		CIDR:          "192.168.1.0/24",
+		InterfaceName: "eth1",
+	}}
+	containerTag := names.NewMachineTag("1/lxd/0")
+	result, err := env.AllocateContainerAddresses(instance.Id("1"), containerTag, prepared)
+	c.Assert(err, jc.ErrorIsNil)
+	expected := []network.InterfaceInfo{{
+		DeviceIndex:       0,
+		MACAddress:        "53:54:00:70:88:aa",
+		CIDR:              "10.20.19.0/24",
+		ProviderId:        "93",
+		ProviderSubnetId:  "3",
+		VLANTag:           0,
+		ProviderVLANId:    "5001",
+		ProviderAddressId: "480",
+		InterfaceName:     "eth0",
+		InterfaceType:     "ethernet",
+		ConfigType:        "static",
+		Address:           network.NewAddressOnSpace("freckles", "10.20.19.105"),
+		DNSServers:        network.NewAddressesOnSpace("freckles", "10.20.19.2", "10.20.19.3"),
+		MTU:               1500,
+		GatewayAddress:    network.NewAddressOnSpace("freckles", "10.20.19.2"),
+		Routes:            []network.Route{},
+	}, {
+		DeviceIndex:       1,
+		MACAddress:        "53:54:00:70:88:bb",
+		CIDR:              "192.168.1.0/24",
+		ProviderId:        "94",
+		ProviderSubnetId:  "4",
+		VLANTag:           0,
+		ProviderVLANId:    "5002",
+		ProviderAddressId: "481",
+		InterfaceName:     "eth1",
+		InterfaceType:     "ethernet",
+		ConfigType:        "static",
+		Address:           network.NewAddressOnSpace("freckles", "192.168.1.101"),
+		DNSServers:        network.NewAddressesOnSpace("freckles", "192.168.1.2"),
+		MTU:               1500,
+		GatewayAddress:    network.NewAddressOnSpace("freckles", "192.168.1.1"),
+		Routes:            []network.Route{},
+	}}
+	c.Assert(result, jc.DeepEquals, expected)
 }
 
 func (suite *maas2EnvironSuite) TestStartInstanceEndToEnd(c *gc.C) {

--- a/provider/maas/maas2_environ_whitebox_test.go
+++ b/provider/maas/maas2_environ_whitebox_test.go
@@ -910,7 +910,7 @@ func (suite *maas2EnvironSuite) TestStartInstanceNetworkInterfaces(c *gc.C) {
 		MTU:               1500,
 		GatewayAddress:    network.NewAddressOnSpace("default", "10.20.19.2"),
 	}, {
-		DeviceIndex:       1,
+		DeviceIndex:       0,
 		MACAddress:        "52:54:00:70:9b:fe",
 		CIDR:              "10.20.19.0/24",
 		ProviderId:        "91",


### PR DESCRIPTION
## Description of change

When fixing [bug #1670873](pad.lv/1670873), we made it possible for the 'retry' logic of AllocateContainerAddresses to re-use a device that might have been created in the first attempt. However, we only really tested that support with containers that had a single interface. And it turned out our logic around reusing the existing device would do the wrong thing if we wanted multiple interfaces (it would assume it still needed to create all but the primary interface).

This refactors the code quite a bit, but mostly in an attempt to make it easier to understand the logical steps of how we create a device, and populate all of its interfaces.
The main functional change is that we'll now look for an existing device, and then validate if the existing device matches all of the requested network information. If it does, then we will use it, if it doesn't, then we will Delete() it and create it as though it didn't exist.

## QA steps

Ideally we would have a way to inject failure after the point of device registration in MAAS. I don't have amazing ideas here, something around causing LXD to fail to provision, injecting some sort of code that will fail once, but not every time, etc. We should see that containers with multiple network interfaces still continue to be provisioned. We might also be able to test it by allocating a MAAS machine, and then manually issuing a "CreateDevice" call with the name we know we are going to give a container (the name we ask MAAS to use matches the machine id in Juju). We should see that it doesn't use the device that is improperly configured and Deletes it to add the right definition.

## Documentation changes

No

## Bug reference

[lp:1682338](https://bugs.launchpad.net/juju/+bug/1682338)