### PR TITLE
cmr: Add remote spaces and bindings to remote applications

### DIFF
--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -21,7 +21,7 @@ github.com/juju/ansiterm	git	b99631de12cf04a906c1d4e4ec54fb86eae5863d	2016-09-07
 github.com/juju/blobstore	git	06056004b3d7b54bbb7984d830c537bad00fec21	2015-07-29T11:18:58Z
 github.com/juju/bundlechanges	git	7725027b95e0d54635e0fb11efc2debdcdf19f75	2016-12-15T16:06:52Z
 github.com/juju/cmd	git	e47739aefe0adb68a401fcd371c0c92c8f6f8d99	2017-04-13T02:13:06Z
-github.com/juju/description	git	50b9bb7345dcc1d0443cc137337fdb15a4296ac2	2017-04-06T03:03:04Z
+github.com/juju/description	git	c1f554b8467afc4ec5e9175d162cc9a7217436a5	2017-05-09T00:06:37Z
 github.com/juju/errors	git	1b5e39b83d1835fa480e0c2ddefb040ee82d58b3	2015-09-16T12:56:42Z
 github.com/juju/gnuflag	git	4e76c56581859c14d9d87e1ddbe29e1c0f10195f	2016-08-09T16:52:14Z
 github.com/juju/go-oracle-cloud	git	932a8cea00a1cd5cba3829a672c823955db674ae	2017-04-21T13:45:47Z

--- a/state/migration_export.go
+++ b/state/migration_export.go
@@ -1430,6 +1430,11 @@ func (e *exporter) addRemoteApplication(app *RemoteApplication) error {
 		IsConsumerProxy: app.IsConsumerProxy(),
 	}
 	descApp := e.model.AddRemoteApplication(args)
+	status, err := e.statusArgs(app.globalKey())
+	if err != nil {
+		return errors.Trace(err)
+	}
+	descApp.SetStatus(status)
 	endpoints, err := app.Endpoints()
 	if err != nil {
 		return errors.Trace(err)

--- a/state/migration_export.go
+++ b/state/migration_export.go
@@ -943,14 +943,20 @@ func (e *exporter) subnets() error {
 	e.logger.Debugf("read %d subnets", len(subnets))
 
 	for _, subnet := range subnets {
-		e.model.AddSubnet(description.SubnetArgs{
+		args := description.SubnetArgs{
 			CIDR:              subnet.CIDR(),
 			ProviderId:        string(subnet.ProviderId()),
 			ProviderNetworkId: string(subnet.ProviderNetworkId()),
 			VLANTag:           subnet.VLANTag(),
-			AvailabilityZone:  subnet.AvailabilityZone(),
 			SpaceName:         subnet.SpaceName(),
-		})
+		}
+		// TODO(babbageclunk): at the moment state.Subnet only stores
+		// one AZ.
+		az := subnet.AvailabilityZone()
+		if az != "" {
+			args.AvailabilityZones = []string{az}
+		}
+		e.model.AddSubnet(args)
 	}
 	return nil
 }

--- a/state/migration_export.go
+++ b/state/migration_export.go
@@ -1428,6 +1428,7 @@ func (e *exporter) addRemoteApplication(app *RemoteApplication) error {
 		URL:             url,
 		SourceModel:     app.SourceModel(),
 		IsConsumerProxy: app.IsConsumerProxy(),
+		Bindings:        app.Bindings(),
 	}
 	descApp := e.model.AddRemoteApplication(args)
 	status, err := e.statusArgs(app.globalKey())
@@ -1448,7 +1449,29 @@ func (e *exporter) addRemoteApplication(app *RemoteApplication) error {
 			Scope:     string(ep.Scope),
 		})
 	}
+	for _, space := range app.Spaces() {
+		e.addRemoteSpace(descApp, space)
+	}
 	return nil
