### PR TITLE
cloud: add google/australia-southeast1

### DIFF
--- a/cloud/fallback-public-cloud.yaml
+++ b/cloud/fallback-public-cloud.yaml
@@ -66,6 +66,8 @@ clouds:
         endpoint: https://www.googleapis.com
       asia-southeast1:
         endpoint: https://www.googleapis.com
+      australia-southeast1:
+        endpoint: https://www.googleapis.com
   azure:
     type: azure
     description: Microsoft Azure

--- a/cloud/fallback_public_cloud.go
+++ b/cloud/fallback_public_cloud.go
@@ -73,6 +73,8 @@ clouds:
         endpoint: https://www.googleapis.com
       asia-southeast1:
         endpoint: https://www.googleapis.com
+      australia-southeast1:
+        endpoint: https://www.googleapis.com
   azure:
     type: azure
     description: Microsoft Azure

--- a/cmd/juju/cloud/regions_test.go
+++ b/cmd/juju/cloud/regions_test.go
@@ -109,6 +109,7 @@ europe-west1
 asia-east1
 asia-northeast1
 asia-southeast1
+australia-southeast1
 
 `[1:])
 }
@@ -131,6 +132,8 @@ asia-east1:
 asia-northeast1:
   endpoint: https://www.googleapis.com
 asia-southeast1:
+  endpoint: https://www.googleapis.com
+australia-southeast1:
   endpoint: https://www.googleapis.com
 `[1:])
 }


### PR DESCRIPTION
## Description of change

Add the new GCE Sydney region:
https://cloud.google.com/about/locations/sydney/

## QA steps

Can't use it until cloud-images has been updated:
https://bugs.launchpad.net/cloud-images/+bug/1699379

## Documentation changes

None.

## Bug reference

None.