### PR TITLE
uniter: Relations between subordinates shouldn't keep the sub units alive

### DIFF
--- a/api/facadeversions.go
+++ b/api/facadeversions.go
@@ -84,7 +84,7 @@ var facadeVersions = map[string]int{
 	"Subnets":                      2,
 	"Undertaker":                   1,
 	"UnitAssigner":                 1,
-	"Uniter":                       5,
+	"Uniter":                       6,
 	"Upgrader":                     1,
 	"UserManager":                  1,
 	"VolumeAttachmentsWatcher":     2,

--- a/api/uniter/relation.go
+++ b/api/uniter/relation.go
@@ -19,10 +19,11 @@ import (
 // Relation represents a relation between one or two service
 // endpoints.
 type Relation struct {
-	st   *State
-	tag  names.RelationTag
-	id   int
-	life params.Life
+	st       *State
+	tag      names.RelationTag
+	id       int
+	life     params.Life
+	otherApp string
 }
 
 // Tag returns the relation tag.
@@ -46,6 +47,12 @@ func (r *Relation) Id() int {
 // Life returns the relation's current life state.
 func (r *Relation) Life() params.Life {
 	return r.life
+}
+
+// OtherApplication returns the name of the application on the other
+// end of the relation (from this unit's perspective).
+func (r *Relation) OtherApplication() string {
+	return r.otherApp
 }
 
 // Refresh refreshes the contents of the relation from the underlying

--- a/api/uniter/relation_test.go
+++ b/api/uniter/relation_test.go
@@ -44,6 +44,10 @@ func (s *relationSuite) TestIdAndTag(c *gc.C) {
 	c.Assert(s.apiRelation.Tag(), gc.Equals, s.stateRelation.Tag().(names.RelationTag))
 }
 
+func (s *relationSuite) TestOtherApplication(c *gc.C) {
+	c.Assert(s.apiRelation.OtherApplication(), gc.Equals, "mysql")
+}
+
 func (s *relationSuite) TestRefresh(c *gc.C) {
 	c.Assert(s.apiRelation.Life(), gc.Equals, params.Alive)
 

--- a/api/uniter/storage_test.go
+++ b/api/uniter/storage_test.go
@@ -21,6 +21,8 @@ type storageSuite struct {
 	coretesting.BaseSuite
 }
 
+const expectedVersion = 6
+
 func (s *storageSuite) TestUnitStorageAttachments(c *gc.C) {
 	storageAttachmentIds := []params.StorageAttachmentId{{
 		StorageTag: "storage-whatever-0",
@@ -30,7 +32,7 @@ func (s *storageSuite) TestUnitStorageAttachments(c *gc.C) {
 	var called bool
 	apiCaller := testing.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
 		c.Check(objType, gc.Equals, "Uniter")
-		c.Check(version, gc.Equals, 5)
+		c.Check(version, gc.Equals, expectedVersion)
 		c.Check(id, gc.Equals, "")
 		c.Check(request, gc.Equals, "UnitStorageAttachments")
 		c.Check(arg, gc.DeepEquals, params.Entities{
@@ -57,7 +59,7 @@ func (s *storageSuite) TestDestroyUnitStorageAttachments(c *gc.C) {
 	var called bool
 	apiCaller := testing.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
 		c.Check(objType, gc.Equals, "Uniter")
-		c.Check(version, gc.Equals, 5)
+		c.Check(version, gc.Equals, expectedVersion)
 		c.Check(id, gc.Equals, "")
 		c.Check(request, gc.Equals, "DestroyUnitStorageAttachments")
 		c.Check(arg, gc.DeepEquals, params.Entities{
@@ -103,7 +105,7 @@ func (s *storageSuite) TestWatchUnitStorageAttachments(c *gc.C) {
 	var called bool
 	apiCaller := testing.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
 		c.Check(objType, gc.Equals, "Uniter")
-		c.Check(version, gc.Equals, 5)
+		c.Check(version, gc.Equals, expectedVersion)
 		c.Check(id, gc.Equals, "")
 		c.Check(request, gc.Equals, "WatchUnitStorageAttachments")
 		c.Check(arg, gc.DeepEquals, params.Entities{
@@ -129,7 +131,7 @@ func (s *storageSuite) TestWatchStorageAttachments(c *gc.C) {
 	var called bool
 	apiCaller := testing.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
 		c.Check(objType, gc.Equals, "Uniter")
-		c.Check(version, gc.Equals, 5)
+		c.Check(version, gc.Equals, expectedVersion)
 		c.Check(id, gc.Equals, "")
 		c.Check(request, gc.Equals, "WatchStorageAttachments")
 		c.Check(arg, gc.DeepEquals, params.StorageAttachmentIds{
@@ -166,7 +168,7 @@ func (s *storageSuite) TestStorageAttachments(c *gc.C) {
 	var called bool
 	apiCaller := testing.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
 		c.Check(objType, gc.Equals, "Uniter")
-		c.Check(version, gc.Equals, 5)
+		c.Check(version, gc.Equals, expectedVersion)
 		c.Check(id, gc.Equals, "")
 		c.Check(request, gc.Equals, "StorageAttachments")
 		c.Check(arg, gc.DeepEquals, params.StorageAttachmentIds{
@@ -195,7 +197,7 @@ func (s *storageSuite) TestStorageAttachments(c *gc.C) {
 func (s *storageSuite) TestStorageAttachmentLife(c *gc.C) {
 	apiCaller := testing.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
 		c.Check(objType, gc.Equals, "Uniter")
-		c.Check(version, gc.Equals, 5)
+		c.Check(version, gc.Equals, expectedVersion)
 		c.Check(id, gc.Equals, "")
 		c.Check(request, gc.Equals, "StorageAttachmentLife")
 		c.Check(arg, gc.DeepEquals, params.StorageAttachmentIds{
@@ -225,7 +227,7 @@ func (s *storageSuite) TestStorageAttachmentLife(c *gc.C) {
 func (s *storageSuite) TestRemoveStorageAttachment(c *gc.C) {
 	apiCaller := testing.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
 		c.Check(objType, gc.Equals, "Uniter")
-		c.Check(version, gc.Equals, 5)
+		c.Check(version, gc.Equals, expectedVersion)
 		c.Check(id, gc.Equals, "")
 		c.Check(request, gc.Equals, "RemoveStorageAttachments")
 		c.Check(arg, gc.DeepEquals, params.StorageAttachmentIds{

--- a/api/uniter/uniter.go
+++ b/api/uniter/uniter.go
@@ -69,12 +69,12 @@ func newStateForVersionFn(version int) func(base.APICaller, names.UnitTag) *Stat
 	}
 }
 
-// newStateV5 creates a new client-side Uniter facade, version 5.
-var newStateV5 = newStateForVersionFn(5)
+// newStateV6 creates a new client-side Uniter facade, version 6
+var newStateV6 = newStateForVersionFn(6)
 
 // NewState creates a new client-side Uniter facade.
 // Defined like this to allow patching during tests.
-var NewState = newStateV5
+var NewState = newStateV6
 
 // BestAPIVersion returns the API version that we were able to
 // determine is supported by both the client and the API Server.
@@ -203,10 +203,11 @@ func (st *State) Relation(relationTag names.RelationTag) (*Relation, error) {
 		return nil, err
 	}
 	return &Relation{
-		id:   result.Id,
-		tag:  relationTag,
-		life: result.Life,
-		st:   st,
+		id:       result.Id,
+		tag:      relationTag,
+		life:     result.Life,
+		st:       st,
+		otherApp: result.OtherApplication,
 	}, nil
 }
 
@@ -294,10 +295,11 @@ func (st *State) RelationById(id int) (*Relation, error) {
 	}
 	relationTag := names.NewRelationTag(result.Key)
 	return &Relation{
-		id:   result.Id,
-		tag:  relationTag,
-		life: result.Life,
-		st:   st,
+		id:       result.Id,
+		tag:      relationTag,
+		life:     result.Life,
+		st:       st,
+		otherApp: result.OtherApplication,
 	}, nil
 }
 

--- a/api/uniter/uniter_test.go
+++ b/api/uniter/uniter_test.go
@@ -132,12 +132,3 @@ func (s *uniterSuite) patchNewState(
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(s.uniter, gc.NotNil)
 }
-
-func (s *uniterSuite) TestSLALevel(c *gc.C) {
-	err := s.State.SetSLA("essential", "bob", []byte("creds"))
-	c.Assert(err, jc.ErrorIsNil)
-
-	level, err := s.uniter.SLALevel()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(level, gc.Equals, "essential")
-}

--- a/api/uniter/unitstorage_test.go
+++ b/api/uniter/unitstorage_test.go
@@ -21,6 +21,8 @@ type unitStorageSuite struct {
 
 var _ = gc.Suite(&unitStorageSuite{})
 
+const expectedAPIVersion = 6
+
 func (s *unitStorageSuite) createTestUnit(c *gc.C, t string, apiCaller basetesting.APICallerFunc) *uniter.Unit {
 	tag := names.NewUnitTag(t)
 	st := uniter.NewState(apiCaller, tag)
@@ -42,7 +44,7 @@ func (s *unitStorageSuite) TestAddUnitStorage(c *gc.C) {
 
 	apiCaller := basetesting.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
 		c.Assert(objType, gc.Equals, "Uniter")
-		c.Assert(version, gc.Equals, 5)
+		c.Assert(version, gc.Equals, expectedAPIVersion)
 		c.Assert(id, gc.Equals, "")
 		c.Assert(request, gc.Equals, "AddUnitStorage")
 		c.Assert(arg, gc.DeepEquals, expected)
@@ -75,7 +77,7 @@ func (s *unitStorageSuite) TestAddUnitStorageError(c *gc.C) {
 	msg := "yoink"
 	apiCaller := basetesting.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
 		c.Assert(objType, gc.Equals, "Uniter")
-		c.Assert(version, gc.Equals, 5)
+		c.Assert(version, gc.Equals, expectedAPIVersion)
 		c.Assert(id, gc.Equals, "")
 		c.Assert(request, gc.Equals, "AddUnitStorage")
 		c.Assert(arg, gc.DeepEquals, expected)

--- a/apiserver/allfacades.go
+++ b/apiserver/allfacades.go
@@ -204,7 +204,8 @@ func AllFacades() *facade.Registry {
 	reg("UnitAssigner", 1, unitassigner.New)
 
 	reg("Uniter", 4, uniter.NewUniterAPIV4)
-	reg("Uniter", 5, uniter.NewUniterAPI)
+	reg("Uniter", 5, uniter.NewUniterAPIV5)
+	reg("Uniter", 6, uniter.NewUniterAPI)
 
 	reg("Upgrader", 1, upgrader.NewUpgraderFacade)
 	reg("UserManager", 1, usermanager.NewUserManagerAPI)

--- a/apiserver/params/internal.go
+++ b/apiserver/params/internal.go
@@ -294,9 +294,26 @@ type RelationUnitsSettings struct {
 	RelationUnits []RelationUnitSettings `json:"relation-units"`
 }
 
+// RelationResults holds the result of an API call that returns
+// information about multiple relations.
+type RelationResults struct {
+	Results []RelationResult `json:"results"`
+}
+
 // RelationResult returns information about a single relation,
 // or an error.
 type RelationResult struct {
+	Error            *Error                `json:"error,omitempty"`
+	Life             Life                  `json:"life"`
+	Id               int                   `json:"id"`
+	Key              string                `json:"key"`
+	Endpoint         multiwatcher.Endpoint `json:"endpoint"`
+	OtherApplication string                `json:"other-application,omitempty"`
+}
+
+// RelationResultV5 returns information about a single relation,
+// or an error, but doesn't include the other application name.
+type RelationResultV5 struct {
 	Error    *Error                `json:"error,omitempty"`
 	Life     Life                  `json:"life"`
 	Id       int                   `json:"id"`
@@ -304,10 +321,10 @@ type RelationResult struct {
 	Endpoint multiwatcher.Endpoint `json:"endpoint"`
 }
 
-// RelationResults holds the result of an API call that returns
-// information about multiple relations.
-type RelationResults struct {
-	Results []RelationResult `json:"results"`
+// RelationResultsV5 holds the result of an API call that returns
+// information about multiple V5 relations.
+type RelationResultsV5 struct {
+	Results []RelationResultV5 `json:"results"`
 }
 
 // EntityCharmURL holds an entity's tag and a charm URL.

--- a/state/application.go
+++ b/state/application.go
@@ -197,7 +197,6 @@ func (a *Application) destroyOps() ([]txn.Op, error) {
 		}
 		ops = append(ops, relOps...)
 	}
-	// TODO(ericsnow) Use a generic registry instead.
 	resOps, err := removeResourcesOps(a.st, a.doc.Name)
 	if err != nil {
 		return nil, errors.Trace(err)

--- a/worker/uniter/relation/relations_test.go
+++ b/worker/uniter/relation/relations_test.go
@@ -78,7 +78,7 @@ func mockAPICaller(c *gc.C, callNumber *int32, apiCalls ...apiCall) apitesting.A
 			c.Check(index < len(apiCalls), jc.IsTrue)
 			call := apiCalls[index]
 			c.Logf("request %d, %s", index, request)
-			c.Check(version, gc.Equals, 5)
+			c.Check(version, gc.Equals, 6)
 			c.Check(id, gc.Equals, "")
 			c.Check(request, gc.Equals, call.request)
 			c.Check(arg, jc.DeepEquals, call.args)
@@ -511,4 +511,174 @@ func (s *relationsSuite) TestImplicitRelationNoHooks(c *gc.C) {
 	relationsResolver := relation.NewRelationsResolver(r)
 	_, err = relationsResolver.NextOp(localState, remoteState, &mockOperations{})
 	c.Assert(errors.Cause(err), gc.Equals, resolver.ErrNoOperation)
+}
+
+var (
+	noErrorResult  = params.ErrorResults{Results: []params.ErrorResult{{}}}
+	nrpeUnitTag    = names.NewUnitTag("nrpe/0")
+	nrpeUnitEntity = params.Entities{Entities: []params.Entity{params.Entity{Tag: nrpeUnitTag.String()}}}
+)
+
+func subSubRelationAPICalls() []apiCall {
+	joinedRelationsResults := params.StringsResults{Results: []params.StringsResult{{Result: []string{
+		"relation-wordpress:juju-info nrpe:general-info",
+		"relation-ntp:nrpe-external-master nrpe:external-master",
+	}}}}
+	relationUnits1 := params.RelationUnits{RelationUnits: []params.RelationUnit{
+		{Relation: "relation-wordpress.juju-info#nrpe.general-info", Unit: "unit-nrpe-0"},
+	}}
+	relationResults1 := params.RelationResults{
+		Results: []params.RelationResult{{
+			Id:               1,
+			Key:              "wordpress:juju-info nrpe:general-info",
+			Life:             params.Alive,
+			OtherApplication: "wordpress",
+			Endpoint: multiwatcher.Endpoint{
+				ApplicationName: "nrpe",
+				Relation: multiwatcher.CharmRelation{
+					Name:      "general-info",
+					Role:      string(charm.RoleRequirer),
+					Interface: "juju-info",
+					Scope:     "container",
+				},
+			},
+		}},
+	}
+	relationUnits2 := params.RelationUnits{RelationUnits: []params.RelationUnit{
+		{Relation: "relation-ntp.nrpe-external-master#nrpe.external-master", Unit: "unit-nrpe-0"},
+	}}
+	relationResults2 := params.RelationResults{
+		Results: []params.RelationResult{{
+			Id:               2,
+			Key:              "ntp:nrpe-external-master nrpe:external-master",
+			Life:             params.Alive,
+			OtherApplication: "ntp",
+			Endpoint: multiwatcher.Endpoint{
+				ApplicationName: "nrpe",
+				Relation: multiwatcher.CharmRelation{
+					Name:      "external-master",
+					Role:      string(charm.RoleRequirer),
+					Interface: "nrpe-external-master",
+					Scope:     "container",
+				},
+			},
+		}},
+	}
+
+	return []apiCall{
+		uniterAPICall("Life", nrpeUnitEntity, params.LifeResults{Results: []params.LifeResult{{Life: params.Alive}}}, nil),
+		uniterAPICall("GetPrincipal", nrpeUnitEntity, params.StringBoolResults{Results: []params.StringBoolResult{{Result: "unit-wordpress-0", Ok: true}}}, nil),
+		uniterAPICall("JoinedRelations", nrpeUnitEntity, joinedRelationsResults, nil),
+		uniterAPICall("Relation", relationUnits1, relationResults1, nil),
+		uniterAPICall("Relation", relationUnits2, relationResults2, nil),
+		uniterAPICall("Relation", relationUnits1, relationResults1, nil),
+		uniterAPICall("Watch", nrpeUnitEntity, params.NotifyWatchResults{Results: []params.NotifyWatchResult{{NotifyWatcherId: "1"}}}, nil),
+		uniterAPICall("EnterScope", relationUnits1, noErrorResult, nil),
+		uniterAPICall("Relation", relationUnits2, relationResults2, nil),
+		uniterAPICall("Watch", nrpeUnitEntity, params.NotifyWatchResults{Results: []params.NotifyWatchResult{{NotifyWatcherId: "2"}}}, nil),
+		uniterAPICall("EnterScope", relationUnits2, noErrorResult, nil),
+	}
+}
+
+func (s *relationsSuite) TestSubSubPrincipalRelationDyingDestroysUnit(c *gc.C) {
+	// When two subordinate units are related on a principal unit's
+	// machine, the sub-sub relation shouldn't keep them alive if the
+	// relation to the principal dies.
+	var numCalls int32
+	apiCalls := subSubRelationAPICalls()
+	callsBeforeDestroy := int32(len(apiCalls))
+	callsAfterDestroy := callsBeforeDestroy + 1
+	// This should only be called once the relation to the
+	// principal app is destroyed.
+	apiCalls = append(apiCalls, uniterAPICall("Destroy", nrpeUnitEntity, noErrorResult, nil))
+	apiCaller := mockAPICaller(c, &numCalls, apiCalls...)
+
+	st := uniter.NewState(apiCaller, nrpeUnitTag)
+	r, err := relation.NewRelations(st, nrpeUnitTag, s.stateDir, s.relationsDir, make(chan struct{}))
+	c.Assert(err, jc.ErrorIsNil)
+	assertNumCalls(c, &numCalls, callsBeforeDestroy)
+
+	// So now we have a relations object with two relations, one to
+	// wordpress and one to ntp. We want to ensure that if the
+	// relation to wordpress changes to Dying, the unit is destroyed,
+	// even if the ntp relation is still going strong.
+	localState := resolver.LocalState{
+		State: operation.State{
+			Kind: operation.Continue,
+		},
+	}
+
+	remoteState := remotestate.Snapshot{
+		Relations: map[int]remotestate.RelationSnapshot{
+			1: remotestate.RelationSnapshot{
+				Life: params.Dying,
+				Members: map[string]int64{
+					"wordpress/0": 1,
+				},
+			},
+			2: remotestate.RelationSnapshot{
+				Life: params.Alive,
+				Members: map[string]int64{
+					"ntp/0": 1,
+				},
+			},
+		},
+	}
+
+	rr := relation.NewRelationsResolver(r)
+	_, err = rr.NextOp(localState, remoteState, &mockOperations{})
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Check that we've made the destroy unit call.
+	assertNumCalls(c, &numCalls, callsAfterDestroy)
+}
+
+func (s *relationsSuite) TestSubSubOtherRelationDyingNotDestroyed(c *gc.C) {
+	var numCalls int32
+	apiCalls := subSubRelationAPICalls()
+	// Sanity check: there shouldn't be a destroy at the end.
+	c.Assert(apiCalls[len(apiCalls)-1].request, gc.Not(gc.Equals), "Destroy")
+
+	expectedCalls := int32(len(apiCalls))
+	apiCaller := mockAPICaller(c, &numCalls, apiCalls...)
+
+	st := uniter.NewState(apiCaller, nrpeUnitTag)
+	r, err := relation.NewRelations(st, nrpeUnitTag, s.stateDir, s.relationsDir, make(chan struct{}))
+	c.Assert(err, jc.ErrorIsNil)
+	assertNumCalls(c, &numCalls, expectedCalls)
+
+	// So now we have a relations object with two relations, one to
+	// wordpress and one to ntp. We want to ensure that if the
+	// relation to ntp changes to Dying, the unit isn't destroyed,
+	// since it's kept alive by the principal relation.
+	localState := resolver.LocalState{
+		State: operation.State{
+			Kind: operation.Continue,
+		},
+	}
+
+	remoteState := remotestate.Snapshot{
+		Relations: map[int]remotestate.RelationSnapshot{
+			1: remotestate.RelationSnapshot{
+				Life: params.Alive,
+				Members: map[string]int64{
+					"wordpress/0": 1,
+				},
+			},
+			2: remotestate.RelationSnapshot{
+				Life: params.Dying,
+				Members: map[string]int64{
+					"ntp/0": 1,
+				},
+			},
+		},
+	}
+
+	rr := relation.NewRelationsResolver(r)
+	_, err = rr.NextOp(localState, remoteState, &mockOperations{})
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Check that we didn't try to make a destroy call (the apiCaller
+	// should panic in that case anyway).
+	assertNumCalls(c, &numCalls, expectedCalls)
 }


### PR DESCRIPTION
## Description of change

Relating two subordinates and then trying to remove the principal application would leave the units of the application in _terminating_ state. The principal units wouldn't be cleaned up until their subordinates were, and they wouldn't die because the sub-sub relation would keep them alive. For example, if you had this configuration:
```
mysql/0
    ntp/0
    nrpe/0
```
...and nrpe and ntp were also related, then `mysql/0` wouldn't get removed if you removed `mysql`.

Fix this by making the subordinate units only consider the relations to their principal when checking whether they should destroy themselves.

## QA steps

* Deploy the following bundle:
```
series: xenial
machines:
  '0':
    series: xenial
services:
  min:
    charm: cs:ubuntu-10
    num_units: 1
    to:
      - "0"
  nrpe:
    charm: cs:nrpe-23
  ntp:
    charm: cs:ntp-18
relations:
- - min:juju-info
  - nrpe:general-info
- - ntp:nrpe-external-master
  - nrpe:nrpe-external-master
- - ntp:juju-info
  - min:juju-info
```
* Wait for the three units to become idle.
* Remove the min application.
* It should remove cleanly.

## Bug reference
Fixes part of https://bugs.launchpad.net/juju/+bug/1702636