### PR TITLE
Workaround for relation address in postgres cmr

### DIFF
--- a/state/relationunit.go
+++ b/state/relationunit.go
@@ -6,6 +6,7 @@ package state
 import (
 	stderrors "errors"
 	"fmt"
+	"net"
 	"strings"
 
 	"github.com/juju/errors"
@@ -485,6 +486,32 @@ func (ru *RelationUnit) SettingsAddress() (network.Address, error) {
 		return unit.PrivateAddress()
 	}
 
+	// If there's egress cidr's defined, we'll use that value.
+	// TODO(wallyworld) - this is an interim measure until network-get is updated.
+	// It's needed for postgresql which uses the value to set up the hba file.
+	// This substitution is only applicable where the user has set the ingress-cidrs
+	// model attribute, which is only relevant in the consuming model.
+	cfg, err := ru.st.ModelConfig()
+	if err != nil {
+		return network.Address{}, errors.Trace(err)
+	}
+	cidrs := cfg.EgressCidrs()
+	if len(cidrs) > 0 {
+		ip, _, err := net.ParseCIDR(cidrs[0])
+		if err != nil {
+			return network.Address{}, errors.Trace(err)
+		}
+		addrType := network.IPv4Address
+		if ip4 := ip.To4(); ip4 == nil {
+			addrType = network.IPv6Address
+		}
+		address := network.Address{
+			Value: ip.String(),
+			Type:  addrType,
+			Scope: network.ScopePublic,
+		}
+		return address, nil
+	}
 	address, err := unit.PublicAddress()
 	if err != nil {
 		// TODO(wallyworld) - it's ok to return a private address sometimes

--- a/state/relationunit_test.go
+++ b/state/relationunit_test.go
@@ -869,6 +869,28 @@ func (s *RelationUnitSuite) TestSettingsAddressRemoteRelationNoPublicAddr(c *gc.
 	c.Assert(address, gc.DeepEquals, network.NewScopedAddress("1.2.3.4", network.ScopeCloudLocal))
 }
 
+func (s *RelationUnitSuite) TestSettingsAddressRemoteRelationEgressCidrs(c *gc.C) {
+	err := s.State.UpdateModelConfig(map[string]interface{}{"egress-cidrs": "192.168.1.0/32"}, nil)
+	c.Assert(err, jc.ErrorIsNil)
+	prr := newRemoteProReqRelation(c, &s.ConnSuite)
+	err = prr.ru0.AssignToNewMachine()
+	c.Assert(err, jc.ErrorIsNil)
+	id, err := prr.ru0.AssignedMachineId()
+	c.Assert(err, jc.ErrorIsNil)
+	machine, err := s.State.Machine(id)
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = machine.SetProviderAddresses(
+		network.NewScopedAddress("1.2.3.4", network.ScopeCloudLocal),
+		network.NewScopedAddress("4.3.2.1", network.ScopePublic),
+	)
+
+	address, err := prr.rru0.SettingsAddress()
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Assert(address, gc.DeepEquals, network.NewScopedAddress("192.168.1.0", network.ScopePublic))
+}
+
 func (s *RelationUnitSuite) TestValidYes(c *gc.C) {
 	prr := newProReqRelation(c, &s.ConnSuite, charm.ScopeContainer)
 	rus := []*state.RelationUnit{prr.pru0, prr.pru1, prr.rru0, prr.rru1}


### PR DESCRIPTION
## Description of change

This is a temporary workaround for cmr.
There will be a network-get enhancement to allow a charm to ask for the egress cidrs for a relation.
Until then, we need to enhance the private-address substitution already used to account for egress-cidr if defined on the consuming model. For now, we'll just use the first value as a /32.

This change allows the postgresql charm to set up its hba file correctly if the consuming model is behind a NAT firewall and the user needs to set the egress-cidrs model config.

## QA steps

Deploy psotgres in a cmr scenario
The consuming model has egress-cidrs defined
Add a relation to that postgres
Check the hba file uses the egress-cidrs value.
