### PR TITLE
Firewaller worker on offering model opens ingress holes in firewall

### DIFF
--- a/apiserver/common/crossmodel/crossmodel.go
+++ b/apiserver/common/crossmodel/crossmodel.go
@@ -202,15 +202,7 @@ func PublishIngressNetworkChange(backend Backend, change params.IngressNetworksC
 		return errors.Trace(err)
 	}
 
-	// Look up the application on the remote side of this relation
-	// ie from the model which published this change.
-	applicationTag, err := getRemoteEntityTag(backend, change.ApplicationId)
-	if err != nil {
-		return errors.Trace(err)
-	}
-	logger.Debugf("application tag for remote id %+v is %v", change.ApplicationId, applicationTag)
-
-	// TODO(wallyworld) - record this info in the model so firewaller can see it.
-	logger.Infof("rel %v has networks %v", rel, change.Networks)
-	return nil
+	logger.Debugf("relation %v requires ingress networks %v", rel, change.Networks)
+	_, err = backend.SaveIngressNetworks(rel.Tag().Id(), change.Networks)
+	return err
 }

--- a/apiserver/common/crossmodel/interface.go
+++ b/apiserver/common/crossmodel/interface.go
@@ -48,6 +48,9 @@ type Backend interface {
 	// ImportRemoteEntity adds an entity to the remote entities collection
 	// with the specified opaque token.
 	ImportRemoteEntity(sourceModel names.ModelTag, entity names.Tag, token string) error
+
+	// SaveIngressNetworks stores in state the ingress networks for the relation.
+	SaveIngressNetworks(relationKey string, cidrs []string) (RelationIngress, error)
 }
 
 // Relation provides access a relation in global state.

--- a/apiserver/common/crossmodel/state.go
+++ b/apiserver/common/crossmodel/state.go
@@ -90,6 +90,13 @@ func (st stateShim) ImportRemoteEntity(model names.ModelTag, entity names.Tag, t
 	return r.ImportRemoteEntity(model, entity, token)
 }
 
