### PR TITLE
cmd/modelcmd: per-controller cookie jars

### DIFF
--- a/cmd/juju/application/addrelation_test.go
+++ b/cmd/juju/application/addrelation_test.go
@@ -35,7 +35,9 @@ func (s *AddRelationSuite) SetUpTest(c *gc.C) {
 var _ = gc.Suite(&AddRelationSuite{})
 
 func (s *AddRelationSuite) runAddRelation(c *gc.C, args ...string) error {
-	_, err := cmdtesting.RunCommand(c, NewAddRelationCommandForTest(s.mockAPI), args...)
+	cmd := NewAddRelationCommandForTest(s.mockAPI)
+	cmd.SetClientStore(NewMockStore())
+	_, err := cmdtesting.RunCommand(c, cmd, args...)
 	return err
 }
 
@@ -82,7 +84,9 @@ func (s *AddRelationSuite) TestAddRelationUnauthorizedMentionsJujuGrant(c *gc.C)
 		Message: "permission denied",
 		Code:    params.CodeUnauthorized,
 	})
-	ctx, _ := cmdtesting.RunCommand(c, NewAddRelationCommandForTest(s.mockAPI), "application1", "application2")
+	cmd := NewAddRelationCommandForTest(s.mockAPI)
+	cmd.SetClientStore(NewMockStore())
+	ctx, _ := cmdtesting.RunCommand(c, cmd, "application1", "application2")
 	errString := strings.Replace(cmdtesting.Stderr(ctx), "\n", " ", -1)
 	c.Assert(errString, gc.Matches, `.*juju grant.*`)
 }

--- a/cmd/juju/application/config.go
+++ b/cmd/juju/application/config.go
@@ -54,6 +54,13 @@ func NewConfigCommand() cmd.Command {
 	return modelcmd.Wrap(&configCommand{})
 }
 
+// NewConfigCommandForTest returns a SetCommand with the api provided as specified.
+func NewConfigCommandForTest(api configCommandAPI) modelcmd.ModelCommand {
+	return modelcmd.Wrap(&configCommand{
+		api: api,
+	})
+}
+
 type attributes map[string]string
 
 // configCommand get, sets, and resets configuration values of an application.

--- a/cmd/juju/application/constraints.go
+++ b/cmd/juju/application/constraints.go
@@ -68,7 +68,7 @@ See also:
     set-model-constraints`
 
 // NewServiceGetConstraintsCommand returns a command which gets application constraints.
-func NewServiceGetConstraintsCommand() cmd.Command {
+func NewServiceGetConstraintsCommand() modelcmd.ModelCommand {
 	return modelcmd.Wrap(&serviceGetConstraintsCommand{})
 }
 
@@ -155,7 +155,7 @@ type serviceSetConstraintsCommand struct {
 }
 
 // NewServiceSetConstraintsCommand returns a command which sets application constraints.
-func NewServiceSetConstraintsCommand() cmd.Command {
+func NewServiceSetConstraintsCommand() modelcmd.ModelCommand {
 	return modelcmd.Wrap(&serviceSetConstraintsCommand{})
 }
 

--- a/cmd/juju/application/constraints_test.go
+++ b/cmd/juju/application/constraints_test.go
@@ -22,27 +22,27 @@ func (s *ServiceConstraintsCommandsSuite) TestSetInit(c *gc.C) {
 	for _, test := range []struct {
 		args []string
 		err  string
-	}{
-		{
-			args: []string{"--application", "mysql", "mem=4G"},
-			err:  `flag provided but not defined: --application`,
-		}, {
-			args: []string{"-s", "mysql", "mem=4G"},
-			err:  `flag provided but not defined: -s`,
-		}, {
-			args: []string{},
-			err:  `no application name specified`,
-		}, {
-			args: []string{"mysql", "="},
-			err:  `malformed constraint "="`,
-		}, {
-			args: []string{"cpu-power=250"},
-			err:  `invalid application name "cpu-power=250"`,
-		}, {
-			args: []string{"mysql", "cpu-power=250"},
-		},
-	} {
-		err := cmdtesting.InitCommand(application.NewServiceSetConstraintsCommand(), test.args)
+	}{{
+		args: []string{"--application", "mysql", "mem=4G"},
+		err:  `flag provided but not defined: --application`,
+	}, {
+		args: []string{"-s", "mysql", "mem=4G"},
+		err:  `flag provided but not defined: -s`,
+	}, {
+		args: []string{},
+		err:  `no application name specified`,
+	}, {
+		args: []string{"mysql", "="},
+		err:  `malformed constraint "="`,
+	}, {
+		args: []string{"cpu-power=250"},
+		err:  `invalid application name "cpu-power=250"`,
+	}, {
+		args: []string{"mysql", "cpu-power=250"},
+	}} {
+		cmd := application.NewServiceSetConstraintsCommand()
+		cmd.SetClientStore(application.NewMockStore())
+		err := cmdtesting.InitCommand(cmd, test.args)
 		if test.err == "" {
 			c.Check(err, jc.ErrorIsNil)
 		} else {
@@ -72,7 +72,9 @@ func (s *ServiceConstraintsCommandsSuite) TestGetInit(c *gc.C) {
 			args: []string{"mysql"},
 		},
 	} {
-		err := cmdtesting.InitCommand(application.NewServiceGetConstraintsCommand(), test.args)
+		cmd := application.NewServiceGetConstraintsCommand()
+		cmd.SetClientStore(application.NewMockStore())
+		err := cmdtesting.InitCommand(cmd, test.args)
 		if test.err == "" {
 			c.Check(err, jc.ErrorIsNil)
 		} else {

--- a/cmd/juju/application/consume.go
+++ b/cmd/juju/application/consume.go
@@ -66,21 +66,6 @@ func (c *consumeCommand) Init(args []string) error {
 		return errors.New("no remote application specified")
 	}
 	c.remoteApplication = args[0]
-	url, err := crossmodel.ParseApplicationURL(c.remoteApplication)
-	if err != nil {
-		return errors.Trace(err)
-	}
-	if url.HasEndpoint() {
-		return errors.Errorf("remote application %q shouldn't include endpoint", c.remoteApplication)
-	}
-	if url.User == "" {
-		details, err := c.ClientStore().AccountDetails(c.ControllerName())
-		if err != nil {
-			return errors.Trace(err)
-		}
-		url.User = details.User
-		c.remoteApplication = url.Path()
-	}
 	if len(args) > 1 {
 		if !names.IsValidApplication(args[1]) {
 			return errors.Errorf("invalid application name %q", args[1])
@@ -105,6 +90,21 @@ func (c *consumeCommand) getAPI() (applicationConsumeAPI, error) {
 // Run adds the requested remote application to the model. Implements
 // cmd.Command.
 func (c *consumeCommand) Run(ctx *cmd.Context) error {
+	url, err := crossmodel.ParseApplicationURL(c.remoteApplication)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	if url.HasEndpoint() {
+		return errors.Errorf("remote application %q shouldn't include endpoint", c.remoteApplication)
+	}
+	if url.User == "" {
+		details, err := c.CurrentAccountDetails()
+		if err != nil {
+			return errors.Trace(err)
+		}
+		url.User = details.User
+		c.remoteApplication = url.Path()
+	}
 	client, err := c.getAPI()
 	if err != nil {
 		return err

--- a/cmd/juju/application/consume_test.go
+++ b/cmd/juju/application/consume_test.go
@@ -56,7 +56,7 @@ func (s *ConsumeSuite) TestNoArguments(c *gc.C) {
 
 func (s *ConsumeSuite) TestTooManyArguments(c *gc.C) {
 	_, err := s.runConsume(c, "model.application", "alias", "something else")
-	c.Assert(err, gc.ErrorMatches, `unrecognized args: \["something else"\]`)
+	c.Assert(err, gc.ErrorMatches, `unrecognized args: \["something else"\]`, gc.Commentf("details: %s", errors.Details(err)))
 }
 
 func (s *ConsumeSuite) TestInvalidRemoteApplication(c *gc.C) {

--- a/cmd/juju/application/deploy.go
+++ b/cmd/juju/application/deploy.go
@@ -416,9 +416,8 @@ func (c *DeployCommand) Info() *cmd.Info {
 var (
 	// charmOnlyFlags and bundleOnlyFlags are used to validate flags based on
 	// whether we are deploying a charm or a bundle.
-	charmOnlyFlags        = []string{"bind", "config", "constraints", "force", "n", "num-units", "series", "to", "resource"}
-	bundleOnlyFlags       = []string{}
-	modelCommandBaseFlags = []string{"B", "no-browser-login"}
+	charmOnlyFlags  = []string{"bind", "config", "constraints", "force", "n", "num-units", "series", "to", "resource"}
+	bundleOnlyFlags = []string{}
 )
 
 func (c *DeployCommand) SetFlags(f *gnuflag.FlagSet) {
@@ -531,7 +530,6 @@ func (c *DeployCommand) deployCharm(
 	if serviceName == "" {
 		serviceName = charmInfo.Meta.Name
 	}
-
 	var configYAML []byte
 	if c.Config.Path != "" {
 		configYAML, err = c.Config.Read(ctx)

--- a/cmd/juju/application/deploy_test.go
+++ b/cmd/juju/application/deploy_test.go
@@ -513,7 +513,7 @@ func (s *DeploySuite) TestDeployFlags(c *gc.C) {
 	})
 	declaredFlags := append(charmAndBundleFlags, charmOnlyFlags...)
 	declaredFlags = append(declaredFlags, bundleOnlyFlags...)
-	declaredFlags = append(declaredFlags, modelCommandBaseFlags...)
+	declaredFlags = append(declaredFlags, "B", "no-browser-login")
 	sort.Strings(declaredFlags)
 	c.Assert(declaredFlags, jc.DeepEquals, allFlags)
 }
@@ -1267,7 +1267,7 @@ func (s *DeployUnitTestSuite) SetUpTest(c *gc.C) {
 	s.PatchEnvironment("JUJU_COOKIEFILE", cookiesFile)
 }
 
-func (s *DeployUnitTestSuite) TestDeployLocalCharm_GivesCorrectUserMessage(c *gc.C) {
+func (s *DeployUnitTestSuite) TestDeployLocalCharmGivesCorrectUserMessage(c *gc.C) {
 	// Copy multi-series charm to path where we can deploy it from
 	charmsPath := c.MkDir()
 	charmDir := testcharms.Repo.ClonedDir(charmsPath, "multi-series")
@@ -1286,6 +1286,7 @@ func (s *DeployUnitTestSuite) TestDeployLocalCharm_GivesCorrectUserMessage(c *gc
 	cmd := NewDeployCommandForTest(func() (DeployAPI, error) {
 		return fakeAPI, nil
 	}, nil)
+	cmd.SetClientStore(NewMockStore())
 	context, err := cmdtesting.RunCommand(c, cmd, charmDir.Path, "--series", "trusty")
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -1309,6 +1310,7 @@ func (s *DeployUnitTestSuite) TestAddMetricCredentialsDefaultForUnmeteredCharm(c
 	deployCmd := NewDeployCommandForTest(func() (DeployAPI, error) {
 		return fakeAPI, nil
 	}, nil)
+	deployCmd.SetClientStore(NewMockStore())
 	_, err := cmdtesting.RunCommand(c, deployCmd, charmDir.Path, "--series", "trusty")
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -1320,7 +1322,7 @@ func (s *DeployUnitTestSuite) TestAddMetricCredentialsDefaultForUnmeteredCharm(c
 	}
 }
 
-func (s *DeployUnitTestSuite) TestRedeployLocalCharm_SucceedsWhenDeployed(c *gc.C) {
+func (s *DeployUnitTestSuite) TestRedeployLocalCharmSucceedsWhenDeployed(c *gc.C) {
 	charmsPath := c.MkDir()
 	charmDir := testcharms.Repo.ClonedDir(charmsPath, "dummy")
 
@@ -1336,6 +1338,7 @@ func (s *DeployUnitTestSuite) TestRedeployLocalCharm_SucceedsWhenDeployed(c *gc.
 	deployCmd := NewDeployCommandForTest(func() (DeployAPI, error) {
 		return fakeAPI, nil
 	}, nil)
+	deployCmd.SetClientStore(NewMockStore())
 	context, err := cmdtesting.RunCommand(c, deployCmd, dummyURL.String())
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -1396,6 +1399,7 @@ func (s *DeployUnitTestSuite) TestDeployBundle_OutputsCorrectMessage(c *gc.C) {
 	deployCmd := NewDeployCommandForTest(func() (DeployAPI, error) {
 		return fakeAPI, nil
 	}, nil)
+	deployCmd.SetClientStore(NewMockStore())
 	context, err := cmdtesting.RunCommand(c, deployCmd, "cs:bundle/wordpress-simple")
 	c.Assert(err, jc.ErrorIsNil)
 

--- a/cmd/juju/application/export_test.go
+++ b/cmd/juju/application/export_test.go
@@ -39,13 +39,6 @@ func NewUpgradeCharmCommandForTest(
 	return modelcmd.Wrap(cmd)
 }
 
-// NewConfigCommandForTest returns a SetCommand with the api provided as specified.
-func NewConfigCommandForTest(api configCommandAPI) cmd.Command {
-	return modelcmd.Wrap(&configCommand{
-		api: api,
-	})
-}
-
 // NewAddUnitCommandForTest returns an AddUnitCommand with the api provided as specified.
 func NewAddUnitCommandForTest(api serviceAddUnitAPI) cmd.Command {
 	return modelcmd.Wrap(&addUnitCommand{
@@ -54,7 +47,7 @@ func NewAddUnitCommandForTest(api serviceAddUnitAPI) cmd.Command {
 }
 
 // NewAddRelationCommandForTest returns an AddRelationCommand with the api provided as specified.
-func NewAddRelationCommandForTest(api ApplicationAddRelationAPI) cmd.Command {
+func NewAddRelationCommandForTest(api ApplicationAddRelationAPI) modelcmd.ModelCommand {
 	cmd := &addRelationCommand{newAPIFunc: func() (ApplicationAddRelationAPI, error) {
 		return api, nil
 	}}
@@ -62,7 +55,7 @@ func NewAddRelationCommandForTest(api ApplicationAddRelationAPI) cmd.Command {
 }
 
 // NewRemoveRelationCommandForTest returns an RemoveRelationCommand with the api provided as specified.
-func NewRemoveRelationCommandForTest(api ApplicationDestroyRelationAPI) cmd.Command {
+func NewRemoveRelationCommandForTest(api ApplicationDestroyRelationAPI) modelcmd.ModelCommand {
 	cmd := &removeRelationCommand{newAPIFunc: func() (ApplicationDestroyRelationAPI, error) {
 		return api, nil
 	}}

--- a/cmd/juju/application/expose.go
+++ b/cmd/juju/application/expose.go
@@ -26,7 +26,7 @@ See also:
     unexpose`[1:]
 
 // NewExposeCommand returns a command to expose services.
-func NewExposeCommand() cmd.Command {
+func NewExposeCommand() modelcmd.ModelCommand {
 	return modelcmd.Wrap(&exposeCommand{})
 }
 

--- a/cmd/juju/application/removeunit.go
+++ b/cmd/juju/application/removeunit.go
@@ -14,7 +14,7 @@ import (
 )
 
 // NewRemoveUnitCommand returns a command which removes an application's units.
-func NewRemoveUnitCommand() cmd.Command {
+func NewRemoveUnitCommand() modelcmd.ModelCommand {
 	return modelcmd.Wrap(&removeUnitCommand{})
 }
 

--- a/cmd/juju/application/unexpose.go
+++ b/cmd/juju/application/unexpose.go
@@ -27,7 +27,7 @@ See also:
     expose`[1:]
 
 // NewUnexposeCommand returns a command to unexpose services.
-func NewUnexposeCommand() cmd.Command {
+func NewUnexposeCommand() modelcmd.ModelCommand {
 	return modelcmd.Wrap(&unexposeCommand{})
 }
 

--- a/cmd/juju/cloud/updatecredential.go
+++ b/cmd/juju/cloud/updatecredential.go
@@ -99,7 +99,7 @@ func (c *updateCredentialCommand) Run(ctx *cmd.Context) error {
 		return nil
 	}
 
-	accountDetails, err := c.ClientStore().AccountDetails(c.ControllerName())
+	accountDetails, err := c.CurrentAccountDetails()
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/cmd/juju/commands/bootstrap.go
+++ b/cmd/juju/commands/bootstrap.go
@@ -583,7 +583,7 @@ See `[1:] + "`juju kill-controller`" + `.`)
 		return errors.Annotate(err, "failed to bootstrap model")
 	}
 
