### PR TITLE
resources: Don't run multiple cleanups for one storage path

### DIFF
--- a/state/cleanup.go
+++ b/state/cleanup.go
@@ -146,7 +146,11 @@ func (st *State) cleanupResourceBlob(storagePath string) error {
 
 	persist := st.newPersistence()
 	storage := persist.NewStorage()
-	return storage.Remove(storagePath)
+	err := storage.Remove(storagePath)
+	if errors.IsNotFound(err) {
+		return nil
+	}
+	return errors.Trace(err)
 }
 
 func (st *State) cleanupRelationSettings(prefix string) error {

--- a/state/resources_persistence_test.go
+++ b/state/resources_persistence_test.go
@@ -573,6 +573,29 @@ func (s *ResourcePersistenceSuite) TestNewResourcePendingResourceOpsNotFound(c *
 	})
 }
 
+func (s *ResourcePersistenceSuite) TestRemoveResourcesCleansUpUniqueStoragePaths(c *gc.C) {
+	// We shouldn't schedule multiple cleanups for the same path (when
+	// application and units use the same resource).
+	appResource, appDoc := newPersistenceResource(c, "appa", "yipyip")
+	_, unitDoc := newPersistenceUnitResource(c, "appa", "appa/0", "yipyip")
+	s.base.ReturnAll = []resourceDoc{appDoc, unitDoc}
+	p := NewResourcePersistence(s.base)
+
+	ops, err := p.NewRemoveResourcesOps("appa")
+	c.Assert(err, jc.ErrorIsNil)
+
+	var cleanups []txn.Op
+	for _, op := range ops {
+		if op.C == cleanupsC {
+			cleanups = append(cleanups, op)
+		}
+	}
+	c.Assert(cleanups, gc.HasLen, 1)
+	c.Assert(cleanups[0].Insert, gc.Not(gc.IsNil))
+	c.Assert(cleanups[0].Insert.(*cleanupDoc).Kind, gc.Equals, cleanupResourceBlob)
+	c.Assert(cleanups[0].Insert.(*cleanupDoc).Prefix, gc.Equals, appResource.storagePath)
+}
+
 func newPersistenceUnitResources(c *gc.C, serviceID, unitID string, resources []resource.Resource) ([]resource.Resource, []resourceDoc) {
 	var unitResources []resource.Resource
 	var docs []resourceDoc


### PR DESCRIPTION
## Description of change

Destroying an application with units would result in multiple cleanups being scheduled for the same storage path, because there are resource records for the application and the units. Change `ResourcePersistence.NewRemoveResourcesOps` to only schedule a cleanup once for a given path.

If a resource blob had already been deleted from storage when the cleanup ran, it would fail (logging an error) and leave the cleanup record around. This would prevent migrations, since the source precheck
ensures there aren't any cleanups. If the blob's already gone, the cleanup should succeed.

## QA steps

* Deploy an application that takes a resource (like cs:~cmars/mattermost).
* Remove the application.
* Check that there are no errors in the log about failed cleanups, and that only one "resourceBlob" cleanup is run.
* Check that there are no cleanups remaining in the database once the system is idle.

## Bug reference

Fixes https://bugs.launchpad.net/juju/+bug/1705352

