### PR TITLE
Fixes lp#1693530: adding agent-version to model info and related outputs. 

### DIFF
--- a/api/base/types.go
+++ b/api/base/types.go
@@ -6,6 +6,8 @@ package base
 import (
 	"time"
 
+	"github.com/juju/version"
+
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/status"
 )
@@ -57,6 +59,7 @@ type ModelInfo struct {
 	Status          Status
 	Users           []UserInfo
 	Machines        []Machine
+	AgentVersion    *version.Number
 }
 
 // Status represents the status of a machine, application, or unit.

--- a/api/modelmanager/modelmanager.go
+++ b/api/modelmanager/modelmanager.go
@@ -103,9 +103,7 @@ func convertParamsModelInfo(modelInfo params.ModelInfo) (base.ModelInfo, error) 
 		CloudCredential: credential,
 		Owner:           ownerTag.Id(),
 		Life:            string(modelInfo.Life),
-	}
-	if modelInfo.AgentVersion != nil {
-		result.AgentVersion = modelInfo.AgentVersion
+		AgentVersion:    modelInfo.AgentVersion,
 	}
 	result.Status = base.Status{
 		Status: modelInfo.Status.Status,

--- a/api/modelmanager/modelmanager.go
+++ b/api/modelmanager/modelmanager.go
@@ -104,6 +104,9 @@ func convertParamsModelInfo(modelInfo params.ModelInfo) (base.ModelInfo, error) 
 		Owner:           ownerTag.Id(),
 		Life:            string(modelInfo.Life),
 	}
