### PR TITLE
dependencies.tsv: update gopkg.in/retry.v1

### DIFF
--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -103,6 +103,6 @@ gopkg.in/macaroon.v1	git	ab3940c6c16510a850e1c2dd628b919f0f3f1464	2015-01-21T11:
 gopkg.in/mgo.v2	git	f2b6f6c918c452ad107eec89615f074e3bd80e33	2016-08-18T01:52:18Z
 gopkg.in/natefinch/lumberjack.v2	git	514cbda263a734ae8caac038dadf05f8f3f9f738	2016-01-25T11:17:49Z
 gopkg.in/natefinch/npipe.v2	git	c1b8fa8bdccecb0b8db834ee0b92fdbcfa606dd6	2016-06-21T03:49:01Z
-gopkg.in/retry.v1	git	c09f6b86ba4d5d2cf5bdf0665364aec9fd4815db	2016-10-25T18:14:30Z
+gopkg.in/retry.v1	git	01631078ef2fdce601e38cfe5f527fab24c9a6d2	2017-05-31T09:12:38Z
 gopkg.in/tomb.v1	git	dd632973f1e7218eb1089048e0798ec9ae7dceb8	2014-10-24T13:56:13Z
 gopkg.in/yaml.v2	git	a3f3340b5840cee44f372bddb5880fcbc419b46a	2017-02-08T14:18:51Z


### PR DESCRIPTION
## Description of change

This brings in the fix in https://github.com/go-retry/retry/pull/1. This should address http://qa.jujucharms.com/releases/5319/job/run-unit-tests-win2012-amd64/attempt/3809.

## QA steps

I temporarily changed TestDialAPIMultipleError to pass in a `fakeClock`, which will advance the time exactly the amount requested. Since the sleep amount is 0, the time will not advance, and so the retry would previously loop forever. With the updated dependency, it works as expected.

The test would previously fail with the system clock because if the time doesn't advance at all (which is more likely with a low resolution system clock), an additional dial attempt would be made.

## Documentation changes

None.

## Bug reference

None.