### PR TITLE
Opensuse support

### DIFF
--- a/cloudconfig/cloudinit/cloudinit_centos.go
+++ b/cloudconfig/cloudinit/cloudinit_centos.go
@@ -17,23 +17,49 @@ import (
 	"github.com/juju/juju/feature"
 )
 
+//PackageHelper is the interface for configuring specific parameter of the package manager
+type packageHelper interface {
+	// addPackageProxyCmd is a helper method which returns the corresponding runcmd
+	// to apply the package proxy settings.
+	addPackageProxyCmd(url string) string
+
+	//Returns the required packages, depending on the OS
+	getRequiredPackages() []string
+}
+
+//Implementation of PackageHelper for CentOS
+type centOSHelper struct {
+}
+
+//Returns the list of required packages in CentOS
+func (helper centOSHelper) getRequiredPackages() []string {
+	return []string{
+		"curl",
+		"bridge-utils",
+		"cloud-utils",
+		"nmap-ncat",
+		"tmux",
+	}
+}
+
+// addPackageProxyCmd is a helper method which returns the corresponding runcmd
+// to apply the package proxy settings for CentOS
+func (helper centOSHelper) addPackageProxyCmd(url string) string {
+	return fmt.Sprintf("/bin/echo 'proxy=%s' >> /etc/yum.conf", url)
+}
+
 // centOSCloudConfig is the cloudconfig type specific to CentOS machines.
 // It simply contains a cloudConfig and adds the package management related
 // methods for CentOS, which are mostly modeled as runcmds.
 // It implements the cloudinit.Config interface.
 type centOSCloudConfig struct {
 	*cloudConfig
+	helper packageHelper
 }
 
 // SetPackageProxy is defined on the PackageProxyConfig interface.
 func (cfg *centOSCloudConfig) SetPackageProxy(url string) {
 	cfg.SetAttr("package_proxy", url)
-}
-
-// addPackageProxyCmd is a helper function which returns the corresponding runcmd
-// to apply the package proxy settings on a CentOS machine.
-func addPackageProxyCmd(cfg CloudConfig, url string) string {
-	return fmt.Sprintf("/bin/echo 'proxy=%s' >> /etc/yum.conf", url)
 }
 
 // UnsetPackageProxy is defined on the PackageProxyConfig interface.
