### PR TITLE
Fix segfault when cancelling actions that are not pending.

### DIFF
--- a/cmd/juju/action/cancel_test.go
+++ b/cmd/juju/action/cancel_test.go
@@ -38,8 +38,8 @@ func (s *CancelSuite) TestRun(c *gc.C) {
 	emptyArgs := []string{}
 	emptyPrefixArgs := []string{}
 	prefixArgs := []string{prefix}
-	result1 := []params.ActionResult{{Status: "some-random-status"}}
-	result2 := []params.ActionResult{{Status: "a status"}, {Status: "another status"}}
+	result1 := []params.ActionResult{{Action: &params.Action{}, Status: "some-random-status"}}
+	result2 := []params.ActionResult{{Action: &params.Action{}, Status: "a status"}, {Action: &params.Action{}, Status: "another status"}}
 
 	errNotFound := "no actions specified"
 	errNotFoundForPrefix := `no actions found matching prefix ` + prefix + `, no actions have been canceled`


### PR DESCRIPTION
## Description of change

Fix segmentation fault that occurs when attempting to cancel an action. When a request to cancel an action is sent to the agent API it will return a response with a non-nil action only if the action being canceled was in the pending state. Since we don't filter on state before attempting to cancel (since it would be a race) this seg fault slipped in... This PR is a work around.

## QA steps

Cancel an action that is not in a pending state. You should receive a warning not a seg fault.

## Documentation changes

N/A

## Bug reference

N/A
