### PR TITLE
Added a bit of jitter to the metric sending worker period.

### DIFF
--- a/worker/metrics/spool/listener.go
+++ b/worker/metrics/spool/listener.go
@@ -77,7 +77,7 @@ func (l *socketListener) loop() error {
 // when it is killed.
 func NewPeriodicWorker(do jworker.PeriodicWorkerCall, period time.Duration, newTimer func(time.Duration) jworker.PeriodicTimer, stop func()) worker.Worker {
 	return &periodicWorker{
-		Worker: jworker.NewPeriodicWorker(do, period, newTimer),
+		Worker: jworker.NewPeriodicWorker(do, period, newTimer, jworker.Jitter(0.2)),
 		stop:   stop,
 	}
 }


### PR DESCRIPTION
## Description of change

Why is this change needed?

In case all units regain connection to the controller, this change will prevent all of them from sending metrics at the same time. Instead they will send with a rand metrics with a period of 5minutes +- 20%..

## QA steps

Metrics collection should still work as expected. The small jitter introduced to the period should not affect that. Use "juju metrics" to verify that metrics are still being collected as expected.

## Documentation changes

No documentation change required.

## Bug reference

N/A
