### PR TITLE
Always try to dial local API first

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -796,16 +796,13 @@ func (c *configInternal) APIInfo() (*api.Info, bool) {
 		// loopback, and when/if this changes localhost should resolve
 		// to IPv6 loopback in any case (lp:1644009). Review.
 		localAPIAddr := net.JoinHostPort("localhost", strconv.Itoa(port))
-		addrInAddrs := false
+		newAddrs := []string{localAPIAddr}
 		for _, addr := range addrs {
-			if addr == localAPIAddr {
-				addrInAddrs = true
-				break
+			if addr != localAPIAddr {
+				newAddrs = append(newAddrs, addr)
 			}
 		}
-		if !addrInAddrs {
-			addrs = append(addrs, localAPIAddr)
-		}
+		addrs = newAddrs
 	}
 	return &api.Info{
 		Addrs:    addrs,

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -462,7 +462,7 @@ func (*suite) TestAPIInfoMissingAddress(c *gc.C) {
 	c.Assert(ok, jc.IsFalse)
 }
 
-func (*suite) TestAPIInfoAddsLocalhostWhenServingInfoPresent(c *gc.C) {
+func (*suite) TestAPIInfoPutsLocalhostFirstWhenServingInfoPresent(c *gc.C) {
 	attrParams := attributeParams
 	servingInfo := stateServingInfo()
 	conf, err := agent.NewStateMachineConfig(attrParams, servingInfo)
@@ -470,14 +470,19 @@ func (*suite) TestAPIInfoAddsLocalhostWhenServingInfoPresent(c *gc.C) {
 	apiinfo, ok := conf.APIInfo()
 	c.Assert(ok, jc.IsTrue)
 	c.Check(apiinfo.Addrs, gc.HasLen, len(attrParams.APIAddresses)+1)
-	localhostAddressFound := false
-	for _, eachAPIAddress := range apiinfo.Addrs {
-		if eachAPIAddress == "localhost:47" {
-			localhostAddressFound = true
-			break
-		}
-	}
-	c.Assert(localhostAddressFound, jc.IsTrue)
+	c.Check(apiinfo.Addrs[0], gc.Equals, "localhost:47")
+}
+
+func (*suite) TestAPIInfoMovesLocalhostFirstWhenServingInfoPresent(c *gc.C) {
+	attrParams := attributeParams
+	attrParams.APIAddresses = []string{"localhost:1235", "localhost:47"}
+	servingInfo := stateServingInfo()
+	conf, err := agent.NewStateMachineConfig(attrParams, servingInfo)
+	c.Assert(err, jc.ErrorIsNil)
+	apiinfo, ok := conf.APIInfo()
+	c.Assert(ok, jc.IsTrue)
+	c.Check(apiinfo.Addrs, gc.HasLen, len(attrParams.APIAddresses))
+	c.Check(apiinfo.Addrs[0], gc.Equals, "localhost:47")
 }
 
 func (*suite) TestMongoInfo(c *gc.C) {


### PR DESCRIPTION
## Description of change
When choosing IP to dial always try to dial localhost first, dialing other servers can cause problems (e.g. during upgrade, when dialing node is not yet upgraded and other nodes are doing upgrade)

## QA steps
Launch agent/ unit tests.

## Documentation changes
None

## Bug reference
https://bugs.launchpad.net/juju/+bug/1697956