### PR TITLE
state: Squash another unknown collection error

### DIFF
--- a/state/database.go
+++ b/state/database.go
@@ -5,13 +5,16 @@ package state
 
 import (
 	"fmt"
+	"runtime/debug"
 
 	"github.com/juju/errors"
 	jujutxn "github.com/juju/txn"
+	"github.com/juju/utils/featureflag"
 	"gopkg.in/juju/names.v2"
 	"gopkg.in/mgo.v2"
 	"gopkg.in/mgo.v2/txn"
 
+	"github.com/juju/juju/feature"
 	"github.com/juju/juju/mongo"
 )
 
@@ -271,6 +274,9 @@ func (db *database) GetCollection(name string) (collection mongo.Collection, clo
 	info, found := db.schema[name]
 	if !found {
 		logger.Errorf("using unknown collection %q", name)
+		if featureflag.Enabled(feature.DeveloperMode) {
+			logger.Errorf("from %s", string(debug.Stack()))
+		}
 	}
 
 	// Copy session if necessary.

--- a/state/relation.go
+++ b/state/relation.go
@@ -10,11 +10,14 @@ import (
 
 	"github.com/juju/errors"
 	jujutxn "github.com/juju/txn"
+	"github.com/juju/utils/featureflag"
 	"gopkg.in/juju/charm.v6-unstable"
 	"gopkg.in/juju/names.v2"
 	"gopkg.in/mgo.v2"
 	"gopkg.in/mgo.v2/bson"
 	"gopkg.in/mgo.v2/txn"
+
+	"github.com/juju/juju/feature"
 )
 
 // relationKey returns a string describing the relation defined by
@@ -355,6 +358,9 @@ func (r *Relation) RemoteUnit(unitName string) (*RelationUnit, error) {
 // IsCrossModel returns whether this relation is a cross-model
 // relation.
 func (r *Relation) IsCrossModel() (bool, error) {
+	if !featureflag.Enabled(feature.CrossModelRelations) {
+		return false, nil
+	}
 	for _, ep := range r.Endpoints() {
 		_, err := r.st.RemoteApplication(ep.ApplicationName)
 		if err == nil {


### PR DESCRIPTION
## Description of change

We were seeing another `unknown collection "remoteApplications"` error which turned out to be from Relation.IsCrossModel - it needed to check the feature flag.

Dump stack when an unknown collection is requested and we're in developer mode. This will make it much easier to find them in future.

## QA steps

Create a model, deploy mysql and wordpress to it, relate them together, destroy the model. The unknown collection error shouldn't appear in the logs.
