### PR TITLE
Add application offers to allwatcher

### DIFF
--- a/apiserver/client/api_test.go
+++ b/apiserver/client/api_test.go
@@ -7,10 +7,10 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils/clock"
 	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/charm.v6-unstable"
 	"gopkg.in/juju/names.v2"
 	worker "gopkg.in/juju/worker.v1"
 
@@ -19,6 +19,7 @@ import (
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/constraints"
 	"github.com/juju/juju/environs/config"
+	"github.com/juju/juju/feature"
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/mongo"
@@ -36,59 +37,13 @@ type baseSuite struct {
 }
 
 func (s *baseSuite) SetUpTest(c *gc.C) {
+	s.SetInitialFeatureFlags(feature.CrossModelRelations)
 	s.JujuConnSuite.SetUpTest(c)
 	s.BlockHelper = commontesting.NewBlockHelper(s.APIState)
 	s.AddCleanup(func(*gc.C) { s.BlockHelper.Close() })
 }
 
 var _ = gc.Suite(&baseSuite{})
-
-func chanReadEmpty(c *gc.C, ch <-chan struct{}, what string) bool {
-	select {
-	case _, ok := <-ch:
-		return ok
-	case <-time.After(10 * time.Second):
-		c.Fatalf("timed out reading from %s", what)
-	}
-	panic("unreachable")
-}
-
-func chanReadStrings(c *gc.C, ch <-chan []string, what string) ([]string, bool) {
-	select {
-	case changes, ok := <-ch:
-		return changes, ok
-	case <-time.After(10 * time.Second):
-		c.Fatalf("timed out reading from %s", what)
-	}
-	panic("unreachable")
-}
-
-func chanReadConfig(c *gc.C, ch <-chan *config.Config, what string) (*config.Config, bool) {
-	select {
-	case envConfig, ok := <-ch:
-		return envConfig, ok
-	case <-time.After(10 * time.Second):
-		c.Fatalf("timed out reading from %s", what)
-	}
-	panic("unreachable")
-}
-
-func removeServiceAndUnits(c *gc.C, service *state.Application) {
-	// Destroy all units for the application.
-	units, err := service.AllUnits()
-	c.Assert(err, jc.ErrorIsNil)
-	for _, unit := range units {
-		err = unit.EnsureDead()
-		c.Assert(err, jc.ErrorIsNil)
-		err = unit.Remove()
-		c.Assert(err, jc.ErrorIsNil)
-	}
-	err = service.Destroy()
-	c.Assert(err, jc.ErrorIsNil)
-
-	err = service.Refresh()
-	c.Assert(err, jc.Satisfies, errors.IsNotFound)
-}
 
 // apiAuthenticator represents a simple authenticator object with only the
 // SetPassword and Tag methods.  This will fit types from both the state
@@ -232,7 +187,24 @@ var scenarioStatus = &params.FullStatus{
 			WantsVote:   false,
 		},
 	},
