### PR TITLE
Run action multi

### DIFF
--- a/cmd/juju/action/export_test.go
+++ b/cmd/juju/action/export_test.go
@@ -29,8 +29,8 @@ type RunCommand struct {
 	*runCommand
 }
 
-func (c *RunCommand) UnitTag() names.UnitTag {
-	return c.unitTag
+func (c *RunCommand) UnitTags() []names.UnitTag {
+	return c.unitTags
 }
 
 func (c *RunCommand) ActionName() string {

--- a/cmd/juju/action/package_test.go
+++ b/cmd/juju/action/package_test.go
@@ -27,6 +27,7 @@ const (
 	validActionId          = "f47ac10b-58cc-4372-a567-0e02b2c3d479"
 	invalidActionId        = "f47ac10b-58cc-4372-a567-0e02b2c3d47"
 	validUnitId            = "mysql/0"
+	validUnitId2           = "mysql/1"
 	invalidUnitId          = "something-strange-"
 	validServiceId         = "mysql"
 	invalidServiceId       = "something-strange-"

--- a/cmd/juju/action/run.go
+++ b/cmd/juju/action/run.go
@@ -30,7 +30,7 @@ func NewRunCommand() cmd.Command {
 // params
 type runCommand struct {
 	ActionCommandBase
-	unitTag      names.UnitTag
+	unitTags     []names.UnitTag
 	actionName   string
 	paramsYAML   cmd.FileVar
 	parseStrings bool
@@ -133,53 +133,54 @@ func (c *runCommand) SetFlags(f *gnuflag.FlagSet) {
 func (c *runCommand) Info() *cmd.Info {
 	return &cmd.Info{
 		Name:    "run-action",
-		Args:    "<unit> <action name> [key.key.key...=value]",
+		Args:    "<unit> [<unit> ...] <action name> [key.key.key...=value]",
 		Purpose: "Queue an action for execution.",
 		Doc:     runDoc,
 	}
 }
 
-// Init gets the unit tag, and checks for other correct args.
+// Init gets the unit tag(s), action name and action arguments.
 func (c *runCommand) Init(args []string) error {
-	switch len(args) {
-	case 0:
-		return errors.New("no unit specified")
-	case 1:
-		return errors.New("no action specified")
-	default:
-		// Grab and verify the unit and action names.
-		unitName := args[0]
-		if !names.IsValidUnit(unitName) {
-			return errors.Errorf("invalid unit name %q", unitName)
+	var unitNames []string
+	for idx, arg := range args {
+		if names.IsValidUnit(arg) {
+			unitNames = args[:idx+1]
+		} else if ActionNameRule.MatchString(arg) {
+			c.actionName = arg
+			break
+		} else {
+			return errors.Errorf("invalid unit or action name %q", arg)
 		}
-		ActionName := args[1]
-		if valid := ActionNameRule.MatchString(ActionName); !valid {
-			return errors.Errorf("invalid action name %q", ActionName)
-		}
-		c.unitTag = names.NewUnitTag(unitName)
-		c.actionName = ActionName
-		if len(args) == 2 {
-			return nil
-		}
-		// Parse CLI key-value args if they exist.
-		c.args = make([][]string, 0)
-		for _, arg := range args[2:] {
-			thisArg := strings.SplitN(arg, "=", 2)
-			if len(thisArg) != 2 {
-				return errors.Errorf("argument %q must be of the form key...=value", arg)
-			}
-			keySlice := strings.Split(thisArg[0], ".")
-			// check each key for validity
-			for _, key := range keySlice {
-				if valid := keyRule.MatchString(key); !valid {
-					return errors.Errorf("key %q must start and end with lowercase alphanumeric, and contain only lowercase alphanumeric and hyphens", key)
-				}
-			}
-			// c.args={..., [key, key, key, key, value]}
-			c.args = append(c.args, append(keySlice, thisArg[1]))
-		}
-		return nil
 	}
+	if len(unitNames) == 0 {
+		return errors.New("no unit specified")
+	}
+	if c.actionName == "" {
+		return errors.New("no action specified")
+	}
+	c.unitTags = make([]names.UnitTag, len(unitNames))
+	for idx, unitName := range unitNames {
+		c.unitTags[idx] = names.NewUnitTag(unitName)
+	}
+
+	// Parse CLI key-value args if they exist.
+	c.args = make([][]string, 0)
+	for _, arg := range args[len(unitNames)+1:] {
+		thisArg := strings.SplitN(arg, "=", 2)
+		if len(thisArg) != 2 {
+			return errors.Errorf("argument %q must be of the form key...=value", arg)
+		}
+		keySlice := strings.Split(thisArg[0], ".")
+		// check each key for validity
+		for _, key := range keySlice {
+			if valid := keyRule.MatchString(key); !valid {
+				return errors.Errorf("key %q must start and end with lowercase alphanumeric, and contain only lowercase alphanumeric and hyphens", key)
+			}
+		}
+		// c.args={..., [key, key, key, key, value]}
+		c.args = append(c.args, append(keySlice, thisArg[1]))
+	}
+	return nil
 }
 
 func (c *runCommand) Run(ctx *cmd.Context) error {
@@ -242,42 +243,61 @@ func (c *runCommand) Run(ctx *cmd.Context) error {
 		return errors.Errorf("params must be a map, got %T", typedConformantParams)
 	}
 
-	actionParam := params.Actions{
-		Actions: []params.Action{{
-			Receiver:   c.unitTag.String(),
-			Name:       c.actionName,
-			Parameters: actionParams,
-		}},
+	actions := make([]params.Action, len(c.unitTags))
+	for i, unitTag := range c.unitTags {
+		actions[i].Receiver = unitTag.String()
+		actions[i].Name = c.actionName
+		actions[i].Parameters = actionParams
 	}
-
-	results, err := api.Enqueue(actionParam)
+	results, err := api.Enqueue(params.Actions{Actions: actions})
 	if err != nil {
 		return err
 	}
-	if len(results.Results) != 1 {
+
+	if len(results.Results) != len(c.unitTags) {
 		return errors.New("illegal number of results returned")
 	}
 
-	result := results.Results[0]
+	for _, result := range results.Results {
+		if result.Error != nil {
+			return result.Error
+		}
+		if result.Action == nil {
+			return errors.Errorf("action failed to enqueue on %q", result.Action.Receiver)
+		}
+		tag, err := names.ParseActionTag(result.Action.Tag)
+		if err != nil {
+			return err
+		}
 
-	if result.Error != nil {
-		return result.Error
+		// Legacy Juju 1.25 output format for a single unit, no wait.
+		if !c.wait.forever && c.wait.d.Nanoseconds() <= 0 && len(results.Results) == 1 {
+			output := map[string]string{"Action queued with id": tag.Id()}
+			return c.out.Write(ctx, output)
+		}
 	}
 
-	if result.Action == nil {
-		return errors.New("action failed to enqueue")
-	}
+	output := make(map[string]interface{}, len(results.Results))
 
-	tag, err := names.ParseActionTag(result.Action.Tag)
-	if err != nil {
-		return err
-	}
-
+	// Immediate return. This is the default, although rarely
+	// what cli users want. We should consider changing this
+	// default with Juju 3.0.
 	if !c.wait.forever && c.wait.d.Nanoseconds() <= 0 {
-		// Immediate return. This is the default, although rarely
-		// what cli users want. We should consider changing this
-		// default with Juju 3.0.
-		output := map[string]string{"Action queued with id": tag.Id()}
+		for _, result := range results.Results {
+			output[result.Action.Receiver] = result.Action.Tag
+			actionTag, err := names.ParseActionTag(result.Action.Tag)
+			if err != nil {
+				return err
+			}
+			unitTag, err := names.ParseUnitTag(result.Action.Receiver)
+			if err != nil {
+				return err
+			}
+			output[result.Action.Receiver] = map[string]string{
+				"id":   actionTag.Id(),
+				"unit": unitTag.Id(),
+			}
+		}
 		return c.out.Write(ctx, output)
 	}
 
@@ -290,11 +310,23 @@ func (c *runCommand) Run(ctx *cmd.Context) error {
 		wait = time.NewTimer(c.wait.d)
 	}
 
-	result, err = GetActionResult(api, tag.Id(), wait)
-	if err != nil {
-		return errors.Trace(err)
+	for _, result := range results.Results {
+		tag, err := names.ParseActionTag(result.Action.Tag)
+		if err != nil {
+			return err
+		}
+		result, err = GetActionResult(api, tag.Id(), wait)
+		if err != nil {
+			return errors.Trace(err)
+		}
+		unitTag, err := names.ParseUnitTag(result.Action.Receiver)
+		if err != nil {
+			return err
+		}
+		d := FormatActionResult(result)
+		d["id"] = tag.Id()       // Action ID is required in case we timed out.
+		d["unit"] = unitTag.Id() // Formatted unit is nice to have.
+		output[result.Action.Receiver] = d
 	}
-	output := FormatActionResult(result)
-	output["action-id"] = tag.Id() // Action ID is required in case we timed out.
 	return c.out.Write(ctx, output)
 }

--- a/cmd/juju/action/run_test.go
+++ b/cmd/juju/action/run_test.go
@@ -79,6 +79,20 @@ func (s *RunSuite) TestInit(c *gc.C) {
 		args:        []string{invalidUnitId, "valid-action-name"},
 		expectError: "invalid unit or action name \"something-strange-\"",
 	}, {
+		should:      "fail with invalid unit tag first",
+		args:        []string{validUnitId, invalidUnitId, "valid-action-name"},
+		expectError: "invalid unit or action name \"something-strange-\"",
+	}, {
+		should:      "fail with invalid unit tag second",
+		args:        []string{invalidUnitId, validUnitId, "valid-action-name"},
+		expectError: "invalid unit or action name \"something-strange-\"",
+	}, {
+		should:       "work with multiple valid units",
+		args:         []string{validUnitId, validUnitId2, "valid-action-name"},
+		expectUnits:  []names.UnitTag{names.NewUnitTag(validUnitId), names.NewUnitTag(validUnitId2)},
+		expectAction: "valid-action-name",
+		expectKVArgs: [][]string{},
+	}, {}, {
 		should:      "fail with invalid action name",
 		args:        []string{validUnitId, "BadName"},
 		expectError: "invalid unit or action name \"BadName\"",

--- a/cmd/juju/action/run_test.go
+++ b/cmd/juju/action/run_test.go
@@ -59,7 +59,7 @@ func (s *RunSuite) TestInit(c *gc.C) {
 	tests := []struct {
 		should               string
 		args                 []string
-		expectUnit           names.UnitTag
+		expectUnits          []names.UnitTag
 		expectAction         string
 		expectParamsYamlPath string
 		expectParseStrings   bool
@@ -77,11 +77,11 @@ func (s *RunSuite) TestInit(c *gc.C) {
 	}, {
 		should:      "fail with invalid unit tag",
 		args:        []string{invalidUnitId, "valid-action-name"},
-		expectError: "invalid unit name \"something-strange-\"",
+		expectError: "invalid unit or action name \"something-strange-\"",
 	}, {
 		should:      "fail with invalid action name",
 		args:        []string{validUnitId, "BadName"},
-		expectError: "invalid action name \"BadName\"",
+		expectError: "invalid unit or action name \"BadName\"",
 	}, {
 		should:      "fail with wrong formatting of k-v args",
 		args:        []string{validUnitId, "valid-action-name", "uh"},
@@ -97,31 +97,31 @@ func (s *RunSuite) TestInit(c *gc.C) {
 	}, {
 		should:       "work with empty values",
 		args:         []string{validUnitId, "valid-action-name", "ok="},
-		expectUnit:   names.NewUnitTag(validUnitId),
+		expectUnits:  []names.UnitTag{names.NewUnitTag(validUnitId)},
 		expectAction: "valid-action-name",
 		expectKVArgs: [][]string{{"ok", ""}},
 	}, {
 		should:             "handle --parse-strings",
 		args:               []string{validUnitId, "valid-action-name", "--string-args"},
-		expectUnit:         names.NewUnitTag(validUnitId),
+		expectUnits:        []names.UnitTag{names.NewUnitTag(validUnitId)},
 		expectAction:       "valid-action-name",
 		expectParseStrings: true,
 	}, {
 		// cf. worker/uniter/runner/jujuc/action-set_test.go per @fwereade
 		should:       "work with multiple '=' signs",
 		args:         []string{validUnitId, "valid-action-name", "ok=this=is=weird="},
-		expectUnit:   names.NewUnitTag(validUnitId),
+		expectUnits:  []names.UnitTag{names.NewUnitTag(validUnitId)},
 		expectAction: "valid-action-name",
 		expectKVArgs: [][]string{{"ok", "this=is=weird="}},
 	}, {
 		should:       "init properly with no params",
 		args:         []string{validUnitId, "valid-action-name"},
-		expectUnit:   names.NewUnitTag(validUnitId),
+		expectUnits:  []names.UnitTag{names.NewUnitTag(validUnitId)},
 		expectAction: "valid-action-name",
 	}, {
 		should:               "handle --params properly",
 		args:                 []string{validUnitId, "valid-action-name", "--params=foo.yml"},
-		expectUnit:           names.NewUnitTag(validUnitId),
+		expectUnits:          []names.UnitTag{names.NewUnitTag(validUnitId)},
 		expectAction:         "valid-action-name",
 		expectParamsYamlPath: "foo.yml",
 	}, {
@@ -134,7 +134,7 @@ func (s *RunSuite) TestInit(c *gc.C) {
 			"foo.baz.bo=3",
 			"bar.foo=hello",
 		},
-		expectUnit:           names.NewUnitTag(validUnitId),
+		expectUnits:          []names.UnitTag{names.NewUnitTag(validUnitId)},
 		expectAction:         "valid-action-name",
 		expectParamsYamlPath: "foo.yml",
 		expectKVArgs: [][]string{
@@ -151,7 +151,7 @@ func (s *RunSuite) TestInit(c *gc.C) {
 			"foo.baz.bo=y",
 			"bar.foo=hello",
 		},
-		expectUnit:   names.NewUnitTag(validUnitId),
+		expectUnits:  []names.UnitTag{names.NewUnitTag(validUnitId)},
 		expectAction: "valid-action-name",
 		expectKVArgs: [][]string{
 			{"foo", "bar", "2"},
@@ -168,7 +168,7 @@ func (s *RunSuite) TestInit(c *gc.C) {
 			args := append([]string{modelFlag, "admin"}, t.args...)
 			err := cmdtesting.InitCommand(wrappedCommand, args)
 			if t.expectError == "" {
-				c.Check(command.UnitTag(), gc.Equals, t.expectUnit)
+				c.Check(command.UnitTags(), gc.DeepEquals, t.expectUnits)
 				c.Check(command.ActionName(), gc.Equals, t.expectAction)
 				c.Check(command.ParamsYAML().Path, gc.Equals, t.expectParamsYamlPath)
 				c.Check(command.Args(), jc.DeepEquals, t.expectKVArgs)


### PR DESCRIPTION
## Description of change

Extends the cli to allow running an action on multiple units.

In addition to charms where this is useful (eg. PostgreSQL, to control replication on all standby units at the same time), it makes way to run actions on all units (eg. Cassandra, to report cluster health on all units).

## QA steps

The following commands have unchanged results:
```sh
    juju run-action postgresql/0 pause-replication
    juju run-action postgresql/0 pause-replication --wait
```
The following now work, returning details of all units affected:
```sh
    juju run-action postgresql/0 postgresql/1 pause-replication
    juju run-action postgresql/0 postgresql/1 pause-replication --wait
```

## Documentation changes

It extends the existing cli. Generated cli documentation will pick up the change. I did not add any specific examples with multiple units as there are already quite a lot and felt it would make things worse.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1667213
