### PR TITLE
remote relations worker polls offer model

### DIFF
--- a/api/crossmodelrelations/crossmodelrelations.go
+++ b/api/crossmodelrelations/crossmodelrelations.go
@@ -7,7 +7,9 @@ import (
 	"github.com/juju/errors"
 
 	"github.com/juju/juju/api/base"
+	apiwatcher "github.com/juju/juju/api/watcher"
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/watcher"
 )
 
 // Client provides access to the crossmodelrelations api facade.
@@ -21,14 +23,14 @@ func NewClient(caller base.APICaller) *Client {
 	return &Client{facadeCaller}
 }
 
-// PublishLocalRelationChange publishes local relations changes to the
-// remote side offering those relations.
-func (c *Client) PublishLocalRelationChange(change params.RemoteRelationChangeEvent) error {
+// PublishRelationChange publishes relation changes to the
+// model hosting the remote application involved in the relation.
+func (c *Client) PublishRelationChange(change params.RemoteRelationChangeEvent) error {
 	args := params.RemoteRelationsChanges{
 		Changes: []params.RemoteRelationChangeEvent{change},
 	}
 	var results params.ErrorResults
-	err := c.facade.FacadeCall("PublishLocalRelationChange", args, &results)
+	err := c.facade.FacadeCall("PublishRelationChange", args, &results)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -42,7 +44,8 @@ func (c *Client) PublishLocalRelationChange(change params.RemoteRelationChangeEv
 	return nil
 }
 
-// RegisterRemoteRelations sets up the local model to participate in the specified relations.
+// RegisterRemoteRelation sets up the remote model to participate
+// in the specified relations.
 func (c *Client) RegisterRemoteRelations(relations ...params.RegisterRemoteRelation) ([]params.RemoteEntityIdResult, error) {
 	args := params.RegisterRemoteRelations{Relations: relations}
 	var results params.RemoteEntityIdResults
@@ -52,6 +55,40 @@ func (c *Client) RegisterRemoteRelations(relations ...params.RegisterRemoteRelat
 	}
 	if len(results.Results) != len(relations) {
 		return nil, errors.Errorf("expected %d result(s), got %d", len(relations), len(results.Results))
+	}
+	return results.Results, nil
+}
+
+// WatchRelationUnits returns a watcher that notifies of changes to the
+// units in the remote model for the relation with the given remote id.
+func (c *Client) WatchRelationUnits(remoteRelationId params.RemoteEntityId) (watcher.RelationUnitsWatcher, error) {
+	args := params.RemoteEntities{Entities: []params.RemoteEntityId{remoteRelationId}}
+	var results params.RelationUnitsWatchResults
+	err := c.facade.FacadeCall("WatchRelationUnits", args, &results)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	if len(results.Results) != 1 {
+		return nil, errors.Errorf("expected 1 result, got %d", len(results.Results))
+	}
+	result := results.Results[0]
+	if result.Error != nil {
+		return nil, result.Error
+	}
+	w := apiwatcher.NewRelationUnitsWatcher(c.facade.RawAPICaller(), result)
+	return w, nil
+}
+
+// RelationUnitSettings returns the relation unit settings for the given relation units in the remote model.
+func (c *Client) RelationUnitSettings(relationUnits []params.RemoteRelationUnit) ([]params.SettingsResult, error) {
+	args := params.RemoteRelationUnits{relationUnits}
+	var results params.SettingsResults
+	err := c.facade.FacadeCall("RelationUnitSettings", args, &results)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	if len(results.Results) != len(relationUnits) {
+		return nil, errors.Errorf("expected %d result(s), got %d", len(relationUnits), len(results.Results))
 	}
 	return results.Results, nil
 }

--- a/api/remoterelations/remoterelations.go
+++ b/api/remoterelations/remoterelations.go
@@ -242,3 +242,17 @@ func (c *Client) WatchRemoteRelations() (watcher.StringsWatcher, error) {
 	w := apiwatcher.NewStringsWatcher(c.facade.RawAPICaller(), result)
 	return w, nil
 }
+
+// ConsumeRemoteRelationChange consumes a change to settings originating
+// from the remote/offering side of a relation.
+func (c *Client) ConsumeRemoteRelationChange(change params.RemoteRelationChangeEvent) error {
+	args := params.RemoteRelationsChanges{
+		Changes: []params.RemoteRelationChangeEvent{change},
+	}
+	var results params.ErrorResults
+	err := c.facade.FacadeCall("ConsumeRemoteRelationChange", args, &results)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	return results.OneError()
+}

--- a/apiserver/admin_test.go
+++ b/apiserver/admin_test.go
@@ -559,6 +559,7 @@ func (s *loginSuite) TestAnonymousModelLogin(c *gc.C) {
 	c.Assert(result.ModelTag, gc.Equals, s.State.ModelTag().String())
 	c.Assert(result.Facades, jc.DeepEquals, []params.FacadeVersions{
 		{Name: "CrossModelRelations", Versions: []int{1}},
+		{Name: "RelationUnitsWatcher", Versions: []int{1}},
 	})
 }
 

--- a/apiserver/common/crossmodel/crossmodel.go
+++ b/apiserver/common/crossmodel/crossmodel.go
@@ -1,0 +1,184 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package crossmodel
+
+import (
+	"fmt"
+
+	"github.com/juju/errors"
+	"github.com/juju/loggo"
+	"gopkg.in/juju/names.v2"
+
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/state"
+)
+
+var logger = loggo.GetLogger("juju.apiserver.common.crossmodel")
+
+// PublishRelationChange applies the relation change event to the specified backend.
+func PublishRelationChange(backend Backend, change params.RemoteRelationChangeEvent) error {
+	logger.Debugf("publish into model %v change: %+v", backend.ModelUUID(), change)
+
+	relationTag, err := getRemoteEntityTag(backend, change.RelationId)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			logger.Debugf("not found relation tag %+v in model %v, exit early", change.RelationId, backend.ModelUUID())
+			return nil
+		}
+		return errors.Trace(err)
+	}
+	logger.Debugf("relation tag for remote id %+v is %v", change.RelationId, relationTag)
+
+	// Ensure the relation exists.
+	rel, err := backend.KeyRelation(relationTag.Id())
+	if errors.IsNotFound(err) {
+		if change.Life != params.Alive {
+			return nil
+		}
+	}
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	// Look up the application on the remote side of this relation
+	// ie from the model which published this change.
+	applicationTag, err := getRemoteEntityTag(backend, change.ApplicationId)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	logger.Debugf("application tag for remote id %+v is %v", change.ApplicationId, applicationTag)
+
+	// If the remote model has destroyed the relation, do it here also.
+	if change.Life != params.Alive {
+		logger.Debugf("remote side of %v died", relationTag)
+		if err := rel.Destroy(); err != nil {
+			return errors.Trace(err)
+		}
+		// See if we need to remove the remote application proxy - we do this
+		// on the offering side as there is 1:1 between proxy and consuming app.
+		if applicationTag != nil {
+			remoteApp, err := backend.RemoteApplication(applicationTag.Id())
+			if err != nil && !errors.IsNotFound(err) {
+				return errors.Trace(err)
+			}
+			if err == nil && remoteApp.IsConsumerProxy() {
+				logger.Debugf("destroy consuming app proxy for %v", applicationTag.Id())
+				if err := remoteApp.Destroy(); err != nil {
+					return errors.Trace(err)
+				}
+			}
+		}
+	}
+
+	// TODO(wallyworld) - deal with remote application being removed
+	if applicationTag == nil {
+		logger.Infof("no remote application found for %v", relationTag.Id())
+		return nil
+	}
+	logger.Debugf("remote applocation for changed relation %v is %v", relationTag.Id(), applicationTag.Id())
+
+	for _, id := range change.DepartedUnits {
+		unitTag := names.NewUnitTag(fmt.Sprintf("%s/%v", applicationTag.Id(), id))
+		logger.Debugf("unit %v has departed relation %v", unitTag.Id(), relationTag.Id())
+		ru, err := rel.RemoteUnit(unitTag.Id())
+		if err != nil {
+			return errors.Trace(err)
+		}
+		logger.Debugf("%s leaving scope", unitTag.Id())
+		if err := ru.LeaveScope(); err != nil {
+			return errors.Trace(err)
+		}
+	}
+
+	for _, change := range change.ChangedUnits {
+		unitTag := names.NewUnitTag(fmt.Sprintf("%s/%v", applicationTag.Id(), change.UnitId))
+		logger.Debugf("changed unit tag for remote id %v is %v", change.UnitId, unitTag)
+		ru, err := rel.RemoteUnit(unitTag.Id())
+		if err != nil {
+			return errors.Trace(err)
+		}
+		inScope, err := ru.InScope()
+		if err != nil {
+			return errors.Trace(err)
+		}
+		settings := make(map[string]interface{})
+		for k, v := range change.Settings {
+			settings[k] = v
+		}
+		if !inScope {
+			logger.Debugf("%s entering scope (%v)", unitTag.Id(), settings)
+			err = ru.EnterScope(settings)
+		} else {
+			logger.Debugf("%s updated settings (%v)", unitTag.Id(), settings)
+			err = ru.ReplaceSettings(settings)
+		}
+		if err != nil {
+			return errors.Trace(err)
+		}
+	}
+	return nil
+}
+
+func getRemoteEntityTag(backend Backend, id params.RemoteEntityId) (names.Tag, error) {
+	modelTag := names.NewModelTag(id.ModelUUID)
+	return backend.GetRemoteEntity(modelTag, id.Token)
+}
+
+// WatchRelationUnits returns a watcher for changes to the units on the specified relation.
+func WatchRelationUnits(backend Backend, tag names.RelationTag) (state.RelationUnitsWatcher, error) {
+	relation, err := backend.KeyRelation(tag.Id())
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	for _, ep := range relation.Endpoints() {
+		_, err := backend.Application(ep.ApplicationName)
+		if errors.IsNotFound(err) {
+			// Not found, so it's the remote application. Try the next endpoint.
+			continue
+		} else if err != nil {
+			return nil, errors.Trace(err)
+		}
+		w, err := relation.WatchUnits(ep.ApplicationName)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		return w, nil
+	}
+	return nil, errors.NotFoundf("local application for %s", names.ReadableString(tag))
+}
+
+// RelationUnitSettings returns the unit settings for the specified relation unit.
+func RelationUnitSettings(backend Backend, ru params.RelationUnit) (params.Settings, error) {
+	relationTag, err := names.ParseRelationTag(ru.Relation)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	rel, err := backend.KeyRelation(relationTag.Id())
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	unitTag, err := names.ParseUnitTag(ru.Unit)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	unit, err := rel.Unit(unitTag.Id())
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	settings, err := unit.Settings()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	paramsSettings := make(params.Settings)
+	for k, v := range settings {
+		vString, ok := v.(string)
+		if !ok {
+			return nil, errors.Errorf(
+				"invalid relation setting %q: expected string, got %T", k, v,
+			)
+		}
+		paramsSettings[k] = vString
+	}
+	return paramsSettings, nil
+}

