### PR TITLE
apiserver/uniter: Ignore EnterScope with invalid principals

### DIFF
--- a/apiserver/uniter/uniter.go
+++ b/apiserver/uniter/uniter.go
@@ -1035,7 +1035,16 @@ func (u *UniterAPI) EnterScope(args params.RelationUnits) (params.ErrorResults, 
 			return err
 		}
 		relUnit, err := rel.Unit(unit)
-		if err != nil {
+		if state.IsInvalidPrincipalError(err) {
+			// This error indicates that the agent asked to EnterScope
+			// for a unit whose principal isn't a participant in the
+			// relation. These should be ignored for backwards
+			// compatibility reasons - see
+			// https://bugs.launchpad.net/juju/+bug/1699050 for
+			// details.
+			logger.Debugf("ignoring EnterScope for %q: %s", unitTag.Id(), err)
+			return nil
+		} else if err != nil {
 			return err
 		}
 

--- a/state/errors.go
+++ b/state/errors.go
@@ -134,3 +134,38 @@ func IsParentDeviceHasChildrenError(err interface{}) bool {
 	_, ok := value.(*ErrParentDeviceHasChildren)
 	return ok
 }
+
+// ErrInvalidPrincipal is raised when we try to create a relation unit
+// where the unit's principal application isn't a member of the
+// relation.
+type ErrInvalidPrincipal struct {
+	principalName string
+	relationKey   string
+}
+
+func (e *ErrInvalidPrincipal) Error() string {
+	return fmt.Sprintf("principal %q is not a member of %q", e.principalName, e.relationKey)
+}
+
+func newInvalidPrincipalError(principalName, relationKey string) error {
+	return &ErrInvalidPrincipal{
+		principalName: principalName,
+		relationKey:   relationKey,
+	}
+}
+
+// IsInvalidPrincipalError returns whether the given error or its
+// cause is ErrInvalidPrincipal.
+func IsInvalidPrincipalError(err interface{}) bool {
+	if err == nil {
+		return false
+	}
+	// In case of a wrapped error, check the cause first.
+	value := err
+	cause := errors.Cause(err.(error))
+	if cause != nil {
+		value = cause
+	}
+	_, ok := value.(*ErrInvalidPrincipal)
+	return ok
+}

--- a/state/relation.go
+++ b/state/relation.go
@@ -378,11 +378,11 @@ func (r *Relation) unit(
 	isPrincipal bool,
 	checkUnitLife bool,
 ) (*RelationUnit, error) {
-	serviceName, err := names.UnitApplication(unitName)
+	appName, err := names.UnitApplication(unitName)
 	if err != nil {
 		return nil, err
 	}
-	ep, err := r.Endpoint(serviceName)
+	ep, err := r.Endpoint(appName)
 	if err != nil {
 		return nil, err
 	}
@@ -391,6 +391,17 @@ func (r *Relation) unit(
 		container := principal
 		if container == "" {
 			container = unitName
+		} else {
+			// Ensure the principal is in this relation.
+			principalAppName, err := names.UnitApplication(container)
+			if err != nil {
+				return nil, errors.Trace(err)
+			}
+			_, err = r.Endpoint(principalAppName)
+			if err != nil {
+				return nil, errors.Wrap(
+					err, newInvalidPrincipalError(container, r.String()))
+			}
 		}
 		scope = fmt.Sprintf("%s#%s", scope, container)
 	}


### PR DESCRIPTION
## Description of change
If an uniter for a subordinate unit requests to EnterScope for a
relation that isn't valid because its principal isn't a member of the
relation, we ignore it. This is needed for clean upgrading from 2.1 to
2.2.1 - there's an upgrade step that corrects unitcounts and invalid
relationscope records, but without this change the agents will re-enter
the scopes incorrectly when they reconnect to the controller (because we
don't get a chance to upgrade them first).

## QA steps

* Bootstrap a 2.1.1 controller.
* Deploy the ubuntu charm twice as ubuntu and ubuntu2 apps, and ntp.
* Relate ntp to ubuntu and ubuntu2.
* Confirm in the DB that there are relationscopes records referring to ubuntu2 for the relation between ubuntu and ntp.
* Confirm that the unitcount for the ubuntu-ntp relation is 3, which is consistent with other information in the DB but incorrect.
* Upgrade the controller and model to the version including this PR (2.2.1)
* Confirm that the "correct unit counts" upgrade step message appears in the logs.
* Check in the DB that the unit count for the ubuntu-ntp relation is now 2, and that there aren't any ubuntu2 records in the relationscopes records for the ubuntu-ntp relation.
* Remove the ubuntu application - it should finish successfully.

## Bug reference

Actually fixes https://bugs.launchpad.net/juju/+bug/1699050
