### PR TITLE
Always reload interfaces from MAAS when creating a container

### DIFF
--- a/provider/maas/maas2_environ_whitebox_test.go
+++ b/provider/maas/maas2_environ_whitebox_test.go
@@ -2098,7 +2098,7 @@ func (suite *maas2EnvironSuite) TestAllocateContainerRefusesReuseInvalidNIC(c *g
 				subnets: []gomaasapi.Subnet{subnet1},
 			},
 		},
-		// devices:      []gomaasapi.Device{device},
+		devices: []gomaasapi.Device{goodDevice},
 	}
 	suite.injectController(controller)
 	suite.setupFakeTools(c)


### PR DESCRIPTION
## Description of change
When multiple interfaces are created for a container we need to reload device structure for MAAS so that it's complete.

## QA steps
Create a MAAS machine with interfaces in two spaces, create a container on this machine with those two spaces, check that there are 2 interfaces in the container

## Documentation changes
None

## Bug reference
https://bugs.launchpad.net/juju/+bug/1698443