### PR TITLE
cmd/modelcmd: respect JUJU_MODEL env var

### DIFF
--- a/cmd/juju/commands/ssh_common_test.go
+++ b/cmd/juju/commands/ssh_common_test.go
@@ -74,7 +74,7 @@ func (s *argsSpec) check(c *gc.C, output string) {
 
 	if s.withProxy {
 		expect("-o ProxyCommand juju ssh " +
-			"--model=admin/controller " +
+			"--model=controller " +
 			"--proxy=false " +
 			"--no-host-key-checks " +
 			"--pty=false ubuntu@localhost -q \"nc %h %p\"")

--- a/cmd/juju/commands/sshkeys_test.go
+++ b/cmd/juju/commands/sshkeys_test.go
@@ -99,7 +99,7 @@ func (s *ListKeysSuite) TestListKeys(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	output := strings.TrimSpace(cmdtesting.Stdout(context))
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(output, gc.Matches, "Keys used in model: admin/controller\n.*\\(user@host\\)\n.*\\(another@host\\)")
+	c.Assert(output, gc.Matches, "Keys used in model: controller\n.*\\(user@host\\)\n.*\\(another@host\\)")
 }
 
 func (s *ListKeysSuite) TestListFullKeys(c *gc.C) {
@@ -111,7 +111,7 @@ func (s *ListKeysSuite) TestListFullKeys(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	output := strings.TrimSpace(cmdtesting.Stdout(context))
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(output, gc.Matches, "Keys used in model: admin/controller\n.*user@host\n.*another@host")
+	c.Assert(output, gc.Matches, "Keys used in model: controller\n.*user@host\n.*another@host")
 }
 
 func (s *ListKeysSuite) TestTooManyArgs(c *gc.C) {

--- a/cmd/juju/gui/gui_test.go
+++ b/cmd/juju/gui/gui_test.go
@@ -117,7 +117,7 @@ func (s *guiSuite) TestGUISuccessNoBrowser(c *gc.C) {
 	out, err := s.run(c, "--hide-credential")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(out, gc.Equals, fmt.Sprintf(`
-GUI 4.5.6 for model "admin/controller" is enabled at:
+GUI 4.5.6 for model "controller" is enabled at:
   %s`[1:], s.guiURL(c)))
 }
 
@@ -132,7 +132,7 @@ func (s *guiSuite) TestGUISuccessOldGUI(c *gc.C) {
 	out, err := s.run(c, "--hide-credential")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(out, gc.Equals, fmt.Sprintf(`
-GUI 4.5.6 for model "admin/controller" is enabled at:
+GUI 4.5.6 for model "controller" is enabled at:
   %s`[1:], s.guiOldURL(c)))
 }
 
@@ -142,7 +142,7 @@ func (s *guiSuite) TestGUISuccessNoBrowserDeprecated(c *gc.C) {
 	out, err := s.run(c, "--no-browser", "--hide-credential")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(out, gc.Equals, fmt.Sprintf(`
-GUI 4.5.6 for model "admin/controller" is enabled at:
+GUI 4.5.6 for model "controller" is enabled at:
   %s`[1:], s.guiURL(c)))
 }
 


### PR DESCRIPTION
In https://github.com/juju/juju/pull/7294, we accidentally
removed the logic that used the JUJU_MODEL
environment variable to set the current model.

This restores that, removes the unused GetCurrentModel
function, and improves the test coverage for this area
so that it's tested.

Fixes https://bugs.launchpad.net/juju/+bug/1693356

To QA, check that JUJU_MODEL is respected when running
juju commands.