### PR TITLE
ec2: start instance in same zone as existing volume attachment(s)

### DIFF
--- a/apiserver/params/internal.go
+++ b/apiserver/params/internal.go
@@ -606,16 +606,17 @@ type AgentVersionResult struct {
 
 // ProvisioningInfo holds machine provisioning info.
 type ProvisioningInfo struct {
-	Constraints      constraints.Value         `json:"constraints"`
-	Series           string                    `json:"series"`
-	Placement        string                    `json:"placement"`
-	Jobs             []multiwatcher.MachineJob `json:"jobs"`
-	Volumes          []VolumeParams            `json:"volumes,omitempty"`
-	Tags             map[string]string         `json:"tags,omitempty"`
-	SubnetsToZones   map[string][]string       `json:"subnets-to-zones,omitempty"`
-	ImageMetadata    []CloudImageMetadata      `json:"image-metadata,omitempty"`
-	EndpointBindings map[string]string         `json:"endpoint-bindings,omitempty"`
-	ControllerConfig map[string]interface{}    `json:"controller-config,omitempty"`
+	Constraints       constraints.Value         `json:"constraints"`
+	Series            string                    `json:"series"`
+	Placement         string                    `json:"placement"`
+	Jobs              []multiwatcher.MachineJob `json:"jobs"`
+	Volumes           []VolumeParams            `json:"volumes,omitempty"`
+	VolumeAttachments []VolumeAttachmentParams  `json:"volume-attachments,omitempty"`
+	Tags              map[string]string         `json:"tags,omitempty"`
+	SubnetsToZones    map[string][]string       `json:"subnets-to-zones,omitempty"`
+	ImageMetadata     []CloudImageMetadata      `json:"image-metadata,omitempty"`
+	EndpointBindings  map[string]string         `json:"endpoint-bindings,omitempty"`
+	ControllerConfig  map[string]interface{}    `json:"controller-config,omitempty"`
 }
 
 // ProvisioningInfoResult holds machine provisioning info or an error.

--- a/apiserver/provisioner/provisioner_test.go
+++ b/apiserver/provisioner/provisioner_test.go
@@ -28,7 +28,9 @@ import (
 	"github.com/juju/juju/state"
 	statetesting "github.com/juju/juju/state/testing"
 	"github.com/juju/juju/status"
+	"github.com/juju/juju/storage"
 	"github.com/juju/juju/storage/poolmanager"
+	"github.com/juju/juju/storage/provider"
 	coretesting "github.com/juju/juju/testing"
 )
 
@@ -978,7 +980,10 @@ func (s *withoutControllerSuite) TestConstraints(c *gc.C) {
 }
 
 func (s *withoutControllerSuite) TestSetInstanceInfo(c *gc.C) {
-	pm := poolmanager.New(state.NewStateSettings(s.State), dummy.StorageProviders())
+	pm := poolmanager.New(state.NewStateSettings(s.State), storage.ChainedProviderRegistry{
+		dummy.StorageProviders(),
+		provider.CommonStorageProviders(),
+	})
 	_, err := pm.Create("static-pool", "static", map[string]interface{}{"foo": "bar"})
 	c.Assert(err, jc.ErrorIsNil)
 	err = s.State.UpdateModelConfig(map[string]interface{}{

--- a/apiserver/provisioner/provisioninginfo_test.go
+++ b/apiserver/provisioner/provisioninginfo_test.go
@@ -6,6 +6,7 @@ package provisioner_test
 import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/apiserver/provisioner"
@@ -16,12 +17,17 @@ import (
 	"github.com/juju/juju/provider/dummy"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/multiwatcher"
+	"github.com/juju/juju/storage"
 	"github.com/juju/juju/storage/poolmanager"
+	"github.com/juju/juju/storage/provider"
 	coretesting "github.com/juju/juju/testing"
 )
 
 func (s *withoutControllerSuite) TestProvisioningInfoWithStorage(c *gc.C) {
-	pm := poolmanager.New(state.NewStateSettings(s.State), dummy.StorageProviders())
+	pm := poolmanager.New(state.NewStateSettings(s.State), storage.ChainedProviderRegistry{
+		dummy.StorageProviders(),
+		provider.CommonStorageProviders(),
+	})
 	_, err := pm.Create("static-pool", "static", map[string]interface{}{"foo": "bar"})
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -275,7 +281,7 @@ func (s *withoutControllerSuite) TestStorageProviderFallbackToType(c *gc.C) {
 		Jobs:      []state.MachineJob{state.JobHostUnits},
 		Placement: "valid",
 		Volumes: []state.MachineVolumeParams{
-			{Volume: state.VolumeParams{Size: 1000, Pool: "modelscoped"}},
+			{Volume: state.VolumeParams{Size: 1000, Pool: "loop"}},
 			{Volume: state.VolumeParams{Size: 1000, Pool: "static"}},
 		},
 	}
@@ -304,6 +310,8 @@ func (s *withoutControllerSuite) TestStorageProviderFallbackToType(c *gc.C) {
 					tags.JujuController: coretesting.ControllerTag.Id(),
 					tags.JujuModel:      coretesting.ModelTag.Id(),
 				},
+				// volume-0 should not be included as it is not managed by
+				// the environ provider.
 				Volumes: []params.VolumeParams{{
 					VolumeTag:  "volume-1",
 					Size:       1000,
@@ -322,6 +330,60 @@ func (s *withoutControllerSuite) TestStorageProviderFallbackToType(c *gc.C) {
 			}},
 		},
 	})
+}
+
+func (s *withoutControllerSuite) TestStorageProviderVolumes(c *gc.C) {
+	template := state.MachineTemplate{
+		Series: "quantal",
+		Jobs:   []state.MachineJob{state.JobHostUnits},
+		Volumes: []state.MachineVolumeParams{
+			{Volume: state.VolumeParams{Size: 1000, Pool: "modelscoped"}},
+			{Volume: state.VolumeParams{Size: 1000, Pool: "modelscoped"}},
+		},
+	}
+	machine, err := s.State.AddOneMachine(template)
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Provision just one of the volumes, but neither of the attachments.
+	err = s.State.SetVolumeInfo(names.NewVolumeTag("1"), state.VolumeInfo{
+		Pool:       "modelscoped",
+		Size:       1000,
+		VolumeId:   "vol-ume",
+		Persistent: true,
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	args := params.Entities{Entities: []params.Entity{
+		{Tag: machine.Tag().String()},
+	}}
+	result, err := s.provisioner.ProvisioningInfo(args)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result.Results[0].Error, gc.IsNil)
+	c.Assert(result.Results[0].Result, gc.NotNil)
+
+	// volume-0 should be created, as it hasn't yet been provisioned.
+	c.Assert(result.Results[0].Result.Volumes, jc.DeepEquals, []params.VolumeParams{{
+		VolumeTag: "volume-0",
+		Size:      1000,
+		Provider:  "modelscoped",
+		Tags: map[string]string{
+			tags.JujuController: coretesting.ControllerTag.Id(),
+			tags.JujuModel:      coretesting.ModelTag.Id(),
+		},
+		Attachment: &params.VolumeAttachmentParams{
+			MachineTag: machine.Tag().String(),
+			VolumeTag:  "volume-0",
+			Provider:   "modelscoped",
+		},
+	}})
+
+	// volume-1 has already been provisioned, it just needs to be attached.
+	c.Assert(result.Results[0].Result.VolumeAttachments, jc.DeepEquals, []params.VolumeAttachmentParams{{
+		MachineTag: machine.Tag().String(),
+		VolumeTag:  "volume-1",
+		VolumeId:   "vol-ume",
+		Provider:   "modelscoped",
+	}})
 }
 
 func (s *withoutControllerSuite) TestProvisioningInfoPermissions(c *gc.C) {

--- a/environs/broker.go
+++ b/environs/broker.go
@@ -55,6 +55,15 @@ type StartInstanceParams struct {
 	// for attachment to the instance being started.
 	Volumes []storage.VolumeParams
 
+	// VolumeAttachments is a set of parameters for existing volumes that
+	// should be attached. If the StartInstance method does not attach the
+	// volumes, they will be attached by the storage provisioner once the
+	// machine has been created. The attachments are presented here to
+	// give the provider an opportunity for the volume attachments to
+	// influence the instance creation, e.g. by restricting the machine
+	// to specific availability zones.
+	VolumeAttachments []storage.VolumeAttachmentParams
+
 	// NetworkInfo is an optional list of network interface details,
 	// necessary to configure on the instance.
 	NetworkInfo []network.InterfaceInfo
@@ -69,6 +78,7 @@ type StartInstanceParams struct {
 	// provider-specific space IDs. It is populated when provisioning a machine
 	// to host a unit of a service with endpoint bindings.
 	EndpointBindings map[string]network.Id
+
 	// ImageMetadata is a collection of image metadata
 	// that may be used to start this instance.
 	ImageMetadata []*imagemetadata.ImageMetadata

--- a/state/conn_test.go
+++ b/state/conn_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/juju/juju/state"
 	statetesting "github.com/juju/juju/state/testing"
 	"github.com/juju/juju/storage"
+	"github.com/juju/juju/storage/provider"
 	"github.com/juju/juju/testing"
 )
 
@@ -36,7 +37,10 @@ type ConnSuite struct {
 func (cs *ConnSuite) SetUpTest(c *gc.C) {
 	cs.policy = statetesting.MockPolicy{
 		GetStorageProviderRegistry: func() (storage.ProviderRegistry, error) {
-			return dummy.StorageProviders(), nil
+			return storage.ChainedProviderRegistry{
+				dummy.StorageProviders(),
+				provider.CommonStorageProviders(),
+			}, nil
 		},
 	}
 	cs.StateSuite.NewPolicy = func(*state.State) state.Policy {

--- a/state/conn_wallclock_test.go
+++ b/state/conn_wallclock_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/juju/juju/state"
 	statetesting "github.com/juju/juju/state/testing"
 	"github.com/juju/juju/storage"
+	"github.com/juju/juju/storage/provider"
 	"github.com/juju/juju/testing"
 )
 
@@ -38,7 +39,10 @@ type ConnWithWallClockSuite struct {
 func (cs *ConnWithWallClockSuite) SetUpTest(c *gc.C) {
 	cs.policy = statetesting.MockPolicy{
 		GetStorageProviderRegistry: func() (storage.ProviderRegistry, error) {
-			return dummy.StorageProviders(), nil
+			return storage.ChainedProviderRegistry{
+				dummy.StorageProviders(),
+				provider.CommonStorageProviders(),
+			}, nil
 		},
 	}
 	cs.StateWithWallClockSuite.NewPolicy = func(*state.State) state.Policy {

--- a/state/machine_test.go
+++ b/state/machine_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/testing"
 	"github.com/juju/juju/status"
+	"github.com/juju/juju/storage"
 	"github.com/juju/juju/storage/poolmanager"
 	"github.com/juju/juju/storage/provider"
 	coretesting "github.com/juju/juju/testing"
@@ -969,7 +970,10 @@ func (s *MachineSuite) addVolume(c *gc.C, params state.VolumeParams, machineId s
 }
 
 func (s *MachineSuite) TestMachineSetInstanceInfoSuccess(c *gc.C) {
-	pm := poolmanager.New(state.NewStateSettings(s.State), dummy.StorageProviders())
+	pm := poolmanager.New(state.NewStateSettings(s.State), storage.ChainedProviderRegistry{
+		dummy.StorageProviders(),
+		provider.CommonStorageProviders(),
+	})
 	_, err := pm.Create("loop-pool", provider.LoopProviderType, map[string]interface{}{})
 	c.Assert(err, jc.ErrorIsNil)
 

--- a/state/migration_export_test.go
+++ b/state/migration_export_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/cloudimagemetadata"
 	"github.com/juju/juju/status"
+	"github.com/juju/juju/storage"
 	"github.com/juju/juju/storage/poolmanager"
 	"github.com/juju/juju/storage/provider"
 	"github.com/juju/juju/testing/factory"
@@ -102,7 +103,10 @@ func (s *MigrationBaseSuite) makeUnitWithStorage(c *gc.C) (*state.Application, *
 	pool := "loop-pool"
 	kind := "block"
 	// Create a default pool for block devices.
-	pm := poolmanager.New(state.NewStateSettings(s.State), dummy.StorageProviders())
+	pm := poolmanager.New(state.NewStateSettings(s.State), storage.ChainedProviderRegistry{
+		dummy.StorageProviders(),
+		provider.CommonStorageProviders(),
+	})
 	_, err := pm.Create(pool, provider.LoopProviderType, map[string]interface{}{})
 	c.Assert(err, jc.ErrorIsNil)
 

--- a/state/storage_test.go
+++ b/state/storage_test.go
@@ -33,7 +33,10 @@ func (s *StorageStateSuiteBase) SetUpTest(c *gc.C) {
 	s.ConnSuite.SetUpTest(c)
 
 	// Create a default pool for block devices.
-	pm := poolmanager.New(state.NewStateSettings(s.State), dummy.StorageProviders())
+	pm := poolmanager.New(state.NewStateSettings(s.State), storage.ChainedProviderRegistry{
+		dummy.StorageProviders(),
+		provider.CommonStorageProviders(),
+	})
 	_, err := pm.Create("loop-pool", provider.LoopProviderType, map[string]interface{}{})
 	c.Assert(err, jc.ErrorIsNil)
 

--- a/state/testing/conn.go
+++ b/state/testing/conn.go
@@ -15,6 +15,8 @@ import (
 	"github.com/juju/juju/mongo"
 	"github.com/juju/juju/mongo/mongotest"
 	"github.com/juju/juju/state"
+	"github.com/juju/juju/storage"
+	"github.com/juju/juju/storage/provider"
 	dummystorage "github.com/juju/juju/storage/provider/dummy"
 	"github.com/juju/juju/testing"
 )
@@ -67,7 +69,10 @@ func InitializeWithArgs(c *gc.C, args InitializeArgs) *state.State {
 			CloudRegion: "dummy-region",
 			Config:      args.InitialConfig,
 			Owner:       args.Owner,
-			StorageProviderRegistry: dummystorage.StorageProviders(),
+			StorageProviderRegistry: storage.ChainedProviderRegistry{
+				dummystorage.StorageProviders(),
+				provider.CommonStorageProviders(),
+			},
 		},
 		ControllerInheritedConfig: args.ControllerInheritedConfig,
 		Cloud: cloud.Cloud{

--- a/state/volume_test.go
+++ b/state/volume_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/juju/juju/provider/dummy"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/testing"
+	"github.com/juju/juju/storage"
 	"github.com/juju/juju/storage/poolmanager"
 	"github.com/juju/juju/storage/provider"
 )
@@ -112,7 +113,10 @@ func (s *VolumeStateSuite) TestAddServiceNoUserDefaultPool(c *gc.C) {
 
 func (s *VolumeStateSuite) TestAddServiceDefaultPool(c *gc.C) {
 	// Register a default pool.
-	pm := poolmanager.New(state.NewStateSettings(s.State), dummy.StorageProviders())
+	pm := poolmanager.New(state.NewStateSettings(s.State), storage.ChainedProviderRegistry{
+		dummy.StorageProviders(),
+		provider.CommonStorageProviders(),
+	})
 	_, err := pm.Create("default-block", provider.LoopProviderType, map[string]interface{}{})
 	c.Assert(err, jc.ErrorIsNil)
 	err = s.State.UpdateModelConfig(map[string]interface{}{

--- a/storage/interface.go
+++ b/storage/interface.go
@@ -35,7 +35,7 @@ type ProviderRegistry interface {
 
 	// StorageProvider returns the storage provider with the given
 	// provider type. StorageProvider must return an errors satisfying
-	// errors.IsNotFound if the registry does not contain said the
+	// errors.IsNotFound if the registry does not contain the
 	// specified provider type.
 	StorageProvider(ProviderType) (Provider, error)
 }

--- a/storage/provider/dummy/common.go
+++ b/storage/provider/dummy/common.go
@@ -3,35 +3,29 @@
 
 package dummy
 
-import (
-	"github.com/juju/juju/storage"
-	"github.com/juju/juju/storage/provider"
-)
+import "github.com/juju/juju/storage"
 
 // StorageProviders returns a provider registry with some
 // well-defined dummy storage providers.
 func StorageProviders() storage.ProviderRegistry {
-	return storage.ChainedProviderRegistry{
-		storage.StaticProviderRegistry{
-			map[storage.ProviderType]storage.Provider{
-				"static": &StorageProvider{IsDynamic: false},
-				"modelscoped": &StorageProvider{
-					StorageScope: storage.ScopeEnviron,
-					IsDynamic:    true,
-				},
-				"modelscoped-block": &StorageProvider{
-					StorageScope: storage.ScopeEnviron,
-					IsDynamic:    true,
-					SupportsFunc: func(k storage.StorageKind) bool {
-						return k == storage.StorageKindBlock
-					},
-				},
-				"machinescoped": &StorageProvider{
-					StorageScope: storage.ScopeMachine,
-					IsDynamic:    true,
+	return storage.StaticProviderRegistry{
+		map[storage.ProviderType]storage.Provider{
+			"static": &StorageProvider{IsDynamic: false},
+			"modelscoped": &StorageProvider{
+				StorageScope: storage.ScopeEnviron,
+				IsDynamic:    true,
+			},
+			"modelscoped-block": &StorageProvider{
+				StorageScope: storage.ScopeEnviron,
+				IsDynamic:    true,
+				SupportsFunc: func(k storage.StorageKind) bool {
+					return k == storage.StorageKindBlock
 				},
 			},
+			"machinescoped": &StorageProvider{
+				StorageScope: storage.ScopeMachine,
+				IsDynamic:    true,
+			},
 		},
-		provider.CommonStorageProviders(),
 	}
 }

--- a/worker/uniter/runner/context/unitStorage_test.go
+++ b/worker/uniter/runner/context/unitStorage_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/provider/dummy"
 	"github.com/juju/juju/state"
+	"github.com/juju/juju/storage"
 	"github.com/juju/juju/storage/poolmanager"
 	"github.com/juju/juju/storage/provider"
 	"github.com/juju/juju/worker/uniter/runner/context"
@@ -135,7 +136,10 @@ func (s *unitStorageSuite) TestAddUnitStorageAccumulatedSame(c *gc.C) {
 
 func setupTestStorageSupport(c *gc.C, s *state.State) {
 	stsetts := state.NewStateSettings(s)
-	poolManager := poolmanager.New(stsetts, dummy.StorageProviders())
+	poolManager := poolmanager.New(stsetts, storage.ChainedProviderRegistry{
+		dummy.StorageProviders(),
+		provider.CommonStorageProviders(),
+	})
 	_, err := poolManager.Create(testPool, provider.LoopProviderType, map[string]interface{}{"it": "works"})
 	c.Assert(err, jc.ErrorIsNil)
 	_, err = poolManager.Create(testPersistentPool, "modelscoped", map[string]interface{}{"persistent": true})


### PR DESCRIPTION
## Description of change

Some providers, like AWS, require that VMs and attached disks/volumes be in the same availability zone. When deploying an application with --attach-storage, we should create the first unit's machine instance in the same availability zone as the existing volume.

## QA steps

1. juju bootstrap aws/ap-southeast-2
2. juju deploy postgresql --storage pgdata=ebs,10G --to zone=ap-southeast-2c
3. juju remove-application postgresql
4. juju deploy postgresql pg2 --attach-storage pgdata/0

pg2/0's machine should be in AZ ap-southeast-2c

## Documentation changes

Using "--to zone=..." will be incompatible with --attach-storage, unless you happen to specify the same zone as the volumes are in.

## Bug reference

None.