### PR TITLE
Only controller superusers can set a model log level to trace

### DIFF
--- a/api/keymanager/client_test.go
+++ b/api/keymanager/client_test.go
@@ -37,7 +37,7 @@ func (s *keymanagerSuite) SetUpTest(c *gc.C) {
 }
 
 func (s *keymanagerSuite) setAuthorisedKeys(c *gc.C, keys string) {
-	err := s.BackingState.UpdateModelConfig(map[string]interface{}{"authorized-keys": keys}, nil, nil)
+	err := s.BackingState.UpdateModelConfig(map[string]interface{}{"authorized-keys": keys}, nil)
 	c.Assert(err, jc.ErrorIsNil)
 }
 

--- a/api/keyupdater/authorisedkeys_test.go
+++ b/api/keyupdater/authorisedkeys_test.go
@@ -56,7 +56,7 @@ func (s *keyupdaterSuite) TestAuthorisedKeys(c *gc.C) {
 }
 
 func (s *keyupdaterSuite) setAuthorisedKeys(c *gc.C, keys string) {
-	err := s.BackingState.UpdateModelConfig(map[string]interface{}{"authorized-keys": keys}, nil, nil)
+	err := s.BackingState.UpdateModelConfig(map[string]interface{}{"authorized-keys": keys}, nil)
 	c.Assert(err, jc.ErrorIsNil)
 }
 

--- a/api/logger/logger_test.go
+++ b/api/logger/logger_test.go
@@ -52,7 +52,7 @@ func (s *loggerSuite) TestLoggingConfig(c *gc.C) {
 }
 
 func (s *loggerSuite) setLoggingConfig(c *gc.C, loggingConfig string) {
-	err := s.BackingState.UpdateModelConfig(map[string]interface{}{"logging-config": loggingConfig}, nil, nil)
+	err := s.BackingState.UpdateModelConfig(map[string]interface{}{"logging-config": loggingConfig}, nil)
 	c.Assert(err, jc.ErrorIsNil)
 }
 

