### PR TITLE
api: implement CACert entry point

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -48,6 +48,12 @@ func (c *Client) Status(patterns []string) (*params.FullStatus, error) {
 	return &result, nil
 }
 
+// CACert returns the CA certificate associated with
+// the connection.
+func (c *Client) CACert() (string, error) {
+	return common.NewAPIAddresser(c.facade).CACert()
+}
+
 // StatusHistory retrieves the last <size> results of
 // <kind:combined|agent|workload|machine|machineinstance|container|containerinstance> status
 // for <name> unit

--- a/api/machiner/machiner.go
+++ b/api/machiner/machiner.go
@@ -27,7 +27,6 @@ func NewState(caller base.APICaller) *State {
 		facade:       facadeCaller,
 		APIAddresser: common.NewAPIAddresser(facadeCaller),
 	}
-
 }
 
 // machineLife requests the lifecycle of the given machine from the server.

--- a/apiserver/client/client.go
+++ b/apiserver/client/client.go
@@ -49,11 +49,18 @@ func (api *API) state() *state.State {
 	return api.stateAccessor.(stateShim).State
 }
 
+// caCerter implements the subset of common.APIAddresser
+// methods that we choose to expose in the client facade.
+type caCerter interface {
+	CACert() params.BytesResult
+}
+
 // Client serves client-specific API methods.
 type Client struct {
 	// TODO(wallyworld) - we'll retain model config facade methods
 	// on the client facade until GUI and Python client library are updated.
 	*modelconfig.ModelConfigAPI
+	caCerter
 
 	api        *API
 	newEnviron func() (environs.Environ, error)
@@ -106,6 +113,7 @@ func NewFacade(st *state.State, resources facade.Resources, authorizer facade.Au
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
+	addresser := common.NewAPIAddresser(st, resources)
 	return NewClient(
 		NewStateBackend(st),
 		modelConfigAPI,
@@ -115,6 +123,7 @@ func NewFacade(st *state.State, resources facade.Resources, authorizer facade.Au
 		toolsFinder,
 		newEnviron,
 		blockChecker,
+		addresser,
 	)
 }
 
@@ -128,21 +137,23 @@ func NewClient(
 	toolsFinder *common.ToolsFinder,
 	newEnviron func() (environs.Environ, error),
 	blockChecker *common.BlockChecker,
+	caCerter caCerter,
 ) (*Client, error) {
 	if !authorizer.AuthClient() {
 		return nil, common.ErrPerm
 	}
 	client := &Client{
-		modelConfigAPI,
-		&API{
+		ModelConfigAPI: modelConfigAPI,
+		caCerter:       caCerter,
+		api: &API{
 			stateAccessor: st,
 			auth:          authorizer,
 			resources:     resources,
 			statusSetter:  statusSetter,
 			toolsFinder:   toolsFinder,
 		},
-		newEnviron,
-		blockChecker,
+		newEnviron: newEnviron,
+		check:      blockChecker,
 	}
 	return client, nil
 }

--- a/apiserver/client/client_test.go
+++ b/apiserver/client/client_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/juju/juju/apiserver/client"
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/facade"
-	"github.com/juju/juju/apiserver/modelconfig"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/apiserver/testing"
 	"github.com/juju/juju/constraints"
@@ -63,30 +62,14 @@ func (s *serverSuite) SetUpTest(c *gc.C) {
 }
 
 func (s *serverSuite) authClientForState(c *gc.C, st *state.State, auth facade.Authorizer) *client.Client {
-	urlGetter := common.NewToolsURLGetter(st.ModelUUID(), st)
-	configGetter := stateenvirons.EnvironConfigGetter{st}
-	statusSetter := common.NewStatusSetter(st, common.AuthAlways())
-	toolsFinder := common.NewToolsFinder(configGetter, st, urlGetter)
+	apiserverClient, err := client.NewFacade(st, common.NewResources(), auth)
+	c.Assert(err, jc.ErrorIsNil)
 	s.newEnviron = func() (environs.Environ, error) {
-		return environs.GetEnviron(configGetter, environs.New)
+		return environs.GetEnviron(stateenvirons.EnvironConfigGetter{st}, environs.New)
 	}
-	newEnviron := func() (environs.Environ, error) {
+	client.SetNewEnviron(apiserverClient, func() (environs.Environ, error) {
 		return s.newEnviron()
-	}
-	blockChecker := common.NewBlockChecker(st)
-	modelConfigAPI, err := modelconfig.NewModelConfigAPI(st, auth)
-	c.Assert(err, jc.ErrorIsNil)
-	apiserverClient, err := client.NewClient(
-		client.NewStateBackend(st),
-		modelConfigAPI,
-		common.NewResources(),
-		auth,
-		statusSetter,
-		toolsFinder,
-		newEnviron,
-		blockChecker,
-	)
-	c.Assert(err, jc.ErrorIsNil)
+	})
 	return apiserverClient
 }
 
@@ -590,6 +573,12 @@ func (s *clientSuite) assertResolved(c *gc.C, u *state.Unit) {
 func (s *clientSuite) assertResolvedBlocked(c *gc.C, u *state.Unit, msg string) {
 	err := s.APIState.Client().Resolved("wordpress/0", false)
 	s.AssertBlocked(c, err, msg)
+}
+
+func (s *serverSuite) TestCACert(c *gc.C) {
+	r, err := s.APIState.Client().CACert()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(r, gc.Equals, coretesting.CACert)
 }
 
 func (s *clientSuite) TestBlockDestroyUnitResolved(c *gc.C) {

--- a/apiserver/client/export_test.go
+++ b/apiserver/client/export_test.go
@@ -3,6 +3,10 @@
 
 package client
 
+import (
+	"github.com/juju/juju/environs"
+)
+
 // Filtering exports
 var (
 	MatchPortRanges = matchPortRanges
@@ -14,5 +18,9 @@ var (
 	ProcessMachines   = processMachines
 	MakeMachineStatus = makeMachineStatus
 )
+
+func SetNewEnviron(c *Client, newEnviron func() (environs.Environ, error)) {
+	c.newEnviron = newEnviron
+}
 
 type MachineAndContainers machineAndContainers

--- a/apiserver/client/statushistory_test.go
+++ b/apiserver/client/statushistory_test.go
@@ -40,6 +40,7 @@ func (s *statusHistoryTestSuite) SetUpTest(c *gc.C) {
 		nil, // toolsFinder
 		nil, // newEnviron
 		nil, // blockChecker
+		nil, // addresser
 	)
 	c.Assert(err, jc.ErrorIsNil)
 }


### PR DESCRIPTION
This will enable a client to find out the CA certificate from a controller
even when it has connected without a CA cert (for example when connecting
to a public controller). This means that when migrating models,
the source controller can find out the correct CA certificate to install
in the agent configuration files.
