### PR TITLE
cmr: Capture remote space info when creating a remote application

### DIFF
--- a/apiserver/application/application_unit_test.go
+++ b/apiserver/application/application_unit_test.go
@@ -95,6 +95,7 @@ func (s *ApplicationSuite) SetUpTest(c *gc.C) {
 		func(application.Backend, juju.DeployApplicationParams) error {
 			return nil
 		},
+		nil,
 	)
 	c.Assert(err, jc.ErrorIsNil)
 	s.api = api

--- a/apiserver/application/conversions.go
+++ b/apiserver/application/conversions.go
@@ -1,0 +1,85 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package application
+
+import (
+	"github.com/juju/errors"
+
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/environs"
+	"github.com/juju/juju/network"
+	"github.com/juju/juju/state"
+)
+
+// paramsFromProviderSpaceInfo converts a ProviderSpaceInfo into the
+// equivalent params.RemoteSpace.
+func paramsFromProviderSpaceInfo(info *environs.ProviderSpaceInfo) params.RemoteSpace {
+	result := params.RemoteSpace{
+		CloudType:          info.CloudType,
+		Name:               info.Name,
+		ProviderId:         string(info.ProviderId),
+		ProviderAttributes: info.ProviderAttributes,
+	}
+	for _, subnet := range info.Subnets {
+		resultSubnet := params.Subnet{
+			CIDR:              subnet.CIDR,
+			ProviderId:        string(subnet.ProviderId),
+			ProviderNetworkId: string(subnet.ProviderNetworkId),
+			ProviderSpaceId:   string(subnet.SpaceProviderId),
+			VLANTag:           subnet.VLANTag,
+			Zones:             subnet.AvailabilityZones,
+		}
+		result.Subnets = append(result.Subnets, resultSubnet)
+	}
+	return result
+}
+
+// providerSpaceInfoFromParams converts a params.RemoteSpace to the
+// equivalent ProviderSpaceInfo.
+func providerSpaceInfoFromParams(space params.RemoteSpace) *environs.ProviderSpaceInfo {
+	result := &environs.ProviderSpaceInfo{
+		CloudType:          space.CloudType,
+		ProviderAttributes: space.ProviderAttributes,
+		SpaceInfo: network.SpaceInfo{
+			Name:       space.Name,
+			ProviderId: network.Id(space.ProviderId),
+		},
+	}
+	for _, subnet := range space.Subnets {
+		resultSubnet := network.SubnetInfo{
+			CIDR:              subnet.CIDR,
+			ProviderId:        network.Id(subnet.ProviderId),
+			ProviderNetworkId: network.Id(subnet.ProviderNetworkId),
+			SpaceProviderId:   network.Id(subnet.ProviderSpaceId),
+			VLANTag:           subnet.VLANTag,
+			AvailabilityZones: subnet.Zones,
+		}
+		result.Subnets = append(result.Subnets, resultSubnet)
+	}
+	return result
+}
+
+// spaceInfoFromState converts a state.Space into the equivalent
+// network.SpaceInfo.
+func spaceInfoFromState(space *state.Space) (*network.SpaceInfo, error) {
+	result := &network.SpaceInfo{
+		Name:       space.Name(),
+		ProviderId: space.ProviderId(),
+	}
+	subnets, err := space.Subnets()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	for _, subnet := range subnets {
+		resultSubnet := network.SubnetInfo{
+			CIDR:              subnet.CIDR(),
+			ProviderId:        subnet.ProviderId(),
+			ProviderNetworkId: subnet.ProviderNetworkId(),
+			VLANTag:           subnet.VLANTag(),
+			AvailabilityZones: []string{subnet.AvailabilityZone()},
+		}
+		result.Subnets = append(result.Subnets, resultSubnet)
+	}
+	return result, nil
+}

--- a/apiserver/application/get_test.go
+++ b/apiserver/application/get_test.go
@@ -43,6 +43,7 @@ func (s *getSuite) SetUpTest(c *gc.C) {
 		backend, s.authorizer, resources, s.BackingStatePool,
 		blockChecker, application.CharmToStateCharm,
 		application.DeployApplication,
+		nil,
 	)
 	c.Assert(err, jc.ErrorIsNil)
 }

