### PR TITLE
all: remove ExternalControl from migration

### DIFF
--- a/api/controller/controller.go
+++ b/api/controller/controller.go
@@ -224,8 +224,6 @@ type MigrationSpec struct {
 	TargetUser           string
 	TargetPassword       string
 	TargetMacaroons      []macaroon.Slice
-	ExternalControl      bool
-	SkipInitialPrechecks bool
 }
 
 // Validate performs sanity checks on the migration configuration it
@@ -276,8 +274,6 @@ func (c *Client) InitiateMigration(spec MigrationSpec) (string, error) {
 				Password:      spec.TargetPassword,
 				Macaroons:     string(macsJSON),
 			},
-			ExternalControl:      spec.ExternalControl,
-			SkipInitialPrechecks: spec.SkipInitialPrechecks,
 		}},
 	}
 	response := params.InitiateMigrationResults{}

--- a/api/controller/controller_test.go
+++ b/api/controller/controller_test.go
@@ -31,18 +31,6 @@ func (s *Suite) TestInitiateMigration(c *gc.C) {
 	s.checkInitiateMigration(c, makeSpec())
 }
 
-func (s *Suite) TestInitiateMigrationExternalControl(c *gc.C) {
-	spec := makeSpec()
-	spec.ExternalControl = true
-	s.checkInitiateMigration(c, spec)
-}
-
-func (s *Suite) TestInitiateMigrationSkipPrechecks(c *gc.C) {
-	spec := makeSpec()
-	spec.SkipInitialPrechecks = true
-	s.checkInitiateMigration(c, spec)
-}
-
 func (s *Suite) TestInitiateMigrationEmptyCACert(c *gc.C) {
 	spec := makeSpec()
 	spec.TargetCACert = ""
@@ -83,8 +71,6 @@ func specToArgs(spec controller.MigrationSpec) params.InitiateMigrationArgs {
 				Password:      spec.TargetPassword,
 				Macaroons:     string(macsJSON),
 			},
-			ExternalControl:      spec.ExternalControl,
-			SkipInitialPrechecks: spec.SkipInitialPrechecks,
 		}},
 	}
 }

