### PR TITLE
Fix LP:#1696828 by sanitizing meter status code inputs on import.

### DIFF
--- a/state/migration_import.go
+++ b/state/migration_import.go
@@ -208,7 +208,7 @@ func (st *State) Import(model description.Model) (_ *Model, _ *State, err error)
 		return nil, nil, errors.Trace(err)
 	}
 
-	if model.MeterStatus().Code() != MeterNotAvailable.String() {
+	if MeterStatusFromString(model.MeterStatus().Code()).String() != MeterNotAvailable.String() {
 		if err := dbModel.SetMeterStatus(model.MeterStatus().Code(), model.MeterStatus().Info()); err != nil {
 			return nil, nil, errors.Trace(err)
 		}

--- a/state/migration_import_test.go
+++ b/state/migration_import_test.go
@@ -268,6 +268,21 @@ func (s *MigrationImportSuite) TestMeterStatus(c *gc.C) {
 	c.Assert(ms.Info, gc.Equals, "info message")
 }
 
+func (s *MigrationImportSuite) TestMeterStatusNotAvailable(c *gc.C) {
+	newModel, newSt := s.importModel(c, func(desc map[string]interface{}) {
+		c.Log(desc["meter-status"])
+		desc["meter-status"].(map[interface{}]interface{})["code"] = ""
+	})
+
+	ms := newModel.MeterStatus()
+	c.Assert(ms.Code.String(), gc.Equals, "NOT AVAILABLE")
+	c.Assert(ms.Info, gc.Equals, "")
+	ms, err := newSt.ModelMeterStatus()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(ms.Code.String(), gc.Equals, "NOT AVAILABLE")
+	c.Assert(ms.Info, gc.Equals, "")
+}
+
 func (s *MigrationImportSuite) AssertMachineEqual(c *gc.C, newMachine, oldMachine *state.Machine) {
 	c.Assert(newMachine.Id(), gc.Equals, oldMachine.Id())
 	c.Assert(newMachine.Principals(), jc.DeepEquals, oldMachine.Principals())


### PR DESCRIPTION
## Description of change

> Why is this change needed?

Meter status codes need to be sanitized to a set of enumerated values before setting them in state during a model migration.

## QA steps

> How do we verify that the change works?

Export a model from a 2.1.3 controller and import into a 2.2-rc1 controller, per [LP:#1696828](https://bugs.launchpad.net/juju/+bug/1696828).

## Documentation changes

> Does it affect current user workflow? CLI? API?

No.

## Bug reference

> Does this change fix a bug? Please add a link to it.

[LP:#1696828](https://bugs.launchpad.net/juju/+bug/1696828)