### PR TITLE
state: make clock available via modelBackend

### DIFF
--- a/state/addmachine.go
+++ b/state/addmachine.go
@@ -507,7 +507,7 @@ func (st *State) machineDocForTemplate(template MachineTemplate, id string) *mac
 // into the database, based on the given template. Only the constraints are
 // taken from the template.
 func (st *State) insertNewMachineOps(mdoc *machineDoc, template MachineTemplate) (prereqOps []txn.Op, machineOp txn.Op, err error) {
-	now := st.clock.Now()
+	now := st.clock().Now()
 	machineStatusDoc := statusDoc{
 		Status:    status.Pending,
 		ModelUUID: st.ModelUUID(),

--- a/state/allwatcher.go
+++ b/state/allwatcher.go
@@ -463,7 +463,7 @@ func (app *backingApplication) updated(st *State, store *multiwatcherStore, id s
 			// Not sure how status can even return NotFound as it is created
 			// with the application initially. For now, we'll log the error as per
 			// the above and return Unknown.
-			now := st.clock.Now()
+			now := st.clock().Now()
 			info.Status = multiwatcher.StatusInfo{
 				Current: status.Unknown,
 				Since:   &now,

--- a/state/allwatcher_internal_test.go
+++ b/state/allwatcher_internal_test.go
@@ -3714,7 +3714,7 @@ done:
 					break done
 				}
 			}
-		case <-tw.st.clock.After(maxDuration):
+		case <-tw.st.clock().After(maxDuration):
 			// timed out
 			break done
 		}
@@ -3735,7 +3735,7 @@ func (tw *testWatcher) AssertNoChange(c *gc.C) {
 		if len(d) > 0 {
 			c.Error("change detected")
 		}
-	case <-tw.st.clock.After(testing.ShortWait):
+	case <-tw.st.clock().After(testing.ShortWait):
 		// expected
 	}
 }
@@ -3743,7 +3743,7 @@ func (tw *testWatcher) AssertNoChange(c *gc.C) {
 func (tw *testWatcher) AssertChanges(c *gc.C, expected int) {
 	var count int
 	tw.st.StartSync()
-	maxWait := tw.st.clock.After(testing.LongWait)
+	maxWait := tw.st.clock().After(testing.LongWait)
 done:
 	for {
 		select {

--- a/state/application.go
+++ b/state/application.go
@@ -1211,7 +1211,7 @@ func (a *Application) addUnitOpsWithCons(args applicationAddUnitOpsArgs) (string
 		Principal:              args.principalName,
 		StorageAttachmentCount: numStorageAttachments,
 	}
-	now := a.st.clock.Now()
+	now := a.st.clock().Now()
 	agentStatusDoc := statusDoc{
 		Status:  status.Allocating,
 		Updated: now.UnixNano(),
@@ -1729,7 +1729,7 @@ func (a *Application) SetStatus(statusInfo status.StatusInfo) error {
 		status:    statusInfo.Status,
 		message:   statusInfo.Message,
 		rawData:   statusInfo.Data,
-		updated:   timeOrNow(statusInfo.Since, a.st.clock),
+		updated:   timeOrNow(statusInfo.Since, a.st.clock()),
 	})
 }
 

--- a/state/backend.go
+++ b/state/backend.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/juju/errors"
+	"github.com/juju/utils/clock"
 
 	"github.com/juju/juju/state/watcher"
 )
@@ -34,6 +35,7 @@ type modelBackend interface {
 	// misleading to store any more than precision to the second.
 	nowToTheSecond() time.Time
 
+	clock() clock.Clock
 	db() Database
 	modelUUID() string
 	txnLogWatcher() *watcher.Watcher
@@ -59,10 +61,14 @@ func (st *State) strictLocalID(id string) (string, error) {
 	return localID, nil
 }
 
+func (st *State) clock() clock.Clock {
+	return st.stateClock
+}
+
 func (st *State) modelUUID() string {
 	return st.ModelUUID()
 }
 
 func (st *State) nowToTheSecond() time.Time {
-	return st.clock.Now().Round(time.Second).UTC()
+	return st.clock().Now().Round(time.Second).UTC()
 }

--- a/state/filesystem.go
+++ b/state/filesystem.go
@@ -853,7 +853,7 @@ func (st *State) addFilesystemOps(params FilesystemParams, machineId string) ([]
 
 	status := statusDoc{
 		Status:  status.Pending,
-		Updated: st.clock.Now().UnixNano(),
+		Updated: st.clock().Now().UnixNano(),
 	}
 	doc := filesystemDoc{
 		FilesystemId: filesystemId,
@@ -1288,6 +1288,6 @@ func (st *State) SetFilesystemStatus(tag names.FilesystemTag, fsStatus status.St
 		status:    fsStatus,
 		message:   info,
 		rawData:   data,
-		updated:   timeOrNow(updated, st.clock),
+		updated:   timeOrNow(updated, st.clock()),
 	})
 }

--- a/state/initialize.go
+++ b/state/initialize.go
@@ -280,7 +280,7 @@ func (st *State) modelSetupOps(controllerUUID string, args ModelArgs, inherited 
 	modelUUID := args.Config.UUID()
 	modelStatusDoc = statusDoc{
 		ModelUUID: modelUUID,
-		Updated:   st.clock.Now().UnixNano(),
+		Updated:   st.clock().Now().UnixNano(),
 		Status:    status.Available,
 	}
 

--- a/state/machine.go
+++ b/state/machine.go
@@ -996,7 +996,7 @@ func (m *Machine) SetInstanceStatus(sInfo status.StatusInfo) (err error) {
 		status:    sInfo.Status,
 		message:   sInfo.Message,
 		rawData:   sInfo.Data,
-		updated:   timeOrNow(sInfo.Since, m.st.clock),
+		updated:   timeOrNow(sInfo.Since, m.st.clock()),
 	})
 
 }
@@ -1633,7 +1633,7 @@ func (m *Machine) SetStatus(statusInfo status.StatusInfo) error {
 		status:    statusInfo.Status,
 		message:   statusInfo.Message,
 		rawData:   statusInfo.Data,
-		updated:   timeOrNow(statusInfo.Since, m.st.clock),
+		updated:   timeOrNow(statusInfo.Since, m.st.clock()),
 	})
 }
 
