### PR TITLE
environs: Update the cross-model methods in NetworkingEnviron

### DIFF
--- a/provider/dummy/environs.go
+++ b/provider/dummy/environs.go
@@ -1669,11 +1669,11 @@ func (e *environ) ReleaseContainerAddresses(interfaces []network.ProviderInterfa
 }
 
 // ProviderSpaceInfo implements NetworkingEnviron.
-func (*environ) ProviderSpaceInfo(string) (*environs.ProviderSpaceInfo, error) {
+func (*environ) ProviderSpaceInfo(space *network.SpaceInfo) (*environs.ProviderSpaceInfo, error) {
 	return nil, errors.NotSupportedf("provider space info")
 }
 
-// IsSpaceRoutable implements NetworkingEnviron.
-func (*environ) IsSpaceRoutable(targetSpace *environs.ProviderSpaceInfo) (bool, error) {
+// AreSpacesRoutable implements NetworkingEnviron.
+func (*environ) AreSpacesRoutable(space1, space2 *environs.ProviderSpaceInfo) (bool, error) {
 	return false, nil
 }

--- a/provider/ec2/environ.go
+++ b/provider/ec2/environ.go
@@ -1888,11 +1888,11 @@ func (e *environ) hasDefaultVPC() (bool, error) {
 }
 
 // ProviderSpaceInfo implements NetworkingEnviron.
-func (*environ) ProviderSpaceInfo(string) (*environs.ProviderSpaceInfo, error) {
+func (*environ) ProviderSpaceInfo(space *network.SpaceInfo) (*environs.ProviderSpaceInfo, error) {
 	return nil, errors.NotSupportedf("provider space info")
 }
 
-// IsSpaceRoutable implements NetworkingEnviron.
-func (*environ) IsSpaceRoutable(targetSpace *environs.ProviderSpaceInfo) (bool, error) {
+// AreSpacesRoutable implements NetworkingEnviron.
+func (*environ) AreSpacesRoutable(space1, space2 *environs.ProviderSpaceInfo) (bool, error) {
 	return false, nil
 }

--- a/provider/gce/environ_network.go
+++ b/provider/gce/environ_network.go
@@ -271,12 +271,12 @@ func (e *environ) ReleaseContainerAddresses([]network.ProviderInterfaceInfo) err
 }
 
 // ProviderSpaceInfo implements environs.NetworkingEnviron.
-func (*environ) ProviderSpaceInfo(string) (*environs.ProviderSpaceInfo, error) {
+func (*environ) ProviderSpaceInfo(space *network.SpaceInfo) (*environs.ProviderSpaceInfo, error) {
 	return nil, errors.NotSupportedf("provider space info")
 }
 
-// IsSpaceRoutable implements environs.NetworkingEnviron.
-func (*environ) IsSpaceRoutable(targetSpace *environs.ProviderSpaceInfo) (bool, error) {
+// AreSpacesRoutable implements environs.NetworkingEnviron.
+func (*environ) AreSpacesRoutable(space1, space2 *environs.ProviderSpaceInfo) (bool, error) {
 	return false, nil
 }
 

--- a/provider/maas/environ.go
+++ b/provider/maas/environ.go
@@ -2338,11 +2338,11 @@ func (env *maasEnviron) AdoptResources(controllerUUID string, fromVersion versio
 }
 
 // ProviderSpaceInfo implements environs.NetworkingEnviron.
-func (*maasEnviron) ProviderSpaceInfo(string) (*environs.ProviderSpaceInfo, error) {
+func (*maasEnviron) ProviderSpaceInfo(space *network.SpaceInfo) (*environs.ProviderSpaceInfo, error) {
 	return nil, errors.NotSupportedf("provider space info")
 }
 
-// IsSpaceRoutable implements environs.NetworkingEnviron.
-func (*maasEnviron) IsSpaceRoutable(targetSpace *environs.ProviderSpaceInfo) (bool, error) {
+// AreSpacesRoutable implements environs.NetworkingEnviron.
+func (*maasEnviron) AreSpacesRoutable(space1, space2 *environs.ProviderSpaceInfo) (bool, error) {
 	return false, nil
 }

--- a/provider/openstack/provider.go
+++ b/provider/openstack/provider.go
@@ -1723,11 +1723,11 @@ func (e *Environ) ReleaseContainerAddresses(interfaces []network.ProviderInterfa
 }
 
 // ProviderSpaceInfo is specified on environs.NetworkingEnviron.
-func (*Environ) ProviderSpaceInfo(string) (*environs.ProviderSpaceInfo, error) {
+func (*Environ) ProviderSpaceInfo(space *network.SpaceInfo) (*environs.ProviderSpaceInfo, error) {
 	return nil, errors.NotSupportedf("provider space info")
 }
 
-// IsSpaceRoutable is specified on environs.NetworkingEnviron.
-func (*Environ) IsSpaceRoutable(targetSpace *environs.ProviderSpaceInfo) (bool, error) {
+// AreSpacesRoutable is specified on environs.NetworkingEnviron.
+func (*Environ) AreSpacesRoutable(space1, space2 *environs.ProviderSpaceInfo) (bool, error) {
 	return false, nil
 }

--- a/provider/oracle/network/environ.go
+++ b/provider/oracle/network/environ.go
@@ -352,11 +352,11 @@ func (e Environ) Spaces() ([]network.SpaceInfo, error) {
 }
 
 // ProviderSpaceInfo is defined on the environs.NetworkingEnviron interface.
-func (Environ) ProviderSpaceInfo(providerSpaceId string) (*environs.ProviderSpaceInfo, error) {
+func (Environ) ProviderSpaceInfo(space *network.SpaceInfo) (*environs.ProviderSpaceInfo, error) {
 	return nil, errors.NotSupportedf("provider space info")
 }
 
-// IsSpaceRoutable is defined on the environs.NetworkingEnviron interface.
-func (Environ) IsSpaceRoutable(targetSpace *environs.ProviderSpaceInfo) (bool, error) {
+// AreSpacesRoutable is defined on the environs.NetworkingEnviron interface.
+func (Environ) AreSpacesRoutable(space1, space2 *environs.ProviderSpaceInfo) (bool, error) {
 	return false, nil
 }


### PR DESCRIPTION
## Description of change

After discussing the interface with jam it became clear that the
original definitions of the methods weren't right.

With the exception of MAAS which fully supports spaces, providers don't
have any way to determine which subnets should be in a space. State is
the authority in that case, so just passing `ProviderId` into
`ProviderSpaceInfo` doesn't work. (We could change the providers to tag
subnets with space information, but that's not straightforward - at the
provider level the subnets are shared between controllers, so multiple
controllers trying to manage the tags on one subnet could clobber each
other's changes unless care was taken.)

Change `Networking.ProviderSpaceInfo` to take a `network.SpaceInfo` 
with state's view of the subnets instead - if the provider knows better it 
can discard that, but otherwise the space info can be included in the result.

Also change `IsSpaceRoutable` to `AreSpacesRoutable`, which takes two
spaces. The arguments to this will be the `ProviderSpaceInfo`s for the two
endpoints of the cross-model relation.

## QA steps

No behaviour changes in this PR - it just tweaks interface methods with stub 
implementations in the providers that support networking.