### PR TITLE
2.2 agent logging override

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -180,6 +180,11 @@ const (
 	AgentConnLookbackWindow = "AGENT_CONN_LOOKBACK_WINDOW"
 
 	MgoStatsEnabled = "MGO_STATS_ENABLED"
+
+	// LoggingOverride will set the logging for this agent to the value
+	// specified. Model configuration will be ignored and this value takes
+	// precidence for the agent.
+	LoggingOverride = "LOGGING_OVERRIDE"
 )
 
 // The Config interface is the sole way that the agent gets access to the

--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -224,12 +224,22 @@ func (a *machineAgentCmd) Init(args []string) error {
 		return errors.Annotate(err, "cannot read agent configuration")
 	}
 
+	config := a.currentConfig.CurrentConfig()
 	// the context's stderr is set as the loggo writer in github.com/juju/cmd/logging.go
 	a.ctx.Stderr = &lumberjack.Logger{
-		Filename:   agent.LogFilename(a.currentConfig.CurrentConfig()),
+		Filename:   agent.LogFilename(config),
 		MaxSize:    300, // megabytes
 		MaxBackups: 2,
 		Compress:   true,
+	}
+
+	if loggingOverride := config.Value(agent.LoggingOverride); loggingOverride != "" {
+		logger.Infof("setting logging override to %q", loggingOverride)
+		loggo.DefaultContext().ResetLoggerLevels()
+		err := loggo.ConfigureLoggers(loggingOverride)
+		if err != nil {
+			logger.Errorf("setting override %v", err)
+		}
 	}
 
 	return nil

--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -239,7 +239,7 @@ func (a *machineAgentCmd) Init(args []string) error {
 		loggo.DefaultContext().ResetLoggerLevels()
 		err := loggo.ConfigureLoggers(loggingOverride)
 		if err != nil {
-			logger.Errorf("setting override %v", err)
+			logger.Errorf("setting logging override %v", err)
 		}
 	}
 

--- a/cmd/jujud/agent/unit.go
+++ b/cmd/jujud/agent/unit.go
@@ -129,7 +129,7 @@ func (a *UnitAgent) Init(args []string) error {
 		loggo.DefaultContext().ResetLoggerLevels()
 		err := loggo.ConfigureLoggers(loggingOverride)
 		if err != nil {
-			logger.Errorf("setting override %v", err)
+			logger.Errorf("setting logging override %v", err)
 		}
 	}
 

--- a/cmd/jujud/agent/unit_test.go
+++ b/cmd/jujud/agent/unit_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/juju/cmd"
 	"github.com/juju/cmd/cmdtesting"
+	"github.com/juju/loggo"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils/arch"
 	"github.com/juju/utils/series"
@@ -93,16 +94,19 @@ func (s *UnitSuite) newBufferedLogWriter() *logsender.BufferedLogWriter {
 }
 
 func (s *UnitSuite) TestParseSuccess(c *gc.C) {
+	s.primeAgent(c)
+	// Now init actually reads the agent configuration file.
+	// So use the prime agent call which installs a wordpress unit.
 	a, err := NewUnitAgent(nil, s.newBufferedLogWriter())
 	c.Assert(err, jc.ErrorIsNil)
 	err = cmdtesting.InitCommand(a, []string{
-		"--data-dir", "jd",
-		"--unit-name", "w0rd-pre55/1",
+		"--data-dir", s.DataDir(),
+		"--unit-name", "wordpress/0",
 		"--log-to-stderr",
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	c.Check(a.AgentConf.DataDir(), gc.Equals, "jd")
-	c.Check(a.UnitName, gc.Equals, "w0rd-pre55/1")
+	c.Check(a.AgentConf.DataDir(), gc.Equals, s.DataDir())
+	c.Check(a.UnitName, gc.Equals, "wordpress/0")
 }
 
 func (s *UnitSuite) TestParseMissing(c *gc.C) {
@@ -334,6 +338,26 @@ func (s *UnitSuite) TestUnitAgentRunsAPIAddressUpdaterWorker(c *gc.C) {
 		}
 	}
 	c.Fatalf("timeout while waiting for agent config to change")
+}
+
+func (s *UnitSuite) TestLoggingOverride(c *gc.C) {
+	ctx, err := cmd.DefaultContext()
+	c.Assert(err, gc.IsNil)
+	agentConf := FakeAgentConfig{
+		values: map[string]string{agent.LoggingOverride: "test=trace"},
+	}
+
+	a := UnitAgent{
+		AgentConf: agentConf,
+		ctx:       ctx,
+		UnitName:  "mysql/25",
+	}
+
+	err = a.Init(nil)
+	c.Assert(err, gc.IsNil)
+
+	test := loggo.GetLogger("test")
+	c.Assert(test.LogLevel(), gc.Equals, loggo.TRACE)
 }
 
 func (s *UnitSuite) TestUseLumberjack(c *gc.C) {

--- a/cmd/jujud/agent/util_test.go
+++ b/cmd/jujud/agent/util_test.go
@@ -531,6 +531,7 @@ func newDummyWorker() worker.Worker {
 
 type FakeConfig struct {
 	agent.ConfigSetter
+	values map[string]string
 }
 
 func (FakeConfig) LogDir() string {
@@ -541,14 +542,22 @@ func (FakeConfig) Tag() names.Tag {
 	return names.NewMachineTag("42")
 }
 
+func (f FakeConfig) Value(key string) string {
+	if f.values == nil {
+		return ""
+	}
+	return f.values[key]
+}
+
 type FakeAgentConfig struct {
 	AgentConf
+	values map[string]string
 }
 
 func (FakeAgentConfig) ReadConfig(string) error { return nil }
 
-func (FakeAgentConfig) CurrentConfig() agent.Config {
-	return FakeConfig{}
+func (a FakeAgentConfig) CurrentConfig() agent.Config {
+	return FakeConfig{values: a.values}
 }
 
 func (FakeAgentConfig) ChangeConfig(mutate agent.ConfigMutator) error {


### PR DESCRIPTION
## Description of change

If there are many units in a model, it is not always desirable to enable debug mode for the entire model while attempting to resolve issues or work out why things aren't working. This branch introduces an agent config file option that allows overriding of the model logging config so a single agent can log at specified severity levels different to the model.

## QA steps

Bootstrap a model and deploy a unit.
SSH into the unit and edit the agent.conf file to specify
  LOGGING_OVERRIDE=juju=debug
In the values section.
Restart the agent
Observer the continued debug logging in juju debug-log.

## Documentation changes

Probably worth adding a section to the troubleshooting section of the docs.