### PR TITLE
2.2 presence log tweak

### DIFF
--- a/state/presence/pingbatcher.go
+++ b/state/presence/pingbatcher.go
@@ -336,7 +336,7 @@ func (pb *PingBatcher) flush() error {
 		}
 	}
 	// usually we should only be processing 1 slot
-	logger.Tracef("[%v] pingbatcher recorded %d pings for %d ping slot(s) and %d fields in %v",
-		strings.Join(uuids.SortedValues(), ", "), pingCount, docCount, fieldCount, time.Since(t))
+	logger.Tracef("[%v] recorded %d pings for %d ping slot(s) and %d fields in %.3fs",
+		strings.Join(uuids.SortedValues(), ", "), pingCount, docCount, fieldCount, time.Since(t).Seconds())
 	return nil
 }

--- a/state/presence/pingbatcher.go
+++ b/state/presence/pingbatcher.go
@@ -4,10 +4,12 @@ package presence
 
 import (
 	"math/rand"
+	"strings"
 	"sync"
 	"time"
 
 	"github.com/juju/errors"
+	"github.com/juju/utils/set"
 	"gopkg.in/mgo.v2"
 	"gopkg.in/mgo.v2/bson"
 	"gopkg.in/tomb.v1"
@@ -279,9 +281,9 @@ func (pb *PingBatcher) flush() error {
 		}
 	}()
 	if pb.pingCount == 0 {
-		logger.Tracef("pingbatcher has 0 pings to record")
 		return nil
 	}
+	uuids := set.NewStrings()
 	// We treat all of these as 'consumed'. Even if the query fails, it is
 	// not safe to ever $inc the same fields a second time, so we just move on.
 	next := pb.pending
@@ -314,6 +316,11 @@ func (pb *PingBatcher) flush() error {
 				{"$inc", incFields},
 			},
 		)
+		if logger.IsTraceEnabled() {
+			// the rest of Pings records the first 6 characters of
+			// model-uuids, so we include that here if we are TRACEing.
+			uuids.Add(docId[:6])
+		}
 		bulkCount++
 		if bulkCount >= maxBatch {
 			if _, err := bulk.Run(); err != nil {
@@ -329,7 +336,7 @@ func (pb *PingBatcher) flush() error {
 		}
 	}
 	// usually we should only be processing 1 slot
-	logger.Tracef("pingbatcher recorded %d pings for %d ping slot(s) and %d fields in %v",
-		pingCount, docCount, fieldCount, time.Since(t))
+	logger.Tracef("[%v] pingbatcher recorded %d pings for %d ping slot(s) and %d fields in %v",
+		strings.Join(uuids.SortedValues(), ", "), pingCount, docCount, fieldCount, time.Since(t))
 	return nil
 }


### PR DESCRIPTION
## Description of change

Tweaks the TRACE level logging for pingbatcher.
1) Drops the 'pingbatcher has 0 pings to record'. It triggers every 1s for every PingBatcher, which means in an HA controller it writes a message 6 times/second. It isn't very interesting, so we can just drop it, even at TRACE. (3 of those batchers also never have anything to do because they aren't the apiserver backing state object.)
2) Include the model uuid prefix and drop the 'pingbatcher' wording. This makes TRACE logging look more consistent, and is a little bit easier to follow. (PingBatcher was written to support multiple models at the same time, and I didn't want to give that up, so we just aggregate the model uuids from the docs we're updating.)

## QA steps
```
$ juju model-config logging-config=juju.state.presence=TRACE
$ juju debug-log --include-model juju.state.presence
```

Should look a little better after these changes. (removal of lots of '0 to record' messages, and better formatting of existing messages.

## Documentation changes

None

## Bug reference

None
