### PR TITLE
Agent introspection command improvements

### DIFF
--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -101,9 +101,11 @@ import (
 )
 
 var (
-	logger       = loggo.GetLogger("juju.cmd.jujud")
-	jujuRun      = paths.MustSucceed(paths.JujuRun(series.MustHostSeries()))
-	jujuDumpLogs = paths.MustSucceed(paths.JujuDumpLogs(series.MustHostSeries()))
+	logger         = loggo.GetLogger("juju.cmd.jujud")
+	jujuRun        = paths.MustSucceed(paths.JujuRun(series.MustHostSeries()))
+	jujuDumpLogs   = paths.MustSucceed(paths.JujuDumpLogs(series.MustHostSeries()))
+	jujuIntrospect = paths.MustSucceed(paths.JujuIntrospect(series.MustHostSeries()))
+	jujudSymlinks  = []string{jujuRun, jujuDumpLogs, jujuIntrospect}
 
 	// The following are defined as variables to allow the tests to
 	// intercept calls to the functions. In every case, they should
@@ -1556,7 +1558,7 @@ func (a *MachineAgent) Tag() names.Tag {
 
 func (a *MachineAgent) createJujudSymlinks(dataDir string) error {
 	jujud := filepath.Join(tools.ToolsDir(dataDir, a.Tag().String()), jujunames.Jujud)
-	for _, link := range []string{jujuRun, jujuDumpLogs} {
+	for _, link := range jujudSymlinks {
 		err := a.createSymlink(jujud, link)
 		if err != nil {
 			return errors.Annotatef(err, "failed to create %s symlink", link)
@@ -1590,7 +1592,7 @@ func (a *MachineAgent) createSymlink(target, link string) error {
 }
 
 func (a *MachineAgent) removeJujudSymlinks() (errs []error) {
-	for _, link := range []string{jujuRun, jujuDumpLogs} {
+	for _, link := range jujudSymlinks {
 		err := os.Remove(utils.EnsureBaseDir(a.rootDir, link))
 		if err != nil && !os.IsNotExist(err) {
 			errs = append(errs, errors.Annotatef(err, "failed to remove %s symlink", link))

--- a/cmd/jujud/agent/machine_test.go
+++ b/cmd/jujud/agent/machine_test.go
@@ -800,7 +800,7 @@ func (s *MachineSuite) TestMachineAgentSymlinks(c *gc.C) {
 	_, done := s.waitForOpenState(c, a)
 
 	// Symlinks should have been created
-	for _, link := range []string{jujuRun, jujuDumpLogs} {
+	for _, link := range jujudSymlinks {
 		_, err := os.Stat(utils.EnsureBaseDir(a.rootDir, link))
 		c.Assert(err, jc.ErrorIsNil, gc.Commentf(link))
 	}
@@ -820,9 +820,8 @@ func (s *MachineSuite) TestMachineAgentSymlinkJujuRunExists(c *gc.C) {
 	defer a.Stop()
 
 	// Pre-create the symlinks, but pointing to the incorrect location.
-	links := []string{jujuRun, jujuDumpLogs}
 	a.rootDir = c.MkDir()
-	for _, link := range links {
+	for _, link := range jujudSymlinks {
 		fullLink := utils.EnsureBaseDir(a.rootDir, link)
 		c.Assert(os.MkdirAll(filepath.Dir(fullLink), os.FileMode(0755)), jc.ErrorIsNil)
 		c.Assert(symlink.New("/nowhere/special", fullLink), jc.ErrorIsNil, gc.Commentf(link))
@@ -832,7 +831,7 @@ func (s *MachineSuite) TestMachineAgentSymlinkJujuRunExists(c *gc.C) {
 	_, done := s.waitForOpenState(c, a)
 
 	// juju-run symlink should have been recreated.
-	for _, link := range links {
+	for _, link := range jujudSymlinks {
 		fullLink := utils.EnsureBaseDir(a.rootDir, link)
 		linkTarget, err := symlink.Read(fullLink)
 		c.Assert(err, jc.ErrorIsNil)
@@ -850,9 +849,8 @@ func (s *MachineSuite) TestMachineAgentUninstall(c *gc.C) {
 	err = runWithTimeout(a)
 	c.Assert(err, jc.ErrorIsNil)
 
-	// juju-run and juju-dumplogs symlinks should have been removed on
-	// termination.
-	for _, link := range []string{jujuRun, jujuDumpLogs} {
+	// juju-* symlinks should have been removed on termination.
+	for _, link := range []string{jujuRun, jujuDumpLogs, jujuIntrospect} {
 		_, err = os.Stat(utils.EnsureBaseDir(a.rootDir, link))
 		c.Assert(err, jc.Satisfies, os.IsNotExist)
 	}

--- a/cmd/jujud/introspect/introspect.go
+++ b/cmd/jujud/introspect/introspect.go
@@ -1,0 +1,177 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package introspect
+
+import (
+	"io"
+	"net"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"os"
+	"path/filepath"
+
+	"github.com/juju/cmd"
+	"github.com/juju/errors"
+	"github.com/juju/gnuflag"
+	"gopkg.in/juju/names.v2"
+
+	"github.com/juju/juju/cmd/jujud/agent"
+	cmdutil "github.com/juju/juju/cmd/jujud/util"
+)
+
+type IntrospectCommand struct {
+	cmd.CommandBase
+	dataDir string
+	agent   string
+	path    string
+	listen  string
+
+	// IntrospectionSocketName returns the socket name
+	// for a given tag. If IntrospectionSocketName is nil,
+	// agent.DefaultIntrospectionSocketName is used.
+	IntrospectionSocketName func(names.Tag) string
+}
+
+const introspectCommandDoc = `
+Introspect Juju agents running on this machine.
+
+The juju-introspect can be used to expose the
+agent's introspection socket via HTTP, using
+the --listen flag. e.g.
+
+    juju-introspect --listen=:6060
+
+Otherwise, a single positional argument is required,
+which is the path to query. e.g.
+
+    juju-introspect /debug/pprof/heap?debug=1
+
+By default, juju-introspect operates on the
+machine agent. If you wish to introspect a
+unit agent on the machine, you can specify the
+agent using --agent. e.g.
+
+    juju-introspect --agent=unit-mysql-0 metrics
+`
+
+// Info returns usage information for the command.
+func (c *IntrospectCommand) Info() *cmd.Info {
+	return &cmd.Info{
+		Name:    "juju-introspect",
+		Args:    "(--listen=...|<path>)",
+		Purpose: "introspect Juju agents running on this machine",
+		Doc:     introspectCommandDoc,
+	}
+}
+
+func (c *IntrospectCommand) SetFlags(f *gnuflag.FlagSet) {
+	c.CommandBase.SetFlags(f)
+	f.StringVar(&c.dataDir, "data-dir", cmdutil.DataDir, "Juju base data directory")
+	f.StringVar(&c.agent, "agent", "", "agent to introspect (defaults to machine agent)")
+	f.StringVar(&c.listen, "listen", "", "address on which to expose the introspection socket")
+}
+
+func (c *IntrospectCommand) Init(args []string) error {
+	if len(args) >= 1 {
+		c.path, args = args[0], args[1:]
+	}
+	if c.path == "" && c.listen == "" {
+		return errors.New("either a query path or a --listen address must be specified")
+	}
+	if c.path != "" && c.listen != "" {
+		return errors.New("a query path may not be specified with --listen")
+	}
+	return c.CommandBase.Init(args)
+}
+
+func (c *IntrospectCommand) Run(ctx *cmd.Context) error {
+	targetURL, err := url.Parse("http://unix.socket/" + c.path)
+	if err != nil {
+		return err
+	}
+
+	tag, err := c.getAgentTag()
+	if err != nil {
+		return err
+	}
+
+	getSocketName := c.IntrospectionSocketName
+	if getSocketName == nil {
+		getSocketName = agent.DefaultIntrospectionSocketName
+	}
+	socketName := "@" + getSocketName(tag)
+	if c.listen != "" {
+		listener, err := net.Listen("tcp", c.listen)
+		if err != nil {
+			return err
+		}
+		defer listener.Close()
+		ctx.Infof("Exposing %s introspection socket on %s", socketName, listener.Addr())
+		proxy := httputil.NewSingleHostReverseProxy(targetURL)
+		proxy.Transport = unixSocketHTTPTransport(socketName)
+		return http.Serve(listener, proxy)
+	}
+
+	ctx.Infof("Querying %s introspection socket: %s", socketName, c.path)
+	client := unixSocketHTTPClient(socketName)
+	resp, err := client.Get(targetURL.String())
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		io.Copy(ctx.Stderr, resp.Body)
+		return errors.Errorf(
+			"response returned %d (%s)",
+			resp.StatusCode,
+			http.StatusText(resp.StatusCode),
+		)
+	}
+	_, err = io.Copy(ctx.Stdout, resp.Body)
+	return err
+}
+
+func (c *IntrospectCommand) getAgentTag() (names.Tag, error) {
+	if c.agent != "" {
+		return names.ParseTag(c.agent)
+	}
+	agentsDir := filepath.Join(c.dataDir, "agents")
+	dir, err := os.Open(agentsDir)
+	if err != nil {
+		return nil, errors.Annotate(err, "opening agents dir")
+	}
+	defer dir.Close()
+
+	entries, err := dir.Readdir(-1)
+	if err != nil {
+		return nil, errors.Annotate(err, "reading agents dir")
+	}
+	for _, info := range entries {
+		name := info.Name()
+		tag, err := names.ParseTag(name)
+		if err != nil {
+			continue
+		}
+		if tag.Kind() == names.MachineTagKind {
+			return tag, nil
+		}
+	}
+	return nil, errors.New("could not determine machine tag")
+}
+
+func unixSocketHTTPClient(socketPath string) *http.Client {
+	return &http.Client{
+		Transport: unixSocketHTTPTransport(socketPath),
+	}
+}
+
+func unixSocketHTTPTransport(socketPath string) *http.Transport {
+	return &http.Transport{
+		Dial: func(proto, addr string) (net.Conn, error) {
+			return net.Dial("unix", socketPath)
+		},
+	}
+}

--- a/cmd/jujud/introspect/introspect_test.go
+++ b/cmd/jujud/introspect/introspect_test.go
@@ -1,0 +1,197 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package introspect_test
+
+import (
+	"bufio"
+	"context"
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"net"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	stdtesting "testing"
+
+	"github.com/juju/cmd"
+	"github.com/juju/cmd/cmdtesting"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/names.v2"
+
+	"github.com/juju/juju/cmd/jujud/introspect"
+	cmdutil "github.com/juju/juju/cmd/jujud/util"
+	"github.com/juju/juju/testing"
+)
+
+type IntrospectCommandSuite struct {
+	testing.BaseSuite
+}
+
+func (s *IntrospectCommandSuite) SetUpTest(c *gc.C) {
+	if runtime.GOOS == "windows" {
+		c.Skip("introspection socket does not run on windows")
+	}
+	s.BaseSuite.SetUpTest(c)
+	s.PatchValue(&cmdutil.DataDir, c.MkDir())
+}
+
+var _ = gc.Suite(&IntrospectCommandSuite{})
+
+func (s *IntrospectCommandSuite) TestInitErrors(c *gc.C) {
+	s.assertInitError(c, "either a query path or a --listen address must be specified")
+	s.assertInitError(c, "a query path may not be specified with --listen", "query-path", "--listen=foo")
+	s.assertInitError(c, `unrecognized args: \["path"\]`, "query", "path")
+}
+
+func (*IntrospectCommandSuite) assertInitError(c *gc.C, expect string, args ...string) {
+	err := cmdtesting.InitCommand(&introspect.IntrospectCommand{}, args)
+	c.Assert(err, gc.ErrorMatches, expect)
+}
+
+func (*IntrospectCommandSuite) run(c *gc.C, args ...string) (*cmd.Context, error) {
+	return cmdtesting.RunCommand(c, &introspect.IntrospectCommand{
+		IntrospectionSocketName: func(tag names.Tag) string {
+			return filepath.Join(cmdutil.DataDir, "jujud-"+tag.String())
+		},
+	}, args...)
+}
+
+func (s *IntrospectCommandSuite) TestAutoDetectMachineAgent(c *gc.C) {
+	machineDir := filepath.Join(cmdutil.DataDir, "agents", "machine-1024")
+	err := os.MkdirAll(machineDir, 0755)
+	c.Assert(err, jc.ErrorIsNil)
+
+	_, err = s.run(c, "query")
+	c.Assert(err, gc.ErrorMatches, ".*jujud-machine-1024.*")
+}
+
+func (s *IntrospectCommandSuite) TestAutoDetectMachineAgentFails(c *gc.C) {
+	machineDir := filepath.Join(cmdutil.DataDir, "agents")
+	err := os.MkdirAll(machineDir, 0755)
+	c.Assert(err, jc.ErrorIsNil)
+
+	_, err = s.run(c, "query")
+	c.Assert(err, gc.ErrorMatches, "could not determine machine tag")
+}
+
+func (s *IntrospectCommandSuite) TestAgentSpecified(c *gc.C) {
+	_, err := s.run(c, "query", "--agent=unit-foo-0")
+	c.Assert(err, gc.ErrorMatches, ".*jujud-unit-foo-0.*")
+}
+
+func (s *IntrospectCommandSuite) TestQuery(c *gc.C) {
+	listener, err := net.Listen("unix", "@"+filepath.Join(cmdutil.DataDir, "jujud-machine-0"))
+	c.Assert(err, jc.ErrorIsNil)
+	defer listener.Close()
+
+	srv := newServer(listener)
+	go srv.Serve(listener)
+	defer srv.Shutdown(context.Background())
+
+	ctx, err := s.run(c, "query", "--agent=machine-0")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, "hello")
+}
+
+func (s *IntrospectCommandSuite) TestQueryFails(c *gc.C) {
+	listener, err := net.Listen("unix", "@"+filepath.Join(cmdutil.DataDir, "jujud-machine-0"))
+	c.Assert(err, jc.ErrorIsNil)
+	defer listener.Close()
+
+	srv := newServer(listener)
+	go srv.Serve(listener)
+	defer srv.Shutdown(context.Background())
+
+	ctx, err := s.run(c, "missing", "--agent=machine-0")
+	c.Assert(err, gc.ErrorMatches, `response returned 404 \(Not Found\)`)
+	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, fmt.Sprintf(`
+Querying @%s introspection socket: missing
+404 page not found
+`[1:], filepath.Join(cmdutil.DataDir, "jujud-machine-0")))
+	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, "")
+
+	ctx, err = s.run(c, "badness", "--agent=machine-0")
+	c.Assert(err, gc.ErrorMatches, `response returned 500 \(Internal Server Error\)`)
+	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, fmt.Sprintf(`
+Querying @%s introspection socket: badness
+argh
+`[1:], filepath.Join(cmdutil.DataDir, "jujud-machine-0")))
+	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, "")
+}
+
+func (s *IntrospectCommandSuite) TestListen(c *gc.C) {
+	socketName := filepath.Join(cmdutil.DataDir, "jujud-machine-0")
+	listener, err := net.Listen("unix", "@"+socketName)
+	c.Assert(err, jc.ErrorIsNil)
+	defer listener.Close()
+
+	srv := newServer(listener)
+	go srv.Serve(listener)
+	defer srv.Shutdown(context.Background())
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	cmd := exec.CommandContext(ctx, os.Args[0], "-run-listen="+socketName)
+	stderr, err := cmd.StderrPipe()
+	c.Assert(err, jc.ErrorIsNil)
+	defer stderr.Close()
+	err = cmd.Start()
+	c.Assert(err, jc.ErrorIsNil)
+
+	scanner := bufio.NewScanner(stderr)
+	c.Assert(scanner.Scan(), jc.IsTrue)
+	line := scanner.Text()
+	c.Assert(line, gc.Matches, "Exposing @.* introspection socket on 127.0.0.1:.*")
+
+	fields := strings.Fields(line)
+	addr := fields[len(fields)-1]
+	resp, err := http.Get(fmt.Sprintf("http://%s/query", addr))
+	c.Assert(err, jc.ErrorIsNil)
+	defer resp.Body.Close()
+	c.Assert(resp.StatusCode, gc.Equals, http.StatusOK)
+	body, err := ioutil.ReadAll(resp.Body)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(string(body), gc.Equals, "hello")
+}
+
+func newServer(l net.Listener) *http.Server {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/query", func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("hello"))
+	})
+	mux.HandleFunc("/badness", func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "argh", http.StatusInternalServerError)
+	})
+	srv := &http.Server{}
+	srv.Handler = mux
+	return srv
+}
+
+var flagListen = flag.String("run-listen", "", "Name of the Unix socket to connect the introspect command to using --listen=:0")
+
+func TestRunListen(t *stdtesting.T) {
+	if *flagListen != "" {
+		introspectCommand := &introspect.IntrospectCommand{
+			IntrospectionSocketName: func(names.Tag) string {
+				return *flagListen
+			},
+		}
+		args := append(flag.Args(), "--listen=127.0.0.1:0", "--agent=machine-0")
+		if err := cmdtesting.InitCommand(introspectCommand, args); err != nil {
+			t.Fatal(err)
+		}
+		ctx, err := cmd.DefaultContext()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := introspectCommand.Run(ctx); err != nil {
+			t.Fatal(err)
+		}
+	}
+}

--- a/cmd/jujud/introspect/package_test.go
+++ b/cmd/jujud/introspect/package_test.go
@@ -1,0 +1,18 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package introspect_test
+
+import (
+	"runtime"
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func TestPackage(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("introspection socket only runs on Linux")
+	}
+	gc.TestingT(t)
+}

--- a/cmd/jujud/main.go
+++ b/cmd/jujud/main.go
@@ -23,6 +23,7 @@ import (
 	jujucmd "github.com/juju/juju/cmd"
 	agentcmd "github.com/juju/juju/cmd/jujud/agent"
 	"github.com/juju/juju/cmd/jujud/dumplogs"
+	"github.com/juju/juju/cmd/jujud/introspect"
 	components "github.com/juju/juju/component/all"
 	"github.com/juju/juju/juju/names"
 	"github.com/juju/juju/juju/sockets"
@@ -226,6 +227,8 @@ func Main(args []string) int {
 		code = cmd.Main(run, ctx, args[1:])
 	case names.JujuDumpLogs:
 		code = cmd.Main(dumplogs.NewCommand(), ctx, args[1:])
+	case names.JujuIntrospect:
+		code = cmd.Main(&introspect.IntrospectCommand{}, ctx, args[1:])
 	default:
 		code, err = jujuCMain(commandName, ctx, args)
 	}

--- a/juju/names/names.go
+++ b/juju/names/names.go
@@ -6,9 +6,10 @@
 package names
 
 const (
-	Juju         = "juju"
-	Jujud        = "jujud"
-	Jujuc        = "jujuc"
-	JujuRun      = "juju-run"
-	JujuDumpLogs = "juju-dumplogs"
+	Juju           = "juju"
+	Jujud          = "jujud"
+	Jujuc          = "jujuc"
+	JujuRun        = "juju-run"
+	JujuDumpLogs   = "juju-dumplogs"
+	JujuIntrospect = "juju-introspect"
 )

--- a/juju/names/names_windows.go
+++ b/juju/names/names_windows.go
@@ -5,9 +5,10 @@
 package names
 
 const (
-	Juju         = "juju.exe"
-	Jujud        = "jujud.exe"
-	Jujuc        = "jujuc.exe"
-	JujuRun      = "juju-run.exe"
-	JujuDumpLogs = "juju-dumplogs.exe"
+	Juju           = "juju.exe"
+	Jujud          = "jujud.exe"
+	Jujuc          = "jujuc.exe"
+	JujuRun        = "juju-run.exe"
+	JujuDumpLogs   = "juju-dumplogs.exe"
+	JujuIntrospect = "juju-introspect.exe"
 )

--- a/juju/paths/paths.go
+++ b/juju/paths/paths.go
@@ -22,6 +22,7 @@ const (
 	metricsSpoolDir
 	uniterStateDir
 	jujuDumpLogs
+	jujuIntrospect
 )
 
 var nixVals = map[osVarType]string{
@@ -32,6 +33,7 @@ var nixVals = map[osVarType]string{
 	confDir:         "/etc/juju",
 	jujuRun:         "/usr/bin/juju-run",
 	jujuDumpLogs:    "/usr/bin/juju-dumplogs",
+	jujuIntrospect:  "/usr/bin/juju-introspect",
 	certDir:         "/etc/juju/certs.d",
 	metricsSpoolDir: "/var/lib/juju/metricspool",
 	uniterStateDir:  "/var/lib/juju/uniter/state",
@@ -45,6 +47,7 @@ var winVals = map[osVarType]string{
 	confDir:         "C:/Juju/etc",
 	jujuRun:         "C:/Juju/bin/juju-run.exe",
 	jujuDumpLogs:    "C:/Juju/bin/juju-dumplogs.exe",
+	jujuIntrospect:  "C:/Juju/bin/juju-introspect.exe",
 	certDir:         "C:/Juju/certs",
 	metricsSpoolDir: "C:/Juju/lib/juju/metricspool",
 	uniterStateDir:  "C:/Juju/lib/juju/uniter/state",
@@ -120,6 +123,12 @@ func JujuRun(series string) (string, error) {
 // for a particular series.
 func JujuDumpLogs(series string) (string, error) {
 	return osVal(series, jujuDumpLogs)
+}
+
+// JujuIntrospect returns the absolute path to the juju-introspect
+// binary for a particular series.
+func JujuIntrospect(series string) (string, error) {
+	return osVal(series, jujuIntrospect)
 }
 
 func MustSucceed(s string, e error) string {

--- a/worker/introspection/script.go
+++ b/worker/introspection/script.go
@@ -43,7 +43,7 @@ jujuAgentCall () {
   for i in "$@"; do
     path="$path/$i"
   done
-  echo -e "GET $path HTTP/1.0\r\n" | socat abstract-connect:jujud-$agent STDIO
+  juju-introspect --agent=$agent $path
 }
 
 jujuMachineAgentName () {
@@ -69,6 +69,16 @@ juju-goroutines () {
   jujuMachineOrUnit debug/pprof/goroutine?debug=1 $@
 }
 
+juju-cpu-profile () {
+  N=30
+  if test -n "$1"; then
+    N=$1
+    shift
+  fi
+  echo "Sampling CPU for $N seconds." >&2
+  jujuMachineOrUnit "debug/pprof/profile?debug=1&seconds=$N" $@
+}
+
 juju-heap-profile () {
   jujuMachineOrUnit debug/pprof/heap?debug=1 $@
 }
@@ -89,6 +99,7 @@ export -f jujuAgentCall
 export -f jujuMachineAgentName
 export -f jujuMachineOrUnit
 export -f juju-goroutines
+export -f juju-cpu-profile
 export -f juju-heap-profile
 export -f juju-engine-report
 export -f juju-statepool-report


### PR DESCRIPTION
## Description of change

This branch brings several improvements to the
agent introspection shell functions:

- we no longer use socat to communicate with the
  introspection socket, which was causing problems
  with the CPU profile endpoint. Instead, we add
  a new "juju-introspect" command/symlink to jujud,
  which serves as a frontend to the introspection
  socket. The helpers for getting specific profiles
  are left as bash functions.
- the new juju-introspect command has a --listen
  flag which, if specified, causes the command to
  expose the socket over HTTP. This enables the
  user to use "go tool pprof" with the HTTP endpoint,
  for example.
- A new function, juju-cpu-profile, is added, which
  will capture a CPU profile. The first (optional)
  argument is interpreted as the number of seconds
  to sample for.

Since we are no longer writing out the raw HTTP output,
the output of the various juju-foo-profile functions
no longer include the HTTP response header, so the
output can be fed directly into "go tool pprof".

By moving the main frontend out of the bash script and
into Go code, we get a step closer to having
introspection on Windows. We still need an alternative
to the abstract domain sockets solution that we have
today (probably named pipes?)

## QA steps

1. juju bootstrap
2. juju deploy -m controller ubuntu --to 0
3. juju ssh -m controller 0
4. juju-goroutines
5. juju-goroutines unit-ubuntu-0
6. juju-heap-profile
7. juju-cpu-profile # samples for 30 seconds
8. juju-cpu-profile 5 # samples for 5 seconds
9. juju-introspect --listen=:6060
(then on another machine, go tool pprof path/to/jujud http:<address>:6060)
10. juju-introspect metrics # scrapes prometheus metrics

## Documentation changes

We should update any debugging docs we have with mention of the new "juju-cpu-profile" helper, and possibly the "juju-introspect --listen=..." command.

## Bug reference

None.