### PR TITLE
apiserver: Fix race in two watchers calling EnsureErr

### DIFF
--- a/apiserver/remotefirewaller/ingressaddresswatcher.go
+++ b/apiserver/remotefirewaller/ingressaddresswatcher.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/network"
-	"github.com/juju/juju/state/watcher"
 	"github.com/juju/juju/worker/catacomb"
 )
 
@@ -147,7 +146,7 @@ func (w *IngressAddressWatcher) loop() error {
 			out = nil
 		case c, ok := <-ruw.Changes():
 			if !ok {
-				return watcher.EnsureErr(ruw)
+				return w.catacomb.ErrDying()
 			}
 			// A unit has entered or left scope.
 			// Get the new set of addresses resulting from that

--- a/apiserver/uniter/subordinaterelationwatcher.go
+++ b/apiserver/uniter/subordinaterelationwatcher.go
@@ -9,7 +9,6 @@ import (
 	"gopkg.in/juju/charm.v6-unstable"
 
 	"github.com/juju/juju/state"
-	"github.com/juju/juju/state/watcher"
 	"github.com/juju/juju/worker/catacomb"
 )
 
@@ -70,7 +69,7 @@ func (w *subRelationsWatcher) loop() error {
 			out = nil
 		case newRelations, ok := <-relationsw.Changes():
 			if !ok {
-				return watcher.EnsureErr(relationsw)
+				return w.catacomb.ErrDying()
 			}
 			for _, relation := range newRelations {
 				if currentRelations.Contains(relation) {


### PR DESCRIPTION
## Description of change

The use of `watcher.EnsureErr` in `subRelationsWatcher` and 
`IngressAddressWatcher` had a potential race.

If the loop saw a closed Changes channel from the child
watcher (relationsw in the subRelationsWatcher, ruw in the ingress
address watcher) because the catacomb had stopped it, then w.Err() would
be nil in EnsureErr. Formatting the watcher as part of the error message
would then trigger a data race since it would examine mutex data inside
the tomb.

We don't actually need to worry about collecting the error that killed
the child watcher here (if it's not just dying because it was asked),
since the catacomb will propagate the error itself. So just return
w.catacomb.ErrDying() instead.

## QA steps

Run `unitMetricBatchesSuite.TestWatchSubordinateUnitRelations` under the stress tool - before the fix it would fail at a rate of about 1 in 50 runs.

Similarly run the `addressWatcherSuite` (in apiserver/remotefirewaller. Although I haven't been able to trigger the race there.

## Bug reference

Fixes the race can be seen here:
http://reports.vapour.ws/releases/5275/job/run-unit-tests-race/attempt/2764
