### PR TITLE
Rename oracle-compute provider to oracle

### DIFF
--- a/cloud/clouds.go
+++ b/cloud/clouds.go
@@ -305,19 +305,19 @@ func DefaultCloudDescription(cloudType string) string {
 }
 
 var defaultCloudDescription = map[string]string{
-	"aws":            "Amazon Web Services",
-	"aws-china":      "Amazon China",
-	"aws-gov":        "Amazon (USA Government)",
-	"google":         "Google Cloud Platform",
-	"azure":          "Microsoft Azure",
-	"azure-china":    "Microsoft Azure China",
-	"rackspace":      "Rackspace Cloud",
-	"joyent":         "Joyent Cloud",
-	"cloudsigma":     "CloudSigma Cloud",
-	"lxd":            "LXD Container Hypervisor",
-	"maas":           "Metal As A Service",
-	"openstack":      "Openstack Cloud",
-	"oracle-compute": "Oracle Compute Cloud Service",
+	"aws":         "Amazon Web Services",
+	"aws-china":   "Amazon China",
+	"aws-gov":     "Amazon (USA Government)",
+	"google":      "Google Cloud Platform",
+	"azure":       "Microsoft Azure",
+	"azure-china": "Microsoft Azure China",
+	"rackspace":   "Rackspace Cloud",
+	"joyent":      "Joyent Cloud",
+	"cloudsigma":  "CloudSigma Cloud",
+	"lxd":         "LXD Container Hypervisor",
+	"maas":        "Metal As A Service",
+	"openstack":   "Openstack Cloud",
+	"oracle":      "Oracle Compute Cloud Service",
 }
 
 // WritePublicCloudMetadata marshals to YAML and writes the cloud metadata

--- a/cloud/clouds_test.go
+++ b/cloud/clouds_test.go
@@ -21,7 +21,7 @@ type cloudSuite struct {
 var _ = gc.Suite(&cloudSuite{})
 
 var publicCloudNames = []string{
-	"aws", "aws-china", "aws-gov", "google", "azure", "azure-china", "rackspace", "joyent", "cloudsigma", "oracle-compute",
+	"aws", "aws-china", "aws-gov", "google", "azure", "azure-china", "rackspace", "joyent", "cloudsigma", "oracle",
 }
 
 func parsePublicClouds(c *gc.C) map[string]cloud.Cloud {

--- a/cloud/fallback-public-cloud.yaml
+++ b/cloud/fallback-public-cloud.yaml
@@ -230,8 +230,8 @@ clouds:
         endpoint: https://wdc.cloudsigma.com/api/2.0/
       zrh:
         endpoint: https://zrh.cloudsigma.com/api/2.0/
-  oracle-compute:
-    type: oracle-compute
+  oracle:
+    type: oracle
     description: Oracle Cloud
     auth-types: [ userpass ]
     regions:

--- a/cloud/fallback_public_cloud.go
+++ b/cloud/fallback_public_cloud.go
@@ -237,8 +237,8 @@ clouds:
         endpoint: https://wdc.cloudsigma.com/api/2.0/
       zrh:
         endpoint: https://zrh.cloudsigma.com/api/2.0/
-  oracle-compute:
-    type: oracle-compute
+  oracle:
+    type: oracle
     description: Oracle Cloud
     auth-types: [ userpass ]
     regions:

--- a/cmd/juju/cloud/add_test.go
+++ b/cmd/juju/cloud/add_test.go
@@ -249,7 +249,7 @@ func (*addSuite) TestInteractive(c *gc.C) {
 		"  maas\n"+
 		"  manual\n"+
 		"  openstack\n"+
-		"  oracle-compute\n"+
+		"  oracle\n"+
 		"  vsphere\n"+
 		"\n"+
 		"Select cloud type: \n",

--- a/cmd/juju/cloud/list_test.go
+++ b/cmd/juju/cloud/list_test.go
@@ -57,7 +57,7 @@ clouds:
 	// Just check a snippet of the output to make sure it looks ok.
 	// local clouds are last.
 	// homestack should abut localhost and hence come last in the output.
-	c.Assert(out, jc.Contains, `Hypervisorhomestack             1  london           openstack       Openstack Cloud`)
+	c.Assert(out, jc.Contains, `Hypervisorhomestack          1  london           openstack   Openstack Cloud`)
 }
 
 func (s *listSuite) TestListPublicAndPersonalSameName(c *gc.C) {

--- a/cmd/juju/commands/bootstrap_test.go
+++ b/cmd/juju/commands/bootstrap_test.go
@@ -1663,7 +1663,7 @@ azure-china
 cloudsigma                                   
 google                                       
 joyent                                       
-oracle-compute                               
+oracle                                       
 rackspace                                    
 localhost                                    
 dummy-cloud                     joe          home

--- a/provider/oracle/provider.go
+++ b/provider/oracle/provider.go
@@ -16,10 +16,10 @@ import (
 	"github.com/juju/juju/environs/config"
 )
 
-var logger = loggo.GetLogger("juju.provider.oracle-compute")
+var logger = loggo.GetLogger("juju.provider.oracle")
 
 const (
-	providerType = "oracle-compute"
+	providerType = "oracle"
 )
 
 // EnvironProvider type implements environs.EnvironProvider interface

--- a/provider/oracle/provider_test.go
+++ b/provider/oracle/provider_test.go
@@ -19,7 +19,7 @@ type environProviderSuite struct{}
 var _ = gc.Suite(&environProviderSuite{})
 
 func (e *environProviderSuite) NewProvider(c *gc.C) environs.EnvironProvider {
-	provider, err := environs.Provider("oracle-compute")
+	provider, err := environs.Provider("oracle")
 	c.Assert(err, gc.IsNil)
 	c.Assert(provider, gc.NotNil)
 	return provider
@@ -59,8 +59,8 @@ func (e *environProviderSuite) TestPrepareConfig(c *gc.C) {
 	)
 	_, err := provider.PrepareConfig(environs.PrepareConfigParams{
 		Cloud: environs.CloudSpec{
-			Type:       "oracle-compute",
-			Name:       "oracle-compute",
+			Type:       "oracle",
+			Name:       "oracle",
 			Credential: &credentials,
 		},
 		Config: testing.ModelConfig(c),
@@ -80,8 +80,8 @@ func (e *environProviderSuite) TestOpen(c *gc.C) {
 	)
 	_, err := provider.Open(environs.OpenParams{
 		Cloud: environs.CloudSpec{
-			Type:       "oracle-compute",
-			Name:       "oracle-compute",
+			Type:       "oracle",
+			Name:       "oracle",
 			Credential: &credentials,
 			Endpoint:   "https://127.0.0.1/",
 		},


### PR DESCRIPTION
## Description of change

We rename the "oracle-compute" provider to "oracle"

## QA steps

bootstrap oracle

## Documentation changes

The doc will need to change to reflect the new name.
