### PR TITLE
SetObservedNetworkConfig should work for manually provisioned machines

### DIFF
--- a/apiserver/common/networkingcommon/networkconfigapi.go
+++ b/apiserver/common/networkingcommon/networkconfigapi.go
@@ -37,6 +37,16 @@ func (api *NetworkConfigAPI) getMachine(tag names.MachineTag) (*state.Machine, e
 }
 
 func (api *NetworkConfigAPI) getOneMachineProviderNetworkConfig(m *state.Machine) ([]params.NetworkConfig, error) {
+	manual, err := m.IsManual()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	if manual {
+		logger.Infof("provider network config not supported on manually provisioned machines")
+		return nil, nil
+	}
+
 	instId, err := m.InstanceId()
 	if err != nil {
 		return nil, errors.Trace(err)


### PR DESCRIPTION
## Description of change
SetObservedNetworkConfig failed for manually provisioned machines, it should not.

## QA steps
Create a MAAS based setup, add a manually provisioned machine (juju add-machine ssh:1.2.3.4), see in logs on that machine that there are no SetObservedNetworkConfig errors. 

## Documentation changes
None

## Bug reference
https://bugs.launchpad.net/juju/+bug/1685180