### PR TITLE
Simplify mongo opLogSize calculation

### DIFF
--- a/mongo/export_test.go
+++ b/mongo/export_test.go
@@ -17,11 +17,11 @@ var (
 
 	NewConf = newConf
 
-	HostWordSize   = &hostWordSize
-	RuntimeGOOS    = &runtimeGOOS
-	AvailSpace     = &availSpace
-	MinOplogSizeMB = &minOplogSizeMB
-	PreallocFile   = &preallocFile
+	HostWordSize     = &hostWordSize
+	RuntimeGOOS      = &runtimeGOOS
+	AvailSpace       = &availSpace
+	SmallOplogSizeMB = &smallOplogSizeMB
+	PreallocFile     = &preallocFile
 
 	DefaultOplogSize  = defaultOplogSize
 	FsAvailSpace      = fsAvailSpace

--- a/mongo/mongo_test.go
+++ b/mongo/mongo_test.go
@@ -146,7 +146,7 @@ func (s *MongoSuite) SetUpTest(c *gc.C) {
 		}
 		return 0, fmt.Errorf("not a directory")
 	})
-	s.PatchValue(mongo.MinOplogSizeMB, 1)
+	s.PatchValue(mongo.SmallOplogSizeMB, 1)
 
 	testPath := c.MkDir()
 	s.mongodConfigPath = filepath.Join(testPath, "mongodConfig")


### PR DESCRIPTION
## Description of change
The previous method was based on available disk space:
- 512MB if below 10G
- linearly from 512MB to 1G for 10G to 20G
- 1G for above 20G
Since each change in opLogSize requires restarting mongo restarting jujud while available disk space was varying between 10G and 20G caused mongo restart, which could cause problems in HA environments. 
The new method is simply 512MB if available disk space below 15G, 1G if above - this should limit mongo restarts to minimum.

## QA steps
Bootstrap controller with 50G free space available, fill the disk to 18G available, restart jujud, verify that mongo wasn't restarted, fill the disk to 13G available, restart jujud, verify that mongo was restarted, fill the disk to 5G available, verify that mongo wasn't restarted.

## Documentation changes
None

## Bug reference
https://bugs.launchpad.net/juju/+bug/1677592