### PR TITLE
storage: nix-only paths for block devices

### DIFF
--- a/apiserver/common/storagecommon/storage_test.go
+++ b/apiserver/common/storagecommon/storage_test.go
@@ -4,8 +4,6 @@
 package storagecommon_test
 
 import (
-	"path/filepath"
-
 	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
@@ -84,7 +82,7 @@ func (s *storageAttachmentInfoSuite) TestStorageAttachmentInfoPersistentDeviceNa
 	s.st.CheckCallNames(c, "StorageInstance", "StorageInstanceVolume", "VolumeAttachment", "BlockDevices")
 	c.Assert(info, jc.DeepEquals, &storage.StorageAttachmentInfo{
 		Kind:     storage.StorageKindBlock,
-		Location: filepath.FromSlash("/dev/sda"),
+		Location: "/dev/sda",
 	})
 }
 
@@ -116,7 +114,7 @@ func (s *storageAttachmentInfoSuite) TestStorageAttachmentInfoPersistentHardware
 	s.st.CheckCallNames(c, "StorageInstance", "StorageInstanceVolume", "VolumeAttachment", "BlockDevices")
 	c.Assert(info, jc.DeepEquals, &storage.StorageAttachmentInfo{
 		Kind:     storage.StorageKindBlock,
-		Location: filepath.FromSlash("/dev/disk/by-id/whatever"),
+		Location: "/dev/disk/by-id/whatever",
 	})
 }
 
@@ -127,7 +125,7 @@ func (s *storageAttachmentInfoSuite) TestStorageAttachmentInfoPersistentWWN(c *g
 	s.st.CheckCallNames(c, "StorageInstance", "StorageInstanceVolume", "VolumeAttachment", "BlockDevices")
 	c.Assert(info, jc.DeepEquals, &storage.StorageAttachmentInfo{
 		Kind:     storage.StorageKindBlock,
-		Location: filepath.FromSlash("/dev/disk/by-id/wwn-drbr"),
+		Location: "/dev/disk/by-id/wwn-drbr",
 	})
 }
 
@@ -147,7 +145,7 @@ func (s *storageAttachmentInfoSuite) TestStorageAttachmentInfoMatchingBlockDevic
 	s.st.CheckCallNames(c, "StorageInstance", "StorageInstanceVolume", "VolumeAttachment", "BlockDevices")
 	c.Assert(info, jc.DeepEquals, &storage.StorageAttachmentInfo{
 		Kind:     storage.StorageKindBlock,
-		Location: filepath.FromSlash("/dev/sdb"),
+		Location: "/dev/sdb",
 	})
 }
 

--- a/apiserver/storage/volumelist_test.go
+++ b/apiserver/storage/volumelist_test.go
@@ -4,8 +4,6 @@
 package storage_test
 
 import (
-	"path/filepath"
-
 	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
@@ -190,7 +188,7 @@ func (s *volumeSuite) TestListVolumesStorageLocationBlockDevicePath(c *gc.C) {
 	expected.Storage.Kind = params.StorageKindBlock
 	expected.Storage.Status.Status = status.Attached
 	storageAttachmentDetails := expected.Storage.Attachments["unit-mysql-0"]
-	storageAttachmentDetails.Location = filepath.FromSlash("/dev/sdd")
+	storageAttachmentDetails.Location = "/dev/sdd"
 	expected.Storage.Attachments["unit-mysql-0"] = storageAttachmentDetails
 	expected.MachineAttachments[s.machineTag.String()] = params.VolumeAttachmentDetails{
 		VolumeAttachmentInfo: params.VolumeAttachmentInfo{

--- a/storage/path.go
+++ b/storage/path.go
@@ -4,7 +4,7 @@
 package storage
 
 import (
-	"path/filepath"
+	"path"
 
 	"github.com/juju/errors"
 )
@@ -24,14 +24,14 @@ func BlockDevicePath(device BlockDevice) (string, error) {
 		return diskByWWN + device.WWN, nil
 	}
 	if device.HardwareId != "" {
-		return filepath.Join(diskByID, device.HardwareId), nil
+		return path.Join(diskByID, device.HardwareId), nil
 	}
 	if len(device.DeviceLinks) > 0 {
 		// return the first device link in the list
 		return device.DeviceLinks[0], nil
 	}
 	if device.DeviceName != "" {
-		return filepath.Join(diskByDeviceName, device.DeviceName), nil
+		return path.Join(diskByDeviceName, device.DeviceName), nil
 	}
 	return "", errors.Errorf("could not determine path for block device")
 }


### PR DESCRIPTION
## Description of change

Storage is not supported on Windows currently,
and the block device paths will only ever work
on *nix machines. Don't use filepath.

## QA steps

Run the tests on Linux and Windows.

## Documentation changes

None.

## Bug reference

http://reports.vapour.ws/releases/5227/job/run-unit-tests-win2012-amd64/attempt/3720