### PR TITLE
apiserver/...: fix several auth issues

### DIFF
--- a/api/keymanager/client_test.go
+++ b/api/keymanager/client_test.go
@@ -18,7 +18,6 @@ import (
 	"github.com/juju/juju/apiserver/params"
 	jujutesting "github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/rpc"
-	"github.com/juju/juju/state"
 )
 
 type keymanagerSuite struct {
@@ -93,31 +92,12 @@ func (s *keymanagerSuite) TestAddKeys(c *gc.C) {
 	s.assertModelKeys(c, append([]string{key1}, newKeys[:2]...))
 }
 
-func (s *keymanagerSuite) TestAddSystemKey(c *gc.C) {
+func (s *keymanagerSuite) TestAddSystemKeyForbidden(c *gc.C) {
 	key1 := sshtesting.ValidKeyOne.Key + " user@host"
 	s.setAuthorisedKeys(c, key1)
 
-	apiState, _ := s.OpenAPIAsNewMachine(c, state.JobManageModel)
-	keyManager := keymanager.NewClient(apiState)
-	defer keyManager.Close()
 	newKey := sshtesting.ValidKeyTwo.Key
-	errResults, err := keyManager.AddKeys("juju-system-key", newKey)
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(errResults, gc.DeepEquals, []params.ErrorResult{
-		{Error: nil},
-	})
-	s.assertModelKeys(c, []string{key1, newKey})
-}
-
-func (s *keymanagerSuite) TestAddSystemKeyWrongUser(c *gc.C) {
-	key1 := sshtesting.ValidKeyOne.Key + " user@host"
-	s.setAuthorisedKeys(c, key1)
-
-	apiState, _ := s.OpenAPIAsNewMachine(c, state.JobManageModel)
-	keyManager := keymanager.NewClient(apiState)
-	defer keyManager.Close()
-	newKey := sshtesting.ValidKeyTwo.Key
-	_, err := keyManager.AddKeys("some-user", newKey)
+	_, err := s.keymanager.AddKeys("juju-system-key", newKey)
 	c.Assert(errors.Cause(err), gc.DeepEquals, &rpc.RequestError{
 		Message: "permission denied",
 		Code:    "unauthorized access",

--- a/apiserver/charmrevisionupdater/updater.go
+++ b/apiserver/charmrevisionupdater/updater.go
@@ -37,7 +37,7 @@ func NewCharmRevisionUpdaterAPI(
 	resources facade.Resources,
 	authorizer facade.Authorizer,
 ) (*CharmRevisionUpdaterAPI, error) {
-	if !authorizer.AuthMachineAgent() && !authorizer.AuthController() {
+	if !authorizer.AuthController() {
 		return nil, common.ErrPerm
 	}
 	return &CharmRevisionUpdaterAPI{

--- a/apiserver/charmrevisionupdater/updater_test.go
+++ b/apiserver/charmrevisionupdater/updater_test.go
@@ -13,6 +13,7 @@ import (
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/charm.v6-unstable"
 	"gopkg.in/juju/charmrepo.v2-unstable"
+	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/apiserver/charmrevisionupdater"
 	"github.com/juju/juju/apiserver/charmrevisionupdater/testing"
@@ -52,6 +53,7 @@ func (s *charmVersionSuite) SetUpTest(c *gc.C) {
 	s.AddCleanup(func(_ *gc.C) { s.resources.StopAll() })
 	s.authoriser = apiservertesting.FakeAuthorizer{
 		Controller: true,
+		Tag:        names.NewMachineTag("99"),
 	}
 	var err error
 	s.charmrevisionupdater, err = charmrevisionupdater.NewCharmRevisionUpdaterAPI(s.State, s.resources, s.authoriser)

--- a/apiserver/highavailability/highavailability.go
+++ b/apiserver/highavailability/highavailability.go
@@ -39,8 +39,8 @@ var _ HighAvailability = (*HighAvailabilityAPI)(nil)
 
 // NewHighAvailabilityAPI creates a new server-side highavailability API end point.
 func NewHighAvailabilityAPI(st *state.State, resources facade.Resources, authorizer facade.Authorizer) (*HighAvailabilityAPI, error) {
-	// Only clients and model managers can access the high availability facade.
-	if !authorizer.AuthClient() && !authorizer.AuthController() {
+	// Only clients can access the high availability facade.
+	if !authorizer.AuthClient() {
 		return nil, common.ErrPerm
 	}
 	return &HighAvailabilityAPI{

--- a/apiserver/keymanager/keymanager_test.go
+++ b/apiserver/keymanager/keymanager_test.go
@@ -58,28 +58,24 @@ func (s *keyManagerSuite) TestNewKeyManagerAPIAcceptsClient(c *gc.C) {
 	c.Assert(endPoint, gc.NotNil)
 }
 
-func (s *keyManagerSuite) TestNewKeyManagerAPIAcceptsController(c *gc.C) {
-	anAuthoriser := s.authoriser
-	anAuthoriser.Controller = true
-	endPoint, err := keymanager.NewKeyManagerAPI(s.State, s.resources, anAuthoriser)
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(endPoint, gc.NotNil)
+func (s *keyManagerSuite) TestNewKeyManagerAPIRefusesController(c *gc.C) {
+	s.testNewKeyManagerAPIRefuses(c, names.NewMachineTag("0"), true)
 }
 
-func (s *keyManagerSuite) TestNewKeyManagerAPIRefusesNonClient(c *gc.C) {
-	anAuthoriser := s.authoriser
-	anAuthoriser.Tag = names.NewUnitTag("mysql/0")
-	anAuthoriser.Controller = false
-	endPoint, err := keymanager.NewKeyManagerAPI(s.State, s.resources, anAuthoriser)
-	c.Assert(endPoint, gc.IsNil)
-	c.Assert(err, gc.ErrorMatches, "permission denied")
+func (s *keyManagerSuite) TestNewKeyManagerAPIRefusesUnit(c *gc.C) {
+	s.testNewKeyManagerAPIRefuses(c, names.NewUnitTag("mysql/0"), false)
 }
 
-func (s *keyManagerSuite) TestNewKeyManagerAPIRefusesNonController(c *gc.C) {
-	anAuthoriser := s.authoriser
-	anAuthoriser.Tag = names.NewMachineTag("99")
-	anAuthoriser.Controller = false
-	endPoint, err := keymanager.NewKeyManagerAPI(s.State, s.resources, anAuthoriser)
+func (s *keyManagerSuite) TestNewKeyManagerAPIRefusesMachine(c *gc.C) {
+	s.testNewKeyManagerAPIRefuses(c, names.NewMachineTag("99"), false)
+}
+
+func (s *keyManagerSuite) testNewKeyManagerAPIRefuses(c *gc.C, tag names.Tag, controller bool) {
+	auth := apiservertesting.FakeAuthorizer{
+		Tag:        tag,
+		Controller: controller,
+	}
+	endPoint, err := keymanager.NewKeyManagerAPI(s.State, s.resources, auth)
 	c.Assert(endPoint, gc.IsNil)
 	c.Assert(err, gc.ErrorMatches, "permission denied")
 }
@@ -138,7 +134,7 @@ func (s *keyManagerSuite) TestListKeysHidesJujuInternal(c *gc.C) {
 	})
 }
 
-func (s *keyManagerSuite) TestListJujuSystemKeyAsUser(c *gc.C) {
+func (s *keyManagerSuite) TestListJujuSystemKey(c *gc.C) {
 	anAuthoriser := s.authoriser
 	anAuthoriser.Tag = names.NewUserTag("fred")
 	var err error
@@ -252,57 +248,7 @@ func (s *keyManagerSuite) TestBlockAddKeys(c *gc.C) {
 	s.assertModelKeys(c, initialKeys)
 }
 
-func (s *keyManagerSuite) TestAddJujuSystemKeyAsController(c *gc.C) {
-	anAuthoriser := s.authoriser
-	anAuthoriser.Controller = true
-	anAuthoriser.Tag = names.NewMachineTag("0")
-	var err error
-	s.keymanager, err = keymanager.NewKeyManagerAPI(s.State, s.resources, anAuthoriser)
-	c.Assert(err, jc.ErrorIsNil)
-	key1 := sshtesting.ValidKeyOne.Key + " user@host"
-	key2 := sshtesting.ValidKeyTwo.Key
-	initialKeys := []string{key1, key2}
-	s.setAuthorisedKeys(c, strings.Join(initialKeys, "\n"))
-
-	newKey := sshtesting.ValidKeyThree.Key + " juju-system-key"
-	args := params.ModifyUserSSHKeys{
-		User: "juju-system-key",
-		Keys: []string{newKey},
-	}
-	results, err := s.keymanager.AddKeys(args)
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(results, gc.DeepEquals, params.ErrorResults{
-		Results: []params.ErrorResult{
-			{Error: nil},
-		},
-	})
-	s.assertModelKeys(c, append(initialKeys, newKey))
-}
-
-func (s *keyManagerSuite) TestAddUserKeyAsController(c *gc.C) {
-	anAuthoriser := s.authoriser
-	anAuthoriser.Tag = names.NewMachineTag("controller")
-	anAuthoriser.Controller = true
-	var err error
-	s.keymanager, err = keymanager.NewKeyManagerAPI(s.State, s.resources, anAuthoriser)
-	c.Assert(err, jc.ErrorIsNil)
-	key1 := sshtesting.ValidKeyOne.Key + " user@host"
-	key2 := sshtesting.ValidKeyTwo.Key
-	initialKeys := []string{key1, key2}
-	s.setAuthorisedKeys(c, strings.Join(initialKeys, "\n"))
-
-	newKey := sshtesting.ValidKeyThree.Key + " some-user"
-	args := params.ModifyUserSSHKeys{
-		User: "some-user",
-		Keys: []string{newKey},
-	}
-	_, err = s.keymanager.AddKeys(args)
-	c.Assert(err, gc.ErrorMatches, "permission denied")
-	c.Assert(params.ErrCode(err), gc.Equals, params.CodeUnauthorized)
-	s.assertModelKeys(c, initialKeys)
-}
-
-func (s *keyManagerSuite) TestAddJujuSystemKeyAsUser(c *gc.C) {
+func (s *keyManagerSuite) TestAddJujuSystemKey(c *gc.C) {
 	anAuthoriser := s.authoriser
 	anAuthoriser.Tag = names.NewUserTag("fred")
 	var err error

--- a/apiserver/logfwd/lastsent.go
+++ b/apiserver/logfwd/lastsent.go
@@ -46,7 +46,7 @@ type LogForwardingAPI struct {
 
 // NewLogForwardingAPI creates a new server-side logger API end point.
 func NewLogForwardingAPI(st LogForwardingState, auth facade.Authorizer) (*LogForwardingAPI, error) {
-	if !auth.AuthMachineAgent() { // the controller's machine agent
+	if !auth.AuthController() {
 		return nil, common.ErrPerm
 	}
 	api := &LogForwardingAPI{

--- a/apiserver/logfwd/lastsent_test.go
+++ b/apiserver/logfwd/lastsent_test.go
@@ -22,7 +22,6 @@ type LastSentSuite struct {
 
 	stub       *testing.Stub
 	state      *stubState
-	machineTag names.MachineTag
 	authorizer apiservertesting.FakeAuthorizer
 }
 
@@ -33,16 +32,26 @@ func (s *LastSentSuite) SetUpTest(c *gc.C) {
 
 	s.stub = &testing.Stub{}
 	s.state = &stubState{stub: s.stub}
-	s.machineTag = names.NewMachineTag("99")
-	// The default auth is as the machine agent
 	s.authorizer = apiservertesting.FakeAuthorizer{
-		Tag: s.machineTag,
+		Tag:        names.NewMachineTag("99"),
+		Controller: true,
 	}
 }
 
 func (s *LastSentSuite) TestAuthRefusesUser(c *gc.C) {
-	anAuthorizer := s.authorizer
-	anAuthorizer.Tag = names.NewUserTag("bob")
+	anAuthorizer := apiservertesting.FakeAuthorizer{
+		Tag: names.NewUserTag("bob"),
+	}
+
+	_, err := logfwd.NewLogForwardingAPI(s.state, anAuthorizer)
+
+	c.Check(err, gc.ErrorMatches, "permission denied")
+}
+
+func (s *LastSentSuite) TestAuthRefusesNonController(c *gc.C) {
+	anAuthorizer := apiservertesting.FakeAuthorizer{
+		Tag: names.NewMachineTag("99"),
+	}
 
 	_, err := logfwd.NewLogForwardingAPI(s.state, anAuthorizer)
 

--- a/apiserver/metricsmanager/metricsmanager.go
+++ b/apiserver/metricsmanager/metricsmanager.go
@@ -65,7 +65,7 @@ func NewMetricsManagerAPI(
 	authorizer facade.Authorizer,
 	clock clock.Clock,
 ) (*MetricsManagerAPI, error) {
-	if !(authorizer.AuthMachineAgent() && authorizer.AuthController()) {
+	if !authorizer.AuthController() {
 		return nil, common.ErrPerm
 	}
 

--- a/apiserver/metricsmanager/metricsmanager_test.go
+++ b/apiserver/metricsmanager/metricsmanager_test.go
@@ -49,14 +49,14 @@ func (s *metricsManagerSuite) SetUpTest(c *gc.C) {
 	s.unit = s.Factory.MakeUnit(c, &factory.UnitParams{Application: meteredService, SetCharmURL: true})
 }
 
-func (s *metricsManagerSuite) TestNewMetricsManagerAPIRefusesNonMachine(c *gc.C) {
+func (s *metricsManagerSuite) TestNewMetricsManagerAPIRefusesNonController(c *gc.C) {
 	tests := []struct {
 		tag            names.Tag
 		environManager bool
 		expectedError  string
 	}{
-		{names.NewUnitTag("mysql/0"), true, "permission denied"},
-		{names.NewLocalUserTag("admin"), true, "permission denied"},
+		{names.NewUnitTag("mysql/0"), false, "permission denied"},
+		{names.NewLocalUserTag("admin"), false, "permission denied"},
 		{names.NewMachineTag("0"), false, "permission denied"},
 		{names.NewMachineTag("0"), true, ""},
 	}

--- a/apiserver/payloads/facade.go
+++ b/apiserver/payloads/facade.go
@@ -6,6 +6,7 @@ package payloads
 import (
 	"github.com/juju/errors"
 
+	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/payload"
@@ -15,6 +16,9 @@ import (
 
 // NewFacade provides the signature required for facade registration.
 func NewFacade(st *state.State, resources facade.Resources, authorizer facade.Authorizer) (*API, error) {
+	if !authorizer.AuthClient() {
+		return nil, common.ErrPerm
+	}
 	backend, err := st.ModelPayloads()
 	if err != nil {
 		return nil, errors.Trace(err)

--- a/apiserver/undertaker/undertaker.go
+++ b/apiserver/undertaker/undertaker.go
@@ -27,7 +27,7 @@ func NewUndertakerAPI(st *state.State, resources facade.Resources, authorizer fa
 }
 
 func newUndertakerAPI(st State, resources facade.Resources, authorizer facade.Authorizer) (*UndertakerAPI, error) {
-	if !authorizer.AuthMachineAgent() || !authorizer.AuthController() {
+	if !authorizer.AuthController() {
 		return nil, common.ErrPerm
 	}
 	model, err := st.Model()

--- a/apiserver/undertaker/undertaker_test.go
+++ b/apiserver/undertaker/undertaker_test.go
@@ -40,15 +40,11 @@ func (s *undertakerSuite) setupStateAndAPI(c *gc.C, isSystem bool, envName strin
 }
 
 func (s *undertakerSuite) TestNoPerms(c *gc.C) {
-	for _, authorizer := range []apiservertesting.FakeAuthorizer{
-		{
-			Tag: names.NewMachineTag("0"),
-		},
-		{
-			Tag:        names.NewUserTag("bob"),
-			Controller: true,
-		},
-	} {
+	for _, authorizer := range []apiservertesting.FakeAuthorizer{{
+		Tag: names.NewMachineTag("0"),
+	}, {
+		Tag: names.NewUserTag("bob"),
+	}} {
 		st := newMockState(names.NewUserTag("admin"), "admin", true)
 		_, err := undertaker.NewUndertaker(
 			st,


### PR DESCRIPTION
## Description of change

Backport of auth issues found/fixed in
https://github.com/juju/juju/pull/7606.

- logfwd was using AuthMachineAgent, and should
  have used AuthController. It has been updated
  to use the latter.
- payloads had no auth at all; it has been updated
  to use AuthClient.
- metricsmanager and undertaker: redundant calls
  to AuthMachineAgent, when AuthController would
  do. Simplified.
- charmrevisionupdater: was allowing non-controller
  agents, now does not.
- keymanager and highavailability: both were allowing
  controller unnecessarily; dropped.

## QA steps

Run tests. Bootstrap.

## Documentation changes

None.

## Bug reference

None.