### PR TITLE
state: add AttachStorage to AddApplicationArgs

### DIFF
--- a/state/application.go
+++ b/state/application.go
@@ -1062,6 +1062,7 @@ type applicationAddUnitOpsArgs struct {
 	principalName string
 	cons          constraints.Value
 	storageCons   map[string]StorageConstraints
+	attachStorage []names.StorageTag
 }
 
 // addApplicationUnitOps is just like addUnitOps but explicitly takes a
@@ -1092,6 +1093,30 @@ func (a *Application) addUnitOpsWithCons(args applicationAddUnitOpsArgs) (string
 		return "", nil, err
 	}
 
+	// Reduce the count of new storage created for each existing storage
+	// being attached.
+	var storageCons map[string]StorageConstraints
+	for _, tag := range args.attachStorage {
+		storageName, err := names.StorageName(tag.Id())
+		if err != nil {
+			return "", nil, errors.Trace(err)
+		}
+		if cons, ok := args.storageCons[storageName]; ok && cons.Count > 0 {
+			if storageCons == nil {
+				// We must not modify the conents of the original
+				// args.storageCons map, as it comes from the
+				// user. Make a copy and modify that.
+				storageCons = make(map[string]StorageConstraints)
+				for name, cons := range args.storageCons {
+					storageCons[name] = cons
+				}
+				args.storageCons = storageCons
+			}
+			cons.Count--
+			storageCons[storageName] = cons
+		}
+	}
+
 	// Add storage instances/attachments for the unit. If the
 	// application is subordinate, we'll add the machine storage
 	// if the principal is assigned to a machine. Otherwise, we
@@ -1105,7 +1130,7 @@ func (a *Application) addUnitOpsWithCons(args applicationAddUnitOpsArgs) (string
 		}
 		machineAssignable = pu
 	}
-	storageOps, numStorageAttachments, err := createStorageOps(
+	storageOps, storageCounts, numStorageAttachments, err := createStorageOps(
 		a.st,
 		unitTag,
 		charm.Meta(),
@@ -1115,6 +1140,40 @@ func (a *Application) addUnitOpsWithCons(args applicationAddUnitOpsArgs) (string
 	)
 	if err != nil {
 		return "", nil, errors.Trace(err)
+	}
+	for _, storageTag := range args.attachStorage {
+		si, err := a.st.storageInstance(storageTag)
+		if err != nil {
+			return "", nil, errors.Annotatef(
+				err, "attaching %s",
+				names.ReadableString(storageTag),
+			)
+		}
+		ops, err := a.st.attachStorageOps(
+			si,
+			unitTag,
+			a.doc.Series,
+			charm,
+			args.storageCons,
+			machineAssignable,
+		)
+		if err != nil {
+			return "", nil, errors.Trace(err)
+		}
+		storageOps = append(storageOps, ops...)
+		numStorageAttachments++
+		storageCounts[si.StorageName()]++
+	}
+	for name, count := range storageCounts {
+		charmStorage := charm.Meta().Storage[name]
+		if err := validateCharmStorageCountChange(charmStorage, 0, count); err != nil {
+			return "", nil, errors.Trace(err)
+		}
+		incRefOp, err := increfEntityStorageOp(a.st, unitTag, name, count)
+		if err != nil {
+			return "", nil, errors.Trace(err)
+		}
+		storageOps = append(storageOps, incRefOp)
 	}
 
 	docID := a.st.docID(name)


### PR DESCRIPTION
## Description of change

Support attaching existing storage to the first unit when deploying an application. When the api/cmd changes are made, this will enable users to `juju deploy foo --attach-storage bar/0`, attaching existing persistent storage to a new application unit.

## QA steps

Smoke test existing attach, since the new stuff is not connected yet:

1. juju bootstrap aws
2. juju deploy postgresql --storage pgdata=ebs
3. juju detach-storage pgdata/0
4. juju attach-storage postgresql/0 pgdata/0

## Documentation changes

None yet.

## Bug reference

None.