### PR TITLE
Consume details for an offer now includes the connection details for the host controller

### DIFF
--- a/api/crossmodelrelations/crossmodelrelations.go
+++ b/api/crossmodelrelations/crossmodelrelations.go
@@ -1,0 +1,57 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package crossmodelrelations
+
+import (
+	"github.com/juju/errors"
+
+	"github.com/juju/juju/api/base"
+	"github.com/juju/juju/apiserver/params"
+)
+
+// Client provides access to the crossmodelrelations api facade.
+type Client struct {
+	facade base.FacadeCaller
+}
+
+// NewClient creates a new client-side CrossModelRelations facade.
+func NewClient(caller base.APICaller) *Client {
+	facadeCaller := base.NewFacadeCaller(caller, "CrossModelRelations")
+	return &Client{facadeCaller}
+}
+
+// PublishLocalRelationChange publishes local relations changes to the
+// remote side offering those relations.
+func (c *Client) PublishLocalRelationChange(change params.RemoteRelationChangeEvent) error {
+	args := params.RemoteRelationsChanges{
+		Changes: []params.RemoteRelationChangeEvent{change},
+	}
+	var results params.ErrorResults
+	err := c.facade.FacadeCall("PublishLocalRelationChange", args, &results)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	if len(results.Results) != 1 {
+		return errors.Errorf("expected 1 result, got %d", len(results.Results))
+	}
+	result := results.Results[0]
+	if result.Error != nil {
+		return errors.Trace(result.Error)
+	}
+	return nil
+}
+
+// RegisterRemoteRelations sets up the local model to participate in the specified relations.
+func (c *Client) RegisterRemoteRelations(relations ...params.RegisterRemoteRelation) ([]params.RemoteEntityIdResult, error) {
+	args := params.RegisterRemoteRelations{Relations: relations}
+	var results params.RemoteEntityIdResults
+	err := c.facade.FacadeCall("RegisterRemoteRelations", args, &results)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	if len(results.Results) != len(relations) {
+		return nil, errors.Errorf("expected %d result(s), got %d", len(relations), len(results.Results))
+	}
+	return results.Results, nil
+}

--- a/api/crossmodelrelations/crossmodelrelations_test.go
+++ b/api/crossmodelrelations/crossmodelrelations_test.go
@@ -1,0 +1,95 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package crossmodelrelations_test
+
+import (
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/api/base/testing"
+	"github.com/juju/juju/api/crossmodelrelations"
+	"github.com/juju/juju/apiserver/params"
+	coretesting "github.com/juju/juju/testing"
+)
+
+var _ = gc.Suite(&CrossModelRelationsSuite{})
+
+type CrossModelRelationsSuite struct {
+	coretesting.BaseSuite
+}
+
+func (s *CrossModelRelationsSuite) TestNewClient(c *gc.C) {
+	apiCaller := testing.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
+		return nil
+	})
+	client := crossmodelrelations.NewClient(apiCaller)
+	c.Assert(client, gc.NotNil)
+}
+
+func (s *CrossModelRelationsSuite) TestPublishLocalRelationChange(c *gc.C) {
+	var callCount int
+	apiCaller := testing.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
+		c.Check(objType, gc.Equals, "CrossModelRelations")
+		c.Check(version, gc.Equals, 0)
+		c.Check(id, gc.Equals, "")
+		c.Check(request, gc.Equals, "PublishLocalRelationChange")
+		c.Check(arg, gc.DeepEquals, params.RemoteRelationsChanges{
+			Changes: []params.RemoteRelationChangeEvent{{
+				DepartedUnits: []int{1}}},
+		})
+		c.Assert(result, gc.FitsTypeOf, &params.ErrorResults{})
+		*(result.(*params.ErrorResults)) = params.ErrorResults{
+			Results: []params.ErrorResult{{
+				Error: &params.Error{Message: "FAIL"},
+			}},
+		}
+		callCount++
+		return nil
+	})
+	client := crossmodelrelations.NewClient(apiCaller)
+	err := client.PublishLocalRelationChange(params.RemoteRelationChangeEvent{DepartedUnits: []int{1}})
+	c.Check(err, gc.ErrorMatches, "FAIL")
+	c.Check(callCount, gc.Equals, 1)
+}
+
+func (s *CrossModelRelationsSuite) TestRegisterRemoteRelations(c *gc.C) {
+	var callCount int
+	apiCaller := testing.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
+		c.Check(objType, gc.Equals, "CrossModelRelations")
+		c.Check(version, gc.Equals, 0)
+		c.Check(id, gc.Equals, "")
+		c.Check(request, gc.Equals, "RegisterRemoteRelations")
+		c.Check(arg, gc.DeepEquals, params.RegisterRemoteRelations{
+			Relations: []params.RegisterRemoteRelation{{OfferName: "offeredapp"}}})
+		c.Assert(result, gc.FitsTypeOf, &params.RemoteEntityIdResults{})
+		*(result.(*params.RemoteEntityIdResults)) = params.RemoteEntityIdResults{
+			Results: []params.RemoteEntityIdResult{{
+				Error: &params.Error{Message: "FAIL"},
+			}},
+		}
+		callCount++
+		return nil
+	})
+	client := crossmodelrelations.NewClient(apiCaller)
+	result, err := client.RegisterRemoteRelations(params.RegisterRemoteRelation{OfferName: "offeredapp"})
+	c.Check(err, jc.ErrorIsNil)
+	c.Assert(result, gc.HasLen, 1)
+	c.Check(result[0].Error, gc.ErrorMatches, "FAIL")
+	c.Check(callCount, gc.Equals, 1)
+}
+
+func (s *CrossModelRelationsSuite) TestRegisterRemoteRelationCount(c *gc.C) {
+	apiCaller := testing.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
+		*(result.(*params.RemoteEntityIdResults)) = params.RemoteEntityIdResults{
+			Results: []params.RemoteEntityIdResult{
+				{Error: &params.Error{Message: "FAIL"}},
+				{Error: &params.Error{Message: "FAIL"}},
+			},
+		}
+		return nil
+	})
+	client := crossmodelrelations.NewClient(apiCaller)
+	_, err := client.RegisterRemoteRelations(params.RegisterRemoteRelation{})
+	c.Check(err, gc.ErrorMatches, `expected 1 result\(s\), got 2`)
+}

--- a/api/crossmodelrelations/package_test.go
+++ b/api/crossmodelrelations/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package crossmodelrelations_test
+
+import (
+	stdtesting "testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func TestAll(t *stdtesting.T) {
+	gc.TestingT(t)
+}

--- a/api/facadeversions.go
+++ b/api/facadeversions.go
@@ -29,6 +29,7 @@ var facadeVersions = map[string]int{
 	"Client":                       1,
 	"Cloud":                        1,
 	"Controller":                   3,
+	"CrossModelRelations":          1,
 	"Deployer":                     1,
 	"DiskManager":                  2,
 	"EntityWatcher":                2,

--- a/api/remoterelations/remoterelations.go
+++ b/api/remoterelations/remoterelations.go
@@ -26,27 +26,6 @@ func NewClient(caller base.APICaller) *Client {
 	return &Client{facadeCaller}
 }
 
-// PublishLocalRelationChange publishes local relations changes to the
-// remote side offering those relations.
-func (c *Client) PublishLocalRelationChange(change params.RemoteRelationChangeEvent) error {
-	args := params.RemoteRelationsChanges{
-		Changes: []params.RemoteRelationChangeEvent{change},
-	}
-	var results params.ErrorResults
-	err := c.facade.FacadeCall("PublishLocalRelationChange", args, &results)
-	if err != nil {
-		return errors.Trace(err)
-	}
-	if len(results.Results) != 1 {
-		return errors.Errorf("expected 1 result, got %d", len(results.Results))
-	}
-	result := results.Results[0]
-	if result.Error != nil {
-		return errors.Trace(result.Error)
-	}
-	return nil
-}
-
 // ImportRemoteEntity adds an entity to the remote entities collection
 // with the specified opaque token.
 func (c *Client) ImportRemoteEntity(sourceModelUUID string, entity names.Tag, token string) error {
@@ -126,20 +105,6 @@ func (c *Client) RemoveRemoteEntity(sourceModelUUID string, entity names.Tag) er
 		return errors.Trace(result.Error)
 	}
 	return nil
-}
-
-// RegisterRemoteRelations sets up the local model to participate in the specified relations.
-func (c *Client) RegisterRemoteRelations(relations ...params.RegisterRemoteRelation) ([]params.RemoteEntityIdResult, error) {
-	args := params.RegisterRemoteRelations{Relations: relations}
-	var results params.RemoteEntityIdResults
-	err := c.facade.FacadeCall("RegisterRemoteRelations", args, &results)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	if len(results.Results) != len(relations) {
-		return nil, errors.Errorf("expected %d result(s), got %d", len(relations), len(results.Results))
-	}
-	return results.Results, nil
 }
 
 // RelationUnitSettings returns the relation unit settings for the given relation units in the local model.

--- a/api/remoterelations/remoterelations_test.go
+++ b/api/remoterelations/remoterelations_test.go
@@ -101,32 +101,6 @@ func (s *remoteRelationsSuite) TestWatchLocalRelationUnits(c *gc.C) {
 	c.Check(callCount, gc.Equals, 1)
 }
 
-func (s *remoteRelationsSuite) TestPublishLocalRelationChange(c *gc.C) {
-	var callCount int
-	apiCaller := testing.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
-		c.Check(objType, gc.Equals, "RemoteRelations")
-		c.Check(version, gc.Equals, 0)
-		c.Check(id, gc.Equals, "")
-		c.Check(request, gc.Equals, "PublishLocalRelationChange")
-		c.Check(arg, gc.DeepEquals, params.RemoteRelationsChanges{
-			Changes: []params.RemoteRelationChangeEvent{{
-				DepartedUnits: []int{1}}},
-		})
-		c.Assert(result, gc.FitsTypeOf, &params.ErrorResults{})
-		*(result.(*params.ErrorResults)) = params.ErrorResults{
-			Results: []params.ErrorResult{{
-				Error: &params.Error{Message: "FAIL"},
-			}},
-		}
-		callCount++
-		return nil
-	})
-	client := remoterelations.NewClient(apiCaller)
-	err := client.PublishLocalRelationChange(params.RemoteRelationChangeEvent{DepartedUnits: []int{1}})
-	c.Check(err, gc.ErrorMatches, "FAIL")
-	c.Check(callCount, gc.Equals, 1)
-}
-
 func (s *remoteRelationsSuite) TestExportEntities(c *gc.C) {
 	var callCount int
 	apiCaller := testing.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
@@ -284,47 +258,6 @@ func (s *remoteRelationsSuite) TestRemoteApplicationsResultsCount(c *gc.C) {
 	})
 	client := remoterelations.NewClient(apiCaller)
 	_, err := client.RemoteApplications([]string{"foo"})
-	c.Check(err, gc.ErrorMatches, `expected 1 result\(s\), got 2`)
-}
-
-func (s *remoteRelationsSuite) TestRegisterRemoteRelations(c *gc.C) {
-	var callCount int
-	apiCaller := testing.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
-		c.Check(objType, gc.Equals, "RemoteRelations")
-		c.Check(version, gc.Equals, 0)
-		c.Check(id, gc.Equals, "")
-		c.Check(request, gc.Equals, "RegisterRemoteRelations")
-		c.Check(arg, gc.DeepEquals, params.RegisterRemoteRelations{
-			Relations: []params.RegisterRemoteRelation{{OfferName: "offeredapp"}}})
-		c.Assert(result, gc.FitsTypeOf, &params.RemoteEntityIdResults{})
-		*(result.(*params.RemoteEntityIdResults)) = params.RemoteEntityIdResults{
-			Results: []params.RemoteEntityIdResult{{
-				Error: &params.Error{Message: "FAIL"},
-			}},
-		}
-		callCount++
-		return nil
-	})
-	client := remoterelations.NewClient(apiCaller)
-	result, err := client.RegisterRemoteRelations(params.RegisterRemoteRelation{OfferName: "offeredapp"})
-	c.Check(err, jc.ErrorIsNil)
-	c.Assert(result, gc.HasLen, 1)
-	c.Check(result[0].Error, gc.ErrorMatches, "FAIL")
-	c.Check(callCount, gc.Equals, 1)
-}
-
-func (s *remoteRelationsSuite) TestRegisterRemoteRelationCount(c *gc.C) {
-	apiCaller := testing.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
-		*(result.(*params.RemoteEntityIdResults)) = params.RemoteEntityIdResults{
-			Results: []params.RemoteEntityIdResult{
-				{Error: &params.Error{Message: "FAIL"}},
-				{Error: &params.Error{Message: "FAIL"}},
-			},
-		}
-		return nil
-	})
-	client := remoterelations.NewClient(apiCaller)
-	_, err := client.RegisterRemoteRelations(params.RegisterRemoteRelation{})
 	c.Check(err, gc.ErrorMatches, `expected 1 result\(s\), got 2`)
 }
 

