### PR TITLE
Version check for model migration test now handles final versions pro…

### DIFF
--- a/acceptancetests/assess_model_migration.py
+++ b/acceptancetests/assess_model_migration.py
@@ -5,7 +5,10 @@ from __future__ import print_function
 
 import argparse
 from contextlib import contextmanager
-from distutils.version import LooseVersion
+from distutils.version import (
+    LooseVersion,
+    StrictVersion
+    )
 import logging
 import os
 from subprocess import CalledProcessError
@@ -93,6 +96,12 @@ def client_is_at_least_2_1(client):
 
 
 def after_22beta4(client_version):
+    # LooseVersion considers 2.2-somealpha to be newer than 2.2.0.
+    # Attempt strict versioning first.
+    try:
+        return StrictVersion(client_version) >= StrictVersion('2.2.0')
+    except ValueError:
+        pass
     return LooseVersion(client_version) >= LooseVersion('2.2-beta4')
 
 

--- a/acceptancetests/tests/test_assess_model_migration.py
+++ b/acceptancetests/tests/test_assess_model_migration.py
@@ -90,6 +90,14 @@ class TestParseArgs(TestCase):
 
 class TestAfter22Beta4(TestCase):
 
+    def test_returns_False_for_prev_final_releases(self):
+        self.assertFalse(amm.after_22beta4('2.1'))
+
+    def test_returns_True_for_final_release(self):
+        self.assertTrue(amm.after_22beta4('2.2.0'))
+        self.assertTrue(amm.after_22beta4('2.2'))
+        self.assertTrue(amm.after_22beta4('2.2.1'))
+
     def test_returns_True_when_newer(self):
         self.assertTrue(amm.after_22beta4('2.2-beta8-xenial-amd64'))
         self.assertTrue(amm.after_22beta4('2.3-beta4-xenial-amd64'))


### PR DESCRIPTION
Fixes model migration functional test that was getting confused by 2.2.0 version string.