### PR TITLE
Add index to relationscopes collection

### DIFF
--- a/state/allcollections.go
+++ b/state/allcollections.go
@@ -274,7 +274,11 @@ func allCollections() collectionSchema {
 				Key: []string{"model-uuid", "endpoints.applicationname"},
 			}},
 		},
-		relationScopesC: {},
+		relationScopesC: {
+			indexes: []mgo.Index{{
+				Key: []string{"model-uuid", "key", "departing"},
+			}},
+		},
 
 		// -----
 

--- a/state/relationunit.go
+++ b/state/relationunit.go
@@ -477,7 +477,7 @@ type relationScopeDoc struct {
 	DocID     string `bson:"_id"`
 	Key       string `bson:"key"`
 	ModelUUID string `bson:"model-uuid"`
-	Departing bool
+	Departing bool   `bson:"departing"`
 }
 
 func (d *relationScopeDoc) unitName() string {


### PR DESCRIPTION
## Description of change

As per the referenced bug, a new index is added to the relationscopes collection.
The index contains doc attributes: model-uuid, key, departing

## QA steps

bootstrap smoketest

## Bug reference

https://bugs.launchpad.net/juju/+bug/1676297
