### PR TITLE
Always use pointer receiver to avoid data race.

### DIFF
--- a/provider/dummy/environs.go
+++ b/provider/dummy/environs.go
@@ -537,17 +537,17 @@ var _ config.ConfigSchemaSource = (*environProvider)(nil)
 
 // ConfigSchema returns extra config attributes specific
 // to this provider only.
-func (p environProvider) ConfigSchema() schema.Fields {
+func (p *environProvider) ConfigSchema() schema.Fields {
 	return configFields
 }
 
 // ConfigDefaults returns the default values for the
 // provider specific config attributes.
-func (p environProvider) ConfigDefaults() schema.Defaults {
+func (p *environProvider) ConfigDefaults() schema.Defaults {
 	return configDefaults
 }
 
-func (environProvider) CredentialSchemas() map[cloud.AuthType]cloud.CredentialSchema {
+func (*environProvider) CredentialSchemas() map[cloud.AuthType]cloud.CredentialSchema {
 	return map[cloud.AuthType]cloud.CredentialSchema{
 		cloud.EmptyAuthType: {},
 		cloud.UserPassAuthType: {
@@ -620,12 +620,12 @@ func (p *environProvider) Open(args environs.OpenParams) (environs.Environ, erro
 
 // CloudSchema returns the schema used to validate input for add-cloud.  Since
 // this provider does not support custom clouds, this always returns nil.
-func (p environProvider) CloudSchema() *jsonschema.Schema {
+func (p *environProvider) CloudSchema() *jsonschema.Schema {
 	return nil
 }
 
 // Ping tests the connection to the cloud, to verify the endpoint is valid.
-func (p environProvider) Ping(endpoint string) error {
+func (p *environProvider) Ping(endpoint string) error {
 	return errors.NotImplementedf("Ping")
 }
 


### PR DESCRIPTION
## Description of change

This was a bit of a doozy because it wasn't at all obvious. This fixes a data race found in the BootstrapSuite. The CredentialSchemas() method was being called on a non-pointer receiver of the environProvider. Even though the method is returning a new structure just filled with constants, the method is just syntactic sugar for a function that takes the receiver as the first arg, and the receiver was being copied. The structure has a mutex, and other values were being written to on other goroutines, and that triggered the race detector. The solution here is to just make sure that all the receivers are pointer receivers.

## QA steps

I was not able to trigger this locally, but @davecheney recognised the error pattern from an earlier fix he had done.
