### PR TITLE
worker/modelupgrade: set model status

### DIFF
--- a/api/modelupgrader/modelupgrader.go
+++ b/api/modelupgrader/modelupgrader.go
@@ -11,6 +11,7 @@ import (
 	"github.com/juju/juju/api/base"
 	"github.com/juju/juju/api/common"
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/status"
 	"github.com/juju/juju/watcher"
 )
 
@@ -89,4 +90,18 @@ func (c *Client) SetModelEnvironVersion(tag names.ModelTag, v int) error {
 // changes to the environ version of the model with the specified tag.
 func (c *Client) WatchModelEnvironVersion(tag names.ModelTag) (watcher.NotifyWatcher, error) {
 	return common.Watch(c.facade, "WatchModelEnvironVersion", tag)
+}
+
+// SetModelStatus sets the status of a model.
+func (c *Client) SetModelStatus(tag names.ModelTag, status status.Status, info string, data map[string]interface{}) error {
+	var result params.ErrorResults
+	args := params.SetStatus{
+		Entities: []params.EntityStatusArgs{
+			{Tag: tag.String(), Status: status.String(), Info: info, Data: data},
+		},
+	}
+	if err := c.facade.FacadeCall("SetModelStatus", args, &result); err != nil {
+		return errors.Trace(err)
+	}
+	return result.OneError()
 }

--- a/status/status.go
+++ b/status/status.go
@@ -283,7 +283,8 @@ func ValidModelStatus(status Status) bool {
 	case
 		Available,
 		Busy,
-		Destroying:
+		Destroying,
+		Error:
 		return true
 	default:
 		return false


### PR DESCRIPTION
## Description of change

Set model status before and after upgrading the
model's environ. Allow the "error" status for
models, so that we can indicate that the model
requires attention (e.g. credentials are out of
date and need to be refreshed.)

## QA steps

1. juju bootstrap localhost
2. modify provider code, bumping provider version to 1, and introducing an environ upgrade step that fails
3. juju upgrade-juju -m controller
4. observe model status indicates a failure occurred
5. fix the provider code, re-run juju upgrade-juju -m controller
6. observe model status is back to normal

## Documentation changes

None.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1700451