--- a/apiserver/allfacades.go
+++ b/apiserver/allfacades.go
@@ -27,6 +27,7 @@ import (
 	"github.com/juju/juju/apiserver/cloud"  // ModelUser Read
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/controller" // ModelUser Admin (although some methods check for read only)
+	"github.com/juju/juju/apiserver/crossmodelrelations"
 	"github.com/juju/juju/apiserver/deployer"
 	"github.com/juju/juju/apiserver/diskmanager"
 	"github.com/juju/juju/apiserver/facade"
@@ -214,6 +215,7 @@ func AllFacades() *facade.Registry {
 		reg("ApplicationOffers", 1, applicationoffers.NewOffersAPI)
 		reg("RemoteFirewaller", 1, remotefirewaller.NewStateRemoteFirewallerAPI)
 		reg("RemoteRelations", 1, remoterelations.NewStateRemoteRelationsAPI)
+		reg("CrossModelRelations", 1, crossmodelrelations.NewStateCrossModelRelationsAPI)
 	}
 
 	regRaw("AllWatcher", 1, NewAllWatcher, reflect.TypeOf((*SrvAllWatcher)(nil)))

--- a/apiserver/application/backend.go
+++ b/apiserver/application/backend.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/juju/juju/apiserver/common/storagecommon"
 	"github.com/juju/juju/constraints"
+	"github.com/juju/juju/core/crossmodel"
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/state"
@@ -33,6 +34,8 @@ type Backend interface {
 	Machine(string) (Machine, error)
 	ModelTag() names.ModelTag
 	Unit(string) (Unit, error)
+	SaveController(crossmodel.ControllerInfo) (ExternalController, error)
+	ControllerTag() names.ControllerTag
 }
 
 // BlockChecker defines the block-checking functionality required by
@@ -118,6 +121,13 @@ type Model interface {
 
 type stateShim struct {
 	*state.State
+}
+
+type ExternalController state.ExternalController
+
+func (s stateShim) SaveController(controllerInfo crossmodel.ControllerInfo) (ExternalController, error) {
+	api := state.NewExternalControllers(s.State)
+	return api.Save(controllerInfo)
 }
 
 // NewStateBackend converts a state.State into a Backend.

--- a/apiserver/applicationoffers/applicationoffers_test.go
+++ b/apiserver/applicationoffers/applicationoffers_test.go
@@ -976,6 +976,11 @@ func (s *consumeSuite) TestConsumeDetailsWithPermission(c *gc.C) {
 		},
 		Access: "consume",
 	})
+	c.Assert(results.Results[0].ControllerInfo, jc.DeepEquals, &params.ExternalControllerInfo{
+		ControllerTag: testing.ControllerTag.String(),
+		Addrs:         []string{"192.168.1.1:17070"},
+		CACert:        testing.CACert,
+	})
 	// TODO(wallyworld)
 	c.Assert(results.Results[0].Macaroon, gc.IsNil)
 }

