### PR TITLE
all: disable mongo SSL where not necessary

### DIFF
--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -488,6 +488,7 @@ func (*suite) TestMongoInfo(c *gc.C) {
 	mongoInfo, ok := conf.MongoInfo()
 	c.Assert(ok, jc.IsTrue)
 	c.Check(mongoInfo.Info.Addrs, jc.DeepEquals, []string{"localhost:69"})
+	c.Check(mongoInfo.Info.DisableTLS, jc.IsFalse)
 }
 
 func (*suite) TestAPIInfoDoesntAddLocalhostWhenNoServingInfo(c *gc.C) {

--- a/cmd/jujud/agent/package_test.go
+++ b/cmd/jujud/agent/package_test.go
@@ -20,5 +20,5 @@ func init() {
 func TestPackage(t *stdtesting.T) {
 	// TODO(waigani) 2014-03-19 bug 1294458
 	// Refactor to use base suites
-	coretesting.MgoTestPackage(t)
+	coretesting.MgoSSLTestPackage(t)
 }

--- a/cmd/jujud/bootstrap_test.go
+++ b/cmd/jujud/bootstrap_test.go
@@ -261,8 +261,9 @@ func (s *BootstrapSuite) TestGUIArchiveSuccess(c *gc.C) {
 		ControllerModelTag: testing.ModelTag,
 		MongoInfo: &mongo.MongoInfo{
 			Info: mongo.Info{
-				Addrs:  []string{gitjujutesting.MgoServer.Addr()},
-				CACert: testing.CACert,
+				Addrs:      []string{gitjujutesting.MgoServer.Addr()},
+				CACert:     testing.CACert,
+				DisableTLS: !gitjujutesting.MgoServer.SSLEnabled(),
 			},
 			Password: testPassword,
 		},
@@ -383,8 +384,9 @@ func (s *BootstrapSuite) TestInitializeEnvironment(c *gc.C) {
 		ControllerModelTag: testing.ModelTag,
 		MongoInfo: &mongo.MongoInfo{
 			Info: mongo.Info{
-				Addrs:  []string{gitjujutesting.MgoServer.Addr()},
-				CACert: testing.CACert,
+				Addrs:      []string{gitjujutesting.MgoServer.Addr()},
+				CACert:     testing.CACert,
+				DisableTLS: !gitjujutesting.MgoServer.SSLEnabled(),
 			},
 			Password: testPassword,
 		},
@@ -443,8 +445,9 @@ func (s *BootstrapSuite) TestInitializeEnvironmentToolsNotFound(c *gc.C) {
 		ControllerModelTag: testing.ModelTag,
 		MongoInfo: &mongo.MongoInfo{
 			Info: mongo.Info{
-				Addrs:  []string{gitjujutesting.MgoServer.Addr()},
-				CACert: testing.CACert,
+				Addrs:      []string{gitjujutesting.MgoServer.Addr()},
+				CACert:     testing.CACert,
+				DisableTLS: !gitjujutesting.MgoServer.SSLEnabled(),
 			},
 			Password: testPassword,
 		},
@@ -477,8 +480,9 @@ func (s *BootstrapSuite) TestSetConstraints(c *gc.C) {
 		ControllerModelTag: testing.ModelTag,
 		MongoInfo: &mongo.MongoInfo{
 			Info: mongo.Info{
-				Addrs:  []string{gitjujutesting.MgoServer.Addr()},
-				CACert: testing.CACert,
+				Addrs:      []string{gitjujutesting.MgoServer.Addr()},
+				CACert:     testing.CACert,
+				DisableTLS: !gitjujutesting.MgoServer.SSLEnabled(),
 			},
 			Password: testPassword,
 		},
@@ -520,8 +524,9 @@ func (s *BootstrapSuite) TestDefaultMachineJobs(c *gc.C) {
 		ControllerModelTag: testing.ModelTag,
 		MongoInfo: &mongo.MongoInfo{
 			Info: mongo.Info{
-				Addrs:  []string{gitjujutesting.MgoServer.Addr()},
-				CACert: testing.CACert,
+				Addrs:      []string{gitjujutesting.MgoServer.Addr()},
+				CACert:     testing.CACert,
+				DisableTLS: !gitjujutesting.MgoServer.SSLEnabled(),
 			},
 			Password: testPassword,
 		},
@@ -548,8 +553,9 @@ func (s *BootstrapSuite) TestConfiguredMachineJobs(c *gc.C) {
 		ControllerModelTag: testing.ModelTag,
 		MongoInfo: &mongo.MongoInfo{
 			Info: mongo.Info{
-				Addrs:  []string{gitjujutesting.MgoServer.Addr()},
-				CACert: testing.CACert,
+				Addrs:      []string{gitjujutesting.MgoServer.Addr()},
+				CACert:     testing.CACert,
+				DisableTLS: !gitjujutesting.MgoServer.SSLEnabled(),
 			},
 			Password: testPassword,
 		},
@@ -572,8 +578,9 @@ func (s *BootstrapSuite) TestInitialPassword(c *gc.C) {
 
 	info := &mongo.MongoInfo{
 		Info: mongo.Info{
-			Addrs:  []string{gitjujutesting.MgoServer.Addr()},
-			CACert: testing.CACert,
+			Addrs:      []string{gitjujutesting.MgoServer.Addr()},
+			CACert:     testing.CACert,
+			DisableTLS: !gitjujutesting.MgoServer.SSLEnabled(),
 		},
 	}
 
@@ -750,8 +757,9 @@ func (s *BootstrapSuite) testToolsMetadata(c *gc.C, exploded bool) {
 		ControllerModelTag: testing.ModelTag,
 		MongoInfo: &mongo.MongoInfo{
 			Info: mongo.Info{
-				Addrs:  []string{gitjujutesting.MgoServer.Addr()},
-				CACert: testing.CACert,
+				Addrs:      []string{gitjujutesting.MgoServer.Addr()},
+				CACert:     testing.CACert,
+				DisableTLS: !gitjujutesting.MgoServer.SSLEnabled(),
 			},
 			Password: testPassword,
 		},
@@ -806,8 +814,9 @@ func assertWrittenToState(c *gc.C, metadata cloudimagemetadata.Metadata) {
 		ControllerModelTag: testing.ModelTag,
 		MongoInfo: &mongo.MongoInfo{
 			Info: mongo.Info{
-				Addrs:  []string{gitjujutesting.MgoServer.Addr()},
-				CACert: testing.CACert,
+				Addrs:      []string{gitjujutesting.MgoServer.Addr()},
+				CACert:     testing.CACert,
+				DisableTLS: !gitjujutesting.MgoServer.SSLEnabled(),
 			},
 			Password: testPassword,
 		},

--- a/cmd/jujud/main_test.go
+++ b/cmd/jujud/main_test.go
@@ -9,7 +9,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -29,38 +28,11 @@ import (
 	"github.com/juju/juju/worker/uniter/runner/jujuc"
 )
 
-var caCertFile string
-
-func mkdtemp(prefix string) string {
-	d, err := ioutil.TempDir("", prefix)
-	if err != nil {
-		panic(err)
-	}
-	return d
-}
-
-func mktemp(prefix string, content string) string {
-	f, err := ioutil.TempFile("", prefix)
-	if err != nil {
-		panic(err)
-	}
-	_, err = f.WriteString(content)
-	if err != nil {
-		panic(err)
-	}
-	f.Close()
-	return f.Name()
-}
-
 func TestPackage(t *stdtesting.T) {
 	// TODO(waigani) 2014-03-19 bug 1294458
 	// Refactor to use base suites
 
-	// Create a CA certificate available for all tests.
-	caCertFile = mktemp("juju-test-cert", coretesting.CACert)
-	defer os.Remove(caCertFile)
-
-	coretesting.MgoTestPackage(t)
+	coretesting.MgoSSLTestPackage(t)
 }
 
 type MainSuite struct{}

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -45,7 +45,7 @@ github.com/juju/rfc	git	ebdbbdb950cd039a531d15cdc2ac2cbd94f068ee	2016-07-11T02:4
 github.com/juju/romulus	git	b5ad384db5630652da632e49adabb968d1143e4c	2017-04-19T22:07:23Z
 github.com/juju/schema	git	075de04f9b7d7580d60a1e12a0b3f50bb18e6998	2016-04-20T04:42:03Z
 github.com/juju/terms-client	git	9b925afd677234e4146dde3cb1a11e187cbed64e	2016-08-09T13:19:00Z
-github.com/juju/testing	git	fce9bc4ebf7a77310c262ac4884e03b778eae06a	2017-02-22T09:01:19Z
+github.com/juju/testing	git	06d21ddace802a83d08c82f513e30d84010ce31f	2017-05-01T02:35:42Z
 github.com/juju/txn	git	5c6f1c49ecbd4a916ed7b5a8f81ee67203e86043	2017-04-21T05:33:50Z
 github.com/juju/usso	git	68a59c96c178fbbad65926e7f93db50a2cd14f33	2016-04-01T10:44:24Z
 github.com/juju/utils	git	51660d020f8c823ce1d0b7904c26e6b907163050	2017-04-21T12:10:45Z

--- a/featuretests/package_test.go
+++ b/featuretests/package_test.go
@@ -64,7 +64,7 @@ func init() {
 }
 
 func TestPackage(t *testing.T) {
-	coretesting.MgoTestPackage(t)
+	coretesting.MgoSSLTestPackage(t)
 }
 
 func runCommand(c *gc.C, args ...string) (*cmd.Context, error) {

--- a/mongo/open.go
+++ b/mongo/open.go
@@ -81,6 +81,10 @@ type Info struct {
 	// CACert holds the CA certificate that will be used
 	// to validate the controller's certificate, in PEM format.
 	CACert string
+
+	// DisableTLS controls whether the connection to MongoDB servers
+	// is made using TLS (the default), or not.
+	DisableTLS bool
 }
 
 // MongoInfo encapsulates information about cluster of
@@ -89,6 +93,7 @@ type Info struct {
 type MongoInfo struct {
 	// mongo.Info contains the addresses and cert of the mongo cluster.
 	Info
+
 	// Tag holds the name of the entity that is connecting.
 	// It should be nil when connecting as an administrator.
 	Tag names.Tag
@@ -104,27 +109,31 @@ func DialInfo(info Info, opts DialOpts) (*mgo.DialInfo, error) {
 	if len(info.Addrs) == 0 {
 		return nil, stderrors.New("no mongo addresses")
 	}
-	if len(info.CACert) == 0 {
-		return nil, stderrors.New("missing CA certificate")
-	}
-	xcert, err := cert.ParseCert(info.CACert)
-	if err != nil {
-		return nil, fmt.Errorf("cannot parse CA certificate: %v", err)
-	}
-	pool := x509.NewCertPool()
-	pool.AddCert(xcert)
-	tlsConfig := utils.SecureTLSConfig()
 
-	// TODO(natefinch): revisit this when are full-time on mongo 3.
-	// We have to add non-ECDHE suites because mongo doesn't support ECDHE.
-	moreSuites := []uint16{
-		tls.TLS_RSA_WITH_AES_128_GCM_SHA256,
-		tls.TLS_RSA_WITH_AES_256_GCM_SHA384,
-	}
+	var tlsConfig *tls.Config
+	if !info.DisableTLS {
+		if len(info.CACert) == 0 {
+			return nil, stderrors.New("missing CA certificate")
+		}
+		xcert, err := cert.ParseCert(info.CACert)
+		if err != nil {
+			return nil, fmt.Errorf("cannot parse CA certificate: %v", err)
+		}
+		pool := x509.NewCertPool()
+		pool.AddCert(xcert)
 
-	tlsConfig.CipherSuites = append(tlsConfig.CipherSuites, moreSuites...)
-	tlsConfig.RootCAs = pool
-	tlsConfig.ServerName = "juju-mongodb"
+		tlsConfig = utils.SecureTLSConfig()
+		tlsConfig.RootCAs = pool
+		tlsConfig.ServerName = "juju-mongodb"
+
+		// TODO(natefinch): revisit this when are full-time on mongo 3.
+		// We have to add non-ECDHE suites because mongo doesn't support ECDHE.
+		moreSuites := []uint16{
+			tls.TLS_RSA_WITH_AES_128_GCM_SHA256,
+			tls.TLS_RSA_WITH_AES_256_GCM_SHA384,
+		}
+		tlsConfig.CipherSuites = append(tlsConfig.CipherSuites, moreSuites...)
+	}
 
 	dial := func(server *mgo.ServerAddr) (net.Conn, error) {
 		addr := server.TCPAddr().String()
@@ -133,16 +142,19 @@ func DialInfo(info Info, opts DialOpts) (*mgo.DialInfo, error) {
 			logger.Warningf("mongodb connection failed, will retry: %v", err)
 			return nil, err
 		}
-		cc := tls.Client(c, tlsConfig)
-		if err := cc.Handshake(); err != nil {
-			logger.Warningf("TLS handshake failed: %v", err)
-			if err := c.Close(); err != nil {
-				logger.Warningf("failed to close connection: %v", err)
+		if tlsConfig != nil {
+			cc := tls.Client(c, tlsConfig)
+			if err := cc.Handshake(); err != nil {
+				logger.Warningf("TLS handshake failed: %v", err)
+				if err := c.Close(); err != nil {
+					logger.Warningf("failed to close connection: %v", err)
+				}
+				return nil, err
 			}
-			return nil, err
+			c = cc
 		}
 		logger.Debugf("dialled mongodb server at %q", addr)
-		return cc, nil
+		return c, nil
 	}
 
 	return &mgo.DialInfo{

--- a/provider/dummy/environs.go
+++ b/provider/dummy/environs.go
@@ -131,8 +131,9 @@ func stateInfo() *mongo.MongoInfo {
 	addrs := []string{net.JoinHostPort("localhost", mongoPort)}
 	return &mongo.MongoInfo{
 		Info: mongo.Info{
-			Addrs:  addrs,
-			CACert: testing.CACert,
+			Addrs:      addrs,
+			CACert:     testing.CACert,
+			DisableTLS: !gitjujutesting.MgoServer.SSLEnabled(),
 		},
 	}
 }

--- a/scripts/checktesting.bash
+++ b/scripts/checktesting.bash
@@ -8,7 +8,7 @@ do
 	# The -s flag is needed to suppress errors when
 	# the above pattern does not match any files.
 	if grep -s -q -l 'gopkg.in/check.v1' $src &&
-		! egrep -l -q 'gc\.TestingT|testing\.(\w*)MgoTestPackage' $src
+		! egrep -l -q 'gc\.TestingT|testing\.(\w*)Mgo(SSL)?TestPackage' $src
 	then
 		# There are _test.go files that use gocheck but
 		# don't call gocheck.TestingT.

--- a/state/internal_test.go
+++ b/state/internal_test.go
@@ -58,8 +58,9 @@ func (s *internalStateSuite) SetUpTest(c *gc.C) {
 	// Copied from NewMongoInfo (due to import loops).
 	info := &mongo.MongoInfo{
 		Info: mongo.Info{
-			Addrs:  []string{jujutesting.MgoServer.Addr()},
-			CACert: testing.CACert,
+			Addrs:      []string{jujutesting.MgoServer.Addr()},
+			CACert:     testing.CACert,
+			DisableTLS: !jujutesting.MgoServer.SSLEnabled(),
 		},
 	}
 	modelCfg := testing.ModelConfig(c)

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -4598,7 +4598,7 @@ func setAdminPassword(c *gc.C, inst *gitjujutesting.MgoInstance, owner names.Use
 
 func (s *SetAdminMongoPasswordSuite) TestSetAdminMongoPassword(c *gc.C) {
 	inst := &gitjujutesting.MgoInstance{EnableAuth: true}
-	err := inst.Start(testing.Certs)
+	err := inst.Start(nil)
 	c.Assert(err, jc.ErrorIsNil)
 	defer inst.DestroyWithLog()
 
@@ -4612,8 +4612,9 @@ func (s *SetAdminMongoPasswordSuite) TestSetAdminMongoPassword(c *gc.C) {
 
 	noAuthInfo := &mongo.MongoInfo{
 		Info: mongo.Info{
-			Addrs:  []string{inst.Addr()},
-			CACert: testing.CACert,
+			Addrs:      []string{inst.Addr()},
+			CACert:     testing.CACert,
+			DisableTLS: true,
 		},
 	}
 	authInfo := &mongo.MongoInfo{

--- a/state/testing/conn.go
+++ b/state/testing/conn.go
@@ -109,8 +109,9 @@ func InitializeWithArgs(c *gc.C, args InitializeArgs) *state.State {
 func NewMongoInfo() *mongo.MongoInfo {
 	return &mongo.MongoInfo{
 		Info: mongo.Info{
-			Addrs:  []string{jujutesting.MgoServer.Addr()},
-			CACert: testing.CACert,
+			Addrs:      []string{jujutesting.MgoServer.Addr()},
+			CACert:     testing.CACert,
+			DisableTLS: !jujutesting.MgoServer.SSLEnabled(),
 		},
 	}
 }

--- a/testing/mgo.go
+++ b/testing/mgo.go
@@ -10,7 +10,17 @@ import (
 )
 
 // MgoTestPackage should be called to register the tests for any package
-// that requires a secure connection to a MongoDB server.
+// that requires a connection to a MongoDB server.
+//
+// The server will be configured without SSL enabled, which slows down
+// tests. For tests that care about security (which should be few), use
+// MgoSSLTestPackage.
 func MgoTestPackage(t *testing.T) {
+	gitjujutesting.MgoTestPackage(t, nil)
+}
+
+// MgoSSLTestPackage should be called to register the tests for any package
+// that requires a secure (SSL) connection to a MongoDB server.
+func MgoSSLTestPackage(t *testing.T) {
 	gitjujutesting.MgoTestPackage(t, Certs)
 }


### PR DESCRIPTION
## Description of change

For tests that require Mongo to be running,
disable SSL except integration and end-to-end
tests (e.g. in the jujud/agent and feature
tests). Disabling SSL speeds up the tests
significantly. In my testing, the state
package takes ~500 seconds with SSL, and
~170 seconds without.

This branch updates to a newer juju/testing,
which defaults the storage engine to mmapv1.

## QA steps

Run the tests.

## Documentation changes

None.

## Bug reference

None.