### PR TITLE
Improve GUI handler.

### DIFF
--- a/apiserver/apiserver.go
+++ b/apiserver/apiserver.go
@@ -527,9 +527,8 @@ func (srv *Server) endpoints() []apihttp.Endpoint {
 	)
 	add("/model/:modeluuid/api", mainAPIHandler)
 
-	// GUI now supports URLs without the model uuid, just the user/model.
-	endpoints = append(endpoints, guiEndpoints(guiURLPathPrefix+"u/:user/:modelname/", srv.dataDir, httpCtxt)...)
-	endpoints = append(endpoints, guiEndpoints(guiURLPathPrefix+":modeluuid/", srv.dataDir, httpCtxt)...)
+	// GUI related paths.
+	endpoints = append(endpoints, guiEndpoints(guiURLPathPrefix, srv.dataDir, httpCtxt)...)
 	add("/gui-archive", &guiArchiveHandler{
 		ctxt: httpCtxt,
 	})

--- a/apiserver/export_test.go
+++ b/apiserver/export_test.go
@@ -29,6 +29,7 @@ var (
 	NewBackups            = &newBackups
 	BZMimeType            = bzMimeType
 	JSMimeType            = jsMimeType
+	GUIURLPathPrefix      = guiURLPathPrefix
 	SpritePath            = spritePath
 )
 

--- a/apiserver/httpcontext.go
+++ b/apiserver/httpcontext.go
@@ -29,44 +29,13 @@ type httpContext struct {
 	srv *Server
 }
 
-// modelUUIDFromRequest returns the uuid of the model based on path elements
-// in the request, and a boolean indicating if the model uuid were included directly.
-// A request either has the modeluuid directly in the path, or the path is
-// u/user/modelname and we need to look up the model uuid.
-func (ctxt *httpContext) modelUUIDFromRequest(r *http.Request) (string, bool, error) {
-	uuid := r.URL.Query().Get(":modeluuid")
-	if uuid != "" {
-		return uuid, true, nil
-	}
-
-	user := r.URL.Query().Get(":user")
-	model := r.URL.Query().Get(":modelname")
-	if user == "" || model == "" {
-		return "", false, nil
-	}
-	models, err := ctxt.srv.state.ModelsForUser(names.NewUserTag(user))
-	if err != nil {
-		return "", false, errors.Trace(err)
-	}
-	for _, m := range models {
-		if m.Name() == model {
-			return m.UUID(), false, nil
-		}
-	}
-	return "", false, errors.NotFoundf("model %s/%s", user, model)
-}
-
 // stateForRequestUnauthenticated returns a state instance appropriate for
 // using for the model implicit in the given request
 // without checking any authentication information.
 func (ctxt *httpContext) stateForRequestUnauthenticated(r *http.Request) (*state.State, func(), error) {
-	modelUUID, _, err := ctxt.modelUUIDFromRequest(r)
-	if err != nil {
-		return nil, nil, errors.Trace(err)
-	}
-	modelUUID, err = validateModelUUID(validateArgs{
+	modelUUID, err := validateModelUUID(validateArgs{
 		statePool:           ctxt.srv.statePool,
-		modelUUID:           modelUUID,
+		modelUUID:           r.URL.Query().Get(":modeluuid"),
 		strict:              ctxt.strictValidation,
 		controllerModelOnly: ctxt.controllerModelOnly,
 	})


### PR DESCRIPTION
Avoid using too much logic on the server side, and support all URLs starting from /gui/.
The GUI knows how to handle model connections based on the path.
This change fixes some weird issues in which some valid paths from the perspective of the GUI (for instance /u/{user}, the profile page) were not valid from the handler perspective, resulting in errors after refreshing.
This branch also simplifies the URLs for static files to no longer assume there is always a model connected.

QA:
- bootstrap a controller (for instance by running `juju bootstrap lxd local --config identity-url=https://api.jujucharms.com/identity --build-agent`);
- run `juju gui --browser`, then visit the GUI, log in and check that everything works correctly;
- visit the profile page and refresh: check that the GUI loads correctly on the profile page again;
- switch models and refresh: check that the GUI loads correctly on the model you switched to;
- try to visit directly an external user page, like `/gui/u/bac`;
- use `juju show-model | grep model-uuid` to find your current model UUID, copy that and use that to make a request to the legacy GUI URL, like `/gui/753a800d-80de-4d13-8552-e972376b5946`: ensure everything works well in that case, and the GUI handler still handles correctly requests from old Juju clients; the whole URL is considered the base for the GUI, as it used to be;
- run `juju upgrade-gui 2.2.0` in order to install an old version of the GUI, which didn't support the new "/u/user/model" paths;
- run `juju gui --browser` again, and check that even this old version works.



