### PR TITLE
state: include the workload version in the AllWatcher application info.

### DIFF
--- a/apiserver/params/params_test.go
+++ b/apiserver/params/params_test.go
@@ -78,9 +78,10 @@ var marshalTestCases = []struct {
 				Current: status.Active,
 				Message: "all good",
 			},
+			WorkloadVersion: "42.47",
 		},
 	},
-	json: `["application","change",{"model-uuid": "uuid", "charm-url": "cs:quantal/name","name":"Benji","exposed":true,"life":"dying","owner-tag":"test-owner","min-units":42,"constraints":{"arch":"armhf", "mem": 1024},"config": {"hello":"goodbye","foo":false},"subordinate":false,"status":{"current":"active", "message":"all good", "version": ""}}]`,
+	json: `["application","change",{"model-uuid": "uuid", "charm-url": "cs:quantal/name","name":"Benji","exposed":true,"life":"dying","owner-tag":"test-owner","workload-version":"42.47","min-units":42,"constraints":{"arch":"armhf", "mem": 1024},"config": {"hello":"goodbye","foo":false},"subordinate":false,"status":{"current":"active", "message":"all good", "version": ""}}]`,
 }, {
 	about: "UnitInfo Delta",
 	value: multiwatcher.Delta{

--- a/state/multiwatcher/multiwatcher.go
+++ b/state/multiwatcher/multiwatcher.go
@@ -176,17 +176,18 @@ func NewStatusInfo(s status.StatusInfo, err error) StatusInfo {
 // ApplicationInfo holds the information about an application that is tracked
 // by multiwatcherStore.
 type ApplicationInfo struct {
-	ModelUUID   string                 `json:"model-uuid"`
-	Name        string                 `json:"name"`
-	Exposed     bool                   `json:"exposed"`
-	CharmURL    string                 `json:"charm-url"`
-	OwnerTag    string                 `json:"owner-tag"`
-	Life        Life                   `json:"life"`
-	MinUnits    int                    `json:"min-units"`
-	Constraints constraints.Value      `json:"constraints"`
-	Config      map[string]interface{} `json:"config,omitempty"`
-	Subordinate bool                   `json:"subordinate"`
-	Status      StatusInfo             `json:"status"`
+	ModelUUID       string                 `json:"model-uuid"`
+	Name            string                 `json:"name"`
+	Exposed         bool                   `json:"exposed"`
+	CharmURL        string                 `json:"charm-url"`
+	OwnerTag        string                 `json:"owner-tag"`
+	Life            Life                   `json:"life"`
+	MinUnits        int                    `json:"min-units"`
+	Constraints     constraints.Value      `json:"constraints"`
+	Config          map[string]interface{} `json:"config,omitempty"`
+	Subordinate     bool                   `json:"subordinate"`
+	Status          StatusInfo             `json:"status"`
+	WorkloadVersion string                 `json:"workload-version"`
 }
 
 // EntityId returns a unique identifier for an application across


### PR DESCRIPTION
## Description of change

Include the workload version as part of the application info sent by the all watcher.
See https://github.com/juju/juju-gui/issues/2600

## QA steps

Deploy postgresq, run the API calls (WatchAll + Next) to watch the model, and you should see the workload-version as part of the stream when the charm sets it.
