### PR TITLE
BUG 1699941 stop ignoring region-config values set for a cloud

### DIFF
--- a/cmd/juju/commands/bootstrap.go
+++ b/cmd/juju/commands/bootstrap.go
@@ -897,6 +897,19 @@ func (c *bootstrapCommand) bootstrapConfigs(
 		}
 		inheritedControllerAttrs[k] = v
 	}
+	// Region config values, for the region to be bootstrapped, from clouds.yaml
+	// override what is in the cloud config.
+	for k, v := range cloud.RegionConfig[c.Region] {
+		switch {
+		case bootstrap.IsBootstrapAttribute(k):
+			bootstrapConfigAttrs[k] = v
+			continue
+		case controller.ControllerOnlyAttribute(k):
+			controllerConfigAttrs[k] = v
+			continue
+		}
+		inheritedControllerAttrs[k] = v
+	}
 	// Model defaults are added to the inherited controller attributes.
 	// Any command line set model defaults override what is in the cloud config.
 	for k, v := range modelDefaultConfigAttrs {


### PR DESCRIPTION
by adding their values to the bootstrap config.

## Please provide the following details to expedite Pull Request review:

----

## Description of change

Add the region-config values for use during bootstrap.  They should over
write the cloud-config values, but not any config values specified on the CLI
during bootstrap.

## QA steps

1. Create a yaml cloud config file to add an openstack cloud, including both
cloud-config and region-config values.  Suggest using the network config
attribute, where only the related value in region-config will work.
2. Add an openstack cloud to juju with yaml file from step two.
3. Bootstrap the new cloud.
4. Try to bootstrap the new cloud including --config network=no-such-network and 
watch it fail.

## Documentation changes

N/A

## Bug reference

https://bugs.launchpad.net/juju/+bug/1699941