### PR TITLE
cmd/juju/romulus/listagreements Added tabular output format.

### DIFF
--- a/cmd/juju/romulus/listagreements/listagreements.go
+++ b/cmd/juju/romulus/listagreements/listagreements.go
@@ -5,8 +5,10 @@ package listagreements
 
 import (
 	"encoding/json"
+	"fmt"
 	"io"
 
+	"github.com/gosuri/uitable"
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
 	"github.com/juju/gnuflag"
@@ -56,9 +58,10 @@ type listAgreementsCommand struct {
 // SetFlags implements Command.SetFlags.
 func (c *listAgreementsCommand) SetFlags(f *gnuflag.FlagSet) {
 	c.CommandBase.SetFlags(f)
-	c.out.AddFlags(f, "json", map[string]cmd.Formatter{
-		"json": formatJSON,
-		"yaml": cmd.FormatYaml,
+	c.out.AddFlags(f, "tabular", map[string]cmd.Formatter{
+		"tabular": formatTabular,
+		"json":    formatJSON,
+		"yaml":    cmd.FormatYaml,
 	})
 }
 
@@ -107,4 +110,31 @@ func formatJSON(writer io.Writer, value interface{}) error {
 	bytes = append(bytes, '\n')
 	_, err = writer.Write(bytes)
 	return err
+}
+
+func formatTabular(writer io.Writer, value interface{}) error {
+	agreements, ok := value.([]wireformat.AgreementResponse)
+	if !ok {
+		return errors.Errorf("expected value of type %T, got %T", agreements, value)
+	}
+	table := uitable.New()
+	table.MaxColWidth = 50
+	table.Wrap = true
+	for _, col := range []int{1, 2, 3, 4} {
+		table.RightAlign(col)
+	}
+	table.AddRow("Term", "Agreed on")
+	for _, agreement := range agreements {
+		if agreement.Owner != "" {
+			table.AddRow(fmt.Sprintf("%s/%s/%d", agreement.Owner, agreement.Term, agreement.Revision), agreement.CreatedOn)
+		} else {
+			table.AddRow(fmt.Sprintf("%s/%d", agreement.Term, agreement.Revision), agreement.CreatedOn)
+		}
+	}
+
+	_, err := fmt.Fprint(writer, table)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	return nil
 }

--- a/cmd/juju/romulus/listagreements/listagreements_test.go
+++ b/cmd/juju/romulus/listagreements/listagreements_test.go
@@ -39,6 +39,14 @@ func (s *listAgreementsSuite) SetUpTest(c *gc.C) {
 }
 
 const (
+	expectedListAgreementsTabularOutput = `Term       	                    Agreed on
+test-term/1	2015-12-25 00:00:00 +0000 UTC
+`
+
+	expectedListAgreementsTabularOutputWithOwner = `Term             	                    Agreed on
+owner/test-term/1	2015-12-25 00:00:00 +0000 UTC
+`
+
 	expectedListAgreementsJSONOutput = `[
     {
         "user": "test-user",
@@ -84,13 +92,19 @@ func (s *listAgreementsSuite) TestGetUsersAgreements(c *gc.C) {
 	ctx, err = s.runCommand(c)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(ctx, gc.NotNil)
-	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, expectedListAgreementsJSONOutput)
+	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, expectedListAgreementsTabularOutput)
 	c.Assert(s.client.called, jc.IsTrue)
 
 	ctx, err = s.runCommand(c, "--format", "yaml")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(ctx, gc.NotNil)
 	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, "- user: test-user\n  term: test-term\n  revision: 1\n  createdon: 2015-12-25T00:00:00Z\n")
+	c.Assert(s.client.called, jc.IsTrue)
+
+	ctx, err = s.runCommand(c, "--format", "json")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(ctx, gc.NotNil)
+	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, expectedListAgreementsJSONOutput)
 	c.Assert(s.client.called, jc.IsTrue)
 }
 
@@ -110,6 +124,12 @@ func (s *listAgreementsSuite) TestGetUsersAgreementsWithTermOwner(c *gc.C) {
 	s.client.setAgreements(agreements)
 
 	ctx, err = s.runCommand(c)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(ctx, gc.NotNil)
+	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, expectedListAgreementsTabularOutputWithOwner)
+	c.Assert(s.client.called, jc.IsTrue)
+
+	ctx, err = s.runCommand(c, "--format", "json")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(ctx, gc.NotNil)
 	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, expectedListAgreementsJSONOutputWithOwner)


### PR DESCRIPTION
## Description of change

This PR makes the tabular format the default output format of the "juju list-agreements" command, which is also the default output format of other romulus commands.

## QA steps

1. run "juju list-agreements"
2. if you have any agreements to "Terms and Conditions" documents you should see a tabular output
3. run "juju list-agreements --format json" and the output should be json
4. run again with --yaml and check that the output is yaml

## Documentation changes

No documentation change required.

## Bug reference

N/A