### PR TITLE
Bug 1596888

### DIFF
--- a/cmd/juju/action/status.go
+++ b/cmd/juju/action/status.go
@@ -4,6 +4,8 @@
 package action
 
 import (
+	"time"
+
 	"github.com/juju/cmd"
 	errors "github.com/juju/errors"
 	"github.com/juju/gnuflag"
@@ -90,7 +92,7 @@ func (c *statusCommand) Run(ctx *cmd.Context) error {
 
 	entities := []params.Entity{}
 	for _, tag := range actionTags {
-		entities = append(entities, params.Entity{tag.String()})
+		entities = append(entities, params.Entity{Tag: tag.String()})
 	}
 
 	actions, err := api.Actions(params.Entities{Entities: entities})
@@ -122,6 +124,7 @@ func resultToMap(result params.ActionResult) map[string]interface{} {
 		item["error"] = result.Error.Error()
 	}
 	if result.Action != nil {
+		item["action"] = result.Action.Name
 		atag, err := names.ParseActionTag(result.Action.Tag)
 		if err != nil {
 			item["id"] = result.Action.Tag
@@ -138,6 +141,14 @@ func resultToMap(result params.ActionResult) map[string]interface{} {
 
 	}
 	item["status"] = result.Status
+
+	// result.Completed uses the zero-value to indicate not completed
+	if result.Completed.Equal(time.Time{}) {
+		item["completed at"] = "n/a"
+	} else {
+		item["completed at"] = result.Completed.UTC().Format("2006-01-02 15:04:05")
+	}
+
 	return item
 }
 

--- a/cmd/juju/action/status_test.go
+++ b/cmd/juju/action/status_test.go
@@ -38,8 +38,9 @@ func (s *StatusSuite) TestRun(c *gc.C) {
 	emptyArgs := []string{}
 	emptyPrefixArgs := []string{}
 	prefixArgs := []string{prefix}
-	result1 := []params.ActionResult{{Status: "some-random-status"}}
-	result2 := []params.ActionResult{{Status: "a status"}, {Status: "another status"}}
+	result1 := []params.ActionResult{{Status: "some-random-status", Action: &params.Action{Tag: faketag, Name: "fakeName"}}}
+	result2 := []params.ActionResult{{Status: "a status", Action: &params.Action{Tag: faketag2, Name: "fakeName2"}}, {Status: "another status"}}
+	errResult := []params.ActionResult{{Status: "", Error: &params.Error{Message: "an error"}}}
 
 	errNotFound := "no actions found"
 	errNotFoundForPrefix := `no actions found matching prefix "` + prefix + `"`
@@ -82,6 +83,7 @@ func (s *StatusSuite) TestRun(c *gc.C) {
 		{args: nameArgs, actionsByNames: resultOneError, expectError: errNames.Message},
 		{args: nameArgs, actionsByNames: params.ActionsByNames{[]params.ActionsByName{{Name: "action_name"}}}, expectError: "no actions were found for name action_name"},
 		{args: nameArgs, actionsByNames: resultOne, results: result1},
+		{args: prefixArgs, tags: tagsForIdPrefix(prefix, faketag), results: errResult},
 	}
 
 	for i, test := range tests {
@@ -114,10 +116,38 @@ func (s *StatusSuite) runTestCase(c *gc.C, tc statusTestCase) {
 		}
 		if len(tc.results) > 0 {
 			out := &bytes.Buffer{}
+			checkActionResultsMap(c, tc.results)
 			err := cmd.FormatYaml(out, action.ActionResultsToMap(tc.results))
 			c.Check(err, jc.ErrorIsNil)
 			c.Check(ctx.Stdout.(*bytes.Buffer).String(), gc.Equals, out.String())
 			c.Check(ctx.Stderr.(*bytes.Buffer).String(), gc.Equals, "")
+		}
+	}
+}
+
+func checkActionResultsMap(c *gc.C, results []params.ActionResult) {
+	requiredOutputFields := []string{"status", "completed at"}
+	actionFields := []string{"action", "id", "unit"}
+
+	actionResults := action.ActionResultsToMap(results)
+
+	for i, result := range results {
+		a := actionResults["actions"].([]map[string]interface{})[i]
+
+		for _, field := range requiredOutputFields {
+			c.Logf("checking for presence of result output field: %s", field)
+			c.Check(a[field], gc.NotNil)
+		}
+
+		if result.Action != nil {
+			for _, field := range actionFields {
+				c.Logf("checking for presence of action output field: %s", field)
+				c.Check(a[field], gc.NotNil)
+			}
+		}
+
+		if result.Error != nil {
+			c.Check(a["error"], gc.NotNil)
 		}
 	}
 }


### PR DESCRIPTION
## Description of change

Adds info to `juju actions` output so that users can identify actions more easily (by name, completion time)

## QA steps

#### Bootstrap a controller: 
```
juju bootstrap lxd bug_1596888
```

#### Deploy a charm with actions (here we use mongodb):
```bash
juju deploy mongodb
```

#### Run an action:
```bash
juju run-action mongodb/0 perf
```

#### Check the status of your action:
```bash
juju show-action-status
```

#### Check to see that completion time and action name output:
```bash
- action: perf
  completed at: 2017-05-08 21:37:26
  id: e344fd3c-a225-43c7-85df-4c8ee06bc71c
  status: completed
  unit: mongodb/0
```



## Documentation changes

This change does not affect the API or CLI but does add to the output of the `show-action-status` command.

## Bug reference

[lp#1596888](https://bugs.launchpad.net/juju/+bug/1596888)
