### PR TITLE
Fixes lp#1699607 - panic in 'juju charm resources'.

### DIFF
--- a/resource/cmd/export_test.go
+++ b/resource/cmd/export_test.go
@@ -1,7 +1,11 @@
 package cmd
 
-func ListCharmResourcesCommandChannel(c *ListCharmResourcesCommand) string {
-	return c.channel
+import (
+	"github.com/juju/juju/cmd/modelcmd"
+)
+
+func ListCharmResourcesCommandChannel(c modelcmd.Command) string {
+	return modelcmd.InnerCommand(c).(*ListCharmResourcesCommand).channel
 }
 
 func ShowServiceCommandTarget(c *ShowServiceCommand) string {
@@ -19,3 +23,7 @@ func UploadCommandService(c *UploadCommand) string {
 }
 
 var FormatServiceResources = formatServiceResources
+
+func SetResourceLister(c modelcmd.Command, lister ResourceLister) {
+	modelcmd.InnerCommand(c).(*ListCharmResourcesCommand).resourceLister = lister
+}

--- a/resource/cmd/list_charm_resources.go
+++ b/resource/cmd/list_charm_resources.go
@@ -24,10 +24,9 @@ type ResourceLister interface {
 type ListCharmResourcesCommand struct {
 	modelcmd.ModelCommandBase
 
-	// ResourceLister is called by Run to list charm resources. The
-	// default implementation uses juju/juju/charmstore.Client, but
-	// it may be set to mock out the call to that method.
-	ResourceLister ResourceLister
+	// resourceLister is called by Run to list charm resources and
+	// uses juju/juju/charmstore.Client.
+	resourceLister ResourceLister
 
 	out     cmd.Output
 	channel string
@@ -36,10 +35,10 @@ type ListCharmResourcesCommand struct {
 
 // NewListCharmResourcesCommand returns a new command that lists resources defined
 // by a charm.
-func NewListCharmResourcesCommand() *ListCharmResourcesCommand {
+func NewListCharmResourcesCommand() modelcmd.ModelCommand {
 	var c ListCharmResourcesCommand
-	c.ResourceLister = &c
-	return &c
+	c.resourceLister = &c
+	return modelcmd.Wrap(&c)
 }
 
 var listCharmResourcesDoc = `
@@ -109,7 +108,7 @@ func (c *ListCharmResourcesCommand) Run(ctx *cmd.Context) error {
 		charms[i] = charmstore.CharmID{URL: id, Channel: csparams.Channel(c.channel)}
 	}
 
-	resources, err := c.ResourceLister.ListResources(charms)
+	resources, err := c.resourceLister.ListResources(charms)
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/resource/cmd/list_charm_resources_test.go
+++ b/resource/cmd/list_charm_resources_test.go
@@ -70,7 +70,7 @@ func (s *ListCharmSuite) TestOkay(c *gc.C) {
 	s.client.ReturnListResources = [][]charmresource.Resource{resources}
 
 	command := resourcecmd.NewListCharmResourcesCommand()
-	command.ResourceLister = s.client
+	resourcecmd.SetResourceLister(command, s.client)
 	code, stdout, stderr := runCmd(c, command, "cs:a-charm")
 	c.Check(code, gc.Equals, 0)
 
@@ -96,7 +96,7 @@ func (s *ListCharmSuite) TestNoResources(c *gc.C) {
 	s.client.ReturnListResources = [][]charmresource.Resource{{}}
 
 	command := resourcecmd.NewListCharmResourcesCommand()
-	command.ResourceLister = s.client
+	resourcecmd.SetResourceLister(command, s.client)
 	code, stdout, stderr := runCmd(c, command, "cs:a-charm")
 	c.Check(code, gc.Equals, 0)
 
@@ -168,7 +168,7 @@ music     1
 	for format, expected := range formats {
 		c.Logf("checking format %q", format)
 		command := resourcecmd.NewListCharmResourcesCommand()
-		command.ResourceLister = s.client
+		resourcecmd.SetResourceLister(command, s.client)
 		args := []string{
 			"--format", format,
 			"cs:a-charm",
@@ -192,7 +192,7 @@ func (s *ListCharmSuite) TestChannelFlag(c *gc.C) {
 	}
 	s.client.ReturnListResources = [][]charmresource.Resource{resources}
 	command := resourcecmd.NewListCharmResourcesCommand()
-	command.ResourceLister = s.client
+	resourcecmd.SetResourceLister(command, s.client)
 
 	code, _, stderr := runCmd(c, command,
 		"--channel", "development",


### PR DESCRIPTION
## Description of change

This command was omitted in a general sweep in commit titled "per-controller cookie jars", https://github.com/juju/juju/commit/de037523650be86f5eed2785de2c3efa829970af

This command escaped notice most likely because it is not under the main cmd directory. However, it also needs to be wrapped as per model cmd infrastructure.

Note that other commands in this directory, 'juju attach' and 'juju resources' (for an application or a unit), do not require this fix as they are wrapped further down in the pipeline.

## QA steps

'juju charm resources' does not panic when called.

## Documentation changes

n/a

## Bug reference

https://bugs.launchpad.net/juju/+bug/1699607
