### PR TITLE
Reduce log level of SLA API error.

### DIFF
--- a/cmd/juju/model/destroy.go
+++ b/cmd/juju/model/destroy.go
@@ -207,7 +207,7 @@ func (c *destroyCommand) Run(ctx *cmd.Context) error {
 	if err == nil {
 		slaIsSet = slaLevel != "" && slaLevel != slaUnsupported
 	} else {
-		ctx.Warningf("could not determine model SLA level: %v", err)
+		logger.Debugf("could not determine model SLA level: %v", err)
 	}
 
 	// Attempt to destroy the model.


### PR DESCRIPTION
SLA allocation is removed with best effort. Because the SLA API call
will fail on pre-2.2 controllers, debug level is more appropriate for
this error.

## Description of change

> Why is this change needed?

Before this change, when using a Juju 2.2 client with pre-2.2 controllers, you'll get an unactionable warning about SLAs when destroying a model, because the controller does not support them:

```
c@zeugmatic:~/go/juju/src/github.com/juju/juju$ juju add-model foo azure/westus --credential azure-cmars
Uploading credential 'azure/cmars@external/azure-cmars' to controller
Added 'foo' model on azure/westus with credential 'azure-cmars' for user 'cmars'
c@zeugmatic:~/go/juju/src/github.com/juju/juju$ juju destroy-model foo
WARNING! This command will destroy the "foo" model.
This includes all machines, applications, data and other resources.

Continue [y/N]? y
WARNING could not determine model SLA level: no such request - method ModelConfig(1).SLALevel is not implemented (not implemented)
Destroying model
```

## QA steps

> How do we verify that the change works?

You won't see the API error warning when destroying a model on a pre-2.2 controller.

```
c@zeugmatic:~/go/juju/src/github.com/juju/juju$ juju add-model foo azure/westus --credential azure-cmars
Uploading credential 'azure/cmars@external/azure-cmars' to controller
Added 'foo' model on azure/westus with credential 'azure-cmars' for user 'cmars'
c@zeugmatic:~/go/juju/src/github.com/juju/juju$ juju destroy-model foo                                                                                 
WARNING! This command will destroy the "foo" model.
This includes all machines, applications, data and other resources.

Continue [y/N]? y
Destroying model
Waiting on model to be removed...
Waiting on model to be removed...
Waiting on model to be removed...
```

## Documentation changes

> Does it affect current user workflow? CLI? API?

No

## Bug reference

> Does this change fix a bug? Please add a link to it.

N/A