### PR TITLE
apiserver/controller: fetch target controller CA cert if needed

### DIFF
--- a/apiserver/controller/controller.go
+++ b/apiserver/controller/controller.go
@@ -429,7 +429,7 @@ func (c *ControllerAPI) initiateOneMigration(spec params.MigrationSpec) (string,
 	}
 
 	// Check if the migration is likely to succeed.
-	if err := runMigrationPrechecks(hostedState, targetInfo); err != nil {
+	if err := runMigrationPrechecks(hostedState, &targetInfo); err != nil {
 		return "", errors.Trace(err)
 	}
 
@@ -482,7 +482,10 @@ func (c *ControllerAPI) ModifyControllerAccess(args params.ModifyControllerAcces
 	return result, nil
 }
 
-var runMigrationPrechecks = func(st *state.State, targetInfo coremigration.TargetInfo) error {
+// runMigrationPrechecks runs prechecks on the migration and updates
+// information in targetInfo as needed based on information
+// retrieved from the target controller.
+var runMigrationPrechecks = func(st *state.State, targetInfo *coremigration.TargetInfo) error {
 	// Check model and source controller.
 	backend, err := migration.PrecheckShim(st)
 	if err != nil {
@@ -502,7 +505,19 @@ var runMigrationPrechecks = func(st *state.State, targetInfo coremigration.Targe
 	if err != nil {
 		return errors.Trace(err)
 	}
-	err = migrationtarget.NewClient(conn).Prechecks(modelInfo)
+	client := migrationtarget.NewClient(conn)
+	if targetInfo.CACert == "" {
+		targetInfo.CACert, err = client.CACert()
+		if err != nil {
+			if !params.IsCodeNotImplemented(err) {
+				return errors.Annotatef(err, "cannot retrieve CA certificate")
+			}
+			// If the call's not implemented, it indicates an earlier version
+			// of the controller, which we can't migrate to.
+			return errors.New("controller API version is too old")
+		}
+	}
+	err = client.Prechecks(modelInfo)
 	return errors.Annotate(err, "target prechecks failed")
 }
 
@@ -541,7 +556,7 @@ func makeModelInfo(st *state.State) (coremigration.ModelInfo, error) {
 	}, nil
 }
 
-func targetToAPIInfo(ti coremigration.TargetInfo) *api.Info {
+func targetToAPIInfo(ti *coremigration.TargetInfo) *api.Info {
 	return &api.Info{
 		Addrs:     ti.Addrs,
 		CACert:    ti.CACert,

--- a/apiserver/controller/export_test.go
+++ b/apiserver/controller/export_test.go
@@ -13,7 +13,7 @@ type patcher interface {
 }
 
 func SetPrecheckResult(p patcher, err error) {
-	p.PatchValue(&runMigrationPrechecks, func(*state.State, migration.TargetInfo) error {
+	p.PatchValue(&runMigrationPrechecks, func(*state.State, *migration.TargetInfo) error {
 		return err
 	})
 }


### PR DESCRIPTION
This means that if we're migrating to a public controller, where
the client initiating the migration doesn't know the CA cert, the
source controller will obtain its certificate anyway so that agents will receive it
and be able to connect to the new controller even when their addresses
are updated so they don't know the public DNS name.

QA:
- bootstrap two controllers with public DNS names, C1 and C2
- create a model on C1
- ensure that the entry for C2 in controllers.yaml is empty and that
its API addresses contains its public DNS name.
- migrate the model from C1 to C2
- check that the model has migrated successfully.

