### PR TITLE
provider/vsphere: fix intermittent test failures

### DIFF
--- a/provider/vsphere/internal/vsphereclient/createvm_test.go
+++ b/provider/vsphere/internal/vsphereclient/createvm_test.go
@@ -29,16 +29,39 @@ func (s *clientSuite) TestCreateVirtualMachine(c *gc.C) {
 	)
 	c.Assert(err, jc.ErrorIsNil)
 
+	var statusUpdates []string
+	statusUpdatesCh := make(chan string, 3)
+	dequeueStatusUpdates := func() {
+		for {
+			select {
+			case <-statusUpdatesCh:
+			default:
+				return
+			}
+		}
+	}
+
 	testClock := testing.NewClock(time.Time{})
-	s.onImageUpload = func(*http.Request) {
-		// Wait until the status and lease updaters are waiting for
-		// the time to tick over, and then advance by 2 seconds to
-		// wake them both up.
-		testClock.WaitAdvance(2*time.Second, coretesting.LongWait, 2)
+	s.onImageUpload = func(r *http.Request) {
+		dequeueStatusUpdates()
+
+		// Wait 1.5 seconds, which is long enough to trigger the status
+		// update timer, but not the lease update timer.
+		testClock.WaitAdvance(1500*time.Millisecond, coretesting.LongWait, 2)
+		// Waiting for the status update here guarantees that a report is
+		// available, since we don't update status until that is true.
+		<-statusUpdatesCh
+
+		// Now wait 0.5 seconds, which is long enough to trigger the
+		// lease updater's timer, but not the status updater's timer.
+		// Since the status update was received above, we know that a
+		// report has been delivered and so the lease updater should
+		// report 100%.
+		testClock.WaitAdvance(500*time.Millisecond, coretesting.LongWait, 2)
+		<-s.roundTripper.leaseProgress
 		s.onImageUpload = nil
 	}
 
-	var progressUpdates []string
 	client := s.newFakeClient(&s.roundTripper, "dc0")
 	args := CreateVirtualMachineParams{
 		Name:     "vm-0",
@@ -59,15 +82,16 @@ func (s *clientSuite) TestCreateVirtualMachine(c *gc.C) {
 		Metadata:        map[string]string{"k": "v"},
 		Constraints:     constraints.Value{},
 		ExternalNetwork: "arpa",
-		UpdateProgress: func(progress string) {
-			progressUpdates = append(progressUpdates, progress)
+		UpdateProgress: func(status string) {
+			statusUpdatesCh <- status
+			statusUpdates = append(statusUpdates, status)
 		},
-		UpdateProgressInterval: 2 * time.Second,
+		UpdateProgressInterval: time.Second,
 		Clock: testClock,
 	}
 	_, err = client.CreateVirtualMachine(context.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(progressUpdates, jc.DeepEquals, []string{
+	c.Assert(statusUpdates, jc.DeepEquals, []string{
 		"creating import spec",
 		`creating VM "vm-0"`,
 		"uploading ubuntu-14.04-server-cloudimg-amd64.vmdk: 100.00% (0B/s)",

--- a/provider/vsphere/mock_test.go
+++ b/provider/vsphere/mock_test.go
@@ -5,6 +5,7 @@ package vsphere_test
 
 import (
 	"net/url"
+	"sync"
 
 	"github.com/juju/testing"
 	"github.com/vmware/govmomi/vim25/mo"
@@ -26,58 +27,82 @@ func newMockDialFunc(dialStub *testing.Stub, client vsphere.Client) vsphere.Dial
 }
 
 type mockClient struct {
+	// mu guards testing.Stub access, to ensure that the recorded
+	// method calls correspond to the errors returned.
+	mu sync.Mutex
 	testing.Stub
+
 	computeResources      []*mo.ComputeResource
 	createdVirtualMachine *mo.VirtualMachine
 	virtualMachines       []*mo.VirtualMachine
 }
 
 func (c *mockClient) Close(ctx context.Context) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
 	c.MethodCall(c, "Close", ctx)
 	return c.NextErr()
 }
 
 func (c *mockClient) ComputeResources(ctx context.Context) ([]*mo.ComputeResource, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
 	c.MethodCall(c, "ComputeResources", ctx)
 	return c.computeResources, c.NextErr()
 }
 
 func (c *mockClient) CreateVirtualMachine(ctx context.Context, args vsphereclient.CreateVirtualMachineParams) (*mo.VirtualMachine, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
 	c.MethodCall(c, "CreateVirtualMachine", ctx, args)
 	return c.createdVirtualMachine, c.NextErr()
 }
 
 func (c *mockClient) DestroyVMFolder(ctx context.Context, path string) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
 	c.MethodCall(c, "DestroyVMFolder", ctx, path)
 	return c.NextErr()
 }
 
 func (c *mockClient) EnsureVMFolder(ctx context.Context, path string) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
 	c.MethodCall(c, "EnsureVMFolder", ctx, path)
 	return c.NextErr()
 }
 
 func (c *mockClient) MoveVMFolderInto(ctx context.Context, parent string, child string) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
 	c.MethodCall(c, "MoveVMFolderInto", ctx, parent, child)
 	return c.NextErr()
 }
 
 func (c *mockClient) MoveVMsInto(ctx context.Context, folder string, vms ...types.ManagedObjectReference) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
 	c.MethodCall(c, "MoveVMsInto", ctx, folder, vms)
 	return c.NextErr()
 }
 
 func (c *mockClient) RemoveVirtualMachines(ctx context.Context, path string) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
 	c.MethodCall(c, "RemoveVirtualMachines", ctx, path)
 	return c.NextErr()
 }
 
 func (c *mockClient) UpdateVirtualMachineExtraConfig(ctx context.Context, vm *mo.VirtualMachine, attrs map[string]string) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
 	c.MethodCall(c, "UpdateVirtualMachineExtraConfig", ctx, vm, attrs)
 	return c.NextErr()
 }
 
 func (c *mockClient) VirtualMachines(ctx context.Context, path string) ([]*mo.VirtualMachine, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
 	c.MethodCall(c, "VirtualMachines", ctx, path)
 	return c.virtualMachines, c.NextErr()
 }


### PR DESCRIPTION
## Description of change

This PR fixes several intermittent test failures.

In the interal/vsphereclient package, the CreateVM test was failing intermittently due to timing around progress reports being sent and timers being fired. The govmomi/vim25/progress report is not necessarily delivered before the lease update timer fires, so we now wait for a status update first and then a lease update later, when we know a report has been delivered.

TestStopInstancesMultipleFailures was failing due to a problem with the mock vsphere client: the calls to testing.Stub.MethodCall and NextErr were not locked together, so the code in the test to swap the errors based on the name of the VM destroyed first was ineffective. This is fixed by introducing a mutex into the mock, and locking the two calls together.

## QA steps

I temporarily introduced tests that called the failing tests in a loop. I could easily reproduce before the changes, not at all after.

## Documentation changes

None.

## Bug reference

None.