### PR TITLE
Drop lxd-storage feature flag

### DIFF
--- a/feature/flags.go
+++ b/feature/flags.go
@@ -37,9 +37,6 @@ const DeveloperMode = "developer-mode"
 // CrossModelRelations allows cross model relations functionality.
 const CrossModelRelations = "cross-model"
 
-// LXDStorage enables the LXD storage provider.
-const LXDStorage = "lxd-storage"
-
 // StrictMigration will cause migration to error if there are unexported
 // values for annotations, status, status history, or settings.
 const StrictMigration = "strict-migration"

--- a/provider/lxd/environ.go
+++ b/provider/lxd/environ.go
@@ -168,6 +168,11 @@ func (env *environ) Destroy() error {
 	if err := env.base.DestroyEnv(); err != nil {
 		return errors.Trace(err)
 	}
+	if env.storageSupported() {
+		if err := destroyModelFilesystems(env); err != nil {
+			return errors.Annotate(err, "destroying LXD filesystems for model")
+		}
+	}
 	return nil
 }
 
@@ -178,6 +183,11 @@ func (env *environ) DestroyController(controllerUUID string) error {
 	}
 	if err := env.destroyHostedModelResources(controllerUUID); err != nil {
 		return errors.Trace(err)
+	}
+	if env.storageSupported() {
+		if err := destroyControllerFilesystems(env, controllerUUID); err != nil {
+			return errors.Annotate(err, "destroying LXD filesystems for controller")
+		}
 	}
 	return nil
 }

