### PR TITLE
cmd/juju/application: Document placement for multiple units

### DIFF
--- a/cmd/juju/application/addunit.go
+++ b/cmd/juju/application/addunit.go
@@ -24,33 +24,49 @@ var usageAddUnitSummary = `
 Adds one or more units to a deployed application.`[1:]
 
 var usageAddUnitDetails = `
-Adding units to an existing application is a way to scale out that application. 
-Many charms will seamlessly support horizontal scaling, others may need an
-additional application to facilitate load-balancing (check the individual 
-charm documentation).
-This command is applied to applications that have already been deployed.
-By default, applications are deployed to newly provisioned machines in
-accordance with any application or model constraints. Alternatively, this 
-command also supports the placement directive ("--to") for targeting
-specific machines or containers, which will bypass any existing
+The add-unit command adds units to an existing application. It is used
+to scale out an application for improved performance or availability.
+
+Many charms will seamlessly support horizontal scaling while others
+may need an additional application support (e.g. a separate load
+balancer). See the documentation for specfic charms to check how
+scale-out is supported.
+
+By default, units are deployed to newly provisioned machines in
+accordance with any application or model constraints. This command
+also supports the placement directive ("--to") for targeting specific
+machines or containers, which will bypass application and model
 constraints.
 
 Examples:
-Add five units of wordpress on five new machines:
 
+Add five units of wordpress on five new machines:
     juju add-unit wordpress -n 5
 
-Add one unit of mysql to the existing machine 23:
-
+Add a unit of mysql to machine 23 (which already exists):
     juju add-unit mysql --to 23
 
-Create a new LXD container on machine 7 and add one unit of mysql:
+Add two units of mysql to machines 3 and 4:
+   juju add-unit mysql -n 2 --to 3,4
 
+Add three units of mysql to machine 7:
+    juju add-unit mysql -n 3 --to 7,7,7
+
+Add three units of mysql, one to machine 3 and the others to new
+machines:
+    juju add-unit mysql -n 3 --to 7
+
+Add a unit into a new LXD container on machine 7:
     juju add-unit mysql --to lxd:7
 
-Add a unit of mariadb to LXD container number 3 on machine 24:
+Add two units into two new LXD containers on machine 7:
+    juju add-unit mysql -n 2 --to lxd:7,lxd:7
 
+Add a unit of mariadb to LXD container number 3 on machine 24:
     juju add-unit mariadb --to 24/lxd/3
+
+Add a unit of mariadb to LXD container on a new machine:
+    juju add-unit mariadb --to lxd
 
 See also: 
     remove-unit`[1:]

--- a/cmd/juju/application/deploy.go
+++ b/cmd/juju/application/deploy.go
@@ -374,10 +374,20 @@ latter prefixed with "^", similar to the 'tags' constraint).
 
 
 Examples:
-    juju deploy mysql --to 23       (deploy to machine 23)
-    juju deploy mysql --to 24/lxd/3 (deploy to lxd container 3 on machine 24)
-    juju deploy mysql --to lxd:25   (deploy to a new lxd container on machine 25)
-    juju deploy mysql --to lxd      (deploy to a new lxd container on a new machine)
+    juju deploy mysql               (deploy to a new machine)
+    juju deploy mysql --to 23       (deploy to preexisting machine 23)
+    juju deploy mysql --to lxd      (deploy to a new LXD container on a new machine)
+    juju deploy mysql --to lxd:25   (deploy to a new LXD container on machine 25)
+    juju deploy mysql --to 24/lxd/3 (deploy to LXD container 3 on machine 24)
+
+    juju deploy mysql -n 2 --to 3,lxd:5
+    (deploy 2 units, one on machine 3 & one to a new LXD container on machine 5)
+
+    juju deploy mysql -n 3 --to 3
+    (deploy 3 units, one on machine 3 & the remaining two on new machines)
+
+    juju deploy mysql -n 5 --constraints mem=8G
+    (deploy 5 units to machines with at least 8 GB of memory)
 
     juju deploy mysql --to zone=us-east-1a
     (provider-dependent; deploy to a specific AZ)
@@ -385,12 +395,9 @@ Examples:
     juju deploy mysql --to host.maas
     (deploy to a specific MAAS node)
 
-    juju deploy mysql -n 5 --constraints mem=8G
-    (deploy 5 units to machines with at least 8 GB of memory)
-
     juju deploy haproxy -n 2 --constraints spaces=dmz,^cms,^database
-    (deploy 2 units to machines that are part of the 'dmz' space but not of the
-    'cmd' or the 'database' spaces)
+    (deploy 2 units to machines that are in the 'dmz' space but not of
+    the 'cmd' or the 'database' spaces)
 
 See also:
     spaces


### PR DESCRIPTION
## Description of change

It wasn't clear how to specify placement when multiple units were being created with add-unit and deploy. The syntax for `--to` with multiple targets is now documented. 

Some other general clean ups of the help for these commands was also made.

## QA steps

`juju add-unit -h` and `juju deploy -h`

## Documentation changes

N.A.

## Bug reference
https://bugs.launchpad.net/juju/+bug/1687663