### PR TITLE
Clean AWS security groups on all regions

### DIFF
--- a/acceptancetests/clean_resources.py
+++ b/acceptancetests/clean_resources.py
@@ -27,28 +27,62 @@ def get_regions(args, env):
 
 def clean(args):
     env = SimpleEnvironment.from_config(args.env)
-    selected_regions = get_regions(args, env)
+    # To Do: Read regions from public-clouds.yaml
+    selected_regions = ['us-east-1', 'us-east-2', 'us-west-1', 'us-west-2',
+                        'ca-central-1',
+                        'eu-west-1', 'eu-west-2', 'eu-central-1',
+                        'ap-south-1', 'ap-southeast-1', 'ap-southeast-2',
+                        'ap-northeast-1', 'ap-northeast-2',
+                        'sa-east-1']
+    logging.info('The target regions for cleaning job are \n{}'
+                 .format('\n'.join(selected_regions)))
     for region in selected_regions:
         with AWSAccount.from_boot_config(env, region=region) as substrate:
-            logging.info('Cleaning resources in {}.'.format(substrate.region))
-            all_groups = dict(substrate.iter_security_groups())
-            instance_groups = dict(substrate.iter_instance_security_groups())
-            non_instance_groups = dict((k, v) for k, v in all_groups.items()
-                                       if k not in instance_groups)
-            try:
-                unclean = substrate.delete_detached_interfaces(
-                    non_instance_groups.keys())
-                logging.info('Unable to delete {} groups'.format(len(unclean)))
-            except:
-                logging.info('Unable to delete non-instance groups {}'.format(non_instance_groups.keys()))
-            for group_id in unclean:
-                logging.debug('Cannot delete {}'.format(all_groups[group_id]))
-            for group_id in unclean:
-                non_instance_groups.pop(group_id, None)
-            try:
-                substrate.destroy_security_groups(non_instance_groups.values())
-            except:
-                logging.debug('Failed to delete groups {}'.format(non_instance_groups.values()))
+            if substrate is not None:
+                logging.info('Cleaning resources in {}.'
+                             .format(substrate.region))
+                all_groups = dict(substrate.iter_security_groups())
+                instance_groups = dict(substrate.iter_instance_security_groups())
+                logging.info('{} items found from instance groups on {} \n{}'
+                             .format(str(len(instance_groups)),
+                                     region,
+                                     '\n'.join(instance_groups)))
+                non_instance_groups = dict((k, v) for k, v in all_groups.items()
+                                           if k not in instance_groups)
+                logging.info('{} items found from non-instance groups on {} \n{}'
+                             .format(str(len(non_instance_groups)),
+                                     region,
+                                     '\n'.join(non_instance_groups)))
+                try:
+                    logging.info('{} detached interfaces will be deleted from {} \n{}'
+                                 .format(str(len(non_instance_groups.keys())),
+                                         region,
+                                         '\n'.join(non_instance_groups.keys())))
+                    unclean = substrate.delete_detached_interfaces(
+                        non_instance_groups.keys())
+                    logging.info('Unable to delete {} groups from {}'
+                                 .format(str(len(unclean)), region))
+                except:
+                    logging.info('Unable to delete non-instance groups {} from {}'
+                                 .format(non_instance_groups.keys(), region))
+                for group_id in unclean:
+                    logging.debug('Cannot delete {}'
+                                  .format(all_groups[group_id]))
+                for group_id in unclean:
+                    non_instance_groups.pop(group_id, None)
+                try:
+                    substrate.destroy_security_groups(non_instance_groups.values())
+                    logging.info('{} security groups have been deleted on region {} \n{}'
+                                 .format(len(non_instance_groups.values()),
+                                         region,
+                                         '\n'.join(non_instance_groups.values())))
+                except:
+                    logging.debug('Failed to delete groups {} from {}'
+                                  .format(non_instance_groups.values(), region))
+            else:
+                logging.info('Skipping {}, substrate object returns NoneType'
+                             .format(region))
+
 
 def main():
     args = parse_args()

--- a/acceptancetests/clean_resources.py
+++ b/acceptancetests/clean_resources.py
@@ -10,7 +10,7 @@ from substrate import AWSAccount
 
 
 def parse_args(argv=None):
-    parser = ArgumentParser('Clean up leftover resources.')
+    parser = ArgumentParser('Clean up leftover security groups.')
     parser.add_argument('env', help='The juju environment to use.')
     parser.add_argument('--verbose', '-v', action='count', default=0)
     return parser.parse_args(argv)
@@ -29,8 +29,31 @@ def get_regions():
             selected_regions = data['clouds']['aws']['regions'].keys()
         return selected_regions
     except IOError as io_err:
-        print('Cloud list file {} does not exist.'.format(cloud_list))
+        logging.info('Cloud list file {} does not exist.'.format(cloud_list))
         raise io_err
