### PR TITLE
Deploying applications in development mode

### DIFF
--- a/api/application/client.go
+++ b/api/application/client.go
@@ -103,6 +103,9 @@ type DeployArgs struct {
 	// value being the unique ID of a pre-uploaded resources in
 	// storage.
 	Resources map[string]string
+
+	// Development signals if the application is to be deployed in development mode.
+	Development bool
 }
 
 // Deploy obtains the charm, either locally or from the charm store, and deploys
@@ -138,6 +141,7 @@ func (c *Client) Deploy(args DeployArgs) error {
 			AttachStorage:    attachStorage,
 			EndpointBindings: args.EndpointBindings,
 			Resources:        args.Resources,
+			Development:      args.Development,
 		}},
 	}
 	var results params.ErrorResults

--- a/apiserver/facades/client/application/application.go
+++ b/apiserver/facades/client/application/application.go
@@ -262,6 +262,7 @@ func deployApplication(
 		AttachStorage:    attachStorage,
 		EndpointBindings: args.EndpointBindings,
 		Resources:        args.Resources,
+		Development:      args.Development,
 	})
 	return errors.Trace(err)
 }

--- a/apiserver/facades/client/application/application_test.go
+++ b/apiserver/facades/client/application/application_test.go
@@ -247,6 +247,27 @@ func (s *applicationSuite) TestApplicationDeployWithStorage(c *gc.C) {
 	})
 }
 
