### PR TITLE
Fix typo in flag doc for add-model no-switch flag

### DIFF
--- a/cmd/juju/controller/addmodel.go
+++ b/cmd/juju/controller/addmodel.go
@@ -116,7 +116,7 @@ func (c *addModelCommand) SetFlags(f *gnuflag.FlagSet) {
 	f.StringVar(&c.Owner, "owner", "", "The owner of the new model if not the current user")
 	f.StringVar(&c.CredentialName, "credential", "", "Credential used to add the model")
 	f.Var(&c.Config, "config", "Path to YAML model configuration file or individual options (--config config.yaml [--config key=value ...])")
-	f.BoolVar(&c.noSwitch, "no-switch", false, "Do not switch to the newly created controller")
+	f.BoolVar(&c.noSwitch, "no-switch", false, "Do not switch to the newly created model")
 }
 
 func (c *addModelCommand) Init(args []string) error {


### PR DESCRIPTION
Signed-off-by: Michael McCracken <mike.mccracken@canonical.com>

`juju help add-model` currently says this about --no-switch:

```
...
--no-switch  (= false)
    Do not switch to the newly created controller
...
```

It should say "newly created model".