### PR TITLE
Make the hostsPortsEquals function agnostic to the order.

### DIFF
--- a/state/address_internal_test.go
+++ b/state/address_internal_test.go
@@ -1,0 +1,123 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package state
+
+import (
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/network"
+)
+
+type AddressEqualitySuite struct{}
+
+var _ = gc.Suite(&AddressEqualitySuite{})
+
+func (*AddressEqualitySuite) TestHostPortsEqual(c *gc.C) {
+	first := [][]network.HostPort{
+		{
+			{
+				Address: network.Address{
+					Value: "10.144.9.113",
+					Type:  "ipv4",
+					Scope: "local-cloud",
+				},
+				Port: 17070,
+			}, {
+				Address: network.Address{
+					Value: "127.0.0.1",
+					Type:  "ipv4",
+					Scope: "local-machine",
+				},
+				Port: 17070,
+			},
+		}, {
+			{
+				Address: network.Address{
+					Value: "10.144.9.62",
+					Type:  "ipv4",
+					Scope: "local-cloud",
+				},
+				Port: 17070,
+			}, {
+				Address: network.Address{
+					Value: "127.0.0.1",
+					Type:  "ipv4",
+					Scope: "local-machine",
+				},
+				Port: 17070,
+			},
+		}, {
+			{
+				Address: network.Address{
+					Value: "10.144.9.56",
+					Type:  "ipv4",
+					Scope: "local-cloud",
+				},
+				Port: 17070,
+			}, {
+				Address: network.Address{
+					Value: "127.0.0.1",
+					Type:  "ipv4",
+					Scope: "local-machine",
+				},
+				Port: 17070,
+			},
+		},
+	}
+	// second is the same as first with the first set of machines at the
+	// end rather than the start.
+	second := [][]network.HostPort{
+		{
+			{
+				Address: network.Address{
+					Value: "10.144.9.62",
+					Type:  "ipv4",
+					Scope: "local-cloud",
+				},
+				Port: 17070,
+			}, {
+				Address: network.Address{
+					Value: "127.0.0.1",
+					Type:  "ipv4",
+					Scope: "local-machine",
+				},
+				Port: 17070,
+			},
+		}, {
+			{
+				Address: network.Address{
+					Value: "10.144.9.56",
+					Type:  "ipv4",
+					Scope: "local-cloud",
+				},
+				Port: 17070,
+			}, {
+				Address: network.Address{
+					Value: "127.0.0.1",
+					Type:  "ipv4",
+					Scope: "local-machine",
+				},
+				Port: 17070,
+			},
+		}, {
+			{
+				Address: network.Address{
+					Value: "10.144.9.113",
+					Type:  "ipv4",
+					Scope: "local-cloud",
+				},
+				Port: 17070,
+			}, {
+				Address: network.Address{
+					Value: "127.0.0.1",
+					Type:  "ipv4",
+					Scope: "local-machine",
+				},
+				Port: 17070,
+			},
+		},
+	}
+	c.Assert(hostsPortsEqual(first, second), jc.IsTrue)
+}


### PR DESCRIPTION
## Description of change

Periodially the peergrouper tries to update the api host ports. This was causing churn on the apiHostPorts doc in the controllers collection when there was no need. When the apiHostPorts docs change, every proxy worker, every uniter, and every agent host port update worker wake up and ask for info. This introduces much churn when there are thousands of agents.

## QA steps

Unit tests.

## Documentation changes

No visible changes.