--- a/provider/lxd/environ_raw.go
+++ b/provider/lxd/environ_raw.go
@@ -61,6 +61,11 @@ type lxdImages interface {
 
 type lxdStorage interface {
 	StorageSupported() bool
+
+	StoragePool(name string) (lxdapi.StoragePool, error)
+	StoragePools() ([]lxdapi.StoragePool, error)
+	CreateStoragePool(name, driver string, attrs map[string]string) error
+
 	VolumeCreate(pool, volume string, config map[string]string) error
 	VolumeDelete(pool, volume string) error
 	VolumeList(pool string) ([]lxdapi.StorageVolume, error)

--- a/provider/lxd/storage_test.go
+++ b/provider/lxd/storage_test.go
@@ -24,9 +24,7 @@ type storageSuite struct {
 var _ = gc.Suite(&storageSuite{})
 
 func (s *storageSuite) SetUpTest(c *gc.C) {
-	s.SetInitialFeatureFlags("lxd-storage")
 	s.BaseSuite.SetUpTest(c)
-	s.Client.StorageIsSupported = true
 
 	provider, err := s.Env.StorageProvider("lxd")
 	c.Assert(err, jc.ErrorIsNil)
@@ -52,11 +50,6 @@ func (s *storageSuite) TestStorageProviderTypes(c *gc.C) {
 	types, err = s.Env.StorageProviderTypes()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(types, jc.DeepEquals, []storage.ProviderType{"lxd"})
-
-	s.SetFeatureFlags( /*none*/ )
-	types, err = s.Env.StorageProviderTypes()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(types, gc.HasLen, 0)
 }
 
 func (s *storageSuite) TestVolumeSource(c *gc.C) {
@@ -83,13 +76,17 @@ func (s *storageSuite) TestScope(c *gc.C) {
 }
 
 func (s *storageSuite) TestCreateFilesystems(c *gc.C) {
-	source := s.filesystemSource(c, "radiance")
+	source := s.filesystemSource(c, "source")
 	results, err := source.CreateFilesystems([]storage.FilesystemParams{{
 		Tag:      names.NewFilesystemTag("0"),
 		Provider: "lxd",
 		Size:     1024,
 		ResourceTags: map[string]string{
 			"key": "value",
+		},
+		Attributes: map[string]interface{}{
+			"lxd-pool": "radiance",
+			"driver":   "btrfs",
 		},
 	}})
 	c.Assert(err, jc.ErrorIsNil)
@@ -99,34 +96,71 @@ func (s *storageSuite) TestCreateFilesystems(c *gc.C) {
 		names.NewFilesystemTag("0"),
 		names.VolumeTag{},
 		storage.FilesystemInfo{
-			FilesystemId: "radiance:filesystem-0",
+			FilesystemId: "radiance:juju-f75cba-filesystem-0",
 			Size:         1024,
 		},
 	})
 
-	s.Stub.CheckCallNames(c, "VolumeCreate")
-	s.Stub.CheckCall(c, 0, "VolumeCreate", "radiance", "filesystem-0", map[string]string{
+	s.Stub.CheckCallNames(c, "CreateStoragePool", "VolumeCreate")
+	s.Stub.CheckCall(c, 0, "CreateStoragePool", "radiance", "btrfs", map[string]string(nil))
+	s.Stub.CheckCall(c, 1, "VolumeCreate", "radiance", "juju-f75cba-filesystem-0", map[string]string{
+		"user.key": "value",
+		"size":     "1024MB",
+	})
+}
+
+func (s *storageSuite) TestCreateFilesystemsPoolExists(c *gc.C) {
+	s.Stub.SetErrors(errors.New("pool already exists"))
+	source := s.filesystemSource(c, "source")
+	results, err := source.CreateFilesystems([]storage.FilesystemParams{{
+		Tag:      names.NewFilesystemTag("0"),
+		Provider: "lxd",
+		Size:     1024,
+		ResourceTags: map[string]string{
+			"key": "value",
+		},
+		Attributes: map[string]interface{}{
+			"lxd-pool": "radiance",
+			"driver":   "dir",
+		},
+	}})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(results, gc.HasLen, 1)
+	c.Assert(results[0].Error, jc.ErrorIsNil)
+	c.Assert(results[0].Filesystem, jc.DeepEquals, &storage.Filesystem{
+		names.NewFilesystemTag("0"),
+		names.VolumeTag{},
+		storage.FilesystemInfo{
+			FilesystemId: "radiance:juju-f75cba-filesystem-0",
+			Size:         1024,
+		},
+	})
+
+	s.Stub.CheckCallNames(c, "CreateStoragePool", "StoragePool", "VolumeCreate")
+	s.Stub.CheckCall(c, 0, "CreateStoragePool", "radiance", "dir", map[string]string(nil))
+	s.Stub.CheckCall(c, 1, "StoragePool", "radiance")
+	s.Stub.CheckCall(c, 2, "VolumeCreate", "radiance", "juju-f75cba-filesystem-0", map[string]string{
 		"user.key": "value",
 	})
 }
 
 func (s *storageSuite) TestDestroyFilesystems(c *gc.C) {
 	s.Stub.SetErrors(nil, errors.New("boom"))
-	source := s.filesystemSource(c, "pool")
+	source := s.filesystemSource(c, "source")
 	results, err := source.DestroyFilesystems([]string{
-		"notmypool:filesystem-0",
-		"pool:filesystem-0",
-		"pool:filesystem-1",
+		"filesystem-0",
+		"pool0:filesystem-0",
+		"pool1:filesystem-1",
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, gc.HasLen, 3)
-	c.Assert(results[0], gc.ErrorMatches, `filesystem ID "notmypool:filesystem-0" not valid`)
+	c.Assert(results[0], gc.ErrorMatches, `filesystem ID "filesystem-0" not valid`)
 	c.Assert(results[1], jc.ErrorIsNil)
 	c.Assert(results[2], gc.ErrorMatches, "boom")
 
 	s.Stub.CheckCalls(c, []testing.StubCall{
-		{"VolumeDelete", []interface{}{"pool", "filesystem-0"}},
-		{"VolumeDelete", []interface{}{"pool", "filesystem-1"}},
+		{"VolumeDelete", []interface{}{"pool0", "filesystem-0"}},
+		{"VolumeDelete", []interface{}{"pool1", "filesystem-1"}},
 	})
 }
 

--- a/provider/lxd/testing_test.go
+++ b/provider/lxd/testing_test.go
@@ -328,7 +328,8 @@ func (s *BaseSuite) SetUpTest(c *gc.C) {
 
 	s.Stub = &gitjujutesting.Stub{}
 	s.Client = &StubClient{
-		Stub: s.Stub,
+		Stub:               s.Stub,
+		StorageIsSupported: true,
 		Server: &api.Server{
 			ServerPut: api.ServerPut{
 				Config: map[string]interface{}{},
@@ -599,6 +600,30 @@ func (conn *StubClient) RemoveDevice(container, device string) error {
 func (conn *StubClient) StorageSupported() bool {
 	conn.AddCall("StorageSupported")
 	return conn.StorageIsSupported
+}
+
+func (conn *StubClient) StoragePool(name string) (api.StoragePool, error) {
+	conn.AddCall("StoragePool", name)
+	return api.StoragePool{
+		Name:   name,
+		Driver: "dir",
+	}, conn.NextErr()
+}
+
+func (conn *StubClient) StoragePools() ([]api.StoragePool, error) {
+	conn.AddCall("StoragePools")
+	return []api.StoragePool{{
+		Name:   "juju",
+		Driver: "dir",
+	}, {
+		Name:   "juju-zfs",
+		Driver: "zfs",
+	}}, conn.NextErr()
+}
+
+func (conn *StubClient) CreateStoragePool(name, driver string, attrs map[string]string) error {
+	conn.AddCall("CreateStoragePool", name, driver, attrs)
+	return conn.NextErr()
 }
 
 func (conn *StubClient) VolumeCreate(pool, volume string, config map[string]string) error {

--- a/storage/interface.go
+++ b/storage/interface.go
@@ -306,13 +306,6 @@ type CreateFilesystemsResult struct {
 	Error      error
 }
 
-// DescribeFilesystemsResult contains the result of a FilesystemSource.DescribeFilesystems call
-// for one filesystem. Filesystem should only be used if Error is nil.
-type DescribeFilesystemsResult struct {
-	FilesystemInfo *FilesystemInfo
-	Error          error
-}
-
 // AttachFilesystemsResult contains the result of a FilesystemSource.AttachFilesystems call
 // for one filesystem. FilesystemAttachment should only be used if Error is nil.
 type AttachFilesystemsResult struct {

--- a/tools/lxdclient/client_storage.go
+++ b/tools/lxdclient/client_storage.go
@@ -6,11 +6,18 @@
 package lxdclient
 
 import (
+	"net/http"
+
 	"github.com/juju/errors"
+	"github.com/lxc/lxd"
 	"github.com/lxc/lxd/shared/api"
 )
 
 type rawStorageClient interface {
+	StoragePoolCreate(name string, driver string, config map[string]string) error
+	StoragePoolGet(name string) (api.StoragePool, error)
+	ListStoragePools() ([]api.StoragePool, error)
+
 	StoragePoolVolumeTypeCreate(pool string, volume string, volumeType string, config map[string]string) error
 	StoragePoolVolumeTypeDelete(pool string, volume string, volumeType string) error
 	StoragePoolVolumesList(pool string) ([]api.StorageVolume, error)
@@ -39,7 +46,13 @@ func (c *storageClient) VolumeDelete(pool, volume string) error {
 	if !c.supported {
 		return errors.NotSupportedf("storage API on this remote")
 	}
-	return c.raw.StoragePoolVolumeTypeDelete(pool, volume, "custom")
+	if err := c.raw.StoragePoolVolumeTypeDelete(pool, volume, "custom"); err != nil {
+		if err == lxd.LXDErrors[http.StatusNotFound] {
+			return errors.NotFoundf("volume %q in pool %q", volume, pool)
+		}
+		return err
+	}
+	return nil
 }
 
 // VolumeList lists volumes in a storage pool, excluding any non-custom type
@@ -59,4 +72,41 @@ func (c *storageClient) VolumeList(pool string) ([]api.StorageVolume, error) {
 		}
 	}
 	return custom, nil
+}
+
+// StoragePool returns the LXD storage pool with the given name.
+func (c *storageClient) StoragePool(name string) (api.StoragePool, error) {
+	if !c.supported {
+		return api.StoragePool{}, errors.NotSupportedf("storage API on this remote")
+	}
+	pool, err := c.raw.StoragePoolGet(name)
+	if err != nil {
+		if err == lxd.LXDErrors[http.StatusNotFound] {
+			return api.StoragePool{}, errors.NotFoundf("storage pool %q", name)
+		}
+		return api.StoragePool{}, errors.Annotatef(err, "getting storage pool %q", name)
+	}
+	return pool, nil
+}
+
+// StoragePools returns all of the LXD storage pools.
+func (c *storageClient) StoragePools() ([]api.StoragePool, error) {
+	if !c.supported {
+		return nil, errors.NotSupportedf("storage API on this remote")
+	}
+	pools, err := c.raw.ListStoragePools()
+	if err != nil {
+		return nil, errors.Annotate(err, "listing storage pools")
+	}
+	return pools, nil
+}
+
+// CreateStoragePool creates a LXD storage pool with the given name, driver,
+// and configuration attributes.
+func (c *storageClient) CreateStoragePool(name, driver string, attrs map[string]string) error {
+	if !c.supported {
+		return errors.NotSupportedf("storage API on this remote")
+	}
+	err := c.raw.StoragePoolCreate(name, driver, attrs)
+	return errors.Annotatef(err, "creating storage pool %q", name)
 }


### PR DESCRIPTION
## Description of change

Tidy up the lxd storage provider, and drop the feature flag.
This PR makes the "lxd" storage provider usable for creating
model-level filesystems. This provider does not support
block storage. The filesystems can be dynamically created,
destroyed, attached, and detached.

Using the "lxd" storage pool (i.e. without configuration),
storage will be allocated from the LXD storage pool called
"juju", using the driver "dir". The provider also predefines
a "lxd-zfs" storage pool, which maps to the LXD storage pool
called "juju-zfs", using a zfs pool of the same name. Juju
will create the LXD storage pools as necessary, and will
ensure that they have the same configuration before use.

## QA steps

1. juju bootstrap localhost
2. juju deploy postgresql --storage pgdata=1G,lxd

Confirm that the machine comes up, and postgresql deploys successfully. Using "lxd storage list juju", you should be able to see the volume created by Juju. Then, opening a terminal in the container, you should be able to see that volume mounted at /srv/pgdata, with the postgresql database stored within it.

## Documentation changes

Yes, we should update the storage docs to refer to this new storage provider.

## Bug reference

None.