### PR TITLE
state: cleanup modelBackend and migrate additional functions

### DIFF
--- a/state/addmachine.go
+++ b/state/addmachine.go
@@ -277,7 +277,7 @@ func (st *State) addMachineOps(template MachineTemplate) (*machineDoc, []txn.Op,
 			return nil, nil, err
 		}
 	}
-	seq, err := st.sequence("machine")
+	seq, err := sequence(st, "machine")
 	if err != nil {
 		return nil, nil, err
 	}
@@ -377,7 +377,7 @@ func (st *State) addMachineInsideMachineOps(template MachineTemplate, parentId s
 // newContainerId returns a new id for a machine within the machine
 // with id parentId and the given container type.
 func (st *State) newContainerId(parentId string, containerType instance.ContainerType) (string, error) {
-	seq, err := st.sequence(fmt.Sprintf("machine%s%sContainer", parentId, containerType))
+	seq, err := sequence(st, fmt.Sprintf("machine%s%sContainer", parentId, containerType))
 	if err != nil {
 		return "", err
 	}
@@ -392,7 +392,7 @@ func (st *State) addMachineInsideNewMachineOps(template, parentTemplate MachineT
 	if template.InstanceId != "" || parentTemplate.InstanceId != "" {
 		return nil, nil, errors.New("cannot specify instance id for a new container")
 	}
-	seq, err := st.sequence("machine")
+	seq, err := sequence(st, "machine")
 	if err != nil {
 		return nil, nil, err
 	}

--- a/state/application.go
+++ b/state/application.go
@@ -1030,7 +1030,7 @@ func (a *Application) Refresh() error {
 
 // newUnitName returns the next unit name.
 func (a *Application) newUnitName() (string, error) {
-	unitSeq, err := a.st.sequence(a.Tag().String())
+	unitSeq, err := sequence(a.st, a.Tag().String())
 	if err != nil {
 		return "", errors.Trace(err)
 	}

--- a/state/backend.go
+++ b/state/backend.go
@@ -12,39 +12,45 @@ import (
 // modelBackend collects together some useful internal state methods for
 // accessing mongo and mapping local and global ids to one another.
 type modelBackend interface {
+	// docID generates a globally unique ID value
+	// where the model UUID is prefixed to the
+	// localID.
 	docID(string) string
+
+	// localID returns the local ID value by stripping
+	// off the model UUID prefix if it is there.
 	localID(string) string
+
+	// strictLocalID returns the local ID value by removing the
+	// model UUID prefix. If there is no prefix matching the
+	// State's model, an error is returned.
 	strictLocalID(string) (string, error)
+
 	db() Database
+	modelUUID() string
 	txnLogWatcher() *watcher.Watcher
 }
 
-// docID generates a globally unique id value
-// where the model uuid is prefixed to the
-// localID.
 func (st *State) docID(localID string) string {
 	return ensureModelUUID(st.ModelUUID(), localID)
 }
 
-// localID returns the local id value by stripping
-// off the model uuid prefix if it is there.
-func (st *State) localID(ID string) string {
-	modelUUID, localID, ok := splitDocID(ID)
+func (st *State) localID(id string) string {
+	modelUUID, localID, ok := splitDocID(id)
 	if !ok || modelUUID != st.ModelUUID() {
-		return ID
+		return id
 	}
 	return localID
 }
 
-// strictLocalID returns the local id value by removing the
-// model UUID prefix.
-//
-// If there is no prefix matching the State's model, an error is
-// returned.
-func (st *State) strictLocalID(ID string) (string, error) {
-	modelUUID, localID, ok := splitDocID(ID)
+func (st *State) strictLocalID(id string) (string, error) {
+	modelUUID, localID, ok := splitDocID(id)
 	if !ok || modelUUID != st.ModelUUID() {
-		return "", errors.Errorf("unexpected id: %#v", ID)
+		return "", errors.Errorf("unexpected id: %#v", id)
 	}
 	return localID, nil
+}
+
+func (st *State) modelUUID() string {
+	return st.ModelUUID()
 }

--- a/state/block.go
+++ b/state/block.go
@@ -271,7 +271,7 @@ func setModelBlock(st *State, t BlockType, msg string) error {
 
 // newBlockId returns a sequential block id for this model.
 func newBlockId(st *State) (string, error) {
-	seq, err := st.sequence("block")
+	seq, err := sequence(st, "block")
 	if err != nil {
 		return "", errors.Trace(err)
 	}

--- a/state/charm.go
+++ b/state/charm.go
@@ -650,7 +650,7 @@ func (st *State) PrepareLocalCharmUpload(curl *charm.URL) (chosenURL *charm.URL,
 	}
 
 	revisionSeq := charmRevSeqName(curl.WithRevision(-1).String())
-	revision, err := st.sequenceWithMin(revisionSeq, curl.Revision)
+	revision, err := sequenceWithMin(st, revisionSeq, curl.Revision)
 	if err != nil {
 		return nil, errors.Annotate(err, "unable to allocate charm revision")
 	}

--- a/state/export_test.go
+++ b/state/export_test.go
@@ -355,11 +355,11 @@ func MultiEnvCollections() []string {
 }
 
 func Sequence(st *State, name string) (int, error) {
-	return st.sequence(name)
+	return sequence(st, name)
 }
 
 func SequenceWithMin(st *State, name string, minVal int) (int, error) {
-	return st.sequenceWithMin(name, minVal)
+	return sequenceWithMin(st, name, minVal)
 }
 
 func SequenceEnsure(st *State, name string, nextVal int) error {

--- a/state/filesystem.go
+++ b/state/filesystem.go
@@ -792,7 +792,7 @@ func ParseFilesystemAttachmentId(id string) (names.MachineTag, names.FilesystemT
 // filesystem ID will incorporate it as the
 // filesystem's machine scope.
 func newFilesystemId(st *State, machineId string) (string, error) {
-	seq, err := st.sequence("filesystem")
+	seq, err := sequence(st, "filesystem")
 	if err != nil {
 		return "", errors.Trace(err)
 	}

--- a/state/modelmigration.go
+++ b/state/modelmigration.go
@@ -652,7 +652,7 @@ func (st *State) CreateMigration(spec MigrationSpec) (ModelMigration, error) {
 			return nil, errors.Trace(err)
 		}
 
-		attempt, err := st.sequence("modelmigration")
+		attempt, err := sequence(st, "modelmigration")
 		if err != nil {
 			return nil, errors.Trace(err)
 		}

--- a/state/sequence.go
+++ b/state/sequence.go
@@ -20,15 +20,15 @@ type sequenceDoc struct {
 
 // sequence safely increments a database backed sequence, returning
 // the next value.
-func (st *State) sequence(name string) (int, error) {
-	sequences, closer := st.db().GetCollection(sequenceC)
+func sequence(mb modelBackend, name string) (int, error) {
+	sequences, closer := mb.db().GetCollection(sequenceC)
 	defer closer()
 	query := sequences.FindId(name)
 	inc := mgo.Change{
 		Update: bson.M{
 			"$set": bson.M{
 				"name":       name,
-				"model-uuid": st.ModelUUID(),
+				"model-uuid": mb.modelUUID(),
 			},
 			"$inc": bson.M{"counter": 1},
 		},
@@ -54,10 +54,10 @@ func (st *State) sequence(name string) (int, error) {
 //
 // `sequence` is more efficient than `sequenceWithMin` and should be
 // preferred if there is no minimum value requirement.
-func (st *State) sequenceWithMin(name string, minVal int) (int, error) {
-	sequences, closer := st.db().GetRawCollection(sequenceC)
+func sequenceWithMin(mb modelBackend, name string, minVal int) (int, error) {
+	sequences, closer := mb.db().GetRawCollection(sequenceC)
 	defer closer()
-	updater := newDbSeqUpdater(sequences, st.ModelUUID(), name)
+	updater := newDbSeqUpdater(sequences, mb.modelUUID(), name)
 	return updateSeqWithMin(updater, minVal)
 }
 

--- a/state/state.go
+++ b/state/state.go
@@ -942,7 +942,7 @@ func (st *State) tagToCollectionAndId(tag names.Tag) (string, interface{}, error
 func (st *State) addPeerRelationsOps(applicationname string, peers map[string]charm.Relation) ([]txn.Op, error) {
 	var ops []txn.Op
 	for _, rel := range peers {
-		relId, err := st.sequence("relation")
+		relId, err := sequence(st, "relation")
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
@@ -1779,7 +1779,7 @@ func (st *State) AddRelation(eps ...Endpoint) (r *Relation, err error) {
 		// an operation to create the relation document.
 		if id == -1 {
 			var err error
-			if id, err = st.sequence("relation"); err != nil {
+			if id, err = sequence(st, "relation"); err != nil {
 				return nil, errors.Trace(err)
 			}
 		}

--- a/state/storage.go
+++ b/state/storage.go
@@ -211,7 +211,7 @@ type storageAttachmentDoc struct {
 // incorporates the storage name as defined in the charm storage metadata,
 // and a unique sequence number.
 func newStorageInstanceId(st *State, store string) (string, error) {
-	seq, err := st.sequence("stores")
+	seq, err := sequence(st, "stores")
 	if err != nil {
 		return "", errors.Trace(err)
 	}

--- a/state/volume.go
+++ b/state/volume.go
@@ -740,7 +740,7 @@ func (st *State) RemoveVolume(tag names.VolumeTag) (err error) {
 // volume ID will incorporate it as the volume's
 // machine scope.
 func newVolumeName(st *State, machineId string) (string, error) {
-	seq, err := st.sequence("volume")
+	seq, err := sequence(st, "volume")
 	if err != nil {
 		return "", errors.Trace(err)
 	}


### PR DESCRIPTION
Cleanup parts of the modelBackend code and migrate additional functions to take
modelBackend as an argument, instead of being declared on a *State receiver.
This will allow for further migration to modelBackend and reduced dependency
on state.State.

No functional change.