### PR TITLE
Use default space for offer endpoint if none is defined

### DIFF
--- a/apiserver/applicationoffers/base.go
+++ b/apiserver/applicationoffers/base.go
@@ -326,9 +326,13 @@ func (api *BaseAPI) makeOfferParams(backend Backend, offer *jujucrossmodel.Appli
 		})
 		spaceName, ok := appBindings[ep.Name]
 		if !ok {
-			// There should always be some binding (even if it's to
-			// the default space).
-			return nil, nil, errors.Errorf("no binding for %q endpoint", ep.Name)
+			// There should always be some binding (even if it's to the default space).
+			// This isn't currently the case so add the default binding here.
+			logger.Warningf("no binding for %q endpoint on application %q", ep.Name, offer.ApplicationName)
+			if result.Bindings == nil {
+				result.Bindings = make(map[string]string)
+			}
+			result.Bindings[ep.Name] = environs.DefaultSpaceName
 		}
 		spaceNames.Add(spaceName)
 	}

--- a/apiserver/applicationoffers/mock_test.go
+++ b/apiserver/applicationoffers/mock_test.go
@@ -72,8 +72,12 @@ type mockEnviron struct {
 
 func (e *mockEnviron) ProviderSpaceInfo(space *network.SpaceInfo) (*environs.ProviderSpaceInfo, error) {
 	e.stub.MethodCall(e, "ProviderSpaceInfo", space)
-	if e.spaceInfo == nil || space.Name != e.spaceInfo.Name {
-		return nil, errors.NotFoundf("space %s", space.Name)
+	spaceName := environs.DefaultSpaceName
+	if space != nil {
+		spaceName = space.Name
+	}
+	if e.spaceInfo == nil || spaceName != e.spaceInfo.Name {
+		return nil, errors.NotFoundf("space %q", spaceName)
 	}
 	return e.spaceInfo, e.stub.NextErr()
 }

--- a/state/state.go
+++ b/state/state.go
@@ -1747,9 +1747,6 @@ func (st *State) AddRelation(eps ...Endpoint) (r *Relation, err error) {
 			} else {
 				localSvc := svc.(*Application)
 				if localSvc.doc.Subordinate {
-					if remoteRelation {
-						return nil, errors.Errorf("cannot relate subordinate %q to remote application", localSvc.Name())
-					}
 					subordinateCount++
 				}
 				series[localSvc.doc.Series] = true


### PR DESCRIPTION
## Description of change

All application endpoints should have a space binding, even if only to the default space.

## QA steps

Offer an application using an endpoint without a space.
