### PR TITLE
Bump juju/txn dep to get pruning nil handling fix

### DIFF
--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -46,7 +46,7 @@ github.com/juju/romulus	git	eede3e29dd7784b7265bb2cc175eca35420d37e7	2017-05-19T
 github.com/juju/schema	git	075de04f9b7d7580d60a1e12a0b3f50bb18e6998	2016-04-20T04:42:03Z
 github.com/juju/terms-client	git	9b925afd677234e4146dde3cb1a11e187cbed64e	2016-08-09T13:19:00Z
 github.com/juju/testing	git	2fe0e88cf2321d801acedd2b4f0d7f63735fb732	2017-06-08T05:44:51Z
-github.com/juju/txn	git	941c396af5296a396a375bd88549552bd7a40dcd	2017-05-16T04:42:59Z
+github.com/juju/txn	git	dbb63c620814d1a0f96260f4cad3e2cca14f702b	2017-06-13T23:44:54Z
 github.com/juju/usso	git	68a59c96c178fbbad65926e7f93db50a2cd14f33	2016-04-01T10:44:24Z
 github.com/juju/utils	git	61a75f1933a523d7f9d38bc5b1bf2010f1c157c3	2017-06-07T09:20:57Z
 github.com/juju/version	git	1f41e27e54f21acccf9b2dddae063a782a8a7ceb	2016-10-31T05:19:06Z


### PR DESCRIPTION
## Description of change

This updates Juju's juju/txn dependency to include a bug fix for a unhandled nil.

## QA steps

Unit tests still pass.

## Documentation changes

N.A.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1697795
