### PR TITLE
apiserver: return PublicHostName in login results

### DIFF
--- a/api/apiclient.go
+++ b/api/apiclient.go
@@ -90,6 +90,11 @@ type state struct {
 	// which the client may cache and use for failover.
 	hostPorts [][]network.HostPort
 
+	// publicDNSName is the public host name returned from Login
+	// which the client can use to make a connection verified
+	// by an officially signed certificate.
+	publicDNSName string
+
 	// facadeVersions holds the versions of all facades as reported by
 	// Login
 	facadeVersions map[string][]int
@@ -815,6 +820,14 @@ func (s *state) APIHostPorts() [][]network.HostPort {
 		hostPorts[i] = append([]network.HostPort{}, server...)
 	}
 	return hostPorts
+}
+
+// PublicDNSName returns the host name for which an officially
+// signed certificate will be used for TLS connection to the server.
+// If empty, the private Juju CA certificate must be used to verify
+// the connection.
+func (s *state) PublicDNSName() string {
+	return s.publicDNSName
 }
 
 // AllFacadeVersions returns what versions we know about for all facades

--- a/api/interface.go
+++ b/api/interface.go
@@ -178,8 +178,21 @@ type OpenFunc func(*Info, DialOpts) (Connection, error)
 type Connection interface {
 
 	// This first block of methods is pretty close to a sane Connection interface.
+
+	// Close closes the connection.
 	Close() error
+
+	// Addr returns the address used to connect to the API server.
 	Addr() string
+
+	// APIHostPorts returns addresses that may be used to connect
+	// to the API server, including the address used to connect.
+	//
+	// The addresses are scoped (public, cloud-internal, etc.), so
+	// the client may choose which addresses to attempt. For the
+	// Juju CLI, all addresses must be attempted, as the CLI may
+	// be invoked both within and outside the model (think
+	// private clouds).
 	APIHostPorts() [][]network.HostPort
 
 	// Broken returns a channel which will be closed if the connection
@@ -191,6 +204,12 @@ type Connection interface {
 	// the Broken channel and if that is open, attempts a connection
 	// ping.
 	IsBroken() bool
+
+	// PublicDNSName returns the host name for which an officially
+	// signed certificate will be used for TLS connection to the server.
+	// If empty, the private Juju CA certificate must be used to verify
+	// the connection.
+	PublicDNSName() string
 
 	// These are a bit off -- ServerVersion is apparently not known until after
 	// Login()? Maybe evidence of need for a separate AuthenticatedConnection..?

--- a/api/state.go
+++ b/api/state.go
@@ -129,6 +129,7 @@ func (st *state) Login(tag names.Tag, password, nonce string, macaroons []macaro
 		modelTag:         result.ModelTag,
 		controllerTag:    result.ControllerTag,
 		servers:          servers,
+		publicDNSName:    result.PublicDNSName,
 		facades:          result.Facades,
 		modelAccess:      modelAccess,
 		controllerAccess: controllerAccess,
@@ -150,6 +151,7 @@ type loginResultParams struct {
 	controllerAccess string
 	servers          [][]network.HostPort
 	facades          []params.FacadeVersions
+	publicDNSName    string
 }
 
 func (st *state) setLoginResult(p loginResultParams) error {
@@ -181,6 +183,7 @@ func (st *state) setLoginResult(p loginResultParams) error {
 		return err
 	}
 	st.hostPorts = hostPorts
+	st.publicDNSName = p.publicDNSName
 
 	st.facadeVersions = make(map[string][]int, len(p.facades))
 	for _, facade := range p.facades {

--- a/apiserver/admin.go
+++ b/apiserver/admin.go
@@ -201,6 +201,7 @@ func (a *admin) login(req params.LoginRequest, loginVersion int) (params.LoginRe
 		ControllerTag: model.ControllerTag().String(),
 		UserInfo:      maybeUserInfo,
 		ServerVersion: jujuversion.Current.String(),
+		PublicDNSName: a.srv.publicDNSName(),
 	}
 
 	if controllerOnlyLogin {

--- a/apiserver/params/params.go
+++ b/apiserver/params/params.go
@@ -407,7 +407,7 @@ type Creds struct {
 // then the provided macaroon slices will be used for authentication (if
 // any one is valid, the authentication succeeds). If there are no
 // valid macaroons and macaroon authentication is configured,
-// the LoginResponse will contain a macaroon that when
+// the LoginResult will contain a macaroon that when
 // discharged, may allow access.
 type LoginRequest struct {
 	AuthTag     string           `json:"auth-tag"`
@@ -665,6 +665,12 @@ type LoginResult struct {
 
 	// Servers is the list of API server addresses.
 	Servers [][]HostPort `json:"servers,omitempty"`
+
+	// PublicDNSName holds the host name for which an officially
+	// signed certificate will be used for TLS connection to the server.
+	// If empty, the private Juju CA certificate must be used to verify
+	// the connection.
+	PublicDNSName string `json:"public-dns-name,omitempty"`
 
 	// ModelTag is the tag for the model that is being connected to.
 	ModelTag string `json:"model-tag,omitempty"`

--- a/cmd/juju/backups/restore_test.go
+++ b/cmd/juju/backups/restore_test.go
@@ -243,10 +243,6 @@ func (s *restoreSuite) TestRestoreReboostrapWritesUpdatedControllerInfo(c *gc.C)
 		return nil
 	})
 
-	intPtr := func(i int) *int {
-		return &i
-	}
-
 	_, err := cmdtesting.RunCommand(c, s.command, "restore", "-m", "testing:test1", "--file", "afile", "-b")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(boostrapped, jc.IsTrue)
@@ -258,8 +254,10 @@ func (s *restoreSuite) TestRestoreReboostrapWritesUpdatedControllerInfo(c *gc.C)
 		APIEndpoints:           []string{"10.0.0.1:17777"},
 		UnresolvedAPIEndpoints: []string{"10.0.0.1:17777"},
 		AgentVersion:           version.Current.String(),
-		ModelCount:             intPtr(2),
-		MachineCount:           intPtr(1),
+		// We won't get correct model and machine counts until
+		// we connect properly eventually.
+		ModelCount:             nil,
+		MachineCount:           nil,
 		ControllerMachineCount: 1,
 	})
 }

--- a/cmd/juju/user/logincontroller_test.go
+++ b/cmd/juju/user/logincontroller_test.go
@@ -62,7 +62,7 @@ Welcome, bob@external. You are now logged into "bighost".
 	c.Check(stderr, gc.Equals, "")
 }
 
-func (s *LoginCommandSuite) TestLoginPublicHostname(c *gc.C) {
+func (s *LoginCommandSuite) TestLoginPublicDNSName(c *gc.C) {
 	s.apiConnection.authTag = names.NewUserTag("bob@external")
 	s.apiConnection.controllerAccess = "login"
 	stdout, stderr, code := s.run(c, "0.1.2.3")
@@ -89,7 +89,7 @@ Welcome, bob@external. You are now logged into "0.1.2.3".
 	})
 }
 
-func (s *LoginCommandSuite) TestRegisterPublicHostnameWithPort(c *gc.C) {
+func (s *LoginCommandSuite) TestRegisterPublicDNSNameWithPort(c *gc.C) {
 	s.apiConnection.authTag = names.NewUserTag("bob@external")
 	s.apiConnection.controllerAccess = "login"
 	stdout, stderr, code := s.run(c, "0.1.2.3:5678")
@@ -98,7 +98,7 @@ func (s *LoginCommandSuite) TestRegisterPublicHostnameWithPort(c *gc.C) {
 	c.Check(code, gc.Equals, 1)
 }
 
-func (s *LoginCommandSuite) TestRegisterPublicHostnameWithPortAndControllerFlag(c *gc.C) {
+func (s *LoginCommandSuite) TestRegisterPublicDNSNameWithPortAndControllerFlag(c *gc.C) {
 	s.apiConnection.authTag = names.NewUserTag("bob@external")
 	s.apiConnection.controllerAccess = "login"
 	stdout, stderr, code := s.run(c, "-c", "foo", "0.1.2.3:5678")


### PR DESCRIPTION
This will enable a client to know if a server supports connections
with officially signed certificates and store that fact in the controllers.yaml file.

Also move a few doc comments from the private api.state methods
onto the public api.Connection interface.
