### PR TITLE
cmd/juju/application: make deploy init tests assume less about internals

### DIFF
--- a/cmd/juju/application/cmd_test.go
+++ b/cmd/juju/application/cmd_test.go
@@ -4,11 +4,8 @@
 package application
 
 import (
-	"os"
-
 	"github.com/juju/cmd"
 	"github.com/juju/cmd/cmdtesting"
-	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/cmd/modelcmd"
@@ -18,92 +15,78 @@ import (
 
 type CmdSuite struct {
 	coretesting.FakeJujuXDGDataHomeSuite
-	ControllerStore *jujuclient.MemStore
 }
 
 var _ = gc.Suite(&CmdSuite{})
 
 func (s *CmdSuite) SetUpTest(c *gc.C) {
 	s.FakeJujuXDGDataHomeSuite.SetUpTest(c)
-	s.ControllerStore = jujuclient.NewMemStore()
 }
 
 var deployTests = []struct {
-	args []string
-	com  *DeployCommand
-}{
-	{
-		[]string{"charm-name"},
-		&DeployCommand{},
-	}, {
-		[]string{"charm-name", "application-name"},
-		&DeployCommand{ApplicationName: "application-name"},
-	}, {
-		[]string{"--num-units", "33", "charm-name"},
-		&DeployCommand{UnitCommandBase: UnitCommandBase{NumUnits: 33}},
-	}, {
-		[]string{"-n", "104", "charm-name"},
-		&DeployCommand{UnitCommandBase: UnitCommandBase{NumUnits: 104}},
-	},
-}
-
-func initExpectations(com *DeployCommand, store jujuclient.ClientStore) {
-	if com.CharmOrBundle == "" {
-		com.CharmOrBundle = "charm-name"
-	}
-	if com.NumUnits == 0 {
-		com.NumUnits = 1
-	}
-	com.SetClientStore(modelcmd.QualifyingClientStore{store})
-	com.SetModelName("controller")
-}
-
-func initDeployCommand(store jujuclient.ClientStore, args ...string) (*DeployCommand, error) {
-	com := &DeployCommand{}
-	com.SetClientStore(store)
-	return com, cmdtesting.InitCommand(modelcmd.Wrap(com), args)
-}
+	about                 string
+	args                  []string
+	expectCharmOrBundle   string
+	expectApplicationName string
+	expectNumUnits        int
+	expectError           string
+	expectConfigFile      string
+}{{
+	about:               "simple init",
+	args:                []string{"charm-name"},
+	expectCharmOrBundle: "charm-name",
+	expectNumUnits:      1,
+}, {
+	about:                 "charm and application name specified",
+	args:                  []string{"charm-name", "application-name"},
+	expectCharmOrBundle:   "charm-name",
+	expectApplicationName: "application-name",
+	expectNumUnits:        1,
+}, {
+	about:               "--num-units long form",
+	args:                []string{"--num-units", "33", "charm-name"},
+	expectNumUnits:      33,
+	expectCharmOrBundle: "charm-name",
+}, {
+	about:               "--num-units short form",
+	args:                []string{"-n", "104", "charm-name"},
+	expectNumUnits:      104,
+	expectCharmOrBundle: "charm-name",
+}, {
+	about:               "config specified",
+	args:                []string{"--config", "testconfig.yaml", "charm-name"},
+	expectCharmOrBundle: "charm-name",
+	expectNumUnits:      1,
+	expectConfigFile:    "testconfig.yaml",
+}, {
+	about:       "missing args",
+	expectError: "no charm or bundle specified",
+}, {
+	about:       "bad unit count",
+	args:        []string{"charm-name", "--num-units", "0"},
+	expectError: "--num-units must be a positive integer",
+}, {
+	about:       "bad unit count (short form)",
+	args:        []string{"charm-name", "-n", "0"},
+	expectError: "--num-units must be a positive integer",
+}}
 
 func (s *CmdSuite) TestDeployCommandInit(c *gc.C) {
 	for i, t := range deployTests {
-		c.Logf("\ntest %d: args %q", i, t.args)
-		initExpectations(t.com, s.ControllerStore)
-		com, err := initDeployCommand(s.ControllerStore, t.args...)
-		// Testing that the flag set is populated is good enough for the scope
-		// of this test.
-		c.Assert(com.flagSet, gc.NotNil)
-		com.flagSet = nil
-		c.Assert(err, jc.ErrorIsNil)
-		c.Assert(com, jc.DeepEquals, t.com)
+		c.Logf("\ntest %d: %s", i, t.about)
+		wrappedDeployCmd := NewDeployCommandForTest(nil, nil)
+		wrappedDeployCmd.SetClientStore(jujuclient.NewMemStore())
+		err := cmdtesting.InitCommand(wrappedDeployCmd, t.args)
+		if t.expectError != "" {
+			c.Assert(err, gc.ErrorMatches, t.expectError)
+			continue
+		}
+		deployCmd := modelcmd.InnerCommand(wrappedDeployCmd).(*DeployCommand)
+		c.Assert(deployCmd.ApplicationName, gc.Equals, t.expectApplicationName)
+		c.Assert(deployCmd.CharmOrBundle, gc.Equals, t.expectCharmOrBundle)
+		c.Assert(deployCmd.NumUnits, gc.Equals, t.expectNumUnits)
+		c.Assert(deployCmd.Config.Path, gc.Equals, t.expectConfigFile)
 	}
-
-	// test relative --config path
-	ctx := cmdtesting.Context(c)
-	expected := []byte("test: data")
-	path := ctx.AbsPath("testconfig.yaml")
-	file, err := os.Create(path)
-	c.Assert(err, jc.ErrorIsNil)
-	_, err = file.Write(expected)
-	c.Assert(err, jc.ErrorIsNil)
-	file.Close()
-
-	com, err := initDeployCommand(s.ControllerStore, "--config", "testconfig.yaml", "charm-name")
-	c.Assert(err, jc.ErrorIsNil)
-	actual, err := com.Config.Read(ctx)
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(expected, gc.DeepEquals, actual)
-
-	// missing args
-	_, err = initDeployCommand(s.ControllerStore)
-	c.Assert(err, gc.ErrorMatches, "no charm or bundle specified")
-
-	// bad unit count
-	_, err = initDeployCommand(s.ControllerStore, "charm-name", "--num-units", "0")
-	c.Assert(err, gc.ErrorMatches, "--num-units must be a positive integer")
-	_, err = initDeployCommand(s.ControllerStore, "charm-name", "-n", "0")
-	c.Assert(err, gc.ErrorMatches, "--num-units must be a positive integer")
-
-	// environment tested elsewhere
 }
 
 func initExposeCommand(args ...string) (*exposeCommand, error) {

--- a/cmd/juju/application/expose_test.go
+++ b/cmd/juju/application/expose_test.go
@@ -44,7 +44,7 @@ func (s *ExposeSuite) assertExposed(c *gc.C, application string) {
 
 func (s *ExposeSuite) TestExpose(c *gc.C) {
 	ch := testcharms.Repo.CharmArchivePath(s.CharmsPath, "dummy")
-	err := runDeploy(c, ch, "some-application-name", "--series", "trusty")
+	_, err := runDeploy(c, ch, "some-application-name", "--series", "trusty")
 	c.Assert(err, jc.ErrorIsNil)
 	curl := charm.MustParseURL("local:trusty/dummy-1")
 	s.AssertService(c, "some-application-name", curl, 1, 0)
@@ -62,7 +62,7 @@ func (s *ExposeSuite) TestExpose(c *gc.C) {
 
 func (s *ExposeSuite) TestBlockExpose(c *gc.C) {
 	ch := testcharms.Repo.CharmArchivePath(s.CharmsPath, "dummy")
-	err := runDeploy(c, ch, "some-application-name", "--series", "trusty")
+	_, err := runDeploy(c, ch, "some-application-name", "--series", "trusty")
 	c.Assert(err, jc.ErrorIsNil)
 	curl := charm.MustParseURL("local:trusty/dummy-1")
 	s.AssertService(c, "some-application-name", curl, 1, 0)

--- a/cmd/juju/application/removeapplication_test.go
+++ b/cmd/juju/application/removeapplication_test.go
@@ -44,7 +44,7 @@ func runRemoveApplication(c *gc.C, args ...string) (*cmd.Context, error) {
 func (s *RemoveApplicationSuite) setupTestApplication(c *gc.C) {
 	// Destroy an application that exists.
 	ch := testcharms.Repo.CharmArchivePath(s.CharmsPath, "riak")
-	err := runDeploy(c, ch, "riak", "--series", "quantal")
+	_, err := runDeploy(c, ch, "riak", "--series", "quantal")
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -61,7 +61,7 @@ func (s *RemoveApplicationSuite) TestLocalApplication(c *gc.C) {
 
 func (s *RemoveApplicationSuite) TestInformStorageRemoved(c *gc.C) {
 	ch := testcharms.Repo.CharmArchivePath(s.CharmsPath, "storage-filesystem")
-	err := runDeploy(c, ch, "storage-filesystem", "--series", "quantal", "-n2", "--storage", "data=2,rootfs")
+	_, err := runDeploy(c, ch, "storage-filesystem", "--series", "quantal", "-n2", "--storage", "data=2,rootfs")
 	c.Assert(err, jc.ErrorIsNil)
 
 	ctx, err := runRemoveApplication(c, "storage-filesystem")
@@ -98,7 +98,7 @@ func (s *RemoveApplicationSuite) TestRemoteApplication(c *gc.C) {
 
 func (s *RemoveApplicationSuite) TestRemoveLocalMetered(c *gc.C) {
 	ch := testcharms.Repo.CharmArchivePath(s.CharmsPath, "metered")
-	deploy := NewDefaultDeployCommand()
+	deploy := NewDeployCommand()
 	_, err := cmdtesting.RunCommand(c, deploy, ch, "--series", "quantal")
 	c.Assert(err, jc.ErrorIsNil)
 	_, err = runRemoveApplication(c, "metered")

--- a/cmd/juju/application/removeunit_test.go
+++ b/cmd/juju/application/removeunit_test.go
@@ -39,7 +39,7 @@ func runRemoveUnit(c *gc.C, args ...string) (*cmd.Context, error) {
 
 func (s *RemoveUnitSuite) setupUnitForRemove(c *gc.C) *state.Application {
 	ch := testcharms.Repo.CharmArchivePath(s.CharmsPath, "dummy")
-	err := runDeploy(c, "-n", "2", ch, "dummy", "--series", series.LatestLts())
+	_, err := runDeploy(c, "-n", "2", ch, "dummy", "--series", series.LatestLts())
 	c.Assert(err, jc.ErrorIsNil)
 	curl := charm.MustParseURL(fmt.Sprintf("local:%s/dummy-1", series.LatestLts()))
 	svc, _ := s.AssertService(c, "dummy", curl, 2, 0)
@@ -68,7 +68,7 @@ removing unit sillybilly/17 failed: unit "sillybilly/17" does not exist
 
 func (s *RemoveUnitSuite) TestRemoveUnitInformsStorageRemoval(c *gc.C) {
 	ch := testcharms.Repo.CharmArchivePath(s.CharmsPath, "storage-filesystem")
-	err := runDeploy(c, ch, "storage-filesystem", "--series", "quantal", "--storage", "data=rootfs,2")
+	_, err := runDeploy(c, ch, "storage-filesystem", "--series", "quantal", "--storage", "data=rootfs,2")
 	c.Assert(err, jc.ErrorIsNil)
 
 	ctx, err := runRemoveUnit(c, "storage-filesystem/0")

--- a/cmd/juju/application/unexpose_test.go
+++ b/cmd/juju/application/unexpose_test.go
@@ -44,7 +44,7 @@ func (s *UnexposeSuite) assertExposed(c *gc.C, application string, expected bool
 
 func (s *UnexposeSuite) TestUnexpose(c *gc.C) {
 	ch := testcharms.Repo.CharmArchivePath(s.CharmsPath, "dummy")
-	err := runDeploy(c, ch, "some-application-name", "--series", "trusty")
+	_, err := runDeploy(c, ch, "some-application-name", "--series", "trusty")
 	c.Assert(err, jc.ErrorIsNil)
 	curl := charm.MustParseURL("local:trusty/dummy-1")
 	s.AssertService(c, "some-application-name", curl, 1, 0)
@@ -66,7 +66,7 @@ func (s *UnexposeSuite) TestUnexpose(c *gc.C) {
 
 func (s *UnexposeSuite) TestBlockUnexpose(c *gc.C) {
 	ch := testcharms.Repo.CharmArchivePath(s.CharmsPath, "dummy")
-	err := runDeploy(c, ch, "some-application-name", "--series", "trusty")
+	_, err := runDeploy(c, ch, "some-application-name", "--series", "trusty")
 	c.Assert(err, jc.ErrorIsNil)
 	curl := charm.MustParseURL("local:trusty/dummy-1")
 	s.AssertService(c, "some-application-name", curl, 1, 0)

--- a/cmd/juju/application/upgradecharm_resources_test.go
+++ b/cmd/juju/application/upgradecharm_resources_test.go
@@ -45,7 +45,7 @@ func (s *UpgradeCharmResourceSuite) SetUpTest(c *gc.C) {
 	s.RepoSuite.SetUpTest(c)
 	chPath := testcharms.Repo.ClonedDirPath(s.CharmsPath, "riak")
 
-	_, err := cmdtesting.RunCommand(c, application.NewDefaultDeployCommand(), chPath, "riak", "--series", "quantal")
+	_, err := runDeploy(c, chPath, "riak", "--series", "quantal")
 	c.Assert(err, jc.ErrorIsNil)
 	riak, err := s.State.Application("riak")
 	c.Assert(err, jc.ErrorIsNil)
@@ -193,13 +193,11 @@ func (s *UpgradeCharmStoreResourceSuite) TestDeployStarsaySuccess(c *gc.C) {
 	err := ioutil.WriteFile(resourceFile, []byte(resourceContent), 0644)
 	c.Assert(err, jc.ErrorIsNil)
 
-	ctx, err := cmdtesting.RunCommand(c, application.NewDefaultDeployCommand(), "trusty/starsay", "--resource", "upload-resource="+resourceFile)
+	output, err := runDeploy(c, "trusty/starsay", "--resource", "upload-resource="+resourceFile)
 	c.Assert(err, jc.ErrorIsNil)
-	output := cmdtesting.Stderr(ctx)
 
 	expectedOutput := `Located charm "cs:trusty/starsay-1".
-Deploying charm "cs:trusty/starsay-1".
-`
+Deploying charm "cs:trusty/starsay-1".`
 	c.Assert(output, gc.Equals, expectedOutput)
 	s.assertCharmsUploaded(c, "cs:trusty/starsay-1")
 	s.assertServicesDeployed(c, map[string]serviceInfo{
@@ -373,4 +371,12 @@ type serviceInfo struct {
 	exposed          bool
 	storage          map[string]state.StorageConstraints
 	endpointBindings map[string]string
+}
+
+// runDeploy executes the deploy command in order to deploy the given
+// charm or bundle. The deployment stderr output and error are returned.
+// TODO(rog) delete this when tests are universally internal or external.
+func runDeploy(c *gc.C, args ...string) (string, error) {
+	ctx, err := cmdtesting.RunCommand(c, application.NewDeployCommand(), args...)
+	return strings.Trim(cmdtesting.Stderr(ctx), "\n"), err
 }

--- a/cmd/juju/application/upgradecharm_test.go
+++ b/cmd/juju/application/upgradecharm_test.go
@@ -287,7 +287,7 @@ func (s *UpgradeCharmErrorsStateSuite) TestInvalidService(c *gc.C) {
 
 func (s *UpgradeCharmErrorsStateSuite) deployService(c *gc.C) {
 	ch := testcharms.Repo.ClonedDirPath(s.CharmsPath, "riak")
-	err := runDeploy(c, ch, "riak", "--series", "quantal")
+	_, err := runDeploy(c, ch, "riak", "--series", "quantal")
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -355,7 +355,7 @@ var _ = gc.Suite(&UpgradeCharmSuccessStateSuite{})
 func (s *UpgradeCharmSuccessStateSuite) SetUpTest(c *gc.C) {
 	s.RepoSuite.SetUpTest(c)
 	s.path = testcharms.Repo.ClonedDirPath(s.CharmsPath, "riak")
-	err := runDeploy(c, s.path, "--series", "quantal")
+	_, err := runDeploy(c, s.path, "--series", "quantal")
 	c.Assert(err, jc.ErrorIsNil)
 	s.riak, err = s.State.Application("riak")
 	c.Assert(err, jc.ErrorIsNil)
@@ -407,7 +407,7 @@ func (s *UpgradeCharmSuccessStateSuite) TestRespectsLocalRevisionWhenPossible(c 
 
 func (s *UpgradeCharmSuccessStateSuite) TestForcedSeriesUpgrade(c *gc.C) {
 	path := testcharms.Repo.ClonedDirPath(c.MkDir(), "multi-series")
-	err := runDeploy(c, path, "multi-series", "--series", "precise")
+	_, err := runDeploy(c, path, "multi-series", "--series", "precise")
 	c.Assert(err, jc.ErrorIsNil)
 	application, err := s.State.Application("multi-series")
 	c.Assert(err, jc.ErrorIsNil)
@@ -585,7 +585,7 @@ var upgradeCharmAuthorizationTests = []struct {
 
 func (s *UpgradeCharmCharmStoreStateSuite) TestUpgradeCharmAuthorization(c *gc.C) {
 	testcharms.UploadCharm(c, s.client, "cs:~other/trusty/wordpress-0", "wordpress")
-	err := runDeploy(c, "cs:~other/trusty/wordpress-0")
+	_, err := runDeploy(c, "cs:~other/trusty/wordpress-0")
 	c.Assert(err, jc.ErrorIsNil)
 	for i, test := range upgradeCharmAuthorizationTests {
 		c.Logf("test %d: %s", i, test.about)
@@ -605,7 +605,7 @@ func (s *UpgradeCharmCharmStoreStateSuite) TestUpgradeCharmAuthorization(c *gc.C
 func (s *UpgradeCharmCharmStoreStateSuite) TestSwitch(c *gc.C) {
 	testcharms.UploadCharm(c, s.client, "cs:~other/trusty/riak-0", "riak")
 	testcharms.UploadCharm(c, s.client, "cs:~other/trusty/anotherriak-7", "riak")
-	err := runDeploy(c, "cs:~other/trusty/riak-0")
+	_, err := runDeploy(c, "cs:~other/trusty/riak-0")
 	c.Assert(err, jc.ErrorIsNil)
 
 	riak, err := s.State.Application("riak")
@@ -634,7 +634,7 @@ func (s *UpgradeCharmCharmStoreStateSuite) TestSwitch(c *gc.C) {
 
 func (s *UpgradeCharmCharmStoreStateSuite) TestUpgradeCharmWithChannel(c *gc.C) {
 	id, ch := testcharms.UploadCharm(c, s.client, "cs:~client-username/trusty/wordpress-0", "wordpress")
-	err := runDeploy(c, "cs:~client-username/trusty/wordpress-0")
+	_, err := runDeploy(c, "cs:~client-username/trusty/wordpress-0")
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Upload a new revision of the charm, but publish it
@@ -658,7 +658,7 @@ func (s *UpgradeCharmCharmStoreStateSuite) TestUpgradeCharmWithChannel(c *gc.C) 
 
 func (s *UpgradeCharmCharmStoreStateSuite) TestUpgradeWithTermsNotSigned(c *gc.C) {
 	id, ch := testcharms.UploadCharm(c, s.client, "quantal/terms1-1", "terms1")
-	err := runDeploy(c, "quantal/terms1")
+	_, err := runDeploy(c, "quantal/terms1")
 	c.Assert(err, jc.ErrorIsNil)
 	id.Revision = id.Revision + 1
 	err = s.client.UploadCharmWithRevision(id, ch, -1)

--- a/cmd/juju/commands/main.go
+++ b/cmd/juju/commands/main.go
@@ -371,7 +371,7 @@ func registerCommands(r commandRegistry, ctx *cmd.Context) {
 	// Manage and control services
 	r.Register(application.NewAddUnitCommand())
 	r.Register(application.NewConfigCommand())
-	r.Register(application.NewDefaultDeployCommand())
+	r.Register(application.NewDeployCommand())
 	r.Register(application.NewExposeCommand())
 	r.Register(application.NewUnexposeCommand())
 	r.Register(application.NewServiceGetConstraintsCommand())

--- a/cmd/juju/commands/main_test.go
+++ b/cmd/juju/commands/main_test.go
@@ -41,7 +41,7 @@ type MainSuite struct {
 var _ = gc.Suite(&MainSuite{})
 
 func deployHelpText() string {
-	return cmdtesting.HelpText(application.NewDefaultDeployCommand(), "juju deploy")
+	return cmdtesting.HelpText(application.NewDeployCommand(), "juju deploy")
 }
 func configHelpText() string {
 	return cmdtesting.HelpText(application.NewConfigCommand(), "juju config")

--- a/cmd/juju/commands/resolved_test.go
+++ b/cmd/juju/commands/resolved_test.go
@@ -38,7 +38,7 @@ func runResolved(c *gc.C, args []string) error {
 }
 
 func runDeploy(c *gc.C, args ...string) error {
-	_, err := cmdtesting.RunCommand(c, application.NewDefaultDeployCommand(), args...)
+	_, err := cmdtesting.RunCommand(c, application.NewDeployCommand(), args...)
 	return err
 }
 


### PR DESCRIPTION
The tests are doing a deep-equal comparison of the deploy
command, which assumes more than it should about what
the state of the embedded objects. Make the code check
the fields it cares about explicitly.

Also clean up things a little bit:
- NewDeployCommand is now the standard constructor, consistent
with the other commands.
- use runDeploy throughout, losing the hard-to-remember distinction
between runDeploy and runDeployCommand.

QA check that the deploy command works.