### PR TITLE
apiserver: Replace ForModel with pool in ModelStatus

### DIFF
--- a/apiserver/common/modelstatus_test.go
+++ b/apiserver/common/modelstatus_test.go
@@ -26,6 +26,7 @@ type modelStatusSuite struct {
 	controller *controller.ControllerAPI
 	resources  *common.Resources
 	authorizer apiservertesting.FakeAuthorizer
+	pool       *state.StatePool
 }
 
 var _ = gc.Suite(&modelStatusSuite{})
@@ -45,11 +46,15 @@ func (s *modelStatusSuite) SetUpTest(c *gc.C) {
 		AdminTag: s.Owner,
 	}
 
+	s.pool = state.NewStatePool(s.State)
+	s.AddCleanup(func(*gc.C) { s.pool.Close() })
+
 	controller, err := controller.NewControllerAPI(
 		facadetest.Context{
 			State_:     s.State,
 			Resources_: s.resources,
 			Auth_:      s.authorizer,
+			StatePool_: s.pool,
 		})
 	c.Assert(err, jc.ErrorIsNil)
 	s.controller = controller
@@ -92,6 +97,7 @@ func (s *modelStatusSuite) TestModelStatusOwnerAllowed(c *gc.C) {
 			State_:     s.State,
 			Resources_: s.resources,
 			Auth_:      anAuthoriser,
+			StatePool_: s.pool,
 		})
 	c.Assert(err, jc.ErrorIsNil)
 

--- a/apiserver/controller/controller.go
+++ b/apiserver/controller/controller.go
@@ -79,13 +79,18 @@ func NewControllerAPI(ctx facade.Context) (*ControllerAPI, error) {
 	environConfigGetter := stateenvirons.EnvironConfigGetter{st}
 	return &ControllerAPI{
 		ControllerConfigAPI: common.NewControllerConfig(st),
-		ModelStatusAPI:      common.NewModelStatusAPI(common.NewModelManagerBackend(st), authorizer, apiUser),
-		CloudSpecAPI:        cloudspec.NewCloudSpec(environConfigGetter.CloudSpec, common.AuthFuncForTag(st.ModelTag())),
-		state:               st,
-		statePool:           ctx.StatePool(),
-		authorizer:          authorizer,
-		apiUser:             apiUser,
-		resources:           ctx.Resources(),
+		ModelStatusAPI: common.NewModelStatusAPI(
+			common.NewModelManagerBackend(st),
+			common.NewBackendPool(ctx.StatePool()),
+			authorizer,
+			apiUser,
+		),
+		CloudSpecAPI: cloudspec.NewCloudSpec(environConfigGetter.CloudSpec, common.AuthFuncForTag(st.ModelTag())),
+		state:        st,
+		statePool:    ctx.StatePool(),
+		authorizer:   authorizer,
+		apiUser:      apiUser,
+		resources:    ctx.Resources(),
 	}, nil
 }
 

--- a/apiserver/modelmanager/modelmanager.go
+++ b/apiserver/modelmanager/modelmanager.go
@@ -61,7 +61,7 @@ type ModelManagerV2 interface {
 type ModelManagerAPI struct {
 	*common.ModelStatusAPI
 	state       common.ModelManagerBackend
-	pool        StatePool
+	pool        common.BackendPool
 	check       *common.BlockChecker
 	authorizer  facade.Authorizer
 	toolsFinder *common.ToolsFinder
@@ -89,7 +89,7 @@ func NewFacadeV3(ctx facade.Context) (*ModelManagerAPI, error) {
 
 	return NewModelManagerAPI(
 		common.NewModelManagerBackend(st),
-		&statePool{pool}, configGetter, auth)
+		common.NewBackendPool(pool), configGetter, auth)
 }
 
 // NewFacade is used for API registration.
@@ -101,30 +101,11 @@ func NewFacadeV2(ctx facade.Context) (*ModelManagerAPIV2, error) {
 	return &ModelManagerAPIV2{v3}, nil
 }
 
-// StatePool provides access to a pool of states.
-type StatePool interface {
-	Get(modelUUID string) (common.ModelManagerBackend, func(), error)
-}
-
-// TODO: move statePool shim into common package.
-type statePool struct {
-	pool *state.StatePool
-}
-
-// Get implements StatePool.
-func (p *statePool) Get(modelUUID string) (common.ModelManagerBackend, func(), error) {
-	st, releaser, err := p.pool.Get(modelUUID)
-	closer := func() {
-		releaser()
-	}
-	return common.NewModelManagerBackend(st), closer, err
-}
-
 // NewModelManagerAPI creates a new api server endpoint for managing
 // models.
 func NewModelManagerAPI(
 	st common.ModelManagerBackend,
-	statePool StatePool,
+	pool common.BackendPool,
 	configGetter environs.EnvironConfigGetter,
 	authorizer facade.Authorizer,
 ) (*ModelManagerAPI, error) {
@@ -142,9 +123,9 @@ func NewModelManagerAPI(
 	}
 	urlGetter := common.NewToolsURLGetter(st.ModelUUID(), st)
 	return &ModelManagerAPI{
-		ModelStatusAPI: common.NewModelStatusAPI(st, authorizer, apiUser),
+		ModelStatusAPI: common.NewModelStatusAPI(st, pool, authorizer, apiUser),
 		state:          st,
-		pool:           statePool,
+		pool:           pool,
 		check:          common.NewBlockChecker(st),
 		authorizer:     authorizer,
 		toolsFinder:    common.NewToolsFinder(configGetter, st, urlGetter),


### PR DESCRIPTION
## Description of change
Having status use an existing state instead of starting a fresh one (with the attendant workers) is more efficient.

## QA steps
Bootstrap and create a few models. Verify that status works.

## Bug reference
Part of https://bugs.launchpad.net/juju/+bug/1698702