### PR TITLE
Don't remove ingress networks without feature flag

### DIFF
--- a/state/relation.go
+++ b/state/relation.go
@@ -199,7 +199,9 @@ func (r *Relation) removeOps(ignoreService string, departingUnitName string) ([]
 			ops = append(ops, epOps...)
 		}
 	}
-	ops = append(ops, removeRelationIngressNetworksOps(r.st, r.doc.Key)...)
+	if featureflag.Enabled(feature.CrossModelRelations) {
+		ops = append(ops, removeRelationIngressNetworksOps(r.st, r.doc.Key)...)
+	}
 	cleanupOp := newCleanupOp(cleanupRelationSettings, fmt.Sprintf("r#%d#", r.Id()))
 	return append(ops, cleanupOp), nil
 }

--- a/state/relation_test.go
+++ b/state/relation_test.go
@@ -377,3 +377,19 @@ func (s *RelationSuite) TestRemoveAlsoDeletesIngressNetworks(c *gc.C) {
 	_, err = state.IngressNetworks(relation)
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 }
+
+func (s *RelationSuite) TestRemoveNoFeatureFlag(c *gc.C) {
+	s.SetFeatureFlags( /*none*/ )
+	wordpress := s.AddTestingService(c, "wordpress", s.AddTestingCharm(c, "wordpress"))
+	wordpressEP, err := wordpress.Endpoint("db")
+	c.Assert(err, jc.ErrorIsNil)
+	mysql := s.AddTestingService(c, "mysql", s.AddTestingCharm(c, "mysql"))
+	mysqlEP, err := mysql.Endpoint("server")
+	c.Assert(err, jc.ErrorIsNil)
+	relation, err := s.State.AddRelation(wordpressEP, mysqlEP)
+	c.Assert(err, jc.ErrorIsNil)
+
+	state.RemoveRelation(c, relation)
+	_, err = s.State.KeyRelation(relation.Tag().Id())
+	c.Assert(err, jc.Satisfies, errors.IsNotFound)
+}


### PR DESCRIPTION
## Description of change

When removing a relation, don't create the txn to remove ingress addresses unless cross-model feature flag is set.

## QA steps

Add and remove a relation without the feature flag.