### PR TITLE
apiserver: improve pinger test reliability

### DIFF
--- a/api/apiclient_test.go
+++ b/api/apiclient_test.go
@@ -836,6 +836,15 @@ func (s *apiclientSuite) TestPing(c *gc.C) {
 	}})
 }
 
+func (s *apiclientSuite) TestPingBroken(c *gc.C) {
+	conn := api.NewTestingState(api.TestingStateParams{
+		RPCConnection: newRPCConnection(errors.New("no biscuit")),
+		Clock:         &fakeClock{},
+	})
+	err := conn.Ping()
+	c.Assert(err, gc.ErrorMatches, "no biscuit")
+}
+
 func (s *apiclientSuite) TestIsBrokenOk(c *gc.C) {
 	conn := api.NewTestingState(api.TestingStateParams{
 		RPCConnection: newRPCConnection(),

--- a/apiserver/pinger_test.go
+++ b/apiserver/pinger_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/juju/loggo"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
-	"github.com/juju/utils"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/api"
@@ -149,18 +148,11 @@ func waitForClock(c *gc.C, clock *testing.Clock) {
 }
 
 func checkConnectionDies(c *gc.C, conn api.Connection) {
-	attempt := utils.AttemptStrategy{
-		Total: coretesting.LongWait,
-		Delay: coretesting.ShortWait,
+	select {
+	case <-conn.Broken():
+	case <-time.After(coretesting.LongWait):
+		c.Fatal("connection didn't get shut down")
 	}
-	for a := attempt.Start(); a.Next(); {
-		err := pingConn(conn)
-		if err != nil {
-			c.Assert(err, gc.ErrorMatches, "connection is shut down", gc.Commentf("details: %s", errors.Details(err)))
-			return
-		}
-	}
-	c.Fatal("connection didn't get shut down")
 }
 
 func pingConn(conn api.Connection) error {


### PR DESCRIPTION
## Description of change

Instead of calling Ping from the client
and expecting a specific error, use the
api.Connection's Broken channel.

## QA steps

Run the tests.

## Documentation changes

None.

## Bug reference

None.