### PR TITLE
Revert "worker/uniter: Remove relation state dir even if non-empty"

### DIFF
--- a/worker/uniter/relation/state.go
+++ b/worker/uniter/relation/state.go
@@ -219,22 +219,10 @@ func (d *StateDir) Write(hi hook.Info) (err error) {
 
 // Remove removes the directory if it exists and is empty.
 func (d *StateDir) Remove() error {
-	if files, err := ioutil.ReadDir(d.path); err != nil && !os.IsNotExist(err) {
+	if err := os.Remove(d.path); err != nil && !os.IsNotExist(err) {
 		return err
-	} else if err == nil {
-		if len(files) > 0 {
-			names := make([]string, len(files))
-			for i, file := range files {
-				names[i] = file.Name()
-			}
-			logger.Debugf("relation state directory %q not empty on removal: %v", d.path, names)
-		}
-		if err := os.RemoveAll(d.path); err != nil {
-			return err
-		}
 	}
-
-	// If delete succeeded, update own state.
+	// If atomic delete succeeded, update own state.
 	d.state.Members = nil
 	return nil
 }


### PR DESCRIPTION
## Description of change

This reverts commit 3eb00f2f0bd6b0d3b1fedeca988f768bdd53d10a.

The non-empty relation state dir was for a subordinate-subordinate
relation which isn't being correctly handled by the relation filtering
in the fix for bug 1686696. We shouldn't delete that file - it's an indication
that there are some relation scopes that have been excluded.

Revert this change, a more correct implementation is on the way.

## Bug reference

Related to https://bugs.launchpad.net/juju/+bug/1699050