### PR TITLE
Set CHARM_DIR in restricted contexts.

### DIFF
--- a/worker/meterstatus/context.go
+++ b/worker/meterstatus/context.go
@@ -34,6 +34,7 @@ func NewLimitedContext(unitName string) *limitedContext {
 // HookVars implements runner.Context.
 func (ctx *limitedContext) HookVars(paths context.Paths) ([]string, error) {
 	vars := []string{
+		"CHARM_DIR=" + paths.GetCharmDir(), // legacy
 		"JUJU_CHARM_DIR=" + paths.GetCharmDir(),
 		"JUJU_CONTEXT_ID=" + ctx.id,
 		"JUJU_AGENT_SOCKET=" + paths.GetJujucSocket(),

--- a/worker/meterstatus/context_test.go
+++ b/worker/meterstatus/context_test.go
@@ -34,6 +34,8 @@ func (s *ContextSuite) TestHookContextEnv(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(varMap["JUJU_AGENT_SOCKET"], gc.Equals, "/dummy/jujuc.sock")
 	c.Assert(varMap["JUJU_UNIT_NAME"], gc.Equals, "u/0")
+	c.Assert(varMap["JUJU_CHARM_DIR"], gc.Equals, "/dummy/charm")
+	c.Assert(varMap["CHARM_DIR"], gc.Equals, "/dummy/charm")
 	key := "PATH"
 	if runtime.GOOS == "windows" {
 		key = "Path"

--- a/worker/metrics/collect/context.go
+++ b/worker/metrics/collect/context.go
@@ -32,6 +32,7 @@ func newHookContext(unitName string, recorder spool.MetricRecorder) *hookContext
 // HookVars implements runner.Context.
 func (ctx *hookContext) HookVars(paths context.Paths) ([]string, error) {
 	vars := []string{
+		"CHARM_DIR=" + paths.GetCharmDir(), // legacy
 		"JUJU_CHARM_DIR=" + paths.GetCharmDir(),
 		"JUJU_CONTEXT_ID=" + ctx.id,
 		"JUJU_AGENT_SOCKET=" + paths.GetJujucSocket(),

--- a/worker/metrics/collect/context_test.go
+++ b/worker/metrics/collect/context_test.go
@@ -64,6 +64,8 @@ func (s *ContextSuite) TestHookContextEnv(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(varMap["JUJU_AGENT_SOCKET"], gc.Equals, "/dummy/jujuc.sock")
 	c.Assert(varMap["JUJU_UNIT_NAME"], gc.Equals, "u/0")
+	c.Assert(varMap["JUJU_CHARM_DIR"], gc.Equals, "/dummy/charm")
+	c.Assert(varMap["CHARM_DIR"], gc.Equals, "/dummy/charm")
 	key := "PATH"
 	if runtime.GOOS == "windows" {
 		key = "Path"


### PR DESCRIPTION

## Description of change

charm-helpers still uses the `CHARM_DIR` environment variable (instead of `JUJU_CHARM_DIR`) to determine the charm directory. This change makes the `meter-status-changed` and `collect-metrics` hook contexts declare that environment variable.

## QA steps

A charm with a `meter-status-changed` or `collect-metrics` hook will be able to use the `charm-helpers` hookenv.charm_dir() method to determine the charm directory.

## Documentation changes

No changes to user workflow.

