### PR TITLE
Introduce environ/provider versioning

### DIFF
--- a/agent/agentbootstrap/bootstrap.go
+++ b/agent/agentbootstrap/bootstrap.go
@@ -116,6 +116,7 @@ func InitializeState(
 			CloudRegion:             args.ControllerCloudRegion,
 			CloudCredential:         cloudCredentialTag,
 			StorageProviderRegistry: args.StorageProviderRegistry,
+			EnvironVersion:          args.ControllerModelEnvironVersion,
 		},
 		Cloud:                     args.ControllerCloud,
 		CloudCredentials:          cloudCredentials,
@@ -206,6 +207,7 @@ func InitializeState(
 		CloudRegion:             args.ControllerCloudRegion,
 		CloudCredential:         cloudCredentialTag,
 		StorageProviderRegistry: args.StorageProviderRegistry,
+		EnvironVersion:          hostedModelEnv.Provider().Version(),
 	})
 	if err != nil {
 		return nil, nil, errors.Annotate(err, "creating hosted model")

--- a/apiserver/modelmanager/modelmanager.go
+++ b/apiserver/modelmanager/modelmanager.go
@@ -377,6 +377,7 @@ func (m *ModelManagerAPI) CreateModel(args params.ModelCreateArgs) (params.Model
 		Config:          newConfig,
 		Owner:           ownerTag,
 		StorageProviderRegistry: storageProviderRegistry,
+		EnvironVersion:          env.Provider().Version(),
 	})
 	if err != nil {
 		return result, errors.Annotate(err, "failed to create new model")

--- a/cloudconfig/instancecfg/instancecfg.go
+++ b/cloudconfig/instancecfg/instancecfg.go
@@ -229,6 +229,10 @@ type StateInitializationParams struct {
 	// ControllerModelConfig holds the initial controller model configuration.
 	ControllerModelConfig *config.Config
 
+	// ControllerModelEnvironVersion holds the initial controller model
+	// environ version.
+	ControllerModelEnvironVersion int
+
 	// ControllerCloud contains the properties of the cloud that Juju will
 	// be bootstrapped in.
 	ControllerCloud cloud.Cloud
@@ -287,6 +291,7 @@ type StateInitializationParams struct {
 type stateInitializationParamsInternal struct {
 	ControllerConfig                        map[string]interface{}            `yaml:"controller-config"`
 	ControllerModelConfig                   map[string]interface{}            `yaml:"controller-model-config"`
+	ControllerModelEnvironVersion           int                               `yaml:"controller-model-version"`
 	ControllerInheritedConfig               map[string]interface{}            `yaml:"controller-config-defaults,omitempty"`
 	RegionInheritedConfig                   cloud.RegionConfig                `yaml:"region-inherited-config,omitempty"`
 	HostedModelConfig                       map[string]interface{}            `yaml:"hosted-model-config,omitempty"`
@@ -314,6 +319,7 @@ func (p *StateInitializationParams) Marshal() ([]byte, error) {
 	internal := stateInitializationParamsInternal{
 		p.ControllerConfig,
 		p.ControllerModelConfig.AllAttrs(),
+		p.ControllerModelEnvironVersion,
 		p.ControllerInheritedConfig,
 		p.RegionInheritedConfig,
 		p.HostedModelConfig,
@@ -352,6 +358,7 @@ func (p *StateInitializationParams) Unmarshal(data []byte) error {
 	*p = StateInitializationParams{
 		ControllerConfig:                        internal.ControllerConfig,
 		ControllerModelConfig:                   cfg,
+		ControllerModelEnvironVersion:           internal.ControllerModelEnvironVersion,
 		ControllerInheritedConfig:               internal.ControllerInheritedConfig,
 		RegionInheritedConfig:                   internal.RegionInheritedConfig,
 		HostedModelConfig:                       internal.HostedModelConfig,

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -21,7 +21,7 @@ github.com/juju/ansiterm	git	b99631de12cf04a906c1d4e4ec54fb86eae5863d	2016-09-07
 github.com/juju/blobstore	git	06056004b3d7b54bbb7984d830c537bad00fec21	2015-07-29T11:18:58Z
 github.com/juju/bundlechanges	git	7725027b95e0d54635e0fb11efc2debdcdf19f75	2016-12-15T16:06:52Z
 github.com/juju/cmd	git	e47739aefe0adb68a401fcd371c0c92c8f6f8d99	2017-04-13T02:13:06Z
-github.com/juju/description	git	a720edaca89342e01beeb64ad190468468baf248	2017-05-25T03:39:51Z
+github.com/juju/description	git	b764a15740dbcb800ec894fedd41cc0a37826419	2017-07-06T03:32:20Z
 github.com/juju/errors	git	1b5e39b83d1835fa480e0c2ddefb040ee82d58b3	2015-09-16T12:56:42Z
 github.com/juju/gnuflag	git	4e76c56581859c14d9d87e1ddbe29e1c0f10195f	2016-08-09T16:52:14Z
 github.com/juju/go-oracle-cloud	git	932a8cea00a1cd5cba3829a672c823955db674ae	2017-04-21T13:45:47Z

--- a/environs/bootstrap/bootstrap.go
+++ b/environs/bootstrap/bootstrap.go
@@ -411,7 +411,10 @@ func Bootstrap(ctx environs.BootstrapContext, environ environs.Environ, args Boo
 	// Make sure we have the most recent environ config as the specified
 	// tools version has been updated there.
 	cfg = environ.Config()
-	if err := finalizeInstanceBootstrapConfig(ctx, instanceConfig, args, cfg, customImageMetadata); err != nil {
+	environVersion := environ.Provider().Version()
+	if err := finalizeInstanceBootstrapConfig(
+		ctx, instanceConfig, args, cfg, environVersion, customImageMetadata,
+	); err != nil {
 		return errors.Annotate(err, "finalizing bootstrap instance config")
 	}
 	if err := result.Finalize(ctx, instanceConfig, args.DialOpts); err != nil {
@@ -426,6 +429,7 @@ func finalizeInstanceBootstrapConfig(
 	icfg *instancecfg.InstanceConfig,
 	args BootstrapParams,
 	cfg *config.Config,
+	environVersion int,
 	customImageMetadata []*imagemetadata.ImageMetadata,
 ) error {
 	if icfg.APIInfo != nil || icfg.Controller.MongoInfo != nil {
@@ -466,6 +470,7 @@ func finalizeInstanceBootstrapConfig(
 	}
 
 	icfg.Bootstrap.ControllerModelConfig = cfg
+	icfg.Bootstrap.ControllerModelEnvironVersion = environVersion
 	icfg.Bootstrap.CustomImageMetadata = customImageMetadata
 	icfg.Bootstrap.ControllerCloud = args.Cloud
 	icfg.Bootstrap.ControllerCloudRegion = args.CloudRegion

--- a/environs/bootstrap/bootstrap_test.go
+++ b/environs/bootstrap/bootstrap_test.go
@@ -239,6 +239,7 @@ func (s *bootstrapSuite) TestBootstrapImage(c *gc.C) {
 	expectedCons := bootstrapCons
 	expectedCons.Mem = intPtr(3584)
 	c.Assert(env.instanceConfig.Bootstrap.BootstrapMachineConstraints, jc.DeepEquals, expectedCons)
+	c.Assert(env.instanceConfig.Bootstrap.ControllerModelEnvironVersion, gc.Equals, 123)
 }
 
 func (s *bootstrapSuite) TestBootstrapAddsArchFromImageToExistingProviderSupportedArches(c *gc.C) {
@@ -1341,6 +1342,18 @@ func (e *bootstrapEnviron) ConstraintsValidator() (constraints.Validator, error)
 	v := constraints.NewValidator()
 	v.RegisterVocabulary(constraints.Arch, []string{arch.AMD64, arch.ARM64})
 	return v, nil
+}
+
+func (e *bootstrapEnviron) Provider() environs.EnvironProvider {
+	return bootstrapEnvironProvider{}
+}
+
+type bootstrapEnvironProvider struct {
+	environs.EnvironProvider
+}
+
+func (p bootstrapEnvironProvider) Version() int {
+	return 123
 }
 
 type bootstrapEnvironWithRegion struct {

--- a/environs/interface.go
+++ b/environs/interface.go
@@ -24,6 +24,12 @@ type EnvironProvider interface {
 	config.Validator
 	ProviderCredentials
 
+	// Version returns the version of the provider. This is recorded as the
+	// environ version for each model, and used to identify which upgrade
+	// operations to run when upgrading a model's environ. Providers should
+	// start out at version 0.
+	Version() int
+
 	// CloudSchema returns the schema used to validate input for add-cloud.  If
 	// a provider does not suppport custom clouds, CloudSchema should return
 	// nil.
@@ -411,17 +417,20 @@ type Upgrader interface {
 // UpgradeOperationsParams contains the parameters for
 // Upgrader.UpgradeOperations.
 type UpgradeOperationsParams struct {
-	// ControllerUUID is the UUID of the controller to be that contains
-	// the Environ that is to be upgraded.
+	// ControllerUUID is the UUID of the controller that manages
+	// the Environ being upgraded.
 	ControllerUUID string
 }
 
 // UpgradeOperation contains a target agent version and sequence of upgrade
 // steps to apply to get to that version.
 type UpgradeOperation struct {
-	// TargetVersion is the target agent version number to which the
-	// upgrade steps pertain.
-	TargetVersion version.Number
+	// TargetVersion is the target environ provider version number to
+	// which the upgrade steps pertain. When a model is upgraded, all
+	// upgrade operations will be run for versions greater than the
+	// recorded environ version. This version number is independent of
+	// the agent and controller versions.
+	TargetVersion int
 
 	// Steps contains the sequence of upgrade steps to apply when
 	// upgrading to the accompanying target version number.

--- a/provider/azure/environprovider.go
+++ b/provider/azure/environprovider.go
@@ -15,6 +15,15 @@ import (
 	"github.com/juju/juju/provider/azure/internal/azurestorage"
 )
 
+const (
+	// provider version 1 introduces the "common" deployment,
+	// which contains common resources such as the virtual
+	// network and network security group.
+	providerVersion1 = 1
+
+	currentProviderVersion = providerVersion1
+)
+
 // Logger for the Azure provider.
 var logger = loggo.GetLogger("juju.provider.azure")
 
@@ -92,6 +101,11 @@ func NewEnvironProvider(config ProviderConfig) (*azureEnvironProvider, error) {
 		},
 		config: config,
 	}, nil
+}
+
+// Version is part of the EnvironProvider interface.
+func (prov *azureEnvironProvider) Version() int {
+	return currentProviderVersion
 }
 
 // Open is part of the EnvironProvider interface.

--- a/provider/azure/upgrades.go
+++ b/provider/azure/upgrades.go
@@ -9,7 +9,6 @@ import (
 	"github.com/Azure/go-autorest/autorest"
 	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/juju/errors"
-	"github.com/juju/version"
 
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/tags"
@@ -18,7 +17,7 @@ import (
 // UpgradeOperations is part of the upgrades.OperationSource interface.
 func (env *azureEnviron) UpgradeOperations(environs.UpgradeOperationsParams) []environs.UpgradeOperation {
 	return []environs.UpgradeOperation{{
-		version.MustParse("2.2-alpha1"),
+		providerVersion1,
 		[]environs.UpgradeStep{
 			commonDeploymentUpgradeStep{env},
 		},

--- a/provider/azure/upgrades_test.go
+++ b/provider/azure/upgrades_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/arm/storage"
 	"github.com/Azure/go-autorest/autorest/to"
 	jc "github.com/juju/testing/checkers"
-	"github.com/juju/version"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/environs"
@@ -54,7 +53,7 @@ func (s *environUpgradeSuite) TestEnvironUpgradeOperations(c *gc.C) {
 	upgrader := s.env.(environs.Upgrader)
 	ops := upgrader.UpgradeOperations(environs.UpgradeOperationsParams{})
 	c.Assert(ops, gc.HasLen, 1)
-	c.Assert(ops[0].TargetVersion, gc.Equals, version.MustParse("2.2-alpha1"))
+	c.Assert(ops[0].TargetVersion, gc.Equals, 1)
 	c.Assert(ops[0].Steps, gc.HasLen, 1)
 	c.Assert(ops[0].Steps[0].Description(), gc.Equals, "Create common resource deployment")
 }

--- a/provider/cloudsigma/provider.go
+++ b/provider/cloudsigma/provider.go
@@ -57,6 +57,11 @@ func init() {
 	environs.RegisterImageDataSourceFunc("cloud sigma image source", getImageSource)
 }
 
+// Version is part of the EnvironProvider interface.
+func (environProvider) Version() int {
+	return 0
+}
+
 // Open opens the environment and returns it.
 // The configuration must have come from a previously
 // prepared environment.

--- a/provider/dummy/environs.go
+++ b/provider/dummy/environs.go
@@ -598,6 +598,11 @@ func (e *environ) state() (*environState, error) {
 	return state, nil
 }
 
+// Version is part of the EnvironProvider interface.
+func (*environProvider) Version() int {
+	return 0
+}
+
 func (p *environProvider) Open(args environs.OpenParams) (environs.Environ, error) {
 	p.mu.Lock()
 	defer p.mu.Unlock()

--- a/provider/ec2/provider.go
+++ b/provider/ec2/provider.go
@@ -27,6 +27,11 @@ type environProvider struct {
 
 var providerInstance environProvider
 
+// Version is part of the EnvironProvider interface.
+func (environProvider) Version() int {
+	return 0
+}
+
 // Open is specified in the EnvironProvider interface.
 func (p environProvider) Open(args environs.OpenParams) (environs.Environ, error) {
 	logger.Infof("opening model %q", args.Config.Name())

--- a/provider/gce/provider.go
+++ b/provider/gce/provider.go
@@ -20,6 +20,11 @@ type environProvider struct {
 
 var providerInstance environProvider
 
+// Version is part of the EnvironProvider interface.
+func (environProvider) Version() int {
+	return 0
+}
+
 // Open implements environs.EnvironProvider.
 func (environProvider) Open(args environs.OpenParams) (environs.Environ, error) {
 	if err := validateCloudSpec(args.Cloud); err != nil {

--- a/provider/joyent/provider.go
+++ b/provider/joyent/provider.go
@@ -114,6 +114,11 @@ func credentials(cloud environs.CloudSpec) (*auth.Credentials, error) {
 	}, nil
 }
 
+// Version is part of the EnvironProvider interface.
+func (joyentProvider) Version() int {
+	return 0
+}
+
 func (joyentProvider) Open(args environs.OpenParams) (environs.Environ, error) {
 	if err := validateCloudSpec(args.Cloud); err != nil {
 		return nil, errors.Annotate(err, "validating cloud spec")

--- a/provider/lxd/provider.go
+++ b/provider/lxd/provider.go
@@ -41,6 +41,11 @@ func NewProvider() environs.EnvironProvider {
 	}
 }
 
+// Version is part of the EnvironProvider interface.
+func (*environProvider) Version() int {
+	return 0
+}
+
 // Open implements environs.EnvironProvider.
 func (p *environProvider) Open(args environs.OpenParams) (environs.Environ, error) {
 	local, err := p.validateCloudSpec(args.Cloud)
@@ -64,7 +69,7 @@ func (p *environProvider) CloudSchema() *jsonschema.Schema {
 }
 
 // Ping tests the connection to the cloud, to verify the endpoint is valid.
-func (p environProvider) Ping(endpoint string) error {
+func (p *environProvider) Ping(endpoint string) error {
 	return errors.NotImplementedf("Ping")
 }
 

--- a/provider/maas/environprovider.go
+++ b/provider/maas/environprovider.go
@@ -52,6 +52,11 @@ var _ environs.EnvironProvider = (*MaasEnvironProvider)(nil)
 
 var providerInstance MaasEnvironProvider
 
+// Version is part of the EnvironProvider interface.
+func (MaasEnvironProvider) Version() int {
+	return 0
+}
+
 func (MaasEnvironProvider) Open(args environs.OpenParams) (environs.Environ, error) {
 	logger.Debugf("opening model %q.", args.Config.Name())
 	if err := validateCloudSpec(args.Cloud); err != nil {

--- a/provider/manual/provider.go
+++ b/provider/manual/provider.go
@@ -101,6 +101,11 @@ func (p ManualProvider) PrepareConfig(args environs.PrepareConfigParams) (*confi
 	return args.Config.Apply(envConfig.attrs)
 }
 
+// Version is part of the EnvironProvider interface.
+func (ManualProvider) Version() int {
+	return 0
+}
+
 func (p ManualProvider) Open(args environs.OpenParams) (environs.Environ, error) {
 	if err := validateCloudSpec(args.Cloud); err != nil {
 		return nil, errors.Trace(err)

--- a/provider/openstack/provider.go
+++ b/provider/openstack/provider.go
@@ -135,6 +135,11 @@ var shortAttempt = utils.AttemptStrategy{
 	Delay: 200 * time.Millisecond,
 }
 
+// Version is part of the EnvironProvider interface.
+func (EnvironProvider) Version() int {
+	return 0
+}
+
 func (p EnvironProvider) Open(args environs.OpenParams) (environs.Environ, error) {
 	logger.Infof("opening model %q", args.Config.Name())
 	if err := validateCloudSpec(args.Cloud); err != nil {

--- a/provider/oracle/provider.go
+++ b/provider/oracle/provider.go
@@ -83,6 +83,11 @@ func (e EnvironProvider) validateCloudSpec(spec environs.CloudSpec) error {
 	return nil
 }
 
+// Version is part of the EnvironProvider interface.
+func (EnvironProvider) Version() int {
+	return 0
+}
+
 // Open is defined on the environs.EnvironProvider interface.
 func (e *EnvironProvider) Open(params environs.OpenParams) (environs.Environ, error) {
 	logger.Debugf("opening model %q", params.Config.Name())

--- a/provider/rackspace/provider_test.go
+++ b/provider/rackspace/provider_test.go
@@ -61,6 +61,11 @@ type fakeProvider struct {
 	testing.Stub
 }
 
+func (p *fakeProvider) Version() int {
+	p.MethodCall(p, "Version")
+	return 0
+}
+
 func (p *fakeProvider) Open(args environs.OpenParams) (environs.Environ, error) {
 	p.MethodCall(p, "Open", args)
 	return nil, nil

--- a/provider/vsphere/provider.go
+++ b/provider/vsphere/provider.go
@@ -18,6 +18,13 @@ import (
 
 var logger = loggo.GetLogger("juju.provider.vmware")
 
+const (
+	// provider version 1 organises VMs into folders.
+	providerVersion1 = 1
+
+	currentProviderVersion = providerVersion1
+)
+
 type environProvider struct {
 	environProviderCredentials
 	dial           DialFunc
@@ -48,6 +55,11 @@ func NewEnvironProvider(config EnvironProviderConfig) environs.EnvironProvider {
 		ovaCacheDir:    config.OVACacheDir,
 		ovaCacheLocker: config.OVACacheLocker,
 	}
+}
+
+// Version implements environs.EnvironProvider.
+func (p *environProvider) Version() int {
+	return currentProviderVersion
 }
 
 // Open implements environs.EnvironProvider.

--- a/provider/vsphere/upgrades_test.go
+++ b/provider/vsphere/upgrades_test.go
@@ -5,7 +5,6 @@ package vsphere_test
 
 import (
 	jc "github.com/juju/testing/checkers"
-	"github.com/juju/version"
 	"github.com/vmware/govmomi/vim25/mo"
 	"github.com/vmware/govmomi/vim25/types"
 	gc "gopkg.in/check.v1"
@@ -27,7 +26,7 @@ func (s *environUpgradeSuite) TestEnvironUpgradeOperations(c *gc.C) {
 	upgrader := s.env.(environs.Upgrader)
 	ops := upgrader.UpgradeOperations(environs.UpgradeOperationsParams{})
 	c.Assert(ops, gc.HasLen, 1)
-	c.Assert(ops[0].TargetVersion, gc.Equals, version.MustParse("2.2-beta3"))
+	c.Assert(ops[0].TargetVersion, gc.Equals, 1)
 	c.Assert(ops[0].Steps, gc.HasLen, 2)
 	c.Assert(ops[0].Steps[0].Description(), gc.Equals, "Update ExtraConfig properties with standard Juju tags")
 	c.Assert(ops[0].Steps[1].Description(), gc.Equals, "Move VMs into controller/model folders")

--- a/state/migration_export.go
+++ b/state/migration_export.go
@@ -96,6 +96,7 @@ func (st *State) exportImpl(cfg ExportConfig) (description.Model, error) {
 		Owner:              dbModel.Owner(),
 		Config:             modelConfig.Settings,
 		LatestToolsVersion: dbModel.LatestToolsVersion(),
+		EnvironVersion:     dbModel.EnvironVersion(),
 		Blocks:             blocks,
 	}
 	export.model = description.NewModel(args)

--- a/state/migration_export_test.go
+++ b/state/migration_export_test.go
@@ -159,6 +159,9 @@ func (s *MigrationExportSuite) TestModelInfo(c *gc.C) {
 	machineSeq := s.setRandSequenceValue(c, "machine")
 	fooSeq := s.setRandSequenceValue(c, "application-foo")
 	s.State.SwitchBlockOn(state.ChangeBlock, "locked down")
+	environVersion := 123
+	err = stModel.SetEnvironVersion(environVersion)
+	c.Assert(err, jc.ErrorIsNil)
 
 	model, err := s.State.Export()
 	c.Assert(err, jc.ErrorIsNil)
@@ -175,6 +178,7 @@ func (s *MigrationExportSuite) TestModelInfo(c *gc.C) {
 	modelCfg["resource-tags"] = map[string]string{}
 	c.Assert(modelCfg, jc.DeepEquals, modelAttrs)
 	c.Assert(model.LatestToolsVersion(), gc.Equals, latestTools)
+	c.Assert(model.EnvironVersion(), gc.Equals, environVersion)
 	c.Assert(model.Annotations(), jc.DeepEquals, testAnnotations)
 	constraints := model.Constraints()
 	c.Assert(constraints, gc.NotNil)

--- a/state/migration_import.go
+++ b/state/migration_import.go
@@ -68,11 +68,12 @@ func (st *State) Import(model description.Model) (_ *Model, _ *State, err error)
 		return nil, nil, errors.Trace(err)
 	}
 	args := ModelArgs{
-		CloudName:     model.Cloud(),
-		CloudRegion:   model.CloudRegion(),
-		Config:        cfg,
-		Owner:         model.Owner(),
-		MigrationMode: MigrationModeImporting,
+		CloudName:      model.Cloud(),
+		CloudRegion:    model.CloudRegion(),
+		Config:         cfg,
+		Owner:          model.Owner(),
+		MigrationMode:  MigrationModeImporting,
+		EnvironVersion: model.EnvironVersion(),
 
 		// NOTE(axw) we create the model without any storage
 		// pools. We'll need to import the storage pools from

--- a/state/migration_import_test.go
+++ b/state/migration_import_test.go
@@ -108,6 +108,10 @@ func (s *MigrationImportSuite) TestNewModel(c *gc.C) {
 	original, err := s.State.Model()
 	c.Assert(err, jc.ErrorIsNil)
 
+	environVersion := 123
+	err = original.SetEnvironVersion(environVersion)
+	c.Assert(err, jc.ErrorIsNil)
+
 	err = s.State.SetAnnotations(original, testAnnotations)
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -124,6 +128,7 @@ func (s *MigrationImportSuite) TestNewModel(c *gc.C) {
 	c.Assert(newModel.Owner(), gc.Equals, original.Owner())
 	c.Assert(newModel.LatestToolsVersion(), gc.Equals, latestTools)
 	c.Assert(newModel.MigrationMode(), gc.Equals, state.MigrationModeImporting)
+	c.Assert(newModel.EnvironVersion(), gc.Equals, environVersion)
 	s.assertAnnotations(c, newSt, newModel)
 
 	statusInfo, err := newModel.Status()

--- a/state/migration_internal_test.go
+++ b/state/migration_internal_test.go
@@ -228,6 +228,7 @@ func (s *MigrationSuite) TestModelDocFields(c *gc.C) {
 		"LatestAvailableTools",
 		"SLA",
 		"MeterStatus",
+		"EnvironVersion",
 	)
 	s.AssertExportedFields(c, modelDoc{}, fields)
 }

--- a/state/model.go
+++ b/state/model.go
@@ -66,6 +66,11 @@ type modelDoc struct {
 	ControllerUUID string        `bson:"controller-uuid"`
 	MigrationMode  MigrationMode `bson:"migration-mode"`
 
+	// EnvironVersion is the version of the Environ. As providers
+	// evolve, cloud resource representations may change; the environ
+	// version tracks the current version of that.
+	EnvironVersion int `bson:"environ-version"`
+
 	// Cloud is the name of the cloud to which the model is deployed.
 	Cloud string `bson:"cloud"`
 
@@ -244,6 +249,9 @@ type ModelArgs struct {
 
 	// MigrationMode is the initial migration mode of the model.
 	MigrationMode MigrationMode
+
+	// EnvironVersion is the initial version of the Environ for the model.
+	EnvironVersion int
 }
 
 // Validate validates the ModelArgs.
@@ -721,6 +729,50 @@ func (m *Model) MeterStatus() MeterStatus {
 	}
 }
 
+// EnvironVersion is the version of the model's environ -- the related
+// cloud provider resources. The environ version is used by the controller
+// to identify environ/provider upgrade steps to run for a model's environ
+// after the controller is upgraded, or the model is migrated to another
+// controller.
+func (m *Model) EnvironVersion() int {
+	return m.doc.EnvironVersion
+}
+
+// SetEnvironVersion sets the model's current environ version. The value
+// must be monotonically increasing.
+func (m *Model) SetEnvironVersion(v int) error {
+	mOrig := m
+	mCopy := *m
+	m = &mCopy // copy so we can refresh without affecting the original m
+	buildTxn := func(attempt int) ([]txn.Op, error) {
+		if attempt > 0 {
+			if err := m.Refresh(); err != nil {
+				return nil, errors.Trace(err)
+			}
+		}
+		if v < m.doc.EnvironVersion {
+			return nil, errors.Errorf(
+				"cannot set environ version to %v, which is less than the current version %v",
+				v, m.doc.EnvironVersion,
+			)
+		}
+		if v == m.doc.EnvironVersion {
+			return nil, jujutxn.ErrNoOperations
+		}
+		return []txn.Op{{
+			C:      modelsC,
+			Id:     m.doc.UUID,
+			Assert: bson.D{{"environ-version", m.doc.EnvironVersion}},
+			Update: bson.D{{"$set", bson.D{{"environ-version", v}}}},
+		}}, nil
+	}
+	if err := m.globalState.db().Run(buildTxn); err != nil {
+		return errors.Trace(err)
+	}
+	mOrig.doc.EnvironVersion = v
+	return nil
+}
+
 // globalKey returns the global database key for the model.
 func (m *Model) globalKey() string {
 	return modelGlobalKey
@@ -1085,6 +1137,7 @@ func createModelOp(
 	name, uuid, controllerUUID, cloudName, cloudRegion string,
 	cloudCredential names.CloudCredentialTag,
 	migrationMode MigrationMode,
+	environVersion int,
 ) txn.Op {
 	doc := &modelDoc{
 		UUID:            uuid,
@@ -1093,6 +1146,7 @@ func createModelOp(
 		Owner:           owner.Id(),
 		ControllerUUID:  controllerUUID,
 		MigrationMode:   migrationMode,
+		EnvironVersion:  environVersion,
 		Cloud:           cloudName,
 		CloudRegion:     cloudRegion,
 		CloudCredential: cloudCredential.Id(),

--- a/state/model_test.go
+++ b/state/model_test.go
@@ -970,6 +970,59 @@ func (s *ModelSuite) TestHostedModelCount(c *gc.C) {
 	c.Assert(state.HostedModelCount(c, s.State), gc.Equals, 0)
 }
 
+func (s *ModelSuite) TestNewModelEnvironVersion(c *gc.C) {
+	v := 123
+	st := s.Factory.MakeModel(c, &factory.ModelParams{
+		EnvironVersion: v,
+	})
+	defer st.Close()
+
+	m, err := st.Model()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(m.EnvironVersion(), gc.Equals, v)
+}
+
+func (s *ModelSuite) TestSetEnvironVersion(c *gc.C) {
+	v := 123
+	m, err := s.State.Model()
+	c.Assert(err, jc.ErrorIsNil)
+
+	defer state.SetBeforeHooks(c, s.State, func() {
+		m, err := s.State.Model()
+		c.Assert(err, jc.ErrorIsNil)
+		c.Assert(m.EnvironVersion(), gc.Equals, 0)
+		err = m.SetEnvironVersion(v)
+		c.Assert(err, jc.ErrorIsNil)
+		c.Assert(m.EnvironVersion(), gc.Equals, v)
+	}).Check()
+
+	err = m.SetEnvironVersion(v)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(m.EnvironVersion(), gc.Equals, v)
+}
+
+func (s *ModelSuite) TestSetEnvironVersionCannotDecrease(c *gc.C) {
+	m, err := s.State.Model()
+	c.Assert(err, jc.ErrorIsNil)
+
+	defer state.SetBeforeHooks(c, s.State, func() {
+		m, err := s.State.Model()
+		c.Assert(err, jc.ErrorIsNil)
+		err = m.SetEnvironVersion(2)
+		c.Assert(err, jc.ErrorIsNil)
+		c.Assert(m.EnvironVersion(), gc.Equals, 2)
+	}).Check()
+
+	err = m.SetEnvironVersion(1)
+	c.Assert(err, gc.ErrorMatches, `cannot set environ version to 1, which is less than the current version 2`)
+	// m's cached version is only updated on success
+	c.Assert(m.EnvironVersion(), gc.Equals, 0)
+
+	err = m.Refresh()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(m.EnvironVersion(), gc.Equals, 2)
+}
+
 type ModelCloudValidationSuite struct {
 	gitjujutesting.MgoSuite
 }

--- a/state/open.go
+++ b/state/open.go
@@ -483,6 +483,7 @@ func (st *State) modelSetupOps(controllerUUID string, args ModelArgs, inherited 
 			modelUUID, controllerUUID,
 			args.CloudName, args.CloudRegion, args.CloudCredential,
 			args.MigrationMode,
+			args.EnvironVersion,
 		),
 		createUniqueOwnerModelNameOp(args.Owner, args.Config.Name()),
 	)

--- a/state/state.go
+++ b/state/state.go
@@ -139,6 +139,7 @@ func (st *State) IsController() bool {
 func (st *State) ControllerUUID() string {
 	return st.controllerTag.Id()
 }
+
 func (st *State) ControllerTag() names.ControllerTag {
 	return st.controllerTag
 }

--- a/state/upgrade.go
+++ b/state/upgrade.go
@@ -169,48 +169,24 @@ func (info *UpgradeInfo) getProvisionedControllers() ([]string, error) {
 		return provisioned, errors.Annotate(err, "cannot read controllers")
 	}
 
-	upgradeDone, err := info.isModelUUIDUpgradeDone()
-	if err != nil {
-		return provisioned, errors.Trace(err)
-	}
-
 	// Extract current and provisioned controllers.
 	instanceData, closer := info.st.getRawCollection(instanceDataC)
 	defer closer()
 
-	// If instanceData has the env UUID upgrade query using the
-	// machineid field, otherwise check using _id.
-	var sel bson.D
-	var field string
-	if upgradeDone {
-		sel = bson.D{{"model-uuid", info.st.ModelUUID()}}
-		field = "machineid"
-	} else {
-		field = "_id"
+	query := bson.D{
+		{"model-uuid", info.st.ModelUUID()},
+		{"machineid", bson.D{{"$in", controllerInfo.MachineIds}}},
 	}
-	sel = append(sel, bson.DocElem{field, bson.D{{"$in", controllerInfo.MachineIds}}})
-	iter := instanceData.Find(sel).Select(bson.D{{field, true}}).Iter()
+	iter := instanceData.Find(query).Select(bson.D{{"machineid", true}}).Iter()
 
 	var doc bson.M
 	for iter.Next(&doc) {
-		provisioned = append(provisioned, doc[field].(string))
+		provisioned = append(provisioned, doc["machineid"].(string))
 	}
 	if err := iter.Close(); err != nil {
 		return provisioned, errors.Annotate(err, "cannot read provisioned machines")
 	}
 	return provisioned, nil
-}
-
-func (info *UpgradeInfo) isModelUUIDUpgradeDone() (bool, error) {
-	instanceData, closer := info.st.getRawCollection(instanceDataC)
-	defer closer()
-
-	query := instanceData.Find(bson.D{{"model-uuid", bson.D{{"$exists", true}}}})
-	n, err := query.Count()
-	if err != nil {
-		return false, errors.Annotatef(err, "couldn't query instance upgrade status")
-	}
-	return n > 0, nil
 }
 
 // upgradeStatusHistoryAndOps sets the model's status history and returns ops for

--- a/testing/factory/factory.go
+++ b/testing/factory/factory.go
@@ -129,6 +129,7 @@ type ModelParams struct {
 	CloudRegion             string
 	CloudCredential         names.CloudCredentialTag
 	StorageProviderRegistry storage.ProviderRegistry
+	EnvironVersion          int
 }
 
 type SpaceParams struct {
@@ -645,6 +646,7 @@ func (factory *Factory) MakeModel(c *gc.C, params *ModelParams) *state.State {
 		Config:          cfg,
 		Owner:           params.Owner.(names.UserTag),
 		StorageProviderRegistry: params.StorageProviderRegistry,
+		EnvironVersion:          params.EnvironVersion,
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	return st

--- a/upgrades/backend.go
+++ b/upgrades/backend.go
@@ -32,6 +32,7 @@ type StateBackend interface {
 	SplitLogCollections() error
 	AddUpdateStatusHookSettings() error
 	CorrectRelationUnitCounts() error
+	AddModelEnvironVersion() error
 }
 
 // Model is an interface providing access to the details of a model within the
@@ -120,6 +121,10 @@ func (s stateBackend) SplitLogCollections() error {
 
 func (s stateBackend) CorrectRelationUnitCounts() error {
 	return state.CorrectRelationUnitCounts(s.st)
+}
+
+func (s stateBackend) AddModelEnvironVersion() error {
+	return state.AddModelEnvironVersion(s.st)
 }
 
 type modelShim struct {

--- a/upgrades/steps_22.go
+++ b/upgrades/steps_22.go
@@ -53,6 +53,13 @@ func stateStepsFor22() []Step {
 				return context.State().SplitLogCollections()
 			},
 		},
+		&upgradeStep{
+			description: "add environ-version to model docs",
+			targets:     []Target{DatabaseMaster},
+			run: func(context Context) error {
+				return context.State().AddModelEnvironVersion()
+			},
+		},
 	}
 }
 

--- a/upgrades/steps_22_test.go
+++ b/upgrades/steps_22_test.go
@@ -77,3 +77,9 @@ func (s *steps22Suite) TestSplitLogStep(c *gc.C) {
 	// Logic for step itself is tested in state package.
 	c.Assert(step.Targets(), jc.DeepEquals, []upgrades.Target{upgrades.DatabaseMaster})
 }
+
+func (s *steps22Suite) TestAddModelEnvironVersionStep(c *gc.C) {
+	step := findStateStep(c, v220, "add environ-version to model docs")
+	// Logic for step itself is tested in state package.
+	c.Assert(step.Targets(), jc.DeepEquals, []upgrades.Target{upgrades.DatabaseMaster})
+}

--- a/upgrades/upgrade_test.go
+++ b/upgrades/upgrade_test.go
@@ -637,7 +637,7 @@ func (s *upgradeSuite) TestStateStepsNotAttemptedWhenNoStateTarget(c *gc.C) {
 	}
 
 	check(upgrades.Controller, 1, nil)
-	check(upgrades.DatabaseMaster, 1, []string{"AllModels"})
+	check(upgrades.DatabaseMaster, 1, []string{"ControllerUUID", "AllModels"})
 	check(upgrades.AllMachines, 0, nil)
 	check(upgrades.HostMachine, 0, nil)
 }
@@ -651,13 +651,7 @@ func (s *upgradeSuite) TestEnvironUpgradeOperations(c *gc.C) {
 	models := []upgrades.Model{model0, model1}
 	var opsRun int
 	ops := []environs.UpgradeOperation{{
-		TargetVersion: fromVers,
-		Steps: []environs.UpgradeStep{&mockEnvironUpgradeStep{
-			"should not be run",
-			func() error { return errors.New("should not be run") },
-		}},
-	}, {
-		TargetVersion: version.MustParse("1.19.0"),
+		TargetVersion: 1, // ignored
 		Steps: []environs.UpgradeStep{&mockEnvironUpgradeStep{
 			"should be run",
 			func() error {
@@ -695,7 +689,7 @@ func (s *upgradeSuite) TestEnvironUpgradeOperations(c *gc.C) {
 	err := upgrades.PerformUpgrade(fromVers, targets(upgrades.DatabaseMaster), ctx)
 	c.Assert(err, jc.ErrorIsNil)
 
-	state.CheckCallNames(c, "AllModels", "ControllerUUID")
+	state.CheckCallNames(c, "ControllerUUID", "AllModels")
 	model0.CheckCallNames(c, "Config", "CloudSpec")
 	model1.CheckCallNames(c, "Config", "CloudSpec")
 	newEnvironStub.CheckCallNames(c, "NewEnviron", "NewEnviron")


### PR DESCRIPTION
## Description of change

Environs (i.e. the cloud representation of
a model) are now versioned, so that we can
upgrade them as necessary. Previously this
has been done as part of controller upgrades,
but this poses a problem when the environs
cannot be opened; thus we seek to decouple
the upgrading of a model's environ from the
upgrading of the controller.

EnvironProvider now has a Version method,
which returns the current/most up-to-date
environ version. Model docs now record the
version of the model's associated environ.
Environ upgrade operations specify an
environ/provider version, rather than
controller/agent version.

Once this lands, we will introduce a new
worker that will run under the model
dependency engine to upgrade the model's
environ, and which will gate access to the
model until that has happened.

Requires https://github.com/juju/description/pull/16

(There is a drive-by fix in state/upgrade.go, to stop checking for env-uuid upgrades. That all happened before 2.0, so we don't need to carry that code anymore.)

## QA steps

No functional changes. Bootstrap azure with 2.1.x, juju upgrade-juju to this branch.

## Documentation changes

None.

## Bug reference

Part of the fix for https://bugs.launchpad.net/juju/+bug/1700451