### PR TITLE
state: clean up NowToTheSecond and move to modelBackend

### DIFF
--- a/state/action.go
+++ b/state/action.go
@@ -192,7 +192,7 @@ func (a *action) Begin() (Action, error) {
 			Assert: bson.D{{"status", ActionPending}},
 			Update: bson.D{{"$set", bson.D{
 				{"status", ActionRunning},
-				{"started", a.st.NowToTheSecond()},
+				{"started", a.st.nowToTheSecond()},
 			}}},
 		}})
 	if err != nil {
@@ -225,7 +225,7 @@ func (a *action) removeAndLog(finalStatus ActionStatus, results map[string]inter
 				{"status", finalStatus},
 				{"message", message},
 				{"results", results},
-				{"completed", a.st.NowToTheSecond()},
+				{"completed", a.st.nowToTheSecond()},
 			}}},
 		}, {
 			C:      actionNotificationsC,
@@ -261,7 +261,7 @@ func newActionDoc(st *State, receiverTag names.Tag, actionName string, parameter
 			Receiver:   receiverTag.Id(),
 			Name:       actionName,
 			Parameters: parameters,
-			Enqueued:   st.NowToTheSecond(),
+			Enqueued:   st.nowToTheSecond(),
 			Status:     ActionPending,
 		}, actionNotificationDoc{
 			DocId:     st.docID(prefix + actionId.String()),

--- a/state/action_test.go
+++ b/state/action_test.go
@@ -131,7 +131,7 @@ func (s *ActionSuite) TestAddAction(c *gc.C) {
 		expectedErr: "validation failed: \\(root\\)\\.outfile : must be of type string, given 5",
 	}} {
 		c.Logf("Test %d: should %s", i, t.should)
-		before := s.State.NowToTheSecond()
+		before := state.NowToTheSecond(s.State)
 		later := before.Add(testing.LongWait)
 
 		// Copy params over into empty premade map for comparison later
@@ -161,7 +161,7 @@ func (s *ActionSuite) TestAddAction(c *gc.C) {
 
 			// Enqueued time should be within a reasonable time of the beginning
 			// of the test
-			now := s.State.NowToTheSecond()
+			now := state.NowToTheSecond(s.State)
 			c.Check(action.Enqueued(), jc.TimeBetween(before, now))
 			c.Check(action.Enqueued(), jc.TimeBetween(before, later))
 			continue

--- a/state/backend.go
+++ b/state/backend.go
@@ -4,6 +4,8 @@
 package state
 
 import (
+	"time"
+
 	"github.com/juju/errors"
 
 	"github.com/juju/juju/state/watcher"
@@ -25,6 +27,12 @@ type modelBackend interface {
 	// model UUID prefix. If there is no prefix matching the
 	// State's model, an error is returned.
 	strictLocalID(string) (string, error)
+
+	// nowToTheSecond returns the current time in UTC to the nearest second. We use
+	// this for a time source that is not more precise than we can handle. When
+	// serializing time in and out of mongo, we lose enough precision that it's
+	// misleading to store any more than precision to the second.
+	nowToTheSecond() time.Time
 
 	db() Database
 	modelUUID() string
@@ -53,4 +61,8 @@ func (st *State) strictLocalID(id string) (string, error) {
 
 func (st *State) modelUUID() string {
 	return st.ModelUUID()
+}
+
+func (st *State) nowToTheSecond() time.Time {
+	return st.clock.Now().Round(time.Second).UTC()
 }

--- a/state/export_test.go
+++ b/state/export_test.go
@@ -266,6 +266,10 @@ func ConvertTagToCollectionNameAndId(st *State, tag names.Tag) (string, interfac
 	return st.tagToCollectionAndId(tag)
 }
 
+func NowToTheSecond(st *State) time.Time {
+	return st.nowToTheSecond()
+}
+
 func RunTransaction(st *State, ops []txn.Op) error {
 	return st.db().RunTransaction(ops)
 }

--- a/state/metrics_test.go
+++ b/state/metrics_test.go
@@ -34,7 +34,7 @@ func (s *MetricSuite) SetUpTest(c *gc.C) {
 }
 
 func (s *MetricSuite) TestAddNoMetrics(c *gc.C) {
-	now := s.State.NowToTheSecond()
+	now := state.NowToTheSecond(s.State)
 	_, err := s.State.AddMetrics(state.BatchParam{
 		UUID:     utils.MustNewUUID().String(),
 		CharmURL: s.meteredCharm.URL().String(),
@@ -57,7 +57,7 @@ func ensureUnitDead(c *gc.C, unit *state.Unit) {
 }
 
 func (s *MetricSuite) TestAddMetric(c *gc.C) {
-	now := s.State.NowToTheSecond()
+	now := state.NowToTheSecond(s.State)
 	modelUUID := s.State.ModelUUID()
 	m := state.Metric{"pings", "5", now}
 	metricBatch, err := s.State.AddMetrics(
@@ -95,7 +95,7 @@ func (s *MetricSuite) TestAddMetric(c *gc.C) {
 }
 
 func (s *MetricSuite) TestAddModelMetricMetric(c *gc.C) {
-	now := s.State.NowToTheSecond()
+	now := state.NowToTheSecond(s.State)
 	modelUUID := s.State.ModelUUID()
 	m := state.Metric{"pings", "5", now}
 	metricBatch, err := s.State.AddModelMetrics(
@@ -134,7 +134,7 @@ func (s *MetricSuite) TestAddModelMetricMetric(c *gc.C) {
 
 func (s *MetricSuite) TestAddMetricNonExistentUnit(c *gc.C) {
 	removeUnit(c, s.unit)
-	now := s.State.NowToTheSecond()
+	now := state.NowToTheSecond(s.State)
 	m := state.Metric{"pings", "5", now}
 	unitTag := names.NewUnitTag("test/0")
 	_, err := s.State.AddMetrics(
@@ -151,7 +151,7 @@ func (s *MetricSuite) TestAddMetricNonExistentUnit(c *gc.C) {
 
 func (s *MetricSuite) TestAddMetricDeadUnit(c *gc.C) {
 	ensureUnitDead(c, s.unit)
-	now := s.State.NowToTheSecond()
+	now := state.NowToTheSecond(s.State)
 	m := state.Metric{"pings", "5", now}
 	_, err := s.State.AddMetrics(
 		state.BatchParam{
@@ -166,7 +166,7 @@ func (s *MetricSuite) TestAddMetricDeadUnit(c *gc.C) {
 }
 
 func (s *MetricSuite) TestSetMetricSent(c *gc.C) {
-	now := s.State.NowToTheSecond()
+	now := state.NowToTheSecond(s.State)
 	m := state.Metric{"pings", "5", now}
 	added, err := s.State.AddMetrics(
 		state.BatchParam{
@@ -284,7 +284,7 @@ func (s *MetricSuite) TestCleanupMetricsIgnoreNotSent(c *gc.C) {
 }
 
 func (s *MetricSuite) TestAllMetricBatches(c *gc.C) {
-	now := s.State.NowToTheSecond()
+	now := state.NowToTheSecond(s.State)
 	m := state.Metric{"pings", "5", now}
 	_, err := s.State.AddMetrics(
 		state.BatchParam{
@@ -306,7 +306,7 @@ func (s *MetricSuite) TestAllMetricBatches(c *gc.C) {
 }
 
 func (s *MetricSuite) TestAllMetricBatchesCustomCharmURLAndUUID(c *gc.C) {
-	now := s.State.NowToTheSecond()
+	now := state.NowToTheSecond(s.State)
 	m := state.Metric{"pings", "5", now}
 	uuid := utils.MustNewUUID().String()
 	charmURL := "cs:quantal/metered-1"
@@ -331,7 +331,7 @@ func (s *MetricSuite) TestAllMetricBatchesCustomCharmURLAndUUID(c *gc.C) {
 }
 
 func (s *MetricSuite) TestMetricCredentials(c *gc.C) {
-	now := s.State.NowToTheSecond()
+	now := state.NowToTheSecond(s.State)
 	m := state.Metric{"pings", "5", now}
 	err := s.application.SetMetricCredentials([]byte("hello there"))
 	c.Assert(err, gc.IsNil)
@@ -388,7 +388,7 @@ func (s *MetricSuite) TestSetMetricBatchesSent(c *gc.C) {
 }
 
 func (s *MetricSuite) TestMetricsToSend(c *gc.C) {
-	now := s.State.NowToTheSecond()
+	now := state.NowToTheSecond(s.State)
 	m := []state.Metric{{Key: "pings", Value: "123", Time: now}}
 	s.Factory.MakeMetric(c, &factory.MetricParams{Unit: s.unit, Sent: false, Time: &now, Metrics: m})
 	s.Factory.MakeMetric(c, &factory.MetricParams{Unit: s.unit, Sent: false, Time: &now, Metrics: m})
@@ -400,7 +400,7 @@ func (s *MetricSuite) TestMetricsToSend(c *gc.C) {
 
 // TestMetricsToSendBatches checks that metrics are properly batched.
 func (s *MetricSuite) TestMetricsToSendBatches(c *gc.C) {
-	now := s.State.NowToTheSecond()
+	now := state.NowToTheSecond(s.State)
 	for i := 0; i < 6; i++ {
 		m := []state.Metric{{Key: "pings", Value: "123", Time: now}}
 		s.Factory.MakeMetric(c, &factory.MetricParams{Unit: s.unit, Sent: false, Time: &now, Metrics: m})
@@ -503,7 +503,7 @@ func (s *MetricSuite) TestMetricValidation(c *gc.C) {
 }
 
 func (s *MetricSuite) TestAddMetricDuplicateUUID(c *gc.C) {
-	now := s.State.NowToTheSecond()
+	now := state.NowToTheSecond(s.State)
 	mUUID := utils.MustNewUUID().String()
 	_, err := s.State.AddMetrics(
 		state.BatchParam{
@@ -552,7 +552,7 @@ func (s *MetricSuite) TestAddBuiltInMetric(c *gc.C) {
 	}
 	for _, test := range tests {
 		c.Logf("running test: %v", test.about)
-		now := s.State.NowToTheSecond()
+		now := state.NowToTheSecond(s.State)
 		modelUUID := s.State.ModelUUID()
 		m := state.Metric{"juju-units", test.value, now}
 		metricBatch, err := s.State.AddMetrics(
@@ -595,7 +595,7 @@ func (s *MetricSuite) TestAddBuiltInMetric(c *gc.C) {
 }
 
 func (s *MetricSuite) TestUnitMetricBatchesMatchesAllCharms(c *gc.C) {
-	now := s.State.NowToTheSecond()
+	now := state.NowToTheSecond(s.State)
 	m := state.Metric{"pings", "5", now}
 	_, err := s.State.AddMetrics(
 		state.BatchParam{
@@ -654,7 +654,7 @@ func (s *MetricLocalCharmSuite) SetUpTest(c *gc.C) {
 }
 
 func (s *MetricLocalCharmSuite) TestUnitMetricBatches(c *gc.C) {
-	now := s.State.NowToTheSecond()
+	now := state.NowToTheSecond(s.State)
 	m := state.Metric{"pings", "5", now}
 	m2 := state.Metric{"pings", "10", now}
 	_, err := s.State.AddMetrics(
@@ -700,7 +700,7 @@ func (s *MetricLocalCharmSuite) TestUnitMetricBatches(c *gc.C) {
 }
 
 func (s *MetricLocalCharmSuite) TestApplicationMetricBatches(c *gc.C) {
-	now := s.State.NowToTheSecond()
+	now := state.NowToTheSecond(s.State)
 	m := state.Metric{"pings", "5", now}
 	m2 := state.Metric{"pings", "10", now}
 	_, err := s.State.AddMetrics(
@@ -744,7 +744,7 @@ func (s *MetricLocalCharmSuite) TestApplicationMetricBatches(c *gc.C) {
 }
 
 func (s *MetricLocalCharmSuite) TestModelMetricBatches(c *gc.C) {
-	now := s.State.NowToTheSecond()
+	now := state.NowToTheSecond(s.State)
 	// Add 2 metric batches to a single unit.
 	m := state.Metric{"pings", "5", now}
 	m2 := state.Metric{"pings", "10", now}
@@ -896,7 +896,7 @@ func assertMetricBatchesTimeAscending(c *gc.C, batches []state.MetricBatch) {
 }
 
 func (s *MetricLocalCharmSuite) TestUnitMetricBatchesReturnsAllCharms(c *gc.C) {
-	now := s.State.NowToTheSecond()
+	now := state.NowToTheSecond(s.State)
 	m := state.Metric{"pings", "5", now}
 	_, err := s.State.AddMetrics(
 		state.BatchParam{
@@ -929,7 +929,7 @@ func (s *MetricLocalCharmSuite) TestUnitMetricBatchesReturnsAllCharms(c *gc.C) {
 }
 
 func (s *MetricLocalCharmSuite) TestUnique(c *gc.C) {
-	t0 := s.State.NowToTheSecond()
+	t0 := state.NowToTheSecond(s.State)
 	t1 := t0.Add(time.Second)
 	batch, err := s.State.AddMetrics(
 		state.BatchParam{
@@ -1012,7 +1012,7 @@ func mustCreateMeteredModel(c *gc.C, stateFactory *factory.Factory) (modelData, 
 }
 
 func (s *CrossModelMetricSuite) TestMetricsAcrossEnvironments(c *gc.C) {
-	now := s.State.NowToTheSecond().Add(-48 * time.Hour)
+	now := state.NowToTheSecond(s.State).Add(-48 * time.Hour)
 	m := state.Metric{"pings", "5", now}
 	m1, err := s.models[0].state.AddMetrics(
 		state.BatchParam{

--- a/state/migration_export_test.go
+++ b/state/migration_export_test.go
@@ -199,7 +199,7 @@ func (s *MigrationExportSuite) TestModelInfo(c *gc.C) {
 func (s *MigrationExportSuite) TestModelUsers(c *gc.C) {
 	// Make sure we have some last connection times for the admin user,
 	// and create a few other users.
-	lastConnection := s.State.NowToTheSecond()
+	lastConnection := state.NowToTheSecond(s.State)
 	owner, err := s.State.UserAccess(s.Owner, s.State.ModelTag())
 	c.Assert(err, jc.ErrorIsNil)
 	err = state.UpdateModelUserLastConnection(s.State, owner, lastConnection)

--- a/state/migration_import_test.go
+++ b/state/migration_import_test.go
@@ -218,7 +218,7 @@ func (s *MigrationImportSuite) TestModelUsers(c *gc.C) {
 	err := s.State.RemoveUserAccess(s.Owner, s.modelTag)
 	c.Assert(err, jc.ErrorIsNil)
 
-	lastConnection := s.State.NowToTheSecond()
+	lastConnection := state.NowToTheSecond(s.State)
 
 	bravo := s.newModelUser(c, "bravo@external", false, lastConnection)
 	charlie := s.newModelUser(c, "charlie@external", true, lastConnection)

--- a/state/model.go
+++ b/state/model.go
@@ -982,7 +982,7 @@ func (m *Model) destroyOps(ensureNoHostedModels, ensureEmpty bool) ([]txn.Op, er
 		prereqOps = append(prereqOps, assertHostedModelsOp(aliveEmpty+dead))
 	}
 
-	timeOfDying := st.NowToTheSecond()
+	timeOfDying := st.nowToTheSecond()
 	modelUpdateValues := bson.D{
 		{"life", nextLife},
 		{"time-of-dying", timeOfDying},

--- a/state/modeluser.go
+++ b/state/modeluser.go
@@ -79,7 +79,7 @@ func IsNeverConnectedError(err error) bool {
 
 // UpdateLastModelConnection updates the last connection time of the model user.
 func (st *State) UpdateLastModelConnection(user names.UserTag) error {
-	return st.updateLastModelConnection(user, st.NowToTheSecond())
+	return st.updateLastModelConnection(user, st.nowToTheSecond())
 }
 
 func (st *State) updateLastModelConnection(user names.UserTag, when time.Time) error {

--- a/state/modeluser_test.go
+++ b/state/modeluser_test.go
@@ -27,7 +27,7 @@ type ModelUserSuite struct {
 var _ = gc.Suite(&ModelUserSuite{})
 
 func (s *ModelUserSuite) TestAddModelUser(c *gc.C) {
-	now := s.State.NowToTheSecond()
+	now := state.NowToTheSecond(s.State)
 	user := s.Factory.MakeUser(c,
 		&factory.UserParams{
 			Name:        "validusername",
@@ -304,7 +304,7 @@ func (s *ModelUserSuite) TestRemoveModelUserFails(c *gc.C) {
 }
 
 func (s *ModelUserSuite) TestUpdateLastConnection(c *gc.C) {
-	now := s.State.NowToTheSecond()
+	now := state.NowToTheSecond(s.State)
 	createdBy := s.Factory.MakeUser(c, &factory.UserParams{Name: "createdby"})
 	user := s.Factory.MakeUser(c, &factory.UserParams{Name: "validusername", Creator: createdBy.Tag()})
 	modelUser, err := s.State.UserAccess(user.UserTag(), s.State.ModelTag())
@@ -319,7 +319,7 @@ func (s *ModelUserSuite) TestUpdateLastConnection(c *gc.C) {
 }
 
 func (s *ModelUserSuite) TestUpdateLastConnectionTwoModelUsers(c *gc.C) {
-	now := s.State.NowToTheSecond()
+	now := state.NowToTheSecond(s.State)
 
 	// Create a user and add them to the inital model.
 	createdBy := s.Factory.MakeUser(c, &factory.UserParams{Name: "createdby"})

--- a/state/open.go
+++ b/state/open.go
@@ -330,7 +330,7 @@ func Initialize(args InitializeParams) (_ *State, err error) {
 		return nil, err
 	}
 
-	dateCreated := st.NowToTheSecond()
+	dateCreated := st.nowToTheSecond()
 	ops := createInitialUserOps(
 		args.ControllerConfig.ControllerUUID(),
 		args.ControllerModelArgs.Owner,
@@ -422,7 +422,7 @@ func (st *State) modelSetupOps(controllerUUID string, args ModelArgs, inherited 
 	}
 
 	modelUserOps := createModelUserOps(
-		modelUUID, args.Owner, args.Owner, args.Owner.Name(), st.NowToTheSecond(), permission.AdminAccess,
+		modelUUID, args.Owner, args.Owner, args.Owner.Name(), st.nowToTheSecond(), permission.AdminAccess,
 	)
 	ops := []txn.Op{
 		createStatusOp(st, modelGlobalKey, modelStatusDoc),

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -4451,7 +4451,7 @@ func (s *StateSuite) TestWatchMachineAddresses(c *gc.C) {
 }
 
 func (s *StateSuite) TestNowToTheSecond(c *gc.C) {
-	t := s.State.NowToTheSecond()
+	t := state.NowToTheSecond(s.State)
 	rounded := t.Round(time.Second)
 	c.Assert(t, gc.DeepEquals, rounded)
 }

--- a/state/undertaker.go
+++ b/state/undertaker.go
@@ -46,7 +46,7 @@ func (st *State) ProcessDyingModel() (err error) {
 			Assert: isDyingDoc,
 			Update: bson.M{"$set": bson.M{
 				"life":          Dead,
-				"time-of-death": st.NowToTheSecond(),
+				"time-of-death": st.nowToTheSecond(),
 			}},
 		}}
 		return ops, nil

--- a/state/user.go
+++ b/state/user.go
@@ -72,7 +72,7 @@ func (st *State) addUser(name, displayName, password, creator string, secretKey 
 	}
 	nameToLower := strings.ToLower(name)
 
-	dateCreated := st.NowToTheSecond()
+	dateCreated := st.nowToTheSecond()
 	user := &User{
 		st: st,
 		doc: userDoc{
@@ -350,14 +350,6 @@ func (u *User) LastLogin() (time.Time, error) {
 	return lastLogin.LastLogin.UTC(), nil
 }
 
-// NowToTheSecond returns the current time in UTC to the nearest second. We use
-// this for a time source that is not more precise than we can handle. When
-// serializing time in and out of mongo, we lose enough precision that it's
-// misleading to store any more than precision to the second.
-func (st *State) NowToTheSecond() time.Time {
-	return st.clock.Now().Round(time.Second).UTC()
-}
-
 // NeverLoggedInError is used to indicate that a user has never logged in.
 type NeverLoggedInError string
 
@@ -392,7 +384,7 @@ func (u *User) UpdateLastLogin() (err error) {
 	lastLogin := userLastLoginDoc{
 		DocID:     u.doc.DocID,
 		ModelUUID: u.st.ModelUUID(),
-		LastLogin: u.st.NowToTheSecond(),
+		LastLogin: u.st.nowToTheSecond(),
 	}
 
 	_, err = lastLoginsW.UpsertId(lastLogin.DocID, lastLogin)

--- a/state/useraccess.go
+++ b/state/useraccess.go
@@ -89,7 +89,7 @@ func (st *State) addUserAccess(spec UserAccessSpec, target userAccessTarget) (pe
 			spec.User,
 			spec.CreatedBy,
 			spec.DisplayName,
-			st.NowToTheSecond(),
+			st.nowToTheSecond(),
 			spec.Access)
 		targetTag = names.NewModelTag(target.uuid)
 	case controllerGlobalKey:
@@ -98,7 +98,7 @@ func (st *State) addUserAccess(spec UserAccessSpec, target userAccessTarget) (pe
 			spec.User,
 			spec.CreatedBy,
 			spec.DisplayName,
-			st.NowToTheSecond(),
+			st.nowToTheSecond(),
 			spec.Access)
 		targetTag = st.controllerTag
 	default:


### PR DESCRIPTION
Stop exporting State.NowToTheSecond - it is not necessary outside of
testing; provide a NowToTheSecond via export_test.go instead. Also
provide nowToTheSecond via modelBackend instead of directly on State,
which will simplify future modelBackend migrations.