### PR TITLE
Handle subordinate-subordinate relations in subordinate filtering

### DIFF
--- a/apiserver/uniter/subordinaterelationwatcher.go
+++ b/apiserver/uniter/subordinaterelationwatcher.go
@@ -119,13 +119,21 @@ func (w *subRelationsWatcher) shouldSendCheck(key string) (bool, error) {
 		return true, nil
 	}
 
-	// Only allow container relations if the other end is our principal.
+	// Only allow container relations if the other end is our
+	// principal or the other end is a subordinate.
 	otherEnds, err := rel.RelatedEndpoints(w.app.Name())
 	if err != nil {
 		return false, errors.Trace(err)
 	}
 	for _, otherEnd := range otherEnds {
 		if otherEnd.ApplicationName == w.principalName {
+			return true, nil
+		}
+		otherApp, err := w.backend.Application(otherEnd.ApplicationName)
+		if err != nil {
+			return false, errors.Trace(err)
+		}
+		if !otherApp.IsPrincipal() {
 			return true, nil
 		}
 	}

--- a/state/relation.go
+++ b/state/relation.go
@@ -301,7 +301,8 @@ func (r *Relation) Endpoint(applicationname string) (Endpoint, error) {
 			return ep, nil
 		}
 	}
-	return Endpoint{}, errors.Errorf("application %q is not a member of %q", applicationname, r)
+	msg := fmt.Sprintf("application %q is not a member of %q", applicationname, r)
+	return Endpoint{}, errors.NewNotFound(nil, msg)
 }
 
 // Endpoints returns the endpoints for the relation.

--- a/state/upgrades_test.go
+++ b/state/upgrades_test.go
@@ -1495,6 +1495,8 @@ func (s *upgradesSuite) TestCorrectRelationUnitCounts(c *gc.C) {
 	defer rCloser()
 	scopes, sCloser := s.state.getRawCollection(relationScopesC)
 	defer sCloser()
+	applications, aCloser := s.state.getRawCollection(applicationsC)
+	defer aCloser()
 
 	// Use the non-controller model to ensure we can run the function
 	// across multiple models.
@@ -1547,6 +1549,33 @@ func (s *upgradesSuite) TestCorrectRelationUnitCounts(c *gc.C) {
 			},
 		}},
 		"unitcount": 2,
