### PR TITLE
BUG 1699941 stop ignoring region-config values (backport to 2.2)

### DIFF
--- a/cmd/juju/commands/bootstrap.go
+++ b/cmd/juju/commands/bootstrap.go
@@ -890,6 +890,19 @@ func (c *bootstrapCommand) bootstrapConfigs(
 		}
 		inheritedControllerAttrs[k] = v
 	}
+	// Region config values, for the region to be bootstrapped, from clouds.yaml
+	// override what is in the cloud config.
+	for k, v := range cloud.RegionConfig[c.Region] {
+		switch {
+		case bootstrap.IsBootstrapAttribute(k):
+			bootstrapConfigAttrs[k] = v
+			continue
+		case controller.ControllerOnlyAttribute(k):
+			controllerConfigAttrs[k] = v
+			continue
+		}
+		inheritedControllerAttrs[k] = v
+	}
 	// Model defaults are added to the inherited controller attributes.
 	// Any command line set model defaults override what is in the cloud config.
 	for k, v := range modelDefaultConfigAttrs {

--- a/cmd/juju/commands/bootstrap_test.go
+++ b/cmd/juju/commands/bootstrap_test.go
@@ -707,6 +707,42 @@ func (s *BootstrapSuite) TestBootstrapAttributesInheritedOverDefaults(c *gc.C) {
 	})
 }
 
+func (s *BootstrapSuite) TestBootstrapRegionConfigAttributesOverCloudConfig(c *gc.C) {
+	/* Test that cloud config attributes are overwritten by region config
+	   attributes by setting both to something different in the config setup.
+	   Only the region config values should be found */
+	s.patchVersionAndSeries(c, "raring")
+
+	bootstrapCmd := bootstrapCommand{Region: "region-2"}
+	ctx := cmdtesting.Context(c)
+
+	// The OpenStack provider has a config attribute of network we can use.
+	env := &openstack.Environ{}
+	provider := env.Provider()
+
+	// First test that the network is set to the cloud config value
+	key := "network"
+	testCloud, err := cloud.CloudByName("dummy-cloud-with-region-config")
+	c.Assert(err, jc.ErrorIsNil)
+
+	checkConfigs(c, bootstrapCmd, key, ctx, testCloud, provider, map[string]map[string]interface{}{
+		"bootstrapModelConfig":     {key: "cloud-network"},
+		"inheritedControllerAttrs": {key: "cloud-network"},
+		"userConfigAttrs":          {},
+	})
+
+	// Second test that network in the region config overwrites the cloud config network value.
+	bootstrapCmd = bootstrapCommand{Region: "region-1"}
+	testCloud, err = cloud.CloudByName("dummy-cloud-with-region-config")
+	c.Assert(err, jc.ErrorIsNil)
+
+	checkConfigs(c, bootstrapCmd, key, ctx, testCloud, provider, map[string]map[string]interface{}{
+		"bootstrapModelConfig":     {key: "region-network"},
+		"inheritedControllerAttrs": {key: "region-network"},
+		"userConfigAttrs":          {},
+	})
+}
+
 func (s *BootstrapSuite) TestBootstrapAttributesCLIOverDefaults(c *gc.C) {
 	/* Test that defaults are overwritten by CLI passed attributes by setting
 	   the inherited attribute enable-os-upgrade to true in the cloud
@@ -1667,6 +1703,7 @@ rackspace
 localhost                                    
 dummy-cloud                     joe          home
 dummy-cloud-with-config                      
+dummy-cloud-with-region-config               
 dummy-cloud-without-regions                  
 many-credentials-no-auth-types               
 
@@ -1815,6 +1852,16 @@ clouds:
             region-2:
     dummy-cloud-without-regions:
         type: dummy
+    dummy-cloud-with-region-config:
+        type: dummy
+        regions:
+            region-1:
+            region-2:
+        config:
+            network: cloud-network
+        region-config:
+            region-1:
+                network: region-network
     dummy-cloud-with-config:
         type: dummy
         config:


### PR DESCRIPTION
## Description of change

Add the region-config values for use during bootstrap. They should over
write the cloud-config values, but not any config values specified on the CLI
during bootstrap.

This is a straight backport of #7634 to the 2.2 branch.

## QA steps

1. Create a yaml cloud config file to add an openstack cloud, including both cloud-config and region-config values. Suggest using the network config attribute, where only the related value in region-config will work.
2. Add an openstack cloud to juju with yaml file from step two.
3. Bootstrap the new cloud.
4. Try to bootstrap the new cloud including --config network=no-such-network and watch it fail.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1699941