### PR TITLE
Ensure any missing controller config is added when restoring from backup

### DIFF
--- a/cmd/juju/backups/restore.go
+++ b/cmd/juju/backups/restore.go
@@ -203,12 +203,14 @@ func (c *restoreCommand) getRebootstrapParams(
 		return nil, errors.Annotatef(err, "cannot enable provisioner-safe-mode")
 	}
 
-	controllerCfg := make(controller.Config)
+	controllerCfgAttrs := make(map[string]interface{})
 	for k, v := range config.ControllerConfig {
-		controllerCfg[k] = v
+		controllerCfgAttrs[k] = v
 	}
-	controllerCfg[controller.ControllerUUIDKey] = controllerDetails.ControllerUUID
-	controllerCfg[controller.CACertKey] = meta.CACert
+	controllerCfg, err := controller.NewConfig(controllerDetails.ControllerUUID, meta.CACert, controllerCfgAttrs)
+	if err != nil {
+		return nil, errors.Annotatef(err, "cannot create controller config")
+	}
 
 	return &restoreBootstrapParams{
 		controllerCfg,


### PR DESCRIPTION
## Description of change

When restoring a system originally bootstrapped with an older Juju, there may be new controller config attributes not originally present in the older Juju. This caused a panic. Restore now ensures any necessary default controller attributes are filled in as needed.

## QA steps

Follow steps in bug.
Deploy Juju 2.1.3
Upgrade to 2.2
Take backup
Kill controller
Restore from backup

## Bug reference

https://bugs.launchpad.net/juju/+bug/1688635
