### PR TITLE
Volume backed filesystems take on scope of backing volume

### DIFF
--- a/apiserver/storageprovisioner/shim.go
+++ b/apiserver/storageprovisioner/shim.go
@@ -44,11 +44,11 @@ type Backend interface {
 	WatchBlockDevices(names.MachineTag) state.NotifyWatcher
 	WatchMachine(names.MachineTag) (state.NotifyWatcher, error)
 	WatchModelFilesystems() state.StringsWatcher
-	WatchEnvironFilesystemAttachments() state.StringsWatcher
+	WatchModelFilesystemAttachments() state.StringsWatcher
 	WatchMachineFilesystems(names.MachineTag) state.StringsWatcher
 	WatchMachineFilesystemAttachments(names.MachineTag) state.StringsWatcher
 	WatchModelVolumes() state.StringsWatcher
-	WatchEnvironVolumeAttachments() state.StringsWatcher
+	WatchModelVolumeAttachments() state.StringsWatcher
 	WatchMachineVolumes(names.MachineTag) state.StringsWatcher
 	WatchMachineVolumeAttachments(names.MachineTag) state.StringsWatcher
 	WatchVolumeAttachment(names.MachineTag, names.VolumeTag) state.NotifyWatcher

--- a/apiserver/storageprovisioner/storageprovisioner.go
+++ b/apiserver/storageprovisioner/storageprovisioner.go
@@ -329,7 +329,7 @@ func (s *StorageProvisionerAPI) watchStorageEntities(
 func (s *StorageProvisionerAPI) WatchVolumeAttachments(args params.Entities) (params.MachineStorageIdsWatchResults, error) {
 	return s.watchAttachments(
 		args,
-		s.st.WatchEnvironVolumeAttachments,
+		s.st.WatchModelVolumeAttachments,
 		s.st.WatchMachineVolumeAttachments,
 		storagecommon.ParseVolumeAttachmentIds,
 	)
@@ -340,7 +340,7 @@ func (s *StorageProvisionerAPI) WatchVolumeAttachments(args params.Entities) (pa
 func (s *StorageProvisionerAPI) WatchFilesystemAttachments(args params.Entities) (params.MachineStorageIdsWatchResults, error) {
 	return s.watchAttachments(
 		args,
-		s.st.WatchEnvironFilesystemAttachments,
+		s.st.WatchModelFilesystemAttachments,
 		s.st.WatchMachineFilesystemAttachments,
 		storagecommon.ParseFilesystemAttachmentIds,
 	)

--- a/apiserver/storageprovisioner/storageprovisioner_test.go
+++ b/apiserver/storageprovisioner/storageprovisioner_test.go
@@ -1070,12 +1070,12 @@ func (s *provisionerSuite) TestRemoveFilesystemsEnvironManager(c *gc.C) {
 
 	result, err := s.api.Remove(args)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(result, gc.DeepEquals, params.ErrorResults{
+	c.Assert(result, jc.DeepEquals, params.ErrorResults{
 		Results: []params.ErrorResult{
 			{Error: &params.Error{Message: "permission denied", Code: "unauthorized access"}},
 			{Error: nil},
 			{Error: &params.Error{Message: "removing filesystem 2: filesystem is not dead"}},
-			{Error: nil},
+			{Error: &params.Error{Message: "permission denied", Code: "unauthorized access"}},
 			{Error: &params.Error{Message: `"filesystem-invalid" is not a valid filesystem tag`}},
 			{Error: &params.Error{Message: "permission denied", Code: "unauthorized access"}},
 		},

--- a/cmd/juju/storage/filesystem.go
+++ b/cmd/juju/storage/filesystem.go
@@ -146,6 +146,9 @@ func createFilesystemInfo(details params.FilesystemDetails) (names.FilesystemTag
 		}
 		info.Storage = storageTag.Id()
 		if storageInfo.Attachments != nil {
+			if info.Attachments == nil {
+				info.Attachments = &FilesystemAttachments{}
+			}
 			info.Attachments.Units = storageInfo.Attachments.Units
 		}
 	}

--- a/cmd/juju/storage/filesystemlist_test.go
+++ b/cmd/juju/storage/filesystemlist_test.go
@@ -296,6 +296,29 @@ func (s mockListAPI) ListFilesystems(machines []string) ([]params.FilesystemDeta
 					},
 				},
 			},
+		}, {
+			// filesystem 5 is assigned to db-dir/1100, but is not yet
+			// attached to any machines.
+			FilesystemTag: "filesystem-5",
+			Info: params.FilesystemInfo{
+				FilesystemId: "provider-supplied-filesystem-5",
+				Size:         3,
+			},
+			Status: createTestStatus(status.Attached, ""),
+			Storage: &params.StorageDetails{
+				StorageTag: "storage-db-dir-1100",
+				OwnerTag:   "unit-abc-0",
+				Kind:       params.StorageKindBlock,
+				Life:       "alive",
+				Status:     createTestStatus(status.Attached, ""),
+				Attachments: map[string]params.StorageAttachmentDetails{
+					"unit-abc-0": params.StorageAttachmentDetails{
+						StorageTag: "storage-db-dir-1100",
+						UnitTag:    "unit-abc-0",
+						Location:   "/mnt/fuji",
+					},
+				},
+			},
 		},
 	}}}
 	if s.omitPool {

--- a/cmd/juju/storage/list_test.go
+++ b/cmd/juju/storage/list_test.go
@@ -41,12 +41,12 @@ func (s *ListSuite) TestList(c *gc.C) {
 		// Default format is tabular
 		`
 \[Storage\]
-Unit          Id            Type        Pool      Provider id                 Size    Status    Message
-              persistent/1  filesystem                                                detached  
-postgresql/0  db-dir/1100   block                                                     attached  
-transcode/0   db-dir/1000   block                                                     pending   creating volume
-transcode/0   shared-fs/0   filesystem  radiance  provider-supplied-volume-4  1.0GiB  attached  
-transcode/1   shared-fs/0   filesystem  radiance  provider-supplied-volume-4  1.0GiB  attached  
+Unit          Id            Type        Pool      Provider id                     Size    Status    Message
+              persistent/1  filesystem                                                    detached  
+postgresql/0  db-dir/1100   block                 provider-supplied-filesystem-5  3.0MiB  attached  
+transcode/0   db-dir/1000   block                                                         pending   creating volume
+transcode/0   shared-fs/0   filesystem  radiance  provider-supplied-volume-4      1.0GiB  attached  
+transcode/1   shared-fs/0   filesystem  radiance  provider-supplied-volume-4      1.0GiB  attached  
 
 `[1:])
 }
@@ -59,12 +59,12 @@ func (s *ListSuite) TestListNoPool(c *gc.C) {
 		// Default format is tabular
 		`
 \[Storage\]
-Unit          Id            Type        Provider id                 Size    Status    Message
-              persistent/1  filesystem                                      detached  
-postgresql/0  db-dir/1100   block                                           attached  
-transcode/0   db-dir/1000   block                                           pending   creating volume
-transcode/0   shared-fs/0   filesystem  provider-supplied-volume-4  1.0GiB  attached  
-transcode/1   shared-fs/0   filesystem  provider-supplied-volume-4  1.0GiB  attached  
+Unit          Id            Type        Provider id                     Size    Status    Message
+              persistent/1  filesystem                                          detached  
+postgresql/0  db-dir/1100   block       provider-supplied-filesystem-5  3.0MiB  attached  
+transcode/0   db-dir/1000   block                                               pending   creating volume
+transcode/0   shared-fs/0   filesystem  provider-supplied-volume-4      1.0GiB  attached  
+transcode/1   shared-fs/0   filesystem  provider-supplied-volume-4      1.0GiB  attached  
 
 `[1:])
 }
@@ -189,6 +189,17 @@ filesystems:
           location: /mnt/pieces
     pool: radiance
     size: 1024
+    status:
+      current: attached
+      since: .*
+  "5":
+    provider-id: provider-supplied-filesystem-5
+    storage: db-dir/1100
+    attachments:
+      units:
+        abc/0:
+          location: /mnt/fuji
+    size: 3
     status:
       current: attached
       since: .*

--- a/cmd/juju/storage/volume.go
+++ b/cmd/juju/storage/volume.go
@@ -157,6 +157,9 @@ func createVolumeInfo(details params.VolumeDetails) (names.VolumeTag, VolumeInfo
 		}
 		info.Storage = storageTag.Id()
 		if storageInfo.Attachments != nil {
+			if info.Attachments == nil {
+				info.Attachments = &VolumeAttachments{}
+			}
 			info.Attachments.Units = storageInfo.Attachments.Units
 		}
 	}

--- a/state/filesystem.go
+++ b/state/filesystem.go
@@ -492,12 +492,6 @@ func isDetachableFilesystemPool(st *State, pool string) (bool, error) {
 		// to the machine.
 		return false, nil
 	}
-	if !provider.Supports(storage.StorageKindFilesystem) {
-		// TODO(axw) remove this when volume-backed filesystems
-		// inherit the scope of the volume. For now, volume-backed
-		// filesystems are always machine-scoped.
-		return false, nil
-	}
 	return true, nil
 }
 
