### PR TITLE
enable-ha --to should ignore constraints and always land the new controller on provided machine

### DIFF
--- a/apiserver/highavailability/highavailability_test.go
+++ b/apiserver/highavailability/highavailability_test.go
@@ -226,7 +226,7 @@ func (s *clientSuite) TestBlockMakeHA(c *gc.C) {
 
 func (s *clientSuite) TestEnableHAPlacement(c *gc.C) {
 	placement := []string{"valid"}
-	enableHAResult, err := s.enableHA(c, 3, constraints.MustParse("mem=4G"), defaultSeries, placement)
+	enableHAResult, err := s.enableHA(c, 3, constraints.MustParse("mem=4G tags=foobar"), defaultSeries, placement)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(enableHAResult.Maintained, gc.DeepEquals, []string{"machine-0"})
 	c.Assert(enableHAResult.Added, gc.DeepEquals, []string{"machine-1", "machine-2"})
@@ -238,8 +238,8 @@ func (s *clientSuite) TestEnableHAPlacement(c *gc.C) {
 	c.Assert(machines, gc.HasLen, 3)
 	expectedCons := []constraints.Value{
 		controllerCons,
-		constraints.MustParse("mem=4G"),
-		constraints.MustParse("mem=4G"),
+		{},
+		constraints.MustParse("mem=4G tags=foobar"),
 	}
 	expectedPlacement := []string{"", "valid", ""}
 	for i, m := range machines {

--- a/state/addmachine.go
+++ b/state/addmachine.go
@@ -844,27 +844,28 @@ func (st *State) enableHAIntentionOps(
 	}
 	// Use any placement directives that have been provided
 	// when adding new machines, until the directives have
-	// been all used up. Set up a helper function to do the
-	// work required.
+	// been all used up. Ignore constraints for provided machines.
+	// Set up a helper function to do the work required.
 	placementCount := 0
-	getPlacement := func() string {
+	getPlacementConstraints := func() (string, constraints.Value) {
 		if placementCount >= len(intent.placement) {
-			return ""
+			return "", cons
 		}
 		result := intent.placement[placementCount]
 		placementCount++
-		return result
+		return result, constraints.Value{}
 	}
 	mdocs := make([]*machineDoc, intent.newCount)
 	for i := range mdocs {
+		placement, constraints := getPlacementConstraints()
 		template := MachineTemplate{
 			Series: series,
 			Jobs: []MachineJob{
 				JobHostUnits,
 				JobManageModel,
 			},
-			Constraints: cons,
-			Placement:   getPlacement(),
+			Constraints: constraints,
+			Placement:   placement,
 		}
 		mdoc, addOps, err := st.addMachineOps(template)
 		if err != nil {


### PR DESCRIPTION
## Description of change
--enable-ha --to machineX should ignore set or derived constraints and always land the new controller on provided machine

## QA steps
Test 1:
a) bootstrap on MAAS to machine1
b) --enable-ha -n 3 --to machine2 --constraints tags=foobarbaz (a non existing tag)
c) result - we should have 2 controllers running on machine1 and machine2, juju should complaint that it can't find a machine with tag foobarbaz

Test2:
a) bootstrap on MAAS to machine1
b) --enable-ha -n 3 --to machine_with_1G_RAM 
c) result - we should have 3 controllers, one on machine_with_1G_RAM 

## Documentation changes
None

## Bug reference
https://bugs.launchpad.net/juju/+bug/1684049