### PR TITLE
Fixes lp#1700697: test failure on windows. 

### DIFF
--- a/cmd/juju/commands/helptool_test.go
+++ b/cmd/juju/commands/helptool_test.go
@@ -66,6 +66,9 @@ func (suite *HelpToolSuite) TestHelpTool(c *gc.C) {
 	template := "%v"
 	if runtime.GOOS == "windows" {
 		template = "%v.exe"
+		for i, aCmd := range expectedCommands {
+			expectedCommands[i] = fmt.Sprintf(template, aCmd)
+		}
 	}
 	for i, line := range lines {
 		command := strings.Fields(line)[0]


### PR DESCRIPTION
## Description of change

Test failure on windows: expected commands need '.exe' appended too.

## QA steps

HelpToolSuite.TestHelpTool passes on windows.

## Documentation changes

Does it affect current user workflow? CLI? API?

## Bug reference

https://bugs.launchpad.net/juju/+bug/1700697