@@ -1740,7 +1740,7 @@ func (m *Machine) markInvalidContainers() error {
 			}
 			if statusInfo.Status == status.Pending {
 				containerType := ContainerTypeFromId(containerId)
-				now := m.st.clock.Now()
+				now := m.st.clock().Now()
 				s := status.StatusInfo{
 					Status:  status.Error,
 					Message: "unsupported container",

--- a/state/metrics.go
+++ b/state/metrics.go
@@ -302,7 +302,7 @@ func (st *State) MetricBatch(id string) (*MetricBatch, error) {
 // CleanupOldMetrics looks for metrics that are 24 hours old (or older)
 // and have been sent. Any metrics it finds are deleted.
 func (st *State) CleanupOldMetrics() error {
-	now := st.clock.Now()
+	now := st.clock().Now()
 	metrics, closer := st.db().GetCollection(metricsC)
 	defer closer()
 	// Nothing else in the system will interact with sent metrics, and nothing needs
@@ -470,7 +470,7 @@ func setSentOps(batchUUIDs []string, deleteTime time.Time) []txn.Op {
 
 // SetMetricBatchesSent sets sent on each MetricBatch corresponding to the uuids provided.
 func (st *State) SetMetricBatchesSent(batchUUIDs []string) error {
-	deleteTime := st.clock.Now().UTC().Add(CleanupAge)
+	deleteTime := st.clock().Now().UTC().Add(CleanupAge)
 	ops := setSentOps(batchUUIDs, deleteTime)
 	if err := st.db().RunTransaction(ops); err != nil {
 		return errors.Annotatef(err, "cannot set metric sent in bulk call")

--- a/state/metricsmanager.go
+++ b/state/metricsmanager.go
@@ -160,7 +160,7 @@ func (m *MetricsManager) IncrementConsecutiveErrors() error {
 }
 
 func (m *MetricsManager) gracePeriodExceeded() bool {
-	now := m.st.clock.Now()
+	now := m.st.clock().Now()
 	t := m.LastSuccessfulSend().Add(m.GracePeriod())
 	return t.Before(now) || t.Equal(now)
 }

--- a/state/model.go
+++ b/state/model.go
@@ -331,7 +331,7 @@ func (st *State) NewModel(args ModelArgs) (_ *Model, _ *State, err error) {
 		session,
 		st.mongoInfo,
 		st.newPolicy,
-		st.clock,
+		st.clock(),
 		st.runTransactionObserver,
 	)
 	if err != nil {
@@ -592,7 +592,7 @@ func (m *Model) SetStatus(sInfo status.StatusInfo) error {
 		status:    sInfo.Status,
 		message:   sInfo.Message,
 		rawData:   sInfo.Data,
-		updated:   timeOrNow(sInfo.Since, m.globalState.clock),
+		updated:   timeOrNow(sInfo.Since, m.globalState.clock()),
 	})
 }
 

--- a/state/modelmigration.go
+++ b/state/modelmigration.go
@@ -277,7 +277,7 @@ func (mig *modelMigration) TargetInfo() (*migration.TargetInfo, error) {
 
 // SetPhase implements ModelMigration.
 func (mig *modelMigration) SetPhase(nextPhase migration.Phase) error {
-	now := mig.st.clock.Now().UnixNano()
+	now := mig.st.clock().Now().UnixNano()
 
 	phase, err := mig.Phase()
 	if err != nil {
@@ -393,7 +393,7 @@ func (mig *modelMigration) SetStatusMessage(text string) error {
 		return errors.Trace(err)
 	}
 
-	ops, err := migStatusHistoryAndOps(mig.st, phase, mig.st.clock.Now().UnixNano(), text)
+	ops, err := migStatusHistoryAndOps(mig.st, phase, mig.st.clock().Now().UnixNano(), text)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -423,7 +423,7 @@ func (mig *modelMigration) SubmitMinionReport(tag names.Tag, phase migration.Pha
 		MigrationId: mig.Id(),
 		Phase:       phase.String(),
 		EntityKey:   globalKey,
-		Time:        mig.st.clock.Now().UnixNano(),
+		Time:        mig.st.clock().Now().UnixNano(),
 		Success:     success,
 	}
 	ops := []txn.Op{{
@@ -621,7 +621,7 @@ func (st *State) CreateMigration(spec MigrationSpec) (ModelMigration, error) {
 		return nil, errors.Trace(err)
 	}
 
-	now := st.clock.Now().UnixNano()
+	now := st.clock().Now().UnixNano()
 	modelUUID := st.ModelUUID()
 	var doc modelMigDoc
 	var statusDoc modelMigStatusDoc

--- a/state/open.go
+++ b/state/open.go
@@ -266,7 +266,7 @@ func newState(
 
 	// Create State.
 	st := &State{
-		clock:                  clock,
+		stateClock:             clock,
 		modelTag:               modelTag,
 		controllerModelTag:     controllerModelTag,
 		mongoInfo:              mongoInfo,

--- a/state/remoteapplication.go
+++ b/state/remoteapplication.go
@@ -381,7 +381,7 @@ func (s *RemoteApplication) SetStatus(info status.StatusInfo) error {
 		status:    info.Status,
 		message:   info.Message,
 		rawData:   info.Data,
-		updated:   timeOrNow(info.Since, s.st.clock),
+		updated:   timeOrNow(info.Since, s.st.clock()),
 	})
 }
 

--- a/state/resources_adapters.go
+++ b/state/resources_adapters.go
@@ -29,7 +29,7 @@ func NewResourceState(persist Persistence, base *State) Resources {
 			persist: persist,
 		},
 		storage: persist.NewStorage(),
-		clock:   base.clock,
+		clock:   base.clock(),
 	}
 }
 

--- a/state/state.go
+++ b/state/state.go
@@ -79,7 +79,7 @@ type providerIdDoc struct {
 // State represents the state of an model
 // managed by juju.
 type State struct {
-	clock                  clock.Clock
+	stateClock             clock.Clock
 	modelTag               names.ModelTag
 	controllerModelTag     names.ModelTag
 	controllerTag          names.ControllerTag
@@ -305,7 +305,7 @@ func (st *State) removeInCollectionOps(name string, sel interface{}) ([]txn.Op, 
 func (st *State) ForModel(modelTag names.ModelTag) (*State, error) {
 	session := st.session.Copy()
 	newSt, err := newState(
-		modelTag, st.controllerModelTag, session, st.mongoInfo, st.newPolicy, st.clock,
+		modelTag, st.controllerModelTag, session, st.mongoInfo, st.newPolicy, st.stateClock,
 		st.runTransactionObserver,
 	)
 	if err != nil {
@@ -412,7 +412,7 @@ func (st *State) getLeadershipLeaseClient() (lease.Client, error) {
 		Namespace:    applicationLeadershipNamespace,
 		Collection:   leasesC,
 		Mongo:        &environMongo{st},
-		Clock:        st.clock,
+		Clock:        st.stateClock,
 		MonotonicNow: monotonic.Now,
 	})
 	if err != nil {
@@ -427,7 +427,7 @@ func (st *State) getSingularLeaseClient() (lease.Client, error) {
 		Namespace:    singularControllerNamespace,
 		Collection:   leasesC,
 		Mongo:        &environMongo{st},
-		Clock:        st.clock,
+		Clock:        st.stateClock,
 		MonotonicNow: monotonic.Now,
 	})
 	if err != nil {
@@ -1180,7 +1180,7 @@ func (st *State) AddApplication(args AddApplicationArgs) (_ *Application, err er
 		ModelUUID:  st.ModelUUID(),
 		Status:     status.Waiting,
 		StatusInfo: status.MessageWaitForMachine,
-		Updated:    st.clock.Now().UnixNano(),
+		Updated:    st.clock().Now().UnixNano(),
 		// This exists to preserve questionable unit-aggregation behaviour
 		// while we work out how to switch to an implementation that makes
 		// sense.
@@ -2263,7 +2263,7 @@ func (st *State) SetClockForTesting(clock clock.Clock) error {
 	if err != nil {
 		return errors.Trace(err)
 	}
-	st.clock = clock
+	st.stateClock = clock
 	err = st.start(st.controllerTag)
 	if err != nil {
 		return errors.Trace(err)

--- a/state/status.go
+++ b/state/status.go
@@ -309,7 +309,7 @@ func PruneStatusHistory(st *State, maxHistoryTime time.Duration, maxHistoryMB in
 
 	// Status Record Age
 	if maxHistoryTime > 0 {
-		t := st.clock.Now().Add(-maxHistoryTime)
+		t := st.clock().Now().Add(-maxHistoryTime)
 		_, err := history.RemoveAll(bson.D{
 			{"model-uuid", st.ModelUUID()},
 			{"updated", bson.M{"$lt": t.UnixNano()}},

--- a/state/unit.go
+++ b/state/unit.go
@@ -211,7 +211,7 @@ func (u *Unit) SetWorkloadVersion(version string) error {
 	// Store in status rather than an attribute of the unit doc - we
 	// want to avoid everything being an attr of the main docs to
 	// stop a swarm of watchers being notified for irrelevant changes.
-	now := u.st.clock.Now()
+	now := u.st.clock().Now()
 	return setStatus(u.st.db(), setStatusParams{
 		badge:     "workload",
 		globalKey: u.globalWorkloadVersionKey(),
@@ -895,7 +895,7 @@ func (u *Unit) SetStatus(unitStatus status.StatusInfo) error {
 		status:    unitStatus.Status,
 		message:   unitStatus.Message,
 		rawData:   unitStatus.Data,
-		updated:   timeOrNow(unitStatus.Since, u.st.clock),
+		updated:   timeOrNow(unitStatus.Since, u.st.clock()),
 	})
 }
 

--- a/state/unitagent.go
+++ b/state/unitagent.go
@@ -91,7 +91,7 @@ func (u *UnitAgent) SetStatus(unitAgentStatus status.StatusInfo) (err error) {
 		status:    unitAgentStatus.Status,
 		message:   unitAgentStatus.Message,
 		rawData:   unitAgentStatus.Data,
-		updated:   timeOrNow(unitAgentStatus.Since, u.st.clock),
+		updated:   timeOrNow(unitAgentStatus.Since, u.st.clock()),
 	})
 }
 

--- a/state/upgrade.go
+++ b/state/upgrade.go
@@ -277,7 +277,7 @@ func (info *UpgradeInfo) SetStatus(status UpgradeStatus) error {
 		Update: bson.D{{"$set", bson.D{{"status", status}}}},
 	}}
 
-	extraOps, err := upgradeStatusHistoryAndOps(info.st, status, info.st.clock.Now())
+	extraOps, err := upgradeStatusHistoryAndOps(info.st, status, info.st.clock().Now())
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -308,7 +308,7 @@ func (st *State) EnsureUpgradeInfo(machineId string, previousVersion, targetVers
 		PreviousVersion:  previousVersion,
 		TargetVersion:    targetVersion,
 		Status:           UpgradePending,
-		Started:          st.clock.Now().UTC(),
+		Started:          st.clock().Now().UTC(),
 		ControllersReady: []string{machineId},
 	}
 
@@ -445,7 +445,7 @@ func (info *UpgradeInfo) SetControllerDone(machineId string) error {
 			doc.ControllersDone = controllersDone.SortedValues()
 
 			ops := info.makeArchiveOps(doc, UpgradeComplete)
-			extraOps, err := upgradeStatusHistoryAndOps(info.st, UpgradeComplete, info.st.clock.Now())
+			extraOps, err := upgradeStatusHistoryAndOps(info.st, UpgradeComplete, info.st.clock().Now())
 			if err != nil {
 				return nil, errors.Trace(err)
 			}
@@ -482,7 +482,7 @@ func (info *UpgradeInfo) Abort() error {
 			return nil, errors.Trace(err)
 		}
 		ops := info.makeArchiveOps(doc, UpgradeAborted)
-		extraOps, err := upgradeStatusHistoryAndOps(info.st, UpgradeAborted, info.st.clock.Now())
+		extraOps, err := upgradeStatusHistoryAndOps(info.st, UpgradeAborted, info.st.clock().Now())
 		if err != nil {
 			return nil, errors.Trace(err)
 		}

--- a/state/volume.go
+++ b/state/volume.go
@@ -775,7 +775,7 @@ func (st *State) addVolumeOps(params VolumeParams, machineId string) ([]txn.Op, 
 	}
 	status := statusDoc{
 		Status:  status.Pending,
-		Updated: st.clock.Now().UnixNano(),
+		Updated: st.clock().Now().UnixNano(),
 	}
 	doc := volumeDoc{
 		Name:      name,
@@ -1103,6 +1103,6 @@ func (st *State) SetVolumeStatus(tag names.VolumeTag, volumeStatus status.Status
 		status:    volumeStatus,
 		message:   info,
 		rawData:   data,
-		updated:   timeOrNow(updated, st.clock),
+		updated:   timeOrNow(updated, st.clock()),
 	})
 }

--- a/state/workers.go
+++ b/state/workers.go
@@ -43,7 +43,7 @@ func newWorkers(st *State) (*workers, error) {
 			// Logger: loggo.GetLogger(logger.Name() + ".workers"),
 			IsFatal:      func(err error) bool { return err == jworker.ErrRestartAgent },
 			RestartDelay: time.Second,
-			Clock:        st.clock,
+			Clock:        st.clock(),
 		}),
 	}
 	ws.StartWorker(txnLogWorker, func() (worker.Worker, error) {
@@ -63,7 +63,7 @@ func newWorkers(st *State) (*workers, error) {
 		manager, err := lease.NewManager(lease.ManagerConfig{
 			Secretary: leadershipSecretary{},
 			Client:    client,
-			Clock:     ws.state.clock,
+			Clock:     ws.state.clock(),
 			MaxSleep:  time.Minute,
 		})
 		if err != nil {
@@ -79,7 +79,7 @@ func newWorkers(st *State) (*workers, error) {
 		manager, err := lease.NewManager(lease.ManagerConfig{
 			Secretary: singularSecretary{st.ModelUUID()},
 			Client:    client,
-			Clock:     st.clock,
+			Clock:     st.clock(),
 			MaxSleep:  time.Minute,
 		})
 		if err != nil {


### PR DESCRIPTION
Make the clock available via the modelBackend interface - this will
simplify upcoming changes and allow more functions to depend on
modelBackend instead of *State.