### PR TITLE
api: impose stricter deadline on api.Open

### DIFF
--- a/api/apiclient_test.go
+++ b/api/apiclient_test.go
@@ -233,8 +233,10 @@ func (s *apiclientSuite) TestDialWebsocketStopsOtherDialAttempts(c *gc.C) {
 	c.Assert(info0.location, gc.Equals, "wss://place1.example:1234/api")
 
 	var info1 dialInfo
-	// Wait for the next dial to be made.
-	err := clock.WaitAdvance(dialAddressInterval, time.Second, 1)
+	// Wait for the next dial to be made. Note that we wait for two
+	// waiters because ContextWithTimeout as created by the
+	// outer level of api.Open also waits.
+	err := clock.WaitAdvance(dialAddressInterval, time.Second, 2)
 	c.Assert(err, jc.ErrorIsNil)
 
 	select {
@@ -455,8 +457,6 @@ func (s *apiclientSuite) testOpenDialError(c *gc.C, t dialTest) {
 	go func() {
 		defer close(done)
 		conn, err := api.Open(t.apiInfo, api.DialOpts{
-			Timeout:        5 * time.Second,
-			RetryDelay:     1 * time.Second,
 			DialWebsocket:  fakeDialer,
 			IPAddrResolver: seqResolver(t.apiInfo.Addrs...),
 			Clock:          &fakeClock{},
@@ -586,14 +586,11 @@ func (s *apiclientSuite) TestOpenCachesDNS(c *gc.C) {
 		SkipLogin: true,
 		CACert:    jtesting.CACert,
 	}, api.DialOpts{
-		Timeout:       5 * time.Second,
-		RetryDelay:    1 * time.Second,
 		DialWebsocket: fakeDialer,
 		IPAddrResolver: apitesting.IPAddrResolverMap{
 			"place1.example": {"0.1.1.1"},
 		},
 		DNSCache: dnsCache,
-		Clock:    &fakeClock{},
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(conn, gc.NotNil)
@@ -622,7 +619,6 @@ func (s *apiclientSuite) TestDNSCacheUsed(c *gc.C) {
 		DNSCache: dnsCacheMap{
 			"place1.example": {"0.1.1.1"},
 		},
-		Clock: &fakeClock{},
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(conn, gc.NotNil)
@@ -644,12 +640,9 @@ func (s *apiclientSuite) TestNumericAddressIsNotAddedToCache(c *gc.C) {
 		SkipLogin: true,
 		CACert:    jtesting.CACert,
 	}, api.DialOpts{
-		Timeout:        5 * time.Second,
-		RetryDelay:     1 * time.Second,
 		DialWebsocket:  fakeDialer,
 		IPAddrResolver: apitesting.IPAddrResolverMap{},
 		DNSCache:       dnsCache,
-		Clock:          &fakeClock{},
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(conn, gc.NotNil)
@@ -692,7 +685,6 @@ func (s *apiclientSuite) TestFallbackToIPLookupWhenCacheOutOfDate(c *gc.C) {
 				"place1.example": {"0.2.2.2"},
 			},
 			DNSCache: dnsCache,
-			Clock:    &fakeClock{},
 		})
 		openc <- openResult{conn, err}
 	}()
@@ -729,6 +721,38 @@ func (s *apiclientSuite) TestFallbackToIPLookupWhenCacheOutOfDate(c *gc.C) {
 	c.Assert(dnsCache.Lookup("place1.example"), jc.DeepEquals, []string{"0.2.2.2"})
 }
 
+func (s *apiclientSuite) TestOpenTimesOutOnLogin(c *gc.C) {
+	unblock := make(chan struct{})
+	srv := apiservertesting.NewAPIServer(func(modelUUID string) interface{} {
+		return &loginTimeoutAPI{
+			unblock: unblock,
+		}
+	})
+	defer srv.Close()
+
+	clk := testing.NewClock(time.Now())
+	done := make(chan error, 1)
+	go func() {
+		_, err := api.Open(&api.Info{
+			Addrs:    srv.Addrs,
+			CACert:   jtesting.CACert,
+			ModelTag: names.NewModelTag("beef1beef1-0000-0000-000011112222"),
+		}, api.DialOpts{
+			Clock:   clk,
+			Timeout: 5 * time.Second,
+		})
+		done <- err
+	}()
+	err := clk.WaitAdvance(5*time.Second, time.Second, 1)
+	c.Assert(err, jc.ErrorIsNil)
+	select {
+	case err := <-done:
+		c.Assert(err, gc.ErrorMatches, `cannot log in: context deadline exceeded`)
+	case <-time.After(time.Second):
+		c.Fatalf("timed out waiting for api.Open timeout")
+	}
+}
+
 func (s *apiclientSuite) TestWithUnresolvableAddr(c *gc.C) {
 	fakeDialer := func(ctx context.Context, urlStr string, tlsConfig *tls.Config, ipAddr string) (jsoncodec.JSONConn, error) {
 		c.Errorf("dial was called but should not have been")
@@ -741,11 +765,8 @@ func (s *apiclientSuite) TestWithUnresolvableAddr(c *gc.C) {
 		SkipLogin: true,
 		CACert:    jtesting.CACert,
 	}, api.DialOpts{
-		Timeout:        5 * time.Second,
-		RetryDelay:     1 * time.Second,
 		DialWebsocket:  fakeDialer,
 		IPAddrResolver: apitesting.IPAddrResolverMap{},
-		Clock:          &fakeClock{},
 	})
 	c.Assert(err, gc.ErrorMatches, `cannot resolve "nowhere.example": mock resolver cannot resolve "nowhere.example"`)
 	c.Assert(conn, jc.ErrorIsNil)
@@ -770,14 +791,11 @@ func (s *apiclientSuite) TestWithUnresolvableAddrAfterCacheFallback(c *gc.C) {
 		SkipLogin: true,
 		CACert:    jtesting.CACert,
 	}, api.DialOpts{
-		Timeout:       5 * time.Second,
-		RetryDelay:    1 * time.Second,
 		DialWebsocket: fakeDialer,
 		IPAddrResolver: apitesting.IPAddrResolverMap{
 			"place1.example": {"0.2.2.2"},
 		},
 		DNSCache: dnsCache,
-		Clock:    &fakeClock{},
 	})
 	c.Assert(err, gc.NotNil)
 	c.Assert(conn, gc.Equals, nil)
@@ -931,6 +949,10 @@ func (f *fakeClock) After(d time.Duration) <-chan time.Time {
 	return time.After(0)
 }
 
+func (f *fakeClock) NewTimer(d time.Duration) clock.Timer {
+	panic("NewTimer called on fakeClock - perhaps because fakeClock can't be used with DialOpts.Timeout")
+}
+
 func newRPCConnection(errs ...error) *fakeRPCConnection {
 	conn := new(fakeRPCConnection)
 	conn.stub.SetErrors(errs...)
@@ -1044,4 +1066,21 @@ func (m dnsCacheMap) Lookup(host string) []string {
 
 func (m dnsCacheMap) Add(host string, ips []string) {
 	m[host] = append([]string{}, ips...)
+}
+
+type loginTimeoutAPI struct {
+	unblock chan struct{}
+}
+
+func (r *loginTimeoutAPI) Admin(id string) (*loginTimeoutAPIAdmin, error) {
+	return &loginTimeoutAPIAdmin{r}, nil
+}
+
+type loginTimeoutAPIAdmin struct {
+	r *loginTimeoutAPI
+}
+
+func (a *loginTimeoutAPIAdmin) Login(req params.LoginRequest) (params.LoginResult, error) {
+	<-a.r.unblock
+	return params.LoginResult{}, errors.Errorf("login failed")
 }

--- a/api/export_test.go
+++ b/api/export_test.go
@@ -4,6 +4,7 @@
 package api
 
 import (
+	"context"
 	"net/url"
 
 	"github.com/juju/errors"
@@ -26,7 +27,7 @@ var (
 )
 
 func DialAPI(info *Info, opts DialOpts) (jsoncodec.JSONConn, string, error) {
-	result, err := dialAPI(info, opts)
+	result, err := dialAPI(context.TODO(), info, opts)
 	if err != nil {
 		return nil, "", err
 	}

--- a/api/interface.go
+++ b/api/interface.go
@@ -124,12 +124,13 @@ type DialOpts struct {
 	// before starting to dial another address.
 	DialAddressInterval time.Duration
 
-	// Timeout is the amount of time to wait contacting
-	// a controller.
+	// Timeout is the amount of time to wait for
+	// the api.Open to succeed. If this is zero, there is no timeout.
 	Timeout time.Duration
 
 	// RetryDelay is the amount of time to wait between
-	// unsuccessful connection attempts.
+	// unsuccessful connection attempts. If this is
+	// zero, only one attempt will be made.
 	RetryDelay time.Duration
 
 	// BakeryClient is the httpbakery Client, which

--- a/api/pubsub/pubsub_test.go
+++ b/api/pubsub/pubsub_test.go
@@ -159,11 +159,6 @@ func (s *PubSubIntegrationSuite) SetUpTest(c *gc.C) {
 }
 
 func (s *PubSubIntegrationSuite) connect(c *gc.C) apipubsub.MessageWriter {
-	dialOpts := api.DialOpts{
-		DialAddressInterval: 20 * time.Millisecond,
-		Timeout:             50 * time.Millisecond,
-		RetryDelay:          50 * time.Millisecond,
-	}
 	info := &api.Info{
 		Addrs:    []string{s.address},
 		CACert:   coretesting.CACert,
@@ -172,7 +167,7 @@ func (s *PubSubIntegrationSuite) connect(c *gc.C) apipubsub.MessageWriter {
 		Password: s.password,
 		Nonce:    s.nonce,
 	}
-	conn, err := api.Open(info, dialOpts)
+	conn, err := api.Open(info, api.DialOpts{})
 	c.Assert(err, jc.ErrorIsNil)
 	s.AddCleanup(func(_ *gc.C) { conn.Close() })
 

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -34,7 +34,7 @@ github.com/juju/httpprof	git	14bf14c307672fd2456bdbf35d19cf0ccd3cf565	2014-12-17
 github.com/juju/httprequest	git	266fd1e9debf09c037a63f074d099a2da4559ece	2016-10-06T15:09:09Z
 github.com/juju/idmclient	git	4dc25171f675da4206b71695d3fd80e519ad05c1	2017-02-09T16:27:49Z
 github.com/juju/jsonschema	git	a0ef8b74ebcffeeff9fc374854deb4af388f037e	2016-11-02T18:19:19Z
-github.com/juju/loggo	git	21bc4c63e8b435779a080e39e592969b7b90b889	2017-02-22T12:20:47Z
+github.com/juju/loggo	git	8232ab8918d91c72af1a9fb94d3edbe31d88b790	2017-06-05T01:46:07Z
 github.com/juju/mempool	git	24974d6c264fe5a29716e7d56ea24c4bd904b7cc	2016-02-05T10:49:27Z
 github.com/juju/mutex	git	59c26ee163447c5c57f63ff71610d433862013de	2016-06-17T01:09:07Z
 github.com/juju/persistent-cookiejar	git	d67418f14c93a698e37b52468958d5d4dcf8a7dd	2017-04-28T16:15:59Z
@@ -48,7 +48,7 @@ github.com/juju/terms-client	git	9b925afd677234e4146dde3cb1a11e187cbed64e	2016-0
 github.com/juju/testing	git	2fe0e88cf2321d801acedd2b4f0d7f63735fb732	2017-06-08T05:44:51Z
 github.com/juju/txn	git	dbb63c620814d1a0f96260f4cad3e2cca14f702b	2017-06-13T23:44:54Z
 github.com/juju/usso	git	68a59c96c178fbbad65926e7f93db50a2cd14f33	2016-04-01T10:44:24Z
-github.com/juju/utils	git	61a75f1933a523d7f9d38bc5b1bf2010f1c157c3	2017-06-07T09:20:57Z
+github.com/juju/utils	git	08502f040bb5dc1b256f206f1780079610316f66	2017-06-16T07:58:09Z
 github.com/juju/version	git	1f41e27e54f21acccf9b2dddae063a782a8a7ceb	2016-10-31T05:19:06Z
 github.com/juju/webbrowser	git	54b8c57083b4afb7dc75da7f13e2967b2606a507	2016-03-09T14:36:29Z
 github.com/juju/xml	git	eb759a627588d35166bc505fceb51b88500e291e	2015-04-13T13:11:21Z


### PR DESCRIPTION
Currently if you call api.Open with a given timeout,
it might exceed that timeout if the connect succeeds
but (for whatever reason) the Login API call doesn't return.

This PR imposes the timeout on the login too, so clients
that care can be more sure that the api.Open will actually
return soon after a timeout.

To avoid changing the useful semantic (relied on by many tests)
that the zero DialOpts will log in without any particular timeout,
we change the semantics slightly, such that a zero timeout
means no timeout and a zero RetryDelay means "don't retry",
which means that the zero DialOpts means pretty much what
it currently means.

QA no regressions. This should not affect normal behaviour.