### PR TITLE
Fix aws resource cleanup during CI runs

### DIFF
--- a/acceptancetests/aws.py
+++ b/acceptancetests/aws.py
@@ -13,6 +13,7 @@ import os
 import sys
 
 from dateutil import tz
+from libcloud.common.types import MalformedResponseError
 
 
 __metaclass__ = type
@@ -128,8 +129,8 @@ def delete_instances(client, name_id, old_age=OLD_MACHINE_AGE, dry_run=False):
                     deleted_count += 1
                 else:
                     log.error('Cannot delete {}'.format(node_name))
-            except:
-                log.error('Cannot delete {}'.format(node_name))
+            except MalformedResponseError as e:
+                log.error('Cannot delete {}: {}'.format(node_name, e))
     return deleted_count
 
 

--- a/acceptancetests/aws.py
+++ b/acceptancetests/aws.py
@@ -121,11 +121,14 @@ def delete_instances(client, name_id, old_age=OLD_MACHINE_AGE, dry_run=False):
         if not dry_run:
             # Do not pass destroy_boot_disk=True unless the node has a special
             # boot disk that is not set to autodestroy.
-            success = client.destroy_node(node)
-            if success:
-                log.debug('Deleted {}'.format(node_name))
-                deleted_count += 1
-            else:
+            try:
+                success = client.destroy_node(node)
+                if success:
+                    log.debug('Deleted {}'.format(node_name))
+                    deleted_count += 1
+                else:
+                    log.error('Cannot delete {}'.format(node_name))
+            except:
                 log.error('Cannot delete {}'.format(node_name))
     return deleted_count
 

--- a/acceptancetests/clean_resources.py
+++ b/acceptancetests/clean_resources.py
@@ -35,15 +35,20 @@ def clean(args):
             instance_groups = dict(substrate.iter_instance_security_groups())
             non_instance_groups = dict((k, v) for k, v in all_groups.items()
                                        if k not in instance_groups)
-            unclean = substrate.delete_detached_interfaces(
-                non_instance_groups.keys())
-            logging.info('Unable to delete {} groups'.format(len(unclean)))
+            try:
+                unclean = substrate.delete_detached_interfaces(
+                    non_instance_groups.keys())
+                logging.info('Unable to delete {} groups'.format(len(unclean)))
+            except:
+                logging.info('Unable to delete non-instance groups {}'.format(non_instance_groups.keys()))
             for group_id in unclean:
                 logging.debug('Cannot delete {}'.format(all_groups[group_id]))
             for group_id in unclean:
                 non_instance_groups.pop(group_id, None)
-            substrate.destroy_security_groups(non_instance_groups.values())
-
+            try:
+                substrate.destroy_security_groups(non_instance_groups.values())
+            except:
+                logging.debug('Failed to delete groups {}'.format(non_instance_groups.values()))
 
 def main():
     args = parse_args()


### PR DESCRIPTION
## Description of change
Old instances were not being cleaned on AWS due to the script failing silently when encountering instances with termination protection.

## QA steps

This was tested on the z-clean-resources-aws job and properly cleaned up resources that had been left sitting.

## Documentation changes

N/A

## Bug reference

N/A
