### PR TITLE
state: prevent `using unknown collection "remoteApplications"` error

### DIFF
--- a/state/state.go
+++ b/state/state.go
@@ -1571,7 +1571,15 @@ func applicationByName(st *State, name string) (ApplicationEntity, error) {
 	} else if !featureflag.Enabled(feature.CrossModelRelations) {
 		return nil, err
 	}
-	return st.RemoteApplication(name)
+	remoteApp, remoteErr := st.RemoteApplication(name)
+	if errors.IsNotFound(remoteErr) {
+		// We can't find either an application or a remote application
+		// by that name. Report the missing application, since that's
+		// probably what was intended (and still indicates the problem
+		// for remote applications).
+		return nil, err
+	}
+	return remoteApp, remoteErr
 }
 
 // endpoints returns all endpoints that could be intended by the

--- a/state/state.go
+++ b/state/state.go
@@ -1563,13 +1563,15 @@ func containerScopeOk(st *State, ep1, ep2 Endpoint) (bool, error) {
 }
 
 func applicationByName(st *State, name string) (ApplicationEntity, error) {
-	s, err := st.RemoteApplication(name)
+	app, err := st.Application(name)
 	if err == nil {
-		return s, nil
+		return app, nil
 	} else if err != nil && !errors.IsNotFound(err) {
 		return nil, err
+	} else if !featureflag.Enabled(feature.CrossModelRelations) {
+		return nil, err
 	}
-	return st.Application(name)
+	return st.RemoteApplication(name)
 }
 
 // endpoints returns all endpoints that could be intended by the


### PR DESCRIPTION
## Description of change

The `state/applicationByName` function would always try to get a remote application, and if that wasn't found would get an application instead. Change this to try returning a local application first (this will generally be the right thing), then if that's not found and the cross model flag is set try getting a remote application instead.

If neither are found, we still return the error `application "needle" not found`. This is less confusing for the user, since it's probably what they were intending, and remote applications are also (conceptually) applications so it's not wrong in that case either.

## QA steps

* Bootstrap a controller with the crossmodel flag disabled.
* Deploy some applications and relate them.
* Check that the log contains no messages containing `unknown collection "remoteApplications"`