### PR TITLE
Skip non-insert records when tailing the oplog.

### DIFF
--- a/worker/uniter/resolver.go
+++ b/worker/uniter/resolver.go
@@ -118,7 +118,7 @@ func (s *uniterResolver) NextOp(
 		}
 
 	case operation.Continue:
-		logger.Infof("no operations in progress; waiting for changes")
+		logger.Debugf("no operations in progress; waiting for changes")
 		return s.nextOp(localState, remoteState, opFactory)
 
 	default:


### PR DESCRIPTION
## Description of change

The debug-log implementation of tailing the oplog was getting messed up when the log pruning ran, as it caused deletion entries in the oplog.

## QA steps

```
cd state
go test -check.f TestLogDeletionDuringTailing -check.vv
```
And observe that there is no log deserialisation warning.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1700453