+	}, bson.M{
+		"_id":        uuid + ":ntp:juju-info nrpe:general-info",
+		"key":        "ntp:juju-info nrpe:general-info",
+		"model-uuid": uuid,
+		"id":         5,
+		"endpoints": []bson.M{{
+			"applicationname": "ntp",
+			"relation": bson.M{
+				"name":      "juju-info",
+				"role":      "provider",
+				"interface": "juju-info",
+				"optional":  false,
+				"limit":     0,
+				"scope":     "container",
+			},
+		}, {
+			"applicationname": "nrpe",
+			"relation": bson.M{
+				"name":      "general-info",
+				"role":      "requirer",
+				"interface": "juju-info",
+				"optional":  false,
+				"limit":     1,
+				"scope":     "container",
+			},
+		}},
+		"unitcount": 4,
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -1590,6 +1619,44 @@ func (s *upgradesSuite) TestCorrectRelationUnitCounts(c *gc.C) {
 		"key":        "r#3#peer#ntp/1",
 		"model-uuid": uuid,
 		"departing":  false,
+	}, bson.M{
+		"_id":        uuid + ":r#5#min/0#provider#ntp/0",
+		"key":        "r#5#min/0#provider#ntp/0",
+		"model-uuid": uuid,
+		"departing":  false,
+	}, bson.M{
+		"_id":        uuid + ":r#5#min/0#requirer#nrpe/0",
+		"key":        "r#5#min/0#requirer#nrpe/0",
+		"model-uuid": uuid,
+		"departing":  false,
+	}, bson.M{
+		"_id":        uuid + ":r#5#min/1#provider#ntp/1",
+		"key":        "r#5#min/1#provider#ntp/1",
+		"model-uuid": uuid,
+		"departing":  false,
+	}, bson.M{
+		"_id":        uuid + ":r#5#min/1#requirer#nrpe/1",
+		"key":        "r#5#min/1#requirer#nrpe/1",
+		"model-uuid": uuid,
+		"departing":  false,
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = applications.Insert(bson.M{
+		"_id":         uuid + ":min",
+		"name":        "min",
+		"model-uuid":  uuid,
+		"subordinate": false,
+	}, bson.M{
+		"_id":         uuid + ":ntp",
+		"name":        "ntp",
+		"model-uuid":  uuid,
+		"subordinate": true,
+	}, bson.M{
+		"_id":         uuid + ":nrpe",
+		"name":        "nrpe",
+		"model-uuid":  uuid,
+		"subordinate": true,
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -1600,6 +1667,33 @@ func (s *upgradesSuite) TestCorrectRelationUnitCounts(c *gc.C) {
 		"id":         4,
 		"endpoints": []interface{}{bson.M{
 			"applicationname": "min",
+			"relation": bson.M{
+				"name":      "juju-info",
+				"role":      "provider",
+				"interface": "juju-info",
+				"optional":  false,
+				"limit":     0,
+				"scope":     "container",
+			},
+		}, bson.M{
+			"applicationname": "nrpe",
+			"relation": bson.M{
+				"name":      "general-info",
+				"role":      "requirer",
+				"interface": "juju-info",
+				"optional":  false,
+				"limit":     1,
+				"scope":     "container",
+			},
+		}},
+		"unitcount": 4,
+	}, {
+		"_id":        uuid + ":ntp:juju-info nrpe:general-info",
+		"key":        "ntp:juju-info nrpe:general-info",
+		"model-uuid": uuid,
+		"id":         5,
+		"endpoints": []interface{}{bson.M{
+			"applicationname": "ntp",
 			"relation": bson.M{
 				"name":      "juju-info",
 				"role":      "provider",
@@ -1666,6 +1760,26 @@ func (s *upgradesSuite) TestCorrectRelationUnitCounts(c *gc.C) {
 	}, {
 		"_id":        uuid + ":r#4#min/1#requirer#nrpe/1",
 		"key":        "r#4#min/1#requirer#nrpe/1",
+		"model-uuid": uuid,
+		"departing":  false,
+	}, {
+		"_id":        uuid + ":r#5#min/0#provider#ntp/0",
+		"key":        "r#5#min/0#provider#ntp/0",
+		"model-uuid": uuid,
+		"departing":  false,
+	}, {
+		"_id":        uuid + ":r#5#min/0#requirer#nrpe/0",
+		"key":        "r#5#min/0#requirer#nrpe/0",
+		"model-uuid": uuid,
+		"departing":  false,
+	}, {
+		"_id":        uuid + ":r#5#min/1#provider#ntp/1",
+		"key":        "r#5#min/1#provider#ntp/1",
+		"model-uuid": uuid,
+		"departing":  false,
+	}, {
+		"_id":        uuid + ":r#5#min/1#requirer#nrpe/1",
+		"key":        "r#5#min/1#requirer#nrpe/1",
 		"model-uuid": uuid,
 		"departing":  false,
 	}}


### PR DESCRIPTION
## Description of change
In fixing [bug 1686696](https://bugs.launchpad.net/juju/+bug/1686696) I changed the uniter API WatchUnitRelations to restrict container-scoped relations to those where the other end was the app for the principal unit. Then in the fixes for the related [bug 1699050](https://bugs.launchpad.net/juju/+bug/1699050) an upgrade step was added to make the same change in the database, and the uniter API was changed to prevent invalid relation units entering scope.

This excluded relations between subordinate applications (like ntp and nrpe), which meant that upgrading a model with sub-sub relations would result in the uniters repeatedly crashing as they tried to remove a relation state directory with files in it (because that sub-sub relation had been incorrectly filtered out).

Change the watcher, upgrade step and uniter API EnterScope method to allow sub-sub relations through.

## QA steps

* Bootstrap a 2.1.3 controller and add a model.
* Deploy the following bundle:
```
series: xenial
machines:
  '0':
    series: xenial
  '1':
    series: xenial
services:
  min:
    charm: cs:ubuntu-10
    num_units: 1
    to:
      - "0"
  min2:
    charm: cs:ubuntu-10
    num_units: 1
    to:
      - "1"
  nrpe:
    charm: cs:nrpe-23
  ntp:
    charm: cs:ntp-18
relations:
- - min:juju-info
  - nrpe:general-info
- - min2:juju-info
  - nrpe:general-info
- - ntp:nrpe-external-master
  - nrpe:nrpe-external-master
- - ntp:juju-info
  - min:juju-info
- - ntp:juju-info
  - min2:juju-info
```
* Observe in the DB that the min-ntp, min2-ntp, min-nrpe and min2-nrpe relations all have an incorrect unitcount of 3, but the ntp-nrpe relation unitcount is 4 (which is right).
* Upgrade the controller and model from 2.1.3 to the version containing this PR.
* Check in the DB that the incorrect unitcounts have been changed to 2, but the ntp-nrpe relation is still 4.
* Check that there aren't repeated errors in the log from the uniter crashing and restarting in a loop.

## Bug reference

Fixes https://bugs.launchpad.net/juju/+bug/1700450
