### PR TITLE
Add new apiserver listener which throttles incoming connections

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -167,6 +167,13 @@ const (
 	AgentServiceName  = "AGENT_SERVICE_NAME"
 	MongoOplogSize    = "MONGO_OPLOG_SIZE"
 	NUMACtlPreference = "NUMA_CTL_PREFERENCE"
+
+	AgentLoginRateLimit  = "AGENT_LOGIN_RATE_LIMIT"
+	AgentLoginMinPause   = "AGENT_LOGIN_MIN_PAUSE"
+	AgentLoginMaxPause   = "AGENT_LOGIN_MAX_PAUSE"
+	AgentLoginRetryPause = "AGENT_LOGIN_RETRY_PAUSE"
+	AgentConnMinPause    = "AGENT_CONN_MIN_PAUSE"
+	AgentConnMaxPause    = "AGENT_CONN_MAX_PAUSE"
 )
 
 // The Config interface is the sole way that the agent gets access to the

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -172,8 +172,12 @@ const (
 	AgentLoginMinPause   = "AGENT_LOGIN_MIN_PAUSE"
 	AgentLoginMaxPause   = "AGENT_LOGIN_MAX_PAUSE"
 	AgentLoginRetryPause = "AGENT_LOGIN_RETRY_PAUSE"
-	AgentConnMinPause    = "AGENT_CONN_MIN_PAUSE"
-	AgentConnMaxPause    = "AGENT_CONN_MAX_PAUSE"
+
+	AgentConnMinPause       = "AGENT_CONN_MIN_PAUSE"
+	AgentConnMaxPause       = "AGENT_CONN_MAX_PAUSE"
+	AgentConnLowerThreshold = "AGENT_CONN_LOWER_THRESHOLD"
+	AgentConnUpperThreshold = "AGENT_CONN_UPPER_THRESHOLD"
+	AgentConnLookbackWindow = "AGENT_CONN_LOOKBACK_WINDOW"
 )
 
 // The Config interface is the sole way that the agent gets access to the

