### PR TITLE
Allow user defined egress-cidrs for use with cmr

### DIFF
--- a/environs/config/config_test.go
+++ b/environs/config/config_test.go
@@ -1124,6 +1124,13 @@ func (s *ConfigSuite) TestUpdateStatusHookIntervalConfigValue(c *gc.C) {
 	c.Assert(cfg.UpdateStatusHookInterval(), gc.Equals, 30*time.Minute)
 }
 
+func (s *ConfigSuite) TestEgressCidrs(c *gc.C) {
+	cfg := newTestConfig(c, testing.Attrs{
+		"egress-cidrs": "10.0.0.1/32, 192.168.1.1/16",
+	})
+	c.Assert(cfg.EgressCidrs(), gc.DeepEquals, []string{"10.0.0.1/32", "192.168.1.1/16"})
+}
+
 func (s *ConfigSuite) TestSchemaNoExtra(c *gc.C) {
 	schema, err := config.Schema(nil)
 	c.Assert(err, gc.IsNil)


### PR DESCRIPTION
## Description of change

If a Juju model is deployed behind a NAT firewall or similar, the source address of cmr traffic across controllers will not be the addresses of the consuming workloads. We introduce a new model config attribute "egress-cidrs" to allow the user to define one or more egress cidrs which will override the source addresses sent to the offering model to open in the firewaller.

## QA steps

deploy a cmr solution
set the egress-cidrs model config attribute in the consuming model
check the firewall in the offering model to see that the correct addresses have been allowed access
