### PR TITLE
Fix recovery functional tests

### DIFF
--- a/acceptancetests/assess_recovery.py
+++ b/acceptancetests/assess_recovery.py
@@ -163,7 +163,7 @@ def restore_missing_state_server(bs_manager, controller_client, backup_file,
         controller_client.wait_for_started(600)
         # status can return even if controller isn't ready
         logging.info('Waiting for application to be ready')
-        self.wait_for_application('dummy-source', 600)
+        controller_client.wait_for_application('dummy-source', 600)
     show_controller(bs_manager.client)
     bs_manager.has_controller = True
     bs_manager.client.set_config('dummy-source', {'token': 'Two'})

--- a/acceptancetests/assess_recovery.py
+++ b/acceptancetests/assess_recovery.py
@@ -161,6 +161,9 @@ def restore_missing_state_server(bs_manager, controller_client, backup_file,
         raise LoggedException(e)
     if check_controller:
         controller_client.wait_for_started(600)
+        # status can return even if controller isn't ready
+        logging.info('Waiting for application to be ready')
+        self.wait_for_application('dummy-source', 600)
     show_controller(bs_manager.client)
     bs_manager.has_controller = True
     bs_manager.client.set_config('dummy-source', {'token': 'Two'})

--- a/acceptancetests/jujupy/client.py
+++ b/acceptancetests/jujupy/client.py
@@ -2430,8 +2430,8 @@ class ModelClient:
         return status
 
     def wait_for_application(self, application, timeout=60):
-        """Wait till config returns without error. This is used as a 
-        proxy for the application itself being ready to accept 
+        """Wait till config returns without error. This is used as a
+        proxy for the application itself being ready to accept
         operations.
 
         :param application: Application to wait for
@@ -2440,7 +2440,7 @@ class ModelClient:
             try:
                 return self.get_config(application)
             except subprocess.CalledProcessError:
-                sleep(10)
+                time.sleep(10)
                 pass
         raise Exception(
             'Timed out waiting for %s' % (application))

--- a/acceptancetests/jujupy/client.py
+++ b/acceptancetests/jujupy/client.py
@@ -2430,9 +2430,9 @@ class ModelClient:
         return status
 
     def wait_for_application(self, application, timeout=60):
-        """Wait till config returns without error. This is used as a
-        proxy for the application itself being ready to accept
-        operations.
+        """Wait till config returns without error.
+        This is used as a proxy for the application itself being ready
+        to accept operations.
 
         :param application: Application to wait for
         """
@@ -2441,9 +2441,7 @@ class ModelClient:
                 return self.get_config(application)
             except subprocess.CalledProcessError:
                 time.sleep(10)
-                pass
-        raise Exception(
-            'Timed out waiting for %s' % (application))
+        raise Exception('Timed out waiting for {}'.format(application))
 
     def wait_for_started(self, timeout=1200, start=None):
         """Wait until all unit/machine agents are 'started'."""


### PR DESCRIPTION
## Description of change
This change accounts for the expected behavior within juju post-restore. The controller is restarted and not immediately available. Checking status doesn't work. We need to insure the controller has finished.

## QA steps
Verify by modifying and vetting the change