### PR TITLE
Ensure storage constraints are removed when an application is deleted

### DIFF
--- a/state/application.go
+++ b/state/application.go
@@ -275,17 +275,19 @@ func (a *Application) removeOps(asserts bson.D) ([]txn.Op, error) {
 		},
 	}
 	// Note that appCharmDecRefOps might not catch the final decref
-	// when run in a transaction that decrefs more than once. In
-	// this case, luckily, we can be sure that we unconditionally
-	// need finalAppCharmRemoveOps; and we trust that it's written
-	// such that it's safe to run multiple times.
+	// when run in a transaction that decrefs more than once. So we
+	// avoid attempting to do the final cleanup in the ref dec ops and
+	// do it explicitly below.
 	name := a.doc.Name
 	curl := a.doc.CharmURL
-	charmOps, err := appCharmDecRefOps(a.st, name, curl)
+	charmOps, err := appCharmDecRefOps(a.st, name, curl, false)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
 	ops = append(ops, charmOps...)
+	// By the time we get to here, all units and charm refs have been removed,
+	// so it's safe to do this additonal cleanup.
+	ops = append(ops, finalAppCharmRemoveOps(name, curl)...)
 
 	globalKey := a.globalKey()
 	ops = append(ops,
@@ -675,7 +677,7 @@ func (a *Application) changeCharmOps(
 	// Drop the references to the old settings, storage constraints,
 	// and charm docs (if the refs actually exist yet).
 	if oldSettings != nil {
-		decOps, err = appCharmDecRefOps(a.st, a.doc.Name, a.doc.CharmURL) // current charm
+		decOps, err = appCharmDecRefOps(a.st, a.doc.Name, a.doc.CharmURL, true) // current charm
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
@@ -1256,7 +1258,10 @@ func (a *Application) removeUnitOps(u *Unit, asserts bson.D) ([]txn.Op, error) {
 	ops = append(ops, portsOps...)
 	ops = append(ops, storageInstanceOps...)
 	if u.doc.CharmURL != nil {
-		decOps, err := appCharmDecRefOps(a.st, a.doc.Name, u.doc.CharmURL)
+		// If the unit has a different URL to the application, allow any final
+		// cleanup to happen; otherwise we just do it when the app itself is removed.
+		maybeDoFinal := u.doc.CharmURL != a.doc.CharmURL
+		decOps, err := appCharmDecRefOps(a.st, a.doc.Name, u.doc.CharmURL, maybeDoFinal)
 		if errors.IsNotFound(err) {
 			return nil, errRefresh
 		} else if err != nil {

--- a/state/export_test.go
+++ b/state/export_test.go
@@ -684,3 +684,7 @@ func GetControllerSettings(st *State) *Settings {
 func NewSLALevel(level string) (slaLevel, error) {
 	return newSLALevel(level)
 }
+
+func AppStorageConstraints(app *Application) (map[string]StorageConstraints, error) {
+	return readStorageConstraints(app.st, app.storageConstraintsKey())
+}

--- a/state/unit.go
+++ b/state/unit.go
@@ -1135,7 +1135,7 @@ func (u *Unit) SetCharmURL(curl *charm.URL) error {
 			})
 		if u.doc.CharmURL != nil {
 			// Drop the reference to the old charm.
-			decOps, err := appCharmDecRefOps(u.st, u.doc.Application, u.doc.CharmURL)
+			decOps, err := appCharmDecRefOps(u.st, u.doc.Application, u.doc.CharmURL, true)
 			if err != nil {
 				return nil, errors.Trace(err)
 			}


### PR DESCRIPTION
## Description of change

When removing an application, ensure that artefacts such as storage constraints are also removed.

## QA steps

$ juju bootstrap aws
$ juju deploy postgresql --storage pgdata="ebs,10G"
$ juju remove-application postgresql

wait for postgresql app to disappear from status after it cleans itself up

$ juju deploy postgresql --storage pgdata="ebs,10G"

## Bug reference

https://bugs.launchpad.net/juju/+bug/1687878
