### PR TITLE
Skip flaky serverSuite.TestClosesStateFromPool

### DIFF
--- a/apiserver/server_test.go
+++ b/apiserver/server_test.go
@@ -544,6 +544,7 @@ func (s *serverSuite) TestAPIHandlerConnectedModel(c *gc.C) {
 }
 
 func (s *serverSuite) TestClosesStateFromPool(c *gc.C) {
+	coretesting.SkipFlaky(c, "lp:1702215")
 	pool := state.NewStatePool(s.State)
 	defer pool.Close()
 	cfg := defaultServerConfig(c)


### PR DESCRIPTION
## Description of change

This test fails frequently in builds - marking it as flaky so we can track it.

## QA steps

Ran the tests, saw that it was skipped.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1702215
