### PR TITLE
Support releasing storage (model/apiserver changes)

### DIFF
--- a/api/facadeversions.go
+++ b/api/facadeversions.go
@@ -81,7 +81,7 @@ var facadeVersions = map[string]int{
 	"SSHClient":                    2,
 	"StatusHistory":                2,
 	"Storage":                      4,
-	"StorageProvisioner":           3,
+	"StorageProvisioner":           4,
 	"StringsWatcher":               1,
 	"Subnets":                      2,
 	"Undertaker":                   1,

--- a/apiserver/allfacades.go
+++ b/apiserver/allfacades.go
@@ -210,7 +210,8 @@ func AllFacades() *facade.Registry {
 	reg("Storage", 3, storage.NewFacadeV3)
 	reg("Storage", 4, storage.NewFacadeV4) // changes Destroy() method signature.
 
-	reg("StorageProvisioner", 3, storageprovisioner.NewFacade)
+	reg("StorageProvisioner", 3, storageprovisioner.NewFacadeV3)
+	reg("StorageProvisioner", 4, storageprovisioner.NewFacadeV4)
 	reg("Subnets", 2, subnets.NewAPI)
 	reg("Undertaker", 1, undertaker.NewUndertakerAPI)
 	reg("UnitAssigner", 1, unitassigner.New)

--- a/apiserver/facades/agent/storageprovisioner/shim.go
+++ b/apiserver/facades/agent/storageprovisioner/shim.go
@@ -21,15 +21,24 @@ import (
 // to change any part of it so that it were no longer *obviously* and
 // *trivially* correct, you would be Doing It Wrong.
 
-// NewFacade provides the signature required for facade registration.
-func NewFacade(st *state.State, resources facade.Resources, authorizer facade.Authorizer) (*StorageProvisionerAPI, error) {
+// NewFacadeV3 provides the signature required for facade registration.
+func NewFacadeV3(st *state.State, resources facade.Resources, authorizer facade.Authorizer) (*StorageProvisionerAPIv3, error) {
 	env, err := stateenvirons.GetNewEnvironFunc(environs.New)(st)
 	if err != nil {
 		return nil, errors.Annotate(err, "getting environ")
 	}
 	registry := stateenvirons.NewStorageProviderRegistry(env)
 	pm := poolmanager.New(state.NewStateSettings(st), registry)
-	return NewStorageProvisionerAPI(stateShim{st}, resources, authorizer, registry, pm)
+	return NewStorageProvisionerAPIv3(stateShim{st}, resources, authorizer, registry, pm)
+}
+
+// NewFacadeV4 provides the signature required for facade registration.
+func NewFacadeV4(st *state.State, resources facade.Resources, authorizer facade.Authorizer) (*StorageProvisionerAPIv4, error) {
+	v3, err := NewFacadeV3(st, resources, authorizer)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return NewStorageProvisionerAPIv4(v3), nil
 }
 
 type Backend interface {

--- a/apiserver/facades/client/storage/base_test.go
+++ b/apiserver/facades/client/storage/base_test.go
@@ -94,6 +94,7 @@ const (
 	attachStorageCall                       = "attachStorage"
 	detachStorageCall                       = "detachStorage"
 	destroyStorageInstanceCall              = "destroyStorageInstance"
+	releaseStorageInstanceCall              = "releaseStorageInstance"
 	addExistingFilesystemCall               = "addExistingFilesystem"
 )
 
@@ -269,6 +270,10 @@ func (s *baseStorageSuite) constructState() *mockState {
 		},
 		destroyStorageInstance: func(tag names.StorageTag, destroyAttached bool) error {
 			s.stub.AddCall(destroyStorageInstanceCall, tag, destroyAttached)
+			return errors.New("cannae do it")
+		},
+		releaseStorageInstance: func(tag names.StorageTag, destroyAttached bool) error {
+			s.stub.AddCall(releaseStorageInstanceCall, tag, destroyAttached)
 			return errors.New("cannae do it")
 		},
 		addExistingFilesystem: func(f state.FilesystemInfo, v *state.VolumeInfo, storageName string) (names.StorageTag, error) {

--- a/apiserver/facades/client/storage/mock_test.go
+++ b/apiserver/facades/client/storage/mock_test.go
@@ -64,6 +64,7 @@ type mockState struct {
 	getBlockForType                     func(t state.BlockType) (state.Block, bool, error)
 	blockDevices                        func(names.MachineTag) ([]state.BlockDeviceInfo, error)
 	destroyStorageInstance              func(names.StorageTag, bool) error
+	releaseStorageInstance              func(names.StorageTag, bool) error
 	attachStorage                       func(names.StorageTag, names.UnitTag) error
 	detachStorage                       func(names.StorageTag, names.UnitTag) error
 	addExistingFilesystem               func(state.FilesystemInfo, *state.VolumeInfo, string) (names.StorageTag, error)
@@ -186,6 +187,10 @@ func (st *mockState) DetachStorage(storage names.StorageTag, unit names.UnitTag)
 
 func (st *mockState) DestroyStorageInstance(tag names.StorageTag, destroyAttached bool) error {
 	return st.destroyStorageInstance(tag, destroyAttached)
+}
+
+func (st *mockState) ReleaseStorageInstance(tag names.StorageTag, destroyAttached bool) error {
+	return st.releaseStorageInstance(tag, destroyAttached)
 }
 
 func (st *mockState) UnitStorageAttachments(tag names.UnitTag) ([]state.StorageAttachment, error) {

--- a/apiserver/facades/client/storage/shim.go
+++ b/apiserver/facades/client/storage/shim.go
@@ -139,6 +139,9 @@ type storageAccess interface {
 	// DestroyStorageInstance destroys the storage instance with the specified tag.
 	DestroyStorageInstance(names.StorageTag, bool) error
 
+	// ReleaseStorageInstance releases the storage instance with the specified tag.
+	ReleaseStorageInstance(names.StorageTag, bool) error
+
 	// UnitStorageAttachments returns the storage attachments for the
 	// identified unit.
 	UnitStorageAttachments(names.UnitTag) ([]state.StorageAttachment, error)

--- a/apiserver/facades/client/storage/storage.go
+++ b/apiserver/facades/client/storage/storage.go
@@ -763,7 +763,9 @@ func (a *APIv3) Destroy(args params.Entities) (params.ErrorResults, error) {
 }
 
 // Destroy sets the specified storage entities to Dying, unless they are
-// already Dying or Dead.
+// already Dying or Dead, such that the storage will eventually be removed
+// from the model. If the arguments specify that the storage should be
+// *released*, then it will be removed from the model non-destructively.
 func (a *APIv4) Destroy(args params.DestroyStorage) (params.ErrorResults, error) {
 	return a.destroy(args)
 }
@@ -785,8 +787,12 @@ func (a *APIv3) destroy(args params.DestroyStorage) (params.ErrorResults, error)
 			result[i].Error = common.ServerError(err)
 			continue
 		}
+		destroy := a.storage.DestroyStorageInstance
+		if arg.ReleaseStorage {
+			destroy = a.storage.ReleaseStorageInstance
+		}
 		result[i].Error = common.ServerError(
-			a.storage.DestroyStorageInstance(tag, arg.DestroyAttached),
+			destroy(tag, arg.DestroyAttached),
 		)
 	}
 	return params.ErrorResults{result}, nil

--- a/apiserver/facades/client/storage/storage_test.go
+++ b/apiserver/facades/client/storage/storage_test.go
@@ -330,12 +330,14 @@ func (s *storageSuite) TestDestroy(c *gc.C) {
 	results, err := s.api.Destroy(params.DestroyStorage{[]params.DestroyStorageInstance{
 		{Tag: "storage-foo-0"},
 		{Tag: "storage-foo-1", DestroyAttached: true},
+		{Tag: "storage-foo-1", DestroyAttached: true, ReleaseStorage: true},
 		{Tag: "volume-0"},
 		{Tag: "filesystem-1-2"},
 		{Tag: "machine-0"},
 	}})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results.Results, jc.DeepEquals, []params.ErrorResult{
+		{Error: &params.Error{Message: "cannae do it"}},
 		{Error: &params.Error{Message: "cannae do it"}},
 		{Error: &params.Error{Message: "cannae do it"}},
 		{Error: &params.Error{Message: `"volume-0" is not a valid storage tag`}},
@@ -347,9 +349,11 @@ func (s *storageSuite) TestDestroy(c *gc.C) {
 		getBlockForTypeCall, // Change
 		destroyStorageInstanceCall,
 		destroyStorageInstanceCall,
+		releaseStorageInstanceCall,
 	)
 	s.stub.CheckCall(c, 2, destroyStorageInstanceCall, names.NewStorageTag("foo/0"), false)
 	s.stub.CheckCall(c, 3, destroyStorageInstanceCall, names.NewStorageTag("foo/1"), true)
+	s.stub.CheckCall(c, 4, releaseStorageInstanceCall, names.NewStorageTag("foo/1"), true)
 }
 
 func (s *storageSuite) TestDestroyV3(c *gc.C) {

--- a/apiserver/params/storage.go
+++ b/apiserver/params/storage.go
@@ -218,6 +218,19 @@ type VolumeParams struct {
 	Attachment *VolumeAttachmentParams `json:"attachment,omitempty"`
 }
 
+// DestroyVolumeParams holds the parameters for destroying a storage volume.
+type DestroyVolumeParams struct {
+	// Provider is the storage provider that manages the volume.
+	Provider string `json:"provider"`
+
+	// VolumeId is the storage provider's unique ID for the volume.
+	VolumeId string `json:"volume-id"`
+
+	// Release controls whether the volume should be completely
+	// destroyed, or merely released from Juju's management.
+	Release bool `json:"release,omitempty"`
+}
+
 // VolumeAttachmentParams holds the parameters for creating a volume
 // attachment.
 type VolumeAttachmentParams struct {
@@ -274,6 +287,17 @@ type VolumeParamsResult struct {
 // VolumeParamsResults holds provisioning parameters for multiple volumes.
 type VolumeParamsResults struct {
 	Results []VolumeParamsResult `json:"results,omitempty"`
+}
+
+// DestroyVolumeParamsResults holds parameters for destroying a volume.
+type DestroyVolumeParamsResult struct {
+	Result DestroyVolumeParams `json:"result"`
+	Error  *Error              `json:"error,omitempty"`
+}
+
+// DestroyVolumeParamsResults holds parameters for destroying multiple volumes.
+type DestroyVolumeParamsResults struct {
+	Results []DestroyVolumeParamsResult `json:"results,omitempty"`
 }
 
 // VolumeAttachmentParamsResults holds provisioning parameters for a volume
@@ -342,6 +366,19 @@ type FilesystemParams struct {
 	Attachment    *FilesystemAttachmentParams `json:"attachment,omitempty"`
 }
 
+// DestroyFilesystemParams holds the parameters for destroying a filesystem.
+type DestroyFilesystemParams struct {
+	// Provider is the storage provider that manages the filesystem.
+	Provider string `json:"provider"`
+
+	// FilesystemId is the storage provider's unique ID for the filesystem.
+	FilesystemId string `json:"filesystem-id"`
+
+	// Release controls whether the filesystem should be completely
+	// destroyed, or merely released from Juju's management.
+	Release bool `json:"release,omitempty"`
+}
+
 // FilesystemAttachmentParams holds the parameters for creating a filesystem
 // attachment.
 type FilesystemAttachmentParams struct {
@@ -386,6 +423,17 @@ type FilesystemParamsResult struct {
 // FilesystemParamsResults holds provisioning parameters for multiple filesystems.
 type FilesystemParamsResults struct {
 	Results []FilesystemParamsResult `json:"results,omitempty"`
+}
+
+// DestroyFilesystemParamsResults holds parameters for destroying a filesystem.
+type DestroyFilesystemParamsResult struct {
+	Result DestroyFilesystemParams `json:"result"`
+	Error  *Error                  `json:"error,omitempty"`
+}
+
+// DestroyFilesystemParamsResults holds parameters for destroying multiple filesystems.
+type DestroyFilesystemParamsResults struct {
+	Results []DestroyFilesystemParamsResult `json:"results,omitempty"`
 }
 
 // FilesystemAttachmentParamsResults holds provisioning parameters for a filesystem
@@ -742,10 +790,18 @@ type DestroyStorageInstance struct {
 	// Tag is the tag of the storage instance to be destroyed.
 	Tag string `json:"tag"`
 
-	// DestroyAttached controls whether or not the storage will be
-	// destroyed if it is currently attached. If destroy-attached
-	// is false, then the storage must already be detached.
-	DestroyAttached bool `json:"destroy-attached,bool"`
+	// DestroyAttached controls whether or not the storage attachments
+	// will be destroyed automatically. If DestroyAttachments is false,
+	// then the storage must already be detached.
+	//
+	// TODO(axw) rename to DestroyAttachments, json:"destroy-attachments".
+	DestroyAttached bool `json:"destroy-attached,omitempty"`
+
+	// ReleaseStorage controls whether or not the associated
+	// cloud storage is destroyed. If ReleaseStorage is true,
+	// then the cloud storage will not be destroyed, otherwise
+	// it will be.
+	ReleaseStorage bool `json:"release-storage,omitempty"`
 }
 
 // BulkImportStorageParams contains the parameters for importing a collection

--- a/state/migration_internal_test.go
+++ b/state/migration_internal_test.go
@@ -683,6 +683,7 @@ func (s *MigrationSuite) TestVolumeDocFields(c *gc.C) {
 		"DocID",
 		"Life",
 		"MachineId", // recreated from pool properties
+		"Releasing", // only when dying; can't migrate dying storage
 	)
 	migrated := set.NewStrings(
 		"Name",
@@ -725,6 +726,7 @@ func (s *MigrationSuite) TestFilesystemDocFields(c *gc.C) {
 		"DocID",
 		"Life",
 		"MachineId", // recreated from pool properties
+		"Releasing", // only when dying; can't migrate dying storage
 	)
 	migrated := set.NewStrings(
 		"FilesystemId",
@@ -767,6 +769,7 @@ func (s *MigrationSuite) TestStorageInstanceDocFields(c *gc.C) {
 		"ModelUUID",
 		"DocID",
 		"Life",
+		"Releasing", // only when dying; can't migrate dying storage
 	)
 	migrated := set.NewStrings(
 		"Id",

--- a/state/volume.go
+++ b/state/volume.go
@@ -49,6 +49,10 @@ type Volume interface {
 
 	// Detachable reports whether or not the volume is detachable.
 	Detachable() bool
+
+	// Releasing reports whether or not the volume is to be released
+	// from the model when it is Dying/Dead.
+	Releasing() bool
 }
 
 // VolumeAttachment describes an attachment of a volume to a machine.
@@ -89,6 +93,7 @@ type volumeDoc struct {
 	Name            string        `bson:"name"`
 	ModelUUID       string        `bson:"model-uuid"`
 	Life            Life          `bson:"life"`
+	Releasing       bool          `bson:"releasing,omitempty"`
 	StorageId       string        `bson:"storageid,omitempty"`
 	AttachmentCount int           `bson:"attachmentcount"`
 	Info            *VolumeInfo   `bson:"info,omitempty"`
@@ -200,6 +205,11 @@ func (v *volume) Params() (VolumeParams, bool) {
 		return VolumeParams{}, false
 	}
 	return *v.doc.Params, true
+}
+
+// Releasing is required to imeplement Volume.
+func (v *volume) Releasing() bool {
+	return v.doc.Releasing
 }
 
 // Status is required to implement StatusGetter.
@@ -660,28 +670,34 @@ func (st *State) DestroyVolume(tag names.VolumeTag) (err error) {
 			{{"storageid", ""}},
 			{{"storageid", bson.D{{"$exists", false}}}},
 		}}}
-		return destroyVolumeOps(st, volume, hasNoStorageAssignment)
+		return destroyVolumeOps(st, volume, false, hasNoStorageAssignment)
 	}
 	return st.db().Run(buildTxn)
 }
 
-func destroyVolumeOps(st *State, v *volume, extraAssert bson.D) ([]txn.Op, error) {
+func destroyVolumeOps(st *State, v *volume, release bool, extraAssert bson.D) ([]txn.Op, error) {
 	baseAssert := append(isAliveDoc, extraAssert...)
+	setFields := bson.D{}
+	if release {
+		setFields = append(setFields, bson.DocElem{"releasing", true})
+	}
 	if v.doc.AttachmentCount == 0 {
 		hasNoAttachments := bson.D{{"attachmentcount", 0}}
+		setFields = append(setFields, bson.DocElem{"life", Dead})
 		return []txn.Op{{
 			C:      volumesC,
 			Id:     v.doc.Name,
 			Assert: append(hasNoAttachments, baseAssert...),
-			Update: bson.D{{"$set", bson.D{{"life", Dead}}}},
+			Update: bson.D{{"$set", setFields}},
 		}}, nil
 	}
 	hasAttachments := bson.D{{"attachmentcount", bson.D{{"$gt", 0}}}}
+	setFields = append(setFields, bson.DocElem{"life", Dying})
 	ops := []txn.Op{{
 		C:      volumesC,
 		Id:     v.doc.Name,
 		Assert: append(hasAttachments, baseAssert...),
-		Update: bson.D{{"$set", bson.D{{"life", Dying}}}},
+		Update: bson.D{{"$set", setFields}},
 	}}
 	if !v.Detachable() {
 		// This volume cannot be directly detached, so we do not


### PR DESCRIPTION
## Description of change

Add state/apiserver support for non-destructively removing storage from a model. This PR is just about modifying the model entities, and updating the storage provisioner API with methods for reporting the new information to a storage provisioner worker.

There will be a followup PR that adds the API client, CLI, worker, and storage provider changes.

## QA steps

Smoke test, ensure "remove-storage" works as before.

## Documentation changes

None (yet).

## Bug reference

None.