### PR TITLE
worker/uniter: handle storage IDs with hyphens

### DIFF
--- a/worker/uniter/storage/state.go
+++ b/worker/uniter/storage/state.go
@@ -106,8 +106,14 @@ func readAllStateFiles(dirPath string) (files map[names.StorageTag]*stateFile, e
 		if fi.IsDir() {
 			continue
 		}
-		storageId := strings.Replace(fi.Name(), "-", "/", -1)
-		if !names.IsValidStorage(storageId) {
+		storageId := fi.Name()
+		if i := strings.LastIndex(storageId, "-"); i > 0 {
+			storageId = storageId[:i] + "/" + storageId[i+1:]
+			if !names.IsValidStorage(storageId) {
+				continue
+			}
+		} else {
+			// Lack of "-" means it's not a valid storage ID.
 			continue
 		}
 		tag := names.NewStorageTag(storageId)

--- a/worker/uniter/storage/state_test.go
+++ b/worker/uniter/storage/state_test.go
@@ -58,17 +58,20 @@ func (s *stateSuite) TestReadAllStateFiles(c *gc.C) {
 func (s *stateSuite) TestReadAllStateFilesJunk(c *gc.C) {
 	dir := c.MkDir()
 	writeFile(c, filepath.Join(dir, "data-0"), "attached: true")
-	// data-extra-1 is not a valid storage ID, so it will
+	writeFile(c, filepath.Join(dir, "data-hyphen-1"), "attached: true")
+	// data_underscore-2 is not a valid storage ID, so it will
 	// be ignored by ReadAllStateFiles.
-	writeFile(c, filepath.Join(dir, "data-extra-1"), "attached: false")
+	writeFile(c, filepath.Join(dir, "data_underscore-2"), "attached: false")
 	// subdirs are ignored.
 	err := os.Mkdir(filepath.Join(dir, "data-1"), 0755)
 	c.Assert(err, jc.ErrorIsNil)
 
 	states, err := storage.ReadAllStateFiles(dir)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(states, gc.HasLen, 1)
+	c.Assert(states, gc.HasLen, 2)
 	_, ok := states[names.NewStorageTag("data/0")]
+	c.Assert(ok, jc.IsTrue)
+	_, ok = states[names.NewStorageTag("data-hyphen/1")]
 	c.Assert(ok, jc.IsTrue)
 }
 


### PR DESCRIPTION
## Description of change

Some code in the uniter's storage resolver was
based on old rules for storage ID names, which
disallowed hyphens. We would translate the "/"
in a storage ID to "-" when writing to disk,
and then translating all "-" to "/" on the way
back in, and ignoring the file because it's an
invalid storage ID. Instead we should only
translate the final "-" to "/", since the name
may now contain hyphens.

## QA steps

1. juju bootstrap localhost
2. juju deploy something-with-storage-where-the-storage-name-contains-a-hyphen
3. wait for the unit to become idle, and restart the unit agent

previously the agent would go into a resolver loop, now it does not

## Documentation changes

None.

## Bug reference

Fixes https://bugs.launchpad.net/juju/+bug/1674148