### PR TITLE
Fix the series selection logic for deploying local charms.

### DIFF
--- a/cmd/juju/application/deploy.go
+++ b/cmd/juju/application/deploy.go
@@ -809,17 +809,15 @@ func (c *DeployCommand) maybeReadLocalCharm(apiRoot DeployAPI) (deployFn, error)
 	// needed for a more elegant fix.
 
 	ch, err := charm.ReadCharm(c.CharmOrBundle)
-	var series string
-	if err != nil {
-		series = c.Series
-	} else {
+	series := c.Series
+	if err == nil {
 		modelCfg, err := getModelConfig(apiRoot)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
 
 		seriesSelector := seriesSelector{
-			seriesFlag:      c.Series,
+			seriesFlag:      series,
 			supportedSeries: ch.Meta().Series,
 			force:           c.Force,
 			conf:            modelCfg,

--- a/cmd/juju/application/store.go
+++ b/cmd/juju/application/store.go
@@ -21,15 +21,6 @@ import (
 	"github.com/juju/juju/environs/config"
 )
 
-func isSeriesSupported(requestedSeries string, supportedSeries []string) bool {
-	for _, series := range supportedSeries {
-		if series == requestedSeries {
-			return true
-		}
-	}
-	return false
-}
-
 // TODO(ericsnow) Return charmstore.CharmID from resolve()?
 
 // ResolveCharmFunc is the type of a function that resolves a charm URL.

--- a/cmd/juju/application/upgradecharm.go
+++ b/cmd/juju/application/upgradecharm.go
@@ -536,7 +536,8 @@ func (c *upgradeCharmCommand) addCharm(
 		return id, nil, errors.Trace(err)
 	}
 	id.Channel = channel
-	if !c.ForceSeries && deployedSeries != "" && newURL.Series == "" && !isSeriesSupported(deployedSeries, supportedSeries) {
+	_, seriesSupportedErr := charm.SeriesForCharm(deployedSeries, supportedSeries)
+	if !c.ForceSeries && deployedSeries != "" && newURL.Series == "" && seriesSupportedErr != nil {
 		series := []string{"no series"}
 		if len(supportedSeries) > 0 {
 			series = supportedSeries

--- a/cmd/juju/application/upgradecharm_test.go
+++ b/cmd/juju/application/upgradecharm_test.go
@@ -287,7 +287,7 @@ func (s *UpgradeCharmErrorsStateSuite) TestInvalidService(c *gc.C) {
 
 func (s *UpgradeCharmErrorsStateSuite) deployService(c *gc.C) {
 	ch := testcharms.Repo.ClonedDirPath(s.CharmsPath, "riak")
-	_, err := runDeploy(c, ch, "riak", "--series", "quantal", "--force")
+	_, err := runDeploy(c, ch, "riak", "--series", "quantal")
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -355,7 +355,7 @@ var _ = gc.Suite(&UpgradeCharmSuccessStateSuite{})
 func (s *UpgradeCharmSuccessStateSuite) SetUpTest(c *gc.C) {
 	s.RepoSuite.SetUpTest(c)
 	s.path = testcharms.Repo.ClonedDirPath(s.CharmsPath, "riak")
-	_, err := runDeploy(c, s.path, "--series", "quantal", "--force")
+	_, err := runDeploy(c, s.path, "--series", "quantal")
 	c.Assert(err, jc.ErrorIsNil)
 	s.riak, err = s.State.Application("riak")
 	c.Assert(err, jc.ErrorIsNil)


### PR DESCRIPTION
## Description of change

There was incorrect logic around old style local charms and the series that should be used by default.
The seriesSelector object now holds all that logic. Precedence is as follows:
 * series specified on the command line
 * series determined through charm URL
 * model default series
 * errors if none of those are specified

## QA steps

This will fix our CI test failures where they are deploying an old style charm with no series specified in the metadata.
