### PR TITLE
Fix quoting of openstack provider instance uuid for bug 1692004

### DIFF
--- a/provider/openstack/provider.go
+++ b/provider/openstack/provider.go
@@ -1086,7 +1086,7 @@ func (e *Environ) StartInstance(args environs.StartInstanceParams) (*environs.St
 				return nil
 			},
 			NotifyFunc: func(lastError error, attempt int) {
-				args.StatusCallback(status.Provisioning, fmt.Sprintf("%q, wait 10 seconds before retry, attempt %d", lastError, attempt), nil)
+				args.StatusCallback(status.Provisioning, fmt.Sprintf("%s, wait 10 seconds before retry, attempt %d", lastError, attempt), nil)
 			},
 			IsFatalError: func(err error) bool {
 				return err != errStillBuilding


### PR DESCRIPTION
## Please provide the following details to expedite Pull Request review:

----

## Description of change

Resolve a cosmetic issue, incorrect quoting, in customer viewable output.

## QA steps

Look at juju bootstrap of openstack-provider output and juju status while a machine is 
deployed. 
       instance <uuid> has status BUILD", wait 10 seconds before retry, attempt 1
Above output should have no quotes

## Documentation changes

N/A

## Bug reference

https://bugs.launchpad.net/juju/+bug/1692004