### PR TITLE
provider/vsphere: various fixes

### DIFF
--- a/provider/vsphere/environ_broker.go
+++ b/provider/vsphere/environ_broker.go
@@ -9,14 +9,15 @@ import (
 	"os"
 	"path"
 	"sync"
+	"time"
 
 	"github.com/juju/errors"
+	"github.com/juju/utils/clock"
 	"github.com/vmware/govmomi/vim25/mo"
 
 	"github.com/juju/juju/cloudconfig/cloudinit"
 	"github.com/juju/juju/cloudconfig/instancecfg"
 	"github.com/juju/juju/cloudconfig/providerinit"
-	"github.com/juju/juju/constraints"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/provider/common"
@@ -26,9 +27,8 @@ import (
 )
 
 const (
-	DefaultCpuCores = uint64(2)
-	DefaultCpuPower = uint64(2000)
-	DefaultMemMb    = uint64(2000)
+	startInstanceUpdateProgressInterval = 30 * time.Second
+	bootstrapUpdateProgressInterval     = 5 * time.Second
 )
 
 func controllerFolderName(controllerUUID string) string {
@@ -135,22 +135,7 @@ func (env *sessionEnviron) newRawInstance(
 	logger.Debugf("Vmware user data; %d bytes", len(userData))
 
 	// Obtain the final constraints by merging with defaults.
-	uint64ptr := func(v uint64) *uint64 {
-		return &v
-	}
-	defaultCons := constraints.Value{
-		CpuCores: uint64ptr(DefaultCpuCores),
-		CpuPower: uint64ptr(DefaultCpuPower),
-		Mem:      uint64ptr(DefaultMemMb),
-	}
-	validator, err := env.ConstraintsValidator()
-	if err != nil {
-		return nil, nil, errors.Trace(err)
-	}
-	cons, err := validator.Merge(defaultCons, args.Constraints)
-	if err != nil {
-		return nil, nil, errors.Trace(err)
-	}
+	cons := args.Constraints
 	minRootDisk := common.MinRootDiskSizeGiB(args.InstanceConfig.Series) * 1024
 	if cons.RootDisk == nil || *cons.RootDisk < minRootDisk {
 		cons.RootDisk = &minRootDisk
@@ -165,6 +150,10 @@ func (env *sessionEnviron) newRawInstance(
 
 	// Download and extract the OVA file. If we're bootstrapping we use
 	// a temporary directory, otherwise we cache the image for future use.
+	updateProgressInterval := startInstanceUpdateProgressInterval
+	if args.InstanceConfig.Bootstrap != nil {
+		updateProgressInterval = bootstrapUpdateProgressInterval
+	}
 	updateProgress := func(message string) {
 		args.StatusCallback(status.Provisioning, message, nil)
 	}
@@ -180,13 +169,15 @@ func (env *sessionEnviron) newRawInstance(
 			controllerFolderName(args.ControllerUUID),
 			env.modelFolderName(),
 		),
-		OVADir:          ovaDir,
-		OVF:             string(ovf),
-		UserData:        string(userData),
-		Metadata:        args.InstanceConfig.Tags,
-		Constraints:     cons,
-		ExternalNetwork: externalNetwork,
-		UpdateProgress:  updateProgress,
+		OVADir:                 ovaDir,
+		OVF:                    string(ovf),
+		UserData:               string(userData),
+		Metadata:               args.InstanceConfig.Tags,
+		Constraints:            cons,
+		ExternalNetwork:        externalNetwork,
+		UpdateProgress:         updateProgress,
+		UpdateProgressInterval: updateProgressInterval,
+		Clock: clock.WallClock,
 	}
 
 	// Attempt to create a VM in each of the AZs in turn.

--- a/provider/vsphere/environ_broker_test.go
+++ b/provider/vsphere/environ_broker_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"time"
 
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
@@ -119,12 +120,14 @@ func (s *environBrokerSuite) TestStartInstance(c *gc.C) {
 	createVMArgs.UserData = ""
 	createVMArgs.Constraints = constraints.Value{}
 	createVMArgs.UpdateProgress = nil
+	createVMArgs.Clock = nil
 	c.Assert(createVMArgs, jc.DeepEquals, vsphereclient.CreateVirtualMachineParams{
-		Name:            "juju-f75cba-0",
-		Folder:          `Juju Controller (deadbeef-1bad-500d-9000-4b1d0d06f00d)/Model "testenv" (2d02eeac-9dbb-11e4-89d3-123b93f75cba)`,
-		OVF:             "FakeOvfContent",
-		Metadata:        startInstArgs.InstanceConfig.Tags,
-		ComputeResource: s.client.computeResources[0],
+		Name:                   "juju-f75cba-0",
+		Folder:                 `Juju Controller (deadbeef-1bad-500d-9000-4b1d0d06f00d)/Model "testenv" (2d02eeac-9dbb-11e4-89d3-123b93f75cba)`,
+		OVF:                    "FakeOvfContent",
+		Metadata:               startInstArgs.InstanceConfig.Tags,
+		ComputeResource:        s.client.computeResources[0],
+		UpdateProgressInterval: 5 * time.Second,
 	})
 }
 
@@ -234,16 +237,10 @@ func (s *environBrokerSuite) TestStartInstanceDefaultConstraintsApplied(c *gc.C)
 
 	var (
 		arch     = "amd64"
-		cpuCores = vsphere.DefaultCpuCores
-		cpuPower = vsphere.DefaultCpuPower
-		mem      = vsphere.DefaultMemMb
 		rootDisk = common.MinRootDiskSizeGiB("trusty") * 1024
 	)
 	c.Assert(res.Hardware, jc.DeepEquals, &instance.HardwareCharacteristics{
 		Arch:     &arch,
-		CpuCores: &cpuCores,
-		CpuPower: &cpuPower,
-		Mem:      &mem,
 		RootDisk: &rootDisk,
 	})
 }

--- a/provider/vsphere/internal/vsphereclient/createvm.go
+++ b/provider/vsphere/internal/vsphereclient/createvm.go
@@ -9,8 +9,11 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"time"
 
 	"github.com/juju/errors"
+	"github.com/juju/loggo"
+	"github.com/juju/utils/clock"
 	"github.com/vmware/govmomi/object"
 	"github.com/vmware/govmomi/vim25"
 	"github.com/vmware/govmomi/vim25/mo"
@@ -18,9 +21,12 @@ import (
 	"github.com/vmware/govmomi/vim25/soap"
 	"github.com/vmware/govmomi/vim25/types"
 	"golang.org/x/net/context"
+	"gopkg.in/juju/worker.v1"
 	"gopkg.in/tomb.v1"
 
 	"github.com/juju/juju/constraints"
+	jujuworker "github.com/juju/juju/worker"
+	"github.com/juju/juju/worker/catacomb"
 )
 
 // CreateVirtualMachineParams contains the parameters required for creating
@@ -61,6 +67,14 @@ type CreateVirtualMachineParams struct {
 	// UpdateProgress is a function that should be called before/during
 	// long-running operations to provide a progress reporting.
 	UpdateProgress func(string)
+
+	// UpdateProgressInterval is the amount of time to wait between calls
+	// to UpdateProgress. This should be lower when the operation is
+	// interactive (bootstrap), and higher when non-interactive.
+	UpdateProgressInterval time.Duration
+
+	// Clock is used for controlling the timing of progress updates.
+	Clock clock.Clock
 }
 
 // CreateVirtualMachine creates and powers on a new VM.
@@ -144,16 +158,31 @@ func (c *Client) CreateVirtualMachine(
 			})
 		}
 	}
