### PR TITLE
Fix bug lp#1694734

### DIFF
--- a/worker/uniter/actions/resolver_test.go
+++ b/worker/uniter/actions/resolver_test.go
@@ -72,6 +72,44 @@ func (s *actionsSuite) TestNextAction(c *gc.C) {
 	c.Assert(op, jc.DeepEquals, mockOp("actionB"))
 }
 
+func (s *actionsSuite) TestActionStateKindRunAction(c *gc.C) {
+	actionResolver := actions.NewResolver()
+	var actionA string = "actionA"
+
+	localState := resolver.LocalState{
+		State: operation.State{
+			Kind:     operation.RunAction,
+			ActionId: &actionA,
+		},
+		CompletedActions: map[string]struct{}{},
+	}
+	remoteState := remotestate.Snapshot{
+		Actions: []string{},
+	}
+	op, err := actionResolver.NextOp(localState, remoteState, &mockOperations{})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(op, jc.DeepEquals, mockOp("actionA"))
+}
+
+func (s *actionsSuite) TestActionStateKindRunActionPendingRemote(c *gc.C) {
+	actionResolver := actions.NewResolver()
+	var actionA string = "actionA"
+
+	localState := resolver.LocalState{
+		State: operation.State{
+			Kind:     operation.RunAction,
+			ActionId: &actionA,
+		},
+		CompletedActions: map[string]struct{}{},
+	}
+	remoteState := remotestate.Snapshot{
+		Actions: []string{"actionA", "actionB"},
+	}
+	op, err := actionResolver.NextOp(localState, remoteState, &mockOperations{})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(op, jc.DeepEquals, mockFailAction("actionA"))
+}
+
 type mockOperations struct {
 	operation.Factory
 }
@@ -80,8 +118,16 @@ func (m *mockOperations) NewAction(id string) (operation.Operation, error) {
 	return mockOp(id), nil
 }
 
+func (m *mockOperations) NewFailAction(id string) (operation.Operation, error) {
+	return mockFailAction(id), nil
+}
+
 func mockOp(name string) operation.Operation {
 	return &mockOperation{name: name}
+}
+
+func mockFailAction(name string) operation.Operation {
+	return &mockFailOp{name: name}
 }
 
 type mockOperation struct {
@@ -90,5 +136,14 @@ type mockOperation struct {
 }
 
 func (op *mockOperation) String() string {
+	return op.name
+}
+
+type mockFailOp struct {
+	operation.Operation
+	name string
+}
+
+func (op *mockFailOp) String() string {
 	return op.name
 }


### PR DESCRIPTION
## Description of change

**Why is this change needed?**

Fixes the referenced bug.

In a nutshell, if the `uniter` was to crash while running an action, upon restart it would attempt to fail that action, regardless of what the `controller` thought. This was bad since the `controller` does not allow the failure of arbitrary actions (only pending ones) and thus the `controller` would deny the `uniter's` failure request for actions that it considered to be finished. This would cause the uniter to spin in a never ending loop of failure request retries. A `juju run "reboot"` was a good way to potentially jam up the `uniter` in this fashion. 

**How do we verify that the change works?**

It is difficult to verify this bug from the CLI since invoking its cause does not always lead to the error. It is quite non-deterministic. Concretely, running `juju run "reboot"` may cause the issue to arise or may not. However, changing the code in such a way that the `uniter` "crashes" at specific points in its operation is a good way to flex the error and thus test the solution. Read on...

Add the following code immediately before the `uniter` writes to its local state after executing an operation (action). At this PR's proposed commit point the line should be https://github.com/juju/juju/blob/develop/worker/uniter/operation/executor.go#L103

```
  if step.verb == "executing" && x.state.Kind == RunAction {
     panic("stopping uniter before writing")
  }
```

This will crash the `uniter` when running an action. The `uniter` should restart, realize that it shutdown while running an action, and move back into a normal state of operation, no longer wanting to run the action that it was running when it crashed.

You may want to crash the `uniter` after it begins running an action but before it updates the `controller's` state. To do this you can put a panic in the appropriate spot in the code. Upon restart, the `uniter` should recover from this too without attempting to again run the action in question and move into a normal waiting state.

In summary, deploy a simple service:

```
juju deploy ubuntu
```

make one of the code changes above (which help to reproduce the bug's error condition) and then run an action (try the other code change afterwards):

``` 
juju run "ls -la" --unit=ubuntu/0
```

This will simulate a hard stop of the uniter in a places that will cause the referenced bug's error. It will show that the `uniter` is now able to recover from such conditions.

**Does it affect current user workflow? CLI? API?**
No

## Bug reference
[lp#1694734](https://bugs.launchpad.net/juju/+bug/1694734)