### PR TITLE
2.2 short vs full model name lp1693581

### DIFF
--- a/cmd/juju/common/model.go
+++ b/cmd/juju/common/model.go
@@ -4,7 +4,6 @@
 package common
 
 import (
-	"fmt"
 	"reflect"
 	"time"
 
@@ -12,12 +11,17 @@ import (
 	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/jujuclient"
 	"github.com/juju/juju/status"
 )
 
 // ModelInfo contains information about a model.
 type ModelInfo struct {
-	Name           string                      `json:"name" yaml:"name"`
+	// Name is a fully qualified model name, i.e. having the format $owner/$model.
+	Name string `json:"name" yaml:"name"`
+
+	// ShortName is un-qualified model name.
+	ShortName      string                      `json:"short-name" yaml:"short-name"`
 	UUID           string                      `json:"model-uuid" yaml:"model-uuid"`
 	ControllerUUID string                      `json:"controller-uuid" yaml:"controller-uuid"`
 	ControllerName string                      `json:"controller-name" yaml:"controller-name"`
@@ -70,7 +74,7 @@ func friendlyDuration(when *time.Time, now time.Time) string {
 
 // ModelInfoFromParams translates a params.ModelInfo to ModelInfo.
 func ModelInfoFromParams(info params.ModelInfo, now time.Time) (ModelInfo, error) {
-	tag, err := names.ParseUserTag(info.OwnerTag)
+	ownerTag, err := names.ParseUserTag(info.OwnerTag)
 	if err != nil {
 		return ModelInfo{}, errors.Trace(err)
 	}
@@ -79,10 +83,11 @@ func ModelInfoFromParams(info params.ModelInfo, now time.Time) (ModelInfo, error
 		return ModelInfo{}, errors.Trace(err)
 	}
 	modelInfo := ModelInfo{
-		Name:           info.Name,
+		ShortName:      info.Name,
+		Name:           jujuclient.JoinOwnerModelName(ownerTag, info.Name),
 		UUID:           info.UUID,
 		ControllerUUID: info.ControllerUUID,
-		Owner:          tag.Id(),
+		Owner:          ownerTag.Id(),
 		Life:           string(info.Life),
 		Cloud:          cloudTag.Id(),
 		CloudRegion:    info.CloudRegion,
@@ -182,6 +187,5 @@ func OwnerQualifiedModelName(modelName string, owner, user names.UserTag) string
 	if owner.Id() == user.Id() {
 		return modelName
 	}
-	ownerName := owner.Id()
-	return fmt.Sprintf("%s/%s", ownerName, modelName)
+	return jujuclient.JoinOwnerModelName(owner, modelName)
 }

--- a/cmd/juju/controller/listmodels.go
+++ b/cmd/juju/controller/listmodels.go
@@ -264,10 +264,10 @@ func (c *modelsCommand) formatTabular(writer io.Writer, value interface{}) error
 	// the model display names.
 	loggedInUser := names.NewUserTag(c.loggedInUser)
 	userForLastConn := loggedInUser
-	var userForListing names.UserTag
+	var currentUser names.UserTag
 	if c.user != "" {
-		userForListing = names.NewUserTag(c.user)
-		userForLastConn = userForListing
+		currentUser = names.NewUserTag(c.user)
+		userForLastConn = currentUser
 	}
 
 	tw := output.TabWriter(writer)
@@ -303,8 +303,12 @@ func (c *modelsCommand) formatTabular(writer io.Writer, value interface{}) error
 	for _, model := range modelSet.Models {
 		cloudRegion := strings.Trim(model.Cloud+"/"+model.CloudRegion, "/")
 		owner := names.NewUserTag(model.Owner)
-		name := common.OwnerQualifiedModelName(model.Name, owner, userForListing)
-		if jujuclient.JoinOwnerModelName(owner, model.Name) == modelSet.CurrentModelQualified {
+		name := model.Name
+		if currentUser == owner {
+			// No need to display fully qualified model name to its owner.
+			name = model.ShortName
+		}
+		if model.Name == modelSet.CurrentModelQualified {
 			name += "*"
 			w.PrintColor(output.CurrentHighlight, name)
 		} else {

--- a/cmd/juju/controller/listmodels_test.go
+++ b/cmd/juju/controller/listmodels_test.go
@@ -174,6 +174,65 @@ func (s *ModelsSuite) TestModelsOwner(c *gc.C) {
 		"\n")
 }
 
+func (s *ModelsSuite) TestModelsYaml(c *gc.C) {
+	context, err := cmdtesting.RunCommand(c, s.newCommand(), "--format", "yaml")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(s.api.user, gc.Equals, "admin")
+	c.Assert(cmdtesting.Stdout(context), gc.Equals, `
+models:
+- name: admin/test-model1
+  short-name: test-model1
+  model-uuid: test-model1-UUID
+  controller-uuid: ""
+  controller-name: fake
+  owner: admin
+  cloud: dummy
+  life: ""
+  status:
+    current: active
+  users:
+    admin:
+      access: read
+      last-connection: 2015-03-20
+  agent-version: 2.55.5
+- name: carlotta/test-model2
+  short-name: test-model2
+  model-uuid: test-model2-UUID
+  controller-uuid: ""
+  controller-name: fake
+  owner: carlotta
+  cloud: dummy
+  life: ""
+  status:
+    current: active
+  users:
+    admin:
+      access: write
+      last-connection: 2015-03-01
+  agent-version: 2.55.5
+- name: daiwik@external/test-model3
+  short-name: test-model3
+  model-uuid: test-model3-UUID
+  controller-uuid: ""
+  controller-name: fake
+  owner: daiwik@external
+  cloud: dummy
+  life: ""
+  status:
+    current: destroying
+  agent-version: 2.55.5
+current-model: test-model1
+`[1:])
+}
+
+func (s *ModelsSuite) TestModelsJson(c *gc.C) {
+	context, err := cmdtesting.RunCommand(c, s.newCommand(), "--format", "json")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(s.api.user, gc.Equals, "admin")
+	c.Assert(cmdtesting.Stdout(context), gc.Equals, `{"models":[{"name":"admin/test-model1","short-name":"test-model1","model-uuid":"test-model1-UUID","controller-uuid":"","controller-name":"fake","owner":"admin","cloud":"dummy","life":"","status":{"current":"active"},"users":{"admin":{"access":"read","last-connection":"2015-03-20"}},"agent-version":"2.55.5"},{"name":"carlotta/test-model2","short-name":"test-model2","model-uuid":"test-model2-UUID","controller-uuid":"","controller-name":"fake","owner":"carlotta","cloud":"dummy","life":"","status":{"current":"active"},"users":{"admin":{"access":"write","last-connection":"2015-03-01"}},"agent-version":"2.55.5"},{"name":"daiwik@external/test-model3","short-name":"test-model3","model-uuid":"test-model3-UUID","controller-uuid":"","controller-name":"fake","owner":"daiwik@external","cloud":"dummy","life":"","status":{"current":"destroying"},"agent-version":"2.55.5"}],"current-model":"test-model1"}
+`)
+}
+
 func (s *ModelsSuite) TestModelsNonOwner(c *gc.C) {
 	context, err := cmdtesting.RunCommand(c, s.newCommand(), "--user", "bob")
 	c.Assert(err, jc.ErrorIsNil)

--- a/cmd/juju/model/show.go
+++ b/cmd/juju/model/show.go
@@ -144,12 +144,7 @@ func (c *showModelCommand) apiModelInfoToModelInfoMap(modelInfo []params.ModelIn
 			return nil, errors.Trace(err)
 		}
 		out.ControllerName = controllerName
-		// TODO (anastasiamac 2017-06-01) Since we have changed model.Name
-		// to be a quantified model name, i.e. $owner/$name, I wonder
-		// if we should now key on model.ShortName to preserve previous
-		// behavior. We need to revisit this area anyway when re-working owner
-		// concept in the models.
-		output[out.Name] = out
+		output[out.ShortName] = out
 	}
 	return output, nil
 }

--- a/cmd/juju/model/show.go
+++ b/cmd/juju/model/show.go
@@ -144,6 +144,11 @@ func (c *showModelCommand) apiModelInfoToModelInfoMap(modelInfo []params.ModelIn
 			return nil, errors.Trace(err)
 		}
 		out.ControllerName = controllerName
+		// TODO (anastasiamac 2017-06-01) Since we have changed model.Name
+		// to be a quantified model name, i.e. $owner/$name, I wonder
+		// if we should now key on model.ShortName to preserve previous
+		// behavior. We need to revisit this area anyway when re-working owner
+		// concept in the models.
 		output[out.Name] = out
 	}
 	return output, nil

--- a/cmd/juju/model/show_test.go
+++ b/cmd/juju/model/show_test.go
@@ -74,7 +74,7 @@ func (s *ShowCommandSuite) SetUpTest(c *gc.C) {
 	}
 
 	s.expectedOutput = attrs{
-		"admin/mymodel": attrs{
+		"mymodel": attrs{
 			"name":            "admin/mymodel",
 			"short-name":      "mymodel",
 			"model-uuid":      "deadbeef-0bad-400d-8000-4b1d0d06f00d",
@@ -161,7 +161,7 @@ func (s *ShowCommandSuite) TestShowBasicIncompleteModelsYaml(c *gc.C) {
 		params.ModelInfoResult{Result: createBasicModelInfo()},
 	}
 	s.expectedDisplay = `
-owner/basic-model:
+basic-model:
   name: owner/basic-model
   short-name: basic-model
   model-uuid: deadbeef-0bad-400d-8000-4b1d0d06f00d
@@ -179,7 +179,7 @@ func (s *ShowCommandSuite) TestShowBasicIncompleteModelsJson(c *gc.C) {
 	s.fake.infos = []params.ModelInfoResult{
 		params.ModelInfoResult{Result: createBasicModelInfo()},
 	}
-	s.expectedDisplay = "{\"owner/basic-model\":" +
+	s.expectedDisplay = "{\"basic-model\":" +
 		"{\"name\":\"owner/basic-model\"," +
 		"\"short-name\":\"basic-model\"," +
 		"\"model-uuid\":\"deadbeef-0bad-400d-8000-4b1d0d06f00d\"," +
@@ -197,7 +197,7 @@ func (s *ShowCommandSuite) TestShowBasicWithStatusIncompleteModelsYaml(c *gc.C) 
 		params.ModelInfoResult{Result: createBasicModelInfoWithStatus()},
 	}
 	s.expectedDisplay = `
-owner/basic-model:
+basic-model:
   name: owner/basic-model
   short-name: basic-model
   model-uuid: deadbeef-0bad-400d-8000-4b1d0d06f00d
@@ -217,7 +217,7 @@ func (s *ShowCommandSuite) TestShowBasicWithStatusIncompleteModelsJson(c *gc.C) 
 	s.fake.infos = []params.ModelInfoResult{
 		params.ModelInfoResult{Result: createBasicModelInfoWithStatus()},
 	}
-	s.expectedDisplay = "{\"owner/basic-model\":" +
+	s.expectedDisplay = "{\"basic-model\":" +
 		"{\"name\":\"owner/basic-model\"," +
 		"\"short-name\":\"basic-model\"," +
 		"\"model-uuid\":\"deadbeef-0bad-400d-8000-4b1d0d06f00d\"," +
@@ -239,7 +239,7 @@ func (s *ShowCommandSuite) TestShowBasicWithMigrationIncompleteModelsYaml(c *gc.
 		params.ModelInfoResult{Result: basicAndMigrationStatusInfo},
 	}
 	s.expectedDisplay = `
-owner/basic-model:
+basic-model:
   name: owner/basic-model
   short-name: basic-model
   model-uuid: deadbeef-0bad-400d-8000-4b1d0d06f00d
@@ -262,7 +262,7 @@ func (s *ShowCommandSuite) TestShowBasicWithMigrationIncompleteModelsJson(c *gc.
 	s.fake.infos = []params.ModelInfoResult{
 		params.ModelInfoResult{Result: basicAndMigrationStatusInfo},
 	}
-	s.expectedDisplay = "{\"owner/basic-model\":" +
+	s.expectedDisplay = "{\"basic-model\":" +
 		"{\"name\":\"owner/basic-model\"," +
 		"\"short-name\":\"basic-model\"," +
 		"\"model-uuid\":\"deadbeef-0bad-400d-8000-4b1d0d06f00d\"," +
@@ -283,7 +283,7 @@ func (s *ShowCommandSuite) TestShowBasicWithStatusAndMigrationIncompleteModelsYa
 		params.ModelInfoResult{Result: basicAndStatusAndMigrationInfo},
 	}
 	s.expectedDisplay = `
-owner/basic-model:
+basic-model:
   name: owner/basic-model
   short-name: basic-model
   model-uuid: deadbeef-0bad-400d-8000-4b1d0d06f00d
@@ -307,7 +307,7 @@ func (s *ShowCommandSuite) TestShowBasicWithStatusAndMigrationIncompleteModelsJs
 	s.fake.infos = []params.ModelInfoResult{
 		params.ModelInfoResult{Result: basicAndStatusAndMigrationInfo},
 	}
-	s.expectedDisplay = "{\"owner/basic-model\":" +
+	s.expectedDisplay = "{\"basic-model\":" +
 		"{\"name\":\"owner/basic-model\"," +
 		"\"short-name\":\"basic-model\"," +
 		"\"model-uuid\":\"deadbeef-0bad-400d-8000-4b1d0d06f00d\"," +
@@ -329,7 +329,7 @@ func (s *ShowCommandSuite) TestShowBasicWithProviderIncompleteModelsYaml(c *gc.C
 		params.ModelInfoResult{Result: basicAndProviderTypeInfo},
 	}
 	s.expectedDisplay = `
-owner/basic-model:
+basic-model:
   name: owner/basic-model
   short-name: basic-model
   model-uuid: deadbeef-0bad-400d-8000-4b1d0d06f00d
@@ -350,7 +350,7 @@ func (s *ShowCommandSuite) TestShowBasicWithProviderIncompleteModelsJson(c *gc.C
 	s.fake.infos = []params.ModelInfoResult{
 		params.ModelInfoResult{Result: basicAndProviderTypeInfo},
 	}
-	s.expectedDisplay = "{\"owner/basic-model\":" +
+	s.expectedDisplay = "{\"basic-model\":" +
 		"{\"name\":\"owner/basic-model\"," +
 		"\"short-name\":\"basic-model\"," +
 		"\"model-uuid\":\"deadbeef-0bad-400d-8000-4b1d0d06f00d\"," +
@@ -373,7 +373,7 @@ func (s *ShowCommandSuite) TestShowBasicWithUsersIncompleteModelsYaml(c *gc.C) {
 		params.ModelInfoResult{Result: basicAndUsersInfo},
 	}
 	s.expectedDisplay = `
-owner/basic-model:
+basic-model:
   name: owner/basic-model
   short-name: basic-model
   model-uuid: deadbeef-0bad-400d-8000-4b1d0d06f00d
@@ -401,7 +401,7 @@ func (s *ShowCommandSuite) TestShowBasicWithUsersIncompleteModelsJson(c *gc.C) {
 	s.fake.infos = []params.ModelInfoResult{
 		params.ModelInfoResult{Result: basicAndUsersInfo},
 	}
-	s.expectedDisplay = "{\"owner/basic-model\":" +
+	s.expectedDisplay = "{\"basic-model\":" +
 		"{\"name\":\"owner/basic-model\"," +
 		"\"short-name\":\"basic-model\"," +
 		"\"model-uuid\":\"deadbeef-0bad-400d-8000-4b1d0d06f00d\"," +
@@ -425,7 +425,7 @@ func (s *ShowCommandSuite) TestShowBasicWithMachinesIncompleteModelsYaml(c *gc.C
 		params.ModelInfoResult{Result: basicAndMachinesInfo},
 	}
 	s.expectedDisplay = `
-owner/basic-model:
+basic-model:
   name: owner/basic-model
   short-name: basic-model
   model-uuid: deadbeef-0bad-400d-8000-4b1d0d06f00d
@@ -453,7 +453,7 @@ func (s *ShowCommandSuite) TestShowBasicWithMachinesIncompleteModelsJson(c *gc.C
 	s.fake.infos = []params.ModelInfoResult{
 		params.ModelInfoResult{Result: basicAndMachinesInfo},
 	}
-	s.expectedDisplay = "{\"owner/basic-model\":" +
+	s.expectedDisplay = "{\"basic-model\":" +
 		"{\"name\":\"owner/basic-model\"," +
 		"\"short-name\":\"basic-model\"," +
 		"\"model-uuid\":\"deadbeef-0bad-400d-8000-4b1d0d06f00d\"," +
@@ -477,7 +477,7 @@ func (s *ShowCommandSuite) TestShowBasicWithSLAIncompleteModelsYaml(c *gc.C) {
 		params.ModelInfoResult{Result: basicAndSLAInfo},
 	}
 	s.expectedDisplay = `
-owner/basic-model:
+basic-model:
   name: owner/basic-model
   short-name: basic-model
   model-uuid: deadbeef-0bad-400d-8000-4b1d0d06f00d
@@ -502,7 +502,7 @@ func (s *ShowCommandSuite) TestShowBasicWithSLAIncompleteModelsJson(c *gc.C) {
 	s.fake.infos = []params.ModelInfoResult{
 		params.ModelInfoResult{Result: basicAndSLAInfo},
 	}
-	s.expectedDisplay = "{\"owner/basic-model\":" +
+	s.expectedDisplay = "{\"basic-model\":" +
 		"{\"name\":\"owner/basic-model\"," +
 		"\"short-name\":\"basic-model\"," +
 		"\"model-uuid\":\"deadbeef-0bad-400d-8000-4b1d0d06f00d\"," +
@@ -518,7 +518,7 @@ func (s *ShowCommandSuite) TestShowBasicWithSLAIncompleteModelsJson(c *gc.C) {
 }
 
 func (s *ShowCommandSuite) TestShowModelWithAgentVersionInJson(c *gc.C) {
-	s.expectedDisplay = "{\"owner/basic-model\":" +
+	s.expectedDisplay = "{\"basic-model\":" +
 		"{\"name\":\"owner/basic-model\"," +
 		"\"short-name\":\"basic-model\"," +
 		"\"model-uuid\":\"deadbeef-0bad-400d-8000-4b1d0d06f00d\"," +
@@ -534,7 +534,7 @@ func (s *ShowCommandSuite) TestShowModelWithAgentVersionInJson(c *gc.C) {
 
 func (s *ShowCommandSuite) TestShowModelWithAgentVersionInYaml(c *gc.C) {
 	s.expectedDisplay = `
-owner/basic-model:
+basic-model:
   name: owner/basic-model
   short-name: basic-model
   model-uuid: deadbeef-0bad-400d-8000-4b1d0d06f00d
@@ -611,7 +611,7 @@ func (s *showSLACommandSuite) SetUpTest(c *gc.C) {
 		Level: "next",
 		Owner: "user",
 	}
-	slaOutput := s.expectedOutput["admin/mymodel"].(attrs)
+	slaOutput := s.expectedOutput["mymodel"].(attrs)
 	slaOutput["sla"] = "next"
 	slaOutput["sla-owner"] = "user"
 }

--- a/cmd/juju/model/show_test.go
+++ b/cmd/juju/model/show_test.go
@@ -74,8 +74,9 @@ func (s *ShowCommandSuite) SetUpTest(c *gc.C) {
 	}
 
 	s.expectedOutput = attrs{
-		"mymodel": attrs{
-			"name":            "mymodel",
+		"admin/mymodel": attrs{
+			"name":            "admin/mymodel",
+			"short-name":      "mymodel",
 			"model-uuid":      "deadbeef-0bad-400d-8000-4b1d0d06f00d",
 			"controller-uuid": "1ca2293b-fdb9-4299-97d6-55583bb39364",
 			"controller-name": "testing",
@@ -160,8 +161,9 @@ func (s *ShowCommandSuite) TestShowBasicIncompleteModelsYaml(c *gc.C) {
 		params.ModelInfoResult{Result: createBasicModelInfo()},
 	}
 	s.expectedDisplay = `
-basic-model:
-  name: basic-model
+owner/basic-model:
+  name: owner/basic-model
+  short-name: basic-model
   model-uuid: deadbeef-0bad-400d-8000-4b1d0d06f00d
   controller-uuid: deadbeef-1bad-500d-9000-4b1d0d06f00d
   controller-name: testing
@@ -177,11 +179,15 @@ func (s *ShowCommandSuite) TestShowBasicIncompleteModelsJson(c *gc.C) {
 	s.fake.infos = []params.ModelInfoResult{
 		params.ModelInfoResult{Result: createBasicModelInfo()},
 	}
-	s.expectedDisplay = "{\"basic-model\":{\"name\":\"basic-model\"," +
+	s.expectedDisplay = "{\"owner/basic-model\":" +
+		"{\"name\":\"owner/basic-model\"," +
+		"\"short-name\":\"basic-model\"," +
 		"\"model-uuid\":\"deadbeef-0bad-400d-8000-4b1d0d06f00d\"," +
 		"\"controller-uuid\":\"deadbeef-1bad-500d-9000-4b1d0d06f00d\"," +
-		"\"controller-name\":\"testing\",\"owner\":\"owner\"," +
-		"\"cloud\":\"altostratus\",\"region\":\"mid-level\"," +
+		"\"controller-name\":\"testing\"," +
+		"\"owner\":\"owner\"," +
+		"\"cloud\":\"altostratus\"," +
+		"\"region\":\"mid-level\"," +
 		"\"life\":\"dead\"}}\n"
 	s.assertShowOutput(c, "json")
 }
@@ -191,8 +197,9 @@ func (s *ShowCommandSuite) TestShowBasicWithStatusIncompleteModelsYaml(c *gc.C) 
 		params.ModelInfoResult{Result: createBasicModelInfoWithStatus()},
 	}
 	s.expectedDisplay = `
-basic-model:
-  name: basic-model
+owner/basic-model:
+  name: owner/basic-model
+  short-name: basic-model
   model-uuid: deadbeef-0bad-400d-8000-4b1d0d06f00d
   controller-uuid: deadbeef-1bad-500d-9000-4b1d0d06f00d
   controller-name: testing
@@ -210,12 +217,18 @@ func (s *ShowCommandSuite) TestShowBasicWithStatusIncompleteModelsJson(c *gc.C) 
 	s.fake.infos = []params.ModelInfoResult{
 		params.ModelInfoResult{Result: createBasicModelInfoWithStatus()},
 	}
-	s.expectedDisplay = "{\"basic-model\":{\"name\":\"basic-model\"," +
+	s.expectedDisplay = "{\"owner/basic-model\":" +
+		"{\"name\":\"owner/basic-model\"," +
+		"\"short-name\":\"basic-model\"," +
 		"\"model-uuid\":\"deadbeef-0bad-400d-8000-4b1d0d06f00d\"," +
 		"\"controller-uuid\":\"deadbeef-1bad-500d-9000-4b1d0d06f00d\"," +
-		"\"controller-name\":\"testing\",\"owner\":\"owner\"," +
-		"\"cloud\":\"altostratus\",\"region\":\"mid-level\"," +
-		"\"life\":\"dead\",\"status\":{\"current\":\"busy\"}}}\n"
+		"\"controller-name\":\"testing\"," +
+		"\"owner\":\"owner\"," +
+		"\"cloud\":\"altostratus\"," +
+		"\"region\":\"mid-level\"," +
+		"\"life\":\"dead\"," +
+		"\"status\":{\"current\":\"busy\"}}}\n"
+
 	s.assertShowOutput(c, "json")
 }
 
@@ -226,8 +239,9 @@ func (s *ShowCommandSuite) TestShowBasicWithMigrationIncompleteModelsYaml(c *gc.
 		params.ModelInfoResult{Result: basicAndMigrationStatusInfo},
 	}
 	s.expectedDisplay = `
-basic-model:
-  name: basic-model
+owner/basic-model:
+  name: owner/basic-model
+  short-name: basic-model
   model-uuid: deadbeef-0bad-400d-8000-4b1d0d06f00d
   controller-uuid: deadbeef-1bad-500d-9000-4b1d0d06f00d
   controller-name: testing
@@ -248,14 +262,17 @@ func (s *ShowCommandSuite) TestShowBasicWithMigrationIncompleteModelsJson(c *gc.
 	s.fake.infos = []params.ModelInfoResult{
 		params.ModelInfoResult{Result: basicAndMigrationStatusInfo},
 	}
-	s.expectedDisplay = "{\"basic-model\":{\"name\":\"basic-model\"," +
+	s.expectedDisplay = "{\"owner/basic-model\":" +
+		"{\"name\":\"owner/basic-model\"," +
+		"\"short-name\":\"basic-model\"," +
 		"\"model-uuid\":\"deadbeef-0bad-400d-8000-4b1d0d06f00d\"," +
 		"\"controller-uuid\":\"deadbeef-1bad-500d-9000-4b1d0d06f00d\"," +
-		"\"controller-name\":\"testing\",\"owner\":\"owner\"," +
-		"\"cloud\":\"altostratus\",\"region\":\"mid-level\"," +
+		"\"controller-name\":\"testing\"," +
+		"\"owner\":\"owner\"," +
+		"\"cloud\":\"altostratus\"," +
+		"\"region\":\"mid-level\"," +
 		"\"life\":\"dead\"," +
-		"\"status\":{\"migration\":\"importing\"," +
-		"\"migration-start\":\"just now\"}}}\n"
+		"\"status\":{\"migration\":\"importing\",\"migration-start\":\"just now\"}}}\n"
 	s.assertShowOutput(c, "json")
 }
 
@@ -266,8 +283,9 @@ func (s *ShowCommandSuite) TestShowBasicWithStatusAndMigrationIncompleteModelsYa
 		params.ModelInfoResult{Result: basicAndStatusAndMigrationInfo},
 	}
 	s.expectedDisplay = `
-basic-model:
-  name: basic-model
+owner/basic-model:
+  name: owner/basic-model
+  short-name: basic-model
   model-uuid: deadbeef-0bad-400d-8000-4b1d0d06f00d
   controller-uuid: deadbeef-1bad-500d-9000-4b1d0d06f00d
   controller-name: testing
@@ -289,13 +307,18 @@ func (s *ShowCommandSuite) TestShowBasicWithStatusAndMigrationIncompleteModelsJs
 	s.fake.infos = []params.ModelInfoResult{
 		params.ModelInfoResult{Result: basicAndStatusAndMigrationInfo},
 	}
-	s.expectedDisplay = "{\"basic-model\":{\"name\":\"basic-model\"," +
+	s.expectedDisplay = "{\"owner/basic-model\":" +
+		"{\"name\":\"owner/basic-model\"," +
+		"\"short-name\":\"basic-model\"," +
 		"\"model-uuid\":\"deadbeef-0bad-400d-8000-4b1d0d06f00d\"," +
 		"\"controller-uuid\":\"deadbeef-1bad-500d-9000-4b1d0d06f00d\"," +
-		"\"controller-name\":\"testing\",\"owner\":\"owner\"," +
-		"\"cloud\":\"altostratus\",\"region\":\"mid-level\"," +
-		"\"life\":\"dead\",\"status\":{\"current\":\"busy\"," +
-		"\"migration\":\"importing\",\"migration-start\":\"just now\"}}}\n"
+		"\"controller-name\":\"testing\"," +
+		"\"owner\":\"owner\"," +
+		"\"cloud\":\"altostratus\"," +
+		"\"region\":\"mid-level\"," +
+		"\"life\":\"dead\"," +
+		"\"status\":{\"current\":\"busy\",\"migration\":\"importing\",\"migration-start\":\"just now\"}}}\n"
+
 	s.assertShowOutput(c, "json")
 }
 
@@ -306,8 +329,9 @@ func (s *ShowCommandSuite) TestShowBasicWithProviderIncompleteModelsYaml(c *gc.C
 		params.ModelInfoResult{Result: basicAndProviderTypeInfo},
 	}
 	s.expectedDisplay = `
-basic-model:
-  name: basic-model
+owner/basic-model:
+  name: owner/basic-model
+  short-name: basic-model
   model-uuid: deadbeef-0bad-400d-8000-4b1d0d06f00d
   controller-uuid: deadbeef-1bad-500d-9000-4b1d0d06f00d
   controller-name: testing
@@ -326,12 +350,17 @@ func (s *ShowCommandSuite) TestShowBasicWithProviderIncompleteModelsJson(c *gc.C
 	s.fake.infos = []params.ModelInfoResult{
 		params.ModelInfoResult{Result: basicAndProviderTypeInfo},
 	}
-	s.expectedDisplay = "{\"basic-model\":{\"name\":\"basic-model\"," +
+	s.expectedDisplay = "{\"owner/basic-model\":" +
+		"{\"name\":\"owner/basic-model\"," +
+		"\"short-name\":\"basic-model\"," +
 		"\"model-uuid\":\"deadbeef-0bad-400d-8000-4b1d0d06f00d\"," +
 		"\"controller-uuid\":\"deadbeef-1bad-500d-9000-4b1d0d06f00d\"," +
-		"\"controller-name\":\"testing\",\"owner\":\"owner\"," +
-		"\"cloud\":\"altostratus\",\"region\":\"mid-level\"," +
-		"\"type\":\"aws\",\"life\":\"dead\"}}\n"
+		"\"controller-name\":\"testing\"," +
+		"\"owner\":\"owner\"," +
+		"\"cloud\":\"altostratus\"," +
+		"\"region\":\"mid-level\"," +
+		"\"type\":\"aws\"," +
+		"\"life\":\"dead\"}}\n"
 	s.assertShowOutput(c, "json")
 }
 
@@ -344,8 +373,9 @@ func (s *ShowCommandSuite) TestShowBasicWithUsersIncompleteModelsYaml(c *gc.C) {
 		params.ModelInfoResult{Result: basicAndUsersInfo},
 	}
 	s.expectedDisplay = `
-basic-model:
-  name: basic-model
+owner/basic-model:
+  name: owner/basic-model
+  short-name: basic-model
   model-uuid: deadbeef-0bad-400d-8000-4b1d0d06f00d
   controller-uuid: deadbeef-1bad-500d-9000-4b1d0d06f00d
   controller-name: testing
@@ -371,14 +401,17 @@ func (s *ShowCommandSuite) TestShowBasicWithUsersIncompleteModelsJson(c *gc.C) {
 	s.fake.infos = []params.ModelInfoResult{
 		params.ModelInfoResult{Result: basicAndUsersInfo},
 	}
-	s.expectedDisplay = "{\"basic-model\":{\"name\":\"basic-model\"," +
+	s.expectedDisplay = "{\"owner/basic-model\":" +
+		"{\"name\":\"owner/basic-model\"," +
+		"\"short-name\":\"basic-model\"," +
 		"\"model-uuid\":\"deadbeef-0bad-400d-8000-4b1d0d06f00d\"," +
 		"\"controller-uuid\":\"deadbeef-1bad-500d-9000-4b1d0d06f00d\"," +
-		"\"controller-name\":\"testing\",\"owner\":\"owner\"," +
-		"\"cloud\":\"altostratus\",\"region\":\"mid-level\"," +
+		"\"controller-name\":\"testing\"," +
+		"\"owner\":\"owner\"," +
+		"\"cloud\":\"altostratus\"," +
+		"\"region\":\"mid-level\"," +
 		"\"life\":\"dead\"," +
-		"\"users\":{\"admin\":{\"display-name\":\"display name\"," +
-		"\"access\":\"admin\",\"last-connection\":\"never connected\"}}}}\n"
+		"\"users\":{\"admin\":{\"display-name\":\"display name\",\"access\":\"admin\",\"last-connection\":\"never connected\"}}}}\n"
 	s.assertShowOutput(c, "json")
 }
 
@@ -392,8 +425,9 @@ func (s *ShowCommandSuite) TestShowBasicWithMachinesIncompleteModelsYaml(c *gc.C
 		params.ModelInfoResult{Result: basicAndMachinesInfo},
 	}
 	s.expectedDisplay = `
-basic-model:
-  name: basic-model
+owner/basic-model:
+  name: owner/basic-model
+  short-name: basic-model
   model-uuid: deadbeef-0bad-400d-8000-4b1d0d06f00d
   controller-uuid: deadbeef-1bad-500d-9000-4b1d0d06f00d
   controller-name: testing
@@ -419,11 +453,15 @@ func (s *ShowCommandSuite) TestShowBasicWithMachinesIncompleteModelsJson(c *gc.C
 	s.fake.infos = []params.ModelInfoResult{
 		params.ModelInfoResult{Result: basicAndMachinesInfo},
 	}
-	s.expectedDisplay = "{\"basic-model\":{\"name\":\"basic-model\"," +
+	s.expectedDisplay = "{\"owner/basic-model\":" +
+		"{\"name\":\"owner/basic-model\"," +
+		"\"short-name\":\"basic-model\"," +
 		"\"model-uuid\":\"deadbeef-0bad-400d-8000-4b1d0d06f00d\"," +
 		"\"controller-uuid\":\"deadbeef-1bad-500d-9000-4b1d0d06f00d\"," +
-		"\"controller-name\":\"testing\",\"owner\":\"owner\"," +
-		"\"cloud\":\"altostratus\",\"region\":\"mid-level\"," +
+		"\"controller-name\":\"testing\"," +
+		"\"owner\":\"owner\"," +
+		"\"cloud\":\"altostratus\"," +
+		"\"region\":\"mid-level\"," +
 		"\"life\":\"dead\"," +
 		"\"machines\":{\"12\":{\"cores\":0},\"2\":{\"cores\":0}}}}\n"
 	s.assertShowOutput(c, "json")
@@ -439,8 +477,9 @@ func (s *ShowCommandSuite) TestShowBasicWithSLAIncompleteModelsYaml(c *gc.C) {
 		params.ModelInfoResult{Result: basicAndSLAInfo},
 	}
 	s.expectedDisplay = `
-basic-model:
-  name: basic-model
+owner/basic-model:
+  name: owner/basic-model
+  short-name: basic-model
   model-uuid: deadbeef-0bad-400d-8000-4b1d0d06f00d
   controller-uuid: deadbeef-1bad-500d-9000-4b1d0d06f00d
   controller-name: testing
@@ -463,30 +502,41 @@ func (s *ShowCommandSuite) TestShowBasicWithSLAIncompleteModelsJson(c *gc.C) {
 	s.fake.infos = []params.ModelInfoResult{
 		params.ModelInfoResult{Result: basicAndSLAInfo},
 	}
-	s.expectedDisplay = "{\"basic-model\":{\"name\":\"basic-model\"," +
+	s.expectedDisplay = "{\"owner/basic-model\":" +
+		"{\"name\":\"owner/basic-model\"," +
+		"\"short-name\":\"basic-model\"," +
 		"\"model-uuid\":\"deadbeef-0bad-400d-8000-4b1d0d06f00d\"," +
 		"\"controller-uuid\":\"deadbeef-1bad-500d-9000-4b1d0d06f00d\"," +
-		"\"controller-name\":\"testing\",\"owner\":\"owner\"," +
-		"\"cloud\":\"altostratus\",\"region\":\"mid-level\"," +
-		"\"life\":\"dead\",\"sla\":\"level\"," +
+		"\"controller-name\":\"testing\"," +
+		"\"owner\":\"owner\"," +
+		"\"cloud\":\"altostratus\"," +
+		"\"region\":\"mid-level\"," +
+		"\"life\":\"dead\"," +
+		"\"sla\":\"level\"," +
 		"\"sla-owner\":\"owner\"}}\n"
 	s.assertShowOutput(c, "json")
 }
 
 func (s *ShowCommandSuite) TestShowModelWithAgentVersionInJson(c *gc.C) {
-	s.expectedDisplay = "{\"basic-model\":{\"name\":\"basic-model\"," +
+	s.expectedDisplay = "{\"owner/basic-model\":" +
+		"{\"name\":\"owner/basic-model\"," +
+		"\"short-name\":\"basic-model\"," +
 		"\"model-uuid\":\"deadbeef-0bad-400d-8000-4b1d0d06f00d\"," +
 		"\"controller-uuid\":\"deadbeef-1bad-500d-9000-4b1d0d06f00d\"," +
-		"\"controller-name\":\"testing\",\"owner\":\"owner\"," +
-		"\"cloud\":\"altostratus\",\"region\":\"mid-level\"," +
-		"\"life\":\"dead\",\"agent-version\":\"2.55.5\"}}\n"
+		"\"controller-name\":\"testing\"," +
+		"\"owner\":\"owner\"," +
+		"\"cloud\":\"altostratus\"," +
+		"\"region\":\"mid-level\"," +
+		"\"life\":\"dead\"," +
+		"\"agent-version\":\"2.55.5\"}}\n"
 	s.assertShowModelWithAgent(c, "json")
 }
 
 func (s *ShowCommandSuite) TestShowModelWithAgentVersionInYaml(c *gc.C) {
 	s.expectedDisplay = `
-basic-model:
-  name: basic-model
+owner/basic-model:
+  name: owner/basic-model
+  short-name: basic-model
   model-uuid: deadbeef-0bad-400d-8000-4b1d0d06f00d
   controller-uuid: deadbeef-1bad-500d-9000-4b1d0d06f00d
   controller-name: testing
@@ -561,7 +611,7 @@ func (s *showSLACommandSuite) SetUpTest(c *gc.C) {
 		Level: "next",
 		Owner: "user",
 	}
-	slaOutput := s.expectedOutput["mymodel"].(attrs)
+	slaOutput := s.expectedOutput["admin/mymodel"].(attrs)
 	slaOutput["sla"] = "next"
 	slaOutput["sla-owner"] = "user"
 }

--- a/featuretests/cmd_juju_controller_test.go
+++ b/featuretests/cmd_juju_controller_test.go
@@ -115,7 +115,8 @@ func (s *cmdControllerSuite) TestListModelsYAML(c *gc.C) {
 	context := s.run(c, "list-models", "--format=yaml")
 	expectedOutput := `
 models:
-- name: controller
+- name: admin/controller
+  short-name: controller
   model-uuid: deadbeef-0bad-400d-8000-4b1d0d06f00d
   controller-uuid: deadbeef-1bad-500d-9000-4b1d0d06f00d
   controller-name: kontroll


### PR DESCRIPTION
## Description of change

In some circumstances, like hosted models or other user models, model name needs to be prefixed with the owner name. From usability perspective, it is easier for users if Juju provides the needed incantation somewhere.

This PR changes the command output in yaml ('show-model', 'models') and json ('models') to contain a "name" with the fully qualified model name ($owner/$name) and a "short-name" with the model name ($name).

'models' command output in tabular format did not change - all models displayed show fully qualified model names except for the models that are owned by the currently logged on user. These models only display the short name.

(this is is https://github.com/juju/juju/pull/7435 with just the one tweak I asked in the output)

## QA steps

Run 'models' command with different format options and 'show-model' and observe the behavior described above. 

## Documentation changes

If there are samples of 'models' or 'show-model' output commands in the docs, these will need to be updated.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1693581
