### PR TITLE
Log and status history pruner workers react to pruning config changes

### DIFF
--- a/api/statushistory/pruner.go
+++ b/api/statushistory/pruner.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/juju/juju/api/base"
+	"github.com/juju/juju/api/common"
 	"github.com/juju/juju/apiserver/params"
 )
 
@@ -15,12 +16,13 @@ const apiName = "StatusHistory"
 // Facade allows calls to "StatusHistory" endpoints
 type Facade struct {
 	facade base.FacadeCaller
+	*common.ModelWatcher
 }
 
 // NewFacade returns a status "StatusHistory" Facade.
 func NewFacade(caller base.APICaller) *Facade {
 	facadeCaller := base.NewFacadeCaller(caller, apiName)
-	return &Facade{facadeCaller}
+	return &Facade{facade: facadeCaller, ModelWatcher: common.NewModelWatcher(facadeCaller)}
 }
 
 // Prune calls "StatusHistory.Prune"

--- a/apiserver/statushistory/pruner.go
+++ b/apiserver/statushistory/pruner.go
@@ -10,17 +10,19 @@ import (
 	"github.com/juju/juju/state"
 )
 
-// API is the concrete implementation of the Pruner endpoint..
+// API is the concrete implementation of the Pruner endpoint.
 type API struct {
+	*common.ModelWatcher
 	st         *state.State
 	authorizer facade.Authorizer
 }
 
 // NewAPI returns an API Instance.
