### PR TITLE
Merge pull request #7507 from rogpeppe/167-api-open-login-timeout

### DIFF
--- a/api/apiclient.go
+++ b/api/apiclient.go
@@ -185,7 +185,13 @@ func Open(info *Info, opts DialOpts) (Connection, error) {
 	if opts.Clock == nil {
 		opts.Clock = clock.WallClock
 	}
-	dialResult, err := dialAPI(info, opts)
+	ctx := context.TODO()
+	if opts.Timeout > 0 {
+		ctx1, cancel := utils.ContextWithTimeout(ctx, opts.Clock, opts.Timeout)
+		defer cancel()
+		ctx = ctx1
+	}
+	dialResult, err := dialAPI(ctx, info, opts)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -240,7 +246,7 @@ func Open(info *Info, opts DialOpts) (Connection, error) {
 		modelTag:     info.ModelTag,
 	}
 	if !info.SkipLogin {
-		if err := st.Login(info.Tag, info.Password, info.Nonce, info.Macaroons); err != nil {
+		if err := loginWithContext(ctx, st, info); err != nil {
 			dialResult.conn.Close()
 			return nil, errors.Trace(err)
 		}
@@ -259,6 +265,23 @@ func Open(info *Info, opts DialOpts) (Connection, error) {
 		broken:      st.broken,
 	}).run()
 	return st, nil
+}
+
+// loginWithContext wraps st.Login with code that terminates
+// if the context is cancelled.
+// TODO(rogpeppe) pass Context into Login (and all API calls) so
+// that this becomes unnecessary.
+func loginWithContext(ctx context.Context, st *state, info *Info) error {
+	result := make(chan error, 1)
+	go func() {
+		result <- st.Login(info.Tag, info.Password, info.Nonce, info.Macaroons)
+	}()
+	select {
+	case err := <-result:
+		return errors.Trace(err)
+	case <-ctx.Done():
+		return errors.Annotatef(ctx.Err(), "cannot log in")
+	}
 }
 
 type NewConnectionForModelFunc func(*Info) (func(string) (Connection, error), error)
@@ -549,7 +572,7 @@ type dialOpts struct {
 // connection wins.
 //
 // It also returns the TLS configuration that it has derived from the Info.
-func dialAPI(info *Info, opts0 DialOpts) (*dialResult, error) {
+func dialAPI(ctx context.Context, info *Info, opts0 DialOpts) (*dialResult, error) {
 	if len(info.Addrs) == 0 {
 		return nil, errors.New("no API addresses to connect to")
 	}
@@ -578,15 +601,6 @@ func dialAPI(info *Info, opts0 DialOpts) (*dialResult, error) {
 	if opts.DNSCache == nil {
 		opts.DNSCache = nopDNSCache{}
 	}
-	// TODO(rogpeppe) Pass a context with an existing deadline into dialAPI.
-	// We're avoiding that for the moment because it will break
-	// lots of tests that rely on passing a zero timeout into
-	// DialOpts.
-	ctx := context.TODO()
-	opts.deadline = opts.Clock.Now().Add(opts.Timeout)
-	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
-
 	path, err := apiPath(info.ModelTag, "/api")
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -750,15 +764,23 @@ func recordTryError(try *parallel.Try, err error) {
 	})
 }
 
+var oneAttempt = retry.LimitCount(1, retry.Regular{
+	Min: 1,
+})
+
 // startDialWebsocket starts websocket connection to a single address
 // on the given try instance.
 func startDialWebsocket(ctx context.Context, try *parallel.Try, ipAddr, addr, path string, opts dialOpts) error {
-	openAttempt := retry.Regular{
-		Total: opts.Timeout,
-		Delay: opts.RetryDelay,
-	}
-	if openAttempt.Min == 0 && openAttempt.Delay > 0 {
-		openAttempt.Min = int(openAttempt.Total / openAttempt.Delay)
+	var openAttempt retry.Strategy
+	if opts.RetryDelay > 0 {
+		openAttempt = retry.Regular{
+			Total: opts.Timeout,
+			Delay: opts.RetryDelay,
+			Min:   int(opts.Timeout / opts.RetryDelay),
+		}
+	} else {
+		// Zero retry delay implies exactly one try.
+		openAttempt = oneAttempt
 	}
 	d := dialer{
 		ctx:         ctx,

--- a/api/export_test.go
+++ b/api/export_test.go
@@ -4,6 +4,7 @@
 package api
 
 import (
+	"context"
 	"net/url"
 
 	"github.com/juju/errors"
@@ -26,7 +27,7 @@ var (
 )
 
 func DialAPI(info *Info, opts DialOpts) (jsoncodec.JSONConn, string, error) {
-	result, err := dialAPI(info, opts)
+	result, err := dialAPI(context.TODO(), info, opts)
 	if err != nil {
 		return nil, "", err
 	}

--- a/api/interface.go
+++ b/api/interface.go
@@ -124,12 +124,13 @@ type DialOpts struct {
 	// before starting to dial another address.
 	DialAddressInterval time.Duration
 
-	// Timeout is the amount of time to wait contacting
-	// a controller.
+	// Timeout is the amount of time to wait for
+	// the api.Open to succeed. If this is zero, there is no timeout.
 	Timeout time.Duration
 
 	// RetryDelay is the amount of time to wait between
-	// unsuccessful connection attempts.
+	// unsuccessful connection attempts. If this is
+	// zero, only one attempt will be made.
 	RetryDelay time.Duration
 
 	// BakeryClient is the httpbakery Client, which

--- a/api/pubsub/pubsub_test.go
+++ b/api/pubsub/pubsub_test.go
@@ -162,11 +162,6 @@ func (s *PubSubIntegrationSuite) SetUpTest(c *gc.C) {
 }
 
 func (s *PubSubIntegrationSuite) connect(c *gc.C) apipubsub.MessageWriter {
-	dialOpts := api.DialOpts{
-		DialAddressInterval: 20 * time.Millisecond,
-		Timeout:             50 * time.Millisecond,
-		RetryDelay:          50 * time.Millisecond,
-	}
 	info := &api.Info{
 		Addrs:    []string{s.address},
 		CACert:   coretesting.CACert,
@@ -175,7 +170,7 @@ func (s *PubSubIntegrationSuite) connect(c *gc.C) apipubsub.MessageWriter {
 		Password: s.password,
 		Nonce:    s.nonce,
 	}
-	conn, err := api.Open(info, dialOpts)
+	conn, err := api.Open(info, api.DialOpts{})
 	c.Assert(err, jc.ErrorIsNil)
 	s.AddCleanup(func(_ *gc.C) { conn.Close() })
 

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -34,7 +34,7 @@ github.com/juju/httpprof	git	14bf14c307672fd2456bdbf35d19cf0ccd3cf565	2014-12-17
 github.com/juju/httprequest	git	266fd1e9debf09c037a63f074d099a2da4559ece	2016-10-06T15:09:09Z
 github.com/juju/idmclient	git	4dc25171f675da4206b71695d3fd80e519ad05c1	2017-02-09T16:27:49Z
 github.com/juju/jsonschema	git	a0ef8b74ebcffeeff9fc374854deb4af388f037e	2016-11-02T18:19:19Z
-github.com/juju/loggo	git	21bc4c63e8b435779a080e39e592969b7b90b889	2017-02-22T12:20:47Z
+github.com/juju/loggo	git	8232ab8918d91c72af1a9fb94d3edbe31d88b790	2017-06-05T01:46:07Z
 github.com/juju/mempool	git	24974d6c264fe5a29716e7d56ea24c4bd904b7cc	2016-02-05T10:49:27Z
 github.com/juju/mutex	git	59c26ee163447c5c57f63ff71610d433862013de	2016-06-17T01:09:07Z
 github.com/juju/persistent-cookiejar	git	d67418f14c93a698e37b52468958d5d4dcf8a7dd	2017-04-28T16:15:59Z
@@ -49,7 +49,7 @@ github.com/juju/terms-client	git	9b925afd677234e4146dde3cb1a11e187cbed64e	2016-0
 github.com/juju/testing	git	2fe0e88cf2321d801acedd2b4f0d7f63735fb732	2017-06-08T05:44:51Z
 github.com/juju/txn	git	dbb63c620814d1a0f96260f4cad3e2cca14f702b	2017-06-13T23:44:54Z
 github.com/juju/usso	git	68a59c96c178fbbad65926e7f93db50a2cd14f33	2016-04-01T10:44:24Z
-github.com/juju/utils	git	61a75f1933a523d7f9d38bc5b1bf2010f1c157c3	2017-06-07T09:20:57Z
+github.com/juju/utils	git	08502f040bb5dc1b256f206f1780079610316f66	2017-06-16T07:58:09Z
 github.com/juju/version	git	1f41e27e54f21acccf9b2dddae063a782a8a7ceb	2016-10-31T05:19:06Z
 github.com/juju/webbrowser	git	54b8c57083b4afb7dc75da7f13e2967b2606a507	2016-03-09T14:36:29Z
 github.com/juju/xml	git	eb759a627588d35166bc505fceb51b88500e291e	2015-04-13T13:11:21Z


### PR DESCRIPTION
api: impose stricter deadline on api.Open

Currently if you call api.Open with a given timeout,
it might exceed that timeout if the connect succeeds
but (for whatever reason) the Login API call doesn't return.

This PR imposes the timeout on the login too, so clients
that care can be more sure that the api.Open will actually
return soon after a timeout.

To avoid changing the useful semantic (relied on by many tests)
that the zero DialOpts will log in without any particular timeout,
we change the semantics slightly, such that a zero timeout
means no timeout and a zero RetryDelay means "don't retry",
which means that the zero DialOpts means pretty much what
it currently means.

QA no regressions. This should not affect normal behaviour.

## Please provide the following details to expedite Pull Request review:

----

## Description of change

Why is this change needed?

## QA steps

How do we verify that the change works?

## Documentation changes

Does it affect current user workflow? CLI? API?

## Bug reference

Does this change fix a bug? Please add a link to it.
