### PR TITLE
Always use /etc/network/interfaces as -i option to ifup/ifdown is broken sometimes

### DIFF
--- a/network/debinterfaces/activate.go
+++ b/network/debinterfaces/activate.go
@@ -59,7 +59,7 @@ set -eu
 if [ $DRYRUN ]; then
   if [ %[4]d == 25694 ]; then sleep 30; fi
   if [ %[4]d == 25695 ]; then echo "artificial failure" >&2; exit 1; fi
- fi
+fi
 
 write_backup() {
     cat << 'EOF' > "$1"
@@ -79,8 +79,18 @@ fi
 ${DRYRUN} write_content %[3]q
 ${DRYRUN} ifdown --interfaces=%[1]q %[7]s
 ${DRYRUN} sleep %[4]d
-${DRYRUN} ifup --interfaces=%[3]q -a
-${DRYRUN} mv %[3]q %[1]q
+${DRYRUN} cp %[3]q %[1]q
+# we want to have full control over what happens next
+set +e
+${DRYRUN} ifup --interfaces=%[1]q -a
+RESULT=$?
+if [ ${RESULT} != 0 ]; then
+    echo "Bringing up bridged interfaces failed, see system logs and %[3]q" >&2
+    ${DRYRUN} ifdown --interfaces=%[1]q %[7]s
+    ${DRYRUN} cp %[2]q %[1]q
+    ${DRYRUN} ifup --interfaces=%[1]q -a
+    exit ${RESULT}
+fi
 `,
 		params.Filename,
 		params.Filename+".backup",

--- a/network/debinterfaces/activate.go
+++ b/network/debinterfaces/activate.go
@@ -47,6 +47,7 @@ func activationCmd(oldContent, newContent string, params *ActivationParams) stri
 		i++
 	}
 	sort.Strings(deviceNames)
+	backupFilename := fmt.Sprintf("%s.backup-%d", params.Filename, time.Now().Unix())
 	// The magic value of 25694 here causes the script to sleep for 30 seconds, simulating timeout
 	// The value of 25695 causes the script to fail.
 	return fmt.Sprintf(`
@@ -93,7 +94,7 @@ if [ ${RESULT} != 0 ]; then
 fi
 `,
 		params.Filename,
-		params.Filename+".backup",
+		backupFilename,
 		params.Filename+".new",
 		params.ReconfigureDelay,
 		oldContent,

--- a/network/debinterfaces/activate_test.go
+++ b/network/debinterfaces/activate_test.go
@@ -66,8 +66,8 @@ write_backup testdata/TestInputSourceStanza/interfaces.backup
 write_content testdata/TestInputSourceStanza/interfaces.new
 ifdown --interfaces=testdata/TestInputSourceStanza/interfaces eth0 eth1
 sleep 10
-ifup --interfaces=testdata/TestInputSourceStanza/interfaces.new -a
-mv testdata/TestInputSourceStanza/interfaces.new testdata/TestInputSourceStanza/interfaces
+cp testdata/TestInputSourceStanza/interfaces.new testdata/TestInputSourceStanza/interfaces
+ifup --interfaces=testdata/TestInputSourceStanza/interfaces -a
 `
 	c.Assert(string(result.Stdout), gc.Equals, expected[1:])
 }
@@ -94,8 +94,8 @@ write_backup testdata/TestInputSourceStanza/interfaces.backup
 write_content testdata/TestInputSourceStanza/interfaces.new
 ifdown --interfaces=testdata/TestInputSourceStanza/interfaces eth0 eth1
 sleep 100
