### PR TITLE
ensure images exist in user account

### DIFF
--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -24,7 +24,7 @@ github.com/juju/cmd	git	e47739aefe0adb68a401fcd371c0c92c8f6f8d99	2017-04-13T02:1
 github.com/juju/description	git	50b9bb7345dcc1d0443cc137337fdb15a4296ac2	2017-04-06T03:03:04Z
 github.com/juju/errors	git	1b5e39b83d1835fa480e0c2ddefb040ee82d58b3	2015-09-16T12:56:42Z
 github.com/juju/gnuflag	git	4e76c56581859c14d9d87e1ddbe29e1c0f10195f	2016-08-09T16:52:14Z
-github.com/juju/go-oracle-cloud	git	94f29b1b5517a3a94f68f1bc887f1798606a015e	2017-04-14T14:56:09Z
+github.com/juju/go-oracle-cloud	git	932a8cea00a1cd5cba3829a672c823955db674ae	2017-04-21T13:45:47Z
 github.com/juju/go4	git	40d72ab9641a2a8c36a9c46a51e28367115c8e59	2016-02-22T16:32:58Z
 github.com/juju/gojsonpointer	git	afe8b77aa08f272b49e01b82de78510c11f61500	2015-02-04T19:46:29Z
 github.com/juju/gojsonreference	git	f0d24ac5ee330baa21721cdff56d45e4ee42628e	2015-02-04T19:46:33Z

--- a/provider/oracle/common/interfaces.go
+++ b/provider/oracle/common/interfaces.go
@@ -57,6 +57,9 @@ type Shaper interface {
 // oracle cloud environment
 type Imager interface {
 	AllImageLists([]api.Filter) (response.AllImageLists, error)
+	CreateImageList(def int, description string, name string) (resp response.ImageList, err error)
+	CreateImageListEntry(name string, attributes map[string]interface{}, version int, machineImages []string) (resp response.ImageListEntryAdd, err error)
+	DeleteImageList(name string) (err error)
 }
 
 // IpReservationAPI provider methods for retrieving, updating, creating

--- a/provider/oracle/fakeenvironapi_test.go
+++ b/provider/oracle/fakeenvironapi_test.go
@@ -67,21 +67,21 @@ func (f FakeImager) AllImageLists([]api.Filter) (response.AllImageLists, error) 
 }
 
 func (f FakeImager) CreateImageList(def int, description string, name string) (resp response.ImageList, err error) {
-    return response.ImageList{}, nil
+	return response.ImageList{}, nil
 }
 
 func (f FakeImager) CreateImageListEntry(
-    name string,
-    attributes map[string]interface{},
-    version int,
-    machineImages []string,
-) (resp response.ImageListEntryAdd, err error){
+	name string,
+	attributes map[string]interface{},
+	version int,
+	machineImages []string,
+) (resp response.ImageListEntryAdd, err error) {
 
-    return response.ImageListEntryAdd{}, nil
+	return response.ImageListEntryAdd{}, nil
 }
 
 func (f FakeImager) DeleteImageList(name string) (err error) {
-    return nil
+	return nil
 }
 
 type FakeIpReservation struct {

--- a/provider/oracle/fakeenvironapi_test.go
+++ b/provider/oracle/fakeenvironapi_test.go
@@ -66,6 +66,24 @@ func (f FakeImager) AllImageLists([]api.Filter) (response.AllImageLists, error) 
 	return f.All, f.AllErr
 }
 
