### PR TITLE
Pass volume attachments to PrecheckInstance

### DIFF
--- a/apiserver/uniter/storage.go
+++ b/apiserver/uniter/storage.go
@@ -315,7 +315,11 @@ func (s *StorageAPI) removeOneStorageAttachment(id params.StorageAttachmentId, c
 	if err != nil {
 		return err
 	}
-	return s.st.RemoveStorageAttachment(storageTag, unitTag)
+	err = s.st.RemoveStorageAttachment(storageTag, unitTag)
+	if errors.IsNotFound(err) {
+		err = nil
+	}
+	return err
 }
 
 // AddUnitStorage validates and creates additional storage instances for units.

--- a/environs/jujutest/livetests.go
+++ b/environs/jujutest/livetests.go
@@ -233,14 +233,13 @@ func (t *LiveTests) Destroy(c *gc.C) {
 }
 
 func (t *LiveTests) TestPrechecker(c *gc.C) {
-	// Providers may implement Prechecker. If they do, then they should
-	// return nil for empty constraints (excluding the null provider).
-	prechecker, ok := t.Env.(state.Prechecker)
-	if !ok {
-		return
-	}
-	const placement = ""
-	err := prechecker.PrecheckInstance("precise", constraints.Value{}, placement)
+	// All implementations of InstancePrechecker should
+	// return nil for empty constraints (excluding the
+	// manual provider).
+	t.PrepareOnce(c)
+	err := t.Env.PrecheckInstance(environs.PrecheckInstanceParams{
+		Series: "precise",
+	})
 	c.Assert(err, jc.ErrorIsNil)
 }
 

--- a/provider/azure/environ.go
+++ b/provider/azure/environ.go
@@ -44,7 +44,6 @@ import (
 	"github.com/juju/juju/provider/azure/internal/tracing"
 	"github.com/juju/juju/provider/azure/internal/useragent"
 	"github.com/juju/juju/provider/common"
-	"github.com/juju/juju/state"
 	"github.com/juju/juju/tools"
 )
 
@@ -111,7 +110,6 @@ type azureEnviron struct {
 }
 
 var _ environs.Environ = (*azureEnviron)(nil)
