### PR TITLE
state: Split logs collection into a collection per model

### DIFF
--- a/apiserver/logsink_test.go
+++ b/apiserver/logsink_test.go
@@ -125,7 +125,7 @@ func (s *logsinkSuite) TestLogging(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Wait for the log documents to be written to the DB.
-	logsColl := s.State.MongoSession().DB("logs").C("logs")
+	logsColl := s.State.MongoSession().DB("logs").C("logs." + s.State.ModelUUID())
 	var docs []bson.M
 	for a := coretesting.LongAttempt.Start(); a.Next(); {
 		err := logsColl.Find(nil).Sort("t").All(&docs)
@@ -144,7 +144,6 @@ func (s *logsinkSuite) TestLogging(c *gc.C) {
 	// Check the recorded logs are correct.
 	modelUUID := s.State.ModelUUID()
 	c.Assert(docs[0]["t"], gc.Equals, t0.UnixNano())
-	c.Assert(docs[0]["e"], gc.Equals, modelUUID)
 	c.Assert(docs[0]["n"], gc.Equals, s.machineTag.String())
 	c.Assert(docs[0]["m"], gc.Equals, "some.where")
 	c.Assert(docs[0]["l"], gc.Equals, "foo.go:42")
@@ -152,7 +151,6 @@ func (s *logsinkSuite) TestLogging(c *gc.C) {
 	c.Assert(docs[0]["x"], gc.Equals, "all is well")
 
 	c.Assert(docs[1]["t"], gc.Equals, t1.UnixNano())
-	c.Assert(docs[1]["e"], gc.Equals, modelUUID)
 	c.Assert(docs[1]["n"], gc.Equals, s.machineTag.String())
 	c.Assert(docs[1]["m"], gc.Equals, "else.where")
 	c.Assert(docs[1]["l"], gc.Equals, "bar.go:99")

--- a/apiserver/logtransfer_test.go
+++ b/apiserver/logtransfer_test.go
@@ -164,7 +164,7 @@ func (s *logtransferSuite) TestLogging(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Wait for the log documents to be written to the DB.
-	logsColl := s.State.MongoSession().DB("logs").C("logs")
+	logsColl := s.State.MongoSession().DB("logs").C("logs." + s.State.ModelUUID())
 	var docs []bson.M
 	for a := coretesting.LongAttempt.Start(); a.Next(); {
 		err := logsColl.Find(nil).Sort("t").All(&docs)
@@ -181,9 +181,7 @@ func (s *logtransferSuite) TestLogging(c *gc.C) {
 	}
 
 	// Check the recorded logs are correct.
-	modelUUID := s.State.ModelUUID()
 	c.Assert(docs[0]["t"], gc.Equals, t0.UnixNano())
-	c.Assert(docs[0]["e"], gc.Equals, modelUUID)
 	c.Assert(docs[0]["n"], gc.Equals, "machine-23")
 	c.Assert(docs[0]["m"], gc.Equals, "some.where")
 	c.Assert(docs[0]["l"], gc.Equals, "foo.go:42")
@@ -191,7 +189,6 @@ func (s *logtransferSuite) TestLogging(c *gc.C) {
 	c.Assert(docs[0]["x"], gc.Equals, "all is well")
 
 	c.Assert(docs[1]["t"], gc.Equals, t1.UnixNano())
-	c.Assert(docs[1]["e"], gc.Equals, modelUUID)
 	c.Assert(docs[1]["n"], gc.Equals, "machine-101")
 	c.Assert(docs[1]["m"], gc.Equals, "else.where")
 	c.Assert(docs[1]["l"], gc.Equals, "bar.go:99")

--- a/state/export_test.go
+++ b/state/export_test.go
@@ -464,7 +464,6 @@ func AssertHostPortConversion(c *gc.C, netHostPort network.HostPort) {
 
 // MakeLogDoc creates a database document for a single log message.
 func MakeLogDoc(
-	modelUUID string,
 	entity names.Tag,
 	t time.Time,
 	module string,
@@ -473,15 +472,14 @@ func MakeLogDoc(
 	msg string,
 ) *logDoc {
 	return &logDoc{
-		Id:        bson.NewObjectId(),
-		Time:      t.UnixNano(),
-		ModelUUID: modelUUID,
-		Entity:    entity.String(),
-		Version:   version.Current.String(),
-		Module:    module,
-		Location:  location,
-		Level:     int(level),
-		Message:   msg,
+		Id:       bson.NewObjectId(),
+		Time:     t.UnixNano(),
+		Entity:   entity.String(),
+		Version:  version.Current.String(),
+		Module:   module,
+		Location: location,
+		Level:    int(level),
+		Message:  msg,
 	}
 }
 

--- a/state/logs.go
+++ b/state/logs.go
@@ -28,9 +28,9 @@ import (
 
 // TODO(wallyworld) - lp:1602508 - collections need to be defined in collections.go
 const (
-	logsDB     = "logs"
-	logsPrefix = "logs."
-	forwardedC = "forwarded"
+	logsDB      = "logs"
+	logsCPrefix = "logs."
+	forwardedC  = "forwarded"
 )
 
 // ErrNeverForwarded signals to the caller that the ID of a
@@ -69,7 +69,7 @@ var logIndexes = [][]string{
 }
 
 func logCollectionName(modelUUID string) string {
-	return logsPrefix + modelUUID
+	return logsCPrefix + modelUUID
 }
 
 // InitDbLogs sets up the indexes for the logs collection. It should
@@ -744,7 +744,8 @@ func PruneLogs(st ControllerSessioner, minLogTime time.Time, maxLogsMB int) erro
 		pruneCounts[modelUUID] = removeInfo.Removed
 	}
 
-	// Do further pruning if the logs collection is over the maximum size.
+	// Do further pruning if the total size of the log collections is
+	// over the maximum size.
 	for {
 		collMB, err := getCollectionTotalMB(logColls)
 		if err != nil {
@@ -854,10 +855,10 @@ func getLogCollections(db *mgo.Database) (map[string]*mgo.Collection, error) {
 		return nil, errors.Trace(err)
 	}
 	for _, name := range names {
-		if !strings.HasPrefix(name, logsPrefix) {
+		if !strings.HasPrefix(name, logsCPrefix) {
 			continue
 		}
-		uuid := name[len(logsPrefix):]
+		uuid := name[len(logsCPrefix):]
 		result[uuid] = db.C(name)
 	}
 	return result, nil

--- a/state/logs_test.go
+++ b/state/logs_test.go
@@ -33,7 +33,7 @@ func (s *LogsSuite) SetUpTest(c *gc.C) {
 	s.ConnSuite.SetUpTest(c)
 
 	session := s.State.MongoSession()
-	s.logsColl = session.DB("logs").C("logs")
+	s.logsColl = session.DB("logs").C("logs." + s.State.ModelUUID())
 }
 
 func (s *LogsSuite) TestLastSentLogTrackerSetGet(c *gc.C) {
@@ -262,7 +262,7 @@ func (s *LogsSuite) TestPruneLogsBySize(c *gc.C) {
 	// Ensure that the latest log records are still there.
 	assertLatestTs := func(st *state.State) {
 		var doc bson.M
-		err := s.logsColl.Find(bson.M{"e": st.ModelUUID()}).Sort("-t").One(&doc)
+		err := s.logsColl.Find(nil).Sort("-t").One(&doc)
 		c.Assert(err, jc.ErrorIsNil)
 		c.Assert(doc["t"], gc.Equals, now.UnixNano())
 	}
@@ -282,7 +282,7 @@ func (s *LogsSuite) generateLogs(c *gc.C, st *state.State, endTime time.Time, co
 }
 
 func (s *LogsSuite) countLogs(c *gc.C, st *state.State) int {
-	count, err := s.logsColl.Find(bson.M{"e": st.ModelUUID()}).Count()
+	count, err := s.logsColl.Count()
 	c.Assert(err, jc.ErrorIsNil)
 	return count
 }

--- a/state/model.go
+++ b/state/model.go
@@ -396,7 +396,7 @@ func (st *State) NewModel(args ModelArgs) (_ *Model, _ *State, err error) {
 	}
 
 	if err := InitDbLogs(session, uuid); err != nil {
-		return nil, nil, errors.Trace(err)
+		return nil, nil, errors.Annotate(err, "initialising model logs collection")
 	}
 	return newModel, newSt, nil
 }

--- a/state/model.go
+++ b/state/model.go
@@ -395,6 +395,9 @@ func (st *State) NewModel(args ModelArgs) (_ *Model, _ *State, err error) {
 		return nil, nil, errors.Annotate(err, "granting admin permission to the owner")
 	}
 
+	if err := InitDbLogs(session, uuid); err != nil {
+		return nil, nil, errors.Trace(err)
+	}
 	return newModel, newSt, nil
 }
 

--- a/state/open.go
+++ b/state/open.go
@@ -146,7 +146,7 @@ func open(
 		return nil, errors.Trace(err)
 	}
 	if initDatabase != nil {
-		if err := initDatabase(session, controllerConfig); err != nil {
+		if err := initDatabase(session, controllerModelTag.Id(), controllerConfig); err != nil {
 			session.Close()
 			return nil, errors.Trace(err)
 		}
@@ -258,10 +258,10 @@ func (p InitializeParams) Validate() error {
 
 // InitDatabaseFunc defines a function used to
 // create the collections and indices in a Juju database.
-type InitDatabaseFunc func(*mgo.Session, *controller.Config) error
+type InitDatabaseFunc func(*mgo.Session, string, *controller.Config) error
 
 // InitDatabase creates all the collections and indices in a Juju database.
-func InitDatabase(session *mgo.Session, settings *controller.Config) error {
+func InitDatabase(session *mgo.Session, modelUUID string, settings *controller.Config) error {
 	schema := allCollections()
 	err := schema.Create(
 		session.DB(jujuDB),
@@ -270,7 +270,7 @@ func InitDatabase(session *mgo.Session, settings *controller.Config) error {
 	if err != nil {
 		return errors.Trace(err)
 	}
-	if err := InitDbLogs(session); err != nil {
+	if err := InitDbLogs(session, modelUUID); err != nil {
 		return errors.Trace(err)
 	}
 	return nil

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -2798,8 +2798,8 @@ func writeLogs(c *gc.C, st *state.State, n int) {
 }
 
 func assertLogCount(c *gc.C, st *state.State, expected int) {
-	logColl := st.MongoSession().DB("logs").C("logs")
-	actual, err := logColl.Find(bson.M{"e": st.ModelUUID()}).Count()
+	logColl := st.MongoSession().DB("logs").C("logs." + st.ModelUUID())
+	actual, err := logColl.Count()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(actual, gc.Equals, expected)
 }

--- a/state/txns_test.go
+++ b/state/txns_test.go
@@ -33,6 +33,7 @@ const (
 func (s *MultiModelRunnerSuite) SetUpTest(c *gc.C) {
 	s.BaseSuite.SetUpTest(c)
 	s.testRunner = &recordingRunner{}
+	logsC := logCollectionName(modelUUID)
 	s.multiModelRunner = &multiModelRunner{
 		rawRunner: s.testRunner,
 		modelUUID: modelUUID,
@@ -286,6 +287,7 @@ type objIdDoc struct {
 
 func (s *MultiModelRunnerSuite) TestWithObjectIds(c *gc.C) {
 	id := bson.NewObjectId()
+	logsC := logCollectionName(modelUUID)
 	inOps := []txn.Op{{
 		C:      logsC,
 		Id:     id,

--- a/state/upgrades.go
+++ b/state/upgrades.go
@@ -235,7 +235,7 @@ func DropOldLogIndex(st *State) error {
 	// If the log collection still has the old e,t index, remove it.
 	key := []string{"e", "t"}
 	db := st.MongoSession().DB(logsDB)
-	collection := db.C(logsC)
+	collection := db.C(logCollectionName(st.ModelUUID()))
 	err := collection.DropIndex(key...)
 	if err == nil {
 		return nil

--- a/state/upgrades_test.go
+++ b/state/upgrades_test.go
@@ -382,6 +382,7 @@ func (s *upgradesSuite) TestRenameAddModelPermission(c *gc.C) {
 }
 
 func (s *upgradesSuite) TestDropOldLogIndex(c *gc.C) {
+	logsC := logCollectionName(s.state.ModelUUID())
 	coll := s.state.MongoSession().DB(logsDB).C(logsC)
 	err := coll.EnsureIndexKey("e", "t")
 	c.Assert(err, jc.ErrorIsNil)
@@ -398,6 +399,7 @@ func (s *upgradesSuite) TestDropOldLogIndex(c *gc.C) {
 }
 
 func (s *upgradesSuite) TestDropOldIndexWhenNoIndex(c *gc.C) {
+	logsC := logCollectionName(s.state.ModelUUID())
 	coll := s.state.MongoSession().DB(logsDB).C(logsC)
 	exists, err := hasIndex(coll, []string{"e", "t"})
 	c.Assert(err, jc.ErrorIsNil)

--- a/upgrades/backend.go
+++ b/upgrades/backend.go
@@ -30,6 +30,7 @@ type StateBackend interface {
 	AddControllerLogCollectionsSizeSettings() error
 	AddStatusHistoryPruneSettings() error
 	AddStorageInstanceConstraints() error
+	SplitLogCollections() error
 }
 
 // Model is an interface providing access to the details of a model within the
@@ -110,6 +111,10 @@ func (s stateBackend) AddStatusHistoryPruneSettings() error {
 
 func (s stateBackend) AddStorageInstanceConstraints() error {
 	return state.AddStorageInstanceConstraints(s.st)
+}
+
+func (s stateBackend) SplitLogCollections() error {
+	return state.SplitLogCollections(s.st)
 }
 
 type modelShim struct {

--- a/upgrades/backend.go
+++ b/upgrades/backend.go
@@ -20,7 +20,6 @@ type StateBackend interface {
 
 	StripLocalUserDomain() error
 	RenameAddModelPermission() error
-	DropOldLogIndex() error
 	AddMigrationAttempt() error
 	AddLocalCharmSequences() error
 	UpdateLegacyLXDCloudCredentials(string, cloud.Credential) error
@@ -71,10 +70,6 @@ func (s stateBackend) StripLocalUserDomain() error {
 
 func (s stateBackend) RenameAddModelPermission() error {
 	return state.RenameAddModelPermission(s.st)
-}
-
-func (s stateBackend) DropOldLogIndex() error {
-	return state.DropOldLogIndex(s.st)
 }
 
 func (s stateBackend) AddMigrationAttempt() error {

--- a/upgrades/steps_21.go
+++ b/upgrades/steps_21.go
@@ -7,13 +7,6 @@ package upgrades
 func stateStepsFor21() []Step {
 	return []Step{
 		&upgradeStep{
-			description: "drop old log index",
-			targets:     []Target{DatabaseMaster},
-			run: func(context Context) error {
-				return context.State().DropOldLogIndex()
-			},
-		},
-		&upgradeStep{
 			description: "add attempt to migration docs",
 			targets:     []Target{DatabaseMaster},
 			run: func(context Context) error {

--- a/upgrades/steps_21_test.go
+++ b/upgrades/steps_21_test.go
@@ -20,12 +20,6 @@ type steps21Suite struct {
 
 var _ = gc.Suite(&steps21Suite{})
 
-func (s *steps21Suite) TestDropOldLogIndex(c *gc.C) {
-	step := findStateStep(c, v210, "drop old log index")
-	// Logic for step itself is tested in state package.
-	c.Assert(step.Targets(), jc.DeepEquals, []upgrades.Target{upgrades.DatabaseMaster})
-}
-
 func (s *steps21Suite) TestAddMigrationAttempt(c *gc.C) {
 	step := findStateStep(c, v210, "add attempt to migration docs")
 	// Logic for step itself is tested in state package.

--- a/upgrades/steps_22.go
+++ b/upgrades/steps_22.go
@@ -46,6 +46,13 @@ func stateStepsFor22() []Step {
 				return context.State().AddStorageInstanceConstraints()
 			},
 		},
+		&upgradeStep{
+			description: "split log collections",
+			targets:     []Target{DatabaseMaster},
+			run: func(context Context) error {
+				return context.State().SplitLogCollections()
+			},
+		},
 	}
 }
 

--- a/upgrades/steps_22_test.go
+++ b/upgrades/steps_22_test.go
@@ -71,3 +71,9 @@ func (s *steps22Suite) TestAddStorageInstanceConstraints(c *gc.C) {
 	// Logic for step itself is tested in state package.
 	c.Assert(step.Targets(), jc.DeepEquals, []upgrades.Target{upgrades.DatabaseMaster})
 }
+
+func (s *steps22Suite) TestSplitLogStep(c *gc.C) {
+	step := findStateStep(c, v220, "split log collections")
+	// Logic for step itself is tested in state package.
+	c.Assert(step.Targets(), jc.DeepEquals, []upgrades.Target{upgrades.DatabaseMaster})
+}

--- a/worker/dblogpruner/worker_test.go
+++ b/worker/dblogpruner/worker_test.go
@@ -71,7 +71,7 @@ func (s *suite) setupState(c *gc.C, maxLogAge, maxCollectionMB string) {
 		ControllerConfig: controllerConfig,
 	})
 	s.AddCleanup(func(*gc.C) { s.state.Close() })
-	s.logsColl = s.state.MongoSession().DB("logs").C("logs")
+	s.logsColl = s.state.MongoSession().DB("logs").C("logs." + s.state.ModelUUID())
 }
 
 func (s *suite) startWorker(c *gc.C) {


### PR DESCRIPTION
## Description of change

When destroying a model on a controller with lots of models, deleting the logs for that model is by far the most expensive part of the operation. Splitting the log collection so we have one log collection per model will mean that we can drop the collection instead, and save space by not storing the model UUID on each row and in the indexes.

## QA steps