+func (f FakeImager) CreateImageList(def int, description string, name string) (resp response.ImageList, err error) {
+    return response.ImageList{}, nil
+}
+
+func (f FakeImager) CreateImageListEntry(
+    name string,
+    attributes map[string]interface{},
+    version int,
+    machineImages []string,
+) (resp response.ImageListEntryAdd, err error){
+
+    return response.ImageListEntryAdd{}, nil
+}
+
+func (f FakeImager) DeleteImageList(name string) (err error) {
+    return nil
+}
+
 type FakeIpReservation struct {
 	All       response.AllIpReservations
 	AllErr    error

--- a/provider/oracle/images.go
+++ b/provider/oracle/images.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/juju/errors"
 	"github.com/juju/utils/series"
+	"github.com/juju/utils/set"
 
 	"github.com/juju/juju/environs/imagemetadata"
 	"github.com/juju/juju/environs/instances"
@@ -18,6 +19,63 @@ import (
 var windowsServerMap = map[string]string{
 	"Microsoft_Windows_Server_2012_R2": "win2012r2",
 	"Microsoft_Windows_Server_2008_R2": "win2018r2",
+}
+
+// defaultImages is a list of official Ubuntu images available on Oracle cloud
+// TODO (gsamfira): seed this from simplestreams
+var defaultImages = []string{
+	"Ubuntu.12.04-LTS.amd64.20170417",
+	"Ubuntu.14.04-LTS.amd64.20170405",
+	"Ubuntu.16.04-LTS.amd64.20170221",
+	"Ubuntu.16.10.amd64.20170330",
+}
+
+// ensureImageInventory populates the image inventory for the current user
+// with official Ubuntu images
+func ensureImageInventory(c EnvironAPI) error {
+	logger.Debugf("checking image inventory")
+	images, err := c.AllImageLists(nil)
+	if err != nil {
+		return err
+	}
+	names := set.Strings{}
+	for _, val := range images.Result {
+		trimmed := strings.Split(val.Name, "/")
+		names.Add(trimmed[len(trimmed)-1])
+	}
+	logger.Debugf("found %d images", names.Size())
+	errs := []error{}
+	for _, val := range defaultImages {
+		if !names.Contains(val) {
+			logger.Debugf("adding missing image: %s", val)
+			imageName := c.ComposeName(val)
+			listDetails, err := c.CreateImageList(1, val, imageName)
+			if err != nil {
+				errs = append(errs, err)
+				continue
+			}
+			// mirror the default attributes
+			entryAttributes := map[string]interface{}{
+				"type":            val,
+				"defaultShape":    "oc2m",
+				"minimumDiskSize": "10",
+				"supportedShapes": "oc3,oc4,oc5,oc6,oc7,oc1m,oc2m,oc3m,oc4m,oc5m,ocio1m,ocio2m,ocio3m,ocio4m,ocio5m,ociog1k80,ociog2k80,ociog3k80",
+			}
+			_, err = c.CreateImageListEntry(
+				listDetails.Name,
+				entryAttributes,
+				1, []string{imageName})
+			if err != nil {
+				errs = append(errs, err)
+				// Cleanup list in case of error
+				_ = c.DeleteImageList(listDetails.Name)
+			}
+		}
+	}
+	if len(errs) > 0 {
+		return errors.Errorf("failed to add images to inventory: %v", errs)
+	}
+	return nil
 }
 
 // instanceTypes returns all oracle cloud shapes and wraps them into instance.InstanceType
@@ -127,6 +185,10 @@ func checkImageList(c EnvironAPI) ([]*imagemetadata.ImageMetadata, error) {
 		return nil, errors.NotFoundf("oracle client")
 	}
 
+	err := ensureImageInventory(c)
+	if err != nil {
+		return nil, err
+	}
 	// take a list of all images that are in the oracle cloud account
 	resp, err := c.AllImageLists(nil)
 	if err != nil {

--- a/provider/oracle/images.go
+++ b/provider/oracle/images.go
@@ -33,6 +33,7 @@ var defaultImages = []string{
 // ensureImageInventory populates the image inventory for the current user
 // with official Ubuntu images
 func ensureImageInventory(c EnvironAPI) error {
+	// TODO (gsamfira): add tests for this
 	logger.Debugf("checking image inventory")
 	images, err := c.AllImageLists(nil)
 	if err != nil {
@@ -187,7 +188,7 @@ func checkImageList(c EnvironAPI) ([]*imagemetadata.ImageMetadata, error) {
 
 	err := ensureImageInventory(c)
 	if err != nil {
-		return nil, err
+		return nil, errors.Trace(err)
 	}
 	// take a list of all images that are in the oracle cloud account
 	resp, err := c.AllImageLists(nil)


### PR DESCRIPTION
by default a new user does not have any usable images. We need to populate the inventory with the official ubuntu images. For now, this adds a static list of image names, but this needs to be extended to use simplestreams

this change depends on: https://github.com/juju/go-oracle-cloud/pull/3

## Please provide the following details to expedite Pull Request review:

----

## Description of change

avoids the need for the user to add OS images manually from the marketplace

## QA steps

remove all images from your oracle account, and simply bootstrap. It should work.

## Documentation changes

no

## Bug reference

no
