### PR TITLE
apiserver/uniter: Ignore EnterScope from invalid units

### DIFF
--- a/apiserver/uniter/uniter.go
+++ b/apiserver/uniter/uniter.go
@@ -1039,6 +1039,17 @@ func (u *UniterAPI) EnterScope(args params.RelationUnits) (params.ErrorResults, 
 			return err
 		}
 
+		valid, err := relUnit.Valid()
+		if err != nil {
+			return err
+		}
+		if !valid {
+			principalName, _ := unit.PrincipalName()
+			logger.Debugf("ignoring %q EnterScope for %q - unit has invalid principal %q",
+				unit.Name(), rel.String(), principalName)
+			return nil
+		}
+
 		settings := map[string]interface{}{}
 		settingsAddress, err := relUnit.SettingsAddress()
 		if err == nil {


### PR DESCRIPTION
## Description of change

If we see a request to EnterScope where the unit's principal isn't in
the relation specified, we log and ignore it. These requests can happen
when a controller is upgraded from 2.1 to 2.2, and the model has a 
subordinate application related to multiple principals - the uniter used to think
that those units should be in the relation, but they shouldn't, and
allowing them to enter scope will prevent the application from being
removed because its relations don't go away (since they have units in
scope that never leave).

Ignore the requests to prevent the old uniters from crashing with an
error, which would prevent upgrading them.
Alternative implementation of #7542, with the check for validity of the relation unit being
opt-in rather than raising an error on construction - there are at least 3 or 4 places in the
code that create potentially-invalid `RelationUnit`s to query `InScope` or `Joined`, and
this was a simpler fix to avoid breaking them.

## QA steps

* Bootstrap a 2.1.1 controller.
* Deploy the ubuntu charm twice as ubuntu and ubuntu2 apps, and ntp.
* Relate ntp to ubuntu and ubuntu2.
* Confirm in the DB that there are relationscopes records referring to ubuntu2 for the relation between ubuntu and ntp.
* Confirm that the unitcount for the ubuntu-ntp relation is 3, which is consistent with other information in the DB but incorrect.
* Upgrade the controller and model to the version including this PR (2.2.1)
* Confirm that the "correct unit counts" upgrade step message appears in the logs.
* Check in the DB that the unit count for the ubuntu-ntp relation is now 2, and that there aren't any ubuntu2 records in the relationscopes records for the ubuntu-ntp relation.
* Observe "ignoring <unit> EnterScope" messages in the controller log indicating that the uniter tried to re-enter the invalid unit.
* Remove the ubuntu application - it should finish successfully.

## Bug reference

Really fixes https://bugs.launchpad.net/juju/+bug/1699050
