### PR TITLE
state: introduce AddUnitParams

### DIFF
--- a/api/agent/unit_test.go
+++ b/api/agent/unit_test.go
@@ -30,7 +30,7 @@ func (s *unitSuite) SetUpTest(c *gc.C) {
 	var err error
 	s.JujuConnSuite.SetUpTest(c)
 	svc := s.AddTestingService(c, "wordpress", s.AddTestingCharm(c, "wordpress"))
-	s.unit, err = svc.AddUnit()
+	s.unit, err = svc.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	password, err := utils.RandomPassword()
 	c.Assert(err, jc.ErrorIsNil)

--- a/api/deployer/deployer_test.go
+++ b/api/deployer/deployer_test.go
@@ -60,7 +60,7 @@ func (s *deployerSuite) SetUpTest(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Create principal and subordinate units and assign them.
-	s.principal, err = s.service0.AddUnit()
+	s.principal, err = s.service0.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	err = s.principal.AssignToMachine(s.machine)
 	c.Assert(err, jc.ErrorIsNil)
@@ -139,7 +139,7 @@ func (s *deployerSuite) TestUnit(c *gc.C) {
 	// First create a new machine and deploy another unit there.
 	machine, err := s.State.AddMachine("quantal", state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)
-	principal1, err := s.service0.AddUnit()
+	principal1, err := s.service0.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	err = principal1.AssignToMachine(machine)
 	c.Assert(err, jc.ErrorIsNil)

--- a/api/firewaller/firewaller_test.go
+++ b/api/firewaller/firewaller_test.go
@@ -63,7 +63,7 @@ func (s *firewallerSuite) SetUpTest(c *gc.C) {
 	s.application = s.AddTestingService(c, "wordpress", s.charm)
 	// Add the rest of the units and assign them.
 	for i := 0; i <= 2; i++ {
-		s.units[i], err = s.application.AddUnit()
+		s.units[i], err = s.application.AddUnit(state.AddUnitParams{})
 		c.Check(err, jc.ErrorIsNil)
 		err = s.units[i].AssignToMachine(s.machines[i])
 		c.Check(err, jc.ErrorIsNil)

--- a/api/provisioner/provisioner_test.go
+++ b/api/provisioner/provisioner_test.go
@@ -378,7 +378,7 @@ func (s *provisionerSuite) TestDistributionGroup(c *gc.C) {
 
 	var unitNames []string
 	for i := 0; i < 3; i++ {
-		unit, err := wordpress.AddUnit()
+		unit, err := wordpress.AddUnit(state.AddUnitParams{})
 		c.Assert(err, jc.ErrorIsNil)
 		unitNames = append(unitNames, unit.Name())
 		err = unit.AssignToMachine(machine1)

--- a/api/uniter/state_test.go
+++ b/api/uniter/state_test.go
@@ -11,6 +11,7 @@ import (
 	apitesting "github.com/juju/juju/api/testing"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/network"
+	"github.com/juju/juju/state"
 )
 
 type stateSuite struct {
@@ -46,7 +47,7 @@ func (s *stateSuite) TestAllMachinePorts(c *gc.C) {
 	c.Assert(unitPorts, gc.HasLen, 0)
 
 	// Add another wordpress unit on the same machine.
-	wordpressUnit1, err := s.wordpressApplication.AddUnit()
+	wordpressUnit1, err := s.wordpressApplication.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	err = wordpressUnit1.AssignToMachine(s.wordpressMachine)
 	c.Assert(err, jc.ErrorIsNil)

--- a/api/uniter/uniter_test.go
+++ b/api/uniter/uniter_test.go
@@ -83,7 +83,7 @@ func (s *uniterSuite) addMachineBoundAppCharmAndUnit(c *gc.C, appName string, bi
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
-	unit, err := app.AddUnit()
+	unit, err := app.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 
 	err = unit.AssignToMachine(machine)

--- a/api/upgrader/unitupgrader_test.go
+++ b/api/upgrader/unitupgrader_test.go
@@ -63,7 +63,7 @@ func (s *unitUpgraderSuite) addMachineServiceCharmAndUnit(c *gc.C, serviceName s
 	c.Assert(err, jc.ErrorIsNil)
 	charm := s.AddTestingCharm(c, serviceName)
 	service := s.AddTestingService(c, serviceName, charm)
-	unit, err := service.AddUnit()
+	unit, err := service.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	err = unit.AssignToMachine(machine)
 	c.Assert(err, jc.ErrorIsNil)

--- a/api/watcher/watcher_test.go
+++ b/api/watcher/watcher_test.go
@@ -107,7 +107,7 @@ func (s *watcherSuite) TestWatchUnitsKeepsEvents(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	rel, err := s.State.AddRelation(eps...)
 	c.Assert(err, jc.ErrorIsNil)
-	principal, err := mysql.AddUnit()
+	principal, err := mysql.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	err = principal.AssignToMachine(s.rawMachine)
 	c.Assert(err, jc.ErrorIsNil)
@@ -166,7 +166,7 @@ func (s *watcherSuite) TestStringsWatcherStopsWithPendingSend(c *gc.C) {
 
 	// Create a service, deploy a unit of it on the machine.
 	mysql := s.AddTestingService(c, "mysql", s.AddTestingCharm(c, "mysql"))
-	principal, err := mysql.AddUnit()
+	principal, err := mysql.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	err = principal.AssignToMachine(s.rawMachine)
 	c.Assert(err, jc.ErrorIsNil)

--- a/apiserver/action/run_test.go
+++ b/apiserver/action/run_test.go
@@ -48,7 +48,7 @@ func (s *runSuite) addMachine(c *gc.C) *state.Machine {
 }
 
 func (s *runSuite) addUnit(c *gc.C, service *state.Application) *state.Unit {
-	unit, err := service.AddUnit()
+	unit, err := service.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	err = unit.AssignToNewMachine()
 	c.Assert(err, jc.ErrorIsNil)
@@ -63,7 +63,7 @@ func (s *runSuite) TestGetAllUnitNames(c *gc.C) {
 
 	notAssigned, err := s.State.AddApplication(state.AddApplicationArgs{Name: "not-assigned", Charm: charm})
 	c.Assert(err, jc.ErrorIsNil)
-	_, err = notAssigned.AddUnit()
+	_, err = notAssigned.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 
 	_, err = s.State.AddApplication(state.AddApplicationArgs{Name: "no-units", Charm: charm})

--- a/apiserver/application/application_test.go
+++ b/apiserver/application/application_test.go
@@ -2124,7 +2124,7 @@ func (s *applicationSuite) TestDestroyPrincipalUnits(c *gc.C) {
 	wordpress := s.AddTestingService(c, "wordpress", s.AddTestingCharm(c, "wordpress"))
 	units := make([]*state.Unit, 5)
 	for i := range units {
-		unit, err := wordpress.AddUnit()
+		unit, err := wordpress.AddUnit(state.AddUnitParams{})
 		c.Assert(err, jc.ErrorIsNil)
 		unit.AssignToNewMachine()
 		c.Assert(err, jc.ErrorIsNil)
@@ -2143,7 +2143,7 @@ func (s *applicationSuite) TestDestroyPrincipalUnits(c *gc.C) {
 
 func (s *applicationSuite) TestDestroySubordinateUnits(c *gc.C) {
 	wordpress := s.AddTestingService(c, "wordpress", s.AddTestingCharm(c, "wordpress"))
-	wordpress0, err := wordpress.AddUnit()
+	wordpress0, err := wordpress.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	s.AddTestingService(c, "logging", s.AddTestingCharm(c, "logging"))
 	eps, err := s.State.InferEndpoints("logging", "wordpress")
@@ -2209,7 +2209,7 @@ func (s *applicationSuite) setupDestroyPrincipalUnits(c *gc.C) []*state.Unit {
 	units := make([]*state.Unit, 5)
 	wordpress := s.AddTestingService(c, "wordpress", s.AddTestingCharm(c, "wordpress"))
 	for i := range units {
-		unit, err := wordpress.AddUnit()
+		unit, err := wordpress.AddUnit(state.AddUnitParams{})
 		c.Assert(err, jc.ErrorIsNil)
 		err = unit.AssignToNewMachine()
 		c.Assert(err, jc.ErrorIsNil)
@@ -2285,7 +2285,7 @@ func (s *applicationSuite) assertDestroySubordinateUnits(c *gc.C, wordpress0, lo
 
 func (s *applicationSuite) TestBlockRemoveDestroySubordinateUnits(c *gc.C) {
 	wordpress := s.AddTestingService(c, "wordpress", s.AddTestingCharm(c, "wordpress"))
-	wordpress0, err := wordpress.AddUnit()
+	wordpress0, err := wordpress.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	s.AddTestingService(c, "logging", s.AddTestingCharm(c, "logging"))
 	eps, err := s.State.InferEndpoints("logging", "wordpress")
@@ -2320,7 +2320,7 @@ func (s *applicationSuite) TestBlockRemoveDestroySubordinateUnits(c *gc.C) {
 
 func (s *applicationSuite) TestBlockChangesDestroySubordinateUnits(c *gc.C) {
 	wordpress := s.AddTestingService(c, "wordpress", s.AddTestingCharm(c, "wordpress"))
-	wordpress0, err := wordpress.AddUnit()
+	wordpress0, err := wordpress.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	s.AddTestingService(c, "logging", s.AddTestingCharm(c, "logging"))
 	eps, err := s.State.InferEndpoints("logging", "wordpress")
@@ -2355,7 +2355,7 @@ func (s *applicationSuite) TestBlockChangesDestroySubordinateUnits(c *gc.C) {
 
 func (s *applicationSuite) TestBlockDestroyDestroySubordinateUnits(c *gc.C) {
 	wordpress := s.AddTestingService(c, "wordpress", s.AddTestingCharm(c, "wordpress"))
-	wordpress0, err := wordpress.AddUnit()
+	wordpress0, err := wordpress.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	s.AddTestingService(c, "logging", s.AddTestingCharm(c, "logging"))
 	eps, err := s.State.InferEndpoints("logging", "wordpress")

--- a/apiserver/application/backend.go
+++ b/apiserver/application/backend.go
@@ -53,7 +53,7 @@ type BlockChecker interface {
 // details on the methods, see the methods on state.Application with
 // the same names.
 type Application interface {
-	AddUnit() (*state.Unit, error)
+	AddUnit(state.AddUnitParams) (*state.Unit, error)
 	AllUnits() ([]Unit, error)
 	Charm() (Charm, bool, error)
 	CharmURL() (*charm.URL, bool)

--- a/apiserver/application/deploy.go
+++ b/apiserver/application/deploy.go
@@ -50,7 +50,7 @@ type UnitAssigner interface {
 }
 
 type UnitAdder interface {
-	AddUnit() (*state.Unit, error)
+	AddUnit(state.AddUnitParams) (*state.Unit, error)
 }
 
 // DeployApplication takes a charm and various parameters and deploys it.
@@ -178,7 +178,7 @@ func addUnits(
 	policy := state.AssignCleanEmpty
 	// TODO what do we do if we fail half-way through this process?
 	for i := 0; i < n; i++ {
-		unit, err := unitAdder.AddUnit()
+		unit, err := unitAdder.AddUnit(state.AddUnitParams{})
 		if err != nil {
 			return nil, errors.Annotatef(err, "cannot add unit %d/%d to application %q", i+1, n, appName)
 		}

--- a/apiserver/authentication/agent_test.go
+++ b/apiserver/authentication/agent_test.go
@@ -55,7 +55,7 @@ func (s *agentAuthenticatorSuite) SetUpTest(c *gc.C) {
 	// add a unit for testing unit agent authentication
 	wordpress := s.AddTestingService(c, "wordpress", s.AddTestingCharm(c, "wordpress"))
 	c.Assert(err, jc.ErrorIsNil)
-	unit, err := wordpress.AddUnit()
+	unit, err := wordpress.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	s.unit = unit
 	password, err = utils.RandomPassword()

--- a/apiserver/authentication/user_test.go
+++ b/apiserver/authentication/user_test.go
@@ -70,7 +70,7 @@ func (s *userAuthenticatorSuite) TestMachineLoginFails(c *gc.C) {
 func (s *userAuthenticatorSuite) TestUnitLoginFails(c *gc.C) {
 	// add a unit for testing unit agent authentication
 	wordpress := s.AddTestingService(c, "wordpress", s.AddTestingCharm(c, "wordpress"))
-	unit, err := wordpress.AddUnit()
+	unit, err := wordpress.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	password, err := utils.RandomPassword()
 	c.Assert(err, jc.ErrorIsNil)

--- a/apiserver/charmrevisionupdater/testing/suite.go
+++ b/apiserver/charmrevisionupdater/testing/suite.go
@@ -127,7 +127,7 @@ func (s *CharmSuite) AddService(c *gc.C, charmName, serviceName string) {
 func (s *CharmSuite) AddUnit(c *gc.C, serviceName, machineId string) {
 	svc, err := s.jcSuite.State.Application(serviceName)
 	c.Assert(err, jc.ErrorIsNil)
-	u, err := svc.AddUnit()
+	u, err := svc.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	m, err := s.jcSuite.State.Machine(machineId)
 	c.Assert(err, jc.ErrorIsNil)

--- a/apiserver/client/api_test.go
+++ b/apiserver/client/api_test.go
@@ -416,7 +416,7 @@ func (s *baseSuite) setUpScenario(c *gc.C) (entities []names.Tag) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	for i := 0; i < 2; i++ {
-		wu, err := wordpress.AddUnit()
+		wu, err := wordpress.AddUnit(state.AddUnitParams{})
 		c.Assert(err, jc.ErrorIsNil)
 		c.Assert(wu.Tag(), gc.Equals, names.NewUnitTag(fmt.Sprintf("wordpress/%d", i)))
 		setDefaultPassword(c, wu)

--- a/apiserver/client/client_test.go
+++ b/apiserver/client/client_test.go
@@ -495,7 +495,7 @@ func (s *clientSuite) setupDestroyMachinesTest(c *gc.C) (*state.Machine, *state.
 
 	sch := s.AddTestingCharm(c, "wordpress")
 	wordpress := s.AddTestingService(c, "wordpress", sch)
-	u, err := wordpress.AddUnit()
+	u, err := wordpress.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	err = u.AssignToMachine(m1)
 	c.Assert(err, jc.ErrorIsNil)

--- a/apiserver/client/status_test.go
+++ b/apiserver/client/status_test.go
@@ -156,7 +156,7 @@ func (s *statusUnitTestSuite) TestMeterStatus(c *gc.C) {
 	c.Assert(units, gc.HasLen, 0)
 
 	for i, unit := range testUnits {
-		u, err := service.AddUnit()
+		u, err := service.AddUnit(state.AddUnitParams{})
 		testUnits[i].unitName = u.Name()
 		c.Assert(err, jc.ErrorIsNil)
 		if unit.setStatus != nil {
@@ -193,7 +193,7 @@ func (s *statusUnitTestSuite) TestNoMeterStatusWhenNotRequired(c *gc.C) {
 	c.Assert(units, gc.HasLen, 0)
 
 	for i, unit := range testUnits {
-		u, err := service.AddUnit()
+		u, err := service.AddUnit(state.AddUnitParams{})
 		testUnits[i].unitName = u.Name()
 		c.Assert(err, jc.ErrorIsNil)
 		if unit.setStatus != nil {
@@ -221,7 +221,7 @@ func (s *statusUnitTestSuite) TestMeterStatusWithCredentials(c *gc.C) {
 	c.Assert(units, gc.HasLen, 0)
 
 	for i, unit := range testUnits {
-		u, err := service.AddUnit()
+		u, err := service.AddUnit(state.AddUnitParams{})
 		testUnits[i].unitName = u.Name()
 		c.Assert(err, jc.ErrorIsNil)
 		if unit.setStatus != nil {
@@ -251,7 +251,7 @@ func (s *statusUnitTestSuite) TestMeterStatusWithCredentials(c *gc.C) {
 }
 
 func addUnitWithVersion(c *gc.C, application *state.Application, version string) *state.Unit {
-	unit, err := application.AddUnit()
+	unit, err := application.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	// Ensure that the timestamp on this version record is different
 	// from the previous one.
@@ -316,7 +316,7 @@ func (s *statusUnitTestSuite) TestWorkloadVersionNoUnits(c *gc.C) {
 
 func (s *statusUnitTestSuite) TestWorkloadVersionOkWithUnset(c *gc.C) {
 	application := s.Factory.MakeApplication(c, nil)
-	unit, err := application.AddUnit()
+	unit, err := application.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	appStatus := s.checkAppVersion(c, application, "")
 	checkUnitVersion(c, appStatus, unit, "")

--- a/apiserver/deployer/deployer_test.go
+++ b/apiserver/deployer/deployer_test.go
@@ -68,12 +68,12 @@ func (s *deployerSuite) SetUpTest(c *gc.C) {
 	rel, err := s.State.AddRelation(eps...)
 	c.Assert(err, jc.ErrorIsNil)
 
-	s.principal0, err = s.service0.AddUnit()
+	s.principal0, err = s.service0.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	err = s.principal0.AssignToMachine(s.machine1)
 	c.Assert(err, jc.ErrorIsNil)
 
-	s.principal1, err = s.service0.AddUnit()
+	s.principal1, err = s.service0.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	err = s.principal1.AssignToMachine(s.machine0)
 	c.Assert(err, jc.ErrorIsNil)

--- a/apiserver/firewaller/firewaller_base_test.go
+++ b/apiserver/firewaller/firewaller_base_test.go
@@ -53,7 +53,7 @@ func (s *firewallerBaseSuite) setUpTest(c *gc.C) {
 	s.service = s.AddTestingService(c, "wordpress", s.charm)
 	// Add the rest of the units and assign them.
 	for i := 0; i <= 2; i++ {
-		unit, err := s.service.AddUnit()
+		unit, err := s.service.AddUnit(state.AddUnitParams{})
 		c.Check(err, jc.ErrorIsNil)
 		err = unit.AssignToMachine(s.machines[i])
 		c.Check(err, jc.ErrorIsNil)

--- a/apiserver/provisioner/provisioner_test.go
+++ b/apiserver/provisioner/provisioner_test.go
@@ -823,7 +823,7 @@ func (s *withoutControllerSuite) TestDistributionGroup(c *gc.C) {
 	addUnits := func(name string, machines ...*state.Machine) (units []*state.Unit) {
 		svc := s.AddTestingService(c, name, s.AddTestingCharm(c, name))
 		for _, m := range machines {
-			unit, err := svc.AddUnit()
+			unit, err := svc.AddUnit(state.AddUnitParams{})
 			c.Assert(err, jc.ErrorIsNil)
 			err = unit.AssignToMachine(m)
 			c.Assert(err, jc.ErrorIsNil)

--- a/apiserver/provisioner/provisioninginfo_test.go
+++ b/apiserver/provisioner/provisioninginfo_test.go
@@ -197,7 +197,7 @@ func (s *withoutControllerSuite) TestProvisioningInfoWithEndpointBindings(c *gc.
 	}
 	wordpressCharm := s.AddTestingCharm(c, "wordpress")
 	wordpressService := s.AddTestingServiceWithBindings(c, "wordpress", wordpressCharm, bindings)
-	wordpressUnit, err := wordpressService.AddUnit()
+	wordpressUnit, err := wordpressService.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	err = wordpressUnit.AssignToMachine(wordpressMachine)
 	c.Assert(err, jc.ErrorIsNil)

--- a/apiserver/uniter/uniter_test.go
+++ b/apiserver/uniter/uniter_test.go
@@ -284,7 +284,7 @@ func (s *uniterSuite) TestLife(c *gc.C) {
 
 	// Add another unit, so the service will stay dying when we
 	// destroy it later.
-	extraUnit, err := s.wordpress.AddUnit()
+	extraUnit, err := s.wordpress.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(extraUnit, gc.NotNil)
 
@@ -2275,7 +2275,7 @@ func (s *uniterSuite) TestStorageAttachments(c *gc.C) {
 		"data": {Pool: "", Size: 1024, Count: 1},
 	}
 	service := s.AddTestingServiceWithStorage(c, "storage-block", ch, sCons)
-	unit, err := service.AddUnit()
+	unit, err := service.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	err = s.State.AssignUnit(unit, state.AssignCleanEmpty)
 	c.Assert(err, jc.ErrorIsNil)
@@ -2407,7 +2407,7 @@ func (s *uniterSuite) TestAllMachinePorts(c *gc.C) {
 	c.Assert(unitPorts, gc.HasLen, 0)
 
 	// Add another mysql unit on machine 0.
-	mysqlUnit1, err := s.mysql.AddUnit()
+	mysqlUnit1, err := s.mysql.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	err = mysqlUnit1.AssignToMachine(s.machine0)
 	c.Assert(err, jc.ErrorIsNil)

--- a/apiserver/upgrader/unitupgrader_test.go
+++ b/apiserver/upgrader/unitupgrader_test.go
@@ -56,7 +56,7 @@ func (s *unitUpgraderSuite) SetUpTest(c *gc.C) {
 	_, err = s.State.AddMachine("quantal", state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)
 	svc := s.AddTestingService(c, "wordpress", s.AddTestingCharm(c, "wordpress"))
-	s.rawUnit, err = svc.AddUnit()
+	s.rawUnit, err = svc.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	// Assign the unit to the machine.
 	s.rawMachine, err = s.rawUnit.AssignToCleanMachine()

--- a/cmd/juju/setmeterstatus/setmeterstatus_test.go
+++ b/cmd/juju/setmeterstatus/setmeterstatus_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/juju/juju/cmd/juju/setmeterstatus"
 	"github.com/juju/juju/cmd/modelcmd"
 	jujutesting "github.com/juju/juju/juju/testing"
+	"github.com/juju/juju/state"
 	coretesting "github.com/juju/juju/testing"
 	"github.com/juju/juju/testing/factory"
 )
@@ -96,9 +97,9 @@ func (s *DebugMetricsCommandSuite) TestUnits(c *gc.C) {
 func (s *DebugMetricsCommandSuite) TestService(c *gc.C) {
 	charm := s.Factory.MakeCharm(c, &factory.CharmParams{Name: "mysql", URL: "local:quantal/mysql-1"})
 	service := s.Factory.MakeApplication(c, &factory.ApplicationParams{Charm: charm})
-	unit0, err := service.AddUnit()
+	unit0, err := service.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
-	unit1, err := service.AddUnit()
+	unit1, err := service.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	_, err = cmdtesting.RunCommand(c, setmeterstatus.New(), "mysql", "RED", "--info", "foobar")
 	c.Assert(err, jc.ErrorIsNil)

--- a/cmd/juju/status/status_test.go
+++ b/cmd/juju/status/status_test.go
@@ -3317,7 +3317,7 @@ type addUnit struct {
 func (au addUnit) step(c *gc.C, ctx *context) {
 	s, err := ctx.st.Application(au.serviceName)
 	c.Assert(err, jc.ErrorIsNil)
-	u, err := s.AddUnit()
+	u, err := s.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	m, err := ctx.st.Machine(au.machineId)
 	c.Assert(err, jc.ErrorIsNil)
@@ -3333,7 +3333,7 @@ type addAliveUnit struct {
 func (aau addAliveUnit) step(c *gc.C, ctx *context) {
 	s, err := ctx.st.Application(aau.serviceName)
 	c.Assert(err, jc.ErrorIsNil)
-	u, err := s.AddUnit()
+	u, err := s.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	pinger := ctx.setAgentPresence(c, u)
 	m, err := ctx.st.Machine(aau.machineId)

--- a/cmd/jujud/agent/machine_test.go
+++ b/cmd/jujud/agent/machine_test.go
@@ -250,9 +250,9 @@ func (s *MachineSuite) TestHostUnits(c *gc.C) {
 
 	// check that unassigned units don't trigger any deployments.
 	svc := s.AddTestingService(c, "wordpress", s.AddTestingCharm(c, "wordpress"))
-	u0, err := svc.AddUnit()
+	u0, err := svc.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
-	u1, err := svc.AddUnit()
+	u1, err := svc.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 
 	ctx.waitDeployed(c)
@@ -343,7 +343,7 @@ func (s *MachineSuite) TestManageModel(c *gc.C) {
 	svc := s.AddTestingService(c, "test-service", charm)
 	err := svc.SetExposed()
 	c.Assert(err, jc.ErrorIsNil)
-	unit, err := svc.AddUnit()
+	unit, err := svc.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	err = s.State.AssignUnit(unit, state.AssignCleanEmpty)
 	c.Assert(err, jc.ErrorIsNil)
@@ -395,7 +395,7 @@ func (s *MachineSuite) TestManageModelRunsInstancePoller(c *gc.C) {
 	// Add one unit to a service;
 	charm := s.AddTestingCharm(c, "dummy")
 	svc := s.AddTestingService(c, "test-service", charm)
-	unit, err := svc.AddUnit()
+	unit, err := svc.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	err = s.State.AssignUnit(unit, state.AssignCleanEmpty)
 	c.Assert(err, jc.ErrorIsNil)
@@ -694,7 +694,7 @@ func (s *MachineSuite) TestManageModelRunsCleaner(c *gc.C) {
 	s.assertJobWithState(c, state.JobManageModel, func(conf agent.Config, agentState *state.State) {
 		// Create a service and unit, and destroy the service.
 		service := s.AddTestingService(c, "wordpress", s.AddTestingCharm(c, "wordpress"))
-		unit, err := service.AddUnit()
+		unit, err := service.AddUnit(state.AddUnitParams{})
 		c.Assert(err, jc.ErrorIsNil)
 		err = service.Destroy()
 		c.Assert(err, jc.ErrorIsNil)

--- a/environs/jujutest/livetests.go
+++ b/environs/jujutest/livetests.go
@@ -659,7 +659,7 @@ func (t *LiveTests) TestBootstrapAndDeploy(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	svc, err := st.AddApplication(state.AddApplicationArgs{Name: "dummy", Charm: sch})
 	c.Assert(err, jc.ErrorIsNil)
-	unit, err := svc.AddUnit()
+	unit, err := svc.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	err = st.AssignUnit(unit, state.AssignCleanEmpty)
 	c.Assert(err, jc.ErrorIsNil)

--- a/featuretests/application_config_test.go
+++ b/featuretests/application_config_test.go
@@ -61,7 +61,7 @@ func (s *ApplicationConfigSuite) SetUpTest(c *gc.C) {
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
-	unit, err := app.AddUnit()
+	unit, err := app.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	unit.SetCharmURL(s.charm.URL())
 

--- a/featuretests/remoterelations_test.go
+++ b/featuretests/remoterelations_test.go
@@ -152,7 +152,7 @@ func (s *remoteRelationsSuite) TestWatchLocalRelationUnits(c *gc.C) {
 
 	// Add a unit of wordpress, expect a change.
 	settings := map[string]interface{}{"key": "value"}
-	wordpress0, err := wordpress.AddUnit()
+	wordpress0, err := wordpress.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	ru, err := rel.Unit(wordpress0)
 	c.Assert(err, jc.ErrorIsNil)

--- a/featuretests/storage_test.go
+++ b/featuretests/storage_test.go
@@ -49,7 +49,7 @@ func createUnitWithStorage(c *gc.C, s *jujutesting.JujuConnSuite, poolName strin
 		"data": makeStorageCons(poolName, 1024, 1),
 	}
 	service := s.AddTestingServiceWithStorage(c, "storage-block", ch, storage)
-	unit, err := service.AddUnit()
+	unit, err := service.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	err = s.State.AssignUnit(unit, state.AssignCleanEmpty)
 	c.Assert(err, jc.ErrorIsNil)
@@ -611,7 +611,7 @@ func createUnitWithFileSystemStorage(c *gc.C, s *jujutesting.JujuConnSuite, pool
 		"data": makeStorageCons(poolName, 1024, 1),
 	}
 	service := s.AddTestingServiceWithStorage(c, "storage-filesystem", ch, storage)
-	unit, err := service.AddUnit()
+	unit, err := service.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	err = s.State.AssignUnit(unit, state.AssignCleanEmpty)
 	c.Assert(err, jc.ErrorIsNil)
@@ -623,7 +623,7 @@ func (s *cmdStorageSuite) TestStorageDetachAttach(c *gc.C) {
 	u := createUnitWithStorage(c, &s.JujuConnSuite, testPool)
 	app, err := s.State.Application("storage-block")
 	c.Assert(err, jc.ErrorIsNil)
-	u2, err := app.AddUnit()
+	u2, err := app.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	err = s.State.AssignUnit(u2, state.AssignCleanEmpty)
 	c.Assert(err, jc.ErrorIsNil)

--- a/network/containerizer/bridgepolicy_test.go
+++ b/network/containerizer/bridgepolicy_test.go
@@ -343,7 +343,7 @@ func (s *bridgePolicyStateSuite) TestPopulateContainerLinkLayerDevicesUnitBindin
 	s.assertNoDevicesOnMachine(c, s.containerMachine)
 	svc := addApplication(c, s.State, "", "mysql",
 		addCharm(c, s.State, "quantal", "mysql"), map[string]string{"server": "default"})
-	unit, err := svc.AddUnit()
+	unit, err := svc.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	err = unit.AssignToMachine(s.containerMachine)
 	c.Assert(err, jc.ErrorIsNil)

--- a/state/action_test.go
+++ b/state/action_test.go
@@ -52,25 +52,25 @@ func (s *ActionSuite) SetUpTest(c *gc.C) {
 	actionlessSURL, _ := s.actionlessService.CharmURL()
 	c.Assert(actionlessSURL, gc.NotNil)
 
-	s.unit, err = s.service.AddUnit()
+	s.unit, err = s.service.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(s.unit.Series(), gc.Equals, "quantal")
 
 	err = s.unit.SetCharmURL(sURL)
 	c.Assert(err, jc.ErrorIsNil)
 
-	s.unit2, err = s.service.AddUnit()
+	s.unit2, err = s.service.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(s.unit2.Series(), gc.Equals, "quantal")
 
 	err = s.unit2.SetCharmURL(sURL)
 	c.Assert(err, jc.ErrorIsNil)
 
-	s.charmlessUnit, err = s.service.AddUnit()
+	s.charmlessUnit, err = s.service.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(s.charmlessUnit.Series(), gc.Equals, "quantal")
 
-	s.actionlessUnit, err = s.actionlessService.AddUnit()
+	s.actionlessUnit, err = s.actionlessService.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(s.actionlessUnit.Series(), gc.Equals, "quantal")
 
@@ -283,7 +283,7 @@ func makeUnits(c *gc.C, s *ActionSuite, units map[string]*state.Unit, schemas ma
 
 		// Add a unit
 		var err error
-		u, err := svc.AddUnit()
+		u, err := svc.AddUnit(state.AddUnitParams{})
 		c.Assert(err, jc.ErrorIsNil)
 		c.Assert(u.Series(), gc.Equals, "quantal")
 		err = u.SetCharmURL(sURL)
@@ -532,7 +532,7 @@ func (s *ActionSuite) TestActionsWatcherEmitsInitialChanges(c *gc.C) {
 
 	// preamble
 	svc := s.AddTestingService(c, "dummy3", s.charm)
-	unit, err := svc.AddUnit()
+	unit, err := svc.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	u, err := s.State.Unit(unit.Name())
 	c.Assert(err, jc.ErrorIsNil)
@@ -744,7 +744,7 @@ func (s *ActionSuite) TestMakeIdFilter(c *gc.C) {
 
 func (s *ActionSuite) TestWatchActionNotifications(c *gc.C) {
 	svc := s.AddTestingService(c, "dummy2", s.charm)
-	u, err := svc.AddUnit()
+	u, err := svc.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 
 	w := u.WatchActionNotifications()

--- a/state/allwatcher_internal_test.go
+++ b/state/allwatcher_internal_test.go
@@ -165,7 +165,7 @@ func (s *allWatcherBaseSuite) setUpScenario(c *gc.C, st *State, units int, inclu
 	})
 
 	for i := 0; i < units; i++ {
-		wu, err := wordpress.AddUnit()
+		wu, err := wordpress.AddUnit(AddUnitParams{})
 		c.Assert(err, jc.ErrorIsNil)
 		c.Assert(wu.Tag().String(), gc.Equals, fmt.Sprintf("unit-wordpress-%d", i))
 
@@ -594,7 +594,7 @@ func (s *allWatcherStateSuite) TestChangeActions(c *gc.C) {
 	changeTestFuncs := []changeTestFunc{
 		func(c *gc.C, st *State) changeTestCase {
 			wordpress := AddTestingService(c, st, "wordpress", AddTestingCharm(c, st, "wordpress"))
-			u, err := wordpress.AddUnit()
+			u, err := wordpress.AddUnit(AddUnitParams{})
 			c.Assert(err, jc.ErrorIsNil)
 			action, err := st.EnqueueAction(u.Tag(), "vacuumdb", map[string]interface{}{})
 			c.Assert(err, jc.ErrorIsNil)
@@ -696,7 +696,7 @@ func (s *allWatcherStateSuite) TestChangeBlocks(c *gc.C) {
 func (s *allWatcherStateSuite) TestClosingPorts(c *gc.C) {
 	// Init the test model.
 	wordpress := AddTestingService(c, s.state, "wordpress", AddTestingCharm(c, s.state, "wordpress"))
-	u, err := wordpress.AddUnit()
+	u, err := wordpress.AddUnit(AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	m, err := s.state.AddMachine("quantal", JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)
@@ -970,7 +970,7 @@ func (s *allWatcherStateSuite) TestStateWatcher(c *gc.C) {
 	c.Assert(m2.Id(), gc.Equals, "2")
 
 	wordpress := AddTestingService(c, s.state, "wordpress", AddTestingCharm(c, s.state, "wordpress"))
-	wu, err := wordpress.AddUnit()
+	wu, err := wordpress.AddUnit(AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	err = wu.AssignToMachine(m2)
 	c.Assert(err, jc.ErrorIsNil)
@@ -1097,7 +1097,7 @@ func (s *allWatcherStateSuite) TestStateWatcherTwoModels(c *gc.C) {
 				app, err := st.Application("wordpress")
 				c.Assert(err, jc.ErrorIsNil)
 
-				_, err = app.AddUnit()
+				_, err = app.AddUnit(AddUnitParams{})
 				c.Assert(err, jc.ErrorIsNil)
 				return 3
 			},
@@ -1798,7 +1798,7 @@ func (s *allModelWatcherStateSuite) TestStateWatcher(c *gc.C) {
 	c.Assert(m11.Id(), gc.Equals, "1")
 
 	wordpress := AddTestingService(c, st1, "wordpress", AddTestingCharm(c, st1, "wordpress"))
-	wu, err := wordpress.AddUnit()
+	wu, err := wordpress.AddUnit(AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	err = wu.AssignToMachine(m11)
 	c.Assert(err, jc.ErrorIsNil)
@@ -2621,7 +2621,7 @@ func testChangeUnits(c *gc.C, owner names.UserTag, runChangeTests func(*gc.C, []
 		},
 		func(c *gc.C, st *State) changeTestCase {
 			wordpress := AddTestingService(c, st, "wordpress", AddTestingCharm(c, st, "wordpress"))
-			u, err := wordpress.AddUnit()
+			u, err := wordpress.AddUnit(AddUnitParams{})
 			c.Assert(err, jc.ErrorIsNil)
 			m, err := st.AddMachine("quantal", JobHostUnits)
 			c.Assert(err, jc.ErrorIsNil)
@@ -2682,7 +2682,7 @@ func testChangeUnits(c *gc.C, owner names.UserTag, runChangeTests func(*gc.C, []
 		},
 		func(c *gc.C, st *State) changeTestCase {
 			wordpress := AddTestingService(c, st, "wordpress", AddTestingCharm(c, st, "wordpress"))
-			u, err := wordpress.AddUnit()
+			u, err := wordpress.AddUnit(AddUnitParams{})
 			c.Assert(err, jc.ErrorIsNil)
 			m, err := st.AddMachine("quantal", JobHostUnits)
 			c.Assert(err, jc.ErrorIsNil)
@@ -2738,7 +2738,7 @@ func testChangeUnits(c *gc.C, owner names.UserTag, runChangeTests func(*gc.C, []
 		},
 		func(c *gc.C, st *State) changeTestCase {
 			wordpress := AddTestingService(c, st, "wordpress", AddTestingCharm(c, st, "wordpress"))
-			u, err := wordpress.AddUnit()
+			u, err := wordpress.AddUnit(AddUnitParams{})
 			c.Assert(err, jc.ErrorIsNil)
 			m, err := st.AddMachine("quantal", JobHostUnits)
 			c.Assert(err, jc.ErrorIsNil)
@@ -2778,7 +2778,7 @@ func testChangeUnits(c *gc.C, owner names.UserTag, runChangeTests func(*gc.C, []
 		},
 		func(c *gc.C, st *State) changeTestCase {
 			wordpress := AddTestingService(c, st, "wordpress", AddTestingCharm(c, st, "wordpress"))
-			u, err := wordpress.AddUnit()
+			u, err := wordpress.AddUnit(AddUnitParams{})
 			c.Assert(err, jc.ErrorIsNil)
 			m, err := st.AddMachine("quantal", JobHostUnits)
 			c.Assert(err, jc.ErrorIsNil)
@@ -2826,7 +2826,7 @@ func testChangeUnits(c *gc.C, owner names.UserTag, runChangeTests func(*gc.C, []
 		},
 		func(c *gc.C, st *State) changeTestCase {
 			wordpress := AddTestingService(c, st, "wordpress", AddTestingCharm(c, st, "wordpress"))
-			u, err := wordpress.AddUnit()
+			u, err := wordpress.AddUnit(AddUnitParams{})
 			c.Assert(err, jc.ErrorIsNil)
 			m, err := st.AddMachine("quantal", JobHostUnits)
 			c.Assert(err, jc.ErrorIsNil)
@@ -2927,7 +2927,7 @@ func testChangeUnits(c *gc.C, owner names.UserTag, runChangeTests func(*gc.C, []
 		},
 		func(c *gc.C, st *State) changeTestCase {
 			wordpress := AddTestingService(c, st, "wordpress", AddTestingCharm(c, st, "wordpress"))
-			u, err := wordpress.AddUnit()
+			u, err := wordpress.AddUnit(AddUnitParams{})
 			c.Assert(err, jc.ErrorIsNil)
 			err = u.AssignToNewMachine()
 			c.Assert(err, jc.ErrorIsNil)
@@ -2982,7 +2982,7 @@ func testChangeUnits(c *gc.C, owner names.UserTag, runChangeTests func(*gc.C, []
 		},
 		func(c *gc.C, st *State) changeTestCase {
 			wordpress := AddTestingService(c, st, "wordpress", AddTestingCharm(c, st, "wordpress"))
-			u, err := wordpress.AddUnit()
+			u, err := wordpress.AddUnit(AddUnitParams{})
 			c.Assert(err, jc.ErrorIsNil)
 			now := testing.ZeroTime()
 			sInfo := status.StatusInfo{
@@ -3044,7 +3044,7 @@ func testChangeUnits(c *gc.C, owner names.UserTag, runChangeTests func(*gc.C, []
 		},
 		func(c *gc.C, st *State) changeTestCase {
 			wordpress := AddTestingService(c, st, "wordpress", AddTestingCharm(c, st, "wordpress"))
-			u, err := wordpress.AddUnit()
+			u, err := wordpress.AddUnit(AddUnitParams{})
 			c.Assert(err, jc.ErrorIsNil)
 			now := testing.ZeroTime()
 			sInfo := status.StatusInfo{
@@ -3104,7 +3104,7 @@ func testChangeUnits(c *gc.C, owner names.UserTag, runChangeTests func(*gc.C, []
 		},
 		func(c *gc.C, st *State) changeTestCase {
 			wordpress := AddTestingService(c, st, "wordpress", AddTestingCharm(c, st, "wordpress"))
-			u, err := wordpress.AddUnit()
+			u, err := wordpress.AddUnit(AddUnitParams{})
 			c.Assert(err, jc.ErrorIsNil)
 			err = u.AssignToNewMachine()
 			c.Assert(err, jc.ErrorIsNil)
@@ -3196,7 +3196,7 @@ const (
 func testChangeUnitsNonNilPorts(c *gc.C, owner names.UserTag, runChangeTests func(*gc.C, []changeTestFunc)) {
 	initEnv := func(c *gc.C, st *State, flag initFlag) {
 		wordpress := AddTestingService(c, st, "wordpress", AddTestingCharm(c, st, "wordpress"))
-		u, err := wordpress.AddUnit()
+		u, err := wordpress.AddUnit(AddUnitParams{})
 		c.Assert(err, jc.ErrorIsNil)
 		m, err := st.AddMachine("quantal", JobHostUnits)
 		c.Assert(err, jc.ErrorIsNil)
@@ -3408,7 +3408,7 @@ func testChangeRemoteApplications(c *gc.C, runChangeTests func(*gc.C, []changeTe
 			rel, err := st.AddRelation(eps[0], eps[1])
 			c.Assert(err, jc.ErrorIsNil)
 
-			wu, err := wordpress.AddUnit()
+			wu, err := wordpress.AddUnit(AddUnitParams{})
 			c.Assert(err, jc.ErrorIsNil)
 			wru, err := rel.Unit(wu)
 			c.Assert(err, jc.ErrorIsNil)

--- a/state/application.go
+++ b/state/application.go
@@ -1251,8 +1251,11 @@ func (a *Application) incUnitCountOp(asserts bson.D) txn.Op {
 	return op
 }
 
+// AddUnitParams contains parameters for the Application.AddUnit method.
+type AddUnitParams struct{}
+
 // AddUnit adds a new principal unit to the application.
-func (a *Application) AddUnit() (unit *Unit, err error) {
+func (a *Application) AddUnit(args AddUnitParams) (unit *Unit, err error) {
 	defer errors.DeferredAnnotatef(&err, "cannot add unit to application %q", a)
 	name, ops, err := a.addUnitOps("", nil)
 	if err != nil {

--- a/state/application_test.go
+++ b/state/application_test.go
@@ -469,7 +469,7 @@ func (s *ApplicationSuite) TestSetCharmConfig(c *gc.C) {
 func (s *ApplicationSuite) TestSetCharmWithDyingService(c *gc.C) {
 	sch := s.AddMetaCharm(c, "mysql", metaBase, 2)
 
-	_, err := s.mysql.AddUnit()
+	_, err := s.mysql.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	err = s.mysql.Destroy()
 	c.Assert(err, jc.ErrorIsNil)
@@ -483,7 +483,7 @@ func (s *ApplicationSuite) TestSetCharmWithDyingService(c *gc.C) {
 }
 
 func (s *ApplicationSuite) TestSequenceUnitIdsAfterDestroy(c *gc.C) {
-	unit, err := s.mysql.AddUnit()
+	unit, err := s.mysql.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(unit.Name(), gc.Equals, "mysql/0")
 	err = unit.Destroy()
@@ -491,16 +491,16 @@ func (s *ApplicationSuite) TestSequenceUnitIdsAfterDestroy(c *gc.C) {
 	err = s.mysql.Destroy()
 	c.Assert(err, jc.ErrorIsNil)
 	s.mysql = s.AddTestingService(c, "mysql", s.charm)
-	unit, err = s.mysql.AddUnit()
+	unit, err = s.mysql.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(unit.Name(), gc.Equals, "mysql/1")
 }
 
 func (s *ApplicationSuite) TestSequenceUnitIds(c *gc.C) {
-	unit, err := s.mysql.AddUnit()
+	unit, err := s.mysql.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(unit.Name(), gc.Equals, "mysql/0")
-	unit, err = s.mysql.AddUnit()
+	unit, err = s.mysql.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(unit.Name(), gc.Equals, "mysql/1")
 }
@@ -509,7 +509,7 @@ func (s *ApplicationSuite) TestSetCharmWhenDead(c *gc.C) {
 	sch := s.AddMetaCharm(c, "mysql", metaBase, 2)
 
 	defer state.SetBeforeHooks(c, s.State, func() {
-		_, err := s.mysql.AddUnit()
+		_, err := s.mysql.AddUnit(state.AddUnitParams{})
 		err = s.mysql.Destroy()
 		c.Assert(err, jc.ErrorIsNil)
 		assertLife(c, s.mysql, state.Dying)
@@ -572,7 +572,7 @@ func (s *ApplicationSuite) TestSetCharmWhenDyingIsOK(c *gc.C) {
 	sch := s.AddMetaCharm(c, "mysql", metaBase, 2)
 
 	defer state.SetBeforeHooks(c, s.State, func() {
-		_, err := s.mysql.AddUnit()
+		_, err := s.mysql.AddUnit(state.AddUnitParams{})
 		c.Assert(err, jc.ErrorIsNil)
 		err = s.mysql.Destroy()
 		c.Assert(err, jc.ErrorIsNil)
@@ -669,9 +669,9 @@ func (s *ApplicationSuite) TestSetCharmRetriesWhenBothOldAndNewSettingsChanged(c
 				// and newCh settings greater than 0, while the service's
 				// charm URLs change between oldCh and newCh. Ensure
 				// refcounts change as expected.
-				unit1, err := s.mysql.AddUnit()
+				unit1, err := s.mysql.AddUnit(state.AddUnitParams{})
 				c.Assert(err, jc.ErrorIsNil)
-				unit2, err := s.mysql.AddUnit()
+				unit2, err := s.mysql.AddUnit(state.AddUnitParams{})
 				c.Assert(err, jc.ErrorIsNil)
 				cfg := state.SetCharmConfig{Charm: newCh}
 				err = s.mysql.SetCharm(cfg)
@@ -974,7 +974,7 @@ func (s *ApplicationSuite) TestSettingsRefCountWorks(c *gc.C) {
 
 	// Adding a unit without a charm URL set does not affect the
 	// refcount.
-	u, err := svc.AddUnit()
+	u, err := svc.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	curl, ok := u.CharmURL()
 	c.Assert(ok, jc.IsFalse)
@@ -1028,7 +1028,7 @@ func (s *ApplicationSuite) TestSettingsRefCreateRace(c *gc.C) {
 	appName := "mywp"
 
 	app := s.AddTestingService(c, appName, oldCh)
-	unit, err := app.AddUnit()
+	unit, err := app.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 
 	// just before setting the unit charm url, switch the service
@@ -1053,7 +1053,7 @@ func (s *ApplicationSuite) TestSettingsRefRemoveRace(c *gc.C) {
 	appName := "mywp"
 
 	app := s.AddTestingService(c, appName, oldCh)
-	unit, err := app.AddUnit()
+	unit, err := app.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 
 	// just before updating the app charm url, set that charm url on
@@ -1373,7 +1373,7 @@ func (s *ApplicationSuite) TestServiceExposed(c *gc.C) {
 
 	// Make the service Dying and check that ClearExposed and SetExposed fail.
 	// TODO(fwereade): maybe service destruction should always unexpose?
-	u, err := s.mysql.AddUnit()
+	u, err := s.mysql.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	err = s.mysql.Destroy()
 	c.Assert(err, jc.ErrorIsNil)
@@ -1395,14 +1395,14 @@ func (s *ApplicationSuite) TestServiceExposed(c *gc.C) {
 
 func (s *ApplicationSuite) TestAddUnit(c *gc.C) {
 	// Check that principal units can be added on their own.
-	unitZero, err := s.mysql.AddUnit()
+	unitZero, err := s.mysql.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(unitZero.Name(), gc.Equals, "mysql/0")
 	c.Assert(unitZero.IsPrincipal(), jc.IsTrue)
 	c.Assert(unitZero.SubordinateNames(), gc.HasLen, 0)
 	c.Assert(state.GetUnitModelUUID(unitZero), gc.Equals, s.State.ModelUUID())
 
-	unitOne, err := s.mysql.AddUnit()
+	unitOne, err := s.mysql.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(unitOne.Name(), gc.Equals, "mysql/1")
 	c.Assert(unitOne.IsPrincipal(), jc.IsTrue)
@@ -1418,7 +1418,7 @@ func (s *ApplicationSuite) TestAddUnit(c *gc.C) {
 	// to add a subordinate unit.
 	subCharm := s.AddTestingCharm(c, "logging")
 	logging := s.AddTestingService(c, "logging", subCharm)
-	_, err = logging.AddUnit()
+	_, err = logging.AddUnit(state.AddUnitParams{})
 	c.Assert(err, gc.ErrorMatches, `cannot add unit to application "logging": application is a subordinate`)
 
 	// Indirectly create a subordinate unit by adding a relation and entering
@@ -1446,24 +1446,24 @@ func (s *ApplicationSuite) TestAddUnit(c *gc.C) {
 }
 
 func (s *ApplicationSuite) TestAddUnitWhenNotAlive(c *gc.C) {
-	u, err := s.mysql.AddUnit()
+	u, err := s.mysql.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	err = s.mysql.Destroy()
 	c.Assert(err, jc.ErrorIsNil)
-	_, err = s.mysql.AddUnit()
+	_, err = s.mysql.AddUnit(state.AddUnitParams{})
 	c.Assert(err, gc.ErrorMatches, `cannot add unit to application "mysql": application is not alive`)
 	err = u.EnsureDead()
 	c.Assert(err, jc.ErrorIsNil)
 	err = u.Remove()
 	c.Assert(err, jc.ErrorIsNil)
-	_, err = s.mysql.AddUnit()
+	_, err = s.mysql.AddUnit(state.AddUnitParams{})
 	c.Assert(err, gc.ErrorMatches, `cannot add unit to application "mysql": application "mysql" not found`)
 }
 
 func (s *ApplicationSuite) TestReadUnit(c *gc.C) {
-	_, err := s.mysql.AddUnit()
+	_, err := s.mysql.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
-	_, err = s.mysql.AddUnit()
+	_, err = s.mysql.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Check that retrieving a unit from state works correctly.
@@ -1487,7 +1487,7 @@ func (s *ApplicationSuite) TestReadUnit(c *gc.C) {
 
 func (s *ApplicationSuite) TestReadUnitWhenDying(c *gc.C) {
 	// Test that we can still read units when the service is Dying...
-	unit, err := s.mysql.AddUnit()
+	unit, err := s.mysql.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	preventUnitDestroyRemove(c, unit)
 	err = s.mysql.Destroy()
@@ -1521,7 +1521,7 @@ func (s *ApplicationSuite) TestDestroySimple(c *gc.C) {
 }
 
 func (s *ApplicationSuite) TestDestroyStillHasUnits(c *gc.C) {
-	unit, err := s.mysql.AddUnit()
+	unit, err := s.mysql.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	err = s.mysql.Destroy()
 	c.Assert(err, jc.ErrorIsNil)
@@ -1540,7 +1540,7 @@ func (s *ApplicationSuite) TestDestroyStillHasUnits(c *gc.C) {
 }
 
 func (s *ApplicationSuite) TestDestroyOnceHadUnits(c *gc.C) {
-	unit, err := s.mysql.AddUnit()
+	unit, err := s.mysql.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	err = unit.EnsureDead()
 	c.Assert(err, jc.ErrorIsNil)
@@ -1555,7 +1555,7 @@ func (s *ApplicationSuite) TestDestroyOnceHadUnits(c *gc.C) {
 }
 
 func (s *ApplicationSuite) TestDestroyStaleNonZeroUnitCount(c *gc.C) {
-	unit, err := s.mysql.AddUnit()
+	unit, err := s.mysql.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	err = s.mysql.Refresh()
 	c.Assert(err, jc.ErrorIsNil)
@@ -1572,7 +1572,7 @@ func (s *ApplicationSuite) TestDestroyStaleNonZeroUnitCount(c *gc.C) {
 }
 
 func (s *ApplicationSuite) TestDestroyStaleZeroUnitCount(c *gc.C) {
-	unit, err := s.mysql.AddUnit()
+	unit, err := s.mysql.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 
 	err = s.mysql.Destroy()
@@ -1634,7 +1634,7 @@ func (s *ApplicationSuite) assertDestroyWithReferencedRelation(c *gc.C, refresh 
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Add a separate reference to the first relation.
-	unit, err := wordpress.AddUnit()
+	unit, err := wordpress.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	ru, err := rel0.Unit(unit)
 	c.Assert(err, jc.ErrorIsNil)
@@ -1672,7 +1672,7 @@ func (s *ApplicationSuite) TestDestroyQueuesUnitCleanup(c *gc.C) {
 	// Add 5 units; block quick-remove of mysql/1 and mysql/3
 	units := make([]*state.Unit, 5)
 	for i := range units {
-		unit, err := s.mysql.AddUnit()
+		unit, err := s.mysql.AddUnit(state.AddUnitParams{})
 		c.Assert(err, jc.ErrorIsNil)
 		units[i] = unit
 		if i%2 != 0 {
@@ -1712,7 +1712,7 @@ func (s *ApplicationSuite) TestDestroyQueuesUnitCleanup(c *gc.C) {
 }
 
 func (s *ApplicationSuite) TestRemoveServiceMachine(c *gc.C) {
-	unit, err := s.mysql.AddUnit()
+	unit, err := s.mysql.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	machine, err := s.State.AddMachine("quantal", state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)
@@ -1877,7 +1877,7 @@ func (s *ApplicationSuite) TestSetUnsupportedConstraintsWarning(c *gc.C) {
 
 func (s *ApplicationSuite) TestConstraintsLifecycle(c *gc.C) {
 	// Dying.
-	unit, err := s.mysql.AddUnit()
+	unit, err := s.mysql.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	err = s.mysql.Destroy()
 	c.Assert(err, jc.ErrorIsNil)
@@ -1912,18 +1912,18 @@ func (s *ApplicationSuite) TestSubordinateConstraints(c *gc.C) {
 
 func (s *ApplicationSuite) TestWatchUnitsBulkEvents(c *gc.C) {
 	// Alive unit...
-	alive, err := s.mysql.AddUnit()
+	alive, err := s.mysql.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Dying unit...
-	dying, err := s.mysql.AddUnit()
+	dying, err := s.mysql.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	preventUnitDestroyRemove(c, dying)
 	err = dying.Destroy()
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Dead unit...
-	dead, err := s.mysql.AddUnit()
+	dead, err := s.mysql.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	preventUnitDestroyRemove(c, dead)
 	err = dead.Destroy()
@@ -1932,7 +1932,7 @@ func (s *ApplicationSuite) TestWatchUnitsBulkEvents(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Gone unit.
-	gone, err := s.mysql.AddUnit()
+	gone, err := s.mysql.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	err = gone.Destroy()
 	c.Assert(err, jc.ErrorIsNil)
@@ -1966,7 +1966,7 @@ func (s *ApplicationSuite) TestWatchUnitsLifecycle(c *gc.C) {
 	wc.AssertNoChange()
 
 	// Create one unit, check one change.
-	quick, err := s.mysql.AddUnit()
+	quick, err := s.mysql.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	wc.AssertChange(quick.Name())
 	wc.AssertNoChange()
@@ -1978,7 +1978,7 @@ func (s *ApplicationSuite) TestWatchUnitsLifecycle(c *gc.C) {
 	wc.AssertNoChange()
 
 	// Create another, check one change.
-	slow, err := s.mysql.AddUnit()
+	slow, err := s.mysql.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	wc.AssertChange(slow.Name())
 	wc.AssertNoChange()
@@ -2056,7 +2056,7 @@ func (s *ApplicationSuite) TestWatchRelations(c *gc.C) {
 	wc.AssertNoChange()
 
 	// Add a unit to the new relation; check no change.
-	unit, err := s.mysql.AddUnit()
+	unit, err := s.mysql.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	ru2, err := rel2.Unit(unit)
 	c.Assert(err, jc.ErrorIsNil)
@@ -2155,7 +2155,7 @@ func (s *ApplicationSuite) TestMetricCredentials(c *gc.C) {
 }
 
 func (s *ApplicationSuite) TestMetricCredentialsOnDying(c *gc.C) {
-	_, err := s.mysql.AddUnit()
+	_, err := s.mysql.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	err = s.mysql.SetMetricCredentials([]byte("set before dying"))
 	c.Assert(err, jc.ErrorIsNil)
@@ -2167,7 +2167,7 @@ func (s *ApplicationSuite) TestMetricCredentialsOnDying(c *gc.C) {
 }
 
 func (s *ApplicationSuite) testStatus(c *gc.C, status1, status2, expected status.Status) {
-	u1, err := s.mysql.AddUnit()
+	u1, err := s.mysql.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	now := coretesting.ZeroTime()
 	sInfo := status.StatusInfo{
@@ -2178,7 +2178,7 @@ func (s *ApplicationSuite) testStatus(c *gc.C, status1, status2, expected status
 	err = u1.SetStatus(sInfo)
 	c.Assert(err, jc.ErrorIsNil)
 
-	u2, err := s.mysql.AddUnit()
+	u2, err := s.mysql.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	sInfo = status.StatusInfo{
 		Status:  status2,
@@ -2349,7 +2349,7 @@ func (s *ApplicationSuite) TestSetCharmOptionalUsedStorageRemoved(c *gc.C) {
 	})
 	defer state.SetBeforeHooks(c, s.State, func() {
 		// Adding a unit will cause the storage to be in-use.
-		_, err := svc.AddUnit()
+		_, err := svc.AddUnit(state.AddUnitParams{})
 		c.Assert(err, jc.ErrorIsNil)
 	}).Check()
 	cfg := state.SetCharmConfig{Charm: newCh}
@@ -2369,7 +2369,7 @@ func (s *ApplicationSuite) TestSetCharmRequiredStorageAddedDefaultConstraints(c 
 	oldCh := s.AddMetaCharm(c, "mysql", mysqlBaseMeta+oneRequiredStorageMeta, 2)
 	newCh := s.AddMetaCharm(c, "mysql", mysqlBaseMeta+twoRequiredStorageMeta, 3)
 	svc := s.AddTestingService(c, "test", oldCh)
-	u, err := svc.AddUnit()
+	u, err := svc.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 
 	cfg := state.SetCharmConfig{Charm: newCh}
@@ -2386,7 +2386,7 @@ func (s *ApplicationSuite) TestSetCharmStorageAddedUserSpecifiedConstraints(c *g
 	oldCh := s.AddMetaCharm(c, "mysql", mysqlBaseMeta+oneRequiredStorageMeta, 2)
 	newCh := s.AddMetaCharm(c, "mysql", mysqlBaseMeta+twoOptionalStorageMeta, 3)
 	svc := s.AddTestingService(c, "test", oldCh)
-	u, err := svc.AddUnit()
+	u, err := svc.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 
 	cfg := state.SetCharmConfig{

--- a/state/assign_test.go
+++ b/state/assign_test.go
@@ -56,7 +56,7 @@ func (s *AssignSuite) addSubordinate(c *gc.C, principal *state.Unit) *state.Unit
 }
 
 func (s *AssignSuite) TestUnassignUnitFromMachineWithoutBeingAssigned(c *gc.C) {
-	unit, err := s.wordpress.AddUnit()
+	unit, err := s.wordpress.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	// When unassigning a machine from a unit, it is possible that
 	// the machine has not been previously assigned, or that it
@@ -74,7 +74,7 @@ func (s *AssignSuite) TestUnassignUnitFromMachineWithoutBeingAssigned(c *gc.C) {
 }
 
 func (s *AssignSuite) TestAssignUnitToMachineAgainFails(c *gc.C) {
-	unit, err := s.wordpress.AddUnit()
+	unit, err := s.wordpress.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	// Check that assigning an already assigned unit to
 	// a machine fails if it isn't precisely the same
@@ -101,7 +101,7 @@ func (s *AssignSuite) TestAssignUnitToMachineAgainFails(c *gc.C) {
 }
 
 func (s *AssignSuite) TestAssignedMachineIdWhenNotAlive(c *gc.C) {
-	unit, err := s.wordpress.AddUnit()
+	unit, err := s.wordpress.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	machine, err := s.State.AddMachine("quantal", state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)
@@ -117,7 +117,7 @@ func (s *AssignSuite) TestAssignedMachineIdWhenNotAlive(c *gc.C) {
 }
 
 func (s *AssignSuite) TestAssignedMachineIdWhenPrincipalNotAlive(c *gc.C) {
-	unit, err := s.wordpress.AddUnit()
+	unit, err := s.wordpress.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	machine, err := s.State.AddMachine("quantal", state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)
@@ -133,7 +133,7 @@ func (s *AssignSuite) TestAssignedMachineIdWhenPrincipalNotAlive(c *gc.C) {
 }
 
 func (s *AssignSuite) TestUnassignUnitFromMachineWithChangingState(c *gc.C) {
-	unit, err := s.wordpress.AddUnit()
+	unit, err := s.wordpress.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	// Check that unassigning while the state changes fails nicely.
 	// Remove the unit for the tests.
@@ -157,7 +157,7 @@ func (s *AssignSuite) TestUnassignUnitFromMachineWithChangingState(c *gc.C) {
 
 func (s *AssignSuite) TestAssignSubordinatesToMachine(c *gc.C) {
 	// Check that assigning a principal unit assigns its subordinates too.
-	unit, err := s.wordpress.AddUnit()
+	unit, err := s.wordpress.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	subUnit := s.addSubordinate(c, unit)
 
@@ -190,7 +190,7 @@ func (s *AssignSuite) TestAssignSubordinatesToMachine(c *gc.C) {
 func (s *AssignSuite) TestDeployerTag(c *gc.C) {
 	machine, err := s.State.AddMachine("quantal", state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)
-	principal, err := s.wordpress.AddUnit()
+	principal, err := s.wordpress.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	subordinate := s.addSubordinate(c, principal)
 
@@ -233,7 +233,7 @@ func (s *AssignSuite) TestDirectAssignIgnoresConstraints(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Unit will take combined service/environ constraints on creation.
-	unit, err := s.wordpress.AddUnit()
+	unit, err := s.wordpress.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Machine keeps its original constraints on direct assignment.
@@ -247,7 +247,7 @@ func (s *AssignSuite) TestDirectAssignIgnoresConstraints(c *gc.C) {
 func (s *AssignSuite) TestAssignBadSeries(c *gc.C) {
 	machine, err := s.State.AddMachine("burble", state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)
-	unit, err := s.wordpress.AddUnit()
+	unit, err := s.wordpress.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	err = unit.AssignToMachine(machine)
 	c.Assert(err, gc.ErrorMatches, `cannot assign unit "wordpress/0" to machine 0: series does not match`)
@@ -257,7 +257,7 @@ func (s *AssignSuite) TestAssignMachineWhenDying(c *gc.C) {
 	machine, err := s.State.AddMachine("quantal", state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)
 
-	unit, err := s.wordpress.AddUnit()
+	unit, err := s.wordpress.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	subUnit := s.addSubordinate(c, unit)
 	assignTest := func() error {
@@ -276,7 +276,7 @@ func (s *AssignSuite) TestAssignMachineWhenDying(c *gc.C) {
 	testWhenDying(c, unit, expect, expect, assignTest)
 
 	expect = ".*: machine is not alive"
-	unit, err = s.wordpress.AddUnit()
+	unit, err = s.wordpress.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	testWhenDying(c, machine, expect, expect, assignTest)
 }
@@ -284,7 +284,7 @@ func (s *AssignSuite) TestAssignMachineWhenDying(c *gc.C) {
 func (s *AssignSuite) TestAssignMachineDifferentSeries(c *gc.C) {
 	machine, err := s.State.AddMachine("trusty", state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)
-	unit, err := s.wordpress.AddUnit()
+	unit, err := s.wordpress.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	err = unit.AssignToMachine(machine)
 	c.Assert(err, gc.ErrorMatches,
@@ -297,7 +297,7 @@ func (s *AssignSuite) TestPrincipals(c *gc.C) {
 	principals := machine.Principals()
 	c.Assert(principals, jc.DeepEquals, []string{})
 
-	unit, err := s.wordpress.AddUnit()
+	unit, err := s.wordpress.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	err = unit.AssignToMachine(machine)
 	c.Assert(err, jc.ErrorIsNil)
@@ -311,11 +311,11 @@ func (s *AssignSuite) TestPrincipals(c *gc.C) {
 func (s *AssignSuite) TestAssignMachinePrincipalsChange(c *gc.C) {
 	machine, err := s.State.AddMachine("quantal", state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)
-	unit, err := s.wordpress.AddUnit()
+	unit, err := s.wordpress.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	err = unit.AssignToMachine(machine)
 	c.Assert(err, jc.ErrorIsNil)
-	unit, err = s.wordpress.AddUnit()
+	unit, err = s.wordpress.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	err = unit.AssignToMachine(machine)
 	c.Assert(err, jc.ErrorIsNil)
@@ -355,7 +355,7 @@ func (s *AssignSuite) assertAssignedUnit(c *gc.C, unit *state.Unit) string {
 }
 
 func (s *AssignSuite) TestAssignUnitToNewMachine(c *gc.C) {
-	unit, err := s.wordpress.AddUnit()
+	unit, err := s.wordpress.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 
 	err = unit.AssignToNewMachine()
@@ -364,7 +364,7 @@ func (s *AssignSuite) TestAssignUnitToNewMachine(c *gc.C) {
 }
 
 func (s *AssignSuite) assertAssignUnitToNewMachineContainerConstraint(c *gc.C) {
-	unit, err := s.wordpress.AddUnit()
+	unit, err := s.wordpress.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	err = unit.AssignToNewMachine()
 	c.Assert(err, jc.ErrorIsNil)
@@ -390,7 +390,7 @@ func (s *AssignSuite) TestAssignUnitToNewMachineDefaultContainerConstraint(c *gc
 }
 
 func (s *AssignSuite) TestAssignToNewMachineMakesDirty(c *gc.C) {
-	unit, err := s.wordpress.AddUnit()
+	unit, err := s.wordpress.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 
 	err = unit.AssignToNewMachine()
@@ -412,7 +412,7 @@ func (s *AssignSuite) TestAssignUnitToNewMachineSetsConstraints(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Unit will take combined service/environ constraints on creation.
-	unit, err := s.wordpress.AddUnit()
+	unit, err := s.wordpress.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Change service/env constraints before assigning, to verify this.
@@ -439,7 +439,7 @@ func (s *AssignSuite) TestAssignUnitToNewMachineSetsConstraints(c *gc.C) {
 }
 
 func (s *AssignSuite) TestAssignUnitToNewMachineCleanAvailable(c *gc.C) {
-	unit, err := s.wordpress.AddUnit()
+	unit, err := s.wordpress.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Add a clean machine.
@@ -458,7 +458,7 @@ func (s *AssignSuite) TestAssignUnitToNewMachineCleanAvailable(c *gc.C) {
 }
 
 func (s *AssignSuite) TestAssignUnitToNewMachineAlreadyAssigned(c *gc.C) {
-	unit, err := s.wordpress.AddUnit()
+	unit, err := s.wordpress.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	// Make the unit assigned
 	err = unit.AssignToNewMachine()
@@ -469,7 +469,7 @@ func (s *AssignSuite) TestAssignUnitToNewMachineAlreadyAssigned(c *gc.C) {
 }
 
 func (s *AssignSuite) TestAssignUnitToNewMachineUnitNotAlive(c *gc.C) {
-	unit, err := s.wordpress.AddUnit()
+	unit, err := s.wordpress.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	subUnit := s.addSubordinate(c, unit)
 
@@ -491,7 +491,7 @@ func (s *AssignSuite) TestAssignUnitToNewMachineUnitNotAlive(c *gc.C) {
 }
 
 func (s *AssignSuite) TestAssignUnitToNewMachineUnitRemoved(c *gc.C) {
-	unit, err := s.wordpress.AddUnit()
+	unit, err := s.wordpress.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	err = unit.Destroy()
 	c.Assert(err, jc.ErrorIsNil)
@@ -509,9 +509,9 @@ func (s *AssignSuite) TestAssignUnitToNewMachineBecomesDirty(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Create some units and a clean machine.
-	unit, err := s.wordpress.AddUnit()
+	unit, err := s.wordpress.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
-	anotherUnit, err := s.wordpress.AddUnit()
+	anotherUnit, err := s.wordpress.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	machine, err := s.State.AddMachine("quantal", state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)
@@ -542,7 +542,7 @@ func (s *AssignSuite) TestAssignUnitToNewMachineBecomesHost(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Create a unit and a clean machine.
-	unit, err := s.wordpress.AddUnit()
+	unit, err := s.wordpress.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	machine, err := s.State.AddMachine("quantal", state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)
@@ -567,7 +567,7 @@ func (s *AssignSuite) TestAssignUnitToNewMachineBecomesHost(c *gc.C) {
 }
 
 func (s *AssignSuite) TestAssignUnitBadPolicy(c *gc.C) {
-	unit, err := s.wordpress.AddUnit()
+	unit, err := s.wordpress.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	// Check nonsensical policy
 	err = s.State.AssignUnit(unit, state.AssignmentPolicy("random"))
@@ -580,7 +580,7 @@ func (s *AssignSuite) TestAssignUnitBadPolicy(c *gc.C) {
 func (s *AssignSuite) TestAssignUnitLocalPolicy(c *gc.C) {
 	m, err := s.State.AddMachine("quantal", state.JobManageModel, state.JobHostUnits) // bootstrap machine
 	c.Assert(err, jc.ErrorIsNil)
-	unit, err := s.wordpress.AddUnit()
+	unit, err := s.wordpress.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 
 	for i := 0; i < 2; i++ {
@@ -596,7 +596,7 @@ func (s *AssignSuite) TestAssignUnitLocalPolicy(c *gc.C) {
 func (s *AssignSuite) assertAssignUnitNewPolicyNoContainer(c *gc.C) {
 	_, err := s.State.AddMachine("quantal", state.JobHostUnits) // available machine
 	c.Assert(err, jc.ErrorIsNil)
-	unit, err := s.wordpress.AddUnit()
+	unit, err := s.wordpress.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 
 	err = s.State.AssignUnit(unit, state.AssignNew)
@@ -619,7 +619,7 @@ func (s *AssignSuite) TestAssignUnitNewPolicyWithContainerConstraintIgnoresNone(
 }
 
 func (s *AssignSuite) assertAssignUnitNewPolicyWithContainerConstraint(c *gc.C) {
-	unit, err := s.wordpress.AddUnit()
+	unit, err := s.wordpress.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	err = s.State.AssignUnit(unit, state.AssignNew)
 	c.Assert(err, jc.ErrorIsNil)
@@ -652,7 +652,7 @@ func (s *AssignSuite) TestAssignUnitNewPolicyWithDefaultContainerConstraint(c *g
 func (s *AssignSuite) TestAssignUnitWithSubordinate(c *gc.C) {
 	_, err := s.State.AddMachine("quantal", state.JobManageModel) // bootstrap machine
 	c.Assert(err, jc.ErrorIsNil)
-	unit, err := s.wordpress.AddUnit()
+	unit, err := s.wordpress.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Check cannot assign subordinates to machines
@@ -727,7 +727,7 @@ func (s *assignCleanSuite) setupMachines(c *gc.C) (hostMachine *state.Machine, c
 	service1 := s.AddTestingService(c, "mysql", s.AddTestingCharm(c, "mysql"))
 	units := make([]*state.Unit, 3)
 	for i := range units {
-		u, err := service1.AddUnit()
+		u, err := service1.AddUnit(state.AddUnitParams{})
 		c.Assert(err, jc.ErrorIsNil)
 		m, err := s.State.AddMachine("quantal", state.JobHostUnits)
 		c.Assert(err, jc.ErrorIsNil)
@@ -755,7 +755,7 @@ func (s *assignCleanSuite) setupMachines(c *gc.C) (hostMachine *state.Machine, c
 }
 
 func (s *assignCleanSuite) assertAssignUnit(c *gc.C, expectedMachine *state.Machine) {
-	unit, err := s.wordpress.AddUnit()
+	unit, err := s.wordpress.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	reusedMachine, err := s.assignUnit(unit)
 	c.Assert(err, jc.ErrorIsNil)
@@ -778,7 +778,7 @@ func (s *assignCleanSuite) TestAssignUnit(c *gc.C) {
 
 func (s *assignCleanSuite) TestAssignUnitTwiceFails(c *gc.C) {
 	s.setupMachines(c)
-	unit, err := s.wordpress.AddUnit()
+	unit, err := s.wordpress.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	// Assign the first time.
 	_, err = s.assignUnit(unit)
@@ -797,7 +797,7 @@ const eligibleMachinesInUse = "all eligible machines in use"
 
 func (s *assignCleanSuite) TestAssignToMachineNoneAvailable(c *gc.C) {
 	// Try to assign a unit to a clean (maybe empty) machine and check that we can't.
-	unit, err := s.wordpress.AddUnit()
+	unit, err := s.wordpress.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 
 	m, err := s.assignUnit(unit)
@@ -934,7 +934,7 @@ func (s *assignCleanSuite) TestAssignUsingConstraintsToMachine(c *gc.C) {
 		err := s.State.SetModelConstraints(cons)
 		c.Assert(err, jc.ErrorIsNil)
 
-		unit, err := s.wordpress.AddUnit()
+		unit, err := s.wordpress.AddUnit(state.AddUnitParams{})
 		c.Assert(err, jc.ErrorIsNil)
 
 		m, err := s.State.AddMachine("quantal", state.JobHostUnits)
@@ -962,7 +962,7 @@ func (s *assignCleanSuite) TestAssignUsingConstraintsToMachine(c *gc.C) {
 func (s *assignCleanSuite) TestAssignUnitWithRemovedService(c *gc.C) {
 	_, err := s.State.AddMachine("quantal", state.JobManageModel) // bootstrap machine
 	c.Assert(err, jc.ErrorIsNil)
-	unit, err := s.wordpress.AddUnit()
+	unit, err := s.wordpress.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Fail if service is removed.
@@ -978,7 +978,7 @@ func (s *assignCleanSuite) TestAssignUnitWithRemovedService(c *gc.C) {
 func (s *assignCleanSuite) TestAssignUnitToMachineWithRemovedUnit(c *gc.C) {
 	_, err := s.State.AddMachine("quantal", state.JobManageModel) // bootstrap machine
 	c.Assert(err, jc.ErrorIsNil)
-	unit, err := s.wordpress.AddUnit()
+	unit, err := s.wordpress.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	// Fail if unit is removed.
 	err = unit.EnsureDead()
@@ -996,7 +996,7 @@ func (s *assignCleanSuite) TestAssignUnitToMachineWorksWithMachine0(c *gc.C) {
 	m, err := s.State.AddMachine("quantal", state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(m.Id(), gc.Equals, "0")
-	unit, err := s.wordpress.AddUnit()
+	unit, err := s.wordpress.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	assignedTo, err := s.assignUnit(unit)
 	c.Assert(err, jc.ErrorIsNil)
@@ -1011,7 +1011,7 @@ func (s *assignCleanSuite) setupSingleStorage(c *gc.C, kind, pool string) (*stat
 		"data": makeStorageCons(pool, 1024, 1),
 	}
 	service := s.AddTestingServiceWithStorage(c, "storage-"+kind, ch, storage)
-	unit, err := service.AddUnit()
+	unit, err := service.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	storageTag := names.NewStorageTag("data/0")
 	return service, unit, storageTag
@@ -1110,7 +1110,7 @@ func (s *assignCleanSuite) TestAssignUnitPolicy(c *gc.C) {
 
 	// Check unassigned placements with no clean and/or empty machines.
 	for i := 0; i < 10; i++ {
-		unit, err := s.wordpress.AddUnit()
+		unit, err := s.wordpress.AddUnit(state.AddUnitParams{})
 		c.Assert(err, jc.ErrorIsNil)
 		err = s.State.AssignUnit(unit, s.policy)
 		c.Assert(err, jc.ErrorIsNil)
@@ -1171,7 +1171,7 @@ func (s *assignCleanSuite) TestAssignUnitPolicy(c *gc.C) {
 	// Assign units to all the expectedMachines machines.
 	var got []string
 	for _ = range expectedMachines {
-		unit, err := s.wordpress.AddUnit()
+		unit, err := s.wordpress.AddUnit(state.AddUnitParams{})
 		c.Assert(err, jc.ErrorIsNil)
 		err = s.State.AssignUnit(unit, s.policy)
 		c.Assert(err, jc.ErrorIsNil)
@@ -1206,7 +1206,7 @@ func (s *assignCleanSuite) TestAssignUnitPolicyWithContainers(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Check the first placement goes into the newly created, clean container above.
-	unit, err := s.wordpress.AddUnit()
+	unit, err := s.wordpress.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	err = s.State.AssignUnit(unit, s.policy)
 	c.Assert(err, jc.ErrorIsNil)
@@ -1215,7 +1215,7 @@ func (s *assignCleanSuite) TestAssignUnitPolicyWithContainers(c *gc.C) {
 	c.Assert(mid, gc.Equals, container.Id())
 
 	assertContainerPlacement := func(expectedNumUnits int) {
-		unit, err := s.wordpress.AddUnit()
+		unit, err := s.wordpress.AddUnit(state.AddUnitParams{})
 		c.Assert(err, jc.ErrorIsNil)
 		err = s.State.AssignUnit(unit, s.policy)
 		c.Assert(err, jc.ErrorIsNil)
@@ -1242,7 +1242,7 @@ func (s *assignCleanSuite) TestAssignUnitPolicyWithContainers(c *gc.C) {
 	// Create a new, clean instance and check that the next container creation uses it.
 	hostMachine, err = s.State.AddMachine("quantal", state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)
-	unit, err = s.wordpress.AddUnit()
+	unit, err = s.wordpress.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	err = s.State.AssignUnit(unit, s.policy)
 	c.Assert(err, jc.ErrorIsNil)
@@ -1263,7 +1263,7 @@ func (s *assignCleanSuite) TestAssignUnitPolicyConcurrently(c *gc.C) {
 	}
 	us := make([]*state.Unit, unitCount)
 	for i := range us {
-		us[i], err = s.wordpress.AddUnit()
+		us[i], err = s.wordpress.AddUnit(state.AddUnitParams{})
 		c.Assert(err, jc.ErrorIsNil)
 	}
 	type result struct {

--- a/state/bench_test.go
+++ b/state/bench_test.go
@@ -31,7 +31,7 @@ func (*BenchmarkSuite) BenchmarkAddUnit(c *gc.C) {
 	svc := s.AddTestingService(c, "wordpress", charm)
 	c.ResetTimer()
 	for i := 0; i < c.N; i++ {
-		_, err := svc.AddUnit()
+		_, err := svc.AddUnit(state.AddUnitParams{})
 		c.Assert(err, jc.ErrorIsNil)
 	}
 }
@@ -46,7 +46,7 @@ func (*BenchmarkSuite) BenchmarkAddAndAssignUnit(c *gc.C) {
 	svc := s.AddTestingService(c, "wordpress", charm)
 	c.ResetTimer()
 	for i := 0; i < c.N; i++ {
-		unit, err := svc.AddUnit()
+		unit, err := svc.AddUnit(state.AddUnitParams{})
 		c.Assert(err, jc.ErrorIsNil)
 		err = s.State.AssignUnit(unit, state.AssignClean)
 		c.Assert(err, jc.ErrorIsNil)
@@ -80,7 +80,7 @@ func benchmarkAddMetrics(metricsPerBatch, batches int, c *gc.C) {
 	}
 	charm := s.AddTestingCharm(c, "wordpress")
 	svc := s.AddTestingService(c, "wordpress", charm)
-	unit, err := svc.AddUnit()
+	unit, err := svc.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	serviceCharmURL, _ := svc.CharmURL()
 	err = unit.SetCharmURL(serviceCharmURL)
@@ -114,7 +114,7 @@ func (*BenchmarkSuite) BenchmarkCleanupMetrics(c *gc.C) {
 	oldTime := time.Now().Add(-(state.CleanupAge))
 	charm := s.AddTestingCharm(c, "wordpress")
 	svc := s.AddTestingService(c, "wordpress", charm)
-	unit, err := svc.AddUnit()
+	unit, err := svc.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	serviceCharmURL, _ := svc.CharmURL()
 	err = unit.SetCharmURL(serviceCharmURL)

--- a/state/charm_test.go
+++ b/state/charm_test.go
@@ -256,7 +256,7 @@ func (s *CharmSuite) TestDestroyFinalUnitReference(c *gc.C) {
 	app := s.Factory.MakeApplication(c, &factory.ApplicationParams{
 		Charm: s.charm,
 	})
-	unit, err := app.AddUnit()
+	unit, err := app.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 
 	err = app.Destroy()

--- a/state/cleanup_test.go
+++ b/state/cleanup_test.go
@@ -34,7 +34,7 @@ func (s *CleanupSuite) TestCleanupDyingApplicationUnits(c *gc.C) {
 	mysql := s.AddTestingService(c, "mysql", s.AddTestingCharm(c, "mysql"))
 	units := make([]*state.Unit, 3)
 	for i := range units {
-		unit, err := mysql.AddUnit()
+		unit, err := mysql.AddUnit(state.AddUnitParams{})
 		c.Assert(err, jc.ErrorIsNil)
 		units[i] = unit
 	}
@@ -220,7 +220,7 @@ func (s *CleanupSuite) TestCleanupModelApplications(c *gc.C) {
 	mysql := s.AddTestingService(c, "mysql", s.AddTestingCharm(c, "mysql"))
 	units := make([]*state.Unit, 3)
 	for i := range units {
-		unit, err := mysql.AddUnit()
+		unit, err := mysql.AddUnit(state.AddUnitParams{})
 		c.Assert(err, jc.ErrorIsNil)
 		units[i] = unit
 	}
@@ -341,7 +341,7 @@ func (s *CleanupSuite) TestCleanupForceDestroyMachineCleansStorageAttachments(c 
 		"data": makeStorageCons("loop", 1024, 1),
 	}
 	application := s.AddTestingServiceWithStorage(c, "storage-block", ch, storage)
-	u, err := application.AddUnit()
+	u, err := application.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	err = u.AssignToMachine(machine)
 	c.Assert(err, jc.ErrorIsNil)
@@ -506,7 +506,7 @@ func (s *CleanupSuite) TestCleanupDyingUnitAlreadyRemoved(c *gc.C) {
 func (s *CleanupSuite) TestCleanupActions(c *gc.C) {
 	// Create a application with a unit.
 	dummy := s.AddTestingService(c, "dummy", s.AddTestingCharm(c, "dummy"))
-	unit, err := dummy.AddUnit()
+	unit, err := dummy.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 
 	// check no cleanups
@@ -548,7 +548,7 @@ func (s *CleanupSuite) TestCleanupActions(c *gc.C) {
 func (s *CleanupSuite) TestCleanupWithCompletedActions(c *gc.C) {
 	// Create a application with a unit.
 	dummy := s.AddTestingService(c, "dummy", s.AddTestingCharm(c, "dummy"))
-	unit, err := dummy.AddUnit()
+	unit, err := dummy.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	s.assertDoesNotNeedCleanup(c)
 
@@ -581,7 +581,7 @@ func (s *CleanupSuite) TestCleanupStorageAttachments(c *gc.C) {
 		"data": makeStorageCons("loop", 1024, 1),
 	}
 	application := s.AddTestingServiceWithStorage(c, "storage-block", ch, storage)
-	u, err := application.AddUnit()
+	u, err := application.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 
 	// check no cleanups
@@ -614,7 +614,7 @@ func (s *CleanupSuite) TestCleanupStorageInstances(c *gc.C) {
 		"allecto": makeStorageCons("modelscoped-block", 1024, 1),
 	}
 	application := s.AddTestingServiceWithStorage(c, "storage-block", ch, storage)
-	u, err := application.AddUnit()
+	u, err := application.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 
 	// check no cleanups
@@ -653,7 +653,7 @@ func (s *CleanupSuite) TestCleanupMachineStorage(c *gc.C) {
 		"data": makeStorageCons("modelscoped", 1024, 1),
 	}
 	application := s.AddTestingServiceWithStorage(c, "storage-block", ch, storage)
-	unit, err := application.AddUnit()
+	unit, err := application.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	err = s.State.AssignUnit(unit, state.AssignCleanEmpty)
 	c.Assert(err, jc.ErrorIsNil)

--- a/state/constraintsvalidation_test.go
+++ b/state/constraintsvalidation_test.go
@@ -254,7 +254,7 @@ func (s *constraintsValidationSuite) TestServiceConstraints(c *gc.C) {
 		// Set the service deployment constraints.
 		err = service.SetConstraints(constraints.MustParse(t.consToSet))
 		c.Check(err, jc.ErrorIsNil)
-		u, err := service.AddUnit()
+		u, err := service.AddUnit(state.AddUnitParams{})
 		c.Check(err, jc.ErrorIsNil)
 		// New unit deployment constraints get merged with the fallbacks.
 		ucons, err := u.Constraints()

--- a/state/distribution_test.go
+++ b/state/distribution_test.go
@@ -65,7 +65,7 @@ func (s *InstanceDistributorSuite) SetUpTest(c *gc.C) {
 func (s *InstanceDistributorSuite) setupScenario(c *gc.C) {
 	// Assign a unit so we have a non-empty distribution group, and
 	// provision all instances so we have candidates.
-	unit, err := s.wordpress.AddUnit()
+	unit, err := s.wordpress.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	err = unit.AssignToMachine(s.machines[0])
 	c.Assert(err, jc.ErrorIsNil)
@@ -78,7 +78,7 @@ func (s *InstanceDistributorSuite) setupScenario(c *gc.C) {
 
 func (s *InstanceDistributorSuite) TestDistributeInstances(c *gc.C) {
 	s.setupScenario(c)
-	unit, err := s.wordpress.AddUnit()
+	unit, err := s.wordpress.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	_, err = unit.AssignToCleanMachine()
 	c.Assert(err, jc.ErrorIsNil)
@@ -91,7 +91,7 @@ func (s *InstanceDistributorSuite) TestDistributeInstances(c *gc.C) {
 
 func (s *InstanceDistributorSuite) TestDistributeInstancesInvalidInstances(c *gc.C) {
 	s.setupScenario(c)
-	unit, err := s.wordpress.AddUnit()
+	unit, err := s.wordpress.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	s.distributor.result = []instance.Id{"notthere"}
 	_, err = unit.AssignToCleanMachine()
@@ -101,7 +101,7 @@ func (s *InstanceDistributorSuite) TestDistributeInstancesInvalidInstances(c *gc
 func (s *InstanceDistributorSuite) TestDistributeInstancesNoEmptyMachines(c *gc.C) {
 	for i := range s.machines {
 		// Assign a unit so we have a non-empty distribution group.
-		unit, err := s.wordpress.AddUnit()
+		unit, err := s.wordpress.AddUnit(state.AddUnitParams{})
 		c.Assert(err, jc.ErrorIsNil)
 		m, err := unit.AssignToCleanMachine()
 		c.Assert(err, jc.ErrorIsNil)
@@ -112,7 +112,7 @@ func (s *InstanceDistributorSuite) TestDistributeInstancesNoEmptyMachines(c *gc.
 
 	// InstanceDistributor is not called if there are no empty instances.
 	s.distributor.err = fmt.Errorf("no assignment for you")
-	unit, err := s.wordpress.AddUnit()
+	unit, err := s.wordpress.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	_, err = unit.AssignToCleanMachine()
 	c.Assert(err, gc.ErrorMatches, eligibleMachinesInUse)
@@ -120,7 +120,7 @@ func (s *InstanceDistributorSuite) TestDistributeInstancesNoEmptyMachines(c *gc.
 
 func (s *InstanceDistributorSuite) TestDistributeInstancesErrors(c *gc.C) {
 	s.setupScenario(c)
-	unit, err := s.wordpress.AddUnit()
+	unit, err := s.wordpress.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Ensure that assignment fails when DistributeInstances returns an error.
@@ -141,14 +141,14 @@ func (s *InstanceDistributorSuite) TestDistributeInstancesEmptyDistributionGroup
 	s.distributor.err = fmt.Errorf("no assignment for you")
 
 	// InstanceDistributor is not called if the distribution group is empty.
-	unit0, err := s.wordpress.AddUnit()
+	unit0, err := s.wordpress.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	_, err = unit0.AssignToCleanMachine()
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Distribution group is still empty, because the machine assigned to has
 	// not been provisioned.
-	unit1, err := s.wordpress.AddUnit()
+	unit1, err := s.wordpress.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	_, err = unit1.AssignToCleanMachine()
 	c.Assert(err, jc.ErrorIsNil)
@@ -160,7 +160,7 @@ func (s *InstanceDistributorSuite) TestInstanceDistributorUnimplemented(c *gc.C)
 	s.policy.GetInstanceDistributor = func() (instance.Distributor, error) {
 		return nil, distributorErr
 	}
-	unit, err := s.wordpress.AddUnit()
+	unit, err := s.wordpress.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	_, err = unit.AssignToCleanMachine()
 	c.Assert(err, gc.ErrorMatches, `cannot assign unit "wordpress/1" to clean machine: policy returned nil instance distributor without an error`)
@@ -175,7 +175,7 @@ func (s *InstanceDistributorSuite) TestDistributeInstancesNoPolicy(c *gc.C) {
 		return nil, nil
 	}
 	state.SetPolicy(s.State, nil)
-	unit, err := s.wordpress.AddUnit()
+	unit, err := s.wordpress.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	_, err = unit.AssignToCleanMachine()
 	c.Assert(err, jc.ErrorIsNil)

--- a/state/filesystem_test.go
+++ b/state/filesystem_test.go
@@ -210,7 +210,7 @@ func (s *FilesystemStateSuite) addUnitWithFilesystemUnprovisioned(c *gc.C, pool 
 		"data": makeStorageCons(pool, 1024, 1),
 	}
 	app := s.AddTestingServiceWithStorage(c, "storage-filesystem", ch, storage)
-	unit, err := app.AddUnit()
+	unit, err := app.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	err = s.State.AssignUnit(unit, state.AssignCleanEmpty)
 	c.Assert(err, jc.ErrorIsNil)
@@ -355,7 +355,7 @@ func (s *FilesystemStateSuite) TestVolumeBackedFilesystemScope(c *gc.C) {
 func (s *FilesystemStateSuite) TestWatchModelFilesystems(c *gc.C) {
 	app := s.setupMixedScopeStorageApplication(c, "filesystem")
 	addUnit := func() *state.Unit {
-		u, err := app.AddUnit()
+		u, err := app.AddUnit(state.AddUnitParams{})
 		c.Assert(err, jc.ErrorIsNil)
 		err = s.State.AssignUnit(u, state.AssignCleanEmpty)
 		c.Assert(err, jc.ErrorIsNil)
@@ -397,7 +397,7 @@ func (s *FilesystemStateSuite) TestWatchModelFilesystems(c *gc.C) {
 func (s *FilesystemStateSuite) TestWatchEnvironFilesystemAttachments(c *gc.C) {
 	app := s.setupMixedScopeStorageApplication(c, "filesystem")
 	addUnit := func() *state.Unit {
-		u, err := app.AddUnit()
+		u, err := app.AddUnit(state.AddUnitParams{})
 		c.Assert(err, jc.ErrorIsNil)
 		err = s.State.AssignUnit(u, state.AssignCleanEmpty)
 		c.Assert(err, jc.ErrorIsNil)
@@ -439,7 +439,7 @@ func (s *FilesystemStateSuite) TestWatchEnvironFilesystemAttachments(c *gc.C) {
 func (s *FilesystemStateSuite) TestWatchMachineFilesystems(c *gc.C) {
 	app := s.setupMixedScopeStorageApplication(c, "filesystem")
 	addUnit := func() *state.Unit {
-		u, err := app.AddUnit()
+		u, err := app.AddUnit(state.AddUnitParams{})
 		c.Assert(err, jc.ErrorIsNil)
 		err = s.State.AssignUnit(u, state.AssignCleanEmpty)
 		c.Assert(err, jc.ErrorIsNil)
@@ -488,7 +488,7 @@ func (s *FilesystemStateSuite) TestWatchMachineFilesystemAttachments(c *gc.C) {
 	app := s.setupMixedScopeStorageApplication(c, "filesystem", "machinescoped", "modelscoped")
 	addUnit := func(to *state.Machine) (u *state.Unit, m *state.Machine) {
 		var err error
-		u, err = app.AddUnit()
+		u, err = app.AddUnit(state.AddUnitParams{})
 		c.Assert(err, jc.ErrorIsNil)
 		if to != nil {
 			err = u.AssignToMachine(to)
@@ -985,7 +985,7 @@ func (s *FilesystemStateSuite) testFilesystemAttachmentParams(
 	}
 
 	app := s.AddTestingServiceWithStorage(c, "storage-filesystem", ch, storage)
-	unit, err := app.AddUnit()
+	unit, err := app.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	err = s.State.AssignUnit(unit, state.AssignCleanEmpty)
 	c.Assert(err, jc.ErrorIsNil)
@@ -1035,7 +1035,7 @@ func (s *FilesystemStateSuite) testFilesystemAttachmentParamsConcurrent(c *gc.C,
 			Location: location,
 		}, rev)
 		app := s.AddTestingServiceWithStorage(c, applicationname, ch, storage)
-		unit, err := app.AddUnit()
+		unit, err := app.AddUnit(state.AddUnitParams{})
 		c.Assert(err, jc.ErrorIsNil)
 		return unit.AssignToMachine(machine)
 	}
@@ -1065,7 +1065,7 @@ func (s *FilesystemStateSuite) TestFilesystemAttachmentParamsConcurrentRemove(c 
 		Location: "/not/in/srv",
 	})
 	app := s.AddTestingService(c, "storage-filesystem", ch)
-	unit, err := app.AddUnit()
+	unit, err := app.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 
 	defer state.SetBeforeHooks(c, s.State, func() {
@@ -1090,7 +1090,7 @@ func (s *FilesystemStateSuite) TestFilesystemAttachmentParamsLocationStorageDir(
 		Location: "/var/lib/juju/storage",
 	})
 	app := s.AddTestingService(c, "storage-filesystem", ch)
-	unit, err := app.AddUnit()
+	unit, err := app.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	err = s.State.AssignUnit(unit, state.AssignCleanEmpty)
 	c.Assert(err, gc.ErrorMatches, `cannot assign unit \"storage-filesystem/0\" to machine: `+
@@ -1113,7 +1113,7 @@ func (s *FilesystemStateSuite) TestFilesystemAttachmentLocationConflict(c *gc.C)
 	})
 	svc := s.AddTestingService(c, "storage-filesystem", ch)
 
-	u, err := svc.AddUnit()
+	u, err := svc.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	err = u.AssignToMachine(machine)
 	c.Assert(err, gc.ErrorMatches,

--- a/state/life_test.go
+++ b/state/life_test.go
@@ -94,7 +94,7 @@ func (l *unitLife) id() (coll string, id interface{}) {
 }
 
 func (l *unitLife) setup(s *LifeSuite, c *gc.C) state.AgentLiving {
-	unit, err := s.svc.AddUnit()
+	unit, err := s.svc.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	preventUnitDestroyRemove(c, unit)
 	l.unit = unit

--- a/state/machine_test.go
+++ b/state/machine_test.go
@@ -297,7 +297,7 @@ func (s *MachineSuite) TestLifeMachineWithContainer(c *gc.C) {
 func (s *MachineSuite) TestLifeJobHostUnits(c *gc.C) {
 	// A machine with an assigned unit must not advance lifecycle.
 	svc := s.AddTestingService(c, "wordpress", s.AddTestingCharm(c, "wordpress"))
-	unit, err := svc.AddUnit()
+	unit, err := svc.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	err = unit.AssignToMachine(s.machine)
 	c.Assert(err, jc.ErrorIsNil)
@@ -331,7 +331,7 @@ func (s *MachineSuite) TestLifeJobHostUnits(c *gc.C) {
 
 func (s *MachineSuite) TestDestroyRemovePorts(c *gc.C) {
 	svc := s.AddTestingService(c, "wordpress", s.AddTestingCharm(c, "wordpress"))
-	unit, err := svc.AddUnit()
+	unit, err := svc.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	err = unit.AssignToMachine(s.machine)
 	c.Assert(err, jc.ErrorIsNil)
@@ -386,7 +386,7 @@ func (s *MachineSuite) TestDestroyAbort(c *gc.C) {
 
 func (s *MachineSuite) TestDestroyCancel(c *gc.C) {
 	svc := s.AddTestingService(c, "wordpress", s.AddTestingCharm(c, "wordpress"))
-	unit, err := svc.AddUnit()
+	unit, err := svc.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 
 	defer state.SetBeforeHooks(c, s.State, func() {
@@ -398,7 +398,7 @@ func (s *MachineSuite) TestDestroyCancel(c *gc.C) {
 
 func (s *MachineSuite) TestDestroyContention(c *gc.C) {
 	svc := s.AddTestingService(c, "wordpress", s.AddTestingCharm(c, "wordpress"))
-	unit, err := svc.AddUnit()
+	unit, err := svc.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 
 	perturb := jujutxn.TestHook{
@@ -413,7 +413,7 @@ func (s *MachineSuite) TestDestroyContention(c *gc.C) {
 
 func (s *MachineSuite) TestDestroyWithServiceDestroyPending(c *gc.C) {
 	svc := s.AddTestingService(c, "wordpress", s.AddTestingCharm(c, "wordpress"))
-	unit, err := svc.AddUnit()
+	unit, err := svc.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	err = unit.AssignToMachine(s.machine)
 	c.Assert(err, jc.ErrorIsNil)
@@ -429,7 +429,7 @@ func (s *MachineSuite) TestDestroyWithServiceDestroyPending(c *gc.C) {
 
 func (s *MachineSuite) TestDestroyFailsWhenNewUnitAdded(c *gc.C) {
 	svc := s.AddTestingService(c, "wordpress", s.AddTestingCharm(c, "wordpress"))
-	unit, err := svc.AddUnit()
+	unit, err := svc.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	err = unit.AssignToMachine(s.machine)
 	c.Assert(err, jc.ErrorIsNil)
@@ -439,7 +439,7 @@ func (s *MachineSuite) TestDestroyFailsWhenNewUnitAdded(c *gc.C) {
 
 	defer state.SetBeforeHooks(c, s.State, func() {
 		anotherSvc := s.AddTestingService(c, "mysql", s.AddTestingCharm(c, "mysql"))
-		anotherUnit, err := anotherSvc.AddUnit()
+		anotherUnit, err := anotherSvc.AddUnit(state.AddUnitParams{})
 		c.Assert(err, jc.ErrorIsNil)
 		err = anotherUnit.AssignToMachine(s.machine)
 		c.Assert(err, jc.ErrorIsNil)
@@ -453,7 +453,7 @@ func (s *MachineSuite) TestDestroyFailsWhenNewUnitAdded(c *gc.C) {
 
 func (s *MachineSuite) TestDestroyWithUnitDestroyPending(c *gc.C) {
 	svc := s.AddTestingService(c, "wordpress", s.AddTestingCharm(c, "wordpress"))
-	unit, err := svc.AddUnit()
+	unit, err := svc.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	err = unit.AssignToMachine(s.machine)
 	c.Assert(err, jc.ErrorIsNil)
@@ -469,7 +469,7 @@ func (s *MachineSuite) TestDestroyWithUnitDestroyPending(c *gc.C) {
 
 func (s *MachineSuite) TestDestroyFailsWhenNewContainerAdded(c *gc.C) {
 	svc := s.AddTestingService(c, "wordpress", s.AddTestingCharm(c, "wordpress"))
-	unit, err := svc.AddUnit()
+	unit, err := svc.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	err = unit.AssignToMachine(s.machine)
 	c.Assert(err, jc.ErrorIsNil)
@@ -775,7 +775,7 @@ func (s *MachineSuite) TestDesiredSpacesEndpoints(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	svc := s.AddTestingServiceWithBindings(c, "mysql",
 		s.AddTestingCharm(c, "mysql"), map[string]string{"server": "db"})
-	unit, err := svc.AddUnit()
+	unit, err := svc.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	err = unit.AssignToMachine(machine)
 	c.Assert(err, jc.ErrorIsNil)
@@ -797,7 +797,7 @@ func (s *MachineSuite) TestDesiredSpacesEndpointsAndConstraints(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	svc := s.AddTestingServiceWithBindings(c, "mysql",
 		s.AddTestingCharm(c, "mysql"), map[string]string{"server": "db"})
-	unit, err := svc.AddUnit()
+	unit, err := svc.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	err = unit.AssignToMachine(machine)
 	c.Assert(err, jc.ErrorIsNil)
@@ -833,7 +833,7 @@ func (s *MachineSuite) TestDesiredSpacesNothingRequested(c *gc.C) {
 	// And empty bindings
 	svc := s.AddTestingServiceWithBindings(c, "mysql",
 		s.AddTestingCharm(c, "mysql"), map[string]string{})
-	unit, err := svc.AddUnit()
+	unit, err := svc.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	err = unit.AssignToMachine(machine)
 	c.Assert(err, jc.ErrorIsNil)
@@ -1087,7 +1087,7 @@ func (s *MachineSuite) TestMachinePrincipalUnits(c *gc.C) {
 	for i, svc := range []*state.Application{s0, s1, s2} {
 		units[i] = make([]*state.Unit, 3)
 		for j := range units[i] {
-			units[i][j], err = svc.AddUnit()
+			units[i][j], err = svc.AddUnit(state.AddUnitParams{})
 			c.Assert(err, jc.ErrorIsNil)
 		}
 	}
@@ -1154,7 +1154,7 @@ func (s *MachineSuite) assertMachineDirtyAfterAddingUnit(c *gc.C) (*state.Machin
 	c.Assert(m.Clean(), jc.IsTrue)
 
 	svc := s.AddTestingService(c, "wordpress", s.AddTestingCharm(c, "wordpress"))
-	unit, err := svc.AddUnit()
+	unit, err := svc.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	err = unit.AssignToMachine(m)
 	c.Assert(err, jc.ErrorIsNil)
@@ -1253,7 +1253,7 @@ func (s *MachineSuite) TestWatchPrincipalUnits(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	wc.AssertNoChange()
 	mysql := s.AddTestingService(c, "mysql", s.AddTestingCharm(c, "mysql"))
-	mysql0, err := mysql.AddUnit()
+	mysql0, err := mysql.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	wc.AssertNoChange()
 
@@ -1277,7 +1277,7 @@ func (s *MachineSuite) TestWatchPrincipalUnits(c *gc.C) {
 	wc.AssertNoChange()
 
 	// Assign another unit and make the first Dying; check both changes detected.
-	mysql1, err := mysql.AddUnit()
+	mysql1, err := mysql.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	err = mysql1.AssignToMachine(machine)
 	c.Assert(err, jc.ErrorIsNil)
@@ -1371,7 +1371,7 @@ func (s *MachineSuite) TestWatchUnits(c *gc.C) {
 
 	// Assign a unit (to a separate instance); change detected.
 	mysql := s.AddTestingService(c, "mysql", s.AddTestingCharm(c, "mysql"))
-	mysql0, err := mysql.AddUnit()
+	mysql0, err := mysql.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	machine, err := s.State.Machine(s.machine.Id())
 	c.Assert(err, jc.ErrorIsNil)
@@ -1392,7 +1392,7 @@ func (s *MachineSuite) TestWatchUnits(c *gc.C) {
 	wc.AssertNoChange()
 
 	// Assign another unit and make the first Dying; check both changes detected.
-	mysql1, err := mysql.AddUnit()
+	mysql1, err := mysql.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	err = mysql1.AssignToMachine(machine)
 	c.Assert(err, jc.ErrorIsNil)

--- a/state/metrics_test.go
+++ b/state/metrics_test.go
@@ -428,7 +428,7 @@ func (s *MetricSuite) TestMetricValidation(c *gc.C) {
 	nonMeteredUnit := s.Factory.MakeUnit(c, &factory.UnitParams{SetCharmURL: true})
 	meteredApplication := s.Factory.MakeApplication(c, &factory.ApplicationParams{Name: "metered-service", Charm: s.meteredCharm})
 	meteredUnit := s.Factory.MakeUnit(c, &factory.UnitParams{Application: meteredApplication, SetCharmURL: true})
-	dyingUnit, err := meteredApplication.AddUnit()
+	dyingUnit, err := meteredApplication.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	err = dyingUnit.SetCharmURL(s.meteredCharm.URL())
 	c.Assert(err, jc.ErrorIsNil)
@@ -667,7 +667,7 @@ func (s *MetricLocalCharmSuite) TestUnitMetricBatches(c *gc.C) {
 		},
 	)
 	c.Assert(err, jc.ErrorIsNil)
-	newUnit, err := s.application.AddUnit()
+	newUnit, err := s.application.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	_, err = s.State.AddMetrics(
 		state.BatchParam{
@@ -713,7 +713,7 @@ func (s *MetricLocalCharmSuite) TestApplicationMetricBatches(c *gc.C) {
 		},
 	)
 	c.Assert(err, jc.ErrorIsNil)
-	newUnit, err := s.application.AddUnit()
+	newUnit, err := s.application.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	_, err = s.State.AddMetrics(
 		state.BatchParam{
@@ -758,7 +758,7 @@ func (s *MetricLocalCharmSuite) TestModelMetricBatches(c *gc.C) {
 		},
 	)
 	c.Assert(err, jc.ErrorIsNil)
-	newUnit, err := s.application.AddUnit()
+	newUnit, err := s.application.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	_, err = s.State.AddMetrics(
 		state.BatchParam{
@@ -827,7 +827,7 @@ func (s *MetricLocalCharmSuite) TestModelMetricBatches(c *gc.C) {
 }
 
 func (s *MetricLocalCharmSuite) TestMetricsSorted(c *gc.C) {
-	newUnit, err := s.application.AddUnit()
+	newUnit, err := s.application.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 
 	t0 := time.Date(2016, time.August, 16, 16, 00, 35, 0, time.Local)

--- a/state/migration_export_test.go
+++ b/state/migration_export_test.go
@@ -117,7 +117,7 @@ func (s *MigrationBaseSuite) makeUnitWithStorage(c *gc.C) (*state.Application, *
 		"data": makeStorageCons(pool, 1024, 1),
 	}
 	service := s.AddTestingServiceWithStorage(c, "storage-"+kind, ch, storage)
-	unit, err := service.AddUnit()
+	unit, err := service.AddUnit(state.AddUnitParams{})
 
 	machine := s.Factory.MakeMachine(c, nil)
 	err = unit.AssignToMachine(machine)

--- a/state/minimumunits_test.go
+++ b/state/minimumunits_test.go
@@ -31,7 +31,7 @@ func (s *MinUnitsSuite) assertRevno(c *gc.C, expectedRevno int, expectedErr erro
 
 func (s *MinUnitsSuite) addUnits(c *gc.C, count int) {
 	for i := 0; i < count; i++ {
-		_, err := s.service.AddUnit()
+		_, err := s.service.AddUnit(state.AddUnitParams{})
 		c.Assert(err, jc.ErrorIsNil)
 	}
 }
@@ -197,9 +197,9 @@ func (s *MinUnitsSuite) TestMinUnitsSetDestroyEntities(c *gc.C) {
 	s.assertRevno(c, 0, nil)
 
 	// Add two units to the service for later use.
-	unit1, err := s.service.AddUnit()
+	unit1, err := s.service.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
-	unit2, err := s.service.AddUnit()
+	unit2, err := s.service.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Destroy a unit and ensure the revno has been increased.
@@ -221,9 +221,9 @@ func (s *MinUnitsSuite) TestMinUnitsSetDestroyEntities(c *gc.C) {
 
 func (s *MinUnitsSuite) TestMinUnitsNotSetDestroyEntities(c *gc.C) {
 	// Add two units to the service for later use.
-	unit1, err := s.service.AddUnit()
+	unit1, err := s.service.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
-	unit2, err := s.service.AddUnit()
+	unit2, err := s.service.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Destroy a unit and ensure the minUnits document has not been created.

--- a/state/payloads_test.go
+++ b/state/payloads_test.go
@@ -667,7 +667,7 @@ func addUnit(c *gc.C, s ConnSuite, args unitArgs) *state.Unit {
 	ch = s.AddMetaCharm(c, args.charm, args.metadata, 2)
 
 	svc := s.AddTestingService(c, args.service, ch)
-	unit, err := svc.AddUnit()
+	unit, err := svc.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 
 	// TODO(ericsnow) Explicitly: call unit.AssignToMachine(m)?

--- a/state/prechecker_test.go
+++ b/state/prechecker_test.go
@@ -159,7 +159,7 @@ func (s *PrecheckerSuite) TestPrecheckAddApplication(c *gc.C) {
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
-	unit, err := app.AddUnit()
+	unit, err := app.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	err = unit.AssignToNewMachine()
 	c.Assert(err, jc.ErrorIsNil)

--- a/state/relation_test.go
+++ b/state/relation_test.go
@@ -69,7 +69,7 @@ func (s *RelationSuite) TestAddRelationErrors(c *gc.C) {
 	assertNoRelations(c, mysql)
 
 	// Check that a relation can't be added to a Dying service.
-	_, err = wordpress.AddUnit()
+	_, err = wordpress.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	err = wordpress.Destroy()
 	c.Assert(err, jc.ErrorIsNil)

--- a/state/relationunit_test.go
+++ b/state/relationunit_test.go
@@ -56,7 +56,7 @@ func assertNotJoined(c *gc.C, ru *state.RelationUnit) {
 
 func (s *RelationUnitSuite) TestReadSettingsErrors(c *gc.C) {
 	riak := s.AddTestingService(c, "riak", s.AddTestingCharm(c, "riak"))
-	u0, err := riak.AddUnit()
+	u0, err := riak.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	riakEP, err := riak.Endpoint("ring")
 	c.Assert(err, jc.ErrorIsNil)
@@ -272,7 +272,7 @@ func (s *RelationUnitSuite) TestContainerCreateSubordinate(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	rel, err := s.State.AddRelation(eps...)
 	c.Assert(err, jc.ErrorIsNil)
-	punit, err := psvc.AddUnit()
+	punit, err := psvc.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	pru, err := rel.Unit(punit)
 	c.Assert(err, jc.ErrorIsNil)
@@ -950,7 +950,7 @@ func addRU(c *gc.C, svc *state.Application, rel *state.Relation, principal *stat
 	// relation's scope as the principal.
 	var u *state.Unit
 	if principal == nil {
-		unit, err := svc.AddUnit()
+		unit, err := svc.AddUnit(state.AddUnitParams{})
 		c.Assert(err, jc.ErrorIsNil)
 		u = unit
 	} else {
@@ -1055,7 +1055,7 @@ func (s *WatchScopeSuite) TestPeer(c *gc.C) {
 	// the information to be available, and uses it to populate the
 	// relation settings node.)
 	addUnit := func(i int) *state.RelationUnit {
-		unit, err := riak.AddUnit()
+		unit, err := riak.AddUnit(state.AddUnitParams{})
 		c.Assert(err, jc.ErrorIsNil)
 		err = unit.AssignToNewMachine()
 		c.Assert(err, jc.ErrorIsNil)
@@ -1185,7 +1185,7 @@ func (s *WatchScopeSuite) TestProviderRequirerGlobal(c *gc.C) {
 
 	// Add some units to the services and set their private addresses.
 	addUnit := func(srv *state.Application, sub string, ep state.Endpoint) *state.RelationUnit {
-		unit, err := srv.AddUnit()
+		unit, err := srv.AddUnit(state.AddUnitParams{})
 		c.Assert(err, jc.ErrorIsNil)
 		ru, err := rel.Unit(unit)
 		c.Assert(err, jc.ErrorIsNil)
@@ -1318,7 +1318,7 @@ func (s *WatchScopeSuite) TestProviderRequirerContainer(c *gc.C) {
 
 	// Add some units to the services and set their private addresses.
 	addUnits := func(i int) (*state.RelationUnit, *state.RelationUnit) {
-		msu, err := mysql.AddUnit()
+		msu, err := mysql.AddUnit(state.AddUnitParams{})
 		c.Assert(err, jc.ErrorIsNil)
 		msru, err := rel.Unit(msu)
 		c.Assert(err, jc.ErrorIsNil)
@@ -1462,7 +1462,7 @@ func (s *WatchUnitsSuite) TestProviderRequirerGlobal(c *gc.C) {
 
 	// Add some units to the services and set their private addresses.
 	addUnit := func(srv *state.Application) *state.RelationUnit {
-		unit, err := srv.AddUnit()
+		unit, err := srv.AddUnit(state.AddUnitParams{})
 		c.Assert(err, jc.ErrorIsNil)
 		ru, err := rel.Unit(unit)
 		c.Assert(err, jc.ErrorIsNil)

--- a/state/remoteapplication_test.go
+++ b/state/remoteapplication_test.go
@@ -736,7 +736,7 @@ func (s *remoteApplicationSuite) assertDestroyWithReferencedRelation(c *gc.C, re
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Add a separate reference to the first relation.
-	unit, err := wordpress.AddUnit()
+	unit, err := wordpress.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	ru, err := rel0.Unit(unit)
 	c.Assert(err, jc.ErrorIsNil)
@@ -910,7 +910,7 @@ func (s *remoteApplicationSuite) TestWatchRemoteApplicationsDying(c *gc.C) {
 
 	// Add a unit to the relation so the remote application is not
 	// short-circuit removed.
-	unit, err := wordpress.AddUnit()
+	unit, err := wordpress.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	ru, err := rel.Unit(unit)
 	c.Assert(err, jc.ErrorIsNil)

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -586,7 +586,7 @@ func (s *MultiModelStateSuite) TestWatchTwoModels(c *gc.C) {
 				dummyCharm := f.MakeCharm(c, &factory.CharmParams{Name: "dummy"})
 				service := f.MakeApplication(c, &factory.ApplicationParams{Name: "dummy", Charm: dummyCharm})
 
-				unit, err := service.AddUnit()
+				unit, err := service.AddUnit(state.AddUnitParams{})
 				c.Assert(err, jc.ErrorIsNil)
 				return unit.WatchActionNotifications()
 			},
@@ -1373,13 +1373,13 @@ func (s *StateSuite) TestAllRelations(c *gc.C) {
 	_, err := s.State.AddMachine("quantal", state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)
 	mysql := s.AddTestingService(c, "mysql", s.AddTestingCharm(c, "mysql"))
-	_, err = mysql.AddUnit()
+	_, err = mysql.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	wordpressCharm := s.AddTestingCharm(c, "wordpress")
 	for i := 0; i < numRelations; i++ {
 		applicationname := fmt.Sprintf("wordpress%d", i)
 		wordpress := s.AddTestingService(c, applicationname, wordpressCharm)
-		_, err = wordpress.AddUnit()
+		_, err = wordpress.AddUnit(state.AddUnitParams{})
 		c.Assert(err, jc.ErrorIsNil)
 		eps, err := s.State.InferEndpoints(applicationname, "mysql")
 		c.Assert(err, jc.ErrorIsNil)
@@ -2068,7 +2068,7 @@ func (s *StateSuite) TestWatchServicesBulkEvents(c *gc.C) {
 
 	// Dying service...
 	dying := s.AddTestingService(c, "service1", dummyCharm)
-	keepDying, err := dying.AddUnit()
+	keepDying, err := dying.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	err = dying.Destroy()
 	c.Assert(err, jc.ErrorIsNil)
@@ -2108,7 +2108,7 @@ func (s *StateSuite) TestWatchServicesLifecycle(c *gc.C) {
 	wc.AssertNoChange()
 
 	// Change the service: not reported.
-	keepDying, err := service.AddUnit()
+	keepDying, err := service.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	wc.AssertNoChange()
 
@@ -2868,7 +2868,7 @@ func (s *StateSuite) TestAddAndGetEquivalence(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(wordpress1, jc.DeepEquals, wordpress2)
 
-	unit1, err := wordpress1.AddUnit()
+	unit1, err := wordpress1.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	unit2, err := s.State.Unit("wordpress/0")
 	c.Assert(err, jc.ErrorIsNil)
@@ -3047,7 +3047,7 @@ func (s *StateSuite) TestFindEntity(c *gc.C) {
 	_, err := s.State.AddMachine("quantal", state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)
 	svc := s.AddTestingService(c, "ser-vice2", s.AddTestingCharm(c, "mysql"))
-	unit, err := svc.AddUnit()
+	unit, err := svc.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	_, err = unit.AddAction("fakeaction", nil)
 	c.Assert(err, jc.ErrorIsNil)
@@ -3119,7 +3119,7 @@ func (s *StateSuite) TestParseApplicationTag(c *gc.C) {
 
 func (s *StateSuite) TestParseUnitTag(c *gc.C) {
 	svc := s.AddTestingService(c, "service2", s.AddTestingCharm(c, "dummy"))
-	u, err := svc.AddUnit()
+	u, err := svc.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	coll, id, err := state.ConvertTagToCollectionNameAndId(s.State, u.Tag())
 	c.Assert(err, jc.ErrorIsNil)
@@ -3129,7 +3129,7 @@ func (s *StateSuite) TestParseUnitTag(c *gc.C) {
 
 func (s *StateSuite) TestParseActionTag(c *gc.C) {
 	svc := s.AddTestingService(c, "service2", s.AddTestingCharm(c, "dummy"))
-	u, err := svc.AddUnit()
+	u, err := svc.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	f, err := u.AddAction("snapshot", nil)
 	c.Assert(err, jc.ErrorIsNil)
@@ -3254,11 +3254,11 @@ func (s *StateSuite) TestWatchMinUnits(c *gc.C) {
 	wordpressName := wordpress.Name()
 
 	// Add service units for later use.
-	wordpress0, err := wordpress.AddUnit()
+	wordpress0, err := wordpress.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
-	wordpress1, err := wordpress.AddUnit()
+	wordpress1, err := wordpress.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
-	mysql0, err := mysql.AddUnit()
+	mysql0, err := mysql.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	// No events should occur.
 	wc.AssertNoChange()
@@ -3532,17 +3532,17 @@ func (s *StateSuite) TestSetEnvironAgentVersionErrors(c *gc.C) {
 	// with the new version.
 	service, err := s.State.AddApplication(state.AddApplicationArgs{Name: "wordpress", Charm: s.AddTestingCharm(c, "wordpress")})
 	c.Assert(err, jc.ErrorIsNil)
-	unit0, err := service.AddUnit()
+	unit0, err := service.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	err = unit0.SetAgentVersion(version.MustParseBinary("6.6.6-quantal-amd64"))
 	c.Assert(err, jc.ErrorIsNil)
-	_, err = service.AddUnit()
+	_, err = service.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
-	unit2, err := service.AddUnit()
+	unit2, err := service.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	err = unit2.SetAgentVersion(version.MustParseBinary(stringVersion + "-quantal-amd64"))
 	c.Assert(err, jc.ErrorIsNil)
-	unit3, err := service.AddUnit()
+	unit3, err := service.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	err = unit3.SetAgentVersion(version.MustParseBinary("4.5.6-quantal-amd64"))
 	c.Assert(err, jc.ErrorIsNil)
@@ -3582,7 +3582,7 @@ func (s *StateSuite) prepareAgentVersionTests(c *gc.C, st *state.State) (*config
 	c.Assert(err, jc.ErrorIsNil)
 	service, err := st.AddApplication(state.AddApplicationArgs{Name: "wordpress", Charm: s.AddTestingCharm(c, "wordpress")})
 	c.Assert(err, jc.ErrorIsNil)
-	unit, err := service.AddUnit()
+	unit, err := service.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 
 	err = machine.SetAgentVersion(version.MustParseBinary(currentVersion + "-quantal-amd64"))

--- a/state/status_service_test.go
+++ b/state/status_service_test.go
@@ -100,7 +100,7 @@ func (s *ServiceStatusSuite) checkGetSetStatus(c *gc.C) {
 }
 
 func (s *ServiceStatusSuite) TestGetSetStatusDying(c *gc.C) {
-	_, err := s.service.AddUnit()
+	_, err := s.service.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	err = s.service.Destroy()
 	c.Assert(err, jc.ErrorIsNil)
@@ -162,7 +162,7 @@ func (s *ServiceStatusSuite) TestDeriveStatus(c *gc.C) {
 
 	// Create a unit with each possible status.
 	addUnit := func(unitStatus status.Status) *state.Unit {
-		unit, err := s.service.AddUnit()
+		unit, err := s.service.AddUnit(state.AddUnitParams{})
 		c.Assert(err, gc.IsNil)
 		now := testing.ZeroTime()
 		sInfo := status.StatusInfo{
@@ -182,7 +182,7 @@ func (s *ServiceStatusSuite) TestDeriveStatus(c *gc.C) {
 	unknownUnit := addUnit(status.Unknown)
 
 	// ...and create one with error status by setting it on the agent :-/.
-	errorUnit, err := s.service.AddUnit()
+	errorUnit, err := s.service.AddUnit(state.AddUnitParams{})
 	c.Assert(err, gc.IsNil)
 	now := testing.ZeroTime()
 	sInfo := status.StatusInfo{
@@ -218,7 +218,7 @@ func (s *ServiceStatusSuite) TestDeriveStatus(c *gc.C) {
 }
 
 func (s *ServiceStatusSuite) TestServiceStatusOverridesDerivedStatus(c *gc.C) {
-	unit, err := s.service.AddUnit()
+	unit, err := s.service.AddUnit(state.AddUnitParams{})
 	c.Assert(err, gc.IsNil)
 	now := testing.ZeroTime()
 	sInfo := status.StatusInfo{

--- a/state/status_unitagent_test.go
+++ b/state/status_unitagent_test.go
@@ -81,7 +81,7 @@ func (s *StatusUnitAgentSuite) TestSetAllocatingStatusAlreadyAssigned(c *gc.C) {
 
 func (s *StatusUnitAgentSuite) TestSetStatusUnassigned(c *gc.C) {
 	app := s.Factory.MakeApplication(c, &factory.ApplicationParams{Name: "foo"})
-	u, err := app.AddUnit()
+	u, err := app.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	agent := u.Agent()
 	for _, value := range []status.Status{status.Idle, status.Executing, status.Rebooting, status.Failed} {

--- a/state/storage_dynamicadd_test.go
+++ b/state/storage_dynamicadd_test.go
@@ -32,7 +32,7 @@ func (s *storageAddSuite) setupMultipleStoragesForAdd(c *gc.C) *state.Unit {
 	charm := s.AddTestingCharm(c, "storage-block2")
 	service, err := s.State.AddApplication(state.AddApplicationArgs{Name: "storage-block2", Charm: charm, Storage: storageCons})
 	c.Assert(err, jc.ErrorIsNil)
-	u, err := service.AddUnit()
+	u, err := service.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	s.unitTag = u.UnitTag()
 	all, err := s.State.AllStorageInstances()

--- a/state/storage_test.go
+++ b/state/storage_test.go
@@ -55,7 +55,7 @@ func (s *StorageStateSuiteBase) setupSingleStorage(c *gc.C, kind, pool string) (
 		"data": makeStorageCons(pool, 1024, 1),
 	}
 	app := s.AddTestingServiceWithStorage(c, "storage-"+kind, ch, storage)
-	unit, err := app.AddUnit()
+	unit, err := app.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	storageTag := names.NewStorageTag("data/0")
 	return app, unit, storageTag
@@ -89,7 +89,7 @@ func (s *StorageStateSuiteBase) setupSingleStorageDetachable(c *gc.C, kind, pool
 		"data": makeStorageCons(pool, 1024, 1),
 	}
 	app := s.AddTestingServiceWithStorage(c, ch.URL().Name, ch, storage)
-	unit, err := app.AddUnit()
+	unit, err := app.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	storageTag := names.NewStorageTag("data/0")
 	return app, unit, storageTag
@@ -566,7 +566,7 @@ func (s *StorageStateSuite) assertStorageUnitsAdded(c *gc.C) {
 	}
 	app := s.AddTestingServiceWithStorage(c, "storage-block2", ch, storage)
 	for i := 0; i < 2; i++ {
-		u, err := app.AddUnit()
+		u, err := app.AddUnit(state.AddUnitParams{})
 		c.Assert(err, jc.ErrorIsNil)
 		storageAttachments, err := s.State.UnitStorageAttachments(u.UnitTag())
 		c.Assert(err, jc.ErrorIsNil)
@@ -720,7 +720,7 @@ func (s *StorageStateSuite) TestRemoveStorageAttachmentsDisownsUnitOwnedInstance
 
 func (s *StorageStateSuite) TestAttachStorageTakesOwnership(c *gc.C) {
 	app, u, storageTag := s.setupSingleStorageDetachable(c, "block", "modelscoped")
-	u2, err := app.AddUnit()
+	u2, err := app.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Detach, but do not destroy, the storage.
@@ -739,7 +739,7 @@ func (s *StorageStateSuite) TestAttachStorageTakesOwnership(c *gc.C) {
 
 func (s *StorageStateSuite) TestAttachStorageAssignedMachine(c *gc.C) {
 	app, u, storageTag := s.setupSingleStorageDetachable(c, "block", "modelscoped")
-	u2, err := app.AddUnit()
+	u2, err := app.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Detach, but do not destroy, the storage.
@@ -769,7 +769,7 @@ func (s *StorageStateSuite) TestAttachStorageAssignedMachine(c *gc.C) {
 func (s *StorageStateSuite) TestAttachStorageAssignedMachineExistingVolume(c *gc.C) {
 	// Create volume-backed filesystem storage.
 	app, u, storageTag := s.setupSingleStorageDetachable(c, "filesystem", "modelscoped-block")
-	u2, err := app.AddUnit()
+	u2, err := app.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Assign the first unit to a machine so that we have a
@@ -816,7 +816,7 @@ func (s *StorageStateSuite) TestAttachStorageAssignedMachineExistingVolume(c *gc
 
 func (s *StorageStateSuite) TestAttachStorageAssignedMachineExistingVolumeAttached(c *gc.C) {
 	app, u, storageTag := s.setupSingleStorageDetachable(c, "block", "modelscoped")
-	u2, err := app.AddUnit()
+	u2, err := app.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Assign the first unit to a machine so that we have a
@@ -904,7 +904,7 @@ func (s *StorageStateSuite) TestAddApplicationAttachStorageTooMany(c *gc.C) {
 	// application creation should fail.
 	var storageTags []names.StorageTag
 	for i := 0; i < 3; i++ {
-		u, err := app.AddUnit()
+		u, err := app.AddUnit(state.AddUnitParams{})
 		c.Assert(err, jc.ErrorIsNil)
 		storageTag := names.NewStorageTag("data/" + fmt.Sprint(i+1))
 		storageTags = append(storageTags, storageTag)
@@ -1044,7 +1044,7 @@ func (s *StorageStateSuite) TestWatchStorageAttachments(c *gc.C) {
 		"multi2up":   makeStorageCons("loop-pool", 2048, 2),
 	}
 	app := s.AddTestingServiceWithStorage(c, "storage-block2", ch, storage)
-	u, err := app.AddUnit()
+	u, err := app.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 
 	w := s.State.WatchStorageAttachments(u.UnitTag())
@@ -1084,7 +1084,7 @@ func (s *StorageStateSuite) TestWatchStorageAttachment(c *gc.C) {
 
 func (s *StorageStateSuite) TestDestroyUnitStorageAttachments(c *gc.C) {
 	app := s.setupMixedScopeStorageApplication(c, "block")
-	u, err := app.AddUnit()
+	u, err := app.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	err = u.Destroy()
 	c.Assert(err, jc.ErrorIsNil)
@@ -1176,7 +1176,7 @@ func (s *StorageStateSuite) testStorageLocationConflict(c *gc.C, first, second, 
 	svc1 := s.AddTestingService(c, "storage-filesystem", ch1)
 	svc2 := s.AddTestingService(c, "storage-filesystem2", ch2)
 
-	u1, err := svc1.AddUnit()
+	u1, err := svc1.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	err = s.State.AssignUnit(u1, state.AssignCleanEmpty)
 	c.Assert(err, jc.ErrorIsNil)
@@ -1186,7 +1186,7 @@ func (s *StorageStateSuite) testStorageLocationConflict(c *gc.C, first, second, 
 	m, err := s.State.Machine(machineId)
 	c.Assert(err, jc.ErrorIsNil)
 
-	u2, err := svc2.AddUnit()
+	u2, err := svc2.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	err = u2.AssignToMachine(m)
 	if expectErr == "" {
@@ -1273,7 +1273,7 @@ func (s *StorageSubordinateStateSuite) SetUpTest(c *gc.C) {
 	storageCharm := s.AddTestingCharm(c, "storage-filesystem-subordinate")
 	s.subordinateApplication = s.AddTestingService(c, "storage-filesystem-subordinate", storageCharm)
 	s.mysql = s.AddTestingService(c, "mysql", s.AddTestingCharm(c, "mysql"))
-	s.mysqlUnit, err = s.mysql.AddUnit()
+	s.mysqlUnit, err = s.mysql.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 
 	eps, err := s.State.InferEndpoints("mysql", "storage-filesystem-subordinate")

--- a/state/unit_test.go
+++ b/state/unit_test.go
@@ -41,7 +41,7 @@ func (s *UnitSuite) SetUpTest(c *gc.C) {
 	var err error
 	s.service = s.AddTestingService(c, "wordpress", s.charm)
 	c.Assert(err, jc.ErrorIsNil)
-	s.unit, err = s.service.AddUnit()
+	s.unit, err = s.service.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(s.unit.Series(), gc.Equals, "quantal")
 }
@@ -347,7 +347,7 @@ func (s *UnitSuite) destroyMachineTestCases(c *gc.C) []destroyMachineTestCase {
 		tc := destroyMachineTestCase{desc: "standalone principal", destroyed: true}
 		tc.host, err = s.State.AddMachine("quantal", state.JobHostUnits)
 		c.Assert(err, jc.ErrorIsNil)
-		tc.target, err = s.service.AddUnit()
+		tc.target, err = s.service.AddUnit(state.AddUnitParams{})
 		c.Assert(err, jc.ErrorIsNil)
 		c.Assert(tc.target.AssignToMachine(tc.host), gc.IsNil)
 		result = append(result, tc)
@@ -356,10 +356,10 @@ func (s *UnitSuite) destroyMachineTestCases(c *gc.C) []destroyMachineTestCase {
 		tc := destroyMachineTestCase{desc: "co-located principals", destroyed: false}
 		tc.host, err = s.State.AddMachine("quantal", state.JobHostUnits)
 		c.Assert(err, jc.ErrorIsNil)
-		tc.target, err = s.service.AddUnit()
+		tc.target, err = s.service.AddUnit(state.AddUnitParams{})
 		c.Assert(err, jc.ErrorIsNil)
 		c.Assert(tc.target.AssignToMachine(tc.host), gc.IsNil)
-		colocated, err := s.service.AddUnit()
+		colocated, err := s.service.AddUnit(state.AddUnitParams{})
 		c.Assert(err, jc.ErrorIsNil)
 		c.Assert(colocated.AssignToMachine(tc.host), gc.IsNil)
 
@@ -374,7 +374,7 @@ func (s *UnitSuite) destroyMachineTestCases(c *gc.C) []destroyMachineTestCase {
 			Jobs:   []state.MachineJob{state.JobHostUnits},
 		}, tc.host.Id(), instance.LXD)
 		c.Assert(err, jc.ErrorIsNil)
-		tc.target, err = s.service.AddUnit()
+		tc.target, err = s.service.AddUnit(state.AddUnitParams{})
 		c.Assert(err, jc.ErrorIsNil)
 		c.Assert(tc.target.AssignToMachine(tc.host), gc.IsNil)
 
@@ -385,7 +385,7 @@ func (s *UnitSuite) destroyMachineTestCases(c *gc.C) []destroyMachineTestCase {
 		tc.host, err = s.State.AddMachine("quantal", state.JobHostUnits)
 		c.Assert(err, jc.ErrorIsNil)
 		c.Assert(tc.host.SetHasVote(true), gc.IsNil)
-		tc.target, err = s.service.AddUnit()
+		tc.target, err = s.service.AddUnit(state.AddUnitParams{})
 		c.Assert(err, jc.ErrorIsNil)
 		c.Assert(tc.target.AssignToMachine(tc.host), gc.IsNil)
 
@@ -395,7 +395,7 @@ func (s *UnitSuite) destroyMachineTestCases(c *gc.C) []destroyMachineTestCase {
 		tc := destroyMachineTestCase{desc: "unassigned unit", destroyed: true}
 		tc.host, err = s.State.AddMachine("quantal", state.JobHostUnits)
 		c.Assert(err, jc.ErrorIsNil)
-		tc.target, err = s.service.AddUnit()
+		tc.target, err = s.service.AddUnit(state.AddUnitParams{})
 		c.Assert(err, jc.ErrorIsNil)
 		c.Assert(tc.target.AssignToMachine(tc.host), gc.IsNil)
 		result = append(result, tc)
@@ -444,7 +444,7 @@ func (s *UnitSuite) setMachineVote(c *gc.C, id string, hasVote bool) {
 func (s *UnitSuite) TestRemoveUnitMachineThrashed(c *gc.C) {
 	host, err := s.State.AddMachine("quantal", state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)
-	target, err := s.service.AddUnit()
+	target, err := s.service.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(target.AssignToMachine(host), gc.IsNil)
 	flip := jujutxn.TestHook{
@@ -467,7 +467,7 @@ func (s *UnitSuite) TestRemoveUnitMachineThrashed(c *gc.C) {
 func (s *UnitSuite) TestRemoveUnitMachineRetryVoter(c *gc.C) {
 	host, err := s.State.AddMachine("quantal", state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)
-	target, err := s.service.AddUnit()
+	target, err := s.service.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(target.AssignToMachine(host), gc.IsNil)
 
@@ -482,7 +482,7 @@ func (s *UnitSuite) TestRemoveUnitMachineRetryVoter(c *gc.C) {
 func (s *UnitSuite) TestRemoveUnitMachineRetryNoVoter(c *gc.C) {
 	host, err := s.State.AddMachine("quantal", state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)
-	target, err := s.service.AddUnit()
+	target, err := s.service.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(target.AssignToMachine(host), gc.IsNil)
 	c.Assert(host.SetHasVote(true), gc.IsNil)
@@ -498,7 +498,7 @@ func (s *UnitSuite) TestRemoveUnitMachineRetryNoVoter(c *gc.C) {
 func (s *UnitSuite) TestRemoveUnitMachineRetryContainer(c *gc.C) {
 	host, err := s.State.AddMachine("quantal", state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)
-	target, err := s.service.AddUnit()
+	target, err := s.service.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(target.AssignToMachine(host), gc.IsNil)
 	defer state.SetTestHooks(c, s.State, jujutxn.TestHook{
@@ -526,12 +526,12 @@ func (s *UnitSuite) TestRemoveUnitMachineRetryContainer(c *gc.C) {
 func (s *UnitSuite) TestRemoveUnitMachineRetryOrCond(c *gc.C) {
 	host, err := s.State.AddMachine("quantal", state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)
-	target, err := s.service.AddUnit()
+	target, err := s.service.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(target.AssignToMachine(host), gc.IsNil)
 
 	// This unit will be colocated in the transaction hook to cause a retry.
-	colocated, err := s.service.AddUnit()
+	colocated, err := s.service.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Assert(host.SetHasVote(true), gc.IsNil)
@@ -875,7 +875,7 @@ func (s *UnitSuite) TestCannotShortCircuitDestroyWithAgentStatus(c *gc.C) {
 		status.Rebooting, "blah",
 	}} {
 		c.Logf("test %d: %s", i, test.status)
-		unit, err := s.service.AddUnit()
+		unit, err := s.service.AddUnit(state.AddUnitParams{})
 		c.Assert(err, jc.ErrorIsNil)
 		err = unit.AssignToNewMachine()
 		c.Assert(err, jc.ErrorIsNil)
@@ -1271,7 +1271,7 @@ func (s *UnitSuite) TestRemoveUnitRemovesItsPortsOnly(c *gc.C) {
 	err = s.unit.AssignToMachine(machine)
 	c.Assert(err, jc.ErrorIsNil)
 
-	otherUnit, err := s.service.AddUnit()
+	otherUnit, err := s.service.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	err = otherUnit.AssignToMachine(machine)
 	c.Assert(err, jc.ErrorIsNil)
@@ -1370,13 +1370,13 @@ func (s *UnitSuite) TestSubordinateChangeInPrincipal(c *gc.C) {
 
 func (s *UnitSuite) TestDeathWithSubordinates(c *gc.C) {
 	// Check that units can become dead when they've never had subordinates.
-	u, err := s.service.AddUnit()
+	u, err := s.service.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	err = u.EnsureDead()
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Create a new unit and add a subordinate.
-	u, err = s.service.AddUnit()
+	u, err = s.service.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	s.AddTestingService(c, "logging", s.AddTestingCharm(c, "logging"))
 	c.Assert(err, jc.ErrorIsNil)
@@ -1446,7 +1446,7 @@ func (s *UnitSuite) TestPrincipalName(c *gc.C) {
 func (s *UnitSuite) TestRelations(c *gc.C) {
 	wordpress0 := s.unit
 	mysql := s.AddTestingService(c, "mysql", s.AddTestingCharm(c, "mysql"))
-	mysql0, err := mysql.AddUnit()
+	mysql0, err := mysql.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	eps, err := s.State.InferEndpoints("wordpress", "mysql")
 	c.Assert(err, jc.ErrorIsNil)
@@ -1529,7 +1529,7 @@ func (s *UnitSuite) TestRemovePathological(c *gc.C) {
 	// However, if a unit of the *other* service joins the relation, that
 	// will add an additional reference and prevent the relation -- and
 	// thus wordpress itself -- from being removed when its last unit is.
-	mysql0, err := mysql.AddUnit()
+	mysql0, err := mysql.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	mysql0ru, err := rel.Unit(mysql0)
 	c.Assert(err, jc.ErrorIsNil)
@@ -1576,7 +1576,7 @@ func (s *UnitSuite) TestRemovePathologicalWithBuggyUniter(c *gc.C) {
 	// However, if a unit of the *other* service joins the relation, that
 	// will add an additional reference and prevent the relation -- and
 	// thus wordpress itself -- from being removed when its last unit is.
-	mysql0, err := mysql.AddUnit()
+	mysql0, err := mysql.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	mysql0ru, err := rel.Unit(mysql0)
 	c.Assert(err, jc.ErrorIsNil)
@@ -1728,7 +1728,7 @@ snapshot:
 `[1:]
 
 	wordpress := s.AddTestingService(c, "wordpress-actions", s.AddActionsCharm(c, "wordpress", basicActions, 1))
-	unit1, err := wordpress.AddUnit()
+	unit1, err := wordpress.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	specs, err := unit1.ActionSpecs()
 	c.Assert(err, jc.ErrorIsNil)
@@ -1811,10 +1811,10 @@ action-b-b:
 	// Add simple service and two units
 	dummy := s.AddTestingService(c, "dummy", s.AddActionsCharm(c, "dummy", basicActions, 1))
 
-	unit1, err := dummy.AddUnit()
+	unit1, err := dummy.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 
-	unit2, err := dummy.AddUnit()
+	unit2, err := dummy.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Add 3 actions to first unit, and 2 to the second unit
@@ -1852,7 +1852,7 @@ action-b-b:
 func (s *UnitSuite) TestWorkloadVersion(c *gc.C) {
 	ch := state.AddTestingCharm(c, s.State, "dummy")
 	app := state.AddTestingService(c, s.State, "alexandrite", ch)
-	unit, err := app.AddUnit()
+	unit, err := app.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 
 	version, err := unit.WorkloadVersion()

--- a/state/volume_test.go
+++ b/state/volume_test.go
@@ -278,7 +278,7 @@ func (s *VolumeStateSuite) TestWatchVolumeAttachment(c *gc.C) {
 func (s *VolumeStateSuite) TestWatchModelVolumes(c *gc.C) {
 	app := s.setupMixedScopeStorageApplication(c, "block")
 	addUnit := func() {
-		u, err := app.AddUnit()
+		u, err := app.AddUnit(state.AddUnitParams{})
 		c.Assert(err, jc.ErrorIsNil)
 		err = s.State.AssignUnit(u, state.AssignCleanEmpty)
 		c.Assert(err, jc.ErrorIsNil)
@@ -319,7 +319,7 @@ func (s *VolumeStateSuite) TestWatchModelVolumes(c *gc.C) {
 func (s *VolumeStateSuite) TestWatchEnvironVolumeAttachments(c *gc.C) {
 	app := s.setupMixedScopeStorageApplication(c, "block")
 	addUnit := func() {
-		u, err := app.AddUnit()
+		u, err := app.AddUnit(state.AddUnitParams{})
 		c.Assert(err, jc.ErrorIsNil)
 		err = s.State.AssignUnit(u, state.AssignCleanEmpty)
 		c.Assert(err, jc.ErrorIsNil)
@@ -350,7 +350,7 @@ func (s *VolumeStateSuite) TestWatchEnvironVolumeAttachments(c *gc.C) {
 func (s *VolumeStateSuite) TestWatchMachineVolumes(c *gc.C) {
 	app := s.setupMixedScopeStorageApplication(c, "block", "machinescoped", "modelscoped")
 	addUnit := func() {
-		u, err := app.AddUnit()
+		u, err := app.AddUnit(state.AddUnitParams{})
 		c.Assert(err, jc.ErrorIsNil)
 		err = s.State.AssignUnit(u, state.AssignCleanEmpty)
 		c.Assert(err, jc.ErrorIsNil)
@@ -391,7 +391,7 @@ func (s *VolumeStateSuite) TestWatchMachineVolumeAttachments(c *gc.C) {
 	app := s.setupMixedScopeStorageApplication(c, "block", "machinescoped", "modelscoped")
 	addUnit := func(to *state.Machine) (u *state.Unit, m *state.Machine) {
 		var err error
-		u, err = app.AddUnit()
+		u, err = app.AddUnit(state.AddUnitParams{})
 		c.Assert(err, jc.ErrorIsNil)
 		if to != nil {
 			err = u.AssignToMachine(to)

--- a/testing/factory/factory.go
+++ b/testing/factory/factory.go
@@ -488,7 +488,7 @@ func (factory *Factory) MakeUnitReturningPassword(c *gc.C, params *UnitParams) (
 		params.Password, err = utils.RandomPassword()
 		c.Assert(err, jc.ErrorIsNil)
 	}
-	unit, err := params.Application.AddUnit()
+	unit, err := params.Application.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	err = unit.AssignToMachine(params.Machine)
 	c.Assert(err, jc.ErrorIsNil)

--- a/worker/deployer/deployer_test.go
+++ b/worker/deployer/deployer_test.go
@@ -58,9 +58,9 @@ func (s *deployerSuite) makeDeployerAndContext(c *gc.C) (worker.Worker, deployer
 func (s *deployerSuite) TestDeployRecallRemovePrincipals(c *gc.C) {
 	// Create a machine, and a couple of units.
 	svc := s.AddTestingService(c, "wordpress", s.AddTestingCharm(c, "wordpress"))
-	u0, err := svc.AddUnit()
+	u0, err := svc.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
-	u1, err := svc.AddUnit()
+	u1, err := svc.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 
 	dep, ctx := s.makeDeployerAndContext(c)
@@ -110,7 +110,7 @@ func (s *deployerSuite) TestDeployRecallRemovePrincipals(c *gc.C) {
 
 func (s *deployerSuite) TestInitialStatusMessages(c *gc.C) {
 	svc := s.AddTestingService(c, "wordpress", s.AddTestingCharm(c, "wordpress"))
-	u0, err := svc.AddUnit()
+	u0, err := svc.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 
 	dep, _ := s.makeDeployerAndContext(c)
@@ -126,9 +126,9 @@ func (s *deployerSuite) TestInitialStatusMessages(c *gc.C) {
 func (s *deployerSuite) TestRemoveNonAlivePrincipals(c *gc.C) {
 	// Create a service, and a couple of units.
 	svc := s.AddTestingService(c, "wordpress", s.AddTestingCharm(c, "wordpress"))
-	u0, err := svc.AddUnit()
+	u0, err := svc.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
-	u1, err := svc.AddUnit()
+	u1, err := svc.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Assign the units to the machine, and set them to Dying/Dead.
@@ -163,7 +163,7 @@ func (s *deployerSuite) TestRemoveNonAlivePrincipals(c *gc.C) {
 
 func (s *deployerSuite) prepareSubordinates(c *gc.C) (*state.Unit, []*state.RelationUnit) {
 	svc := s.AddTestingService(c, "wordpress", s.AddTestingCharm(c, "wordpress"))
-	u, err := svc.AddUnit()
+	u, err := svc.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	err = u.AssignToMachine(s.machine)
 	c.Assert(err, jc.ErrorIsNil)

--- a/worker/firewaller/firewaller_test.go
+++ b/worker/firewaller/firewaller_test.go
@@ -150,7 +150,7 @@ func (s *firewallerBaseSuite) assertEnvironPorts(c *gc.C, expected []network.Ing
 }
 
 func (s *firewallerBaseSuite) addUnit(c *gc.C, app *state.Application) (*state.Unit, *state.Machine) {
-	u, err := app.AddUnit()
+	u, err := app.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	err = s.State.AssignUnit(u, state.AssignCleanEmpty)
 	c.Assert(err, jc.ErrorIsNil)
@@ -419,7 +419,7 @@ func (s *InstanceModeSuite) TestStartWithPartialState(c *gc.C) {
 	s.assertPorts(c, inst, m.Id(), nil)
 
 	// Complete steps to open port.
-	u, err := app.AddUnit()
+	u, err := app.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	err = u.AssignToMachine(m)
 	c.Assert(err, jc.ErrorIsNil)
@@ -437,7 +437,7 @@ func (s *InstanceModeSuite) TestStartWithUnexposedApplication(c *gc.C) {
 	inst := s.startInstance(c, m)
 
 	app := s.AddTestingService(c, "wordpress", s.charm)
-	u, err := app.AddUnit()
+	u, err := app.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	err = u.AssignToMachine(m)
 	c.Assert(err, jc.ErrorIsNil)
@@ -893,7 +893,7 @@ func (s *GlobalModeSuite) TestStartWithUnexposedApplication(c *gc.C) {
 	s.startInstance(c, m)
 
 	app := s.AddTestingService(c, "wordpress", s.charm)
-	u, err := app.AddUnit()
+	u, err := app.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	err = u.AssignToMachine(m)
 	c.Assert(err, jc.ErrorIsNil)

--- a/worker/minunitsworker/minunitsworker_test.go
+++ b/worker/minunitsworker/minunitsworker_test.go
@@ -12,6 +12,7 @@ import (
 	worker "gopkg.in/juju/worker.v1"
 
 	"github.com/juju/juju/juju/testing"
+	"github.com/juju/juju/state"
 	coretesting "github.com/juju/juju/testing"
 	"github.com/juju/juju/worker/minunitsworker"
 )
@@ -31,9 +32,9 @@ func (s *minUnitsWorkerSuite) TestMinUnitsWorker(c *gc.C) {
 	// Set up services and units for later use.
 	wordpress := s.AddTestingService(c, "wordpress", s.AddTestingCharm(c, "wordpress"))
 	mysql := s.AddTestingService(c, "mysql", s.AddTestingCharm(c, "mysql"))
-	unit, err := wordpress.AddUnit()
+	unit, err := wordpress.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
-	_, err = wordpress.AddUnit()
+	_, err = wordpress.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Set up minimum units for applications.

--- a/worker/uniter/charm/bundles_test.go
+++ b/worker/uniter/charm/bundles_test.go
@@ -46,7 +46,7 @@ func (s *BundlesDirSuite) SetUpTest(c *gc.C) {
 	// Add a charm, service and unit to login to the API with.
 	charm := s.AddTestingCharm(c, "wordpress")
 	service := s.AddTestingService(c, "wordpress", charm)
-	unit, err := service.AddUnit()
+	unit, err := service.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	password, err := utils.RandomPassword()
 	c.Assert(err, jc.ErrorIsNil)

--- a/worker/uniter/relation/relationer_test.go
+++ b/worker/uniter/relation/relationer_test.go
@@ -74,7 +74,7 @@ func (s *RelationerSuite) SetUpTest(c *gc.C) {
 }
 
 func (s *RelationerSuite) AddRelationUnit(c *gc.C, name string) (*state.RelationUnit, *state.Unit) {
-	u, err := s.app.AddUnit()
+	u, err := s.app.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(u.Name(), gc.Equals, name)
 	machine, err := s.State.AddMachine("quantal", state.JobHostUnits)
@@ -297,7 +297,7 @@ var _ = gc.Suite(&RelationerImplicitSuite{})
 func (s *RelationerImplicitSuite) TestImplicitRelationer(c *gc.C) {
 	// Create a relationer for an implicit endpoint (mysql:juju-info).
 	mysql := s.AddTestingService(c, "mysql", s.AddTestingCharm(c, "mysql"))
-	u, err := mysql.AddUnit()
+	u, err := mysql.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	machine, err := s.State.AddMachine("quantal", state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)

--- a/worker/uniter/runner/context/flush_test.go
+++ b/worker/uniter/runner/context/flush_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/network"
+	"github.com/juju/juju/state"
 	"github.com/juju/juju/worker/metrics/spool"
 	"github.com/juju/juju/worker/uniter/runner/context"
 	runnertesting "github.com/juju/juju/worker/uniter/runner/testing"
@@ -101,7 +102,7 @@ func (s *FlushContextSuite) TestRunHookOpensAndClosesPendingPorts(c *gc.C) {
 	c.Assert(machinePorts, gc.HasLen, 0)
 
 	// Add another unit on the same machine.
-	otherUnit, err := s.service.AddUnit()
+	otherUnit, err := s.service.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	err = otherUnit.AssignToMachine(s.machine)
 	c.Assert(err, jc.ErrorIsNil)

--- a/worker/uniter/runner/context/relation_test.go
+++ b/worker/uniter/runner/context/relation_test.go
@@ -47,7 +47,7 @@ func (s *ContextRelationSuite) SetUpTest(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(rels, gc.HasLen, 1)
 	s.rel = rels[0]
-	unit, err := s.svc.AddUnit()
+	unit, err := s.svc.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	err = unit.AssignToMachine(machine)
 	s.ru, err = s.rel.Unit(unit)
@@ -73,7 +73,7 @@ func (s *ContextRelationSuite) SetUpTest(c *gc.C) {
 }
 
 func (s *ContextRelationSuite) TestMemberCaching(c *gc.C) {
-	unit, err := s.svc.AddUnit()
+	unit, err := s.svc.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	ru, err := s.rel.Unit(unit)
 	c.Assert(err, jc.ErrorIsNil)
@@ -105,7 +105,7 @@ func (s *ContextRelationSuite) TestMemberCaching(c *gc.C) {
 }
 
 func (s *ContextRelationSuite) TestNonMemberCaching(c *gc.C) {
-	unit, err := s.svc.AddUnit()
+	unit, err := s.svc.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	ru, err := s.rel.Unit(unit)
 	c.Assert(err, jc.ErrorIsNil)

--- a/worker/uniter/runner/context/util_test.go
+++ b/worker/uniter/runner/context/util_test.go
@@ -128,7 +128,7 @@ func (s *HookContextSuite) GetContext(
 }
 
 func (s *HookContextSuite) addUnit(c *gc.C, svc *state.Application) *state.Unit {
-	unit, err := svc.AddUnit()
+	unit, err := svc.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	if s.machine != nil {
 		err = unit.AssignToMachine(s.machine)

--- a/worker/uniter/runner/factory_test.go
+++ b/worker/uniter/runner/factory_test.go
@@ -295,7 +295,7 @@ func (s *FactorySuite) TestNewActionRunnerMissingAction(c *gc.C) {
 
 func (s *FactorySuite) TestNewActionRunnerUnauthAction(c *gc.C) {
 	s.SetCharm(c, "dummy")
-	otherUnit, err := s.service.AddUnit()
+	otherUnit, err := s.service.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	action, err := s.State.EnqueueAction(otherUnit.Tag(), "snapshot", nil)
 	c.Assert(err, jc.ErrorIsNil)

--- a/worker/uniter/runner/util_test.go
+++ b/worker/uniter/runner/util_test.go
@@ -137,7 +137,7 @@ func (s *ContextSuite) AddContextRelation(c *gc.C, name string) {
 }
 
 func (s *ContextSuite) AddUnit(c *gc.C, svc *state.Application) *state.Unit {
-	unit, err := svc.AddUnit()
+	unit, err := svc.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	if s.machine != nil {
 		err = unit.AssignToMachine(s.machine)

--- a/worker/uniter/uniter_test.go
+++ b/worker/uniter/uniter_test.go
@@ -1561,7 +1561,7 @@ func (s *UniterSuite) TestSubordinateDying(c *gc.C) {
 
 	// Create the principal service and add a relation.
 	wps := s.AddTestingService(c, "wordpress", s.AddTestingCharm(c, "wordpress"))
-	wpu, err := wps.AddUnit()
+	wpu, err := wps.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	eps, err := s.State.InferEndpoints("wordpress", "u")
 	c.Assert(err, jc.ErrorIsNil)

--- a/worker/uniter/util_test.go
+++ b/worker/uniter/util_test.go
@@ -414,7 +414,7 @@ func (csau createServiceAndUnit) step(c *gc.C, ctx *context) {
 	sch, err := ctx.st.Charm(curl(0))
 	c.Assert(err, jc.ErrorIsNil)
 	svc := ctx.s.AddTestingServiceWithStorage(c, csau.serviceName, sch, csau.storage)
-	unit, err := svc.AddUnit()
+	unit, err := svc.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Assign the unit to a provisioned machine to match expected state.
@@ -1167,7 +1167,7 @@ func (s addRelation) step(c *gc.C, ctx *context) {
 type addRelationUnit struct{}
 
 func (s addRelationUnit) step(c *gc.C, ctx *context) {
-	u, err := ctx.relatedSvc.AddUnit()
+	u, err := ctx.relatedSvc.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	ru, err := ctx.relation.Unit(u)
 	c.Assert(err, jc.ErrorIsNil)


### PR DESCRIPTION
## Description of change

We parameterise the Application.AddUnit method, and update all of the existing calls. The AddUnitParams struct is currently empty; it will be updated with the IDs of storage instances to attach to the unit in a follow-up.

This was partially automated using [the eg refactoring tool](https://godoc.org/golang.org/x/tools/cmd/eg), with the following template:

```go
package main
import "github.com/juju/juju/state"
func before(app *state.Application) {app.AddUnit()}
func after(app *state.Application) {app.AddUnitWithParams(state.AddUnitParams{})}
```

(where AddUnitWithParams was a temporary function, later renamed to AddUnit along with all of the callers)

## QA steps

There is no functional changes. Running the unit tests is more than sufficient.

## Documentation changes

None.

## Bug reference

None.