### PR TITLE
Clean up presence tables on model destruction.

### DIFF
--- a/state/presence/presence.go
+++ b/state/presence/presence.go
@@ -1027,3 +1027,23 @@ func beingsC(base *mgo.Collection) *mgo.Collection {
 func pingsC(base *mgo.Collection) *mgo.Collection {
 	return base.Database.C(base.Name + ".pings")
 }
+
+// RemovePresenceForModel removes all of the records of entities for a given model
+// across all of the collections.
+func RemovePresenceForModel(base *mgo.Collection, modelTag names.ModelTag) error {
+	modelIDMatch := bson.M{"_id": bson.RegEx{"^" + modelTag.Id() + ":", ""}}
+	errs := make([]error, 0)
+	if _, err := pingsC(base).RemoveAll(modelIDMatch); err != nil && err != mgo.ErrNotFound {
+		errs = append(errs, err)
+	}
+	if _, err := beingsC(base).RemoveAll(modelIDMatch); err != nil && err != mgo.ErrNotFound {
+		errs = append(errs, err)
+	}
+	if _, err := seqsC(base).RemoveAll(modelIDMatch); err != nil && err != mgo.ErrNotFound {
+		errs = append(errs, err)
+	}
+	if len(errs) != 0 {
+		return errors.Errorf("errors removing presence for model %q: %v", modelTag.Id(), errs)
+	}
+	return nil
+}

--- a/state/presence/presence.go
+++ b/state/presence/presence.go
@@ -1028,19 +1028,30 @@ func pingsC(base *mgo.Collection) *mgo.Collection {
 	return base.Database.C(base.Name + ".pings")
 }
 
+func removeModelFromCollection(coll *mgo.Collection, modelUUID string) error {
+	modelIDMatch := bson.M{"_id": bson.RegEx{"^" + modelUUID + ":", ""}}
+	if changed, err := coll.RemoveAll(modelIDMatch); err != nil {
+		if err == mgo.ErrNotFound {
+			// not a worthy error
+			return nil
+		}
+		return errors.Trace(err)
+	} else {
+		logger.Debugf("removed %d entries from %q for model %q",
+			changed.Removed, coll.FullName, modelUUID)
+	}
+	return nil
+}
+
 // RemovePresenceForModel removes all of the records of entities for a given model
 // across all of the collections.
 func RemovePresenceForModel(base *mgo.Collection, modelTag names.ModelTag) error {
-	modelIDMatch := bson.M{"_id": bson.RegEx{"^" + modelTag.Id() + ":", ""}}
 	errs := make([]error, 0)
-	if _, err := pingsC(base).RemoveAll(modelIDMatch); err != nil && err != mgo.ErrNotFound {
-		errs = append(errs, err)
-	}
-	if _, err := beingsC(base).RemoveAll(modelIDMatch); err != nil && err != mgo.ErrNotFound {
-		errs = append(errs, err)
-	}
-	if _, err := seqsC(base).RemoveAll(modelIDMatch); err != nil && err != mgo.ErrNotFound {
-		errs = append(errs, err)
+	for _, f := range []func(*mgo.Collection) *mgo.Collection{pingsC, beingsC, seqsC} {
+		err := removeModelFromCollection(f(base), modelTag.Id())
+		if err != nil {
+			errs = append(errs, err)
+		}
 	}
 	if len(errs) != 0 {
 		return errors.Errorf("errors removing presence for model %q: %v", modelTag.Id(), errs)

--- a/state/presence/presence_test.go
+++ b/state/presence/presence_test.go
@@ -16,6 +16,7 @@ import (
 	"gopkg.in/juju/names.v2"
 	worker "gopkg.in/juju/worker.v1"
 	"gopkg.in/mgo.v2"
+	"gopkg.in/mgo.v2/bson"
 	"gopkg.in/tomb.v1"
 
 	"github.com/juju/juju/state/presence"
@@ -531,4 +532,77 @@ func (s *PresenceSuite) setup(c *gc.C, key string) (*presence.Watcher, *presence
 	w.Watch(key, ch)
 	assertChange(c, ch, presence.Change{key, false})
 	return w, p, ch
+}
+
+func countModelIds(c *gc.C, coll *mgo.Collection, modelTag names.ModelTag) int {
+	count, err := coll.Find(bson.M{"_id": bson.RegEx{"^" + modelTag.Id() +":", ""}}).Count()
+	// either the error is NotFound or nil
+	if err != nil {
+		c.Assert(err, gc.Equals, mgo.ErrNotFound)
+	}
+	return count
+}
+
+func (s *PresenceSuite) TestRemovePresenceForModel(c *gc.C) {
+	key := "a"
+
+	// Start a pinger in this model
+	w1 := presence.NewWatcher(s.presence, s.modelTag)
+	p1 := presence.NewPinger(s.presence, s.modelTag, key)
+	ch1 := make(chan presence.Change)
+	w1.Watch(key, ch1)
+	assertChange(c, ch1, presence.Change{key, false})
+	defer assertStopped(c, w1)
+	defer assertStopped(c, p1)
+	p1.Start()
+	w1.StartSync()
+	assertChange(c, ch1, presence.Change{"a", true})
+
+	// Start a second model and pinger with the same key
+	modelTag2 := newModelTag(c)
+	w2 := presence.NewWatcher(s.presence, modelTag2)
+	p2 := presence.NewPinger(s.presence, modelTag2, key)
+	ch2 := make(chan presence.Change)
+	w2.Watch(key, ch2)
+	assertChange(c, ch2, presence.Change{key, false})
+	defer assertStopped(c, w2)
+	defer assertStopped(c, p2)
+	// Start them, and check that we see they're alive
+	p2.Start()
+	w2.StartSync()
+	assertChange(c, ch2, presence.Change{"a", true})
+
+	beings := s.presence.Database.C(s.presence.Name + ".beings")
+	pings := s.presence.Database.C(s.presence.Name + ".pings")
+	seqs := s.presence.Database.C(s.presence.Name + ".seqs")
+	// we should have a being and pings for both pingers
+	c.Check(countModelIds(c, beings, s.modelTag), gc.Equals, 1)
+	c.Check(countModelIds(c, beings, modelTag2), gc.Equals, 1)
+	c.Check(countModelIds(c, pings, s.modelTag), jc.GreaterThan,0)
+	c.Check(countModelIds(c, pings, modelTag2), jc.GreaterThan, 0)
+	c.Check(countModelIds(c, seqs, s.modelTag), gc.Equals, 1)
+	c.Check(countModelIds(c, seqs, modelTag2), gc.Equals, 1)
+
+	// kill everything in the first model
+	assertStopped(c, w1)
+	assertStopped(c, p1)
+	// And cleanup the resources
+	err := presence.RemovePresenceForModel(s.presence, s.modelTag)
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Should not cause the second pinger to go dead
+	w2.StartSync()
+	assertNoChange(c, ch2)
+
+	// And we should only have the second model in the databases
+	c.Check(countModelIds(c, beings, s.modelTag), gc.Equals, 0)
+	c.Check(countModelIds(c, beings, modelTag2), gc.Equals, 1)
+	c.Check(countModelIds(c, pings, s.modelTag), gc.Equals,0)
+	c.Check(countModelIds(c, pings, modelTag2), jc.GreaterThan, 0)
+	c.Check(countModelIds(c, seqs, s.modelTag), gc.Equals, 0)
+	c.Check(countModelIds(c, seqs, modelTag2), gc.Equals, 1)
+
+	// Removing a Model that is no longer there should not be an error
+	err = presence.RemovePresenceForModel(s.presence, s.modelTag)
+	c.Assert(err, jc.ErrorIsNil)
 }

--- a/state/presence/presence_test.go
+++ b/state/presence/presence_test.go
@@ -535,7 +535,7 @@ func (s *PresenceSuite) setup(c *gc.C, key string) (*presence.Watcher, *presence
 }
 
 func countModelIds(c *gc.C, coll *mgo.Collection, modelTag names.ModelTag) int {
-	count, err := coll.Find(bson.M{"_id": bson.RegEx{"^" + modelTag.Id() +":", ""}}).Count()
+	count, err := coll.Find(bson.M{"_id": bson.RegEx{"^" + modelTag.Id() + ":", ""}}).Count()
 	// either the error is NotFound or nil
 	if err != nil {
 		c.Assert(err, gc.Equals, mgo.ErrNotFound)
@@ -578,7 +578,7 @@ func (s *PresenceSuite) TestRemovePresenceForModel(c *gc.C) {
 	// we should have a being and pings for both pingers
 	c.Check(countModelIds(c, beings, s.modelTag), gc.Equals, 1)
 	c.Check(countModelIds(c, beings, modelTag2), gc.Equals, 1)
-	c.Check(countModelIds(c, pings, s.modelTag), jc.GreaterThan,0)
+	c.Check(countModelIds(c, pings, s.modelTag), jc.GreaterThan, 0)
 	c.Check(countModelIds(c, pings, modelTag2), jc.GreaterThan, 0)
 	c.Check(countModelIds(c, seqs, s.modelTag), gc.Equals, 1)
 	c.Check(countModelIds(c, seqs, modelTag2), gc.Equals, 1)
@@ -597,7 +597,7 @@ func (s *PresenceSuite) TestRemovePresenceForModel(c *gc.C) {
 	// And we should only have the second model in the databases
 	c.Check(countModelIds(c, beings, s.modelTag), gc.Equals, 0)
 	c.Check(countModelIds(c, beings, modelTag2), gc.Equals, 1)
-	c.Check(countModelIds(c, pings, s.modelTag), gc.Equals,0)
+	c.Check(countModelIds(c, pings, s.modelTag), gc.Equals, 0)
 	c.Check(countModelIds(c, pings, modelTag2), jc.GreaterThan, 0)
 	c.Check(countModelIds(c, seqs, s.modelTag), gc.Equals, 0)
 	c.Check(countModelIds(c, seqs, modelTag2), gc.Equals, 1)

--- a/state/state.go
+++ b/state/state.go
@@ -43,6 +43,7 @@ import (
 	"github.com/juju/juju/state/cloudimagemetadata"
 	stateaudit "github.com/juju/juju/state/internal/audit"
 	statelease "github.com/juju/juju/state/lease"
+	"github.com/juju/juju/state/presence"
 	"github.com/juju/juju/state/watcher"
 	"github.com/juju/juju/status"
 	jujuversion "github.com/juju/juju/version"
@@ -213,9 +214,13 @@ func (st *State) removeAllModelDocs(modelAssertion bson.D) error {
 			}
 		}
 	}
-	// Logs are in a separate database so don't get caught by that
+	// Logs and presence are in separate databases so don't get caught by that
 	// loop.
 	removeModelLogs(st.MongoSession(), modelUUID)
+	err := presence.RemovePresenceForModel(st.getPresenceCollection(), st.modelTag)
+	if err != nil {
+		return errors.Trace(err)
+	}
 
 	// Remove all user permissions for the model.
 	permPattern := bson.M{


### PR DESCRIPTION
## Description of change

It seems we were destroying Logs but not Presence.
This just adds a helper to the presence package for
removing everything for a given model UUID and then
updates the state destruction code to call it.

## QA steps

```
  $ juju bootstrap
  $ for i in `seq 10`;  do 
    juju add-model model-$i; 
    juju deploy ubuntu;
    juju add-unit ubuntu -n 9 --to 0,0,0,0,0,0,0,0,0
    # wait
    juju destroy-model -y model-$i
  done
```

At this point, the presence collection should not be very big, it should only have records for the controller model. It should not have any beings, seqs, or pings for any of the units that were created in the middle.

## Documentation changes

No, this is an internal cleanup.

## Bug reference

It was realized as part of [bug #1454661](https://bugs.launchpad.net/juju-core/+bug/1454661) though it is not directly that bug.
