### PR TITLE
provider/maas: use block device id_path

### DIFF
--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -28,7 +28,7 @@ github.com/juju/go4	git	40d72ab9641a2a8c36a9c46a51e28367115c8e59	2016-02-22T16:3
 github.com/juju/gojsonpointer	git	afe8b77aa08f272b49e01b82de78510c11f61500	2015-02-04T19:46:29Z
 github.com/juju/gojsonreference	git	f0d24ac5ee330baa21721cdff56d45e4ee42628e	2015-02-04T19:46:33Z
 github.com/juju/gojsonschema	git	e1ad140384f254c82f89450d9a7c8dd38a632838	2015-03-12T17:00:16Z
-github.com/juju/gomaasapi	git	985fb1ceb89e7371c592691b502b98eb85ec82b8	2017-04-06T00:25:07Z
+github.com/juju/gomaasapi	git	38cd919ffb22103d167294b29b2c81653ece8eb2	2017-04-18T06:39:07Z
 github.com/juju/httpprof	git	14bf14c307672fd2456bdbf35d19cf0ccd3cf565	2014-12-17T16:00:36Z
 github.com/juju/httprequest	git	266fd1e9debf09c037a63f074d099a2da4559ece	2016-10-06T15:09:09Z
 github.com/juju/idmclient	git	4dc25171f675da4206b71695d3fd80e519ad05c1	2017-02-09T16:27:49Z