--- a/apiserver/common/crossmodel/interface.go
+++ b/apiserver/common/crossmodel/interface.go
@@ -1,0 +1,157 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package crossmodel
+
+import (
+	"gopkg.in/juju/names.v2"
+	"gopkg.in/macaroon.v1"
+
+	"github.com/juju/juju/state"
+	"github.com/juju/juju/status"
+)
+
+type Backend interface {
+	// ModelUUID returns the model UUID for the model
+	// controlled by this state instance.
+	ModelUUID() string
+
+	// KeyRelation returns the existing relation with the given key (which can
+	// be derived unambiguously from the relation's endpoints).
+	KeyRelation(string) (Relation, error)
+
+	// Application returns a local application by name.
+	Application(string) (Application, error)
+
+	// RemoteApplication returns a remote application by name.
+	RemoteApplication(string) (RemoteApplication, error)
+
+	// AddRelation adds a relation between the specified endpoints and returns the relation info.
+	AddRelation(...state.Endpoint) (Relation, error)
+
+	// EndpointsRelation returns the existing relation with the given endpoints.
+	EndpointsRelation(...state.Endpoint) (Relation, error)
+
+	// AddRemoteApplication creates a new remote application record, having the supplied relation endpoints,
+	// with the supplied name (which must be unique across all applications, local and remote).
+	AddRemoteApplication(state.AddRemoteApplicationParams) (RemoteApplication, error)
+
+	// GetRemoteEntity returns the tag of the entity associated with the given
+	// token and model.
+	GetRemoteEntity(names.ModelTag, string) (names.Tag, error)
+
+	// ExportLocalEntity adds an entity to the remote entities collection,
+	// returning an opaque token that uniquely identifies the entity within
+	// the model.
+	ExportLocalEntity(names.Tag) (string, error)
+
+	// ImportRemoteEntity adds an entity to the remote entities collection
+	// with the specified opaque token.
+	ImportRemoteEntity(sourceModel names.ModelTag, entity names.Tag, token string) error
+}
+
+// Relation provides access a relation in global state.
+type Relation interface {
+	// Destroy ensures that the relation will be removed at some point; if
+	// no units are currently in scope, it will be removed immediately.
+	Destroy() error
+
+	// Id returns the integer internal relation key.
+	Id() int
+
+	// Life returns the relation's current life state.
+	Life() state.Life
+
+	// Tag returns the relation's tag.
+	Tag() names.Tag
+
+	// RemoteUnit returns a RelationUnit for the remote application unit
+	// with the supplied ID.
+	RemoteUnit(unitId string) (RelationUnit, error)
+
+	// Endpoints returns the endpoints that constitute the relation.
+	Endpoints() []state.Endpoint
+
+	// Unit returns a RelationUnit for the unit with the supplied ID.
+	Unit(unitId string) (RelationUnit, error)
+
+	// WatchUnits returns a watcher that notifies of changes to the units of the
+	// specified application in the relation.
+	WatchUnits(applicationName string) (state.RelationUnitsWatcher, error)
+}
+
+// RelationUnit provides access to the settings of a single unit in a relation,
+// and methods for modifying the unit's involvement in the relation.
+type RelationUnit interface {
+	// EnterScope ensures that the unit has entered its scope in the
+	// relation. When the unit has already entered its scope, EnterScope
+	// will report success but make no changes to state.
+	EnterScope(settings map[string]interface{}) error
+
+	// InScope returns whether the relation unit has entered scope and
+	// not left it.
+	InScope() (bool, error)
+
+	// LeaveScope signals that the unit has left its scope in the relation.
+	// After the unit has left its relation scope, it is no longer a member
+	// of the relation; if the relation is dying when its last member unit
+	// leaves, it is removed immediately. It is not an error to leave a
+	// scope that the unit is not, or never was, a member of.
+	LeaveScope() error
+
+	// Settings returns the relation unit's settings within the relation.
+	Settings() (map[string]interface{}, error)
+
+	// ReplaceSettings replaces the relation unit's settings within the
+	// relation.
+	ReplaceSettings(map[string]interface{}) error
+}
+
+// Application represents the state of a application hosted in the local model.
+type Application interface {
+	// Name is the name of the application.
+	Name() string
+
+	// Life returns the lifecycle state of the application.
+	Life() state.Life
+
+	// Endpoints returns the application's currently available relation endpoints.
+	Endpoints() ([]state.Endpoint, error)
+}
+
+// RemoteApplication represents the state of an application hosted in an external
+// (remote) model.
+type RemoteApplication interface {
+	// Destroy ensures that this remote application reference and all its relations
+	// will be removed at some point; if no relation involving the
+	// application has any units in scope, they are all removed immediately.
+	Destroy() error
+
+	// Name returns the name of the remote application.
+	Name() string
+
+	// Tag returns the remote applications's tag.
+	Tag() names.Tag
+
+	// URL returns the remote application URL, at which it is offered.
+	URL() (string, bool)
+
+	// OfferName returns the name the offering side has given to the remote application..
+	OfferName() string
+
+	// SourceModel returns the tag of the model hosting the remote application.
+	SourceModel() names.ModelTag
+
+	// Macaroon returns the macaroon used for authentication.
+	Macaroon() (*macaroon.Macaroon, error)
+
+	// Status returns the status of the remote application.
+	Status() (status.StatusInfo, error)
+
+	// IsConsumerProxy returns whether application is created
+	// from a registration operation by a consuming model.
+	IsConsumerProxy() bool
+
+	// Life returns the lifecycle state of the application.
+	Life() state.Life
+}

