### PR TITLE
api: check before using pre-resolved address

### DIFF
--- a/api/apiclient_test.go
+++ b/api/apiclient_test.go
@@ -9,6 +9,8 @@ import (
 	"crypto/x509"
 	"fmt"
 	"net"
+	"net/http"
+	"net/http/httptest"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -17,6 +19,7 @@ import (
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils/clock"
+	proxyutils "github.com/juju/utils/proxy"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/names.v2"
 	"gopkg.in/juju/worker.v1"
@@ -35,6 +38,7 @@ import (
 	"github.com/juju/juju/rpc/jsoncodec"
 	"github.com/juju/juju/state"
 	jtesting "github.com/juju/juju/testing"
+	"github.com/juju/juju/utils/proxy"
 	jujuversion "github.com/juju/juju/version"
 )
 
@@ -84,6 +88,45 @@ func (s *apiclientSuite) TestDialAPIMultiple(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	conn.Close()
 	assertConnAddrForModel(c, location, serverAddr, s.State.ModelUUID())
+}
+
+func (s *apiclientSuite) TestDialAPIWithProxy(c *gc.C) {
+	info := s.APIInfo(c)
+	opts := api.DialOpts{IPAddrResolver: apitesting.IPAddrResolverMap{
+		"testing.invalid": {"0.1.1.1"},
+	}}
+	fakeAddr := "testing.invalid:1234"
+
+	// Confirm that the proxy configuration is used. See:
+	//     https://bugs.launchpad.net/juju/+bug/1698989
+	//
+	// TODO(axw) use github.com/elazarl/goproxy set up a real
+	// forward proxy, and confirm that we can dial a successful
+	// connection.
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "CONNECT" {
+			http.Error(w, fmt.Sprintf("invalid method %s", r.Method), http.StatusMethodNotAllowed)
+			return
+		}
+		if r.URL.Host != fakeAddr {
+			http.Error(w, fmt.Sprintf("unexpected host %s", r.URL.Host), http.StatusBadRequest)
+			return
+		}
+		http.Error(w, "🍵", http.StatusTeapot)
+	}
+	proxyServer := httptest.NewServer(http.HandlerFunc(handler))
+	defer proxyServer.Close()
+
+	err := proxy.DefaultConfig.Set(proxyutils.Settings{
+		Https: proxyServer.Listener.Addr().String(),
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	defer proxy.DefaultConfig.Set(proxyutils.Settings{})
+
+	// Check that we can use the proxy to connect.
+	info.Addrs = []string{fakeAddr}
+	_, _, err = api.DialAPI(info, opts)
+	c.Assert(err, gc.ErrorMatches, "unable to connect to API: I'm a teapot")
 }
 
 func (s *apiclientSuite) TestDialAPIMultipleError(c *gc.C) {


### PR DESCRIPTION
## Description of change

When dialing a websocket, check that the address
we're asked to dial is the same as the one that
we pre-resolved. It will not match when we're
using a proxy.

This is a short-term fix. If we should be doing
any client-side resolution at all, it should be
disabled when a proxy is to be used.

## QA steps

1. juju bootstrap localhost
2. `go get github.com/elazarl/goproxy`, then `go run` the following program:

```go
package main

import (
    "github.com/elazarl/goproxy"
    "log"
    "net/http"
)

func main() {
    proxy := goproxy.NewProxyHttpServer()
    proxy.Verbose = true
    log.Fatal(http.ListenAndServe(":8080", proxy))
}
```

3. export https_proxy=localhost:8080
4. juju status

## Documentation changes

None.

## Bug reference

Fixes https://bugs.launchpad.net/juju/+bug/1698989