### PR TITLE
state: introduce state.IAASModel and start migration

### DIFF
--- a/apiserver/application/application.go
+++ b/apiserver/application/application.go
@@ -54,7 +54,10 @@ type API struct {
 
 // NewFacade provides the signature required for facade registration.
 func NewFacade(ctx facade.Context) (*API, error) {
-	backend := NewStateBackend(ctx.State())
+	backend, err := NewStateBackend(ctx.State())
+	if err != nil {
+		return nil, errors.Annotate(err, "getting state")
+	}
 	blockChecker := common.NewBlockChecker(ctx.State())
 	stateCharm := CharmToStateCharm
 	return NewAPI(

--- a/apiserver/application/application_test.go
+++ b/apiserver/application/application_test.go
@@ -85,7 +85,8 @@ func (s *applicationSuite) TearDownTest(c *gc.C) {
 func (s *applicationSuite) makeAPI(c *gc.C) *application.API {
 	resources := common.NewResources()
 	resources.RegisterNamed("dataDir", common.StringResource(c.MkDir()))
-	backend := application.NewStateBackend(s.State)
+	backend, err := application.NewStateBackend(s.State)
+	c.Assert(err, jc.ErrorIsNil)
 	blockChecker := common.NewBlockChecker(s.State)
 	api, err := application.NewAPI(
 		backend, s.authorizer, s.BackingStatePool,

--- a/apiserver/application/backend.go
+++ b/apiserver/application/backend.go
@@ -121,6 +121,7 @@ type Model interface {
 
 type stateShim struct {
 	*state.State
+	*state.IAASModel
 }
 
 type ExternalController state.ExternalController
@@ -131,8 +132,12 @@ func (s stateShim) SaveController(controllerInfo crossmodel.ControllerInfo, mode
 }
 
 // NewStateBackend converts a state.State into a Backend.
-func NewStateBackend(st *state.State) Backend {
-	return stateShim{st}
+func NewStateBackend(st *state.State) (Backend, error) {
+	im, err := st.IAASModel()
+	if err != nil {
+		return nil, err
+	}
+	return stateShim{State: st, IAASModel: im}, nil
 }
 
 // NewStateApplication converts a state.Application into an Application.

--- a/apiserver/application/get_test.go
+++ b/apiserver/application/get_test.go
@@ -34,8 +34,8 @@ func (s *getSuite) SetUpTest(c *gc.C) {
 	s.authorizer = apiservertesting.FakeAuthorizer{
 		Tag: s.AdminUserTag(c),
 	}
-	var err error
-	backend := application.NewStateBackend(s.State)
+	backend, err := application.NewStateBackend(s.State)
+	c.Assert(err, jc.ErrorIsNil)
 	blockChecker := common.NewBlockChecker(s.State)
 	s.serviceAPI, err = application.NewAPI(
 		backend, s.authorizer, s.BackingStatePool,

--- a/apiserver/machinemanager/export_test.go
+++ b/apiserver/machinemanager/export_test.go
@@ -15,8 +15,8 @@ type Patcher interface {
 }
 
 func PatchState(p Patcher, st StateInterface) {
-	p.PatchValue(&getState, func(*state.State) stateInterface {
-		return st
+	p.PatchValue(&getState, func(*state.State) (stateInterface, error) {
+		return st, nil
 	})
 }
 

--- a/apiserver/machinemanager/state.go
+++ b/apiserver/machinemanager/state.go
@@ -34,6 +34,7 @@ type stateInterface interface {
 
 type stateShim struct {
 	*state.State
+	*state.IAASModel
 }
 
 func (s stateShim) Machine(name string) (Machine, error) {

--- a/apiserver/provisioner/provisioninginfo.go
+++ b/apiserver/provisioner/provisioninginfo.go
@@ -118,6 +118,10 @@ func (p *ProvisionerAPI) machineVolumeParams(
 	m *state.Machine,
 	env environs.Environ,
 ) ([]params.VolumeParams, []params.VolumeAttachmentParams, error) {
+	im, err := p.st.IAASModel()
+	if err != nil {
+		return nil, nil, errors.Trace(err)
+	}
 	volumeAttachments, err := m.VolumeAttachments()
 	if err != nil {
 		return nil, nil, errors.Trace(err)
@@ -137,7 +141,7 @@ func (p *ProvisionerAPI) machineVolumeParams(
 	var allVolumeAttachmentParams []params.VolumeAttachmentParams
 	for _, volumeAttachment := range volumeAttachments {
 		volumeTag := volumeAttachment.Volume()
-		volume, err := p.st.Volume(volumeTag)
+		volume, err := im.Volume(volumeTag)
 		if err != nil {
 			return nil, nil, errors.Annotatef(err, "getting volume %q", volumeTag.Id())
 		}

--- a/apiserver/storageprovisioner/shim.go
+++ b/apiserver/storageprovisioner/shim.go
@@ -29,7 +29,11 @@ func NewFacade(st *state.State, resources facade.Resources, authorizer facade.Au
 	}
 	registry := stateenvirons.NewStorageProviderRegistry(env)
 	pm := poolmanager.New(state.NewStateSettings(st), registry)
-	return NewStorageProvisionerAPI(stateShim{st}, resources, authorizer, registry, pm)
+	ss, err := NewStateBackend(st)
+	if err != nil {
+		return nil, errors.Annotate(err, "getting state")
+	}
+	return NewStorageProvisionerAPI(ss, resources, authorizer, registry, pm)
 }
 
 type Backend interface {
@@ -75,11 +79,16 @@ type Backend interface {
 
 type stateShim struct {
 	*state.State
+	*state.IAASModel
 }
 
 // NewStateBackend creates a Backend from the given *state.State.
-func NewStateBackend(st *state.State) Backend {
-	return stateShim{st}
+func NewStateBackend(st *state.State) (Backend, error) {
+	im, err := st.IAASModel()
+	if err != nil {
+		return nil, err
+	}
+	return stateShim{State: st, IAASModel: im}, nil
 }
 
 func (s stateShim) MachineInstanceId(tag names.MachineTag) (instance.Id, error) {

--- a/apiserver/storageprovisioner/storageprovisioner_test.go
+++ b/apiserver/storageprovisioner/storageprovisioner_test.go
@@ -58,7 +58,8 @@ func (s *provisionerSuite) SetUpTest(c *gc.C) {
 		Tag:        names.NewMachineTag("0"),
 		Controller: true,
 	}
-	backend := storageprovisioner.NewStateBackend(s.State)
+	backend, err := storageprovisioner.NewStateBackend(s.State)
+	c.Assert(err, jc.ErrorIsNil)
 	s.api, err = storageprovisioner.NewStorageProvisionerAPI(backend, s.resources, s.authorizer, registry, pm)
 	c.Assert(err, jc.ErrorIsNil)
 }
@@ -66,8 +67,9 @@ func (s *provisionerSuite) SetUpTest(c *gc.C) {
 func (s *provisionerSuite) TestNewStorageProvisionerAPINonMachine(c *gc.C) {
 	tag := names.NewUnitTag("mysql/0")
 	authorizer := &apiservertesting.FakeAuthorizer{Tag: tag}
-	backend := storageprovisioner.NewStateBackend(s.State)
-	_, err := storageprovisioner.NewStorageProvisionerAPI(backend, common.NewResources(), authorizer, nil, nil)
+	backend, err := storageprovisioner.NewStateBackend(s.State)
+	c.Assert(err, jc.ErrorIsNil)
+	_, err = storageprovisioner.NewStorageProvisionerAPI(backend, common.NewResources(), authorizer, nil, nil)
 	c.Assert(err, gc.ErrorMatches, "permission denied")
 }
 

--- a/apiserver/uniter/state.go
+++ b/apiserver/uniter/state.go
@@ -33,10 +33,15 @@ type storageStateInterface interface {
 
 type storageStateShim struct {
 	*state.State
+	*state.IAASModel
 }
 
-var getStorageState = func(st *state.State) storageStateInterface {
-	return storageStateShim{st}
+var getStorageState = func(st *state.State) (storageStateInterface, error) {
+	im, err := st.IAASModel()
+	if err != nil {
+		return nil, err
+	}
+	return storageStateShim{State: st, IAASModel: im}, nil
 }
 
 // UnitAssignedMachine returns the tag of the machine that the unit

--- a/apiserver/uniter/uniter.go
+++ b/apiserver/uniter/uniter.go
@@ -112,7 +112,11 @@ func NewUniterAPI(st *state.State, resources facade.Resources, authorizer facade
 			return nil, errors.Errorf("expected names.UnitTag, got %T", tag)
 		}
 	}
-	storageAPI, err := newStorageAPI(getStorageState(st), resources, accessUnit)
+	ss, err := getStorageState(st)
+	if err != nil {
+		return nil, errors.Annotate(err, "getting state")
+	}
+	storageAPI, err := newStorageAPI(ss, resources, accessUnit)
 	if err != nil {
 		return nil, err
 	}

--- a/state/addmachine.go
+++ b/state/addmachine.go
@@ -448,9 +448,13 @@ func (st *State) addMachineInsideNewMachineOps(template, parentTemplate MachineT
 }
 
 func (st *State) machineTemplateVolumeAttachmentParams(t MachineTemplate) ([]storage.VolumeAttachmentParams, error) {
+	im, err := st.IAASModel()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	out := make([]storage.VolumeAttachmentParams, 0, len(t.VolumeAttachments))
 	for volumeTag, a := range t.VolumeAttachments {
-		v, err := st.Volume(volumeTag)
+		v, err := im.Volume(volumeTag)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
@@ -622,6 +626,11 @@ func (st *State) machineStorageOps(
 		attachOnly      = true
 	)
 
+	im, err := st.IAASModel()
+	if err != nil {
+		return nil, nil, nil, errors.Trace(err)
+	}
+
 	// Create filesystems and filesystem attachments.
 	for _, f := range args.filesystems {
 		ops, filesystemTag, volumeTag, err := st.addFilesystemOps(f.Filesystem, mdoc.Id)
@@ -647,7 +656,7 @@ func (st *State) machineStorageOps(
 
 	// Create volumes and volume attachments.
 	for _, v := range args.volumes {
-		ops, tag, err := st.addVolumeOps(v.Volume, mdoc.Id)
+		ops, tag, err := im.addVolumeOps(v.Volume, mdoc.Id)
 		if err != nil {
 			return nil, nil, nil, errors.Trace(err)
 		}

--- a/state/assign_test.go
+++ b/state/assign_test.go
@@ -1093,11 +1093,13 @@ func (s *assignCleanSuite) TestAssignUnitWithDynamicStorageCleanAvailable(c *gc.
 	// Check that a volume attachments were added to the machine.
 	machine, err := s.State.Machine(machineId)
 	c.Assert(err, jc.ErrorIsNil)
-	volumeAttachments, err := s.State.MachineVolumeAttachments(machine.MachineTag())
+	im, err := s.State.IAASModel()
+	c.Assert(err, jc.ErrorIsNil)
+	volumeAttachments, err := im.MachineVolumeAttachments(machine.MachineTag())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(volumeAttachments, gc.HasLen, 1)
 
-	volume, err := s.State.Volume(volumeAttachments[0].Volume())
+	volume, err := im.Volume(volumeAttachments[0].Volume())
 	c.Assert(err, jc.ErrorIsNil)
 	volumeStorageInstance, err := volume.StorageInstance()
 	c.Assert(err, jc.ErrorIsNil)

--- a/state/blockdevices.go
+++ b/state/blockdevices.go
@@ -48,13 +48,13 @@ type BlockDeviceInfo struct {
 
 // WatchBlockDevices returns a new NotifyWatcher watching for
 // changes to block devices associated with the specified machine.
-func (st *State) WatchBlockDevices(machine names.MachineTag) NotifyWatcher {
-	return newBlockDevicesWatcher(st, machine.Id())
+func (im *IAASModel) WatchBlockDevices(machine names.MachineTag) NotifyWatcher {
+	return newBlockDevicesWatcher(im.mb, machine.Id())
 }
 
 // BlockDevices returns the BlockDeviceInfo for the specified machine.
-func (st *State) BlockDevices(machine names.MachineTag) ([]BlockDeviceInfo, error) {
-	return getBlockDevices(st.db(), machine.Id())
+func (im *IAASModel) BlockDevices(machine names.MachineTag) ([]BlockDeviceInfo, error) {
+	return getBlockDevices(im.mb.db(), machine.Id())
 }
 
 func getBlockDevices(db Database, machineId string) ([]BlockDeviceInfo, error) {

--- a/state/blockdevices_test.go
+++ b/state/blockdevices_test.go
@@ -28,7 +28,9 @@ func (s *BlockDevicesSuite) SetUpTest(c *gc.C) {
 }
 
 func (s *BlockDevicesSuite) assertBlockDevices(c *gc.C, tag names.MachineTag, expected []state.BlockDeviceInfo) {
-	info, err := s.State.BlockDevices(tag)
+	im, err := s.State.IAASModel()
+	c.Assert(err, jc.ErrorIsNil)
+	info, err := im.BlockDevices(tag)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(info, gc.DeepEquals, expected)
 }
@@ -145,7 +147,9 @@ func (s *BlockDevicesSuite) TestBlockDevicesMachineRemove(c *gc.C) {
 	err = s.machine.Remove()
 	c.Assert(err, jc.ErrorIsNil)
 
-	_, err = s.State.BlockDevices(s.machine.MachineTag())
+	im, err := s.State.IAASModel()
+	c.Assert(err, jc.ErrorIsNil)
+	_, err = im.BlockDevices(s.machine.MachineTag())
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 }
 
@@ -157,7 +161,9 @@ func (s *BlockDevicesSuite) TestWatchBlockDevices(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Start block device watcher.
-	w := s.State.WatchBlockDevices(s.machine.MachineTag())
+	im, err := s.State.IAASModel()
+	c.Assert(err, jc.ErrorIsNil)
+	w := im.WatchBlockDevices(s.machine.MachineTag())
 	defer testing.AssertStop(c, w)
 	wc := testing.NewNotifyWatcherC(c, s.State, w)
 	wc.AssertOneChange()

--- a/state/cleanup_test.go
+++ b/state/cleanup_test.go
@@ -678,7 +678,10 @@ func (s *CleanupSuite) TestCleanupMachineStorage(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	s.assertCleanupRuns(c)
 
-	vas, err := s.State.MachineVolumeAttachments(machine.MachineTag())
+	im, err := s.State.IAASModel()
+	c.Assert(err, jc.ErrorIsNil)
+
+	vas, err := im.MachineVolumeAttachments(machine.MachineTag())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(vas, gc.HasLen, 1)
 	c.Assert(vas[0].Life(), gc.Equals, state.Dying)
@@ -698,11 +701,14 @@ func (s *CleanupSuite) TestCleanupVolumeAttachments(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	s.assertDoesNotNeedCleanup(c)
 
-	err = s.State.DestroyVolume(names.NewVolumeTag("0/0"))
+	im, err := s.State.IAASModel()
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = im.DestroyVolume(names.NewVolumeTag("0/0"))
 	c.Assert(err, jc.ErrorIsNil)
 	s.assertCleanupRuns(c)
 
-	attachment, err := s.State.VolumeAttachment(names.NewMachineTag("0"), names.NewVolumeTag("0/0"))
+	attachment, err := im.VolumeAttachment(names.NewMachineTag("0"), names.NewVolumeTag("0/0"))
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(attachment.Life(), gc.Equals, state.Dying)
 }

--- a/state/export_test.go
+++ b/state/export_test.go
@@ -55,7 +55,6 @@ var (
 	ControllerAvailable                  = &controllerAvailable
 	GetOrCreatePorts                     = getOrCreatePorts
 	GetPorts                             = getPorts
-	AddVolumeOps                         = (*State).addVolumeOps
 	CombineMeterStatus                   = combineMeterStatus
 	ApplicationGlobalKey                 = applicationGlobalKey
 	ControllerInheritedSettingsGlobalKey = controllerInheritedSettingsGlobalKey
@@ -674,4 +673,12 @@ func IngressNetworks(rel *Relation) ([]string, error) {
 		return nil, err
 	}
 	return doc.CIDRS, nil
+}
+
+func AddVolumeOps(st *State, params VolumeParams, machineId string) ([]txn.Op, names.VolumeTag, error) {
+	im, err := st.IAASModel()
+	if err != nil {
+		return nil, names.VolumeTag{}, err
+	}
+	return im.addVolumeOps(params, machineId)
 }

--- a/state/filesystem_test.go
+++ b/state/filesystem_test.go
@@ -162,19 +162,22 @@ func (s *FilesystemStateSuite) addUnitWithFilesystem(c *gc.C, pool string, withV
 		c, pool, withVolume,
 	)
 
+	im, err := s.State.IAASModel()
+	c.Assert(err, jc.ErrorIsNil)
+
 	// Machine must be provisioned before either volume or
 	// filesystem can be attached.
-	err := machine.SetProvisioned("inst-id", "fake_nonce", nil)
+	err = machine.SetProvisioned("inst-id", "fake_nonce", nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	if withVolume {
 		// Volume must be provisioned before the filesystem.
 		volume := s.filesystemVolume(c, filesystem.FilesystemTag())
-		err := s.State.SetVolumeInfo(volume.VolumeTag(), state.VolumeInfo{VolumeId: "vol-123"})
+		err := im.SetVolumeInfo(volume.VolumeTag(), state.VolumeInfo{VolumeId: "vol-123"})
 		c.Assert(err, jc.ErrorIsNil)
 
 		// Volume must be attached before the filesystem.
-		err = s.State.SetVolumeAttachmentInfo(
+		err = im.SetVolumeAttachmentInfo(
 			machine.MachineTag(),
 			volume.VolumeTag(),
 			state.VolumeAttachmentInfo{DeviceName: "sdc"},
@@ -234,7 +237,10 @@ func (s *FilesystemStateSuite) addUnitWithFilesystemUnprovisioned(c *gc.C, pool 
 	_, ok := filesystem.Params()
 	c.Assert(ok, jc.IsTrue)
 
-	volume, err := s.State.StorageInstanceVolume(storageInstance.StorageTag())
+	im, err := s.State.IAASModel()
+	c.Assert(err, jc.ErrorIsNil)
+
+	volume, err := im.StorageInstanceVolume(storageInstance.StorageTag())
 	if withVolume {
 		c.Assert(err, jc.ErrorIsNil)
 		c.Assert(volume.VolumeTag(), gc.Equals, names.NewVolumeTag("0"))
@@ -244,7 +250,7 @@ func (s *FilesystemStateSuite) addUnitWithFilesystemUnprovisioned(c *gc.C, pool 
 		filesystemVolume, err := filesystem.Volume()
 		c.Assert(err, jc.ErrorIsNil)
 		c.Assert(filesystemVolume, gc.Equals, volume.VolumeTag())
-		_, err = s.State.VolumeAttachment(assignedMachineTag, filesystemVolume)
+		_, err = im.VolumeAttachment(assignedMachineTag, filesystemVolume)
 		c.Assert(err, jc.ErrorIsNil)
 	} else {
 		c.Assert(err, jc.Satisfies, errors.IsNotFound)
@@ -570,6 +576,9 @@ func (s *FilesystemStateSuite) TestRemoveStorageInstanceDestroysAndUnassignsFile
 	)
 	c.Assert(err, jc.ErrorIsNil)
 
+	im, err := s.State.IAASModel()
+	c.Assert(err, jc.ErrorIsNil)
+
 	u, err := s.State.Unit(unitTag.Id())
 	c.Assert(err, jc.ErrorIsNil)
 	err = u.Destroy()
@@ -591,7 +600,7 @@ func (s *FilesystemStateSuite) TestRemoveStorageInstanceDestroysAndUnassignsFile
 	// be assigned to the storage.
 	_, err = s.State.StorageInstanceFilesystem(storageTag)
 	c.Assert(err, gc.ErrorMatches, `filesystem for storage instance "data/0" not found`)
-	_, err = s.State.StorageInstanceVolume(storageTag)
+	_, err = im.StorageInstanceVolume(storageTag)
 	c.Assert(err, gc.ErrorMatches, `volume for storage instance "data/0" not found`)
 
 	// The filesystem and volume should still exist. The filesystem
@@ -754,11 +763,14 @@ func (s *FilesystemStateSuite) TestFilesystemVolumeBackedDestroyDetachVolumeFail
 	err := s.State.DetachFilesystem(machine.MachineTag(), filesystem.FilesystemTag())
 	c.Assert(err, jc.ErrorIsNil)
 
+	im, err := s.State.IAASModel()
+	c.Assert(err, jc.ErrorIsNil)
+
 	// Can't destroy (detach) volume until the filesystem (attachment) is removed.
-	err = s.State.DetachVolume(machine.MachineTag(), volume.VolumeTag())
+	err = im.DetachVolume(machine.MachineTag(), volume.VolumeTag())
 	c.Assert(err, gc.ErrorMatches, "detaching volume 0 from machine 0: volume contains attached filesystem")
 	c.Assert(err, jc.Satisfies, state.IsContainsFilesystem)
-	err = s.State.DestroyVolume(volume.VolumeTag())
+	err = im.DestroyVolume(volume.VolumeTag())
 	c.Assert(err, gc.ErrorMatches, "destroying volume 0: volume contains filesystem")
 	c.Assert(err, jc.Satisfies, state.IsContainsFilesystem)
 	assertMachineStorageRefs(c, s.State, machine.MachineTag())
@@ -768,9 +780,9 @@ func (s *FilesystemStateSuite) TestFilesystemVolumeBackedDestroyDetachVolumeFail
 	err = s.State.RemoveFilesystem(filesystem.FilesystemTag())
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = s.State.DetachVolume(machine.MachineTag(), volume.VolumeTag())
+	err = im.DetachVolume(machine.MachineTag(), volume.VolumeTag())
 	c.Assert(err, jc.ErrorIsNil)
-	err = s.State.DestroyVolume(volume.VolumeTag())
+	err = im.DestroyVolume(volume.VolumeTag())
 	c.Assert(err, jc.ErrorIsNil)
 }
 

--- a/state/iaasmodel.go
+++ b/state/iaasmodel.go
@@ -7,4 +7,8 @@ package state
 // Infrastructure-As-A-Service (IAAS) model.
 type IAASModel struct {
 	mb modelBackend
+
+	// TODO(jsing): This should be removed once things
+	// have been sufficiently untangled.
+	st *State
 }

--- a/state/iaasmodel.go
+++ b/state/iaasmodel.go
@@ -1,0 +1,10 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package state
+
+// IAASModel contains data that is specific to an
+// Infrastructure-As-A-Service (IAAS) model.
+type IAASModel struct {
+	mb modelBackend
+}

--- a/state/machine.go
+++ b/state/machine.go
@@ -735,10 +735,14 @@ func (original *Machine) advanceLifecycle(life Life) (err error) {
 // filesystems attached to the machine, and returns any mgo/txn assertions
 // required to ensure that remains true.
 func (m *Machine) assertNoPersistentStorage() (bson.D, error) {
+	im, err := m.st.IAASModel()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	attachments := make(set.Tags)
 	for _, v := range m.doc.Volumes {
 		tag := names.NewVolumeTag(v)
-		detachable, err := isDetachableVolumeTag(m.st, tag)
+		detachable, err := isDetachableVolumeTag(im, tag)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
@@ -809,6 +813,10 @@ func (m *Machine) removePortsOps() ([]txn.Op, error) {
 }
 
 func (m *Machine) removeOps() ([]txn.Op, error) {
+	im, err := m.st.IAASModel()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	if m.doc.Life != Dead {
 		return nil, fmt.Errorf("machine is not dead")
 	}
@@ -849,7 +857,7 @@ func (m *Machine) removeOps() ([]txn.Op, error) {
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	volumeOps, err := m.st.removeMachineVolumesOps(m)
+	volumeOps, err := im.removeMachineVolumesOps(m)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -1203,12 +1211,17 @@ func (m *Machine) SetInstanceInfo(
 		return errors.Trace(err)
 	}
 
-	// Record volumes and volume attachments, and set the initial
-	// status: attached or attaching.
-	if err := setProvisionedVolumeInfo(m.st, volumes); err != nil {
+	im, err := m.st.IAASModel()
+	if err != nil {
 		return errors.Trace(err)
 	}
-	if err := setMachineVolumeAttachmentInfo(m.st, m.Id(), volumeAttachments); err != nil {
+
+	// Record volumes and volume attachments, and set the initial
+	// status: attached or attaching.
+	if err := setProvisionedVolumeInfo(im, volumes); err != nil {
+		return errors.Trace(err)
+	}
+	if err := setMachineVolumeAttachmentInfo(im, m.Id(), volumeAttachments); err != nil {
 		return errors.Trace(err)
 	}
 	volumeStatus := make(map[names.VolumeTag]status.Status)
@@ -1219,7 +1232,7 @@ func (m *Machine) SetInstanceInfo(
 		volumeStatus[tag] = status.Attached
 	}
 	for tag, status := range volumeStatus {
-		if err := m.st.SetVolumeStatus(tag, status, "", nil, nil); err != nil {
+		if err := im.SetVolumeStatus(tag, status, "", nil, nil); err != nil {
 			return errors.Annotatef(
 				err, "setting status of %s", names.ReadableString(tag),
 			)
@@ -1763,7 +1776,11 @@ func (m *Machine) SetMachineBlockDevices(info ...BlockDeviceInfo) error {
 
 // VolumeAttachments returns the machine's volume attachments.
 func (m *Machine) VolumeAttachments() ([]VolumeAttachment, error) {
-	return m.st.MachineVolumeAttachments(m.MachineTag())
+	im, err := m.st.IAASModel()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return im.MachineVolumeAttachments(m.MachineTag())
 }
 
 // AddAction is part of the ActionReceiver interface.

--- a/state/machine_test.go
+++ b/state/machine_test.go
@@ -991,7 +991,10 @@ func (s *MachineSuite) TestMachineSetInstanceInfoSuccess(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(s.machine.CheckProvisioned("fake_nonce"), jc.IsTrue)
 
-	volume, err := s.State.Volume(volumeTag)
+	im, err := s.State.IAASModel()
+	c.Assert(err, jc.ErrorIsNil)
+
+	volume, err := im.Volume(volumeTag)
 	c.Assert(err, jc.ErrorIsNil)
 	info, err := volume.Info()
 	c.Assert(err, jc.ErrorIsNil)

--- a/state/migration_export.go
+++ b/state/migration_export.go
@@ -1569,11 +1569,16 @@ func (e *exporter) volumes() error {
 		return errors.Trace(err)
 	}
 
+	im, err := e.st.IAASModel()
+	if err != nil {
+		return errors.Trace(err)
+	}
+
 	var doc volumeDoc
 	iter := coll.Find(nil).Sort("_id").Iter()
 	defer iter.Close()
 	for iter.Next(&doc) {
-		vol := &volume{e.st, doc}
+		vol := &volume{im, doc}
 		if err := e.addVolume(vol, attachments[doc.Name]); err != nil {
 			return errors.Trace(err)
 		}

--- a/state/migration_export_test.go
+++ b/state/migration_export_test.go
@@ -932,10 +932,13 @@ func (s *MigrationExportSuite) TestVolumes(c *gc.C) {
 	})
 	machineTag := machine.MachineTag()
 
+	im, err := s.State.IAASModel()
+	c.Assert(err, jc.ErrorIsNil)
+
 	// We know that the first volume is called "0/0" as it is the first volume
 	// (volumes use sequences), and it is bound to machine 0.
 	volTag := names.NewVolumeTag("0/0")
-	err := s.State.SetVolumeInfo(volTag, state.VolumeInfo{
+	err = im.SetVolumeInfo(volTag, state.VolumeInfo{
 		HardwareId: "magic",
 		WWN:        "drbr",
 		Size:       1500,
@@ -943,7 +946,7 @@ func (s *MigrationExportSuite) TestVolumes(c *gc.C) {
 		Persistent: true,
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	err = s.State.SetVolumeAttachmentInfo(machineTag, volTag, state.VolumeAttachmentInfo{
+	err = im.SetVolumeAttachmentInfo(machineTag, volTag, state.VolumeAttachmentInfo{
 		DeviceName: "device name",
 		DeviceLink: "device link",
 		BusAddress: "bus address",

--- a/state/migration_import.go
+++ b/state/migration_import.go
@@ -1651,7 +1651,10 @@ func (i *importer) volumes() error {
 }
 
 func (i *importer) addVolume(volume description.Volume) error {
-
+	im, err := i.st.IAASModel()
+	if err != nil {
+		return errors.Trace(err)
+	}
 	attachments := volume.Attachments()
 	tag := volume.Tag()
 	var params *VolumeParams
@@ -1679,13 +1682,13 @@ func (i *importer) addVolume(volume description.Volume) error {
 		Info:            info,
 		AttachmentCount: len(attachments),
 	}
-	if detachable, err := isDetachableVolumePool(i.st, volume.Pool()); err != nil {
+	if detachable, err := isDetachableVolumePool(im, volume.Pool()); err != nil {
 		return errors.Trace(err)
 	} else if !detachable && len(attachments) == 1 {
 		doc.MachineId = attachments[0].Machine().Id()
 	}
 	status := i.makeStatusDoc(volume.Status())
-	ops := i.st.newVolumeOps(doc, status)
+	ops := im.newVolumeOps(doc, status)
 
 	for _, attachment := range attachments {
 		ops = append(ops, i.addVolumeAttachmentOp(tag.Id(), attachment))

--- a/state/migration_import_test.go
+++ b/state/migration_import_test.go
@@ -1004,6 +1004,9 @@ func (s *MigrationImportSuite) TestVolumes(c *gc.C) {
 	})
 	machineTag := machine.MachineTag()
 
+	im, err := s.State.IAASModel()
+	c.Assert(err, jc.ErrorIsNil)
+
 	// We know that the first volume is called "0/0" - although I don't know why.
 	volTag := names.NewVolumeTag("0/0")
 	volInfo := state.VolumeInfo{
@@ -1014,7 +1017,7 @@ func (s *MigrationImportSuite) TestVolumes(c *gc.C) {
 		VolumeId:   "volume id",
 		Persistent: true,
 	}
-	err := s.State.SetVolumeInfo(volTag, volInfo)
+	err = im.SetVolumeInfo(volTag, volInfo)
 	c.Assert(err, jc.ErrorIsNil)
 	volAttachmentInfo := state.VolumeAttachmentInfo{
 		DeviceName: "device name",
@@ -1022,12 +1025,14 @@ func (s *MigrationImportSuite) TestVolumes(c *gc.C) {
 		BusAddress: "bus address",
 		ReadOnly:   true,
 	}
-	err = s.State.SetVolumeAttachmentInfo(machineTag, volTag, volAttachmentInfo)
+	err = im.SetVolumeAttachmentInfo(machineTag, volTag, volAttachmentInfo)
 	c.Assert(err, jc.ErrorIsNil)
 
 	_, newSt := s.importModel(c)
+	newIM, err := newSt.IAASModel()
+	c.Assert(err, jc.ErrorIsNil)
 
-	volume, err := newSt.Volume(volTag)
+	volume, err := newIM.Volume(volTag)
 	c.Assert(err, jc.ErrorIsNil)
 
 	// TODO: check status
@@ -1036,14 +1041,14 @@ func (s *MigrationImportSuite) TestVolumes(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(info, jc.DeepEquals, volInfo)
 
-	attachment, err := newSt.VolumeAttachment(machineTag, volTag)
+	attachment, err := newIM.VolumeAttachment(machineTag, volTag)
 	c.Assert(err, jc.ErrorIsNil)
 	attInfo, err := attachment.Info()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(attInfo, jc.DeepEquals, volAttachmentInfo)
 
 	volTag = names.NewVolumeTag("0/1")
-	volume, err = newSt.Volume(volTag)
+	volume, err = newIM.Volume(volTag)
 	c.Assert(err, jc.ErrorIsNil)
 
 	params, needsProvisioning := volume.Params()
@@ -1051,7 +1056,7 @@ func (s *MigrationImportSuite) TestVolumes(c *gc.C) {
 	c.Check(params.Pool, gc.Equals, "loop")
 	c.Check(params.Size, gc.Equals, uint64(4000))
 
-	attachment, err = newSt.VolumeAttachment(machineTag, volTag)
+	attachment, err = newIM.VolumeAttachment(machineTag, volTag)
 	c.Assert(err, jc.ErrorIsNil)
 	attParams, needsProvisioning := attachment.Params()
 	c.Check(needsProvisioning, jc.IsTrue)

--- a/state/migration_import_test.go
+++ b/state/migration_import_test.go
@@ -397,7 +397,9 @@ func (s *MigrationImportSuite) TestMachineDevices(c *gc.C) {
 	imported, err := newSt.Machine(machine.Id())
 	c.Assert(err, jc.ErrorIsNil)
 
-	devices, err := newSt.BlockDevices(imported.MachineTag())
+	im, err := newSt.IAASModel()
+	c.Assert(err, jc.ErrorIsNil)
+	devices, err := im.BlockDevices(imported.MachineTag())
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Check(devices, jc.DeepEquals, []state.BlockDeviceInfo{sda, sdb})

--- a/state/model_test.go
+++ b/state/model_test.go
@@ -762,6 +762,9 @@ func (s *ModelSuite) TestProcessDyingModelWithVolumeBackedFilesystems(c *gc.C) {
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
+	im, err := st.IAASModel()
+	c.Assert(err, jc.ErrorIsNil)
+
 	filesystems, err := st.AllFilesystems()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(filesystems, gc.HasLen, 1)
@@ -773,9 +776,9 @@ func (s *ModelSuite) TestProcessDyingModelWithVolumeBackedFilesystems(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	err = st.RemoveFilesystemAttachment(machine.MachineTag(), names.NewFilesystemTag("0"))
 	c.Assert(err, jc.ErrorIsNil)
-	err = st.DetachVolume(machine.MachineTag(), names.NewVolumeTag("0"))
+	err = im.DetachVolume(machine.MachineTag(), names.NewVolumeTag("0"))
 	c.Assert(err, jc.ErrorIsNil)
-	err = st.RemoveVolumeAttachment(machine.MachineTag(), names.NewVolumeTag("0"))
+	err = im.RemoveVolumeAttachment(machine.MachineTag(), names.NewVolumeTag("0"))
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(machine.EnsureDead(), jc.ErrorIsNil)
 	c.Assert(machine.Remove(), jc.ErrorIsNil)
@@ -793,6 +796,9 @@ func (s *ModelSuite) TestProcessDyingModelWithVolumes(c *gc.C) {
 	model, err := st.Model()
 	c.Assert(err, jc.ErrorIsNil)
 
+	im, err := st.IAASModel()
+	c.Assert(err, jc.ErrorIsNil)
+
 	machine, err := st.AddOneMachine(state.MachineTemplate{
 		Series: "quantal",
 		Jobs:   []state.MachineJob{state.JobHostUnits},
@@ -805,14 +811,14 @@ func (s *ModelSuite) TestProcessDyingModelWithVolumes(c *gc.C) {
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
-	volumes, err := st.AllVolumes()
+	volumes, err := im.AllVolumes()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(volumes, gc.HasLen, 1)
 
 	c.Assert(model.Destroy(), jc.ErrorIsNil)
-	err = st.DetachVolume(machine.MachineTag(), names.NewVolumeTag("0"))
+	err = im.DetachVolume(machine.MachineTag(), names.NewVolumeTag("0"))
 	c.Assert(err, jc.ErrorIsNil)
-	err = st.RemoveVolumeAttachment(machine.MachineTag(), names.NewVolumeTag("0"))
+	err = im.RemoveVolumeAttachment(machine.MachineTag(), names.NewVolumeTag("0"))
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(machine.EnsureDead(), jc.ErrorIsNil)
 	c.Assert(machine.Remove(), jc.ErrorIsNil)

--- a/state/prechecker_test.go
+++ b/state/prechecker_test.go
@@ -175,14 +175,17 @@ func (s *PrecheckerSuite) TestPrecheckAddApplication(c *gc.C) {
 		storageAttachments[1].StorageInstance(),
 	}
 
+	im, err := s.State.IAASModel()
+	c.Assert(err, jc.ErrorIsNil)
+
 	volumeTags := make([]names.VolumeTag, len(storageTags))
 	for i, storageTag := range storageTags {
-		volume, err := s.State.StorageInstanceVolume(storageTag)
+		volume, err := im.StorageInstanceVolume(storageTag)
 		c.Assert(err, jc.ErrorIsNil)
 		volumeTags[i] = volume.VolumeTag()
 	}
 	// Provision only the first volume.
-	err = s.State.SetVolumeInfo(volumeTags[0], state.VolumeInfo{
+	err = im.SetVolumeInfo(volumeTags[0], state.VolumeInfo{
 		VolumeId: "foo",
 		Pool:     "modelscoped",
 	})
@@ -195,9 +198,9 @@ func (s *PrecheckerSuite) TestPrecheckAddApplication(c *gc.C) {
 		c.Assert(err, jc.ErrorIsNil)
 	}
 	for _, volumeTag := range volumeTags {
-		err = s.State.DetachVolume(machineTag, volumeTag)
+		err = im.DetachVolume(machineTag, volumeTag)
 		c.Assert(err, jc.ErrorIsNil)
-		err = s.State.RemoveVolumeAttachment(machineTag, volumeTag)
+		err = im.RemoveVolumeAttachment(machineTag, volumeTag)
 		c.Assert(err, jc.ErrorIsNil)
 	}
 

--- a/state/state.go
+++ b/state/state.go
@@ -2270,3 +2270,8 @@ func (st *State) SetClockForTesting(clock clock.Clock) error {
 	}
 	return nil
 }
+
+// IAASModel returns an Infrastructure-As-A-Service (IAAS) model.
+func (st *State) IAASModel() (*IAASModel, error) {
+	return &IAASModel{mb: st}, nil
+}

--- a/state/state.go
+++ b/state/state.go
@@ -2273,5 +2273,8 @@ func (st *State) SetClockForTesting(clock clock.Clock) error {
 
 // IAASModel returns an Infrastructure-As-A-Service (IAAS) model.
 func (st *State) IAASModel() (*IAASModel, error) {
-	return &IAASModel{mb: st}, nil
+	return &IAASModel{
+		mb: st,
+		st: st,
+	}, nil
 }

--- a/state/state.go
+++ b/state/state.go
@@ -888,7 +888,11 @@ func (st *State) FindEntity(tag names.Tag) (Entity, error) {
 			return st.Charm(url)
 		}
 	case names.VolumeTag:
-		return st.Volume(tag)
+		im, err := st.IAASModel()
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		return im.Volume(tag)
 	case names.FilesystemTag:
 		return st.Filesystem(tag)
 	default:
@@ -1108,9 +1112,13 @@ func (st *State) AddApplication(args AddApplicationArgs) (_ *Application, err er
 			// attached. We need to pass them along to precheckInstance, in
 			// case the volumes cannot be attached to a machine with the given
 			// placement directive.
+			im, err := st.IAASModel()
+			if err != nil {
+				return nil, errors.Trace(err)
+			}
 			volumeAttachments := make([]storage.VolumeAttachmentParams, 0, len(args.AttachStorage))
 			for _, storageTag := range args.AttachStorage {
-				v, err := st.StorageInstanceVolume(storageTag)
+				v, err := im.StorageInstanceVolume(storageTag)
 				if errors.IsNotFound(err) {
 					continue
 				} else if err != nil {

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -536,7 +536,9 @@ func (s *MultiModelStateSuite) TestWatchTwoModels(c *gc.C) {
 				f := factory.NewFactory(st)
 				m := f.MakeMachine(c, &factory.MachineParams{})
 				c.Assert(m.Id(), gc.Equals, "0")
-				return st.WatchBlockDevices(m.MachineTag())
+				im, err := st.IAASModel()
+				c.Assert(err, jc.ErrorIsNil)
+				return im.WatchBlockDevices(m.MachineTag())
 			},
 			setUpState: func(st *state.State) bool {
 				m, err := st.Machine("0")

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -1007,7 +1007,10 @@ func (s *StateSuite) TestAddMachineWithVolumes(c *gc.C) {
 	// have been set on the volume params.
 	machineTemplate.Volumes[1].Volume.Pool = "loop"
 
-	volumeAttachments, err := s.State.MachineVolumeAttachments(m.MachineTag())
+	im, err := s.State.IAASModel()
+	c.Assert(err, jc.ErrorIsNil)
+
+	volumeAttachments, err := im.MachineVolumeAttachments(m.MachineTag())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(volumeAttachments, gc.HasLen, 2)
 	if volumeAttachments[0].Volume() == names.NewVolumeTag(m.Id()+"/1") {
@@ -1020,7 +1023,7 @@ func (s *StateSuite) TestAddMachineWithVolumes(c *gc.C) {
 		attachmentParams, ok := att.Params()
 		c.Assert(ok, jc.IsTrue)
 		c.Check(attachmentParams, gc.Equals, machineTemplate.Volumes[i].Attachment)
-		volume, err := s.State.Volume(att.Volume())
+		volume, err := im.Volume(att.Volume())
 		c.Assert(err, jc.ErrorIsNil)
 		_, err = volume.Info()
 		c.Assert(err, jc.Satisfies, errors.IsNotProvisioned)

--- a/state/status_volume_test.go
+++ b/state/status_volume_test.go
@@ -38,7 +38,10 @@ func (s *VolumeStatusSuite) SetUpTest(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(volumeAttachments, gc.HasLen, 1)
 
-	volume, err := s.State.Volume(volumeAttachments[0].Volume())
+	im, err := s.State.IAASModel()
+	c.Assert(err, jc.ErrorIsNil)
+
+	volume, err := im.Volume(volumeAttachments[0].Volume())
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.machine = machine
@@ -125,7 +128,10 @@ func (s *VolumeStatusSuite) checkGetSetStatus(c *gc.C, volumeStatus status.Statu
 	err := s.volume.SetStatus(sInfo)
 	c.Check(err, jc.ErrorIsNil)
 
-	volume, err := s.State.Volume(s.volume.VolumeTag())
+	im, err := s.State.IAASModel()
+	c.Assert(err, jc.ErrorIsNil)
+
+	volume, err := im.Volume(s.volume.VolumeTag())
 	c.Assert(err, jc.ErrorIsNil)
 
 	statusInfo, err := volume.Status()
@@ -141,21 +147,27 @@ func (s *VolumeStatusSuite) checkGetSetStatus(c *gc.C, volumeStatus status.Statu
 }
 
 func (s *VolumeStatusSuite) TestGetSetStatusDying(c *gc.C) {
-	err := s.State.DestroyVolume(s.volume.VolumeTag())
+	im, err := s.State.IAASModel()
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = im.DestroyVolume(s.volume.VolumeTag())
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.checkGetSetStatus(c, status.Attaching)
 }
 
 func (s *VolumeStatusSuite) TestGetSetStatusDead(c *gc.C) {
-	err := s.State.DestroyVolume(s.volume.VolumeTag())
-	c.Assert(err, jc.ErrorIsNil)
-	err = s.State.DetachVolume(s.machine.MachineTag(), s.volume.VolumeTag())
-	c.Assert(err, jc.ErrorIsNil)
-	err = s.State.RemoveVolumeAttachment(s.machine.MachineTag(), s.volume.VolumeTag())
+	im, err := s.State.IAASModel()
 	c.Assert(err, jc.ErrorIsNil)
 
-	volume, err := s.State.Volume(s.volume.VolumeTag())
+	err = im.DestroyVolume(s.volume.VolumeTag())
+	c.Assert(err, jc.ErrorIsNil)
+	err = im.DetachVolume(s.machine.MachineTag(), s.volume.VolumeTag())
+	c.Assert(err, jc.ErrorIsNil)
+	err = im.RemoveVolumeAttachment(s.machine.MachineTag(), s.volume.VolumeTag())
+	c.Assert(err, jc.ErrorIsNil)
+
+	volume, err := im.Volume(s.volume.VolumeTag())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(volume.Life(), gc.Equals, state.Dead)
 
@@ -194,7 +206,10 @@ func (s *VolumeStatusSuite) TestSetStatusPendingUnprovisioned(c *gc.C) {
 }
 
 func (s *VolumeStatusSuite) TestSetStatusPendingProvisioned(c *gc.C) {
-	err := s.State.SetVolumeInfo(s.volume.VolumeTag(), state.VolumeInfo{
+	im, err := s.State.IAASModel()
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = im.SetVolumeInfo(s.volume.VolumeTag(), state.VolumeInfo{
 		VolumeId: "vol-ume",
 	})
 	c.Assert(err, jc.ErrorIsNil)

--- a/state/storage_dynamicadd_test.go
+++ b/state/storage_dynamicadd_test.go
@@ -52,7 +52,10 @@ func (s *storageAddSuite) assignUnit(c *gc.C, u *state.Unit) {
 	c.Assert(err, jc.ErrorIsNil)
 	s.machineTag = m.MachineTag()
 
-	volumes, err := s.State.AllVolumes()
+	im, err := s.State.IAASModel()
+	c.Assert(err, jc.ErrorIsNil)
+
+	volumes, err := im.AllVolumes()
 	c.Assert(err, jc.ErrorIsNil)
 	s.originalVolumeCount = len(volumes)
 
@@ -68,7 +71,9 @@ func (s *storageAddSuite) assertStorageCount(c *gc.C, count int) {
 }
 
 func (s *storageAddSuite) assertVolumeCount(c *gc.C, count int) {
-	all, err := s.State.AllVolumes()
+	im, err := s.State.IAASModel()
+	c.Assert(err, jc.ErrorIsNil)
+	all, err := im.AllVolumes()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(all, gc.HasLen, count)
 }
@@ -127,11 +132,13 @@ func (s *storageAddSuite) TestAddStorageToUnitNotAssigned(c *gc.C) {
 }
 
 func allMachineVolumeParams(c *gc.C, st *state.State, m names.MachineTag) []state.VolumeParams {
+	im, err := st.IAASModel()
+	c.Assert(err, jc.ErrorIsNil)
 	var allVolumeParams []state.VolumeParams
-	volumeAttachments, err := st.MachineVolumeAttachments(m)
+	volumeAttachments, err := im.MachineVolumeAttachments(m)
 	c.Assert(err, jc.ErrorIsNil)
 	for _, a := range volumeAttachments {
-		volume, err := st.Volume(a.Volume())
+		volume, err := im.Volume(a.Volume())
 		c.Assert(err, jc.ErrorIsNil)
 		volumeParams, ok := volume.Params()
 		c.Assert(ok, jc.IsTrue)
@@ -206,7 +213,10 @@ func (s *storageAddSuite) createAndAssignUnitWithSingleStorage(c *gc.C) names.Un
 	err := s.State.AssignUnit(u, state.AssignCleanEmpty)
 	c.Assert(err, jc.ErrorIsNil)
 
-	volumes, err := s.State.AllVolumes()
+	im, err := s.State.IAASModel()
+	c.Assert(err, jc.ErrorIsNil)
+
+	volumes, err := im.AllVolumes()
 	c.Assert(err, jc.ErrorIsNil)
 	s.originalVolumeCount = len(volumes)
 

--- a/state/volume_test.go
+++ b/state/volume_test.go
@@ -63,7 +63,10 @@ func (s *VolumeStateSuite) assertMachineVolume(c *gc.C, unit *state.Unit) {
 
 	machine, err := s.State.Machine(assignedMachineId)
 	c.Assert(err, jc.ErrorIsNil)
-	volumeAttachments, err := s.State.MachineVolumeAttachments(machine.MachineTag())
+	im, err := s.State.IAASModel()
+	c.Assert(err, jc.ErrorIsNil)
+
+	volumeAttachments, err := im.MachineVolumeAttachments(machine.MachineTag())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(volumeAttachments, gc.HasLen, 1)
 	c.Assert(volumeAttachments[0].Volume(), gc.Equals, volume.VolumeTag())
@@ -73,7 +76,7 @@ func (s *VolumeStateSuite) assertMachineVolume(c *gc.C, unit *state.Unit) {
 	_, ok = volumeAttachments[0].Params()
 	c.Assert(ok, jc.IsTrue)
 
-	_, err = s.State.VolumeAttachment(machine.MachineTag(), volume.VolumeTag())
+	_, err = im.VolumeAttachment(machine.MachineTag(), volume.VolumeTag())
 	c.Assert(err, jc.ErrorIsNil)
 
 	assertMachineStorageRefs(c, s.State, machine.MachineTag())
@@ -154,8 +157,11 @@ func (s *VolumeStateSuite) TestSetVolumeInfo(c *gc.C) {
 	volumeTag := volume.VolumeTag()
 	s.assertVolumeUnprovisioned(c, volumeTag)
 
+	im, err := s.State.IAASModel()
+	c.Assert(err, jc.ErrorIsNil)
+
 	volumeInfoSet := state.VolumeInfo{Size: 123, Persistent: true, VolumeId: "vol-ume"}
-	err = s.State.SetVolumeInfo(volume.VolumeTag(), volumeInfoSet)
+	err = im.SetVolumeInfo(volume.VolumeTag(), volumeInfoSet)
 	c.Assert(err, jc.ErrorIsNil)
 	volumeInfoSet.Pool = "loop-pool" // taken from params
 	s.assertVolumeInfo(c, volumeTag, volumeInfoSet)
@@ -170,8 +176,11 @@ func (s *VolumeStateSuite) TestSetVolumeInfoNoVolumeId(c *gc.C) {
 	volumeTag := volume.VolumeTag()
 	s.assertVolumeUnprovisioned(c, volumeTag)
 
+	im, err := s.State.IAASModel()
+	c.Assert(err, jc.ErrorIsNil)
+
 	volumeInfoSet := state.VolumeInfo{Size: 123, Persistent: true}
-	err = s.State.SetVolumeInfo(volume.VolumeTag(), volumeInfoSet)
+	err = im.SetVolumeInfo(volume.VolumeTag(), volumeInfoSet)
 	c.Assert(err, gc.ErrorMatches, `cannot set info for volume "0/0": volume ID not set`)
 }
 
@@ -201,7 +210,10 @@ func (s *VolumeStateSuite) TestSetVolumeInfoNoStorageAssigned(c *gc.C) {
 	m, err := s.State.Machine(machines[0].Id())
 	c.Assert(err, jc.ErrorIsNil)
 
-	volumeAttachments, err := s.State.MachineVolumeAttachments(m.MachineTag())
+	im, err := s.State.IAASModel()
+	c.Assert(err, jc.ErrorIsNil)
+
+	volumeAttachments, err := im.MachineVolumeAttachments(m.MachineTag())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(volumeAttachments, gc.HasLen, 1)
 	volumeTag := volumeAttachments[0].Volume()
@@ -212,7 +224,7 @@ func (s *VolumeStateSuite) TestSetVolumeInfoNoStorageAssigned(c *gc.C) {
 
 	s.assertVolumeUnprovisioned(c, volumeTag)
 	volumeInfoSet := state.VolumeInfo{Size: 123, VolumeId: "vol-ume"}
-	err = s.State.SetVolumeInfo(volume.VolumeTag(), volumeInfoSet)
+	err = im.SetVolumeInfo(volume.VolumeTag(), volumeInfoSet)
 	c.Assert(err, jc.ErrorIsNil)
 	volumeInfoSet.Pool = "loop-pool" // taken from params
 	s.assertVolumeInfo(c, volumeTag, volumeInfoSet)
@@ -225,15 +237,18 @@ func (s *VolumeStateSuite) TestSetVolumeInfoImmutable(c *gc.C) {
 	volume := s.storageInstanceVolume(c, storageTag)
 	volumeTag := volume.VolumeTag()
 
+	im, err := s.State.IAASModel()
+	c.Assert(err, jc.ErrorIsNil)
+
 	volumeInfoSet := state.VolumeInfo{Size: 123, VolumeId: "vol-ume"}
-	err = s.State.SetVolumeInfo(volume.VolumeTag(), volumeInfoSet)
+	err = im.SetVolumeInfo(volume.VolumeTag(), volumeInfoSet)
 	c.Assert(err, jc.ErrorIsNil)
 
 	// The first call to SetVolumeInfo takes the pool name from
 	// the params; the second does not, but it must not change
 	// either. Callers are expected to get the existing info and
 	// update it, leaving immutable values intact.
-	err = s.State.SetVolumeInfo(volume.VolumeTag(), volumeInfoSet)
+	err = im.SetVolumeInfo(volume.VolumeTag(), volumeInfoSet)
 	c.Assert(err, gc.ErrorMatches, `cannot set info for volume "0/0": cannot change pool from "loop-pool" to ""`)
 
 	volumeInfoSet.Pool = "loop-pool"
@@ -261,12 +276,15 @@ func (s *VolumeStateSuite) TestWatchVolumeAttachment(c *gc.C) {
 	err = machine.SetProvisioned("inst-id", "fake_nonce", nil)
 	c.Assert(err, jc.ErrorIsNil)
 
+	im, err := s.State.IAASModel()
+	c.Assert(err, jc.ErrorIsNil)
+
 	// volume attachment will NOT react to volume changes
-	err = s.State.SetVolumeInfo(volumeTag, state.VolumeInfo{VolumeId: "vol-123"})
+	err = im.SetVolumeInfo(volumeTag, state.VolumeInfo{VolumeId: "vol-123"})
 	c.Assert(err, jc.ErrorIsNil)
 	wc.AssertNoChange()
 
-	err = s.State.SetVolumeAttachmentInfo(
+	err = im.SetVolumeAttachmentInfo(
 		machineTag, volumeTag, state.VolumeAttachmentInfo{
 			DeviceName: "xvdf1",
 		},
@@ -285,6 +303,9 @@ func (s *VolumeStateSuite) TestWatchModelVolumes(c *gc.C) {
 	}
 	addUnit()
 
+	im, err := s.State.IAASModel()
+	c.Assert(err, jc.ErrorIsNil)
+
 	w := s.State.WatchModelVolumes()
 	defer testing.AssertStop(c, w)
 	wc := testing.NewStringsWatcherC(c, s.State, w)
@@ -295,22 +316,22 @@ func (s *VolumeStateSuite) TestWatchModelVolumes(c *gc.C) {
 	wc.AssertChangeInSingleEvent("4", "5")
 	wc.AssertNoChange()
 
-	volume, err := s.State.Volume(names.NewVolumeTag("0"))
+	volume, err := im.Volume(names.NewVolumeTag("0"))
 	c.Assert(err, jc.ErrorIsNil)
 	storageTag, err := volume.StorageInstance()
 	c.Assert(err, jc.ErrorIsNil)
 	removeStorageInstance(c, s.State, storageTag)
-	err = s.State.DestroyVolume(names.NewVolumeTag("0"))
+	err = im.DestroyVolume(names.NewVolumeTag("0"))
 	c.Assert(err, jc.ErrorIsNil)
 	wc.AssertChangeInSingleEvent("0") // dying
 	wc.AssertNoChange()
 
-	err = s.State.DetachVolume(names.NewMachineTag("0"), names.NewVolumeTag("0"))
+	err = im.DetachVolume(names.NewMachineTag("0"), names.NewVolumeTag("0"))
 	c.Assert(err, jc.ErrorIsNil)
-	err = s.State.RemoveVolumeAttachment(names.NewMachineTag("0"), names.NewVolumeTag("0"))
+	err = im.RemoveVolumeAttachment(names.NewMachineTag("0"), names.NewVolumeTag("0"))
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = s.State.RemoveVolume(names.NewVolumeTag("0"))
+	err = im.RemoveVolume(names.NewVolumeTag("0"))
 	c.Assert(err, jc.ErrorIsNil)
 	wc.AssertChangeInSingleEvent("0") // removed
 	wc.AssertNoChange()
@@ -326,6 +347,9 @@ func (s *VolumeStateSuite) TestWatchEnvironVolumeAttachments(c *gc.C) {
 	}
 	addUnit()
 
+	im, err := s.State.IAASModel()
+	c.Assert(err, jc.ErrorIsNil)
+
 	w := s.State.WatchModelVolumeAttachments()
 	defer testing.AssertStop(c, w)
 	wc := testing.NewStringsWatcherC(c, s.State, w)
@@ -336,12 +360,12 @@ func (s *VolumeStateSuite) TestWatchEnvironVolumeAttachments(c *gc.C) {
 	wc.AssertChangeInSingleEvent("1:4", "1:5")
 	wc.AssertNoChange()
 
-	err := s.State.DetachVolume(names.NewMachineTag("0"), names.NewVolumeTag("0"))
+	err = im.DetachVolume(names.NewMachineTag("0"), names.NewVolumeTag("0"))
 	c.Assert(err, jc.ErrorIsNil)
 	wc.AssertChangeInSingleEvent("0:0") // dying
 	wc.AssertNoChange()
 
-	err = s.State.RemoveVolumeAttachment(names.NewMachineTag("0"), names.NewVolumeTag("0"))
+	err = im.RemoveVolumeAttachment(names.NewMachineTag("0"), names.NewVolumeTag("0"))
 	c.Assert(err, jc.ErrorIsNil)
 	wc.AssertChangeInSingleEvent("0:0") // removed
 	wc.AssertNoChange()
@@ -357,6 +381,9 @@ func (s *VolumeStateSuite) TestWatchMachineVolumes(c *gc.C) {
 	}
 	addUnit()
 
+	im, err := s.State.IAASModel()
+	c.Assert(err, jc.ErrorIsNil)
+
 	w := s.State.WatchMachineVolumes(names.NewMachineTag("0"))
 	defer testing.AssertStop(c, w)
 	wc := testing.NewStringsWatcherC(c, s.State, w)
@@ -367,21 +394,21 @@ func (s *VolumeStateSuite) TestWatchMachineVolumes(c *gc.C) {
 	// no change, since we're only interested in the one machine.
 	wc.AssertNoChange()
 
-	volume, err := s.State.Volume(names.NewVolumeTag("0/0"))
+	volume, err := im.Volume(names.NewVolumeTag("0/0"))
 	c.Assert(err, jc.ErrorIsNil)
 	storageTag, err := volume.StorageInstance()
 	c.Assert(err, jc.ErrorIsNil)
 	removeStorageInstance(c, s.State, storageTag)
-	err = s.State.DestroyVolume(volume.VolumeTag())
+	err = im.DestroyVolume(volume.VolumeTag())
 	c.Assert(err, jc.ErrorIsNil)
 	wc.AssertChangeInSingleEvent("0/0") // dying
 	wc.AssertNoChange()
 
-	err = s.State.DestroyVolume(names.NewVolumeTag("0/0"))
+	err = im.DestroyVolume(names.NewVolumeTag("0/0"))
 	c.Assert(err, jc.ErrorIsNil)
-	err = s.State.RemoveVolumeAttachment(names.NewMachineTag("0"), names.NewVolumeTag("0/0"))
+	err = im.RemoveVolumeAttachment(names.NewMachineTag("0"), names.NewVolumeTag("0/0"))
 	c.Assert(err, jc.ErrorIsNil)
-	err = s.State.RemoveVolume(names.NewVolumeTag("0/0"))
+	err = im.RemoveVolume(names.NewVolumeTag("0/0"))
 	c.Assert(err, jc.ErrorIsNil)
 	wc.AssertChangeInSingleEvent("0/0") // removed
 	wc.AssertNoChange()
@@ -405,6 +432,9 @@ func (s *VolumeStateSuite) TestWatchMachineVolumeAttachments(c *gc.C) {
 	}
 	_, m0 := addUnit(nil)
 
+	im, err := s.State.IAASModel()
+	c.Assert(err, jc.ErrorIsNil)
+
 	w := s.State.WatchMachineVolumeAttachments(names.NewMachineTag("0"))
 	defer testing.AssertStop(c, w)
 	wc := testing.NewStringsWatcherC(c, s.State, w)
@@ -415,19 +445,19 @@ func (s *VolumeStateSuite) TestWatchMachineVolumeAttachments(c *gc.C) {
 	// no change, since we're only interested in the one machine.
 	wc.AssertNoChange()
 
-	err := s.State.DetachVolume(names.NewMachineTag("0"), names.NewVolumeTag("2"))
+	err = im.DetachVolume(names.NewMachineTag("0"), names.NewVolumeTag("2"))
 	c.Assert(err, jc.ErrorIsNil)
 	// no change, since we're only interested in attachments of
 	// machine-scoped volumes.
 	wc.AssertNoChange()
 
 	removeVolumeStorageInstance(c, s.State, names.NewVolumeTag("0/0"))
-	err = s.State.DestroyVolume(names.NewVolumeTag("0/0"))
+	err = im.DestroyVolume(names.NewVolumeTag("0/0"))
 	c.Assert(err, jc.ErrorIsNil)
 	wc.AssertChangeInSingleEvent("0:0/0") // dying
 	wc.AssertNoChange()
 
-	err = s.State.RemoveVolumeAttachment(names.NewMachineTag("0"), names.NewVolumeTag("0/0"))
+	err = im.RemoveVolumeAttachment(names.NewMachineTag("0"), names.NewVolumeTag("0/0"))
 	c.Assert(err, jc.ErrorIsNil)
 	wc.AssertChangeInSingleEvent("0:0/0") // removed
 	wc.AssertNoChange()
@@ -462,7 +492,10 @@ func (s *VolumeStateSuite) TestParseVolumeAttachmentIdError(c *gc.C) {
 func (s *VolumeStateSuite) TestAllVolumes(c *gc.C) {
 	_, expected, _ := s.assertCreateVolumes(c)
 
-	volumes, err := s.State.AllVolumes()
+	im, err := s.State.IAASModel()
+	c.Assert(err, jc.ErrorIsNil)
+
+	volumes, err := im.AllVolumes()
 	c.Assert(err, jc.ErrorIsNil)
 	tags := make([]names.VolumeTag, len(volumes))
 	for i, v := range volumes {
@@ -486,16 +519,19 @@ func (s *VolumeStateSuite) assertCreateVolumes(c *gc.C) (_ *state.Machine, all, 
 	c.Assert(err, jc.ErrorIsNil)
 	assertMachineStorageRefs(c, s.State, machine.MachineTag())
 
+	im, err := s.State.IAASModel()
+	c.Assert(err, jc.ErrorIsNil)
+
 	volume1 := s.volume(c, names.NewVolumeTag("0"))
 	volume2 := s.volume(c, names.NewVolumeTag("0/1"))
 	volume3 := s.volume(c, names.NewVolumeTag("2"))
 
 	volumeInfoSet := state.VolumeInfo{Size: 123, Persistent: true, VolumeId: "vol-1"}
-	err = s.State.SetVolumeInfo(volume1.VolumeTag(), volumeInfoSet)
+	err = im.SetVolumeInfo(volume1.VolumeTag(), volumeInfoSet)
 	c.Assert(err, jc.ErrorIsNil)
 
 	volumeInfoSet = state.VolumeInfo{Size: 456, Persistent: false, VolumeId: "vol-2"}
-	err = s.State.SetVolumeInfo(volume2.VolumeTag(), volumeInfoSet)
+	err = im.SetVolumeInfo(volume2.VolumeTag(), volumeInfoSet)
 	c.Assert(err, jc.ErrorIsNil)
 
 	all = []names.VolumeTag{
@@ -519,15 +555,18 @@ func (s *VolumeStateSuite) TestRemoveStorageInstanceDestroysAndUnassignsVolume(c
 	err = u.Destroy()
 	c.Assert(err, jc.ErrorIsNil)
 
+	im, err := s.State.IAASModel()
+	c.Assert(err, jc.ErrorIsNil)
+
 	// Provision volume attachment so that detaching the storage
 	// attachment does not short-circuit.
 	defer state.SetBeforeHooks(c, s.State, func() {
 		machine := unitMachine(c, s.State, u)
 		err = machine.SetProvisioned("inst-id", "fake_nonce", nil)
 		c.Assert(err, jc.ErrorIsNil)
-		err = s.State.SetVolumeInfo(volume.VolumeTag(), state.VolumeInfo{VolumeId: "vol-123"})
+		err = im.SetVolumeInfo(volume.VolumeTag(), state.VolumeInfo{VolumeId: "vol-123"})
 		c.Assert(err, jc.ErrorIsNil)
-		err = s.State.SetVolumeAttachmentInfo(
+		err = im.SetVolumeAttachmentInfo(
 			machine.MachineTag(), volume.VolumeTag(),
 			state.VolumeAttachmentInfo{DeviceName: "xvdf1"},
 		)
@@ -548,7 +587,7 @@ func (s *VolumeStateSuite) TestRemoveStorageInstanceDestroysAndUnassignsVolume(c
 
 	// The storage instance is now gone; the volume should no longer
 	// be assigned to the storage.
-	_, err = s.State.StorageInstanceVolume(storageTag)
+	_, err = im.StorageInstanceVolume(storageTag)
 	c.Assert(err, gc.ErrorMatches, `volume for storage instance "data/0" not found`)
 
 	// The volume should still exist, but it should be dying.
@@ -564,10 +603,13 @@ func (s *VolumeStateSuite) TestSetVolumeAttachmentInfoVolumeNotProvisioned(c *gc
 	c.Assert(err, jc.ErrorIsNil)
 	machineTag := names.NewMachineTag(assignedMachineId)
 
+	im, err := s.State.IAASModel()
+	c.Assert(err, jc.ErrorIsNil)
+
 	volume := s.storageInstanceVolume(c, storageTag)
 	volumeTag := volume.VolumeTag()
 
-	err = s.State.SetVolumeAttachmentInfo(
+	err = im.SetVolumeAttachmentInfo(
 		machineTag, volumeTag, state.VolumeAttachmentInfo{
 			DeviceName: "xvdf1",
 		},
@@ -577,8 +619,10 @@ func (s *VolumeStateSuite) TestSetVolumeAttachmentInfoVolumeNotProvisioned(c *gc
 
 func (s *VolumeStateSuite) TestDestroyVolume(c *gc.C) {
 	volume, _ := s.setupMachineScopedVolumeAttachment(c)
+	im, err := s.State.IAASModel()
+	c.Assert(err, jc.ErrorIsNil)
 	assertDestroy := func() {
-		err := s.State.DestroyVolume(volume.VolumeTag())
+		err = im.DestroyVolume(volume.VolumeTag())
 		c.Assert(err, jc.ErrorIsNil)
 		volume = s.volume(c, volume.VolumeTag())
 		c.Assert(volume.Life(), gc.Equals, state.Dying)
@@ -588,7 +632,9 @@ func (s *VolumeStateSuite) TestDestroyVolume(c *gc.C) {
 }
 
 func (s *VolumeStateSuite) TestDestroyVolumeNotFound(c *gc.C) {
-	err := s.State.DestroyVolume(names.NewVolumeTag("0"))
+	im, err := s.State.IAASModel()
+	c.Assert(err, jc.ErrorIsNil)
+	err = im.DestroyVolume(names.NewVolumeTag("0"))
 	c.Assert(err, gc.ErrorMatches, `destroying volume 0: volume "0" not found`)
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 }
@@ -598,28 +644,33 @@ func (s *VolumeStateSuite) TestDestroyVolumeStorageAssigned(c *gc.C) {
 	storageTag, err := volume.StorageInstance()
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = s.State.DestroyVolume(volume.VolumeTag())
+	im, err := s.State.IAASModel()
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = im.DestroyVolume(volume.VolumeTag())
 	c.Assert(err, gc.ErrorMatches, "destroying volume 0: volume is assigned to storage data/0")
 
 	err = u.Destroy()
 	c.Assert(err, jc.ErrorIsNil)
 	removeStorageInstance(c, s.State, storageTag)
-	err = s.State.DestroyVolume(volume.VolumeTag())
+	err = im.DestroyVolume(volume.VolumeTag())
 	c.Assert(err, jc.ErrorIsNil)
 }
 
 func (s *VolumeStateSuite) TestDestroyVolumeNoAttachments(c *gc.C) {
 	volume, machine := s.setupModelScopedVolumeAttachment(c)
+	im, err := s.State.IAASModel()
+	c.Assert(err, jc.ErrorIsNil)
 
-	err := s.State.DetachVolume(machine.MachineTag(), volume.VolumeTag())
+	err = im.DetachVolume(machine.MachineTag(), volume.VolumeTag())
 	c.Assert(err, jc.ErrorIsNil)
 
 	defer state.SetBeforeHooks(c, s.State, func() {
-		err := s.State.RemoveVolumeAttachment(machine.MachineTag(), volume.VolumeTag())
+		err := im.RemoveVolumeAttachment(machine.MachineTag(), volume.VolumeTag())
 		c.Assert(err, jc.ErrorIsNil)
 	}).Check()
 
-	err = s.State.DestroyVolume(volume.VolumeTag())
+	err = im.DestroyVolume(volume.VolumeTag())
 	c.Assert(err, jc.ErrorIsNil)
 	volume = s.volume(c, volume.VolumeTag())
 
@@ -630,14 +681,17 @@ func (s *VolumeStateSuite) TestDestroyVolumeNoAttachments(c *gc.C) {
 
 func (s *VolumeStateSuite) TestRemoveVolume(c *gc.C) {
 	volume, machine := s.setupMachineScopedVolumeAttachment(c)
-	err := s.State.DestroyVolume(volume.VolumeTag())
+	im, err := s.State.IAASModel()
 	c.Assert(err, jc.ErrorIsNil)
-	err = s.State.RemoveVolumeAttachment(machine.MachineTag(), volume.VolumeTag())
+
+	err = im.DestroyVolume(volume.VolumeTag())
+	c.Assert(err, jc.ErrorIsNil)
+	err = im.RemoveVolumeAttachment(machine.MachineTag(), volume.VolumeTag())
 	c.Assert(err, jc.ErrorIsNil)
 	assertRemove := func() {
-		err = s.State.RemoveVolume(volume.VolumeTag())
+		err = im.RemoveVolume(volume.VolumeTag())
 		c.Assert(err, jc.ErrorIsNil)
-		_, err = s.State.Volume(volume.VolumeTag())
+		_, err = im.Volume(volume.VolumeTag())
 		c.Assert(err, jc.Satisfies, errors.IsNotFound)
 	}
 	defer state.SetBeforeHooks(c, s.State, assertRemove).Check()
@@ -645,24 +699,30 @@ func (s *VolumeStateSuite) TestRemoveVolume(c *gc.C) {
 }
 
 func (s *VolumeStateSuite) TestRemoveVolumeNotFound(c *gc.C) {
-	err := s.State.RemoveVolume(names.NewVolumeTag("42"))
+	im, err := s.State.IAASModel()
+	c.Assert(err, jc.ErrorIsNil)
+	err = im.RemoveVolume(names.NewVolumeTag("42"))
 	c.Assert(err, jc.ErrorIsNil)
 }
 
 func (s *VolumeStateSuite) TestRemoveVolumeNotDead(c *gc.C) {
 	volume, _ := s.setupMachineScopedVolumeAttachment(c)
-	err := s.State.RemoveVolume(volume.VolumeTag())
-	c.Assert(err, gc.ErrorMatches, "removing volume 0/0: volume is not dead")
-	err = s.State.DestroyVolume(volume.VolumeTag())
+	im, err := s.State.IAASModel()
 	c.Assert(err, jc.ErrorIsNil)
-	err = s.State.RemoveVolume(volume.VolumeTag())
+	err = im.RemoveVolume(volume.VolumeTag())
+	c.Assert(err, gc.ErrorMatches, "removing volume 0/0: volume is not dead")
+	err = im.DestroyVolume(volume.VolumeTag())
+	c.Assert(err, jc.ErrorIsNil)
+	err = im.RemoveVolume(volume.VolumeTag())
 	c.Assert(err, gc.ErrorMatches, "removing volume 0/0: volume is not dead")
 }
 
 func (s *VolumeStateSuite) TestDetachVolume(c *gc.C) {
+	im, err := s.State.IAASModel()
+	c.Assert(err, jc.ErrorIsNil)
 	volume, machine := s.setupModelScopedVolumeAttachment(c)
 	assertDetach := func() {
-		err := s.State.DetachVolume(machine.MachineTag(), volume.VolumeTag())
+		err := im.DetachVolume(machine.MachineTag(), volume.VolumeTag())
 		c.Assert(err, jc.ErrorIsNil)
 		attachment := s.volumeAttachment(c, machine.MachineTag(), volume.VolumeTag())
 		c.Assert(attachment.Life(), gc.Equals, state.Dying)
@@ -673,16 +733,18 @@ func (s *VolumeStateSuite) TestDetachVolume(c *gc.C) {
 
 func (s *VolumeStateSuite) TestRemoveLastVolumeAttachment(c *gc.C) {
 	volume, machine := s.setupModelScopedVolumeAttachment(c)
-
-	err := s.State.DetachVolume(machine.MachineTag(), volume.VolumeTag())
+	im, err := s.State.IAASModel()
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = s.State.DestroyVolume(volume.VolumeTag())
+	err = im.DetachVolume(machine.MachineTag(), volume.VolumeTag())
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = im.DestroyVolume(volume.VolumeTag())
 	c.Assert(err, jc.ErrorIsNil)
 	volume = s.volume(c, volume.VolumeTag())
 	c.Assert(volume.Life(), gc.Equals, state.Dying)
 
-	err = s.State.RemoveVolumeAttachment(machine.MachineTag(), volume.VolumeTag())
+	err = im.RemoveVolumeAttachment(machine.MachineTag(), volume.VolumeTag())
 	c.Assert(err, jc.ErrorIsNil)
 
 	// The volume was Dying when the last attachment was
@@ -693,18 +755,20 @@ func (s *VolumeStateSuite) TestRemoveLastVolumeAttachment(c *gc.C) {
 
 func (s *VolumeStateSuite) TestRemoveLastVolumeAttachmentConcurrently(c *gc.C) {
 	volume, machine := s.setupModelScopedVolumeAttachment(c)
+	im, err := s.State.IAASModel()
+	c.Assert(err, jc.ErrorIsNil)
 
-	err := s.State.DetachVolume(machine.MachineTag(), volume.VolumeTag())
+	err = im.DetachVolume(machine.MachineTag(), volume.VolumeTag())
 	c.Assert(err, jc.ErrorIsNil)
 
 	defer state.SetBeforeHooks(c, s.State, func() {
-		err := s.State.DestroyVolume(volume.VolumeTag())
+		err := im.DestroyVolume(volume.VolumeTag())
 		c.Assert(err, jc.ErrorIsNil)
 		volume := s.volume(c, volume.VolumeTag())
 		c.Assert(volume.Life(), gc.Equals, state.Dying)
 	}).Check()
 
-	err = s.State.RemoveVolumeAttachment(machine.MachineTag(), volume.VolumeTag())
+	err = im.RemoveVolumeAttachment(machine.MachineTag(), volume.VolumeTag())
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Last attachment was removed, and the volume was (concurrently)
@@ -714,17 +778,21 @@ func (s *VolumeStateSuite) TestRemoveLastVolumeAttachmentConcurrently(c *gc.C) {
 }
 
 func (s *VolumeStateSuite) TestRemoveVolumeAttachmentNotFound(c *gc.C) {
-	err := s.State.RemoveVolumeAttachment(names.NewMachineTag("42"), names.NewVolumeTag("42"))
+	im, err := s.State.IAASModel()
+	c.Assert(err, jc.ErrorIsNil)
+	err = im.RemoveVolumeAttachment(names.NewMachineTag("42"), names.NewVolumeTag("42"))
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 	c.Assert(err, gc.ErrorMatches, `removing attachment of volume 42 from machine 42: volume "42" on machine "42" not found`)
 }
 
 func (s *VolumeStateSuite) TestRemoveVolumeAttachmentConcurrently(c *gc.C) {
 	volume, machine := s.setupMachineScopedVolumeAttachment(c)
-	err := s.State.DestroyVolume(volume.VolumeTag())
+	im, err := s.State.IAASModel()
+	c.Assert(err, jc.ErrorIsNil)
+	err = im.DestroyVolume(volume.VolumeTag())
 	c.Assert(err, jc.ErrorIsNil)
 	remove := func() {
-		err := s.State.RemoveVolumeAttachment(machine.MachineTag(), volume.VolumeTag())
+		err := im.RemoveVolumeAttachment(machine.MachineTag(), volume.VolumeTag())
 		c.Assert(err, jc.ErrorIsNil)
 		assertMachineStorageRefs(c, s.State, machine.MachineTag())
 	}
@@ -734,7 +802,9 @@ func (s *VolumeStateSuite) TestRemoveVolumeAttachmentConcurrently(c *gc.C) {
 
 func (s *VolumeStateSuite) TestRemoveVolumeAttachmentAlive(c *gc.C) {
 	volume, machine := s.setupMachineScopedVolumeAttachment(c)
-	err := s.State.RemoveVolumeAttachment(machine.MachineTag(), volume.VolumeTag())
+	im, err := s.State.IAASModel()
+	c.Assert(err, jc.ErrorIsNil)
+	err = im.RemoveVolumeAttachment(machine.MachineTag(), volume.VolumeTag())
 	c.Assert(err, gc.ErrorMatches, "removing attachment of volume 0/0 from machine 0: volume attachment is not dying")
 }
 
@@ -758,17 +828,20 @@ func (s *VolumeStateSuite) TestRemoveMachineRemovesVolumes(c *gc.C) {
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
-	volumeInfoSet := state.VolumeInfo{Size: 123, Persistent: true, VolumeId: "vol-1"}
-	err = s.State.SetVolumeInfo(names.NewVolumeTag("0/1"), volumeInfoSet)
-	c.Assert(err, jc.ErrorIsNil)
-	volumeInfoSet = state.VolumeInfo{Size: 456, Persistent: false, VolumeId: "vol-2"}
-	err = s.State.SetVolumeInfo(names.NewVolumeTag("0/3"), volumeInfoSet)
-	c.Assert(err, jc.ErrorIsNil)
-	volumeInfoSet = state.VolumeInfo{Size: 789, Persistent: false, VolumeId: "vol-3"}
-	err = s.State.SetVolumeInfo(names.NewVolumeTag("4"), volumeInfoSet)
+	im, err := s.State.IAASModel()
 	c.Assert(err, jc.ErrorIsNil)
 
-	allVolumes, err := s.State.AllVolumes()
+	volumeInfoSet := state.VolumeInfo{Size: 123, Persistent: true, VolumeId: "vol-1"}
+	err = im.SetVolumeInfo(names.NewVolumeTag("0/1"), volumeInfoSet)
+	c.Assert(err, jc.ErrorIsNil)
+	volumeInfoSet = state.VolumeInfo{Size: 456, Persistent: false, VolumeId: "vol-2"}
+	err = im.SetVolumeInfo(names.NewVolumeTag("0/3"), volumeInfoSet)
+	c.Assert(err, jc.ErrorIsNil)
+	volumeInfoSet = state.VolumeInfo{Size: 789, Persistent: false, VolumeId: "vol-3"}
+	err = im.SetVolumeInfo(names.NewVolumeTag("4"), volumeInfoSet)
+	c.Assert(err, jc.ErrorIsNil)
+
+	allVolumes, err := im.AllVolumes()
 	c.Assert(err, jc.ErrorIsNil)
 
 	persistentVolumes := make([]state.Volume, 0, len(allVolumes))
@@ -791,13 +864,13 @@ func (s *VolumeStateSuite) TestRemoveMachineRemovesVolumes(c *gc.C) {
 	c.Assert(machine.Remove(), jc.ErrorIsNil)
 
 	// Machine is gone: non-detachable storage should be done too.
-	allVolumes, err = s.State.AllVolumes()
+	allVolumes, err = im.AllVolumes()
 	c.Assert(err, jc.ErrorIsNil)
 	// We should only have the persistent volume remaining.
 	c.Assert(allVolumes, gc.HasLen, 1)
 	c.Assert(allVolumes[0].Tag().String(), gc.Equals, "volume-0")
 
-	attachments, err := s.State.MachineVolumeAttachments(machine.MachineTag())
+	attachments, err := im.MachineVolumeAttachments(machine.MachineTag())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(attachments, gc.HasLen, 0)
 }
@@ -856,12 +929,15 @@ func (s *VolumeStateSuite) TestVolumeMachineScoped(c *gc.C) {
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
+	im, err := s.State.IAASModel()
+	c.Assert(err, jc.ErrorIsNil)
+
 	volume := s.volume(c, names.NewVolumeTag("0/0"))
 	c.Assert(volume.Life(), gc.Equals, state.Alive)
 
-	err = s.State.DestroyVolume(volume.VolumeTag())
+	err = im.DestroyVolume(volume.VolumeTag())
 	c.Assert(err, jc.ErrorIsNil)
-	err = s.State.RemoveVolumeAttachment(machine.MachineTag(), volume.VolumeTag())
+	err = im.RemoveVolumeAttachment(machine.MachineTag(), volume.VolumeTag())
 	c.Assert(err, jc.ErrorIsNil)
 	volume = s.volume(c, volume.VolumeTag())
 	c.Assert(volume.Life(), gc.Equals, state.Dead)
@@ -873,7 +949,7 @@ func (s *VolumeStateSuite) TestVolumeMachineScoped(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	err = machine.Remove()
 	c.Assert(err, jc.ErrorIsNil)
-	volume, err = s.State.Volume(volume.VolumeTag())
+	volume, err = im.Volume(volume.VolumeTag())
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 }
 
@@ -919,16 +995,20 @@ func (s *VolumeStateSuite) setupVolumeAttachment(c *gc.C, pool string) (state.Vo
 		}},
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	volumeAttachments, err := s.State.MachineVolumeAttachments(machine.MachineTag())
+	im, err := s.State.IAASModel()
+	c.Assert(err, jc.ErrorIsNil)
+	volumeAttachments, err := im.MachineVolumeAttachments(machine.MachineTag())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(volumeAttachments, gc.HasLen, 1)
-	volume, err := s.State.Volume(volumeAttachments[0].Volume())
+	volume, err := im.Volume(volumeAttachments[0].Volume())
 	c.Assert(err, jc.ErrorIsNil)
 	return volume, machine
 }
 
 func removeVolumeStorageInstance(c *gc.C, st *state.State, volumeTag names.VolumeTag) {
-	volume, err := st.Volume(volumeTag)
+	im, err := st.IAASModel()
+	c.Assert(err, jc.ErrorIsNil)
+	volume, err := im.Volume(volumeTag)
 	c.Assert(err, jc.ErrorIsNil)
 	storageTag, err := volume.StorageInstance()
 	c.Assert(err, jc.ErrorIsNil)


### PR DESCRIPTION
This change introduces a state.IAASModel type as a way of starting to untangle the
state.State code and pull out the IAAS specific code. BlockDevices and Volumes are
both migrated to the new type.

There is no intentional functional change.