### PR TITLE
log the right error (bug #1696484)

### DIFF
--- a/state/unit.go
+++ b/state/unit.go
@@ -336,7 +336,7 @@ func (u *Unit) Destroy() (err error) {
 	}
 	if err = unit.st.run(buildTxn); err == nil {
 		if historyErr := unit.eraseHistory(); historyErr != nil {
-			logger.Errorf("cannot delete history for unit %q: %v", unit.globalKey(), err)
+			logger.Errorf("cannot delete history for unit %q: %v", unit.globalKey(), historyErr)
 		}
 		if err = unit.Refresh(); errors.IsNotFound(err) {
 			return nil


### PR DESCRIPTION
## Description of change

While debugging log files, I noted that we were always logging a 'nil' error. Turns out we were logging the wrong error.

## QA steps

I don't yet know how to reproduce the bug that causes us to get the error, but its fairly obviously correct. (err will always be nil)

## Documentation changes

No

## Bug reference

[lp:1696484](https://bugs.launchpad.net/juju/+bug/1696484)