+type RelationIngress state.RelationIngress
+
+func (s stateShim) SaveIngressNetworks(relationKey string, cidrs []string) (RelationIngress, error) {
+	api := state.NewRelationIngressNetworks(s.State)
+	return api.Save(relationKey, cidrs)
+}
+
 type relationShim struct {
 	*state.Relation
 	st *state.State

--- a/apiserver/crossmodelrelations/mock_test.go
+++ b/apiserver/crossmodelrelations/mock_test.go
@@ -11,6 +11,7 @@ import (
 	"gopkg.in/juju/names.v2"
 
 	common "github.com/juju/juju/apiserver/common/crossmodel"
+	"github.com/juju/juju/apiserver/crossmodelrelations"
 	"github.com/juju/juju/core/crossmodel"
 	"github.com/juju/juju/state"
 	coretesting "github.com/juju/juju/testing"
@@ -18,6 +19,7 @@ import (
 
 type mockState struct {
 	testing.Stub
+	crossmodelrelations.CrossModelRelationsState
 	relations          map[string]*mockRelation
 	remoteApplications map[string]*mockRemoteApplication
 	applications       map[string]*mockApplication

--- a/apiserver/firewaller/mock_test.go
+++ b/apiserver/firewaller/mock_test.go
@@ -223,6 +223,12 @@ func (r *mockRelation) UnitInScope(u firewaller.Unit) (bool, error) {
 	return r.inScope.Contains(u.Name()), nil
 }
 
+func (r *mockRelation) WatchRelationIngressNetworks() state.StringsWatcher {
+	w := newMockStringsWatcher()
+	w.changes <- []string{"1.2.3.4/32"}
+	return w
+}
+
 func newMockRelationUnitsWatcher() *mockRelationUnitsWatcher {
 	w := &mockRelationUnitsWatcher{changes: make(chan params.RelationUnitsChange, 1)}
 	go w.doneWhenDying()

--- a/apiserver/firewaller/state.go
+++ b/apiserver/firewaller/state.go
@@ -62,6 +62,7 @@ type Relation interface {
 	Endpoints() []state.Endpoint
 	WatchUnits(applicationName string) (state.RelationUnitsWatcher, error)
 	UnitInScope(Unit) (bool, error)
+	WatchRelationIngressNetworks() state.StringsWatcher
 }
 
 type relationShim struct {

--- a/state/allcollections.go
+++ b/state/allcollections.go
@@ -439,6 +439,8 @@ func allCollections() collectionSchema {
 			externalControllersC: {
 				global: true,
 			},
+			// relationIngressC holds required ingress cidrs for remote relations.
+			relationIngressC: {},
 		} {
 			result[name] = details
 		}
@@ -533,4 +535,5 @@ const (
 	remoteEntitiesC      = "remoteEntities"
 	tokensC              = "tokens"
 	externalControllersC = "externalControllers"
+	relationIngressC     = "relationIngress"
 )

--- a/state/export_test.go
+++ b/state/export_test.go
@@ -656,3 +656,19 @@ func NewSLALevel(level string) (slaLevel, error) {
 func AppStorageConstraints(app *Application) (map[string]StorageConstraints, error) {
 	return readStorageConstraints(app.st, app.storageConstraintsKey())
 }
+
+func RemoveRelation(c *gc.C, rel *Relation) {
+	ops, err := rel.removeOps("", "")
+	c.Assert(err, jc.ErrorIsNil)
+	err = rel.st.db().RunTransaction(ops)
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func IngressNetworks(rel *Relation) ([]string, error) {
+	relIngress := NewRelationIngressNetworks(rel.st)
+	doc, err := relIngress.ingressNetworks(rel.Tag().Id())
+	if err != nil {
+		return nil, err
+	}
+	return doc.CIDRS, nil
+}

--- a/state/externalcontroller.go
+++ b/state/externalcontroller.go
@@ -92,10 +92,9 @@ func (ec *externalControllers) Save(controller crossmodel.ControllerInfo, modelU
 		if err != nil {
 			return nil, errors.Annotate(err, "failed to load model")
 		}
-		if model.Life() != Alive {
-			return nil, errors.New("model is not alive")
+		if err := checkModelActive(ec.st); err != nil {
+			return nil, errors.Trace(err)
 		}
-
 		existing, err := ec.controller(controller.ControllerTag.Id())
 		if err != nil && !errors.IsNotFound(err) {
 			return nil, errors.Trace(err)

--- a/state/migration_internal_test.go
+++ b/state/migration_internal_test.go
@@ -190,6 +190,7 @@ func (s *MigrationSuite) TestKnownCollections(c *gc.C) {
 		tokensC,
 		remoteEntitiesC,
 		externalControllersC,
+		relationIngressC,
 	)
 
 	envCollections := set.NewStrings()

--- a/state/relation.go
+++ b/state/relation.go
@@ -199,6 +199,7 @@ func (r *Relation) removeOps(ignoreService string, departingUnitName string) ([]
 			ops = append(ops, epOps...)
 		}
 	}
+	ops = append(ops, removeRelationIngressNetworksOps(r.st, r.doc.Key)...)
 	cleanupOp := newCleanupOp(cleanupRelationSettings, fmt.Sprintf("r#%d#", r.Id()))
 	return append(ops, cleanupOp), nil
 }

--- a/state/relation_test.go
+++ b/state/relation_test.go
@@ -359,3 +359,21 @@ func assertOneRelation(c *gc.C, srv *state.Application, relId int, endpoints ...
 	c.Assert(eps, gc.DeepEquals, []state.Endpoint{expectEp})
 	return rel
 }
+
+func (s *RelationSuite) TestRemoveAlsoDeletesIngressNetworks(c *gc.C) {
+	wordpress := s.AddTestingService(c, "wordpress", s.AddTestingCharm(c, "wordpress"))
+	wordpressEP, err := wordpress.Endpoint("db")
+	c.Assert(err, jc.ErrorIsNil)
+	mysql := s.AddTestingService(c, "mysql", s.AddTestingCharm(c, "mysql"))
+	mysqlEP, err := mysql.Endpoint("server")
+	c.Assert(err, jc.ErrorIsNil)
+	relation, err := s.State.AddRelation(wordpressEP, mysqlEP)
+	c.Assert(err, jc.ErrorIsNil)
+
+	relIngress := state.NewRelationIngressNetworks(s.State)
+	_, err = relIngress.Save(relation.Tag().Id(), []string{"1.2.3.4/32", "4.3.2.1/16"})
+	c.Assert(err, jc.ErrorIsNil)
+	state.RemoveRelation(c, relation)
+	_, err = state.IngressNetworks(relation)
+	c.Assert(err, jc.Satisfies, errors.IsNotFound)
+}

--- a/state/relationingress.go
+++ b/state/relationingress.go
@@ -1,0 +1,149 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package state
+
+import (
+	"fmt"
+	"net"
+
+	"github.com/juju/errors"
+	"gopkg.in/mgo.v2"
+	"gopkg.in/mgo.v2/bson"
+	"gopkg.in/mgo.v2/txn"
+)
+
+// RelationIngress instances describe the ingress networks
+// required for a cross model relation.
+type RelationIngress interface {
+	RelationKey() string
+	CIDRS() []string
+}
+
+type relationIngressDoc struct {
+	Id    string   `bson:"_id"`
+	CIDRS []string `bson:"cidrs"`
+}
+
+type relationIngress struct {
+	st  *State
+	doc relationIngressDoc
+}
+
+// String returns r as a user-readable string.
+func (r *relationIngress) String() string {
+	return fmt.Sprintf("cidrs for relation %q", r.RelationKey())
+}
+
+// RelationKey is the key of the relation.
+func (r *relationIngress) RelationKey() string {
+	return r.st.localID(r.doc.Id)
+}
+
+// CIDRS returns the ingress networks for the relation.
+func (r *relationIngress) CIDRS() []string {
+	return r.doc.CIDRS
+}
+
+// RelationIngressNetworks instances provide access to relation ingress in state.
+type RelationIngressNetworks interface {
+	Save(relationKey string, cidrs []string) (RelationIngress, error)
+}
+
+type relationIngressNetworks struct {
+	st *State
+}
+
+// RelationIngressNetworks creates a RelationIngressNetworks instance backed by a state.
+func NewRelationIngressNetworks(st *State) *relationIngressNetworks {
+	return &relationIngressNetworks{st: st}
+}
+
+// Save stores the specified ingress networks for the relation.
+func (rin *relationIngressNetworks) Save(relationKey string, cidrs []string) (RelationIngress, error) {
+	logger.Debugf("save ingress networks for %v: %v", relationKey, cidrs)
+	for _, cidr := range cidrs {
+		if _, _, err := net.ParseCIDR(cidr); err != nil {
+			return nil, errors.NotValidf("CIDR %q", cidr)
+		}
+	}
+	doc := relationIngressDoc{
+		Id:    rin.st.docID(relationKey),
+		CIDRS: cidrs,
+	}
+	buildTxn := func(int) ([]txn.Op, error) {
+		model, err := rin.st.Model()
+		if err != nil {
+			return nil, errors.Annotate(err, "failed to load model")
+		}
+		if err := checkModelActive(rin.st); err != nil {
+			return nil, errors.Trace(err)
+		}
+		if _, err := rin.st.KeyRelation(relationKey); err != nil {
+			return nil, errors.Trace(err)
+		}
+
+		relationExistsAssert := txn.Op{
+			C:      relationsC,
+			Id:     doc.Id,
+			Assert: txn.DocExists,
+		}
+
+		existing, err := rin.ingressNetworks(relationKey)
+		if err != nil && !errors.IsNotFound(err) {
+			return nil, errors.Trace(err)
+		}
+		var ops []txn.Op
+		if err == nil {
+			ops = []txn.Op{{
+				C:      relationIngressC,
+				Id:     existing.Id,
+				Assert: txn.DocExists,
+				Update: bson.D{
+					{"$set", bson.D{{"cidrs", cidrs}}},
+				},
+			}, model.assertActiveOp(), relationExistsAssert}
+		} else {
+			doc.CIDRS = cidrs
+			ops = []txn.Op{{
+				C:      relationIngressC,
+				Id:     doc.Id,
+				Assert: txn.DocMissing,
+				Insert: doc,
+			}, model.assertActiveOp(), relationExistsAssert}
+		}
+		return ops, nil
+	}
+	if err := rin.st.db().Run(buildTxn); err != nil {
+		return nil, errors.Annotate(err, "failed to create relation ingress networks")
+	}
+
+	return &relationIngress{
+		st:  rin.st,
+		doc: doc,
+	}, nil
+}
+
+func (rin *relationIngressNetworks) ingressNetworks(relationKey string) (*relationIngressDoc, error) {
+	coll, closer := rin.st.db().GetCollection(relationIngressC)
+	defer closer()
+
+	var doc relationIngressDoc
+	err := coll.FindId(relationKey).One(&doc)
+	if err == mgo.ErrNotFound {
+		return nil, errors.NotFoundf("ingress networks for relation %v", relationKey)
+	}
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return &doc, nil
+}
+
+func removeRelationIngressNetworksOps(st *State, relationKey string) []txn.Op {
+	ops := []txn.Op{{
+		C:      relationIngressC,
+		Id:     st.docID(relationKey),
+		Remove: true,
+	}}
+	return ops
+}

--- a/state/relationingress_test.go
+++ b/state/relationingress_test.go
@@ -1,0 +1,86 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package state_test
+
+import (
+	"fmt"
+	"regexp"
+
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/mgo.v2/bson"
+
+	"github.com/juju/juju/state"
+)
+
+type relationIngressSuite struct {
+	ConnSuite
+	relationIngressNetworks state.RelationIngressNetworks
+}
+
+var _ = gc.Suite(&relationIngressSuite{})
+
+func (s *relationIngressSuite) SetUpTest(c *gc.C) {
+	s.ConnSuite.SetUpTest(c)
+	s.relationIngressNetworks = state.NewRelationIngressNetworks(s.State)
+	wordpress := s.AddTestingService(c, "wordpress", s.AddTestingCharm(c, "wordpress"))
+	wordpressEP, err := wordpress.Endpoint("db")
+	c.Assert(err, jc.ErrorIsNil)
+	mysql := s.AddTestingService(c, "mysql", s.AddTestingCharm(c, "mysql"))
+	mysqlEP, err := mysql.Endpoint("server")
+	c.Assert(err, jc.ErrorIsNil)
+	_, err = s.State.AddRelation(wordpressEP, mysqlEP)
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *relationIngressSuite) TestSaveMissingRelation(c *gc.C) {
+	_, err := s.relationIngressNetworks.Save("wordpress:db something:database", []string{"192.168.1.0/32"})
+	c.Assert(err, gc.ErrorMatches, ".*"+regexp.QuoteMeta(`"wordpress:db something:database" not found`))
+}
+
+func (s *relationIngressSuite) TestSaveInvalidAddress(c *gc.C) {
+	_, err := s.relationIngressNetworks.Save("wordpress:db mysql:server", []string{"192.168.1"})
+	c.Assert(err, gc.ErrorMatches, regexp.QuoteMeta(`CIDR "192.168.1" not valid`))
+}
+
+func (s *relationIngressSuite) assertSavedIngressInfo(c *gc.C, relationKey string, expectedCIDRS ...string) {
+	coll, closer := state.GetCollection(s.State, "relationIngress")
+	defer closer()
+
+	var raw bson.M
+	err := coll.FindId(relationKey).One(&raw)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(raw["_id"], gc.Equals, fmt.Sprintf("%v:%v", s.State.ModelUUID(), relationKey))
+	var cidrs []string
+	for _, m := range raw["cidrs"].([]interface{}) {
+		cidrs = append(cidrs, m.(string))
+	}
+	c.Assert(cidrs, jc.SameContents, expectedCIDRS)
+}
+
+func (s *relationIngressSuite) TestSave(c *gc.C) {
+	rin, err := s.relationIngressNetworks.Save("wordpress:db mysql:server", []string{"192.168.1.0/16"})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(rin.RelationKey(), gc.Equals, "wordpress:db mysql:server")
+	c.Assert(rin.CIDRS(), jc.DeepEquals, []string{"192.168.1.0/16"})
+	s.assertSavedIngressInfo(c, "wordpress:db mysql:server", "192.168.1.0/16")
+}
+
+func (s *relationIngressSuite) TestSaveIdempotent(c *gc.C) {
+	rin, err := s.relationIngressNetworks.Save("wordpress:db mysql:server", []string{"192.168.1.0/16"})
+	c.Assert(err, jc.ErrorIsNil)
+	rin, err = s.relationIngressNetworks.Save("wordpress:db mysql:server", []string{"192.168.1.0/16"})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(rin.RelationKey(), gc.Equals, "wordpress:db mysql:server")
+	c.Assert(rin.CIDRS(), jc.DeepEquals, []string{"192.168.1.0/16"})
+	s.assertSavedIngressInfo(c, "wordpress:db mysql:server", "192.168.1.0/16")
+}
+
+func (s *relationIngressSuite) TestUpdateCIDRs(c *gc.C) {
+	_, err := s.relationIngressNetworks.Save("wordpress:db mysql:server", []string{"192.168.1.0/16"})
+	c.Assert(err, jc.ErrorIsNil)
+	_, err = s.relationIngressNetworks.Save("wordpress:db mysql:server", []string{"10.0.0.1/16"})
+	c.Assert(err, jc.ErrorIsNil)
+	s.assertSavedIngressInfo(c, "wordpress:db mysql:server", "10.0.0.1/16")
+}

--- a/state/watcher.go
+++ b/state/watcher.go
@@ -2728,3 +2728,129 @@ func isLocalID(st modelBackend) func(interface{}) bool {
 		return err == nil
 	}
 }
+
+// relationIngressWatcher notifies of changes in the
+// relationIngress collection.
+type relationIngressWatcher struct {
+	commonWatcher
+	key         string
+	filter      func(key interface{}) bool
+	knownTxnRev int64
+	knownCidrs  set.Strings
+	out         chan []string
+}
+
+var _ Watcher = (*relationIngressWatcher)(nil)
+
+// WatchRelationIngressNetworks starts and returns a StringsWatcher notifying
+// of changes to the relationIngress collection for the relation.
+func (r *Relation) WatchRelationIngressNetworks() StringsWatcher {
+	return newrelationIngressWatcher(r.st, r.Tag().Id())
+}
+
+func newrelationIngressWatcher(st modelBackend, relationKey string) StringsWatcher {
+	filter := func(id interface{}) bool {
+		k, err := st.strictLocalID(id.(string))
+		if err != nil {
+			return false
+		}
+		return k == relationKey
+	}
+	w := &relationIngressWatcher{
+		commonWatcher: newCommonWatcher(st),
+		key:           relationKey,
+		filter:        filter,
+		knownCidrs:    set.NewStrings(),
+		out:           make(chan []string),
+	}
+	go func() {
+		defer w.tomb.Done()
+		defer close(w.out)
+		w.tomb.Kill(w.loop())
+	}()
+
+	return w
+}
+
+// Changes returns the event channel for watching changes
+// to a relation's ingress networks.
+func (w *relationIngressWatcher) Changes() <-chan []string {
+	return w.out
+}
+
+func (w *relationIngressWatcher) loadCIDRs() (bool, error) {
+	coll, closer := w.db.GetCollection(relationIngressC)
+	defer closer()
+
+	var doc struct {
+		TxnRevno int64    `bson:"txn-revno"`
+		Id       string   `bson:"_id"`
+		CIDRs    []string `bson:"cidrs"`
+	}
+	err := coll.FindId(w.key).One(&doc)
+	if err == mgo.ErrNotFound {
+		// Record deleted.
+		changed := w.knownCidrs.Size() > 0
+		w.knownCidrs = set.NewStrings()
+		return changed, nil
+	}
+	if err != nil {
+		return false, errors.Trace(err)
+
+	}
+	cidrs := w.knownCidrs
+	if doc.TxnRevno == -1 {
+		// Record deleted.
+		cidrs = set.NewStrings()
+	}
+	if doc.TxnRevno > w.knownTxnRev {
+		cidrs = set.NewStrings(doc.CIDRs...)
+	}
+	w.knownTxnRev = doc.TxnRevno
+	changed := !cidrs.Difference(w.knownCidrs).IsEmpty() || !w.knownCidrs.Difference(cidrs).IsEmpty()
+	w.knownCidrs = cidrs
+	return changed, nil
+}
+
+func (w *relationIngressWatcher) loop() error {
+	in := make(chan watcher.Change)
+	w.watcher.WatchCollectionWithFilter(relationIngressC, in, w.filter)
+	defer w.watcher.UnwatchCollection(relationIngressC, in)
+
+	var (
+		sentInitial bool
+		changed     bool
+		out         chan<- []string
+		err         error
+	)
+	if _, err = w.loadCIDRs(); err != nil {
+		logger.Criticalf(err.Error())
+		return errors.Trace(err)
+	}
+	for {
+		if !sentInitial || changed {
+			changed = false
+			out = w.out
+		}
+		select {
+		case <-w.tomb.Dying():
+			return tomb.ErrDying
+		case <-w.watcher.Dead():
+			return stateWatcherDeadError(w.watcher.Err())
+		case _, ok := <-in:
+			if !ok {
+				return tomb.ErrDying
+			}
+			if changed, err = w.loadCIDRs(); err != nil {
+				return errors.Trace(err)
+			}
+		case out <- w.knownCidrs.Values():
+			out = nil
+			sentInitial = true
+		}
+		if w.knownTxnRev == -1 {
+			// Record deleted
+			return tomb.ErrDying
+		}
+	}
+}


### PR DESCRIPTION
## Description of change

Followup from https://github.com/juju/juju/pull/7540
The firewaller listens for required ingress changes on the offering side of a cross model relation and opens the relevant ports.
A new collection is used to store incoming ingress changes from the consuming side. A new watcher notifies the firewaller worker of those changes.

## QA steps

Deploy a cross model scenario on AWS. Use the console to see that the security group has the right ports opened.
