### PR TITLE
Fix misleading README install instructions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,24 @@ stable PPA, `https://launchpad.net/~juju/+archive/stable`, and can be installed 
     sudo apt-add-repository ppa:juju/stable
     sudo apt-get update
     sudo apt-get install juju
+    
+Installing Go
+--------------
+
+`Juju's` source code currently depends on Go 1.8. One of the easiest ways
+to install golang is from a snap. You may need to first install
+the [snap client](https://snapcraft.io/docs/core/install). Installing the golang
+snap package is then as easy as
+
+    snap install go --classic
+
+You can read about the "classic" confinement policy [here](https://insights.ubuntu.com/2017/01/09/how-to-snap-introducing-classic-confinement/)
+
+If you want to use `apt`, then you can add the [juju-golang PPA](https://launchpad.net/~juju/+archive/ubuntu/golang) and then run the following
+
+    sudo apt install golang-1.8
+
+Alternatively, you can always follow the official [binary installation instructions](https://golang.org/doc/install#install)
 
 Setting GOPATH
 --------------

--- a/acceptancetests/run-unit-tests
+++ b/acceptancetests/run-unit-tests
@@ -189,6 +189,7 @@ if [[ "$USE_PPA" != "" ]]; then
 fi
 if [[ "$INSTALL_DEPS" == "" ]]; then
     echo "Installing default deps."
+    make install-go
     make install-dependencies
 else
     echo "Installing deps from command line."


### PR DESCRIPTION
## Description of change

Fixes the referenced bug. 

- The README did not mention what version of `Go` is required to build the source
- The top-level Makefile installed `Go` as a dependency but `Go` may already be installed by other means leading to confusing situations when coupled with the issue above

## QA steps

Follow the README instructions. They should work the same with the installation of `Go` happening as an explicit step.

## Documentation changes

N/A

## Bug reference

https://bugs.launchpad.net/juju/+bug/1662857
