### PR TITLE
provider/azure: import credentials from Azure CLI

### DIFF
--- a/provider/azure/credentials.go
+++ b/provider/azure/credentials.go
@@ -4,14 +4,15 @@
 package azure
 
 import (
-	"github.com/Azure/go-autorest/autorest"
+	"io"
+	"strings"
+
 	"github.com/juju/errors"
-	"github.com/juju/utils"
-	"github.com/juju/utils/clock"
 
 	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/provider/azure/internal/azureauth"
+	"github.com/juju/juju/provider/azure/internal/azurecli"
 )
 
 const (
@@ -30,25 +31,45 @@ const (
 	deviceCodeAuthType cloud.AuthType = "interactive"
 )
 
+type ServicePrincipalCreator interface {
+	InteractiveCreate(stderr io.Writer, params azureauth.ServicePrincipalParams) (appid, password string, _ error)
+	Create(params azureauth.ServicePrincipalParams) (appid, password string, _ error)
+}
+
+type AzureCLI interface {
+	ListAccounts() ([]azurecli.Account, error)
+	FindAccountsWithCloudName(name string) ([]azurecli.Account, error)
+	ShowAccount(subscription string) (*azurecli.Account, error)
+	GetAccessToken(subscription, resource string) (*azurecli.AccessToken, error)
+	FindCloudsWithResourceManagerEndpoint(url string) ([]azurecli.Cloud, error)
+	ShowCloud(name string) (*azurecli.Cloud, error)
+}
+
 // environPoviderCredentials is an implementation of
 // environs.ProviderCredentials for the Azure Resource
 // Manager cloud provider.
 type environProviderCredentials struct {
-	sender                            autorest.Sender
-	requestInspector                  autorest.PrepareDecorator
-	interactiveCreateServicePrincipal azureauth.InteractiveCreateServicePrincipalFunc
+	servicePrincipalCreator ServicePrincipalCreator
+	azureCLI                AzureCLI
 }
 
 // CredentialSchemas is part of the environs.ProviderCredentials interface.
-func (environProviderCredentials) CredentialSchemas() map[cloud.AuthType]cloud.CredentialSchema {
+func (c environProviderCredentials) CredentialSchemas() map[cloud.AuthType]cloud.CredentialSchema {
+	interactiveSchema := cloud.CredentialSchema{{
+		credAttrSubscriptionId, cloud.CredentialAttr{Description: "Azure subscription ID"},
+	}}
+	if _, err := c.azureCLI.ShowAccount(""); err == nil {
+		// If az account show returns successfully then we can
+		// use that to get at least some login details, otherwise
+		// we need the user to supply their subscription ID.
+		interactiveSchema[0].CredentialAttr.Optional = true
+	}
 	return map[cloud.AuthType]cloud.CredentialSchema{
 		// deviceCodeAuthType is the interactive device-code oauth
 		// flow. This is only supported on the client side; it will
 		// be used to generate a service principal, and transformed
 		// into clientCredentialsAuthType.
-		deviceCodeAuthType: {{
-			credAttrSubscriptionId, cloud.CredentialAttr{Description: "Azure subscription ID"},
-		}},
+		deviceCodeAuthType: interactiveSchema,
 
 		// clientCredentialsAuthType is the "client credentials"
 		// oauth flow, which requires a service principal with a
@@ -68,8 +89,9 @@ func (environProviderCredentials) CredentialSchemas() map[cloud.AuthType]cloud.C
 	}
 }
 
-// DetectCredentials is part of the environs.ProviderCredentials interface.
-func (environProviderCredentials) DetectCredentials() (*cloud.CloudCredential, error) {
+// DetectCredentials is part of the environs.ProviderCredentials
+// interface.
+func (c environProviderCredentials) DetectCredentials() (*cloud.CloudCredential, error) {
 	return nil, errors.NotFoundf("credentials")
 }
 
@@ -80,36 +102,119 @@ func (c environProviderCredentials) FinalizeCredential(
 ) (*cloud.Credential, error) {
 	switch authType := args.Credential.AuthType(); authType {
 	case deviceCodeAuthType:
-		resourceManagerResourceId, err := azureauth.ResourceManagerResourceId(args.CloudStorageEndpoint)
-		if err != nil {
-			return nil, errors.Trace(err)
-		}
 		subscriptionId := args.Credential.Attributes()[credAttrSubscriptionId]
-		applicationId, password, err := c.interactiveCreateServicePrincipal(
-			ctx.GetStderr(),
-			c.sender,
-			c.requestInspector,
-			args.CloudEndpoint,
-			resourceManagerResourceId,
-			args.CloudIdentityEndpoint,
-			subscriptionId,
-			clock.WallClock,
-			utils.NewUUID,
-		)
+		if subscriptionId != "" {
+			// If a subscription ID was specified then fall
+			// back to the interactive device login. attempt
+			// to get subscription details from Azure CLI.
+			graphResourceId := azureauth.TokenResource(args.CloudIdentityEndpoint)
+			resourceManagerResourceId, err := azureauth.ResourceManagerResourceId(args.CloudStorageEndpoint)
+			if err != nil {
+				return nil, errors.Trace(err)
+			}
+			return c.deviceCodeCredential(ctx, args, azureauth.ServicePrincipalParams{
+				GraphEndpoint:             args.CloudIdentityEndpoint,
+				GraphResourceId:           graphResourceId,
+				ResourceManagerEndpoint:   args.CloudEndpoint,
+				ResourceManagerResourceId: resourceManagerResourceId,
+				SubscriptionId:            subscriptionId,
+			})
+		}
+		params, err := c.getServicePrincipalParams(args.CloudEndpoint)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
-		out := cloud.NewCredential(clientCredentialsAuthType, map[string]string{
-			credAttrSubscriptionId: subscriptionId,
-			credAttrAppId:          applicationId,
-			credAttrAppPassword:    password,
-		})
-		out.Label = args.Credential.Label
-		return &out, nil
-
+		return c.azureCLICredential(ctx, args, params)
 	case clientCredentialsAuthType:
 		return &args.Credential, nil
 	default:
 		return nil, errors.NotSupportedf("%q auth-type", authType)
 	}
+}
+
+func (c environProviderCredentials) deviceCodeCredential(
+	ctx environs.FinalizeCredentialContext,
+	args environs.FinalizeCredentialParams,
+	params azureauth.ServicePrincipalParams,
+) (*cloud.Credential, error) {
+	applicationId, password, err := c.servicePrincipalCreator.InteractiveCreate(ctx.GetStderr(), params)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	out := cloud.NewCredential(clientCredentialsAuthType, map[string]string{
+		credAttrSubscriptionId: params.SubscriptionId,
+		credAttrAppId:          applicationId,
+		credAttrAppPassword:    password,
+	})
+	out.Label = args.Credential.Label
+	return &out, nil
+}
+
+func (c environProviderCredentials) azureCLICredential(
+	ctx environs.FinalizeCredentialContext,
+	args environs.FinalizeCredentialParams,
+	params azureauth.ServicePrincipalParams,
+) (*cloud.Credential, error) {
+	graphToken, err := c.azureCLI.GetAccessToken(params.SubscriptionId, params.GraphResourceId)
+	if err != nil {
+		// The version of Azure CLI may not support
+		// get-access-token so fallback to using device
+		// authentication.
+		logger.Debugf("error getting access token: %s", err)
+		return c.deviceCodeCredential(ctx, args, params)
+	}
+	params.GraphAuthorizer = graphToken.Token()
+
+	resourceManagerAuthorizer, err := c.azureCLI.GetAccessToken(params.SubscriptionId, params.ResourceManagerResourceId)
+	if err != nil {
+		return nil, errors.Annotatef(err, "cannot get access token for %s", params.SubscriptionId)
+	}
+	params.ResourceManagerAuthorizer = resourceManagerAuthorizer.Token()
+
+	applicationId, password, err := c.servicePrincipalCreator.Create(params)
+	if err != nil {
+		return nil, errors.Annotatef(err, "cannot get service principal")
+	}
+	out := cloud.NewCredential(clientCredentialsAuthType, map[string]string{
+		credAttrSubscriptionId: params.SubscriptionId,
+		credAttrAppId:          applicationId,
+		credAttrAppPassword:    password,
+	})
+	out.Label = args.Credential.Label
+	return &out, nil
+}
+
+func (c environProviderCredentials) getServicePrincipalParams(cloudEndpoint string) (azureauth.ServicePrincipalParams, error) {
+	if !strings.HasSuffix(cloudEndpoint, "/") {
+		cloudEndpoint += "/"
+	}
+	clouds, err := c.azureCLI.FindCloudsWithResourceManagerEndpoint(cloudEndpoint)
+	if err != nil {
+		return azureauth.ServicePrincipalParams{}, errors.Annotatef(err, "cannot list clouds")
+	}
+	if len(clouds) != 1 {
+		return azureauth.ServicePrincipalParams{}, errors.Errorf("cannot find cloud for %s", cloudEndpoint)
+	}
+	accounts, err := c.azureCLI.FindAccountsWithCloudName(clouds[0].Name)
+	if err != nil {
+		return azureauth.ServicePrincipalParams{}, errors.Annotatef(err, "cannot get accounts")
+	}
+	if len(accounts) < 1 {
+		return azureauth.ServicePrincipalParams{}, errors.Errorf("no %s accounts found", clouds[0].Name)
+	}
+	acc := accounts[0]
+	for _, a := range accounts[1:] {
+		if a.IsDefault {
+			acc = a
+		}
+	}
+	return azureauth.ServicePrincipalParams{
+		GraphEndpoint:             clouds[0].Endpoints.ActiveDirectoryGraphResourceID,
+		GraphResourceId:           clouds[0].Endpoints.ActiveDirectoryGraphResourceID,
+		ResourceManagerEndpoint:   clouds[0].Endpoints.ResourceManager,
+		ResourceManagerResourceId: clouds[0].Endpoints.ResourceManager,
+		SubscriptionId:            acc.ID,
+		TenantId:                  acc.TenantId,
+	}, nil
+
 }

--- a/provider/azure/credentials_test.go
+++ b/provider/azure/credentials_test.go
@@ -4,36 +4,39 @@
 package azure_test
 
 import (
+	"fmt"
 	"io"
 
-	"github.com/Azure/go-autorest/autorest"
 	"github.com/juju/cmd/cmdtesting"
 	"github.com/juju/errors"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
-	"github.com/juju/utils"
-	"github.com/juju/utils/clock"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/environs"
 	envtesting "github.com/juju/juju/environs/testing"
 	"github.com/juju/juju/provider/azure"
+	"github.com/juju/juju/provider/azure/internal/azureauth"
+	"github.com/juju/juju/provider/azure/internal/azurecli"
 )
 
 type credentialsSuite struct {
 	testing.IsolationSuite
-	interactiveCreateServicePrincipalCreator
-	provider environs.EnvironProvider
+	servicePrincipalCreator servicePrincipalCreator
+	azureCLI                azureCLI
+	provider                environs.EnvironProvider
 }
 
 var _ = gc.Suite(&credentialsSuite{})
 
 func (s *credentialsSuite) SetUpTest(c *gc.C) {
 	s.IsolationSuite.SetUpTest(c)
-	s.interactiveCreateServicePrincipalCreator = interactiveCreateServicePrincipalCreator{}
+	s.servicePrincipalCreator = servicePrincipalCreator{}
+	s.azureCLI = azureCLI{}
 	s.provider = newProvider(c, azure.ProviderConfig{
-		InteractiveCreateServicePrincipal: s.interactiveCreateServicePrincipalCreator.InteractiveCreateServicePrincipal,
+		ServicePrincipalCreator: &s.servicePrincipalCreator,
+		AzureCLI:                &s.azureCLI,
 	})
 }
 
@@ -85,17 +88,20 @@ func (s *credentialsSuite) TestFinalizeCredentialInteractive(c *gc.C) {
 		"subscription-id":      "subscription",
 	})
 
-	s.interactiveCreateServicePrincipalCreator.CheckCallNames(c, "InteractiveCreateServicePrincipal")
-	args := s.interactiveCreateServicePrincipalCreator.Calls()[0].Args
-	c.Assert(args[3], gc.Equals, "https://arm.invalid")
-	c.Assert(args[4], gc.Equals, "https://management.core.invalid/")
-	c.Assert(args[5], gc.Equals, "https://graph.invalid")
-	c.Assert(args[6], gc.Equals, "subscription")
+	s.servicePrincipalCreator.CheckCallNames(c, "InteractiveCreate")
+	args := s.servicePrincipalCreator.Calls()[0].Args
+	c.Assert(args[1], jc.DeepEquals, azureauth.ServicePrincipalParams{
+		GraphEndpoint:             "https://graph.invalid",
+		GraphResourceId:           "https://graph.invalid/",
+		ResourceManagerEndpoint:   "https://arm.invalid",
+		ResourceManagerResourceId: "https://management.core.invalid/",
+		SubscriptionId:            "subscription",
+	})
 }
 
 func (s *credentialsSuite) TestFinalizeCredentialInteractiveError(c *gc.C) {
 	in := cloud.NewCredential("interactive", map[string]string{"subscription-id": "subscription"})
-	s.interactiveCreateServicePrincipalCreator.SetErrors(errors.New("blargh"))
+	s.servicePrincipalCreator.SetErrors(errors.New("blargh"))
 	ctx := cmdtesting.Context(c)
 	_, err := s.provider.FinalizeCredential(ctx, environs.FinalizeCredentialParams{
 		Credential:            in,
@@ -105,26 +111,332 @@ func (s *credentialsSuite) TestFinalizeCredentialInteractiveError(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, "blargh")
 }
 
-type interactiveCreateServicePrincipalCreator struct {
+func (s *credentialsSuite) TestFinalizeCredentialAzureCLI(c *gc.C) {
+	s.azureCLI.Accounts = []azurecli.Account{{
+		CloudName: "AzureCloud",
+		ID:        "test-account1-id",
+		IsDefault: true,
+		Name:      "test-account1",
+		State:     "Enabled",
+		TenantId:  "tenant-id",
+	}, {
+		CloudName: "AzureCloud",
+		ID:        "test-account2-id",
+		IsDefault: false,
+		Name:      "test-account2",
+		State:     "Enabled",
+		TenantId:  "tenant-id",
+	}}
+	s.azureCLI.Clouds = []azurecli.Cloud{{
+		Endpoints: azurecli.CloudEndpoints{
+			ActiveDirectoryGraphResourceID: "https://graph.invalid/",
+			ResourceManager:                "https://arm.invalid/",
+		},
+		IsActive: true,
+		Name:     "AzureCloud",
+	}}
+	in := cloud.NewCredential("interactive", nil)
+	ctx := cmdtesting.Context(c)
+	cred, err := s.provider.FinalizeCredential(ctx, environs.FinalizeCredentialParams{
+		Credential:            in,
+		CloudEndpoint:         "https://arm.invalid",
+		CloudIdentityEndpoint: "https://graph.invalid",
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(cred, gc.Not(gc.IsNil))
+	c.Assert(cred.AuthType(), gc.Equals, cloud.AuthType("service-principal-secret"))
+	attrs := cred.Attributes()
+	c.Assert(attrs["subscription-id"], gc.Equals, "test-account1-id")
+	c.Assert(attrs["application-id"], gc.Equals, "appid")
+	c.Assert(attrs["application-password"], gc.Equals, "service-principal-password")
+}
+
+func (s *credentialsSuite) TestFinalizeCredentialAzureCLIShowAccountError(c *gc.C) {
+	s.azureCLI.Accounts = []azurecli.Account{{
+		CloudName: "AzureCloud",
+		ID:        "test-account1-id",
+		IsDefault: true,
+		Name:      "test-account1",
+		State:     "Enabled",
+		TenantId:  "tenant-id",
+	}, {
+		CloudName: "AzureCloud",
+		ID:        "test-account2-id",
+		IsDefault: false,
+		Name:      "test-account2",
+		State:     "Enabled",
+		TenantId:  "tenant-id",
+	}}
+	s.azureCLI.Clouds = []azurecli.Cloud{{
+		Endpoints: azurecli.CloudEndpoints{
+			ActiveDirectoryGraphResourceID: "https://graph.invalid/",
+			ResourceManager:                "https://arm.invalid/",
+		},
+		IsActive: true,
+		Name:     "AzureCloud",
+	}}
+	s.azureCLI.SetErrors(nil, errors.New("test error"))
+	in := cloud.NewCredential("interactive", nil)
+	ctx := cmdtesting.Context(c)
+	cred, err := s.provider.FinalizeCredential(ctx, environs.FinalizeCredentialParams{
+		Credential:            in,
+		CloudEndpoint:         "https://arm.invalid",
+		CloudIdentityEndpoint: "https://graph.invalid",
+	})
+	c.Assert(err, gc.ErrorMatches, `cannot get accounts: test error`)
+	c.Assert(cred, gc.IsNil)
+}
+
+func (s *credentialsSuite) TestFinalizeCredentialAzureCLIGraphTokenError(c *gc.C) {
+	s.azureCLI.Accounts = []azurecli.Account{{
+		CloudName: "AzureCloud",
+		ID:        "test-account1-id",
+		IsDefault: true,
+		Name:      "test-account1",
+		State:     "Enabled",
+		TenantId:  "tenant-id",
+	}, {
+		CloudName: "AzureCloud",
+		ID:        "test-account2-id",
+		IsDefault: false,
+		Name:      "test-account2",
+		State:     "Enabled",
+		TenantId:  "tenant-id",
+	}}
+	s.azureCLI.Clouds = []azurecli.Cloud{{
+		Endpoints: azurecli.CloudEndpoints{
+			ActiveDirectoryGraphResourceID: "https://graph.invalid/",
+			ResourceManager:                "https://arm.invalid/",
+		},
+		IsActive: true,
+		Name:     "AzureCloud",
+	}}
+	s.azureCLI.SetErrors(nil, nil, nil, errors.New("test error"))
+	in := cloud.NewCredential("interactive", nil)
+	ctx := cmdtesting.Context(c)
+	cred, err := s.provider.FinalizeCredential(ctx, environs.FinalizeCredentialParams{
+		Credential:            in,
+		CloudEndpoint:         "https://arm.invalid",
+		CloudIdentityEndpoint: "https://graph.invalid",
+	})
+	c.Assert(err, gc.ErrorMatches, `cannot get access token for test-account1-id: test error`)
+	c.Assert(cred, gc.IsNil)
+}
+
+func (s *credentialsSuite) TestFinalizeCredentialAzureCLIResourceManagerTokenError(c *gc.C) {
+	s.azureCLI.Accounts = []azurecli.Account{{
+		CloudName: "AzureCloud",
+		ID:        "test-account1-id",
+		IsDefault: true,
+		Name:      "test-account1",
+		State:     "Enabled",
+		TenantId:  "tenant-id",
+	}, {
+		CloudName: "AzureCloud",
+		ID:        "test-account2-id",
+		IsDefault: false,
+		Name:      "test-account2",
+		State:     "Enabled",
+		TenantId:  "tenant-id",
+	}}
+	s.azureCLI.Clouds = []azurecli.Cloud{{
+		Endpoints: azurecli.CloudEndpoints{
+			ActiveDirectoryGraphResourceID: "https://graph.invalid/",
+			ResourceManager:                "https://arm.invalid/",
+		},
+		IsActive: true,
+		Name:     "AzureCloud",
+	}}
+	s.azureCLI.SetErrors(nil, nil, nil, errors.New("test error"))
+	in := cloud.NewCredential("interactive", nil)
+	ctx := cmdtesting.Context(c)
+	cred, err := s.provider.FinalizeCredential(ctx, environs.FinalizeCredentialParams{
+		Credential:            in,
+		CloudEndpoint:         "https://arm.invalid",
+		CloudIdentityEndpoint: "https://graph.invalid",
+	})
+	c.Assert(err, gc.ErrorMatches, `cannot get access token for test-account1-id: test error`)
+	c.Assert(cred, gc.IsNil)
+}
+
+func (s *credentialsSuite) TestFinalizeCredentialAzureCLIServicePrincipalError(c *gc.C) {
+	s.azureCLI.Accounts = []azurecli.Account{{
+		CloudName: "AzureCloud",
+		ID:        "test-account1-id",
+		IsDefault: true,
+		Name:      "test-account1",
+		State:     "Enabled",
+		TenantId:  "tenant-id",
+	}, {
+		CloudName: "AzureCloud",
+		ID:        "test-account2-id",
+		IsDefault: false,
+		Name:      "test-account2",
+		State:     "Enabled",
+		TenantId:  "tenant-id",
+	}}
+	s.azureCLI.Clouds = []azurecli.Cloud{{
+		Endpoints: azurecli.CloudEndpoints{
+			ActiveDirectoryGraphResourceID: "https://graph.invalid/",
+			ResourceManager:                "https://arm.invalid/",
+		},
+		IsActive: true,
+		Name:     "AzureCloud",
+	}}
+	s.servicePrincipalCreator.SetErrors(errors.New("test error"))
+	in := cloud.NewCredential("interactive", nil)
+	ctx := cmdtesting.Context(c)
+	cred, err := s.provider.FinalizeCredential(ctx, environs.FinalizeCredentialParams{
+		Credential:            in,
+		CloudEndpoint:         "https://arm.invalid",
+		CloudIdentityEndpoint: "https://graph.invalid",
+	})
+	c.Assert(err, gc.ErrorMatches, `cannot get service principal: test error`)
+	c.Assert(cred, gc.IsNil)
+}
+
+func (s *credentialsSuite) TestFinalizeCredentialAzureCLIDeviceFallback(c *gc.C) {
+	s.azureCLI.Accounts = []azurecli.Account{{
+		CloudName: "AzureCloud",
+		ID:        "test-account1-id",
+		IsDefault: true,
+		Name:      "test-account1",
+		State:     "Enabled",
+		TenantId:  "tenant-id",
+	}, {
+		CloudName: "AzureCloud",
+		ID:        "test-account2-id",
+		IsDefault: false,
+		Name:      "test-account2",
+		State:     "Enabled",
+		TenantId:  "tenant-id",
+	}}
+	s.azureCLI.Clouds = []azurecli.Cloud{{
+		Endpoints: azurecli.CloudEndpoints{
+			ActiveDirectoryGraphResourceID: "https://graph.invalid/",
+			ResourceManager:                "https://arm.invalid/",
+		},
+		IsActive: true,
+		Name:     "AzureCloud",
+	}}
+	s.azureCLI.SetErrors(nil, nil, errors.New("test error"))
+	in := cloud.NewCredential("interactive", nil)
+	ctx := cmdtesting.Context(c)
+	cred, err := s.provider.FinalizeCredential(ctx, environs.FinalizeCredentialParams{
+		Credential:            in,
+		CloudEndpoint:         "https://arm.invalid",
+		CloudIdentityEndpoint: "https://graph.invalid",
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(cred, gc.Not(gc.IsNil))
+	c.Assert(cred.AuthType(), gc.Equals, cloud.AuthType("service-principal-secret"))
+	attrs := cred.Attributes()
+	c.Assert(attrs["subscription-id"], gc.Equals, "test-account1-id")
+	c.Assert(attrs["application-id"], gc.Equals, "appid")
+	c.Assert(attrs["application-password"], gc.Equals, "service-principal-password")
+	s.servicePrincipalCreator.CheckCallNames(c, "InteractiveCreate")
+}
+
+type servicePrincipalCreator struct {
 	testing.Stub
 }
 
-func (c *interactiveCreateServicePrincipalCreator) InteractiveCreateServicePrincipal(
-	stderr io.Writer,
-	sender autorest.Sender,
-	requestInspector autorest.PrepareDecorator,
-	resourceManagerEndpoint string,
-	resourceManagerResourceId string,
-	graphEndpoint string,
-	subscriptionId string,
-	clock clock.Clock,
-	newUUID func() (utils.UUID, error),
-) (appId, password string, _ error) {
-	c.MethodCall(
-		c, "InteractiveCreateServicePrincipal",
-		stderr, sender, requestInspector, resourceManagerEndpoint,
-		resourceManagerResourceId, graphEndpoint, subscriptionId,
-		clock, newUUID,
-	)
+func (c *servicePrincipalCreator) InteractiveCreate(stderr io.Writer, params azureauth.ServicePrincipalParams) (appId, password string, _ error) {
+	c.MethodCall(c, "InteractiveCreate", stderr, params)
 	return "appid", "service-principal-password", c.NextErr()
+}
+
+func (c *servicePrincipalCreator) Create(params azureauth.ServicePrincipalParams) (appId, password string, _ error) {
+	c.MethodCall(c, "Create", params)
+	return "appid", "service-principal-password", c.NextErr()
+}
+
+type azureCLI struct {
+	testing.Stub
+	Accounts []azurecli.Account
+	Clouds   []azurecli.Cloud
+}
+
+func (e *azureCLI) ListAccounts() ([]azurecli.Account, error) {
+	e.MethodCall(e, "ListAccounts")
+	if err := e.NextErr(); err != nil {
+		return nil, err
+	}
+	return e.Accounts, nil
+}
+
+func (e *azureCLI) FindAccountsWithCloudName(name string) ([]azurecli.Account, error) {
+	e.MethodCall(e, "FindAccountsWithCloudName", name)
+	if err := e.NextErr(); err != nil {
+		return nil, err
+	}
+	var accs []azurecli.Account
+	for _, acc := range e.Accounts {
+		if acc.CloudName == name {
+			accs = append(accs, acc)
+		}
+	}
+	return accs, nil
+}
+
+func (e *azureCLI) ShowAccount(subscription string) (*azurecli.Account, error) {
+	e.MethodCall(e, "ShowAccount", subscription)
+	if err := e.NextErr(); err != nil {
+		return nil, err
+	}
+	return e.findAccount(subscription)
+}
+
+func (e *azureCLI) findAccount(subscription string) (*azurecli.Account, error) {
+	for _, acc := range e.Accounts {
+		if acc.ID == subscription {
+			return &acc, nil
+		}
+		if subscription == "" && acc.IsDefault {
+			return &acc, nil
+		}
+	}
+	return nil, errors.New("account not found")
+}
+
+func (e *azureCLI) GetAccessToken(subscription, resource string) (*azurecli.AccessToken, error) {
+	e.MethodCall(e, "GetAccessToken", subscription, resource)
+	if err := e.NextErr(); err != nil {
+		return nil, err
+	}
+	acc, err := e.findAccount(subscription)
+	if err != nil {
+		return nil, err
+	}
+	return &azurecli.AccessToken{
+		AccessToken: fmt.Sprintf("%s|%s|access-token", subscription, resource),
+		Tenant:      acc.TenantId,
+		TokenType:   "Bearer",
+	}, nil
+}
+
+func (e *azureCLI) ShowCloud(name string) (*azurecli.Cloud, error) {
+	e.MethodCall(e, "ShowCloud", name)
+	if err := e.NextErr(); err != nil {
+		return nil, err
+	}
+	for _, cloud := range e.Clouds {
+		if cloud.Name == name || name == "" {
+			return &cloud, nil
+		}
+	}
+	return nil, errors.New("cloud not found")
+}
+
+func (e *azureCLI) FindCloudsWithResourceManagerEndpoint(url string) ([]azurecli.Cloud, error) {
+	e.MethodCall(e, "FindCloudsWithResourceManagerEndpoint", url)
+	if err := e.NextErr(); err != nil {
+		return nil, err
+	}
+	for _, cloud := range e.Clouds {
+		if cloud.Endpoints.ResourceManager == url {
+			return []azurecli.Cloud{cloud}, nil
+		}
+	}
+	return nil, errors.New("cloud not found")
 }

--- a/provider/azure/environ_test.go
+++ b/provider/azure/environ_test.go
@@ -44,7 +44,6 @@ import (
 	jujutesting "github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/provider/azure"
 	"github.com/juju/juju/provider/azure/internal/armtemplates"
-	"github.com/juju/juju/provider/azure/internal/azureauth"
 	"github.com/juju/juju/provider/azure/internal/azuretesting"
 	"github.com/juju/juju/testing"
 	"github.com/juju/juju/tools"
@@ -124,8 +123,7 @@ func (s *environSuite) SetUpTest(c *gc.C) {
 		RetryClock: &gitjujutesting.AutoAdvancingClock{
 			&s.retryClock, s.retryClock.Advance,
 		},
-		RandomWindowsAdminPassword:        func() string { return "sorandom" },
-		InteractiveCreateServicePrincipal: azureauth.InteractiveCreateServicePrincipal,
+		RandomWindowsAdminPassword: func() string { return "sorandom" },
 	})
 
 	s.controllerUUID = testing.ControllerTag.Id()

--- a/provider/azure/environprovider.go
+++ b/provider/azure/environprovider.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/config"
-	"github.com/juju/juju/provider/azure/internal/azureauth"
 	"github.com/juju/juju/provider/azure/internal/azurestorage"
 )
 
@@ -45,10 +44,11 @@ type ProviderConfig struct {
 	// key pair for provisioning Linux machines.
 	GenerateSSHKey func(comment string) (private, public string, _ error)
 
-	// InteractiveCreateServicePrincipal is a function used to
-	// interactively create/update service principals with
-	// password credentials.
-	InteractiveCreateServicePrincipal azureauth.InteractiveCreateServicePrincipalFunc
+	// ServicePrincipalCreator is the interface used to create service principals.
+	ServicePrincipalCreator ServicePrincipalCreator
+
+	// AzureCLI is the interface the to Azure CLI (az) command.
+	AzureCLI AzureCLI
 }
 
 // Validate validates the Azure provider configuration.
@@ -65,8 +65,11 @@ func (cfg ProviderConfig) Validate() error {
 	if cfg.GenerateSSHKey == nil {
 		return errors.NotValidf("nil GenerateSSHKey")
 	}
-	if cfg.InteractiveCreateServicePrincipal == nil {
-		return errors.NotValidf("nil InteractiveCreateServicePrincipal")
+	if cfg.ServicePrincipalCreator == nil {
+		return errors.NotValidf("nil ServicePrincipalCreator")
+	}
+	if cfg.AzureCLI == nil {
+		return errors.NotValidf("nil AzureCLI")
 	}
 	return nil
 }
@@ -84,9 +87,8 @@ func NewEnvironProvider(config ProviderConfig) (*azureEnvironProvider, error) {
 	}
 	return &azureEnvironProvider{
 		environProviderCredentials: environProviderCredentials{
-			sender:                            config.Sender,
-			requestInspector:                  config.RequestInspector,
-			interactiveCreateServicePrincipal: config.InteractiveCreateServicePrincipal,
+			servicePrincipalCreator: config.ServicePrincipalCreator,
+			azureCLI:                config.AzureCLI,
 		},
 		config: config,
 	}, nil

--- a/provider/azure/environprovider_test.go
+++ b/provider/azure/environprovider_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/provider/azure"
 	"github.com/juju/juju/provider/azure/internal/azureauth"
+	"github.com/juju/juju/provider/azure/internal/azurecli"
 	"github.com/juju/juju/provider/azure/internal/azuretesting"
 	"github.com/juju/juju/testing"
 )
@@ -32,10 +33,9 @@ var _ = gc.Suite(&environProviderSuite{})
 func (s *environProviderSuite) SetUpTest(c *gc.C) {
 	s.BaseSuite.SetUpTest(c)
 	s.provider = newProvider(c, azure.ProviderConfig{
-		Sender:                            &s.sender,
-		RequestInspector:                  azuretesting.RequestRecorder(&s.requests),
-		RandomWindowsAdminPassword:        func() string { return "sorandom" },
-		InteractiveCreateServicePrincipal: azureauth.InteractiveCreateServicePrincipal,
+		Sender:                     &s.sender,
+		RequestInspector:           azuretesting.RequestRecorder(&s.requests),
+		RandomWindowsAdminPassword: func() string { return "sorandom" },
 	})
 	s.spec = environs.CloudSpec{
 		Type:             "azure",
@@ -108,8 +108,11 @@ func newProvider(c *gc.C, config azure.ProviderConfig) environs.EnvironProvider 
 	if config.RetryClock == nil {
 		config.RetryClock = jujutesting.NewClock(time.Time{})
 	}
-	if config.InteractiveCreateServicePrincipal == nil {
-		config.InteractiveCreateServicePrincipal = azureauth.InteractiveCreateServicePrincipal
+	if config.ServicePrincipalCreator == nil {
+		config.ServicePrincipalCreator = &azureauth.ServicePrincipalCreator{}
+	}
+	if config.AzureCLI == nil {
+		config.AzureCLI = azurecli.AzureCLI{}
 	}
 	config.RandomWindowsAdminPassword = func() string { return "sorandom" }
 	config.GenerateSSHKey = func(string) (string, string, error) {

--- a/provider/azure/init.go
+++ b/provider/azure/init.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/provider/azure/internal/azureauth"
+	"github.com/juju/juju/provider/azure/internal/azurecli"
 	"github.com/juju/juju/provider/azure/internal/azurestorage"
 )
 
@@ -29,11 +30,12 @@ func NewProvider(config ProviderConfig) (environs.EnvironProvider, error) {
 
 func init() {
 	environProvider, err := NewProvider(ProviderConfig{
-		NewStorageClient:                  azurestorage.NewClient,
-		RetryClock:                        &clock.WallClock,
-		RandomWindowsAdminPassword:        randomAdminPassword,
-		GenerateSSHKey:                    ssh.GenerateKey,
-		InteractiveCreateServicePrincipal: azureauth.InteractiveCreateServicePrincipal,
+		NewStorageClient:           azurestorage.NewClient,
+		RetryClock:                 &clock.WallClock,
+		RandomWindowsAdminPassword: randomAdminPassword,
+		GenerateSSHKey:             ssh.GenerateKey,
+		ServicePrincipalCreator:    &azureauth.ServicePrincipalCreator{},
+		AzureCLI:                   azurecli.AzureCLI{},
 	})
 	if err != nil {
 		panic(err)

--- a/provider/azure/instance_test.go
+++ b/provider/azure/instance_test.go
@@ -19,7 +19,6 @@ import (
 	"github.com/juju/juju/instance"
 	jujunetwork "github.com/juju/juju/network"
 	"github.com/juju/juju/provider/azure"
-	"github.com/juju/juju/provider/azure/internal/azureauth"
 	"github.com/juju/juju/provider/azure/internal/azuretesting"
 	"github.com/juju/juju/status"
 	"github.com/juju/juju/testing"
@@ -42,10 +41,9 @@ var _ = gc.Suite(&instanceSuite{})
 func (s *instanceSuite) SetUpTest(c *gc.C) {
 	s.BaseSuite.SetUpTest(c)
 	s.provider = newProvider(c, azure.ProviderConfig{
-		Sender:                            &s.sender,
-		RequestInspector:                  azuretesting.RequestRecorder(&s.requests),
-		RandomWindowsAdminPassword:        func() string { return "sorandom" },
-		InteractiveCreateServicePrincipal: azureauth.InteractiveCreateServicePrincipal,
+		Sender:                     &s.sender,
+		RequestInspector:           azuretesting.RequestRecorder(&s.requests),
+		RandomWindowsAdminPassword: func() string { return "sorandom" },
 	})
 	s.env = openEnviron(c, s.provider, &s.sender)
 	s.sender = nil

--- a/provider/azure/internal/azurecli/az.go
+++ b/provider/azure/internal/azurecli/az.go
@@ -1,0 +1,206 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package azurecli
+
+import (
+	"encoding/json"
+	"fmt"
+	"os/exec"
+	"strings"
+
+	"github.com/Azure/go-autorest/autorest/azure"
+	"github.com/juju/errors"
+	"github.com/juju/loggo"
+)
+
+// Logger for the Azure provider.
+var logger = loggo.GetLogger("juju.provider.azure.internal.azurecli")
+
+// AzureCLI
+type AzureCLI struct {
+	// Exec is a function that executes system commands and returns
+	// the output. If this is nil then a default implentation using
+	// os.exec will be used.
+	Exec func(cmd string, args []string) (stdout []byte, err error)
+}
+
+// exec runs the given command using Exec if specified, or
+// os.exec.Command.
+func (a AzureCLI) exec(cmd string, args []string) ([]byte, error) {
+	if a.Exec != nil {
+		return a.Exec(cmd, args)
+	}
+	return exec.Command(cmd, args...).Output()
+}
+
+// run attempts to execute "az" with the given arguments. Unmarshalling
+// the json output into v.
+func (a AzureCLI) run(v interface{}, args []string) error {
+	args = append(args, "-o", "json")
+	logger.Debugf("running az %s", strings.Join(args, " "))
+	b, err := a.exec("az", args)
+	if err != nil {
+		return errors.Annotate(err, "execution failure")
+	}
+	if err := json.Unmarshal(b, v); err != nil {
+		return errors.Annotate(err, "cannot unmarshal output")
+	}
+	return nil
+}
+
+// AccessToken contains the result of the GetAccessToken function.
+type AccessToken struct {
+	AccessToken  string `json:"accessToken"`
+	ExpiresOn    string `json:"expiresOn"`
+	Subscription string `json:"subscription"`
+	Tenant       string `json:"tenant"`
+	TokenType    string `json:"tokenType"`
+}
+
+// Token creates an azure.Token from the AccessToken. This token can be
+// used with go-autorest to access azure endpoints.
+func (t AccessToken) Token() *azure.Token {
+	return &azure.Token{
+		AccessToken: t.AccessToken,
+		Type:        t.TokenType,
+	}
+}
+
+// GetAccessToken gets an access token from the Azure CLI to access the
+// given resource using the given subscription. Either subscription or
+// resource may be empty in which case the default from the az
+// application are used.
+func (a AzureCLI) GetAccessToken(subscription, resource string) (*AccessToken, error) {
+	cmd := []string{"account", "get-access-token"}
+	if subscription != "" {
+		cmd = append(cmd, "--subscription", subscription)
+	}
+	if resource != "" {
+		cmd = append(cmd, "--resource", resource)
+	}
+	var tok AccessToken
+	if err := a.run(&tok, cmd); err != nil {
+		return nil, errors.Trace(err)
+	}
+	return &tok, nil
+}
+
+// Account contains details of an azure account (subscription).
+type Account struct {
+	CloudName string `json:"cloudName"`
+	ID        string `json:"id"`
+	IsDefault bool   `json:"isDefault"`
+	Name      string `json:"name"`
+	State     string `json:"state"`
+	TenantId  string `json:"tenantId"`
+}
+
+// showAccount is a version of Account, but that can handle the subtle
+// difference in output from az account show.
+type showAccount struct {
+	Account
+	EnvironmentName string `json:"environmentName"`
+}
+
+// ShowAccount returns the account details for the account with the given
+// subscription ID. If the subscription is empty then the default Azure
+// CLI account is returned.
+func (a AzureCLI) ShowAccount(subscription string) (*Account, error) {
+	cmd := []string{"account", "show"}
+	if subscription != "" {
+		cmd = append(cmd, "--subscription", subscription)
+	}
+	var acc showAccount
+	if err := a.run(&acc, cmd); err != nil {
+		return nil, errors.Trace(err)
+	}
+	if acc.Account.CloudName == "" {
+		acc.Account.CloudName = acc.EnvironmentName
+	}
+	return &acc.Account, nil
+}
+
+// ListAccounts returns the details for all accounts available in the
+// Azure CLI.
+func (a AzureCLI) ListAccounts() ([]Account, error) {
+	var accounts []Account
+	if err := a.run(&accounts, []string{"account", "list"}); err != nil {
+		return nil, errors.Trace(err)
+	}
+	return accounts, nil
+}
+
+// FindAccountsWithCloudName returns the details for all accounts with
+// the given cloud name..
+func (a AzureCLI) FindAccountsWithCloudName(name string) ([]Account, error) {
+	var accounts []Account
+	cmd := []string{
+		"account",
+		"list",
+		"--query", fmt.Sprintf("[?cloudName=='%s']", name),
+	}
+	if err := a.run(&accounts, cmd); err != nil {
+		return nil, errors.Trace(err)
+	}
+	return accounts, nil
+}
+
+// Cloud contains details of a cloud configured in the Azure CLI.
+type Cloud struct {
+	Endpoints CloudEndpoints `json:"endpoints"`
+	IsActive  bool           `json:"isActive"`
+	Name      string         `json:"name"`
+	Profile   string         `json:"profile"`
+	Suffixes  CloudSuffixes  `json:"suffixes"`
+}
+
+// CloudEndpoints contains the endpoints used by a cloud.
+type CloudEndpoints struct {
+	ActiveDirectory                string `json:"activeDirectory"`
+	ActiveDirectoryGraphResourceID string `json:"activeDirectoryGraphResourceId"`
+	ActiveDirectoryResourceID      string `json:"activeDirectoryResourceId"`
+	BatchResourceID                string `json:"batchResourceId"`
+	Management                     string `json:"management"`
+	ResourceManager                string `json:"resourceManager"`
+	SQLManagement                  string `json:"sqlManagement"`
+}
+
+// CloudSuffixes contains the suffixes used with a cloud.
+type CloudSuffixes struct {
+	AzureDatalakeAnalyticsCatalogAndJobEndpoint string `json:"azureDatalakeAnalyticsCatalogAndJobEndpoint"`
+	AzureDatalakeStoreFileSystemEndpoint        string `json:"azureDatalakeStoreFileSystemEndpoint"`
+	KeyvaultDNS                                 string `json:"keyvaultDns"`
+	SQLServerHostname                           string `json:"sqlServerHostname"`
+	StorageEndpoint                             string `json:"storageEndpoint"`
+}
+
+// ShowCloud returns the details of the cloud with the given name. If the
+// name is empty then the details of the default cloud will be returned.
+func (a AzureCLI) ShowCloud(name string) (*Cloud, error) {
+	cmd := []string{"cloud", "show"}
+	if name != "" {
+		cmd = append(cmd, "--name", name)
+	}
+	var cloud Cloud
+	if err := a.run(&cloud, cmd); err != nil {
+		return nil, err
+	}
+	return &cloud, nil
+}
+
+// FindCloudsWithResourceManagerEndpoint returns a list of clouds which
+// use the given url for it's resource manager endpoint.
+func (a AzureCLI) FindCloudsWithResourceManagerEndpoint(url string) ([]Cloud, error) {
+	var clouds []Cloud
+	cmd := []string{
+		"cloud",
+		"list",
+		"--query",
+		fmt.Sprintf("[?endpoints.resourceManager=='%s']", url),
+	}
+	if err := a.run(&clouds, cmd); err != nil {
+		return nil, err
+	}
+	return clouds, nil
+}

--- a/provider/azure/internal/azurecli/az_test.go
+++ b/provider/azure/internal/azurecli/az_test.go
@@ -1,0 +1,572 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package azurecli_test
+
+import (
+	"strings"
+
+	"github.com/Azure/go-autorest/autorest/azure"
+	"github.com/juju/errors"
+	"github.com/juju/juju/provider/azure/internal/azurecli"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+)
+
+type azSuite struct{}
+
+var _ = gc.Suite(&azSuite{})
+
+func (s *azSuite) TestGetAccessToken(c *gc.C) {
+	azcli := azurecli.AzureCLI{
+		Exec: testExecutor{
+			commands: map[string]result{
+				"az account get-access-token -o json": result{
+					stdout: []byte(`
+{
+  "accessToken": "ACCESSTOKEN",
+  "expiresOn": "2017-06-07 09:27:58.063743",
+  "subscription": "5544b9a5-0000-0000-0000-fedceb5d3696",
+  "tenant": "a52afd7f-0000-0000-0000-e47a54b982da",
+  "tokenType": "Bearer"
+}
+`[1:]),
+				},
+			},
+		}.Exec,
+	}
+	tok, err := azcli.GetAccessToken("", "")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(tok, jc.DeepEquals, &azurecli.AccessToken{
+		AccessToken:  "ACCESSTOKEN",
+		ExpiresOn:    "2017-06-07 09:27:58.063743",
+		Subscription: "5544b9a5-0000-0000-0000-fedceb5d3696",
+		Tenant:       "a52afd7f-0000-0000-0000-e47a54b982da",
+		TokenType:    "Bearer",
+	})
+}
+
+func (s *azSuite) TestGetAccessTokenWithSubscriptionAndResource(c *gc.C) {
+	azcli := azurecli.AzureCLI{
+		Exec: testExecutor{
+			commands: map[string]result{
+				"az account get-access-token --subscription 5544b9a5-0000-0000-0000-fedceb5d3696 --resource resid -o json": result{
+					stdout: []byte(`
+{
+  "accessToken": "ACCESSTOKEN",
+  "expiresOn": "2017-06-07 09:27:58.063743",
+  "subscription": "5544b9a5-0000-0000-0000-fedceb5d3696",
+  "tenant": "a52afd7f-0000-0000-0000-e47a54b982da",
+  "tokenType": "Bearer"
+}
+`[1:]),
+				},
+			},
+		}.Exec,
+	}
+	tok, err := azcli.GetAccessToken("5544b9a5-0000-0000-0000-fedceb5d3696", "resid")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(tok, jc.DeepEquals, &azurecli.AccessToken{
+		AccessToken:  "ACCESSTOKEN",
+		ExpiresOn:    "2017-06-07 09:27:58.063743",
+		Subscription: "5544b9a5-0000-0000-0000-fedceb5d3696",
+		Tenant:       "a52afd7f-0000-0000-0000-e47a54b982da",
+		TokenType:    "Bearer",
+	})
+}
+
+func (s *azSuite) TestGetAccessTokenError(c *gc.C) {
+	azcli := azurecli.AzureCLI{
+		Exec: testExecutor{
+			commands: map[string]result{
+				"az account get-access-token -o json": result{
+					error: errors.New("test error"),
+				},
+			},
+		}.Exec,
+	}
+	tok, err := azcli.GetAccessToken("", "")
+	c.Assert(err, gc.ErrorMatches, `execution failure: test error`)
+	c.Assert(tok, gc.IsNil)
+}
+
+func (s *azSuite) TestGetAccessTokenJSONError(c *gc.C) {
+	azcli := azurecli.AzureCLI{
+		Exec: testExecutor{
+			commands: map[string]result{
+				"az account get-access-token -o json": result{
+					stdout: []byte(`}`),
+				},
+			},
+		}.Exec,
+	}
+	tok, err := azcli.GetAccessToken("", "")
+	c.Assert(err, gc.ErrorMatches, `cannot unmarshal output: invalid character '}' looking for beginning of value`)
+	c.Assert(tok, gc.IsNil)
+}
+
+func (s *azSuite) TestAzureTokenFromAccessToken(c *gc.C) {
+	tok := azurecli.AccessToken{
+		AccessToken:  "0123456789",
+		ExpiresOn:    "2017-06-05 10:20:43.752534",
+		Subscription: "00000000-0000-0000-0000-00000001",
+		Tenant:       "00000000-0000-0000-0000-00000002",
+		TokenType:    "Bearer",
+	}
+	tok1 := tok.Token()
+	c.Assert(tok1, jc.DeepEquals, &azure.Token{
+		AccessToken: "0123456789",
+		Type:        "Bearer",
+	})
+}
+
+func (s *azSuite) TestShowAccount(c *gc.C) {
+	azcli := azurecli.AzureCLI{
+		Exec: testExecutor{
+			commands: map[string]result{
+				"az account show -o json": result{
+					stdout: []byte(`
+{
+  "environmentName": "AzureCloud",
+  "id": "5544b9a5-0000-0000-0000-fedceb5d3696",
+  "isDefault": true,
+  "name": "AccountName",
+  "state": "Enabled",
+  "tenantId": "a52afd7f-0000-0000-0000-e47a54b982da",
+  "user": {
+    "name": "user@example.com",
+    "type": "user"
+  }
+}
+
+`[1:]),
+				},
+			},
+		}.Exec,
+	}
+	acc, err := azcli.ShowAccount("")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(acc, jc.DeepEquals, &azurecli.Account{
+		CloudName: "AzureCloud",
+		ID:        "5544b9a5-0000-0000-0000-fedceb5d3696",
+		IsDefault: true,
+		Name:      "AccountName",
+		State:     "Enabled",
+		TenantId:  "a52afd7f-0000-0000-0000-e47a54b982da",
+	})
+}
+
+func (s *azSuite) TestShowAccountWithSubscription(c *gc.C) {
+	azcli := azurecli.AzureCLI{
+		Exec: testExecutor{
+			commands: map[string]result{
+				"az account show --subscription 5544b9a5-0000-0000-0000-fedceb5d3696 -o json": result{
+					stdout: []byte(`
+{
+  "environmentName": "AzureCloud",
+  "id": "5544b9a5-0000-0000-0000-fedceb5d3696",
+  "isDefault": true,
+  "name": "AccountName",
+  "state": "Enabled",
+  "tenantId": "a52afd7f-0000-0000-0000-e47a54b982da",
+  "user": {
+    "name": "user@example.com",
+    "type": "user"
+  }
+}
+
+`[1:]),
+				},
+			},
+		}.Exec,
+	}
+	acc, err := azcli.ShowAccount("5544b9a5-0000-0000-0000-fedceb5d3696")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(acc, jc.DeepEquals, &azurecli.Account{
+		CloudName: "AzureCloud",
+		ID:        "5544b9a5-0000-0000-0000-fedceb5d3696",
+		IsDefault: true,
+		Name:      "AccountName",
+		State:     "Enabled",
+		TenantId:  "a52afd7f-0000-0000-0000-e47a54b982da",
+	})
+}
+
+func (s *azSuite) TestShowAccountError(c *gc.C) {
+	azcli := azurecli.AzureCLI{
+		Exec: testExecutor{
+			commands: map[string]result{
+				"az account show -o json": result{
+					error: errors.New("test error"),
+				},
+			},
+		}.Exec,
+	}
+	acc, err := azcli.ShowAccount("")
+	c.Assert(err, gc.ErrorMatches, `execution failure: test error`)
+	c.Assert(acc, gc.IsNil)
+}
+
+func (s *azSuite) TestListAccounts(c *gc.C) {
+	azcli := azurecli.AzureCLI{
+		Exec: testExecutor{
+			commands: map[string]result{
+				"az account list -o json": result{
+					stdout: []byte(`
+[
+  {
+    "cloudName": "AzureCloud",
+    "id": "d7ad3057-0000-0000-0000-513d7136eec5",
+    "isDefault": false,
+    "name": "Free Trial",
+    "state": "Enabled",
+    "tenantId": "b7bb0664-0000-0000-0000-4d5f1481ef22",
+    "user": {
+      "name": "user@example.com",
+      "type": "user"
+    }
+  },
+  {
+    "cloudName": "AzureCloud",
+    "id": "5af17b7d-0000-0000-0000-5cd99887fdf7",
+    "isDefault": true,
+    "name": "Pay-As-You-Go",
+    "state": "Enabled",
+    "tenantId": "2da419a9-0000-0000-0000-ac7c24bbe2e7",
+    "user": {
+      "name": "user@example.com",
+      "type": "user"
+    }
+  }
+]
+`[1:]),
+				},
+			},
+		}.Exec,
+	}
+	accs, err := azcli.ListAccounts()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(accs, jc.DeepEquals, []azurecli.Account{{
+		CloudName: "AzureCloud",
+		ID:        "d7ad3057-0000-0000-0000-513d7136eec5",
+		IsDefault: false,
+		Name:      "Free Trial",
+		State:     "Enabled",
+		TenantId:  "b7bb0664-0000-0000-0000-4d5f1481ef22",
+	}, {
+		CloudName: "AzureCloud",
+		ID:        "5af17b7d-0000-0000-0000-5cd99887fdf7",
+		IsDefault: true,
+		Name:      "Pay-As-You-Go",
+		State:     "Enabled",
+		TenantId:  "2da419a9-0000-0000-0000-ac7c24bbe2e7",
+	}})
+}
+
+func (s *azSuite) TestListAccountsError(c *gc.C) {
+	azcli := azurecli.AzureCLI{
+		Exec: testExecutor{
+			commands: map[string]result{
+				"az account list -o json": result{
+					error: errors.New("test error"),
+				},
+			},
+		}.Exec,
+	}
+	accs, err := azcli.ListAccounts()
+	c.Assert(err, gc.ErrorMatches, `execution failure: test error`)
+	c.Assert(accs, gc.IsNil)
+}
+
+func (s *azSuite) TestFindAccountsWithCloudName(c *gc.C) {
+	azcli := azurecli.AzureCLI{
+		Exec: testExecutor{
+			commands: map[string]result{
+				"az account list --query [?cloudName=='AzureCloud'] -o json": result{
+					stdout: []byte(`
+[
+  {
+    "cloudName": "AzureCloud",
+    "id": "d7ad3057-0000-0000-0000-513d7136eec5",
+    "isDefault": false,
+    "name": "Free Trial",
+    "state": "Enabled",
+    "tenantId": "b7bb0664-0000-0000-0000-4d5f1481ef22",
+    "user": {
+      "name": "user@example.com",
+      "type": "user"
+    }
+  },
+  {
+    "cloudName": "AzureCloud",
+    "id": "5af17b7d-0000-0000-0000-5cd99887fdf7",
+    "isDefault": true,
+    "name": "Pay-As-You-Go",
+    "state": "Enabled",
+    "tenantId": "2da419a9-0000-0000-0000-ac7c24bbe2e7",
+    "user": {
+      "name": "user@example.com",
+      "type": "user"
+    }
+  }
+]
+`[1:]),
+				},
+			},
+		}.Exec,
+	}
+	accs, err := azcli.FindAccountsWithCloudName("AzureCloud")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(accs, jc.DeepEquals, []azurecli.Account{{
+		CloudName: "AzureCloud",
+		ID:        "d7ad3057-0000-0000-0000-513d7136eec5",
+		IsDefault: false,
+		Name:      "Free Trial",
+		State:     "Enabled",
+		TenantId:  "b7bb0664-0000-0000-0000-4d5f1481ef22",
+	}, {
+		CloudName: "AzureCloud",
+		ID:        "5af17b7d-0000-0000-0000-5cd99887fdf7",
+		IsDefault: true,
+		Name:      "Pay-As-You-Go",
+		State:     "Enabled",
+		TenantId:  "2da419a9-0000-0000-0000-ac7c24bbe2e7",
+	}})
+}
+
+func (s *azSuite) TestFindAccountsWithCloudNameError(c *gc.C) {
+	azcli := azurecli.AzureCLI{
+		Exec: testExecutor{
+			commands: map[string]result{
+				"az account list --query [?cloudName=='AzureCloud'] -o json": result{
+					error: errors.New("test error"),
+				},
+			},
+		}.Exec,
+	}
+	accs, err := azcli.FindAccountsWithCloudName("AzureCloud")
+	c.Assert(err, gc.ErrorMatches, `execution failure: test error`)
+	c.Assert(accs, gc.IsNil)
+}
+
+func (s *azSuite) TestShowCloud(c *gc.C) {
+	azcli := azurecli.AzureCLI{
+		Exec: testExecutor{
+			commands: map[string]result{
+				"az cloud show -o json": result{
+					stdout: []byte(`
+{
+  "endpoints": {
+    "activeDirectory": "https://login.microsoftonline.com",
+    "activeDirectoryGraphResourceId": "https://graph.windows.net/",
+    "activeDirectoryResourceId": "https://management.core.windows.net/",
+    "batchResourceId": "https://batch.core.windows.net/",
+    "gallery": "https://gallery.azure.com/",
+    "management": "https://management.core.windows.net/",
+    "resourceManager": "https://management.azure.com/",
+    "sqlManagement": "https://management.core.windows.net:8443/"
+  },
+  "isActive": true,
+  "name": "AzureCloud",
+  "profile": "latest",
+  "suffixes": {
+    "azureDatalakeAnalyticsCatalogAndJobEndpoint": "azuredatalakeanalytics.net",
+    "azureDatalakeStoreFileSystemEndpoint": "azuredatalakestore.net",
+    "keyvaultDns": ".vault.azure.net",
+    "sqlServerHostname": ".database.windows.net",
+    "storageEndpoint": "core.windows.net"
+  }
+}
+`[1:]),
+				},
+			},
+		}.Exec,
+	}
+	cloud, err := azcli.ShowCloud("")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(cloud, jc.DeepEquals, &azurecli.Cloud{
+		Endpoints: azurecli.CloudEndpoints{
+			ActiveDirectory:                "https://login.microsoftonline.com",
+			ActiveDirectoryGraphResourceID: "https://graph.windows.net/",
+			ActiveDirectoryResourceID:      "https://management.core.windows.net/",
+			BatchResourceID:                "https://batch.core.windows.net/",
+			Management:                     "https://management.core.windows.net/",
+			ResourceManager:                "https://management.azure.com/",
+			SQLManagement:                  "https://management.core.windows.net:8443/",
+		},
+		IsActive: true,
+		Name:     "AzureCloud",
+		Profile:  "latest",
+		Suffixes: azurecli.CloudSuffixes{
+			AzureDatalakeAnalyticsCatalogAndJobEndpoint: "azuredatalakeanalytics.net",
+			AzureDatalakeStoreFileSystemEndpoint:        "azuredatalakestore.net",
+			KeyvaultDNS:                                 ".vault.azure.net",
+			SQLServerHostname:                           ".database.windows.net",
+			StorageEndpoint:                             "core.windows.net",
+		},
+	})
+}
+
+func (s *azSuite) TestShowCloudWithName(c *gc.C) {
+	azcli := azurecli.AzureCLI{
+		Exec: testExecutor{
+			commands: map[string]result{
+				"az cloud show --name AzureUSGovernment -o json": result{
+					stdout: []byte(`
+{
+  "endpoints": {
+    "activeDirectory": "https://login.microsoftonline.com",
+    "activeDirectoryGraphResourceId": "https://graph.windows.net/",
+    "activeDirectoryResourceId": "https://management.core.usgovcloudapi.net/",
+    "batchResourceId": "https://batch.core.usgovcloudapi.net/",
+    "gallery": "https://gallery.usgovcloudapi.net/",
+    "management": "https://management.core.usgovcloudapi.net/",
+    "resourceManager": "https://management.usgovcloudapi.net/",
+    "sqlManagement": "https://management.core.usgovcloudapi.net:8443/"
+  },
+  "isActive": false,
+  "name": "AzureUSGovernment",
+  "profile": "latest",
+  "suffixes": {
+    "azureDatalakeAnalyticsCatalogAndJobEndpoint": null,
+    "azureDatalakeStoreFileSystemEndpoint": null,
+    "keyvaultDns": ".vault.usgovcloudapi.net",
+    "sqlServerHostname": ".database.usgovcloudapi.net",
+    "storageEndpoint": "core.usgovcloudapi.net"
+  }
+}
+`[1:]),
+				},
+			},
+		}.Exec,
+	}
+	cloud, err := azcli.ShowCloud("AzureUSGovernment")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(cloud, jc.DeepEquals, &azurecli.Cloud{
+		Endpoints: azurecli.CloudEndpoints{
+			ActiveDirectory:                "https://login.microsoftonline.com",
+			ActiveDirectoryGraphResourceID: "https://graph.windows.net/",
+			ActiveDirectoryResourceID:      "https://management.core.usgovcloudapi.net/",
+			BatchResourceID:                "https://batch.core.usgovcloudapi.net/",
+			Management:                     "https://management.core.usgovcloudapi.net/",
+			ResourceManager:                "https://management.usgovcloudapi.net/",
+			SQLManagement:                  "https://management.core.usgovcloudapi.net:8443/",
+		},
+		IsActive: false,
+		Name:     "AzureUSGovernment",
+		Profile:  "latest",
+		Suffixes: azurecli.CloudSuffixes{
+			KeyvaultDNS:       ".vault.usgovcloudapi.net",
+			SQLServerHostname: ".database.usgovcloudapi.net",
+			StorageEndpoint:   "core.usgovcloudapi.net",
+		},
+	})
+}
+
+func (s *azSuite) TestShowCloudError(c *gc.C) {
+	azcli := azurecli.AzureCLI{
+		Exec: testExecutor{
+			commands: map[string]result{
+				"az cloud show -o json": result{
+					error: errors.New("test error"),
+				},
+			},
+		}.Exec,
+	}
+	cloud, err := azcli.ShowCloud("")
+	c.Assert(err, gc.ErrorMatches, `execution failure: test error`)
+	c.Assert(cloud, gc.IsNil)
+}
+
+func (s *azSuite) TestFindCloudsWithResourceManagerEndpoint(c *gc.C) {
+	azcli := azurecli.AzureCLI{
+		Exec: testExecutor{
+			commands: map[string]result{
+				"az cloud list --query [?endpoints.resourceManager=='https://management.azure.com/'] -o json": result{
+					stdout: []byte(`
+[
+  {
+    "endpoints": {
+      "activeDirectory": "https://login.microsoftonline.com",
+      "activeDirectoryGraphResourceId": "https://graph.windows.net/",
+      "activeDirectoryResourceId": "https://management.core.windows.net/",
+      "batchResourceId": "https://batch.core.windows.net/",
+      "gallery": "https://gallery.azure.com/",
+      "management": "https://management.core.windows.net/",
+      "resourceManager": "https://management.azure.com/",
+      "sqlManagement": "https://management.core.windows.net:8443/"
+    },
+    "isActive": true,
+    "name": "AzureCloud",
+    "profile": "latest",
+    "suffixes": {
+      "azureDatalakeAnalyticsCatalogAndJobEndpoint": "azuredatalakeanalytics.net",
+      "azureDatalakeStoreFileSystemEndpoint": "azuredatalakestore.net",
+      "keyvaultDns": ".vault.azure.net",
+      "sqlServerHostname": ".database.windows.net",
+      "storageEndpoint": "core.windows.net"
+    }
+  }
+]
+`[1:]),
+				},
+			},
+		}.Exec,
+	}
+	cloud, err := azcli.FindCloudsWithResourceManagerEndpoint("https://management.azure.com/")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(cloud, jc.DeepEquals, []azurecli.Cloud{{
+		Endpoints: azurecli.CloudEndpoints{
+			ActiveDirectory:                "https://login.microsoftonline.com",
+			ActiveDirectoryGraphResourceID: "https://graph.windows.net/",
+			ActiveDirectoryResourceID:      "https://management.core.windows.net/",
+			BatchResourceID:                "https://batch.core.windows.net/",
+			Management:                     "https://management.core.windows.net/",
+			ResourceManager:                "https://management.azure.com/",
+			SQLManagement:                  "https://management.core.windows.net:8443/",
+		},
+		IsActive: true,
+		Name:     "AzureCloud",
+		Profile:  "latest",
+		Suffixes: azurecli.CloudSuffixes{
+			AzureDatalakeAnalyticsCatalogAndJobEndpoint: "azuredatalakeanalytics.net",
+			AzureDatalakeStoreFileSystemEndpoint:        "azuredatalakestore.net",
+			KeyvaultDNS:                                 ".vault.azure.net",
+			SQLServerHostname:                           ".database.windows.net",
+			StorageEndpoint:                             "core.windows.net",
+		},
+	}})
+}
+
+func (s *azSuite) TestFindCloudsWithResourceManagerEndpointError(c *gc.C) {
+	azcli := azurecli.AzureCLI{
+		Exec: testExecutor{
+			commands: map[string]result{
+				"az cloud list --query [?endpoints.resourceManager=='https://management.azure.com/'] -o json": result{
+					error: errors.New("test error"),
+				},
+			},
+		}.Exec,
+	}
+	cloud, err := azcli.FindCloudsWithResourceManagerEndpoint("https://management.azure.com/")
+	c.Assert(err, gc.ErrorMatches, `execution failure: test error`)
+	c.Assert(cloud, gc.IsNil)
+}
+
+type result struct {
+	stdout []byte
+	error  error
+}
+
+type testExecutor struct {
+	commands map[string]result
+}
+
+func (e testExecutor) Exec(cmd string, args []string) ([]byte, error) {
+	c := strings.Join(append([]string{cmd}, args...), " ")
+	r, ok := e.commands[c]
+	if !ok {
+		return nil, errors.Errorf("unexpected command '%s'", c)
+	}
+	return r.stdout, r.error
+}

--- a/provider/azure/internal/azurecli/package_test.go
+++ b/provider/azure/internal/azurecli/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package azurecli_test
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func TestPackage(t *testing.T) {
+	gc.TestingT(t)
+}

--- a/provider/azure/storage_test.go
+++ b/provider/azure/storage_test.go
@@ -18,7 +18,6 @@ import (
 
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/provider/azure"
-	"github.com/juju/juju/provider/azure/internal/azureauth"
 	"github.com/juju/juju/provider/azure/internal/azuretesting"
 	"github.com/juju/juju/storage"
 	"github.com/juju/juju/testing"
@@ -40,11 +39,10 @@ func (s *storageSuite) SetUpTest(c *gc.C) {
 	s.storageClient = azuretesting.MockStorageClient{}
 	s.requests = nil
 	envProvider := newProvider(c, azure.ProviderConfig{
-		Sender:                            &s.sender,
-		NewStorageClient:                  s.storageClient.NewClient,
-		RequestInspector:                  azuretesting.RequestRecorder(&s.requests),
-		RandomWindowsAdminPassword:        func() string { return "sorandom" },
-		InteractiveCreateServicePrincipal: azureauth.InteractiveCreateServicePrincipal,
+		Sender:                     &s.sender,
+		NewStorageClient:           s.storageClient.NewClient,
+		RequestInspector:           azuretesting.RequestRecorder(&s.requests),
+		RandomWindowsAdminPassword: func() string { return "sorandom" },
 	})
 	s.sender = nil
 


### PR DESCRIPTION
## Please provide the following details to expedite Pull Request review:

----

## Description of change
This adds support in the azure provider for using azure CLI to import credentials. This removes the requirement that the user discover their subscription ID before creating credentials.

## QA steps

After installing an appropriate version of the Azure CLI (pip install --pre azure-cli --extra-index-url https://azureclinightly.blob.core.windows.net/packages) and use az login to log in the CLI.

run "juju add-credential azure" to import using add-credential

use "juju autoload-credential" to detect and import available credentials

## Documentation changes

This adds additional options for add-credentials with the CLI provider

## Bug reference


