### PR TITLE
Minimal fix for bug #1682411.

### DIFF
--- a/juju/sockets/sockets_nix.go
+++ b/juju/sockets/sockets_nix.go
@@ -24,5 +24,12 @@ func Listen(socketPath string) (net.Listener, error) {
 		logger.Tracef("ignoring error on removing %q: %v", socketPath, err)
 	}
 	listener, err := net.Listen("unix", socketPath)
-	return listener, errors.Trace(err)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	if err := os.Chmod(socketPath, 0700); err != nil {
+		listener.Close()
+		return nil, errors.Trace(err)
+	}
+	return listener, nil
 }


### PR DESCRIPTION
## Description of change

Chmod the socket after we create it, to prevent anyone but root from accessing the socket.

## QA steps

```
  $ juju bootstrap
  $ juju deploy -m controller ubuntu --to 0
  $ juju ssh -m controller 0
  $$ sudo su - ubuntu
  $$ juju-run whoami
  # should fail
```

## Bug reference

[lp:1682411](https://bugs.launchpad.net/juju-core/+bug/1682411)