### PR TITLE
Update Makefile to utilize go-1.8, update old dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ PROJECT := github.com/juju/juju
 PROJECT_DIR := $(shell go list -e -f '{{.Dir}}' $(PROJECT))
 
 ifeq ($(shell uname -p | sed -r 's/.*(86|armel|armhf|aarch64|ppc64le|s390x).*/golang/'), golang)
-	GO_C := golang-1.[6-9]
+	GO_C := golang-1.8
 	INSTALL_FLAGS :=
 else
 	GO_C := gccgo-4.9  gccgo-go
@@ -27,10 +27,8 @@ endif
 define DEPENDENCIES
   ca-certificates
   bzip2
-  bzr
   distro-info-data
-  git-core
-  mercurial
+  git
   zip
   $(GO_C)
 endef
@@ -56,7 +54,7 @@ build: godeps
 	go build $(PROJECT)/...
 
 check: godeps
-	go test -test.timeout=$(TEST_TIMEOUT) $(PROJECT)/... 
+	go test -test.timeout=$(TEST_TIMEOUT) $(PROJECT)/...
 
 install: godeps
 	go install $(INSTALL_FLAGS) -v $(PROJECT)/...
@@ -98,14 +96,12 @@ rebuild-dependencies.tsv: godeps
 # Install packages required to develop Juju and run tests. The stable
 # PPA includes the required mongodb-server binaries.
 install-dependencies:
-ifeq ($(shell lsb_release -cs|sed -r 's/precise|wily/old/'),old)
-	@echo Adding juju PPAs for golang and mongodb-server
+	@echo Adding PPAs for golang and juju
 	@sudo apt-add-repository --yes ppa:juju/golang
 	@sudo apt-add-repository --yes ppa:juju/stable
 	@sudo apt-get update
-endif
 	@echo Installing dependencies
-	@sudo apt-get --yes install --no-install-recommends \
+	@sudo apt-get --yes install  \
 	$(strip $(DEPENDENCIES)) \
 	$(shell apt-cache madison juju-mongodb3.2 juju-mongodb mongodb-server | head -1 | cut -d '|' -f1)
 

--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,7 @@ endif
 define DEPENDENCIES
   ca-certificates
   bzip2
+  bzr
   distro-info-data
   git
   zip
@@ -96,7 +97,7 @@ rebuild-dependencies.tsv: godeps
 # Install packages required to develop Juju and run tests. The stable
 # PPA includes the required mongodb-server binaries.
 install-dependencies:
-	@echo Adding PPAs for golang and juju
+	@echo Adding juju PPAs for golang and juju
 	@sudo apt-add-repository --yes ppa:juju/golang
 	@sudo apt-add-repository --yes ppa:juju/stable
 	@sudo apt-get update


### PR DESCRIPTION
## Description of change
This change updates the Makefile to depend on go-1.8 only for non gcc-go.

Why is this change needed? This change allows us to build with go-1.8, which will be required for new changes going forward.

## QA steps

The github-check-merge job is currently experimenting with building with go-1.8 to minimize impact. Once that job blesses this PR, we should be good to merge.

In addition, manual verification of running make install-dependencies.


This helps land https://bugs.launchpad.net/juju/+bug/1683099