### PR TITLE
Add info to list-clouds output to list maas and other such providers

### DIFF
--- a/cmd/juju/cloud/add.go
+++ b/cmd/juju/cloud/add.go
@@ -264,15 +264,15 @@ func queryName(
 	}
 }
 
-func queryCloudType(pollster *interact.Pollster) (string, error) {
+// cloudProviders returns the names of providers supported by add-cloud,
+// and also the names of those which are not supported.
+func cloudProviders() (providers []string, unsupported []string, _ error) {
 	allproviders := environs.RegisteredProviders()
-	var unsupported []string
-	var providers []string
 	for _, name := range allproviders {
 		provider, err := environs.Provider(name)
 		if err != nil {
 			// should be impossible
-			return "", errors.Trace(err)
+			return nil, nil, errors.Trace(err)
 		}
 
 		if provider.CloudSchema() != nil {
@@ -282,7 +282,15 @@ func queryCloudType(pollster *interact.Pollster) (string, error) {
 		}
 	}
 	sort.Strings(providers)
+	return providers, unsupported, nil
+}
 
+func queryCloudType(pollster *interact.Pollster) (string, error) {
+	providers, unsupported, err := cloudProviders()
+	if err != nil {
+		// should be impossible
+		return "", errors.Trace(err)
+	}
 	supportedCloud := interact.VerifyOptions("cloud type", providers, false)
 
 	cloudVerify := func(s string) (ok bool, errmsg string, err error) {

--- a/cmd/juju/cloud/add.go
+++ b/cmd/juju/cloud/add.go
@@ -264,9 +264,9 @@ func queryName(
 	}
 }
 
-// cloudProviders returns the names of providers supported by add-cloud,
+// addableCloudProviders returns the names of providers supported by add-cloud,
 // and also the names of those which are not supported.
-func cloudProviders() (providers []string, unsupported []string, _ error) {
+func addableCloudProviders() (providers []string, unsupported []string, _ error) {
 	allproviders := environs.RegisteredProviders()
 	for _, name := range allproviders {
 		provider, err := environs.Provider(name)
@@ -286,7 +286,7 @@ func cloudProviders() (providers []string, unsupported []string, _ error) {
 }
 
 func queryCloudType(pollster *interact.Pollster) (string, error) {
-	providers, unsupported, err := cloudProviders()
+	providers, unsupported, err := addableCloudProviders()
 	if err != nil {
 		// should be impossible
 		return "", errors.Trace(err)

--- a/cmd/juju/cloud/addcredential_test.go
+++ b/cmd/juju/cloud/addcredential_test.go
@@ -40,7 +40,10 @@ var _ = gc.Suite(&addCredentialSuite{
 
 func (s *addCredentialSuite) SetUpSuite(c *gc.C) {
 	s.BaseSuite.SetUpSuite(c)
-	environs.RegisterProvider("mock-addcredential-provider", &mockProvider{credSchemas: &s.schema})
+	unreg := environs.RegisterProvider("mock-addcredential-provider", &mockProvider{credSchemas: &s.schema})
+	s.AddCleanup(func(_ *gc.C) {
+		unreg()
+	})
 	s.cloudByNameFunc = func(cloud string) (*jujucloud.Cloud, error) {
 		if cloud != "somecloud" && cloud != "anothercloud" {
 			return nil, errors.NotFoundf("cloud %v", cloud)

--- a/cmd/juju/cloud/detectcredentials_test.go
+++ b/cmd/juju/cloud/detectcredentials_test.go
@@ -19,9 +19,12 @@ import (
 	"github.com/juju/juju/cmd/juju/cloud"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/jujuclient"
+	"github.com/juju/juju/testing"
 )
 
 type detectCredentialsSuite struct {
+	testing.BaseSuite
+
 	store       *jujuclient.MemStore
 	aCredential jujucloud.CloudCredential
 }
@@ -93,10 +96,15 @@ func (p *mockProvider) FinalizeCredential(
 }
 
 func (s *detectCredentialsSuite) SetUpSuite(c *gc.C) {
-	environs.RegisterProvider("mock-provider", &mockProvider{detectedCreds: &s.aCredential})
+	s.BaseSuite.SetUpSuite(c)
+	unreg := environs.RegisterProvider("mock-provider", &mockProvider{detectedCreds: &s.aCredential})
+	s.AddCleanup(func(_ *gc.C) {
+		unreg()
+	})
 }
 
 func (s *detectCredentialsSuite) SetUpTest(c *gc.C) {
+	s.BaseSuite.SetUpTest(c)
 	s.store = jujuclient.NewMemStore()
 	s.aCredential = jujucloud.CloudCredential{}
 }

--- a/cmd/juju/cloud/list.go
+++ b/cmd/juju/cloud/list.go
@@ -6,6 +6,7 @@ package cloud
 import (
 	"io"
 	"sort"
+	"strings"
 
 	"github.com/juju/ansiterm"
 	"github.com/juju/cmd"
@@ -203,10 +204,18 @@ func formatCloudsTabular(writer io.Writer, value interface{}) error {
 	printClouds(clouds.builtin, nil)
 	printClouds(clouds.personal, ansiterm.Foreground(ansiterm.BrightBlue))
 
+	// Get other provider types supported by add-cloud.
+	// These will typically be for private clouds like maas etc.
+	providers, _, err := cloudProviders()
+	if err != nil {
+		return errors.Trace(err)
+	}
+
 	w.Println("\nTry 'list-regions <cloud>' to see available regions.")
 	w.Println("'show-cloud <cloud>' or 'regions --format yaml <cloud>' can be used to see region endpoints.")
-	w.Println("'add-cloud' can add private clouds or private infrastructure.")
 	w.Println("Update the known public clouds with 'update-clouds'.")
+	w.Println("'add-cloud' can add private clouds or private infrastructure built using:")
+	w.Printf("  - %s\n", strings.Join(providers, ", "))
 	tw.Flush()
 	return nil
 }

--- a/cmd/juju/cloud/list.go
+++ b/cmd/juju/cloud/list.go
@@ -206,7 +206,7 @@ func formatCloudsTabular(writer io.Writer, value interface{}) error {
 
 	// Get other provider types supported by add-cloud.
 	// These will typically be for private clouds like maas etc.
-	providers, _, err := cloudProviders()
+	providers, _, err := addableCloudProviders()
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -214,7 +214,7 @@ func formatCloudsTabular(writer io.Writer, value interface{}) error {
 	w.Println("\nTry 'list-regions <cloud>' to see available regions.")
 	w.Println("'show-cloud <cloud>' or 'regions --format yaml <cloud>' can be used to see region endpoints.")
 	w.Println("Update the known public clouds with 'update-clouds'.")
-	w.Println("'add-cloud' can add private clouds or private infrastructure built using:")
+	w.Println("'add-cloud' can add private clouds / infrastructure built for the following provider types:")
 	w.Printf("  - %s\n", strings.Join(providers, ", "))
 	tw.Flush()
 	return nil

--- a/cmd/juju/cloud/list_test.go
+++ b/cmd/juju/cloud/list_test.go
@@ -31,9 +31,10 @@ func (s *listSuite) TestListPublic(c *gc.C) {
 	out = strings.Replace(out, "\n", "", -1)
 	// Just check couple of snippets of the output to make sure it looks ok.
 	c.Assert(out, gc.Matches, `.*aws-china[ ]*1[ ]*cn-north-1[ ]*ec2.*`)
-	// TODO(wallyworld) - uncomment when we build with go 1.3 or greater
 	// LXD should be there too.
-	// c.Assert(out, gc.Matches, `.*localhost[ ]*lxd[ ]*localhost.*`)
+	c.Assert(out, gc.Matches, `.*localhost[ ]*1[ ]*localhost[ ]*lxd.*`)
+	// The private provider types should be there also.
+	c.Assert(out, gc.Matches, `.*maas, manual, openstack, oracle, vsphere.*`)
 }
 
 func (s *listSuite) TestListPublicAndPersonal(c *gc.C) {

--- a/cmd/juju/cloud/listcredentials_test.go
+++ b/cmd/juju/cloud/listcredentials_test.go
@@ -41,7 +41,10 @@ var _ = gc.Suite(&listCredentialsSuite{
 
 func (s *listCredentialsSuite) SetUpSuite(c *gc.C) {
 	s.BaseSuite.SetUpSuite(c)
-	environs.RegisterProvider("test-provider", &mockProvider{})
+	unreg := environs.RegisterProvider("test-provider", &mockProvider{})
+	s.AddCleanup(func(_ *gc.C) {
+		unreg()
+	})
 }
 
 func (s *listCredentialsSuite) SetUpTest(c *gc.C) {

--- a/environs/config_test.go
+++ b/environs/config_test.go
@@ -4,6 +4,7 @@
 package environs_test
 
 import (
+	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
@@ -119,4 +120,18 @@ func (s *suite) TestRegisterProvider(c *gc.C) {
 			}
 		}
 	}
+}
+
+func (s *suite) TestUnregisterProvider(c *gc.C) {
+	s.PatchValue(environs.Providers, make(map[string]environs.EnvironProvider))
+	s.PatchValue(environs.ProviderAliases, make(map[string]string))
+	registered := &dummyProvider{}
+	unreg := environs.RegisterProvider("test", registered, "alias1", "alias2")
+	unreg()
+	_, err := environs.Provider("test")
+	c.Assert(err, jc.Satisfies, errors.IsNotFound)
+	_, err = environs.Provider("alias1")
+	c.Assert(err, jc.Satisfies, errors.IsNotFound)
+	_, err = environs.Provider("alias2")
+	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 }


### PR DESCRIPTION
## Description of change

juju clouds output is improved to show private cloud providers like maas

## QA steps

$ juju clouds
Cloud        Regions  Default          Type        Description
aws               14  us-east-1        ec2         Amazon Web Services
aws-china          1  cn-north-1       ec2         Amazon China
aws-gov            1  us-gov-west-1    ec2         Amazon (USA Government)
<snip>

Try 'list-regions <cloud>' to see available regions.
'show-cloud <cloud>' or 'regions --format yaml <cloud>' can be used to see region endpoints.
Update the known public clouds with 'update-clouds'.
'add-cloud' can add private clouds or private infrastructure built using:
  - maas, manual, openstack, oracle, vsphere

^^^^^ new