--- a/api/migrationmaster/client.go
+++ b/api/migrationmaster/client.go
@@ -100,7 +100,6 @@ func (c *Client) MigrationStatus() (migration.MigrationStatus, error) {
 	return migration.MigrationStatus{
 		MigrationId:      status.MigrationId,
 		ModelUUID:        modelTag.Id(),
-		ExternalControl:  status.Spec.ExternalControl,
 		Phase:            phase,
 		PhaseChangedTime: status.PhaseChangedTime,
 		TargetInfo: migration.TargetInfo{

--- a/api/migrationmaster/client_test.go
+++ b/api/migrationmaster/client_test.go
@@ -93,7 +93,6 @@ func (s *ClientSuite) TestMigrationStatus(c *gc.C) {
 					Password:      "secret",
 					Macaroons:     string(macsJSON),
 				},
-				ExternalControl: true,
 			},
 			MigrationId:      "id",
 			Phase:            "IMPORT",
@@ -109,7 +108,6 @@ func (s *ClientSuite) TestMigrationStatus(c *gc.C) {
 		ModelUUID:        modelUUID,
 		Phase:            migration.IMPORT,
 		PhaseChangedTime: timestamp,
-		ExternalControl:  true,
 		TargetInfo: migration.TargetInfo{
 			ControllerTag: controllerTag,
 			Addrs:         []string{"2.2.2.2:2"},

--- a/apiserver/controller/controller.go
+++ b/apiserver/controller/controller.go
@@ -429,17 +429,14 @@ func (c *ControllerAPI) initiateOneMigration(spec params.MigrationSpec) (string,
 	}
 
 	// Check if the migration is likely to succeed.
-	if !(spec.ExternalControl && spec.SkipInitialPrechecks) {
-		if err := runMigrationPrechecks(hostedState, targetInfo); err != nil {
-			return "", errors.Trace(err)
-		}
+	if err := runMigrationPrechecks(hostedState, targetInfo); err != nil {
+		return "", errors.Trace(err)
 	}
 
 	// Trigger the migration.
 	mig, err := hostedState.CreateMigration(state.MigrationSpec{
-		InitiatedBy:     c.apiUser,
-		TargetInfo:      targetInfo,
-		ExternalControl: spec.ExternalControl,
+		InitiatedBy: c.apiUser,
+		TargetInfo:  targetInfo,
 	})
 	if err != nil {
 		return "", errors.Trace(err)

--- a/apiserver/controller/controller_test.go
+++ b/apiserver/controller/controller_test.go
@@ -394,7 +394,6 @@ func (s *controllerSuite) TestInitiateMigration(c *gc.C) {
 					Macaroons:     string(macsJSON),
 					Password:      "secret2",
 				},
-				ExternalControl: true,
 			},
 		},
 	}
@@ -419,7 +418,6 @@ func (s *controllerSuite) TestInitiateMigration(c *gc.C) {
 		c.Check(mig.Id(), gc.Equals, expectedId)
 		c.Check(mig.ModelUUID(), gc.Equals, st.ModelUUID())
 		c.Check(mig.InitiatedBy(), gc.Equals, s.Owner.Id())
-		c.Check(mig.ExternalControl(), gc.Equals, args.Specs[i].ExternalControl)
 
 		targetInfo, err := mig.TargetInfo()
 		c.Assert(err, jc.ErrorIsNil)
@@ -541,34 +539,6 @@ func (s *controllerSuite) TestInitiateMigrationPrecheckFail(c *gc.C) {
 	active, err := st.IsMigrationActive()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(active, jc.IsFalse)
-}
-
-func (s *controllerSuite) TestInitiateMigrationSkipPrechecks(c *gc.C) {
-	st := s.Factory.MakeModel(c, nil)
-	defer st.Close()
-	controller.SetPrecheckResult(s, errors.New("should not happen"))
-
-	args := params.InitiateMigrationArgs{
-		Specs: []params.MigrationSpec{
-			{
-				ModelTag: st.ModelTag().String(),
-				TargetInfo: params.MigrationTargetInfo{
-					ControllerTag: randomControllerTag(),
-					Addrs:         []string{"1.1.1.1:1111", "2.2.2.2:2222"},
-					CACert:        "cert",
-					AuthTag:       names.NewUserTag("admin").String(),
-					Password:      "secret",
-				},
-				ExternalControl:      true,
-				SkipInitialPrechecks: true,
-			},
-		},
-	}
-	out, err := s.controller.InitiateMigration(args)
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(out.Results, gc.HasLen, 1)
-	c.Check(out.Results[0].ModelTag, gc.Equals, st.ModelTag().String())
-	c.Check(out.Results[0].Error, gc.IsNil)
 }
 
 func randomControllerTag() string {

--- a/apiserver/migrationmaster/facade.go
+++ b/apiserver/migrationmaster/facade.go
@@ -96,7 +96,6 @@ func (api *API) MigrationStatus() (params.MasterMigrationStatus, error) {
 				Password:      target.Password,
 				Macaroons:     string(macsJSON),
 			},
-			ExternalControl: mig.ExternalControl(),
 		},
 		MigrationId:      mig.Id(),
 		Phase:            phase.String(),

--- a/apiserver/migrationmaster/facade_test.go
+++ b/apiserver/migrationmaster/facade_test.go
@@ -114,13 +114,6 @@ func (s *Suite) TestMigrationStatus(c *gc.C) {
 	})
 }
 
-func (s *Suite) TestMigrationStatusExternalControl(c *gc.C) {
-	s.backend.migration.externalControl = true
-	status, err := s.mustMakeAPI(c).MigrationStatus()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Check(status.Spec.ExternalControl, jc.IsTrue)
-}
-
 func (s *Suite) TestModelInfo(c *gc.C) {
 	api := s.mustMakeAPI(c)
 	model, err := api.ModelInfo()
@@ -480,10 +473,6 @@ func (m *stubMigration) PhaseChangedTime() time.Time {
 
 func (m *stubMigration) ModelUUID() string {
 	return modelUUID
-}
-
-func (m *stubMigration) ExternalControl() bool {
-	return m.externalControl
 }
 
 func (m *stubMigration) TargetInfo() (*coremigration.TargetInfo, error) {

--- a/apiserver/params/migration.go
+++ b/apiserver/params/migration.go
@@ -23,14 +23,8 @@ type InitiateMigrationArgs struct {
 // MigrationSpec holds the details required to start the migration of
 // a single model.
 type MigrationSpec struct {
-	ModelTag        string              `json:"model-tag"`
-	TargetInfo      MigrationTargetInfo `json:"target-info"`
-	ExternalControl bool                `json:"external-control"`
-
-	// SkipInitialPrechecks allows the migration prechecks run during
-	// handling of the InitiateMigration API call to be bypassed. It
-	// is only honoured if ExternalControl is true.
-	SkipInitialPrechecks bool `json:"skip-initial-prechecks"`
+	ModelTag   string              `json:"model-tag"`
+	TargetInfo MigrationTargetInfo `json:"target-info"`
 }
 
 // MigrationTargetInfo holds the details required to connect to and
@@ -142,10 +136,9 @@ type MigrationModelInfo struct {
 
 // MigrationStatus reports the current status of a model migration.
 type MigrationStatus struct {
-	MigrationId     string `json:"migration-id"`
-	Attempt         int    `json:"attempt"`
-	Phase           string `json:"phase"`
-	ExternalControl bool   `json:"external-control"`
+	MigrationId string `json:"migration-id"`
+	Attempt     int    `json:"attempt"`
+	Phase       string `json:"phase"`
 
 	// TODO(mjs): I'm not convinced these Source fields will get used.
 	SourceAPIAddrs []string `json:"source-api-addrs"`

--- a/core/migration/migration.go
+++ b/core/migration/migration.go
@@ -29,10 +29,6 @@ type MigrationStatus struct {
 	// its current value.
 	PhaseChangedTime time.Time
 
-	// ExternalControl indicates the current migration should be
-	// controlled by an external process.
-	ExternalControl bool
-
 	// TargetInfo contains the details of how to connect to the target
 	// controller.
 	TargetInfo TargetInfo

--- a/state/modelmigration.go
+++ b/state/modelmigration.go
@@ -34,10 +34,6 @@ type ModelMigration interface {
 	// ModelUUID returns the UUID for the model being migrated.
 	ModelUUID() string
 
-	// ExternalControl returns true if the model migration should be
-	// managed by an external process.
-	ExternalControl() bool
-
 	// Attempt returns the migration attempt identifier. This
 	// increments for each migration attempt for the model.
 	Attempt() int
@@ -134,10 +130,6 @@ type modelMigDoc struct {
 	// migration. It should be in "user@domain" format.
 	InitiatedBy string `bson:"initiated-by"`
 
-	// ExternalControl is true if the migration will be controlled by
-	// an external process, instead of the migrationmaster worker.
-	ExternalControl bool `bson:"external-control"`
-
 	// TargetController holds the UUID of the target controller.
 	TargetController string `bson:"target-controller"`
 
@@ -217,11 +209,6 @@ func (mig *modelMigration) Id() string {
 // ModelUUID implements ModelMigration.
 func (mig *modelMigration) ModelUUID() string {
 	return mig.doc.ModelUUID
-}
-
-// ExternalControl implements ModelMigration.
-func (mig *modelMigration) ExternalControl() bool {
-	return mig.doc.ExternalControl
 }
 
 // Attempt implements ModelMigration.
@@ -607,9 +594,8 @@ func (mig *modelMigration) Refresh() error {
 // MigrationSpec holds the information required to create a
 // ModelMigration instance.
 type MigrationSpec struct {
-	InitiatedBy     names.UserTag
-	TargetInfo      migration.TargetInfo
-	ExternalControl bool
+	InitiatedBy names.UserTag
+	TargetInfo  migration.TargetInfo
 }
 
 // Validate returns an error if the MigrationSpec contains bad
@@ -677,7 +663,6 @@ func (st *State) CreateMigration(spec MigrationSpec) (ModelMigration, error) {
 			ModelUUID:        modelUUID,
 			Attempt:          attempt,
 			InitiatedBy:      spec.InitiatedBy.Id(),
-			ExternalControl:  spec.ExternalControl,
 			TargetController: spec.TargetInfo.ControllerTag.Id(),
 			TargetAddrs:      spec.TargetInfo.Addrs,
 			TargetCACert:     spec.TargetInfo.CACert,

--- a/state/modelmigration_test.go
+++ b/state/modelmigration_test.go
@@ -75,7 +75,6 @@ func (s *MigrationSuite) TestCreate(c *gc.C) {
 	c.Check(mig.EndTime().IsZero(), jc.IsTrue)
 	c.Check(mig.StatusMessage(), gc.Equals, "starting")
 	c.Check(mig.InitiatedBy(), gc.Equals, "admin")
-	c.Check(mig.ExternalControl(), jc.IsFalse)
 
 	info, err := mig.TargetInfo()
 	c.Assert(err, jc.ErrorIsNil)
@@ -88,15 +87,6 @@ func (s *MigrationSuite) TestCreate(c *gc.C) {
 
 	c.Assert(model.Refresh(), jc.ErrorIsNil)
 	c.Check(model.MigrationMode(), gc.Equals, state.MigrationModeExporting)
-}
-
-func (s *MigrationSuite) TestCreateExternalControl(c *gc.C) {
-	spec := s.stdSpec
-	spec.ExternalControl = true
-	mig, err := s.State2.CreateMigration(spec)
-	c.Assert(err, jc.ErrorIsNil)
-	c.Check(mig.ModelUUID(), gc.Equals, s.State2.ModelUUID())
-	c.Check(mig.ExternalControl(), jc.IsTrue)
 }
 
 func (s *MigrationSuite) TestIsMigrationActive(c *gc.C) {

--- a/worker/migrationmaster/worker.go
+++ b/worker/migrationmaster/worker.go
@@ -210,11 +210,6 @@ func (w *Worker) run() error {
 		return errors.Trace(err)
 	}
 
-	if status.ExternalControl {
-		err := w.waitForMigrationEnd()
-		return errors.Trace(err)
-	}
-
 	phase := status.Phase
 
 	for {

--- a/worker/migrationmaster/worker_test.go
+++ b/worker/migrationmaster/worker_test.go
@@ -717,48 +717,6 @@ func (s *Suite) TestAPIConnectWithMacaroon(c *gc.C) {
 	))
 }
 
-func (s *Suite) TestExternalControl(c *gc.C) {
-	status := s.makeStatus(coremigration.QUIESCE)
-	status.ExternalControl = true
-	s.facade.queueStatus(status)
-
-	status.Phase = coremigration.DONE
-	s.facade.queueStatus(status)
-
-	s.checkWorkerReturns(c, migrationmaster.ErrMigrated)
-	s.stub.CheckCalls(c, joinCalls(
-		// Wait for migration to start.
-		watchStatusLockdownCalls,
-
-		// Wait for migration to end.
-		[]jujutesting.StubCall{
-			{"facade.Watch", nil},
-			{"facade.MigrationStatus", nil},
-		},
-	))
-}
-
-func (s *Suite) TestExternalControlABORT(c *gc.C) {
-	status := s.makeStatus(coremigration.QUIESCE)
-	status.ExternalControl = true
-	s.facade.queueStatus(status)
-
-	status.Phase = coremigration.ABORTDONE
-	s.facade.queueStatus(status)
-
-	s.checkWorkerReturns(c, migrationmaster.ErrInactive)
-	s.stub.CheckCalls(c, joinCalls(
-		// Wait for migration to start.
-		watchStatusLockdownCalls,
-
-		// Wait for migration to end.
-		[]jujutesting.StubCall{
-			{"facade.Watch", nil},
-			{"facade.MigrationStatus", nil},
-		},
-	))
-}
-
 func (s *Suite) TestLogTransferErrorOpeningTargetAPI(c *gc.C) {
 	s.facade.queueStatus(s.makeStatus(coremigration.LOGTRANSFER))
 	s.connectionErr = errors.New("people of earth")


### PR DESCRIPTION
Following from a remark from Menno, both ExternalControl
and SkipInitialPrechecks were only there if full migrations
were not implemented in time, but they're implemented now
so we can remove them.

This prepares for adding CACert-fetching logic to the
initial pre-check in the apiserver InitiateMigration logic - that
didn't make sense if the pre-check was optional.

QA no migration regressions.