### PR TITLE
Handle empty model meter status responses.

### DIFF
--- a/apiserver/metricsender/metricsender.go
+++ b/apiserver/metricsender/metricsender.go
@@ -43,12 +43,14 @@ func handleModelResponse(st ModelBackend, modelUUID string, modelResp wireformat
 			logger.Errorf("failed to set unit %q meter status to %v: %v", unitName, status, err)
 		}
 	}
-	err = st.SetModelMeterStatus(
-		modelResp.ModelStatus.Status,
-		modelResp.ModelStatus.Info,
-	)
-	if err != nil {
-		logger.Errorf("failed to set the model meter status: %v", err)
+	if modelResp.ModelStatus.Status != "" {
+		err = st.SetModelMeterStatus(
+			modelResp.ModelStatus.Status,
+			modelResp.ModelStatus.Info,
+		)
+		if err != nil {
+			logger.Errorf("failed to set the model meter status: %v", err)
+		}
 	}
 	return len(modelResp.AcknowledgedBatches)
 }

--- a/apiserver/metricsender/testing/mocksender.go
+++ b/apiserver/metricsender/testing/mocksender.go
@@ -14,8 +14,9 @@ import (
 
 // MockSender implements the metric sender interface.
 type MockSender struct {
-	UnackedBatches map[string]struct{}
-	Data           [][]*wireformat.MetricBatch
+	UnackedBatches      map[string]struct{}
+	Data                [][]*wireformat.MetricBatch
+	MeterStatusResponse string
 }
 
 // Send implements the Send interface.
@@ -35,7 +36,7 @@ func (m *MockSender) Send(d []*wireformat.MetricBatch) (*wireformat.Response, er
 			}
 		}
 		envResponses.Ack(batch.ModelUUID, batch.UUID)
-		envResponses.SetModelStatus(batch.ModelUUID, "RED", "mocked response")
+		envResponses.SetModelStatus(batch.ModelUUID, m.MeterStatusResponse, "mocked response")
 	}
 	return &wireformat.Response{
 		UUID:         respUUID.String(),


### PR DESCRIPTION
## Please provide the following details to expedite Pull Request review:

----

## Description of change
Without this change, the metricsender logs an error when it receives an empty model meter status response.

## QA steps

contact @tasdomas or @cmars 

## Documentation changes

No changes. Completely internal change.

## Bug reference

Bug report is private. Contact @tasdomas or @cmars 
