### PR TITLE
use latest juju/txn

### DIFF
--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -46,7 +46,7 @@ github.com/juju/romulus	git	b5ad384db5630652da632e49adabb968d1143e4c	2017-04-19T
 github.com/juju/schema	git	075de04f9b7d7580d60a1e12a0b3f50bb18e6998	2016-04-20T04:42:03Z
 github.com/juju/terms-client	git	9b925afd677234e4146dde3cb1a11e187cbed64e	2016-08-09T13:19:00Z
 github.com/juju/testing	git	fce9bc4ebf7a77310c262ac4884e03b778eae06a	2017-02-22T09:01:19Z
-github.com/juju/txn	git	42e03dbca6a4f5333d92daae67228c032a109aad	2017-04-11T10:02:47Z
+github.com/juju/txn	git	5c6f1c49ecbd4a916ed7b5a8f81ee67203e86043	2017-04-21T05:33:50Z
 github.com/juju/usso	git	68a59c96c178fbbad65926e7f93db50a2cd14f33	2016-04-01T10:44:24Z
 github.com/juju/utils	git	51660d020f8c823ce1d0b7904c26e6b907163050	2017-04-21T12:10:45Z
 github.com/juju/version	git	1f41e27e54f21acccf9b2dddae063a782a8a7ceb	2016-10-31T05:19:06Z


### PR DESCRIPTION
## Description of change

When running mgopurge against older Juju repositories, we found it doesn't do well with very large (2M+) txn collections on mongo 2.4. This brings in the fix for that. Its my understanding that Juju controllers on Trusty still use Mongo 2.4.

## QA steps

Running Juju against Mongo 2.4 with very large txn collections should successfully prune the txn collection instead of getting an error about the aggregation document being too large.

## Documentation changes

None

## Bug reference

juju/txn reference issue: https://github.com/juju/txn/pull/31