--- a/apiserver/common/crossmodel/state.go
+++ b/apiserver/common/crossmodel/state.go
@@ -1,0 +1,144 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package crossmodel
+
+import (
+	"github.com/juju/errors"
+	"gopkg.in/juju/names.v2"
+
+	"github.com/juju/juju/state"
+)
+
+// GetBackend wraps a State to provide a Backend interface implementation.
+func GetBackend(st *state.State) stateShim {
+	return stateShim{State: st}
+}
+
+type stateShim struct {
+	*state.State
+}
+
+func (st stateShim) KeyRelation(key string) (Relation, error) {
+	r, err := st.State.KeyRelation(key)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return relationShim{r, st.State}, nil
+}
+
+type applicationShim struct {
+	*state.Application
+}
+
+func (st stateShim) Application(name string) (Application, error) {
+	a, err := st.State.Application(name)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return applicationShim{a}, nil
+}
+
+type remoteApplicationShim struct {
+	*state.RemoteApplication
+}
+
+func (st stateShim) RemoteApplication(name string) (RemoteApplication, error) {
+	a, err := st.State.RemoteApplication(name)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return &remoteApplicationShim{a}, nil
+}
+
+func (st stateShim) AddRelation(eps ...state.Endpoint) (Relation, error) {
+	r, err := st.State.AddRelation(eps...)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return relationShim{r, st.State}, nil
+}
+
+func (st stateShim) EndpointsRelation(eps ...state.Endpoint) (Relation, error) {
+	r, err := st.State.EndpointsRelation(eps...)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return relationShim{r, st.State}, nil
+}
+
+func (st stateShim) AddRemoteApplication(args state.AddRemoteApplicationParams) (RemoteApplication, error) {
+	a, err := st.State.AddRemoteApplication(args)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return remoteApplicationShim{a}, nil
+}
+
+func (st stateShim) GetRemoteEntity(model names.ModelTag, token string) (names.Tag, error) {
+	r := st.State.RemoteEntities()
+	return r.GetRemoteEntity(model, token)
+}
+
+func (st stateShim) ExportLocalEntity(entity names.Tag) (string, error) {
+	r := st.State.RemoteEntities()
+	return r.ExportLocalEntity(entity)
+}
+
+func (st stateShim) ImportRemoteEntity(model names.ModelTag, entity names.Tag, token string) error {
+	r := st.State.RemoteEntities()
+	return r.ImportRemoteEntity(model, entity, token)
+}
+
+type relationShim struct {
+	*state.Relation
+	st *state.State
+}
+
+func (r relationShim) RemoteUnit(unitId string) (RelationUnit, error) {
+	ru, err := r.Relation.RemoteUnit(unitId)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return relationUnitShim{ru}, nil
+}
+
+func (r relationShim) Unit(unitId string) (RelationUnit, error) {
+	unit, err := r.st.Unit(unitId)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	ru, err := r.Relation.Unit(unit)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return relationUnitShim{ru}, nil
+}
+
+type relationUnitShim struct {
+	*state.RelationUnit
+}
+
+func (r relationUnitShim) Settings() (map[string]interface{}, error) {
+	settings, err := r.RelationUnit.Settings()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return settings.Map(), nil
+}
+
+func (r relationUnitShim) ReplaceSettings(s map[string]interface{}) error {
+	settings, err := r.RelationUnit.Settings()
+	if err != nil {
+		return errors.Trace(err)
+	}
+	settings.Update(s)
+	for _, key := range settings.Keys() {
+		if _, ok := s[key]; ok {
+			continue
+		}
+		settings.Delete(key)
+	}
+	_, err = settings.Write()
+	return errors.Trace(err)
+}

--- a/apiserver/crossmodelrelations/state.go
+++ b/apiserver/crossmodelrelations/state.go
@@ -4,9 +4,7 @@
 package crossmodelrelations
 
 import (
-	"github.com/juju/errors"
-	"gopkg.in/juju/names.v2"
-
+	common "github.com/juju/juju/apiserver/common/crossmodel"
 	"github.com/juju/juju/core/crossmodel"
 	"github.com/juju/juju/state"
 )
