### PR TITLE
Compress logs during rotation

### DIFF
--- a/acceptancetests/assess_log_rotation.py
+++ b/acceptancetests/assess_log_rotation.py
@@ -148,7 +148,7 @@ def check_expected_backup(key, logprefix, action_output):
         raise LogRotateError(
             "Missing backup log '{}' after rotation.".format(key))
 
-    backup_pattern = "/var/log/juju/%s-(.+?)\.log" % logprefix
+    backup_pattern = "/var/log/juju/%s-(.+?)\.log.gz" % logprefix
 
     log_name = log["name"]
     matches = re.match(backup_pattern, log_name)
@@ -158,9 +158,9 @@ def check_expected_backup(key, logprefix, action_output):
             (log_name, backup_pattern))
 
     size = int(log["size"])
-    if size < 299 or size > 301:
+    if size > 30:
         raise LogRotateError(
-            "Backup log '%s' should be ~300MB, but is %sMB." %
+            "Backup log '%s' should be less than 30MB (as gzipped), but is %sMB." %
             (log_name, size))
 
     dt = matches.groups()[0]

--- a/acceptancetests/repository/charms/fill-logs/actions/actions.go
+++ b/acceptancetests/repository/charms/fill-logs/actions/actions.go
@@ -40,11 +40,11 @@ func fillUnit() error {
 }
 
 func unitLogSizes() error {
-	return writeSizes("/var/log/juju/unit-fill-logs*.log")
+	return writeSizes("/var/log/juju/unit-fill-logs*.log*")
 }
 
 func machineLogSizes() error {
-	return writeSizes("/var/log/juju/machine-*.log")
+	return writeSizes("/var/log/juju/machine-*.log*")
 }
 
 func fillMachine() (err error) {

--- a/apiserver/logsink.go
+++ b/apiserver/logsink.go
@@ -133,6 +133,7 @@ func newLogSinkWriter(logPath string) (io.WriteCloser, error) {
 		Filename:   logPath,
 		MaxSize:    300, // MB
 		MaxBackups: 2,
+		Compress:   true,
 	}, nil
 }
 

--- a/audit/auditlogfile.go
+++ b/audit/auditlogfile.go
@@ -34,6 +34,7 @@ func NewLogFileSink(logDir string) AuditEntrySinkFn {
 			Filename:   logPath,
 			MaxSize:    300, // MB
 			MaxBackups: 10,
+			Compress:   true,
 		},
 	}
 	return handler.handle

--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -226,6 +226,7 @@ func (a *machineAgentCmd) Init(args []string) error {
 		Filename:   agent.LogFilename(a.currentConfig.CurrentConfig()),
 		MaxSize:    300, // megabytes
 		MaxBackups: 2,
+		Compress:   true,
 	}
 
 	return nil

--- a/cmd/jujud/agent/unit.go
+++ b/cmd/jujud/agent/unit.go
@@ -118,6 +118,7 @@ func (a *UnitAgent) Init(args []string) error {
 			Filename:   agent.LogFilename(agentConfig),
 			MaxSize:    300, // megabytes
 			MaxBackups: 2,
+			Compress:   true,
 		}
 
 	}

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -101,7 +101,7 @@ gopkg.in/juju/worker.v1	git	6965b9d826717287bb002e02d1fd4d079978083e	2017-03-08T
 gopkg.in/macaroon-bakery.v1	git	469b44e6f1f9479e115c8ae879ef80695be624d5	2016-06-22T12:14:21Z
 gopkg.in/macaroon.v1	git	ab3940c6c16510a850e1c2dd628b919f0f3f1464	2015-01-21T11:42:31Z
 gopkg.in/mgo.v2	git	f2b6f6c918c452ad107eec89615f074e3bd80e33	2016-08-18T01:52:18Z
-gopkg.in/natefinch/lumberjack.v2	git	514cbda263a734ae8caac038dadf05f8f3f9f738	2016-01-25T11:17:49Z
+gopkg.in/natefinch/lumberjack.v2	git	df99d62fd42d8b3752c8a42c6723555372c02a03	2017-05-31T18:08:50Z
 gopkg.in/natefinch/npipe.v2	git	c1b8fa8bdccecb0b8db834ee0b92fdbcfa606dd6	2016-06-21T03:49:01Z
 gopkg.in/retry.v1	git	c09f6b86ba4d5d2cf5bdf0665364aec9fd4815db	2016-10-25T18:14:30Z
 gopkg.in/tomb.v1	git	dd632973f1e7218eb1089048e0798ec9ae7dceb8	2014-10-24T13:56:13Z


### PR DESCRIPTION
## Description of change

Rotated logs take up a significant amount of disk space, and compressing the logs has been long asked for. Yesterday lumberjack acquired a fix that adds a Compress flag to the configuration struct.

This branch sets that flag, updates the dependency for lumberjack, and fixes the CI tests for log rotation.

## QA steps

Manually, I bootstrapped a lxd provider, deployed the fill-logs charm from the CI tests, and ran the fill-logs-units action, and observed compressed logs. I also deployed an older Juju, made sure there were already rotated logs that were uncompressed, then upgraded juju, then forced another rotate, and observed that all existing logs were also compressed.

## Documentation changes

I'm not sure it is documentation worthy.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1494661