### PR TITLE
Expose action canceling CLI.

### DIFF
--- a/api/action/client.go
+++ b/api/action/client.go
@@ -84,7 +84,7 @@ func (c *Client) ListCompleted(arg params.Entities) (params.ActionsByReceivers, 
 }
 
 // Cancel attempts to cancel a queued up Action from running.
-func (c *Client) Cancel(arg params.Actions) (params.ActionResults, error) {
+func (c *Client) Cancel(arg params.Entities) (params.ActionResults, error) {
 	results := params.ActionResults{}
 	err := c.facade.FacadeCall("Cancel", arg, &results)
 	return results, err

--- a/apiserver/action/action.go
+++ b/apiserver/action/action.go
@@ -239,8 +239,10 @@ func (a *ActionAPI) Cancel(arg params.Entities) (params.ActionResults, error) {
 	}
 
 	response := params.ActionResults{Results: make([]params.ActionResult, len(arg.Entities))}
+
 	for i, entity := range arg.Entities {
 		currentResult := &response.Results[i]
+		currentResult.Action = &params.Action{Tag: entity.Tag}
 		tag, err := names.ParseTag(entity.Tag)
 		if err != nil {
 			currentResult.Error = common.ServerError(common.ErrBadId)

--- a/cmd/juju/action/action.go
+++ b/cmd/juju/action/action.go
@@ -39,7 +39,7 @@ type APIClient interface {
 	ListCompleted(params.Entities) (params.ActionsByReceivers, error)
 
 	// Cancel attempts to cancel a queued up Action from running.
-	Cancel(params.Actions) (params.ActionResults, error)
+	Cancel(params.Entities) (params.ActionResults, error)
 
 	// ApplicationCharmActions is a single query which uses ApplicationsCharmsActions to
 	// get the charm.Actions for a single Service by tag.

--- a/cmd/juju/action/cancel.go
+++ b/cmd/juju/action/cancel.go
@@ -1,0 +1,109 @@
+// Copyright 2014-2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package action
+
+import (
+	"github.com/juju/cmd"
+	errors "github.com/juju/errors"
+	"github.com/juju/gnuflag"
+	"gopkg.in/juju/names.v2"
+
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/cmd/modelcmd"
+	"github.com/juju/juju/cmd/output"
+)
+
+func NewCancelCommand() cmd.Command {
+	return modelcmd.Wrap(&cancelCommand{})
+}
+
+type cancelCommand struct {
+	ActionCommandBase
+	out          cmd.Output
+	requestedIds []string
+}
+
+// Set up the output.
+func (c *cancelCommand) SetFlags(f *gnuflag.FlagSet) {
+	c.ActionCommandBase.SetFlags(f)
+	c.out.AddFlags(f, "yaml", output.DefaultFormatters)
+}
+
+const cancelDoc = `
+Cancel actions matching given IDs or partial ID prefixes.`
+
+func (c *cancelCommand) Info() *cmd.Info {
+	return &cmd.Info{
+		Name:    "cancel-action",
+		Args:    "<<action ID | action ID prefix>...>",
+		Purpose: "Cancel pending actions.",
+		Doc:     cancelDoc,
+	}
+}
+
+func (c *cancelCommand) Init(args []string) error {
+	c.requestedIds = args
+	return nil
+}
+
+func (c *cancelCommand) Run(ctx *cmd.Context) error {
+	api, err := c.NewActionAPIClient()
+	if err != nil {
+		return err
+	}
+	defer api.Close()
+
+	if len(c.requestedIds) == 0 {
+		return errors.Errorf("no actions specified")
+	}
+
+	var actionTags []names.ActionTag
+	for _, requestedId := range c.requestedIds {
+		requestedActionTags, err := getActionTagsByPrefix(api, requestedId)
+		if err != nil {
+			return err
+		}
+
+		// If a non existing ID was submitted we abort the command taking no further action.
+		if len(requestedActionTags) < 1 {
+			return errors.Errorf("no actions found matching prefix %s, no actions have been canceled", requestedId)
+		}
+
+		actionTags = append(actionTags, requestedActionTags...)
+	}
+
+	entities := []params.Entity{}
+	for _, tag := range actionTags {
+		entities = append(entities, params.Entity{Tag: tag.String()})
+	}
+
+	actions, err := api.Cancel(params.Entities{Entities: entities})
+	if err != nil {
+		return err
+	}
+
+	if len(actions.Results) < 1 {
+		return errors.Errorf("identifier(s) %q matched action(s) %q, but no actions were canceled", c.requestedIds, actionTags)
+	}
+
+	var unCanceledActions []string
+	var canceledActions []params.ActionResult
+	for _, result := range actions.Results {
+		if result.Error != nil {
+			unCanceledActions = append(unCanceledActions, result.Action.Tag)
+			continue
+		}
+		canceledActions = append(canceledActions, result)
+	}
+
+	if len(canceledActions) > 0 {
+		err = c.out.Write(ctx, resultsToMap(canceledActions))
+	}
+
+	if len(unCanceledActions) > 0 {
+		logger.Warningf("The following actions could not be canceled: %v. The actions may not have been in the pending state at the time of attempted cancellation", unCanceledActions)
+	}
+
+	return err
+}

--- a/cmd/juju/action/cancel_test.go
+++ b/cmd/juju/action/cancel_test.go
@@ -1,0 +1,107 @@
+// Copyright 2014-2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package action_test
+
+import (
+	"bytes"
+	"time"
+
+	"github.com/juju/cmd"
+	"github.com/juju/cmd/cmdtesting"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/cmd/juju/action"
+)
+
+type CancelSuite struct {
+	BaseActionSuite
+	subcommand cmd.Command
+}
+
+var _ = gc.Suite(&CancelSuite{})
+
+func (s *CancelSuite) SetUpTest(c *gc.C) {
+	s.BaseActionSuite.SetUpTest(c)
+	s.subcommand, _ = action.NewCancelCommandForTest(s.store)
+}
+
+func (s *CancelSuite) TestRun(c *gc.C) {
+	prefix := "deadbeef"
+	fakeid := prefix + "-0000-4000-8000-feedfacebeef"
+	fakeid2 := prefix + "-0001-4000-8000-feedfacebeef"
+	faketag := "action-" + fakeid
+	faketag2 := "action-" + fakeid2
+
+	emptyArgs := []string{}
+	emptyPrefixArgs := []string{}
+	prefixArgs := []string{prefix}
+	result1 := []params.ActionResult{{Status: "some-random-status"}}
+	result2 := []params.ActionResult{{Status: "a status"}, {Status: "another status"}}
+
+	errNotFound := "no actions specified"
+	errNotFoundForPrefix := `no actions found matching prefix ` + prefix + `, no actions have been canceled`
+	errFoundTagButNotCanceled := `identifier\(s\) \["` + prefix + `"\] matched action\(s\) \[.*\], but no actions were canceled`
+
+	tests := []cancelTestCase{
+		{expectError: errNotFound},
+		{args: emptyArgs, expectError: errNotFound},
+		{args: emptyArgs, tags: tagsForIdPrefix("", faketag, faketag2), expectError: errNotFound},
+		{args: emptyPrefixArgs, expectError: errNotFound},
+		{args: emptyPrefixArgs, tags: tagsForIdPrefix("", faketag, faketag2), expectError: errNotFound},
+		{args: prefixArgs, expectError: errNotFoundForPrefix},
+		{args: prefixArgs, expectError: errNotFoundForPrefix, tags: tagsForIdPrefix(prefix)},
+		{args: prefixArgs, expectError: errNotFoundForPrefix, tags: tagsForIdPrefix(prefix, "bb", "bc")},
+		{args: prefixArgs, expectError: errFoundTagButNotCanceled, tags: tagsForIdPrefix(prefix, faketag, faketag2)},
+		{args: prefixArgs, expectError: errFoundTagButNotCanceled, tags: tagsForIdPrefix(prefix, faketag)},
+		{args: prefixArgs, tags: tagsForIdPrefix(prefix, faketag), results: result1},
+		{args: prefixArgs, tags: tagsForIdPrefix(prefix, faketag, faketag2), results: result2},
+	}
+
+	for i, test := range tests {
+		c.Logf("iteration %d, test case %+v", i, test)
+		s.runTestCase(c, test)
+	}
+}
+
+func (s *CancelSuite) runTestCase(c *gc.C, tc cancelTestCase) {
+	for _, modelFlag := range s.modelFlags {
+		fakeClient := makeFakeClient(
+			0*time.Second, // No API delay
+			5*time.Second, // 5 second test timeout
+			tc.tags,
+			tc.results,
+			tc.actionsByNames,
+			"", // No API error
+		)
+
+		restore := s.patchAPIClient(fakeClient)
+		defer restore()
+
+		s.subcommand, _ = action.NewCancelCommandForTest(s.store)
+		args := append([]string{modelFlag, "admin"}, tc.args...)
+		ctx, err := cmdtesting.RunCommand(c, s.subcommand, args...)
+		if tc.expectError == "" {
+			c.Assert(err, jc.ErrorIsNil)
+		} else {
+			c.Assert(err, gc.ErrorMatches, tc.expectError)
+		}
+		if len(tc.results) > 0 {
+			out := &bytes.Buffer{}
+			err := cmd.FormatYaml(out, action.ActionResultsToMap(tc.results))
+			c.Check(err, jc.ErrorIsNil)
+			c.Check(ctx.Stdout.(*bytes.Buffer).String(), gc.Equals, out.String())
+			c.Check(ctx.Stderr.(*bytes.Buffer).String(), gc.Equals, "")
+		}
+	}
+}
+
+type cancelTestCase struct {
+	args           []string
+	expectError    string
+	tags           params.FindTagsResults
+	results        []params.ActionResult
+	actionsByNames params.ActionsByNames
+}

--- a/cmd/juju/action/export_test.go
+++ b/cmd/juju/action/export_test.go
@@ -25,6 +25,10 @@ type StatusCommand struct {
 	*statusCommand
 }
 
+type CancelCommand struct {
+	*cancelCommand
+}
+
 type RunCommand struct {
 	*runCommand
 }
@@ -71,6 +75,12 @@ func NewStatusCommandForTest(store jujuclient.ClientStore) (cmd.Command, *Status
 	c := &statusCommand{}
 	c.SetClientStore(store)
 	return modelcmd.Wrap(c), &StatusCommand{c}
+}
+
+func NewCancelCommandForTest(store jujuclient.ClientStore) (cmd.Command, *CancelCommand) {
+	c := &cancelCommand{}
+	c.SetClientStore(store)
+	return modelcmd.Wrap(c), &CancelCommand{c}
 }
 
 func NewListCommandForTest(store jujuclient.ClientStore) (cmd.Command, *ListCommand) {

--- a/cmd/juju/action/package_test.go
+++ b/cmd/juju/action/package_test.go
@@ -165,7 +165,7 @@ func (c *fakeAPIClient) ListCompleted(args params.Entities) (params.ActionsByRec
 	}, c.apiErr
 }
 
-func (c *fakeAPIClient) Cancel(args params.Actions) (params.ActionResults, error) {
+func (c *fakeAPIClient) Cancel(args params.Entities) (params.ActionResults, error) {
 	return params.ActionResults{
 		Results: c.actionResults,
 	}, c.apiErr

--- a/cmd/juju/commands/main.go
+++ b/cmd/juju/commands/main.go
@@ -364,6 +364,7 @@ func registerCommands(r commandRegistry, ctx *cmd.Context) {
 	r.Register(action.NewRunCommand())
 	r.Register(action.NewShowOutputCommand())
 	r.Register(action.NewListCommand())
+	r.Register(action.NewCancelCommand())
 
 	// Manage controller availability
 	r.Register(newEnableHACommand())

--- a/cmd/juju/commands/main_test.go
+++ b/cmd/juju/commands/main_test.go
@@ -407,6 +407,7 @@ var commandNames = []string{
 	"bootstrap",
 	"budget",
 	"cached-images",
+	"cancel-action",
 	"change-user-password",
 	"charm",
 	"clouds",


### PR DESCRIPTION
## Description of change

This change adds a basic ability to cancel Actions from the CLI. Actions are canceled by first obtaining the action ID(s) or prefix(es) and then using the `juju cancel-action [options] <<Action ID | Action ID prefix>...>` to cancel the identified Action(s).

Only pending actions may be canceled.

This PR fixes the bug referenced below

## QA steps

#### View the help documentation for the newly added command:

```bash
juju cancel-action --help
```

#### Bootstrap a controller: 
```
juju bootstrap lxd bug_1588092
```

#### Deploy a charm with actions (here we use mongodb):

```bash
juju deploy mongodb
```

#### Run a few long-running actions so to end up with some pending actions:

```bash
for ((n=0;n<3;n++)); do juju run-action mongodb/0 perf; done
```

#### View your Actions:

```bash
juju show-action-status
```

#### Cancel one or more of your pending Actions:

```bash
juju cancel-action <your pending action ID...>  
```

#### Check to see that your pending Actions were canceled:

```bash
juju show-action-status <one of your pending action IDs>
````

#### You should see that your Action has been canceled
```bash
actions:
- id: <the action ID specified above>
  status: cancelled
  unit: mongodb/0
```

#### Try `juju cancel-action` with mulitple IDs/prefixes. Try to cancel Actions that are not of status `pending`.

## Documentation changes

This change is strictly additive and thus alters no existing work flow. However, the added CLI functionality will need to be documented.  

## Bug reference

[lp#1588092](https://bugs.launchpad.net/juju/+bug/1588092)
