### PR TITLE
prettify instance ID and fixes

### DIFF
--- a/provider/oracle/common/interfaces.go
+++ b/provider/oracle/common/interfaces.go
@@ -7,7 +7,16 @@ import (
 	"github.com/juju/go-oracle-cloud/api"
 	"github.com/juju/go-oracle-cloud/common"
 	"github.com/juju/go-oracle-cloud/response"
+
+	"github.com/juju/juju/environs"
+	"github.com/juju/juju/instance"
 )
+
+type OracleInstancer interface {
+	environs.Environ
+
+	ProviderID(id instance.Id) (string, error)
+}
 
 // Instancer used to retrieve details from a given instance
 // in the oracle cloud infrastructure

--- a/provider/oracle/common/interfaces.go
+++ b/provider/oracle/common/interfaces.go
@@ -15,7 +15,7 @@ import (
 type OracleInstancer interface {
 	environs.Environ
 
-	ProviderID(id instance.Id) (string, error)
+	Details(id instance.Id) (response.Instance, error)
 }
 
 // Instancer used to retrieve details from a given instance

--- a/provider/oracle/environ.go
+++ b/provider/oracle/environ.go
@@ -296,11 +296,6 @@ func (e *OracleEnviron) getInstanceNetworks(
 		}
 	}
 
