### PR TITLE
cmd/juju: Remove -S short option for --no-switch

### DIFF
--- a/cmd/juju/commands/bootstrap.go
+++ b/cmd/juju/commands/bootstrap.go
@@ -182,8 +182,7 @@ func (c *bootstrapCommand) SetFlags(f *gnuflag.FlagSet) {
 	f.BoolVar(&c.showClouds, "clouds", false, "Print the available clouds which can be used to bootstrap a Juju environment")
 	f.StringVar(&c.showRegionsForCloud, "regions", "", "Print the available regions for the specified cloud")
 	f.BoolVar(&c.noGUI, "no-gui", false, "Do not install the Juju GUI in the controller when bootstrapping")
-	f.BoolVar(&c.noSwitch, "S", false, "Do not switch to the newly created controller")
-	f.BoolVar(&c.noSwitch, "no-switch", false, "")
+	f.BoolVar(&c.noSwitch, "no-switch", false, "Do not switch to the newly created controller")
 }
 
 func (c *bootstrapCommand) Init(args []string) (err error) {

--- a/cmd/juju/controller/addmodel.go
+++ b/cmd/juju/controller/addmodel.go
@@ -116,8 +116,7 @@ func (c *addModelCommand) SetFlags(f *gnuflag.FlagSet) {
 	f.StringVar(&c.Owner, "owner", "", "The owner of the new model if not the current user")
 	f.StringVar(&c.CredentialName, "credential", "", "Credential used to add the model")
 	f.Var(&c.Config, "config", "Path to YAML model configuration file or individual options (--config config.yaml [--config key=value ...])")
-	f.BoolVar(&c.noSwitch, "S", false, "Do not switch to the newly created controller")
-	f.BoolVar(&c.noSwitch, "no-switch", false, "")
+	f.BoolVar(&c.noSwitch, "no-switch", false, "Do not switch to the newly created controller")
 }
 
 func (c *addModelCommand) Init(args []string) error {


### PR DESCRIPTION
## Description of change

Following tech board discussions, it was decided that this functionality wasn't going to be used enough to warrant the short option.

## QA steps

`juju bootstrap -S` and `juju add-model -S` no longer work. `--no-switch` still works.

## Documentation changes

Not required as there's not been an official release that supported `-S`.

## Bug reference

N.A.
