### PR TITLE
Add firewaller support for provider role on consuming side of cmr

### DIFF
--- a/api/crossmodelrelations/crossmodelrelations.go
+++ b/api/crossmodelrelations/crossmodelrelations.go
@@ -108,3 +108,25 @@ func (c *Client) RelationUnitSettings(relationUnits []params.RemoteRelationUnit)
 	}
 	return results.Results, nil
 }
+
+// WatchEgressAddressesForRelation returns a watcher that notifies when addresses,
+// from which connections will originate to the offering side of the relation, change.
+// Each event contains the entire set of addresses which the offering side is required
+// to allow for access to the other side of the relation.
+func (c *Client) WatchEgressAddressesForRelation(remoteRelationArg params.RemoteRelationArg) (watcher.StringsWatcher, error) {
+	args := params.RemoteRelationArgs{Args: []params.RemoteRelationArg{remoteRelationArg}}
+	var results params.StringsWatchResults
+	err := c.facade.FacadeCall("WatchEgressAddressesForRelations", args, &results)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	if len(results.Results) != 1 {
+		return nil, errors.Errorf("expected 1 result, got %d", len(results.Results))
+	}
+	result := results.Results[0]
+	if result.Error != nil {
+		return nil, result.Error
+	}
+	w := apiwatcher.NewStringsWatcher(c.facade.RawAPICaller(), result)
+	return w, nil
+}

--- a/api/firewaller/firewaller.go
+++ b/api/firewaller/firewaller.go
@@ -134,9 +134,9 @@ func (c *Client) Relation(tag names.RelationTag) (*Relation, error) {
 }
 
 // WatchEgressAddressesForRelation returns a watcher that notifies when addresses,