-var _ state.Prechecker = (*azureEnviron)(nil)
 
 // newEnviron creates a new azureEnviron.
 func newEnviron(
@@ -392,12 +390,12 @@ func (env *azureEnviron) ConstraintsValidator() (constraints.Validator, error) {
 	return validator, nil
 }
 
-// PrecheckInstance is defined on the state.Prechecker interface.
-func (env *azureEnviron) PrecheckInstance(series string, cons constraints.Value, placement string) error {
-	if placement != "" {
-		return fmt.Errorf("unknown placement directive: %s", placement)
+// PrecheckInstance is defined on the environs.InstancePrechecker interface.
+func (env *azureEnviron) PrecheckInstance(args environs.PrecheckInstanceParams) error {
+	if args.Placement != "" {
+		return fmt.Errorf("unknown placement directive: %s", args.Placement)
 	}
-	if !cons.HasInstanceType() {
+	if !args.Constraints.HasInstanceType() {
 		return nil
 	}
 	// Constraint has an instance-type constraint so let's see if it is valid.
@@ -406,11 +404,11 @@ func (env *azureEnviron) PrecheckInstance(series string, cons constraints.Value,
 		return err
 	}
 	for _, instanceType := range instanceTypes {
-		if instanceType.Name == *cons.InstanceType {
+		if instanceType.Name == *args.Constraints.InstanceType {
 			return nil
 		}
 	}
-	return fmt.Errorf("invalid instance type %q", *cons.InstanceType)
+	return fmt.Errorf("invalid instance type %q", *args.Constraints.InstanceType)
 }
 
 // MaintainInstance is specified in the InstanceBroker interface.

--- a/provider/cloudsigma/environ.go
+++ b/provider/cloudsigma/environ.go
@@ -10,7 +10,6 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/version"
 
-	"github.com/juju/juju/constraints"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/environs/simplestreams"
@@ -131,7 +130,7 @@ func (env *environ) DestroyController(controllerUUID string) error {
 // all invalid parameters. If PrecheckInstance returns nil, it is not
 // guaranteed that the constraints are valid; if a non-nil error is
 // returned, then the constraints are definitely invalid.
-func (env *environ) PrecheckInstance(series string, cons constraints.Value, placement string) error {
+func (env *environ) PrecheckInstance(environs.PrecheckInstanceParams) error {
 	return nil
 }
 

--- a/provider/cloudsigma/environ_test.go
+++ b/provider/cloudsigma/environ_test.go
@@ -54,7 +54,7 @@ func (s *environSuite) TestBase(c *gc.C) {
 	c.Assert(cfg, gc.NotNil)
 	c.Check(cfg.Name(), gc.Equals, "testname")
 
-	c.Check(env.PrecheckInstance("", constraints.Value{}, ""), gc.IsNil)
+	c.Check(env.PrecheckInstance(environs.PrecheckInstanceParams{}), gc.IsNil)
 
 	hasRegion, ok := env.(simplestreams.HasRegion)
 	c.Check(ok, gc.Equals, true)

--- a/provider/dummy/environs.go
+++ b/provider/dummy/environs.go
@@ -658,10 +658,10 @@ func (e *environ) checkBroken(method string) error {
 	return nil
 }
 
-// PrecheckInstance is specified in the state.Prechecker interface.
-func (*environ) PrecheckInstance(series string, cons constraints.Value, placement string) error {
-	if placement != "" && placement != "valid" {
-		return fmt.Errorf("%s placement is invalid", placement)
+// PrecheckInstance is specified in the environs.InstancePrechecker interface.
+func (*environ) PrecheckInstance(args environs.PrecheckInstanceParams) error {
+	if args.Placement != "" && args.Placement != "valid" {
+		return fmt.Errorf("%s placement is invalid", args.Placement)
 	}
 	return nil
 }

--- a/provider/ec2/environ.go
+++ b/provider/ec2/environ.go
@@ -304,10 +304,12 @@ func (e *environ) parsePlacement(placement string) (*ec2Placement, error) {
 
 // PrecheckInstance is defined on the environs.InstancePrechecker interface.
 func (e *environ) PrecheckInstance(args environs.PrecheckInstanceParams) error {
-	if args.Placement != "" {
-		if _, err := e.parsePlacement(args.Placement); err != nil {
-			return err
-		}
+	volumeAttachmentsZone, err := volumeAttachmentsZone(e.ec2, args.VolumeAttachments)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	if _, _, err := e.instancePlacementZone(args.Placement, volumeAttachmentsZone); err != nil {
+		return errors.Trace(err)
 	}
 	if !args.Constraints.HasInstanceType() {
 		return nil
@@ -411,46 +413,18 @@ func (e *environ) StartInstance(args environs.StartInstanceParams) (_ *environs.
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	if volumeAttachmentsZone != "" {
-		logger.Debugf("volume attachment(s) are in availability zone %q", volumeAttachmentsZone)
+	placementZone, placementSubnetID, err := e.instancePlacementZone(args.Placement, volumeAttachmentsZone)
+	if err != nil {
+		return nil, errors.Trace(err)
 	}
-
 	var availabilityZones []string
-	var placementSubnetID string
-	if args.Placement != "" {
-		placement, err := e.parsePlacement(args.Placement)
-		if err != nil {
-			return nil, err
-		}
-		if placement.availabilityZone.State != availableState {
-			return nil, errors.Errorf("availability zone %q is %q", placement.availabilityZone.Name, placement.availabilityZone.State)
-		}
-		if volumeAttachmentsZone != "" && volumeAttachmentsZone != placement.availabilityZone.Name {
-			return nil, errors.Errorf(
-				"cannot create instance with placement %q, as this will prevent attaching EBS volumes in zone %q",
-				args.Placement, volumeAttachmentsZone,
-			)
-		}
-		availabilityZones = append(availabilityZones, placement.availabilityZone.Name)
-		if placement.subnet != nil {
-			if placement.subnet.State != availableState {
-				return nil, errors.Errorf("subnet %q is %q", placement.subnet.CIDRBlock, placement.subnet.State)
-			}
-			placementSubnetID = placement.subnet.Id
-		}
-	}
-
-	// If any existing volumes are to be attached, and no placement was
-	// specified, we allocate the instance in the same zone as the
-	// volume(s).
-	if volumeAttachmentsZone != "" && len(availabilityZones) == 0 {
-		availabilityZones = append(availabilityZones, volumeAttachmentsZone)
+	if placementZone != "" {
+		availabilityZones = []string{placementZone}
 	}
 
 	// If no availability zone is specified or required, then automatically
 	// spread across the known zones for optimal spread across the instance
 	// distribution group.
-	var zoneInstances []common.AvailabilityZoneInstances
 	if len(availabilityZones) == 0 {
 		var err error
 		var group []instance.Id
@@ -460,7 +434,7 @@ func (e *environ) StartInstance(args environs.StartInstanceParams) (_ *environs.
 				return nil, err
 			}
 		}
-		zoneInstances, err = availabilityZoneAllocations(e, group)
+		zoneInstances, err := availabilityZoneAllocations(e, group)
 		if err != nil {
 			return nil, err
 		}
@@ -678,6 +652,37 @@ func (e *environ) StartInstance(args environs.StartInstanceParams) (_ *environs.
 		Instance: inst,
 		Hardware: &hc,
 	}, nil
+}
+
+func (e *environ) instancePlacementZone(placement, volumeAttachmentsZone string) (zone, subnet string, _ error) {
+	if placement == "" {
+		return volumeAttachmentsZone, "", nil
+	}
+	var placementSubnetID string
+	instPlacement, err := e.parsePlacement(placement)
+	if err != nil {
+		return "", "", errors.Trace(err)
+	}
+	if instPlacement.availabilityZone.State != availableState {
+		return "", "", errors.Errorf(
+			"availability zone %q is %q",
+			instPlacement.availabilityZone.Name,
+			instPlacement.availabilityZone.State,
+		)
+	}
+	if volumeAttachmentsZone != "" && volumeAttachmentsZone != instPlacement.availabilityZone.Name {
+		return "", "", errors.Errorf(
+			"cannot create instance with placement %q, as this will prevent attaching the requested EBS volumes in zone %q",
+			placement, volumeAttachmentsZone,
+		)
+	}
+	if instPlacement.subnet != nil {
+		if instPlacement.subnet.State != availableState {
+			return "", "", errors.Errorf("subnet %q is %q", instPlacement.subnet.CIDRBlock, instPlacement.subnet.State)
+		}
+		placementSubnetID = instPlacement.subnet.Id
+	}
+	return instPlacement.availabilityZone.Name, placementSubnetID, nil
 }
 
 // volumeAttachmentsZone determines the availability zone for each volume

--- a/provider/ec2/environ.go
+++ b/provider/ec2/environ.go
@@ -302,14 +302,14 @@ func (e *environ) parsePlacement(placement string) (*ec2Placement, error) {
 	return nil, fmt.Errorf("unknown placement directive: %v", placement)
 }
 
-// PrecheckInstance is defined on the state.Prechecker interface.
-func (e *environ) PrecheckInstance(series string, cons constraints.Value, placement string) error {
-	if placement != "" {
-		if _, err := e.parsePlacement(placement); err != nil {
+// PrecheckInstance is defined on the environs.InstancePrechecker interface.
+func (e *environ) PrecheckInstance(args environs.PrecheckInstanceParams) error {
+	if args.Placement != "" {
+		if _, err := e.parsePlacement(args.Placement); err != nil {
 			return err
 		}
 	}
-	if !cons.HasInstanceType() {
+	if !args.Constraints.HasInstanceType() {
 		return nil
 	}
 	// Constraint has an instance-type constraint so let's see if it is valid.
@@ -318,17 +318,17 @@ func (e *environ) PrecheckInstance(series string, cons constraints.Value, placem
 		return errors.Trace(err)
 	}
 	for _, itype := range instanceTypes {
-		if itype.Name != *cons.InstanceType {
+		if itype.Name != *args.Constraints.InstanceType {
 			continue
 		}
-		if archMatches(itype.Arches, cons.Arch) {
+		if archMatches(itype.Arches, args.Constraints.Arch) {
 			return nil
 		}
 	}
-	if cons.Arch == nil {
-		return fmt.Errorf("invalid AWS instance type %q specified", *cons.InstanceType)
+	if args.Constraints.Arch == nil {
+		return fmt.Errorf("invalid AWS instance type %q specified", *args.Constraints.InstanceType)
 	}
-	return fmt.Errorf("invalid AWS instance type %q and arch %q specified", *cons.InstanceType, *cons.Arch)
+	return fmt.Errorf("invalid AWS instance type %q and arch %q specified", *args.Constraints.InstanceType, *args.Constraints.Arch)
 }
 
 // MetadataLookupParams returns parameters which are used to query simplestreams metadata.

--- a/provider/ec2/environ_test.go
+++ b/provider/ec2/environ_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/juju/juju/environs/simplestreams"
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/network"
-	"github.com/juju/juju/state"
 )
 
 // Ensure EC2 provider supports the expected interfaces,
@@ -23,7 +22,6 @@ var (
 	_ environs.NetworkingEnviron = (*environ)(nil)
 	_ config.ConfigSchemaSource  = (*environProvider)(nil)
 	_ simplestreams.HasRegion    = (*environ)(nil)
-	_ state.Prechecker           = (*environ)(nil)
 	_ instance.Distributor       = (*environ)(nil)
 )
 

--- a/provider/gce/environ_availzones_test.go
+++ b/provider/gce/environ_availzones_test.go
@@ -204,5 +204,5 @@ func (s *environAZSuite) TestStartInstanceAvailabilityZonesVolumeAttachmentsConf
 	}}
 
 	_, err := gce.StartInstanceAvailabilityZones(s.Env, s.StartInstArgs)
-	c.Assert(err, gc.ErrorMatches, `cannot create instance with placement "zone=away-zone", as this will prevent attaching disks in zone "home-zone"`)
+	c.Assert(err, gc.ErrorMatches, `cannot create instance with placement "zone=away-zone", as this will prevent attaching the requested disks in zone "home-zone"`)
 }

--- a/provider/gce/environ_policy.go
+++ b/provider/gce/environ_policy.go
@@ -13,7 +13,11 @@ import (
 // PrecheckInstance verifies that the provided series and constraints
 // are valid for use in creating an instance in this environment.
 func (env *environ) PrecheckInstance(args environs.PrecheckInstanceParams) error {
-	if _, err := env.parsePlacement(args.Placement); err != nil {
+	volumeAttachmentsZone, err := volumeAttachmentsZone(args.VolumeAttachments)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	if _, err := env.instancePlacementZone(args.Placement, volumeAttachmentsZone); err != nil {
 		return errors.Trace(err)
 	}
 

--- a/provider/gce/environ_policy.go
+++ b/provider/gce/environ_policy.go
@@ -7,18 +7,19 @@ import (
 	"github.com/juju/errors"
 
 	"github.com/juju/juju/constraints"
+	"github.com/juju/juju/environs"
 )
 
 // PrecheckInstance verifies that the provided series and constraints
 // are valid for use in creating an instance in this environment.
-func (env *environ) PrecheckInstance(series string, cons constraints.Value, placement string) error {
-	if _, err := env.parsePlacement(placement); err != nil {
+func (env *environ) PrecheckInstance(args environs.PrecheckInstanceParams) error {
+	if _, err := env.parsePlacement(args.Placement); err != nil {
 		return errors.Trace(err)
 	}
 
-	if cons.HasInstanceType() {
-		if !checkInstanceType(cons) {
-			return errors.Errorf("invalid GCE instance type %q", *cons.InstanceType)
+	if args.Constraints.HasInstanceType() {
+		if !checkInstanceType(args.Constraints) {
+			return errors.Errorf("invalid GCE instance type %q", *args.Constraints.InstanceType)
 		}
 	}
 

--- a/provider/joyent/environ.go
+++ b/provider/joyent/environ.go
@@ -12,7 +12,6 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/version"
 
-	"github.com/juju/juju/constraints"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/environs/simplestreams"
@@ -57,12 +56,12 @@ func (*joyentEnviron) Provider() environs.EnvironProvider {
 	return providerInstance
 }
 
-// PrecheckInstance is defined on the state.Prechecker interface.
-func (env *joyentEnviron) PrecheckInstance(series string, cons constraints.Value, placement string) error {
-	if placement != "" {
-		return fmt.Errorf("unknown placement directive: %s", placement)
+// PrecheckInstance is defined on the environs.InstancePrechecker interface.
+func (env *joyentEnviron) PrecheckInstance(args environs.PrecheckInstanceParams) error {
+	if args.Placement != "" {
+		return fmt.Errorf("unknown placement directive: %s", args.Placement)
 	}
-	if !cons.HasInstanceType() {
+	if !args.Constraints.HasInstanceType() {
 		return nil
 	}
 	// Constraint has an instance-type constraint so let's see if it is valid.
@@ -71,11 +70,11 @@ func (env *joyentEnviron) PrecheckInstance(series string, cons constraints.Value
 		return err
 	}
 	for _, instanceType := range instanceTypes {
-		if instanceType.Name == *cons.InstanceType {
+		if instanceType.Name == *args.Constraints.InstanceType {
 			return nil
 		}
 	}
-	return fmt.Errorf("invalid Joyent instance %q specified", *cons.InstanceType)
+	return fmt.Errorf("invalid Joyent instance %q specified", *args.Constraints.InstanceType)
 }
 
 func (env *joyentEnviron) SetConfig(cfg *config.Config) error {

--- a/provider/lxd/environ_policy.go
+++ b/provider/lxd/environ_policy.go
@@ -10,17 +10,18 @@ import (
 	"github.com/juju/utils/arch"
 
 	"github.com/juju/juju/constraints"
+	"github.com/juju/juju/environs"
 )
 
 // PrecheckInstance verifies that the provided series and constraints
 // are valid for use in creating an instance in this environment.
-func (env *environ) PrecheckInstance(series string, cons constraints.Value, placement string) error {
-	if _, err := env.parsePlacement(placement); err != nil {
+func (env *environ) PrecheckInstance(args environs.PrecheckInstanceParams) error {
+	if _, err := env.parsePlacement(args.Placement); err != nil {
 		return errors.Trace(err)
 	}
 
-	if cons.HasInstanceType() {
-		return errors.Errorf("LXD does not support instance types (got %q)", *cons.InstanceType)
+	if args.Constraints.HasInstanceType() {
+		return errors.Errorf("LXD does not support instance types (got %q)", *args.Constraints.InstanceType)
 	}
 
 	return nil

--- a/provider/lxd/environ_policy_test.go
+++ b/provider/lxd/environ_policy_test.go
@@ -14,6 +14,7 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/constraints"
+	"github.com/juju/juju/environs"
 	"github.com/juju/juju/provider/lxd"
 )
 
@@ -23,18 +24,8 @@ type environPolSuite struct {
 
 var _ = gc.Suite(&environPolSuite{})
 
-func (s *environPolSuite) TestPrecheckInstanceOkay(c *gc.C) {
-	cons := constraints.Value{}
-	placement := ""
-	err := s.Env.PrecheckInstance(series.LatestLts(), cons, placement)
-
-	c.Check(err, jc.ErrorIsNil)
-}
-
-func (s *environPolSuite) TestPrecheckInstanceAPI(c *gc.C) {
-	cons := constraints.Value{}
-	placement := ""
-	err := s.Env.PrecheckInstance(series.LatestLts(), cons, placement)
+func (s *environPolSuite) TestPrecheckInstanceDefaults(c *gc.C) {
+	err := s.Env.PrecheckInstance(environs.PrecheckInstanceParams{Series: series.LatestLts()})
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.CheckNoAPI(c)
@@ -42,16 +33,14 @@ func (s *environPolSuite) TestPrecheckInstanceAPI(c *gc.C) {
 
 func (s *environPolSuite) TestPrecheckInstanceHasInstanceType(c *gc.C) {
 	cons := constraints.MustParse("instance-type=some-instance-type")
-	placement := ""
-	err := s.Env.PrecheckInstance(series.LatestLts(), cons, placement)
+	err := s.Env.PrecheckInstance(environs.PrecheckInstanceParams{Series: series.LatestLts(), Constraints: cons})
 
 	c.Check(err, gc.ErrorMatches, `LXD does not support instance types.*`)
 }
 
 func (s *environPolSuite) TestPrecheckInstanceDiskSize(c *gc.C) {
 	cons := constraints.MustParse("root-disk=1G")
-	placement := ""
-	err := s.Env.PrecheckInstance(series.LatestLts(), cons, placement)
+	err := s.Env.PrecheckInstance(environs.PrecheckInstanceParams{Series: series.LatestLts(), Constraints: cons})
 
 	c.Check(err, jc.ErrorIsNil)
 }
@@ -60,16 +49,14 @@ func (s *environPolSuite) TestPrecheckInstanceUnsupportedArch(c *gc.C) {
 	s.PatchValue(&arch.HostArch, func() string { return arch.AMD64 })
 
 	cons := constraints.MustParse("arch=i386")
-	placement := ""
-	err := s.Env.PrecheckInstance(series.LatestLts(), cons, placement)
+	err := s.Env.PrecheckInstance(environs.PrecheckInstanceParams{Series: series.LatestLts(), Constraints: cons})
 
 	c.Check(err, jc.ErrorIsNil)
 }
 
 func (s *environPolSuite) TestPrecheckInstanceAvailZone(c *gc.C) {
-	cons := constraints.Value{}
 	placement := "zone=a-zone"
-	err := s.Env.PrecheckInstance(series.LatestLts(), cons, placement)
+	err := s.Env.PrecheckInstance(environs.PrecheckInstanceParams{Series: series.LatestLts(), Placement: placement})
 
 	c.Check(err, gc.ErrorMatches, `unknown placement directive: .*`)
 }

--- a/provider/maas/environ.go
+++ b/provider/maas/environ.go
@@ -607,11 +607,11 @@ func (e *maasEnviron) parsePlacement(placement string) (*maasPlacement, error) {
 	return nil, errors.Errorf("unknown placement directive: %v", placement)
 }
 
-func (env *maasEnviron) PrecheckInstance(series string, cons constraints.Value, placement string) error {
-	if placement == "" {
+func (env *maasEnviron) PrecheckInstance(args environs.PrecheckInstanceParams) error {
+	if args.Placement == "" {
 		return nil
 	}
-	_, err := env.parsePlacement(placement)
+	_, err := env.parsePlacement(args.Placement)
 	return err
 }
 

--- a/provider/maas/environ_whitebox_test.go
+++ b/provider/maas/environ_whitebox_test.go
@@ -671,35 +671,32 @@ func (suite *environSuite) TestSubnetsMissingSubnet(c *gc.C) {
 func (s *environSuite) TestPrecheckInstanceAvailZone(c *gc.C) {
 	s.testMAASObject.TestServer.AddZone("zone1", "the grass is greener in zone1")
 	env := s.makeEnviron()
-	placement := "zone=zone1"
-	err := env.PrecheckInstance(series.LatestLts(), constraints.Value{}, placement)
+	err := env.PrecheckInstance(environs.PrecheckInstanceParams{Series: series.LatestLts(), Placement: "zone=zone1"})
 	c.Assert(err, jc.ErrorIsNil)
 }
 
 func (s *environSuite) TestPrecheckInstanceAvailZoneUnknown(c *gc.C) {
 	s.testMAASObject.TestServer.AddZone("zone1", "the grass is greener in zone1")
 	env := s.makeEnviron()
-	placement := "zone=zone2"
-	err := env.PrecheckInstance(series.LatestLts(), constraints.Value{}, placement)
+	err := env.PrecheckInstance(environs.PrecheckInstanceParams{Series: series.LatestLts(), Placement: "zone=zone2"})
 	c.Assert(err, gc.ErrorMatches, `invalid availability zone "zone2"`)
 }
 
 func (s *environSuite) TestPrecheckInstanceAvailZonesUnsupported(c *gc.C) {
 	env := s.makeEnviron()
-	placement := "zone=test-unknown"
-	err := env.PrecheckInstance(series.LatestLts(), constraints.Value{}, placement)
+	err := env.PrecheckInstance(environs.PrecheckInstanceParams{Series: series.LatestLts(), Placement: "zone=test-unknown"})
 	c.Assert(err, jc.Satisfies, errors.IsNotImplemented)
 }
 
 func (s *environSuite) TestPrecheckInvalidPlacement(c *gc.C) {
 	env := s.makeEnviron()
-	err := env.PrecheckInstance(series.LatestLts(), constraints.Value{}, "notzone=anything")
+	err := env.PrecheckInstance(environs.PrecheckInstanceParams{Series: series.LatestLts(), Placement: "notzone=anything"})
 	c.Assert(err, gc.ErrorMatches, "unknown placement directive: notzone=anything")
 }
 
 func (s *environSuite) TestPrecheckNodePlacement(c *gc.C) {
 	env := s.makeEnviron()
-	err := env.PrecheckInstance(series.LatestLts(), constraints.Value{}, "assumed_node_name")
+	err := env.PrecheckInstance(environs.PrecheckInstanceParams{Series: series.LatestLts(), Placement: "assumed_node_name"})
 	c.Assert(err, jc.ErrorIsNil)
 }
 

--- a/provider/manual/environ.go
+++ b/provider/manual/environ.go
@@ -314,7 +314,7 @@ exit 0
 	return err
 }
 
-func (*manualEnviron) PrecheckInstance(series string, _ constraints.Value, placement string) error {
+func (*manualEnviron) PrecheckInstance(environs.PrecheckInstanceParams) error {
 	return errors.New(`use "juju add-machine ssh:[user@]<host>" to provision machines`)
 }
 

--- a/provider/openstack/local_test.go
+++ b/provider/openstack/local_test.go
@@ -1260,42 +1260,112 @@ func (s *localServerSuite) TestFindImageInvalidInstanceConstraint(c *gc.C) {
 func (s *localServerSuite) TestPrecheckInstanceValidInstanceType(c *gc.C) {
 	env := s.Open(c, s.env.Config())
 	cons := constraints.MustParse("instance-type=m1.small")
-	placement := ""
-	err := env.PrecheckInstance(series.LatestLts(), cons, placement)
+	err := env.PrecheckInstance(environs.PrecheckInstanceParams{Series: series.LatestLts(), Constraints: cons})
 	c.Assert(err, jc.ErrorIsNil)
 }
 
 func (s *localServerSuite) TestPrecheckInstanceInvalidInstanceType(c *gc.C) {
 	env := s.Open(c, s.env.Config())
 	cons := constraints.MustParse("instance-type=m1.large")
-	placement := ""
-	err := env.PrecheckInstance(series.LatestLts(), cons, placement)
+	err := env.PrecheckInstance(environs.PrecheckInstanceParams{Series: series.LatestLts(), Constraints: cons})
 	c.Assert(err, gc.ErrorMatches, `invalid Openstack flavour "m1.large" specified`)
 }
 
 func (t *localServerSuite) TestPrecheckInstanceAvailZone(c *gc.C) {
 	placement := "zone=test-available"
-	err := t.env.PrecheckInstance(series.LatestLts(), constraints.Value{}, placement)
+	err := t.env.PrecheckInstance(environs.PrecheckInstanceParams{Series: series.LatestLts(), Placement: placement})
 	c.Assert(err, jc.ErrorIsNil)
 }
 
 func (t *localServerSuite) TestPrecheckInstanceAvailZoneUnavailable(c *gc.C) {
 	placement := "zone=test-unavailable"
-	err := t.env.PrecheckInstance(series.LatestLts(), constraints.Value{}, placement)
-	c.Assert(err, jc.ErrorIsNil)
+	err := t.env.PrecheckInstance(environs.PrecheckInstanceParams{Series: series.LatestLts(), Placement: placement})
+	c.Assert(err, gc.ErrorMatches, `availability zone "test-unavailable" is unavailable`)
 }
 
 func (t *localServerSuite) TestPrecheckInstanceAvailZoneUnknown(c *gc.C) {
 	placement := "zone=test-unknown"
-	err := t.env.PrecheckInstance(series.LatestLts(), constraints.Value{}, placement)
+	err := t.env.PrecheckInstance(environs.PrecheckInstanceParams{Series: series.LatestLts(), Placement: placement})
 	c.Assert(err, gc.ErrorMatches, `invalid availability zone "test-unknown"`)
 }
 
 func (t *localServerSuite) TestPrecheckInstanceAvailZonesUnsupported(c *gc.C) {
 	t.srv.Nova.SetAvailabilityZones() // no availability zone support
 	placement := "zone=test-unknown"
-	err := t.env.PrecheckInstance(series.LatestLts(), constraints.Value{}, placement)
+	err := t.env.PrecheckInstance(environs.PrecheckInstanceParams{Series: series.LatestLts(), Placement: placement})
 	c.Assert(err, jc.Satisfies, errors.IsNotImplemented)
+}
+
+func (t *localServerSuite) TestPrecheckInstanceVolumeAvailZonesNoPlacement(c *gc.C) {
+	t.testPrecheckInstanceVolumeAvailZones(c, "")
+}
+
+func (t *localServerSuite) TestPrecheckInstanceVolumeAvailZonesSameZonePlacement(c *gc.C) {
+	t.testPrecheckInstanceVolumeAvailZones(c, "zone=az1")
+}
+
+func (t *localServerSuite) testPrecheckInstanceVolumeAvailZones(c *gc.C, placement string) {
+	t.srv.Nova.SetAvailabilityZones(
+		nova.AvailabilityZone{
+			Name: "az1",
+			State: nova.AvailabilityZoneState{
+				Available: true,
+			},
+		},
+	)
+
+	_, err := t.storageAdapter.CreateVolume(cinder.CreateVolumeVolumeParams{
+		Size:             123,
+		Name:             "foo",
+		AvailabilityZone: "az1",
+		Metadata: map[string]string{
+			"juju-model-uuid":      coretesting.ModelTag.Id(),
+			"juju-controller-uuid": coretesting.ControllerTag.Id(),
+		},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = t.env.PrecheckInstance(environs.PrecheckInstanceParams{
+		Series:            series.LatestLts(),
+		Placement:         placement,
+		VolumeAttachments: []storage.VolumeAttachmentParams{{VolumeId: "foo"}},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (t *localServerSuite) TestPrecheckInstanceAvailZonesConflictsVolume(c *gc.C) {
+	t.srv.Nova.SetAvailabilityZones(
+		nova.AvailabilityZone{
+			Name: "az1",
+			State: nova.AvailabilityZoneState{
+				Available: true,
+			},
+		},
+		nova.AvailabilityZone{
+			Name: "az2",
+			State: nova.AvailabilityZoneState{
+				Available: true,
+			},
+		},
+	)
+
+	_, err := t.storageAdapter.CreateVolume(cinder.CreateVolumeVolumeParams{
+		Size:             123,
+		Name:             "foo",
+		AvailabilityZone: "az1",
+		Metadata: map[string]string{
+			"juju-model-uuid":      coretesting.ModelTag.Id(),
+			"juju-controller-uuid": coretesting.ControllerTag.Id(),
+		},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = t.env.PrecheckInstance(environs.PrecheckInstanceParams{
+		Series:            series.LatestLts(),
+		Placement:         "zone=az2",
+		VolumeAttachments: []storage.VolumeAttachmentParams{{VolumeId: "foo"}},
+	})
+	c.Assert(err, gc.ErrorMatches, `cannot create instance with placement "zone=az2", as this will prevent attaching the requested disks in zone "az1"`)
 }
 
 func (s *localServerSuite) TestValidateImageMetadata(c *gc.C) {
@@ -2052,7 +2122,7 @@ func (t *localServerSuite) TestStartInstanceVolumeAttachmentsAvailZoneConflictsP
 		VolumeAttachments: []storage.VolumeAttachmentParams{{VolumeId: "foo"}},
 		Placement:         "zone=test-available",
 	})
-	c.Assert(err, gc.ErrorMatches, `cannot create instance with placement "zone=test-available", as this will prevent attaching disks in zone "az1"`)
+	c.Assert(err, gc.ErrorMatches, `cannot create instance with placement "zone=test-available", as this will prevent attaching the requested disks in zone "az1"`)
 }
 
 func (t *localServerSuite) TestStartInstanceNoValidHost(c *gc.C) {

--- a/provider/openstack/provider.go
+++ b/provider/openstack/provider.go
@@ -40,7 +40,6 @@ import (
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/provider/common"
-	"github.com/juju/juju/state"
 	"github.com/juju/juju/status"
 	"github.com/juju/juju/storage"
 	"github.com/juju/juju/tools"
@@ -293,7 +292,6 @@ type Environ struct {
 
 var _ environs.Environ = (*Environ)(nil)
 var _ simplestreams.HasRegion = (*Environ)(nil)
-var _ state.Prechecker = (*Environ)(nil)
 var _ instance.Distributor = (*Environ)(nil)
 var _ environs.InstanceTagger = (*Environ)(nil)
 
@@ -592,14 +590,14 @@ func (e *Environ) parsePlacement(placement string) (*openstackPlacement, error) 
 	return nil, errors.Errorf("unknown placement directive: %v", placement)
 }
 
-// PrecheckInstance is defined on the state.Prechecker interface.
-func (e *Environ) PrecheckInstance(series string, cons constraints.Value, placement string) error {
-	if placement != "" {
-		if _, err := e.parsePlacement(placement); err != nil {
+// PrecheckInstance is defined on the environs.InstancePrechecker interface.
+func (e *Environ) PrecheckInstance(args environs.PrecheckInstanceParams) error {
+	if args.Placement != "" {
+		if _, err := e.parsePlacement(args.Placement); err != nil {
 			return err
 		}
 	}
-	if !cons.HasInstanceType() {
+	if !args.Constraints.HasInstanceType() {
 		return nil
 	}
 	// Constraint has an instance-type constraint so let's see if it is valid.
@@ -609,11 +607,11 @@ func (e *Environ) PrecheckInstance(series string, cons constraints.Value, placem
 		return err
 	}
 	for _, flavor := range flavors {
-		if flavor.Name == *cons.InstanceType {
+		if flavor.Name == *args.Constraints.InstanceType {
 			return nil
 		}
 	}
-	return errors.Errorf("invalid Openstack flavour %q specified", *cons.InstanceType)
+	return errors.Errorf("invalid Openstack flavour %q specified", *args.Constraints.InstanceType)
 }
 
 // PrepareForBootstrap is part of the Environ interface.

--- a/provider/oracle/environ.go
+++ b/provider/oracle/environ.go
@@ -774,7 +774,7 @@ func (o *OracleEnviron) Provider() environs.EnvironProvider {
 }
 
 // PrecheckInstance is part of the environs.Environ interface.
-func (o *OracleEnviron) PrecheckInstance(series string, cons constraints.Value, placement string) error {
+func (o *OracleEnviron) PrecheckInstance(environs.PrecheckInstanceParams) error {
 	return nil
 }
 

--- a/provider/oracle/environ_test.go
+++ b/provider/oracle/environ_test.go
@@ -260,8 +260,8 @@ func (e *environSuite) TestProvider(c *gc.C) {
 	c.Assert(p, gc.NotNil)
 }
 
-func (e *environSuite) TestPrecheckInstnace(c *gc.C) {
-	err := e.env.PrecheckInstance("", constraints.Value{}, "")
+func (e *environSuite) TestPrecheckInstance(c *gc.C) {
+	err := e.env.PrecheckInstance(environs.PrecheckInstanceParams{})
 	c.Assert(err, gc.IsNil)
 }
 

--- a/provider/rackspace/environ_test.go
+++ b/provider/rackspace/environ_test.go
@@ -214,8 +214,8 @@ func (e *fakeEnviron) Provider() environs.EnvironProvider {
 	return nil
 }
 
-func (e *fakeEnviron) PrecheckInstance(series string, cons constraints.Value, placement string) error {
-	e.Push("PrecheckInstance", series, cons, placement)
+func (e *fakeEnviron) PrecheckInstance(args environs.PrecheckInstanceParams) error {
+	e.Push("PrecheckInstance", args)
 	return nil
 }
 

--- a/provider/vsphere/environ_policy.go
+++ b/provider/vsphere/environ_policy.go
@@ -7,21 +7,22 @@ import (
 	"github.com/juju/utils/arch"
 
 	"github.com/juju/juju/constraints"
+	"github.com/juju/juju/environs"
 )
 
 // PrecheckInstance is part of the environs.Environ interface.
-func (env *environ) PrecheckInstance(series string, cons constraints.Value, placement string) error {
-	if placement == "" {
+func (env *environ) PrecheckInstance(args environs.PrecheckInstanceParams) error {
+	if args.Placement == "" {
 		return nil
 	}
 	return env.withSession(func(env *sessionEnviron) error {
-		return env.PrecheckInstance(series, cons, placement)
+		return env.PrecheckInstance(args)
 	})
 }
 
 // PrecheckInstance is part of the environs.Environ interface.
-func (env *sessionEnviron) PrecheckInstance(series string, cons constraints.Value, placement string) error {
-	_, err := env.parsePlacement(placement)
+func (env *sessionEnviron) PrecheckInstance(args environs.PrecheckInstanceParams) error {
+	_, err := env.parsePlacement(args.Placement)
 	return err
 }
 

--- a/state/internal_test.go
+++ b/state/internal_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/constraints"
+	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/feature"
 	"github.com/juju/juju/instance"
@@ -128,7 +129,7 @@ func (s *internalStateSuite) newState(c *gc.C) *State {
 
 type internalStatePolicy struct{}
 
-func (internalStatePolicy) Prechecker() (Prechecker, error) {
+func (internalStatePolicy) Prechecker() (environs.InstancePrechecker, error) {
 	return nil, errors.NotImplementedf("Prechecker")
 }
 

--- a/state/prechecker_test.go
+++ b/state/prechecker_test.go
@@ -9,11 +9,14 @@ import (
 	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/agent"
 	"github.com/juju/juju/constraints"
+	"github.com/juju/juju/environs"
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/state"
+	"github.com/juju/juju/storage"
 )
 
 type PrecheckerSuite struct {
@@ -24,23 +27,19 @@ type PrecheckerSuite struct {
 var _ = gc.Suite(&PrecheckerSuite{})
 
 type mockPrechecker struct {
-	precheckInstanceError       error
-	precheckInstanceSeries      string
-	precheckInstanceConstraints constraints.Value
-	precheckInstancePlacement   string
+	precheckInstanceError error
+	precheckInstanceArgs  environs.PrecheckInstanceParams
 }
 
-func (p *mockPrechecker) PrecheckInstance(series string, cons constraints.Value, placement string) error {
-	p.precheckInstanceSeries = series
-	p.precheckInstanceConstraints = cons
-	p.precheckInstancePlacement = placement
+func (p *mockPrechecker) PrecheckInstance(args environs.PrecheckInstanceParams) error {
+	p.precheckInstanceArgs = args
 	return p.precheckInstanceError
 }
 
 func (s *PrecheckerSuite) SetUpTest(c *gc.C) {
 	s.ConnSuite.SetUpTest(c)
 	s.prechecker = mockPrechecker{}
-	s.policy.GetPrechecker = func() (state.Prechecker, error) {
+	s.policy.GetPrechecker = func() (environs.InstancePrechecker, error) {
 		return &s.prechecker, nil
 	}
 }
@@ -54,12 +53,12 @@ func (s *PrecheckerSuite) TestPrecheckInstance(c *gc.C) {
 	placement := "abc123"
 	template, err := s.addOneMachine(c, envCons, placement)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(s.prechecker.precheckInstanceSeries, gc.Equals, template.Series)
-	c.Assert(s.prechecker.precheckInstancePlacement, gc.Equals, placement)
+	c.Assert(s.prechecker.precheckInstanceArgs.Series, gc.Equals, template.Series)
+	c.Assert(s.prechecker.precheckInstanceArgs.Placement, gc.Equals, placement)
 	validator := constraints.NewValidator()
 	cons, err := validator.Merge(envCons, template.Constraints)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(s.prechecker.precheckInstanceConstraints, gc.DeepEquals, cons)
+	c.Assert(s.prechecker.precheckInstanceArgs.Constraints, gc.DeepEquals, cons)
 }
 
 func (s *PrecheckerSuite) TestPrecheckErrors(c *gc.C) {
@@ -69,7 +68,7 @@ func (s *PrecheckerSuite) TestPrecheckErrors(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, ".*no instance for you")
 
 	// If the policy's Prechecker method fails, that will be returned first.
-	s.policy.GetPrechecker = func() (state.Prechecker, error) {
+	s.policy.GetPrechecker = func() (environs.InstancePrechecker, error) {
 		return nil, fmt.Errorf("no prechecker for you")
 	}
 	_, err = s.addOneMachine(c, constraints.Value{}, "placement")
@@ -78,7 +77,7 @@ func (s *PrecheckerSuite) TestPrecheckErrors(c *gc.C) {
 
 func (s *PrecheckerSuite) TestPrecheckPrecheckerUnimplemented(c *gc.C) {
 	var precheckerErr error
-	s.policy.GetPrechecker = func() (state.Prechecker, error) {
+	s.policy.GetPrechecker = func() (environs.InstancePrechecker, error) {
 		return nil, precheckerErr
 	}
 	_, err := s.addOneMachine(c, constraints.Value{}, "placement")
@@ -89,7 +88,7 @@ func (s *PrecheckerSuite) TestPrecheckPrecheckerUnimplemented(c *gc.C) {
 }
 
 func (s *PrecheckerSuite) TestPrecheckNoPolicy(c *gc.C) {
-	s.policy.GetPrechecker = func() (state.Prechecker, error) {
+	s.policy.GetPrechecker = func() (environs.InstancePrechecker, error) {
 		c.Errorf("should not have been invoked")
 		return nil, nil
 	}
@@ -125,8 +124,8 @@ func (s *PrecheckerSuite) TestPrecheckInstanceInjectMachine(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	// PrecheckInstance should not have been called, as we've
 	// injected a machine with an existing instance.
-	c.Assert(s.prechecker.precheckInstanceSeries, gc.Equals, "")
-	c.Assert(s.prechecker.precheckInstancePlacement, gc.Equals, "")
+	c.Assert(s.prechecker.precheckInstanceArgs.Series, gc.Equals, "")
+	c.Assert(s.prechecker.precheckInstanceArgs.Placement, gc.Equals, "")
 }
 
 func (s *PrecheckerSuite) TestPrecheckContainerNewMachine(c *gc.C) {
@@ -139,6 +138,90 @@ func (s *PrecheckerSuite) TestPrecheckContainerNewMachine(c *gc.C) {
 	}
 	_, err := s.State.AddMachineInsideNewMachine(template, template, instance.LXD)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(s.prechecker.precheckInstanceSeries, gc.Equals, template.Series)
-	c.Assert(s.prechecker.precheckInstancePlacement, gc.Equals, template.Placement)
+	c.Assert(s.prechecker.precheckInstanceArgs.Series, gc.Equals, template.Series)
+	c.Assert(s.prechecker.precheckInstanceArgs.Placement, gc.Equals, template.Placement)
+}
+
+func (s *PrecheckerSuite) TestPrecheckAddApplication(c *gc.C) {
+	// Deploy an application for the purpose of creating a
+	// storage instance. We'll then destroy the unit and detach
+	// the storage, so that it can be attached to a new
+	// application unit.
+	ch := s.AddTestingCharm(c, "storage-block")
+	app, err := s.State.AddApplication(state.AddApplicationArgs{
+		Name:     "storage-block",
+		Charm:    ch,
+		NumUnits: 1,
+		Storage: map[string]state.StorageConstraints{
+			"data":    {Count: 1, Pool: "modelscoped"},
+			"allecto": {Count: 1, Pool: "modelscoped"},
+		},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	unit, err := app.AddUnit()
+	c.Assert(err, jc.ErrorIsNil)
+	err = unit.AssignToNewMachine()
+	c.Assert(err, jc.ErrorIsNil)
+	machineId, err := unit.AssignedMachineId()
+	c.Assert(err, jc.ErrorIsNil)
+	machineTag := names.NewMachineTag(machineId)
+
+	storageAttachments, err := s.State.UnitStorageAttachments(unit.UnitTag())
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(storageAttachments, gc.HasLen, 2)
+	storageTags := []names.StorageTag{
+		storageAttachments[0].StorageInstance(),
+		storageAttachments[1].StorageInstance(),
+	}
+
+	volumeTags := make([]names.VolumeTag, len(storageTags))
+	for i, storageTag := range storageTags {
+		volume, err := s.State.StorageInstanceVolume(storageTag)
+		c.Assert(err, jc.ErrorIsNil)
+		volumeTags[i] = volume.VolumeTag()
+	}
+	// Provision only the first volume.
+	err = s.State.SetVolumeInfo(volumeTags[0], state.VolumeInfo{
+		VolumeId: "foo",
+		Pool:     "modelscoped",
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = unit.Destroy()
+	c.Assert(err, jc.ErrorIsNil)
+	for _, storageTag := range storageTags {
+		err = s.State.DetachStorage(storageTag, unit.UnitTag())
+		c.Assert(err, jc.ErrorIsNil)
+	}
+	for _, volumeTag := range volumeTags {
+		err = s.State.DetachVolume(machineTag, volumeTag)
+		c.Assert(err, jc.ErrorIsNil)
+		err = s.State.RemoveVolumeAttachment(machineTag, volumeTag)
+		c.Assert(err, jc.ErrorIsNil)
+	}
+
+	_, err = s.State.AddApplication(state.AddApplicationArgs{
+		Name:     "storage-block-the-second",
+		Charm:    ch,
+		NumUnits: 1,
+		Placement: []*instance.Placement{{
+			Scope:     s.State.ModelUUID(),
+			Directive: "whatever",
+		}},
+		AttachStorage: storageTags,
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	// The volume corresponding to the provisioned storage volume (only)
+	// should be presented to PrecheckInstance. The unprovisioned volume
+	// will be provisioned later by the storage provisioner.
+	c.Assert(s.prechecker.precheckInstanceArgs.Placement, gc.Equals, "whatever")
+	c.Assert(s.prechecker.precheckInstanceArgs.VolumeAttachments, jc.DeepEquals, []storage.VolumeAttachmentParams{{
+		AttachmentParams: storage.AttachmentParams{
+			Provider: "modelscoped",
+		},
+		Volume:   volumeTags[0],
+		VolumeId: "foo",
+	}})
 }

--- a/state/state.go
+++ b/state/state.go
@@ -46,6 +46,7 @@ import (
 	"github.com/juju/juju/state/presence"
 	"github.com/juju/juju/state/watcher"
 	"github.com/juju/juju/status"
+	"github.com/juju/juju/storage"
 	jujuversion "github.com/juju/juju/version"
 )
 
@@ -1097,7 +1098,44 @@ func (st *State) AddApplication(args AddApplicationArgs) (_ *Application, err er
 			}
 
 		case directivePlacement:
-			if err := st.precheckInstance(args.Series, args.Constraints, data.directive); err != nil {
+			// Obtain volume attachment params corresponding to storage being
+			// attached. We need to pass them along to precheckInstance, in
+			// case the volumes cannot be attached to a machine with the given
+			// placement directive.
+			volumeAttachments := make([]storage.VolumeAttachmentParams, 0, len(args.AttachStorage))
+			for _, storageTag := range args.AttachStorage {
+				v, err := st.StorageInstanceVolume(storageTag)
+				if errors.IsNotFound(err) {
+					continue
+				} else if err != nil {
+					return nil, errors.Trace(err)
+				}
+				volumeInfo, err := v.Info()
+				if err != nil {
+					// Volume has not been provisioned yet,
+					// so it cannot be attached.
+					continue
+				}
+				providerType, _, err := poolStorageProvider(st, volumeInfo.Pool)
+				if err != nil {
+					return nil, errors.Annotatef(err, "cannot attach %s", names.ReadableString(storageTag))
+				}
+				storageName, _ := names.StorageName(storageTag.Id())
+				volumeAttachments = append(volumeAttachments, storage.VolumeAttachmentParams{
+					AttachmentParams: storage.AttachmentParams{
+						Provider: providerType,
+						ReadOnly: args.Charm.Meta().Storage[storageName].ReadOnly,
+					},
+					Volume:   v.VolumeTag(),
+					VolumeId: volumeInfo.VolumeId,
+				})
+			}
+			if err := st.precheckInstance(
+				args.Series,
+				args.Constraints,
+				data.directive,
+				volumeAttachments,
+			); err != nil {
 				return nil, errors.Trace(err)
 			}
 		}

--- a/state/stateenvirons/policy.go
+++ b/state/stateenvirons/policy.go
@@ -33,8 +33,8 @@ func GetNewPolicyFunc(getEnviron func(*state.State) (environs.Environ, error)) s
 }
 
 // Prechecker implements state.Policy.
-func (p environStatePolicy) Prechecker() (state.Prechecker, error) {
-	// Environ implements state.Prechecker.
+func (p environStatePolicy) Prechecker() (environs.InstancePrechecker, error) {
+	// Environ implements environs.InstancePrechecker.
 	return p.getEnviron(p.st)
 }
 

--- a/state/storage.go
+++ b/state/storage.go
@@ -1007,7 +1007,8 @@ func (st *State) DetachStorage(storage names.StorageTag, unit names.UnitTag) (er
 	defer errors.DeferredAnnotatef(&err, "cannot destroy storage attachment %s:%s", storage.Id(), unit.Id())
 	buildTxn := func(attempt int) ([]txn.Op, error) {
 		s, err := st.storageAttachment(storage, unit)
-		if errors.IsNotFound(err) {
+		if errors.IsNotFound(err) && attempt > 0 {
+			// On the first attempt, we expect it to exist.
 			return nil, jujutxn.ErrNoOperations
 		} else if err != nil {
 			return nil, errors.Trace(err)
@@ -1165,7 +1166,8 @@ func (st *State) RemoveStorageAttachment(storage names.StorageTag, unit names.Un
 	defer errors.DeferredAnnotatef(&err, "cannot remove storage attachment %s:%s", storage.Id(), unit.Id())
 	buildTxn := func(attempt int) ([]txn.Op, error) {
 		s, err := st.storageAttachment(storage, unit)
-		if errors.IsNotFound(err) {
+		if errors.IsNotFound(err) && attempt > 0 {
+			// On the first attempt, we expect it to exist.
 			return nil, jujutxn.ErrNoOperations
 		} else if err != nil {
 			return nil, errors.Trace(err)

--- a/state/storage_test.go
+++ b/state/storage_test.go
@@ -292,8 +292,10 @@ func (s *StorageStateSuiteBase) obliterateUnitStorage(c *gc.C, tag names.UnitTag
 	for _, a := range attachments {
 		err = s.State.DetachStorage(a.StorageInstance(), a.Unit())
 		c.Assert(err, jc.ErrorIsNil)
-		err = s.State.RemoveStorageAttachment(a.StorageInstance(), a.Unit())
-		c.Assert(err, jc.ErrorIsNil)
+		if _, err := s.State.StorageAttachment(a.StorageInstance(), a.Unit()); err == nil {
+			err = s.State.RemoveStorageAttachment(a.StorageInstance(), a.Unit())
+			c.Assert(err, jc.ErrorIsNil)
+		}
 	}
 }
 
@@ -676,8 +678,6 @@ func (s *StorageStateSuite) TestRemoveStorageAttachmentsRemovesDyingInstance(c *
 
 	err = s.State.DetachStorage(storageTag, u.UnitTag())
 	c.Assert(err, jc.ErrorIsNil)
-	err = s.State.RemoveStorageAttachment(storageTag, u.UnitTag())
-	c.Assert(err, jc.ErrorIsNil)
 	exists := s.storageInstanceExists(c, storageTag)
 	c.Assert(exists, jc.IsFalse)
 }
@@ -705,8 +705,6 @@ func (s *StorageStateSuite) TestRemoveStorageAttachmentsDisownsUnitOwnedInstance
 	c.Assert(err, jc.ErrorIsNil)
 	err = s.State.DetachStorage(storageTag, u.UnitTag())
 	c.Assert(err, jc.ErrorIsNil)
-	err = s.State.RemoveStorageAttachment(storageTag, u.UnitTag())
-	c.Assert(err, jc.ErrorIsNil)
 
 	si, err = s.State.StorageInstance(storageTag)
 	c.Assert(err, jc.ErrorIsNil)
@@ -728,8 +726,6 @@ func (s *StorageStateSuite) TestAttachStorageTakesOwnership(c *gc.C) {
 	// Detach, but do not destroy, the storage.
 	err = s.State.DetachStorage(storageTag, u.UnitTag())
 	c.Assert(err, jc.ErrorIsNil)
-	err = s.State.RemoveStorageAttachment(storageTag, u.UnitTag())
-	c.Assert(err, jc.ErrorIsNil)
 
 	// Now attach the storage to the second unit.
 	err = s.State.AttachStorage(storageTag, u2.UnitTag())
@@ -748,8 +744,6 @@ func (s *StorageStateSuite) TestAttachStorageAssignedMachine(c *gc.C) {
 
 	// Detach, but do not destroy, the storage.
 	err = s.State.DetachStorage(storageTag, u.UnitTag())
-	c.Assert(err, jc.ErrorIsNil)
-	err = s.State.RemoveStorageAttachment(storageTag, u.UnitTag())
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Assign the second unit to a machine so that when we
@@ -794,8 +788,6 @@ func (s *StorageStateSuite) TestAttachStorageAssignedMachineExistingVolume(c *gc
 
 	// Detach, but do not destroy, the storage.
 	err = s.State.DetachStorage(storageTag, u.UnitTag())
-	c.Assert(err, jc.ErrorIsNil)
-	err = s.State.RemoveStorageAttachment(storageTag, u.UnitTag())
 	c.Assert(err, jc.ErrorIsNil)
 	err = s.State.RemoveFilesystemAttachment(oldMachineTag, filesystem.FilesystemTag())
 	c.Assert(err, jc.ErrorIsNil)
@@ -845,8 +837,6 @@ func (s *StorageStateSuite) TestAttachStorageAssignedMachineExistingVolumeAttach
 	// another unit/machine until it's gone.
 	err = s.State.DetachStorage(storageTag, u.UnitTag())
 	c.Assert(err, jc.ErrorIsNil)
-	err = s.State.RemoveStorageAttachment(storageTag, u.UnitTag())
-	c.Assert(err, jc.ErrorIsNil)
 
 	err = s.State.AttachStorage(storageTag, u2.UnitTag())
 	c.Assert(err, gc.ErrorMatches,
@@ -859,8 +849,6 @@ func (s *StorageStateSuite) TestAddApplicationAttachStorage(c *gc.C) {
 
 	// Detach, but do not destroy, the storage.
 	err := s.State.DetachStorage(storageTag, u.UnitTag())
-	c.Assert(err, jc.ErrorIsNil)
-	err = s.State.RemoveStorageAttachment(storageTag, u.UnitTag())
 	c.Assert(err, jc.ErrorIsNil)
 
 	ch, _, err := app.Charm()
@@ -924,8 +912,6 @@ func (s *StorageStateSuite) TestAddApplicationAttachStorageTooMany(c *gc.C) {
 		// Detach, but do not destroy, the storage.
 		err = s.State.DetachStorage(storageTag, u.UnitTag())
 		c.Assert(err, jc.ErrorIsNil)
-		err = s.State.RemoveStorageAttachment(storageTag, u.UnitTag())
-		c.Assert(err, jc.ErrorIsNil)
 	}
 
 	ch, _, err := app.Charm()
@@ -955,8 +941,6 @@ func (s *StorageStateSuite) TestConcurrentDestroyStorageInstanceRemoveStorageAtt
 
 	defer state.SetBeforeHooks(c, s.State, func() {
 		err := s.State.DetachStorage(storageTag, u.UnitTag())
-		c.Assert(err, jc.ErrorIsNil)
-		err = s.State.RemoveStorageAttachment(storageTag, u.UnitTag())
 		c.Assert(err, jc.ErrorIsNil)
 	}).Check()
 
@@ -1024,8 +1008,6 @@ func (s *StorageStateSuite) TestConcurrentDestroyInstanceRemoveStorageAttachment
 	// changes to the storage instance's life, and recompute operations
 	// if it does.
 	err = s.State.DetachStorage(storageTag, u.UnitTag())
-	c.Assert(err, jc.ErrorIsNil)
-	err = s.State.RemoveStorageAttachment(storageTag, u.UnitTag())
 	c.Assert(err, jc.ErrorIsNil)
 	exists := s.storageInstanceExists(c, storageTag)
 	c.Assert(exists, jc.IsFalse)

--- a/state/testing/policy.go
+++ b/state/testing/policy.go
@@ -9,14 +9,14 @@ import (
 	"gopkg.in/juju/environschema.v1"
 
 	"github.com/juju/juju/constraints"
+	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/instance"
-	"github.com/juju/juju/state"
 	"github.com/juju/juju/storage"
 )
 
 type MockPolicy struct {
-	GetPrechecker                 func() (state.Prechecker, error)
+	GetPrechecker                 func() (environs.InstancePrechecker, error)
 	GetConfigValidator            func() (config.Validator, error)
 	GetProviderConfigSchemaSource func() (config.ConfigSchemaSource, error)
 	GetConstraintsValidator       func() (constraints.Validator, error)
@@ -24,7 +24,7 @@ type MockPolicy struct {
 	GetStorageProviderRegistry    func() (storage.ProviderRegistry, error)
 }
 
-func (p *MockPolicy) Prechecker() (state.Prechecker, error) {
+func (p *MockPolicy) Prechecker() (environs.InstancePrechecker, error) {
 	if p.GetPrechecker != nil {
 		return p.GetPrechecker()
 	}

--- a/state/volume_test.go
+++ b/state/volume_test.go
@@ -943,8 +943,6 @@ func removeStorageInstance(c *gc.C, st *state.State, storageTag names.StorageTag
 	for _, a := range attachments {
 		err = st.DetachStorage(storageTag, a.Unit())
 		c.Assert(err, jc.ErrorIsNil)
-		err = st.RemoveStorageAttachment(storageTag, a.Unit())
-		c.Assert(err, jc.ErrorIsNil)
 	}
 	_, err = st.StorageInstance(storageTag)
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)


### PR DESCRIPTION
## Description of change

We extend the Prechecker (now InstancePrechecker) interface's PrecheckInstance method with an additional parameter, the *existing* volumes that are to be attached to the instance. This allows a provider to, say, identify a conflict between zone placement and the zone in which the volumes are found. PrecheckInstance now takes a parameter struct.

The gce, ec2, and openstack providers have been updated to check for placement/volume availability zone conflicts.

## QA steps

1. juju bootstrap (openstack|aws|google)
2. juju deploy postgresql --storage pgdata=10G
(waiit)
3. juju remove-application postgresql
(wait)
4. juju deploy postgresql pg2 --attach-storage pgdata/0 --to zone=<some-other-zone>
(should fail immediately, rather than being recorded in state and failing at provisioning time)

## Documentation changes

None.

## Bug reference

None.