### PR TITLE
Add a prometheus collectior for api metrics

### DIFF
--- a/apiserver/admin.go
+++ b/apiserver/admin.go
@@ -5,6 +5,7 @@ package apiserver
 
 import (
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/juju/errors"
@@ -86,6 +87,12 @@ func (a *admin) login(req params.LoginRequest, loginVersion int) (params.LoginRe
 		var err error
 		kind, err = names.TagKind(req.AuthTag)
 		if err != nil || kind != names.UserTagKind {
+			addCount := func(delta int64) {
+				atomic.AddInt64(&a.srv.loginAttempts, delta)
+			}
+			addCount(1)
+			defer addCount(-1)
+
 			isUser = false
 			// Users are not rate limited, all other entities are.
 			if !a.srv.limiter.Acquire() {

--- a/apiserver/apiservermetrics.go
+++ b/apiserver/apiservermetrics.go
@@ -1,0 +1,84 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package apiserver
+
+import (
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const (
+	apiserverMetricsNamespace = "juju_apiserver"
+)
+
+// ServerMetricsSource implementations provide apiserver metrics.
+type ServerMetricsSource interface {
+	TotalConnections() int64
+	ConnectionCount() int64
+	ConcurrentLoginAttempts() int64
+	ConnectionPauseTime() time.Duration
+}
+
+// Collector is a prometheus.Collector that collects metrics based
+// on apiserver status.
+type Collector struct {
+	src ServerMetricsSource
+
+	connectionCounter        prometheus.Counter
+	connectionCountGauge     prometheus.Gauge
+	connectionPauseTimeGauge prometheus.Gauge
+	concurrentLoginsGauge    prometheus.Gauge
+}
+
+// NewMetricsCollector returns a new Collector.
+func NewMetricsCollector(src ServerMetricsSource) *Collector {
+	return &Collector{
+		src: src,
+		connectionCounter: prometheus.NewCounter(prometheus.CounterOpts{
+			Namespace: apiserverMetricsNamespace,
+			Name:      "connections_total",
+			Help:      "Total number of apiserver connections ever made",
+		}),
+		connectionCountGauge: prometheus.NewGauge(prometheus.GaugeOpts{
+			Namespace: apiserverMetricsNamespace,
+			Name:      "connection_count",
+			Help:      "Current number of active apiserver connections",
+		}),
+		connectionPauseTimeGauge: prometheus.NewGauge(prometheus.GaugeOpts{
+			Namespace: apiserverMetricsNamespace,
+			Name:      "connection_pause_seconds",
+			Help:      "Current wait time in before accepting incoming connections",
+		}),
+		concurrentLoginsGauge: prometheus.NewGauge(prometheus.GaugeOpts{
+			Namespace: apiserverMetricsNamespace,
+			Name:      "active_login_attempts",
+			Help:      "Current number of active agent login attempts",
+		}),
+	}
+}
+
+// Describe is part of the prometheus.Collector interface.
+func (c *Collector) Describe(ch chan<- *prometheus.Desc) {
+	c.connectionCounter.Describe(ch)
+	c.connectionCountGauge.Describe(ch)
+	c.connectionPauseTimeGauge.Describe(ch)
+	c.concurrentLoginsGauge.Describe(ch)
+}
+
+// Collect is part of the prometheus.Collector interface.
+func (c *Collector) Collect(ch chan<- prometheus.Metric) {
+	c.connectionCountGauge.Set(float64(c.src.ConnectionCount()))
+	c.connectionPauseTimeGauge.Set(float64(c.src.ConnectionPauseTime()) / float64(time.Second))
+	c.concurrentLoginsGauge.Set(float64(c.src.ConcurrentLoginAttempts()))
+
+	ch <- prometheus.MustNewConstMetric(
+		c.connectionCounter.Desc(),
+		prometheus.CounterValue,
+		float64(c.src.TotalConnections()),
+	)
+	c.connectionCountGauge.Collect(ch)
+	c.connectionPauseTimeGauge.Collect(ch)
+	c.concurrentLoginsGauge.Collect(ch)
+}

--- a/apiserver/apiservermetrics_test.go
+++ b/apiserver/apiservermetrics_test.go
@@ -1,0 +1,93 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENSE file for details.
+
+package apiserver_test
+
+import (
+	"time"
+
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/apiserver"
+)
+
+type apiservermetricsSuite struct {
+	testing.IsolationSuite
+	collector prometheus.Collector
+}
+
+var _ = gc.Suite(&apiservermetricsSuite{})
+
+func (s *apiservermetricsSuite) SetUpTest(c *gc.C) {
+	s.IsolationSuite.SetUpTest(c)
+	s.collector = apiserver.NewMetricsCollector(&stubCollector{})
+}
+
+func (s *apiservermetricsSuite) TestDescribe(c *gc.C) {
+	ch := make(chan *prometheus.Desc)
+	go func() {
+		defer close(ch)
+		s.collector.Describe(ch)
+	}()
+	var descs []*prometheus.Desc
+	for desc := range ch {
+		descs = append(descs, desc)
+	}
+	c.Assert(descs, gc.HasLen, 4)
+	c.Assert(descs[0].String(), gc.Matches, `.*fqName: "juju_apiserver_connections_total".*`)
+	c.Assert(descs[1].String(), gc.Matches, `.*fqName: "juju_apiserver_connection_count".*`)
+	c.Assert(descs[2].String(), gc.Matches, `.*fqName: "juju_apiserver_connection_pause_seconds".*`)
+	c.Assert(descs[3].String(), gc.Matches, `.*fqName: "juju_apiserver_active_login_attempts".*`)
+}
+
+func (s *apiservermetricsSuite) TestCollect(c *gc.C) {
+	ch := make(chan prometheus.Metric)
+	go func() {
+		defer close(ch)
+		s.collector.Collect(ch)
+	}()
+
+	var metrics []prometheus.Metric
+	for metric := range ch {
+		metrics = append(metrics, metric)
+	}
+	c.Assert(metrics, gc.HasLen, 4)
+
+	var dtoMetrics [4]dto.Metric
+	for i, metric := range metrics {
+		err := metric.Write(&dtoMetrics[i])
+		c.Assert(err, jc.ErrorIsNil)
+	}
+
+	float64ptr := func(v float64) *float64 {
+		return &v
+	}
+	c.Assert(dtoMetrics, jc.DeepEquals, [4]dto.Metric{
+		{Counter: &dto.Counter{Value: float64ptr(200)}},
+		{Gauge: &dto.Gauge{Value: float64ptr(2)}},
+		{Gauge: &dto.Gauge{Value: float64ptr(0.02)}},
+		{Gauge: &dto.Gauge{Value: float64ptr(3)}},
+	})
+}
+
+type stubCollector struct{}
+
+func (a *stubCollector) TotalConnections() int64 {
+	return 200
+}
+
+func (a *stubCollector) ConnectionCount() int64 {
+	return 2
+}
+
+func (a *stubCollector) ConcurrentLoginAttempts() int64 {
+	return 3
+}
+
+func (a *stubCollector) ConnectionPauseTime() time.Duration {
+	return 20 * time.Millisecond
+}

--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -1293,6 +1293,7 @@ func (a *MachineAgent) newAPIserverWorker(
 		StatePool:                     statePool,
 		RegisterIntrospectionHandlers: registerIntrospectionHandlers,
 		RateLimitConfig:               rateLimitConfig,
+		PrometheusRegisterer:          a.prometheusRegistry,
 	})
 	if err != nil {
 		return nil, errors.Annotate(err, "cannot start api server worker")


### PR DESCRIPTION
Merge pull request #7487 but with a fix for metrics registration when the api server is restarted if an error occurs.

Add a prometheus collectior for api metrics

Add an prometheus collector for apiserver metrics:
- current connection count
- connection rate (per second)
- connection pause time (ms)
- concurrent login attempts

bootstrap
ssh into controller
juju-introspect metrics

