### PR TITLE
worker/peergrouper: fix race in tests

### DIFF
--- a/worker/peergrouper/desired_test.go
+++ b/worker/peergrouper/desired_test.go
@@ -186,8 +186,8 @@ func desiredPeerGroupTests(ipVersion TestIPVersion) []desiredPeerGroupTest {
 		}}
 }
 
-func (*desiredPeerGroupSuite) TestDesiredPeerGroup(c *gc.C) {
-	DoTestForIPv4AndIPv6(func(ipVersion TestIPVersion) {
+func (s *desiredPeerGroupSuite) TestDesiredPeerGroup(c *gc.C) {
+	DoTestForIPv4AndIPv6(c, s, func(ipVersion TestIPVersion) {
 		for i, test := range desiredPeerGroupTests(ipVersion) {
 			c.Logf("\ntest %d: %s", i, test.about)
 			trackerMap := make(map[string]*machineTracker)


### PR DESCRIPTION
## Description of change

DoTestForIPv4AndIPv6 causes races in tests,
as the tests start workers which are only
stopped by a cleanup, performed when the
test completes. We fix the race by calling
TearDownTest/SetUpTest between the IPv4
and IPv6 variations.

## QA steps

go test -race github.com/juju/juju/worker/peergrouper -test.cpu=1

## Documentation changes

None.

## Bug reference

None.