### PR TITLE
storageprovisioner: fix watching of volume-backed filesystems

### DIFF
--- a/apiserver/storageprovisioner/internal/filesystemwatcher/backend.go
+++ b/apiserver/storageprovisioner/internal/filesystemwatcher/backend.go
@@ -1,0 +1,22 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package filesystemwatcher
+
+import (
+	"gopkg.in/juju/names.v2"
+
+	"github.com/juju/juju/state"
+)
+
+// Backend provides access to filesystems and volumes for the
+// filesystem watchers to use.
+type Backend interface {
+	Filesystem(names.FilesystemTag) (state.Filesystem, error)
+	VolumeAttachment(names.MachineTag, names.VolumeTag) (state.VolumeAttachment, error)
+	WatchMachineFilesystems(names.MachineTag) state.StringsWatcher
+	WatchMachineFilesystemAttachments(names.MachineTag) state.StringsWatcher
+	WatchModelFilesystems() state.StringsWatcher
+	WatchModelFilesystemAttachments() state.StringsWatcher
+	WatchModelVolumeAttachments() state.StringsWatcher
+}

--- a/apiserver/storageprovisioner/internal/filesystemwatcher/mock_test.go
+++ b/apiserver/storageprovisioner/internal/filesystemwatcher/mock_test.go
@@ -1,0 +1,92 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package filesystemwatcher_test
+
+import (
+	"gopkg.in/juju/names.v2"
+
+	"github.com/juju/errors"
+	"github.com/juju/juju/state"
+	"github.com/juju/juju/state/watcher/watchertest"
+)
+
+type mockBackend struct {
+	machineFilesystemsW           *watchertest.StringsWatcher
+	machineFilesystemAttachmentsW *watchertest.StringsWatcher
+	modelFilesystemsW             *watchertest.StringsWatcher
+	modelFilesystemAttachmentsW   *watchertest.StringsWatcher
+	modelVolumeAttachmentsW       *watchertest.StringsWatcher
+
+	filesystems       map[string]*mockFilesystem
+	volumeAttachments map[string]*mockVolumeAttachment
+}
+
+func (b *mockBackend) Filesystem(tag names.FilesystemTag) (state.Filesystem, error) {
+	if f, ok := b.filesystems[tag.Id()]; ok {
+		return f, nil
+	}
+	return nil, errors.NotFoundf("filesystem %s", tag.Id())
+}
+
+func (b *mockBackend) VolumeAttachment(m names.MachineTag, v names.VolumeTag) (state.VolumeAttachment, error) {
+	if m.Id() != "0" {
+		// The tests all operate on machine "0", and the watchers
+		// should ignore attachments for other machines, so we should
+		// never get here.
+		return nil, errors.New("should not get here")
+	}
+	if a, ok := b.volumeAttachments[v.Id()]; ok {
+		return a, nil
+	}
+	return nil, errors.NotFoundf("attachment for volume %s to machine %s", v.Id(), m.Id())
+}
+
+func (b *mockBackend) WatchMachineFilesystems(tag names.MachineTag) state.StringsWatcher {
+	return b.machineFilesystemsW
+}
+
+func (b *mockBackend) WatchMachineFilesystemAttachments(tag names.MachineTag) state.StringsWatcher {
+	return b.machineFilesystemAttachmentsW
+}
+
+func (b *mockBackend) WatchModelFilesystems() state.StringsWatcher {
+	return b.modelFilesystemsW
+}
+
+func (b *mockBackend) WatchModelFilesystemAttachments() state.StringsWatcher {
+	return b.modelFilesystemAttachmentsW
+}
+
+func (b *mockBackend) WatchModelVolumeAttachments() state.StringsWatcher {
+	return b.modelVolumeAttachmentsW
+}
+
+func newStringsWatcher() *watchertest.StringsWatcher {
+	return watchertest.NewStringsWatcher(make(chan []string, 1))
+}
+
+type mockFilesystem struct {
+	state.Filesystem
+	volume names.VolumeTag
+}
+
+func (f *mockFilesystem) Volume() (names.VolumeTag, error) {
+	if f.volume == (names.VolumeTag{}) {
+		return names.VolumeTag{}, state.ErrNoBackingVolume
+	}
+	return f.volume, nil
+}
+
+type mockVolumeAttachment struct {
+	state.VolumeAttachment
+	life state.Life
+}
+
+func (a *mockVolumeAttachment) Life() state.Life {
+	return a.life
+}
+
+type nopSyncStarter struct{}
+
+func (nopSyncStarter) StartSync() {}

--- a/apiserver/storageprovisioner/internal/filesystemwatcher/package_test.go
+++ b/apiserver/storageprovisioner/internal/filesystemwatcher/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package filesystemwatcher_test
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func TestAll(t *testing.T) {
+	gc.TestingT(t)
+}

