### PR TITLE
cmd/juju/romulus/sla Added a response message to the output.

### DIFF
--- a/cmd/juju/romulus/sla/sla.go
+++ b/cmd/juju/romulus/sla/sla.go
@@ -41,8 +41,9 @@ type slaClient interface {
 }
 
 type slaLevel struct {
-	Model string `json:"model" yaml:"model"`
-	SLA   string `json:"sla" yaml:"sla"`
+	Model   string `json:"model,omitempty" yaml:"model,omitempty"`
+	SLA     string `json:"sla,omitempty" yaml:"sla,omitempty"`
+	Message string `json:"message,omitempty" yaml:"message,omitempty"`
 }
 
 var newSLAClient = func(conn api.Connection) slaClient {
@@ -122,37 +123,35 @@ func (c *slaCommand) Init(args []string) error {
 	return c.ModelCommandBase.Init(args[1:])
 }
 
-func (c *slaCommand) requestSupportCredentials(modelUUID string) (string, []byte, error) {
+func (c *slaCommand) requestSupportCredentials(modelUUID string) (string, string, []byte, error) {
+	fail := func(err error) (string, string, []byte, error) {
+		return "", "", nil, err
+	}
 	hc, err := c.BakeryClient()
 	if err != nil {
-		return "", nil, errors.Trace(err)
+		return fail(errors.Trace(err))
 	}
 	authClient, err := c.newAuthorizationClient(sla.HTTPClient(hc))
 	if err != nil {
-		return "", nil, errors.Trace(err)
+		return fail(errors.Trace(err))
 	}
 	slaResp, err := authClient.Authorize(modelUUID, c.Level, c.Budget)
 	if err != nil {
 		err = common.MaybeTermsAgreementError(err)
 		if termErr, ok := errors.Cause(err).(*common.TermsRequiredError); ok {
-			return "", nil, errors.Trace(termErr.UserErr())
+			return fail(errors.Trace(termErr.UserErr()))
 		}
-		return "", nil, errors.Trace(err)
+		return fail(errors.Trace(err))
 	}
 	ms := macaroon.Slice{slaResp.Credentials}
 	mbuf, err := json.Marshal(ms)
 	if err != nil {
-		return "", nil, errors.Trace(err)
+		return fail(errors.Trace(err))
 	}
-	return slaResp.Owner, mbuf, nil
+	return slaResp.Owner, slaResp.Message, mbuf, nil
 }
 
-func (c *slaCommand) displayCurrentLevel(client slaClient, modelID string, ctx *cmd.Context) error {
-	modelNameMap := modelNameMap()
-	modelName := modelID
-	if name, ok := modelNameMap[modelID]; ok {
-		modelName = name
-	}
+func (c *slaCommand) displayCurrentLevel(client slaClient, modelName string, ctx *cmd.Context) error {
 	level, err := client.SLALevel()
 	if err != nil {
 		return errors.Trace(err)
@@ -171,13 +170,28 @@ func (c *slaCommand) Run(ctx *cmd.Context) error {
 	}
 	client := c.newSLAClient(root)
 	modelId := modelId(root)
+	modelNameMap := modelNameMap()
+	modelName := modelId
+	if name, ok := modelNameMap[modelId]; ok {
+		modelName = name
+	}
 
 	if c.Level == "" {
-		return c.displayCurrentLevel(client, modelId, ctx)
+		return c.displayCurrentLevel(client, modelName, ctx)
 	}
-	owner, credentials, err := c.requestSupportCredentials(modelId)
+	owner, message, credentials, err := c.requestSupportCredentials(modelId)
 	if err != nil {
 		return errors.Trace(err)
+	}
+	if message != "" {
+		err = c.out.Write(ctx, &slaLevel{
+			Model:   modelName,
+			SLA:     c.Level,
+			Message: message,
+		})
+		if err != nil {
+			return errors.Trace(err)
+		}
 	}
 	err = client.SetSLALevel(c.Level, owner, credentials)
 	if err != nil {
@@ -197,8 +211,8 @@ func formatTabular(writer io.Writer, value interface{}) error {
 	for _, col := range []int{2, 3, 5} {
 		table.RightAlign(col)
 	}
-	table.AddRow("Model", "SLA")
-	table.AddRow(l.Model, l.SLA)
+	table.AddRow("Model", "SLA", "Message")
+	table.AddRow(l.Model, l.SLA, l.Message)
 	fmt.Fprint(writer, table)
 	return nil
 }

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -42,7 +42,7 @@ github.com/juju/pubsub	git	f4dfa62f30adc6955341b3dd73dde7c8d9b23b9e	2017-03-31T0
 github.com/juju/replicaset	git	6b5becf2232ce76656ea765d8d915d41755a1513	2016-11-25T16:08:49Z
 github.com/juju/retry	git	62c62032529169c7ec02fa48f93349604c345e1f	2015-10-29T02:48:21Z
 github.com/juju/rfc	git	ebdbbdb950cd039a531d15cdc2ac2cbd94f068ee	2016-07-11T02:42:13Z
-github.com/juju/romulus	git	b5ad384db5630652da632e49adabb968d1143e4c	2017-04-19T22:07:23Z
+github.com/juju/romulus	git	eede3e29dd7784b7265bb2cc175eca35420d37e7	2017-05-19T13:49:06Z
 github.com/juju/schema	git	075de04f9b7d7580d60a1e12a0b3f50bb18e6998	2016-04-20T04:42:03Z
 github.com/juju/terms-client	git	9b925afd677234e4146dde3cb1a11e187cbed64e	2016-08-09T13:19:00Z
 github.com/juju/testing	git	06d21ddace802a83d08c82f513e30d84010ce31f	2017-05-01T02:35:42Z


### PR DESCRIPTION
## Description of change

To display the message returned by the SLA authorization call.

## QA steps

1. bootstrap a controller
2. add a model
3. run "juju sla"
4. verify that the returned message is displayed in tabular, json and yaml output formats.

## Documentation changes

No documentation changes required.

## Bug reference
N/A