### PR TITLE
provider/lxd: validate results of DefaultPools

### DIFF
--- a/provider/lxd/storage.go
+++ b/provider/lxd/storage.go
@@ -156,7 +156,19 @@ func (e *lxdStorageProvider) DefaultPools() []*storage.Config {
 		attrLXDStoragePool:   "juju-zfs",
 		"zfs.pool_name":      "juju-lxd",
 	})
-	return []*storage.Config{zfsPool}
+	btrfsPool, _ := storage.NewConfig("lxd-btrfs", lxdStorageProviderType, map[string]interface{}{
+		attrLXDStorageDriver: "btrfs",
+		attrLXDStoragePool:   "juju-btrfs",
+	})
+
+	var pools []*storage.Config
+	if e.ValidateConfig(zfsPool) == nil {
+		pools = append(pools, zfsPool)
+	}
+	if e.ValidateConfig(btrfsPool) == nil {
+		pools = append(pools, btrfsPool)
+	}
+	return pools
 }
 
 // VolumeSource is part of the Provider interface.


### PR DESCRIPTION
## Description of change

Don't return invalid storage pool config from
DefaultPools, as it'll cause bootstrap to fail.
If the "zfs" tool is unavailable, then validation
will fail. Also, add a "lxd-btrfs" pool while
we're there.

## QA steps

1. make sure "btrfs-tools" is not present on the machine
2. juju bootstrap localhost
3. juju storage-pools
(should *not* show "lxd-btrfs" as a pool)
4. juju destroy-controller -y localhost
5. sudo apt install btrfs-tools
6. juju bootstrap localhost
7. juju storage-pools
(should show "lxd-btrfs" as a pool; there should be a corresponding "juju-btrfs" pool in LXD)

## Documentation changes

None.

## Bug reference

None.