### PR TITLE
Methods called on DeadManager should no longer panic.

### DIFF
--- a/worker/lease/dead_manager_test.go
+++ b/worker/lease/dead_manager_test.go
@@ -1,0 +1,59 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package lease_test
+
+import (
+	"reflect"
+
+	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/worker.v1"
+
+	"github.com/juju/juju/worker/lease"
+)
+
+type deadManagerSuite struct{}
+
+var _ = gc.Suite(&deadManagerSuite{})
+
+type deadManagerError struct{}
+
+const DeadManagerErrorMessage = "DeadManagerError"
+
+func (*deadManagerError) Error() string {
+	return DeadManagerErrorMessage
+}
+
+// This creates a new DeadManager and calls all of its exported methods with zero
+// values. All methods should return the specified DeadManagerError.
+func (s *deadManagerSuite) TestDeadManager(c *gc.C) {
+	deadManagerErr := deadManagerError{}
+	deadManager := lease.NewDeadManager(&deadManagerErr)
+	deadManagerType := reflect.TypeOf(deadManager)
+	deadManagerValue := reflect.ValueOf(deadManager)
+	errorIface := reflect.TypeOf((*error)(nil)).Elem()
+	workerIface := reflect.TypeOf((*worker.Worker)(nil)).Elem()
+
+	for i := 0; i < deadManagerType.NumMethod(); i++ {
+		method := deadManagerType.Method(i)
+		methodV := deadManagerValue.MethodByName(method.Name)
+
+		var args []reflect.Value
+		for n := 0; n < methodV.Type().NumIn(); n++ {
+			argType := methodV.Type().In(n)
+			args = append(args, reflect.Zero(argType))
+		}
+
+		for j := 0; j < method.Type.NumOut(); j++ {
+			if returnType := method.Type.Out(j); returnType.Implements(errorIface) {
+				errorValue := methodV.Call(args)[j]
+				if _, ok := workerIface.MethodByName(method.Name); ok {
+					c.Check(errorValue.Interface(), gc.ErrorMatches, DeadManagerErrorMessage)
+				} else {
+					c.Check(errorValue.Interface(), gc.ErrorMatches, "lease manager stopped")
+				}
+
+			}
+		}
+	}
+}

--- a/worker/lease/manager.go
+++ b/worker/lease/manager.go
@@ -21,10 +21,20 @@ var logger = loggo.GetLogger("juju.worker.lease")
 // the manager has started (and possibly finished) shutdown.
 var errStopped = errors.New("lease manager stopped")
 
+type dummySecretary struct{}
+
+func (d dummySecretary) CheckLease(name string) error               { return nil }
+func (d dummySecretary) CheckHolder(name string) error              { return nil }
+func (d dummySecretary) CheckDuration(duration time.Duration) error { return nil }
+
 // NewDeadManager returns a manager that's already dead
 // and always returns the given error.
 func NewDeadManager(err error) *Manager {
-	var m Manager
+	m := Manager{
+		config: ManagerConfig{
+			Secretary: dummySecretary{},
+		},
+	}
 	catacomb.Invoke(catacomb.Plan{
 		Site: &m.catacomb,
 		Work: func() error {


### PR DESCRIPTION
## Description of change

Some `DeadManager` methods would panic. `DeadManager` methods no longer panic but return appropriate errors.

## QA steps

N/A

## Documentation changes

N/A

## Bug reference
[lp#1686720](https://bugs.launchpad.net/juju/+bug/1686720)
