### PR TITLE
state: remove APIAddressesFromMachines

### DIFF
--- a/apiserver/common/addresses.go
+++ b/apiserver/common/addresses.go
@@ -15,7 +15,6 @@ import (
 // controller addresses and the CA public certificate.
 type AddressAndCertGetter interface {
 	Addresses() ([]string, error)
-	APIAddressesFromMachines() ([]string, error)
 	CACert() string
 	ModelUUID() string
 	APIHostPorts() ([][]network.HostPort, error)

--- a/apiserver/common/addresses_test.go
+++ b/apiserver/common/addresses_test.go
@@ -108,10 +108,6 @@ func (fakeAddresses) Addresses() ([]string, error) {
 	return []string{"addresses:1", "addresses:2"}, nil
 }
 
-func (fakeAddresses) APIAddressesFromMachines() ([]string, error) {
-	panic("should never be called")
-}
-
 func (fakeAddresses) CACert() string {
 	return "a cert"
 }

--- a/state/address.go
+++ b/state/address.go
@@ -85,22 +85,6 @@ func (st *State) Addresses() ([]string, error) {
 	return appendPort(addrs, config.StatePort()), nil
 }
 
-// APIAddressesFromMachines returns the list of cloud-internal addresses that
-// can be used to connect to the state API server.
-// This method will be deprecated when API addresses are
-// stored independently in their own document.
-func (st *State) APIAddressesFromMachines() ([]string, error) {
-	addrs, err := st.controllerAddresses()
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	config, err := st.ControllerConfig()
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	return appendPort(addrs, config.APIPort()), nil
-}
-
 const apiHostPortsKey = "apiHostPorts"
 
 type apiHostPortsDoc struct {

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -770,15 +770,6 @@ func (s *StateSuite) TestAddresses(c *gc.C) {
 		fmt.Sprintf("10.0.0.2:%d", cfg.StatePort()),
 		fmt.Sprintf("10.0.0.3:%d", cfg.StatePort()),
 	})
-
-	addrs, err = s.State.APIAddressesFromMachines()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(addrs, gc.HasLen, 3)
-	c.Assert(addrs, jc.SameContents, []string{
-		fmt.Sprintf("10.0.0.0:%d", cfg.APIPort()),
-		fmt.Sprintf("10.0.0.2:%d", cfg.APIPort()),
-		fmt.Sprintf("10.0.0.3:%d", cfg.APIPort()),
-	})
 }
 
 func (s *StateSuite) TestPing(c *gc.C) {

--- a/worker/uniter/util_test.go
+++ b/worker/uniter/util_test.go
@@ -293,9 +293,6 @@ func (s ensureStateWorker) step(c *gc.C, ctx *context) {
 	if err != nil || len(addresses) == 0 {
 		addControllerMachine(c, ctx.st)
 	}
-	addresses, err = ctx.st.APIAddressesFromMachines()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(addresses, gc.HasLen, 1)
 }
 
 func addControllerMachine(c *gc.C, st *state.State) {


### PR DESCRIPTION
This method is not used, so remove it.

QA no regressions
