### PR TITLE
During install hook, do not overwrite workload status if it has already been set by the charm

### DIFF
--- a/worker/uniter/operation/runhook_test.go
+++ b/worker/uniter/operation/runhook_test.go
@@ -272,6 +272,44 @@ func (s *RunHookSuite) TestExecuteOtherError(c *gc.C) {
 	c.Assert(callbacks.MockNotifyHookCompleted.gotName, gc.IsNil)
 }
 
+func (s *RunHookSuite) TestInstallHookPreservesStatus(c *gc.C) {
+	op, callbacks, f := s.getExecuteRunnerTest(c, (operation.Factory).NewRunHook, hooks.Install, nil)
+	err := f.MockNewHookRunner.runner.Context().SetUnitStatus(jujuc.StatusInfo{Status: "blocked", Info: "no database"})
+	c.Assert(err, jc.ErrorIsNil)
+	st := operation.State{
+		StatusSet: true,
+	}
+	midState, err := op.Prepare(st)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(midState, gc.NotNil)
+
+	_, err = op.Execute(*midState)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(callbacks.executingMessage, gc.Equals, "running some-hook-name hook")
+	status, err := f.MockNewHookRunner.runner.Context().UnitStatus()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(status.Status, gc.Equals, "blocked")
+	c.Assert(status.Info, gc.Equals, "no database")
+}
+
+func (s *RunHookSuite) TestInstallHookWHenNoStatusSet(c *gc.C) {
+	op, callbacks, f := s.getExecuteRunnerTest(c, (operation.Factory).NewRunHook, hooks.Install, nil)
+	st := operation.State{
+		StatusSet: false,
+	}
+	midState, err := op.Prepare(st)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(midState, gc.NotNil)
+
+	_, err = op.Execute(*midState)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(callbacks.executingMessage, gc.Equals, "running some-hook-name hook")
+	status, err := f.MockNewHookRunner.runner.Context().UnitStatus()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(status.Status, gc.Equals, "maintenance")
+	c.Assert(status.Info, gc.Equals, "installing charm software")
+}
+
 func (s *RunHookSuite) testExecuteSuccess(
 	c *gc.C, before, after operation.State, setStatusCalled bool,
 ) {


### PR DESCRIPTION
## Description of change

When the install hook is about to run, we first check to see whether the charm has already set the workload status. If set, we don't overwrite with the default install status.

## QA steps

The bug shows the ghost charm doing the wrong thing.
Deploy the ghost charm and observe the correct show-status-log output.

$ juju show-status-log ghost/0
TIME                            TYPE            STATUS          MESSAGE                                 
22 May 2017 13:18:53+10:00      juju-unit       executing       running app-storage-attached hook       
22 May 2017 13:24:13+10:00      workload        waiting         Updating apt cache                      
22 May 2017 13:24:17+10:00      workload        waiting         Installing nginx-full,nodejs            
22 May 2017 13:24:41+10:00      workload        active          node.js is ready                        
22 May 2017 13:24:41+10:00      workload        active          NGINX is ready                          
22 May 2017 13:24:41+10:00      workload        maintenance     installing NPM dependencies for /srv/app
22 May 2017 13:24:50+10:00      workload        maintenance     Configuring site default                
22 May 2017 13:24:51+10:00      workload        maintenance     updating configuration                  
22 May 2017 13:25:13+10:00      workload        maintenance     installing NPM dependencies for /srv/app
22 May 2017 13:25:48+10:00      workload        active          ready                                   
22 May 2017 13:25:48+10:00      juju-unit       executing       installing charm software               
22 May 2017 13:25:48+10:00      juju-unit       executing       running install hook  
22 May 2017 13:25:48+10:00      workload        active          ready

## Bug reference

https://bugs.launchpad.net/juju/+bug/1597481
