### PR TITLE
Add support for new GCE region asia-southeast1

### DIFF
--- a/cloud/fallback-public-cloud.yaml
+++ b/cloud/fallback-public-cloud.yaml
@@ -64,6 +64,8 @@ clouds:
         endpoint: https://www.googleapis.com
       asia-northeast1:
         endpoint: https://www.googleapis.com
+      asia-southeast1:
+        endpoint: https://www.googleapis.com
   azure:
     type: azure
     description: Microsoft Azure

--- a/cloud/fallback_public_cloud.go
+++ b/cloud/fallback_public_cloud.go
@@ -71,6 +71,8 @@ clouds:
         endpoint: https://www.googleapis.com
       asia-northeast1:
         endpoint: https://www.googleapis.com
+      asia-southeast1:
+        endpoint: https://www.googleapis.com
   azure:
     type: azure
     description: Microsoft Azure

--- a/cmd/juju/cloud/regions_test.go
+++ b/cmd/juju/cloud/regions_test.go
@@ -108,6 +108,7 @@ us-west1
 europe-west1
 asia-east1
 asia-northeast1
+asia-southeast1
 
 `[1:])
 }
@@ -128,6 +129,8 @@ europe-west1:
 asia-east1:
   endpoint: https://www.googleapis.com
 asia-northeast1:
+  endpoint: https://www.googleapis.com
+asia-southeast1:
   endpoint: https://www.googleapis.com
 `[1:])
 }


### PR DESCRIPTION
## Description of change

Add a new region asia-southeast1 to the google cloud.

## QA steps

juju bootstrap google/asia-southeast1

## Documentation changes

Docs which mention Google cloud regions need to have this new one added.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1686075
