### PR TITLE
merge the latest peer-xplod into core

### DIFF
--- a/acceptancetests/repository/charms/peer-xplod/hooks/install
+++ b/acceptancetests/repository/charms/peer-xplod/hooks/install
@@ -2,3 +2,4 @@
 
 # Try to call status-set but don't fail if it isn't available
 status-set maintenance "installing" || true
+apt-get install -y python

--- a/acceptancetests/repository/charms/peer-xplod/hooks/update.py
+++ b/acceptancetests/repository/charms/peer-xplod/hooks/update.py
@@ -136,7 +136,7 @@ def update_locally():
 
 
 def check_set_v(v, maximum, info, relation_id=None):
-    if v <= maximum:
+    if maximum <= 0 or v <= maximum:
         juju_log("setting v %s.v=%s" % (unitName, v))
         relation_set(relation_id=relation_id, v=v, stopped="")
         set_unit_status(STATE_ACTIVE)
@@ -144,7 +144,7 @@ def check_set_v(v, maximum, info, relation_id=None):
         juju_log("maximum (%s) exceeded %s" % (maximum, v))
         check_set_stopped(info, maximum, relation_id=relation_id)
         set_unit_status(STATE_WAITING, "reached maximum count %d" % (maximum,))
-    
+
 
 def update_value():
     info = my_info()

--- a/acceptancetests/repository/charms/peer-xplod/metadata.yaml
+++ b/acceptancetests/repository/charms/peer-xplod/metadata.yaml
@@ -5,8 +5,11 @@ description: |
   Every peer connects to every other peer, and on every change, broadcasts an update to its own values.
   This triggers all the other units to wake up and try to do the same.
   You can use the config setting "maximum" to cause the exploding to stop after reaching a certain value.
-categories:
+tags:
   - misc
+series:
+  - xenial
+  - trusty
 subordinate: false
 peers:
   xplod:


### PR DESCRIPTION
## Description of change

Peer-xplod currently uses python2 for all of its hooks. Xenial doesn't have it installed by default, so we need to install it in the 'install' hook.
This also lets us change the charm into a multi-series charm, and fixes 'categories' vs 'tags' which is something that 'charm proof' complains about.

It also changes it so if you `juju set peer-xplod maximum=0` the charm hooks never stop firing, which was the original intent.

## QA steps

You should be able to `juju deploy ./peer-xplod --series xenial` and have it work.

## Documentation changes

No, this is used for internal testing.

## Bug reference

No