### PR TITLE
Fix removing and adding a remote relation

### DIFF
--- a/api/remoterelations/remoterelations.go
+++ b/api/remoterelations/remoterelations.go
@@ -109,26 +109,6 @@ func (c *Client) SaveMacaroon(entity names.Tag, mac *macaroon.Macaroon) error {
 	return nil
 }
 
-// RemoveRemoteEntity removes the specified entity from the remote entities collection.
-func (c *Client) RemoveRemoteEntity(sourceModelUUID string, entity names.Tag) error {
-	args := params.RemoteEntityArgs{Args: []params.RemoteEntityArg{
-		{ModelTag: names.NewModelTag(sourceModelUUID).String(), Tag: entity.String()}},
-	}
-	var results params.ErrorResults
-	err := c.facade.FacadeCall("RemoveRemoteEntities", args, &results)
-	if err != nil {
-		return errors.Trace(err)
-	}
-	if len(results.Results) != 1 {
-		return errors.Errorf("expected 1 result, got %d", len(results.Results))
-	}
-	result := results.Results[0]
-	if result.Error != nil {
-		return errors.Trace(result.Error)
-	}
-	return nil
-}
-
 // RelationUnitSettings returns the relation unit settings for the given relation units in the local model.
 func (c *Client) RelationUnitSettings(relationUnits []params.RelationUnit) ([]params.SettingsResult, error) {
 	args := params.RelationUnits{relationUnits}

--- a/api/remoterelations/remoterelations_test.go
+++ b/api/remoterelations/remoterelations_test.go
@@ -340,45 +340,6 @@ func (s *remoteRelationsSuite) TestImportRemoteEntityCount(c *gc.C) {
 	c.Check(err, gc.ErrorMatches, `expected 1 result, got 2`)
 }
 
-func (s *remoteRelationsSuite) TestRemoveRemoteEntity(c *gc.C) {
-	var callCount int
-	apiCaller := testing.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
-		c.Check(objType, gc.Equals, "RemoteRelations")
-		c.Check(version, gc.Equals, 0)
-		c.Check(id, gc.Equals, "")
-		c.Check(request, gc.Equals, "RemoveRemoteEntities")
-		c.Check(arg, gc.DeepEquals, params.RemoteEntityArgs{
-			Args: []params.RemoteEntityArg{{ModelTag: coretesting.ModelTag.String(), Tag: "application-app"}}})
-		c.Assert(result, gc.FitsTypeOf, &params.ErrorResults{})
-		*(result.(*params.ErrorResults)) = params.ErrorResults{
-			Results: []params.ErrorResult{{
-				Error: &params.Error{Message: "FAIL"},
-			}},
-		}
-		callCount++
-		return nil
-	})
-	client := remoterelations.NewClient(apiCaller)
-	err := client.RemoveRemoteEntity(coretesting.ModelTag.Id(), names.NewApplicationTag("app"))
-	c.Check(err, gc.ErrorMatches, "FAIL")
-	c.Check(callCount, gc.Equals, 1)
-}
-
-func (s *remoteRelationsSuite) TestRemoveRemoteEntityCount(c *gc.C) {
-	apiCaller := testing.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
-		*(result.(*params.ErrorResults)) = params.ErrorResults{
-			Results: []params.ErrorResult{
-				{Error: &params.Error{Message: "FAIL"}},
-				{Error: &params.Error{Message: "FAIL"}},
-			},
-		}
-		return nil
-	})
-	client := remoterelations.NewClient(apiCaller)
-	err := client.RemoveRemoteEntity(coretesting.ModelTag.Id(), names.NewApplicationTag("app"))
-	c.Check(err, gc.ErrorMatches, `expected 1 result, got 2`)
-}
-
 func (s *remoteRelationsSuite) TestWatchRemoteRelations(c *gc.C) {
 	var callCount int
 	apiCaller := testing.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {

--- a/apiserver/common/crossmodel/crossmodel.go
+++ b/apiserver/common/crossmodel/crossmodel.go
@@ -33,7 +33,8 @@ func PublishRelationChange(backend Backend, relationTag names.Tag, change params
 
 	// Look up the application on the remote side of this relation
 	// ie from the model which published this change.
-	applicationTag, err := getRemoteEntityTag(backend, change.ApplicationId)
+	applicationTag, err := backend.GetRemoteEntity(
+		names.NewModelTag(change.ApplicationId.ModelUUID), change.ApplicationId.Token)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -108,11 +109,6 @@ func PublishRelationChange(backend Backend, relationTag names.Tag, change params
 		}
 	}
 	return nil
-}
-
-func getRemoteEntityTag(backend Backend, id params.RemoteEntityId) (names.Tag, error) {
-	modelTag := names.NewModelTag(id.ModelUUID)
-	return backend.GetRemoteEntity(modelTag, id.Token)
 }
 
 // WatchRelationUnits returns a watcher for changes to the units on the specified relation.

--- a/apiserver/facades/controller/crossmodelrelations/crossmodelrelations.go
+++ b/apiserver/facades/controller/crossmodelrelations/crossmodelrelations.go
@@ -90,7 +90,7 @@ func (api *CrossModelRelationsAPI) PublishRelationChanges(
 		Results: make([]params.ErrorResult, len(changes.Changes)),
 	}
 	for i, change := range changes.Changes {
-		relationTag, err := api.st.GetRemoteEntity(names.NewModelTag(change.RelationId.ModelUUID), change.RelationId.Token)
+		relationTag, err := api.st.GetRemoteEntity(names.NewModelTag(api.st.ModelUUID()), change.RelationId.Token)
 		if err != nil {
 			if errors.IsNotFound(err) {
 				logger.Debugf("no relation tag %+v in model %v, exit early", change.RelationId, api.st.ModelUUID())
@@ -253,7 +253,7 @@ func (api *CrossModelRelationsAPI) registerRemoteRelation(relation params.Regist
 	logger.Debugf("importing remote relation into model %v", api.st.ModelUUID())
 	logger.Debugf("remote model is %v", remoteModelTag.Id())
 
-	err = api.st.ImportRemoteEntity(remoteModelTag, localRel.Tag(), relation.RelationId.Token)
+	err = api.st.ImportRemoteEntity(names.NewModelTag(api.st.ModelUUID()), localRel.Tag(), relation.RelationId.Token)
 	if err != nil && !errors.IsAlreadyExists(err) {
 		return nil, errors.Annotatef(err, "importing remote relation %v to local model", localRel.Tag().Id())
 	}
@@ -297,7 +297,7 @@ func (api *CrossModelRelationsAPI) WatchRelationUnits(remoteRelationArgs params.
 		Results: make([]params.RelationUnitsWatchResult, len(remoteRelationArgs.Args)),
 	}
 	for i, arg := range remoteRelationArgs.Args {
-		relationTag, err := api.st.GetRemoteEntity(names.NewModelTag(arg.ModelUUID), arg.Token)
+		relationTag, err := api.st.GetRemoteEntity(names.NewModelTag(api.st.ModelUUID()), arg.Token)
 		if err != nil {
 			results.Results[i].Error = common.ServerError(err)
 			continue
@@ -328,7 +328,7 @@ func (api *CrossModelRelationsAPI) RelationUnitSettings(relationUnits params.Rem
 		Results: make([]params.SettingsResult, len(relationUnits.RelationUnits)),
 	}
 	for i, arg := range relationUnits.RelationUnits {
-		relationTag, err := api.st.GetRemoteEntity(names.NewModelTag(arg.RelationId.ModelUUID), arg.RelationId.Token)
+		relationTag, err := api.st.GetRemoteEntity(names.NewModelTag(api.st.ModelUUID()), arg.RelationId.Token)
 		if err != nil {
 			results.Results[i].Error = common.ServerError(err)
 			continue
@@ -361,7 +361,7 @@ func (api *CrossModelRelationsAPI) PublishIngressNetworkChanges(
 		Results: make([]params.ErrorResult, len(changes.Changes)),
 	}
 	for i, change := range changes.Changes {
-		relationTag, err := api.st.GetRemoteEntity(names.NewModelTag(change.RelationId.ModelUUID), change.RelationId.Token)
+		relationTag, err := api.st.GetRemoteEntity(names.NewModelTag(api.st.ModelUUID()), change.RelationId.Token)
 		if err != nil {
 			results.Results[i].Error = common.ServerError(err)
 			continue
@@ -389,7 +389,7 @@ func (api *CrossModelRelationsAPI) WatchEgressAddressesForRelations(remoteRelati
 	}
 	var relations params.Entities
 	for i, arg := range remoteRelationArgs.Args {
-		relationTag, err := api.st.GetRemoteEntity(names.NewModelTag(arg.ModelUUID), arg.Token)
+		relationTag, err := api.st.GetRemoteEntity(names.NewModelTag(api.st.ModelUUID()), arg.Token)
 		if err != nil {
 			results.Results[i].Error = common.ServerError(err)
 			continue

--- a/apiserver/facades/controller/crossmodelrelations/crossmodelrelations_test.go
+++ b/apiserver/facades/controller/crossmodelrelations/crossmodelrelations_test.go
@@ -103,7 +103,7 @@ func (s *crossmodelRelationsSuite) TestPublishRelationsChanges(c *gc.C) {
 	err = results.Combine()
 	c.Assert(err, jc.ErrorIsNil)
 	s.st.CheckCalls(c, []testing.StubCall{
-		{"GetRemoteEntity", []interface{}{names.NewModelTag("uuid"), "token-db2:db django:db"}},
+		{"GetRemoteEntity", []interface{}{names.NewModelTag(s.st.ModelUUID()), "token-db2:db django:db"}},
 		{"KeyRelation", []interface{}{"db2:db django:db"}},
 		{"GetRemoteEntity", []interface{}{names.NewModelTag("uuid"), "token-db2"}},
 	})
@@ -231,7 +231,7 @@ func (s *crossmodelRelationsSuite) TestPublishIngressNetworkChanges(c *gc.C) {
 	err = results.Combine()
 	c.Assert(err, jc.ErrorIsNil)
 	s.st.CheckCalls(c, []testing.StubCall{
-		{"GetRemoteEntity", []interface{}{names.NewModelTag("uuid"), "token-db2:db django:db"}},
+		{"GetRemoteEntity", []interface{}{names.NewModelTag(s.st.ModelUUID()), "token-db2:db django:db"}},
 		{"KeyRelation", []interface{}{"db2:db django:db"}},
 	})
 	// TODO(wallyworld) - add mre tests when implementation finished
@@ -278,9 +278,9 @@ func (s *crossmodelRelationsSuite) TestWatchEgressAddressesForRelations(c *gc.C)
 		Entities: []params.Entity{{Tag: "relation-db2.db#django.db"}}},
 	)
 	s.st.CheckCalls(c, []testing.StubCall{
-		{"GetRemoteEntity", []interface{}{names.NewModelTag(uuid), "token-mysql:db django:db"}},
+		{"GetRemoteEntity", []interface{}{names.NewModelTag(s.st.ModelUUID()), "token-mysql:db django:db"}},
 		{"GetRemoteEntity", []interface{}{names.NewModelTag(s.st.ModelUUID()), "token-db2:db django:db"}},
-		{"GetRemoteEntity", []interface{}{names.NewModelTag(uuid), "token-postgresql:db django:db"}},
+		{"GetRemoteEntity", []interface{}{names.NewModelTag(s.st.ModelUUID()), "token-postgresql:db django:db"}},
 	})
 	// TODO(wallyworld) - add mre tests when implementation finished
 }

--- a/apiserver/facades/controller/remoterelations/remoterelations.go
+++ b/apiserver/facades/controller/remoterelations/remoterelations.go
@@ -101,30 +101,6 @@ func (api *RemoteRelationsAPI) ExportEntities(entities params.Entities) (params.
 	return results, nil
 }
 
-// RemoveRemoteEntities removes the specified entities from the remote entities collection.
-func (api *RemoteRelationsAPI) RemoveRemoteEntities(args params.RemoteEntityArgs) (params.ErrorResults, error) {
-	results := params.ErrorResults{
-		Results: make([]params.ErrorResult, len(args.Args)),
-	}
-	for i, arg := range args.Args {
-		err := api.removeRemoteEntity(arg)
-		results.Results[i].Error = common.ServerError(err)
-	}
-	return results, nil
-}
-
-func (api *RemoteRelationsAPI) removeRemoteEntity(arg params.RemoteEntityArg) error {
-	entityTag, err := names.ParseTag(arg.Tag)
-	if err != nil {
-		return errors.Trace(err)
-	}
-	modelTag, err := names.ParseModelTag(arg.ModelTag)
-	if err != nil {
-		return errors.Trace(err)
-	}
-	return api.st.RemoveRemoteEntity(modelTag, entityTag)
-}
-
 // GetTokens returns the token associated with the entities with the given tags for the given models.
 func (api *RemoteRelationsAPI) GetTokens(args params.GetTokenArgs) (params.StringResults, error) {
 	results := params.StringResults{
@@ -421,7 +397,7 @@ func (api *RemoteRelationsAPI) ConsumeRemoteRelationChange(
 		Results: make([]params.ErrorResult, len(changes.Changes)),
 	}
 	for i, change := range changes.Changes {
-		relationTag, err := api.st.GetRemoteEntity(names.NewModelTag(change.RelationId.ModelUUID), change.RelationId.Token)
+		relationTag, err := api.st.GetRemoteEntity(names.NewModelTag(api.st.ModelUUID()), change.RelationId.Token)
 		if err != nil {
 			if errors.IsNotFound(err) {
 				continue

--- a/apiserver/facades/controller/remoterelations/remoterelations_test.go
+++ b/apiserver/facades/controller/remoterelations/remoterelations_test.go
@@ -195,19 +195,6 @@ func (s *remoteRelationsSuite) TestImportRemoteEntitiesTwice(c *gc.C) {
 	})
 }
 
-func (s *remoteRelationsSuite) TestRemoveRemoteEntities(c *gc.C) {
-	result, err := s.api.RemoveRemoteEntities(params.RemoteEntityArgs{
-		Args: []params.RemoteEntityArg{
-			{ModelTag: coretesting.ModelTag.String(), Tag: "application-django"},
-		}})
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(result.Results, gc.HasLen, 1)
-	c.Assert(result.Results[0], jc.DeepEquals, params.ErrorResult{})
-	s.st.CheckCalls(c, []testing.StubCall{
-		{"RemoveRemoteEntity", []interface{}{coretesting.ModelTag, names.ApplicationTag{Name: "django"}}},
-	})
-}
-
 func (s *remoteRelationsSuite) TestExportEntities(c *gc.C) {
 	s.st.applications["django"] = newMockApplication("django")
 	result, err := s.api.ExportEntities(params.Entities{Entities: []params.Entity{{Tag: "application-django"}}})

--- a/state/remoteentities_test.go
+++ b/state/remoteentities_test.go
@@ -116,6 +116,29 @@ func (s *RemoteEntitiesSuite) TestImportRemoteEntity(c *gc.C) {
 	c.Assert(entity, gc.Equals, expected)
 }
 
+func (s *RemoteEntitiesSuite) TestImportRemoteEntityOverwrites(c *gc.C) {
+	re := s.State.RemoteEntities()
+	entity := names.NewApplicationTag("mysql")
+	token := utils.MustNewUUID().String()
+	err := re.ImportRemoteEntity(s.State.ModelTag(), entity, token)
+	c.Assert(err, jc.ErrorIsNil)
+
+	anotherToken := utils.MustNewUUID().String()
+	err = re.ImportRemoteEntity(s.State.ModelTag(), entity, anotherToken)
+	c.Assert(err, jc.ErrorIsNil)
+
+	anotherState, err := s.State.ForModel(s.State.ModelTag())
+	c.Assert(err, jc.ErrorIsNil)
+	defer anotherState.Close()
+
+	re = anotherState.RemoteEntities()
+	_, err = re.GetRemoteEntity(s.State.ModelTag(), token)
+	c.Assert(err, jc.Satisfies, errors.IsNotFound)
+	expected, err := re.GetRemoteEntity(s.State.ModelTag(), anotherToken)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(entity, gc.Equals, expected)
+}
+
 func (s *RemoteEntitiesSuite) TestImportRemoteEntityEmptyToken(c *gc.C) {
 	re := s.State.RemoteEntities()
 	entity := names.NewApplicationTag("mysql")

--- a/worker/firewaller/firewaller_test.go
+++ b/worker/firewaller/firewaller_test.go
@@ -932,7 +932,7 @@ func (s *InstanceModeSuite) TestRemoteRelationProviderRoleOffering(c *gc.C) {
 
 	// Export the relation details so the firewaller knows it's ready to be processed.
 	re := s.State.RemoteEntities()
-	err = re.ImportRemoteEntity(consumingModelTag, rel.Tag(), relToken)
+	err = re.ImportRemoteEntity(s.State.ModelTag(), rel.Tag(), relToken)
 	c.Assert(err, jc.ErrorIsNil)
 	err = re.ImportRemoteEntity(consumingModelTag, app.Tag(), appToken)
 	c.Assert(err, jc.ErrorIsNil)

--- a/worker/remoterelations/mock_test.go
+++ b/worker/remoterelations/mock_test.go
@@ -131,11 +131,6 @@ func (m *mockRelationsFacade) SaveMacaroon(entity names.Tag, mac *macaroon.Macar
 	return m.stub.NextErr()
 }
 
-func (m *mockRelationsFacade) RemoveRemoteEntity(sourceModelUUID string, entity names.Tag) error {
-	m.stub.MethodCall(m, "RemoveRemoteEntity", sourceModelUUID, entity)
-	return m.stub.NextErr()
-}
-
 func (m *mockRelationsFacade) GetToken(modelUUID string, entity names.Tag) (string, error) {
 	m.stub.MethodCall(m, "GetToken", modelUUID, entity)
 	if err := m.stub.NextErr(); err != nil {

--- a/worker/remoterelations/remoterelations_test.go
+++ b/worker/remoterelations/remoterelations_test.go
@@ -208,14 +208,14 @@ func (s *remoteRelationsSuite) TestRemoteRelationsWorkers(c *gc.C) {
 	c.Check(relWatcher.killed(), jc.IsTrue)
 }
 
-func (s *remoteRelationsSuite) TestRemoteRelationsDead(c *gc.C) {
+func (s *remoteRelationsSuite) TestRemoteRelationsDying(c *gc.C) {
 	// Checks that when a remote relation dies, the relation units
 	// workers are killed.
 	w := s.assertRemoteRelationsWorkers(c)
 	defer workertest.CleanKill(c, w)
 	s.stub.ResetCalls()
 
-	unitsWatcher, _ := s.relationsFacade.updateRelationLife("db2:db django:db", params.Dead)
+	unitsWatcher, _ := s.relationsFacade.updateRelationLife("db2:db django:db", params.Dying)
 	relWatcher, _ := s.relationsFacade.remoteApplicationRelationsWatcher("db2")
 	relWatcher.changes <- []string{"db2:db django:db"}
 	for a := coretesting.LongAttempt.Start(); a.Next(); {
@@ -233,11 +233,10 @@ func (s *remoteRelationsSuite) TestRemoteRelationsDead(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	expected := []jujutesting.StubCall{
 		{"Relations", []interface{}{[]string{"db2:db django:db"}}},
-		{"GetToken", []interface{}{"model-uuid", names.NewRelationTag("db2:db django:db")}},
-		{"RemoveRemoteEntity", []interface{}{"model-uuid", names.NewRelationTag("db2:db django:db")}},
+		{"GetToken", []interface{}{"local-model-uuid", names.NewRelationTag("db2:db django:db")}},
 		{"PublishRelationChange", []interface{}{
 			params.RemoteRelationChangeEvent{
-				Life: params.Dead,
+				Life: params.Dying,
 				ApplicationId: params.RemoteEntityId{
 					ModelUUID: "model-uuid",
 					Token:     "token-django"},
@@ -272,11 +271,10 @@ func (s *remoteRelationsSuite) TestRemoteRelationsRemoved(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	expected := []jujutesting.StubCall{
 		{"Relations", []interface{}{[]string{"db2:db django:db"}}},
-		{"GetToken", []interface{}{"model-uuid", names.NewRelationTag("db2:db django:db")}},
-		{"RemoveRemoteEntity", []interface{}{"model-uuid", names.NewRelationTag("db2:db django:db")}},
+		{"GetToken", []interface{}{"local-model-uuid", names.NewRelationTag("db2:db django:db")}},
 		{"PublishRelationChange", []interface{}{
 			params.RemoteRelationChangeEvent{
-				Life: params.Dead,
+				Life: params.Dying,
 				ApplicationId: params.RemoteEntityId{
 					ModelUUID: "model-uuid",
 					Token:     "token-django"},
@@ -421,7 +419,7 @@ func (s *remoteRelationsSuite) TestRegisteredApplicationNotRegistered(c *gc.C) {
 
 	expected = []jujutesting.StubCall{
 		{"Relations", []interface{}{[]string{"db2:db django:db"}}},
-		{"GetToken", []interface{}{"remote-model-uuid", names.NewRelationTag("db2:db django:db")}},
+		{"GetToken", []interface{}{"local-model-uuid", names.NewRelationTag("db2:db django:db")}},
 		{"GetToken", []interface{}{"local-model-uuid", names.NewApplicationTag("django")}},
 	}
 	s.waitForWorkerStubCalls(c, expected)


### PR DESCRIPTION
## Description of change

If a cross model relation is removed and re-added, the relation would not be created again. This PR fixes that and makes other improvements:
- import remote entity now overwrites any existing token
- deleting a remote app or relation also now deletes any token
- relation dying is used to trigger cross model updates, not dead
- remote relations are always exported using the local model uuid

The last 3 changes will be used in a subsequent PR to clean up remote entity references.

## QA steps

Deploy a cmr scenario with mediawiki and mysql
remove relation -> media wiki is blocked
add relation again -> mediawiki is repaired
