### PR TITLE
provider/azure: retry service principal creation

### DIFF
--- a/provider/azure/internal/ad/client.go
+++ b/provider/azure/internal/ad/client.go
@@ -92,8 +92,11 @@ func WithOdataErrorUnlessStatusCode(codes ...int) autorest.RespondDecorator {
 				}
 
 				e := azure.RequestError{
-					ServiceError: &azure.ServiceError{Code: oe.ServiceError.Code},
-					RequestID:    azure.ExtractRequestID(resp),
+					ServiceError: &azure.ServiceError{
+						Code:    oe.ServiceError.Code,
+						Message: oe.ServiceError.Message.Value,
+					},
+					RequestID: azure.ExtractRequestID(resp),
 				}
 				if e.StatusCode == nil {
 					e.StatusCode = resp.StatusCode
@@ -105,10 +108,17 @@ func WithOdataErrorUnlessStatusCode(codes ...int) autorest.RespondDecorator {
 	}
 }
 
+// See https://msdn.microsoft.com/en-us/library/azure/ad/graph/howto/azure-ad-graph-api-error-codes-and-error-handling
 type odataRequestError struct {
 	ServiceError *odataServiceError `json:"odata.error"`
 }
 
 type odataServiceError struct {
-	Code string `json:"code"`
+	Code    string                   `json:"code"`
+	Message odataServiceErrorMessage `json:"message"`
+}
+
+type odataServiceErrorMessage struct {
+	Lang  string `json:"lang"`
+	Value string `json:"value"`
 }


### PR DESCRIPTION
## Description of change

When running "juju add-credential azure", with the
interactive auth-type, retry creation of the service
principal and role assignment. This is necessary as
the AAD replication occurs asynchronously, and may
not be complete by the time we get to these steps.

## QA steps

juju add-credential azure
(interactive)

## Documentation changes

None.

## Bug reference

Fixes https://bugs.launchpad.net/juju/+bug/1680523