### PR TITLE
cmd/juju/romulus/sla Output format change.

### DIFF
--- a/cmd/juju/romulus/sla/export_test.go
+++ b/cmd/juju/romulus/sla/export_test.go
@@ -14,6 +14,7 @@ var (
 	NewAuthorizationClient = &newAuthorizationClient
 	NewSLAClient           = &newSLAClient
 	ModelId                = &modelId
+	NewJujuClientStore     = &newJujuClientStore
 )
 
 // NewSLACommandForTest returns an slaCommand with apis provided by the given arguments

--- a/cmd/juju/romulus/sla/sla.go
+++ b/cmd/juju/romulus/sla/sla.go
@@ -8,10 +8,13 @@ package sla
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 
+	"github.com/gosuri/uitable"
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
 	"github.com/juju/gnuflag"
+	"github.com/juju/loggo"
 	"github.com/juju/romulus/api/sla"
 	slawire "github.com/juju/romulus/wireformat/sla"
 	"gopkg.in/macaroon.v1"
@@ -20,7 +23,10 @@ import (
 	"github.com/juju/juju/api/modelconfig"
 	"github.com/juju/juju/cmd/juju/common"
 	"github.com/juju/juju/cmd/modelcmd"
+	"github.com/juju/juju/jujuclient"
 )
+
+var logger = loggo.GetLogger("romulus.cmd.sla")
 
 // authorizationClient defines the interface of an api client that
 // the command uses to create an sla authorization macaroon.
