### PR TITLE
remove-storage: fail if storage is attached

### DIFF
--- a/api/facadeversions.go
+++ b/api/facadeversions.go
@@ -79,7 +79,7 @@ var facadeVersions = map[string]int{
 	"Spaces":                       3,
 	"SSHClient":                    2,
 	"StatusHistory":                2,
-	"Storage":                      3,
+	"Storage":                      4,
 	"StorageProvisioner":           3,
 	"StringsWatcher":               1,
 	"Subnets":                      2,

--- a/apiserver/allfacades.go
+++ b/apiserver/allfacades.go
@@ -200,7 +200,10 @@ func AllFacades() *facade.Registry {
 	reg("Spaces", 3, spaces.NewAPI)
 
 	reg("StatusHistory", 2, statushistory.NewAPI)
-	reg("Storage", 3, storage.NewFacade)
+
+	reg("Storage", 3, storage.NewFacadeV3)
+	reg("Storage", 4, storage.NewFacadeV4) // changes Destroy() method signature.
+
 	reg("StorageProvisioner", 3, storageprovisioner.NewFacade)
 	reg("Subnets", 2, subnets.NewAPI)
 	reg("Undertaker", 1, undertaker.NewUndertakerAPI)

--- a/apiserver/common/errors.go
+++ b/apiserver/common/errors.go
@@ -225,6 +225,8 @@ func ServerError(err error) *params.Error {
 		code = params.CodeUpgradeInProgress
 	case state.IsHasAttachmentsError(err):
 		code = params.CodeMachineHasAttachedStorage
+	case state.IsStorageAttachedError(err):
+		code = params.CodeStorageAttached
 	case isUnknownModelError(err):
 		code = params.CodeModelNotFound
 	case errors.IsNotSupported(err):
@@ -321,6 +323,8 @@ func RestoreError(err error) error {
 	case params.IsCodeMachineHasAttachedStorage(err):
 		// TODO(ericsnow) Handle state.HasAttachmentsError here.
 		// ...by parsing msg?
+		return err
+	case params.IsCodeStorageAttached(err):
 		return err
 	case params.IsCodeNotSupported(err):
 		return errors.NewNotSupported(nil, msg)

--- a/apiserver/facades/client/storage/base_test.go
+++ b/apiserver/facades/client/storage/base_test.go
@@ -25,7 +25,8 @@ type baseStorageSuite struct {
 	resources  *common.Resources
 	authorizer apiservertesting.FakeAuthorizer
 
-	api   *storage.API
+	api   *storage.APIv4
+	apiv3 *storage.APIv3
 	state *mockState
 
 	storageTag      names.StorageTag
@@ -60,7 +61,9 @@ func (s *baseStorageSuite) SetUpTest(c *gc.C) {
 	s.poolManager = s.constructPoolManager()
 
 	var err error
-	s.api, err = storage.NewAPI(s.state, s.registry, s.poolManager, s.resources, s.authorizer)
+	s.api, err = storage.NewAPIv4(s.state, s.registry, s.poolManager, s.resources, s.authorizer)
+	c.Assert(err, jc.ErrorIsNil)
+	s.apiv3, err = storage.NewAPIv3(s.state, s.registry, s.poolManager, s.resources, s.authorizer)
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -263,8 +266,8 @@ func (s *baseStorageSuite) constructState() *mockState {
 				names.ReadableString(unit),
 			)
 		},
-		destroyStorageInstance: func(tag names.StorageTag) error {
-			s.stub.AddCall(destroyStorageInstanceCall)
+		destroyStorageInstance: func(tag names.StorageTag, destroyAttached bool) error {
+			s.stub.AddCall(destroyStorageInstanceCall, tag, destroyAttached)
 			return errors.New("cannae do it")
 		},
 	}

--- a/apiserver/facades/client/storage/export_test.go
+++ b/apiserver/facades/client/storage/export_test.go
@@ -4,7 +4,7 @@
 package storage
 
 var (
-	ValidatePoolListFilter   = (*API).validatePoolListFilter
-	ValidateNameCriteria     = (*API).validateNameCriteria
-	ValidateProviderCriteria = (*API).validateProviderCriteria
+	ValidatePoolListFilter   = (*APIv4).validatePoolListFilter
+	ValidateNameCriteria     = (*APIv4).validateNameCriteria
+	ValidateProviderCriteria = (*APIv4).validateProviderCriteria
 )

--- a/apiserver/facades/client/storage/mock_test.go
+++ b/apiserver/facades/client/storage/mock_test.go
@@ -62,7 +62,7 @@ type mockState struct {
 	addStorageForUnit                   func(u names.UnitTag, name string, cons state.StorageConstraints) error
 	getBlockForType                     func(t state.BlockType) (state.Block, bool, error)
 	blockDevices                        func(names.MachineTag) ([]state.BlockDeviceInfo, error)
-	destroyStorageInstance              func(names.StorageTag) error
+	destroyStorageInstance              func(names.StorageTag, bool) error
 	attachStorage                       func(names.StorageTag, names.UnitTag) error
 	detachStorage                       func(names.StorageTag, names.UnitTag) error
 }
@@ -178,8 +178,8 @@ func (st *mockState) DetachStorage(storage names.StorageTag, unit names.UnitTag)
 	return st.detachStorage(storage, unit)
 }
 
-func (st *mockState) DestroyStorageInstance(tag names.StorageTag) error {
-	return st.destroyStorageInstance(tag)
+func (st *mockState) DestroyStorageInstance(tag names.StorageTag, destroyAttached bool) error {
+	return st.destroyStorageInstance(tag, destroyAttached)
 }
 
 func (st *mockState) UnitStorageAttachments(tag names.UnitTag) ([]state.StorageAttachment, error) {

--- a/apiserver/facades/client/storage/shim.go
+++ b/apiserver/facades/client/storage/shim.go
@@ -19,19 +19,34 @@ import (
 // to change any part of it so that it were no longer *obviously* and
 // *trivially* correct, you would be Doing It Wrong.
 
-// NewFacade provides the signature required for facade registration.
-func NewFacade(
+// NewFacadeV4 provides the signature required for facade registration.
+func NewFacadeV4(
 	st *state.State,
 	resources facade.Resources,
 	authorizer facade.Authorizer,
-) (*API, error) {
+) (*APIv4, error) {
 	env, err := stateenvirons.GetNewEnvironFunc(environs.New)(st)
 	if err != nil {
 		return nil, errors.Annotate(err, "getting environ")
 	}
 	registry := stateenvirons.NewStorageProviderRegistry(env)
 	pm := poolmanager.New(state.NewStateSettings(st), registry)
-	return NewAPI(getState(st), registry, pm, resources, authorizer)
+	return NewAPIv4(getState(st), registry, pm, resources, authorizer)
+}
+
+// NewFacadeV3 provides the signature required for facade registration.
+func NewFacadeV3(
+	st *state.State,
+	resources facade.Resources,
+	authorizer facade.Authorizer,
+) (*APIv3, error) {
+	env, err := stateenvirons.GetNewEnvironFunc(environs.New)(st)
+	if err != nil {
+		return nil, errors.Annotate(err, "getting environ")
+	}
+	registry := stateenvirons.NewStorageProviderRegistry(env)
+	pm := poolmanager.New(state.NewStateSettings(st), registry)
+	return NewAPIv3(getState(st), registry, pm, resources, authorizer)
 }
 
 type storageAccess interface {
@@ -119,7 +134,7 @@ type storageAccess interface {
 	DetachStorage(names.StorageTag, names.UnitTag) error
 
 	// DestroyStorageInstance destroys the storage instance with the specified tag.
-	DestroyStorageInstance(names.StorageTag) error
+	DestroyStorageInstance(names.StorageTag, bool) error
 
 	// UnitStorageAttachments returns the storage attachments for the
 	// identified unit.

--- a/apiserver/params/apierror.go
+++ b/apiserver/params/apierror.go
@@ -76,6 +76,7 @@ const (
 	CodeHasAssignedUnits          = "machine has assigned units"
 	CodeHasHostedModels           = "controller has hosted models"
 	CodeMachineHasAttachedStorage = "machine has attached storage"
+	CodeStorageAttached           = "storage is attached"
 	CodeNotProvisioned            = "not provisioned"
 	CodeNoAddressSet              = "no address set"
 	CodeTryAgain                  = "try again"
@@ -186,6 +187,10 @@ func IsCodeHasHostedModels(err error) bool {
 
 func IsCodeMachineHasAttachedStorage(err error) bool {
 	return ErrCode(err) == CodeMachineHasAttachedStorage
+}
+
+func IsCodeStorageAttached(err error) bool {
+	return ErrCode(err) == CodeStorageAttached
 }
 
 func IsCodeNotProvisioned(err error) bool {

--- a/apiserver/params/storage.go
+++ b/apiserver/params/storage.go
@@ -731,3 +731,19 @@ type StorageAddParams struct {
 type StoragesAddParams struct {
 	Storages []StorageAddParams `json:"storages"`
 }
+
+// DestroyStorage holds the parameters for destroying storage.
+type DestroyStorage struct {
+	Storage []DestroyStorageInstance `json:"storage"`
+}
+
+// DestroyStorage holds the parameters for destroying a storage instance.
+type DestroyStorageInstance struct {
+	// Tag is the tag of the storage instance to be destroyed.
+	Tag string `json:"tag"`
+
+	// DestroyAttached controls whether or not the storage will be
+	// destroyed if it is currently attached. If destroy-attached
+	// is false, then the storage must already be detached.
+	DestroyAttached bool `json:"destroy-attached,bool"`
+}

--- a/cmd/juju/storage/remove_test.go
+++ b/cmd/juju/storage/remove_test.go
@@ -21,37 +21,52 @@ type RemoveStorageSuite struct {
 var _ = gc.Suite(&RemoveStorageSuite{})
 
 func (s *RemoveStorageSuite) TestRemoveStorage(c *gc.C) {
-	fake := fakeEntityDestroyer{results: []params.ErrorResult{
+	fake := fakeStorageDestroyer{results: []params.ErrorResult{
 		{},
 		{},
 	}}
 	cmd := storage.NewRemoveStorageCommand(fake.new)
 	ctx, err := cmdtesting.RunCommand(c, cmd, "pgdata/0", "pgdata/1")
 	c.Assert(err, jc.ErrorIsNil)
-	fake.CheckCallNames(c, "NewEntityDestroyerCloser", "Destroy", "Close")
-	fake.CheckCall(c, 1, "Destroy", []string{"pgdata/0", "pgdata/1"})
+	fake.CheckCallNames(c, "NewStorageDestroyerCloser", "Destroy", "Close")
+	fake.CheckCall(c, 1, "Destroy", []string{"pgdata/0", "pgdata/1"}, false)
 	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, `
 removing pgdata/0
 removing pgdata/1
 `[1:])
 }
 
+func (s *RemoveStorageSuite) TestRemoveStorageForce(c *gc.C) {
+	fake := fakeStorageDestroyer{results: []params.ErrorResult{
+		{},
+		{},
+	}}
+	cmd := storage.NewRemoveStorageCommand(fake.new)
+	_, err := cmdtesting.RunCommand(c, cmd, "--force", "pgdata/0", "pgdata/1")
+	c.Assert(err, jc.ErrorIsNil)
+	fake.CheckCall(c, 1, "Destroy", []string{"pgdata/0", "pgdata/1"}, true)
+}
+
 func (s *RemoveStorageSuite) TestRemoveStorageError(c *gc.C) {
-	fake := fakeEntityDestroyer{results: []params.ErrorResult{
+	fake := fakeStorageDestroyer{results: []params.ErrorResult{
 		{Error: &params.Error{Message: "foo"}},
-		{Error: &params.Error{Message: "bar"}},
+		{Error: &params.Error{Message: "storage is attached", Code: params.CodeStorageAttached}},
 	}}
 	removeCmd := storage.NewRemoveStorageCommand(fake.new)
 	ctx, err := cmdtesting.RunCommand(c, removeCmd, "pgdata/0", "pgdata/1")
 	stderr := cmdtesting.Stderr(ctx)
 	c.Assert(stderr, gc.Equals, `failed to remove pgdata/0: foo
-failed to remove pgdata/1: bar
+failed to remove pgdata/1: storage is attached
+
+Use the --force flag to remove attached storage, or use
+"juju detach-storage" to explicitly detach the storage
+before removing.
 `)
 	c.Assert(err, gc.Equals, cmd.ErrSilent)
 }
 
 func (s *RemoveStorageSuite) TestRemoveStorageUnauthorizedError(c *gc.C) {
-	var fake fakeEntityDestroyer
+	var fake fakeStorageDestroyer
 	fake.SetErrors(nil, &params.Error{Code: params.CodeUnauthorized, Message: "nope"})
 	cmd := storage.NewRemoveStorageCommand(fake.new)
 	ctx, err := cmdtesting.RunCommand(c, cmd, "pgdata/0")
@@ -68,28 +83,28 @@ func (s *RemoveStorageSuite) TestRemoveStorageInitErrors(c *gc.C) {
 }
 
 func (s *RemoveStorageSuite) testRemoveStorageInitError(c *gc.C, args []string, expect string) {
-	var fake fakeEntityDestroyer
+	var fake fakeStorageDestroyer
 	cmd := storage.NewRemoveStorageCommand(fake.new)
 	_, err := cmdtesting.RunCommand(c, cmd, args...)
 	c.Assert(err, gc.ErrorMatches, expect)
 }
 
-type fakeEntityDestroyer struct {
+type fakeStorageDestroyer struct {
 	testing.Stub
 	results []params.ErrorResult
 }
 
-func (f *fakeEntityDestroyer) new() (storage.EntityDestroyerCloser, error) {
-	f.MethodCall(f, "NewEntityDestroyerCloser")
+func (f *fakeStorageDestroyer) new() (storage.StorageDestroyerCloser, error) {
+	f.MethodCall(f, "NewStorageDestroyerCloser")
 	return f, f.NextErr()
 }
 
-func (f *fakeEntityDestroyer) Close() error {
+func (f *fakeStorageDestroyer) Close() error {
 	f.MethodCall(f, "Close")
 	return f.NextErr()
 }
 
-func (f *fakeEntityDestroyer) Destroy(ids []string) ([]params.ErrorResult, error) {
-	f.MethodCall(f, "Destroy", ids)
+func (f *fakeStorageDestroyer) Destroy(ids []string, destroyAttached bool) ([]params.ErrorResult, error) {
+	f.MethodCall(f, "Destroy", ids, destroyAttached)
 	return f.results, f.NextErr()
 }

--- a/state/cleanup.go
+++ b/state/cleanup.go
@@ -217,7 +217,8 @@ func (st *State) cleanupStorageForDyingModel() (err error) {
 		return errors.Trace(err)
 	}
 	for _, s := range storage {
-		err := st.DestroyStorageInstance(s.StorageTag())
+		const destroyAttached = true
+		err := st.DestroyStorageInstance(s.StorageTag(), destroyAttached)
 		if errors.IsNotFound(err) {
 			continue
 		} else if err != nil {

--- a/state/cleanup_test.go
+++ b/state/cleanup_test.go
@@ -628,7 +628,7 @@ func (s *CleanupSuite) TestCleanupStorageInstances(c *gc.C) {
 	c.Assert(si.Life(), gc.Equals, state.Alive)
 
 	// destroy storage instance and run cleanups
-	err = s.State.DestroyStorageInstance(storageTag)
+	err = s.State.DestroyStorageInstance(storageTag, true)
 	c.Assert(err, jc.ErrorIsNil)
 	si, err = s.State.StorageInstance(storageTag)
 	c.Assert(err, jc.ErrorIsNil)

--- a/state/filesystem_test.go
+++ b/state/filesystem_test.go
@@ -574,7 +574,7 @@ func (s *FilesystemStateSuite) TestRemoveStorageInstanceDestroysAndUnassignsFile
 	c.Assert(err, jc.ErrorIsNil)
 	err = u.Destroy()
 	c.Assert(err, jc.ErrorIsNil)
-	err = s.State.DestroyStorageInstance(storageTag)
+	err = s.State.DestroyStorageInstance(storageTag, true)
 	c.Assert(err, jc.ErrorIsNil)
 	err = s.State.DetachStorage(storageTag, unitTag)
 	c.Assert(err, jc.ErrorIsNil)

--- a/state/volume_test.go
+++ b/state/volume_test.go
@@ -534,7 +534,7 @@ func (s *VolumeStateSuite) TestRemoveStorageInstanceDestroysAndUnassignsVolume(c
 		c.Assert(err, jc.ErrorIsNil)
 	}).Check()
 
-	err = s.State.DestroyStorageInstance(storageTag)
+	err = s.State.DestroyStorageInstance(storageTag, true)
 	c.Assert(err, jc.ErrorIsNil)
 	err = s.State.DetachStorage(storageTag, u.UnitTag())
 	c.Assert(err, jc.ErrorIsNil)
@@ -936,7 +936,7 @@ func removeVolumeStorageInstance(c *gc.C, st *state.State, volumeTag names.Volum
 }
 
 func removeStorageInstance(c *gc.C, st *state.State, storageTag names.StorageTag) {
-	err := st.DestroyStorageInstance(storageTag)
+	err := st.DestroyStorageInstance(storageTag, true)
 	c.Assert(err, jc.ErrorIsNil)
 	attachments, err := st.StorageAttachments(storageTag)
 	c.Assert(err, jc.ErrorIsNil)


### PR DESCRIPTION
## Description of change

The remove-storage command should fail if the
specified storage is currently attached. The
user may pass --force to cause the storage to
be atomically marked for detachment and removal.

## QA steps

1. export JUJU_DEV_FEATURE_FLAGS=lxd-storage
2. juju bootstrap localhost
3. juju deploy ~axwalk/storagetest --storage fs=lxd
4. juju remove-storage fs/0
(fails, saying that the storage is attached, and that you either have to detach it first, or use --force.)
5. juju remove-storage --force fs/0
(succeeds, storage is detached, destroyed, removed)

## Documentation changes

Yes, this is new behaviour, and should be documented along with the rest of the persistent storage changes.

## Bug reference

None.