### PR TITLE
Merge pull request #7476 from mhilton/006-azure-service-principal-from-azure-cli-with-autoload

### DIFF
--- a/provider/azure/credentials_test.go
+++ b/provider/azure/credentials_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 
+	arazure "github.com/Azure/go-autorest/autorest/azure"
 	"github.com/juju/cmd/cmdtesting"
 	"github.com/juju/errors"
 	"github.com/juju/testing"
@@ -65,9 +66,253 @@ func (s *credentialsSuite) TestServicePrincipalSecretHiddenAttributes(c *gc.C) {
 	envtesting.AssertProviderCredentialsAttributesHidden(c, s.provider, "service-principal-secret", "application-password")
 }
 
-func (s *credentialsSuite) TestDetectCredentials(c *gc.C) {
+func (s *credentialsSuite) TestDetectCredentialsNoAccounts(c *gc.C) {
 	_, err := s.provider.DetectCredentials()
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
+	calls := s.azureCLI.Calls()
+	c.Assert(calls, gc.HasLen, 1)
+	c.Assert(calls[0].FuncName, gc.Equals, "ListAccounts")
+}
+
+func (s *credentialsSuite) TestDetectCredentialsListError(c *gc.C) {
+	s.azureCLI.SetErrors(errors.New("test error"))
+	_, err := s.provider.DetectCredentials()
+	c.Assert(err, jc.Satisfies, errors.IsNotFound)
+}
+
+func (s *credentialsSuite) TestDetectCredentialsOneAccount(c *gc.C) {
+	s.azureCLI.Accounts = []azurecli.Account{{
+		CloudName: "AzureCloud",
+		ID:        "test-account-id",
+		IsDefault: true,
+		Name:      "test-account",
+		State:     "Enabled",
+		TenantId:  "tenant-id",
+	}}
+	s.azureCLI.Clouds = []azurecli.Cloud{{
+		Endpoints: azurecli.CloudEndpoints{
+			ActiveDirectoryGraphResourceID: "https://graph.invalid/",
+			ResourceManager:                "https://arm.invalid/",
+		},
+		IsActive: true,
+		Name:     "AzureCloud",
+	}}
+	cred, err := s.provider.DetectCredentials()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(cred, gc.Not(gc.IsNil))
+	c.Assert(cred.DefaultCredential, gc.Equals, "test-account")
+	c.Assert(cred.DefaultRegion, gc.Equals, "")
+	c.Assert(cred.AuthCredentials, gc.HasLen, 1)
+	c.Assert(cred.AuthCredentials["test-account"].Label, gc.Equals, "AzureCloud subscription test-account")
+
+	calls := s.azureCLI.Calls()
+	c.Assert(calls, gc.HasLen, 4)
+	c.Assert(calls[0].FuncName, gc.Equals, "ListAccounts")
+	c.Assert(calls[1].FuncName, gc.Equals, "ListClouds")
+	c.Assert(calls[2].FuncName, gc.Equals, "GetAccessToken")
+	c.Assert(calls[2].Args, jc.DeepEquals, []interface{}{"test-account-id", "https://graph.invalid/"})
+	c.Assert(calls[3].FuncName, gc.Equals, "GetAccessToken")
+	c.Assert(calls[3].Args, jc.DeepEquals, []interface{}{"test-account-id", "https://arm.invalid/"})
+
+	calls = s.servicePrincipalCreator.Calls()
+	c.Assert(calls, gc.HasLen, 1)
+	c.Assert(calls[0].FuncName, gc.Equals, "Create")
+	c.Assert(calls[0].Args[0], jc.DeepEquals, azureauth.ServicePrincipalParams{
+		GraphEndpoint:   "https://graph.invalid/",
+		GraphResourceId: "https://graph.invalid/",
+		GraphAuthorizer: &arazure.Token{
+			AccessToken: "test-account-id|https://graph.invalid/|access-token",
+			Type:        "Bearer",
+		},
+		ResourceManagerEndpoint:   "https://arm.invalid/",
+		ResourceManagerResourceId: "https://arm.invalid/",
+		ResourceManagerAuthorizer: &arazure.Token{
+			AccessToken: "test-account-id|https://arm.invalid/|access-token",
+			Type:        "Bearer",
+		},
+		SubscriptionId: "test-account-id",
+		TenantId:       "tenant-id",
+	})
+}
+
+func (s *credentialsSuite) TestDetectCredentialsCloudError(c *gc.C) {
+	s.azureCLI.Accounts = []azurecli.Account{{
+		CloudName: "AzureCloud",
+		ID:        "test-account-id",
+		IsDefault: true,
+		Name:      "test-account",
+		State:     "Enabled",
+		TenantId:  "tenant-id",
+	}}
+	s.azureCLI.Clouds = []azurecli.Cloud{{
+		Endpoints: azurecli.CloudEndpoints{
+			ActiveDirectoryGraphResourceID: "https://graph.invalid",
+			ResourceManager:                "https://arm.invalid",
+		},
+		IsActive: true,
+		Name:     "AzureCloud",
+	}}
+	s.azureCLI.SetErrors(nil, errors.New("test error"))
+	cred, err := s.provider.DetectCredentials()
+	c.Assert(err, jc.Satisfies, errors.IsNotFound)
+	c.Assert(cred, gc.IsNil)
+
+	calls := s.azureCLI.Calls()
+	c.Assert(calls, gc.HasLen, 2)
+	c.Assert(calls[0].FuncName, gc.Equals, "ListAccounts")
+	c.Assert(calls[1].FuncName, gc.Equals, "ListClouds")
+
+	calls = s.servicePrincipalCreator.Calls()
+	c.Assert(calls, gc.HasLen, 0)
+}
+
+func (s *credentialsSuite) TestDetectCredentialsTwoAccounts(c *gc.C) {
+	s.azureCLI.Accounts = []azurecli.Account{{
+		CloudName: "AzureCloud",
+		ID:        "test-account1-id",
+		IsDefault: true,
+		Name:      "test-account1",
+		State:     "Enabled",
+		TenantId:  "tenant-id",
+	}, {
+		CloudName: "AzureCloud",
+		ID:        "test-account2-id",
+		IsDefault: false,
+		Name:      "test-account2",
+		State:     "Enabled",
+		TenantId:  "tenant-id",
+	}}
+	s.azureCLI.Clouds = []azurecli.Cloud{{
+		Endpoints: azurecli.CloudEndpoints{
+			ActiveDirectoryGraphResourceID: "https://graph.invalid/",
+			ResourceManager:                "https://arm.invalid/",
+		},
+		IsActive: true,
+		Name:     "AzureCloud",
+	}}
+	cred, err := s.provider.DetectCredentials()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(cred, gc.Not(gc.IsNil))
+	c.Assert(cred.DefaultCredential, gc.Equals, "test-account1")
+	c.Assert(cred.DefaultRegion, gc.Equals, "")
+	c.Assert(cred.AuthCredentials, gc.HasLen, 2)
+	c.Assert(cred.AuthCredentials["test-account1"].Label, gc.Equals, "AzureCloud subscription test-account1")
+	c.Assert(cred.AuthCredentials["test-account2"].Label, gc.Equals, "AzureCloud subscription test-account2")
+
+	calls := s.azureCLI.Calls()
+	c.Assert(calls, gc.HasLen, 6)
+	c.Assert(calls[0].FuncName, gc.Equals, "ListAccounts")
+	c.Assert(calls[1].FuncName, gc.Equals, "ListClouds")
+	c.Assert(calls[2].FuncName, gc.Equals, "GetAccessToken")
+	c.Assert(calls[2].Args, jc.DeepEquals, []interface{}{"test-account1-id", "https://graph.invalid/"})
+	c.Assert(calls[3].FuncName, gc.Equals, "GetAccessToken")
+	c.Assert(calls[3].Args, jc.DeepEquals, []interface{}{"test-account1-id", "https://arm.invalid/"})
+	c.Assert(calls[4].FuncName, gc.Equals, "GetAccessToken")
+	c.Assert(calls[4].Args, jc.DeepEquals, []interface{}{"test-account2-id", "https://graph.invalid/"})
+	c.Assert(calls[5].FuncName, gc.Equals, "GetAccessToken")
+	c.Assert(calls[5].Args, jc.DeepEquals, []interface{}{"test-account2-id", "https://arm.invalid/"})
+
+	calls = s.servicePrincipalCreator.Calls()
+	c.Assert(calls, gc.HasLen, 2)
+	c.Assert(calls[0].FuncName, gc.Equals, "Create")
+	c.Assert(calls[0].Args[0], jc.DeepEquals, azureauth.ServicePrincipalParams{
+		GraphEndpoint:   "https://graph.invalid/",
+		GraphResourceId: "https://graph.invalid/",
+		GraphAuthorizer: &arazure.Token{
+			AccessToken: "test-account1-id|https://graph.invalid/|access-token",
+			Type:        "Bearer",
+		},
+		ResourceManagerEndpoint:   "https://arm.invalid/",
+		ResourceManagerResourceId: "https://arm.invalid/",
+		ResourceManagerAuthorizer: &arazure.Token{
+			AccessToken: "test-account1-id|https://arm.invalid/|access-token",
+			Type:        "Bearer",
+		},
+		SubscriptionId: "test-account1-id",
+		TenantId:       "tenant-id",
+	})
+	c.Assert(calls[1].FuncName, gc.Equals, "Create")
+	c.Assert(calls[1].Args[0], jc.DeepEquals, azureauth.ServicePrincipalParams{
+		GraphEndpoint:   "https://graph.invalid/",
+		GraphResourceId: "https://graph.invalid/",
+		GraphAuthorizer: &arazure.Token{
+			AccessToken: "test-account2-id|https://graph.invalid/|access-token",
+			Type:        "Bearer",
+		},
+		ResourceManagerEndpoint:   "https://arm.invalid/",
+		ResourceManagerResourceId: "https://arm.invalid/",
+		ResourceManagerAuthorizer: &arazure.Token{
+			AccessToken: "test-account2-id|https://arm.invalid/|access-token",
+			Type:        "Bearer",
+		},
+		SubscriptionId: "test-account2-id",
+		TenantId:       "tenant-id",
+	})
+}
+
+func (s *credentialsSuite) TestDetectCredentialsTwoAccountsOneError(c *gc.C) {
+	s.azureCLI.Accounts = []azurecli.Account{{
+		CloudName: "AzureCloud",
+		ID:        "test-account1-id",
+		IsDefault: false,
+		Name:      "test-account1",
+		State:     "Enabled",
+		TenantId:  "tenant-id",
+	}, {
+		CloudName: "AzureCloud",
+		ID:        "test-account2-id",
+		IsDefault: true,
+		Name:      "test-account2",
+		State:     "Enabled",
+		TenantId:  "tenant-id",
+	}}
+	s.azureCLI.Clouds = []azurecli.Cloud{{
+		Endpoints: azurecli.CloudEndpoints{
+			ActiveDirectoryGraphResourceID: "https://graph.invalid/",
+			ResourceManager:                "https://arm.invalid/",
+		},
+		IsActive: true,
+		Name:     "AzureCloud",
+	}}
+	s.azureCLI.SetErrors(nil, nil, nil, nil, errors.New("test error"))
+	cred, err := s.provider.DetectCredentials()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(cred, gc.Not(gc.IsNil))
+	c.Assert(cred.DefaultCredential, gc.Equals, "")
+	c.Assert(cred.DefaultRegion, gc.Equals, "")
+	c.Assert(cred.AuthCredentials, gc.HasLen, 1)
+	c.Assert(cred.AuthCredentials["test-account1"].Label, gc.Equals, "AzureCloud subscription test-account1")
+
+	calls := s.azureCLI.Calls()
+	c.Assert(calls, gc.HasLen, 5)
+	c.Assert(calls[0].FuncName, gc.Equals, "ListAccounts")
+	c.Assert(calls[1].FuncName, gc.Equals, "ListClouds")
+	c.Assert(calls[2].FuncName, gc.Equals, "GetAccessToken")
+	c.Assert(calls[2].Args, jc.DeepEquals, []interface{}{"test-account1-id", "https://graph.invalid/"})
+	c.Assert(calls[3].FuncName, gc.Equals, "GetAccessToken")
+	c.Assert(calls[3].Args, jc.DeepEquals, []interface{}{"test-account1-id", "https://arm.invalid/"})
+	c.Assert(calls[4].FuncName, gc.Equals, "GetAccessToken")
+	c.Assert(calls[4].Args, jc.DeepEquals, []interface{}{"test-account2-id", "https://graph.invalid/"})
+
+	calls = s.servicePrincipalCreator.Calls()
+	c.Assert(calls, gc.HasLen, 1)
+	c.Assert(calls[0].FuncName, gc.Equals, "Create")
+	c.Assert(calls[0].Args[0], jc.DeepEquals, azureauth.ServicePrincipalParams{
+		GraphEndpoint:   "https://graph.invalid/",
+		GraphResourceId: "https://graph.invalid/",
+		GraphAuthorizer: &arazure.Token{
+			AccessToken: "test-account1-id|https://graph.invalid/|access-token",
+			Type:        "Bearer",
+		},
+		ResourceManagerEndpoint:   "https://arm.invalid/",
+		ResourceManagerResourceId: "https://arm.invalid/",
+		ResourceManagerAuthorizer: &arazure.Token{
+			AccessToken: "test-account1-id|https://arm.invalid/|access-token",
+			Type:        "Bearer",
+		},
+		SubscriptionId: "test-account1-id",
+		TenantId:       "tenant-id",
+	})
 }
 
 func (s *credentialsSuite) TestFinalizeCredentialInteractive(c *gc.C) {
@@ -439,4 +684,12 @@ func (e *azureCLI) FindCloudsWithResourceManagerEndpoint(url string) ([]azurecli
 		}
 	}
 	return nil, errors.New("cloud not found")
+}
+
+func (e *azureCLI) ListClouds() ([]azurecli.Cloud, error) {
+	e.MethodCall(e, "ListClouds")
+	if err := e.NextErr(); err != nil {
+		return nil, err
+	}
+	return e.Clouds, nil
 }

