### PR TITLE
state: Upgrade step to correct relation unit counts in 2.2.1

### DIFF
--- a/state/upgrades.go
+++ b/state/upgrades.go
@@ -892,3 +892,130 @@ func SplitLogCollections(st *State) error {
 	}
 	return nil
 }
+
+type relationUnitCountInfo struct {
+	docId     string
+	endpoints set.Strings
+	unitCount int
+}
+
+// CorrectRelationUnitCounts ensures that there aren't any rows in
+// relationscopes for applications that shouldn't be there. Fix for
+// https://bugs.launchpad.net/juju/+bug/1699050
+func CorrectRelationUnitCounts(st *State) error {
+	relationsColl, rCloser := st.getRawCollection(relationsC)
+	defer rCloser()
+
+	scopesColl, sCloser := st.getRawCollection(relationScopesC)
+	defer sCloser()
+
+	relations, err := collectRelationInfo(relationsColl)
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	var ops []txn.Op
+	var scope struct {
+		DocId     string `bson:"_id"`
+		Key       string `bson:"key"`
+		ModelUUID string `bson:"model-uuid"`
+	}
+	relationsToUpdate := set.NewStrings()
+	iter := scopesColl.Find(nil).Iter()
+
+	for iter.Next(&scope) {
+		// Scope key looks like: r#<relation id>#[<principal unit for container scope>#]<role>#<unit>
+		keyParts := strings.Split(scope.Key, "#")
+		if len(keyParts) < 4 {
+			upgradesLogger.Errorf("malformed scope key %q", scope.Key)
+			continue
+		}
+
+		principalApp, found := extractPrincipalUnitApp(keyParts)
+		if !found {
+			// No change needed - this isn't a container scope.
+			continue
+		}
+		relationKey := scope.ModelUUID + ":" + keyParts[1]
+		relation, ok := relations[relationKey]
+		if !ok {
+			upgradesLogger.Errorf("orphaned relation scope %q", scope.DocId)
+			continue
+		}
+
+		if relation.endpoints.Contains(principalApp) {
+			// This scope record is fine - it's for an app that's in the relation.
+			continue
+		}
+
+		// This scope record needs to be removed and the unit count updated.
+		relation.unitCount--
+		relationsToUpdate.Add(relationKey)
+		ops = append(ops, txn.Op{
+			C:      relationScopesC,
+			Id:     scope.DocId,
+			Assert: txn.DocExists,
+			Remove: true,
+		})
+	}
+	if err := iter.Close(); err != nil {
+		return errors.Trace(err)
+	}
+
+	// Add in the updated unit counts.
+	for _, key := range relationsToUpdate.Values() {
+		relation := relations[key]
+		ops = append(ops, txn.Op{
+			C:      relationsC,
+			Id:     relation.docId,
+			Assert: txn.DocExists,
+			Update: bson.M{"$set": bson.M{"unitcount": relation.unitCount}},
+		})
+	}
+	if len(ops) > 0 {
+		return errors.Trace(st.runTransaction(ops))
+	}
+	return nil
+}
+
+func collectRelationInfo(coll *mgo.Collection) (map[string]*relationUnitCountInfo, error) {
+	relations := make(map[string]*relationUnitCountInfo)
+	var doc struct {
+		DocId     string   `bson:"_id"`
+		ModelUUID string   `bson:"model-uuid"`
+		Id        int      `bson:"id"`
+		UnitCount int      `bson:"unitcount"`
+		Endpoints []bson.M `bson:"endpoints"`
+	}
+
+	iter := coll.Find(nil).Iter()
+	for iter.Next(&doc) {
+		endpoints := set.NewStrings()
+		for _, epDoc := range doc.Endpoints {
+			appName, ok := epDoc["applicationname"].(string)
+			if !ok {
+				return nil, errors.Errorf("invalid application name: %v", epDoc["applicationname"])
+			}
+			endpoints.Add(appName)
+		}
+		key := fmt.Sprintf("%s:%d", doc.ModelUUID, doc.Id)
+		relations[key] = &relationUnitCountInfo{
+			docId:     doc.DocId,
+			endpoints: endpoints,
+			unitCount: doc.UnitCount,
+		}
+	}
+	if err := iter.Close(); err != nil {
+		return nil, errors.Trace(err)
+	}
+	return relations, nil
+}
+
+func extractPrincipalUnitApp(scopeKeyParts []string) (string, bool) {
+	if len(scopeKeyParts) < 5 {
+		return "", false
+	}
+	unitName := scopeKeyParts[2]
+	unitParts := strings.Split(unitName, "/")
+	return unitParts[0], true
+}

