### PR TITLE
Buffer mongo log record insertions

### DIFF
--- a/apiserver/applicationoffers/state.go
+++ b/apiserver/applicationoffers/state.go
@@ -29,9 +29,12 @@ type statePoolShim struct {
 }
 
 func (pool statePoolShim) Get(modelUUID string) (Backend, func(), error) {
-	st, closer, err := pool.StatePool.Get(modelUUID)
+	st, releaser, err := pool.StatePool.Get(modelUUID)
 	if err != nil {
 		return nil, nil, errors.Trace(err)
+	}
+	closer := func() {
+		releaser()
 	}
 	return &stateShim{st}, closer, nil
 }

--- a/apiserver/charms.go
+++ b/apiserver/charms.go
@@ -76,7 +76,7 @@ func (h *CharmsHTTPHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 type charmsHandler struct {
 	ctxt          httpContext
 	dataDir       string
-	stateAuthFunc func(*http.Request) (*state.State, func(), error)
+	stateAuthFunc func(*http.Request) (*state.State, state.StatePoolReleaser, error)
 }
 
 // bundleContentSenderFunc functions are responsible for sending a

--- a/apiserver/debuglog.go
+++ b/apiserver/debuglog.go
@@ -32,7 +32,7 @@ type debugLogHandler struct {
 
 type debugLogHandlerFunc func(
 	state.LogTailerState,
-	*debugLogParams,
+	debugLogParams,
 	debugLogSocket,
 	<-chan struct{},
 ) error
@@ -156,13 +156,13 @@ type debugLogParams struct {
 	excludeModule []string
 }
 
-func readDebugLogParams(queryMap url.Values) (*debugLogParams, error) {
-	params := new(debugLogParams)
+func readDebugLogParams(queryMap url.Values) (debugLogParams, error) {
+	var params debugLogParams
 
 	if value := queryMap.Get("maxLines"); value != "" {
 		num, err := strconv.ParseUint(value, 10, 64)
 		if err != nil {
-			return nil, errors.Errorf("maxLines value %q is not a valid unsigned number", value)
+			return params, errors.Errorf("maxLines value %q is not a valid unsigned number", value)
 		}
 		params.maxLines = uint(num)
 	}
@@ -170,7 +170,7 @@ func readDebugLogParams(queryMap url.Values) (*debugLogParams, error) {
 	if value := queryMap.Get("replay"); value != "" {
 		replay, err := strconv.ParseBool(value)
 		if err != nil {
-			return nil, errors.Errorf("replay value %q is not a valid boolean", value)
+			return params, errors.Errorf("replay value %q is not a valid boolean", value)
 		}
 		params.fromTheStart = replay
 	}
@@ -178,7 +178,7 @@ func readDebugLogParams(queryMap url.Values) (*debugLogParams, error) {
 	if value := queryMap.Get("noTail"); value != "" {
 		noTail, err := strconv.ParseBool(value)
 		if err != nil {
-			return nil, errors.Errorf("noTail value %q is not a valid boolean", value)
+			return params, errors.Errorf("noTail value %q is not a valid boolean", value)
 		}
 		params.noTail = noTail
 	}
@@ -186,7 +186,7 @@ func readDebugLogParams(queryMap url.Values) (*debugLogParams, error) {
 	if value := queryMap.Get("backlog"); value != "" {
 		num, err := strconv.ParseUint(value, 10, 64)
 		if err != nil {
-			return nil, errors.Errorf("backlog value %q is not a valid unsigned number", value)
+			return params, errors.Errorf("backlog value %q is not a valid unsigned number", value)
 		}
 		params.backlog = uint(num)
 	}
@@ -195,7 +195,7 @@ func readDebugLogParams(queryMap url.Values) (*debugLogParams, error) {
 		var ok bool
 		level, ok := loggo.ParseLevel(value)
 		if !ok || level < loggo.TRACE || level > loggo.ERROR {
-			return nil, errors.Errorf("level value %q is not one of %q, %q, %q, %q, %q",
+			return params, errors.Errorf("level value %q is not one of %q, %q, %q, %q, %q",
 				value, loggo.TRACE, loggo.DEBUG, loggo.INFO, loggo.WARNING, loggo.ERROR)
 		}
 		params.filterLevel = level
@@ -204,7 +204,7 @@ func readDebugLogParams(queryMap url.Values) (*debugLogParams, error) {
 	if value := queryMap.Get("startTime"); value != "" {
 		startTime, err := time.Parse(time.RFC3339Nano, value)
 		if err != nil {
-			return nil, errors.Errorf("start time %q is not a valid time in RFC3339 format", value)
+			return params, errors.Errorf("start time %q is not a valid time in RFC3339 format", value)
 		}
 		params.startTime = startTime
 	}

--- a/apiserver/debuglog_db.go
+++ b/apiserver/debuglog_db.go
@@ -18,7 +18,7 @@ func newDebugLogDBHandler(ctxt httpContext) http.Handler {
 
 func handleDebugLogDBRequest(
 	st state.LogTailerState,
-	reqParams *debugLogParams,
+	reqParams debugLogParams,
 	socket debugLogSocket,
 	stop <-chan struct{},
 ) error {
@@ -54,8 +54,8 @@ func handleDebugLogDBRequest(
 	}
 }
 
-func makeLogTailerParams(reqParams *debugLogParams) *state.LogTailerParams {
-	params := &state.LogTailerParams{
+func makeLogTailerParams(reqParams debugLogParams) state.LogTailerParams {
+	params := state.LogTailerParams{
 		MinLevel:      reqParams.filterLevel,
 		NoTail:        reqParams.noTail,
 		StartTime:     reqParams.startTime,
@@ -84,6 +84,6 @@ func formatLogRecord(r *state.LogRecord) *params.LogMessage {
 
 var newLogTailer = _newLogTailer // For replacing in tests
 
-func _newLogTailer(st state.LogTailerState, params *state.LogTailerParams) (state.LogTailer, error) {
+func _newLogTailer(st state.LogTailerState, params state.LogTailerParams) (state.LogTailer, error) {
 	return state.NewLogTailer(st, params)
 }

--- a/apiserver/logsink.go
+++ b/apiserver/logsink.go
@@ -23,7 +23,7 @@ type agentLoggingStrategy struct {
 	fileLogger io.Writer
 
 	st         *state.State
-	releaser   func()
+	releaser   state.StatePoolReleaser
 	version    version.Number
 	entity     names.Tag
 	filePrefix string

--- a/apiserver/logsink.go
+++ b/apiserver/logsink.go
@@ -75,7 +75,7 @@ func (s *agentLoggingStrategy) init(ctxt httpContext, req *http.Request) error {
 // WriteLog is part of the logsink.LogWriteCloser interface.
 func (s *agentLoggingStrategy) WriteLog(m params.LogRecord) error {
 	level, _ := loggo.ParseLevel(m.Level)
-	dbErr := errors.Annotate(s.dbLogger.Log(state.LogRecord{
+	dbErr := errors.Annotate(s.dbLogger.Log([]state.LogRecord{{
 		Time:     m.Time,
 		Entity:   s.entity,
 		Version:  s.version,
@@ -83,7 +83,7 @@ func (s *agentLoggingStrategy) WriteLog(m params.LogRecord) error {
 		Location: m.Location,
 		Level:    level,
 		Message:  m.Message,
-	}), "logging to DB failed")
+	}}), "logging to DB failed")
 
 	m.Entity = s.entity.String()
 	fileErr := errors.Annotate(

--- a/apiserver/logsink.go
+++ b/apiserver/logsink.go
@@ -7,27 +7,105 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
+	"github.com/juju/utils/clock"
 	"github.com/juju/version"
 	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/apiserver/logsink"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/state"
+	"github.com/juju/juju/state/logdb"
+)
+
+const (
+	// dbLoggerBufferSize is the capacity of the log buffer.
+	// When the buffer fills up, it will be flushed to the
+	// database.
+	dbLoggerBufferSize = 1024
+
+	// dbLoggerFlushInterval is the amount of time to allow
+	// a log record to sit in the buffer before being flushed
+	// to the database.
+	dbLoggerFlushInterval = 2 * time.Second
 )
 
 type agentLoggingStrategy struct {
+	dbloggers  *dbloggers
 	fileLogger io.Writer
 
-	st         *state.State
-	releaser   state.StatePoolReleaser
+	dblogger   recordLogger
+	releaser   func()
 	version    version.Number
 	entity     names.Tag
 	filePrefix string
-	dbLogger   *state.DbLogger
+}
+
+type recordLogger interface {
+	Log([]state.LogRecord) error
+}
+
+// dbloggers contains a map of buffered DB loggers. When one of the
+// logging strategies requires a DB logger, it uses this to get it.
+// When the State corresponding to the DB logger is removed from the
+// state pool, the strategies must call the dbloggers.remove method.
+type dbloggers struct {
+	clock   clock.Clock
+	mu      sync.Mutex
+	loggers map[*state.State]*bufferedDbLogger
+}
+
+func (d *dbloggers) get(st *state.State) recordLogger {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if l, ok := d.loggers[st]; ok {
+		return l
+	}
+	if d.loggers == nil {
+		d.loggers = make(map[*state.State]*bufferedDbLogger)
+	}
+	dbl := state.NewDbLogger(st)
+	l := &bufferedDbLogger{dbl, logdb.NewBufferedLogger(
+		dbl,
+		dbLoggerBufferSize,
+		dbLoggerFlushInterval,
+		d.clock,
+	)}
+	d.loggers[st] = l
+	return l
+}
+
+func (d *dbloggers) remove(st *state.State) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if l, ok := d.loggers[st]; ok {
+		l.Close()
+		delete(d.loggers, st)
+	}
+}
+
+// dispose closes all dbloggers in the map, and clears the memory. This
+// must not be called concurrently with any other dbloggers methods.
+func (d *dbloggers) dispose() {
+	for _, l := range d.loggers {
+		l.Close()
+	}
+	d.loggers = nil
+}
+
+type bufferedDbLogger struct {
+	dbl *state.DbLogger
+	*logdb.BufferedLogger
+}
+
+func (b *bufferedDbLogger) Close() error {
+	err := errors.Trace(b.Flush())
+	b.dbl.Close()
+	return err
 }
 
 // newAgentLogWriteCloserFunc returns a function that will create a
@@ -36,9 +114,13 @@ type agentLoggingStrategy struct {
 func newAgentLogWriteCloserFunc(
 	ctxt httpContext,
 	fileLogger io.Writer,
+	dbloggers *dbloggers,
 ) logsink.NewLogWriteCloserFunc {
 	return func(req *http.Request) (logsink.LogWriteCloser, error) {
-		strategy := &agentLoggingStrategy{fileLogger: fileLogger}
+		strategy := &agentLoggingStrategy{
+			dbloggers:  dbloggers,
+			fileLogger: fileLogger,
+		}
 		if err := strategy.init(ctxt, req); err != nil {
 			return nil, errors.Annotate(err, "initialising agent logsink session")
 		}
@@ -47,7 +129,7 @@ func newAgentLogWriteCloserFunc(
 }
 
 func (s *agentLoggingStrategy) init(ctxt httpContext, req *http.Request) error {
-	st, releaser, entity, err := ctxt.stateForRequestAuthenticatedAgent(req)
+	st, releaseState, entity, err := ctxt.stateForRequestAuthenticatedAgent(req)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -61,21 +143,35 @@ func (s *agentLoggingStrategy) init(ctxt httpContext, req *http.Request) error {
 	// address this caveat appropriately.
 	ver, err := logsink.JujuClientVersionFromRequest(req)
 	if err != nil {
-		releaser()
+		releaseState()
 		return errors.Trace(err)
 	}
-	s.releaser = releaser
 	s.version = ver
 	s.entity = entity.Tag()
 	s.filePrefix = st.ModelUUID() + ":"
-	s.dbLogger = state.NewDbLogger(st)
+	s.dblogger = s.dbloggers.get(st)
+	s.releaser = func() {
+		if removed := releaseState(); removed {
+			s.dbloggers.remove(st)
+		}
+	}
+	return nil
+}
+
+// Close is part of the logsink.LogWriteCloser interface.
+//
+// Close releases the StatePool entry, closing the DB logger
+// if the State is closed/removed. The file logger is owned
+// by the apiserver, so it is not closed.
+func (s *agentLoggingStrategy) Close() error {
+	s.releaser()
 	return nil
 }
 
 // WriteLog is part of the logsink.LogWriteCloser interface.
 func (s *agentLoggingStrategy) WriteLog(m params.LogRecord) error {
 	level, _ := loggo.ParseLevel(m.Level)
-	dbErr := errors.Annotate(s.dbLogger.Log([]state.LogRecord{{
+	dbErr := errors.Annotate(s.dblogger.Log([]state.LogRecord{{
 		Time:     m.Time,
 		Entity:   s.entity,
 		Version:  s.version,
@@ -111,13 +207,4 @@ func logToFile(writer io.Writer, prefix string, m params.LogRecord) error {
 		m.Message,
 	}, " ") + "\n"))
 	return err
-}
-
-// Close is part of the logsink.LogWriteCloser interface. Close closes
-// the DB logger and releases the state. It doesn't close the file logger
-// because that lives longer than one request.
-func (s *agentLoggingStrategy) Close() error {
-	s.dbLogger.Close()
-	s.releaser()
-	return nil
 }

--- a/apiserver/logstream.go
+++ b/apiserver/logstream.go
@@ -20,7 +20,7 @@ import (
 
 type logStreamSource interface {
 	getStart(sink string) (time.Time, error)
-	newTailer(*state.LogTailerParams) (state.LogTailer, error)
+	newTailer(state.LogTailerParams) (state.LogTailer, error)
 }
 
 type messageWriter interface {
@@ -125,7 +125,7 @@ func (h *logStreamEndpointHandler) newTailer(source logStreamSource, cfg params.
 		}
 	}
 
-	tailerArgs := &state.LogTailerParams{
+	tailerArgs := state.LogTailerParams{
 		StartTime:    start,
 		InitialLines: cfg.MaxLookbackRecords,
 	}
@@ -175,7 +175,7 @@ func (st logStreamState) getStart(sink string) (time.Time, error) {
 	return time.Unix(0, lastSentTimestamp), nil
 }
 
-func (st logStreamState) newTailer(args *state.LogTailerParams) (state.LogTailer, error) {
+func (st logStreamState) newTailer(args state.LogTailerParams) (state.LogTailer, error) {
 	tailer, err := state.NewLogTailer(st, args)
 	if err != nil {
 		return nil, errors.Trace(err)

--- a/apiserver/logstream_test.go
+++ b/apiserver/logstream_test.go
@@ -254,14 +254,15 @@ type stubSource struct {
 	ReturnNewTailer state.LogTailer
 }
 
-func (s *stubSource) newSource(req *http.Request) (logStreamSource, closerFunc, error) {
+func (s *stubSource) newSource(req *http.Request) (logStreamSource, state.StatePoolReleaser, error) {
 	s.stub.AddCall("newSource", req)
 	if err := s.stub.NextErr(); err != nil {
 		return nil, nil, errors.Trace(err)
 	}
 
-	closer := func() {
+	closer := func() bool {
 		s.stub.AddCall("close")
+		return false
 	}
 	return s, closer, nil
 }

--- a/apiserver/logstream_test.go
+++ b/apiserver/logstream_test.go
@@ -53,7 +53,7 @@ func (s *LogStreamIntSuite) TestParamConversion(c *gc.C) {
 
 	stub.CheckCallNames(c, "newSource", "getStart", "newTailer")
 	stub.CheckCall(c, 1, "getStart", "spam")
-	stub.CheckCall(c, 2, "newTailer", &state.LogTailerParams{
+	stub.CheckCall(c, 2, "newTailer", state.LogTailerParams{
 		StartTime:    time.Unix(10, 0),
 		InitialLines: 100,
 	})
@@ -91,7 +91,7 @@ func (s *LogStreamIntSuite) TestParamStartTruncate(c *gc.C) {
 
 	stub.CheckCallNames(c, "newSource", "getStart", "newTailer")
 	stub.CheckCall(c, 1, "getStart", "spam")
-	stub.CheckCall(c, 2, "newTailer", &state.LogTailerParams{
+	stub.CheckCall(c, 2, "newTailer", state.LogTailerParams{
 		StartTime: now.Add(-2 * time.Hour),
 	})
 }
@@ -275,7 +275,7 @@ func (s *stubSource) getStart(sink string) (time.Time, error) {
 	return time.Unix(s.ReturnGetStart, 0), nil
 }
 
-func (s *stubSource) newTailer(args *state.LogTailerParams) (state.LogTailer, error) {
+func (s *stubSource) newTailer(args state.LogTailerParams) (state.LogTailer, error) {
 	s.stub.AddCall("newTailer", args)
 	if err := s.stub.NextErr(); err != nil {
 		return nil, errors.Trace(err)

--- a/apiserver/logtransfer.go
+++ b/apiserver/logtransfer.go
@@ -18,7 +18,7 @@ import (
 
 type migrationLoggingStrategy struct {
 	st         *state.State
-	releaser   func()
+	releaser   state.StatePoolReleaser
 	filePrefix string
 	dbLogger   *state.DbLogger
 	tracker    *logTracker

--- a/apiserver/logtransfer.go
+++ b/apiserver/logtransfer.go
@@ -17,19 +17,19 @@ import (
 )
 
 type migrationLoggingStrategy struct {
-	st         *state.State
-	releaser   state.StatePoolReleaser
-	filePrefix string
-	dbLogger   *state.DbLogger
-	tracker    *logTracker
+	dbloggers *dbloggers
+
+	dblogger recordLogger
+	releaser func()
+	tracker  *logTracker
 }
 
 // newMigrationLogWriteCloserFunc returns a function that will create a
 // logsink.LoggingStrategy given an *http.Request, that writes log
 // messages to the state database and tracks their migration.
-func newMigrationLogWriteCloserFunc(ctxt httpContext) logsink.NewLogWriteCloserFunc {
+func newMigrationLogWriteCloserFunc(ctxt httpContext, dbloggers *dbloggers) logsink.NewLogWriteCloserFunc {
 	return func(req *http.Request) (logsink.LogWriteCloser, error) {
-		strategy := &migrationLoggingStrategy{}
+		strategy := &migrationLoggingStrategy{dbloggers: dbloggers}
 		if err := strategy.init(ctxt, req); err != nil {
 			return nil, errors.Annotate(err, "initialising migration logsink session")
 		}
@@ -40,7 +40,7 @@ func newMigrationLogWriteCloserFunc(ctxt httpContext) logsink.NewLogWriteCloserF
 func (s *migrationLoggingStrategy) init(ctxt httpContext, req *http.Request) error {
 	// Require MigrationModeNone because logtransfer happens after the
 	// model proper is completely imported.
-	st, releaser, err := ctxt.stateForMigration(req, state.MigrationModeNone)
+	st, releaseState, err := ctxt.stateForMigration(req, state.MigrationModeNone)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -53,15 +53,28 @@ func (s *migrationLoggingStrategy) init(ctxt httpContext, req *http.Request) err
 	// conversion of log messages from an old client.
 	_, err = logsink.JujuClientVersionFromRequest(req)
 	if err != nil {
-		releaser()
+		releaseState()
 		return errors.Trace(err)
 	}
 
-	s.releaser = releaser
-	s.filePrefix = st.ModelUUID() + ":"
-	s.dbLogger = state.NewDbLogger(st)
+	s.dblogger = s.dbloggers.get(st)
 	s.tracker = newLogTracker(st)
+	s.releaser = func() {
+		if removed := releaseState(); removed {
+			s.dbloggers.remove(st)
+		}
+	}
 	return nil
+}
+
+// Close is part of the logsink.LogWriteCloser interface.
+func (s *migrationLoggingStrategy) Close() error {
+	err := errors.Annotate(
+		s.tracker.Close(),
+		"closing last-sent tracker",
+	)
+	s.releaser()
+	return err
 }
 
 // WriteLog is part of the logsink.LogWriteCloser interface.
@@ -75,7 +88,7 @@ func (s *migrationLoggingStrategy) WriteLog(m params.LogRecord) error {
 			return errors.Annotate(err, "parsing entity from log record")
 		}
 	}
-	err := s.dbLogger.Log([]state.LogRecord{{
+	err := s.dblogger.Log([]state.LogRecord{{
 		Time:     m.Time,
 		Entity:   entity,
 		Module:   m.Module,
@@ -89,18 +102,16 @@ func (s *migrationLoggingStrategy) WriteLog(m params.LogRecord) error {
 	return errors.Annotate(err, "logging to DB failed")
 }
 
-// Close is part of the logsink.LogWriteCloser interface.
-func (s *migrationLoggingStrategy) Close() error {
-	s.dbLogger.Close()
-	s.tracker.Close()
-	s.releaser()
-	return nil
-}
-
+// trackingPeriod is used to limit the number of database writes
+// made in order to record the ID of the log record last persisted.
 const trackingPeriod = 2 * time.Minute
 
 func newLogTracker(st *state.State) *logTracker {
-	return &logTracker{tracker: state.NewLastSentLogTracker(st, st.ModelUUID(), "migration-logtransfer")}
+	return &logTracker{
+		tracker: state.NewLastSentLogTracker(
+			st, st.ModelUUID(), "migration-logtransfer",
+		),
+	}
 }
 
 // logTracker assumes that log messages are sent in time order (which

--- a/apiserver/logtransfer.go
+++ b/apiserver/logtransfer.go
@@ -75,14 +75,14 @@ func (s *migrationLoggingStrategy) WriteLog(m params.LogRecord) error {
 			return errors.Annotate(err, "parsing entity from log record")
 		}
 	}
-	err := s.dbLogger.Log(state.LogRecord{
+	err := s.dbLogger.Log([]state.LogRecord{{
 		Time:     m.Time,
 		Entity:   entity,
 		Module:   m.Module,
 		Location: m.Location,
 		Level:    level,
 		Message:  m.Message,
-	})
+	}})
 	if err == nil {
 		err = s.tracker.Track(m.Time)
 	}

--- a/apiserver/modelmanager/modelmanager.go
+++ b/apiserver/modelmanager/modelmanager.go
@@ -114,7 +114,10 @@ type statePool struct {
 // Get implements StatePool.
 func (p *statePool) Get(modelUUID string) (common.ModelManagerBackend, func(), error) {
 	st, releaser, err := p.pool.Get(modelUUID)
-	return common.NewModelManagerBackend(st), releaser, err
+	closer := func() {
+		releaser()
+	}
+	return common.NewModelManagerBackend(st), closer, err
 }
 
 // NewModelManagerAPI creates a new api server endpoint for managing

--- a/apiserver/remoterelations/state.go
+++ b/apiserver/remoterelations/state.go
@@ -194,9 +194,12 @@ type statePoolShim struct {
 }
 
 func (pool statePoolShim) Get(modelUUID string) (RemoteRelationsState, func(), error) {
-	st, closer, err := pool.StatePool.Get(modelUUID)
+	st, releaser, err := pool.StatePool.Get(modelUUID)
 	if err != nil {
 		return nil, nil, errors.Trace(err)
+	}
+	closer := func() {
+		releaser()
 	}
 	return stateShim{st}, closer, nil
 }

--- a/apiserver/resources.go
+++ b/apiserver/resources.go
@@ -18,6 +18,7 @@ import (
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/resource"
 	"github.com/juju/juju/resource/api"
+	"github.com/juju/juju/state"
 )
 
 // ResourcesBackend is the functionality of Juju's state needed for the resources API.
@@ -41,7 +42,7 @@ type ResourcesBackend interface {
 // ResourcesHandler is the HTTP handler for client downloads and
 // uploads of resources.
 type ResourcesHandler struct {
-	StateAuthFunc func(*http.Request, ...string) (ResourcesBackend, func(), names.Tag, error)
+	StateAuthFunc func(*http.Request, ...string) (ResourcesBackend, state.StatePoolReleaser, names.Tag, error)
 }
 
 // ServeHTTP implements http.Handler.

--- a/apiserver/resources_mig.go
+++ b/apiserver/resources_mig.go
@@ -20,7 +20,7 @@ import (
 // resourcesMigrationUploadHandler handles resources uploads for model migrations.
 type resourcesMigrationUploadHandler struct {
 	ctxt          httpContext
-	stateAuthFunc func(*http.Request) (*state.State, func(), error)
+	stateAuthFunc func(*http.Request) (*state.State, state.StatePoolReleaser, error)
 }
 
 func (h *resourcesMigrationUploadHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {

--- a/apiserver/resources_test.go
+++ b/apiserver/resources_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/juju/juju/resource"
 	"github.com/juju/juju/resource/api"
 	"github.com/juju/juju/resource/resourcetesting"
+	"github.com/juju/juju/state"
 )
 
 type ResourcesHandlerSuite struct {
@@ -61,11 +62,11 @@ func (s *ResourcesHandlerSuite) SetUpTest(c *gc.C) {
 	}
 }
 
-func (s *ResourcesHandlerSuite) authState(req *http.Request, tagKinds ...string) (apiserver.ResourcesBackend, func(), names.Tag, error) {
+func (s *ResourcesHandlerSuite) authState(req *http.Request, tagKinds ...string) (apiserver.ResourcesBackend, state.StatePoolReleaser, names.Tag, error) {
 	if s.stateAuthErr != nil {
 		return nil, nil, nil, errors.Trace(s.stateAuthErr)
 	}
-	closer := func() {}
+	closer := func() bool { return false }
 	tag := names.NewUserTag(s.username)
 	return s.backend, closer, tag, nil
 }

--- a/apiserver/resources_unit.go
+++ b/apiserver/resources_unit.go
@@ -14,12 +14,13 @@ import (
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/resource"
 	"github.com/juju/juju/resource/api"
+	"github.com/juju/juju/state"
 )
 
 // ResourcesHandler is the HTTP handler for unit agent downloads of
 // resources.
 type UnitResourcesHandler struct {
-	NewOpener func(*http.Request, ...string) (resource.Opener, func(), error)
+	NewOpener func(*http.Request, ...string) (resource.Opener, state.StatePoolReleaser, error)
 }
 
 // ServeHTTP implements http.Handler.

--- a/apiserver/resources_unit_test.go
+++ b/apiserver/resources_unit_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/juju/juju/apiserver"
 	"github.com/juju/juju/resource"
 	"github.com/juju/juju/resource/resourcetesting"
+	"github.com/juju/juju/state"
 )
 
 type UnitResourcesHandlerSuite struct {
@@ -41,8 +42,9 @@ func (s *UnitResourcesHandlerSuite) SetUpTest(c *gc.C) {
 	s.recorder = httptest.NewRecorder()
 }
 
-func (s *UnitResourcesHandlerSuite) closer() {
+func (s *UnitResourcesHandlerSuite) closer() bool {
 	s.stub.AddCall("Close")
+	return false
 }
 
 func (s *UnitResourcesHandlerSuite) TestWrongMethod(c *gc.C) {
@@ -60,7 +62,7 @@ func (s *UnitResourcesHandlerSuite) TestWrongMethod(c *gc.C) {
 func (s *UnitResourcesHandlerSuite) TestOpenerCreationError(c *gc.C) {
 	failure, expectedBody := apiFailure("boom", "")
 	handler := &apiserver.UnitResourcesHandler{
-		NewOpener: func(_ *http.Request, kinds ...string) (resource.Opener, func(), error) {
+		NewOpener: func(_ *http.Request, kinds ...string) (resource.Opener, state.StatePoolReleaser, error) {
 			return nil, nil, failure
 		},
 	}
@@ -84,7 +86,7 @@ func (s *UnitResourcesHandlerSuite) TestOpenResourceError(c *gc.C) {
 	failure, expectedBody := apiFailure("boom", "")
 	s.stub.SetErrors(failure)
 	handler := &apiserver.UnitResourcesHandler{
-		NewOpener: func(_ *http.Request, kinds ...string) (resource.Opener, func(), error) {
+		NewOpener: func(_ *http.Request, kinds ...string) (resource.Opener, state.StatePoolReleaser, error) {
 			s.stub.AddCall("NewOpener", kinds)
 			return opener, s.closer, nil
 		},
@@ -111,7 +113,7 @@ func (s *UnitResourcesHandlerSuite) TestSuccess(c *gc.C) {
 		ReturnOpenResource: opened,
 	}
 	handler := &apiserver.UnitResourcesHandler{
-		NewOpener: func(_ *http.Request, kinds ...string) (resource.Opener, func(), error) {
+		NewOpener: func(_ *http.Request, kinds ...string) (resource.Opener, state.StatePoolReleaser, error) {
 			s.stub.AddCall("NewOpener", kinds)
 			return opener, s.closer, nil
 		},

--- a/apiserver/rest.go
+++ b/apiserver/rest.go
@@ -44,7 +44,7 @@ func (h *RestHTTPHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 type modelRestHandler struct {
 	ctxt          httpContext
 	dataDir       string
-	stateAuthFunc func(*http.Request) (*state.State, func(), error)
+	stateAuthFunc func(*http.Request) (*state.State, state.StatePoolReleaser, error)
 }
 
 // ServeGet handles http GET requests.

--- a/apiserver/tools.go
+++ b/apiserver/tools.go
@@ -30,7 +30,7 @@ import (
 // toolsHandler handles tool upload through HTTPS in the API server.
 type toolsUploadHandler struct {
 	ctxt          httpContext
-	stateAuthFunc func(*http.Request) (*state.State, func(), error)
+	stateAuthFunc func(*http.Request) (*state.State, state.StatePoolReleaser, error)
 }
 
 // toolsHandler handles tool download through HTTPS in the API server.

--- a/cmd/jujud/dumplogs/dumplogs.go
+++ b/cmd/jujud/dumplogs/dumplogs.go
@@ -170,7 +170,7 @@ func (c *dumpLogsCommand) dumpLogsForEnv(ctx *cmd.Context, st0 *state.State, tag
 	writer := bufio.NewWriter(file)
 	defer writer.Flush()
 
-	tailer, err := state.NewLogTailer(st, &state.LogTailerParams{NoTail: true})
+	tailer, err := state.NewLogTailer(st, state.LogTailerParams{NoTail: true})
 	if err != nil {
 		return errors.Annotate(err, "failed to create a log tailer")
 	}

--- a/featuretests/cmd_juju_dumplogs_test.go
+++ b/featuretests/cmd_juju_dumplogs_test.go
@@ -51,10 +51,18 @@ func (s *dumpLogsCommandSuite) TestRun(c *gc.C) {
 
 	t := time.Date(2015, 11, 4, 3, 2, 1, 0, time.UTC)
 	for _, st := range states {
-		w := state.NewEntityDbLogger(st, names.NewMachineTag("42"), version.Current)
+		w := state.NewDbLogger(st)
 		defer w.Close()
 		for i := 0; i < 3; i++ {
-			err := w.Log(t, "module", "location", loggo.INFO, fmt.Sprintf("%d", i))
+			err := w.Log([]state.LogRecord{{
+				Time:     t,
+				Entity:   names.NewMachineTag("42"),
+				Version:  version.Current,
+				Module:   "module",
+				Location: "location",
+				Level:    loggo.INFO,
+				Message:  fmt.Sprintf("%d", i),
+			}})
 			c.Assert(err, jc.ErrorIsNil)
 		}
 	}

--- a/state/allwatcher.go
+++ b/state/allwatcher.go
@@ -1399,7 +1399,7 @@ func (b *allModelWatcherStateBacking) idForChange(change watcher.Change) (string
 	return modelUUID, id, nil
 }
 
-func (b *allModelWatcherStateBacking) getState(modelUUID string) (*State, func(), error) {
+func (b *allModelWatcherStateBacking) getState(modelUUID string) (*State, StatePoolReleaser, error) {
 	st, releaser, err := b.stPool.Get(modelUUID)
 	if err != nil {
 		return nil, nil, errors.Trace(err)

--- a/state/logdb/buf.go
+++ b/state/logdb/buf.go
@@ -1,0 +1,107 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package logdb
+
+import (
+	"sync"
+	"time"
+
+	"github.com/juju/errors"
+	"github.com/juju/utils/clock"
+
+	"github.com/juju/juju/state"
+)
+
+// Logger provides an interface for writing log records.
+type Logger interface {
+	// Log writes the given log records to the logger's storage.
+	Log([]state.LogRecord) error
+}
+
+// BufferedLogger wraps a Logger, providing a buffer that
+// accumulates log messages, flushing them to the underlying logger
+// when enough messages have been accumulated.
+type BufferedLogger struct {
+	l             Logger
+	clock         clock.Clock
+	flushInterval time.Duration
+
+	mu         sync.Mutex
+	buf        []state.LogRecord
+	flushTimer clock.Timer
+}
+
+// NewBufferedLogger returns a new BufferedLogger, wrapping the given
+// Logger with a buffer of the specified size and flush interval.
+func NewBufferedLogger(
+	l Logger,
+	bufferSize int,
+	flushInterval time.Duration,
+	clock clock.Clock,
+) *BufferedLogger {
+	return &BufferedLogger{
+		l:             l,
+		buf:           make([]state.LogRecord, 0, bufferSize),
+		clock:         clock,
+		flushInterval: flushInterval,
+	}
+}
+
+// Log is part of the Logger interface.
+//
+// BufferedLogger's Log implementation will buffer log records up to
+// the specified capacity and duration; after either of which is exceeded,
+// the records will be flushed to the underlying logger.
+func (b *BufferedLogger) Log(in []state.LogRecord) error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	for len(in) > 0 {
+		r := cap(b.buf) - len(b.buf)
+		n := len(in)
+		if n > r {
+			n = r
+		}
+		b.buf = append(b.buf, in[:n]...)
+		in = in[n:]
+		if len(b.buf) == cap(b.buf) {
+			if err := b.flush(); err != nil {
+				return errors.Trace(err)
+			}
+		}
+	}
+	if len(b.buf) > 0 && b.flushTimer == nil {
+		b.flushTimer = b.clock.AfterFunc(b.flushInterval, b.flushOnTimer)
+	}
+	return nil
+}
+
+// Flush flushes any buffered log records to the underlying Logger.
+func (b *BufferedLogger) Flush() error {
+	b.mu.Lock()
+	b.mu.Unlock()
+	return b.flush()
+}
+
+func (b *BufferedLogger) flushOnTimer() {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	// Can't do anything about errors here, except to
+	// ignore them and let the Log() method report them
+	// when the buffer fills up.
+	b.flush()
+}
+
+func (b *BufferedLogger) flush() error {
+	if b.flushTimer != nil {
+		b.flushTimer.Stop()
+		b.flushTimer = nil
+	}
+	if len(b.buf) > 0 {
+		if err := b.l.Log(b.buf); err != nil {
+			return errors.Trace(err)
+		}
+		b.buf = b.buf[:0]
+	}
+	return nil
+}

--- a/state/logdb/buf.go
+++ b/state/logdb/buf.go
@@ -64,7 +64,7 @@ func (b *BufferedLogger) Log(in []state.LogRecord) error {
 		}
 		b.buf = append(b.buf, in[:n]...)
 		in = in[n:]
-		if len(b.buf) == cap(b.buf) {
+		if len(b.buf) >= cap(b.buf) {
 			if err := b.flush(); err != nil {
 				return errors.Trace(err)
 			}
@@ -92,6 +92,8 @@ func (b *BufferedLogger) flushOnTimer() {
 	b.flush()
 }
 
+// flush flushes any buffered log records to the underlying Logger, and stops
+// the flush timer if there is one. The caller must be holding b.mu.
 func (b *BufferedLogger) flush() error {
 	if b.flushTimer != nil {
 		b.flushTimer.Stop()

--- a/state/logdb/buf_test.go
+++ b/state/logdb/buf_test.go
@@ -1,0 +1,161 @@
+package logdb_test
+
+import (
+	"errors"
+	"time"
+
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/names.v2"
+
+	"github.com/juju/juju/state"
+	"github.com/juju/juju/state/logdb"
+	coretesting "github.com/juju/juju/testing"
+)
+
+var _ = gc.Suite(&BufferedLoggerSuite{})
+
+type BufferedLoggerSuite struct {
+	testing.IsolationSuite
+
+	mock  mockLogger
+	clock *testing.Clock
+}
+
+func (s *BufferedLoggerSuite) SetUpTest(c *gc.C) {
+	s.IsolationSuite.SetUpTest(c)
+	s.mock = mockLogger{}
+	s.clock = testing.NewClock(time.Time{})
+}
+
+func (s *BufferedLoggerSuite) TestLogFlushes(c *gc.C) {
+	const bufsz = 3
+	b := logdb.NewBufferedLogger(&s.mock, bufsz, time.Minute, s.clock)
+	in := []state.LogRecord{{
+		Entity:  names.NewMachineTag("0"),
+		Message: "foo",
+	}, {
+		Entity:  names.NewMachineTag("0"),
+		Message: "bar",
+	}, {
+		Entity:  names.NewMachineTag("0"),
+		Message: "baz",
+	}}
+
+	err := b.Log(in[:2])
+	c.Assert(err, jc.ErrorIsNil)
+	s.mock.CheckNoCalls(c)
+
+	err = b.Log(in[2:])
+	c.Assert(err, jc.ErrorIsNil)
+	s.mock.CheckCalls(c, []testing.StubCall{
+		{"Log", []interface{}{in}},
+	})
+}
+
+func (s *BufferedLoggerSuite) TestLogFlushesMultiple(c *gc.C) {
+	const bufsz = 1
+	b := logdb.NewBufferedLogger(&s.mock, bufsz, time.Minute, s.clock)
+	in := []state.LogRecord{{
+		Entity:  names.NewMachineTag("0"),
+		Message: "foo",
+	}, {
+		Entity:  names.NewMachineTag("0"),
+		Message: "bar",
+	}, {
+		Entity:  names.NewMachineTag("0"),
+		Message: "baz",
+	}}
+
+	err := b.Log(in)
+	c.Assert(err, jc.ErrorIsNil)
+	s.mock.CheckCalls(c, []testing.StubCall{
+		{"Log", []interface{}{in[:1]}},
+		{"Log", []interface{}{in[1:2]}},
+		{"Log", []interface{}{in[2:]}},
+	})
+}
+
+func (s *BufferedLoggerSuite) TestTimerFlushes(c *gc.C) {
+	const bufsz = 10
+	const flushInterval = time.Minute
+	s.mock.called = make(chan []state.LogRecord)
+
+	b := logdb.NewBufferedLogger(&s.mock, bufsz, flushInterval, s.clock)
+	in := []state.LogRecord{{
+		Entity:  names.NewMachineTag("0"),
+		Message: "foo",
+	}, {
+		Entity:  names.NewMachineTag("0"),
+		Message: "bar",
+	}}
+
+	err := b.Log(in[:1])
+	c.Assert(err, jc.ErrorIsNil)
+	s.mock.CheckNoCalls(c)
+
+	// Advance, but not far enough to trigger the flush.
+	s.clock.WaitAdvance(30*time.Second, coretesting.LongWait, 1)
+	s.mock.CheckNoCalls(c)
+
+	// Log again; the timer should not have been reset.
+	err = b.Log(in[1:])
+	s.mock.CheckNoCalls(c)
+
+	// Advance to to the flush interval.
+	s.clock.Advance(30 * time.Second)
+	select {
+	case records := <-s.mock.called:
+		c.Assert(records, jc.DeepEquals, in)
+		s.mock.CheckCalls(c, []testing.StubCall{
+			{"Log", []interface{}{in}},
+		})
+	case <-time.After(coretesting.LongWait):
+		c.Fatal("timed out waiting for logs to be flushed")
+	}
+}
+
+func (s *BufferedLoggerSuite) TestFlushNothing(c *gc.C) {
+	b := logdb.NewBufferedLogger(&s.mock, 1, time.Minute, s.clock)
+	err := b.Flush()
+	c.Assert(err, jc.ErrorIsNil)
+	s.mock.CheckNoCalls(c)
+}
+
+func (s *BufferedLoggerSuite) TestFlushReportsError(c *gc.C) {
+	s.mock.SetErrors(errors.New("nope"))
+	b := logdb.NewBufferedLogger(&s.mock, 2, time.Minute, s.clock)
+	err := b.Log([]state.LogRecord{{
+		Entity:  names.NewMachineTag("0"),
+		Message: "foo",
+	}})
+	c.Assert(err, jc.ErrorIsNil)
+	err = b.Flush()
+	c.Assert(err, gc.ErrorMatches, "nope")
+}
+
+func (s *BufferedLoggerSuite) TestLogReportsError(c *gc.C) {
+	s.mock.SetErrors(errors.New("nope"))
+	b := logdb.NewBufferedLogger(&s.mock, 1, time.Minute, s.clock)
+	err := b.Log([]state.LogRecord{{
+		Entity:  names.NewMachineTag("0"),
+		Message: "foo",
+	}})
+	c.Assert(err, gc.ErrorMatches, "nope")
+}
+
+type mockLogger struct {
+	testing.Stub
+	called chan []state.LogRecord
+}
+
+func (m *mockLogger) Log(in []state.LogRecord) error {
+	incopy := make([]state.LogRecord, len(in))
+	copy(incopy, in)
+	m.MethodCall(m, "Log", incopy)
+	if m.called != nil {
+		m.called <- incopy
+	}
+	return m.NextErr()
+}

--- a/state/logdb/package_test.go
+++ b/state/logdb/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package logdb_test
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func TestPackage(t *testing.T) {
+	gc.TestingT(t)
+}

--- a/state/logs.go
+++ b/state/logs.go
@@ -362,7 +362,7 @@ type LogTailerState interface {
 
 // NewLogTailer returns a LogTailer which filters according to the
 // parameters given.
-func NewLogTailer(st LogTailerState, params *LogTailerParams) (LogTailer, error) {
+func NewLogTailer(st LogTailerState, params LogTailerParams) (LogTailer, error) {
 	session := st.MongoSession().Copy()
 	t := &logTailer{
 		modelUUID:       st.ModelUUID(),
@@ -388,7 +388,7 @@ type logTailer struct {
 	modelUUID       string
 	session         *mgo.Session
 	logsColl        *mgo.Collection
-	params          *LogTailerParams
+	params          LogTailerParams
 	logCh           chan *LogRecord
 	lastID          int64
 	lastTime        time.Time
@@ -581,7 +581,7 @@ func (t *logTailer) tailOplog() error {
 	}
 }
 
-func (t *logTailer) paramsToSelector(params *LogTailerParams, prefix string) bson.D {
+func (t *logTailer) paramsToSelector(params LogTailerParams, prefix string) bson.D {
 	sel := bson.D{}
 	if !params.StartTime.IsZero() {
 		sel = append(sel, bson.DocElem{"t", bson.M{"$gte": params.StartTime.UnixNano()}})

--- a/state/logs.go
+++ b/state/logs.go
@@ -230,7 +230,6 @@ func (logger *DbLogger) Log(records []LogRecord) error {
 			return errors.Annotate(err, "validating input log record")
 		}
 	}
-	// TODO(axw) copy session here and close after?
 	bulk := logger.logsColl.Bulk()
 	for _, r := range records {
 		var versionString string

--- a/state/logs.go
+++ b/state/logs.go
@@ -420,7 +420,7 @@ func (t *logTailer) processReversed(query *mgo.Query) error {
 		return errors.Errorf("too many lines requested (%d) maximum is %d",
 			t.params.InitialLines, maxInitialLines)
 	}
-	query.Sort("-e", "-t", "-_id")
+	query.Sort("-t", "-_id")
 	query.Limit(t.params.InitialLines)
 	iter := query.Iter()
 	queue := make([]logDoc, t.params.InitialLines)

--- a/state/logs_test.go
+++ b/state/logs_test.go
@@ -341,7 +341,7 @@ func (s *LogTailerSuite) TestTimeFiltering(c *gc.C) {
 	// Add 5 logs that should be returned.
 	want := logTemplate{Message: "want"}
 	s.writeLogsT(c, s.otherUUID, threshT, threshT.Add(5*time.Second), 5, want)
-	tailer, err := state.NewLogTailer(s.otherState, &state.LogTailerParams{
+	tailer, err := state.NewLogTailer(s.otherState, state.LogTailerParams{
 		StartTime: threshT,
 		Oplog:     s.oplogColl,
 	})
@@ -367,7 +367,7 @@ func (s *LogTailerSuite) TestOplogTransition(c *gc.C) {
 		s.writeLogs(c, s.otherUUID, 1, logTemplate{Message: strconv.Itoa(i)})
 	}
 
-	tailer, err := state.NewLogTailer(s.otherState, &state.LogTailerParams{
+	tailer, err := state.NewLogTailer(s.otherState, state.LogTailerParams{
 		Oplog: s.oplogColl,
 	})
 	c.Assert(err, jc.ErrorIsNil)
@@ -401,7 +401,7 @@ func (s *LogTailerSuite) TestModelFiltering(c *gc.C) {
 		s.assertTailer(c, tailer, 1, good)
 	}
 
-	s.checkLogTailerFiltering(c, s.otherState, &state.LogTailerParams{}, writeLogs, assert)
+	s.checkLogTailerFiltering(c, s.otherState, state.LogTailerParams{}, writeLogs, assert)
 }
 
 func (s *LogTailerSuite) TestTailingLogsOnlyForOneModel(c *gc.C) {
@@ -443,7 +443,7 @@ func (s *LogTailerSuite) TestTailingLogsOnlyForOneModel(c *gc.C) {
 			}
 		}
 	}
-	s.checkLogTailerFiltering(c, s.State, &state.LogTailerParams{}, writeLogs, assert)
+	s.checkLogTailerFiltering(c, s.State, state.LogTailerParams{}, writeLogs, assert)
 }
 
 func (s *LogTailerSuite) TestLevelFiltering(c *gc.C) {
@@ -454,7 +454,7 @@ func (s *LogTailerSuite) TestLevelFiltering(c *gc.C) {
 		s.writeLogs(c, s.otherUUID, 1, info)
 		s.writeLogs(c, s.otherUUID, 1, error)
 	}
-	params := &state.LogTailerParams{
+	params := state.LogTailerParams{
 		MinLevel: loggo.INFO,
 	}
 	assert := func(tailer state.LogTailer) {
@@ -469,7 +469,7 @@ func (s *LogTailerSuite) TestInitialLines(c *gc.C) {
 	s.writeLogs(c, s.otherUUID, 3, logTemplate{Message: "dont want"})
 	s.writeLogs(c, s.otherUUID, 5, expected)
 
-	tailer, err := state.NewLogTailer(s.otherState, &state.LogTailerParams{
+	tailer, err := state.NewLogTailer(s.otherState, state.LogTailerParams{
 		InitialLines: 5,
 	})
 	c.Assert(err, jc.ErrorIsNil)
@@ -490,7 +490,7 @@ func (s *LogTailerSuite) TestRecordsAddedOutOfTimeOrder(c *gc.C) {
 	migrated := logTemplate{Message: "transferred by migration"}
 	s.writeLogsT(c, s.otherUUID, t1, t1, 1, migrated)
 
-	tailer, err := state.NewLogTailer(s.otherState, &state.LogTailerParams{})
+	tailer, err := state.NewLogTailer(s.otherState, state.LogTailerParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	defer tailer.Stop()
 
@@ -503,7 +503,7 @@ func (s *LogTailerSuite) TestInitialLinesWithNotEnoughLines(c *gc.C) {
 	expected := logTemplate{Message: "want"}
 	s.writeLogs(c, s.otherUUID, 2, expected)
 
-	tailer, err := state.NewLogTailer(s.otherState, &state.LogTailerParams{
+	tailer, err := state.NewLogTailer(s.otherState, state.LogTailerParams{
 		InitialLines: 5,
 	})
 	c.Assert(err, jc.ErrorIsNil)
@@ -523,7 +523,7 @@ func (s *LogTailerSuite) TestNoTail(c *gc.C) {
 	err := s.writeLogToOplog(s.otherUUID, doc)
 	c.Assert(err, jc.ErrorIsNil)
 
-	tailer, err := state.NewLogTailer(s.otherState, &state.LogTailerParams{
+	tailer, err := state.NewLogTailer(s.otherState, state.LogTailerParams{
 		NoTail: true,
 	})
 	c.Assert(err, jc.ErrorIsNil)
@@ -560,7 +560,7 @@ func (s *LogTailerSuite) TestIncludeEntity(c *gc.C) {
 		s.writeLogs(c, s.otherUUID, 1, foo1)
 		s.writeLogs(c, s.otherUUID, 3, machine0)
 	}
-	params := &state.LogTailerParams{
+	params := state.LogTailerParams{
 		IncludeEntity: []string{
 			"unit-foo-0",
 			"unit-foo-1",
@@ -583,7 +583,7 @@ func (s *LogTailerSuite) TestIncludeEntityWildcard(c *gc.C) {
 		s.writeLogs(c, s.otherUUID, 1, foo1)
 		s.writeLogs(c, s.otherUUID, 3, machine0)
 	}
-	params := &state.LogTailerParams{
+	params := state.LogTailerParams{
 		IncludeEntity: []string{
 			"unit-foo*",
 		},
@@ -605,7 +605,7 @@ func (s *LogTailerSuite) TestExcludeEntity(c *gc.C) {
 		s.writeLogs(c, s.otherUUID, 1, foo1)
 		s.writeLogs(c, s.otherUUID, 3, machine0)
 	}
-	params := &state.LogTailerParams{
+	params := state.LogTailerParams{
 		ExcludeEntity: []string{
 			"machine-0",
 			"unit-foo-0",
@@ -627,7 +627,7 @@ func (s *LogTailerSuite) TestExcludeEntityWildcard(c *gc.C) {
 		s.writeLogs(c, s.otherUUID, 1, foo1)
 		s.writeLogs(c, s.otherUUID, 3, machine0)
 	}
-	params := &state.LogTailerParams{
+	params := state.LogTailerParams{
 		ExcludeEntity: []string{
 			"machine*",
 			"unit-*-0",
@@ -651,7 +651,7 @@ func (s *LogTailerSuite) TestIncludeModule(c *gc.C) {
 		s.writeLogs(c, s.otherUUID, 1, mod0)
 		s.writeLogs(c, s.otherUUID, 1, mod2)
 	}
-	params := &state.LogTailerParams{
+	params := state.LogTailerParams{
 		IncludeModule: []string{"juju.thing", "elsewhere"},
 	}
 	assert := func(tailer state.LogTailer) {
@@ -675,7 +675,7 @@ func (s *LogTailerSuite) TestExcludeModule(c *gc.C) {
 		s.writeLogs(c, s.otherUUID, 1, mod0)
 		s.writeLogs(c, s.otherUUID, 1, mod2)
 	}
-	params := &state.LogTailerParams{
+	params := state.LogTailerParams{
 		ExcludeModule: []string{"juju.thing", "elsewhere"},
 	}
 	assert := func(tailer state.LogTailer) {
@@ -697,7 +697,7 @@ func (s *LogTailerSuite) TestIncludeExcludeModule(c *gc.C) {
 		s.writeLogs(c, s.otherUUID, 1, baz)
 		s.writeLogs(c, s.otherUUID, 1, qux)
 	}
-	params := &state.LogTailerParams{
+	params := state.LogTailerParams{
 		IncludeModule: []string{"foo", "bar", "qux"},
 		ExcludeModule: []string{"foo", "bar"},
 	}
@@ -712,7 +712,7 @@ func (s *LogTailerSuite) TestIncludeExcludeModule(c *gc.C) {
 func (s *LogTailerSuite) checkLogTailerFiltering(
 	c *gc.C,
 	st *state.State,
-	params *state.LogTailerParams,
+	params state.LogTailerParams,
 	writeLogs func(),
 	assertTailer func(state.LogTailer),
 ) {

--- a/state/pool.go
+++ b/state/pool.go
@@ -110,7 +110,9 @@ func (p *StatePool) Get(modelUUID string) (*State, StatePoolReleaser, error) {
 
 // release indicates that the client has finished using the State. If the
 // state has been marked for removal, it will be closed and removed
-// when the final Release is done.
+// when the final Release is done; if there are no references, it will be
+// closed and removed immediately. The boolean result reports whether or
+// not the state was closed and removed.
 func (p *StatePool) release(modelUUID string, key uint64) (bool, error) {
 	if modelUUID == p.systemState.ModelUUID() {
 		// We don't maintain a refcount for the controller.

--- a/state/pool.go
+++ b/state/pool.go
@@ -47,12 +47,18 @@ type StatePool struct {
 	sourceKey uint64
 }
 
+// StatePoolReleaser is the type of a function returned by StatePool.Get,
+// for releasing the State back into the pool. The boolean result indicates
+// whether or not releasing the State also caused it to be removed from
+// the pool (because its Remove method was previously called).
+type StatePoolReleaser func() bool
+
 // Get returns a State for a given model from the pool, creating one
 // if required. If the State has been marked for removal because there
 // are outstanding uses, an error will be returned.
-func (p *StatePool) Get(modelUUID string) (*State, func(), error) {
+func (p *StatePool) Get(modelUUID string) (*State, StatePoolReleaser, error) {
 	if modelUUID == p.systemState.ModelUUID() {
-		return p.systemState, func() {}, nil
+		return p.systemState, func() bool { return false }, nil
 	}
 
 	p.mu.Lock()
@@ -71,15 +77,16 @@ func (p *StatePool) Get(modelUUID string) (*State, func(), error) {
 	// This is to ensure that the releaser function can only be called once.
 	released := false
 
-	releaser := func() {
+	releaser := func() bool {
 		if released {
-			return
+			return false
 		}
-		err := p.release(modelUUID, key)
+		removed, err := p.release(modelUUID, key)
 		if err != nil {
 			logger.Errorf("releasing state back to pool: %s", err.Error())
 		}
 		released = true
+		return removed
 	}
 	source := string(debug.Stack())
 
@@ -104,10 +111,10 @@ func (p *StatePool) Get(modelUUID string) (*State, func(), error) {
 // release indicates that the client has finished using the State. If the
 // state has been marked for removal, it will be closed and removed
 // when the final Release is done.
-func (p *StatePool) release(modelUUID string, key uint64) error {
+func (p *StatePool) release(modelUUID string, key uint64) (bool, error) {
 	if modelUUID == p.systemState.ModelUUID() {
 		// We don't maintain a refcount for the controller.
-		return nil
+		return false, nil
 	}
 
 	p.mu.Lock()
@@ -115,10 +122,10 @@ func (p *StatePool) release(modelUUID string, key uint64) error {
 
 	item, ok := p.pool[modelUUID]
 	if !ok {
-		return errors.Errorf("unable to return unknown model %v to the pool", modelUUID)
+		return false, errors.Errorf("unable to return unknown model %v to the pool", modelUUID)
 	}
 	if item.refCount() == 0 {
-		return errors.Errorf("state pool refcount for model %v is already 0", modelUUID)
+		return false, errors.Errorf("state pool refcount for model %v is already 0", modelUUID)
 	}
 	delete(item.referenceSources, key)
 	return p.maybeRemoveItem(modelUUID, item)
@@ -126,11 +133,12 @@ func (p *StatePool) release(modelUUID string, key uint64) error {
 
 // Remove takes the state out of the pool and closes it, or marks it
 // for removal if it's currently being used (indicated by Gets without
-// corresponding Releases).
-func (p *StatePool) Remove(modelUUID string) error {
+// corresponding Releases). The boolean result indicates whether or
+// not the state was removed.
+func (p *StatePool) Remove(modelUUID string) (bool, error) {
 	if modelUUID == p.systemState.ModelUUID() {
 		// We don't manage the controller state.
-		return nil
+		return false, nil
 	}
 
 	p.mu.Lock()
@@ -140,18 +148,18 @@ func (p *StatePool) Remove(modelUUID string) error {
 	if !ok {
 		// Don't require the client to keep track of what we've seen -
 		// ignore unknown model uuids.
-		return nil
+		return false, nil
 	}
 	item.remove = true
 	return p.maybeRemoveItem(modelUUID, item)
 }
 
-func (p *StatePool) maybeRemoveItem(modelUUID string, item *PoolItem) error {
+func (p *StatePool) maybeRemoveItem(modelUUID string, item *PoolItem) (bool, error) {
 	if item.remove && item.refCount() == 0 {
 		delete(p.pool, modelUUID)
-		return item.state.Close()
+		return true, item.state.Close()
 	}
-	return nil
+	return false, nil
 }
 
 // SystemState returns the State passed in to NewStatePool.

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -2785,14 +2785,14 @@ func writeLogs(c *gc.C, st *state.State, n int) {
 	dbLogger := state.NewDbLogger(st)
 	defer dbLogger.Close()
 	for i := 0; i < n; i++ {
-		err := dbLogger.Log(state.LogRecord{
+		err := dbLogger.Log([]state.LogRecord{{
 			Time:     time.Now(),
 			Entity:   names.NewApplicationTag("van-occupanther"),
 			Module:   "chasing after deer",
 			Location: "in a log house",
 			Level:    loggo.INFO,
 			Message:  "why are your fingers like that of a hedge in winter?",
-		})
+		}})
 		c.Assert(err, jc.ErrorIsNil)
 	}
 }

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -2785,14 +2785,14 @@ func writeLogs(c *gc.C, st *state.State, n int) {
 	dbLogger := state.NewDbLogger(st)
 	defer dbLogger.Close()
 	for i := 0; i < n; i++ {
-		err := dbLogger.Log(
-			time.Now(),
-			"van occupanther",
-			"chasing after deer",
-			"in a log house",
-			loggo.INFO,
-			"why are your fingers like that of a hedge in winter?",
-		)
+		err := dbLogger.Log(state.LogRecord{
+			Time:     time.Now(),
+			Entity:   names.NewApplicationTag("van-occupanther"),
+			Module:   "chasing after deer",
+			Location: "in a log house",
+			Level:    loggo.INFO,
+			Message:  "why are your fingers like that of a hedge in winter?",
+		})
 		c.Assert(err, jc.ErrorIsNil)
 	}
 }

--- a/worker/dblogpruner/worker_test.go
+++ b/worker/dblogpruner/worker_test.go
@@ -140,11 +140,19 @@ func (s *suite) TestPrunesLogsBySize(c *gc.C) {
 }
 
 func (s *suite) addLogs(c *gc.C, t0 time.Time, text string, count int) {
-	dbLogger := state.NewEntityDbLogger(s.state, names.NewMachineTag("0"), version.Current)
+	dbLogger := state.NewDbLogger(s.state)
 	defer dbLogger.Close()
 
 	for offset := 0; offset < count; offset++ {
 		t := t0.Add(-time.Duration(offset) * time.Second)
-		dbLogger.Log(t, "some.module", "foo.go:42", loggo.INFO, text)
+		dbLogger.Log([]state.LogRecord{{
+			Time:     t,
+			Entity:   names.NewMachineTag("0"),
+			Version:  version.Current,
+			Module:   "some.module",
+			Location: "foo.go:42",
+			Level:    loggo.INFO,
+			Message:  text,
+		}})
 	}
 }


### PR DESCRIPTION
## Description of change

- Refactor and simplify the state.DbLogger code.
- Introduce a state/logdb package, which I intend to move the existing DbLogger and friends into, but first things first. This package initially holds a BufferedLogger, which buffers log records and flushes to an underlying logger (e.g. DbLogger) when either the buffer capacity or a time interval are exceeded.
- Update state.DbLogger.Log to insert records in bulk.
- Update the "release" function returned by StatePool.Get, and StatePool.Remove, to report whether or not they remove/close the State.
- Update the apiserver logsink/logtransfer code to share a single DbLogger for all uses of a shared state pool entry, to cut down on the number of sockets used for logging.
- Update the apiserver logsink/logtransfer code to use state/logdb.BufferedLogger to buffer log writes. The parameters are currently hard-coded: a buffer capacity of 1024, and flush interval of 2 seconds. We can make these configurable as needed.

Note to reviewers: there are a few refactoring commits, which you may wish to review first. If it makes your life easier, I'll split this up - I just wanted to get it in front of people ASAP.

## QA steps

1. juju bootstrap localhost
2. juju add-machine
3. juju debug-log -m controller

Watch the logs roll in; perform some activity and observe that, unless there is a flurry of logs, debug-log will take ~2 seconds to update. The number of mongo sockets and insertions should be reduced from before. I added temporary instrumentation to prove this to myself, but it should be possible to eyeball the improvements via mongo stats with a larger deployment.

## Documentation changes

None.

## Bug reference

None.