### PR TITLE
Change oracle provider type to oracle-compute.

### DIFF
--- a/cloud/clouds.go
+++ b/cloud/clouds.go
@@ -305,19 +305,19 @@ func DefaultCloudDescription(cloudType string) string {
 }
 
 var defaultCloudDescription = map[string]string{
-	"aws":         "Amazon Web Services",
-	"aws-china":   "Amazon China",
-	"aws-gov":     "Amazon (USA Government)",
-	"google":      "Google Cloud Platform",
-	"azure":       "Microsoft Azure",
-	"azure-china": "Microsoft Azure China",
-	"rackspace":   "Rackspace Cloud",
-	"joyent":      "Joyent Cloud",
-	"cloudsigma":  "CloudSigma Cloud",
-	"lxd":         "LXD Container Hypervisor",
-	"maas":        "Metal As A Service",
-	"openstack":   "Openstack Cloud",
-	"oracle":      "Oracle Compute Cloud Service",
+	"aws":            "Amazon Web Services",
+	"aws-china":      "Amazon China",
+	"aws-gov":        "Amazon (USA Government)",
+	"google":         "Google Cloud Platform",
+	"azure":          "Microsoft Azure",
+	"azure-china":    "Microsoft Azure China",
+	"rackspace":      "Rackspace Cloud",
+	"joyent":         "Joyent Cloud",
+	"cloudsigma":     "CloudSigma Cloud",
+	"lxd":            "LXD Container Hypervisor",
+	"maas":           "Metal As A Service",
+	"openstack":      "Openstack Cloud",
+	"oracle-compute": "Oracle Compute Cloud Service",
 }
 
 // WritePublicCloudMetadata marshals to YAML and writes the cloud metadata

