### PR TITLE
Fix add-storage for units without assigned machines

### DIFF
--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -21,7 +21,7 @@ github.com/juju/ansiterm	git	b99631de12cf04a906c1d4e4ec54fb86eae5863d	2016-09-07
 github.com/juju/blobstore	git	06056004b3d7b54bbb7984d830c537bad00fec21	2015-07-29T11:18:58Z
 github.com/juju/bundlechanges	git	7725027b95e0d54635e0fb11efc2debdcdf19f75	2016-12-15T16:06:52Z
 github.com/juju/cmd	git	e47739aefe0adb68a401fcd371c0c92c8f6f8d99	2017-04-13T02:13:06Z
-github.com/juju/description	git	142fe63614f1a2defb592b6bdf6bd0ee47fdccfd	2017-05-10T01:22:00Z
+github.com/juju/description	git	a720edaca89342e01beeb64ad190468468baf248	2017-05-25T03:39:51Z
 github.com/juju/errors	git	1b5e39b83d1835fa480e0c2ddefb040ee82d58b3	2015-09-16T12:56:42Z
 github.com/juju/gnuflag	git	4e76c56581859c14d9d87e1ddbe29e1c0f10195f	2016-08-09T16:52:14Z
 github.com/juju/go-oracle-cloud	git	932a8cea00a1cd5cba3829a672c823955db674ae	2017-04-21T13:45:47Z