+	leaseUpdaterContext := leaseUpdaterContext{lease: lease}
 	for _, item := range uploadItems {
+		leaseUpdaterContext.total += item.item.Size
+	}
+	for _, item := range uploadItems {
+		leaseUpdaterContext.size = item.item.Size
 		if err := uploadImage(
+			ctx,
 			c.client.Client,
 			item.item,
 			args.OVADir,
 			item.url,
 			args.UpdateProgress,
+			args.UpdateProgressInterval,
+			leaseUpdaterContext,
+			args.Clock,
+			c.logger,
 		); err != nil {
-			return nil, errors.Trace(err)
+			return nil, errors.Annotatef(
+				err, "uploading %s to %s",
+				filepath.Base(item.item.Path),
+				item.url,
+			)
 		}
+		leaseUpdaterContext.start += leaseUpdaterContext.size
 	}
 	if err := lease.HttpNfcLeaseComplete(ctx); err != nil {
 		return nil, errors.Trace(err)
@@ -206,13 +235,12 @@ func (c *Client) createImportSpec(
 	if args.Constraints.HasMem() {
 		s.MemoryMB = int64(*args.Constraints.Mem)
 	}
-	var cpuPower int64
 	if args.Constraints.HasCpuPower() {
-		cpuPower = int64(*args.Constraints.CpuPower)
-	}
-	s.CpuAllocation = &types.ResourceAllocationInfo{
-		Limit:       cpuPower,
-		Reservation: cpuPower,
+		cpuPower := int64(*args.Constraints.CpuPower)
+		s.CpuAllocation = &types.ResourceAllocationInfo{
+			Limit:       cpuPower,
+			Reservation: cpuPower,
+		}
 	}
 	for _, d := range s.DeviceChange {
 		disk, ok := d.GetVirtualDeviceConfigSpec().Device.(*types.VirtualDisk)
@@ -273,11 +301,16 @@ func (c *Client) createImportSpec(
 // uploadImage uploads an image from the given extracted OVA directory
 // to a target URL.
 func uploadImage(
+	ctx context.Context,
 	client *vim25.Client,
 	item types.OvfFileItem,
 	ovaDir string,
 	targetURL *url.URL,
-	updateProgress func(string),
+	updateStatus func(string),
+	updateStatusInterval time.Duration,
+	leaseUpdaterContext leaseUpdaterContext,
+	clock clock.Clock,
+	logger loggo.Logger,
 ) error {
 	sourcePath := filepath.Join(ovaDir, item.Path)
 	f, err := os.Open(sourcePath)
@@ -286,72 +319,157 @@ func uploadImage(
 	}
 	defer f.Close()
 
-	// Transfer image upload progress to the UpdateProgress function.
-	progressChan := make(chan progress.Report)
-	progressSink := progressUpdater{
-		ch:     progressChan,
-		update: updateProgress,
-		action: fmt.Sprintf("uploading %s", item.Path),
+	// Transfer upload progress to the updateStatus function.
+	statusUpdater := statusUpdater{
+		ch:       make(chan progress.Report),
+		clock:    clock,
+		logger:   logger,
+		update:   updateStatus,
+		action:   fmt.Sprintf("uploading %s", item.Path),
+		interval: updateStatusInterval,
 	}
-	go progressSink.loop()
-	defer progressSink.done()
 
+	// Update the lease periodically.
+	leaseUpdater := leaseUpdater{
+		ch:                  make(chan progress.Report),
+		clock:               clock,
+		logger:              logger,
+		ctx:                 ctx,
+		leaseUpdaterContext: leaseUpdaterContext,
+	}
+
+	// Upload.
 	opts := soap.Upload{
-		Method:        "POST",
-		Type:          "application/x-vnd.vmware-streamVmdk",
 		ContentLength: item.Size,
-		Progress:      &progressSink,
+		Progress:      progress.Tee(&statusUpdater, &leaseUpdater),
 	}
-	if err := client.Upload(f, targetURL, &opts); err != nil {
-		return errors.Annotatef(err, "uploading %s to %s", filepath.Base(item.Path), targetURL)
+	if item.Create {
+		opts.Method = "PUT"
+		opts.Headers = map[string]string{"Overwrite": "t"}
+	} else {
+		opts.Method = "POST"
+		opts.Type = "application/x-vnd.vmware-streamVmdk"
 	}
-	return nil
+	doUpload := func() error {
+		// NOTE(axw) client.Upload is not cancellable,
+		// as there is no way to inject a context. We
+		// should send a patch to govmomi to make it
+		// cancellable.
+		return errors.Trace(client.Upload(f, targetURL, &opts))
+	}
+
+	var site catacomb.Catacomb
+	if err := catacomb.Invoke(catacomb.Plan{
+		Site: &site,
+		Work: doUpload,
+		Init: []worker.Worker{
+			jujuworker.NewSimpleWorker(statusUpdater.loop),
+			jujuworker.NewSimpleWorker(leaseUpdater.loop),
+		},
+	}); err != nil {
+		return errors.Trace(err)
+	}
+	return site.Wait()
 }
 
-type progressUpdater struct {
-	tomb   tomb.Tomb
-	ch     chan progress.Report
-	update func(string)
-	action string
+type statusUpdater struct {
+	clock    clock.Clock
+	logger   loggo.Logger
+	ch       chan progress.Report
+	update   func(string)
+	action   string
+	interval time.Duration
 }
 
 // Sink is part of the progress.Sinker interface.
-func (u *progressUpdater) Sink() chan<- progress.Report {
+func (u *statusUpdater) Sink() chan<- progress.Report {
 	return u.ch
 }
 
-func (u *progressUpdater) loop() {
-	defer u.tomb.Done()
-	var last float32
-	const threshold = 10 // update status every X%
+func (u *statusUpdater) loop(abort <-chan struct{}) error {
+	timer := u.clock.NewTimer(u.interval)
+	defer timer.Stop()
+	var timerChan <-chan time.Time
+
+	var message string
 	for {
 		select {
-		case <-u.tomb.Dying():
-			u.tomb.Kill(tomb.ErrDying)
-			return
+		case <-abort:
+			return tomb.ErrDying
+		case <-timerChan:
+			u.update(message)
+			timer.Reset(u.interval)
+			timerChan = nil
 		case report, ok := <-u.ch:
 			if !ok {
-				return
+				return nil
 			}
-			var message string
 			if err := report.Error(); err != nil {
 				message = fmt.Sprintf("%s: %s", u.action, err)
 			} else {
-				pc := report.Percentage()
-				if pc < 100 && (pc-last) < threshold {
-					// Don't update yet, to avoid spamming
-					// status updates.
-					continue
-				}
-				last = pc
-				message = fmt.Sprintf("%s: %.2f%% (%s)", u.action, pc, report.Detail())
+				message = fmt.Sprintf(
+					"%s: %.2f%% (%s)",
+					u.action,
+					report.Percentage(),
+					report.Detail(),
+				)
 			}
-			u.update(message)
+			timerChan = timer.Chan()
 		}
 	}
 }
 
-func (u *progressUpdater) done() {
-	u.tomb.Kill(nil)
-	u.tomb.Wait()
+type leaseUpdaterContext struct {
+	lease *object.HttpNfcLease
+	start int64
+	size  int64
+	total int64
+}
+
+type leaseUpdater struct {
+	clock  clock.Clock
+	logger loggo.Logger
+	ch     chan progress.Report
+	ctx    context.Context
+	leaseUpdaterContext
+}
+
+// Sink is part of the progress.Sinker interface.
+func (u *leaseUpdater) Sink() chan<- progress.Report {
+	return u.ch
+}
+
+func (u *leaseUpdater) loop(abort <-chan struct{}) error {
+	const interval = 2 * time.Second
+	timer := u.clock.NewTimer(interval)
+	defer timer.Stop()
+
+	var progress int32
+	for {
+		select {
+		case <-abort:
+			return tomb.ErrDying
+		case report, ok := <-u.ch:
+			if !ok {
+				return nil
+			}
+			progress = u.progress(report.Percentage())
+		case <-timer.Chan():
+			if err := u.lease.HttpNfcLeaseProgress(u.ctx, progress); err != nil {
+				// NOTE(axw) we don't bail on error here, in
+				// case it's just a transient failure. If it
+				// is not, we would expect the upload to fail
+				// to abort anyway.
+				u.logger.Debugf("failed to update lease progress: %v", err)
+			}
+			timer.Reset(interval)
+		}
+	}
+}
+
+// progress computes the overall progress based on the size of the items
+// uploaded prior, and the upload percentage of the current item.
+func (u *leaseUpdater) progress(pc float32) int32 {
+	pos := float64(u.start) + (float64(pc) * float64(u.size) / 100)
+	return int32((100 * pos) / float64(u.total))
 }

--- a/provider/vsphere/internal/vsphereclient/createvm_test.go
+++ b/provider/vsphere/internal/vsphereclient/createvm_test.go
@@ -5,8 +5,11 @@ package vsphereclient
 
 import (
 	"io/ioutil"
+	"net/http"
 	"path/filepath"
+	"time"
 
+	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"github.com/vmware/govmomi/vim25/mo"
 	"github.com/vmware/govmomi/vim25/types"
@@ -14,6 +17,7 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/constraints"
+	coretesting "github.com/juju/juju/testing"
 )
 
 func (s *clientSuite) TestCreateVirtualMachine(c *gc.C) {
@@ -25,6 +29,16 @@ func (s *clientSuite) TestCreateVirtualMachine(c *gc.C) {
 	)
 	c.Assert(err, jc.ErrorIsNil)
 
+	testClock := testing.NewClock(time.Time{})
+	s.onImageUpload = func(*http.Request) {
+		// Wait until the status and lease updaters are waiting for
+		// the time to tick over, and then advance by 2 seconds to
+		// wake them both up.
+		testClock.WaitAdvance(2*time.Second, coretesting.LongWait, 2)
+		s.onImageUpload = nil
+	}
+
+	var progressUpdates []string
 	client := s.newFakeClient(&s.roundTripper, "dc0")
 	args := CreateVirtualMachineParams{
 		Name:     "vm-0",
@@ -45,13 +59,45 @@ func (s *clientSuite) TestCreateVirtualMachine(c *gc.C) {
 		Metadata:        map[string]string{"k": "v"},
 		Constraints:     constraints.Value{},
 		ExternalNetwork: "arpa",
-		UpdateProgress:  func(string) {},
+		UpdateProgress: func(progress string) {
+			progressUpdates = append(progressUpdates, progress)
+		},
+		UpdateProgressInterval: 2 * time.Second,
+		Clock: testClock,
 	}
 	_, err = client.CreateVirtualMachine(context.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(progressUpdates, jc.DeepEquals, []string{
+		"creating import spec",
+		`creating VM "vm-0"`,
+		"uploading ubuntu-14.04-server-cloudimg-amd64.vmdk: 100.00% (0B/s)",
+		"powering on",
+	})
 
 	c.Assert(s.uploadRequests, gc.HasLen, 1)
 	contents, err := ioutil.ReadAll(s.uploadRequests[0].Body)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(string(contents), gc.Equals, "image-contents")
+
+	s.roundTripper.CheckCalls(c, []testing.StubCall{
+		testing.StubCall{"CreateImportSpec", nil},
+		retrievePropertiesStubCall("FakeRootFolder"),
+		retrievePropertiesStubCall("FakeRootFolder"),
+		retrievePropertiesStubCall("FakeDatacenter"),
+		retrievePropertiesStubCall("FakeRootFolder"),
+		retrievePropertiesStubCall("FakeDatacenter"),
+		retrievePropertiesStubCall("FakeVmFolder"),
+		retrievePropertiesStubCall("FakeHostFolder"),
+		testing.StubCall{"ImportVApp", nil},
+		testing.StubCall{"CreatePropertyCollector", nil},
+		testing.StubCall{"CreateFilter", nil},
+		testing.StubCall{"WaitForUpdatesEx", nil},
+		testing.StubCall{"HttpNfcLeaseProgress", []interface{}{"FakeLease", int32(100)}},
+		testing.StubCall{"HttpNfcLeaseComplete", []interface{}{"FakeLease"}},
+		testing.StubCall{"PowerOnVM_Task", nil},
+		testing.StubCall{"CreatePropertyCollector", nil},
+		testing.StubCall{"CreateFilter", nil},
+		testing.StubCall{"WaitForUpdatesEx", nil},
+		retrievePropertiesStubCall(""),
+	})
 }

--- a/provider/vsphere/internal/vsphereclient/mock_test.go
+++ b/provider/vsphere/internal/vsphereclient/mock_test.go
@@ -92,12 +92,14 @@ func (r *mockRoundTripper) RoundTrip(ctx context.Context, req, res soap.HasFault
 					types.OvfFileItem{
 						DeviceId: "key1",
 						Path:     "ubuntu-14.04-server-cloudimg-amd64.vmdk",
+						Size:     14,
 					},
 				},
 				ImportSpec: &types.VirtualMachineImportSpec{},
 			},
 		}
 	case *methods.ImportVAppBody:
+		r.MethodCall(r, "ImportVApp")
 		res.Res = &types.ImportVAppResponse{lease}
 	case *methods.CreatePropertyCollectorBody:
 		r.MethodCall(r, "CreatePropertyCollector")
@@ -118,8 +120,13 @@ func (r *mockRoundTripper) RoundTrip(ctx context.Context, req, res soap.HasFault
 		}
 	case *methods.HttpNfcLeaseCompleteBody:
 		req := req.(*methods.HttpNfcLeaseCompleteBody).Req
+		r.MethodCall(r, "HttpNfcLeaseComplete", req.This.Value)
 		delete(r.collectors, req.This.Value)
 		res.Res = &types.HttpNfcLeaseCompleteResponse{}
+	case *methods.HttpNfcLeaseProgressBody:
+		req := req.(*methods.HttpNfcLeaseProgressBody).Req
+		r.MethodCall(r, "HttpNfcLeaseProgress", req.This.Value, req.Percent)
+		res.Res = &types.HttpNfcLeaseProgressResponse{}
 	case *methods.WaitForUpdatesExBody:
 		r.MethodCall(r, "WaitForUpdatesEx")
 		req := req.(*methods.WaitForUpdatesExBody).Req
@@ -170,29 +177,36 @@ func (r *mockRoundTripper) RoundTrip(ctx context.Context, req, res soap.HasFault
 
 func (r *mockRoundTripper) retrieveProperties(req *types.RetrieveProperties) *types.RetrievePropertiesResponse {
 	spec := req.SpecSet[0]
-	obj := spec.ObjectSet[0].Obj.Value
-	r.MethodCall(r, "RetrieveProperties", obj)
-	logger.Debugf("RetrieveProperties for %s", obj)
+	var args []interface{}
+	for _, obj := range spec.ObjectSet {
+		args = append(args, obj.Obj.Value)
+	}
+	r.MethodCall(r, "RetrieveProperties", args...)
+	logger.Debugf("RetrieveProperties for %s", args)
 	var contents []types.ObjectContent
-	for _, content := range r.contents[obj] {
-		var match bool
-		for _, prop := range spec.PropSet {
-			if prop.Type == content.Obj.Type {
-				match = true
-				break
+	for _, obj := range spec.ObjectSet {
+		for _, content := range r.contents[obj.Obj.Value] {
+			var match bool
+			for _, prop := range spec.PropSet {
+				if prop.Type == content.Obj.Type {
+					match = true
+					break
+				}
 			}
-		}
-		if match {
-			contents = append(contents, content)
+			if match {
+				contents = append(contents, content)
+			}
 		}
 	}
 	return &types.RetrievePropertiesResponse{contents}
 }
 
-func retrievePropertiesStubCall(obj string) testing.StubCall {
-	return testing.StubCall{
-		"RetrieveProperties", []interface{}{obj},
+func retrievePropertiesStubCall(objs ...string) testing.StubCall {
+	args := make([]interface{}, len(objs))
+	for i, obj := range objs {
+		args[i] = obj
 	}
+	return testing.StubCall{"RetrieveProperties", args}
 }
 
 type collector struct {


### PR DESCRIPTION
## Description of change

There are a few fixes bundled up here, for
issues found while testing against a resource
limited vCenter 6.5 installation.

The first and main change is to update the
lease obtained while uploading the VM image
and metadata. If this is not done, the
lease may expire, which will cause the VM
creation to fail. As part of making this
change, we now update the progress periodically
rather than when meeting/exceeding a bytes
transferred delta. This provides better
feedback in slow environments, and also
ensures the lease is updated regularly.

The second change is to not provide defaults
for cpu-cores, cpu-power, or mem. These
constraints not be satisfiable by all vSphere
environments.

The thid and final change is to stop making a
PowerOffVM_Task call for VMs that are not
powered on, when removing VMs. Making that
call causes an error, which prevents VM
removal.

## QA steps

1. Find a slow vCenter 6.5. The one I tested against was running on NUCs.
2. juju bootstrap vsphere
3. juju destroy-controller -y vsphere

## Documentation changes

None.

## Bug reference

Fixes https://bugs.launchpad.net/juju/+bug/1682393