--- a/apiserver/storageprovisioner/internal/filesystemwatcher/watchers.go
+++ b/apiserver/storageprovisioner/internal/filesystemwatcher/watchers.go
@@ -1,0 +1,464 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package filesystemwatcher
+
+import (
+	"gopkg.in/juju/names.v2"
+	"gopkg.in/tomb.v1"
+
+	"github.com/juju/errors"
+	"github.com/juju/juju/state"
+	"github.com/juju/juju/state/watcher"
+	"github.com/juju/utils/set"
+)
+
+// Watchers provides methods for watching filesystems. The watches aggregate
+// results from machine- and model-scoped watchers, to conform to the behaviour
+// of the storageprovisioner worker. The model-level storageprovisioner watches
+// model-scoped filesystems that have no backing volume. The machine-level worker
+// watches both machine-scoped filesytems, and model-scoped filesystems whose
+// backing volumes are attached to the machine.
+type Watchers struct {
+	Backend Backend
+}
+
+// WatchModelManagedFilesystems returns a strings watcher that reports
+// model-scoped filesystems that have no backing volume. Volume-backed
+// filesystems are always managed by the machine to which they are attached.
+func (fw Watchers) WatchModelManagedFilesystems() state.StringsWatcher {
+	return newFilteredStringsWatcher(fw.Backend.WatchModelFilesystems(), func(id string) (bool, error) {
+		f, err := fw.Backend.Filesystem(names.NewFilesystemTag(id))
+		if errors.IsNotFound(err) {
+			return false, nil
+		} else if err != nil {
+			return false, errors.Trace(err)
+		}
+		_, err = f.Volume()
+		return err == state.ErrNoBackingVolume, nil
+	})
+}
+
+// WatchMachineManagedFilesystems returns a strings watcher that reports both
+// machine-scoped filesystems, and model-scoped, volume-backed filesystems
+// that are attached to the specified machine.
+func (fw Watchers) WatchMachineManagedFilesystems(m names.MachineTag) state.StringsWatcher {
+	w := &machineFilesystemsWatcher{
+		stringsWatcherBase:     stringsWatcherBase{out: make(chan []string)},
+		backend:                fw.Backend,
+		machine:                m,
+		changes:                make(set.Strings),
+		machineFilesystems:     fw.Backend.WatchMachineFilesystems(m),
+		modelFilesystems:       fw.Backend.WatchModelFilesystems(),
+		modelVolumeAttachments: fw.Backend.WatchModelVolumeAttachments(),
+		modelVolumesAttached:   make(set.Tags),
+		modelVolumeFilesystems: make(map[names.VolumeTag]names.FilesystemTag),
+	}
+	go func() {
+		defer w.tomb.Done()
+		defer watcher.Stop(w.machineFilesystems, &w.tomb)
+		defer watcher.Stop(w.modelFilesystems, &w.tomb)
+		defer watcher.Stop(w.modelVolumeAttachments, &w.tomb)
+		w.tomb.Kill(w.loop())
+	}()
+	return w
+}
+
+// machineFilesystemsWatcher is a strings watcher that reports both
+// machine-scoped filesystems, and model-scoped, volume-backed filesystems
+// that are attached to the specified machine.
+//
+// NOTE(axw) we use the existence of the *volume* attachment rather than
+// filesystem attachment because the filesystem attachment can be destroyed
+// before the filesystem, but the volume attachment cannot.
+type machineFilesystemsWatcher struct {
+	stringsWatcherBase
+	changes                set.Strings
+	backend                Backend
+	machine                names.MachineTag
+	machineFilesystems     state.StringsWatcher
+	modelFilesystems       state.StringsWatcher
+	modelVolumeAttachments state.StringsWatcher
+	modelVolumesAttached   set.Tags
+	modelVolumeFilesystems map[names.VolumeTag]names.FilesystemTag
+}
+
+func (w *machineFilesystemsWatcher) loop() error {
+	defer close(w.out)
+	var out chan<- []string
+	var machineFilesystemsReceived bool
+	var modelFilesystemsReceived bool
+	var modelVolumeAttachmentsReceived bool
+	var sentFirst bool
+	for {
+		select {
+		case <-w.tomb.Dying():
+			return tomb.ErrDying
+		case values, ok := <-w.machineFilesystems.Changes():
+			if !ok {
+				return watcher.EnsureErr(w.machineFilesystems)
+			}
+			machineFilesystemsReceived = true
+			for _, v := range values {
+				w.changes.Add(v)
+			}
+		case values, ok := <-w.modelFilesystems.Changes():
+			if !ok {
+				return watcher.EnsureErr(w.modelFilesystems)
+			}
+			modelFilesystemsReceived = true
+			for _, id := range values {
+				filesystemTag := names.NewFilesystemTag(id)
+				if err := w.modelFilesystemChanged(filesystemTag); err != nil {
+					return errors.Trace(err)
+				}
+			}
+		case values, ok := <-w.modelVolumeAttachments.Changes():
+			if !ok {
+				return watcher.EnsureErr(w.modelVolumeAttachments)
+			}
+			modelVolumeAttachmentsReceived = true
+			for _, id := range values {
+				machineTag, volumeTag, err := state.ParseVolumeAttachmentId(id)
+				if err != nil {
+					return errors.Annotate(err, "parsing volume attachment ID")
+				}
+				if machineTag != w.machine {
+					continue
+				}
+				if err := w.modelVolumeAttachmentChanged(volumeTag); err != nil {
+					return errors.Trace(err)
+				}
+			}
+		case out <- w.changes.SortedValues():
+			w.changes = make(set.Strings)
+			out = nil
+		}
+		// NOTE(axw) we don't send any changes until we have received
+		// an initial event from each of the watchers. This ensures
+		// that we provide a complete view of the world in the initial
+		// event, which is expected of all watchers.
+		if machineFilesystemsReceived &&
+			modelFilesystemsReceived &&
+			modelVolumeAttachmentsReceived &&
+			(!sentFirst || len(w.changes) > 0) {
+			sentFirst = true
+			out = w.out
+		}
+	}
+}
+
+func (w *machineFilesystemsWatcher) modelFilesystemChanged(filesystemTag names.FilesystemTag) error {
+	filesystem, err := w.backend.Filesystem(filesystemTag)
+	if errors.IsNotFound(err) {
+		// Filesystem removed: nothing more to do.
+		return nil
+	} else if err != nil {
+		return errors.Annotate(err, "getting filesystem")
+	}
+	volumeTag, err := filesystem.Volume()
+	if err == state.ErrNoBackingVolume {
+		// Filesystem has no backing volume: nothing more to do.
+		return nil
+	} else if err != nil {
+		return errors.Annotate(err, "getting filesystem volume")
+	}
+	w.modelVolumeFilesystems[volumeTag] = filesystemTag
+	if w.modelVolumesAttached.Contains(volumeTag) {
+		w.changes.Add(filesystemTag.Id())
+	}
+	return nil
+}
+
+func (w *machineFilesystemsWatcher) modelVolumeAttachmentChanged(volumeTag names.VolumeTag) error {
+	va, err := w.backend.VolumeAttachment(w.machine, volumeTag)
+	if err != nil && !errors.IsNotFound(err) {
+		return errors.Annotate(err, "getting volume attachment")
+	}
+	if errors.IsNotFound(err) || va.Life() == state.Dead {
+		filesystemTag, ok := w.modelVolumeFilesystems[volumeTag]
+		if ok {
+			// If the volume attachment is Dead/removed,
+			// the filesystem must have been removed. We
+			// don't get a change notification for removed
+			// entities, so we use this to clean up.
+			delete(w.modelVolumeFilesystems, volumeTag)
+			w.changes.Remove(filesystemTag.Id())
+			w.modelVolumesAttached.Remove(volumeTag)
+		}
+		return nil
+	}
+	w.modelVolumesAttached.Add(volumeTag)
+	if filesystemTag, ok := w.modelVolumeFilesystems[volumeTag]; ok {
+		w.changes.Add(filesystemTag.Id())
+	}
+	return nil
+}
+
+// WatchModelManagedFilesystemAttachments returns a strings watcher that
+// reports lifecycle changes to attachments of model-scoped filesystem that
+// have no backing volume. Volume-backed filesystems are always managed by
+// the machine to which they are attached.
+func (fw Watchers) WatchModelManagedFilesystemAttachments() state.StringsWatcher {
+	return newFilteredStringsWatcher(fw.Backend.WatchModelFilesystemAttachments(), func(id string) (bool, error) {
+		_, filesystemTag, err := state.ParseFilesystemAttachmentId(id)
+		if err != nil {
+			return false, errors.Annotate(err, "parsing filesystem attachment ID")
+		}
+		f, err := fw.Backend.Filesystem(filesystemTag)
+		if errors.IsNotFound(err) {
+			return false, nil
+		} else if err != nil {
+			return false, errors.Trace(err)
+		}
+		_, err = f.Volume()
+		return err == state.ErrNoBackingVolume, nil
+	})
+}
+
+// WatchMachineManagedFilesystemAttachments returns a strings watcher that
+// reports lifecycle change sfor attachments to both machine-scoped filesystems,
+// and model-scoped, volume-backed filesystems that are attached to the
+// specified machine.
+func (fw Watchers) WatchMachineManagedFilesystemAttachments(m names.MachineTag) state.StringsWatcher {
+	w := &machineFilesystemAttachmentsWatcher{
+		stringsWatcherBase: stringsWatcherBase{out: make(chan []string)},
+		backend:            fw.Backend,
+		machine:            m,
+		changes:            make(set.Strings),
+		machineFilesystemAttachments:     fw.Backend.WatchMachineFilesystemAttachments(m),
+		modelFilesystemAttachments:       fw.Backend.WatchModelFilesystemAttachments(),
+		modelVolumeAttachments:           fw.Backend.WatchModelVolumeAttachments(),
+		modelVolumesAttached:             make(set.Tags),
+		modelVolumeFilesystemAttachments: make(map[names.VolumeTag]string),
+	}
+	go func() {
+		defer w.tomb.Done()
+		defer watcher.Stop(w.machineFilesystemAttachments, &w.tomb)
+		defer watcher.Stop(w.modelFilesystemAttachments, &w.tomb)
+		defer watcher.Stop(w.modelVolumeAttachments, &w.tomb)
+		w.tomb.Kill(w.loop())
+	}()
+	return w
+}
+
+// machineFilesystemAttachmentsWatcher is a strings watcher that reports
+// lifechcle changes for attachments to both machine-scoped filesystems,
+// and model-scoped, volume-backed filesystems that are attached to the
+// specified machine.
+//
+// NOTE(axw) we use the existence of the *volume* attachment rather than
+// filesystem attachment because the filesystem attachment can be destroyed
+// before the filesystem, but the volume attachment cannot.
+type machineFilesystemAttachmentsWatcher struct {
+	stringsWatcherBase
+	changes                          set.Strings
+	backend                          Backend
+	machine                          names.MachineTag
+	machineFilesystemAttachments     state.StringsWatcher
+	modelFilesystemAttachments       state.StringsWatcher
+	modelVolumeAttachments           state.StringsWatcher
+	modelVolumesAttached             set.Tags
+	modelVolumeFilesystemAttachments map[names.VolumeTag]string
+}
+
+func (w *machineFilesystemAttachmentsWatcher) loop() error {
+	defer close(w.out)
+	var out chan<- []string
+	var machineFilesystemAttachmentsReceived bool
+	var modelFilesystemAttachmentsReceived bool
+	var modelVolumeAttachmentsReceived bool
+	var sentFirst bool
+	for {
+		select {
+		case <-w.tomb.Dying():
+			return tomb.ErrDying
+		case values, ok := <-w.machineFilesystemAttachments.Changes():
+			if !ok {
+				return watcher.EnsureErr(w.machineFilesystemAttachments)
+			}
+			machineFilesystemAttachmentsReceived = true
+			for _, v := range values {
+				w.changes.Add(v)
+			}
+		case values, ok := <-w.modelFilesystemAttachments.Changes():
+			if !ok {
+				return watcher.EnsureErr(w.modelFilesystemAttachments)
+			}
+			modelFilesystemAttachmentsReceived = true
+			for _, id := range values {
+				machineTag, filesystemTag, err := state.ParseFilesystemAttachmentId(id)
+				if err != nil {
+					return errors.Annotate(err, "parsing filesystem attachment ID")
+				}
+				if machineTag != w.machine {
+					continue
+				}
+				if err := w.modelFilesystemAttachmentChanged(id, filesystemTag); err != nil {
+					return errors.Trace(err)
+				}
+			}
+		case values, ok := <-w.modelVolumeAttachments.Changes():
+			if !ok {
+				return watcher.EnsureErr(w.modelVolumeAttachments)
+			}
+			modelVolumeAttachmentsReceived = true
+			for _, id := range values {
+				machineTag, volumeTag, err := state.ParseVolumeAttachmentId(id)
+				if err != nil {
+					return errors.Annotate(err, "parsing volume attachment ID")
+				}
+				if machineTag != w.machine {
+					continue
+				}
+				if err := w.modelVolumeAttachmentChanged(volumeTag); err != nil {
+					return errors.Trace(err)
+				}
+			}
+		case out <- w.changes.SortedValues():
+			w.changes = make(set.Strings)
+			out = nil
+		}
+		// NOTE(axw) we don't send any changes until we have received
+		// an initial event from each of the watchers. This ensures
+		// that we provide a complete view of the world in the initial
+		// event, which is expected of all watchers.
+		if machineFilesystemAttachmentsReceived &&
+			modelFilesystemAttachmentsReceived &&
+			modelVolumeAttachmentsReceived &&
+			(!sentFirst || len(w.changes) > 0) {
+			sentFirst = true
+			out = w.out
+		}
+	}
+}
+
+func (w *machineFilesystemAttachmentsWatcher) modelFilesystemAttachmentChanged(
+	filesystemAttachmentId string,
+	filesystemTag names.FilesystemTag,
+) error {
+	filesystem, err := w.backend.Filesystem(filesystemTag)
+	if errors.IsNotFound(err) {
+		// Filesystem removed: nothing more to do.
+		return nil
+	} else if err != nil {
+		return errors.Annotate(err, "getting filesystem")
+	}
+	volumeTag, err := filesystem.Volume()
+	if err == state.ErrNoBackingVolume {
+		// Filesystem has no backing volume: nothing more to do.
+		return nil
+	} else if err != nil {
+		return errors.Annotate(err, "getting filesystem volume")
+	}
+	w.modelVolumeFilesystemAttachments[volumeTag] = filesystemAttachmentId
+	if w.modelVolumesAttached.Contains(volumeTag) {
+		w.changes.Add(filesystemAttachmentId)
+	}
+	return nil
+}
+
+func (w *machineFilesystemAttachmentsWatcher) modelVolumeAttachmentChanged(volumeTag names.VolumeTag) error {
+	va, err := w.backend.VolumeAttachment(w.machine, volumeTag)
+	if err != nil && !errors.IsNotFound(err) {
+		return errors.Annotate(err, "getting volume attachment")
+	}
+	if errors.IsNotFound(err) || va.Life() == state.Dead {
+		filesystemAttachmentId, ok := w.modelVolumeFilesystemAttachments[volumeTag]
+		if ok {
+			// If the volume attachment is Dead/removed,
+			// the filesystem attachment must have been
+			// removed. We don't get a change notification
+			// for removed entities, so we use this to
+			// clean up.
+			delete(w.modelVolumeFilesystemAttachments, volumeTag)
+			w.changes.Remove(filesystemAttachmentId)
+			w.modelVolumesAttached.Remove(volumeTag)
+		}
+		return nil
+	}
+	w.modelVolumesAttached.Add(volumeTag)
+	if filesystemAttachmentId, ok := w.modelVolumeFilesystemAttachments[volumeTag]; ok {
+		w.changes.Add(filesystemAttachmentId)
+	}
+	return nil
+}
+
+type filteredStringsWatcher struct {
+	stringsWatcherBase
+	w      state.StringsWatcher
+	filter func(string) (bool, error)
+}
+
+func newFilteredStringsWatcher(w state.StringsWatcher, filter func(string) (bool, error)) *filteredStringsWatcher {
+	fw := &filteredStringsWatcher{
+		stringsWatcherBase: stringsWatcherBase{out: make(chan []string)},
+		w:                  w,
+		filter:             filter,
+	}
+	go func() {
+		defer fw.tomb.Done()
+		defer watcher.Stop(fw.w, &fw.tomb)
+		fw.tomb.Kill(fw.loop())
+	}()
+	return fw
+}
+
+func (fw *filteredStringsWatcher) loop() error {
+	defer close(fw.out)
+	var out chan []string
+	var values []string
+	for {
+		select {
+		case <-fw.tomb.Dying():
+			return tomb.ErrDying
+		case in, ok := <-fw.w.Changes():
+			if !ok {
+				return watcher.EnsureErr(fw.w)
+			}
+			values = make([]string, 0, len(in))
+			for _, value := range in {
+				ok, err := fw.filter(value)
+				if err != nil {
+					return errors.Trace(err)
+				} else if ok {
+					values = append(values, value)
+				}
+			}
+			out = fw.out
+		case out <- values:
+			out = nil
+		}
+	}
+}
+
+type stringsWatcherBase struct {
+	tomb tomb.Tomb
+	out  chan []string
+}
+
+// Err is part of the state.StringsWatcher interface.
+func (w *stringsWatcherBase) Err() error {
+	return w.tomb.Err()
+}
+
+// Stop is part of the state.StringsWatcher interface.
+func (w *stringsWatcherBase) Stop() error {
+	w.Kill()
+	return w.Wait()
+}
+
+// Kill is part of the state.StringsWatcher interface.
+func (w *stringsWatcherBase) Kill() {
+	w.tomb.Kill(nil)
+}
+
+// Wait is part of the state.StringsWatcher interface.
+func (w *stringsWatcherBase) Wait() error {
+	return w.tomb.Wait()
+}
+
+// Changes is part of the state.StringsWatcher interface.
+func (w *stringsWatcherBase) Changes() <-chan []string {
+	return w.out
+}

