### PR TITLE
Set assess_user_grant_revoke logging to be args provided.

### DIFF
--- a/acceptancetests/assess_user_grant_revoke.py
+++ b/acceptancetests/assess_user_grant_revoke.py
@@ -381,7 +381,7 @@ def parse_args(argv):
 
 def main(argv=None):
     args = parse_args(argv)
-    configure_logging(logging.DEBUG)
+    configure_logging(args.verbose)
     bs_manager = BootstrapManager.from_args(args)
     with bs_manager.booted_context(args.upload_tools):
         assess_user_grant_revoke(bs_manager.client)


### PR DESCRIPTION
## Please provide the following details to expedite Pull Request review:

----

## Description of change

Why is this change needed?
The test was defaulting to DEBUG level logging which was filling the logs with noise.