### PR TITLE
state: stop using ForModel in Model methods

### DIFF
--- a/state/addmachine.go
+++ b/state/addmachine.go
@@ -503,8 +503,8 @@ func (st *State) insertNewMachineOps(mdoc *machineDoc, template MachineTemplate)
 	// history entry. This is risky, and may lead to extra entries, but that's
 	// an intrinsic problem with mixing txn and non-txn ops -- we can't sync
 	// them cleanly.
-	probablyUpdateStatusHistory(st, machineGlobalKey(mdoc.Id), machineStatusDoc)
-	probablyUpdateStatusHistory(st, machineGlobalInstanceKey(mdoc.Id), instanceStatusDoc)
+	probablyUpdateStatusHistory(st.db(), machineGlobalKey(mdoc.Id), machineStatusDoc)
+	probablyUpdateStatusHistory(st.db(), machineGlobalInstanceKey(mdoc.Id), instanceStatusDoc)
 	return prereqOps, machineOp, nil
 }
 

--- a/state/allwatcher.go
+++ b/state/allwatcher.go
@@ -149,7 +149,7 @@ func (e *backingModel) updated(st *State, store *multiwatcherStore, id string) e
 		return errors.Trace(err)
 	}
 	info.Constraints = c
-	modelStatus, err := getStatus(st, modelGlobalKey, "model")
+	modelStatus, err := getStatus(st.db(), modelGlobalKey, "model")
 	if e.isNotFoundAndModelDead(err) {
 		// Treat it as if the model is removed.
 		return e.removed(store, e.UUID, e.UUID, st)
@@ -446,7 +446,7 @@ func (app *backingApplication) updated(st *State, store *multiwatcherStore, id s
 		}
 		info.Constraints = c
 		needConfig = true
-		applicationStatus, err := getStatus(st, key, "application")
+		applicationStatus, err := getStatus(st.db(), key, "application")
 		if err != nil {
 			return errors.Annotatef(err, "reading application status for key %s", key)
 		}
@@ -485,7 +485,7 @@ func (app *backingApplication) updated(st *State, store *multiwatcherStore, id s
 		}
 	}
 	if needConfig {
-		doc, err := readSettingsDoc(st, settingsC, applicationSettingsKey(app.Name, app.CharmURL))
+		doc, err := readSettingsDoc(st.db(), settingsC, applicationSettingsKey(app.Name, app.CharmURL))
 		if err != nil {
 			return errors.Trace(err)
 		}
@@ -530,7 +530,7 @@ func (app *backingRemoteApplication) updated(st *State, store *multiwatcherStore
 		logger.Debugf("new remote application %q added to backing state", app.Name)
 		// Fetch the status.
 		key := remoteApplicationGlobalKey(app.Name)
-		serviceStatus, err := getStatus(st, key, "remote application")
+		serviceStatus, err := getStatus(st.db(), key, "remote application")
 		if err != nil {
 			return errors.Annotatef(err, "reading remote application status for key %s", key)
 		}
@@ -787,7 +787,7 @@ func (s *backingStatus) updated(st *State, store *multiwatcherStore, id string) 
 		newInfo := *info
 		// Get the unit's current recorded status from state.
 		// It's needed to reset the unit status when a unit comes off error.
-		statusInfo, err := getStatus(st, unitGlobalKey(newInfo.Name), "unit")
+		statusInfo, err := getStatus(st.db(), unitGlobalKey(newInfo.Name), "unit")
 		if err != nil {
 			return err
 		}

--- a/state/allwatcher_internal_test.go
+++ b/state/allwatcher_internal_test.go
@@ -1607,7 +1607,7 @@ func (s *allModelWatcherStateSuite) TestMissingModelSettings(c *gc.C) {
 
 	// Updating a dead model with missing settings actually causes the
 	// model to be removed from the watcher.
-	err := removeSettings(s.state, settingsC, modelGlobalKey)
+	err := removeSettings(s.state.db(), settingsC, modelGlobalKey)
 	c.Assert(err, jc.ErrorIsNil)
 	ops := []txn.Op{{
 		C:      modelsC,

--- a/state/application.go
+++ b/state/application.go
@@ -575,7 +575,7 @@ func (a *Application) changeCharmOps(
 ) ([]txn.Op, error) {
 	// Build the new application config from what can be used of the old one.
 	var newSettings charm.Settings
-	oldSettings, err := readSettings(a.st, settingsC, a.settingsKey())
+	oldSettings, err := readSettings(a.st.db(), settingsC, a.settingsKey())
 	if err == nil {
 		// Filter the old settings through to get the new settings.
 		newSettings = ch.Config().FilterSettings(oldSettings.Map())
@@ -592,14 +592,14 @@ func (a *Application) changeCharmOps(
 	// Create or replace application settings.
 	var settingsOp txn.Op
 	newSettingsKey := applicationSettingsKey(a.doc.Name, ch.URL())
-	if _, err := readSettings(a.st, settingsC, newSettingsKey); errors.IsNotFound(err) {
+	if _, err := readSettings(a.st.db(), settingsC, newSettingsKey); errors.IsNotFound(err) {
 		// No settings for this key yet, create it.
 		settingsOp = createSettingsOp(settingsC, newSettingsKey, newSettings)
 	} else if err != nil {
 		return nil, errors.Trace(err)
 	} else {
 		// Settings exist, just replace them with the new ones.
-		settingsOp, _, err = replaceSettingsOp(a.st, settingsC, newSettingsKey, newSettings)
+		settingsOp, _, err = replaceSettingsOp(a.st.db(), settingsC, newSettingsKey, newSettings)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
@@ -1194,9 +1194,9 @@ func (a *Application) addUnitOpsWithCons(args applicationAddUnitOpsArgs) (string
 	// history entries. This is risky, and may lead to extra entries, but that's
 	// an intrinsic problem with mixing txn and non-txn ops -- we can't sync
 	// them cleanly.
-	probablyUpdateStatusHistory(a.st, globalKey, unitStatusDoc)
-	probablyUpdateStatusHistory(a.st, agentGlobalKey, agentStatusDoc)
-	probablyUpdateStatusHistory(a.st, globalWorkloadVersionKey(name), workloadVersionDoc)
+	probablyUpdateStatusHistory(a.st.db(), globalKey, unitStatusDoc)
+	probablyUpdateStatusHistory(a.st.db(), agentGlobalKey, agentStatusDoc)
+	probablyUpdateStatusHistory(a.st.db(), globalWorkloadVersionKey(name), workloadVersionDoc)
 	return name, ops, nil
 }
 
@@ -1376,7 +1376,7 @@ func applicationRelations(st *State, name string) (relations []*Relation, err er
 // ConfigSettings returns the raw user configuration for the application's charm.
 // Unset values are omitted.
 func (a *Application) ConfigSettings() (charm.Settings, error) {
-	settings, err := readSettings(a.st, settingsC, a.settingsKey())
+	settings, err := readSettings(a.st.db(), settingsC, a.settingsKey())
 	if err != nil {
 		return nil, err
 	}
@@ -1398,7 +1398,7 @@ func (a *Application) UpdateConfigSettings(changes charm.Settings) error {
 	// about every use case. This needs to be resolved some time; but at
 	// least the settings docs are keyed by charm url as well as application
 	// name, so the actual impact of a race is non-threatening.
-	node, err := readSettings(a.st, settingsC, a.settingsKey())
+	node, err := readSettings(a.st.db(), settingsC, a.settingsKey())
 	if err != nil {
 		return err
 	}
@@ -1420,7 +1420,7 @@ func (a *Application) LeaderSettings() (map[string]string, error) {
 	// thus require an extra db read to access them -- but it stops the State
 	// type getting even more cluttered.
 
-	doc, err := readSettingsDoc(a.st, settingsC, leadershipSettingsKey(a.doc.Name))
+	doc, err := readSettingsDoc(a.st.db(), settingsC, leadershipSettingsKey(a.doc.Name))
 	if errors.IsNotFound(err) {
 		return nil, errors.NotFoundf("application")
 	} else if err != nil {
@@ -1482,7 +1482,7 @@ func (a *Application) UpdateLeaderSettings(token leadership.Token, updates map[s
 		// Read the current document state so we can abort if there's
 		// no actual change; and the version number so we can assert
 		// on it and prevent these settings from landing late.
-		doc, err := readSettingsDoc(a.st, settingsC, key)
+		doc, err := readSettingsDoc(a.st.db(), settingsC, key)
 		if errors.IsNotFound(err) {
 			return nil, errors.NotFoundf("application")
 		} else if err != nil {
@@ -1647,7 +1647,7 @@ func (a *Application) Status() (status.StatusInfo, error) {
 			return a.deriveStatus(units)
 		}
 	}
-	return getStatus(a.st, a.globalKey(), "application")
+	return getStatus(a.st.db(), a.globalKey(), "application")
 }
 
 // SetStatus sets the status for the application.
@@ -1655,13 +1655,13 @@ func (a *Application) SetStatus(statusInfo status.StatusInfo) error {
 	if !status.ValidWorkloadStatus(statusInfo.Status) {
 		return errors.Errorf("cannot set invalid status %q", statusInfo.Status)
 	}
-	return setStatus(a.st, setStatusParams{
+	return setStatus(a.st.db(), setStatusParams{
 		badge:     "application",
 		globalKey: a.globalKey(),
 		status:    statusInfo.Status,
 		message:   statusInfo.Message,
 		rawData:   statusInfo.Data,
-		updated:   statusInfo.Since,
+		updated:   timeOrNow(statusInfo.Since, a.st.clock),
 	})
 }
 
@@ -1670,7 +1670,7 @@ func (a *Application) SetStatus(statusInfo status.StatusInfo) error {
 // representing past statuses for this application.
 func (a *Application) StatusHistory(filter status.StatusHistoryFilter) ([]status.StatusInfo, error) {
 	args := &statusHistoryArgs{
-		st:        a.st,
+		db:        a.st.db(),
 		globalKey: a.globalKey(),
 		filter:    filter,
 	}

--- a/state/controller.go
+++ b/state/controller.go
@@ -27,7 +27,7 @@ func controllerKey(controllerUUID string) string {
 
 // ControllerConfig returns the config values for the controller.
 func (st *State) ControllerConfig() (jujucontroller.Config, error) {
-	settings, err := readSettings(st, controllersC, controllerSettingsGlobalKey)
+	settings, err := readSettings(st.db(), controllersC, controllerSettingsGlobalKey)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/state/export_test.go
+++ b/state/export_test.go
@@ -58,7 +58,6 @@ var (
 	AddVolumeOps                         = (*State).addVolumeOps
 	CombineMeterStatus                   = combineMeterStatus
 	ApplicationGlobalKey                 = applicationGlobalKey
-	ReadSettings                         = readSettings
 	ControllerInheritedSettingsGlobalKey = controllerInheritedSettingsGlobalKey
 	ModelGlobalKey                       = modelGlobalKey
 	MergeBindings                        = mergeBindings
@@ -601,7 +600,7 @@ func PrimeUnitStatusHistory(
 	}
 
 	var buildTxn jujutxn.TransactionSource = func(int) ([]txn.Op, error) {
-		return statusSetOps(unit.st, doc, globalKey)
+		return statusSetOps(unit.st.db(), doc, globalKey)
 	}
 
 	err := unit.st.run(buildTxn)
@@ -669,13 +668,13 @@ func AssertNoCleanups(c *gc.C, st *State) {
 // GetApplicationSettings allows access to settings collection for a
 // given application.
 func GetApplicationSettings(st *State, app *Application) *Settings {
-	return newSettings(st, settingsC, app.settingsKey())
+	return newSettings(st.db(), settingsC, app.settingsKey())
 }
 
 // GetControllerSettings allows access to settings collection for
 // the controller.
 func GetControllerSettings(st *State) *Settings {
-	return newSettings(st, controllersC, controllerSettingsGlobalKey)
+	return newSettings(st.db(), controllersC, controllerSettingsGlobalKey)
 }
 
 // NewSLALevel returns a new SLA level.

--- a/state/filesystem.go
+++ b/state/filesystem.go
@@ -1218,7 +1218,7 @@ func filesystemGlobalKey(name string) string {
 
 // FilesystemStatus returns the status of the specified filesystem.
 func (st *State) FilesystemStatus(tag names.FilesystemTag) (status.StatusInfo, error) {
-	return getStatus(st, filesystemGlobalKey(tag.Id()), "filesystem")
+	return getStatus(st.db(), filesystemGlobalKey(tag.Id()), "filesystem")
 }
 
 // SetFilesystemStatus sets the status of the specified filesystem.
@@ -1244,12 +1244,12 @@ func (st *State) SetFilesystemStatus(tag names.FilesystemTag, fsStatus status.St
 	default:
 		return errors.Errorf("cannot set invalid status %q", fsStatus)
 	}
-	return setStatus(st, setStatusParams{
+	return setStatus(st.db(), setStatusParams{
 		badge:     "filesystem",
 		globalKey: filesystemGlobalKey(tag.Id()),
 		status:    fsStatus,
 		message:   info,
 		rawData:   data,
-		updated:   updated,
+		updated:   timeOrNow(updated, st.clock),
 	})
 }

--- a/state/initialize_test.go
+++ b/state/initialize_test.go
@@ -250,7 +250,7 @@ func (s *InitializeSuite) TestInitializeWithControllerInheritedConfig(c *gc.C) {
 
 	s.openState(c, modelTag)
 
-	controllerInheritedConfig, err := state.ReadSettings(s.State, state.GlobalSettingsC, state.ControllerInheritedSettingsGlobalKey)
+	controllerInheritedConfig, err := s.State.ReadSettings(state.GlobalSettingsC, state.ControllerInheritedSettingsGlobalKey)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(controllerInheritedConfig.Map(), jc.DeepEquals, controllerInheritedConfigIn)
 
@@ -455,8 +455,8 @@ func (s *InitializeSuite) TestInitializeWithCloudRegionConfig(c *gc.C) {
 
 	for k := range regionInheritedConfigIn {
 		// Query for config for each region
-		regionInheritedConfig, err := state.ReadSettings(
-			s.State, state.GlobalSettingsC,
+		regionInheritedConfig, err := s.State.ReadSettings(
+			state.GlobalSettingsC,
 			"dummy#"+k)
 		c.Assert(err, jc.ErrorIsNil)
 		c.Assert(

--- a/state/model_test.go
+++ b/state/model_test.go
@@ -849,23 +849,6 @@ func (s *ModelSuite) TestListModelUsers(c *gc.C) {
 	assertObtainedUsersMatchExpectedUsers(c, obtained, expected)
 }
 
-func (s *ModelSuite) TestMisMatchedEnvs(c *gc.C) {
-	// create another model
-	otherEnvState := s.Factory.MakeModel(c, nil)
-	defer otherEnvState.Close()
-	otherEnv, err := otherEnvState.Model()
-	c.Assert(err, jc.ErrorIsNil)
-
-	// get that model from State
-	env, err := s.State.GetModel(otherEnv.ModelTag())
-	c.Assert(err, jc.ErrorIsNil)
-
-	// check that the Users method errors
-	users, err := env.Users()
-	c.Assert(users, gc.IsNil)
-	c.Assert(err, gc.ErrorMatches, "cannot lookup model users outside the current model")
-}
-
 func (s *ModelSuite) TestListUsersIgnoredDeletedUsers(c *gc.C) {
 	model, err := s.State.Model()
 	c.Assert(err, jc.ErrorIsNil)
@@ -907,6 +890,13 @@ func (s *ModelSuite) TestListUsersTwoModels(c *gc.C) {
 	obtainedUsersOtherEnv, err := otherEnv.Users()
 	c.Assert(err, jc.ErrorIsNil)
 	assertObtainedUsersMatchExpectedUsers(c, obtainedUsersOtherEnv, expectedUsersOtherEnv)
+
+	// It doesn't matter how you obtain the Model.
+	otherEnv2, err := s.State.GetModel(otherEnv.ModelTag())
+	c.Assert(err, jc.ErrorIsNil)
+	obtainedUsersOtherEnv2, err := otherEnv2.Users()
+	c.Assert(err, jc.ErrorIsNil)
+	assertObtainedUsersMatchExpectedUsers(c, obtainedUsersOtherEnv2, expectedUsersOtherEnv)
 }
 
 func addModelUsers(c *gc.C, st *state.State) (expected []permission.UserAccess) {

--- a/state/modelmigration.go
+++ b/state/modelmigration.go
@@ -378,11 +378,11 @@ func migStatusHistoryAndOps(st *State, phase migration.Phase, now int64, msg str
 		Updated:    now,
 	}
 
-	ops, err := statusSetOps(st, doc, globalKey)
+	ops, err := statusSetOps(st.db(), doc, globalKey)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	probablyUpdateStatusHistory(st, globalKey, doc)
+	probablyUpdateStatusHistory(st.db(), globalKey, doc)
 	return ops, nil
 }
 

--- a/state/modeluser.go
+++ b/state/modeluser.go
@@ -180,7 +180,9 @@ type UserModel struct {
 // LastConnection returns the last time the user has connected to the
 // model.
 func (e *UserModel) LastConnection() (time.Time, error) {
-	lastConnections, lastConnCloser := e.st.getRawCollection(modelUserLastConnectionC)
+	db, dbCloser := e.modelDatabase()
+	defer dbCloser()
+	lastConnections, lastConnCloser := db.GetRawCollection(modelUserLastConnectionC)
 	defer lastConnCloser()
 
 	lastConnDoc := modelUserLastConnectionDoc{}

--- a/state/open.go
+++ b/state/open.go
@@ -390,7 +390,7 @@ func Initialize(args InitializeParams) (_ *State, err error) {
 	if err := st.start(controllerTag); err != nil {
 		return nil, errors.Trace(err)
 	}
-	probablyUpdateStatusHistory(st, modelGlobalKey, modelStatusDoc)
+	probablyUpdateStatusHistory(st.db(), modelGlobalKey, modelStatusDoc)
 	return st, nil
 }
 

--- a/state/relationunit.go
+++ b/state/relationunit.go
@@ -116,7 +116,7 @@ func (ru *RelationUnit) EnterScope(settings map[string]interface{}) error {
 		ops = append(ops, createSettingsOp(settingsC, ruKey, settings))
 	} else {
 		var rop txn.Op
-		rop, settingsChanged, err = replaceSettingsOp(ru.st, settingsC, ruKey, settings)
+		rop, settingsChanged, err = replaceSettingsOp(ru.st.db(), settingsC, ruKey, settings)
 		if err != nil {
 			return err
 		}
@@ -414,7 +414,7 @@ func watchRelationScope(
 // Settings returns a Settings which allows access to the unit's settings
 // within the relation.
 func (ru *RelationUnit) Settings() (*Settings, error) {
-	return readSettings(ru.st, settingsC, ru.key())
+	return readSettings(ru.st.db(), settingsC, ru.key())
 }
 
 // ReadSettings returns a map holding the settings of the unit with the
@@ -433,7 +433,7 @@ func (ru *RelationUnit) ReadSettings(uname string) (m map[string]interface{}, er
 	if err != nil {
 		return nil, err
 	}
-	node, err := readSettings(ru.st, settingsC, key)
+	node, err := readSettings(ru.st.db(), settingsC, key)
 	if err != nil {
 		return nil, err
 	}

--- a/state/remoteapplication.go
+++ b/state/remoteapplication.go
@@ -364,7 +364,7 @@ func (s *RemoteApplication) removeOps(asserts bson.D) []txn.Op {
 
 // Status returns the status of the remote application.
 func (s *RemoteApplication) Status() (status.StatusInfo, error) {
-	return getStatus(s.st, s.globalKey(), "remote application")
+	return getStatus(s.st.db(), s.globalKey(), "remote application")
 }
 
 // SetStatus sets the status for the application.
@@ -372,13 +372,13 @@ func (s *RemoteApplication) SetStatus(info status.StatusInfo) error {
 	if !info.Status.KnownWorkloadStatus() {
 		return errors.Errorf("cannot set invalid status %q", info.Status)
 	}
-	return setStatus(s.st, setStatusParams{
+	return setStatus(s.st.db(), setStatusParams{
 		badge:     "remote application",
 		globalKey: s.globalKey(),
 		status:    info.Status,
 		message:   info.Message,
 		rawData:   info.Data,
-		updated:   info.Since,
+		updated:   timeOrNow(info.Since, s.st.clock),
 	})
 }
 

--- a/state/settings_test.go
+++ b/state/settings_test.go
@@ -25,11 +25,11 @@ func (s *SettingsSuite) SetUpTest(c *gc.C) {
 }
 
 func (s *SettingsSuite) createSettings(key string, values map[string]interface{}) (*Settings, error) {
-	return createSettings(s.state, s.collection, key, values)
+	return createSettings(s.state.db(), s.collection, key, values)
 }
 
 func (s *SettingsSuite) readSettings() (*Settings, error) {
-	return readSettings(s.state, s.collection, s.key)
+	return readSettings(s.state.db(), s.collection, s.key)
 }
 
 func (s *SettingsSuite) TestCreateEmptySettings(c *gc.C) {
@@ -55,7 +55,7 @@ func (s *SettingsSuite) TestCannotWriteMissing(c *gc.C) {
 	node, err := s.createSettings(s.key, nil)
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = removeSettings(s.state, s.collection, s.key)
+	err = removeSettings(s.state.db(), s.collection, s.key)
 	c.Assert(err, jc.ErrorIsNil)
 
 	node.Set("foo", "bar")
@@ -221,7 +221,7 @@ func (s *SettingsSuite) TestReplaceSettingsEscape(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	options := map[string]interface{}{"$baz": 1, "foo.bar": "beta"}
-	rop, settingsChanged, err := replaceSettingsOp(s.state, s.collection, s.key, options)
+	rop, settingsChanged, err := replaceSettingsOp(s.state.db(), s.collection, s.key, options)
 	c.Assert(err, jc.ErrorIsNil)
 	ops := []txn.Op{rop}
 	err = node.db.RunTransaction(ops)

--- a/state/state.go
+++ b/state/state.go
@@ -659,7 +659,7 @@ func (st *State) SetModelAgentVersion(newVersion version.Number) (err error) {
 	}
 
 	buildTxn := func(attempt int) ([]txn.Op, error) {
-		settings, err := readSettings(st, settingsC, modelGlobalKey)
+		settings, err := readSettings(st.db(), settingsC, modelGlobalKey)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
@@ -1229,7 +1229,7 @@ func (st *State) AddApplication(args AddApplicationArgs) (_ *Application, err er
 		return ops, nil
 	}
 	// At the last moment before inserting the application, prime status history.
-	probablyUpdateStatusHistory(st, app.globalKey(), statusDoc)
+	probablyUpdateStatusHistory(st.db(), app.globalKey(), statusDoc)
 
 	if err = st.run(buildTxn); err == nil {
 		// Refresh to pick the txn-revno.

--- a/state/txns.go
+++ b/state/txns.go
@@ -12,8 +12,8 @@ import (
 	"gopkg.in/mgo.v2/txn"
 )
 
-func (st *State) readTxnRevno(collectionName string, id interface{}) (int64, error) {
-	collection, closer := st.database.GetCollection(collectionName)
+func readTxnRevno(db Database, collectionName string, id interface{}) (int64, error) {
+	collection, closer := db.GetCollection(collectionName)
 	defer closer()
 	query := collection.FindId(id).Select(bson.D{{"txn-revno", 1}})
 	var result struct {

--- a/state/unit.go
+++ b/state/unit.go
@@ -120,7 +120,7 @@ func (u *Unit) ConfigSettings() (charm.Settings, error) {
 	if u.doc.CharmURL == nil {
 		return nil, fmt.Errorf("unit charm not set")
 	}
-	settings, err := readSettings(u.st, settingsC, applicationSettingsKey(u.doc.Application, u.doc.CharmURL))
+	settings, err := readSettings(u.st.db(), settingsC, applicationSettingsKey(u.doc.Application, u.doc.CharmURL))
 	if err != nil {
 		return nil, err
 	}
@@ -196,7 +196,7 @@ func (u *Unit) Life() Life {
 // the charm (eg, the version of postgresql that is running, as
 // opposed to the version of the postgresql charm).
 func (u *Unit) WorkloadVersion() (string, error) {
-	status, err := getStatus(u.st, u.globalWorkloadVersionKey(), "workload")
+	status, err := getStatus(u.st.db(), u.globalWorkloadVersionKey(), "workload")
 	if errors.IsNotFound(err) {
 		return "", nil
 	} else if err != nil {
@@ -212,7 +212,7 @@ func (u *Unit) SetWorkloadVersion(version string) error {
 	// want to avoid everything being an attr of the main docs to
 	// stop a swarm of watchers being notified for irrelevant changes.
 	now := u.st.clock.Now()
-	return setStatus(u.st, setStatusParams{
+	return setStatus(u.st.db(), setStatusParams{
 		badge:     "workload",
 		globalKey: u.globalWorkloadVersionKey(),
 		status:    status.Active,
@@ -406,7 +406,7 @@ func (u *Unit) destroyOps() ([]txn.Op, error) {
 	// If so then we can't set directly to dead.
 	isAssigned := u.doc.MachineId != ""
 	agentStatusDocId := u.globalAgentKey()
-	agentStatusInfo, agentErr := getStatus(u.st, agentStatusDocId, "agent")
+	agentStatusInfo, agentErr := getStatus(u.st.db(), agentStatusDocId, "agent")
 	if errors.IsNotFound(agentErr) {
 		return nil, errAlreadyDying
 	} else if agentErr != nil {
@@ -857,7 +857,7 @@ func (u *Unit) AgentStatus() (status.StatusInfo, error) {
 // representing past statuses for this unit.
 func (u *Unit) StatusHistory(filter status.StatusHistoryFilter) ([]status.StatusInfo, error) {
 	args := &statusHistoryArgs{
-		st:        u.st,
+		db:        u.st.db(),
 		globalKey: u.globalKey(),
 		filter:    filter,
 	}
@@ -874,12 +874,12 @@ func (u *Unit) Status() (status.StatusInfo, error) {
 	// itself as being in error. So we'll do that model translation here.
 	// TODO(fwereade) as on unitagent, this transformation does not belong here.
 	// For now, pretend we're always reading the unit status.
-	info, err := getStatus(u.st, u.globalAgentKey(), "unit")
+	info, err := getStatus(u.st.db(), u.globalAgentKey(), "unit")
 	if err != nil {
 		return status.StatusInfo{}, err
 	}
 	if info.Status != status.Error {
-		info, err = getStatus(u.st, u.globalKey(), "unit")
+		info, err = getStatus(u.st.db(), u.globalKey(), "unit")
 		if err != nil {
 			return status.StatusInfo{}, err
 		}
@@ -896,13 +896,13 @@ func (u *Unit) SetStatus(unitStatus status.StatusInfo) error {
 	if !status.ValidWorkloadStatus(unitStatus.Status) {
 		return errors.Errorf("cannot set invalid status %q", unitStatus.Status)
 	}
-	return setStatus(u.st, setStatusParams{
+	return setStatus(u.st.db(), setStatusParams{
 		badge:     "unit",
 		globalKey: u.globalKey(),
 		status:    unitStatus.Status,
 		message:   unitStatus.Message,
 		rawData:   unitStatus.Data,
-		updated:   unitStatus.Since,
+		updated:   timeOrNow(unitStatus.Since, u.st.clock),
 	})
 }
 
@@ -2466,7 +2466,7 @@ type HistoryGetter struct {
 // StatusHistory implements status.StatusHistoryGetter.
 func (g *HistoryGetter) StatusHistory(filter status.StatusHistoryFilter) ([]status.StatusInfo, error) {
 	args := &statusHistoryArgs{
-		st:        g.st,
+		db:        g.st.db(),
 		globalKey: g.globalKey,
 		filter:    filter,
 	}

--- a/state/unitagent.go
+++ b/state/unitagent.go
@@ -35,7 +35,7 @@ func (u *UnitAgent) String() string {
 
 // Status returns the status of the unit agent.
 func (u *UnitAgent) Status() (status.StatusInfo, error) {
-	info, err := getStatus(u.st, u.globalKey(), "agent")
+	info, err := getStatus(u.st.db(), u.globalKey(), "agent")
 	if err != nil {
 		return status.StatusInfo{}, errors.Trace(err)
 	}
@@ -85,13 +85,13 @@ func (u *UnitAgent) SetStatus(unitAgentStatus status.StatusInfo) (err error) {
 	default:
 		return errors.Errorf("cannot set invalid status %q", unitAgentStatus.Status)
 	}
-	return setStatus(u.st, setStatusParams{
+	return setStatus(u.st.db(), setStatusParams{
 		badge:     "agent",
 		globalKey: u.globalKey(),
 		status:    unitAgentStatus.Status,
 		message:   unitAgentStatus.Message,
 		rawData:   unitAgentStatus.Data,
-		updated:   unitAgentStatus.Since,
+		updated:   timeOrNow(unitAgentStatus.Since, u.st.clock),
 	})
 }
 
@@ -100,7 +100,7 @@ func (u *UnitAgent) SetStatus(unitAgentStatus status.StatusInfo) (err error) {
 // representing past statuses for this agent.
 func (u *UnitAgent) StatusHistory(filter status.StatusHistoryFilter) ([]status.StatusInfo, error) {
 	args := &statusHistoryArgs{
-		st:        u.st,
+		db:        u.st.db(),
 		globalKey: u.globalKey(),
 		filter:    filter,
 	}

--- a/state/upgrade.go
+++ b/state/upgrade.go
@@ -236,11 +236,11 @@ func upgradeStatusHistoryAndOps(st *State, upgradeStatus UpgradeStatus, now time
 		StatusInfo: msg,
 		Updated:    now.UnixNano(),
 	}
-	ops, err := statusSetOps(st, doc, modelGlobalKey)
+	ops, err := statusSetOps(st.db(), doc, modelGlobalKey)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	probablyUpdateStatusHistory(st, modelGlobalKey, doc)
+	probablyUpdateStatusHistory(st.db(), modelGlobalKey, doc)
 	return ops, nil
 }
 

--- a/state/volume.go
+++ b/state/volume.go
@@ -1059,7 +1059,7 @@ func volumeGlobalKey(name string) string {
 
 // VolumeStatus returns the status of the specified volume.
 func (st *State) VolumeStatus(tag names.VolumeTag) (status.StatusInfo, error) {
-	return getStatus(st, volumeGlobalKey(tag.Id()), "volume")
+	return getStatus(st.db(), volumeGlobalKey(tag.Id()), "volume")
 }
 
 // SetVolumeStatus sets the status of the specified volume.
@@ -1085,12 +1085,12 @@ func (st *State) SetVolumeStatus(tag names.VolumeTag, volumeStatus status.Status
 	default:
 		return errors.Errorf("cannot set invalid status %q", volumeStatus)
 	}
-	return setStatus(st, setStatusParams{
+	return setStatus(st.db(), setStatusParams{
 		badge:     "volume",
 		globalKey: volumeGlobalKey(tag.Id()),
 		status:    volumeStatus,
 		message:   info,
 		rawData:   data,
-		updated:   updated,
+		updated:   timeOrNow(updated, st.clock),
 	})
 }

--- a/state/watcher.go
+++ b/state/watcher.go
@@ -994,7 +994,7 @@ func (w *relationUnitsWatcher) mergeSettings(changes *params.RelationUnitsChange
 		TxnRevno int64 `bson:"txn-revno"`
 		Version  int64 `bson:"version"`
 	}
-	if err := readSettingsDocInto(w.backend, settingsC, key, &doc); err != nil {
+	if err := readSettingsDocInto(w.backend.db(), settingsC, key, &doc); err != nil {
 		return -1, err
 	}
 	setRelationUnitChangeVersion(changes, key, doc.Version)
@@ -1349,8 +1349,8 @@ func (u *Unit) Watch() NotifyWatcher {
 }
 
 // Watch returns a watcher for observing changes to a model.
-func (e *Model) Watch() NotifyWatcher {
-	return newEntityWatcher(e.st, modelsC, e.doc.UUID)
+func (m *Model) Watch() NotifyWatcher {
+	return newEntityWatcher(m.globalState, modelsC, m.doc.UUID)
 }
 
 // WatchUpgradeInfo returns a watcher for observing changes to upgrade


### PR DESCRIPTION
## Description of change

Model methods were using ForModel if the
State that returned the Model was not opened
for the model UUID. This is expensive.

Instead, use the Database and copy for the
model UUID as necessary. Many of the uses
do not even require this, as they operate
on global collections only. Making this change
requires that various functions (e.g. reading
settings) operate on a Database, and not a
*State.

## QA steps

1. juju bootstrap, deploy ubuntu (smoke test)
2. run all the unit tests
3. run "juju-introspect" on the controller, observe no "started state for model..." messages in the log

## Documentation changes

None.

## Bug reference

Fixes https://bugs.launchpad.net/juju/+bug/1570269.