-	if err := c.SetModelName(modelcmd.JoinModelName(c.controllerName, c.hostedModelName)); err != nil {
+	if err := c.SetModelName(modelcmd.JoinModelName(c.controllerName, c.hostedModelName), false); err != nil {
 		return errors.Trace(err)
 	}
 

--- a/cmd/juju/commands/bootstrap_test.go
+++ b/cmd/juju/commands/bootstrap_test.go
@@ -1719,7 +1719,9 @@ func (s *BootstrapSuite) TestBootstrapSetsControllerOnBase(c *gc.C) {
 	// Record the controller name seen by ModelCommandBase at the end of bootstrap.
 	var seenControllerName string
 	s.PatchValue(&waitForAgentInitialisation, func(_ *cmd.Context, base *modelcmd.ModelCommandBase, _, _ string) error {
-		seenControllerName = base.ControllerName()
+		controllerName, err := base.ControllerName()
+		c.Check(err, jc.ErrorIsNil)
+		seenControllerName = controllerName
 		return nil
 	})
 

--- a/cmd/juju/commands/commands_test.go
+++ b/cmd/juju/commands/commands_test.go
@@ -79,21 +79,20 @@ func (c *stubCommand) Run(ctx *cmd.Context) error {
 	if err := c.stub.NextErr(); err != nil {
 		return errors.Trace(err)
 	}
-
 	return nil
 }
 
-func (c *stubCommand) SetModelName(name string) error {
+func (c *stubCommand) SetModelName(name string, allowDefault bool) error {
 	c.stub.AddCall("SetModelName", name)
 	c.envName = name
 	return c.stub.NextErr()
 }
 
-func (c *stubCommand) ModelName() string {
+func (c *stubCommand) ModelName() (string, error) {
 	c.stub.AddCall("ModelName")
 	c.stub.NextErr() // pop one off
 
-	return c.envName
+	return c.envName, nil
 }
 
 type stubRegistry struct {

--- a/cmd/juju/commands/list_sshkeys.go
+++ b/cmd/juju/commands/list_sshkeys.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/juju/cmd"
+	"github.com/juju/errors"
 	"github.com/juju/gnuflag"
 	"github.com/juju/utils/ssh"
 
@@ -78,17 +79,21 @@ func (c *listKeysCommand) Run(context *cmd.Context) error {
 	c.user = "admin"
 	results, err := client.ListKeys(mode, c.user)
 	if err != nil {
-		return err
+		return errors.Trace(err)
 	}
 	result := results[0]
 	if result.Error != nil {
-		return result.Error
+		return errors.Trace(result.Error)
 	}
 	if len(result.Result) == 0 {
 		context.Infof("No keys to display.")
 		return nil
 	}
-	fmt.Fprintf(context.Stdout, "Keys used in model: %s\n", c.ConnectionName())
+	modelName, err := c.ModelName()
+	if err != nil {
+		return errors.Trace(err)
+	}
+	fmt.Fprintf(context.Stdout, "Keys used in model: %s\n", modelName)
 	fmt.Fprintln(context.Stdout, strings.Join(result.Result, "\n"))
 	return nil
 }

--- a/cmd/juju/commands/migrate.go
+++ b/cmd/juju/commands/migrate.go
@@ -191,7 +191,7 @@ func (c *migrateCommand) getAPI() (migrateAPI, error) {
 }
 
 func (c *migrateCommand) getTargetControllerMacaroons() ([]macaroon.Slice, error) {
-	apiContext, err := c.APIContext()
+	jar, err := c.CommandBase.CookieJar(c.ClientStore(), c.targetController)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -206,5 +206,5 @@ func (c *migrateCommand) getTargetControllerMacaroons() ([]macaroon.Slice, error
 		return nil, errors.Annotate(err, "connecting to target controller")
 	}
 	defer api.Close()
-	return httpbakery.MacaroonsForURL(apiContext.CookieJar(), api.CookieURL()), nil
+	return httpbakery.MacaroonsForURL(jar, api.CookieURL()), nil
 }

--- a/cmd/juju/commands/plugin.go
+++ b/cmd/juju/commands/plugin.go
@@ -94,7 +94,11 @@ func (c *PluginCommand) Init(args []string) error {
 
 func (c *PluginCommand) Run(ctx *cmd.Context) error {
 	command := exec.Command(c.name, c.args...)
-	command.Env = utils.Setenv(os.Environ(), osenv.JujuModelEnvKey+"="+c.ConnectionName())
+
+	// Ignore the error from ModelName - if we can't find the model
+	// we'll run the plugin anyway.
+	modelName, _ := c.ModelName()
+	command.Env = utils.Setenv(os.Environ(), osenv.JujuModelEnvKey+"="+modelName)
 
 	// Now hook up stdin, stdout, stderr
 	command.Stdin = ctx.Stdin

--- a/cmd/juju/commands/ssh_common.go
+++ b/cmd/juju/commands/ssh_common.go
@@ -273,6 +273,10 @@ func (c *SSHCommon) setProxyCommand(options *ssh.Options) error {
 		return errors.Errorf("failed to get juju executable path: %v", err)
 	}
 
+	modelName, err := c.ModelName()
+	if err != nil {
+		return errors.Trace(err)
+	}
 	// TODO(mjs) 2016-05-09 LP #1579592 - It would be good to check the
 	// host key of the controller machine being used for proxying
 	// here. This isn't too serious as all traffic passing through the
@@ -281,7 +285,7 @@ func (c *SSHCommon) setProxyCommand(options *ssh.Options) error {
 	// this extra level of checking.
 	options.SetProxyCommand(
 		juju, "ssh",
-		"--model="+c.ModelName(),
+		"--model="+modelName,
 		"--proxy=false",
 		"--no-host-key-checks",
 		"--pty=false",

--- a/cmd/juju/commands/ssh_common_test.go
+++ b/cmd/juju/commands/ssh_common_test.go
@@ -74,7 +74,7 @@ func (s *argsSpec) check(c *gc.C, output string) {
 
 	if s.withProxy {
 		expect("-o ProxyCommand juju ssh " +
-			"--model=controller " +
+			"--model=admin/controller " +
 			"--proxy=false " +
 			"--no-host-key-checks " +
 			"--pty=false ubuntu@localhost -q \"nc %h %p\"")

--- a/cmd/juju/commands/sshkeys_test.go
+++ b/cmd/juju/commands/sshkeys_test.go
@@ -99,7 +99,7 @@ func (s *ListKeysSuite) TestListKeys(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	output := strings.TrimSpace(cmdtesting.Stdout(context))
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(output, gc.Matches, "Keys used in model: controller\n.*\\(user@host\\)\n.*\\(another@host\\)")
+	c.Assert(output, gc.Matches, "Keys used in model: admin/controller\n.*\\(user@host\\)\n.*\\(another@host\\)")
 }
 
 func (s *ListKeysSuite) TestListFullKeys(c *gc.C) {
@@ -111,7 +111,7 @@ func (s *ListKeysSuite) TestListFullKeys(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	output := strings.TrimSpace(cmdtesting.Stdout(context))
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(output, gc.Matches, "Keys used in model: controller\n.*user@host\n.*another@host")
+	c.Assert(output, gc.Matches, "Keys used in model: admin/controller\n.*user@host\n.*another@host")
 }
 
 func (s *ListKeysSuite) TestTooManyArgs(c *gc.C) {

--- a/cmd/juju/controller/addmodel.go
+++ b/cmd/juju/controller/addmodel.go
@@ -165,6 +165,10 @@ func (c *addModelCommand) newAPIRoot() (api.Connection, error) {
 }
 
 func (c *addModelCommand) Run(ctx *cmd.Context) error {
+	controllerName, err := c.ControllerName()
+	if err != nil {
+		return errors.Trace(err)
+	}
 	api, err := c.newAPIRoot()
 	if err != nil {
 		return errors.Annotate(err, "opening API connection")
@@ -172,7 +176,6 @@ func (c *addModelCommand) Run(ctx *cmd.Context) error {
 	defer api.Close()
 
 	store := c.ClientStore()
-	controllerName := c.ControllerName()
 	accountDetails, err := store.AccountDetails(controllerName)
 	if err != nil {
 		return errors.Trace(err)
@@ -231,7 +234,6 @@ func (c *addModelCommand) Run(ctx *cmd.Context) error {
 	messageArgs := []interface{}{c.Name}
 
 	if modelOwner == accountDetails.User {
-		controllerName := c.ControllerName()
 		if err := store.UpdateModel(controllerName, c.Name, jujuclient.ModelDetails{
 			model.UUID,
 		}); err != nil {

--- a/cmd/juju/controller/export_test.go
+++ b/cmd/juju/controller/export_test.go
@@ -74,8 +74,12 @@ func NewListModelsCommandForTest(modelAPI ModelManagerAPI, sysAPI ModelsSysAPI, 
 
 // NewRegisterCommandForTest returns a RegisterCommand with the function used
 // to open the API connection mocked out.
-func NewRegisterCommandForTest(apiOpen api.OpenFunc, listModels func(jujuclient.ClientStore, string, string) ([]base.UserModel, error), store jujuclient.ClientStore) *registerCommand {
-	return &registerCommand{apiOpen: apiOpen, listModelsFunc: listModels, store: store}
+func NewRegisterCommandForTest(apiOpen api.OpenFunc, listModels func(jujuclient.ClientStore, string, string) ([]base.UserModel, error), store jujuclient.ClientStore) modelcmd.Command {
+	return modelcmd.WrapBase(&registerCommand{
+		apiOpen:        apiOpen,
+		listModelsFunc: listModels,
+		store:          store,
+	})
 }
 
 // NewEnableDestroyControllerCommandForTest returns a enableDestroyController with the

--- a/cmd/juju/controller/getconfig.go
+++ b/cmd/juju/controller/getconfig.go
@@ -86,6 +86,10 @@ func (c *getConfigCommand) getAPI() (controllerAPI, error) {
 }
 
 func (c *getConfigCommand) Run(ctx *cmd.Context) error {
+	controllerName, err := c.ControllerName()
+	if err != nil {
+		return errors.Trace(err)
+	}
 	client, err := c.getAPI()
 	if err != nil {
 		return err
@@ -107,7 +111,7 @@ func (c *getConfigCommand) Run(ctx *cmd.Context) error {
 			}
 			return c.out.Write(ctx, value)
 		}
-		return errors.Errorf("key %q not found in %q controller.", c.key, c.ControllerName())
+		return errors.Errorf("key %q not found in %q controller.", c.key, controllerName)
 	}
 	// If key is empty, write out the whole lot.
 	return c.out.Write(ctx, attrs)

--- a/cmd/juju/controller/kill.go
+++ b/cmd/juju/controller/kill.go
@@ -91,7 +91,10 @@ var errConnTimedOut = errors.New("open connection timed out")
 
 // Run implements Command.Run
 func (c *killCommand) Run(ctx *cmd.Context) error {
-	controllerName := c.ControllerName()
+	controllerName, err := c.ControllerName()
+	if err != nil {
+		return errors.Trace(err)
+	}
 	store := c.ClientStore()
 	if !c.assumeYes {
 		if err := confirmDestruction(ctx, controllerName); err != nil {

--- a/cmd/juju/controller/listmodels.go
+++ b/cmd/juju/controller/listmodels.go
@@ -129,7 +129,11 @@ type ModelSet struct {
 
 // Run implements Command.Run
 func (c *modelsCommand) Run(ctx *cmd.Context) error {
-	accountDetails, err := c.ClientStore().AccountDetails(c.ControllerName())
+	controllerName, err := c.ControllerName()
+	if err != nil {
+		return errors.Trace(err)
+	}
+	accountDetails, err := c.CurrentAccountDetails()
 	if err != nil {
 		return err
 	}
@@ -163,12 +167,12 @@ func (c *modelsCommand) Run(ctx *cmd.Context) error {
 		if err != nil {
 			return errors.Trace(err)
 		}
-		model.ControllerName = c.ControllerName()
+		model.ControllerName = controllerName
 		modelInfo = append(modelInfo, model)
 	}
 
 	modelSet := ModelSet{Models: modelInfo}
-	current, err := c.ClientStore().CurrentModel(c.ControllerName())
+	current, err := c.ClientStore().CurrentModel(controllerName)
 	if err != nil && !errors.IsNotFound(err) {
 		return err
 	}
@@ -268,7 +272,11 @@ func (c *modelsCommand) formatTabular(writer io.Writer, value interface{}) error
 
 	tw := output.TabWriter(writer)
 	w := output.Wrapper{tw}
-	w.Println("Controller: " + c.ControllerName())
+	controllerName, err := c.ControllerName()
+	if err != nil {
+		return errors.Trace(err)
+	}
+	w.Println("Controller: " + controllerName)
 	w.Println()
 	w.Print("Model")
 	if c.listUUID {

--- a/cmd/juju/controller/register_test.go
+++ b/cmd/juju/controller/register_test.go
@@ -87,10 +87,6 @@ func (s *RegisterSuite) TestInit(c *gc.C) {
 	err := cmdtesting.InitCommand(registerCommand, []string{})
 	c.Assert(err, gc.ErrorMatches, "registration data missing")
 
-	err = cmdtesting.InitCommand(registerCommand, []string{"foo"})
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(registerCommand.Arg, gc.Equals, "foo")
-
 	err = cmdtesting.InitCommand(registerCommand, []string{"foo", "bar"})
 	c.Assert(err, gc.ErrorMatches, `unrecognized args: \["bar"\]`)
 }
@@ -114,8 +110,8 @@ Enter a new password: »hunter2
 
 Confirm password: »hunter2
 
-Initial password successfully set for bob.
 Enter a name for this controller \[controller-name\]: »
+Initial password successfully set for bob.
 
 Welcome, bob. You are now logged into "controller-name".
 
@@ -146,8 +142,8 @@ Enter a new password: »hunter2
 
 Confirm password: »hunter2
 
-Initial password successfully set for bob.
 Enter a name for this controller \[controller-name\]: »
+Initial password successfully set for bob.
 
 Welcome, bob. You are now logged into "controller-name".
 
@@ -191,8 +187,8 @@ Enter a new password: »hunter2
 
 Confirm password: »hunter2
 
-Initial password successfully set for bob.
 Enter a name for this controller \[controller-name\]: »
+Initial password successfully set for bob.
 
 Welcome, bob. You are now logged into "controller-name".
 `[1:]+noModelsText)
@@ -260,7 +256,6 @@ Enter a new password: »hunter2
 
 Confirm password: »hunter2
 
-Initial password successfully set for bob.
 Enter a name for this controller: »
 You must specify a non-empty controller name.
 Enter a name for this controller: »
@@ -283,10 +278,10 @@ Enter a new password: »hunter2
 
 Confirm password: »hunter2
 
-Initial password successfully set for bob.
 Enter a name for this controller: »controller-name
 Controller "controller-name" already exists.
 Enter a name for this controller: »other-name
+Initial password successfully set for bob.
 
 Welcome, bob. You are now logged into "other-name".
 `[1:]+noModelsText)
@@ -324,6 +319,7 @@ Enter a new password: »hunter2
 
 Confirm password: »hunter2
 
+Enter a name for this controller: »foo
 Initial password successfully set for bob.
 `[1:])
 	err = s.run(c, prompter, registrationData)
@@ -353,10 +349,10 @@ Enter a new password: »hunter2
 
 Confirm password: »hunter2
 
-Initial password successfully set for bob.
 Enter a name for this controller: »controller-name
 Controller "controller-name" already exists.
 Enter a name for this controller: »other-name
+Initial password successfully set for bob.
 
 Welcome, bob. You are now logged into "other-name".
 
@@ -406,6 +402,7 @@ Enter a new password: »hunter2
 
 Confirm password: »hunter2
 
+Enter a name for this controller: »foo
 `[1:])
 	defer prompter.CheckDone()
 	s.apiOpenError = errors.New("open failed")
@@ -427,6 +424,8 @@ func (s *RegisterSuite) TestRegisterServerError(c *gc.C) {
 Enter a new password: »hunter2
 
 Confirm password: »hunter2
+
+Enter a name for this controller: »foo
 
 `[1:])
 
@@ -474,7 +473,11 @@ Welcome, bob@external. You are now logged into "public-controller-name".
 
 func (s *RegisterSuite) TestRegisterPublicAPIOpenError(c *gc.C) {
 	s.apiOpenError = errors.New("open failed")
-	err := s.run(c, noPrompts(c), "0.1.2.3")
+	prompter := cmdtesting.NewSeqPrompter(c, "»", `
+Enter a name for this controller: »public-controller-name
+`[1:])
+	defer prompter.CheckDone()
+	err := s.run(c, prompter, "0.1.2.3")
 	c.Assert(err, gc.ErrorMatches, `open failed`)
 }
 

--- a/cmd/juju/crossmodel/list.go
+++ b/cmd/juju/crossmodel/list.go
@@ -124,7 +124,10 @@ func (c *listCommand) Run(ctx *cmd.Context) (err error) {
 	}
 
 	// For now, all offers come from the one controller.
-	controllerName := c.ControllerName()
+	controllerName, err := c.ControllerName()
+	if err != nil {
+		return errors.Trace(err)
+	}
 	data, err := formatApplicationOfferDetails(controllerName, valid)
 	if err != nil {
 		return errors.Annotate(err, "failed to format found applications")

--- a/cmd/juju/gui/gui.go
+++ b/cmd/juju/gui/gui.go
@@ -97,15 +97,28 @@ func (c *guiCommand) Run(ctx *cmd.Context) error {
 	}
 	defer conn.Close()
 
-	store := modelcmd.QualifyingClientStore{c.ClientStore()}
-	details, err := store.ModelByName(c.ControllerName(), c.ModelName())
+	store, ok := c.ClientStore().(modelcmd.QualifyingClientStore)
+	if !ok {
+		store = modelcmd.QualifyingClientStore{c.ClientStore()}
+	}
+	controllerName, err := c.ControllerName()
+	if err != nil {
+		return errors.Trace(err)
+	}
+	modelName, err := c.ModelName()
+	if err != nil {
+		return errors.Trace(err)
+	}
+	// TODO(rog) It looks like this won't work if the model isn't locally
+	// cached already.
+	details, err := store.ModelByName(controllerName, modelName)
 	if err != nil {
 		return errors.Annotate(err, "cannot retrieve model details: please make sure you switched to a valid model")
 	}
 
 	// Make 2 URLs to try - the old and the new.
 	rawURL := fmt.Sprintf("https://%s/gui/%s/", conn.Addr(), details.ModelUUID)
-	qualifiedModelName, err := store.QualifiedModelName(c.ControllerName(), c.ModelName())
+	qualifiedModelName, err := store.QualifiedModelName(controllerName, modelName)
 	if err != nil {
 		return errors.Annotate(err, "cannot construct model name")
 	}
@@ -171,7 +184,11 @@ func (c *guiCommand) openBrowser(ctx *cmd.Context, rawURL string, vers *version.
 		if vers != nil {
 			versInfo = fmt.Sprintf("%v ", vers)
 		}
-		ctx.Infof("GUI %sfor model %q is enabled at:\n  %s", versInfo, c.ModelName(), u.String())
+		modelName, err := c.ModelName()
+		if err != nil {
+			return errors.Trace(err)
+		}
+		ctx.Infof("GUI %sfor model %q is enabled at:\n  %s", versInfo, modelName, u.String())
 		return nil
 	}
 	err = webbrowserOpen(u)
@@ -193,7 +210,7 @@ func (c *guiCommand) showCredentials(ctx *cmd.Context) error {
 		return nil
 	}
 	// TODO(wallyworld) - what to do if we are using a macaroon.
-	accountDetails, err := c.ClientStore().AccountDetails(c.ControllerName())
+	accountDetails, err := c.CurrentAccountDetails()
 	if err != nil {
 		return errors.Annotate(err, "cannot retrieve credentials")
 	}

--- a/cmd/juju/gui/gui_test.go
+++ b/cmd/juju/gui/gui_test.go
@@ -117,7 +117,7 @@ func (s *guiSuite) TestGUISuccessNoBrowser(c *gc.C) {
 	out, err := s.run(c, "--hide-credential")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(out, gc.Equals, fmt.Sprintf(`
-GUI 4.5.6 for model "controller" is enabled at:
+GUI 4.5.6 for model "admin/controller" is enabled at:
   %s`[1:], s.guiURL(c)))
 }
 
@@ -132,7 +132,7 @@ func (s *guiSuite) TestGUISuccessOldGUI(c *gc.C) {
 	out, err := s.run(c, "--hide-credential")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(out, gc.Equals, fmt.Sprintf(`
-GUI 4.5.6 for model "controller" is enabled at:
+GUI 4.5.6 for model "admin/controller" is enabled at:
   %s`[1:], s.guiOldURL(c)))
 }
 
@@ -142,7 +142,7 @@ func (s *guiSuite) TestGUISuccessNoBrowserDeprecated(c *gc.C) {
 	out, err := s.run(c, "--no-browser", "--hide-credential")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(out, gc.Equals, fmt.Sprintf(`
-GUI 4.5.6 for model "controller" is enabled at:
+GUI 4.5.6 for model "admin/controller" is enabled at:
   %s`[1:], s.guiURL(c)))
 }
 

--- a/cmd/juju/model/defaultscommand_test.go
+++ b/cmd/juju/model/defaultscommand_test.go
@@ -42,184 +42,179 @@ func (s *DefaultsCommandSuite) TestDefaultsInit(c *gc.C) {
 		args        []string
 		errorMatch  string
 		nilErr      bool
-	}{
-		{
-			// Test set
-			description: "test set key specified more than once",
-			args:        []string{"special=extra", "special=other"},
-			errorMatch:  `key "special" specified more than once`,
-		}, {
-			description: "test cannot set agent-version",
-			args:        []string{"agent-version=2.0.0"},
-			errorMatch:  `"agent-version" must be set via "upgrade-juju"`,
-		}, {
-			description: "test set multiple keys",
-			args:        []string{"foo=bar", "baz=eggs"},
-			nilErr:      true,
-		}, {
-			// Test reset
-			description: "test empty args with reset fails",
-			args:        []string{"--reset"},
-			errorMatch:  "flag needs an argument: --reset",
-		}, {
-			description: "test reset with positional arg interpereted as invalid region",
-			args:        []string{"--reset", "something", "weird"},
-			errorMatch:  `invalid region specified: "weird"`,
-		},
-		{
-			description: "test reset with valid region and duplicate key set",
-			args:        []string{"--reset", "something", "dummy-region", "something=weird"},
-			errorMatch:  `key "something" cannot be both set and unset in the same command`,
-		},
-		{
-			description: "test reset with valid region and extra positional arg",
-			args:        []string{"--reset", "something", "dummy-region", "weird"},
-			errorMatch:  "cannot retrieve defaults for a region and reset attributes at the same time",
-		}, {
-			description: "test reset with valid region only",
-			args:        []string{"--reset", "foo", "dummy-region"},
-			nilErr:      true,
-		}, {
-			description: "test cannot reset agent version",
-			args:        []string{"--reset", "agent-version"},
-			errorMatch:  `"agent-version" cannot be reset`,
-		}, {
-			description: "test reset inits",
-			args:        []string{"--reset", "foo"},
-			nilErr:      true,
-		}, {
-			description: "test trailing reset fails",
-			args:        []string{"foo=bar", "--reset"},
-			errorMatch:  "flag needs an argument: --reset",
-		}, {
-			description: "test reset and get init",
-			args:        []string{"--reset", "agent-version,b", "foo=bar"},
-			errorMatch:  `"agent-version" cannot be reset`,
-		}, {
-			description: "test reset with key=val fails",
-			args:        []string{"--reset", "foo=bar"},
-			errorMatch:  `--reset accepts a comma delimited set of keys "a,b,c", received: "foo=bar"`,
-		}, {
-			description: "test reset multiple with key=val fails",
-			args:        []string{"--reset", "a,foo=bar,b"},
-			errorMatch:  `--reset accepts a comma delimited set of keys "a,b,c", received: "foo=bar"`,
-		}, {
-			description: "test reset with two positional args fails expecting a region",
-			args:        []string{"--reset", "a", "b", "c"},
-			errorMatch:  `invalid region specified: "b"`,
-		}, {
-			description: "test reset with two positional args fails expecting a region reordered",
-			args:        []string{"a", "--reset", "b", "c"},
-			errorMatch:  `invalid region specified: "a"`,
-		}, {
-			description: "test multiple reset inits",
-			args:        []string{"--reset", "a", "--reset", "b"},
-			nilErr:      true,
-		}, {
-			description: "test multiple reset and set inits",
-			args:        []string{"--reset", "a", "b=c", "--reset", "d"},
-			nilErr:      true,
-		}, {
-			description: "test multiple reset with valid region inits",
-			args:        []string{"dummy-region", "--reset", "a", "--reset", "b"},
-			nilErr:      true,
-		}, {
-			description: "test multiple reset with two positional args fails expecting a region reordered",
-			args:        []string{"a", "--reset", "b", "--reset", "c", "d"},
-			errorMatch:  `invalid region specified: "a"`,
-		}, {
-			description: "test reset multiple with key=val fails",
-			args:        []string{"--reset", "a", "--reset", "b,foo=bar,c"},
-			errorMatch:  `--reset accepts a comma delimited set of keys "a,b,c", received: "foo=bar"`,
-		}, {
-			// test get
-			description: "test no args inits",
-			args:        nil,
-			nilErr:      true,
-		}, {
-			description: "one key arg inits",
-			args:        []string{"one"},
-			nilErr:      true,
-		}, {
-			description: "test two key args fails",
-			args:        []string{"one", "two"},
-			errorMatch:  "can only retrieve defaults for one key or all",
-		}, {
-			description: "test multiple key args fails",
-			args:        []string{"one", "two", "three"},
-			errorMatch:  "can only retrieve defaults for one key or all",
-		}, {
-			description: "test valid region and one arg",
-			args:        []string{"dummy-region", "one"},
-			nilErr:      true,
-		}, {
-			description: "test valid region and no args",
-			args:        []string{"dummy-region"},
-			nilErr:      true,
-		}, {
-			// test cloud/region
-			description: "test invalid cloud fails",
-			args:        []string{"invalidCloud/invalidRegion", "one=two"},
-			errorMatch:  "Unknown cloud",
-		}, {
-			description: "test valid cloud with invalid region fails",
-			args:        []string{"dummy/invalidRegion", "one=two"},
-			errorMatch:  `invalid region specified: "dummy/invalidRegion"`,
-		}, {
-			description: "test no cloud with invalid region fails",
-			args:        []string{"invalidRegion", "one=two"},
-			errorMatch:  `invalid region specified: "invalidRegion"`,
-		}, {
-			description: "test valid region with set arg succeeds",
-			args:        []string{"dummy-region", "one=two"},
-			nilErr:      true,
-		}, {
-			description: "test valid region with set and reset succeeds",
-			args:        []string{"dummy-region", "one=two", "--reset", "three"},
-			nilErr:      true,
-		}, {
-			description: "test reset and set with extra key is interpereted as invalid region",
-			args:        []string{"--reset", "something,else", "invalidRegion", "is=weird"},
-			errorMatch:  `invalid region specified: "invalidRegion"`,
-		}, {
-			description: "test reset and set with valid region and extra key fails",
-			args:        []string{"--reset", "something,else", "dummy-region", "invalidkey", "is=weird"},
-			errorMatch:  "cannot set and retrieve default values simultaneously",
-		}, {
-			// test various invalid
-			description: "test too many positional args with reset",
-			args:        []string{"--reset", "a", "b", "c", "d"},
-			errorMatch:  "invalid input",
-		}, {
-			description: "test too many positional args with invalid region set",
-			args:        []string{"a", "a=b", "b", "c=d"},
-			errorMatch:  `invalid region specified: "a"`,
-		}, {
-			description: "test invalid positional args with set",
-			args:        []string{"a=b", "b", "c=d"},
-			errorMatch:  `expected "key=value", got "b"`,
-		}, {
-			description: "test invalid positional args with set and trailing key",
-			args:        []string{"a=b", "c=d", "e"},
-			errorMatch:  "cannot set and retrieve default values simultaneously",
-		}, {
-			description: "test invalid positional args with valid region, set, reset",
-			args:        []string{"dummy-region", "a=b", "--reset", "c,d,", "e=f", "g"},
-			errorMatch:  "cannot set and retrieve default values simultaneously",
-		}, {
-			// Test some random orderings
-			description: "test invalid positional args with set, reset with trailing comman and split key=values",
-			args:        []string{"dummy-region", "a=b", "--reset", "c,d,", "e=f"},
-			nilErr:      true,
-		}, {
-			description: "test leading comma with reset",
-			args:        []string{"--reset", ",a,b"},
-			nilErr:      true,
-		},
-	} {
+	}{{
+		// Test set
+		description: "test set key specified more than once",
+		args:        []string{"special=extra", "special=other"},
+		errorMatch:  `key "special" specified more than once`,
+	}, {
+		description: "test cannot set agent-version",
+		args:        []string{"agent-version=2.0.0"},
+		errorMatch:  `"agent-version" must be set via "upgrade-juju"`,
+	}, {
+		description: "test set multiple keys",
+		args:        []string{"foo=bar", "baz=eggs"},
+		nilErr:      true,
+	}, {
+		// Test reset
+		description: "test empty args with reset fails",
+		args:        []string{"--reset"},
+		errorMatch:  "flag needs an argument: --reset",
+	}, {
+		description: "test reset with positional arg interpereted as invalid region",
+		args:        []string{"--reset", "something", "weird"},
+		errorMatch:  `invalid region specified: "weird"`,
+	}, {
+		description: "test reset with valid region and duplicate key set",
+		args:        []string{"--reset", "something", "dummy-region", "something=weird"},
+		errorMatch:  `key "something" cannot be both set and unset in the same command`,
+	}, {
+		description: "test reset with valid region and extra positional arg",
+		args:        []string{"--reset", "something", "dummy-region", "weird"},
+		errorMatch:  "cannot retrieve defaults for a region and reset attributes at the same time",
+	}, {
+		description: "test reset with valid region only",
+		args:        []string{"--reset", "foo", "dummy-region"},
+		nilErr:      true,
+	}, {
+		description: "test cannot reset agent version",
+		args:        []string{"--reset", "agent-version"},
+		errorMatch:  `"agent-version" cannot be reset`,
+	}, {
+		description: "test reset inits",
+		args:        []string{"--reset", "foo"},
+		nilErr:      true,
+	}, {
+		description: "test trailing reset fails",
+		args:        []string{"foo=bar", "--reset"},
+		errorMatch:  "flag needs an argument: --reset",
+	}, {
+		description: "test reset and get init",
+		args:        []string{"--reset", "agent-version,b", "foo=bar"},
+		errorMatch:  `"agent-version" cannot be reset`,
+	}, {
+		description: "test reset with key=val fails",
+		args:        []string{"--reset", "foo=bar"},
+		errorMatch:  `--reset accepts a comma delimited set of keys "a,b,c", received: "foo=bar"`,
+	}, {
+		description: "test reset multiple with key=val fails",
+		args:        []string{"--reset", "a,foo=bar,b"},
+		errorMatch:  `--reset accepts a comma delimited set of keys "a,b,c", received: "foo=bar"`,
+	}, {
+		description: "test reset with two positional args fails expecting a region",
+		args:        []string{"--reset", "a", "b", "c"},
+		errorMatch:  `invalid region specified: "b"`,
+	}, {
+		description: "test reset with two positional args fails expecting a region reordered",
+		args:        []string{"a", "--reset", "b", "c"},
+		errorMatch:  `invalid region specified: "a"`,
+	}, {
+		description: "test multiple reset inits",
+		args:        []string{"--reset", "a", "--reset", "b"},
+		nilErr:      true,
+	}, {
+		description: "test multiple reset and set inits",
+		args:        []string{"--reset", "a", "b=c", "--reset", "d"},
+		nilErr:      true,
+	}, {
+		description: "test multiple reset with valid region inits",
+		args:        []string{"dummy-region", "--reset", "a", "--reset", "b"},
+		nilErr:      true,
+	}, {
+		description: "test multiple reset with two positional args fails expecting a region reordered",
+		args:        []string{"a", "--reset", "b", "--reset", "c", "d"},
+		errorMatch:  `invalid region specified: "a"`,
+	}, {
+		description: "test reset multiple with key=val fails",
+		args:        []string{"--reset", "a", "--reset", "b,foo=bar,c"},
+		errorMatch:  `--reset accepts a comma delimited set of keys "a,b,c", received: "foo=bar"`,
+	}, {
+		// test get
+		description: "test no args inits",
+		args:        nil,
+		nilErr:      true,
+	}, {
+		description: "one key arg inits",
+		args:        []string{"attr"},
+		nilErr:      true,
+	}, {
+		description: "test two key args fails",
+		args:        []string{"one", "two"},
+		errorMatch:  "can only retrieve defaults for one key or all",
+	}, {
+		description: "test multiple key args fails",
+		args:        []string{"one", "two", "three"},
+		errorMatch:  "can only retrieve defaults for one key or all",
+	}, {
+		description: "test valid region and one arg",
+		args:        []string{"dummy-region", "attr2"},
+		nilErr:      true,
+	}, {
+		description: "test valid region and no args",
+		args:        []string{"dummy-region"},
+		nilErr:      true,
+	}, {
+		// test cloud/region
+		description: "test invalid cloud fails",
+		args:        []string{"invalidCloud/invalidRegion", "one=two"},
+		errorMatch:  "Unknown cloud",
+	}, {
+		description: "test valid cloud with invalid region fails",
+		args:        []string{"dummy/invalidRegion", "one=two"},
+		errorMatch:  `invalid region specified: "dummy/invalidRegion"`,
+	}, {
+		description: "test no cloud with invalid region fails",
+		args:        []string{"invalidRegion", "one=two"},
+		errorMatch:  `invalid region specified: "invalidRegion"`,
+	}, {
+		description: "test valid region with set arg succeeds",
+		args:        []string{"dummy-region", "one=two"},
+		nilErr:      true,
+	}, {
+		description: "test valid region with set and reset succeeds",
+		args:        []string{"dummy-region", "one=two", "--reset", "three"},
+		nilErr:      true,
+	}, {
+		description: "test reset and set with extra key is interpereted as invalid region",
+		args:        []string{"--reset", "something,else", "invalidRegion", "is=weird"},
+		errorMatch:  `invalid region specified: "invalidRegion"`,
+	}, {
+		description: "test reset and set with valid region and extra key fails",
+		args:        []string{"--reset", "something,else", "dummy-region", "invalidkey", "is=weird"},
+		errorMatch:  "cannot set and retrieve default values simultaneously",
+	}, {
+		// test various invalid
+		description: "test too many positional args with reset",
+		args:        []string{"--reset", "a", "b", "c", "d"},
+		errorMatch:  "invalid input",
+	}, {
+		description: "test too many positional args with invalid region set",
+		args:        []string{"a", "a=b", "b", "c=d"},
+		errorMatch:  `invalid region specified: "a"`,
+	}, {
+		description: "test invalid positional args with set",
+		args:        []string{"a=b", "b", "c=d"},
+		errorMatch:  `expected "key=value", got "b"`,
+	}, {
+		description: "test invalid positional args with set and trailing key",
+		args:        []string{"a=b", "c=d", "e"},
+		errorMatch:  "cannot set and retrieve default values simultaneously",
+	}, {
+		description: "test invalid positional args with valid region, set, reset",
+		args:        []string{"dummy-region", "a=b", "--reset", "c,d,", "e=f", "g"},
+		errorMatch:  "cannot set and retrieve default values simultaneously",
+	}, {
+		// Test some random orderings
+		description: "test invalid positional args with set, reset with trailing comman and split key=values",
+		args:        []string{"dummy-region", "a=b", "--reset", "c,d,", "e=f"},
+		nilErr:      true,
+	}, {
+		description: "test leading comma with reset",
+		args:        []string{"--reset", ",a,b"},
+		nilErr:      true,
+	}} {
 		c.Logf("test %d: %s", i, test.description)
-		cmd := model.NewDefaultsCommandForTest(s.fakeAPIRoot, s.fakeDefaultsAPI, s.fakeCloudAPI, s.store)
-		err := cmdtesting.InitCommand(cmd, test.args)
+		_, err := s.run(c, test.args...)
 		if test.nilErr {
 			c.Check(err, jc.ErrorIsNil)
 			continue

--- a/cmd/juju/model/destroy.go
+++ b/cmd/juju/model/destroy.go
@@ -120,7 +120,7 @@ func (c *destroyCommand) Init(args []string) error {
 	case 0:
 		return errors.New("no model specified")
 	case 1:
-		return c.SetModelName(args[0])
+		return c.SetModelName(args[0], false)
 	default:
 		return cmd.CheckEmpty(args[1:])
 	}
@@ -151,8 +151,14 @@ func (c *destroyCommand) getModelConfigAPI() (ModelConfigAPI, error) {
 // Run implements Command.Run
 func (c *destroyCommand) Run(ctx *cmd.Context) error {
 	store := c.ClientStore()
-	controllerName := c.ControllerName()
-	modelName := c.ModelName()
+	controllerName, err := c.ControllerName()
+	if err != nil {
+		return errors.Trace(err)
+	}
+	modelName, err := c.ModelName()
+	if err != nil {
+		return errors.Trace(err)
+	}
 
 	controllerDetails, err := store.ControllerByName(controllerName)
 	if err != nil {

--- a/cmd/juju/model/dump.go
+++ b/cmd/juju/model/dump.go
@@ -19,6 +19,7 @@ func NewDumpCommand() cmd.Command {
 }
 
 type dumpCommand struct {
+	// TODO(rog) change to use ModelCommandBase.
 	modelcmd.ControllerCommandBase
 	out cmd.Output
 	api DumpModelAPI
@@ -79,6 +80,10 @@ func (c *dumpCommand) getAPI() (DumpModelAPI, error) {
 
 // Run implements Command.
 func (c *dumpCommand) Run(ctx *cmd.Context) error {
+	controllerName, err := c.ControllerName()
+	if err != nil {
+		return errors.Trace(err)
+	}
 	client, err := c.getAPI()
 	if err != nil {
 		return err
@@ -87,16 +92,13 @@ func (c *dumpCommand) Run(ctx *cmd.Context) error {
 
 	store := c.ClientStore()
 	if c.model == "" {
-		c.model, err = store.CurrentModel(c.ControllerName())
+		c.model, err = store.CurrentModel(controllerName)
 		if err != nil {
 			return err
 		}
 	}
 
-	modelDetails, err := store.ModelByName(
-		c.ControllerName(),
-		c.model,
-	)
+	modelDetails, err := store.ModelByName(controllerName, c.model)
 	if err != nil {
 		return errors.Annotate(err, "getting model details")
 	}

--- a/cmd/juju/model/dumpdb.go
+++ b/cmd/juju/model/dumpdb.go
@@ -19,6 +19,7 @@ func NewDumpDBCommand() cmd.Command {
 }
 
 type dumpDBCommand struct {
+	// TODO(rog) change to use ModelCommandBase.
 	modelcmd.ControllerCommandBase
 	out cmd.Output
 	api DumpDBAPI
@@ -78,24 +79,27 @@ func (c *dumpDBCommand) getAPI() (DumpDBAPI, error) {
 
 // Run implements Command.
 func (c *dumpDBCommand) Run(ctx *cmd.Context) error {
+	controllerName, err := c.ControllerName()
+	if err != nil {
+		return errors.Trace(err)
+	}
+
 	client, err := c.getAPI()
 	if err != nil {
-		return err
+		return errors.Trace(err)
 	}
 	defer client.Close()
 
+	// TODO(rog) this could be taken care of by ModelCommandBase.
 	store := c.ClientStore()
 	if c.model == "" {
-		c.model, err = store.CurrentModel(c.ControllerName())
+		c.model, err = store.CurrentModel(controllerName)
 		if err != nil {
-			return err
+			return errors.Trace(err)
 		}
 	}
 
-	modelDetails, err := store.ModelByName(
-		c.ControllerName(),
-		c.model,
-	)
+	modelDetails, err := store.ModelByName(controllerName, c.model)
 	if err != nil {
 		return errors.Annotate(err, "getting model details")
 	}

--- a/cmd/juju/model/export_test.go
+++ b/cmd/juju/model/export_test.go
@@ -46,7 +46,7 @@ func NewRetryProvisioningCommandForTest(api RetryProvisioningAPI) cmd.Command {
 func NewShowCommandForTest(api ShowModelAPI, refreshFunc func(jujuclient.ClientStore, string) error, store jujuclient.ClientStore) cmd.Command {
 	cmd := &showModelCommand{api: api, RefreshModels: refreshFunc}
 	cmd.SetClientStore(store)
-	return modelcmd.Wrap(cmd)
+	return modelcmd.Wrap(cmd, modelcmd.WrapSkipModelFlags)
 }
 
 // NewDumpCommandForTest returns a DumpCommand with the api provided as specified.

--- a/cmd/juju/model/retryprovisioning_test.go
+++ b/cmd/juju/model/retryprovisioning_test.go
@@ -143,10 +143,10 @@ func (s *retryProvisioningSuite) TestRetryProvisioning(c *gc.C) {
 
 func (s *retryProvisioningSuite) TestBlockRetryProvisioning(c *gc.C) {
 	s.fake.err = common.OperationBlockedError("TestBlockRetryProvisioning")
-	command := model.NewRetryProvisioningCommandForTest(s.fake)
 
 	for i, t := range resolvedMachineTests {
 		c.Logf("test %d: %v", i, t.args)
+		command := model.NewRetryProvisioningCommandForTest(s.fake)
 		_, err := cmdtesting.RunCommand(c, command, t.args...)
 		if t.err != "" {
 			c.Check(err, gc.ErrorMatches, t.err)

--- a/cmd/juju/romulus/agree/agree.go
+++ b/cmd/juju/romulus/agree/agree.go
@@ -47,8 +47,8 @@ Examples:
 
 // NewAgreeCommand returns a new command that can be
 // used to create user agreements.
-func NewAgreeCommand() cmd.Command {
-	return modelcmd.WrapBase(&agreeCommand{})
+func NewAgreeCommand() modelcmd.ControllerCommand {
+	return modelcmd.WrapController(&agreeCommand{})
 }
 
 type term struct {
@@ -59,7 +59,7 @@ type term struct {
 
 // agreeCommand creates a user agreement to the specified terms.
 type agreeCommand struct {
-	modelcmd.CommandBase
+	modelcmd.ControllerCommandBase
 
 	terms           []term
 	termIds         []string

--- a/cmd/juju/romulus/agree/agree_test.go
+++ b/cmd/juju/romulus/agree/agree_test.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/juju/cmd"
 	"github.com/juju/cmd/cmdtesting"
 	"github.com/juju/terms-client/api"
 	"github.com/juju/terms-client/api/wireformat"
@@ -16,6 +17,7 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/cmd/juju/romulus/agree"
+	"github.com/juju/juju/jujuclient"
 	coretesting "github.com/juju/juju/testing"
 )
 
@@ -49,7 +51,7 @@ func (s *agreeSuite) TestAgreementNothingToSign(c *gc.C) {
 	s.client.user = "test-user"
 	s.client.setUnsignedTerms([]wireformat.GetTermsResponse{})
 
-	ctx, err := cmdtesting.RunCommand(c, agree.NewAgreeCommand(), "test-term/1")
+	ctx, err := s.runCommand(c, "test-term/1")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, `Already agreed
 `)
@@ -207,7 +209,7 @@ Do you agree to the displayed terms? (Y/n): Agreed to revision 1 of test-owner/t
 		if test.answer != "" {
 			answer = test.answer
 		}
-		ctx, err := cmdtesting.RunCommand(c, agree.NewAgreeCommand(), test.args...)
+		ctx, err := s.runCommand(c, test.args...)
 		if test.err != "" {
 			c.Assert(err, gc.ErrorMatches, test.err)
 		} else {
@@ -220,6 +222,12 @@ Do you agree to the displayed terms? (Y/n): Agreed to revision 1 of test-owner/t
 			s.client.CheckCalls(c, test.apiCalls)
 		}
 	}
+}
+
+func (s *agreeSuite) runCommand(c *gc.C, args ...string) (*cmd.Context, error) {
+	cmd := agree.NewAgreeCommand()
+	cmd.SetClientStore(newMockStore())
+	return cmdtesting.RunCommand(c, cmd, args...)
 }
 
 type mockClient struct {
@@ -264,4 +272,13 @@ func (c *mockClient) GetUnsignedTerms(p *wireformat.CheckAgreementsRequest) ([]w
 func (c *mockClient) GetUsersAgreements() ([]wireformat.AgreementResponse, error) {
 	c.MethodCall(c, "GetUsersAgreements")
 	return []wireformat.AgreementResponse{}, nil
+}
+
+func newMockStore() *jujuclient.MemStore {
+	store := jujuclient.NewMemStore()
+	store.CurrentControllerName = "foo"
+	store.Controllers["foo"] = jujuclient.ControllerDetails{
+		APIEndpoints: []string{"0.1.2.3:1234"},
+	}
+	return store
 }

--- a/cmd/juju/romulus/budget/budget.go
+++ b/cmd/juju/romulus/budget/budget.go
@@ -86,7 +86,15 @@ func (c *budgetCommand) getModelUUID() (string, error) {
 	if c.modelUUID != "" {
 		return c.modelUUID, nil
 	}
-	model, err := c.ClientStore().ModelByName(c.ControllerName(), c.ModelName())
+	modelName, err := c.ModelName()
+	if err != nil {
+		return "", errors.Trace(err)
+	}
+	controllerName, err := c.ControllerName()
+	if err != nil {
+		return "", errors.Trace(err)
+	}
+	model, err := c.ClientStore().ModelByName(controllerName, modelName)
 	if err != nil {
 		return "", errors.Trace(err)
 	}

--- a/cmd/juju/romulus/budget/budget_test.go
+++ b/cmd/juju/romulus/budget/budget_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/juju/cmd"
 	"github.com/juju/cmd/cmdtesting"
 	"github.com/juju/errors"
+	"github.com/juju/persistent-cookiejar"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils"
@@ -56,6 +57,7 @@ func (s *budgetSuite) SetUpTest(c *gc.C) {
 				User: "admin",
 			},
 		},
+		CookieJars: make(map[string]*cookiejar.Jar),
 	}
 	s.stub = &testing.Stub{}
 	s.mockAPI = newMockAPI(s.stub)

--- a/cmd/juju/romulus/createwallet/createwallet.go
+++ b/cmd/juju/romulus/createwallet/createwallet.go
@@ -16,14 +16,14 @@ import (
 )
 
 type createWalletCommand struct {
-	modelcmd.CommandBase
+	modelcmd.ControllerCommandBase
 	Name  string
 	Value string
 }
 
 // NewCreateWalletCommand returns a new createWalletCommand
-func NewCreateWalletCommand() cmd.Command {
-	return modelcmd.WrapBase(&createWalletCommand{})
+func NewCreateWalletCommand() modelcmd.ControllerCommand {
+	return modelcmd.WrapController(&createWalletCommand{})
 }
 
 const doc = `

--- a/cmd/juju/romulus/listagreements/listagreements.go
+++ b/cmd/juju/romulus/listagreements/listagreements.go
@@ -35,8 +35,8 @@ List terms the user has agreed to.
 
 // NewListAgreementsCommand returns a new command that can be
 // used to list agreements a user has made.
-func NewListAgreementsCommand() cmd.Command {
-	return modelcmd.WrapBase(&listAgreementsCommand{})
+func NewListAgreementsCommand() modelcmd.ControllerCommand {
+	return modelcmd.WrapController(&listAgreementsCommand{})
 }
 
 type term struct {
@@ -49,7 +49,7 @@ var _ cmd.Command = (*listAgreementsCommand)(nil)
 // listAgreementsCommand creates a user agreement to the specified
 // Terms and Conditions document.
 type listAgreementsCommand struct {
-	modelcmd.CommandBase
+	modelcmd.ControllerCommandBase
 	out cmd.Output
 }
 

--- a/cmd/juju/romulus/listplans/list_plans.go
+++ b/cmd/juju/romulus/listplans/list_plans.go
@@ -45,7 +45,7 @@ Examples:
 
 // ListPlansCommand retrieves plans that are available for the specified charm
 type ListPlansCommand struct {
-	modelcmd.CommandBase
+	modelcmd.ControllerCommandBase
 
 	out      cmd.Output
 	CharmURL string
@@ -54,8 +54,8 @@ type ListPlansCommand struct {
 }
 
 // NewListPlansCommand creates a new ListPlansCommand.
-func NewListPlansCommand() cmd.Command {
-	return modelcmd.WrapBase(&ListPlansCommand{
+func NewListPlansCommand() modelcmd.ControllerCommand {
+	return modelcmd.WrapController(&ListPlansCommand{
 		CharmResolver: rcmd.NewCharmStoreResolver(),
 	})
 }

--- a/cmd/juju/romulus/listwallets/list-wallets.go
+++ b/cmd/juju/romulus/listwallets/list-wallets.go
@@ -21,12 +21,12 @@ import (
 
 // NewListWalletsCommand returns a new command that is used
 // to list wallets a user has access to.
-func NewListWalletsCommand() cmd.Command {
-	return modelcmd.WrapBase(&listWalletsCommand{})
+func NewListWalletsCommand() modelcmd.ControllerCommand {
+	return modelcmd.WrapController(&listWalletsCommand{})
 }
 
 type listWalletsCommand struct {
-	modelcmd.CommandBase
+	modelcmd.ControllerCommandBase
 
 	out cmd.Output
 }

--- a/cmd/juju/romulus/setwallet/setwallet.go
+++ b/cmd/juju/romulus/setwallet/setwallet.go
@@ -16,14 +16,14 @@ import (
 )
 
 type setWalletCommand struct {
-	modelcmd.CommandBase
+	modelcmd.ControllerCommandBase
 	Name  string
 	Value string
 }
 
 // NewSetWalletCommand returns a new setWalletCommand.
-func NewSetWalletCommand() cmd.Command {
-	return modelcmd.WrapBase(&setWalletCommand{})
+func NewSetWalletCommand() modelcmd.ControllerCommand {
+	return modelcmd.WrapController(&setWalletCommand{})
 }
 
 const doc = `

--- a/cmd/juju/romulus/showwallet/show_wallet.go
+++ b/cmd/juju/romulus/showwallet/show_wallet.go
@@ -26,12 +26,12 @@ var logger = loggo.GetLogger("romulus.cmd.showwallet")
 
 // NewShowWalletCommand returns a new command that is used
 // to show details of the specified wireformat.
-func NewShowWalletCommand() cmd.Command {
-	return modelcmd.WrapBase(&showWalletCommand{})
+func NewShowWalletCommand() modelcmd.ControllerCommand {
+	return modelcmd.WrapController(&showWalletCommand{})
 }
 
 type showWalletCommand struct {
-	modelcmd.CommandBase
+	modelcmd.ControllerCommandBase
 
 	out    cmd.Output
 	wallet string

--- a/cmd/juju/romulus/showwallet/show_wallet_test.go
+++ b/cmd/juju/romulus/showwallet/show_wallet_test.go
@@ -4,6 +4,7 @@
 package showwallet_test
 
 import (
+	"github.com/juju/cmd"
 	"github.com/juju/cmd/cmdtesting"
 	"github.com/juju/errors"
 	"github.com/juju/romulus/wireformat/budget"
@@ -86,9 +87,7 @@ func (s *showWalletSuite) TestShowWalletCommand(c *gc.C) {
 		}
 		s.mockAPI.SetErrors(errs...)
 
-		showWallet := showwallet.NewShowWalletCommand()
-
-		ctx, err := cmdtesting.RunCommand(c, showWallet, test.args...)
+		ctx, err := s.runCommand(c, test.args...)
 		if test.err == "" {
 			c.Assert(err, jc.ErrorIsNil)
 			s.stub.CheckCalls(c, []testing.StubCall{
@@ -100,6 +99,21 @@ func (s *showWalletSuite) TestShowWalletCommand(c *gc.C) {
 			c.Assert(err, gc.ErrorMatches, test.err)
 		}
 	}
+}
+
+func (s *showWalletSuite) runCommand(c *gc.C, args ...string) (*cmd.Context, error) {
+	cmd := showwallet.NewShowWalletCommand()
+	cmd.SetClientStore(newMockStore())
+	return cmdtesting.RunCommand(c, cmd, args...)
+}
+
+func newMockStore() *jujuclient.MemStore {
+	store := jujuclient.NewMemStore()
+	store.CurrentControllerName = "foo"
+	store.Controllers["foo"] = jujuclient.ControllerDetails{
+		APIEndpoints: []string{"0.1.2.3:1234"},
+	}
+	return store
 }
 
 type mockAPI struct {

--- a/cmd/juju/romulus/sla/export_test.go
+++ b/cmd/juju/romulus/sla/export_test.go
@@ -4,7 +4,6 @@
 package sla
 
 import (
-	"github.com/juju/cmd"
 	"github.com/juju/romulus/api/sla"
 
 	"github.com/juju/juju/api"
@@ -18,7 +17,7 @@ var (
 )
 
 // NewSLACommandForTest returns an slaCommand with apis provided by the given arguments
-func NewSLACommandForTest(apiRoot api.Connection, slaC slaClient, authClient authorizationClient) cmd.Command {
+func NewSLACommandForTest(apiRoot api.Connection, slaC slaClient, authClient authorizationClient) modelcmd.ModelCommand {
 	cmd := &slaCommand{
 		newAPIRoot:   func() (api.Connection, error) { return apiRoot, nil },
 		newSLAClient: func(api.Connection) slaClient { return slaC },

--- a/cmd/juju/romulus/sla/sla_test.go
+++ b/cmd/juju/romulus/sla/sla_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/juju/juju/api"
 	"github.com/juju/juju/cmd/juju/romulus/sla"
+	"github.com/juju/juju/jujuclient"
 )
 
 func TestPackage(t *stdtesting.T) {
@@ -51,7 +52,21 @@ func (s *supportCommandSuite) SetUpTest(c *gc.C) {
 
 func (s *supportCommandSuite) run(c *gc.C, args ...string) (*cmd.Context, error) {
 	command := sla.NewSLACommandForTest(s.fakeAPIRoot, s.mockSLAClient, s.mockAPI)
+	command.SetClientStore(newMockStore())
 	return cmdtesting.RunCommand(c, command, args...)
+}
+
+func newMockStore() *jujuclient.MemStore {
+	store := jujuclient.NewMemStore()
+	store.CurrentControllerName = "foo"
+	store.Controllers["foo"] = jujuclient.ControllerDetails{
+		APIEndpoints: []string{"0.1.2.3:1234"},
+	}
+	store.Models["foo"] = &jujuclient.ControllerModels{
+		CurrentModel: "admin/bar",
+		Models:       map[string]jujuclient.ModelDetails{"admin/bar": {}},
+	}
+	return store
 }
 
 func (s supportCommandSuite) TestSupportCommand(c *gc.C) {

--- a/cmd/juju/space/add.go
+++ b/cmd/juju/space/add.go
@@ -17,12 +17,12 @@ import (
 )
 
 // NewAddCommand returns a command used to add a network space.
-func NewAddCommand() cmd.Command {
-	return modelcmd.Wrap(&addCommand{})
+func NewAddCommand() modelcmd.ModelCommand {
+	return modelcmd.Wrap(&AddCommand{})
 }
 
-// addCommand calls the API to add a new network space.
-type addCommand struct {
+// AddCommand calls the API to add a new network space.
+type AddCommand struct {
 	SpaceCommandBase
 	Name  string
 	CIDRs set.Strings
@@ -33,7 +33,7 @@ Adds a new space with the given name and associates the given
 (optional) list of existing subnet CIDRs with it.`
 
 // Info is defined on the cmd.Command interface.
-func (c *addCommand) Info() *cmd.Info {
+func (c *AddCommand) Info() *cmd.Info {
 	return &cmd.Info{
 		Name:    "add-space",
 		Args:    "<name> [<CIDR1> <CIDR2> ...]",
@@ -44,14 +44,14 @@ func (c *addCommand) Info() *cmd.Info {
 
 // Init is defined on the cmd.Command interface. It checks the
 // arguments for sanity and sets up the command to run.
-func (c *addCommand) Init(args []string) error {
+func (c *AddCommand) Init(args []string) error {
 	var err error
 	c.Name, c.CIDRs, err = ParseNameAndCIDRs(args, true)
 	return err
 }
 
 // Run implements Command.Run.
-func (c *addCommand) Run(ctx *cmd.Context) error {
+func (c *AddCommand) Run(ctx *cmd.Context) error {
 	return c.RunWithAPI(ctx, func(api SpaceAPI, ctx *cmd.Context) error {
 		// Prepare a nicer message and proper arguments to use in case
 		// there are not CIDRs given.

--- a/cmd/juju/space/add_test.go
+++ b/cmd/juju/space/add_test.go
@@ -20,8 +20,7 @@ var _ = gc.Suite(&AddSuite{})
 
 func (s *AddSuite) SetUpTest(c *gc.C) {
 	s.BaseSpaceSuite.SetUpTest(c)
-	s.command = space.NewAddCommandForTest(s.api)
-	c.Assert(s.command, gc.NotNil)
+	s.newCommand = space.NewAddCommand
 }
 
 func (s *AddSuite) TestRunWithoutSubnetsSucceeds(c *gc.C) {

--- a/cmd/juju/space/export_test.go
+++ b/cmd/juju/space/export_test.go
@@ -3,63 +3,14 @@
 
 package space
 
-import (
-	"github.com/juju/cmd"
-
-	"github.com/juju/juju/cmd/modelcmd"
-)
-
-func NewAddCommandForTest(api SpaceAPI) cmd.Command {
-	addCmd := &addCommand{
-		SpaceCommandBase: SpaceCommandBase{api: api},
-	}
-	return modelcmd.Wrap(addCmd)
-}
-
-type RemoveCommand struct {
-	*removeCommand
+func (base *SpaceCommandBase) SetAPI(api SpaceAPI) {
+	base.api = api
 }
 
 func (c *RemoveCommand) Name() string {
 	return c.name
 }
 
-func NewRemoveCommandForTest(api SpaceAPI) (cmd.Command, *RemoveCommand) {
-	removeCmd := &removeCommand{
-		SpaceCommandBase: SpaceCommandBase{api: api},
-	}
-	return modelcmd.Wrap(removeCmd), &RemoveCommand{removeCmd}
-}
-
-func NewUpdateCommandForTest(api SpaceAPI) cmd.Command {
-	updateCmd := &updateCommand{
-		SpaceCommandBase: SpaceCommandBase{api: api},
-	}
-	return modelcmd.Wrap(updateCmd)
-}
-
-type RenameCommand struct {
-	*renameCommand
-}
-
-func NewRenameCommandForTest(api SpaceAPI) (cmd.Command, *RenameCommand) {
-	renameCmd := &renameCommand{
-		SpaceCommandBase: SpaceCommandBase{api: api},
-	}
-	return modelcmd.Wrap(renameCmd), &RenameCommand{renameCmd}
-}
-
-type ListCommand struct {
-	*listCommand
-}
-
 func (c *ListCommand) ListFormat() string {
 	return c.out.Name()
-}
-
-func NewListCommandForTest(api SpaceAPI) (cmd.Command, *ListCommand) {
-	listCmd := &listCommand{
-		SpaceCommandBase: SpaceCommandBase{api: api},
-	}
-	return modelcmd.Wrap(listCmd), &ListCommand{listCmd}
 }

--- a/cmd/juju/space/list.go
+++ b/cmd/juju/space/list.go
@@ -20,12 +20,12 @@ import (
 )
 
 // NewListCommand returns a command used to list spaces.
-func NewListCommand() cmd.Command {
-	return modelcmd.Wrap(&listCommand{})
+func NewListCommand() modelcmd.ModelCommand {
+	return modelcmd.Wrap(&ListCommand{})
 }
 
 // listCommand displays a list of all spaces known to Juju.
-type listCommand struct {
+type ListCommand struct {
 	SpaceCommandBase
 	Short bool
 	out   cmd.Output
@@ -39,7 +39,7 @@ their subnets are displayed, otherwise just a list of spaces. The
 output to be redirected to a file. `
 
 // Info is defined on the cmd.Command interface.
-func (c *listCommand) Info() *cmd.Info {
+func (c *ListCommand) Info() *cmd.Info {
 	return &cmd.Info{
 		Name:    "spaces",
 		Args:    "[--short] [--format yaml|json] [--output <path>]",
@@ -50,7 +50,7 @@ func (c *listCommand) Info() *cmd.Info {
 }
 
 // SetFlags is defined on the cmd.Command interface.
-func (c *listCommand) SetFlags(f *gnuflag.FlagSet) {
+func (c *ListCommand) SetFlags(f *gnuflag.FlagSet) {
 	c.SpaceCommandBase.SetFlags(f)
 	c.out.AddFlags(f, "tabular", map[string]cmd.Formatter{
 		"yaml":    cmd.FormatYaml,
@@ -62,7 +62,7 @@ func (c *listCommand) SetFlags(f *gnuflag.FlagSet) {
 
 // Init is defined on the cmd.Command interface. It checks the
 // arguments for sanity and sets up the command to run.
-func (c *listCommand) Init(args []string) error {
+func (c *ListCommand) Init(args []string) error {
 	// No arguments are accepted, just flags.
 	if err := cmd.CheckEmpty(args); err != nil {
 		return errors.Trace(err)
@@ -72,7 +72,7 @@ func (c *listCommand) Init(args []string) error {
 }
 
 // Run implements Command.Run.
-func (c *listCommand) Run(ctx *cmd.Context) error {
+func (c *ListCommand) Run(ctx *cmd.Context) error {
 	return c.RunWithAPI(ctx, func(api SpaceAPI, ctx *cmd.Context) error {
 		spaces, err := api.ListSpaces()
 		if err != nil {
@@ -139,7 +139,7 @@ func (c *listCommand) Run(ctx *cmd.Context) error {
 }
 
 // printTabular prints the list of spaces in tabular format
-func (c *listCommand) printTabular(writer io.Writer, value interface{}) error {
+func (c *ListCommand) printTabular(writer io.Writer, value interface{}) error {
 	tw := output.TabWriter(writer)
 	if c.Short {
 		list, ok := value.(formattedShortList)

--- a/cmd/juju/space/package_test.go
+++ b/cmd/juju/space/package_test.go
@@ -16,7 +16,9 @@ import (
 
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/cmd/juju/space"
+	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/feature"
+	"github.com/juju/juju/jujuclient"
 	coretesting "github.com/juju/juju/testing"
 )
 
@@ -29,8 +31,8 @@ type BaseSpaceSuite struct {
 	coretesting.FakeJujuXDGDataHomeSuite
 	coretesting.BaseSuite
 
-	command cmd.Command
-	api     *StubAPI
+	newCommand func() modelcmd.ModelCommand
+	api        *StubAPI
 }
 
 var _ = gc.Suite(&BaseSpaceSuite{})
@@ -60,7 +62,7 @@ func (s *BaseSpaceSuite) SetUpTest(c *gc.C) {
 	c.Assert(s.api, gc.NotNil)
 
 	// All subcommand suites embedding this one should initialize
-	// s.command immediately after calling this method!
+	// s.newCommand immediately after calling this method!
 }
 
 func (s *BaseSpaceSuite) TearDownTest(c *gc.C) {
@@ -68,18 +70,33 @@ func (s *BaseSpaceSuite) TearDownTest(c *gc.C) {
 	s.BaseSuite.TearDownTest(c)
 }
 
-// RunCommand executes the s.command subcommand passing any args
-// and returning the stdout and stderr output as strings, as well as
-// any error.
+// InitCommand creates a command with s.newCommand and runs its
+// Init method only. It returns the inner command and any error.
+func (s *BaseSpaceSuite) InitCommand(c *gc.C, args ...string) (cmd.Command, error) {
+	cmd := s.newCommandForTest()
+	err := cmdtesting.InitCommand(cmd, args)
+	return modelcmd.InnerCommand(cmd), err
+}
+
+// RunCommand creates a command with s.newCommand and executes it,
+// passing any args and returning the stdout and stderr output as
+// strings, as well as any error.
 func (s *BaseSpaceSuite) RunCommand(c *gc.C, args ...string) (string, string, error) {
-	if s.command == nil {
-		panic("subcommand is nil")
-	}
-	ctx, err := cmdtesting.RunCommand(c, s.command, args...)
-	if ctx != nil {
-		return cmdtesting.Stdout(ctx), cmdtesting.Stderr(ctx), err
-	}
-	return "", "", err
+	cmd := s.newCommandForTest()
+	ctx, err := cmdtesting.RunCommand(c, cmd, args...)
+	return cmdtesting.Stdout(ctx), cmdtesting.Stderr(ctx), err
+}
+
+func (s *BaseSpaceSuite) newCommandForTest() modelcmd.ModelCommand {
+	cmd := s.newCommand()
+	// The client store shouldn't be used, but mock it
+	// out to make sure.
+	cmd.SetClientStore(jujuclient.NewMemStore())
+	cmd1 := modelcmd.InnerCommand(cmd).(interface {
+		SetAPI(space.SpaceAPI)
+	})
+	cmd1.SetAPI(s.api)
+	return cmd
 }
 
 // AssertRunSpacesNotSupported is a shortcut for calling RunCommand with the

--- a/cmd/juju/space/remove.go
+++ b/cmd/juju/space/remove.go
@@ -14,12 +14,12 @@ import (
 )
 
 // NewRemoveCommand returns a command used to remove a space.
-func NewRemoveCommand() cmd.Command {
-	return modelcmd.Wrap(&removeCommand{})
+func NewRemoveCommand() modelcmd.ModelCommand {
+	return modelcmd.Wrap(&RemoveCommand{})
 }
 
-// removeCommand calls the API to remove an existing network space.
-type removeCommand struct {
+// RemoveCommand calls the API to remove an existing network space.
+type RemoveCommand struct {
 	SpaceCommandBase
 	name string
 }
@@ -30,7 +30,7 @@ associated with the space will be transfered to the default space.
 `
 
 // Info is defined on the cmd.Command interface.
-func (c *removeCommand) Info() *cmd.Info {
+func (c *RemoveCommand) Info() *cmd.Info {
 	return &cmd.Info{
 		Name:    "remove-space",
 		Args:    "<name>",
@@ -41,7 +41,7 @@ func (c *removeCommand) Info() *cmd.Info {
 
 // Init is defined on the cmd.Command interface. It checks the
 // arguments for sanity and sets up the command to run.
-func (c *removeCommand) Init(args []string) (err error) {
+func (c *RemoveCommand) Init(args []string) (err error) {
 	defer errors.DeferredAnnotatef(&err, "invalid arguments specified")
 
 	// Validate given name.
@@ -58,7 +58,7 @@ func (c *removeCommand) Init(args []string) (err error) {
 }
 
 // Run implements Command.Run.
-func (c *removeCommand) Run(ctx *cmd.Context) error {
+func (c *RemoveCommand) Run(ctx *cmd.Context) error {
 	return c.RunWithAPI(ctx, func(api SpaceAPI, ctx *cmd.Context) error {
 		// Remove the space.
 		err := api.RemoveSpace(c.name)

--- a/cmd/juju/space/remove_test.go
+++ b/cmd/juju/space/remove_test.go
@@ -4,7 +4,6 @@
 package space_test
 
 import (
-	"github.com/juju/cmd/cmdtesting"
 	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
@@ -22,8 +21,7 @@ var _ = gc.Suite(&RemoveSuite{})
 func (s *RemoveSuite) SetUpTest(c *gc.C) {
 	s.BaseSuite.SetFeatureFlags(feature.PostNetCLIMVP)
 	s.BaseSpaceSuite.SetUpTest(c)
-	s.command, _ = space.NewRemoveCommandForTest(s.api)
-	c.Assert(s.command, gc.NotNil)
+	s.newCommand = space.NewRemoveCommand
 }
 
 func (s *RemoveSuite) TestInit(c *gc.C) {
@@ -50,18 +48,15 @@ func (s *RemoveSuite) TestInit(c *gc.C) {
 		expectName: "myspace",
 	}} {
 		c.Logf("test #%d: %s", i, test.about)
-		// Create a new instance of the subcommand for each test, but
-		// since we're not running the command no need to use
-		// modelcmd.Wrap().
-		wrappedCommand, command := space.NewRemoveCommandForTest(s.api)
-		err := cmdtesting.InitCommand(wrappedCommand, test.args)
+		command, err := s.InitCommand(c, test.args...)
 		if test.expectErr != "" {
 			prefixedErr := "invalid arguments specified: " + test.expectErr
 			c.Check(err, gc.ErrorMatches, prefixedErr)
 		} else {
 			c.Check(err, jc.ErrorIsNil)
+			command := command.(*space.RemoveCommand)
+			c.Check(command.Name(), gc.Equals, test.expectName)
 		}
-		c.Check(command.Name(), gc.Equals, test.expectName)
 		// No API calls should be recorded at this stage.
 		s.api.CheckCallNames(c)
 	}

--- a/cmd/juju/space/rename.go
+++ b/cmd/juju/space/rename.go
@@ -15,12 +15,12 @@ import (
 )
 
 // NewRenameCommand returns a command used to rename an existing space.
-func NewRenameCommand() cmd.Command {
-	return modelcmd.Wrap(&renameCommand{})
+func NewRenameCommand() modelcmd.ModelCommand {
+	return modelcmd.Wrap(&RenameCommand{})
 }
 
-// renameCommand calls the API to rename an existing network space.
-type renameCommand struct {
+// RenameCommand calls the API to rename an existing network space.
+type RenameCommand struct {
 	SpaceCommandBase
 	Name    string
 	NewName string
@@ -31,13 +31,13 @@ Renames an existing space from "old-name" to "new-name". Does not change the
 associated subnets and "new-name" must not match another existing space.
 `
 
-func (c *renameCommand) SetFlags(f *gnuflag.FlagSet) {
+func (c *RenameCommand) SetFlags(f *gnuflag.FlagSet) {
 	c.SpaceCommandBase.SetFlags(f)
 	f.StringVar(&c.NewName, "rename", "", "the new name for the network space")
 }
 
 // Info is defined on the cmd.Command interface.
-func (c *renameCommand) Info() *cmd.Info {
+func (c *RenameCommand) Info() *cmd.Info {
 	return &cmd.Info{
 		Name:    "rename-space",
 		Args:    "<old-name> <new-name>",
@@ -48,7 +48,7 @@ func (c *renameCommand) Info() *cmd.Info {
 
 // Init is defined on the cmd.Command interface. It checks the
 // arguments for sanity and sets up the command to run.
-func (c *renameCommand) Init(args []string) (err error) {
+func (c *RenameCommand) Init(args []string) (err error) {
 	defer errors.DeferredAnnotatef(&err, "invalid arguments specified")
 
 	switch len(args) {
@@ -73,7 +73,7 @@ func (c *renameCommand) Init(args []string) (err error) {
 }
 
 // Run implements Command.Run.
-func (c *renameCommand) Run(ctx *cmd.Context) error {
+func (c *RenameCommand) Run(ctx *cmd.Context) error {
 	return c.RunWithAPI(ctx, func(api SpaceAPI, ctx *cmd.Context) error {
 		err := api.RenameSpace(c.Name, c.NewName)
 		if err != nil {

--- a/cmd/juju/space/rename_test.go
+++ b/cmd/juju/space/rename_test.go
@@ -4,7 +4,6 @@
 package space_test
 
 import (
-	"github.com/juju/cmd/cmdtesting"
 	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
@@ -22,8 +21,7 @@ var _ = gc.Suite(&RenameSuite{})
 func (s *RenameSuite) SetUpTest(c *gc.C) {
 	s.BaseSuite.SetFeatureFlags(feature.PostNetCLIMVP)
 	s.BaseSpaceSuite.SetUpTest(c)
-	s.command, _ = space.NewRenameCommandForTest(s.api)
-	c.Assert(s.command, gc.NotNil)
+	s.newCommand = space.NewRenameCommand
 }
 
 func (s *RenameSuite) TestInit(c *gc.C) {
@@ -75,19 +73,16 @@ func (s *RenameSuite) TestInit(c *gc.C) {
 		expectNewName: "another-space",
 	}} {
 		c.Logf("test #%d: %s", i, test.about)
-		// Create a new instance of the subcommand for each test, but
-		// since we're not running the command no need to use
-		// modelcmd.Wrap().
-		wrappedCommand, command := space.NewRenameCommandForTest(s.api) // surely can use s.command??
-		err := cmdtesting.InitCommand(wrappedCommand, test.args)
+		command, err := s.InitCommand(c, test.args...)
 		if test.expectErr != "" {
 			prefixedErr := "invalid arguments specified: " + test.expectErr
 			c.Check(err, gc.ErrorMatches, prefixedErr)
 		} else {
 			c.Check(err, jc.ErrorIsNil)
+			command := command.(*space.RenameCommand)
+			c.Check(command.Name, gc.Equals, test.expectName)
+			c.Check(command.NewName, gc.Equals, test.expectNewName)
 		}
-		c.Check(command.Name, gc.Equals, test.expectName)
-		c.Check(command.NewName, gc.Equals, test.expectNewName)
 		// No API calls should be recorded at this stage.
 		s.api.CheckCallNames(c)
 	}

--- a/cmd/juju/space/update.go
+++ b/cmd/juju/space/update.go
@@ -14,12 +14,12 @@ import (
 )
 
 // NewUpdateCommand returns a command used to update subnets in a space.
-func NewUpdateCommand() cmd.Command {
-	return modelcmd.Wrap(&updateCommand{})
+func NewUpdateCommand() modelcmd.ModelCommand {
+	return modelcmd.Wrap(&UpdateCommand{})
 }
 
-// updateCommand calls the API to update an existing network space.
-type updateCommand struct {
+// UpdateCommand calls the API to update an existing network space.
+type UpdateCommand struct {
 	SpaceCommandBase
 	Name  string
 	CIDRs set.Strings
@@ -32,7 +32,7 @@ CIDRs) "leave" their current space and "enter" the one we're updating.
 `
 
 // Info is defined on the cmd.Command interface.
-func (c *updateCommand) Info() *cmd.Info {
+func (c *UpdateCommand) Info() *cmd.Info {
 	return &cmd.Info{
 		Name:    "update-space",
 		Args:    "<name> <CIDR1> [ <CIDR2> ...]",
@@ -43,14 +43,14 @@ func (c *updateCommand) Info() *cmd.Info {
 
 // Init is defined on the cmd.Command interface. It checks the
 // arguments for sanity and sets up the command to run.
-func (c *updateCommand) Init(args []string) error {
+func (c *UpdateCommand) Init(args []string) error {
 	var err error
 	c.Name, c.CIDRs, err = ParseNameAndCIDRs(args, false)
 	return errors.Trace(err)
 }
 
 // Run implements Command.Run.
-func (c *updateCommand) Run(ctx *cmd.Context) error {
+func (c *UpdateCommand) Run(ctx *cmd.Context) error {
 	return c.RunWithAPI(ctx, func(api SpaceAPI, ctx *cmd.Context) error {
 		// Update the space.
 		err := api.UpdateSpace(c.Name, c.CIDRs.SortedValues())

--- a/cmd/juju/space/update_test.go
+++ b/cmd/juju/space/update_test.go
@@ -20,8 +20,7 @@ var _ = gc.Suite(&UpdateSuite{})
 func (s *UpdateSuite) SetUpTest(c *gc.C) {
 	s.BaseSuite.SetFeatureFlags(feature.PostNetCLIMVP)
 	s.BaseSpaceSuite.SetUpTest(c)
-	s.command = space.NewUpdateCommandForTest(s.api)
-	c.Assert(s.command, gc.NotNil)
+	s.newCommand = space.NewUpdateCommand
 }
 
 func (s *UpdateSuite) TestRunWithSubnetsSucceeds(c *gc.C) {

--- a/cmd/juju/status/status.go
+++ b/cmd/juju/status/status.go
@@ -144,7 +144,7 @@ func (c *statusCommand) Run(ctx *cmd.Context) error {
 	if err != nil {
 		if status == nil {
 			// Status call completely failed, there is nothing to report
-			return err
+			return errors.Trace(err)
 		}
 		// Display any error, but continue to print status if some was returned
 		fmt.Fprintf(ctx.Stderr, "%v\n", err)
@@ -152,10 +152,14 @@ func (c *statusCommand) Run(ctx *cmd.Context) error {
 		return errors.Errorf("unable to obtain the current status")
 	}
 
-	formatter := newStatusFormatter(status, c.ControllerName(), c.isoTime)
+	controllerName, err := c.ControllerName()
+	if err != nil {
+		return errors.Trace(err)
+	}
+	formatter := newStatusFormatter(status, controllerName, c.isoTime)
 	formatted, err := formatter.format()
 	if err != nil {
-		return err
+		return errors.Trace(err)
 	}
 	return c.out.Write(ctx, formatted)
 }

--- a/cmd/juju/subnet/add.go
+++ b/cmd/juju/subnet/add.go
@@ -17,12 +17,12 @@ import (
 )
 
 // NewAddCommand returns a command used to add an existing subnet to Juju.
-func NewAddCommand() cmd.Command {
-	return modelcmd.Wrap(&addCommand{})
+func NewAddCommand() modelcmd.ModelCommand {
+	return modelcmd.Wrap(&AddCommand{})
 }
 
-// addCommand calls the API to add an existing subnet to Juju.
-type addCommand struct {
+// AddCommand calls the API to add an existing subnet to Juju.
+type AddCommand struct {
 	SubnetCommandBase
 
 	CIDR       names.SubnetTag
@@ -51,7 +51,7 @@ zone(s) is required.
 `
 
 // Info is defined on the cmd.Command interface.
-func (c *addCommand) Info() *cmd.Info {
+func (c *AddCommand) Info() *cmd.Info {
 	return &cmd.Info{
 		Name:    "add-subnet",
 		Args:    "<CIDR>|<provider-id> <space> [<zone1> <zone2> ...]",
@@ -62,7 +62,7 @@ func (c *addCommand) Info() *cmd.Info {
 
 // Init is defined on the cmd.Command interface. It checks the
 // arguments for sanity and sets up the command to run.
-func (c *addCommand) Init(args []string) (err error) {
+func (c *AddCommand) Init(args []string) (err error) {
 	defer errors.DeferredAnnotatef(&err, "invalid arguments specified")
 
 	// Ensure we have 2 or more arguments.
@@ -97,7 +97,7 @@ func (c *addCommand) Init(args []string) (err error) {
 }
 
 // Run implements Command.Run.
-func (c *addCommand) Run(ctx *cmd.Context) error {
+func (c *AddCommand) Run(ctx *cmd.Context) error {
 	return c.RunWithAPI(ctx, func(api SubnetAPI, ctx *cmd.Context) error {
 		if c.CIDR.Id() != "" && c.RawCIDR != c.CIDR.Id() {
 			ctx.Infof(

--- a/cmd/juju/subnet/add_test.go
+++ b/cmd/juju/subnet/add_test.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/juju/cmd/cmdtesting"
 	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
@@ -26,8 +25,7 @@ var _ = gc.Suite(&AddSuite{})
 
 func (s *AddSuite) SetUpTest(c *gc.C) {
 	s.BaseSubnetSuite.SetUpTest(c)
-	s.command, _ = subnet.NewAddCommandForTest(s.api)
-	c.Assert(s.command, gc.NotNil)
+	s.newCommand = subnet.NewAddCommand
 }
 
 func (s *AddSuite) TestInit(c *gc.C) {
@@ -92,16 +90,13 @@ func (s *AddSuite) TestInit(c *gc.C) {
 		expectErr:        `"%inv\$alid" is not a valid space name`,
 	}} {
 		c.Logf("test #%d: %s", i, test.about)
-		// Create a new instance of the subcommand for each test, but
-		// since we're not running the command no need to use
-		// modelcmd.Wrap().
-		wrappedCommand, command := subnet.NewAddCommandForTest(s.api)
-		err := cmdtesting.InitCommand(wrappedCommand, test.args)
+		command, err := s.InitCommand(c, test.args...)
 		if test.expectErr != "" {
 			prefixedErr := "invalid arguments specified: " + test.expectErr
 			c.Check(err, gc.ErrorMatches, prefixedErr)
 		} else {
 			c.Check(err, jc.ErrorIsNil)
+			command := command.(*subnet.AddCommand)
 			c.Check(command.CIDR.Id(), gc.Equals, test.expectCIDR)
 			c.Check(command.RawCIDR, gc.Equals, test.expectRawCIDR)
 			c.Check(command.ProviderId, gc.Equals, test.expectProviderId)

--- a/cmd/juju/subnet/create.go
+++ b/cmd/juju/subnet/create.go
@@ -16,12 +16,12 @@ import (
 )
 
 // NewCreateCommand returns a command to create a new subnet.
-func NewCreateCommand() cmd.Command {
-	return modelcmd.Wrap(&createCommand{})
+func NewCreateCommand() modelcmd.ModelCommand {
+	return modelcmd.Wrap(&CreateCommand{})
 }
 
-// createCommand calls the API to create a new subnet.
-type createCommand struct {
+// CreateCommand calls the API to create a new subnet.
+type CreateCommand struct {
 	SubnetCommandBase
 
 	CIDR      names.SubnetTag
@@ -60,7 +60,7 @@ supported.
 `
 
 // Info is defined on the cmd.Command interface.
-func (c *createCommand) Info() *cmd.Info {
+func (c *CreateCommand) Info() *cmd.Info {
 	return &cmd.Info{
 		Name:    "create-subnet",
 		Args:    "<CIDR> <space> <zone1> [<zone2> <zone3> ...] [--public|--private]",
@@ -70,7 +70,7 @@ func (c *createCommand) Info() *cmd.Info {
 }
 
 // SetFlags is defined on the cmd.Command interface.
-func (c *createCommand) SetFlags(f *gnuflag.FlagSet) {
+func (c *CreateCommand) SetFlags(f *gnuflag.FlagSet) {
 	c.SubnetCommandBase.SetFlags(f)
 	f.BoolVar(&c.IsPublic, "public", false, "enable public access with shadow addresses")
 	f.BoolVar(&c.IsPrivate, "private", true, "disable public access with shadow addresses")
@@ -84,7 +84,7 @@ func (c *createCommand) SetFlags(f *gnuflag.FlagSet) {
 
 // Init is defined on the cmd.Command interface. It checks the
 // arguments for sanity and sets up the command to run.
-func (c *createCommand) Init(args []string) error {
+func (c *CreateCommand) Init(args []string) error {
 	// Ensure we have at least 3 arguments.
 	// TODO:(mfoord) we need to support VLANTag as an additional optional
 	// argument.
@@ -140,7 +140,7 @@ func (c *createCommand) Init(args []string) error {
 }
 
 // Run implements Command.Run.
-func (c *createCommand) Run(ctx *cmd.Context) error {
+func (c *CreateCommand) Run(ctx *cmd.Context) error {
 	return c.RunWithAPI(ctx, func(api SubnetAPI, ctx *cmd.Context) error {
 		if !c.Zones.IsEmpty() {
 			// Fetch all zones to validate the given zones.

--- a/cmd/juju/subnet/create_test.go
+++ b/cmd/juju/subnet/create_test.go
@@ -4,7 +4,6 @@
 package subnet_test
 
 import (
-	"github.com/juju/cmd/cmdtesting"
 	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
@@ -23,8 +22,7 @@ var _ = gc.Suite(&CreateSuite{})
 func (s *CreateSuite) SetUpTest(c *gc.C) {
 	s.BaseSubnetSuite.SetFeatureFlags(feature.PostNetCLIMVP)
 	s.BaseSubnetSuite.SetUpTest(c)
-	s.command, _ = subnet.NewCreateCommandForTest(s.api)
-	c.Assert(s.command, gc.NotNil)
+	s.newCommand = subnet.NewCreateCommand
 }
 
 func (s *CreateSuite) TestInit(c *gc.C) {
@@ -122,15 +120,12 @@ func (s *CreateSuite) TestInit(c *gc.C) {
 		expectErr:     "",
 	}} {
 		c.Logf("test #%d: %s", i, test.about)
-		// Create a new instance of the subcommand for each test, but
-		// since we're not running the command no need to use
-		// modelcmd.Wrap().
-		wrappedCommand, command := subnet.NewCreateCommandForTest(s.api)
-		err := cmdtesting.InitCommand(wrappedCommand, test.args)
+		command, err := s.InitCommand(c, test.args...)
 		if test.expectErr != "" {
 			c.Check(err, gc.ErrorMatches, test.expectErr)
 		} else {
 			c.Check(err, jc.ErrorIsNil)
+			command := command.(*subnet.CreateCommand)
 			c.Check(command.CIDR.Id(), gc.Equals, test.expectCIDR)
 			c.Check(command.Space.Id(), gc.Equals, test.expectSpace)
 			c.Check(command.Zones.SortedValues(), jc.DeepEquals, test.expectZones)

--- a/cmd/juju/subnet/export_test.go
+++ b/cmd/juju/subnet/export_test.go
@@ -3,52 +3,6 @@
 
 package subnet
 
-import (
-	"github.com/juju/cmd"
-
-	"github.com/juju/juju/cmd/modelcmd"
-)
-
-type CreateCommand struct {
-	*createCommand
-}
-
-func NewCreateCommandForTest(api SubnetAPI) (cmd.Command, *CreateCommand) {
-	cmd := &createCommand{
-		SubnetCommandBase: SubnetCommandBase{api: api},
-	}
-	return modelcmd.Wrap(cmd), &CreateCommand{cmd}
-}
-
-type AddCommand struct {
-	*addCommand
-}
-
-func NewAddCommandForTest(api SubnetAPI) (cmd.Command, *AddCommand) {
-	cmd := &addCommand{
-		SubnetCommandBase: SubnetCommandBase{api: api},
-	}
-	return modelcmd.Wrap(cmd), &AddCommand{cmd}
-}
-
-type RemoveCommand struct {
-	*removeCommand
-}
-
-func NewRemoveCommandForTest(api SubnetAPI) (cmd.Command, *RemoveCommand) {
-	removeCmd := &removeCommand{
-		SubnetCommandBase: SubnetCommandBase{api: api},
-	}
-	return modelcmd.Wrap(removeCmd), &RemoveCommand{removeCmd}
-}
-
-type ListCommand struct {
-	*listCommand
-}
-
-func NewListCommandForTest(api SubnetAPI) (cmd.Command, *ListCommand) {
-	cmd := &listCommand{
-		SubnetCommandBase: SubnetCommandBase{api: api},
-	}
-	return modelcmd.Wrap(cmd), &ListCommand{cmd}
+func (base *SubnetCommandBase) SetAPI(api SubnetAPI) {
+	base.api = api
 }

--- a/cmd/juju/subnet/list.go
+++ b/cmd/juju/subnet/list.go
@@ -19,12 +19,12 @@ import (
 
 // NewListCommand returns a cammin used to list all subnets
 // known to Juju.
-func NewListCommand() cmd.Command {
-	return modelcmd.Wrap(&listCommand{})
+func NewListCommand() modelcmd.ModelCommand {
+	return modelcmd.Wrap(&ListCommand{})
 }
 
-// listCommand displays a list of all subnets known to Juju
-type listCommand struct {
+// ListCommand displays a list of all subnets known to Juju
+type ListCommand struct {
 	SubnetCommandBase
 
 	SpaceName string
@@ -47,7 +47,7 @@ output to a file, use --output.
 `
 
 // Info is defined on the cmd.Command interface.
-func (c *listCommand) Info() *cmd.Info {
+func (c *ListCommand) Info() *cmd.Info {
 	return &cmd.Info{
 		Name:    "subnets",
 		Args:    "[--space <name>] [--zone <name>] [--format yaml|json] [--output <path>]",
@@ -58,7 +58,7 @@ func (c *listCommand) Info() *cmd.Info {
 }
 
 // SetFlags is defined on the cmd.Command interface.
-func (c *listCommand) SetFlags(f *gnuflag.FlagSet) {
+func (c *ListCommand) SetFlags(f *gnuflag.FlagSet) {
 	c.SubnetCommandBase.SetFlags(f)
 	c.Out.AddFlags(f, "yaml", output.DefaultFormatters)
 
@@ -68,7 +68,7 @@ func (c *listCommand) SetFlags(f *gnuflag.FlagSet) {
 
 // Init is defined on the cmd.Command interface. It checks the
 // arguments for sanity and sets up the command to run.
-func (c *listCommand) Init(args []string) error {
+func (c *ListCommand) Init(args []string) error {
 	// No arguments are accepted, just flags.
 	err := cmd.CheckEmpty(args)
 	if err != nil {
@@ -89,8 +89,8 @@ func (c *listCommand) Init(args []string) error {
 }
 
 // Run implements Command.Run.
-func (c *listCommand) Run(ctx *cmd.Context) error {
-	return c.RunWithAPI(ctx, func(api SubnetAPI, ctx *cmd.Context) error {
+func (c *ListCommand) Run(ctx *cmd.Context) error {
+	return errors.Trace(c.RunWithAPI(ctx, func(api SubnetAPI, ctx *cmd.Context) error {
 		// Validate space and/or zone, if given to display a nicer error
 		// message.
 		// Get the list of subnets, filtering them as requested.
@@ -150,7 +150,7 @@ func (c *listCommand) Run(ctx *cmd.Context) error {
 		}
 
 		return c.Out.Write(ctx, result)
-	})
+	}))
 }
 
 const (

--- a/cmd/juju/subnet/list_test.go
+++ b/cmd/juju/subnet/list_test.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/juju/cmd/cmdtesting"
 	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
@@ -25,8 +24,7 @@ var _ = gc.Suite(&ListSuite{})
 
 func (s *ListSuite) SetUpTest(c *gc.C) {
 	s.BaseSubnetSuite.SetUpTest(c)
-	s.command, _ = subnet.NewListCommandForTest(s.api)
-	c.Assert(s.command, gc.NotNil)
+	s.newCommand = subnet.NewListCommand
 }
 
 func (s *ListSuite) TestInit(c *gc.C) {
@@ -83,19 +81,16 @@ func (s *ListSuite) TestInit(c *gc.C) {
 		expectFormat: "yaml",
 	}} {
 		c.Logf("test #%d: %s", i, test.about)
-		// Create a new instance of the subcommand for each test, but
-		// since we're not running the command no need to use
-		// modelcmd.Wrap().
-		wrappedCommand, command := subnet.NewListCommandForTest(s.api)
-		err := cmdtesting.InitCommand(wrappedCommand, test.args)
+		command, err := s.InitCommand(c, test.args...)
 		if test.expectErr != "" {
 			c.Check(err, gc.ErrorMatches, test.expectErr)
 		} else {
 			c.Check(err, jc.ErrorIsNil)
+			command := command.(*subnet.ListCommand)
+			c.Check(command.SpaceName, gc.Equals, test.expectSpace)
+			c.Check(command.ZoneName, gc.Equals, test.expectZone)
+			c.Check(command.Out.Name(), gc.Equals, test.expectFormat)
 		}
-		c.Check(command.SpaceName, gc.Equals, test.expectSpace)
-		c.Check(command.ZoneName, gc.Equals, test.expectZone)
-		c.Check(command.Out.Name(), gc.Equals, test.expectFormat)
 
 		// No API calls should be recorded at this stage.
 		s.api.CheckCallNames(c)

--- a/cmd/juju/subnet/package_test.go
+++ b/cmd/juju/subnet/package_test.go
@@ -16,7 +16,9 @@ import (
 
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/cmd/juju/subnet"
+	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/feature"
+	"github.com/juju/juju/jujuclient"
 	"github.com/juju/juju/network"
 	coretesting "github.com/juju/juju/testing"
 )
@@ -29,8 +31,8 @@ func TestPackage(t *stdtesting.T) {
 type BaseSubnetSuite struct {
 	coretesting.FakeJujuXDGDataHomeSuite
 
-	command cmd.Command
-	api     *StubAPI
+	newCommand func() modelcmd.ModelCommand
+	api        *StubAPI
 }
 
 var _ = gc.Suite(&BaseSubnetSuite{})
@@ -57,25 +59,40 @@ func (s *BaseSubnetSuite) SetUpTest(c *gc.C) {
 	c.Assert(s.api, gc.NotNil)
 
 	// All subcommand suites embedding this one should initialize
-	// s.command immediately after calling this method!
+	// s.newCommand immediately after calling this method!
 }
 
 func (s *BaseSubnetSuite) TearDownTest(c *gc.C) {
 	s.FakeJujuXDGDataHomeSuite.TearDownTest(c)
 }
 
-// RunCommand executes the s.command passing any args
-// and returning the stdout and stderr output as strings, as well as
-// any error.
+// InitCommand creates a command with s.newCommand and runs its
+// Init method only. It returns the inner command and any error.
+func (s *BaseSubnetSuite) InitCommand(c *gc.C, args ...string) (cmd.Command, error) {
+	cmd := s.newCommandForTest()
+	err := cmdtesting.InitCommand(cmd, args)
+	return modelcmd.InnerCommand(cmd), err
+}
+
+// RunCommand creates a command with s.newCommand and executes it,
+// passing any args and returning the stdout and stderr output as
+// strings, as well as any error.
 func (s *BaseSubnetSuite) RunCommand(c *gc.C, args ...string) (string, string, error) {
-	if s.command == nil {
-		panic("command is nil")
-	}
-	ctx, err := cmdtesting.RunCommand(c, s.command, args...)
-	if ctx != nil {
-		return cmdtesting.Stdout(ctx), cmdtesting.Stderr(ctx), err
-	}
-	return "", "", err
+	cmd := s.newCommandForTest()
+	ctx, err := cmdtesting.RunCommand(c, cmd, args...)
+	return cmdtesting.Stdout(ctx), cmdtesting.Stderr(ctx), err
+}
+
+func (s *BaseSubnetSuite) newCommandForTest() modelcmd.ModelCommand {
+	cmd := s.newCommand()
+	// The client store shouldn't be used, but mock it
+	// out to make sure.
+	cmd.SetClientStore(jujuclient.NewMemStore())
+	cmd1 := modelcmd.InnerCommand(cmd).(interface {
+		SetAPI(subnet.SubnetAPI)
+	})
+	cmd1.SetAPI(s.api)
+	return cmd
 }
 
 // AssertRunFails is a shortcut for calling RunCommand with the

--- a/cmd/juju/subnet/remove.go
+++ b/cmd/juju/subnet/remove.go
@@ -14,13 +14,13 @@ import (
 )
 
 // NewRemoveCommand returns a command used to remove an unused subnet from Juju.
-func NewRemoveCommand() cmd.Command {
-	return modelcmd.Wrap(&removeCommand{})
+func NewRemoveCommand() modelcmd.ModelCommand {
+	return modelcmd.Wrap(&RemoveCommand{})
 }
 
-// removeCommand calls the API to remove an existing, unused subnet
+// RemoveCommand calls the API to remove an existing, unused subnet
 // from Juju.
-type removeCommand struct {
+type RemoveCommand struct {
 	SubnetCommandBase
 
 	CIDR names.SubnetTag
@@ -41,7 +41,7 @@ until all related entites are cleaned up (e.g. allocated addresses).
 `
 
 // Info is defined on the cmd.Command interface.
-func (c *removeCommand) Info() *cmd.Info {
+func (c *RemoveCommand) Info() *cmd.Info {
 	return &cmd.Info{
 		Name:    "remove-subnet",
 		Args:    "<CIDR>",
@@ -52,7 +52,7 @@ func (c *removeCommand) Info() *cmd.Info {
 
 // Init is defined on the cmd.Command interface. It checks the
 // arguments for sanity and sets up the command to run.
-func (c *removeCommand) Init(args []string) error {
+func (c *RemoveCommand) Init(args []string) error {
 	// Ensure we have exactly 1 argument.
 	err := c.CheckNumArgs(args, []error{errNoCIDR})
 	if err != nil {
@@ -69,7 +69,7 @@ func (c *removeCommand) Init(args []string) error {
 }
 
 // Run implements Command.Run.
-func (c *removeCommand) Run(ctx *cmd.Context) error {
+func (c *RemoveCommand) Run(ctx *cmd.Context) error {
 	return c.RunWithAPI(ctx, func(api SubnetAPI, ctx *cmd.Context) error {
 		// Try removing the subnet.
 		if err := api.RemoveSubnet(c.CIDR); err != nil {

--- a/cmd/juju/subnet/remove_test.go
+++ b/cmd/juju/subnet/remove_test.go
@@ -4,7 +4,6 @@
 package subnet_test
 
 import (
-	"github.com/juju/cmd/cmdtesting"
 	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
@@ -23,8 +22,7 @@ var _ = gc.Suite(&RemoveSuite{})
 func (s *RemoveSuite) SetUpTest(c *gc.C) {
 	s.BaseSubnetSuite.SetFeatureFlags(feature.PostNetCLIMVP)
 	s.BaseSubnetSuite.SetUpTest(c)
-	s.command, _ = subnet.NewRemoveCommandForTest(s.api)
-	c.Assert(s.command, gc.NotNil)
+	s.newCommand = subnet.NewRemoveCommand
 }
 
 func (s *RemoveSuite) TestInit(c *gc.C) {
@@ -51,15 +49,12 @@ func (s *RemoveSuite) TestInit(c *gc.C) {
 		expectErr: `"5.4.3.2/10" is not correctly specified, expected "5.0.0.0/10"`,
 	}} {
 		c.Logf("test #%d: %s", i, test.about)
-		// Create a new instance of the subcommand for each test, but
-		// since we're not running the command no need to use
-		// modelcmd.Wrap().
-		wrappedCommand, command := subnet.NewRemoveCommandForTest(s.api)
-		err := cmdtesting.InitCommand(wrappedCommand, test.args)
+		command, err := s.InitCommand(c, test.args...)
 		if test.expectErr != "" {
 			c.Check(err, gc.ErrorMatches, test.expectErr)
 		} else {
 			c.Check(err, jc.ErrorIsNil)
+			command := command.(*subnet.RemoveCommand)
 			c.Check(command.CIDR, gc.Equals, test.expectCIDR)
 		}
 

--- a/cmd/juju/user/add.go
+++ b/cmd/juju/user/add.go
@@ -86,6 +86,10 @@ func (c *addCommand) Init(args []string) error {
 
 // Run implements Command.Run.
 func (c *addCommand) Run(ctx *cmd.Context) error {
+	controllerName, err := c.ControllerName()
+	if err != nil {
+		return errors.Trace(err)
+	}
 	api := c.api
 	if api == nil {
 		var err error
@@ -115,7 +119,7 @@ func (c *addCommand) Run(ctx *cmd.Context) error {
 	// Generate the base64-encoded string for the user to pass to
 	// "juju register". We marshal the information using ASN.1
 	// to keep the size down, since we need to encode binary data.
-	controllerDetails, err := c.ClientStore().ControllerByName(c.ControllerName())
+	controllerDetails, err := c.ClientStore().ControllerByName(controllerName)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -123,7 +127,7 @@ func (c *addCommand) Run(ctx *cmd.Context) error {
 		User:           c.User,
 		Addrs:          controllerDetails.APIEndpoints,
 		SecretKey:      secretKey,
-		ControllerName: c.ControllerName(),
+		ControllerName: controllerName,
 	}
 	registrationData, err := asn1.Marshal(registrationInfo)
 	if err != nil {

--- a/cmd/juju/user/change_password.go
+++ b/cmd/juju/user/change_password.go
@@ -97,7 +97,10 @@ func (c *changePasswordCommand) Run(ctx *cmd.Context) error {
 		return errors.Trace(err)
 	}
 
-	controllerName := c.ControllerName()
+	controllerName, err := c.ControllerName()
+	if err != nil {
+		return errors.Trace(err)
+	}
 	store := c.ClientStore()
 	accountDetails, err := store.AccountDetails(controllerName)
 	if err != nil {
@@ -154,9 +157,13 @@ func (c *changePasswordCommand) Run(ctx *cmd.Context) error {
 }
 
 func (c *changePasswordCommand) recordMacaroon(user, password string) error {
+	controllerName, err := c.ControllerName()
+	if err != nil {
+		return errors.Trace(err)
+	}
 	accountDetails := &jujuclient.AccountDetails{User: user}
 	args, err := c.NewAPIConnectionParams(
-		c.ClientStore(), c.ControllerName(), "", accountDetails,
+		c.ClientStore(), controllerName, "", accountDetails,
 	)
 	if err != nil {
 		return errors.Trace(err)

--- a/cmd/juju/user/info.go
+++ b/cmd/juju/user/info.go
@@ -117,7 +117,7 @@ func (c *infoCommand) Run(ctx *cmd.Context) (err error) {
 	defer client.Close()
 	username := c.Username
 	if username == "" {
-		accountDetails, err := c.ClientStore().AccountDetails(c.ControllerName())
+		accountDetails, err := c.CurrentAccountDetails()
 		if err != nil {
 			return err
 		}

--- a/cmd/juju/user/list.go
+++ b/cmd/juju/user/list.go
@@ -116,7 +116,7 @@ func (c *listCommand) Run(ctx *cmd.Context) (err error) {
 	if c.out.Name() == "tabular" {
 		// Only the tabular outputters need to know the current user,
 		// but both of them do, so do it in one place.
-		accountDetails, err := c.ClientStore().AccountDetails(c.ControllerName())
+		accountDetails, err := c.CurrentAccountDetails()
 		if err != nil {
 			return err
 		}
@@ -209,6 +209,10 @@ func (c *listCommand) formatModelUsers(writer io.Writer, value interface{}) erro
 }
 
 func (c *listCommand) formatControllerUsers(writer io.Writer, value interface{}) error {
+	controllerName, err := c.ControllerName()
+	if err != nil {
+		return errors.Trace(err)
+	}
 	users, valueConverted := value.([]UserInfo)
 	if !valueConverted {
 		return errors.Errorf("expected value of type %T, got %T", users, value)
@@ -216,7 +220,7 @@ func (c *listCommand) formatControllerUsers(writer io.Writer, value interface{})
 
 	tw := output.TabWriter(writer)
 	w := output.Wrapper{tw}
-	w.Println("Controller: " + c.ControllerName())
+	w.Println("Controller: " + controllerName)
 	w.Println()
 	w.Println("Name", "Display name", "Access", "Date created", "Last connection")
 	for _, user := range users {

--- a/cmd/juju/user/login.go
+++ b/cmd/juju/user/login.go
@@ -188,7 +188,9 @@ func (c *loginCommand) run(ctx *cmd.Context) error {
 	}
 	switch {
 	case c.domain != "":
-		conn, publicControllerDetails, accountDetails, err = c.publicControllerLogin(ctx, c.domain, oldAccountDetails)
+		// Note: the controller name is guaranteed to be non-empty
+		// in this case via the test at the start of this function.
+		conn, publicControllerDetails, accountDetails, err = c.publicControllerLogin(ctx, c.domain, c.controllerName, oldAccountDetails)
 		if err != nil {
 			return errors.Annotatef(err, "cannot log into %q", c.domain)
 		}
@@ -274,13 +276,14 @@ func (c *loginCommand) existingControllerLogin(ctx *cmd.Context, store jujuclien
 func (c *loginCommand) publicControllerLogin(
 	ctx *cmd.Context,
 	host string,
+	controllerName string,
 	currentAccountDetails *jujuclient.AccountDetails,
 ) (api.Connection, *jujuclient.ControllerDetails, *jujuclient.AccountDetails, error) {
 	fail := func(err error) (api.Connection, *jujuclient.ControllerDetails, *jujuclient.AccountDetails, error) {
 		return nil, nil, nil, err
 	}
 	if !strings.ContainsAny(host, ".:") {
-		host1, err := c.getKnownControllerDomain(host)
+		host1, err := c.getKnownControllerDomain(host, controllerName)
 		if errors.IsNotFound(err) {
 			return fail(errors.Errorf("%q is not a known public controller", host))
 		}
@@ -299,7 +302,7 @@ func (c *loginCommand) publicControllerLogin(
 	// Unfortunately this means we'll connect twice to the controller
 	// but it's probably best to go through the conventional path the
 	// second time.
-	bclient, err := c.BakeryClient()
+	bclient, err := c.CommandBase.BakeryClient(c.ClientStore(), controllerName)
 	if err != nil {
 		return fail(errors.Trace(err))
 	}
@@ -324,7 +327,7 @@ func (c *loginCommand) publicControllerLogin(
 	// If we get to here, then we have a cached macaroon for the registered
 	// user. If we encounter an error after here, we need to clear it.
 	c.onRunError = func() {
-		if err := c.ClearControllerMacaroons([]string{host}); err != nil {
+		if err := c.ClearControllerMacaroons(c.ClientStore(), controllerName); err != nil {
 			logger.Errorf("failed to clear macaroon: %v", err)
 		}
 	}
@@ -468,7 +471,7 @@ const defaultJujuDirectory = "https://api.jujucharms.com/directory"
 
 // getKnownControllerDomain returns the list of known
 // controller domain aliases.
-func (c *loginCommand) getKnownControllerDomain(name string) (string, error) {
+func (c *loginCommand) getKnownControllerDomain(name, controllerName string) (string, error) {
 	if strings.Contains(name, ".") || strings.Contains(name, ":") {
 		return "", errors.NotFoundf("controller %q", name)
 	}
@@ -476,7 +479,7 @@ func (c *loginCommand) getKnownControllerDomain(name string) (string, error) {
 	if u := os.Getenv("JUJU_DIRECTORY"); u != "" {
 		baseURL = u
 	}
-	client, err := c.BakeryClient()
+	client, err := c.CommandBase.BakeryClient(c.ClientStore(), controllerName)
 	if err != nil {
 		return "", errors.Trace(err)
 	}

--- a/cmd/juju/user/logout.go
+++ b/cmd/juju/user/logout.go
@@ -68,7 +68,10 @@ func (c *logoutCommand) SetFlags(f *gnuflag.FlagSet) {
 
 // Run implements Command.Run.
 func (c *logoutCommand) Run(ctx *cmd.Context) error {
-	controllerName := c.ControllerName()
+	controllerName, err := c.ControllerName()
+	if err != nil {
+		return errors.Trace(err)
+	}
 	store := c.ClientStore()
 	if err := c.logout(store, controllerName); err != nil {
 		return errors.Trace(err)
@@ -131,11 +134,7 @@ this command again with the "--force" flag.
 `)
 	}
 
-	details, err := store.ControllerByName(controllerName)
-	if err != nil {
-		return errors.Trace(err)
-	}
-	if err := c.ClearControllerMacaroons(details.APIEndpoints); err != nil {
+	if err := c.ClearControllerMacaroons(c.ClientStore(), controllerName); err != nil {
 		return errors.Trace(err)
 	}
 

--- a/cmd/juju/user/remove.go
+++ b/cmd/juju/user/remove.go
@@ -98,6 +98,10 @@ func (c *removeCommand) Init(args []string) error {
 
 // Run implements Command.Run.
 func (c *removeCommand) Run(ctx *cmd.Context) error {
+	controllerName, err := c.ControllerName()
+	if err != nil {
+		return errors.Trace(err)
+	}
 	api := c.api // This is for testing.
 
 	if api == nil { // The real McCoy.
@@ -111,13 +115,12 @@ func (c *removeCommand) Run(ctx *cmd.Context) error {
 
 	// Confirm deletion if the user didn't specify -y/--yes in the command.
 	if !c.ConfirmDelete {
-		if err := confirmDelete(ctx, c.ControllerName(), c.UserName); err != nil {
-			return err
+		if err := confirmDelete(ctx, controllerName, c.UserName); err != nil {
+			return errors.Trace(err)
 		}
 	}
 
-	err := api.RemoveUser(c.UserName)
-	if err != nil {
+	if err := api.RemoveUser(c.UserName); err != nil {
 		// This is very awful, but it makes the user experience crisper. At
 		// least maybe more tenable until users and authn/z are overhauled.
 		if e, ok := err.(*params.Error); ok {

--- a/cmd/modelcmd/apicontext.go
+++ b/cmd/modelcmd/apicontext.go
@@ -12,16 +12,15 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/gnuflag"
 	"github.com/juju/idmclient/ussologin"
-	"github.com/juju/persistent-cookiejar"
 	"gopkg.in/juju/environschema.v1/form"
 	"gopkg.in/macaroon-bakery.v1/httpbakery"
 
 	"github.com/juju/juju/jujuclient"
 )
 
-// APIContext holds the context required for making connections to
+// apiContext holds the context required for making connections to
 // APIs used by juju.
-type APIContext struct {
+type apiContext struct {
 	// jar holds the internal version of the cookie jar - it has
 	// methods that clients should not use, such as Save.
 	jar            *domainCookieJar
@@ -40,7 +39,7 @@ func (o *AuthOpts) SetFlags(f *gnuflag.FlagSet) {
 	f.BoolVar(&o.NoBrowser, "no-browser-login", false, "")
 }
 
-// NewAPIContext returns an API context that will use the given
+// newAPIContext returns an API context that will use the given
 // context for user interactions when authorizing.
 // The returned API context must be closed after use.
 //
@@ -49,10 +48,8 @@ func (o *AuthOpts) SetFlags(f *gnuflag.FlagSet) {
 //
 // This function is provided for use by commands that cannot use
 // CommandBase. Most clients should use that instead.
-func NewAPIContext(ctxt *cmd.Context, opts *AuthOpts) (*APIContext, error) {
-	jar0, err := cookiejar.New(&cookiejar.Options{
-		Filename: cookieFile(),
-	})
+func newAPIContext(ctxt *cmd.Context, opts *AuthOpts, store jujuclient.CookieStore, controllerName string) (*apiContext, error) {
+	jar0, err := store.CookieJar(controllerName)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -61,8 +58,8 @@ func NewAPIContext(ctxt *cmd.Context, opts *AuthOpts) (*APIContext, error) {
 	// We set up a cookie jar that will send it to all sites because
 	// we don't know where the third party might be.
 	jar := &domainCookieJar{
-		Jar:    jar0,
-		domain: os.Getenv("JUJU_USER_DOMAIN"),
+		CookieJar: jar0,
+		domain:    os.Getenv("JUJU_USER_DOMAIN"),
 	}
 	var visitors []httpbakery.Visitor
 	if ctxt != nil && opts != nil && opts.NoBrowser {
@@ -74,7 +71,7 @@ func NewAPIContext(ctxt *cmd.Context, opts *AuthOpts) (*APIContext, error) {
 	} else {
 		visitors = append(visitors, httpbakery.WebBrowserVisitor)
 	}
-	return &APIContext{
+	return &apiContext{
 		jar:            jar,
 		webPageVisitor: httpbakery.NewMultiVisitor(visitors...),
 	}, nil
@@ -82,32 +79,22 @@ func NewAPIContext(ctxt *cmd.Context, opts *AuthOpts) (*APIContext, error) {
 
 // CookieJar returns the cookie jar used to make
 // HTTP requests.
-func (ctx *APIContext) CookieJar() http.CookieJar {
+func (ctx *apiContext) CookieJar() http.CookieJar {
 	return ctx.jar
 }
 
 // NewBakeryClient returns a new httpbakery.Client, using the API context's
 // persistent cookie jar and web page visitor.
-func (ctx *APIContext) NewBakeryClient() *httpbakery.Client {
+func (ctx *apiContext) NewBakeryClient() *httpbakery.Client {
 	client := httpbakery.NewClient()
 	client.Jar = ctx.jar
 	client.WebPageVisitor = ctx.webPageVisitor
 	return client
 }
 
-// cookieFile returns the path to the cookie used to store authorization
-// macaroons. The returned value can be overridden by setting the
-// JUJU_COOKIEFILE or GO_COOKIEFILE environment variables.
-func cookieFile() string {
-	if file := os.Getenv("JUJU_COOKIEFILE"); file != "" {
-		return file
-	}
-	return cookiejar.DefaultCookieFile()
-}
-
 // Close closes the API context, saving any cookies to the
 // persistent cookie jar.
-func (ctxt *APIContext) Close() error {
+func (ctxt *apiContext) Close() error {
 	if err := ctxt.jar.Save(); err != nil {
 		return errors.Annotatef(err, "cannot save cookie jar")
 	}
@@ -119,7 +106,7 @@ const domainCookieName = "domain"
 // domainCookieJar implements a variant of CookieJar that
 // always includes a domain cookie regardless of the site.
 type domainCookieJar struct {
-	*cookiejar.Jar
+	jujuclient.CookieJar
 	// domain holds the value of the domain cookie.
 	domain string
 }
@@ -127,7 +114,7 @@ type domainCookieJar struct {
 // Cookies implements http.CookieJar.Cookies by
 // adding the domain cookie when the domain is non-empty.
 func (j *domainCookieJar) Cookies(u *url.URL) []*http.Cookie {
-	cookies := j.Jar.Cookies(u)
+	cookies := j.CookieJar.Cookies(u)
 	if j.domain == "" {
 		return cookies
 	}

--- a/cmd/modelcmd/base_test.go
+++ b/cmd/modelcmd/base_test.go
@@ -53,8 +53,11 @@ func (s *BaseCommandSuite) assertUnknownModel(c *gc.C, current, expectedCurrent 
 	apiOpen := func(*api.Info, api.DialOpts) (api.Connection, error) {
 		return nil, errors.Trace(&params.Error{Code: params.CodeModelNotFound, Message: "model deaddeaf not found"})
 	}
-	cmd := modelcmd.NewModelCommandBase(s.store, "foo", "admin/badmodel")
+	cmd := new(modelcmd.ModelCommandBase)
+	cmd.SetClientStore(s.store)
 	cmd.SetAPIOpen(apiOpen)
+	modelcmd.SetRunStarted(cmd)
+	cmd.SetModelName("foo:admin/badmodel", false)
 	conn, err := cmd.NewAPIRoot()
 	c.Assert(conn, gc.IsNil)
 	msg := strings.Replace(err.Error(), "\n", "", -1)

--- a/cmd/modelcmd/controller.go
+++ b/cmd/modelcmd/controller.go
@@ -4,9 +4,12 @@
 package modelcmd
 
 import (
+	"net/http"
+
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
 	"github.com/juju/gnuflag"
+	"gopkg.in/macaroon-bakery.v1/httpbakery"
 
 	"github.com/juju/juju/api"
 	"github.com/juju/juju/api/controller"
@@ -48,15 +51,17 @@ type ControllerCommand interface {
 	// associated with.
 	ClientStore() jujuclient.ClientStore
 
-	// SetControllerName sets the value returned by ControllerName.
-	// It returns an error if the controller with the given name
-	// is not found, unless the name is empty and allowDefault is true,
-	// in which case the name of the current controller will be used.
+	// SetControllerName sets the name of the current controller.
 	SetControllerName(controllerName string, allowDefault bool) error
 
 	// ControllerName returns the name of the controller
-	// that the command should use.
-	ControllerName() string
+	// that the command should use. It must only be called
+	// after Run has been called.
+	ControllerName() (string, error)
+
+	// initModel initializes the controller, resolving an empty
+	// controller to the current controller if allowDefault is true.
+	initController() error
 }
 
 // ControllerCommandBase is a convenience type for embedding in commands
@@ -64,8 +69,16 @@ type ControllerCommand interface {
 type ControllerCommandBase struct {
 	CommandBase
 
-	store          jujuclient.ClientStore
-	controllerName string
+	store jujuclient.ClientStore
+
+	_controllerName        string
+	allowDefaultController bool
+
+	// doneInitController holds whether initController has been called.
+	doneInitController bool
+
+	// initControllerError holds the result of the initController call.
+	initControllerError error
 }
 
 // SetClientStore implements the ControllerCommand interface.
@@ -75,28 +88,73 @@ func (c *ControllerCommandBase) SetClientStore(store jujuclient.ClientStore) {
 
 // ClientStore implements the ControllerCommand interface.
 func (c *ControllerCommandBase) ClientStore() jujuclient.ClientStore {
+	c.assertRunStarted()
 	return c.store
+}
+
+func (c *ControllerCommandBase) initController() error {
+	if c.doneInitController {
+		return errors.Trace(c.initControllerError)
+	}
+	c.doneInitController = true
+	c.initControllerError = c.initController0()
+	return c.initControllerError
+}
+
+func (c *ControllerCommandBase) initController0() error {
+	if c._controllerName == "" && !c.allowDefaultController {
+		return errors.New("no controller specified")
+	}
+	store := c.ClientStore()
+	if c._controllerName == "" {
+		currentController, err := store.CurrentController()
+		if err != nil {
+			return errors.Trace(translateControllerError(store, err))
+		}
+		c._controllerName = currentController
+	}
+	if _, err := store.ControllerByName(c._controllerName); err != nil {
+		return errors.Trace(err)
+	}
+	return nil
 }
 
 // SetControllerName implements ControllerCommand.SetControllerName.
 func (c *ControllerCommandBase) SetControllerName(controllerName string, allowDefault bool) error {
-	store := c.ClientStore()
-	if controllerName == "" && allowDefault {
-		currentController, err := store.CurrentController()
-		if err != nil {
-			return translateControllerError(store, err)
+	logger.Infof("setting controllerName to %q %v", controllerName, allowDefault)
+	c._controllerName = controllerName
+	c.allowDefaultController = allowDefault
+	if c.runStarted {
+		if err := c.initController(); err != nil {
+			return errors.Trace(err)
 		}
-		controllerName = currentController
-	} else if _, err := store.ControllerByName(controllerName); err != nil {
-		return errors.Trace(err)
 	}
-	c.controllerName = controllerName
 	return nil
 }
 
 // ControllerName implements the ControllerCommand interface.
-func (c *ControllerCommandBase) ControllerName() string {
-	return c.controllerName
+func (c *ControllerCommandBase) ControllerName() (string, error) {
+	c.assertRunStarted()
+	if err := c.initController(); err != nil {
+		return "", errors.Trace(err)
+	}
+	return c._controllerName, nil
+}
+
+func (c *ControllerCommandBase) BakeryClient() (*httpbakery.Client, error) {
+	controllerName, err := c.ControllerName()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return c.CommandBase.BakeryClient(c.ClientStore(), controllerName)
+}
+
+func (c *ControllerCommandBase) CookieJar() (http.CookieJar, error) {
+	controllerName, err := c.ControllerName()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return c.CommandBase.CookieJar(c.ClientStore(), controllerName)
 }
 
 // NewModelManagerAPIClient returns an API client for the
@@ -139,14 +197,18 @@ func (c *ControllerCommandBase) NewAPIRoot() (api.Connection, error) {
 // NewAPIRoot returns a new connection to the API server for the named model
 // in the specified controller.
 func (c *ControllerCommandBase) NewModelAPIRoot(modelName string) (api.Connection, error) {
-	_, err := c.store.ModelByName(c.controllerName, modelName)
+	controllerName, err := c.ControllerName()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	_, err = c.store.ModelByName(controllerName, modelName)
 	if err != nil {
 		if !errors.IsNotFound(err) {
 			return nil, errors.Trace(err)
 		}
 		// The model isn't known locally, so query the models
 		// available in the controller, and cache them locally.
-		if err := c.RefreshModels(c.store, c.controllerName); err != nil {
+		if err := c.RefreshModels(c.store, controllerName); err != nil {
 			return nil, errors.Annotate(err, "refreshing models")
 		}
 	}
@@ -154,24 +216,21 @@ func (c *ControllerCommandBase) NewModelAPIRoot(modelName string) (api.Connectio
 }
 
 func (c *ControllerCommandBase) newAPIRoot(modelName string) (api.Connection, error) {
-	if c.controllerName == "" {
-		controllers, err := c.store.AllControllers()
-		if err != nil {
-			return nil, errors.Trace(err)
-		}
-		if len(controllers) == 0 {
-			return nil, errors.Trace(ErrNoControllersDefined)
-		}
-		return nil, errors.Trace(ErrNoCurrentController)
+	controllerName, err := c.ControllerName()
+	if err != nil {
+		return nil, errors.Trace(err)
 	}
-	return c.CommandBase.NewAPIRoot(c.store, c.controllerName, modelName)
+	return c.CommandBase.NewAPIRoot(c.store, controllerName, modelName)
 }
 
 // ModelUUIDs returns the model UUIDs for the given model names.
 func (c *ControllerCommandBase) ModelUUIDs(modelNames []string) ([]string, error) {
 	var result []string
 	store := c.ClientStore()
-	controllerName := c.ControllerName()
+	controllerName, err := c.ControllerName()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	for _, modelName := range modelNames {
 		model, err := store.ModelByName(controllerName, modelName)
 		if errors.IsNotFound(err) {
@@ -183,15 +242,25 @@ func (c *ControllerCommandBase) ModelUUIDs(modelNames []string) ([]string, error
 			model, err = store.ModelByName(controllerName, modelName)
 		}
 		if err != nil {
-			return nil, errors.Annotatef(err, "model %q not found", modelName)
+			return nil, errors.Trace(err)
 		}
 		result = append(result, model.ModelUUID)
 	}
 	return result, nil
 }
 
+// CurrentAccountDetails returns details of the account associated with
+// the current controller.
+func (c *ControllerCommandBase) CurrentAccountDetails() (*jujuclient.AccountDetails, error) {
+	controllerName, err := c.ControllerName()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return c.ClientStore().AccountDetails(controllerName)
+}
+
 // WrapControllerOption specifies an option to the WrapController function.
-type WrapControllerOption func(*sysCommandWrapper)
+type WrapControllerOption func(*controllerCommandWrapper)
 
 // Options for the WrapController call.
 var (
@@ -204,18 +273,18 @@ var (
 	WrapControllerSkipDefaultController WrapControllerOption = wrapControllerSkipDefaultController
 )
 
-func wrapControllerSkipControllerFlags(w *sysCommandWrapper) {
+func wrapControllerSkipControllerFlags(w *controllerCommandWrapper) {
 	w.setControllerFlags = false
 }
 
-func wrapControllerSkipDefaultController(w *sysCommandWrapper) {
+func wrapControllerSkipDefaultController(w *controllerCommandWrapper) {
 	w.useDefaultController = false
 }
 
 // WrapController wraps the specified ControllerCommand, returning a Command
 // that proxies to each of the ControllerCommand methods.
-func WrapController(c ControllerCommand, options ...WrapControllerOption) Command {
-	wrapper := &sysCommandWrapper{
+func WrapController(c ControllerCommand, options ...WrapControllerOption) ControllerCommand {
+	wrapper := &controllerCommandWrapper{
 		ControllerCommand:    c,
 		setControllerFlags:   true,
 		useDefaultController: true,
@@ -223,10 +292,24 @@ func WrapController(c ControllerCommand, options ...WrapControllerOption) Comman
 	for _, option := range options {
 		option(wrapper)
 	}
-	return WrapBase(wrapper)
+	// Define a new type so that we can embed the ModelCommand
+	// interface one level deeper than cmd.Command, so that
+	// we'll get the Command methods from WrapBase
+	// and all the ModelCommand methods not in cmd.Command
+	// from modelCommandWrapper.
+	type embed struct {
+		*controllerCommandWrapper
+	}
+	return struct {
+		embed
+		cmd.Command
+	}{
+		Command: WrapBase(wrapper),
+		embed:   embed{wrapper},
+	}
 }
 
-type sysCommandWrapper struct {
+type controllerCommandWrapper struct {
 	ControllerCommand
 	setControllerFlags   bool
 	useDefaultController bool
@@ -234,12 +317,12 @@ type sysCommandWrapper struct {
 }
 
 // wrapped implements wrapper.wrapped.
-func (w *sysCommandWrapper) inner() cmd.Command {
+func (w *controllerCommandWrapper) inner() cmd.Command {
 	return w.ControllerCommand
 }
 
 // SetFlags implements Command.SetFlags, then calls the wrapped command's SetFlags.
-func (w *sysCommandWrapper) SetFlags(f *gnuflag.FlagSet) {
+func (w *controllerCommandWrapper) SetFlags(f *gnuflag.FlagSet) {
 	if w.setControllerFlags {
 		f.StringVar(&w.controllerName, "c", "", "Controller to operate in")
 		f.StringVar(&w.controllerName, "controller", "", "")
@@ -248,20 +331,27 @@ func (w *sysCommandWrapper) SetFlags(f *gnuflag.FlagSet) {
 }
 
 // Init implements Command.Init, then calls the wrapped command's Init.
-func (w *sysCommandWrapper) Init(args []string) error {
+func (w *controllerCommandWrapper) Init(args []string) error {
+	if w.setControllerFlags {
+		if err := w.SetControllerName(w.controllerName, w.useDefaultController); err != nil {
+			return errors.Trace(err)
+		}
+	}
+	if err := w.ControllerCommand.Init(args); err != nil {
+		return errors.Trace(err)
+	}
+	return nil
+}
+
+func (w *controllerCommandWrapper) Run(ctx *cmd.Context) error {
+	w.setRunStarted()
 	store := w.ClientStore()
 	if store == nil {
 		store = jujuclient.NewFileClientStore()
 	}
 	store = QualifyingClientStore{store}
 	w.SetClientStore(store)
-
-	if w.setControllerFlags {
-		if err := w.SetControllerName(w.controllerName, w.useDefaultController); err != nil {
-			return errors.Trace(err)
-		}
-	}
-	return w.ControllerCommand.Init(args)
+	return w.ControllerCommand.Run(ctx)
 }
 
 func translateControllerError(store jujuclient.ClientStore, err error) error {

--- a/cmd/modelcmd/export_test.go
+++ b/cmd/modelcmd/export_test.go
@@ -1,16 +1,9 @@
-// Copyright 2013 Canonical Ltd.
-// Licensed under the AGPLv3, see LICENCE file for details.
-
 package modelcmd
 
-import "github.com/juju/juju/jujuclient"
+var NewAPIContext = newAPIContext
 
-// NewModelCommandBase returns a new ModelCommandBase with the given client
-// store, controller name, and model name.
-func NewModelCommandBase(store jujuclient.ClientStore, controller, model string) *ModelCommandBase {
-	return &ModelCommandBase{
-		store:          store,
-		controllerName: controller,
-		modelName:      model,
-	}
+func SetRunStarted(b interface {
+	setRunStarted()
+}) {
+	b.setRunStarted()
 }

--- a/cmd/plugins/juju-metadata/imagemetadata.go
+++ b/cmd/plugins/juju-metadata/imagemetadata.go
@@ -28,12 +28,16 @@ type imageMetadataCommandBase struct {
 }
 
 func (c *imageMetadataCommandBase) prepare(context *cmd.Context) (environs.Environ, error) {
+	controllerName, err := c.ControllerName()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	// NOTE(axw) this is a work-around for the TODO below. This
 	// means that the command will only work if you've bootstrapped
 	// the specified environment.
 	bootstrapConfig, params, err := modelcmd.NewGetBootstrapConfigParamsFunc(
 		context, c.ClientStore(), environs.GlobalProviderRegistry(),
-	)(c.ControllerName())
+	)(controllerName)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -37,7 +37,7 @@ github.com/juju/jsonschema	git	a0ef8b74ebcffeeff9fc374854deb4af388f037e	2016-11-
 github.com/juju/loggo	git	21bc4c63e8b435779a080e39e592969b7b90b889	2017-02-22T12:20:47Z
 github.com/juju/mempool	git	24974d6c264fe5a29716e7d56ea24c4bd904b7cc	2016-02-05T10:49:27Z
 github.com/juju/mutex	git	59c26ee163447c5c57f63ff71610d433862013de	2016-06-17T01:09:07Z
-github.com/juju/persistent-cookiejar	git	5243747bf8f2d0897f6c7a52799327dc97d585e8	2016-11-15T13:33:28Z
+github.com/juju/persistent-cookiejar	git	d67418f14c93a698e37b52468958d5d4dcf8a7dd	2017-04-28T16:15:59Z
 github.com/juju/pubsub	git	f4dfa62f30adc6955341b3dd73dde7c8d9b23b9e	2017-03-31T03:24:24Z
 github.com/juju/replicaset	git	6b5becf2232ce76656ea765d8d915d41755a1513	2016-11-25T16:08:49Z
 github.com/juju/retry	git	62c62032529169c7ec02fa48f93349604c345e1f	2015-10-29T02:48:21Z

--- a/featuretests/cmd_juju_register_test.go
+++ b/featuretests/cmd_juju_register_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/juju/juju/cmd/juju/commands"
 	"github.com/juju/juju/juju"
 	jujutesting "github.com/juju/juju/juju/testing"
+	"github.com/juju/juju/jujuclient"
 )
 
 type cmdRegistrationSuite struct {
@@ -59,8 +60,8 @@ Enter a new password: »hunter2
 
 Confirm password: »hunter2
 
-Initial password successfully set for bob.
 Enter a name for this controller \[kontroll\]: »bob-controller
+Initial password successfully set for bob.
 
 Welcome, bob. You are now logged into "bob-controller".
 
@@ -73,7 +74,7 @@ There are no models available. (.|\n)*
 	// Make sure that the saved server details are sufficient to connect
 	// to the api server.
 	jar, err := cookiejar.New(&cookiejar.Options{
-		Filename: cookiejar.DefaultCookieFile(),
+		Filename: jujuclient.JujuCookiePath("bob-controller"),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	dialOpts := api.DefaultDialOpts()

--- a/jujuclient/controllers_test.go
+++ b/jujuclient/controllers_test.go
@@ -5,6 +5,7 @@ package jujuclient_test
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
@@ -16,7 +17,7 @@ import (
 
 type ControllersSuite struct {
 	testing.FakeJujuXDGDataHomeSuite
-	store          jujuclient.ControllerStore
+	store          jujuclient.ClientStore
 	controllerName string
 	controller     jujuclient.ControllerDetails
 }
@@ -152,6 +153,30 @@ func (s *ControllersSuite) TestCurrentControllerNoneExists(c *gc.C) {
 	_, err := s.store.CurrentController()
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 	c.Assert(err, gc.ErrorMatches, "current controller not found")
+}
+
+func (s *ControllersSuite) TestRemoveControllerRemovesCookieJar(c *gc.C) {
+	name := firstTestControllerName(c)
+
+	jar, err := s.store.CookieJar(name)
+	c.Assert(err, jc.ErrorIsNil)
+	err = jar.Save()
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Sanity-check that the cookie jar file exists.
+	_, err = os.Stat(jujuclient.JujuCookiePath(name))
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = s.store.RemoveController(name)
+	c.Assert(err, jc.ErrorIsNil)
+
+	found, err := s.store.ControllerByName(name)
+	c.Assert(err, gc.ErrorMatches, fmt.Sprintf("controller %v not found", name))
+	c.Assert(found, gc.IsNil)
+
+	// Check that the cookie jar has been removed.
+	_, err = os.Stat(jujuclient.JujuCookiePath(name))
+	c.Assert(err, jc.Satisfies, os.IsNotExist)
 }
 
 func (s *ControllersSuite) TestCurrentController(c *gc.C) {

--- a/jujuclient/interface.go
+++ b/jujuclient/interface.go
@@ -4,6 +4,8 @@
 package jujuclient
 
 import (
+	"net/http"
+
 	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/controller"
 )
@@ -284,6 +286,24 @@ type BootstrapConfigGetter interface {
 	BootstrapConfigForController(string) (*BootstrapConfig, error)
 }
 
+// CookieJar is the interface implemented by cookie jars.
+type CookieJar interface {
+	http.CookieJar
+
+	// RemoveAll removes all the cookies (note: this doesn't
+	// save the cookie file).
+	RemoveAll()
+
+	// Save saves the cookies.
+	Save() error
+}
+
+// CookieStore allows the retrieval of cookie jars for storage
+// of per-controller authorization information.
+type CookieStore interface {
+	CookieJar(controllerName string) (CookieJar, error)
+}
+
 // ControllerStore is an amalgamation of ControllerUpdater, ControllerRemover,
 // and ControllerGetter.
 type ControllerStore interface {
@@ -327,4 +347,5 @@ type ClientStore interface {
 	ControllerStore
 	CredentialStore
 	ModelStore
+	CookieStore
 }

--- a/jujuclient/jujuclienttesting/stub.go
+++ b/jujuclient/jujuclienttesting/stub.go
@@ -38,6 +38,8 @@ type StubStore struct {
 
 	BootstrapConfigForControllerFunc func(controllerName string) (*jujuclient.BootstrapConfig, error)
 	UpdateBootstrapConfigFunc        func(controllerName string, cfg jujuclient.BootstrapConfig) error
+
+	CookieJarFunc func(controllerName string) (jujuclient.CookieJar, error)
 }
 
 func NewStubStore() *StubStore {
@@ -111,6 +113,9 @@ func NewStubStore() *StubStore {
 	result.UpdateBootstrapConfigFunc = func(controllerName string, cfg jujuclient.BootstrapConfig) error {
 		return result.Stub.NextErr()
 	}
+	result.CookieJarFunc = func(controllerName string) (jujuclient.CookieJar, error) {
+		return nil, result.Stub.NextErr()
+	}
 	return result
 }
 
@@ -137,6 +142,7 @@ func WrapClientStore(underlying jujuclient.ClientStore) *StubStore {
 	stub.RemoveAccountFunc = underlying.RemoveAccount
 	stub.BootstrapConfigForControllerFunc = underlying.BootstrapConfigForController
 	stub.UpdateBootstrapConfigFunc = underlying.UpdateBootstrapConfig
+	stub.CookieJarFunc = underlying.CookieJar
 	return stub
 }
 
@@ -264,4 +270,9 @@ func (c *StubStore) BootstrapConfigForController(controllerName string) (*jujucl
 func (c *StubStore) UpdateBootstrapConfig(controllerName string, cfg jujuclient.BootstrapConfig) error {
 	c.MethodCall(c, "UpdateBootstrapConfig", controllerName, cfg)
 	return c.UpdateBootstrapConfigFunc(controllerName, cfg)
+}
+
+func (c *StubStore) CookieJar(controllerName string) (jujuclient.CookieJar, error) {
+	c.MethodCall(c, "CookieJar", controllerName)
+	return c.CookieJarFunc(controllerName)
 }

--- a/provider/oracle/environ_test.go
+++ b/provider/oracle/environ_test.go
@@ -8,6 +8,12 @@ import (
 	"fmt"
 	"time"
 
+	gitjujutesting "github.com/juju/testing"
+	"github.com/juju/utils/arch"
+	//"github.com/juju/utils/clock"
+	"github.com/juju/version"
+	gc "gopkg.in/check.v1"
+
 	"github.com/juju/juju/constraints"
 	"github.com/juju/juju/environs"
 	envtesting "github.com/juju/juju/environs/testing"
@@ -15,11 +21,6 @@ import (
 	"github.com/juju/juju/provider/oracle"
 	"github.com/juju/juju/testing"
 	"github.com/juju/juju/tools"
-	gitjujutesting "github.com/juju/testing"
-	"github.com/juju/utils/arch"
-	//"github.com/juju/utils/clock"
-	"github.com/juju/version"
-	gc "gopkg.in/check.v1"
 )
 
 type environSuite struct{}

--- a/provider/oracle/fakeenvironapi_test.go
+++ b/provider/oracle/fakeenvironapi_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/juju/go-oracle-cloud/api"
 	"github.com/juju/go-oracle-cloud/common"
 	"github.com/juju/go-oracle-cloud/response"
+
 	"github.com/juju/juju/provider/oracle"
 	providertest "github.com/juju/juju/provider/oracle/network/testing"
 )

--- a/provider/oracle/fakestorageapi_test.go
+++ b/provider/oracle/fakestorageapi_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/juju/go-oracle-cloud/api"
 	"github.com/juju/go-oracle-cloud/common"
 	"github.com/juju/go-oracle-cloud/response"
+
 	"github.com/juju/juju/provider/oracle"
 )
 

--- a/provider/oracle/images_test.go
+++ b/provider/oracle/images_test.go
@@ -6,10 +6,11 @@ package oracle_test
 import (
 	"errors"
 
+	gc "gopkg.in/check.v1"
+
 	"github.com/juju/juju/environs/imagemetadata"
 	"github.com/juju/juju/environs/instances"
 	"github.com/juju/juju/provider/oracle"
-	gc "gopkg.in/check.v1"
 )
 
 type imageSuite struct{}

--- a/provider/oracle/instance_test.go
+++ b/provider/oracle/instance_test.go
@@ -7,12 +7,13 @@ import (
 	"errors"
 
 	"github.com/juju/go-oracle-cloud/response"
+	gc "gopkg.in/check.v1"
+
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/config"
 	jujunetwork "github.com/juju/juju/network"
 	"github.com/juju/juju/provider/oracle"
 	"github.com/juju/juju/testing"
-	gc "gopkg.in/check.v1"
 )
 
 type instanceSuite struct{}

--- a/provider/oracle/network/environ_test.go
+++ b/provider/oracle/network/environ_test.go
@@ -9,13 +9,14 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/go-oracle-cloud/api"
 	"github.com/juju/go-oracle-cloud/response"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	names "gopkg.in/juju/names.v2"
+
 	"github.com/juju/juju/instance"
 	networkenv "github.com/juju/juju/network"
 	"github.com/juju/juju/provider/oracle/network"
 	"github.com/juju/juju/testing"
-	jc "github.com/juju/testing/checkers"
-	gc "gopkg.in/check.v1"
-	names "gopkg.in/juju/names.v2"
 )
 
 type environSuite struct{}

--- a/provider/oracle/network/firewall_test.go
+++ b/provider/oracle/network/firewall_test.go
@@ -7,14 +7,11 @@ import (
 	"time"
 
 	"github.com/juju/errors"
-
-	gc "gopkg.in/check.v1"
-
 	"github.com/juju/go-oracle-cloud/api"
 	"github.com/juju/go-oracle-cloud/common"
 	"github.com/juju/go-oracle-cloud/response"
-
 	gitjujutesting "github.com/juju/testing"
+	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/environs/config"
 	jujunetwork "github.com/juju/juju/network"

--- a/provider/oracle/network/testing/fakefirewall.go
+++ b/provider/oracle/network/testing/fakefirewall.go
@@ -7,6 +7,7 @@ import (
 	"github.com/juju/go-oracle-cloud/api"
 	"github.com/juju/go-oracle-cloud/common"
 	"github.com/juju/go-oracle-cloud/response"
+
 	"github.com/juju/juju/provider/oracle/network"
 )
 

--- a/provider/oracle/network/util_test.go
+++ b/provider/oracle/network/util_test.go
@@ -4,9 +4,10 @@
 package network_test
 
 import (
-	"github.com/juju/juju/provider/oracle/network"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/provider/oracle/network"
 )
 
 type utilSuite struct{}

--- a/provider/oracle/network/zone_test.go
+++ b/provider/oracle/network/zone_test.go
@@ -4,9 +4,10 @@
 package network_test
 
 import (
-	"github.com/juju/juju/provider/oracle/network"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/provider/oracle/network"
 )
 
 type zoneSuite struct{}

--- a/provider/oracle/networking.go
+++ b/provider/oracle/networking.go
@@ -4,10 +4,10 @@
 package oracle
 
 import (
+	"github.com/juju/errors"
 	oci "github.com/juju/go-oracle-cloud/api"
 	ociResponse "github.com/juju/go-oracle-cloud/response"
 
-	"github.com/juju/errors"
 	"github.com/juju/juju/environs"
 )
 

--- a/provider/oracle/networking_test.go
+++ b/provider/oracle/networking_test.go
@@ -4,10 +4,11 @@
 package oracle_test
 
 import (
+	gc "gopkg.in/check.v1"
+
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/provider/oracle"
 	"github.com/juju/juju/testing"
-	gc "gopkg.in/check.v1"
 )
 
 type networkingSuite struct{}

--- a/provider/oracle/provider_test.go
+++ b/provider/oracle/provider_test.go
@@ -4,14 +4,14 @@
 package oracle_test
 
 import (
+	"github.com/juju/errors"
+	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
-	"github.com/juju/errors"
 	jujucloud "github.com/juju/juju/cloud"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/provider/oracle"
 	"github.com/juju/juju/testing"
-	jc "github.com/juju/testing/checkers"
 )
 
 type environProviderSuite struct{}

--- a/provider/oracle/storage_provider.go
+++ b/provider/oracle/storage_provider.go
@@ -4,11 +4,11 @@
 package oracle
 
 import (
-	ociCommon "github.com/juju/go-oracle-cloud/common"
-
 	"github.com/juju/errors"
-	"github.com/juju/juju/storage"
+	ociCommon "github.com/juju/go-oracle-cloud/common"
 	"github.com/juju/utils/clock"
+
+	"github.com/juju/juju/storage"
 )
 
 type poolType string

--- a/provider/oracle/storage_provider_test.go
+++ b/provider/oracle/storage_provider_test.go
@@ -5,12 +5,13 @@ package oracle_test
 
 import (
 	"github.com/juju/errors"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/provider/oracle"
 	"github.com/juju/juju/storage"
 	"github.com/juju/juju/testing"
-	jc "github.com/juju/testing/checkers"
-	gc "gopkg.in/check.v1"
 )
 
 type storageProviderSuite struct{}

--- a/provider/oracle/storage_volumes.go
+++ b/provider/oracle/storage_volumes.go
@@ -9,11 +9,10 @@ import (
 	"sync"
 	"time"
 
+	"github.com/juju/errors"
 	oci "github.com/juju/go-oracle-cloud/api"
 	ociCommon "github.com/juju/go-oracle-cloud/common"
 	ociResponse "github.com/juju/go-oracle-cloud/response"
-
-	"github.com/juju/errors"
 	"github.com/juju/utils/clock"
 
 	"github.com/juju/juju/environs/tags"

--- a/provider/oracle/storage_volumes_test.go
+++ b/provider/oracle/storage_volumes_test.go
@@ -8,12 +8,13 @@ import (
 
 	"github.com/juju/go-oracle-cloud/api"
 	"github.com/juju/go-oracle-cloud/response"
+	"github.com/juju/utils/clock"
+	gc "gopkg.in/check.v1"
+
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/provider/oracle"
 	"github.com/juju/juju/storage"
 	"github.com/juju/juju/testing"
-	"github.com/juju/utils/clock"
-	gc "gopkg.in/check.v1"
 )
 
 type oracleVolumeSource struct{}

--- a/provider/oracle/userdata_test.go
+++ b/provider/oracle/userdata_test.go
@@ -4,11 +4,11 @@
 package oracle_test
 
 import (
-	"github.com/juju/juju/provider/oracle"
 	jujuos "github.com/juju/utils/os"
+	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/cloudconfig/cloudinit"
-	gc "gopkg.in/check.v1"
+	"github.com/juju/juju/provider/oracle"
 )
 
 type userdataSuite struct{}

--- a/resource/cmd/show_service.go
+++ b/resource/cmd/show_service.go
@@ -90,7 +90,7 @@ func (c *ShowServiceCommand) Init(args []string) error {
 func (c *ShowServiceCommand) Run(ctx *cmd.Context) error {
 	apiclient, err := c.deps.NewClient(c)
 	if err != nil {
-		return errors.Annotatef(err, "can't connect to %s", c.ConnectionName())
+		return errors.Trace(err)
 	}
 	defer apiclient.Close()
 

--- a/resource/cmd/upload.go
+++ b/resource/cmd/upload.go
@@ -110,7 +110,7 @@ func (c *UploadCommand) addResourceFile(arg string) error {
 func (c *UploadCommand) Run(*cmd.Context) error {
 	apiclient, err := c.deps.NewClient(c)
 	if err != nil {
-		return errors.Annotatef(err, "can't connect to %s", c.ConnectionName())
+		return errors.Trace(err)
 	}
 	defer apiclient.Close()
 

--- a/testing/cmdblockhelper.go
+++ b/testing/cmdblockhelper.go
@@ -6,6 +6,7 @@ package testing
 import (
 	"strings"
 
+	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
@@ -63,7 +64,7 @@ func (s *CmdBlockHelper) AssertBlocked(c *gc.C, err error, msg string) {
 }
 
 func AssertOperationWasBlocked(c *gc.C, err error, msg string) {
-	c.Assert(err.Error(), jc.Contains, "disabled")
+	c.Assert(err.Error(), jc.Contains, "disabled", gc.Commentf("%s", errors.Details(err)))
 	// msg is logged
 	stripped := strings.Replace(c.GetTestLog(), "\n", "", -1)
 	c.Check(stripped, gc.Matches, msg)


### PR DESCRIPTION
This makes all macaroons per-controller, so you can potentially
be logged into as a separate external user to every controller.

The cookies are stored in $JUJU_DATA/cookies-$controllername
in the same format already used for the $HOME/.go-cookies.

This disturbed quite a few invariants that tests were used to.
Here's a summary of some of the changes:

- add cookiejars to jujuclient.ClientStore so that tests weren't
inadvertently creating cookie files.

- there is now no access to ClientStore in commands before Run.
ControllerName and ModelName now return errors
because they resolve the current model or controller
name when called if needed. If a command tries to
use any of these methods during Init (or any method that relies
on them), it will panic.

- since we now have modelcmd.InnerCommand because the modelcmd
Wrap functions now return more specific interfaces, we can simplify tests
in quite a few places. In particular, many functions that returned a pair
of objects (the wrapped command and the inner command) now
just return the wrapped command, leaving it to specific test logic
to obtain the inner command if needed (for example to test the values
of instance variables after Init)

- the register command now needs to prompt for a controller
name before connecting otherwise it can't create the
cookie jar because it doesn't know where to store the cookies.

- some tests (cmd/juju/subnet, cmd/juju/space) were
reusing the same command instance several times.
