### PR TITLE
Minimal fix for bug #1682411.

### DIFF
--- a/juju/sockets/sockets_nix.go
+++ b/juju/sockets/sockets_nix.go
@@ -22,5 +22,9 @@ func Listen(socketPath string) (net.Listener, error) {
 		logger.Errorf("failed to listen on unix:%s: %v", socketPath, err)
 		return nil, err
 	}
+	if err := os.chmod(socketPath, 0700); err != nil {
+		listener.Close()
+		return nil, err
+	}
 	return listener, err
 }


### PR DESCRIPTION
## Description of change

Chmod the socket after we create it, to prevent anyone but root from accessing the socket.

## QA steps

```
  $ juju bootstrap
  $ juju deploy ubuntu --to 0
  $ juju ssh 0
  $ sudo su - ubuntu
  $ juju-run whoami
  # should fail
```

## Bug reference

[lp:1682411](https://bugs.launchpad.net/juju-core/+bug/1682411)