### PR TITLE
Return original error when retrying TLS connection with system wide CA set

### DIFF
--- a/api/apiclient.go
+++ b/api/apiclient.go
@@ -741,8 +741,10 @@ func (d dialer) dial1() (jsoncodec.JSONConn, *tls.Config, error) {
 	tlsConfig1 := *d.opts.tlsConfig
 	tlsConfig1.RootCAs = nil
 	tlsConfig1.ServerName = d.opts.sniHostName
-	conn, err = d.opts.DialWebsocket(d.ctx, d.urlStr, &tlsConfig1)
-	if err != nil {
+	conn, rootCAErr := d.opts.DialWebsocket(d.ctx, d.urlStr, &tlsConfig1)
+	if rootCAErr != nil {
+		logger.Warningf("Failed dialing websocket with both private CA - %q and public CA - %q", err, rootCAErr)
+		// We return the original error as it's usually more meaningful.
 		return nil, nil, errors.Trace(err)
 	}
 	return conn, &tlsConfig1, nil

--- a/api/apiclient_test.go
+++ b/api/apiclient_test.go
@@ -357,7 +357,7 @@ func (s *apiclientSuite) TestFallbackToSNIHostnameOnCertErrorAndNonNumericHostna
 			CACert:      jtesting.CACert,
 			SNIHostName: "foo.com",
 		},
-		expectOpenError: `unable to connect to API: x509: failed to load system roots and no roots provided`,
+		expectOpenError: `unable to connect to API: x509: a root or intermediate certificate is not authorized to sign in this domain`,
 		expectDials: []dialAttempt{{
 			// The first dial attempt should use the private CA cert.
 			check: func(info dialInfo) {


### PR DESCRIPTION
## Description of change
There is a fallback to system CA set if root CA is set and server cert fails verification. If it fails we should return original error as it's more specific. This is especially important on Windows as with current code a certificate that's expired but is correctly signed by custom CA will fail as unsigned (by system CA) instead of expired.

## QA steps
Check TestUpdateCert unit test on Windows.