### PR TITLE
Refresh controller in local store when doing show-controller

### DIFF
--- a/cmd/juju/controller/listcontrollers.go
+++ b/cmd/juju/controller/listcontrollers.go
@@ -162,11 +162,11 @@ func (c *listControllersCommand) refreshControllerDetails(client ControllerAcces
 		machineCount += s.TotalMachineCount
 	}
 	details.MachineCount = &machineCount
-	details.ActiveControllerMachineCount, details.ControllerMachineCount = controllerMachineCounts(controllerModelUUID, modelStatus)
+	details.ActiveControllerMachineCount, details.ControllerMachineCount = ControllerMachineCounts(controllerModelUUID, modelStatus)
 	return c.store.UpdateController(controllerName, *details)
 }
 
-func controllerMachineCounts(controllerModelUUID string, modelStatus []base.ModelStatus) (activeCount, totalCount int) {
+func ControllerMachineCounts(controllerModelUUID string, modelStatus []base.ModelStatus) (activeCount, totalCount int) {
 	for _, s := range modelStatus {
 		if s.UUID != controllerModelUUID {
 			continue

--- a/cmd/juju/controller/package_test.go
+++ b/cmd/juju/controller/package_test.go
@@ -85,7 +85,7 @@ controllers:
     current-model: controller
   mallards:
     models:
-      controller:
+      model0:
         uuid: abc
       my-model:
         uuid: def


### PR DESCRIPTION
## Description of change
juju list-controllers will show outdated information until someone launches it with --refresh. Since when doing show-controller we have all the necessary information to refresh the state - do it.
Why is this change needed?

## QA steps
- Bootstrap a controller
- list-controllers, see that HA is not enabled
- enable-ha, wait for it to settle without doing show-controller
- list-controllers, see that HA there is still not enabled
- show-controller
- list-controllers, HA should be visible.

## Documentation changes
None

## Bug reference
https://bugs.launchpad.net/juju/+bug/1634847
