### PR TITLE
Expose unit.Charm()

### DIFF
--- a/state/storage.go
+++ b/state/storage.go
@@ -472,7 +472,7 @@ func validateRemoveOwnerStorageInstanceOps(si *storageInstance) ([]txn.Op, error
 		if u.Life() != Alive {
 			return nil, nil
 		}
-		ch, err := u.charm()
+		ch, err := u.Charm()
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
@@ -845,7 +845,7 @@ func (st *State) AttachStorage(storage names.StorageTag, unit names.UnitTag) (er
 		if u.Life() != Alive {
 			return nil, errors.New("unit not alive")
 		}
-		ch, err := u.charm()
+		ch, err := u.Charm()
 		if err != nil {
 			return nil, errors.Annotate(err, "getting charm")
 		}
@@ -1824,7 +1824,7 @@ func (st *State) addStorageForUnitOps(
 	// Storage addition is based on the charm metadata; u.charm()
 	// returns txn.Ops that ensure the charm URL does not change
 	// during the transaction.
-	ch, err := u.charm()
+	ch, err := u.Charm()
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/state/unit.go
+++ b/state/unit.go
@@ -1142,9 +1142,9 @@ func (u *Unit) SetCharmURL(curl *charm.URL) error {
 	return err
 }
 
-// charm returns the charm for the unit, or the application if the unit's charm
+// Charm returns the charm for the unit, or the application if the unit's charm
 // has not been set yet.
-func (u *Unit) charm() (*Charm, error) {
+func (u *Unit) Charm() (*Charm, error) {
 	curl, ok := u.CharmURL()
 	if !ok {
 		app, err := u.Application()
@@ -1812,7 +1812,7 @@ func unitMachineStorageParams(u *Unit) (*machineStorageParams, error) {
 	if err != nil {
 		return nil, errors.Annotate(err, "getting storage attachments")
 	}
-	ch, err := u.charm()
+	ch, err := u.Charm()
 	if err != nil {
 		return nil, errors.Annotate(err, "getting charm")
 	}
@@ -2325,7 +2325,7 @@ func (u *Unit) AddAction(name string, payload map[string]interface{}) (Action, e
 // ActionSpecs gets the ActionSpec map for the Unit's charm.
 func (u *Unit) ActionSpecs() (ActionSpecsByName, error) {
 	none := ActionSpecsByName{}
-	ch, err := u.charm()
+	ch, err := u.Charm()
 	if err != nil {
 		return none, errors.Trace(err)
 	}


### PR DESCRIPTION
## Description of change

Access to the charm of the unit is useful at apiserver layer too, for example for validation of user supplied names such as payloads.

## QA steps

Internal change - unit tests pass.

## Documentation changes

n/a

## Bug reference

 n/a
