### PR TITLE
api: add DialTimeout

### DIFF
--- a/api/apiclient.go
+++ b/api/apiclient.go
@@ -605,6 +605,11 @@ func dialAPI(ctx context.Context, info *Info, opts0 DialOpts) (*dialResult, erro
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
+	if opts.DialTimeout > 0 {
+		ctx1, cancel := utils.ContextWithTimeout(ctx, opts.Clock, opts.DialTimeout)
+		defer cancel()
+		ctx = ctx1
+	}
 	dialInfo, err := dialWebsocketMulti(ctx, info.Addrs, path, opts)
 	if err != nil {
 		return nil, errors.Trace(err)

--- a/api/apiclient_test.go
+++ b/api/apiclient_test.go
@@ -766,13 +766,14 @@ func (s *apiclientSuite) TestFallbackToIPLookupWhenCacheOutOfDate(c *gc.C) {
 }
 
 func (s *apiclientSuite) TestOpenTimesOutOnLogin(c *gc.C) {
-	unblock := make(chan struct{})
+	unblock := make(chan chan struct{})
 	srv := apiservertesting.NewAPIServer(func(modelUUID string) interface{} {
 		return &loginTimeoutAPI{
 			unblock: unblock,
 		}
 	})
 	defer srv.Close()
+	defer close(unblock)
 
 	clk := testing.NewClock(time.Now())
 	done := make(chan error, 1)
@@ -794,6 +795,120 @@ func (s *apiclientSuite) TestOpenTimesOutOnLogin(c *gc.C) {
 		c.Assert(err, gc.ErrorMatches, `cannot log in: context deadline exceeded`)
 	case <-time.After(time.Second):
 		c.Fatalf("timed out waiting for api.Open timeout")
+	}
+}
+
+func (s *apiclientSuite) TestOpenTimeoutAffectsDial(c *gc.C) {
+	fakeDialer := func(ctx context.Context, urlStr string, tlsConfig *tls.Config, ipAddr string) (jsoncodec.JSONConn, error) {
+		<-ctx.Done()
+		return nil, ctx.Err()
+	}
+
+	clk := testing.NewClock(time.Now())
+	done := make(chan error, 1)
+	go func() {
+		_, err := api.Open(&api.Info{
+			Addrs:     []string{"127.0.0.1:1234"},
+			CACert:    jtesting.CACert,
+			ModelTag:  names.NewModelTag("beef1beef1-0000-0000-000011112222"),
+			SkipLogin: true,
+		}, api.DialOpts{
+			Clock:         clk,
+			Timeout:       5 * time.Second,
+			DialWebsocket: fakeDialer,
+		})
+		done <- err
+	}()
+	err := clk.WaitAdvance(5*time.Second, time.Second, 1)
+	c.Assert(err, jc.ErrorIsNil)
+	select {
+	case err := <-done:
+		c.Assert(err, gc.ErrorMatches, `unable to connect to API: context deadline exceeded`)
+	case <-time.After(time.Second):
+		c.Fatalf("timed out waiting for api.Open timeout")
+	}
+}
+
+func (s *apiclientSuite) TestOpenDialTimeoutAffectsDial(c *gc.C) {
+	fakeDialer := func(ctx context.Context, urlStr string, tlsConfig *tls.Config, ipAddr string) (jsoncodec.JSONConn, error) {
+		<-ctx.Done()
+		return nil, ctx.Err()
+	}
+
+	clk := testing.NewClock(time.Now())
+	done := make(chan error, 1)
+	go func() {
+		_, err := api.Open(&api.Info{
+			Addrs:     []string{"127.0.0.1:1234"},
+			CACert:    jtesting.CACert,
+			ModelTag:  names.NewModelTag("beef1beef1-0000-0000-000011112222"),
+			SkipLogin: true,
+		}, api.DialOpts{
+			Clock:         clk,
+			Timeout:       5 * time.Second,
+			DialTimeout:   3 * time.Second,
+			DialWebsocket: fakeDialer,
+		})
+		done <- err
+	}()
+	err := clk.WaitAdvance(3*time.Second, time.Second, 2) // Timeout & DialTimeout
+	c.Assert(err, jc.ErrorIsNil)
+	select {
+	case err := <-done:
+		c.Assert(err, gc.ErrorMatches, `unable to connect to API: context deadline exceeded`)
+	case <-time.After(time.Second):
+		c.Fatalf("timed out waiting for api.Open timeout")
+	}
+}
+
+func (s *apiclientSuite) TestOpenDialTimeoutDoesNotAffectLogin(c *gc.C) {
+	unblock := make(chan chan struct{})
+	srv := apiservertesting.NewAPIServer(func(modelUUID string) interface{} {
+		return &loginTimeoutAPI{
+			unblock: unblock,
+		}
+	})
+	defer srv.Close()
+	defer close(unblock)
+
+	clk := testing.NewClock(time.Now())
+	done := make(chan error, 1)
+	go func() {
+		_, err := api.Open(&api.Info{
+			Addrs:    srv.Addrs,
+			CACert:   jtesting.CACert,
+			ModelTag: names.NewModelTag("beef1beef1-0000-0000-000011112222"),
+		}, api.DialOpts{
+			Clock:       clk,
+			DialTimeout: 5 * time.Second,
+		})
+		done <- err
+	}()
+
+	// We should not get a response from api.Open until we
+	// unblock the login.
+	unblockRecv := make(chan struct{})
+	unblock <- unblockRecv
+	select {
+	case <-done:
+		c.Fatalf("unexpected return from api.Open")
+	case <-time.After(jtesting.ShortWait):
+	}
+
+	// There should be nothing waiting.
+	err := clk.WaitAdvance(0, 0, 0)
+	c.Assert(err, jc.ErrorIsNil)
+
+	select {
+	case <-unblockRecv:
+	case <-time.After(jtesting.LongWait):
+		c.Fatalf("timed out waiting for login to unblock")
+	}
+	select {
+	case err := <-done:
+		c.Assert(err, gc.ErrorMatches, "login failed")
+	case <-time.After(jtesting.LongWait):
+		c.Fatalf("timed out waiting for api.Open to return")
 	}
 }
 
@@ -1113,7 +1228,7 @@ func (m dnsCacheMap) Add(host string, ips []string) {
 }
 
 type loginTimeoutAPI struct {
-	unblock chan struct{}
+	unblock chan chan struct{}
 }
 
 func (r *loginTimeoutAPI) Admin(id string) (*loginTimeoutAPIAdmin, error) {
@@ -1125,6 +1240,10 @@ type loginTimeoutAPIAdmin struct {
 }
 
 func (a *loginTimeoutAPIAdmin) Login(req params.LoginRequest) (params.LoginResult, error) {
-	<-a.r.unblock
+	ch, ok := <-a.r.unblock
+	if !ok {
+		return params.LoginResult{}, errors.New("abort")
+	}
+	ch <- struct{}{}
 	return params.LoginResult{}, errors.Errorf("login failed")
 }

--- a/api/interface.go
+++ b/api/interface.go
@@ -124,8 +124,13 @@ type DialOpts struct {
 	// before starting to dial another address.
 	DialAddressInterval time.Duration
 
-	// Timeout is the amount of time to wait for
-	// the api.Open to succeed. If this is zero, there is no timeout.
+	// DialTimeout is the amount of time to wait for the dial
+	// portion only of the api.Open to succeed. If this is zero,
+	// there is no dial timeout.
+	DialTimeout time.Duration
+
+	// Timeout is the amount of time to wait for the entire
+	// api.Open to succeed. If this is zero, there is no timeout.
 	Timeout time.Duration
 
 	// RetryDelay is the amount of time to wait between

--- a/worker/apicaller/connect.go
+++ b/worker/apicaller/connect.go
@@ -89,8 +89,12 @@ func connectFallback(
 	// than the alternatives.
 	var tryConnect = func() {
 		conn, err = apiOpen(info, api.DialOpts{
-			Timeout:    time.Second,
-			RetryDelay: 200 * time.Millisecond,
+			// NOTE we set DialTimeout but not Timeout, because
+			// the server may apply server-side rate-limiting
+			// before responding to the Login request. The dial
+			// should be fast, but the login may not be.
+			DialTimeout: time.Second,
+			RetryDelay:  200 * time.Millisecond,
 		})
 	}
 

--- a/worker/apicaller/util_test.go
+++ b/worker/apicaller/util_test.go
@@ -190,8 +190,8 @@ func openCalls(model names.ModelTag, entity names.Tag, passwords ...string) []te
 		calls[i] = testing.StubCall{
 			FuncName: "apiOpen",
 			Args: []interface{}{info, api.DialOpts{
-				Timeout:    time.Second,
-				RetryDelay: 200 * time.Millisecond,
+				DialTimeout: time.Second,
+				RetryDelay:  200 * time.Millisecond,
 			}},
 		}
 	}


### PR DESCRIPTION
## Description of change

Add DialTimeout to api.DialOpts, and use
it in worker/apicaller instead of Timeout.
This will cause the workers to not timeout
in case of server-side rate-limiting.

## QA steps

1. juju bootstrap localhost
2. juju enable-ha

Modify apiserver/admin.go to add a Sleep(2*time.Second) before responding to Login. This emulates a highly loaded apiserver which is rate-limiting clients.

3. juju upgrade-juju -m controller --build-agent
4. juju debug-log -m controller
(observe no errors; there were "context deadline exceeded" errors without the DialTimeout changes)

## Documentation changes

None.

## Bug reference

Fixes https://bugs.launchpad.net/juju/+bug/1701438