+}
+
+func (e *exporter) addRemoteSpace(descApp description.RemoteApplication, space RemoteSpace) {
+	descSpace := descApp.AddSpace(description.RemoteSpaceArgs{
+		CloudType:          space.CloudType,
+		Name:               space.Name,
+		ProviderId:         space.ProviderId,
+		ProviderAttributes: space.ProviderAttributes,
+	})
+	for _, subnet := range space.Subnets {
+		descSpace.AddSubnet(description.SubnetArgs{
+			CIDR:              subnet.CIDR,
+			ProviderId:        subnet.ProviderId,
+			VLANTag:           subnet.VLANTag,
+			AvailabilityZones: subnet.AvailabilityZones,
+			ProviderSpaceId:   subnet.ProviderSpaceId,
+			ProviderNetworkId: subnet.ProviderNetworkId,
+		})
+	}
 }
 
 func (e *exporter) storage() error {

--- a/state/migration_export_test.go
+++ b/state/migration_export_test.go
@@ -1146,8 +1146,6 @@ func (s *MigrationExportSuite) newResource(c *gc.C, appName, name string, revisi
 func (s *MigrationExportSuite) TestRemoteApplications(c *gc.C) {
 	// NOTE: the key 'c#<name>' isn't overly useful for someone looking
 	// at a DB dump of the status collection for identifying what it is for.
-	c.Skip("the remote application needs to export the assocated status " +
-		"document for the remote application 'c#grave-rainbow'.")
 	_, err := s.State.AddRemoteApplication(state.AddRemoteApplicationParams{
 		Name:        "gravy-rainbow",
 		URL:         "me/model.rainbow",

--- a/state/migration_export_test.go
+++ b/state/migration_export_test.go
@@ -18,6 +18,7 @@ import (
 	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/constraints"
+	"github.com/juju/juju/environs"
 	"github.com/juju/juju/feature"
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/payload"
@@ -1146,7 +1147,7 @@ func (s *MigrationExportSuite) newResource(c *gc.C, appName, name string, revisi
 func (s *MigrationExportSuite) TestRemoteApplications(c *gc.C) {
 	// NOTE: the key 'c#<name>' isn't overly useful for someone looking
 	// at a DB dump of the status collection for identifying what it is for.
-	_, err := s.State.AddRemoteApplication(state.AddRemoteApplicationParams{
+	sApp, err := s.State.AddRemoteApplication(state.AddRemoteApplicationParams{
 		Name:        "gravy-rainbow",
 		URL:         "me/model.rainbow",
 		SourceModel: s.State.ModelTag(),
@@ -1168,6 +1169,48 @@ func (s *MigrationExportSuite) TestRemoteApplications(c *gc.C) {
 			Role:      charm.RoleProvider,
 			Scope:     charm.ScopeGlobal,
 		}},
+		Spaces: []*environs.ProviderSpaceInfo{{
+			CloudType: "ec2",
+			ProviderAttributes: map[string]interface{}{
+				"thing1":  23,
+				"thing2":  "halberd",
+				"network": "network-1",
+			},
+			SpaceInfo: network.SpaceInfo{
+				Name:       "public",
+				ProviderId: "juju-space-public",
+				Subnets: []network.SubnetInfo{{
+					ProviderId:        "juju-subnet-12",
+					CIDR:              "1.2.3.0/24",
+					AvailabilityZones: []string{"az1", "az2"},
+					SpaceProviderId:   "juju-space-public",
+					ProviderNetworkId: "network-1",
+				}},
+			},
+		}, {
+			CloudType: "ec2",
+			ProviderAttributes: map[string]interface{}{
+				"thing1":  24,
+				"thing2":  "bardiche",
+				"network": "network-1",
+			},
+			SpaceInfo: network.SpaceInfo{
+				Name:       "private",
+				ProviderId: "juju-space-private",
+				Subnets: []network.SubnetInfo{{
+					ProviderId:        "juju-subnet-24",
+					CIDR:              "1.2.4.0/24",
+					AvailabilityZones: []string{"az1", "az2"},
+					SpaceProviderId:   "juju-space-private",
+					ProviderNetworkId: "network-1",
+				}},
+			},
+		}},
+		Bindings: map[string]string{
+			"db":       "private",
+			"db-admin": "private",
+			"logging":  "public",
+		},
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -1182,6 +1225,11 @@ func (s *MigrationExportSuite) TestRemoteApplications(c *gc.C) {
 	c.Check(app.URL(), gc.Equals, "me/model.rainbow")
 	c.Check(app.SourceModelTag(), gc.Equals, s.State.ModelTag())
 	c.Check(app.IsConsumerProxy(), jc.IsFalse)
+	c.Check(app.Bindings(), gc.DeepEquals, map[string]string{
+		"db":       "private",
+		"db-admin": "private",
+		"logging":  "public",
+	})
 
 	c.Assert(app.Endpoints(), gc.HasLen, 3)
 	ep := app.Endpoints()[0]
@@ -1202,6 +1250,34 @@ func (s *MigrationExportSuite) TestRemoteApplications(c *gc.C) {
 	c.Check(ep.Limit(), gc.Equals, 0)
 	c.Check(ep.Role(), gc.Equals, "provider")
 	c.Check(ep.Scope(), gc.Equals, "global")
+
+	originalSpaces := sApp.Spaces()
+	actualSpaces := app.Spaces()
+	c.Assert(actualSpaces, gc.HasLen, 2)
+	checkSpaceMatches(c, actualSpaces[0], originalSpaces[0])
+	checkSpaceMatches(c, actualSpaces[1], originalSpaces[1])
+}
+
+func checkSpaceMatches(c *gc.C, actual description.RemoteSpace, original state.RemoteSpace) {
+	c.Check(actual.CloudType(), gc.Equals, original.CloudType)
+	c.Check(actual.Name(), gc.Equals, original.Name)
+	c.Check(actual.ProviderId(), gc.Equals, original.ProviderId)
+	c.Check(actual.ProviderAttributes(), gc.DeepEquals, map[string]interface{}(original.ProviderAttributes))
+	subnets := actual.Subnets()
+	c.Assert(subnets, gc.HasLen, len(original.Subnets))
+	for i, subnet := range subnets {
+		c.Logf("subnet %d", i)
+		checkSubnetMatches(c, subnet, original.Subnets[i])
+	}
+}
+
+func checkSubnetMatches(c *gc.C, actual description.Subnet, original state.RemoteSubnet) {
+	c.Check(actual.CIDR(), gc.Equals, original.CIDR)
+	c.Check(actual.ProviderId(), gc.Equals, original.ProviderId)
+	c.Check(actual.VLANTag(), gc.Equals, original.VLANTag)
+	c.Check(actual.AvailabilityZones(), gc.DeepEquals, original.AvailabilityZones)
+	c.Check(actual.ProviderSpaceId(), gc.Equals, original.ProviderSpaceId)
+	c.Check(actual.ProviderNetworkId(), gc.Equals, original.ProviderNetworkId)
 }
 
 func (s *MigrationExportSuite) TestModelStatus(c *gc.C) {

--- a/state/migration_export_test.go
+++ b/state/migration_export_test.go
@@ -674,7 +674,7 @@ func (s *MigrationExportSuite) TestSubnets(c *gc.C) {
 	c.Assert(subnet.ProviderId(), gc.Equals, "foo")
 	c.Assert(subnet.ProviderNetworkId(), gc.Equals, "rust")
 	c.Assert(subnet.VLANTag(), gc.Equals, 64)
-	c.Assert(subnet.AvailabilityZone(), gc.Equals, "bar")
+	c.Assert(subnet.AvailabilityZones(), gc.DeepEquals, []string{"bar"})
 	c.Assert(subnet.SpaceName(), gc.Equals, "bam")
 }
 

--- a/state/migration_export_test.go
+++ b/state/migration_export_test.go
@@ -1145,9 +1145,7 @@ func (s *MigrationExportSuite) newResource(c *gc.C, appName, name string, revisi
 }
 
 func (s *MigrationExportSuite) TestRemoteApplications(c *gc.C) {
-	// NOTE: the key 'c#<name>' isn't overly useful for someone looking
-	// at a DB dump of the status collection for identifying what it is for.
-	sApp, err := s.State.AddRemoteApplication(state.AddRemoteApplicationParams{
+	dbApp, err := s.State.AddRemoteApplication(state.AddRemoteApplicationParams{
 		Name:        "gravy-rainbow",
 		URL:         "me/model.rainbow",
 		SourceModel: s.State.ModelTag(),
@@ -1251,7 +1249,7 @@ func (s *MigrationExportSuite) TestRemoteApplications(c *gc.C) {
 	c.Check(ep.Role(), gc.Equals, "provider")
 	c.Check(ep.Scope(), gc.Equals, "global")
 
-	originalSpaces := sApp.Spaces()
+	originalSpaces := dbApp.Spaces()
 	actualSpaces := app.Spaces()
 	c.Assert(actualSpaces, gc.HasLen, 2)
 	checkSpaceMatches(c, actualSpaces[0], originalSpaces[0])

--- a/state/migration_import.go
+++ b/state/migration_import.go
@@ -1176,14 +1176,20 @@ func (i *importer) addLinkLayerDevice(device description.LinkLayerDevice) error 
 func (i *importer) subnets() error {
 	i.logger.Debugf("importing subnets")
 	for _, subnet := range i.model.Subnets() {
-		err := i.addSubnet(SubnetInfo{
+		info := SubnetInfo{
 			CIDR:              subnet.CIDR(),
 			ProviderId:        network.Id(subnet.ProviderId()),
 			ProviderNetworkId: network.Id(subnet.ProviderNetworkId()),
 			VLANTag:           subnet.VLANTag(),
-			AvailabilityZone:  subnet.AvailabilityZone(),
 			SpaceName:         subnet.SpaceName(),
-		})
+		}
+		// TODO(babbageclunk): at the moment state.Subnet only stores
+		// one AZ.
+		zones := subnet.AvailabilityZones()
+		if len(zones) > 0 {
+			info.AvailabilityZone = zones[0]
+		}
+		err := i.addSubnet(info)
 		if err != nil {
 			return errors.Trace(err)
 		}

--- a/state/remoteapplication.go
+++ b/state/remoteapplication.go
@@ -155,6 +155,15 @@ func (s *RemoteApplication) Spaces() []RemoteSpace {
 	return result
 }
 
+// Bindings returns the endpoint->space bindings for the application.
+func (s *RemoteApplication) Bindings() map[string]string {
+	result := make(map[string]string)
+	for epName, spName := range s.doc.Bindings {
+		result[epName] = spName
+	}
+	return result
+}
+
 // SpaceForEndpoint returns the remote space an endpoint is bound to,
 // if one is found.
 func (s *RemoteApplication) SpaceForEndpoint(endpointName string) (RemoteSpace, bool) {

--- a/state/remoteapplication.go
+++ b/state/remoteapplication.go
@@ -18,6 +18,7 @@ import (
 	"gopkg.in/mgo.v2/txn"
 
 	"github.com/juju/juju/core/crossmodel"
+	"github.com/juju/juju/environs"
 	"github.com/juju/juju/status"
 )
 
@@ -36,6 +37,8 @@ type remoteApplicationDoc struct {
 	URL             string              `bson:"url,omitempty"`
 	SourceModelUUID string              `bson:"source-model-uuid"`
 	Endpoints       []remoteEndpointDoc `bson:"endpoints"`
+	Spaces          []RemoteSpace       `bson:"spaces"`
+	Bindings        map[string]string   `bson:"bindings"`
 	Life            Life                `bson:"life"`
 	RelationCount   int                 `bson:"relationcount"`
 	IsConsumerProxy bool                `bson:"is-consumer-proxy"`
@@ -48,6 +51,29 @@ type remoteEndpointDoc struct {
 	Interface string              `bson:"interface"`
 	Limit     int                 `bson:"limit"`
 	Scope     charm.RelationScope `bson:"scope"`
+}
+
+type attributeMap map[string]interface{}
+
+// RemoteSpace represents a space in another model that endpoints are
+// bound to.
+type RemoteSpace struct {
+	CloudType          string         `bson:"cloud-type"`
+	Name               string         `bson:"name"`
+	ProviderId         string         `bson:"provider-id"`
+	ProviderAttributes attributeMap   `bson:"provider-attributes"`
+	Subnets            []RemoteSubnet `bson:"subnets"`
+}
+
+// RemoteSubnet represents a subnet in another model. Unfortunately we
+// can't reuse state.Subnet - it's tied to the subnets collection.
+type RemoteSubnet struct {
+	CIDR              string   `bson:"cidr"`
+	ProviderId        string   `bson:"provider-id"`
+	VLANTag           int      `bson:"vlan-tag"`
+	AvailabilityZones []string `bson:"availability-zones"`
+	ProviderSpaceId   string   `bson:"provider-space-id"`
+	ProviderNetworkId string   `bson:"provider-network-id"`
 }
 
 func newRemoteApplication(st *State, doc *remoteApplicationDoc) *RemoteApplication {
@@ -117,6 +143,51 @@ func (s *RemoteApplication) Tag() names.Tag {
 // Life returns whether the application is Alive, Dying or Dead.
 func (s *RemoteApplication) Life() Life {
 	return s.doc.Life
+}
+
+// Spaces returns the remote spaces this application is connected to.
+func (s *RemoteApplication) Spaces() []RemoteSpace {
+	var result []RemoteSpace
+	for _, space := range s.doc.Spaces {
+		space.Subnets = copySubnets(space.Subnets)
+		result = append(result, space)
+	}
+	return result
+}
+
+// SpaceForEndpoint returns the remote space an endpoint is bound to,
+// if one is found.
+func (s *RemoteApplication) SpaceForEndpoint(endpointName string) (RemoteSpace, bool) {
+	spaceName, ok := s.doc.Bindings[endpointName]
+	if !ok {
+		return RemoteSpace{}, false
+	}
+	for _, space := range s.doc.Spaces {
+		if space.Name == spaceName {
+			// Prevent modification of the original's subnets.
+			space.Subnets = copySubnets(space.Subnets)
+			return space, true
+		}
+	}
+	return RemoteSpace{}, false
+}
+
+func copySubnets(subnets []RemoteSubnet) []RemoteSubnet {
+	result := make([]RemoteSubnet, len(subnets))
+	for i, subnet := range subnets {
+		subnet.AvailabilityZones = copyStrings(subnet.AvailabilityZones)
+		result[i] = subnet
+	}
+	return result
+}
+
+func copyStrings(values []string) []string {
+	if values == nil {
+		return nil
+	}
+	result := make([]string, len(values))
+	copy(result, values)
+	return result
 }
 
 // Destroy ensures that this remote application reference and all its relations
@@ -431,6 +502,13 @@ type AddRemoteApplicationParams struct {
 	// Endpoints describes the endpoints that the remote application implements.
 	Endpoints []charm.Relation
 
+	// Spaces describes the network spaces that the remote
+	// application's endpoints inhabit in the remote model.
+	Spaces []*environs.ProviderSpaceInfo
+
+	// Bindings maps each endpoint name to the remote space it is bound to.
+	Bindings map[string]string
+
 	// IsConsumerProxy is true when a remote application is created as a result
 	// of a registration operation from a remote model.
 	IsConsumerProxy bool
@@ -451,6 +529,15 @@ func (p AddRemoteApplicationParams) Validate() error {
 	}
 	if p.SourceModel == (names.ModelTag{}) {
 		return errors.NotValidf("empty source model tag")
+	}
+	spaceNames := set.NewStrings()
+	for _, space := range p.Spaces {
+		spaceNames.Add(space.Name)
+	}
+	for endpoint, space := range p.Bindings {
+		if !spaceNames.Contains(space) {
+			return errors.NotValidf("endpoint %q bound to missing space %q", endpoint, space)
+		}
 	}
 	return nil
 }
@@ -479,6 +566,7 @@ func (st *State) AddRemoteApplication(args AddRemoteApplicationParams) (_ *Remot
 		OfferName:       args.OfferName,
 		SourceModelUUID: args.SourceModel.Id(),
 		URL:             args.URL,
+		Bindings:        args.Bindings,
 		Life:            Alive,
 		IsConsumerProxy: args.IsConsumerProxy,
 	}
@@ -493,6 +581,28 @@ func (st *State) AddRemoteApplication(args AddRemoteApplicationParams) (_ *Remot
 		}
 	}
 	appDoc.Endpoints = eps
+	spaces := make([]RemoteSpace, len(args.Spaces))
+	for i, space := range args.Spaces {
+		spaces[i] = RemoteSpace{
+			CloudType:          space.CloudType,
+			Name:               space.Name,
+			ProviderId:         string(space.ProviderId),
+			ProviderAttributes: space.ProviderAttributes,
+		}
+		subnets := make([]RemoteSubnet, len(space.Subnets))
+		for i, subnet := range space.Subnets {
+			subnets[i] = RemoteSubnet{
+				CIDR:              subnet.CIDR,
+				ProviderId:        string(subnet.ProviderId),
+				VLANTag:           subnet.VLANTag,
+				AvailabilityZones: copyStrings(subnet.AvailabilityZones),
+				ProviderSpaceId:   string(subnet.SpaceProviderId),
+				ProviderNetworkId: string(subnet.ProviderNetworkId),
+			}
+		}
+		spaces[i].Subnets = subnets
+	}
+	appDoc.Spaces = spaces
 	app := newRemoteApplication(st, appDoc)
 	statusDoc := statusDoc{
 		ModelUUID:  st.ModelUUID(),

--- a/state/remoteapplication_test.go
+++ b/state/remoteapplication_test.go
@@ -12,6 +12,8 @@ import (
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/charm.v6-unstable"
 
+	"github.com/juju/juju/environs"
+	"github.com/juju/juju/network"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/testing"
 	"github.com/juju/juju/status"
@@ -46,6 +48,49 @@ func (s *remoteApplicationSuite) SetUpTest(c *gc.C) {
 			Scope:     charm.ScopeGlobal,
 		},
 	}
+
+	spaces := []*environs.ProviderSpaceInfo{{
+		CloudType: "ec2",
+		ProviderAttributes: map[string]interface{}{
+			"thing1":  23,
+			"thing2":  "halberd",
+			"network": "network-1",
+		},
+		SpaceInfo: network.SpaceInfo{
+			Name:       "public",
+			ProviderId: "juju-space-public",
+			Subnets: []network.SubnetInfo{{
+				ProviderId:        "juju-subnet-12",
+				CIDR:              "1.2.3.0/24",
+				AvailabilityZones: []string{"az1", "az2"},
+				SpaceProviderId:   "juju-space-public",
+				ProviderNetworkId: "network-1",
+			}},
+		},
+	}, {
+		CloudType: "ec2",
+		ProviderAttributes: map[string]interface{}{
+			"thing1":  24,
+			"thing2":  "bardiche",
+			"network": "network-1",
+		},
+		SpaceInfo: network.SpaceInfo{
+			Name:       "private",
+			ProviderId: "juju-space-private",
+			Subnets: []network.SubnetInfo{{
+				ProviderId:        "juju-subnet-24",
+				CIDR:              "1.2.4.0/24",
+				AvailabilityZones: []string{"az1", "az2"},
+				SpaceProviderId:   "juju-space-private",
+				ProviderNetworkId: "network-1",
+			}},
+		},
+	}}
+	bindings := map[string]string{
+		"db":       "private",
+		"db-admin": "private",
+		"logging":  "public",
+	}
 	var err error
 	s.application, err = s.State.AddRemoteApplication(state.AddRemoteApplicationParams{
 		Name:        "mysql",
@@ -53,6 +98,8 @@ func (s *remoteApplicationSuite) SetUpTest(c *gc.C) {
 		SourceModel: s.State.ModelTag(),
 		Token:       "t0",
 		Endpoints:   eps,
+		Spaces:      spaces,
+		Bindings:    bindings,
 	})
 	c.Assert(err, jc.ErrorIsNil)
 }
@@ -168,6 +215,54 @@ func (s *remoteApplicationSuite) TestURL(c *gc.C) {
 	c.Assert(url, gc.Equals, "")
 }
 
+func (s *remoteApplicationSuite) TestSpaces(c *gc.C) {
+	spaces := s.application.Spaces()
+	c.Assert(spaces, gc.DeepEquals, []state.RemoteSpace{{
+		CloudType:  "ec2",
+		Name:       "public",
+		ProviderId: "juju-space-public",
+		ProviderAttributes: map[string]interface{}{
+			"thing1":  23,
+			"thing2":  "halberd",
+			"network": "network-1",
+		},
+		Subnets: []state.RemoteSubnet{{
+			ProviderId:        "juju-subnet-12",
+			CIDR:              "1.2.3.0/24",
+			AvailabilityZones: []string{"az1", "az2"},
+			ProviderSpaceId:   "juju-space-public",
+			ProviderNetworkId: "network-1",
+		}},
+	}, {
+		CloudType:  "ec2",
+		Name:       "private",
+		ProviderId: "juju-space-private",
+		ProviderAttributes: map[string]interface{}{
+			"thing1":  24,
+			"thing2":  "bardiche",
+			"network": "network-1",
+		},
+		Subnets: []state.RemoteSubnet{{
+			ProviderId:        "juju-subnet-24",
+			CIDR:              "1.2.4.0/24",
+			AvailabilityZones: []string{"az1", "az2"},
+			ProviderSpaceId:   "juju-space-private",
+			ProviderNetworkId: "network-1",
+		}},
+	}})
+}
+
+func (s *remoteApplicationSuite) TestSpaceForEndpoint(c *gc.C) {
+	space, ok := s.application.SpaceForEndpoint("db")
+	c.Assert(ok, jc.IsTrue)
+	c.Assert(space.Name, gc.Equals, "private")
+	space, ok = s.application.SpaceForEndpoint("logging")
+	c.Assert(ok, jc.IsTrue)
+	c.Assert(space.Name, gc.Equals, "public")
+	space, ok = s.application.SpaceForEndpoint("something else")
+	c.Assert(ok, jc.IsFalse)
+}
+
 func (s *remoteApplicationSuite) TestMysqlEndpoints(c *gc.C) {
 	_, err := s.application.Endpoint("foo")
 	c.Assert(err, gc.ErrorMatches, `remote application "mysql" has no "foo" relation`)
@@ -257,6 +352,42 @@ func (s *remoteApplicationSuite) TestAddRemoteApplicationErrors(c *gc.C) {
 	)
 	_, err = s.State.RemoteApplication("borken")
 	c.Assert(err, gc.ErrorMatches, `remote application "borken" not found`)
+}
+
+func (s *remoteApplicationSuite) TestParamsValidateChecksBindings(c *gc.C) {
+	eps := []charm.Relation{
+		{
+			Interface: "mysql",
+			Name:      "db",
+			Role:      charm.RoleProvider,
+			Scope:     charm.ScopeGlobal,
+		},
+	}
+
+	spaces := []*environs.ProviderSpaceInfo{{
+		SpaceInfo: network.SpaceInfo{
+			Name: "public",
+		},
+	}}
+	bindings := map[string]string{
+		"db": "private",
+	}
+	args := state.AddRemoteApplicationParams{
+		Name:        "mysql",
+		URL:         "me/model.mysql",
+		SourceModel: s.State.ModelTag(),
+		Token:       "t0",
+		Endpoints:   eps,
+		Spaces:      spaces,
+		Bindings:    bindings,
+	}
+	err := args.Validate()
+	c.Assert(err, gc.ErrorMatches, `endpoint "db" bound to missing space "private" not valid`)
+	bindings["db"] = "public"
+	// Tolerates bindings for non-existent endpoints.
+	bindings["gidget"] = "public"
+	err = args.Validate()
+	c.Assert(err, jc.ErrorIsNil)
 }
 
 func (s *remoteApplicationSuite) TestAddRemoteApplication(c *gc.C) {

--- a/state/remoteapplication_test.go
+++ b/state/remoteapplication_test.go
@@ -263,6 +263,14 @@ func (s *remoteApplicationSuite) TestSpaceForEndpoint(c *gc.C) {
 	c.Assert(ok, jc.IsFalse)
 }
 
+func (s *remoteApplicationSuite) TestBindings(c *gc.C) {
+	c.Assert(s.application.Bindings(), gc.DeepEquals, map[string]string{
+		"db":       "private",
+		"db-admin": "private",
+		"logging":  "public",
+	})
+}
+
 func (s *remoteApplicationSuite) TestMysqlEndpoints(c *gc.C) {
 	_, err := s.application.Endpoint("foo")
 	c.Assert(err, gc.ErrorMatches, `remote application "mysql" has no "foo" relation`)


### PR DESCRIPTION
## Description of change

We need to capture provider-specific information about the spaces that remote application endpoints are bound to, so that we can use that information to decide whether we can use cloud-local addresses for units in cross-model relations.

Add `state.RemoteApplication.Spaces` and `.Bindings` - these will be stored when a remote application is created. This information can then be used to decide what address should be used.

Since these details won't change and don't need to be queried separately from the remote application they're stored in the remote application document rather than in a separate collection.

## QA Steps
None at the moment - the space information won't be populated until a follow-up PR.