### PR TITLE
Update CLI for debug-log to handle machines, units, and applications

### DIFF
--- a/cmd/juju/commands/debuglog_test.go
+++ b/cmd/juju/commands/debuglog_test.go
@@ -49,16 +49,32 @@ func (s *DebugLogSuite) TestArgParsing(c *gc.C) {
 				Level:   loggo.INFO,
 			},
 		}, {
-			args: []string{"--include", "machine-1", "-i", "machine-2"},
+			args: []string{
+				"--include", "machine-1",
+				"-i", "2",
+				"--include", "unit-foo-2",
+				"-i", "foo/3",
+				"--include", "bar"},
 			expected: common.DebugLogParams{
-				IncludeEntity: []string{"machine-1", "machine-2"},
-				Backlog:       10,
+				IncludeEntity: []string{
+					"machine-1", "machine-2",
+					"unit-foo-2", "unit-foo-3",
+					"unit-bar-*"},
+				Backlog: 10,
 			},
 		}, {
-			args: []string{"--exclude", "machine-1", "-x", "machine-2"},
+			args: []string{
+				"--exclude", "machine-1",
+				"-x", "2",
+				"--exclude", "unit-foo-2",
+				"-x", "foo/3",
+				"--exclude", "bar"},
 			expected: common.DebugLogParams{
-				ExcludeEntity: []string{"machine-1", "machine-2"},
-				Backlog:       10,
+				ExcludeEntity: []string{
+					"machine-1", "machine-2",
+					"unit-foo-2", "unit-foo-3",
+					"unit-bar-*"},
+				Backlog: 10,
 			},
 		}, {
 			args: []string{"--include-module", "juju.foo", "--include-module", "unit"},


### PR DESCRIPTION
## Description of change

The --include and --exclude options for debug-log can now take machines, units, or applications.

## QA steps

Bootstrap a controller, deploy two different ubuntu units.

juju debug-log -i ubuntu
juju debug-log -i 1
juju debug-log -i ubuntu/1

## Documentation changes

The debug-log section should be updated for the entity specification.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1576851
