### PR TITLE
apiserver/facade: add Registry.ListDetails method

### DIFF
--- a/apiserver/admin.go
+++ b/apiserver/admin.go
@@ -205,11 +205,11 @@ func (a *admin) login(req params.LoginRequest, loginVersion int) (params.LoginRe
 	}
 
 	if controllerOnlyLogin {
-		loginResult.Facades = filterFacades(a.srv.facades, isControllerFacade)
+		loginResult.Facades = filterFacades(a.srv.facades, IsControllerFacade)
 		apiRoot = restrictRoot(apiRoot, controllerFacadesOnly)
 	} else {
 		loginResult.ModelTag = model.Tag().String()
-		loginResult.Facades = filterFacades(a.srv.facades, isModelFacade)
+		loginResult.Facades = filterFacades(a.srv.facades, IsModelFacade)
 		apiRoot = restrictRoot(apiRoot, modelFacadesOnly)
 	}
 

--- a/apiserver/admin_test.go
+++ b/apiserver/admin_test.go
@@ -38,20 +38,13 @@ import (
 
 type baseLoginSuite struct {
 	jujutesting.JujuConnSuite
-	setAdminAPI func(*apiserver.Server)
 }
 
 type loginSuite struct {
 	baseLoginSuite
 }
 
-var _ = gc.Suite(&loginSuite{
-	baseLoginSuite{
-		setAdminAPI: func(srv *apiserver.Server) {
-			apiserver.SetAdminAPIVersions(srv, 3)
-		},
-	},
-})
+var _ = gc.Suite(&loginSuite{})
 
 func (s *baseLoginSuite) SetUpTest(c *gc.C) {
 	s.JujuConnSuite.SetUpTest(c)
@@ -1109,13 +1102,7 @@ func setEveryoneAccess(c *gc.C, st *state.State, adminUser names.UserTag, access
 	c.Assert(err, jc.ErrorIsNil)
 }
 
-var _ = gc.Suite(&migrationSuite{
-	baseLoginSuite{
-		setAdminAPI: func(srv *apiserver.Server) {
-			apiserver.SetAdminAPIVersions(srv, 3)
-		},
-	},
-})
+var _ = gc.Suite(&migrationSuite{})
 
 type migrationSuite struct {
 	baseLoginSuite

--- a/apiserver/adminv3_test.go
+++ b/apiserver/adminv3_test.go
@@ -10,7 +10,6 @@ import (
 	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/api"
-	"github.com/juju/juju/apiserver"
 	"github.com/juju/juju/rpc"
 	"github.com/juju/juju/testing/factory"
 )
@@ -19,15 +18,7 @@ type loginV3Suite struct {
 	loginSuite
 }
 
-var _ = gc.Suite(&loginV3Suite{
-	loginSuite{
-		baseLoginSuite{
-			setAdminAPI: func(srv *apiserver.Server) {
-				apiserver.SetAdminAPIVersions(srv, 3)
-			},
-		},
-	},
-})
+var _ = gc.Suite(&loginV3Suite{})
 
 func (s *loginV3Suite) TestClientLoginToEnvironment(c *gc.C) {
 	info := s.APIInfo(c)

--- a/apiserver/allfacades.go
+++ b/apiserver/allfacades.go
@@ -231,6 +231,27 @@ func AllFacades() *facade.Registry {
 	return registry
 }
 
+var adminAPIFactories = map[int]adminAPIFactory{
+	3: newAdminAPIV3,
+}
+
+// AdminFacadeDetails returns information on the Admin facade provided
+// at login time. The Facade field of the returned slice elements will
+// be nil.
+func AdminFacadeDetails() []facade.Details {
+	var fs []facade.Details
+	for v, f := range adminAPIFactories {
+		api := f(nil, nil, nil)
+		t := reflect.TypeOf(api)
+		fs = append(fs, facade.Details{
+			Name:    "Admin",
+			Version: v,
+			Type:    t,
+		})
+	}
+	return fs
+}
+
 type hookContextFacadeFn func(*state.State, *state.Unit) (interface{}, error)
 
 // regHookContextFacade registers facades for use within a hook

--- a/apiserver/apiserver.go
+++ b/apiserver/apiserver.go
@@ -53,30 +53,29 @@ const loginRateLimit = 10
 
 // Server holds the server side of the API.
 type Server struct {
-	tomb              tomb.Tomb
-	clock             clock.Clock
-	pingClock         clock.Clock
-	wg                sync.WaitGroup
-	state             *state.State
-	statePool         *state.StatePool
-	lis               net.Listener
-	tag               names.Tag
-	dataDir           string
-	logDir            string
-	limiter           utils.Limiter
-	validator         LoginValidator
-	adminAPIFactories map[int]adminAPIFactory
-	facades           *facade.Registry
-	modelUUID         string
-	authCtxt          *authContext
-	lastConnectionID  uint64
-	centralHub        *pubsub.StructuredHub
-	newObserver       observer.ObserverFactory
-	connCount         int64
-	certChanged       <-chan params.StateServingInfo
-	tlsConfig         *tls.Config
-	allowModelAccess  bool
-	logSinkWriter     io.WriteCloser
+	tomb             tomb.Tomb
+	clock            clock.Clock
+	pingClock        clock.Clock
+	wg               sync.WaitGroup
+	state            *state.State
+	statePool        *state.StatePool
+	lis              net.Listener
+	tag              names.Tag
+	dataDir          string
+	logDir           string
+	limiter          utils.Limiter
+	validator        LoginValidator
+	facades          *facade.Registry
+	modelUUID        string
+	authCtxt         *authContext
+	lastConnectionID uint64
+	centralHub       *pubsub.StructuredHub
+	newObserver      observer.ObserverFactory
+	connCount        int64
+	certChanged      <-chan params.StateServingInfo
+	tlsConfig        *tls.Config
+	allowModelAccess bool
+	logSinkWriter    io.WriteCloser
 
 	// mu guards the fields below it.
 	mu sync.Mutex
@@ -215,7 +214,6 @@ func newServer(s *state.State, lis net.Listener, cfg ServerConfig) (_ *Server, e
 		logDir:                        cfg.LogDir,
 		limiter:                       utils.NewLimiter(loginRateLimit),
 		validator:                     cfg.Validator,
-		adminAPIFactories:             map[int]adminAPIFactory{3: newAdminAPIV3},
 		facades:                       AllFacades(),
 		centralHub:                    cfg.Hub,
 		certChanged:                   cfg.CertChanged,
@@ -715,7 +713,7 @@ func (srv *Server) serveConn(wsConn *websocket.Conn, modelUUID string, apiObserv
 		conn.ServeRoot(&errRoot{errors.Trace(err)}, serverError)
 	} else {
 		adminAPIs := make(map[int]interface{})
-		for apiVersion, factory := range srv.adminAPIFactories {
+		for apiVersion, factory := range adminAPIFactories {
 			adminAPIs[apiVersion] = factory(srv, h, apiObserver)
 		}
 		conn.ServeRoot(newAnonRoot(h, adminAPIs), serverError)

--- a/apiserver/export_test.go
+++ b/apiserver/export_test.go
@@ -4,7 +4,6 @@
 package apiserver
 
 import (
-	"fmt"
 	"net"
 	"time"
 
@@ -146,19 +145,6 @@ func TestingModelOnlyRoot() rpc.Root {
 func TestingRestrictedRoot(check func(string, string) error) rpc.Root {
 	r := TestingAPIRoot(AllFacades())
 	return restrictRoot(r, check)
-}
-
-func SetAdminAPIVersions(srv *Server, versions ...int) {
-	factories := make(map[int]adminAPIFactory)
-	for _, n := range versions {
-		switch n {
-		case 3:
-			factories[n] = newAdminAPIV3
-		default:
-			panic(fmt.Errorf("unknown admin API version %d", n))
-		}
-	}
-	srv.adminAPIFactories = factories
 }
 
 // TestingAboutToRestoreRoot returns a limited root which allows

--- a/apiserver/facade/registry.go
+++ b/apiserver/facade/registry.go
@@ -140,6 +140,44 @@ func (f *Registry) List() []Description {
 	return descriptions
 }
 
+// Details holds information about a facade.
+type Details struct {
+	// Name is the name of the facade.
+	Name string
+	// Version holds the version of the facade.
+	Version int
+	// Factory holds the factory function for making
+	// instances of the facade.
+	Factory Factory
+	// Type holds the type of object that the Factory
+	// will return. This can be used to find out
+	// details of the facade without actually creating
+	// a facade instance (see rpcreflect.ObjTypeOf).
+	Type reflect.Type
+}
+
+// ListDetails returns information about all the facades
+// registered in f, ordered lexically by name.
+func (f *Registry) ListDetails() []Details {
+	names := make([]string, 0, len(f.facades))
+	for name := range f.facades {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	var details []Details
+	for _, name := range names {
+		for v, info := range f.facades[name] {
+			details = append(details, Details{
+				Name:    name,
+				Version: v,
+				Factory: info.factory,
+				Type:    info.facadeType,
+			})
+		}
+	}
+	return details
+}
+
 // Discard gets rid of a registration that has already been done. Calling
 // discard on an entry that is not present is not considered an error.
 func (f *Registry) Discard(name string, version int) {

--- a/apiserver/restrict_controller.go
+++ b/apiserver/restrict_controller.go
@@ -36,14 +36,14 @@ var commonFacadeNames = set.NewStrings(
 )
 
 func controllerFacadesOnly(facadeName, _ string) error {
-	if !isControllerFacade(facadeName) {
+	if !IsControllerFacade(facadeName) {
 		return errors.NewNotSupported(nil, fmt.Sprintf("facade %q not supported for controller API connection", facadeName))
 	}
 	return nil
 }
 
-// isControllerFacade reports whether the given facade name can be accessed
-// using the controller connection.
-func isControllerFacade(facadeName string) bool {
+// IsControllerFacade reports whether the given facade name can be accessed
+// using a controller connection.
+func IsControllerFacade(facadeName string) bool {
 	return controllerFacadeNames.Contains(facadeName) || commonFacadeNames.Contains(facadeName)
 }

--- a/apiserver/restrict_model.go
+++ b/apiserver/restrict_model.go
@@ -10,12 +10,14 @@ import (
 )
 
 func modelFacadesOnly(facadeName, _ string) error {
-	if !isModelFacade(facadeName) {
+	if !IsModelFacade(facadeName) {
 		return errors.NewNotSupported(nil, fmt.Sprintf("facade %q not supported for model API connection", facadeName))
 	}
 	return nil
 }
 
-func isModelFacade(facadeName string) bool {
+// IsModelFacade reports whether the given facade name can be accessed
+// using a model connection.
+func IsModelFacade(facadeName string) bool {
 	return !controllerFacadeNames.Contains(facadeName)
 }


### PR DESCRIPTION
We add a ListDetails method to obtain information
on the available facades and also add AdminFacadeDetails in apiserver
for the Admin facade, which isn't available from apiserver.AllFacades.

This enables an external program to obtain information about
the juju API, for example to generate documentation
automatically or to do static compatibility checks.

Also export IsControllerFacade and IsModelFacade so that it's
possible to tell which facades are available in which mode.
In the future, it would be nice to be able to find which facades
are available to users as opposed to agents, but that's for
another PR.

Also remove some unused cruft from the tests (we only have
one admin facade version at the moment).

QA:

    go get github.com/rogpeppe/misc/cmd/jujuapidoc github.com/rogpeppe/misc/cmd/jujuapidochtml
    jujuapidoc > /tmp/apidoc.json
    jujuapidochtml /tmp/apidoc.json > /tmp/apidoc.html
    open /tmp/apidoc.html
    # observe the beauty of the Juju API.


    