### PR TITLE
Restart agent when txn log errors occur; provider configurable txn log size

### DIFF
--- a/agent/agentbootstrap/bootstrap_test.go
+++ b/agent/agentbootstrap/bootstrap_test.go
@@ -224,6 +224,7 @@ LXC_BRIDGE="ignored"`[1:])
 		"set-numa-control-policy": false,
 		"max-logs-age":            "72h",
 		"max-logs-size":           "4G",
+		"max-txn-log-size":        "10M",
 	})
 
 	// Check that controller model configuration has been added, and

--- a/api/watcher/watcher.go
+++ b/api/watcher/watcher.go
@@ -14,6 +14,7 @@ import (
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/core/migration"
 	"github.com/juju/juju/watcher"
+	"github.com/juju/juju/worker"
 )
 
 var logger = loggo.GetLogger("juju.api.watcher")
@@ -83,7 +84,10 @@ func (w *commonWatcher) commonLoop() {
 		defer wg.Done()
 		<-w.tomb.Dying()
 		if err := w.call("Stop", nil); err != nil {
-			logger.Errorf("error trying to stop watcher: %v", err)
+			// Don't log an error if a watcher is stopped due to an agent restart.
+			if err.Error() != worker.ErrRestartAgent.Error() {
+				logger.Errorf("error trying to stop watcher: %v", err)
+			}
 		}
 	}()
 	wg.Add(1)

--- a/cmd/juju/backups/restore_test.go
+++ b/cmd/juju/backups/restore_test.go
@@ -238,6 +238,7 @@ func (s *restoreSuite) TestRestoreReboostrapWritesUpdatedControllerInfo(c *gc.C)
 			"set-numa-control-policy": false,
 			"max-logs-age":            "72h",
 			"max-logs-size":           "4G",
+			"max-txn-log-size":        "10M",
 		})
 		boostrapped = true
 		return nil

--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -853,6 +853,10 @@ func (a *MachineAgent) openStateForUpgrade() (*state.State, error) {
 		NewPolicy: stateenvirons.GetNewPolicyFunc(
 			stateenvirons.GetNewEnvironFunc(environs.New),
 		),
+		// state.InitDatabase is idempotent and needs to be called just
+		// prior to performing any upgrades since a new Juju binary may
+		// declare new indices or explicit collections.
+		InitDatabaseFunc:       state.InitDatabase,
 		RunTransactionObserver: a.txnmetricsCollector.AfterRunTransaction,
 	})
 	if err != nil {

--- a/cmd/jujud/util/util.go
+++ b/cmd/jujud/util/util.go
@@ -37,7 +37,7 @@ func RequiredError(name string) error {
 func IsFatal(err error) bool {
 	err = errors.Cause(err)
 	switch err {
-	case jworker.ErrTerminateAgent, jworker.ErrRebootMachine, jworker.ErrShutdownMachine:
+	case jworker.ErrTerminateAgent, jworker.ErrRebootMachine, jworker.ErrShutdownMachine, jworker.ErrRestartAgent:
 		return true
 	}
 
@@ -112,6 +112,9 @@ func AgentDone(logger loggo.Logger, err error) error {
 			logger.Infof(err.Error())
 			return err
 		}
+	}
+	if err == jworker.ErrRestartAgent {
+		logger.Warningf("agent restarting")
 	}
 	return err
 }

--- a/cmd/jujud/util/util_test.go
+++ b/cmd/jujud/util/util_test.go
@@ -54,6 +54,12 @@ var isFatalTests = []struct {
 		err:     errors.Trace(worker.ErrTerminateAgent),
 		isFatal: true,
 	}, {
+		err:     worker.ErrRestartAgent,
+		isFatal: true,
+	}, {
+		err:     errors.Trace(worker.ErrRestartAgent),
+		isFatal: true,
+	}, {
 		err:     &upgrader.UpgradeReadyError{},
 		isFatal: true,
 	}, {

--- a/controller/config_test.go
+++ b/controller/config_test.go
@@ -155,3 +155,21 @@ func (s *ConfigSuite) TestLogConfigValues(c *gc.C) {
 	c.Assert(cfg.MaxLogsAge(), gc.Equals, 96*time.Hour)
 	c.Assert(cfg.MaxLogSizeMB(), gc.Equals, 8192)
 }
+
+func (s *ConfigSuite) TestTxnLogConfigDefault(c *gc.C) {
+	cfg, err := controller.NewConfig(testing.ControllerTag.Id(), testing.CACert, nil)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(cfg.MaxTxnLogSizeMB(), gc.Equals, 10)
+}
+
+func (s *ConfigSuite) TestTxnLogConfigValue(c *gc.C) {
+	cfg, err := controller.NewConfig(
+		testing.ControllerTag.Id(),
+		testing.CACert,
+		map[string]interface{}{
+			"max-txn-log-size": "8G",
+		},
+	)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(cfg.MaxTxnLogSizeMB(), gc.Equals, 8192)
+}

--- a/mongo/oplog.go
+++ b/mongo/oplog.go
@@ -85,19 +85,20 @@ func isRealOplog(c *mgo.Collection) bool {
 	return c.Database.Name == "local" && c.Name == "oplog.rs"
 }
 
-// OplogIterator defines the parts of the mgo.Iter that we use - this
+// Iterator defines the parts of the mgo.Iter that we use - this
 // interface allows us to switch out the querying for testing.
-type OplogIterator interface {
+type Iterator interface {
 	Next(interface{}) bool
 	Err() error
 	Timeout() bool
+	Close() error
 }
 
 // OplogSession represents a connection to the oplog store, used
 // to create an iterator to get oplog documents (and recreate it if it
 // gets killed or times out).
 type OplogSession interface {
-	NewIter(bson.MongoTimestamp, []int64) OplogIterator
+	NewIter(bson.MongoTimestamp, []int64) Iterator
 	Close()
 }
 
@@ -129,7 +130,7 @@ func NewOplogSession(collection *mgo.Collection, query bson.D) *oplogSession {
 
 const oplogTailTimeout = time.Second
 
-func (s *oplogSession) NewIter(fromTimestamp bson.MongoTimestamp, excludeIds []int64) OplogIterator {
+func (s *oplogSession) NewIter(fromTimestamp bson.MongoTimestamp, excludeIds []int64) Iterator {
 	// When recreating the iterator (required when the cursor
 	// is invalidated) avoid reporting oplog entries that have
 	// already been reported.
@@ -219,7 +220,7 @@ func (t *OplogTailer) Err() error {
 }
 
 func (t *OplogTailer) loop() error {
-	var iter OplogIterator
+	var iter Iterator
 
 	// lastTimestamp tracks the most recent oplog timestamp reported.
 	lastTimestamp := t.initialTs

--- a/mongo/oplog_test.go
+++ b/mongo/oplog_test.go
@@ -346,6 +346,10 @@ func (i *fakeIterator) Timeout() bool {
 	return i.timeout
 }
 
+func (i *fakeIterator) Close() error {
+	return nil
+}
+
 func newFakeIterator(err error, docs ...*mongo.OplogDoc) *fakeIterator {
 	return &fakeIterator{docs: docs, err: err}
 }
@@ -363,7 +367,7 @@ type fakeSession struct {
 
 var timeoutIterator = fakeIterator{timeout: true}
 
-func (s *fakeSession) NewIter(ts bson.MongoTimestamp, ids []int64) mongo.OplogIterator {
+func (s *fakeSession) NewIter(ts bson.MongoTimestamp, ids []int64) mongo.Iterator {
 	if s.pos >= len(s.iterators) {
 		// We've run out of results - at this point the calls to get
 		// more data would just keep timing out.

--- a/state/database.go
+++ b/state/database.go
@@ -10,10 +10,10 @@ import (
 	"github.com/juju/errors"
 	jujutxn "github.com/juju/txn"
 	"github.com/juju/utils/featureflag"
-	"gopkg.in/juju/names.v2"
 	"gopkg.in/mgo.v2"
 	"gopkg.in/mgo.v2/txn"
 
+	"github.com/juju/juju/controller"
 	"github.com/juju/juju/feature"
 	"github.com/juju/juju/mongo"
 )
@@ -173,37 +173,34 @@ type collectionInfo struct {
 // collectionSchema defines the set of collections used in juju.
 type collectionSchema map[string]collectionInfo
 
-// Load causes all recorded collections to be created and indexed as specified;
-// the returned Database will filter queries and transactions according to the
-// suppplied model UUID.
-func (schema collectionSchema) Load(
+// Create causes all recorded collections to be created and indexed as specified
+func (schema collectionSchema) Create(
 	db *mgo.Database,
-	modelUUID string,
-	runTransactionObserver RunTransactionObserverFunc,
-) (Database, error) {
-	if !names.IsValidModel(modelUUID) {
-		return nil, errors.New("invalid model UUID")
-	}
+	settings controller.Config,
+) error {
 	for name, info := range schema {
 		rawCollection := db.C(name)
 		if spec := info.explicitCreate; spec != nil {
+			// We allow the max txn log collection size to be overridden by the user.
+			if name == txnLogC {
+				maxSize := settings.MaxTxnLogSizeMB()
+				if maxSize > 0 {
+					logger.Infof("overriding max txn log collection size: %dM", maxSize)
+					spec.MaxBytes = maxSize * 1024 * 1024
+				}
+			}
 			if err := createCollection(rawCollection, spec); err != nil {
 				message := fmt.Sprintf("cannot create collection %q", name)
-				return nil, maybeUnauthorized(err, message)
+				return maybeUnauthorized(err, message)
 			}
 		}
 		for _, index := range info.indexes {
 			if err := rawCollection.EnsureIndex(index); err != nil {
-				return nil, maybeUnauthorized(err, "cannot create index")
+				return maybeUnauthorized(err, "cannot create index")
 			}
 		}
 	}
-	return &database{
-		raw:                    db,
-		schema:                 schema,
-		modelUUID:              modelUUID,
-		runTransactionObserver: runTransactionObserver,
-	}, nil
+	return nil
 }
 
 // createCollection swallows collection-already-exists errors.

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -4564,13 +4564,22 @@ func (s *StateSuite) TestRunTransactionObserver(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	calls := getCalls()
-	c.Assert(calls, gc.HasLen, 1)
-	c.Assert(calls[0].dbName, gc.Equals, "juju")
-	c.Assert(calls[0].modelUUID, gc.Equals, s.modelTag.Id())
-	c.Assert(calls[0].err, gc.IsNil)
-	c.Assert(calls[0].ops, gc.HasLen, 1)
-	c.Assert(calls[0].ops[0].C, gc.Equals, "constraints")
-	c.Assert(calls[0].ops[0].Update, gc.NotNil)
+	// There may be some leadership txns in the call list.
+	// We onlt care about the constraints call.
+	found := false
+	for _, call := range calls {
+		if call.ops[0].C != "constraints" {
+			continue
+		}
+		c.Check(call.dbName, gc.Equals, "juju")
+		c.Check(call.modelUUID, gc.Equals, s.modelTag.Id())
+		c.Check(call.err, gc.IsNil)
+		c.Check(call.ops, gc.HasLen, 1)
+		c.Check(call.ops[0].Update, gc.NotNil)
+		found = true
+		break
+	}
+	c.Assert(found, jc.IsTrue)
 }
 
 type SetAdminMongoPasswordSuite struct {

--- a/state/testing/conn.go
+++ b/state/testing/conn.go
@@ -75,19 +75,19 @@ func InitializeWithArgs(c *gc.C, args InitializeArgs) *state.State {
 			Type:      "dummy",
 			AuthTypes: []cloud.AuthType{cloud.EmptyAuthType},
 			Regions: []cloud.Region{
-				cloud.Region{
+				{
 					Name:             "dummy-region",
 					Endpoint:         "dummy-endpoint",
 					IdentityEndpoint: "dummy-identity-endpoint",
 					StorageEndpoint:  "dummy-storage-endpoint",
 				},
-				cloud.Region{
+				{
 					Name:             "nether-region",
 					Endpoint:         "nether-endpoint",
 					IdentityEndpoint: "nether-identity-endpoint",
 					StorageEndpoint:  "nether-storage-endpoint",
 				},
-				cloud.Region{
+				{
 					Name:             "unused-region",
 					Endpoint:         "unused-endpoint",
 					IdentityEndpoint: "unused-identity-endpoint",

--- a/state/upgrades.go
+++ b/state/upgrades.go
@@ -636,9 +636,9 @@ func RemoveNilValueApplicationSettings(st *State) error {
 	return nil
 }
 
-// AddControllerLogPruneSettings adds the controller
-// settings to control log pruning if they are missing.
-func AddControllerLogPruneSettings(st *State) error {
+// AddControllerLogCollectionsSizeSettings adds the controller
+// settings to control log pruning and txn log size if they are missing.
+func AddControllerLogCollectionsSizeSettings(st *State) error {
 	coll, closer := st.getRawCollection(controllersC)
 	defer closer()
 	var doc settingsDoc
@@ -653,6 +653,8 @@ func AddControllerLogPruneSettings(st *State) error {
 	settingsChanged := maybeUpdateSettings(doc.Settings, controller.MaxLogsAge, fmt.Sprintf("%vh", controller.DefaultMaxLogsAgeDays*24))
 	settingsChanged =
 		maybeUpdateSettings(doc.Settings, controller.MaxLogsSize, fmt.Sprintf("%vM", controller.DefaultMaxLogCollectionMB)) || settingsChanged
+	settingsChanged =
+		maybeUpdateSettings(doc.Settings, controller.MaxTxnLogSize, fmt.Sprintf("%vM", controller.DefaultMaxTxnLogCollectionMB)) || settingsChanged
 	if settingsChanged {
 		ops = append(ops, txn.Op{
 			C:      controllersC,

--- a/state/upgrades_test.go
+++ b/state/upgrades_test.go
@@ -928,7 +928,7 @@ func (s *upgradesSuite) TestRemoveNilValueApplicationSettings(c *gc.C) {
 	)
 }
 
-func (s *upgradesSuite) TestAddControllerLogPruneSettingsKeepExisting(c *gc.C) {
+func (s *upgradesSuite) TestAddControllerLogCollectionsSizeSettingsKeepExisting(c *gc.C) {
 	settingsColl, settingsCloser := s.state.getRawCollection(controllersC)
 	defer settingsCloser()
 	_, err := settingsColl.RemoveAll(nil)
@@ -936,9 +936,10 @@ func (s *upgradesSuite) TestAddControllerLogPruneSettingsKeepExisting(c *gc.C) {
 	err = settingsColl.Insert(bson.M{
 		"_id": "controllerSettings",
 		"settings": bson.M{
-			"key":           "value",
-			"max-logs-age":  "96h",
-			"max-logs-size": "5G",
+			"key":              "value",
+			"max-logs-age":     "96h",
+			"max-logs-size":    "5G",
+			"max-txn-log-size": "8G",
 		},
 	}, bson.M{
 		"_id": "someothersettingshouldnotbetouched",
@@ -951,9 +952,10 @@ func (s *upgradesSuite) TestAddControllerLogPruneSettingsKeepExisting(c *gc.C) {
 		{
 			"_id": "controllerSettings",
 			"settings": bson.M{
-				"key":           "value",
-				"max-logs-age":  "96h",
-				"max-logs-size": "5G",
+				"key":              "value",
+				"max-logs-age":     "96h",
+				"max-logs-size":    "5G",
+				"max-txn-log-size": "8G",
 			},
 		}, {
 			"_id":      "someothersettingshouldnotbetouched",
@@ -961,12 +963,12 @@ func (s *upgradesSuite) TestAddControllerLogPruneSettingsKeepExisting(c *gc.C) {
 		},
 	}
 
-	s.assertUpgradedData(c, AddControllerLogPruneSettings,
+	s.assertUpgradedData(c, AddControllerLogCollectionsSizeSettings,
 		expectUpgradedData{settingsColl, expectedSettings},
 	)
 }
 
-func (s *upgradesSuite) TestAddControllerLogPruneSettings(c *gc.C) {
+func (s *upgradesSuite) TestAddControllerLogCollectionsSizeSettings(c *gc.C) {
 	settingsColl, settingsCloser := s.state.getRawCollection(controllersC)
 	defer settingsCloser()
 	_, err := settingsColl.RemoveAll(nil)
@@ -985,9 +987,10 @@ func (s *upgradesSuite) TestAddControllerLogPruneSettings(c *gc.C) {
 		{
 			"_id": "controllerSettings",
 			"settings": bson.M{
-				"key":           "value",
-				"max-logs-age":  "72h",
-				"max-logs-size": "4096M",
+				"key":              "value",
+				"max-logs-age":     "72h",
+				"max-logs-size":    "4096M",
+				"max-txn-log-size": "10M",
 			},
 		}, {
 			"_id":      "someothersettingshouldnotbetouched",
@@ -995,7 +998,7 @@ func (s *upgradesSuite) TestAddControllerLogPruneSettings(c *gc.C) {
 		},
 	}
 
-	s.assertUpgradedData(c, AddControllerLogPruneSettings,
+	s.assertUpgradedData(c, AddControllerLogCollectionsSizeSettings,
 		expectUpgradedData{settingsColl, expectedSettings},
 	)
 }

--- a/state/watcher/export_text.go
+++ b/state/watcher/export_text.go
@@ -1,0 +1,14 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package watcher
+
+import (
+	"gopkg.in/mgo.v2"
+
+	"github.com/juju/juju/mongo"
+)
+
+func NewTestWatcher(changelog *mgo.Collection, iteratorFunc func() mongo.Iterator) *Watcher {
+	return newWatcher(changelog, iteratorFunc)
+}

--- a/state/watcher/watcher.go
+++ b/state/watcher/watcher.go
@@ -114,7 +114,11 @@ var Period time.Duration = 5 * time.Second
 
 // New returns a new Watcher observing the changelog collection,
 // which must be a capped collection maintained by mgo/txn.
-func New(changelog *mgo.Collection, iteratorFunc func() mongo.Iterator) *Watcher {
+func New(changelog *mgo.Collection) *Watcher {
+	return newWatcher(changelog, nil)
+}
+
+func newWatcher(changelog *mgo.Collection, iteratorFunc func() mongo.Iterator) *Watcher {
 	w := &Watcher{
 		log:          changelog,
 		iteratorFunc: iteratorFunc,

--- a/state/watcher/watcher.go
+++ b/state/watcher/watcher.go
@@ -8,6 +8,7 @@ package watcher
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/juju/errors"
@@ -16,14 +17,18 @@ import (
 	"gopkg.in/mgo.v2"
 	"gopkg.in/mgo.v2/bson"
 	"gopkg.in/tomb.v1"
+
+	"github.com/juju/juju/mongo"
+	jworker "github.com/juju/juju/worker"
 )
 
 var logger = loggo.GetLogger("juju.state.watcher")
 
 // A Watcher can watch any number of collections and documents for changes.
 type Watcher struct {
-	tomb tomb.Tomb
-	log  *mgo.Collection
+	tomb         tomb.Tomb
+	iteratorFunc func() mongo.Iterator
+	log          *mgo.Collection
 
 	// watches holds the observers managed by Watch/Unwatch.
 	watches map[watchKey][]watchInfo
@@ -109,12 +114,16 @@ var Period time.Duration = 5 * time.Second
 
 // New returns a new Watcher observing the changelog collection,
 // which must be a capped collection maintained by mgo/txn.
-func New(changelog *mgo.Collection) *Watcher {
+func New(changelog *mgo.Collection, iteratorFunc func() mongo.Iterator) *Watcher {
 	w := &Watcher{
-		log:     changelog,
-		watches: make(map[watchKey][]watchInfo),
-		current: make(map[watchKey]int64),
-		request: make(chan interface{}),
+		log:          changelog,
+		iteratorFunc: iteratorFunc,
+		watches:      make(map[watchKey][]watchInfo),
+		current:      make(map[watchKey]int64),
+		request:      make(chan interface{}),
+	}
+	if w.iteratorFunc == nil {
+		w.iteratorFunc = w.iter
 	}
 	go func() {
 		err := w.loop(Period)
@@ -243,6 +252,14 @@ func (w *Watcher) loop(period time.Duration) error {
 	for {
 		if w.needSync {
 			if err := w.sync(); err != nil {
+				// If the txn log collection overflows from underneath us,
+				// the easiest cause of action to recover is to cause the
+				// agen tto restart.
+				if errors.Cause(err) == cappedPositionLostError {
+					// Ideally we'd not import the worker package but that's
+					// where all the errors are defined.
+					return jworker.ErrRestartAgent
+				}
 				return errors.Trace(err)
 			}
 			w.flush()
@@ -362,12 +379,18 @@ func (w *Watcher) initLastId() error {
 	return nil
 }
 
+func (w *Watcher) iter() mongo.Iterator {
+	return w.log.Find(nil).Batch(10).Sort("-$natural").Iter()
+}
+
+var cappedPositionLostError = errors.New("capped position lost")
+
 // sync updates the watcher knowledge from the database, and
 // queues events to observing channels.
 func (w *Watcher) sync() error {
 	w.needSync = false
 	// Iterate through log events in reverse insertion order (newest first).
-	iter := w.log.Find(nil).Batch(10).Sort("-$natural").Iter()
+	iter := w.iteratorFunc()
 	seen := make(map[watchKey]bool)
 	first := true
 	lastId := w.lastId
@@ -441,7 +464,15 @@ func (w *Watcher) sync() error {
 		}
 	}
 	if err := iter.Close(); err != nil {
-		return errors.Errorf("watcher iteration error: %v", err)
+		if qerr, ok := err.(*mgo.QueryError); ok {
+			// CappedPositionLost is code 136.
+			// Just in case that changes for some reason, we'll also check the error message.
+			if qerr.Code == 136 || strings.Contains(qerr.Message, "CappedPositionLost") {
+				logger.Warningf("watcher iterator failed due to txn log collection overflow")
+				err = cappedPositionLostError
+			}
+		}
+		return errors.Annotate(err, "watcher iteration error")
 	}
 	return nil
 }

--- a/state/watcher/watcher_test.go
+++ b/state/watcher/watcher_test.go
@@ -14,6 +14,7 @@ import (
 	"gopkg.in/mgo.v2/txn"
 	"gopkg.in/tomb.v1"
 
+	"github.com/juju/juju/mongo"
 	"github.com/juju/juju/state/watcher"
 	"github.com/juju/juju/testing"
 )
@@ -50,12 +51,13 @@ type watcherSuite struct {
 	gitjujutesting.MgoSuite
 	testing.BaseSuite
 
-	log       *mgo.Collection
-	stash     *mgo.Collection
-	runner    *txn.Runner
-	w         *watcher.Watcher
-	ch        chan watcher.Change
-	oldPeriod time.Duration
+	log          *mgo.Collection
+	stash        *mgo.Collection
+	runner       *txn.Runner
+	w            *watcher.Watcher
+	ch           chan watcher.Change
+	oldPeriod    time.Duration
+	iteratorFunc func() mongo.Iterator
 }
 
 // FastPeriodSuite implements tests that should
@@ -96,7 +98,7 @@ func (s *watcherSuite) SetUpTest(c *gc.C) {
 	s.stash = db.C("txn.stash")
 	s.runner = txn.NewRunner(db.C("txn"))
 	s.runner.ChangeLog(s.log)
-	s.w = watcher.New(s.log)
+	s.w = watcher.New(s.log, s.iteratorFunc)
 	s.ch = make(chan watcher.Change)
 }
 
@@ -300,7 +302,7 @@ func (s *FastPeriodSuite) TestWatchMultipleChannels(c *gc.C) {
 func (s *FastPeriodSuite) TestIgnoreAncientHistory(c *gc.C) {
 	s.insert(c, "test", "a")
 
-	w := watcher.New(s.log)
+	w := watcher.New(s.log, s.iteratorFunc)
 	defer w.Stop()
 	w.StartSync()
 
@@ -702,4 +704,73 @@ func (s *SlowPeriodSuite) TestStartSyncStartsImmediately(c *gc.C) {
 		c.Fatalf("got event %#v when starting watcher after doc was removed", got)
 	case <-time.After(justLongEnough):
 	}
+}
+
+type badIter struct {
+	*mgo.Iter
+
+	errorAfter *int
+}
+
+func (b *badIter) Close() (err error) {
+	defer func() {
+		err2 := b.Iter.Close()
+		if err == nil {
+			err = err2
+		}
+	}()
+
+	*b.errorAfter--
+	if *b.errorAfter < 0 {
+		return &mgo.QueryError{
+			Code: 136,
+		}
+	}
+	return nil
+}
+
+type WatcherErrorSuite struct {
+	watcherSuite
+
+	iterErrorAfter int
+}
+
+func (s *WatcherErrorSuite) SetUpSuite(c *gc.C) {
+	s.iterErrorAfter = 2
+	s.iteratorFunc = func() mongo.Iterator {
+		return &badIter{
+			Iter:       s.log.Find(nil).Batch(10).Sort("-$natural").Iter(),
+			errorAfter: &s.iterErrorAfter,
+		}
+	}
+	s.watcherSuite.SetUpSuite(c)
+	watcher.Period = fastPeriod
+}
+
+func (s *WatcherErrorSuite) TearDownTest(c *gc.C) {
+	s.MgoSuite.TearDownTest(c)
+	s.BaseSuite.TearDownTest(c)
+}
+
+var _ = gc.Suite(&WatcherErrorSuite{})
+
+func (s *WatcherErrorSuite) TestCappedCollectionError(c *gc.C) {
+	s.w.Watch("test", "a", -1, s.ch)
+	s.w.StartSync()
+
+	s.insert(c, "test", "a")
+	for i := 1; i < 30; i++ {
+		s.update(c, "test", "a")
+	}
+
+	select {
+	case <-s.w.Dead():
+		// the watcher will die when the iter close fails.
+	case <-time.After(worstCase):
+		c.Fatalf("watcher didn't die")
+	}
+
+	err := s.w.Stop()
+	c.Assert(err, gc.NotNil)
+	c.Assert(err, gc.ErrorMatches, "agent should be restarted")
 }

--- a/state/workers.go
+++ b/state/workers.go
@@ -44,7 +44,7 @@ func newWorkers(st *State) (*workers, error) {
 		}),
 	}
 	ws.StartWorker(txnLogWorker, func() (worker.Worker, error) {
-		return watcher.New(st.getTxnLogCollection(), nil), nil
+		return watcher.New(st.getTxnLogCollection()), nil
 	})
 	ws.StartWorker(presenceWorker, func() (worker.Worker, error) {
 		return presence.NewWatcher(st.getPresenceCollection(), st.ModelTag()), nil

--- a/state/workers.go
+++ b/state/workers.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/juju/juju/state/presence"
 	"github.com/juju/juju/state/watcher"
+	jworker "github.com/juju/juju/worker"
 	"github.com/juju/juju/worker/lease"
 )
 
@@ -37,13 +38,13 @@ func newWorkers(st *State) (*workers, error) {
 		Runner: worker.NewRunner(worker.RunnerParams{
 			// TODO add a Logger parameter to RunnerParams:
 			// Logger: loggo.GetLogger(logger.Name() + ".workers"),
-			IsFatal:      func(error) bool { return false },
+			IsFatal:      func(err error) bool { return err == jworker.ErrRestartAgent },
 			RestartDelay: time.Second,
 			Clock:        st.clock,
 		}),
 	}
 	ws.StartWorker(txnLogWorker, func() (worker.Worker, error) {
-		return watcher.New(st.getTxnLogCollection()), nil
+		return watcher.New(st.getTxnLogCollection(), nil), nil
 	})
 	ws.StartWorker(presenceWorker, func() (worker.Worker, error) {
 		return presence.NewWatcher(st.getPresenceCollection(), st.ModelTag()), nil

--- a/testing/environ.go
+++ b/testing/environ.go
@@ -49,6 +49,7 @@ func FakeControllerConfig() controller.Config {
 		"set-numa-control-policy": false,
 		"max-logs-age":            "72h",
 		"max-logs-size":           "4G",
+		"max-txn-log-size":        "10M",
 	}
 }
 

--- a/upgrades/backend.go
+++ b/upgrades/backend.go
@@ -27,7 +27,7 @@ type StateBackend interface {
 	UpgradeNoProxyDefaults() error
 	AddNonDetachableStorageMachineId() error
 	RemoveNilValueApplicationSettings() error
-	AddControllerLogPruneSettings() error
+	AddControllerLogCollectionsSizeSettings() error
 	AddStatusHistoryPruneSettings() error
 	AddStorageInstanceConstraints() error
 }
@@ -100,8 +100,8 @@ func (s stateBackend) RemoveNilValueApplicationSettings() error {
 	return state.RemoveNilValueApplicationSettings(s.st)
 }
 
-func (s stateBackend) AddControllerLogPruneSettings() error {
-	return state.AddControllerLogPruneSettings(s.st)
+func (s stateBackend) AddControllerLogCollectionsSizeSettings() error {
+	return state.AddControllerLogCollectionsSizeSettings(s.st)
 }
 
 func (s stateBackend) AddStatusHistoryPruneSettings() error {

--- a/upgrades/steps_22.go
+++ b/upgrades/steps_22.go
@@ -26,10 +26,10 @@ func stateStepsFor22() []Step {
 			},
 		},
 		&upgradeStep{
-			description: "add controller log pruning config settings",
+			description: "add controller log collection sizing config settings",
 			targets:     []Target{DatabaseMaster},
 			run: func(context Context) error {
-				return context.State().AddControllerLogPruneSettings()
+				return context.State().AddControllerLogCollectionsSizeSettings()
 			},
 		},
 		&upgradeStep{

--- a/upgrades/steps_22_test.go
+++ b/upgrades/steps_22_test.go
@@ -54,8 +54,8 @@ func (s *steps22Suite) TestMeterStatusFile(c *gc.C) {
 	check() // Check OK when file not present.
 }
 
-func (s *steps22Suite) TestAddControllerLogPruneSettings(c *gc.C) {
-	step := findStateStep(c, v220, "add controller log pruning config settings")
+func (s *steps22Suite) TestAddControllerLogCollectionsSizeSettings(c *gc.C) {
+	step := findStateStep(c, v220, "add controller log collection sizing config settings")
 	// Logic for step itself is tested in state package.
 	c.Assert(step.Targets(), jc.DeepEquals, []upgrades.Target{upgrades.DatabaseMaster})
 }

--- a/worker/errors.go
+++ b/worker/errors.go
@@ -17,6 +17,7 @@ import (
 // *its* host; depending on these values punching right through N layers (but
 // only when we want them to!) is kinda terrible.
 var (
+	ErrRestartAgent    = errors.New("agent should be restarted")
 	ErrTerminateAgent  = errors.New("agent should be terminated")
 	ErrRebootMachine   = errors.New("machine needs to reboot")
 	ErrShutdownMachine = errors.New("machine needs to shutdown")


### PR DESCRIPTION
## Description of change

During scale testing, destroying many models all at once would cause the capped txn log to roll over from underneath the watcher iterator. The watcher would error and things would go pear shaped from there.

We now catch that error in the watcher and bubble it up as a fatal agent error. This causes the agent to restart. The restart has the effect of starting from a known point again.

A small refactoring was done as part of this work to only initialise the database collections during state initialisation at bootstrap time, rather than every time a state instance is opened. This was needed because it was only at init time that the controller config with the max txn log size is available, plus it is dumb to initialise the collections after initialisation.

## QA steps

$ juju bootstrap aws --config max-txn-log-size=1M
$ juju controller-config
verify that the max-txn-log-size is shown as 1M
run juju debug-log
create many models and destroy all at once
verify that debug log shows the capped position lost error and the agent should be restarted error and then exits as the agent is killed
run juju debug-log again and see that the logs show the agent has restarted

$ juju bootstrap aws
$ juju controller-config
verify that the max-txn-log-size is shown as 10M

bootstrap with an older client and upgrade
$ juju controller-config
verify that the max-txn-log-size is shown as 10M

## Documentation changes

There's a new controller config attribute - max-txn-log-size, defaults to 10M
	// MaxTxnLogSize is the maximum size the of capped txn log collection, eg "10M"
	MaxTxnLogSize = "max-txn-log-size"

## Bug reference

https://bugs.launchpad.net/juju/+bug/1692792