+func (s *applicationSuite) TestApplicationDeployDevelopment(c *gc.C) {
+	curl, _ := s.UploadCharm(c, "utopic/storage-block-10", "storage-block")
+	err := application.AddCharmWithAuthorization(s.State, params.AddCharmWithAuthorization{
+		URL: curl.String(),
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	args := params.ApplicationDeploy{
+		ApplicationName: "application",
+		CharmURL:        curl.String(),
+		NumUnits:        1,
+		Development:     true,
+	}
+	results, err := s.applicationAPI.Deploy(params.ApplicationsDeploy{
+		Applications: []params.ApplicationDeploy{args}},
+	)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(results, gc.DeepEquals, params.ErrorResults{
+		Results: []params.ErrorResult{{Error: nil}},
+	})
+}
+
 func (s *applicationSuite) TestMinJujuVersionTooHigh(c *gc.C) {
 	curl, _ := s.UploadCharm(c, "quantal/minjujuversion-0", "minjujuversion")
 	err := application.AddCharmWithAuthorization(s.State, params.AddCharmWithAuthorization{

--- a/apiserver/facades/client/application/deploy.go
+++ b/apiserver/facades/client/application/deploy.go
@@ -37,7 +37,8 @@ type DeployApplicationParams struct {
 	AttachStorage    []names.StorageTag
 	EndpointBindings map[string]string
 	// Resources is a map of resource name to IDs of pending resources.
-	Resources map[string]string
+	Resources   map[string]string
+	Development bool
 }
 
 type ApplicationDeployer interface {
@@ -82,6 +83,7 @@ func DeployApplication(st ApplicationDeployer, args DeployApplicationParams) (Ap
 		Placement:        args.Placement,
 		Resources:        args.Resources,
 		EndpointBindings: effectiveBindings,
+		Development:      args.Development,
 	}
 
 	if !args.Charm.Meta().Subordinate {

--- a/apiserver/facades/client/application/deploy_test.go
+++ b/apiserver/facades/client/application/deploy_test.go
@@ -404,6 +404,24 @@ func (s *DeployLocalSuite) TestDeploy(c *gc.C) {
 	c.Assert(f.args.Placement, gc.DeepEquals, placement)
 }
 
+func (s *DeployLocalSuite) TestDeployDevelopment(c *gc.C) {
+	var f fakeDeployer
+
+	_, err := application.DeployApplication(&f,
+		application.DeployApplicationParams{
+			ApplicationName: "bob",
+			Charm:           s.charm,
+			NumUnits:        4,
+			Development:     true,
+		})
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Assert(f.args.Name, gc.Equals, "bob")
+	c.Assert(f.args.Charm, gc.DeepEquals, s.charm)
+	c.Assert(f.args.NumUnits, gc.Equals, 4)
+	c.Assert(f.args.Development, jc.IsTrue)
+}
+
 func (s *DeployLocalSuite) TestDeployWithFewerPlacement(c *gc.C) {
 	var f fakeDeployer
 	serviceCons := constraints.MustParse("cores=2")

--- a/apiserver/params/params.go
+++ b/apiserver/params/params.go
@@ -250,6 +250,7 @@ type ApplicationDeploy struct {
 	AttachStorage    []string                       `json:"attach-storage,omitempty"`
 	EndpointBindings map[string]string              `json:"endpoint-bindings,omitempty"`
 	Resources        map[string]string              `json:"resources,omitempty"`
+	Development      bool                           `json:"development,omitempty"`
 }
 
 // ApplicationUpdate holds the parameters for making the application Update call.

--- a/cmd/juju/application/deploy_test.go
+++ b/cmd/juju/application/deploy_test.go
@@ -938,7 +938,7 @@ func (s *DeployCharmStoreSuite) TestDevelopmentMode(c *gc.C) {
 			return fakeAPI, nil
 		},
 	}
-	_, err = cmdtesting.RunCommand(c, modelcmd.Wrap(deploy), "cs:quantal/metered-1", "--development")
+	_, err = cmdtesting.RunCommand(c, modelcmd.Wrap(deploy), "cs:quantal/metered-1", "--develop-commercial")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(setMetricCredentialsCall(), gc.Equals, 1)
 
@@ -1352,7 +1352,7 @@ func (s *DeployUnitTestSuite) TestDeployLocalWithBundleConfig(c *gc.C) {
 
 	multiSeriesURL := charm.MustParseURL("local:trusty/multi-series-1")
 	withLocalCharmDeployable(fakeAPI, multiSeriesURL, charmDir)
-	withCharmDeployable(fakeAPI, multiSeriesURL, "trusty", charmDir.Meta(), charmDir.Metrics(), false, 1, nil)
+	withCharmDeployable(fakeAPI, multiSeriesURL, "trusty", charmDir.Meta(), charmDir.Metrics(), false, 1, nil, false)
 
 	_, err := s.runDeploy(c, fakeAPI, charmDir.Path, "--bundle-config", "somefile")
 	c.Check(err, gc.ErrorMatches, "flags provided but not supported when deploying a charm: --bundle-config")
@@ -1365,7 +1365,7 @@ func (s *DeployUnitTestSuite) TestDeployLocalCharmGivesCorrectUserMessage(c *gc.
 
 	multiSeriesURL := charm.MustParseURL("local:trusty/multi-series-1")
 	withLocalCharmDeployable(fakeAPI, multiSeriesURL, charmDir)
-	withCharmDeployable(fakeAPI, multiSeriesURL, "trusty", charmDir.Meta(), charmDir.Metrics(), false, 1, nil)
+	withCharmDeployable(fakeAPI, multiSeriesURL, "trusty", charmDir.Meta(), charmDir.Metrics(), false, 1, nil, false)
 
 	context, err := s.runDeploy(c, fakeAPI, charmDir.Path, "--series", "trusty")
 	c.Check(err, jc.ErrorIsNil)

--- a/cmd/juju/application/deploy_test.go
+++ b/cmd/juju/application/deploy_test.go
@@ -813,6 +813,7 @@ type serviceInfo struct {
 	exposed          bool
 	storage          map[string]state.StorageConstraints
 	endpointBindings map[string]string
+	development      bool
 }
 
 // assertDeployedServiceBindings checks that services were deployed into the
@@ -854,6 +855,7 @@ func (s *charmStoreSuite) assertApplicationsDeployed(c *gc.C, info map[string]se
 			constraints: constraints,
 			exposed:     application.IsExposed(),
 			storage:     storage,
+			development: application.IsDevMode(),
 		}
 	}
 	c.Assert(deployed, jc.DeepEquals, info)
@@ -901,6 +903,54 @@ func (t *testMetricCredentialsSetter) Close() error {
 	return nil
 }
 
+func (s *DeployCharmStoreSuite) TestDevelopmentMode(c *gc.C) {
+	stub := &jujutesting.Stub{}
+	handler := &testMetricsRegistrationHandler{Stub: stub}
+	server := httptest.NewServer(handler)
+	defer server.Close()
+
+	testcharms.UploadCharm(c, s.client, "cs:quantal/metered-1", "metered")
+	charmDir := testcharms.Repo.CharmDir("metered")
+
+	cfgAttrs := map[string]interface{}{
+		"name":        "name",
+		"uuid":        "deadbeef-0bad-400d-8000-4b1d0d06f00d",
+		"type":        "foo",
+		"development": true,
+	}
+	meteredURL := charm.MustParseURL("cs:quantal/metered-1")
+	fakeAPI := vanillaFakeModelAPI(cfgAttrs)
+	withCharmDeployable(fakeAPI, meteredURL, "quantal", charmDir.Meta(), charmDir.Metrics(), true, 1, nil, true)
+
+	cfg, err := config.New(config.NoDefaults, cfgAttrs)
+	c.Assert(err, jc.ErrorIsNil)
+	withCharmRepoResolvable(fakeAPI, meteredURL, cfg)
+
+	// `"hello registration"\n` (quotes and newline from json
+	// encoding) is returned by the fake http server. This is binary64
+	// encoded before the call into SetMetricCredentials.
+	creds := append([]byte(`"aGVsbG8gcmVnaXN0cmF0aW9u"`), 0xA)
+	setMetricCredentialsCall := fakeAPI.Call("SetMetricCredentials", meteredURL.Name, creds).Returns(error(nil))
+
+	deploy := &DeployCommand{
+		Steps: []DeployStep{&RegisterMeteredCharm{DevelopmentURL: server.URL}},
+		NewAPIRoot: func() (DeployAPI, error) {
+			return fakeAPI, nil
+		},
+	}
+	_, err = cmdtesting.RunCommand(c, modelcmd.Wrap(deploy), "cs:quantal/metered-1", "--development")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(setMetricCredentialsCall(), gc.Equals, 1)
+
+	stub.CheckCalls(c, []jujutesting.StubCall{{
+		"Authorize", []interface{}{metricRegistrationPost{
+			ModelUUID:       "deadbeef-0bad-400d-8000-4b1d0d06f00d",
+			CharmURL:        "cs:quantal/metered-1",
+			ApplicationName: "metered",
+		}},
+	}})
+}
+
 func (s *DeployCharmStoreSuite) TestAddMetricCredentials(c *gc.C) {
 	stub := &jujutesting.Stub{}
 	handler := &testMetricsRegistrationHandler{Stub: stub}
@@ -917,7 +967,7 @@ func (s *DeployCharmStoreSuite) TestAddMetricCredentials(c *gc.C) {
 	}
 	meteredURL := charm.MustParseURL("cs:quantal/metered-1")
 	fakeAPI := vanillaFakeModelAPI(cfgAttrs)
-	withCharmDeployable(fakeAPI, meteredURL, "quantal", charmDir.Meta(), charmDir.Metrics(), true, 1, nil)
+	withCharmDeployable(fakeAPI, meteredURL, "quantal", charmDir.Meta(), charmDir.Metrics(), true, 1, nil, false)
 
 	cfg, err := config.New(config.NoDefaults, cfgAttrs)
 	c.Assert(err, jc.ErrorIsNil)
@@ -967,7 +1017,7 @@ func (s *DeployCharmStoreSuite) TestAddMetricCredentialsDefaultPlan(c *gc.C) {
 	}
 	meteredURL := charm.MustParseURL("cs:quantal/metered-1")
 	fakeAPI := vanillaFakeModelAPI(cfgAttrs)
-	withCharmDeployable(fakeAPI, meteredURL, "quantal", charmDir.Meta(), charmDir.Metrics(), true, 1, nil)
+	withCharmDeployable(fakeAPI, meteredURL, "quantal", charmDir.Meta(), charmDir.Metrics(), true, 1, nil, false)
 
 	cfg, err := config.New(config.NoDefaults, cfgAttrs)
 	c.Assert(err, jc.ErrorIsNil)
@@ -1014,7 +1064,7 @@ func (s *DeployCharmStoreSuite) TestSetMetricCredentialsNotCalledForUnmeteredCha
 	cfg, err := config.New(config.NoDefaults, cfgAttrs)
 	c.Assert(err, jc.ErrorIsNil)
 	withCharmRepoResolvable(fakeAPI, charmURL, cfg)
-	withCharmDeployable(fakeAPI, charmURL, "quantal", charmDir.Meta(), charmDir.Metrics(), false, 1, nil)
+	withCharmDeployable(fakeAPI, charmURL, "quantal", charmDir.Meta(), charmDir.Metrics(), false, 1, nil, false)
 
 	deploy := &DeployCommand{
 		Steps: []DeployStep{&RegisterMeteredCharm{}},
@@ -1059,7 +1109,7 @@ summary: summary
 	cfg, err := config.New(config.NoDefaults, cfgAttrs)
 	c.Assert(err, jc.ErrorIsNil)
 	withCharmRepoResolvable(fakeAPI, url, cfg)
-	withCharmDeployable(fakeAPI, url, "quantal", ch.Meta(), ch.Metrics(), true, 1, nil)
+	withCharmDeployable(fakeAPI, url, "quantal", ch.Meta(), ch.Metrics(), true, 1, nil, false)
 
 	stub := &jujutesting.Stub{}
 	handler := &testMetricsRegistrationHandler{Stub: stub}
@@ -1103,7 +1153,7 @@ summary: summary
 	cfg, err := config.New(config.NoDefaults, cfgAttrs)
 	c.Assert(err, jc.ErrorIsNil)
 	withCharmRepoResolvable(fakeAPI, url, cfg)
-	withCharmDeployable(fakeAPI, url, "quantal", ch.Meta(), ch.Metrics(), true, 1, nil)
+	withCharmDeployable(fakeAPI, url, "quantal", ch.Meta(), ch.Metrics(), true, 1, nil, false)
 
 	stub := &jujutesting.Stub{}
 	handler := &testMetricsRegistrationHandler{Stub: stub}
@@ -1179,7 +1229,7 @@ func (s *DeployCharmStoreSuite) TestDeployCharmsEndpointNotImplemented(c *gc.C) 
 	cfg, err := config.New(config.NoDefaults, cfgAttrs)
 	c.Assert(err, jc.ErrorIsNil)
 	withCharmRepoResolvable(fakeAPI, meteredCharmURL, cfg)
-	withCharmDeployable(fakeAPI, meteredCharmURL, "quantal", charmDir.Meta(), charmDir.Metrics(), true, 1, nil)
+	withCharmDeployable(fakeAPI, meteredCharmURL, "quantal", charmDir.Meta(), charmDir.Metrics(), true, 1, nil, false)
 
 	// `"hello registration"\n` (quotes and newline from json
 	// encoding) is returned by the fake http server. This is binary64
@@ -1327,7 +1377,7 @@ func (s *DeployUnitTestSuite) TestAddMetricCredentialsDefaultForUnmeteredCharm(c
 	multiSeriesURL := charm.MustParseURL("local:trusty/multi-series-1")
 	fakeAPI := s.fakeAPI()
 	withLocalCharmDeployable(fakeAPI, multiSeriesURL, charmDir)
-	withCharmDeployable(fakeAPI, multiSeriesURL, "trusty", charmDir.Meta(), charmDir.Metrics(), true, 1, nil)
+	withCharmDeployable(fakeAPI, multiSeriesURL, "trusty", charmDir.Meta(), charmDir.Metrics(), true, 1, nil, false)
 
 	_, err := s.runDeploy(c, fakeAPI, charmDir.Path, "--series", "trusty")
 	c.Assert(err, jc.ErrorIsNil)
@@ -1345,7 +1395,7 @@ func (s *DeployUnitTestSuite) TestRedeployLocalCharmSucceedsWhenDeployed(c *gc.C
 	fakeAPI := s.fakeAPI()
 	dummyURL := charm.MustParseURL("local:trusty/dummy-0")
 	withLocalCharmDeployable(fakeAPI, dummyURL, charmDir)
-	withCharmDeployable(fakeAPI, dummyURL, "trusty", charmDir.Meta(), charmDir.Metrics(), false, 1, nil)
+	withCharmDeployable(fakeAPI, dummyURL, "trusty", charmDir.Meta(), charmDir.Metrics(), false, 1, nil, false)
 
 	context, err := s.runDeploy(c, fakeAPI, dummyURL.String())
 	c.Assert(err, jc.ErrorIsNil)
@@ -1379,6 +1429,7 @@ func (s *DeployUnitTestSuite) TestDeployBundle_OutputsCorrectMessage(c *gc.C) {
 		false,
 		0,
 		nil,
+		false,
 	)
 	fakeAPI.Call("AddUnits", application.AddUnitsParams{
 		ApplicationName: "mysql",
@@ -1396,6 +1447,7 @@ func (s *DeployUnitTestSuite) TestDeployBundle_OutputsCorrectMessage(c *gc.C) {
 		false,
 		0,
 		nil,
+		false,
 	)
 	fakeAPI.Call("AddUnits", application.AddUnitsParams{
 		ApplicationName: "wordpress",
@@ -1437,7 +1489,7 @@ func (s *DeployUnitTestSuite) TestDeployAttachStorage(c *gc.C) {
 	dummyURL := charm.MustParseURL("local:trusty/dummy-0")
 	withLocalCharmDeployable(fakeAPI, dummyURL, charmDir)
 	withCharmDeployable(
-		fakeAPI, dummyURL, "trusty", charmDir.Meta(), charmDir.Metrics(), false, 1, []string{"foo/0", "bar/1", "baz/2"},
+		fakeAPI, dummyURL, "trusty", charmDir.Meta(), charmDir.Metrics(), false, 1, []string{"foo/0", "bar/1", "baz/2"}, false,
 	)
 
 	cmd := NewDeployCommandForTest(func() (DeployAPI, error) { return fakeAPI, nil }, nil)
@@ -1462,7 +1514,7 @@ func (s *DeployUnitTestSuite) TestDeployAttachStorageNotSupported(c *gc.C) {
 	dummyURL := charm.MustParseURL("local:trusty/dummy-0")
 	withLocalCharmDeployable(fakeAPI, dummyURL, charmDir)
 	withCharmDeployable(
-		fakeAPI, dummyURL, "trusty", charmDir.Meta(), charmDir.Metrics(), false, 1, []string{"foo/0", "bar/1", "baz/2"},
+		fakeAPI, dummyURL, "trusty", charmDir.Meta(), charmDir.Metrics(), false, 1, []string{"foo/0", "bar/1", "baz/2"}, false,
 	)
 
 	cmd := NewDeployCommandForTest(func() (DeployAPI, error) { return fakeAPI, nil }, nil)
@@ -1658,6 +1710,7 @@ func withCharmDeployable(
 	metered bool,
 	numUnits int,
 	attachStorage []string,
+	development bool,
 ) {
 	fakeAPI.Call("AddCharm", url, csclientparams.Channel("")).Returns(error(nil))
 	fakeAPI.Call("CharmInfo", url.String()).Returns(
@@ -1674,6 +1727,7 @@ func withCharmDeployable(
 		Series:          series,
 		NumUnits:        numUnits,
 		AttachStorage:   attachStorage,
+		Development:     development,
 	}).Returns(error(nil))
 	fakeAPI.Call("IsMetered", url.String()).Returns(metered, error(nil))
 

--- a/cmd/juju/application/register.go
+++ b/cmd/juju/application/register.go
@@ -15,14 +15,16 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/gnuflag"
 	"gopkg.in/macaroon-bakery.v1/httpbakery"
+
+	"github.com/juju/juju/api/application"
 )
 
 type metricRegistrationPost struct {
 	ModelUUID       string `json:"env-uuid"`
 	CharmURL        string `json:"charm-url"`
 	ApplicationName string `json:"service-name"`
-	PlanURL         string `json:"plan-url"`
-	IncreaseBudget  int    `json:"increase-budget"`
+	PlanURL         string `json:"plan-url,omitempty"`
+	IncreaseBudget  int    `json:"increase-budget,omitempty"`
 }
 
 // RegisterMeteredCharm implements the DeployStep interface.
@@ -30,18 +32,58 @@ type RegisterMeteredCharm struct {
 	Plan           string
 	IncreaseBudget int
 	RegisterURL    string
+	DevelopmentURL string
 	QueryURL       string
 	credentials    []byte
+	Development    bool
 }
 
 func (r *RegisterMeteredCharm) SetFlags(f *gnuflag.FlagSet) {
 	f.IntVar(&r.IncreaseBudget, "increase-budget", 0, "increase model budget allocation by this amount")
 	f.StringVar(&r.Plan, "plan", "", "plan to deploy charm under")
+	f.BoolVar(&r.Development, "development", false, "deploy application in development mode")
 }
 
-// RunPre obtains authorization to deploy this charm. The authorization, if received is not
+// RunPre is run before the deployment of an application.
+func (r *RegisterMeteredCharm) RunPre(api MeteredDeployAPI, bakeryClient *httpbakery.Client, ctx *cmd.Context, deployInfo DeploymentInfo, args *application.DeployArgs) error {
+	if r.Development {
+		return r.runPreDevelopment(api, bakeryClient, ctx, deployInfo, args)
+	}
+	return r.runPreMetered(api, bakeryClient, ctx, deployInfo, args)
+}
+
+// runPreMetered obtains authorization to deploy this charm. The authorization, if received is not
 // sent to the controller, rather it is kept as an attribute on RegisterMeteredCharm.
-func (r *RegisterMeteredCharm) RunPre(api MeteredDeployAPI, bakeryClient *httpbakery.Client, ctx *cmd.Context, deployInfo DeploymentInfo) error {
+func (r *RegisterMeteredCharm) runPreDevelopment(api MeteredDeployAPI, bakeryClient *httpbakery.Client, ctx *cmd.Context, deployInfo DeploymentInfo, args *application.DeployArgs) error {
+	if r.Plan != "" {
+		return errors.Errorf("plans not supported in development mode")
+	}
+	if r.IncreaseBudget != 0 {
+		return errors.Errorf("modifying budget allocations not supported in development mode")
+	}
+	registrationPost := metricRegistrationPost{
+		ModelUUID:       deployInfo.ModelUUID,
+		CharmURL:        deployInfo.CharmID.URL.String(),
+		ApplicationName: deployInfo.ApplicationName,
+	}
+
+	var err error
+	r.credentials, err = r.register(r.DevelopmentURL, registrationPost, bakeryClient)
+	if err != nil {
+		if deployInfo.CharmID.URL.Schema == "cs" {
+			logger.Infof("failed to obtain development authorization: %v", err)
+			return err
+		}
+		logger.Debugf("no development authorization: %v", err)
+	}
+	// Set the deployment request to deploy in development mode.
+	args.Development = true
+	return nil
+}
+
+// runPreMetered obtains authorization to deploy this charm. The authorization, if received is not
+// sent to the controller, rather it is kept as an attribute on RegisterMeteredCharm.
+func (r *RegisterMeteredCharm) runPreMetered(api MeteredDeployAPI, bakeryClient *httpbakery.Client, ctx *cmd.Context, deployInfo DeploymentInfo, args *application.DeployArgs) error {
 	if r.IncreaseBudget < 0 {
 		return errors.Errorf("invalid budget increase %d", r.IncreaseBudget)
 	}
@@ -76,12 +118,15 @@ func (r *RegisterMeteredCharm) RunPre(api MeteredDeployAPI, bakeryClient *httpba
 		}
 	}
 
-	r.credentials, err = r.registerMetrics(
-		deployInfo.ModelUUID,
-		deployInfo.CharmID.URL.String(),
-		deployInfo.ApplicationName,
-		bakeryClient,
-	)
+	registrationPost := metricRegistrationPost{
+		ModelUUID:       deployInfo.ModelUUID,
+		CharmURL:        deployInfo.CharmID.URL.String(),
+		ApplicationName: deployInfo.ApplicationName,
+		PlanURL:         r.Plan,
+		IncreaseBudget:  r.IncreaseBudget,
+	}
+
+	r.credentials, err = r.register(r.RegisterURL, registrationPost, bakeryClient)
 	if err != nil {
 		if deployInfo.CharmID.URL.Schema == "cs" {
 			logger.Infof("failed to obtain plan authorization: %v", err)
@@ -208,26 +253,19 @@ func (r *RegisterMeteredCharm) getCharmPlans(client *httpbakery.Client, cURL str
 	return info, nil
 }
 
-func (r *RegisterMeteredCharm) registerMetrics(modelUUID, charmURL, serviceName string, client *httpbakery.Client) ([]byte, error) {
-	if r.RegisterURL == "" {
+// register sends a registration message on the provided url and expects credentials to be returned in response.
+func (r *RegisterMeteredCharm) register(reqUrl string, msg interface{}, client *httpbakery.Client) ([]byte, error) {
+	if reqUrl == "" {
 		return nil, errors.Errorf("no metric registration url is specified")
 	}
-	registerURL, err := url.Parse(r.RegisterURL)
+	registerURL, err := url.Parse(reqUrl)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
 
-	registrationPost := metricRegistrationPost{
-		ModelUUID:       modelUUID,
-		CharmURL:        charmURL,
-		ApplicationName: serviceName,
-		PlanURL:         r.Plan,
-		IncreaseBudget:  r.IncreaseBudget,
-	}
-
 	buff := &bytes.Buffer{}
 	encoder := json.NewEncoder(buff)
-	err = encoder.Encode(registrationPost)
+	err = encoder.Encode(msg)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/cmd/juju/application/register.go
+++ b/cmd/juju/application/register.go
@@ -41,7 +41,7 @@ type RegisterMeteredCharm struct {
 func (r *RegisterMeteredCharm) SetFlags(f *gnuflag.FlagSet) {
 	f.IntVar(&r.IncreaseBudget, "increase-budget", 0, "increase model budget allocation by this amount")
 	f.StringVar(&r.Plan, "plan", "", "plan to deploy charm under")
-	f.BoolVar(&r.Development, "development", false, "deploy application in development mode")
+	f.BoolVar(&r.Development, "develop-commercial", false, "deploy application in development mode")
 }
 
 // RunPre is run before the deployment of an application.

--- a/state/application.go
+++ b/state/application.go
@@ -50,6 +50,7 @@ type applicationDoc struct {
 	MinUnits             int        `bson:"minunits"`
 	TxnRevno             int64      `bson:"txn-revno"`
 	MetricCredentials    []byte     `bson:"metric-credentials"`
+	IsDevMode            bool       `bson:"is-dev-mode"`
 }
 
 func newApplication(st *State, doc *applicationDoc) *Application {
@@ -58,6 +59,11 @@ func newApplication(st *State, doc *applicationDoc) *Application {
 		doc: *doc,
 	}
 	return app
+}
+
+// IsDevMode returns true when the application is deployed in development mode.
+func (a *Application) IsDevMode() bool {
+	return a.doc.IsDevMode
 }
 
 // IsRemote returns false for a local application.

--- a/state/application_test.go
+++ b/state/application_test.go
@@ -2981,10 +2981,10 @@ func (s *ApplicationSuite) TestRenamePeerRelationOnUpgradeWithMoreThanOneUnit(c 
 func (s *ApplicationSuite) TestAddApplicationInDevMode(c *gc.C) {
 	ch := s.AddTestingCharm(c, "wordpress")
 	app, err := s.State.AddApplication(state.AddApplicationArgs{
-		Name:    "wp",
-		Series:  "",
-		Charm:   ch,
-		DevMode: true,
+		Name:        "wp",
+		Series:      "",
+		Charm:       ch,
+		Development: true,
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(app.IsDevMode(), jc.IsTrue)

--- a/state/application_test.go
+++ b/state/application_test.go
@@ -2977,3 +2977,15 @@ func (s *ApplicationSuite) TestRenamePeerRelationOnUpgradeWithMoreThanOneUnit(c 
 	c.Assert(err, gc.ErrorMatches, `*would break relation "mysql:replication"*`)
 	c.Assert(s.mysql.CharmModifiedVersion() == obtainedV, jc.IsTrue)
 }
+
+func (s *ApplicationSuite) TestAddApplicationInDevMode(c *gc.C) {
+	ch := s.AddTestingCharm(c, "wordpress")
+	app, err := s.State.AddApplication(state.AddApplicationArgs{
+		Name:    "wp",
+		Series:  "",
+		Charm:   ch,
+		DevMode: true,
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(app.IsDevMode(), jc.IsTrue)
+}

--- a/state/migration_internal_test.go
+++ b/state/migration_internal_test.go
@@ -360,6 +360,8 @@ func (s *MigrationSuite) TestApplicationDocFields(c *gc.C) {
 		// RelationCount is handled by the number of times the application name
 		// appears in relation endpoints.
 		"RelationCount",
+		// IsDevMode signals whether the application is in development mode.
+		"IsDevMode",
 	)
 	migrated := set.NewStrings(
 		"Name",

--- a/state/state.go
+++ b/state/state.go
@@ -1024,6 +1024,7 @@ type AddApplicationArgs struct {
 	Placement        []*instance.Placement
 	Constraints      constraints.Value
 	Resources        map[string]string
+	Development      bool // The application is created in development mode.
 }
 
 // AddApplication creates a new application, running the supplied charm, with the
@@ -1210,6 +1211,7 @@ func (st *State) AddApplication(args AddApplicationArgs) (_ *Application, err er
 		Channel:       string(args.Channel),
 		RelationCount: len(peers),
 		Life:          Alive,
+		IsDevMode:     args.Development,
 	}
 
 	app := newApplication(st, appDoc)


### PR DESCRIPTION
## Description of change
This add a `--develop` flag to the deploy command. The flag registers the application as being in development mode both with an outside API call and on state.
Later the fact that an application is in `development mode` will be used to gate access to things like meter status overrides and metrics debugging.

## QA steps

Run `juju deploy wordpress --develop`. For the time being this should result in an error (server side not supported).

## Documentation changes

Documentation for the `deploy` command will need to be updated. Check with @cmars regarding the details.

