### PR TITLE
apiserver: Set migration to DONE when reaping (backport to 2.2)

### DIFF
--- a/worker/migrationmaster/worker.go
+++ b/worker/migrationmaster/worker.go
@@ -571,6 +571,10 @@ func (w *Worker) transferLogs(targetInfo coremigration.TargetInfo, modelUUID str
 
 func (w *Worker) doREAP() (coremigration.Phase, error) {
 	w.setInfoStatus("successful, removing model from source controller")
+	// NOTE(babbageclunk): Calling Reap will set the migration phase
+	// to DONE if successful - this avoids a race where this worker is
+	// killed by the model going away before it can update the phase
+	// itself.
 	err := w.config.Facade.Reap()
 	if err != nil {
 		w.setErrorStatus("removing exported model failed: %s", err.Error())


### PR DESCRIPTION
## Description of change

This avoids a race at the end of the migration where the migrationmaster
worker could be killed (because the model was gone) before it had a
chance to update the migration phase.

This is a straight backport of #7647 to the 2.2 branch.

## QA steps

Bootstrap two controllers in the same cloud.
Create a model in one, deploy it to the other.
(I added a sleep to the migrationmaster worker to cause the model removal to trigger the worker being killed - I'm not sure how we could test that at the functional level.)

## Bug reference

Fixes https://bugs.launchpad.net/juju/+bug/1667162
