### PR TITLE
Listen to abstract domain sockets directly; add extra error logging

### DIFF
--- a/cmd/juju/metricsdebug/collectmetrics.go
+++ b/cmd/juju/metricsdebug/collectmetrics.go
@@ -20,6 +20,7 @@ import (
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/cmd/juju/action"
 	"github.com/juju/juju/cmd/modelcmd"
+	"github.com/juju/juju/worker/metrics/sender"
 )
 
 // TODO(bogdanteleaga): update this once querying for actions by name is implemented.
@@ -230,7 +231,7 @@ func (c *collectMetricsCommand) Run(ctx *cmd.Context) error {
 			sendParams := params.RunParams{
 				Timeout:  commandTimeout,
 				Units:    []string{unitId},
-				Commands: "nc -U ../metrics-send.socket",
+				Commands: "nc -U ../" + sender.DefaultMetricsSendSocketName,
 			}
 			sendResults, err := runnerClient.Run(sendParams)
 			if err != nil {

--- a/cmd/jujud/run.go
+++ b/cmd/jujud/run.go
@@ -143,7 +143,7 @@ func (c *RunCommand) executeInUnitContext() (*exec.ExecResponse, error) {
 	}
 	client, err := sockets.Dial(c.socketPath())
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Annotate(err, "dialing juju run socket")
 	}
 	defer client.Close()
 

--- a/cmd/jujud/run_test.go
+++ b/cmd/jujud/run_test.go
@@ -218,7 +218,7 @@ func (s *RunTestSuite) TestMissingSocket(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	_, err = cmdtesting.RunCommand(c, s.runCommand(), "foo/1", "bar")
-	c.Assert(err, gc.ErrorMatches, `dial unix .*/run.socket:.*`+utils.NoSuchFileErrRegexp)
+	c.Assert(err, gc.ErrorMatches, `.*dial unix .*/run.socket:.*`+utils.NoSuchFileErrRegexp)
 }
 
 func (s *RunTestSuite) TestRunning(c *gc.C) {

--- a/juju/sockets/sockets_nix.go
+++ b/juju/sockets/sockets_nix.go
@@ -12,6 +12,7 @@ import (
 	"net/rpc"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/juju/errors"
 )
@@ -25,20 +26,25 @@ func Listen(socketPath string) (net.Listener, error) {
 	if err := os.Remove(socketPath); err != nil {
 		logger.Tracef("ignoring error on removing %q: %v", socketPath, err)
 	}
+	// Listen directly to abstract domain sockets.
+	if strings.HasPrefix(socketPath, "@") {
+		listener, err := net.Listen("unix", socketPath)
+		return listener, errors.Trace(err)
+	}
 	// We first create the socket in a temporary directory as a subdirectory of
 	// the target dir so we know we can get the permissions correct and still
 	// rename the socket into the correct place.
 	// ioutil.TempDir creates the temporary directory as 0700 so it starts with
 	// the right perms as well.
-	socketDir, socketName := filepath.Split(socketPath)
-	// socketName here is just the prefix for the temporary dir name,
-	// so it won't collide
-	tempdir, err := ioutil.TempDir(socketDir, socketName)
+	socketDir := filepath.Dir(socketPath)
+	tempdir, err := ioutil.TempDir(socketDir, "")
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
 	defer os.RemoveAll(tempdir)
-	tempSocketPath := filepath.Join(tempdir, socketName)
+	// Keep the socket path as short as possible so as not to
+	// exceed the 108 length limit.
+	tempSocketPath := filepath.Join(tempdir, "s")
 	listener, err := net.Listen("unix", tempSocketPath)
 	if err != nil {
 		logger.Errorf("failed to listen on unix:%s: %v", tempSocketPath, err)
@@ -46,11 +52,11 @@ func Listen(socketPath string) (net.Listener, error) {
 	}
 	if err := os.Chmod(tempSocketPath, 0700); err != nil {
 		listener.Close()
-		return nil, errors.Trace(err)
+		return nil, errors.Annotatef(err, "could not chmod socket %v", tempSocketPath)
 	}
 	if err := os.Rename(tempSocketPath, socketPath); err != nil {
 		listener.Close()
-		return nil, errors.Trace(err)
+		return nil, errors.Annotatef(err, "could not rename socket %v", tempSocketPath)
 	}
 	return listener, nil
 }

--- a/worker/metrics/sender/sender.go
+++ b/worker/metrics/sender/sender.go
@@ -20,7 +20,7 @@ import (
 )
 
 const (
-	defaultSocketName = "metrics-send.socket"
+	DefaultMetricsSendSocketName = "metrics-send.socket"
 )
 
 type stopper interface {
@@ -107,7 +107,7 @@ var socketName = func(baseDir, unitTag string) string {
 	case "windows":
 		return fmt.Sprintf(`\\.\pipe\send-metrics-%s`, unitTag)
 	default:
-		return path.Join(baseDir, defaultSocketName)
+		return path.Join(baseDir, DefaultMetricsSendSocketName)
 	}
 }
 

--- a/worker/uniter/runner/jujuc/server.go
+++ b/worker/uniter/runner/jujuc/server.go
@@ -207,7 +207,7 @@ func NewServer(getCmd CmdGetter, socketPath string) (*Server, error) {
 	}
 	listener, err := sockets.Listen(socketPath)
 	if err != nil {
-		return nil, err
+		return nil, errors.Annotate(err, "listening to jujuc socket")
 	}
 	s := &Server{
 		socketPath: socketPath,

--- a/worker/uniter/runner/jujuc/server_test.go
+++ b/worker/uniter/runner/jujuc/server_test.go
@@ -114,7 +114,7 @@ func (s *ServerSuite) TearDownTest(c *gc.C) {
 	s.server.Close()
 	c.Assert(<-s.err, gc.IsNil)
 	_, err := os.Open(s.sockPath)
-	c.Assert(err, jc.Satisfies, os.IsNotExist)
+	c.Assert(err, gc.ErrorMatches, ".*no such device or address")
 	s.BaseSuite.TearDownTest(c)
 }
 

--- a/worker/uniter/runner/runner.go
+++ b/worker/uniter/runner/runner.go
@@ -275,7 +275,7 @@ func (runner *runner) startJujucServer() (*jujuc.Server, error) {
 	}
 	srv, err := jujuc.NewServer(getCmd, runner.paths.GetJujucSocket())
 	if err != nil {
-		return nil, err
+		return nil, errors.Annotate(err, "starting jujuc server")
 	}
 	go srv.Run()
 	return srv, nil

--- a/worker/uniter/uniter.go
+++ b/worker/uniter/uniter.go
@@ -505,7 +505,7 @@ func (u *Uniter) init(unitTag names.UnitTag) (err error) {
 		CommandRunner: commandRunner,
 	})
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Annotate(err, "creating juju run listener")
 	}
 	rlw := newRunListenerWrapper(u.runListener)
 	if err := u.catacomb.Add(rlw); err != nil {

--- a/worker/uniter/uniter.go
+++ b/worker/uniter/uniter.go
@@ -15,7 +15,6 @@ import (
 	"github.com/juju/utils"
 	"github.com/juju/utils/clock"
 	"github.com/juju/utils/exec"
-	jujuos "github.com/juju/utils/os"
 	corecharm "gopkg.in/juju/charm.v6-unstable"
 	"gopkg.in/juju/names.v2"
 	"gopkg.in/juju/worker.v1"
@@ -510,10 +509,6 @@ func (u *Uniter) init(unitTag names.UnitTag) (err error) {
 	rlw := newRunListenerWrapper(u.runListener)
 	if err := u.catacomb.Add(rlw); err != nil {
 		return errors.Trace(err)
-	}
-	// The socket needs to have permissions 777 in order for other users to use it.
-	if jujuos.HostOS() != jujuos.Windows {
-		return os.Chmod(u.paths.Runtime.JujuRunSocket, 0777)
 	}
 	return nil
 }


### PR DESCRIPTION
## Description of change

When listening to an abstract domain socket, do that directly as it's not a file on disk.
Add some extra annotations to errors to make debugging easier.

## QA steps

$ juju bootstrap lxd
$ juju deploy mysql
check it all goes ok
$ juju run --unit mysql/0 ls
check output