--- a/apiserver/storageprovisioner/internal/filesystemwatcher/watchers_test.go
+++ b/apiserver/storageprovisioner/internal/filesystemwatcher/watchers_test.go
@@ -1,0 +1,231 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package filesystemwatcher_test
+
+import (
+	"errors"
+
+	"github.com/juju/testing"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/names.v2"
+
+	"github.com/juju/juju/apiserver/storageprovisioner/internal/filesystemwatcher"
+	"github.com/juju/juju/state"
+	statetesting "github.com/juju/juju/state/testing"
+)
+
+var _ = gc.Suite(&WatchersSuite{})
+
+type WatchersSuite struct {
+	testing.IsolationSuite
+	backend  *mockBackend
+	watchers filesystemwatcher.Watchers
+}
+
+func (s *WatchersSuite) SetUpTest(c *gc.C) {
+	s.IsolationSuite.SetUpTest(c)
+	s.backend = &mockBackend{
+		machineFilesystemsW:           newStringsWatcher(),
+		machineFilesystemAttachmentsW: newStringsWatcher(),
+		modelFilesystemsW:             newStringsWatcher(),
+		modelFilesystemAttachmentsW:   newStringsWatcher(),
+		modelVolumeAttachmentsW:       newStringsWatcher(),
+		filesystems: map[string]*mockFilesystem{
+			// filesystem 0 has no backing volume.
+			"0": {},
+			// filesystem 1 is backed by volume 1.
+			"1": {volume: names.NewVolumeTag("1")},
+			// filesystem 2 is backed by volume 2.
+			"2": {volume: names.NewVolumeTag("2")},
+		},
+		volumeAttachments: map[string]*mockVolumeAttachment{
+			"1": {life: state.Alive},
+			"2": {life: state.Alive},
+		},
+	}
+	s.AddCleanup(func(*gc.C) {
+		s.backend.machineFilesystemsW.Stop()
+		s.backend.machineFilesystemAttachmentsW.Stop()
+		s.backend.modelFilesystemsW.Stop()
+		s.backend.modelFilesystemAttachmentsW.Stop()
+		s.backend.modelVolumeAttachmentsW.Stop()
+	})
+	s.watchers.Backend = s.backend
+}
+
+func (s *WatchersSuite) TestWatchModelManagedFilesystems(c *gc.C) {
+	w := s.watchers.WatchModelManagedFilesystems()
+	defer statetesting.AssertKillAndWait(c, w)
+	s.backend.modelFilesystemsW.C <- []string{"0", "1"}
+
+	// Filesystem 1 has a backing volume, so should not be reported.
+	wc := statetesting.NewStringsWatcherC(c, nopSyncStarter{}, w)
+	wc.AssertChangeInSingleEvent("0")
+	wc.AssertNoChange()
+}
+
+func (s *WatchersSuite) TestWatchModelManagedFilesystemsWatcherErrorsPropagate(c *gc.C) {
+	w := s.watchers.WatchModelManagedFilesystems()
+	s.backend.modelFilesystemsW.T.Kill(errors.New("rah"))
+	c.Assert(w.Wait(), gc.ErrorMatches, "rah")
+}
+
+func (s *WatchersSuite) TestWatchModelManagedFilesystemAttachments(c *gc.C) {
+	w := s.watchers.WatchModelManagedFilesystemAttachments()
+	defer statetesting.AssertKillAndWait(c, w)
+	s.backend.modelFilesystemAttachmentsW.C <- []string{"0:0", "0:1"}
+
+	// Filesystem 1 has a backing volume, so should not be reported.
+	wc := statetesting.NewStringsWatcherC(c, nopSyncStarter{}, w)
+	wc.AssertChangeInSingleEvent("0:0")
+	wc.AssertNoChange()
+}
+
+func (s *WatchersSuite) TestWatchModelManagedFilesystemAttachmentsWatcherErrorsPropagate(c *gc.C) {
+	w := s.watchers.WatchModelManagedFilesystemAttachments()
+	s.backend.modelFilesystemAttachmentsW.T.Kill(errors.New("rah"))
+	c.Assert(w.Wait(), gc.ErrorMatches, "rah")
+}
+
+func (s *WatchersSuite) TestWatchMachineManagedFilesystems(c *gc.C) {
+	w := s.watchers.WatchMachineManagedFilesystems(names.NewMachineTag("0"))
+	defer statetesting.AssertKillAndWait(c, w)
+	s.backend.modelFilesystemsW.C <- []string{"0", "1"}
+	s.backend.machineFilesystemsW.C <- []string{"0/2", "0/3"}
+	s.backend.modelVolumeAttachmentsW.C <- []string{"0:1", "0:2", "1:3"}
+
+	wc := statetesting.NewStringsWatcherC(c, nopSyncStarter{}, w)
+	wc.AssertChangeInSingleEvent("0/2", "0/3", "1")
+	wc.AssertNoChange()
+}
+
+func (s *WatchersSuite) TestWatchMachineManagedFilesystemsErrorsPropagate(c *gc.C) {
+	w := s.watchers.WatchMachineManagedFilesystems(names.NewMachineTag("0"))
+	s.backend.modelFilesystemsW.T.Kill(errors.New("rah"))
+	c.Assert(w.Wait(), gc.ErrorMatches, "rah")
+}
+
+// TestWatchMachineManagedFilesystemsVolumeAttachedFirst is the same as
+// TestWatchMachineManagedFilesystems, but the order of volume attachment
+// and model filesystem events is swapped.
+func (s *WatchersSuite) TestWatchMachineManagedFilesystemsVolumeAttachedFirst(c *gc.C) {
+	w := s.watchers.WatchMachineManagedFilesystems(names.NewMachineTag("0"))
+	defer statetesting.AssertKillAndWait(c, w)
+	s.backend.modelVolumeAttachmentsW.C <- []string{"0:1", "0:2", "1:3"}
+	s.backend.modelFilesystemsW.C <- []string{"0", "1"}
+	s.backend.machineFilesystemsW.C <- []string{"0/2", "0/3"}
+
+	wc := statetesting.NewStringsWatcherC(c, nopSyncStarter{}, w)
+	wc.AssertChangeInSingleEvent("0/2", "0/3", "1")
+	wc.AssertNoChange()
+}
+
+func (s *WatchersSuite) TestWatchMachineManagedFilesystemsVolumeAttachedLater(c *gc.C) {
+	w := s.watchers.WatchMachineManagedFilesystems(names.NewMachineTag("0"))
+	defer statetesting.AssertKillAndWait(c, w)
+	s.backend.modelFilesystemsW.C <- []string{"0", "1"}
+	s.backend.machineFilesystemsW.C <- []string{"0/2", "0/3"}
+	// No volumes are attached to begin with.
+	s.backend.modelVolumeAttachmentsW.C <- []string{}
+
+	wc := statetesting.NewStringsWatcherC(c, nopSyncStarter{}, w)
+	wc.AssertChangeInSingleEvent("0/2", "0/3")
+	wc.AssertNoChange()
+
+	s.backend.modelVolumeAttachmentsW.C <- []string{"0:1", "0:2", "1:3"}
+	wc.AssertChangeInSingleEvent("1")
+	wc.AssertNoChange()
+}
+
+func (s *WatchersSuite) TestWatchMachineManagedFilesystemsVolumeAttachmentDead(c *gc.C) {
+	w := s.watchers.WatchMachineManagedFilesystems(names.NewMachineTag("0"))
+	defer statetesting.AssertKillAndWait(c, w)
+
+	s.backend.machineFilesystemsW.C <- []string{}
+	// Volume-backed filesystems 1 and 2 change.
+	s.backend.modelFilesystemsW.C <- []string{"1", "2"}
+	// The volumes are attached initially...
+	s.backend.modelVolumeAttachmentsW.C <- []string{"0:1", "0:2"}
+	// ... but before the client consumes the event, the backing volume
+	// attachments 0:1 and 0:2 become Dead and removed respectively,
+	// negating the previous change.
+	s.backend.volumeAttachments["1"].life = state.Dead
+	delete(s.backend.volumeAttachments, "2")
+	s.backend.modelVolumeAttachmentsW.C <- []string{"0:1", "0:2"}
+
+	wc := statetesting.NewStringsWatcherC(c, nopSyncStarter{}, w)
+	wc.AssertChangeInSingleEvent()
+	wc.AssertNoChange()
+}
+
+func (s *WatchersSuite) TestWatchMachineManagedFilesystemAttachments(c *gc.C) {
+	w := s.watchers.WatchMachineManagedFilesystemAttachments(names.NewMachineTag("0"))
+	defer statetesting.AssertKillAndWait(c, w)
+	s.backend.modelFilesystemAttachmentsW.C <- []string{"0:0", "0:1"}
+	s.backend.machineFilesystemAttachmentsW.C <- []string{"0:0/2", "0:0/3"}
+	s.backend.modelVolumeAttachmentsW.C <- []string{"0:1", "0:2", "1:3"}
+
+	wc := statetesting.NewStringsWatcherC(c, nopSyncStarter{}, w)
+	wc.AssertChangeInSingleEvent("0:0/2", "0:0/3", "0:1")
+	wc.AssertNoChange()
+}
+
+func (s *WatchersSuite) TestWatchMachineManagedFilesystemAttachmentsErrorsPropagate(c *gc.C) {
+	w := s.watchers.WatchMachineManagedFilesystemAttachments(names.NewMachineTag("0"))
+	s.backend.modelFilesystemAttachmentsW.T.Kill(errors.New("rah"))
+	c.Assert(w.Wait(), gc.ErrorMatches, "rah")
+}
+
+// TestWatchMachineManagedFilesystemAttachmentsVolumeAttachedFirst is the same as
+// TestWatchMachineManagedFilesystemAttachments, but the order of volume attachment
+// and model filesystem attachment events is swapped.
+func (s *WatchersSuite) TestWatchMachineManagedFilesystemAttachmentsVolumeAttachedFirst(c *gc.C) {
+	w := s.watchers.WatchMachineManagedFilesystemAttachments(names.NewMachineTag("0"))
+	defer statetesting.AssertKillAndWait(c, w)
+	s.backend.modelVolumeAttachmentsW.C <- []string{"0:1", "0:2", "1:3"}
+	s.backend.modelFilesystemAttachmentsW.C <- []string{"0:0", "0:1"}
+	s.backend.machineFilesystemAttachmentsW.C <- []string{"0:0/2", "0:0/3"}
+
+	wc := statetesting.NewStringsWatcherC(c, nopSyncStarter{}, w)
+	wc.AssertChangeInSingleEvent("0:0/2", "0:0/3", "0:1")
+	wc.AssertNoChange()
+}
+
+func (s *WatchersSuite) TestWatchMachineManagedFilesystemAttachmentsVolumeAttachedLater(c *gc.C) {
+	w := s.watchers.WatchMachineManagedFilesystemAttachments(names.NewMachineTag("0"))
+	defer statetesting.AssertKillAndWait(c, w)
+	s.backend.modelFilesystemAttachmentsW.C <- []string{"0:0", "0:1"}
+	s.backend.machineFilesystemAttachmentsW.C <- []string{"0:0/2", "0:0/3"}
+	// No volumes are attached to begin with.
+	s.backend.modelVolumeAttachmentsW.C <- []string{}
+
+	wc := statetesting.NewStringsWatcherC(c, nopSyncStarter{}, w)
+	wc.AssertChangeInSingleEvent("0:0/2", "0:0/3")
+	wc.AssertNoChange()
+
+	s.backend.modelVolumeAttachmentsW.C <- []string{"0:1", "0:2", "1:3"}
+	wc.AssertChangeInSingleEvent("0:1")
+	wc.AssertNoChange()
+}
+
+func (s *WatchersSuite) TestWatchMachineManagedFilesystemAttachmentsVolumeAttachmentDead(c *gc.C) {
+	w := s.watchers.WatchMachineManagedFilesystemAttachments(names.NewMachineTag("0"))
+	defer statetesting.AssertKillAndWait(c, w)
+
+	s.backend.machineFilesystemAttachmentsW.C <- []string{}
+	// Volume-backed filesystems attachments 0:1 and 0:2 change.
+	s.backend.modelFilesystemAttachmentsW.C <- []string{"0:1", "0:2"}
+	// The volumes are attached initially...
+	s.backend.modelVolumeAttachmentsW.C <- []string{"0:1", "0:2"}
+	// ... but before the client consumes the event, the backing volume
+	// attachments 0:1 and 0:2 become Dead and removed respectively,
+	// negating the previous change.
+	s.backend.volumeAttachments["1"].life = state.Dead
+	delete(s.backend.volumeAttachments, "2")
+	s.backend.modelVolumeAttachmentsW.C <- []string{"0:1", "0:2"}
+
+	wc := statetesting.NewStringsWatcherC(c, nopSyncStarter{}, w)
+	wc.AssertChangeInSingleEvent()
+	wc.AssertNoChange()
+}

