### PR TITLE
worker/statushistorypruner: use clock.Clock

### DIFF
--- a/cmd/jujud/agent/model/manifolds.go
+++ b/cmd/jujud/agent/model/manifolds.go
@@ -18,7 +18,6 @@ import (
 	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/feature"
-	jworker "github.com/juju/juju/worker"
 	"github.com/juju/juju/worker/agent"
 	"github.com/juju/juju/worker/apicaller"
 	"github.com/juju/juju/worker/apiconfigwatcher"
@@ -289,11 +288,10 @@ func Manifolds(config ManifoldsConfig) dependency.Manifolds {
 		statusHistoryPrunerName: ifNotMigrating(statushistorypruner.Manifold(statushistorypruner.ManifoldConfig{
 			APICallerName: apiCallerName,
 			EnvironName:   environTrackerName,
+			ClockName:     clockName,
 			NewWorker:     statushistorypruner.New,
 			NewFacade:     statushistorypruner.NewFacade,
 			PruneInterval: config.StatusHistoryPrunerInterval,
-			// TODO(fwereade): 2016-03-17 lp:1558657
-			NewTimer: jworker.NewTimer,
 		})),
 		machineUndertakerName: ifNotMigrating(machineundertaker.Manifold(machineundertaker.ManifoldConfig{
 			APICallerName: apiCallerName,

--- a/worker/statushistorypruner/manifold_test.go
+++ b/worker/statushistorypruner/manifold_test.go
@@ -60,6 +60,7 @@ func (s *ManifoldConfigSuite) validConfig() statushistorypruner.ManifoldConfig {
 	return statushistorypruner.ManifoldConfig{
 		APICallerName: "api-caller",
 		EnvironName:   "environ",
+		ClockName:     "clock",
 		NewWorker:     func(statushistorypruner.Config) (worker.Worker, error) { return nil, nil },
 		NewFacade:     func(caller base.APICaller) statushistorypruner.Facade { return nil },
 	}
@@ -77,6 +78,11 @@ func (s *ManifoldConfigSuite) TestMissingAPICallerName(c *gc.C) {
 func (s *ManifoldConfigSuite) TestMissingEnvironName(c *gc.C) {
 	s.config.EnvironName = ""
 	s.checkNotValid(c, "empty EnvironName not valid")
+}
+
+func (s *ManifoldConfigSuite) TestMissingClockName(c *gc.C) {
+	s.config.ClockName = ""
+	s.checkNotValid(c, "empty ClockName not valid")
 }
 
 func (s *ManifoldConfigSuite) TestMissingNewWorker(c *gc.C) {


### PR DESCRIPTION
## Description of change

Fixes an intermittent test failure, as seen in http://qa.jujucharms.com/releases/5314/job/run-unit-tests-race/attempt/2811.

The main change here is to only start the timer once the initial model config has been received. We change over to using clock.Clock (passed in via a manifold input). Also, use testing.ShortWait for checking things that *shouldn't* occur, to avoid 10 second waits.

## QA steps

Run the tests a bunch of times, with and without -race.

## Documentation changes

None.

## Bug reference

None.