### PR TITLE
Fix deleting status history in Unit.Destroy

### DIFF
--- a/state/unit.go
+++ b/state/unit.go
@@ -346,15 +346,14 @@ func (u *Unit) Destroy() (err error) {
 }
 
 func (u *Unit) eraseHistory() error {
-	history, closer := u.st.getCollection(statusesHistoryC)
-	defer closer()
-	historyW := history.Writeable()
-
-	if _, err := historyW.RemoveAll(bson.D{{"statusid", u.globalKey()}}); err != nil {
-		return err
+	if err := eraseStatusHistory(u.st, u.globalKey()); err != nil {
+		return errors.Annotate(err, "workload")
 	}
-	if _, err := historyW.RemoveAll(bson.D{{"statusid", u.globalAgentKey()}}); err != nil {
-		return err
+	if err := eraseStatusHistory(u.st, u.globalAgentKey()); err != nil {
+		return errors.Annotate(err, "agent")
+	}
+	if err := eraseStatusHistory(u.st, u.globalWorkloadVersionKey()); err != nil {
+		return errors.Annotate(err, "version")
 	}
 	return nil
 }


### PR DESCRIPTION
## Description of change

The deletion code expected the key to be in the `statusid` field, but
the status history docs were changed to have the global key stored as
`globalkey`, so the `RemoveAll` calls were never deleting anything and
always doing a full scan.

Add a test that the status history is gone and correct the deletion.
Also move eraseStatusHistory to status - keeping everything that needs
to know about the fields of the underlying collection in one place
reduces the likelihood of them getting out of sync.
(Backport from https://github.com/juju/juju/pull/7468)

## QA steps

* Bootstrap a controller
* Deploy an application with multiple units and wait for the units to be idle
* Check the status history for one unit contains entries
* Remove that unit
* Check that the status history records for that unit are gone (by looking in Mongo).

## Bug reference

Fixes https://bugs.launchpad.net/juju/+bug/1696491