+	if modelInfo.AgentVersion != nil {
+		result.AgentVersion = modelInfo.AgentVersion
+	}
 	result.Status = base.Status{
 		Status: modelInfo.Status.Status,
 		Info:   modelInfo.Status.Info,

--- a/apiserver/client/client.go
+++ b/apiserver/client/client.go
@@ -486,6 +486,9 @@ func (c *Client) ModelInfo() (params.ModelInfo, error) {
 		OwnerTag:      model.Owner().String(),
 		Life:          params.Life(model.Life().String()),
 	}
+	if agentVersion, exists := conf.AgentVersion(); exists {
+		info.AgentVersion = &agentVersion
+	}
 	if tag, ok := model.CloudCredential(); ok {
 		info.CloudCredentialTag = tag.String()
 	}

--- a/apiserver/client/client_test.go
+++ b/apiserver/client/client_test.go
@@ -112,6 +112,8 @@ func (s *serverSuite) TestModelInfo(c *gc.C) {
 	c.Assert(info.UUID, gc.Equals, model.UUID())
 	c.Assert(info.OwnerTag, gc.Equals, model.Owner().String())
 	c.Assert(info.Life, gc.Equals, params.Alive)
+	expectedAgentVersion, _ := conf.AgentVersion()
+	c.Assert(info.AgentVersion, gc.DeepEquals, &expectedAgentVersion)
 	// The controller UUID is not returned by the ModelInfo endpoint on the
 	// Client facade.
 	c.Assert(info.ControllerUUID, gc.Equals, "")

--- a/apiserver/modelmanager/modelinfo_test.go
+++ b/apiserver/modelmanager/modelinfo_test.go
@@ -149,6 +149,8 @@ func (s *modelInfoSuite) setAPIUser(c *gc.C, user names.UserTag) {
 
 func (s *modelInfoSuite) TestModelInfo(c *gc.C) {
 	info := s.getModelInfo(c, s.st.model.cfg.UUID())
+	expectedAgentVersion, exists := s.st.model.cfg.AgentVersion()
+	c.Assert(exists, jc.IsTrue)
 	c.Assert(info, jc.DeepEquals, params.ModelInfo{
 		Name:               "testenv",
 		UUID:               s.st.model.cfg.UUID(),
@@ -194,6 +196,7 @@ func (s *modelInfoSuite) TestModelInfo(c *gc.C) {
 			Level: "essential",
 			Owner: "user",
 		},
+		AgentVersion: &expectedAgentVersion,
 	})
 	s.st.CheckCalls(c, []gitjujutesting.StubCall{
 		{"ControllerTag", nil},

--- a/apiserver/modelmanager/modelmanager.go
+++ b/apiserver/modelmanager/modelmanager.go
@@ -600,6 +600,9 @@ func (m *ModelManagerAPI) getModelInfo(tag names.ModelTag) (params.ModelInfo, er
 	if err == nil {
 		info.ProviderType = cfg.Type()
 		info.DefaultSeries = config.PreferredSeries(cfg)
+		if agentVersion, exists := cfg.AgentVersion(); exists {
+			info.AgentVersion = &agentVersion
+		}
 	}
 
 	status, err := model.Status()

--- a/apiserver/params/model.go
+++ b/apiserver/params/model.go
@@ -157,6 +157,9 @@ type ModelInfo struct {
 
 	// SLA contains the information about the SLA for the model, if set.
 	SLA *ModelSLAInfo `json:"sla"`
+
+	// AgentVersion is the agent version for this model.
+	AgentVersion *version.Number `json:"agent-version"`
 }
 
 // ModelSLAInfo describes the SLA info for a model.

--- a/cmd/juju/common/model.go
+++ b/cmd/juju/common/model.go
@@ -31,6 +31,7 @@ type ModelInfo struct {
 	Machines       map[string]ModelMachineInfo `json:"machines,omitempty" yaml:"machines,omitempty"`
 	SLA            string                      `json:"sla,omitempty" yaml:"sla,omitempty"`
 	SLAOwner       string                      `json:"sla-owner,omitempty" yaml:"sla-owner,omitempty"`
+	AgentVersion   string                      `json:"agent-version,omitempty" yaml:"agent-version,omitempty"`
 }
 
 // ModelMachineInfo contains information about a machine in a model.
@@ -85,6 +86,9 @@ func ModelInfoFromParams(info params.ModelInfo, now time.Time) (ModelInfo, error
 		Life:           string(info.Life),
 		Cloud:          cloudTag.Id(),
 		CloudRegion:    info.CloudRegion,
+	}
+	if info.AgentVersion != nil {
+		modelInfo.AgentVersion = info.AgentVersion.String()
 	}
 	// Although this may be more performance intensive, we have to use reflection
 	// since structs containing map[string]interface {} cannot be compared, i.e

--- a/cmd/juju/controller/addmodel_test.go
+++ b/cmd/juju/controller/addmodel_test.go
@@ -44,7 +44,7 @@ var _ = gc.Suite(&AddModelSuite{})
 func (s *AddModelSuite) SetUpTest(c *gc.C) {
 	s.FakeJujuXDGDataHomeSuite.SetUpTest(c)
 
-	agentVersion, err := version.Parse("2.2-rc1")
+	agentVersion, err := version.Parse("2.55.5")
 	c.Assert(err, jc.ErrorIsNil)
 	s.fakeAddModelAPI = &fakeAddClient{
 		model: base.ModelInfo{

--- a/cmd/juju/controller/addmodel_test.go
+++ b/cmd/juju/controller/addmodel_test.go
@@ -14,6 +14,7 @@ import (
 	gitjujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils"
+	"github.com/juju/version"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/names.v2"
 	"gopkg.in/yaml.v2"
@@ -42,11 +43,15 @@ var _ = gc.Suite(&AddModelSuite{})
 
 func (s *AddModelSuite) SetUpTest(c *gc.C) {
 	s.FakeJujuXDGDataHomeSuite.SetUpTest(c)
+
+	agentVersion, err := version.Parse("2.2-rc1")
+	c.Assert(err, jc.ErrorIsNil)
 	s.fakeAddModelAPI = &fakeAddClient{
 		model: base.ModelInfo{
-			Name:  "test",
-			UUID:  "fake-model-uuid",
-			Owner: "ignored-for-now",
+			Name:         "test",
+			UUID:         "fake-model-uuid",
+			Owner:        "ignored-for-now",
+			AgentVersion: &agentVersion,
 		},
 	}
 	s.fakeCloudAPI = &fakeCloudAPI{

--- a/cmd/juju/controller/listmodels_test.go
+++ b/cmd/juju/controller/listmodels_test.go
@@ -65,7 +65,7 @@ func (f *fakeModelMgrAPIClient) ModelInfo(tags []names.ModelTag) ([]params.Model
 	if f.infos != nil {
 		return f.infos, nil
 	}
-	agentVersion, _ := version.Parse("2.2-rc1")
+	agentVersion, _ := version.Parse("2.55.5")
 	results := make([]params.ModelInfoResult, len(tags))
 	for i, tag := range tags {
 		for _, model := range f.models {
@@ -271,7 +271,7 @@ func (s *ModelsSuite) TestModelsError(c *gc.C) {
 }
 
 func createBasicModelInfo() *params.ModelInfo {
-	agentVersion, _ := version.Parse("2.2-rc1")
+	agentVersion, _ := version.Parse("2.55.5")
 	return &params.ModelInfo{
 		Name:           "basic-model",
 		UUID:           testing.ModelTag.Id(),

--- a/cmd/juju/model/show_test.go
+++ b/cmd/juju/model/show_test.go
@@ -479,7 +479,7 @@ func (s *ShowCommandSuite) TestShowModelWithAgentVersionInJson(c *gc.C) {
 		"\"controller-uuid\":\"deadbeef-1bad-500d-9000-4b1d0d06f00d\"," +
 		"\"controller-name\":\"testing\",\"owner\":\"owner\"," +
 		"\"cloud\":\"altostratus\",\"region\":\"mid-level\"," +
-		"\"life\":\"dead\",\"agent-version\":\"2.2-rc1\"}}\n"
+		"\"life\":\"dead\",\"agent-version\":\"2.55.5\"}}\n"
 	s.assertShowModelWithAgent(c, "json")
 }
 
@@ -494,7 +494,7 @@ basic-model:
   cloud: altostratus
   region: mid-level
   life: dead
-  agent-version: 2.2-rc1
+  agent-version: 2.55.5
 `[1:]
 	s.assertShowModelWithAgent(c, "yaml")
 }
@@ -502,7 +502,7 @@ basic-model:
 func (s *ShowCommandSuite) assertShowModelWithAgent(c *gc.C, format string) {
 	// Since most of the tests in this suite already test model infos without
 	// agent version, all we need to do here is to test one with it.
-	agentVersion, err := version.Parse("2.2-rc1")
+	agentVersion, err := version.Parse("2.55.5")
 	c.Assert(err, jc.ErrorIsNil)
 	basicTestInfo := createBasicModelInfo()
 	basicTestInfo.AgentVersion = &agentVersion

--- a/cmd/juju/model/show_test.go
+++ b/cmd/juju/model/show_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/juju/errors"
 	gitjujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
+	"github.com/juju/version"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/names.v2"
 
@@ -470,6 +471,45 @@ func (s *ShowCommandSuite) TestShowBasicWithSLAIncompleteModelsJson(c *gc.C) {
 		"\"life\":\"dead\",\"sla\":\"level\"," +
 		"\"sla-owner\":\"owner\"}}\n"
 	s.assertShowOutput(c, "json")
+}
+
+func (s *ShowCommandSuite) TestShowModelWithAgentVersionInJson(c *gc.C) {
+	s.expectedDisplay = "{\"basic-model\":{\"name\":\"basic-model\"," +
+		"\"model-uuid\":\"deadbeef-0bad-400d-8000-4b1d0d06f00d\"," +
+		"\"controller-uuid\":\"deadbeef-1bad-500d-9000-4b1d0d06f00d\"," +
+		"\"controller-name\":\"testing\",\"owner\":\"owner\"," +
+		"\"cloud\":\"altostratus\",\"region\":\"mid-level\"," +
+		"\"life\":\"dead\",\"agent-version\":\"2.2-rc1\"}}\n"
+	s.assertShowModelWithAgent(c, "json")
+}
+
+func (s *ShowCommandSuite) TestShowModelWithAgentVersionInYaml(c *gc.C) {
+	s.expectedDisplay = `
+basic-model:
+  name: basic-model
+  model-uuid: deadbeef-0bad-400d-8000-4b1d0d06f00d
+  controller-uuid: deadbeef-1bad-500d-9000-4b1d0d06f00d
+  controller-name: testing
+  owner: owner
+  cloud: altostratus
+  region: mid-level
+  life: dead
+  agent-version: 2.2-rc1
+`[1:]
+	s.assertShowModelWithAgent(c, "yaml")
+}
+
+func (s *ShowCommandSuite) assertShowModelWithAgent(c *gc.C, format string) {
+	// Since most of the tests in this suite already test model infos without
+	// agent version, all we need to do here is to test one with it.
+	agentVersion, err := version.Parse("2.2-rc1")
+	c.Assert(err, jc.ErrorIsNil)
+	basicTestInfo := createBasicModelInfo()
+	basicTestInfo.AgentVersion = &agentVersion
+	s.fake.infos = []params.ModelInfoResult{
+		params.ModelInfoResult{Result: basicTestInfo},
+	}
+	s.assertShowOutput(c, format)
 }
 
 func (s *ShowCommandSuite) newShowCommand() cmd.Command {

--- a/featuretests/cmd_juju_controller_test.go
+++ b/featuretests/cmd_juju_controller_test.go
@@ -4,6 +4,7 @@
 package featuretests
 
 import (
+	"fmt"
 	"os"
 	"reflect"
 	"time"
@@ -30,6 +31,7 @@ import (
 	"github.com/juju/juju/status"
 	"github.com/juju/juju/testing"
 	"github.com/juju/juju/testing/factory"
+	"github.com/juju/juju/version"
 )
 
 type cmdControllerSuite struct {
@@ -111,7 +113,7 @@ func (s *cmdControllerSuite) TestListModelsYAML(c *gc.C) {
 	two := uint64(2)
 	s.Factory.MakeMachine(c, &factory.MachineParams{Characteristics: &instance.HardwareCharacteristics{CpuCores: &two}})
 	context := s.run(c, "list-models", "--format=yaml")
-	c.Assert(cmdtesting.Stdout(context), gc.Matches, `
+	expectedOutput := `
 models:
 - name: controller
   model-uuid: deadbeef-0bad-400d-8000-4b1d0d06f00d
@@ -136,8 +138,10 @@ models:
     "1":
       cores: 2
   sla: unsupported
+  agent-version: %v
 current-model: controller
-`[1:])
+`[1:]
+	c.Assert(cmdtesting.Stdout(context), gc.Matches, fmt.Sprintf(expectedOutput, version.Current))
 }
 
 func (s *cmdControllerSuite) TestListDeadModels(c *gc.C) {


### PR DESCRIPTION
## Description of change

As per linked bug, specifying agent-version in model related commands is very useful and allows for more efficient work flows.

This PR adds agent version as an optional parameter to the command output of 'show-model' and 'juju models' (in yaml/json).

It has been decided, at this stage, not to augment API versions as we are adding new but optional parameter.
It has also been decided not to display agent version in the tabular output of 'juju models'.

This PR also adds/updates tests to ensure both models with and without agent versions are tested.

## QA steps

1. bootstrap
2. run show-model or 'juju models --format=yaml' commands

It is expected that agent-version and it's value will be in the output.

## Documentation changes

If there are sample outputs for show-model or 'juju models' commands, they will need to be updated.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1693530
