### PR TITLE
add option for mongo socket pool limit to be set

### DIFF
--- a/mongo/open.go
+++ b/mongo/open.go
@@ -55,6 +55,9 @@ type DialOpts struct {
 	// mgo.Session after a successful dial but before DialWithInfo
 	// returns to its caller.
 	PostDial func(*mgo.Session) error
+
+	// PoolLimit defines the per-server socket pool limit
+	PoolLimit int
 }
 
 // DefaultDialOpts returns a DialOpts representing the default
@@ -162,6 +165,7 @@ func DialInfo(info Info, opts DialOpts) (*mgo.DialInfo, error) {
 		Timeout:    opts.Timeout,
 		DialServer: dial,
 		Direct:     opts.Direct,
+		PoolLimit:  opts.PoolLimit,
 	}, nil
 }
 


### PR DESCRIPTION
## Description of change

Maybe helps to fix https://bugs.launchpad.net/juju/+bug/1696739
See comments in the bug. We provide a knob to tweak the mgo socket pool limit.
This requires a value to be set in the agentconfig file(s) for the controller. A suggested value to try is 100.

MONGO_SOCKET_POOL_LIMIT = 100

The default behaviour on bootstrap is not changed - you will need to bootstrap, edit agent config, and restart controller agents. Once we get a feel for if this works, we can adjust the defaults.

This tweak appeared to make a difference when running up a test system.

## QA steps

bootstrap and deploy peer-xplod

## Bug reference

https://bugs.launchpad.net/juju/+bug/1696739
