### PR TITLE
Add a script to target an agent version

### DIFF
--- a/scripts/forceagentversion/main.go
+++ b/scripts/forceagentversion/main.go
@@ -1,0 +1,113 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/juju/loggo"
+	"github.com/juju/utils/clock"
+	"github.com/juju/version"
+	"gopkg.in/juju/names.v2"
+
+	"github.com/juju/juju/mongo"
+	"github.com/juju/juju/state"
+	"github.com/juju/juju/cmd/jujud/agent"
+)
+
+var logger = loggo.GetLogger("forceagentversion")
+
+func setupLogging(logLevel loggo.Level) error {
+	writer := loggo.NewSimpleWriter(os.Stderr, logFormatter)
+	loggo.ReplaceDefaultWriter(writer)
+	return loggo.ConfigureLoggers(fmt.Sprintf("<root>=%s", logLevel.String()))
+}
+
+func logFormatter(entry loggo.Entry) string {
+	ts := entry.Timestamp.In(time.UTC).Format("2006-01-02 15:04:05")
+	return fmt.Sprintf("%s %s", ts, entry.Message)
+
+}
+
+type commandLineArgs struct {
+	port			int
+	modelUUID      string
+	rawVersion     string
+	version        version.Number
+	rawLogLevel    string
+	logLevel       loggo.Level
+}
+
+func commandLine() commandLineArgs {
+	flags := flag.NewFlagSet("mgopurge", flag.ExitOnError)
+	var a commandLineArgs
+	flags.StringVar(&a.modelUUID, "uuid", "",
+		"UUID of the Model to update")
+	flags.StringVar(&a.rawVersion, "version", "",
+		"version to upgrade to")
+	flags.IntVar(&a.port, "port", 37017,
+		"mongo port to connect to")
+	flags.StringVar(&a.rawLogLevel, "log-level", "TRACE",
+		"log level to use (TRACE/DEBUG/INFO/etc)")
+
+	flags.Parse(os.Args[1:])
+
+	targetVersion := version.MustParse(a.rawVersion)
+	a.version = targetVersion
+	a.logLevel, _ = loggo.ParseLevel(a.rawLogLevel)
+
+	return a
+}
+
+func checkErr(label string, err error) {
+	if err != nil {
+		logger.Errorf("%s: %s", label, err)
+		os.Exit(1)
+	}
+}
+
+const jujuDataDir = "/var/lib/juju"
+const jujuAgentDir = jujuDataDir + "/agents/"
+
+func main() {
+	args := commandLine()
+	checkErr("setup logging", setupLogging(args.logLevel))
+	// Check to see who we might be
+	matches, err := filepath.Glob(jujuAgentDir + "machine-*")
+	checkErr("finding machine agent", err)
+	if len(matches) == 0 {
+		logger.Errorf("no machines in %q", jujuAgentDir)
+		os.Exit(1)
+	} else if len(matches) > 1 {
+		logger.Errorf("too many machines in %q: %v", jujuAgentDir, matches)
+		os.Exit(1)
+	}
+	agentTag := matches[0][len(jujuAgentDir):]
+	agentConf := agent.NewAgentConf(jujuDataDir)
+	checkErr("read config", agentConf.ReadConfig(agentTag))
+	conf := agentConf.CurrentConfig()
+	mongoInfo, available := conf.MongoInfo()
+	if !available {
+		logger.Errorf("must be run from a controller machine, no mongo info available")
+		os.Exit(1)
+	}
+
+	openParams := state.OpenParams{
+		Clock: clock.WallClock,
+		MongoInfo: mongoInfo,
+		MongoDialOpts: mongo.DialOpts{
+			Timeout:       time.Second,
+			SocketTimeout: time.Second,
+			Direct:        false,
+		},
+		ControllerTag:      conf.Controller(),
+		ControllerModelTag: conf.Model(),
+	}
+	st, err := state.Open(openParams)
+	checkErr("open state", err)
+	modelSt, err := st.ForModel(names.NewModelTag(args.modelUUID))
+	checkErr("open model", err)
+	checkErr("set model agent version", modelSt.SetModelAgentVersion(args.version))
+}


### PR DESCRIPTION
## Description of change

When using `juju upgrade-juju`, it currently checks that doing an upgrade is sane (all agents are running the same current version, no upgrades are in progress, etc.)

This gives us a back-door directly to `State.SetModelAgentVersion()` to allow us to bypass that check.

The one limitation I'm aware of, is that it currently doesn't let you specify build revisions. I haven't figured out how `juju upgrade-juju` gets around this, but it tells me:
```
set model agent version: a hosted model cannot have a higher version than the server model: 2.2-rc1.2 > 2.2-rc1
```
(Even though my controller is currently *at* `2.2-rc1.2`.)

## QA steps

```
 $ go install github.com/juju/juju/...
 $ juju scp $GOPATH/bin/forceagentversion -m controller 0
 $ juju ssh 0
 $$ sudo su -
 $$ ~ubuntu/forceagentversion  -version 2.2-rc1.2 -uuid MODEL_UUID
```

## Documentation changes

We could document this command, but it is meant to be more of a backdoor than something we generally suggest users use.

## Bug reference

None.
