### PR TITLE
Handle PingBatcher getting restarted (bug #1703526)

### DIFF
--- a/state/machine.go
+++ b/state/machine.go
@@ -959,7 +959,8 @@ func (m *Machine) WaitAgentPresence(timeout time.Duration) (err error) {
 func (m *Machine) SetAgentPresence() (*presence.Pinger, error) {
 	presenceCollection := m.st.getPresenceCollection()
 	recorder := m.st.getPingBatcher()
-	p := presence.NewPinger(presenceCollection, m.st.modelTag, m.globalKey(), recorder)
+	p := presence.NewPinger(presenceCollection, m.st.modelTag, m.globalKey(),
+		func() presence.PingRecorder { return m.st.getPingBatcher() })
 	err := p.Start()
 	if err != nil {
 		return nil, err

--- a/state/presence/presence_test.go
+++ b/state/presence/presence_test.go
@@ -121,6 +121,10 @@ func (s *PresenceSuite) TestErrAndDead(c *gc.C) {
 	}
 }
 
+func (s *PresenceSuite) getDirectRecorder() presence.PingRecorder {
+	return presence.DirectRecordFunc(s.presence)
+}
+
 func (s *PresenceSuite) TestAliveError(c *gc.C) {
 	w := presence.NewWatcher(s.presence, s.modelTag)
 	c.Assert(w.Stop(), gc.IsNil)
@@ -133,8 +137,8 @@ func (s *PresenceSuite) TestAliveError(c *gc.C) {
 
 func (s *PresenceSuite) TestWorkflow(c *gc.C) {
 	w := presence.NewWatcher(s.presence, s.modelTag)
-	pa := presence.NewPinger(s.presence, s.modelTag, "a", presence.DirectRecordFunc(s.presence))
-	pb := presence.NewPinger(s.presence, s.modelTag, "b", presence.DirectRecordFunc(s.presence))
+	pa := presence.NewPinger(s.presence, s.modelTag, "a", s.getDirectRecorder)
+	pb := presence.NewPinger(s.presence, s.modelTag, "b", s.getDirectRecorder)
 	defer assertStopped(c, w)
 	defer assertStopped(c, pa)
 	defer assertStopped(c, pb)
@@ -171,7 +175,7 @@ func (s *PresenceSuite) TestWorkflow(c *gc.C) {
 	assertNoChange(c, cha)
 	pa.KillForTesting()
 	w.Sync()
-	pa = presence.NewPinger(s.presence, s.modelTag, "a", presence.DirectRecordFunc(s.presence))
+	pa = presence.NewPinger(s.presence, s.modelTag, "a", s.getDirectRecorder)
 	pa.Start()
 	w.StartSync()
 	assertNoChange(c, cha)
@@ -219,7 +223,7 @@ func (s *PresenceSuite) TestScale(c *gc.C) {
 
 	c.Logf("Starting %d pingers...", N)
 	for i := 0; i < N; i++ {
-		p := presence.NewPinger(s.presence, s.modelTag, strconv.Itoa(i), presence.DirectRecordFunc(s.presence))
+		p := presence.NewPinger(s.presence, s.modelTag, strconv.Itoa(i), s.getDirectRecorder)
 		c.Assert(p.Start(), gc.IsNil)
 		ps = append(ps, p)
 	}
@@ -247,7 +251,7 @@ func (s *PresenceSuite) TestScale(c *gc.C) {
 
 func (s *PresenceSuite) TestExpiry(c *gc.C) {
 	w := presence.NewWatcher(s.presence, s.modelTag)
-	p := presence.NewPinger(s.presence, s.modelTag, "a", presence.DirectRecordFunc(s.presence))
+	p := presence.NewPinger(s.presence, s.modelTag, "a", s.getDirectRecorder)
 	defer assertStopped(c, w)
 	defer assertStopped(c, p)
 
@@ -280,7 +284,7 @@ func (s *PresenceSuite) TestWatchPeriod(c *gc.C) {
 	presence.RealTimeSlot()
 
 	w := presence.NewWatcher(s.presence, s.modelTag)
-	p := presence.NewPinger(s.presence, s.modelTag, "a", presence.DirectRecordFunc(s.presence))
+	p := presence.NewPinger(s.presence, s.modelTag, "a", s.getDirectRecorder)
 	defer assertStopped(c, w)
 	defer assertStopped(c, p)
 
@@ -325,7 +329,7 @@ func (s *PresenceSuite) TestWatchUnwatchOnQueue(c *gc.C) {
 }
 
 func (s *PresenceSuite) TestRestartWithoutGaps(c *gc.C) {
-	p := presence.NewPinger(s.presence, s.modelTag, "a", presence.DirectRecordFunc(s.presence))
+	p := presence.NewPinger(s.presence, s.modelTag, "a", s.getDirectRecorder)
 	c.Assert(p.Start(), gc.IsNil)
 	defer assertStopped(c, p)
 
@@ -379,8 +383,8 @@ func (s *PresenceSuite) TestPingerPeriodAndResilience(c *gc.C) {
 	presence.RealTimeSlot()
 
 	w := presence.NewWatcher(s.presence, s.modelTag)
-	p1 := presence.NewPinger(s.presence, s.modelTag, "a", presence.DirectRecordFunc(s.presence))
-	p2 := presence.NewPinger(s.presence, s.modelTag, "a", presence.DirectRecordFunc(s.presence))
+	p1 := presence.NewPinger(s.presence, s.modelTag, "a", s.getDirectRecorder)
+	p2 := presence.NewPinger(s.presence, s.modelTag, "a", s.getDirectRecorder)
 	defer assertStopped(c, w)
 	defer assertStopped(c, p1)
 	defer assertStopped(c, p2)
@@ -410,7 +414,7 @@ func (s *PresenceSuite) TestPingerPeriodAndResilience(c *gc.C) {
 
 func (s *PresenceSuite) TestStartSync(c *gc.C) {
 	w := presence.NewWatcher(s.presence, s.modelTag)
-	p := presence.NewPinger(s.presence, s.modelTag, "a", presence.DirectRecordFunc(s.presence))
+	p := presence.NewPinger(s.presence, s.modelTag, "a", s.getDirectRecorder)
 	defer assertStopped(c, w)
 	defer assertStopped(c, p)
 
@@ -439,7 +443,7 @@ func (s *PresenceSuite) TestStartSync(c *gc.C) {
 
 func (s *PresenceSuite) TestSync(c *gc.C) {
 	w := presence.NewWatcher(s.presence, s.modelTag)
-	p := presence.NewPinger(s.presence, s.modelTag, "a", presence.DirectRecordFunc(s.presence))
+	p := presence.NewPinger(s.presence, s.modelTag, "a", s.getDirectRecorder)
 	defer assertStopped(c, w)
 	defer assertStopped(c, p)
 
@@ -526,7 +530,7 @@ func (s *PresenceSuite) setup(c *gc.C, key string) (*presence.Watcher, *presence
 	modelTag := newModelTag(c)
 
 	w := presence.NewWatcher(s.presence, modelTag)
-	p := presence.NewPinger(s.presence, modelTag, key, presence.DirectRecordFunc(s.presence))
+	p := presence.NewPinger(s.presence, modelTag, key, s.getDirectRecorder)
 
 	ch := make(chan presence.Change)
 	w.Watch(key, ch)
@@ -548,7 +552,7 @@ func (s *PresenceSuite) TestRemovePresenceForModel(c *gc.C) {
 
 	// Start a pinger in this model
 	w1 := presence.NewWatcher(s.presence, s.modelTag)
-	p1 := presence.NewPinger(s.presence, s.modelTag, key, presence.DirectRecordFunc(s.presence))
+	p1 := presence.NewPinger(s.presence, s.modelTag, key, s.getDirectRecorder)
 	ch1 := make(chan presence.Change)
 	w1.Watch(key, ch1)
 	assertChange(c, ch1, presence.Change{key, false})
@@ -561,7 +565,7 @@ func (s *PresenceSuite) TestRemovePresenceForModel(c *gc.C) {
 	// Start a second model and pinger with the same key
 	modelTag2 := newModelTag(c)
 	w2 := presence.NewWatcher(s.presence, modelTag2)
-	p2 := presence.NewPinger(s.presence, modelTag2, key, presence.DirectRecordFunc(s.presence))
+	p2 := presence.NewPinger(s.presence, modelTag2, key, s.getDirectRecorder)
 	ch2 := make(chan presence.Change)
 	w2.Watch(key, ch2)
 	assertChange(c, ch2, presence.Change{key, false})

--- a/state/unit.go
+++ b/state/unit.go
@@ -1236,7 +1236,8 @@ func (u *Unit) WaitAgentPresence(timeout time.Duration) (err error) {
 func (u *Unit) SetAgentPresence() (*presence.Pinger, error) {
 	presenceCollection := u.st.getPresenceCollection()
 	recorder := u.st.getPingBatcher()
-	p := presence.NewPinger(presenceCollection, u.st.ModelTag(), u.globalAgentKey(), recorder)
+	p := presence.NewPinger(presenceCollection, u.st.ModelTag(), u.globalKey(),
+		func() presence.PingRecorder { return u.st.getPingBatcher() })
 	err := p.Start()
 	if err != nil {
 		return nil, err

--- a/state/unit.go
+++ b/state/unit.go
@@ -1236,7 +1236,7 @@ func (u *Unit) WaitAgentPresence(timeout time.Duration) (err error) {
 func (u *Unit) SetAgentPresence() (*presence.Pinger, error) {
 	presenceCollection := u.st.getPresenceCollection()
 	recorder := u.st.getPingBatcher()
-	p := presence.NewPinger(presenceCollection, u.st.ModelTag(), u.globalKey(),
+	p := presence.NewPinger(presenceCollection, u.st.ModelTag(), u.globalAgentKey(),
 		func() presence.PingRecorder { return u.st.getPingBatcher() })
 	err := p.Start()
 	if err != nil {


### PR DESCRIPTION
## Description of change

Instead of fixing a PingBatcher when initializing a Pinger,
we instead have the pinger ask for whatever the current PingBatcher is.
That way if the PingBatcher gets restarted due to an error, then the
Pingers can find the correct one.

Only other problem is we probably don't restart the Pingers either if
they encounter an error, so that needs testing as well.

Also, we're missing a test for the fact that Pinger's always use the
fresh PingBatcher (they do by inspection, but it should be actually tested.)

## QA steps

```
  $ juju bootstrap lxd
  $ juju deploy ubuntu
  # connect to the mongo
  > use presence
  > db.presence.pings.find()
  # grab the most recent ping and add something like 60 seconds to the
  # timestamp, inject a broken record to the database, which will force
  # the PingBatcher to die.
  > db.presence.pings.insert(
{"_id": "8e869b13-85a7-4d86-8a3e-4d332b4306e8:1499793870", "slot" : NumberLong(1499793870), "alive" : { "1" : "a"}})
  # note that the slot is both its own field and the tail of the _id, both need to be updated
  $ juju debug-log
  # should show the PingBatcher die once the appropriate slot is the current slot.
  $ juju status
  # might show the agents go down temporarily, but ultimately they should come back up again
```
I did manage to QA this by injecting bad data, seeing PingBatcher die, seeing some agents show up as down, but see everything recover afterward.
Without this patch, everything stays dead after injecting bad data.

## Documentation changes

Just fixes a bug.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1703526
