### PR TITLE
api: fall back to using public cert on cert error

### DIFF
--- a/api/export_test.go
+++ b/api/export_test.go
@@ -4,7 +4,6 @@
 package api
 
 import (
-	"github.com/gorilla/websocket"
 	"github.com/juju/errors"
 	"github.com/juju/utils/clock"
 	"gopkg.in/juju/names.v2"
@@ -13,18 +12,18 @@ import (
 
 	"github.com/juju/juju/api/base"
 	"github.com/juju/juju/network"
+	"github.com/juju/juju/rpc/jsoncodec"
 )
 
 var (
 	CertDir             = &certDir
-	NewWebsocketDialer  = newWebsocketDialer
 	WebsocketDial       = &websocketDial
 	SlideAddressToFront = slideAddressToFront
 	BestVersion         = bestVersion
 	FacadeVersions      = &facadeVersions
 )
 
-func DialAPI(info *Info, opts DialOpts) (*websocket.Conn, string, error) {
+func DialAPI(info *Info, opts DialOpts) (jsoncodec.JSONConn, string, error) {
 	result, err := dialAPI(info, opts)
 	if err != nil {
 		return nil, "", err
@@ -45,6 +44,11 @@ func SetServerAddress(c *Client, scheme, addr string) {
 // ServerRoot is exported so that we can test the built URL.
 func ServerRoot(c *Client) string {
 	return c.st.serverRoot()
+}
+
+// UnderlyingConn returns the underlying transport connection.
+func UnderlyingConn(c Connection) jsoncodec.JSONConn {
+	return c.(*state).conn
 }
 
 // TestingStateParams is the parameters for NewTestingState, so that you can

--- a/api/interface.go
+++ b/api/interface.go
@@ -4,13 +4,13 @@
 package api
 
 import (
+	"context"
 	"crypto/tls"
-	"net/http"
 	"net/url"
 	"time"
 
-	"github.com/gorilla/websocket"
 	"github.com/juju/errors"
+	"github.com/juju/utils/clock"
 	"github.com/juju/utils/set"
 	"github.com/juju/version"
 	"gopkg.in/juju/names.v2"
@@ -28,6 +28,7 @@ import (
 	"github.com/juju/juju/api/uniter"
 	"github.com/juju/juju/api/upgrader"
 	"github.com/juju/juju/network"
+	"github.com/juju/juju/rpc/jsoncodec"
 )
 
 // Info encapsulates information about a server holding juju state and
@@ -148,13 +149,13 @@ type DialOpts struct {
 	// It will be called with a websocket URL to connect to,
 	// and the TLS configuration to use to secure the connection.
 	//
-	// If DialWebsocket is nil, webaocket.DialConfig will be used.
-	//
-	// This field is provided for testing purposes only.
-	DialWebsocket func(urlStr string, tlsConfig *tls.Config, requestHeader http.Header) (*websocket.Conn, *http.Response, error)
+	// If DialWebsocket is nil, a default implementation using
+	// gorilla websockets will be used.
+	DialWebsocket func(ctx context.Context, urlStr string, tlsConfig *tls.Config) (jsoncodec.JSONConn, error)
 
-	// Internal use only.
-	tlsConfig *tls.Config
+	// Clock is used as a time source for retries.
+	// If it is nil, clock.WallClock will be used.
+	Clock clock.Clock
 }
 
 // DefaultDialOpts returns a DialOpts representing the default

--- a/apiserver/pinger_test.go
+++ b/apiserver/pinger_test.go
@@ -156,7 +156,7 @@ func checkConnectionDies(c *gc.C, conn api.Connection) {
 	for a := attempt.Start(); a.Next(); {
 		err := pingConn(conn)
 		if err != nil {
-			c.Assert(err, gc.ErrorMatches, "connection is shut down")
+			c.Assert(err, gc.ErrorMatches, "connection is shut down", gc.Commentf("details: %s", errors.Details(err)))
 			return
 		}
 	}

--- a/rpc/jsoncodec/conn.go
+++ b/rpc/jsoncodec/conn.go
@@ -16,7 +16,7 @@ import (
 // NewWebsocket returns an rpc codec that uses the given websocket
 // connection to send and receive messages.
 func NewWebsocket(conn *websocket.Conn) *Codec {
-	return New(&wsJSONConn{conn: conn})
+	return New(NewWebsocketConn(conn))
 }
 
 type wsJSONConn struct {
@@ -25,6 +25,12 @@ type wsJSONConn struct {
 	// one concurrent reader.
 	writeMutex sync.Mutex
 	readMutex  sync.Mutex
+}
+
+// NewWebsocketConn returns a JSONConn implementation
+// that uses the given connection for transport.
+func NewWebsocketConn(conn *websocket.Conn) JSONConn {
+	return &wsJSONConn{conn: conn}
 }
 
 func (conn *wsJSONConn) Send(msg interface{}) error {


### PR DESCRIPTION
If we get a certificate error trying to connect to a controller,
then it's possible that we're using the private CA but
the address we're connecting to is a proxy that doesn't
have a private CA certificate. In this case, try
again with the public CA.

To test this properly, some refactoring was required. A brief overview:

- separate concerns between internal and external dial parameters by creating
an internal dialOpts type rather than having unexported fields in the otherwise-public
DialOpts type.
- add a Clock to DialOpts so that we can fake the clock logic used by Open.
- make DialWebsocket return an interface so that we can easily return a fake connection in tests.
- add jsoncodec.NewWebsocketConn to make that possible.

QA do a model migration to a controller with a frontend proxy.