### PR TITLE
Don't infer spaces from host machines if UseLocalBridge is specified

### DIFF
--- a/network/containerizer/bridgepolicy.go
+++ b/network/containerizer/bridgepolicy.go
@@ -61,10 +61,15 @@ var _ Container = (*state.Machine)(nil)
 // inferContainerSpaces tries to find a valid space for the container to be
 // on. This should only be used when the container itself doesn't have any
 // valid constraints on what spaces it should be in.
+// If UseLocalBridges is set we fall back to "" and use lxdbr0 as we probably
+// won't be able to get an IP on hosts space.
 // If this machine is in a single space, then that space is used. Else, if
 // the machine has the default space, then that space is used.
 // If neither of those conditions is true, then we return an error.
 func (p *BridgePolicy) inferContainerSpaces(m Machine, containerId, defaultSpaceName string) (set.Strings, error) {
+	if p.UseLocalBridges {
+		return set.NewStrings(""), nil
+	}
 	hostSpaces, err := m.AllSpaces()
 	if err != nil {
 		return nil, errors.Trace(err)


### PR DESCRIPTION
## Description of change
If UseLocalBridges is set and no explicit space for container is set don't infer spaces from host machine but use local bridge (lxdbr0) instead

## QA steps
Add a machine on AWS with --constraints spaces="foo". Add a container on this machine. Verify that the container is bound to local lxdbr0 and not external NIC

## Documentation changes
None.

## Bug reference
https://bugs.launchpad.net/juju/+bug/1685782