### PR TITLE
provider/azure: add Juju/<version> to User-Agent

### DIFF
--- a/provider/azure/environ.go
+++ b/provider/azure/environ.go
@@ -42,6 +42,7 @@ import (
 	internalazurestorage "github.com/juju/juju/provider/azure/internal/azurestorage"
 	"github.com/juju/juju/provider/azure/internal/errorutils"
 	"github.com/juju/juju/provider/azure/internal/tracing"
+	"github.com/juju/juju/provider/azure/internal/useragent"
 	"github.com/juju/juju/provider/common"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/tools"
@@ -177,6 +178,7 @@ func (env *azureEnviron) initEnviron() error {
 		"azure.network":   &env.network.Client,
 	}
 	for id, client := range clients {
+		useragent.UpdateClient(client)
 		client.Authorizer = env.authorizer
 		logger := loggo.GetLogger(id)
 		if env.provider.config.Sender != nil {

--- a/provider/azure/internal/ad/client.go
+++ b/provider/azure/internal/ad/client.go
@@ -35,7 +35,7 @@ var (
 )
 
 func UserAgent() string {
-	return "Juju/" + version.Current.String()
+	return fmt.Sprintf("Juju/%s arm-graphrbac/%s", version.Current, APIVersion)
 }
 
 type ManagementClient struct {

--- a/provider/azure/internal/azureauth/interactive_test.go
+++ b/provider/azure/internal/azureauth/interactive_test.go
@@ -210,21 +210,22 @@ Creating/updating service principal.
 Assigning Owner role to service principal.
 `[1:])
 
-	// Token refreshes don't go through the inspectors.
-	c.Assert(requests, gc.HasLen, 7)
+	c.Assert(requests, gc.HasLen, 9)
 	c.Check(requests[0].URL.Path, gc.Equals, "/subscriptions/22222222-2222-2222-2222-222222222222")
 	c.Check(requests[1].URL.Path, gc.Equals, "/11111111-1111-1111-1111-111111111111/oauth2/devicecode")
 	c.Check(requests[2].URL.Path, gc.Equals, "/11111111-1111-1111-1111-111111111111/oauth2/token")
-	c.Check(requests[3].URL.Path, gc.Equals, "/11111111-1111-1111-1111-111111111111/me")
-	c.Check(requests[4].URL.Path, gc.Equals, "/11111111-1111-1111-1111-111111111111/servicePrincipals")
-	c.Check(requests[5].URL.Path, gc.Equals, "/subscriptions/22222222-2222-2222-2222-222222222222/providers/Microsoft.Authorization/roleDefinitions")
-	c.Check(requests[6].URL.Path, gc.Equals, "/subscriptions/22222222-2222-2222-2222-222222222222/providers/Microsoft.Authorization/roleAssignments/55555555-5555-5555-5555-555555555555")
+	c.Check(requests[3].URL.Path, gc.Equals, "/11111111-1111-1111-1111-111111111111/oauth2/token")
+	c.Check(requests[4].URL.Path, gc.Equals, "/11111111-1111-1111-1111-111111111111/oauth2/token")
+	c.Check(requests[5].URL.Path, gc.Equals, "/11111111-1111-1111-1111-111111111111/me")
+	c.Check(requests[6].URL.Path, gc.Equals, "/11111111-1111-1111-1111-111111111111/servicePrincipals")
+	c.Check(requests[7].URL.Path, gc.Equals, "/subscriptions/22222222-2222-2222-2222-222222222222/providers/Microsoft.Authorization/roleDefinitions")
+	c.Check(requests[8].URL.Path, gc.Equals, "/subscriptions/22222222-2222-2222-2222-222222222222/providers/Microsoft.Authorization/roleAssignments/55555555-5555-5555-5555-555555555555")
 
 	// The service principal creation includes the password. Check that the
 	// password returned from the function is the same as the one set in the
 	// request.
 	var params ad.ServicePrincipalCreateParameters
-	err = json.NewDecoder(requests[4].Body).Decode(&params)
+	err = json.NewDecoder(requests[6].Body).Decode(&params)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(params.PasswordCredentials, gc.HasLen, 1)
 	assertPasswordCredential(c, params.PasswordCredentials[0])
@@ -314,23 +315,25 @@ func (s *InteractiveSuite) testInteractiveServicePrincipalAlreadyExists(c *gc.C,
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(password, gc.Equals, "33333333-3333-3333-3333-333333333333")
 
-	c.Assert(requests, gc.HasLen, 10)
+	c.Assert(requests, gc.HasLen, 12)
 	c.Check(requests[0].URL.Path, gc.Equals, "/subscriptions/22222222-2222-2222-2222-222222222222")
 	c.Check(requests[1].URL.Path, gc.Equals, "/11111111-1111-1111-1111-111111111111/oauth2/devicecode")
 	c.Check(requests[2].URL.Path, gc.Equals, "/11111111-1111-1111-1111-111111111111/oauth2/token")
-	c.Check(requests[3].URL.Path, gc.Equals, "/11111111-1111-1111-1111-111111111111/me")
-	c.Check(requests[4].URL.Path, gc.Equals, "/11111111-1111-1111-1111-111111111111/servicePrincipals")                                  // create
-	c.Check(requests[5].URL.Path, gc.Equals, "/11111111-1111-1111-1111-111111111111/servicePrincipals")                                  // list
-	c.Check(requests[6].URL.Path, gc.Equals, "/11111111-1111-1111-1111-111111111111/servicePrincipals/sp-object-id/passwordCredentials") // list
-	c.Check(requests[7].URL.Path, gc.Equals, "/11111111-1111-1111-1111-111111111111/servicePrincipals/sp-object-id/passwordCredentials") // update
-	c.Check(requests[8].URL.Path, gc.Equals, "/subscriptions/22222222-2222-2222-2222-222222222222/providers/Microsoft.Authorization/roleDefinitions")
-	c.Check(requests[9].URL.Path, gc.Equals, "/subscriptions/22222222-2222-2222-2222-222222222222/providers/Microsoft.Authorization/roleAssignments/55555555-5555-5555-5555-555555555555")
+	c.Check(requests[3].URL.Path, gc.Equals, "/11111111-1111-1111-1111-111111111111/oauth2/token")
+	c.Check(requests[4].URL.Path, gc.Equals, "/11111111-1111-1111-1111-111111111111/oauth2/token")
+	c.Check(requests[5].URL.Path, gc.Equals, "/11111111-1111-1111-1111-111111111111/me")
+	c.Check(requests[6].URL.Path, gc.Equals, "/11111111-1111-1111-1111-111111111111/servicePrincipals")                                  // create
+	c.Check(requests[7].URL.Path, gc.Equals, "/11111111-1111-1111-1111-111111111111/servicePrincipals")                                  // list
+	c.Check(requests[8].URL.Path, gc.Equals, "/11111111-1111-1111-1111-111111111111/servicePrincipals/sp-object-id/passwordCredentials") // list
+	c.Check(requests[9].URL.Path, gc.Equals, "/11111111-1111-1111-1111-111111111111/servicePrincipals/sp-object-id/passwordCredentials") // update
+	c.Check(requests[10].URL.Path, gc.Equals, "/subscriptions/22222222-2222-2222-2222-222222222222/providers/Microsoft.Authorization/roleDefinitions")
+	c.Check(requests[11].URL.Path, gc.Equals, "/subscriptions/22222222-2222-2222-2222-222222222222/providers/Microsoft.Authorization/roleAssignments/55555555-5555-5555-5555-555555555555")
 
 	// Make sure that we don't wipe existing password credentials, and that
 	// the new password credential matches the one returned from the
 	// function.
 	var params ad.PasswordCredentialsUpdateParameters
-	err = json.NewDecoder(requests[7].Body).Decode(&params)
+	err = json.NewDecoder(requests[9].Body).Decode(&params)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(params.Value, gc.HasLen, 2)
 	c.Assert(params.Value[0], jc.DeepEquals, ad.PasswordCredential{
@@ -380,15 +383,17 @@ func (s *InteractiveSuite) testInteractiveRetriesCreateServicePrincipal(c *gc.C,
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(password, gc.Equals, "33333333-3333-3333-3333-333333333333")
 
-	c.Assert(requests, gc.HasLen, 8)
+	c.Assert(requests, gc.HasLen, 10)
 	c.Check(requests[0].URL.Path, gc.Equals, "/subscriptions/22222222-2222-2222-2222-222222222222")
 	c.Check(requests[1].URL.Path, gc.Equals, "/11111111-1111-1111-1111-111111111111/oauth2/devicecode")
 	c.Check(requests[2].URL.Path, gc.Equals, "/11111111-1111-1111-1111-111111111111/oauth2/token")
-	c.Check(requests[3].URL.Path, gc.Equals, "/11111111-1111-1111-1111-111111111111/me")
-	c.Check(requests[4].URL.Path, gc.Equals, "/11111111-1111-1111-1111-111111111111/servicePrincipals") // create
-	c.Check(requests[5].URL.Path, gc.Equals, "/11111111-1111-1111-1111-111111111111/servicePrincipals") // create
-	c.Check(requests[6].URL.Path, gc.Equals, "/subscriptions/22222222-2222-2222-2222-222222222222/providers/Microsoft.Authorization/roleDefinitions")
-	c.Check(requests[7].URL.Path, gc.Equals, "/subscriptions/22222222-2222-2222-2222-222222222222/providers/Microsoft.Authorization/roleAssignments/55555555-5555-5555-5555-555555555555")
+	c.Check(requests[3].URL.Path, gc.Equals, "/11111111-1111-1111-1111-111111111111/oauth2/token")
+	c.Check(requests[4].URL.Path, gc.Equals, "/11111111-1111-1111-1111-111111111111/oauth2/token")
+	c.Check(requests[5].URL.Path, gc.Equals, "/11111111-1111-1111-1111-111111111111/me")
+	c.Check(requests[6].URL.Path, gc.Equals, "/11111111-1111-1111-1111-111111111111/servicePrincipals") // create
+	c.Check(requests[7].URL.Path, gc.Equals, "/11111111-1111-1111-1111-111111111111/servicePrincipals") // create
+	c.Check(requests[8].URL.Path, gc.Equals, "/subscriptions/22222222-2222-2222-2222-222222222222/providers/Microsoft.Authorization/roleDefinitions")
+	c.Check(requests[9].URL.Path, gc.Equals, "/subscriptions/22222222-2222-2222-2222-222222222222/providers/Microsoft.Authorization/roleAssignments/55555555-5555-5555-5555-555555555555")
 }
 
 func (s *InteractiveSuite) TestInteractiveRetriesRoleAssignment(c *gc.C) {
@@ -422,13 +427,15 @@ func (s *InteractiveSuite) TestInteractiveRetriesRoleAssignment(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(password, gc.Equals, "33333333-3333-3333-3333-333333333333")
 
-	c.Assert(requests, gc.HasLen, 8)
+	c.Assert(requests, gc.HasLen, 10)
 	c.Check(requests[0].URL.Path, gc.Equals, "/subscriptions/22222222-2222-2222-2222-222222222222")
 	c.Check(requests[1].URL.Path, gc.Equals, "/11111111-1111-1111-1111-111111111111/oauth2/devicecode")
 	c.Check(requests[2].URL.Path, gc.Equals, "/11111111-1111-1111-1111-111111111111/oauth2/token")
-	c.Check(requests[3].URL.Path, gc.Equals, "/11111111-1111-1111-1111-111111111111/me")
-	c.Check(requests[4].URL.Path, gc.Equals, "/11111111-1111-1111-1111-111111111111/servicePrincipals") // create
-	c.Check(requests[5].URL.Path, gc.Equals, "/subscriptions/22222222-2222-2222-2222-222222222222/providers/Microsoft.Authorization/roleDefinitions")
-	c.Check(requests[6].URL.Path, gc.Equals, "/subscriptions/22222222-2222-2222-2222-222222222222/providers/Microsoft.Authorization/roleAssignments/55555555-5555-5555-5555-555555555555")
-	c.Check(requests[7].URL.Path, gc.Equals, "/subscriptions/22222222-2222-2222-2222-222222222222/providers/Microsoft.Authorization/roleAssignments/55555555-5555-5555-5555-555555555555")
+	c.Check(requests[3].URL.Path, gc.Equals, "/11111111-1111-1111-1111-111111111111/oauth2/token")
+	c.Check(requests[4].URL.Path, gc.Equals, "/11111111-1111-1111-1111-111111111111/oauth2/token")
+	c.Check(requests[5].URL.Path, gc.Equals, "/11111111-1111-1111-1111-111111111111/me")
+	c.Check(requests[6].URL.Path, gc.Equals, "/11111111-1111-1111-1111-111111111111/servicePrincipals") // create
+	c.Check(requests[7].URL.Path, gc.Equals, "/subscriptions/22222222-2222-2222-2222-222222222222/providers/Microsoft.Authorization/roleDefinitions")
+	c.Check(requests[8].URL.Path, gc.Equals, "/subscriptions/22222222-2222-2222-2222-222222222222/providers/Microsoft.Authorization/roleAssignments/55555555-5555-5555-5555-555555555555")
+	c.Check(requests[9].URL.Path, gc.Equals, "/subscriptions/22222222-2222-2222-2222-222222222222/providers/Microsoft.Authorization/roleAssignments/55555555-5555-5555-5555-555555555555")
 }

--- a/provider/azure/internal/azuretesting/senders.go
+++ b/provider/azure/internal/azuretesting/senders.go
@@ -8,11 +8,15 @@ import (
 	"fmt"
 	"net/http"
 	"regexp"
+	"strings"
 	"sync"
 
 	"github.com/Azure/go-autorest/autorest"
 	"github.com/Azure/go-autorest/autorest/mocks"
+	"github.com/juju/errors"
 	"github.com/juju/loggo"
+
+	"github.com/juju/juju/version"
 )
 
 var logger = loggo.GetLogger("juju.provider.azure.internal.azuretesting")
@@ -28,6 +32,9 @@ type MockSender struct {
 }
 
 func (s *MockSender) Do(req *http.Request) (*http.Response, error) {
+	if ua := req.UserAgent(); !strings.HasPrefix(ua, "Juju/"+version.Current.String()) {
+		return nil, errors.Errorf("request has unexpected User-Agent %q", ua)
+	}
 	if s.PathPattern != "" {
 		matched, err := regexp.MatchString(s.PathPattern, req.URL.Path)
 		if err != nil {

--- a/provider/azure/internal/useragent/useragent.go
+++ b/provider/azure/internal/useragent/useragent.go
@@ -1,0 +1,24 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package useragent
+
+import (
+	"github.com/Azure/go-autorest/autorest"
+
+	"github.com/juju/juju/version"
+)
+
+// JujuPrefix returns the User-Agent prefix set by Juju.
+func JujuPrefix() string {
+	return "Juju/" + version.Current.String()
+}
+
+// UpdateClient updates the UserAgent field of the given autorest.Client.
+func UpdateClient(client *autorest.Client) {
+	if client.UserAgent == "" {
+		client.UserAgent = JujuPrefix()
+	} else {
+		client.UserAgent = JujuPrefix() + " " + client.UserAgent
+	}
+}


### PR DESCRIPTION
## Description of change

Add Juju/<version> to the User-Agent header sent
to Azure. This will aid Microsoft in identifying
requests coming from Juju.

## QA steps

1. juju add-credential azure --logging-config 'azure=TRACE;<root>=DEBUG'
(select interactive, check User-Agent in log messages)
2. juju bootstrap azure --logging-config 'azure=TRACE;<root>=DEBUG'
(check User-Agent in log messages)

## Documentation changes

None.

## Bug reference

None.