### PR TITLE
state: Really delete status history in Unit.Destroy

### DIFF
--- a/state/status.go
+++ b/state/status.go
@@ -163,6 +163,10 @@ func removeStatusOp(st *State, globalKey string) txn.Op {
 	}
 }
 
+// globalKeyField must have the same value as the tag for
+// historicalStatusDoc.GlobalKey.
+const globalKeyField = "globalkey"
+
 type historicalStatusDoc struct {
 	ModelUUID  string                 `bson:"model-uuid"`
 	GlobalKey  string                 `bson:"globalkey"`
@@ -189,6 +193,17 @@ func probablyUpdateStatusHistory(st *State, globalKey string, doc statusDoc) {
 	if err := historyW.Insert(historyDoc); err != nil {
 		logger.Errorf("failed to write status history: %v", err)
 	}
+}
+
+func eraseStatusHistory(st *State, globalKey string) error {
+	history, closer := st.db().GetCollection(statusesHistoryC)
+	defer closer()
+	historyW := history.Writeable()
+
+	if _, err := historyW.RemoveAll(bson.D{{globalKeyField, globalKey}}); err != nil {
+		return err
+	}
+	return nil
 }
 
 // statusHistoryArgs hold the arguments to call statusHistory.

--- a/state/unit.go
+++ b/state/unit.go
@@ -346,15 +346,14 @@ func (u *Unit) Destroy() (err error) {
 }
 
 func (u *Unit) eraseHistory() error {
-	history, closer := u.st.db().GetCollection(statusesHistoryC)
-	defer closer()
-	historyW := history.Writeable()
-
-	if _, err := historyW.RemoveAll(bson.D{{"statusid", u.globalKey()}}); err != nil {
-		return err
+	if err := eraseStatusHistory(u.st, u.globalKey()); err != nil {
+		return errors.Annotate(err, "workload")
 	}
-	if _, err := historyW.RemoveAll(bson.D{{"statusid", u.globalAgentKey()}}); err != nil {
-		return err
+	if err := eraseStatusHistory(u.st, u.globalAgentKey()); err != nil {
+		return errors.Annotate(err, "agent")
+	}
+	if err := eraseStatusHistory(u.st, u.globalWorkloadVersionKey()); err != nil {
+		return errors.Annotate(err, "version")
 	}
 	return nil
 }


### PR DESCRIPTION
## Description of change

The deletion code expected the key to be in the `statusid` field, but
the status history docs were changed to have the global key stored as
`globalkey`, so the `RemoveAll` calls were never deleting anything and
always doing a full scan.

Add a test that the status history is gone and correct the deletion. Also move the eraseHistory function into status. Keeping everything that needs to know about the fields of the underlying collection in one place reduces the likelihood of them getting out of sync (although obviously tests are the final check).

## QA steps
* Bootstrap a controller
* Deploy an application with multiple units and wait for the units to be idle
* Check the status history for one unit contains entries
* Remove that unit
* Check that the status history records for that unit are gone (by looking in Mongo).

## Bug reference

Fixes https://bugs.launchpad.net/juju/+bug/1696491