--- a/apiserver/storageprovisioner/storageprovisioner.go
+++ b/apiserver/storageprovisioner/storageprovisioner.go
@@ -1105,9 +1105,7 @@ func (s *StorageProvisionerAPI) AttachmentLife(args params.MachineStorageIds) (p
 		case names.FilesystemTag:
 			lifer, err = s.st.FilesystemAttachment(machineTag, attachmentTag)
 		}
-		if errors.IsNotFound(err) {
-			return "", common.ErrPerm
-		} else if err != nil {
+		if err != nil {
 			return "", errors.Trace(err)
 		}
 		return params.Life(lifer.Life().String()), nil

--- a/apiserver/storageprovisioner/storageprovisioner.go
+++ b/apiserver/storageprovisioner/storageprovisioner.go
@@ -12,6 +12,7 @@ import (
 	"github.com/juju/juju/apiserver/common/storagecommon"
 	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/apiserver/storageprovisioner/internal/filesystemwatcher"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/watcher"
 	"github.com/juju/juju/storage"
@@ -279,7 +280,8 @@ func (s *StorageProvisionerAPI) WatchVolumes(args params.Entities) (params.Strin
 // WatchFilesystems watches for changes to filesystems scoped
 // to the entity with the tag passed to NewState.
 func (s *StorageProvisionerAPI) WatchFilesystems(args params.Entities) (params.StringsWatchResults, error) {
-	return s.watchStorageEntities(args, s.st.WatchModelFilesystems, s.st.WatchMachineFilesystems)
+	w := filesystemwatcher.Watchers{s.st}
+	return s.watchStorageEntities(args, w.WatchModelManagedFilesystems, w.WatchMachineManagedFilesystems)
 }
 
 func (s *StorageProvisionerAPI) watchStorageEntities(
@@ -338,10 +340,11 @@ func (s *StorageProvisionerAPI) WatchVolumeAttachments(args params.Entities) (pa
 // WatchFilesystemAttachments watches for changes to filesystem attachments
 // scoped to the entity with the tag passed to NewState.
 func (s *StorageProvisionerAPI) WatchFilesystemAttachments(args params.Entities) (params.MachineStorageIdsWatchResults, error) {
+	w := filesystemwatcher.Watchers{s.st}
 	return s.watchAttachments(
 		args,
-		s.st.WatchModelFilesystemAttachments,
-		s.st.WatchMachineFilesystemAttachments,
+		w.WatchModelManagedFilesystemAttachments,
+		w.WatchMachineManagedFilesystemAttachments,
 		storagecommon.ParseFilesystemAttachmentIds,
 	)
 }

--- a/apiserver/storageprovisioner/storageprovisioner_test.go
+++ b/apiserver/storageprovisioner/storageprovisioner_test.go
@@ -1006,7 +1006,7 @@ func (s *provisionerSuite) TestAttachmentLife(c *gc.C) {
 			{Life: params.Alive},
 			{Life: params.Alive},
 			{Life: params.Alive},
-			{Error: &params.Error{Message: "permission denied", Code: "unauthorized access"}},
+			{Error: &params.Error{Message: `volume "42" on machine "0" not found`, Code: "not found"}},
 		},
 	})
 }

--- a/provider/gce/disks.go
+++ b/provider/gce/disks.go
@@ -368,7 +368,10 @@ func (v *volumeSource) AttachVolumes(attachParams []storage.VolumeAttachmentPara
 			attachment.Volume,
 			attachment.Machine,
 			storage.VolumeAttachmentInfo{
-				DeviceName: attached.DeviceName,
+				DeviceLink: fmt.Sprintf(
+					"/dev/disk/by-id/google-%s",
+					attached.DeviceName,
+				),
 			},
 		}
 	}

--- a/provider/gce/disks_test.go
+++ b/provider/gce/disks_test.go
@@ -274,7 +274,8 @@ func (s *volumeSourceSuite) TestAttachVolumes(c *gc.C) {
 	c.Assert(res, gc.HasLen, 1)
 	c.Assert(res[0].VolumeAttachment.Volume.String(), gc.Equals, "volume-0")
 	c.Assert(res[0].VolumeAttachment.Machine.String(), gc.Equals, "machine-0")
-	c.Assert(res[0].VolumeAttachment.VolumeAttachmentInfo.DeviceName, gc.Equals, "home-zone-1234567")
+	c.Assert(res[0].VolumeAttachment.VolumeAttachmentInfo.DeviceName, gc.Equals, "")
+	c.Assert(res[0].VolumeAttachment.VolumeAttachmentInfo.DeviceLink, gc.Equals, "/dev/disk/by-id/google-home-zone-1234567")
 
 	// Disk Was attached
 	attachCalled, call := s.FakeConn.WasCalled("AttachDisk")

--- a/state/filesystem.go
+++ b/state/filesystem.go
@@ -113,8 +113,8 @@ type filesystemDoc struct {
 
 	// MachineId is the ID of the machine that a non-detachable
 	// volume is initially attached to. We use this to identify
-	// the volume as being non-detachable, and to determine
-	// which volumes must be removed along with said machine.
+	// the filesystem as being non-detachable, and to determine
+	// which filesystems must be removed along with said machine.
 	MachineId string `bson:"machineid,omitempty"`
 }
 

--- a/state/watcher/watchertest/strings.go
+++ b/state/watcher/watchertest/strings.go
@@ -1,0 +1,53 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package watchertest
+
+import "gopkg.in/tomb.v1"
+
+// StringsWatcher is an implementation of state.StringsWatcher that can
+// be manipulated, for testing.
+type StringsWatcher struct {
+	T tomb.Tomb
+	C chan []string
+}
+
+// NewStringsWatcher returns a new StringsWatcher that returns the given
+// channel in its "Changes" method. NewStringsWatcher takes ownership of
+// the channel, closing it when it is stopped.
+func NewStringsWatcher(ch chan []string) *StringsWatcher {
+	w := &StringsWatcher{C: ch}
+	go func() {
+		defer w.T.Done()
+		defer w.T.Kill(nil)
+		defer close(ch)
+		<-w.T.Dying()
+	}()
+	return w
+}
+
+// Changes is part of the state.StringsWatcher interface.
+func (w *StringsWatcher) Changes() <-chan []string {
+	return w.C
+}
+
+// Err is part of the state.StringsWatcher interface.
+func (w *StringsWatcher) Err() error {
+	return w.T.Err()
+}
+
+// Stop is part of the state.StringsWatcher interface.
+func (w *StringsWatcher) Stop() error {
+	w.Kill()
+	return w.Wait()
+}
+
+// Kill is part of the state.StringsWatcher interface.
+func (w *StringsWatcher) Kill() {
+	w.T.Kill(nil)
+}
+
+// Wait is part of the state.StringsWatcher interface.
+func (w *StringsWatcher) Wait() error {
+	return w.T.Wait()
+}

--- a/worker/storageprovisioner/filesystem_events.go
+++ b/worker/storageprovisioner/filesystem_events.go
@@ -74,10 +74,8 @@ func filesystemAttachmentsChanged(ctx *context, watcherIds []watcher.MachineStor
 		return errors.Trace(err)
 	}
 	logger.Debugf("filesystem attachment alive: %v, dying: %v, dead: %v", alive, dying, dead)
-	if len(dead) != 0 {
-		// We should not see dead filesystem attachments;
-		// attachments go directly from Dying to removed.
-		logger.Warningf("unexpected dead filesystem attachments: %v", dead)
+	if err := processDeadFilesystemAttachments(ctx, dead); err != nil {
+		return errors.Annotate(err, "removing dead volume attachments")
 	}
 	if len(alive)+len(dying) == 0 {
 		return nil
@@ -88,7 +86,7 @@ func filesystemAttachmentsChanged(ctx *context, watcherIds []watcher.MachineStor
 	ids = append(alive, dying...)
 	filesystemAttachmentResults, err := ctx.config.Filesystems.FilesystemAttachments(ids)
 	if err != nil {
-		return errors.Annotatef(err, "getting filesystem attachment information")
+		return errors.Annotate(err, "getting filesystem attachment information")
 	}
 
 	// Deprovision Dying filesystem attachments.
@@ -232,6 +230,18 @@ func processDeadFilesystems(ctx *context, tags []names.FilesystemTag, filesystem
 	}
 	if err := removeEntities(ctx, remove); err != nil {
 		return errors.Annotate(err, "removing filesystems from state")
+	}
+	return nil
+}
+
+// processDeadFilesystemAttachments processes the IDs for Dead filesystem
+// attachments, removing the filesystem attachments from state.
+func processDeadFilesystemAttachments(ctx *context, ids []params.MachineStorageId) error {
+	if err := removeAttachments(ctx, ids); err != nil {
+		return errors.Annotate(err, "removing attachments from state")
+	}
+	for _, id := range ids {
+		delete(ctx.filesystemAttachments, id)
 	}
 	return nil
 }

--- a/worker/storageprovisioner/filesystem_ops.go
+++ b/worker/storageprovisioner/filesystem_ops.go
@@ -321,12 +321,6 @@ func detachFilesystems(ctx *context, ops map[params.MachineStorageId]*detachFile
 	}
 	scheduleOperations(ctx, reschedule...)
 	setStatus(ctx, statuses)
-	if err := removeAttachments(ctx, remove); err != nil {
-		return errors.Annotate(err, "removing attachments from state")
-	}
-	for _, id := range remove {
-		delete(ctx.filesystemAttachments, id)
-	}
 	return nil
 }
 

--- a/worker/storageprovisioner/storageprovisioner_test.go
+++ b/worker/storageprovisioner/storageprovisioner_test.go
@@ -1167,6 +1167,37 @@ func (s *storageProvisionerSuite) TestSetVolumeInfoErrorResultDoesNotStopWorker(
 	assertNoEvent(c, done, "worker exited")
 }
 
+func (s *storageProvisionerSuite) TestRemoveDeadVolumeAttachments(c *gc.C) {
+	removed := make(chan interface{})
+	removeAttachments := func(ids []params.MachineStorageId) ([]params.ErrorResult, error) {
+		defer close(removed)
+		c.Assert(ids, gc.DeepEquals, []params.MachineStorageId{{
+			MachineTag:    "machine-0",
+			AttachmentTag: "volume-0",
+		}})
+		return make([]params.ErrorResult, len(ids)), nil
+	}
+	attachmentLife := func(ids []params.MachineStorageId) ([]params.LifeResult, error) {
+		return []params.LifeResult{{Life: params.Dead}}, nil
+	}
+
+	args := &workerArgs{
+		life: &mockLifecycleManager{
+			attachmentLife:    attachmentLife,
+			removeAttachments: removeAttachments,
+		},
+		registry: s.registry,
+	}
+	worker := newStorageProvisioner(c, args)
+	defer worker.Wait()
+	defer worker.Kill()
+
+	args.volumes.attachmentsWatcher.changes <- []watcher.MachineStorageId{{
+		MachineTag: "machine-0", AttachmentTag: "volume-0",
+	}}
+	waitChannel(c, removed, "waiting for attachment to be removed")
+}
+
 func (s *storageProvisionerSuite) TestDetachVolumesUnattached(c *gc.C) {
 	removed := make(chan interface{})
 	removeAttachments := func(ids []params.MachineStorageId) ([]params.ErrorResult, error) {
@@ -1231,13 +1262,6 @@ func (s *storageProvisionerSuite) TestDetachVolumes(c *gc.C) {
 		return make([]error, len(args)), nil
 	}
 
-	removed := make(chan interface{})
-	removeAttachments := func(ids []params.MachineStorageId) ([]params.ErrorResult, error) {
-		c.Assert(ids, gc.DeepEquals, expectedAttachmentIds)
-		close(removed)
-		return make([]params.ErrorResult, len(ids)), nil
-	}
-
 	// volume-1 and machine-1 are provisioned.
 	volumeAccessor.provisionedVolumes["volume-1"] = params.Volume{
 		VolumeTag: "volume-1",
@@ -1250,8 +1274,7 @@ func (s *storageProvisionerSuite) TestDetachVolumes(c *gc.C) {
 	args := &workerArgs{
 		volumes: volumeAccessor,
 		life: &mockLifecycleManager{
-			attachmentLife:    attachmentLife,
-			removeAttachments: removeAttachments,
+			attachmentLife: attachmentLife,
 		},
 		registry: s.registry,
 	}
@@ -1268,7 +1291,6 @@ func (s *storageProvisionerSuite) TestDetachVolumes(c *gc.C) {
 		MachineTag: "machine-1", AttachmentTag: "volume-1",
 	}}
 	waitChannel(c, detached, "waiting for volume to be detached")
-	waitChannel(c, removed, "waiting for attachment to be removed")
 }
 
 func (s *storageProvisionerSuite) TestDetachVolumesRetry(c *gc.C) {
@@ -1300,26 +1322,21 @@ func (s *storageProvisionerSuite) TestDetachVolumesRetry(c *gc.C) {
 	clock := &mockClock{}
 	var detachVolumeTimes []time.Time
 
+	detached := make(chan interface{})
 	s.provider.detachVolumesFunc = func(args []storage.VolumeAttachmentParams) ([]error, error) {
 		detachVolumeTimes = append(detachVolumeTimes, clock.Now())
 		if len(detachVolumeTimes) < 10 {
 			return []error{errors.New("badness")}, nil
 		}
+		close(detached)
 		return []error{nil}, nil
-	}
-
-	removed := make(chan interface{})
-	removeAttachments := func(ids []params.MachineStorageId) ([]params.ErrorResult, error) {
-		close(removed)
-		return make([]params.ErrorResult, len(ids)), nil
 	}
 
 	args := &workerArgs{
 		volumes: volumeAccessor,
 		clock:   clock,
 		life: &mockLifecycleManager{
-			attachmentLife:    attachmentLife,
-			removeAttachments: removeAttachments,
+			attachmentLife: attachmentLife,
 		},
 		registry: s.registry,
 	}
@@ -1332,7 +1349,7 @@ func (s *storageProvisionerSuite) TestDetachVolumesRetry(c *gc.C) {
 		MachineTag:    machine.String(),
 		AttachmentTag: volume.String(),
 	}}
-	waitChannel(c, removed, "waiting for attachment to be removed")
+	waitChannel(c, detached, "waiting for attachment to be detached")
 	c.Assert(detachVolumeTimes, gc.HasLen, 10)
 
 	// The first attempt should have been immediate: T0.
@@ -1366,6 +1383,37 @@ func (s *storageProvisionerSuite) TestDetachVolumesRetry(c *gc.C) {
 		{Tag: "volume-1", Status: "detaching", Info: "badness"},
 		{Tag: "volume-1", Status: "detached", Info: ""},
 	})
+}
+
+func (s *storageProvisionerSuite) TestRemoveDeadFilesystemAttachments(c *gc.C) {
+	removed := make(chan interface{})
+	removeAttachments := func(ids []params.MachineStorageId) ([]params.ErrorResult, error) {
+		defer close(removed)
+		c.Assert(ids, gc.DeepEquals, []params.MachineStorageId{{
+			MachineTag:    "machine-0",
+			AttachmentTag: "filesystem-0",
+		}})
+		return make([]params.ErrorResult, len(ids)), nil
+	}
+	attachmentLife := func(ids []params.MachineStorageId) ([]params.LifeResult, error) {
+		return []params.LifeResult{{Life: params.Dead}}, nil
+	}
+
+	args := &workerArgs{
+		life: &mockLifecycleManager{
+			attachmentLife:    attachmentLife,
+			removeAttachments: removeAttachments,
+		},
+		registry: s.registry,
+	}
+	worker := newStorageProvisioner(c, args)
+	defer worker.Wait()
+	defer worker.Kill()
+
+	args.filesystems.attachmentsWatcher.changes <- []watcher.MachineStorageId{{
+		MachineTag: "machine-0", AttachmentTag: "filesystem-0",
+	}}
+	waitChannel(c, removed, "waiting for attachment to be removed")
 }
 
 func (s *storageProvisionerSuite) TestDetachFilesystemsUnattached(c *gc.C) {
@@ -1432,13 +1480,6 @@ func (s *storageProvisionerSuite) TestDetachFilesystems(c *gc.C) {
 		return make([]error, len(args)), nil
 	}
 
-	removed := make(chan interface{})
-	removeAttachments := func(ids []params.MachineStorageId) ([]params.ErrorResult, error) {
-		c.Assert(ids, gc.DeepEquals, expectedAttachmentIds)
-		close(removed)
-		return make([]params.ErrorResult, len(ids)), nil
-	}
-
 	// filesystem-1 and machine-1 are provisioned.
 	filesystemAccessor.provisionedFilesystems["filesystem-1"] = params.Filesystem{
 		FilesystemTag: "filesystem-1",
@@ -1451,8 +1492,7 @@ func (s *storageProvisionerSuite) TestDetachFilesystems(c *gc.C) {
 	args := &workerArgs{
 		filesystems: filesystemAccessor,
 		life: &mockLifecycleManager{
-			attachmentLife:    attachmentLife,
-			removeAttachments: removeAttachments,
+			attachmentLife: attachmentLife,
 		},
 		registry: s.registry,
 	}
@@ -1469,7 +1509,6 @@ func (s *storageProvisionerSuite) TestDetachFilesystems(c *gc.C) {
 		MachineTag: "machine-1", AttachmentTag: "filesystem-1",
 	}}
 	waitChannel(c, detached, "waiting for filesystem to be detached")
-	waitChannel(c, removed, "waiting for attachment to be removed")
 }
 
 func (s *storageProvisionerSuite) TestDestroyVolumes(c *gc.C) {

--- a/worker/storageprovisioner/volume_ops.go
+++ b/worker/storageprovisioner/volume_ops.go
@@ -313,12 +313,6 @@ func detachVolumes(ctx *context, ops map[params.MachineStorageId]*detachVolumeOp
 	}
 	scheduleOperations(ctx, reschedule...)
 	setStatus(ctx, statuses)
-	if err := removeAttachments(ctx, remove); err != nil {
-		return errors.Annotate(err, "removing attachments from state")
-	}
-	for _, id := range remove {
-		delete(ctx.volumeAttachments, id)
-	}
 	return nil
 }
 


### PR DESCRIPTION
## Description of change

A recent change was made to the state package's filesystem and filesystem attachment watchers. The change was to filter the results based on the state of volume attachments. This doesn't work without also watching the volume attachment collection for changes, so that change has been reverted.

In its place, we introduce composite watchers in the apiserver/storageprovisioner/internal/filesystemwatcher package. These watchers compose watchers for model and machine filesystems, and volume attachments, to produce answers that the storage provisioner worker expects.

There are some incidental bug fixes, found while verifying this change:
 - the gce provider's AttachVolumes has been fixed to set DeviceLink instead of DevicePath, as in CreateVolumes
 - the storage provisioner will now react to block device changes when there are incomplete filesystem *attachments*, as well as incomplete filesystems
 - the storage provisioner removes attachments when they are Dead, not immediately after detaching the storage. This avoids an ugly "not found" error.

## QA steps

$ juju bootstrap google
$ juju deploy postgresql --storage pgdata=gce,10G
(wait)
$ juju detach-storage pgdata/0
(wait)
$ juju attach-storage postgresql/0 pgdata/0
(storage should show up as attached)

## Documentation changes

None.

## Bug reference

None.