--- a/api/testing/environwatcher.go
+++ b/api/testing/environwatcher.go
@@ -57,24 +57,24 @@ func (s *ModelWatcherTests) TestWatchForModelConfigChanges(c *gc.C) {
 
 	// Change the model configuration by updating an existing attribute, check it's detected.
 	newAttrs := map[string]interface{}{"logging-config": "juju=ERROR"}
-	err = s.state.UpdateModelConfig(newAttrs, nil, nil)
+	err = s.state.UpdateModelConfig(newAttrs, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	wc.AssertOneChange()
 
 	// Change the model configuration by adding a new attribute, check it's detected.
 	newAttrs = map[string]interface{}{"foo": "bar"}
-	err = s.state.UpdateModelConfig(newAttrs, nil, nil)
+	err = s.state.UpdateModelConfig(newAttrs, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	wc.AssertOneChange()
 
 	// Change the model configuration by removing an attribute, check it's detected.
-	err = s.state.UpdateModelConfig(map[string]interface{}{}, []string{"foo"}, nil)
+	err = s.state.UpdateModelConfig(map[string]interface{}{}, []string{"foo"})
 	c.Assert(err, jc.ErrorIsNil)
 	wc.AssertOneChange()
 
 	// Change it back to the original config.
 	oldAttrs := map[string]interface{}{"logging-config": envConfig.AllAttrs()["logging-config"]}
-	err = s.state.UpdateModelConfig(oldAttrs, nil, nil)
+	err = s.state.UpdateModelConfig(oldAttrs, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	wc.AssertOneChange()
 }

--- a/apiserver/application/application_test.go
+++ b/apiserver/application/application_test.go
@@ -961,7 +961,7 @@ func (s *applicationSuite) TestSpecializeStoreOnDeployApplicationSetCharmAndAddC
 		return repo
 	})
 	attrs := map[string]interface{}{"test-mode": true}
-	err := s.State.UpdateModelConfig(attrs, nil, nil)
+	err := s.State.UpdateModelConfig(attrs, nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Check that the store's test mode is enabled when calling application Deploy.

--- a/apiserver/client/api_test.go
+++ b/apiserver/client/api_test.go
@@ -376,7 +376,7 @@ func (s *baseSuite) setUpScenario(c *gc.C) (entities []names.Tag) {
 	setDefaultPassword(c, u)
 	add(u)
 	err = s.State.UpdateModelConfig(map[string]interface{}{
-		config.AgentVersionKey: "1.2.3"}, nil, nil)
+		config.AgentVersionKey: "1.2.3"}, nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	u = s.Factory.MakeUser(c, &factory.UserParams{Name: "other"})

--- a/apiserver/client/backend.go
+++ b/apiserver/client/backend.go
@@ -72,7 +72,7 @@ type Backend interface {
 	SetModelConstraints(constraints.Value) error
 	Subnet(string) (*state.Subnet, error)
 	Unit(string) (Unit, error)
-	UpdateModelConfig(map[string]interface{}, []string, state.ValidateConfigFunc) error
+	UpdateModelConfig(map[string]interface{}, []string, ...state.ValidateConfigFunc) error
 	Watch(params state.WatchParams) *state.Multiwatcher
 }
 

--- a/apiserver/client/client_test.go
+++ b/apiserver/client/client_test.go
@@ -1045,7 +1045,7 @@ func (s *clientSuite) TestClientAddMachineInsideMachine(c *gc.C) {
 // updateConfig sets config variable with given key to a given value
 // Asserts that no errors were encountered.
 func (s *baseSuite) updateConfig(c *gc.C, key string, block bool) {
-	err := s.State.UpdateModelConfig(map[string]interface{}{key: block}, nil, nil)
+	err := s.State.UpdateModelConfig(map[string]interface{}{key: block}, nil)
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -1256,7 +1256,6 @@ func (s *clientSuite) TestProvisioningScriptDisablePackageCommands(c *gc.C) {
 				"enable-os-upgrade":        upgrade,
 				"enable-os-refresh-update": update,
 			},
-			nil,
 			nil,
 		)
 	}

--- a/apiserver/keymanager/keymanager.go
+++ b/apiserver/keymanager/keymanager.go
@@ -180,7 +180,7 @@ func (api *KeyManagerAPI) writeSSHKeys(sshKeys []string) error {
 	// TODO(waigani) 2014-03-17 bug #1293324
 	// Pass in validation to ensure SSH keys
 	// have not changed underfoot
-	err := api.state.UpdateModelConfig(attrs, nil, nil)
+	err := api.state.UpdateModelConfig(attrs, nil)
 	if err != nil {
 		return fmt.Errorf("writing environ config: %v", err)
 	}

--- a/apiserver/keymanager/keymanager_test.go
+++ b/apiserver/keymanager/keymanager_test.go
@@ -89,7 +89,7 @@ func (s *keyManagerSuite) setAuthorisedKeys(c *gc.C, keys string) {
 }
 
 func (s *keyManagerSuite) setAuthorisedKeysForModel(c *gc.C, st *state.State, keys string) {
-	err := st.UpdateModelConfig(map[string]interface{}{"authorized-keys": keys}, nil, nil)
+	err := st.UpdateModelConfig(map[string]interface{}{"authorized-keys": keys}, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	modelConfig, err := st.ModelConfig()
 	c.Assert(err, jc.ErrorIsNil)

--- a/apiserver/keyupdater/authorisedkeys_test.go
+++ b/apiserver/keyupdater/authorisedkeys_test.go
@@ -73,7 +73,7 @@ func (s *authorisedKeysSuite) TestWatchAuthorisedKeysNothing(c *gc.C) {
 }
 
 func (s *authorisedKeysSuite) setAuthorizedKeys(c *gc.C, keys string) {
-	err := s.State.UpdateModelConfig(map[string]interface{}{"authorized-keys": keys}, nil, nil)
+	err := s.State.UpdateModelConfig(map[string]interface{}{"authorized-keys": keys}, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	envConfig, err := s.State.ModelConfig()
 	c.Assert(err, jc.ErrorIsNil)

--- a/apiserver/logger/logger_test.go
+++ b/apiserver/logger/logger_test.go
@@ -73,7 +73,7 @@ func (s *loggerSuite) TestWatchLoggingConfigNothing(c *gc.C) {
 }
 
 func (s *loggerSuite) setLoggingConfig(c *gc.C, loggingConfig string) {
-	err := s.State.UpdateModelConfig(map[string]interface{}{"logging-config": loggingConfig}, nil, nil)
+	err := s.State.UpdateModelConfig(map[string]interface{}{"logging-config": loggingConfig}, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	envConfig, err := s.State.ModelConfig()
 	c.Assert(err, jc.ErrorIsNil)

--- a/apiserver/modelconfig/backend.go
+++ b/apiserver/modelconfig/backend.go
@@ -18,7 +18,7 @@ type Backend interface {
 	ControllerTag() names.ControllerTag
 	ModelTag() names.ModelTag
 	ModelConfigValues() (config.ConfigValues, error)
-	UpdateModelConfig(map[string]interface{}, []string, state.ValidateConfigFunc) error
+	UpdateModelConfig(map[string]interface{}, []string, ...state.ValidateConfigFunc) error
 	SetSLA(level, owner string, credentials []byte) error
 	SLALevel() (string, error)
 }

--- a/apiserver/modelconfig/modelconfig.go
+++ b/apiserver/modelconfig/modelconfig.go
@@ -5,6 +5,7 @@ package modelconfig
 
 import (
 	"github.com/juju/errors"
+	"github.com/juju/loggo"
 
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/facade"
@@ -50,7 +51,7 @@ func (c *ModelConfigAPI) checkCanWrite() error {
 	return nil
 }
 
-func (c *ModelConfigAPI) isAdmin() error {
+func (c *ModelConfigAPI) isControllerAdmin() error {
 	hasAccess, err := c.auth.HasPermission(permission.SuperuserAccess, c.backend.ControllerTag())
 	if err != nil {
 		return errors.Trace(err)
@@ -110,9 +111,40 @@ func (c *ModelConfigAPI) ModelSet(args params.ModelSet) error {
 		}
 		return nil
 	}
+	// Only controller admins can set trace level debugging on a model.
+	checkLogTrace := func(updateAttrs map[string]interface{}, removeAttrs []string, oldConfig *config.Config) error {
+		spec, ok := updateAttrs["logging-config"]
+		if !ok {
+			return nil
+		}
+		logCfg, err := loggo.ParseConfigString(spec.(string))
+		if err != nil {
+			return errors.Trace(err)
+		}
+		// Does at least one package have TRACE level logging requested.
+		haveTrace := false
+		for _, level := range logCfg {
+			haveTrace = level == loggo.TRACE
+			if haveTrace {
+				break
+			}
+		}
+		// No TRACE level requested, so no need to check for admin.
+		if !haveTrace {
+			return nil
+		}
+		if err := c.isControllerAdmin(); err != nil {
+			if errors.Cause(err) != common.ErrPerm {
+				return errors.Trace(err)
+			}
+			return errors.New("only controller admins can set a model's logging level to TRACE")
+		}
+		return nil
+	}
+
 	// Replace any deprecated attributes with their new values.
 	attrs := config.ProcessDeprecatedAttributes(args.Config)
-	return c.backend.UpdateModelConfig(attrs, nil, checkAgentVersion)
+	return c.backend.UpdateModelConfig(attrs, nil, checkAgentVersion, checkLogTrace)
 }
 
 // ModelUnset implements the server-side part of the
@@ -124,7 +156,7 @@ func (c *ModelConfigAPI) ModelUnset(args params.ModelUnset) error {
 	if err := c.check.ChangeAllowed(); err != nil {
 		return errors.Trace(err)
 	}
-	return c.backend.UpdateModelConfig(nil, args.Keys, nil)
+	return c.backend.UpdateModelConfig(nil, args.Keys)
 }
 
 // SetSLALevel sets the sla level on the model.

--- a/apiserver/modelconfig/modelconfig_test.go
+++ b/apiserver/modelconfig/modelconfig_test.go
@@ -126,8 +126,46 @@ func (s *modelconfigSuite) TestModelSetCannotChangeAgentVersion(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 }
 
+func (s *modelconfigSuite) TestAdminCanSetLogTrace(c *gc.C) {
+	args := params.ModelSet{
+		map[string]interface{}{"logging-config": "<root>=DEBUG;somepackage=TRACE"},
+	}
+	err := s.api.ModelSet(args)
+	c.Assert(err, jc.ErrorIsNil)
+
+	result, err := s.api.ModelGet()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result.Config["logging-config"].Value, gc.Equals, "<root>=DEBUG;somepackage=TRACE")
+}
+
+func (s *modelconfigSuite) TestUserCanSetLogNoTrace(c *gc.C) {
+	args := params.ModelSet{
+		map[string]interface{}{"logging-config": "<root>=DEBUG;somepackage=ERROR"},
+	}
+	apiUser := names.NewUserTag("fred")
+	s.authorizer.Tag = apiUser
+	s.authorizer.HasWriteTag = apiUser
+	err := s.api.ModelSet(args)
+	c.Assert(err, jc.ErrorIsNil)
+
+	result, err := s.api.ModelGet()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result.Config["logging-config"].Value, gc.Equals, "<root>=DEBUG;somepackage=ERROR")
+}
+
+func (s *modelconfigSuite) TestUserCannotSetLogTrace(c *gc.C) {
+	args := params.ModelSet{
+		map[string]interface{}{"logging-config": "<root>=DEBUG;somepackage=TRACE"},
+	}
+	apiUser := names.NewUserTag("fred")
+	s.authorizer.Tag = apiUser
+	s.authorizer.HasWriteTag = apiUser
+	err := s.api.ModelSet(args)
+	c.Assert(err, gc.ErrorMatches, `only controller admins can set a model's logging level to TRACE`)
+}
+
 func (s *modelconfigSuite) TestModelUnset(c *gc.C) {
-	err := s.backend.UpdateModelConfig(map[string]interface{}{"abc": 123}, nil, nil)
+	err := s.backend.UpdateModelConfig(map[string]interface{}{"abc": 123}, nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	args := params.ModelUnset{[]string{"abc"}}
@@ -137,7 +175,7 @@ func (s *modelconfigSuite) TestModelUnset(c *gc.C) {
 }
 
 func (s *modelconfigSuite) TestBlockModelUnset(c *gc.C) {
-	err := s.backend.UpdateModelConfig(map[string]interface{}{"abc": 123}, nil, nil)
+	err := s.backend.UpdateModelConfig(map[string]interface{}{"abc": 123}, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	s.blockAllChanges(c, "TestBlockModelUnset")
 
@@ -169,10 +207,9 @@ func (m *mockBackend) ModelConfigValues() (config.ConfigValues, error) {
 	return m.cfg, nil
 }
 
-func (m *mockBackend) UpdateModelConfig(update map[string]interface{}, remove []string, validate state.ValidateConfigFunc) error {
-	if validate != nil {
-		err := validate(update, remove, m.old)
-		if err != nil {
+func (m *mockBackend) UpdateModelConfig(update map[string]interface{}, remove []string, validate ...state.ValidateConfigFunc) error {
+	for _, validateFunc := range validate {
+		if err := validateFunc(update, remove, m.old); err != nil {
 			return err
 		}
 	}

--- a/apiserver/provisioner/provisioner_test.go
+++ b/apiserver/provisioner/provisioner_test.go
@@ -983,7 +983,7 @@ func (s *withoutControllerSuite) TestSetInstanceInfo(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	err = s.State.UpdateModelConfig(map[string]interface{}{
 		"storage-default-block-source": "static-pool",
-	}, nil, nil)
+	}, nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Provision machine 0 first.
@@ -1173,7 +1173,7 @@ func (s *withoutControllerSuite) TestContainerConfig(c *gc.C) {
 		"allow-lxd-loop-mounts": true,
 		"apt-mirror":            "http://example.mirror.com",
 	}
-	err := s.State.UpdateModelConfig(attrs, nil, nil)
+	err := s.State.UpdateModelConfig(attrs, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	expectedAPTProxy := proxy.Settings{
 		Http:    "http://proxy.example.com:9000",

--- a/apiserver/retrystrategy/retrystrategy_test.go
+++ b/apiserver/retrystrategy/retrystrategy_test.go
@@ -119,7 +119,7 @@ func (s *retryStrategySuite) TestRetryStrategy(c *gc.C) {
 }
 
 func (s *retryStrategySuite) setRetryStrategy(c *gc.C, automaticallyRetryHooks bool) {
-	err := s.State.UpdateModelConfig(map[string]interface{}{"automatically-retry-hooks": automaticallyRetryHooks}, nil, nil)
+	err := s.State.UpdateModelConfig(map[string]interface{}{"automatically-retry-hooks": automaticallyRetryHooks}, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	envConfig, err := s.State.ModelConfig()
 	c.Assert(err, jc.ErrorIsNil)

--- a/cmd/juju/application/deploy_test.go
+++ b/cmd/juju/application/deploy_test.go
@@ -172,7 +172,7 @@ func (s *DeploySuite) TestDeployFromPathOldCharm(c *gc.C) {
 func (s *DeploySuite) TestDeployFromPathOldCharmMissingSeries(c *gc.C) {
 	// Update the model default series to be unset.
 	updateAttrs := map[string]interface{}{"default-series": ""}
-	err := s.State.UpdateModelConfig(updateAttrs, nil, nil)
+	err := s.State.UpdateModelConfig(updateAttrs, nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	path := testcharms.Repo.ClonedDirPath(s.CharmsPath, "dummy")
@@ -193,7 +193,7 @@ func (s *DeploySuite) TestDeployFromPathDefaultSeries(c *gc.C) {
 	// and yet, here, the model defaults to the series "trusty". This test
 	// asserts that the model's default takes precedence.
 	updateAttrs := map[string]interface{}{"default-series": "trusty"}
-	err := s.State.UpdateModelConfig(updateAttrs, nil, nil)
+	err := s.State.UpdateModelConfig(updateAttrs, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	path := testcharms.Repo.ClonedDirPath(s.CharmsPath, "multi-series")
 	_, err = runDeploy(c, path)

--- a/cmd/juju/commands/ssh_unix_test.go
+++ b/cmd/juju/commands/ssh_unix_test.go
@@ -195,7 +195,7 @@ func (s *SSHSuite) TestSSHCommandModelConfigProxySSH(c *gc.C) {
 	s.setupModel(c)
 
 	// Setting proxy-ssh=true in the environment overrides --proxy.
-	err := s.State.UpdateModelConfig(map[string]interface{}{"proxy-ssh": true}, nil, nil)
+	err := s.State.UpdateModelConfig(map[string]interface{}{"proxy-ssh": true}, nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.setForceAPIv1(true)

--- a/cmd/juju/commands/sshkeys_test.go
+++ b/cmd/juju/commands/sshkeys_test.go
@@ -70,7 +70,7 @@ func (s *keySuiteBase) SetUpTest(c *gc.C) {
 
 func (s *keySuiteBase) setAuthorizedKeys(c *gc.C, keys ...string) {
 	keyString := strings.Join(keys, "\n")
-	err := s.State.UpdateModelConfig(map[string]interface{}{"authorized-keys": keyString}, nil, nil)
+	err := s.State.UpdateModelConfig(map[string]interface{}{"authorized-keys": keyString}, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	envConfig, err := s.State.ModelConfig()
 	c.Assert(err, jc.ErrorIsNil)

--- a/cmd/juju/commands/upgradejuju_test.go
+++ b/cmd/juju/commands/upgradejuju_test.go
@@ -332,7 +332,7 @@ func (s *UpgradeJujuSuite) TestUpgradeJuju(c *gc.C) {
 			"agent-version":      test.agentVersion,
 			"agent-metadata-url": "file://" + toolsDir + "/tools",
 		}
-		err := s.State.UpdateModelConfig(updateAttrs, nil, nil)
+		err := s.State.UpdateModelConfig(updateAttrs, nil)
 		c.Assert(err, jc.ErrorIsNil)
 		versions := make([]version.Binary, len(test.tools))
 		for i, v := range test.tools {
@@ -424,7 +424,7 @@ func (s *UpgradeJujuSuite) Reset(c *gc.C) {
 		"default-series": "raring",
 		"agent-version":  "1.2.3",
 	}
-	err := s.State.UpdateModelConfig(updateAttrs, nil, nil)
+	err := s.State.UpdateModelConfig(updateAttrs, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	s.PatchValue(&sync.BuildAgentTarball, toolstesting.GetMockBuildTools(c))
 
@@ -629,7 +629,7 @@ func (s *UpgradeJujuSuite) setUpEnvAndTools(c *gc.C, currentVersion string, agen
 		"agent-metadata-url": "file://" + toolsDir + "/tools",
 	}
 
-	err := s.State.UpdateModelConfig(updateAttrs, nil, nil)
+	err := s.State.UpdateModelConfig(updateAttrs, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	versions := make([]version.Binary, len(tools))
 	for i, v := range tools {

--- a/cmd/jujud/agent/machine_test.go
+++ b/cmd/jujud/agent/machine_test.go
@@ -769,7 +769,7 @@ func (s *MachineSuite) TestMachineAgentRunsAuthorisedKeysWorker(c *gc.C) {
 
 	// Update the keys in the environment.
 	sshKey := sshtesting.ValidKeyOne.Key + " user@host"
-	err := s.BackingState.UpdateModelConfig(map[string]interface{}{"authorized-keys": sshKey}, nil, nil)
+	err := s.BackingState.UpdateModelConfig(map[string]interface{}{"authorized-keys": sshKey}, nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Wait for ssh keys file to be updated.
@@ -1145,7 +1145,7 @@ func (s *MachineSuite) setupIgnoreAddresses(c *gc.C, expectedIgnoreValue bool) c
 	})
 
 	attrs := coretesting.Attrs{"ignore-machine-addresses": expectedIgnoreValue}
-	err := s.BackingState.UpdateModelConfig(attrs, nil, nil)
+	err := s.BackingState.UpdateModelConfig(attrs, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	return ignoreAddressCh
 }

--- a/environs/manual/sshprovisioner/provisioner_test.go
+++ b/environs/manual/sshprovisioner/provisioner_test.go
@@ -164,7 +164,7 @@ func (s *provisionerSuite) TestProvisioningScript(c *gc.C) {
 	err = s.State.UpdateModelConfig(
 		map[string]interface{}{
 			"enable-os-upgrade": false,
-		}, nil, nil)
+		}, nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	icfg, err := client.InstanceConfig(s.State, machineId, agent.BootstrapNonce, "/var/lib/juju")

--- a/environs/testing/tools.go
+++ b/environs/testing/tools.go
@@ -563,6 +563,6 @@ var BootstrapToolsTests = []BootstrapToolsTest{
 	}}
 
 func SetSSLHostnameVerification(c *gc.C, st *state.State, SSLHostnameVerification bool) {
-	err := st.UpdateModelConfig(map[string]interface{}{"ssl-hostname-verification": SSLHostnameVerification}, nil, nil)
+	err := st.UpdateModelConfig(map[string]interface{}{"ssl-hostname-verification": SSLHostnameVerification}, nil)
 	c.Assert(err, jc.ErrorIsNil)
 }

--- a/featuretests/cmd_juju_model_test.go
+++ b/featuretests/cmd_juju_model_test.go
@@ -109,7 +109,7 @@ func (s *cmdModelSuite) TestModelUsersCmd(c *gc.C) {
 }
 
 func (s *cmdModelSuite) TestModelConfigGet(c *gc.C) {
-	err := s.State.UpdateModelConfig(map[string]interface{}{"special": "known"}, nil, nil)
+	err := s.State.UpdateModelConfig(map[string]interface{}{"special": "known"}, nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	context := s.run(c, "model-config", "special")
@@ -122,7 +122,7 @@ func (s *cmdModelSuite) TestModelConfigSet(c *gc.C) {
 }
 
 func (s *cmdModelSuite) TestModelConfigReset(c *gc.C) {
-	err := s.State.UpdateModelConfig(map[string]interface{}{"special": "known"}, nil, nil)
+	err := s.State.UpdateModelConfig(map[string]interface{}{"special": "known"}, nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.run(c, "model-config", "--reset", "special")

--- a/featuretests/syslog_test.go
+++ b/featuretests/syslog_test.go
@@ -124,7 +124,7 @@ func (s *syslogSuite) SetUpTest(c *gc.C) {
 		"syslog-ca-cert":     coretesting.CACert,
 		"syslog-client-cert": coretesting.ServerCert,
 		"syslog-client-key":  coretesting.ServerKey,
-	}, nil, nil)
+	}, nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.logger, err = logsender.InstallBufferedLogWriter(1000)
@@ -218,7 +218,7 @@ func (s *syslogSuite) TestLogRecordForwarded(c *gc.C) {
 
 	err = s.State.UpdateModelConfig(map[string]interface{}{
 		"logforward-enabled": true,
-	}, nil, nil)
+	}, nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.assertLogRecordForwarded(c, s.received)
@@ -260,7 +260,7 @@ func (s *syslogSuite) TestConfigChange(c *gc.C) {
 		"syslog-ca-cert":     coretesting.CACert,
 		"syslog-client-cert": coretesting.ServerCert,
 		"syslog-client-key":  coretesting.ServerKey,
-	}, nil, nil)
+	}, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	s.assertLogRecordForwarded(c, received)
 }

--- a/juju/testing/conn.go
+++ b/juju/testing/conn.go
@@ -727,6 +727,6 @@ func (s *JujuConnSuite) AgentConfigForTag(c *gc.C, tag names.Tag) agent.ConfigSe
 // AssertConfigParameterUpdated updates environment parameter and
 // asserts that no errors were encountered
 func (s *JujuConnSuite) AssertConfigParameterUpdated(c *gc.C, key string, value interface{}) {
-	err := s.BackingState.UpdateModelConfig(map[string]interface{}{key: value}, nil, nil)
+	err := s.BackingState.UpdateModelConfig(map[string]interface{}{key: value}, nil)
 	c.Assert(err, jc.ErrorIsNil)
 }

--- a/juju/testing/repo.go
+++ b/juju/testing/repo.go
@@ -27,7 +27,7 @@ func (s *RepoSuite) SetUpTest(c *gc.C) {
 	s.CharmsPath = c.MkDir()
 	// Change the environ's config to ensure we're using the one in state.
 	updateAttrs := map[string]interface{}{"default-series": series.LatestLts()}
-	err := s.State.UpdateModelConfig(updateAttrs, nil, nil)
+	err := s.State.UpdateModelConfig(updateAttrs, nil)
 	c.Assert(err, jc.ErrorIsNil)
 }
 

--- a/state/allwatcher_internal_test.go
+++ b/state/allwatcher_internal_test.go
@@ -445,7 +445,7 @@ func setApplicationConfigAttr(c *gc.C, app *Application, attr string, val interf
 }
 
 func setModelConfigAttr(c *gc.C, st *State, attr string, val interface{}) {
-	err := st.UpdateModelConfig(map[string]interface{}{attr: val}, nil, nil)
+	err := st.UpdateModelConfig(map[string]interface{}{attr: val}, nil)
 	c.Assert(err, jc.ErrorIsNil)
 }
 

--- a/state/configvalidator_test.go
+++ b/state/configvalidator_test.go
@@ -63,7 +63,7 @@ func (s *ConfigValidatorSuite) updateModelConfig(c *gc.C) error {
 		"authorized-keys": "different-keys",
 		"arbitrary-key":   "shazam!",
 	}
-	return s.State.UpdateModelConfig(updateAttrs, nil, nil)
+	return s.State.UpdateModelConfig(updateAttrs, nil)
 }
 
 func (s *ConfigValidatorSuite) TestConfigValidate(c *gc.C) {

--- a/state/filesystem_test.go
+++ b/state/filesystem_test.go
@@ -45,7 +45,7 @@ func (s *FilesystemStateSuite) TestAddServiceNoPoolDefaultBlock(c *gc.C) {
 	// block with managed fs on top.
 	err := s.State.UpdateModelConfig(map[string]interface{}{
 		"storage-default-block-source": "machinescoped",
-	}, nil, nil)
+	}, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	s.testAddServiceDefaultPool(c, "machinescoped", 0)
 }

--- a/state/initialize_test.go
+++ b/state/initialize_test.go
@@ -361,7 +361,7 @@ func (s *InitializeSuite) testBadModelConfig(c *gc.C, update map[string]interfac
 	st.Close()
 
 	s.openState(c, st.ModelTag())
-	err = s.State.UpdateModelConfig(update, remove, nil)
+	err = s.State.UpdateModelConfig(update, remove)
 	c.Assert(err, gc.ErrorMatches, expect)
 
 	// ModelConfig remains inviolate.

--- a/state/machine_test.go
+++ b/state/machine_test.go
@@ -220,7 +220,7 @@ func (s *MachineSuite) TestMachineIsManualBootstrap(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(manual, jc.IsFalse)
 	attrs := map[string]interface{}{"type": "null"}
-	err = s.State.UpdateModelConfig(attrs, nil, nil)
+	err = s.State.UpdateModelConfig(attrs, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	manual, err = s.machine0.IsManual()
 	c.Assert(err, jc.ErrorIsNil)

--- a/state/modelconfig.go
+++ b/state/modelconfig.go
@@ -276,7 +276,7 @@ type ValidateConfigFunc func(updateAttrs map[string]interface{}, removeAttrs []s
 // UpdateModelConfig adds, updates or removes attributes in the current
 // configuration of the model with the provided updateAttrs and
 // removeAttrs.
-func (st *State) UpdateModelConfig(updateAttrs map[string]interface{}, removeAttrs []string, additionalValidation ValidateConfigFunc) error {
+func (st *State) UpdateModelConfig(updateAttrs map[string]interface{}, removeAttrs []string, additionalValidation ...ValidateConfigFunc) error {
 	if len(updateAttrs)+len(removeAttrs) == 0 {
 		return nil
 	}
@@ -323,8 +323,8 @@ func (st *State) UpdateModelConfig(updateAttrs map[string]interface{}, removeAtt
 	if err != nil {
 		return errors.Trace(err)
 	}
-	if additionalValidation != nil {
-		err = additionalValidation(updateAttrs, removeAttrs, oldConfig)
+	for _, additionalValidationFunc := range additionalValidation {
+		err = additionalValidationFunc(updateAttrs, removeAttrs, oldConfig)
 		if err != nil {
 			return errors.Trace(err)
 		}

--- a/state/modelconfig_test.go
+++ b/state/modelconfig_test.go
@@ -87,6 +87,9 @@ func (s *ModelConfigSuite) TestAdditionalValidation(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, "cannot remove some-attr")
 	err = s.State.UpdateModelConfig(updateAttrs, nil, configValidator3)
 	c.Assert(err, jc.ErrorIsNil)
+	// First error is returned.
+	err = s.State.UpdateModelConfig(updateAttrs, nil, configValidator1, configValidator2)
+	c.Assert(err, gc.ErrorMatches, "cannot change logging-config")
 }
 
 func (s *ModelConfigSuite) TestModelConfig(c *gc.C) {
@@ -96,7 +99,7 @@ func (s *ModelConfigSuite) TestModelConfig(c *gc.C) {
 	}
 	cfg, err := s.State.ModelConfig()
 	c.Assert(err, jc.ErrorIsNil)
-	err = s.State.UpdateModelConfig(attrs, nil, nil)
+	err = s.State.UpdateModelConfig(attrs, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	cfg, err = cfg.Apply(attrs)
 	c.Assert(err, jc.ErrorIsNil)
@@ -184,7 +187,7 @@ func (s *ModelConfigSuite) TestComposeNewModelConfigRegionInherits(c *gc.C) {
 
 func (s *ModelConfigSuite) TestUpdateModelConfigRejectsControllerConfig(c *gc.C) {
 	updateAttrs := map[string]interface{}{"api-port": 1234}
-	err := s.State.UpdateModelConfig(updateAttrs, nil, nil)
+	err := s.State.UpdateModelConfig(updateAttrs, nil)
 	c.Assert(err, gc.ErrorMatches, `cannot set controller attribute "api-port" on a model`)
 }
 
@@ -195,10 +198,10 @@ func (s *ModelConfigSuite) TestUpdateModelConfigRemoveInherited(c *gc.C) {
 		"providerAttr":  "beef", // provider
 		"whimsy-key":    "eggs", // region
 	}
-	err := s.State.UpdateModelConfig(attrs, nil, nil)
+	err := s.State.UpdateModelConfig(attrs, nil)
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = s.State.UpdateModelConfig(nil, []string{"apt-mirror", "arbitrary-key", "providerAttr", "whimsy-key"}, nil)
+	err = s.State.UpdateModelConfig(nil, []string{"apt-mirror", "arbitrary-key", "providerAttr", "whimsy-key"})
 	c.Assert(err, jc.ErrorIsNil)
 	cfg, err := s.State.ModelConfig()
 	c.Assert(err, jc.ErrorIsNil)
@@ -214,7 +217,7 @@ func (s *ModelConfigSuite) TestUpdateModelConfigCoerce(c *gc.C) {
 	attrs := map[string]interface{}{
 		"resource-tags": map[string]string{"a": "b", "c": "d"},
 	}
-	err := s.State.UpdateModelConfig(attrs, nil, nil)
+	err := s.State.UpdateModelConfig(attrs, nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	modelSettings, err := s.State.ReadSettings(state.SettingsC, state.ModelGlobalKey)
@@ -240,13 +243,13 @@ func (s *ModelConfigSuite) TestUpdateModelConfigPreferredOverRemove(c *gc.C) {
 		"arbitrary-key": "shazam!",
 		"providerAttr":  "beef", // provider
 	}
-	err := s.State.UpdateModelConfig(attrs, nil, nil)
+	err := s.State.UpdateModelConfig(attrs, nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	err = s.State.UpdateModelConfig(map[string]interface{}{
 		"apt-mirror":   "http://another-mirror",
 		"providerAttr": "pork",
-	}, []string{"apt-mirror", "arbitrary-key"}, nil)
+	}, []string{"apt-mirror", "arbitrary-key"})
 	c.Assert(err, jc.ErrorIsNil)
 	cfg, err := s.State.ModelConfig()
 	c.Assert(err, jc.ErrorIsNil)
@@ -288,7 +291,7 @@ func (s *ModelConfigSourceSuite) TestModelConfigWhenSetOverridesControllerValue(
 		"authorized-keys": "different-keys",
 		"apt-mirror":      "http://anothermirror",
 	}
-	err := s.State.UpdateModelConfig(attrs, nil, nil)
+	err := s.State.UpdateModelConfig(attrs, nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	cfg, err := s.State.ModelConfig()
@@ -383,7 +386,7 @@ func (s *ModelConfigSourceSuite) TestModelConfigUpdateSource(c *gc.C) {
 		"http-proxy": "http://anotherproxy",
 		"apt-mirror": "http://mirror",
 	}
-	err := s.State.UpdateModelConfig(attrs, nil, nil)
+	err := s.State.UpdateModelConfig(attrs, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	modelCfg, err := s.State.ModelConfig()
 	c.Assert(err, jc.ErrorIsNil)
@@ -576,10 +579,11 @@ func (s *ModelConfigSourceSuite) TestUpdateModelConfigDefaultValuesUnknownRegion
 		Default:    "127.0.0.1,localhost,::1",
 		Controller: nil,
 		Regions: []config.RegionDefaultValue{
-			config.RegionDefaultValue{
+			{
 				Name:  "dummy-region",
-				Value: "dummy-proxy"},
-			config.RegionDefaultValue{
+				Value: "dummy-proxy",
+			}, {
 				Name:  "unused-region",
-				Value: "changed-proxy"}}})
+				Value: "changed-proxy",
+			}}})
 }

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -3596,7 +3596,7 @@ func (s *StateSuite) prepareAgentVersionTests(c *gc.C, st *state.State) (*config
 func (s *StateSuite) changeEnviron(c *gc.C, envConfig *config.Config, name string, value interface{}) {
 	attrs := envConfig.AllAttrs()
 	attrs[name] = value
-	c.Assert(s.State.UpdateModelConfig(attrs, nil, nil), gc.IsNil)
+	c.Assert(s.State.UpdateModelConfig(attrs, nil), gc.IsNil)
 }
 
 func assertAgentVersion(c *gc.C, st *state.State, vers string) {

--- a/state/storage_test.go
+++ b/state/storage_test.go
@@ -430,7 +430,7 @@ func (s *StorageStateSuite) assertAddServiceStorageConstraintsDefaults(c *gc.C, 
 	if pool != "" {
 		err := s.State.UpdateModelConfig(map[string]interface{}{
 			"storage-default-block-source": pool,
-		}, nil, nil)
+		}, nil)
 		c.Assert(err, jc.ErrorIsNil)
 	}
 	ch := s.AddTestingCharm(c, "storage-block")
@@ -532,7 +532,7 @@ func (s *StorageStateSuite) TestAddUnit(c *gc.C) {
 func (s *StorageStateSuite) assertStorageUnitsAdded(c *gc.C) {
 	err := s.State.UpdateModelConfig(map[string]interface{}{
 		"storage-default-block-source": "loop-pool",
-	}, nil, nil)
+	}, nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Each unit added to the application will create storage instances

--- a/state/testing/agent.go
+++ b/state/testing/agent.go
@@ -14,5 +14,5 @@ import (
 // This is similar to state.SetModelAgentVersion but it doesn't require that
 // the model have all agents at the same version already.
 func SetAgentVersion(st *state.State, vers version.Number) error {
-	return st.UpdateModelConfig(map[string]interface{}{"agent-version": vers.String()}, nil, nil)
+	return st.UpdateModelConfig(map[string]interface{}{"agent-version": vers.String()}, nil)
 }

--- a/state/volume_test.go
+++ b/state/volume_test.go
@@ -117,7 +117,7 @@ func (s *VolumeStateSuite) TestAddServiceDefaultPool(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	err = s.State.UpdateModelConfig(map[string]interface{}{
 		"storage-default-block-source": "default-block",
-	}, nil, nil)
+	}, nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	ch := s.AddTestingCharm(c, "storage-block")

--- a/upgrades/environconfig.go
+++ b/upgrades/environconfig.go
@@ -16,7 +16,7 @@ import (
 type environConfigUpdater interface {
 	// UpdateModelConfig atomically updates and removes environment
 	// config attributes to the global state.
-	UpdateModelConfig(map[string]interface{}, []string, state.ValidateConfigFunc) error
+	UpdateModelConfig(map[string]interface{}, []string, ...state.ValidateConfigFunc) error
 }
 
 // environConfigReader is an interface used to read the current environment
@@ -58,7 +58,7 @@ func upgradeModelConfig(
 			removedAttrs = append(removedAttrs, key)
 		}
 	}
-	if err := updater.UpdateModelConfig(newAttrs, removedAttrs, nil); err != nil {
+	if err := updater.UpdateModelConfig(newAttrs, removedAttrs); err != nil {
 		return errors.Annotate(err, "updating config in state")
 	}
 	return nil

--- a/upgrades/environconfig_test.go
+++ b/upgrades/environconfig_test.go
@@ -43,7 +43,7 @@ func (s *upgradeModelConfigSuite) SetUpTest(c *gc.C) {
 	})
 
 	s.updater = updateModelConfigFunc(func(
-		update map[string]interface{}, remove []string, validate state.ValidateConfigFunc,
+		update map[string]interface{}, remove []string, validate ...state.ValidateConfigFunc,
 	) error {
 		s.stub.AddCall("UpdateModelConfig", update, remove, validate)
 		return s.stub.NextErr()
@@ -132,12 +132,12 @@ func (f environConfigFunc) ModelConfig() (*config.Config, error) {
 	return f()
 }
 
-type updateModelConfigFunc func(map[string]interface{}, []string, state.ValidateConfigFunc) error
+type updateModelConfigFunc func(map[string]interface{}, []string, ...state.ValidateConfigFunc) error
 
 func (f updateModelConfigFunc) UpdateModelConfig(
-	update map[string]interface{}, remove []string, validate state.ValidateConfigFunc,
+	update map[string]interface{}, remove []string, validate ...state.ValidateConfigFunc,
 ) error {
-	return f(update, remove, validate)
+	return f(update, remove, validate...)
 }
 
 type mockProviderRegistry struct {

--- a/worker/authenticationworker/worker_test.go
+++ b/worker/authenticationworker/worker_test.go
@@ -85,7 +85,7 @@ func agentConfig(c *gc.C, tag names.MachineTag) *mockConfig {
 
 func (s *workerSuite) setAuthorisedKeys(c *gc.C, keys ...string) {
 	keyStr := strings.Join(keys, "\n")
-	err := s.BackingState.UpdateModelConfig(map[string]interface{}{"authorized-keys": keyStr}, nil, nil)
+	err := s.BackingState.UpdateModelConfig(map[string]interface{}{"authorized-keys": keyStr}, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	s.BackingState.StartSync()
 }

--- a/worker/provisioner/provisioner_test.go
+++ b/worker/provisioner/provisioner_test.go
@@ -69,7 +69,7 @@ func (s *CommonProvisionerSuite) assertProvisionerObservesConfigChanges(c *gc.C,
 	attrs := map[string]interface{}{
 		config.ProvisionerHarvestModeKey: config.HarvestAll.String(),
 	}
-	err := s.State.UpdateModelConfig(attrs, nil, nil)
+	err := s.State.UpdateModelConfig(attrs, nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.BackingState.StartSync()

--- a/worker/uniter/util_test.go
+++ b/worker/uniter/util_test.go
@@ -1455,7 +1455,7 @@ func (s setProxySettings) step(c *gc.C, ctx *context) {
 		"ftp-proxy":   s.Ftp,
 		"no-proxy":    s.NoProxy,
 	}
-	err := ctx.st.UpdateModelConfig(attrs, nil, nil)
+	err := ctx.st.UpdateModelConfig(attrs, nil)
 	c.Assert(err, jc.ErrorIsNil)
 }
 


### PR DESCRIPTION
## Description of change

Setting a model's log level to TRACE can flood the controller and cause performance issues. Until we can implement a solution like throttling, we restrict it so that only controller admins can set a model's log level to trace.

## QA steps

As controller admin
$ juju model-config logging-config="<root>=DEBUG;juju.apiserver.keymanager=TRACE"

As a user with write on the model
$ juju model-config logging-config="<root>=DEBUG;juju.apiserver.keymanager=TRACE"
only controller admins can set a model's logging level to TRACE

## Documentation changes

Doc should mention the new restriction
