### PR TITLE
cmd/modelcmd: rename CommandBase to Command

### DIFF
--- a/cmd/juju/commands/migrate.go
+++ b/cmd/juju/commands/migrate.go
@@ -20,7 +20,7 @@ import (
 
 func newMigrateCommand() cmd.Command {
 	var cmd migrateCommand
-	cmd.newAPIRoot = cmd.JujuCommandBase.NewAPIRoot
+	cmd.newAPIRoot = cmd.CommandBase.NewAPIRoot
 	return modelcmd.WrapController(&cmd)
 }
 

--- a/cmd/juju/commands/switch.go
+++ b/cmd/juju/commands/switch.go
@@ -19,12 +19,12 @@ func newSwitchCommand() cmd.Command {
 	cmd := &switchCommand{
 		Store: jujuclient.NewFileClientStore(),
 	}
-	cmd.RefreshModels = cmd.JujuCommandBase.RefreshModels
+	cmd.RefreshModels = cmd.CommandBase.RefreshModels
 	return modelcmd.WrapBase(cmd)
 }
 
 type switchCommand struct {
-	modelcmd.JujuCommandBase
+	modelcmd.CommandBase
 	RefreshModels func(jujuclient.ClientStore, string) error
 
 	Store  jujuclient.ClientStore

--- a/cmd/juju/controller/kill.go
+++ b/cmd/juju/controller/kill.go
@@ -41,7 +41,7 @@ See also:
 
 // NewKillCommand returns a command to kill a controller. Killing is a
 // forceful destroy.
-func NewKillCommand() modelcmd.CommandBase {
+func NewKillCommand() modelcmd.Command {
 	return wrapKillCommand(&killCommand{
 		clock: clock.WallClock,
 	})
@@ -49,7 +49,7 @@ func NewKillCommand() modelcmd.CommandBase {
 
 // wrapKillCommand provides the common wrapping used by tests and
 // the default NewKillCommand above.
-func wrapKillCommand(kill *killCommand) modelcmd.CommandBase {
+func wrapKillCommand(kill *killCommand) modelcmd.Command {
 	return modelcmd.WrapController(
 		kill,
 		modelcmd.WrapControllerSkipControllerFlags,

--- a/cmd/juju/controller/listcontrollers.go
+++ b/cmd/juju/controller/listcontrollers.go
@@ -56,7 +56,7 @@ func (c *listControllersCommand) Info() *cmd.Info {
 
 // SetFlags implements Command.SetFlags.
 func (c *listControllersCommand) SetFlags(f *gnuflag.FlagSet) {
-	c.JujuCommandBase.SetFlags(f)
+	c.CommandBase.SetFlags(f)
 	f.BoolVar(&c.refresh, "refresh", false, "Connect to each controller to download the latest details")
 	c.out.AddFlags(f, "tabular", map[string]cmd.Formatter{
 		"yaml":    cmd.FormatYaml,
@@ -185,7 +185,7 @@ func controllerMachineCounts(controllerModelUUID string, modelStatus []base.Mode
 }
 
 type listControllersCommand struct {
-	modelcmd.JujuCommandBase
+	modelcmd.CommandBase
 
 	out     cmd.Output
 	store   jujuclient.ClientStore

--- a/cmd/juju/controller/register.go
+++ b/cmd/juju/controller/register.go
@@ -52,7 +52,7 @@ func NewRegisterCommand() cmd.Command {
 // registerCommand logs in to a Juju controller and caches the connection
 // information.
 type registerCommand struct {
-	modelcmd.JujuCommandBase
+	modelcmd.CommandBase
 	apiOpen        api.OpenFunc
 	listModelsFunc func(_ jujuclient.ClientStore, controller, user string) ([]base.UserModel, error)
 	store          jujuclient.ClientStore

--- a/cmd/juju/controller/showcontroller.go
+++ b/cmd/juju/controller/showcontroller.go
@@ -36,7 +36,7 @@ See also:
     controllers`[1:]
 
 type showControllerCommand struct {
-	modelcmd.JujuCommandBase
+	modelcmd.CommandBase
 
 	out   cmd.Output
 	store jujuclient.ClientStore
@@ -72,7 +72,7 @@ func (c *showControllerCommand) Info() *cmd.Info {
 
 // SetFlags implements Command.SetFlags.
 func (c *showControllerCommand) SetFlags(f *gnuflag.FlagSet) {
-	c.JujuCommandBase.SetFlags(f)
+	c.CommandBase.SetFlags(f)
 	f.BoolVar(&c.showPasswords, "show-password", false, "Show password for logged in user")
 	c.out.AddFlags(f, "yaml", map[string]cmd.Formatter{
 		"yaml": cmd.FormatYaml,

--- a/cmd/juju/controller/unregister.go
+++ b/cmd/juju/controller/unregister.go
@@ -26,7 +26,7 @@ func NewUnregisterCommand(store jujuclient.ClientStore) cmd.Command {
 
 // unregisterCommand removes a Juju controller from the local store.
 type unregisterCommand struct {
-	modelcmd.JujuCommandBase
+	modelcmd.CommandBase
 	controllerName string
 	assumeYes      bool
 	store          jujuclient.ClientStore

--- a/cmd/juju/romulus/agree/agree.go
+++ b/cmd/juju/romulus/agree/agree.go
@@ -59,7 +59,7 @@ type term struct {
 
 // agreeCommand creates a user agreement to the specified terms.
 type agreeCommand struct {
-	modelcmd.JujuCommandBase
+	modelcmd.CommandBase
 
 	terms           []term
 	termIds         []string
@@ -68,7 +68,7 @@ type agreeCommand struct {
 
 // SetFlags implements Command.SetFlags.
 func (c *agreeCommand) SetFlags(f *gnuflag.FlagSet) {
-	c.JujuCommandBase.SetFlags(f)
+	c.CommandBase.SetFlags(f)
 	f.BoolVar(&c.SkipTermContent, "yes", false, "Agree to terms non interactively")
 }
 
@@ -102,7 +102,7 @@ func (c *agreeCommand) Init(args []string) error {
 	if len(c.terms) == 0 {
 		return errors.New("must specify a valid term revision")
 	}
-	return c.JujuCommandBase.Init([]string{})
+	return c.CommandBase.Init([]string{})
 }
 
 // Run implements Command.Run.

--- a/cmd/juju/romulus/createwallet/createwallet.go
+++ b/cmd/juju/romulus/createwallet/createwallet.go
@@ -16,7 +16,7 @@ import (
 )
 
 type createWalletCommand struct {
-	modelcmd.JujuCommandBase
+	modelcmd.CommandBase
 	Name  string
 	Value string
 }
@@ -52,7 +52,7 @@ func (c *createWalletCommand) Init(args []string) error {
 	if _, err := strconv.ParseInt(c.Value, 10, 32); err != nil {
 		return errors.New("wallet value needs to be a whole number")
 	}
-	return c.JujuCommandBase.Init(args[2:])
+	return c.CommandBase.Init(args[2:])
 }
 
 // Run implements cmd.Command.Run and has most of the logic for the run command.

--- a/cmd/juju/romulus/listagreements/listagreements.go
+++ b/cmd/juju/romulus/listagreements/listagreements.go
@@ -49,13 +49,13 @@ var _ cmd.Command = (*listAgreementsCommand)(nil)
 // listAgreementsCommand creates a user agreement to the specified
 // Terms and Conditions document.
 type listAgreementsCommand struct {
-	modelcmd.JujuCommandBase
+	modelcmd.CommandBase
 	out cmd.Output
 }
 
 // SetFlags implements Command.SetFlags.
 func (c *listAgreementsCommand) SetFlags(f *gnuflag.FlagSet) {
-	c.JujuCommandBase.SetFlags(f)
+	c.CommandBase.SetFlags(f)
 	c.out.AddFlags(f, "json", map[string]cmd.Formatter{
 		"json": formatJSON,
 		"yaml": cmd.FormatYaml,

--- a/cmd/juju/romulus/listplans/list_plans.go
+++ b/cmd/juju/romulus/listplans/list_plans.go
@@ -45,7 +45,7 @@ Examples:
 
 // ListPlansCommand retrieves plans that are available for the specified charm
 type ListPlansCommand struct {
-	modelcmd.JujuCommandBase
+	modelcmd.CommandBase
 
 	out      cmd.Output
 	CharmURL string
@@ -81,12 +81,12 @@ func (c *ListPlansCommand) Init(args []string) error {
 		return errors.Errorf("unknown command line arguments: " + strings.Join(args, ","))
 	}
 	c.CharmURL = charmURL
-	return c.JujuCommandBase.Init(args)
+	return c.CommandBase.Init(args)
 }
 
 // SetFlags implements Command.SetFlags.
 func (c *ListPlansCommand) SetFlags(f *gnuflag.FlagSet) {
-	c.JujuCommandBase.SetFlags(f)
+	c.CommandBase.SetFlags(f)
 	defaultFormat := "tabular"
 	c.out.AddFlags(f, defaultFormat, map[string]cmd.Formatter{
 		"yaml":    cmd.FormatYaml,

--- a/cmd/juju/romulus/listwallets/list-wallets.go
+++ b/cmd/juju/romulus/listwallets/list-wallets.go
@@ -26,7 +26,7 @@ func NewListWalletsCommand() cmd.Command {
 }
 
 type listWalletsCommand struct {
-	modelcmd.JujuCommandBase
+	modelcmd.CommandBase
 
 	out cmd.Output
 }
@@ -50,7 +50,7 @@ func (c *listWalletsCommand) Info() *cmd.Info {
 
 // SetFlags implements cmd.Command.SetFlags.
 func (c *listWalletsCommand) SetFlags(f *gnuflag.FlagSet) {
-	c.JujuCommandBase.SetFlags(f)
+	c.CommandBase.SetFlags(f)
 	c.out.AddFlags(f, "tabular", map[string]cmd.Formatter{
 		"tabular": formatTabular,
 		"json":    cmd.FormatJson,

--- a/cmd/juju/romulus/setwallet/setwallet.go
+++ b/cmd/juju/romulus/setwallet/setwallet.go
@@ -16,7 +16,7 @@ import (
 )
 
 type setWalletCommand struct {
-	modelcmd.JujuCommandBase
+	modelcmd.CommandBase
 	Name  string
 	Value string
 }
@@ -53,7 +53,7 @@ func (c *setWalletCommand) Init(args []string) error {
 	if _, err := strconv.ParseInt(c.Value, 10, 32); err != nil {
 		return errors.New("wallet value needs to be a whole number")
 	}
-	return c.JujuCommandBase.Init(args[2:])
+	return c.CommandBase.Init(args[2:])
 }
 
 // Run implements cmd.Command.Run and contains most of the setwallet logic.

--- a/cmd/juju/romulus/showwallet/show_wallet.go
+++ b/cmd/juju/romulus/showwallet/show_wallet.go
@@ -31,7 +31,7 @@ func NewShowWalletCommand() cmd.Command {
 }
 
 type showWalletCommand struct {
-	modelcmd.JujuCommandBase
+	modelcmd.CommandBase
 
 	out    cmd.Output
 	wallet string
@@ -61,12 +61,12 @@ func (c *showWalletCommand) Init(args []string) error {
 	}
 	c.wallet, args = args[0], args[1:]
 
-	return c.JujuCommandBase.Init(args)
+	return c.CommandBase.Init(args)
 }
 
 // SetFlags implements cmd.Command.SetFlags.
 func (c *showWalletCommand) SetFlags(f *gnuflag.FlagSet) {
-	c.JujuCommandBase.SetFlags(f)
+	c.CommandBase.SetFlags(f)
 	c.out.AddFlags(f, "tabular", map[string]cmd.Formatter{
 		"tabular": c.formatTabular,
 		"json":    cmd.FormatJson,

--- a/cmd/juju/user/login.go
+++ b/cmd/juju/user/login.go
@@ -72,7 +72,7 @@ See also:
 
 // Functions defined as variables so they can be overridden in tests.
 var (
-	apiOpen          = (*modelcmd.JujuCommandBase).APIOpen
+	apiOpen          = (*modelcmd.CommandBase).APIOpen
 	newAPIConnection = juju.NewAPIConnection
 	listModels       = func(c api.Connection, userName string) ([]apibase.UserModel, error) {
 		return modelmanager.NewClient(c).ListModels(userName)
@@ -311,7 +311,7 @@ func (c *loginCommand) publicControllerLogin(
 		if d.User != "" {
 			tag = names.NewUserTag(d.User)
 		}
-		return apiOpen(&c.JujuCommandBase, &api.Info{
+		return apiOpen(&c.CommandBase, &api.Info{
 			Tag:      tag,
 			Password: d.Password,
 			Addrs:    []string{host},

--- a/cmd/juju/user/login_test.go
+++ b/cmd/juju/user/login_test.go
@@ -51,7 +51,7 @@ func (s *LoginCommandSuite) SetUpTest(c *gc.C) {
 	s.PatchValue(user.ListModels, func(c api.Connection, userName string) ([]apibase.UserModel, error) {
 		return nil, nil
 	})
-	s.PatchValue(user.APIOpen, func(c *modelcmd.JujuCommandBase, info *api.Info, opts api.DialOpts) (api.Connection, error) {
+	s.PatchValue(user.APIOpen, func(c *modelcmd.CommandBase, info *api.Info, opts api.DialOpts) (api.Connection, error) {
 		return s.apiConnection, nil
 	})
 	s.PatchValue(user.LoginClientStore, s.store)

--- a/cmd/juju/user/logincontroller_test.go
+++ b/cmd/juju/user/logincontroller_test.go
@@ -124,7 +124,7 @@ func (s *LoginCommandSuite) TestRegisterPublicAPIOpenError(c *gc.C) {
 	srv := serveDirectory(map[string]string{"bighost": "https://0.1.2.3/directory"})
 	defer srv.Close()
 	os.Setenv("JUJU_DIRECTORY", srv.URL)
-	*user.APIOpen = func(c *modelcmd.JujuCommandBase, info *api.Info, opts api.DialOpts) (api.Connection, error) {
+	*user.APIOpen = func(c *modelcmd.CommandBase, info *api.Info, opts api.DialOpts) (api.Connection, error) {
 		return nil, errors.New("open failed")
 	}
 	stdout, stderr, code := s.run(c, "bighost")

--- a/cmd/juju/user/whoami.go
+++ b/cmd/juju/user/whoami.go
@@ -51,7 +51,7 @@ func (c *whoAmICommand) Info() *cmd.Info {
 
 // SetFlags implements Command.SetFlags.
 func (c *whoAmICommand) SetFlags(f *gnuflag.FlagSet) {
-	c.JujuCommandBase.SetFlags(f)
+	c.CommandBase.SetFlags(f)
 	c.out.AddFlags(f, "tabular", map[string]cmd.Formatter{
 		"yaml":    cmd.FormatYaml,
 		"json":    cmd.FormatJson,
@@ -120,7 +120,7 @@ func (c *whoAmICommand) Run(ctx *cmd.Context) error {
 }
 
 type whoAmICommand struct {
-	modelcmd.JujuCommandBase
+	modelcmd.CommandBase
 
 	out   cmd.Output
 	store jujuclient.ClientStore

--- a/cmd/modelcmd/apicontext.go
+++ b/cmd/modelcmd/apicontext.go
@@ -48,7 +48,7 @@ func (o *AuthOpts) SetFlags(f *gnuflag.FlagSet) {
 // will be supported.
 //
 // This function is provided for use by commands that cannot use
-// JujuCommandBase. Most clients should use that instead.
+// CommandBase. Most clients should use that instead.
 func NewAPIContext(ctxt *cmd.Context, opts *AuthOpts) (*APIContext, error) {
 	jar0, err := cookiejar.New(&cookiejar.Options{
 		Filename: cookieFile(),

--- a/cmd/modelcmd/controller.go
+++ b/cmd/modelcmd/controller.go
@@ -37,7 +37,7 @@ Please use "juju switch" to select a controller.
 // ControllerCommand is intended to be a base for all commands
 // that need to operate on controllers as opposed to models.
 type ControllerCommand interface {
-	CommandBase
+	Command
 
 	// SetClientStore is called prior to the wrapped command's Init method
 	// with the default controller store. It may also be called to override the
@@ -62,7 +62,7 @@ type ControllerCommand interface {
 // ControllerCommandBase is a convenience type for embedding in commands
 // that wish to implement ControllerCommand.
 type ControllerCommandBase struct {
-	JujuCommandBase
+	CommandBase
 
 	store          jujuclient.ClientStore
 	controllerName string
@@ -164,7 +164,7 @@ func (c *ControllerCommandBase) newAPIRoot(modelName string) (api.Connection, er
 		}
 		return nil, errors.Trace(ErrNoCurrentController)
 	}
-	return c.JujuCommandBase.NewAPIRoot(c.store, c.controllerName, modelName)
+	return c.CommandBase.NewAPIRoot(c.store, c.controllerName, modelName)
 }
 
 // ModelUUIDs returns the model UUIDs for the given model names.
@@ -214,7 +214,7 @@ func wrapControllerSkipDefaultController(w *sysCommandWrapper) {
 
 // WrapController wraps the specified ControllerCommand, returning a Command
 // that proxies to each of the ControllerCommand methods.
-func WrapController(c ControllerCommand, options ...WrapControllerOption) CommandBase {
+func WrapController(c ControllerCommand, options ...WrapControllerOption) Command {
 	wrapper := &sysCommandWrapper{
 		ControllerCommand:    c,
 		setControllerFlags:   true,

--- a/cmd/modelcmd/modelcommand.go
+++ b/cmd/modelcmd/modelcommand.go
@@ -67,7 +67,7 @@ func GetCurrentModel(store jujuclient.ClientStore) (string, error) {
 
 // ModelCommand extends cmd.Command with a SetModelName method.
 type ModelCommand interface {
-	CommandBase
+	Command
 
 	// SetClientStore is called prior to the wrapped command's Init method
 	// with the default controller store. It may also be called to override the
@@ -100,7 +100,7 @@ type ModelCommand interface {
 // ModelCommandBase is a convenience type for embedding in commands
 // that wish to implement ModelCommand.
 type ModelCommandBase struct {
-	JujuCommandBase
+	CommandBase
 
 	// store is the client controller store that contains information
 	// about controllers, models, etc.
@@ -204,7 +204,7 @@ func (c *ModelCommandBase) newAPIRoot(modelName string) (api.Connection, error) 
 		}
 		return nil, errors.Trace(ErrNoCurrentController)
 	}
-	return c.JujuCommandBase.NewAPIRoot(c.store, c.controllerName, modelName)
+	return c.CommandBase.NewAPIRoot(c.store, c.controllerName, modelName)
 }
 
 // ConnectionName returns the name of the connection if there is one.


### PR DESCRIPTION
The "CommandBase" name is inconsistent with all the other *Base
names - it's an interface but all the others (ControllerCommandBase,
ModelCommandBase and cmd.CommandBase) are static embeddable structs.
This is confusing, so rename it to Command, allowing us to rename the
awkwardly-differentiated JujuCommandBase to CommandBase.

This PR was entirely mechanically generated with

	gorename -from '"github.com/juju/juju/cmd/modelcmd".CommandBase' -to Command
	gorename -from '"github.com/juju/juju/cmd/modelcmd".JujuCommandBase' -to CommandBase

with the exception of some of the comment adjustments.

QA No regressions