--- a/apiserver/applicationoffers/mock_test.go
+++ b/apiserver/applicationoffers/mock_test.go
@@ -13,6 +13,7 @@ import (
 	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/apiserver/applicationoffers"
+	"github.com/juju/juju/apiserver/common"
 	jujucrossmodel "github.com/juju/juju/core/crossmodel"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/network"
@@ -262,6 +263,7 @@ type offerAccess struct {
 }
 
 type mockState struct {
+	common.AddressAndCertGetter
 	modelUUID         string
 	model             applicationoffers.Model
 	allmodels         []applicationoffers.Model
@@ -364,6 +366,19 @@ func (m *mockState) RemoveOfferAccess(offer names.ApplicationOfferTag, user name
 	}
 	delete(m.accessPerms, offerAccess{user: user, offer: offer})
 	return nil
+}
+
+func (m *mockState) APIHostPorts() ([][]network.HostPort, error) {
+	return [][]network.HostPort{
+		{
+			{Address: network.Address{Value: "192.168.1.1", Scope: network.ScopeCloudLocal}, Port: 17070},
+			{Address: network.Address{Value: "10.1.1.1", Scope: network.ScopeMachineLocal}, Port: 17070},
+		},
+	}, nil
+}
+
+func (m *mockState) CACert() string {
+	return testing.CACert
 }
 
 type mockStatePool struct {

--- a/apiserver/applicationoffers/state.go
+++ b/apiserver/applicationoffers/state.go
@@ -8,6 +8,7 @@ import (
 	"gopkg.in/juju/charm.v6-unstable"
 	"gopkg.in/juju/names.v2"
 
+	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/core/crossmodel"
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/permission"
@@ -40,13 +41,13 @@ func (pool statePoolShim) Get(modelUUID string) (Backend, func(), error) {
 
 // Backend provides selected methods off the state.State struct.
 type Backend interface {
+	common.AddressAndCertGetter
 	ControllerTag() names.ControllerTag
 	Charm(*charm.URL) (Charm, error)
 	Application(name string) (Application, error)
 	ApplicationOffer(name string) (*crossmodel.ApplicationOffer, error)
 	Model() (Model, error)
 	AllModels() ([]Model, error)
-	ModelUUID() string
 	ModelTag() names.ModelTag
 	RemoteConnectionStatus(offerName string) (RemoteConnectionStatus, error)
 	Space(string) (Space, error)

--- a/apiserver/crossmodelrelations/crossmodelrelations.go
+++ b/apiserver/crossmodelrelations/crossmodelrelations.go
@@ -1,0 +1,307 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package crossmodelrelations
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/juju/errors"
+	"github.com/juju/loggo"
+	"gopkg.in/juju/charm.v6-unstable"
+	"gopkg.in/juju/names.v2"
+
+	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/facade"
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/core/crossmodel"
+	"github.com/juju/juju/state"
+)
+
+var logger = loggo.GetLogger("juju.apiserver.crossmodelrelations")
+
+// CrossModelRelationsAPI provides access to the CrossModelRelations API facade.
+type CrossModelRelationsAPI struct {
+	st         CrossModelRelationsState
+	resources  facade.Resources
+	authorizer facade.Authorizer
+}
+
+// NewStateCrossModelRelationsAPI creates a new server-side CrossModelRelations API facade
+// backed by global state.
+func NewStateCrossModelRelationsAPI(ctx facade.Context) (*CrossModelRelationsAPI, error) {
+	return NewCrossModelRelationsAPI(stateShim{ctx.State()}, ctx.Resources(), ctx.Auth())
+}
+
+// NewCrossModelRelationsAPI returns a new server-side CrossModelRelationsAPI facade.
+func NewCrossModelRelationsAPI(
+	st CrossModelRelationsState,
+	resources facade.Resources,
+	authorizer facade.Authorizer,
+) (*CrossModelRelationsAPI, error) {
+	if !authorizer.AuthController() {
+		return nil, common.ErrPerm
+	}
+	return &CrossModelRelationsAPI{
+		st:         st,
+		resources:  resources,
+		authorizer: authorizer,
+	}, nil
+}
+
+// PublishLocalRelationChange publishes local relations changes to the
+// remote side offering those relations.
+func (api *CrossModelRelationsAPI) PublishLocalRelationChange(
+	changes params.RemoteRelationsChanges,
+) (params.ErrorResults, error) {
+	results := params.ErrorResults{
+		Results: make([]params.ErrorResult, len(changes.Changes)),
+	}
+	for i, change := range changes.Changes {
+		if err := api.publishRelationChange(change); err != nil {
+			results.Results[i].Error = common.ServerError(err)
+			continue
+		}
+	}
+	return results, nil
+}
+
+func (api *CrossModelRelationsAPI) publishRelationChange(change params.RemoteRelationChangeEvent) error {
+	logger.Debugf("publish into model %v change: %+v", api.st.ModelUUID(), change)
+
+	relationTag, err := api.getRemoteEntityTag(change.RelationId)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			logger.Debugf("not found relation tag %+v in model %v, exit early", change.RelationId, api.st.ModelUUID())
+			return nil
+		}
+		return errors.Trace(err)
+	}
+	logger.Debugf("relation tag for remote id %+v is %v", change.RelationId, relationTag)
+
+	// Ensure the relation exists.
+	rel, err := api.st.KeyRelation(relationTag.Id())
+	if errors.IsNotFound(err) {
+		if change.Life != params.Alive {
+			return nil
+		}
+	}
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	// Look up the application on the remote side of this relation
+	// ie from the model which published this change.
+	applicationTag, err := api.getRemoteEntityTag(change.ApplicationId)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	logger.Debugf("application tag for remote id %+v is %v", change.ApplicationId, applicationTag)
+
+	// If the remote model has destroyed the relation, do it here also.
+	if change.Life != params.Alive {
+		logger.Debugf("remote side of %v died", relationTag)
+		if err := rel.Destroy(); err != nil {
+			return errors.Trace(err)
+		}
+		// See if we need to remove the remote application proxy - we do this
+		// on the offering side as there is 1:1 between proxy and consuming app.
+		if applicationTag != nil {
+			remoteApp, err := api.st.RemoteApplication(applicationTag.Id())
+			if err != nil && !errors.IsNotFound(err) {
+				return errors.Trace(err)
+			}
+			if err == nil && remoteApp.IsConsumerProxy() {
+				logger.Debugf("destroy consuming app proxy for %v", applicationTag.Id())
+				if err := remoteApp.Destroy(); err != nil {
+					return errors.Trace(err)
+				}
+			}
+		}
+	}
+
+	// TODO(wallyworld) - deal with remote application being removed
+	if applicationTag == nil {
+		logger.Infof("no remote application found for %v", relationTag.Id())
+		return nil
+	}
+	logger.Debugf("remote applocation for changed relation %v is %v", relationTag.Id(), applicationTag.Id())
+
+	for _, id := range change.DepartedUnits {
+		unitTag := names.NewUnitTag(fmt.Sprintf("%s/%v", applicationTag.Id(), id))
+		logger.Debugf("unit %v has departed relation %v", unitTag.Id(), relationTag.Id())
+		ru, err := rel.RemoteUnit(unitTag.Id())
+		if err != nil {
+			return errors.Trace(err)
+		}
+		logger.Debugf("%s leaving scope", unitTag.Id())
+		if err := ru.LeaveScope(); err != nil {
+			return errors.Trace(err)
+		}
+	}
+
+	for _, change := range change.ChangedUnits {
+		unitTag := names.NewUnitTag(fmt.Sprintf("%s/%v", applicationTag.Id(), change.UnitId))
+		logger.Debugf("changed unit tag for remote id %v is %v", change.UnitId, unitTag)
+		ru, err := rel.RemoteUnit(unitTag.Id())
+		if err != nil {
+			return errors.Trace(err)
+		}
+		inScope, err := ru.InScope()
+		if err != nil {
+			return errors.Trace(err)
+		}
+		settings := make(map[string]interface{})
+		for k, v := range change.Settings {
+			settings[k] = v
+		}
+		if !inScope {
+			logger.Debugf("%s entering scope (%v)", unitTag.Id(), settings)
+			err = ru.EnterScope(settings)
+		} else {
+			logger.Debugf("%s updated settings (%v)", unitTag.Id(), settings)
+			err = ru.ReplaceSettings(settings)
+		}
+		if err != nil {
+			return errors.Trace(err)
+		}
+	}
+	return nil
+}
+
+func (api *CrossModelRelationsAPI) getRemoteEntityTag(id params.RemoteEntityId) (names.Tag, error) {
+	modelTag := names.NewModelTag(id.ModelUUID)
+	return api.st.GetRemoteEntity(modelTag, id.Token)
+}
+
+// RegisterRemoteRelations sets up the local model to participate
+// in the specified relations. This operation is idempotent.
+func (api *CrossModelRelationsAPI) RegisterRemoteRelations(
+	relations params.RegisterRemoteRelations,
+) (params.RemoteEntityIdResults, error) {
+	results := params.RemoteEntityIdResults{
+		Results: make([]params.RemoteEntityIdResult, len(relations.Relations)),
+	}
+	for i, relation := range relations.Relations {
+		// TODO(wallyworld) - check macaroon
+		if id, err := api.registerRemoteRelation(relation); err != nil {
+			results.Results[i].Error = common.ServerError(err)
+			continue
+		} else {
+			results.Results[i].Result = id
+		}
+	}
+	return results, nil
+}
+
+func (api *CrossModelRelationsAPI) registerRemoteRelation(relation params.RegisterRemoteRelation) (*params.RemoteEntityId, error) {
+	logger.Debugf("register remote relation %+v", relation)
+	// TODO(wallyworld) - do this as a transaction so the result is atomic
+	// Perform some initial validation - is the local application alive?
+
+	// Look up the offer record so get the local application to which we need to relate.
+	appOffers, err := api.st.ListOffers(crossmodel.ApplicationOfferFilter{
+		OfferName: relation.OfferName,
+	})
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	if len(appOffers) == 0 {
+		return nil, errors.NotFoundf("application offer %v", relation.OfferName)
+	}
+	localApplicationName := appOffers[0].ApplicationName
+
+	localApp, err := api.st.Application(localApplicationName)
+	if err != nil {
+		return nil, errors.Annotatef(err, "cannot get application for offer %q", relation.OfferName)
+	}
+	if localApp.Life() != state.Alive {
+		// We don't want to leak the application name so just log it.
+		logger.Warningf("local application for offer %v not found", localApplicationName)
+		return nil, errors.NotFoundf("local application for offer %v", relation.OfferName)
+	}
+	eps, err := localApp.Endpoints()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	// Does the requested local endpoint exist?
+	var localEndpoint *state.Endpoint
+	for _, ep := range eps {
+		if ep.Name == relation.LocalEndpointName {
+			localEndpoint = &ep
+			break
+		}
+	}
+	if localEndpoint == nil {
+		return nil, errors.NotFoundf("relation endpoint %v", relation.LocalEndpointName)
+	}
+
+	// Add the remote application reference. We construct a unique, opaque application name based on the
+	// token passed in from the consuming model. This model, which is offering the application being
+	// related to, does not need to know the name of the consuming application.
+	uniqueRemoteApplicationName := "remote-" + strings.Replace(relation.ApplicationId.Token, "-", "", -1)
+	remoteEndpoint := state.Endpoint{
+		ApplicationName: uniqueRemoteApplicationName,
+		Relation: charm.Relation{
+			Name:      relation.RemoteEndpoint.Name,
+			Scope:     relation.RemoteEndpoint.Scope,
+			Interface: relation.RemoteEndpoint.Interface,
+			Role:      relation.RemoteEndpoint.Role,
+			Limit:     relation.RemoteEndpoint.Limit,
+		},
+	}
+
+	remoteModelTag := names.NewModelTag(relation.ApplicationId.ModelUUID)
+	_, err = api.st.AddRemoteApplication(state.AddRemoteApplicationParams{
+		Name:            uniqueRemoteApplicationName,
+		OfferName:       relation.OfferName,
+		SourceModel:     names.NewModelTag(relation.ApplicationId.ModelUUID),
+		Token:           relation.ApplicationId.Token,
+		Endpoints:       []charm.Relation{remoteEndpoint.Relation},
+		IsConsumerProxy: true,
+	})
+	// If it already exists, that's fine.
+	if err != nil && !errors.IsAlreadyExists(err) {
+		return nil, errors.Annotatef(err, "adding remote application %v", uniqueRemoteApplicationName)
+	}
+	logger.Debugf("added remote application %v to local model with token %v", uniqueRemoteApplicationName, relation.ApplicationId.Token)
+
+	// Now add the relation if it doesn't already exist.
+	localRel, err := api.st.EndpointsRelation(*localEndpoint, remoteEndpoint)
+	if err != nil && !errors.IsNotFound(err) {
+		return nil, errors.Trace(err)
+	}
+	if err != nil {
+		localRel, err = api.st.AddRelation(*localEndpoint, remoteEndpoint)
+		// Again, if it already exists, that's fine.
+		if err != nil && !errors.IsAlreadyExists(err) {
+			return nil, errors.Annotate(err, "adding remote relation")
+		}
+		logger.Debugf("added relation %v to model %v", localRel.Tag().Id(), api.st.ModelUUID())
+	}
+
+	// Ensure we have references recorded.
+	logger.Debugf("importing remote relation into model %v", api.st.ModelUUID())
+	logger.Debugf("remote model is %v", remoteModelTag.Id())
+
+	err = api.st.ImportRemoteEntity(remoteModelTag, localRel.Tag(), relation.RelationId.Token)
+	if err != nil && !errors.IsAlreadyExists(err) {
+		return nil, errors.Annotatef(err, "importing remote relation %v to local model", localRel.Tag().Id())
+	}
+	logger.Debugf("relation token %v exported for %v ", relation.RelationId.Token, localRel.Tag().Id())
+
+	// Export the local application from this model so we can tell the caller what the remote id is.
+	// NB we need to export the application last so that everything else is in place when the worker is
+	// woken up by the watcher.
+	token, err := api.st.ExportLocalEntity(names.NewApplicationTag(localApplicationName))
+	if err != nil && !errors.IsAlreadyExists(err) {
+		return nil, errors.Annotatef(err, "exporting local application %v", localApplicationName)
+	}
+	logger.Debugf("local application %v from model %v exported with token %v ", localApplicationName, api.st.ModelUUID(), token)
+	return &params.RemoteEntityId{
+		ModelUUID: api.st.ModelUUID(),
+		Token:     token,
+	}, nil
+}

--- a/apiserver/crossmodelrelations/crossmodelrelations_test.go
+++ b/apiserver/crossmodelrelations/crossmodelrelations_test.go
@@ -1,0 +1,139 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package crossmodelrelations_test
+
+import (
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/charm.v6-unstable"
+	"gopkg.in/juju/names.v2"
+
+	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/crossmodelrelations"
+	"github.com/juju/juju/apiserver/params"
+	apiservertesting "github.com/juju/juju/apiserver/testing"
+	"github.com/juju/juju/core/crossmodel"
+	"github.com/juju/juju/state"
+	coretesting "github.com/juju/juju/testing"
+)
+
+var _ = gc.Suite(&remoteRelationsSuite{})
+
+type remoteRelationsSuite struct {
+	coretesting.BaseSuite
+
+	resources  *common.Resources
+	authorizer *apiservertesting.FakeAuthorizer
+	st         *mockState
+	api        *crossmodelrelations.CrossModelRelationsAPI
+}
+
+func (s *remoteRelationsSuite) SetUpTest(c *gc.C) {
+	s.BaseSuite.SetUpTest(c)
+
+	s.resources = common.NewResources()
+	s.AddCleanup(func(_ *gc.C) { s.resources.StopAll() })
+
+	s.authorizer = &apiservertesting.FakeAuthorizer{
+		Tag:        names.NewMachineTag("0"),
+		Controller: true,
+	}
+
+	s.st = newMockState()
+	api, err := crossmodelrelations.NewCrossModelRelationsAPI(s.st, s.resources, s.authorizer)
+	c.Assert(err, jc.ErrorIsNil)
+	s.api = api
+}
+
+func (s *remoteRelationsSuite) TestPublishLocalRelationsChange(c *gc.C) {
+	s.st.remoteApplications["db2"] = &mockRemoteApplication{}
+	s.st.remoteEntities[names.NewApplicationTag("db2")] = "token-db2"
+	rel := newMockRelation(1)
+	ru1 := newMockRelationUnit()
+	ru2 := newMockRelationUnit()
+	rel.units["db2/1"] = ru1
+	rel.units["db2/2"] = ru2
+	s.st.relations["db2:db django:db"] = rel
+	s.st.remoteEntities[names.NewRelationTag("db2:db django:db")] = "token-db2:db django:db"
+	results, err := s.api.PublishLocalRelationChange(params.RemoteRelationsChanges{
+		Changes: []params.RemoteRelationChangeEvent{
+			{
+				Life: params.Alive,
+				ApplicationId: params.RemoteEntityId{
+					ModelUUID: "uuid",
+					Token:     "token-db2"},
+				RelationId: params.RemoteEntityId{
+					ModelUUID: "uuid",
+					Token:     "token-db2:db django:db"},
+				ChangedUnits: []params.RemoteRelationUnitChange{{
+					UnitId:   1,
+					Settings: map[string]interface{}{"foo": "bar"},
+				}},
+				DepartedUnits: []int{2},
+			},
+		},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	err = results.Combine()
+	c.Assert(err, jc.ErrorIsNil)
+	s.st.CheckCalls(c, []testing.StubCall{
+		{"GetRemoteEntity", []interface{}{names.NewModelTag("uuid"), "token-db2:db django:db"}},
+		{"KeyRelation", []interface{}{"db2:db django:db"}},
+		{"GetRemoteEntity", []interface{}{names.NewModelTag("uuid"), "token-db2"}},
+	})
+	ru1.CheckCalls(c, []testing.StubCall{
+		{"InScope", []interface{}{}},
+		{"EnterScope", []interface{}{map[string]interface{}{"foo": "bar"}}},
+	})
+	ru2.CheckCalls(c, []testing.StubCall{
+		{"LeaveScope", []interface{}{}},
+	})
+}
+
+func (s *remoteRelationsSuite) assertRegisterRemoteRelations(c *gc.C) {
+	app := &mockApplication{}
+	app.eps = []state.Endpoint{{
+		ApplicationName: "offeredapp",
+		Relation:        charm.Relation{Name: "local"},
+	}}
+	s.st.applications["offeredapp"] = app
+	s.st.offers = []crossmodel.ApplicationOffer{{
+		OfferName:       "offered",
+		ApplicationName: "offeredapp",
+	}}
+	results, err := s.api.RegisterRemoteRelations(params.RegisterRemoteRelations{
+		Relations: []params.RegisterRemoteRelation{{
+			ApplicationId:     params.RemoteEntityId{ModelUUID: "model-uuid", Token: "app-token"},
+			RelationId:        params.RemoteEntityId{ModelUUID: "model-uuid", Token: "rel-token"},
+			RemoteEndpoint:    params.RemoteEndpoint{Name: "remote"},
+			OfferName:         "offered",
+			LocalEndpointName: "local",
+		}}})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(results.Results, gc.HasLen, 1)
+	result := results.Results[0]
+	c.Assert(result.Error, gc.IsNil)
+	c.Check(result.Result, jc.DeepEquals, &params.RemoteEntityId{
+		ModelUUID: coretesting.ModelTag.Id(), Token: "token-offeredapp"})
+	expectedRemoteApp := s.st.remoteApplications["remote-apptoken"]
+	expectedRemoteApp.Stub = testing.Stub{} // don't care about api calls
+
+	c.Check(expectedRemoteApp, jc.DeepEquals, &mockRemoteApplication{consumerproxy: true})
+	expectedRel := s.st.relations["offeredapp:local remote-apptoken:remote"]
+	expectedRel.Stub = testing.Stub{} // don't care about api calls
+	c.Check(expectedRel, jc.DeepEquals, &mockRelation{key: "offeredapp:local remote-apptoken:remote"})
+	c.Check(s.st.remoteEntities, gc.HasLen, 2)
+	c.Check(s.st.remoteEntities[names.NewApplicationTag("offeredapp")], gc.Equals, "token-offeredapp")
+	c.Check(s.st.remoteEntities[names.NewRelationTag("offeredapp:local remote-apptoken:remote")], gc.Equals, "rel-token")
+}
+
+func (s *remoteRelationsSuite) TestRegisterRemoteRelations(c *gc.C) {
+	s.assertRegisterRemoteRelations(c)
+}
+
+func (s *remoteRelationsSuite) TestRegisterRemoteRelationsIdempotent(c *gc.C) {
+	s.assertRegisterRemoteRelations(c)
+	s.assertRegisterRemoteRelations(c)
+}

--- a/apiserver/crossmodelrelations/mock_test.go
+++ b/apiserver/crossmodelrelations/mock_test.go
@@ -1,0 +1,285 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package crossmodelrelations_test
+
+import (
+	"fmt"
+
+	"github.com/juju/errors"
+	"github.com/juju/testing"
+	"gopkg.in/juju/names.v2"
+
+	"github.com/juju/juju/apiserver/crossmodelrelations"
+	"github.com/juju/juju/core/crossmodel"
+	"github.com/juju/juju/state"
+	coretesting "github.com/juju/juju/testing"
+)
+
+type mockState struct {
+	testing.Stub
+	relations          map[string]*mockRelation
+	remoteApplications map[string]*mockRemoteApplication
+	applications       map[string]*mockApplication
+	offers             []crossmodel.ApplicationOffer
+	remoteEntities     map[names.Tag]string
+}
+
+func newMockState() *mockState {
+	return &mockState{
+		relations:          make(map[string]*mockRelation),
+		remoteApplications: make(map[string]*mockRemoteApplication),
+		applications:       make(map[string]*mockApplication),
+		remoteEntities:     make(map[names.Tag]string),
+	}
+}
+
+func (st *mockState) ListOffers(filter ...crossmodel.ApplicationOfferFilter) ([]crossmodel.ApplicationOffer, error) {
+	return st.offers, nil
+}
+
+func (st *mockState) ModelUUID() string {
+	return coretesting.ModelTag.Id()
+}
+
+func (st *mockState) AddRelation(eps ...state.Endpoint) (crossmodelrelations.Relation, error) {
+	rel := &mockRelation{
+		key: fmt.Sprintf("%v:%v %v:%v", eps[0].ApplicationName, eps[0].Name, eps[1].ApplicationName, eps[1].Name)}
+	st.relations[rel.key] = rel
+	return rel, nil
+}
+
+func (st *mockState) EndpointsRelation(eps ...state.Endpoint) (crossmodelrelations.Relation, error) {
+	rel := &mockRelation{
+		key: fmt.Sprintf("%v:%v %v:%v", eps[0].ApplicationName, eps[0].Name, eps[1].ApplicationName, eps[1].Name)}
+	st.relations[rel.key] = rel
+	return rel, nil
+}
+
+func (st *mockState) AddRemoteApplication(params state.AddRemoteApplicationParams) (crossmodelrelations.RemoteApplication, error) {
+	app := &mockRemoteApplication{consumerproxy: params.IsConsumerProxy}
+	st.remoteApplications[params.Name] = app
+	return app, nil
+}
+
+func (st *mockState) ImportRemoteEntity(sourceModel names.ModelTag, entity names.Tag, token string) error {
+	st.MethodCall(st, "ImportRemoteEntity", sourceModel, entity, token)
+	if err := st.NextErr(); err != nil {
+		return err
+	}
+	if _, ok := st.remoteEntities[entity]; ok {
+		return errors.AlreadyExistsf(entity.Id())
+	}
+	st.remoteEntities[entity] = token
+	return nil
+}
+
+func (st *mockState) RemoveRemoteEntity(sourceModel names.ModelTag, entity names.Tag) error {
+	st.MethodCall(st, "RemoveRemoteEntity", sourceModel, entity)
+	if err := st.NextErr(); err != nil {
+		return err
+	}
+	delete(st.remoteEntities, entity)
+	return nil
+}
+
+func (st *mockState) ExportLocalEntity(entity names.Tag) (string, error) {
+	st.MethodCall(st, "ExportLocalEntity", entity)
+	if err := st.NextErr(); err != nil {
+		return "", err
+	}
+	if token, ok := st.remoteEntities[entity]; ok {
+		return token, errors.AlreadyExistsf(entity.Id())
+	}
+	token := "token-" + entity.Id()
+	st.remoteEntities[entity] = token
+	return token, nil
+}
+
+func (st *mockState) GetRemoteEntity(sourceModel names.ModelTag, token string) (names.Tag, error) {
+	st.MethodCall(st, "GetRemoteEntity", sourceModel, token)
+	if err := st.NextErr(); err != nil {
+		return nil, err
+	}
+	for e, t := range st.remoteEntities {
+		if t == token {
+			return e, nil
+		}
+	}
+	return nil, errors.NotFoundf("token %v", token)
+}
+
+func (st *mockState) GetToken(sourceModel names.ModelTag, entity names.Tag) (string, error) {
+	st.MethodCall(st, "GetToken", sourceModel, entity)
+	if err := st.NextErr(); err != nil {
+		return "", err
+	}
+	return "token-" + entity.String(), nil
+}
+
+func (st *mockState) KeyRelation(key string) (crossmodelrelations.Relation, error) {
+	st.MethodCall(st, "KeyRelation", key)
+	if err := st.NextErr(); err != nil {
+		return nil, err
+	}
+	r, ok := st.relations[key]
+	if !ok {
+		return nil, errors.NotFoundf("relation %q", key)
+	}
+	return r, nil
+}
+
+func (st *mockState) Relation(id int) (crossmodelrelations.Relation, error) {
+	st.MethodCall(st, "Relation", id)
+	if err := st.NextErr(); err != nil {
+		return nil, err
+	}
+	for _, r := range st.relations {
+		if r.id == id {
+			return r, nil
+		}
+	}
+	return nil, errors.NotFoundf("relation %d", id)
+}
+
+func (st *mockState) RemoteApplication(id string) (crossmodelrelations.RemoteApplication, error) {
+	st.MethodCall(st, "RemoteApplication", id)
+	if err := st.NextErr(); err != nil {
+		return nil, err
+	}
+	a, ok := st.remoteApplications[id]
+	if !ok {
+		return nil, errors.NotFoundf("remote application %q", id)
+	}
+	return a, nil
+}
+
+func (st *mockState) Application(id string) (crossmodelrelations.Application, error) {
+	st.MethodCall(st, "Application", id)
+	if err := st.NextErr(); err != nil {
+		return nil, err
+	}
+	a, ok := st.applications[id]
+	if !ok {
+		return nil, errors.NotFoundf("application %q", id)
+	}
+	return a, nil
+}
+
+type mockRelation struct {
+	testing.Stub
+	id    int
+	key   string
+	units map[string]crossmodelrelations.RelationUnit
+}
+
+func newMockRelation(id int) *mockRelation {
+	return &mockRelation{
+		id:    id,
+		units: make(map[string]crossmodelrelations.RelationUnit),
+	}
+}
+
+func (r *mockRelation) Tag() names.Tag {
+	r.MethodCall(r, "Tag")
+	return names.NewRelationTag(r.key)
+}
+
+func (r *mockRelation) Destroy() error {
+	r.MethodCall(r, "Destroy")
+	return r.NextErr()
+}
+
+func (r *mockRelation) RemoteUnit(unitId string) (crossmodelrelations.RelationUnit, error) {
+	r.MethodCall(r, "RemoteUnit", unitId)
+	if err := r.NextErr(); err != nil {
+		return nil, err
+	}
+	u, ok := r.units[unitId]
+	if !ok {
+		return nil, errors.NotFoundf("unit %q", unitId)
+	}
+	return u, nil
+}
+
+type mockRemoteApplication struct {
+	testing.Stub
+	consumerproxy bool
+}
+
+func (r *mockRemoteApplication) IsConsumerProxy() bool {
+	r.MethodCall(r, "IsConsumerProxy")
+	return r.consumerproxy
+}
+
+func (r *mockRemoteApplication) Destroy() error {
+	r.MethodCall(r, "Destroy")
+	return r.NextErr()
+}
+
+type mockApplication struct {
+	testing.Stub
+	life state.Life
+	eps  []state.Endpoint
+}
+
+func (a *mockApplication) Endpoints() ([]state.Endpoint, error) {
+	a.MethodCall(a, "Endpoints")
+	return a.eps, nil
+}
+
+func (a *mockApplication) Life() state.Life {
+	a.MethodCall(a, "Life")
+	return a.life
+}
+
+type mockRelationUnit struct {
+	testing.Stub
+	inScope  bool
+	settings map[string]interface{}
+}
+
+func newMockRelationUnit() *mockRelationUnit {
+	return &mockRelationUnit{
+		settings: make(map[string]interface{}),
+	}
+}
+
+func (u *mockRelationUnit) InScope() (bool, error) {
+	u.MethodCall(u, "InScope")
+	return u.inScope, u.NextErr()
+}
+
+func (u *mockRelationUnit) LeaveScope() error {
+	u.MethodCall(u, "LeaveScope")
+	if err := u.NextErr(); err != nil {
+		return err
+	}
+	u.inScope = false
+	return nil
+}
+
+func (u *mockRelationUnit) EnterScope(settings map[string]interface{}) error {
+	u.MethodCall(u, "EnterScope", settings)
+	if err := u.NextErr(); err != nil {
+		return err
+	}
+	u.inScope = true
+	u.settings = make(map[string]interface{})
+	for k, v := range settings {
+		u.settings[k] = v
+	}
+	return nil
+}
+
+func (u *mockRelationUnit) ReplaceSettings(settings map[string]interface{}) error {
+	u.MethodCall(u, "ReplaceSettings", settings)
+	if err := u.NextErr(); err != nil {
+		return err
+	}
+	u.settings = make(map[string]interface{})
+	for k, v := range settings {
+		u.settings[k] = v
+	}
+	return nil
+}

--- a/apiserver/crossmodelrelations/package_test.go
+++ b/apiserver/crossmodelrelations/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package crossmodelrelations_test
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func TestAll(t *testing.T) {
+	gc.TestingT(t)
+}

--- a/apiserver/crossmodelrelations/state.go
+++ b/apiserver/crossmodelrelations/state.go
@@ -1,20 +1,19 @@
-// Copyright 2015 Canonical Ltd.
+// Copyright 2017 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package remoterelations
+package crossmodelrelations
 
 import (
 	"github.com/juju/errors"
 	"gopkg.in/juju/names.v2"
-	"gopkg.in/macaroon.v1"
 
+	"github.com/juju/juju/core/crossmodel"
 	"github.com/juju/juju/state"
-	"github.com/juju/juju/status"
 )
 
 // RemoteRelationState provides the subset of global state required by the
 // remote relations facade.
-type RemoteRelationsState interface {
+type CrossModelRelationsState interface {
 	// ModelUUID returns the model UUID for the model
 	// controlled by this state instance.
 	ModelUUID() string
@@ -23,24 +22,21 @@ type RemoteRelationsState interface {
 	// be derived unambiguously from the relation's endpoints).
 	KeyRelation(string) (Relation, error)
 
+	// AddRelation adds a relation between the specified endpoints and returns the relation info.
+	AddRelation(...state.Endpoint) (Relation, error)
+
+	// EndpointsRelation returns the existing relation with the given endpoints.
+	EndpointsRelation(...state.Endpoint) (Relation, error)
+
+	// AddRemoteApplication creates a new remote application record, having the supplied relation endpoints,
+	// with the supplied name (which must be unique across all applications, local and remote).
+	AddRemoteApplication(state.AddRemoteApplicationParams) (RemoteApplication, error)
+
 	// RemoteApplication returns a remote application by name.
 	RemoteApplication(string) (RemoteApplication, error)
 
 	// Application returns a local application by name.
 	Application(string) (Application, error)
-
-	// WatchRemoteApplications returns a StringsWatcher that notifies of changes to
-	// the lifecycles of the remote applications in the model.
-	WatchRemoteApplications() state.StringsWatcher
-
-	// WatchRemoteApplicationRelations returns a StringsWatcher that notifies of
-	// changes to the lifecycles of relations involving the specified remote
-	// application.
-	WatchRemoteApplicationRelations(applicationName string) (state.StringsWatcher, error)
-
-	// WatchRemoteRelations returns a StringsWatcher that notifies of changes to
-	// the lifecycles of remote relations in the model.
-	WatchRemoteRelations() state.StringsWatcher
 
 	// ExportLocalEntity adds an entity to the remote entities collection,
 	// returning an opaque token that uniquely identifies the entity within
@@ -55,86 +51,78 @@ type RemoteRelationsState interface {
 	// with the specified opaque token.
 	ImportRemoteEntity(sourceModel names.ModelTag, entity names.Tag, token string) error
 
-	// RemoveRemoteEntity removes the specified entity from the remote entities collection.
-	RemoveRemoteEntity(sourceModel names.ModelTag, entity names.Tag) error
-
-	// GetToken returns the token associated with the entity with the given tag
-	// and model.
-	GetToken(names.ModelTag, names.Tag) (string, error)
+	// ListOffers returns the application offers matching any one of the filter terms.
+	ListOffers(filter ...crossmodel.ApplicationOfferFilter) ([]crossmodel.ApplicationOffer, error)
 }
 
 // Relation provides access a relation in global state.
 type Relation interface {
-	// Id returns the integer internal relation key.
-	Id() int
+	// Destroy ensures that the relation will be removed at some point; if
+	// no units are currently in scope, it will be removed immediately.
+	Destroy() error
 
 	// Tag returns the relation's tag.
 	Tag() names.Tag
 
-	// Life returns the relation's current life state.
-	Life() state.Life
-
 	// Endpoints returns the endpoints that constitute the relation.
-	Endpoints() []state.Endpoint
-
-	// Unit returns a RelationUnit for the unit with the supplied ID.
-	Unit(unitId string) (RelationUnit, error)
-
-	// WatchUnits returns a watcher that notifies of changes to the units of the
-	// specified application in the relation.
-	WatchUnits(applicationName string) (state.RelationUnitsWatcher, error)
+	// RemoteUnit returns a RelationUnit for the remote application unit
+	// with the supplied ID.
+	RemoteUnit(unitId string) (RelationUnit, error)
 }
 
 // RelationUnit provides access to the settings of a single unit in a relation,
 // and methods for modifying the unit's involvement in the relation.
 type RelationUnit interface {
-	// Settings returns the relation unit's settings within the relation.
-	Settings() (map[string]interface{}, error)
+	// EnterScope ensures that the unit has entered its scope in the
+	// relation. When the unit has already entered its scope, EnterScope
+	// will report success but make no changes to state.
+	EnterScope(settings map[string]interface{}) error
+
+	// InScope returns whether the relation unit has entered scope and
+	// not left it.
+	InScope() (bool, error)
+
+	// LeaveScope signals that the unit has left its scope in the relation.
+	// After the unit has left its relation scope, it is no longer a member
+	// of the relation; if the relation is dying when its last member unit
+	// leaves, it is removed immediately. It is not an error to leave a
+	// scope that the unit is not, or never was, a member of.
+	LeaveScope() error
+
+	// ReplaceSettings replaces the relation unit's settings within the
+	// relation.
+	ReplaceSettings(map[string]interface{}) error
 }
 
 // RemoteApplication represents the state of an application hosted in an external
 // (remote) model.
 type RemoteApplication interface {
-	// Name returns the name of the remote application.
-	Name() string
-
-	// OfferName returns the name the offering side has given to the remote application..
-	OfferName() string
-
-	// Tag returns the remote applications's tag.
-	Tag() names.Tag
-
-	// SourceModel returns the tag of the model hosting the remote application.
-	SourceModel() names.ModelTag
-
-	// Macaroon returns the macaroon used for authentication.
-	Macaroon() (*macaroon.Macaroon, error)
-
 	// IsConsumerProxy returns whether application is created
 	// from a registration operation by a consuming model.
 	IsConsumerProxy() bool
 
-	// URL returns the remote application URL, at which it is offered.
-	URL() (string, bool)
-
-	// Life returns the lifecycle state of the application.
-	Life() state.Life
-
-	// Status returns the status of the remote application.
-	Status() (status.StatusInfo, error)
+	// Destroy ensures that this remote application reference and all its relations
+	// will be removed at some point; if no relation involving the
+	// application has any units in scope, they are all removed immediately.
+	Destroy() error
 }
 
 // Application represents the state of a application hosted in the local model.
 type Application interface {
-	// Name is the name of the application.
-	Name() string
-
 	// Life returns the lifecycle state of the application.
 	Life() state.Life
+
+	// Endpoints returns the application's currently available relation endpoints.
+	Endpoints() ([]state.Endpoint, error)
 }
 
 type stateShim struct {
 	*state.State
+}
+
+func (st stateShim) ListOffers(filter ...crossmodel.ApplicationOfferFilter) ([]crossmodel.ApplicationOffer, error) {
+	oa := state.NewApplicationOffers(st.State)
+	return oa.ListOffers(filter...)
 }
 
 func (st stateShim) ExportLocalEntity(entity names.Tag) (string, error) {
@@ -170,6 +158,30 @@ func (st stateShim) KeyRelation(key string) (Relation, error) {
 	return relationShim{r, st.State}, nil
 }
 
+func (st stateShim) Relation(id int) (Relation, error) {
+	r, err := st.State.Relation(id)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return relationShim{r, st.State}, nil
+}
+
+func (st stateShim) AddRelation(eps ...state.Endpoint) (Relation, error) {
+	r, err := st.State.AddRelation(eps...)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return relationShim{r, st.State}, nil
+}
+
+func (st stateShim) EndpointsRelation(eps ...state.Endpoint) (Relation, error) {
+	r, err := st.State.EndpointsRelation(eps...)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return relationShim{r, st.State}, nil
+}
+
 func (st stateShim) RemoteApplication(name string) (RemoteApplication, error) {
 	a, err := st.State.RemoteApplication(name)
 	if err != nil {
@@ -178,12 +190,12 @@ func (st stateShim) RemoteApplication(name string) (RemoteApplication, error) {
 	return &remoteApplicationShim{a}, nil
 }
 
-func (st stateShim) WatchRemoteApplicationRelations(applicationName string) (state.StringsWatcher, error) {
-	a, err := st.State.RemoteApplication(applicationName)
+func (st stateShim) AddRemoteApplication(args state.AddRemoteApplicationParams) (RemoteApplication, error) {
+	a, err := st.State.AddRemoteApplication(args)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	return a.WatchRelations(), nil
+	return remoteApplicationShim{a}, nil
 }
 
 type relationShim struct {
@@ -199,28 +211,24 @@ func (r relationShim) RemoteUnit(unitId string) (RelationUnit, error) {
 	return relationUnitShim{ru}, nil
 }
 
-func (r relationShim) Unit(unitId string) (RelationUnit, error) {
-	unit, err := r.st.Unit(unitId)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	ru, err := r.Relation.Unit(unit)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	return relationUnitShim{ru}, nil
-}
-
 type relationUnitShim struct {
 	*state.RelationUnit
 }
 
-func (r relationUnitShim) Settings() (map[string]interface{}, error) {
+func (r relationUnitShim) ReplaceSettings(s map[string]interface{}) error {
 	settings, err := r.RelationUnit.Settings()
 	if err != nil {
-		return nil, errors.Trace(err)
+		return errors.Trace(err)
 	}
-	return settings.Map(), nil
+	settings.Update(s)
+	for _, key := range settings.Keys() {
+		if _, ok := s[key]; ok {
+			continue
+		}
+		settings.Delete(key)
+	}
+	_, err = settings.Write()
+	return errors.Trace(err)
 }
 
 type remoteApplicationShim struct {

--- a/apiserver/params/crossmodel.go
+++ b/apiserver/params/crossmodel.go
@@ -132,6 +132,10 @@ type ConsumeApplicationArg struct {
 	// Macaroon is used for authentication.
 	Macaroon *macaroon.Macaroon `json:"macaroon,omitempty"`
 
+	// ControllerInfo contains connection details to the controller
+	// hosting the offer.
+	ControllerInfo *ExternalControllerInfo `json:"external-controller,omitempty"`
+
 	// ApplicationAlias is the name of the alias to use for the application name.
 	ApplicationAlias string `json:"application-alias,omitempty"`
 }
@@ -205,6 +209,9 @@ type RemoteApplication struct {
 	// IsConsumerProxy returns the application is created
 	// from a registration operation by a consuming model.
 	Registered bool `json:"registered"`
+
+	// Macaroon is used for authentication.
+	Macaroon *macaroon.Macaroon `json:"macaroon,omitempty"`
 }
 
 // GetTokenArgs holds the arguments to a GetTokens API call.
@@ -313,6 +320,9 @@ type RemoteRelationChangeEvent struct {
 	// DepartedUnits contains the ids of units that have departed
 	// the relation since the last change.
 	DepartedUnits []int `json:"departed-units,omitempty"`
+
+	// Macaroon is used for authentication.
+	Macaroon *macaroon.Macaroon `json:"macaroon,omitempty"`
 }
 
 // RegisterRemoteRelation holds attributes used to register a remote relation.
@@ -335,6 +345,9 @@ type RegisterRemoteRelation struct {
 
 	// LocalEndpointName is the name of the endpoint in the local model.
 	LocalEndpointName string `json:"local-endpoint-name"`
+
+	// Macaroon is used for authentication.
+	Macaroon *macaroon.Macaroon `json:"macaroon,omitempty"`
 }
 
 // RegisterRemoteRelations holds args used to add remote relations.
@@ -372,8 +385,9 @@ type RemoteApplicationInfoResults struct {
 // ConsumeOfferDetails contains the details necessary to
 // consume an application offer.
 type ConsumeOfferDetails struct {
-	Offer    *ApplicationOffer  `json:"offer,omitempty"`
-	Macaroon *macaroon.Macaroon `json:"macaroon,omitempty"`
+	Offer          *ApplicationOffer       `json:"offer,omitempty"`
+	Macaroon       *macaroon.Macaroon      `json:"macaroon,omitempty"`
+	ControllerInfo *ExternalControllerInfo `json:"external-controller,omitempty"`
 }
 
 // ConsumeOfferDetailsResult contains the details necessary to
@@ -425,3 +439,11 @@ const (
 	OfferConsumeAccess OfferAccessPermission = "consume"
 	OfferReadAccess    OfferAccessPermission = "read"
 )
+
+// ExternalControllerInfo holds addressed and other information
+// needed to make a connection to an external controller.
+type ExternalControllerInfo struct {
+	ControllerTag string   `json:"controller-tag"`
+	Addrs         []string `json:"addrs"`
+	CACert        string   `json:"ca-cert"`
+}

--- a/apiserver/remoterelations/mock_test.go
+++ b/apiserver/remoterelations/mock_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/juju/testing"
 	"gopkg.in/juju/charm.v6-unstable"
 	"gopkg.in/juju/names.v2"
+	"gopkg.in/macaroon.v1"
 	"gopkg.in/tomb.v1"
 
 	"github.com/juju/juju/apiserver/params"
@@ -341,6 +342,11 @@ func (r *mockRemoteApplication) URL() (string, bool) {
 func (r *mockRemoteApplication) SourceModel() names.ModelTag {
 	r.MethodCall(r, "SourceModel")
 	return names.NewModelTag("model-uuid")
+}
+
+func (r *mockRemoteApplication) Macaroon() (*macaroon.Macaroon, error) {
+	r.MethodCall(r, "Macaroon")
+	return macaroon.New(nil, "test", "")
 }
 
 func (r *mockRemoteApplication) Destroy() error {

--- a/apiserver/remoterelations/remoterelations.go
+++ b/apiserver/remoterelations/remoterelations.go
@@ -4,42 +4,32 @@
 package remoterelations
 
 import (
-	"fmt"
-	"strings"
-
 	"github.com/juju/errors"
-	"github.com/juju/loggo"
-	"gopkg.in/juju/charm.v6-unstable"
 	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/apiserver/params"
-	"github.com/juju/juju/core/crossmodel"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/watcher"
 )
 
-var logger = loggo.GetLogger("juju.apiserver.remoterelations")
-
-// RemoteRelationsAPI provides access to the Provisioner API facade.
+// RemoteRelationsAPI provides access to the RemoteRelations API facade.
 type RemoteRelationsAPI struct {
 	st         RemoteRelationsState
-	pool       StatePool
 	resources  facade.Resources
 	authorizer facade.Authorizer
 }
 
-// NewRemoteRelationsAPI creates a new server-side RemoteRelationsAPI facade
+// NewStateRemoteRelationsAPI creates a new server-side RemoteRelationsAPI facade
 // backed by global state.
 func NewStateRemoteRelationsAPI(ctx facade.Context) (*RemoteRelationsAPI, error) {
-	return NewRemoteRelationsAPI(stateShim{ctx.State()}, statePoolShim{ctx.StatePool()}, ctx.Resources(), ctx.Auth())
+	return NewRemoteRelationsAPI(stateShim{ctx.State()}, ctx.Resources(), ctx.Auth())
 }
 
 // NewRemoteRelationsAPI returns a new server-side RemoteRelationsAPI facade.
 func NewRemoteRelationsAPI(
 	st RemoteRelationsState,
-	pool StatePool,
 	resources facade.Resources,
 	authorizer facade.Authorizer,
 ) (*RemoteRelationsAPI, error) {
@@ -48,7 +38,6 @@ func NewRemoteRelationsAPI(
 	}
 	return &RemoteRelationsAPI{
 		st:         st,
-		pool:       pool,
 		resources:  resources,
 		authorizer: authorizer,
 	}, nil
@@ -304,262 +293,6 @@ func (api *RemoteRelationsAPI) RemoteApplications(entities params.Entities) (par
 		results.Results[i].Result = remoteApplication
 	}
 	return results, nil
-}
-
-// PublishLocalRelationChange publishes local relations changes to the
-// remote side offering those relations.
-func (api *RemoteRelationsAPI) PublishLocalRelationChange(
-	changes params.RemoteRelationsChanges,
-) (params.ErrorResults, error) {
-	results := params.ErrorResults{
-		Results: make([]params.ErrorResult, len(changes.Changes)),
-	}
-	for i, change := range changes.Changes {
-		if err := api.publishRelationChange(change); err != nil {
-			results.Results[i].Error = common.ServerError(err)
-			continue
-		}
-	}
-	return results, nil
-}
-
-func (api *RemoteRelationsAPI) publishRelationChange(change params.RemoteRelationChangeEvent) error {
-	logger.Debugf("publish into model %v change: %+v", api.st.ModelUUID(), change)
-
-	relationTag, err := api.getRemoteEntityTag(change.RelationId)
-	if err != nil {
-		if errors.IsNotFound(err) {
-			logger.Debugf("not found relation tag %+v in model %v, exit early", change.RelationId, api.st.ModelUUID())
-			return nil
-		}
-		return errors.Trace(err)
-	}
-	logger.Debugf("relation tag for remote id %+v is %v", change.RelationId, relationTag)
-
-	// Ensure the relation exists.
-	rel, err := api.st.KeyRelation(relationTag.Id())
-	if errors.IsNotFound(err) {
-		if change.Life != params.Alive {
-			return nil
-		}
-	}
-	if err != nil {
-		return errors.Trace(err)
-	}
-
-	// Look up the application on the remote side of this relation
-	// ie from the model which published this change.
-	applicationTag, err := api.getRemoteEntityTag(change.ApplicationId)
-	if err != nil {
-		return errors.Trace(err)
-	}
-	logger.Debugf("application tag for remote id %+v is %v", change.ApplicationId, applicationTag)
-
-	// If the remote model has destroyed the relation, do it here also.
-	if change.Life != params.Alive {
-		logger.Debugf("remote side of %v died", relationTag)
-		if err := rel.Destroy(); err != nil {
-			return errors.Trace(err)
-		}
-		// See if we need to remove the remote application proxy - we do this
-		// on the offering side as there is 1:1 between proxy and consuming app.
-		if applicationTag != nil {
-			remoteApp, err := api.st.RemoteApplication(applicationTag.Id())
-			if err != nil && !errors.IsNotFound(err) {
-				return errors.Trace(err)
-			}
-			if err == nil && remoteApp.IsConsumerProxy() {
-				logger.Debugf("destroy consuming app proxy for %v", remoteApp.Name())
-				if err := remoteApp.Destroy(); err != nil {
-					return errors.Trace(err)
-				}
-			}
-		}
-	}
-
-	// TODO(wallyworld) - deal with remote application being removed
-	if applicationTag == nil {
-		logger.Infof("no remote application found for %v", relationTag.Id())
-		return nil
-	}
-	logger.Debugf("remote applocation for changed relation %v is %v", relationTag.Id(), applicationTag.Id())
-
-	for _, id := range change.DepartedUnits {
-		unitTag := names.NewUnitTag(fmt.Sprintf("%s/%v", applicationTag.Id(), id))
-		logger.Debugf("unit %v has departed relation %v", unitTag.Id(), relationTag.Id())
-		ru, err := rel.RemoteUnit(unitTag.Id())
-		if err != nil {
-			return errors.Trace(err)
-		}
-		logger.Debugf("%s leaving scope", unitTag.Id())
-		if err := ru.LeaveScope(); err != nil {
-			return errors.Trace(err)
-		}
-	}
-
-	for _, change := range change.ChangedUnits {
-		unitTag := names.NewUnitTag(fmt.Sprintf("%s/%v", applicationTag.Id(), change.UnitId))
-		logger.Debugf("changed unit tag for remote id %v is %v", change.UnitId, unitTag)
-		ru, err := rel.RemoteUnit(unitTag.Id())
-		if err != nil {
-			return errors.Trace(err)
-		}
-		inScope, err := ru.InScope()
-		if err != nil {
-			return errors.Trace(err)
-		}
-		settings := make(map[string]interface{})
-		for k, v := range change.Settings {
-			settings[k] = v
-		}
-		if !inScope {
-			logger.Debugf("%s entering scope (%v)", unitTag.Id(), settings)
-			err = ru.EnterScope(settings)
-		} else {
-			logger.Debugf("%s updated settings (%v)", unitTag.Id(), settings)
-			err = ru.ReplaceSettings(settings)
-		}
-		if err != nil {
-			return errors.Trace(err)
-		}
-	}
-	return nil
-}
-
-func (api *RemoteRelationsAPI) getRemoteEntityTag(id params.RemoteEntityId) (names.Tag, error) {
-	modelTag := names.NewModelTag(id.ModelUUID)
-	return api.st.GetRemoteEntity(modelTag, id.Token)
-}
-
-// RegisterRemoteRelations sets up the local model to participate
-// in the specified relations. This operation is idempotent.
-func (api *RemoteRelationsAPI) RegisterRemoteRelations(
-	relations params.RegisterRemoteRelations,
-) (params.RemoteEntityIdResults, error) {
-	results := params.RemoteEntityIdResults{
-		Results: make([]params.RemoteEntityIdResult, len(relations.Relations)),
-	}
-	for i, relation := range relations.Relations {
-		// TODO(wallyworld) - check macaroon
-		if id, err := api.registerRemoteRelation(relation); err != nil {
-			results.Results[i].Error = common.ServerError(err)
-			continue
-		} else {
-			results.Results[i].Result = id
-		}
-	}
-	return results, nil
-}
-
-func (api *RemoteRelationsAPI) registerRemoteRelation(relation params.RegisterRemoteRelation) (*params.RemoteEntityId, error) {
-	logger.Debugf("register remote relation %+v", relation)
-	// TODO(wallyworld) - do this as a transaction so the result is atomic
-	// Perform some initial validation - is the local application alive?
-
-	// Look up the offer record so get the local application to which we need to relate.
-	appOffers, err := api.st.ListOffers(crossmodel.ApplicationOfferFilter{
-		OfferName: relation.OfferName,
-	})
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	if len(appOffers) == 0 {
-		return nil, errors.NotFoundf("application offer %v", relation.OfferName)
-	}
-	localApplicationName := appOffers[0].ApplicationName
-
-	localApp, err := api.st.Application(localApplicationName)
-	if err != nil {
-		return nil, errors.Annotatef(err, "cannot get application for offer %q", relation.OfferName)
-	}
-	if localApp.Life() != state.Alive {
-		// We don't want to leak the application name so just log it.
-		logger.Warningf("local application for offer %v not found", localApplicationName)
-		return nil, errors.NotFoundf("local application for offer %v", relation.OfferName)
-	}
-	eps, err := localApp.Endpoints()
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-
-	// Does the requested local endpoint exist?
-	var localEndpoint *state.Endpoint
-	for _, ep := range eps {
-		if ep.Name == relation.LocalEndpointName {
-			localEndpoint = &ep
-			break
-		}
-	}
-	if localEndpoint == nil {
-		return nil, errors.NotFoundf("relation endpoint %v", relation.LocalEndpointName)
-	}
-
-	// Add the remote application reference. We construct a unique, opaque application name based on the
-	// token passed in from the consuming model. This model, which is offering the application being
-	// related to, does not need to know the name of the consuming application.
-	uniqueRemoteApplicationName := "remote-" + strings.Replace(relation.ApplicationId.Token, "-", "", -1)
-	remoteEndpoint := state.Endpoint{
-		ApplicationName: uniqueRemoteApplicationName,
-		Relation: charm.Relation{
-			Name:      relation.RemoteEndpoint.Name,
-			Scope:     relation.RemoteEndpoint.Scope,
-			Interface: relation.RemoteEndpoint.Interface,
-			Role:      relation.RemoteEndpoint.Role,
-			Limit:     relation.RemoteEndpoint.Limit,
-		},
-	}
-
-	remoteModelTag := names.NewModelTag(relation.ApplicationId.ModelUUID)
-	_, err = api.st.AddRemoteApplication(state.AddRemoteApplicationParams{
-		Name:            uniqueRemoteApplicationName,
-		OfferName:       relation.OfferName,
-		SourceModel:     names.NewModelTag(relation.ApplicationId.ModelUUID),
-		Token:           relation.ApplicationId.Token,
-		Endpoints:       []charm.Relation{remoteEndpoint.Relation},
-		IsConsumerProxy: true,
-	})
-	// If it already exists, that's fine.
-	if err != nil && !errors.IsAlreadyExists(err) {
-		return nil, errors.Annotatef(err, "adding remote application %v", uniqueRemoteApplicationName)
-	}
-	logger.Debugf("added remote application %v to local model with token %v", uniqueRemoteApplicationName, relation.ApplicationId.Token)
-
-	// Now add the relation if it doesn't already exist.
-	localRel, err := api.st.EndpointsRelation(*localEndpoint, remoteEndpoint)
-	if err != nil && !errors.IsNotFound(err) {
-		return nil, errors.Trace(err)
-	}
-	if err != nil {
-		localRel, err = api.st.AddRelation(*localEndpoint, remoteEndpoint)
-		// Again, if it already exists, that's fine.
-		if err != nil && !errors.IsAlreadyExists(err) {
-			return nil, errors.Annotate(err, "adding remote relation")
-		}
-		logger.Debugf("added relation %v to model %v", localRel.Tag().Id(), api.st.ModelUUID())
-	}
-
-	// Ensure we have references recorded.
-	logger.Debugf("importing remote relation into model %v", api.st.ModelUUID())
-	logger.Debugf("remote model is %v", remoteModelTag.Id())
-
-	err = api.st.ImportRemoteEntity(remoteModelTag, localRel.Tag(), relation.RelationId.Token)
-	if err != nil && !errors.IsAlreadyExists(err) {
-		return nil, errors.Annotatef(err, "importing remote relation %v to local model", localRel.Tag().Id())
-	}
-	logger.Debugf("relation token %v exported for %v ", relation.RelationId.Token, localRel.Tag().Id())
-
-	// Export the local application from this model so we can tell the caller what the remote id is.
-	// NB we need to export the application last so that everything else is in place when the worker is
-	// woken up by the watcher.
-	token, err := api.st.ExportLocalEntity(names.NewApplicationTag(localApp.Name()))
-	if err != nil && !errors.IsAlreadyExists(err) {
-		return nil, errors.Annotatef(err, "exporting local application %v", localApp.Name())
-	}
-	logger.Debugf("local application %v from model %v exported with token %v ", localApp.Name(), api.st.ModelUUID(), token)
-	return &params.RemoteEntityId{
-		ModelUUID: api.st.ModelUUID(),
-		Token:     token,
-	}, nil
 }
 
 // WatchRemoteApplications starts a strings watcher that notifies of the addition,

--- a/apiserver/remoterelations/remoterelations.go
+++ b/apiserver/remoterelations/remoterelations.go
@@ -281,6 +281,10 @@ func (api *RemoteRelationsAPI) RemoteApplications(entities params.Entities) (par
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
+		mac, err := remoteApp.Macaroon()
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
 		return &params.RemoteApplication{
 			Name:       remoteApp.Name(),
 			OfferName:  remoteApp.OfferName(),
@@ -288,6 +292,7 @@ func (api *RemoteRelationsAPI) RemoteApplications(entities params.Entities) (par
 			Status:     status.Status.String(),
 			ModelUUID:  remoteApp.SourceModel().Id(),
 			Registered: remoteApp.IsConsumerProxy(),
+			Macaroon:   mac,
 		}, nil
 	}
 	for i, entity := range entities.Entities {
@@ -435,6 +440,7 @@ func (api *RemoteRelationsAPI) RegisterRemoteRelations(
 		Results: make([]params.RemoteEntityIdResult, len(relations.Relations)),
 	}
 	for i, relation := range relations.Relations {
+		// TODO(wallyworld) - check macaroon
 		if id, err := api.registerRemoteRelation(relation); err != nil {
 			results.Results[i].Error = common.ServerError(err)
 			continue

--- a/apiserver/remoterelations/remoterelations_test.go
+++ b/apiserver/remoterelations/remoterelations_test.go
@@ -9,6 +9,7 @@ import (
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/charm.v6-unstable"
 	"gopkg.in/juju/names.v2"
+	"gopkg.in/macaroon.v1"
 
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/params"
@@ -318,8 +319,16 @@ func (s *remoteRelationsSuite) TestRemoteApplications(c *gc.C) {
 	s.st.remoteApplications["django"] = newMockRemoteApplication("django", "me/model.riak")
 	result, err := s.api.RemoteApplications(params.Entities{Entities: []params.Entity{{Tag: "application-django"}}})
 	c.Assert(err, jc.ErrorIsNil)
+	mac, err := macaroon.New(nil, "test", "")
+	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.Results, jc.DeepEquals, []params.RemoteApplicationResult{{
-		Result: &params.RemoteApplication{Name: "django", OfferName: "django-alias", Life: "alive", ModelUUID: "model-uuid"}}})
+		Result: &params.RemoteApplication{
+			Name:      "django",
+			OfferName: "django-alias",
+			Life:      "alive",
+			ModelUUID: "model-uuid",
+			Macaroon:  mac,
+		}}})
 	s.st.CheckCalls(c, []testing.StubCall{
 		{"RemoteApplication", []interface{}{"django"}},
 	})

--- a/apiserver/remoterelations/state.go
+++ b/apiserver/remoterelations/state.go
@@ -6,6 +6,7 @@ package remoterelations
 import (
 	"github.com/juju/errors"
 	"gopkg.in/juju/names.v2"
+	"gopkg.in/macaroon.v1"
 
 	"github.com/juju/juju/core/crossmodel"
 	"github.com/juju/juju/state"
@@ -157,6 +158,9 @@ type RemoteApplication interface {
 
 	// SourceModel returns the tag of the model hosting the remote application.
 	SourceModel() names.ModelTag
+
+	// Macaroon returns the macaroon used for authentication.
+	Macaroon() (*macaroon.Macaroon, error)
 
 	// IsConsumerProxy returns whether application is created
 	// from a registration operation by a consuming model.

--- a/cmd/juju/application/addrelation_test.go
+++ b/cmd/juju/application/addrelation_test.go
@@ -11,10 +11,10 @@ import (
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
-	"gopkg.in/macaroon.v1"
 
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/core/crossmodel"
 	jtesting "github.com/juju/juju/testing"
 )
 
@@ -112,7 +112,7 @@ func (s mockAddAPI) BestAPIVersion() int {
 	return 2
 }
 
-func (mockAddAPI) Consume(params.ApplicationOffer, string, *macaroon.Macaroon) (string, error) {
+func (mockAddAPI) Consume(crossmodel.ConsumeApplicationArgs) (string, error) {
 	return "", errors.New("unexpected method call: Consume")
 }
 

--- a/cmd/juju/application/deploy.go
+++ b/cmd/juju/application/deploy.go
@@ -397,10 +397,8 @@ Examples:
 
 See also:
     spaces
-    constraints
+    config
     add-unit
-    set-config
-    get-config
     set-constraints
     get-constraints
 `

--- a/core/crossmodel/externalcontroller.go
+++ b/core/crossmodel/externalcontroller.go
@@ -1,0 +1,42 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package crossmodel
+
+import (
+	"github.com/juju/errors"
+	"gopkg.in/juju/names.v2"
+
+	"github.com/juju/juju/network"
+)
+
+// ControllerInfo holds the details required to connect to a controller.
+type ControllerInfo struct {
+	// ControllerTag holds tag for the controller.
+	ControllerTag names.ControllerTag
+
+	// Addrs holds the addresses and ports of the controller's API servers.
+	Addrs []string
+
+	// CACert holds the CA certificate that will be used to validate
+	// the API server's certificate, in PEM format.
+	CACert string
+}
+
+// Validate returns an error if the ControllerInfo contains bad data.
+func (info *ControllerInfo) Validate() error {
+	if !names.IsValidModel(info.ControllerTag.Id()) {
+		return errors.NotValidf("ControllerTag")
+	}
+
+	if len(info.Addrs) < 1 {
+		return errors.NotValidf("empty controller api addresses")
+	}
+	for _, addr := range info.Addrs {
+		_, err := network.ParseHostPort(addr)
+		if err != nil {
+			return errors.NotValidf("controller api address %q", addr)
+		}
+	}
+	return nil
+}

--- a/core/crossmodel/interface.go
+++ b/core/crossmodel/interface.go
@@ -5,6 +5,9 @@ package crossmodel
 
 import (
 	"gopkg.in/juju/charm.v6-unstable"
+	"gopkg.in/macaroon.v1"
+
+	"github.com/juju/juju/apiserver/params"
 )
 
 // ApplicationOffer holds the details of an application offered
@@ -25,7 +28,7 @@ type ApplicationOffer struct {
 	Endpoints map[string]charm.Relation
 }
 
-// AddApplicationOfferArgs contain parameters used to create an application offer.
+// AddApplicationOfferArgs contains parameters used to create an application offer.
 type AddApplicationOfferArgs struct {
 	// OfferName is the name of the offer.
 	OfferName string
@@ -50,6 +53,22 @@ type AddApplicationOfferArgs struct {
 	// Icon is an icon to display when browsing the ApplicationOffers, which by default
 	// comes from the charm.
 	Icon []byte
+}
+
+// ConsumeApplicationArgs contains parameters used to consume an offer.
+type ConsumeApplicationArgs struct {
+	// The offer to be consumed.
+	ApplicationOffer params.ApplicationOffer
+
+	// Macaroon is used for authentication.
+	Macaroon *macaroon.Macaroon
+
+	// ControllerInfo contains connection details to the controller
+	// hosting the offer.
+	ControllerInfo *ControllerInfo
+
+	// ApplicationAlias is the name of the alias to use for the application name.
+	ApplicationAlias string
 }
 
 // String returns the offered application name.

--- a/state/allcollections.go
+++ b/state/allcollections.go
@@ -434,6 +434,11 @@ func allCollections() collectionSchema {
 			},
 			// tokensC holds unique tokens for the model.
 			tokensC: {},
+			// externalControllersC holds connection information for other
+			// controllers hosting models involved in cross-model relations.
+			externalControllersC: {
+				global: true,
+			},
 		} {
 			result[name] = details
 		}
@@ -523,8 +528,9 @@ const (
 	// "resources" (see resource/persistence/mongo.go)
 
 	// Cross model relations
-	applicationOffersC  = "applicationOffers"
-	remoteApplicationsC = "remoteApplications"
-	remoteEntitiesC     = "remoteEntities"
-	tokensC             = "tokens"
+	applicationOffersC   = "applicationOffers"
+	remoteApplicationsC  = "remoteApplications"
+	remoteEntitiesC      = "remoteEntities"
+	tokensC              = "tokens"
+	externalControllersC = "externalControllers"
 )

--- a/state/externalcontroller.go
+++ b/state/externalcontroller.go
@@ -1,0 +1,173 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package state
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/utils/set"
+	"gopkg.in/juju/names.v2"
+	"gopkg.in/mgo.v2"
+	"gopkg.in/mgo.v2/bson"
+	"gopkg.in/mgo.v2/txn"
+
+	"github.com/juju/juju/core/crossmodel"
+)
+
+// ExternalController represents the state of a controller hosting
+// other models.
+type ExternalController interface {
+	// Id returns the external controller UUID, also used as
+	// the mongo id.
+	Id() string
+
+	// ControllerInfo returns the details required to connect to the
+	// external controller.
+	ControllerInfo() crossmodel.ControllerInfo
+}
+
+// externalController is an implementation of ExternalController.
+type externalController struct {
+	doc externalControllerDoc
+}
+
+type externalControllerDoc struct {
+	// Id holds external controller document key.
+	// It is the controller UUID.
+	Id string `bson:"_id"`
+
+	// Addrs holds the host:port values for the external
+	// controller's API server.
+	Addrs []string `bson:"addresses"`
+
+	// CACert holds the certificate to validate the external
+	// controller's target API server's TLS certificate.
+	CACert string `bson:"cacert"`
+
+	// Models holds model UUIDs hosted on this controller.
+	Models []string `bson:"models"`
+}
+
+// Id implements ExternalController.
+func (rc *externalController) Id() string {
+	return rc.doc.Id
+}
+
+// ControllerInfo implements ExternalController.
+func (rc *externalController) ControllerInfo() crossmodel.ControllerInfo {
+	return crossmodel.ControllerInfo{
+		ControllerTag: names.NewControllerTag(rc.doc.Id),
+		Addrs:         rc.doc.Addrs,
+		CACert:        rc.doc.CACert,
+	}
+}
+
+// ExternalControllers instances provide access to external controllers in state.
+type ExternalControllers interface {
+	Save(_ crossmodel.ControllerInfo, modelUUIDs ...string) (ExternalController, error)
+	ControllerForModel(modelUUID string) (ExternalController, error)
+}
+
+type externalControllers struct {
+	st *State
+}
+
+// NewExternalControllers creates an external controllers instance backed by a state.
+func NewExternalControllers(st *State) *externalControllers {
+	return &externalControllers{st: st}
+}
+
+// Add creates a new external controller record.
+func (ec *externalControllers) Save(controller crossmodel.ControllerInfo, modelUUIDs ...string) (ExternalController, error) {
+	if err := controller.Validate(); err != nil {
+		return nil, errors.Trace(err)
+	}
+	doc := externalControllerDoc{
+		Id:     controller.ControllerTag.Id(),
+		Addrs:  controller.Addrs,
+		CACert: controller.CACert,
+	}
+	buildTxn := func(int) ([]txn.Op, error) {
+		model, err := ec.st.Model()
+		if err != nil {
+			return nil, errors.Annotate(err, "failed to load model")
+		}
+		if model.Life() != Alive {
+			return nil, errors.New("model is not alive")
+		}
+
+		existing, err := ec.controller(controller.ControllerTag.Id())
+		if err != nil && !errors.IsNotFound(err) {
+			return nil, errors.Trace(err)
+		}
+		var ops []txn.Op
+		if err == nil {
+			models := set.NewStrings(existing.Models...)
+			models = models.Union(set.NewStrings(modelUUIDs...))
+			ops = []txn.Op{{
+				C:      externalControllersC,
+				Id:     existing.Id,
+				Assert: txn.DocExists,
+				Update: bson.D{
+					{"$set",
+						bson.D{{"addresses", doc.Addrs},
+							{"cacert", doc.CACert},
+							{"models", models.Values()}},
+					},
+				},
+			}, model.assertActiveOp()}
+		} else {
+			doc.Models = modelUUIDs
+			ops = []txn.Op{{
+				C:      externalControllersC,
+				Id:     doc.Id,
+				Assert: txn.DocMissing,
+				Insert: doc,
+			}, model.assertActiveOp()}
+		}
+		return ops, nil
+	}
+	if err := ec.st.run(buildTxn); err != nil {
+		return nil, errors.Annotate(err, "failed to create external controllers")
+	}
+
+	return &externalController{
+		doc: doc,
+	}, nil
+}
+
+func (ec *externalControllers) controller(controllerUUID string) (*externalControllerDoc, error) {
+	coll, closer := ec.st.db().GetCollection(externalControllersC)
+	defer closer()
+
+	var doc externalControllerDoc
+	err := coll.FindId(controllerUUID).One(&doc)
+	if err == mgo.ErrNotFound {
+		return nil, errors.NotFoundf("external controller with UUID %v", controllerUUID)
+	}
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return &doc, nil
+}
+
+// ControllerForModel retrieves an ExternalController with a given model UUID.
+func (ec *externalControllers) ControllerForModel(modelUUID string) (ExternalController, error) {
+	coll, closer := ec.st.db().GetCollection(externalControllersC)
+	defer closer()
+
+	var doc []externalControllerDoc
+	err := coll.Find(bson.M{"models": bson.M{"$in": []string{modelUUID}}}).All(&doc)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	switch len(doc) {
+	case 0:
+		return nil, errors.NotFoundf("external controller with model %v", modelUUID)
+	case 1:
+		return &externalController{
+			doc: doc[0],
+		}, nil
+	}
+	return nil, errors.Errorf("expected 1 controller with model %v, got %d", modelUUID, len(doc))
+}

--- a/state/externalcontroller_test.go
+++ b/state/externalcontroller_test.go
@@ -1,0 +1,133 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package state_test
+
+import (
+	"regexp"
+
+	"github.com/juju/errors"
+	jc "github.com/juju/testing/checkers"
+	"github.com/juju/utils"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/mgo.v2/bson"
+
+	"github.com/juju/juju/core/crossmodel"
+	"github.com/juju/juju/state"
+	"github.com/juju/juju/testing"
+)
+
+type externalControllerSuite struct {
+	ConnSuite
+	externalControllers state.ExternalControllers
+}
+
+var _ = gc.Suite(&externalControllerSuite{})
+
+func (s *externalControllerSuite) SetUpTest(c *gc.C) {
+	s.ConnSuite.SetUpTest(c)
+	s.externalControllers = state.NewExternalControllers(s.State)
+}
+
+func (s *externalControllerSuite) TestSaveInvalidAddress(c *gc.C) {
+	controllerInfo := crossmodel.ControllerInfo{
+		ControllerTag: testing.ControllerTag,
+		Addrs:         []string{"192.168.1.0"},
+		CACert:        testing.CACert,
+	}
+	_, err := s.externalControllers.Save(controllerInfo)
+	c.Assert(err, gc.ErrorMatches, regexp.QuoteMeta(`controller api address "192.168.1.0" not valid`))
+}
+
+func (s *externalControllerSuite) TestSaveNoModels(c *gc.C) {
+	controllerInfo := crossmodel.ControllerInfo{
+		ControllerTag: testing.ControllerTag,
+		Addrs:         []string{"192.168.1.0:1234", "10.0.0.1:1234"},
+		CACert:        testing.CACert,
+	}
+	ec, err := s.externalControllers.Save(controllerInfo)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(ec.Id(), gc.Equals, testing.ControllerTag.Id())
+	c.Assert(ec.ControllerInfo(), jc.DeepEquals, controllerInfo)
+	s.assertSavedControllerInfo(c)
+}
+
+func (s *externalControllerSuite) assertSavedControllerInfo(c *gc.C, modelUUIDs ...string) {
+	coll, closer := state.GetCollection(s.State, "externalControllers")
+	defer closer()
+
+	var raw bson.M
+	err := coll.FindId(testing.ControllerTag.Id()).One(&raw)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(raw["_id"], gc.Equals, testing.ControllerTag.Id())
+	c.Assert(raw["addresses"], jc.SameContents, []interface{}{"192.168.1.0:1234", "10.0.0.1:1234"})
+	c.Assert(raw["cacert"], gc.Equals, testing.CACert)
+	var models []string
+	for _, m := range raw["models"].([]interface{}) {
+		models = append(models, m.(string))
+	}
+	c.Assert(models, jc.SameContents, modelUUIDs)
+}
+
+func (s *externalControllerSuite) TestSave(c *gc.C) {
+	controllerInfo := crossmodel.ControllerInfo{
+		ControllerTag: testing.ControllerTag,
+		Addrs:         []string{"192.168.1.0:1234", "10.0.0.1:1234"},
+		CACert:        testing.CACert,
+	}
+	uuid1 := utils.MustNewUUID().String()
+	uuid2 := utils.MustNewUUID().String()
+	ec, err := s.externalControllers.Save(controllerInfo, uuid1, uuid2)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(ec.Id(), gc.Equals, testing.ControllerTag.Id())
+	c.Assert(ec.ControllerInfo(), jc.DeepEquals, controllerInfo)
+	s.assertSavedControllerInfo(c, uuid1, uuid2)
+}
+
+func (s *externalControllerSuite) TestSaveIdempotent(c *gc.C) {
+	controllerInfo := crossmodel.ControllerInfo{
+		ControllerTag: testing.ControllerTag,
+		Addrs:         []string{"192.168.1.0:1234", "10.0.0.1:1234"},
+		CACert:        testing.CACert,
+	}
+	uuid1 := utils.MustNewUUID().String()
+	ec, err := s.externalControllers.Save(controllerInfo, uuid1)
+	c.Assert(err, jc.ErrorIsNil)
+	ec, err = s.externalControllers.Save(controllerInfo, uuid1)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(ec.Id(), gc.Equals, testing.ControllerTag.Id())
+	c.Assert(ec.ControllerInfo(), jc.DeepEquals, controllerInfo)
+	s.assertSavedControllerInfo(c, uuid1)
+}
+
+func (s *externalControllerSuite) TestUpdateModels(c *gc.C) {
+	controllerInfo := crossmodel.ControllerInfo{
+		ControllerTag: testing.ControllerTag,
+		Addrs:         []string{"192.168.1.0:1234", "10.0.0.1:1234"},
+		CACert:        testing.CACert,
+	}
+	uuid1 := utils.MustNewUUID().String()
+	_, err := s.externalControllers.Save(controllerInfo, uuid1)
+	c.Assert(err, jc.ErrorIsNil)
+	uuid2 := utils.MustNewUUID().String()
+	_, err = s.externalControllers.Save(controllerInfo, uuid2)
+	c.Assert(err, jc.ErrorIsNil)
+	s.assertSavedControllerInfo(c, uuid1, uuid2)
+}
+
+func (s *externalControllerSuite) TestControllerForModel(c *gc.C) {
+	controllerInfo := crossmodel.ControllerInfo{
+		ControllerTag: testing.ControllerTag,
+		Addrs:         []string{"192.168.1.0:1234", "10.0.0.1:1234"},
+		CACert:        testing.CACert,
+	}
+	uuid1 := utils.MustNewUUID().String()
+	uuid2 := utils.MustNewUUID().String()
+	ec, err := s.externalControllers.Save(controllerInfo, uuid1, uuid2)
+	c.Assert(err, jc.ErrorIsNil)
+	found, err := s.externalControllers.ControllerForModel(uuid1)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(ec, jc.DeepEquals, found)
+	_, err = s.externalControllers.ControllerForModel("1234")
+	c.Assert(err, jc.Satisfies, errors.IsNotFound)
+}

--- a/state/migration_export_test.go
+++ b/state/migration_export_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/juju/juju/storage/poolmanager"
 	"github.com/juju/juju/storage/provider"
 	"github.com/juju/juju/testing/factory"
+	"gopkg.in/macaroon.v1"
 )
 
 // Constraints stores megabytes by default for memory and root disk.
@@ -1329,6 +1330,8 @@ func (s *MigrationExportSuite) TestRemoteApplications(c *gc.C) {
 			"db-admin": "private",
 			"logging":  "public",
 		},
+		// Macaroon not exported.
+		Macaroon: &macaroon.Macaroon{},
 	})
 	c.Assert(err, jc.ErrorIsNil)
 

--- a/state/migration_internal_test.go
+++ b/state/migration_internal_test.go
@@ -189,6 +189,7 @@ func (s *MigrationSuite) TestKnownCollections(c *gc.C) {
 		applicationOffersC,
 		tokensC,
 		remoteEntitiesC,
+		externalControllersC,
 	)
 
 	envCollections := set.NewStrings()

--- a/state/remoteapplication_test.go
+++ b/state/remoteapplication_test.go
@@ -11,6 +11,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/charm.v6-unstable"
+	"gopkg.in/macaroon.v1"
 
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/network"
@@ -91,7 +92,8 @@ func (s *remoteApplicationSuite) SetUpTest(c *gc.C) {
 		"db-admin": "private",
 		"logging":  "public",
 	}
-	var err error
+	mac, err := macaroon.New(nil, "test", "")
+	c.Assert(err, jc.ErrorIsNil)
 	s.application, err = s.State.AddRemoteApplication(state.AddRemoteApplicationParams{
 		Name:        "mysql",
 		URL:         "me/model.mysql",
@@ -100,6 +102,7 @@ func (s *remoteApplicationSuite) SetUpTest(c *gc.C) {
 		Endpoints:   eps,
 		Spaces:      spaces,
 		Bindings:    bindings,
+		Macaroon:    mac,
 	})
 	c.Assert(err, jc.ErrorIsNil)
 }
@@ -308,6 +311,14 @@ func (s *remoteApplicationSuite) TestMysqlEndpoints(c *gc.C) {
 	eps, err := s.application.Endpoints()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(eps, gc.DeepEquals, []state.Endpoint{serverEP, adminEp, loggingEp})
+}
+
+func (s *remoteApplicationSuite) TestMacaroon(c *gc.C) {
+	mac, err := macaroon.New(nil, "test", "")
+	c.Assert(err, jc.ErrorIsNil)
+	appMac, err := s.application.Macaroon()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(appMac, gc.DeepEquals, mac)
 }
 
 func (s *remoteApplicationSuite) TestApplicationRefresh(c *gc.C) {

--- a/worker/remoterelations/mock_test.go
+++ b/worker/remoterelations/mock_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/watcher"
 	"github.com/juju/juju/worker/remoterelations"
+	"gopkg.in/macaroon.v1"
 )
 
 type mockRelationsFacade struct {
@@ -190,6 +191,10 @@ func (m *mockRelationsFacade) RemoteApplications(names []string) ([]params.Remot
 	if err := m.stub.NextErr(); err != nil {
 		return nil, err
 	}
+	mac, err := macaroon.New(nil, "test", "")
+	if err != nil {
+		return nil, err
+	}
 	result := make([]params.RemoteApplicationResult, len(names))
 	for i, name := range names {
 		if app, ok := m.remoteApplications[name]; ok {
@@ -201,6 +206,7 @@ func (m *mockRelationsFacade) RemoteApplications(names []string) ([]params.Remot
 					Status:     app.status,
 					ModelUUID:  app.modelUUID,
 					Registered: app.registered,
+					Macaroon:   mac,
 				},
 			}
 		} else {

--- a/worker/remoterelations/remoterelations.go
+++ b/worker/remoterelations/remoterelations.go
@@ -42,8 +42,6 @@ type RemoteRelationChangePublisher interface {
 
 // RemoteRelationsFacade exposes remote relation functionality to a worker.
 type RemoteRelationsFacade interface {
-	RemoteRelationChangePublisher
-
 	// ImportRemoteEntity adds an entity to the remote entities collection
 	// with the specified opaque token.
 	ImportRemoteEntity(sourceModelUUID string, entity names.Tag, token string) error

--- a/worker/remoterelations/remoterelations_test.go
+++ b/worker/remoterelations/remoterelations_test.go
@@ -12,6 +12,7 @@ import (
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/names.v2"
 	worker "gopkg.in/juju/worker.v1"
+	"gopkg.in/macaroon.v1"
 
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/params"
@@ -146,6 +147,8 @@ func (s *remoteRelationsSuite) assertRemoteRelationsWorkers(c *gc.C) worker.Work
 	relWatcher, _ := s.relationsFacade.remoteApplicationRelationsWatcher("db2")
 	relWatcher.changes <- []string{"db2:db django:db"}
 
+	mac, err := macaroon.New(nil, "test", "")
+	c.Assert(err, jc.ErrorIsNil)
 	expected := []jujutesting.StubCall{
 		{"Relations", []interface{}{[]string{"db2:db django:db"}}},
 		{"ExportEntities", []interface{}{
@@ -162,6 +165,7 @@ func (s *remoteRelationsSuite) assertRemoteRelationsWorkers(c *gc.C) worker.Work
 			},
 			OfferName:         "offer-db2",
 			LocalEndpointName: "data",
+			Macaroon:          mac,
 		}}}},
 		{"ImportRemoteEntity", []interface{}{"source-model-uuid", names.NewApplicationTag("db2"), "token-offer-db2"}},
 		{"WatchLocalRelationUnits", []interface{}{"db2:db django:db"}},
@@ -203,6 +207,8 @@ func (s *remoteRelationsSuite) TestRemoteRelationsDead(c *gc.C) {
 		}
 	}
 	c.Assert(unitsWatcher.killed(), jc.IsTrue)
+	mac, err := macaroon.New(nil, "test", "")
+	c.Assert(err, jc.ErrorIsNil)
 	expected := []jujutesting.StubCall{
 		{"Relations", []interface{}{[]string{"db2:db django:db"}}},
 		{"GetToken", []interface{}{"model-uuid", names.NewRelationTag("db2:db django:db")}},
@@ -216,6 +222,7 @@ func (s *remoteRelationsSuite) TestRemoteRelationsDead(c *gc.C) {
 				RelationId: params.RemoteEntityId{
 					ModelUUID: "model-uuid",
 					Token:     "token-db2:db django:db"},
+				Macaroon: mac,
 			},
 		}},
 	}
@@ -239,6 +246,8 @@ func (s *remoteRelationsSuite) TestRemoteRelationsRemoved(c *gc.C) {
 		}
 	}
 	c.Assert(unitsWatcher.killed(), jc.IsTrue)
+	mac, err := macaroon.New(nil, "test", "")
+	c.Assert(err, jc.ErrorIsNil)
 	expected := []jujutesting.StubCall{
 		{"Relations", []interface{}{[]string{"db2:db django:db"}}},
 		{"GetToken", []interface{}{"model-uuid", names.NewRelationTag("db2:db django:db")}},
@@ -252,6 +261,7 @@ func (s *remoteRelationsSuite) TestRemoteRelationsRemoved(c *gc.C) {
 				RelationId: params.RemoteEntityId{
 					ModelUUID: "model-uuid",
 					Token:     "token-db2:db django:db"},
+				Macaroon: mac,
 			},
 		}},
 	}
@@ -269,6 +279,8 @@ func (s *remoteRelationsSuite) TestRemoteRelationsChangedNotifies(c *gc.C) {
 		Departed: []string{"unit/2"},
 	}
 
+	mac, err := macaroon.New(nil, "test", "")
+	c.Assert(err, jc.ErrorIsNil)
 	expected := []jujutesting.StubCall{
 		{"RelationUnitSettings", []interface{}{
 			[]params.RelationUnit{{
@@ -288,6 +300,7 @@ func (s *remoteRelationsSuite) TestRemoteRelationsChangedNotifies(c *gc.C) {
 					Settings: map[string]interface{}{"foo": "bar"},
 				}},
 				DepartedUnits: []int{2},
+				Macaroon:      mac,
 			},
 		}},
 	}

--- a/worker/remoterelations/shim.go
+++ b/worker/remoterelations/shim.go
@@ -11,11 +11,17 @@ import (
 
 	"github.com/juju/juju/api"
 	"github.com/juju/juju/api/base"
+	"github.com/juju/juju/api/crossmodelrelations"
 	"github.com/juju/juju/api/remoterelations"
 )
 
 func NewRemoteRelationsFacade(apiCaller base.APICaller) (RemoteRelationsFacade, error) {
 	facade := remoterelations.NewClient(apiCaller)
+	return facade, nil
+}
+
+func NewCrossModelRelationsFacade(apiCaller base.APICaller) (RemoteRelationChangePublisher, error) {
+	facade := crossmodelrelations.NewClient(apiCaller)
 	return facade, nil
 }
 
@@ -31,8 +37,7 @@ func NewWorker(config Config) (worker.Worker, error) {
 // can be used be construct instances which publish remote relation
 // changes for a given model.
 
-// For now we use a facade on the same controller, but in future this
-// may evolve into a REST caller.
+// For now we use a facade, but in future this may evolve into a REST caller.
 func relationChangePublisherForModelFunc(
 	apiConnForModelFunc func(string) (api.Connection, error),
 ) func(string) (RemoteRelationChangePublisherCloser, error) {
@@ -41,7 +46,7 @@ func relationChangePublisherForModelFunc(
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
-		facade, err := NewRemoteRelationsFacade(conn)
+		facade, err := NewCrossModelRelationsFacade(conn)
 		if err != nil {
 			conn.Close()
 			return nil, errors.Trace(err)


### PR DESCRIPTION
## Description of change

When consuming offers from another controller, we need to record details for how to connect to that controller in the consuming model. We also need to record against the remote application on the consuming side a macaroon that proves permission to consume; this macaroon will be used when communicating with the offering model once the relation is set up.

The various params structs have been modified to cater for passing the macaroon, but it's not used yet. Also, CMR is still for single controller, so the external controller details are not used yet either. This is all ground work for enabling multi-controller CMR.

## QA steps

No visible changes yet - all infrastructure for later.
bootstrap and perform a consumer/relate.

