### PR TITLE
CI: Change use of SSH to run as jenkins had issues with it.

### DIFF
--- a/acceptancetests/assess_primary_sub_relations.py
+++ b/acceptancetests/assess_primary_sub_relations.py
@@ -180,8 +180,10 @@ def assert_subordinate_unit_operational(client, primary_app_name):
     primary_unit = '{}/0'.format(primary_app_name)
     try:
         client.juju(
-            'ssh',
-            (primary_unit, 'sudo', 'service', sub_unit_name, 'status'))
+            'run',
+            (
+                '--unit', primary_unit,
+                'sudo', 'service', sub_unit_name, 'status'))
     except subprocess.CalledProcessError:
         raise JujuAssertionError('Subordinate charm unit not running.')
 


### PR DESCRIPTION
Update recent primary/sub relations test to use 'juju run' instead of 'juju ssh' due to jenkins terminal choking on it.
I've run this test and it succeeds.