### PR TITLE
Implement "juju deploy --attach-storage"

### DIFF
--- a/api/application/client.go
+++ b/api/application/client.go
@@ -108,7 +108,7 @@ type DeployArgs struct {
 // is deployed.
 func (c *Client) Deploy(args DeployArgs) error {
 	if len(args.AttachStorage) > 0 && args.NumUnits != 1 {
-		return errors.Errorf("AttachStorage is non-empty, but NumUnits is %d", args.NumUnits)
+		return errors.New("cannot attach existing storage when more than one unit is requested")
 	}
 	attachStorage := make([]string, len(args.AttachStorage))
 	for i, id := range args.AttachStorage {

--- a/api/application/client_test.go
+++ b/api/application/client_test.go
@@ -125,7 +125,7 @@ func (s *applicationSuite) TestDeployAttachStorageMultipleUnits(c *gc.C) {
 		AttachStorage: []string{"data/0"},
 	}
 	err := client.Deploy(args)
-	c.Assert(err, gc.ErrorMatches, "AttachStorage is non-empty, but NumUnits is 2")
+	c.Assert(err, gc.ErrorMatches, "cannot attach existing storage when more than one unit is requested")
 	c.Assert(called, jc.IsFalse)
 }
 

--- a/apiserver/application/deploy.go
+++ b/apiserver/application/deploy.go
@@ -1,7 +1,7 @@
 // Copyright 2012, 2013 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package juju
+package application
 
 import (
 	"fmt"
@@ -12,6 +12,7 @@ import (
 	"github.com/juju/errors"
 	"gopkg.in/juju/charm.v6-unstable"
 	csparams "gopkg.in/juju/charmrepo.v2-unstable/csclient/params"
+	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/constraints"
 	"github.com/juju/juju/instance"
@@ -33,6 +34,7 @@ type DeployApplicationParams struct {
 	// instead of a machine spec.
 	Placement        []*instance.Placement
 	Storage          map[string]storage.Constraints
+	AttachStorage    []names.StorageTag
 	EndpointBindings map[string]string
 	// Resources is a map of resource name to IDs of pending resources.
 	Resources map[string]string
@@ -52,7 +54,7 @@ type UnitAdder interface {
 }
 
 // DeployApplication takes a charm and various parameters and deploys it.
-func DeployApplication(st ApplicationDeployer, args DeployApplicationParams) (*state.Application, error) {
+func DeployApplication(st ApplicationDeployer, args DeployApplicationParams) (Application, error) {
 	settings, err := args.Charm.Config().ValidateSettings(args.ConfigSettings)
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -79,6 +81,7 @@ func DeployApplication(st ApplicationDeployer, args DeployApplicationParams) (*s
 		Charm:            args.Charm,
 		Channel:          args.Channel,
 		Storage:          stateStorageConstraints(args.Storage),
+		AttachStorage:    args.AttachStorage,
 		Settings:         settings,
 		NumUnits:         args.NumUnits,
 		Placement:        args.Placement,
@@ -90,7 +93,11 @@ func DeployApplication(st ApplicationDeployer, args DeployApplicationParams) (*s
 		asa.Constraints = args.Constraints
 	}
 
-	return st.AddApplication(asa)
+	app, err := st.AddApplication(asa)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return stateApplicationShim{app}, nil
 }
 
 func quoteStrings(vals []string) string {
@@ -157,9 +164,9 @@ func getEffectiveBindingsForCharmMeta(charmMeta *charm.Meta, givenBindings map[s
 	return effectiveBindings, nil
 }
 
-// AddUnits starts n units of the given application using the specified placement
+// addUnits starts n units of the given application using the specified placement
 // directives to allocate the machines.
-func AddUnits(
+func addUnits(
 	unitAssigner UnitAssigner,
 	unitAdder UnitAdder,
 	appName string,

--- a/apiserver/params/params.go
+++ b/apiserver/params/params.go
@@ -223,6 +223,7 @@ type ApplicationDeploy struct {
 	Constraints      constraints.Value              `json:"constraints"`
 	Placement        []*instance.Placement          `json:"placement,omitempty"`
 	Storage          map[string]storage.Constraints `json:"storage,omitempty"`
+	AttachStorage    []string                       `json:"attach-storage,omitempty"`
 	EndpointBindings map[string]string              `json:"endpoint-bindings,omitempty"`
 	Resources        map[string]string              `json:"resources,omitempty"`
 }

--- a/cmd/juju/application/deploy.go
+++ b/cmd/juju/application/deploy.go
@@ -91,9 +91,6 @@ type DeployAPI interface {
 	GetBundle(*charm.URL) (charm.Bundle, error)
 
 	WatchAll() (*api.AllWatcher, error)
-
-	// AddPendingResources(client.AddPendingResourcesArgs) (ids []string, _ error)
-	// DeployResources(cmd.DeployResourcesArgs) (ids []string, _ error)
 }
 
 // The following structs exist purely because Go cannot create a
@@ -267,6 +264,13 @@ type DeployCommand struct {
 	// the storage name defined in that application's charm storage metadata.
 	BundleStorage map[string]map[string]storage.Constraints
 
+	// TODO(axw) move this to UnitCommandBase once we support --attach-storage
+	// on add-unit too.
+	//
+	// AttachStorage is a list of storage IDs, identifying storage to
+	// attach to the unit created by deploy.
+	AttachStorage []string
+
 	// Resources is a map of resource name to filename to be uploaded on deploy.
 	Resources map[string]string
 
@@ -416,7 +420,10 @@ func (c *DeployCommand) Info() *cmd.Info {
 var (
 	// charmOnlyFlags and bundleOnlyFlags are used to validate flags based on
 	// whether we are deploying a charm or a bundle.
-	charmOnlyFlags        = []string{"bind", "config", "constraints", "force", "n", "num-units", "series", "to", "resource"}
+	charmOnlyFlags = []string{
+		"bind", "config", "constraints", "force", "n", "num-units",
+		"series", "to", "resource", "attach-storage",
+	}
 	bundleOnlyFlags       = []string{}
 	modelCommandBaseFlags = []string{"B", "no-browser-login"}
 )
@@ -433,6 +440,7 @@ func (c *DeployCommand) SetFlags(f *gnuflag.FlagSet) {
 	f.StringVar(&c.Series, "series", "", "The series on which to deploy")
 	f.BoolVar(&c.Force, "force", false, "Allow a charm to be deployed to a machine running an unsupported series")
 	f.Var(storageFlag{&c.Storage, &c.BundleStorage}, "storage", "Charm storage constraints")
+	f.Var(attachStorageFlag{&c.AttachStorage}, "attach-storage", "Existing storage to attach to the deployed unit")
 	f.Var(stringMap{&c.Resources}, "resource", "Resource to be uploaded to the controller")
 	f.StringVar(&c.BindToSpaces, "bind", "", "Configure application endpoint bindings to spaces")
 
@@ -445,6 +453,9 @@ func (c *DeployCommand) SetFlags(f *gnuflag.FlagSet) {
 func (c *DeployCommand) Init(args []string) error {
 	if c.Force && c.Series == "" && c.PlacementSpec == "" {
 		return errors.New("--force is only used with --series")
+	}
+	if len(c.AttachStorage) > 0 && c.NumUnits != 1 {
+		return errors.New("--attach-storage cannot be used with -n")
 	}
 	switch len(args) {
 	case 2:
@@ -599,6 +610,7 @@ func (c *DeployCommand) deployCharm(
 		ConfigYAML:       string(configYAML),
 		Placement:        c.Placement,
 		Storage:          c.Storage,
+		AttachStorage:    c.AttachStorage,
 		Resources:        ids,
 		EndpointBindings: c.Bindings,
 	}))

--- a/cmd/juju/application/deploy_test.go
+++ b/cmd/juju/application/deploy_test.go
@@ -94,6 +94,9 @@ var initErrorTests = []struct {
 	}, {
 		args: []string{"charm", "application", "--force"},
 		err:  `--force is only used with --series`,
+	}, {
+		args: []string{"--attach-storage", "foo/0", "-n", "2"},
+		err:  `--attach-storage cannot be used with -n`,
 	},
 }
 
@@ -913,7 +916,7 @@ func (s *DeployCharmStoreSuite) TestAddMetricCredentials(c *gc.C) {
 	}
 	meteredURL := charm.MustParseURL("cs:quantal/metered-1")
 	fakeAPI := vanillaFakeModelAPI(cfgAttrs)
-	withCharmDeployable(fakeAPI, meteredURL, "quantal", charmDir.Meta(), charmDir.Metrics(), true, 1)
+	withCharmDeployable(fakeAPI, meteredURL, "quantal", charmDir.Meta(), charmDir.Metrics(), true, 1, nil)
 
 	cfg, err := config.New(config.NoDefaults, cfgAttrs)
 	c.Assert(err, jc.ErrorIsNil)
@@ -963,7 +966,7 @@ func (s *DeployCharmStoreSuite) TestAddMetricCredentialsDefaultPlan(c *gc.C) {
 	}
 	meteredURL := charm.MustParseURL("cs:quantal/metered-1")
 	fakeAPI := vanillaFakeModelAPI(cfgAttrs)
-	withCharmDeployable(fakeAPI, meteredURL, "quantal", charmDir.Meta(), charmDir.Metrics(), true, 1)
+	withCharmDeployable(fakeAPI, meteredURL, "quantal", charmDir.Meta(), charmDir.Metrics(), true, 1, nil)
 
 	cfg, err := config.New(config.NoDefaults, cfgAttrs)
 	c.Assert(err, jc.ErrorIsNil)
@@ -1010,7 +1013,7 @@ func (s *DeployCharmStoreSuite) TestSetMetricCredentialsNotCalledForUnmeteredCha
 	cfg, err := config.New(config.NoDefaults, cfgAttrs)
 	c.Assert(err, jc.ErrorIsNil)
 	withCharmRepoResolvable(fakeAPI, charmURL, cfg)
-	withCharmDeployable(fakeAPI, charmURL, "quantal", charmDir.Meta(), charmDir.Metrics(), false, 1)
+	withCharmDeployable(fakeAPI, charmURL, "quantal", charmDir.Meta(), charmDir.Metrics(), false, 1, nil)
 
 	deploy := &DeployCommand{
 		Steps: []DeployStep{&RegisterMeteredCharm{}},
@@ -1055,7 +1058,7 @@ summary: summary
 	cfg, err := config.New(config.NoDefaults, cfgAttrs)
 	c.Assert(err, jc.ErrorIsNil)
 	withCharmRepoResolvable(fakeAPI, url, cfg)
-	withCharmDeployable(fakeAPI, url, "quantal", ch.Meta(), ch.Metrics(), true, 1)
+	withCharmDeployable(fakeAPI, url, "quantal", ch.Meta(), ch.Metrics(), true, 1, nil)
 
 	stub := &jujutesting.Stub{}
 	handler := &testMetricsRegistrationHandler{Stub: stub}
@@ -1099,7 +1102,7 @@ summary: summary
 	cfg, err := config.New(config.NoDefaults, cfgAttrs)
 	c.Assert(err, jc.ErrorIsNil)
 	withCharmRepoResolvable(fakeAPI, url, cfg)
-	withCharmDeployable(fakeAPI, url, "quantal", ch.Meta(), ch.Metrics(), true, 1)
+	withCharmDeployable(fakeAPI, url, "quantal", ch.Meta(), ch.Metrics(), true, 1, nil)
 
 	stub := &jujutesting.Stub{}
 	handler := &testMetricsRegistrationHandler{Stub: stub}
@@ -1175,7 +1178,7 @@ func (s *DeployCharmStoreSuite) TestDeployCharmsEndpointNotImplemented(c *gc.C) 
 	cfg, err := config.New(config.NoDefaults, cfgAttrs)
 	c.Assert(err, jc.ErrorIsNil)
 	withCharmRepoResolvable(fakeAPI, meteredCharmURL, cfg)
-	withCharmDeployable(fakeAPI, meteredCharmURL, "quantal", charmDir.Meta(), charmDir.Metrics(), true, 1)
+	withCharmDeployable(fakeAPI, meteredCharmURL, "quantal", charmDir.Meta(), charmDir.Metrics(), true, 1, nil)
 
 	// `"hello registration"\n` (quotes and newline from json
 	// encoding) is returned by the fake http server. This is binary64
@@ -1281,7 +1284,7 @@ func (s *DeployUnitTestSuite) TestDeployLocalCharm_GivesCorrectUserMessage(c *gc
 
 	multiSeriesURL := charm.MustParseURL("local:trusty/multi-series-1")
 	withLocalCharmDeployable(fakeAPI, multiSeriesURL, charmDir)
-	withCharmDeployable(fakeAPI, multiSeriesURL, "trusty", charmDir.Meta(), charmDir.Metrics(), false, 1)
+	withCharmDeployable(fakeAPI, multiSeriesURL, "trusty", charmDir.Meta(), charmDir.Metrics(), false, 1, nil)
 
 	cmd := NewDeployCommandForTest(func() (DeployAPI, error) {
 		return fakeAPI, nil
@@ -1304,7 +1307,7 @@ func (s *DeployUnitTestSuite) TestAddMetricCredentialsDefaultForUnmeteredCharm(c
 	multiSeriesURL := charm.MustParseURL("local:trusty/multi-series-1")
 	fakeAPI := vanillaFakeModelAPI(cfgAttrs)
 	withLocalCharmDeployable(fakeAPI, multiSeriesURL, charmDir)
-	withCharmDeployable(fakeAPI, multiSeriesURL, "trusty", charmDir.Meta(), charmDir.Metrics(), true, 1)
+	withCharmDeployable(fakeAPI, multiSeriesURL, "trusty", charmDir.Meta(), charmDir.Metrics(), true, 1, nil)
 
 	deployCmd := NewDeployCommandForTest(func() (DeployAPI, error) {
 		return fakeAPI, nil
@@ -1331,7 +1334,7 @@ func (s *DeployUnitTestSuite) TestRedeployLocalCharm_SucceedsWhenDeployed(c *gc.
 	})
 	dummyURL := charm.MustParseURL("local:trusty/dummy-0")
 	withLocalCharmDeployable(fakeAPI, dummyURL, charmDir)
-	withCharmDeployable(fakeAPI, dummyURL, "trusty", charmDir.Meta(), charmDir.Metrics(), false, 1)
+	withCharmDeployable(fakeAPI, dummyURL, "trusty", charmDir.Meta(), charmDir.Metrics(), false, 1, nil)
 
 	deployCmd := NewDeployCommandForTest(func() (DeployAPI, error) {
 		return fakeAPI, nil
@@ -1372,6 +1375,7 @@ func (s *DeployUnitTestSuite) TestDeployBundle_OutputsCorrectMessage(c *gc.C) {
 		&charm.Metrics{},
 		false,
 		0,
+		nil,
 	)
 	fakeAPI.Call("AddUnits", "mysql", 1, []*instance.Placement(nil)).Returns([]string{"mysql/0"}, error(nil))
 
@@ -1385,6 +1389,7 @@ func (s *DeployUnitTestSuite) TestDeployBundle_OutputsCorrectMessage(c *gc.C) {
 		&charm.Metrics{},
 		false,
 		0,
+		nil,
 	)
 	fakeAPI.Call("AddUnits", "wordpress", 1, []*instance.Placement(nil)).Returns([]string{"wordpress/0"}, error(nil))
 
@@ -1407,6 +1412,29 @@ func (s *DeployUnitTestSuite) TestDeployBundle_OutputsCorrectMessage(c *gc.C) {
 		`Deploy of bundle completed.`+
 		"\n",
 	)
+}
+
+func (s *DeployUnitTestSuite) TestDeployAttachStorage(c *gc.C) {
+	charmsPath := c.MkDir()
+	charmDir := testcharms.Repo.ClonedDir(charmsPath, "dummy")
+
+	fakeAPI := vanillaFakeModelAPI(map[string]interface{}{
+		"name": "name",
+		"uuid": "deadbeef-0bad-400d-8000-4b1d0d06f00d",
+		"type": "foo",
+	})
+	dummyURL := charm.MustParseURL("local:trusty/dummy-0")
+	withLocalCharmDeployable(fakeAPI, dummyURL, charmDir)
+	withCharmDeployable(
+		fakeAPI, dummyURL, "trusty", charmDir.Meta(), charmDir.Metrics(), false, 1, []string{"foo/0", "bar/1", "baz/2"},
+	)
+
+	cmd := NewDeployCommandForTest(func() (DeployAPI, error) { return fakeAPI, nil }, nil)
+	_, err := cmdtesting.RunCommand(c, cmd, dummyURL.String(),
+		"--attach-storage", "foo/0",
+		"--attach-storage", "bar/1,baz/2",
+	)
+	c.Assert(err, jc.ErrorIsNil)
 }
 
 // fakeDeployAPI is a mock of the API used by the deploy command. It's
@@ -1605,6 +1633,7 @@ func withCharmDeployable(
 	metrics *charm.Metrics,
 	metered bool,
 	numUnits int,
+	attachStorage []string,
 ) {
 	fakeAPI.Call("AddCharm", url, csclientparams.Channel("")).Returns(error(nil))
 	fakeAPI.Call("CharmInfo", url.String()).Returns(
@@ -1620,6 +1649,7 @@ func withCharmDeployable(
 		ApplicationName: url.Name,
 		Series:          series,
 		NumUnits:        numUnits,
+		AttachStorage:   attachStorage,
 	}).Returns(error(nil))
 	fakeAPI.Call("IsMetered", url.String()).Returns(metered, error(nil))
 

--- a/cmd/juju/application/flags.go
+++ b/cmd/juju/application/flags.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/juju/errors"
+	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/storage"
 )
@@ -75,6 +76,29 @@ func (f storageFlag) String() string {
 		}
 	}
 	return strings.Join(strs, " ")
+}
+
+type attachStorageFlag struct {
+	storageIDs *[]string
+}
+
+// Set implements gnuflag.Value.Set.
+func (f attachStorageFlag) Set(s string) error {
+	if s == "" {
+		return nil
+	}
+	for _, id := range strings.Split(s, ",") {
+		if !names.IsValidStorage(id) {
+			return errors.NotValidf("storage ID %q", id)
+		}
+		*f.storageIDs = append(*f.storageIDs, id)
+	}
+	return nil
+}
+
+// String implements gnuflag.Value.String.
+func (f attachStorageFlag) String() string {
+	return strings.Join(*f.storageIDs, ",")
 }
 
 // stringMap is a type that deserializes a CLI string using gnuflag's Value

--- a/cmd/juju/application/flags_test.go
+++ b/cmd/juju/application/flags_test.go
@@ -93,3 +93,17 @@ func (FlagSuite) TestStorageFlagBundleStorageErrors(c *gc.C) {
 	err := flag.Set("foo")
 	c.Assert(err, gc.ErrorMatches, `expected \[<application>\:]<store>=<constraints>`)
 }
+
+func (FlagSuite) TestAttachStorageFlag(c *gc.C) {
+	var stores []string
+	flag := attachStorageFlag{&stores}
+	err := flag.Set("foo/0,bar/1")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(stores, jc.DeepEquals, []string{"foo/0", "bar/1"})
+}
+
+func (FlagSuite) TestAttachStorageFlagErrors(c *gc.C) {
+	flag := attachStorageFlag{new([]string)}
+	err := flag.Set("zing")
+	c.Assert(err, gc.ErrorMatches, `storage ID "zing" not valid`)
+}

--- a/cmd/jujud/agent/machine_test.go
+++ b/cmd/jujud/agent/machine_test.go
@@ -349,7 +349,7 @@ func (s *MachineSuite) TestManageModel(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	// It should be allocated to a machine, which should then be provisioned.
-	c.Logf("service %q added with 1 unit, waiting for unit %q's machine to be started...", svc.Name(), unit.Name())
+	c.Logf("application %q added with 1 unit, waiting for unit %q's machine to be started...", svc.Name(), unit.Name())
 	c.Check(opRecvTimeout(c, s.State, op, dummy.OpStartInstance{}), gc.NotNil)
 	c.Logf("machine hosting unit %q started, waiting for the unit to be deployed...", unit.Name())
 	s.waitProvisioned(c, unit)

--- a/cmd/jujud/agent/machine_test.go
+++ b/cmd/jujud/agent/machine_test.go
@@ -43,7 +43,6 @@ import (
 	"github.com/juju/juju/environs"
 	envtesting "github.com/juju/juju/environs/testing"
 	"github.com/juju/juju/instance"
-	"github.com/juju/juju/juju"
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/provider/dummy"
 	"github.com/juju/juju/state"
@@ -344,21 +343,23 @@ func (s *MachineSuite) TestManageModel(c *gc.C) {
 	svc := s.AddTestingService(c, "test-service", charm)
 	err := svc.SetExposed()
 	c.Assert(err, jc.ErrorIsNil)
-	units, err := juju.AddUnits(s.State, svc, svc.Name(), 1, nil)
+	unit, err := svc.AddUnit()
+	c.Assert(err, jc.ErrorIsNil)
+	err = s.State.AssignUnit(unit, state.AssignCleanEmpty)
 	c.Assert(err, jc.ErrorIsNil)
 
 	// It should be allocated to a machine, which should then be provisioned.
-	c.Logf("service %q added with 1 unit, waiting for unit %q's machine to be started...", svc.Name(), units[0].Name())
+	c.Logf("service %q added with 1 unit, waiting for unit %q's machine to be started...", svc.Name(), unit.Name())
 	c.Check(opRecvTimeout(c, s.State, op, dummy.OpStartInstance{}), gc.NotNil)
-	c.Logf("machine hosting unit %q started, waiting for the unit to be deployed...", units[0].Name())
-	s.waitProvisioned(c, units[0])
+	c.Logf("machine hosting unit %q started, waiting for the unit to be deployed...", unit.Name())
+	s.waitProvisioned(c, unit)
 
 	// Open a port on the unit; it should be handled by the firewaller.
-	c.Logf("unit %q deployed, opening port tcp/999...", units[0].Name())
-	err = units[0].OpenPort("tcp", 999)
+	c.Logf("unit %q deployed, opening port tcp/999...", unit.Name())
+	err = unit.OpenPort("tcp", 999)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(opRecvTimeout(c, s.State, op, dummy.OpOpenPorts{}), gc.NotNil)
-	c.Logf("unit %q port tcp/999 opened, cleaning up...", units[0].Name())
+	c.Logf("unit %q port tcp/999 opened, cleaning up...", unit.Name())
 
 	err = a.Stop()
 	c.Assert(err, jc.ErrorIsNil)
@@ -394,10 +395,12 @@ func (s *MachineSuite) TestManageModelRunsInstancePoller(c *gc.C) {
 	// Add one unit to a service;
 	charm := s.AddTestingCharm(c, "dummy")
 	svc := s.AddTestingService(c, "test-service", charm)
-	units, err := juju.AddUnits(s.State, svc, svc.Name(), 1, nil)
+	unit, err := svc.AddUnit()
+	c.Assert(err, jc.ErrorIsNil)
+	err = s.State.AssignUnit(unit, state.AssignCleanEmpty)
 	c.Assert(err, jc.ErrorIsNil)
 
-	m, instId := s.waitProvisioned(c, units[0])
+	m, instId := s.waitProvisioned(c, unit)
 	insts, err := s.Environ.Instances([]instance.Id{instId})
 	c.Assert(err, jc.ErrorIsNil)
 	addrs := network.NewAddresses("1.2.3.4")

--- a/environs/jujutest/livetests.go
+++ b/environs/jujutest/livetests.go
@@ -33,7 +33,6 @@ import (
 	envtools "github.com/juju/juju/environs/tools"
 	envtoolstesting "github.com/juju/juju/environs/tools/testing"
 	"github.com/juju/juju/instance"
-	"github.com/juju/juju/juju"
 	"github.com/juju/juju/juju/keys"
 	jujutesting "github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/jujuclient"
@@ -661,9 +660,10 @@ func (t *LiveTests) TestBootstrapAndDeploy(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	svc, err := st.AddApplication(state.AddApplicationArgs{Name: "dummy", Charm: sch})
 	c.Assert(err, jc.ErrorIsNil)
-	units, err := juju.AddUnits(st, svc, "dummy", 1, nil)
+	unit, err := svc.AddUnit()
 	c.Assert(err, jc.ErrorIsNil)
-	unit := units[0]
+	err = st.AssignUnit(unit, state.AssignCleanEmpty)
+	c.Assert(err, jc.ErrorIsNil)
 
 	// Wait for the unit's machine and associated agent to come up
 	// and announce itself.

--- a/juju/package_test.go
+++ b/juju/package_test.go
@@ -1,0 +1,11 @@
+package juju_test
+
+import (
+	stdtesting "testing"
+
+	coretesting "github.com/juju/juju/testing"
+)
+
+func Test(t *stdtesting.T) {
+	coretesting.MgoTestPackage(t)
+}

--- a/state/blockdevices.go
+++ b/state/blockdevices.go
@@ -86,7 +86,7 @@ func setMachineBlockDevices(st modelBackend, machineId string, newInfo []BlockDe
 		ops := []txn.Op{{
 			C:      machinesC,
 			Id:     machineId,
-			Assert: isAliveDoc,
+			Assert: notDeadDoc,
 		}, {
 			C:      blockDevicesC,
 			Id:     machineId,

--- a/state/blockdevices_test.go
+++ b/state/blockdevices_test.go
@@ -75,6 +75,16 @@ func (s *BlockDevicesSuite) TestSetMachineBlockDevicesUpdates(c *gc.C) {
 	})
 }
 
+func (s *BlockDevicesSuite) TestSetMachineBlockDevicesMachineDying(c *gc.C) {
+	err := s.machine.Destroy()
+	c.Assert(err, jc.ErrorIsNil)
+
+	sda := state.BlockDeviceInfo{DeviceName: "sda"}
+	err = s.machine.SetMachineBlockDevices(sda)
+	c.Assert(err, jc.ErrorIsNil)
+	s.assertBlockDevices(c, s.machine.MachineTag(), []state.BlockDeviceInfo{sda})
+}
+
 func (s *BlockDevicesSuite) TestSetMachineBlockDevicesUnchanged(c *gc.C) {
 	sda := state.BlockDeviceInfo{DeviceName: "sda"}
 	err := s.machine.SetMachineBlockDevices(sda)

--- a/state/filesystem_test.go
+++ b/state/filesystem_test.go
@@ -735,8 +735,10 @@ func (s *FilesystemStateSuite) TestRemoveFilesystemVolumeBacked(c *gc.C) {
 	// to be detached.
 	assertVolumeAttachmentLife(state.Dying)
 
-	err = s.State.RemoveFilesystem(filesystem.FilesystemTag())
-	c.Assert(err, jc.ErrorIsNil)
+	// Removing the last attachment should cause the filesystem
+	// to be removed, since it is volume-backed and dying.
+	_, err = s.State.Filesystem(filesystem.FilesystemTag())
+	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 	// Removing the filesystem causes the backing-volume to be
 	// destroyed.
 	assertVolumeLife(state.Dying)

--- a/worker/firewaller/firewaller_test.go
+++ b/worker/firewaller/firewaller_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/feature"
 	"github.com/juju/juju/instance"
-	"github.com/juju/juju/juju"
 	jujutesting "github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/provider/dummy"
@@ -151,9 +150,10 @@ func (s *firewallerBaseSuite) assertEnvironPorts(c *gc.C, expected []network.Ing
 }
 
 func (s *firewallerBaseSuite) addUnit(c *gc.C, app *state.Application) (*state.Unit, *state.Machine) {
-	units, err := juju.AddUnits(s.State, app, app.Name(), 1, nil)
+	u, err := app.AddUnit()
 	c.Assert(err, jc.ErrorIsNil)
-	u := units[0]
+	err = s.State.AssignUnit(u, state.AssignCleanEmpty)
+	c.Assert(err, jc.ErrorIsNil)
 	id, err := u.AssignedMachineId()
 	c.Assert(err, jc.ErrorIsNil)
 	m, err := s.State.Machine(id)

--- a/worker/storageprovisioner/filesystem_ops.go
+++ b/worker/storageprovisioner/filesystem_ops.go
@@ -321,6 +321,12 @@ func detachFilesystems(ctx *context, ops map[params.MachineStorageId]*detachFile
 	}
 	scheduleOperations(ctx, reschedule...)
 	setStatus(ctx, statuses)
+	if err := removeAttachments(ctx, remove); err != nil {
+		return errors.Annotate(err, "removing attachments from state")
+	}
+	for _, id := range remove {
+		delete(ctx.filesystemAttachments, id)
+	}
 	return nil
 }
 

--- a/worker/storageprovisioner/internal/schedule/schedule.go
+++ b/worker/storageprovisioner/internal/schedule/schedule.go
@@ -34,7 +34,6 @@ func NewSchedule(clock clock.Clock) *Schedule {
 // has been reached. If there are no scheduled items, nil is returned.
 func (s *Schedule) Next() <-chan time.Time {
 	if len(s.items) > 0 {
-		// TODO(fwereade): 2016-03-17 lp:1558657
 		return s.time.After(s.items[0].t.Sub(s.time.Now()))
 	}
 	return nil

--- a/worker/storageprovisioner/volume_events.go
+++ b/worker/storageprovisioner/volume_events.go
@@ -63,8 +63,10 @@ func volumeAttachmentsChanged(ctx *context, watcherIds []watcher.MachineStorageI
 		return errors.Trace(err)
 	}
 	logger.Debugf("volume attachments alive: %v, dying: %v, dead: %v", alive, dying, dead)
-	if err := processDeadVolumeAttachments(ctx, dead); err != nil {
-		return errors.Annotate(err, "removing dead volume attachments")
+	if len(dead) != 0 {
+		// We should not see dead volume attachments;
+		// attachments go directly from Dying to removed.
+		logger.Warningf("unexpected dead volume attachments: %v", dead)
 	}
 	if len(alive)+len(dying) == 0 {
 		return nil
@@ -75,7 +77,7 @@ func volumeAttachmentsChanged(ctx *context, watcherIds []watcher.MachineStorageI
 	ids = append(alive, dying...)
 	volumeAttachmentResults, err := ctx.config.Volumes.VolumeAttachments(ids)
 	if err != nil {
-		return errors.Annotate(err, "getting volume attachment information")
+		return errors.Annotatef(err, "getting volume attachment information")
 	}
 
 	// Deprovision Dying volume attachments.
@@ -197,18 +199,6 @@ func processDeadVolumes(ctx *context, tags []names.VolumeTag, volumeResults []pa
 	}
 	if err := removeEntities(ctx, remove); err != nil {
 		return errors.Annotate(err, "removing volumes from state")
-	}
-	return nil
-}
-
-// processDeadVolumeAttachments processes the IDs for Dead volume attachments,
-// removing the volume attachments from state.
-func processDeadVolumeAttachments(ctx *context, ids []params.MachineStorageId) error {
-	if err := removeAttachments(ctx, ids); err != nil {
-		return errors.Annotate(err, "removing attachments from state")
-	}
-	for _, id := range ids {
-		delete(ctx.volumeAttachments, id)
 	}
 	return nil
 }

--- a/worker/storageprovisioner/volume_ops.go
+++ b/worker/storageprovisioner/volume_ops.go
@@ -313,6 +313,12 @@ func detachVolumes(ctx *context, ops map[params.MachineStorageId]*detachVolumeOp
 	}
 	scheduleOperations(ctx, reschedule...)
 	setStatus(ctx, statuses)
+	if err := removeAttachments(ctx, remove); err != nil {
+		return errors.Annotate(err, "removing attachments from state")
+	}
+	for _, id := range remove {
+		delete(ctx.volumeAttachments, id)
+	}
 	return nil
 }
 


### PR DESCRIPTION
## Description of change

This branch adds the --attach-storage flag to the "juju deploy" command, along with the corresponding API and API server changes. The state changes were made in a previous branch. With this change, it is possible to attach existing storage to the initial unit of an application.

There are a few fixes bundled in here as separate commits:
 - revert the changes to handling Dead volume/filesystem attachments. Machine storage attachments go from Alive to Dying, and Dying to removed. There is no Dead state.
 - modify the preconditions for block device updates so that they can still occur for Dying, but not Dead, machines. A Dying machine may still require block device updates to clean up storage (e.g. to detach a volume-backed filesystem).
 - add short-circuit removal of volume-backed filesystems. Once a volume-backed filesystem is detached, it has no responsible storage provisioner. Thus, destroying a detached volume-backed filesystem should cause it to be removed immediately; the contents will be destroyed along with the volume.

## QA steps

1. juju bootstrap (tested with aws and google; google assumed below)
2. juju deploy postgresql --storage pgdata=gce,10G
3. juju ssh postgresql/0
$ sudo -u postgres psql
> CREATE TABLE FOO(bar VARCHAR);
> INSERT INTO FOO VALUES('baz');
4. juju remove-application postgresql
5. juju deploy postgresql pg2 --attach-storage pgdata/0 --to zone=<same availability zone as postgresql/0 was deployed to>
6. juju ssh pg2/0
$ sudo -u postgres psql
> SELECT * FROM FOO;
(check for previously inserted row)
7. juju destroy-controller -y

NOTE: it is a current limitation that the AZ must be explicitly specified. This limitation will be addressed before 2.3 is released.

## Documentation changes

Yes, we will need to add documentation of the new --attach-storage flag. It accepts a list of detached storage IDs, which will be attached to the initial unit of the application. This flag may not be used with "-n".

## Bug reference

None.