### PR TITLE
Add known Oracle cloud regions to fallbacl clouds yaml

### DIFF
--- a/cloud/clouds_test.go
+++ b/cloud/clouds_test.go
@@ -21,7 +21,7 @@ type cloudSuite struct {
 var _ = gc.Suite(&cloudSuite{})
 
 var publicCloudNames = []string{
-	"aws", "aws-china", "aws-gov", "google", "azure", "azure-china", "rackspace", "joyent", "cloudsigma",
+	"aws", "aws-china", "aws-gov", "google", "azure", "azure-china", "rackspace", "joyent", "cloudsigma", "oracle",
 }
 
 func parsePublicClouds(c *gc.C) map[string]cloud.Cloud {

--- a/cloud/fallback-public-cloud.yaml
+++ b/cloud/fallback-public-cloud.yaml
@@ -228,3 +228,18 @@ clouds:
         endpoint: https://wdc.cloudsigma.com/api/2.0/
       zrh:
         endpoint: https://zrh.cloudsigma.com/api/2.0/
+  oracle:
+    type: oracle
+    description: Oracle Cloud
+    auth-types: [ userpass ]
+    regions:
+      uscom-central-1:
+        endpoint: https://compute.uscom-central-1.oraclecloud.com
+      us2:
+        endpoint: https://compute.uscom-central-1.oraclecloud.com
+      us6:
+        endpoint: https://compute.us6.oraclecloud.com
+      em2:
+        endpoint: https://compute.em2.oraclecloud.com
+      em3:
+        endpoint: https://compute.em3.oraclecloud.com

--- a/cloud/fallback_public_cloud.go
+++ b/cloud/fallback_public_cloud.go
@@ -235,4 +235,19 @@ clouds:
         endpoint: https://wdc.cloudsigma.com/api/2.0/
       zrh:
         endpoint: https://zrh.cloudsigma.com/api/2.0/
+  oracle:
+    type: oracle
+    description: Oracle Cloud
+    auth-types: [ userpass ]
+    regions:
+      uscom-central-1:
+        endpoint: https://compute.uscom-central-1.oraclecloud.com
+      us2:
+        endpoint: https://compute.uscom-central-1.oraclecloud.com
+      us6:
+        endpoint: https://compute.us6.oraclecloud.com
+      em2:
+        endpoint: https://compute.em2.oraclecloud.com
+      em3:
+        endpoint: https://compute.em3.oraclecloud.com
 `

--- a/cmd/juju/cloud/list_test.go
+++ b/cmd/juju/cloud/list_test.go
@@ -57,7 +57,7 @@ clouds:
 	// Just check a snippet of the output to make sure it looks ok.
 	// local clouds are last.
 	// homestack should abut localhost and hence come last in the output.
-	c.Assert(out, jc.Contains, `Hypervisorhomestack          1  london         openstack   Openstack Cloud`)
+	c.Assert(out, jc.Contains, `Hypervisorhomestack          1  london           openstack   Openstack Cloud`)
 }
 
 func (s *listSuite) TestListPublicAndPersonalSameName(c *gc.C) {

--- a/cmd/juju/commands/bootstrap_test.go
+++ b/cmd/juju/commands/bootstrap_test.go
@@ -1654,6 +1654,7 @@ azure-china
 cloudsigma                                   
 google                                       
 joyent                                       
+oracle                                       
 rackspace                                    
 localhost                                    
 dummy-cloud                     joe          home

--- a/provider/oracle/images.go
+++ b/provider/oracle/images.go
@@ -26,7 +26,7 @@ var windowsServerMap = map[string]string{
 var defaultImages = []string{
 	"Ubuntu.12.04-LTS.amd64.20170417",
 	"Ubuntu.14.04-LTS.amd64.20170405",
-	"Ubuntu.16.04-LTS.amd64.20170221",
+	"Ubuntu.16.04-LTS.amd64.20170330",
 	"Ubuntu.16.10.amd64.20170330",
 }
 
@@ -44,7 +44,7 @@ func ensureImageInventory(c EnvironAPI) error {
 		trimmed := strings.Split(val.Name, "/")
 		names.Add(trimmed[len(trimmed)-1])
 	}
-	logger.Debugf("found %d images", names.Size())
+	logger.Debugf("found images: %v", names)
 	errs := []error{}
 	for _, val := range defaultImages {
 		if !names.Contains(val) {
@@ -67,14 +67,14 @@ func ensureImageInventory(c EnvironAPI) error {
 				entryAttributes,
 				1, []string{imageName})
 			if err != nil {
-				errs = append(errs, err)
+				errs = append(errs, errors.Annotatef(err, "failed to create image entry %v", imageName))
 				// Cleanup list in case of error
 				_ = c.DeleteImageList(listDetails.Name)
 			}
 		}
 	}
 	if len(errs) > 0 {
-		return errors.Errorf("failed to add images to inventory: %v", errs)
+		logger.Debugf("failed to add some images to inventory: %v", errs)
 	}
 	return nil
 }


### PR DESCRIPTION
## Description of change

Add the known Oracle cloud regions to fallback-public-cloud.yaml so the cloud is usable out of the box.
Also, tweak the recently added experimental code to copy images across to the users account so that it logs any errors but does not abort (there's upstream issues preventing it working).

## QA steps

bootstrap an oracle model