--- a/apiserver/application/mock_test.go
+++ b/apiserver/application/mock_test.go
@@ -1,0 +1,27 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package application_test
+
+import (
+	"github.com/juju/testing"
+
+	"github.com/juju/juju/environs"
+	"github.com/juju/juju/network"
+)
+
+type mockEnviron struct {
+	environs.NetworkingEnviron
+
+	stub      testing.Stub
+	spaceInfo *environs.ProviderSpaceInfo
+}
+
+func (e *mockEnviron) ProviderSpaceInfo(space *network.SpaceInfo) (*environs.ProviderSpaceInfo, error) {
+	e.stub.MethodCall(e, "ProviderSpaceInfo", space)
+	return e.spaceInfo, e.stub.NextErr()
+}
+
+type mockNoNetworkEnviron struct {
+	environs.Environ
+}

--- a/apiserver/params/crossmodel.go
+++ b/apiserver/params/crossmodel.go
@@ -39,12 +39,14 @@ type OfferFilter struct {
 
 // ApplicationOffer represents an application offering from an external model.
 type ApplicationOffer struct {
-	SourceModelTag         string           `json:"source-model-tag"`
-	OfferURL               string           `json:"offer-url"`
-	OfferName              string           `json:"offer-name"`
-	ApplicationDescription string           `json:"application-description"`
-	Endpoints              []RemoteEndpoint `json:"endpoints"`
-	Access                 string           `json:"access"`
+	SourceModelTag         string            `json:"source-model-tag"`
+	OfferURL               string            `json:"offer-url"`
+	OfferName              string            `json:"offer-name"`
+	ApplicationDescription string            `json:"application-description"`
+	Endpoints              []RemoteEndpoint  `json:"endpoints"`
+	Spaces                 []RemoteSpace     `json:"spaces"`
+	Bindings               map[string]string `json:"bindings"`
+	Access                 string            `json:"access"`
 }
 
 // ApplicationOfferDetails represents an application offering,
@@ -83,6 +85,15 @@ type RemoteEndpoint struct {
 	Interface string              `json:"interface"`
 	Limit     int                 `json:"limit"`
 	Scope     charm.RelationScope `json:"scope"`
+}
+
+// RemoteSpace represents a space in some remote model.
+type RemoteSpace struct {
+	CloudType          string                 `json:"cloud-type"`
+	Name               string                 `json:"name"`
+	ProviderId         string                 `json:"provider-id"`
+	ProviderAttributes map[string]interface{} `json:"provider-attributes"`
+	Subnets            []Subnet               `json:"subnets"`
 }
 
 // FindApplicationOffersResults is a result of finding remote application offers.
@@ -310,6 +321,10 @@ type RegisterRemoteRelation struct {
 
 	// RemoteEndpoint contains info about the endpoint in the remote model.
 	RemoteEndpoint RemoteEndpoint `json:"remote-endpoint"`
+
+	// RemoteSpace contains provider-level info about the space the
+	// endpoint is bound to in the remote model.
+	RemoteSpace RemoteSpace `json:"remote-space"`
 
 	// OfferName is the name of the application offer from the local model.
 	OfferName string `json:"offer-name"`

--- a/apiserver/params/network.go
+++ b/apiserver/params/network.go
@@ -24,6 +24,12 @@ type Subnet struct {
 	// provider doesn't support distinct networks.
 	ProviderNetworkId string `json:"provider-network-id,omitempty"`
 
+	// ProviderSpaceId is the id of the space containing this subnet
+	// from the provider's perspective. It can be empty if the
+	// provider doesn't support spaces (in which case all subnets are
+	// effectively in the default space).
+	ProviderSpaceId string `json:"provider-space-id,omitempty"`
+
 	// VLANTag needs to be between 1 and 4094 for VLANs and 0 for
 	// normal networks. It's defined by IEEE 802.1Q standard.
 	VLANTag int `json:"vlan-tag"`

--- a/environs/networking.go
+++ b/environs/networking.go
@@ -20,6 +20,10 @@ var SupportsNetworking = supportsNetworking
 // to get information about the default space.
 var DefaultSpaceInfo *network.SpaceInfo
 
+// DefaultSpaceName is the name of the default space (to which
+// application endpoints are bound if no explicit binding is given).
+const DefaultSpaceName = ""
+
 // Networking interface defines methods that environments
 // with networking capabilities must implement.
 type Networking interface {

--- a/state/endpoint_bindings.go
+++ b/state/endpoint_bindings.go
@@ -11,7 +11,14 @@ import (
 	"gopkg.in/mgo.v2"
 	"gopkg.in/mgo.v2/bson"
 	"gopkg.in/mgo.v2/txn"
+
+	"github.com/juju/juju/environs"
 )
+
+// defaultEndpointName is the key in the bindings map that stores the
+// space name that endpoints should be bound to if they aren't found
+// individually.
+const defaultEndpointName = ""
 
 // endpointBindingsDoc represents how a service endpoints are bound to spaces.
 // The DocID field contains the service's global key, so there is always one
@@ -73,8 +80,8 @@ func (b bindingsMap) GetBSON() (interface{}, error) {
 // Returns true/false if there are any actual differences.
 func mergeBindings(newMap, oldMap map[string]string, meta *charm.Meta) (map[string]string, bool, error) {
 	defaultsMap := DefaultEndpointBindingsForCharm(meta)
-	defaultBinding := oldMap[""]
-	if newDefaultBinding, ok := newMap[""]; ok {
+	defaultBinding := oldMap[defaultEndpointName]
+	if newDefaultBinding, ok := newMap[defaultEndpointName]; ok {
 		// new default binding supersedes the old default binding
 		defaultBinding = newDefaultBinding
 	}
@@ -102,8 +109,8 @@ func mergeBindings(newMap, oldMap map[string]string, meta *charm.Meta) (map[stri
 
 		updated[key] = effectiveValue
 	}
-	if defaultBinding != "" {
-		updated[""] = defaultBinding
+	if defaultBinding != environs.DefaultSpaceName {
+		updated[defaultEndpointName] = defaultBinding
 	}
 
 	// Any other bindings in newMap are most likely extraneous, but add them
@@ -264,10 +271,10 @@ func validateEndpointBindingsForCharm(st *State, bindings map[string]string, cha
 	// in bindings. In follow-up, this will be enforced by using refcounts on
 	// spaces.
 	for endpoint, space := range bindings {
-		if endpoint != "" && !endpointsNamesSet.Contains(endpoint) {
+		if endpoint != defaultEndpointName && !endpointsNamesSet.Contains(endpoint) {
 			return errors.NotValidf("unknown endpoint %q", endpoint)
 		}
-		if space != "" && !spacesNamesSet.Contains(space) {
+		if space != environs.DefaultSpaceName && !spacesNamesSet.Contains(space) {
 			return errors.NotValidf("unknown space %q", space)
 		}
 	}
@@ -281,12 +288,10 @@ func DefaultEndpointBindingsForCharm(charmMeta *charm.Meta) map[string]string {
 	allRelations := charmMeta.CombinedRelations()
 	bindings := make(map[string]string, len(allRelations)+len(charmMeta.ExtraBindings))
 	for name := range allRelations {
-		bindings[name] = ""
+		bindings[name] = environs.DefaultSpaceName
 	}
 	for name := range charmMeta.ExtraBindings {
-		bindings[name] = ""
+		bindings[name] = environs.DefaultSpaceName
 	}
-	// All charms have a 'default' binding
-	// bindings[""] = ""
 	return bindings
 }


### PR DESCRIPTION
## Description of change
Change the Application facade to capture information (from the provider) about the spaces for a remote application when a remote relation is created or an offer is consumed. This will be used in other parts of the system to decide whether connections between units in each endpoint can use cloud-local addresses rather than going via the public internet (we're calling this short-circuiting).

This required rejigging the apiserver/application code to pass application offers around, since we now have spaces and bindings on them as well as the other information that was being passed around individually.

## QA steps

Smoke test bootstrapping and making a remote relation.
No behaviour change yet - a future PR will add `ProviderSpaceInfo` support to a provider (probably ec2) and then adding a remote relation will capture space info for the remote application.
