### PR TITLE
solved error in OpenSUSE version detection

### DIFF
--- a/environs/manual/sshprovisioner/sshprovisioner.go
+++ b/environs/manual/sshprovisioner/sshprovisioner.go
@@ -195,7 +195,7 @@ if [ "$os_id" = 'centos' ]; then
   echo "centos$os_version"
 elif [ "$os_id" = 'opensuse' ]; then
   os_version=$(grep '^VERSION_ID=' /etc/os-release | tr -d '"' | cut -d= -f2 | cut -d. -f1)
-  if [ $os_version -eq 42]; then
+  if [ $os_version -eq 42 ]; then
     echo "opensuseleap"
   fi
 else


### PR DESCRIPTION
## Please provide the following details to expedite Pull Request review:

----

## Description of change

In the manual ssh provisioning, the OS detection script has a little bug (a missing space) in the detection of the OpenSUSE version and the provisioning fails

## QA steps

How do we verify that the change works?

A manual ssh provisioning shall detect correctly the version of an OpenSUSE Leap machine.

## Documentation changes

Does it affect current user workflow? CLI? API?

## Bug reference

Does this change fix a bug? Please add a link to it.

I did't create a bug 