--- a/api/apiclient_test.go
+++ b/api/apiclient_test.go
@@ -536,14 +536,7 @@ func (s *apiclientSuite) TestPublicDNSName(c *gc.C) {
 		AutocertDNSName: "somewhere.example.com",
 		NewObserver:     func() observer.Observer { return &fakeobserver.Instance{} },
 		AutocertURL:     "https://0.1.2.3/no-autocert-here",
-		RateLimitConfig: apiserver.RateLimitConfig{
-			LoginRateLimit:  apiserver.DefaultLoginRateLimit,
-			LoginMinPause:   apiserver.DefaultLoginMinPause,
-			LoginMaxPause:   apiserver.DefaultLoginMaxPause,
-			LoginRetryPause: apiserver.DefaultLoginRetryPause,
-			ConnMinPause:    apiserver.DefaultConnMinPause,
-			ConnMaxPause:    apiserver.DefaultConnMaxPause,
-		},
+		RateLimitConfig: apiserver.DefaultRateLimitConfig(),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	defer worker.Stop(srv)

--- a/api/apiclient_test.go
+++ b/api/apiclient_test.go
@@ -536,6 +536,14 @@ func (s *apiclientSuite) TestPublicDNSName(c *gc.C) {
 		AutocertDNSName: "somewhere.example.com",
 		NewObserver:     func() observer.Observer { return &fakeobserver.Instance{} },
 		AutocertURL:     "https://0.1.2.3/no-autocert-here",
+		RateLimitConfig: apiserver.RateLimitConfig{
+			LoginRateLimit:  apiserver.DefaultLoginRateLimit,
+			LoginMinPause:   apiserver.DefaultLoginMinPause,
+			LoginMaxPause:   apiserver.DefaultLoginMaxPause,
+			LoginRetryPause: apiserver.DefaultLoginRetryPause,
+			ConnMinPause:    apiserver.DefaultConnMinPause,
+			ConnMaxPause:    apiserver.DefaultConnMaxPause,
+		},
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	defer worker.Stop(srv)

--- a/api/controller/legacy_test.go
+++ b/api/controller/legacy_test.go
@@ -217,16 +217,17 @@ func (s *legacySuite) TestAPIServerCanShutdownWithOutstandingNext(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	srv, err := apiserver.NewServer(s.State, lis, apiserver.ServerConfig{
-		Clock:       clock.WallClock,
-		Cert:        testing.ServerCert,
-		Key:         testing.ServerKey,
-		Tag:         names.NewMachineTag("0"),
-		Hub:         pubsub.NewStructuredHub(nil),
-		DataDir:     c.MkDir(),
-		LogDir:      c.MkDir(),
-		NewObserver: func() observer.Observer { return &fakeobserver.Instance{} },
-		AutocertURL: "https://0.1.2.3/no-autocert-here",
-		StatePool:   state.NewStatePool(s.State),
+		Clock:           clock.WallClock,
+		Cert:            testing.ServerCert,
+		Key:             testing.ServerKey,
+		Tag:             names.NewMachineTag("0"),
+		Hub:             pubsub.NewStructuredHub(nil),
+		DataDir:         c.MkDir(),
+		LogDir:          c.MkDir(),
+		NewObserver:     func() observer.Observer { return &fakeobserver.Instance{} },
+		AutocertURL:     "https://0.1.2.3/no-autocert-here",
+		StatePool:       state.NewStatePool(s.State),
+		RateLimitConfig: apiserver.DefaultRateLimitConfig(),
 	})
 	c.Assert(err, gc.IsNil)
 

--- a/api/pubsub/pubsub_test.go
+++ b/api/pubsub/pubsub_test.go
@@ -227,14 +227,15 @@ func newServerWithHub(c *gc.C, st *state.State, hub *pubsub.StructuredHub) (*api
 	listener, err := net.Listen("tcp", ":0")
 	c.Assert(err, jc.ErrorIsNil)
 	srv, err := apiserver.NewServer(st, listener, apiserver.ServerConfig{
-		Clock:       clock.WallClock,
-		Cert:        coretesting.ServerCert,
-		Key:         coretesting.ServerKey,
-		Tag:         names.NewMachineTag("0"),
-		LogDir:      c.MkDir(),
-		Hub:         hub,
-		NewObserver: func() observer.Observer { return &fakeobserver.Instance{} },
-		StatePool:   state.NewStatePool(st),
+		Clock:           clock.WallClock,
+		Cert:            coretesting.ServerCert,
+		Key:             coretesting.ServerKey,
+		Tag:             names.NewMachineTag("0"),
+		LogDir:          c.MkDir(),
+		Hub:             hub,
+		NewObserver:     func() observer.Observer { return &fakeobserver.Instance{} },
+		StatePool:       state.NewStatePool(st),
+		RateLimitConfig: apiserver.DefaultRateLimitConfig(),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	port := listener.Addr().(*net.TCPAddr).Port

--- a/apiserver/admin.go
+++ b/apiserver/admin.go
@@ -90,6 +90,9 @@ func (a *admin) login(req params.LoginRequest, loginVersion int) (params.LoginRe
 			// Users are not rate limited, all other entities are.
 			if !a.srv.limiter.Acquire() {
 				logger.Debugf("rate limiting for agent %s", req.AuthTag)
+				select {
+				case <-time.After(loginRetyPause):
+				}
 				return fail, common.ErrTryAgain
 			}
 			defer a.srv.limiter.Release()

--- a/apiserver/admin.go
+++ b/apiserver/admin.go
@@ -91,7 +91,7 @@ func (a *admin) login(req params.LoginRequest, loginVersion int) (params.LoginRe
 			if !a.srv.limiter.Acquire() {
 				logger.Debugf("rate limiting for agent %s", req.AuthTag)
 				select {
-				case <-time.After(loginRetyPause):
+				case <-time.After(a.srv.loginRetryPause):
 				}
 				return fail, common.ErrTryAgain
 			}

--- a/apiserver/admin_test.go
+++ b/apiserver/admin_test.go
@@ -332,7 +332,7 @@ func (s *loginSuite) TestLoginRateLimited(c *gc.C) {
 	select {
 	case err := <-errResults:
 		c.Check(err, jc.Satisfies, params.IsCodeTryAgain)
-	case <-time.After(coretesting.LongWait):
+	case <-time.After(apiserver.LoginRetyPause + coretesting.LongWait):
 		c.Fatalf("timed out waiting for login to get rejected.")
 	}
 

--- a/apiserver/apiserver_test.go
+++ b/apiserver/apiserver_test.go
@@ -54,6 +54,14 @@ func (s *apiserverBaseSuite) sampleConfig(c *gc.C) apiserver.ServerConfig {
 		NewObserver: func() observer.Observer { return &fakeobserver.Instance{} },
 		AutocertURL: "https://0.1.2.3/no-autocert-here",
 		StatePool:   state.NewStatePool(s.State),
+		RateLimitConfig: apiserver.RateLimitConfig{
+			LoginRateLimit:  apiserver.DefaultLoginRateLimit,
+			LoginMinPause:   apiserver.DefaultLoginMinPause,
+			LoginMaxPause:   apiserver.DefaultLoginMaxPause,
+			LoginRetryPause: apiserver.DefaultLoginRetryPause,
+			ConnMinPause:    apiserver.DefaultConnMinPause,
+			ConnMaxPause:    apiserver.DefaultConnMaxPause,
+		},
 	}
 }
 

--- a/apiserver/apiserver_test.go
+++ b/apiserver/apiserver_test.go
@@ -45,23 +45,16 @@ func (s *apiserverBaseSuite) SetUpTest(c *gc.C) {
 func (s *apiserverBaseSuite) sampleConfig(c *gc.C) apiserver.ServerConfig {
 	machineTag := names.NewMachineTag("0")
 	return apiserver.ServerConfig{
-		Clock:       clock.WallClock,
-		Cert:        coretesting.ServerCert,
-		Key:         coretesting.ServerKey,
-		Tag:         machineTag,
-		LogDir:      c.MkDir(),
-		Hub:         centralhub.New(machineTag),
-		NewObserver: func() observer.Observer { return &fakeobserver.Instance{} },
-		AutocertURL: "https://0.1.2.3/no-autocert-here",
-		StatePool:   state.NewStatePool(s.State),
-		RateLimitConfig: apiserver.RateLimitConfig{
-			LoginRateLimit:  apiserver.DefaultLoginRateLimit,
-			LoginMinPause:   apiserver.DefaultLoginMinPause,
-			LoginMaxPause:   apiserver.DefaultLoginMaxPause,
-			LoginRetryPause: apiserver.DefaultLoginRetryPause,
-			ConnMinPause:    apiserver.DefaultConnMinPause,
-			ConnMaxPause:    apiserver.DefaultConnMaxPause,
-		},
+		Clock:           clock.WallClock,
+		Cert:            coretesting.ServerCert,
+		Key:             coretesting.ServerKey,
+		Tag:             machineTag,
+		LogDir:          c.MkDir(),
+		Hub:             centralhub.New(machineTag),
+		NewObserver:     func() observer.Observer { return &fakeobserver.Instance{} },
+		AutocertURL:     "https://0.1.2.3/no-autocert-here",
+		StatePool:       state.NewStatePool(s.State),
+		RateLimitConfig: apiserver.DefaultRateLimitConfig(),
 	}
 }
 

--- a/apiserver/export_test.go
+++ b/apiserver/export_test.go
@@ -58,7 +58,10 @@ func APIHandlerWithEntity(entity state.Entity) *apiHandler {
 	return &apiHandler{entity: entity}
 }
 
-const LoginRateLimit = loginRateLimit
+var (
+	LoginRateLimit = loginRateLimit
+	LoginRetyPause = loginRetyPause
+)
 
 // DelayLogins changes how the Login code works so that logins won't proceed
 // until they get a message on the returned channel.

--- a/apiserver/export_test.go
+++ b/apiserver/export_test.go
@@ -58,9 +58,9 @@ func APIHandlerWithEntity(entity state.Entity) *apiHandler {
 	return &apiHandler{entity: entity}
 }
 
-var (
-	LoginRateLimit = loginRateLimit
-	LoginRetyPause = loginRetyPause
+const (
+	LoginRateLimit = defaultLoginRateLimit
+	LoginRetyPause = defaultLoginRetryPause
 )
 
 // DelayLogins changes how the Login code works so that logins won't proceed

--- a/apiserver/listener.go
+++ b/apiserver/listener.go
@@ -1,0 +1,121 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package apiserver
+
+import (
+	"math/rand"
+	"net"
+	"sync"
+	"time"
+
+	"github.com/juju/utils/clock"
+)
+
+func newThrottlingListener(inner net.Listener, minPause, maxPause time.Duration, clk clock.Clock) net.Listener {
+	rand.Seed(time.Now().UTC().UnixNano())
+	if clk == nil {
+		clk = clock.WallClock
+	}
+	return &throttlingListener{
+		Listener:        inner,
+		maxPause:        maxPause,
+		minPause:        minPause,
+		clk:             clk,
+		connAcceptTimes: make([]*time.Time, 500),
+	}
+}
+
+type throttlingListener struct {
+	sync.Mutex
+	net.Listener
+	connAcceptTimes []*time.Time
+	nextSlot        int
+
+	minPause time.Duration
+	maxPause time.Duration
+	clk      clock.Clock
+}
+
+// connRateMetric returns an int value based on the rate of new connections.
+func (l *throttlingListener) connRateMetric() int {
+	l.Lock()
+	defer l.Unlock()
+
+	var (
+		earliestConnTime *time.Time
+		connCount        float64
+	)
+	// Figure out the most recent connection timestamp.
+	startIndex := l.nextSlot - 1
+	if startIndex < 0 {
+		startIndex = len(l.connAcceptTimes) - 1
+	}
+	latestConnTime := l.connAcceptTimes[startIndex]
+	if latestConnTime == nil {
+		return 0
+	}
+	// Loop backwards to get the earlier known connection timestamp.
+	for index := startIndex; index != l.nextSlot; {
+		if connTime := l.connAcceptTimes[index]; connTime == nil {
+			break
+		} else {
+			earliestConnTime = connTime
+		}
+		connCount++
+		index--
+		if index < 0 {
+			index = len(l.connAcceptTimes) - 1
+		}
+	}
+	if connCount < 2 {
+		return 0
+	}
+	// We use as a metric how many connections per 10ms
+	connRate := connCount * float64(10*time.Millisecond) / (1.0 + float64(latestConnTime.Sub(*earliestConnTime)))
+	logger.Tracef("server listener has received %d connections per 10ms", connRate)
+	return int(connRate)
+}
+
+// Accept waits for and returns the next connection to the listener.
+func (l *throttlingListener) Accept() (net.Conn, error) {
+	l.pause()
+	conn, err := l.Listener.Accept()
+	if err == nil {
+		l.Lock()
+		defer l.Unlock()
+		now := l.clk.Now()
+		l.connAcceptTimes[l.nextSlot] = &now
+		l.nextSlot++
+		if l.nextSlot > len(l.connAcceptTimes)-1 {
+			l.nextSlot = 0
+		}
+	}
+	return conn, err
+}
+
+// pauseTime returns a random time based on rate of connections.
+func (l *throttlingListener) pauseTime() time.Duration {
+	// The pause time is minPause plus 5ms for each unit increase
+	// in connection rate, up to a maximum of maxPause,
+	wantedMaxPause := l.minPause + time.Duration(l.connRateMetric()*5)*time.Millisecond
+	if wantedMaxPause > l.maxPause {
+		return l.maxPause
+	}
+	if wantedMaxPause == l.minPause {
+		return l.minPause
+	}
+	pauseTime := time.Duration(rand.Intn(int((wantedMaxPause-l.minPause)/time.Millisecond))) * time.Millisecond
+	pauseTime += l.minPause
+	return pauseTime
+}
+
+func (l *throttlingListener) pause() {
+	if l.minPause <= 0 || l.maxPause <= 0 {
+		return
+	}
+	pauseTime := l.pauseTime()
+	select {
+	case <-l.clk.After(pauseTime):
+	}
+}

--- a/apiserver/listener_test.go
+++ b/apiserver/listener_test.go
@@ -1,0 +1,155 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package apiserver
+
+import (
+	"net"
+	"time"
+
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+)
+
+type listenerSuite struct {
+	testing.IsolationSuite
+
+	listener *mockListener
+
+	minPause time.Duration
+	maxPause time.Duration
+	clock    *testing.Clock
+}
+
+var _ = gc.Suite(&listenerSuite{})
+
+func (s *listenerSuite) SetUpTest(c *gc.C) {
+	s.minPause = 10 * time.Millisecond
+	s.maxPause = 5 * time.Second
+	s.clock = testing.NewClock(time.Now())
+	s.listener = &mockListener{}
+}
+
+func (s *listenerSuite) testListener() *throttlingListener {
+	return newThrottlingListener(s.listener, s.minPause, s.maxPause, s.clock).(*throttlingListener)
+}
+
+func (s *listenerSuite) TestConnRateNoConnections(c *gc.C) {
+	l := s.testListener()
+	c.Assert(l.connRateMetric(), gc.Equals, 0)
+}
+
+func (s *listenerSuite) TestConnRateOneConnection(c *gc.C) {
+	l := s.testListener()
+	s.listener.Accept()
+	c.Assert(l.connRateMetric(), gc.Equals, 0)
+}
+
+func (s *listenerSuite) TestConnRateBufferUnder(c *gc.C) {
+	l := s.testListener()
+	l.maxPause = 0
+	for i := 0; i < 100; i++ {
+		l.Accept()
+		s.clock.Advance(time.Millisecond)
+	}
+	c.Assert(s.listener.count, gc.Equals, 100)
+	c.Assert(l.connRateMetric(), gc.Equals, 10)
+}
+
+func (s *listenerSuite) TestConnRateBufferOver(c *gc.C) {
+	l := s.testListener()
+	l.maxPause = 0
+	for i := 0; i < 550; i++ {
+		l.Accept()
+		s.clock.Advance(2 * time.Millisecond)
+	}
+	c.Assert(s.listener.count, gc.Equals, 550)
+	c.Assert(l.connRateMetric(), gc.Equals, 5)
+}
+
+func (s *listenerSuite) TestConnRateNonContiguous(c *gc.C) {
+	l := s.testListener()
+	l.maxPause = 0
+	for i := 0; i < 550; i++ {
+		l.Accept()
+		if i == 200 {
+			s.clock.Advance(100 * time.Millisecond)
+		}
+		s.clock.Advance(2 * time.Millisecond)
+	}
+	c.Assert(s.listener.count, gc.Equals, 550)
+	c.Assert(l.connRateMetric(), gc.Equals, 4)
+}
+
+func (s *listenerSuite) setupConnRate(l *throttlingListener, rate int) {
+	max := l.maxPause
+	l.maxPause = 0
+	for i := 0; i < rate; i++ {
+		l.Accept()
+		s.clock.Advance(10 * time.Millisecond / time.Duration(rate-1))
+	}
+	l.maxPause = max
+}
+
+func (s *listenerSuite) TestPauseTimeMin(c *gc.C) {
+	l := s.testListener()
+	for i := 0; i < 100; i++ {
+		c.Assert(l.pauseTime(), gc.Equals, s.minPause)
+	}
+}
+
+func (s *listenerSuite) TestPauseTimeMax(c *gc.C) {
+	l := s.testListener()
+	s.setupConnRate(l, 1+int(l.maxPause-l.minPause)/int(5*time.Millisecond))
+	for i := 0; i < 100; i++ {
+		c.Assert(l.pauseTime(), gc.Equals, s.maxPause)
+	}
+}
+
+func (s *listenerSuite) TestPauseTimeInBetween(c *gc.C) {
+	l := s.testListener()
+	s.setupConnRate(l, 1+int(l.maxPause-l.minPause)/int(20*time.Millisecond))
+	for i := 0; i < 100; i++ {
+		pauseTime := l.pauseTime()
+		c.Assert(pauseTime, jc.LessThan, s.minPause+(s.maxPause-s.minPause+1)/2)
+		c.Assert(pauseTime, jc.GreaterThan, l.minPause)
+	}
+}
+
+func (s *listenerSuite) TestPause(c *gc.C) {
+	l := s.testListener()
+	start := make(chan bool, 0)
+	done := make(chan bool, 1)
+	go func() {
+		<-start
+		l.Accept()
+		done <- true
+	}()
+
+	start <- true
+	s.clock.Advance((l.minPause/time.Millisecond - 1) * time.Millisecond)
+	select {
+	case <-done:
+		c.Fatal("pause returned too soon")
+	case <-time.After(50 * time.Millisecond):
+	}
+	c.Assert(s.listener.count, gc.Equals, 0)
+	s.clock.Advance(time.Millisecond)
+	select {
+	case <-done:
+	case <-time.After(10 * time.Millisecond):
+		c.Fatal("pause failed")
+	}
+	c.Assert(s.listener.count, gc.Equals, 1)
+}
+
+type mockListener struct {
+	net.Listener
+	count int
+}
+
+func (m *mockListener) Accept() (net.Conn, error) {
+	m.count++
+	return nil, nil
+}

--- a/apiserver/listener_test.go
+++ b/apiserver/listener_test.go
@@ -4,11 +4,11 @@
 package apiserver
 
 import (
+	"math"
 	"net"
 	"time"
 
 	"github.com/juju/testing"
-	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 )
 
@@ -17,9 +17,11 @@ type listenerSuite struct {
 
 	listener *mockListener
 
-	minPause time.Duration
-	maxPause time.Duration
-	clock    *testing.Clock
+	minPause       time.Duration
+	maxPause       time.Duration
+	lowerThreshold int
+	upperThreshold int
+	clock          *testing.Clock
 }
 
 var _ = gc.Suite(&listenerSuite{})
@@ -27,12 +29,24 @@ var _ = gc.Suite(&listenerSuite{})
 func (s *listenerSuite) SetUpTest(c *gc.C) {
 	s.minPause = 10 * time.Millisecond
 	s.maxPause = 5 * time.Second
+	s.lowerThreshold = 1000
+	s.upperThreshold = 10000
+
 	s.clock = testing.NewClock(time.Now())
 	s.listener = &mockListener{}
 }
 
 func (s *listenerSuite) testListener() *throttlingListener {
-	return newThrottlingListener(s.listener, s.minPause, s.maxPause, s.clock).(*throttlingListener)
+	cfg := DefaultRateLimitConfig()
+	cfg.ConnMinPause = s.minPause
+	cfg.ConnMaxPause = s.maxPause
+	cfg.ConnLowerThreshold = s.lowerThreshold
+	cfg.ConnUpperThreshold = s.upperThreshold
+	return newThrottlingListener(s.listener, cfg, s.clock).(*throttlingListener)
+}
+
+func (s *listenerSuite) roundRate(rate int) int {
+	return (rate / 100) * 100
 }
 
 func (s *listenerSuite) TestConnRateNoConnections(c *gc.C) {
@@ -54,67 +68,82 @@ func (s *listenerSuite) TestConnRateBufferUnder(c *gc.C) {
 		s.clock.Advance(time.Millisecond)
 	}
 	c.Assert(s.listener.count, gc.Equals, 100)
-	c.Assert(l.connRateMetric(), gc.Equals, 10)
+	c.Assert(s.roundRate(l.connRateMetric()), gc.Equals, 1000)
 }
 
 func (s *listenerSuite) TestConnRateBufferOver(c *gc.C) {
 	l := s.testListener()
 	l.maxPause = 0
-	for i := 0; i < 550; i++ {
+	for i := 0; i < 250; i++ {
 		l.Accept()
 		s.clock.Advance(2 * time.Millisecond)
 	}
-	c.Assert(s.listener.count, gc.Equals, 550)
-	c.Assert(l.connRateMetric(), gc.Equals, 5)
+	c.Assert(s.listener.count, gc.Equals, 250)
+	c.Assert(s.roundRate(l.connRateMetric()), gc.Equals, 500)
 }
 
 func (s *listenerSuite) TestConnRateNonContiguous(c *gc.C) {
 	l := s.testListener()
 	l.maxPause = 0
-	for i := 0; i < 550; i++ {
+	for i := 0; i < 90; i++ {
 		l.Accept()
-		if i == 200 {
-			s.clock.Advance(100 * time.Millisecond)
+		if i == 80 {
+			s.clock.Advance(50 * time.Millisecond)
 		}
-		s.clock.Advance(2 * time.Millisecond)
+		s.clock.Advance(time.Millisecond)
 	}
-	c.Assert(s.listener.count, gc.Equals, 550)
-	c.Assert(l.connRateMetric(), gc.Equals, 4)
+	c.Assert(s.listener.count, gc.Equals, 90)
+	c.Assert(s.roundRate(l.connRateMetric()), gc.Equals, 600)
+}
+
+func (s *listenerSuite) TestConnRateIgnoresOld(c *gc.C) {
+	l := s.testListener()
+	l.maxPause = 0
+	for i := 0; i < 140; i++ {
+		l.Accept()
+		if i < 100 {
+			s.clock.Advance(10 * time.Microsecond)
+		} else if i == 100 {
+			s.clock.Advance(time.Second)
+		} else {
+			s.clock.Advance(10 * time.Microsecond)
+		}
+	}
+	c.Assert(s.listener.count, gc.Equals, 140)
+	c.Assert(l.connRateMetric(), gc.Equals, 39)
 }
 
 func (s *listenerSuite) setupConnRate(l *throttlingListener, rate int) {
 	max := l.maxPause
 	l.maxPause = 0
-	for i := 0; i < rate; i++ {
+	for i := 0; i <= rate; i++ {
 		l.Accept()
-		s.clock.Advance(10 * time.Millisecond / time.Duration(rate-1))
+		s.clock.Advance(time.Second / time.Duration(rate))
 	}
 	l.maxPause = max
 }
 
 func (s *listenerSuite) TestPauseTimeMin(c *gc.C) {
 	l := s.testListener()
-	for i := 0; i < 100; i++ {
-		c.Assert(l.pauseTime(), gc.Equals, s.minPause)
-	}
+	c.Assert(l.pauseTime(), gc.Equals, s.minPause)
+	s.setupConnRate(l, s.lowerThreshold-100)
+	c.Assert(l.pauseTime(), gc.Equals, s.minPause)
 }
 
 func (s *listenerSuite) TestPauseTimeMax(c *gc.C) {
 	l := s.testListener()
-	s.setupConnRate(l, 1+int(l.maxPause-l.minPause)/int(5*time.Millisecond))
-	for i := 0; i < 100; i++ {
-		c.Assert(l.pauseTime(), gc.Equals, s.maxPause)
-	}
+	s.setupConnRate(l, s.upperThreshold+1)
+	c.Assert(l.pauseTime(), gc.Equals, s.maxPause)
 }
 
 func (s *listenerSuite) TestPauseTimeInBetween(c *gc.C) {
 	l := s.testListener()
-	s.setupConnRate(l, 1+int(l.maxPause-l.minPause)/int(20*time.Millisecond))
-	for i := 0; i < 100; i++ {
-		pauseTime := l.pauseTime()
-		c.Assert(pauseTime, jc.LessThan, s.minPause+(s.maxPause-s.minPause+1)/2)
-		c.Assert(pauseTime, jc.GreaterThan, l.minPause)
+	s.setupConnRate(l, (s.lowerThreshold+s.upperThreshold)/2)
+	pauseTime := l.pauseTime()
+	round := func(t time.Duration) float64 {
+		return 1.0 * math.Floor(10.0*float64(t)/float64(time.Second)) / 10.0
 	}
+	c.Assert(round(pauseTime), gc.Equals, round(s.minPause+(s.maxPause-s.minPause+1)/2))
 }
 
 func (s *listenerSuite) TestPause(c *gc.C) {
@@ -138,7 +167,7 @@ func (s *listenerSuite) TestPause(c *gc.C) {
 	s.clock.Advance(time.Millisecond)
 	select {
 	case <-done:
-	case <-time.After(10 * time.Millisecond):
+	case <-time.After(10 * time.Second):
 		c.Fatal("pause failed")
 	}
 	c.Assert(s.listener.count, gc.Equals, 1)

--- a/apiserver/server_test.go
+++ b/apiserver/server_test.go
@@ -615,23 +615,16 @@ func defaultServerConfig(c *gc.C, st *state.State) apiserver.ServerConfig {
 	fakeOrigin := names.NewMachineTag("0")
 	hub := centralhub.New(fakeOrigin)
 	return apiserver.ServerConfig{
-		Clock:       clock.WallClock,
-		Cert:        coretesting.ServerCert,
-		Key:         coretesting.ServerKey,
-		Tag:         names.NewMachineTag("0"),
-		LogDir:      c.MkDir(),
-		Hub:         hub,
-		NewObserver: func() observer.Observer { return &fakeobserver.Instance{} },
-		AutocertURL: "https://0.1.2.3/no-autocert-here",
-		StatePool:   state.NewStatePool(st),
-		RateLimitConfig: apiserver.RateLimitConfig{
-			LoginRateLimit:  apiserver.DefaultLoginRateLimit,
-			LoginMinPause:   apiserver.DefaultLoginMinPause,
-			LoginMaxPause:   apiserver.DefaultLoginMaxPause,
-			LoginRetryPause: apiserver.DefaultLoginRetryPause,
-			ConnMinPause:    apiserver.DefaultConnMinPause,
-			ConnMaxPause:    apiserver.DefaultConnMaxPause,
-		},
+		Clock:           clock.WallClock,
+		Cert:            coretesting.ServerCert,
+		Key:             coretesting.ServerKey,
+		Tag:             names.NewMachineTag("0"),
+		LogDir:          c.MkDir(),
+		Hub:             hub,
+		NewObserver:     func() observer.Observer { return &fakeobserver.Instance{} },
+		AutocertURL:     "https://0.1.2.3/no-autocert-here",
+		StatePool:       state.NewStatePool(st),
+		RateLimitConfig: apiserver.DefaultRateLimitConfig(),
 	}
 }
 

--- a/apiserver/server_test.go
+++ b/apiserver/server_test.go
@@ -624,6 +624,14 @@ func defaultServerConfig(c *gc.C, st *state.State) apiserver.ServerConfig {
 		NewObserver: func() observer.Observer { return &fakeobserver.Instance{} },
 		AutocertURL: "https://0.1.2.3/no-autocert-here",
 		StatePool:   state.NewStatePool(st),
+		RateLimitConfig: apiserver.RateLimitConfig{
+			LoginRateLimit:  apiserver.DefaultLoginRateLimit,
+			LoginMinPause:   apiserver.DefaultLoginMinPause,
+			LoginMaxPause:   apiserver.DefaultLoginMaxPause,
+			LoginRetryPause: apiserver.DefaultLoginRetryPause,
+			ConnMinPause:    apiserver.DefaultConnMinPause,
+			ConnMaxPause:    apiserver.DefaultConnMaxPause,
+		},
 	}
 }
 

--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -1259,14 +1259,7 @@ func (a *MachineAgent) newAPIserverWorker(
 }
 
 func getRateLimitConfig(cfg agent.Config) (apiserver.RateLimitConfig, error) {
-	result := apiserver.RateLimitConfig{
-		LoginRateLimit:  apiserver.DefaultLoginRateLimit,
-		LoginMinPause:   apiserver.DefaultLoginMinPause,
-		LoginMaxPause:   apiserver.DefaultLoginMaxPause,
-		LoginRetryPause: apiserver.DefaultLoginRetryPause,
-		ConnMinPause:    apiserver.DefaultConnMinPause,
-		ConnMaxPause:    apiserver.DefaultConnMaxPause,
-	}
+	result := apiserver.DefaultRateLimitConfig()
 	if v := cfg.Value(agent.AgentLoginRateLimit); v != "" {
 		val, err := strconv.Atoi(v)
 		if err != nil {
@@ -1320,6 +1313,33 @@ func getRateLimitConfig(cfg agent.Config) (apiserver.RateLimitConfig, error) {
 			)
 		}
 		result.ConnMaxPause = val
+	}
+	if v := cfg.Value(agent.AgentConnLookbackWindow); v != "" {
+		val, err := time.ParseDuration(v)
+		if err != nil {
+			return apiserver.RateLimitConfig{}, errors.Annotatef(
+				err, "parsing %s", agent.AgentConnLookbackWindow,
+			)
+		}
+		result.ConnLookbackWindow = val
+	}
+	if v := cfg.Value(agent.AgentConnLowerThreshold); v != "" {
+		val, err := strconv.Atoi(v)
+		if err != nil {
+			return apiserver.RateLimitConfig{}, errors.Annotatef(
+				err, "parsing %s", agent.AgentConnLowerThreshold,
+			)
+		}
+		result.ConnLowerThreshold = val
+	}
+	if v := cfg.Value(agent.AgentConnUpperThreshold); v != "" {
+		val, err := strconv.Atoi(v)
+		if err != nil {
+			return apiserver.RateLimitConfig{}, errors.Annotatef(
+				err, "parsing %s", agent.AgentConnUpperThreshold,
+			)
+		}
+		result.ConnUpperThreshold = val
 	}
 	return result, nil
 }

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -48,7 +48,7 @@ github.com/juju/terms-client	git	9b925afd677234e4146dde3cb1a11e187cbed64e	2016-0
 github.com/juju/testing	git	2fe0e88cf2321d801acedd2b4f0d7f63735fb732	2017-06-08T05:44:51Z
 github.com/juju/txn	git	941c396af5296a396a375bd88549552bd7a40dcd	2017-05-16T04:42:59Z
 github.com/juju/usso	git	68a59c96c178fbbad65926e7f93db50a2cd14f33	2016-04-01T10:44:24Z
-github.com/juju/utils	git	e126b30255fbcc0f65a84fcef3c919e9b714602e	2017-05-18T11:00:59Z
+github.com/juju/utils	git	61a75f1933a523d7f9d38bc5b1bf2010f1c157c3	2017-06-07T09:20:57Z
 github.com/juju/version	git	1f41e27e54f21acccf9b2dddae063a782a8a7ceb	2016-10-31T05:19:06Z
 github.com/juju/webbrowser	git	54b8c57083b4afb7dc75da7f13e2967b2606a507	2016-03-09T14:36:29Z
 github.com/juju/xml	git	eb759a627588d35166bc505fceb51b88500e291e	2015-04-13T13:11:21Z

--- a/provider/dummy/environs.go
+++ b/provider/dummy/environs.go
@@ -834,6 +834,14 @@ func (e *environ) Bootstrap(ctx environs.BootstrapContext, args environs.Bootstr
 						io.WriteString(w, "gazing")
 					}))
 				},
+				RateLimitConfig: apiserver.RateLimitConfig{
+					LoginRateLimit:  apiserver.DefaultLoginRateLimit,
+					LoginMinPause:   apiserver.DefaultLoginMinPause,
+					LoginMaxPause:   apiserver.DefaultLoginMaxPause,
+					LoginRetryPause: apiserver.DefaultLoginRetryPause,
+					ConnMinPause:    apiserver.DefaultConnMinPause,
+					ConnMaxPause:    apiserver.DefaultConnMaxPause,
+				},
 			})
 			if err != nil {
 				panic(err)

--- a/provider/dummy/environs.go
+++ b/provider/dummy/environs.go
@@ -834,14 +834,7 @@ func (e *environ) Bootstrap(ctx environs.BootstrapContext, args environs.Bootstr
 						io.WriteString(w, "gazing")
 					}))
 				},
-				RateLimitConfig: apiserver.RateLimitConfig{
-					LoginRateLimit:  apiserver.DefaultLoginRateLimit,
-					LoginMinPause:   apiserver.DefaultLoginMinPause,
-					LoginMaxPause:   apiserver.DefaultLoginMaxPause,
-					LoginRetryPause: apiserver.DefaultLoginRetryPause,
-					ConnMinPause:    apiserver.DefaultConnMinPause,
-					ConnMaxPause:    apiserver.DefaultConnMaxPause,
-				},
+				RateLimitConfig: apiserver.DefaultRateLimitConfig(),
 			})
 			if err != nil {
 				panic(err)


### PR DESCRIPTION
## Description of change

For models with many agents, it's possible to DDOS the controller (the thundering herd problem) if the controller agent bounces, eg after an upgrade, and everything attempts to re-connect at the same time.

Rate limiting is introduced to logins and general api connections. In addition, when a login is rejected with a retry error, we first pause so that the agent doesn't get to try again too soon.

The connection rate limit is achieved by pausing when accepting api connections. The pause time is based on the connection rate - the higher the rate of incoming connections, the longer the pause. The pause time is increased by 5ms for each new connection received per 10ms, up to a maximum of 5s pause time. 

## QA steps

bootstrap and deploy peer-xplod charm
add units
add new models, rinse and repeat
system should reach steady state without errors
on my lxd system, the units all got to the "reached maximum count 1000" state without noticeable impact on system interactions

## Bug

Partially addresses https://bugs.launchpad.net/juju/+bug/1696113
