### PR TITLE
2.2 ec2 subnets fixes

### DIFF
--- a/provider/ec2/environ.go
+++ b/provider/ec2/environ.go
@@ -909,7 +909,7 @@ func (e *environ) NetworkInterfaces(instId instance.Id) ([]network.InterfaceInfo
 	return result, nil
 }
 
-func makeSubnetInfo(cidr string, subnetId network.Id, availZones []string) (network.SubnetInfo, error) {
+func makeSubnetInfo(cidr string, subnetId, providerNetworkId network.Id, availZones []string) (network.SubnetInfo, error) {
 	_, _, err := net.ParseCIDR(cidr)
 	if err != nil {
 		return network.SubnetInfo{}, errors.Annotatef(err, "skipping subnet %q, invalid CIDR", cidr)
@@ -918,6 +918,7 @@ func makeSubnetInfo(cidr string, subnetId network.Id, availZones []string) (netw
 	info := network.SubnetInfo{
 		CIDR:              cidr,
 		ProviderId:        subnetId,
+		ProviderNetworkId: providerNetworkId,
 		VLANTag:           0, // Not supported on EC2
 		AvailabilityZones: availZones,
 	}
@@ -960,7 +961,7 @@ func (e *environ) Subnets(instId instance.Id, subnetIds []network.Id) ([]network
 				continue
 			}
 			subIdSet[string(iface.ProviderSubnetId)] = true
-			info, err := makeSubnetInfo(iface.CIDR, iface.ProviderSubnetId, iface.AvailabilityZones)
+			info, err := makeSubnetInfo(iface.CIDR, iface.ProviderSubnetId, iface.ProviderNetworkId, iface.AvailabilityZones)
 			if err != nil {
 				// Error will already have been logged.
 				continue
@@ -986,7 +987,7 @@ func (e *environ) Subnets(instId instance.Id, subnetIds []network.Id) ([]network
 			}
 			subIdSet[subnet.Id] = true
 			cidr := subnet.CIDRBlock
-			info, err := makeSubnetInfo(cidr, network.Id(subnet.Id), []string{subnet.AvailZone})
+			info, err := makeSubnetInfo(cidr, network.Id(subnet.Id), network.Id(subnet.VPCId), []string{subnet.AvailZone})
 			if err != nil {
 				// Error will already have been logged.
 				continue

--- a/provider/ec2/environ.go
+++ b/provider/ec2/environ.go
@@ -296,7 +296,7 @@ func (e *environ) parsePlacement(placement string) (*ec2Placement, error) {
 				logger.Debugf("found a matching subnet (%v) but couldn't find the AZ", subnet)
 			}
 		}
-		logger.Debugf("searched for subnet %q, did not find it in all subnets %v for vpcid %q", value, allSubnets, vpcId)
+		logger.Debugf("searched for subnet %q, did not find it in all subnets %v for vpc-id %q", value, allSubnets, vpcId)
 	}
 	return nil, fmt.Errorf("unknown placement directive: %v", placement)
 }
@@ -1018,9 +1018,7 @@ func (e *environ) subnetsForVPC() (resp *ec2.SubnetsResp, vpcId string, err erro
 			vpcId = e.defaultVPC.Id
 		}
 	}
-	if isVPCIDSet(vpcId) {
-		filter.Add("vpc-id", vpcId)
-	}
+	filter.Add("vpc-id", vpcId)
 	resp, err = e.ec2.Subnets(nil, filter)
 	return resp, vpcId, err
 }

--- a/provider/ec2/local_test.go
+++ b/provider/ec2/local_test.go
@@ -1015,7 +1015,6 @@ func (t *localServerSuite) addTestingSubnets(c *gc.C) ([]network.Id, string) {
 		CIDRBlock: "0.1.0.0/16",
 		IsDefault: true,
 	})