@@ -784,12 +778,6 @@ func newFilesystemId(st *State, machineId string) (string, error) {
 // directly, a volume will be created and Juju will manage a filesystem
 // on it.
 func (st *State) addFilesystemOps(params FilesystemParams, machineId string) ([]txn.Op, names.FilesystemTag, names.VolumeTag, error) {
-	// TODO(axw) the scope of a volume-backed filesystem should be the
-	// same as the volume. Machine storage provisioners would be
-	// responsible for managing filesystems backed by volumes attached
-	// to that machine. Making this change will enable persistent
-	// filesystems; until then, destroying a volume-backed filesystem
-	// always destroys the volume.
 	params, err := st.filesystemParamsWithDefaults(params, machineId)
 	if err != nil {
 		return nil, names.FilesystemTag{}, names.VolumeTag{}, errors.Trace(err)
@@ -944,18 +932,25 @@ func (st *State) SetFilesystemInfo(tag names.FilesystemTag, info FilesystemInfo)
 		return errors.Trace(err)
 	}
 	// If the filesystem is volume-backed, the volume must be provisioned
-	// and attachment first.
+	// and attached first.
 	if volumeTag, err := fs.Volume(); err == nil {
-		machineTag, ok := names.FilesystemMachine(tag)
-		if !ok {
-			return errors.Errorf("filesystem %s is not machine-scoped, but volume-backed", tag.Id())
-		}
-		volumeAttachment, err := st.VolumeAttachment(machineTag, volumeTag)
+		volumeAttachments, err := st.VolumeAttachments(volumeTag)
 		if err != nil {
 			return errors.Trace(err)
 		}
-		if _, err := volumeAttachment.Info(); err != nil {
-			return errors.Trace(err)
+		var anyAttached bool
+		for _, a := range volumeAttachments {
+			if _, err := a.Info(); err == nil {
+				anyAttached = true
+			} else if !errors.IsNotProvisioned(err) {
+				return err
+			}
+		}
+		if !anyAttached {
+			return errors.Errorf(
+				"backing volume %q is not attached",
+				volumeTag.Id(),
+			)
 		}
 	} else if errors.Cause(err) != ErrNoBackingVolume {
 		return errors.Trace(err)

--- a/state/filesystem_test.go
+++ b/state/filesystem_test.go
@@ -405,7 +405,7 @@ func (s *FilesystemStateSuite) TestWatchEnvironFilesystemAttachments(c *gc.C) {
 	}
 	u := addUnit()
 
-	w := s.State.WatchEnvironFilesystemAttachments()
+	w := s.State.WatchModelFilesystemAttachments()
 	defer testing.AssertStop(c, w)
 	wc := testing.NewStringsWatcherC(c, s.State, w)
 	wc.AssertChangeInSingleEvent("0:0", "0:1") // initial

--- a/state/model_test.go
+++ b/state/model_test.go
@@ -767,9 +767,11 @@ func (s *ModelSuite) TestProcessDyingModelWithVolumeBackedFilesystems(c *gc.C) {
 	c.Assert(filesystems, gc.HasLen, 1)
 
 	c.Assert(model.Destroy(), jc.ErrorIsNil)
-	err = st.DestroyFilesystem(names.NewFilesystemTag("0/0"))
+	err = st.DestroyFilesystem(names.NewFilesystemTag("0"))
 	c.Assert(err, jc.ErrorIsNil)
-	err = st.RemoveFilesystemAttachment(machine.MachineTag(), names.NewFilesystemTag("0/0"))
+	err = st.DetachFilesystem(machine.MachineTag(), names.NewFilesystemTag("0"))
+	c.Assert(err, jc.ErrorIsNil)
+	err = st.RemoveFilesystemAttachment(machine.MachineTag(), names.NewFilesystemTag("0"))
 	c.Assert(err, jc.ErrorIsNil)
 	err = st.DetachVolume(machine.MachineTag(), names.NewVolumeTag("0"))
 	c.Assert(err, jc.ErrorIsNil)

--- a/state/storage.go
+++ b/state/storage.go
@@ -1574,15 +1574,9 @@ func validateStoragePool(
 	kindSupported := provider.Supports(kind)
 	if !kindSupported && kind == storage.StorageKindFilesystem {
 		// Filesystems can be created if either filesystem
-		// or block storage are supported.
-		if provider.Supports(storage.StorageKindBlock) {
-			kindSupported = true
-			// The filesystem is to be backed by a volume,
-			// so the filesystem must be managed on the
-			// machine. Skip the scope-check below by
-			// setting the pointer to nil.
-			machineId = nil
-		}
+		// or block storage are supported. The scope of the
+		// filesystem is the same as the backing volume.
+		kindSupported = provider.Supports(storage.StorageKindBlock)
 	}
 	if !kindSupported {
 		return errors.Errorf("%q provider does not support %q storage", providerType, kind)

--- a/state/volume_test.go
+++ b/state/volume_test.go
@@ -322,7 +322,7 @@ func (s *VolumeStateSuite) TestWatchEnvironVolumeAttachments(c *gc.C) {
 	}
 	addUnit()
 
-	w := s.State.WatchEnvironVolumeAttachments()
+	w := s.State.WatchModelVolumeAttachments()
 	defer testing.AssertStop(c, w)
 	wc := testing.NewStringsWatcherC(c, s.State, w)
 	wc.AssertChangeInSingleEvent("0:0", "0:1") // initial

--- a/state/watcher.go
+++ b/state/watcher.go
@@ -318,10 +318,10 @@ func (st *State) WatchMachineFilesystems(m names.MachineTag) StringsWatcher {
 	return newLifecycleWatcher(st, filesystemsC, members, filter, nil)
 }
 
-// WatchEnvironVolumeAttachments returns a StringsWatcher that notifies of
-// changes to the lifecycles of all volume attachments related to environ-
+// WatchModelVolumeAttachments returns a StringsWatcher that notifies of
+// changes to the lifecycles of all volume attachments related to model-
 // scoped volumes.
-func (st *State) WatchEnvironVolumeAttachments() StringsWatcher {
+func (st *State) WatchModelVolumeAttachments() StringsWatcher {
 	pattern := fmt.Sprintf("^%s.*:%s$", st.docID(""), names.NumberSnippet)
 	members := bson.D{{"_id", bson.D{{"$regex", pattern}}}}
 	filter := func(id interface{}) bool {
@@ -338,11 +338,11 @@ func (st *State) WatchEnvironVolumeAttachments() StringsWatcher {
 	return newLifecycleWatcher(st, volumeAttachmentsC, members, filter, nil)
 }
 
-// WatchEnvironFilesystemAttachments returns a StringsWatcher that notifies
+// WatchModelFilesystemAttachments returns a StringsWatcher that notifies
 // of changes to the lifecycles of all filesystem attachments related to
 // model-scoped filesystems, excluding those that are volume-backed, and
 // whose volume is currently attached to a machine.
-func (st *State) WatchEnvironFilesystemAttachments() StringsWatcher {
+func (st *State) WatchModelFilesystemAttachments() StringsWatcher {
 	pattern := fmt.Sprintf("^%s.*:%s$", st.docID(""), names.NumberSnippet)
 	members := bson.D{{"_id", bson.D{{"$regex", pattern}}}}
 	filter := func(id interface{}) bool {

--- a/state/watcher.go
+++ b/state/watcher.go
@@ -220,16 +220,6 @@ func (st *State) WatchModelLives() StringsWatcher {
 // WatchModelVolumes returns a StringsWatcher that notifies of changes to
 // the lifecycles of all model-scoped volumes.
 func (st *State) WatchModelVolumes() StringsWatcher {
-	return st.watchModelMachinestorage(volumesC)
-}
-
-// WatchModelFilesystems returns a StringsWatcher that notifies of changes
-// to the lifecycles of all model-scoped filesystems.
-func (st *State) WatchModelFilesystems() StringsWatcher {
-	return st.watchModelMachinestorage(filesystemsC)
-}
-
-func (st *State) watchModelMachinestorage(collection string) StringsWatcher {
 	pattern := fmt.Sprintf("^%s$", st.docID(names.NumberSnippet))
 	members := bson.D{{"_id", bson.D{{"$regex", pattern}}}}
 	filter := func(id interface{}) bool {
@@ -239,22 +229,45 @@ func (st *State) watchModelMachinestorage(collection string) StringsWatcher {
 		}
 		return !strings.Contains(k, "/")
 	}
-	return newLifecycleWatcher(st, collection, members, filter, nil)
+	return newLifecycleWatcher(st, volumesC, members, filter, nil)
+}
+
+// WatchModelFilesystems returns a StringsWatcher that notifies of changes
+// to the lifecycles of all model-scoped filesystems, excluding those that
+// are volume-backed, and whose volume is currently attached to a machine.
+func (st *State) WatchModelFilesystems() StringsWatcher {
+	pattern := fmt.Sprintf("^%s$", st.docID(names.NumberSnippet))
+	members := bson.D{{"_id", bson.D{{"$regex", pattern}}}}
+	filter := func(id interface{}) bool {
+		localID, err := st.strictLocalID(id.(string))
+		if err != nil {
+			return false
+		}
+		if strings.Contains(localID, "/") {
+			return false
+		}
+		f, err := st.filesystemByTag(names.NewFilesystemTag(localID))
+		if err != nil {
+			return false
+		}
+		if f.doc.VolumeId == "" {
+			// This is not a volume-backed filesystem;
+			// it's model-scoped, so it qualifies.
+			return true
+		}
+		volumeTag := names.NewVolumeTag(f.doc.VolumeId)
+		attachments, err := st.VolumeAttachments(volumeTag)
+		if err != nil || len(attachments) > 0 {
+			return false
+		}
+		return true
+	}
+	return newLifecycleWatcher(st, filesystemsC, members, filter, nil)
 }
 
 // WatchMachineVolumes returns a StringsWatcher that notifies of changes to
 // the lifecycles of all volumes scoped to the specified machine.
 func (st *State) WatchMachineVolumes(m names.MachineTag) StringsWatcher {
-	return st.watchMachineStorage(m, volumesC)
-}
-
-// WatchMachineFilesystems returns a StringsWatcher that notifies of changes
-// to the lifecycles of all filesystems scoped to the specified machine.
-func (st *State) WatchMachineFilesystems(m names.MachineTag) StringsWatcher {
-	return st.watchMachineStorage(m, filesystemsC)
-}
-
-func (st *State) watchMachineStorage(m names.MachineTag, collection string) StringsWatcher {
 	pattern := fmt.Sprintf("^%s/%s$", st.docID(m.Id()), names.NumberSnippet)
 	members := bson.D{{"_id", bson.D{{"$regex", pattern}}}}
 	prefix := m.Id() + "/"
@@ -265,24 +278,50 @@ func (st *State) watchMachineStorage(m names.MachineTag, collection string) Stri
 		}
 		return strings.HasPrefix(k, prefix)
 	}
-	return newLifecycleWatcher(st, collection, members, filter, nil)
+	return newLifecycleWatcher(st, volumesC, members, filter, nil)
+}
+
+// WatchMachineFilesystems returns a StringsWatcher that notifies of changes
+// to the lifecycles of all filesystems scoped to the specified machine, or
+// having a backing volume attached to the machine.
+func (st *State) WatchMachineFilesystems(m names.MachineTag) StringsWatcher {
+	machinePrefix := m.Id() + "/"
+	machinePattern := fmt.Sprintf("^%s/%s$", st.docID(m.Id()), names.NumberSnippet)
+	modelPattern := fmt.Sprintf("^%s$", st.docID(names.NumberSnippet))
+	members := bson.D{{"$or", []bson.D{
+		{{"_id", bson.D{{"$regex", machinePattern}}}},
+		{
+			{"_id", bson.D{{"$regex", modelPattern}}},
+			{"volumeid", bson.D{{"$exists", true}}},
+		},
+	}}}
+	filter := func(id interface{}) bool {
+		localID, err := st.strictLocalID(id.(string))
+		if err != nil {
+			return false
+		}
+		if strings.HasPrefix(localID, machinePrefix) {
+			// Scoped to the specified machine.
+			return true
+		} else if strings.Contains(localID, "/") {
+			// Machine-scoped, but not for the specified machine.
+			return false
+		}
+		f, err := st.filesystemByTag(names.NewFilesystemTag(localID))
+		if err != nil || f.doc.VolumeId == "" {
+			return false
+		}
+		volumeTag := names.NewVolumeTag(f.doc.VolumeId)
+		_, err = st.VolumeAttachment(m, volumeTag)
+		return err == nil
+	}
+	return newLifecycleWatcher(st, filesystemsC, members, filter, nil)
 }
 
 // WatchEnvironVolumeAttachments returns a StringsWatcher that notifies of
 // changes to the lifecycles of all volume attachments related to environ-
 // scoped volumes.
 func (st *State) WatchEnvironVolumeAttachments() StringsWatcher {
-	return st.watchModelMachinestorageAttachments(volumeAttachmentsC)
-}
-
-// WatchEnvironFilesystemAttachments returns a StringsWatcher that notifies
-// of changes to the lifecycles of all filesystem attachments related to
-// environ-scoped filesystems.
-func (st *State) WatchEnvironFilesystemAttachments() StringsWatcher {
-	return st.watchModelMachinestorageAttachments(filesystemAttachmentsC)
-}
-
-func (st *State) watchModelMachinestorageAttachments(collection string) StringsWatcher {
 	pattern := fmt.Sprintf("^%s.*:%s$", st.docID(""), names.NumberSnippet)
 	members := bson.D{{"_id", bson.D{{"$regex", pattern}}}}
 	filter := func(id interface{}) bool {
@@ -296,24 +335,55 @@ func (st *State) watchModelMachinestorageAttachments(collection string) StringsW
 		}
 		return !strings.Contains(k[colon+1:], "/")
 	}
-	return newLifecycleWatcher(st, collection, members, filter, nil)
+	return newLifecycleWatcher(st, volumeAttachmentsC, members, filter, nil)
+}
+
+// WatchEnvironFilesystemAttachments returns a StringsWatcher that notifies
+// of changes to the lifecycles of all filesystem attachments related to
+// model-scoped filesystems, excluding those that are volume-backed, and
+// whose volume is currently attached to a machine.
+func (st *State) WatchEnvironFilesystemAttachments() StringsWatcher {
+	pattern := fmt.Sprintf("^%s.*:%s$", st.docID(""), names.NumberSnippet)
+	members := bson.D{{"_id", bson.D{{"$regex", pattern}}}}
+	filter := func(id interface{}) bool {
+		localID, err := st.strictLocalID(id.(string))
+		if err != nil {
+			return false
+		}
+		colon := strings.IndexRune(localID, ':')
+		if colon == -1 {
+			return false
+		} else if strings.Contains(localID[colon+1:], "/") {
+			// Machine-scoped.
+			return false
+		}
+		_, filesystemTag, err := ParseFilesystemAttachmentId(localID)
+		if err != nil {
+			return false
+		}
+		f, err := st.filesystemByTag(filesystemTag)
+		if err != nil {
+			return false
+		}
+		if f.doc.VolumeId == "" {
+			// This is not a volume-backed filesystem;
+			// it's model-scoped, so it qualifies.
+			return true
+		}
+		volumeTag := names.NewVolumeTag(f.doc.VolumeId)
+		attachments, err := st.VolumeAttachments(volumeTag)
+		if err != nil || len(attachments) > 0 {
+			return false
+		}
+		return true
+	}
+	return newLifecycleWatcher(st, filesystemAttachmentsC, members, filter, nil)
 }
 
 // WatchMachineVolumeAttachments returns a StringsWatcher that notifies of
 // changes to the lifecycles of all volume attachments related to the specified
 // machine, for volumes scoped to the machine.
 func (st *State) WatchMachineVolumeAttachments(m names.MachineTag) StringsWatcher {
-	return st.watchMachineStorageAttachments(m, volumeAttachmentsC)
-}
-
-// WatchMachineFilesystemAttachments returns a StringsWatcher that notifies of
-// changes to the lifecycles of all filesystem attachments related to the specified
-// machine, for filesystems scoped to the machine.
-func (st *State) WatchMachineFilesystemAttachments(m names.MachineTag) StringsWatcher {
-	return st.watchMachineStorageAttachments(m, filesystemAttachmentsC)
-}
-
-func (st *State) watchMachineStorageAttachments(m names.MachineTag, collection string) StringsWatcher {
 	pattern := fmt.Sprintf("^%s:%s/.*", st.docID(m.Id()), m.Id())
 	members := bson.D{{"_id", bson.D{{"$regex", pattern}}}}
 	prefix := m.Id() + fmt.Sprintf(":%s/", m.Id())
@@ -324,7 +394,43 @@ func (st *State) watchMachineStorageAttachments(m names.MachineTag, collection s
 		}
 		return strings.HasPrefix(k, prefix)
 	}
-	return newLifecycleWatcher(st, collection, members, filter, nil)
+	return newLifecycleWatcher(st, volumeAttachmentsC, members, filter, nil)
+}
+
+// WatchMachineFilesystemAttachments returns a StringsWatcher that notifies of
+// changes to the lifecycles of all filesystem attachments related to the specified
+// machine, for filesystems scoped to the machine, or having a backing volume
+// attached to the machine.
+func (st *State) WatchMachineFilesystemAttachments(m names.MachineTag) StringsWatcher {
+	pattern := fmt.Sprintf("^%s:.*$", st.docID(m.Id()))
+	members := bson.D{{"_id", bson.D{{"$regex", pattern}}}}
+	machineScopedPrefix := m.Id() + fmt.Sprintf(":%s/", m.Id())
+	filter := func(id interface{}) bool {
+		localID, err := st.strictLocalID(id.(string))
+		if err != nil {
+			return false
+		}
+		if strings.HasPrefix(localID, machineScopedPrefix) {
+			// Scoped to the specified machine.
+			return true
+		}
+		_, filesystemTag, err := ParseFilesystemAttachmentId(localID)
+		if err != nil {
+			return false
+		}
+		if _, ok := names.FilesystemMachine(filesystemTag); ok {
+			// Machine-scoped, but not for the specified machine.
+			return false
+		}
+		f, err := st.filesystemByTag(filesystemTag)
+		if err != nil || f.doc.VolumeId == "" {
+			return false
+		}
+		volumeTag := names.NewVolumeTag(f.doc.VolumeId)
+		_, err = st.VolumeAttachment(m, volumeTag)
+		return err == nil
+	}
+	return newLifecycleWatcher(st, filesystemAttachmentsC, members, filter, nil)
 }
 
 // WatchServices returns a StringsWatcher that notifies of changes to
@@ -492,9 +598,7 @@ func (w *lifecycleWatcher) initial() (set.Strings, error) {
 	var doc lifeDoc
 	iter := coll.Find(w.members).Select(lifeFields).Iter()
 	for iter.Next(&doc) {
-		// If no members criteria is specified, use the filter
-		// to reject any unsuitable initial elements.
-		if w.members == nil && w.filter != nil && !w.filter(doc.Id) {
+		if w.filter != nil && !w.filter(doc.Id) {
 			continue
 		}
 		id := w.backend.localID(doc.Id)


### PR DESCRIPTION
## Description of change

Volume-backed filesystems now take on the scope of
the backing volume. If the volume is model-scoped,
then so is the filesystem. This enables us to detach
and reattach volume-backed filesystem storage.

The watcher implementation for machine filesystems
and filesystem attachments has been updated to
report filesystems whose backing volumes are attached
to the specified machine. The apiserver/storageprovisioner
allows access to a volume-backed filesystem if access
to the backing volume is allowed.

There's also a drive-by fix for a cmd/juju/storage bug
that appeared while testing. If storage is attached to a
unit, but not yet a machine, "juju storage" would panic.

## QA steps

1. juju bootstrap aws
2. juju deploy postgresql --storage pgdata=ebs-ssd,10G
The filesystem should have ID "0" (previously it would have been "0/0"). Confirm with "juju storage --filesystem".

3. juju remove-application postgresql
The output of "juju remove-application" should inform the user that the storage will be detached.

4. wait for application, unit, and machine to be removed
The storage should remain.

## Documentation changes

None.

## Bug reference

None.