### PR TITLE
Fixes lp#1694176: Controller admins should be able to upgrade hosted models.

### DIFF
--- a/apiserver/modelconfig/modelconfig.go
+++ b/apiserver/modelconfig/modelconfig.go
@@ -62,11 +62,26 @@ func (c *ModelConfigAPI) isControllerAdmin() error {
 	return nil
 }
 
+func (c *ModelConfigAPI) canReadModel() error {
+	isAdmin, err := c.auth.HasPermission(permission.SuperuserAccess, c.backend.ControllerTag())
+	if err != nil {
+		return errors.Trace(err)
+	}
+	canRead, err := c.auth.HasPermission(permission.ReadAccess, c.backend.ModelTag())
+	if err != nil {
+		return errors.Trace(err)
+	}
+	if !isAdmin && !canRead {
+		return common.ErrPerm
+	}
+	return nil
+}
+
 // ModelGet implements the server-side part of the
 // model-config CLI command.
 func (c *ModelConfigAPI) ModelGet() (params.ModelConfigResults, error) {
 	result := params.ModelConfigResults{}
-	if err := c.checkCanWrite(); err != nil {
+	if err := c.canReadModel(); err != nil {
 		return result, errors.Trace(err)
 	}
 

--- a/apiserver/modelconfig/modelconfig_test.go
+++ b/apiserver/modelconfig/modelconfig_test.go
@@ -153,6 +153,17 @@ func (s *modelconfigSuite) TestUserCanSetLogNoTrace(c *gc.C) {
 	c.Assert(result.Config["logging-config"].Value, gc.Equals, "<root>=DEBUG;somepackage=ERROR")
 }
 
+func (s *modelconfigSuite) TestUserReadAccess(c *gc.C) {
+	apiUser := names.NewUserTag("read")
+	s.authorizer.Tag = apiUser
+
+	_, err := s.api.ModelGet()
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = s.api.ModelSet(params.ModelSet{})
+	c.Assert(errors.Cause(err), gc.ErrorMatches, "permission denied")
+}
+
 func (s *modelconfigSuite) TestUserCannotSetLogTrace(c *gc.C) {
 	args := params.ModelSet{
 		map[string]interface{}{"logging-config": "<root>=DEBUG;somepackage=TRACE"},

--- a/apiserver/testing/fakeauthorizer.go
+++ b/apiserver/testing/fakeauthorizer.go
@@ -60,7 +60,7 @@ func (fa FakeAuthorizer) HasPermission(operation permission.Access, target names
 		if fa.AdminTag != emptyTag && ut == fa.AdminTag {
 			return true, nil
 		}
-		if operation == permission.WriteAccess && ut == fa.HasWriteTag {
+		if ut == fa.HasWriteTag && (operation == permission.WriteAccess || operation == permission.ReadAccess) {
 			return true, nil
 		}
 

--- a/featuretests/cmd_juju_upgrade_test.go
+++ b/featuretests/cmd_juju_upgrade_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/juju/cmd/cmdtesting"
 	"github.com/juju/loggo"
 	jc "github.com/juju/testing/checkers"
+	"github.com/juju/utils/series"
 	"github.com/juju/version"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/names.v2"
@@ -37,10 +38,11 @@ func (s *cmdUpgradeSuite) SetUpTest(c *gc.C) {
 
 	s.JujuConnSuite.SetUpTest(c)
 
-	s.AddToolsToState(c, version.MustParseBinary(fmt.Sprintf("%v-precise-amd64", newVersion)))
-	s.AddToolsToState(c, version.MustParseBinary(fmt.Sprintf("%v-trusty-amd64", newVersion)))
-	s.AddToolsToState(c, version.MustParseBinary(fmt.Sprintf("%v-xenial-amd64", newVersion)))
-	s.AddToolsToState(c, version.MustParseBinary(fmt.Sprintf("%v-yakkety-amd64", newVersion)))
+	supported := series.SupportedLts()
+	supported = append(supported, series.MustHostSeries())
+	for _, aSeries := range supported {
+		s.AddToolsToState(c, version.MustParseBinary(fmt.Sprintf("%v-%v-amd64", newVersion, aSeries)))
+	}
 
 	s.hostedModelUser = "otheruser"
 	s.hostedModelUserTag = names.NewUserTag(s.hostedModelUser)

--- a/featuretests/cmd_juju_upgrade_test.go
+++ b/featuretests/cmd_juju_upgrade_test.go
@@ -1,0 +1,106 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package featuretests
+
+import (
+	"fmt"
+
+	"github.com/juju/cmd"
+	"github.com/juju/cmd/cmdtesting"
+	"github.com/juju/loggo"
+	jc "github.com/juju/testing/checkers"
+	"github.com/juju/version"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/names.v2"
+
+	"github.com/juju/juju/cmd/juju/commands"
+	jujutesting "github.com/juju/juju/juju/testing"
+	"github.com/juju/juju/state"
+	"github.com/juju/juju/testing"
+	"github.com/juju/juju/testing/factory"
+	coreversion "github.com/juju/juju/version"
+)
+
+type cmdUpgradeSuite struct {
+	jujutesting.JujuConnSuite
+
+	hostedModelUser    string
+	hostedModelUserTag names.UserTag
+
+	hostedModel string
+}
+
+func (s *cmdUpgradeSuite) SetUpTest(c *gc.C) {
+	v, _ := version.Parse(oldVersion)
+	s.PatchValue(&coreversion.Current, v)
+
+	s.JujuConnSuite.SetUpTest(c)
+
+	s.AddToolsToState(c, version.MustParseBinary(fmt.Sprintf("%v-precise-amd64", newVersion)))
+	s.AddToolsToState(c, version.MustParseBinary(fmt.Sprintf("%v-trusty-amd64", newVersion)))
+	s.AddToolsToState(c, version.MustParseBinary(fmt.Sprintf("%v-xenial-amd64", newVersion)))
+	s.AddToolsToState(c, version.MustParseBinary(fmt.Sprintf("%v-yakkety-amd64", newVersion)))
+
+	s.hostedModelUser = "otheruser"
+	s.hostedModelUserTag = names.NewUserTag(s.hostedModelUser)
+
+	s.hostedModel = "othermodel"
+}
+
+func (s *cmdUpgradeSuite) TestControllerAdminCanUpgradeHostedModel(c *gc.C) {
+	testing.SkipIfWindowsBug(c, "lp:1446885")
+
+	s.Factory.MakeUser(c, &factory.UserParams{Name: s.hostedModelUser})
+
+	// Ensure we have hosted model.
+	ctx := s.run(c, "add-model", s.hostedModel, "--owner", s.hostedModelUser)
+	expectedModelAddedMsg := fmt.Sprintf("Added '%v' model on dummy/dummy-region for user '%v'", s.hostedModel, s.hostedModelUser)
+	c.Assert(cmdtesting.Stderr(ctx), jc.Contains, expectedModelAddedMsg)
+	s.assertHostModelAgentVersion(c, oldVersion)
+
+	// We are only testing here that controller admin can upgrade hosted model,
+	// so it does not matter that the model is empty.
+	// Upgrade hosted model.
+	v, _ := version.Parse(newVersion)
+	s.PatchValue(&coreversion.Current, v)
+	ctx = s.run(c, "upgrade-juju", "-m", fmt.Sprintf("%v/%v", s.hostedModelUser, s.hostedModel))
+	expectedUpgradeMsg := fmt.Sprintf("started upgrade to %v", newVersion)
+	c.Assert(cmdtesting.Stdout(ctx), jc.Contains, expectedUpgradeMsg)
+	s.assertHostModelAgentVersion(c, newVersion)
+}
+
+var (
+	oldVersion = "2.22.2"
+	newVersion = "2.22.3"
+)
+
+func (s *cmdUpgradeSuite) run(c *gc.C, args ...string) *cmd.Context {
+	context := cmdtesting.Context(c)
+	jujuCmd := commands.NewJujuCommand(context)
+	err := cmdtesting.InitCommand(jujuCmd, args)
+	c.Assert(err, jc.ErrorIsNil)
+	err = jujuCmd.Run(context)
+	loggo.RemoveWriter("warning")
+	c.Assert(err, jc.ErrorIsNil)
+	return context
+}
+
+func (s *cmdUpgradeSuite) assertHostModelAgentVersion(c *gc.C, desiredAgentVersion string) {
+	userModels, err := s.State.ModelsForUser(s.hostedModelUserTag)
+	c.Assert(err, jc.ErrorIsNil)
+
+	var desiredModel *state.UserModel
+	for _, m := range userModels {
+		if m.Name() == s.hostedModel {
+			desiredModel = m
+		}
+	}
+	c.Assert(desiredModel, gc.NotNil)
+
+	cfg, err := desiredModel.Config()
+	c.Assert(err, jc.ErrorIsNil)
+	currentVersion, exists := cfg.AgentVersion()
+	c.Assert(exists, jc.IsTrue)
+	c.Assert(currentVersion.String(), gc.Equals, desiredAgentVersion)
+}

--- a/featuretests/package_test.go
+++ b/featuretests/package_test.go
@@ -60,6 +60,7 @@ func init() {
 	if runtime.GOOS == "linux" {
 		gc.Suite(&cloudImageMetadataSuite{})
 		gc.Suite(&cmdSpaceSuite{})
+		gc.Suite(&cmdUpgradeSuite{})
 	}
 }
 


### PR DESCRIPTION
## Description of change

Controller admins were not able to upgrade hosted models, i.e. run "upgrade-juju -m user/model'.
This was not due to the permission on the actual upgrade on the model, but because controller admins were not able to read model details. 
As part of the investigation, it was discovered that only users with write access were able to read model details.
This PR addresses both issues and adds feature test to confirm that functionality works.

## QA steps

1. bootstrap with a previous version of juju that can be upgraded
2. create a user 
3. add model specifying this user as an owner
4. upgrade this model
Expected result - model upgraded.

## Documentation changes

It might be worthwhile noting that controller admins can and will upgrade hosted models.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1694176
