### PR TITLE
Print available bootstrap config options 

### DIFF
--- a/cmd/juju/cloud/show.go
+++ b/cmd/juju/cloud/show.go
@@ -4,12 +4,14 @@
 package cloud
 
 import (
+	"fmt"
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
 	"github.com/juju/gnuflag"
 	"gopkg.in/yaml.v2"
 
 	jujucloud "github.com/juju/juju/cloud"
+	"github.com/juju/juju/cmd/juju/common"
 )
 
 type showCloudCommand struct {
@@ -17,11 +19,17 @@ type showCloudCommand struct {
 	out cmd.Output
 
 	CloudName string
+
+	includeConfig bool
 }
 
 var showCloudDoc = `
 Provided information includes 'defined' (public, built-in), 'type',
-'auth-type', 'regions', and 'endpoints'.
+'auth-type', 'regions', 'endpoints', and cloud specific configuration
+options.
+
+If ‘--include-config’ is used, additional configuration (key, type, and
+description) specific to the cloud are displayed if available.
 
 Examples:
 
@@ -44,6 +52,7 @@ func (c *showCloudCommand) SetFlags(f *gnuflag.FlagSet) {
 	c.out.AddFlags(f, "yaml", map[string]cmd.Formatter{
 		"yaml": cmd.FormatYaml,
 	})
+	f.BoolVar(&c.includeConfig, "include-config", false, "Print available config option details specific to the specified cloud")
 }
 
 func (c *showCloudCommand) Init(args []string) error {
@@ -74,7 +83,17 @@ func (c *showCloudCommand) Run(ctxt *cmd.Context) error {
 	if !ok {
 		return errors.NotFoundf("cloud %q", c.CloudName)
 	}
-	return c.out.Write(ctxt, cloud)
+	if err = c.out.Write(ctxt, cloud); err != nil {
+		return err
+	}
+	if c.includeConfig {
+		config := getCloudConfigDetails(cloud.CloudType)
+		if len(config) > 0 {
+			fmt.Fprintln(ctxt.Stdout, fmt.Sprintf("\nThe available config options specific to %s clouds are:", cloud.CloudType))
+			return c.out.Write(ctxt, config)
+		}
+	}
+	return nil
 }
 
 type regionDetails struct {
@@ -98,6 +117,11 @@ type cloudDetails struct {
 	RegionsMap   map[string]regionDetails `yaml:"-" json:"regions,omitempty"`
 	Config       map[string]interface{}   `yaml:"config,omitempty" json:"config,omitempty"`
 	RegionConfig jujucloud.RegionConfig   `yaml:"region-config,omitempty" json:"region-config,omitempty"`
+}
+
+type cloudConfig struct {
+	Type        string `yaml:"type,omitempty" json:"type,omitempty"`
+	Description string `yaml:"description,omitempty" json:"description,omitempty"`
 }
 
 func makeCloudDetails(cloud jujucloud.Cloud) *cloudDetails {
@@ -131,6 +155,34 @@ func makeCloudDetails(cloud jujucloud.Cloud) *cloudDetails {
 		result.RegionsMap[region.Name] = r
 	}
 	return result
+}
+
+func getCloudConfigDetails(cloudType string) map[string]interface{} {
+	// providerSchema has all config options, including their descriptions
+	// and types.
+	providerSchema, err := common.CloudSchemaByType(cloudType)
+	if err != nil {
+		// Some providers do not implement the ProviderSchema interface.
+		return nil
+	}
+	specifics := make(map[string]interface{})
+	ps, err := common.ProviderConfigSchemaSourceByType(cloudType)
+	if err != nil {
+		// Some providers do not implement the ConfigSchema interface.
+		return nil
+	}
+	// ps.ConfigSchema() returns the provider specific config option names, but no
+	// description etc.
+	for attr := range ps.ConfigSchema() {
+		if providerSchema[attr].Secret {
+			continue
+		}
+		specifics[attr] = cloudConfig{
+			Description: providerSchema[attr].Description,
+			Type:        fmt.Sprintf("%s", providerSchema[attr].Type),
+		}
+	}
+	return specifics
 }
 
 func getCloudDetails() (map[string]*cloudDetails, error) {

--- a/cmd/juju/cloud/show_test.go
+++ b/cmd/juju/cloud/show_test.go
@@ -5,6 +5,7 @@ package cloud_test
 
 import (
 	"io/ioutil"
+	"strings"
 
 	"github.com/juju/cmd/cmdtesting"
 	jc "github.com/juju/testing/checkers"
@@ -55,6 +56,7 @@ clouds:
         endpoint: http://london/1.0
     config:
       bootstrap-timeout: 1800
+      use-default-secgroup: true
 `[1:]
 	err := ioutil.WriteFile(osenv.JujuXDGDataHomePath("clouds.yaml"), []byte(data), 0600)
 
@@ -72,10 +74,32 @@ regions:
     endpoint: http://london/1.0
 config:
   bootstrap-timeout: 1800
+  use-default-secgroup: true
 `[1:])
 }
 
-func (s *showSuite) TestShowWithRegionConfig(c *gc.C) {
+var openstackProviderConfig = `
+The available config options specific to openstack clouds are:
+external-network:
+  type: string
+  description: The network label or UUID to create floating IP addresses on when multiple
+    external networks exist.
+network:
+  type: string
+  description: The network label or UUID to bring machines up on when multiple networks
+    exist.
+use-default-secgroup:
+  type: bool
+  description: Whether new machine instances should have the "default" Openstack security
+    group assigned in addition to juju defined security groups.
+use-floating-ip:
+  type: bool
+  description: Whether a floating IP address is required to give the nodes a public
+    IP address. Some installations assign public IP addresses by default without requiring
+    a floating IP address.
+`
+
+func (s *showSuite) TestShowWithRegionConfigAndFlags(c *gc.C) {
 	data := `
 clouds:
   homestack:
@@ -86,17 +110,20 @@ clouds:
     regions:
       london:
         endpoint: http://london/1.0
+    config:
+      bootstrap-retry-delay: 1500
+      network: nameme
     region-config:
       london:
         bootstrap-timeout: 1800
+        use-floating-ip: true
 `[1:]
 	err := ioutil.WriteFile(osenv.JujuXDGDataHomePath("clouds.yaml"), []byte(data), 0600)
 
-	ctx, err := cmdtesting.RunCommand(c, cloud.NewShowCloudCommand(), "homestack")
+	ctx, err := cmdtesting.RunCommand(c, cloud.NewShowCloudCommand(), "homestack", "--include-config")
 	c.Assert(err, jc.ErrorIsNil)
 	out := cmdtesting.Stdout(ctx)
-	c.Assert(out, gc.Equals, `
-defined: local
+	c.Assert(out, gc.Equals, strings.Join([]string{`defined: local
 type: openstack
 description: Openstack Cloud
 auth-types: [userpass, access-key]
@@ -104,8 +131,37 @@ endpoint: http://homestack
 regions:
   london:
     endpoint: http://london/1.0
+config:
+  bootstrap-retry-delay: 1500
+  network: nameme
 region-config:
   london:
     bootstrap-timeout: 1800
+    use-floating-ip: true
+`, openstackProviderConfig}, ""))
+}
+
+func (s *showSuite) TestShowWithRegionConfigAndFlagNoExtraOut(c *gc.C) {
+	ctx, err := cmdtesting.RunCommand(c, cloud.NewShowCloudCommand(), "joyent", "--include-config")
+	c.Assert(err, jc.ErrorIsNil)
+	out := cmdtesting.Stdout(ctx)
+	c.Assert(out, gc.Equals, `
+defined: public
+type: joyent
+description: Joyent Cloud
+auth-types: [userpass]
+regions:
+  eu-ams-1:
+    endpoint: https://eu-ams-1.api.joyentcloud.com
+  us-sw-1:
+    endpoint: https://us-sw-1.api.joyentcloud.com
+  us-east-1:
+    endpoint: https://us-east-1.api.joyentcloud.com
+  us-east-2:
+    endpoint: https://us-east-2.api.joyentcloud.com
+  us-east-3:
+    endpoint: https://us-east-3.api.joyentcloud.com
+  us-west-1:
+    endpoint: https://us-west-1.api.joyentcloud.com
 `[1:])
 }


### PR DESCRIPTION
## Description of change

This change is to help improve juju usability by providing a method for users to
obtain possible config options for bootstrap before bootstrapping. 

The output of juju show-cloud --include-config will now include a description of config 
options unique to the specific cloud and differentiate bootstrap config options from ones
for a model. 

The intent is to ask for user feedback on the new output and adjust accordingly.

## QA steps

Run:
* juju show-cloud aws --include-config
* juju show-cloud <existing openstack cloud> --include-config
* juju show-cloud joyent --include-config

## Documentation changes

Unknown.

## Bug reference

No