### PR TITLE
Implement the consume command using the new application offer APIs

### DIFF
--- a/api/application/client.go
+++ b/api/application/client.go
@@ -12,6 +12,7 @@ import (
 	"github.com/juju/loggo"
 	"gopkg.in/juju/charm.v6-unstable"
 	"gopkg.in/juju/names.v2"
+	"gopkg.in/macaroon.v1"
 
 	"github.com/juju/juju/api/base"
 	"github.com/juju/juju/apiserver/params"
@@ -408,12 +409,13 @@ func (c *Client) DestroyRelation(endpoints ...string) error {
 }
 
 // Consume adds a remote application to the model.
-func (c *Client) Consume(offer params.ApplicationOffer, alias string) (string, error) {
-	var consumeRes params.ConsumeApplicationResults
+func (c *Client) Consume(offer params.ApplicationOffer, alias string, macaroon *macaroon.Macaroon) (string, error) {
+	var consumeRes params.ErrorResults
 	args := params.ConsumeApplicationArgs{
 		Args: []params.ConsumeApplicationArg{{
 			ApplicationAlias: alias,
 			ApplicationOffer: offer,
+			Macaroon:         macaroon,
 		}},
 	}
 	err := c.facade.FacadeCall("Consume", args, &consumeRes)
@@ -426,5 +428,9 @@ func (c *Client) Consume(offer params.ApplicationOffer, alias string) (string, e
 	if err := consumeRes.Results[0].Error; err != nil {
 		return "", errors.Trace(err)
 	}
-	return consumeRes.Results[0].LocalName, nil
+	localName := offer.OfferName
+	if alias != "" {
+		localName = alias
+	}
+	return localName, nil
 }

--- a/api/application/client_test.go
+++ b/api/application/client_test.go
@@ -8,6 +8,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/charm.v6-unstable"
+	"gopkg.in/macaroon.v1"
 
 	"github.com/juju/juju/api/application"
 	basetesting "github.com/juju/juju/api/base/testing"
@@ -321,6 +322,8 @@ func (s *applicationSuite) TestConsume(c *gc.C) {
 		ApplicationDescription: "description",
 		Endpoints:              []params.RemoteEndpoint{{Name: "endpoint"}},
 	}
+	mac, err := macaroon.New(nil, "id", "loc")
+	c.Assert(err, jc.ErrorIsNil)
 	var called bool
 	apiCaller := basetesting.APICallerFunc(
 		func(objType string,
@@ -336,19 +339,18 @@ func (s *applicationSuite) TestConsume(c *gc.C) {
 				{
 					ApplicationAlias: "alias",
 					ApplicationOffer: offer,
+					Macaroon:         mac,
 				},
 			})
-			if results, ok := result.(*params.ConsumeApplicationResults); ok {
-				result := params.ConsumeApplicationResult{
-					LocalName: "result",
-				}
-				results.Results = []params.ConsumeApplicationResult{result}
+			if results, ok := result.(*params.ErrorResults); ok {
+				result := params.ErrorResult{}
+				results.Results = []params.ErrorResult{result}
 			}
 			return nil
 		})
 	client := application.NewClient(apiCaller)
-	name, err := client.Consume(offer, "alias")
+	name, err := client.Consume(offer, "alias", mac)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(name, gc.Equals, "result")
+	c.Assert(name, gc.Equals, "alias")
 	c.Assert(called, jc.IsTrue)
 }

--- a/apiserver/application/application.go
+++ b/apiserver/application/application.go
@@ -936,8 +936,8 @@ func (api *API) DestroyRelation(args params.DestroyRelation) error {
 
 // Consume adds remote applications to the model without creating any
 // relations.
-func (api *API) Consume(args params.ConsumeApplicationArgs) (params.ConsumeApplicationResults, error) {
-	var consumeResults params.ConsumeApplicationResults
+func (api *API) Consume(args params.ConsumeApplicationArgs) (params.ErrorResults, error) {
+	var consumeResults params.ErrorResults
 	if !featureflag.Enabled(feature.CrossModelRelations) {
 		err := errors.Errorf(
 			"set %q feature flag to enable consuming remote applications",
@@ -952,28 +952,27 @@ func (api *API) Consume(args params.ConsumeApplicationArgs) (params.ConsumeAppli
 		return consumeResults, errors.Trace(err)
 	}
 
-	results := make([]params.ConsumeApplicationResult, len(args.Args))
+	results := make([]params.ErrorResult, len(args.Args))
 	for i, arg := range args.Args {
-		localName, err := api.consumeOne(arg)
-		results[i].LocalName = localName
+		err := api.consumeOne(arg)
 		results[i].Error = common.ServerError(err)
 	}
 	consumeResults.Results = results
 	return consumeResults, nil
 }
 
-func (api *API) consumeOne(arg params.ConsumeApplicationArg) (string, error) {
+func (api *API) consumeOne(arg params.ConsumeApplicationArg) error {
 	sourceModelTag, err := names.ParseModelTag(arg.SourceModelTag)
 	if err != nil {
-		return "", errors.Trace(err)
+		return errors.Trace(err)
 	}
 
 	appName := arg.ApplicationAlias
 	if appName == "" {
 		appName = arg.OfferName
 	}
-	remoteApp, err := api.saveRemoteApplication(sourceModelTag, appName, arg.ApplicationOffer)
-	return remoteApp.Name(), err
+	_, err = api.saveRemoteApplication(sourceModelTag, appName, arg.ApplicationOffer)
+	return err
 }
 
 // saveRemoteApplication saves the details of the specified remote application and its endpoints

--- a/apiserver/application/application.go
+++ b/apiserver/application/application.go
@@ -832,58 +832,11 @@ func (api *API) AddRelation(args params.AddRelation) (params.AddRelationResults,
 	if err := api.check.ChangeAllowed(); err != nil {
 		return params.AddRelationResults{}, errors.Trace(err)
 	}
-
-	endpoints := make([]string, len(args.Endpoints))
-	// We may have a remote application passed in as the endpoint spec.
-	// We'll iterate the endpoints to check.
-	//isRemote := false
-	for i, ep := range args.Endpoints {
-		endpoints[i] = ep
-
-		// TODO(wallyworld) - re-implement when facade updates are done
-		//// If cross model relations not enabled, ignore remote endpoints.
-		//if !featureflag.Enabled(feature.CrossModelRelations) {
-		//	continue
-		//}
-		//
-		//// If the endpoint is not remote, skip it.
-		//// We first need to strip off any relation name
-		//// which may have been appended to the URL, then
-		//// we try parsing the URL.
-		//possibleURL := applicationUrlEndpointParse.ReplaceAllString(ep, "$url")
-		//relName := applicationUrlEndpointParse.ReplaceAllString(ep, "$relname")
-		//
-		//// If the URL parses, we need to look up the remote application
-		//// details and save to state.
-		//url, err := jujucrossmodel.ParseApplicationURL(possibleURL)
-		//if err != nil {
-		//	// Not a URL.
-		//	continue
-		//}
-		//// Save the remote application details into state.
-		//// TODO(wallyworld) - allow app name to be aliased
-		//alias := url.ApplicationName
-		//remoteApp, err := api.processRemoteApplication(url, alias)
-		//if err != nil {
-		//	return params.AddRelationResults{}, errors.Trace(err)
-		//}
-		//// The endpoint is named after the remote application name,
-		//// not the application name from the URL.
-		//endpoints[i] = remoteApp.Name()
-		//if relName != "" {
-		//	endpoints[i] = remoteApp.Name() + ":" + relName
-		//}
-		//isRemote = true
-	}
-	// If it's not a remote relation to another model then
-	// the user needs write access to the model.
-	//if !isRemote {
 	if err := api.checkCanWrite(); err != nil {
 		return params.AddRelationResults{}, errors.Trace(err)
 	}
-	//}
 
-	inEps, err := api.backend.InferEndpoints(endpoints...)
+	inEps, err := api.backend.InferEndpoints(args.Endpoints...)
 	if err != nil {
 		return params.AddRelationResults{}, errors.Trace(err)
 	}
@@ -928,11 +881,6 @@ func (api *API) DestroyRelation(args params.DestroyRelation) error {
 	}
 	return rel.Destroy()
 }
-
-// TODO(wallyworld) - we'll use this when the ConsumeDetails API is added.
-// applicationUrlEndpointParse is used to split an application url and optional
-// relation name into url and relation name.
-//var applicationUrlEndpointParse = regexp.MustCompile("(?P<url>.*[/.][^:]*)(:(?P<relname>.*)$)?")
 
 // Consume adds remote applications to the model without creating any
 // relations.

--- a/apiserver/application/application_unit_test.go
+++ b/apiserver/application/application_unit_test.go
@@ -358,7 +358,6 @@ func (s *ApplicationSuite) TestConsumeIncludesSpaceInfo(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results.Results, gc.HasLen, 1)
 	c.Assert(results.Results[0].Error, gc.IsNil)
-	c.Assert(results.Results[0].LocalName, gc.Equals, "beirut")
 
 	obtained, ok := s.backend.remoteApplications["beirut"]
 	c.Assert(ok, jc.IsTrue)

--- a/apiserver/application/mock_test.go
+++ b/apiserver/application/mock_test.go
@@ -5,6 +5,7 @@ package application_test
 
 import (
 	"io"
+	"strings"
 	"sync"
 
 	"github.com/juju/errors"
@@ -20,7 +21,6 @@ import (
 	statestorage "github.com/juju/juju/state/storage"
 	"github.com/juju/juju/storage"
 	coretesting "github.com/juju/juju/testing"
-	"strings"
 )
 
 type mockEnviron struct {

--- a/apiserver/applicationoffers/base.go
+++ b/apiserver/applicationoffers/base.go
@@ -8,12 +8,14 @@ import (
 	"sort"
 
 	"github.com/juju/errors"
+	"github.com/juju/utils/set"
 	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/apiserver/params"
 	jujucrossmodel "github.com/juju/juju/core/crossmodel"
+	"github.com/juju/juju/environs"
 	"github.com/juju/juju/permission"
 )
 
@@ -23,6 +25,7 @@ type BaseAPI struct {
 	GetApplicationOffers func(interface{}) jujucrossmodel.ApplicationOffers
 	ControllerModel      Backend
 	StatePool            StatePool
+	getEnviron           environFromModelFunc
 }
 
 // checkPermission ensures that the logged in user holds the given permission on an entity.
@@ -57,9 +60,9 @@ func (api *BaseAPI) checkAdmin(backend Backend) error {
 
 // modelForName looks up the model details for the named model.
 func (api *BaseAPI) modelForName(modelName, ownerName string) (Model, bool, error) {
-	user := api.Authorizer.GetAuthTag().(names.UserTag)
+	user := api.Authorizer.GetAuthTag()
 	if ownerName == "" {
-		ownerName = user.Name()
+		ownerName = user.Id()
 	}
 	var model Model
 	models, err := api.ControllerModel.AllModels()
@@ -78,7 +81,7 @@ func (api *BaseAPI) modelForName(modelName, ownerName string) (Model, bool, erro
 // applicationOffersFromModel gets details about remote applications that match given filters.
 func (api *BaseAPI) applicationOffersFromModel(
 	modelUUID string,
-	requireAdmin bool,
+	requiredAccess permission.Access,
 	filters ...jujucrossmodel.ApplicationOfferFilter,
 ) ([]params.ApplicationOfferDetails, error) {
 	// Get the relevant backend for the specified model.
@@ -96,8 +99,8 @@ func (api *BaseAPI) applicationOffersFromModel(
 		return nil, errors.Trace(err)
 	}
 	isAdmin = err == nil
-	if requireAdmin && !isAdmin {
-		return nil, common.ServerError(err)
+	if requiredAccess == permission.AdminAccess && !isAdmin {
+		return nil, common.ErrPerm
 	}
 
 	offers, err := api.GetApplicationOffers(backend).ListOffers(filters...)
@@ -106,34 +109,38 @@ func (api *BaseAPI) applicationOffersFromModel(
 	}
 
 	var results []params.ApplicationOfferDetails
-	for _, offer := range offers {
+	for _, appOffer := range offers {
 		userAccess := permission.AdminAccess
 		// If the user is not a model admin, they need at least read
 		// access on an offer to see it.
 		if !isAdmin {
-			if userAccess, err = api.checkOfferAccess(backend, offer.OfferName, permission.ReadAccess); err != nil {
+			if userAccess, err = api.checkOfferAccess(backend, appOffer.OfferName, requiredAccess); err != nil {
 				return nil, errors.Trace(err)
 			}
 			if userAccess == permission.NoAccess {
 				continue
 			}
+			isAdmin = userAccess == permission.AdminAccess
 		}
-		app, err := backend.Application(offer.ApplicationName)
+		offerParams, app, err := api.makeOfferParams(backend, &appOffer, userAccess)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
-		curl, _ := app.CharmURL()
-		status, err := backend.RemoteConnectionStatus(offer.OfferName)
-		if err != nil {
-			return nil, errors.Trace(err)
+		offer := params.ApplicationOfferDetails{
+			ApplicationOffer: *offerParams,
 		}
-		offerDetails := params.ApplicationOfferDetails{
-			ApplicationOffer: makeOfferParamsFromOffer(offer, modelUUID, userAccess),
-			ApplicationName:  app.Name(),
-			CharmName:        curl.Name,
-			ConnectedCount:   status.ConnectionCount(),
+		// Only admins can see some sensitive details of the offer.
+		if isAdmin {
+			curl, _ := app.CharmURL()
+			status, err := backend.RemoteConnectionStatus(offer.OfferName)
+			if err != nil {
+				return nil, errors.Trace(err)
+			}
+			offer.ApplicationName = app.Name()
+			offer.CharmName = curl.Name
+			offer.ConnectedCount = status.ConnectionCount()
 		}
-		results = append(results, offerDetails)
+		results = append(results, offer)
 	}
 	return results, nil
 }
@@ -150,26 +157,6 @@ func (api *BaseAPI) checkOfferAccess(backend Backend, offerName string, perm per
 		return permission.NoAccess, nil
 	}
 	return access, nil
-}
-
-func makeOfferParamsFromOffer(offer jujucrossmodel.ApplicationOffer, modelUUID string, access permission.Access) params.ApplicationOffer {
-	result := params.ApplicationOffer{
-		SourceModelTag:         names.NewModelTag(modelUUID).String(),
-		OfferName:              offer.OfferName,
-		ApplicationDescription: offer.ApplicationDescription,
-		Access:                 string(access),
-	}
-	for alias, ep := range offer.Endpoints {
-		result.Endpoints = append(result.Endpoints, params.RemoteEndpoint{
-			Name:      alias,
-			Interface: ep.Interface,
-			Role:      ep.Role,
-			Scope:     ep.Scope,
-			Limit:     ep.Limit,
-		})
-	}
-
-	return result
 }
 
 type offerModel struct {
@@ -259,20 +246,20 @@ func (api *BaseAPI) getModelFilters(filters params.OfferFilters) (
 // getApplicationOffersDetails gets details about remote applications that match given filter.
 func (api *BaseAPI) getApplicationOffersDetails(
 	filters params.OfferFilters,
-	requireAdmin bool,
+	requiredPermission permission.Access,
 ) ([]params.ApplicationOfferDetails, error) {
 
 	// If there are no filters specified, that's an error since the
 	// caller is expected to specify at the least one or more models
 	// to avoid an unbounded query across all models.
 	if len(filters.Filters) == 0 {
-		return nil, common.ServerError(errors.New("at least one offer filter is required"))
+		return nil, errors.New("at least one offer filter is required")
 	}
 
 	// Gather all the filter details for doing a query for each model.
 	models, filtersPerModel, err := api.getModelFilters(filters)
 	if err != nil {
-		return nil, common.ServerError(errors.Trace(err))
+		return nil, errors.Trace(err)
 	}
 
 	// Ensure the result is deterministic.
@@ -286,15 +273,15 @@ func (api *BaseAPI) getApplicationOffersDetails(
 	var result []params.ApplicationOfferDetails
 	for _, modelUUID := range allUUIDs {
 		filters := filtersPerModel[modelUUID]
-		offers, err := api.applicationOffersFromModel(modelUUID, requireAdmin, filters...)
+		offers, err := api.applicationOffersFromModel(modelUUID, requiredPermission, filters...)
 		if err != nil {
-			return nil, common.ServerError(errors.Trace(err))
+			return nil, errors.Trace(err)
 		}
 		model := models[modelUUID]
 
-		for _, offer := range offers {
-			offer.OfferURL = jujucrossmodel.MakeURL(model.Owner().Name(), model.Name(), offer.OfferName, "")
-			result = append(result, offer)
+		for _, offerDetails := range offers {
+			offerDetails.OfferURL = jujucrossmodel.MakeURL(model.Owner().Name(), model.Name(), offerDetails.OfferName, "")
+			result = append(result, offerDetails)
 		}
 	}
 	return result, nil
@@ -308,4 +295,114 @@ func makeOfferFilterFromParams(filter params.OfferFilter) jujucrossmodel.Applica
 	}
 	// TODO(wallyworld) - add support for Endpoint filter attribute
 	return offerFilter
+}
+
+func (api *BaseAPI) makeOfferParams(backend Backend, offer *jujucrossmodel.ApplicationOffer, access permission.Access) (
+	*params.ApplicationOffer, Application, error,
+) {
+	app, err := backend.Application(offer.ApplicationName)
+	if err != nil {
+		return nil, nil, errors.Trace(err)
+	}
+	appBindings, err := app.EndpointBindings()
+	if err != nil {
+		return nil, nil, errors.Trace(err)
+	}
+	result := params.ApplicationOffer{
+		SourceModelTag:         backend.ModelTag().String(),
+		OfferName:              offer.OfferName,
+		ApplicationDescription: offer.ApplicationDescription,
+		Access:                 string(access),
+	}
+
+	spaceNames := set.NewStrings()
+	for alias, ep := range offer.Endpoints {
+		result.Endpoints = append(result.Endpoints, params.RemoteEndpoint{
+			Name:      alias,
+			Interface: ep.Interface,
+			Role:      ep.Role,
+			Scope:     ep.Scope,
+			Limit:     ep.Limit,
+		})
+		spaceName, ok := appBindings[ep.Name]
+		if !ok {
+			// There should always be some binding (even if it's to
+			// the default space).
+			return nil, nil, errors.Errorf("no binding for %q endpoint", ep.Name)
+		}
+		spaceNames.Add(spaceName)
+	}
+
+	spaces, err := api.collectRemoteSpaces(backend, spaceNames.SortedValues())
+	if errors.IsNotSupported(err) {
+		// Provider doesn't support ProviderSpaceInfo; continue
+		// without any space information, we shouldn't short-circuit
+		// cross-model connections.
+		return &result, app, nil
+	}
+	if err != nil {
+		return nil, nil, errors.Trace(err)
+	}
+
+	// Ensure bindings only contains entries for which we have spaces.
+	for epName, spaceName := range appBindings {
+		space, ok := spaces[spaceName]
+		if !ok {
+			continue
+		}
+		if result.Bindings == nil {
+			result.Bindings = make(map[string]string)
+		}
+		result.Bindings[epName] = spaceName
+		result.Spaces = append(result.Spaces, space)
+	}
+	return &result, app, nil
+}
+
+// collectRemoteSpaces gets provider information about the spaces from
+// the state passed in. (This state will be for a different model than
+// this API instance, which is why the results are *remote* spaces.)
+// These can be used by the provider later on to decide whether a
+// connection can be made via cloud-local addresses. If the provider
+// doesn't support getting ProviderSpaceInfo the NotSupported error
+// will be returned.
+func (api *BaseAPI) collectRemoteSpaces(backend Backend, spaceNames []string) (map[string]params.RemoteSpace, error) {
+	env, err := api.getEnviron(backend.ModelUUID())
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	netEnv, ok := environs.SupportsNetworking(env)
+	if !ok {
+		logger.Debugf("cloud provider doesn't support networking, not getting space info")
+		return nil, nil
+	}
+
+	results := make(map[string]params.RemoteSpace)
+	for _, name := range spaceNames {
+		space := environs.DefaultSpaceInfo
+		if name != environs.DefaultSpaceName {
+			dbSpace, err := backend.Space(name)
+			if err != nil {
+				return nil, errors.Trace(err)
+			}
+			space, err = spaceInfoFromState(dbSpace)
+			if err != nil {
+				return nil, errors.Trace(err)
+			}
+		}
+		providerSpace, err := netEnv.ProviderSpaceInfo(space)
+		if err != nil && !errors.IsNotFound(err) {
+			return nil, errors.Trace(err)
+		}
+		if providerSpace == nil {
+			logger.Warningf("no provider space info for %q", name)
+			continue
+		}
+		remoteSpace := paramsFromProviderSpaceInfo(providerSpace)
+		// Use the name from state in case provider and state disagree.
+		remoteSpace.Name = name
+		results[name] = remoteSpace
+	}
+	return results, nil
 }

--- a/apiserver/applicationoffers/mock_test.go
+++ b/apiserver/applicationoffers/mock_test.go
@@ -71,6 +71,9 @@ type mockEnviron struct {
 
 func (e *mockEnviron) ProviderSpaceInfo(space *network.SpaceInfo) (*environs.ProviderSpaceInfo, error) {
 	e.stub.MethodCall(e, "ProviderSpaceInfo", space)
+	if e.spaceInfo == nil || space.Name != e.spaceInfo.Name {
+		return nil, errors.NotFoundf("space %s", space.Name)
+	}
 	return e.spaceInfo, e.stub.NextErr()
 }
 

--- a/apiserver/params/crossmodel.go
+++ b/apiserver/params/crossmodel.go
@@ -5,6 +5,7 @@ package params
 
 import (
 	"gopkg.in/juju/charm.v6-unstable"
+	"gopkg.in/macaroon.v1"
 )
 
 // EndpointFilterAttributes is used to filter offers matching the
@@ -105,7 +106,7 @@ type FindApplicationOffersResults struct {
 // ApplicationOfferResult is a result of listing a remote application offer.
 type ApplicationOfferResult struct {
 	// Result contains application offer information.
-	Result ApplicationOffer `json:"result"`
+	Result *ApplicationOffer `json:"result,omitempty"`
 
 	// Error contains related error.
 	Error *Error `json:"error,omitempty"`
@@ -127,6 +128,9 @@ type ApplicationURLs struct {
 type ConsumeApplicationArg struct {
 	// The offer to be consumed.
 	ApplicationOffer
+
+	// Macaroon is used for authentication.
+	Macaroon *macaroon.Macaroon `json:"macaroon,omitempty"`
 
 	// ApplicationAlias is the name of the alias to use for the application name.
 	ApplicationAlias string `json:"application-alias,omitempty"`
@@ -365,16 +369,24 @@ type RemoteApplicationInfoResults struct {
 	Results []RemoteApplicationInfoResult `json:"results"`
 }
 
-// ConsumeApplicationResult is the response for one request to consume
-// a remote application.
-type ConsumeApplicationResult struct {
-	LocalName string `json:"local-name,omitempty"`
-	Error     *Error `json:"error,omitempty"`
+// ConsumeOfferDetails contains the details necessary to
+// consume an application offer.
+type ConsumeOfferDetails struct {
+	Offer    *ApplicationOffer  `json:"offer,omitempty"`
+	Macaroon *macaroon.Macaroon `json:"macaroon,omitempty"`
 }
 
-// ConsumeApplicationResults is the result of a Consume call.
-type ConsumeApplicationResults struct {
-	Results []ConsumeApplicationResult `json:"results"`
+// ConsumeOfferDetailsResult contains the details necessary to
+// consume an application offer or an error.
+type ConsumeOfferDetailsResult struct {
+	ConsumeOfferDetails
+	Error *Error `json:"error,omitempty"`
+}
+
+// ConsumeOfferDetailsResults represents the result of a
+// ConsumeOfferDetails call.
+type ConsumeOfferDetailsResults struct {
+	Results []ConsumeOfferDetailsResult `json:"results,omitempty"`
 }
 
 // RemoteEntities identifies multiple remote entities.

--- a/cmd/juju/application/addrelation_test.go
+++ b/cmd/juju/application/addrelation_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
+	"gopkg.in/macaroon.v1"
 
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/params"
@@ -35,7 +36,7 @@ func (s *AddRelationSuite) SetUpTest(c *gc.C) {
 var _ = gc.Suite(&AddRelationSuite{})
 
 func (s *AddRelationSuite) runAddRelation(c *gc.C, args ...string) error {
-	cmd := NewAddRelationCommandForTest(s.mockAPI)
+	cmd := NewAddRelationCommandForTest(s.mockAPI, s.mockAPI)
 	cmd.SetClientStore(NewMockStore())
 	_, err := cmdtesting.RunCommand(c, cmd, args...)
 	return err
@@ -84,7 +85,7 @@ func (s *AddRelationSuite) TestAddRelationUnauthorizedMentionsJujuGrant(c *gc.C)
 		Message: "permission denied",
 		Code:    params.CodeUnauthorized,
 	})
-	cmd := NewAddRelationCommandForTest(s.mockAPI)
+	cmd := NewAddRelationCommandForTest(s.mockAPI, s.mockAPI)
 	cmd.SetClientStore(NewMockStore())
 	ctx, _ := cmdtesting.RunCommand(c, cmd, "application1", "application2")
 	errString := strings.Replace(cmdtesting.Stderr(ctx), "\n", " ", -1)
@@ -109,4 +110,12 @@ func (s mockAddAPI) AddRelation(endpoints ...string) (*params.AddRelationResults
 func (s mockAddAPI) BestAPIVersion() int {
 	s.MethodCall(s, "BestAPIVersion")
 	return 2
+}
+
+func (mockAddAPI) Consume(params.ApplicationOffer, string, *macaroon.Macaroon) (string, error) {
+	return "", errors.New("unexpected method call: Consume")
+}
+
+func (mockAddAPI) GetConsumeDetails(string) (params.ConsumeOfferDetails, error) {
+	return params.ConsumeOfferDetails{}, errors.New("unexpected method call: GetConsumeDetails")
 }

--- a/cmd/juju/application/consume.go
+++ b/cmd/juju/application/consume.go
@@ -7,46 +7,45 @@ import (
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
 	"gopkg.in/juju/names.v2"
+	"gopkg.in/macaroon.v1"
 
 	"github.com/juju/juju/api/application"
+	"github.com/juju/juju/api/applicationoffers"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/core/crossmodel"
 )
 
 var usageConsumeSummary = `
-Add a remote application to the model.`[1:]
+Add a remote offer to the model.`[1:]
 
 var usageConsumeDetails = `
-Adds a remote application to the model. Relations can be created later using "juju relate".
+Adds a remote offer to the model. Relations can be created later using "juju relate".
 
-The remote application can be identified in two ways:
+The remote offer is identified by providing a path to the offer:
     [<model owner>/]<model name>.<application name>
         for an application in another model in this controller (if owner isn't specified it's assumed to be the logged-in user)
-or
-    <remote endpoint url>
-        for remote applications that have been shared using the offer command
 
 Examples:
     $ juju consume othermodel.mysql
-
-    $ juju consume local:/u/fred/db2
+    $ juju consume owner/othermodel.mysql
 
 See also:
     add-relation
     offer`[1:]
 
-// NewConsumeCommand returns a command to add remote applications to
+// NewConsumeCommand returns a command to add remote offers to
 // the model.
 func NewConsumeCommand() cmd.Command {
-	return modelcmd.WrapController(&consumeCommand{})
+	return modelcmd.Wrap(&consumeCommand{})
 }
 
-// consumeCommand adds remote applications to the model without
+// consumeCommand adds remote offers to the model without
 // relating them to other applications.
 type consumeCommand struct {
-	modelcmd.ControllerCommandBase
-	api               applicationConsumeAPI
+	modelcmd.ModelCommandBase
+	sourceAPI         applicationConsumeDetailsAPI
+	targetAPI         applicationConsumeAPI
 	remoteApplication string
 	applicationAlias  string
 }
@@ -55,7 +54,7 @@ type consumeCommand struct {
 func (c *consumeCommand) Info() *cmd.Info {
 	return &cmd.Info{
 		Name:    "consume",
-		Args:    "<remote application> [<local application name>]",
+		Args:    "<remote offer path> [<local application name>]",
 		Purpose: usageConsumeSummary,
 		Doc:     usageConsumeDetails,
 	}
@@ -64,7 +63,7 @@ func (c *consumeCommand) Info() *cmd.Info {
 // Init implements cmd.Command.
 func (c *consumeCommand) Init(args []string) error {
 	if len(args) == 0 {
-		return errors.New("no remote application specified")
+		return errors.New("no remote offer specified")
 	}
 	c.remoteApplication = args[0]
 	if len(args) > 1 {
@@ -77,51 +76,83 @@ func (c *consumeCommand) Init(args []string) error {
 	return nil
 }
 
-func (c *consumeCommand) getAPI(modelName string) (applicationConsumeAPI, error) {
-	if c.api != nil {
-		return c.api, nil
+func (c *consumeCommand) getTargetAPI() (applicationConsumeAPI, error) {
+	if c.targetAPI != nil {
+		return c.targetAPI, nil
 	}
-	root, err := c.NewModelAPIRoot(modelName)
+	root, err := c.NewAPIRoot()
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
 	return application.NewClient(root), nil
 }
 
-// Run adds the requested remote application to the model. Implements
+func (c *consumeCommand) getSourceAPI() (applicationConsumeDetailsAPI, error) {
+	if c.sourceAPI != nil {
+		return c.sourceAPI, nil
+	}
+
+	controllerName, err := c.ControllerName()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	root, err := c.CommandBase.NewAPIRoot(c.ClientStore(), controllerName, "")
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return applicationoffers.NewClient(root), nil
+}
+
+// Run adds the requested remote offer to the model. Implements
 // cmd.Command.
 func (c *consumeCommand) Run(ctx *cmd.Context) error {
+	accountDetails, err := c.CurrentAccountDetails()
+	if err != nil {
+		return errors.Trace(err)
+	}
 	url, err := crossmodel.ParseApplicationURL(c.remoteApplication)
 	if err != nil {
 		return errors.Trace(err)
 	}
 	if url.HasEndpoint() {
-		return errors.Errorf("remote application %q shouldn't include endpoint", c.remoteApplication)
+		return errors.Errorf("remote offer %q shouldn't include endpoint", c.remoteApplication)
 	}
 	if url.User == "" {
-		details, err := c.CurrentAccountDetails()
-		if err != nil {
-			return errors.Trace(err)
-		}
-		url.User = details.User
+		url.User = accountDetails.User
 		c.remoteApplication = url.Path()
 	}
-	// TODO(wallyworld) - use proper model name
-	client, err := c.getAPI("")
+	sourceClient, err := c.getSourceAPI()
 	if err != nil {
-		return err
+		return errors.Trace(err)
 	}
-	defer client.Close()
-	// TODO(wallyworld) - re-implement
-	//localName, err := client.Consume(c.remoteApplication, c.applicationAlias)
-	//if err != nil {
-	//	return errors.Trace(err)
-	//}
-	//ctx.Infof("Added %s as %s", c.remoteApplication, localName)
+	defer sourceClient.Close()
+
+	consumeDetails, err := sourceClient.GetConsumeDetails(url.String())
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	targetClient, err := c.getTargetAPI()
+	if err != nil {
+		return errors.Trace(err)
+	}
+	defer targetClient.Close()
+
+	//
+	localName, err := targetClient.Consume(*consumeDetails.Offer, c.applicationAlias, consumeDetails.Macaroon)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	ctx.Infof("Added %s as %s", c.remoteApplication, localName)
 	return nil
 }
 
 type applicationConsumeAPI interface {
 	Close() error
-	Consume(params.ApplicationOffer, string) (string, error)
+	Consume(params.ApplicationOffer, string, *macaroon.Macaroon) (string, error)
+}
+
+type applicationConsumeDetailsAPI interface {
+	Close() error
+	GetConsumeDetails(string) (params.ConsumeOfferDetails, error)
 }

--- a/cmd/juju/application/consume_test.go
+++ b/cmd/juju/application/consume_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
+	"gopkg.in/macaroon.v1"
 
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/cmd/juju/application"
@@ -47,12 +48,12 @@ func (s *ConsumeSuite) SetUpTest(c *gc.C) {
 }
 
 func (s *ConsumeSuite) runConsume(c *gc.C, args ...string) (*cmd.Context, error) {
-	return cmdtesting.RunCommand(c, application.NewConsumeCommandForTest(s.store, s.mockAPI), args...)
+	return cmdtesting.RunCommand(c, application.NewConsumeCommandForTest(s.store, s.mockAPI, s.mockAPI), args...)
 }
 
 func (s *ConsumeSuite) TestNoArguments(c *gc.C) {
 	_, err := s.runConsume(c)
-	c.Assert(err, gc.ErrorMatches, "no remote application specified")
+	c.Assert(err, gc.ErrorMatches, "no remote offer specified")
 }
 
 func (s *ConsumeSuite) TestTooManyArguments(c *gc.C) {
@@ -75,34 +76,40 @@ func (s *ConsumeSuite) TestInvalidRemoteApplication(c *gc.C) {
 }
 
 func (s *ConsumeSuite) TestErrorFromAPI(c *gc.C) {
-	c.Skip("TODO")
 	s.mockAPI.SetErrors(errors.New("infirmary"))
 	_, err := s.runConsume(c, "model.application")
 	c.Assert(err, gc.ErrorMatches, "infirmary")
 }
 
-func (s *ConsumeSuite) TestSuccessModelDotApplication(c *gc.C) {
-	c.Skip("TODO")
+func (s *ConsumeSuite) assertSuccessModelDotApplication(c *gc.C, alias string) {
 	s.mockAPI.localName = "mary-weep"
-	ctx, err := s.runConsume(c, "booster.uke")
+	var (
+		ctx *cmd.Context
+		err error
+	)
+	if alias != "" {
+		ctx, err = s.runConsume(c, "booster.uke", alias)
+	} else {
+		ctx, err = s.runConsume(c, "booster.uke")
+	}
+	c.Assert(err, jc.ErrorIsNil)
+	mac, err := macaroon.New(nil, "id", "loc")
 	c.Assert(err, jc.ErrorIsNil)
 	s.mockAPI.CheckCalls(c, []testing.StubCall{
-		{"Consume", []interface{}{"bob/booster.uke", ""}},
+		{"GetConsumeDetails", []interface{}{"bob/booster.uke"}},
+		{"Consume", []interface{}{params.ApplicationOffer{OfferName: "an offer"}, alias, mac}},
+		{"Close", nil},
 		{"Close", nil},
 	})
 	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "Added bob/booster.uke as mary-weep\n")
 }
 
+func (s *ConsumeSuite) TestSuccessModelDotApplication(c *gc.C) {
+	s.assertSuccessModelDotApplication(c, "")
+}
+
 func (s *ConsumeSuite) TestSuccessModelDotApplicationWithAlias(c *gc.C) {
-	c.Skip("TODO")
-	s.mockAPI.localName = "mary-weep"
-	ctx, err := s.runConsume(c, "booster.uke", "alias")
-	c.Assert(err, jc.ErrorIsNil)
-	s.mockAPI.CheckCalls(c, []testing.StubCall{
-		{"Consume", []interface{}{"bob/booster.uke", "alias"}},
-		{"Close", nil},
-	})
-	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "Added bob/booster.uke as mary-weep\n")
+	s.assertSuccessModelDotApplication(c, "alias")
 }
 
 type mockConsumeAPI struct {
@@ -116,7 +123,19 @@ func (a *mockConsumeAPI) Close() error {
 	return a.NextErr()
 }
 
-func (a *mockConsumeAPI) Consume(offer params.ApplicationOffer, alias string) (string, error) {
-	a.MethodCall(a, "Consume", offer, alias)
+func (a *mockConsumeAPI) Consume(offer params.ApplicationOffer, alias string, mac *macaroon.Macaroon) (string, error) {
+	a.MethodCall(a, "Consume", offer, alias, mac)
 	return a.localName, a.NextErr()
+}
+
+func (a *mockConsumeAPI) GetConsumeDetails(url string) (params.ConsumeOfferDetails, error) {
+	a.MethodCall(a, "GetConsumeDetails", url)
+	mac, err := macaroon.New(nil, "id", "loc")
+	if err != nil {
+		return params.ConsumeOfferDetails{}, err
+	}
+	return params.ConsumeOfferDetails{
+		Offer:    &params.ApplicationOffer{OfferName: "an offer"},
+		Macaroon: mac,
+	}, a.NextErr()
 }

--- a/cmd/juju/application/export_test.go
+++ b/cmd/juju/application/export_test.go
@@ -47,10 +47,8 @@ func NewAddUnitCommandForTest(api serviceAddUnitAPI) cmd.Command {
 }
 
 // NewAddRelationCommandForTest returns an AddRelationCommand with the api provided as specified.
-func NewAddRelationCommandForTest(api ApplicationAddRelationAPI) modelcmd.ModelCommand {
-	cmd := &addRelationCommand{newAPIFunc: func() (ApplicationAddRelationAPI, error) {
-		return api, nil
-	}}
+func NewAddRelationCommandForTest(addAPI applicationAddRelationAPI, consumeAPI applicationConsumeDetailsAPI) modelcmd.ModelCommand {
+	cmd := &addRelationCommand{addRelationAPI: addAPI, consumeDetailsAPI: consumeAPI}
 	return modelcmd.Wrap(cmd)
 }
 

--- a/cmd/juju/application/export_test.go
+++ b/cmd/juju/application/export_test.go
@@ -63,10 +63,14 @@ func NewRemoveRelationCommandForTest(api ApplicationDestroyRelationAPI) modelcmd
 }
 
 // NewConsumeCommandForTest returns a ConsumeCommand with the specified api.
-func NewConsumeCommandForTest(store jujuclient.ClientStore, api applicationConsumeAPI) cmd.Command {
-	c := &consumeCommand{api: api}
+func NewConsumeCommandForTest(
+	store jujuclient.ClientStore,
+	sourceAPI applicationConsumeDetailsAPI,
+	targetAPI applicationConsumeAPI,
+) cmd.Command {
+	c := &consumeCommand{sourceAPI: sourceAPI, targetAPI: targetAPI}
 	c.SetClientStore(store)
-	return modelcmd.WrapController(c)
+	return modelcmd.Wrap(c)
 }
 
 type Patcher interface {


### PR DESCRIPTION

## Description of change

Add the controller facade GetConsumeDetails API. This allows the consume command to be re-implemented and functional again. As part of the work, a whole lot of code was consolidated into fewer common methods and a hundreds of lines deleted. The core facade apis remain the same, with the addition of the new api mentioned above.

For future use, the api params also cater for handling a macaroon which will be used for authentication between controllers/models.

## QA steps

juju bootstrap
juju deploy mysql
juju offer mysql:db
juu switch controller
juju consume default.mysql
juju status

Also check the operation of the other cmr commands find-endpoints etc
