### PR TITLE
upgrades: Make fix-unitcount upgrade step run across models

### DIFF
--- a/state/upgrades.go
+++ b/state/upgrades.go
@@ -973,7 +973,7 @@ func CorrectRelationUnitCounts(st *State) error {
 		})
 	}
 	if len(ops) > 0 {
-		return errors.Trace(st.runTransaction(ops))
+		return errors.Trace(st.runRawTransaction(ops))
 	}
 	return nil
 }

--- a/state/upgrades_test.go
+++ b/state/upgrades_test.go
@@ -1487,7 +1487,12 @@ func (s *upgradesSuite) TestCorrectRelationUnitCounts(c *gc.C) {
 	scopes, sCloser := s.state.getRawCollection(relationScopesC)
 	defer sCloser()
 
-	uuid := s.state.ModelUUID()
+	// Use the non-controller model to ensure we can run the function
+	// across multiple models.
+	otherState := s.makeModel(c, "crack-up", testing.Attrs{})
+	defer otherState.Close()
+
+	uuid := otherState.ModelUUID()
 
 	err := relations.Insert(bson.M{
 		"_id":        uuid + ":min:juju-info nrpe:general-info",


### PR DESCRIPTION
## Description of change

The upgrade step in #7536  passed unit tests because the DB records 
were in the same model as the state used to run the upgrade. Change the 
test to use a separate model, and the code to use runRawTransaction 
(which avoids the model uuid mangling).

## QA steps
Same as the steps for #7536.

## Bug reference
Fixes https://bugs.launchpad.net/juju/+bug/1699050