### PR TITLE
Model info fix: related to list models failures.

### DIFF
--- a/apiserver/common/modelmanagerinterface.go
+++ b/apiserver/common/modelmanagerinterface.go
@@ -86,6 +86,10 @@ type Model interface {
 	DestroyIncludingHosted() error
 	SLALevel() string
 	SLAOwner() string
+	MigrationMode() state.MigrationMode
+	Name() string
+	UUID() string
+	ControllerUUID() string
 }
 
 var _ ModelManagerBackend = (*modelManagerStateShim)(nil)

--- a/apiserver/modelmanager/modelinfo_test.go
+++ b/apiserver/modelmanager/modelinfo_test.go
@@ -160,7 +160,7 @@ func (s *modelInfoSuite) TestModelInfo(c *gc.C) {
 		CloudCredentialTag: "cloudcred-some-cloud_bob_some-credential",
 		DefaultSeries:      series.LatestLts(),
 		Life:               params.Dying,
-		Status: &params.EntityStatus{
+		Status: params.EntityStatus{
 			Status: status.Destroying,
 			Since:  &time.Time{},
 		},

--- a/apiserver/modelmanager/modelmanager_test.go
+++ b/apiserver/modelmanager/modelmanager_test.go
@@ -78,8 +78,7 @@ func (s *modelManagerSuite) SetUpTest(c *gc.C) {
 	}
 
 	s.st = &mockState{
-		modelUUID: coretesting.ModelTag.Id(),
-		cloud:     dummyCloud,
+		cloud: dummyCloud,
 		clouds: map[names.CloudTag]cloud.Cloud{
 			names.NewCloudTag("some-cloud"): dummyCloud,
 		},
@@ -192,7 +191,6 @@ func (s *modelManagerSuite) TestCreateModelArgs(c *gc.C) {
 		"NewModel",
 		"ForModel",
 		"Model",
-		"ControllerConfig",
 		"LastModelConnection",
 		"LastModelConnection",
 		"LastModelConnection",

--- a/apiserver/params/model.go
+++ b/apiserver/params/model.go
@@ -126,8 +126,8 @@ type ModelInfo struct {
 	Name               string `json:"name"`
 	UUID               string `json:"uuid"`
 	ControllerUUID     string `json:"controller-uuid"`
-	ProviderType       string `json:"provider-type"`
-	DefaultSeries      string `json:"default-series"`
+	ProviderType       string `json:"provider-type,omitempty"`
+	DefaultSeries      string `json:"default-series,omitempty"`
 	CloudTag           string `json:"cloud-tag"`
 	CloudRegion        string `json:"cloud-region,omitempty"`
 	CloudCredentialTag string `json:"cloud-credential-tag,omitempty"`
@@ -139,7 +139,7 @@ type ModelInfo struct {
 	Life Life `json:"life"`
 
 	// Status is the current status of the model.
-	Status EntityStatus `json:"status"`
+	Status *EntityStatus `json:"status,omitempty"`
 
 	// Users contains information about the users that have access
 	// to the model. Owners and administrators can see all users

--- a/apiserver/params/model.go
+++ b/apiserver/params/model.go
@@ -139,7 +139,7 @@ type ModelInfo struct {
 	Life Life `json:"life"`
 
 	// Status is the current status of the model.
-	Status *EntityStatus `json:"status,omitempty"`
+	Status EntityStatus `json:"status,omitempty"`
 
 	// Users contains information about the users that have access
 	// to the model. Owners and administrators can see all users

--- a/cmd/juju/common/model.go
+++ b/cmd/juju/common/model.go
@@ -5,6 +5,7 @@ package common
 
 import (
 	"fmt"
+	"reflect"
 	"time"
 
 	"github.com/juju/errors"
@@ -12,7 +13,6 @@ import (
 
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/status"
-	"reflect"
 )
 
 // ModelInfo contains information about a model.
@@ -86,7 +86,7 @@ func ModelInfoFromParams(info params.ModelInfo, now time.Time) (ModelInfo, error
 		Cloud:          cloudTag.Id(),
 		CloudRegion:    info.CloudRegion,
 	}
-	// Although this may be more performance intensive, w have to use reflection
+	// Although this may be more performance intensive, we have to use reflection
 	// since structs containing map[string]interface {} cannot be compared, i.e
 	// cannot use simple '==' here.
 	if !reflect.DeepEqual(info.Status, params.EntityStatus{}) {

--- a/cmd/juju/common/model.go
+++ b/cmd/juju/common/model.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/status"
+	"reflect"
 )
 
 // ModelInfo contains information about a model.
@@ -85,7 +86,10 @@ func ModelInfoFromParams(info params.ModelInfo, now time.Time) (ModelInfo, error
 		Cloud:          cloudTag.Id(),
 		CloudRegion:    info.CloudRegion,
 	}
-	if info.Status != nil {
+	// Although this may be more performance intensive, w have to use reflection
+	// since structs containing map[string]interface {} cannot be compared, i.e
+	// cannot use simple '==' here.
+	if !reflect.DeepEqual(info.Status, params.EntityStatus{}) {
 		modelInfo.Status = &ModelStatus{
 			Current: info.Status.Status,
 			Message: info.Status.Info,

--- a/cmd/juju/common/model.go
+++ b/cmd/juju/common/model.go
@@ -23,10 +23,10 @@ type ModelInfo struct {
 	Owner          string                      `json:"owner" yaml:"owner"`
 	Cloud          string                      `json:"cloud" yaml:"cloud"`
 	CloudRegion    string                      `json:"region,omitempty" yaml:"region,omitempty"`
-	ProviderType   string                      `json:"type" yaml:"type"`
+	ProviderType   string                      `json:"type,omitempty" yaml:"type,omitempty"`
 	Life           string                      `json:"life" yaml:"life"`
-	Status         ModelStatus                 `json:"status" yaml:"status"`
-	Users          map[string]ModelUserInfo    `json:"users" yaml:"users"`
+	Status         *ModelStatus                `json:"status,omitempty" yaml:"status,omitempty"`
+	Users          map[string]ModelUserInfo    `json:"users,omitempty" yaml:"users,omitempty"`
 	Machines       map[string]ModelMachineInfo `json:"machines,omitempty" yaml:"machines,omitempty"`
 	SLA            string                      `json:"sla,omitempty" yaml:"sla,omitempty"`
 	SLAOwner       string                      `json:"sla-owner,omitempty" yaml:"sla-owner,omitempty"`
@@ -41,7 +41,7 @@ type ModelMachineInfo struct {
 
 // ModelStatus contains the current status of a model.
 type ModelStatus struct {
-	Current        status.Status `json:"current" yaml:"current"`
+	Current        status.Status `json:"current,omitempty" yaml:"current,omitempty"`
 	Message        string        `json:"message,omitempty" yaml:"message,omitempty"`
 	Since          string        `json:"since,omitempty" yaml:"since,omitempty"`
 	Migration      string        `json:"migration,omitempty" yaml:"migration,omitempty"`
@@ -72,35 +72,52 @@ func ModelInfoFromParams(info params.ModelInfo, now time.Time) (ModelInfo, error
 	if err != nil {
 		return ModelInfo{}, errors.Trace(err)
 	}
-	status := ModelStatus{
-		Current: info.Status.Status,
-		Message: info.Status.Info,
-		Since:   friendlyDuration(info.Status.Since, now),
-	}
-	if info.Migration != nil {
-		status.Migration = info.Migration.Status
-		status.MigrationStart = friendlyDuration(info.Migration.Start, now)
-		status.MigrationEnd = friendlyDuration(info.Migration.End, now)
-	}
 	cloudTag, err := names.ParseCloudTag(info.CloudTag)
 	if err != nil {
 		return ModelInfo{}, errors.Trace(err)
 	}
-	return ModelInfo{
+	modelInfo := ModelInfo{
 		Name:           info.Name,
 		UUID:           info.UUID,
 		ControllerUUID: info.ControllerUUID,
 		Owner:          tag.Id(),
 		Life:           string(info.Life),
-		Status:         status,
 		Cloud:          cloudTag.Id(),
 		CloudRegion:    info.CloudRegion,
-		ProviderType:   info.ProviderType,
-		Users:          ModelUserInfoFromParams(info.Users, now),
-		Machines:       ModelMachineInfoFromParams(info.Machines),
-		SLA:            modelSLAFromParams(info.SLA),
-		SLAOwner:       modelSLAOwnerFromParams(info.SLA),
-	}, nil
+	}
+	if info.Status != nil {
+		modelInfo.Status = &ModelStatus{
+			Current: info.Status.Status,
+			Message: info.Status.Info,
+			Since:   friendlyDuration(info.Status.Since, now),
+		}
+	}
+	if info.Migration != nil {
+		status := modelInfo.Status
+		if status == nil {
+			status = &ModelStatus{}
+			modelInfo.Status = status
+		}
+		status.Migration = info.Migration.Status
+		status.MigrationStart = friendlyDuration(info.Migration.Start, now)
+		status.MigrationEnd = friendlyDuration(info.Migration.End, now)
+	}
+
+	if info.ProviderType != "" {
+		modelInfo.ProviderType = info.ProviderType
+
+	}
+	if len(info.Users) != 0 {
+		modelInfo.Users = ModelUserInfoFromParams(info.Users, now)
+	}
+	if len(info.Machines) != 0 {
+		modelInfo.Machines = ModelMachineInfoFromParams(info.Machines)
+	}
+	if info.SLA != nil {
+		modelInfo.SLA = modelSLAFromParams(info.SLA)
+		modelInfo.SLAOwner = modelSLAOwnerFromParams(info.SLA)
+	}
+	return modelInfo, nil
 }
 
 // ModelMachineInfoFromParams translates []params.ModelMachineInfo to a map of

--- a/cmd/juju/controller/listmodels.go
+++ b/cmd/juju/controller/listmodels.go
@@ -255,7 +255,6 @@ func (c *modelsCommand) formatTabular(writer io.Writer, value interface{}) error
 	if !ok {
 		return errors.Errorf("expected value of type %T, got %T", modelSet, value)
 	}
-
 	// We need the tag of the user for which we're listing models,
 	// and for the logged-in user. We use these below when formatting
 	// the model display names.
@@ -306,16 +305,15 @@ func (c *modelsCommand) formatTabular(writer io.Writer, value interface{}) error
 		if c.listUUID {
 			w.Print(model.UUID)
 		}
-		lastConnection := model.Users[userForLastConn.Id()].LastConnection
-		if lastConnection == "" {
-			lastConnection = "never connected"
-		}
 		userForAccess := loggedInUser
 		if c.user != "" {
 			userForAccess = names.NewUserTag(c.user)
 		}
-		access := model.Users[userForAccess.Id()].Access
-		w.Print(cloudRegion, model.Status.Current)
+		status := "-"
+		if model.Status != nil {
+			status = model.Status.Current.String()
+		}
+		w.Print(cloudRegion, status)
 		if haveMachineInfo {
 			machineInfo := fmt.Sprintf("%d", len(model.Machines))
 			cores := uint64(0)
@@ -327,6 +325,14 @@ func (c *modelsCommand) formatTabular(writer io.Writer, value interface{}) error
 				coresInfo = fmt.Sprintf("%d", cores)
 			}
 			w.Print(machineInfo, coresInfo)
+		}
+		access := model.Users[userForAccess.Id()].Access
+		if access == "" {
+			access = "-"
+		}
+		lastConnection := model.Users[userForLastConn.Id()].LastConnection
+		if lastConnection == "" {
+			lastConnection = "never connected"
 		}
 		w.Println(access, lastConnection)
 	}

--- a/cmd/juju/controller/listmodels_test.go
+++ b/cmd/juju/controller/listmodels_test.go
@@ -75,7 +75,7 @@ func (f *fakeModelMgrAPIClient) ModelInfo(tags []names.ModelTag) ([]params.Model
 				UUID:     model.UUID,
 				OwnerTag: names.NewUserTag(model.Owner).String(),
 				CloudTag: "cloud-dummy",
-				Status:   &params.EntityStatus{},
+				Status:   params.EntityStatus{},
 			}
 			switch model.Name {
 			case "test-model1":
@@ -281,7 +281,7 @@ func createBasicModelInfo() *params.ModelInfo {
 
 func (s *ModelsSuite) TestWithIncompleteModels(c *gc.C) {
 	basicAndStatusInfo := createBasicModelInfo()
-	basicAndStatusInfo.Status = &params.EntityStatus{
+	basicAndStatusInfo.Status = params.EntityStatus{
 		Status: status.Busy,
 	}
 

--- a/cmd/juju/controller/listmodels_test.go
+++ b/cmd/juju/controller/listmodels_test.go
@@ -36,6 +36,7 @@ type fakeModelMgrAPIClient struct {
 	all          bool
 	inclMachines bool
 	denyAccess   bool
+	infos        []params.ModelInfoResult
 }
 
 func (f *fakeModelMgrAPIClient) Close() error {
@@ -60,6 +61,9 @@ func (f *fakeModelMgrAPIClient) AllModels() ([]base.UserModel, error) {
 }
 
 func (f *fakeModelMgrAPIClient) ModelInfo(tags []names.ModelTag) ([]params.ModelInfoResult, error) {
+	if f.infos != nil {
+		return f.infos, nil
+	}
 	results := make([]params.ModelInfoResult, len(tags))
 	for i, tag := range tags {
 		for _, model := range f.models {
@@ -71,6 +75,7 @@ func (f *fakeModelMgrAPIClient) ModelInfo(tags []names.ModelTag) ([]params.Model
 				UUID:     model.UUID,
 				OwnerTag: names.NewUserTag(model.Owner).String(),
 				CloudTag: "cloud-dummy",
+				Status:   &params.EntityStatus{},
 			}
 			switch model.Name {
 			case "test-model1":
@@ -162,7 +167,7 @@ func (s *ModelsSuite) TestModelsOwner(c *gc.C) {
 		"Model                        Cloud/Region  Status      Access  Last connection\n"+
 		"test-model1*                 dummy         active      read    2015-03-20\n"+
 		"carlotta/test-model2         dummy         active      write   2015-03-01\n"+
-		"daiwik@external/test-model3  dummy         destroying          never connected\n"+
+		"daiwik@external/test-model3  dummy         destroying  -       never connected\n"+
 		"\n")
 }
 
@@ -176,7 +181,7 @@ func (s *ModelsSuite) TestModelsNonOwner(c *gc.C) {
 		"Model                        Cloud/Region  Status      Access  Last connection\n"+
 		"admin/test-model1*           dummy         active      read    2015-03-20\n"+
 		"carlotta/test-model2         dummy         active      write   2015-03-01\n"+
-		"daiwik@external/test-model3  dummy         destroying          never connected\n"+
+		"daiwik@external/test-model3  dummy         destroying  -       never connected\n"+
 		"\n")
 }
 
@@ -190,7 +195,7 @@ func (s *ModelsSuite) TestAllModels(c *gc.C) {
 		"Model                        Cloud/Region  Status      Access  Last connection\n"+
 		"admin/test-model1*           dummy         active      read    2015-03-20\n"+
 		"carlotta/test-model2         dummy         active      write   2015-03-01\n"+
-		"daiwik@external/test-model3  dummy         destroying          never connected\n"+
+		"daiwik@external/test-model3  dummy         destroying  -       never connected\n"+
 		"\n")
 }
 
@@ -204,7 +209,7 @@ func (s *ModelsSuite) TestAllModelsNoneCurrent(c *gc.C) {
 		"Model                        Cloud/Region  Status      Access  Last connection\n"+
 		"test-model1                  dummy         active      read    2015-03-20\n"+
 		"carlotta/test-model2         dummy         active      write   2015-03-01\n"+
-		"daiwik@external/test-model3  dummy         destroying          never connected\n"+
+		"daiwik@external/test-model3  dummy         destroying  -       never connected\n"+
 		"\n")
 }
 
@@ -219,7 +224,7 @@ func (s *ModelsSuite) TestModelsUUID(c *gc.C) {
 		"Model                        UUID              Cloud/Region  Status      Machines  Cores  Access  Last connection\n"+
 		"test-model1*                 test-model1-UUID  dummy         active             2      1  read    2015-03-20\n"+
 		"carlotta/test-model2         test-model2-UUID  dummy         active             0      -  write   2015-03-01\n"+
-		"daiwik@external/test-model3  test-model3-UUID  dummy         destroying         0      -          never connected\n"+
+		"daiwik@external/test-model3  test-model3-UUID  dummy         destroying         0      -  -       never connected\n"+
 		"\n")
 }
 
@@ -234,7 +239,7 @@ func (s *ModelsSuite) TestModelsMachineInfo(c *gc.C) {
 		"Model                        Cloud/Region  Status      Machines  Cores  Access  Last connection\n"+
 		"test-model1*                 dummy         active             2      1  read    2015-03-20\n"+
 		"carlotta/test-model2         dummy         active             0      -  write   2015-03-01\n"+
-		"daiwik@external/test-model3  dummy         destroying         0      -          never connected\n"+
+		"daiwik@external/test-model3  dummy         destroying         0      -  -       never connected\n"+
 		"\n")
 }
 
@@ -260,4 +265,53 @@ func (s *ModelsSuite) TestModelsError(c *gc.C) {
 	s.api.err = common.ErrPerm
 	_, err := cmdtesting.RunCommand(c, s.newCommand())
 	c.Assert(err, gc.ErrorMatches, "cannot list models: permission denied")
+}
+
+func createBasicModelInfo() *params.ModelInfo {
+	return &params.ModelInfo{
+		Name:           "basic-model",
+		UUID:           testing.ModelTag.Id(),
+		ControllerUUID: testing.ControllerTag.Id(),
+		OwnerTag:       names.NewUserTag("owner").String(),
+		Life:           params.Dead,
+		CloudTag:       names.NewCloudTag("altostratus").String(),
+		CloudRegion:    "mid-level",
+	}
+}
+
+func (s *ModelsSuite) TestWithIncompleteModels(c *gc.C) {
+	basicAndStatusInfo := createBasicModelInfo()
+	basicAndStatusInfo.Status = &params.EntityStatus{
+		Status: status.Busy,
+	}
+
+	basicAndUsersInfo := createBasicModelInfo()
+	basicAndUsersInfo.Users = []params.ModelUserInfo{
+		params.ModelUserInfo{"admin", "display name", nil, params.UserAccessPermission("admin")},
+	}
+
+	basicAndMachinesInfo := createBasicModelInfo()
+	basicAndMachinesInfo.Machines = []params.ModelMachineInfo{
+		params.ModelMachineInfo{Id: "2"},
+		params.ModelMachineInfo{Id: "12"},
+	}
+
+	s.api.infos = []params.ModelInfoResult{
+		params.ModelInfoResult{Result: createBasicModelInfo()},
+		params.ModelInfoResult{Result: basicAndStatusInfo},
+		params.ModelInfoResult{Result: basicAndUsersInfo},
+		params.ModelInfoResult{Result: basicAndMachinesInfo},
+	}
+	context, err := cmdtesting.RunCommand(c, s.newCommand())
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(cmdtesting.Stdout(context), gc.Equals, `
+Controller: fake
+
+Model              Cloud/Region           Status  Machines  Cores  Access  Last connection
+owner/basic-model  altostratus/mid-level  -              0      -  -       never connected
+owner/basic-model  altostratus/mid-level  busy           0      -  -       never connected
+owner/basic-model  altostratus/mid-level  -              0      -  admin   never connected
+owner/basic-model  altostratus/mid-level  -              2      -  -       never connected
+
+`[1:])
 }

--- a/cmd/juju/model/show_test.go
+++ b/cmd/juju/model/show_test.go
@@ -21,38 +21,16 @@ import (
 	"github.com/juju/juju/testing"
 )
 
+var _ = gc.Suite(&ShowCommandSuite{})
+var _ = gc.Suite(&showSLACommandSuite{})
+
 type ShowCommandSuite struct {
 	testing.FakeJujuXDGDataHomeSuite
-	fake           fakeModelShowClient
-	store          *jujuclient.MemStore
-	expectedOutput attrs
+	fake            fakeModelShowClient
+	store           *jujuclient.MemStore
+	expectedOutput  attrs
+	expectedDisplay string
 }
-
-var _ = gc.Suite(&ShowCommandSuite{})
-
-type fakeModelShowClient struct {
-	gitjujutesting.Stub
-	info params.ModelInfo
-	err  *params.Error
-}
-
-func (f *fakeModelShowClient) Close() error {
-	f.MethodCall(f, "Close")
-	return f.NextErr()
-}
-
-func (f *fakeModelShowClient) ModelInfo(tags []names.ModelTag) ([]params.ModelInfoResult, error) {
-	f.MethodCall(f, "ModelInfo", tags)
-	if len(tags) != 1 {
-		return nil, errors.Errorf("expected 1 tag, got %d", len(tags))
-	}
-	if tags[0] != testing.ModelTag {
-		return nil, errors.Errorf("expected %s, got %s", testing.ModelTag.Id(), tags[0].Id())
-	}
-	return []params.ModelInfoResult{{Result: &f.info, Error: f.err}}, f.NextErr()
-}
-
-type attrs map[string]interface{}
 
 func (s *ShowCommandSuite) SetUpTest(c *gc.C) {
 	s.FakeJujuXDGDataHomeSuite.SetUpTest(c)
@@ -71,26 +49,26 @@ func (s *ShowCommandSuite) SetUpTest(c *gc.C) {
 		Access:      "read",
 	}}
 
-	s.fake.ResetCalls()
-	s.fake.err = nil
-	s.fake.info = params.ModelInfo{
-		Name:           "mymodel",
-		UUID:           testing.ModelTag.Id(),
-		ControllerUUID: "1ca2293b-fdb9-4299-97d6-55583bb39364",
-		OwnerTag:       "user-admin",
-		CloudTag:       "cloud-some-cloud",
-		CloudRegion:    "some-region",
-		ProviderType:   "openstack",
-		Life:           params.Alive,
-		Status: params.EntityStatus{
-			Status: status.Active,
-			Since:  &statusSince,
-		},
-		Users: users,
-		Migration: &params.ModelMigrationStatus{
-			Status: "obfuscating Quigley matrix",
-			Start:  &migrationStart,
-			End:    &migrationEnd,
+	s.fake = fakeModelShowClient{
+		info: params.ModelInfo{
+			Name:           "mymodel",
+			UUID:           testing.ModelTag.Id(),
+			ControllerUUID: "1ca2293b-fdb9-4299-97d6-55583bb39364",
+			OwnerTag:       "user-admin",
+			CloudTag:       "cloud-some-cloud",
+			CloudRegion:    "some-region",
+			ProviderType:   "openstack",
+			Life:           params.Alive,
+			Status: &params.EntityStatus{
+				Status: status.Active,
+				Since:  &statusSince,
+			},
+			Users: users,
+			Migration: &params.ModelMigrationStatus{
+				Status: "obfuscating Quigley matrix",
+				Start:  &migrationStart,
+				End:    &migrationEnd,
+			},
 		},
 	}
 
@@ -139,10 +117,6 @@ func (s *ShowCommandSuite) SetUpTest(c *gc.C) {
 	s.store.Models["testing"].CurrentModel = "admin/mymodel"
 }
 
-func (s *ShowCommandSuite) newShowCommand() cmd.Command {
-	return model.NewShowCommandForTest(&s.fake, noOpRefresh, s.store)
-}
-
 func (s *ShowCommandSuite) TestShow(c *gc.C) {
 	_, err := cmdtesting.RunCommand(c, s.newShowCommand())
 	c.Assert(err, jc.ErrorIsNil)
@@ -180,11 +154,365 @@ func (s *ShowCommandSuite) TestUnrecognizedArg(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, `unrecognized args: \["whoops"\]`)
 }
 
+func (s *ShowCommandSuite) TestShowBasicIncompleteModelsYaml(c *gc.C) {
+	s.fake.infos = []params.ModelInfoResult{
+		params.ModelInfoResult{Result: createBasicModelInfo()},
+	}
+	s.expectedDisplay = `
+basic-model:
+  name: basic-model
+  model-uuid: deadbeef-0bad-400d-8000-4b1d0d06f00d
+  controller-uuid: deadbeef-1bad-500d-9000-4b1d0d06f00d
+  controller-name: testing
+  owner: owner
+  cloud: altostratus
+  region: mid-level
+  life: dead
+`[1:]
+	s.assertShowOutput(c, "yaml")
+}
+
+func (s *ShowCommandSuite) TestShowBasicIncompleteModelsJson(c *gc.C) {
+	s.fake.infos = []params.ModelInfoResult{
+		params.ModelInfoResult{Result: createBasicModelInfo()},
+	}
+	s.expectedDisplay = "{\"basic-model\":{\"name\":\"basic-model\"," +
+		"\"model-uuid\":\"deadbeef-0bad-400d-8000-4b1d0d06f00d\"," +
+		"\"controller-uuid\":\"deadbeef-1bad-500d-9000-4b1d0d06f00d\"," +
+		"\"controller-name\":\"testing\",\"owner\":\"owner\"," +
+		"\"cloud\":\"altostratus\",\"region\":\"mid-level\"," +
+		"\"life\":\"dead\"}}\n"
+	s.assertShowOutput(c, "json")
+}
+
+func (s *ShowCommandSuite) TestShowBasicWithStatusIncompleteModelsYaml(c *gc.C) {
+	s.fake.infos = []params.ModelInfoResult{
+		params.ModelInfoResult{Result: createBasicModelInfoWithStatus()},
+	}
+	s.expectedDisplay = `
+basic-model:
+  name: basic-model
+  model-uuid: deadbeef-0bad-400d-8000-4b1d0d06f00d
+  controller-uuid: deadbeef-1bad-500d-9000-4b1d0d06f00d
+  controller-name: testing
+  owner: owner
+  cloud: altostratus
+  region: mid-level
+  life: dead
+  status:
+    current: busy
+`[1:]
+	s.assertShowOutput(c, "yaml")
+}
+
+func (s *ShowCommandSuite) TestShowBasicWithStatusIncompleteModelsJson(c *gc.C) {
+	s.fake.infos = []params.ModelInfoResult{
+		params.ModelInfoResult{Result: createBasicModelInfoWithStatus()},
+	}
+	s.expectedDisplay = "{\"basic-model\":{\"name\":\"basic-model\"," +
+		"\"model-uuid\":\"deadbeef-0bad-400d-8000-4b1d0d06f00d\"," +
+		"\"controller-uuid\":\"deadbeef-1bad-500d-9000-4b1d0d06f00d\"," +
+		"\"controller-name\":\"testing\",\"owner\":\"owner\"," +
+		"\"cloud\":\"altostratus\",\"region\":\"mid-level\"," +
+		"\"life\":\"dead\",\"status\":{\"current\":\"busy\"}}}\n"
+	s.assertShowOutput(c, "json")
+}
+
+func (s *ShowCommandSuite) TestShowBasicWithMigrationIncompleteModelsYaml(c *gc.C) {
+	basicAndMigrationStatusInfo := createBasicModelInfo()
+	addMigrationStatusStatus(basicAndMigrationStatusInfo)
+	s.fake.infos = []params.ModelInfoResult{
+		params.ModelInfoResult{Result: basicAndMigrationStatusInfo},
+	}
+	s.expectedDisplay = `
+basic-model:
+  name: basic-model
+  model-uuid: deadbeef-0bad-400d-8000-4b1d0d06f00d
+  controller-uuid: deadbeef-1bad-500d-9000-4b1d0d06f00d
+  controller-name: testing
+  owner: owner
+  cloud: altostratus
+  region: mid-level
+  life: dead
+  status:
+    migration: importing
+    migration-start: just now
+`[1:]
+	s.assertShowOutput(c, "yaml")
+}
+
+func (s *ShowCommandSuite) TestShowBasicWithMigrationIncompleteModelsJson(c *gc.C) {
+	basicAndMigrationStatusInfo := createBasicModelInfo()
+	addMigrationStatusStatus(basicAndMigrationStatusInfo)
+	s.fake.infos = []params.ModelInfoResult{
+		params.ModelInfoResult{Result: basicAndMigrationStatusInfo},
+	}
+	s.expectedDisplay = "{\"basic-model\":{\"name\":\"basic-model\"," +
+		"\"model-uuid\":\"deadbeef-0bad-400d-8000-4b1d0d06f00d\"," +
+		"\"controller-uuid\":\"deadbeef-1bad-500d-9000-4b1d0d06f00d\"," +
+		"\"controller-name\":\"testing\",\"owner\":\"owner\"," +
+		"\"cloud\":\"altostratus\",\"region\":\"mid-level\"," +
+		"\"life\":\"dead\"," +
+		"\"status\":{\"migration\":\"importing\"," +
+		"\"migration-start\":\"just now\"}}}\n"
+	s.assertShowOutput(c, "json")
+}
+
+func (s *ShowCommandSuite) TestShowBasicWithStatusAndMigrationIncompleteModelsYaml(c *gc.C) {
+	basicAndStatusAndMigrationInfo := createBasicModelInfoWithStatus()
+	addMigrationStatusStatus(basicAndStatusAndMigrationInfo)
+	s.fake.infos = []params.ModelInfoResult{
+		params.ModelInfoResult{Result: basicAndStatusAndMigrationInfo},
+	}
+	s.expectedDisplay = `
+basic-model:
+  name: basic-model
+  model-uuid: deadbeef-0bad-400d-8000-4b1d0d06f00d
+  controller-uuid: deadbeef-1bad-500d-9000-4b1d0d06f00d
+  controller-name: testing
+  owner: owner
+  cloud: altostratus
+  region: mid-level
+  life: dead
+  status:
+    current: busy
+    migration: importing
+    migration-start: just now
+`[1:]
+	s.assertShowOutput(c, "yaml")
+}
+
+func (s *ShowCommandSuite) TestShowBasicWithStatusAndMigrationIncompleteModelsJson(c *gc.C) {
+	basicAndStatusAndMigrationInfo := createBasicModelInfoWithStatus()
+	addMigrationStatusStatus(basicAndStatusAndMigrationInfo)
+	s.fake.infos = []params.ModelInfoResult{
+		params.ModelInfoResult{Result: basicAndStatusAndMigrationInfo},
+	}
+	s.expectedDisplay = "{\"basic-model\":{\"name\":\"basic-model\"," +
+		"\"model-uuid\":\"deadbeef-0bad-400d-8000-4b1d0d06f00d\"," +
+		"\"controller-uuid\":\"deadbeef-1bad-500d-9000-4b1d0d06f00d\"," +
+		"\"controller-name\":\"testing\",\"owner\":\"owner\"," +
+		"\"cloud\":\"altostratus\",\"region\":\"mid-level\"," +
+		"\"life\":\"dead\",\"status\":{\"current\":\"busy\"," +
+		"\"migration\":\"importing\",\"migration-start\":\"just now\"}}}\n"
+	s.assertShowOutput(c, "json")
+}
+
+func (s *ShowCommandSuite) TestShowBasicWithProviderIncompleteModelsYaml(c *gc.C) {
+	basicAndProviderTypeInfo := createBasicModelInfo()
+	basicAndProviderTypeInfo.ProviderType = "aws"
+	s.fake.infos = []params.ModelInfoResult{
+		params.ModelInfoResult{Result: basicAndProviderTypeInfo},
+	}
+	s.expectedDisplay = `
+basic-model:
+  name: basic-model
+  model-uuid: deadbeef-0bad-400d-8000-4b1d0d06f00d
+  controller-uuid: deadbeef-1bad-500d-9000-4b1d0d06f00d
+  controller-name: testing
+  owner: owner
+  cloud: altostratus
+  region: mid-level
+  type: aws
+  life: dead
+`[1:]
+	s.assertShowOutput(c, "yaml")
+}
+
+func (s *ShowCommandSuite) TestShowBasicWithProviderIncompleteModelsJson(c *gc.C) {
+	basicAndProviderTypeInfo := createBasicModelInfo()
+	basicAndProviderTypeInfo.ProviderType = "aws"
+	s.fake.infos = []params.ModelInfoResult{
+		params.ModelInfoResult{Result: basicAndProviderTypeInfo},
+	}
+	s.expectedDisplay = "{\"basic-model\":{\"name\":\"basic-model\"," +
+		"\"model-uuid\":\"deadbeef-0bad-400d-8000-4b1d0d06f00d\"," +
+		"\"controller-uuid\":\"deadbeef-1bad-500d-9000-4b1d0d06f00d\"," +
+		"\"controller-name\":\"testing\",\"owner\":\"owner\"," +
+		"\"cloud\":\"altostratus\",\"region\":\"mid-level\"," +
+		"\"type\":\"aws\",\"life\":\"dead\"}}\n"
+	s.assertShowOutput(c, "json")
+}
+
+func (s *ShowCommandSuite) TestShowBasicWithUsersIncompleteModelsYaml(c *gc.C) {
+	basicAndUsersInfo := createBasicModelInfo()
+	basicAndUsersInfo.Users = []params.ModelUserInfo{
+		params.ModelUserInfo{"admin", "display name", nil, params.UserAccessPermission("admin")},
+	}
+	s.fake.infos = []params.ModelInfoResult{
+		params.ModelInfoResult{Result: basicAndUsersInfo},
+	}
+	s.expectedDisplay = `
+basic-model:
+  name: basic-model
+  model-uuid: deadbeef-0bad-400d-8000-4b1d0d06f00d
+  controller-uuid: deadbeef-1bad-500d-9000-4b1d0d06f00d
+  controller-name: testing
+  owner: owner
+  cloud: altostratus
+  region: mid-level
+  life: dead
+  users:
+    admin:
+      display-name: display name
+      access: admin
+      last-connection: never connected
+`[1:]
+	s.assertShowOutput(c, "yaml")
+}
+
+func (s *ShowCommandSuite) TestShowBasicWithUsersIncompleteModelsJson(c *gc.C) {
+	basicAndUsersInfo := createBasicModelInfo()
+	basicAndUsersInfo.Users = []params.ModelUserInfo{
+		params.ModelUserInfo{"admin", "display name", nil, params.UserAccessPermission("admin")},
+	}
+
+	s.fake.infos = []params.ModelInfoResult{
+		params.ModelInfoResult{Result: basicAndUsersInfo},
+	}
+	s.expectedDisplay = "{\"basic-model\":{\"name\":\"basic-model\"," +
+		"\"model-uuid\":\"deadbeef-0bad-400d-8000-4b1d0d06f00d\"," +
+		"\"controller-uuid\":\"deadbeef-1bad-500d-9000-4b1d0d06f00d\"," +
+		"\"controller-name\":\"testing\",\"owner\":\"owner\"," +
+		"\"cloud\":\"altostratus\",\"region\":\"mid-level\"," +
+		"\"life\":\"dead\"," +
+		"\"users\":{\"admin\":{\"display-name\":\"display name\"," +
+		"\"access\":\"admin\",\"last-connection\":\"never connected\"}}}}\n"
+	s.assertShowOutput(c, "json")
+}
+
+func (s *ShowCommandSuite) TestShowBasicWithMachinesIncompleteModelsYaml(c *gc.C) {
+	basicAndMachinesInfo := createBasicModelInfo()
+	basicAndMachinesInfo.Machines = []params.ModelMachineInfo{
+		params.ModelMachineInfo{Id: "2"},
+		params.ModelMachineInfo{Id: "12"},
+	}
+	s.fake.infos = []params.ModelInfoResult{
+		params.ModelInfoResult{Result: basicAndMachinesInfo},
+	}
+	s.expectedDisplay = `
+basic-model:
+  name: basic-model
+  model-uuid: deadbeef-0bad-400d-8000-4b1d0d06f00d
+  controller-uuid: deadbeef-1bad-500d-9000-4b1d0d06f00d
+  controller-name: testing
+  owner: owner
+  cloud: altostratus
+  region: mid-level
+  life: dead
+  machines:
+    "2":
+      cores: 0
+    "12":
+      cores: 0
+`[1:]
+	s.assertShowOutput(c, "yaml")
+}
+
+func (s *ShowCommandSuite) TestShowBasicWithMachinesIncompleteModelsJson(c *gc.C) {
+	basicAndMachinesInfo := createBasicModelInfo()
+	basicAndMachinesInfo.Machines = []params.ModelMachineInfo{
+		params.ModelMachineInfo{Id: "2"},
+		params.ModelMachineInfo{Id: "12"},
+	}
+	s.fake.infos = []params.ModelInfoResult{
+		params.ModelInfoResult{Result: basicAndMachinesInfo},
+	}
+	s.expectedDisplay = "{\"basic-model\":{\"name\":\"basic-model\"," +
+		"\"model-uuid\":\"deadbeef-0bad-400d-8000-4b1d0d06f00d\"," +
+		"\"controller-uuid\":\"deadbeef-1bad-500d-9000-4b1d0d06f00d\"," +
+		"\"controller-name\":\"testing\",\"owner\":\"owner\"," +
+		"\"cloud\":\"altostratus\",\"region\":\"mid-level\"," +
+		"\"life\":\"dead\"," +
+		"\"machines\":{\"12\":{\"cores\":0},\"2\":{\"cores\":0}}}}\n"
+	s.assertShowOutput(c, "json")
+}
+
+func (s *ShowCommandSuite) TestShowBasicWithSLAIncompleteModelsYaml(c *gc.C) {
+	basicAndSLAInfo := createBasicModelInfo()
+	basicAndSLAInfo.SLA = &params.ModelSLAInfo{
+		Owner: "owner",
+		Level: "level",
+	}
+	s.fake.infos = []params.ModelInfoResult{
+		params.ModelInfoResult{Result: basicAndSLAInfo},
+	}
+	s.expectedDisplay = `
+basic-model:
+  name: basic-model
+  model-uuid: deadbeef-0bad-400d-8000-4b1d0d06f00d
+  controller-uuid: deadbeef-1bad-500d-9000-4b1d0d06f00d
+  controller-name: testing
+  owner: owner
+  cloud: altostratus
+  region: mid-level
+  life: dead
+  sla: level
+  sla-owner: owner
+`[1:]
+	s.assertShowOutput(c, "yaml")
+}
+
+func (s *ShowCommandSuite) TestShowBasicWithSLAIncompleteModelsJson(c *gc.C) {
+	basicAndSLAInfo := createBasicModelInfo()
+	basicAndSLAInfo.SLA = &params.ModelSLAInfo{
+		Owner: "owner",
+		Level: "level",
+	}
+	s.fake.infos = []params.ModelInfoResult{
+		params.ModelInfoResult{Result: basicAndSLAInfo},
+	}
+	s.expectedDisplay = "{\"basic-model\":{\"name\":\"basic-model\"," +
+		"\"model-uuid\":\"deadbeef-0bad-400d-8000-4b1d0d06f00d\"," +
+		"\"controller-uuid\":\"deadbeef-1bad-500d-9000-4b1d0d06f00d\"," +
+		"\"controller-name\":\"testing\",\"owner\":\"owner\"," +
+		"\"cloud\":\"altostratus\",\"region\":\"mid-level\"," +
+		"\"life\":\"dead\",\"sla\":\"level\"," +
+		"\"sla-owner\":\"owner\"}}\n"
+	s.assertShowOutput(c, "json")
+}
+
+func (s *ShowCommandSuite) newShowCommand() cmd.Command {
+	return model.NewShowCommandForTest(&s.fake, noOpRefresh, s.store)
+}
+
+func (s *ShowCommandSuite) assertShowOutput(c *gc.C, format string) {
+	ctx, err := cmdtesting.RunCommand(c, s.newShowCommand(), "--format", format)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, s.expectedDisplay)
+}
+
+func createBasicModelInfo() *params.ModelInfo {
+	return &params.ModelInfo{
+		Name:           "basic-model",
+		UUID:           testing.ModelTag.Id(),
+		ControllerUUID: testing.ControllerTag.Id(),
+		OwnerTag:       names.NewUserTag("owner").String(),
+		Life:           params.Dead,
+		CloudTag:       names.NewCloudTag("altostratus").String(),
+		CloudRegion:    "mid-level",
+	}
+}
+
+func createBasicModelInfoWithStatus() *params.ModelInfo {
+	basicAndStatusInfo := createBasicModelInfo()
+	basicAndStatusInfo.Status = &params.EntityStatus{
+		Status: status.Busy,
+	}
+	return basicAndStatusInfo
+}
+
+func addMigrationStatusStatus(existingInfo *params.ModelInfo) {
+	now := time.Now()
+	existingInfo.Migration = &params.ModelMigrationStatus{
+		Status: "importing",
+		Start:  &now,
+	}
+}
+
 type showSLACommandSuite struct {
 	ShowCommandSuite
 }
-
-var _ = gc.Suite(&showSLACommandSuite{})
 
 func (s *showSLACommandSuite) SetUpTest(c *gc.C) {
 	s.ShowCommandSuite.SetUpTest(c)
@@ -200,4 +528,32 @@ func (s *showSLACommandSuite) SetUpTest(c *gc.C) {
 
 func noOpRefresh(jujuclient.ClientStore, string) error {
 	return nil
+}
+
+type attrs map[string]interface{}
+
+type fakeModelShowClient struct {
+	gitjujutesting.Stub
+	info  params.ModelInfo
+	err   *params.Error
+	infos []params.ModelInfoResult
+}
+
+func (f *fakeModelShowClient) Close() error {
+	f.MethodCall(f, "Close")
+	return f.NextErr()
+}
+
+func (f *fakeModelShowClient) ModelInfo(tags []names.ModelTag) ([]params.ModelInfoResult, error) {
+	f.MethodCall(f, "ModelInfo", tags)
+	if f.infos != nil {
+		return f.infos, nil
+	}
+	if len(tags) != 1 {
+		return nil, errors.Errorf("expected 1 tag, got %d", len(tags))
+	}
+	if tags[0] != testing.ModelTag {
+		return nil, errors.Errorf("expected %s, got %s", testing.ModelTag.Id(), tags[0].Id())
+	}
+	return []params.ModelInfoResult{{Result: &f.info, Error: f.err}}, f.NextErr()
 }

--- a/cmd/juju/model/show_test.go
+++ b/cmd/juju/model/show_test.go
@@ -59,7 +59,7 @@ func (s *ShowCommandSuite) SetUpTest(c *gc.C) {
 			CloudRegion:    "some-region",
 			ProviderType:   "openstack",
 			Life:           params.Alive,
-			Status: &params.EntityStatus{
+			Status: params.EntityStatus{
 				Status: status.Active,
 				Since:  &statusSince,
 			},
@@ -496,7 +496,7 @@ func createBasicModelInfo() *params.ModelInfo {
 
 func createBasicModelInfoWithStatus() *params.ModelInfo {
 	basicAndStatusInfo := createBasicModelInfo()
-	basicAndStatusInfo.Status = &params.EntityStatus{
+	basicAndStatusInfo.Status = params.EntityStatus{
 		Status: status.Busy,
 	}
 	return basicAndStatusInfo

--- a/featuretests/cmd_juju_controller_test.go
+++ b/featuretests/cmd_juju_controller_test.go
@@ -102,7 +102,7 @@ func (s *cmdControllerSuite) TestAddModelNormalUser(c *gc.C) {
 		"\n"+
 		"Model              Cloud/Region        Status     Access  Last connection\n"+
 		"admin/controller*  dummy/dummy-region  available  admin   just now\n"+
-		"test/new-model     dummy/dummy-region  available          never connected\n"+
+		"test/new-model     dummy/dummy-region  available  -       never connected\n"+
 		"\n")
 }
 


### PR DESCRIPTION
## Description of change

Under some circumstances, list models could fail. This was particularly apparent in the cases where models were marked for destruction or have been in process of being imported. The listing itself was not failing. However, the code that retrieved model information for display could not handle partial information.
Previous code expected all information for a model to be present and accessible.
This PR changes the behavior:
* For models that are alive and active, we do expect to receive all information. When we cannot, we consider it a fatal error and surface it;
* For models that are not alive - dead or dying, i.e. the models that are in some phases of lifecycle leading to their total destruction - or the models that are being imported, we do not expect to receive all information. When we encounter NotFound errors, they are not considered fatal. This allows us to send partial information or, at least, all available-at-the-time-of-the-request information. Note that all other types of errors are still considered fatal.

The most interesting part of this PR is in apiserver/modelmanager/modelmanager.go.
The rest of the PR is dealing with the ability to display partial information without too many surprises. It also contains a comprehensive amount of testing to ensure that most common combinations of partial information are formatted in a manner that is pleasing to the eye and is not-surprising for automatic digestion.

## QA steps

Since this change is for the models in particular phases in lifecycle, there is a bit of timing competition with Juju to test this change reliably. This is most notoriously better in CI or on some very slow machines. When manually verifying, you would need to be able to catch a model in either dying state or when migrating, in importing phase. On my machine, mongo powers through and does the right things quickly, so it was very hard to catch.
Steps to re-produce:
1. bootstrap
2. add model with various entities - machines and users worked bets for me;
3. destroy model while listing models
You should  observe any errors.

In CI,  model migration related tests were the best at detecting the issue intermittently.

## Documentation changes

This PR changes output of list models as well as show models, essentially omitting fields with empty values.
For list models, in tabular output, empty values are shown as  '-' to ensure that lines are easily deduced for larger outputs.
If documentation has sample outputs for these two commands, they may need to be updated.

## Bug reference
https://bugs.launchpad.net/juju/+bug/1674805
For https://bugs.launchpad.net/juju/+bug/1676279, this PR addresses the list models failure only. The bug itself about canceling model destruction still stands. 

