### PR TITLE
Update statemetrics to take a StatePool

### DIFF
--- a/api/apiclient_test.go
+++ b/api/apiclient_test.go
@@ -524,7 +524,9 @@ func (s *apiclientSuite) TestPublicDNSName(c *gc.C) {
 	listener, err := net.Listen("tcp", "localhost:0")
 	c.Assert(err, gc.IsNil)
 	machineTag := names.NewMachineTag("0")
-	srv, err := apiserver.NewServer(s.State, listener, apiserver.ServerConfig{
+	statePool := state.NewStatePool(s.State)
+	defer statePool.Close()
+	srv, err := apiserver.NewServer(statePool, listener, apiserver.ServerConfig{
 		Clock:           clock.WallClock,
 		Cert:            jtesting.ServerCert,
 		Key:             jtesting.ServerKey,
@@ -532,7 +534,6 @@ func (s *apiclientSuite) TestPublicDNSName(c *gc.C) {
 		Hub:             centralhub.New(machineTag),
 		DataDir:         c.MkDir(),
 		LogDir:          c.MkDir(),
-		StatePool:       state.NewStatePool(s.State),
 		AutocertDNSName: "somewhere.example.com",
 		NewObserver:     func() observer.Observer { return &fakeobserver.Instance{} },
 		AutocertURL:     "https://0.1.2.3/no-autocert-here",

--- a/api/controller/legacy_test.go
+++ b/api/controller/legacy_test.go
@@ -216,7 +216,10 @@ func (s *legacySuite) TestAPIServerCanShutdownWithOutstandingNext(c *gc.C) {
 	lis, err := net.Listen("tcp", "localhost:0")
 	c.Assert(err, jc.ErrorIsNil)
 
-	srv, err := apiserver.NewServer(s.State, lis, apiserver.ServerConfig{
+	statePool := state.NewStatePool(s.State)
+	defer statePool.Close()
+
+	srv, err := apiserver.NewServer(statePool, lis, apiserver.ServerConfig{
 		Clock:           clock.WallClock,
 		Cert:            testing.ServerCert,
 		Key:             testing.ServerKey,
@@ -226,7 +229,6 @@ func (s *legacySuite) TestAPIServerCanShutdownWithOutstandingNext(c *gc.C) {
 		LogDir:          c.MkDir(),
 		NewObserver:     func() observer.Observer { return &fakeobserver.Instance{} },
 		AutocertURL:     "https://0.1.2.3/no-autocert-here",
-		StatePool:       state.NewStatePool(s.State),
 		RateLimitConfig: apiserver.DefaultRateLimitConfig(),
 	})
 	c.Assert(err, gc.IsNil)

--- a/apiserver/admin.go
+++ b/apiserver/admin.go
@@ -313,7 +313,7 @@ func (a *admin) checkCreds(req params.LoginRequest, lookForModelUser bool) (stat
 }
 
 func (a *admin) checkControllerMachineCreds(req params.LoginRequest) (state.Entity, error) {
-	return checkControllerMachineCreds(a.srv.state, req, a.authenticator())
+	return checkControllerMachineCreds(a.srv.statePool.SystemState(), req, a.authenticator())
 }
 
 func (a *admin) authenticator() authentication.EntityAuthenticator {

--- a/apiserver/admin_test.go
+++ b/apiserver/admin_test.go
@@ -38,6 +38,7 @@ import (
 
 type baseLoginSuite struct {
 	jujutesting.JujuConnSuite
+	pool *state.StatePool
 }
 
 type loginSuite struct {
@@ -49,12 +50,14 @@ var _ = gc.Suite(&loginSuite{})
 func (s *baseLoginSuite) SetUpTest(c *gc.C) {
 	s.JujuConnSuite.SetUpTest(c)
 	loggo.GetLogger("juju.apiserver").SetLogLevel(loggo.TRACE)
+	s.pool = state.NewStatePool(s.State)
+	s.AddCleanup(func(*gc.C) { s.pool.Close() })
 }
 
 func (s *baseLoginSuite) newMachineAndServer(c *gc.C) (*api.Info, *apiserver.Server) {
 	machine, password := s.Factory.MakeMachineReturningPassword(
 		c, &factory.MachineParams{Nonce: "fake_nonce"})
-	info, srv := newServer(c, s.State)
+	info, srv := newServer(c, s.pool)
 	info.Tag = machine.Tag()
 	info.Password = password
 	info.Nonce = "fake_nonce"
@@ -81,7 +84,7 @@ func (s *loginSuite) TestBadLogin(c *gc.C) {
 	// Start our own server so we can control when the first login
 	// happens. Otherwise in JujuConnSuite.SetUpTest api.Open is
 	// called with user-admin permissions automatically.
-	info, srv := newServer(c, s.State)
+	info, srv := newServer(c, s.pool)
 	defer assertStop(c, srv)
 	info.ModelTag = s.State.ModelTag()
 
@@ -136,7 +139,7 @@ func (s *loginSuite) TestBadLogin(c *gc.C) {
 }
 
 func (s *loginSuite) TestLoginAsDeactivatedUser(c *gc.C) {
-	info, srv := newServer(c, s.State)
+	info, srv := newServer(c, s.pool)
 	defer assertStop(c, srv)
 	info.ModelTag = s.State.ModelTag()
 
@@ -162,7 +165,7 @@ func (s *loginSuite) TestLoginAsDeactivatedUser(c *gc.C) {
 }
 
 func (s *baseLoginSuite) runLoginSetsLogIdentifier(c *gc.C) {
-	info, srv := newServer(c, s.State)
+	info, srv := newServer(c, s.pool)
 	defer assertStop(c, srv)
 
 	machine, password := s.Factory.MakeMachineReturningPassword(
@@ -422,7 +425,7 @@ func (s *loginSuite) TestUsersLoginWhileRateLimited(c *gc.C) {
 }
 
 func (s *loginSuite) TestUsersAreNotRateLimited(c *gc.C) {
-	info, srv := newServer(c, s.State)
+	info, srv := newServer(c, s.pool)
 	defer assertStop(c, srv)
 
 	info.Tag = s.AdminUserTag(c)
@@ -452,7 +455,7 @@ func (s *loginSuite) TestUsersAreNotRateLimited(c *gc.C) {
 }
 
 func (s *loginSuite) TestNonModelUserLoginFails(c *gc.C) {
-	info, srv := newServer(c, s.State)
+	info, srv := newServer(c, s.pool)
 	defer assertStop(c, srv)
 	info.ModelTag = s.State.ModelTag()
 	user := s.Factory.MakeUser(c, &factory.UserParams{Password: "dummy-password", NoModelUser: true})
@@ -509,11 +512,11 @@ func (s *loginSuite) TestLoginValidationDuringUpgrade(c *gc.C) {
 }
 
 func (s *loginSuite) TestFailedLoginDuringMaintenance(c *gc.C) {
-	cfg := defaultServerConfig(c, s.State)
+	cfg := defaultServerConfig(c)
 	cfg.Validator = func(params.LoginRequest) error {
 		return errors.New("something")
 	}
-	info, srv := newServerWithConfig(c, s.State, cfg)
+	info, srv := newServerWithConfig(c, s.pool, cfg)
 	defer assertStop(c, srv)
 	info.ModelTag = s.State.ModelTag()
 
@@ -529,9 +532,9 @@ func (s *loginSuite) TestFailedLoginDuringMaintenance(c *gc.C) {
 type validationChecker func(c *gc.C, err error, st api.Connection)
 
 func (s *baseLoginSuite) checkLoginWithValidator(c *gc.C, validator apiserver.LoginValidator, checker validationChecker) {
-	cfg := defaultServerConfig(c, s.State)
+	cfg := defaultServerConfig(c)
 	cfg.Validator = validator
-	info, srv := newServerWithConfig(c, s.State, cfg)
+	info, srv := newServerWithConfig(c, s.pool, cfg)
 	defer assertStop(c, srv)
 	info.ModelTag = s.State.ModelTag()
 
@@ -563,7 +566,7 @@ func (s *baseLoginSuite) openAPIWithoutLogin(c *gc.C, info0 *api.Info) api.Conne
 }
 
 func (s *loginSuite) TestControllerModel(c *gc.C) {
-	info, srv := newServer(c, s.State)
+	info, srv := newServer(c, s.pool)
 	defer assertStop(c, srv)
 
 	info.ModelTag = s.State.ModelTag()
@@ -577,7 +580,7 @@ func (s *loginSuite) TestControllerModel(c *gc.C) {
 }
 
 func (s *loginSuite) TestControllerModelBadCreds(c *gc.C) {
-	info, srv := newServer(c, s.State)
+	info, srv := newServer(c, s.pool)
 	defer assertStop(c, srv)
 
 	info.ModelTag = s.State.ModelTag()
@@ -589,7 +592,7 @@ func (s *loginSuite) TestControllerModelBadCreds(c *gc.C) {
 }
 
 func (s *loginSuite) TestNonExistentModel(c *gc.C) {
-	info, srv := newServer(c, s.State)
+	info, srv := newServer(c, s.pool)
 	defer assertStop(c, srv)
 
 	uuid, err := utils.NewUUID()
@@ -606,7 +609,7 @@ func (s *loginSuite) TestNonExistentModel(c *gc.C) {
 }
 
 func (s *loginSuite) TestInvalidModel(c *gc.C) {
-	info, srv := newServer(c, s.State)
+	info, srv := newServer(c, s.pool)
 	defer assertStop(c, srv)
 	info.ModelTag = names.NewModelTag("rubbish")
 
@@ -621,7 +624,7 @@ func (s *loginSuite) TestInvalidModel(c *gc.C) {
 }
 
 func (s *loginSuite) TestOtherModel(c *gc.C) {
-	info, srv := newServer(c, s.State)
+	info, srv := newServer(c, s.pool)
 	defer assertStop(c, srv)
 
 	envOwner := s.Factory.MakeUser(c, nil)
@@ -642,7 +645,7 @@ func (s *loginSuite) TestMachineLoginOtherModel(c *gc.C) {
 	// Machine credentials are checked against environment specific
 	// machines, so this makes sure that the credential checking is
 	// using the correct state connection.
-	info, srv := newServer(c, s.State)
+	info, srv := newServer(c, s.pool)
 	defer assertStop(c, srv)
 
 	envOwner := s.Factory.MakeUser(c, nil)
@@ -667,7 +670,7 @@ func (s *loginSuite) TestMachineLoginOtherModel(c *gc.C) {
 }
 
 func (s *loginSuite) TestMachineLoginOtherModelNotProvisioned(c *gc.C) {
-	info, srv := newServer(c, s.State)
+	info, srv := newServer(c, s.pool)
 	defer assertStop(c, srv)
 
 	envOwner := s.Factory.MakeUser(c, nil)
@@ -694,7 +697,7 @@ func (s *loginSuite) TestMachineLoginOtherModelNotProvisioned(c *gc.C) {
 }
 
 func (s *loginSuite) TestOtherEnvironmentFromController(c *gc.C) {
-	info, srv := newServer(c, s.State)
+	info, srv := newServer(c, s.pool)
 	defer assertStop(c, srv)
 
 	machine, password := s.Factory.MakeMachineReturningPassword(c, &factory.MachineParams{
@@ -711,7 +714,7 @@ func (s *loginSuite) TestOtherEnvironmentFromController(c *gc.C) {
 }
 
 func (s *loginSuite) TestOtherEnvironmentFromControllerOtherNotProvisioned(c *gc.C) {
-	info, srv := newServer(c, s.State)
+	info, srv := newServer(c, s.pool)
 	defer assertStop(c, srv)
 
 	managerMachine, password := s.Factory.MakeMachineReturningPassword(c, &factory.MachineParams{
@@ -737,7 +740,7 @@ func (s *loginSuite) TestOtherEnvironmentFromControllerOtherNotProvisioned(c *gc
 }
 
 func (s *loginSuite) TestOtherEnvironmentWhenNotController(c *gc.C) {
-	info, srv := newServer(c, s.State)
+	info, srv := newServer(c, s.pool)
 	defer assertStop(c, srv)
 
 	machine, password := s.Factory.MakeMachineReturningPassword(c, nil)
@@ -770,7 +773,7 @@ func (s *loginSuite) loginLocalUser(c *gc.C, info *api.Info) (*state.User, param
 }
 
 func (s *loginSuite) TestLoginResultLocalUser(c *gc.C) {
-	info, srv := newServer(c, s.State)
+	info, srv := newServer(c, s.pool)
 	defer assertStop(c, srv)
 	info.ModelTag = s.State.ModelTag()
 
@@ -781,7 +784,7 @@ func (s *loginSuite) TestLoginResultLocalUser(c *gc.C) {
 }
 
 func (s *loginSuite) TestLoginResultLocalUserEveryoneCreateOnlyNonLocal(c *gc.C) {
-	info, srv := newServer(c, s.State)
+	info, srv := newServer(c, s.pool)
 	defer assertStop(c, srv)
 	info.ModelTag = s.State.ModelTag()
 
@@ -861,6 +864,13 @@ var _ = gc.Suite(&macaroonLoginSuite{})
 
 type macaroonLoginSuite struct {
 	apitesting.MacaroonSuite
+	pool *state.StatePool
+}
+
+func (s *macaroonLoginSuite) SetUpTest(c *gc.C) {
+	s.MacaroonSuite.SetUpTest(c)
+	s.pool = state.NewStatePool(s.State)
+	s.AddCleanup(func(*gc.C) { s.pool.Close() })
 }
 
 func (s *macaroonLoginSuite) TestLoginToController(c *gc.C) {
@@ -997,10 +1007,10 @@ func (s *macaroonLoginSuite) TestRemoteUserLoginToModelWithExplicitAccessAndAllo
 }
 
 func (s *macaroonLoginSuite) testRemoteUserLoginToModelWithExplicitAccess(c *gc.C, allowModelAccess bool) {
-	cfg := defaultServerConfig(c, s.State)
+	cfg := defaultServerConfig(c)
 	cfg.AllowModelAccess = allowModelAccess
 
-	info, srv := newServerWithConfig(c, s.State, cfg)
+	info, srv := newServerWithConfig(c, s.pool, cfg)
 	defer assertStop(c, srv)
 	info.ModelTag = s.State.ModelTag()
 

--- a/apiserver/export_test.go
+++ b/apiserver/export_test.go
@@ -94,13 +94,13 @@ func TestingAPIRoot(facades *facade.Registry) rpc.Root {
 
 // TestingAPIHandler gives you an APIHandler that isn't connected to
 // anything real. It's enough to let test some basic functionality though.
-func TestingAPIHandler(c *gc.C, srvSt, st *state.State) (*apiHandler, *common.Resources) {
-	authCtxt, err := newAuthContext(srvSt)
+func TestingAPIHandler(c *gc.C, pool *state.StatePool, st *state.State) (*apiHandler, *common.Resources) {
+	authCtxt, err := newAuthContext(pool.SystemState())
 	c.Assert(err, jc.ErrorIsNil)
 	srv := &Server{
-		authCtxt: authCtxt,
-		state:    srvSt,
-		tag:      names.NewMachineTag("0"),
+		authCtxt:  authCtxt,
+		statePool: pool,
+		tag:       names.NewMachineTag("0"),
 	}
 	h, err := newAPIHandler(srv, st, nil, st.ModelUUID(), "testing.invalid:1234")
 	c.Assert(err, jc.ErrorIsNil)
@@ -110,8 +110,8 @@ func TestingAPIHandler(c *gc.C, srvSt, st *state.State) (*apiHandler, *common.Re
 // TestingAPIHandlerWithEntity gives you the sane kind of APIHandler as
 // TestingAPIHandler but sets the passed entity as the apiHandler
 // entity.
-func TestingAPIHandlerWithEntity(c *gc.C, srvSt, st *state.State, entity state.Entity) (*apiHandler, *common.Resources) {
-	h, hr := TestingAPIHandler(c, srvSt, st)
+func TestingAPIHandlerWithEntity(c *gc.C, pool *state.StatePool, st *state.State, entity state.Entity) (*apiHandler, *common.Resources) {
+	h, hr := TestingAPIHandler(c, pool, st)
 	h.entity = entity
 	return h, hr
 }

--- a/apiserver/httpcontext.go
+++ b/apiserver/httpcontext.go
@@ -84,7 +84,7 @@ func (ctxt *httpContext) stateForRequestAuthenticated(r *http.Request) (
 		// Handle the special case of a worker on a controller machine
 		// acting on behalf of a hosted model.
 		if isMachineTag(req.AuthTag) {
-			entity, err := checkControllerMachineCreds(ctxt.srv.state, req, authenticator)
+			entity, err := checkControllerMachineCreds(ctxt.srv.statePool.SystemState(), req, authenticator)
 			if err != nil {
 				return nil, nil, nil, errors.NewUnauthorized(err, "")
 			}

--- a/apiserver/pubsub_test.go
+++ b/apiserver/pubsub_test.go
@@ -28,6 +28,7 @@ import (
 
 type pubsubSuite struct {
 	statetesting.StateSuite
+	pool       *state.StatePool
 	machineTag names.Tag
 	password   string
 	nonce      string
@@ -48,7 +49,9 @@ func (s *pubsubSuite) SetUpTest(c *gc.C) {
 	s.machineTag = m.Tag()
 	s.password = password
 	s.hub = pubsub.NewStructuredHub(nil)
-	_, s.server = newServerWithHub(c, s.State, s.hub)
+	s.pool = state.NewStatePool(s.State)
+	s.AddCleanup(func(*gc.C) { s.pool.Close() })
+	_, s.server = newServerWithHub(c, s.pool, s.hub)
 	s.AddCleanup(func(*gc.C) { s.server.Stop() })
 
 	// A net.TCPAddr cannot be directly stringified into a valid hostname.

--- a/apiserver/server_test.go
+++ b/apiserver/server_test.go
@@ -49,14 +49,21 @@ var fastDialOpts = api.DialOpts{}
 
 type serverSuite struct {
 	jujutesting.JujuConnSuite
+	pool *state.StatePool
 }
 
 var _ = gc.Suite(&serverSuite{})
 
+func (s *serverSuite) SetUpTest(c *gc.C) {
+	s.JujuConnSuite.SetUpTest(c)
+	s.pool = state.NewStatePool(s.State)
+	s.AddCleanup(func(*gc.C) { s.pool.Close() })
+}
+
 func (s *serverSuite) TestStop(c *gc.C) {
 	// Start our own instance of the server so we have
 	// a handle on it to stop it.
-	_, srv := newServer(c, s.State)
+	_, srv := newServer(c, s.pool)
 	defer assertStop(c, srv)
 
 	machine, password := s.Factory.MakeMachineReturningPassword(
@@ -101,7 +108,7 @@ func (s *serverSuite) TestAPIServerCanListenOnBothIPv4AndIPv6(c *gc.C) {
 
 	// Start our own instance of the server listening on
 	// both IPv4 and IPv6 localhost addresses and an ephemeral port.
-	_, srv := newServer(c, s.State)
+	_, srv := newServer(c, s.pool)
 	defer assertStop(c, srv)
 
 	port := srv.Addr().Port
@@ -210,6 +217,9 @@ func (s *serverSuite) TestNewServerDoesNotAccessState(c *gc.C) {
 	c.Assert(err, gc.IsNil)
 	defer st.Close()
 
+	pool := state.NewStatePool(st)
+	defer pool.Close()
+
 	// Now close the proxy so that any attempts to use the
 	// controller will fail.
 	proxy.Close()
@@ -217,7 +227,7 @@ func (s *serverSuite) TestNewServerDoesNotAccessState(c *gc.C) {
 	// Creating the server should succeed because it doesn't
 	// access the state (note that newServer does not log in,
 	// which *would* access the state).
-	_, srv := newServer(c, st)
+	_, srv := newServer(c, pool)
 	srv.Stop()
 }
 
@@ -293,7 +303,7 @@ func dialWebsocket(c *gc.C, addr, path string, tlsVersion uint16) (*websocket.Co
 
 func (s *serverSuite) TestMinTLSVersion(c *gc.C) {
 	loggo.GetLogger("juju.apiserver").SetLogLevel(loggo.TRACE)
-	_, srv := newServer(c, s.State)
+	_, srv := newServer(c, s.pool)
 	defer assertStop(c, srv)
 
 	// We have to use 'localhost' because that is what the TLS cert says.
@@ -309,7 +319,7 @@ func (s *serverSuite) TestNonCompatiblePathsAre404(c *gc.C) {
 	// We expose the API at '/api', '/' (controller-only), and at '/ModelUUID/api'
 	// for the correct location, but other paths should fail.
 	loggo.GetLogger("juju.apiserver").SetLogLevel(loggo.TRACE)
-	_, srv := newServer(c, s.State)
+	_, srv := newServer(c, s.pool)
 	defer assertStop(c, srv)
 
 	// We have to use 'localhost' because that is what the TLS cert says.
@@ -340,7 +350,7 @@ func (s *serverSuite) TestNonCompatiblePathsAre404(c *gc.C) {
 }
 
 func (s *serverSuite) TestNoBakeryWhenNoIdentityURL(c *gc.C) {
-	_, srv := newServer(c, s.State)
+	_, srv := newServer(c, s.pool)
 	defer assertStop(c, srv)
 	// By default, when there is no identity location, no
 	// bakery service or macaroon is created.
@@ -353,6 +363,7 @@ func (s *serverSuite) TestNoBakeryWhenNoIdentityURL(c *gc.C) {
 type macaroonServerSuite struct {
 	jujutesting.JujuConnSuite
 	discharger *bakerytest.Discharger
+	pool       *state.StatePool
 }
 
 var _ = gc.Suite(&macaroonServerSuite{})
@@ -363,6 +374,8 @@ func (s *macaroonServerSuite) SetUpTest(c *gc.C) {
 		controller.IdentityURL: s.discharger.Location(),
 	}
 	s.JujuConnSuite.SetUpTest(c)
+	s.pool = state.NewStatePool(s.State)
+	s.AddCleanup(func(*gc.C) { s.pool.Close() })
 }
 
 func (s *macaroonServerSuite) TearDownTest(c *gc.C) {
@@ -371,7 +384,7 @@ func (s *macaroonServerSuite) TearDownTest(c *gc.C) {
 }
 
 func (s *macaroonServerSuite) TestServerBakery(c *gc.C) {
-	_, srv := newServer(c, s.State)
+	_, srv := newServer(c, s.pool)
 	defer assertStop(c, srv)
 	m, err := apiserver.ServerMacaroon(srv)
 	c.Assert(err, gc.IsNil)
@@ -401,6 +414,7 @@ func (s *macaroonServerSuite) TestServerBakery(c *gc.C) {
 type macaroonServerWrongPublicKeySuite struct {
 	jujutesting.JujuConnSuite
 	discharger *bakerytest.Discharger
+	pool       *state.StatePool
 }
 
 var _ = gc.Suite(&macaroonServerWrongPublicKeySuite{})
@@ -414,6 +428,8 @@ func (s *macaroonServerWrongPublicKeySuite) SetUpTest(c *gc.C) {
 		controller.IdentityPublicKey: wrongKey.Public.String(),
 	}
 	s.JujuConnSuite.SetUpTest(c)
+	s.pool = state.NewStatePool(s.State)
+	s.AddCleanup(func(*gc.C) { s.pool.Close() })
 }
 
 func (s *macaroonServerWrongPublicKeySuite) TearDownTest(c *gc.C) {
@@ -422,7 +438,7 @@ func (s *macaroonServerWrongPublicKeySuite) TearDownTest(c *gc.C) {
 }
 
 func (s *macaroonServerWrongPublicKeySuite) TestDischargeFailsWithWrongPublicKey(c *gc.C) {
-	_, srv := newServer(c, s.State)
+	_, srv := newServer(c, s.pool)
 	defer assertStop(c, srv)
 	m, err := apiserver.ServerMacaroon(srv)
 	c.Assert(err, gc.IsNil)
@@ -469,7 +485,7 @@ func (s *serverSuite) bootstrapHasPermissionTest(c *gc.C) (*state.User, names.Co
 func (s *serverSuite) TestAPIHandlerHasPermissionLogin(c *gc.C) {
 	u, ctag := s.bootstrapHasPermissionTest(c)
 
-	handler, _ := apiserver.TestingAPIHandlerWithEntity(c, s.State, s.State, u)
+	handler, _ := apiserver.TestingAPIHandlerWithEntity(c, s.pool, s.State, u)
 	defer handler.Kill()
 
 	apiserver.AssertHasPermission(c, handler, permission.LoginAccess, ctag, true)
@@ -481,7 +497,7 @@ func (s *serverSuite) TestAPIHandlerHasPermissionAddmodel(c *gc.C) {
 	u, ctag := s.bootstrapHasPermissionTest(c)
 	user := u.UserTag()
 
-	handler, _ := apiserver.TestingAPIHandlerWithEntity(c, s.State, s.State, u)
+	handler, _ := apiserver.TestingAPIHandlerWithEntity(c, s.pool, s.State, u)
 	defer handler.Kill()
 
 	ua, err := s.State.SetUserAccess(user, ctag, permission.AddModelAccess)
@@ -497,7 +513,7 @@ func (s *serverSuite) TestAPIHandlerHasPermissionSuperUser(c *gc.C) {
 	u, ctag := s.bootstrapHasPermissionTest(c)
 	user := u.UserTag()
 
-	handler, _ := apiserver.TestingAPIHandlerWithEntity(c, s.State, s.State, u)
+	handler, _ := apiserver.TestingAPIHandlerWithEntity(c, s.pool, s.State, u)
 	defer handler.Kill()
 
 	ua, err := s.State.SetUserAccess(user, ctag, permission.SuperuserAccess)
@@ -522,16 +538,16 @@ func (s *serverSuite) TestAPIHandlerTeardownOtherEnviron(c *gc.C) {
 func (s *serverSuite) TestAPIHandlerConnectedModel(c *gc.C) {
 	otherState := s.Factory.MakeModel(c, nil)
 	defer otherState.Close()
-	handler, _ := apiserver.TestingAPIHandler(c, s.State, otherState)
+	handler, _ := apiserver.TestingAPIHandler(c, s.pool, otherState)
 	defer handler.Kill()
 	c.Check(handler.ConnectedModel(), gc.Equals, otherState.ModelUUID())
 }
 
 func (s *serverSuite) TestClosesStateFromPool(c *gc.C) {
 	pool := state.NewStatePool(s.State)
-	cfg := defaultServerConfig(c, s.State)
-	cfg.StatePool = pool
-	_, server := newServerWithConfig(c, s.State, cfg)
+	defer pool.Close()
+	cfg := defaultServerConfig(c)
+	_, server := newServerWithConfig(c, pool, cfg)
 	defer assertStop(c, server)
 
 	w := s.State.WatchModels()
@@ -601,7 +617,7 @@ func assertStateBecomesClosed(c *gc.C, st *state.State) {
 }
 
 func (s *serverSuite) checkAPIHandlerTeardown(c *gc.C, srvSt, st *state.State) {
-	handler, resources := apiserver.TestingAPIHandler(c, srvSt, st)
+	handler, resources := apiserver.TestingAPIHandler(c, s.pool, st)
 	resource := new(fakeResource)
 	resources.Register(resource)
 
@@ -611,7 +627,7 @@ func (s *serverSuite) checkAPIHandlerTeardown(c *gc.C, srvSt, st *state.State) {
 }
 
 // defaultServerConfig returns the default configuration for starting a test server.
-func defaultServerConfig(c *gc.C, st *state.State) apiserver.ServerConfig {
+func defaultServerConfig(c *gc.C) apiserver.ServerConfig {
 	fakeOrigin := names.NewMachineTag("0")
 	hub := centralhub.New(fakeOrigin)
 	return apiserver.ServerConfig{
@@ -623,7 +639,6 @@ func defaultServerConfig(c *gc.C, st *state.State) apiserver.ServerConfig {
 		Hub:             hub,
 		NewObserver:     func() observer.Observer { return &fakeobserver.Instance{} },
 		AutocertURL:     "https://0.1.2.3/no-autocert-here",
-		StatePool:       state.NewStatePool(st),
 		RateLimitConfig: apiserver.DefaultRateLimitConfig(),
 	}
 }
@@ -635,25 +650,25 @@ func defaultServerConfig(c *gc.C, st *state.State) apiserver.ServerConfig {
 // It returns information suitable for connecting to the state
 // without any authentication information or model tag, and the server
 // that's been started.
-func newServer(c *gc.C, st *state.State) (*api.Info, *apiserver.Server) {
-	return newServerWithConfig(c, st, defaultServerConfig(c, st))
+func newServer(c *gc.C, statePool *state.StatePool) (*api.Info, *apiserver.Server) {
+	return newServerWithConfig(c, statePool, defaultServerConfig(c))
 }
 
-func newServerWithHub(c *gc.C, st *state.State, hub *pubsub.StructuredHub) (*api.Info, *apiserver.Server) {
-	cfg := defaultServerConfig(c, st)
+func newServerWithHub(c *gc.C, statePool *state.StatePool, hub *pubsub.StructuredHub) (*api.Info, *apiserver.Server) {
+	cfg := defaultServerConfig(c)
 	cfg.Hub = hub
-	return newServerWithConfig(c, st, cfg)
+	return newServerWithConfig(c, statePool, cfg)
 }
 
 // newServerWithConfig is like newServer except that the entire
 // server configuration may be specified (see defaultServerConfig
 // for a suitable starting point).
-func newServerWithConfig(c *gc.C, st *state.State, cfg apiserver.ServerConfig) (*api.Info, *apiserver.Server) {
+func newServerWithConfig(c *gc.C, statePool *state.StatePool, cfg apiserver.ServerConfig) (*api.Info, *apiserver.Server) {
 	// Note that we can't listen on localhost here because TestAPIServerCanListenOnBothIPv4AndIPv6 assumes
 	// that we listen on IPv6 too, and listening on localhost does not do that.
 	listener, err := net.Listen("tcp", ":0")
 	c.Assert(err, jc.ErrorIsNil)
-	srv, err := apiserver.NewServer(st, listener, cfg)
+	srv, err := apiserver.NewServer(statePool, listener, cfg)
 	c.Assert(err, jc.ErrorIsNil)
 	return &api.Info{
 		Addrs:  []string{fmt.Sprintf("localhost:%d", srv.Addr().Port)},

--- a/cmd/jujud/agent/introspection.go
+++ b/cmd/jujud/agent/introspection.go
@@ -84,6 +84,8 @@ func newPrometheusRegistry() (*prometheus.Registry, error) {
 }
 
 func (h *statePoolHolder) IntrospectionReport() string {
+	h.mu.Lock()
+	defer h.mu.Unlock()
 	if h.pool == nil {
 		return "agent has no pool set"
 	}

--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -81,6 +81,7 @@ import (
 	"github.com/juju/juju/watcher"
 	jworker "github.com/juju/juju/worker"
 	"github.com/juju/juju/worker/apicaller"
+	"github.com/juju/juju/worker/catacomb"
 	"github.com/juju/juju/worker/certupdater"
 	"github.com/juju/juju/worker/conv2state"
 	"github.com/juju/juju/worker/dblogpruner"
@@ -388,7 +389,14 @@ type MachineAgent struct {
 }
 
 type statePoolHolder struct {
+	mu   sync.Mutex
 	pool *state.StatePool
+}
+
+func (h *statePoolHolder) set(pool *state.StatePool) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.pool = pool
 }
 
 // IsRestorePreparing returns bool representing if we are in restore mode
@@ -1073,9 +1081,6 @@ func (a *MachineAgent) startStateWorkers(
 			a.startWorkerAfterUpgrade(runner, "mongoupgrade", func() (worker.Worker, error) {
 				return newUpgradeMongoWorker(st, a.machineId, a.maybeStopMongo)
 			})
-			a.startWorkerAfterUpgrade(runner, "statemetrics", func() (worker.Worker, error) {
-				return newStateMetricsWorker(st, a.prometheusRegistry), nil
-			})
 
 			// certChangedChan is shared by multiple workers it's up
 			// to the agent to close it rather than any one of the
@@ -1198,8 +1203,12 @@ func (a *MachineAgent) apiserverWorkerStarter(
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
-		w, err := a.newAPIserverWorker(st, certChanged, dependencyReporter)
+		statePool := state.NewStatePool(st)
+		w, err := a.newAPIserverWorker(
+			st, statePool, certChanged, dependencyReporter,
+		)
 		if err != nil {
+			statePool.Close()
 			st.Close()
 			return nil, errors.Trace(err)
 		}
@@ -1209,6 +1218,7 @@ func (a *MachineAgent) apiserverWorkerStarter(
 
 func (a *MachineAgent) newAPIserverWorker(
 	st *state.State,
+	statePool *state.StatePool,
 	certChanged chan params.StateServingInfo,
 	dependencyReporter dependency.Reporter,
 ) (worker.Worker, error) {
@@ -1261,8 +1271,6 @@ func (a *MachineAgent) newAPIserverWorker(
 	if err != nil {
 		return nil, errors.Annotate(err, "cannot create RPC observer factory")
 	}
-	statePool := state.NewStatePool(st)
-	a.statePool.pool = statePool
 
 	registerIntrospectionHandlers := func(f func(string, http.Handler)) {
 		introspection.RegisterHTTPHandlers(
@@ -1280,7 +1288,8 @@ func (a *MachineAgent) newAPIserverWorker(
 	if err != nil {
 		return nil, errors.Annotate(err, "getting log sink config")
 	}
-	server, err := apiserver.NewServer(st, listener, apiserver.ServerConfig{
+
+	server, err := apiserver.NewServer(statePool, listener, apiserver.ServerConfig{
 		Clock:                         clock.WallClock,
 		Cert:                          cert,
 		Key:                           key,
@@ -1294,7 +1303,6 @@ func (a *MachineAgent) newAPIserverWorker(
 		AutocertDNSName:               controllerConfig.AutocertDNSName(),
 		AllowModelAccess:              controllerConfig.AllowModelAccess(),
 		NewObserver:                   newObserver,
-		StatePool:                     statePool,
 		RegisterIntrospectionHandlers: registerIntrospectionHandlers,
 		RateLimitConfig:               rateLimitConfig,
 		LogSinkConfig:                 &logSinkConfig,
@@ -1304,7 +1312,45 @@ func (a *MachineAgent) newAPIserverWorker(
 		return nil, errors.Annotate(err, "cannot start api server worker")
 	}
 
-	return server, nil
+	// Report state metrics.
+	stateMetricsRunner := worker.NewRunner(worker.RunnerParams{
+		IsFatal:       cmdutil.IsFatal,
+		MoreImportant: cmdutil.MoreImportant,
+		RestartDelay:  jworker.RestartDelay,
+	})
+	stateMetricsRunner.StartWorker("statemetrics", func() (worker.Worker, error) {
+		return newStateMetricsWorker(statePool, a.prometheusRegistry), nil
+	})
+
+	var apiserverWorker catacombWorker
+	if err := catacomb.Invoke(catacomb.Plan{
+		Site: &apiserverWorker.Catacomb,
+		Work: func() error {
+			defer st.Close()
+			defer statePool.Close()
+			defer a.statePool.set(nil)
+			<-apiserverWorker.Catacomb.Dying()
+			// Wait for the workers to die before
+			// closing the state pool, as they
+			// may still be using it.
+			server.Wait()
+			stateMetricsRunner.Wait()
+			return apiserverWorker.Catacomb.ErrDying()
+		},
+		Init: []worker.Worker{server, stateMetricsRunner},
+	}); err != nil {
+		return nil, errors.Trace(err)
+	}
+	a.statePool.set(statePool)
+	return &apiserverWorker, nil
+}
+
+type catacombWorker struct {
+	catacomb.Catacomb
+}
+
+func (w *catacombWorker) Kill() {
+	w.Catacomb.Kill(nil)
 }
 
 func getRateLimitConfig(cfg agent.Config) (apiserver.RateLimitConfig, error) {
@@ -1837,9 +1883,9 @@ var newDeployContext = func(st *apideployer.State, agentConfig agent.Config) dep
 	return deployer.NewSimpleContext(agentConfig, st)
 }
 
-func newStateMetricsWorker(st *state.State, registry *prometheus.Registry) worker.Worker {
+func newStateMetricsWorker(statePool *state.StatePool, registry *prometheus.Registry) worker.Worker {
 	return jworker.NewSimpleWorker(func(stop <-chan struct{}) error {
-		collector := statemetrics.New(statemetrics.NewState(st))
+		collector := statemetrics.New(statemetrics.NewStatePool(statePool))
 		if err := registry.Register(collector); err != nil {
 			return errors.Annotate(err, "registering statemetrics collector")
 		}

--- a/provider/dummy/environs.go
+++ b/provider/dummy/environs.go
@@ -792,20 +792,25 @@ func (e *environ) Bootstrap(ctx environs.BootstrapContext, args environs.Bootstr
 				return err
 			}
 			if err := st.SetModelConstraints(args.ModelConstraints); err != nil {
+				st.Close()
 				return err
 			}
 			if err := st.SetAdminMongoPassword(icfg.Controller.MongoInfo.Password); err != nil {
+				st.Close()
 				return err
 			}
 			if err := st.MongoSession().DB("admin").Login("admin", icfg.Controller.MongoInfo.Password); err != nil {
+				st.Close()
 				return err
 			}
 			env, err := st.Model()
 			if err != nil {
+				st.Close()
 				return err
 			}
 			owner, err := st.User(env.Owner())
 			if err != nil {
+				st.Close()
 				return err
 			}
 			// We log this out for test purposes only. No one in real life can use
@@ -814,17 +819,15 @@ func (e *environ) Bootstrap(ctx environs.BootstrapContext, args environs.Bootstr
 			logger.Debugf("setting password for %q to %q", owner.Name(), icfg.Controller.MongoInfo.Password)
 			owner.SetPassword(icfg.Controller.MongoInfo.Password)
 
-			estate.apiStatePool = state.NewStatePool(st)
-
+			statePool := state.NewStatePool(st)
 			machineTag := names.NewMachineTag("0")
-			estate.apiServer, err = apiserver.NewServer(st, estate.apiListener, apiserver.ServerConfig{
+			estate.apiServer, err = apiserver.NewServer(statePool, estate.apiListener, apiserver.ServerConfig{
 				Clock:       clock.WallClock,
 				Cert:        testing.ServerCert,
 				Key:         testing.ServerKey,
 				Tag:         machineTag,
 				DataDir:     DataDir,
 				LogDir:      LogDir,
-				StatePool:   estate.apiStatePool,
 				Hub:         centralhub.New(machineTag),
 				NewObserver: func() observer.Observer { return &fakeobserver.Instance{} },
 				// Should never be used but prevent external access just in case.
@@ -837,9 +840,12 @@ func (e *environ) Bootstrap(ctx environs.BootstrapContext, args environs.Bootstr
 				RateLimitConfig: apiserver.DefaultRateLimitConfig(),
 			})
 			if err != nil {
+				statePool.Close()
+				st.Close()
 				panic(err)
 			}
 			estate.apiState = st
+			estate.apiStatePool = statePool
 		}
 		estate.ops <- OpFinalizeBootstrap{Context: ctx, Env: e.name, InstanceConfig: icfg}
 		return nil

--- a/state/statemetrics/statemetrics_test.go
+++ b/state/statemetrics/statemetrics_test.go
@@ -22,7 +22,7 @@ import (
 
 type collectorSuite struct {
 	testing.IsolationSuite
-	st        mockState
+	pool      mockStatePool
 	collector *statemetrics.Collector
 }
 
@@ -67,11 +67,13 @@ func (s *collectorSuite) SetUpTest(c *gc.C) {
 		}},
 	}}
 
-	s.st = mockState{
-		users:  users,
-		models: models,
+	s.pool = mockStatePool{
+		system: &mockState{
+			users:  users,
+			models: models,
+		},
 	}
-	s.collector = statemetrics.New(&s.st)
+	s.collector = statemetrics.New(&s.pool)
 }
 
 func (s *collectorSuite) TestDescribe(c *gc.C) {
@@ -226,7 +228,7 @@ func (s *collectorSuite) TestCollect(c *gc.C) {
 }
 
 func (s *collectorSuite) TestCollectErrors(c *gc.C) {
-	s.st.SetErrors(
+	s.pool.system.SetErrors(
 		errors.New("no models for you"),
 		errors.New("no users for you"),
 	)


### PR DESCRIPTION
## Description of change

The primary aim of this PR is to stop using State.ForModel in the statemetrics code.

To enable this, we make a change to the apiserver code: this apiserver.Server no longer owns its StatePool (or State), so it does not Close it when exiting. We also make a small change to stop passing in both a StatePool and "system" State, and pass in just the StatePool. The machine agent now passes the same StatePool into both the apiserver.NewServer and statemetrics.New constructors, and closes it when both have stopped.

There is also a small fix to the introspection code, making it hold a mutex before using the state pool (which could change at runtime).

## QA steps

1. juju bootstrap
2. juju ssh -m controller 0 juju-introspect metrics
3. juju ssh -m controller 0 juju-statepool-report

## Documentation changes

None.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1697843