### PR TITLE
Model config to control the update-status hook interval

### DIFF
--- a/api/common/modelwatcher.go
+++ b/api/common/modelwatcher.go
@@ -4,6 +4,8 @@
 package common
 
 import (
+	"time"
+
 	"github.com/juju/juju/api/base"
 	apiwatcher "github.com/juju/juju/api/watcher"
 	"github.com/juju/juju/apiserver/params"
@@ -67,4 +69,15 @@ func (e *ModelWatcher) LogForwardConfig() (*syslog.RawConfig, bool, error) {
 	}
 	cfg, ok := modelConfig.LogFwdSyslog()
 	return cfg, ok, nil
+}
+
+// UpdateStatusHookInterval returns the current update status hook interval.
+func (e *ModelWatcher) UpdateStatusHookInterval() (time.Duration, error) {
+	// TODO(wallyworld) - lp:1602237 - this needs to have it's own backend implementation.
+	// For now, we'll piggyback off the ModelConfig API.
+	modelConfig, err := e.ModelConfig()
+	if err != nil {
+		return 0, err
+	}
+	return modelConfig.UpdateStatusHookInterval(), nil
 }

--- a/api/watcher/watcher.go
+++ b/api/watcher/watcher.go
@@ -13,6 +13,7 @@ import (
 	"github.com/juju/juju/api/base"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/core/migration"
+	"github.com/juju/juju/rpc"
 	"github.com/juju/juju/watcher"
 	"github.com/juju/juju/worker"
 )
