### PR TITLE
worker/singular: translate ErrRefresh to ErrBounce

### DIFF
--- a/worker/singular/fixture_test.go
+++ b/worker/singular/fixture_test.go
@@ -112,6 +112,30 @@ func (facade *stubFacade) Wait() error {
 	return facade.stub.NextErr()
 }
 
+type stubWorker struct {
+	stub *testing.Stub
+}
+
+func newStubWorker(stub *testing.Stub) *stubWorker {
+	return &stubWorker{
+		stub: stub,
+	}
+}
+
+func (w *stubWorker) Check() bool {
+	w.stub.MethodCall(w, "Check")
+	return true
+}
+
+func (w *stubWorker) Kill() {
+	w.stub.MethodCall(w, "Kill")
+}
+
+func (w *stubWorker) Wait() error {
+	w.stub.MethodCall(w, "Wait")
+	return w.stub.NextErr()
+}
+
 var errClaimDenied = errors.Trace(lease.ErrClaimDenied)
 
 type mockAgent struct {

--- a/worker/singular/manifold.go
+++ b/worker/singular/manifold.go
@@ -63,7 +63,22 @@ func (config ManifoldConfig) start(context dependency.Context) (worker.Worker, e
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	return flag, nil
+	return wrappedWorker{flag}, nil
+}
+
+// wrappedWorker wraps a flag worker, translating ErrRefresh into
+// dependency.ErrBounce.
+type wrappedWorker struct {
+	worker.Worker
+}
+
+// Wait is part of the worker.Worker interface.
+func (w wrappedWorker) Wait() error {
+	err := w.Worker.Wait()
+	if err == ErrRefresh {
+		err = dependency.ErrBounce
+	}
+	return err
 }
 
 // Manifold returns a dependency.Manifold that will run a FlagWorker and
@@ -75,7 +90,12 @@ func Manifold(config ManifoldConfig) dependency.Manifold {
 			config.APICallerName,
 			config.AgentName,
 		},
-		Start:  config.start,
-		Output: engine.FlagOutput,
+		Start: config.start,
+		Output: func(in worker.Worker, out interface{}) error {
+			if w, ok := in.(wrappedWorker); ok {
+				in = w.Worker
+			}
+			return engine.FlagOutput(in, out)
+		},
 	}
 }


### PR DESCRIPTION
## Description of change

If the flag worker returns ErrRefresh, we should
translate to dependency.ErrBounce to bounce the
agent. Otherwise the agent is restarted anyway,
but we get unuseful error message that has no
action.

## QA steps

1. juju bootstrap localhost
2. juju enable-ha
3. stop machine-0 (lxc stop ...-0)
4. juju debug-log -m controller -l ERROR (will take a while for another machine to step up)
5. start machine-0 (lxc start ...-0)

There should be no error messages stating `"is-responsible-flag" manifold worker returned unexpected error: model responsibility unclear, please retry`

## Documentation changes

None.

## Bug reference

Fixes https://bugs.launchpad.net/juju/+bug/1696539