@@ -101,7 +127,7 @@ func (cfg *centOSCloudConfig) RenderYAML() ([]byte, error) {
 	// check for package proxy setting and add commands:
 	var proxy string
 	if proxy = cfg.PackageProxy(); proxy != "" {
-		cfg.AddRunCmd(addPackageProxyCmd(cfg, proxy))
+		cfg.AddRunCmd(cfg.helper.addPackageProxyCmd(proxy))
 		cfg.UnsetPackageProxy()
 	}
 
@@ -208,13 +234,8 @@ func (cfg *centOSCloudConfig) AddPackageCommands(
 
 // addRequiredPackages is defined on the AdvancedPackagingConfig interface.
 func (cfg *centOSCloudConfig) addRequiredPackages() {
-	packages := []string{
-		"curl",
-		"bridge-utils",
-		"cloud-utils",
-		"nmap-ncat",
-		"tmux",
-	}
+
+	packages := cfg.helper.getRequiredPackages()
 	if featureflag.Enabled(feature.DeveloperMode) {
 		packages = append(packages, "socat")
 	}

--- a/cloudconfig/cloudinit/cloudinit_opensuse.go
+++ b/cloudconfig/cloudinit/cloudinit_opensuse.go
@@ -1,0 +1,34 @@
+// Copyright 2015 Canonical Ltd.
+// Copyright 2015 Cloudbase Solutions SRL
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package cloudinit
+
+import (
+	"github.com/juju/utils/packaging/commands"
+	"github.com/juju/utils/proxy"
+)
+
+//Implementation of PackageHelper for OpenSUSE
+type openSUSEHelper struct {
+	paccmder commands.PackageCommander
+}
+
+//Returns the list of required packages in OpenSUSE
+func (helper openSUSEHelper) getRequiredPackages() []string {
+	return []string{
+		"curl",
+		"bridge-utils",
+		//"cloud-utils", Put as a requirement to the cloud image (requires subscription)
+		"ncat",
+		"tmux",
+	}
+}
+
+// addPackageProxyCmd is a helper method which returns the corresponding runcmd
+// to apply the package proxy settings for OpenSUSE
+func (helper openSUSEHelper) addPackageProxyCmd(url string) string {
+	return helper.paccmder.SetProxyCmds(proxy.Settings{
+		Http: url,
+	})[0]
+}

--- a/cloudconfig/cloudinit/interface.go
+++ b/cloudconfig/cloudinit/interface.go
@@ -426,12 +426,27 @@ func New(ser string) (CloudConfig, error) {
 	case os.CentOS:
 		renderer, _ := shell.NewRenderer("bash")
 		return &centOSCloudConfig{
-			&cloudConfig{
+			cloudConfig: &cloudConfig{
 				series:    ser,
 				paccmder:  commands.NewYumPackageCommander(),
 				pacconfer: config.NewYumPackagingConfigurer(ser),
 				renderer:  renderer,
 				attrs:     make(map[string]interface{}),
+			},
+			helper: centOSHelper{},
+		}, nil
+	case os.OpenSUSE:
+		renderer, _ := shell.NewRenderer("bash")
+		return &centOSCloudConfig{
+			cloudConfig: &cloudConfig{
+				series:    ser,
+				paccmder:  commands.NewZypperPackageCommander(),
+				pacconfer: config.NewZypperPackagingConfigurer(ser),
+				renderer:  renderer,
+				attrs:     make(map[string]interface{}),
+			},
+			helper: openSUSEHelper{
+				paccmder: commands.NewZypperPackageCommander(),
 			},
 		}, nil
 	default:

--- a/cloudconfig/userdatacfg.go
+++ b/cloudconfig/userdatacfg.go
@@ -66,6 +66,8 @@ func NewUserdataConfig(icfg *instancecfg.InstanceConfig, conf cloudinit.CloudCon
 		return &unixConfigure{base}, nil
 	case os.CentOS:
 		return &unixConfigure{base}, nil
+	case os.OpenSUSE:
+		return &unixConfigure{base}, nil
 	case os.Windows:
 		return &windowsConfigure{base}, nil
 	default:
@@ -151,6 +153,8 @@ func SetUbuntuUser(conf cloudinit.CloudConfig, authorizedKeys string) {
 			groups = UbuntuGroups
 		case os.CentOS:
 			groups = CentOSGroups
+		case os.OpenSUSE:
+			groups = OpenSUSEGroups
 		}
 		conf.AddUser(&cloudinit.User{
 			Name:              "ubuntu",

--- a/cmd/jujud/upgrade_mongo.go
+++ b/cmd/jujud/upgrade_mongo.go
@@ -612,9 +612,11 @@ func (u *UpgradeMongoCommand) removeOldDb(dataDir string) error {
 }
 
 func satisfyPrerequisites(operatingsystem string) error {
-	// CentOS is not currently supported by our mongo package.
+	// CentOS and OpenSUSE are  not currently supported by our mongo package.
 	if operatingsystem == "centos7" {
 		return errors.New("centos7 is still not suported by this upgrade")
+	} else if operatingsystem == "opensuseleap" {
+		return errors.New("openSUSE Leap is still not suported by this upgrade")
 	}
 
 	pacman, err := manager.NewPackageManager(operatingsystem)

--- a/environs/manual/sshprovisioner/sshprovisioner.go
+++ b/environs/manual/sshprovisioner/sshprovisioner.go
@@ -80,7 +80,8 @@ func InitUbuntuUser(host, login, authorizedKeys string, read io.Reader, write io
 
 const initUbuntuScript = `
 set -e
-(id ubuntu &> /dev/null) || useradd -m ubuntu -s /bin/bash
+(grep ubuntu /etc/group) || groupadd ubuntu
+(id ubuntu &> /dev/null) || useradd -m ubuntu -s /bin/bash -g ubuntu
 umask 0077
 temp=$(mktemp)
 echo 'ubuntu ALL=(ALL) NOPASSWD:ALL' > $temp
@@ -192,6 +193,11 @@ os_id=$(grep '^ID=' /etc/os-release | tr -d '"' | cut -d= -f2)
 if [ "$os_id" = 'centos' ]; then
   os_version=$(grep '^VERSION_ID=' /etc/os-release | tr -d '"' | cut -d= -f2)
   echo "centos$os_version"
+elif [ "$os_id" = 'opensuse' ]; then
+  os_version=$(grep '^VERSION_ID=' /etc/os-release | tr -d '"' | cut -d= -f2 | cut -d. -f1)
+  if [ $os_version -eq 42]; then
+    echo "opensuseleap"
+  fi
 else
   lsb_release -cs
 fi

--- a/provider/common/disk.go
+++ b/provider/common/disk.go
@@ -16,7 +16,7 @@ func MinRootDiskSizeGiB(series string) uint64 {
 	// See comment below that explains why we're ignoring the error
 	os, _ := jujuseries.GetOSFromSeries(series)
 	switch os {
-	case jujuos.Ubuntu, jujuos.CentOS:
+	case jujuos.Ubuntu, jujuos.CentOS, jujuos.OpenSUSE:
 		return 8
 	case jujuos.Windows:
 		return 40

--- a/provider/common/disk_test.go
+++ b/provider/common/disk_test.go
@@ -21,6 +21,7 @@ func (s *DiskSuite) TestMinRootDiskSizeGiB(c *gc.C) {
 		{"trusty", 8},
 		{"win2012r2", 40},
 		{"centos7", 8},
+		{"opensuseleap", 8},
 		{"fake-series", 8},
 	}
 	for _, t := range diskTests {

--- a/provider/lxd/userdata.go
+++ b/provider/lxd/userdata.go
@@ -18,7 +18,7 @@ type lxdRenderer struct{}
 // EncodeUserdata implements renderers.ProviderRenderer.
 func (lxdRenderer) Render(cfg cloudinit.CloudConfig, os jujuos.OSType) ([]byte, error) {
 	switch os {
-	case jujuos.Ubuntu, jujuos.CentOS:
+	case jujuos.Ubuntu, jujuos.CentOS, jujuos.OpenSUSE:
 		return renderers.RenderYAML(cfg)
 	default:
 		return nil, errors.Errorf("cannot encode userdata for OS %q", os)

--- a/service/discovery.go
+++ b/service/discovery.go
@@ -87,6 +87,8 @@ func versionInitSystem(ser string) (string, error) {
 		}
 	case os.CentOS:
 		return InitSystemSystemd, nil
+	case os.OpenSUSE:
+		return InitSystemSystemd, nil
 	}
 	return "", errors.NotFoundf("unknown os %q (from series %q), init system", seriesos, ser)
 }

--- a/service/discovery_test.go
+++ b/service/discovery_test.go
@@ -136,6 +136,10 @@ var discoveryTests = []discoveryTest{{
 	series:   "centos7",
 	expected: service.InitSystemSystemd,
 }, {
+	os:       jujuos.OpenSUSE,
+	series:   "opensuseleap",
+	expected: service.InitSystemSystemd,
+}, {
 	os:       jujuos.Unknown,
 	expected: "",
 }}

--- a/service/systemd/conf.go
+++ b/service/systemd/conf.go
@@ -46,6 +46,8 @@ func syslogUserGroup() (string, string) {
 	switch os.HostOS() {
 	case os.CentOS:
 		return "root", "adm"
+	case os.OpenSUSE:
+		return "root", "root"
 	default:
 		return "syslog", "syslog"
 	}

--- a/testing/base.go
+++ b/testing/base.go
@@ -250,6 +250,10 @@ func GetPackageManager() (s PackageManagerStruct, err error) {
 		s.PackageManager = "yum"
 		s.PackageQuery = "yum"
 		s.RepositoryManager = "yum-config-manager --add-repo"
+	case jujuos.OpenSUSE:
+		s.PackageManager = "zypper"
+		s.PackageQuery = "zypper"
+		s.RepositoryManager = "zypper addrepo"
 	case jujuos.Ubuntu:
 		s.PackageManager = "apt-get"
 		s.PackageQuery = "dpkg-query"

--- a/tools/lxdclient/client_image.go
+++ b/tools/lxdclient/client_image.go
@@ -203,6 +203,10 @@ func seriesRemoteAliases(series, arch string) ([]string, error) {
 		if series == "centos7" && arch == jujuarch.AMD64 {
 			return []string{"centos/7/amd64"}, nil
 		}
+	case os.OpenSUSE:
+		if series == "opensuseleap" && arch == jujuarch.AMD64 {
+			return []string{"opensuse/42.2/amd64"}, nil
+		}
 	}
 	return nil, errors.NotSupportedf("series %q", series)
 }

--- a/tools/lxdclient/client_image_test.go
+++ b/tools/lxdclient/client_image_test.go
@@ -129,6 +129,7 @@ func (s *stubConnector) connectToSource(remote Remote) (remoteClient, error) {
 func (s *imageSuite) TestEnsureImageExistsAlreadyPresent(c *gc.C) {
 	s.testEnsureImageExistsAlreadyPresent(c, "trusty", "ppc64el", "juju/trusty/ppc64el")
 	s.testEnsureImageExistsAlreadyPresent(c, "centos7", "ppc64el", "juju/centos7/ppc64el")
+	s.testEnsureImageExistsAlreadyPresent(c, "opensuseleap", "ppc64el", "juju/opensuseleap/ppc64el")
 }
 
 func (s *imageSuite) testEnsureImageExistsAlreadyPresent(c *gc.C, series, arch, localAlias string) {

--- a/version/current_test.go
+++ b/version/current_test.go
@@ -42,6 +42,13 @@ func (*CurrentSuite) TestCurrentSeries(c *gc.C) {
 			}
 		}
 	} else {
-		c.Assert(string(out), gc.Equals, "Codename:\t"+s+"\n")
+		//OpenSUSE lsb-release returns n/a
+		current_os, err := series.GetOSFromSeries(s)
+		c.Assert(err, gc.IsNil)
+		if string(out) == "n/a" && current_os == os.OpenSUSE {
+			c.Check(s, gc.Matches, "opensuseleap")
+		} else {
+			c.Assert(string(out), gc.Equals, "Codename:\t"+s+"\n")
+		}
 	}
 }

--- a/worker/provisioner/container_initialisation_test.go
+++ b/worker/provisioner/container_initialisation_test.go
@@ -289,6 +289,10 @@ func (s *ContainerSetupSuite) assertContainerInitialised(c *gc.C, cont Container
 		ser = "centos7"
 		expected_initial = []string{
 			"yum", "--assumeyes", "--debuglevel=1", "install"}
+	case jujuos.OpenSUSE:
+		ser = "opensuseleap"
+		expected_initial = []string{
+			"zypper", " --quiet", "--non-interactive-include-reboot-patches", "install"}
 	default:
 		ser = "precise"
 		expected_initial = []string{

--- a/worker/uniter/runner/context/env.go
+++ b/worker/uniter/runner/context/env.go
@@ -20,6 +20,8 @@ func OSDependentEnvVars(paths Paths) []string {
 		return ubuntuEnv(paths)
 	case jujuos.CentOS:
 		return centosEnv(paths)
+	case jujuos.OpenSUSE:
+		return opensuseEnv(paths)
 	}
 	return nil
 }
@@ -41,6 +43,10 @@ func ubuntuEnv(paths Paths) []string {
 }
 
 func centosEnv(paths Paths) []string {
+	return appendPath(paths)
+}
+
+func opensuseEnv(paths Paths) []string {
 	return appendPath(paths)
 }
 


### PR DESCRIPTION
## Description of change

This change add the support of OpenSUSE Leap (42 series) to Juju. 

Main reason for the change is that most of our NVF run on top of OpenSUSE/SLES and I was doing some hands-on for evaluating Juju as a generic VNF-M. This PR  (and other for juju/utils) is the result of my work.

With these PR, Juju users are able to deploy OpenSUSE charms in LXD and in manual provisioned OpenSUSE host.

This PR depends on: https://github.com/juju/utils/pull/277

## QA steps

A part of the testing that I added, it is possible to deploy an OpenSUSE charm:
https://github.com/marcmolla/juju-OpenSUSE/tree/master/charms/test-opensuseleap

using a modified OpenSUSE image:
https://github.com/marcmolla/juju-OpenSUSE/blob/master/lxd-opensuse-42.2-image.md

I also describe how I tested the software locally:
https://github.com/marcmolla/juju-OpenSUSE/blob/master/test-compiled-Juju.md

For all those testing we also need another PR to juju/utils (https://github.com/juju/utils/pull/272)

## Documentation changes

If this PR is accepted, we should include reference to OpenSUSE in general doc.

## Bug reference

N/A