@@ -85,7 +86,7 @@ func (w *commonWatcher) commonLoop() {
 		<-w.tomb.Dying()
 		if err := w.call("Stop", nil); err != nil {
 			// Don't log an error if a watcher is stopped due to an agent restart.
-			if err.Error() != worker.ErrRestartAgent.Error() {
+			if err.Error() != worker.ErrRestartAgent.Error() && err.Error() != rpc.ErrShutdown.Error() {
 				logger.Errorf("error trying to stop watcher: %v", err)
 			}
 		}

--- a/environs/config/config.go
+++ b/environs/config/config.go
@@ -975,8 +975,16 @@ func (c *Config) MaxStatusHistorySizeMB() uint {
 // UpdateStatusHookInterval is how often to run the charm
 // update-status hook.
 func (c *Config) UpdateStatusHookInterval() time.Duration {
+	// TODO(wallyworld) - remove this work around when possible as
+	// we already have a defaulting mechanism for config.
+	// It's only here to guard against using Juju clients >= 2.2
+	// with Juju controllers running 2.1.x
+	raw := c.asString(UpdateStatusHookInterval)
+	if raw == "" {
+		raw = DefaultUpdateStatusHookInterval
+	}
 	// Value has already been validated.
-	val, _ := time.ParseDuration(c.mustString(UpdateStatusHookInterval))
+	val, _ := time.ParseDuration(raw)
 	return val
 }
 

--- a/environs/config/config.go
+++ b/environs/config/config.go
@@ -149,6 +149,9 @@ const (
 	// collection can grow to before it is pruned, eg "5M"
 	MaxStatusHistorySize = "max-status-history-size"
 
+	// UpdateStatusHookInterval is how often to run the update-status hook.
+	UpdateStatusHookInterval = "update-status-hook-interval"
+
 	//
 	// Deprecated Settings Attributes
 	//
@@ -303,6 +306,9 @@ const (
 
 	// DefaultStatusHistorySize is the default value for MaxStatusHistorySize.
 	DefaultStatusHistorySize = "5G"
+
+	// DefaultUpdateStatusHookInterval is the default value for UpdateStatusHookInterval
+	DefaultUpdateStatusHookInterval = "5m"
 )
 
 var defaultConfigValues = map[string]interface{}{
@@ -342,6 +348,7 @@ var defaultConfigValues = map[string]interface{}{
 	"development":              false,
 	"test-mode":                false,
 	TransmitVendorMetricsKey:   true,
+	UpdateStatusHookInterval:   DefaultUpdateStatusHookInterval,
 
 	// Image and agent streams and URLs.
 	"image-stream":       "released",
@@ -512,6 +519,19 @@ func Validate(cfg, old *Config) error {
 	if v, ok := cfg.defined[MaxStatusHistorySize].(string); ok {
 		if _, err := utils.ParseSize(v); err != nil {
 			return errors.Annotate(err, "invalid max status history size in model configuration")
+		}
+	}
+
+	if v, ok := cfg.defined[UpdateStatusHookInterval].(string); ok {
+		if f, err := time.ParseDuration(v); err != nil {
+			return errors.Annotate(err, "invalid update status hook interval in model configuration")
+		} else {
+			if f < 1*time.Minute {
+				return errors.Annotatef(err, "update status hook frequency %v cannot be less than 1m", f)
+			}
+			if f > 60*time.Minute {
+				return errors.Annotatef(err, "update status hook frequency %v cannot be greater than 60m", f)
+			}
 		}
 	}
 
@@ -952,6 +972,14 @@ func (c *Config) MaxStatusHistorySizeMB() uint {
 	return uint(val)
 }
 
+// UpdateStatusHookInterval is how often to run the charm
+// update-status hook.
+func (c *Config) UpdateStatusHookInterval() time.Duration {
+	// Value has already been validated.
+	val, _ := time.ParseDuration(c.mustString(UpdateStatusHookInterval))
+	return val
+}
+
 // UnknownAttrs returns a copy of the raw configuration attributes
 // that are supposedly specific to the environment type. They could
 // also be wrong attributes, though. Only the specific environment
@@ -1059,6 +1087,7 @@ var alwaysOptional = schema.Defaults{
 	NetBondReconfigureDelayKey:   schema.Omit,
 	MaxStatusHistoryAge:          schema.Omit,
 	MaxStatusHistorySize:         schema.Omit,
+	UpdateStatusHookInterval:     schema.Omit,
 }
 
 func allowEmpty(attr string) bool {
@@ -1437,6 +1466,11 @@ data of the store. (default false)`,
 	},
 	MaxStatusHistorySize: {
 		Description: "The maximum size for the status history collection, in human-readable memory format",
+		Type:        environschema.Tstring,
+		Group:       environschema.EnvironGroup,
+	},
+	UpdateStatusHookInterval: {
+		Description: "How often to run the charm update-status hook, in human-readable time format",
 		Type:        environschema.Tstring,
 		Group:       environschema.EnvironGroup,
 	},

--- a/environs/config/config_test.go
+++ b/environs/config/config_test.go
@@ -1121,6 +1121,18 @@ func (s *ConfigSuite) TestStatusHistoryConfigValues(c *gc.C) {
 	c.Assert(cfg.MaxStatusHistorySizeMB(), gc.Equals, uint(8192))
 }
 
+func (s *ConfigSuite) TestUpdateStatusHookIntervalConfigDefault(c *gc.C) {
+	cfg := newTestConfig(c, testing.Attrs{})
+	c.Assert(cfg.UpdateStatusHookInterval(), gc.Equals, 5*time.Minute)
+}
+
+func (s *ConfigSuite) TestUpdateStatusHookIntervalConfigValue(c *gc.C) {
+	cfg := newTestConfig(c, testing.Attrs{
+		"update-status-hook-interval": "30m",
+	})
+	c.Assert(cfg.UpdateStatusHookInterval(), gc.Equals, 30*time.Minute)
+}
+
 func (s *ConfigSuite) TestSchemaNoExtra(c *gc.C) {
 	schema, err := config.Schema(nil)
 	c.Assert(err, gc.IsNil)

--- a/state/upgrades_test.go
+++ b/state/upgrades_test.go
@@ -1055,6 +1055,59 @@ func (s *upgradesSuite) TestAddStatusHistoryPruneSettings(c *gc.C) {
 	)
 }
 
+func (s *upgradesSuite) TestAddUpdateStatusHookSettings(c *gc.C) {
+	settingsColl, settingsCloser := s.state.getRawCollection(settingsC)
+	defer settingsCloser()
+	_, err := settingsColl.RemoveAll(nil)
+	c.Assert(err, jc.ErrorIsNil)
+
+	m1 := s.makeModel(c, "m1", testing.Attrs{
+		"update-status-hook-interval": "20m",
+	})
+	defer m1.Close()
+
+	m2 := s.makeModel(c, "m2", testing.Attrs{})
+	defer m2.Close()
+
+	err = settingsColl.Insert(bson.M{
+		"_id": "someothersettingshouldnotbetouched",
+		// non-model setting: should not be touched
+		"settings": bson.M{"key": "value"},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	cfg1, err := m1.ModelConfig()
+	c.Assert(err, jc.ErrorIsNil)
+	expected1 := cfg1.AllAttrs()
+	expected1["resource-tags"] = ""
+
+	cfg2, err := m2.ModelConfig()
+	c.Assert(err, jc.ErrorIsNil)
+	expected2 := cfg2.AllAttrs()
+	expected2["update-status-hook-interval"] = "5m"
+	expected2["resource-tags"] = ""
+
+	expectedSettings := bsonMById{
+		{
+			"_id":        m1.ModelUUID() + ":e",
+			"settings":   bson.M(expected1),
+			"model-uuid": m1.ModelUUID(),
+		}, {
+			"_id":        m2.ModelUUID() + ":e",
+			"settings":   bson.M(expected2),
+			"model-uuid": m2.ModelUUID(),
+		}, {
+			"_id":      "someothersettingshouldnotbetouched",
+			"settings": bson.M{"key": "value"},
+		},
+	}
+	sort.Sort(expectedSettings)
+
+	s.assertUpgradedData(c, AddUpdateStatusHookSettings,
+		expectUpgradedData{settingsColl, expectedSettings},
+	)
+}
+
 func (s *upgradesSuite) TestAddStorageInstanceConstraints(c *gc.C) {
 	storageInstancesColl, storageInstancesCloser := s.state.getRawCollection(storageInstancesC)
 	defer storageInstancesCloser()

--- a/upgrades/backend.go
+++ b/upgrades/backend.go
@@ -30,6 +30,7 @@ type StateBackend interface {
 	AddStatusHistoryPruneSettings() error
 	AddStorageInstanceConstraints() error
 	SplitLogCollections() error
+	AddUpdateStatusHookSettings() error
 }
 
 // Model is an interface providing access to the details of a model within the
@@ -102,6 +103,10 @@ func (s stateBackend) AddControllerLogCollectionsSizeSettings() error {
 
 func (s stateBackend) AddStatusHistoryPruneSettings() error {
 	return state.AddStatusHistoryPruneSettings(s.st)
+}
+
+func (s stateBackend) AddUpdateStatusHookSettings() error {
+	return state.AddUpdateStatusHookSettings(s.st)
 }
 
 func (s stateBackend) AddStorageInstanceConstraints() error {

--- a/upgrades/operations.go
+++ b/upgrades/operations.go
@@ -22,6 +22,7 @@ var stateUpgradeOperations = func() []Operation {
 		upgradeToVersion{version.MustParse("2.0.0"), stateStepsFor20()},
 		upgradeToVersion{version.MustParse("2.1.0"), stateStepsFor21()},
 		upgradeToVersion{version.MustParse("2.2.0"), stateStepsFor22()},
+		upgradeToVersion{version.MustParse("2.2.1"), stateStepsFor221()},
 	}
 	return steps
 }

--- a/upgrades/steps_221.go
+++ b/upgrades/steps_221.go
@@ -1,0 +1,17 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package upgrades
+
+// stateStepsFor221 returns upgrade steps for Juju 2.2.1 that manipulate state directly.
+func stateStepsFor221() []Step {
+	return []Step{
+		&upgradeStep{
+			description: "add update-status hook config settings",
+			targets:     []Target{DatabaseMaster},
+			run: func(context Context) error {
+				return context.State().AddUpdateStatusHookSettings()
+			},
+		},
+	}
+}

--- a/upgrades/steps_221_test.go
+++ b/upgrades/steps_221_test.go
@@ -1,0 +1,27 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package upgrades_test
+
+import (
+	jc "github.com/juju/testing/checkers"
+	"github.com/juju/version"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/testing"
+	"github.com/juju/juju/upgrades"
+)
+
+var v221 = version.MustParse("2.2.1")
+
+type steps221Suite struct {
+	testing.BaseSuite
+}
+
+var _ = gc.Suite(&steps221Suite{})
+
+func (s *steps221Suite) TestUpdateStatusHistoryHookSettings(c *gc.C) {
+	step := findStateStep(c, v221, "add update-status hook config settings")
+	// Logic for step itself is tested in state package.
+	c.Assert(step.Targets(), jc.DeepEquals, []upgrades.Target{upgrades.DatabaseMaster})
+}

--- a/upgrades/upgrade_test.go
+++ b/upgrades/upgrade_test.go
@@ -720,6 +720,7 @@ func (s *upgradeSuite) TestStateUpgradeOperationsVersions(c *gc.C) {
 		"2.0.0",
 		"2.1.0",
 		"2.2.0",
+		"2.2.1",
 	})
 }
 

--- a/worker/uniter/remotestate/mock_test.go
+++ b/worker/uniter/remotestate/mock_test.go
@@ -5,6 +5,7 @@ package remotestate_test
 
 import (
 	"sync"
+	"time"
 
 	"gopkg.in/juju/charm.v6-unstable"
 	"gopkg.in/juju/names.v2"
@@ -179,6 +180,10 @@ func (st *mockState) WatchStorageAttachment(
 		return nil, &params.Error{Code: params.CodeNotFound}
 	}
 	return watcher, nil
+}
+
+func (st *mockState) UpdateStatusHookInterval() (time.Duration, error) {
+	return 5 * time.Minute, nil
 }
 
 type mockUnit struct {

--- a/worker/uniter/remotestate/state.go
+++ b/worker/uniter/remotestate/state.go
@@ -4,6 +4,8 @@
 package remotestate
 
 import (
+	"time"
+
 	"gopkg.in/juju/charm.v6-unstable"
 	"gopkg.in/juju/names.v2"
 
@@ -12,6 +14,8 @@ import (
 	"github.com/juju/juju/watcher"
 )
 
+type UpdateStatusTimerFunc func(time.Duration) func() <-chan time.Time
+
 type State interface {
 	Relation(names.RelationTag) (Relation, error)
 	StorageAttachment(names.StorageTag, names.UnitTag) (params.StorageAttachment, error)
@@ -19,6 +23,7 @@ type State interface {
 	Unit(names.UnitTag) (Unit, error)
 	WatchRelationUnits(names.RelationTag, names.UnitTag) (watcher.RelationUnitsWatcher, error)
 	WatchStorageAttachment(names.StorageTag, names.UnitTag) (watcher.NotifyWatcher, error)
+	UpdateStatusHookInterval() (time.Duration, error)
 }
 
 type Unit interface {

--- a/worker/uniter/remotestate/state.go
+++ b/worker/uniter/remotestate/state.go
@@ -14,7 +14,11 @@ import (
 	"github.com/juju/juju/watcher"
 )
 
-type UpdateStatusTimerFunc func(time.Duration) func() <-chan time.Time
+type Waiter interface {
+	After() <-chan time.Time
+}
+
+type UpdateStatusTimerFunc func(time.Duration) Waiter
 
 type State interface {
 	Relation(names.RelationTag) (Relation, error)

--- a/worker/uniter/remotestate/watcher.go
+++ b/worker/uniter/remotestate/watcher.go
@@ -418,7 +418,7 @@ func (w *RemoteStateWatcher) loop(unitTag names.UnitTag) (err error) {
 				return errors.Trace(err)
 			}
 
-		case <-w.updateStatusChannel(updateStatusInterval)():
+		case <-w.updateStatusChannel(updateStatusInterval).After():
 			logger.Debugf("update status timer triggered")
 			if err := w.updateStatusChanged(); err != nil {
 				return errors.Trace(err)

--- a/worker/uniter/remotestate/watcher_test.go
+++ b/worker/uniter/remotestate/watcher_test.go
@@ -67,8 +67,8 @@ func (s *WatcherSuite) SetUpTest(c *gc.C) {
 	}
 
 	s.clock = testing.NewClock(time.Now())
-	statusTicker := func() <-chan time.Time {
-		return s.clock.After(statusTickDuration)
+	statusTicker := func(wait time.Duration) remotestate.Waiter {
+		return dummyWaiter{s.clock.After(statusTickDuration)}
 	}
 
 	w, err := remotestate.NewWatcher(remotestate.WatcherConfig{
@@ -79,6 +79,14 @@ func (s *WatcherSuite) SetUpTest(c *gc.C) {
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	s.watcher = w
+}
+
+type dummyWaiter struct {
+	c <-chan time.Time
+}
+
+func (w dummyWaiter) After() <-chan time.Time {
+	return w.c
 }
 
 func (s *WatcherSuite) TearDownTest(c *gc.C) {

--- a/worker/uniter/timer.go
+++ b/worker/uniter/timer.go
@@ -4,21 +4,26 @@
 package uniter
 
 import (
+	"math/rand"
 	"time"
+
+	"github.com/juju/juju/worker/uniter/remotestate"
 )
 
-const (
-	// interval at which the unit's status should be polled
-	statusPollInterval = 5 * time.Minute
-)
+// NewUpdateStatusTimer returns a func returning timed signal suitable for update-status hook.
+func NewUpdateStatusTimer() remotestate.UpdateStatusTimerFunc {
+	r := rand.New(rand.NewSource(time.Now().Unix()))
+	return func(wait time.Duration) func() <-chan time.Time {
+		// Actual time to wait is randomised to be +/-20%
+		// of the nominal value.
+		lower := 0.8 * float64(wait)
+		window := 0.4 * float64(wait)
+		offset := float64(r.Int63n(int64(window)))
+		wait = time.Duration(lower + offset)
 
-// updateStatusSignal returns a time channel that fires after a given interval.
-func updateStatusSignal() <-chan time.Time {
-	// TODO(fwereade): 2016-03-17 lp:1558657
-	return time.After(statusPollInterval)
-}
-
-// NewUpdateStatusTimer returns a timed signal suitable for update-status hook.
-func NewUpdateStatusTimer() func() <-chan time.Time {
-	return updateStatusSignal
+		return func() <-chan time.Time {
+			// TODO(fwereade): 2016-03-17 lp:1558657
+			return time.After(wait)
+		}
+	}
 }

--- a/worker/uniter/timer_test.go
+++ b/worker/uniter/timer_test.go
@@ -1,0 +1,30 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package uniter_test
+
+import (
+	"time"
+
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/worker/uniter"
+)
+
+type timerSuite struct{}
+
+var _ = gc.Suite(&timerSuite{})
+
+func (s *timerSuite) TestTimer(c *gc.C) {
+	nominal := 100 * time.Second
+	min := 80*time.Second - time.Millisecond
+	max := 120*time.Second + time.Millisecond
+
+	timer := uniter.NewUpdateStatusTimer()
+	for i := 0; i < 100; i++ {
+		wait := timer(nominal)
+		c.Assert(min, jc.LessThan, wait)
+		c.Assert(wait, jc.LessThan, max)
+	}
+}

--- a/worker/uniter/timer_test.go
+++ b/worker/uniter/timer_test.go
@@ -4,6 +4,7 @@
 package uniter_test
 
 import (
+	"reflect"
 	"time"
 
 	jc "github.com/juju/testing/checkers"
@@ -18,13 +19,49 @@ var _ = gc.Suite(&timerSuite{})
 
 func (s *timerSuite) TestTimer(c *gc.C) {
 	nominal := 100 * time.Second
-	min := 80*time.Second - time.Millisecond
-	max := 120*time.Second + time.Millisecond
+	minTime := 80*time.Second - time.Millisecond
+	maxTime := 120*time.Second + time.Millisecond
 
 	timer := uniter.NewUpdateStatusTimer()
-	for i := 0; i < 100; i++ {
+	var lastTime time.Duration
+	var measuredMinTime time.Duration
+	var measuredMaxTime time.Duration
+
+	for i := 0; i < 1000; i++ {
 		wait := timer(nominal)
-		c.Assert(min, jc.LessThan, wait)
-		c.Assert(wait, jc.LessThan, max)
+		waitDuration := time.Duration(reflect.ValueOf(wait).Int())
+		// We use Assert rather than Check because we don't want 100s of failures
+		c.Assert(wait, jc.GreaterThan, minTime)
+		c.Assert(wait, jc.LessThan, maxTime)
+		if lastTime == 0 {
+			measuredMinTime = waitDuration
+			measuredMaxTime = waitDuration
+		} else {
+			// We are using a range in 100s of milliseconds at a
+			// resolution of nanoseconds. The chance of getting the
+			// same random value 2x in a row is sufficiently low that
+			// we can just assert the value is changing.
+			// (Chance of collision is roughly 1 in 100 Million)
+			c.Assert(wait, gc.Not(gc.Equals), lastTime)
+			if waitDuration < measuredMinTime {
+				measuredMinTime = waitDuration
+			}
+			if waitDuration > measuredMaxTime {
+				measuredMaxTime = waitDuration
+			}
+		}
+		lastTime = waitDuration
 	}
+	// Check that we're actually using the full range that was requested.
+	// Assert that after 1000 tries we've used a good portion of the range
+	// If we sampled perfectly, then we would have fully sampled the range,
+	// spread very 1/1000 of the range.
+	// If we set the required range to 1/100, then a given sample would fail 99%
+	// of the time, 1000 samples would fail 0.99^1000=4e-5 or ~1-in-20,000 times.
+	// (actual measurements showed 18 in 20,000, probably due to double ended range vs single ended)
+	// However, at 1/10 its 0.9^1000=1.7e-46, or 10^41 times less likely to fail.
+	// In 100,000 runs, a range of 1/10 never failed
+	expectedCloseness := (maxTime - minTime) / 10
+	c.Check(measuredMinTime, jc.LessThan, minTime+expectedCloseness)
+	c.Check(measuredMaxTime, jc.GreaterThan, maxTime-expectedCloseness)
 }

--- a/worker/uniter/uniter.go
+++ b/worker/uniter/uniter.go
@@ -93,7 +93,7 @@ type Uniter struct {
 
 	// updateStatusAt defines a function that will be used to generate signals for
 	// the update-status hook
-	updateStatusAt func() <-chan time.Time
+	updateStatusAt remotestate.UpdateStatusTimerFunc
 
 	// hookRetryStrategy represents configuration for hook retries
 	hookRetryStrategy params.RetryStrategy
@@ -112,7 +112,7 @@ type UniterParams struct {
 	Downloader           charm.Downloader
 	MachineLockName      string
 	CharmDirGuard        fortress.Guard
-	UpdateStatusSignal   func() <-chan time.Time
+	UpdateStatusSignal   remotestate.UpdateStatusTimerFunc
 	HookRetryStrategy    params.RetryStrategy
 	NewOperationExecutor NewExecutorFunc
 	TranslateResolverErr func(error) error

--- a/worker/uniter/util_test.go
+++ b/worker/uniter/util_test.go
@@ -48,6 +48,7 @@ import (
 	"github.com/juju/juju/worker/fortress"
 	"github.com/juju/juju/worker/uniter"
 	"github.com/juju/juju/worker/uniter/operation"
+	"github.com/juju/juju/worker/uniter/remotestate"
 )
 
 // worstCase is used for timeouts when timing out
@@ -510,7 +511,7 @@ func (s startUniter) step(c *gc.C, ctx *context) {
 		DataDir:              ctx.dataDir,
 		Downloader:           downloader,
 		MachineLockName:      hookExecutionLockName(),
-		UpdateStatusSignal:   ctx.updateStatusHookTicker.ReturnTimer,
+		UpdateStatusSignal:   ctx.updateStatusHookTicker.ReturnTimer(),
 		NewOperationExecutor: operationExecutor,
 		TranslateResolverErr: s.translateResolverErr,
 		Observer:             ctx,
@@ -1806,9 +1807,19 @@ func (t *manualTicker) Tick() error {
 	return nil
 }
 
+type dummyWaiter struct {
+	c chan time.Time
+}
+
+func (w dummyWaiter) After() <-chan time.Time {
+	return w.c
+}
+
 // ReturnTimer can be used to replace the update status signal generator.
-func (t *manualTicker) ReturnTimer() <-chan time.Time {
-	return t.c
+func (t *manualTicker) ReturnTimer() remotestate.UpdateStatusTimerFunc {
+	return func(_ time.Duration) remotestate.Waiter {
+		return dummyWaiter{t.c}
+	}
 }
 
 func newManualTicker() *manualTicker {


### PR DESCRIPTION
## Description of change

Provide a model config attribute "update-status-hook-interval" which controls how often to run the update-status hook. Whatever value is provided has a random +/- 20% offset applied to avoid all hooks for all units firing art once.
This implementation doesn't yet  listen for changes in the model config value - whatever value is provided as bootstrap via --config is what's used.

## QA steps

juju bootstrap --debug
juju deploy mysql
juju debug-log

watch for update-status hooks firing at staggered but regular intervals

## Documentation changes

model config doc needs updating

## Bug reference

https://bugs.launchpad.net/juju/+bug/1697841
https://bugs.launchpad.net/juju/+bug/1698139
