### PR TITLE
Related to bug 1625830, rephrase description of use-default-secgroup

### DIFF
--- a/provider/openstack/config.go
+++ b/provider/openstack/config.go
@@ -18,7 +18,7 @@ var configSchema = environschema.Fields{
 		Type:        environschema.Tbool,
 	},
 	"use-default-secgroup": {
-		Description: `Whether new machine instances should have the "default" Openstack security group assigned.`,
+		Description: `Whether new machine instances should have the "default" Openstack security group assigned in addition to juju defined security groups.`,
 		Type:        environschema.Tbool,
 	},
 	"network": {


### PR DESCRIPTION
config flag for the openstack provider to reduce confusion.

## Please provide the following details to expedite Pull Request review:

----

## Description of change

The current description of the use-default-secgroups isn't clear as to whether the default
security group will be the only one used for the openstack provider.  Updating it to clarify.

## QA steps

N/A

## Documentation changes

Maybe, are the provider config flags documented on a wiki or online document outside of the juju
code?

## Bug reference

https://bugs.launchpad.net/juju/+bug/1625830