### PR TITLE
Support a simplifed dump-model

### DIFF
--- a/api/base/testing/apicaller.go
+++ b/api/base/testing/apicaller.go
@@ -53,6 +53,16 @@ func (APICallerFunc) ConnectControllerStream(path string, attrs url.Values, head
 	return nil, errors.NotImplementedf("controller stream connection")
 }
 
+// BestVersionCaller is an APICallerFunc that has a particular best version.
+type BestVersionCaller struct {
+	APICallerFunc
+	BestVersion int
+}
+
+func (c BestVersionCaller) BestFacadeVersion(facade string) int {
+	return c.BestVersion
+}
+
 // CallChecker is an APICaller implementation that checks
 // calls as they are made.
 type CallChecker struct {

--- a/api/facadeversions.go
+++ b/api/facadeversions.go
@@ -59,7 +59,7 @@ var facadeVersions = map[string]int{
 	"MigrationStatusWatcher":       1,
 	"MigrationTarget":              1,
 	"ModelConfig":                  1,
-	"ModelManager":                 2,
+	"ModelManager":                 3,
 	"NotifyWatcher":                1,
 	"Payloads":                     1,
 	"PayloadsHookContext":          1,

--- a/api/modelmanager/modelmanager.go
+++ b/api/modelmanager/modelmanager.go
@@ -201,6 +201,9 @@ func (c *Client) ModelInfo(tags []names.ModelTag) ([]params.ModelInfoResult, err
 func (c *Client) DumpModel(model names.ModelTag, simplified bool) (map[string]interface{}, error) {
 	if bestVer := c.BestAPIVersion(); bestVer < 3 {
 		logger.Debugf("calling older dump model on v%d", bestVer)
+		if simplified {
+			logger.Warningf("simplified dump-model not available, server too old")
+		}
 		return c.dumpModelV2(model)
 	}
 

--- a/apiserver/allfacades.go
+++ b/apiserver/allfacades.go
@@ -164,7 +164,8 @@ func AllFacades() *facade.Registry {
 	reg("MigrationTarget", 1, migrationtarget.NewFacade)
 
 	reg("ModelConfig", 1, modelconfig.NewFacade)
-	reg("ModelManager", 2, modelmanager.NewFacade)
+	reg("ModelManager", 2, modelmanager.NewFacadeV2)
+	reg("ModelManager", 3, modelmanager.NewFacadeV3)
 
 	reg("Payloads", 1, payloads.NewFacade)
 	regHookContext(

--- a/apiserver/common/modelmanagerinterface.go
+++ b/apiserver/common/modelmanagerinterface.go
@@ -53,6 +53,7 @@ type ModelManagerBackend interface {
 	ControllerUUID() string
 	ControllerTag() names.ControllerTag
 	Export() (description.Model, error)
+	ExportPartial(state.ExportConfig) (description.Model, error)
 	SetUserAccess(subject names.UserTag, target names.Tag, access permission.Access) (permission.UserAccess, error)
 	SetModelMeterStatus(string, string) error
 	ReloadSpaces(environ environs.Environ) error

--- a/apiserver/modelmanager/modelinfo_test.go
+++ b/apiserver/modelmanager/modelinfo_test.go
@@ -136,14 +136,14 @@ func (s *modelInfoSuite) SetUpTest(c *gc.C) {
 	}
 
 	var err error
-	s.modelmanager, err = modelmanager.NewModelManagerAPI(s.st, nil, &s.authorizer)
+	s.modelmanager, err = modelmanager.NewModelManagerAPI(s.st, nil, nil, &s.authorizer)
 	c.Assert(err, jc.ErrorIsNil)
 }
 
 func (s *modelInfoSuite) setAPIUser(c *gc.C, user names.UserTag) {
 	s.authorizer.Tag = user
 	var err error
-	s.modelmanager, err = modelmanager.NewModelManagerAPI(s.st, nil, s.authorizer)
+	s.modelmanager, err = modelmanager.NewModelManagerAPI(s.st, nil, nil, s.authorizer)
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -1009,4 +1009,12 @@ func (m *mockMigration) StartTime() time.Time {
 
 func (m *mockMigration) EndTime() time.Time {
 	return m.end
+}
+
+type mockPool struct {
+	st *mockState
+}
+
+func (p *mockPool) Get(modelUUID string) (common.ModelManagerBackend, func(), error) {
+	return p.st, func() {}, p.st.NextErr()
 }

--- a/apiserver/modelmanager/modelinfo_test.go
+++ b/apiserver/modelmanager/modelinfo_test.go
@@ -563,6 +563,10 @@ func (st *mockState) Export() (description.Model, error) {
 	return &fakeModelDescription{UUID: st.model.UUID()}, nil
 }
 
+func (st *mockState) ExportPartial(state.ExportConfig) (description.Model, error) {
+	return st.Export()
+}
+
 func (st *mockState) ModelUUID() string {
 	st.MethodCall(st, "ModelUUID")
 	return st.model.UUID()

--- a/apiserver/modelmanager/modelmanager.go
+++ b/apiserver/modelmanager/modelmanager.go
@@ -12,6 +12,7 @@ import (
 	"sort"
 	"time"
 
+	"github.com/juju/description"
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	"github.com/juju/txn"
@@ -27,7 +28,6 @@ import (
 	"github.com/juju/juju/controller/modelmanager"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/config"
-	"github.com/juju/juju/migration"
 	"github.com/juju/juju/permission"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/stateenvirons"
@@ -36,8 +36,19 @@ import (
 
 var logger = loggo.GetLogger("juju.apiserver.modelmanager")
 
-// ModelManager defines the methods on the modelmanager API endpoint.
-type ModelManager interface {
+// ModelManagerV3 defines the methods on the version 2 facade for the
+// modelmanager API endpoint.
+type ModelManagerV3 interface {
+	CreateModel(args params.ModelCreateArgs) (params.ModelInfo, error)
+	DumpModels(args params.DumpModelRequest) params.StringResults
+	DumpModelsDB(args params.Entities) params.MapResults
+	ListModels(user params.Entity) (params.UserModelList, error)
+	DestroyModels(args params.Entities) (params.ErrorResults, error)
+}
+
+// ModelManagerV2 defines the methods on the version 2 facade for the
+// modelmanager API endpoint.
+type ModelManagerV2 interface {
 	CreateModel(args params.ModelCreateArgs) (params.ModelInfo, error)
 	DumpModels(args params.Entities) params.MapResults
 	DumpModelsDB(args params.Entities) params.MapResults
@@ -57,12 +68,30 @@ type ModelManagerAPI struct {
 	isAdmin     bool
 }
 
-var _ ModelManager = (*ModelManagerAPI)(nil)
+// ModelManagerAPIV2 provides a way to wrap the different calls between
+// version 2 and version 3 of the model manager API
+type ModelManagerAPIV2 struct {
+	*ModelManagerAPI
+}
+
+var (
+	_ ModelManagerV3 = (*ModelManagerAPI)(nil)
+	_ ModelManagerV2 = (*ModelManagerAPIV2)(nil)
+)
 
 // NewFacade is used for API registration.
-func NewFacade(st *state.State, _ facade.Resources, auth facade.Authorizer) (*ModelManagerAPI, error) {
+func NewFacadeV3(st *state.State, _ facade.Resources, auth facade.Authorizer) (*ModelManagerAPI, error) {
 	configGetter := stateenvirons.EnvironConfigGetter{st}
 	return NewModelManagerAPI(common.NewModelManagerBackend(st), configGetter, auth)
+}
+
+// NewFacade is used for API registration.
+func NewFacadeV2(st *state.State, resources facade.Resources, auth facade.Authorizer) (*ModelManagerAPIV2, error) {
+	v3, err := NewFacadeV3(st, resources, auth)
+	if err != nil {
+		return nil, err
+	}
+	return &ModelManagerAPIV2{v3}, nil
 }
 
 // NewModelManagerAPI creates a new api server endpoint for managing
@@ -337,7 +366,7 @@ func (m *ModelManagerAPI) CreateModel(args params.ModelCreateArgs) (params.Model
 	return m.getModelInfo(model.ModelTag())
 }
 
-func (m *ModelManagerAPI) dumpModel(args params.Entity) (map[string]interface{}, error) {
+func (m *ModelManagerAPI) dumpModel(args params.Entity, simplified bool) ([]byte, error) {
 	modelTag, err := names.ParseModelTag(args.Tag)
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -353,6 +382,7 @@ func (m *ModelManagerAPI) dumpModel(args params.Entity) (map[string]interface{},
 
 	st := m.state
 	if st.ModelTag() != modelTag {
+		// XXX state pool
 		st, err = m.state.ForModel(modelTag)
 		if err != nil {
 			if errors.IsNotFound(err) {
@@ -363,7 +393,32 @@ func (m *ModelManagerAPI) dumpModel(args params.Entity) (map[string]interface{},
 		defer st.Close()
 	}
 
-	bytes, err := migration.ExportModel(st)
+	var exportConfig state.ExportConfig
+	if simplified {
+		exportConfig.SkipActions = true
+		exportConfig.SkipAnnotations = true
+		exportConfig.SkipCloudImageMetadata = true
+		exportConfig.SkipCredentials = true
+		exportConfig.SkipIPAddresses = true
+		exportConfig.SkipSettings = true
+		exportConfig.SkipSSHHostKeys = true
+		exportConfig.SkipStatusHistory = true
+		exportConfig.SkipLinkLayerDevices = true
+	}
+
+	model, err := st.ExportPartial(exportConfig)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	bytes, err := description.Serialize(model)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return bytes, nil
+}
+
+func (m *ModelManagerAPIV2) dumpModel(args params.Entity) (map[string]interface{}, error) {
+	bytes, err := m.ModelManagerAPI.dumpModel(args, false)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -412,10 +467,26 @@ func (m *ModelManagerAPI) dumpModelDB(args params.Entity) (map[string]interface{
 	return st.DumpAll()
 }
 
+func (m *ModelManagerAPI) DumpModels(args params.DumpModelRequest) params.StringResults {
+	results := params.StringResults{
+		Results: make([]params.StringResult, len(args.Entities)),
+	}
+	for i, entity := range args.Entities {
+		bytes, err := m.dumpModel(entity, args.Simplified)
+		if err != nil {
+			results.Results[i].Error = common.ServerError(err)
+			continue
+		}
+		// We know here that the bytes are valid YAML.
+		results.Results[i].Result = string(bytes)
+	}
+	return results
+}
+
 // DumpModels will export the models into the database agnostic
 // representation. The user needs to either be a controller admin, or have
 // admin privileges on the model itself.
-func (m *ModelManagerAPI) DumpModels(args params.Entities) params.MapResults {
+func (m *ModelManagerAPIV2) DumpModels(args params.Entities) params.MapResults {
 	results := params.MapResults{
 		Results: make([]params.MapResult, len(args.Entities)),
 	}

--- a/apiserver/params/params.go
+++ b/apiserver/params/params.go
@@ -989,3 +989,11 @@ type DestroyUnitInfo struct {
 	// destroyed as a result of destroying the unit.
 	DestroyedStorage []Entity `json:"destroyed-storage,omitempty"`
 }
+
+// DumpModelRequest wraps the request for a dump-model call.
+// A simplified dump will not contain a complete export, but instead
+// a reduced set that is determined by the server.
+type DumpModelRequest struct {
+	Entities   []Entity `json:"entities"`
+	Simplified bool     `json:"simplified"`
+}

--- a/cmd/juju/model/dump.go
+++ b/cmd/juju/model/dump.go
@@ -24,7 +24,8 @@ type dumpCommand struct {
 	out cmd.Output
 	api DumpModelAPI
 
-	model string
+	model      string
+	simplified bool
 }
 
 const dumpModelHelpDoc = `
@@ -54,6 +55,7 @@ func (c *dumpCommand) Info() *cmd.Info {
 func (c *dumpCommand) SetFlags(f *gnuflag.FlagSet) {
 	c.ControllerCommandBase.SetFlags(f)
 	c.out.AddFlags(f, "yaml", output.DefaultFormatters)
+	f.BoolVar(&c.simplified, "simplified", false, "Dump a simplified partial model")
 }
 
 // Init implements Command.
@@ -68,7 +70,7 @@ func (c *dumpCommand) Init(args []string) error {
 // DumpModelAPI specifies the used function calls of the ModelManager.
 type DumpModelAPI interface {
 	Close() error
-	DumpModel(names.ModelTag) (map[string]interface{}, error)
+	DumpModel(names.ModelTag, bool) (map[string]interface{}, error)
 }
 
 func (c *dumpCommand) getAPI() (DumpModelAPI, error) {
@@ -104,7 +106,7 @@ func (c *dumpCommand) Run(ctx *cmd.Context) error {
 	}
 
 	modelTag := names.NewModelTag(modelDetails.ModelUUID)
-	results, err := client.DumpModel(modelTag)
+	results, err := client.DumpModel(modelTag, c.simplified)
 	if err != nil {
 		return err
 	}

--- a/state/migration_export.go
+++ b/state/migration_export.go
@@ -22,8 +22,33 @@ import (
 	"github.com/juju/juju/storage/poolmanager"
 )
 
+// ExportConfig allows certain aspects of the model to be skipped
+// during the export. The intent of this is to be able to get a partial
+// export to support other API calls, like status.
+type ExportConfig struct {
+	SkipActions            bool
+	SkipAnnotations        bool
+	SkipCloudImageMetadata bool
+	SkipCredentials        bool
+	SkipIPAddresses        bool
+	SkipSettings           bool
+	SkipSSHHostKeys        bool
+	SkipStatusHistory      bool
+	SkipLinkLayerDevices   bool
+}
+
+// ExportPartial the current model for the State optionally skipping
+// aspects as defined by the ExportConfig.
+func (st *State) ExportPartial(cfg ExportConfig) (description.Model, error) {
+	return st.exportImpl(cfg)
+}
+
 // Export the current model for the State.
 func (st *State) Export() (description.Model, error) {
+	return st.exportImpl(ExportConfig{})
+}
+
+func (st *State) exportImpl(cfg ExportConfig) (description.Model, error) {
 	dbModel, err := st.Model()
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -31,6 +56,7 @@ func (st *State) Export() (description.Model, error) {
 
 	export := exporter{
 		st:      st,
+		cfg:     cfg,
 		dbModel: dbModel,
 		logger:  loggo.GetLogger("juju.state.export-model"),
 	}
@@ -54,7 +80,7 @@ func (st *State) Export() (description.Model, error) {
 	}
 
 	modelConfig, found := export.modelSettings[modelGlobalKey]
-	if !found {
+	if !found && !cfg.SkipSettings {
 		return nil, errors.New("missing model config")
 	}
 	delete(export.modelSettings, modelGlobalKey)
@@ -73,7 +99,7 @@ func (st *State) Export() (description.Model, error) {
 		Blocks:             blocks,
 	}
 	export.model = description.NewModel(args)
-	if credsTag, credsSet := dbModel.CloudCredential(); credsSet {
+	if credsTag, credsSet := dbModel.CloudCredential(); credsSet && !cfg.SkipCredentials {
 		creds, err := st.CloudCredential(credsTag)
 		if err != nil {
 			return nil, errors.Trace(err)
@@ -145,8 +171,13 @@ func (st *State) Export() (description.Model, error) {
 		return nil, errors.Trace(err)
 	}
 
-	if err := export.model.Validate(); err != nil {
-		return nil, errors.Trace(err)
+	// If we are doing a partial export, it doesn't really make sense
+	// to validate the model.
+	fullExport := ExportConfig{}
+	if cfg == fullExport {
+		if err := export.model.Validate(); err != nil {
+			return nil, errors.Trace(err)
+		}
 	}
 
 	export.model.SetSLA(dbModel.SLALevel(), dbModel.SLAOwner(), string(dbModel.SLACredential()))
@@ -162,6 +193,7 @@ func (st *State) Export() (description.Model, error) {
 }
 
 type exporter struct {
+	cfg     ExportConfig
 	st      *State
 	dbModel *Model
 	model   description.Model
@@ -626,12 +658,12 @@ func (e *exporter) addApplication(ctx addApplicationContext) error {
 	storageConstraintsKey := application.storageConstraintsKey()
 
 	applicationSettingsDoc, found := e.modelSettings[settingsKey]
-	if !found {
+	if !found && !e.cfg.SkipSettings {
 		return errors.Errorf("missing settings for application %q", appName)
 	}
 	delete(e.modelSettings, settingsKey)
 	leadershipSettingsDoc, found := e.modelSettings[leadershipKey]
-	if !found {
+	if !found && !e.cfg.SkipSettings {
 		return errors.Errorf("missing leadership settings for application %q", appName)
 	}
 	delete(e.modelSettings, leadershipKey)
@@ -886,7 +918,7 @@ func (e *exporter) relations() error {
 					return errors.Errorf("missing relation scope for %s and %s", relation, unit.Name())
 				}
 				settingsDoc, found := e.modelSettings[key]
-				if !found {
+				if !found && !e.cfg.SkipSettings {
 					return errors.Errorf("missing relation settings for %s and %s", relation, unit.Name())
 				}
 				delete(e.modelSettings, key)
@@ -915,6 +947,9 @@ func (e *exporter) spaces() error {
 }
 
 func (e *exporter) linklayerdevices() error {
+	if e.cfg.SkipLinkLayerDevices {
+		return nil
+	}
 	linklayerdevices, err := e.st.AllLinkLayerDevices()
 	if err != nil {
 		return errors.Trace(err)
@@ -963,6 +998,9 @@ func (e *exporter) subnets() error {
 }
 
 func (e *exporter) ipaddresses() error {
+	if e.cfg.SkipIPAddresses {
+		return nil
+	}
 	ipaddresses, err := e.st.AllIPAddresses()
 	if err != nil {
 		return errors.Trace(err)
@@ -985,6 +1023,9 @@ func (e *exporter) ipaddresses() error {
 }
 
 func (e *exporter) sshHostKeys() error {
+	if e.cfg.SkipSSHHostKeys {
+		return nil
+	}
 	machines, err := e.st.AllMachines()
 	if err != nil {
 		return errors.Trace(err)
@@ -1008,6 +1049,9 @@ func (e *exporter) sshHostKeys() error {
 }
 
 func (e *exporter) cloudimagemetadata() error {
+	if e.cfg.SkipCloudImageMetadata {
+		return nil
+	}
 	cloudimagemetadata, err := e.st.CloudImageMetadataStorage.AllCloudImageMetadata()
 	if err != nil {
 		return errors.Trace(err)
@@ -1033,6 +1077,9 @@ func (e *exporter) cloudimagemetadata() error {
 }
 
 func (e *exporter) actions() error {
+	if e.cfg.SkipActions {
+		return nil
+	}
 	actions, err := e.st.AllActions()
 	if err != nil {
 		return errors.Trace(err)
@@ -1143,6 +1190,11 @@ func (e *exporter) readLastConnectionTimes() (map[string]time.Time, error) {
 }
 
 func (e *exporter) readAllAnnotations() error {
+	e.annotations = make(map[string]annotatorDoc)
+	if e.cfg.SkipAnnotations {
+		return nil
+	}
+
 	annotations, closer := e.st.db().GetCollection(annotationsC)
 	defer closer()
 
@@ -1152,7 +1204,6 @@ func (e *exporter) readAllAnnotations() error {
 	}
 	e.logger.Debugf("read %d annotations docs", len(docs))
 
-	e.annotations = make(map[string]annotatorDoc)
 	for _, doc := range docs {
 		e.annotations[doc.GlobalKey] = doc
 	}
@@ -1198,6 +1249,11 @@ func (e *exporter) getAnnotations(key string) map[string]string {
 }
 
 func (e *exporter) readAllSettings() error {
+	e.modelSettings = make(map[string]settingsDoc)
+	if e.cfg.SkipSettings {
+		return nil
+	}
+
 	settings, closer := e.st.db().GetCollection(settingsC)
 	defer closer()
 
@@ -1206,7 +1262,6 @@ func (e *exporter) readAllSettings() error {
 		return errors.Trace(err)
 	}
 
-	e.modelSettings = make(map[string]settingsDoc)
 	for _, doc := range docs {
 		key := e.st.localID(doc.DocID)
 		e.modelSettings[key] = doc
@@ -1244,6 +1299,9 @@ func (e *exporter) readAllStatusHistory() error {
 
 	count := 0
 	e.statusHistory = make(map[string][]historicalStatusDoc)
+	if e.cfg.SkipStatusHistory {
+		return nil
+	}
 	var doc historicalStatusDoc
 	// In tests, sorting by time can leave the results
 	// underconstrained - include document id for deterministic

--- a/state/migration_export_test.go
+++ b/state/migration_export_test.go
@@ -654,6 +654,26 @@ func (s *MigrationExportSuite) TestLinkLayerDevices(c *gc.C) {
 	c.Assert(device.Type(), gc.Equals, string(state.EthernetDevice))
 }
 
+func (s *MigrationExportSuite) TestLinkLayerDevicesSkipped(c *gc.C) {
+	machine := s.Factory.MakeMachine(c, &factory.MachineParams{
+		Constraints: constraints.MustParse("arch=amd64 mem=8G"),
+	})
+	deviceArgs := state.LinkLayerDeviceArgs{
+		Name: "foo",
+		Type: state.EthernetDevice,
+	}
+	err := machine.SetLinkLayerDevices(deviceArgs)
+	c.Assert(err, jc.ErrorIsNil)
+
+	model, err := s.State.ExportPartial(state.ExportConfig{
+		SkipLinkLayerDevices: true,
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	devices := model.LinkLayerDevices()
+	c.Assert(devices, gc.HasLen, 0)
+}
+
 func (s *MigrationExportSuite) TestSubnets(c *gc.C) {
 	_, err := s.State.AddSubnet(state.SubnetInfo{
 		CIDR:              "10.0.0.0/24",
@@ -722,6 +742,39 @@ func (s *MigrationExportSuite) TestIPAddresses(c *gc.C) {
 	c.Assert(addr.GatewayAddress(), gc.Equals, "0.1.2.1")
 }
 
+func (s *MigrationExportSuite) TestIPAddressesSkipped(c *gc.C) {
+	machine := s.Factory.MakeMachine(c, &factory.MachineParams{
+		Constraints: constraints.MustParse("arch=amd64 mem=8G"),
+	})
+	_, err := s.State.AddSubnet(state.SubnetInfo{CIDR: "0.1.2.0/24"})
+	c.Assert(err, jc.ErrorIsNil)
+	deviceArgs := state.LinkLayerDeviceArgs{
+		Name: "foo",
+		Type: state.EthernetDevice,
+	}
+	err = machine.SetLinkLayerDevices(deviceArgs)
+	c.Assert(err, jc.ErrorIsNil)
+	args := state.LinkLayerDeviceAddress{
+		DeviceName:       "foo",
+		ConfigMethod:     state.StaticAddress,
+		CIDRAddress:      "0.1.2.3/24",
+		ProviderID:       "bar",
+		DNSServers:       []string{"bam", "mam"},
+		DNSSearchDomains: []string{"weeee"},
+		GatewayAddress:   "0.1.2.1",
+	}
+	err = machine.SetDevicesAddresses(args)
+	c.Assert(err, jc.ErrorIsNil)
+
+	model, err := s.State.ExportPartial(state.ExportConfig{
+		SkipIPAddresses: true,
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	addresses := model.IPAddresses()
+	c.Assert(addresses, gc.HasLen, 0)
+}
+
 func (s *MigrationExportSuite) TestSSHHostKeys(c *gc.C) {
 	machine := s.Factory.MakeMachine(c, &factory.MachineParams{
 		Constraints: constraints.MustParse("arch=amd64 mem=8G"),
@@ -739,7 +792,23 @@ func (s *MigrationExportSuite) TestSSHHostKeys(c *gc.C) {
 	c.Assert(key.Keys(), jc.DeepEquals, []string{"bam", "mam"})
 }
 
-func (s *MigrationExportSuite) TestCloudImageMetadatas(c *gc.C) {
+func (s *MigrationExportSuite) TestSSHHostKeysSkipped(c *gc.C) {
+	machine := s.Factory.MakeMachine(c, &factory.MachineParams{
+		Constraints: constraints.MustParse("arch=amd64 mem=8G"),
+	})
+	err := s.State.SetSSHHostKeys(machine.MachineTag(), []string{"bam", "mam"})
+	c.Assert(err, jc.ErrorIsNil)
+
+	model, err := s.State.ExportPartial(state.ExportConfig{
+		SkipSSHHostKeys: true,
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	keys := model.SSHHostKeys()
+	c.Assert(keys, gc.HasLen, 0)
+}
+
+func (s *MigrationExportSuite) TestCloudImageMetadata(c *gc.C) {
 	storageSize := uint64(3)
 	attrs := cloudimagemetadata.MetadataAttributes{
 		Stream:          "stream",
@@ -778,6 +847,33 @@ func (s *MigrationExportSuite) TestCloudImageMetadatas(c *gc.C) {
 	c.Check(image.DateCreated(), gc.Equals, int64(2))
 }
 
+func (s *MigrationExportSuite) TestCloudImageMetadataSkipped(c *gc.C) {
+	storageSize := uint64(3)
+	attrs := cloudimagemetadata.MetadataAttributes{
+		Stream:          "stream",
+		Region:          "region-test",
+		Version:         "14.04",
+		Series:          "trusty",
+		Arch:            "arch",
+		VirtType:        "virtType-test",
+		RootStorageType: "rootStorageType-test",
+		RootStorageSize: &storageSize,
+		Source:          "test",
+	}
+	metadata := []cloudimagemetadata.Metadata{{attrs, 2, "1", 2}}
+
+	err := s.State.CloudImageMetadataStorage.SaveMetadata(metadata)
+	c.Assert(err, jc.ErrorIsNil)
+
+	model, err := s.State.ExportPartial(state.ExportConfig{
+		SkipCloudImageMetadata: true,
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	images := model.CloudImageMetadata()
+	c.Assert(images, gc.HasLen, 0)
+}
+
 func (s *MigrationExportSuite) TestActions(c *gc.C) {
 	machine := s.Factory.MakeMachine(c, &factory.MachineParams{
 		Constraints: constraints.MustParse("arch=amd64 mem=8G"),
@@ -795,6 +891,22 @@ func (s *MigrationExportSuite) TestActions(c *gc.C) {
 	c.Check(action.Name(), gc.Equals, "foo")
 	c.Check(action.Status(), gc.Equals, "pending")
 	c.Check(action.Message(), gc.Equals, "")
+}
+
+func (s *MigrationExportSuite) TestActionsSkipped(c *gc.C) {
+	machine := s.Factory.MakeMachine(c, &factory.MachineParams{
+		Constraints: constraints.MustParse("arch=amd64 mem=8G"),
+	})
+	_, err := s.State.EnqueueAction(machine.MachineTag(), "foo", nil)
+	c.Assert(err, jc.ErrorIsNil)
+
+	model, err := s.State.ExportPartial(state.ExportConfig{
+		SkipActions: true,
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	actions := model.Actions()
+	c.Assert(actions, gc.HasLen, 0)
 }
 
 type goodToken struct{}


### PR DESCRIPTION
## Description of change

juju status is shown to be terribly slow on very large systems. This is mostly due to how complexity of status has grown over time and the O(n²) operations it has. This code adds an arg struct to state.Export to allow a simplified export which could be used in the status generation. This allows us to test the timing of the information gathering aspect of what status could be in order to determine if the work is worthwhile doing.

## QA steps

juju bootstrap lxd testing
juju deploy ubuntu
JUJU_DEV_FEATURE_FLAGS=developer-mode juju dump-model

observe that status history, ssh host keys, model config is in the output

JUJU_DEV_FEATURE_FLAGS=developer-mode juju dump-model --simplified

observe that those values are empty.

## Documentation changes

None at this stage.
