### PR TITLE
Don't attempt to use max-txn-log-size on upgrades

### DIFF
--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -856,6 +856,10 @@ func (a *MachineAgent) openStateForUpgrade() (*state.State, error) {
 		// state.InitDatabase is idempotent and needs to be called just
 		// prior to performing any upgrades since a new Juju binary may
 		// declare new indices or explicit collections.
+		// NB until https://jira.mongodb.org/browse/SERVER-1864 is resolved,
+		// it is not possible to resize capped collections so there's no
+		// point in reading existing controller config from state in order
+		// to pass in the max-txn-log-size value.
 		InitDatabaseFunc:       state.InitDatabase,
 		RunTransactionObserver: a.txnmetricsCollector.AfterRunTransaction,
 	})

--- a/state/database.go
+++ b/state/database.go
@@ -176,13 +176,13 @@ type collectionSchema map[string]collectionInfo
 // Create causes all recorded collections to be created and indexed as specified
 func (schema collectionSchema) Create(
 	db *mgo.Database,
-	settings controller.Config,
+	settings *controller.Config,
 ) error {
 	for name, info := range schema {
 		rawCollection := db.C(name)
 		if spec := info.explicitCreate; spec != nil {
 			// We allow the max txn log collection size to be overridden by the user.
-			if name == txnLogC {
+			if name == txnLogC && settings != nil {
 				maxSize := settings.MaxTxnLogSizeMB()
 				if maxSize > 0 {
 					logger.Infof("overriding max txn log collection size: %dM", maxSize)

--- a/state/open.go
+++ b/state/open.go
@@ -146,18 +146,7 @@ func open(
 		return nil, errors.Trace(err)
 	}
 	if initDatabase != nil {
-		if controllerConfig == nil {
-			// If no controller config is passed in, we get
-			// it from state. This occurs if we are opening
-			// an existing state database as opposed to creating
-			// a new one for the first time.
-			cfg, err := st.ControllerConfig()
-			if err != nil {
-				return nil, errors.Trace(err)
-			}
-			controllerConfig = &cfg
-		}
-		if err := initDatabase(session, *controllerConfig); err != nil {
+		if err := initDatabase(session, controllerConfig); err != nil {
 			session.Close()
 			return nil, errors.Trace(err)
 		}
@@ -269,10 +258,10 @@ func (p InitializeParams) Validate() error {
 
 // InitDatabaseFunc defines a function used to
 // create the collections and indices in a Juju database.
-type InitDatabaseFunc func(*mgo.Session, controller.Config) error
+type InitDatabaseFunc func(*mgo.Session, *controller.Config) error
 
 // InitDatabase creates all the collections and indices in a Juju database.
-func InitDatabase(session *mgo.Session, settings controller.Config) error {
+func InitDatabase(session *mgo.Session, settings *controller.Config) error {
 	schema := allCollections()
 	err := schema.Create(
 		session.DB(jujuDB),


### PR DESCRIPTION
## Description of change

Upgrading Juju paniced because when state was opened for the upgrade, the max-txn-log-size attribute was missing. This value would have been filled in by the upgrade steps, so it's a catch 22 thing. But the thing is, the max-txn-log-size is only useful when bootstrapping, because capped collections cannot be resized yet (https://jira.mongodb.org/browse/SERVER-1864). So now we only use the max-txn-log-size when initialising state on bootstrap, not on subsequent opens.

## QA steps

bootstrap older juju
upgrade

## Bug reference

https://bugs.launchpad.net/bugs/1694116
