### PR TITLE
Removed deprecated ssl arg for mongo

### DIFF
--- a/acceptancetests/tests/test_assess_update_mongo.py
+++ b/acceptancetests/tests/test_assess_update_mongo.py
@@ -60,11 +60,11 @@ class TestMain(TestCase):
 
 EG_MONGO3_PROC = (
     "4709 ?        Ssl    0:11 /usr/lib/juju/mongo3/bin/mongod "
-    "--dbpath /var/lib/juju/db --sslOnNormalPorts "
+    "--dbpath /var/lib/juju/db --sslMode requireSSL "
     "--sslPEMKeyFile /var/lib/juju/server.pem --sslPEMKeyPassword xxxxxxx "
     "--port 37017 --syslog --journal --replSet juju --ipv6 --quiet "
     "--oplogSize 512 --auth --keyFile /var/lib/juju/shared-secret "
-    "--noprealloc --smallfiles"
+    "-storageEngine wiredTiger"
 )
 
 

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -45,7 +45,7 @@ github.com/juju/rfc	git	ebdbbdb950cd039a531d15cdc2ac2cbd94f068ee	2016-07-11T02:4
 github.com/juju/romulus	git	eede3e29dd7784b7265bb2cc175eca35420d37e7	2017-05-19T13:49:06Z
 github.com/juju/schema	git	075de04f9b7d7580d60a1e12a0b3f50bb18e6998	2016-04-20T04:42:03Z
 github.com/juju/terms-client	git	9b925afd677234e4146dde3cb1a11e187cbed64e	2016-08-09T13:19:00Z
-github.com/juju/testing	git	06d21ddace802a83d08c82f513e30d84010ce31f	2017-05-01T02:35:42Z
+github.com/juju/testing	git	2fe0e88cf2321d801acedd2b4f0d7f63735fb732	2017-06-08T05:44:51Z
 github.com/juju/txn	git	941c396af5296a396a375bd88549552bd7a40dcd	2017-05-16T04:42:59Z
 github.com/juju/usso	git	68a59c96c178fbbad65926e7f93db50a2cd14f33	2016-04-01T10:44:24Z
 github.com/juju/utils	git	e126b30255fbcc0f65a84fcef3c919e9b714602e	2017-05-18T11:00:59Z

--- a/mongo/service.go
+++ b/mongo/service.go
@@ -156,7 +156,6 @@ func newConf(args ConfigArgs) common.Conf {
 	mongoCmd := args.MongoPath +
 
 		" --dbpath " + utils.ShQuote(args.DBDir) +
-		" --sslOnNormalPorts" +
 		" --sslPEMKeyFile " + utils.ShQuote(sslKeyPath(args.DataDir)) +
 		// --sslPEMKeyPassword has to have its argument passed with = thanks to
 		// https://bugs.launchpad.net/juju-core/+bug/1581284.
@@ -181,6 +180,13 @@ func newConf(args ConfigArgs) common.Conf {
 	} else {
 		mongoCmd = mongoCmd +
 			" --noauth"
+	}
+	if args.Version.Major == 2 {
+		mongoCmd = mongoCmd +
+			" --sslOnNormalPorts"
+	} else {
+		mongoCmd = mongoCmd +
+			" --sslMode requireSSL"
 	}
 	if args.Version.StorageEngine != WiredTiger {
 		mongoCmd = mongoCmd +

--- a/mongo/service_test.go
+++ b/mongo/service_test.go
@@ -21,7 +21,7 @@ type serviceSuite struct {
 
 var _ = gc.Suite(&serviceSuite{})
 
-func (s *serviceSuite) TestNewConf(c *gc.C) {
+func (s *serviceSuite) TestNewConf24(c *gc.C) {
 	dataDir := "/var/lib/juju"
 	dbDir := dataDir + "/db"
 	mongodPath := "/mgo/bin/mongod"
@@ -49,7 +49,6 @@ func (s *serviceSuite) TestNewConf(c *gc.C) {
 		Timeout: 300,
 		ExecStart: "/mgo/bin/mongod" +
 			" --dbpath '/var/lib/juju/db'" +
-			" --sslOnNormalPorts" +
 			" --sslPEMKeyFile '/var/lib/juju/server.pem'" +
 			" --sslPEMKeyPassword=ignored" +
 			" --port 12345" +
@@ -61,8 +60,56 @@ func (s *serviceSuite) TestNewConf(c *gc.C) {
 			" --ipv6" +
 			" --auth" +
 			" --keyFile '/var/lib/juju/shared-secret'" +
+			" --sslOnNormalPorts" +
 			" --noprealloc" +
 			" --smallfiles",
+	}
+
+	c.Check(conf, jc.DeepEquals, expected)
+	c.Check(strings.Fields(conf.ExecStart), jc.DeepEquals, strings.Fields(expected.ExecStart))
+}
+
+func (s *serviceSuite) TestNewConf32(c *gc.C) {
+	dataDir := "/var/lib/juju"
+	dbDir := dataDir + "/db"
+	mongodPath := "/mgo/bin/mongod"
+	mongodVersion := mongo.Mongo32wt
+	port := 12345
+	oplogSizeMB := 10
+	conf := mongo.NewConf(mongo.ConfigArgs{
+		DataDir:     dataDir,
+		DBDir:       dbDir,
+		MongoPath:   mongodPath,
+		Port:        port,
+		OplogSizeMB: oplogSizeMB,
+		WantNUMACtl: false,
+		Version:     mongodVersion,
+		Auth:        true,
+		IPv6:        true,
+	})
+
+	expected := common.Conf{
+		Desc: "juju state database",
+		Limit: map[string]int{
+			"nofile": 65000,
+			"nproc":  20000,
+		},
+		Timeout: 300,
+		ExecStart: "/mgo/bin/mongod" +
+			" --dbpath '/var/lib/juju/db'" +
+			" --sslPEMKeyFile '/var/lib/juju/server.pem'" +
+			" --sslPEMKeyPassword=ignored" +
+			" --port 12345" +
+			" --syslog" +
+			" --journal" +
+			" --replSet juju" +
+			" --quiet" +
+			" --oplogSize 10" +
+			" --ipv6" +
+			" --auth" +
+			" --keyFile '/var/lib/juju/shared-secret'" +
+			" --sslMode requireSSL" +
+			" --storageEngine wiredTiger",
 	}
 
 	c.Check(conf, jc.DeepEquals, expected)


### PR DESCRIPTION
## Description of change

Mongo was being started with a deprecated ssl argument.
Add support for the new arg in 3.2.
Also add a missing test for mongo 3.2 service config.

## QA steps

(trusty still uses mongo 2.4)
$ juju bootstrap lxd --bootstrap-series=trusty
$ juju bootstrap lxd

## Bug reference
https://bugs.launchpad.net/juju/+bug/1696005