### PR TITLE
juju add-unit --attach-storage

### DIFF
--- a/api/facadeversions.go
+++ b/api/facadeversions.go
@@ -17,7 +17,7 @@ var facadeVersions = map[string]int{
 	"AllModelWatcher":              2,
 	"AllWatcher":                   1,
 	"Annotations":                  2,
-	"Application":                  4,
+	"Application":                  5,
 	"ApplicationOffers":            1,
 	"ApplicationScaler":            1,
 	"Backups":                      1,

--- a/apiserver/allfacades.go
+++ b/apiserver/allfacades.go
@@ -120,6 +120,7 @@ func AllFacades() *facade.Registry {
 	reg("Application", 2, application.NewFacade)
 	reg("Application", 3, application.NewFacade)
 	reg("Application", 4, application.NewFacade)
+	reg("Application", 5, application.NewFacade)
 
 	reg("ApplicationScaler", 1, applicationscaler.NewAPI)
 	reg("Backups", 1, backups.NewFacade)

--- a/apiserver/application/application_test.go
+++ b/apiserver/application/application_test.go
@@ -1615,12 +1615,14 @@ func (s *applicationSuite) TestBlockChangesServerUnset(c *gc.C) {
 var clientAddApplicationUnitsTests = []struct {
 	about       string
 	application string // if not set, defaults to 'dummy'
+	numUnits    int
 	expected    []string
 	to          string
 	err         string
 }{
 	{
 		about:    "returns unit names",
+		numUnits: 3,
 		expected: []string{"dummy/0", "dummy/1", "dummy/2"},
 	},
 	{
@@ -1631,12 +1633,14 @@ var clientAddApplicationUnitsTests = []struct {
 		// Note: chained-state, we add 1 unit here, but the 3 units
 		// from the first condition still exist
 		about:    "force the unit onto bootstrap machine",
+		numUnits: 1,
 		expected: []string{"dummy/3"},
 		to:       "0",
 	},
 	{
 		about:       "unknown application name",
 		application: "unknown-application",
+		numUnits:    1,
 		err:         `application "unknown-application" not found`,
 	},
 }
@@ -1651,7 +1655,7 @@ func (s *applicationSuite) TestClientAddApplicationUnits(c *gc.C) {
 		}
 		args := params.AddApplicationUnits{
 			ApplicationName: applicationName,
-			NumUnits:        len(t.expected),
+			NumUnits:        t.numUnits,
 		}
 		if t.to != "" {
 			args.Placement = []*instance.Placement{instance.MustParsePlacement(t.to)}

--- a/apiserver/application/deploy_test.go
+++ b/apiserver/application/deploy_test.go
@@ -47,7 +47,7 @@ func (s *DeployLocalSuite) SetUpTest(c *gc.C) {
 }
 
 func (s *DeployLocalSuite) TestDeployMinimal(c *gc.C) {
-	app, err := application.DeployApplication(s.State,
+	app, err := application.DeployApplication(stateDeployer{s.State},
 		application.DeployApplicationParams{
 			ApplicationName: "bob",
 			Charm:           s.charm,
@@ -60,9 +60,9 @@ func (s *DeployLocalSuite) TestDeployMinimal(c *gc.C) {
 }
 
 func (s *DeployLocalSuite) TestDeploySeries(c *gc.C) {
-	f := &fakeDeployer{State: s.State}
+	var f fakeDeployer
 
-	_, err := application.DeployApplication(f,
+	_, err := application.DeployApplication(&f,
 		application.DeployApplicationParams{
 			ApplicationName: "bob",
 			Charm:           s.charm,
@@ -78,7 +78,7 @@ func (s *DeployLocalSuite) TestDeploySeries(c *gc.C) {
 func (s *DeployLocalSuite) TestDeployWithImplicitBindings(c *gc.C) {
 	wordpressCharm := s.addWordpressCharmWithExtraBindings(c)
 
-	app, err := application.DeployApplication(s.State,
+	app, err := application.DeployApplication(stateDeployer{s.State},
 		application.DeployApplicationParams{
 			ApplicationName:  "bob",
 			Charm:            wordpressCharm,
@@ -133,7 +133,7 @@ func (s *DeployLocalSuite) TestDeployWithSomeSpecifiedBindings(c *gc.C) {
 	_, err = s.State.AddSpace("public", "", nil, false)
 	c.Assert(err, jc.ErrorIsNil)
 
-	app, err := application.DeployApplication(s.State,
+	app, err := application.DeployApplication(stateDeployer{s.State},
 		application.DeployApplicationParams{
 			ApplicationName: "bob",
 			Charm:           wordpressCharm,
@@ -169,7 +169,7 @@ func (s *DeployLocalSuite) TestDeployWithBoundRelationNamesAndExtraBindingsNames
 	_, err = s.State.AddSpace("internal", "", nil, false)
 	c.Assert(err, jc.ErrorIsNil)
 
-	app, err := application.DeployApplication(s.State,
+	app, err := application.DeployApplication(stateDeployer{s.State},
 		application.DeployApplicationParams{
 			ApplicationName: "bob",
 			Charm:           wordpressCharm,
@@ -206,7 +206,7 @@ func (s *DeployLocalSuite) TestDeployWithInvalidSpace(c *gc.C) {
 	_, err = s.State.AddSpace("internal", "", nil, false)
 	c.Assert(err, jc.ErrorIsNil)
 
-	app, err := application.DeployApplication(s.State,
+	app, err := application.DeployApplication(stateDeployer{s.State},
 		application.DeployApplicationParams{
 			ApplicationName: "bob",
 			Charm:           wordpressCharm,
@@ -232,7 +232,7 @@ func (s *DeployLocalSuite) TestDeployWithInvalidBinding(c *gc.C) {
 	_, err = s.State.AddSpace("internal", "", nil, false)
 	c.Assert(err, jc.ErrorIsNil)
 
-	app, err := application.DeployApplication(s.State,
+	app, err := application.DeployApplication(stateDeployer{s.State},
 		application.DeployApplicationParams{
 			ApplicationName: "bob",
 			Charm:           wordpressCharm,
@@ -252,9 +252,9 @@ func (s *DeployLocalSuite) TestDeployWithInvalidBinding(c *gc.C) {
 }
 
 func (s *DeployLocalSuite) TestDeployResources(c *gc.C) {
-	f := &fakeDeployer{State: s.State}
+	var f fakeDeployer
 
-	_, err := application.DeployApplication(f,
+	_, err := application.DeployApplication(&f,
 		application.DeployApplicationParams{
 			ApplicationName: "bob",
 			Charm:           s.charm,
@@ -271,7 +271,7 @@ func (s *DeployLocalSuite) TestDeployResources(c *gc.C) {
 }
 
 func (s *DeployLocalSuite) TestDeploySettings(c *gc.C) {
-	app, err := application.DeployApplication(s.State,
+	app, err := application.DeployApplication(stateDeployer{s.State},
 		application.DeployApplicationParams{
 			ApplicationName: "bob",
 			Charm:           s.charm,
@@ -288,7 +288,7 @@ func (s *DeployLocalSuite) TestDeploySettings(c *gc.C) {
 }
 
 func (s *DeployLocalSuite) TestDeploySettingsError(c *gc.C) {
-	_, err := application.DeployApplication(s.State,
+	_, err := application.DeployApplication(stateDeployer{s.State},
 		application.DeployApplicationParams{
 			ApplicationName: "bob",
 			Charm:           s.charm,
@@ -305,7 +305,7 @@ func (s *DeployLocalSuite) TestDeployConstraints(c *gc.C) {
 	err := s.State.SetModelConstraints(constraints.MustParse("mem=2G"))
 	c.Assert(err, jc.ErrorIsNil)
 	serviceCons := constraints.MustParse("cores=2")
-	app, err := application.DeployApplication(s.State,
+	app, err := application.DeployApplication(stateDeployer{s.State},
 		application.DeployApplicationParams{
 			ApplicationName: "bob",
 			Charm:           s.charm,
@@ -316,10 +316,10 @@ func (s *DeployLocalSuite) TestDeployConstraints(c *gc.C) {
 }
 
 func (s *DeployLocalSuite) TestDeployNumUnits(c *gc.C) {
-	f := &fakeDeployer{State: s.State}
+	var f fakeDeployer
 
 	serviceCons := constraints.MustParse("cores=2")
-	_, err := application.DeployApplication(f,
+	_, err := application.DeployApplication(&f,
 		application.DeployApplicationParams{
 			ApplicationName: "bob",
 			Charm:           s.charm,
@@ -335,10 +335,10 @@ func (s *DeployLocalSuite) TestDeployNumUnits(c *gc.C) {
 }
 
 func (s *DeployLocalSuite) TestDeployForceMachineId(c *gc.C) {
-	f := &fakeDeployer{State: s.State}
+	var f fakeDeployer
 
 	serviceCons := constraints.MustParse("cores=2")
-	_, err := application.DeployApplication(f,
+	_, err := application.DeployApplication(&f,
 		application.DeployApplicationParams{
 			ApplicationName: "bob",
 			Charm:           s.charm,
@@ -357,10 +357,10 @@ func (s *DeployLocalSuite) TestDeployForceMachineId(c *gc.C) {
 }
 
 func (s *DeployLocalSuite) TestDeployForceMachineIdWithContainer(c *gc.C) {
-	f := &fakeDeployer{State: s.State}
+	var f fakeDeployer
 
 	serviceCons := constraints.MustParse("cores=2")
-	_, err := application.DeployApplication(f,
+	_, err := application.DeployApplication(&f,
 		application.DeployApplicationParams{
 			ApplicationName: "bob",
 			Charm:           s.charm,
@@ -378,7 +378,7 @@ func (s *DeployLocalSuite) TestDeployForceMachineIdWithContainer(c *gc.C) {
 }
 
 func (s *DeployLocalSuite) TestDeploy(c *gc.C) {
-	f := &fakeDeployer{State: s.State}
+	var f fakeDeployer
 
 	serviceCons := constraints.MustParse("cores=2")
 	placement := []*instance.Placement{
@@ -387,7 +387,7 @@ func (s *DeployLocalSuite) TestDeploy(c *gc.C) {
 		{Scope: "lxd", Directive: "1"},
 		{Scope: "lxd", Directive: ""},
 	}
-	_, err := application.DeployApplication(f,
+	_, err := application.DeployApplication(&f,
 		application.DeployApplicationParams{
 			ApplicationName: "bob",
 			Charm:           s.charm,
@@ -405,10 +405,10 @@ func (s *DeployLocalSuite) TestDeploy(c *gc.C) {
 }
 
 func (s *DeployLocalSuite) TestDeployWithFewerPlacement(c *gc.C) {
-	f := &fakeDeployer{State: s.State}
+	var f fakeDeployer
 	serviceCons := constraints.MustParse("cores=2")
 	placement := []*instance.Placement{{Scope: s.State.ModelUUID(), Directive: "valid"}}
-	_, err := application.DeployApplication(f,
+	_, err := application.DeployApplication(&f,
 		application.DeployApplicationParams{
 			ApplicationName: "bob",
 			Charm:           s.charm,
@@ -477,12 +477,23 @@ func (s *DeployLocalSuite) assertMachines(c *gc.C, app application.Application, 
 	c.Assert(unseenIds, gc.DeepEquals, set.NewStrings())
 }
 
-type fakeDeployer struct {
+type stateDeployer struct {
 	*state.State
+}
+
+func (d stateDeployer) AddApplication(args state.AddApplicationArgs) (application.Application, error) {
+	app, err := d.State.AddApplication(args)
+	if err != nil {
+		return nil, err
+	}
+	return application.NewStateApplication(d.State, app), nil
+}
+
+type fakeDeployer struct {
 	args state.AddApplicationArgs
 }
 
-func (f *fakeDeployer) AddApplication(args state.AddApplicationArgs) (*state.Application, error) {
+func (f *fakeDeployer) AddApplication(args state.AddApplicationArgs) (application.Application, error) {
 	f.args = args
 	return nil, nil
 }

--- a/apiserver/application/mock_test.go
+++ b/apiserver/application/mock_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/juju/juju/apiserver/application"
 	"github.com/juju/juju/environs"
+	"github.com/juju/juju/instance"
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/state"
 	statestorage "github.com/juju/juju/state/storage"
@@ -130,6 +131,15 @@ func (a *mockApplication) SetCharm(cfg state.SetCharmConfig) error {
 func (a *mockApplication) Destroy() error {
 	a.MethodCall(a, "Destroy")
 	return a.NextErr()
+}
+
+func (a *mockApplication) AddUnit(args state.AddUnitParams) (application.Unit, error) {
+	a.MethodCall(a, "AddUnit", args)
+	if err := a.NextErr(); err != nil {
+		return nil, err
+	}
+	unitTag := names.NewUnitTag(a.name + "/99")
+	return &mockUnit{tag: unitTag}, nil
 }
 
 type mockRemoteApplication struct {
@@ -499,6 +509,16 @@ func (u *mockUnit) IsPrincipal() bool {
 
 func (u *mockUnit) Destroy() error {
 	u.MethodCall(u, "Destroy")
+	return u.NextErr()
+}
+
+func (u *mockUnit) AssignWithPolicy(policy state.AssignmentPolicy) error {
+	u.MethodCall(u, "AssignWithPolicy", policy)
+	return u.NextErr()
+}
+
+func (u *mockUnit) AssignWithPlacement(placement *instance.Placement) error {
+	u.MethodCall(u, "AssignWithPlacement", placement)
 	return u.NextErr()
 }
 

--- a/apiserver/client/perm_test.go
+++ b/apiserver/client/perm_test.go
@@ -342,7 +342,10 @@ func opClientServiceSetCharm(c *gc.C, st api.Connection, mst *state.State) (func
 }
 
 func opClientAddServiceUnits(c *gc.C, st api.Connection, mst *state.State) (func(), error) {
-	_, err := application.NewClient(st).AddUnits("nosuch", 1, nil)
+	_, err := application.NewClient(st).AddUnits(application.AddUnitsParams{
+		ApplicationName: "nosuch",
+		NumUnits:        1,
+	})
 	if params.IsCodeNotFound(err) {
 		err = nil
 	}

--- a/apiserver/params/params.go
+++ b/apiserver/params/params.go
@@ -384,6 +384,7 @@ type AddApplicationUnits struct {
 	ApplicationName string                `json:"application"`
 	NumUnits        int                   `json:"num-units"`
 	Placement       []*instance.Placement `json:"placement"`
+	AttachStorage   []string              `json:"attach-storage,omitempty"`
 }
 
 // DestroyApplicationUnits holds parameters for the DestroyUnits call.

--- a/cmd/juju/application/deploy_test.go
+++ b/cmd/juju/application/deploy_test.go
@@ -95,7 +95,7 @@ var initErrorTests = []struct {
 		args: []string{"charm", "application", "--force"},
 		err:  `--force is only used with --series`,
 	}, {
-		args: []string{"--attach-storage", "foo/0", "-n", "2"},
+		args: []string{"charm", "--attach-storage", "foo/0", "-n", "2"},
 		err:  `--attach-storage cannot be used with -n`,
 	},
 }
@@ -1380,7 +1380,10 @@ func (s *DeployUnitTestSuite) TestDeployBundle_OutputsCorrectMessage(c *gc.C) {
 		0,
 		nil,
 	)
-	fakeAPI.Call("AddUnits", "mysql", 1, []*instance.Placement(nil)).Returns([]string{"mysql/0"}, error(nil))
+	fakeAPI.Call("AddUnits", application.AddUnitsParams{
+		ApplicationName: "mysql",
+		NumUnits:        1,
+	}).Returns([]string{"mysql/0"}, error(nil))
 
 	wordpressURL := charm.MustParseURL("cs:wordpress")
 	withCharmRepoResolvable(fakeAPI, wordpressURL, cfg)
@@ -1394,7 +1397,10 @@ func (s *DeployUnitTestSuite) TestDeployBundle_OutputsCorrectMessage(c *gc.C) {
 		0,
 		nil,
 	)
-	fakeAPI.Call("AddUnits", "wordpress", 1, []*instance.Placement(nil)).Returns([]string{"wordpress/0"}, error(nil))
+	fakeAPI.Call("AddUnits", application.AddUnitsParams{
+		ApplicationName: "wordpress",
+		NumUnits:        1,
+	}).Returns([]string{"wordpress/0"}, error(nil))
 
 	fakeAPI.Call("AddRelation", "wordpress:db", "mysql:server").Returns(
 		&params.AddRelationResults{},
@@ -1553,8 +1559,8 @@ func (f *fakeDeployAPI) AddRelation(endpoints ...string) (*params.AddRelationRes
 	return results[0].(*params.AddRelationResults), jujutesting.TypeAssertError(results[1])
 }
 
-func (f *fakeDeployAPI) AddUnits(application string, numUnits int, placement []*instance.Placement) ([]string, error) {
-	results := f.MethodCall(f, "AddUnits", application, numUnits, placement)
+func (f *fakeDeployAPI) AddUnits(args application.AddUnitsParams) ([]string, error) {
+	results := f.MethodCall(f, "AddUnits", args)
 	return results[0].([]string), jujutesting.TypeAssertError(results[1])
 }
 

--- a/state/minimumunits.go
+++ b/state/minimumunits.go
@@ -195,5 +195,5 @@ func aliveUnitsCount(app *Application) (int, error) {
 // will be aborted if the application document changes when running the operations.
 func ensureMinUnitsOps(app *Application) (string, []txn.Op, error) {
 	asserts := bson.D{{"txn-revno", app.doc.TxnRevno}}
-	return app.addUnitOps("", asserts)
+	return app.addUnitOps("", AddUnitParams{}, asserts)
 }

--- a/state/relationunit.go
+++ b/state/relationunit.go
@@ -227,7 +227,7 @@ func (ru *RelationUnit) subordinateOps() ([]txn.Op, string, error) {
 		if err != nil {
 			return nil, "", err
 		}
-		_, ops, err := application.addUnitOps(unitName, nil)
+		_, ops, err := application.addUnitOps(unitName, AddUnitParams{}, nil)
 		return ops, "", err
 	} else if err != nil {
 		return nil, "", err


### PR DESCRIPTION
## Description of change

Update the add-unit command, API, API server and
state code to enable users to add a new unit to
an application, attaching existing storage.

## QA steps

1. juju bootstrap aws
2. juju deploy postgresql --storage pgdata=ebs,10G
(wait for idle)
3. juju remove-unit postgresql/0
(wait till machine 0 is removed; storage should remain)
4. juju add-unit postgresql --attach-storage pgdata/0
(wait for idle)

## Documentation changes

Yes, we will need to document the new flag.

## Bug reference

None.