### PR TITLE
Default to YAML output format when --schema flag is used.

### DIFF
--- a/cmd/juju/action/list_test.go
+++ b/cmd/juju/action/list_test.go
@@ -66,6 +66,11 @@ func (s *ListSuite) TestInit(c *gc.C) {
 		args:                 []string{"--format=yaml", "--schema", validServiceId},
 		expectedOutputSchema: true,
 		expectedSvc:          names.NewApplicationTag(validServiceId),
+	}, {
+		should:               "default to yaml output when --schema flag is specified",
+		args:                 []string{"--schema", validServiceId},
+		expectedOutputSchema: true,
+		expectedSvc:          names.NewApplicationTag(validServiceId),
 	}}
 
 	for i, t := range tests {
@@ -93,7 +98,6 @@ kill            Kill the database.
 no-description  No description
 no-params       An action with no parameters.
 snapshot        Take a snapshot of the database.
-
 `[1:]
 
 	tests := []struct {
@@ -124,6 +128,15 @@ snapshot        Take a snapshot of the database.
 		withArgs:        []string{validServiceId},
 		expectNoResults: true,
 		expectMessage:   fmt.Sprintf("No actions defined for %s.\n", validServiceId),
+	}, {
+		should:           "get tabular default output when --schema is NOT specified",
+		withArgs:         []string{"--format=default", validServiceId},
+		withCharmActions: someCharmActions,
+	}, {
+		should:           "get full schema default output (YAML) when --schema is specified",
+		withArgs:         []string{"--format=default", "--schema", validServiceId},
+		expectFullSchema: true,
+		withCharmActions: someCharmActions,
 	}}
 
 	for i, t := range tests {


### PR DESCRIPTION
## Description of change

This change fixes the referenced bug by defaulting to YAML output format when the `--schema` flag is used with the `juju actions` command.

## QA steps

#### deploy a charm with actions (here we use mongodb)
```bash
juju deploy mongodb
```

#### list the actions for mongodb specifying no output format. You should see the command default tabular format.
```bash
juju actions mongodb
```

#### list the full schema of the mongodb actions. You should see the command default to YAML format
```bash
juju actions --schema mongodb
```

#### list the full schema of the mongodb actions specifying `tabular` as the format. You should see an error.
```bash
juju actions --schema --format=tabular mongodb

>> ERROR full schema not compatible with tabular output
```

## Documentation changes

The CLI changes in accordance with the description of this PR.

## Bug reference

[lp#1682024](https://bugs.launchpad.net/juju/+bug/1682024)
