### PR TITLE
Test the optional slice aspects of constraints.

### DIFF
--- a/state/migration_export.go
+++ b/state/migration_export.go
@@ -1333,7 +1333,7 @@ func (e *exporter) constraintsArgs(globalKey string) (description.ConstraintsArg
 		case string:
 			return value
 		default:
-			optionalErr = errors.Errorf("expected uint64 for %s, got %T", name, value)
+			optionalErr = errors.Errorf("expected string for %s, got %T", name, value)
 		}
 		return ""
 	}
@@ -1354,8 +1354,19 @@ func (e *exporter) constraintsArgs(globalKey string) (description.ConstraintsArg
 		case nil:
 		case []string:
 			return value
+		case []interface{}:
+			var result []string
+			for _, val := range value {
+				sval, ok := val.(string)
+				if !ok {
+					optionalErr = errors.Errorf("expected string slice for %s, got %T value", name, val)
+					return nil
+				}
+				result = append(result, sval)
+			}
+			return result
 		default:
-			optionalErr = errors.Errorf("expected []string] for %s, got %T", name, value)
+			optionalErr = errors.Errorf("expected []string for %s, got %T", name, value)
 		}
 		return nil
 	}

--- a/state/migration_export_test.go
+++ b/state/migration_export_test.go
@@ -262,7 +262,7 @@ func (s *MigrationExportSuite) TestMeterStatus(c *gc.C) {
 }
 
 func (s *MigrationExportSuite) TestMachines(c *gc.C) {
-	s.assertMachinesMigrated(c, constraints.MustParse("arch=amd64 mem=8G"))
+	s.assertMachinesMigrated(c, constraints.MustParse("arch=amd64 mem=8G tags=foo,bar spaces=dmz"))
 }
 
 func (s *MigrationExportSuite) TestMachinesWithVirtConstraint(c *gc.C) {


### PR DESCRIPTION
There were missing tests around the tags and spaces aspects of constraints, so of cource it was broken. This branch addes the tests and fixes the code.

## QA steps

go test -check.f MigrationExportSuite.TestMachines

## Documentation changes

No change.

## Bug reference

http://pad.lv/1680392