### PR TITLE
all: use utils.Setenv where appropriate

### DIFF
--- a/cloudconfig/userdatacfg_test.go
+++ b/cloudconfig/userdatacfg_test.go
@@ -1168,12 +1168,12 @@ func (s *cloudinitSuite) TestProxyWritten(c *gc.C) {
 	expected := []string{
 		`export http_proxy=http://user@10.0.0.1`,
 		`export HTTP_PROXY=http://user@10.0.0.1`,
-		`export no_proxy=localhost,10.0.3.1`,
-		`export NO_PROXY=localhost,10.0.3.1`,
+		`export no_proxy=10.0.3.1,localhost`,
+		`export NO_PROXY=10.0.3.1,localhost`,
 		`(id ubuntu &> /dev/null) && (printf '%s\n' 'export http_proxy=http://user@10.0.0.1
 export HTTP_PROXY=http://user@10.0.0.1
-export no_proxy=localhost,10.0.3.1
-export NO_PROXY=localhost,10.0.3.1' > /home/ubuntu/.juju-proxy && chown ubuntu:ubuntu /home/ubuntu/.juju-proxy)`,
+export no_proxy=10.0.3.1,localhost
+export NO_PROXY=10.0.3.1,localhost' > /home/ubuntu/.juju-proxy && chown ubuntu:ubuntu /home/ubuntu/.juju-proxy)`,
 	}
 	found := false
 	for i, cmd := range cmds {

--- a/cmd/juju/commands/cmd_test.go
+++ b/cmd/juju/commands/cmd_test.go
@@ -13,8 +13,6 @@ import (
 	"github.com/juju/cmd/cmdtesting"
 	"github.com/juju/testing"
 	gc "gopkg.in/check.v1"
-
-	"github.com/juju/juju/juju/osenv"
 )
 
 // flagRunMain is used to indicate that the -run-main flag was used.
@@ -64,7 +62,6 @@ func TestRunMain(t *stdtesting.T) {
 func badrun(c *gc.C, exit int, args ...string) string {
 	localArgs := append([]string{"-test.run", "TestRunMain", "-run-main", "--", "juju"}, args...)
 	ps := exec.Command(os.Args[0], localArgs...)
-	ps.Env = append(os.Environ(), osenv.JujuXDGDataHomeEnvKey+"="+osenv.JujuXDGDataHome())
 	output, err := ps.CombinedOutput()
 	c.Logf("command output: %q", output)
 	if exit != 0 {

--- a/cmd/juju/commands/plugin.go
+++ b/cmd/juju/commands/plugin.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/juju/cmd"
 	"github.com/juju/gnuflag"
+	"github.com/juju/utils"
 
 	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/juju/osenv"
@@ -93,9 +94,7 @@ func (c *PluginCommand) Init(args []string) error {
 
 func (c *PluginCommand) Run(ctx *cmd.Context) error {
 	command := exec.Command(c.name, c.args...)
-	command.Env = append(os.Environ(), []string{
-		osenv.JujuModelEnvKey + "=" + c.ConnectionName()}...,
-	)
+	command.Env = utils.Setenv(os.Environ(), osenv.JujuModelEnvKey+"="+c.ConnectionName())
 
 	// Now hook up stdin, stdout, stderr
 	command.Stdin = ctx.Stdin

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -48,7 +48,7 @@ github.com/juju/terms-client	git	9b925afd677234e4146dde3cb1a11e187cbed64e	2016-0
 github.com/juju/testing	git	fce9bc4ebf7a77310c262ac4884e03b778eae06a	2017-02-22T09:01:19Z
 github.com/juju/txn	git	42e03dbca6a4f5333d92daae67228c032a109aad	2017-04-11T10:02:47Z
 github.com/juju/usso	git	68a59c96c178fbbad65926e7f93db50a2cd14f33	2016-04-01T10:44:24Z
-github.com/juju/utils	git	6a26b0e1230eeaad6d2321bb63700da1b1116c2b	2017-03-17T14:03:37Z
+github.com/juju/utils	git	51660d020f8c823ce1d0b7904c26e6b907163050	2017-04-21T12:10:45Z
 github.com/juju/version	git	1f41e27e54f21acccf9b2dddae063a782a8a7ceb	2016-10-31T05:19:06Z
 github.com/juju/webbrowser	git	54b8c57083b4afb7dc75da7f13e2967b2606a507	2016-03-09T14:36:29Z
 github.com/juju/xml	git	eb759a627588d35166bc505fceb51b88500e291e	2015-04-13T13:11:21Z

--- a/environs/tools/build.go
+++ b/environs/tools/build.go
@@ -111,17 +111,6 @@ func closeErrorCheck(errp *error, c io.Closer) {
 	}
 }
 
-func setenv(env []string, val string) []string {
-	prefix := val[0 : strings.Index(val, "=")+1]
-	for i, eval := range env {
-		if strings.HasPrefix(eval, prefix) {
-			env[i] = val
-			return env
-		}
-	}
-	return append(env, val)
-}
-
 func findExecutable(execFile string) (string, error) {
 	logger.Debugf("looking for: %s", execFile)
 	if filepath.IsAbs(execFile) {

--- a/environs/tools/export_test.go
+++ b/environs/tools/export_test.go
@@ -4,7 +4,6 @@
 package tools
 
 var (
-	Setenv                        = setenv
 	FindExecutable                = findExecutable
 	CheckToolsSeries              = checkToolsSeries
 	ArchiveAndSHA256              = archiveAndSHA256

--- a/environs/tools/storage_test.go
+++ b/environs/tools/storage_test.go
@@ -103,24 +103,3 @@ func (s *StorageSuite) TestReadListLegacyPPC64(c *gc.C) {
 	}
 	c.Assert(list, gc.DeepEquals, expected)
 }
-
-var setenvTests = []struct {
-	set    string
-	expect []string
-}{
-	{"foo=1", []string{"foo=1", "arble="}},
-	{"foo=", []string{"foo=", "arble="}},
-	{"arble=23", []string{"foo=bar", "arble=23"}},
-	{"zaphod=42", []string{"foo=bar", "arble=", "zaphod=42"}},
-}
-
-func (*StorageSuite) TestSetenv(c *gc.C) {
-	env0 := []string{"foo=bar", "arble="}
-	for i, t := range setenvTests {
-		c.Logf("test %d", i)
-		env := make([]string, len(env0))
-		copy(env, env0)
-		env = envtools.Setenv(env, t.set)
-		c.Check(env, gc.DeepEquals, t.expect)
-	}
-}

--- a/network/bridge_test.go
+++ b/network/bridge_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/juju/testing"
+	"github.com/juju/utils"
 	"github.com/juju/utils/clock"
 	gc "gopkg.in/check.v1"
 
@@ -218,8 +219,7 @@ func (*BridgeSuite) TestENIBridgerWithTimeout(c *gc.C) {
 			DeviceName: "ens3",
 		},
 	}
-	environ := os.Environ()
-	environ = append(environ, "ADD_JUJU_BRIDGE_SLEEP_PREAMBLE_FOR_TESTING=10")
+	environ := utils.Setenv(os.Environ(), "ADD_JUJU_BRIDGE_SLEEP_PREAMBLE_FOR_TESTING=10")
 	expected := "bridgescript timed out after 500ms"
 	assertENIBridgerError(c, devices, environ, 500*time.Millisecond, clock.WallClock, "br-", "testdata/non-existent-file", true, 0, expected)
 }


### PR DESCRIPTION
Also remove the environment append where it
was actually a no-op and remove the unused setenv
function in environs/tools.

This makes the juju/juju/cmd tests pass under
Go tip.

QA no regressions