### PR TITLE
Ensure test works on windows as well

### DIFF
--- a/cmd/juju/model/defaultscommand_test.go
+++ b/cmd/juju/model/defaultscommand_test.go
@@ -192,7 +192,7 @@ func (s *DefaultsCommandSuite) TestDefaultsInit(c *gc.C) {
 	}, {
 		description: "test invalid positional args with set",
 		args:        []string{"a=b", "b", "c=d"},
-		errorMatch:  `.*no such file or directory`,
+		errorMatch:  `.*(no such file or directory|cannot find the file specified).*`,
 	}, {
 		description: "test invalid positional args with set and trailing key",
 		args:        []string{"a=b", "c=d", "e"},


### PR DESCRIPTION
## Description of change

DefaultsCommandSuite.TestDefaultsInit failed on Windows due to an error msg regexp not matching.

## QA steps

Run the unit tests on Windows/Linux.
