### PR TITLE
Fix an assert that wasn't testing anything.

### DIFF
--- a/state/presence/presence_test.go
+++ b/state/presence/presence_test.go
@@ -88,10 +88,10 @@ func assertNoChange(c *gc.C, watch <-chan presence.Change) {
 	}
 }
 
-func assertAlive(c *gc.C, w *presence.Watcher, key string, alive bool) {
-	alive, err := w.Alive("a")
+func assertAlive(c *gc.C, w *presence.Watcher, key string, expAlive bool) {
+	realAlive, err := w.Alive(key)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(alive, gc.Equals, alive)
+	c.Assert(realAlive, gc.Equals, expAlive)
 }
 
 // assertStopped stops a worker and waits until it reports stopped.


### PR DESCRIPTION
## Description of change

In one of the recent refactorings, I pulled out a helper
function to test whether an entity was alive. I turned out
that the helper was broken in many ways.
It hard coded the 'key', but that didn't end up mattering because
it ended up doing:
   c.Assert(alive, gc.Equals, alive)
which will always be true (it reused a parameter as a local variable).

The test happened to be correct anyway, this just fixes it to actually be
testing what we thought it was.

## QA steps

Internal test change. You could change one of the values from "assertAlive" calls and see that it actually fails when it is supposed to instead of universally succeeding.

## Documentation changes

No.

## Bug reference

None (drive by while fixing a bug, but not directly related)