### PR TITLE
Quick fix for Omnibus CI

### DIFF
--- a/acceptancetests/assess_budget.py
+++ b/acceptancetests/assess_budget.py
@@ -14,11 +14,12 @@ import logging
 from random import randint
 import subprocess
 import sys
+import os
 
+from deploy_stack import (
+    BootstrapManager,
+    )
 
-from jujupy import (
-    client_from_config,
-)
 from utility import (
     add_basic_testing_arguments,
     JujuAssertionError,
@@ -245,8 +246,16 @@ def parse_args(argv):
 def main(argv=None):
     args = parse_args(argv)
     configure_logging(args.verbose)
-    client = client_from_config(args.env, args.juju_bin, False)
-    assess_budget(client)
+    bs_manager = BootstrapManager.from_args(args)
+    with bs_manager.booted_context(args.upload_tools):
+        user_home = os.getenv('HOME', default='/var/lib/jenkins')
+        juju_home = os.getenv('JUJU_HOME',
+                              default='/var/lib/jenkins/cloud-city')
+        ctrl_name = os.getenv('JOB_NAME', default='budget-management')
+        cookies_source = '{}/go-cookies-extended'.format(user_home)
+        cookies_target = '{}/jes-homes/{}/cookies/{}.json'.format(juju_home, ctrl_name, ctrl_name)
+        subprocess.call(['cp', cookies_source, cookies_target])
+        assess_budget(bs_manager.client)
     return 0
 
 

--- a/acceptancetests/assess_budget.py
+++ b/acceptancetests/assess_budget.py
@@ -242,19 +242,23 @@ def parse_args(argv):
     add_basic_testing_arguments(parser)
     return parser.parse_args(argv)
 
-def feed_cookie():
+
+def set_controller_cookie_file():
     """Plant pre-generated cookie file to avoid launching Browser."""
     user_home = os.getenv('HOME', default='/var/lib/jenkins')
-    juju_home = os.getenv('JUJU_HOME',
-                            default='/var/lib/jenkins/cloud-city')
+    juju_home = os.getenv('JUJU_HOME', default='/var/lib/jenkins/cloud-city')
     ctrl_name = os.getenv('JOB_NAME', default='budget-management')
     cookies_source = '{}/go-cookies-extended'.format(user_home)
-    cookies_target = '{}/jes-homes/{}/cookies/{}.json'.format(juju_home, ctrl_name, ctrl_name)
+    cookies_target = '{}/jes-homes/{}/cookies/{}.json'.format(juju_home,
+                                                              ctrl_name,
+                                                              ctrl_name)
     try:
-        subprocess.check_call(['cp', cookies_source, cookies_target])
+        subprocess.check_output(['cp', cookies_source, cookies_target],
+                                stderr=subprocess.STDOUT)
         log.info('Cookie file go-cookies-extended has been planted.')
     except subprocess.CalledProcessError as e:
-        raise JujuAssertionError('Failed to plant the cookie file!')
+        log.info(e.output)
+        raise
 
 
 def main(argv=None):
@@ -262,7 +266,7 @@ def main(argv=None):
     configure_logging(args.verbose)
     bs_manager = BootstrapManager.from_args(args)
     with bs_manager.booted_context(args.upload_tools):
-        feed_cookie()
+        set_controller_cookie_file()
         assess_budget(bs_manager.client)
     return 0
 


### PR DESCRIPTION
## Description of change

Quick fix for Ominibus CI failure:
http://reports.vapour.ws/releases/issue/589cd61d749a565024f979ab

## QA steps

With pre-generated cookie file go-cookies-extended under {HOME}, run:
$ export GOPATH=/<path_to>/build
$ export PATH=$GOPATH/bin:$PATH
$ export JUJU_HOME=/<path_to>/cloud-city
$ export JUJU_DATA=/<path_to>/data
$ export JUJU_BIN=$GOPATH/bin/juju
$ export JOB_NAME=budget-management
$ python assess_budget.py parallel-lxd $JUJU_BIN $JUJU_DATA $JOB_NAME

## Documentation changes

N/A

## Bug reference

http://reports.vapour.ws/releases/issue/589cd61d749a565024f979ab

This change has been locally tested with juju 2.2-rc1.
