### PR TITLE
Clean AWS security groups on all regions

### DIFF
--- a/acceptancetests/clean_resources.py
+++ b/acceptancetests/clean_resources.py
@@ -27,28 +27,62 @@ def get_regions(args, env):
 
 def clean(args):
     env = SimpleEnvironment.from_config(args.env)
-    selected_regions = get_regions(args, env)
+    # To Do: Read regions from public-clouds.yaml
+    selected_regions = ['us-east-1', 'us-east-2', 'us-west-1', 'us-west-2',
+                        'ca-central-1',
+                        'eu-west-1', 'eu-west-2', 'eu-central-1',
+                        'ap-south-1', 'ap-southeast-1', 'ap-southeast-2',
+                        'ap-northeast-1', 'ap-northeast-2',
+                        'sa-east-1']
+    logging.info('The target regions for cleaning job are \n{}'
+                 .format('\n'.join(selected_regions)))
     for region in selected_regions:
         with AWSAccount.from_boot_config(env, region=region) as substrate:
-            logging.info('Cleaning resources in {}.'.format(substrate.region))
-            all_groups = dict(substrate.iter_security_groups())
-            instance_groups = dict(substrate.iter_instance_security_groups())
-            non_instance_groups = dict((k, v) for k, v in all_groups.items()
-                                       if k not in instance_groups)
-            try:
-                unclean = substrate.delete_detached_interfaces(
-                    non_instance_groups.keys())
-                logging.info('Unable to delete {} groups'.format(len(unclean)))
-            except:
-                logging.info('Unable to delete non-instance groups {}'.format(non_instance_groups.keys()))
-            for group_id in unclean:
-                logging.debug('Cannot delete {}'.format(all_groups[group_id]))
-            for group_id in unclean:
-                non_instance_groups.pop(group_id, None)
-            try:
-                substrate.destroy_security_groups(non_instance_groups.values())
-            except:
-                logging.debug('Failed to delete groups {}'.format(non_instance_groups.values()))
+            if substrate is not None:
+                logging.info('Cleaning resources in {}.'
+                             .format(substrate.region))
+                all_groups = dict(substrate.iter_security_groups())
+                instance_groups = dict(substrate.iter_instance_security_groups())
+                logging.info('{} items found from instance groups on {} \n{}'
+                             .format(str(len(instance_groups)),
+                                     region,
+                                     '\n'.join(instance_groups)))
+                non_instance_groups = dict((k, v) for k, v in all_groups.items()
+                                           if k not in instance_groups)
+                logging.info('{} items found from non-instance groups on {} \n{}'
+                             .format(str(len(non_instance_groups)),
+                                     region,
+                                     '\n'.join(non_instance_groups)))
+                try:
+                    logging.info('{} detached interfaces will be deleted from {} \n{}'
+                                 .format(str(len(non_instance_groups.keys())),
+                                         region,
+                                         '\n'.join(non_instance_groups.keys())))
+                    unclean = substrate.delete_detached_interfaces(
+                        non_instance_groups.keys())
+                    logging.info('Unable to delete {} groups from {}'
+                                 .format(len(unclean)), region)
+                except:
+                    logging.info('Unable to delete non-instance groups {} from {}'
+                                 .format(non_instance_groups.keys(), region))
+                for group_id in unclean:
+                    logging.debug('Cannot delete {}'
+                                  .format(all_groups[group_id]))
+                for group_id in unclean:
+                    non_instance_groups.pop(group_id, None)
+                try:
+                    substrate.destroy_security_groups(non_instance_groups.values())
+                    logging.info('{} security groups have been deleted on region {} \n{}'
+                                 .format(len(non_instance_groups.values()),
+                                         region,
+                                         '\n'.join(non_instance_groups.values())))
+                except:
+                    logging.debug('Failed to delete groups {} from {}'
+                                  .format(non_instance_groups.values(), region))
+            else:
+                logging.info('Skipping {}, substrate object returns NoneType'
+                             .format(region))
+
 
 def main():
     args = parse_args()

--- a/acceptancetests/clean_resources.py
+++ b/acceptancetests/clean_resources.py
@@ -61,7 +61,7 @@ def clean(args):
                     unclean = substrate.delete_detached_interfaces(
                         non_instance_groups.keys())
                     logging.info('Unable to delete {} groups from {}'
-                                 .format(len(unclean)), region)
+                                 .format(str(len(unclean)), region))
                 except:
                     logging.info('Unable to delete non-instance groups {} from {}'
                                  .format(non_instance_groups.keys(), region))

--- a/api/apiclient_test.go
+++ b/api/apiclient_test.go
@@ -836,6 +836,15 @@ func (s *apiclientSuite) TestPing(c *gc.C) {
 	}})
 }
 
+func (s *apiclientSuite) TestPingBroken(c *gc.C) {
+	conn := api.NewTestingState(api.TestingStateParams{
+		RPCConnection: newRPCConnection(errors.New("no biscuit")),
+		Clock:         &fakeClock{},
+	})
+	err := conn.Ping()
+	c.Assert(err, gc.ErrorMatches, "no biscuit")
+}
+
 func (s *apiclientSuite) TestIsBrokenOk(c *gc.C) {
 	conn := api.NewTestingState(api.TestingStateParams{
 		RPCConnection: newRPCConnection(),

--- a/apiserver/pinger_test.go
+++ b/apiserver/pinger_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/juju/loggo"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
-	"github.com/juju/utils"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/api"
@@ -149,18 +148,11 @@ func waitForClock(c *gc.C, clock *testing.Clock) {
 }
 
 func checkConnectionDies(c *gc.C, conn api.Connection) {
-	attempt := utils.AttemptStrategy{
-		Total: coretesting.LongWait,
-		Delay: coretesting.ShortWait,
+	select {
+	case <-conn.Broken():
+	case <-time.After(coretesting.LongWait):
+		c.Fatal("connection didn't get shut down")
 	}
-	for a := attempt.Start(); a.Next(); {
-		err := pingConn(conn)
-		if err != nil {
-			c.Assert(err, gc.ErrorMatches, "connection is shut down", gc.Commentf("details: %s", errors.Details(err)))
-			return
-		}
-	}
-	c.Fatal("connection didn't get shut down")
 }
 
 func pingConn(conn api.Connection) error {


### PR DESCRIPTION
## Description of change
Address the issue about the number of security groups on AWS exceeds the limit.
Also extend the scan from 3 AWS regions to all regions currently being used in CI.

## QA steps
$ export JUJU_HOME=<path_to>/cloud-city
$ source ${JUJU_HOME}/cloud-city/ec2rc
$ python clean_resources.py -v default-aws

## Documentation changes
N/A

## Bug reference
http://juju-ci.vapour.ws/job/mediawiki-aws/1509/console

