### PR TITLE
Fix CPU cores detection on non-x86 arches

### DIFF
--- a/environs/manual/sshprovisioner/init_test.go
+++ b/environs/manual/sshprovisioner/init_test.go
@@ -104,7 +104,18 @@ func (s *initialisationSuite) TestDetectHardwareCharacteristics(c *gc.C) {
 			"cpu cores: 1",
 		},
 		"arch=armhf cores=2 mem=4M",
+	}, {
+		"4 CPU sockets, each single-core, no hyper-threading, no physical id field",
+		[]string{
+			"edgy", "arm64", "MemTotal: 16384 kB",
+			"processor: 0",
+			"processor: 1",
+			"processor: 2",
+			"processor: 3",
+		},
+		"arch=arm64 cores=4 mem=16M",
 	}}
+
 	for i, test := range tests {
 		c.Logf("test %d: %s", i, test.summary)
 		scriptResponse := strings.Join(test.scriptResponse, "\n")


### PR DESCRIPTION
## Description of change
Detection of number of cores on non-x86 arches was broken and always gave '1'

## QA steps
Run unit tests for environs/manual/sshprovisioner; check that number of cores is detected correctly on e.g. amd64 and arm64 

## Documentation changes
None.

## Bug reference
https://bugs.launchpad.net/juju/+bug/1664434