-// from which connections will originate to the offering side of the relation, change.
-// Each event contains the entire set of addresses which the offering side is required
-// to allow for access to the other side of the relation.
+// from which connections will originate to the provider side of the relation, change.
+// Each event contains the entire set of addresses which the provider side is required
+// to allow for access from the other side of the relation.
 func (c *Client) WatchEgressAddressesForRelation(relationTag names.RelationTag) (watcher.StringsWatcher, error) {
 	args := params.Entities{[]params.Entity{{Tag: relationTag.String()}}}
 	var results params.StringsWatchResults
@@ -158,7 +158,7 @@ func (c *Client) WatchEgressAddressesForRelation(relationTag names.RelationTag) 
 // WatchIngressAddressesForRelation returns a watcher that notifies when addresses,
 // from which connections will originate for the relation, change.
 // Each event contains the entire set of addresses which are required
-// for ingress into this model from the other (consuming) side of the relation.
+// for ingress into this model from the other requirer side of the relation.
 func (c *Client) WatchIngressAddressesForRelation(relationTag names.RelationTag) (watcher.StringsWatcher, error) {
 	args := params.Entities{[]params.Entity{{Tag: relationTag.String()}}}
 	var results params.StringsWatchResults

--- a/apiserver/admin_test.go
+++ b/apiserver/admin_test.go
@@ -563,6 +563,7 @@ func (s *loginSuite) TestAnonymousModelLogin(c *gc.C) {
 	c.Assert(result.Facades, jc.DeepEquals, []params.FacadeVersions{
 		{Name: "CrossModelRelations", Versions: []int{1}},
 		{Name: "RelationUnitsWatcher", Versions: []int{1}},
+		{Name: "StringsWatcher", Versions: []int{1}},
 	})
 }
 

--- a/apiserver/common/firewall/egressaddresswatcher_test.go
+++ b/apiserver/common/firewall/egressaddresswatcher_test.go
@@ -1,7 +1,7 @@
 // Copyright 2017 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package firewaller_test
+package firewall_test
 
 import (
 	jc "github.com/juju/testing/checkers"
@@ -10,7 +10,7 @@ import (
 	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/apiserver/common"
-	"github.com/juju/juju/apiserver/facades/controller/firewaller"
+	"github.com/juju/juju/apiserver/common/firewall"
 	"github.com/juju/juju/apiserver/params"
 	apiservertesting "github.com/juju/juju/apiserver/testing"
 	"github.com/juju/juju/network"
@@ -26,7 +26,6 @@ type addressWatcherSuite struct {
 	resources  *common.Resources
 	authorizer *apiservertesting.FakeAuthorizer
 	st         *mockState
-	api        *firewaller.FirewallerAPIV3
 }
 
 type nopSyncStarter struct{}
@@ -45,9 +44,6 @@ func (s *addressWatcherSuite) SetUpTest(c *gc.C) {
 	}
 
 	s.st = newMockState(coretesting.ModelTag.Id())
-	api, err := firewaller.NewFirewallerAPI(s.st, s.resources, s.authorizer, &mockCloudSpecAPI{})
-	c.Assert(err, jc.ErrorIsNil)
-	s.api = api
 }
 
 func (s *addressWatcherSuite) setupRelation(c *gc.C, addr string) *mockRelation {
@@ -68,7 +64,7 @@ func (s *addressWatcherSuite) setupRelation(c *gc.C, addr string) *mockRelation 
 func (s *addressWatcherSuite) TestInitial(c *gc.C) {
 	rel := s.setupRelation(c, "54.1.2.3")
 	s.st.relations["remote-db2:db django:db"].inScope = set.NewStrings("django/0")
-	w, err := firewaller.NewIngressAddressWatcher(s.st, rel, "django")
+	w, err := firewall.NewEgressAddressWatcher(s.st, rel, "django")
 	c.Assert(err, jc.ErrorIsNil)
 	defer statetesting.AssertStop(c, w)
 	wc := statetesting.NewStringsWatcherC(c, nopSyncStarter{}, w)
@@ -79,7 +75,7 @@ func (s *addressWatcherSuite) TestInitial(c *gc.C) {
 
 func (s *addressWatcherSuite) TestUnitEntersScope(c *gc.C) {
 	rel := s.setupRelation(c, "54.1.2.3")
-	w, err := firewaller.NewIngressAddressWatcher(s.st, rel, "django")
+	w, err := firewall.NewEgressAddressWatcher(s.st, rel, "django")
 	c.Assert(err, jc.ErrorIsNil)
 	defer statetesting.AssertStop(c, w)
 	wc := statetesting.NewStringsWatcherC(c, nopSyncStarter{}, w)
@@ -107,7 +103,7 @@ func (s *addressWatcherSuite) TestUnitEntersScope(c *gc.C) {
 
 func (s *addressWatcherSuite) TestTwoUnitsEntersScope(c *gc.C) {
 	rel := s.setupRelation(c, "54.1.2.3")
-	w, err := firewaller.NewIngressAddressWatcher(s.st, rel, "django")
+	w, err := firewall.NewEgressAddressWatcher(s.st, rel, "django")
 	c.Assert(err, jc.ErrorIsNil)
 	defer statetesting.AssertStop(c, w)
 	wc := statetesting.NewStringsWatcherC(c, nopSyncStarter{}, w)
@@ -134,7 +130,7 @@ func (s *addressWatcherSuite) TestTwoUnitsEntersScope(c *gc.C) {
 
 func (s *addressWatcherSuite) TestAnotherUnitsEntersScope(c *gc.C) {
 	rel := s.setupRelation(c, "54.1.2.3")
-	w, err := firewaller.NewIngressAddressWatcher(s.st, rel, "django")
+	w, err := firewall.NewEgressAddressWatcher(s.st, rel, "django")
 	c.Assert(err, jc.ErrorIsNil)
 	defer statetesting.AssertStop(c, w)
 	wc := statetesting.NewStringsWatcherC(c, nopSyncStarter{}, w)
@@ -167,7 +163,7 @@ func (s *addressWatcherSuite) TestAnotherUnitsEntersScope(c *gc.C) {
 
 func (s *addressWatcherSuite) TestUnitEntersScopeNoPublicAddress(c *gc.C) {
 	rel := s.setupRelation(c, "")
-	w, err := firewaller.NewIngressAddressWatcher(s.st, rel, "django")
+	w, err := firewall.NewEgressAddressWatcher(s.st, rel, "django")
 	c.Assert(err, jc.ErrorIsNil)
 	defer statetesting.AssertStop(c, w)
 	wc := statetesting.NewStringsWatcherC(c, nopSyncStarter{}, w)
@@ -195,7 +191,7 @@ func (s *addressWatcherSuite) TestUnitEntersScopeNoPublicAddress(c *gc.C) {
 func (s *addressWatcherSuite) TestUnitEntersScopeNotAssigned(c *gc.C) {
 	rel := s.setupRelation(c, "")
 	s.st.units["django/0"].assigned = false
-	w, err := firewaller.NewIngressAddressWatcher(s.st, rel, "django")
+	w, err := firewall.NewEgressAddressWatcher(s.st, rel, "django")
 	c.Assert(err, jc.ErrorIsNil)
 	defer statetesting.AssertStop(c, w)
 	wc := statetesting.NewStringsWatcherC(c, nopSyncStarter{}, w)
@@ -222,7 +218,7 @@ func (s *addressWatcherSuite) TestUnitEntersScopeNotAssigned(c *gc.C) {
 
 func (s *addressWatcherSuite) TestUnitLeavesScopeInitial(c *gc.C) {
 	rel := s.setupRelation(c, "54.1.2.3")
-	w, err := firewaller.NewIngressAddressWatcher(s.st, rel, "django")
+	w, err := firewall.NewEgressAddressWatcher(s.st, rel, "django")
 	c.Assert(err, jc.ErrorIsNil)
 	defer statetesting.AssertStop(c, w)
 	wc := statetesting.NewStringsWatcherC(c, nopSyncStarter{}, w)
@@ -239,7 +235,7 @@ func (s *addressWatcherSuite) TestUnitLeavesScopeInitial(c *gc.C) {
 
 func (s *addressWatcherSuite) TestUnitLeavesScope(c *gc.C) {
 	rel := s.setupRelation(c, "54.1.2.3")
-	w, err := firewaller.NewIngressAddressWatcher(s.st, rel, "django")
+	w, err := firewall.NewEgressAddressWatcher(s.st, rel, "django")
 	c.Assert(err, jc.ErrorIsNil)
 	defer statetesting.AssertStop(c, w)
 	wc := statetesting.NewStringsWatcherC(c, nopSyncStarter{}, w)
@@ -273,7 +269,7 @@ func (s *addressWatcherSuite) TestUnitLeavesScope(c *gc.C) {
 
 func (s *addressWatcherSuite) TestTwoUnitsSameAddressOneLeaves(c *gc.C) {
 	rel := s.setupRelation(c, "54.1.2.3")
-	w, err := firewaller.NewIngressAddressWatcher(s.st, rel, "django")
+	w, err := firewall.NewEgressAddressWatcher(s.st, rel, "django")
 	c.Assert(err, jc.ErrorIsNil)
 	defer statetesting.AssertStop(c, w)
 	wc := statetesting.NewStringsWatcherC(c, nopSyncStarter{}, w)
@@ -315,7 +311,7 @@ func (s *addressWatcherSuite) TestTwoUnitsSameAddressOneLeaves(c *gc.C) {
 func (s *addressWatcherSuite) TestSecondUnitJoinsOnSameMachine(c *gc.C) {
 	rel := s.setupRelation(c, "55.1.2.3")
 	s.st.relations["remote-db2:db django:db"].inScope = set.NewStrings("django/0")
-	w, err := firewaller.NewIngressAddressWatcher(s.st, rel, "django")
+	w, err := firewall.NewEgressAddressWatcher(s.st, rel, "django")
 	c.Assert(err, jc.ErrorIsNil)
 	defer statetesting.AssertStop(c, w)
 	wc := statetesting.NewStringsWatcherC(c, nopSyncStarter{}, w)
@@ -348,7 +344,7 @@ func (s *addressWatcherSuite) TestSecondUnitJoinsOnSameMachine(c *gc.C) {
 func (s *addressWatcherSuite) TestSeesMachineAddressChanges(c *gc.C) {
 	rel := s.setupRelation(c, "2.3.4.5")
 	s.st.relations["remote-db2:db django:db"].inScope = set.NewStrings("django/0")
-	w, err := firewaller.NewIngressAddressWatcher(s.st, rel, "django")
+	w, err := firewall.NewEgressAddressWatcher(s.st, rel, "django")
 	c.Assert(err, jc.ErrorIsNil)
 	defer statetesting.AssertStop(c, w)
 	wc := statetesting.NewStringsWatcherC(c, nopSyncStarter{}, w)
@@ -366,7 +362,7 @@ func (s *addressWatcherSuite) TestSeesMachineAddressChanges(c *gc.C) {
 func (s *addressWatcherSuite) TestHandlesMachineAddressChangesWithNoEffect(c *gc.C) {
 	rel := s.setupRelation(c, "2.3.4.5")
 	s.st.relations["remote-db2:db django:db"].inScope = set.NewStrings("django/0")
-	w, err := firewaller.NewIngressAddressWatcher(s.st, rel, "django")
+	w, err := firewall.NewEgressAddressWatcher(s.st, rel, "django")
 	c.Assert(err, jc.ErrorIsNil)
 	defer statetesting.AssertStop(c, w)
 	wc := statetesting.NewStringsWatcherC(c, nopSyncStarter{}, w)
@@ -388,7 +384,7 @@ func (s *addressWatcherSuite) TestHandlesUnitGoneWhenMachineAddressChanges(c *gc
 	s.st.units["django/1"] = unit
 
 	s.st.relations["remote-db2:db django:db"].inScope = set.NewStrings("django/0", "django/1")
-	w, err := firewaller.NewIngressAddressWatcher(s.st, rel, "django")
+	w, err := firewall.NewEgressAddressWatcher(s.st, rel, "django")
 	c.Assert(err, jc.ErrorIsNil)
 	defer statetesting.AssertStop(c, w)
 	wc := statetesting.NewStringsWatcherC(c, nopSyncStarter{}, w)
@@ -407,7 +403,7 @@ func (s *addressWatcherSuite) TestHandlesUnitGoneWhenMachineAddressChanges(c *gc
 func (s *addressWatcherSuite) TestEgressAddressConfigured(c *gc.C) {
 	s.st.configAttrs["egress-cidrs"] = "10.0.0.1/16"
 	rel := s.setupRelation(c, "54.1.2.3")
-	w, err := firewaller.NewIngressAddressWatcher(s.st, rel, "django")
+	w, err := firewall.NewEgressAddressWatcher(s.st, rel, "django")
 	c.Assert(err, jc.ErrorIsNil)
 	defer statetesting.AssertStop(c, w)
 	wc := statetesting.NewStringsWatcherC(c, nopSyncStarter{}, w)

--- a/apiserver/common/firewall/firewall.go
+++ b/apiserver/common/firewall/firewall.go
@@ -1,0 +1,134 @@
+package firewall
+
+import (
+	"net"
+
+	"github.com/juju/errors"
+	"github.com/juju/loggo"
+	"gopkg.in/juju/names.v2"
+
+	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/facade"
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/state/watcher"
+	"gopkg.in/juju/charm.v6-unstable"
+)
+
+var logger = loggo.GetLogger("juju.apiserver.crossmodelrelations")
+
+// WatchEgressAddressesForRelations creates a watcher that notifies when addresses, from which
+// connections will originate for the relation, change.
+// Each event contains the entire set of addresses which are required for ingress for the relation.
+func WatchEgressAddressesForRelations(resources facade.Resources, st State, relations params.Entities) (params.StringsWatchResults, error) {
+	results := params.StringsWatchResults{
+		make([]params.StringsWatchResult, len(relations.Entities)),
+	}
+
+	one := func(tag string) (id string, changes []string, _ error) {
+		logger.Debugf("Watching egress addresses for %+v", tag)
+
+		relationTag, err := names.ParseRelationTag(tag)
+		if err != nil {
+			return "", nil, errors.Trace(err)
+		}
+
+		// Load the relation details for the current token.
+		localEndpoint, err := localApplication(st, relationTag)
+		if err != nil {
+			return "", nil, errors.Trace(err)
+		}
+
+		w, err := NewEgressAddressWatcher(st, localEndpoint.relation, localEndpoint.application)
+		if err != nil {
+			return "", nil, errors.Trace(err)
+		}
+
+		// TODO(wallyworld) - we will need to watch subnets too, but only
+		// when we support using cloud local addresses
+		//filter := func(id interface{}) bool {
+		//	include, err := includeAsIngressSubnet(id.(string))
+		//	if err != nil {
+		//		logger.Warningf("invalid CIDR %q", id)
+		//	}
+		//	return include
+		//}
+		//w := api.st.WatchSubnets(filter)
+
+		changes, ok := <-w.Changes()
+		if !ok {
+			return "", nil, common.ServerError(watcher.EnsureErr(w))
+		}
+		return resources.Register(w), changes, nil
+	}
+
+	for i, e := range relations.Entities {
+		watcherId, changes, err := one(e.Tag)
+		if err != nil {
+			results.Results[i].Error = common.ServerError(err)
+			continue
+		}
+		results.Results[i].StringsWatcherId = watcherId
+		results.Results[i].Changes = changes
+	}
+	return results, nil
+}
+
+type localEndpointInfo struct {
+	relation    Relation
+	application string
+	name        string
+	role        charm.RelationRole
+}
+
+func localApplication(st State, relationTag names.RelationTag) (*localEndpointInfo, error) {
+	rel, err := st.KeyRelation(relationTag.Id())
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	// Gather info about the local (this model) application of the relation.
+	// We'll use the info to figure out what addresses/subnets to include.
+	localEndpoint := localEndpointInfo{relation: rel}
+	for _, ep := range rel.Endpoints() {
+		// Try looking up the info for the local application.
+		_, err = st.Application(ep.ApplicationName)
+		if err != nil && !errors.IsNotFound(err) {
+			return nil, errors.Trace(err)
+		} else if err == nil {
+			localEndpoint.application = ep.ApplicationName
+			localEndpoint.name = ep.Name
+			localEndpoint.role = ep.Role
+			break
+		}
+	}
+	// Until networking support becomes more sophisticated, for now
+	// we only care about opening access to applications with an endpoint
+	// having the "provider" role. The assumption is that such endpoints listen
+	// to incoming connections and thus require ingress. An exception to this
+	// would be applications which accept connections onto an endpoint which
+	// has a "requirer" role.
+	// We are operating in the model hosting the "consuming" application, so check
+	// that its endpoint has the "requirer" role, meaning that we need to notify
+	// the offering model of subnets from this model required for ingress.
+	if localEndpoint.role != charm.RoleRequirer {
+		return nil, errors.NotSupportedf(
+			"egress network for application %v without requires endpoint", localEndpoint.application)
+	}
+	return &localEndpoint, nil
+}
+
+// TODO(wallyworld) - this is unused until we query subnets again
+func includeAsEgressSubnet(cidr string) (bool, error) {
+	ip, _, err := net.ParseCIDR(cidr)
+	if err != nil {
+		return false, errors.Trace(err)
+	}
+	if ip.IsLoopback() || ip.IsMulticast() {
+		return false, nil
+	}
+	// TODO(wallyworld) - We only support IPv4 addresses as not all providers support IPv6.
+	if ip.To4() == nil {
+		return false, nil
+	}
+	return true, nil
+}

--- a/apiserver/common/firewall/firewall_test.go
+++ b/apiserver/common/firewall/firewall_test.go
@@ -1,0 +1,132 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package firewall_test
+
+import (
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	"github.com/juju/utils/set"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/charm.v6-unstable"
+	"gopkg.in/juju/names.v2"
+
+	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/common/firewall"
+	"github.com/juju/juju/apiserver/params"
+	apiservertesting "github.com/juju/juju/apiserver/testing"
+	"github.com/juju/juju/network"
+	"github.com/juju/juju/state"
+	coretesting "github.com/juju/juju/testing"
+)
+
+var _ = gc.Suite(&FirewallSuite{})
+
+type FirewallSuite struct {
+	coretesting.BaseSuite
+
+	resources  *common.Resources
+	authorizer *apiservertesting.FakeAuthorizer
+	st         *mockState
+}
+
+func (s *FirewallSuite) SetUpTest(c *gc.C) {
+	s.BaseSuite.SetUpTest(c)
+
+	s.resources = common.NewResources()
+	s.AddCleanup(func(_ *gc.C) { s.resources.StopAll() })
+
+	s.authorizer = &apiservertesting.FakeAuthorizer{
+		Tag:        names.NewMachineTag("0"),
+		Controller: true,
+	}
+
+	s.st = newMockState(coretesting.ModelTag.Id())
+}
+
+func (s *FirewallSuite) TestWatchEgressAddressesForRelations(c *gc.C) {
+	db2Relation := newMockRelation(123)
+	db2Relation.ruwApp = "django"
+	db2Relation.endpoints = []state.Endpoint{
+		{
+			ApplicationName: "django",
+			Relation: charm.Relation{
+				Name:      "db",
+				Interface: "db2",
+				Role:      "requirer",
+				Limit:     1,
+				Scope:     charm.ScopeGlobal,
+			},
+		},
+	}
+	db2Relation.inScope = set.NewStrings("django/0", "django/1")
+	s.st.relations["remote-db2:db django:db"] = db2Relation
+	s.st.remoteEntities[names.NewRelationTag("remote-db2:db django:db")] = "token-db2:db django:db"
+
+	unit := newMockUnit("django/0")
+	unit.publicAddress = network.NewScopedAddress("1.2.3.4", network.ScopePublic)
+	unit.machineId = "0"
+	s.st.units["django/0"] = unit
+	unit1 := newMockUnit("django/1")
+	unit1.publicAddress = network.NewScopedAddress("4.3.2.1", network.ScopePublic)
+	unit1.machineId = "1"
+	s.st.units["django/1"] = unit1
+	s.st.machines["0"] = newMockMachine("0")
+	s.st.machines["1"] = newMockMachine("1")
+	app := newMockApplication("django")
+	app.units = []*mockUnit{unit, unit1}
+	s.st.applications["django"] = app
+
+	result, err := firewall.WatchEgressAddressesForRelations(
+		s.resources, s.st,
+		params.Entities{Entities: []params.Entity{{
+			Tag: names.NewRelationTag("remote-db2:db django:db").String(),
+		}}})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result.Results, gc.HasLen, 1)
+	c.Assert(result.Results[0].Changes, jc.SameContents, []string{"1.2.3.4/32", "4.3.2.1/32"})
+	c.Assert(result.Results[0].Error, gc.IsNil)
+	c.Assert(result.Results[0].StringsWatcherId, gc.Equals, "1")
+
+	resource := s.resources.Get("1")
+	c.Assert(resource, gc.NotNil)
+	c.Assert(resource, gc.Implements, new(state.StringsWatcher))
+
+	s.st.CheckCalls(c, []testing.StubCall{
+		{"KeyRelation", []interface{}{"remote-db2:db django:db"}},
+		{"Application", []interface{}{"django"}},
+		{"Application", []interface{}{"django"}},
+		{"Machine", []interface{}{"0"}},
+		{"Machine", []interface{}{"1"}},
+	})
+}
+
+func (s *FirewallSuite) TestWatchEgressAddressesForRelationsIgnoresProvider(c *gc.C) {
+	db2Relation := newMockRelation(123)
+	db2Relation.endpoints = []state.Endpoint{
+		{
+			ApplicationName: "db2",
+			Relation: charm.Relation{
+				Name:      "data",
+				Interface: "db2",
+				Role:      "provider",
+				Limit:     1,
+				Scope:     charm.ScopeGlobal,
+			},
+		},
+	}
+
+	s.st.relations["remote-db2:db django:db"] = db2Relation
+	app := newMockApplication("db2")
+	s.st.applications["db2"] = app
+	s.st.remoteEntities[names.NewRelationTag("remote-db2:db django:db")] = "token-db2:db django:db"
+
+	result, err := firewall.WatchEgressAddressesForRelations(
+		s.resources, s.st,
+		params.Entities{Entities: []params.Entity{{
+			Tag: names.NewRelationTag("remote-db2:db django:db").String(),
+		}}})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result.Results, gc.HasLen, 1)
+	c.Assert(result.Results[0].Error, gc.ErrorMatches, "egress network for application db2 without requires endpoint not supported")
+}

--- a/apiserver/common/firewall/package_test.go
+++ b/apiserver/common/firewall/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package firewall_test
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func TestAll(t *testing.T) {
+	gc.TestingT(t)
+}

--- a/apiserver/common/firewall/state.go
+++ b/apiserver/common/firewall/state.go
@@ -1,0 +1,111 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package firewall
+
+import (
+	"github.com/juju/errors"
+
+	"github.com/juju/juju/network"
+	"github.com/juju/juju/state"
+)
+
+// State provides the subset of global state required by the
+// remote firewaller facade.
+type State interface {
+	state.ModelMachinesWatcher
+	state.ModelAccessor
+
+	WatchSubnets(func(id interface{}) bool) state.StringsWatcher
+
+	KeyRelation(string) (Relation, error)
+
+	Unit(string) (Unit, error)
+
+	Machine(string) (Machine, error)
+
+	Application(string) (Application, error)
+}
+
+// TODO(wallyworld) - for tests, remove when remaining firewaller tests become unit tests.
+func StateShim(st *state.State) stateShim {
+	return stateShim{st}
+}
+
+type stateShim struct {
+	*state.State
+}
+
+func (st stateShim) KeyRelation(key string) (Relation, error) {
+	rel, err := st.State.KeyRelation(key)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return relationShim{rel}, nil
+}
+
+type Relation interface {
+	Endpoints() []state.Endpoint
+	WatchUnits(applicationName string) (state.RelationUnitsWatcher, error)
+	UnitInScope(Unit) (bool, error)
+	WatchRelationIngressNetworks() state.StringsWatcher
+}
+
+type relationShim struct {
+	*state.Relation
+}
+
+func (r relationShim) UnitInScope(u Unit) (bool, error) {
+	ru, err := r.Relation.Unit(u.(*state.Unit))
+	if err != nil {
+		return false, errors.Trace(err)
+	}
+	return ru.InScope()
+}
+
+func (st stateShim) Application(name string) (Application, error) {
+	app, err := st.State.Application(name)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return applicationShim{app}, nil
+}
+
+type Application interface {
+	Name() string
+	AllUnits() ([]Unit, error)
+}
+
+type applicationShim struct {
+	*state.Application
+}
+
+func (a applicationShim) AllUnits() (results []Unit, err error) {
+	units, err := a.Application.AllUnits()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	for _, unit := range units {
+		results = append(results, unit)
+	}
+	return results, nil
+}
+
+type Unit interface {
+	Name() string
+	PublicAddress() (network.Address, error)
+	AssignedMachineId() (string, error)
+}
+
+func (st stateShim) Unit(name string) (Unit, error) {
+	return st.State.Unit(name)
+}
+
+type Machine interface {
+	Id() string
+	WatchAddresses() state.NotifyWatcher
+}
+
+func (st stateShim) Machine(id string) (Machine, error) {
+	return st.State.Machine(id)
+}

--- a/apiserver/facades/controller/crossmodelrelations/mock_test.go
+++ b/apiserver/facades/controller/crossmodelrelations/mock_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/juju/juju/apiserver/authentication"
 	common "github.com/juju/juju/apiserver/common/crossmodel"
+	"github.com/juju/juju/apiserver/common/firewall"
 	"github.com/juju/juju/apiserver/facades/controller/crossmodelrelations"
 	"github.com/juju/juju/core/crossmodel"
 	"github.com/juju/juju/state"
@@ -144,6 +145,10 @@ func (st *mockState) Application(id string) (common.Application, error) {
 		return nil, errors.NotFoundf("application %q", id)
 	}
 	return a, nil
+}
+
+type mockFirewallState struct {
+	firewall.State
 }
 
 type mockModel struct {

--- a/apiserver/facades/controller/firewaller/firewaller.go
+++ b/apiserver/facades/controller/firewaller/firewaller.go
@@ -4,15 +4,13 @@
 package firewaller
 
 import (
-	"net"
-
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
-	"gopkg.in/juju/charm.v6-unstable"
 	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/common/cloudspec"
+	"github.com/juju/juju/apiserver/common/firewall"
 	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/network"
@@ -53,7 +51,7 @@ func NewStateFirewallerAPIV3(context facade.Context) (*FirewallerAPIV3, error) {
 	st := context.State()
 	environConfigGetter := stateenvirons.EnvironConfigGetter{st}
 	cloudSpecAPI := cloudspec.NewCloudSpec(environConfigGetter.CloudSpec, common.AuthFuncForTag(st.ModelTag()))
-	return NewFirewallerAPI(stateShim{st}, context.Resources(), context.Auth(), cloudSpecAPI)
+	return NewFirewallerAPI(stateShim{st: st, State: firewall.StateShim(st)}, context.Resources(), context.Auth(), cloudSpecAPI)
 }
 
 // NewStateFirewallerAPIv4 creates a new server-side FirewallerAPIV4 facade.
@@ -382,117 +380,7 @@ func (f *FirewallerAPIV3) getMachine(canAccess common.AuthFunc, tag names.Machin
 // connections will originate for the relation, change.
 // Each event contains the entire set of addresses which are required for ingress for the relation.
 func (f *FirewallerAPIV4) WatchEgressAddressesForRelations(relations params.Entities) (params.StringsWatchResults, error) {
-	results := params.StringsWatchResults{
-		make([]params.StringsWatchResult, len(relations.Entities)),
-	}
-
-	one := func(tag string) (id string, changes []string, _ error) {
-		logger.Debugf("Watching egress addresses for %+v from model %v", tag, f.st.ModelUUID())
-
-		relationTag, err := names.ParseRelationTag(tag)
-		if err != nil {
-			return "", nil, errors.Trace(err)
-		}
-
-		// Load the relation details for the current token.
-		localEndpoint, err := f.localApplication(relationTag)
-		if err != nil {
-			return "", nil, errors.Trace(err)
-		}
-
-		w, err := NewIngressAddressWatcher(f.st, localEndpoint.relation, localEndpoint.application)
-		if err != nil {
-			return "", nil, errors.Trace(err)
-		}
-
-		// TODO(wallyworld) - we will need to watch subnets too, but only
-		// when we support using cloud local addresses
-		//filter := func(id interface{}) bool {
-		//	include, err := includeAsIngressSubnet(id.(string))
-		//	if err != nil {
-		//		logger.Warningf("invalid CIDR %q", id)
-		//	}
-		//	return include
-		//}
-		//w := api.st.WatchSubnets(filter)
-
-		changes, ok := <-w.Changes()
-		if !ok {
-			return "", nil, common.ServerError(watcher.EnsureErr(w))
-		}
-		return f.resources.Register(w), changes, nil
-	}
-
-	for i, e := range relations.Entities {
-		watcherId, changes, err := one(e.Tag)
-		if err != nil {
-			results.Results[i].Error = common.ServerError(err)
-			continue
-		}
-		results.Results[i].StringsWatcherId = watcherId
-		results.Results[i].Changes = changes
-	}
-	return results, nil
-}
-
-type localEndpointInfo struct {
-	relation    Relation
-	application string
-	name        string
-	role        charm.RelationRole
-}
-
-func (f *FirewallerAPIV3) localApplication(relationTag names.RelationTag) (*localEndpointInfo, error) {
-	rel, err := f.st.KeyRelation(relationTag.Id())
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-
-	// Gather info about the local (this model) application of the relation.
-	// We'll use the info to figure out what addresses/subnets to include.
-	localEndpoint := localEndpointInfo{relation: rel}
-	for _, ep := range rel.Endpoints() {
-		// Try looking up the info for the local application.
-		_, err = f.st.Application(ep.ApplicationName)
-		if err != nil && !errors.IsNotFound(err) {
-			return nil, errors.Trace(err)
-		} else if err == nil {
-			localEndpoint.application = ep.ApplicationName
-			localEndpoint.name = ep.Name
-			localEndpoint.role = ep.Role
-			break
-		}
-	}
-	// Until networking support becomes more sophisticated, for now
-	// we only care about opening access to applications with an endpoint
-	// having the "provider" role. The assumption is that such endpoints listen
-	// to incoming connections and thus require ingress. An exception to this
-	// would be applications which accept connections onto an endpoint which
-	// has a "requirer" role.
-	// We are operating in the model hosting the "consuming" application, so check
-	// that its endpoint has the "requirer" role, meaning that we need to notify
-	// the offering model of subnets from this model required for ingress.
-	if localEndpoint.role != charm.RoleRequirer {
-		return nil, errors.NotSupportedf(
-			"egress network for application %v without requires endpoint", localEndpoint.application)
-	}
-	return &localEndpoint, nil
-}
-
-// TODO(wallyworld) - this is unused until we query subnets again
-func includeAsEgressSubnet(cidr string) (bool, error) {
-	ip, _, err := net.ParseCIDR(cidr)
-	if err != nil {
-		return false, errors.Trace(err)
-	}
-	if ip.IsLoopback() || ip.IsMulticast() {
-		return false, nil
-	}
-	// TODO(wallyworld) - We only support IPv4 addresses as not all providers support IPv6.
-	if ip.To4() == nil {
-		return false, nil
-	}
-	return true, nil
+	return firewall.WatchEgressAddressesForRelations(f.resources, f.st, relations)
 }
 
 // WatchIngressAddressesForRelations creates a watcher that returns the ingress networks

--- a/apiserver/facades/controller/firewaller/firewaller_unit_test.go
+++ b/apiserver/facades/controller/firewaller/firewaller_unit_test.go
@@ -6,9 +6,7 @@ package firewaller_test
 import (
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
-	"github.com/juju/utils/set"
 	gc "gopkg.in/check.v1"
-	"gopkg.in/juju/charm.v6-unstable"
 	"gopkg.in/juju/names.v2"
 	"gopkg.in/macaroon.v1"
 
@@ -17,7 +15,6 @@ import (
 	"github.com/juju/juju/apiserver/params"
 	apiservertesting "github.com/juju/juju/apiserver/testing"
 	"github.com/juju/juju/core/crossmodel"
-	"github.com/juju/juju/network"
 	"github.com/juju/juju/state"
 	coretesting "github.com/juju/juju/testing"
 )
@@ -48,91 +45,6 @@ func (s *RemoteFirewallerSuite) SetUpTest(c *gc.C) {
 	api, err := firewaller.NewFirewallerAPI(s.st, s.resources, s.authorizer, &mockCloudSpecAPI{})
 	c.Assert(err, jc.ErrorIsNil)
 	s.api = &firewaller.FirewallerAPIV4{FirewallerAPIV3: api, ControllerConfigAPI: common.NewControllerConfig(s.st)}
-}
-
-func (s *RemoteFirewallerSuite) TestWatchEgressAddressesForRelations(c *gc.C) {
-	db2Relation := newMockRelation(123)
-	db2Relation.ruwApp = "django"
-	db2Relation.endpoints = []state.Endpoint{
-		{
-			ApplicationName: "django",
-			Relation: charm.Relation{
-				Name:      "db",
-				Interface: "db2",
-				Role:      "requirer",
-				Limit:     1,
-				Scope:     charm.ScopeGlobal,
-			},
-		},
-	}
-	db2Relation.inScope = set.NewStrings("django/0", "django/1")
-	s.st.relations["remote-db2:db django:db"] = db2Relation
-	s.st.remoteEntities[names.NewRelationTag("remote-db2:db django:db")] = "token-db2:db django:db"
-
-	unit := newMockUnit("django/0")
-	unit.publicAddress = network.NewScopedAddress("1.2.3.4", network.ScopePublic)
-	unit.machineId = "0"
-	s.st.units["django/0"] = unit
-	unit1 := newMockUnit("django/1")
-	unit1.publicAddress = network.NewScopedAddress("4.3.2.1", network.ScopePublic)
-	unit1.machineId = "1"
-	s.st.units["django/1"] = unit1
-	s.st.machines["0"] = newMockMachine("0")
-	s.st.machines["1"] = newMockMachine("1")
-	app := newMockApplication("django")
-	app.units = []*mockUnit{unit, unit1}
-	s.st.applications["django"] = app
-
-	result, err := s.api.WatchEgressAddressesForRelations(
-		params.Entities{Entities: []params.Entity{{
-			Tag: names.NewRelationTag("remote-db2:db django:db").String(),
-		}}})
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(result.Results, gc.HasLen, 1)
-	c.Assert(result.Results[0].Changes, jc.SameContents, []string{"1.2.3.4/32", "4.3.2.1/32"})
-	c.Assert(result.Results[0].Error, gc.IsNil)
-	c.Assert(result.Results[0].StringsWatcherId, gc.Equals, "1")
-
-	resource := s.resources.Get("1")
-	c.Assert(resource, gc.NotNil)
-	c.Assert(resource, gc.Implements, new(state.StringsWatcher))
-
-	s.st.CheckCalls(c, []testing.StubCall{
-		{"KeyRelation", []interface{}{"remote-db2:db django:db"}},
-		{"Application", []interface{}{"django"}},
-		{"Application", []interface{}{"django"}},
-		{"Machine", []interface{}{"0"}},
-		{"Machine", []interface{}{"1"}},
-	})
-}
-
-func (s *RemoteFirewallerSuite) TestWatchEgressAddressesForRelationsIgnoresProvider(c *gc.C) {
-	db2Relation := newMockRelation(123)
-	db2Relation.endpoints = []state.Endpoint{
-		{
-			ApplicationName: "db2",
-			Relation: charm.Relation{
-				Name:      "data",
-				Interface: "db2",
-				Role:      "provider",
-				Limit:     1,
-				Scope:     charm.ScopeGlobal,
-			},
-		},
-	}
-
-	s.st.relations["remote-db2:db django:db"] = db2Relation
-	app := newMockApplication("db2")
-	s.st.applications["db2"] = app
-	s.st.remoteEntities[names.NewRelationTag("remote-db2:db django:db")] = "token-db2:db django:db"
-
-	result, err := s.api.WatchEgressAddressesForRelations(
-		params.Entities{Entities: []params.Entity{{
-			Tag: names.NewRelationTag("remote-db2:db django:db").String(),
-		}}})
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(result.Results, gc.HasLen, 1)
-	c.Assert(result.Results[0].Error, gc.ErrorMatches, "egress network for application db2 without requires endpoint not supported")
 }
 
 func (s *RemoteFirewallerSuite) TestWatchIngressAddressesForRelations(c *gc.C) {

--- a/apiserver/facades/controller/firewaller/state.go
+++ b/apiserver/facades/controller/firewaller/state.go
@@ -4,35 +4,21 @@
 package firewaller
 
 import (
-	"github.com/juju/errors"
 	"gopkg.in/juju/names.v2"
 	"gopkg.in/macaroon.v1"
 
-	"github.com/juju/juju/network"
+	"github.com/juju/juju/apiserver/common/firewall"
 	"github.com/juju/juju/state"
 )
 
 // State provides the subset of global state required by the
 // remote firewaller facade.
 type State interface {
-	state.ModelMachinesWatcher
-	state.ModelAccessor
+	firewall.State
 
 	ModelUUID() string
 
-	WatchSubnets(func(id interface{}) bool) state.StringsWatcher
-
-	GetRemoteEntity(model names.ModelTag, token string) (names.Tag, error)
-
 	GetMacaroon(model names.ModelTag, entity names.Tag) (*macaroon.Macaroon, error)
-
-	KeyRelation(string) (Relation, error)
-
-	Application(string) (Application, error)
-
-	Unit(string) (Unit, error)
-
-	Machine(string) (Machine, error)
 
 	WatchOpenedPorts() state.StringsWatcher
 
@@ -41,93 +27,27 @@ type State interface {
 
 // TODO(wallyworld) - for tests, remove when remaining firewaller tests become unit tests.
 func StateShim(st *state.State) stateShim {
-	return stateShim{st}
+	return stateShim{st: st, State: firewall.StateShim(st)}
 }
 
 type stateShim struct {
-	*state.State
+	firewall.State
+	st *state.State
 }
 
-func (st stateShim) GetRemoteEntity(model names.ModelTag, token string) (names.Tag, error) {
-	r := st.State.RemoteEntities()
-	return r.GetRemoteEntity(model, token)
+func (st stateShim) ModelUUID() string {
+	return st.st.ModelUUID()
 }
 
 func (st stateShim) GetMacaroon(model names.ModelTag, entity names.Tag) (*macaroon.Macaroon, error) {
-	r := st.State.RemoteEntities()
+	r := st.st.RemoteEntities()
 	return r.GetMacaroon(model, entity)
 }
 
-func (st stateShim) KeyRelation(key string) (Relation, error) {
-	rel, err := st.State.KeyRelation(key)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	return relationShim{rel}, nil
+func (st stateShim) FindEntity(tag names.Tag) (state.Entity, error) {
+	return st.st.FindEntity(tag)
 }
 
-type Relation interface {
-	Endpoints() []state.Endpoint
-	WatchUnits(applicationName string) (state.RelationUnitsWatcher, error)
-	UnitInScope(Unit) (bool, error)
-	WatchRelationIngressNetworks() state.StringsWatcher
-}
-
-type relationShim struct {
-	*state.Relation
-}
-
-func (r relationShim) UnitInScope(u Unit) (bool, error) {
-	ru, err := r.Relation.Unit(u.(*state.Unit))
-	if err != nil {
-		return false, errors.Trace(err)
-	}
-	return ru.InScope()
-}
-
-func (st stateShim) Application(name string) (Application, error) {
-	app, err := st.State.Application(name)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	return applicationShim{app}, nil
-}
-
-type Application interface {
-	Name() string
-	AllUnits() ([]Unit, error)
-}
-
-type applicationShim struct {
-	*state.Application
-}
-
-func (a applicationShim) AllUnits() (results []Unit, err error) {
-	units, err := a.Application.AllUnits()
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	for _, unit := range units {
-		results = append(results, unit)
-	}
-	return results, nil
-}
-
-type Unit interface {
-	Name() string
-	PublicAddress() (network.Address, error)
-	AssignedMachineId() (string, error)
-}
-
-func (st stateShim) Unit(name string) (Unit, error) {
-	return st.State.Unit(name)
-}
-
-type Machine interface {
-	Id() string
-	WatchAddresses() state.NotifyWatcher
-}
-
-func (st stateShim) Machine(id string) (Machine, error) {
-	return st.State.Machine(id)
+func (st stateShim) WatchOpenedPorts() state.StringsWatcher {
+	return st.st.WatchOpenedPorts()
 }

--- a/apiserver/restrict_anonymous.go
+++ b/apiserver/restrict_anonymous.go
@@ -16,6 +16,7 @@ import (
 var anonymousFacadeNames = set.NewStrings(
 	"CrossModelRelations",
 	"RelationUnitsWatcher",
+	"StringsWatcher",
 )
 
 func anonymousFacadesOnly(facadeName, _ string) error {

--- a/apiserver/watcher.go
+++ b/apiserver/watcher.go
@@ -140,7 +140,9 @@ func newStringsWatcher(context facade.Context) (facade.Facade, error) {
 	auth := context.Auth()
 	resources := context.Resources()
 
-	if !isAgent(auth) {
+	// TODO(wallyworld) - enhance this watcher to support
+	// anonymous api calls with macaroons.
+	if auth.GetAuthTag() != nil && !isAgent(auth) {
 		return nil, common.ErrPerm
 	}
 	watcher, ok := resources.Get(id).(state.StringsWatcher)

--- a/cmd/juju/crossmodel/offer.go
+++ b/cmd/juju/crossmodel/offer.go
@@ -87,9 +87,6 @@ func (c *offerCommand) Init(args []string) error {
 		argCount = 2
 		c.OfferName = args[1]
 	}
-	if c.OfferName == "" {
-		c.OfferName = c.Application
-	}
 	return cmd.CheckEmpty(args[argCount:])
 }
 
@@ -138,6 +135,9 @@ func (c *offerCommand) Run(ctx *cmd.Context) error {
 		return errors.Annotate(err, "getting model details")
 	}
 
+	if c.OfferName == "" {
+		c.OfferName = c.Application
+	}
 	// TODO (anastasiamac 2015-11-16) Add a sensible way for user to specify long-ish (at times) description when offering
 	results, err := api.Offer(modelDetails.ModelUUID, c.Application, c.Endpoints, c.OfferName, "")
 	if err != nil {


### PR DESCRIPTION
## Description of change

When the consuming side of a cross model relation has the provider role, different firewaller logic is needed. A new cross model watcher API (WatchEgressAddressesForRelation) is added to allow the firewaller worker on the consuming side to watch for egress address changes on the offer side.

Most of the diff in this PR is moving existing firewaller facade logic into a new common package so it can be shared between the firewaller and cross model facades.

Also includes a drive by fix for the output of the offer command.

## QA steps

Deploy prometheus and offer it.
Deploy telegraf in another model and relate.
Check that the telegraf model has firewall ports opened for port 9103 (telegraf port)

