### PR TITLE
Add juju-metadata and juju-upgrade-mongo to snapcraft snap build

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -35,7 +35,6 @@ parts:
       #If you are releasing a build with public streams, you don't need to build the agent
       - github.com/juju/juju/cmd/jujud
       - github.com/juju/juju/cmd/plugins/juju-metadata
-      - github.com/juju/juju/cmd/plugins/juju-upgrade-mongo
     install: |
       mkdir -p $SNAPCRAFT_PART_INSTALL/bash_completions
       cp -a etc/bash_completion.d/juju* $SNAPCRAFT_PART_INSTALL/bash_completions/.

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -34,6 +34,8 @@ parts:
       - github.com/juju/juju/cmd/juju
       #If you are releasing a build with public streams, you don't need to build the agent
       - github.com/juju/juju/cmd/jujud
+      - github.com/juju/juju/cmd/plugins/juju-metadata
+      - github.com/juju/juju/cmd/plugins/juju-upgrade-mongo
     install: |
       mkdir -p $SNAPCRAFT_PART_INSTALL/bash_completions
       cp -a etc/bash_completion.d/juju* $SNAPCRAFT_PART_INSTALL/bash_completions/.


### PR DESCRIPTION
This adds the plugin binaries to the snap to ensure feature parity.