### PR TITLE
provider/gce: start instance in same AZ as volumes

### DIFF
--- a/provider/gce/disks.go
+++ b/provider/gce/disks.go
@@ -313,6 +313,7 @@ func (v *volumeSource) ListVolumes() ([]string, error) {
 	}
 	return volumes, nil
 }
+
 func (v *volumeSource) DescribeVolumes(volNames []string) ([]storage.DescribeVolumesResult, error) {
 	results := make([]storage.DescribeVolumesResult, len(volNames))
 	for i, vol := range volNames {

--- a/provider/gce/environ_availzones.go
+++ b/provider/gce/environ_availzones.go
@@ -10,6 +10,7 @@ import (
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/provider/common"
 	"github.com/juju/juju/provider/gce/google"
+	"github.com/juju/juju/storage"
 )
 
 // AvailabilityZones returns all availability zones in the environment.
@@ -79,28 +80,42 @@ func (env *environ) availZoneUp(name string) (*google.AvailabilityZone, error) {
 
 var availabilityZoneAllocations = common.AvailabilityZoneAllocations
 
-// parseAvailabilityZones returns the availability zones that should be
-// tried for the given instance spec. If a placement argument was
-// provided then only that one is returned. Otherwise the environment is
-// queried for available zones. In that case, the resulting list is
+// startInstanceAvailabilityZones returns the availability zones that
+// should be tried for the given instance spec. If a placement argument
+// was provided then only that one is returned. Otherwise the environment
+// is queried for available zones. In that case, the resulting list is
 // roughly ordered such that the environment's instances are spread
 // evenly across the region.
-func (env *environ) parseAvailabilityZones(args environs.StartInstanceParams) ([]string, error) {
+func (env *environ) startInstanceAvailabilityZones(args environs.StartInstanceParams) ([]string, error) {
+	volumeAttachmentsZone, err := volumeAttachmentsZone(args.VolumeAttachments)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
 	if args.Placement != "" {
 		// args.Placement will always be a zone name or empty.
 		placement, err := env.parsePlacement(args.Placement)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
+		if volumeAttachmentsZone != "" && placement.Zone.Name() != volumeAttachmentsZone {
+			return nil, errors.Errorf(
+				"cannot create instance with placement %q, as this will prevent attaching disks in zone %q",
+				args.Placement, volumeAttachmentsZone,
+			)
+		}
 		// TODO(ericsnow) Fail if placement.Zone is not in the env's configured region?
 		return []string{placement.Zone.Name()}, nil
+	}
+
+	if volumeAttachmentsZone != "" {
+		return []string{volumeAttachmentsZone}, nil
 	}
 
 	// If no availability zone is specified, then automatically spread across
 	// the known zones for optimal spread across the instance distribution
 	// group.
 	var group []instance.Id
-	var err error
 	if args.DistributionGroup != nil {
 		group, err = args.DistributionGroup()
 		if err != nil {
@@ -123,4 +138,26 @@ func (env *environ) parseAvailabilityZones(args environs.StartInstanceParams) ([
 	}
 
 	return zoneNames, nil
+}
+
+// volumeAttachmentsZone determines the availability zone for each volume
+// identified in the volume attachment parameters, checking that they are
+// all the same, and returns the availability zone name.
+func volumeAttachmentsZone(volumeAttachments []storage.VolumeAttachmentParams) (string, error) {
+	var zone string
+	for i, a := range volumeAttachments {
+		volumeZone, _, err := parseVolumeId(a.VolumeId)
+		if err != nil {
+			return "", errors.Trace(err)
+		}
+		if zone == "" {
+			zone = volumeZone
+		} else if zone != volumeZone {
+			return "", errors.Errorf(
+				"cannot attach volumes from multiple availability zones: %s is in %s, %s is in %s",
+				volumeAttachments[i-1].VolumeId, zone, a.VolumeId, volumeZone,
+			)
+		}
+	}
+	return zone, nil
 }

--- a/provider/gce/environ_broker.go
+++ b/provider/gce/environ_broker.go
@@ -170,7 +170,7 @@ func (env *environ) newRawInstance(args environs.StartInstanceParams, spec *inst
 		// Network is omitted (left empty).
 	}
 
-	zones, err := env.parseAvailabilityZones(args)
+	zones, err := env.startInstanceAvailabilityZones(args)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/provider/gce/export_test.go
+++ b/provider/gce/export_test.go
@@ -30,8 +30,8 @@ func ExposeInstEnv(inst *environInstance) *environ {
 	return inst.env
 }
 
-func ParseAvailabilityZones(env *environ, args environs.StartInstanceParams) ([]string, error) {
-	return env.parseAvailabilityZones(args)
+func StartInstanceAvailabilityZones(env *environ, args environs.StartInstanceParams) ([]string, error) {
+	return env.startInstanceAvailabilityZones(args)
 }
 
 func ExposeEnvConfig(env *environ) *environConfig {


### PR DESCRIPTION
## Description of change

When starting a GCE VM, create it in the same AZ
as the volume(s) being attached, if any.

## QA steps

1. juju bootstrap google
2. juju deploy -n 2 postgresql --storage pgdata=gce,10G
(wait for idle)
3. juju remove-application postgresql
(wait for machines to be removed)
4. juju deploy postgresql pg2 --attach-storage pgdata/0
5. juju deploy postgresql pg3 --attach-storage pgdata/1
(both application units should be deployed successfully to the zones associated with the storage volumes)

## Documentation changes

None.

## Bug reference

None.