### PR TITLE
Fix lp#1703000 - cloud file validation error

### DIFF
--- a/cloud/validations.go
+++ b/cloud/validations.go
@@ -104,7 +104,7 @@ func validateCloud(data []byte, jsonSchema *map[string]interface{}) error {
 	formatKeyError := func(invalidKey, similarValidKey string) string {
 		str := fmt.Sprintf("property %s is invalid.", invalidKey)
 		if similarValidKey != "" {
-			str = fmt.Sprintf("%s Perhaps you mean \"%s\".", str, similarValidKey)
+			str = fmt.Sprintf("%s Perhaps you mean %q.", str, similarValidKey)
 		}
 		return str
 	}

--- a/cmd/juju/cloud/add.go
+++ b/cmd/juju/cloud/add.go
@@ -5,6 +5,7 @@ package cloud
 
 import (
 	"fmt"
+	"io/ioutil"
 	"sort"
 	"strings"
 
@@ -126,6 +127,7 @@ func (c *AddCloudCommand) Run(ctxt *cmd.Context) error {
 	if c.CloudFile == "" {
 		return c.runInteractive(ctxt)
 	}
+
 	specifiedClouds, err := c.cloudMetadataStore.ParseCloudMetadataFile(c.CloudFile)
 	if err != nil {
 		return err
@@ -139,8 +141,12 @@ func (c *AddCloudCommand) Run(ctxt *cmd.Context) error {
 	}
 
 	// first validate cloud input
-	if err = cloud.ValidateCloudSet([]byte(c.CloudFile)); err != nil {
-		ctxt.Warningf("%s", err.Error())
+	data, err := ioutil.ReadFile(c.CloudFile)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	if err = cloud.ValidateCloudSet([]byte(data)); err != nil {
+		ctxt.Warningf(err.Error())
 	}
 
 	// validate cloud data

--- a/state/machine_linklayerdevices.go
+++ b/state/machine_linklayerdevices.go
@@ -183,7 +183,7 @@ func (m *Machine) SetLinkLayerDevices(devicesArgs ...LinkLayerDeviceArgs) (err e
 	defer errors.DeferredAnnotatef(&err, "cannot set link-layer devices to machine %q", m.doc.Id)
 
 	if len(devicesArgs) == 0 {
-		logger.Warningf("no device addresses to set")
+		logger.Debugf("no device addresses to set")
 		return nil
 	}
 
@@ -607,7 +607,7 @@ func (m *Machine) SetDevicesAddresses(devicesAddresses ...LinkLayerDeviceAddress
 	defer errors.DeferredAnnotatef(&err, "cannot set link-layer device addresses of machine %q", m.doc.Id)
 
 	if len(devicesAddresses) == 0 {
-		logger.Warningf("no device addresses to set")
+		logger.Debugf("no device addresses to set")
 		return nil
 	}
 


### PR DESCRIPTION
## Description of change

Fixes the referenced bug.

When validating a cloud definition yaml file, juju would give erroneous warnings of the form described in the referenced bug. This PR fixes that error.  

## QA steps

create a file with the contents:

```yaml
clouds:
  foundations:
    type: maas
    auth-types: [oauth1]
    endpoint: "http://10.245.31.100/MAAS"
```
then issue the following command:

```
juju add-cloud foundations <path to the file>
``` 

juju should issue no warning since the file's contents are valid

change the file's contents to the following:
```yaml
clouds:
  foundations:
    type: maas
    aut-types: [oauth1]
    endoint: "http://10.245.31.100/MAAS"
```

*notice how the property "auth-types" was changed to "aut-types" and the property "endpoint" was changed to "endoint"*.

again, issue the following command:

```
juju add-cloud foundations <path to the file>
``` 

you should receive the following error:

```
WARNING 
property "auh-types" is invalid. Perhaps you mean "auth-types".
property "endoint" is invalid. Perhaps you mean "endpoint".
```

## Documentation changes

No

## Bug reference

[lp#1703000](https://bugs.launchpad.net/juju/+bug/1703000)