### PR TITLE
Fixes lp#1627127 - adjust resource-get retry strategy.

### DIFF
--- a/resource/charmstore/operations.go
+++ b/resource/charmstore/operations.go
@@ -97,6 +97,9 @@ func GetResource(args GetResourceArgs) (resource.Resource, io.ReadCloser, error)
 		Revision: res.Revision,
 	}
 	data, err := args.Client.GetResource(req)
+	// (anastasiamac 2017-05-25) This might not work all the time
+	// as the error types may be lost after call to some clients, for example http.
+	// But for these cases, the next block will bubble an un-annotated error up.
 	if errors.IsNotFound(err) {
 		msg := "while getting resource from the charm store"
 		return resource.Resource{}, nil, errors.Annotate(err, msg)

--- a/resource/resourceadapters/charmstore.go
+++ b/resource/resourceadapters/charmstore.go
@@ -66,21 +66,30 @@ func (cs *charmstoreOpener) NewClient() (*CSRetryClient, error) {
 	return newCSRetryClient(client), nil
 }
 
+// ResourceClient defines a set of functionality that a client
+// needs to define to support resources.
+type ResourceClient interface {
+	GetResource(req charmstore.ResourceRequest) (data charmstore.ResourceData, err error)
+}
+
 // CSRetryClient is a wrapper around a Juju charm store client that
 // retries GetResource() calls.
 type CSRetryClient struct {
-	charmstore.Client
+	ResourceClient
 	retryArgs retry.CallArgs
 }
 
-func newCSRetryClient(client charmstore.Client) *CSRetryClient {
+func newCSRetryClient(client ResourceClient) *CSRetryClient {
 	retryArgs := retry.CallArgs{
-		// The only error that stops the retry loop should be "not found".
-		IsFatalError: errors.IsNotFound,
-		// We want to retry until the charm store either gives us the
-		// resource (and we cache it) or the resource isn't found in the
-		// charm store.
-		Attempts: -1, // retry forever...
+		// (anastasiamac 2017-05-25) This might not work as the error types
+		// may be lost after a call to some clients.
+		IsFatalError: func(err error) bool {
+			return errors.IsNotFound(err) || errors.IsNotValid(err)
+		},
+		// We don't want to retry for ever.
+		// If we cannot get a resource after trying a few times,
+		// most likely user intervention is needed.
+		Attempts: 3,
 		// A one minute gives enough time for potential connection
 		// issues to sort themselves out without making the caller wait
 		// for an exceptional amount of time.
@@ -88,8 +97,8 @@ func newCSRetryClient(client charmstore.Client) *CSRetryClient {
 		Clock: clock.WallClock,
 	}
 	return &CSRetryClient{
-		Client:    client,
-		retryArgs: retryArgs,
+		ResourceClient: client,
+		retryArgs:      retryArgs,
 	}
 }
 
@@ -100,7 +109,7 @@ func (client CSRetryClient) GetResource(req charmstore.ResourceRequest) (charmst
 	var data charmstore.ResourceData
 	args.Func = func() error {
 		var err error
-		data, err = client.Client.GetResource(req)
+		data, err = client.ResourceClient.GetResource(req)
 		if err != nil {
 			return errors.Trace(err)
 		}
@@ -110,7 +119,8 @@ func (client CSRetryClient) GetResource(req charmstore.ResourceRequest) (charmst
 	var lastErr error
 	args.NotifyFunc = func(err error, i int) {
 		// Remember the error we're hiding and then retry!
-		logger.Debugf("(attempt %d) retrying resource download from charm store due to error: %v", i, err)
+		logger.Warningf("(attempt %d) retrying resource %q download from charm store [channel (%v), charm (%v), resource revision (%v)] due to error: %v",
+			i, req.Name, req.Channel, req.Charm, req.Revision, err)
 		lastErr = err
 	}
 

--- a/resource/resourceadapters/charmstore.go
+++ b/resource/resourceadapters/charmstore.go
@@ -119,8 +119,9 @@ func (client CSRetryClient) GetResource(req charmstore.ResourceRequest) (charmst
 	var lastErr error
 	args.NotifyFunc = func(err error, i int) {
 		// Remember the error we're hiding and then retry!
-		logger.Warningf("(attempt %d) retrying resource %q download from charm store [channel (%v), charm (%v), resource revision (%v)] due to error: %v",
-			i, req.Name, req.Channel, req.Charm, req.Revision, err)
+		logger.Warningf("attempt %d/%d to download resource %q from charm store [channel (%v), charm (%v), resource revision (%v)] failed with error (will retry): %v",
+			i, client.retryArgs.Attempts, req.Name, req.Channel, req.Charm, req.Revision, err)
+		logger.Tracef("resource get error stack: %v", errors.ErrorStack(err))
 		lastErr = err
 	}
 

--- a/resource/resourceadapters/charmstore_test.go
+++ b/resource/resourceadapters/charmstore_test.go
@@ -1,0 +1,92 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package resourceadapters_test
+
+import (
+	"fmt"
+
+	"github.com/juju/errors"
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/charmstore"
+	"github.com/juju/juju/resource/resourceadapters"
+)
+
+type CharmStoreSuite struct {
+	testing.IsolationSuite
+
+	resourceClient *testResourceClient
+}
+
+var _ = gc.Suite(&CharmStoreSuite{})
+
+func (s *CharmStoreSuite) SetUpTest(c *gc.C) {
+	s.IsolationSuite.SetUpTest(c)
+	s.resourceClient = &testResourceClient{
+		stub: &testing.Stub{},
+	}
+}
+
+func (s *CharmStoreSuite) TestGetResourceTerminates(c *gc.C) {
+	msg := "trust"
+	attempts := 0
+	s.resourceClient.getResourceF = func(req charmstore.ResourceRequest) (data charmstore.ResourceData, err error) {
+		attempts++
+		return charmstore.ResourceData{}, errors.New(msg)
+	}
+	csRes := resourceadapters.NewCSRetryClientForTest(s.resourceClient)
+
+	_, err := csRes.GetResource(charmstore.ResourceRequest{})
+	c.Assert(err, gc.ErrorMatches, fmt.Sprintf("failed after retrying: %v", msg))
+	// Ensure we logged attempts @ WARNING.
+	c.Assert(c.GetTestLog(), jc.Contains, fmt.Sprintf("WARNING juju.resource.resourceadapters (attempt %v) retrying resource ", attempts))
+
+	callsMade := []string{}
+	for i := 0; i < attempts; i++ {
+		callsMade = append(callsMade, "GetResource")
+	}
+	s.resourceClient.stub.CheckCallNames(c, callsMade...)
+}
+
+func (s *CharmStoreSuite) TestGetResourceAbortedOnNotFound(c *gc.C) {
+	msg := "trust"
+	s.resourceClient.getResourceF = func(req charmstore.ResourceRequest) (data charmstore.ResourceData, err error) {
+		return charmstore.ResourceData{}, errors.NotFoundf(msg)
+	}
+	s.assertAbortedGetResource(c,
+		resourceadapters.NewCSRetryClientForTest(s.resourceClient),
+		fmt.Sprintf("%v not found", msg),
+	)
+}
+
+func (s *CharmStoreSuite) TestGetResourceAbortedOnNotValid(c *gc.C) {
+	msg := "trust"
+	s.resourceClient.getResourceF = func(req charmstore.ResourceRequest) (data charmstore.ResourceData, err error) {
+		return charmstore.ResourceData{}, errors.NotValidf(msg)
+	}
+	s.assertAbortedGetResource(c,
+		resourceadapters.NewCSRetryClientForTest(s.resourceClient),
+		fmt.Sprintf("%v not valid", msg),
+	)
+}
+
+func (s *CharmStoreSuite) assertAbortedGetResource(c *gc.C, csRes *resourceadapters.CSRetryClient, expectedError string) {
+	_, err := csRes.GetResource(charmstore.ResourceRequest{})
+	c.Assert(err, gc.ErrorMatches, expectedError)
+	c.Assert(c.GetTestLog(), gc.Not(jc.Contains), "WARNING juju.resource.resourceadapters")
+	s.resourceClient.stub.CheckCallNames(c, "GetResource")
+}
+
+type testResourceClient struct {
+	stub *testing.Stub
+
+	getResourceF func(req charmstore.ResourceRequest) (data charmstore.ResourceData, err error)
+}
+
+func (f *testResourceClient) GetResource(req charmstore.ResourceRequest) (data charmstore.ResourceData, err error) {
+	f.stub.AddCall("GetResource", req)
+	return f.getResourceF(req)
+}

--- a/resource/resourceadapters/export_test.go
+++ b/resource/resourceadapters/export_test.go
@@ -1,0 +1,15 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package resourceadapters
+
+import (
+	"time"
+)
+
+func NewCSRetryClientForTest(client ResourceClient) *CSRetryClient {
+	retryClient := newCSRetryClient(client)
+	// Reduce retry delay for test.
+	retryClient.retryArgs.Delay = 1 * time.Millisecond
+	return retryClient
+}

--- a/resource/resourceadapters/package_test.go
+++ b/resource/resourceadapters/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package resourceadapters_test
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func Test(t *testing.T) {
+	gc.TestingT(t)
+}


### PR DESCRIPTION
## Description of change

Currently if we get errors when  trying to download resources, we will re-try indefinitely unless we'd get a typed NotFound error. There are couple of problems with that approach:
1. if we'd get a validation error, we should abort trying to download resources as well. It's unrealistic that these errors will be fixed between attempts;
2. we should not re-try to do anything indefinitely;
3. there is no guarantee that we will get typed errors from the client that provides resources.

This PR addresses 1 and 2. The risk of 3 is mitigated by having finite number of re-try attempts. 

We also now log received error at a higher logging level, WARNING, to ensure its better discoverable by the user.
The area is heavily under-tested. This PR also introduces tests for the code modifications.

## QA steps

1. bootstrap
2. deploy a charm or a bundle that has resources will trigger an error. For example, I have used  cs:bundle/canonical-kubernetes-21 that has resource with revision -1 which triggered validation error.
3. once deploy settles, applications should be either active or in blocked state as they require user intervention. Previously, applications would be either active or pending indefinitely.

## Documentation changes

N/A - internal fix, not visible to users.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1627127
