### PR TITLE
worker/uniter: Remove relation state dir even if non-empty

### DIFF
--- a/worker/uniter/relation/state.go
+++ b/worker/uniter/relation/state.go
@@ -219,10 +219,22 @@ func (d *StateDir) Write(hi hook.Info) (err error) {
 
 // Remove removes the directory if it exists and is empty.
 func (d *StateDir) Remove() error {
-	if err := os.Remove(d.path); err != nil && !os.IsNotExist(err) {
+	if files, err := ioutil.ReadDir(d.path); err != nil && !os.IsNotExist(err) {
 		return err
+	} else if err == nil {
+		if len(files) > 0 {
+			names := make([]string, len(files))
+			for i, file := range files {
+				names[i] = file.Name()
+			}
+			logger.Debugf("relation state directory %q not empty on removal: %v", d.path, names)
+		}
+		if err := os.RemoveAll(d.path); err != nil {
+			return err
+		}
 	}
-	// If atomic delete succeeded, update own state.
+
+	// If delete succeeded, update own state.
 	d.state.Members = nil
 	return nil
 }

--- a/worker/uniter/relation/state_test.go
+++ b/worker/uniter/relation/state_test.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"strconv"
 
+	"github.com/juju/loggo"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/charm.v6-unstable/hooks"
@@ -245,26 +246,65 @@ func (s *StateDirSuite) TestWrite(c *gc.C) {
 	}
 }
 
+func checkDir(c *gc.C, basedir string, relId int, shouldExist bool) {
+	path := filepath.Join(basedir, strconv.Itoa(relId))
+	info, err := os.Stat(path)
+	if shouldExist {
+		c.Assert(err, jc.ErrorIsNil)
+		c.Assert(info.IsDir(), jc.IsTrue)
+	} else {
+		c.Assert(err, jc.Satisfies, os.IsNotExist)
+	}
+}
+
 func (s *StateDirSuite) TestRemove(c *gc.C) {
+	var logWriter loggo.TestWriter
+	logger := loggo.GetLogger("juju.worker.uniter.relation")
+	origLevel := logger.LogLevel()
+	logger.SetLogLevel(loggo.DEBUG)
+	c.Assert(loggo.RegisterWriter("relation-state-tests", &logWriter), jc.ErrorIsNil)
+	defer func() {
+		loggo.RemoveWriter("relation-state-tests")
+		logWriter.Clear()
+		logger.SetLogLevel(origLevel)
+	}()
+
 	basedir := c.MkDir()
 	dir, err := relation.ReadStateDir(basedir, 1)
 	c.Assert(err, jc.ErrorIsNil)
 	err = dir.Ensure()
 	c.Assert(err, jc.ErrorIsNil)
+
+	checkDir(c, basedir, 1, true)
+
 	err = dir.Remove()
 	c.Assert(err, jc.ErrorIsNil)
+
+	checkDir(c, basedir, 1, false)
+
 	err = dir.Remove()
 	c.Assert(err, jc.ErrorIsNil)
+
+	// Removing an empty state dir doesn't log.
+	c.Assert(logWriter.Log(), gc.HasLen, 0)
 
 	setUpDir(c, basedir, "99", map[string]string{
 		"foo-1": "change-version: 0\n",
 	})
 	dir, err = relation.ReadStateDir(basedir, 99)
 	c.Assert(err, jc.ErrorIsNil)
+
+	// Calling remove on a non-empty dir is unexpected, but it's
+	// important that it doesn't crash the agent, so we log if it
+	// wasn't empty.
 	err = dir.Remove()
-	// Windows message is The directory is not empty
-	// Unix message is directory not empty
-	c.Assert(err, gc.ErrorMatches, ".* directory (is )?not empty.?")
+	c.Assert(err, jc.ErrorIsNil)
+	checkDir(c, basedir, 99, false)
+	expectedDir := filepath.Join(basedir, "99")
+	message := fmt.Sprintf(`relation state directory %q not empty on removal: \[foo-1\]`, expectedDir)
+	c.Assert(logWriter.Log(), jc.LogMatches, []jc.SimpleMessage{
+		{Level: loggo.DEBUG, Message: message},
+	})
 }
 
 type ReadAllStateDirsSuite struct{}


### PR DESCRIPTION
## Description of change

As part of the fix for bug 1699050, we added an upgrade step to remove spurious relation scopes. In some cases (which I haven't managed to reproduce unfortunately), the uniter state directory has a file under the relation directory for one of the spurious relation. As the uniter restarts it cleans up relation directories that are no longer relevant, but fails because the directory isn't empty. Use `os.RemoveAll` to always remove the directory (but log if it wasn't empty).

## QA steps

* Bootstrap a controller and model in Juju 2.1.3, with debug logging on.
* Deploy the kubernetes-core bundle (since it has a subordinate application related to more than one principal application).
* Use the following commands to find which relation is spurious for one of the flannel units:
  * `juju run flannel/0 "relation-ids cni"`
  * `juju run flannel/0 "relation-list --relation <numeric id from previous output>` - the spurious one will have no remote units listed.
* SSH into the flannel/0 machine and see the spurious relation directory under `/var/lib/juju/agents/unit-flannel-0/state/relations/" . Create an empty file in that directory.
* Upgrade the controller and model to the version including this PR.
* Check that the spurious relation directory is removed, even though it had a file in it.
* Observe the log message that reports that the removed directory wasn't empty.

## Bug reference

Related to https://bugs.launchpad.net/juju/+bug/1699050