### PR TITLE
api: fix racy test

### DIFF
--- a/api/apiclient_test.go
+++ b/api/apiclient_test.go
@@ -611,12 +611,12 @@ func (s *apiclientSuite) TestDNSCacheUsed(c *gc.C) {
 		SkipLogin: true,
 		CACert:    jtesting.CACert,
 	}, api.DialOpts{
-		Timeout:       5 * time.Second,
-		RetryDelay:    1 * time.Second,
 		DialWebsocket: fakeDialer,
-		IPAddrResolver: fakeResolver{
-			"place1.example": {"0.2.2.2"},
-		},
+		// Note: don't resolve any addresses. If we resolve one,
+		// then there's a possibility that the resolving will
+		// happen and a second dial attempt will happen before
+		// the Open returns, giving rise to a race.
+		IPAddrResolver: fakeResolver{},
 		DNSCache: dnsCacheMap{
 			"place1.example": {"0.1.1.1"},
 		},


### PR DESCRIPTION
The DNS fallback functionality meant that we could
make two dials when only one was expected,
giving rise to a race (for example http://reports.vapour.ws/releases/5331/job/run-unit-tests-race/attempt/2831)