### PR TITLE
cmd/juju: check API support for --attach-storage

### DIFF
--- a/api/application/client.go
+++ b/api/application/client.go
@@ -108,8 +108,13 @@ type DeployArgs struct {
 // it. Placement directives, if provided, specify the machine on which the charm
 // is deployed.
 func (c *Client) Deploy(args DeployArgs) error {
-	if len(args.AttachStorage) > 0 && args.NumUnits != 1 {
-		return errors.New("cannot attach existing storage when more than one unit is requested")
+	if len(args.AttachStorage) > 0 {
+		if args.NumUnits != 1 {
+			return errors.New("cannot attach existing storage when more than one unit is requested")
+		}
+		if c.BestAPIVersion() < 5 {
+			return errors.New("this juju controller does not support AttachStorage")
+		}
 	}
 	attachStorage := make([]string, len(args.AttachStorage))
 	for i, id := range args.AttachStorage {
@@ -258,8 +263,13 @@ type AddUnitsParams struct {
 // AddUnits adds a given number of units to an application using the specified
 // placement directives to assign units to machines.
 func (c *Client) AddUnits(args AddUnitsParams) ([]string, error) {
-	if len(args.AttachStorage) > 0 && args.NumUnits != 1 {
-		return nil, errors.New("cannot attach existing storage when more than one unit is requested")
+	if len(args.AttachStorage) > 0 {
+		if args.NumUnits != 1 {
+			return nil, errors.New("cannot attach existing storage when more than one unit is requested")
+		}
+		if c.BestAPIVersion() < 5 {
+			return nil, errors.New("this juju controller does not support AttachStorage")
+		}
 	}
 	attachStorage := make([]string, len(args.AttachStorage))
 	for i, id := range args.AttachStorage {

--- a/apiserver/allfacades.go
+++ b/apiserver/allfacades.go
@@ -121,7 +121,7 @@ func AllFacades() *facade.Registry {
 	reg("Application", 2, application.NewFacade)
 	reg("Application", 3, application.NewFacade)
 	reg("Application", 4, application.NewFacade)
-	reg("Application", 5, application.NewFacade)
+	reg("Application", 5, application.NewFacade) // adds AttachStorage
 
 	reg("ApplicationScaler", 1, applicationscaler.NewAPI)
 	reg("Backups", 1, backups.NewFacade)

--- a/cmd/juju/application/addunit.go
+++ b/cmd/juju/application/addunit.go
@@ -172,6 +172,7 @@ func (c *addUnitCommand) Init(args []string) error {
 // serviceAddUnitAPI defines the methods on the client API
 // that the application add-unit command calls.
 type serviceAddUnitAPI interface {
+	BestAPIVersion() int
 	Close() error
 	ModelUUID() string
 	AddUnits(application.AddUnitsParams) ([]string, error)
@@ -196,6 +197,12 @@ func (c *addUnitCommand) Run(ctx *cmd.Context) error {
 		return err
 	}
 	defer apiclient.Close()
+
+	if len(c.AttachStorage) > 0 && apiclient.BestAPIVersion() < 5 {
+		// AddUnitsPArams.AttachStorage is only supported from
+		// Application API version 5 and onwards.
+		return errors.New("this juju controller does not support --attach-storage")
+	}
 
 	for i, p := range c.Placement {
 		if p.Scope == "model-uuid" {

--- a/cmd/juju/application/deploy.go
+++ b/cmd/juju/application/deploy.go
@@ -545,6 +545,12 @@ func (c *DeployCommand) deployCharm(
 		return err
 	}
 
+	if len(c.AttachStorage) > 0 && apiRoot.BestFacadeVersion("Application") < 5 {
+		// DeployArgs.AttachStorage is only supported from
+		// Application API version 5 and onwards.
+		return errors.New("this juju controller does not support --attach-storage")
+	}
+
 	numUnits := c.NumUnits
 	if charmInfo.Meta.Subordinate {
 		if !constraints.IsEmpty(&c.Constraints) {


### PR DESCRIPTION
## Description of change

Update the deploy and add-unit commands, and Application
API client code, to check the facade version when
--attach-storage is specified. If the controller is too
old, return an error.

## QA steps

(using juju 2.2.x)
1. juju bootstrap
(using this branch)
2. juju deploy postgresql --attach-storage pgdata/0
(doesn't matter that the storage doesn't exist, we never hit this Deploy API; you should see "this juju controller does not support --attach-storage")
3. juju add-unit postgresql --attach-storage pgdata/0
(same as above)

Then smoke-test both commands with a controller bootstrapped from this branch, and all should work.

## Documentation changes

None.

## Bug reference

None.