### PR TITLE
Add a prometheus collectior for api metrics; drive by fixed to reduce…

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -567,7 +567,7 @@ func (c *configInternal) SetAPIHostPorts(servers [][]network.HostPort) {
 		addrs = append(addrs, hps...)
 	}
 	c.apiDetails.addresses = addrs
-	logger.Infof("API server address details %q written to agent config as %q", servers, addrs)
+	logger.Debugf("API server address details %q written to agent config as %q", servers, addrs)
 }
 
 func (c *configInternal) SetCACert(cert string) {

--- a/apiserver/admin.go
+++ b/apiserver/admin.go
@@ -5,6 +5,7 @@ package apiserver
 
 import (
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/juju/errors"
@@ -86,6 +87,12 @@ func (a *admin) login(req params.LoginRequest, loginVersion int) (params.LoginRe
 		var err error
 		kind, err = names.TagKind(req.AuthTag)
 		if err != nil || kind != names.UserTagKind {
+			addCount := func(delta int64) {
+				atomic.AddInt64(&a.srv.loginAttempts, delta)
+			}
+			addCount(1)
+			defer addCount(-1)
+
 			isUser = false
 			// Users are not rate limited, all other entities are.
 			if !a.srv.limiter.Acquire() {

--- a/apiserver/apiserver.go
+++ b/apiserver/apiserver.go
@@ -322,9 +322,11 @@ func newServer(s *state.State, lis net.Listener, cfg ServerConfig) (_ *Server, e
 	}
 	srv.logSinkWriter = logSinkWriter
 
-	apiserverCollectior := NewMetricsCollector(&metricAdaptor{srv})
-	if err := cfg.PrometheusRegisterer.Register(apiserverCollectior); err != nil {
-		return nil, errors.Annotate(err, "registering apiserver metrics collector")
+	if cfg.PrometheusRegisterer != nil {
+		apiserverCollectior := NewMetricsCollector(&metricAdaptor{srv})
+		if err := cfg.PrometheusRegisterer.Register(apiserverCollectior); err != nil {
+			return nil, errors.Annotate(err, "registering apiserver metrics collector")
+		}
 	}
 
 	go srv.run()

--- a/apiserver/apiserver.go
+++ b/apiserver/apiserver.go
@@ -55,7 +55,7 @@ const (
 	defaultLoginMinPause      = 100 * time.Millisecond
 	defaultLoginMaxPause      = 1 * time.Second
 	defaultLoginRetryPause    = 5 * time.Second
-	defaultConnMinPause       = 10 * time.Millisecond
+	defaultConnMinPause       = 0 * time.Millisecond
 	defaultConnMaxPause       = 5 * time.Second
 	defaultConnLookbackWindow = 1 * time.Second
 	defaultConnLowerThreshold = 1000   // connections per second

--- a/apiserver/apiservermetrics.go
+++ b/apiserver/apiservermetrics.go
@@ -1,0 +1,81 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package apiserver
+
+import (
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const (
+	apiserverMetricsNamespace = "juju_apiserver"
+)
+
+// ServerMetricsSource implementations provide apiserver metrics.
+type ServerMetricsSource interface {
+	ConnectionCount() int64
+	ConcurrentLoginAttempts() int64
+	ConnectionPauseTime() time.Duration
+	ConnectionRate() int64
+}
+
+// Collector is a prometheus.Collector that collects metrics based
+// on apiserver status.
+type Collector struct {
+	src ServerMetricsSource
+
+	connectionCountGauge     prometheus.Gauge
+	connectionRateGauge      prometheus.Gauge
+	connectionPauseTimeGauge prometheus.Gauge
+	concurrentLoginsGauge    prometheus.Gauge
+}
+
+// NewMetricsCollector returns a new Collector.
+func NewMetricsCollector(src ServerMetricsSource) *Collector {
+	return &Collector{
+		src: src,
+		connectionCountGauge: prometheus.NewGauge(prometheus.GaugeOpts{
+			Namespace: apiserverMetricsNamespace,
+			Name:      "connection_count",
+			Help:      "Current number of apiserver connections",
+		}),
+		connectionRateGauge: prometheus.NewGauge(prometheus.GaugeOpts{
+			Namespace: apiserverMetricsNamespace,
+			Name:      "connection_rate",
+			Help:      "Rate per second of web socket connections",
+		}),
+		connectionPauseTimeGauge: prometheus.NewGauge(prometheus.GaugeOpts{
+			Namespace: apiserverMetricsNamespace,
+			Name:      "connection_pause_time",
+			Help:      "Current wait time in milliseconds before accepting incoming connections",
+		}),
+		concurrentLoginsGauge: prometheus.NewGauge(prometheus.GaugeOpts{
+			Namespace: apiserverMetricsNamespace,
+			Name:      "concurrent_login_attempts",
+			Help:      "Current number of concurrent agent login attempts",
+		}),
+	}
+}
+
+// Describe is part of the prometheus.Collector interface.
+func (c *Collector) Describe(ch chan<- *prometheus.Desc) {
+	c.connectionCountGauge.Describe(ch)
+	c.connectionRateGauge.Describe(ch)
+	c.connectionPauseTimeGauge.Describe(ch)
+	c.concurrentLoginsGauge.Describe(ch)
+}
+
+// Collect is part of the prometheus.Collector interface.
+func (c *Collector) Collect(ch chan<- prometheus.Metric) {
+	c.connectionCountGauge.Set(float64(c.src.ConnectionCount()))
+	c.connectionRateGauge.Set(float64(c.src.ConnectionRate()))
+	c.connectionPauseTimeGauge.Set(float64(c.src.ConnectionPauseTime() / time.Millisecond))
+	c.concurrentLoginsGauge.Set(float64(c.src.ConcurrentLoginAttempts()))
+
+	c.connectionCountGauge.Collect(ch)
+	c.connectionRateGauge.Collect(ch)
+	c.connectionPauseTimeGauge.Collect(ch)
+	c.concurrentLoginsGauge.Collect(ch)
+}

--- a/apiserver/apiservermetrics_test.go
+++ b/apiserver/apiservermetrics_test.go
@@ -38,10 +38,10 @@ func (s *apiservermetricsSuite) TestDescribe(c *gc.C) {
 		descs = append(descs, desc)
 	}
 	c.Assert(descs, gc.HasLen, 4)
-	c.Assert(descs[0].String(), gc.Matches, `.*fqName: "juju_apiserver_connection_count".*`)
-	c.Assert(descs[1].String(), gc.Matches, `.*fqName: "juju_apiserver_connection_rate".*`)
-	c.Assert(descs[2].String(), gc.Matches, `.*fqName: "juju_apiserver_connection_pause_time".*`)
-	c.Assert(descs[3].String(), gc.Matches, `.*fqName: "juju_apiserver_concurrent_login_attempts".*`)
+	c.Assert(descs[0].String(), gc.Matches, `.*fqName: "juju_apiserver_connections_total".*`)
+	c.Assert(descs[1].String(), gc.Matches, `.*fqName: "juju_apiserver_connection_count".*`)
+	c.Assert(descs[2].String(), gc.Matches, `.*fqName: "juju_apiserver_connection_pause_seconds".*`)
+	c.Assert(descs[3].String(), gc.Matches, `.*fqName: "juju_apiserver_active_login_attempts".*`)
 }
 
 func (s *apiservermetricsSuite) TestCollect(c *gc.C) {
@@ -67,14 +67,18 @@ func (s *apiservermetricsSuite) TestCollect(c *gc.C) {
 		return &v
 	}
 	c.Assert(dtoMetrics, jc.DeepEquals, [4]dto.Metric{
+		{Counter: &dto.Counter{Value: float64ptr(200)}},
 		{Gauge: &dto.Gauge{Value: float64ptr(2)}},
-		{Gauge: &dto.Gauge{Value: float64ptr(100)}},
-		{Gauge: &dto.Gauge{Value: float64ptr(20)}},
+		{Gauge: &dto.Gauge{Value: float64ptr(0.02)}},
 		{Gauge: &dto.Gauge{Value: float64ptr(3)}},
 	})
 }
 
 type stubCollector struct{}
+
+func (a *stubCollector) TotalConnections() int64 {
+	return 200
+}
 
 func (a *stubCollector) ConnectionCount() int64 {
 	return 2
@@ -86,8 +90,4 @@ func (a *stubCollector) ConcurrentLoginAttempts() int64 {
 
 func (a *stubCollector) ConnectionPauseTime() time.Duration {
 	return 20 * time.Millisecond
-}
-
-func (a *stubCollector) ConnectionRate() int64 {
-	return 100
 }

--- a/apiserver/apiservermetrics_test.go
+++ b/apiserver/apiservermetrics_test.go
@@ -1,0 +1,93 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENSE file for details.
+
+package apiserver_test
+
+import (
+	"time"
+
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/apiserver"
+)
+
+type apiservermetricsSuite struct {
+	testing.IsolationSuite
+	collector prometheus.Collector
+}
+
+var _ = gc.Suite(&apiservermetricsSuite{})
+
+func (s *apiservermetricsSuite) SetUpTest(c *gc.C) {
+	s.IsolationSuite.SetUpTest(c)
+	s.collector = apiserver.NewMetricsCollector(&stubCollector{})
+}
+
+func (s *apiservermetricsSuite) TestDescribe(c *gc.C) {
+	ch := make(chan *prometheus.Desc)
+	go func() {
+		defer close(ch)
+		s.collector.Describe(ch)
+	}()
+	var descs []*prometheus.Desc
+	for desc := range ch {
+		descs = append(descs, desc)
+	}
+	c.Assert(descs, gc.HasLen, 4)
+	c.Assert(descs[0].String(), gc.Matches, `.*fqName: "juju_apiserver_connection_count".*`)
+	c.Assert(descs[1].String(), gc.Matches, `.*fqName: "juju_apiserver_connection_rate".*`)
+	c.Assert(descs[2].String(), gc.Matches, `.*fqName: "juju_apiserver_connection_pause_time".*`)
+	c.Assert(descs[3].String(), gc.Matches, `.*fqName: "juju_apiserver_concurrent_login_attempts".*`)
+}
+
+func (s *apiservermetricsSuite) TestCollect(c *gc.C) {
+	ch := make(chan prometheus.Metric)
+	go func() {
+		defer close(ch)
+		s.collector.Collect(ch)
+	}()
+
+	var metrics []prometheus.Metric
+	for metric := range ch {
+		metrics = append(metrics, metric)
+	}
+	c.Assert(metrics, gc.HasLen, 4)
+
+	var dtoMetrics [4]dto.Metric
+	for i, metric := range metrics {
+		err := metric.Write(&dtoMetrics[i])
+		c.Assert(err, jc.ErrorIsNil)
+	}
+
+	float64ptr := func(v float64) *float64 {
+		return &v
+	}
+	c.Assert(dtoMetrics, jc.DeepEquals, [4]dto.Metric{
+		{Gauge: &dto.Gauge{Value: float64ptr(2)}},
+		{Gauge: &dto.Gauge{Value: float64ptr(100)}},
+		{Gauge: &dto.Gauge{Value: float64ptr(20)}},
+		{Gauge: &dto.Gauge{Value: float64ptr(3)}},
+	})
+}
+
+type stubCollector struct{}
+
+func (a *stubCollector) ConnectionCount() int64 {
+	return 2
+}
+
+func (a *stubCollector) ConcurrentLoginAttempts() int64 {
+	return 3
+}
+
+func (a *stubCollector) ConnectionPauseTime() time.Duration {
+	return 20 * time.Millisecond
+}
+
+func (a *stubCollector) ConnectionRate() int64 {
+	return 100
+}

--- a/apiserver/uniter/uniter.go
+++ b/apiserver/uniter/uniter.go
@@ -1775,8 +1775,8 @@ func (u *UniterAPIV4) getOneNetworkConfig(canAccess common.AuthFunc, unitTagArg,
 	if err != nil {
 		return nil, errors.Annotate(err, "cannot get devices addresses")
 	}
-	logger.Infof(
-		"geting network config for machine %q with addresses %+v, hosting unit %q of application %q, with bindings %+v",
+	logger.Debugf(
+		"getting network config for machine %q with addresses %+v, hosting unit %q of application %q, with bindings %+v",
 		machineID, addresses, unit.Name(), application.Name(), bindings,
 	)
 

--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -1293,6 +1293,7 @@ func (a *MachineAgent) newAPIserverWorker(
 		StatePool:                     statePool,
 		RegisterIntrospectionHandlers: registerIntrospectionHandlers,
 		RateLimitConfig:               rateLimitConfig,
+		PrometheusRegisterer:          a.prometheusRegistry,
 	})
 	if err != nil {
 		return nil, errors.Annotate(err, "cannot start api server worker")

--- a/rpc/server.go
+++ b/rpc/server.go
@@ -6,6 +6,7 @@ package rpc
 import (
 	"io"
 	"reflect"
+	"strings"
 	"sync"
 
 	"github.com/juju/errors"
@@ -510,7 +511,15 @@ func (conn *Conn) runRequest(req boundRequest, arg reflect.Value, version int, o
 		conn.sending.Unlock()
 	}
 	if err != nil {
-		logger.Errorf("error writing response: %v", err)
+		// If the message failed due to the other end closing the socket, that
+		// is expected when an agent restarts so no need to log an  error.
+		// The error type here is errors.errorString so all we can do is a match
+		// on the error string content.
+		msg := err.Error()
+		if !strings.Contains(msg, "websocket: close sent") &&
+			!strings.Contains(msg, "write: broken pipe") {
+			logger.Errorf("error writing response: %T %+v", err, err)
+		}
 	}
 }
 

--- a/worker/firewaller/firewaller.go
+++ b/worker/firewaller/firewaller.go
@@ -598,7 +598,7 @@ func (fw *Firewaller) openedPortsChanged(machineTag names.MachineTag, subnetTag 
 		// It is common to receive a port change notification before
 		// registering the machine, so if a machine is not found in
 		// firewaller's list, just skip the change.
-		logger.Errorf("failed to lookup %q, skipping port change", machineTag)
+		logger.Debugf("failed to lookup %q, skipping port change", machineTag)
 		return nil
 	}
 
@@ -619,7 +619,7 @@ func (fw *Firewaller) openedPortsChanged(machineTag names.MachineTag, subnetTag 
 			// It is common to receive port change notification before
 			// registering a unit. Skip handling the port change - it will
 			// be handled when the unit is registered.
-			logger.Errorf("failed to lookup %q, skipping port change", unitTag)
+			logger.Debugf("failed to lookup %q, skipping port change", unitTag)
 			return nil
 		}
 		ranges, ok := newPortRanges[unitd.tag]


### PR DESCRIPTION
## Description of change

Add an prometheus collector for apiserver metrics:
- current connection count
- connection rate (per second)
- connection pause time (ms)
- concurrent login attempts

As a drive by, make logs quieter.
Also tweak the minimum connection pause to 0 - a pause
will only start after reaching the (default) lower threshold of 1000 conns/sec.

## QA steps

bootstrap
ssh into controller
juju-introspect metrics

## Documentation changes

Not really - the general introspection command is documented.

## Bug reference

Fixes some bugs about log noise
https://bugs.launchpad.net/juju/+bug/1695853
https://bugs.launchpad.net/juju/+bug/1695851