--- a/provider/maas/maas2_test.go
+++ b/provider/maas/maas2_test.go
@@ -541,17 +541,17 @@ func (f *fakeFile) ReadAll() ([]byte, error) {
 
 type fakeBlockDevice struct {
 	gomaasapi.BlockDevice
-	name string
-	path string
-	size uint64
+	name   string
+	idPath string
+	size   uint64
 }
 
 func (bd fakeBlockDevice) Name() string {
 	return bd.name
 }
 
-func (bd fakeBlockDevice) Path() string {
-	return bd.path
+func (bd fakeBlockDevice) IDPath() string {
+	return bd.idPath
 }
 
 func (bd fakeBlockDevice) Size() uint64 {

--- a/provider/maas/volumes.go
+++ b/provider/maas/volumes.go
@@ -314,33 +314,65 @@ func (mi *maas2Instance) volumes(
 		if label == rootDiskLabel {
 			continue
 		}
+
 		// We only care about the volumes we specifically asked for.
 		if !validVolumes.Contains(label) {
 			continue
 		}
 
-		for _, device := range devices {
-			volumeTag := names.NewVolumeTag(label)
-			vol := storage.Volume{
-				volumeTag,
-				storage.VolumeInfo{
-					VolumeId:   volumeTag.String(),
-					Size:       uint64(device.Size() / humanize.MiByte),
-					Persistent: false,
-				},
-			}
-			volumes = append(volumes, vol)
-
-			attachment := storage.VolumeAttachment{
-				volumeTag,
-				mTag,
-				storage.VolumeAttachmentInfo{
-					DeviceLink: device.Path(),
-					ReadOnly:   false,
-				},
-			}
-			attachments = append(attachments, attachment)
+		// There should be exactly one block device per label.
+		if len(devices) == 0 {
+			continue
+		} else if len(devices) > 0 {
+			// This should never happen, as we only request one block
+			// device per label. If it does happen, we'll just report
+			// the first block device and log this warning.
+			logger.Warningf(
+				"expected 1 block device for label %s, received %d",
+				label, len(devices),
+			)
 		}
+
+		device := devices[0]
+		volumeTag := names.NewVolumeTag(label)
+		vol := storage.Volume{
+			volumeTag,
+			storage.VolumeInfo{
+				VolumeId:   volumeTag.String(),
+				Size:       uint64(device.Size() / humanize.MiByte),
+				Persistent: false,
+			},
+		}
+		attachment := storage.VolumeAttachment{
+			volumeTag,
+			mTag,
+			storage.VolumeAttachmentInfo{
+				ReadOnly: false,
+			},
+		}
+
+		const devDiskByIdPrefix = "/dev/disk/by-id/"
+		const devPrefix = "/dev/"
+
+		idPath := device.IDPath()
+		if idPath == devPrefix+device.Name() {
+			// On vMAAS (i.e. with virtio), the device name
+			// will be stable, and is what is used to form
+			// id_path.
+			deviceName := idPath[len(devPrefix):]
+			attachment.DeviceName = deviceName
+		} else if strings.HasPrefix(idPath, devDiskByIdPrefix) {
+			hardwareId := idPath[len(devDiskByIdPrefix):]
+			vol.HardwareId = hardwareId
+		} else {
+			// It's neither /dev/<name> nor /dev/disk/by-id/<hardware-id>,
+			// so set it as the device link and hope for
+			// the best. At worst, the path won't exist
+			// and the storage will remain pending.
+			attachment.DeviceLink = idPath
+		}
+		volumes = append(volumes, vol)
+		attachments = append(attachments, attachment)
 	}
 	return volumes, attachments, nil
 }

--- a/provider/maas/volumes_test.go
+++ b/provider/maas/volumes_test.go
@@ -79,14 +79,16 @@ func (s *volumeSuite) TestInstanceVolumesMAAS2(c *gc.C) {
 		machine: &fakeMachine{},
 		constraintMatches: gomaasapi.ConstraintMatches{
 			Storage: map[string][]gomaasapi.BlockDevice{
-				"root": {&fakeBlockDevice{name: "sda", path: "/dev/disk/by-dname/sda", size: 250059350016}},
-				"1":    {&fakeBlockDevice{name: "sdb", path: "/dev/disk/by-dname/sdb", size: 500059350016}},
-				"2": {
-					&fakeBlockDevice{name: "sdc", path: "/dev/disk/by-dname/sdc", size: 250362438230},
-					&fakeBlockDevice{name: "sdf", path: "/dev/disk/by-dname/sdf", size: 280362438231},
+				"root": {&fakeBlockDevice{name: "sda", idPath: "/dev/disk/by-dname/sda", size: 250059350016}},
+				"1":    {&fakeBlockDevice{name: "sdb", idPath: "/dev/sdb", size: 500059350016}},
+				"2":    {&fakeBlockDevice{name: "sdc", idPath: "/dev/disk/by-id/foo", size: 250362438230}},
+				"3": {
+					&fakeBlockDevice{name: "sdd", idPath: "/dev/disk/by-dname/sdd", size: 250362438230},
+					&fakeBlockDevice{name: "sde", idPath: "/dev/disk/by-dname/sde", size: 250362438230},
 				},
-				"3": {&fakeBlockDevice{name: "sdd", path: "/dev/disk/by-dname/sdd", size: 250362438230}},
-				"4": {&fakeBlockDevice{name: "sde", path: "/dev/disk/by-dname/sde", size: 250362438230}},
+				"4": {
+					&fakeBlockDevice{name: "sdf", idPath: "/dev/disk/by-dname/sdf", size: 280362438231},
+				},
 			},
 		},
 	}
@@ -94,53 +96,48 @@ func (s *volumeSuite) TestInstanceVolumesMAAS2(c *gc.C) {
 	volumes, attachments, err := instance.volumes(mTag, []names.VolumeTag{
 		names.NewVolumeTag("1"),
 		names.NewVolumeTag("2"),
+		names.NewVolumeTag("3"),
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	// Expect 3 volumes - root volume is ignored.
+	// Expect 3 volumes - root volume is ignored, as are volumes
+	// with tags we did not request.
 	c.Assert(volumes, gc.HasLen, 3)
 	c.Assert(attachments, gc.HasLen, 3)
 	c.Check(volumes, jc.SameContents, []storage.Volume{{
 		names.NewVolumeTag("1"),
 		storage.VolumeInfo{
-			VolumeId:   "volume-1",
-			Size:       476893,
-			Persistent: false,
+			VolumeId: "volume-1",
+			Size:     476893,
 		},
 	}, {
 		names.NewVolumeTag("2"),
 		storage.VolumeInfo{
 			VolumeId:   "volume-2",
 			Size:       238764,
-			Persistent: false,
+			HardwareId: "foo",
 		},
 	}, {
-		names.NewVolumeTag("2"),
+		names.NewVolumeTag("3"),
 		storage.VolumeInfo{
-			VolumeId:   "volume-2",
-			Size:       267374,
-			Persistent: false,
+			VolumeId: "volume-3",
+			Size:     238764,
 		},
 	}})
 	c.Assert(attachments, jc.SameContents, []storage.VolumeAttachment{{
 		names.NewVolumeTag("1"),
 		mTag,
 		storage.VolumeAttachmentInfo{
-			DeviceLink: "/dev/disk/by-dname/sdb",
-			ReadOnly:   false,
+			DeviceName: "sdb",
 		},
 	}, {
 		names.NewVolumeTag("2"),
 		mTag,
-		storage.VolumeAttachmentInfo{
-			DeviceLink: "/dev/disk/by-dname/sdc",
-			ReadOnly:   false,
-		},
+		storage.VolumeAttachmentInfo{},
 	}, {
-		names.NewVolumeTag("2"),
+		names.NewVolumeTag("3"),
 		mTag,
 		storage.VolumeAttachmentInfo{
-			DeviceLink: "/dev/disk/by-dname/sdf",
-			ReadOnly:   false,
+			DeviceLink: "/dev/disk/by-dname/sdd",
 		},
 	}})
 }


### PR DESCRIPTION
## Description of change

When using MAAS 1.x, we use use the block
device id_path attribute to identify its
hardware ID. If that is not available, we
fall over to "name" (i.e. the device name),
which will be set for virtio devices.

With MAAS 2.x, we have been using the "path"
attribute, which turns out to be set with
paths that do not really exist, or perhaps
depend on the kernel version. Anyway, the
MAAS docs say that id_path should not change
depending on the kernel version, so we will
now use that with both MAAS 1.x and 2.x.

## QA steps

1. juju bootstrap maas (I used finfolk-vmaas)2
2. juju deploy ~axwalk/storagetest --storage filesystem=maas,1G
3. verify the storage status eventually becomes "attached"

## Documentation changes

None.

## Bug reference

Fixes https://bugs.launchpad.net/juju/+bug/1677001