### PR TITLE
firewaller: Ensure ports get closed for old CIDRs

### DIFF
--- a/worker/firewaller/diffrules_test.go
+++ b/worker/firewaller/diffrules_test.go
@@ -117,3 +117,15 @@ func (s *DiffRulesSuite) TestPortRangeOverlap(c *gc.C) {
 		network.MustNewIngressRule("tcp", 80, 90, "192.168.1.0/24"),
 	})
 }
+
+func (s *diffSuite) TestDiffRangesClosesPortsIfRulesAreDisjoint(c *gc.C) {
+	current := []network.IngressRule{
+		network.MustNewIngressRule("tcp", 3306, 3306, "35.187.158.35/32"),
+	}
+	wanted := []network.IngressRule{
+		network.MustNewIngressRule("tcp", 3306, 3306, "35.187.152.241/32"),
+	}
+	toOpen, toClose := diffRanges(current, wanted)
+	c.Assert(toOpen, gc.DeepEquals, wanted)
+	c.Assert(toClose, gc.DeepEquals, current)
+}

--- a/worker/firewaller/diffrules_test.go
+++ b/worker/firewaller/diffrules_test.go
@@ -118,7 +118,7 @@ func (s *DiffRulesSuite) TestPortRangeOverlap(c *gc.C) {
 	})
 }
 
-func (s *diffSuite) TestDiffRangesClosesPortsIfRulesAreDisjoint(c *gc.C) {
+func (s *DiffRulesSuite) TestDiffRangesClosesPortsIfRulesAreDisjoint(c *gc.C) {
 	current := []network.IngressRule{
 		network.MustNewIngressRule("tcp", 3306, 3306, "35.187.158.35/32"),
 	}

--- a/worker/firewaller/firewaller.go
+++ b/worker/firewaller/firewaller.go
@@ -1110,10 +1110,6 @@ func diffRanges(currentRules, wantedRules []network.IngressRule) (toOpen, toClos
 			rule := network.IngressRule{PortRange: portRange, SourceCIDRs: toOpenCidrs.SortedValues()}
 			toOpen = append(toOpen, rule)
 		}
-		// We we have any CIDRs for which to allow access, no need to close the port range.
-		if len(toOpenCidrs) > 0 {
-			continue
-		}
 		toCloseCidrs := existingCidrs.Difference(wantedCidrs)
 		if toCloseCidrs.Size() > 0 {
 			rule := network.IngressRule{PortRange: portRange, SourceCIDRs: toCloseCidrs.SortedValues()}


### PR DESCRIPTION
## Description of change

Even if we're also opening them for another CIDR. This came up while
rejigging the GCE firewall handling - the firewaller would open the
ports for the new CIDR but not close them for the old one.

## QA steps

* Bootstrap and create 2 models with a cross-model relation in GCE
* Stop and start a machine on the consuming side of the relation so that its public address changes.
* When the new address is noticed and the firewall rules updated, check that the old address is removed from the firewall rule.
