### PR TITLE
Drop several AWS logging messages to something more reasonable.

### DIFF
--- a/provider/ec2/environ.go
+++ b/provider/ec2/environ.go
@@ -578,13 +578,10 @@ func (e *environ) StartInstance(args environs.StartInstanceParams) (_ *environs.
 			// (we'll just treat this the same way we treat constrained zones
 			// and retry).
 			runArgs.SubnetId = subnetIDsForZone[rand.Intn(len(subnetIDsForZone))]
-			logger.Infof(
-				"selected random subnet %q from all matching in zone %q: %v",
-				runArgs.SubnetId, zone, subnetIDsForZone,
-			)
+			logger.Debugf("selected random subnet %q from all matching in zone %q", runArgs.SubnetId, zone)
 		case len(subnetIDsForZone) == 1:
 			runArgs.SubnetId = subnetIDsForZone[0]
-			logger.Infof("selected subnet %q in zone %q", runArgs.SubnetId, zone)
+			logger.Debugf("selected subnet %q in zone %q", runArgs.SubnetId, zone)
 		}
 
 		callback(status.Allocating, fmt.Sprintf("Trying to start instance in availability zone %q", zone), nil)

--- a/provider/ec2/environ_vpc.go
+++ b/provider/ec2/environ_vpc.go
@@ -461,11 +461,11 @@ func getVPCSubnetIDsForAvailabilityZone(
 	matchingSubnetIDs := set.NewStrings()
 	for _, subnet := range subnets {
 		if subnet.AvailZone != zoneName {
-			logger.Infof("skipping subnet %q (in VPC %q): not in the chosen AZ %q", subnet.Id, vpcID, zoneName)
+			logger.Debugf("skipping subnet %q (in VPC %q): not in the chosen AZ %q", subnet.Id, vpcID, zoneName)
 			continue
 		}
 		if !allowedSubnets.IsEmpty() && !allowedSubnets.Contains(subnet.Id) {
-			logger.Infof("skipping subnet %q (in VPC %q, AZ %q): not matching spaces constraints", subnet.Id, vpcID, zoneName)
+			logger.Debugf("skipping subnet %q (in VPC %q, AZ %q): not matching spaces constraints", subnet.Id, vpcID, zoneName)
 			continue
 		}
 		matchingSubnetIDs.Add(subnet.Id)


### PR DESCRIPTION
## Description of change

Just a few log messages that are overly verbose during bootstrap.

## QA steps

```
$ juju bootstrap --config vpc-id=X --debug
```
and observe the log messages. This should be different if you supply '--verbose' instead of '--debug'.


## Documentation changes

Not a big documentation issue. They are all hidden by default anyway.

## Bug reference

[lp:1705247](https://bugs.launchpad.net/juju/2.2/+bug/1705247)