### PR TITLE
api, apiserver: implement CACert on MigrationTarget

### DIFF
--- a/api/migrationtarget/client.go
+++ b/api/migrationtarget/client.go
@@ -19,6 +19,7 @@ import (
 	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/api/base"
+	"github.com/juju/juju/api/common"
 	"github.com/juju/juju/apiserver/params"
 	coremigration "github.com/juju/juju/core/migration"
 	"github.com/juju/juju/resource"
@@ -219,4 +220,10 @@ func (c *Client) AdoptResources(modelUUID string) error {
 		SourceControllerVersion: jujuversion.Current,
 	}
 	return errors.Trace(c.caller.FacadeCall("AdoptResources", args, nil))
+}
+
+// CACert returns the CA certificate associated with
+// the connection.
+func (c *Client) CACert() (string, error) {
+	return common.NewAPIAddresser(c.caller).CACert()
 }

--- a/api/migrationtarget/client_test.go
+++ b/api/migrationtarget/client_test.go
@@ -254,6 +254,21 @@ func (s *ClientSuite) TestPlaceholderResource(c *gc.C) {
 	c.Assert(doer.body, gc.Equals, "")
 }
 
+func (s *ClientSuite) TestCACert(c *gc.C) {
+	call := func(objType string, version int, id, request string, args, response interface{}) error {
+		c.Check(objType, gc.Equals, "MigrationTarget")
+		c.Check(request, gc.Equals, "CACert")
+		c.Check(args, gc.Equals, nil)
+		c.Check(response, gc.FitsTypeOf, (*params.BytesResult)(nil))
+		response.(*params.BytesResult).Result = []byte("foo cert")
+		return nil
+	}
+	client := migrationtarget.NewClient(apitesting.APICallerFunc(call))
+	r, err := client.CACert()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(r, gc.Equals, "foo cert")
+}
+
 func (s *ClientSuite) AssertModelCall(c *gc.C, stub *jujutesting.Stub, tag names.ModelTag, call string, err error, expectError bool) {
 	expectedArg := params.ModelArgs{ModelTag: tag.String()}
 	stub.CheckCalls(c, []jujutesting.StubCall{

--- a/apiserver/migrationtarget/migrationtarget.go
+++ b/apiserver/migrationtarget/migrationtarget.go
@@ -24,11 +24,18 @@ import (
 // API implements the API required for the model migration
 // master worker when communicating with the target controller.
 type API struct {
+	addresser
 	state      *state.State
 	authorizer facade.Authorizer
 	resources  facade.Resources
 	pool       *state.StatePool
 	getEnviron stateenvirons.NewEnvironFunc
+}
+
+// addresser implements the subset of common.APIAddresser
+// methods that we choose to expose in the MigrationTarget facade.
+type addresser interface {
+	CACert() params.BytesResult
 }
 
 // NewAPI returns a new API. Accepts a NewEnvironFunc for testing
@@ -39,12 +46,14 @@ func NewAPI(ctx facade.Context, getEnviron stateenvirons.NewEnvironFunc) (*API, 
 	if err := checkAuth(auth, st); err != nil {
 		return nil, errors.Trace(err)
 	}
+	addresser := common.NewAPIAddresser(st, ctx.Resources())
 	return &API{
 		state:      st,
 		authorizer: auth,
 		resources:  ctx.Resources(),
 		pool:       ctx.StatePool(),
 		getEnviron: getEnviron,
+		addresser:  addresser,
 	}, nil
 }
 

--- a/apiserver/migrationtarget/migrationtarget_test.go
+++ b/apiserver/migrationtarget/migrationtarget_test.go
@@ -100,6 +100,12 @@ func (s *Suite) TestPrechecks(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 }
 
+func (s *Suite) TestCACert(c *gc.C) {
+	api := s.mustNewAPI(c)
+	r := api.CACert()
+	c.Assert(string(r.Result), gc.Equals, jujutesting.CACert)
+}
+
 func (s *Suite) TestPrechecksFail(c *gc.C) {
 	controllerVersion := s.controllerVersion(c)
 


### PR DESCRIPTION
A previous PR (https://github.com/juju/juju/pull/7327)
added the CA cert entry point to Client, but the Client
facade isn't available in the controller API connection
that the migration process makes, so make the
call available in the MigrationTarget API too.
