### PR TITLE
Revert "Use random apiserver address when dialing"

### DIFF
--- a/worker/apicaller/connect.go
+++ b/worker/apicaller/connect.go
@@ -4,7 +4,6 @@
 package apicaller
 
 import (
-	"math/rand"
 	"time"
 
 	"github.com/juju/errors"
@@ -59,15 +58,6 @@ func OnlyConnect(a agent.Agent, apiOpen api.OpenFunc) (api.Connection, error) {
 	return conn, nil
 }
 
-func shuffleAddresses(addr []string, r *rand.Rand) []string {
-	result := make([]string, len(addr))
-	perm := r.Perm(len(addr))
-	for i, v := range perm {
-		result[v] = addr[i]
-	}
-	return result
-}
-
 // connectFallback opens an API connection using the supplied info,
 // or a copy using the fallbackPassword; blocks for up to 5 minutes
 // if it encounters a CodeNotProvisioned error, periodically retrying;
@@ -93,18 +83,12 @@ func connectFallback(
 	conn api.Connection, didFallback bool, err error,
 ) {
 
-	infoCopy := *info
-	if len(infoCopy.Addrs) > 1 {
-		src := rand.NewSource(time.Now().UnixNano())
-		infoCopy.Addrs = shuffleAddresses(info.Addrs, rand.New(src))
-	}
-
 	// We expect to assign to `conn`, `err`, *and* `info` in
 	// the course of this operation: wrapping this repeated
 	// atom in a func currently seems to be less treacherous
 	// than the alternatives.
 	var tryConnect = func() {
-		conn, err = apiOpen(&infoCopy, api.DialOpts{
+		conn, err = apiOpen(info, api.DialOpts{
 			Timeout:    time.Second,
 			RetryDelay: 200 * time.Millisecond,
 		})
@@ -125,7 +109,9 @@ func connectFallback(
 	if didFallback {
 		// We've perhaps used the wrong password, so
 		// try again with the fallback password.
-		infoCopy.Password = fallbackPassword
+		infoCopy := *info
+		info = &infoCopy
+		info.Password = fallbackPassword
 		logger.Debugf("connecting with old password")
 		tryConnect()
 	}


### PR DESCRIPTION
Reverts juju/juju#7488

I don't want to introduce a unknown change at this point for 2.2. Let's push this into 2.2.1 and get metrics around if it's even useful or not. As it stands, it seems like HA doesn't like this; it fails to re-elect leader in event of failure.