### PR TITLE
Hook context is less interesting than what command is running

### DIFF
--- a/worker/uniter/runner/jujuc/server.go
+++ b/worker/uniter/runner/jujuc/server.go
@@ -175,8 +175,8 @@ func (j *Jujuc) Main(req Request, resp *exec.ExecResponse) error {
 	// Beware, reducing the log level of the following line will lead
 	// to passwords leaking if passed as args.
 	logger.Tracef("running hook tool %q %q", req.CommandName, req.Args)
-	logger.Tracef("running hook tool %q", req.CommandName)
-	logger.Debugf("hook context id %q; dir %q", req.ContextId, req.Dir)
+	logger.Debugf("running hook tool %q", req.CommandName)
+	logger.Tracef("hook context id %q; dir %q", req.ContextId, req.Dir)
 	wrapper := &cmdWrapper{c, nil}
 	resp.Code = cmd.Main(wrapper, ctx, req.Args)
 	if errors.Cause(wrapper.err) == ErrNoStdin {


### PR DESCRIPTION
## Description of change

If you run under --debug, you see lots of the wrong messages. Instead of seeing something useful, like what commands are being run. You see lots of bogus information about what context the command is being run in.
There is some concern about leaking passwords/etc because eg 'relation-set' would take the secrets you are passing to another application. However, if we just say what command is being run, rather than what args, I think it handles this.

## QA steps

```
$ juju bootstrap --debug
$ juju deploy SOMETHING
$ juju debug-log
```
You should be able to watch the debug log and see that interesting information about what it is doing is being shown, rather than a bunch of unhelpful messages.

This could probably be driven further.


## Documentation changes

Not really.

## Bug reference

[lp:1705405](https://bugs.launchpad.net/juju/+bug/1705405)