### PR TITLE
Display message in SLA Authorize response.

### DIFF
--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -42,7 +42,7 @@ github.com/juju/pubsub	git	f4dfa62f30adc6955341b3dd73dde7c8d9b23b9e	2017-03-31T0
 github.com/juju/replicaset	git	6b5becf2232ce76656ea765d8d915d41755a1513	2016-11-25T16:08:49Z
 github.com/juju/retry	git	62c62032529169c7ec02fa48f93349604c345e1f	2015-10-29T02:48:21Z
 github.com/juju/rfc	git	ebdbbdb950cd039a531d15cdc2ac2cbd94f068ee	2016-07-11T02:42:13Z
-github.com/juju/romulus	git	b5ad384db5630652da632e49adabb968d1143e4c	2017-04-19T22:07:23Z
+github.com/juju/romulus	git	eede3e29dd7784b7265bb2cc175eca35420d37e7	2017-05-19T13:49:06Z
 github.com/juju/schema	git	075de04f9b7d7580d60a1e12a0b3f50bb18e6998	2016-04-20T04:42:03Z
 github.com/juju/terms-client	git	9b925afd677234e4146dde3cb1a11e187cbed64e	2016-08-09T13:19:00Z
 github.com/juju/testing	git	06d21ddace802a83d08c82f513e30d84010ce31f	2017-05-01T02:35:42Z


### PR DESCRIPTION
## Description of change

> Why is this change needed?

To display a message that may be present in the response from an SLA authorize request, indicating when the request will become effective.

## QA steps

> How do we verify that the change works?

Set an SLA with `juju sla essential`. Then try and lower it with `juju sla unsupported`. A message indicating when the model will become unsupported should be displayed.

## Documentation changes

> Does it affect current user workflow? CLI? API?

Yes. Contact @cmars for documentation of this feature.

## Bug reference

> Does this change fix a bug? Please add a link to it.

N/A
