### PR TITLE
provider/vsphere: add network configuration

### DIFF
--- a/provider/vsphere/config.go
+++ b/provider/vsphere/config.go
@@ -12,6 +12,7 @@ import (
 
 // The vmware-specific config keys.
 const (
+	cfgPrimaryNetwork  = "primary-network"
 	cfgExternalNetwork = "external-network"
 	cfgDatastore       = "datastore"
 )
@@ -21,11 +22,13 @@ var (
 	configFields = schema.Fields{
 		cfgExternalNetwork: schema.String(),
 		cfgDatastore:       schema.String(),
+		cfgPrimaryNetwork:  schema.String(),
 	}
 
 	configDefaults = schema.Defaults{
 		cfgExternalNetwork: "",
 		cfgDatastore:       schema.Omit,
+		cfgPrimaryNetwork:  schema.Omit,
 	}
 
 	configRequiredFields  = []string{}
@@ -82,6 +85,11 @@ func (c *environConfig) externalNetwork() string {
 func (c *environConfig) datastore() string {
 	ds, _ := c.attrs[cfgDatastore].(string)
 	return ds
+}
+
+func (c *environConfig) primaryNetwork() string {
+	network, _ := c.attrs[cfgPrimaryNetwork].(string)
+	return network
 }
 
 // validate checks vmware-specific config values.

--- a/provider/vsphere/environ_broker.go
+++ b/provider/vsphere/environ_broker.go
@@ -187,6 +187,7 @@ func (env *sessionEnviron) newRawInstance(
 		UserData:               string(userData),
 		Metadata:               args.InstanceConfig.Tags,
 		Constraints:            cons,
+		PrimaryNetwork:         env.ecfg.primaryNetwork(),
 		ExternalNetwork:        externalNetwork,
 		Datastore:              env.ecfg.datastore(),
 		UpdateProgress:         updateProgress,

--- a/provider/vsphere/environ_broker_test.go
+++ b/provider/vsphere/environ_broker_test.go
@@ -131,6 +131,27 @@ func (s *environBrokerSuite) TestStartInstance(c *gc.C) {
 	})
 }
 
+func (s *environBrokerSuite) TestStartInstanceNetwork(c *gc.C) {
+	env, err := s.provider.Open(environs.OpenParams{
+		Cloud: fakeCloudSpec(),
+		Config: fakeConfig(c, coretesting.Attrs{
+			"primary-network":    "foo",
+			"external-network":   "bar",
+			"image-metadata-url": s.imageServer.URL,
+		}),
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	result, err := env.StartInstance(s.createStartInstanceArgs(c))
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result, gc.NotNil)
+
+	call := s.client.Calls()[1]
+	createVMArgs := call.Args[1].(vsphereclient.CreateVirtualMachineParams)
+	c.Assert(createVMArgs.PrimaryNetwork, gc.Equals, "foo")
+	c.Assert(createVMArgs.ExternalNetwork, gc.Equals, "bar")
+}
+
 func (s *environBrokerSuite) TestStartInstanceLongModelName(c *gc.C) {
 	env, err := s.provider.Open(environs.OpenParams{
 		Cloud: fakeCloudSpec(),
@@ -139,6 +160,7 @@ func (s *environBrokerSuite) TestStartInstanceLongModelName(c *gc.C) {
 			"image-metadata-url": s.imageServer.URL,
 		}),
 	})
+	c.Assert(err, jc.ErrorIsNil)
 	startInstArgs := s.createStartInstanceArgs(c)
 	_, err = env.StartInstance(startInstArgs)
 	c.Assert(err, jc.ErrorIsNil)

--- a/provider/vsphere/internal/vsphereclient/client_test.go
+++ b/provider/vsphere/internal/vsphereclient/client_test.go
@@ -223,6 +223,59 @@ func (s *clientSuite) SetUpTest(c *gc.C) {
 				{Name: "summary.accessible", Val: true},
 			},
 		}},
+		"network-0": []types.ObjectContent{{
+			Obj: types.ManagedObjectReference{
+				Type:  "Network",
+				Value: "network-0",
+			},
+			PropSet: []types.DynamicProperty{
+				{Name: "name", Val: "VM Network"},
+			},
+		}},
+		"network-1": []types.ObjectContent{{
+			Obj: types.ManagedObjectReference{
+				Type:  "Network",
+				Value: "network-1",
+			},
+			PropSet: []types.DynamicProperty{
+				{Name: "name", Val: "zing"},
+			},
+		}},
+		"onetwork-0": []types.ObjectContent{{
+			Obj: types.ManagedObjectReference{
+				Type:  "OpaqueNetwork",
+				Value: "onetwork-0",
+			},
+			PropSet: []types.DynamicProperty{
+				{Name: "name", Val: "arpa"},
+			},
+		}},
+		"dvportgroup-0": []types.ObjectContent{{
+			Obj: types.ManagedObjectReference{
+				Type:  "DistributedVirtualPortgroup",
+				Value: "dvportgroup-0",
+			},
+			PropSet: []types.DynamicProperty{
+				{Name: "name", Val: "yoink"},
+				{Name: "config.key", Val: "hole"},
+				{
+					Name: "config.distributedVirtualSwitch",
+					Val: types.ManagedObjectReference{
+						Type:  "DistributedVirtualSwitch",
+						Value: "dvs-0",
+					},
+				},
+			},
+		}},
+		"dvs-0": []types.ObjectContent{{
+			Obj: types.ManagedObjectReference{
+				Type:  "DistributedVirtualSwitch",
+				Value: "dvs-0",
+			},
+			PropSet: []types.DynamicProperty{
+				{Name: "uuid", Val: "yup"},
+			},
+		}},
 	}
 
 	// Create an HTTP server to receive image uploads.

--- a/provider/vsphere/internal/vsphereclient/mock_test.go
+++ b/provider/vsphere/internal/vsphereclient/mock_test.go
@@ -87,7 +87,7 @@ func (r *mockRoundTripper) RoundTrip(ctx context.Context, req, res soap.HasFault
 		res.Res = &types.CreateFolderResponse{}
 	case *methods.CreateImportSpecBody:
 		req := req.(*methods.CreateImportSpecBody).Req
-		r.MethodCall(r, "CreateImportSpec", req.OvfDescriptor, req.Datastore)
+		r.MethodCall(r, "CreateImportSpec", req.OvfDescriptor, req.Datastore, req.Cisp)
 		res.Res = &types.CreateImportSpecResponse{
 			types.OvfCreateImportSpecResult{
 				FileItem: []types.OvfFileItem{
@@ -101,7 +101,8 @@ func (r *mockRoundTripper) RoundTrip(ctx context.Context, req, res soap.HasFault
 			},
 		}
 	case *methods.ImportVAppBody:
-		r.MethodCall(r, "ImportVApp")
+		req := req.(*methods.ImportVAppBody).Req
+		r.MethodCall(r, "ImportVApp", req.Spec)
 		res.Res = &types.ImportVAppResponse{lease}
 	case *methods.CreatePropertyCollectorBody:
 		r.MethodCall(r, "CreatePropertyCollector")


### PR DESCRIPTION
Add a "primary-network" config attribute to the vsphere
provider. When bootstrapping or adding a model, the
user can set this to the name of the primary network that
VMs will be connected to. This will override the default
"VM Network" specified by the Ubuntu images' OVF files.

Backport from develop.

Fixes https://bugs.launchpad.net/bugs/1619812