-ifup --interfaces=testdata/TestInputSourceStanza/interfaces.new -a
-mv testdata/TestInputSourceStanza/interfaces.new testdata/TestInputSourceStanza/interfaces
+cp testdata/TestInputSourceStanza/interfaces.new testdata/TestInputSourceStanza/interfaces
+ifup --interfaces=testdata/TestInputSourceStanza/interfaces -a
 `
 	c.Assert(string(result.Stdout), gc.Equals, expected[1:])
 }
@@ -122,8 +122,8 @@ write_backup testdata/TestInputSourceStanza/interfaces.backup
 write_content testdata/TestInputSourceStanza/interfaces.new
 ifdown --interfaces=testdata/TestInputSourceStanza/interfaces eth0 eth1
 sleep 0
-ifup --interfaces=testdata/TestInputSourceStanza/interfaces.new -a
-mv testdata/TestInputSourceStanza/interfaces.new testdata/TestInputSourceStanza/interfaces
+cp testdata/TestInputSourceStanza/interfaces.new testdata/TestInputSourceStanza/interfaces
+ifup --interfaces=testdata/TestInputSourceStanza/interfaces -a
 `
 	c.Assert(string(result.Stdout), gc.Equals, expected[1:])
 }

--- a/network/debinterfaces/activate_test.go
+++ b/network/debinterfaces/activate_test.go
@@ -7,6 +7,7 @@ package debinterfaces_test
 // dryrun option to the script that is executed.
 
 import (
+	"fmt"
 	"runtime"
 	"time"
 
@@ -41,7 +42,7 @@ func (*BridgeSuite) TestActivateNonExistentDevice(c *gc.C) {
 
 	result, err := debinterfaces.BridgeAndActivate(params)
 	c.Assert(err, gc.IsNil)
-	c.Assert(result, gc.IsNil)
+	c.Check(result, gc.IsNil)
 }
 
 func (*BridgeSuite) TestActivateEth0(c *gc.C) {
@@ -58,18 +59,18 @@ func (*BridgeSuite) TestActivateEth0(c *gc.C) {
 
 	result, err := debinterfaces.BridgeAndActivate(params)
 	c.Assert(err, gc.IsNil)
-	c.Assert(result, gc.NotNil)
-	c.Assert(result.Code, gc.Equals, 0)
+	c.Check(result, gc.NotNil)
+	c.Check(result.Code, gc.Equals, 0)
 
-	expected := `
-write_backup testdata/TestInputSourceStanza/interfaces.backup
+	expected := fmt.Sprintf(`
+write_backup testdata/TestInputSourceStanza/interfaces.backup-%d
 write_content testdata/TestInputSourceStanza/interfaces.new
 ifdown --interfaces=testdata/TestInputSourceStanza/interfaces eth0 eth1
 sleep 10
 cp testdata/TestInputSourceStanza/interfaces.new testdata/TestInputSourceStanza/interfaces
 ifup --interfaces=testdata/TestInputSourceStanza/interfaces -a
-`
-	c.Assert(string(result.Stdout), gc.Equals, expected[1:])
+`, time.Now().Unix())
+	c.Check(string(result.Stdout), gc.Equals, expected[1:])
 }
 
 func (*BridgeSuite) TestActivateEth0WithoutBackup(c *gc.C) {
@@ -86,18 +87,18 @@ func (*BridgeSuite) TestActivateEth0WithoutBackup(c *gc.C) {
 
 	result, err := debinterfaces.BridgeAndActivate(params)
 	c.Assert(err, gc.IsNil)
-	c.Assert(result, gc.NotNil)
-	c.Assert(result.Code, gc.Equals, 0)
+	c.Check(result, gc.NotNil)
+	c.Check(result.Code, gc.Equals, 0)
 
-	expected := `
-write_backup testdata/TestInputSourceStanza/interfaces.backup
+	expected := fmt.Sprintf(`
+write_backup testdata/TestInputSourceStanza/interfaces.backup-%d
 write_content testdata/TestInputSourceStanza/interfaces.new
 ifdown --interfaces=testdata/TestInputSourceStanza/interfaces eth0 eth1
 sleep 100
 cp testdata/TestInputSourceStanza/interfaces.new testdata/TestInputSourceStanza/interfaces
 ifup --interfaces=testdata/TestInputSourceStanza/interfaces -a
-`
-	c.Assert(string(result.Stdout), gc.Equals, expected[1:])
+`, time.Now().Unix())
+	c.Check(string(result.Stdout), gc.Equals, expected[1:])
 }
 
 func (*BridgeSuite) TestActivateWithNegativeReconfigureDelay(c *gc.C) {
@@ -114,18 +115,18 @@ func (*BridgeSuite) TestActivateWithNegativeReconfigureDelay(c *gc.C) {
 
 	result, err := debinterfaces.BridgeAndActivate(params)
 	c.Assert(err, gc.IsNil)
-	c.Assert(result, gc.NotNil)
-	c.Assert(result.Code, gc.Equals, 0)
+	c.Check(result, gc.NotNil)
+	c.Check(result.Code, gc.Equals, 0)
 
-	expected := `
-write_backup testdata/TestInputSourceStanza/interfaces.backup
+	expected := fmt.Sprintf(`
+write_backup testdata/TestInputSourceStanza/interfaces.backup-%d
 write_content testdata/TestInputSourceStanza/interfaces.new
 ifdown --interfaces=testdata/TestInputSourceStanza/interfaces eth0 eth1
 sleep 0
 cp testdata/TestInputSourceStanza/interfaces.new testdata/TestInputSourceStanza/interfaces
 ifup --interfaces=testdata/TestInputSourceStanza/interfaces -a
-`
-	c.Assert(string(result.Stdout), gc.Equals, expected[1:])
+`, time.Now().Unix())
+	c.Check(string(result.Stdout), gc.Equals, expected[1:])
 }
 
 func (*BridgeSuite) TestActivateWithNoDevicesSpecified(c *gc.C) {
@@ -140,7 +141,7 @@ func (*BridgeSuite) TestActivateWithNoDevicesSpecified(c *gc.C) {
 
 	_, err := debinterfaces.BridgeAndActivate(params)
 	c.Assert(err, gc.NotNil)
-	c.Assert(err, gc.ErrorMatches, "no devices specified")
+	c.Check(err, gc.ErrorMatches, "no devices specified")
 }
 
 func (*BridgeSuite) TestActivateWithParsingError(c *gc.C) {
@@ -157,7 +158,7 @@ func (*BridgeSuite) TestActivateWithParsingError(c *gc.C) {
 	c.Assert(err, gc.NotNil)
 	c.Assert(err, gc.FitsTypeOf, &debinterfaces.ParseError{})
 	parseError := err.(*debinterfaces.ParseError)
-	c.Assert(parseError, gc.DeepEquals, &debinterfaces.ParseError{
+	c.Check(parseError, gc.DeepEquals, &debinterfaces.ParseError{
 		Filename: "testdata/TestInputSourceStanzaWithErrors/interfaces.d/eth1.cfg",
 		Line:     "iface",
 		LineNum:  2,
@@ -180,7 +181,7 @@ func (*BridgeSuite) TestActivateWithTimeout(c *gc.C) {
 
 	_, err := debinterfaces.BridgeAndActivate(params)
 	c.Assert(err, gc.NotNil)
-	c.Assert(err, gc.ErrorMatches, "bridge activation error: command cancelled")
+	c.Check(err, gc.ErrorMatches, "bridge activation error: command cancelled")
 }
 
 func (*BridgeSuite) TestActivateFailure(c *gc.C) {
@@ -198,6 +199,6 @@ func (*BridgeSuite) TestActivateFailure(c *gc.C) {
 
 	result, err := debinterfaces.BridgeAndActivate(params)
 	c.Assert(err, gc.NotNil)
-	c.Assert(err, gc.ErrorMatches, "bridge activation failed: artificial failure\n")
-	c.Assert(result.Code, gc.Equals, 1)
+	c.Check(err, gc.ErrorMatches, "bridge activation failed: artificial failure\n")
+	c.Check(result.Code, gc.Equals, 1)
 }

--- a/network/debinterfaces/bridge.go
+++ b/network/debinterfaces/bridge.go
@@ -109,6 +109,7 @@ func Bridge(stanzas []Stanza, devices map[string]string) []Stanza {
 	autoStanzaSet := map[string]bool{}
 	manualInetSet := map[string]bool{}
 	manualInet6Set := map[string]bool{}
+	bridges := map[string]bool{}
 	ifacesToBridge := make([]IfaceStanza, 0)
 	devicesToBridge := deviceNameSet{}
 
@@ -137,6 +138,9 @@ func Bridge(stanzas []Stanza, devices map[string]string) []Stanza {
 				ifacesToBridge = append(ifacesToBridge, v)
 			} else {
 				result = append(result, s)
+				if v.IsBridged {
+					bridges[v.DeviceName] = true
+				}
 			}
 		case AutoStanza:
 			names := v.DeviceNames
@@ -162,6 +166,11 @@ func Bridge(stanzas []Stanza, devices map[string]string) []Stanza {
 
 	for _, iface := range ifacesToBridge {
 		bridgeName := devices[iface.DeviceName]
+		// skip it if we already have a bridge of this name
+		if _, ok := bridges[bridgeName]; ok {
+			continue
+		}
+
 		// If there was a `auto $DEVICE` stanza make sure we
 		// create the complementary auto stanza for the bridge
 		// device.

--- a/network/debinterfaces/bridge_test.go
+++ b/network/debinterfaces/bridge_test.go
@@ -41,17 +41,17 @@ func (s *BridgeSuite) assertParse(c *gc.C, content string) []debinterfaces.Stanz
 	return stanzas
 }
 
-func (s *BridgeSuite) assertBridge(input, expected string, c *gc.C, devices map[string]string) {
+func (s *BridgeSuite) checkBridge(input, expected string, c *gc.C, devices map[string]string) {
 	stanzas := s.assertParse(c, input)
 	bridged := debinterfaces.Bridge(stanzas, devices)
-	c.Assert(format(bridged), gc.Equals, expected)
+	c.Check(format(bridged), gc.Equals, expected)
 	s.assertParse(c, format(bridged))
 }
 
-func (s *BridgeSuite) assertBridgeUnchanged(input string, c *gc.C, devices map[string]string) {
+func (s *BridgeSuite) checkBridgeUnchanged(input string, c *gc.C, devices map[string]string) {
 	stanzas := s.assertParse(c, input)
 	bridged := debinterfaces.Bridge(stanzas, devices)
-	c.Assert(format(bridged), gc.Equals, input[1:])
+	c.Check(format(bridged), gc.Equals, input[1:])
 	s.assertParse(c, format(bridged))
 }
 
@@ -59,7 +59,7 @@ func (s *BridgeSuite) TestBridgeDeviceNameNotMatched(c *gc.C) {
 	input := `
 auto eth0
 iface eth0 inet manual`
-	s.assertBridgeUnchanged(input, c, map[string]string{"non-existent-interface": "br-non-existent"})
+	s.checkBridgeUnchanged(input, c, map[string]string{"non-existent-interface": "br-non-existent"})
 }
 
 func (s *BridgeSuite) TestBridgeDeviceNameAlreadyBridged(c *gc.C) {
@@ -67,7 +67,7 @@ func (s *BridgeSuite) TestBridgeDeviceNameAlreadyBridged(c *gc.C) {
 auto br-eth0
 iface br-eth0 inet dhcp
     bridge_ports eth0`
-	s.assertBridgeUnchanged(input, c, map[string]string{"br-eth0": "br-eth0-2"})
+	s.checkBridgeUnchanged(input, c, map[string]string{"br-eth0": "br-eth0-2"})
 }
 
 func (s *BridgeSuite) TestBridgeDeviceIsBridgeable(c *gc.C) {
@@ -82,7 +82,7 @@ iface eth0 inet manual
 auto br-eth0
 iface br-eth0 inet dhcp
     bridge_ports eth0`
-	s.assertBridge(input, expected[1:], c, map[string]string{"eth0": "br-eth0"})
+	s.checkBridge(input, expected[1:], c, map[string]string{"eth0": "br-eth0"})
 }
 
 func (s *BridgeSuite) TestBridgeDeviceIsBridgeableButHasNoAutoStanza(c *gc.C) {
@@ -94,13 +94,13 @@ iface eth0 inet manual
 
 iface br-eth0 inet dhcp
     bridge_ports eth0`
-	s.assertBridge(input, expected[1:], c, map[string]string{"eth0": "br-eth0"})
+	s.checkBridge(input, expected[1:], c, map[string]string{"eth0": "br-eth0"})
 }
 
 func (s *BridgeSuite) TestBridgeDeviceIsNotBridgeable(c *gc.C) {
 	input := `
 iface work-wireless bootp`
-	s.assertBridgeUnchanged(input, c, map[string]string{"work-wireless": "br-work-wireless"})
+	s.checkBridgeUnchanged(input, c, map[string]string{"work-wireless": "br-work-wireless"})
 }
 
 func (s *BridgeSuite) TestBridgeSpecialOptionsGetMoved(c *gc.C) {
@@ -141,7 +141,7 @@ iface br-eth1 inet static
     dns-search ubuntu.com
     dns-sortlist 192.168.1.1/24 10.245.168.0/21 192.168.1.0/24
     bridge_ports eth1`
-	s.assertBridge(input, expected[1:], c, map[string]string{"eth0": "br-eth0", "eth1": "br-eth1"})
+	s.checkBridge(input, expected[1:], c, map[string]string{"eth0": "br-eth0", "eth1": "br-eth1"})
 }
 
 func (s *BridgeSuite) TestBridgeVLAN(c *gc.C) {
@@ -164,17 +164,35 @@ auto br-eth0.2
 iface br-eth0.2 inet static
     address 192.168.2.3/24
     bridge_ports eth0.2`
-	s.assertBridge(input, expected[1:], c, map[string]string{"eth0.2": "br-eth0.2"})
+	s.checkBridge(input, expected[1:], c, map[string]string{"eth0.2": "br-eth0.2"})
 }
 
 func (s *BridgeSuite) TestBridgeBond(c *gc.C) {
 	input := `
+auto eth0
+iface eth0 inet manual
+    bond-miimon 100
+    bond-master bond0
+    bond-mode active-backup
+    bond-lacp-rate slow
+    bond-xmit-hash-policy layer2
+    mtu 1500
+
+auto eth1
+iface eth1 inet manual
+    bond-miimon 100
+    bond-master bond0
+    bond-mode active-backup
+    bond-lacp-rate slow
+    bond-xmit-hash-policy layer2
+    mtu 1500
+
 auto bond0
 iface bond0 inet static
     address 10.17.20.211/24
     gateway 10.17.20.1
     dns-nameservers 10.17.20.200
-    bond-slaves none
+    bond-slaves eth0 eth1
     bond-mode active-backup
     bond-xmit_hash_policy layer2
     bond-miimon 100
@@ -183,9 +201,27 @@ iface bond0 inet static
     bond-lacp_rate slow`
 
 	expected := `
+auto eth0
+iface eth0 inet manual
+    bond-miimon 100
+    bond-master bond0
+    bond-mode active-backup
+    bond-lacp-rate slow
+    bond-xmit-hash-policy layer2
+    mtu 1500
+
+auto eth1
+iface eth1 inet manual
+    bond-miimon 100
+    bond-master bond0
+    bond-mode active-backup
+    bond-lacp-rate slow
+    bond-xmit-hash-policy layer2
+    mtu 1500
+
 auto bond0
 iface bond0 inet manual
-    bond-slaves none
+    bond-slaves eth0 eth1
     bond-mode active-backup
     bond-xmit_hash_policy layer2
     bond-miimon 100
@@ -200,7 +236,37 @@ iface br-bond0 inet static
     dns-nameservers 10.17.20.200
     hwaddress 52:54:00:1c:f1:5b
     bridge_ports bond0`
-	s.assertBridge(input, expected[1:], c, map[string]string{"bond0": "br-bond0"})
+	s.checkBridge(input, expected[1:], c, map[string]string{"bond0": "br-bond0"})
+}
+
+func (s *BridgeSuite) TestBridgingIdempotent(c *gc.C) {
+	input := `
+auto eth0
+iface eth0 inet manual
+    bond-miimon 100
+    bond-master bond0
+    bond-mode active-backup
+    bond-lacp-rate slow
+    bond-xmit-hash-policy layer2
+    mtu 1500
+
+auto bond0
+iface bond0 inet manual
+    bond-mode active-backup
+    bond-xmit-hash-policy layer2
+    hwaddress ether 7c:d3:0a:bb:e2:0a
+    bond-slaves eth0
+    mtu 1500
+    bond-lacp-rate slow
+    bond-miimon 100
+
+auto br-bond0
+iface br-bond0 inet static
+    address 10.20.2.253/22
+    gateway 10.20.0.1
+    bridge_ports bond0`
+
+	s.checkBridgeUnchanged(input, c, map[string]string{"bond0": "br-bond0", "bond0.1000": "br-bond0.1000", "bond0.1001": "br-bond0.1001", "bond0.1002": "br-bond0.1002"})
 }
 
 func (s *BridgeSuite) TestBridgeNoIfacesDefined(c *gc.C) {
@@ -210,7 +276,7 @@ mapping eth0
     map home,*,*,*                  home
     map work,*,*,00:11:22:33:44:55  work-wireless
     map work,*,*,01:12:23:34:45:50  work-static`
-	s.assertBridgeUnchanged(input, c, map[string]string{"eth0": "br-eth0"})
+	s.checkBridgeUnchanged(input, c, map[string]string{"eth0": "br-eth0"})
 }
 
 func (s *BridgeSuite) TestBridgeBondMaster(c *gc.C) {
@@ -223,14 +289,14 @@ iface ens5 inet manual
     bond-xmit_hash_policy layer2
     bond-mode active-backup
     bond-miimon 100`
-	s.assertBridgeUnchanged(input, c, map[string]string{"ens5": "br-ens5"})
+	s.checkBridgeUnchanged(input, c, map[string]string{"ens5": "br-ens5"})
 }
 
 func (s *BridgeSuite) TestBridgeNoIfacesDefinedFromFile(c *gc.C) {
 	stanzas, err := debinterfaces.ParseSource("testdata/ifupdown-examples", nil, s.expander)
 	c.Assert(err, gc.IsNil)
 	input := format(stanzas)
-	s.assertBridge(input, input, c, map[string]string{"non-existent-interface": "non-existent-bridge"})
+	s.checkBridge(input, input, c, map[string]string{"non-existent-interface": "non-existent-bridge"})
 }
 
 func (s *BridgeSuite) TestBridgeAlias(c *gc.C) {
@@ -257,7 +323,7 @@ iface br-eth0 inet static
     gateway 10.14.0.1
     address 10.14.0.102/24
     bridge_ports eth0`
-	s.assertBridge(input, expected[1:], c, map[string]string{"eth0": "br-eth0", "eth0:1": "br-eth0:1"})
+	s.checkBridge(input, expected[1:], c, map[string]string{"eth0": "br-eth0", "eth0:1": "br-eth0:1"})
 }
 
 func (s *BridgeSuite) TestBridgeMultipleInterfaces(c *gc.C) {
@@ -287,7 +353,7 @@ iface br-enp1s0f3 inet static
 
 iface br-enp1s0f3 inet6 dhcp
     bridge_ports enp1s0f3`
-	s.assertBridge(input, expected[1:], c, map[string]string{"enp1s0f3": "br-enp1s0f3"})
+	s.checkBridge(input, expected[1:], c, map[string]string{"enp1s0f3": "br-enp1s0f3"})
 }
 
 func (s *BridgeSuite) TestSourceStanzaWithRelativeFilenames(c *gc.C) {
@@ -358,5 +424,5 @@ iface br-xe0db55e41d5b inet6 static
     gateway 3ffe:1234:5678::2
     bridge_ports enxe0db55e41d5b`
 
-	s.assertBridge(input, expected[1:], c, map[string]string{"enxe0db55e41d5b": "br-xe0db55e41d5b"})
+	s.checkBridge(input, expected[1:], c, map[string]string{"enxe0db55e41d5b": "br-xe0db55e41d5b"})
 }


### PR DESCRIPTION
## Description of change
There's a bug in ifenslave - -i option is not passed along to calls for slave devices. This fix works around that.
Fix bug that caused the eni bridger not to be idempotent.

## QA steps
Add machine with bonded interface, add lxd container using this interface, everything should be working correctly (especially - IP address should be attached only to br-bond0, and not to bond0)

## Documentation changes
None

## Bug reference
https://bugs.launchpad.net/juju/+bug/1692297