### PR TITLE
Fix typo in help.

### DIFF
--- a/cmd/juju/backups/remove.go
+++ b/cmd/juju/backups/remove.go
@@ -33,7 +33,7 @@ func (c *removeCommand) Info() *cmd.Info {
 	return &cmd.Info{
 		Name:    "remove-backup",
 		Args:    "<ID>",
-		Purpose: "Remove the spcified backup from remote storage.",
+		Purpose: "Remove the specified backup from remote storage.",
 		Doc:     removeDoc,
 	}
 }


### PR DESCRIPTION
## Description of change

Fixes typo in command help.

## QA steps

n/a

## Documentation changes

n/a

## Bug reference

https://bugs.launchpad.net/juju/+bug/1657642
