### PR TITLE
debug/server.go: change debugging session tips

### DIFF
--- a/worker/uniter/runner/debug/server.go
+++ b/worker/uniter/runner/debug/server.go
@@ -102,8 +102,14 @@ export | grep -v $FILTER > $JUJU_DEBUG/env.sh
 cat > $JUJU_DEBUG/welcome.msg <<END
 This is a Juju debug-hooks tmux session. Remember:
 1. You need to execute hooks manually if you want them to run for trapped events.
-2. When you are finished with an event, you can run 'exit' to close the current window and allow Juju to continue running.
-3. CTRL+a is tmux prefix.
+2. When you are finished with an event, you can run 'exit' to close the current window and allow Juju to continue processing
+new events for this unit without exiting a current debug-session.
+3. To run a hook and end the debugging session avoiding processing any more events manually, use:
+
+./hooks/$JUJU_HOOK_NAME
+tmux kill-session -t $JUJU_UNIT_NAME # or, equivalently, CTRL+a d
+
+4. CTRL+a is tmux prefix.
 
 More help and info is available in the online documentation:
 https://jujucharms.com/docs/authors-hook-debug.html


### PR DESCRIPTION
Currently it is not mentioned how to exit a debugging session and
prevent any further manual event processing, e.g. when you are in
a wildcard debug-hooks session you might be getting new events too fast
and a simple shell exit in an event processing window will result in an
immediate processing of a new event from the backlog.

## Please provide the following details to expedite Pull Request review:

----

## Description of change

Provide instructions on how to exit a debugging session without catching any additional events.
https://lists.ubuntu.com/archives/juju-dev/2017-June/006443.html

## QA steps

Check the shell script syntax and content.

## Documentation changes

No changes required, could optionally add the same here https://jujucharms.com/docs/stable/authors-hook-debug#running-a-debug-session

## Bug reference

No bug in particular.
