### PR TITLE
Update update-jenkins-slave.bash to utilize new git repos

### DIFF
--- a/acceptancetests/update-jenkins-slave.bash
+++ b/acceptancetests/update-jenkins-slave.bash
@@ -10,6 +10,7 @@ update_branch() {
     if [[ -d $local_path ]]; then
         # Clear any changes that haven't been commited to the branch.
         (cd $local_path; bzr revert; bzr pull)
+        cd ..
     else
         bzr branch $local_branch $local_path
     fi
@@ -37,7 +38,7 @@ update_git_repo() {
             chmod 600 $HOME/cloud-city/staging-juju-rsa
             chmod 600 $HOME/.ssh/id_rsa
             git pull $git_repo
-
+            cd ..
         fi
     else
         git clone $git_repo $local_path

--- a/acceptancetests/update-jenkins-slave.bash
+++ b/acceptancetests/update-jenkins-slave.bash
@@ -90,6 +90,9 @@ fi
 
 echo "Updating permissions"
 sudo chown -R jenkins $HOME/cloud-city
+chmod -R go-rwx $HOME/cloud-city
+chmod 700 $HOME/cloud-city/gnupg
+chmod 600 $HOME/cloud-city/staging-juju-rsa
 
 echo "Updating dependencies from branches"
 if [[ $OS == "ubuntu" ]]; then

--- a/acceptancetests/update-jenkins-slave.bash
+++ b/acceptancetests/update-jenkins-slave.bash
@@ -111,7 +111,7 @@ echo "Copying acceptancetests -> juju-ci-tools"
 rsync -avz --delete $HOME/juju/acceptancetests/ $HOME/juju-ci-tools/
 
 echo "Copying releasetests -> juju-release-tools"
-rsync -avz --delete $HOME/juju/acceptancetests/ $HOME/juju-release-tools/
+rsync -avz --delete $HOME/juju/releasetests/ $HOME/juju-release-tools/
 
 echo "Copying acceptancetests/repository -> repository"
 rsync -avz --delete $HOME/juju/acceptancetests/repository/ $HOME/repository/


### PR DESCRIPTION
## Description of change

This change switches over our CI slaves to use this repository as it's source, rather than the older lp sources. Nothing has changed (yet) with how the slaves are updated (or the fact they need to be). We'll make those changes in another PR.

## QA steps

We'll run this across slaves and deal with the fallout.

## Documentation changes

N/A

## Bug reference

N/A
