### PR TITLE
acceptancetests: Improved version check for model migration tests.

### DIFF
--- a/acceptancetests/assess_model_migration.py
+++ b/acceptancetests/assess_model_migration.py
@@ -22,6 +22,7 @@ from deploy_stack import (
     BootstrapManager,
     get_random_string
     )
+from jujupy.client import get_stripped_version_number
 from jujupy.version_client import ModelClient2_0
 from jujucharm import local_charm_path
 from remote import remote_from_address
@@ -98,6 +99,7 @@ def client_is_at_least_2_1(client):
 def after_22beta4(client_version):
     # LooseVersion considers 2.2-somealpha to be newer than 2.2.0.
     # Attempt strict versioning first.
+    client_version = get_stripped_version_number(client_version)
     try:
         return StrictVersion(client_version) >= StrictVersion('2.2.0')
     except ValueError:

--- a/acceptancetests/jujupy/client.py
+++ b/acceptancetests/jujupy/client.py
@@ -1559,6 +1559,16 @@ class CommandComplete(BaseCondition):
                 ' '.join(self.command_time.full_args)))
 
 
+def get_stripped_version_number(version_string):
+    # strip the series and arch from the built version.
+    version_parts = version_string.split('-')
+    if len(version_parts) == 4:
+        version_number = '-'.join(version_parts[0:2])
+    else:
+        version_number = version_parts[0]
+    return version_number
+
+
 class ModelClient:
     """Wraps calls to a juju instance, associated with a single model.
 
@@ -2681,12 +2691,7 @@ class ModelClient:
         condition.do_raise(self.model_name, status)
 
     def get_matching_agent_version(self, no_build=False):
-        # strip the series and srch from the built version.
-        version_parts = self.version.split('-')
-        if len(version_parts) == 4:
-            version_number = '-'.join(version_parts[0:2])
-        else:
-            version_number = version_parts[0]
+        version_number = get_stripped_version_number(self.version)
         if not no_build and self.env.local:
             version_number += '.1'
         return version_number

--- a/acceptancetests/tests/test_assess_model_migration.py
+++ b/acceptancetests/tests/test_assess_model_migration.py
@@ -91,12 +91,12 @@ class TestParseArgs(TestCase):
 class TestAfter22Beta4(TestCase):
 
     def test_returns_False_for_prev_final_releases(self):
-        self.assertFalse(amm.after_22beta4('2.1'))
+        self.assertFalse(amm.after_22beta4('2.1-xenial-amd64'))
 
     def test_returns_True_for_final_release(self):
-        self.assertTrue(amm.after_22beta4('2.2.0'))
-        self.assertTrue(amm.after_22beta4('2.2'))
-        self.assertTrue(amm.after_22beta4('2.2.1'))
+        self.assertTrue(amm.after_22beta4('2.2.0-xenial-amd64'))
+        self.assertTrue(amm.after_22beta4('2.2-xenial-amd64'))
+        self.assertTrue(amm.after_22beta4('2.2.1-xenial-amd64'))
 
     def test_returns_True_when_newer(self):
         self.assertTrue(amm.after_22beta4('2.2-beta8-xenial-amd64'))


### PR DESCRIPTION
Now the version check actually considers the -\<series\>-\<arch\> part of the version string. Previously this was causing confusion in the version check.