### PR TITLE
for juju add-relation don't treat already exists as an error

### DIFF
--- a/cmd/juju/application/addrelation.go
+++ b/cmd/juju/application/addrelation.go
@@ -117,6 +117,12 @@ func (c *addRelationCommand) Run(ctx *cmd.Context) error {
 	if params.IsCodeUnauthorized(err) {
 		common.PermissionsMessage(ctx.Stderr, "add a relation")
 	}
+	if params.IsCodeAlreadyExists(err) {
+		// It's not a real error, mention about it, log it and move along
+		logger.Infof("%s", err)
+		ctx.Infof("%s", err)
+		err = nil
+	}
 	return block.ProcessBlockedError(err, block.BlockChange)
 }
 

--- a/featuretests/cmd_juju_relation_test.go
+++ b/featuretests/cmd_juju_relation_test.go
@@ -6,6 +6,8 @@ package featuretests
 import (
 	"os"
 
+	"github.com/juju/cmd/cmdtesting"
+	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/juju/osenv"
@@ -32,9 +34,11 @@ func (s *CmdRelationSuite) TestAddRelationSuccess(c *gc.C) {
 	runCommandExpectSuccess(c, "add-relation", s.apps...)
 }
 
-func (s *CmdRelationSuite) TestAddRelationFail(c *gc.C) {
+func (s *CmdRelationSuite) TestAddRelationSuccessOnAlreadyExists(c *gc.C) {
 	runCommandExpectSuccess(c, "add-relation", s.apps...)
-	runCommandExpectFailure(c, "add-relation", `cannot add relation "wordpress:db mysql:server": relation wordpress:db mysql:server already exists`, s.apps...)
+	context, err := runCommand(c, append([]string{"add-relation"}, s.apps...)...)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(cmdtesting.Stderr(context), jc.Contains, `cannot add relation "wordpress:db mysql:server": relation wordpress:db mysql:server already exists`)
 }
 
 func (s *CmdRelationSuite) TestRemoveRelationSuccess(c *gc.C) {


### PR DESCRIPTION
## Description of change
juju add-relation should not treat AlreadyExists as an error.

## QA steps
juju add-relation foo bar; juju add-relation foo-bar should not raise an error.

## Documentation changes
None

## Bug reference
https://bugs.launchpad.net/juju/+bug/1696647