-	fmt.Printf("VPCID %q", vpc)
 	results := make([]network.Id, 3)
 	sub1, err := t.srv.ec2srv.AddSubnet(amzec2.Subnet{
 		VPCId:        vpc.Id,
@@ -1488,7 +1487,7 @@ func validateSubnets(c *gc.C, subnets []network.SubnetInfo, vpcId network.Id) {
 		c.Assert(re.Match([]byte(subnet.CIDR)), jc.IsTrue)
 		index, err := strconv.Atoi(re.FindStringSubmatch(subnet.CIDR)[1])
 		c.Assert(err, jc.ErrorIsNil)
-		// Don't know which AZ thkne subnet will end up in.
+		// Don't know which AZ the subnet will end up in.
 		defaultSubnets[index].AvailabilityZones = subnet.AvailabilityZones
 		c.Check(subnet, jc.DeepEquals, defaultSubnets[index])
 	}

--- a/provider/ec2/local_test.go
+++ b/provider/ec2/local_test.go
@@ -777,8 +777,8 @@ func (t *localServerSuite) TestStartInstanceSubnetAZUnavailable(c *gc.C) {
 }
 
 func (t *localServerSuite) testStartInstanceSubnet(c *gc.C, subnet string) (instance.Instance, error) {
-	env := t.prepareAndBootstrap(c)
-	subIDs := t.addTestingSubnets(c)
+	subIDs, vpcId := t.addTestingSubnets(c)
+	env := t.prepareAndBootstrapWithConfig(c, coretesting.Attrs{"vpc-id": vpcId, "vpc-id-force": true})
 	params := environs.StartInstanceParams{
 		ControllerUUID: t.ControllerUUID,
 		Placement:      fmt.Sprintf("subnet=%s", subnet),
@@ -793,6 +793,23 @@ func (t *localServerSuite) testStartInstanceSubnet(c *gc.C, subnet string) (inst
 		return nil, err
 	}
 	return result.Instance, nil
+}
+
+func (t *localServerSuite) TestStartInstanceSubnetWrongVPC(c *gc.C) {
+	subIDs, vpcId := t.addTestingSubnets(c)
+	c.Assert(vpcId, gc.Not(gc.Equals), "vpc-0")
+	env := t.prepareAndBootstrapWithConfig(c, coretesting.Attrs{"vpc-id": "vpc-0", "vpc-id-force": true})
+	params := environs.StartInstanceParams{
+		ControllerUUID: t.ControllerUUID,
+		Placement:      "subnet=0.1.2.0/24",
+		SubnetsToZones: map[network.Id][]string{
+			subIDs[0]: []string{"test-available"},
+			subIDs[1]: []string{"test-available"},
+			subIDs[2]: []string{"test-unavailable"},
+		},
+	}
+	_, err := testing.StartInstanceWithParams(env, "1", params)
+	c.Assert(err, gc.ErrorMatches, `unknown placement directive: subnet=0.1.2.0/24`)
 }
 
 func (t *localServerSuite) TestGetAvailabilityZones(c *gc.C) {
@@ -991,12 +1008,14 @@ func (t *localServerSuite) testStartInstanceAvailZoneAllConstrained(c *gc.C, run
 
 // addTestingSubnets adds a testing default VPC with 3 subnets in the EC2 test
 // server: 2 of the subnets are in the "test-available" AZ, the remaining - in
-// "test-unavailable". Returns a slice with the IDs of the created subnets.
-func (t *localServerSuite) addTestingSubnets(c *gc.C) []network.Id {
+// "test-unavailable". Returns a slice with the IDs of the created subnets and
+// vpc id that those were added to
+func (t *localServerSuite) addTestingSubnets(c *gc.C) ([]network.Id, string) {
 	vpc := t.srv.ec2srv.AddVPC(amzec2.VPC{
 		CIDRBlock: "0.1.0.0/16",
 		IsDefault: true,
 	})
+	fmt.Printf("VPCID %q", vpc)
 	results := make([]network.Id, 3)
 	sub1, err := t.srv.ec2srv.AddSubnet(amzec2.Subnet{
 		VPCId:        vpc.Id,
@@ -1024,11 +1043,17 @@ func (t *localServerSuite) addTestingSubnets(c *gc.C) []network.Id {
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	results[2] = network.Id(sub3.Id)
-	return results
+	return results, vpc.Id
 }
 
 func (t *localServerSuite) prepareAndBootstrap(c *gc.C) environs.Environ {
-	env := t.Prepare(c)
+	return t.prepareAndBootstrapWithConfig(c, coretesting.Attrs{})
+}
+
+func (t *localServerSuite) prepareAndBootstrapWithConfig(c *gc.C, config coretesting.Attrs) environs.Environ {
+	args := t.PrepareParams(c)
+	args.ModelConfig = coretesting.Attrs(args.ModelConfig).Merge(config)
+	env := t.PrepareWithParams(c, args)
 	err := bootstrap.Bootstrap(envtesting.BootstrapContext(c), env, bootstrap.BootstrapParams{
 		ControllerConfig: coretesting.FakeControllerConfig(),
 		AdminSecret:      testing.AdminSecret,
@@ -1041,7 +1066,7 @@ func (t *localServerSuite) prepareAndBootstrap(c *gc.C) environs.Environ {
 func (t *localServerSuite) TestSpaceConstraintsSpaceNotInPlacementZone(c *gc.C) {
 	c.Skip("temporarily disabled")
 	env := t.prepareAndBootstrap(c)
-	subIDs := t.addTestingSubnets(c)
+	subIDs, _ := t.addTestingSubnets(c)
 
 	// Expect an error because zone test-available isn't in SubnetsToZones
 	params := environs.StartInstanceParams{
@@ -1061,7 +1086,7 @@ func (t *localServerSuite) TestSpaceConstraintsSpaceNotInPlacementZone(c *gc.C) 
 
 func (t *localServerSuite) TestSpaceConstraintsSpaceInPlacementZone(c *gc.C) {
 	env := t.prepareAndBootstrap(c)
-	subIDs := t.addTestingSubnets(c)
+	subIDs, _ := t.addTestingSubnets(c)
 
 	// Should work - test-available is in SubnetsToZones and in myspace.
 	params := environs.StartInstanceParams{
@@ -1080,7 +1105,7 @@ func (t *localServerSuite) TestSpaceConstraintsSpaceInPlacementZone(c *gc.C) {
 
 func (t *localServerSuite) TestSpaceConstraintsNoPlacement(c *gc.C) {
 	env := t.prepareAndBootstrap(c)
-	subIDs := t.addTestingSubnets(c)
+	subIDs, _ := t.addTestingSubnets(c)
 
 	// Shoule work because zone is not specified so we can resolve the constraints
 	params := environs.StartInstanceParams{
@@ -1099,8 +1124,8 @@ func (t *localServerSuite) TestSpaceConstraintsNoPlacement(c *gc.C) {
 func (t *localServerSuite) TestSpaceConstraintsNoAvailableSubnets(c *gc.C) {
 	c.Skip("temporarily disabled")
 
-	env := t.prepareAndBootstrap(c)
-	subIDs := t.addTestingSubnets(c)
+	subIDs, vpcId := t.addTestingSubnets(c)
+	env := t.prepareAndBootstrapWithConfig(c, coretesting.Attrs{"vpc-id": vpcId})
 
 	// We requested a space, but there are no subnets in SubnetsToZones, so we can't resolve
 	// the constraints
@@ -1391,7 +1416,7 @@ func (t *localServerSuite) TestSubnetsWithInstanceId(c *gc.C) {
 	subnets, err := env.Subnets(instId, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(subnets, gc.HasLen, 1)
-	validateSubnets(c, subnets)
+	validateSubnets(c, subnets, "")
 
 	interfaces, err := env.NetworkInterfaces(instId)
 	c.Assert(err, jc.ErrorIsNil)
@@ -1409,7 +1434,7 @@ func (t *localServerSuite) TestSubnetsWithInstanceIdAndSubnetId(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(subnets, gc.HasLen, 1)
 	c.Assert(subnets[0].ProviderId, gc.Equals, interfaces[0].ProviderSubnetId)
-	validateSubnets(c, subnets)
+	validateSubnets(c, subnets, "")
 }
 
 func (t *localServerSuite) TestSubnetsWithInstanceIdMissingSubnet(c *gc.C) {
@@ -1433,22 +1458,25 @@ func (t *localServerSuite) TestInstanceInformation(c *gc.C) {
 	c.Assert(types.InstanceTypes, gc.HasLen, 48)
 }
 
-func validateSubnets(c *gc.C, subnets []network.SubnetInfo) {
+func validateSubnets(c *gc.C, subnets []network.SubnetInfo, vpcId network.Id) {
 	// These are defined in the test server for the testing default
 	// VPC.
 	defaultSubnets := []network.SubnetInfo{{
 		CIDR:              "10.10.0.0/24",
 		ProviderId:        "subnet-0",
+		ProviderNetworkId: vpcId,
 		VLANTag:           0,
 		AvailabilityZones: []string{"test-available"},
 	}, {
 		CIDR:              "10.10.1.0/24",
 		ProviderId:        "subnet-1",
+		ProviderNetworkId: vpcId,
 		VLANTag:           0,
 		AvailabilityZones: []string{"test-impaired"},
 	}, {
 		CIDR:              "10.10.2.0/24",
 		ProviderId:        "subnet-2",
+		ProviderNetworkId: vpcId,
 		VLANTag:           0,
 		AvailabilityZones: []string{"test-unavailable"},
 	}}
@@ -1460,9 +1488,9 @@ func validateSubnets(c *gc.C, subnets []network.SubnetInfo) {
 		c.Assert(re.Match([]byte(subnet.CIDR)), jc.IsTrue)
 		index, err := strconv.Atoi(re.FindStringSubmatch(subnet.CIDR)[1])
 		c.Assert(err, jc.ErrorIsNil)
-		// Don't know which AZ the subnet will end up in.
+		// Don't know which AZ thkne subnet will end up in.
 		defaultSubnets[index].AvailabilityZones = subnet.AvailabilityZones
-		c.Assert(subnet, jc.DeepEquals, defaultSubnets[index])
+		c.Check(subnet, jc.DeepEquals, defaultSubnets[index])
 	}
 }
 
@@ -1472,12 +1500,12 @@ func (t *localServerSuite) TestSubnets(c *gc.C) {
 	subnets, err := env.Subnets(instance.UnknownId, []network.Id{"subnet-0"})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(subnets, gc.HasLen, 1)
-	validateSubnets(c, subnets)
+	validateSubnets(c, subnets, "vpc-0")
 
 	subnets, err = env.Subnets(instance.UnknownId, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(subnets, gc.HasLen, 3)
-	validateSubnets(c, subnets)
+	validateSubnets(c, subnets, "vpc-0")
 }
 
 func (t *localServerSuite) TestSubnetsMissingSubnet(c *gc.C) {


### PR DESCRIPTION
## Description of change
1. Storing EC2 vpc-id as ProviderNetworkID in subnets
2. Fetching only subnets for models vpc-id

## QA steps
1. Bootstrap controller on EC2 with multiple VPCs set up, launch 'juju subnets' and verify that it has only subnets for the default vpc and that the default vpc id is stored in ProviderNetworkId
2. juju add-model --config vpc-id=some-other-vpc, launch 'juju subnets' and verify that the model has only subnets for the provided VPC and its id is stored in ProviderNetworkId

## Documentation changes
None

## Bug reference
https://bugs.launchpad.net/juju/+bug/1699930
https://bugs.launchpad.net/juju/+bug/1699849
