### PR TITLE
Fix NetworkInfo in spaceless environments

### DIFF
--- a/state/machine_linklayerdevices.go
+++ b/state/machine_linklayerdevices.go
@@ -1218,6 +1218,16 @@ func (m *Machine) GetNetworkInfoForSpaces(spaces set.Strings) map[string](Machin
 		}
 	}
 
+	// For a spaceless environment we won't find a subnet that's linked to privateAddress,
+	// we have to work around that and at least return minimal information for --primary-address.
+	if r, filledPrivateAddress := results[""]; !filledPrivateAddress && spaces.Contains("") {
+		r.NetworkInfos = []network.NetworkInfo{{
+			Addresses: []network.InterfaceAddress{{
+				Address: privateAddress.Value,
+			}},
+		}}
+		results[""] = r
+	}
 	actualSpacesStr := network.QuoteSpaceSet(actualSpaces)
 
 	for space := range spaces {


### PR DESCRIPTION
## Description of change
Fall back to machine private address if there's no space/subnet found for it when returning NetworkInfo

## QA steps
Launch landscape- tests on spaceless envs (GCE, Rackspace)
 
## Documentation changes
None.

## Bug reference
https://bugs.launchpad.net/juju/+bug/1691591