### PR TITLE
Better error message when attempting to save duplicate image metadata

### DIFF
--- a/state/cloudimagemetadata/image_test.go
+++ b/state/cloudimagemetadata/image_test.go
@@ -192,6 +192,21 @@ func (s *cloudImageMetadataSuite) TestSaveMetadataUpdateSameAttrsDiffImages(c *g
 	s.assertMetadataRecorded(c, cloudimagemetadata.MetadataAttributes{}, metadata1)
 }
 
+func (s *cloudImageMetadataSuite) TestSaveMetadataDuplicates(c *gc.C) {
+	attrs := cloudimagemetadata.MetadataAttributes{
+		Stream:   "stream",
+		Version:  "14.04",
+		Series:   "trusty",
+		Arch:     "arch",
+		Source:   "test",
+		Region:   "wonder",
+		VirtType: "lxd",
+	}
+	metadata0 := cloudimagemetadata.Metadata{attrs, 0, "1", 0}
+	err := s.storage.SaveMetadata([]cloudimagemetadata.Metadata{metadata0, metadata0})
+	c.Assert(err, gc.ErrorMatches, ".*"+regexp.QuoteMeta(`duplicate metadata record for image id 1 (key="stream:wonder:trusty:arch:lxd::test")`))
+}
+
 func (s *cloudImageMetadataSuite) TestSaveDiffMetadataConcurrentlyAndOrderByDateCreated(c *gc.C) {
 	attrs := cloudimagemetadata.MetadataAttributes{
 		Stream:  "stream",
@@ -366,8 +381,8 @@ func (s *cloudImageMetadataSuite) assertConcurrentSave(c *gc.C, metadata0, metad
 	s.assertMetadataRecorded(c, cloudimagemetadata.MetadataAttributes{}, expected...)
 }
 
-func (s *cloudImageMetadataSuite) assertRecordMetadata(c *gc.C, m cloudimagemetadata.Metadata) {
-	err := s.storage.SaveMetadata([]cloudimagemetadata.Metadata{m})
+func (s *cloudImageMetadataSuite) assertRecordMetadata(c *gc.C, m ...cloudimagemetadata.Metadata) {
+	err := s.storage.SaveMetadata(m)
 	c.Assert(err, jc.ErrorIsNil)
 }
 


### PR DESCRIPTION
## Description of change

When bootstrapping with custom image metadata, or when updating metadata upstream and Juju imports it, if there are duplicates the error message was "state changing too quickly".
The PR provides a better error message.

## QA steps

juju bootstrap --metadata-source somedir
where somedir contains bad simplestreams metadata
-> check the error message

## Bug reference

https://bugs.launchpad.net/juju/+bug/1691884