+
+
+def get_security_groups(grp, instgrp, region):
+    """Fetch security groups information in a certain region from AWS:
+       ID of All security groups
+       Security groups attached to existing instances
+       Security groups does not attach to any instances
+       """
+    all_groups = dict(grp)
+    instance_groups = dict(instgrp)
+    logging.info(
+        '{} instance groups found on {} \n{}'.format(
+        str(len(instance_groups)),
+        region,
+        '\n'.join(instance_groups)))
+    non_instance_groups = dict(
+        (k, v) for k, v in all_groups.items() if k not in instance_groups)
+    logging.info(
+        '{} non-instance groups found on {} \n{}'.format(
+        str(len(non_instance_groups)),
+        region,
+        '\n'.join(non_instance_groups)))
+    return (all_groups, instance_groups, non_instance_groups)
 
 
 def clean(args):
@@ -41,58 +64,49 @@ def clean(args):
         '\n'.join(selected_regions)))
     for region in selected_regions:
         with AWSAccount.from_boot_config(env, region=region) as substrate:
-            if substrate is not None:
-                logging.info(
-                    'Cleaning resources in {}.'.format(substrate.region))
-                all_groups = dict(substrate.iter_security_groups())
-                instance_groups = dict(substrate.iter_instance_security_groups())
-                logging.info(
-                    '{} items found from instance groups on {} \n{}'.format(
-                    str(len(instance_groups)),
-                    region,
-                    '\n'.join(instance_groups)))
-                non_instance_groups = dict(
-                    (k, v) for k, v in all_groups.items() if k not in instance_groups)
-                logging.info(
-                    '{} items found from non-instance groups on {} \n{}'.format(
-                    str(len(non_instance_groups)),
-                    region,
-                    '\n'.join(non_instance_groups)))
-                try:
-                    logging.info(
-                        '{} detached interfaces will be deleted from {} \n{}'.format(
-                        str(len(non_instance_groups.keys())),
-                        region,
-                        '\n'.join(non_instance_groups.keys())))
-                    unclean = substrate.delete_detached_interfaces(
-                        non_instance_groups.keys())
-                    logging.info(
-                        'Unable to delete {} groups from {}'.format(
-                            str(len(unclean)), region))
-                except:
-                    logging.info(
-                        'Unable to delete non-instance groups {} from {}'.format(
-                        non_instance_groups.keys(), region))
-                for group_id in unclean:
-                    logging.debug(
-                        'Cannot delete {} from {}'.format(
-                        all_groups[group_id], region))
-                for group_id in unclean:
-                    non_instance_groups.pop(group_id, None)
-                try:
-                    substrate.destroy_security_groups(non_instance_groups.values())
-                    logging.info(
-                        '{} non-instance groups have been deleted from {} \n{}'.format(
-                        len(non_instance_groups.values()),
-                        region,
-                        '\n'.join(non_instance_groups.values())))
-                except:
-                    logging.debug(
-                        'Failed to delete groups {} from {}'.format(
-                        non_instance_groups.values(), region))
-            else:
+            if substrate is None:
                 logging.info(
                     'Skipping {}, substrate object returns NoneType'.format(region))
+                continue
+            logging.info(
+                'Cleaning resources in {}.'.format(substrate.region))
+            all_groups, instance_groups, non_instance_groups = get_security_groups(
+                grp=substrate.iter_security_groups(),
+                instgrp=substrate.iter_instance_security_groups(),
+                region=region)
+
+            try:
+                logging.info(
+                    '{} detached interfaces will be deleted from {} \n{}'.format(
+                    str(len(non_instance_groups.keys())),
+                    region,
+                    '\n'.join(non_instance_groups.keys())))
+                unclean = substrate.delete_detached_interfaces(
+                    non_instance_groups.keys())
+                logging.info(
+                    'Unable to delete {} groups from {}'.format(
+                        str(len(unclean)), region))
+            except:
+                logging.info(
+                    'Unable to delete non-instance groups {} from {}'.format(
+                    non_instance_groups.keys(), region))
+            for group_id in unclean:
+                logging.debug(
+                    'Cannot delete {} from {}'.format(
+                    all_groups[group_id], region))
+            for group_id in unclean:
+                non_instance_groups.pop(group_id, None)
+            try:
+                substrate.destroy_security_groups(non_instance_groups.values())
+                logging.info(
+                    '{} non-instance groups have been deleted from {} \n{}'.format(
+                    len(non_instance_groups.values()),
+                    region,
+                    '\n'.join(non_instance_groups.values())))
+            except:
+                logging.debug(
+                    'Failed to delete groups {} from {}'.format(
+                    non_instance_groups.values(), region))
 
 
 def main():


### PR DESCRIPTION
## Description of change
Address the issue about the number of security groups on AWS exceeds the limit.
Also extend the scan from 3 AWS regions to all regions currently being used in CI.

## QA steps
$ export JUJU_HOME=<path_to>/cloud-city
$ source ${JUJU_HOME}/ec2rc
$ python clean_resources.py -v default-aws

## Documentation changes
N/A

## Bug reference
http://juju-ci.vapour.ws/job/mediawiki-aws/1509/console
