### PR TITLE
provider/openstack: start instance in AZ of volume

### DIFF
--- a/provider/openstack/local_test.go
+++ b/provider/openstack/local_test.go
@@ -161,9 +161,10 @@ func makeMockAdapter() *mockAdapter {
 		createVolume: func(args cinder.CreateVolumeVolumeParams) (*cinder.Volume, error) {
 			metadata := args.Metadata.(map[string]string)
 			volume := cinder.Volume{
-				ID:       args.Name,
-				Metadata: metadata,
-				Status:   "cool",
+				ID:               args.Name,
+				Metadata:         metadata,
+				Status:           "cool",
+				AvailabilityZone: args.AvailabilityZone,
 			}
 			volumes[volume.ID] = &volume
 			return &volume, nil
@@ -1949,6 +1950,111 @@ func (t *localServerSuite) TestStartInstanceWithUnknownAZError(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, "(?s).*Some unknown error.*")
 }
 
+func (t *localServerSuite) TestStartInstanceVolumeAttachmentsAvailZone(c *gc.C) {
+	err := bootstrapEnv(c, t.env)
+	c.Assert(err, jc.ErrorIsNil)
+
+	t.srv.Nova.SetAvailabilityZones(
+		nova.AvailabilityZone{
+			Name: "az1",
+			State: nova.AvailabilityZoneState{
+				Available: true,
+			},
+		},
+		nova.AvailabilityZone{
+			Name: "az2",
+			State: nova.AvailabilityZoneState{
+				Available: true,
+			},
+		},
+	)
+
+	_, err = t.storageAdapter.CreateVolume(cinder.CreateVolumeVolumeParams{
+		Size:             123,
+		Name:             "foo",
+		AvailabilityZone: "az2",
+		Metadata: map[string]string{
+			"juju-model-uuid":      coretesting.ModelTag.Id(),
+			"juju-controller-uuid": coretesting.ControllerTag.Id(),
+		},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	result, err := testing.StartInstanceWithParams(t.env, "1", environs.StartInstanceParams{
+		ControllerUUID: t.ControllerUUID,
+		VolumeAttachments: []storage.VolumeAttachmentParams{
+			{VolumeId: "foo"},
+		},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(openstack.InstanceServerDetail(result.Instance).AvailabilityZone, gc.Equals, "az2")
+}
+
+func (t *localServerSuite) TestStartInstanceVolumeAttachmentsMultipleAvailZones(c *gc.C) {
+	err := bootstrapEnv(c, t.env)
+	c.Assert(err, jc.ErrorIsNil)
+
+	for _, az := range []string{"az1", "az2"} {
+		_, err := t.storageAdapter.CreateVolume(cinder.CreateVolumeVolumeParams{
+			Size:             123,
+			Name:             "vol-" + az,
+			AvailabilityZone: az,
+			Metadata: map[string]string{
+				"juju-model-uuid":      coretesting.ModelTag.Id(),
+				"juju-controller-uuid": coretesting.ControllerTag.Id(),
+			},
+		})
+		c.Assert(err, jc.ErrorIsNil)
+	}
+
+	_, err = testing.StartInstanceWithParams(t.env, "1", environs.StartInstanceParams{
+		ControllerUUID: t.ControllerUUID,
+		VolumeAttachments: []storage.VolumeAttachmentParams{
+			{VolumeId: "vol-az1"},
+			{VolumeId: "vol-az2"},
+		},
+	})
+	c.Assert(err, gc.ErrorMatches, `cannot attach volumes from multiple availability zones: vol-az1 is in az1, vol-az2 is in az2`)
+}
+
+func (t *localServerSuite) TestStartInstanceVolumeAttachmentsAvailZoneConflictsPlacement(c *gc.C) {
+	err := bootstrapEnv(c, t.env)
+	c.Assert(err, jc.ErrorIsNil)
+
+	t.srv.Nova.SetAvailabilityZones(
+		nova.AvailabilityZone{
+			Name: "az1",
+			State: nova.AvailabilityZoneState{
+				Available: true,
+			},
+		},
+		nova.AvailabilityZone{
+			Name: "az2",
+			State: nova.AvailabilityZoneState{
+				Available: true,
+			},
+		},
+	)
+
+	_, err = t.storageAdapter.CreateVolume(cinder.CreateVolumeVolumeParams{
+		Size:             123,
+		Name:             "foo",
+		AvailabilityZone: "az1",
+		Metadata: map[string]string{
+			"juju-model-uuid":      coretesting.ModelTag.Id(),
+			"juju-controller-uuid": coretesting.ControllerTag.Id(),
+		},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	_, err = testing.StartInstanceWithParams(t.env, "1", environs.StartInstanceParams{
+		ControllerUUID:    t.ControllerUUID,
+		VolumeAttachments: []storage.VolumeAttachmentParams{{VolumeId: "foo"}},
+		Placement:         "zone=test-available",
+	})
+	c.Assert(err, gc.ErrorMatches, `cannot create instance with placement "zone=test-available", as this will prevent attaching disks in zone "az1"`)
+}
+
 func (t *localServerSuite) TestStartInstanceNoValidHost(c *gc.C) {
 
 	t.srv.Nova.SetAvailabilityZones(
@@ -2146,7 +2252,7 @@ func (s *localServerSuite) TestAdoptResourcesNoStorage(c *gc.C) {
 	s.checkGroupController(c, env, newController)
 }
 
-func addVolume(c *gc.C, env environs.Environ, controllerUUID, name string) {
+func addVolume(c *gc.C, env environs.Environ, controllerUUID, name string) *storage.Volume {
 	storageAdapter, err := (*openstack.NewOpenstackStorage)(env.(*openstack.Environ))
 	c.Assert(err, jc.ErrorIsNil)
 	modelUUID := env.Config().UUID()
@@ -2161,6 +2267,7 @@ func addVolume(c *gc.C, env environs.Environ, controllerUUID, name string) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.HasLen, 1)
 	c.Assert(result[0].Error, jc.ErrorIsNil)
+	return result[0].Volume
 }
 
 func (s *localServerSuite) checkInstanceTags(c *gc.C, env environs.Environ, expectedController string) {


### PR DESCRIPTION
## Description of change

When creating a new instance which will have Cinder
volume attachments, start the instance in the same
AZ as the volumes, if any.

## QA steps

1. juju bootstrap canonistack
2. juju deploy postgresql --storage pgdata=100G,cinder
(wait)
3. juju remove-application postgresql
(wait)
4. juju deploy postgresql pg2 --attach-storage pgdata/0

## Documentation changes

None.

## Bug reference

None.