### PR TITLE
Remove unrecognized commands from juju help deploy see also section.

### DIFF
--- a/cmd/juju/application/deploy.go
+++ b/cmd/juju/application/deploy.go
@@ -397,10 +397,8 @@ Examples:
 
 See also:
     spaces
-    constraints
+    config
     add-unit
-    set-config
-    get-config
     set-constraints
     get-constraints
 `


### PR DESCRIPTION
Replace with valid commands where possible.

## Please provide the following details to expedite Pull Request review:

----

## Description of change

It's very annoying to have commands listed in help that don't actually exist.  Update
juju help deploy to only show usable commands.

Why is this change needed?

## QA steps

Run juju help deploy, verify that all commands listed in the See Also section exist.

## Documentation changes

No

## Bug reference

No