### PR TITLE
Disable SSH probing on GCE

### DIFF
--- a/cmd/juju/commands/ssh_common.go
+++ b/cmd/juju/commands/ssh_common.go
@@ -399,13 +399,16 @@ func (c *SSHCommon) legacyAddressGetter(entity string) (string, error) {
 
 // reachableAddressGetter dials all addresses of the given entity, returning the
 // first one that succeeds. Only used with SSHClient API facade v2 or later is
-// available.
+// available. It does not try to dial if only one address is available.
 func (c *SSHCommon) reachableAddressGetter(entity string) (string, error) {
 	addresses, err := c.apiClient.AllAddresses(entity)
 	if err != nil {
 		return "", errors.Trace(err)
 	} else if len(addresses) == 0 {
 		return "", network.NoAddressError("available")
+	} else if len(addresses) == 1 {
+		logger.Debugf("Only one SSH address provided (%s), using it without probing", addresses[0])
+		return addresses[0], nil
 	}
 	publicKeys := []string{}
 	if !c.noHostKeyChecks {

--- a/environs/networking.go
+++ b/environs/networking.go
@@ -84,6 +84,9 @@ type Networking interface {
 	// ReleaseContainerAddresses releases the previously allocated
 	// addresses matching the interface details passed in.
 	ReleaseContainerAddresses(interfaces []network.ProviderInterfaceInfo) error
+
+	// SSHAddresses filters provided addresses for addresses usable for SSH
+	SSHAddresses(addresses []network.Address) ([]network.Address, error)
 }
 
 // NetworkingEnviron combines the standard Environ interface with the

--- a/provider/dummy/environs.go
+++ b/provider/dummy/environs.go
@@ -1677,3 +1677,15 @@ func (*environ) ProviderSpaceInfo(space *network.SpaceInfo) (*environs.ProviderS
 func (*environ) AreSpacesRoutable(space1, space2 *environs.ProviderSpaceInfo) (bool, error) {
 	return false, nil
 }
+
+// SSHAddresses implements environs.SSHAddresses.
+// For testing we cut "100.100.100.100" out of this list.
+func (*environ) SSHAddresses(addresses []network.Address) ([]network.Address, error) {
+	var rv []network.Address
+	for _, addr := range addresses {
+		if addr.Value != "100.100.100.100" {
+			rv = append(rv, addr)
+		}
+	}
+	return rv, nil
+}

--- a/provider/ec2/environ.go
+++ b/provider/ec2/environ.go
@@ -1896,3 +1896,8 @@ func (*environ) ProviderSpaceInfo(space *network.SpaceInfo) (*environs.ProviderS
 func (*environ) AreSpacesRoutable(space1, space2 *environs.ProviderSpaceInfo) (bool, error) {
 	return false, nil
 }
+
+// SSHAddresses implements environs.SSHAddresses.
+func (*environ) SSHAddresses(addresses []network.Address) ([]network.Address, error) {
+	return addresses, nil
+}

--- a/provider/gce/environ_network.go
+++ b/provider/gce/environ_network.go
@@ -280,6 +280,19 @@ func (*environ) AreSpacesRoutable(space1, space2 *environs.ProviderSpaceInfo) (b
 	return false, nil
 }
 
+// SSHAddresses implements environs.SSHAddresses.
+// For GCE we want to make sure we're returning only one public address, so that probing won't
+// cause SSHGuard to lock us out
+func (*environ) SSHAddresses(addresses []network.Address) ([]network.Address, error) {
+	bestAddress, ok := network.SelectPublicAddress(addresses)
+	if ok {
+		return []network.Address{bestAddress}, nil
+	} else {
+		// fallback
+		return addresses, nil
+	}
+}
+
 func copyStrings(items []string) []string {
 	if items == nil {
 		return nil

--- a/provider/maas/environ.go
+++ b/provider/maas/environ.go
@@ -2346,3 +2346,8 @@ func (*maasEnviron) ProviderSpaceInfo(space *network.SpaceInfo) (*environs.Provi
 func (*maasEnviron) AreSpacesRoutable(space1, space2 *environs.ProviderSpaceInfo) (bool, error) {
 	return false, nil
 }
+
+// SSHAddresses implements environs.SSHAddresses.
+func (*maasEnviron) SSHAddresses(addresses []network.Address) ([]network.Address, error) {
+	return addresses, nil
+}

--- a/provider/openstack/provider.go
+++ b/provider/openstack/provider.go
@@ -1731,3 +1731,8 @@ func (*Environ) ProviderSpaceInfo(space *network.SpaceInfo) (*environs.ProviderS
 func (*Environ) AreSpacesRoutable(space1, space2 *environs.ProviderSpaceInfo) (bool, error) {
 	return false, nil
 }
+
+// SSHAddresses is specified on environs.SSHAddresses.
+func (*Environ) SSHAddresses(addresses []network.Address) ([]network.Address, error) {
+	return addresses, nil
+}

--- a/provider/oracle/network/environ.go
+++ b/provider/oracle/network/environ.go
@@ -360,3 +360,8 @@ func (Environ) ProviderSpaceInfo(space *network.SpaceInfo) (*environs.ProviderSp
 func (Environ) AreSpacesRoutable(space1, space2 *environs.ProviderSpaceInfo) (bool, error) {
 	return false, nil
 }
+
+// SSHAddresses is defined on the environs.SSHAddresses interface.
+func (*Environ) SSHAddresses(addresses []network.Address) ([]network.Address, error) {
+	return addresses, nil
+}


### PR DESCRIPTION
## Description of change
Due to SSH probing sshguard was triggered on GCE instances. This change causes SSH on GCE to only use one public address, without probing.

## QA steps
Bootstrap on GCE, try juju ssh -m controller 0 a few times, it should work every time (sshguard should not be triggered)

## Documentation changes
juju ssh is not probing all addresses on GCE, only the prefered public one.

## Bug reference
https://bugs.launchpad.net/juju/+bug/1669501