--- a/upgrades/backend.go
+++ b/upgrades/backend.go
@@ -31,6 +31,7 @@ type StateBackend interface {
 	AddStorageInstanceConstraints() error
 	SplitLogCollections() error
 	AddUpdateStatusHookSettings() error
+	CorrectRelationUnitCounts() error
 }
 
 // Model is an interface providing access to the details of a model within the
@@ -115,6 +116,10 @@ func (s stateBackend) AddStorageInstanceConstraints() error {
 
 func (s stateBackend) SplitLogCollections() error {
 	return state.SplitLogCollections(s.st)
+}
+
+func (s stateBackend) CorrectRelationUnitCounts() error {
+	return state.CorrectRelationUnitCounts(s.st)
 }
 
 type modelShim struct {

--- a/upgrades/steps_221.go
+++ b/upgrades/steps_221.go
@@ -13,5 +13,12 @@ func stateStepsFor221() []Step {
 				return context.State().AddUpdateStatusHookSettings()
 			},
 		},
+		&upgradeStep{
+			description: "correct relation unit counts for subordinates",
+			targets:     []Target{DatabaseMaster},
+			run: func(context Context) error {
+				return context.State().CorrectRelationUnitCounts()
+			},
+		},
 	}
 }

--- a/upgrades/steps_221_test.go
+++ b/upgrades/steps_221_test.go
@@ -25,3 +25,9 @@ func (s *steps221Suite) TestUpdateStatusHistoryHookSettings(c *gc.C) {
 	// Logic for step itself is tested in state package.
 	c.Assert(step.Targets(), jc.DeepEquals, []upgrades.Target{upgrades.DatabaseMaster})
 }
+
+func (s *steps221Suite) TestCorrectRelationUnitCounts(c *gc.C) {
+	step := findStateStep(c, v221, "correct relation unit counts for subordinates")
+	// Logic for step itself is tested in state package.
+	c.Assert(step.Targets(), jc.DeepEquals, []upgrades.Target{upgrades.DatabaseMaster})
+}


### PR DESCRIPTION
## Description of change

The subordinate unit handling fix in https://pad.lv/1686696 meant that
fewer units would enter the scope of a container-scoped relation. If a
model with subordinates related to more than one application was
upgraded from version 2.1 to 2.2, there would be records in
relationscopes for units that would never leave scope (since they were
no longer considered in scope for that relation). This meant that the
unit count of the relation would never reach 0, which in turn would
prevent the application from being removed.

Add an upgrade step to detect relationscopes rows that shouldn't be
present and remove them, updating the relation unit count to keep it
consistent.

## QA steps

* Bootstrap a 2.1.1 controller.
* Deploy the ubuntu charm twice as ubuntu and ubuntu2 apps, and ntp.
* Relate ntp to ubuntu and ubuntu2.
* Confirm in the DB that there are relationscopes records referring to ubuntu2 for the relation between ubuntu and ntp.
* Confirm that the unitcount for the ubuntu-ntp relation is 3, which is consistent with other information in the DB but incorrect.
* Upgrade the controller and model to the version including this PR (2.2.1)
* Confirm that the "correct unit counts" upgrade step message appears in the logs.
* Check in the DB that the unit count for the ubuntu-ntp relation is now 2, and that there aren't any ubuntu2 records in the relationscopes records for the ubuntu-ntp relation.
* Remove the ubuntu application - it should finish successfully.

## Bug reference

Fixes https://bugs.launchpad.net/juju/+bug/1699050
