### PR TITLE
Look for offer model uuid in local controller first

### DIFF
--- a/apiserver/common/controllerconfig_test.go
+++ b/apiserver/common/controllerconfig_test.go
@@ -7,12 +7,17 @@ import (
 	"fmt"
 
 	jc "github.com/juju/testing/checkers"
+	"github.com/juju/utils"
 	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/errors"
 	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/controller"
+	"github.com/juju/juju/core/crossmodel"
 	"github.com/juju/juju/environs/config"
+	jujutesting "github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/provider/dummy"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/testing"
@@ -42,8 +47,11 @@ func (f *fakeControllerAccessor) ControllerConfig() (controller.Config, error) {
 	}, nil
 }
 
-func (f *fakeControllerAccessor) ControllerInfo(modelUUID string) (state.ExternalController, error) {
-	return nil, errors.NotImplementedf("ControllerInfo")
+func (f *fakeControllerAccessor) ControllerInfo(modelUUID string) ([]string, string, error) {
+	if modelUUID != testing.ModelTag.Id() {
+		return nil, "", errors.New("wrong model")
+	}
+	return []string{"192.168.1.1:17070"}, testing.CACert, nil
 }
 
 func (s *controllerConfigSuite) TearDownTest(c *gc.C) {
@@ -73,4 +81,64 @@ func (*controllerConfigSuite) TestControllerConfigFetchError(c *gc.C) {
 	)
 	_, err := cc.ControllerConfig()
 	c.Assert(err, gc.ErrorMatches, "pow")
+}
+
+func (*controllerConfigSuite) TestControllerInfo(c *gc.C) {
+	cc := common.NewControllerConfig(
+		&fakeControllerAccessor{},
+	)
+	results, err := cc.ControllerAPIInfoForModels(params.Entities{
+		Entities: []params.Entity{{Tag: testing.ModelTag.String()}}})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(results.Results, gc.HasLen, 1)
+	c.Assert(results.Results[0].Addresses, gc.DeepEquals, []string{"192.168.1.1:17070"})
+	c.Assert(results.Results[0].CACert, gc.Equals, testing.CACert)
+}
+
+type controllerInfoSuite struct {
+	jujutesting.JujuConnSuite
+
+	localModel *state.State
+}
+
+var _ = gc.Suite(&controllerInfoSuite{})
+
+func (s *controllerInfoSuite) SetUpTest(c *gc.C) {
+	s.JujuConnSuite.SetUpTest(c)
+	s.localModel = s.Factory.MakeModel(c, nil)
+	s.AddCleanup(func(*gc.C) {
+		s.localModel.Close()
+	})
+}
+
+func (s *controllerInfoSuite) TestControllerInfoLocalModel(c *gc.C) {
+	cc := common.NewStateControllerConfig(s.State)
+	results, err := cc.ControllerAPIInfoForModels(params.Entities{
+		Entities: []params.Entity{{Tag: s.localModel.ModelTag().String()}}})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(results.Results, gc.HasLen, 1)
+	apiAddr, err := s.State.APIHostPorts()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(results.Results[0].Addresses, gc.HasLen, 1)
+	c.Assert(results.Results[0].Addresses[0], gc.Equals, apiAddr[0][0].String())
+	c.Assert(results.Results[0].CACert, gc.Equals, s.State.CACert())
+}
+
+func (s *controllerInfoSuite) TestControllerInfoExternalModel(c *gc.C) {
+	ec := state.NewExternalControllers(s.State)
+	modelUUID := utils.MustNewUUID().String()
+	info := crossmodel.ControllerInfo{
+		ControllerTag: testing.ControllerTag,
+		Addrs:         []string{"192.168.1.1:12345"},
+		CACert:        testing.CACert,
+	}
+	_, err := ec.Save(info, modelUUID)
+	c.Assert(err, jc.ErrorIsNil)
+	cc := common.NewStateControllerConfig(s.State)
+	results, err := cc.ControllerAPIInfoForModels(params.Entities{
+		Entities: []params.Entity{{Tag: names.NewModelTag(modelUUID).String()}}})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(results.Results, gc.HasLen, 1)
+	c.Assert(results.Results[0].Addresses, gc.DeepEquals, info.Addrs)
+	c.Assert(results.Results[0].CACert, gc.Equals, info.CACert)
 }

--- a/apiserver/firewaller/mock_test.go
+++ b/apiserver/firewaller/mock_test.go
@@ -72,11 +72,11 @@ func (st *mockState) ControllerConfig() (controller.Config, error) {
 	return nil, errors.NotImplementedf("ControllerConfig")
 }
 
-func (st *mockState) ControllerInfo(modelUUID string) (state.ExternalController, error) {
+func (st *mockState) ControllerInfo(modelUUID string) ([]string, string, error) {
 	if info, ok := st.controllerInfo[modelUUID]; !ok {
-		return nil, errors.NotFoundf("controller info for %v", modelUUID)
+		return nil, "", errors.NotFoundf("controller info for %v", modelUUID)
 	} else {
-		return info, nil
+		return info.ControllerInfo().Addrs, info.ControllerInfo().CACert, nil
 	}
 }
 

--- a/apiserver/remoterelations/mock_test.go
+++ b/apiserver/remoterelations/mock_test.go
@@ -53,11 +53,11 @@ func (st *mockState) ControllerConfig() (controller.Config, error) {
 	return nil, errors.NotImplementedf("ControllerConfig")
 }
 
-func (st *mockState) ControllerInfo(modelUUID string) (state.ExternalController, error) {
+func (st *mockState) ControllerInfo(modelUUID string) ([]string, string, error) {
 	if info, ok := st.controllerInfo[modelUUID]; !ok {
-		return nil, errors.NotFoundf("controller info for %v", modelUUID)
+		return nil, "", errors.NotFoundf("controller info for %v", modelUUID)
 	} else {
-		return info, nil
+		return info.ControllerInfo().Addrs, info.ControllerInfo().CACert, nil
 	}
 }
 

--- a/state/interface.go
+++ b/state/interface.go
@@ -103,7 +103,7 @@ type ModelAccessor interface {
 // access controller information.
 type ControllerAccessor interface {
 	ControllerConfig() (controller.Config, error)
-	ControllerInfo(modelUUID string) (ExternalController, error)
+	ControllerInfo(modelUUID string) (addrs []string, CACert string, _ error)
 }
 
 // UnitsWatcher defines the methods needed to retrieve an entity (a


### PR DESCRIPTION
## Description of change

When setting up a cross model relation, the api address of the host controller needs to be determined. This PR ensures that we first look for the model in the local controller before looking for any external controllers.

## QA steps

Deploy a cmr scenario with just one controller.

