### PR TITLE
refcount model usage of cloud credentials

### DIFF
--- a/api/cloud/cloud.go
+++ b/api/cloud/cloud.go
@@ -122,7 +122,21 @@ func (c *Client) UpdateCredential(tag names.CloudCredentialTag, credential jujuc
 	return results.OneError()
 }
 
-// RevokeCredential revokes/deletes a cloud credential.
+// RemoveCredential removes a cloud credential if no models are using it.
+func (c *Client) RemoveCredential(tag names.CloudCredentialTag) error {
+	var results params.ErrorResults
+	args := params.Entities{
+		Entities: []params.Entity{{
+			Tag: tag.String(),
+		}},
+	}
+	if err := c.facade.FacadeCall("RemoveCredentials", args, &results); err != nil {
+		return errors.Trace(err)
+	}
+	return results.OneError()
+}
+
+// RevokeCredential unconditionally revokes/deletes a cloud credential.
 func (c *Client) RevokeCredential(tag names.CloudCredentialTag) error {
 	var results params.ErrorResults
 	args := params.Entities{

--- a/api/cloud/cloud_test.go
+++ b/api/cloud/cloud_test.go
@@ -202,6 +202,36 @@ func (s *cloudSuite) TestUpdateCredentials(c *gc.C) {
 	c.Assert(called, jc.IsTrue)
 }
 
+func (s *cloudSuite) TestRemoveCredential(c *gc.C) {
+	var called bool
+	apiCaller := basetesting.APICallerFunc(
+		func(objType string,
+			version int,
+			id, request string,
+			a, result interface{},
+		) error {
+			c.Check(objType, gc.Equals, "Cloud")
+			c.Check(id, gc.Equals, "")
+			c.Check(request, gc.Equals, "RemoveCredentials")
+			c.Assert(result, gc.FitsTypeOf, &params.ErrorResults{})
+			c.Assert(a, jc.DeepEquals, params.Entities{Entities: []params.Entity{{
+				Tag: "cloudcred-foo_bob_bar",
+			}}})
+			*result.(*params.ErrorResults) = params.ErrorResults{
+				Results: []params.ErrorResult{{}},
+			}
+			called = true
+			return nil
+		},
+	)
+
+	client := cloudapi.NewClient(apiCaller)
+	tag := names.NewCloudCredentialTag("foo/bob/bar")
+	err := client.RemoveCredential(tag)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(called, jc.IsTrue)
+}
+
 func (s *cloudSuite) TestRevokeCredential(c *gc.C) {
 	var called bool
 	apiCaller := basetesting.APICallerFunc(

--- a/apiserver/facades/client/cloud/backend.go
+++ b/apiserver/facades/client/cloud/backend.go
@@ -19,7 +19,7 @@ type Backend interface {
 	ModelConfig() (*config.Config, error)
 	CloudCredentials(user names.UserTag, cloudName string) (map[string]cloud.Credential, error)
 	UpdateCloudCredential(names.CloudCredentialTag, cloud.Credential) error
-	RemoveCloudCredential(names.CloudCredentialTag) error
+	RemoveCloudCredential(names.CloudCredentialTag, bool) error
 	AddCloud(cloud.Cloud) error
 }
 

--- a/apiserver/facades/client/cloud/cloud.go
+++ b/apiserver/facades/client/cloud/cloud.go
@@ -271,8 +271,17 @@ func (api *CloudAPI) UpdateCredentials(args params.TaggedCredentials) (params.Er
 	return results, nil
 }
 
-// RevokeCredentials revokes a set of cloud credentials.
+// RemoveCredentials removes a set of cloud credentials unless they are in use.
+func (api *CloudAPI) RemoveCredentials(args params.Entities) (params.ErrorResults, error) {
+	return api.removeCredentials(args, false)
+}
+
+// RevokeCredentials revokes a set of cloud credentials, removing them unconditionally.
 func (api *CloudAPI) RevokeCredentials(args params.Entities) (params.ErrorResults, error) {
+	return api.removeCredentials(args, true)
+}
+
+func (api *CloudAPI) removeCredentials(args params.Entities, force bool) (params.ErrorResults, error) {
 	results := params.ErrorResults{
 		Results: make([]params.ErrorResult, len(args.Entities)),
 	}
@@ -292,7 +301,7 @@ func (api *CloudAPI) RevokeCredentials(args params.Entities) (params.ErrorResult
 			results.Results[i].Error = common.ServerError(common.ErrPerm)
 			continue
 		}
-		if err := api.backend.RemoveCloudCredential(tag); err != nil {
+		if err := api.backend.RemoveCloudCredential(tag, force); err != nil {
 			results.Results[i].Error = common.ServerError(err)
 		}
 	}

--- a/state/allcollections.go
+++ b/state/allcollections.go
@@ -265,8 +265,9 @@ func allCollections() collectionSchema {
 		assignUnitC: {},
 
 		// meterStatusC is the collection used to store meter status information.
-		meterStatusC: {},
-		refcountsC:   {},
+		meterStatusC:     {},
+		globalrefcountsC: {global: true},
+		refcountsC:       {},
 		relationsC: {
 			indexes: []mgo.Index{{
 				Key: []string{"model-uuid", "endpoints.relationname"},
@@ -507,6 +508,7 @@ const (
 	endpointBindingsC        = "endpointbindings"
 	settingsC                = "settings"
 	refcountsC               = "refcounts"
+	globalrefcountsC         = "globalrefcounts"
 	sshHostKeysC             = "sshhostkeys"
 	spacesC                  = "spaces"
 	statusesC                = "statuses"

--- a/state/cloudcredentials.go
+++ b/state/cloudcredentials.go
@@ -150,6 +150,7 @@ func (st *State) RemoveCloudCredential(tag names.CloudCredentialTag, force bool)
 			ops = append(ops, refOp)
 		} else {
 			ops = append(ops, nsRefcounts.JustRemoveOp(globalrefcountsC, cloudCredKey, -1))
+			// TODO(cmars): clear references from models with this credential
 		}
 		return ops, nil
 	}

--- a/state/cloudcredentials_test.go
+++ b/state/cloudcredentials_test.go
@@ -190,7 +190,7 @@ func (s *CloudCredentialsSuite) TestRemoveCredentialsInUse(c *gc.C) {
 
 	// Try to remove the cloud credential nicely. Can't because a model is using it.
 	err = s.State.RemoveCloudCredential(tag, false)
-	c.Assert(err, gc.ErrorMatches, ".*refcount changed.*")
+	c.Assert(err, gc.ErrorMatches, "removing cloud credential: cannot remove cloud credential \"cloudcred-dummy_bob_bobcred1\", still in use by 1 models: refcount changed")
 
 	// Check it. Still there.
 	_, err = s.State.CloudCredential(tag)

--- a/state/cloudcredentials_test.go
+++ b/state/cloudcredentials_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/state"
 	statetesting "github.com/juju/juju/state/testing"
+	"github.com/juju/juju/testing/factory"
 )
 
 type CloudCredentialsSuite struct {
@@ -157,7 +158,83 @@ func (s *CloudCredentialsSuite) TestRemoveCredentials(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Remove it.
-	err = s.State.RemoveCloudCredential(tag)
+	err = s.State.RemoveCloudCredential(tag, false)
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Check it.
+	_, err = s.State.CloudCredential(tag)
+	c.Assert(err, jc.Satisfies, errors.IsNotFound)
+}
+
+func (s *CloudCredentialsSuite) TestRemoveCredentialsInUse(c *gc.C) {
+	tag := names.NewCloudCredentialTag("dummy/bob/bobcred1")
+	cred := cloud.NewCredential(cloud.EmptyAuthType, map[string]string{
+		"foo": "foo val",
+		"bar": "bar val",
+	})
+	err := s.State.UpdateCloudCredential(tag, cred)
+	c.Assert(err, jc.ErrorIsNil)
+	_, err = s.State.CloudCredential(tag)
+	c.Assert(err, jc.ErrorIsNil)
+
+	s.Factory.MakeUser(c, &factory.UserParams{
+		Name: "bob",
+	})
+	st := s.Factory.MakeModel(c, &factory.ModelParams{
+		Name:            "test",
+		Owner:           names.NewUserTag("bob"),
+		CloudName:       "dummy",
+		CloudCredential: tag,
+	})
+	defer st.Close()
+
+	// Try to remove the cloud credential nicely. Can't because a model is using it.
+	err = s.State.RemoveCloudCredential(tag, false)
+	c.Assert(err, gc.ErrorMatches, ".*refcount changed.*")
+
+	// Check it. Still there.
+	_, err = s.State.CloudCredential(tag)
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Destroy the model.
+	model, err := s.State.Model()
+	c.Assert(err, jc.ErrorIsNil)
+	err = model.Destroy()
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Removes nicely now.
+	err = s.State.RemoveCloudCredential(tag, false)
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Check it.
+	_, err = s.State.CloudCredential(tag)
+	c.Assert(err, jc.Satisfies, errors.IsNotFound)
+}
+
+func (s *CloudCredentialsSuite) TestRevokeCredentialsInUse(c *gc.C) {
+	tag := names.NewCloudCredentialTag("dummy/bob/bobcred1")
+	cred := cloud.NewCredential(cloud.EmptyAuthType, map[string]string{
+		"foo": "foo val",
+		"bar": "bar val",
+	})
+	err := s.State.UpdateCloudCredential(tag, cred)
+	c.Assert(err, jc.ErrorIsNil)
+	_, err = s.State.CloudCredential(tag)
+	c.Assert(err, jc.ErrorIsNil)
+
+	s.Factory.MakeUser(c, &factory.UserParams{
+		Name: "bob",
+	})
+	st := s.Factory.MakeModel(c, &factory.ModelParams{
+		Name:            "test",
+		Owner:           names.NewUserTag("bob"),
+		CloudName:       "dummy",
+		CloudCredential: tag,
+	})
+	defer st.Close()
+
+	// Remove the cloud credential forcefully.
+	err = s.State.RemoveCloudCredential(tag, true)
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Check it.
@@ -191,7 +268,7 @@ func (s *CloudCredentialsSuite) TestWatchCredential(c *gc.C) {
 	wc.AssertOneChange()
 
 	// Remove.
-	err = s.State.RemoveCloudCredential(cred)
+	err = s.State.RemoveCloudCredential(cred, false)
 	c.Assert(err, jc.ErrorIsNil)
 	wc.AssertOneChange()
 

--- a/state/initialize.go
+++ b/state/initialize.go
@@ -97,7 +97,7 @@ func (p InitializeParams) Validate() error {
 	for tag, cred := range p.CloudCredentials {
 		creds[tag.Id()] = cred
 	}
-	if _, err := validateCloudCredential(
+	if _, _, err := validateCloudCredential(
 		p.Cloud,
 		creds,
 		p.ControllerModelArgs.CloudCredential,

--- a/state/migration_internal_test.go
+++ b/state/migration_internal_test.go
@@ -191,6 +191,7 @@ func (s *MigrationSuite) TestKnownCollections(c *gc.C) {
 		remoteEntitiesC,
 		externalControllersC,
 		relationIngressC,
+		globalrefcountsC,
 	)
 
 	envCollections := set.NewStrings()

--- a/state/model.go
+++ b/state/model.go
@@ -1144,7 +1144,7 @@ func (m *Model) destroyOps(
 		}
 	} else {
 		if cloudCredential, ok := m.CloudCredential(); ok {
-			cloudCredentialRefOps, err := cloudCredentialDecRefOps(m.globalState, cloudCredential)
+			cloudCredentialRefOps, err := cloudCredentialDecRefOps(m.st, cloudCredential)
 			if err != nil {
 				return nil, errors.Annotate(err, "failed to decrement cloud credential refcount for destroyed model")
 			}

--- a/state/model.go
+++ b/state/model.go
@@ -319,7 +319,7 @@ func (st *State) NewModel(args ModelArgs) (_ *Model, _ *State, err error) {
 	if err != nil {
 		return nil, nil, errors.Trace(err)
 	}
-	assertCloudCredentialOp, cloudCredentialOk, err := validateCloudCredential(
+	assertCloudCredentialOp, hasNonEmptyAuth, err := validateCloudCredential(
 		controllerCloud, cloudCredentials, args.CloudCredential,
 	)
 	if err != nil {
@@ -364,7 +364,7 @@ func (st *State) NewModel(args ModelArgs) (_ *Model, _ *State, err error) {
 	}
 	ops := append(prereqOps, modelOps...)
 
-	if cloudCredentialOk {
+	if hasNonEmptyAuth {
 		cloudCredentialRefOp, err := cloudCredentialIncRefOp(newSt, args.CloudCredential)
 		if err != nil {
 			return nil, nil, errors.Annotate(err, "failed to increment cloud credential refcount for new model")
@@ -453,8 +453,9 @@ func validateCloudRegion(cloud jujucloud.Cloud, regionName string) (txn.Op, erro
 
 // validateCloudCredential validates the given cloud credential
 // name against the provided cloud definition and credentials,
-// and returns a txn.Op to include in a transaction to assert the
-// same. A user is supplied, for which access to the credential
+// and returns whether a cloud credential with non-empty auth was matched, and
+// a txn.Op to include in a transaction to assert the same. A user is supplied,
+// for which access to the credential
 // will be asserted.
 func validateCloudCredential(
 	cloud jujucloud.Cloud,


### PR DESCRIPTION
Revoking cloud credentials leaves models in a bad state where they
cannot be destroyed, because the cloud provider resources cannot be
cleaned up without them.

This change introduces a global model refcount on cloud credentials and adds a method Cloud.RemoveCredential, which returns an error if the cloud credential is used by any models. This method should be used by user agents such as the GUI.

Cloud.RevokeCredential will continue to unconditionally remove cloud credentials even if in use.

Because state.NewModel increments the cloud credential ref count and is used when importing a model during migration, I do not think any special migration changes are necessary for this change.

----

## Description of change

> Why is this change needed?

We need to prevent casual revocation of cloud credentials through the API which are in-use by models.

## QA steps

> How do we verify that the change works?

An API call to "Cloud.RevokeCredential" will error if the credential is used by any models, unless the force parameter is true.

## Documentation changes

> Does it affect current user workflow? CLI? API?

It changes the API and the GUI team will need to handle the error.

## Bug reference

> Does this change fix a bug? Please add a link to it.

It somewhat mitigates, but does not completely fix [LP:#1700434](https://bugs.launchpad.net/juju/+bug/1700434). However, this change can improve the usability of Juju by preventing the user from inadvertently putting Juju in a state where cloud resources previously allocated cannot be cleaned up.