-	// No spaces specified by user. Just return the default NIC
-	if spaces.IsEmpty() {
-		return networking, nil
-	}
-
 	//start from 1. eth0 is the default nic that gets attached by default.
 	idx := 1
 	for _, space := range spaces.Values() {

--- a/provider/oracle/environ.go
+++ b/provider/oracle/environ.go
@@ -14,6 +14,7 @@ import (
 	"github.com/juju/errors"
 	oci "github.com/juju/go-oracle-cloud/api"
 	ociCommon "github.com/juju/go-oracle-cloud/common"
+	ociResponse "github.com/juju/go-oracle-cloud/response"
 	"github.com/juju/utils/arch"
 	"github.com/juju/utils/clock"
 	"github.com/juju/utils/os"
@@ -691,13 +692,13 @@ func (o *OracleEnviron) SetConfig(cfg *config.Config) error {
 	return nil
 }
 
-func (o *OracleEnviron) ProviderID(id instance.Id) (string, error) {
+func (o *OracleEnviron) Details(id instance.Id) (ociResponse.Instance, error) {
 	inst, err := o.getOracleInstances(id)
 	if err != nil {
-		return "", err
+		return ociResponse.Instance{}, err
 	}
 
-	return inst[0].machine.Name, nil
+	return inst[0].machine, nil
 }
 
 // Instances is part of the environs.Environ interface.

--- a/provider/oracle/environ_test.go
+++ b/provider/oracle/environ_test.go
@@ -19,11 +19,28 @@ import (
 	envtesting "github.com/juju/juju/environs/testing"
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/provider/oracle"
+	oracletesting "github.com/juju/juju/provider/oracle/testing"
 	"github.com/juju/juju/testing"
 	"github.com/juju/juju/tools"
 )
 
-type environSuite struct{}
+type environSuite struct {
+	env *oracle.OracleEnviron
+}
+
+func (e *environSuite) SetUpTest(c *gc.C) {
+	var err error
+	e.env, err = oracle.NewOracleEnviron(
+		&oracle.EnvironProvider{},
+		environs.OpenParams{
+			Config: testing.ModelConfig(c),
+		},
+		oracletesting.DefaultEnvironAPI,
+		&advancingClock,
+	)
+	c.Assert(err, gc.IsNil)
+	c.Assert(e.env, gc.NotNil)
+}
 
 var _ = gc.Suite(&environSuite{})
 
@@ -31,49 +48,14 @@ var _ = gc.Suite(&environSuite{})
 var clk = gitjujutesting.NewClock(time.Time{})
 var advancingClock = gitjujutesting.AutoAdvancingClock{clk, clk.Advance}
 
-func (e *environSuite) TestNewOracleEnviron(c *gc.C) {
-	environ, err := oracle.NewOracleEnviron(
-		oracle.DefaultProvider,
-		environs.OpenParams{
-			Config: testing.ModelConfig(c),
-		},
-		DefaultEnvironAPI,
-		&advancingClock,
-	)
-	c.Assert(err, gc.IsNil)
-	c.Assert(environ, gc.NotNil)
-}
-
 func (e *environSuite) TestAvailabilityZone(c *gc.C) {
-	environ, err := oracle.NewOracleEnviron(
-		oracle.DefaultProvider,
-		environs.OpenParams{
-			Config: testing.ModelConfig(c),
-		},
-		DefaultEnvironAPI,
-		&advancingClock,
-	)
-	c.Assert(err, gc.IsNil)
-	c.Assert(environ, gc.NotNil)
-
-	zones, err := environ.AvailabilityZones()
+	zones, err := e.env.AvailabilityZones()
 	c.Assert(err, gc.IsNil)
 	c.Assert(zones, gc.NotNil)
 }
 
 func (e *environSuite) TestInstanceAvailabilityZoneNames(c *gc.C) {
-	environ, err := oracle.NewOracleEnviron(
-		oracle.DefaultProvider,
-		environs.OpenParams{
-			Config: testing.ModelConfig(c),
-		},
-		DefaultEnvironAPI,
-		&advancingClock,
-	)
-	c.Assert(err, gc.IsNil)
-	c.Assert(environ, gc.NotNil)
-
-	zones, err := environ.InstanceAvailabilityZoneNames([]instance.Id{
+	zones, err := e.env.InstanceAvailabilityZoneNames([]instance.Id{
 		instance.Id("0"),
 	})
 	c.Assert(err, gc.IsNil)
@@ -82,12 +64,12 @@ func (e *environSuite) TestInstanceAvailabilityZoneNames(c *gc.C) {
 
 func (e *environSuite) TestInstanceAvailabilityZoneNamesWithErrors(c *gc.C) {
 	environ, err := oracle.NewOracleEnviron(
-		oracle.DefaultProvider,
+		&oracle.EnvironProvider{},
 		environs.OpenParams{
 			Config: testing.ModelConfig(c),
 		},
-		FakeEnvironAPI{
-			FakeInstancer: FakeInstancer{
+		oracletesting.FakeEnvironAPI{
+			FakeInstancer: oracletesting.FakeInstancer{
 				InstanceErr: errors.New("FakeInstanceErr"),
 			},
 		},
@@ -100,12 +82,12 @@ func (e *environSuite) TestInstanceAvailabilityZoneNamesWithErrors(c *gc.C) {
 	c.Assert(err, gc.NotNil)
 
 	environ, err = oracle.NewOracleEnviron(
-		oracle.DefaultProvider,
+		&oracle.EnvironProvider{},
 		environs.OpenParams{
 			Config: testing.ModelConfig(c),
 		},
-		FakeEnvironAPI{
-			FakeInstance: FakeInstance{
+		oracletesting.FakeEnvironAPI{
+			FakeInstance: oracletesting.FakeInstance{
 				AllErr: errors.New("FakeInstanceErr"),
 			},
 		},
@@ -122,30 +104,19 @@ func (e *environSuite) TestInstanceAvailabilityZoneNamesWithErrors(c *gc.C) {
 }
 
 func (e *environSuite) TestPrepareForBootstrap(c *gc.C) {
-	environ, err := oracle.NewOracleEnviron(
-		oracle.DefaultProvider,
-		environs.OpenParams{
-			Config: testing.ModelConfig(c),
-		},
-		DefaultEnvironAPI,
-		&advancingClock,
-	)
-	c.Assert(err, gc.IsNil)
-	c.Assert(environ, gc.NotNil)
-
 	ctx := envtesting.BootstrapContext(c)
-	err = environ.PrepareForBootstrap(ctx)
+	err := e.env.PrepareForBootstrap(ctx)
 	c.Assert(err, gc.IsNil)
 }
 
 func (e *environSuite) TestPrepareForBootstrapWithErrors(c *gc.C) {
 	environ, err := oracle.NewOracleEnviron(
-		oracle.DefaultProvider,
+		&oracle.EnvironProvider{},
 		environs.OpenParams{
 			Config: testing.ModelConfig(c),
 		},
-		FakeEnvironAPI{
-			FakeAuthenticater: FakeAuthenticater{
+		oracletesting.FakeEnvironAPI{
+			FakeAuthenticater: oracletesting.FakeAuthenticater{
 				AuthenticateErr: errors.New("FakeAuthenticateErr"),
 			},
 		},
@@ -174,11 +145,11 @@ func makeToolsList(series string) tools.List {
 
 func (e *environSuite) TestBootstrap(c *gc.C) {
 	environ, err := oracle.NewOracleEnviron(
-		oracle.DefaultProvider,
+		&oracle.EnvironProvider{},
 		environs.OpenParams{
 			Config: testing.ModelConfig(c),
 		},
-		DefaultEnvironAPI,
+		oracletesting.DefaultEnvironAPI,
 		&advancingClock,
 		//clock.WallClock,
 	)
@@ -197,18 +168,7 @@ func (e *environSuite) TestBootstrap(c *gc.C) {
 }
 
 func (e *environSuite) TestCreate(c *gc.C) {
-	environ, err := oracle.NewOracleEnviron(
-		oracle.DefaultProvider,
-		environs.OpenParams{
-			Config: testing.ModelConfig(c),
-		},
-		DefaultEnvironAPI,
-		&advancingClock,
-	)
-	c.Assert(err, gc.IsNil)
-	c.Assert(environ, gc.NotNil)
-
-	err = environ.Create(environs.CreateParams{
+	err := e.env.Create(environs.CreateParams{
 		ControllerUUID: "dsauhdiuashd",
 	})
 	c.Assert(err, gc.IsNil)
@@ -216,12 +176,12 @@ func (e *environSuite) TestCreate(c *gc.C) {
 
 func (e *environSuite) TestCreateWithErrors(c *gc.C) {
 	environ, err := oracle.NewOracleEnviron(
-		oracle.DefaultProvider,
+		&oracle.EnvironProvider{},
 		environs.OpenParams{
 			Config: testing.ModelConfig(c),
 		},
-		FakeEnvironAPI{
-			FakeAuthenticater: FakeAuthenticater{
+		oracletesting.FakeEnvironAPI{
+			FakeAuthenticater: oracletesting.FakeAuthenticater{
 				AuthenticateErr: errors.New("FakeAuthenticateErr"),
 			},
 		},
@@ -237,230 +197,76 @@ func (e *environSuite) TestCreateWithErrors(c *gc.C) {
 }
 
 func (e *environSuite) TestAdoptResources(c *gc.C) {
-	environ, err := oracle.NewOracleEnviron(
-		oracle.DefaultProvider,
-		environs.OpenParams{
-			Config: testing.ModelConfig(c),
-		},
-		DefaultEnvironAPI,
-		&advancingClock,
-	)
-	c.Assert(err, gc.IsNil)
-	c.Assert(environ, gc.NotNil)
-
-	err = environ.AdoptResources("", version.Number{})
+	err := e.env.AdoptResources("", version.Number{})
 	c.Assert(err, gc.IsNil)
 }
 
 func (e *environSuite) TestStopInstances(c *gc.C) {
-	environ, err := oracle.NewOracleEnviron(
-		oracle.DefaultProvider,
-		environs.OpenParams{
-			Config: testing.ModelConfig(c),
-		},
-		DefaultEnvironAPI,
-		&advancingClock,
-	)
-	c.Assert(err, gc.IsNil)
-	c.Assert(environ, gc.NotNil)
-
 	ids := []instance.Id{instance.Id("0")}
-	err = environ.StopInstances(ids...)
+	err := e.env.StopInstances(ids...)
 	c.Assert(err, gc.IsNil)
 }
 
 func (e *environSuite) TestAllInstances(c *gc.C) {
-	environ, err := oracle.NewOracleEnviron(
-		oracle.DefaultProvider,
-		environs.OpenParams{
-			Config: testing.ModelConfig(c),
-		},
-		DefaultEnvironAPI,
-		&advancingClock,
-	)
-	c.Assert(err, gc.IsNil)
-	c.Assert(environ, gc.NotNil)
-
-	_, err = environ.AllInstances()
+	_, err := e.env.AllInstances()
 	c.Assert(err, gc.IsNil)
 }
 
 func (e *environSuite) TestMaintainInstance(c *gc.C) {
-	environ, err := oracle.NewOracleEnviron(
-		oracle.DefaultProvider,
-		environs.OpenParams{
-			Config: testing.ModelConfig(c),
-		},
-		DefaultEnvironAPI,
-		&advancingClock,
-	)
-	c.Assert(err, gc.IsNil)
-	c.Assert(environ, gc.NotNil)
-
-	err = environ.MaintainInstance(environs.StartInstanceParams{})
+	err := e.env.MaintainInstance(environs.StartInstanceParams{})
 	c.Assert(err, gc.IsNil)
 }
 
 func (e *environSuite) TestConfig(c *gc.C) {
-	environ, err := oracle.NewOracleEnviron(
-		oracle.DefaultProvider,
-		environs.OpenParams{
-			Config: testing.ModelConfig(c),
-		},
-		DefaultEnvironAPI,
-		&advancingClock,
-	)
-	c.Assert(err, gc.IsNil)
-	c.Assert(environ, gc.NotNil)
-
-	cfg := environ.Config()
+	cfg := e.env.Config()
 	c.Assert(cfg, gc.NotNil)
 }
 
 func (e *environSuite) TestConstraintsValidator(c *gc.C) {
-	environ, err := oracle.NewOracleEnviron(
-		oracle.DefaultProvider,
-		environs.OpenParams{
-			Config: testing.ModelConfig(c),
-		},
-		DefaultEnvironAPI,
-		&advancingClock,
-	)
-	c.Assert(err, gc.IsNil)
-	c.Assert(environ, gc.NotNil)
-
-	validator, err := environ.ConstraintsValidator()
+	validator, err := e.env.ConstraintsValidator()
 	c.Assert(err, gc.IsNil)
 	c.Assert(validator, gc.NotNil)
 }
 
 func (e *environSuite) TestSetConfig(c *gc.C) {
-	environ, err := oracle.NewOracleEnviron(
-		oracle.DefaultProvider,
-		environs.OpenParams{
-			Config: testing.ModelConfig(c),
-		},
-		DefaultEnvironAPI,
-		&advancingClock,
-	)
-	c.Assert(err, gc.IsNil)
-	c.Assert(environ, gc.NotNil)
-
-	err = environ.SetConfig(testing.ModelConfig(c))
+	err := e.env.SetConfig(testing.ModelConfig(c))
 	c.Assert(err, gc.NotNil)
 }
 
 func (e *environSuite) TestInstances(c *gc.C) {
-	environ, err := oracle.NewOracleEnviron(
-		oracle.DefaultProvider,
-		environs.OpenParams{
-			Config: testing.ModelConfig(c),
-		},
-		DefaultEnvironAPI,
-		&advancingClock,
-	)
-	c.Assert(err, gc.IsNil)
-	c.Assert(environ, gc.NotNil)
-
-	instances, err := environ.Instances([]instance.Id{instance.Id("0")})
+	instances, err := e.env.Instances([]instance.Id{instance.Id("0")})
 	c.Assert(err, gc.IsNil)
 	c.Assert(instances, gc.NotNil)
 }
 
 func (e *environSuite) TestConstrollerInstances(c *gc.C) {
-	environ, err := oracle.NewOracleEnviron(
-		oracle.DefaultProvider,
-		environs.OpenParams{
-			Config: testing.ModelConfig(c),
-		},
-		DefaultEnvironAPI,
-		&advancingClock,
-	)
-	c.Assert(err, gc.IsNil)
-	c.Assert(environ, gc.NotNil)
-
-	instances, err := environ.ControllerInstances("23123-3123-12312")
+	instances, err := e.env.ControllerInstances("23123-3123-12312")
 	c.Assert(err, gc.Equals, environs.ErrNoInstances)
 	c.Assert(instances, gc.IsNil)
 }
 
 func (e *environSuite) TestDestroy(c *gc.C) {
-	environ, err := oracle.NewOracleEnviron(
-		oracle.DefaultProvider,
-		environs.OpenParams{
-			Config: testing.ModelConfig(c),
-		},
-		DefaultEnvironAPI,
-		&advancingClock,
-	)
-	c.Assert(err, gc.IsNil)
-	c.Assert(environ, gc.NotNil)
-
-	err = environ.Destroy()
+	err := e.env.Destroy()
 	c.Assert(err, gc.IsNil)
 }
 
 func (e *environSuite) TestDestroyController(c *gc.C) {
-	environ, err := oracle.NewOracleEnviron(
-		oracle.DefaultProvider,
-		environs.OpenParams{
-			Config: testing.ModelConfig(c),
-		},
-		DefaultEnvironAPI,
-		&advancingClock,
-	)
-	c.Assert(err, gc.IsNil)
-	c.Assert(environ, gc.NotNil)
-
-	err = environ.DestroyController("231233-312-321-3312")
+	err := e.env.DestroyController("231233-312-321-3312")
 	c.Assert(err, gc.IsNil)
 }
 
 func (e *environSuite) TestProvider(c *gc.C) {
-	environ, err := oracle.NewOracleEnviron(
-		oracle.DefaultProvider,
-		environs.OpenParams{
-			Config: testing.ModelConfig(c),
-		},
-		DefaultEnvironAPI,
-		&advancingClock,
-	)
-	c.Assert(err, gc.IsNil)
-	c.Assert(environ, gc.NotNil)
-
-	p := environ.Provider()
+	p := e.env.Provider()
 	c.Assert(p, gc.NotNil)
 }
 
 func (e *environSuite) TestPrecheckInstnace(c *gc.C) {
-	environ, err := oracle.NewOracleEnviron(
-		oracle.DefaultProvider,
-		environs.OpenParams{
-			Config: testing.ModelConfig(c),
-		},
-		DefaultEnvironAPI,
-		&advancingClock,
-	)
-	c.Assert(err, gc.IsNil)
-	c.Assert(environ, gc.NotNil)
-
-	err = environ.PrecheckInstance("", constraints.Value{}, "")
+	err := e.env.PrecheckInstance("", constraints.Value{}, "")
 	c.Assert(err, gc.IsNil)
 }
 
 func (e *environSuite) TestInstanceTypes(c *gc.C) {
-	environ, err := oracle.NewOracleEnviron(
-		oracle.DefaultProvider,
-		environs.OpenParams{
-			Config: testing.ModelConfig(c),
-		},
-		DefaultEnvironAPI,
-		&advancingClock,
-	)
-	c.Assert(err, gc.IsNil)
-	c.Assert(environ, gc.NotNil)
-
-	types, err := environ.InstanceTypes(constraints.Value{})
+	types, err := e.env.InstanceTypes(constraints.Value{})
 	c.Assert(err, gc.IsNil)
 	c.Assert(types, gc.NotNil)
 }

--- a/provider/oracle/export_test.go
+++ b/provider/oracle/export_test.go
@@ -6,8 +6,7 @@ package oracle
 import "github.com/juju/juju/storage"
 
 var (
-	DefaultTypes = []storage.ProviderType{oracleStorageProvideType}
-	// DefaultProvider            = &environProvider{}
+	DefaultTypes               = []storage.ProviderType{oracleStorageProvideType}
 	DefaultStorageProviderType = oracleStorageProvideType
 	OracleVolumeType           = oracleVolumeType
 	OracleLatencyPool          = latencyPool

--- a/provider/oracle/export_test.go
+++ b/provider/oracle/export_test.go
@@ -6,9 +6,8 @@ package oracle
 import "github.com/juju/juju/storage"
 
 var (
-	DefaultTypes               = []storage.ProviderType{oracleStorageProvideType}
-	DefaultProvider            = &environProvider{}
-	NewOracleEnviron           = newOracleEnviron
+	DefaultTypes = []storage.ProviderType{oracleStorageProvideType}
+	// DefaultProvider            = &environProvider{}
 	DefaultStorageProviderType = oracleStorageProvideType
 	OracleVolumeType           = oracleVolumeType
 	OracleLatencyPool          = latencyPool

--- a/provider/oracle/images_test.go
+++ b/provider/oracle/images_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/juju/juju/environs/imagemetadata"
 	"github.com/juju/juju/environs/instances"
 	"github.com/juju/juju/provider/oracle"
+	oracletesting "github.com/juju/juju/provider/oracle/testing"
 )
 
 type imageSuite struct{}
@@ -18,33 +19,33 @@ type imageSuite struct{}
 var _ = gc.Suite(&imageSuite{})
 
 func (i imageSuite) TestGetImageName(c *gc.C) {
-	name, err := oracle.GetImageName(DefaultEnvironAPI, "0")
+	name, err := oracle.GetImageName(oracletesting.DefaultEnvironAPI, "0")
 	c.Assert(err, gc.IsNil)
 	ok := len(name) > 0
 	c.Assert(ok, gc.Equals, true)
 }
 
 func (i imageSuite) TestGetImageNameWithErrors(c *gc.C) {
-	_, err := oracle.GetImageName(DefaultEnvironAPI, "")
+	_, err := oracle.GetImageName(oracletesting.DefaultEnvironAPI, "")
 	c.Assert(err, gc.NotNil)
 
-	_, err = oracle.GetImageName(FakeEnvironAPI{
-		FakeImager: FakeImager{
+	_, err = oracle.GetImageName(oracletesting.FakeEnvironAPI{
+		FakeImager: oracletesting.FakeImager{
 			AllErr: errors.New("FakeImageListErr"),
 		}}, "0")
 	c.Assert(err, gc.NotNil)
 }
 
 func (i imageSuite) TestCheckImageList(c *gc.C) {
-	images, err := oracle.CheckImageList(DefaultEnvironAPI)
+	images, err := oracle.CheckImageList(oracletesting.DefaultEnvironAPI)
 
 	c.Assert(err, gc.IsNil)
 	c.Assert(images, gc.NotNil)
 }
 
 func (i imageSuite) TestCheckImageListWithErrors(c *gc.C) {
-	_, err := oracle.CheckImageList(FakeEnvironAPI{
-		FakeImager: FakeImager{
+	_, err := oracle.CheckImageList(oracletesting.FakeEnvironAPI{
+		FakeImager: oracletesting.FakeImager{
 			AllErr: errors.New("FakeImageListErr"),
 		},
 	})
@@ -56,7 +57,7 @@ func (i imageSuite) TestCheckImageListWithErrors(c *gc.C) {
 
 func (i imageSuite) TestFindInstanceSpec(c *gc.C) {
 	spec, imagelist, err := oracle.FindInstanceSpec(
-		DefaultEnvironAPI,
+		oracletesting.DefaultEnvironAPI,
 		TestImageMetadata,
 		[]instances.InstanceType{
 			instances.InstanceType{
@@ -79,7 +80,7 @@ func (i imageSuite) TestFindInstanceSpec(c *gc.C) {
 
 func (i imageSuite) TestFindInstanceSpecWithSeriesError(c *gc.C) {
 	_, _, err := oracle.FindInstanceSpec(
-		DefaultEnvironAPI,
+		oracletesting.DefaultEnvironAPI,
 		TestImageMetadata,
 		[]instances.InstanceType{
 			instances.InstanceType{
@@ -100,7 +101,7 @@ func (i imageSuite) TestFindInstanceSpecWithSeriesError(c *gc.C) {
 
 func (i imageSuite) TestFindInstanceSpecWithError(c *gc.C) {
 	_, _, err := oracle.FindInstanceSpec(
-		DefaultEnvironAPI,
+		oracletesting.DefaultEnvironAPI,
 		[]*imagemetadata.ImageMetadata{},
 		[]instances.InstanceType{
 			instances.InstanceType{
@@ -119,15 +120,15 @@ func (i imageSuite) TestFindInstanceSpecWithError(c *gc.C) {
 }
 
 func (i imageSuite) TestInstanceTypes(c *gc.C) {
-	types, err := oracle.InstanceTypes(DefaultEnvironAPI)
+	types, err := oracle.InstanceTypes(oracletesting.DefaultEnvironAPI)
 	c.Assert(err, gc.IsNil)
 	c.Assert(types, gc.NotNil)
 }
 
 func (i imageSuite) TestInstanceTypesWithErrrors(c *gc.C) {
-	for _, fake := range []*FakeEnvironAPI{
-		&FakeEnvironAPI{
-			FakeShaper: FakeShaper{
+	for _, fake := range []*oracletesting.FakeEnvironAPI{
+		&oracletesting.FakeEnvironAPI{
+			FakeShaper: oracletesting.FakeShaper{
 				AllErr: errors.New("FakeShaperErr"),
 			},
 		},

--- a/provider/oracle/init.go
+++ b/provider/oracle/init.go
@@ -6,5 +6,5 @@ package oracle
 import "github.com/juju/juju/environs"
 
 func init() {
-	environs.RegisterProvider(providerType, &environProvider{})
+	environs.RegisterProvider(providerType, &EnvironProvider{})
 }

--- a/provider/oracle/instance.go
+++ b/provider/oracle/instance.go
@@ -31,11 +31,10 @@ type oracleInstance struct {
 	// the provider
 	machine response.Instance
 	// arch will hold the architecture information of the instance
-	arch      *string
-	instType  *instances.InstanceType
-	mutex     *sync.Mutex
-	env       *OracleEnviron
-	machineId string
+	arch     *string
+	instType *instances.InstanceType
+	mutex    *sync.Mutex
+	env      *OracleEnviron
 }
 
 // hardwareCharacteristics returns the hardware characteristics of the current
@@ -55,6 +54,20 @@ func (o *oracleInstance) hardwareCharacteristics() *instance.HardwareCharacteris
 	return hc
 }
 
+// extractHostnameFromProviderID will return the hostname of the machine
+// identified by the provider ID. In the Oracle compute cloud the provider
+// IDs of the instances has the following format:
+// /Compute-tenant_domain/tenant_username/instance_hostname/instance_UUID
+func extractHostnameFromProviderID(id string) (instance.Id, error) {
+	var instId instance.Id
+	name := strings.Split(id, "/")
+	if len(name) < 4 {
+		return instId, errors.Errorf("invalid instance name: %s", id)
+	}
+	instId = instance.Id(name[3])
+	return instId, nil
+}
+
 // newInstance returns a new oracleInstance
 func newInstance(params response.Instance, env *OracleEnviron) (*oracleInstance, error) {
 	if params.Name == "" {
@@ -62,20 +75,20 @@ func newInstance(params response.Instance, env *OracleEnviron) (*oracleInstance,
 			"Instance response does not contain a name",
 		)
 	}
-	//gsamfira: there must be a better way to do this.
-	splitMachineName := strings.Split(params.Label, "-")
-	machineId := splitMachineName[len(splitMachineName)-1]
+	name, err := extractHostnameFromProviderID(params.Name)
+	if err != nil {
+		return nil, err
+	}
 	mutex := &sync.Mutex{}
 	instance := &oracleInstance{
-		name: params.Name,
+		name: string(name),
 		status: instance.InstanceStatus{
 			Status:  status.Status(params.State),
 			Message: "",
 		},
-		machine:   params,
-		mutex:     mutex,
-		env:       env,
-		machineId: machineId,
+		machine: params,
+		mutex:   mutex,
+		env:     env,
 	}
 
 	return instance, nil
@@ -84,7 +97,11 @@ func newInstance(params response.Instance, env *OracleEnviron) (*oracleInstance,
 // Id is defined on the instance.Instance interface.
 func (o *oracleInstance) Id() instance.Id {
 	if o.machine.Name != "" {
-		return instance.Id(o.machine.Name)
+		name, err := extractHostnameFromProviderID(o.machine.Name)
+		if err != nil {
+			return instance.Id(o.machine.Name)
+		}
+		return name
 	}
 
 	return instance.Id(o.name)
@@ -111,7 +128,7 @@ func (o *oracleInstance) refresh() error {
 	o.mutex.Lock()
 	defer o.mutex.Unlock()
 
-	machine, err := o.env.client.InstanceDetails(o.name)
+	machine, err := o.env.client.InstanceDetails(o.machine.Name)
 	// if the request failed for any reason
 	// we should not update the information and
 	// let the old one persist
@@ -158,7 +175,7 @@ func (o *oracleInstance) deleteInstanceAndResources(cleanup bool) error {
 		}
 	}
 
-	if err := o.env.client.DeleteInstance(o.name); err != nil {
+	if err := o.env.client.DeleteInstance(o.machine.Name); err != nil {
 		return errors.Trace(err)
 	}
 
@@ -167,9 +184,9 @@ func (o *oracleInstance) deleteInstanceAndResources(cleanup bool) error {
 		// delete a security list if there is still a VM associated with it.
 		iteration := 0
 		for {
-			if instance, err := o.env.client.InstanceDetails(o.name); !oci.IsNotFound(err) {
+			if instance, err := o.env.client.InstanceDetails(o.machine.Name); !oci.IsNotFound(err) {
 				if instance.State == ociCommon.StateError {
-					logger.Warningf("Instance %s entered error state", o.name)
+					logger.Warningf("Instance %s entered error state", o.machine.Name)
 					break
 				}
 				if iteration >= 30 && instance.State == ociCommon.StateRunning {
@@ -183,21 +200,21 @@ func (o *oracleInstance) deleteInstanceAndResources(cleanup bool) error {
 				iteration++
 				continue
 			}
-			logger.Debugf("Machine %v successfully deleted", o.name)
+			logger.Debugf("Machine %v successfully deleted", o.machine.Name)
 			break
 		}
 
 		// the VM association is now gone, now we can delete the
 		// machine sec list
-		logger.Debugf("deleting seclist for instance: %s", o.machineId)
-		if err := o.env.DeleteMachineSecList(o.machineId); err != nil {
+		logger.Debugf("deleting seclist for instance: %s", string(o.Id()))
+		if err := o.env.DeleteMachineSecList(string(o.Id())); err != nil {
 			logger.Errorf("failed to delete seclist: %s", err)
 			if !oci.IsMethodNotAllowed(err) {
 				return errors.Trace(err)
 			}
 		}
-		logger.Debugf("deleting vnic set for instance: %s", o.machineId)
-		if err := o.env.DeleteMachineVnicSet(o.machineId); err != nil {
+		logger.Debugf("deleting vnic set for instance: %s", string(o.Id()))
+		if err := o.env.DeleteMachineVnicSet(string(o.Id())); err != nil {
 			logger.Errorf("failed to delete vnic set: %s", err)
 			if !oci.IsMethodNotAllowed(err) {
 				return errors.Trace(err)

--- a/provider/oracle/instance.go
+++ b/provider/oracle/instance.go
@@ -54,11 +54,11 @@ func (o *oracleInstance) hardwareCharacteristics() *instance.HardwareCharacteris
 	return hc
 }
 
-// extractHostnameFromProviderID will return the hostname of the machine
+// extractInstanceIDFromMachineName will return the hostname of the machine
 // identified by the provider ID. In the Oracle compute cloud the provider
 // IDs of the instances has the following format:
 // /Compute-tenant_domain/tenant_username/instance_hostname/instance_UUID
-func extractHostnameFromProviderID(id string) (instance.Id, error) {
+func extractInstanceIDFromMachineName(id string) (instance.Id, error) {
 	var instId instance.Id
 	name := strings.Split(id, "/")
 	if len(name) < 4 {
@@ -75,7 +75,7 @@ func newInstance(params response.Instance, env *OracleEnviron) (*oracleInstance,
 			"Instance response does not contain a name",
 		)
 	}
-	name, err := extractHostnameFromProviderID(params.Name)
+	name, err := extractInstanceIDFromMachineName(params.Name)
 	if err != nil {
 		return nil, err
 	}
@@ -97,7 +97,7 @@ func newInstance(params response.Instance, env *OracleEnviron) (*oracleInstance,
 // Id is defined on the instance.Instance interface.
 func (o *oracleInstance) Id() instance.Id {
 	if o.machine.Name != "" {
-		name, err := extractHostnameFromProviderID(o.machine.Name)
+		name, err := extractInstanceIDFromMachineName(o.machine.Name)
 		if err != nil {
 			return instance.Id(o.machine.Name)
 		}

--- a/provider/oracle/instance_test.go
+++ b/provider/oracle/instance_test.go
@@ -5,6 +5,7 @@ package oracle_test
 
 import (
 	"errors"
+	"sync"
 
 	"github.com/juju/go-oracle-cloud/response"
 	gc "gopkg.in/check.v1"
@@ -13,60 +14,52 @@ import (
 	"github.com/juju/juju/environs/config"
 	jujunetwork "github.com/juju/juju/network"
 	"github.com/juju/juju/provider/oracle"
+	oracletesting "github.com/juju/juju/provider/oracle/testing"
 	"github.com/juju/juju/testing"
 )
 
-type instanceSuite struct{}
+type instanceSuite struct {
+	env   *oracle.OracleEnviron
+	mutex *sync.Mutex
+}
+
+func (i *instanceSuite) SetUpTest(c *gc.C) {
+	var err error
+	i.env, err = oracle.NewOracleEnviron(
+		&oracle.EnvironProvider{},
+		environs.OpenParams{
+			Config: testing.ModelConfig(c),
+		},
+		oracletesting.DefaultEnvironAPI,
+		&advancingClock,
+	)
+	c.Assert(err, gc.IsNil)
+	c.Assert(i.env, gc.NotNil)
+	i.mutex = &sync.Mutex{}
+}
+
+func (i *instanceSuite) setEnvironAPI(client oracle.EnvironAPI) {
+	i.mutex.Lock()
+	defer i.mutex.Unlock()
+	i.env.SetEnvironAPI(client)
+}
 
 var _ = gc.Suite(&instanceSuite{})
 
 func (i instanceSuite) TestNewOracleInstanceEmpty(c *gc.C) {
-	environ, err := oracle.NewOracleEnviron(
-		oracle.DefaultProvider,
-		environs.OpenParams{
-			Config: testing.ModelConfig(c),
-		},
-		DefaultEnvironAPI,
-		&advancingClock,
-	)
-	c.Assert(err, gc.IsNil)
-	c.Assert(environ, gc.NotNil)
-
-	instance, err := oracle.NewOracleInstance(response.Instance{}, environ)
+	instance, err := oracle.NewOracleInstance(response.Instance{}, i.env)
 	c.Assert(err, gc.NotNil)
 	c.Assert(instance, gc.IsNil)
 }
 
 func (i instanceSuite) TestNewOracleInstance(c *gc.C) {
-	environ, err := oracle.NewOracleEnviron(
-		oracle.DefaultProvider,
-		environs.OpenParams{
-			Config: testing.ModelConfig(c),
-		},
-		DefaultEnvironAPI,
-		&advancingClock,
-	)
-	c.Assert(err, gc.IsNil)
-	c.Assert(environ, gc.NotNil)
-
-	instance, err := oracle.NewOracleInstance(DefaultFakeInstancer.Instance, environ)
+	instance, err := oracle.NewOracleInstance(oracletesting.DefaultFakeInstancer.Instance, i.env)
 	c.Assert(err, gc.IsNil)
 	c.Assert(instance, gc.NotNil)
 }
 
 func (i instanceSuite) TestId(c *gc.C) {
-	environ, err := oracle.NewOracleEnviron(
-		oracle.DefaultProvider,
-		environs.OpenParams{
-			Config: testing.ModelConfig(c),
-		},
-		DefaultEnvironAPI,
-		&advancingClock,
-	)
-	c.Assert(err, gc.IsNil)
-	c.Assert(environ, gc.NotNil)
-
-	instance, err := oracle.NewOracleInstance(DefaultFakeInstancer.Instance, environ)
+	instance, err := oracle.NewOracleInstance(oracletesting.DefaultFakeInstancer.Instance, i.env)
 	c.Assert(err, gc.IsNil)
 	c.Assert(instance, gc.NotNil)
 
@@ -76,18 +69,7 @@ func (i instanceSuite) TestId(c *gc.C) {
 }
 
 func (i instanceSuite) TestStatus(c *gc.C) {
-	environ, err := oracle.NewOracleEnviron(
-		oracle.DefaultProvider,
-		environs.OpenParams{
-			Config: testing.ModelConfig(c),
-		},
-		DefaultEnvironAPI,
-		&advancingClock,
-	)
-	c.Assert(err, gc.IsNil)
-	c.Assert(environ, gc.NotNil)
-
-	instance, err := oracle.NewOracleInstance(DefaultFakeInstancer.Instance, environ)
+	instance, err := oracle.NewOracleInstance(oracletesting.DefaultFakeInstancer.Instance, i.env)
 	c.Assert(err, gc.IsNil)
 	c.Assert(instance, gc.NotNil)
 
@@ -99,18 +81,7 @@ func (i instanceSuite) TestStatus(c *gc.C) {
 }
 
 func (i instanceSuite) TestStorageAttachments(c *gc.C) {
-	environ, err := oracle.NewOracleEnviron(
-		oracle.DefaultProvider,
-		environs.OpenParams{
-			Config: testing.ModelConfig(c),
-		},
-		DefaultEnvironAPI,
-		&advancingClock,
-	)
-	c.Assert(err, gc.IsNil)
-	c.Assert(environ, gc.NotNil)
-
-	instance, err := oracle.NewOracleInstance(DefaultFakeInstancer.Instance, environ)
+	instance, err := oracle.NewOracleInstance(oracletesting.DefaultFakeInstancer.Instance, i.env)
 	c.Assert(err, gc.IsNil)
 	c.Assert(instance, gc.NotNil)
 
@@ -119,18 +90,7 @@ func (i instanceSuite) TestStorageAttachments(c *gc.C) {
 }
 
 func (i instanceSuite) TestAddresses(c *gc.C) {
-	environ, err := oracle.NewOracleEnviron(
-		oracle.DefaultProvider,
-		environs.OpenParams{
-			Config: testing.ModelConfig(c),
-		},
-		DefaultEnvironAPI,
-		&advancingClock,
-	)
-	c.Assert(err, gc.IsNil)
-	c.Assert(environ, gc.NotNil)
-
-	instance, err := oracle.NewOracleInstance(DefaultFakeInstancer.Instance, environ)
+	instance, err := oracle.NewOracleInstance(oracletesting.DefaultFakeInstancer.Instance, i.env)
 	c.Assert(err, gc.IsNil)
 	c.Assert(instance, gc.NotNil)
 
@@ -140,22 +100,14 @@ func (i instanceSuite) TestAddresses(c *gc.C) {
 }
 
 func (i instanceSuite) TestAddressesWithErrors(c *gc.C) {
-	environ, err := oracle.NewOracleEnviron(
-		oracle.DefaultProvider,
-		environs.OpenParams{
-			Config: testing.ModelConfig(c),
+	fakeEnv := &oracletesting.FakeEnvironAPI{
+		FakeIpAssociation: oracletesting.FakeIpAssociation{
+			AllErr: errors.New("FakeEnvironAPI"),
 		},
-		&FakeEnvironAPI{
-			FakeIpAssociation: FakeIpAssociation{
-				AllErr: errors.New("FakeEnvironAPI"),
-			},
-		},
-		&advancingClock,
-	)
-	c.Assert(err, gc.IsNil)
-	c.Assert(environ, gc.NotNil)
+	}
+	i.setEnvironAPI(fakeEnv)
 
-	instance, err := oracle.NewOracleInstance(DefaultFakeInstancer.Instance, environ)
+	instance, err := oracle.NewOracleInstance(oracletesting.DefaultFakeInstancer.Instance, i.env)
 	c.Assert(err, gc.IsNil)
 	c.Assert(instance, gc.NotNil)
 
@@ -164,22 +116,16 @@ func (i instanceSuite) TestAddressesWithErrors(c *gc.C) {
 }
 
 func (i instanceSuite) TestOpenPorts(c *gc.C) {
-	fakeConfig := testing.CustomModelConfig(c, testing.Attrs{
+	fakeConfig := map[string]interface{}{
 		"firewall-mode": config.FwInstance,
-	})
-
-	environ, err := oracle.NewOracleEnviron(
-		oracle.DefaultProvider,
-		environs.OpenParams{
-			Config: fakeConfig,
-		},
-		DefaultEnvironAPI,
-		&advancingClock,
-	)
+	}
+	config, err := i.env.Config().Apply(fakeConfig)
 	c.Assert(err, gc.IsNil)
-	c.Assert(environ, gc.NotNil)
 
-	instance, err := oracle.NewOracleInstance(DefaultFakeInstancer.Instance, environ)
+	err = i.env.SetConfig(config)
+	c.Assert(err, gc.IsNil)
+
+	instance, err := oracle.NewOracleInstance(oracletesting.DefaultFakeInstancer.Instance, i.env)
 	c.Assert(err, gc.IsNil)
 	c.Assert(instance, gc.NotNil)
 
@@ -196,22 +142,16 @@ func (i instanceSuite) TestOpenPorts(c *gc.C) {
 }
 
 func (i instanceSuite) TestClosePorts(c *gc.C) {
-	fakeConfig := testing.CustomModelConfig(c, testing.Attrs{
+	fakeConfig := map[string]interface{}{
 		"firewall-mode": config.FwInstance,
-	})
-
-	environ, err := oracle.NewOracleEnviron(
-		oracle.DefaultProvider,
-		environs.OpenParams{
-			Config: fakeConfig,
-		},
-		DefaultEnvironAPI,
-		&advancingClock,
-	)
+	}
+	config, err := i.env.Config().Apply(fakeConfig)
 	c.Assert(err, gc.IsNil)
-	c.Assert(environ, gc.NotNil)
 
-	instance, err := oracle.NewOracleInstance(DefaultFakeInstancer.Instance, environ)
+	err = i.env.SetConfig(config)
+	c.Assert(err, gc.IsNil)
+
+	instance, err := oracle.NewOracleInstance(oracletesting.DefaultFakeInstancer.Instance, i.env)
 	c.Assert(err, gc.IsNil)
 	c.Assert(instance, gc.NotNil)
 
@@ -228,22 +168,17 @@ func (i instanceSuite) TestClosePorts(c *gc.C) {
 }
 
 func (i instanceSuite) TestIngressRules(c *gc.C) {
-	fakeConfig := testing.CustomModelConfig(c, testing.Attrs{
+	fakeConfig := map[string]interface{}{
 		"firewall-mode": config.FwInstance,
-	})
+	}
 
-	environ, err := oracle.NewOracleEnviron(
-		oracle.DefaultProvider,
-		environs.OpenParams{
-			Config: fakeConfig,
-		},
-		DefaultEnvironAPI,
-		&advancingClock,
-	)
+	config, err := i.env.Config().Apply(fakeConfig)
 	c.Assert(err, gc.IsNil)
-	c.Assert(environ, gc.NotNil)
 
-	instance, err := oracle.NewOracleInstance(DefaultFakeInstancer.Instance, environ)
+	err = i.env.SetConfig(config)
+	c.Assert(err, gc.IsNil)
+
+	instance, err := oracle.NewOracleInstance(oracletesting.DefaultFakeInstancer.Instance, i.env)
 	c.Assert(err, gc.IsNil)
 	c.Assert(instance, gc.NotNil)
 

--- a/provider/oracle/network/environ.go
+++ b/provider/oracle/network/environ.go
@@ -155,12 +155,7 @@ func (e Environ) getSubnetInfo() ([]network.SubnetInfo, error) {
 
 // NetworkInterfaces is defined on the environs.Networking interface.
 func (e Environ) NetworkInterfaces(instId instance.Id) ([]network.InterfaceInfo, error) {
-	providerId, err := e.env.ProviderID(instId)
-	if err != nil {
-		return nil, err
-	}
-
-	instance, err := e.client.InstanceDetails(providerId)
+	instance, err := e.env.Details(instId)
 	if err != nil {
 		return nil, err
 	}

--- a/provider/oracle/network/environ.go
+++ b/provider/oracle/network/environ.go
@@ -40,14 +40,17 @@ type NetworkingAPI interface {
 // Environ implements the environs.Networking interface
 type Environ struct {
 	client NetworkingAPI
+
+	env commonProvider.OracleInstancer
 }
 
 var _ environs.Networking = (*Environ)(nil)
 
 // NewEnviron returns a new instance of Environ
-func NewEnviron(api NetworkingAPI) *Environ {
+func NewEnviron(api NetworkingAPI, env commonProvider.OracleInstancer) *Environ {
 	return &Environ{
 		client: api,
+		env:    env,
 	}
 }
 
@@ -152,8 +155,12 @@ func (e Environ) getSubnetInfo() ([]network.SubnetInfo, error) {
 
 // NetworkInterfaces is defined on the environs.Networking interface.
 func (e Environ) NetworkInterfaces(instId instance.Id) ([]network.InterfaceInfo, error) {
-	id := string(instId)
-	instance, err := e.client.InstanceDetails(id)
+	providerId, err := e.env.ProviderID(instId)
+	if err != nil {
+		return nil, err
+	}
+
+	instance, err := e.client.InstanceDetails(providerId)
 	if err != nil {
 		return nil, err
 	}

--- a/provider/oracle/network/environ_test.go
+++ b/provider/oracle/network/environ_test.go
@@ -13,17 +13,41 @@ import (
 	gc "gopkg.in/check.v1"
 	names "gopkg.in/juju/names.v2"
 
+	"github.com/juju/juju/environs"
 	"github.com/juju/juju/instance"
 	networkenv "github.com/juju/juju/network"
+	"github.com/juju/juju/provider/oracle"
 	"github.com/juju/juju/provider/oracle/network"
+	oracletesting "github.com/juju/juju/provider/oracle/testing"
 	"github.com/juju/juju/testing"
 )
 
-type environSuite struct{}
+type environSuite struct {
+	env    *oracle.OracleEnviron
+	netEnv *network.Environ
+}
 
 var _ = gc.Suite(&environSuite{})
 
 type fakeNetworkingAPI struct{}
+
+func (f *environSuite) SetUpTest(c *gc.C) {
+	var err error
+	f.env, err = oracle.NewOracleEnviron(
+		&oracle.EnvironProvider{},
+		environs.OpenParams{
+			Config: testing.ModelConfig(c),
+		},
+		oracletesting.DefaultEnvironAPI,
+		&advancingClock,
+	)
+
+	c.Assert(err, gc.IsNil)
+	c.Assert(f.env, gc.NotNil)
+
+	f.netEnv = network.NewEnviron(&fakeNetworkingAPI{}, f.env)
+	c.Assert(f.netEnv, gc.NotNil)
+}
 
 func (f fakeNetworkingAPI) AllIpNetworks(
 	filter []api.Filter,
@@ -47,8 +71,8 @@ func (f fakeNetworkingAPI) InstanceDetails(
 	return response.Instance{
 		Shape:     "oc3",
 		Imagelist: "/oracle/public/oel_6.4_2GB_v1",
-		Name:      "/Compute-acme/jack.jones@example.com/dev-vm",
-		Label:     "dev-vm",
+		Name:      "/Compute-acme/jack.jones@example.com/0/88e5710d-ccce-4da6-97f8-36ab7999b705",
+		Label:     "0",
 		SSHKeys: []string{
 			"/Compute-acme/jack.jones@example.com/dev-key1",
 		},
@@ -60,37 +84,23 @@ func (f fakeNetworkingAPI) AllAcls(filter []api.Filter) (response.AllAcls, error
 }
 
 func (f fakeNetworkingAPI) ComposeName(name string) string {
-	return fmt.Sprintf("https://some-url.us6.com/Compute-test/%s", name)
-}
-
-func (e *environSuite) TestNewEnviron(c *gc.C) {
-	env := network.NewEnviron(&fakeNetworkingAPI{})
-	c.Assert(env, gc.NotNil)
+	return fmt.Sprintf("https://some-url.us6.com/%s", name)
 }
 
 func (e *environSuite) TestSupportSpaces(c *gc.C) {
-	env := network.NewEnviron(&fakeNetworkingAPI{})
-	c.Assert(env, gc.NotNil)
-
-	ok, err := env.SupportsSpaces()
+	ok, err := e.netEnv.SupportsSpaces()
 	c.Assert(err, gc.IsNil)
 	c.Assert(ok, jc.IsTrue)
 }
 
 func (e *environSuite) TestSupportsSpaceDiscovery(c *gc.C) {
-	env := network.NewEnviron(&fakeNetworkingAPI{})
-	c.Assert(env, gc.NotNil)
-
-	ok, err := env.SupportsSpaceDiscovery()
+	ok, err := e.netEnv.SupportsSpaceDiscovery()
 	c.Assert(err, gc.IsNil)
 	c.Assert(ok, jc.IsTrue)
 }
 
 func (e *environSuite) TestSupportsContainerAddress(c *gc.C) {
-	env := network.NewEnviron(&fakeNetworkingAPI{})
-	c.Assert(env, gc.NotNil)
-
-	ok, err := env.SupportsContainerAddresses()
+	ok, err := e.netEnv.SupportsContainerAddresses()
 	c.Assert(err, gc.NotNil)
 	c.Assert(ok, jc.IsFalse)
 	is := errors.IsNotSupported(err)
@@ -98,16 +108,13 @@ func (e *environSuite) TestSupportsContainerAddress(c *gc.C) {
 }
 
 func (e *environSuite) TestAllocateContainerAddress(c *gc.C) {
-	env := network.NewEnviron(&fakeNetworkingAPI{})
-	c.Assert(env, gc.NotNil)
-
 	var (
 		id   instance.Id
 		tag  names.MachineTag
 		info []networkenv.InterfaceInfo
 	)
 
-	addr, err := env.AllocateContainerAddresses(id, tag, info)
+	addr, err := e.netEnv.AllocateContainerAddresses(id, tag, info)
 	c.Assert(err, gc.NotNil)
 	c.Assert(addr, gc.IsNil)
 	is := errors.IsNotSupported(err)
@@ -115,62 +122,40 @@ func (e *environSuite) TestAllocateContainerAddress(c *gc.C) {
 }
 
 func (e *environSuite) TestReleaseContainerAddresses(c *gc.C) {
-	env := network.NewEnviron(&fakeNetworkingAPI{})
-	c.Assert(env, gc.NotNil)
-
 	var i []networkenv.ProviderInterfaceInfo
-	err := env.ReleaseContainerAddresses(i)
+	err := e.netEnv.ReleaseContainerAddresses(i)
 	c.Assert(err, gc.NotNil)
 	is := errors.IsNotSupported(err)
 	c.Assert(is, jc.IsTrue)
 }
 
 func (e *environSuite) TestSubnetsWithEmptyParams(c *gc.C) {
-	env := network.NewEnviron(&fakeNetworkingAPI{})
-	c.Assert(env, gc.NotNil)
-
-	info, err := env.Subnets("", nil)
+	info, err := e.netEnv.Subnets("", nil)
 	c.Assert(info, jc.DeepEquals, []networkenv.SubnetInfo{})
 	c.Assert(err, gc.IsNil)
 }
 
 func (e *environSuite) TestSubnets(c *gc.C) {
-	env := network.NewEnviron(&fakeNetworkingAPI{})
-	c.Assert(env, gc.NotNil)
-
-	cfg := fakeEnvironConfig{cfg: testing.ModelConfig(c)}
-	id := cfg.Config().UUID()
-	ids := []networkenv.Id{networkenv.Id(id)}
-	info, err := env.Subnets(instance.Id(id), ids)
+	ids := []networkenv.Id{networkenv.Id("0")}
+	info, err := e.netEnv.Subnets(instance.Id("0"), ids)
 	c.Assert(info, jc.DeepEquals, []networkenv.SubnetInfo{})
 	c.Assert(err, gc.IsNil)
 }
 
 func (e *environSuite) TestNetworkInterfacesWithEmptyParams(c *gc.C) {
-	env := network.NewEnviron(&fakeNetworkingAPI{})
-	c.Assert(env, gc.NotNil)
-
-	info, err := env.NetworkInterfaces(instance.Id(""))
+	info, err := e.netEnv.NetworkInterfaces(instance.Id("0"))
 	c.Assert(info, jc.DeepEquals, []networkenv.InterfaceInfo{})
 	c.Assert(err, gc.IsNil)
 }
 
 func (e *environSuite) TestNetworkInterfaces(c *gc.C) {
-	env := network.NewEnviron(&fakeNetworkingAPI{})
-	c.Assert(env, gc.NotNil)
-
-	info, err := env.NetworkInterfaces(instance.Id(
-		testing.ModelConfig(c).UUID(),
-	))
+	info, err := e.netEnv.NetworkInterfaces(instance.Id("0"))
 	c.Assert(info, jc.DeepEquals, []networkenv.InterfaceInfo{})
 	c.Assert(err, gc.IsNil)
 }
 
 func (e *environSuite) TestSpaces(c *gc.C) {
-	env := network.NewEnviron(&fakeNetworkingAPI{})
-	c.Assert(env, gc.NotNil)
-
-	info, err := env.Spaces()
+	info, err := e.netEnv.Spaces()
 	c.Assert(err, gc.IsNil)
 	c.Assert(info, jc.DeepEquals, []networkenv.SpaceInfo{})
 }

--- a/provider/oracle/network/firewall_test.go
+++ b/provider/oracle/network/firewall_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/juju/juju/environs/config"
 	jujunetwork "github.com/juju/juju/network"
 	"github.com/juju/juju/provider/oracle/network"
-	providertest "github.com/juju/juju/provider/oracle/network/testing"
+	providertest "github.com/juju/juju/provider/oracle/testing"
 	"github.com/juju/juju/testing"
 )
 

--- a/provider/oracle/networking_test.go
+++ b/provider/oracle/networking_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/provider/oracle"
+	oracletesting "github.com/juju/juju/provider/oracle/testing"
 	"github.com/juju/juju/testing"
 )
 
@@ -17,11 +18,11 @@ var _ = gc.Suite(&networkingSuite{})
 
 func (n networkingSuite) TestDeleteMachineVnicSet(c *gc.C) {
 	environ, err := oracle.NewOracleEnviron(
-		oracle.DefaultProvider,
+		&oracle.EnvironProvider{},
 		environs.OpenParams{
 			Config: testing.ModelConfig(c),
 		},
-		DefaultEnvironAPI,
+		oracletesting.DefaultEnvironAPI,
 		&advancingClock,
 	)
 

--- a/provider/oracle/provider.go
+++ b/provider/oracle/provider.go
@@ -22,8 +22,8 @@ const (
 	providerType = "oracle-compute"
 )
 
-// environProvider type implements environs.EnvironProvider interface
-type environProvider struct{}
+// EnvironProvider type implements environs.EnvironProvider interface
+type EnvironProvider struct{}
 
 var cloudSchema = &jsonschema.Schema{
 	Type:     []jsonschema.Type{jsonschema.ObjectType},
@@ -44,17 +44,17 @@ var cloudSchema = &jsonschema.Schema{
 }
 
 // CloudSchema is defined on the environs.EnvironProvider interface.
-func (e environProvider) CloudSchema() *jsonschema.Schema {
+func (e EnvironProvider) CloudSchema() *jsonschema.Schema {
 	return cloudSchema
 }
 
 // Ping is defined on the environs.EnvironProvider interface.
-func (e environProvider) Ping(endpoint string) error {
+func (e EnvironProvider) Ping(endpoint string) error {
 	return nil
 }
 
 // PrepareConfig is defined on the environs.EnvironProvider interface.
-func (e environProvider) PrepareConfig(config environs.PrepareConfigParams) (*config.Config, error) {
+func (e EnvironProvider) PrepareConfig(config environs.PrepareConfigParams) (*config.Config, error) {
 	if err := e.validateCloudSpec(config.Cloud); err != nil {
 		return nil, errors.Annotatef(err, "validating cloud spec")
 	}
@@ -63,7 +63,7 @@ func (e environProvider) PrepareConfig(config environs.PrepareConfigParams) (*co
 }
 
 // validateCloudSpec validates the given configuration against the oracle cloud spec
-func (e environProvider) validateCloudSpec(spec environs.CloudSpec) error {
+func (e EnvironProvider) validateCloudSpec(spec environs.CloudSpec) error {
 	if err := spec.Validate(); err != nil {
 		return errors.Trace(err)
 	}
@@ -84,7 +84,7 @@ func (e environProvider) validateCloudSpec(spec environs.CloudSpec) error {
 }
 
 // Open is defined on the environs.EnvironProvider interface.
-func (e *environProvider) Open(params environs.OpenParams) (environs.Environ, error) {
+func (e *EnvironProvider) Open(params environs.OpenParams) (environs.Environ, error) {
 	logger.Debugf("opening model %q", params.Config.Name())
 	if err := e.validateCloudSpec(params.Cloud); err != nil {
 		return nil, errors.Annotatef(err, "validating cloud spec")
@@ -104,11 +104,11 @@ func (e *environProvider) Open(params environs.OpenParams) (environs.Environ, er
 		return nil, errors.Trace(err)
 	}
 
-	return newOracleEnviron(e, params, cli, clock.WallClock)
+	return NewOracleEnviron(e, params, cli, clock.WallClock)
 }
 
 // Validate is defined on the config.Validator interface.
-func (e environProvider) Validate(cfg, old *config.Config) (valid *config.Config, err error) {
+func (e EnvironProvider) Validate(cfg, old *config.Config) (valid *config.Config, err error) {
 	if err := config.Validate(cfg, old); err != nil {
 		return nil, err
 	}
@@ -140,17 +140,17 @@ var credentials = map[cloud.AuthType]cloud.CredentialSchema{
 }
 
 // CredentialSchemas is defined on the environs.ProviderCredentials interface.
-func (e environProvider) CredentialSchemas() map[cloud.AuthType]cloud.CredentialSchema {
+func (e EnvironProvider) CredentialSchemas() map[cloud.AuthType]cloud.CredentialSchema {
 	return credentials
 }
 
 // DetectCredentials is defined on the environs.ProviderCredentials interface.
-func (e environProvider) DetectCredentials() (*cloud.CloudCredential, error) {
+func (e EnvironProvider) DetectCredentials() (*cloud.CloudCredential, error) {
 	return nil, errors.NotFoundf("credentials")
 }
 
 // FinalizeCredential is defined on the environs.ProviderCredentials interface.
-func (e environProvider) FinalizeCredential(
+func (e EnvironProvider) FinalizeCredential(
 	cfx environs.FinalizeCredentialContext,
 	params environs.FinalizeCredentialParams,
 ) (*cloud.Credential, error) {

--- a/provider/oracle/storage_provider_test.go
+++ b/provider/oracle/storage_provider_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/provider/oracle"
+	oracletesting "github.com/juju/juju/provider/oracle/testing"
 	"github.com/juju/juju/storage"
 	"github.com/juju/juju/testing"
 )
@@ -20,11 +21,11 @@ var _ = gc.Suite(&storageProviderSuite{})
 
 func NewStorageProviderTest(c *gc.C) storage.Provider {
 	env, err := oracle.NewOracleEnviron(
-		oracle.DefaultProvider,
+		&oracle.EnvironProvider{},
 		environs.OpenParams{
 			Config: testing.ModelConfig(c),
 		},
-		DefaultEnvironAPI,
+		oracletesting.DefaultEnvironAPI,
 		&advancingClock,
 	)
 

--- a/provider/oracle/storage_test.go
+++ b/provider/oracle/storage_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/provider/oracle"
+	oracletesting "github.com/juju/juju/provider/oracle/testing"
 	"github.com/juju/juju/storage"
 	"github.com/juju/juju/testing"
 )
@@ -18,11 +19,11 @@ var _ = gc.Suite(&storageSuite{})
 
 func (s *storageSuite) NewStorageProvider(c *gc.C) storage.ProviderRegistry {
 	env, err := oracle.NewOracleEnviron(
-		oracle.DefaultProvider,
+		&oracle.EnvironProvider{},
 		environs.OpenParams{
 			Config: testing.ModelConfig(c),
 		},
-		DefaultEnvironAPI,
+		oracletesting.DefaultEnvironAPI,
 		&advancingClock,
 	)
 	c.Assert(err, gc.IsNil)

--- a/provider/oracle/storage_volumes.go
+++ b/provider/oracle/storage_volumes.go
@@ -338,7 +338,7 @@ func (s *oracleVolumeSource) getStorageAttachments() (map[string][]ociResponse.S
 	}
 	asMap := map[string][]ociResponse.StorageAttachment{}
 	for _, val := range allAttachments.Result {
-		hostname, err := extractHostnameFromProviderID(val.Instance_name)
+		hostname, err := extractInstanceIDFromMachineName(val.Instance_name)
 		if err != nil {
 			return nil, err
 		}

--- a/provider/oracle/storage_volumes.go
+++ b/provider/oracle/storage_volumes.go
@@ -338,12 +338,16 @@ func (s *oracleVolumeSource) getStorageAttachments() (map[string][]ociResponse.S
 	}
 	asMap := map[string][]ociResponse.StorageAttachment{}
 	for _, val := range allAttachments.Result {
-		if _, ok := asMap[val.Instance_name]; !ok {
-			asMap[val.Instance_name] = []ociResponse.StorageAttachment{
+		hostname, err := extractHostnameFromProviderID(val.Instance_name)
+		if err != nil {
+			return nil, err
+		}
+		if _, ok := asMap[string(hostname)]; !ok {
+			asMap[string(hostname)] = []ociResponse.StorageAttachment{
 				val,
 			}
 		} else {
-			asMap[val.Instance_name] = append(asMap[val.Instance_name], val)
+			asMap[string(hostname)] = append(asMap[string(hostname)], val)
 		}
 	}
 	return asMap, nil
@@ -477,9 +481,10 @@ func (s *oracleVolumeSource) attachVolume(
 	if err != nil {
 		return storage.AttachVolumesResult{Error: errors.Trace(err)}, nil
 	}
+
 	p := oci.StorageAttachmentParams{
 		Index:               ociCommon.Index(idx),
-		Instance_name:       string(instance.Id()),
+		Instance_name:       instance.machine.Name,
 		Storage_volume_name: params.VolumeId,
 	}
 	details, err := s.api.CreateStorageAttachment(p)

--- a/provider/oracle/testing/fakeenvironapi.go
+++ b/provider/oracle/testing/fakeenvironapi.go
@@ -1,7 +1,7 @@
 // Copyright 2017 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package oracle_test
+package testing
 
 import (
 	"github.com/juju/go-oracle-cloud/api"
@@ -9,7 +9,6 @@ import (
 	"github.com/juju/go-oracle-cloud/response"
 
 	"github.com/juju/juju/provider/oracle"
-	providertest "github.com/juju/juju/provider/oracle/network/testing"
 )
 
 type FakeInstancer struct {
@@ -184,14 +183,14 @@ type FakeEnvironAPI struct {
 
 	FakeStorageAPI
 
-	providertest.FakeRules
-	providertest.FakeAcl
-	providertest.FakeSecIp
-	providertest.FakeIpAddressprefixSet
-	providertest.FakeSecList
-	providertest.FakeSecRules
-	providertest.FakeApplication
-	providertest.FakeAssociation
+	FakeRules
+	FakeAcl
+	FakeSecIp
+	FakeIpAddressprefixSet
+	FakeSecList
+	FakeSecRules
+	FakeApplication
+	FakeAssociation
 }
 
 var _ oracle.EnvironAPI = (*FakeEnvironAPI)(nil)
@@ -262,7 +261,7 @@ var (
 				response.Storage{
 					Index:               0x1,
 					Storage_volume_name: "/Compute-a432100/sgiulitti@cloudbase.com/JujuTools_storage",
-					Name:                "/Compute-a432100/sgiulitti@cloudbase.com/JujuTools/ebc4ce91-56bb-4120-ba78-13762597f837/1f90e657-f852-45ad-afbf-9a94f640a7ae",
+					Name:                "/Compute-a432100/sgiulitti@cloudbase.com/0/1f90e657-f852-45ad-afbf-9a94f640a7ae",
 				},
 			},
 			Start_time: "2017-03-11T11:07:14Z", Storage_attachment_associations: []interface{}(nil),
@@ -279,14 +278,14 @@ var (
 				"vm-dev",
 				"juju-tools",
 				"toolsdir",
-				"/Compute-a432100/sgiulitti@cloudbase.com/JujuTools_instance",
+				"/Compute-a432100/sgiulitti@cloudbase.com/0",
 				"16a4e037dd2068fe691aed9ed0c40460",
 			},
 			Resolvers: interface{}(nil),
 			Metrics:   interface{}(nil),
 			Account:   "/Compute-a432100/default",
 			Node_uuid: interface{}(nil),
-			Name:      "/Compute-a432100/sgiulitti@cloudbase.com/JujuTools/ebc4ce91-56bb-4120-ba78-13762597f837",
+			Name:      "/Compute-a432100/sgiulitti@cloudbase.com/0/ebc4ce91-56bb-4120-ba78-13762597f837",
 			Vcable_id: "/Compute-a432100/sgiulitti@cloudbase.com/faa46f2e-28c9-4500-b060-0997717540a6",
 			Higgs:     interface{}(nil),
 			Hypervisor: response.Hypervisor{
@@ -814,12 +813,12 @@ var (
 			DeleteErr:  nil,
 		},
 		FakeStorageAPI:  *DefaultFakeStorageAPI,
-		FakeRules:       providertest.DefaultFakeRules,
-		FakeApplication: providertest.DefaultSecApplications,
-		FakeSecIp:       providertest.DefaultSecIp,
-		FakeSecList:     providertest.DefaultFakeSecList,
-		FakeAssociation: providertest.DefaultFakeAssociation,
-		FakeAcl:         providertest.DefaultFakeAcl,
-		FakeSecRules:    providertest.DefaultFakeSecrules,
+		FakeRules:       DefaultFakeRules,
+		FakeApplication: DefaultSecApplications,
+		FakeSecIp:       DefaultSecIp,
+		FakeSecList:     DefaultFakeSecList,
+		FakeAssociation: DefaultFakeAssociation,
+		FakeAcl:         DefaultFakeAcl,
+		FakeSecRules:    DefaultFakeSecrules,
 	}
 )

--- a/provider/oracle/testing/fakefirewall.go
+++ b/provider/oracle/testing/fakefirewall.go
@@ -11,15 +11,6 @@ import (
 	"github.com/juju/juju/provider/oracle/network"
 )
 
-// FakeComposer implements common.Composer interface
-type FakeComposer struct {
-	Compose string
-}
-
-func (f FakeComposer) ComposeName(name string) string {
-	return f.Compose
-}
-
 // FakeRules implement common.RuleAPI interface
 type FakeRules struct {
 	All       response.AllSecRules

--- a/provider/oracle/testing/fakestorageapi.go
+++ b/provider/oracle/testing/fakestorageapi.go
@@ -1,7 +1,7 @@
 // Copyright 2017 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package oracle_test
+package testing
 
 import (
 	"github.com/juju/go-oracle-cloud/api"
@@ -13,11 +13,11 @@ import (
 
 // FakeComposer implements common.Composer interface
 type FakeComposer struct {
-	compose string
+	Compose string
 }
 
 func (f FakeComposer) ComposeName(name string) string {
-	return f.compose
+	return f.Compose
 }
 
 // FakeStorageVolume implements the common.StorageVolumeAPI
@@ -120,7 +120,7 @@ var (
 
 	DefaultFakeStorageAPI = &FakeStorageAPI{
 		FakeComposer: FakeComposer{
-			compose: "/Compute-acme/jack.jones@example.com/allowed_video_servers",
+			Compose: "/Compute-acme/jack.jones@example.com/allowed_video_servers",
 		},
 		FakeStorageVolume: FakeStorageVolume{
 			All:    DefaultAllStorageVolumes,


### PR DESCRIPTION
This change makes juju use the hostname as the instance ID for the instances booted on Oracle. Internally it still uses the provider ID of the machines when communicating with the provider.

This PR also includes some fixes for spaces, and some tests cleanup.