### PR TITLE
Update deployDoc constant with description of 'application-name' form…

### DIFF
--- a/cmd/juju/application/deploy.go
+++ b/cmd/juju/application/deploy.go
@@ -336,7 +336,12 @@ For example:
   juju deploy /path/to/bundle/openstack/bundle.yaml
 
 If an 'application name' is not provided, the application name used is the
-'charm or bundle' name.
+'charm or bundle' name.  A user-supplied 'application name' must consist only of
+lower-case letters (a-z), numbers (0-9), and single hyphens (-).  The name must
+begin with a letter and not have a group of all numbers follow a hyphen.
+Examples:
+  Valid:   myappname, custom-app, app2-scat-23skidoo
+  Invalid: myAppName, custom--app, app2-scat-23, areacode-555-info
 
 Constraints can be specified by specifying the '--constraints' option. If the
 application is later scaled out with ` + "`juju add-unit`" + `, provisioned machines


### PR DESCRIPTION
…at restrictions

## Please provide the following details to expedite Pull Request review:

----

## Description of change

Why is this change needed?
Fixes https://bugs.launchpad.net/juju/+bug/1693588.  Insufficient description of format restrictions on user-supplied 'application-name' on 'juju help deploy'


## QA steps

How do we verify that the change works?
"juju help deploy" should show expanded description of 'application-name'


## Documentation changes

Does it affect current user workflow? No  CLI? No  API? No


## Bug reference

Does this change fix a bug? Please add a link to it.
https://bugs.launchpad.net/juju/+bug/1693588
