### PR TITLE
Release storage client worker provider

### DIFF
--- a/api/storageprovisioner/provisioner.go
+++ b/api/storageprovisioner/provisioner.go
@@ -243,6 +243,26 @@ func (st *State) VolumeParams(tags []names.VolumeTag) ([]params.VolumeParamsResu
 	return results.Results, nil
 }
 
+// RemoveVolumeParams returns the parameters for destroying or releasing
+// the volumes with the specified tags.
+func (st *State) RemoveVolumeParams(tags []names.VolumeTag) ([]params.RemoveVolumeParamsResult, error) {
+	args := params.Entities{
+		Entities: make([]params.Entity, len(tags)),
+	}
+	for i, tag := range tags {
+		args.Entities[i].Tag = tag.String()
+	}
+	var results params.RemoveVolumeParamsResults
+	err := st.facade.FacadeCall("RemoveVolumeParams", args, &results)
+	if err != nil {
+		return nil, err
+	}
+	if len(results.Results) != len(tags) {
+		panic(errors.Errorf("expected %d result(s), got %d", len(tags), len(results.Results)))
+	}
+	return results.Results, nil
+}
+
 // FilesystemParams returns the parameters for creating the filesystems
 // with the specified tags.
 func (st *State) FilesystemParams(tags []names.FilesystemTag) ([]params.FilesystemParamsResult, error) {
@@ -254,6 +274,26 @@ func (st *State) FilesystemParams(tags []names.FilesystemTag) ([]params.Filesyst
 	}
 	var results params.FilesystemParamsResults
 	err := st.facade.FacadeCall("FilesystemParams", args, &results)
+	if err != nil {
+		return nil, err
+	}
+	if len(results.Results) != len(tags) {
+		panic(errors.Errorf("expected %d result(s), got %d", len(tags), len(results.Results)))
+	}
+	return results.Results, nil
+}
+
+// RemoveFilesystemParams returns the parameters for destroying or releasing
+// the filesystems with the specified tags.
+func (st *State) RemoveFilesystemParams(tags []names.FilesystemTag) ([]params.RemoveFilesystemParamsResult, error) {
+	args := params.Entities{
+		Entities: make([]params.Entity, len(tags)),
+	}
+	for i, tag := range tags {
+		args.Entities[i].Tag = tag.String()
+	}
+	var results params.RemoveFilesystemParamsResults
+	err := st.facade.FacadeCall("RemoveFilesystemParams", args, &results)
 	if err != nil {
 		return nil, err
 	}

--- a/apiserver/facades/agent/storageprovisioner/storageprovisioner.go
+++ b/apiserver/facades/agent/storageprovisioner/storageprovisioner.go
@@ -657,51 +657,51 @@ func (s *StorageProvisionerAPIv3) VolumeParams(args params.Entities) (params.Vol
 	return results, nil
 }
 
-// DestroyVolumeParams returns the parameters for destroying
-// the volumes with the specified tags.
-func (s *StorageProvisionerAPIv4) DestroyVolumeParams(args params.Entities) (params.DestroyVolumeParamsResults, error) {
+// RemoveVolumeParams returns the parameters for destroying
+// or releasing the volumes with the specified tags.
+func (s *StorageProvisionerAPIv4) RemoveVolumeParams(args params.Entities) (params.RemoveVolumeParamsResults, error) {
 	canAccess, err := s.getStorageEntityAuthFunc()
 	if err != nil {
-		return params.DestroyVolumeParamsResults{}, err
+		return params.RemoveVolumeParamsResults{}, err
 	}
-	results := params.DestroyVolumeParamsResults{
-		Results: make([]params.DestroyVolumeParamsResult, len(args.Entities)),
+	results := params.RemoveVolumeParamsResults{
+		Results: make([]params.RemoveVolumeParamsResult, len(args.Entities)),
 	}
-	one := func(arg params.Entity) (params.DestroyVolumeParams, error) {
+	one := func(arg params.Entity) (params.RemoveVolumeParams, error) {
 		tag, err := names.ParseVolumeTag(arg.Tag)
 		if err != nil || !canAccess(tag) {
-			return params.DestroyVolumeParams{}, common.ErrPerm
+			return params.RemoveVolumeParams{}, common.ErrPerm
 		}
 		volume, err := s.st.Volume(tag)
 		if errors.IsNotFound(err) {
-			return params.DestroyVolumeParams{}, common.ErrPerm
+			return params.RemoveVolumeParams{}, common.ErrPerm
 		} else if err != nil {
-			return params.DestroyVolumeParams{}, err
+			return params.RemoveVolumeParams{}, err
 		}
 		if life := volume.Life(); life != state.Dead {
-			return params.DestroyVolumeParams{}, errors.Errorf(
+			return params.RemoveVolumeParams{}, errors.Errorf(
 				"%s is not dead (%s)",
 				names.ReadableString(tag), life,
 			)
 		}
 		volumeInfo, err := volume.Info()
 		if err != nil {
-			return params.DestroyVolumeParams{}, err
+			return params.RemoveVolumeParams{}, err
 		}
 		provider, _, err := storagecommon.StoragePoolConfig(
 			volumeInfo.Pool, s.poolManager, s.registry,
 		)
 		if err != nil {
-			return params.DestroyVolumeParams{}, err
+			return params.RemoveVolumeParams{}, err
 		}
-		return params.DestroyVolumeParams{
+		return params.RemoveVolumeParams{
 			Provider: string(provider),
 			VolumeId: volumeInfo.VolumeId,
-			Release:  volume.Releasing(),
+			Destroy:  !volume.Releasing(),
 		}, nil
 	}
 	for i, arg := range args.Entities {
-		var result params.DestroyVolumeParamsResult
+		var result params.RemoveVolumeParamsResult
 		volumeParams, err := one(arg)
 		if err != nil {
 			result.Error = common.ServerError(err)
@@ -771,51 +771,51 @@ func (s *StorageProvisionerAPIv3) FilesystemParams(args params.Entities) (params
 	return results, nil
 }
 
-// DestroyFilesystemParams returns the parameters for destroying the
-// filesystems with the specified tags.
-func (s *StorageProvisionerAPIv4) DestroyFilesystemParams(args params.Entities) (params.DestroyFilesystemParamsResults, error) {
+// RemoveFilesystemParams returns the parameters for destroying or
+// releasing the filesystems with the specified tags.
+func (s *StorageProvisionerAPIv4) RemoveFilesystemParams(args params.Entities) (params.RemoveFilesystemParamsResults, error) {
 	canAccess, err := s.getStorageEntityAuthFunc()
 	if err != nil {
-		return params.DestroyFilesystemParamsResults{}, err
+		return params.RemoveFilesystemParamsResults{}, err
 	}
-	results := params.DestroyFilesystemParamsResults{
-		Results: make([]params.DestroyFilesystemParamsResult, len(args.Entities)),
+	results := params.RemoveFilesystemParamsResults{
+		Results: make([]params.RemoveFilesystemParamsResult, len(args.Entities)),
 	}
-	one := func(arg params.Entity) (params.DestroyFilesystemParams, error) {
+	one := func(arg params.Entity) (params.RemoveFilesystemParams, error) {
 		tag, err := names.ParseFilesystemTag(arg.Tag)
 		if err != nil || !canAccess(tag) {
-			return params.DestroyFilesystemParams{}, common.ErrPerm
+			return params.RemoveFilesystemParams{}, common.ErrPerm
 		}
 		filesystem, err := s.st.Filesystem(tag)
 		if errors.IsNotFound(err) {
-			return params.DestroyFilesystemParams{}, common.ErrPerm
+			return params.RemoveFilesystemParams{}, common.ErrPerm
 		} else if err != nil {
-			return params.DestroyFilesystemParams{}, err
+			return params.RemoveFilesystemParams{}, err
 		}
 		if life := filesystem.Life(); life != state.Dead {
-			return params.DestroyFilesystemParams{}, errors.Errorf(
+			return params.RemoveFilesystemParams{}, errors.Errorf(
 				"%s is not dead (%s)",
 				names.ReadableString(tag), life,
 			)
 		}
 		filesystemInfo, err := filesystem.Info()
 		if err != nil {
-			return params.DestroyFilesystemParams{}, err
+			return params.RemoveFilesystemParams{}, err
 		}
 		provider, _, err := storagecommon.StoragePoolConfig(
 			filesystemInfo.Pool, s.poolManager, s.registry,
 		)
 		if err != nil {
-			return params.DestroyFilesystemParams{}, err
+			return params.RemoveFilesystemParams{}, err
 		}
-		return params.DestroyFilesystemParams{
+		return params.RemoveFilesystemParams{
 			Provider:     string(provider),
 			FilesystemId: filesystemInfo.FilesystemId,
-			Release:      filesystem.Releasing(),
+			Destroy:      !filesystem.Releasing(),
 		}, nil
 	}
 	for i, arg := range args.Entities {
-		var result params.DestroyFilesystemParamsResult
+		var result params.RemoveFilesystemParamsResult
 		filesystemParams, err := one(arg)
 		if err != nil {
 			result.Error = common.ServerError(err)

--- a/apiserver/facades/agent/storageprovisioner/storageprovisioner_test.go
+++ b/apiserver/facades/agent/storageprovisioner/storageprovisioner_test.go
@@ -413,12 +413,12 @@ func (s *provisionerSuite) TestVolumeParamsEmptyArgs(c *gc.C) {
 	c.Assert(results.Results, gc.HasLen, 0)
 }
 
-func (s *provisionerSuite) TestDestroyVolumeParams(c *gc.C) {
+func (s *provisionerSuite) TestRemoveVolumeParams(c *gc.C) {
 	s.setupVolumes(c)
 
 	// Deploy an application that will create a storage instance,
 	// so we can release the storage and show the effects on the
-	// DestroyVolumeParams.
+	// RemoveVolumeParams.
 	application := s.factory.MakeApplication(c, &factory.ApplicationParams{
 		Charm: s.factory.MakeCharm(c, &factory.CharmParams{
 			Name: "storage-block",
@@ -473,7 +473,7 @@ func (s *provisionerSuite) TestDestroyVolumeParams(c *gc.C) {
 	err = s.State.RemoveVolumeAttachment(unitMachineTag, storageVolume.VolumeTag())
 	c.Assert(err, jc.ErrorIsNil)
 
-	results, err := s.api.DestroyVolumeParams(params.Entities{
+	results, err := s.api.RemoveVolumeParams(params.Entities{
 		Entities: []params.Entity{
 			{"volume-0-0"},
 			{storageVolume.Tag().String()},
@@ -483,17 +483,18 @@ func (s *provisionerSuite) TestDestroyVolumeParams(c *gc.C) {
 		},
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(results, jc.DeepEquals, params.DestroyVolumeParamsResults{
-		Results: []params.DestroyVolumeParamsResult{{
-			Result: params.DestroyVolumeParams{
+	c.Assert(results, jc.DeepEquals, params.RemoveVolumeParamsResults{
+		Results: []params.RemoveVolumeParamsResult{{
+			Result: params.RemoveVolumeParams{
 				Provider: "machinescoped",
 				VolumeId: "abc",
+				Destroy:  true,
 			},
 		}, {
-			Result: params.DestroyVolumeParams{
+			Result: params.RemoveVolumeParams{
 				Provider: "modelscoped",
 				VolumeId: "zing",
-				Release:  true,
+				Destroy:  false,
 			},
 		}, {
 			Error: &params.Error{Message: `volume 1 is not dead (alive)`},
@@ -536,12 +537,12 @@ func (s *provisionerSuite) TestFilesystemParams(c *gc.C) {
 	})
 }
 
-func (s *provisionerSuite) TestDestroyFilesystemParams(c *gc.C) {
+func (s *provisionerSuite) TestRemoveFilesystemParams(c *gc.C) {
 	s.setupFilesystems(c)
 
 	// Deploy an application that will create a storage instance,
 	// so we can release the storage and show the effects on the
-	// DestroyFilesystemParams.
+	// RemoveFilesystemParams.
 	application := s.factory.MakeApplication(c, &factory.ApplicationParams{
 		Charm: s.factory.MakeCharm(c, &factory.CharmParams{
 			Name: "storage-filesystem",
@@ -595,7 +596,7 @@ func (s *provisionerSuite) TestDestroyFilesystemParams(c *gc.C) {
 	err = s.State.RemoveFilesystemAttachment(unitMachineTag, storageFilesystem.FilesystemTag())
 	c.Assert(err, jc.ErrorIsNil)
 
-	results, err := s.api.DestroyFilesystemParams(params.Entities{
+	results, err := s.api.RemoveFilesystemParams(params.Entities{
 		Entities: []params.Entity{
 			{"filesystem-0-0"},
 			{storageFilesystem.Tag().String()},
@@ -605,17 +606,18 @@ func (s *provisionerSuite) TestDestroyFilesystemParams(c *gc.C) {
 		},
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(results, jc.DeepEquals, params.DestroyFilesystemParamsResults{
-		Results: []params.DestroyFilesystemParamsResult{{
-			Result: params.DestroyFilesystemParams{
+	c.Assert(results, jc.DeepEquals, params.RemoveFilesystemParamsResults{
+		Results: []params.RemoveFilesystemParamsResult{{
+			Result: params.RemoveFilesystemParams{
 				Provider:     "machinescoped",
 				FilesystemId: "abc",
+				Destroy:      true,
 			},
 		}, {
-			Result: params.DestroyFilesystemParams{
+			Result: params.RemoveFilesystemParams{
 				Provider:     "modelscoped",
 				FilesystemId: "zing",
-				Release:      true,
+				Destroy:      false,
 			},
 		}, {
 			Error: &params.Error{Message: `filesystem "1" not provisioned`, Code: "not provisioned"},

--- a/apiserver/facades/client/storage/storage_test.go
+++ b/apiserver/facades/client/storage/storage_test.go
@@ -326,11 +326,11 @@ func (s *storageSuite) TestShowStorageInvalidId(c *gc.C) {
 	s.assertInstanceInfoError(c, found.Results[0], params.StorageDetailsResult{}, `"foo" is not a valid tag`)
 }
 
-func (s *storageSuite) TestDestroy(c *gc.C) {
-	results, err := s.api.Destroy(params.DestroyStorage{[]params.DestroyStorageInstance{
-		{Tag: "storage-foo-0"},
-		{Tag: "storage-foo-1", DestroyAttached: true},
-		{Tag: "storage-foo-1", DestroyAttached: true, ReleaseStorage: true},
+func (s *storageSuite) TestRemove(c *gc.C) {
+	results, err := s.api.Remove(params.RemoveStorage{[]params.RemoveStorageInstance{
+		{Tag: "storage-foo-0", DestroyStorage: true},
+		{Tag: "storage-foo-1", DestroyAttachments: true, DestroyStorage: true},
+		{Tag: "storage-foo-1", DestroyAttachments: true, DestroyStorage: false},
 		{Tag: "volume-0"},
 		{Tag: "filesystem-1-2"},
 		{Tag: "machine-0"},

--- a/apiserver/params/storage.go
+++ b/apiserver/params/storage.go
@@ -218,17 +218,18 @@ type VolumeParams struct {
 	Attachment *VolumeAttachmentParams `json:"attachment,omitempty"`
 }
 
-// DestroyVolumeParams holds the parameters for destroying a storage volume.
-type DestroyVolumeParams struct {
+// RemoveVolumeParams holds the parameters for destroying or releasing a
+// storage volume.
+type RemoveVolumeParams struct {
 	// Provider is the storage provider that manages the volume.
 	Provider string `json:"provider"`
 
 	// VolumeId is the storage provider's unique ID for the volume.
 	VolumeId string `json:"volume-id"`
 
-	// Release controls whether the volume should be completely
-	// destroyed, or merely released from Juju's management.
-	Release bool `json:"release,omitempty"`
+	// Destroy controls whether the volume should be completely
+	// destroyed, or otherwise merely released from Juju's management.
+	Destroy bool `json:"destroy,omitempty"`
 }
 
 // VolumeAttachmentParams holds the parameters for creating a volume
@@ -289,15 +290,15 @@ type VolumeParamsResults struct {
 	Results []VolumeParamsResult `json:"results,omitempty"`
 }
 
-// DestroyVolumeParamsResults holds parameters for destroying a volume.
-type DestroyVolumeParamsResult struct {
-	Result DestroyVolumeParams `json:"result"`
-	Error  *Error              `json:"error,omitempty"`
+// RemoveVolumeParamsResults holds parameters for destroying a volume.
+type RemoveVolumeParamsResult struct {
+	Result RemoveVolumeParams `json:"result"`
+	Error  *Error             `json:"error,omitempty"`
 }
 
-// DestroyVolumeParamsResults holds parameters for destroying multiple volumes.
-type DestroyVolumeParamsResults struct {
-	Results []DestroyVolumeParamsResult `json:"results,omitempty"`
+// RemoveVolumeParamsResults holds parameters for destroying multiple volumes.
+type RemoveVolumeParamsResults struct {
+	Results []RemoveVolumeParamsResult `json:"results,omitempty"`
 }
 
 // VolumeAttachmentParamsResults holds provisioning parameters for a volume
@@ -366,17 +367,18 @@ type FilesystemParams struct {
 	Attachment    *FilesystemAttachmentParams `json:"attachment,omitempty"`
 }
 
-// DestroyFilesystemParams holds the parameters for destroying a filesystem.
-type DestroyFilesystemParams struct {
+// RemoveFilesystemParams holds the parameters for destroying or releasing
+// a filesystem.
+type RemoveFilesystemParams struct {
 	// Provider is the storage provider that manages the filesystem.
 	Provider string `json:"provider"`
 
 	// FilesystemId is the storage provider's unique ID for the filesystem.
 	FilesystemId string `json:"filesystem-id"`
 
-	// Release controls whether the filesystem should be completely
-	// destroyed, or merely released from Juju's management.
-	Release bool `json:"release,omitempty"`
+	// Destroy controls whether the filesystem should be completely
+	// destroyed, or otherwise merely released from Juju's management.
+	Destroy bool `json:"destroy,omitempty"`
 }
 
 // FilesystemAttachmentParams holds the parameters for creating a filesystem
@@ -425,15 +427,17 @@ type FilesystemParamsResults struct {
 	Results []FilesystemParamsResult `json:"results,omitempty"`
 }
 
-// DestroyFilesystemParamsResults holds parameters for destroying a filesystem.
-type DestroyFilesystemParamsResult struct {
-	Result DestroyFilesystemParams `json:"result"`
-	Error  *Error                  `json:"error,omitempty"`
+// RemoveFilesystemParamsResult holds parameters for destroying or releasing
+// a filesystem.
+type RemoveFilesystemParamsResult struct {
+	Result RemoveFilesystemParams `json:"result"`
+	Error  *Error                 `json:"error,omitempty"`
 }
 
-// DestroyFilesystemParamsResults holds parameters for destroying multiple filesystems.
-type DestroyFilesystemParamsResults struct {
-	Results []DestroyFilesystemParamsResult `json:"results,omitempty"`
+// RemoveFilesystemParamsResults holds parameters for destroying or releasing
+// multiple filesystems.
+type RemoveFilesystemParamsResults struct {
+	Results []RemoveFilesystemParamsResult `json:"results,omitempty"`
 }
 
 // FilesystemAttachmentParamsResults holds provisioning parameters for a filesystem

--- a/apiserver/params/storage.go
+++ b/apiserver/params/storage.go
@@ -780,28 +780,25 @@ type StoragesAddParams struct {
 	Storages []StorageAddParams `json:"storages"`
 }
 
-// DestroyStorage holds the parameters for destroying storage.
-type DestroyStorage struct {
-	Storage []DestroyStorageInstance `json:"storage"`
+// RemoveStorage holds the parameters for removing storage from the model.
+type RemoveStorage struct {
+	Storage []RemoveStorageInstance `json:"storage"`
 }
 
-// DestroyStorage holds the parameters for destroying a storage instance.
-type DestroyStorageInstance struct {
+// RemoveStorageInstance holds the parameters for removing a storage instance.
+type RemoveStorageInstance struct {
 	// Tag is the tag of the storage instance to be destroyed.
 	Tag string `json:"tag"`
 
-	// DestroyAttached controls whether or not the storage attachments
+	// DestroyAttachments controls whether or not the storage attachments
 	// will be destroyed automatically. If DestroyAttachments is false,
 	// then the storage must already be detached.
-	//
-	// TODO(axw) rename to DestroyAttachments, json:"destroy-attachments".
-	DestroyAttached bool `json:"destroy-attached,omitempty"`
+	DestroyAttachments bool `json:"destroy-attachments,omitempty"`
 
-	// ReleaseStorage controls whether or not the associated
-	// cloud storage is destroyed. If ReleaseStorage is true,
-	// then the cloud storage will not be destroyed, otherwise
-	// it will be.
-	ReleaseStorage bool `json:"release-storage,omitempty"`
+	// DestroyStorage controls whether or not the associated cloud storage
+	// is destroyed. If DestroyStorage is true, the cloud storage will be
+	// destroyed; otherwise it will only be released from Juju's control.
+	DestroyStorage bool `json:"destroy-storage,omitempty"`
 }
 
 // BulkImportStorageParams contains the parameters for importing a collection

--- a/cmd/juju/storage/remove_test.go
+++ b/cmd/juju/storage/remove_test.go
@@ -21,15 +21,15 @@ type RemoveStorageSuite struct {
 var _ = gc.Suite(&RemoveStorageSuite{})
 
 func (s *RemoveStorageSuite) TestRemoveStorage(c *gc.C) {
-	fake := fakeStorageDestroyer{results: []params.ErrorResult{
+	fake := fakeStorageRemover{results: []params.ErrorResult{
 		{},
 		{},
 	}}
 	cmd := storage.NewRemoveStorageCommand(fake.new)
 	ctx, err := cmdtesting.RunCommand(c, cmd, "pgdata/0", "pgdata/1")
 	c.Assert(err, jc.ErrorIsNil)
-	fake.CheckCallNames(c, "NewStorageDestroyerCloser", "Destroy", "Close")
-	fake.CheckCall(c, 1, "Destroy", []string{"pgdata/0", "pgdata/1"}, false)
+	fake.CheckCallNames(c, "NewStorageRemoverCloser", "Remove", "Close")
+	fake.CheckCall(c, 1, "Remove", []string{"pgdata/0", "pgdata/1"}, false, true)
 	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, `
 removing pgdata/0
 removing pgdata/1
@@ -37,18 +37,29 @@ removing pgdata/1
 }
 
 func (s *RemoveStorageSuite) TestRemoveStorageForce(c *gc.C) {
-	fake := fakeStorageDestroyer{results: []params.ErrorResult{
+	fake := fakeStorageRemover{results: []params.ErrorResult{
 		{},
 		{},
 	}}
 	cmd := storage.NewRemoveStorageCommand(fake.new)
 	_, err := cmdtesting.RunCommand(c, cmd, "--force", "pgdata/0", "pgdata/1")
 	c.Assert(err, jc.ErrorIsNil)
-	fake.CheckCall(c, 1, "Destroy", []string{"pgdata/0", "pgdata/1"}, true)
+	fake.CheckCall(c, 1, "Remove", []string{"pgdata/0", "pgdata/1"}, true, true)
+}
+
+func (s *RemoveStorageSuite) TestRemoveStorageNoDestroy(c *gc.C) {
+	fake := fakeStorageRemover{results: []params.ErrorResult{
+		{},
+		{},
+	}}
+	cmd := storage.NewRemoveStorageCommand(fake.new)
+	_, err := cmdtesting.RunCommand(c, cmd, "--no-destroy", "--force", "pgdata/0", "pgdata/1")
+	c.Assert(err, jc.ErrorIsNil)
+	fake.CheckCall(c, 1, "Remove", []string{"pgdata/0", "pgdata/1"}, true, false)
 }
 
 func (s *RemoveStorageSuite) TestRemoveStorageError(c *gc.C) {
-	fake := fakeStorageDestroyer{results: []params.ErrorResult{
+	fake := fakeStorageRemover{results: []params.ErrorResult{
 		{Error: &params.Error{Message: "foo"}},
 		{Error: &params.Error{Message: "storage is attached", Code: params.CodeStorageAttached}},
 	}}
@@ -66,7 +77,7 @@ before removing.
 }
 
 func (s *RemoveStorageSuite) TestRemoveStorageUnauthorizedError(c *gc.C) {
-	var fake fakeStorageDestroyer
+	var fake fakeStorageRemover
 	fake.SetErrors(nil, &params.Error{Code: params.CodeUnauthorized, Message: "nope"})
 	cmd := storage.NewRemoveStorageCommand(fake.new)
 	ctx, err := cmdtesting.RunCommand(c, cmd, "pgdata/0")
@@ -83,28 +94,28 @@ func (s *RemoveStorageSuite) TestRemoveStorageInitErrors(c *gc.C) {
 }
 
 func (s *RemoveStorageSuite) testRemoveStorageInitError(c *gc.C, args []string, expect string) {
-	var fake fakeStorageDestroyer
+	var fake fakeStorageRemover
 	cmd := storage.NewRemoveStorageCommand(fake.new)
 	_, err := cmdtesting.RunCommand(c, cmd, args...)
 	c.Assert(err, gc.ErrorMatches, expect)
 }
 
-type fakeStorageDestroyer struct {
+type fakeStorageRemover struct {
 	testing.Stub
 	results []params.ErrorResult
 }
 
-func (f *fakeStorageDestroyer) new() (storage.StorageDestroyerCloser, error) {
-	f.MethodCall(f, "NewStorageDestroyerCloser")
+func (f *fakeStorageRemover) new() (storage.StorageRemoverCloser, error) {
+	f.MethodCall(f, "NewStorageRemoverCloser")
 	return f, f.NextErr()
 }
 
-func (f *fakeStorageDestroyer) Close() error {
+func (f *fakeStorageRemover) Close() error {
 	f.MethodCall(f, "Close")
 	return f.NextErr()
 }
 
-func (f *fakeStorageDestroyer) Destroy(ids []string, destroyAttached bool) ([]params.ErrorResult, error) {
-	f.MethodCall(f, "Destroy", ids, destroyAttached)
+func (f *fakeStorageRemover) Remove(ids []string, destroyAttached, destroyStorage bool) ([]params.ErrorResult, error) {
+	f.MethodCall(f, "Remove", ids, destroyAttached, destroyStorage)
 	return f.results, f.NextErr()
 }

--- a/provider/azure/storage.go
+++ b/provider/azure/storage.go
@@ -342,6 +342,11 @@ func (v *azureVolumeSource) DestroyVolumes(volumeIds []string) ([]error, error) 
 	return results, nil
 }
 
+// ReleaseVolumes is specified on the storage.VolumeSource interface.
+func (v *azureVolumeSource) ReleaseVolumes(volumeIds []string) ([]error, error) {
+	return nil, errors.NotImplementedf("ReleaseVolumes")
+}
+
 // ValidateVolumeParams is specified on the storage.VolumeSource interface.
 func (v *azureVolumeSource) ValidateVolumeParams(params storage.VolumeParams) error {
 	if mibToGib(params.Size) > volumeSizeMaxGiB {

--- a/provider/ec2/environ.go
+++ b/provider/ec2/environ.go
@@ -1254,7 +1254,7 @@ func (e *environ) destroyControllerManagedEnvirons(controllerUUID string) error 
 	if err != nil {
 		return errors.Annotate(err, "listing volumes")
 	}
-	errs := destroyVolumes(e.ec2, volIds)
+	errs := foreachVolume(e.ec2, volIds, destroyVolume)
 	for i, err := range errs {
 		if err == nil {
 			continue

--- a/provider/gce/disks.go
+++ b/provider/gce/disks.go
@@ -259,6 +259,10 @@ func (v *volumeSource) DestroyVolumes(volNames []string) ([]error, error) {
 	return results, nil
 }
 
+func (v *volumeSource) ReleaseVolumes(volNames []string) ([]error, error) {
+	return nil, errors.NotImplementedf("ReleaseVolumes")
+}
+
 func parseVolumeId(volName string) (string, string, error) {
 	idRest := strings.SplitN(volName, "--", 2)
 	if len(idRest) != 2 {

--- a/provider/openstack/cinder.go
+++ b/provider/openstack/cinder.go
@@ -285,6 +285,11 @@ func (s *cinderVolumeSource) DestroyVolumes(volumeIds []string) ([]error, error)
 	return destroyVolumes(s.storageAdapter, volumeIds), nil
 }
 
+// ReleaseVolumes implements storage.VolumeSource.
+func (s *cinderVolumeSource) ReleaseVolumes(volumeIds []string) ([]error, error) {
+	return nil, errors.NotImplementedf("ReleaseVolumes")
+}
+
 func destroyVolumes(storageAdapter OpenstackStorage, volumeIds []string) []error {
 	var wg sync.WaitGroup
 	wg.Add(len(volumeIds))

--- a/provider/oracle/storage_volumes.go
+++ b/provider/oracle/storage_volumes.go
@@ -322,6 +322,11 @@ func (s *oracleVolumeSource) DestroyVolumes(volIds []string) ([]error, error) {
 	return results, nil
 }
 
+// ReleaseVolumes is specified on the storage.VolumeSource interface.
+func (s *oracleVolumeSource) ReleaseVolumes(volIds []string) ([]error, error) {
+	return nil, errors.NotImplementedf("ReleaseVolumes")
+}
+
 // ValidateVolumeParams is specified on the storage.VolumeSource interface.
 func (s *oracleVolumeSource) ValidateVolumeParams(params storage.VolumeParams) error {
 	size := mibToGib(params.Size)

--- a/storage/interface.go
+++ b/storage/interface.go
@@ -102,6 +102,10 @@ type VolumeSource interface {
 	// volume IDs.
 	DestroyVolumes(volIds []string) ([]error, error)
 
+	// ReleaseVolumes releases the volumes with the specified provider
+	// volume IDs from the model/controller.
+	ReleaseVolumes(volIds []string) ([]error, error)
+
 	// ValidateVolumeParams validates the provided volume creation
 	// parameters, returning an error if they are invalid.
 	ValidateVolumeParams(params VolumeParams) error
@@ -141,6 +145,10 @@ type FilesystemSource interface {
 	// DestroyFilesystems destroys the filesystems with the specified
 	// providerd filesystem IDs.
 	DestroyFilesystems(fsIds []string) ([]error, error)
+
+	// ReleaseFilesystems releases the filesystems with the specified provider
+	// filesystem IDs from the model/controller.
+	ReleaseFilesystems(volIds []string) ([]error, error)
 
 	// AttachFilesystems attaches filesystems to machines.
 	//

--- a/storage/provider/dummy/filesystemsource.go
+++ b/storage/provider/dummy/filesystemsource.go
@@ -18,6 +18,7 @@ type FilesystemSource struct {
 
 	CreateFilesystemsFunc        func([]storage.FilesystemParams) ([]storage.CreateFilesystemsResult, error)
 	DestroyFilesystemsFunc       func([]string) ([]error, error)
+	ReleaseFilesystemsFunc       func([]string) ([]error, error)
 	ValidateFilesystemParamsFunc func(storage.FilesystemParams) error
 	AttachFilesystemsFunc        func([]storage.FilesystemAttachmentParams) ([]storage.AttachFilesystemsResult, error)
 	DetachFilesystemsFunc        func([]storage.FilesystemAttachmentParams) ([]error, error)
@@ -39,6 +40,15 @@ func (s *FilesystemSource) DestroyFilesystems(volIds []string) ([]error, error) 
 		return s.DestroyFilesystemsFunc(volIds)
 	}
 	return nil, errors.NotImplementedf("DestroyFilesystems")
+}
+
+// ReleaseFilesystems is defined on storage.FilesystemSource.
+func (s *FilesystemSource) ReleaseFilesystems(volIds []string) ([]error, error) {
+	s.MethodCall(s, "ReleaseFilesystems", volIds)
+	if s.ReleaseFilesystemsFunc != nil {
+		return s.ReleaseFilesystemsFunc(volIds)
+	}
+	return nil, errors.NotImplementedf("ReleaseFilesystems")
 }
 
 // ValidateFilesystemParams is defined on storage.FilesystemSource.

--- a/storage/provider/dummy/volumesource.go
+++ b/storage/provider/dummy/volumesource.go
@@ -20,6 +20,7 @@ type VolumeSource struct {
 	ListVolumesFunc          func() ([]string, error)
 	DescribeVolumesFunc      func([]string) ([]storage.DescribeVolumesResult, error)
 	DestroyVolumesFunc       func([]string) ([]error, error)
+	ReleaseVolumesFunc       func([]string) ([]error, error)
 	ValidateVolumeParamsFunc func(storage.VolumeParams) error
 	AttachVolumesFunc        func([]storage.VolumeAttachmentParams) ([]storage.AttachVolumesResult, error)
 	DetachVolumesFunc        func([]storage.VolumeAttachmentParams) ([]error, error)
@@ -59,6 +60,15 @@ func (s *VolumeSource) DestroyVolumes(volIds []string) ([]error, error) {
 		return s.DestroyVolumesFunc(volIds)
 	}
 	return nil, errors.NotImplementedf("DestroyVolumes")
+}
+
+// ReleaseVolumes is defined on storage.VolumeSource.
+func (s *VolumeSource) ReleaseVolumes(volIds []string) ([]error, error) {
+	s.MethodCall(s, "ReleaseVolumes", volIds)
+	if s.ReleaseVolumesFunc != nil {
+		return s.ReleaseVolumesFunc(volIds)
+	}
+	return nil, errors.NotImplementedf("ReleaseVolumes")
 }
 
 // ValidateVolumeParams is defined on storage.VolumeSource.

--- a/storage/provider/loop.go
+++ b/storage/provider/loop.go
@@ -157,6 +157,11 @@ func (lvs *loopVolumeSource) DestroyVolumes(volumeIds []string) ([]error, error)
 	return results, nil
 }
 
+// ReleaseVolumes is defined on the VolumeSource interface.
+func (lvs *loopVolumeSource) ReleaseVolumes(volumeIds []string) ([]error, error) {
+	return make([]error, len(volumeIds)), nil
+}
+
 func (lvs *loopVolumeSource) destroyVolume(volumeId string) error {
 	tag, err := names.ParseVolumeTag(volumeId)
 	if err != nil {

--- a/storage/provider/managedfs.go
+++ b/storage/provider/managedfs.go
@@ -117,6 +117,11 @@ func (s *managedFilesystemSource) DestroyFilesystems(filesystemIds []string) ([]
 	return make([]error, len(filesystemIds)), nil
 }
 
+// ReleaseFilesystems is defined on storage.FilesystemSource.
+func (s *managedFilesystemSource) ReleaseFilesystems(filesystemIds []string) ([]error, error) {
+	return make([]error, len(filesystemIds)), nil
+}
+
 // AttachFilesystems is defined on storage.FilesystemSource.
 func (s *managedFilesystemSource) AttachFilesystems(args []storage.FilesystemAttachmentParams) ([]storage.AttachFilesystemsResult, error) {
 	results := make([]storage.AttachFilesystemsResult, len(args))

--- a/storage/provider/rootfs.go
+++ b/storage/provider/rootfs.go
@@ -188,6 +188,11 @@ func (s *rootfsFilesystemSource) DestroyFilesystems(filesystemIds []string) ([]e
 	return make([]error, len(filesystemIds)), nil
 }
 
+// ReleaseFilesystems is defined on the FilesystemSource interface.
+func (s *rootfsFilesystemSource) ReleaseFilesystems(filesystemIds []string) ([]error, error) {
+	return make([]error, len(filesystemIds)), nil
+}
+
 // AttachFilesystems is defined on the FilesystemSource interface.
 func (s *rootfsFilesystemSource) AttachFilesystems(args []storage.FilesystemAttachmentParams) ([]storage.AttachFilesystemsResult, error) {
 	results := make([]storage.AttachFilesystemsResult, len(args))

--- a/storage/provider/tmpfs.go
+++ b/storage/provider/tmpfs.go
@@ -156,6 +156,11 @@ func (s *tmpfsFilesystemSource) DestroyFilesystems(filesystemIds []string) ([]er
 	return make([]error, len(filesystemIds)), nil
 }
 
+// ReleaseFilesystems is defined on the FilesystemSource interface.
+func (s *tmpfsFilesystemSource) ReleaseFilesystems(filesystemIds []string) ([]error, error) {
+	return make([]error, len(filesystemIds)), nil
+}
+
 // AttachFilesystems is defined on the FilesystemSource interface.
 func (s *tmpfsFilesystemSource) AttachFilesystems(args []storage.FilesystemAttachmentParams) ([]storage.AttachFilesystemsResult, error) {
 	results := make([]storage.AttachFilesystemsResult, len(args))

--- a/worker/storageprovisioner/filesystem_events.go
+++ b/worker/storageprovisioner/filesystem_events.go
@@ -226,7 +226,7 @@ func processDeadFilesystems(ctx *context, tags []names.FilesystemTag, filesystem
 	if len(destroy) > 0 {
 		ops := make([]scheduleOp, len(destroy))
 		for i, tag := range destroy {
-			ops[i] = &destroyFilesystemOp{tag: tag}
+			ops[i] = &removeFilesystemOp{tag: tag}
 		}
 		scheduleOperations(ctx, ops...)
 	}
@@ -416,6 +416,22 @@ func filesystemParams(ctx *context, tags []names.FilesystemTag) ([]storage.Files
 			return nil, errors.Annotate(err, "getting filesystem parameters")
 		}
 		allParams[i] = params
+	}
+	return allParams, nil
+}
+
+// removeFilesystemParams obtains the specified filesystems' destruction parameters.
+func removeFilesystemParams(ctx *context, tags []names.FilesystemTag) ([]params.RemoveFilesystemParams, error) {
+	paramsResults, err := ctx.config.Filesystems.RemoveFilesystemParams(tags)
+	if err != nil {
+		return nil, errors.Annotate(err, "getting filesystem params")
+	}
+	allParams := make([]params.RemoveFilesystemParams, len(tags))
+	for i, result := range paramsResults {
+		if result.Error != nil {
+			return nil, errors.Annotate(result.Error, "getting filesystem removal parameters")
+		}
+		allParams[i] = result.Result
 	}
 	return allParams, nil
 }

--- a/worker/storageprovisioner/storageprovisioner_test.go
+++ b/worker/storageprovisioner/storageprovisioner_test.go
@@ -502,9 +502,8 @@ func (s *storageProvisionerSuite) TestAttachFilesystemRetry(c *gc.C) {
 func (s *storageProvisionerSuite) TestValidateVolumeParams(c *gc.C) {
 	volumeAccessor := newMockVolumeAccessor()
 	volumeAccessor.provisionedMachines["machine-1"] = instance.Id("already-provisioned-1")
-	volumeAccessor.provisionedVolumes["volume-3"] = params.Volume{VolumeTag: "volume-3"}
-	volumeAccessor.provisionedVolumes["volume-4"] = params.Volume{
-		VolumeTag: "volume-4",
+	volumeAccessor.provisionedVolumes["volume-3"] = params.Volume{
+		VolumeTag: "volume-3",
 		Info:      params.VolumeInfo{VolumeId: "vol-ume"},
 	}
 
@@ -524,7 +523,7 @@ func (s *storageProvisionerSuite) TestValidateVolumeParams(c *gc.C) {
 		results := make([]params.LifeResult, len(tags))
 		for i := range results {
 			switch tags[i].String() {
-			case "volume-3", "volume-4":
+			case "volume-3":
 				results[i].Life = params.Dead
 			default:
 				results[i].Life = params.Alive
@@ -579,22 +578,16 @@ func (s *storageProvisionerSuite) TestValidateVolumeParams(c *gc.C) {
 	c.Assert(createVolumeParams[0].Tag.String(), gc.Equals, "volume-2")
 	c.Assert(validateCalls, gc.Equals, 2)
 
+	// destroying filesystems does not validate parameters
 	volumeAccessor.volumesWatcher.changes <- []string{"3"}
-	waitChannel(c, validated, "waiting for volume parameter validation")
-	assertNoEvent(c, destroyedVolumes, "volume destroyed")
-	c.Assert(validateCalls, gc.Equals, 3)
-
-	// Failure to destroy volume-3 should not block creation of volume-4.
-	volumeAccessor.volumesWatcher.changes <- []string{"4"}
-	waitChannel(c, validated, "waiting for volume parameter validation")
+	assertNoEvent(c, validated, "volume destruction params validated")
 	destroyVolumeParams := waitChannel(c, destroyedVolumes, "volume destroyed").([]string)
 	c.Assert(destroyVolumeParams, jc.DeepEquals, []string{"vol-ume"})
-	c.Assert(validateCalls, gc.Equals, 4)
+	c.Assert(validateCalls, gc.Equals, 2) // no change
 
 	c.Assert(args.statusSetter.args, jc.DeepEquals, []params.EntityStatusArgs{
 		{Tag: "volume-1", Status: "error", Info: "something is wrong"},
 		{Tag: "volume-2", Status: "attaching"},
-		{Tag: "volume-3", Status: "error", Info: "something is wrong"},
 		// destroyed volumes are removed immediately,
 		// so there is no status update.
 	})
@@ -603,9 +596,8 @@ func (s *storageProvisionerSuite) TestValidateVolumeParams(c *gc.C) {
 func (s *storageProvisionerSuite) TestValidateFilesystemParams(c *gc.C) {
 	filesystemAccessor := newMockFilesystemAccessor()
 	filesystemAccessor.provisionedMachines["machine-1"] = instance.Id("already-provisioned-1")
-	filesystemAccessor.provisionedFilesystems["filesystem-3"] = params.Filesystem{FilesystemTag: "filesystem-3"}
-	filesystemAccessor.provisionedFilesystems["filesystem-4"] = params.Filesystem{
-		FilesystemTag: "filesystem-4",
+	filesystemAccessor.provisionedFilesystems["filesystem-3"] = params.Filesystem{
+		FilesystemTag: "filesystem-3",
 		Info:          params.FilesystemInfo{FilesystemId: "fs-id"},
 	}
 
@@ -625,7 +617,7 @@ func (s *storageProvisionerSuite) TestValidateFilesystemParams(c *gc.C) {
 		results := make([]params.LifeResult, len(tags))
 		for i := range results {
 			switch tags[i].String() {
-			case "filesystem-3", "filesystem-4":
+			case "filesystem-3":
 				results[i].Life = params.Dead
 			default:
 				results[i].Life = params.Alive
@@ -680,22 +672,16 @@ func (s *storageProvisionerSuite) TestValidateFilesystemParams(c *gc.C) {
 	c.Assert(createFilesystemParams[0].Tag.String(), gc.Equals, "filesystem-2")
 	c.Assert(validateCalls, gc.Equals, 2)
 
+	// destroying filesystems does not validate parameters
 	filesystemAccessor.filesystemsWatcher.changes <- []string{"3"}
-	waitChannel(c, validated, "waiting for filesystem parameter validation")
-	assertNoEvent(c, destroyedFilesystems, "filesystem destroyed")
-	c.Assert(validateCalls, gc.Equals, 3)
-
-	// Failure to destroy filesystem-3 should not block creation of filesystem-4.
-	filesystemAccessor.filesystemsWatcher.changes <- []string{"4"}
-	waitChannel(c, validated, "waiting for filesystem parameter validation")
+	assertNoEvent(c, validated, "filesystem destruction params validated")
 	destroyFilesystemParams := waitChannel(c, destroyedFilesystems, "filesystem destroyed").([]string)
 	c.Assert(destroyFilesystemParams, jc.DeepEquals, []string{"fs-id"})
-	c.Assert(validateCalls, gc.Equals, 4)
+	c.Assert(validateCalls, gc.Equals, 2) // no change
 
 	c.Assert(args.statusSetter.args, jc.DeepEquals, []params.EntityStatusArgs{
 		{Tag: "filesystem-1", Status: "error", Info: "something is wrong"},
 		{Tag: "filesystem-2", Status: "attaching"},
-		{Tag: "filesystem-3", Status: "error", Info: "something is wrong"},
 		// destroyed filesystems are removed immediately,
 		// so there is no status update.
 	})
@@ -1515,11 +1501,13 @@ func (s *storageProvisionerSuite) TestDetachFilesystems(c *gc.C) {
 }
 
 func (s *storageProvisionerSuite) TestDestroyVolumes(c *gc.C) {
-	provisionedVolume := names.NewVolumeTag("1")
-	unprovisionedVolume := names.NewVolumeTag("2")
+	unprovisionedVolume := names.NewVolumeTag("0")
+	provisionedDestroyVolume := names.NewVolumeTag("1")
+	provisionedReleaseVolume := names.NewVolumeTag("2")
 
 	volumeAccessor := newMockVolumeAccessor()
-	volumeAccessor.provisionVolume(provisionedVolume)
+	volumeAccessor.provisionVolume(provisionedDestroyVolume)
+	volumeAccessor.provisionVolume(provisionedReleaseVolume)
 
 	life := func(tags []names.Tag) ([]params.LifeResult, error) {
 		results := make([]params.LifeResult, len(tags))
@@ -1532,6 +1520,12 @@ func (s *storageProvisionerSuite) TestDestroyVolumes(c *gc.C) {
 	destroyedChan := make(chan interface{}, 1)
 	s.provider.destroyVolumesFunc = func(volumeIds []string) ([]error, error) {
 		destroyedChan <- volumeIds
+		return make([]error, len(volumeIds)), nil
+	}
+
+	releasedChan := make(chan interface{}, 1)
+	s.provider.releaseVolumesFunc = func(volumeIds []string) ([]error, error) {
+		releasedChan <- volumeIds
 		return make([]error, len(volumeIds)), nil
 	}
 
@@ -1554,23 +1548,32 @@ func (s *storageProvisionerSuite) TestDestroyVolumes(c *gc.C) {
 	defer worker.Kill()
 
 	volumeAccessor.volumesWatcher.changes <- []string{
-		provisionedVolume.Id(),
 		unprovisionedVolume.Id(),
+		provisionedDestroyVolume.Id(),
+		provisionedReleaseVolume.Id(),
 	}
 
-	// Both volumes should be removed; the provisioned one
-	// should be deprovisioned first.
+	// All volumes should be removed; the provisioned ones
+	// should be destroyed/released first.
 
-	destroyed := waitChannel(c, destroyedChan, "waiting for volume to be deprovisioned")
-	assertNoEvent(c, destroyedChan, "volumes deprovisioned")
+	destroyed := waitChannel(c, destroyedChan, "waiting for volume to be destroyed")
+	assertNoEvent(c, destroyedChan, "volumes destroyed")
 	c.Assert(destroyed, jc.DeepEquals, []string{"vol-1"})
 
+	released := waitChannel(c, releasedChan, "waiting for volume to be released")
+	assertNoEvent(c, releasedChan, "volumes released")
+	c.Assert(released, jc.DeepEquals, []string{"vol-2"})
+
 	var removed []names.Tag
-	for len(removed) < 2 {
+	for len(removed) < 3 {
 		tags := waitChannel(c, removedChan, "waiting for volumes to be removed").([]names.Tag)
 		removed = append(removed, tags...)
 	}
-	c.Assert(removed, jc.SameContents, []names.Tag{provisionedVolume, unprovisionedVolume})
+	c.Assert(removed, jc.SameContents, []names.Tag{
+		unprovisionedVolume,
+		provisionedDestroyVolume,
+		provisionedReleaseVolume,
+	})
 	assertNoEvent(c, removedChan, "volumes removed")
 }
 
@@ -1652,11 +1655,13 @@ func (s *storageProvisionerSuite) TestDestroyVolumesRetry(c *gc.C) {
 }
 
 func (s *storageProvisionerSuite) TestDestroyFilesystems(c *gc.C) {
-	provisionedFilesystem := names.NewFilesystemTag("1")
-	unprovisionedFilesystem := names.NewFilesystemTag("2")
+	unprovisionedFilesystem := names.NewFilesystemTag("0")
+	provisionedDestroyFilesystem := names.NewFilesystemTag("1")
+	provisionedReleaseFilesystem := names.NewFilesystemTag("2")
 
 	filesystemAccessor := newMockFilesystemAccessor()
-	filesystemAccessor.provisionFilesystem(provisionedFilesystem)
+	filesystemAccessor.provisionFilesystem(provisionedDestroyFilesystem)
+	filesystemAccessor.provisionFilesystem(provisionedReleaseFilesystem)
 
 	life := func(tags []names.Tag) ([]params.LifeResult, error) {
 		results := make([]params.LifeResult, len(tags))
@@ -1664,6 +1669,18 @@ func (s *storageProvisionerSuite) TestDestroyFilesystems(c *gc.C) {
 			results[i].Life = params.Dead
 		}
 		return results, nil
+	}
+
+	destroyedChan := make(chan interface{}, 1)
+	s.provider.destroyFilesystemsFunc = func(filesystemIds []string) ([]error, error) {
+		destroyedChan <- filesystemIds
+		return make([]error, len(filesystemIds)), nil
+	}
+
+	releasedChan := make(chan interface{}, 1)
+	s.provider.releaseFilesystemsFunc = func(filesystemIds []string) ([]error, error) {
+		releasedChan <- filesystemIds
+		return make([]error, len(filesystemIds)), nil
 	}
 
 	removedChan := make(chan interface{}, 1)
@@ -1685,20 +1702,32 @@ func (s *storageProvisionerSuite) TestDestroyFilesystems(c *gc.C) {
 	defer worker.Kill()
 
 	filesystemAccessor.filesystemsWatcher.changes <- []string{
-		provisionedFilesystem.Id(),
 		unprovisionedFilesystem.Id(),
+		provisionedDestroyFilesystem.Id(),
+		provisionedReleaseFilesystem.Id(),
 	}
 
-	// Both filesystems should be removed; the provisioned one
-	// *should* be deprovisioned first, but we don't currently
-	// have the ability to do so via the storage provider API.
+	// Both filesystems should be removed; the provisioned ones
+	// should be destroyed/released first.
+
+	destroyed := waitChannel(c, destroyedChan, "waiting for filesystem to be destroyed")
+	assertNoEvent(c, destroyedChan, "filesystems destroyed")
+	c.Assert(destroyed, jc.DeepEquals, []string{"fs-1"})
+
+	released := waitChannel(c, releasedChan, "waiting for filesystem to be released")
+	assertNoEvent(c, releasedChan, "filesystems released")
+	c.Assert(released, jc.DeepEquals, []string{"fs-2"})
 
 	var removed []names.Tag
-	for len(removed) < 2 {
+	for len(removed) < 3 {
 		tags := waitChannel(c, removedChan, "waiting for filesystems to be removed").([]names.Tag)
 		removed = append(removed, tags...)
 	}
-	c.Assert(removed, jc.SameContents, []names.Tag{provisionedFilesystem, unprovisionedFilesystem})
+	c.Assert(removed, jc.SameContents, []names.Tag{
+		unprovisionedFilesystem,
+		provisionedDestroyFilesystem,
+		provisionedReleaseFilesystem,
+	})
 	assertNoEvent(c, removedChan, "filesystems removed")
 }
 

--- a/worker/storageprovisioner/volume_events.go
+++ b/worker/storageprovisioner/volume_events.go
@@ -193,7 +193,7 @@ func processDeadVolumes(ctx *context, tags []names.VolumeTag, volumeResults []pa
 	if len(destroy) > 0 {
 		ops := make([]scheduleOp, len(destroy))
 		for i, tag := range destroy {
-			ops[i] = &destroyVolumeOp{tag: tag}
+			ops[i] = &removeVolumeOp{tag: tag}
 		}
 		scheduleOperations(ctx, ops...)
 	}
@@ -378,6 +378,22 @@ func volumeParams(ctx *context, tags []names.VolumeTag) ([]storage.VolumeParams,
 			return nil, errors.Annotate(err, "getting volume parameters")
 		}
 		allParams[i] = params
+	}
+	return allParams, nil
+}
+
+// removeVolumeParams obtains the specified volumes' destruction parameters.
+func removeVolumeParams(ctx *context, tags []names.VolumeTag) ([]params.RemoveVolumeParams, error) {
+	paramsResults, err := ctx.config.Volumes.RemoveVolumeParams(tags)
+	if err != nil {
+		return nil, errors.Annotate(err, "getting volume params")
+	}
+	allParams := make([]params.RemoveVolumeParams, len(tags))
+	for i, result := range paramsResults {
+		if result.Error != nil {
+			return nil, errors.Annotate(result.Error, "getting volume removal parameters")
+		}
+		allParams[i] = result.Result
 	}
 	return allParams, nil
 }


### PR DESCRIPTION
## Description of change

Add api, cmd, worker/storageprovisioner, and storage provider changes required to support non-destructively removing storage from a model.

The `juju remove-storage` command grows a `--no-destroy` flag, which instructs Juju to remove the storage without destroying the associated cloud storage resources. This can be used to release the storage from Juju's control. Once the storage is removed from the model, destroying the model or controller will not destroy the storage.

The VolumeSource and FilesystemSource interfaces grow methods for releasing storage, rather than destroying it. The storageprovisioner worker uses these methods for storage that is marked for releasing.

Requires https://github.com/juju/juju/pull/7648

## QA steps

1. juju bootstrap localhost
2. juju deploy postgresql --storage pgdata=lxd
3. juju remove-storage --force --no-destroy pgdata/0
4. juju destroy-controller localhost
5. lxc storage volume show juju juju-<model-uuid-suffix>-filesystem-0 # use "list" to get the name
(volume should remain, but should show no juju-controller-uuid or juju-model-uuid tags)

As above, but with EBS. In the portal, you should see the juju-controller-uuid/juju-model-uuid tags are empty after the storage is released/removed.

## Documentation changes

Yes, we'll need to document `juju remove-storage --no-destroy`.

## Bug reference

None.