### PR TITLE
provider/vsphere: truncate folder name to 80 chars

### DIFF
--- a/provider/vsphere/environ_broker.go
+++ b/provider/vsphere/environ_broker.go
@@ -36,6 +36,19 @@ func controllerFolderName(controllerUUID string) string {
 }
 
 func modelFolderName(modelUUID, modelName string) string {
+	// We must truncate model names at 33 characters, in order to keep the
+	// folder name to a maximum of 80 characters. The documentation says
+	// "less than 80", but testing shows that it is in fact "no more than 80".
+	//
+	// See https://www.vmware.com/support/developer/vc-sdk/visdk41pubs/ApiReference/vim.Folder.html:
+	//   "The name to be given the new folder. An entity name must be
+	//   a non-empty string of less than 80 characters. The slash (/),
+	//   backslash (\) and percent (%) will be escaped using the URL
+	//   syntax. For example, %2F."
+	const modelNameLimit = 33
+	if len(modelName) > modelNameLimit {
+		modelName = modelName[:modelNameLimit]
+	}
 	return fmt.Sprintf("Model %q (%s)", modelName, modelUUID)
 }
 


### PR DESCRIPTION
## Description of change

There is an 80 character limit on folder names in
vSphere, so we truncate the model name. The model
name limit is 33 characters, which should be more
than enough for most model names. Truncating just
ensures that we do not fail in pathological cases.

## QA steps

1. juju bootstrap vsphere --default-model=<something-longer-than-33-characters>
use "govc ls /\<dc\>/vm/Juju*/*" to check that the folder name includes the default model name, truncated to 33 characters.

## Documentation changes

None.

## Bug reference

Fixes https://bugs.launchpad.net/juju/+bug/1691347