--- a/state/migration_export.go
+++ b/state/migration_export.go
@@ -1744,12 +1744,14 @@ func (e *exporter) addStorage(instance *storageInstance, attachments []names.Uni
 	if !ok {
 		owner = nil
 	}
+	cons := description.StorageInstanceConstraints(instance.doc.Constraints)
 	args := description.StorageArgs{
 		Tag:         instance.StorageTag(),
 		Kind:        instance.Kind().String(),
 		Owner:       owner,
 		Name:        instance.StorageName(),
 		Attachments: attachments,
+		Constraints: &cons,
 	}
 	e.model.AddStorage(args)
 	return nil

--- a/state/migration_import_test.go
+++ b/state/migration_import_test.go
@@ -15,6 +15,7 @@ import (
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/charm.v6-unstable"
 	"gopkg.in/juju/names.v2"
+	"gopkg.in/yaml.v2"
 
 	"github.com/juju/juju/constraints"
 	"github.com/juju/juju/network"
@@ -56,9 +57,26 @@ func (s *MigrationImportSuite) TestExisting(c *gc.C) {
 	c.Assert(err, jc.Satisfies, errors.IsAlreadyExists)
 }
 
-func (s *MigrationImportSuite) importModel(c *gc.C) (*state.Model, *state.State) {
+func (s *MigrationImportSuite) importModel(c *gc.C, transform ...func(map[string]interface{})) (*state.Model, *state.State) {
 	out, err := s.State.Export()
 	c.Assert(err, jc.ErrorIsNil)
+
+	if len(transform) > 0 {
+		var outM map[string]interface{}
+		outYaml, err := description.Serialize(out)
+		c.Assert(err, jc.ErrorIsNil)
+		err = yaml.Unmarshal(outYaml, &outM)
+		c.Assert(err, jc.ErrorIsNil)
+
+		for _, transform := range transform {
+			transform(outM)
+		}
+
+		outYaml, err = yaml.Marshal(outM)
+		c.Assert(err, jc.ErrorIsNil)
+		out, err = description.Deserialize(outYaml)
+		c.Assert(err, jc.ErrorIsNil)
+	}
 
 	uuid := utils.MustNewUUID().String()
 	in := newModel(out, uuid, "new")
@@ -1107,12 +1125,89 @@ func (s *MigrationImportSuite) TestStorage(c *gc.C) {
 	c.Check(instance.Kind(), gc.Equals, original.Kind())
 	c.Check(instance.Life(), gc.Equals, original.Life())
 	c.Check(instance.StorageName(), gc.Equals, original.StorageName())
+	c.Check(instance.Pool(), gc.Equals, original.Pool())
 	c.Check(state.StorageAttachmentCount(instance), gc.Equals, originalCount)
 
 	attachments, err := newSt.StorageAttachments(storageTag)
-
 	c.Assert(attachments, gc.HasLen, 1)
 	c.Assert(attachments[0].Unit(), gc.Equals, u.UnitTag())
+}
+
+func (s *MigrationImportSuite) TestStorageInstanceConstraints(c *gc.C) {
+	_, _, storageTag := s.makeUnitWithStorage(c)
+	_, newSt := s.importModel(c, func(desc map[string]interface{}) {
+		storages := desc["storages"].(map[interface{}]interface{})
+		for _, item := range storages["storages"].([]interface{}) {
+			storage := item.(map[interface{}]interface{})
+			cons := storage["constraints"].(map[interface{}]interface{})
+			cons["pool"] = "static"
+		}
+	})
+	instance, err := newSt.StorageInstance(storageTag)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(instance.Pool(), gc.Equals, "static")
+}
+
+func (s *MigrationImportSuite) TestStorageInstanceConstraintsFallback(c *gc.C) {
+	_, u, storageTag0 := s.makeUnitWithStorage(c)
+
+	err := s.State.AddStorageForUnit(u.UnitTag(), "allecto", state.StorageConstraints{
+		Count: 3,
+		Size:  1234,
+		Pool:  "modelscoped",
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	storageTag1 := names.NewStorageTag("allecto/1")
+	storageTag2 := names.NewStorageTag("allecto/2")
+
+	// We delete the storage instance constraints for each storage
+	// instance. For data/0 and allecto/1 we also delete the volume,
+	// and we delete the application storage constraints for "data".
+	//
+	// We expect:
+	//  - for data/0, to get the defaults (loop, 1G)
+	//  - for allecto/1, to get the application storage constraints
+	//  - for allecto/2, to get the volume pool/size
+
+	_, newSt := s.importModel(c, func(desc map[string]interface{}) {
+		applications := desc["applications"].(map[interface{}]interface{})
+		volumes := desc["volumes"].(map[interface{}]interface{})
+		storages := desc["storages"].(map[interface{}]interface{})
+		storages["version"] = 2
+
+		app := applications["applications"].([]interface{})[0].(map[interface{}]interface{})
+		sc := app["storage-constraints"].(map[interface{}]interface{})
+		delete(sc, "data")
+		sc["allecto"].(map[interface{}]interface{})["pool"] = "modelscoped-block"
+
+		var keepVolumes []interface{}
+		for _, item := range volumes["volumes"].([]interface{}) {
+			volume := item.(map[interface{}]interface{})
+			switch volume["storage-id"] {
+			case storageTag0.Id(), storageTag1.Id():
+			default:
+				keepVolumes = append(keepVolumes, volume)
+			}
+		}
+		volumes["volumes"] = keepVolumes
+
+		for _, item := range storages["storages"].([]interface{}) {
+			storage := item.(map[interface{}]interface{})
+			delete(storage, "constraints")
+		}
+	})
+
+	instance0, err := newSt.StorageInstance(storageTag0)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(instance0.Pool(), gc.Equals, "loop")
+
+	instance1, err := newSt.StorageInstance(storageTag1)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(instance1.Pool(), gc.Equals, "modelscoped-block")
+
+	instance2, err := newSt.StorageInstance(storageTag2)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(instance2.Pool(), gc.Equals, "modelscoped")
 }
 
 func (s *MigrationImportSuite) TestStoragePools(c *gc.C) {

--- a/state/migration_internal_test.go
+++ b/state/migration_internal_test.go
@@ -771,6 +771,7 @@ func (s *MigrationSuite) TestStorageInstanceDocFields(c *gc.C) {
 		"Owner",
 		"StorageName",
 		"AttachmentCount", // through count of attachment instances
+		"Constraints",
 	)
 	s.AssertExportedFields(c, storageInstanceDoc{}, migrated.Union(ignored))
 }

--- a/state/storage.go
+++ b/state/storage.go
@@ -156,12 +156,20 @@ type storageInstanceDoc struct {
 	DocID     string `bson:"_id"`
 	ModelUUID string `bson:"model-uuid"`
 
-	Id              string      `bson:"id"`
-	Kind            StorageKind `bson:"storagekind"`
-	Life            Life        `bson:"life"`
-	Owner           string      `bson:"owner,omitempty"`
-	StorageName     string      `bson:"storagename"`
-	AttachmentCount int         `bson:"attachmentcount"`
+	Id              string                     `bson:"id"`
+	Kind            StorageKind                `bson:"storagekind"`
+	Life            Life                       `bson:"life"`
+	Owner           string                     `bson:"owner,omitempty"`
+	StorageName     string                     `bson:"storagename"`
+	AttachmentCount int                        `bson:"attachmentcount"`
+	Constraints     storageInstanceConstraints `bson:"constraints"`
+}
+
+// storageInstanceConstraints contains a subset of StorageConstraints,
+// for a single storage instance.
+type storageInstanceConstraints struct {
+	Pool string `bson:"pool"`
+	Size uint64 `bson:"size"`
 }
 
 type storageAttachment struct {
@@ -228,19 +236,31 @@ func (st *State) storageInstance(tag names.StorageTag) (*storageInstance, error)
 
 // AllStorageInstances lists all storage instances currently in state
 // for this Juju model.
-func (st *State) AllStorageInstances() (storageInstances []StorageInstance, err error) {
+func (st *State) AllStorageInstances() ([]StorageInstance, error) {
+	storageInstances, err := st.storageInstances(nil)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	out := make([]StorageInstance, len(storageInstances))
+	for i, s := range storageInstances {
+		out[i] = s
+	}
+	return out, nil
+}
+
+func (st *State) storageInstances(query bson.D) (storageInstances []*storageInstance, err error) {
 	storageCollection, closer := st.db().GetCollection(storageInstancesC)
 	defer closer()
 
 	sdocs := []storageInstanceDoc{}
-	err = storageCollection.Find(nil).All(&sdocs)
+	err = storageCollection.Find(query).All(&sdocs)
 	if err != nil {
-		return nil, errors.Annotate(err, "cannot get all storage instances")
+		return nil, errors.Annotate(err, "cannot get storage instances")
 	}
 	for _, doc := range sdocs {
 		storageInstances = append(storageInstances, &storageInstance{st, doc})
 	}
-	return
+	return storageInstances, nil
 }
 
 // DestroyStorageInstance ensures that the storage instance and all its
@@ -619,6 +639,7 @@ func createStorageOps(
 		ops = append(ops, incRefOp)
 
 		for i := uint64(0); i < t.cons.Count; i++ {
+			cons := cons[t.storageName]
 			id, err := newStorageInstanceId(st, t.storageName)
 			if err != nil {
 				return nil, -1, errors.Annotate(err, "cannot generate storage instance name")
@@ -628,6 +649,10 @@ func createStorageOps(
 				Kind:        kind,
 				Owner:       owner,
 				StorageName: t.storageName,
+				Constraints: storageInstanceConstraints{
+					Pool: cons.Pool,
+					Size: cons.Size,
+				},
 			}
 			var machineOps []txn.Op
 			if unitTag, ok := entityTag.(names.UnitTag); ok {
@@ -639,7 +664,7 @@ func createStorageOps(
 				if maybeMachineAssignable != nil {
 					var err error
 					machineOps, err = unitAssignedMachineStorageOps(
-						st, unitTag, charmMeta, cons, series,
+						st, unitTag, charmMeta, series,
 						&storageInstance{st, *doc},
 						maybeMachineAssignable,
 					)
@@ -680,13 +705,12 @@ func unitAssignedMachineStorageOps(
 	st *State,
 	unitTag names.UnitTag,
 	charmMeta *charm.Meta,
-	cons map[string]StorageConstraints,
 	series string,
 	storage *storageInstance,
 	machineAssignable machineAssignable,
 ) (ops []txn.Op, err error) {
 	storageParams, err := machineStorageParamsForStorageInstance(
-		st, charmMeta, unitTag, series, cons, storage,
+		st, charmMeta, unitTag, series, storage,
 	)
 	if err != nil {
 		return nil, errors.Trace(err)

--- a/state/storage.go
+++ b/state/storage.go
@@ -48,6 +48,10 @@ type StorageInstance interface {
 
 	// Life reports whether the storage instance is Alive, Dying or Dead.
 	Life() Life
+
+	// Pool returns the name of the storage pool from which the storage
+	// instance has been or will be provisioned.
+	Pool() string
 }
 
 // StorageAttachment represents the state of a unit's attachment to a storage
@@ -142,6 +146,10 @@ func (s *storageInstance) StorageName() string {
 
 func (s *storageInstance) Life() Life {
 	return s.doc.Life
+}
+
+func (s *storageInstance) Pool() string {
+	return s.doc.Constraints.Pool
 }
 
 // entityStorageRefcountKey returns a key for refcounting charm storage

--- a/state/unit.go
+++ b/state/unit.go
@@ -1796,10 +1796,6 @@ func unitMachineStorageParams(u *Unit) (*machineStorageParams, error) {
 	if err != nil {
 		return nil, errors.Annotate(err, "getting charm")
 	}
-	allCons, err := u.StorageConstraints()
-	if err != nil {
-		return nil, errors.Annotatef(err, "getting storage constraints")
-	}
 
 	// Sort storage attachments so the volume ids are consistent (for testing).
 	sort.Sort(byStorageInstance(storageAttachments))
@@ -1816,7 +1812,7 @@ func unitMachineStorageParams(u *Unit) (*machineStorageParams, error) {
 			return nil, errors.Annotatef(err, "getting storage instance")
 		}
 		machineParams, err := machineStorageParamsForStorageInstance(
-			u.st, chMeta, u.UnitTag(), u.Series(), allCons, storage,
+			u.st, chMeta, u.UnitTag(), u.Series(), storage,
 		)
 		if err != nil {
 			return nil, errors.Trace(err)
@@ -1850,7 +1846,6 @@ func machineStorageParamsForStorageInstance(
 	charmMeta *charm.Meta,
 	unit names.UnitTag,
 	series string,
-	allCons map[string]StorageConstraints,
 	storage *storageInstance,
 ) (*machineStorageParams, error) {
 
@@ -1869,11 +1864,10 @@ func machineStorageParamsForStorageInstance(
 		if unit == storage.maybeOwner() {
 			// The storage instance is owned by the unit, so we'll need
 			// to create a volume.
-			cons := allCons[storage.StorageName()]
 			volumeParams := VolumeParams{
 				storage: storage.StorageTag(),
-				Pool:    cons.Pool,
-				Size:    cons.Size,
+				Pool:    storage.doc.Constraints.Pool,
+				Size:    storage.doc.Constraints.Size,
 			}
 			volumes = append(volumes, MachineVolumeParams{
 				volumeParams, volumeAttachmentParams,
@@ -1904,11 +1898,10 @@ func machineStorageParamsForStorageInstance(
 		if unit == storage.maybeOwner() {
 			// The storage instance is owned by the unit, so we'll need
 			// to create a filesystem.
-			cons := allCons[storage.StorageName()]
 			filesystemParams := FilesystemParams{
 				storage: storage.StorageTag(),
-				Pool:    cons.Pool,
-				Size:    cons.Size,
+				Pool:    storage.doc.Constraints.Pool,
+				Size:    storage.doc.Constraints.Size,
 			}
 			filesystems = append(filesystems, MachineFilesystemParams{
 				filesystemParams, filesystemAttachmentParams,

--- a/state/upgrades.go
+++ b/state/upgrades.go
@@ -20,6 +20,7 @@ import (
 	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/controller"
 	"github.com/juju/juju/environs/config"
+	"github.com/juju/juju/storage/provider"
 )
 
 var upgradesLogger = loggo.GetLogger("juju.state.upgrade")
@@ -708,6 +709,103 @@ func AddStatusHistoryPruneSettings(st *State) error {
 	}
 	if len(ops) > 0 {
 		return errors.Trace(st.runRawTransaction(ops))
+	}
+	return nil
+}
+
+// AddStorageInstanceConstraints sets the "constraints" field on
+// storage instance docs.
+func AddStorageInstanceConstraints(st *State) error {
+	return runForAllModelStates(st, addStorageInstanceConstraints)
+}
+
+func addStorageInstanceConstraints(st *State) error {
+	storageInstances, err := st.storageInstances(bson.D{
+		{"constraints", bson.D{{"$exists", false}}},
+	})
+	if err != nil {
+		return errors.Trace(err)
+	}
+	var ops []txn.Op
+	for _, s := range storageInstances {
+		var siCons storageInstanceConstraints
+		var defaultPool string
+		switch s.Kind() {
+		case StorageKindBlock:
+			v, err := st.storageInstanceVolume(s.StorageTag())
+			if err == nil {
+				if v.doc.Info != nil {
+					siCons.Pool = v.doc.Info.Pool
+					siCons.Size = v.doc.Info.Size
+				} else if v.doc.Params != nil {
+					siCons.Pool = v.doc.Params.Pool
+					siCons.Size = v.doc.Params.Size
+				}
+			} else if errors.IsNotFound(err) {
+				defaultPool = string(provider.LoopProviderType)
+			} else {
+				return errors.Trace(err)
+			}
+		case StorageKindFilesystem:
+			f, err := st.storageInstanceFilesystem(s.StorageTag())
+			if err == nil {
+				if f.doc.Info != nil {
+					siCons.Pool = f.doc.Info.Pool
+					siCons.Size = f.doc.Info.Size
+				} else if f.doc.Params != nil {
+					siCons.Pool = f.doc.Params.Pool
+					siCons.Size = f.doc.Params.Size
+				}
+			} else if errors.IsNotFound(err) {
+				defaultPool = string(provider.RootfsProviderType)
+			} else {
+				return errors.Trace(err)
+			}
+		default:
+			// Unknown storage kind, ignore.
+			continue
+		}
+		if siCons.Pool == "" {
+			// There's no associated volume or filesystem, so
+			// take constraints from the application storage
+			// constraints. This could be wrong, but we've got
+			// nothing else to go on, and this will match the
+			// old broken behaviour at least.
+			//
+			// If there's no owner, just use the defaults.
+			siCons.Pool = defaultPool
+			siCons.Size = 1024
+			if ownerTag := s.maybeOwner(); ownerTag != nil {
+				type withStorageConstraints interface {
+					StorageConstraints() (map[string]StorageConstraints, error)
+				}
+				owner, err := st.FindEntity(ownerTag)
+				if err != nil {
+					return errors.Trace(err)
+				}
+				if owner, ok := owner.(withStorageConstraints); ok {
+					allCons, err := owner.StorageConstraints()
+					if err != nil {
+						return errors.Trace(err)
+					}
+					if cons, ok := allCons[s.StorageName()]; ok {
+						siCons.Pool = cons.Pool
+						siCons.Size = cons.Size
+					}
+				}
+			}
+		}
+		ops = append(ops, txn.Op{
+			C:      storageInstancesC,
+			Id:     s.doc.Id,
+			Assert: txn.DocExists,
+			Update: bson.D{{"$set", bson.D{
+				{"constraints", siCons},
+			}}},
+		})
+	}
+	if len(ops) > 0 {
+		return errors.Trace(st.runTransaction(ops))
 	}
 	return nil
 }

--- a/state/upgrades.go
+++ b/state/upgrades.go
@@ -794,6 +794,10 @@ func addStorageInstanceConstraints(st *State) error {
 					}
 				}
 			}
+			logger.Warningf(
+				"no volume or filesystem found, using application storage constraints for %s",
+				names.ReadableString(s.Tag()),
+			)
 		}
 		ops = append(ops, txn.Op{
 			C:      storageInstancesC,

--- a/upgrades/backend.go
+++ b/upgrades/backend.go
@@ -29,6 +29,7 @@ type StateBackend interface {
 	RemoveNilValueApplicationSettings() error
 	AddControllerLogPruneSettings() error
 	AddStatusHistoryPruneSettings() error
+	AddStorageInstanceConstraints() error
 }
 
 // Model is an interface providing access to the details of a model within the
@@ -105,6 +106,10 @@ func (s stateBackend) AddControllerLogPruneSettings() error {
 
 func (s stateBackend) AddStatusHistoryPruneSettings() error {
 	return state.AddStatusHistoryPruneSettings(s.st)
+}
+
+func (s stateBackend) AddStorageInstanceConstraints() error {
+	return state.AddStorageInstanceConstraints(s.st)
 }
 
 type modelShim struct {

--- a/upgrades/steps_22.go
+++ b/upgrades/steps_22.go
@@ -39,6 +39,13 @@ func stateStepsFor22() []Step {
 				return context.State().AddStatusHistoryPruneSettings()
 			},
 		},
+		&upgradeStep{
+			description: "add storage constraints to storage instance docs",
+			targets:     []Target{DatabaseMaster},
+			run: func(context Context) error {
+				return context.State().AddStorageInstanceConstraints()
+			},
+		},
 	}
 }
 

--- a/upgrades/steps_22_test.go
+++ b/upgrades/steps_22_test.go
@@ -65,3 +65,9 @@ func (s *steps22Suite) TestAddStatusHistoryPruneSettings(c *gc.C) {
 	// Logic for step itself is tested in state package.
 	c.Assert(step.Targets(), jc.DeepEquals, []upgrades.Target{upgrades.DatabaseMaster})
 }
+
+func (s *steps22Suite) TestAddStorageInstanceConstraints(c *gc.C) {
+	step := findStateStep(c, v220, "add storage constraints to storage instance docs")
+	// Logic for step itself is tested in state package.
+	c.Assert(step.Targets(), jc.DeepEquals, []upgrades.Target{upgrades.DatabaseMaster})
+}


### PR DESCRIPTION
## Description of change

When adding a storage instance, store the constraints
in the storage instance document. These will be used
to create the associated volume or filesystem when
assigning the application unit that owns the storage
to a machine.

## QA steps

1. juju bootstrap aws
2. juju deploy ceph-osd && juju add-storage ceph-osd/0 osd-devices=ebs,10G,1
(wait for ceph-osd/0 to be active, it should have ebs attached)
3. juju add-storage ceph-osd/0 osd-devices=ebs,10G,1
(another ebs volume should be attached)

## Documentation changes

None.

## Bug reference

Fixes https://bugs.launchpad.net/juju/+bug/1692729