### PR TITLE
Set logforward-enabled on new model

### DIFF
--- a/acceptancetests/assess_log_forward.py
+++ b/acceptancetests/assess_log_forward.py
@@ -74,12 +74,12 @@ def ensure_multiple_models_forward_messages(
     :raises JujuAssertionError: If the log message check fails in an unexpected
       way.
     """
-    enable_log_forwarding(dummy)
-
     model1 = dummy.add_model('{}-{}'.format(dummy.env.environment, 'model1'))
 
     charm_path = local_charm_path(
         charm='dummy-source', juju_ver=model1.version)
+
+    enable_log_forwarding(model1)
 
     model1.deploy(charm_path)
     model1.wait_for_started()
@@ -163,6 +163,7 @@ def get_assert_regex(raw_uuid, message=None):
 
 
 def enable_log_forwarding(client):
+    client.set_env_option('logforward-enabled', 'true')
     client.get_controller_client().set_env_option('logforward-enabled', 'true')
 
 


### PR DESCRIPTION
## Description of change

There was a slight change in behaviour with log forwarding for models. Test now properly sets log-forward config on the actual model when needed.