### PR TITLE
Use macaroons to authenticate calls from remote relations worker

### DIFF
--- a/api/crossmodelrelations/crossmodelrelations.go
+++ b/api/crossmodelrelations/crossmodelrelations.go
@@ -60,11 +60,11 @@ func (c *Client) PublishIngressNetworkChange(change params.IngressNetworksChange
 	return results.OneError()
 }
 
-// RegisterRemoteRelation sets up the remote model to participate
+// RegisterRemoteRelations sets up the remote model to participate
 // in the specified relations.
-func (c *Client) RegisterRemoteRelations(relations ...params.RegisterRemoteRelation) ([]params.RemoteEntityIdResult, error) {
-	args := params.RegisterRemoteRelations{Relations: relations}
-	var results params.RemoteEntityIdResults
+func (c *Client) RegisterRemoteRelations(relations ...params.RegisterRemoteRelationArg) ([]params.RegisterRemoteRelationResult, error) {
+	args := params.RegisterRemoteRelationArgs{Relations: relations}
+	var results params.RegisterRemoteRelationResults
 	err := c.facade.FacadeCall("RegisterRemoteRelations", args, &results)
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -77,8 +77,8 @@ func (c *Client) RegisterRemoteRelations(relations ...params.RegisterRemoteRelat
 
 // WatchRelationUnits returns a watcher that notifies of changes to the
 // units in the remote model for the relation with the given remote id.
-func (c *Client) WatchRelationUnits(remoteRelationId params.RemoteEntityId) (watcher.RelationUnitsWatcher, error) {
-	args := params.RemoteEntities{Entities: []params.RemoteEntityId{remoteRelationId}}
+func (c *Client) WatchRelationUnits(remoteRelationArg params.RemoteRelationArg) (watcher.RelationUnitsWatcher, error) {
+	args := params.RemoteRelationArgs{Args: []params.RemoteRelationArg{remoteRelationArg}}
 	var results params.RelationUnitsWatchResults
 	err := c.facade.FacadeCall("WatchRelationUnits", args, &results)
 	if err != nil {

--- a/apiserver/common/crossmodel/auth.go
+++ b/apiserver/common/crossmodel/auth.go
@@ -1,0 +1,29 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package crossmodel
+
+import (
+	"time"
+
+	"github.com/juju/errors"
+	"gopkg.in/macaroon-bakery.v1/bakery"
+
+	"github.com/juju/juju/state"
+)
+
+// NewBakery returns a bakery used for minting macaroons used
+// in cross model relations.
+func NewBakery(st *state.State) (*bakery.Service, error) {
+	store, err := st.NewBakeryStorage()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	// TODO(wallyworld) - shorten the exipry time when macaroon
+	// refresh is supported.
+	store = store.ExpireAfter(5 * 24 * 365 * time.Hour)
+	return bakery.NewService(bakery.NewServiceParams{
+		Location: "juju model " + st.ModelUUID(),
+		Store:    store,
+	})
+}

--- a/apiserver/common/crossmodel/crossmodel.go
+++ b/apiserver/common/crossmodel/crossmodel.go
@@ -17,18 +17,8 @@ import (
 var logger = loggo.GetLogger("juju.apiserver.common.crossmodel")
 
 // PublishRelationChange applies the relation change event to the specified backend.
-func PublishRelationChange(backend Backend, change params.RemoteRelationChangeEvent) error {
-	logger.Debugf("publish into model %v change: %+v", backend.ModelUUID(), change)
-
-	relationTag, err := getRemoteEntityTag(backend, change.RelationId)
-	if err != nil {
-		if errors.IsNotFound(err) {
-			logger.Debugf("not found relation tag %+v in model %v, exit early", change.RelationId, backend.ModelUUID())
-			return nil
-		}
-		return errors.Trace(err)
-	}
-	logger.Debugf("relation tag for remote id %+v is %v", change.RelationId, relationTag)
+func PublishRelationChange(backend Backend, relationTag names.Tag, change params.RemoteRelationChangeEvent) error {
+	logger.Debugf("publish into model %v change for %v: %+v", backend.ModelUUID(), relationTag, change)
 
 	// Ensure the relation exists.
 	rel, err := backend.KeyRelation(relationTag.Id())
@@ -184,14 +174,8 @@ func RelationUnitSettings(backend Backend, ru params.RelationUnit) (params.Setti
 }
 
 // PublishIngressNetworkChange saves the specified ingress networks for a relation.
-func PublishIngressNetworkChange(backend Backend, change params.IngressNetworksChangeEvent) error {
-	logger.Debugf("publish into model %v network change: %+v", backend.ModelUUID(), change)
-
-	relationTag, err := getRemoteEntityTag(backend, change.RelationId)
-	if err != nil {
-		return errors.Trace(err)
-	}
-	logger.Debugf("relation tag for remote id %+v is %v", change.RelationId, relationTag)
+func PublishIngressNetworkChange(backend Backend, relationTag names.Tag, change params.IngressNetworksChangeEvent) error {
+	logger.Debugf("publish into model %v network change for %v: %+v", backend.ModelUUID(), relationTag, change)
 
 	// Ensure the relation exists.
 	rel, err := backend.KeyRelation(relationTag.Id())

--- a/apiserver/facades/client/applicationoffers/access_test.go
+++ b/apiserver/facades/client/applicationoffers/access_test.go
@@ -37,7 +37,7 @@ func (s *offerAccessSuite) SetUpTest(c *gc.C) {
 	resources.RegisterNamed("dataDir", common.StringResource(c.MkDir()))
 	var err error
 	s.api, err = applicationoffers.CreateOffersAPI(
-		getApplicationOffers, nil, s.mockState, s.mockStatePool, s.authorizer, resources,
+		getApplicationOffers, nil, s.mockState, s.mockStatePool, s.authorizer, resources, &mockBakeryService{},
 	)
 	c.Assert(err, jc.ErrorIsNil)
 }

--- a/apiserver/facades/client/applicationoffers/applicationoffers_test.go
+++ b/apiserver/facades/client/applicationoffers/applicationoffers_test.go
@@ -33,6 +33,7 @@ var _ = gc.Suite(&applicationOffersSuite{})
 
 func (s *applicationOffersSuite) SetUpTest(c *gc.C) {
 	s.baseSuite.SetUpTest(c)
+	s.bakery = &mockBakeryService{}
 	s.applicationOffers = &stubApplicationOffers{}
 	getApplicationOffers := func(interface{}) jujucrossmodel.ApplicationOffers {
 		return s.applicationOffers
@@ -46,7 +47,7 @@ func (s *applicationOffersSuite) SetUpTest(c *gc.C) {
 	}
 	var err error
 	s.api, err = applicationoffers.CreateOffersAPI(
-		getApplicationOffers, getEnviron, s.mockState, s.mockStatePool, s.authorizer, resources,
+		getApplicationOffers, getEnviron, s.mockState, s.mockStatePool, s.authorizer, resources, s.bakery,
 	)
 	c.Assert(err, jc.ErrorIsNil)
 }
@@ -909,6 +910,7 @@ var _ = gc.Suite(&consumeSuite{})
 
 func (s *consumeSuite) SetUpTest(c *gc.C) {
 	s.baseSuite.SetUpTest(c)
+	s.bakery = &mockBakeryService{}
 	getApplicationOffers := func(st interface{}) jujucrossmodel.ApplicationOffers {
 		return &mockApplicationOffers{st: st.(*mockState)}
 	}
@@ -921,7 +923,7 @@ func (s *consumeSuite) SetUpTest(c *gc.C) {
 	}
 	var err error
 	s.api, err = applicationoffers.CreateOffersAPI(
-		getApplicationOffers, getEnviron, s.mockState, s.mockStatePool, s.authorizer, resources,
+		getApplicationOffers, getEnviron, s.mockState, s.mockStatePool, s.authorizer, resources, s.bakery,
 	)
 	c.Assert(err, jc.ErrorIsNil)
 }
@@ -993,8 +995,7 @@ func (s *consumeSuite) TestConsumeDetailsWithPermission(c *gc.C) {
 		Addrs:         []string{"192.168.1.1:17070"},
 		CACert:        testing.CACert,
 	})
-	// TODO(wallyworld)
-	c.Assert(results.Results[0].Macaroon, gc.IsNil)
+	c.Assert(results.Results[0].Macaroon.Id(), gc.Equals, "")
 }
 
 func (s *consumeSuite) TestConsumeDetailsDefaultEndpoint(c *gc.C) {

--- a/apiserver/facades/client/applicationoffers/base_test.go
+++ b/apiserver/facades/client/applicationoffers/base_test.go
@@ -35,6 +35,7 @@ type baseSuite struct {
 	mockState         *mockState
 	mockStatePool     *mockStatePool
 	env               *mockEnviron
+	bakery            *mockBakeryService
 	applicationOffers *stubApplicationOffers
 }
 

--- a/apiserver/facades/client/applicationoffers/mock_test.go
+++ b/apiserver/facades/client/applicationoffers/mock_test.go
@@ -11,7 +11,10 @@ import (
 	"github.com/juju/utils/set"
 	"gopkg.in/juju/charm.v6-unstable"
 	"gopkg.in/juju/names.v2"
+	"gopkg.in/macaroon-bakery.v1/bakery/checkers"
+	"gopkg.in/macaroon.v1"
 
+	"github.com/juju/juju/apiserver/authentication"
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/facades/client/applicationoffers"
 	jujucrossmodel "github.com/juju/juju/core/crossmodel"
@@ -395,4 +398,14 @@ func (st *mockStatePool) Get(modelUUID string) (applicationoffers.Backend, func(
 		return nil, nil, errors.NotFoundf("model for uuid %s", modelUUID)
 	}
 	return backend, func() {}, nil
+}
+
+type mockBakeryService struct {
+	authentication.BakeryService
+	jtesting.Stub
+}
+
+func (s *mockBakeryService) NewMacaroon(id string, key []byte, caveats []checkers.Caveat) (*macaroon.Macaroon, error) {
+	s.MethodCall(s, "NewMacaroon", id, key, caveats)
+	return macaroon.New(nil, id, "")
 }

--- a/apiserver/facades/controller/crossmodelrelations/state.go
+++ b/apiserver/facades/controller/crossmodelrelations/state.go
@@ -4,6 +4,8 @@
 package crossmodelrelations
 
 import (
+	"gopkg.in/juju/names.v2"
+
 	common "github.com/juju/juju/apiserver/common/crossmodel"
 	"github.com/juju/juju/core/crossmodel"
 	"github.com/juju/juju/state"
@@ -16,6 +18,9 @@ type CrossModelRelationsState interface {
 
 	// ListOffers returns the application offers matching any one of the filter terms.
 	ListOffers(filter ...crossmodel.ApplicationOfferFilter) ([]crossmodel.ApplicationOffer, error)
+
+	// Model returns the model entity.
+	Model() (Model, error)
 }
 
 type stateShim struct {
@@ -26,4 +31,13 @@ type stateShim struct {
 func (st stateShim) ListOffers(filter ...crossmodel.ApplicationOfferFilter) ([]crossmodel.ApplicationOffer, error) {
 	oa := state.NewApplicationOffers(st.st)
 	return oa.ListOffers(filter...)
+}
+
+type Model interface {
+	Name() string
+	Owner() names.UserTag
+}
+
+func (st stateShim) Model() (Model, error) {
+	return st.st.Model()
 }

--- a/apiserver/facades/controller/remoterelations/remoterelations.go
+++ b/apiserver/facades/controller/remoterelations/remoterelations.go
@@ -404,7 +404,15 @@ func (api *RemoteRelationsAPI) ConsumeRemoteRelationChange(
 		Results: make([]params.ErrorResult, len(changes.Changes)),
 	}
 	for i, change := range changes.Changes {
-		if err := commoncrossmodel.PublishRelationChange(api.st, change); err != nil {
+		relationTag, err := api.st.GetRemoteEntity(names.NewModelTag(change.RelationId.ModelUUID), change.RelationId.Token)
+		if err != nil {
+			if errors.IsNotFound(err) {
+				continue
+			}
+			results.Results[i].Error = common.ServerError(err)
+			continue
+		}
+		if err := commoncrossmodel.PublishRelationChange(api.st, relationTag, change); err != nil {
 			results.Results[i].Error = common.ServerError(err)
 			continue
 		}

--- a/apiserver/params/crossmodel.go
+++ b/apiserver/params/crossmodel.go
@@ -322,8 +322,8 @@ type RemoteRelationChangeEvent struct {
 	// the relation since the last change.
 	DepartedUnits []int `json:"departed-units,omitempty"`
 
-	// Macaroon is used for authentication.
-	Macaroon *macaroon.Macaroon `json:"macaroon,omitempty"`
+	// Macaroons are used for authentication.
+	Macaroons macaroon.Slice `json:"macaroons,omitempty"`
 }
 
 // IngressNetworksChanges holds a set of IngressNetworksChangeEvent structures.
@@ -345,12 +345,12 @@ type IngressNetworksChangeEvent struct {
 	// ingress should be disabled.
 	IngressRequired bool `json:"ingress-required"`
 
-	// Macaroon is used for authentication.
-	Macaroon *macaroon.Macaroon `json:"macaroon,omitempty"`
+	// Macaroons are used for authentication.
+	Macaroons macaroon.Slice `json:"macaroons,omitempty"`
 }
 
-// RegisterRemoteRelation holds attributes used to register a remote relation.
-type RegisterRemoteRelation struct {
+// RegisterRemoteRelationArg holds attributes used to register a remote relation.
+type RegisterRemoteRelationArg struct {
 	// ApplicationId is the application id on the remote model.
 	ApplicationId RemoteEntityId `json:"application-id"`
 
@@ -370,13 +370,42 @@ type RegisterRemoteRelation struct {
 	// LocalEndpointName is the name of the endpoint in the local model.
 	LocalEndpointName string `json:"local-endpoint-name"`
 
-	// Macaroon is used for authentication.
-	Macaroon *macaroon.Macaroon `json:"macaroon,omitempty"`
+	// Macaroons are used for authentication.
+	Macaroons macaroon.Slice `json:"macaroons,omitempty"`
 }
 
-// RegisterRemoteRelations holds args used to add remote relations.
-type RegisterRemoteRelations struct {
-	Relations []RegisterRemoteRelation `json:"relations"`
+// RegisterRemoteRelationArgs holds args used to add remote relations.
+type RegisterRemoteRelationArgs struct {
+	Relations []RegisterRemoteRelationArg `json:"relations"`
+}
+
+// RemoteRelationDetails holds the details of the
+// newly registered remote relation.
+type RemoteRelationDetails struct {
+	RemoteEntityId
+	Macaroon *macaroon.Macaroon `json:"macaroon"`
+}
+
+// RemoteEntityIdResult holds a remote entity id and an error.
+type RegisterRemoteRelationResult struct {
+	Result *RemoteRelationDetails `json:"result,omitempty"`
+	Error  *Error                 `json:"error,omitempty"`
+}
+
+// RemoteRemoteRelationResults has a set of remote relation results.
+type RegisterRemoteRelationResults struct {
+	Results []RegisterRemoteRelationResult `json:"results,omitempty"`
+}
+
+// RemoteRelationArg holds a remote relation id and macaroon.
+type RemoteRelationArg struct {
+	RemoteEntityId
+	Macaroons macaroon.Slice `json:"macaroons,omitempty"`
+}
+
+// RemoteRelationArgs holds arguments to an API call dealing with remote relations.
+type RemoteRelationArgs struct {
+	Args []RemoteRelationArg `json:"args"`
 }
 
 // RemoteApplicationInfo has attributes for a remote application.
@@ -436,6 +465,7 @@ type RemoteEntities struct {
 type RemoteRelationUnit struct {
 	RelationId RemoteEntityId `json:"relation"`
 	Unit       string         `json:"unit"`
+	Macaroons  macaroon.Slice `json:"macaroons,omitempty"`
 }
 
 // RemoteRelationUnits identifies multiple remote relation units.

--- a/featuretests/bakerystorage_test.go
+++ b/featuretests/bakerystorage_test.go
@@ -8,6 +8,7 @@ import (
 
 	gitjujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
+	"github.com/juju/utils/clock"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/macaroon-bakery.v1/bakery"
 	"gopkg.in/macaroon.v1"
@@ -41,6 +42,7 @@ func (s *BakeryStorageSuite) initService(c *gc.C, enableExpiry bool) {
 		GetCollection: func() (mongo.Collection, func()) {
 			return mongo.CollectionFromName(s.db, s.coll.Name)
 		},
+		Clock: clock.WallClock,
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	if enableExpiry {

--- a/state/bakerystorage.go
+++ b/state/bakerystorage.go
@@ -4,6 +4,8 @@
 package state
 
 import (
+	"github.com/juju/utils/clock"
+
 	"github.com/juju/juju/mongo"
 	"github.com/juju/juju/state/bakerystorage"
 )
@@ -17,5 +19,6 @@ func (st *State) NewBakeryStorage() (bakerystorage.ExpirableStorage, error) {
 		GetCollection: func() (mongo.Collection, func()) {
 			return st.db().GetCollection(bakeryStorageItemsC)
 		},
+		Clock: clock.WallClock,
 	})
 }


### PR DESCRIPTION
## Description of change is this change needed?

The facade calls made by the remote relations worker now use macaroons to do auth.
When an offer is consumed, a macaroon is minted which is attenuated to the source model and offer url. This macaroon is used to validate the subsequent register remote relation call. Doing the registration mints a new macaroon attenuated to the source model and relation. This new macaroon is then used to validate settings replication and other cross model calls.

A new ExpireAfter() method is added to the bakery storage in state. This allows cmr macaroons to be purged from state after a set time period after minting. Initially, the expiry times and time before caveats are all quite long pending subsequent work to periodically refresh the macaroons.

## QA steps

run a cmr scenario and ensure there are no authentication errors
