### PR TITLE
Fixes lp#1628919: help-tool fix for payload hook tools.

### DIFF
--- a/cmd/juju/commands/helptool_test.go
+++ b/cmd/juju/commands/helptool_test.go
@@ -8,11 +8,9 @@ import (
 	"runtime"
 	"strings"
 
-	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/testing"
-	"github.com/juju/juju/worker/uniter/runner/jujuc"
 )
 
 type HelpToolSuite struct {
@@ -30,8 +28,39 @@ Show help on a Juju charm tool.
 `)
 }
 
+var expectedCommands = []string{
+	"action-fail",
+	"action-get",
+	"action-set",
+	"add-metric",
+	"application-version-set",
+	"close-port",
+	"config-get",
+	"is-leader",
+	"juju-log",
+	"juju-reboot",
+	"leader-get",
+	"leader-set",
+	"network-get",
+	"open-port",
+	"opened-ports",
+	"payload-register",
+	"payload-status-set",
+	"payload-unregister",
+	"relation-get",
+	"relation-ids",
+	"relation-list",
+	"relation-set",
+	"resource-get",
+	"status-get",
+	"status-set",
+	"storage-add",
+	"storage-get",
+	"storage-list",
+	"unit-get",
+}
+
 func (suite *HelpToolSuite) TestHelpTool(c *gc.C) {
-	expectedNames := jujuc.CommandNames()
 	output := badrun(c, 0, "help-tool")
 	lines := strings.Split(strings.TrimSpace(output), "\n")
 	template := "%v"
@@ -42,28 +71,7 @@ func (suite *HelpToolSuite) TestHelpTool(c *gc.C) {
 		command := strings.Fields(line)[0]
 		lines[i] = fmt.Sprintf(template, command)
 	}
-	c.Assert(lines, gc.DeepEquals, expectedNames)
-}
-
-// Component-based features such as payloads and resources
-// are different enough in implementation to the rest
-// of Juju code that we need to ensure that help-tool can reach them
-// explicitely.
-func (suite *HelpToolSuite) TestHelpToolHasComponents(c *gc.C) {
-	hasPayloads, hasResources := false, false
-	output := badrun(c, 0, "help-tool")
-	lines := strings.Split(strings.TrimSpace(output), "\n")
-	for _, line := range lines {
-		command := strings.Fields(line)[0]
-		if strings.HasPrefix(command, "payload-") {
-			hasPayloads = true
-		}
-		if strings.HasPrefix(command, "resource-") {
-			hasResources = true
-		}
-	}
-	c.Assert(hasPayloads, jc.IsTrue)
-	c.Assert(hasResources, jc.IsTrue)
+	c.Assert(lines, gc.DeepEquals, expectedCommands)
 }
 
 func (suite *HelpToolSuite) TestHelpToolName(c *gc.C) {

--- a/component/all/payload.go
+++ b/component/all/payload.go
@@ -28,6 +28,8 @@ func (c payloads) registerForServer() error {
 
 func (c payloads) registerForClient() error {
 	c.registerPublicCommands()
+	// needed for help-tool
+	c.registerHookContextCommands()
 	return nil
 }
 

--- a/payload/context/register_test.go
+++ b/payload/context/register_test.go
@@ -38,17 +38,17 @@ func (s *registerSuite) SetUpTest(c *gc.C) {
 	}
 }
 
-func (s registerSuite) TestInitNilArgs(c *gc.C) {
+func (s *registerSuite) TestInitNilArgs(c *gc.C) {
 	err := s.command.Init(nil)
 	c.Assert(err, gc.NotNil)
 }
 
-func (s registerSuite) TestInitTooFewArgs(c *gc.C) {
+func (s *registerSuite) TestInitTooFewArgs(c *gc.C) {
 	err := s.command.Init([]string{"foo", "bar"})
 	c.Assert(err, gc.NotNil)
 }
 
-func (s registerSuite) TestInit(c *gc.C) {
+func (s *registerSuite) TestInit(c *gc.C) {
 	err := s.command.Init([]string{"type", "class", "id"})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(s.command.typ, gc.Equals, "type")
@@ -57,7 +57,7 @@ func (s registerSuite) TestInit(c *gc.C) {
 	c.Assert(s.command.labels, gc.HasLen, 0)
 }
 
-func (s registerSuite) TestInitWithLabels(c *gc.C) {
+func (s *registerSuite) TestInitWithLabels(c *gc.C) {
 	err := s.command.Init([]string{"type", "class", "id", "tag1", "tag 2"})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(s.command.typ, gc.Equals, "type")
@@ -66,7 +66,7 @@ func (s registerSuite) TestInitWithLabels(c *gc.C) {
 	c.Assert(s.command.labels, gc.DeepEquals, []string{"tag1", "tag 2"})
 }
 
-func (s registerSuite) TestRun(c *gc.C) {
+func (s *registerSuite) TestRun(c *gc.C) {
 	err := s.command.Init([]string{"type", "class", "id", "tag1", "tag 2"})
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -87,7 +87,7 @@ func (s registerSuite) TestRun(c *gc.C) {
 	// TODO (natefinch): we need to do something with the labels
 }
 
-func (s registerSuite) TestRunUnknownClass(c *gc.C) {
+func (s *registerSuite) TestRunUnknownClass(c *gc.C) {
 	err := s.command.Init([]string{"type", "badclass", "id"})
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -96,7 +96,7 @@ func (s registerSuite) TestRunUnknownClass(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, "payload \"badclass\" not found in metadata.yaml")
 }
 
-func (s registerSuite) TestRunUnknownType(c *gc.C) {
+func (s *registerSuite) TestRunUnknownType(c *gc.C) {
 	err := s.command.Init([]string{"badtype", "class", "id"})
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -105,7 +105,7 @@ func (s registerSuite) TestRunUnknownType(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, "incorrect type \"badtype\" for payload \"class\", expected \"type\"")
 }
 
-func (s registerSuite) TestRunTrackErr(c *gc.C) {
+func (s *registerSuite) TestRunTrackErr(c *gc.C) {
 	s.hookCtx.trackerr = errors.Errorf("boo")
 	err := s.command.Init([]string{"type", "class", "id", "tag1", "tag 2"})
 	c.Assert(err, jc.ErrorIsNil)

--- a/payload/context/register_test.go
+++ b/payload/context/register_test.go
@@ -19,53 +19,62 @@ import (
 
 type registerSuite struct {
 	testing.IsolationSuite
+
+	hookCtx *stubRegisterContext
+	command RegisterCmd
 }
 
 var _ = gc.Suite(&registerSuite{})
 
-func (registerSuite) TestInitNilArgs(c *gc.C) {
-	r := RegisterCmd{}
-	err := r.Init(nil)
+func (s *registerSuite) SetUpTest(c *gc.C) {
+	s.IsolationSuite.SetUpTest(c)
+
+	s.hookCtx = &stubRegisterContext{}
+
+	s.command = RegisterCmd{
+		hookContextFunc: func() (Component, error) {
+			return s.hookCtx, nil
+		},
+	}
+}
+
+func (s registerSuite) TestInitNilArgs(c *gc.C) {
+	err := s.command.Init(nil)
 	c.Assert(err, gc.NotNil)
 }
 
-func (registerSuite) TestInitTooFewArgs(c *gc.C) {
-	r := RegisterCmd{}
-	err := r.Init([]string{"foo", "bar"})
+func (s registerSuite) TestInitTooFewArgs(c *gc.C) {
+	err := s.command.Init([]string{"foo", "bar"})
 	c.Assert(err, gc.NotNil)
 }
 
-func (registerSuite) TestInit(c *gc.C) {
-	r := RegisterCmd{}
-	err := r.Init([]string{"type", "class", "id"})
+func (s registerSuite) TestInit(c *gc.C) {
+	err := s.command.Init([]string{"type", "class", "id"})
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(r.typ, gc.Equals, "type")
-	c.Assert(r.class, gc.Equals, "class")
-	c.Assert(r.id, gc.Equals, "id")
-	c.Assert(r.labels, gc.HasLen, 0)
+	c.Assert(s.command.typ, gc.Equals, "type")
+	c.Assert(s.command.class, gc.Equals, "class")
+	c.Assert(s.command.id, gc.Equals, "id")
+	c.Assert(s.command.labels, gc.HasLen, 0)
 }
 
-func (registerSuite) TestInitWithLabels(c *gc.C) {
-	r := RegisterCmd{}
-	err := r.Init([]string{"type", "class", "id", "tag1", "tag 2"})
+func (s registerSuite) TestInitWithLabels(c *gc.C) {
+	err := s.command.Init([]string{"type", "class", "id", "tag1", "tag 2"})
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(r.typ, gc.Equals, "type")
-	c.Assert(r.class, gc.Equals, "class")
-	c.Assert(r.id, gc.Equals, "id")
-	c.Assert(r.labels, gc.DeepEquals, []string{"tag1", "tag 2"})
+	c.Assert(s.command.typ, gc.Equals, "type")
+	c.Assert(s.command.class, gc.Equals, "class")
+	c.Assert(s.command.id, gc.Equals, "id")
+	c.Assert(s.command.labels, gc.DeepEquals, []string{"tag1", "tag 2"})
 }
 
-func (registerSuite) TestRun(c *gc.C) {
-	f := &stubRegisterContext{}
-	r := RegisterCmd{hctx: f}
-	err := r.Init([]string{"type", "class", "id", "tag1", "tag 2"})
+func (s registerSuite) TestRun(c *gc.C) {
+	err := s.command.Init([]string{"type", "class", "id", "tag1", "tag 2"})
 	c.Assert(err, jc.ErrorIsNil)
 
 	ctx := setupMetadata(c)
-	err = r.Run(ctx)
+	err = s.command.Run(ctx)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Check(f.flushed, jc.IsTrue)
-	c.Check(f.payload, jc.DeepEquals, payload.Payload{
+	c.Check(s.hookCtx.flushed, jc.IsTrue)
+	c.Check(s.hookCtx.payload, jc.DeepEquals, payload.Payload{
 		PayloadClass: charm.PayloadClass{
 			Name: "class",
 			Type: "type",
@@ -78,47 +87,41 @@ func (registerSuite) TestRun(c *gc.C) {
 	// TODO (natefinch): we need to do something with the labels
 }
 
-func (registerSuite) TestRunUnknownClass(c *gc.C) {
-	f := &stubRegisterContext{}
-	r := RegisterCmd{hctx: f}
-	err := r.Init([]string{"type", "badclass", "id"})
+func (s registerSuite) TestRunUnknownClass(c *gc.C) {
+	err := s.command.Init([]string{"type", "badclass", "id"})
 	c.Assert(err, jc.ErrorIsNil)
 
 	ctx := setupMetadata(c)
-	err = r.Run(ctx)
+	err = s.command.Run(ctx)
 	c.Assert(err, gc.ErrorMatches, "payload \"badclass\" not found in metadata.yaml")
 }
 
-func (registerSuite) TestRunUnknownType(c *gc.C) {
-	f := &stubRegisterContext{}
-	r := RegisterCmd{hctx: f}
-	err := r.Init([]string{"badtype", "class", "id"})
+func (s registerSuite) TestRunUnknownType(c *gc.C) {
+	err := s.command.Init([]string{"badtype", "class", "id"})
 	c.Assert(err, jc.ErrorIsNil)
 
 	ctx := setupMetadata(c)
-	err = r.Run(ctx)
+	err = s.command.Run(ctx)
 	c.Assert(err, gc.ErrorMatches, "incorrect type \"badtype\" for payload \"class\", expected \"type\"")
 }
 
-func (registerSuite) TestRunTrackErr(c *gc.C) {
-	f := &stubRegisterContext{trackerr: errors.Errorf("boo")}
-	r := RegisterCmd{hctx: f}
-	err := r.Init([]string{"type", "class", "id", "tag1", "tag 2"})
+func (s registerSuite) TestRunTrackErr(c *gc.C) {
+	s.hookCtx.trackerr = errors.Errorf("boo")
+	err := s.command.Init([]string{"type", "class", "id", "tag1", "tag 2"})
 	c.Assert(err, jc.ErrorIsNil)
 
 	ctx := setupMetadata(c)
-	err = r.Run(ctx)
+	err = s.command.Run(ctx)
 	c.Assert(err, gc.ErrorMatches, "boo")
 }
 
-func (registerSuite) TestRunFlushErr(c *gc.C) {
-	f := &stubRegisterContext{flusherr: errors.Errorf("boo")}
-	r := RegisterCmd{hctx: f}
-	err := r.Init([]string{"type", "class", "id", "tag1", "tag 2"})
+func (s registerSuite) TestRunFlushErr(c *gc.C) {
+	s.hookCtx.flusherr = errors.Errorf("boo")
+	err := s.command.Init([]string{"type", "class", "id", "tag1", "tag 2"})
 	c.Assert(err, jc.ErrorIsNil)
 
 	ctx := setupMetadata(c)
-	err = r.Run(ctx)
+	err = s.command.Run(ctx)
 	c.Assert(err, gc.ErrorMatches, "boo")
 }
 

--- a/payload/context/register_test.go
+++ b/payload/context/register_test.go
@@ -115,7 +115,7 @@ func (s *registerSuite) TestRunTrackErr(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, "boo")
 }
 
-func (s registerSuite) TestRunFlushErr(c *gc.C) {
+func (s *registerSuite) TestRunFlushErr(c *gc.C) {
 	s.hookCtx.flusherr = errors.Errorf("boo")
 	err := s.command.Init([]string{"type", "class", "id", "tag1", "tag 2"})
 	c.Assert(err, jc.ErrorIsNil)

--- a/payload/context/status-set.go
+++ b/payload/context/status-set.go
@@ -15,22 +15,17 @@ const StatusSetCmdName = "payload-status-set"
 
 // NewStatusSetCmd returns a new StatusSetCmd that wraps the given context.
 func NewStatusSetCmd(ctx HookContext) (*StatusSetCmd, error) {
-	compCtx, err := ContextComponent(ctx)
-	if err != nil {
-		// The component wasn't tracked properly.
-		return nil, errors.Trace(err)
-	}
-	return &StatusSetCmd{hctx: compCtx}, nil
+	return &StatusSetCmd{hookContextFunc: componentHookContext(ctx)}, nil
 }
 
 // StatusSetCmd is a command that registers a payload with juju.
 type StatusSetCmd struct {
 	cmd.CommandBase
 
-	hctx   Component
-	class  string
-	id     string
-	status string
+	hookContextFunc func() (Component, error)
+	class           string
+	id              string
+	status          string
 }
 
 // Info implements cmd.Command.
@@ -64,16 +59,20 @@ func (c *StatusSetCmd) Run(ctx *cmd.Context) error {
 	if err := c.validate(ctx); err != nil {
 		return errors.Trace(err)
 	}
+	hctx, err := c.hookContextFunc()
+	if err != nil {
+		return errors.Trace(err)
+	}
 
-	if err := c.hctx.SetStatus(c.class, c.id, c.status); err != nil {
+	if err := hctx.SetStatus(c.class, c.id, c.status); err != nil {
 		return errors.Trace(err)
 	}
 
 	// TODO(ericsnow) Is the flush really necessary?
 
-	// We flush to state immedeiately so that status reflects the
+	// We flush to state immediately so that status reflects the
 	// payload correctly.
-	if err := c.hctx.Flush(); err != nil {
+	if err := hctx.Flush(); err != nil {
 		return errors.Trace(err)
 	}
 

--- a/payload/context/utils.go
+++ b/payload/context/utils.go
@@ -12,6 +12,19 @@ import (
 	"gopkg.in/juju/charm.v6-unstable"
 )
 
+type componentHookFunction func() (Component, error)
+
+func componentHookContext(ctx HookContext) componentHookFunction {
+	return func() (Component, error) {
+		compCtx, err := ContextComponent(ctx)
+		if err != nil {
+			// The component wasn't tracked properly.
+			return nil, errors.Trace(err)
+		}
+		return compCtx, nil
+	}
+}
+
 func readMetadata(ctx *cmd.Context) (*charm.Meta, error) {
 	filename := filepath.Join(ctx.Dir, "metadata.yaml")
 	file, err := os.Open(filename)


### PR DESCRIPTION
## Description of change

'juju help-tool' did not contain payload hook tools.
Payload hook tool commands are the only ones in juju codebase that required a valid hook context in the constructors. This approach, whilst commendable, does not work for help-tool command which uses mock dummy hook context to get help information from all commands it can see.

In fact, valid hook context is only important at the time when it is used, in the command's Run method. Majority of this PR changes payload hook commands to not error at construction time. 

Also, since payload hook tools are implemented under component architecture, these hook tools needed to be explicitly registered to be in collection of all hook tools.

Added unit test to ensure that component based hook tools are displayed as part of help-tool output. 

## QA steps

Output of 'juju help-tool' should contain:

payload-register         register a charm payload with juju
payload-status-set       update the status of a payload
payload-unregister       stop tracking a payload
 

## Documentation changes

If output of 'juju help-tool' is shown in online documentation, it may need to be adjusted.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1628919