-	RemoteApplications: map[string]params.RemoteApplicationStatus{},
+	RemoteApplications: map[string]params.RemoteApplicationStatus{
+		"remote-db2": {
+			ApplicationURL:  "admin/prod.db2",
+			ApplicationName: "remote-db2",
+			Endpoints: []params.RemoteEndpoint{{
+				Name:      "database",
+				Interface: "db2",
+				Role:      "provider",
+				Scope:     "global",
+			}},
+			Relations: map[string][]string{},
+			Status: params.DetailedStatus{
+				Status: status.Unknown.String(),
+				Info:   "waiting for remote connection",
+				Data:   map[string]interface{}{},
+			},
+		},
+	},
 	Applications: map[string]params.ApplicationStatus{
 		"logging": {
 			Charm:  "local:quantal/logging-1",
@@ -425,6 +397,22 @@ func (s *baseSuite) setUpScenario(c *gc.C) (entities []names.Tag) {
 	eps, err := s.State.InferEndpoints("logging", "wordpress")
 	c.Assert(err, jc.ErrorIsNil)
 	rel, err := s.State.AddRelation(eps...)
+	c.Assert(err, jc.ErrorIsNil)
+
+	_, err = s.State.AddRemoteApplication(state.AddRemoteApplicationParams{
+		Name:        "remote-db2",
+		OfferName:   "hosted-db2",
+		URL:         "admin/prod.db2",
+		SourceModel: coretesting.ModelTag,
+		Endpoints: []charm.Relation{
+			{
+				Name:      "database",
+				Interface: "db2",
+				Role:      charm.RoleProvider,
+				Scope:     charm.ScopeGlobal,
+			},
+		},
+	})
 	c.Assert(err, jc.ErrorIsNil)
 
 	for i := 0; i < 2; i++ {

--- a/apiserver/client/backend.go
+++ b/apiserver/client/backend.go
@@ -73,7 +73,7 @@ type Backend interface {
 	Subnet(string) (*state.Subnet, error)
 	Unit(string) (Unit, error)
 	UpdateModelConfig(map[string]interface{}, []string, state.ValidateConfigFunc) error
-	Watch() *state.Multiwatcher
+	Watch(params state.WatchParams) *state.Multiwatcher
 }
 
 func NewStateBackend(st *state.State) Backend {

--- a/apiserver/client/client_test.go
+++ b/apiserver/client/client_test.go
@@ -455,8 +455,8 @@ var _ = gc.Suite(&clientSuite{})
 // clearSinceTimes zeros out the updated timestamps inside status
 // so we can easily check the results.
 func clearSinceTimes(status *params.FullStatus) {
-	for applicationId, service := range status.Applications {
-		for unitId, unit := range service.Units {
+	for applicationId, application := range status.Applications {
+		for unitId, unit := range application.Units {
 			unit.WorkloadStatus.Since = nil
 			unit.AgentStatus.Since = nil
 			for id, subord := range unit.Subordinates {
@@ -464,10 +464,14 @@ func clearSinceTimes(status *params.FullStatus) {
 				subord.AgentStatus.Since = nil
 				unit.Subordinates[id] = subord
 			}
-			service.Units[unitId] = unit
+			application.Units[unitId] = unit
 		}
-		service.Status.Since = nil
-		status.Applications[applicationId] = service
+		application.Status.Since = nil
+		status.Applications[applicationId] = application
+	}
+	for applicationId, application := range status.RemoteApplications {
+		application.Status.Since = nil
+		status.RemoteApplications[applicationId] = application
 	}
 	for id, machine := range status.Machines {
 		machine.AgentStatus.Since = nil
@@ -637,7 +641,7 @@ func (s *clientRepoSuite) TearDownTest(c *gc.C) {
 	s.baseSuite.TearDownTest(c)
 }
 
-func (s *clientSuite) TestClientWatchAll(c *gc.C) {
+func (s *clientSuite) TestClientWatchAllReadPermission(c *gc.C) {
 	loggo.GetLogger("juju.apiserver").SetLogLevel(loggo.TRACE)
 	// A very simple end-to-end test, because
 	// all the logic is tested elsewhere.
@@ -645,7 +649,15 @@ func (s *clientSuite) TestClientWatchAll(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	err = m.SetProvisioned("i-0", agent.BootstrapNonce, nil)
 	c.Assert(err, jc.ErrorIsNil)
-	watcher, err := s.APIState.Client().WatchAll()
+
+	user := s.Factory.MakeUser(c, &factory.UserParams{
+		Password: "ro-password",
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	roClient := s.OpenAPIAs(c, user.UserTag(), "ro-password").Client()
+	defer roClient.Close()
+
+	watcher, err := roClient.WatchAll()
 	c.Assert(err, jc.ErrorIsNil)
 	defer func() {
 		err := watcher.Stop()
@@ -678,6 +690,101 @@ func (s *clientSuite) TestClientWatchAll(c *gc.C) {
 			WantsVote:               true,
 		},
 	}}) {
+		c.Logf("got:")
+		for _, d := range deltas {
+			c.Logf("%#v\n", d.Entity)
+		}
+	}
+}
+
+func (s *clientSuite) TestClientWatchAllAdminPermission(c *gc.C) {
+	loggo.GetLogger("juju.apiserver").SetLogLevel(loggo.TRACE)
+	// A very simple end-to-end test, because
+	// all the logic is tested elsewhere.
+	m, err := s.State.AddMachine("quantal", state.JobManageModel)
+	c.Assert(err, jc.ErrorIsNil)
+	err = m.SetProvisioned("i-0", agent.BootstrapNonce, nil)
+	c.Assert(err, jc.ErrorIsNil)
+	// Include a remote app that needs admin access to see.
+	_, err = s.State.AddRemoteApplication(state.AddRemoteApplicationParams{
+		Name:        "remote-db2",
+		OfferName:   "hosted-db2",
+		URL:         "admin/prod.db2",
+		SourceModel: coretesting.ModelTag,
+		Endpoints: []charm.Relation{
+			{
+				Name:      "database",
+				Interface: "db2",
+				Role:      charm.RoleProvider,
+				Scope:     charm.ScopeGlobal,
+			},
+		},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	watcher, err := s.APIState.Client().WatchAll()
+	c.Assert(err, jc.ErrorIsNil)
+	defer func() {
+		err := watcher.Stop()
+		c.Assert(err, jc.ErrorIsNil)
+	}()
+	deltas, err := watcher.Next()
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Assert(len(deltas), gc.Equals, 2)
+	mIndex := 0
+	aIndex := 1
+	dMachine, ok0 := deltas[mIndex].Entity.(*multiwatcher.MachineInfo)
+	dApp, ok1 := deltas[aIndex].Entity.(*multiwatcher.RemoteApplicationInfo)
+	if !ok0 {
+		mIndex = 1
+		aIndex = 0
+		dMachine, ok0 = deltas[mIndex].Entity.(*multiwatcher.MachineInfo)
+		dApp, ok1 = deltas[aIndex].Entity.(*multiwatcher.RemoteApplicationInfo)
+	}
+	c.Assert(ok0, jc.IsTrue)
+	c.Assert(ok1, jc.IsTrue)
+	dMachine.AgentStatus.Since = nil
+	dMachine.InstanceStatus.Since = nil
+	dApp.Status.Since = nil
+
+	if !c.Check(deltas[mIndex], jc.DeepEquals, multiwatcher.Delta{
+		Entity: &multiwatcher.MachineInfo{
+			ModelUUID:  s.State.ModelUUID(),
+			Id:         m.Id(),
+			InstanceId: "i-0",
+			AgentStatus: multiwatcher.StatusInfo{
+				Current: status.Pending,
+			},
+			InstanceStatus: multiwatcher.StatusInfo{
+				Current: status.Pending,
+			},
+			Life:                    multiwatcher.Life("alive"),
+			Series:                  "quantal",
+			Jobs:                    []multiwatcher.MachineJob{state.JobManageModel.ToParams()},
+			Addresses:               []multiwatcher.Address{},
+			HardwareCharacteristics: &instance.HardwareCharacteristics{},
+			HasVote:                 false,
+			WantsVote:               true,
+		},
+	}) {
+		c.Logf("got:")
+		for _, d := range deltas {
+			c.Logf("%#v\n", d.Entity)
+		}
+	}
+	if !c.Check(deltas[aIndex], jc.DeepEquals, multiwatcher.Delta{
+		Entity: &multiwatcher.RemoteApplicationInfo{
+			Name:           "remote-db2",
+			ModelUUID:      s.State.ModelUUID(),
+			ApplicationURL: "admin/prod.db2",
+			Life:           "alive",
+			Status: multiwatcher.StatusInfo{
+				Current: status.Unknown,
+				Message: "waiting for remote connection",
+			},
+		},
+	}) {
 		c.Logf("got:")
 		for _, d := range deltas {
 			c.Logf("%#v\n", d.Entity)

--- a/apiserver/client/status.go
+++ b/apiserver/client/status.go
@@ -896,6 +896,7 @@ func (context *statusContext) processRemoteApplication(application *state.Remote
 			Name:      ep.Name,
 			Interface: ep.Interface,
 			Role:      ep.Role,
+			Scope:     ep.Scope,
 		}
 	}
 	status.Life = processLife(application)

--- a/core/crossmodel/interface.go
+++ b/core/crossmodel/interface.go
@@ -33,7 +33,7 @@ type AddApplicationOfferArgs struct {
 	// Owner is the user name who owns the offer.
 	Owner string
 
-	// HasRead are rthe user names who can see the offer exists.
+	// HasRead are the user names who can see the offer exists.
 	HasRead []string
 
 	// ApplicationName is the name of the application to which the offer pertains.

--- a/state/applicationoffers.go
+++ b/state/applicationoffers.go
@@ -172,7 +172,7 @@ func (s *applicationOffers) AddOffer(offerArgs crossmodel.AddApplicationOfferArg
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	doc := s.makeApplicationOfferDoc(uuid.String(), offerArgs)
+	doc := s.makeApplicationOfferDoc(s.st, uuid.String(), offerArgs)
 	result, err := s.makeApplicationOffer(doc)
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -243,7 +243,7 @@ func (s *applicationOffers) UpdateOffer(offerArgs crossmodel.AddApplicationOffer
 		// In either case, we return the error.
 		return nil, errors.Trace(err)
 	}
-	doc := s.makeApplicationOfferDoc(offer.OfferUUID, offerArgs)
+	doc := s.makeApplicationOfferDoc(s.st, offer.OfferUUID, offerArgs)
 	buildTxn := func(attempt int) ([]txn.Op, error) {
 		// If we've tried once already and failed, check that
 		// environment may have been destroyed.
@@ -276,9 +276,9 @@ func (s *applicationOffers) UpdateOffer(offerArgs crossmodel.AddApplicationOffer
 	return s.makeApplicationOffer(doc)
 }
 
-func (s *applicationOffers) makeApplicationOfferDoc(uuid string, offer crossmodel.AddApplicationOfferArgs) applicationOfferDoc {
+func (s *applicationOffers) makeApplicationOfferDoc(st *State, uuid string, offer crossmodel.AddApplicationOfferArgs) applicationOfferDoc {
 	doc := applicationOfferDoc{
-		DocID:                  offer.OfferName,
+		DocID:                  st.docID(offer.OfferName),
 		OfferUUID:              uuid,
 		OfferName:              offer.OfferName,
 		ApplicationName:        offer.ApplicationName,

--- a/state/multiwatcher/multiwatcher.go
+++ b/state/multiwatcher/multiwatcher.go
@@ -209,13 +209,31 @@ type RemoteApplicationInfo struct {
 	Status         StatusInfo `json:"status"`
 }
 
-// EntityId returns a unique identifier for a remote application across
-// environments.
+// EntityId returns a unique identifier for a remote application across models.
 func (i *RemoteApplicationInfo) EntityId() EntityId {
 	return EntityId{
 		Kind:      "remoteApplication",
 		ModelUUID: i.ModelUUID,
 		Id:        i.Name,
+	}
+}
+
+// ApplicationOfferInfo holds the information about an application offer that is
+// tracked by multiwatcherStore.
+type ApplicationOfferInfo struct {
+	ModelUUID       string `json:"model-uuid"`
+	OfferName       string `json:"offer-name"`
+	ApplicationName string `json:"application-name"`
+	CharmName       string `json:"charm-name"`
+	ConnectedCount  int    `json:"connected-count"`
+}
+
+// EntityId returns a unique identifier for an application offer across models.
+func (i *ApplicationOfferInfo) EntityId() EntityId {
+	return EntityId{
+		Kind:      "applicationOffer",
+		ModelUUID: i.ModelUUID,
+		Id:        i.OfferName,
 	}
 }
 

--- a/state/multiwatcher/multiwatcher_internal_test.go
+++ b/state/multiwatcher/multiwatcher_internal_test.go
@@ -13,6 +13,8 @@ import (
 var (
 	_ EntityInfo = (*MachineInfo)(nil)
 	_ EntityInfo = (*ApplicationInfo)(nil)
+	_ EntityInfo = (*RemoteApplicationInfo)(nil)
+	_ EntityInfo = (*ApplicationOfferInfo)(nil)
 	_ EntityInfo = (*UnitInfo)(nil)
 	_ EntityInfo = (*RelationInfo)(nil)
 	_ EntityInfo = (*AnnotationInfo)(nil)

--- a/state/state.go
+++ b/state/state.go
@@ -538,8 +538,15 @@ func (st *State) MongoSession() *mgo.Session {
 	return st.session
 }
 
-func (st *State) Watch() *Multiwatcher {
-	return NewMultiwatcher(st.workers.allManager())
+// WatchParams defines config to control which
+// entites are included when watching a model.
+type WatchParams struct {
+	// IncludeOffers controls whether application offers should be watched.
+	IncludeOffers bool
+}
+
+func (st *State) Watch(params WatchParams) *Multiwatcher {
+	return NewMultiwatcher(st.workers.allManager(params))
 }
 
 func (st *State) WatchAllModels(pool *StatePool) *Multiwatcher {

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -211,7 +211,7 @@ func (s *StateSuite) TestWatch(c *gc.C) {
 	// elsewhere. This just ensures things are hooked up correctly in
 	// State.Watch()
 
-	w := s.State.Watch()
+	w := s.State.Watch(state.WatchParams{IncludeOffers: true})
 	defer w.Stop()
 	deltasC := makeMultiwatcherOutput(w)
 	s.State.StartSync()

--- a/state/workers.go
+++ b/state/workers.go
@@ -115,7 +115,7 @@ func (ws *workers) singularManager() *lease.Manager {
 	return w.(*lease.Manager)
 }
 
-func (ws *workers) allManager() *storeManager {
+func (ws *workers) allManager(params WatchParams) *storeManager {
 	w, err := ws.Worker(allManagerWorker, nil)
 	if err == nil {
 		return w.(*storeManager)
@@ -125,9 +125,9 @@ func (ws *workers) allManager() *storeManager {
 	}
 	// Note that StartWorker is idempotent if there's a race.
 	ws.StartWorker(allManagerWorker, func() (worker.Worker, error) {
-		return newStoreManager(newAllWatcherStateBacking(ws.state)), nil
+		return newStoreManager(newAllWatcherStateBacking(ws.state, params)), nil
 	})
-	return ws.allManager()
+	return ws.allManager(params)
 }
 
 func (ws *workers) allModelManager(pool *StatePool) *storeManager {


### PR DESCRIPTION
## Description of change

The watcher used by the GUI needs to have application offers added to its model.
This required adding some permissions to the client facade back end so that only admins can see a model's offers. Also, ensure that remote app proxies from consuming apps are excluded from the watcher model.

Also add test coverage for remote applications to the client apiserver status.

## QA steps

The GUI doesn't display offers yet, so just do a smoke test - set up a CMR scenario and use the GUI.
