### PR TITLE
Refactor common image metadata Save in prep for facade split.

### DIFF
--- a/apiserver/common/imagecommon/imagemetadata.go
+++ b/apiserver/common/imagecommon/imagemetadata.go
@@ -1,0 +1,71 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package imagecommon
+
+import (
+	"github.com/juju/errors"
+
+	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/environs/config"
+	"github.com/juju/juju/state/cloudimagemetadata"
+)
+
+// ImageMetadataInterface is an interface for manipulating images metadata.
+type ImageMetadataInterface interface {
+
+	// SaveMetadata persists collection of given images metadata.
+	SaveMetadata([]cloudimagemetadata.Metadata) error
+
+	// ModelConfig retrieves configuration for a current model.
+	ModelConfig() (*config.Config, error)
+}
+
+// Save stores given cloud image metadata using given persistence interface.
+func Save(st ImageMetadataInterface, metadata params.MetadataSaveParams) ([]params.ErrorResult, error) {
+	all := make([]params.ErrorResult, len(metadata.Metadata))
+	if len(metadata.Metadata) == 0 {
+		return nil, nil
+	}
+	modelCfg, err := st.ModelConfig()
+	if err != nil {
+		return nil, errors.Annotatef(err, "getting model config")
+	}
+	for i, one := range metadata.Metadata {
+		md := ParseMetadataListFromParams(one, modelCfg)
+		err := st.SaveMetadata(md)
+		all[i] = params.ErrorResult{Error: common.ServerError(err)}
+	}
+	return all, nil
+}
+
+// ParseMetadataListFromParams translates params.CloudImageMetadataList
+// into a collection of cloudimagemetadata.Metadata.
+func ParseMetadataListFromParams(p params.CloudImageMetadataList, cfg *config.Config) []cloudimagemetadata.Metadata {
+	results := make([]cloudimagemetadata.Metadata, len(p.Metadata))
+	for i, metadata := range p.Metadata {
+		results[i] = cloudimagemetadata.Metadata{
+			MetadataAttributes: cloudimagemetadata.MetadataAttributes{
+				Stream:          metadata.Stream,
+				Region:          metadata.Region,
+				Version:         metadata.Version,
+				Series:          metadata.Series,
+				Arch:            metadata.Arch,
+				VirtType:        metadata.VirtType,
+				RootStorageType: metadata.RootStorageType,
+				RootStorageSize: metadata.RootStorageSize,
+				Source:          metadata.Source,
+			},
+			Priority: metadata.Priority,
+			ImageId:  metadata.ImageId,
+		}
+		// TODO (anastasiamac 2016-08-24) This is a band-aid solution.
+		// Once correct value is read from simplestreams, this needs to go.
+		// Bug# 1616295
+		if results[i].Stream == "" {
+			results[i].Stream = cfg.ImageStream()
+		}
+	}
+	return results
+}