@@ -32,6 +38,11 @@ type authorizationClient interface {
 type slaClient interface {
 	SetSLALevel(level, owner string, creds []byte) error
 	SLALevel() (string, error)
+}
+
+type slaLevel struct {
+	Model string `json:"model" yaml:"model"`
+	SLA   string `json:"sla" yaml:"sla"`
 }
 
 var newSLAClient = func(conn api.Connection) slaClient {
@@ -48,6 +59,8 @@ var modelId = func(conn api.Connection) string {
 	return tag.Id()
 }
 
+var newJujuClientStore = jujuclient.NewFileClientStore
+
 // NewSLACommand returns a new command that is used to set SLA credentials for a
 // deployed application.
 func NewSLACommand() cmd.Command {
@@ -63,6 +76,7 @@ func NewSLACommand() cmd.Command {
 // Model.SLACredential for development & demonstration purposes.
 type slaCommand struct {
 	modelcmd.ModelCommandBase
+	out cmd.Output
 
 	newAPIRoot             func() (api.Connection, error)
 	newSLAClient           func(api.Connection) slaClient
@@ -75,6 +89,11 @@ type slaCommand struct {
 // SetFlags sets additional flags for the support command.
 func (c *slaCommand) SetFlags(f *gnuflag.FlagSet) {
 	c.ModelCommandBase.SetFlags(f)
+	c.out.AddFlags(f, "tabular", map[string]cmd.Formatter{
+		"tabular": formatTabular,
+		"json":    cmd.FormatJson,
+		"yaml":    cmd.FormatYaml,
+	})
 	f.StringVar(&c.Budget, "budget", "", "the maximum spend for the model")
 }
 
@@ -128,13 +147,20 @@ func (c *slaCommand) requestSupportCredentials(modelUUID string) (string, []byte
 	return slaResp.Owner, mbuf, nil
 }
 
-func displayCurrentLevel(client slaClient, ctx *cmd.Context) error {
+func (c *slaCommand) displayCurrentLevel(client slaClient, modelID string, ctx *cmd.Context) error {
+	modelNameMap := modelNameMap()
+	modelName := modelID
+	if name, ok := modelNameMap[modelID]; ok {
+		modelName = name
+	}
 	level, err := client.SLALevel()
 	if err != nil {
 		return errors.Trace(err)
 	}
-	fmt.Fprintln(ctx.Stdout, level)
-	return nil
+	return errors.Trace(c.out.Write(ctx, &slaLevel{
+		Model: modelName,
+		SLA:   level,
+	}))
 }
 
 // Run implements cmd.Command.
@@ -147,7 +173,7 @@ func (c *slaCommand) Run(ctx *cmd.Context) error {
 	modelId := modelId(root)
 
 	if c.Level == "" {
-		return displayCurrentLevel(client, ctx)
+		return c.displayCurrentLevel(client, modelId, ctx)
 	}
 	owner, credentials, err := c.requestSupportCredentials(modelId)
 	if err != nil {
@@ -158,4 +184,42 @@ func (c *slaCommand) Run(ctx *cmd.Context) error {
 		return errors.Trace(err)
 	}
 	return nil
+}
+
+func formatTabular(writer io.Writer, value interface{}) error {
+	l, ok := value.(*slaLevel)
+	if !ok {
+		return errors.Errorf("expected value of type %T, got %T", l, value)
+	}
+	table := uitable.New()
+	table.MaxColWidth = 50
+	table.Wrap = true
+	for _, col := range []int{2, 3, 5} {
+		table.RightAlign(col)
+	}
+	table.AddRow("Model", "SLA")
+	table.AddRow(l.Model, l.SLA)
+	fmt.Fprint(writer, table)
+	return nil
+}
+
+func modelNameMap() map[string]string {
+	store := newJujuClientStore()
+	uuidToName := map[string]string{}
+	controllers, err := store.AllControllers()
+	if err != nil {
+		logger.Warningf("failed to read juju client controller names")
+		return map[string]string{}
+	}
+	for cname := range controllers {
+		models, err := store.AllModels(cname)
+		if err != nil {
+			logger.Warningf("failed to read juju client model names")
+			return map[string]string{}
+		}
+		for mname, mdetails := range models {
+			uuidToName[mdetails.ModelUUID] = cname + ":" + mname
+		}
+	}
+	return uuidToName
 }

--- a/cmd/juju/romulus/sla/sla_test.go
+++ b/cmd/juju/romulus/sla/sla_test.go
@@ -48,6 +48,7 @@ func (s *supportCommandSuite) SetUpTest(c *gc.C) {
 	s.mockSLAClient = &mockSlaClient{}
 	s.modelUUID = utils.MustNewUUID().String()
 	s.fakeAPIRoot = &fakeAPIConnection{model: s.modelUUID}
+	s.PatchValue(sla.NewJujuClientStore, s.newMockClientStore)
 }
 
 func (s *supportCommandSuite) run(c *gc.C, args ...string) (*cmd.Context, error) {
@@ -120,9 +121,40 @@ func (s supportCommandSuite) TestSupportCommand(c *gc.C) {
 }
 
 func (s *supportCommandSuite) TestDiplayCurrentLevel(c *gc.C) {
-	ctx, err := s.run(c)
-	c.Assert(err, jc.ErrorIsNil, gc.Commentf("%s", errors.Details(err)))
-	c.Assert(cmdtesting.Stdout(ctx), jc.DeepEquals, "mock-level\n")
+	tests := []struct {
+		format         string
+		expectedOutput string
+	}{{
+		expectedOutput: `Model	SLA       
+c:m1 	mock-level
+`,
+	}, {
+		format: "tabular",
+		expectedOutput: `Model	SLA       
+c:m1 	mock-level
+`,
+	}, {
+		format: "json",
+		expectedOutput: `{"model":"c:m1","sla":"mock-level"}
+`,
+	}, {
+		format: "yaml",
+		expectedOutput: `model: c:m1
+sla: mock-level
+`,
+	},
+	}
+
+	for i, test := range tests {
+		c.Logf("running test %d", i)
+		args := []string{}
+		if test.format != "" {
+			args = append(args, "--format", test.format)
+		}
+		ctx, err := s.run(c, args...)
+		c.Assert(err, jc.ErrorIsNil, gc.Commentf("%s", errors.Details(err)))
+		c.Assert(cmdtesting.Stdout(ctx), jc.DeepEquals, test.expectedOutput)
+	}
 }
 
 func newMockAPI() (*mockapi, error) {
@@ -191,4 +223,30 @@ func (f *fakeAPIConnection) BestFacadeVersion(facade string) int {
 
 func (f *fakeAPIConnection) ModelTag() (names.ModelTag, bool) {
 	return names.NewModelTag(f.model), false
+}
+
+type mockClientStore struct {
+	jujuclient.ClientStore
+	modelUUID string
+}
+
+func (s *supportCommandSuite) newMockClientStore() jujuclient.ClientStore {
+	return &mockClientStore{modelUUID: s.modelUUID}
+}
+
+func (s *mockClientStore) AllControllers() (map[string]jujuclient.ControllerDetails, error) {
+	n := 3
+	return map[string]jujuclient.ControllerDetails{
+		"c": jujuclient.ControllerDetails{
+			ModelCount: &n,
+		},
+	}, nil
+}
+
+func (s *mockClientStore) AllModels(controllerName string) (map[string]jujuclient.ModelDetails, error) {
+	return map[string]jujuclient.ModelDetails{
+		"m1": jujuclient.ModelDetails{ModelUUID: s.modelUUID},
+		"m2": jujuclient.ModelDetails{ModelUUID: "uuid2"},
+		"m3": jujuclient.ModelDetails{ModelUUID: "uuid3"},
+	}, nil
 }


### PR DESCRIPTION
## Description of change

This change disambiguates the output of the juju sla command.
Before, if one issued "juju sla" the output might be just "unsupported" and for a user it's hard to tell if the command is unsupported or if the SLA level is "unsupported" (which is a valid SLA level).

Not the output would be:
Model   SLA
<uuid>  unsupported
if the format is tabular, or a similar output in json or yaml format

## QA steps

1. bootstrap a controller
2. add a model
3. run "juju sla" and check output

## Documentation changes

No documentation change required, i think.

## Bug reference

N/A