### PR TITLE
api/controller: allow empty CACert in migration

### DIFF
--- a/api/controller/controller.go
+++ b/api/controller/controller.go
@@ -240,9 +240,6 @@ func (s *MigrationSpec) Validate() error {
 	if len(s.TargetAddrs) < 1 {
 		return errors.NotValidf("empty target API addresses")
 	}
-	if s.TargetCACert == "" {
-		return errors.NotValidf("empty target CA cert")
-	}
 	if !names.IsValidUser(s.TargetUser) {
 		return errors.NotValidf("target user")
 	}
@@ -260,12 +257,12 @@ func (s *MigrationSpec) Validate() error {
 // this call just supports starting one migration at a time.
 func (c *Client) InitiateMigration(spec MigrationSpec) (string, error) {
 	if err := spec.Validate(); err != nil {
-		return "", errors.Trace(err)
+		return "", errors.Annotatef(err, "client-side validation failed")
 	}
 
 	macsJSON, err := macaroonsToJSON(spec.TargetMacaroons)
 	if err != nil {
-		return "", errors.Trace(err)
+		return "", errors.Annotatef(err, "client-side validation failed")
 	}
 
 	args := params.InitiateMigrationArgs{

--- a/api/controller/controller_test.go
+++ b/api/controller/controller_test.go
@@ -43,6 +43,12 @@ func (s *Suite) TestInitiateMigrationSkipPrechecks(c *gc.C) {
 	s.checkInitiateMigration(c, spec)
 }
 
+func (s *Suite) TestInitiateMigrationEmptyCACert(c *gc.C) {
+	spec := makeSpec()
+	spec.TargetCACert = ""
+	s.checkInitiateMigration(c, spec)
+}
+
 func (s *Suite) checkInitiateMigration(c *gc.C, spec controller.MigrationSpec) {
 	client, stub := makeClient(params.InitiateMigrationResults{
 		Results: []params.InitiateMigrationResult{{
@@ -122,7 +128,7 @@ func (s *Suite) TestInitiateMigrationValidationError(c *gc.C) {
 	spec.ModelUUID = "not-a-uuid"
 	id, err := client.InitiateMigration(spec)
 	c.Check(id, gc.Equals, "")
-	c.Check(err, gc.ErrorMatches, "model UUID not valid")
+	c.Check(err, gc.ErrorMatches, "client-side validation failed: model UUID not valid")
 	c.Check(stub.Calls(), gc.HasLen, 0) // API call shouldn't have happened
 }
 

--- a/core/migration/targetinfo.go
+++ b/core/migration/targetinfo.go
@@ -59,10 +59,6 @@ func (info *TargetInfo) Validate() error {
 		}
 	}
 
-	if info.CACert == "" {
-		return errors.NotValidf("empty CACert")
-	}
-
 	if info.AuthTag.Id() == "" {
 		return errors.NotValidf("empty AuthTag")
 	}

--- a/core/migration/targetinfo_test.go
+++ b/core/migration/targetinfo_test.go
@@ -51,17 +51,17 @@ func (s *TargetInfoSuite) TestValidation(c *gc.C) {
 		},
 		`"abc" in Addrs not valid`,
 	}, {
-		"CACert",
-		func(info *migration.TargetInfo) {
-			info.CACert = ""
-		},
-		"empty CACert not valid",
-	}, {
 		"AuthTag",
 		func(info *migration.TargetInfo) {
 			info.AuthTag = names.UserTag{}
 		},
 		"empty AuthTag not valid",
+	}, {
+		"Success - empty CACert",
+		func(info *migration.TargetInfo) {
+			info.CACert = ""
+		},
+		"",
 	}, {
 		"Password & Macaroons",
 		func(info *migration.TargetInfo) {

--- a/state/modelmigration_test.go
+++ b/state/modelmigration_test.go
@@ -179,9 +179,9 @@ func (s *MigrationSuite) TestSpecValidation(c *gc.C) {
 	}, {
 		"TargetInfo is validated",
 		func(spec *state.MigrationSpec) {
-			spec.TargetInfo.CACert = ""
+			spec.TargetInfo.Addrs = nil
 		},
-		"empty CACert not valid",
+		"empty Addrs not valid",
 	}}
 	for _, test := range tests {
 		c.Logf("---- %s -----------", test.label)


### PR DESCRIPTION
This allows a model to be migrated to a controller with a
global CA certificate, the common case when using the
JIMM controller.

QA add a controller with an autocert-dns-name configuration,
configure the appropriate DNS entry to point to the controller
instance, remove the ca-cert entry from its controllers.yaml entry,
and try to migrate a model from another controller to that one.