-func NewAPI(st *state.State, _ facade.Resources, auth facade.Authorizer) (*API, error) {
+func NewAPI(st *state.State, r facade.Resources, auth facade.Authorizer) (*API, error) {
 	return &API{
-		st:         st,
-		authorizer: auth,
+		ModelWatcher: common.NewModelWatcher(st, r, auth),
+		st:           st,
+		authorizer:   auth,
 	}, nil
 }
 

--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -985,11 +985,6 @@ func (a *MachineAgent) startStateWorkers(
 		return nil, errors.Trace(err)
 	}
 
-	controllerConfig, err := st.ControllerConfig()
-	if err != nil {
-		return nil, errors.Annotate(err, "cannot fetch the controller config")
-	}
-
 	for _, job := range m.Jobs() {
 		switch job {
 		case state.JobHostUnits:
@@ -1082,10 +1077,7 @@ func (a *MachineAgent) startStateWorkers(
 			})
 
 			a.startWorkerAfterUpgrade(singularRunner, "dblogpruner", func() (worker.Worker, error) {
-				return dblogpruner.New(st, dblogpruner.NewLogPruneParams(
-					controllerConfig.MaxLogsAge(),
-					controllerConfig.MaxLogSizeMB(),
-				)), nil
+				return dblogpruner.New(st, dblogpruner.NewLogPruneParams()), nil
 			})
 
 			a.startWorkerAfterUpgrade(singularRunner, "txnpruner", func() (worker.Worker, error) {

--- a/cmd/jujud/agent/machine_test.go
+++ b/cmd/jujud/agent/machine_test.go
@@ -51,6 +51,7 @@ import (
 	"github.com/juju/juju/status"
 	"github.com/juju/juju/storage"
 	coretesting "github.com/juju/juju/testing"
+	"github.com/juju/juju/testing/factory"
 	"github.com/juju/juju/tools"
 	jujuversion "github.com/juju/juju/version"
 	jworker "github.com/juju/juju/worker"
@@ -1412,7 +1413,12 @@ func (s *MachineSuite) TestModelWorkersRespectSingularResponsibilityFlag(c *gc.C
 
 func (s *MachineSuite) setUpNewModel(c *gc.C) (newSt *state.State, closer func()) {
 	// Create a new environment, tests can now watch if workers start for it.
-	newSt = s.Factory.MakeModel(c, nil)
+	newSt = s.Factory.MakeModel(c, &factory.ModelParams{
+		ConfigAttrs: coretesting.Attrs{
+			"max-status-history-age":  "2h",
+			"max-status-history-size": "4M",
+		},
+	})
 	return newSt, func() {
 		err := newSt.Close()
 		c.Check(err, jc.ErrorIsNil)

--- a/state/export_test.go
+++ b/state/export_test.go
@@ -674,6 +674,12 @@ func GetApplicationSettings(st *State, app *Application) *Settings {
 	return newSettings(st, settingsC, app.settingsKey())
 }
 
+// GetControllerSettings allows access to settings collection for
+// the controller.
+func GetControllerSettings(st *State) *Settings {
+	return newSettings(st, controllersC, controllerSettingsGlobalKey)
+}
+
 // NewSLALevel returns a new SLA level.
 func NewSLALevel(level string) (slaLevel, error) {
 	return newSLALevel(level)

--- a/state/testing/conn.go
+++ b/state/testing/conn.go
@@ -22,6 +22,7 @@ import (
 type InitializeArgs struct {
 	Owner                     names.UserTag
 	InitialConfig             *config.Config
+	ControllerConfig          map[string]interface{}
 	ControllerInheritedConfig map[string]interface{}
 	RegionConfig              cloud.RegionConfig
 	NewPolicy                 state.NewPolicyFunc
@@ -55,6 +56,9 @@ func InitializeWithArgs(c *gc.C, args InitializeArgs) *state.State {
 	dialOpts := mongotest.DialOpts()
 
 	controllerCfg := testing.FakeControllerConfig()
+	for k, v := range args.ControllerConfig {
+		controllerCfg[k] = v
+	}
 	st, err := state.Initialize(state.InitializeParams{
 		Clock:            args.Clock,
 		ControllerConfig: controllerCfg,

--- a/state/watcher.go
+++ b/state/watcher.go
@@ -1321,6 +1321,11 @@ func (st *State) WatchControllerInfo() NotifyWatcher {
 	return newEntityWatcher(st, controllersC, modelGlobalKey)
 }
 
+// WatchControllerConfig returns a NotifyWatcher for controller settings.
+func (st *State) WatchControllerConfig() NotifyWatcher {
+	return newEntityWatcher(st, controllersC, controllerSettingsGlobalKey)
+}
+
 // Watch returns a watcher for observing changes to a machine.
 func (m *Machine) Watch() NotifyWatcher {
 	return newEntityWatcher(m.st, machinesC, m.doc.DocID)

--- a/worker/dblogpruner/worker.go
+++ b/worker/dblogpruner/worker.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/juju/errors"
+	"github.com/juju/loggo"
 	"gopkg.in/juju/worker.v1"
 	"gopkg.in/tomb.v1"
 
@@ -14,22 +15,19 @@ import (
 	jworker "github.com/juju/juju/worker"
 )
 
+var logger = loggo.GetLogger("juju.worker.dblogpruner")
+
 // LogPruneParams specifies how logs should be pruned.
 type LogPruneParams struct {
-	MaxLogAge       time.Duration
-	MaxCollectionMB int
-	PruneInterval   time.Duration
+	PruneInterval time.Duration
 }
 
 const DefaultPruneInterval = 5 * time.Minute
 
-// NewLogPruneParams returns a LogPruneParams initialised with default
-// values.
-func NewLogPruneParams(maxLogAge time.Duration, maxCollectionMB int) *LogPruneParams {
+// NewLogPruneParams returns a LogPruneParams initialised with default values.
+func NewLogPruneParams() *LogPruneParams {
 	return &LogPruneParams{
-		MaxLogAge:       maxLogAge,
-		MaxCollectionMB: maxCollectionMB,
-		PruneInterval:   DefaultPruneInterval,
+		PruneInterval: DefaultPruneInterval,
 	}
 }
 
@@ -50,15 +48,48 @@ type pruneWorker struct {
 }
 
 func (w *pruneWorker) loop(stopCh <-chan struct{}) error {
+
+	controllerConfigWatcher := w.st.WatchControllerConfig()
+	defer worker.Stop(controllerConfigWatcher)
+
+	var (
+		maxLogAge               time.Duration
+		maxCollectionMB         int
+		controllerConfigChanges = controllerConfigWatcher.Changes()
+		// We will also get an initial event, but need to ensure that event is
+		// received before doing any pruning.
+		haveConfig = false
+	)
 	p := w.params
+
 	for {
 		select {
 		case <-stopCh:
 			return tomb.ErrDying
+		case _, ok := <-controllerConfigChanges:
+			if !ok {
+				return errors.New("controller configuration watcher closed")
+			}
+			controllerConfig, err := w.st.ControllerConfig()
+			if err != nil {
+				return errors.Annotate(err, "cannot load controller configuration")
+			}
+			haveConfig = true
+			newMaxAge := controllerConfig.MaxLogsAge()
+			newMaxCollectionMB := controllerConfig.MaxLogSizeMB()
+			if newMaxAge != maxLogAge || newMaxCollectionMB != maxCollectionMB {
+				logger.Infof("log pruning config: max age: %v, max collection size %dM", newMaxAge, newMaxCollectionMB)
+				maxLogAge = newMaxAge
+				maxCollectionMB = newMaxCollectionMB
+			}
+			continue
 		case <-time.After(p.PruneInterval):
+			if !haveConfig {
+				continue
+			}
 			// TODO(fwereade): 2016-03-17 lp:1558657
-			minLogTime := time.Now().Add(-p.MaxLogAge)
-			err := state.PruneLogs(w.st, minLogTime, p.MaxCollectionMB)
+			minLogTime := time.Now().Add(-maxLogAge)
+			err := state.PruneLogs(w.st, minLogTime, maxCollectionMB)
 			if err != nil {
 				return errors.Trace(err)
 			}

--- a/worker/dblogpruner/worker_test.go
+++ b/worker/dblogpruner/worker_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/juju/loggo"
+	jujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/names.v2"
@@ -29,23 +30,55 @@ func TestPackage(t *stdtesting.T) {
 var _ = gc.Suite(&suite{})
 
 type suite struct {
-	statetesting.StateSuite
-	pruner   worker.Worker
-	logsColl *mgo.Collection
+	jujutesting.MgoSuite
+	testing.BaseSuite
+
+	state          *state.State
+	pruner         worker.Worker
+	logsColl       *mgo.Collection
+	controllerColl *mgo.Collection
+}
+
+func (s *suite) SetUpSuite(c *gc.C) {
+	s.MgoSuite.SetUpSuite(c)
+	s.BaseSuite.SetUpSuite(c)
+}
+
+func (s *suite) TearDownSuite(c *gc.C) {
+	s.BaseSuite.TearDownSuite(c)
+	s.MgoSuite.TearDownSuite(c)
 }
 
 func (s *suite) SetUpTest(c *gc.C) {
-	s.StateSuite.SetUpTest(c)
-	s.logsColl = s.State.MongoSession().DB("logs").C("logs")
+	s.MgoSuite.SetUpTest(c)
+	s.BaseSuite.SetUpTest(c)
 }
 
-func (s *suite) StartWorker(c *gc.C, maxLogAge time.Duration, maxCollectionMB int) {
-	params := &dblogpruner.LogPruneParams{
-		MaxLogAge:       maxLogAge,
-		MaxCollectionMB: maxCollectionMB,
-		PruneInterval:   time.Millisecond, // Speed up pruning interval for testing
+func (s *suite) TearDownTest(c *gc.C) {
+	s.BaseSuite.TearDownTest(c)
+	s.MgoSuite.TearDownTest(c)
+}
+
+func (s *suite) setupState(c *gc.C, maxLogAge, maxCollectionMB string) {
+	controllerConfig := map[string]interface{}{
+		"max-logs-age":  maxLogAge,
+		"max-logs-size": maxCollectionMB,
 	}
-	s.pruner = dblogpruner.New(s.State, params)
+
+	s.state = statetesting.InitializeWithArgs(c, statetesting.InitializeArgs{
+		Owner:            names.NewLocalUserTag("test-admin"),
+		Clock:            jujutesting.NewClock(testing.NonZeroTime()),
+		ControllerConfig: controllerConfig,
+	})
+	s.AddCleanup(func(*gc.C) { s.state.Close() })
+	s.logsColl = s.state.MongoSession().DB("logs").C("logs")
+}
+
+func (s *suite) startWorker(c *gc.C) {
+	params := &dblogpruner.LogPruneParams{
+		PruneInterval: time.Millisecond, // Speed up pruning interval for testing
+	}
+	s.pruner = dblogpruner.New(s.state, params)
 	s.AddCleanup(func(*gc.C) {
 		s.pruner.Kill()
 		c.Assert(s.pruner.Wait(), jc.ErrorIsNil)
@@ -54,8 +87,8 @@ func (s *suite) StartWorker(c *gc.C, maxLogAge time.Duration, maxCollectionMB in
 
 func (s *suite) TestPrunesOldLogs(c *gc.C) {
 	maxLogAge := 24 * time.Hour
-	noPruneMB := int(1e9)
-	s.StartWorker(c, maxLogAge, noPruneMB)
+	s.setupState(c, "24h", "1000P")
+	s.startWorker(c)
 
 	now := time.Now()
 	addLogsToPrune := func(count int) {
@@ -88,12 +121,11 @@ func (s *suite) TestPrunesOldLogs(c *gc.C) {
 }
 
 func (s *suite) TestPrunesLogsBySize(c *gc.C) {
+	s.setupState(c, "999h", "2M")
 	startingLogCount := 25000
 	s.addLogs(c, time.Now(), "stuff", startingLogCount)
 
-	noPruneAge := 999 * time.Hour
-	s.StartWorker(c, noPruneAge, 2)
-
+	s.startWorker(c)
 	for attempt := testing.LongAttempt.Start(); attempt.Next(); {
 		count, err := s.logsColl.Count()
 		c.Assert(err, jc.ErrorIsNil)
@@ -108,7 +140,7 @@ func (s *suite) TestPrunesLogsBySize(c *gc.C) {
 }
 
 func (s *suite) addLogs(c *gc.C, t0 time.Time, text string, count int) {
-	dbLogger := state.NewEntityDbLogger(s.State, names.NewMachineTag("0"), version.Current)
+	dbLogger := state.NewEntityDbLogger(s.state, names.NewMachineTag("0"), version.Current)
 	defer dbLogger.Close()
 
 	for offset := 0; offset < count; offset++ {

--- a/worker/statushistorypruner/manifold.go
+++ b/worker/statushistorypruner/manifold.go
@@ -10,7 +10,6 @@ import (
 	"gopkg.in/juju/worker.v1"
 
 	"github.com/juju/juju/api/base"
-	"github.com/juju/juju/environs"
 	jworker "github.com/juju/juju/worker"
 	"github.com/juju/juju/worker/dependency"
 )
@@ -45,19 +44,11 @@ func (config ManifoldConfig) start(context dependency.Context) (worker.Worker, e
 		return nil, errors.Trace(err)
 	}
 
-	var environ environs.Environ
-	if err := context.Get(config.EnvironName, &environ); err != nil {
-		return nil, errors.Trace(err)
-	}
-	cfg := environ.Config()
-
 	facade := config.NewFacade(apiCaller)
 	prunerConfig := Config{
-		Facade:         facade,
-		MaxHistoryTime: cfg.MaxStatusHistoryAge(),
-		MaxHistoryMB:   cfg.MaxStatusHistorySizeMB(),
-		PruneInterval:  config.PruneInterval,
-		NewTimer:       config.NewTimer,
+		Facade:        facade,
+		PruneInterval: config.PruneInterval,
+		NewTimer:      config.NewTimer,
 	}
 	w, err := config.NewWorker(prunerConfig)
 	if err != nil {

--- a/worker/statushistorypruner/manifold_test.go
+++ b/worker/statushistorypruner/manifold_test.go
@@ -4,8 +4,6 @@
 package statushistorypruner_test
 
 import (
-	"time"
-
 	"github.com/juju/errors"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
@@ -15,7 +13,6 @@ import (
 	"github.com/juju/juju/api/base"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/config"
-	coretesting "github.com/juju/juju/testing"
 	"github.com/juju/juju/worker/dependency"
 	"github.com/juju/juju/worker/statushistorypruner"
 )
@@ -25,32 +22,6 @@ type ManifoldSuite struct {
 }
 
 var _ = gc.Suite(&ManifoldSuite{})
-
-func (s *ManifoldSuite) TestStatusHistoryConfig(c *gc.C) {
-	ctx := &mockDependencyContext{
-		env: &mockEnviron{
-			config: coretesting.CustomModelConfig(c, coretesting.Attrs{
-				"max-status-history-age":  "96h",
-				"max-status-history-size": "4G",
-			}),
-		},
-	}
-
-	manifold := statushistorypruner.Manifold(statushistorypruner.ManifoldConfig{
-		APICallerName: "api-caller",
-		EnvironName:   "environ",
-		NewWorker: func(cfg statushistorypruner.Config) (worker.Worker, error) {
-			c.Assert(cfg.MaxHistoryTime, gc.Equals, 96*time.Hour)
-			c.Assert(cfg.MaxHistoryMB, gc.Equals, uint(4096))
-			return nil, dependency.ErrUninstall
-		},
-		NewFacade: func(caller base.APICaller) statushistorypruner.Facade {
-			return nil
-		},
-	})
-	_, err := manifold.Start(ctx)
-	c.Assert(errors.Cause(err), gc.Equals, dependency.ErrUninstall)
-}
 
 type mockDependencyContext struct {
 	dependency.Context

--- a/worker/statushistorypruner/worker.go
+++ b/worker/statushistorypruner/worker.go
@@ -7,24 +7,30 @@ import (
 	"time"
 
 	"github.com/juju/errors"
+	"github.com/juju/loggo"
 	"gopkg.in/juju/worker.v1"
 
 	"github.com/juju/juju/api/base"
 	"github.com/juju/juju/api/statushistory"
+	"github.com/juju/juju/environs/config"
+	"github.com/juju/juju/watcher"
 	jworker "github.com/juju/juju/worker"
+	"github.com/juju/juju/worker/catacomb"
 )
+
+var logger = loggo.GetLogger("juju.worker.statushistorypruner")
 
 // Facade represents an API that implements status history pruning.
 type Facade interface {
 	Prune(time.Duration, int) error
+	WatchForModelConfigChanges() (watcher.NotifyWatcher, error)
+	ModelConfig() (*config.Config, error)
 }
 
 // Config holds all necessary attributes to start a pruner worker.
 type Config struct {
-	Facade         Facade
-	MaxHistoryTime time.Duration
-	MaxHistoryMB   uint
-	PruneInterval  time.Duration
+	Facade        Facade
+	PruneInterval time.Duration
 	// TODO(fwereade): 2016-03-17 lp:1558657
 	NewTimer jworker.NewTimerFunc
 }
@@ -38,12 +44,6 @@ func (c *Config) Validate() error {
 	if c.NewTimer == nil {
 		return errors.New("missing Timer")
 	}
-	// TODO(perrito666) this assumes out of band knowledge of how filter
-	// values are treated, expand config to support the "dont use this filter"
-	// case as an explicit statement.
-	if c.MaxHistoryMB <= 0 && c.MaxHistoryTime <= 0 {
-		return errors.New("missing prune criteria, no size or date limit provided")
-	}
 	return nil
 }
 
@@ -52,18 +52,90 @@ func New(conf Config) (worker.Worker, error) {
 	if err := conf.Validate(); err != nil {
 		return nil, errors.Trace(err)
 	}
-	doPruning := func(stop <-chan struct{}) error {
-		err := conf.Facade.Prune(conf.MaxHistoryTime, int(conf.MaxHistoryMB))
-		if err != nil {
-			return errors.Trace(err)
-		}
-		return nil
-	}
 
-	return jworker.NewPeriodicWorker(doPruning, conf.PruneInterval, conf.NewTimer), nil
+	w := &Worker{
+		config: conf,
+	}
+	err := catacomb.Invoke(catacomb.Plan{
+		Site: &w.catacomb,
+		Work: w.loop,
+	})
+	return w, errors.Trace(err)
 }
 
 // NewFacade returns a new status history facade.
 func NewFacade(caller base.APICaller) Facade {
 	return statushistory.NewFacade(caller)
+}
+
+// Worker prunes status history records at regular intervals.
+type Worker struct {
+	catacomb catacomb.Catacomb
+	config   Config
+}
+
+// Kill is defined on worker.Worker.
+func (w *Worker) Kill() {
+	w.catacomb.Kill(nil)
+}
+
+// Wait is defined on worker.Worker.
+func (w *Worker) Wait() error {
+	return w.catacomb.Wait()
+}
+
+func (w *Worker) loop() error {
+
+	modelConfigWatcher, err := w.config.Facade.WatchForModelConfigChanges()
+	if err != nil {
+		return errors.Trace(err)
+	}
+	err = w.catacomb.Add(modelConfigWatcher)
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	var (
+		maxAge             time.Duration
+		maxCollectionMB    uint
+		modelConfigChanges = modelConfigWatcher.Changes()
+		// We will also get an initial event, but need to ensure that event is
+		// received before doing any pruning.
+		haveConfig = false
+	)
+
+	timer := w.config.NewTimer(0)
+	for {
+		select {
+		case <-w.catacomb.Dying():
+			return w.catacomb.ErrDying()
+		case _, ok := <-modelConfigChanges:
+			if !ok {
+				return errors.New("model configuration watcher closed")
+			}
+			modelConfig, err := w.config.Facade.ModelConfig()
+			if err != nil {
+				return errors.Annotate(err, "cannot load model configuration")
+			}
+			haveConfig = true
+			newMaxAge := modelConfig.MaxStatusHistoryAge()
+			newMaxCollectionMB := modelConfig.MaxStatusHistorySizeMB()
+			if newMaxAge != maxAge || newMaxCollectionMB != maxCollectionMB {
+				logger.Infof("status history config: max age: %v, max collection size %dM for %s (%s)",
+					newMaxAge, newMaxCollectionMB, modelConfig.Name(), modelConfig.UUID())
+				maxAge = newMaxAge
+				maxCollectionMB = newMaxCollectionMB
+			}
+			continue
+		case <-timer.CountDown():
+			if !haveConfig {
+				continue
+			}
+			err := w.config.Facade.Prune(maxAge, int(maxCollectionMB))
+			if err != nil {
+				return errors.Trace(err)
+			}
+			timer.Reset(w.config.PruneInterval)
+		}
+	}
 }

--- a/worker/statushistorypruner/worker_test.go
+++ b/worker/statushistorypruner/worker_test.go
@@ -4,6 +4,7 @@
 package statushistorypruner_test
 
 import (
+	"sync"
 	"time"
 
 	"github.com/juju/errors"
@@ -11,7 +12,9 @@ import (
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/worker.v1"
 
+	"github.com/juju/juju/environs/config"
 	coretesting "github.com/juju/juju/testing"
+	"github.com/juju/juju/watcher"
 	jworker "github.com/juju/juju/worker"
 	"github.com/juju/juju/worker/statushistorypruner"
 )
@@ -22,8 +25,8 @@ type statusHistoryPrunerSuite struct {
 
 var _ = gc.Suite(&statusHistoryPrunerSuite{})
 
-func (s *statusHistoryPrunerSuite) TestWorkerCallsPrune(c *gc.C) {
-	fakeTimer := newMockTimer(coretesting.LongWait)
+func (s *statusHistoryPrunerSuite) setupPruner(c *gc.C) (*fakeFacade, *mockTimer) {
+	fakeTimer := newMockTimer()
 
 	fakeTimerFunc := func(d time.Duration) jworker.PeriodicTimer {
 		// construction of timer should be with 0 because we intend it to
@@ -32,12 +35,17 @@ func (s *statusHistoryPrunerSuite) TestWorkerCallsPrune(c *gc.C) {
 		return fakeTimer
 	}
 	facade := newFakeFacade()
+	attrs := coretesting.FakeConfig()
+	attrs["max-status-history-age"] = "1s"
+	attrs["max-status-history-size"] = "3M"
+	cfg, err := config.New(config.UseDefaults, attrs)
+	c.Assert(err, jc.ErrorIsNil)
+	facade.modelConfig = cfg
+
 	conf := statushistorypruner.Config{
-		Facade:         facade,
-		MaxHistoryTime: 1 * time.Second,
-		MaxHistoryMB:   3,
-		PruneInterval:  coretesting.ShortWait,
-		NewTimer:       fakeTimerFunc,
+		Facade:        facade,
+		PruneInterval: coretesting.ShortWait,
+		NewTimer:      fakeTimerFunc,
 	}
 
 	pruner, err := statushistorypruner.New(conf)
@@ -46,7 +54,17 @@ func (s *statusHistoryPrunerSuite) TestWorkerCallsPrune(c *gc.C) {
 		c.Assert(worker.Stop(pruner), jc.ErrorIsNil)
 	})
 
-	err = fakeTimer.fire()
+	facade.changesWatcher.changes <- struct{}{}
+	select {
+	case <-facade.gotConfig:
+	case <-time.After(coretesting.LongWait):
+		c.Fatal("timed out waiting for model configr")
+	}
+	return facade, fakeTimer
+}
+
+func (s *statusHistoryPrunerSuite) assertWorkerCallsPrune(c *gc.C, facade *fakeFacade, fakeTimer *mockTimer, collectionSize int) {
+	err := fakeTimer.fire()
 	c.Check(err, jc.ErrorIsNil)
 
 	var passedMB int
@@ -55,7 +73,7 @@ func (s *statusHistoryPrunerSuite) TestWorkerCallsPrune(c *gc.C) {
 	case <-time.After(coretesting.LongWait):
 		c.Fatal("timed out waiting for passed logs to pruner")
 	}
-	c.Assert(passedMB, gc.Equals, 3)
+	c.Assert(passedMB, gc.Equals, collectionSize)
 
 	// Reset will have been called with the actual PruneInterval
 	var period time.Duration
@@ -67,35 +85,31 @@ func (s *statusHistoryPrunerSuite) TestWorkerCallsPrune(c *gc.C) {
 	c.Assert(period, gc.Equals, coretesting.ShortWait)
 }
 
+func (s *statusHistoryPrunerSuite) TestWorkerCallsPrune(c *gc.C) {
+	facade, fakeTimer := s.setupPruner(c)
+	s.assertWorkerCallsPrune(c, facade, fakeTimer, 3)
+}
+
 func (s *statusHistoryPrunerSuite) TestWorkerWontCallPruneBeforeFiringTimer(c *gc.C) {
-	fakeTimer := newMockTimer(coretesting.LongWait)
-
-	fakeTimerFunc := func(d time.Duration) jworker.PeriodicTimer {
-		// construction of timer should be with 0 because we intend it to
-		// run once before waiting.
-		c.Assert(d, gc.Equals, 0*time.Nanosecond)
-		return fakeTimer
-	}
-	facade := newFakeFacade()
-	conf := statushistorypruner.Config{
-		Facade:         facade,
-		MaxHistoryTime: 1 * time.Second,
-		MaxHistoryMB:   3,
-		PruneInterval:  coretesting.ShortWait,
-		NewTimer:       fakeTimerFunc,
-	}
-
-	pruner, err := statushistorypruner.New(conf)
-	c.Check(err, jc.ErrorIsNil)
-	s.AddCleanup(func(*gc.C) {
-		c.Assert(worker.Stop(pruner), jc.ErrorIsNil)
-	})
+	facade, _ := s.setupPruner(c)
 
 	select {
 	case <-facade.passedMaxHistoryMB:
 		c.Fatal("called before firing timer.")
 	case <-time.After(coretesting.LongWait):
 	}
+}
+
+func (s *statusHistoryPrunerSuite) TestModelConfigChange(c *gc.C) {
+	facade, fakeTimer := s.setupPruner(c)
+	s.assertWorkerCallsPrune(c, facade, fakeTimer, 3)
+
+	var err error
+	facade.modelConfig, err = facade.modelConfig.Apply(map[string]interface{}{"max-status-history-size": "4M"})
+	c.Assert(err, jc.ErrorIsNil)
+	facade.changesWatcher.changes <- struct{}{}
+
+	s.assertWorkerCallsPrune(c, facade, fakeTimer, 4)
 }
 
 type mockTimer struct {
@@ -125,7 +139,7 @@ func (t *mockTimer) fire() error {
 	return nil
 }
 
-func newMockTimer(d time.Duration) *mockTimer {
+func newMockTimer() *mockTimer {
 	return &mockTimer{period: make(chan time.Duration, 1),
 		c: make(chan time.Time),
 	}
@@ -133,11 +147,16 @@ func newMockTimer(d time.Duration) *mockTimer {
 
 type fakeFacade struct {
 	passedMaxHistoryMB chan int
+	changesWatcher     *mockNotifyWatcher
+	modelConfig        *config.Config
+	gotConfig          chan struct{}
 }
 
 func newFakeFacade() *fakeFacade {
 	return &fakeFacade{
 		passedMaxHistoryMB: make(chan int, 1),
+		gotConfig:          make(chan struct{}, 1),
+		changesWatcher:     newMockNotifyWatcher(),
 	}
 }
 
@@ -151,4 +170,64 @@ func (f *fakeFacade) Prune(_ time.Duration, maxHistoryMB int) error {
 		return errors.New("timed out waiting for facade call Prune to run")
 	}
 	return nil
+}
+
+// WatchForModelConfigChanges implements Facade
+func (f *fakeFacade) WatchForModelConfigChanges() (watcher.NotifyWatcher, error) {
+	return f.changesWatcher, nil
+}
+
+// ModelConfig implements Facade
+func (f *fakeFacade) ModelConfig() (*config.Config, error) {
+	f.gotConfig <- struct{}{}
+	return f.modelConfig, nil
+}
+
+func newMockWatcher() *mockWatcher {
+	return &mockWatcher{
+		stopped: make(chan struct{}),
+	}
+}
+
+type mockWatcher struct {
+	mu      sync.Mutex
+	stopped chan struct{}
+}
+
+func (w *mockWatcher) Kill() {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if !w.Stopped() {
+		close(w.stopped)
+	}
+}
+
+func (w *mockWatcher) Wait() error {
+	<-w.stopped
+	return nil
+}
+
+func (w *mockWatcher) Stopped() bool {
+	select {
+	case <-w.stopped:
+		return true
+	default:
+		return false
+	}
+}
+
+func newMockNotifyWatcher() *mockNotifyWatcher {
+	return &mockNotifyWatcher{
+		mockWatcher: newMockWatcher(),
+		changes:     make(chan struct{}, 1),
+	}
+}
+
+type mockNotifyWatcher struct {
+	*mockWatcher
+	changes chan struct{}
+}
+
+func (w *mockNotifyWatcher) Changes() watcher.NotifyChannel {
+	return w.changes
 }


### PR DESCRIPTION
## Description of change

This PR follows up on the work to allow the log pruner and status history pruner workers to be configured with respect to max record age and size of history collections. It adds the ability for the pruning parameters to be changed and the workers pick up the new parameters.

The log pruning parameters are controller settings and currently we don't support changing those. However, a watcher is added for when such changes are possible.

For the status history pruning parameters, these are changed via the juju model-config CLI.

## QA steps

configure small values for log pruning in clouds.yaml
bootstrap, check debug-log to see that expected pruning values are picked up
deploy a unit
run juju model-config to set small values for status history pruning
check that history pruning occurs via juju show-status-log
check that log pruning occurs using juju debug-log

## Bug reference

http://pad.lv/1681352