@@ -14,235 +12,18 @@ import (
 // RemoteRelationState provides the subset of global state required by the
 // remote relations facade.
 type CrossModelRelationsState interface {
-	// ModelUUID returns the model UUID for the model
-	// controlled by this state instance.
-	ModelUUID() string
-
-	// KeyRelation returns the existing relation with the given key (which can
-	// be derived unambiguously from the relation's endpoints).
-	KeyRelation(string) (Relation, error)
-
-	// AddRelation adds a relation between the specified endpoints and returns the relation info.
-	AddRelation(...state.Endpoint) (Relation, error)
-
-	// EndpointsRelation returns the existing relation with the given endpoints.
-	EndpointsRelation(...state.Endpoint) (Relation, error)
-
-	// AddRemoteApplication creates a new remote application record, having the supplied relation endpoints,
-	// with the supplied name (which must be unique across all applications, local and remote).
-	AddRemoteApplication(state.AddRemoteApplicationParams) (RemoteApplication, error)
-
-	// RemoteApplication returns a remote application by name.
-	RemoteApplication(string) (RemoteApplication, error)
-
-	// Application returns a local application by name.
-	Application(string) (Application, error)
-
-	// ExportLocalEntity adds an entity to the remote entities collection,
-	// returning an opaque token that uniquely identifies the entity within
-	// the model.
-	ExportLocalEntity(names.Tag) (string, error)
-
-	// GetRemoteEntity returns the tag of the entity associated with the given
-	// token and model.
-	GetRemoteEntity(names.ModelTag, string) (names.Tag, error)
-
-	// ImportRemoteEntity adds an entity to the remote entities collection
-	// with the specified opaque token.
-	ImportRemoteEntity(sourceModel names.ModelTag, entity names.Tag, token string) error
+	common.Backend
 
 	// ListOffers returns the application offers matching any one of the filter terms.
 	ListOffers(filter ...crossmodel.ApplicationOfferFilter) ([]crossmodel.ApplicationOffer, error)
 }
 
-// Relation provides access a relation in global state.
-type Relation interface {
-	// Destroy ensures that the relation will be removed at some point; if
-	// no units are currently in scope, it will be removed immediately.
-	Destroy() error
-
-	// Tag returns the relation's tag.
-	Tag() names.Tag
-
-	// Endpoints returns the endpoints that constitute the relation.
-	// RemoteUnit returns a RelationUnit for the remote application unit
-	// with the supplied ID.
-	RemoteUnit(unitId string) (RelationUnit, error)
-}
-
-// RelationUnit provides access to the settings of a single unit in a relation,
-// and methods for modifying the unit's involvement in the relation.
-type RelationUnit interface {
-	// EnterScope ensures that the unit has entered its scope in the
-	// relation. When the unit has already entered its scope, EnterScope
-	// will report success but make no changes to state.
-	EnterScope(settings map[string]interface{}) error
-
-	// InScope returns whether the relation unit has entered scope and
-	// not left it.
-	InScope() (bool, error)
-
-	// LeaveScope signals that the unit has left its scope in the relation.
-	// After the unit has left its relation scope, it is no longer a member
-	// of the relation; if the relation is dying when its last member unit
-	// leaves, it is removed immediately. It is not an error to leave a
-	// scope that the unit is not, or never was, a member of.
-	LeaveScope() error
-
-	// ReplaceSettings replaces the relation unit's settings within the
-	// relation.
-	ReplaceSettings(map[string]interface{}) error
-}
-
-// RemoteApplication represents the state of an application hosted in an external
-// (remote) model.
-type RemoteApplication interface {
-	// IsConsumerProxy returns whether application is created
-	// from a registration operation by a consuming model.
-	IsConsumerProxy() bool
-
-	// Destroy ensures that this remote application reference and all its relations
-	// will be removed at some point; if no relation involving the
-	// application has any units in scope, they are all removed immediately.
-	Destroy() error
-}
-
-// Application represents the state of a application hosted in the local model.
-type Application interface {
-	// Life returns the lifecycle state of the application.
-	Life() state.Life
-
-	// Endpoints returns the application's currently available relation endpoints.
-	Endpoints() ([]state.Endpoint, error)
-}
-
 type stateShim struct {
-	*state.State
-}
-
-func (st stateShim) ListOffers(filter ...crossmodel.ApplicationOfferFilter) ([]crossmodel.ApplicationOffer, error) {
-	oa := state.NewApplicationOffers(st.State)
-	return oa.ListOffers(filter...)
-}
-
-func (st stateShim) ExportLocalEntity(entity names.Tag) (string, error) {
-	r := st.State.RemoteEntities()
-	return r.ExportLocalEntity(entity)
-}
-
-func (st stateShim) GetRemoteEntity(model names.ModelTag, token string) (names.Tag, error) {
-	r := st.State.RemoteEntities()
-	return r.GetRemoteEntity(model, token)
-}
-
-func (st stateShim) ImportRemoteEntity(model names.ModelTag, entity names.Tag, token string) error {
-	r := st.State.RemoteEntities()
-	return r.ImportRemoteEntity(model, entity, token)
-}
-
-func (st stateShim) RemoveRemoteEntity(model names.ModelTag, entity names.Tag) error {
-	r := st.State.RemoteEntities()
-	return r.RemoveRemoteEntity(model, entity)
-}
-
-func (st stateShim) GetToken(model names.ModelTag, entity names.Tag) (string, error) {
-	r := st.State.RemoteEntities()
-	return r.GetToken(model, entity)
-}
-
-func (st stateShim) KeyRelation(key string) (Relation, error) {
-	r, err := st.State.KeyRelation(key)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	return relationShim{r, st.State}, nil
-}
-
-func (st stateShim) Relation(id int) (Relation, error) {
-	r, err := st.State.Relation(id)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	return relationShim{r, st.State}, nil
-}
-
-func (st stateShim) AddRelation(eps ...state.Endpoint) (Relation, error) {
-	r, err := st.State.AddRelation(eps...)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	return relationShim{r, st.State}, nil
-}
-
-func (st stateShim) EndpointsRelation(eps ...state.Endpoint) (Relation, error) {
-	r, err := st.State.EndpointsRelation(eps...)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	return relationShim{r, st.State}, nil
-}
-
-func (st stateShim) RemoteApplication(name string) (RemoteApplication, error) {
-	a, err := st.State.RemoteApplication(name)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	return &remoteApplicationShim{a}, nil
-}
-
-func (st stateShim) AddRemoteApplication(args state.AddRemoteApplicationParams) (RemoteApplication, error) {
-	a, err := st.State.AddRemoteApplication(args)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	return remoteApplicationShim{a}, nil
-}
-
-type relationShim struct {
-	*state.Relation
+	common.Backend
 	st *state.State
 }
 
-func (r relationShim) RemoteUnit(unitId string) (RelationUnit, error) {
-	ru, err := r.Relation.RemoteUnit(unitId)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	return relationUnitShim{ru}, nil
-}
-
-type relationUnitShim struct {
-	*state.RelationUnit
-}
-
-func (r relationUnitShim) ReplaceSettings(s map[string]interface{}) error {
-	settings, err := r.RelationUnit.Settings()
-	if err != nil {
-		return errors.Trace(err)
-	}
-	settings.Update(s)
-	for _, key := range settings.Keys() {
-		if _, ok := s[key]; ok {
-			continue
-		}
-		settings.Delete(key)
-	}
-	_, err = settings.Write()
-	return errors.Trace(err)
-}
-
-type remoteApplicationShim struct {
-	*state.RemoteApplication
-}
-
-type applicationShim struct {
-	*state.Application
-}
-
-func (st stateShim) Application(name string) (Application, error) {
-	a, err := st.State.Application(name)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	return applicationShim{a}, nil
+func (st stateShim) ListOffers(filter ...crossmodel.ApplicationOfferFilter) ([]crossmodel.ApplicationOffer, error) {
+	oa := state.NewApplicationOffers(st.st)
+	return oa.ListOffers(filter...)
 }

--- a/apiserver/params/crossmodel.go
+++ b/apiserver/params/crossmodel.go
@@ -408,6 +408,17 @@ type RemoteEntities struct {
 	Entities []RemoteEntityId `json:"remote-entities"`
 }
 
+// RelationUnit holds a remote relation id and a unit tag.
+type RemoteRelationUnit struct {
+	RelationId RemoteEntityId `json:"relation"`
+	Unit       string         `json:"unit"`
+}
+
+// RemoteRelationUnits identifies multiple remote relation units.
+type RemoteRelationUnits struct {
+	RelationUnits []RemoteRelationUnit `json:"relation-units"`
+}
+
 // ModifyModelAccessRequest holds the parameters for making grant and revoke offer calls.
 type ModifyOfferAccessRequest struct {
 	Changes []ModifyOfferAccess `json:"changes"`

--- a/apiserver/remoterelations/state.go
+++ b/apiserver/remoterelations/state.go
@@ -6,28 +6,15 @@ package remoterelations
 import (
 	"github.com/juju/errors"
 	"gopkg.in/juju/names.v2"
-	"gopkg.in/macaroon.v1"
 
+	common "github.com/juju/juju/apiserver/common/crossmodel"
 	"github.com/juju/juju/state"
-	"github.com/juju/juju/status"
 )
 
 // RemoteRelationState provides the subset of global state required by the
 // remote relations facade.
 type RemoteRelationsState interface {
-	// ModelUUID returns the model UUID for the model
-	// controlled by this state instance.
-	ModelUUID() string
-
-	// KeyRelation returns the existing relation with the given key (which can
-	// be derived unambiguously from the relation's endpoints).
-	KeyRelation(string) (Relation, error)
-
-	// RemoteApplication returns a remote application by name.
-	RemoteApplication(string) (RemoteApplication, error)
-
-	// Application returns a local application by name.
-	Application(string) (Application, error)
+	common.Backend
 
 	// WatchRemoteApplications returns a StringsWatcher that notifies of changes to
 	// the lifecycles of the remote applications in the model.
@@ -42,19 +29,6 @@ type RemoteRelationsState interface {
 	// the lifecycles of remote relations in the model.
 	WatchRemoteRelations() state.StringsWatcher
 
-	// ExportLocalEntity adds an entity to the remote entities collection,
-	// returning an opaque token that uniquely identifies the entity within
-	// the model.
-	ExportLocalEntity(names.Tag) (string, error)
-
-	// GetRemoteEntity returns the tag of the entity associated with the given
-	// token and model.
-	GetRemoteEntity(names.ModelTag, string) (names.Tag, error)
-
-	// ImportRemoteEntity adds an entity to the remote entities collection
-	// with the specified opaque token.
-	ImportRemoteEntity(sourceModel names.ModelTag, entity names.Tag, token string) error
-
 	// RemoveRemoteEntity removes the specified entity from the remote entities collection.
 	RemoveRemoteEntity(sourceModel names.ModelTag, entity names.Tag) error
 
@@ -63,178 +37,33 @@ type RemoteRelationsState interface {
 	GetToken(names.ModelTag, names.Tag) (string, error)
 }
 
-// Relation provides access a relation in global state.
-type Relation interface {
-	// Id returns the integer internal relation key.
-	Id() int
-
-	// Tag returns the relation's tag.
-	Tag() names.Tag
-
-	// Life returns the relation's current life state.
-	Life() state.Life
-
-	// Endpoints returns the endpoints that constitute the relation.
-	Endpoints() []state.Endpoint
-
-	// Unit returns a RelationUnit for the unit with the supplied ID.
-	Unit(unitId string) (RelationUnit, error)
-
-	// WatchUnits returns a watcher that notifies of changes to the units of the
-	// specified application in the relation.
-	WatchUnits(applicationName string) (state.RelationUnitsWatcher, error)
-}
-
-// RelationUnit provides access to the settings of a single unit in a relation,
-// and methods for modifying the unit's involvement in the relation.
-type RelationUnit interface {
-	// Settings returns the relation unit's settings within the relation.
-	Settings() (map[string]interface{}, error)
-}
-
-// RemoteApplication represents the state of an application hosted in an external
-// (remote) model.
-type RemoteApplication interface {
-	// Name returns the name of the remote application.
-	Name() string
-
-	// OfferName returns the name the offering side has given to the remote application..
-	OfferName() string
-
-	// Tag returns the remote applications's tag.
-	Tag() names.Tag
-
-	// SourceModel returns the tag of the model hosting the remote application.
-	SourceModel() names.ModelTag
-
-	// Macaroon returns the macaroon used for authentication.
-	Macaroon() (*macaroon.Macaroon, error)
-
-	// IsConsumerProxy returns whether application is created
-	// from a registration operation by a consuming model.
-	IsConsumerProxy() bool
-
-	// URL returns the remote application URL, at which it is offered.
-	URL() (string, bool)
-
-	// Life returns the lifecycle state of the application.
-	Life() state.Life
-
-	// Status returns the status of the remote application.
-	Status() (status.StatusInfo, error)
-}
-
-// Application represents the state of a application hosted in the local model.
-type Application interface {
-	// Name is the name of the application.
-	Name() string
-
-	// Life returns the lifecycle state of the application.
-	Life() state.Life
-}
-
 type stateShim struct {
-	*state.State
-}
-
-func (st stateShim) ExportLocalEntity(entity names.Tag) (string, error) {
-	r := st.State.RemoteEntities()
-	return r.ExportLocalEntity(entity)
-}
-
-func (st stateShim) GetRemoteEntity(model names.ModelTag, token string) (names.Tag, error) {
-	r := st.State.RemoteEntities()
-	return r.GetRemoteEntity(model, token)
-}
-
-func (st stateShim) ImportRemoteEntity(model names.ModelTag, entity names.Tag, token string) error {
-	r := st.State.RemoteEntities()
-	return r.ImportRemoteEntity(model, entity, token)
+	common.Backend
+	st *state.State
 }
 
 func (st stateShim) RemoveRemoteEntity(model names.ModelTag, entity names.Tag) error {
-	r := st.State.RemoteEntities()
+	r := st.st.RemoteEntities()
 	return r.RemoveRemoteEntity(model, entity)
 }
 
 func (st stateShim) GetToken(model names.ModelTag, entity names.Tag) (string, error) {
-	r := st.State.RemoteEntities()
+	r := st.st.RemoteEntities()
 	return r.GetToken(model, entity)
 }
 
-func (st stateShim) KeyRelation(key string) (Relation, error) {
-	r, err := st.State.KeyRelation(key)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	return relationShim{r, st.State}, nil
+func (st stateShim) WatchRemoteApplications() state.StringsWatcher {
+	return st.st.WatchRemoteApplications()
 }
 
-func (st stateShim) RemoteApplication(name string) (RemoteApplication, error) {
-	a, err := st.State.RemoteApplication(name)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	return &remoteApplicationShim{a}, nil
+func (st stateShim) WatchRemoteRelations() state.StringsWatcher {
+	return st.st.WatchRemoteRelations()
 }
 
 func (st stateShim) WatchRemoteApplicationRelations(applicationName string) (state.StringsWatcher, error) {
-	a, err := st.State.RemoteApplication(applicationName)
+	a, err := st.st.RemoteApplication(applicationName)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
 	return a.WatchRelations(), nil
-}
-
-type relationShim struct {
-	*state.Relation
-	st *state.State
-}
-
-func (r relationShim) RemoteUnit(unitId string) (RelationUnit, error) {
-	ru, err := r.Relation.RemoteUnit(unitId)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	return relationUnitShim{ru}, nil
-}
-
-func (r relationShim) Unit(unitId string) (RelationUnit, error) {
-	unit, err := r.st.Unit(unitId)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	ru, err := r.Relation.Unit(unit)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	return relationUnitShim{ru}, nil
-}
-
-type relationUnitShim struct {
-	*state.RelationUnit
-}
-
-func (r relationUnitShim) Settings() (map[string]interface{}, error) {
-	settings, err := r.RelationUnit.Settings()
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	return settings.Map(), nil
-}
-
-type remoteApplicationShim struct {
-	*state.RemoteApplication
-}
-
-type applicationShim struct {
-	*state.Application
-}
-
-func (st stateShim) Application(name string) (Application, error) {
-	a, err := st.State.Application(name)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	return applicationShim{a}, nil
 }

--- a/apiserver/restrict_anonymous.go
+++ b/apiserver/restrict_anonymous.go
@@ -15,6 +15,7 @@ import (
 // its own authentication and authorisation if required.
 var anonymousFacadeNames = set.NewStrings(
 	"CrossModelRelations",
+	"RelationUnitsWatcher",
 )
 
 func anonymousFacadesOnly(facadeName, _ string) error {

--- a/apiserver/root.go
+++ b/apiserver/root.go
@@ -394,8 +394,11 @@ func (r *apiHandler) AuthClient() bool {
 	return isUser
 }
 
-// GetAuthTag returns the tag of the authenticated entity.
+// GetAuthTag returns the tag of the authenticated entity, if any.
 func (r *apiHandler) GetAuthTag() names.Tag {
+	if r.entity == nil {
+		return nil
+	}
 	return r.entity.Tag()
 }
 
@@ -405,11 +408,6 @@ func (r *apiHandler) GetAuthTag() names.Tag {
 // that method is deprecated.
 func (r *apiHandler) ConnectedModel() string {
 	return r.modelUUID
-}
-
-// GetAuthEntity returns the authenticated entity.
-func (r *apiHandler) GetAuthEntity() state.Entity {
-	return r.entity
 }
 
 // HasPermission returns true if the logged in user can perform <operation> on <target>.

--- a/apiserver/watcher.go
+++ b/apiserver/watcher.go
@@ -182,7 +182,9 @@ func newRelationUnitsWatcher(context facade.Context) (facade.Facade, error) {
 	auth := context.Auth()
 	resources := context.Resources()
 
-	if !isAgent(auth) {
+	// TODO(wallyworld) - enhance this watcher to support
+	// anonymous api calls with macaroons.
+	if auth.GetAuthTag() != nil && !isAgent(auth) {
 		return nil, common.ErrPerm
 	}
 	watcher, ok := resources.Get(id).(state.RelationUnitsWatcher)

--- a/rpc/server.go
+++ b/rpc/server.go
@@ -6,6 +6,7 @@ package rpc
 import (
 	"io"
 	"reflect"
+	"runtime/debug"
 	"strings"
 	"sync"
 
@@ -490,7 +491,16 @@ func (conn *Conn) bindRequest(hdr *Header) (boundRequest, error) {
 
 // runRequest runs the given request and sends the reply.
 func (conn *Conn) runRequest(req boundRequest, arg reflect.Value, version int, observer Observer) {
+	// If the request causes a panic, ensure we log that before closing the connection.
+	defer func() {
+		if panicResult := recover(); panicResult != nil {
+			logger.Criticalf(
+				"panic running request %+v with arg %+v: %v\n%v", req, arg, panicResult, string(debug.Stack()))
+			conn.writeErrorResponse(&req.hdr, errors.Errorf("%v", panicResult), observer)
+		}
+	}()
 	defer conn.srvPending.Done()
+
 	rv, err := req.Call(req.hdr.Request.Id, arg)
 	if err != nil {
 		err = conn.writeErrorResponse(&req.hdr, req.transformErrors(err), observer)

--- a/worker/remoterelations/manifold.go
+++ b/worker/remoterelations/manifold.go
@@ -69,7 +69,7 @@ func (config ManifoldConfig) start(context dependency.Context) (worker.Worker, e
 		return nil, errors.New("no API connection details")
 	}
 	// We use an anonymous connection and macaroon sent with the
-	// publish requests for authentication.
+	// api requests for authentication.
 	apiInfo.Tag = nil
 	apiInfo.Password = ""
 	apiInfo.Macaroons = nil
@@ -81,7 +81,7 @@ func (config ManifoldConfig) start(context dependency.Context) (worker.Worker, e
 	w, err := config.NewWorker(Config{
 		ModelUUID:                agent.CurrentConfig().Model().Id(),
 		RelationsFacade:          facade,
-		NewPublisherForModelFunc: relationChangePublisherForModelFunc(apiConnForModelFunc),
+		NewRemoteModelFacadeFunc: remoteRelationsFacadeForModelFunc(apiConnForModelFunc),
 	})
 	if err != nil {
 		return nil, errors.Trace(err)

--- a/worker/remoterelations/remoterelations.go
+++ b/worker/remoterelations/remoterelations.go
@@ -21,23 +21,31 @@ import (
 
 var logger = loggo.GetLogger("juju.worker.remoterelations")
 
-// RemoteRelationChangePublisherCloser implements RemoteRelationChangePublisher
+// RemoteModelRelationsFacadeCloser implements RemoteModelRelationsFacade
 // and add a Close() method.
-type RemoteRelationChangePublisherCloser interface {
+type RemoteModelRelationsFacadeCloser interface {
 	io.Closer
-	RemoteRelationChangePublisher
+	RemoteModelRelationsFacade
 }
 
-// RemoteRelationChangePublisher instances publish local relation changes to the
-// model hosting the remote application involved in the relation
-type RemoteRelationChangePublisher interface {
-	// RegisterRemoteRelation sets up the local model to participate
+// RemoteModelRelationsFacade instances publish local relation changes to the
+// model hosting the remote application involved in the relation, and also watches
+// for remote relation changes which are then pushed to the local model.
+type RemoteModelRelationsFacade interface {
+	// RegisterRemoteRelation sets up the remote model to participate
 	// in the specified relations.
 	RegisterRemoteRelations(relations ...params.RegisterRemoteRelation) ([]params.RemoteEntityIdResult, error)
 
-	// PublishLocalRelationChange publishes local relation changes to the
+	// PublishRelationChange publishes relation changes to the
 	// model hosting the remote application involved in the relation.
-	PublishLocalRelationChange(params.RemoteRelationChangeEvent) error
+	PublishRelationChange(params.RemoteRelationChangeEvent) error
+
+	// WatchRelationUnits returns a watcher that notifies of changes to the
+	// units in the remote model for the relation with the given remote id.
+	WatchRelationUnits(params.RemoteEntityId) (watcher.RelationUnitsWatcher, error)
+
+	// RelationUnitSettings returns the relation unit settings for the given relation units in the remote model.
+	RelationUnitSettings([]params.RemoteRelationUnit) ([]params.SettingsResult, error)
 }
 
 // RemoteRelationsFacade exposes remote relation functionality to a worker.
@@ -82,13 +90,17 @@ type RemoteRelationsFacade interface {
 	// and initial values, or an error if the applications' relations could not be
 	// watched.
 	WatchRemoteApplicationRelations(application string) (watcher.StringsWatcher, error)
+
+	// ConsumeRemoteRelationChange consumes a change to settings originating
+	// from the remote/offering side of a relation.
+	ConsumeRemoteRelationChange(change params.RemoteRelationChangeEvent) error
 }
 
 // Config defines the operation of a Worker.
 type Config struct {
 	ModelUUID                string
 	RelationsFacade          RemoteRelationsFacade
-	NewPublisherForModelFunc func(modelUUID string) (RemoteRelationChangePublisherCloser, error)
+	NewRemoteModelFacadeFunc func(modelUUID string) (RemoteModelRelationsFacadeCloser, error)
 }
 
 // Validate returns an error if config cannot drive a Worker.
@@ -99,8 +111,8 @@ func (config Config) Validate() error {
 	if config.RelationsFacade == nil {
 		return errors.NotValidf("nil Facade")
 	}
-	if config.NewPublisherForModelFunc == nil {
-		return errors.NotValidf("nil Publisher func")
+	if config.NewRemoteModelFacadeFunc == nil {
+		return errors.NotValidf("nil Remote Model Facade func")
 	}
 	return nil
 }
@@ -213,7 +225,7 @@ func (w *Worker) handleApplicationChanges(applicationIds []string) error {
 			relationsWatcher,
 			w.config.ModelUUID,
 			*result.Result,
-			w.config.NewPublisherForModelFunc,
+			w.config.NewRemoteModelFacadeFunc,
 			w.config.RelationsFacade,
 		)
 		if err != nil {
@@ -236,34 +248,42 @@ func (w *Worker) killApplicationWorker(name string) error {
 	return nil
 }
 
-// remoteApplicationWorker listens for changes to relations
-// involving a remote application, and publishes changes to
-// local relation units to the remote model.
+// remoteApplicationWorker listens for localChanges to relations
+// involving a remote application, and publishes change to
+// local relation units to the remote model. It also watches for
+// changes originating from the offering model and consumes those
+// in the local model.
 type remoteApplicationWorker struct {
-	catacomb         catacomb.Catacomb
-	relationsWatcher watcher.StringsWatcher
-	relationInfo     remoteRelationInfo
-	localModelUUID   string // uuid of the model hosting the local application
-	remoteModelUUID  string // uuid of the model hosting the remote application
-	registered       bool
-	relationChanges  chan params.RemoteRelationChangeEvent
+	catacomb              catacomb.Catacomb
+	relationsWatcher      watcher.StringsWatcher
+	relationInfo          remoteRelationInfo
+	localModelUUID        string // uuid of the model hosting the local application
+	remoteModelUUID       string // uuid of the model hosting the remote application
+	registered            bool
+	localRelationChanges  chan params.RemoteRelationChangeEvent
+	remoteRelationChanges chan params.RemoteRelationChangeEvent
 
 	// macaroon is used to confirm that permission has been granted to consume
 	// the remote application to which this worker pertains.
 	macaroon *macaroon.Macaroon
 
-	facade                   RemoteRelationsFacade
-	newPublisherForModelFunc func(modelUUID string) (RemoteRelationChangePublisherCloser, error)
+	// localModelFacade interacts with the local (consuming) model.
+	localModelFacade RemoteRelationsFacade
+	// remoteModelFacade interacts with the remote (offering) model.
+	remoteModelFacade RemoteModelRelationsFacadeCloser
+
+	newRemoteModelRelationsFacadeFunc func(modelUUID string) (RemoteModelRelationsFacadeCloser, error)
 }
 
 type relation struct {
 	relationId int
 	life       params.Life
-	ruw        *relationUnitsWatcher
+	localRuw   *relationUnitsWorker
+	remoteRuw  *relationUnitsWorker
 }
 
 type remoteRelationInfo struct {
-	applicationId              params.RemoteEntityId
+	localApplicationId         params.RemoteEntityId
 	localEndpoint              params.RemoteEndpoint
 	remoteApplicationName      string
 	remoteApplicationOfferName string
@@ -274,7 +294,7 @@ func newRemoteApplicationWorker(
 	relationsWatcher watcher.StringsWatcher,
 	localModelUUID string,
 	remoteApplication params.RemoteApplication,
-	newPublisherForModelFunc func(modelUUID string) (RemoteRelationChangePublisherCloser, error),
+	newRemoteModelRelationsFacadeFunc func(modelUUID string) (RemoteModelRelationsFacadeCloser, error),
 	facade RemoteRelationsFacade,
 ) (worker.Worker, error) {
 	w := &remoteApplicationWorker{
@@ -283,13 +303,14 @@ func newRemoteApplicationWorker(
 			remoteApplicationOfferName: remoteApplication.OfferName,
 			remoteApplicationName:      remoteApplication.Name,
 		},
-		localModelUUID:  localModelUUID,
-		remoteModelUUID: remoteApplication.ModelUUID,
-		registered:      remoteApplication.Registered,
-		macaroon:        remoteApplication.Macaroon,
-		relationChanges: make(chan params.RemoteRelationChangeEvent),
-		facade:          facade,
-		newPublisherForModelFunc: newPublisherForModelFunc,
+		localModelUUID:                    localModelUUID,
+		remoteModelUUID:                   remoteApplication.ModelUUID,
+		registered:                        remoteApplication.Registered,
+		macaroon:                          remoteApplication.Macaroon,
+		localRelationChanges:              make(chan params.RemoteRelationChangeEvent),
+		remoteRelationChanges:             make(chan params.RemoteRelationChangeEvent),
+		localModelFacade:                  facade,
+		newRemoteModelRelationsFacadeFunc: newRemoteModelRelationsFacadeFunc,
 	}
 	err := catacomb.Invoke(catacomb.Plan{
 		Site: &w.catacomb,
@@ -310,11 +331,12 @@ func (w *remoteApplicationWorker) Wait() error {
 }
 
 func (w *remoteApplicationWorker) loop() error {
-	publisher, err := w.newPublisherForModelFunc(w.remoteModelUUID)
+	var err error
+	w.remoteModelFacade, err = w.newRemoteModelRelationsFacadeFunc(w.remoteModelUUID)
 	if err != nil {
-		return errors.Annotate(err, "opening publisher to remote model")
+		return errors.Annotate(err, "opening facade to remote model")
 	}
-	defer publisher.Close()
+	defer w.remoteModelFacade.Close()
 
 	relations := make(map[string]*relation)
 	for {
@@ -327,43 +349,49 @@ func (w *remoteApplicationWorker) loop() error {
 				// We are dying.
 				continue
 			}
-			results, err := w.facade.Relations(change)
+			results, err := w.localModelFacade.Relations(change)
 			if err != nil {
 				return errors.Annotate(err, "querying relations")
 			}
 			for i, result := range results {
 				key := change[i]
-				if err := w.relationChanged(key, result, relations, publisher); err != nil {
+				if err := w.relationChanged(key, result, relations); err != nil {
 					return errors.Annotatef(err, "handling change for relation %q", key)
 				}
 			}
-		case change := <-w.relationChanges:
-			logger.Debugf("relation units changed: %#v", change)
-			if err := publisher.PublishLocalRelationChange(change); err != nil {
+		case change := <-w.localRelationChanges:
+			logger.Debugf("local relation units changed -> publishing: %#v", change)
+			if err := w.remoteModelFacade.PublishRelationChange(change); err != nil {
 				return errors.Annotatef(err, "publishing relation change %+v to remote model %v", change, w.remoteModelUUID)
+			}
+		case change := <-w.remoteRelationChanges:
+			logger.Debugf("remote relation units changed -> consuming: %#v", change)
+			if err := w.localModelFacade.ConsumeRemoteRelationChange(change); err != nil {
+				return errors.Annotatef(err, "consuming relation change %+v from remote model %v", change, w.remoteModelUUID)
 			}
 		}
 	}
 }
 
-func (w *remoteApplicationWorker) processRelationGone(
-	key string, relations map[string]*relation, publisher RemoteRelationChangePublisher,
-) error {
+func (w *remoteApplicationWorker) processRelationGone(key string, relations map[string]*relation) error {
 	logger.Debugf("relation %v gone", key)
 	relation, ok := relations[key]
 	if !ok {
 		return nil
 	}
 	delete(relations, key)
-	if err := worker.Stop(relation.ruw); err != nil {
-		logger.Warningf("stopping relation unit watcher for %v: %v", key, err)
+	if err := worker.Stop(relation.localRuw); err != nil {
+		logger.Warningf("stopping local relation unit worker for %v: %v", key, err)
+	}
+	if err := worker.Stop(relation.remoteRuw); err != nil {
+		logger.Warningf("stopping remote relation unit worker for %v: %v", key, err)
 	}
 
 	// Remove the remote entity record for the relation to ensure any unregister
 	// call from the remote model that may come across at the same time is short circuited.
-	remoteId := relation.ruw.remoteRelationId
+	remoteId := relation.localRuw.remoteRelationId
 	relTag := names.NewRelationTag(key)
-	_, err := w.facade.GetToken(remoteId.ModelUUID, relTag)
+	_, err := w.localModelFacade.GetToken(remoteId.ModelUUID, relTag)
 	if errors.IsNotFound(err) {
 		logger.Debugf("not found token for %v in %v, exit early", key, w.localModelUUID)
 		return nil
@@ -372,20 +400,23 @@ func (w *remoteApplicationWorker) processRelationGone(
 	}
 
 	// We also need to remove the remote entity reference for the relation.
-	if err := w.facade.RemoveRemoteEntity(remoteId.ModelUUID, relTag); err != nil {
+	if err := w.localModelFacade.RemoveRemoteEntity(remoteId.ModelUUID, relTag); err != nil {
 		return errors.Trace(err)
 	}
 
-	// Inform the remote side the relation has died.
-	change := params.RemoteRelationChangeEvent{
-		RelationId:    remoteId,
-		Life:          params.Dead,
-		ApplicationId: w.relationInfo.applicationId,
-		Macaroon:      w.macaroon,
+	// On the consuming side, inform the remote side the relation has died.
+	if !w.registered {
+		change := params.RemoteRelationChangeEvent{
+			RelationId:    remoteId,
+			Life:          params.Dead,
+			ApplicationId: w.relationInfo.localApplicationId,
+			Macaroon:      w.macaroon,
+		}
+		if err := w.remoteModelFacade.PublishRelationChange(change); err != nil {
+			return errors.Annotatef(err, "publishing relation departed %+v to remote model %v", change, w.remoteModelUUID)
+		}
 	}
-	if err := publisher.PublishLocalRelationChange(change); err != nil {
-		return errors.Annotatef(err, "publishing relation departed %+v to remote model %v", change, w.remoteModelUUID)
-	}
+	// TODO(wallyworld) - on the offering side, ensure the consuming watcher learns about the removal
 	logger.Debugf("remote relation %v removed from remote model", key)
 
 	// TODO(wallyworld) - check that state cleanup worker properly removes the dead relation.
@@ -394,12 +425,11 @@ func (w *remoteApplicationWorker) processRelationGone(
 
 func (w *remoteApplicationWorker) relationChanged(
 	key string, result params.RemoteRelationResult, relations map[string]*relation,
-	publisher RemoteRelationChangePublisher,
 ) error {
 	logger.Debugf("relation %q changed: %+v", key, result)
 	if result.Error != nil {
 		if params.IsCodeNotFound(result.Error) {
-			return w.processRelationGone(key, relations, publisher)
+			return w.processRelationGone(key, relations)
 		}
 		return result.Error
 	}
@@ -407,11 +437,10 @@ func (w *remoteApplicationWorker) relationChanged(
 
 	// If we have previously started the watcher and the
 	// relation is now dead, stop the watcher.
-	relationTag := names.NewRelationTag(key)
 	if r := relations[key]; r != nil {
 		r.life = remoteRelation.Life
 		if r.life == params.Dead {
-			return w.processRelationGone(key, relations, publisher)
+			return w.processRelationGone(key, relations)
 		}
 		// Nothing to do, we have previously started the watcher.
 		return nil
@@ -420,125 +449,198 @@ func (w *remoteApplicationWorker) relationChanged(
 		// We haven't started the relation unit watcher so just exit.
 		return nil
 	}
-
-	var remoteRelationId params.RemoteEntityId
 	if w.registered {
-		// We are on the offering side and the relation has been registered,
-		// so look up the token to use when communicating status.
-		token, err := w.facade.GetToken(w.remoteModelUUID, relationTag)
-		if err != nil {
-			return errors.Annotatef(err, "getting token for relation %v from consuming model", relationTag.Id())
-		}
-		remoteRelationId = params.RemoteEntityId{ModelUUID: w.remoteModelUUID, Token: token}
-		// Look up the exported token of the local application in the relation.
-		// The export was done when the relation was registered.
-		token, err = w.facade.GetToken(w.localModelUUID, names.NewApplicationTag(remoteRelation.ApplicationName))
-		if err != nil {
-			return errors.Annotatef(err, "getting token for application %v from offering model", remoteRelation.ApplicationName)
-		}
-		w.relationInfo.applicationId = params.RemoteEntityId{ModelUUID: w.localModelUUID, Token: token}
-	} else {
-		// We have not seen the relation before, make
-		// sure it is registered on the offering side.
-		w.relationInfo.localEndpoint = remoteRelation.Endpoint
-		w.relationInfo.remoteEndpointName = remoteRelation.RemoteEndpointName
-		var err error
-		applicationTag := names.NewApplicationTag(remoteRelation.ApplicationName)
-		w.relationInfo.applicationId, remoteRelationId, err = w.registerRemoteRelation(applicationTag, relationTag, publisher)
-		if err != nil {
-			return errors.Annotatef(err, "registering application %v and relation %v", remoteRelation.ApplicationName, relationTag.Id())
-		}
+		return w.processNewOfferingRelation(remoteRelation.ApplicationName, key)
+	}
+	return w.processNewConsumingRelation(key, relations, remoteRelation)
+}
+
+func (w *remoteApplicationWorker) processNewOfferingRelation(applicationName string, key string) error {
+	// We are on the offering side and the relation has been registered,
+	// so look up the token to use when communicating status.
+	relationTag := names.NewRelationTag(key)
+	token, err := w.localModelFacade.GetToken(w.remoteModelUUID, relationTag)
+	if err != nil {
+		return errors.Annotatef(err, "getting token for relation %v from consuming model", relationTag.Id())
+	}
+	// Look up the exported token of the local application in the relation.
+	// The export was done when the relation was registered.
+	token, err = w.localModelFacade.GetToken(w.localModelUUID, names.NewApplicationTag(applicationName))
+	if err != nil {
+		return errors.Annotatef(err, "getting token for application %v from offering model", applicationName)
+	}
+	w.relationInfo.localApplicationId = params.RemoteEntityId{ModelUUID: w.localModelUUID, Token: token}
+	return nil
+}
+
+// processNewConsumingRelation starts the sub-workers necessary to listen and publish
+// local unit settings changes, and watch and consume remote unit settings changes.
+func (w *remoteApplicationWorker) processNewConsumingRelation(
+	key string,
+	relations map[string]*relation,
+	remoteRelation *params.RemoteRelation,
+) error {
+	// We have not seen the relation before, make
+	// sure it is registered on the offering side.
+	w.relationInfo.localEndpoint = remoteRelation.Endpoint
+	w.relationInfo.remoteEndpointName = remoteRelation.RemoteEndpointName
+
+	applicationTag := names.NewApplicationTag(remoteRelation.ApplicationName)
+	relationTag := names.NewRelationTag(key)
+	applicationId, remoteApplictionId, relationId, err := w.registerRemoteRelation(applicationTag, relationTag)
+	if err != nil {
+		return errors.Annotatef(err, "registering application %v and relation %v", remoteRelation.ApplicationName, relationTag.Id())
+	}
+	w.relationInfo.localApplicationId = applicationId
+
+	// Start a watcher to track changes to the units in the relation in the local model.
+	localRelationUnitsWatcher, err := w.localModelFacade.WatchLocalRelationUnits(key)
+	if err != nil {
+		return errors.Annotatef(err, "watching local side of relation %v", relationTag.Id())
 	}
 
-	// Start a watcher to track changes to the local units in the
-	// relation, and a worker to process those changes.
-	localRelationUnitsWatcher, err := w.facade.WatchLocalRelationUnits(key)
-	if err != nil {
-		return errors.Trace(err)
+	// localUnitSettingsFunc converts relations units watcher results from the local model
+	// into settings params using an api call to the local model.
+	localUnitSettingsFunc := func(changedUnitNames []string) ([]params.SettingsResult, error) {
+		relationUnits := make([]params.RelationUnit, len(changedUnitNames))
+		for i, changedName := range changedUnitNames {
+			relationUnits[i] = params.RelationUnit{
+				Relation: relationTag.String(),
+				Unit:     names.NewUnitTag(changedName).String(),
+			}
+		}
+		return w.localModelFacade.RelationUnitSettings(relationUnits)
 	}
-	relationUnitsWatcher, err := newRelationUnitsWatcher(
+	localUnitsWorker, err := newRelationUnitsWorker(
 		relationTag,
-		w.relationInfo.applicationId,
+		applicationId,
 		w.macaroon,
-		remoteRelationId,
+		relationId,
 		localRelationUnitsWatcher,
-		w.relationChanges,
-		w.facade,
+		w.localRelationChanges,
+		localUnitSettingsFunc,
 	)
 	if err != nil {
 		return errors.Trace(err)
 	}
-	if err := w.catacomb.Add(relationUnitsWatcher); err != nil {
+	if err := w.catacomb.Add(localUnitsWorker); err != nil {
 		return errors.Trace(err)
 	}
+
+	// Start a watcher to track changes to the units in the relation in the remote model.
+	remoteRelationUnitsWatcher, err := w.remoteModelFacade.WatchRelationUnits(relationId)
+	if err != nil {
+		return errors.Annotatef(
+			err, "watching remote side of application %v and relation %v",
+			remoteRelation.ApplicationName, relationTag.Id())
+	}
+
+	// remoteUnitSettingsFunc converts relations units watcher results from the remote model
+	// into settings params using an api call to the remote model.
+	remoteUnitSettingsFunc := func(changedUnitNames []string) ([]params.SettingsResult, error) {
+		relationUnits := make([]params.RemoteRelationUnit, len(changedUnitNames))
+		for i, changedName := range changedUnitNames {
+			relationUnits[i] = params.RemoteRelationUnit{
+				RelationId: relationId,
+				Unit:       names.NewUnitTag(changedName).String(),
+			}
+		}
+		return w.remoteModelFacade.RelationUnitSettings(relationUnits)
+	}
+	remoteUnitsWorker, err := newRelationUnitsWorker(
+		relationTag,
+		remoteApplictionId,
+		w.macaroon,
+		relationId,
+		remoteRelationUnitsWatcher,
+		w.remoteRelationChanges,
+		remoteUnitSettingsFunc,
+	)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	if err := w.catacomb.Add(remoteUnitsWorker); err != nil {
+		return errors.Trace(err)
+	}
+
 	relations[key] = &relation{
 		relationId: remoteRelation.Id,
 		life:       remoteRelation.Life,
-		ruw:        relationUnitsWatcher,
+		localRuw:   localUnitsWorker,
+		remoteRuw:  remoteUnitsWorker,
 	}
+
 	return nil
 }
 
 func (w *remoteApplicationWorker) registerRemoteRelation(
-	applicationTag, relationTag names.Tag, publisher RemoteRelationChangePublisher,
-) (remoteApplicationId params.RemoteEntityId, remoteRelationId params.RemoteEntityId, _ error) {
+	applicationTag, relationTag names.Tag,
+) (localApplicationId, offeringRemoteAppId, relationId params.RemoteEntityId, _ error) {
 	logger.Debugf("register remote relation %v", relationTag.Id())
+
 	emptyId := params.RemoteEntityId{}
+	fail := func(err error) (params.RemoteEntityId, params.RemoteEntityId, params.RemoteEntityId, error) {
+		return emptyId, emptyId, emptyId, err
+	}
+
 	// Ensure the relation is exported first up.
-	results, err := w.facade.ExportEntities([]names.Tag{applicationTag, relationTag})
+	results, err := w.localModelFacade.ExportEntities([]names.Tag{applicationTag, relationTag})
 	if err != nil {
-		return emptyId, emptyId, errors.Annotatef(err, "exporting relation %v and application", relationTag, applicationTag)
+		return fail(errors.Annotatef(err, "exporting relation %v and application", relationTag, applicationTag))
 	}
 	if results[0].Error != nil && !params.IsCodeAlreadyExists(results[0].Error) {
-		return emptyId, emptyId, errors.Annotatef(err, "exporting application %v", applicationTag)
+		return fail(errors.Annotatef(err, "exporting application %v", applicationTag))
 	}
-	remoteApplicationId = *results[0].Result
+	localApplicationId = *results[0].Result
 	if results[1].Error != nil && !params.IsCodeAlreadyExists(results[1].Error) {
-		return emptyId, emptyId, errors.Annotatef(err, "exporting relation %v", relationTag)
+		return fail(errors.Annotatef(err, "exporting relation %v", relationTag))
 	}
-	remoteRelationId = *results[1].Result
+	relationId = *results[1].Result
 
 	// This data goes to the remote model so we map local info
 	// from this model to the remote arg values and visa versa.
 	arg := params.RegisterRemoteRelation{
-		ApplicationId:     remoteApplicationId,
-		RelationId:        remoteRelationId,
+		ApplicationId:     localApplicationId,
+		RelationId:        relationId,
 		RemoteEndpoint:    w.relationInfo.localEndpoint,
 		OfferName:         w.relationInfo.remoteApplicationOfferName,
 		LocalEndpointName: w.relationInfo.remoteEndpointName,
 		Macaroon:          w.macaroon,
 	}
-	remoteAppIds, err := publisher.RegisterRemoteRelations(arg)
+	remoteAppIds, err := w.remoteModelFacade.RegisterRemoteRelations(arg)
 	if err != nil {
-		return emptyId, emptyId, errors.Trace(err)
+		return fail(errors.Trace(err))
 	}
 	// remoteAppIds is a slice but there's only one item
 	// as we currently only register one remote application
 	if err := remoteAppIds[0].Error; err != nil {
-		return emptyId, emptyId, errors.Trace(err)
+		return fail(errors.Trace(err))
 	}
 	if err := results[0].Error; err != nil && !params.IsCodeAlreadyExists(err) {
-		return emptyId, emptyId, errors.Annotatef(err, "registering relation %v", relationTag)
+		return fail(errors.Annotatef(err, "registering relation %v", relationTag))
 	}
 	// Import the application id from the offering model.
-	offeringRemoteAppId := remoteAppIds[0].Result
+	offeringRemoteAppId = *remoteAppIds[0].Result
 	logger.Debugf("import remote application token %v from %v for %v",
 		offeringRemoteAppId.Token, offeringRemoteAppId.ModelUUID, w.relationInfo.remoteApplicationName)
-	err = w.facade.ImportRemoteEntity(
+	err = w.localModelFacade.ImportRemoteEntity(
 		offeringRemoteAppId.ModelUUID,
 		names.NewApplicationTag(w.relationInfo.remoteApplicationName),
 		offeringRemoteAppId.Token)
 	if err != nil && !params.IsCodeAlreadyExists(err) {
-		return emptyId, emptyId, errors.Annotatef(
-			err, "importing remote application %v to local model", w.relationInfo.remoteApplicationName)
+		return fail(errors.Annotatef(
+			err, "importing remote application %v to local model", w.relationInfo.remoteApplicationName))
 	}
-	return remoteApplicationId, remoteRelationId, nil
+	return localApplicationId, offeringRemoteAppId, relationId, nil
 }
 
-// relationUnitsWatcher uses a watcher.RelationUnitsWatcher to listen
-// to changes to relation settings in the local model and converts
-// to a params.RemoteRelationChanges for export to a remote model.
-type relationUnitsWatcher struct {
+type relationUnitsSettingsFunc func([]string) ([]params.SettingsResult, error)
+
+// relationUnitsWorker uses instances of watcher.RelationUnitsWatcher to
+// listen to changes to relation settings in a model, local or remote.
+// Local changes are exported to the remote model.
+// Remote changes are consumed by the local model.
+type relationUnitsWorker struct {
 	catacomb    catacomb.Catacomb
 	relationTag names.RelationTag
 	ruw         watcher.RelationUnitsWatcher
@@ -549,20 +651,19 @@ type relationUnitsWatcher struct {
 	remoteRelationId params.RemoteEntityId
 	remoteUnitIds    map[string]params.RemoteEntityId
 
-	facade RemoteRelationsFacade
+	unitSettingsFunc relationUnitsSettingsFunc
 }
 
-func newRelationUnitsWatcher(
+func newRelationUnitsWorker(
 	relationTag names.RelationTag,
 	applicationId params.RemoteEntityId,
 	macaroon *macaroon.Macaroon,
 	remoteRelationId params.RemoteEntityId,
 	ruw watcher.RelationUnitsWatcher,
 	changes chan<- params.RemoteRelationChangeEvent,
-
-	facade RemoteRelationsFacade,
-) (*relationUnitsWatcher, error) {
-	w := &relationUnitsWatcher{
+	unitSettingsFunc relationUnitsSettingsFunc,
+) (*relationUnitsWorker, error) {
+	w := &relationUnitsWorker{
 		relationTag:      relationTag,
 		applicationId:    applicationId,
 		macaroon:         macaroon,
@@ -570,7 +671,7 @@ func newRelationUnitsWatcher(
 		ruw:              ruw,
 		changes:          changes,
 		remoteUnitIds:    make(map[string]params.RemoteEntityId),
-		facade:           facade,
+		unitSettingsFunc: unitSettingsFunc,
 	}
 	err := catacomb.Invoke(catacomb.Plan{
 		Site: &w.catacomb,
@@ -581,18 +682,20 @@ func newRelationUnitsWatcher(
 }
 
 // Kill is defined on worker.Worker
-func (w *relationUnitsWatcher) Kill() {
+func (w *relationUnitsWorker) Kill() {
 	w.catacomb.Kill(nil)
 }
 
 // Wait is defined on worker.Worker
-func (w *relationUnitsWatcher) Wait() error {
+func (w *relationUnitsWorker) Wait() error {
 	return w.catacomb.Wait()
 }
 
-func (w *relationUnitsWatcher) loop() error {
-	var changes chan<- params.RemoteRelationChangeEvent
-	var event params.RemoteRelationChangeEvent
+func (w *relationUnitsWorker) loop() error {
+	var (
+		changes chan<- params.RemoteRelationChangeEvent
+		event   params.RemoteRelationChangeEvent
+	)
 	for {
 		select {
 		case <-w.catacomb.Dying():
@@ -618,7 +721,7 @@ func (w *relationUnitsWatcher) loop() error {
 	}
 }
 
-func (w *relationUnitsWatcher) relationUnitsChangeEvent(
+func (w *relationUnitsWorker) relationUnitsChangeEvent(
 	change watcher.RelationUnitsChange,
 ) (*params.RemoteRelationChangeEvent, error) {
 	logger.Debugf("update relation units for %v", w.relationTag)
@@ -656,22 +759,15 @@ func (w *relationUnitsWatcher) relationUnitsChangeEvent(
 		event.DepartedUnits[i] = num
 	}
 
-	if len(change.Changed) > 0 {
-		// For changed units, we publish the current settings values.
-		relationUnits := make([]params.RelationUnit, len(change.Changed))
-		for i, changedName := range changedUnitNames {
-			relationUnits[i] = params.RelationUnit{
-				Relation: w.relationTag.String(),
-				Unit:     names.NewUnitTag(changedName).String(),
-			}
-		}
-		results, err := w.facade.RelationUnitSettings(relationUnits)
+	if len(changedUnitNames) > 0 {
+		// For changed units, we publish/consume the current settings values.
+		results, err := w.unitSettingsFunc(changedUnitNames)
 		if err != nil {
 			return nil, errors.Annotate(err, "fetching relation units settings")
 		}
 		for i, result := range results {
 			if result.Error != nil {
-				return nil, errors.Annotatef(result.Error, "fetching relation unit settings for %v", relationUnits[i].Unit)
+				return nil, errors.Annotatef(result.Error, "fetching relation unit settings for %v", changedUnitNames[i])
 			}
 		}
 		for i, result := range results {


### PR DESCRIPTION
## Description of change

The remote relations worker now polls the offering model - communications is one way from consuming model -> offering model, addressing a routeability issue.

The line count is large, but there's a lot of paper shuffling done to factor out common code. Because of the change in semantics of the worker, both the crossmodelrelations and remoterelations facade now share functionality, eg receiving changes from the other side, watching for unit settings changes. This is now all contained in a apiserver/common/crossmodel package.

The remote relations worker gains a new sub worker to act on listener events for unit settings changes from the offering model.

Still todo - when a relation is removed from the offering side, this is not yet picked up in the listener on the consuming side. Also, the relation units watcher needs a variant that can take macaroons for auth because the consuming controller needs anonymous access to this watcher.

## QA steps

run up a mediawiki->mysql cross model relations scenario

