### PR TITLE
cmd/modelcmd: use FakeJujuXDGDataHomeSuite

### DIFF
--- a/cmd/modelcmd/apicontext_test.go
+++ b/cmd/modelcmd/apicontext_test.go
@@ -5,22 +5,17 @@ import (
 	"net/http"
 	"net/http/httptest"
 
-	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/macaroon-bakery.v1/httpbakery"
 
 	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/jujuclient"
+	"github.com/juju/juju/testing"
 )
 
 type APIContextSuite struct {
-	testing.IsolationSuite
-}
-
-func (s *APIContextSuite) SetUpTest(c *gc.C) {
-	s.IsolationSuite.SetUpTest(c)
-	testing.MakeFakeHome(c)
+	testing.FakeJujuXDGDataHomeSuite
 }
 
 var _ = gc.Suite(&APIContextSuite{})


### PR DESCRIPTION
## Description of change

Use FakeJujuXDGDataHomeSuite to initialise the
"XDG" home directory for tests, isolating them
from one another. We were setting a fake home
directory which isn't sufficient for Windows.

## QA steps

Run the tests.

## Documentation changes

None.

## Bug reference

None.