### PR TITLE
Fix Go 1.8 test failures (2.1 branch)

### DIFF
--- a/api/http_test.go
+++ b/api/http_test.go
@@ -71,7 +71,7 @@ var httpClientTests = []struct {
 			Message: make(map[string]int),
 		})
 	},
-	expectError: `GET http://.*/: incompatible error response: json: cannot unmarshal object into Go value of type string`,
+	expectError: `GET http://.*/: incompatible error response: json: cannot unmarshal object into Go .+`,
 }, {
 	about: "bad charms error response",
 	handler: func(w http.ResponseWriter, req *http.Request) {
@@ -84,7 +84,7 @@ var httpClientTests = []struct {
 			CharmURL: make(map[string]int),
 		})
 	},
-	expectError: `GET http://.*/: incompatible error response: json: cannot unmarshal object into Go value of type string`,
+	expectError: `GET http://.*/: incompatible error response: json: cannot unmarshal object into Go .+`,
 }, {
 	about: "no message in ErrorResponse",
 	handler: func(w http.ResponseWriter, req *http.Request) {

--- a/apiserver/metricsender/sender_test.go
+++ b/apiserver/metricsender/sender_test.go
@@ -153,7 +153,6 @@ func (s *SenderSuite) TestErrorCodes(c *gc.C) {
 	}{
 		{http.StatusBadRequest, "failed to send metrics http 400"},
 		{http.StatusServiceUnavailable, "failed to send metrics http 503"},
-		{http.StatusMovedPermanently, "failed to send metrics http 301"},
 	}
 
 	for _, test := range tests {

--- a/environs/tools/build_test.go
+++ b/environs/tools/build_test.go
@@ -4,9 +4,12 @@
 package tools_test
 
 import (
+	"archive/tar"
 	"bytes"
+	"compress/gzip"
 	"crypto/sha256"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -109,14 +112,17 @@ func (b *buildSuite) TestFindExecutable(c *gc.C) {
 	}
 }
 
-const emptyArchive = "\x1f\x8b\b\x00\x00\tn\x88\x00\xffb\x18\x05\xa3`\x14\x8cX\x00\b\x00\x00\xff\xff.\xaf\xb5\xef\x00\x04\x00\x00"
-
 func (b *buildSuite) TestEmptyArchive(c *gc.C) {
 	var buf bytes.Buffer
 	dir := c.MkDir()
 	err := tools.Archive(&buf, dir)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(buf.String(), gc.Equals, emptyArchive)
+
+	gzr, err := gzip.NewReader(&buf)
+	c.Assert(err, jc.ErrorIsNil)
+	r := tar.NewReader(gzr)
+	_, err = r.Next()
+	c.Assert(err, gc.Equals, io.EOF)
 }
 
 func (b *buildSuite) TestArchiveAndSHA256(c *gc.C) {
@@ -124,11 +130,16 @@ func (b *buildSuite) TestArchiveAndSHA256(c *gc.C) {
 	dir := c.MkDir()
 	sha256hash, err := tools.ArchiveAndSHA256(&buf, dir)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(buf.String(), gc.Equals, emptyArchive)
 
 	h := sha256.New()
-	h.Write([]byte(emptyArchive))
+	h.Write(buf.Bytes())
 	c.Assert(sha256hash, gc.Equals, fmt.Sprintf("%x", h.Sum(nil)))
+
+	gzr, err := gzip.NewReader(&buf)
+	c.Assert(err, jc.ErrorIsNil)
+	r := tar.NewReader(gzr)
+	_, err = r.Next()
+	c.Assert(err, gc.Equals, io.EOF)
 }
 
 func (b *buildSuite) TestGetVersionFromJujud(c *gc.C) {

--- a/network/hostport_test.go
+++ b/network/hostport_test.go
@@ -213,25 +213,25 @@ func (*HostPortSuite) TestParseHostPortsErrors(c *gc.C) {
 		err   string
 	}{{
 		input: "",
-		err:   `cannot parse "" as address:port: missing port in address`,
+		err:   `cannot parse "" as address:port: .*missing port in address.*`,
 	}, {
 		input: " ",
-		err:   `cannot parse " " as address:port: missing port in address  `,
+		err:   `cannot parse " " as address:port: .*missing port in address.*`,
 	}, {
 		input: ":",
 		err:   `cannot parse ":" port: strconv.(ParseInt|Atoi): parsing "": invalid syntax`,
 	}, {
 		input: "host",
-		err:   `cannot parse "host" as address:port: missing port in address host`,
+		err:   `cannot parse "host" as address:port: .*missing port in address.*`,
 	}, {
 		input: "host:port",
 		err:   `cannot parse "host:port" port: strconv.(ParseInt|Atoi): parsing "port": invalid syntax`,
 	}, {
 		input: "::1",
-		err:   `cannot parse "::1" as address:port: too many colons in address ::1`,
+		err:   `cannot parse "::1" as address:port: .*too many colons in address.*`,
 	}, {
 		input: "1.2.3.4",
-		err:   `cannot parse "1.2.3.4" as address:port: missing port in address 1.2.3.4`,
+		err:   `cannot parse "1.2.3.4" as address:port: .*missing port in address.*`,
 	}, {
 		input: "1.2.3.4:foo",
 		err:   `cannot parse "1.2.3.4:foo" port: strconv.(ParseInt|Atoi): parsing "foo": invalid syntax`,
@@ -244,7 +244,7 @@ func (*HostPortSuite) TestParseHostPortsErrors(c *gc.C) {
 	}
 	// Finally, test with mixed valid and invalid args.
 	hps, err := network.ParseHostPorts("1.2.3.4:42", "[fc00::1]:12", "foo")
-	c.Assert(err, gc.ErrorMatches, `cannot parse "foo" as address:port: missing port in address foo`)
+	c.Assert(err, gc.ErrorMatches, `cannot parse "foo" as address:port: .*missing port in address.*`)
 	c.Assert(hps, gc.IsNil)
 }
 

--- a/resource/api/server/handler_test.go
+++ b/resource/api/server/handler_test.go
@@ -113,7 +113,6 @@ func (s *HTTPHandlerSuite) TestServeHTTPConnectFailure(c *gc.C) {
 	s.stub.CheckCall(c, 0, "Connect", req)
 	s.stub.CheckCall(c, 3, "WriteHeader", http.StatusInternalServerError)
 	s.stub.CheckCall(c, 4, "Write", expected)
-	c.Check(req, jc.DeepEquals, s.req) // did not change
 	c.Check(s.header, jc.DeepEquals, http.Header{
 		"Content-Type":   []string{"application/json"},
 		"Content-Length": []string{strconv.Itoa(len(expected))},
@@ -142,7 +141,6 @@ func (s *HTTPHandlerSuite) TestServeHTTPUnsupportedMethod(c *gc.C) {
 	s.stub.CheckCall(c, 0, "Connect", req)
 	s.stub.CheckCall(c, 3, "WriteHeader", http.StatusMethodNotAllowed)
 	s.stub.CheckCall(c, 4, "Write", expected)
-	c.Check(req, jc.DeepEquals, s.req) // did not change
 	c.Check(s.header, jc.DeepEquals, http.Header{
 		"Content-Type":   []string{"application/json"},
 		"Content-Length": []string{strconv.Itoa(len(expected))},
@@ -167,7 +165,6 @@ func (s *HTTPHandlerSuite) TestServeHTTPGetSuccess(c *gc.C) {
 		{"Write", []interface{}{downloadContent}},
 		{"Close", nil},
 	})
-	c.Check(req, jc.DeepEquals, s.req) // did not change
 	c.Check(s.header, jc.DeepEquals, http.Header{
 		"Content-Type":   []string{"application/octet-stream"},
 		"Content-Length": []string{fmt.Sprint(len(downloadContent))},
@@ -201,7 +198,6 @@ func (s *HTTPHandlerSuite) TestServeHTTPPutSuccess(c *gc.C) {
 	s.stub.CheckCall(c, 1, "HandleUpload", "youknowwho", s.data, req)
 	s.stub.CheckCall(c, 4, "WriteHeader", http.StatusOK)
 	s.stub.CheckCall(c, 5, "Write", string(expected))
-	c.Check(req, jc.DeepEquals, s.req) // did not change
 	c.Check(s.header, jc.DeepEquals, http.Header{
 		"Content-Type":   []string{"application/json"},
 		"Content-Length": []string{fmt.Sprint(len(expected))},
@@ -234,7 +230,6 @@ func (s *HTTPHandlerSuite) TestServeHTTPPutHandleUploadFailure(c *gc.C) {
 	s.stub.CheckCall(c, 1, "HandleUpload", "youknowwho", s.data, req)
 	s.stub.CheckCall(c, 4, "WriteHeader", http.StatusInternalServerError)
 	s.stub.CheckCall(c, 5, "Write", expected)
-	c.Check(req, jc.DeepEquals, s.req) // did not change
 	c.Check(s.header, jc.DeepEquals, http.Header{
 		"Content-Type":   []string{"application/json"},
 		"Content-Length": []string{strconv.Itoa(len(expected))},

--- a/rpc/rpc_test.go
+++ b/rpc/rpc_test.go
@@ -947,10 +947,10 @@ func (*rpcSuite) TestContinueAfterReadBodyError(c *gc.C) {
 		X: map[string]int{"hello": 65},
 	}
 	err := client.Call(rpc.Request{"SimpleMethods", 0, "a0", "SliceArg"}, arg0, &ret)
-	c.Assert(err, gc.ErrorMatches, `json: cannot unmarshal object into Go value of type \[\]string`)
+	c.Assert(err, gc.ErrorMatches, `json: cannot unmarshal object into Go (?:value)|(?:struct field \.X) of type \[\]string`)
 
 	err = client.Call(rpc.Request{"SimpleMethods", 0, "a0", "SliceArg"}, arg0, &ret)
-	c.Assert(err, gc.ErrorMatches, `json: cannot unmarshal object into Go value of type \[\]string`)
+	c.Assert(err, gc.ErrorMatches, `json: cannot unmarshal object into Go (?:value)|(?:struct field \.X) of type \[\]string`)
 
 	arg1 := struct {
 		X []string

--- a/state/unit_test.go
+++ b/state/unit_test.go
@@ -1761,17 +1761,19 @@ snapshot:
 		},
 		{
 			actionName: "juju-run",
-			errString:  `validation failed: (root) : "command" property is missing and required, given {}; (root) : "timeout" property is missing and required, given {}`,
+			errString:  `validation failed: \(root\) : "command" property is missing and required, given \{\}; \(root\) : "timeout" property is missing and required, given \{\}`,
 		},
 		{
 			actionName:   "juju-run",
 			givenPayload: map[string]interface{}{"command": "allyourbasearebelongtous"},
-			errString:    `validation failed: (root) : "timeout" property is missing and required, given {"command":"allyourbasearebelongtous"}`,
+			errString:    `validation failed: \(root\) : "timeout" property is missing and required, given \{"command":"allyourbasearebelongtous"\}`,
 		},
 		{
 			actionName:   "juju-run",
 			givenPayload: map[string]interface{}{"timeout": 5 * time.Second},
-			errString:    `validation failed: (root) : "command" property is missing and required, given {"timeout":5e+09}`,
+			// Note: in Go 1.8 the representation of large numbers in JSON changed
+			// to use integer rather than exponential notation, hence the pattern.
+			errString: `validation failed: \(root\) : "command" property is missing and required, given \{"timeout":5.*\}`,
 		},
 		{
 			actionName:      "juju-run",
@@ -1788,7 +1790,7 @@ snapshot:
 		c.Logf("running test %d", i)
 		action, err := unit1.AddAction(t.actionName, t.givenPayload)
 		if t.errString != "" {
-			c.Assert(err.Error(), gc.Equals, t.errString)
+			c.Assert(err, gc.ErrorMatches, t.errString)
 			continue
 		} else {
 			c.Assert(err, jc.ErrorIsNil)

--- a/utils/proxy/proxyconfig.go
+++ b/utils/proxy/proxyconfig.go
@@ -163,6 +163,9 @@ var portMap = map[string]string{
 func canonicalAddr(url *url.URL) string {
 	addr := url.Host
 	if !hasPort(addr) {
+		if strings.HasPrefix(addr, "[") && strings.HasSuffix(addr, "]") {
+			addr = addr[1 : len(addr)-1]
+		}
 		return net.JoinHostPort(addr, portMap[url.Scheme])
 	}
 	return addr

--- a/utils/proxy/proxyconfig_test.go
+++ b/utils/proxy/proxyconfig_test.go
@@ -43,12 +43,17 @@ var (
 		Http:    "http://http.proxy",
 		NoProxy: "*",
 	}
+	ipv6Proxy = proxy.Settings{
+		Http:  "2001:db8:85a3::8a2e:370:7334",
+		Https: "[2001:db8:85a3::8a2e:370:7334]:80",
+	}
 )
 
 func (s *Suite) TestGetProxy(c *gc.C) {
 	checkProxy(c, normal, "https://perfect.crime", "https://https.proxy")
-	checkProxy(c, normal, "decemberists.com", "http://http.proxy")
-	checkProxy(c, normal, "2001:db8:85a3::8a2e:370:7334", "http://http.proxy")
+	checkProxy(c, normal, "http://decemberists.com", "http://http.proxy")
+	checkProxy(c, normal, "http://[2001:db8:85a3::8a2e:370:7334]", "http://http.proxy")
+	checkProxy(c, ipv6Proxy, "http://[2001:db8:85a3::8a2e:370:7334]", "http://2001:db8:85a3::8a2e:370:7334")
 	checkProxy(c, proxy.Settings{}, "https://sufjan.stevens", "")
 	checkProxy(c, normal, "http://adz.foo.com:80", "")
 	checkProxy(c, normal, "http://adz.bar.com", "")
@@ -58,7 +63,7 @@ func (s *Suite) TestGetProxy(c *gc.C) {
 	checkProxy(c, normal, "http://10.0.0.1", "")
 	checkProxy(c, normal, "http://10.0.0.1:1996", "")
 	checkProxy(c, normal, "http://10.23.45.67:80", "http://http.proxy")
-	checkProxy(c, noProxy, "decemberists.com", "")
+	checkProxy(c, noProxy, "http://decemberists.com", "")
 	checkProxy(c, proxy.Settings{Http: "grizzly.bear"}, "veckatimest.com", "http://grizzly.bear")
 }
 

--- a/worker/introspection/socket_test.go
+++ b/worker/introspection/socket_test.go
@@ -108,7 +108,7 @@ func (s *introspectionSuite) TestCmdLine(c *gc.C) {
 }
 
 func (s *introspectionSuite) TestGoroutineProfile(c *gc.C) {
-	buf := s.call(c, "/debug/pprof/goroutine")
+	buf := s.call(c, "/debug/pprof/goroutine?debug=1")
 	c.Assert(buf, gc.NotNil)
 	matches(c, buf, `^goroutine profile: total \d+`)
 }
@@ -126,7 +126,7 @@ func (s *introspectionSuite) TestMissingStatePoolReporter(c *gc.C) {
 }
 
 func (s *introspectionSuite) TestStateTrackerReporter(c *gc.C) {
-	buf := s.call(c, "/debug/pprof/juju/state/tracker")
+	buf := s.call(c, "/debug/pprof/juju/state/tracker?debug=1")
 	matches(c, buf, "200 OK")
 	matches(c, buf, "juju/state/tracker profile: total")
 }


### PR DESCRIPTION
## Description of change

Back port various fixes from the develop branch, to enable building/testing with Go 1.8.

## QA steps

Run the unit tests with go 1.8.

## Documentation changes

None.

## Bug reference

None.