### PR TITLE
juju: use new DNS caching functionality

### DIFF
--- a/api/interface.go
+++ b/api/interface.go
@@ -177,7 +177,7 @@ type IPAddrResolver interface {
 
 // DNSCache implements a cache of DNS lookup results.
 type DNSCache interface {
-	// Lookup returns an IP addresses associated
+	// Lookup returns the IP addresses associated
 	// with the given host.
 	Lookup(host string) []string
 	// Add sets the IP addresses associated with

--- a/api/testing/fakeserver.go
+++ b/api/testing/fakeserver.go
@@ -1,0 +1,27 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package testing
+
+import (
+	"net"
+
+	"github.com/juju/juju/rpc"
+	"github.com/juju/juju/rpc/jsoncodec"
+)
+
+// FakeAPIServer returns a net.Conn implementation
+// that serves the RPC server defined by the given
+// root object (see rpc.Conn.Serve).
+func FakeAPIServer(root interface{}) net.Conn {
+	c0, c1 := net.Pipe()
+	serverCodec := jsoncodec.NewNet(c1)
+	serverRPC := rpc.NewConn(serverCodec, nil)
+	serverRPC.Serve(root, nil)
+	serverRPC.Start()
+	go func() {
+		<-serverRPC.Dead()
+		serverRPC.Close()
+	}()
+	return c0
+}

--- a/api/testing/resolver.go
+++ b/api/testing/resolver.go
@@ -1,0 +1,41 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package testing
+
+import (
+	"context"
+	"net"
+
+	"github.com/juju/errors"
+
+	"github.com/juju/juju/api"
+)
+
+var _ api.IPAddrResolver = IPAddrResolverMap(nil)
+
+// IPAddrResolverMap implements IPAddrResolver by looking up the
+// addresses in the map, which maps host names to IP addresses. The
+// strings in the value slices should be valid IP addresses.
+type IPAddrResolverMap map[string][]string
+
+func (r IPAddrResolverMap) LookupIPAddr(ctx context.Context, host string) ([]net.IPAddr, error) {
+	if ip := net.ParseIP(host); ip != nil {
+		return []net.IPAddr{{IP: ip}}, nil
+	}
+	ipStrs := r[host]
+	if len(ipStrs) == 0 {
+		return nil, errors.Errorf("mock resolver cannot resolve %q", host)
+	}
+	ipAddrs := make([]net.IPAddr, len(ipStrs))
+	for i, ipStr := range ipStrs {
+		ip := net.ParseIP(ipStr)
+		if ip == nil {
+			panic("invalid IP address: " + ipStr)
+		}
+		ipAddrs[i] = net.IPAddr{
+			IP: ip,
+		}
+	}
+	return ipAddrs, nil
+}

--- a/cmd/juju/application/upgradecharm_test.go
+++ b/cmd/juju/application/upgradecharm_test.go
@@ -684,6 +684,10 @@ func (m *mockAPIConnection) Addr() string {
 	return "0.1.2.3:1234"
 }
 
+func (m *mockAPIConnection) IPAddr() string {
+	return "0.1.2.3:1234"
+}
+
 func (m *mockAPIConnection) AuthTag() names.Tag {
 	return names.NewUserTag("testuser")
 }

--- a/cmd/juju/backups/restore_test.go
+++ b/cmd/juju/backups/restore_test.go
@@ -52,12 +52,11 @@ func (s *restoreSuite) SetUpTest(c *gc.C) {
 
 	s.store = jujuclient.NewMemStore()
 	s.store.Controllers["testing"] = jujuclient.ControllerDetails{
-		ControllerUUID:         "deadbeef-0bad-400d-8000-5b1d0d06f00d",
-		CACert:                 testing.CACert,
-		Cloud:                  "mycloud",
-		CloudRegion:            "a-region",
-		APIEndpoints:           []string{"10.0.1.1:17777"},
-		UnresolvedAPIEndpoints: []string{"10.0.1.1:17777"},
+		ControllerUUID: "deadbeef-0bad-400d-8000-5b1d0d06f00d",
+		CACert:         testing.CACert,
+		Cloud:          "mycloud",
+		CloudRegion:    "a-region",
+		APIEndpoints:   []string{"10.0.1.1:17777"},
 	}
 	s.store.CurrentControllerName = "testing"
 	s.store.Models["testing"] = &jujuclient.ControllerModels{
@@ -205,12 +204,11 @@ func (s *restoreSuite) TestFailedRestoreReboostrapMaintainsControllerInfo(c *gc.
 	c.Assert(err, gc.ErrorMatches, "failed")
 	// The details below are as per what was done in test setup, so no changes.
 	c.Assert(s.store.Controllers["testing"], jc.DeepEquals, jujuclient.ControllerDetails{
-		Cloud:                  "mycloud",
-		CloudRegion:            "a-region",
-		CACert:                 testing.CACert,
-		ControllerUUID:         "deadbeef-0bad-400d-8000-5b1d0d06f00d",
-		APIEndpoints:           []string{"10.0.1.1:17777"},
-		UnresolvedAPIEndpoints: []string{"10.0.1.1:17777"},
+		Cloud:          "mycloud",
+		CloudRegion:    "a-region",
+		CACert:         testing.CACert,
+		ControllerUUID: "deadbeef-0bad-400d-8000-5b1d0d06f00d",
+		APIEndpoints:   []string{"10.0.1.1:17777"},
 	})
 }
 
@@ -248,13 +246,12 @@ func (s *restoreSuite) TestRestoreReboostrapWritesUpdatedControllerInfo(c *gc.C)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(boostrapped, jc.IsTrue)
 	c.Assert(s.store.Controllers["testing"], jc.DeepEquals, jujuclient.ControllerDetails{
-		Cloud:                  "mycloud",
-		CloudRegion:            "a-region",
-		CACert:                 testing.CACert,
-		ControllerUUID:         "deadbeef-1bad-500d-9000-4b1d0d06f00d",
-		APIEndpoints:           []string{"10.0.0.1:17777"},
-		UnresolvedAPIEndpoints: []string{"10.0.0.1:17777"},
-		AgentVersion:           version.Current.String(),
+		Cloud:          "mycloud",
+		CloudRegion:    "a-region",
+		CACert:         testing.CACert,
+		ControllerUUID: "deadbeef-1bad-500d-9000-4b1d0d06f00d",
+		APIEndpoints:   []string{"10.0.0.1:17777"},
+		AgentVersion:   version.Current.String(),
 		// We won't get correct model and machine counts until
 		// we connect properly eventually.
 		ModelCount:             nil,

--- a/cmd/juju/commands/bootstrap_test.go
+++ b/cmd/juju/commands/bootstrap_test.go
@@ -296,7 +296,6 @@ func (s *BootstrapSuite) run(c *gc.C, test bootstrapTest) testing.Restorer {
 	controller, err := s.store.ControllerByName(controllerName)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(controller.CACert, gc.Not(gc.Equals), "")
-	c.Assert(controller.UnresolvedAPIEndpoints, gc.DeepEquals, addrConnectedTo)
 	c.Assert(controller.APIEndpoints, gc.DeepEquals, addrConnectedTo)
 	c.Assert(utils.IsValidUUIDString(controller.ControllerUUID), jc.IsTrue)
 	// We don't care about build numbers here.

--- a/juju/deploy_test.go
+++ b/juju/deploy_test.go
@@ -32,9 +32,8 @@ func Test(t *stdtesting.T) {
 // and that's is the simplest way to get one in there.
 type DeployLocalSuite struct {
 	testing.JujuConnSuite
-	repo        charmrepo.Interface
-	charm       *state.Charm
-	oldCacheDir string
+	repo  charmrepo.Interface
+	charm *state.Charm
 }
 
 var _ = gc.Suite(&DeployLocalSuite{})
@@ -426,16 +425,6 @@ func (s *DeployLocalSuite) TestDeployWithFewerPlacement(c *gc.C) {
 	c.Assert(f.args.Constraints, gc.DeepEquals, serviceCons)
 	c.Assert(f.args.NumUnits, gc.Equals, 3)
 	c.Assert(f.args.Placement, gc.DeepEquals, placement)
-}
-
-func (s *DeployLocalSuite) assertAssignedUnit(c *gc.C, u *state.Unit, mId string, cons constraints.Value) {
-	id, err := u.AssignedMachineId()
-	c.Assert(err, jc.ErrorIsNil)
-	machine, err := s.State.Machine(id)
-	c.Assert(err, jc.ErrorIsNil)
-	machineCons, err := machine.Constraints()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(machineCons, gc.DeepEquals, cons)
 }
 
 func (s *DeployLocalSuite) assertCharm(c *gc.C, app *state.Application, expect *charm.URL) {

--- a/juju/export_test.go
+++ b/juju/export_test.go
@@ -1,11 +1,3 @@
-// Copyright 2013 Canonical Ltd.
-// Licensed under the AGPLv3, see LICENCE file for details.
-
 package juju
 
-var (
-	ProviderConnectDelay                = &providerConnectDelay
-	ResolveOrDropHostnames              = &resolveOrDropHostnames
-	ServerAddress                       = &serverAddress
-	FilterAndResolveControllerHostPorts = filterAndResolveControllerHostPorts
-)
+var MoveToFront = moveToFront

--- a/juju/mock_test.go
+++ b/juju/mock_test.go
@@ -21,6 +21,7 @@ type mockAPIState struct {
 	close func(api.Connection) error
 
 	addr          string
+	ipAddr        string
 	apiHostPorts  [][]network.HostPort
 	modelTag      string
 	controllerTag string
@@ -76,6 +77,10 @@ func (s *mockAPIState) Close() error {
 
 func (s *mockAPIState) ServerVersion() (version.Number, bool) {
 	return version.MustParse("1.2.3"), true
+}
+
+func (s *mockAPIState) IPAddr() string {
+	return s.ipAddr
 }
 
 func (s *mockAPIState) Addr() string {

--- a/jujuclient/controllers_test.go
+++ b/jujuclient/controllers_test.go
@@ -29,12 +29,11 @@ func (s *ControllersSuite) SetUpTest(c *gc.C) {
 	s.store = jujuclient.NewFileClientStore()
 	s.controllerName = "test.controller"
 	s.controller = jujuclient.ControllerDetails{
-		UnresolvedAPIEndpoints: []string{"test.server.hostname"},
-		ControllerUUID:         "test.uuid",
-		APIEndpoints:           []string{"test.api.endpoint"},
-		CACert:                 "test.ca.cert",
-		Cloud:                  "aws",
-		CloudRegion:            "southeastasia",
+		ControllerUUID: "test.uuid",
+		APIEndpoints:   []string{"test.api.endpoint"},
+		CACert:         "test.ca.cert",
+		Cloud:          "aws",
+		CloudRegion:    "southeastasia",
 	}
 }
 
@@ -60,7 +59,7 @@ func (s *ControllersSuite) TestControllerByName(c *gc.C) {
 	found, err := s.store.ControllerByName(name)
 	c.Assert(err, jc.ErrorIsNil)
 	expected := s.getControllers(c)[name]
-	c.Assert(found, gc.DeepEquals, &expected)
+	c.Assert(found, jc.DeepEquals, &expected)
 }
 
 func (s *ControllersSuite) TestAddController(c *gc.C) {
@@ -220,7 +219,9 @@ func (s *ControllersSuite) assertControllerNotExists(c *gc.C) {
 }
 
 func (s *ControllersSuite) assertUpdateSucceeded(c *gc.C) {
-	c.Assert(s.getControllers(c)[s.controllerName], gc.DeepEquals, s.controller)
+	ctl := s.getControllers(c)[s.controllerName]
+	ctl.DNSCache = nil
+	c.Assert(ctl, jc.DeepEquals, s.controller)
 }
 
 func (s *ControllersSuite) getControllers(c *gc.C) map[string]jujuclient.ControllerDetails {

--- a/jujuclient/controllersfile_test.go
+++ b/jujuclient/controllersfile_test.go
@@ -24,8 +24,8 @@ const testControllersYAML = `
 controllers:
   aws-test:
     uuid: this-is-the-aws-test-uuid
-    unresolved-api-endpoints: [instance-1-2-4.useast.aws.com]
     api-endpoints: [this-is-aws-test-of-many-api-endpoints]
+    dns-cache: {example.com: [0.1.1.1, 0.2.2.2]}
     ca-cert: this-is-aws-test-ca-cert
     cloud: aws
     region: us-east-1
@@ -33,7 +33,6 @@ controllers:
     active-controller-machine-count: 0
   mallards:
     uuid: this-is-another-uuid
-    unresolved-api-endpoints: [maas-1-05.cluster.mallards]
     api-endpoints: [this-is-another-of-many-api-endpoints, this-is-one-more-of-many-api-endpoints]
     ca-cert: this-is-another-ca-cert
     cloud: mallards
@@ -41,7 +40,6 @@ controllers:
     active-controller-machine-count: 0
   mark-test-prodstack:
     uuid: this-is-a-uuid
-    unresolved-api-endpoints: [vm-23532.prodstack.canonical.com, great.test.server.hostname.co.nz]
     api-endpoints: [this-is-one-of-many-api-endpoints]
     ca-cert: this-is-a-ca-cert
     cloud: prodstack
@@ -80,7 +78,6 @@ func parseControllers(c *gc.C) *jujuclient.Controllers {
 	c.Assert(err, jc.ErrorIsNil)
 
 	// ensure that multiple server hostnames and eapi endpoints are parsed correctly
-	c.Assert(controllers.Controllers["mark-test-prodstack"].UnresolvedAPIEndpoints, gc.HasLen, 2)
 	c.Assert(controllers.Controllers["mallards"].APIEndpoints, gc.HasLen, 2)
 	return controllers
 }

--- a/jujuclient/controllervalidation_test.go
+++ b/jujuclient/controllervalidation_test.go
@@ -18,12 +18,11 @@ type ControllerValidationSuite struct {
 func (s *ControllerValidationSuite) SetUpTest(c *gc.C) {
 	s.BaseSuite.SetUpTest(c)
 	s.controller = jujuclient.ControllerDetails{
-		UnresolvedAPIEndpoints: []string{"test.server.hostname"},
-		ControllerUUID:         "test.uuid",
-		APIEndpoints:           []string{"test.api.endpoint"},
-		CACert:                 "test.ca.cert",
-		Cloud:                  "aws",
-		CloudRegion:            "southeastasia",
+		ControllerUUID: "test.uuid",
+		APIEndpoints:   []string{"test.api.endpoint"},
+		CACert:         "test.ca.cert",
+		Cloud:          "aws",
+		CloudRegion:    "southeastasia",
 	}
 }
 

--- a/jujuclient/interface.go
+++ b/jujuclient/interface.go
@@ -15,17 +15,17 @@ type ControllerDetails struct {
 	// ControllerUUID is the unique ID for the controller.
 	ControllerUUID string `yaml:"uuid"`
 
-	// UnresolvedAPIEndpoints holds a list of API addresses which may
-	// contain unresolved hostnames. It's used to compare more recent
-	// API addresses before resolving hostnames to determine if the
-	// cached addresses have changed and therefore perform (a possibly
-	// slow) local DNS resolution before comparing them against Addresses.
-	UnresolvedAPIEndpoints []string `yaml:"unresolved-api-endpoints,flow"`
-
 	// APIEndpoints holds a list of API addresses. It may not be
 	// current, and it will be empty if the environment has not been
 	// bootstrapped.
 	APIEndpoints []string `yaml:"api-endpoints,flow"`
+
+	// DNSCache holds a map of hostname to IP addresses, holding
+	// a cache of the last time the API endpoints were looked up.
+	// The information held here is strictly optional so that we
+	// can avoid slow DNS queries in the usual case that the controller's
+	// IP addresses haven't changed since the last time we connected.
+	DNSCache map[string][]string `yaml:"dns-cache,omitempty,flow"`
 
 	// PublicDNSName holds the public host name associated with the controller.
 	// If this is non-empty, it indicates that the controller will use an

--- a/rpc/jsoncodec/conn.go
+++ b/rpc/jsoncodec/conn.go
@@ -6,7 +6,6 @@ package jsoncodec
 import (
 	"encoding/json"
 	"io"
-	"net"
 	"sync"
 
 	"github.com/gorilla/websocket"
@@ -65,20 +64,24 @@ func (conn *wsJSONConn) Close() error {
 	return conn.conn.Close()
 }
 
-// NewNet returns an rpc codec that uses the given net
-// connection to send and receive messages.
-func NewNet(conn net.Conn) *Codec {
-	return New(&netConn{
+// NewNet returns an rpc codec that uses the given connection
+// to send and receive messages.
+func NewNet(conn io.ReadWriteCloser) *Codec {
+	return New(NetJSONConn(conn))
+}
+
+func NetJSONConn(conn io.ReadWriteCloser) JSONConn {
+	return &netConn{
 		enc:  json.NewEncoder(conn),
 		dec:  json.NewDecoder(conn),
 		conn: conn,
-	})
+	}
 }
 
 type netConn struct {
 	enc  *json.Encoder
 	dec  *json.Decoder
-	conn net.Conn
+	conn io.ReadWriteCloser
 }
 
 func (conn *netConn) Send(msg interface{}) error {

--- a/rpc/reflect_test.go
+++ b/rpc/reflect_test.go
@@ -135,7 +135,7 @@ func (*reflectSuite) TestFindMethod(c *gc.C) {
 	c.Assert(ret.Interface(), gc.Equals, stringVal{"Call1r1e ret"})
 }
 
-func (*reflectSuite) TestFindMethodRefusesVersionsNot0(c *gc.C) {
+func (*reflectSuite) TestFindMethodAcceptsAnyVersion(c *gc.C) {
 	root := &Root{
 		simple: make(map[string]*SimpleMethods),
 	}
@@ -148,6 +148,7 @@ func (*reflectSuite) TestFindMethodRefusesVersionsNot0(c *gc.C) {
 	c.Assert(m.ResultType(), gc.Equals, reflect.TypeOf(stringVal{}))
 
 	m, err = v.FindMethod("SimpleMethods", 1, "Call1r1e")
-	c.Assert(err, gc.FitsTypeOf, (*rpcreflect.CallNotImplementedError)(nil))
-	c.Assert(err, gc.ErrorMatches, `unknown version \(1\) of interface "SimpleMethods"`)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(m.ParamsType(), gc.Equals, reflect.TypeOf(stringVal{}))
+	c.Assert(m.ResultType(), gc.Equals, reflect.TypeOf(stringVal{}))
 }

--- a/rpc/rpcreflect/value.go
+++ b/rpc/rpcreflect/value.go
@@ -77,18 +77,14 @@ func (v Value) GoValue() reflect.Value {
 // It returns an error if either the root method or the object
 // method were not found.
 // It panics if called on the zero Value.
+// The version argument is ignored - all versions will find
+// the same method.
 func (v Value) FindMethod(rootMethodName string, version int, objMethodName string) (MethodCaller, error) {
 	if !v.IsValid() {
 		panic("FindMethod called on invalid Value")
 	}
 	caller := methodCaller{
 		rootValue: v.rootValue,
-	}
-	if version != 0 {
-		return nil, &CallNotImplementedError{
-			RootMethod: rootMethodName,
-			Version:    version,
-		}
 	}
 	var err error
 	caller.rootMethod, err = v.rootType.Method(rootMethodName)

--- a/rpc/server.go
+++ b/rpc/server.go
@@ -152,9 +152,12 @@ type Conn struct {
 
 // NewConn creates a new connection that uses the given codec for
 // transport, but it does not start it. Conn.Start must be called before
-// any requests are sent or received. If notifier is non-nil, the
+// any requests are sent or received. If observerFactory is non-nil, the
 // appropriate method will be called for every RPC request.
 func NewConn(codec Codec, observerFactory ObserverFactory) *Conn {
+	if observerFactory == nil {
+		observerFactory = nopObserverFactory{}
+	}
 	return &Conn{
 		codec:           codec,
 		clientPending:   make(map[uint64]*Call),
@@ -519,3 +522,15 @@ func (e *serverError) ErrorCode() string {
 	// serverError only knows one error code.
 	return codeNotImplemented
 }
+
+type nopObserverFactory struct{}
+
+func (nopObserverFactory) RPCObserver() Observer {
+	return nopObserver{}
+}
+
+type nopObserver struct{}
+
+func (nopObserver) ServerRequest(hdr *Header, body interface{}) {}
+
+func (nopObserver) ServerReply(req Request, hdr *Header, body interface{}) {}


### PR DESCRIPTION
juju: use new DNS caching functionality

We rely on the new API client functionality to do our
DNS resolving for us, and store any resulting cached
names in the controllers.yaml entry.

The UnresolvedAPIEndpoints field is now redundant
and is replaced by the strictly advisory DNSCache
field. The APIEndpoints field now always contains all
the host names returned from the Login call with
the exception of addresses deemed unusable
(e.g. link-local addresses).

We also change rpcreflect.Value.FindMethod to accept any
version so that it's more useful for testing - this makes it
possible to server limited portions of the juju API from
a mocked API type without implementing a custom FindMethod.
And, in passing, fix rpc.NewConn so that it works with a nil obververFactory
as documented.

QA check that API connections still work OK, particularly on
MAAS setups where some of the returned host names will
not resolve on a client.

Also, check that:

	juju register jaas
	juju list-models

does not produce the "cannot validate certificate for because it
doesn't contain any IP SANs" error.

Fixes https://bugs.launchpad.net/juju/+bug/1692905