--- a/provider/azure/internal/azurecli/az_test.go
+++ b/provider/azure/internal/azurecli/az_test.go
@@ -4,6 +4,7 @@
 package azurecli_test
 
 import (
+	"os/exec"
 	"strings"
 
 	"github.com/Azure/go-autorest/autorest/azure"
@@ -80,7 +81,7 @@ func (s *azSuite) TestGetAccessTokenError(c *gc.C) {
 		Exec: testExecutor{
 			commands: map[string]result{
 				"az account get-access-token -o json": result{
-					error: errors.New("test error"),
+					error: &exec.ExitError{Stderr: []byte("test error")},
 				},
 			},
 		}.Exec,
@@ -197,7 +198,7 @@ func (s *azSuite) TestShowAccountError(c *gc.C) {
 		Exec: testExecutor{
 			commands: map[string]result{
 				"az account show -o json": result{
-					error: errors.New("test error"),
+					error: &exec.ExitError{Stderr: []byte("test error\nusage ...")},
 				},
 			},
 		}.Exec,
@@ -549,6 +550,202 @@ func (s *azSuite) TestFindCloudsWithResourceManagerEndpointError(c *gc.C) {
 		}.Exec,
 	}
 	cloud, err := azcli.FindCloudsWithResourceManagerEndpoint("https://management.azure.com/")
+	c.Assert(err, gc.ErrorMatches, `execution failure: test error`)
+	c.Assert(cloud, gc.IsNil)
+}
+
+func (s *azSuite) TestListClouds(c *gc.C) {
+	azcli := azurecli.AzureCLI{
+		Exec: testExecutor{
+			commands: map[string]result{
+				"az cloud list -o json": result{
+					stdout: []byte(`
+[
+  {
+    "endpoints": {
+      "activeDirectory": "https://login.microsoftonline.com",
+      "activeDirectoryGraphResourceId": "https://graph.windows.net/",
+      "activeDirectoryResourceId": "https://management.core.windows.net/",
+      "batchResourceId": "https://batch.core.windows.net/",
+      "gallery": "https://gallery.azure.com/",
+      "management": "https://management.core.windows.net/",
+      "resourceManager": "https://management.azure.com/",
+      "sqlManagement": "https://management.core.windows.net:8443/"
+    },
+    "isActive": true,
+    "name": "AzureCloud",
+    "profile": "latest",
+    "suffixes": {
+      "azureDatalakeAnalyticsCatalogAndJobEndpoint": "azuredatalakeanalytics.net",
+      "azureDatalakeStoreFileSystemEndpoint": "azuredatalakestore.net",
+      "keyvaultDns": ".vault.azure.net",
+      "sqlServerHostname": ".database.windows.net",
+      "storageEndpoint": "core.windows.net"
+    }
+  },
+  {
+    "endpoints": {
+      "activeDirectory": "https://login.chinacloudapi.cn",
+      "activeDirectoryGraphResourceId": "https://graph.chinacloudapi.cn/",
+      "activeDirectoryResourceId": "https://management.core.chinacloudapi.cn/",
+      "batchResourceId": "https://batch.chinacloudapi.cn/",
+      "gallery": "https://gallery.chinacloudapi.cn/",
+      "management": "https://management.core.chinacloudapi.cn/",
+      "resourceManager": "https://management.chinacloudapi.cn",
+      "sqlManagement": "https://management.core.chinacloudapi.cn:8443/"
+    },
+    "isActive": false,
+    "name": "AzureChinaCloud",
+    "profile": "latest",
+    "suffixes": {
+      "azureDatalakeAnalyticsCatalogAndJobEndpoint": null,
+      "azureDatalakeStoreFileSystemEndpoint": null,
+      "keyvaultDns": ".vault.azure.cn",
+      "sqlServerHostname": ".database.chinacloudapi.cn",
+      "storageEndpoint": "core.chinacloudapi.cn"
+    }
+  },
+  {
+    "endpoints": {
+      "activeDirectory": "https://login.microsoftonline.com",
+      "activeDirectoryGraphResourceId": "https://graph.windows.net/",
+      "activeDirectoryResourceId": "https://management.core.usgovcloudapi.net/",
+      "batchResourceId": "https://batch.core.usgovcloudapi.net/",
+      "gallery": "https://gallery.usgovcloudapi.net/",
+      "management": "https://management.core.usgovcloudapi.net/",
+      "resourceManager": "https://management.usgovcloudapi.net/",
+      "sqlManagement": "https://management.core.usgovcloudapi.net:8443/"
+    },
+    "isActive": false,
+    "name": "AzureUSGovernment",
+    "profile": "latest",
+    "suffixes": {
+      "azureDatalakeAnalyticsCatalogAndJobEndpoint": null,
+      "azureDatalakeStoreFileSystemEndpoint": null,
+      "keyvaultDns": ".vault.usgovcloudapi.net",
+      "sqlServerHostname": ".database.usgovcloudapi.net",
+      "storageEndpoint": "core.usgovcloudapi.net"
+    }
+  },
+  {
+    "endpoints": {
+      "activeDirectory": "https://login.microsoftonline.de",
+      "activeDirectoryGraphResourceId": "https://graph.cloudapi.de/",
+      "activeDirectoryResourceId": "https://management.core.cloudapi.de/",
+      "batchResourceId": "https://batch.cloudapi.de/",
+      "gallery": "https://gallery.cloudapi.de/",
+      "management": "https://management.core.cloudapi.de/",
+      "resourceManager": "https://management.microsoftazure.de",
+      "sqlManagement": "https://management.core.cloudapi.de:8443/"
+    },
+    "isActive": false,
+    "name": "AzureGermanCloud",
+    "profile": "latest",
+    "suffixes": {
+      "azureDatalakeAnalyticsCatalogAndJobEndpoint": null,
+      "azureDatalakeStoreFileSystemEndpoint": null,
+      "keyvaultDns": ".vault.microsoftazure.de",
+      "sqlServerHostname": ".database.cloudapi.de",
+      "storageEndpoint": "core.cloudapi.de"
+    }
+  }
+]
+
+`[1:]),
+				},
+			},
+		}.Exec,
+	}
+	clouds, err := azcli.ListClouds()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(clouds, jc.DeepEquals, []azurecli.Cloud{{
+		Endpoints: azurecli.CloudEndpoints{
+			ActiveDirectory:                "https://login.microsoftonline.com",
+			ActiveDirectoryGraphResourceID: "https://graph.windows.net/",
+			ActiveDirectoryResourceID:      "https://management.core.windows.net/",
+			BatchResourceID:                "https://batch.core.windows.net/",
+			Management:                     "https://management.core.windows.net/",
+			ResourceManager:                "https://management.azure.com/",
+			SQLManagement:                  "https://management.core.windows.net:8443/",
+		},
+		IsActive: true,
+		Name:     "AzureCloud",
+		Profile:  "latest",
+		Suffixes: azurecli.CloudSuffixes{
+			AzureDatalakeAnalyticsCatalogAndJobEndpoint: "azuredatalakeanalytics.net",
+			AzureDatalakeStoreFileSystemEndpoint:        "azuredatalakestore.net",
+			KeyvaultDNS:                                 ".vault.azure.net",
+			SQLServerHostname:                           ".database.windows.net",
+			StorageEndpoint:                             "core.windows.net",
+		},
+	}, {
+		Endpoints: azurecli.CloudEndpoints{
+			ActiveDirectory:                "https://login.chinacloudapi.cn",
+			ActiveDirectoryGraphResourceID: "https://graph.chinacloudapi.cn/",
+			ActiveDirectoryResourceID:      "https://management.core.chinacloudapi.cn/",
+			BatchResourceID:                "https://batch.chinacloudapi.cn/",
+			Management:                     "https://management.core.chinacloudapi.cn/",
+			ResourceManager:                "https://management.chinacloudapi.cn",
+			SQLManagement:                  "https://management.core.chinacloudapi.cn:8443/",
+		},
+		IsActive: false,
+		Name:     "AzureChinaCloud",
+		Profile:  "latest",
+		Suffixes: azurecli.CloudSuffixes{
+			KeyvaultDNS:       ".vault.azure.cn",
+			SQLServerHostname: ".database.chinacloudapi.cn",
+			StorageEndpoint:   "core.chinacloudapi.cn",
+		},
+	}, {
+		Endpoints: azurecli.CloudEndpoints{
+			ActiveDirectory:                "https://login.microsoftonline.com",
+			ActiveDirectoryGraphResourceID: "https://graph.windows.net/",
+			ActiveDirectoryResourceID:      "https://management.core.usgovcloudapi.net/",
+			BatchResourceID:                "https://batch.core.usgovcloudapi.net/",
+			Management:                     "https://management.core.usgovcloudapi.net/",
+			ResourceManager:                "https://management.usgovcloudapi.net/",
+			SQLManagement:                  "https://management.core.usgovcloudapi.net:8443/",
+		},
+		IsActive: false,
+		Name:     "AzureUSGovernment",
+		Profile:  "latest",
+		Suffixes: azurecli.CloudSuffixes{
+			KeyvaultDNS:       ".vault.usgovcloudapi.net",
+			SQLServerHostname: ".database.usgovcloudapi.net",
+			StorageEndpoint:   "core.usgovcloudapi.net",
+		},
+	}, {
+		Endpoints: azurecli.CloudEndpoints{
+			ActiveDirectory:                "https://login.microsoftonline.de",
+			ActiveDirectoryGraphResourceID: "https://graph.cloudapi.de/",
+			ActiveDirectoryResourceID:      "https://management.core.cloudapi.de/",
+			BatchResourceID:                "https://batch.cloudapi.de/",
+			Management:                     "https://management.core.cloudapi.de/",
+			ResourceManager:                "https://management.microsoftazure.de",
+			SQLManagement:                  "https://management.core.cloudapi.de:8443/",
+		},
+		IsActive: false,
+		Name:     "AzureGermanCloud",
+		Profile:  "latest",
+		Suffixes: azurecli.CloudSuffixes{
+			KeyvaultDNS:       ".vault.microsoftazure.de",
+			SQLServerHostname: ".database.cloudapi.de",
+			StorageEndpoint:   "core.cloudapi.de",
+		},
+	}})
+}
+
+func (s *azSuite) TestListCloudsError(c *gc.C) {
+	azcli := azurecli.AzureCLI{
+		Exec: testExecutor{
+			commands: map[string]result{
+				"az cloud list -o json": result{
+					error: errors.New("test error"),
+				},
+			},
+		}.Exec,
+	}
+	cloud, err := azcli.ListClouds()
 	c.Assert(err, gc.ErrorMatches, `execution failure: test error`)
 	c.Assert(cloud, gc.IsNil)
 }


### PR DESCRIPTION
## Description of change
Support autoload-credentials in the azure provider when Azure CLI is installed.

## QA steps

Install a recent Azure CLI and make sure it's logged in. Use juju autoload-credentials to automatically create the credential.

## Documentation changes

It changes the autoload-credentials workflow for azure.

## Bug reference

No bug
