### PR TITLE
apiserver: change default buffer size to 1000, make configurable

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -180,6 +180,9 @@ const (
 	AgentConnLookbackWindow = "AGENT_CONN_LOOKBACK_WINDOW"
 
 	MgoStatsEnabled = "MGO_STATS_ENABLED"
+
+	LogSinkDBLoggerBufferSize    = "LOGSINK_DBLOGGER_BUFFER_SIZE"
+	LogSinkDBLoggerFlushInterval = "LOGSINK_DBLOGGER_FLUSH_INTERVAL"
 )
 
 // The Config interface is the sole way that the agent gets access to the


### PR DESCRIPTION
## Description of change

Change the default logsink buffer size to 1000,
matching the underlying limit of 1000 for bulk
insertions to Mongo. Also make the buffer size
and flush interval configurable via agent.conf.

## QA steps

1. juju bootstrap localhost
2. juju debug-log -m controller
3. juju model-config -m controller logging-config='<root>=TRACE'
(observe the log records are flushed at 2 second intervals)
4. edit agent.conf, set "LOGSINK_DBLOGGER_FLUSH_INTERVAL: 1s" and restart jujud
(observe the log records are flushed at 1 second intervals)
5. edit agent.conf, set "LOGSINK_DBLOGGER_BUFFER_SIZE: 1" and restart jujud
(observe the log records are flushed without delay)

## Documentation changes

None.

## Bug reference

None.