### PR TITLE
worker/uniter: cache principal unit name

### DIFF
--- a/worker/uniter/relation/relations.go
+++ b/worker/uniter/relation/relations.go
@@ -74,6 +74,7 @@ func (s *relationsResolver) NextOp(
 type relations struct {
 	st           *uniter.State
 	unit         *uniter.Unit
+	subordinate  bool
 	charmDir     string
 	relationsDir string
 	relationers  map[int]*Relationer
@@ -86,9 +87,14 @@ func NewRelations(st *uniter.State, tag names.UnitTag, charmDir, relationsDir st
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
+	_, subordinate, err := unit.PrincipalName()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	r := &relations{
 		st:           st,
 		unit:         unit,
+		subordinate:  subordinate,
 		charmDir:     charmDir,
 		relationsDir: relationsDir,
 		relationers:  make(map[int]*Relationer),
@@ -407,9 +413,7 @@ func (r *relations) update(remote map[int]remotestate.RelationSnapshot) error {
 			return errors.Trace(removeErr)
 		}
 	}
-	if _, ok, err := r.unit.PrincipalName(); err != nil {
-		return errors.Trace(err)
-	} else if !ok {
+	if !r.subordinate {
 		return nil
 	}
 	// If no Alive relations remain between a subordinate unit's service


### PR DESCRIPTION
## Description of change

The principal of a subordinate never changes,
nor can a non-subordinate unit become subordinate
or vice versa. Avoid making repeated API calls to
obtain the same, immutable value.

(I found this by deploying canonical-kubernetes and
observing that Uniter.GetPrincipalName was the
second most called API method, behind Pinger.Ping.)

## QA steps

1. juju bootstrap (with tip of 2.2)
2. juju deploy prometheus, configure it to scrape from the controller
3. juju deploy canonical-kubernetes
4. plot juju_api_requests_total, observe Uniter.GetPrincipalName grows over time

Now upgrade to the controller *and agents* to this branch, and observe that the Uniter.GetPrincipalName API call stops growing.

## Documentation changes

None.

## Bug reference

None.