### PR TITLE
apiserver/modelmanager: Removed ForModel call in DumpModel

### DIFF
--- a/apiserver/modelmanager/modelinfo_test.go
+++ b/apiserver/modelmanager/modelinfo_test.go
@@ -1016,5 +1016,6 @@ type mockPool struct {
 }
 
 func (p *mockPool) Get(modelUUID string) (common.ModelManagerBackend, func(), error) {
+	p.st.MethodCall(p, "Get", modelUUID)
 	return p.st, func() {}, p.st.NextErr()
 }

--- a/apiserver/modelmanager/modelmanager.go
+++ b/apiserver/modelmanager/modelmanager.go
@@ -478,14 +478,14 @@ func (m *ModelManagerAPI) dumpModelDB(args params.Entity) (map[string]interface{
 
 	st := m.state
 	if st.ModelTag() != modelTag {
-		st, err = m.state.ForModel(modelTag)
-		if err != nil {
-			if errors.IsNotFound(err) {
-				return nil, errors.Trace(common.ErrBadId)
-			}
+		newSt, releaser, err := m.pool.Get(modelTag.Id())
+		if errors.IsNotFound(err) {
+			return nil, errors.Trace(common.ErrBadId)
+		} else if err != nil {
 			return nil, errors.Trace(err)
 		}
-		defer st.Close()
+		defer releaser()
+		st = newSt
 	}
 
 	return st.DumpAll()

--- a/apiserver/modelmanager/modelmanager_test.go
+++ b/apiserver/modelmanager/modelmanager_test.go
@@ -546,12 +546,11 @@ func (s *modelManagerSuite) TestDumpModelMissingModel(c *gc.C) {
 	tag := names.NewModelTag("deadbeef-0bad-400d-8000-4b1d0d06f000")
 	models := params.DumpModelRequest{Entities: []params.Entity{{Tag: tag.String()}}}
 	results := s.api.DumpModels(models)
-
-	calls := s.st.Calls()
-	c.Logf("%#v", calls)
-	lastCall := calls[len(calls)-1]
-	c.Check(lastCall.FuncName, gc.Equals, "ModelUUID")
-
+	s.st.CheckCalls(c, []gitjujutesting.StubCall{
+		{"ControllerTag", nil},
+		{"ModelUUID", nil},
+		{"Get", []interface{}{tag.Id()}},
+	})
 	c.Assert(results.Results, gc.HasLen, 1)
 	result := results.Results[0]
 	c.Assert(result.Result, gc.Equals, "")
@@ -605,11 +604,12 @@ func (s *modelManagerSuite) TestDumpModelsDBMissingModel(c *gc.C) {
 	models := params.Entities{[]params.Entity{{Tag: tag.String()}}}
 	results := s.api.DumpModelsDB(models)
 
-	calls := s.st.Calls()
-	c.Logf("%#v", calls)
-	lastCall := calls[len(calls)-1]
-	c.Check(lastCall.FuncName, gc.Equals, "ForModel")
-
+	s.st.CheckCalls(c, []gitjujutesting.StubCall{
+		{"ControllerTag", nil},
+		{"ModelUUID", nil},
+		{"ModelTag", nil},
+		{"Get", []interface{}{tag.Id()}},
+	})
 	c.Assert(results.Results, gc.HasLen, 1)
 	result := results.Results[0]
 	c.Assert(result.Result, gc.IsNil)


### PR DESCRIPTION
## Description of change

Use the StatePool instead as this is more efficient.

## QA steps

Bootstrap, create several models and ensure that `juju dump-model`  works.

## Documentation changes

N.A.

## Bug reference

Part of the fix for https://bugs.launchpad.net/juju/2.2/+bug/1698702
