### PR TITLE
Optimize 'debug-log' for the last few items.

### DIFF
--- a/state/logs.go
+++ b/state/logs.go
@@ -383,12 +383,12 @@ func NewLogTailer(st LogTailerState, params *LogTailerParams) (LogTailer, error)
 
 	session := st.MongoSession().Copy()
 	t := &logTailer{
-		modelUUID: st.ModelUUID(),
-		session:   session,
-		logsColl:  session.DB(logsDB).C(logsC).With(session),
-		params:    params,
-		logCh:     make(chan *LogRecord),
-		recentIds: newRecentIdTracker(maxRecentLogIds),
+		modelUUID:       st.ModelUUID(),
+		session:         session,
+		logsColl:        session.DB(logsDB).C(logsC).With(session),
+		params:          params,
+		logCh:           make(chan *LogRecord),
+		recentIds:       newRecentIdTracker(maxRecentLogIds),
 		maxInitialLines: maxInitialLines,
 	}
 	go func() {
@@ -402,15 +402,15 @@ func NewLogTailer(st LogTailerState, params *LogTailerParams) (LogTailer, error)
 }
 
 type logTailer struct {
-	tomb      tomb.Tomb
-	modelUUID string
-	session   *mgo.Session
-	logsColl  *mgo.Collection
-	params    *LogTailerParams
-	logCh     chan *LogRecord
-	lastID    int64
-	lastTime  time.Time
-	recentIds *recentIdTracker
+	tomb            tomb.Tomb
+	modelUUID       string
+	session         *mgo.Session
+	logsColl        *mgo.Collection
+	params          *LogTailerParams
+	logCh           chan *LogRecord
+	lastID          int64
+	lastTime        time.Time
+	recentIds       *recentIdTracker
 	maxInitialLines int
 }
 

--- a/state/logs.go
+++ b/state/logs.go
@@ -361,6 +361,10 @@ const oplogOverlap = time.Minute
 // output of large broken models with logging at DEBUG.
 var maxRecentLogIds = int(oplogOverlap.Minutes() * 150000)
 
+// maxInitialLines limits the number of documents we will load into memory
+// so that we can iterate them in the correct order.
+var maxInitialLines = 10000
+
 // LogTailerState describes the methods on State required for logging to
 // the database.
 type LogTailerState interface {
@@ -385,6 +389,7 @@ func NewLogTailer(st LogTailerState, params *LogTailerParams) (LogTailer, error)
 		params:    params,
 		logCh:     make(chan *LogRecord),
 		recentIds: newRecentIdTracker(maxRecentLogIds),
+		maxInitialLines: maxInitialLines,
 	}
 	go func() {
 		err := t.loop()
@@ -406,6 +411,7 @@ type logTailer struct {
 	lastID    int64
 	lastTime  time.Time
 	recentIds *recentIdTracker
+	maxInitialLines int
 }
 
 // Logs implements the LogTailer interface.
@@ -443,22 +449,70 @@ func (t *logTailer) loop() error {
 	return errors.Trace(err)
 }
 
+func (t *logTailer) processReversed(query *mgo.Query) error {
+	// We must sort by exactly the fields in the index and exactly reversed
+	// so that Mongo will use the index and not try to sort in memory.
+	// Note (jam): 2017-04-19 if this is truly too much memory load we should
+	// a) limit InitialLines to something reasonable
+	// b) we *could* just load the object _ids and then do a forward query
+	//    on exactly those ids (though it races with new items being inserted)
+	// c) use the aggregation pipeline in Mongo 3.2 to write the docs to
+	//    a temp location and iterate them forward from there.
+	// (a) makes the most sense for me :)
+	if t.params.InitialLines > t.maxInitialLines {
+		return errors.Errorf("too many lines requested (%d) maximum is %d",
+			t.params.InitialLines, maxInitialLines)
+	}
+	query.Sort("-e", "-t", "-_id")
+	query.Limit(t.params.InitialLines)
+	iter := query.Iter()
+	queue := make([]logDoc, t.params.InitialLines)
+	cur := t.params.InitialLines
+	var doc logDoc
+	for iter.Next(&doc) {
+		select {
+		case <-t.tomb.Dying():
+			return errors.Trace(tomb.ErrDying)
+		default:
+		}
+		cur--
+		queue[cur] = doc
+		if cur == 0 {
+			break
+		}
+	}
+	if err := iter.Close(); err != nil {
+		return errors.Trace(err)
+	}
+	// We loaded the queue in reverse order, truncate it to just the actual
+	// contents, and then return them in the correct order.
+	queue = queue[cur:]
+	for _, doc := range queue {
+		rec, err := logDocToRecord(&doc)
+		if err != nil {
+			return errors.Annotate(err, "deserialization failed (possible DB corruption)")
+		}
+		select {
+		case <-t.tomb.Dying():
+			return errors.Trace(tomb.ErrDying)
+		case t.logCh <- rec:
+			t.lastID = rec.ID
+			t.lastTime = rec.Time
+			t.recentIds.Add(doc.Id)
+		}
+	}
+	return nil
+}
+
 func (t *logTailer) processCollection() error {
 	// Create a selector from the params.
 	sel := t.paramsToSelector(t.params, "")
 	query := t.logsColl.Find(sel)
 
+	var doc logDoc
 	if t.params.InitialLines > 0 {
-		// This is a little racy but it's good enough.
-		count, err := query.Count()
-		if err != nil {
-			return errors.Annotate(err, "query count failed")
-		}
-		if skipOver := count - t.params.InitialLines; skipOver > 0 {
-			query = query.Skip(skipOver)
-		}
+		return t.processReversed(query)
 	}
-
 	// In tests, sorting by time can leave the result ordering
 	// underconstrained. Since object ids are (timestamp, machine id,
 	// process id, counter)
@@ -469,12 +523,9 @@ func (t *logTailer) processCollection() error {
 	// Important: it is critical that the sort index includes _id,
 	// otherwise MongoDB won't use the index, which risks hitting
 	// MongoDB's 32MB sort limit.  See https://pad.lv/1590605.
-	//
-	// TODO(ericsnow) Sort only by _id once it is a sequential int.
 	iter := query.Sort("e", "t", "_id").Iter()
-	doc := new(logDoc)
-	for iter.Next(doc) {
-		rec, err := logDocToRecord(doc)
+	for iter.Next(&doc) {
+		rec, err := logDocToRecord(&doc)
 		if err != nil {
 			return errors.Annotate(err, "deserialization failed (possible DB corruption)")
 		}


### PR DESCRIPTION
## Description of change

When grabbing the last items from the log, don't Count() and then approximately Skip() the
right number. That turns out to have to load everything and apply all the filters.
Instead, just iterate the index backwards, and load the queue of items, then walk forwards.

On a server with a lot of log entries, this changes ```juju debug-log --some-filters``` from taking 1m30s to start and lots of DB load, into returning 'immediately'.

## QA steps

```
  $ juju bootstrap lxd --debug --no-gui
  $ juju deploy ubuntu
  # generate lots of log entries, though '--debug' is likely to do that for you if you 
  # leave it running
  $ juju debug-log -m controller --include machine-0 --include-module XXX
```

Notice that without this patch, 'debug-log' will sometimes fail to start at all, and cause mongo failures because of loading too many documents to answer the filter.

## Documentation changes

It makes debug-log a lot more responsive. It also happens to force a limit of 10,000 lines in the "juju debug-log --lines XX" but this is more precautionary. I'm reasonably sure nobody really relied on the value, as we have '--replay' if you really want to go deep.

## Bug reference

[lp:1683992](https://bugs.launchpad.net/juju/+bug/1683992)
