### PR TITLE
Fixes lp#1698970: payloads validation moved to state

### DIFF
--- a/payload/context/register.go
+++ b/payload/context/register.go
@@ -64,9 +64,6 @@ func (c *RegisterCmd) Init(args []string) error {
 
 // Run implements cmd.Command.
 func (c *RegisterCmd) Run(ctx *cmd.Context) error {
-	if err := c.validate(ctx); err != nil {
-		return errors.Trace(err)
-	}
 	pl := payload.Payload{
 		PayloadClass: charm.PayloadClass{
 			Name: c.class,
@@ -93,26 +90,5 @@ func (c *RegisterCmd) Run(ctx *cmd.Context) error {
 
 	// TODO(ericsnow) Print out the full ID.
 
-	return nil
-}
-
-func (c *RegisterCmd) validate(ctx *cmd.Context) error {
-	meta, err := readMetadata(ctx)
-	if err != nil {
-		return errors.Trace(err)
-	}
-
-	found := false
-	for _, class := range meta.PayloadClasses {
-		if c.class == class.Name {
-			if c.typ != class.Type {
-				return errors.Errorf("incorrect type %q for payload %q, expected %q", c.typ, class.Name, class.Type)
-			}
-			found = true
-		}
-	}
-	if !found {
-		return errors.Errorf("payload %q not found in metadata.yaml", c.class)
-	}
 	return nil
 }

--- a/payload/context/register_test.go
+++ b/payload/context/register_test.go
@@ -87,24 +87,6 @@ func (s *registerSuite) TestRun(c *gc.C) {
 	// TODO (natefinch): we need to do something with the labels
 }
 
-func (s *registerSuite) TestRunUnknownClass(c *gc.C) {
-	err := s.command.Init([]string{"type", "badclass", "id"})
-	c.Assert(err, jc.ErrorIsNil)
-
-	ctx := setupMetadata(c)
-	err = s.command.Run(ctx)
-	c.Assert(err, gc.ErrorMatches, "payload \"badclass\" not found in metadata.yaml")
-}
-
-func (s *registerSuite) TestRunUnknownType(c *gc.C) {
-	err := s.command.Init([]string{"badtype", "class", "id"})
-	c.Assert(err, jc.ErrorIsNil)
-
-	ctx := setupMetadata(c)
-	err = s.command.Run(ctx)
-	c.Assert(err, gc.ErrorMatches, "incorrect type \"badtype\" for payload \"class\", expected \"type\"")
-}
-
 func (s *registerSuite) TestRunTrackErr(c *gc.C) {
 	s.hookCtx.trackerr = errors.Errorf("boo")
 	err := s.command.Init([]string{"type", "class", "id", "tag1", "tag 2"})

--- a/payload/context/status-set.go
+++ b/payload/context/status-set.go
@@ -6,8 +6,6 @@ package context
 import (
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
-
-	"github.com/juju/juju/payload"
 )
 
 // StatusSetCmdName is the name of the payload status-set command.
@@ -56,9 +54,6 @@ func (c *StatusSetCmd) Init(args []string) error {
 
 // Run implements cmd.Command.
 func (c *StatusSetCmd) Run(ctx *cmd.Context) error {
-	if err := c.validate(ctx); err != nil {
-		return errors.Trace(err)
-	}
 	hctx, err := c.hookContextFunc()
 	if err != nil {
 		return errors.Trace(err)
@@ -77,8 +72,4 @@ func (c *StatusSetCmd) Run(ctx *cmd.Context) error {
 	}
 
 	return nil
-}
-
-func (c *StatusSetCmd) validate(ctx *cmd.Context) error {
-	return payload.ValidateState(c.status)
 }

--- a/payload/context/status-set_test.go
+++ b/payload/context/status-set_test.go
@@ -82,13 +82,6 @@ func (s *statusSetSuite) TestTooFewArgs(c *gc.C) {
 	c.Check(err, gc.ErrorMatches, `missing .*`)
 }
 
-func (s *statusSetSuite) TestInvalidStatjs(c *gc.C) {
-	s.init(c, "docker", "foo", "created")
-	err := s.cmd.Run(s.ctx)
-
-	c.Check(err, gc.ErrorMatches, `status .* not supported; expected .*`)
-}
-
 func (s *statusSetSuite) TestStatusSet(c *gc.C) {
 	s.init(c, "docker", "foo", payload.StateStopped)
 	err := s.cmd.Run(s.ctx)

--- a/payload/context/utils.go
+++ b/payload/context/utils.go
@@ -4,12 +4,7 @@
 package context
 
 import (
-	"os"
-	"path/filepath"
-
-	"github.com/juju/cmd"
 	"github.com/juju/errors"
-	"gopkg.in/juju/charm.v6-unstable"
 )
 
 type componentHookFunction func() (Component, error)
@@ -23,19 +18,4 @@ func componentHookContext(ctx HookContext) componentHookFunction {
 		}
 		return compCtx, nil
 	}
-}
-
-func readMetadata(ctx *cmd.Context) (*charm.Meta, error) {
-	filename := filepath.Join(ctx.Dir, "metadata.yaml")
-	file, err := os.Open(filename)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	defer file.Close()
-	meta, err := charm.ReadMeta(file)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-
-	return meta, nil
 }

--- a/state/export_test.go
+++ b/state/export_test.go
@@ -63,6 +63,7 @@ var (
 	ModelGlobalKey                       = modelGlobalKey
 	MergeBindings                        = mergeBindings
 	UpgradeInProgressError               = errUpgradeInProgress
+	ValidPayloadForUnit                  = &checkPayloadClassForUnit
 )
 
 type (

--- a/state/migration_export_test.go
+++ b/state/migration_export_test.go
@@ -1125,6 +1125,10 @@ func (s *MigrationExportSuite) TestStoragePools(c *gc.C) {
 }
 
 func (s *MigrationExportSuite) TestPayloads(c *gc.C) {
+	s.PatchValue(state.ValidPayloadForUnit, func(unit *state.Unit, c, t string) error {
+		return nil
+	})
+
 	unit := s.Factory.MakeUnit(c, nil)
 	up, err := s.State.UnitPayloads(unit)
 	c.Assert(err, jc.ErrorIsNil)

--- a/state/migration_import_test.go
+++ b/state/migration_import_test.go
@@ -1259,6 +1259,10 @@ func (s *MigrationImportSuite) TestStoragePools(c *gc.C) {
 }
 
 func (s *MigrationImportSuite) TestPayloads(c *gc.C) {
+	s.PatchValue(state.ValidPayloadForUnit, func(unit *state.Unit, c, t string) error {
+		return nil
+	})
+
 	originalUnit := s.Factory.MakeUnit(c, nil)
 	unitID := originalUnit.UnitTag().Id()
 	up, err := s.State.UnitPayloads(originalUnit)

--- a/state/payloads.go
+++ b/state/payloads.go
@@ -43,15 +43,16 @@ func (st *State) UnitPayloads(unit *Unit) (UnitPayloads, error) {
 	}
 	return UnitPayloads{
 		db:      st.database,
-		unit:    unit.Name(),
+		unit:    unit,
 		machine: machineID,
 	}, nil
 }
 
 // UnitPayloads lets you CRUD payloads for a single unit.
 type UnitPayloads struct {
-	db      Database
-	unit    string
+	db Database
+
+	unit    *Unit
 	machine string
 }
 
@@ -65,10 +66,10 @@ func (up UnitPayloads) List(names ...string) ([]payload.Result, error) {
 	var sel bson.D
 	var out func([]payloadDoc) []payload.Result
 	if len(names) == 0 {
-		sel = nsPayloads.forUnit(up.unit)
+		sel = nsPayloads.forUnit(up.unit.Name())
 		out = nsPayloads.asResults
 	} else {
-		sel = nsPayloads.forUnitWithNames(up.unit, names)
+		sel = nsPayloads.forUnitWithNames(up.unit.Name(), names)
 		out = func(docs []payloadDoc) []payload.Result {
 			return nsPayloads.orderedResults(docs, names)
 		}
@@ -100,6 +101,7 @@ func (UnitPayloads) LookUp(name, rawID string) (string, error) {
 // is already in the DB then it is replaced.
 func (up UnitPayloads) Track(pl payload.Payload) error {
 
+	// anastasiamac: not sure why is this a problem if the unit is known here?...
 	// XXX OMFG payload/context/register.go:83 launches bad data
 	// which flies on a majestic unvalidated arc right through the
 	// system until it lands here. This code should be:
@@ -109,9 +111,15 @@ func (up UnitPayloads) Track(pl payload.Payload) error {
 	//    }
 	//
 	// ...but is instead:
-	pl.Unit = up.unit
+	pl.Unit = up.unit.Name()
 
+	// validate general payload correctness
 	if err := pl.Validate(); err != nil {
+		return errors.Trace(err)
+	}
+
+	// validate payload correctness for this charm
+	if err := checkPayloadClassForUnit(up.unit, pl.PayloadClass.Name, pl.PayloadClass.Type); err != nil {
 		return errors.Trace(err)
 	}
 
@@ -134,8 +142,13 @@ func (up UnitPayloads) SetStatus(name, status string) error {
 		return errors.Trace(err)
 	}
 
+	// validate payload correctness for this charm
+	if err := checkPayloadClassForUnit(up.unit, name, ""); err != nil {
+		return errors.Trace(err)
+	}
+
 	change := payloadSetStatusChange{
-		Unit:   up.unit,
+		Unit:   up.unit.Name(),
 		Name:   name,
 		Status: status,
 	}
@@ -150,12 +163,36 @@ func (up UnitPayloads) SetStatus(name, status string) error {
 // missing then this is a noop.
 func (up UnitPayloads) Untrack(name string) error {
 	logger.Tracef("untracking %q", name)
+
+	// validate payload correctness for this charm
+	if err := checkPayloadClassForUnit(up.unit, name, ""); err != nil {
+		return errors.Trace(err)
+	}
 	change := payloadUntrackChange{
-		Unit: up.unit,
+		Unit: up.unit.Name(),
 		Name: name,
 	}
 	if err := Apply(up.db, change); err != nil {
 		return errors.Trace(err)
+	}
+	return nil
+}
+
+var checkPayloadClassForUnit = validatePayloadClassForUnit
+
+func validatePayloadClassForUnit(unit *Unit, c, t string) error {
+	ch, err := unit.charm()
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	metaClass, found := ch.Meta().PayloadClasses[c]
+	if !found {
+		return errors.Errorf("payload %q not declared for unit %q", c, unit.Name())
+	}
+	if t != "" && t != metaClass.Type {
+		return errors.Errorf("incorrect type %q for payload %q, expected %q",
+			t, c, metaClass.Type)
 	}
 	return nil
 }


### PR DESCRIPTION
## Description of change

Payloads were validated too early in the process to ensure that valid data was persisted.
Also validation was done against metadata.yaml read from unit's machine rather than known unit charm.

This PR ensures that payloads' code is using established logic to get unit's charm metadata to avoid logic discrepancies. It also ensures that validation is done at better place to lower the risk of storing invalid data.

The most interesting validation code is in state/payload. The rest of the PR deals with unit tests as well as validation removal from payload/context package.

## QA steps
1. bootstrap
2. deploy a charm that uses payloads
3. use 'payload-register', 'payload-status-set' and 'payload-unregister' as previously 

## Documentation changes

N/A since this is an internal change only.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1698970
