### PR TITLE
WIP: 2.2 prune presence 1454661

### DIFF
--- a/state/presence/export_test.go
+++ b/state/presence/export_test.go
@@ -20,7 +20,3 @@ var realPeriod = period
 func RealPeriod() {
 	period = realPeriod
 }
-
-func FindAllBeings(w *Watcher) (map[int64]beingInfo, error) {
-	return w.findAllBeings()
-}

--- a/state/presence/presence.go
+++ b/state/presence/presence.go
@@ -424,7 +424,6 @@ func (w *Watcher) lookupPings(session *mgo.Session) ([]pingInfo, error) {
 	return lookupPings(pings, w.modelUUID, time.Now(), w.delta)
 }
 
-
 func lookupPings(pings *mgo.Collection, modelUUID string, ts time.Time, delta time.Duration) ([]pingInfo, error) {
 	// TODO(perrito666) 2016-05-02 lp:1558657
 	s := timeSlot(ts, delta)
@@ -507,7 +506,7 @@ func deadSeqs(pings []pingInfo) ([]int64, error) {
 	return decompressPings(maps)
 }
 
-func (w *Watcher) handleAlive(pings []pingInfo) (map[int64]bool, []int64, error){
+func (w *Watcher) handleAlive(pings []pingInfo) (map[int64]bool, []int64, error) {
 	// Learn about all the pingers that reported and queue
 	// events for those that weren't known to be alive and
 	// are not reportedly dead either.
@@ -534,7 +533,7 @@ func (w *Watcher) handleAlive(pings []pingInfo) (map[int64]bool, []int64, error)
 
 // lookupUnknownSeqs handles finding new sequences that we weren't already tracking.
 // Keys that we find are now alive will have a 'found alive' event queued.
-func (w* Watcher) lookupUnknownSeqs(unknownSeqs []int64, dead map[int64]bool, session *mgo.Session) error {
+func (w *Watcher) lookupUnknownSeqs(unknownSeqs []int64, dead map[int64]bool, session *mgo.Session) error {
 	if len(unknownSeqs) == 0 {
 		// Nothing to do, with nothing unknown.
 		return nil
@@ -579,7 +578,7 @@ func (w* Watcher) lookupUnknownSeqs(unknownSeqs []int64, dead map[int64]bool, se
 	rate := ""
 	elapsed := time.Since(startTime)
 	if len(unknownSeqs) > 0 {
-		seqPerMS :=  float64(len(unknownSeqs)) / (elapsed.Seconds() * 1000.0)
+		seqPerMS := float64(len(unknownSeqs)) / (elapsed.Seconds() * 1000.0)
 		rate = fmt.Sprintf(" (%.1fseq/ms)", seqPerMS)
 	}
 	unownedCount := 0
@@ -889,10 +888,9 @@ func (p *Pinger) ping() (err error) {
 // collapsedBeingsInfo tracks the result of aggregating all of the items in the
 // beings table by their key.
 type collapsedBeingsInfo struct {
-	Key    string   `bson:"_id"`
-	Seqs    []int64 `bson:"seqs"`
+	Key  string  `bson:"_id"`
+	Seqs []int64 `bson:"seqs"`
 }
-
 
 // clockDelta returns the approximate skew between
 // the local clock and the database clock.

--- a/state/presence/presence.go
+++ b/state/presence/presence.go
@@ -935,7 +935,8 @@ func (p *BeingPruner) removeOldPings() error {
 	if err != nil {
 		return err
 	}
-	logger.Tracef("pruning %q starting with %d docs", p.pingsC.Name, startCount)
+	logger.Tracef("pruning %q for %q starting with %d docs",
+		p.pingsC.Name, p.modelUUID, startCount)
 	s := timeSlot(time.Now(), p.delta)
 	oldSlot := s - 3*period
 	res, err := p.pingsC.RemoveAll(bson.D{{"_id", bson.RegEx{"^" + p.modelUUID, ""}},
@@ -945,8 +946,8 @@ func (p *BeingPruner) removeOldPings() error {
 		return err
 	}
 	endCount, _ := p.pingsC.Count()
-	logger.Debugf("pruned %q (with %d docs) of %d old pings down to %d docs in %v",
-		p.pingsC.Name, startCount, res.Removed, endCount, time.Since(startTime))
+	logger.Debugf("pruned %q for %q (with %d docs) of %d old pings down to %d docs in %v",
+		p.pingsC.Name, p.modelUUID, startCount, res.Removed, endCount, time.Since(startTime))
 	return nil
 }
 
@@ -956,7 +957,8 @@ func (p *BeingPruner) removeUnusedBeings() error {
 	if err != nil {
 		return err
 	}
-	logger.Tracef("pruning %q starting with %d docs", p.beingsC.Name, startCount)
+	logger.Tracef("pruning %q for %q starting with %d docs",
+		p.beingsC.Name, p.modelUUID, startCount)
 	startTime := time.Now()
 	keyCount := 0
 	seqCount := 0
@@ -991,8 +993,8 @@ func (p *BeingPruner) removeUnusedBeings() error {
 	if err := iter.Close(); err != nil {
 		return err
 	}
-	logger.Debugf("pruned %q (with %d docs) of %d sequence keys (evaluated %d) from %d keys in %v",
-		p.beingsC.Name, startCount, p.removedCount, seqCount, keyCount, time.Since(startTime))
+	logger.Debugf("pruned %q for %q (with %d docs) of %d sequence keys (evaluated %d) from %d keys in %v",
+		p.beingsC.Name, p.modelUUID, startCount, p.removedCount, seqCount, keyCount, time.Since(startTime))
 	return nil
 }
 

--- a/state/presence/presence.go
+++ b/state/presence/presence.go
@@ -931,6 +931,8 @@ func (p *BeingPruner) removeOldPings() error {
 	// now and now-period are both considered active slots, so we don't
 	// touch those. We also leave 2 more slots around
 	startTime := time.Now()
+	// TODO(jam): 2017-04-18 startCount may not be appropriate, because
+	// Count() includes all models, not just the one we are pruning
 	startCount, err := p.pingsC.Count()
 	if err != nil {
 		return err
@@ -953,6 +955,8 @@ func (p *BeingPruner) removeOldPings() error {
 
 func (p *BeingPruner) removeUnusedBeings() error {
 	var keyInfo collapsedBeingsInfo
+	// TODO(jam): 2017-04-18 startCount may not be appropriate, because
+	// Count() includes all models, not just the one we are pruning
 	startCount, err := p.beingsC.Count()
 	if err != nil {
 		return err

--- a/state/presence/presence.go
+++ b/state/presence/presence.go
@@ -739,7 +739,7 @@ func (p *Pinger) ping() (err error) {
 		}
 		p.delta = delta
 	}
-	// TODO(perrito666) 2016-05-02 lp:1558657
+	// TODO(perrito667) 2016-05-02 lp:1558657
 	slot := timeSlot(time.Now(), p.delta)
 	if slot == p.lastSlot {
 		// Never, ever, ping the same slot twice.
@@ -755,6 +755,124 @@ func (p *Pinger) ping() (err error) {
 			{"$inc", bson.D{{"alive." + p.fieldKey, p.fieldBit}}},
 		})
 	return errors.Trace(err)
+}
+
+// collapsedBeingsInfo tracks the result of aggregating all of the items in the
+// beings table by their key.
+type collapsedBeingsInfo struct {
+	Key    string   `bson:"_id"`
+	Seqs    []int64 `bson:"seqs"`
+}
+
+
+// OldBeingPruner tracks the state of removing unworthy beings from the
+// presence.beings collection. Being sequences are unworthy once their sequence
+// has been superseded.
+type OldBeingPruner struct {
+	modelUUID string
+	beingsC *mgo.Collection
+	toRemove []string
+	maxQueue int
+	removedCount uint64
+}
+
+// iterKeys is returns an iterator of Keys from this modelUUId and what Sequences
+// are in use to represent them.
+func (p *OldBeingPruner) iterKeys() *mgo.Iter {
+	thisModelRegex := bson.M{"_id": bson.M{"$regex": bson.RegEx{"^" + p.modelUUID, ""}}}
+	pipe := p.beingsC.Pipe([]bson.M{
+		// Grab all sequences for this model
+		{"$match": thisModelRegex},
+		// We don't need the _id
+		{"$project": bson.M{"_id": 0, "seq": 1, "key": 1}},
+		// Group all the sequences by their key.
+		{"$group": bson.M{
+			"_id":    "$key",
+			"seqs":    bson.M{"$push": "$seq"},
+		}},
+		// Filter out any keys that have only a single sequence
+		// representing them
+		// {"$match": bson.M{"seqs.1": bson.M{"$exists": 1}}},
+	})
+	return pipe.Iter()
+}
+
+// queueRemoval includes this sequence as one that has been superseded
+func (p *OldBeingPruner) queueRemoval(seq int64) {
+	p.toRemove = append(p.toRemove, docIDInt64(p.modelUUID, seq))
+}
+
+// flushRemovals makes sure that we've applied all desired removals
+func (p *OldBeingPruner) flushRemovals() error {
+	if len(p.toRemove) == 0 {
+		return nil
+	}
+	matched, err := p.beingsC.RemoveAll(bson.M{"_id": bson.M{"$in": p.toRemove}})
+	p.toRemove = p.toRemove[:0]
+	if matched.Removed > 0 {
+		p.removedCount += uint64(matched.Removed)
+	}
+	return err
+}
+
+// Prune removes beings from the beings collection that have been superseded by
+// another entry with a higher sequence. It does *not* attempt to remove beings that
+// have not been referenced by recent pings.
+func (p *OldBeingPruner) Prune() error {
+	var keyInfo collapsedBeingsInfo
+	count, err := p.beingsC.Count()
+	if err != nil {
+		return err
+	}
+	startTime := time.Now()
+	logger.Debugf("Pruning %q, starting with %d being sequences", p.beingsC.Name, count)
+	keyCount := 0
+	iter := p.iterKeys()
+	for iter.Next(&keyInfo) {
+		keyCount += 1
+		if len(keyInfo.Seqs) <= 1 {
+			continue
+		}
+		// Find the max
+		maxSeq := int64(-1)
+		for _, seq := range keyInfo.Seqs {
+			if seq > maxSeq {
+				maxSeq = seq
+			}
+		}
+		// Queue everything < max to be deleted
+		for _, seq := range keyInfo.Seqs {
+			if seq >= maxSeq {
+				// It shouldn't be possible to be > at this point
+				continue
+			}
+			p.queueRemoval(seq)
+			if len(p.toRemove) > p.maxQueue {
+				if err := p.flushRemovals(); err != nil {
+					return err
+				}
+			}
+		}
+	}
+	if err := p.flushRemovals(); err != nil {
+		return err
+	}
+	if err := iter.Close(); err != nil {
+		return err
+	}
+	logger.Debugf("Pruned %d sequence keys from %d keys of %q in %v",
+		p.removedCount, keyCount, p.beingsC.Name, time.Since(startTime))
+	return nil
+}
+
+// NewOldBeingPruner returns an object that is ready to prune the Beings collection
+// of old beings sequence entries that we no longer need.
+func NewOldBeingPruner(modelUUID string, beings *mgo.Collection) *OldBeingPruner {
+	return &OldBeingPruner{
+		modelUUID: modelUUID,
+		beingsC: beings,
+		maxQueue: 1000,
+	}
 }
 
 // clockDelta returns the approximate skew between

--- a/state/presence/presence.go
+++ b/state/presence/presence.go
@@ -508,6 +508,10 @@ func (w *Watcher) handleAlive(pings []pingInfo) (map[int64]bool, []int64, error)
 // lookupUnknownSeqs handles finding new sequences that we weren't already tracking.
 // Keys that we find are now alive will have a 'found alive' event queued.
 func (w* Watcher) lookupUnknownSeqs(unknownSeqs []int64, dead map[int64]bool, session *mgo.Session) error {
+	if len(unknownSeqs) == 0 {
+		// Nothing to do, with nothing unknown.
+		return nil
+	}
 	// We do cache *all* beingInfos, but they're reasonably small
 	seqToBeing := make(map[int64]beingInfo, len(unknownSeqs))
 	startTime := time.Now()

--- a/state/presence/presence.go
+++ b/state/presence/presence.go
@@ -587,6 +587,7 @@ func (w* Watcher) lookupUnknownSeqs(unknownSeqs []int64, dead map[int64]bool, se
 			w.pending = append(w.pending, event{ch, being.Key, true})
 		}
 	}
+	// TODO(jam): 2017-04-18 This runs every 30s, probably needs to be Trace...
 	logger.Debugf("looked up %d unknown sequences (%d unowned) in %v%s from %q",
 		len(unknownSeqs), unownedCount, elapsed, rate, beingsC.Name)
 	return nil

--- a/state/presence/presence.go
+++ b/state/presence/presence.go
@@ -588,8 +588,8 @@ func (w* Watcher) lookupUnknownSeqs(unknownSeqs []int64, dead map[int64]bool, se
 		}
 	}
 	// TODO(jam): 2017-04-18 This runs every 30s, probably needs to be Trace...
-	logger.Debugf("looked up %d unknown sequences (%d unowned) in %v%s from %q",
-		len(unknownSeqs), unownedCount, elapsed, rate, beingsC.Name)
+	logger.Debugf("looked up %d unknown sequences for %q (%d unowned) in %v%s from %q",
+		len(unknownSeqs), w.modelUUID, unownedCount, elapsed, rate, beingsC.Name)
 	return nil
 }
 

--- a/state/presence/presence_test.go
+++ b/state/presence/presence_test.go
@@ -532,4 +532,3 @@ func (s *PresenceSuite) setup(c *gc.C, key string) (*presence.Watcher, *presence
 	assertChange(c, ch, presence.Change{key, false})
 	return w, p, ch
 }
-

--- a/state/presence/presence_test.go
+++ b/state/presence/presence_test.go
@@ -81,6 +81,23 @@ func assertChange(c *gc.C, watch <-chan presence.Change, want presence.Change) {
 	}
 }
 
+func waitForFirstChange(c *gc.C, watch <-chan presence.Change, want presence.Change) {
+	timeout := time.After(testing.LongWait)
+	for {
+		select {
+		case got := <-watch:
+			if got == want {
+				return
+			}
+			if got.Alive == false {
+				c.Fatalf("got a not-alive before the one we were expecting: %v (want %v)", got, want)
+			}
+		case <-timeout:
+			c.Fatalf("watch reported nothing, want %v", want)
+		}
+	}
+}
+
 func assertNoChange(c *gc.C, watch <-chan presence.Change) {
 	select {
 	case got := <-watch:
@@ -539,9 +556,12 @@ func (s *PresenceSuite) TestDeepStressStaysSane(c *gc.C) {
 	presence.FakePeriod(1)
 	defer presence.RealPeriod()
 	presence.RealTimeSlot()
-	keys := make([]string, 500)
+	// Each Pinger potentially grabs another socket to Mongo,
+	// which can exhaust connections. Somewhere around 5000 pingers on my
+	// machine everything starts failing because Mongo refuses new connections.
+	keys := make([]string, 3500)
 	for i := 0; i < len(keys); i++ {
-		keys[i] = fmt.Sprintf("being-%03d", i)
+		keys[i] = fmt.Sprintf("being-%04d", i)
 	}
 	modelTag := newModelTag(c)
 	// To create abuse on the system, we leave 2 pingers active for every
@@ -575,15 +595,16 @@ func (s *PresenceSuite) TestDeepStressStaysSane(c *gc.C) {
 	for i, key := range keys {
 		w.Watch(key, ch)
 		// we haven't started the pinger yet, so the initial state must be stopped
-		// TODO: This is probably dangerous, as all other pingers are on the same channel,
-		// so might get their message in the queue before us
-		assertChange(c, ch, presence.Change{key, false})
+		// As this is a busy channel, we may be queued up behind some other
+		// pinger showing up as alive, so allow up to LongWait for the event to show up
+		waitForFirstChange(c, ch, presence.Change{key, false})
 		p := presence.NewPinger(s.presence, modelTag, key)
-		newPingers[i] = p
 		err := p.Start()
 		c.Assert(err, jc.ErrorIsNil)
-		defer assertStopped(c, p)
+		newPingers[i] = p
+		// All newPingers will be checked that they stop cleanly
 	}
+	fmt.Printf("initialized %d pingers\n", len(newPingers))
 	// Make sure all of the entities stay showing up as alive
 	done := make(chan struct{})
 	go func() {
@@ -597,27 +618,37 @@ func (s *PresenceSuite) TestDeepStressStaysSane(c *gc.C) {
 		}
 	}()
 	defer close(done)
-	const loopCount = 10
 	beings := s.presence.Database.C(s.presence.Name + ".beings")
+	// Create a background Pruner task, that prunes items independently of
+	// when they are being updated
+	go func() {
+		for {
+			select {
+			case <-done:
+				return
+			case <-time.After(time.Duration(rand.Intn(500)+3000) * time.Millisecond):
+				oldPruner := presence.NewBeingPruner(modelTag.Id(), beings, s.pings, 0)
+				// Don't assert in a goroutine, as the panic may do bad things
+				c.Check(oldPruner.Prune(), jc.ErrorIsNil)
+			}
+		}
+	}()
+	const loopCount = 10
 	for loop := 0; loop < loopCount; loop++ {
 		t := time.Now()
-		for i, key := range keys {
+		for _, i := range rand.Perm(len(keys)) {
 			old := oldPingers[i]
 			if old != nil {
 				assertStopped(c, old)
 			}
 			oldPingers[i] = newPingers[i]
-			p := presence.NewPinger(s.presence, modelTag, key)
+			p := presence.NewPinger(s.presence, modelTag, keys[i])
 			err := p.Start()
 			c.Assert(err, jc.ErrorIsNil)
 			newPingers[i] = p
-			time.Sleep(time.Duration(rand.Intn(200)) * time.Microsecond)
 		}
-		// how often should we force w.Sync?
-		w.Sync()
+		// no need to force w.Sync() it automatically full syncs every period seconds
 		fmt.Printf("loop %d in %v\n", loop, time.Since(t))
-		// oldPruner := presence.NewOldBeingPruner(modelTag.Id(), beings)
-		// c.Assert(oldPruner.Prune(), jc.ErrorIsNil)
 	}
 	// Now that we've gone through all of that, check that we've created as
 	// many sequences as we think we have
@@ -631,12 +662,15 @@ func (s *PresenceSuite) TestDeepStressStaysSane(c *gc.C) {
 	// we should have created N keys Y+1 times (once in init, once per loop)
 	seqCount := int64(len(keys) * (loopCount + 1))
 	c.Check(sequence.Seq, gc.Equals, seqCount)
-	oldPruner := presence.NewOldBeingPruner(modelTag.Id(), beings)
-	err = oldPruner.Prune()
-	c.Assert(err, jc.ErrorIsNil)
+	oldPruner := presence.NewBeingPruner(modelTag.Id(), beings, s.pings, 0)
+	c.Assert(oldPruner.Prune(), jc.ErrorIsNil)
 	count, err := beings.Count()
 	c.Assert(err, jc.ErrorIsNil)
 	// After pruning, we should have exactly 1 sequence for each key
+	c.Logf("beings has %d keys", count)
 	c.Check(count, gc.Equals, len(keys))
-	c.Fail()
+	// Run the pruner again, it should essentially be a no-op
+	oldPruner = presence.NewBeingPruner(modelTag.Id(), beings, s.pings, 0)
+	c.Assert(oldPruner.Prune(), jc.ErrorIsNil)
+	c.Fatal("dumping logs")
 }

--- a/state/presence/pruner.go
+++ b/state/presence/pruner.go
@@ -1,0 +1,196 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package presence
+
+import (
+	"time"
+
+	"github.com/juju/errors"
+	"gopkg.in/mgo.v2"
+	"gopkg.in/mgo.v2/bson"
+)
+
+// beingRemover tracks what records we've decided we wanted to remove.
+type beingRemover struct {
+	queue []string
+}
+// Pruner tracks the state of removing unworthy beings from the
+// presence.beings and presence.pings collections. Being sequences are unworthy
+// once their sequence has been superseded, and pings older than 2 slots are
+// no longer referenced.
+type Pruner struct {
+	modelUUID string
+	beingsC *mgo.Collection
+	pingsC *mgo.Collection
+	toRemove []string
+	maxQueue int
+	removedCount uint64
+	delta time.Duration
+}
+
+// iterKeys is returns an iterator of Keys from this modelUUID and which Sequences
+// are used to represent them.
+func (p *Pruner) iterKeys() *mgo.Iter {
+	thisModelRegex := bson.M{"_id": bson.M{"$regex": bson.RegEx{"^" + p.modelUUID, ""}}}
+	pipe := p.beingsC.Pipe([]bson.M{
+		// Grab all sequences for this model
+		{"$match": thisModelRegex},
+		// We don't need the _id
+		{"$project": bson.M{"_id": 0, "seq": 1, "key": 1}},
+		// Group all the sequences by their key.
+		{"$group": bson.M{
+			"_id":    "$key",
+			"seqs":    bson.M{"$push": "$seq"},
+		}},
+		// Filter out any keys that have only a single sequence
+		// representing them
+		// Note: indexing is from 0, you can set this to 2 if you wanted
+		// to only bother pruning sequences that have >2 entries.
+		// This mostly helps the 'nothing to do' case, dropping the time
+		// to realize there are no sequences to be removed from 36ms,
+		// down to 15ms with 3500 keys.
+		{"$match": bson.M{"seqs.1": bson.M{"$exists": 1}}},
+	})
+	pipe.Batch(1600)
+	return pipe.Iter()
+}
+
+// queueRemoval includes this sequence as one that has been superseded
+func (p *Pruner) queueRemoval(seq int64) {
+	p.toRemove = append(p.toRemove, docIDInt64(p.modelUUID, seq))
+}
+
+// flushRemovals makes sure that we've applied all desired removals
+func (p *Pruner) flushRemovals() error {
+	if len(p.toRemove) == 0 {
+		return nil
+	}
+	matched, err := p.beingsC.RemoveAll(bson.M{"_id": bson.M{"$in": p.toRemove}})
+	if err != nil {
+		return err
+	}
+	p.toRemove = p.toRemove[:0]
+	if matched.Removed > 0 {
+		p.removedCount += uint64(matched.Removed)
+	}
+	return err
+}
+
+func (p *Pruner) removeOldPings() error {
+	// now and now-period are both considered active slots, so we don't
+	// touch those. We also leave 2 more slots around
+	startTime := time.Now()
+	logger.Tracef("pruning %q for %q", p.pingsC.Name, p.modelUUID)
+	s := timeSlot(time.Now(), p.delta)
+	oldSlot := s - 3*period
+	res, err := p.pingsC.RemoveAll(bson.D{{"_id", bson.RegEx{"^" + p.modelUUID, ""}},
+					      {"slot", bson.M{"$lt": oldSlot}} })
+	if err != nil && err != mgo.ErrNotFound {
+		logger.Errorf("error removing old entries from %q: %v", p.pingsC.Name, err)
+		return err
+	}
+	logger.Debugf("pruned %q for %q of %d old pings in %v",
+		p.pingsC.Name, p.modelUUID, res.Removed, time.Since(startTime))
+	return nil
+}
+
+func (p *Pruner) removeUnusedBeings() error {
+	var keyInfo collapsedBeingsInfo
+	// var seqSet map[int64]struct{}
+	seqSet, err := p.findActiveSeqs()
+	if err != nil {
+	 	return err
+	}
+	logger.Tracef("pruning %q for %q starting", p.beingsC.Name, p.modelUUID)
+	startTime := time.Now()
+	keyCount := 0
+	seqCount := 0
+	iter := p.iterKeys()
+	for iter.Next(&keyInfo) {
+		keyCount += 1
+		// Find the max
+		maxSeq := int64(-1)
+		for _, seq := range keyInfo.Seqs {
+			if seq > maxSeq {
+				maxSeq = seq
+			}
+		}
+		// Queue everything < max to be deleted
+		for _, seq := range keyInfo.Seqs {
+			seqCount++
+			_, isActive := seqSet[seq]
+			if seq >= maxSeq || isActive {
+				// It shouldn't be possible to be > at this point
+				continue
+			}
+			p.queueRemoval(seq)
+			if len(p.toRemove) > p.maxQueue {
+				if err := p.flushRemovals(); err != nil {
+					return err
+				}
+			}
+		}
+	}
+	if err := p.flushRemovals(); err != nil {
+		return err
+	}
+	if err := iter.Close(); err != nil {
+		return err
+	}
+	logger.Debugf("pruned %q for %q of %d sequence keys (evaluated %d) from %d keys in %v",
+		p.beingsC.Name, p.modelUUID, p.removedCount, seqCount, keyCount, time.Since(startTime))
+	return nil
+}
+
+func (p *Pruner) findActiveSeqs() (map[int64]struct{}, error) {
+	// Note: another option is to find all existing pings instead of just
+	// the current most-active pings based on time slots. "anything not pruned"
+	infos, err := lookupPings(p.pingsC, p.modelUUID, time.Now(), p.delta)
+	if err != nil {
+		return nil, err
+	}
+	maps := make([]map[string]int64, len(infos)*2)
+	for _, ping := range infos {
+		maps = append(maps, ping.Alive)
+		maps = append(maps, ping.Dead)
+	}
+	seqs, err := decompressPings(maps)
+	if err != nil {
+		return nil, err
+	}
+	seqSet := make(map[int64]struct{})
+	for _, seq := range seqs {
+		seqSet[seq] = struct{}{}
+	}
+	return seqSet, nil
+}
+
+// Prune removes beings from the beings collection that have been superseded by
+// another entry with a higher sequence.
+// It also removes pings that are outside of the 'active' range
+// (the last few slots)
+func (p *Pruner) Prune() error {
+	err := p.removeOldPings()
+	if err != nil {
+		return errors.Trace(err)
+	}
+	err = p.removeUnusedBeings()
+	if err != nil {
+		return errors.Trace(err)
+	}
+	return nil
+}
+
+// NewPruner returns an object that is ready to prune the Beings collection
+// of old beings sequence entries that we no longer need.
+func NewPruner(modelUUID string, beings *mgo.Collection, pings *mgo.Collection, delta time.Duration) *Pruner {
+	return &Pruner{
+		modelUUID: modelUUID,
+		beingsC: beings,
+		maxQueue: 1000,
+		pingsC: pings,
+		delta: delta,
+	}
+}
+

--- a/state/presence/pruner_test.go
+++ b/state/presence/pruner_test.go
@@ -1,0 +1,302 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package presence
+
+import (
+	"fmt"
+	"math/rand"
+	"time"
+
+	gitjujutesting "github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	"github.com/juju/utils"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/names.v2"
+	worker "gopkg.in/juju/worker.v1"
+	"gopkg.in/mgo.v2"
+
+	"github.com/juju/juju/testing"
+)
+
+type prunerSuite struct {
+	gitjujutesting.MgoSuite
+	testing.BaseSuite
+	presence *mgo.Collection
+	beings   *mgo.Collection
+	pings    *mgo.Collection
+	modelTag names.ModelTag
+}
+
+var _ = gc.Suite(&prunerSuite{})
+
+func (s *prunerSuite) SetUpSuite(c *gc.C) {
+	s.BaseSuite.SetUpSuite(c)
+	s.MgoSuite.SetUpSuite(c)
+	uuid, err := utils.NewUUID()
+	c.Assert(err, jc.ErrorIsNil)
+	s.modelTag = names.NewModelTag(uuid.String())
+}
+
+func (s *prunerSuite) TearDownSuite(c *gc.C) {
+	s.MgoSuite.TearDownSuite(c)
+	s.BaseSuite.TearDownSuite(c)
+}
+
+func (s *prunerSuite) SetUpTest(c *gc.C) {
+	s.BaseSuite.SetUpTest(c)
+	s.MgoSuite.SetUpTest(c)
+
+	db := s.MgoSuite.Session.DB("presence")
+	s.presence = db.C("presence")
+	s.beings = db.C("presence.beings")
+	s.pings = db.C("presence.pings")
+
+	FakeTimeSlot(0)
+}
+
+func (s *prunerSuite) TearDownTest(c *gc.C) {
+	s.MgoSuite.TearDownTest(c)
+	s.BaseSuite.TearDownTest(c)
+
+	RealTimeSlot()
+	RealPeriod()
+}
+
+func findBeing(c *gc.C, beingsC *mgo.Collection, modelUUID string, seq int64) (beingInfo, error) {
+	var being beingInfo
+	err := beingsC.FindId(docIDInt64(modelUUID, seq)).One(&being)
+	return being, err
+}
+
+func checkCollectionCount(c *gc.C, coll *mgo.Collection, count int) {
+	count, err := coll.Count()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(count, gc.Equals, count)
+}
+
+func (s *prunerSuite) TestPrunesOldPingsAndBeings(c *gc.C) {
+	keys := []string{"key1", "key2"}
+	pingers := make([]*Pinger, len(keys))
+	for i, key := range keys {
+		pingers[i] = NewPinger(s.presence, s.modelTag, key)
+	}
+	const numSlots= 10
+	sequences := make([][]int64, len(keys))
+	for i := range keys {
+		sequences[i] = make([]int64, numSlots)
+	}
+
+	for i := 0; i < numSlots; i++ {
+		FakeTimeSlot(i)
+		for j, p := range(pingers) {
+			// Create a new being sequence, and force a ping in this
+			// time slot. We don't Start()/Stop() them so we don't
+			// have to worry about things being async.
+			p.prepare()
+			p.ping()
+			sequences[j][i] = p.beingSeq
+		}
+	}
+	// At this point, we should have 10 ping slots active, and 10 different
+	// beings representing each key
+	checkCollectionCount(c, s.beings, numSlots*len(keys))
+	checkCollectionCount(c, s.pings, numSlots)
+	// Now we prune them, and assert that it removed items, but preserved the
+	// latest beings (things referenced by the latest pings)
+	pruner := NewPruner(s.modelTag.Id(), s.beings, s.pings, 0)
+	c.Assert(pruner.Prune(), jc.ErrorIsNil)
+	checkCollectionCount(c, s.pings, 4)
+	checkCollectionCount(c, s.beings, 2*len(keys))
+	for i, key := range keys {
+		expectedSeq := sequences[i][numSlots-2]
+		being, err := findBeing(c, s.beings, s.modelTag.Id(), expectedSeq)
+		c.Assert(err, jc.ErrorIsNil)
+		c.Check(being.Seq, gc.Equals, expectedSeq)
+		c.Check(being.Key, gc.Equals, key)
+	}
+}
+
+func (s *prunerSuite) TestPreservesLatestSequence(c *gc.C) {
+	FakePeriod(1)
+
+	key := "blah"
+	p1 := NewPinger(s.presence, s.modelTag, key)
+	p1.Start()
+	assertStopped(c, p1)
+	p2 := NewPinger(s.presence, s.modelTag, key)
+	p2.Start()
+	assertStopped(c, p2)
+	// we're starting p2 second, so it should get a higher sequence
+	c.Check(p1.beingSeq, gc.Not(gc.Equals), int64(0))
+	c.Check(p1.beingSeq, jc.LessThan, p2.beingSeq)
+	// Before pruning, we expect both beings to exist
+	being, err := findBeing(c, s.beings, s.modelTag.Id(), p1.beingSeq)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(being.Key, gc.Equals, key)
+	c.Check(being.Seq, gc.Equals, p1.beingSeq)
+	being, err = findBeing(c, s.beings, s.modelTag.Id(), p2.beingSeq)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(being.Key, gc.Equals, key)
+	c.Check(being.Seq, gc.Equals, p2.beingSeq)
+
+	pruner := NewPruner(s.modelTag.Id(), s.beings, s.pings, 0)
+	c.Assert(pruner.Prune(), jc.ErrorIsNil)
+	// After pruning, p2 should still be available
+	c.Check(being.Seq, gc.Equals, p2.beingSeq)
+}
+
+func waitForFirstChange(c *gc.C, watch <-chan Change, want Change) {
+	timeout := time.After(testing.LongWait)
+	for {
+		select {
+		case got := <-watch:
+			if got == want {
+				return
+			}
+			if got.Alive == false {
+				c.Fatalf("got a not-alive before the one we were expecting: %v (want %v)", got, want)
+			}
+		case <-timeout:
+			c.Fatalf("watch reported nothing, want %v", want)
+		}
+	}
+}
+
+// assertStopped stops a worker and waits until it reports stopped.
+// Use this method in favor of defer w.Stop() because you _must_ ensure
+// that the worker has stopped, and thus is no longer using its mgo
+// session before TearDownTest shuts down the connection.
+func assertStopped(c *gc.C, w worker.Worker) {
+	c.Assert(worker.Stop(w), jc.ErrorIsNil)
+}
+
+func (s *prunerSuite) TestDeepStressStaysSane(c *gc.C) {
+	const period = 1
+	FakePeriod(period)
+	RealTimeSlot()
+	// Each Pinger potentially grabs another socket to Mongo,
+	// which can exhaust connections. Somewhere around 5000 pingers on my
+	// machine everything starts failing because Mongo refuses new connections.
+	keys := make([]string, 3500)
+	for i := 0; i < len(keys); i++ {
+		keys[i] = fmt.Sprintf("being-%04d", i)
+	}
+	// To create abuse on the system, we leave 2 pingers active for every
+	// key. We then keep creating new pingers for each one, and rotate them
+	// into old, and stop them when they rotate out. So we potentially have
+	// 3 active pingers for each key. We should never see any key go
+	// inactive, because there is always at least 1 active pinger for each
+	// one
+	oldPingers := make([]*Pinger, len(keys))
+	newPingers := make([]*Pinger, len(keys))
+	ch := make(chan Change)
+	w := NewWatcher(s.presence, s.modelTag)
+	// Ensure that all pingers and the watcher are clean at exit
+	defer assertStopped(c, w)
+	defer func() {
+		for i, p := range oldPingers {
+			if p == nil {
+				continue
+			}
+			assertStopped(c, p)
+			oldPingers[i] = nil
+		}
+		for i, p := range newPingers {
+			if p == nil {
+				continue
+			}
+			assertStopped(c, p)
+			newPingers[i] = nil
+		}
+	}()
+	t := time.Now()
+	sleepUSRange := int(1000000.*float64(period)/float64(len(keys)) - 500)
+	if sleepUSRange <= 0 {
+		sleepUSRange = 1
+	}
+	for i, key := range keys {
+		w.Watch(key, ch)
+		// we haven't started the pinger yet, so the initial state must be stopped
+		// As this is a busy channel, we may be queued up behind some other
+		// pinger showing up as alive, so allow up to LongWait for the event to show up
+		waitForFirstChange(c, ch, Change{key, false})
+		p := NewPinger(s.presence, s.modelTag, key)
+		err := p.Start()
+		c.Assert(err, jc.ErrorIsNil)
+		newPingers[i] = p
+		// All newPingers will be checked that they stop cleanly
+		time.Sleep(time.Duration(rand.Intn(sleepUSRange)) * time.Microsecond)
+	}
+	fmt.Printf("initialized %d pingers in %v: sleeping %dus\n", len(newPingers), time.Since(t), sleepUSRange)
+	// Make sure all of the entities stay showing up as alive
+	done := make(chan struct{})
+	go func() {
+		for {
+			select {
+			case got := <-ch:
+				c.Check(got.Alive, jc.IsTrue, gc.Commentf("key %q reported dead", got.Key))
+			case <-done:
+				return
+			}
+		}
+	}()
+	defer close(done)
+	beings := s.presence.Database.C(s.presence.Name + ".beings")
+	// Create a background Pruner task, that prunes items independently of
+	// when they are being updated
+	go func() {
+		for {
+			select {
+			case <-done:
+				return
+			case <-time.After(time.Duration(rand.Intn(500)+(period*1000)) * time.Millisecond):
+				oldPruner := NewPruner(s.modelTag.Id(), beings, s.pings, 0)
+				// Don't assert in a goroutine, as the panic may do bad things
+				c.Check(oldPruner.Prune(), jc.ErrorIsNil)
+			}
+		}
+	}()
+	const loopCount = 10
+	for loop := 0; loop < loopCount; loop++ {
+		t := time.Now()
+		for _, i := range rand.Perm(len(keys)) {
+			old := oldPingers[i]
+			if old != nil {
+				assertStopped(c, old)
+			}
+			oldPingers[i] = newPingers[i]
+			p := NewPinger(s.presence, s.modelTag, keys[i])
+			err := p.Start()
+			c.Assert(err, jc.ErrorIsNil)
+			newPingers[i] = p
+			time.Sleep(time.Duration(rand.Intn(sleepUSRange)) * time.Microsecond)
+		}
+		// no need to force w.Sync() it automatically full syncs every period seconds
+		fmt.Printf("loop %d in %v\n", loop, time.Since(t))
+	}
+	// Now that we've gone through all of that, check that we've created as
+	// many sequences as we think we have
+	seq := s.presence.Database.C(s.presence.Name + ".seqs")
+	var sequence struct {
+		Seq int64 `bson:"seq"`
+	}
+	seqDocID := s.modelTag.Id() + ":beings"
+	err := seq.FindId(seqDocID).One(&sequence)
+	c.Assert(err, jc.ErrorIsNil)
+	// we should have created N keys Y+1 times (once in init, once per loop)
+	seqCount := int64(len(keys) * (loopCount + 1))
+	c.Check(sequence.Seq, gc.Equals, seqCount)
+	oldPruner := NewPruner(s.modelTag.Id(), beings, s.pings, 0)
+	c.Assert(oldPruner.Prune(), jc.ErrorIsNil)
+	count, err := beings.Count()
+	c.Assert(err, jc.ErrorIsNil)
+	// After pruning, we should have at least one sequence for each key,
+	// but not more than fits in the last pings
+	c.Check(count, jc.GreaterThan, len(keys))
+	c.Check(count, jc.LessThan, len(keys)*4)
+	// Run the pruner again, it should essentially be a no-op
+	oldPruner = NewPruner(s.modelTag.Id(), beings, s.pings, 0)
+	c.Assert(oldPruner.Prune(), jc.ErrorIsNil)
+	c.Fatal("dumping logs")
+}


### PR DESCRIPTION
## Description of change

This adds a "BeingPruner" to state/presence. This will clean up presence.beings and presence.pings so that they only contain recent sequences. Any Key that gets superseded by another sequence no longer pays attention to the old sequence, so it is safe to prune that sequence from the database. And pings older than 2 slots are not used either, so it is safe to remove slots.

This also triggers running the pruner on a pseudo-random cycle. We Sync all Watchers every 30s, and this triggers a prune (on average) every 20 Syncs (every 10 minutes). We use psuedo-random so that in HA, etc, we don't end up in sync across all the watchers. I would consider either
a) Merging this into the txnPruner logic, so it strictly happens every 2hrs.
b) Turning down the frequency.

The other bit about psuedo-random is that it biases so that we are unlikely to run 2x in a row, and will guarantee that we will eventually trigger (each time it doesn't trigger increases the chance it will trigger next time).

I'm currently doing some live testing, and I added a test that does abusive testing. There isn't a lot of focused unit tests, which is why this is WIP.

One thing that is surprising me is that at steady state, we're still seeing "unknown" sequences for pingers. I haven't dug into what keys those represent, but with 180 active unit agents, 
```
machine-0: 18:43:02 DEBUG juju.state.presence looked up 3 unknown sequences for "c3525263-1fe3-4556-8b5c-2bbc3beee6f7" (3 unowned) in 805.143µs (3.7seq/ms) from "presence.beings"
```

That means that in the active 2 ping slots, there are 3 bits set that don't match a known-active agent/key. Now, we generate a new sequence whenever something reconnects, but nothing should be actively doing very much. (Unless we are generating presence sequences for client connections, as I have a 'watch juju status' running.)

This also refactors the Presence logic a lot, so we no longer need to pre-load the 'allBeings' map. Instead we batch-load all of the items that we aren't already actively tracking. At high number of active pingers this improves load fairly significantly. (The torture test creates 3500 active pingers and cycles them every couple of seconds, and loading that is improved significantly.)

## QA steps

Spin up a reasonable sized deployment, with quite a few agents. Run it for a while, make sure none of the agents appears to go offline incorrectly, and monitor the size of presence collections. They should stay at a reasonable size.

You can also currently use:
```
  juju debug-log -m controller --include-machine machine-0 --include-module juju.state.presence
```
To see what is going on. The "lookup" logging statement should probably drop to Tracef if it isn't going to stay silent during normal behavior.

Another trick to force load on the system is to restart various agents, so that they're forced to get new sequences. The easiest way to do that is to bounce controller agents, so everything connected to them has to reconnect.
```
  juju ssh $X sudo /usr/sbin/service jujud-machine-$X restart
```


## Documentation changes

Shouldn't be user-visible, other than improvements around responsiveness, etc for 'juju status'.

## Bug reference

[lp:1454661](https://bugs.launchpad.net/juju/+bug/1454661)