### PR TITLE
Log agent connections/disconnections.

### DIFF
--- a/apiserver/common/networkingcommon/networkconfigapi.go
+++ b/apiserver/common/networkingcommon/networkconfigapi.go
@@ -121,7 +121,7 @@ func (api *NetworkConfigAPI) getMachineForSettingNetworkConfig(machineTag string
 	}
 
 	if m.IsContainer() {
-		logger.Warningf("not updating network config for container %q", m.Id())
+		logger.Debugf("not updating network config for container %q", m.Id())
 	}
 
 	return m, nil

--- a/apiserver/debuglog.go
+++ b/apiserver/debuglog.go
@@ -7,6 +7,7 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"os"
 	"strconv"
 	"syscall"
 	"time"
@@ -99,6 +100,9 @@ func (h *debugLogHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 func isBrokenPipe(err error) bool {
 	err = errors.Cause(err)
 	if opErr, ok := err.(*net.OpError); ok {
+		if sysCallErr, ok := opErr.Err.(*os.SyscallError); ok {
+			return sysCallErr.Err == syscall.EPIPE
+		}
 		return opErr.Err == syscall.EPIPE
 	}
 	return false

--- a/apiserver/metricsender/metricsender.go
+++ b/apiserver/metricsender/metricsender.go
@@ -88,9 +88,9 @@ func SendMetrics(st ModelBackend, sender MetricSender, clock clock.Clock, batchS
 		lenM := len(metrics)
 		if lenM == 0 {
 			if sent == 0 {
-				logger.Infof("nothing to send")
+				logger.Debugf("nothing to send")
 			} else {
-				logger.Infof("done sending")
+				logger.Debugf("done sending")
 			}
 			break
 		}
@@ -151,7 +151,7 @@ func SendMetrics(st ModelBackend, sender MetricSender, clock clock.Clock, batchS
 	if err != nil {
 		return errors.Trace(err)
 	}
-	logger.Infof("metrics collection summary for %s: sent:%d unsent:%d held:%d (%d sent metrics stored)", st.ModelTag(), sent, unsent, held, sentStored)
+	logger.Debugf("metrics collection summary for %s: sent:%d unsent:%d held:%d (%d sent metrics stored)", st.ModelTag(), sent, unsent, held, sentStored)
 
 	return nil
 }

--- a/environs/tools/tools.go
+++ b/environs/tools/tools.go
@@ -98,23 +98,23 @@ func FindTools(env environs.Environ, majorVersion, minorVersion int, stream stri
 		return nil, errors.New("cannot find agent binaries without a complete cloud configuration")
 	}
 
-	logger.Infof("finding agent binaries in stream %q", stream)
+	logger.Debugf("finding agent binaries in stream %q", stream)
 	if minorVersion >= 0 {
-		logger.Infof("reading agent binaries with major.minor version %d.%d", majorVersion, minorVersion)
+		logger.Debugf("reading agent binaries with major.minor version %d.%d", majorVersion, minorVersion)
 	} else {
-		logger.Infof("reading agent binaries with major version %d", majorVersion)
+		logger.Debugf("reading agent binaries with major version %d", majorVersion)
 	}
 	defer convertToolsError(&err)
 	// Construct a tools filter.
 	// Discard all that are known to be irrelevant.
 	if filter.Number != version.Zero {
-		logger.Infof("filtering agent binaries by version: %s", filter.Number)
+		logger.Debugf("filtering agent binaries by version: %s", filter.Number)
 	}
 	if filter.Series != "" {
-		logger.Infof("filtering agent binaries by series: %s", filter.Series)
+		logger.Debugf("filtering agent binaries by series: %s", filter.Series)
 	}
 	if filter.Arch != "" {
-		logger.Infof("filtering agent binaries by architecture: %s", filter.Arch)
+		logger.Debugf("filtering agent binaries by architecture: %s", filter.Arch)
 	}
 	sources, err := GetMetadataSources(env)
 	if err != nil {
@@ -168,7 +168,7 @@ func FindToolsForCloud(sources []simplestreams.DataSource, cloudSpec simplestrea
 
 // FindExactTools returns only the tools that match the supplied version.
 func FindExactTools(env environs.Environ, vers version.Number, series string, arch string) (_ *coretools.Tools, err error) {
-	logger.Infof("finding exact version %s", vers)
+	logger.Debugf("finding exact version %s", vers)
 	// Construct a tools filter.
 	// Discard all that are known to be irrelevant.
 	filter := coretools.Filter{
@@ -177,7 +177,7 @@ func FindExactTools(env environs.Environ, vers version.Number, series string, ar
 		Arch:   arch,
 	}
 	stream := PreferredStream(&vers, env.Config().Development(), env.Config().AgentStream())
-	logger.Infof("looking for tools in stream %q", stream)
+	logger.Debugf("looking for tools in stream %q", stream)
 	availableTools, err := FindTools(env, vers.Major, vers.Minor, stream, filter)
 	if err != nil {
 		return nil, err

--- a/environs/tools/tools_test.go
+++ b/environs/tools/tools_test.go
@@ -208,8 +208,8 @@ func (s *SimpleStreamsToolsSuite) TestFindToolsFiltering(c *gc.C) {
 	// messages. This still helps to ensure that all log messages are
 	// properly formed.
 	messages := []jc.SimpleMessage{
-		{loggo.INFO, "reading agent binaries with major version 1"},
-		{loggo.INFO, "filtering agent binaries by version: \\d+\\.\\d+\\.\\d+"},
+		{loggo.DEBUG, "reading agent binaries with major version 1"},
+		{loggo.DEBUG, "filtering agent binaries by version: \\d+\\.\\d+\\.\\d+"},
 		{loggo.TRACE, "no architecture specified when finding agent binaries, looking for "},
 		{loggo.TRACE, "no series specified when finding agent binaries, looking for \\[.*\\]"},
 	}

--- a/worker/uniter/runner/logger.go
+++ b/worker/uniter/runner/logger.go
@@ -37,7 +37,7 @@ func (l *hookLogger) run() {
 			l.mu.Unlock()
 			return
 		}
-		l.logger.Infof("%s", line)
+		l.logger.Debugf("%s", line)
 		l.mu.Unlock()
 	}
 }


### PR DESCRIPTION
## Description of change

While some information was logged before for connections and disconnections, it is often desirable to know which agents are connecting and disconnecting. This branch logs agent connections using a particular logging module, and at INFO level for ease of finding. This would help make it obvious if a particular agent was bouncing regularly.

Additional logging has been moved from INFO to DEBUG as it was a bit too verbose for an INFO logging controller.

## QA steps

Bootstrap a controller, deploy some agents, then run this:

`juju debug-log --include-module juju.apiserver.connection`

## Documentation changes

I'm not sure this warrents doc changes.
