### PR TITLE
Bug 1690456: validate directory provided by --metadata-url during bootstrap

### DIFF
--- a/cmd/juju/commands/bootstrap_test.go
+++ b/cmd/juju/commands/bootstrap_test.go
@@ -981,11 +981,11 @@ func (s *BootstrapSuite) TestInvalidLocalSource(c *gc.C) {
 
 	stderr := cmdtesting.Stderr(ctx)
 	c.Check(stderr, gc.Matches,
-		"(.|\n)*Looking for packaged Juju agent version 1\\.2\\.0 for amd64\n"+
-			"No packaged binary found, preparing local Juju agent binary(.|\n)*",
+		"Creating Juju controller \"devcontroller\" on dummy/dummy\n"+
+			"Looking for packaged Juju agent version 1.2.0 for amd64\n",
 	)
 	c.Check(s.tw.Log(), jc.LogMatches, []jc.SimpleMessage{
-		{loggo.ERROR, "failed to bootstrap model: cannot package bootstrap agent binary: no agent binaries for you"},
+		{loggo.ERROR, "failed to bootstrap model: no matching tools available"},
 	})
 }
 

--- a/environs/bootstrap/bootstrap.go
+++ b/environs/bootstrap/bootstrap.go
@@ -655,19 +655,54 @@ func isCompatibleVersion(v1, v2 version.Number) bool {
 	return v1.Compare(v2) == 0
 }
 
-// setPrivateMetadataSources sets the default tools metadata source
-// for tools syncing, and adds an image metadata source after verifying
-// the contents.
+// setPrivateMetadataSources verifies the specified metadataDir exists,
+// uses it to set the default agent binary metadata source for agent binaries,
+// and adds an image metadata source after verifying the contents. If the
+// directory ends in tools, only the default tools metadata source will be
+// set. Same for images.
 func setPrivateMetadataSources(metadataDir string) ([]*imagemetadata.ImageMetadata, error) {
-	logger.Infof("Setting default tools and image metadata sources: %s", metadataDir)
-	tools.DefaultBaseURL = metadataDir
+	if _, err := os.Stat(metadataDir); err != nil {
+		if !os.IsNotExist(err) {
+			return nil, errors.Annotate(err, "cannot access simplestreams metadata directory")
+		}
+		return nil, errors.NotFoundf("simplestreams metadata source: %s", metadataDir)
+	}
 
-	imageMetadataDir := filepath.Join(metadataDir, storage.BaseImagesPath)
+	agentBinaryMetadataDir := metadataDir
+	ending := filepath.Base(agentBinaryMetadataDir)
+	if ending != storage.BaseToolsPath {
+		agentBinaryMetadataDir = filepath.Join(metadataDir, storage.BaseToolsPath)
+	}
+	if _, err := os.Stat(agentBinaryMetadataDir); err != nil {
+		if !os.IsNotExist(err) {
+			return nil, errors.Annotate(err, "cannot access agent binary metadata")
+		}
+		logger.Debugf("no agent directory found, using default agent binary metadata source: %s", tools.DefaultBaseURL)
+	} else {
+		if ending == storage.BaseToolsPath {
+			// as the specified metadataDir ended in 'tools'
+			// assume that is the only metadata to find and return
+			tools.DefaultBaseURL = filepath.Dir(metadataDir)
+			logger.Debugf("setting default agent binary metadata source: %s", tools.DefaultBaseURL)
+			return nil, nil
+		} else {
+			tools.DefaultBaseURL = metadataDir
+			logger.Debugf("setting default agent binary metadata source: %s", tools.DefaultBaseURL)
+		}
+	}
+
+	imageMetadataDir := metadataDir
+	ending = filepath.Base(imageMetadataDir)
+	if ending != storage.BaseImagesPath {
+		imageMetadataDir = filepath.Join(metadataDir, storage.BaseImagesPath)
+	}
 	if _, err := os.Stat(imageMetadataDir); err != nil {
 		if !os.IsNotExist(err) {
 			return nil, errors.Annotate(err, "cannot access image metadata")
 		}
 		return nil, nil
+	} else {
+		logger.Debugf("setting default image metadata source: %s", imageMetadataDir)
 	}
 
 	baseURL := fmt.Sprintf("file://%s", filepath.ToSlash(imageMetadataDir))


### PR DESCRIPTION
If the directory ends in 'tools' or images', assume
that only the respective value will be used.  If a high level
directory is listed, check for tools and images in it.  If no
tools are listed, use tools from streams.canonical.com.

## Description of change

Attempting to anticipate what users intend with bootstrap --metadata-source.
* If the directory doesn't exist, fail quickly so the user can retry.
* If the directory does exist, look for tools and images directories inside.
  * If tools does exist, replace the default tool location.
  * If tools doesn't exist, leave the default tools as simple streams.canonical.com....
* If the directory ends in 'images' assume that only image metadata will be found
* If the directory ends in 'tools' assume that only tools metadata will be found

The contents of tools and images are validated further on.

## QA steps

Bootstrap openstack with arm64 nova compute nodes from a host machine with an a
different processor (arm64), don't use a nightly build to test as tools for nightly are not
on streams.canonical.com. - to verify bug fix.

Unit tests will be updated to verify the listed possibilities.

## Documentation changes

N/A

## Bug reference

https://bugs.launchpad.net/juju/+bug/1690456