### PR TITLE
Put the secure into secure shell

### DIFF
--- a/cloudconfig/cloudinit/cloudinit.go
+++ b/cloudconfig/cloudinit/cloudinit.go
@@ -325,6 +325,18 @@ func (cfg *cloudConfig) SetSSHAuthorizedKeys(rawKeys string) {
 	}
 }
 
+// SetSSHKeys is defined on the SSHKeysConfig interface.
+func (cfg *cloudConfig) SetSSHKeys(keys SSHKeys) {
+	if keys.RSA != nil {
+		cfg.SetAttr("ssh_keys", map[string]interface{}{
+			string(RSAPrivate): keys.RSA.Private,
+			string(RSAPublic):  keys.RSA.Public,
+		})
+	} else {
+		cfg.UnsetAttr("ssh_keys")
+	}
+}
+
 // SetDisableRoot is defined on the RootUserConfig interface.
 func (cfg *cloudConfig) SetDisableRoot(disable bool) {
 	cfg.SetAttr("disable_root", disable)

--- a/cloudconfig/cloudinit/cloudinit_test.go
+++ b/cloudconfig/cloudinit/cloudinit_test.go
@@ -366,6 +366,32 @@ var ctests = []struct {
 	func(cfg cloudinit.CloudConfig) {
 		cfg.ManageEtcHosts(true)
 	},
+}, {
+	"SetSSHKeys",
+	map[string]interface{}{"ssh_keys": map[string]interface{}{
+		"rsa_private": "private",
+		"rsa_public":  "public",
+	}},
+	func(cfg cloudinit.CloudConfig) {
+		cfg.SetSSHKeys(cloudinit.SSHKeys{
+			RSA: &cloudinit.SSHKey{
+				Private: "private",
+				Public:  "public",
+			},
+		})
+	},
+}, {
+	"SetSSHKeys unsets keys",
+	map[string]interface{}{},
+	func(cfg cloudinit.CloudConfig) {
+		cfg.SetSSHKeys(cloudinit.SSHKeys{
+			RSA: &cloudinit.SSHKey{
+				Private: "private",
+				Public:  "public",
+			},
+		})
+		cfg.SetSSHKeys(cloudinit.SSHKeys{})
+	},
 }}
 
 func (S) TestOutput(c *gc.C) {

--- a/cloudconfig/cloudinit/interface.go
+++ b/cloudconfig/cloudinit/interface.go
@@ -49,6 +49,7 @@ type CloudConfig interface {
 	DeviceMountConfig
 	OutputConfig
 	SSHAuthorizedKeysConfig
+	SSHKeysConfig
 	RootUserConfig
 	WrittenFilesConfig
 	RenderConfig
@@ -271,6 +272,12 @@ type SSHAuthorizedKeysConfig interface {
 	SetSSHAuthorizedKeys(string)
 }
 
+// SSHKeysConfig is the interface for setting ssh host keys.
+type SSHKeysConfig interface {
+	// SetSSHKeys sets the SSH host keys for the machine.
+	SetSSHKeys(SSHKeys)
+}
+
 // RootUserConfig is the interface for all root user-related settings.
 type RootUserConfig interface {
 	// SetDisableRoot sets whether ssh login to the root account of the new server
@@ -430,6 +437,20 @@ func New(ser string) (CloudConfig, error) {
 	default:
 		return nil, errors.NotFoundf("cloudconfig for series %q", ser)
 	}
+}
+
+// SSHKeys contains SSH host keys to configure on a machine.
+type SSHKeys struct {
+	RSA *SSHKey
+}
+
+// SSHKey is an SSH key pair.
+type SSHKey struct {
+	// Private is the SSH private key.
+	Private string
+
+	// Public is the SSH public key.
+	Public string
 }
 
 // SSHKeyType is the type of the four used key types passed to cloudinit

--- a/cloudconfig/instancecfg/instancecfg.go
+++ b/cloudconfig/instancecfg/instancecfg.go
@@ -184,11 +184,39 @@ type BootstrapConfig struct {
 	// Timeout is the amount of time to wait for bootstrap to complete.
 	Timeout time.Duration
 
+	// InitialSSHHostKeys contains the initial SSH host keys to configure
+	// on the bootstrap machine, indexed by algorithm. These will only be
+	// valid for the initial SSH connection. The first thing we do upon
+	// making the initial SSH connection is to replace each of these host
+	// keys, to avoid the host keys being extracted from the metadata
+	// service by a bad actor post-bootstrap.
+	//
+	// Any existing host keys on the machine with algorithms not specified
+	// in the map will be left alone. This is important so that we do not
+	// trample on the host keys of manually provisioned machines.
+	InitialSSHHostKeys SSHHostKeys
+
 	// StateServingInfo holds the information for serving the state.
 	// This is only specified for bootstrap; controllers started
 	// subsequently will acquire their serving info from another
 	// server.
 	StateServingInfo params.StateServingInfo
+}
+
+// SSHHostKeys contains the SSH host keys to configure for a bootstrap host.
+type SSHHostKeys struct {
+	// RSA, if non-nil, contains the RSA key to configure as the initial
+	// SSH host key.
+	RSA *SSHKeyPair
+}
+
+// SSHKeyPair is an SSH host key pair.
+type SSHKeyPair struct {
+	// Private contains the private key, PEM-encoded.
+	Private string
+
+	// Public contains the public key in authorized_keys format.
+	Public string
 }
 
 // StateInitializationParams contains parameters for initializing the

--- a/cloudconfig/sshinit/configure.go
+++ b/cloudconfig/sshinit/configure.go
@@ -27,6 +27,9 @@ type ConfigureParams struct {
 	// If Client is nil, ssh.DefaultClient will be used.
 	Client ssh.Client
 
+	// SSHOptions contains options for running the SSH command.
+	SSHOptions *ssh.Options
+
 	// Config is the cloudinit config to carry out.
 	Config cloudinit.CloudConfig
 
@@ -52,12 +55,17 @@ cat > $tmpfile
 /bin/bash $tmpfile
 `))
 
+	client := params.Client
+	if client == nil {
+		client = ssh.DefaultClient
+	}
+
 	// bash will read a byte at a time when consuming commands
 	// from stdin. We avoid sending the entire script -- which
 	// will be very large when uploading tools -- directly to
 	// bash for this reason. Instead, run cat which will write
 	// the script to disk, and then execute it from there.
-	cmd := ssh.Command(params.Host, []string{
+	cmd := client.Command(params.Host, []string{
 		"sudo", "/bin/bash", "-c",
 		// The outer bash interprets the $(...), and executes
 		// the decoded script in the nested bash. This avoids
@@ -67,7 +75,7 @@ cat > $tmpfile
 			`/bin/bash -c "$(echo %s | base64 -d)"`,
 			utils.ShQuote(encoded),
 		),
-	}, nil)
+	}, params.SSHOptions)
 
 	cmd.Stdin = strings.NewReader(script)
 	cmd.Stderr = params.ProgressWriter

--- a/cmd/juju/commands/ssh_common.go
+++ b/cmd/juju/commands/ssh_common.go
@@ -172,7 +172,7 @@ func (c *SSHCommon) getSSHOptions(enablePty bool, targets ...*resolvedTarget) (*
 
 	if c.noHostKeyChecks {
 		options.SetStrictHostKeyChecking(ssh.StrictHostChecksNo)
-		options.SetKnownHostsFile("/dev/null")
+		options.SetKnownHostsFile(os.DevNull)
 	} else {
 		knownHostsPath, err := c.generateKnownHosts(targets)
 		if err != nil {
@@ -189,10 +189,6 @@ func (c *SSHCommon) getSSHOptions(enablePty bool, targets ...*resolvedTarget) (*
 			// strict host key checking.
 			options.SetStrictHostKeyChecking(ssh.StrictHostChecksYes)
 			options.SetKnownHostsFile(knownHostsPath)
-		} else {
-			// If the user's personal known_hosts is used, also use
-			// the user's personal StrictHostKeyChecking preferences.
-			options.SetStrictHostKeyChecking(ssh.StrictHostChecksUnset)
 		}
 	}
 

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -48,7 +48,7 @@ github.com/juju/terms-client	git	9b925afd677234e4146dde3cb1a11e187cbed64e	2016-0
 github.com/juju/testing	git	06d21ddace802a83d08c82f513e30d84010ce31f	2017-05-01T02:35:42Z
 github.com/juju/txn	git	5c6f1c49ecbd4a916ed7b5a8f81ee67203e86043	2017-04-21T05:33:50Z
 github.com/juju/usso	git	68a59c96c178fbbad65926e7f93db50a2cd14f33	2016-04-01T10:44:24Z
-github.com/juju/utils	git	51660d020f8c823ce1d0b7904c26e6b907163050	2017-04-21T12:10:45Z
+github.com/juju/utils	git	6622634c402775ec773bb05427bccf976e6917e7	2017-04-27T05:01:38Z
 github.com/juju/version	git	1f41e27e54f21acccf9b2dddae063a782a8a7ceb	2016-10-31T05:19:06Z
 github.com/juju/webbrowser	git	54b8c57083b4afb7dc75da7f13e2967b2606a507	2016-03-09T14:36:29Z
 github.com/juju/xml	git	eb759a627588d35166bc505fceb51b88500e291e	2015-04-13T13:11:21Z
@@ -78,7 +78,7 @@ github.com/prometheus/common	git	dd586c1c5abb0be59e60f942c22af711a2008cb4	2016-0
 github.com/prometheus/procfs	git	abf152e5f3e97f2fafac028d2cc06c1feb87ffa5	2016-04-11T19:08:41Z
 github.com/rogpeppe/fastuuid	git	6724a57986aff9bff1a1770e9347036def7c89f6	2015-01-06T09:32:20Z
 github.com/vmware/govmomi	git	c0c7ce63df7edd78e713257b924c89d9a2dac119	2016-06-30T15:37:42Z
-golang.org/x/crypto	git	8e06e8ddd9629eb88639aba897641bff8031f1d3	2016-09-22T17:06:29Z
+golang.org/x/crypto	git	96846453c37f0876340a66a47f3f75b1f3a6cd2d	2017-04-21T04:31:20Z
 golang.org/x/net	git	ea47fc708ee3e20177f3ca3716217c4ab75942cb	2015-08-29T23:03:18Z
 golang.org/x/oauth2	git	11c60b6f71a6ad48ed6f93c65fa4c6f9b1b5b46a	2015-03-25T02:00:22Z
 golang.org/x/sys	git	7a6e5648d140666db5d920909e082ca00a87ba2c	2017-02-01T05:12:45Z

--- a/juju/home.go
+++ b/juju/home.go
@@ -4,6 +4,8 @@
 package juju
 
 import (
+	"path/filepath"
+
 	"github.com/juju/errors"
 	"github.com/juju/utils/ssh"
 	"gopkg.in/juju/charmrepo.v2-unstable"
@@ -20,9 +22,12 @@ func InitJujuXDGDataHome() error {
 		return errors.New("cannot determine juju data home, required environment variables are not set")
 	}
 	charmrepo.CacheDir = osenv.JujuXDGDataHomePath("charmcache")
-	if err := ssh.LoadClientKeys(osenv.JujuXDGDataHomePath("ssh")); err != nil {
+
+	sshDir := osenv.JujuXDGDataHomePath("ssh")
+	if err := ssh.LoadClientKeys(sshDir); err != nil {
 		return errors.Annotate(err, "cannot load ssh client keys")
 	}
+	ssh.SetGoCryptoKnownHostsFile(filepath.Join(sshDir, "gocrypto_known_hosts"))
 
 	return nil
 }

--- a/provider/common/bootstrap.go
+++ b/provider/common/bootstrap.go
@@ -4,8 +4,10 @@
 package common
 
 import (
+	"bufio"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"os"
 	"path"
 	"strings"
@@ -19,6 +21,7 @@ import (
 	"github.com/juju/utils/series"
 	"github.com/juju/utils/shell"
 	"github.com/juju/utils/ssh"
+	cryptossh "golang.org/x/crypto/ssh"
 
 	"github.com/juju/juju/agent"
 	"github.com/juju/juju/cloudconfig"
@@ -133,6 +136,14 @@ func BootstrapInstance(ctx environs.BootstrapContext, env environs.Environ, args
 	}
 	maybeSetBridge(instanceConfig)
 
+	// We're creating a new instance; inject host keys so that we can then
+	// make an SSH connection with known keys.
+	initialSSHHostKeys, err := generateSSHHostKeys()
+	if err != nil {
+		return nil, "", nil, errors.Annotate(err, "generating SSH host keys")
+	}
+	instanceConfig.Bootstrap.InitialSSHHostKeys = initialSSHHostKeys
+
 	cloudRegion := args.CloudName
 	if args.CloudRegion != "" {
 		cloudRegion += "/" + args.CloudRegion
@@ -185,6 +196,7 @@ func BootstrapInstance(ctx environs.BootstrapContext, env environs.Environ, args
 	finalize := func(ctx environs.BootstrapContext, icfg *instancecfg.InstanceConfig, opts environs.BootstrapDialOpts) error {
 		icfg.Bootstrap.BootstrapMachineInstanceId = result.Instance.Id()
 		icfg.Bootstrap.BootstrapMachineHardwareCharacteristics = result.Hardware
+		icfg.Bootstrap.InitialSSHHostKeys = initialSSHHostKeys
 		envConfig := env.Config()
 		if result.Config != nil {
 			updated, err := envConfig.Apply(result.Config.UnknownAttrs())
@@ -242,6 +254,8 @@ var FinishBootstrap = func(
 	interrupted := make(chan os.Signal, 1)
 	ctx.InterruptNotify(interrupted)
 	defer ctx.StopInterruptNotify(interrupted)
+
+	hostSSHOptions := bootstrapSSHOptionsFunc(instanceConfig)
 	addr, err := WaitSSH(
 		ctx.GetStderr(),
 		interrupted,
@@ -249,11 +263,19 @@ var FinishBootstrap = func(
 		GetCheckNonceCommand(instanceConfig),
 		&RefreshableInstance{inst, env},
 		opts,
+		hostSSHOptions,
 	)
 	if err != nil {
 		return err
 	}
-	return ConfigureMachine(ctx, client, addr, instanceConfig)
+
+	sshOptions, cleanup, err := hostSSHOptions(addr)
+	if err != nil {
+		return err
+	}
+	defer cleanup()
+
+	return ConfigureMachine(ctx, client, addr, instanceConfig, sshOptions)
 }
 
 func GetCheckNonceCommand(instanceConfig *instancecfg.InstanceConfig) string {
@@ -278,7 +300,13 @@ func GetCheckNonceCommand(instanceConfig *instancecfg.InstanceConfig) string {
 	return checkNonceCommand
 }
 
-func ConfigureMachine(ctx environs.BootstrapContext, client ssh.Client, host string, instanceConfig *instancecfg.InstanceConfig) error {
+func ConfigureMachine(
+	ctx environs.BootstrapContext,
+	client ssh.Client,
+	host string,
+	instanceConfig *instancecfg.InstanceConfig,
+	sshOptions *ssh.Options,
+) error {
 	// Bootstrap is synchronous, and will spawn a subprocess
 	// to complete the procedure. If the user hits Ctrl-C,
 	// SIGINT is sent to the foreground process attached to
@@ -309,10 +337,79 @@ func ConfigureMachine(ctx environs.BootstrapContext, client ssh.Client, host str
 	return sshinit.RunConfigureScript(script, sshinit.ConfigureParams{
 		Host:           "ubuntu@" + host,
 		Client:         client,
+		SSHOptions:     sshOptions,
 		Config:         cloudcfg,
 		ProgressWriter: ctx.GetStderr(),
 		Series:         instanceConfig.Series,
 	})
+}
+
+// HostSSHOptionsFunc is a function that, given a hostname, returns
+// an ssh.Options and a cleanup function, or an error.
+type HostSSHOptionsFunc func(host string) (*ssh.Options, func(), error)
+
+// DefaultHostSSHOptions returns a a nil *ssh.Options, which means
+// to use the defaults; and a no-op cleanup function.
+func DefaultHostSSHOptions(host string) (*ssh.Options, func(), error) {
+	return nil, func() {}, nil
+}
+
+// bootstrapSSHOptionsFunc that takes a bootstrap machine's InstanceConfig
+// and returns a HostSSHOptionsFunc.
+func bootstrapSSHOptionsFunc(instanceConfig *instancecfg.InstanceConfig) HostSSHOptionsFunc {
+	return func(host string) (*ssh.Options, func(), error) {
+		return hostBootstrapSSHOptions(host, instanceConfig)
+	}
+}
+
+func hostBootstrapSSHOptions(
+	host string,
+	instanceConfig *instancecfg.InstanceConfig,
+) (_ *ssh.Options, cleanup func(), err error) {
+	cleanup = func() {}
+	defer func() {
+		if err != nil {
+			cleanup()
+		}
+	}()
+
+	options := &ssh.Options{}
+	options.SetStrictHostKeyChecking(ssh.StrictHostChecksYes)
+
+	// If any host keys are being injected, we'll set up a
+	// known_hosts file with their contents, and accept only
+	// them.
+	hostKeys := instanceConfig.Bootstrap.InitialSSHHostKeys
+	var algos []string
+	var pubKeys []string
+	if hostKeys.RSA != nil {
+		algos = append(algos, cryptossh.KeyAlgoRSA)
+		pubKeys = append(pubKeys, hostKeys.RSA.Public)
+	}
+	if len(pubKeys) == 0 {
+		return options, cleanup, nil
+	}
+
+	// Create a temporary known_hosts file.
+	f, err := ioutil.TempFile("", "juju-known-hosts")
+	if err != nil {
+		return nil, cleanup, errors.Trace(err)
+	}
+	cleanup = func() {
+		f.Close()
+		os.RemoveAll(f.Name())
+	}
+	w := bufio.NewWriter(f)
+	for _, pubKey := range pubKeys {
+		fmt.Fprintln(w, host, strings.TrimSpace(pubKey))
+	}
+	if err := w.Flush(); err != nil {
+		return nil, cleanup, errors.Annotate(err, "writing known_hosts")
+	}
+
+	options.SetHostKeyAlgorithms(algos...)
+	options.SetKnownHostsFile(f.Name())
+	return options, cleanup, nil
 }
 
 // InstanceRefresher is the subet of the Instance interface required
@@ -347,9 +444,10 @@ func (i *RefreshableInstance) Refresh() error {
 }
 
 type hostChecker struct {
-	addr   network.Address
-	client ssh.Client
-	wg     *sync.WaitGroup
+	addr           network.Address
+	client         ssh.Client
+	hostSSHOptions HostSSHOptionsFunc
+	wg             *sync.WaitGroup
 
 	// checkDelay is the amount of time to wait between retries.
 	checkDelay time.Duration
@@ -372,15 +470,22 @@ func (*hostChecker) Close() error {
 
 func (hc *hostChecker) loop(dying <-chan struct{}) (io.Closer, error) {
 	defer hc.wg.Done()
+
+	address := hc.addr.Value
+	sshOptions, cleanup, err := hc.hostSSHOptions(address)
+	if err != nil {
+		return nil, err
+	}
+	defer cleanup()
+
 	// The value of connectSSH is taken outside the goroutine that may outlive
 	// hostChecker.loop, or we evoke the wrath of the race detector.
 	connectSSH := connectSSH
-	done := make(chan error, 1)
 	var lastErr error
+	done := make(chan error, 1)
 	for {
-		address := hc.addr.Value
 		go func() {
-			done <- connectSSH(hc.client, address, hc.checkHostScript)
+			done <- connectSSH(hc.client, address, hc.checkHostScript, sshOptions)
 		}()
 		select {
 		case <-dying:
@@ -402,9 +507,10 @@ func (hc *hostChecker) loop(dying <-chan struct{}) (io.Closer, error) {
 
 type parallelHostChecker struct {
 	*parallel.Try
-	client ssh.Client
-	stderr io.Writer
-	wg     sync.WaitGroup
+	client         ssh.Client
+	hostSSHOptions HostSSHOptionsFunc
+	stderr         io.Writer
+	wg             sync.WaitGroup
 
 	// active is a map of adresses to channels for addresses actively
 	// being tested. The goroutine testing the address will continue
@@ -430,6 +536,7 @@ func (p *parallelHostChecker) UpdateAddresses(addrs []network.Address) {
 		hc := &hostChecker{
 			addr:            addr,
 			client:          p.client,
+			hostSSHOptions:  p.hostSSHOptions,
 			checkDelay:      p.checkDelay,
 			checkHostScript: p.checkHostScript,
 			closed:          closed,
@@ -457,8 +564,8 @@ func (p *parallelHostChecker) Close() error {
 
 // connectSSH is called to connect to the specified host and
 // execute the "checkHostScript" bash script on it.
-var connectSSH = func(client ssh.Client, host, checkHostScript string) error {
-	cmd := client.Command("ubuntu@"+host, []string{"/bin/bash"}, nil)
+var connectSSH = func(client ssh.Client, host, checkHostScript string, options *ssh.Options) error {
+	cmd := client.Command("ubuntu@"+host, []string{"/bin/bash"}, options)
 	cmd.Stdin = strings.NewReader(checkHostScript)
 	output, err := cmd.CombinedOutput()
 	if err != nil && len(output) > 0 {
@@ -483,6 +590,7 @@ func WaitSSH(
 	checkHostScript string,
 	inst InstanceRefresher,
 	opts environs.BootstrapDialOpts,
+	hostSSHOptions HostSSHOptionsFunc,
 ) (addr string, err error) {
 	globalTimeout := time.After(opts.Timeout)
 	pollAddresses := time.NewTimer(0)
@@ -497,6 +605,7 @@ func WaitSSH(
 		active:          make(map[network.Address]chan struct{}),
 		checkDelay:      opts.RetryDelay,
 		checkHostScript: checkHostScript,
+		hostSSHOptions:  hostSSHOptions,
 	}
 	defer checker.wg.Wait()
 	defer checker.Kill()
@@ -546,4 +655,19 @@ func WaitSSH(
 			return result.(*hostChecker).addr.Value, nil
 		}
 	}
+}
+
+func generateSSHHostKeys() (instancecfg.SSHHostKeys, error) {
+	// Generate a single ssh-rsa key. We'll configure the SSH client
+	// such that that is the only host key type we'll accept.
+	var keys instancecfg.SSHHostKeys
+	private, public, err := ssh.GenerateKey("juju-bootstrap")
+	if err != nil {
+		return keys, errors.Annotate(err, "generating SSH key")
+	}
+	keys.RSA = &instancecfg.SSHKeyPair{
+		Private: private,
+		Public:  public,
+	}
+	return keys, nil
 }

--- a/provider/common/mock_test.go
+++ b/provider/common/mock_test.go
@@ -20,6 +20,7 @@ import (
 )
 
 type allInstancesFunc func() ([]instance.Instance, error)
+type instancesFunc func([]instance.Id) ([]instance.Instance, error)
 type startInstanceFunc func(string, constraints.Value, []string, tools.List, *instancecfg.InstanceConfig) (instance.Instance, *instance.HardwareCharacteristics, []network.InterfaceInfo, error)
 type stopInstancesFunc func([]instance.Id) error
 type getToolsSourcesFunc func() ([]simplestreams.DataSource, error)
@@ -29,6 +30,7 @@ type setConfigFunc func(*config.Config) error
 type mockEnviron struct {
 	storage          storage.Storage
 	allInstances     allInstancesFunc
+	instances        instancesFunc
 	startInstance    startInstanceFunc
 	stopInstances    stopInstancesFunc
 	getToolsSources  getToolsSourcesFunc
@@ -44,6 +46,10 @@ func (env *mockEnviron) Storage() storage.Storage {
 
 func (env *mockEnviron) AllInstances() ([]instance.Instance, error) {
 	return env.allInstances()
+}
+
+func (env *mockEnviron) Instances(ids []instance.Id) ([]instance.Instance, error) {
+	return env.instances(ids)
 }
 
 func (env *mockEnviron) StartInstance(args environs.StartInstanceParams) (*environs.StartInstanceResult, error) {
@@ -118,11 +124,16 @@ type mockInstance struct {
 	addressesErr      error
 	dnsName           string
 	dnsNameErr        error
+	status            instance.InstanceStatus
 	instance.Instance // stub out other methods with panics
 }
 
 func (inst *mockInstance) Id() instance.Id {
 	return instance.Id(inst.id)
+}
+
+func (inst *mockInstance) Status() instance.InstanceStatus {
+	return inst.status
 }
 
 func (inst *mockInstance) Addresses() ([]network.Address, error) {

--- a/provider/ec2/local_test.go
+++ b/provider/ec2/local_test.go
@@ -374,29 +374,21 @@ func (t *localServerSuite) TestSystemdBootstrapInstanceUserDataAndState(c *gc.C)
 	c.Assert(addresses, gc.Not(gc.HasLen), 0)
 	userData, err := utils.Gunzip(inst.UserData)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(string(userData), jc.YAMLEquals, map[interface{}]interface{}{
-		"output": map[interface{}]interface{}{
-			"all": "| tee -a /var/log/cloud-init-output.log",
-		},
-		"users": []interface{}{
-			map[interface{}]interface{}{
-				"name":        "ubuntu",
-				"lock_passwd": true,
-				"groups": []interface{}{"adm", "audio",
-					"cdrom", "dialout", "dip", "floppy",
-					"netdev", "plugdev", "sudo", "video"},
-				"shell":               "/bin/bash",
-				"sudo":                []interface{}{"ALL=(ALL) NOPASSWD:ALL"},
-				"ssh-authorized-keys": splitAuthKeys(env.Config().AuthorizedKeys()),
-			},
-		},
-		"runcmd": []interface{}{
-			"set -xe",
-			"install -D -m 644 /dev/null '/etc/systemd/system/juju-clean-shutdown.service'",
-			"printf '%s\\n' '\n[Unit]\nDescription=Stop all network interfaces on shutdown\nDefaultDependencies=false\nAfter=final.target\n\n[Service]\nType=oneshot\nExecStart=/sbin/ifdown -a -v --force\nStandardOutput=tty\nStandardError=tty\n\n[Install]\nWantedBy=final.target\n' > '/etc/systemd/system/juju-clean-shutdown.service'", "/bin/systemctl enable '/etc/systemd/system/juju-clean-shutdown.service'",
-			"install -D -m 644 /dev/null '/var/lib/juju/nonce.txt'",
-			"printf '%s\\n' 'user-admin:bootstrap' > '/var/lib/juju/nonce.txt'",
-		},
+
+	var userDataMap map[string]interface{}
+	err = goyaml.Unmarshal(userData, &userDataMap)
+	c.Assert(err, jc.ErrorIsNil)
+	var keys []string
+	for key := range userDataMap {
+		keys = append(keys, key)
+	}
+	c.Assert(keys, jc.SameContents, []string{"output", "users", "runcmd", "ssh_keys"})
+	c.Assert(userDataMap["runcmd"], jc.DeepEquals, []interface{}{
+		"set -xe",
+		"install -D -m 644 /dev/null '/etc/systemd/system/juju-clean-shutdown.service'",
+		"printf '%s\\n' '\n[Unit]\nDescription=Stop all network interfaces on shutdown\nDefaultDependencies=false\nAfter=final.target\n\n[Service]\nType=oneshot\nExecStart=/sbin/ifdown -a -v --force\nStandardOutput=tty\nStandardError=tty\n\n[Install]\nWantedBy=final.target\n' > '/etc/systemd/system/juju-clean-shutdown.service'", "/bin/systemctl enable '/etc/systemd/system/juju-clean-shutdown.service'",
+		"install -D -m 644 /dev/null '/var/lib/juju/nonce.txt'",
+		"printf '%s\\n' 'user-admin:bootstrap' > '/var/lib/juju/nonce.txt'",
 	})
 
 	// check that a new instance will be started with a machine agent
@@ -409,7 +401,7 @@ func (t *localServerSuite) TestSystemdBootstrapInstanceUserDataAndState(c *gc.C)
 	userData, err = utils.Gunzip(inst.UserData)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Logf("second instance: UserData: %q", userData)
-	var userDataMap map[interface{}]interface{}
+	userDataMap = nil
 	err = goyaml.Unmarshal(userData, &userDataMap)
 	c.Assert(err, jc.ErrorIsNil)
 	CheckPackage(c, userDataMap, "curl", true)
@@ -459,29 +451,21 @@ func (t *localServerSuite) TestUpstartBootstrapInstanceUserDataAndState(c *gc.C)
 	c.Assert(addresses, gc.Not(gc.HasLen), 0)
 	userData, err := utils.Gunzip(inst.UserData)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(string(userData), jc.YAMLEquals, map[interface{}]interface{}{
-		"output": map[interface{}]interface{}{
-			"all": "| tee -a /var/log/cloud-init-output.log",
-		},
-		"users": []interface{}{
-			map[interface{}]interface{}{
-				"name":        "ubuntu",
-				"lock_passwd": true,
-				"groups": []interface{}{"adm", "audio",
-					"cdrom", "dialout", "dip", "floppy",
-					"netdev", "plugdev", "sudo", "video"},
-				"shell":               "/bin/bash",
-				"sudo":                []interface{}{"ALL=(ALL) NOPASSWD:ALL"},
-				"ssh-authorized-keys": splitAuthKeys(env.Config().AuthorizedKeys()),
-			},
-		},
-		"runcmd": []interface{}{
-			"set -xe",
-			"install -D -m 644 /dev/null '/etc/init/juju-clean-shutdown.conf'",
-			"printf '%s\\n' '\nauthor \"Juju Team <juju@lists.ubuntu.com>\"\ndescription \"Stop all network interfaces on shutdown\"\nstart on runlevel [016]\ntask\nconsole output\n\nexec /sbin/ifdown -a -v --force\n' > '/etc/init/juju-clean-shutdown.conf'",
-			"install -D -m 644 /dev/null '/var/lib/juju/nonce.txt'",
-			"printf '%s\\n' 'user-admin:bootstrap' > '/var/lib/juju/nonce.txt'",
-		},
+
+	var userDataMap map[string]interface{}
+	err = goyaml.Unmarshal(userData, &userDataMap)
+	c.Assert(err, jc.ErrorIsNil)
+	var keys []string
+	for key := range userDataMap {
+		keys = append(keys, key)
+	}
+	c.Assert(keys, jc.SameContents, []string{"output", "users", "runcmd", "ssh_keys"})
+	c.Assert(userDataMap["runcmd"], jc.DeepEquals, []interface{}{
+		"set -xe",
+		"install -D -m 644 /dev/null '/etc/init/juju-clean-shutdown.conf'",
+		"printf '%s\\n' '\nauthor \"Juju Team <juju@lists.ubuntu.com>\"\ndescription \"Stop all network interfaces on shutdown\"\nstart on runlevel [016]\ntask\nconsole output\n\nexec /sbin/ifdown -a -v --force\n' > '/etc/init/juju-clean-shutdown.conf'",
+		"install -D -m 644 /dev/null '/var/lib/juju/nonce.txt'",
+		"printf '%s\\n' 'user-admin:bootstrap' > '/var/lib/juju/nonce.txt'",
 	})
 
 	// check that a new instance will be started with a machine agent
@@ -494,7 +478,7 @@ func (t *localServerSuite) TestUpstartBootstrapInstanceUserDataAndState(c *gc.C)
 	userData, err = utils.Gunzip(inst.UserData)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Logf("second instance: UserData: %q", userData)
-	var userDataMap map[interface{}]interface{}
+	userDataMap = nil
 	err = goyaml.Unmarshal(userData, &userDataMap)
 	c.Assert(err, jc.ErrorIsNil)
 	CheckPackage(c, userDataMap, "curl", true)
@@ -1764,7 +1748,7 @@ func patchEC2ForTesting(c *gc.C, region aws.Region) func() {
 // by the cloudinit data matches the given regexp pattern, otherwise it
 // checks that no script matches.  It's exported so it can be used by tests
 // defined in ec2_test.
-func CheckScripts(c *gc.C, userDataMap map[interface{}]interface{}, pattern string, match bool) {
+func CheckScripts(c *gc.C, userDataMap map[string]interface{}, pattern string, match bool) {
 	scripts0 := userDataMap["runcmd"]
 	if scripts0 == nil {
 		c.Errorf("cloudinit has no entry for runcmd")
@@ -1790,7 +1774,7 @@ func CheckScripts(c *gc.C, userDataMap map[interface{}]interface{}, pattern stri
 // CheckPackage checks that the cloudinit will or won't install the given
 // package, depending on the value of match.  It's exported so it can be
 // used by tests defined outside the ec2 package.
-func CheckPackage(c *gc.C, userDataMap map[interface{}]interface{}, pkg string, match bool) {
+func CheckPackage(c *gc.C, userDataMap map[string]interface{}, pkg string, match bool) {
 	pkgs0 := userDataMap["packages"]
 	if pkgs0 == nil {
 		if match {

--- a/provider/manual/environ.go
+++ b/provider/manual/environ.go
@@ -119,7 +119,7 @@ func (e *manualEnviron) Bootstrap(ctx environs.BootstrapContext, args environs.B
 		if err := instancecfg.FinishInstanceConfig(icfg, e.Config()); err != nil {
 			return err
 		}
-		return common.ConfigureMachine(ctx, ssh.DefaultClient, e.host, icfg)
+		return common.ConfigureMachine(ctx, ssh.DefaultClient, e.host, icfg, nil)
 	}
 
 	result := &environs.BootstrapResult{

--- a/provider/rackspace/environ.go
+++ b/provider/rackspace/environ.go
@@ -54,7 +54,15 @@ func (e environ) StartInstance(args environs.StartInstanceParams) (*environs.Sta
 			RetryDelay:     time.Second * 5,
 			AddressesDelay: time.Second * 20,
 		}
-		addr, err := waitSSH(ioutil.Discard, interrupted, ssh.DefaultClient, common.GetCheckNonceCommand(args.InstanceConfig), &common.RefreshableInstance{r.Instance, e}, timeout)
+		addr, err := waitSSH(
+			ioutil.Discard,
+			interrupted,
+			ssh.DefaultClient,
+			common.GetCheckNonceCommand(args.InstanceConfig),
+			&common.RefreshableInstance{r.Instance, e},
+			timeout,
+			common.DefaultHostSSHOptions,
+		)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}

--- a/provider/rackspace/environ_test.go
+++ b/provider/rackspace/environ_test.go
@@ -52,7 +52,15 @@ func (s *environSuite) TestBootstrap(c *gc.C) {
 
 func (s *environSuite) TestStartInstance(c *gc.C) {
 	configurator := &fakeConfigurator{}
-	s.PatchValue(rackspace.WaitSSH, func(stdErr io.Writer, interrupted <-chan os.Signal, client ssh.Client, checkHostScript string, inst common.InstanceRefresher, timeout environs.BootstrapDialOpts) (addr string, err error) {
+	s.PatchValue(rackspace.WaitSSH, func(
+		stdErr io.Writer,
+		interrupted <-chan os.Signal,
+		client ssh.Client,
+		checkHostScript string,
+		inst common.InstanceRefresher,
+		timeout environs.BootstrapDialOpts,
+		hostSSHOptions common.HostSSHOptionsFunc,
+	) (addr string, err error) {
 		addresses, err := inst.Addresses()
 		if err != nil {
 			return "", err

--- a/state/autocertcache.go
+++ b/state/autocertcache.go
@@ -4,9 +4,10 @@
 package state
 
 import (
+	"context"
+
 	"github.com/juju/errors"
 	"golang.org/x/crypto/acme/autocert"
-	"golang.org/x/net/context"
 	"gopkg.in/mgo.v2"
 
 	"github.com/juju/juju/mongo"


### PR DESCRIPTION
## Description of change

Up until now, Juju bootstrap has had an insecure
initial SSH connection. The client had no way of
knowing the server's host key, and so strict
host key checking was disabled.

This branch does two main things:
 - updates to the new juju/utils version which
   defaults strict host key checking to "ask"
   (unless overridden in OpenSSH client config)
   for both the golang.org/x/crypto and openssh
   implementations
 - generates and injects an SSH host key into
   the created server via cloud-init, then uses
   the public key to perform strict host key
   checking. The key is regenerated server-side
   as the first thing the initial SSH connection
   does, so that user code deployed to controllers
   cannot sniff the keys from metadata services.

## QA steps

1. juju bootstrap localhost
2. lxc launch ubuntu:xenial x
3. lxc file push ~/.ssh/id_rsa.pub x/home/ubuntu/.ssh/authorized_keys
4. juju add-machine ssh:<ip-of-x>
5. juju ssh -m controller 0 true
6. juju ssh 0 true

Repeat with "ssh" removed from $PATH. There should be no warnings about SSH host keys changing, nor warnings about host keys being added to known_hosts.

## Documentation changes

There is one change for users: on Windows, manual provisioning will now prompt the user to verify host SSH keys.

## Bug reference

Fixes https://bugs.launchpad.net/juju/+bug/1683099
Fixes https://bugs.launchpad.net/juju/+bug/1579593