### PR TITLE
Use macaroon to validate published network changes for cmr

### DIFF
--- a/api/firewaller/application.go
+++ b/api/firewaller/application.go
@@ -15,7 +15,7 @@ import (
 
 // Service represents the state of a service.
 type Application struct {
-	st   *State
+	st   *Client
 	tag  names.ApplicationTag
 	life params.Life
 }

--- a/api/firewaller/firewaller.go
+++ b/api/firewaller/firewaller.go
@@ -14,21 +14,22 @@ import (
 	apiwatcher "github.com/juju/juju/api/watcher"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/watcher"
+	"gopkg.in/macaroon.v1"
 )
 
 const firewallerFacade = "Firewaller"
 
-// State provides access to the Firewaller API facade.
-type State struct {
+// Client provides access to the Firewaller API facade.
+type Client struct {
 	facade base.FacadeCaller
 	*common.ModelWatcher
 	*cloudspec.CloudSpecAPI
 }
 
-// NewState creates a new client-side Firewaller API facade.
-func NewState(caller base.APICaller) *State {
+// NewClient creates a new client-side Firewaller API facade.
+func NewClient(caller base.APICaller) *Client {
 	facadeCaller := base.NewFacadeCaller(caller, firewallerFacade)
-	return &State{
+	return &Client{
 		facade:       facadeCaller,
 		ModelWatcher: common.NewModelWatcher(facadeCaller),
 		CloudSpecAPI: cloudspec.NewCloudSpecAPI(facadeCaller),
@@ -37,67 +38,67 @@ func NewState(caller base.APICaller) *State {
 
 // BestAPIVersion returns the API version that we were able to
 // determine is supported by both the client and the API Server.
-func (st *State) BestAPIVersion() int {
-	return st.facade.BestAPIVersion()
+func (c *Client) BestAPIVersion() int {
+	return c.facade.BestAPIVersion()
 }
 
 // ModelTag returns the current model's tag.
-func (st *State) ModelTag() (names.ModelTag, bool) {
-	return st.facade.RawAPICaller().ModelTag()
+func (c *Client) ModelTag() (names.ModelTag, bool) {
+	return c.facade.RawAPICaller().ModelTag()
 }
 
 // life requests the life cycle of the given entity from the server.
-func (st *State) life(tag names.Tag) (params.Life, error) {
-	return common.Life(st.facade, tag)
+func (c *Client) life(tag names.Tag) (params.Life, error) {
+	return common.Life(c.facade, tag)
 }
 
 // Unit provides access to methods of a state.Unit through the facade.
-func (st *State) Unit(tag names.UnitTag) (*Unit, error) {
-	life, err := st.life(tag)
+func (c *Client) Unit(tag names.UnitTag) (*Unit, error) {
+	life, err := c.life(tag)
 	if err != nil {
 		return nil, err
 	}
 	return &Unit{
 		tag:  tag,
 		life: life,
-		st:   st,
+		st:   c,
 	}, nil
 }
 
 // Machine provides access to methods of a state.Machine through the
 // facade.
-func (st *State) Machine(tag names.MachineTag) (*Machine, error) {
-	life, err := st.life(tag)
+func (c *Client) Machine(tag names.MachineTag) (*Machine, error) {
+	life, err := c.life(tag)
 	if err != nil {
 		return nil, err
 	}
 	return &Machine{
 		tag:  tag,
 		life: life,
-		st:   st,
+		st:   c,
 	}, nil
 }
 
 // WatchModelMachines returns a StringsWatcher that notifies of
 // changes to the life cycles of the top level machines in the current
 // model.
-func (st *State) WatchModelMachines() (watcher.StringsWatcher, error) {
+func (c *Client) WatchModelMachines() (watcher.StringsWatcher, error) {
 	var result params.StringsWatchResult
-	err := st.facade.FacadeCall("WatchModelMachines", nil, &result)
+	err := c.facade.FacadeCall("WatchModelMachines", nil, &result)
 	if err != nil {
 		return nil, err
 	}
 	if err := result.Error; err != nil {
 		return nil, result.Error
 	}
-	w := apiwatcher.NewStringsWatcher(st.facade.RawAPICaller(), result)
+	w := apiwatcher.NewStringsWatcher(c.facade.RawAPICaller(), result)
 	return w, nil
 }
 
 // WatchOpenedPorts returns a StringsWatcher that notifies of
 // changes to the opened ports for the current model.
-func (st *State) WatchOpenedPorts() (watcher.StringsWatcher, error) {
-	modelTag, ok := st.ModelTag()
+func (c *Client) WatchOpenedPorts() (watcher.StringsWatcher, error) {
+	modelTag, ok := c.ModelTag()
 	if !ok {
 		return nil, errors.New("API connection is controller-only (should never happen)")
 	}
@@ -105,7 +106,7 @@ func (st *State) WatchOpenedPorts() (watcher.StringsWatcher, error) {
 	args := params.Entities{
 		Entities: []params.Entity{{Tag: modelTag.String()}},
 	}
-	if err := st.facade.FacadeCall("WatchOpenedPorts", args, &results); err != nil {
+	if err := c.facade.FacadeCall("WatchOpenedPorts", args, &results); err != nil {
 		return nil, err
 	}
 	if len(results.Results) != 1 {
@@ -115,14 +116,14 @@ func (st *State) WatchOpenedPorts() (watcher.StringsWatcher, error) {
 	if err := result.Error; err != nil {
 		return nil, result.Error
 	}
-	w := apiwatcher.NewStringsWatcher(st.facade.RawAPICaller(), result)
+	w := apiwatcher.NewStringsWatcher(c.facade.RawAPICaller(), result)
 	return w, nil
 }
 
 // Relation provides access to methods of a state.Relation through the
 // facade.
-func (st *State) Relation(tag names.RelationTag) (*Relation, error) {
-	life, err := st.life(tag)
+func (c *Client) Relation(tag names.RelationTag) (*Relation, error) {
+	life, err := c.life(tag)
 	if err != nil {
 		return nil, err
 	}
@@ -136,7 +137,7 @@ func (st *State) Relation(tag names.RelationTag) (*Relation, error) {
 // from which connections will originate to the offering side of the relation, change.
 // Each event contains the entire set of addresses which the offering side is required
 // to allow for access to the other side of the relation.
-func (c *State) WatchEgressAddressesForRelation(relationTag names.RelationTag) (watcher.StringsWatcher, error) {
+func (c *Client) WatchEgressAddressesForRelation(relationTag names.RelationTag) (watcher.StringsWatcher, error) {
 	args := params.Entities{[]params.Entity{{Tag: relationTag.String()}}}
 	var results params.StringsWatchResults
 	err := c.facade.FacadeCall("WatchEgressAddressesForRelations", args, &results)
@@ -158,7 +159,7 @@ func (c *State) WatchEgressAddressesForRelation(relationTag names.RelationTag) (
 // from which connections will originate for the relation, change.
 // Each event contains the entire set of addresses which are required
 // for ingress into this model from the other (consuming) side of the relation.
-func (c *State) WatchIngressAddressesForRelation(relationTag names.RelationTag) (watcher.StringsWatcher, error) {
+func (c *Client) WatchIngressAddressesForRelation(relationTag names.RelationTag) (watcher.StringsWatcher, error) {
 	args := params.Entities{[]params.Entity{{Tag: relationTag.String()}}}
 	var results params.StringsWatchResults
 	err := c.facade.FacadeCall("WatchIngressAddressesForRelations", args, &results)
@@ -177,7 +178,7 @@ func (c *State) WatchIngressAddressesForRelation(relationTag names.RelationTag) 
 }
 
 // ControllerAPIInfoForModels returns the controller api connection details for the specified model.
-func (c *State) ControllerAPIInfoForModel(modelUUID string) (*api.Info, error) {
+func (c *Client) ControllerAPIInfoForModel(modelUUID string) (*api.Info, error) {
 	modelTag := names.NewModelTag(modelUUID)
 	args := params.Entities{[]params.Entity{{Tag: modelTag.String()}}}
 	var results params.ControllerAPIInfoResults
@@ -197,4 +198,23 @@ func (c *State) ControllerAPIInfoForModel(modelUUID string) (*api.Info, error) {
 		CACert:   result.CACert,
 		ModelTag: modelTag,
 	}, nil
+}
+
+// MacaroonForRelation returns the macaroon to use when publishing changes for the relation.
+func (c *Client) MacaroonForRelation(relationKey string) (*macaroon.Macaroon, error) {
+	relationTag := names.NewRelationTag(relationKey)
+	args := params.Entities{[]params.Entity{{Tag: relationTag.String()}}}
+	var results params.MacaroonResults
+	err := c.facade.FacadeCall("MacaroonForRelations", args, &results)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	if len(results.Results) != 1 {
+		return nil, errors.Errorf("expected 1 result, got %d", len(results.Results))
+	}
+	result := results.Results[0]
+	if result.Error != nil {
+		return nil, result.Error
+	}
+	return result.Result, nil
 }

--- a/api/firewaller/machine.go
+++ b/api/firewaller/machine.go
@@ -17,7 +17,7 @@ import (
 
 // Machine represents a juju machine as seen by the firewaller worker.
 type Machine struct {
-	st   *State
+	st   *Client
 	tag  names.MachineTag
 	life params.Life
 }

--- a/api/firewaller/unit.go
+++ b/api/firewaller/unit.go
@@ -12,7 +12,7 @@ import (
 
 // Unit represents a juju unit as seen by a firewaller worker.
 type Unit struct {
-	st   *State
+	st   *Client
 	tag  names.UnitTag
 	life params.Life
 }

--- a/api/remoterelations/remoterelations.go
+++ b/api/remoterelations/remoterelations.go
@@ -6,6 +6,7 @@ package remoterelations
 import (
 	"github.com/juju/errors"
 	"gopkg.in/juju/names.v2"
+	"gopkg.in/macaroon.v1"
 
 	"github.com/juju/juju/api"
 	"github.com/juju/juju/api/base"
@@ -86,6 +87,26 @@ func (c *Client) GetToken(sourceModelUUID string, tag names.Tag) (string, error)
 		return "", errors.Trace(result.Error)
 	}
 	return result.Result, nil
+}
+
+// SaveMacaroon saves the macaroon for the entity.
+func (c *Client) SaveMacaroon(entity names.Tag, mac *macaroon.Macaroon) error {
+	args := params.EntityMacaroonArgs{Args: []params.EntityMacaroonArg{
+		{Tag: entity.String(), Macaroon: mac}},
+	}
+	var results params.ErrorResults
+	err := c.facade.FacadeCall("SaveMacaroons", args, &results)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	if len(results.Results) != 1 {
+		return errors.Errorf("expected 1 result, got %d", len(results.Results))
+	}
+	result := results.Results[0]
+	if result.Error != nil {
+		return errors.Trace(result.Error)
+	}
+	return nil
 }
 
 // RemoveRemoteEntity removes the specified entity from the remote entities collection.

--- a/apiserver/facades/controller/crossmodelrelations/crossmodelrelations.go
+++ b/apiserver/facades/controller/crossmodelrelations/crossmodelrelations.go
@@ -353,11 +353,10 @@ func (api *CrossModelRelationsAPI) PublishIngressNetworkChanges(
 		}
 		logger.Debugf("relation tag for remote id %+v is %v", change.RelationId, relationTag)
 
-		// TODO(wallyworld) - firewaller worker needs to use macaroon
-		//if err := api.checkMacaroonsForRelation(relationTag, change.Macaroons); err != nil {
-		//	results.Results[i].Error = common.ServerError(err)
-		//	continue
-		//}
+		if err := api.checkMacaroonsForRelation(relationTag, change.Macaroons); err != nil {
+			results.Results[i].Error = common.ServerError(err)
+			continue
+		}
 		if err := commoncrossmodel.PublishIngressNetworkChange(api.st, relationTag, change); err != nil {
 			results.Results[i].Error = common.ServerError(err)
 			continue

--- a/apiserver/facades/controller/crossmodelrelations/crossmodelrelations_test.go
+++ b/apiserver/facades/controller/crossmodelrelations/crossmodelrelations_test.go
@@ -196,6 +196,12 @@ func (s *crossmodelRelationsSuite) TestPublishIngressNetworkChanges(c *gc.C) {
 	s.st.remoteApplications["db2"] = &mockRemoteApplication{}
 	s.st.remoteEntities[names.NewApplicationTag("db2")] = "token-db2"
 	s.st.remoteEntities[names.NewRelationTag("db2:db django:db")] = "token-db2:db django:db"
+	mac, err := s.bakery.NewMacaroon("", nil,
+		[]checkers.Caveat{
+			checkers.DeclaredCaveat("source-model-uuid", s.st.ModelUUID()),
+			checkers.DeclaredCaveat("relation-key", "db2:db django:db"),
+		})
+	c.Assert(err, jc.ErrorIsNil)
 	results, err := s.api.PublishIngressNetworkChanges(params.IngressNetworksChanges{
 		Changes: []params.IngressNetworksChangeEvent{
 			{
@@ -205,7 +211,8 @@ func (s *crossmodelRelationsSuite) TestPublishIngressNetworkChanges(c *gc.C) {
 				RelationId: params.RemoteEntityId{
 					ModelUUID: "uuid",
 					Token:     "token-db2:db django:db"},
-				Networks: []string{"1.2.3.4/32"},
+				Networks:  []string{"1.2.3.4/32"},
+				Macaroons: macaroon.Slice{mac},
 			},
 		},
 	})

--- a/apiserver/facades/controller/firewaller/firewaller.go
+++ b/apiserver/facades/controller/firewaller/firewaller.go
@@ -532,3 +532,23 @@ func (f *FirewallerAPIV4) WatchIngressAddressesForRelations(relations params.Ent
 	}
 	return results, nil
 }
+
+// MacaroonForRelations returns the macaroon for the specified relations.
+func (f *FirewallerAPIV4) MacaroonForRelations(args params.Entities) (params.MacaroonResults, error) {
+	var result params.MacaroonResults
+	result.Results = make([]params.MacaroonResult, len(args.Entities))
+	for i, entity := range args.Entities {
+		relationTag, err := names.ParseRelationTag(entity.Tag)
+		if err != nil {
+			result.Results[i].Error = common.ServerError(err)
+			continue
+		}
+		mac, err := f.st.GetMacaroon(names.NewModelTag(f.st.ModelUUID()), relationTag)
+		if err != nil {
+			result.Results[i].Error = common.ServerError(err)
+			continue
+		}
+		result.Results[i].Result = mac
+	}
+	return result, nil
+}

--- a/apiserver/facades/controller/firewaller/state.go
+++ b/apiserver/facades/controller/firewaller/state.go
@@ -6,6 +6,7 @@ package firewaller
 import (
 	"github.com/juju/errors"
 	"gopkg.in/juju/names.v2"
+	"gopkg.in/macaroon.v1"
 
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/state"
@@ -22,6 +23,8 @@ type State interface {
 	WatchSubnets(func(id interface{}) bool) state.StringsWatcher
 
 	GetRemoteEntity(model names.ModelTag, token string) (names.Tag, error)
+
+	GetMacaroon(model names.ModelTag, entity names.Tag) (*macaroon.Macaroon, error)
 
 	KeyRelation(string) (Relation, error)
 
@@ -48,6 +51,11 @@ type stateShim struct {
 func (st stateShim) GetRemoteEntity(model names.ModelTag, token string) (names.Tag, error) {
 	r := st.State.RemoteEntities()
 	return r.GetRemoteEntity(model, token)
+}
+
+func (st stateShim) GetMacaroon(model names.ModelTag, entity names.Tag) (*macaroon.Macaroon, error) {
+	r := st.State.RemoteEntities()
+	return r.GetMacaroon(model, entity)
 }
 
 func (st stateShim) KeyRelation(key string) (Relation, error) {

--- a/apiserver/facades/controller/remoterelations/mock_test.go
+++ b/apiserver/facades/controller/remoterelations/mock_test.go
@@ -127,6 +127,11 @@ func (st *mockState) GetToken(sourceModel names.ModelTag, entity names.Tag) (str
 	return "token-" + entity.String(), nil
 }
 
+func (st *mockState) SaveMacaroon(entity names.Tag, mac *macaroon.Macaroon) error {
+	st.MethodCall(st, "SaveMacaroon", entity, mac.Id())
+	return st.NextErr()
+}
+
 func (st *mockState) KeyRelation(key string) (common.Relation, error) {
 	st.MethodCall(st, "KeyRelation", key)
 	if err := st.NextErr(); err != nil {

--- a/apiserver/facades/controller/remoterelations/remoterelations.go
+++ b/apiserver/facades/controller/remoterelations/remoterelations.go
@@ -125,7 +125,7 @@ func (api *RemoteRelationsAPI) removeRemoteEntity(arg params.RemoteEntityArg) er
 	return api.st.RemoveRemoteEntity(modelTag, entityTag)
 }
 
-// GetToken returns the token associated with the entity with the given tag for the current model.
+// GetTokens returns the token associated with the entities with the given tags for the given models.
 func (api *RemoteRelationsAPI) GetTokens(args params.GetTokenArgs) (params.StringResults, error) {
 	results := params.StringResults{
 		Results: make([]params.StringResult, len(args.Args)),
@@ -146,6 +146,23 @@ func (api *RemoteRelationsAPI) GetTokens(args params.GetTokenArgs) (params.Strin
 			results.Results[i].Error = common.ServerError(err)
 		}
 		results.Results[i].Result = token
+	}
+	return results, nil
+}
+
+// SaveMacaroons saves the macaroons for the given entities.
+func (api *RemoteRelationsAPI) SaveMacaroons(args params.EntityMacaroonArgs) (params.ErrorResults, error) {
+	results := params.ErrorResults{
+		Results: make([]params.ErrorResult, len(args.Args)),
+	}
+	for i, arg := range args.Args {
+		entityTag, err := names.ParseTag(arg.Tag)
+		if err != nil {
+			results.Results[i].Error = common.ServerError(err)
+			continue
+		}
+		err = api.st.SaveMacaroon(entityTag, arg.Macaroon)
+		results.Results[i].Error = common.ServerError(err)
 	}
 	return results, nil
 }

--- a/apiserver/facades/controller/remoterelations/remoterelations_test.go
+++ b/apiserver/facades/controller/remoterelations/remoterelations_test.go
@@ -250,6 +250,20 @@ func (s *remoteRelationsSuite) TestGetTokens(c *gc.C) {
 	})
 }
 
+func (s *remoteRelationsSuite) TestSaveMacaroons(c *gc.C) {
+	mac, err := macaroon.New(nil, "id", "")
+	c.Assert(err, jc.ErrorIsNil)
+	relTag := names.NewRelationTag("mysql:db wordpress:db")
+	result, err := s.api.SaveMacaroons(params.EntityMacaroonArgs{
+		Args: []params.EntityMacaroonArg{{Tag: relTag.String(), Macaroon: mac}}})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result.Results, gc.HasLen, 1)
+	c.Assert(result.Results[0].Error, gc.IsNil)
+	s.st.CheckCalls(c, []testing.StubCall{
+		{"SaveMacaroon", []interface{}{relTag, mac.Id()}},
+	})
+}
+
 func (s *remoteRelationsSuite) TestRelationUnitSettings(c *gc.C) {
 	djangoRelationUnit := newMockRelationUnit()
 	djangoRelationUnit.settings["key"] = "value"

--- a/apiserver/facades/controller/remoterelations/state.go
+++ b/apiserver/facades/controller/remoterelations/state.go
@@ -6,6 +6,7 @@ package remoterelations
 import (
 	"github.com/juju/errors"
 	"gopkg.in/juju/names.v2"
+	"gopkg.in/macaroon.v1"
 
 	common "github.com/juju/juju/apiserver/common/crossmodel"
 	"github.com/juju/juju/state"
@@ -35,6 +36,9 @@ type RemoteRelationsState interface {
 	// GetToken returns the token associated with the entity with the given tag
 	// and model.
 	GetToken(names.ModelTag, names.Tag) (string, error)
+
+	// SaveMacaroon saves the given macaroon for the specified entity.
+	SaveMacaroon(entity names.Tag, mac *macaroon.Macaroon) error
 }
 
 type stateShim struct {
@@ -50,6 +54,11 @@ func (st stateShim) RemoveRemoteEntity(model names.ModelTag, entity names.Tag) e
 func (st stateShim) GetToken(model names.ModelTag, entity names.Tag) (string, error) {
 	r := st.st.RemoteEntities()
 	return r.GetToken(model, entity)
+}
+
+func (st stateShim) SaveMacaroon(entity names.Tag, mac *macaroon.Macaroon) error {
+	r := st.st.RemoteEntities()
+	return r.SaveMacaroon(entity, mac)
 }
 
 func (st stateShim) WatchRemoteApplications() state.StringsWatcher {

--- a/apiserver/params/crossmodel.go
+++ b/apiserver/params/crossmodel.go
@@ -246,6 +246,17 @@ type RemoteEntityArg struct {
 	Token string `json:"token,omitempty"`
 }
 
+// EntityMacaroonArgs holds the arguments to a SaveMacaroons API call.
+type EntityMacaroonArgs struct {
+	Args []EntityMacaroonArg
+}
+
+// EntityMacaroonArg holds a macaroon and entity which we want to save.
+type EntityMacaroonArg struct {
+	Macaroon *macaroon.Macaroon `json:"macaroon"`
+	Tag      string             `json:"tag"`
+}
+
 // RemoteApplicationResult holds a remote application and an error.
 type RemoteApplicationResult struct {
 	Result *RemoteApplication `json:"result,omitempty"`

--- a/worker/firewaller/shim.go
+++ b/worker/firewaller/shim.go
@@ -25,7 +25,7 @@ func NewRemoteRelationsFacade(apiCaller base.APICaller) (*remoterelations.Client
 
 // NewFirewallerFacade creates a firewaller API facade.
 func NewFirewallerFacade(apiCaller base.APICaller) (FirewallerAPI, error) {
-	facade := firewaller.NewState(apiCaller)
+	facade := firewaller.NewClient(apiCaller)
 	return facade, nil
 }
 

--- a/worker/remoterelations/mock_test.go
+++ b/worker/remoterelations/mock_test.go
@@ -123,18 +123,17 @@ func (m *mockRelationsFacade) ExportEntities(entities []names.Tag) ([]params.Rem
 
 func (m *mockRelationsFacade) ImportRemoteEntity(sourceModelUUID string, entity names.Tag, token string) error {
 	m.stub.MethodCall(m, "ImportRemoteEntity", sourceModelUUID, entity, token)
-	if err := m.stub.NextErr(); err != nil {
-		return err
-	}
-	return nil
+	return m.stub.NextErr()
+}
+
+func (m *mockRelationsFacade) SaveMacaroon(entity names.Tag, mac *macaroon.Macaroon) error {
+	m.stub.MethodCall(m, "SaveMacaroon", entity, mac)
+	return m.stub.NextErr()
 }
 
 func (m *mockRelationsFacade) RemoveRemoteEntity(sourceModelUUID string, entity names.Tag) error {
 	m.stub.MethodCall(m, "RemoveRemoteEntity", sourceModelUUID, entity)
-	if err := m.stub.NextErr(); err != nil {
-		return err
-	}
-	return nil
+	return m.stub.NextErr()
 }
 
 func (m *mockRelationsFacade) GetToken(modelUUID string, entity names.Tag) (string, error) {

--- a/worker/remoterelations/remoterelations_test.go
+++ b/worker/remoterelations/remoterelations_test.go
@@ -154,11 +154,12 @@ func (s *remoteRelationsSuite) assertRemoteRelationsWorkers(c *gc.C) worker.Work
 	mac, err := macaroon.New(nil, "test", "")
 	c.Assert(err, jc.ErrorIsNil)
 	apiMac, err := macaroon.New(nil, "apimac", "")
+	relTag := names.NewRelationTag("db2:db django:db")
 	expected := []jujutesting.StubCall{
 		{"Relations", []interface{}{[]string{"db2:db django:db"}}},
 		{"ControllerAPIInfoForModel", []interface{}{"remote-model-uuid"}},
 		{"ExportEntities", []interface{}{
-			[]names.Tag{names.NewApplicationTag("django"), names.NewRelationTag("db2:db django:db")}}},
+			[]names.Tag{names.NewApplicationTag("django"), relTag}}},
 		{"RegisterRemoteRelations", []interface{}{[]params.RegisterRemoteRelationArg{{
 			ApplicationId: params.RemoteEntityId{ModelUUID: "model-uuid", Token: "token-django"},
 			RelationId:    params.RemoteEntityId{ModelUUID: "model-uuid", Token: "token-db2:db django:db"},
@@ -173,6 +174,7 @@ func (s *remoteRelationsSuite) assertRemoteRelationsWorkers(c *gc.C) worker.Work
 			LocalEndpointName: "data",
 			Macaroons:         macaroon.Slice{mac},
 		}}}},
+		{"SaveMacaroon", []interface{}{relTag, apiMac}},
 		{"ImportRemoteEntity", []interface{}{"source-model-uuid", names.NewApplicationTag("db2"), "token-offer-db2"}},
 		{"WatchLocalRelationUnits", []interface{}{"db2:db django:db"}},
 		{"WatchRelationUnits", []interface{}{"token-db2:db django:db", macaroon.Slice{apiMac}}},


### PR DESCRIPTION
## Description of change

When the firewaller publishes ingress changes to the offering model, it uses the macaroon associated with the relation. The remote entities functionality in state have been enhanced to allow a macaroon to be saved with the token. The remote relations worker saves the macaroon when it registers the relation, and the firewaller worker gets the macaroon when it needs to publish a change.

## QA steps

Run a cmr scenario and ensure firewall ports are opened as expected.

