### PR TITLE
state: call db().GetRawCollection instead of getRawCollection

### DIFF
--- a/state/block.go
+++ b/state/block.go
@@ -211,7 +211,7 @@ func (st *State) AllBlocks() ([]Block, error) {
 // AllBlocksForController returns all blocks in any models on
 // the controller.
 func (st *State) AllBlocksForController() ([]Block, error) {
-	blocksCollection, closer := st.getRawCollection(blocksC)
+	blocksCollection, closer := st.db().GetRawCollection(blocksC)
 	defer closer()
 
 	var bdocs []blockDoc

--- a/state/collection.go
+++ b/state/collection.go
@@ -11,14 +11,6 @@ import (
 	"github.com/juju/juju/mongo"
 )
 
-// getRawCollection returns the named mgo Collection. As no automatic
-// model filtering is performed by the returned collection it
-// should be rarely used.
-func (st *State) getRawCollection(name string) (*mgo.Collection, func()) {
-	collection, closer := st.database.GetCollection(name)
-	return collection.Writeable().Underlying(), closer
-}
-
 // modelStateCollection wraps a mongo.Collection, preserving the
 // mongo.Collection interface and its Writeable behaviour. It will
 // automatically modify query selectors and documents so that queries

--- a/state/export_test.go
+++ b/state/export_test.go
@@ -337,7 +337,7 @@ func GetCollection(st *State, name string) (mongo.Collection, func()) {
 }
 
 func GetRawCollection(st *State, name string) (*mgo.Collection, func()) {
-	return st.getRawCollection(name)
+	return st.db().GetRawCollection(name)
 }
 
 func HasRawAccess(collectionName string) bool {
@@ -363,7 +363,7 @@ func SequenceWithMin(st *State, name string, minVal int) (int, error) {
 }
 
 func SequenceEnsure(st *State, name string, nextVal int) error {
-	sequences, closer := st.getRawCollection(sequenceC)
+	sequences, closer := st.db().GetRawCollection(sequenceC)
 	defer closer()
 	updater := newDbSeqUpdater(sequences, st.ModelUUID(), name)
 	return updater.ensure(nextVal)

--- a/state/modeluser.go
+++ b/state/modeluser.go
@@ -45,7 +45,7 @@ func (st *State) setModelAccess(access permission.Access, userGlobalKey, modelUU
 // LastModelConnection returns when this User last connected through the API
 // in UTC. The resulting time will be nil if the user has never logged in.
 func (st *State) LastModelConnection(user names.UserTag) (time.Time, error) {
-	lastConnections, closer := st.getRawCollection(modelUserLastConnectionC)
+	lastConnections, closer := st.db().GetRawCollection(modelUserLastConnectionC)
 	defer closer()
 
 	username := user.Id()
@@ -180,7 +180,7 @@ type UserModel struct {
 // LastConnection returns the last time the user has connected to the
 // model.
 func (e *UserModel) LastConnection() (time.Time, error) {
-	lastConnections, lastConnCloser := e.st.getRawCollection(modelUserLastConnectionC)
+	lastConnections, lastConnCloser := e.st.db().GetRawCollection(modelUserLastConnectionC)
 	defer lastConnCloser()
 
 	lastConnDoc := modelUserLastConnectionDoc{}
@@ -224,7 +224,7 @@ func (st *State) ModelsForUser(user names.UserTag) ([]*UserModel, error) {
 	// the models that a particular user can see is to look through the
 	// model user collection. A raw collection is required to support
 	// queries across multiple models.
-	modelUsers, userCloser := st.getRawCollection(modelUsersC)
+	modelUsers, userCloser := st.db().GetRawCollection(modelUsersC)
 	defer userCloser()
 
 	var userSlice []userAccessDoc

--- a/state/restore.go
+++ b/state/restore.go
@@ -88,7 +88,7 @@ func (info *RestoreInfo) Status() (RestoreStatus, error) {
 // These can be caused because this collection is heavy use while backing
 // up and mongo 3.2 does not like this.
 func (info *RestoreInfo) PurgeTxn() error {
-	restoreInfo, closer := info.st.getRawCollection(restoreInfoC)
+	restoreInfo, closer := info.st.db().GetRawCollection(restoreInfoC)
 	defer closer()
 	r := txn.NewRunner(restoreInfo)
 	return r.PurgeMissing(restoreInfoC)

--- a/state/sequence.go
+++ b/state/sequence.go
@@ -55,7 +55,7 @@ func (st *State) sequence(name string) (int, error) {
 // `sequence` is more efficient than `sequenceWithMin` and should be
 // preferred if there is no minimum value requirement.
 func (st *State) sequenceWithMin(name string, minVal int) (int, error) {
-	sequences, closer := st.getRawCollection(sequenceC)
+	sequences, closer := st.db().GetRawCollection(sequenceC)
 	defer closer()
 	updater := newDbSeqUpdater(sequences, st.ModelUUID(), name)
 	return updateSeqWithMin(updater, minVal)

--- a/state/status.go
+++ b/state/status.go
@@ -295,7 +295,7 @@ func PruneStatusHistory(st *State, maxHistoryTime time.Duration, maxHistoryMB in
 	// NOTE(axw) we require a raw collection to obtain the size of the
 	// collection. Take care to include model-uuid in queries where
 	// appropriate.
-	history, closer := st.getRawCollection(statusesHistoryC)
+	history, closer := st.db().GetRawCollection(statusesHistoryC)
 	defer closer()
 
 	// Status Record Age

--- a/state/upgrade.go
+++ b/state/upgrade.go
@@ -175,7 +175,7 @@ func (info *UpgradeInfo) getProvisionedControllers() ([]string, error) {
 	}
 
 	// Extract current and provisioned controllers.
-	instanceData, closer := info.st.getRawCollection(instanceDataC)
+	instanceData, closer := info.st.db().GetRawCollection(instanceDataC)
 	defer closer()
 
 	// If instanceData has the env UUID upgrade query using the
@@ -202,7 +202,7 @@ func (info *UpgradeInfo) getProvisionedControllers() ([]string, error) {
 }
 
 func (info *UpgradeInfo) isModelUUIDUpgradeDone() (bool, error) {
-	instanceData, closer := info.st.getRawCollection(instanceDataC)
+	instanceData, closer := info.st.db().GetRawCollection(instanceDataC)
 	defer closer()
 
 	query := instanceData.Find(bson.D{{"model-uuid", bson.D{{"$exists", true}}}})
@@ -365,7 +365,7 @@ func (st *State) EnsureUpgradeInfo(machineId string, previousVersion, targetVers
 }
 
 func (st *State) isMachineProvisioned(machineId string) (bool, error) {
-	instanceData, closer := st.getRawCollection(instanceDataC)
+	instanceData, closer := st.db().GetRawCollection(instanceDataC)
 	defer closer()
 
 	for _, id := range []string{st.docID(machineId), machineId} {

--- a/state/upgrades_test.go
+++ b/state/upgrades_test.go
@@ -29,7 +29,7 @@ type upgradesSuite struct {
 var _ = gc.Suite(&upgradesSuite{})
 
 func (s *upgradesSuite) TestStripLocalUserDomainCredentials(c *gc.C) {
-	coll, closer := s.state.getRawCollection(cloudCredentialsC)
+	coll, closer := s.state.db().GetRawCollection(cloudCredentialsC)
 	defer closer()
 	err := coll.Insert(
 		cloudCredentialDoc{
@@ -72,7 +72,7 @@ func (s *upgradesSuite) TestStripLocalUserDomainCredentials(c *gc.C) {
 }
 
 func (s *upgradesSuite) TestStripLocalUserDomainModels(c *gc.C) {
-	coll, closer := s.state.getRawCollection(modelsC)
+	coll, closer := s.state.db().GetRawCollection(modelsC)
 	defer closer()
 
 	var initialModels []bson.M
@@ -139,7 +139,7 @@ func (s *upgradesSuite) TestStripLocalUserDomainModels(c *gc.C) {
 }
 
 func (s *upgradesSuite) TestStripLocalUserDomainModelNames(c *gc.C) {
-	coll, closer := s.state.getRawCollection(usermodelnameC)
+	coll, closer := s.state.db().GetRawCollection(usermodelnameC)
 	defer closer()
 
 	err := coll.Insert(
@@ -168,7 +168,7 @@ func (s *upgradesSuite) TestStripLocalUserDomainModelUser(c *gc.C) {
 }
 
 func (s *upgradesSuite) assertStripLocalUserDomainUserAccess(c *gc.C, collName string) {
-	coll, closer := s.state.getRawCollection(collName)
+	coll, closer := s.state.db().GetRawCollection(collName)
 	defer closer()
 
 	var initialUsers []bson.M
@@ -226,7 +226,7 @@ func (s *upgradesSuite) assertStripLocalUserDomainUserAccess(c *gc.C, collName s
 }
 
 func (s *upgradesSuite) TestStripLocalUserDomainPermissions(c *gc.C) {
-	coll, closer := s.state.getRawCollection(permissionsC)
+	coll, closer := s.state.db().GetRawCollection(permissionsC)
 	defer closer()
 
 	var initialPermissions []bson.M
@@ -272,7 +272,7 @@ func (s *upgradesSuite) TestStripLocalUserDomainPermissions(c *gc.C) {
 }
 
 func (s *upgradesSuite) TestStripLocalUserDomainLastConnection(c *gc.C) {
-	coll, closer := s.state.getRawCollection(modelUserLastConnectionC)
+	coll, closer := s.state.db().GetRawCollection(modelUserLastConnectionC)
 	defer closer()
 
 	now := time.Now()
@@ -339,7 +339,7 @@ func (s *upgradesSuite) assertUpgradedData(c *gc.C, upgrade func(*State) error, 
 }
 
 func (s *upgradesSuite) TestRenameAddModelPermission(c *gc.C) {
-	coll, closer := s.state.getRawCollection(permissionsC)
+	coll, closer := s.state.db().GetRawCollection(permissionsC)
 	defer closer()
 
 	var initialPermissions []bson.M
@@ -385,7 +385,7 @@ func (s *upgradesSuite) TestRenameAddModelPermission(c *gc.C) {
 }
 
 func (s *upgradesSuite) TestAddMigrationAttempt(c *gc.C) {
-	coll, closer := s.state.getRawCollection(migrationsC)
+	coll, closer := s.state.db().GetRawCollection(migrationsC)
 	defer closer()
 
 	err := coll.Insert(
@@ -433,7 +433,7 @@ func (s *upgradesSuite) TestAddLocalCharmSequences(c *gc.C) {
 		}
 	}
 
-	charms, closer := s.state.getRawCollection(charmsC)
+	charms, closer := s.state.db().GetRawCollection(charmsC)
 	defer closer()
 	err := charms.Insert(
 		mkInput(uuid0, "local:trusty/bar-2", Alive),
@@ -446,7 +446,7 @@ func (s *upgradesSuite) TestAddLocalCharmSequences(c *gc.C) {
 	)
 	c.Assert(err, jc.ErrorIsNil)
 
-	sequences, closer := s.state.getRawCollection(sequenceC)
+	sequences, closer := s.state.db().GetRawCollection(sequenceC)
 	defer closer()
 
 	mkExpected := func(uuid, urlBase string, counter int) bson.M {
@@ -488,9 +488,9 @@ func (s *upgradesSuite) TestAddLocalCharmSequences(c *gc.C) {
 }
 
 func (s *upgradesSuite) TestUpdateLegacyLXDCloud(c *gc.C) {
-	cloudColl, cloudCloser := s.state.getRawCollection(cloudsC)
+	cloudColl, cloudCloser := s.state.db().GetRawCollection(cloudsC)
 	defer cloudCloser()
-	cloudCredColl, cloudCredCloser := s.state.getRawCollection(cloudCredentialsC)
+	cloudCredColl, cloudCredCloser := s.state.db().GetRawCollection(cloudCredentialsC)
 	defer cloudCredCloser()
 
 	_, err := cloudColl.RemoveAll(nil)
@@ -562,9 +562,9 @@ func (s *upgradesSuite) TestUpdateLegacyLXDCloud(c *gc.C) {
 }
 
 func (s *upgradesSuite) TestUpdateLegacyLXDCloudUnchanged(c *gc.C) {
-	cloudColl, cloudCloser := s.state.getRawCollection(cloudsC)
+	cloudColl, cloudCloser := s.state.db().GetRawCollection(cloudsC)
 	defer cloudCloser()
-	cloudCredColl, cloudCredCloser := s.state.getRawCollection(cloudCredentialsC)
+	cloudCredColl, cloudCredCloser := s.state.db().GetRawCollection(cloudCredentialsC)
 	defer cloudCredCloser()
 
 	_, err := cloudColl.RemoveAll(nil)
@@ -664,7 +664,7 @@ func (s *upgradesSuite) TestUpdateLegacyLXDCloudUnchanged(c *gc.C) {
 }
 
 func (s *upgradesSuite) TestUpgradeNoProxy(c *gc.C) {
-	settingsColl, settingsCloser := s.state.getRawCollection(settingsC)
+	settingsColl, settingsCloser := s.state.db().GetRawCollection(settingsC)
 	defer settingsCloser()
 	_, err := settingsColl.RemoveAll(nil)
 	c.Assert(err, jc.ErrorIsNil)
@@ -706,14 +706,14 @@ func (s *upgradesSuite) TestUpgradeNoProxy(c *gc.C) {
 }
 
 func (s *upgradesSuite) TestAddNonDetachableStorageMachineId(c *gc.C) {
-	volumesColl, volumesCloser := s.state.getRawCollection(volumesC)
+	volumesColl, volumesCloser := s.state.db().GetRawCollection(volumesC)
 	defer volumesCloser()
-	volumeAttachmentsColl, volumeAttachmentsCloser := s.state.getRawCollection(volumeAttachmentsC)
+	volumeAttachmentsColl, volumeAttachmentsCloser := s.state.db().GetRawCollection(volumeAttachmentsC)
 	defer volumeAttachmentsCloser()
 
-	filesystemsColl, filesystemsCloser := s.state.getRawCollection(filesystemsC)
+	filesystemsColl, filesystemsCloser := s.state.db().GetRawCollection(filesystemsC)
 	defer filesystemsCloser()
-	filesystemAttachmentsColl, filesystemAttachmentsCloser := s.state.getRawCollection(filesystemAttachmentsC)
+	filesystemAttachmentsColl, filesystemAttachmentsCloser := s.state.db().GetRawCollection(filesystemAttachmentsC)
 	defer filesystemAttachmentsCloser()
 
 	uuid := s.state.ModelUUID()
@@ -836,7 +836,7 @@ func (s *upgradesSuite) TestAddNonDetachableStorageMachineId(c *gc.C) {
 }
 
 func (s *upgradesSuite) TestRemoveNilValueApplicationSettings(c *gc.C) {
-	settingsColl, settingsCloser := s.state.getRawCollection(settingsC)
+	settingsColl, settingsCloser := s.state.db().GetRawCollection(settingsC)
 	defer settingsCloser()
 	_, err := settingsColl.RemoveAll(nil)
 	c.Assert(err, jc.ErrorIsNil)
@@ -893,7 +893,7 @@ func (s *upgradesSuite) TestRemoveNilValueApplicationSettings(c *gc.C) {
 }
 
 func (s *upgradesSuite) TestAddControllerLogCollectionsSizeSettingsKeepExisting(c *gc.C) {
-	settingsColl, settingsCloser := s.state.getRawCollection(controllersC)
+	settingsColl, settingsCloser := s.state.db().GetRawCollection(controllersC)
 	defer settingsCloser()
 	_, err := settingsColl.RemoveAll(nil)
 	c.Assert(err, jc.ErrorIsNil)
@@ -933,7 +933,7 @@ func (s *upgradesSuite) TestAddControllerLogCollectionsSizeSettingsKeepExisting(
 }
 
 func (s *upgradesSuite) TestAddControllerLogCollectionsSizeSettings(c *gc.C) {
-	settingsColl, settingsCloser := s.state.getRawCollection(controllersC)
+	settingsColl, settingsCloser := s.state.db().GetRawCollection(controllersC)
 	defer settingsCloser()
 	_, err := settingsColl.RemoveAll(nil)
 	c.Assert(err, jc.ErrorIsNil)
@@ -987,7 +987,7 @@ func (s *upgradesSuite) makeModel(c *gc.C, name string, attr testing.Attrs) *Sta
 }
 
 func (s *upgradesSuite) TestAddStatusHistoryPruneSettings(c *gc.C) {
-	settingsColl, settingsCloser := s.state.getRawCollection(settingsC)
+	settingsColl, settingsCloser := s.state.db().GetRawCollection(settingsC)
 	defer settingsCloser()
 	_, err := settingsColl.RemoveAll(nil)
 	c.Assert(err, jc.ErrorIsNil)
@@ -1042,7 +1042,7 @@ func (s *upgradesSuite) TestAddStatusHistoryPruneSettings(c *gc.C) {
 }
 
 func (s *upgradesSuite) TestAddUpdateStatusHookSettings(c *gc.C) {
-	settingsColl, settingsCloser := s.state.getRawCollection(settingsC)
+	settingsColl, settingsCloser := s.state.db().GetRawCollection(settingsC)
 	defer settingsCloser()
 	_, err := settingsColl.RemoveAll(nil)
 	c.Assert(err, jc.ErrorIsNil)
@@ -1104,15 +1104,15 @@ func (s *upgradesSuite) TestAddUpdateStatusHookSettings(c *gc.C) {
 }
 
 func (s *upgradesSuite) TestAddStorageInstanceConstraints(c *gc.C) {
-	storageInstancesColl, storageInstancesCloser := s.state.getRawCollection(storageInstancesC)
+	storageInstancesColl, storageInstancesCloser := s.state.db().GetRawCollection(storageInstancesC)
 	defer storageInstancesCloser()
-	storageConstraintsColl, storageConstraintsCloser := s.state.getRawCollection(storageConstraintsC)
+	storageConstraintsColl, storageConstraintsCloser := s.state.db().GetRawCollection(storageConstraintsC)
 	defer storageConstraintsCloser()
-	volumesColl, volumesCloser := s.state.getRawCollection(volumesC)
+	volumesColl, volumesCloser := s.state.db().GetRawCollection(volumesC)
 	defer volumesCloser()
-	filesystemsColl, filesystemsCloser := s.state.getRawCollection(filesystemsC)
+	filesystemsColl, filesystemsCloser := s.state.db().GetRawCollection(filesystemsC)
 	defer filesystemsCloser()
-	unitsColl, unitsCloser := s.state.getRawCollection(unitsC)
+	unitsColl, unitsCloser := s.state.db().GetRawCollection(unitsC)
 	defer unitsCloser()
 
 	uuid := s.state.ModelUUID()
@@ -1477,9 +1477,9 @@ func (s *upgradesSuite) TestSplitLogsHandlesNoLogsCollection(c *gc.C) {
 }
 
 func (s *upgradesSuite) TestCorrectRelationUnitCounts(c *gc.C) {
-	relations, rCloser := s.state.getRawCollection(relationsC)
+	relations, rCloser := s.state.db().GetRawCollection(relationsC)
 	defer rCloser()
-	scopes, sCloser := s.state.getRawCollection(relationScopesC)
+	scopes, sCloser := s.state.db().GetRawCollection(relationScopesC)
 	defer sCloser()
 
 	// Use the non-controller model to ensure we can run the function

--- a/state/user.go
+++ b/state/user.go
@@ -335,7 +335,7 @@ func (u *User) UserTag() names.UserTag {
 // normal case, the LastLogin is the last time that the user connected through
 // the API server.
 func (u *User) LastLogin() (time.Time, error) {
-	lastLogins, closer := u.st.getRawCollection(userLastLoginC)
+	lastLogins, closer := u.st.db().GetRawCollection(userLastLoginC)
 	defer closer()
 
 	var lastLogin userLastLoginDoc


### PR DESCRIPTION
Also remove the now unused state.getRawCollection function.

This removes unnecessary indirection and makes it easier to refactor
code to take a modelBackend interface.

No functional change.