--- a/cloud/clouds_test.go
+++ b/cloud/clouds_test.go
@@ -21,7 +21,7 @@ type cloudSuite struct {
 var _ = gc.Suite(&cloudSuite{})
 
 var publicCloudNames = []string{
-	"aws", "aws-china", "aws-gov", "google", "azure", "azure-china", "rackspace", "joyent", "cloudsigma", "oracle",
+	"aws", "aws-china", "aws-gov", "google", "azure", "azure-china", "rackspace", "joyent", "cloudsigma", "oracle-compute",
 }
 
 func parsePublicClouds(c *gc.C) map[string]cloud.Cloud {

--- a/cloud/fallback-public-cloud.yaml
+++ b/cloud/fallback-public-cloud.yaml
@@ -228,8 +228,8 @@ clouds:
         endpoint: https://wdc.cloudsigma.com/api/2.0/
       zrh:
         endpoint: https://zrh.cloudsigma.com/api/2.0/
-  oracle:
-    type: oracle
+  oracle-compute:
+    type: oracle-compute
     description: Oracle Cloud
     auth-types: [ userpass ]
     regions:

--- a/cloud/fallback_public_cloud.go
+++ b/cloud/fallback_public_cloud.go
@@ -235,8 +235,8 @@ clouds:
         endpoint: https://wdc.cloudsigma.com/api/2.0/
       zrh:
         endpoint: https://zrh.cloudsigma.com/api/2.0/
-  oracle:
-    type: oracle
+  oracle-compute:
+    type: oracle-compute
     description: Oracle Cloud
     auth-types: [ userpass ]
     regions:

--- a/cmd/juju/cloud/add_test.go
+++ b/cmd/juju/cloud/add_test.go
@@ -249,7 +249,7 @@ func (*addSuite) TestInteractive(c *gc.C) {
 		"  maas\n"+
 		"  manual\n"+
 		"  openstack\n"+
-		"  oracle\n"+
+		"  oracle-compute\n"+
 		"  vsphere\n"+
 		"\n"+
 		"Select cloud type: \n",

--- a/cmd/juju/cloud/list_test.go
+++ b/cmd/juju/cloud/list_test.go
@@ -57,7 +57,7 @@ clouds:
 	// Just check a snippet of the output to make sure it looks ok.
 	// local clouds are last.
 	// homestack should abut localhost and hence come last in the output.
-	c.Assert(out, jc.Contains, `Hypervisorhomestack          1  london           openstack   Openstack Cloud`)
+	c.Assert(out, jc.Contains, `Hypervisorhomestack             1  london           openstack       Openstack Cloud`)
 }
 
 func (s *listSuite) TestListPublicAndPersonalSameName(c *gc.C) {

--- a/cmd/juju/commands/bootstrap_test.go
+++ b/cmd/juju/commands/bootstrap_test.go
@@ -1663,7 +1663,7 @@ azure-china
 cloudsigma                                   
 google                                       
 joyent                                       
-oracle                                       
+oracle-compute                               
 rackspace                                    
 localhost                                    
 dummy-cloud                     joe          home

--- a/provider/oracle/networking.go
+++ b/provider/oracle/networking.go
@@ -53,7 +53,7 @@ func (o *OracleEnviron) DeleteMachineVnicSet(machineId string) error {
 
 func (o *OracleEnviron) ensureVnicSet(machineId string, tags []string) (ociResponse.VnicSet, error) {
 	if access, err := o.SupportsSpaces(); err != nil || access == false {
-		logger.Warningf("spaces is not supported on this API endpoint. SupportsSpaces returned: %v; %s", access, err)
+		logger.Debugf("Spaces is not supported on this API endpoint.")
 		return ociResponse.VnicSet{}, nil
 	}
 

--- a/provider/oracle/provider.go
+++ b/provider/oracle/provider.go
@@ -16,10 +16,10 @@ import (
 	"github.com/juju/juju/environs/config"
 )
 
-var logger = loggo.GetLogger("juju.provider.oracle")
+var logger = loggo.GetLogger("juju.provider.oracle-compute")
 
 const (
-	providerType = "oracle"
+	providerType = "oracle-compute"
 )
 
 // environProvider type implements environs.EnvironProvider interface

--- a/provider/oracle/provider_test.go
+++ b/provider/oracle/provider_test.go
@@ -19,7 +19,7 @@ type environProviderSuite struct{}
 var _ = gc.Suite(&environProviderSuite{})
 
 func (e *environProviderSuite) NewProvider(c *gc.C) environs.EnvironProvider {
-	provider, err := environs.Provider("oracle")
+	provider, err := environs.Provider("oracle-compute")
 	c.Assert(err, gc.IsNil)
 	c.Assert(provider, gc.NotNil)
 	return provider
@@ -59,8 +59,8 @@ func (e *environProviderSuite) TestPrepareConfig(c *gc.C) {
 	)
 	_, err := provider.PrepareConfig(environs.PrepareConfigParams{
 		Cloud: environs.CloudSpec{
-			Type:       "oracle",
-			Name:       "oracle",
+			Type:       "oracle-compute",
+			Name:       "oracle-compute",
 			Credential: &credentials,
 		},
 		Config: testing.ModelConfig(c),
@@ -80,8 +80,8 @@ func (e *environProviderSuite) TestOpen(c *gc.C) {
 	)
 	_, err := provider.Open(environs.OpenParams{
 		Cloud: environs.CloudSpec{
-			Type:       "oracle",
-			Name:       "oracle",
+			Type:       "oracle-compute",
+			Name:       "oracle-compute",
 			Credential: &credentials,
 			Endpoint:   "https://127.0.0.1/",
 		},


### PR DESCRIPTION
Change warning to debug at bootstrap for spaces not supported with trial oracle accounts.

## Please provide the following details to expedite Pull Request review:

----

## Description of change

Changing name of provider type to prepare for possible oracle bare metal cloud type.

Change warning to debug at bootstrap for spaces not supported with trial oracle accounts.

## QA steps

juju clouds

juju bootstrap oracle-compute with trial account credentials, no warning should be seen.

## Documentation changes

N/A

## Bug reference

N/A