--- a/apiserver/common/imagecommon/imagemetadata_test.go
+++ b/apiserver/common/imagecommon/imagemetadata_test.go
@@ -1,0 +1,124 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package imagecommon_test
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/apiserver/common/imagecommon"
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/environs/config"
+	"github.com/juju/juju/state/cloudimagemetadata"
+	coretesting "github.com/juju/juju/testing"
+)
+
+type imageMetadataSuite struct {
+	st *mockState
+}
+
+var _ = gc.Suite(&imageMetadataSuite{})
+
+func (s *imageMetadataSuite) SetUpTest(c *gc.C) {
+	mCfg := testConfig(c)
+
+	s.st = &mockState{
+		Stub: testing.Stub{},
+		saveMetadata: func(m []cloudimagemetadata.Metadata) error {
+			return nil
+		},
+		modelCfg: func() (*config.Config, error) {
+			return mCfg, nil
+		},
+	}
+}
+
+func (s *imageMetadataSuite) TestSaveEmpty(c *gc.C) {
+	errs, err := imagecommon.Save(s.st, params.MetadataSaveParams{})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(errs, gc.HasLen, 0)
+	s.st.CheckCallNames(c, []string{}...)
+}
+
+func (s *imageMetadataSuite) TestSaveModelCfgFailed(c *gc.C) {
+	m := params.CloudImageMetadata{
+		Source: "custom",
+	}
+	msg := "save error"
+
+	s.st.modelCfg = func() (*config.Config, error) {
+		return nil, errors.New(msg)
+	}
+
+	errs, err := imagecommon.Save(s.st, params.MetadataSaveParams{
+		Metadata: []params.CloudImageMetadataList{{
+			Metadata: []params.CloudImageMetadata{m},
+		}},
+	})
+	c.Assert(errors.Cause(err), gc.ErrorMatches, msg)
+	c.Assert(errs, gc.IsNil)
+	s.st.CheckCallNames(c, "ModelConfig")
+}
+
+func (s *imageMetadataSuite) TestSave(c *gc.C) {
+	m := params.CloudImageMetadata{
+		Source: "custom",
+	}
+	msg := "save error"
+
+	saveCalls := 0
+	s.st.saveMetadata = func(m []cloudimagemetadata.Metadata) error {
+		saveCalls += 1
+		c.Assert(m, gc.HasLen, saveCalls)
+		// TODO (anastasiamac 2016-08-24) This is a check for a band-aid solution.
+		// Once correct value is read from simplestreams, this needs to go.
+		// Bug# 1616295
+		// Ensure empty stream is changed to release
+		c.Assert(m[0].Stream, gc.DeepEquals, "released")
+		if saveCalls == 1 {
+			// don't err on first call
+			return nil
+		}
+		return errors.New(msg)
+	}
+
+	errs, err := imagecommon.Save(s.st, params.MetadataSaveParams{
+		Metadata: []params.CloudImageMetadataList{{
+			Metadata: []params.CloudImageMetadata{m},
+		}, {
+			Metadata: []params.CloudImageMetadata{m, m},
+		}},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(errs, gc.HasLen, 2)
+	c.Assert(errs[0].Error, gc.IsNil)
+	c.Assert(errs[1].Error, gc.ErrorMatches, msg)
+	s.st.CheckCallNames(c, "ModelConfig", "SaveMetadata", "SaveMetadata")
+}
+
+type mockState struct {
+	testing.Stub
+	saveMetadata func(m []cloudimagemetadata.Metadata) error
+	modelCfg     func() (*config.Config, error)
+}
+
+func (s *mockState) SaveMetadata(m []cloudimagemetadata.Metadata) error {
+	s.MethodCall(s, "SaveMetadata", m)
+	return s.saveMetadata(m)
+}
+
+func (s *mockState) ModelConfig() (*config.Config, error) {
+	s.MethodCall(s, "ModelConfig")
+	return s.modelCfg()
+}
+
+func testConfig(c *gc.C) *config.Config {
+	cfg, err := config.New(config.UseDefaults, coretesting.FakeConfig().Merge(coretesting.Attrs{
+		"type": "mock",
+	}))
+	c.Assert(err, jc.ErrorIsNil)
+	return cfg
+}

--- a/apiserver/common/imagecommon/package_test.go
+++ b/apiserver/common/imagecommon/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package imagecommon_test
+
+import (
+	stdtesting "testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func TestAll(t *stdtesting.T) {
+	gc.TestingT(t)
+}

--- a/apiserver/facades/client/imagemetadata/updatefrompublished_test.go
+++ b/apiserver/facades/client/imagemetadata/updatefrompublished_test.go
@@ -282,7 +282,7 @@ func (s *regionMetadataSuite) setExpectations(c *gc.C) {
 func (s *regionMetadataSuite) checkStoredPublished(c *gc.C) {
 	err := s.api.UpdateFromPublishedImages()
 	c.Assert(err, jc.ErrorIsNil)
-	s.assertCalls(c, "ControllerTag", "ControllerTag", environConfig, saveMetadata)
+	s.assertCalls(c, "ControllerTag", environConfig, saveMetadata)
 	c.Assert(s.saved, jc.SameContents, s.expected)
 }
 
@@ -398,7 +398,7 @@ func (s *regionMetadataSuite) TestUpdateFromPublishedImagesMultipleDS(c *gc.C) {
 
 	err = s.api.UpdateFromPublishedImages()
 	c.Assert(err, jc.ErrorIsNil)
-	s.assertCalls(c, "ControllerTag", "ControllerTag", environConfig, saveMetadata, "ControllerTag", environConfig, saveMetadata)
+	s.assertCalls(c, "ControllerTag", environConfig, saveMetadata, environConfig, saveMetadata)
 	c.Assert(s.saved, jc.SameContents, s.expected)
 }
 


### PR DESCRIPTION
## Description of change

This is a pre-cursor to image metadata facade split. 
It re-factors Save functionality that caused original amalgamation. It purely moves existing code in a commonly used area.
The reason for this PR is to minimize surface difference of the follow up PRs that will contain the actual facade split.

## QA steps

As this is an internal change, no existing functionality nor behavior is affected, i.e. all unit and CI tests pass. 

## Documentation changes

n/a

## Bug reference

This is part 1 of work to resolve https://bugs.launchpad.net/juju/+bug/1703582
