### PR TITLE
Run txnpruner every hour instead of every 2 hours

### DIFF
--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -1081,7 +1081,7 @@ func (a *MachineAgent) startStateWorkers(
 			})
 
 			a.startWorkerAfterUpgrade(singularRunner, "txnpruner", func() (worker.Worker, error) {
-				return txnpruner.New(st, time.Hour*2, clock.WallClock), nil
+				return txnpruner.New(st, time.Hour, clock.WallClock), nil
 			})
 		default:
 			return nil, errors.Errorf("unknown job type %q", job)


### PR DESCRIPTION
## Description of change

Now that the txnpruner is more efficient it makes sense to run it more often.

## QA steps

Bootstrap and wait. Confirm that pruner runs after an hour by checking the logs and the `txns.prune` collection.

## Documentation changes

N.A.

## Bug reference

N.A.