### PR TITLE
state: partial conversion from *State to modelBackend.

### DIFF
--- a/state/action.go
+++ b/state/action.go
@@ -247,24 +247,24 @@ func newAction(st *State, adoc actionDoc) Action {
 }
 
 // newActionDoc builds the actionDoc with the given name and parameters.
-func newActionDoc(st *State, receiverTag names.Tag, actionName string, parameters map[string]interface{}) (actionDoc, actionNotificationDoc, error) {
+func newActionDoc(mb modelBackend, receiverTag names.Tag, actionName string, parameters map[string]interface{}) (actionDoc, actionNotificationDoc, error) {
 	prefix := ensureActionMarker(receiverTag.Id())
 	actionId, err := NewUUID()
 	if err != nil {
 		return actionDoc{}, actionNotificationDoc{}, err
 	}
 	actionLogger.Debugf("newActionDoc name: '%s', receiver: '%s', actionId: '%s'", actionName, receiverTag, actionId)
-	modelUUID := st.ModelUUID()
+	modelUUID := mb.modelUUID()
 	return actionDoc{
-			DocId:      st.docID(actionId.String()),
+			DocId:      mb.docID(actionId.String()),
 			ModelUUID:  modelUUID,
 			Receiver:   receiverTag.Id(),
 			Name:       actionName,
 			Parameters: parameters,
-			Enqueued:   st.nowToTheSecond(),
+			Enqueued:   mb.nowToTheSecond(),
 			Status:     ActionPending,
 		}, actionNotificationDoc{
-			DocId:     st.docID(prefix + actionId.String()),
+			DocId:     mb.docID(prefix + actionId.String()),
 			ModelUUID: modelUUID,
 			Receiver:  receiverTag.Id(),
 			ActionID:  actionId.String(),

--- a/state/addmachine.go
+++ b/state/addmachine.go
@@ -287,7 +287,7 @@ func (st *State) addMachineOps(template MachineTemplate) (*machineDoc, []txn.Op,
 		return nil, nil, errors.Trace(err)
 	}
 	prereqOps = append(prereqOps, assertModelActiveOp(st.ModelUUID()))
-	prereqOps = append(prereqOps, st.insertNewContainerRefOp(mdoc.Id))
+	prereqOps = append(prereqOps, insertNewContainerRefOp(st, mdoc.Id))
 	if template.InstanceId != "" {
 		prereqOps = append(prereqOps, txn.Op{
 			C:      instanceDataC,
@@ -367,9 +367,9 @@ func (st *State) addMachineInsideMachineOps(template MachineTemplate, parentId s
 	}
 	prereqOps = append(prereqOps,
 		// Update containers record for host machine.
-		st.addChildToContainerRefOp(parentId, mdoc.Id),
+		addChildToContainerRefOp(st, parentId, mdoc.Id),
 		// Create a containers reference document for the container itself.
-		st.insertNewContainerRefOp(mdoc.Id),
+		insertNewContainerRefOp(st, mdoc.Id),
 	)
 	return mdoc, append(prereqOps, machineOp), nil
 }
@@ -440,9 +440,9 @@ func (st *State) addMachineInsideNewMachineOps(template, parentTemplate MachineT
 	prereqOps = append(prereqOps, parentPrereqOps...)
 	prereqOps = append(prereqOps,
 		// The host machine doesn't exist yet, create a new containers record.
-		st.insertNewContainerRefOp(mdoc.Id),
+		insertNewContainerRefOp(st, mdoc.Id),
 		// Create a containers reference document for the container itself.
-		st.insertNewContainerRefOp(parentDoc.Id, mdoc.Id),
+		insertNewContainerRefOp(st, parentDoc.Id, mdoc.Id),
 	)
 	return mdoc, append(prereqOps, parentOp, machineOp), nil
 }
@@ -566,7 +566,7 @@ func (st *State) baseNewMachineOps(mdoc *machineDoc, machineStatusDoc, instanceS
 	globalInstanceKey := machineGlobalInstanceKey(mdoc.Id)
 
 	prereqOps = []txn.Op{
-		createConstraintsOp(st, globalKey, cons),
+		createConstraintsOp(globalKey, cons),
 		createStatusOp(st, globalKey, machineStatusDoc),
 		createStatusOp(st, globalInstanceKey, instanceStatusDoc),
 		createMachineBlockDevicesOp(mdoc.Id),

--- a/state/annotations.go
+++ b/state/annotations.go
@@ -137,10 +137,10 @@ func insertAnnotationsOps(st *State, entity GlobalEntity, toInsert map[string]st
 }
 
 // updateAnnotations returns the operations required to update or remove annotations in MongoDB.
-func updateAnnotations(st *State, entity GlobalEntity, toUpdate, toRemove bson.M) []txn.Op {
+func updateAnnotations(mb modelBackend, entity GlobalEntity, toUpdate, toRemove bson.M) []txn.Op {
 	return []txn.Op{{
 		C:      annotationsC,
-		Id:     st.docID(entity.globalKey()),
+		Id:     mb.docID(entity.globalKey()),
 		Assert: txn.DocExists,
 		Update: setUnsetUpdateAnnotations(toUpdate, toRemove),
 	}}
@@ -148,10 +148,10 @@ func updateAnnotations(st *State, entity GlobalEntity, toUpdate, toRemove bson.M
 
 // annotationRemoveOp returns an operation to remove a given annotation
 // document from MongoDB.
-func annotationRemoveOp(st *State, id string) txn.Op {
+func annotationRemoveOp(mb modelBackend, id string) txn.Op {
 	return txn.Op{
 		C:      annotationsC,
-		Id:     st.docID(id),
+		Id:     mb.docID(id),
 		Remove: true,
 	}
 }

--- a/state/applicationoffers.go
+++ b/state/applicationoffers.go
@@ -276,9 +276,9 @@ func (s *applicationOffers) UpdateOffer(offerArgs crossmodel.AddApplicationOffer
 	return s.makeApplicationOffer(doc)
 }
 
-func (s *applicationOffers) makeApplicationOfferDoc(st *State, uuid string, offer crossmodel.AddApplicationOfferArgs) applicationOfferDoc {
+func (s *applicationOffers) makeApplicationOfferDoc(mb modelBackend, uuid string, offer crossmodel.AddApplicationOfferArgs) applicationOfferDoc {
 	doc := applicationOfferDoc{
-		DocID:                  st.docID(offer.OfferName),
+		DocID:                  mb.docID(offer.OfferName),
 		OfferUUID:              uuid,
 		OfferName:              offer.OfferName,
 		ApplicationName:        offer.ApplicationName,

--- a/state/charmref.go
+++ b/state/charmref.go
@@ -14,9 +14,8 @@ var errCharmInUse = errors.New("charm in use")
 // appCharmIncRefOps returns the operations necessary to record a reference
 // to a charm and its per-application settings and storage constraints
 // documents. It will fail if the charm is not Alive.
-func appCharmIncRefOps(st modelBackend, appName string, curl *charm.URL, canCreate bool) ([]txn.Op, error) {
-	db := st.db()
-	charms, closer := db.GetCollection(charmsC)
+func appCharmIncRefOps(mb modelBackend, appName string, curl *charm.URL, canCreate bool) ([]txn.Op, error) {
+	charms, closer := mb.db().GetCollection(charmsC)
 	defer closer()
 
 	// If we're migrating. charm document will not be present. But
@@ -33,7 +32,7 @@ func appCharmIncRefOps(st modelBackend, appName string, curl *charm.URL, canCrea
 		checkOps = []txn.Op{checkOp}
 	}
 
-	refcounts, closer := db.GetCollection(refcountsC)
+	refcounts, closer := mb.db().GetCollection(refcountsC)
 	defer closer()
 
 	getIncRefOp := nsRefcounts.CreateOrIncRefOp

--- a/state/constraints.go
+++ b/state/constraints.go
@@ -46,7 +46,7 @@ func (doc constraintsDoc) value() constraints.Value {
 	return result
 }
 
-func newConstraintsDoc(st *State, cons constraints.Value) constraintsDoc {
+func newConstraintsDoc(cons constraints.Value) constraintsDoc {
 	result := constraintsDoc{
 		Arch:         cons.Arch,
 		CpuCores:     cons.CpuCores,
@@ -62,25 +62,25 @@ func newConstraintsDoc(st *State, cons constraints.Value) constraintsDoc {
 	return result
 }
 
-func createConstraintsOp(st *State, id string, cons constraints.Value) txn.Op {
+func createConstraintsOp(id string, cons constraints.Value) txn.Op {
 	return txn.Op{
 		C:      constraintsC,
 		Id:     id,
 		Assert: txn.DocMissing,
-		Insert: newConstraintsDoc(st, cons),
+		Insert: newConstraintsDoc(cons),
 	}
 }
 
-func setConstraintsOp(st *State, id string, cons constraints.Value) txn.Op {
+func setConstraintsOp(id string, cons constraints.Value) txn.Op {
 	return txn.Op{
 		C:      constraintsC,
 		Id:     id,
 		Assert: txn.DocExists,
-		Update: bson.D{{"$set", newConstraintsDoc(st, cons)}},
+		Update: bson.D{{"$set", newConstraintsDoc(cons)}},
 	}
 }
 
-func removeConstraintsOp(st *State, id string) txn.Op {
+func removeConstraintsOp(id string) txn.Op {
 	return txn.Op{
 		C:      constraintsC,
 		Id:     id,
@@ -88,8 +88,8 @@ func removeConstraintsOp(st *State, id string) txn.Op {
 	}
 }
 
-func readConstraints(st *State, id string) (constraints.Value, error) {
-	constraintsCollection, closer := st.db().GetCollection(constraintsC)
+func readConstraints(mb modelBackend, id string) (constraints.Value, error) {
+	constraintsCollection, closer := mb.db().GetCollection(constraintsC)
 	defer closer()
 
 	doc := constraintsDoc{}
@@ -101,9 +101,9 @@ func readConstraints(st *State, id string) (constraints.Value, error) {
 	return doc.value(), nil
 }
 
-func writeConstraints(st *State, id string, cons constraints.Value) error {
-	ops := []txn.Op{setConstraintsOp(st, id, cons)}
-	if err := st.db().RunTransaction(ops); err != nil {
+func writeConstraints(mb modelBackend, id string, cons constraints.Value) error {
+	ops := []txn.Op{setConstraintsOp(id, cons)}
+	if err := mb.db().RunTransaction(ops); err != nil {
 		return fmt.Errorf("cannot set constraints: %v", err)
 	}
 	return nil

--- a/state/container.go
+++ b/state/container.go
@@ -21,19 +21,19 @@ type machineContainers struct {
 	Children  []string `bson:",omitempty"`
 }
 
-func (st *State) addChildToContainerRefOp(parentId string, childId string) txn.Op {
+func addChildToContainerRefOp(mb modelBackend, parentId string, childId string) txn.Op {
 	return txn.Op{
 		C:      containerRefsC,
-		Id:     st.docID(parentId),
+		Id:     mb.docID(parentId),
 		Assert: txn.DocExists,
 		Update: bson.D{{"$addToSet", bson.D{{"children", childId}}}},
 	}
 }
 
-func (st *State) insertNewContainerRefOp(machineId string, children ...string) txn.Op {
+func insertNewContainerRefOp(mb modelBackend, machineId string, children ...string) txn.Op {
 	return txn.Op{
 		C:      containerRefsC,
-		Id:     st.docID(machineId),
+		Id:     mb.docID(machineId),
 		Assert: txn.DocMissing,
 		Insert: &machineContainers{
 			Id:       machineId,
@@ -44,10 +44,10 @@ func (st *State) insertNewContainerRefOp(machineId string, children ...string) t
 
 // removeContainerRefOps returns the txn.Op's necessary to remove a machine container record.
 // These include removing the record itself and updating the host machine's children property.
-func removeContainerRefOps(st *State, machineId string) []txn.Op {
+func removeContainerRefOps(mb modelBackend, machineId string) []txn.Op {
 	removeRefOp := txn.Op{
 		C:      containerRefsC,
-		Id:     st.docID(machineId),
+		Id:     mb.docID(machineId),
 		Assert: txn.DocExists,
 		Remove: true,
 	}
@@ -58,7 +58,7 @@ func removeContainerRefOps(st *State, machineId string) []txn.Op {
 	}
 	removeParentRefOp := txn.Op{
 		C:      containerRefsC,
-		Id:     st.docID(parentId),
+		Id:     mb.docID(parentId),
 		Assert: txn.DocExists,
 		Update: bson.D{{"$pull", bson.D{{"children", machineId}}}},
 	}

--- a/state/dump.go
+++ b/state/dump.go
@@ -30,20 +30,20 @@ func (st *State) DumpAll() (map[string]interface{}, error) {
 	return result, nil
 }
 
-func getModelDoc(st *State) (map[string]interface{}, error) {
-	coll, closer := st.db().GetCollection(modelsC)
+func getModelDoc(mb modelBackend) (map[string]interface{}, error) {
+	coll, closer := mb.db().GetCollection(modelsC)
 	defer closer()
 
 	var doc map[string]interface{}
-	if err := coll.FindId(st.ModelUUID()).One(&doc); err != nil {
-		return nil, errors.Annotatef(err, "reading model %q", st.ModelUUID())
+	if err := coll.FindId(mb.modelUUID()).One(&doc); err != nil {
+		return nil, errors.Annotatef(err, "reading model %q", mb.modelUUID())
 	}
 	return doc, nil
 
 }
 
-func getAllModelDocs(st *State, collectionName string) ([]map[string]interface{}, error) {
-	coll, closer := st.db().GetCollection(collectionName)
+func getAllModelDocs(mb modelBackend, collectionName string) ([]map[string]interface{}, error) {
+	coll, closer := mb.db().GetCollection(collectionName)
 	defer closer()
 
 	var (

--- a/state/filesystem.go
+++ b/state/filesystem.go
@@ -791,8 +791,8 @@ func ParseFilesystemAttachmentId(id string) (names.MachineTag, names.FilesystemT
 // If the machine ID supplied is non-empty, the
 // filesystem ID will incorporate it as the
 // filesystem's machine scope.
-func newFilesystemId(st *State, machineId string) (string, error) {
-	seq, err := sequence(st, "filesystem")
+func newFilesystemId(mb modelBackend, machineId string) (string, error) {
+	seq, err := sequence(mb, "filesystem")
 	if err != nil {
 		return "", errors.Trace(err)
 	}

--- a/state/initialize.go
+++ b/state/initialize.go
@@ -289,7 +289,7 @@ func (st *State) modelSetupOps(controllerUUID string, args ModelArgs, inherited 
 	)
 	ops := []txn.Op{
 		createStatusOp(st, modelGlobalKey, modelStatusDoc),
-		createConstraintsOp(st, modelGlobalKey, args.Constraints),
+		createConstraintsOp(modelGlobalKey, args.Constraints),
 	}
 	// Inc ref count for hosted models.
 	if controllerModelUUID != modelUUID {

--- a/state/life.go
+++ b/state/life.go
@@ -61,8 +61,8 @@ type AgentLiving interface {
 	Remove() error
 }
 
-func isAlive(st *State, collName string, id interface{}) (bool, error) {
-	coll, closer := st.db().GetCollection(collName)
+func isAlive(mb modelBackend, collName string, id interface{}) (bool, error) {
+	coll, closer := mb.db().GetCollection(collName)
 	defer closer()
 	return isAliveWithSession(coll, id)
 }
@@ -72,8 +72,8 @@ func isAliveWithSession(coll mongo.Collection, id interface{}) (bool, error) {
 	return n == 1, err
 }
 
-func isNotDead(st *State, collName string, id interface{}) (bool, error) {
-	coll, closer := st.db().GetCollection(collName)
+func isNotDead(mb modelBackend, collName string, id interface{}) (bool, error) {
+	coll, closer := mb.db().GetCollection(collName)
 	defer closer()
 	return isNotDeadWithSession(coll, id)
 }

--- a/state/machine.go
+++ b/state/machine.go
@@ -826,12 +826,12 @@ func (m *Machine) removeOps() ([]txn.Op, error) {
 		},
 		removeStatusOp(m.st, m.globalKey()),
 		removeStatusOp(m.st, m.globalInstanceKey()),
-		removeConstraintsOp(m.st, m.globalKey()),
+		removeConstraintsOp(m.globalKey()),
 		annotationRemoveOp(m.st, m.globalKey()),
 		removeRebootDocOp(m.st, m.globalKey()),
 		removeMachineBlockDevicesOp(m.Id()),
 		removeModelMachineRefOp(m.st, m.Id()),
-		removeSSHHostKeyOp(m.st, m.globalKey()),
+		removeSSHHostKeyOp(m.globalKey()),
 	}
 	linkLayerDevicesOps, err := m.removeAllLinkLayerDevicesOps()
 	if err != nil {
@@ -1571,7 +1571,7 @@ func (m *Machine) SetConstraints(cons constraints.Value) (err error) {
 		return err
 	}
 
-	ops = append(ops, setConstraintsOp(m.st, m.globalKey(), mcons))
+	ops = append(ops, setConstraintsOp(m.globalKey(), mcons))
 	// make multiple attempts to push the ErrExcessiveContention case out of the
 	// realm of plausibility: it implies local state indicating unprovisioned,
 	// and remote state indicating provisioned (reasonable); but which changes

--- a/state/meterstatus.go
+++ b/state/meterstatus.go
@@ -131,11 +131,11 @@ func (u *Unit) SetMeterStatus(codeStr, info string) error {
 
 // createMeterStatusOp returns the operation needed to create the meter status
 // document associated with the given globalKey.
-func createMeterStatusOp(st *State, globalKey string, doc *meterStatusDoc) txn.Op {
-	doc.ModelUUID = st.ModelUUID()
+func createMeterStatusOp(mb modelBackend, globalKey string, doc *meterStatusDoc) txn.Op {
+	doc.ModelUUID = mb.modelUUID()
 	return txn.Op{
 		C:      meterStatusC,
-		Id:     st.docID(globalKey),
+		Id:     mb.docID(globalKey),
 		Assert: txn.DocMissing,
 		Insert: doc,
 	}
@@ -143,10 +143,10 @@ func createMeterStatusOp(st *State, globalKey string, doc *meterStatusDoc) txn.O
 
 // removeMeterStatusOp returns the operation needed to remove the meter status
 // document associated with the given globalKey.
-func removeMeterStatusOp(st *State, globalKey string) txn.Op {
+func removeMeterStatusOp(mb modelBackend, globalKey string) txn.Op {
 	return txn.Op{
 		C:      meterStatusC,
-		Id:     st.docID(globalKey),
+		Id:     mb.docID(globalKey),
 		Remove: true,
 	}
 }

--- a/state/migration_import.go
+++ b/state/migration_import.go
@@ -396,12 +396,12 @@ func (i *importer) machine(m description.Machine) error {
 	if parentId := ParentId(mdoc.Id); parentId != "" {
 		prereqOps = append(prereqOps,
 			// Update containers record for host machine.
-			i.st.addChildToContainerRefOp(parentId, mdoc.Id),
+			addChildToContainerRefOp(i.st, parentId, mdoc.Id),
 		)
 	}
 	// insertNewContainerRefOp adds an empty doc into the containerRefsC
 	// collection for the machine being added.
-	prereqOps = append(prereqOps, i.st.insertNewContainerRefOp(mdoc.Id))
+	prereqOps = append(prereqOps, insertNewContainerRefOp(i.st, mdoc.Id))
 
 	// 4. gather prereqs and machine op, run ops.
 	ops := append(prereqOps, machineOp)
@@ -923,7 +923,7 @@ func (i *importer) unit(s description.Application, u description.Unit) error {
 	// in the imported model, we put them in the database.
 	if cons := u.Constraints(); cons != nil {
 		agentGlobalKey := unitAgentGlobalKey(u.Name())
-		ops = append(ops, createConstraintsOp(i.st, agentGlobalKey, i.constraints(cons)))
+		ops = append(ops, createConstraintsOp(agentGlobalKey, i.constraints(cons)))
 	}
 
 	if err := i.st.db().RunTransaction(ops); err != nil {

--- a/state/model.go
+++ b/state/model.go
@@ -1027,51 +1027,51 @@ func (m *Model) checkEmpty() error {
 	return nil
 }
 
-func addModelMachineRefOp(st *State, machineId string) txn.Op {
-	return addModelEntityRefOp(st, "machines", machineId)
+func addModelMachineRefOp(mb modelBackend, machineId string) txn.Op {
+	return addModelEntityRefOp(mb, "machines", machineId)
 }
 
-func removeModelMachineRefOp(st *State, machineId string) txn.Op {
-	return removeModelEntityRefOp(st, "machines", machineId)
+func removeModelMachineRefOp(mb modelBackend, machineId string) txn.Op {
+	return removeModelEntityRefOp(mb, "machines", machineId)
 }
 
-func addModelApplicationRefOp(st *State, applicationname string) txn.Op {
-	return addModelEntityRefOp(st, "applications", applicationname)
+func addModelApplicationRefOp(mb modelBackend, applicationname string) txn.Op {
+	return addModelEntityRefOp(mb, "applications", applicationname)
 }
 
-func removeModelApplicationRefOp(st *State, applicationname string) txn.Op {
-	return removeModelEntityRefOp(st, "applications", applicationname)
+func removeModelApplicationRefOp(mb modelBackend, applicationname string) txn.Op {
+	return removeModelEntityRefOp(mb, "applications", applicationname)
 }
 
-func addModelVolumeRefOp(st *State, volumeId string) txn.Op {
-	return addModelEntityRefOp(st, "volumes", volumeId)
+func addModelVolumeRefOp(mb modelBackend, volumeId string) txn.Op {
+	return addModelEntityRefOp(mb, "volumes", volumeId)
 }
 
-func removeModelVolumeRefOp(st *State, volumeId string) txn.Op {
-	return removeModelEntityRefOp(st, "volumes", volumeId)
+func removeModelVolumeRefOp(mb modelBackend, volumeId string) txn.Op {
+	return removeModelEntityRefOp(mb, "volumes", volumeId)
 }
 
-func addModelFilesystemRefOp(st *State, filesystemId string) txn.Op {
-	return addModelEntityRefOp(st, "filesystems", filesystemId)
+func addModelFilesystemRefOp(mb modelBackend, filesystemId string) txn.Op {
+	return addModelEntityRefOp(mb, "filesystems", filesystemId)
 }
 
-func removeModelFilesystemRefOp(st *State, filesystemId string) txn.Op {
-	return removeModelEntityRefOp(st, "filesystems", filesystemId)
+func removeModelFilesystemRefOp(mb modelBackend, filesystemId string) txn.Op {
+	return removeModelEntityRefOp(mb, "filesystems", filesystemId)
 }
 
-func addModelEntityRefOp(st *State, entityField, entityId string) txn.Op {
+func addModelEntityRefOp(mb modelBackend, entityField, entityId string) txn.Op {
 	return txn.Op{
 		C:      modelEntityRefsC,
-		Id:     st.ModelUUID(),
+		Id:     mb.modelUUID(),
 		Assert: txn.DocExists,
 		Update: bson.D{{"$addToSet", bson.D{{entityField, entityId}}}},
 	}
 }
 
-func removeModelEntityRefOp(st *State, entityField, entityId string) txn.Op {
+func removeModelEntityRefOp(mb modelBackend, entityField, entityId string) txn.Op {
 	return txn.Op{
 		C:      modelEntityRefsC,
-		Id:     st.ModelUUID(),
+		Id:     mb.modelUUID(),
 		Update: bson.D{{"$pull", bson.D{{entityField, entityId}}}},
 	}
 }

--- a/state/sshhostkeys.go
+++ b/state/sshhostkeys.go
@@ -69,7 +69,7 @@ func (st *State) SetSSHHostKeys(tag names.MachineTag, keys SSHHostKeys) error {
 
 // removeSSHHostKeyOp returns the operation needed to remove the SSH
 // host key document associated with the given globalKey.
-func removeSSHHostKeyOp(st *State, globalKey string) txn.Op {
+func removeSSHHostKeyOp(globalKey string) txn.Op {
 	return txn.Op{
 		C:      sshHostKeysC,
 		Id:     globalKey,

--- a/state/storage.go
+++ b/state/storage.go
@@ -210,8 +210,8 @@ type storageAttachmentDoc struct {
 // newStorageInstanceId returns a unique storage instance name. The name
 // incorporates the storage name as defined in the charm storage metadata,
 // and a unique sequence number.
-func newStorageInstanceId(st *State, store string) (string, error) {
-	seq, err := sequence(st, "stores")
+func newStorageInstanceId(mb modelBackend, store string) (string, error) {
+	seq, err := sequence(mb, "stores")
 	if err != nil {
 		return "", errors.Trace(err)
 	}
@@ -522,8 +522,8 @@ func validateStorageCountChange(
 // count for a storage instance for a given application or unit. This
 // should be called when creating a shared storage instance, or when
 // attaching a non-shared storage instance to a unit.
-func increfEntityStorageOp(st *State, owner names.Tag, storageName string, n int) (txn.Op, error) {
-	refcounts, closer := st.db().GetCollection(refcountsC)
+func increfEntityStorageOp(mb modelBackend, owner names.Tag, storageName string, n int) (txn.Op, error) {
+	refcounts, closer := mb.db().GetCollection(refcountsC)
 	defer closer()
 	storageRefcountKey := entityStorageRefcountKey(owner, storageName)
 	incRefOp, err := nsRefcounts.CreateOrIncRefOp(refcounts, storageRefcountKey, n)
@@ -534,8 +534,8 @@ func increfEntityStorageOp(st *State, owner names.Tag, storageName string, n int
 // count for a storage instance from a given application or unit. This
 // should be called when removing a shared storage instance, or when
 // detaching a non-shared storage instance from a unit.
-func decrefEntityStorageOp(st *State, owner names.Tag, storageName string) (txn.Op, error) {
-	refcounts, closer := st.db().GetCollection(refcountsC)
+func decrefEntityStorageOp(mb modelBackend, owner names.Tag, storageName string) (txn.Op, error) {
+	refcounts, closer := mb.db().GetCollection(refcountsC)
 	defer closer()
 	storageRefcountKey := entityStorageRefcountKey(owner, storageName)
 	decRefOp, _, err := nsRefcounts.DyingDecRefOp(refcounts, storageRefcountKey)

--- a/state/upgrade.go
+++ b/state/upgrade.go
@@ -215,7 +215,7 @@ func (info *UpgradeInfo) isModelUUIDUpgradeDone() (bool, error) {
 
 // upgradeStatusHistoryAndOps sets the model's status history and returns ops for
 // setting model status according to the UpgradeStatus.
-func upgradeStatusHistoryAndOps(st *State, upgradeStatus UpgradeStatus, now time.Time) ([]txn.Op, error) {
+func upgradeStatusHistoryAndOps(mb modelBackend, upgradeStatus UpgradeStatus, now time.Time) ([]txn.Op, error) {
 	var modelStatus status.Status
 	var msg string
 	switch upgradeStatus {
@@ -236,11 +236,11 @@ func upgradeStatusHistoryAndOps(st *State, upgradeStatus UpgradeStatus, now time
 		StatusInfo: msg,
 		Updated:    now.UnixNano(),
 	}
-	ops, err := statusSetOps(st.db(), doc, modelGlobalKey)
+	ops, err := statusSetOps(mb.db(), doc, modelGlobalKey)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	probablyUpdateStatusHistory(st.db(), modelGlobalKey, doc)
+	probablyUpdateStatusHistory(mb.db(), modelGlobalKey, doc)
 	return ops, nil
 }
 


### PR DESCRIPTION
Convert various functions from taking a *State to a modelBackend,
or in some cases removing the unused argument entirely. This change
will simplify future refactoring.