### PR TITLE
Storage import filesystem

### DIFF
--- a/api/storage/client.go
+++ b/api/storage/client.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/juju/juju/api/base"
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/storage"
 )
 
 // Client allows access to the storage API end point.
@@ -243,4 +244,35 @@ func (c *Client) Detach(storageIds []string) ([]params.ErrorResult, error) {
 		)
 	}
 	return results.Results, nil
+}
+
+// Import imports storage into the model.
+func (c *Client) ImportStorage(
+	kind storage.StorageKind,
+	storagePool string,
+	storageProviderId string,
+	storageName string,
+) (names.StorageTag, error) {
+	var results params.ImportStorageResults
+	args := params.BulkImportStorageParams{
+		[]params.ImportStorageParams{{
+			StorageName: storageName,
+			Kind:        params.StorageKind(kind),
+			Pool:        storagePool,
+			ProviderId:  storageProviderId,
+		}},
+	}
+	if err := c.facade.FacadeCall("Import", args, &results); err != nil {
+		return names.StorageTag{}, errors.Trace(err)
+	}
+	if len(results.Results) != 1 {
+		return names.StorageTag{}, errors.Errorf(
+			"expected 1 result, got %d",
+			len(results.Results),
+		)
+	}
+	if err := results.Results[0].Error; err != nil {
+		return names.StorageTag{}, err
+	}
+	return names.ParseStorageTag(results.Results[0].Result.StorageTag)
 }

--- a/apiserver/facades/client/storage/base_test.go
+++ b/apiserver/facades/client/storage/base_test.go
@@ -94,6 +94,7 @@ const (
 	attachStorageCall                       = "attachStorage"
 	detachStorageCall                       = "detachStorage"
 	destroyStorageInstanceCall              = "destroyStorageInstance"
+	importFilesystemCall                    = "importFilesystem"
 )
 
 func (s *baseStorageSuite) constructState() *mockState {
@@ -269,6 +270,10 @@ func (s *baseStorageSuite) constructState() *mockState {
 		destroyStorageInstance: func(tag names.StorageTag, destroyAttached bool) error {
 			s.stub.AddCall(destroyStorageInstanceCall, tag, destroyAttached)
 			return errors.New("cannae do it")
+		},
+		importFilesystem: func(f state.FilesystemInfo, v *state.VolumeInfo, storageName string) (names.StorageTag, error) {
+			s.stub.AddCall(importFilesystemCall, f, v, storageName)
+			return s.storageTag, s.stub.NextErr()
 		},
 	}
 }

--- a/apiserver/facades/client/storage/mock_test.go
+++ b/apiserver/facades/client/storage/mock_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/status"
 	jujustorage "github.com/juju/juju/storage"
