### PR TITLE
Fix TestPruneLogsBySize

### DIFF
--- a/state/logs_test.go
+++ b/state/logs_test.go
@@ -258,12 +258,12 @@ func (s *LogsSuite) TestPruneLogsBySize(c *gc.C) {
 
 	// Logs for second env should be pruned.
 	c.Assert(s.countLogs(c, s1), jc.LessThan, startingLogsS1)
-	c.Assert(s.countLogs(c, s1), jc.GreaterThan, 5000)
+	c.Assert(s.countLogs(c, s1), jc.GreaterThan, 2000)
 
 	// Logs for third env should be pruned to a similar level as
 	// second env.
 	c.Assert(s.countLogs(c, s2), jc.LessThan, startingLogsS1)
-	c.Assert(s.countLogs(c, s2), jc.GreaterThan, 5000)
+	c.Assert(s.countLogs(c, s2), jc.GreaterThan, 2000)
 
 	// Ensure that the latest log records are still there.
 	assertLatestTs := func(st *state.State) {


### PR DESCRIPTION
## Description of change

This would occasionally fail because the logs would be pruned down to
below 5000 (since it was slightly above the threshold before
pruning). Instead check that there are more than 2000 records - this
should never be hit. The thing that I was actually concerned with when
adding the check was that there should still be *some* records left in
the collection (which was a bug I introduced while making changes).

## QA steps

Ran the test a lot of times and it didn't fail (although to be honest I couldn't get it to fail for 5000 either).

## Bug reference

Caused this failure:
http://reports.vapour.ws/releases/5350/job/run-unit-tests-xenial-amd64/attempt/276
