### PR TITLE
provider/vsphere: add "datastore" model config

### DIFF
--- a/provider/vsphere/config.go
+++ b/provider/vsphere/config.go
@@ -13,20 +13,22 @@ import (
 // The vmware-specific config keys.
 const (
 	cfgExternalNetwork = "external-network"
+	cfgDatastore       = "datastore"
 )
 
 // configFields is the spec for each vmware config value's type.
 var (
 	configFields = schema.Fields{
 		cfgExternalNetwork: schema.String(),
+		cfgDatastore:       schema.String(),
 	}
-
-	requiredFields = []string{}
 
 	configDefaults = schema.Defaults{
 		cfgExternalNetwork: "",
+		cfgDatastore:       "",
 	}
 
+	configRequiredFields  = []string{}
 	configImmutableFields = []string{}
 )
 
@@ -46,16 +48,21 @@ func newConfig(cfg *config.Config) *environConfig {
 
 // newValidConfig builds a new environConfig from the provided Config
 // and returns it. The resulting config values are validated.
-func newValidConfig(cfg *config.Config, defaults map[string]interface{}) (*environConfig, error) {
+func newValidConfig(cfg *config.Config) (*environConfig, error) {
 	// Ensure that the provided config is valid.
 	if err := config.Validate(cfg, nil); err != nil {
 		return nil, errors.Trace(err)
 	}
 
 	// Apply the defaults and coerce/validate the custom config attrs.
-	validated, err := cfg.ValidateUnknownAttrs(configFields, defaults)
+	validated, err := cfg.ValidateUnknownAttrs(configFields, configDefaults)
 	if err != nil {
 		return nil, errors.Trace(err)
+	}
+	if validated[cfgDatastore] == "" {
+		// TODO(axw) ValidateUnknownAttrs should not be setting the
+		// empty value when the default is schema.Omit.
+		delete(validated, cfgDatastore)
 	}
 	validCfg, err := cfg.Apply(validated)
 	if err != nil {
@@ -77,10 +84,15 @@ func (c *environConfig) externalNetwork() string {
 	return c.attrs[cfgExternalNetwork].(string)
 }
 
+func (c *environConfig) datastore() string {
+	ds, _ := c.attrs[cfgDatastore].(string)
+	return ds
+}
+
 // validate checks vmware-specific config values.
 func (c environConfig) validate() error {
 	// All fields must be populated, even with just the default.
-	for _, field := range requiredFields {
+	for _, field := range configRequiredFields {
 		if c.attrs[field].(string) == "" {
 			return errors.Errorf("%s: must not be empty", field)
 		}
@@ -97,7 +109,7 @@ func (c *environConfig) update(cfg *config.Config) error {
 		return errors.Trace(err)
 	}
 
-	updates, err := newValidConfig(cfg, configDefaults)
+	updates, err := newValidConfig(cfg)
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/provider/vsphere/environ.go
+++ b/provider/vsphere/environ.go
@@ -36,7 +36,7 @@ func newEnviron(
 	cloud environs.CloudSpec,
 	cfg *config.Config,
 ) (*environ, error) {
-	ecfg, err := newValidConfig(cfg, configDefaults)
+	ecfg, err := newValidConfig(cfg)
 	if err != nil {
 		return nil, errors.Annotate(err, "invalid config")
 	}

--- a/provider/vsphere/environ_broker.go
+++ b/provider/vsphere/environ_broker.go
@@ -188,6 +188,7 @@ func (env *sessionEnviron) newRawInstance(
 		Metadata:               args.InstanceConfig.Tags,
 		Constraints:            cons,
 		ExternalNetwork:        externalNetwork,
+		Datastore:              env.ecfg.datastore(),
 		UpdateProgress:         updateProgress,
 		UpdateProgressInterval: updateProgressInterval,
 		Clock: clock.WallClock,

--- a/provider/vsphere/environ_broker_test.go
+++ b/provider/vsphere/environ_broker_test.go
@@ -370,6 +370,23 @@ func (s *environBrokerSuite) TestStartInstanceTriesToCreateInstanceInAllAvailabi
 	c.Assert(createVMArgs2.ComputeResource, jc.DeepEquals, s.client.computeResources[1])
 }
 
+func (s *environBrokerSuite) TestStartInstanceDatastore(c *gc.C) {
+	cfg := s.env.Config()
+	cfg, err := cfg.Apply(map[string]interface{}{
+		"datastore": "datastore0",
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	err = s.env.SetConfig(cfg)
+	c.Assert(err, jc.ErrorIsNil)
+
+	_, err = s.env.StartInstance(s.createStartInstanceArgs(c))
+	c.Assert(err, jc.ErrorIsNil)
+
+	call := s.client.Calls()[1]
+	createVMArgs := call.Args[1].(vsphereclient.CreateVirtualMachineParams)
+	c.Assert(createVMArgs.Datastore, gc.Equals, "datastore0")
+}
+
 func (s *environBrokerSuite) TestStopInstances(c *gc.C) {
 	err := s.env.StopInstances("vm-0", "vm-1")
 	c.Assert(err, jc.ErrorIsNil)

--- a/provider/vsphere/internal/vsphereclient/client_test.go
+++ b/provider/vsphere/internal/vsphereclient/client_test.go
@@ -203,6 +203,26 @@ func (s *clientSuite) SetUpTest(c *gc.C) {
 				},
 			},
 		}},
+		"FakeDatastore1": []types.ObjectContent{{
+			Obj: types.ManagedObjectReference{
+				Type:  "Datastore",
+				Value: "FakeDatastore1",
+			},
+			PropSet: []types.DynamicProperty{
+				{Name: "name", Val: "datastore1"},
+				{Name: "summary.accessible", Val: false},
+			},
+		}},
+		"FakeDatastore2": []types.ObjectContent{{
+			Obj: types.ManagedObjectReference{
+				Type:  "Datastore",
+				Value: "FakeDatastore2",
+			},
+			PropSet: []types.DynamicProperty{
+				{Name: "name", Val: "datastore2"},
+				{Name: "summary.accessible", Val: true},
+			},
+		}},
 	}
 
 	// Create an HTTP server to receive image uploads.

--- a/provider/vsphere/internal/vsphereclient/createvm_test.go
+++ b/provider/vsphere/internal/vsphereclient/createvm_test.go
@@ -21,14 +21,6 @@ import (
 )
 
 func (s *clientSuite) TestCreateVirtualMachine(c *gc.C) {
-	ovaDir := c.MkDir()
-	err := ioutil.WriteFile(
-		filepath.Join(ovaDir, "ubuntu-14.04-server-cloudimg-amd64.vmdk"),
-		[]byte("image-contents"),
-		0644,
-	)
-	c.Assert(err, jc.ErrorIsNil)
-
 	var statusUpdates []string
 	statusUpdatesCh := make(chan string, 3)
 	dequeueStatusUpdates := func() {
@@ -41,7 +33,8 @@ func (s *clientSuite) TestCreateVirtualMachine(c *gc.C) {
 		}
 	}
 
-	testClock := testing.NewClock(time.Time{})
+	args := baseCreateVirtualMachineParams(c)
+	testClock := args.Clock.(*testing.Clock)
 	s.onImageUpload = func(r *http.Request) {
 		dequeueStatusUpdates()
 
@@ -61,35 +54,13 @@ func (s *clientSuite) TestCreateVirtualMachine(c *gc.C) {
 		<-s.roundTripper.leaseProgress
 		s.onImageUpload = nil
 	}
+	args.UpdateProgress = func(status string) {
+		statusUpdatesCh <- status
+		statusUpdates = append(statusUpdates, status)
+	}
 
 	client := s.newFakeClient(&s.roundTripper, "dc0")
-	args := CreateVirtualMachineParams{
-		Name:     "vm-0",
-		Folder:   "foo",
-		OVADir:   ovaDir,
-		OVF:      "bar",
-		UserData: "baz",
-		ComputeResource: &mo.ComputeResource{
-			ResourcePool: &types.ManagedObjectReference{
-				Type:  "ResourcePool",
-				Value: "FakeResourcePool1",
-			},
-			Datastore: []types.ManagedObjectReference{{
-				Type:  "Datastore",
-				Value: "FakeDatastore1",
-			}},
-		},
-		Metadata:        map[string]string{"k": "v"},
-		Constraints:     constraints.Value{},
-		ExternalNetwork: "arpa",
-		UpdateProgress: func(status string) {
-			statusUpdatesCh <- status
-			statusUpdates = append(statusUpdates, status)
-		},
-		UpdateProgressInterval: time.Second,
-		Clock: testClock,
-	}
-	_, err = client.CreateVirtualMachine(context.Background(), args)
+	_, err := client.CreateVirtualMachine(context.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(statusUpdates, jc.DeepEquals, []string{
 		"creating import spec",
@@ -104,7 +75,11 @@ func (s *clientSuite) TestCreateVirtualMachine(c *gc.C) {
 	c.Assert(string(contents), gc.Equals, "image-contents")
 
 	s.roundTripper.CheckCalls(c, []testing.StubCall{
-		testing.StubCall{"CreateImportSpec", nil},
+		retrievePropertiesStubCall("FakeDatastore1", "FakeDatastore2"),
+		testing.StubCall{"CreateImportSpec", []interface{}{
+			"ovf-descriptor",
+			types.ManagedObjectReference{Type: "Datastore", Value: "FakeDatastore2"},
+		}},
 		retrievePropertiesStubCall("FakeRootFolder"),
 		retrievePropertiesStubCall("FakeRootFolder"),
 		retrievePropertiesStubCall("FakeDatacenter"),
@@ -124,4 +99,87 @@ func (s *clientSuite) TestCreateVirtualMachine(c *gc.C) {
 		testing.StubCall{"WaitForUpdatesEx", nil},
 		retrievePropertiesStubCall(""),
 	})
+}
+
+func (s *clientSuite) TestCreateVirtualMachineDatastoreSpecified(c *gc.C) {
+	args := baseCreateVirtualMachineParams(c)
+	args.Datastore = "datastore1"
+	args.ComputeResource.Datastore = []types.ManagedObjectReference{{
+		Type:  "Datastore",
+		Value: "FakeDatastore2",
+	}, {
+		Type:  "Datastore",
+		Value: "FakeDatastore1",
+	}}
+
+	client := s.newFakeClient(&s.roundTripper, "dc0")
+	_, err := client.CreateVirtualMachine(context.Background(), args)
+	c.Assert(err, jc.ErrorIsNil)
+
+	s.roundTripper.CheckCall(
+		c, 1, "CreateImportSpec", "ovf-descriptor",
+		types.ManagedObjectReference{Type: "Datastore", Value: "FakeDatastore1"},
+	)
+}
+
+func (s *clientSuite) TestCreateVirtualMachineDatastoreNotFound(c *gc.C) {
+	args := baseCreateVirtualMachineParams(c)
+	args.Datastore = "datastore3"
+
+	client := s.newFakeClient(&s.roundTripper, "dc0")
+	_, err := client.CreateVirtualMachine(context.Background(), args)
+	c.Assert(err, gc.ErrorMatches, `creating import spec: could not find datastore "datastore3"`)
+}
+
+func (s *clientSuite) TestCreateVirtualMachineDatastoreNoneAccessible(c *gc.C) {
+	args := baseCreateVirtualMachineParams(c)
+	args.ComputeResource.Datastore = []types.ManagedObjectReference{{
+		Type:  "Datastore",
+		Value: "FakeDatastore1",
+	}}
+
+	client := s.newFakeClient(&s.roundTripper, "dc0")
+	_, err := client.CreateVirtualMachine(context.Background(), args)
+	c.Assert(err, gc.ErrorMatches, "creating import spec: could not find an accessible datastore")
+}
+
+func baseCreateVirtualMachineParams(c *gc.C) CreateVirtualMachineParams {
+	ovaDir := makeOvaDir(c)
+	return CreateVirtualMachineParams{
+		Name:     "vm-0",
+		Folder:   "foo",
+		OVADir:   ovaDir,
+		OVF:      "ovf-descriptor",
+		UserData: "baz",
+		ComputeResource: &mo.ComputeResource{
+			ResourcePool: &types.ManagedObjectReference{
+				Type:  "ResourcePool",
+				Value: "FakeResourcePool1",
+			},
+			Datastore: []types.ManagedObjectReference{{
+				Type:  "Datastore",
+				Value: "FakeDatastore1",
+			}, {
+				Type:  "Datastore",
+				Value: "FakeDatastore2",
+			}},
+		},
+		Metadata:               map[string]string{"k": "v"},
+		Constraints:            constraints.Value{},
+		ExternalNetwork:        "arpa",
+		UpdateProgress:         func(status string) {},
+		UpdateProgressInterval: time.Second,
+		Clock: testing.NewClock(time.Time{}),
+	}
+}
+
+func makeOvaDir(c *gc.C) string {
+	ovaDir := c.MkDir()
+	err := ioutil.WriteFile(
+		filepath.Join(ovaDir, "ubuntu-14.04-server-cloudimg-amd64.vmdk"),
+		[]byte("image-contents"),
+		0644,
+	)
+	c.Assert(err, jc.ErrorIsNil)
+	return ovaDir
 }

--- a/provider/vsphere/internal/vsphereclient/mock_test.go
+++ b/provider/vsphere/internal/vsphereclient/mock_test.go
@@ -86,7 +86,8 @@ func (r *mockRoundTripper) RoundTrip(ctx context.Context, req, res soap.HasFault
 		r.MethodCall(r, "CreateFolder")
 		res.Res = &types.CreateFolderResponse{}
 	case *methods.CreateImportSpecBody:
-		r.MethodCall(r, "CreateImportSpec")
+		req := req.(*methods.CreateImportSpecBody).Req
+		r.MethodCall(r, "CreateImportSpec", req.OvfDescriptor, req.Datastore)
 		res.Res = &types.CreateImportSpecResponse{
 			types.OvfCreateImportSpecResult{
 				FileItem: []types.OvfFileItem{

--- a/provider/vsphere/provider.go
+++ b/provider/vsphere/provider.go
@@ -157,15 +157,14 @@ func (p *environProvider) PrepareConfig(args environs.PrepareConfigParams) (*con
 // Validate implements environs.EnvironProvider.
 func (*environProvider) Validate(cfg, old *config.Config) (valid *config.Config, err error) {
 	if old == nil {
-		ecfg, err := newValidConfig(cfg, configDefaults)
+		ecfg, err := newValidConfig(cfg)
 		if err != nil {
 			return nil, errors.Annotate(err, "invalid config")
 		}
 		return ecfg.Config, nil
 	}
 
-	// The defaults should be set already, so we pass nil.
-	ecfg, err := newValidConfig(old, nil)
+	ecfg, err := newValidConfig(old)
 	if err != nil {
 		return nil, errors.Annotate(err, "invalid base config")
 	}


### PR DESCRIPTION
## Description of change

Enable users to specify a datastore via
model config for vsphere models. If no
datastore is specified, use the first
datastore accessible to the host/cluster.

## QA steps

1. juju bootstrap vsphere --debug
(verify that Juju selects an accessible datastore, and bootstrap succeeds)

2. juju bootstrap vsphere --config datastore=\<name-of-accessible-datastore\>
(verify that Juju selects the specified datastore, and bootstrap succeeds)

3. juju bootstrap vsphere --config datastore=\<name-of-non-existent-datastore\>
(verify that bootstrap fails with a message about the datastore not being found)

## Documentation changes

Yes, we should document the new vsphere-specific "datastore" model config attribute. If specified, this configuration attribute identifies the datastore in which VMs will be stored. If it is not specified, Juju will select any datastore accessible to the VMWare host/cluster.

## Bug reference

Fixes https://bugs.launchpad.net/juju/+bug/1697460