### PR TITLE
juju: remember public hostname in controllers.yaml

### DIFF
--- a/cmd/juju/application/upgradecharm_test.go
+++ b/cmd/juju/application/upgradecharm_test.go
@@ -688,6 +688,10 @@ func (m *mockAPIConnection) AuthTag() names.Tag {
 	return names.NewUserTag("testuser")
 }
 
+func (m *mockAPIConnection) PublicDNSName() string {
+	return ""
+}
+
 func (m *mockAPIConnection) APIHostPorts() [][]network.HostPort {
 	p, _ := network.ParseHostPorts(m.Addr())
 	return [][]network.HostPort{p}

--- a/cmd/juju/commands/bootstrap.go
+++ b/cmd/juju/commands/bootstrap.go
@@ -603,6 +603,7 @@ See `[1:] + "`juju kill-controller`" + `.`)
 		juju.UpdateControllerParams{
 			AgentVersion:           agentVersion.String(),
 			CurrentHostPorts:       [][]network.HostPort{network.AddressesWithPort(addrs, config.controller.APIPort())},
+			PublicDNSName:          newStringIfNonEmpty(config.controller.AutocertDNSName()),
 			MachineCount:           newInt(1),
 			ControllerMachineCount: newInt(1),
 			ModelCount:             newInt(2), // controller model + default model
@@ -1094,4 +1095,11 @@ func handleChooseCloudRegionError(ctx *cmd.Context, err error) error {
 
 func newInt(i int) *int {
 	return &i
+}
+
+func newStringIfNonEmpty(s string) *string {
+	if s == "" {
+		return nil
+	}
+	return &s
 }

--- a/juju/export_test.go
+++ b/juju/export_test.go
@@ -4,7 +4,8 @@
 package juju
 
 var (
-	ProviderConnectDelay   = &providerConnectDelay
-	ResolveOrDropHostnames = &resolveOrDropHostnames
-	ServerAddress          = &serverAddress
+	ProviderConnectDelay                = &providerConnectDelay
+	ResolveOrDropHostnames              = &resolveOrDropHostnames
+	ServerAddress                       = &serverAddress
+	FilterAndResolveControllerHostPorts = filterAndResolveControllerHostPorts
 )

--- a/juju/mock_test.go
+++ b/juju/mock_test.go
@@ -24,6 +24,7 @@ type mockAPIState struct {
 	apiHostPorts  [][]network.HostPort
 	modelTag      string
 	controllerTag string
+	publicDNSName string
 }
 
 type mockedStateFlags int
@@ -79,6 +80,10 @@ func (s *mockAPIState) ServerVersion() (version.Number, bool) {
 
 func (s *mockAPIState) Addr() string {
 	return s.addr
+}
+
+func (s *mockAPIState) PublicDNSName() string {
+	return s.publicDNSName
 }
 
 func (s *mockAPIState) APIHostPorts() [][]network.HostPort {

--- a/jujuclient/controllersfile_test.go
+++ b/jujuclient/controllersfile_test.go
@@ -23,8 +23,8 @@ var _ = gc.Suite(&ControllersFileSuite{})
 const testControllersYAML = `
 controllers:
   aws-test:
-    unresolved-api-endpoints: [instance-1-2-4.useast.aws.com]
     uuid: this-is-the-aws-test-uuid
+    unresolved-api-endpoints: [instance-1-2-4.useast.aws.com]
     api-endpoints: [this-is-aws-test-of-many-api-endpoints]
     ca-cert: this-is-aws-test-ca-cert
     cloud: aws
@@ -32,16 +32,16 @@ controllers:
     controller-machine-count: 0
     active-controller-machine-count: 0
   mallards:
-    unresolved-api-endpoints: [maas-1-05.cluster.mallards]
     uuid: this-is-another-uuid
+    unresolved-api-endpoints: [maas-1-05.cluster.mallards]
     api-endpoints: [this-is-another-of-many-api-endpoints, this-is-one-more-of-many-api-endpoints]
     ca-cert: this-is-another-ca-cert
     cloud: mallards
     controller-machine-count: 0
     active-controller-machine-count: 0
   mark-test-prodstack:
-    unresolved-api-endpoints: [vm-23532.prodstack.canonical.com, great.test.server.hostname.co.nz]
     uuid: this-is-a-uuid
+    unresolved-api-endpoints: [vm-23532.prodstack.canonical.com, great.test.server.hostname.co.nz]
     api-endpoints: [this-is-one-of-many-api-endpoints]
     ca-cert: this-is-a-ca-cert
     cloud: prodstack

--- a/jujuclient/interface.go
+++ b/jujuclient/interface.go
@@ -12,6 +12,9 @@ import (
 
 // ControllerDetails holds the details needed to connect to a controller.
 type ControllerDetails struct {
+	// ControllerUUID is the unique ID for the controller.
+	ControllerUUID string `yaml:"uuid"`
+
 	// UnresolvedAPIEndpoints holds a list of API addresses which may
 	// contain unresolved hostnames. It's used to compare more recent
 	// API addresses before resolving hostnames to determine if the
@@ -19,13 +22,15 @@ type ControllerDetails struct {
 	// slow) local DNS resolution before comparing them against Addresses.
 	UnresolvedAPIEndpoints []string `yaml:"unresolved-api-endpoints,flow"`
 
-	// ControllerUUID is the unique ID for the controller.
-	ControllerUUID string `yaml:"uuid"`
-
 	// APIEndpoints holds a list of API addresses. It may not be
 	// current, and it will be empty if the environment has not been
 	// bootstrapped.
 	APIEndpoints []string `yaml:"api-endpoints,flow"`
+
+	// PublicDNSName holds the public host name associated with the controller.
+	// If this is non-empty, it indicates that the controller will use an
+	// officially signed certificate when connecting with this host name.
+	PublicDNSName string `yaml:"public-hostname,omitempty"`
 
 	// CACert is a security certificate for this controller.
 	CACert string `yaml:"ca-cert"`

--- a/network/hostport.go
+++ b/network/hostport.go
@@ -35,6 +35,20 @@ func (hp HostPort) GoString() string {
 	return hp.String()
 }
 
+// Less reports whether hp1 is ordered before hp2
+// according to the criteria used by SortHostPorts.
+func (hp1 HostPort) Less(hp2 HostPort) bool {
+	order1 := hp1.sortOrder()
+	order2 := hp2.sortOrder()
+	if order1 == order2 {
+		if hp1.Address.Value == hp2.Address.Value {
+			return hp1.Port < hp2.Port
+		}
+		return hp1.Address.Value < hp2.Address.Value
+	}
+	return order1 < order2
+}
+
 // AddressesWithPort returns the given addresses all
 // associated with the given port.
 func AddressesWithPort(addrs []Address, port int) []HostPort {
@@ -108,17 +122,7 @@ type hostPortsPreferringIPv4Slice []HostPort
 func (hp hostPortsPreferringIPv4Slice) Len() int      { return len(hp) }
 func (hp hostPortsPreferringIPv4Slice) Swap(i, j int) { hp[i], hp[j] = hp[j], hp[i] }
 func (hp hostPortsPreferringIPv4Slice) Less(i, j int) bool {
-	hp1 := hp[i]
-	hp2 := hp[j]
-	order1 := hp1.sortOrder()
-	order2 := hp2.sortOrder()
-	if order1 == order2 {
-		if hp1.Address.Value == hp2.Address.Value {
-			return hp1.Port < hp2.Port
-		}
-		return hp1.Address.Value < hp2.Address.Value
-	}
-	return order1 < order2
+	return hp[i].Less(hp[j])
 }
 
 // SortHostPorts sorts the given HostPort slice according to the sortOrder of


### PR DESCRIPTION
This means that however we log in (for example
via juju register), the public hostname is remembered in controllers.yaml.

Also, we use the public hostname information when connecting
to the controller.

We also tidy up some of the code called by juju.NewAPIConnection
to try to make the logic more understandable, renaming
and unexporting the somewhat baroque PrepareEndpointsForCaching
function.

QA: when registering a public controller, check that the public-dns-name
entry is set in controllers.yaml. Also, check that normal juju commands
still work.
