### PR TITLE
Update names dep to bring in CAAS names

### DIFF
--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -96,7 +96,7 @@ gopkg.in/juju/charmrepo.v2-unstable	git	e79aa298df89ea887c9bffec46063c24bfb730f7
 gopkg.in/juju/charmstore.v5-unstable	git	fd1eef3002fc6b6daff5e97efab6f5056d22dcc7	2016-09-16T10:09:07Z
 gopkg.in/juju/environschema.v1	git	7359fc7857abe2b11b5b3e23811a9c64cb6b01e0	2015-11-04T11:58:10Z
 gopkg.in/juju/jujusvg.v2	git	d82160011935ef79fc7aca84aba2c6f74700fe75	2016-06-09T10:52:15Z
-gopkg.in/juju/names.v2	git	8869b97720a9675a8ffbdd506a8f4b72bf720517	2017-03-24T04:25:04Z
+gopkg.in/juju/names.v2	git	0f8ae7499c60de56e4cb4c5eabe2d504615a18ca	2017-05-15T22:48:47Z
 gopkg.in/juju/worker.v1	git	6965b9d826717287bb002e02d1fd4d079978083e	2017-03-08T00:24:58Z
 gopkg.in/macaroon-bakery.v1	git	469b44e6f1f9479e115c8ae879ef80695be624d5	2016-06-22T12:14:21Z
 gopkg.in/macaroon.v1	git	ab3940c6c16510a850e1c2dd628b919f0f3f1464	2015-01-21T11:42:31Z


### PR DESCRIPTION
Bring in recent update to the names package to include tags for CAAS Models.

Signed-off-by: Michael McCracken <mike.mccracken@canonical.com>
