### PR TITLE
Fix destroy model modelconfig facade access

### DIFF
--- a/cmd/juju/model/destroy.go
+++ b/cmd/juju/model/destroy.go
@@ -141,7 +141,7 @@ func (c *destroyCommand) getModelConfigAPI() (ModelConfigAPI, error) {
 	if c.configApi != nil {
 		return c.configApi, nil
 	}
-	root, err := c.NewControllerAPIRoot()
+	root, err := c.NewAPIRoot()
 	if err != nil {
 		return nil, errors.Trace(err)
 	}


### PR DESCRIPTION
## Description of change

Fixes https://pastebin.canonical.com/186426/ 

Why is this change needed?

The juju destroy-model command was complaining about access to ModelConfig facade not being supported for the controller API connection.

## QA steps

1) Bootstrap a new controller (this created a default model)
2) juju destroy-model default
3) you should no longer see the following message
WARNING could not determine model SLA level: facade "ModelConfig" not supported for controller API connection (not supported)

## Documentation changes

No documentation changes required.

## Bug reference

N/A