### PR TITLE
state: Use StatePool instead of ForModel in AllModelWatcher 

### DIFF
--- a/apiserver/controller/controller_test.go
+++ b/apiserver/controller/controller_test.go
@@ -36,6 +36,7 @@ import (
 type controllerSuite struct {
 	statetesting.StateSuite
 
+	statePool  *state.StatePool
 	controller *controller.ControllerAPI
 	resources  *common.Resources
 	authorizer apiservertesting.FakeAuthorizer
@@ -50,6 +51,13 @@ func (s *controllerSuite) SetUpTest(c *gc.C) {
 	})
 
 	s.StateSuite.SetUpTest(c)
+
+	s.statePool = state.NewStatePool(s.State)
+	s.AddCleanup(func(c *gc.C) {
+		err := s.statePool.Close()
+		c.Assert(err, jc.ErrorIsNil)
+	})
+
 	s.resources = common.NewResources()
 	s.AddCleanup(func(_ *gc.C) { s.resources.StopAll() })
 
@@ -61,6 +69,7 @@ func (s *controllerSuite) SetUpTest(c *gc.C) {
 	controller, err := controller.NewControllerAPI(
 		facadetest.Context{
 			State_:     s.State,
+			StatePool_: s.statePool,
 			Resources_: s.resources,
 			Auth_:      s.authorizer,
 		})

--- a/state/allwatcher.go
+++ b/state/allwatcher.go
@@ -1330,11 +1330,11 @@ func (b *allModelWatcherStateBacking) GetAll(all *multiwatcherStore) error {
 }
 
 func (b *allModelWatcherStateBacking) loadAllWatcherEntitiesForModel(m *Model, all *multiwatcherStore) error {
-	st, err := b.st.ForModel(m.ModelTag())
+	st, releaser, err := b.stPool.Get(m.UUID())
 	if err != nil {
 		return errors.Trace(err)
 	}
-	defer st.Close()
+	defer releaser()
 
 	err = loadAllWatcherEntities(st, b.collectionByName, all)
 	if err != nil {

--- a/state/logdb/buf_test.go
+++ b/state/logdb/buf_test.go
@@ -44,7 +44,7 @@ func (s *BufferedLoggerSuite) assertNoFlush(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	select {
 	case records := <-s.mock.called:
-		c.Fatal("unexpected log records: %v", records)
+		c.Fatalf("unexpected log records: %v", records)
 	case <-time.After(coretesting.ShortWait):
 	}
 }


### PR DESCRIPTION
## Description of change

ForModel is inefficient. Starting a AllModelWatcher on a controller with many models would have had a significant resource impact.

Also a drive-by fix for an incorrect call in state/logdb.

## QA steps

Bootstrapped a new controller and then connected using this client: https://gist.github.com/mjs/d9d016433e4348b4aa990a8f81d65d03

Deployed software in multiple models and ensured that all expected changes were observed.

## Documentation changes

N.A.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1698701
