### PR TITLE
provider/vsphere: use schema.Omit for datastore

### DIFF
--- a/provider/vsphere/config.go
+++ b/provider/vsphere/config.go
@@ -25,7 +25,7 @@ var (
 
 	configDefaults = schema.Defaults{
 		cfgExternalNetwork: "",
-		cfgDatastore:       "",
+		cfgDatastore:       schema.Omit,
 	}
 
 	configRequiredFields  = []string{}
@@ -58,11 +58,6 @@ func newValidConfig(cfg *config.Config) (*environConfig, error) {
 	validated, err := cfg.ValidateUnknownAttrs(configFields, configDefaults)
 	if err != nil {
 		return nil, errors.Trace(err)
-	}
-	if validated[cfgDatastore] == "" {
-		// TODO(axw) ValidateUnknownAttrs should not be setting the
-		// empty value when the default is schema.Omit.
-		delete(validated, cfgDatastore)
 	}
 	validCfg, err := cfg.Apply(validated)
 	if err != nil {


### PR DESCRIPTION
## Description of change

I meant to use schema.Omit for datastore in
vsphere config. The TODO I added previously
is nonsense, and is a result of me thinking I'd
used schema.Omit when I hadn't. So: change
default to schema.Omit, drop TODO.

## QA steps

Bootstrap vsphere with and without datastore config.

## Documentation changes

None.

## Bug reference

None.