### PR TITLE
model-config can read values from a file

### DIFF
--- a/cmd/juju/model/configcommand.go
+++ b/cmd/juju/model/configcommand.go
@@ -5,16 +5,17 @@ package model
 import (
 	"bytes"
 	"io"
+	"os"
 	"sort"
 	"strings"
 
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
 	"github.com/juju/gnuflag"
-	"github.com/juju/utils/keyvalues"
 
 	"github.com/juju/juju/api/modelconfig"
 	"github.com/juju/juju/cmd/juju/block"
+	"github.com/juju/juju/cmd/juju/common"
 	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/cmd/output"
 	"github.com/juju/juju/environs/config"
@@ -28,12 +29,14 @@ are displayed.
 
 Supplying one key name returns only the value for the key. Supplying key=value
 will set the supplied key to the supplied value, this can be repeated for
-multiple keys.
+multiple keys. You can also specify a yaml file containing key values.
 
 Examples
     juju model-config default-series
     juju model-config -m mycontroller:mymodel
     juju model-config ftp-proxy=10.0.0.1:8000
+    juju model-config ftp-proxy=10.0.0.1:8000 path/to/file.yaml
+    juju model-config path/to/file.yaml
     juju model-config -m othercontroller:mymodel default-series=yakkety test-mode=false
     juju model-config --reset default-series test-mode
 
@@ -57,11 +60,11 @@ type configCommand struct {
 	modelcmd.ModelCommandBase
 	out cmd.Output
 
-	action    func(configCommandAPI, *cmd.Context) error // The action which we want to handle, set in cmd.Init.
-	keys      []string
-	reset     []string // Holds the keys to be reset until parsed.
-	resetKeys []string // Holds the keys to be reset once parsed.
-	values    attributes
+	action     func(configCommandAPI, *cmd.Context) error // The action which we want to handle, set in cmd.Init.
+	keys       []string
+	reset      []string // Holds the keys to be reset until parsed.
+	resetKeys  []string // Holds the keys to be reset once parsed.
+	setOptions common.ConfigFlag
 }
 
 // configCommandAPI defines an API interface to be used during testing.
@@ -127,7 +130,9 @@ func (c *configCommand) handleZeroArgs() error {
 
 // handleOneArg handles the case where there is one positional arg.
 func (c *configCommand) handleOneArg(arg string) error {
-	if strings.Contains(arg, "=") {
+	// We may have a single config.yaml file
+	_, err := os.Stat(arg)
+	if err == nil || strings.Contains(arg, "=") {
 		return c.parseSetKeys([]string{arg})
 	}
 	// If we are not setting a value, then we are retrieving one so we need to
@@ -144,12 +149,15 @@ func (c *configCommand) handleOneArg(arg string) error {
 
 // handleArgs handles the case where there's more than one positional arg.
 func (c *configCommand) handleArgs(args []string) error {
-	err := c.parseSetKeys(args)
-	if err != nil {
-		if !strings.Contains(strings.Join(args, " "), "=") {
+	if err := c.parseSetKeys(args); err != nil {
+		return errors.Trace(err)
+	}
+	for _, arg := range args {
+		// We may have a config.yaml file.
+		_, err := os.Stat(arg)
+		if err != nil && !strings.Contains(arg, "=") {
 			return errors.New("can only retrieve a single value, or all values")
 		}
-		return errors.Trace(err)
 	}
 	return nil
 }
@@ -157,25 +165,11 @@ func (c *configCommand) handleArgs(args []string) error {
 // parseSetKeys iterates over the args and make sure that the key=value pairs
 // are valid. It also checks that the same key isn't being reset.
 func (c *configCommand) parseSetKeys(args []string) error {
-	options, err := keyvalues.Parse(args, true)
-	if err != nil {
-		return errors.Trace(err)
-	}
-	c.values = make(attributes)
-	for k, v := range options {
-		if k == config.AgentVersionKey {
-			return errors.Errorf(`agent-version must be set via "upgrade-juju"`)
-		}
-		c.values[k] = v
-	}
-
-	for _, k := range c.resetKeys {
-		if _, ok := c.values[k]; ok {
-			return errors.Errorf(
-				"key %q cannot be both set and reset in the same command", k)
+	for _, arg := range args {
+		if err := c.setOptions.Set(arg); err != nil {
+			return errors.Trace(err)
 		}
 	}
-
 	c.action = c.setConfig
 	return nil
 }
@@ -247,7 +241,7 @@ func (c *configCommand) Run(ctx *cmd.Context) error {
 // reset unsets the keys provided to the command.
 func (c *configCommand) resetConfig(client configCommandAPI, ctx *cmd.Context) error {
 	// ctx unused in this method
-	if err := c.verifyKnownKeys(client); err != nil {
+	if err := c.verifyKnownKeys(client, c.resetKeys); err != nil {
 		return errors.Trace(err)
 	}
 
@@ -256,18 +250,31 @@ func (c *configCommand) resetConfig(client configCommandAPI, ctx *cmd.Context) e
 
 // set sets the provided key/value pairs on the model.
 func (c *configCommand) setConfig(client configCommandAPI, ctx *cmd.Context) error {
-	// ctx unused in this method.
-	envAttrs, err := client.ModelGet()
+	attrs, err := c.setOptions.ReadAttrs(ctx)
 	if err != nil {
-		return err
+		return errors.Trace(err)
 	}
-	for key := range c.values {
-		if _, exists := envAttrs[key]; !exists {
-			logger.Warningf("key %q is not defined in the current model configuration: possible misspelling", key)
+	var keys []string
+	values := make(attributes)
+	for k, v := range attrs {
+		if k == config.AgentVersionKey {
+			return errors.Errorf(`"agent-version"" must be set via "upgrade-juju"`)
 		}
-
+		values[k] = v
+		keys = append(keys, k)
 	}
-	return block.ProcessBlockedError(client.ModelSet(c.values), block.BlockChange)
+
+	for _, k := range c.resetKeys {
+		if _, ok := values[k]; ok {
+			return errors.Errorf(
+				"key %q cannot be both set and reset in the same command", k)
+		}
+	}
+
+	if err := c.verifyKnownKeys(client, keys); err != nil {
+		return errors.Trace(err)
+	}
+	return block.ProcessBlockedError(client.ModelSet(values), block.BlockChange)
 }
 
 // get writes the value of a single key or the full output for the model to the cmd.Context.
@@ -313,17 +320,13 @@ func (c *configCommand) getConfig(client configCommandAPI, ctx *cmd.Context) err
 
 // verifyKnownKeys is a helper to validate the keys we are operating with
 // against the set of known attributes from the model.
-func (c *configCommand) verifyKnownKeys(client configCommandAPI) error {
+func (c *configCommand) verifyKnownKeys(client configCommandAPI, keys []string) error {
 	known, err := client.ModelGet()
 	if err != nil {
 		return errors.Trace(err)
 	}
 
-	allKeys := c.resetKeys[:]
-	for k := range c.values {
-		allKeys = append(allKeys, k)
-	}
-
+	allKeys := keys[:]
 	for _, key := range allKeys {
 		// check if the key exists in the known config
 		// and warn the user if the key is not defined

--- a/cmd/juju/model/defaultscommand_test.go
+++ b/cmd/juju/model/defaultscommand_test.go
@@ -3,6 +3,8 @@
 package model_test
 
 import (
+	"io/ioutil"
+	"path/filepath"
 	"strings"
 
 	"github.com/juju/cmd"
@@ -44,10 +46,6 @@ func (s *DefaultsCommandSuite) TestDefaultsInit(c *gc.C) {
 		nilErr      bool
 	}{{
 		// Test set
-		description: "test set key specified more than once",
-		args:        []string{"special=extra", "special=other"},
-		errorMatch:  `key "special" specified more than once`,
-	}, {
 		description: "test cannot set agent-version",
 		args:        []string{"agent-version=2.0.0"},
 		errorMatch:  `"agent-version" must be set via "upgrade-juju"`,
@@ -194,7 +192,7 @@ func (s *DefaultsCommandSuite) TestDefaultsInit(c *gc.C) {
 	}, {
 		description: "test invalid positional args with set",
 		args:        []string{"a=b", "b", "c=d"},
-		errorMatch:  `expected "key=value", got "b"`,
+		errorMatch:  `.*no such file or directory`,
 	}, {
 		description: "test invalid positional args with set and trailing key",
 		args:        []string{"a=b", "c=d", "e"},
@@ -276,6 +274,48 @@ func (s *DefaultsCommandSuite) TestSetUnknownValueLogs(c *gc.C) {
 
 func (s *DefaultsCommandSuite) TestSet(c *gc.C) {
 	_, err := s.run(c, "special=extra", "attr=baz")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(s.fakeDefaultsAPI.defaults, jc.DeepEquals, config.ModelDefaultAttributes{
+		"attr": {Controller: "baz", Default: nil, Regions: nil},
+		"attr2": {Controller: "bar", Default: nil, Regions: []config.RegionDefaultValue{{
+			Name:  "dummy-region",
+			Value: "dummy-value",
+		}, {
+			Name:  "another-region",
+			Value: "another-value",
+		}}},
+		"special": {Controller: "extra", Default: nil, Regions: nil},
+	})
+}
+
+func (s *DefaultsCommandSuite) TestSetFromFile(c *gc.C) {
+	tmpdir := c.MkDir()
+	configFile := filepath.Join(tmpdir, "config.yaml")
+	err := ioutil.WriteFile(configFile, []byte("special: extra\n"), 0644)
+	c.Assert(err, jc.ErrorIsNil)
+
+	_, err = s.run(c, configFile)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(s.fakeDefaultsAPI.defaults, jc.DeepEquals, config.ModelDefaultAttributes{
+		"attr": {Controller: nil, Default: "foo", Regions: nil},
+		"attr2": {Controller: "bar", Default: nil, Regions: []config.RegionDefaultValue{{
+			Name:  "dummy-region",
+			Value: "dummy-value",
+		}, {
+			Name:  "another-region",
+			Value: "another-value",
+		}}},
+		"special": {Controller: "extra", Default: nil, Regions: nil},
+	})
+}
+
+func (s *DefaultsCommandSuite) TestSetFromFileCombined(c *gc.C) {
+	tmpdir := c.MkDir()
+	configFile := filepath.Join(tmpdir, "config.yaml")
+	err := ioutil.WriteFile(configFile, []byte("special: extra\n"), 0644)
+	c.Assert(err, jc.ErrorIsNil)
+
+	_, err = s.run(c, configFile, "attr=baz")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(s.fakeDefaultsAPI.defaults, jc.DeepEquals, config.ModelDefaultAttributes{
 		"attr": {Controller: "baz", Default: nil, Regions: nil},


### PR DESCRIPTION
## Description of change

model-config and model-defaults can now read values from a config.yaml file in addition to key=value args. Any grouping may be used, and last one wins. This is similar to how bootstrap works with its --config args except here there's no --config component. eg

$ juju model-config myconfig.yaml
$ juju model-config http-proxy=someproxy myconfig.yaml

## QA steps

juju bootstrap
create a config.yaml
juju model-config path/to/config.yaml 
etc

## Documentation changes

Doc for model-config and model-defaults commands needs updating.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1647758
