### PR TITLE
follow on to printing config options

### DIFF
--- a/cmd/juju/cloud/show.go
+++ b/cmd/juju/cloud/show.go
@@ -119,11 +119,6 @@ type cloudDetails struct {
 	RegionConfig jujucloud.RegionConfig   `yaml:"region-config,omitempty" json:"region-config,omitempty"`
 }
 
-type cloudConfig struct {
-	Type        string `yaml:"type,omitempty" json:"type,omitempty"`
-	Description string `yaml:"description,omitempty" json:"description,omitempty"`
-}
-
 func makeCloudDetails(cloud jujucloud.Cloud) *cloudDetails {
 	result := &cloudDetails{
 		Source:           "public",
@@ -177,7 +172,7 @@ func getCloudConfigDetails(cloudType string) map[string]interface{} {
 		if providerSchema[attr].Secret {
 			continue
 		}
-		specifics[attr] = cloudConfig{
+		specifics[attr] = common.PrintConfigSchema{
 			Description: providerSchema[attr].Description,
 			Type:        fmt.Sprintf("%s", providerSchema[attr].Type),
 		}

--- a/cmd/juju/commands/bootstrap.go
+++ b/cmd/juju/commands/bootstrap.go
@@ -75,6 +75,10 @@ algorithm by assigning a "placement directive" via the '--to' option. This
 dictates what machine to use for the controller. This would typically be
 used with the MAAS provider ('--to <host>.maas').
 
+Available keys for use with --config can be found here:
+    https://jujucharms.com/docs/stable/controllers-config
+    https://jujucharms.com/docs/stable/models-config
+
 You can change the default timeout and retry delays used during the
 bootstrap by changing the following settings in your configuration
 (all values represent number of seconds):
@@ -107,7 +111,10 @@ Examples:
 See also:
     add-credentials
     add-model
-    set-constraints`
+    controller-config
+    model-config
+    set-constraints
+    show-cloud`
 
 // defaultHostedModelName is the name of the hosted model created in each
 // controller for deploying workloads to, in addition to the "controller" model.

--- a/cmd/juju/common/cloud.go
+++ b/cmd/juju/common/cloud.go
@@ -151,3 +151,9 @@ func ProviderConfigSchemaSourceByType(cloudType string) (config.ConfigSchemaSour
 	}
 	return nil, errors.NotImplementedf("config.ConfigSource")
 }
+
+// PrintConfigSchema is used to print model configuration schema.
+type PrintConfigSchema struct {
+	Type        string `yaml:"type,omitempty" json:"type,omitempty"`
+	Description string `yaml:"description,omitempty" json:"description,omitempty"`
+}

--- a/cmd/juju/controller/getconfig.go
+++ b/cmd/juju/controller/getconfig.go
@@ -36,6 +36,10 @@ const getControllerHelpDoc = `
 By default, all configuration (keys and values) for the controller are
 displayed if a key is not specified.
 
+The controller configuration is set during bootstrap, available keys
+and values can be found here:
+  https://jujucharms.com/docs/stable/controllers-config
+
 Examples:
 
     juju controller-config
@@ -44,6 +48,8 @@ Examples:
 
 See also:
     controllers
+    model-config
+    show-cloud
 `
 
 func (c *getConfigCommand) Info() *cmd.Info {


### PR DESCRIPTION
Adding configuration key output to model-config --help.
Adding configuration reference doc link to controller-config --help.
Move cloudConfig structure to juju/cmd/common and rename
PrintConfigSchema.

## Please provide the following details to expedite Pull Request review:

----

## Description of change

Help clarify what configuration options are available to use for bootstrap.

## QA steps

$ juju help controller-config
$ juju help model-config
$ juju help bootstrap

## Documentation changes

N/A

## Bug reference

N/A