+	"github.com/juju/juju/testing"
 )
 
 type mockPoolManager struct {
@@ -65,6 +66,7 @@ type mockState struct {
 	destroyStorageInstance              func(names.StorageTag, bool) error
 	attachStorage                       func(names.StorageTag, names.UnitTag) error
 	detachStorage                       func(names.StorageTag, names.UnitTag) error
+	importFilesystem                    func(state.FilesystemInfo, *state.VolumeInfo, string) (names.StorageTag, error)
 }
 
 func (st *mockState) StorageInstance(s names.StorageTag) (state.StorageInstance, error) {
@@ -113,6 +115,10 @@ func (st *mockState) WatchVolumeAttachment(mtag names.MachineTag, v names.Volume
 
 func (st *mockState) WatchBlockDevices(mtag names.MachineTag) state.NotifyWatcher {
 	return st.watchBlockDevices(mtag)
+}
+
+func (st *mockState) ControllerTag() names.ControllerTag {
+	return testing.ControllerTag
 }
 
 func (st *mockState) ModelName() (string, error) {
@@ -184,6 +190,10 @@ func (st *mockState) DestroyStorageInstance(tag names.StorageTag, destroyAttache
 
 func (st *mockState) UnitStorageAttachments(tag names.UnitTag) ([]state.StorageAttachment, error) {
 	panic("should not be called")
+}
+
+func (st *mockState) ImportFilesystem(f state.FilesystemInfo, v *state.VolumeInfo, s string) (names.StorageTag, error) {
+	return st.importFilesystem(f, v, s)
 }
 
 type mockVolume struct {

--- a/apiserver/facades/client/storage/shim.go
+++ b/apiserver/facades/client/storage/shim.go
@@ -89,11 +89,14 @@ type storageAccess interface {
 	// BlockDevices is required for storage functionality.
 	BlockDevices(names.MachineTag) ([]state.BlockDeviceInfo, error)
 
+	// ControllerTag the tag of the controller in which we are operating.
+	ControllerTag() names.ControllerTag
+
+	// ModelTag the tag of the model on which we are operating.
+	ModelTag() names.ModelTag
+
 	// ModelName is required for pool functionality.
 	ModelName() (string, error)
-
-	// ModelTag is required for model permission checking.
-	ModelTag() names.ModelTag
 
 	// AllVolumes is required for volume functionality.
 	AllVolumes() ([]state.Volume, error)
@@ -139,6 +142,9 @@ type storageAccess interface {
 	// UnitStorageAttachments returns the storage attachments for the
 	// identified unit.
 	UnitStorageAttachments(names.UnitTag) ([]state.StorageAttachment, error)
+
+	// ImportFilesystem imports an existing filesystem into the model.
+	ImportFilesystem(f state.FilesystemInfo, v *state.VolumeInfo, storageName string) (names.StorageTag, error)
 }
 
 var getState = func(st *state.State) storageAccess {

--- a/apiserver/facades/client/storage/storage_test.go
+++ b/apiserver/facades/client/storage/storage_test.go
@@ -15,6 +15,9 @@ import (
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/status"
+	"github.com/juju/juju/storage"
+	"github.com/juju/juju/storage/provider/dummy"
+	coretesting "github.com/juju/juju/testing"
 )
 
 type storageSuite struct {
@@ -497,4 +500,234 @@ func (s *storageSuite) TestAttach(c *gc.C) {
 		{getBlockForTypeCall, []interface{}{state.ChangeBlock}},
 		{attachStorageCall, []interface{}{s.storageTag, s.unitTag}},
 	})
+}
+
+func (s *storageSuite) TestImportFilesystem(c *gc.C) {
+	s.state.modelTag = coretesting.ModelTag
+	filesystemSource := filesystemImporter{&dummy.FilesystemSource{}}
+	dummyStorageProvider := &dummy.StorageProvider{
+		StorageScope: storage.ScopeEnviron,
+		IsDynamic:    true,
+		FilesystemSourceFunc: func(*storage.Config) (storage.FilesystemSource, error) {
+			return filesystemSource, nil
+		},
+	}
+	s.registry.Providers["radiance"] = dummyStorageProvider
+
+	results, err := s.api.Import(params.BulkImportStorageParams{[]params.ImportStorageParams{{
+		Kind:        params.StorageKindFilesystem,
+		Pool:        "radiance",
+		ProviderId:  "foo",
+		StorageName: "pgdata",
+	}}})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(results.Results, jc.DeepEquals, []params.ImportStorageResult{{
+		Result: &params.ImportStorageDetails{
+			StorageTag: "storage-data-0",
+		},
+	}})
+	filesystemSource.CheckCalls(c, []testing.StubCall{
+		{"ImportFilesystem", []interface{}{
+			"foo", map[string]string{
+				"juju-model-uuid":      "deadbeef-0bad-400d-8000-4b1d0d06f00d",
+				"juju-controller-uuid": "deadbeef-1bad-500d-9000-4b1d0d06f00d",
+			},
+		}},
+	})
+	s.stub.CheckCalls(c, []testing.StubCall{
+		{getBlockForTypeCall, []interface{}{state.ChangeBlock}},
+		{importFilesystemCall, []interface{}{
+			state.FilesystemInfo{
+				FilesystemId: "foo",
+				Pool:         "radiance",
+				Size:         123,
+			},
+			(*state.VolumeInfo)(nil),
+			"pgdata",
+		}},
+	})
+}
+
+func (s *storageSuite) TestImportFilesystemVolumeBacked(c *gc.C) {
+	s.state.modelTag = coretesting.ModelTag
+	volumeSource := volumeImporter{&dummy.VolumeSource{}}
+	dummyStorageProvider := &dummy.StorageProvider{
+		StorageScope: storage.ScopeEnviron,
+		IsDynamic:    true,
+		SupportsFunc: func(kind storage.StorageKind) bool {
+			return kind == storage.StorageKindBlock
+		},
+		VolumeSourceFunc: func(*storage.Config) (storage.VolumeSource, error) {
+			return volumeSource, nil
+		},
+	}
+	s.registry.Providers["radiance"] = dummyStorageProvider
+
+	results, err := s.api.Import(params.BulkImportStorageParams{[]params.ImportStorageParams{{
+		Kind:        params.StorageKindFilesystem,
+		Pool:        "radiance",
+		ProviderId:  "foo",
+		StorageName: "pgdata",
+	}}})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(results.Results, jc.DeepEquals, []params.ImportStorageResult{{
+		Result: &params.ImportStorageDetails{
+			StorageTag: "storage-data-0",
+		},
+	}})
+	volumeSource.CheckCalls(c, []testing.StubCall{
+		{"ImportVolume", []interface{}{
+			"foo", map[string]string{
+				"juju-model-uuid":      "deadbeef-0bad-400d-8000-4b1d0d06f00d",
+				"juju-controller-uuid": "deadbeef-1bad-500d-9000-4b1d0d06f00d",
+			},
+		}},
+	})
+	s.stub.CheckCalls(c, []testing.StubCall{
+		{getBlockForTypeCall, []interface{}{state.ChangeBlock}},
+		{importFilesystemCall, []interface{}{
+			state.FilesystemInfo{
+				Pool: "radiance",
+				Size: 123,
+			},
+			&state.VolumeInfo{
+				VolumeId:   "foo",
+				Pool:       "radiance",
+				Size:       123,
+				HardwareId: "hw",
+			},
+			"pgdata",
+		}},
+	})
+}
+
+func (s *storageSuite) TestImportFilesystemError(c *gc.C) {
+	filesystemSource := filesystemImporter{&dummy.FilesystemSource{}}
+	dummyStorageProvider := &dummy.StorageProvider{
+		StorageScope: storage.ScopeEnviron,
+		IsDynamic:    true,
+		FilesystemSourceFunc: func(*storage.Config) (storage.FilesystemSource, error) {
+			return filesystemSource, nil
+		},
+	}
+	s.registry.Providers["radiance"] = dummyStorageProvider
+
+	filesystemSource.SetErrors(errors.New("nope"))
+	results, err := s.api.Import(params.BulkImportStorageParams{[]params.ImportStorageParams{{
+		Kind:        params.StorageKindFilesystem,
+		Pool:        "radiance",
+		ProviderId:  "foo",
+		StorageName: "pgdata",
+	}}})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(results.Results, jc.DeepEquals, []params.ImportStorageResult{
+		{Error: &params.Error{Message: `importing filesystem: nope`}},
+	})
+	filesystemSource.CheckCallNames(c, "ImportFilesystem")
+	s.stub.CheckCallNames(c, getBlockForTypeCall)
+}
+
+func (s *storageSuite) TestImportFilesystemNotSupported(c *gc.C) {
+	filesystemSource := &dummy.FilesystemSource{}
+	dummyStorageProvider := &dummy.StorageProvider{
+		StorageScope: storage.ScopeEnviron,
+		IsDynamic:    true,
+		FilesystemSourceFunc: func(*storage.Config) (storage.FilesystemSource, error) {
+			return filesystemSource, nil
+		},
+	}
+	s.registry.Providers["radiance"] = dummyStorageProvider
+
+	results, err := s.api.Import(params.BulkImportStorageParams{[]params.ImportStorageParams{{
+		Kind:        params.StorageKindFilesystem,
+		Pool:        "radiance",
+		ProviderId:  "foo",
+		StorageName: "pgdata",
+	}}})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(results.Results, jc.DeepEquals, []params.ImportStorageResult{
+		{Error: &params.Error{
+			Message: `importing filesystem with storage provider "radiance" not supported`,
+			Code:    "not supported",
+		}},
+	})
+	filesystemSource.CheckNoCalls(c)
+	s.stub.CheckCallNames(c, getBlockForTypeCall)
+}
+
+func (s *storageSuite) TestImportFilesystemVolumeBackedNotSupported(c *gc.C) {
+	volumeSource := &dummy.VolumeSource{}
+	dummyStorageProvider := &dummy.StorageProvider{
+		StorageScope: storage.ScopeEnviron,
+		IsDynamic:    true,
+		SupportsFunc: func(kind storage.StorageKind) bool {
+			return kind == storage.StorageKindBlock
+		},
+		VolumeSourceFunc: func(*storage.Config) (storage.VolumeSource, error) {
+			return volumeSource, nil
+		},
+	}
+	s.registry.Providers["radiance"] = dummyStorageProvider
+
+	results, err := s.api.Import(params.BulkImportStorageParams{[]params.ImportStorageParams{{
+		Kind:        params.StorageKindFilesystem,
+		Pool:        "radiance",
+		ProviderId:  "foo",
+		StorageName: "pgdata",
+	}}})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(results.Results, jc.DeepEquals, []params.ImportStorageResult{
+		{Error: &params.Error{
+			Message: `importing volume with storage provider "radiance" not supported`,
+			Code:    "not supported",
+		}},
+	})
+	volumeSource.CheckNoCalls(c)
+	s.stub.CheckCallNames(c, getBlockForTypeCall)
+}
+
+func (s *storageSuite) TestImportValidationErrors(c *gc.C) {
+	results, err := s.api.Import(params.BulkImportStorageParams{[]params.ImportStorageParams{{
+		Kind:        params.StorageKindBlock,
+		Pool:        "radiance",
+		ProviderId:  "foo",
+		StorageName: "pgdata",
+	}, {
+		Kind:        params.StorageKindFilesystem,
+		Pool:        "123",
+		ProviderId:  "foo",
+		StorageName: "pgdata",
+	}}})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(results.Results, jc.DeepEquals, []params.ImportStorageResult{
+		{Error: &params.Error{Message: `storage kind "block" not supported`, Code: "not supported"}},
+		{Error: &params.Error{Message: `pool name "123" not valid`}},
+	})
+}
+
+type filesystemImporter struct {
+	*dummy.FilesystemSource
+}
+
+// ImportFilesystem is part of the storage.FilesystemImporter interface.
+func (f filesystemImporter) ImportFilesystem(providerId string, tags map[string]string) (storage.FilesystemInfo, error) {
+	f.MethodCall(f, "ImportFilesystem", providerId, tags)
+	return storage.FilesystemInfo{
+		FilesystemId: providerId,
+		Size:         123,
+	}, f.NextErr()
+}
+
+type volumeImporter struct {
+	*dummy.VolumeSource
+}
+
+// ImportVolume is part of the storage.VolumeImporter interface.
+func (v volumeImporter) ImportVolume(providerId string, tags map[string]string) (storage.VolumeInfo, error) {
+	v.MethodCall(v, "ImportVolume", providerId, tags)
+	return storage.VolumeInfo{
+		VolumeId:   providerId,
+		Size:       123,
+		HardwareId: "hw",
+	}, v.NextErr()
 }

--- a/apiserver/params/storage.go
+++ b/apiserver/params/storage.go
@@ -747,3 +747,45 @@ type DestroyStorageInstance struct {
 	// is false, then the storage must already be detached.
 	DestroyAttached bool `json:"destroy-attached,bool"`
 }
+
+// BulkImportStorageParams contains the parameters for importing a collection
+// of storage entities.
+type BulkImportStorageParams struct {
+	Storage []ImportStorageParams `json:"storage"`
+}
+
+// ImportStorageParams contains the parameters for importing a storage entity.
+type ImportStorageParams struct {
+	// Kind is the kind of the storage entity to import.
+	Kind StorageKind `json:"kind"`
+
+	// Pool is the name of the storage pool into which the storage is to
+	// be imported.
+	Pool string `json:"pool"`
+
+	// ProviderId is the storage provider's unique ID for the storage,
+	// e.g. the EBS volume ID.
+	ProviderId string `json:"provider-id"`
+
+	// StorageName is the name of the storage to assign to the entity.
+	StorageName string `json:"storage-name"`
+}
+
+// ImportStorageResults contains the results of importing a collection of
+// storage entities.
+type ImportStorageResults struct {
+	Results []ImportStorageResult `json:"results"`
+}
+
+// ImportStorageResult contains the result of importing a storage entity.
+type ImportStorageResult struct {
+	Result *ImportStorageDetails `json:"result,omitempty"`
+	Error  *Error                `json:"error,omitempty"`
+}
+
+// ImportStorageDetails contains the details of an imported storage entity.
+type ImportStorageDetails struct {
+	// StorageTag contains the string representation of the storage tag
+	// assigned to the imported storage entity.
+	StorageTag string `json:"storage-tag"`
+}

--- a/cmd/juju/commands/main.go
+++ b/cmd/juju/commands/main.go
@@ -392,6 +392,7 @@ func registerCommands(r commandRegistry, ctx *cmd.Context) {
 	r.Register(storage.NewRemoveStorageCommandWithAPI())
 	r.Register(storage.NewDetachStorageCommandWithAPI())
 	r.Register(storage.NewAttachStorageCommandWithAPI())
+	r.Register(storage.NewImportFilesystemCommand(storage.NewStorageImporter, nil))
 
 	// Manage spaces
 	r.Register(space.NewAddCommand())

--- a/cmd/juju/commands/main_test.go
+++ b/cmd/juju/commands/main_test.go
@@ -441,6 +441,7 @@ var commandNames = []string{
 	"gui",
 	"help",
 	"help-tool",
+	"import-filesystem",
 	"import-ssh-key",
 	"kill-controller",
 	"list-actions",

--- a/cmd/juju/storage/import.go
+++ b/cmd/juju/storage/import.go
@@ -1,0 +1,154 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package storage
+
+import (
+	"regexp"
+
+	"gopkg.in/juju/names.v2"
+
+	"github.com/juju/cmd"
+	"github.com/juju/errors"
+
+	"github.com/juju/juju/cmd/modelcmd"
+	"github.com/juju/juju/jujuclient"
+	"github.com/juju/juju/storage"
+)
+
+// NewImportFilesystemCommand returns a command used to import a filesystem.
+//
+// newStorageImporter is the function to use to acquire a StorageImporter.
+// A non-nil function must be provided.
+//
+// store is an optional ClientStore to use for interacting with the client
+// model/controller storage. If nil, the default file-based store will be
+// used.
+func NewImportFilesystemCommand(
+	newStorageImporter NewStorageImporterFunc,
+	store jujuclient.ClientStore,
+) cmd.Command {
+	cmd := &importFilesystemCommand{}
+	cmd.newAPIFunc = newStorageImporter
+	if store != nil {
+		cmd.SetClientStore(store)
+	}
+	return modelcmd.Wrap(cmd)
+}
+
+// NewStorageImporterFunc is the type of a function passed to
+// NewImportFilesystemCommand, in order to acquire a StorageImporter.
+type NewStorageImporterFunc func(*StorageCommandBase) (StorageImporter, error)
+
+// NewStorageImporter returns a new StorageImporter,
+// given a StorageCommandBase.
+func NewStorageImporter(cmd *StorageCommandBase) (StorageImporter, error) {
+	return cmd.NewStorageAPI()
+}
+
+const (
+	importFilesystemCommandDoc = `
+Import an existing filesystem into the model. This will lead to the model
+taking ownership of the storage, so you must take care not to import storage
+that is in use by another Juju model.
+
+To import a filesystem, you must specify three things:
+
+ - the storage pool, which identifies the storage provider
+   which manages the storage; and with which the storage
+   will be associated
+ - the storage provider ID for the filesystem, or
+   volume that backs the filesystem
+ - the storage name to assign to the filesystem,
+   corresponding to the storage name used by a charm
+
+Once a filesystem is imported, Juju will create an associated storage
+instance using the given storage name.
+
+Examples:
+    # Import an existing filesystem backed by an EBS volume,
+    # and assign it the "pgdata" storage name. Juju will
+    # associate a storage instance ID like "pgdata/0" with
+    # the volume and filesystem contained within.
+    juju import-filesystem ebs vol-123456 pgdata
+`
+	importFilesystemCommandAgs = `
+<storage-provider|pool> <filesystem|volume-id> <storage-name>
+`
+)
+
+// importFilesystemCommand imports filesystems into the model.
+type importFilesystemCommand struct {
+	StorageCommandBase
+	newAPIFunc NewStorageImporterFunc
+
+	storagePool       string
+	storageProviderId string
+	storageName       string
+}
+
+// Init implements Command.Init.
+func (c *importFilesystemCommand) Init(args []string) error {
+	if len(args) < 3 {
+		return errors.New("import-filesystem requires a storage pool, provider ID, and storage name")
+	}
+	c.storagePool = args[0]
+	c.storageProviderId = args[1]
+	c.storageName = args[2]
+
+	if !storage.IsValidPoolName(c.storagePool) {
+		return errors.NotValidf("pool name %q", c.storagePool)
+	}
+
+	validStorageName, err := regexp.MatchString(names.StorageNameSnippet, c.storageName)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	if !validStorageName {
+		return errors.Errorf("%q is not a valid storage name", c.storageName)
+	}
+	return nil
+}
+
+// Info implements Command.Info.
+func (c *importFilesystemCommand) Info() *cmd.Info {
+	return &cmd.Info{
+		Name:    "import-filesystem",
+		Purpose: "Imports a filesystem into the model.",
+		Doc:     importFilesystemCommandDoc,
+		Args:    importFilesystemCommandAgs,
+	}
+}
+
+// Run implements Command.Run.
+func (c *importFilesystemCommand) Run(ctx *cmd.Context) (err error) {
+	api, err := c.newAPIFunc(&c.StorageCommandBase)
+	if err != nil {
+		return err
+	}
+	defer api.Close()
+
+	ctx.Infof(
+		"importing %q from storage pool %q as storage %q",
+		c.storageProviderId, c.storagePool, c.storageName,
+	)
+	storageTag, err := api.ImportStorage(
+		storage.StorageKindFilesystem,
+		c.storagePool, c.storageProviderId, c.storageName,
+	)
+	if err != nil {
+		return err
+	}
+	ctx.Infof("imported storage %s", storageTag.Id())
+	return nil
+}
+
+// StorageImporter provides a method for importing storage into the model.
+type StorageImporter interface {
+	Close() error
+
+	ImportStorage(
+		kind storage.StorageKind,
+		storagePool, storageProviderId, storageName string,
+	) (names.StorageTag, error)
+}

--- a/cmd/juju/storage/import_test.go
+++ b/cmd/juju/storage/import_test.go
@@ -1,0 +1,108 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package storage_test
+
+import (
+	"errors"
+
+	"github.com/juju/cmd"
+	"github.com/juju/cmd/cmdtesting"
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/names.v2"
+
+	"github.com/juju/juju/cmd/juju/storage"
+	_ "github.com/juju/juju/provider/dummy"
+	jujustorage "github.com/juju/juju/storage"
+)
+
+type ImportFilesystemSuite struct {
+	SubStorageSuite
+	importer mockStorageImporter
+}
+
+var _ = gc.Suite(&ImportFilesystemSuite{})
+
+func (s *ImportFilesystemSuite) SetUpTest(c *gc.C) {
+	s.SubStorageSuite.SetUpTest(c)
+	s.importer = mockStorageImporter{}
+}
+
+var initErrorTests = []struct {
+	args        []string
+	expectedErr string
+}{{
+	args:        []string{"foo", "bar"},
+	expectedErr: "import-filesystem requires a storage pool, provider ID, and storage name",
+}, {
+	args:        []string{"123", "foo", "bar"},
+	expectedErr: `pool name "123" not valid`,
+}, {
+	args:        []string{"foo", "abc123", "123"},
+	expectedErr: `"123" is not a valid storage name`,
+}}
+
+func (s *ImportFilesystemSuite) TestInitErrors(c *gc.C) {
+	for i, t := range initErrorTests {
+		c.Logf("test %d for %q", i, t.args)
+		_, err := s.run(c, t.args...)
+		c.Assert(err, gc.ErrorMatches, t.expectedErr)
+	}
+}
+
+func (s *ImportFilesystemSuite) TestImportSuccess(c *gc.C) {
+	ctx, err := s.run(c, "foo", "bar", "baz")
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, "")
+	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, `
+importing "bar" from storage pool "foo" as storage "baz"
+imported storage baz/0
+`[1:])
+
+	s.importer.CheckCalls(c, []testing.StubCall{
+		{"ImportStorage", []interface{}{
+			jujustorage.StorageKindFilesystem,
+			"foo", "bar", "baz",
+		}},
+		{"Close", nil},
+	})
+}
+
+func (s *ImportFilesystemSuite) TestImportError(c *gc.C) {
+	s.importer.SetErrors(errors.New("nope"))
+
+	ctx, err := s.run(c, "foo", "bar", "baz")
+	c.Assert(err, gc.ErrorMatches, "nope")
+
+	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, "")
+	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, `importing "bar" from storage pool "foo" as storage "baz"`+"\n")
+}
+
+func (s *ImportFilesystemSuite) run(c *gc.C, args ...string) (*cmd.Context, error) {
+	return cmdtesting.RunCommand(c, storage.NewImportFilesystemCommand(
+		func(*storage.StorageCommandBase) (storage.StorageImporter, error) {
+			return &s.importer, nil
+		},
+		s.store,
+	), args...)
+}
+
+type mockStorageImporter struct {
+	testing.Stub
+}
+
+func (m *mockStorageImporter) Close() error {
+	m.MethodCall(m, "Close")
+	return m.NextErr()
+}
+
+func (m *mockStorageImporter) ImportStorage(
+	k jujustorage.StorageKind,
+	pool, providerId, storageName string,
+) (names.StorageTag, error) {
+	m.MethodCall(m, "ImportStorage", k, pool, providerId, storageName)
+	return names.NewStorageTag(storageName + "/0"), m.NextErr()
+}

--- a/provider/lxd/environ_raw.go
+++ b/provider/lxd/environ_raw.go
@@ -66,8 +66,10 @@ type lxdStorage interface {
 	StoragePools() ([]lxdapi.StoragePool, error)
 	CreateStoragePool(name, driver string, attrs map[string]string) error
 
+	Volume(pool, volume string) (lxdapi.StorageVolume, error)
 	VolumeCreate(pool, volume string, config map[string]string) error
 	VolumeDelete(pool, volume string) error
+	VolumeUpdate(pool, volume string, update lxdapi.StorageVolume) error
 	VolumeList(pool string) ([]lxdapi.StorageVolume, error)
 }
 

--- a/provider/lxd/storage_test.go
+++ b/provider/lxd/storage_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
+	"github.com/lxc/lxd/shared/api"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/names.v2"
 
@@ -154,7 +155,7 @@ func (s *storageSuite) TestDestroyFilesystems(c *gc.C) {
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, gc.HasLen, 3)
-	c.Assert(results[0], gc.ErrorMatches, `filesystem ID "filesystem-0" not valid`)
+	c.Assert(results[0], gc.ErrorMatches, `invalid filesystem ID "filesystem-0"; expected ID in format <lxd-pool>:<volume-name>`)
 	c.Assert(results[1], jc.ErrorIsNil)
 	c.Assert(results[2], gc.ErrorMatches, "boom")
 
@@ -299,4 +300,44 @@ func (s *storageSuite) TestDetachFilesystems(c *gc.C) {
 	}, {
 		"RemoveDevice", []interface{}{"inst-0", "filesystem-0"},
 	}})
+}
+
+func (s *storageSuite) TestImportFilesystem(c *gc.C) {
+	source := s.filesystemSource(c, "pool")
+	c.Assert(source, gc.Implements, new(storage.FilesystemImporter))
+	importer := source.(storage.FilesystemImporter)
+
+	s.Client.Volumes = map[string][]api.StorageVolume{
+		"foo": []api.StorageVolume{{
+			StorageVolumePut: api.StorageVolumePut{
+				Name: "bar",
+				Config: map[string]string{
+					"size": "10GB",
+				},
+			},
+		}},
+	}
+
+	info, err := importer.ImportFilesystem("foo:bar", map[string]string{
+		"baz": "qux",
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(info, jc.DeepEquals, storage.FilesystemInfo{
+		FilesystemId: "foo:bar",
+		Size:         10 * 1024,
+	})
+
+	update := api.StorageVolume{
+		StorageVolumePut: api.StorageVolumePut{
+			Name: "bar",
+			Config: map[string]string{
+				"size":     "10GB",
+				"user.baz": "qux",
+			},
+		},
+	}
+	s.Stub.CheckCalls(c, []testing.StubCall{
+		{"Volume", []interface{}{"foo", "bar"}},
+		{"VolumeUpdate", []interface{}{"foo", "bar", update}},
+	})
 }

--- a/provider/lxd/testing_test.go
+++ b/provider/lxd/testing_test.go
@@ -636,12 +636,30 @@ func (conn *StubClient) VolumeDelete(pool, volume string) error {
 	return conn.NextErr()
 }
 
+func (conn *StubClient) Volume(pool, volume string) (api.StorageVolume, error) {
+	conn.AddCall("Volume", pool, volume)
+	if err := conn.NextErr(); err != nil {
+		return api.StorageVolume{}, err
+	}
+	for _, v := range conn.Volumes[pool] {
+		if v.Name == volume {
+			return v, nil
+		}
+	}
+	return api.StorageVolume{}, errors.NotFoundf("volume %q in pool %q", volume, pool)
+}
+
 func (conn *StubClient) VolumeList(pool string) ([]api.StorageVolume, error) {
 	conn.AddCall("VolumeList", pool)
 	if err := conn.NextErr(); err != nil {
 		return nil, err
 	}
 	return conn.Volumes[pool], nil
+}
+
+func (conn *StubClient) VolumeUpdate(pool, volume string, update api.StorageVolume) error {
+	conn.AddCall("VolumeUpdate", pool, volume, update)
+	return conn.NextErr()
 }
 
 // TODO(ericsnow) Move stubFirewaller to environs/testing or provider/common/testing.

--- a/state/volume.go
+++ b/state/volume.go
@@ -119,6 +119,11 @@ type VolumeParams struct {
 	// that the volume is to be assigned to.
 	storage names.StorageTag
 
+	// volumeInfo, if non-empty, is the information for an already
+	// provisioned volume. This is only set when creating a volume
+	// entity for an existing volume.
+	volumeInfo *VolumeInfo
+
 	Pool string `bson:"pool"`
 	Size uint64 `bson:"size"`
 }
@@ -773,21 +778,29 @@ func (st *State) addVolumeOps(params VolumeParams, machineId string) ([]txn.Op, 
 	if err != nil {
 		return nil, names.VolumeTag{}, errors.Annotate(err, "cannot generate volume name")
 	}
-	status := statusDoc{
+	statusDoc := statusDoc{
 		Status:  status.Pending,
 		Updated: st.clock().Now().UnixNano(),
 	}
 	doc := volumeDoc{
 		Name:      name,
 		StorageId: params.storage.Id(),
-		Params:    &params,
-		// Every volume is created with one attachment.
-		AttachmentCount: 1,
+	}
+	if params.volumeInfo != nil {
+		// We're importing an already provisioned volume into the
+		// model. Set provisioned info rather than params, and set
+		// the status to "detached".
+		statusDoc.Status = status.Detached
+		doc.Info = params.volumeInfo
+	} else {
+		// Every new volume is created with one attachment.
+		doc.Params = &params
+		doc.AttachmentCount = 1
 	}
 	if !detachable {
 		doc.MachineId = origMachineId
 	}
-	return st.newVolumeOps(doc, status), names.NewVolumeTag(name), nil
+	return st.newVolumeOps(doc, statusDoc), names.NewVolumeTag(name), nil
 }
 
 func (st *State) newVolumeOps(doc volumeDoc, status statusDoc) []txn.Op {

--- a/storage/interface.go
+++ b/storage/interface.go
@@ -160,6 +160,46 @@ type FilesystemSource interface {
 	DetachFilesystems(params []FilesystemAttachmentParams) ([]error, error)
 }
 
+// FilesystemImporter provides an interface for importing filesystems
+// into the controller/model.
+//
+// TODO(axw) make this part of FilesystemSource?
+type FilesystemImporter interface {
+	// ImportFilesystem updates the filesystem with the specified
+	// filesystem provider ID with the given resource tags, so that
+	// it is seen as being managed by this Juju controller/model.
+	// ImportFilesystem returns the filesystem information to store
+	// in the model.
+	//
+	// Implementations of ImportFilesystem should validate that the
+	// filesystem is not in use before allowing the import to proceed.
+	// Once it is imported, it is assumed to be in a detached state.
+	ImportFilesystem(
+		filesystemId string,
+		resourceTags map[string]string,
+	) (FilesystemInfo, error)
+}
+
+// VolumeImporter provides an interface for importing volumes
+// into the controller/model.
+//
+// TODO(axw) make this part of VolumeSource?
+type VolumeImporter interface {
+	// ImportVolume updates the volume with the specified volume
+	// provider ID with the given resource tags, so that it is
+	// seen as being managed by this Juju controller/model.
+	// ImportVolume returns the volume information to store
+	// in the model.
+	//
+	// Implementations of ImportVolume should validate that the
+	// volume is not in use before allowing the import to proceed.
+	// Once it is imported, it is assumed to be in a detached state.
+	ImportVolume(
+		volumeId string,
+		resourceTags map[string]string,
+	) (VolumeInfo, error)
+}
+
 // VolumeParams is a fully specified set of parameters for volume creation,
 // derived from one or more of user-specified storage constraints, a
 // storage pool definition, and charm storage metadata.

--- a/storage/provider/dummy/filesystemsource.go
+++ b/storage/provider/dummy/filesystemsource.go
@@ -1,0 +1,69 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package dummy
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/testing"
+
+	"github.com/juju/juju/storage"
+)
+
+// FilesystemSource is an implementation of storage.FilesystemSource, suitable for
+// testing. Each method's default behaviour may be overridden by setting
+// the corresponding Func field.
+type FilesystemSource struct {
+	testing.Stub
+
+	CreateFilesystemsFunc        func([]storage.FilesystemParams) ([]storage.CreateFilesystemsResult, error)
+	DestroyFilesystemsFunc       func([]string) ([]error, error)
+	ValidateFilesystemParamsFunc func(storage.FilesystemParams) error
+	AttachFilesystemsFunc        func([]storage.FilesystemAttachmentParams) ([]storage.AttachFilesystemsResult, error)
+	DetachFilesystemsFunc        func([]storage.FilesystemAttachmentParams) ([]error, error)
+}
+
+// CreateFilesystems is defined on storage.FilesystemSource.
+func (s *FilesystemSource) CreateFilesystems(params []storage.FilesystemParams) ([]storage.CreateFilesystemsResult, error) {
+	s.MethodCall(s, "CreateFilesystems", params)
+	if s.CreateFilesystemsFunc != nil {
+		return s.CreateFilesystemsFunc(params)
+	}
+	return nil, errors.NotImplementedf("CreateFilesystems")
+}
+
+// DestroyFilesystems is defined on storage.FilesystemSource.
+func (s *FilesystemSource) DestroyFilesystems(volIds []string) ([]error, error) {
+	s.MethodCall(s, "DestroyFilesystems", volIds)
+	if s.DestroyFilesystemsFunc != nil {
+		return s.DestroyFilesystemsFunc(volIds)
+	}
+	return nil, errors.NotImplementedf("DestroyFilesystems")
+}
+
+// ValidateFilesystemParams is defined on storage.FilesystemSource.
+func (s *FilesystemSource) ValidateFilesystemParams(params storage.FilesystemParams) error {
+	s.MethodCall(s, "ValidateFilesystemParams", params)
+	if s.ValidateFilesystemParamsFunc != nil {
+		return s.ValidateFilesystemParamsFunc(params)
+	}
+	return nil
+}
+
+// AttachFilesystems is defined on storage.FilesystemSource.
+func (s *FilesystemSource) AttachFilesystems(params []storage.FilesystemAttachmentParams) ([]storage.AttachFilesystemsResult, error) {
+	s.MethodCall(s, "AttachFilesystems", params)
+	if s.AttachFilesystemsFunc != nil {
+		return s.AttachFilesystemsFunc(params)
+	}
+	return nil, errors.NotImplementedf("AttachFilesystems")
+}
+
+// DetachFilesystems is defined on storage.FilesystemSource.
+func (s *FilesystemSource) DetachFilesystems(params []storage.FilesystemAttachmentParams) ([]error, error) {
+	s.MethodCall(s, "DetachFilesystems", params)
+	if s.DetachFilesystemsFunc != nil {
+		return s.DetachFilesystemsFunc(params)
+	}
+	return nil, errors.NotImplementedf("DetachFilesystems")
+}


### PR DESCRIPTION
## Description of change

Introduce the "import-filesystem" command. This new command can be used to import an existing, already-provisioned filesystem into the model/controller. This is used to import storage that was created externally, to bring it under the control of this model/controller.

After running import-filesystem, destroying the model or controller is expected to destroy the imported storage.

Importing storage requires provider support. This is initially implemented by LXD and EBS only. Other providers will follow.

## QA steps

1. juju bootstrap localhost
2. lxd storage volume create juju foo
3. juju import-filesystem lxd juju:foo pgdata
4. juju deploy postgresql --attach-storage pgdata/0

(do the same thing with aws/ebs; create the volume through the console, in the same region as the model into which it will be imported)

## Documentation changes

Yes, we will need to document "import-filesystem". The name is subject to change, this is going out for feedback.

## Bug reference

None.