### PR TITLE
Remove RemoteEntityId struct and just use token

### DIFF
--- a/api/crossmodelrelations/crossmodelrelations.go
+++ b/api/crossmodelrelations/crossmodelrelations.go
@@ -76,7 +76,7 @@ func (c *Client) RegisterRemoteRelations(relations ...params.RegisterRemoteRelat
 }
 
 // WatchRelationUnits returns a watcher that notifies of changes to the
-// units in the remote model for the relation with the given remote id.
+// units in the remote model for the relation with the given remote token.
 func (c *Client) WatchRelationUnits(remoteRelationArg params.RemoteRelationArg) (watcher.RelationUnitsWatcher, error) {
 	args := params.RemoteRelationArgs{Args: []params.RemoteRelationArg{remoteRelationArg}}
 	var results params.RelationUnitsWatchResults

--- a/api/crossmodelrelations/crossmodelrelations_test.go
+++ b/api/crossmodelrelations/crossmodelrelations_test.go
@@ -106,7 +106,7 @@ func (s *CrossModelRelationsSuite) TestRegisterRemoteRelationCount(c *gc.C) {
 }
 
 func (s *CrossModelRelationsSuite) TestWatchRelationUnits(c *gc.C) {
-	remoteRelationId := params.RemoteEntityId{}
+	remoteRelationToken := "token"
 	mac, err := macaroon.New(nil, "", "")
 	c.Assert(err, jc.ErrorIsNil)
 	var callCount int
@@ -115,7 +115,7 @@ func (s *CrossModelRelationsSuite) TestWatchRelationUnits(c *gc.C) {
 		c.Check(version, gc.Equals, 0)
 		c.Check(id, gc.Equals, "")
 		c.Check(arg, jc.DeepEquals, params.RemoteRelationArgs{Args: []params.RemoteRelationArg{{
-			RemoteEntityId: remoteRelationId, Macaroons: macaroon.Slice{mac}}}})
+			Token: remoteRelationToken, Macaroons: macaroon.Slice{mac}}}})
 		c.Check(request, gc.Equals, "WatchRelationUnits")
 		c.Assert(result, gc.FitsTypeOf, &params.RelationUnitsWatchResults{})
 		*(result.(*params.RelationUnitsWatchResults)) = params.RelationUnitsWatchResults{
@@ -128,15 +128,15 @@ func (s *CrossModelRelationsSuite) TestWatchRelationUnits(c *gc.C) {
 	})
 	client := crossmodelrelations.NewClient(apiCaller)
 	_, err = client.WatchRelationUnits(params.RemoteRelationArg{
-		RemoteEntityId: remoteRelationId,
-		Macaroons:      macaroon.Slice{mac},
+		Token:     remoteRelationToken,
+		Macaroons: macaroon.Slice{mac},
 	})
 	c.Check(err, gc.ErrorMatches, "FAIL")
 	c.Check(callCount, gc.Equals, 1)
 }
 
 func (s *CrossModelRelationsSuite) TestRelationUnitSettings(c *gc.C) {
-	remoteRelationId := params.RemoteEntityId{}
+	remoteRelationToken := "token"
 	mac, err := macaroon.New(nil, "", "")
 	c.Assert(err, jc.ErrorIsNil)
 	var callCount int
@@ -147,7 +147,7 @@ func (s *CrossModelRelationsSuite) TestRelationUnitSettings(c *gc.C) {
 		c.Check(request, gc.Equals, "RelationUnitSettings")
 		c.Check(arg, gc.DeepEquals, params.RemoteRelationUnits{
 			RelationUnits: []params.RemoteRelationUnit{{
-				RelationId: remoteRelationId, Unit: "u", Macaroons: macaroon.Slice{mac}}}})
+				RelationToken: remoteRelationToken, Unit: "u", Macaroons: macaroon.Slice{mac}}}})
 		c.Assert(result, gc.FitsTypeOf, &params.SettingsResults{})
 		*(result.(*params.SettingsResults)) = params.SettingsResults{
 			Results: []params.SettingsResult{{
@@ -159,7 +159,7 @@ func (s *CrossModelRelationsSuite) TestRelationUnitSettings(c *gc.C) {
 	})
 	client := crossmodelrelations.NewClient(apiCaller)
 	result, err := client.RelationUnitSettings([]params.RemoteRelationUnit{
-		{RelationId: remoteRelationId, Unit: "u", Macaroons: macaroon.Slice{mac}}})
+		{RelationToken: remoteRelationToken, Unit: "u", Macaroons: macaroon.Slice{mac}}})
 	c.Check(err, jc.ErrorIsNil)
 	c.Assert(result, gc.HasLen, 1)
 	c.Check(result[0].Error, gc.ErrorMatches, "FAIL")
@@ -197,10 +197,10 @@ func (s *CrossModelRelationsSuite) TestIngressNetworkChange(c *gc.C) {
 
 func (s *CrossModelRelationsSuite) TestWatchEgressAddressesForRelation(c *gc.C) {
 	var callCount int
-	remoteRelationId := params.RemoteEntityId{}
+	remoteRelationToken := "token"
 	mac, err := macaroon.New(nil, "", "")
 	relation := params.RemoteRelationArg{
-		RemoteEntityId: remoteRelationId, Macaroons: macaroon.Slice{mac}}
+		Token: remoteRelationToken, Macaroons: macaroon.Slice{mac}}
 	c.Check(err, jc.ErrorIsNil)
 	apiCaller := testing.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
 		c.Check(objType, gc.Equals, "CrossModelRelations")

--- a/api/remoterelations/remoterelations.go
+++ b/api/remoterelations/remoterelations.go
@@ -30,9 +30,9 @@ func NewClient(caller base.APICaller) *Client {
 
 // ImportRemoteEntity adds an entity to the remote entities collection
 // with the specified opaque token.
-func (c *Client) ImportRemoteEntity(sourceModelUUID string, entity names.Tag, token string) error {
+func (c *Client) ImportRemoteEntity(entity names.Tag, token string) error {
 	args := params.RemoteEntityArgs{Args: []params.RemoteEntityArg{
-		{ModelTag: names.NewModelTag(sourceModelUUID).String(), Tag: entity.String(), Token: token}},
+		{Tag: entity.String(), Token: token}},
 	}
 	var results params.ErrorResults
 	err := c.facade.FacadeCall("ImportRemoteEntities", args, &results)
@@ -50,12 +50,12 @@ func (c *Client) ImportRemoteEntity(sourceModelUUID string, entity names.Tag, to
 }
 
 // ExportEntities allocates unique, remote entity IDs for the given entities in the local model.
-func (c *Client) ExportEntities(tags []names.Tag) ([]params.RemoteEntityIdResult, error) {
+func (c *Client) ExportEntities(tags []names.Tag) ([]params.TokenResult, error) {
 	args := params.Entities{Entities: make([]params.Entity, len(tags))}
 	for i, tag := range tags {
 		args.Entities[i].Tag = tag.String()
 	}
-	var results params.RemoteEntityIdResults
+	var results params.TokenResults
 	err := c.facade.FacadeCall("ExportEntities", args, &results)
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -67,9 +67,9 @@ func (c *Client) ExportEntities(tags []names.Tag) ([]params.RemoteEntityIdResult
 }
 
 // GetToken returns the token associated with the entity with the given tag for the specified model.
-func (c *Client) GetToken(sourceModelUUID string, tag names.Tag) (string, error) {
+func (c *Client) GetToken(tag names.Tag) (string, error) {
 	args := params.GetTokenArgs{Args: []params.GetTokenArg{
-		{ModelTag: names.NewModelTag(sourceModelUUID).String(), Tag: tag.String()}},
+		{Tag: tag.String()}},
 	}
 	var results params.StringResults
 	err := c.facade.FacadeCall("GetTokens", args, &results)
@@ -82,7 +82,7 @@ func (c *Client) GetToken(sourceModelUUID string, tag names.Tag) (string, error)
 	result := results.Results[0]
 	if result.Error != nil {
 		if params.IsCodeNotFound(result.Error) {
-			return "", errors.NotFoundf("token for %v in model %v", tag, sourceModelUUID)
+			return "", errors.NotFoundf("token for %v", tag)
 		}
 		return "", errors.Trace(result.Error)
 	}

--- a/api/remoterelations/remoterelations_test.go
+++ b/api/remoterelations/remoterelations_test.go
@@ -110,9 +110,9 @@ func (s *remoteRelationsSuite) TestExportEntities(c *gc.C) {
 		c.Check(id, gc.Equals, "")
 		c.Check(request, gc.Equals, "ExportEntities")
 		c.Check(arg, gc.DeepEquals, params.Entities{Entities: []params.Entity{{Tag: "application-foo"}}})
-		c.Assert(result, gc.FitsTypeOf, &params.RemoteEntityIdResults{})
-		*(result.(*params.RemoteEntityIdResults)) = params.RemoteEntityIdResults{
-			Results: []params.RemoteEntityIdResult{{
+		c.Assert(result, gc.FitsTypeOf, &params.TokenResults{})
+		*(result.(*params.TokenResults)) = params.TokenResults{
+			Results: []params.TokenResult{{
 				Error: &params.Error{Message: "FAIL"},
 			}},
 		}
@@ -129,8 +129,8 @@ func (s *remoteRelationsSuite) TestExportEntities(c *gc.C) {
 
 func (s *remoteRelationsSuite) TestExportEntitiesResultCount(c *gc.C) {
 	apiCaller := testing.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
-		*(result.(*params.RemoteEntityIdResults)) = params.RemoteEntityIdResults{
-			Results: []params.RemoteEntityIdResult{
+		*(result.(*params.TokenResults)) = params.TokenResults{
+			Results: []params.TokenResult{
 				{Error: &params.Error{Message: "FAIL"}},
 				{Error: &params.Error{Message: "FAIL"}},
 			},
@@ -270,7 +270,7 @@ func (s *remoteRelationsSuite) TestGetToken(c *gc.C) {
 		c.Check(id, gc.Equals, "")
 		c.Check(request, gc.Equals, "GetTokens")
 		c.Check(arg, gc.DeepEquals, params.GetTokenArgs{
-			Args: []params.GetTokenArg{{ModelTag: coretesting.ModelTag.String(), Tag: "application-app"}}})
+			Args: []params.GetTokenArg{{Tag: "application-app"}}})
 		c.Assert(result, gc.FitsTypeOf, &params.StringResults{})
 		*(result.(*params.StringResults)) = params.StringResults{
 			Results: []params.StringResult{{
@@ -281,7 +281,7 @@ func (s *remoteRelationsSuite) TestGetToken(c *gc.C) {
 		return nil
 	})
 	client := remoterelations.NewClient(apiCaller)
-	_, err := client.GetToken(coretesting.ModelTag.Id(), names.NewApplicationTag("app"))
+	_, err := client.GetToken(names.NewApplicationTag("app"))
 	c.Check(err, gc.ErrorMatches, "FAIL")
 	c.Check(callCount, gc.Equals, 1)
 }
@@ -297,7 +297,7 @@ func (s *remoteRelationsSuite) TestGetTokenCount(c *gc.C) {
 		return nil
 	})
 	client := remoterelations.NewClient(apiCaller)
-	_, err := client.GetToken(coretesting.ModelTag.Id(), names.NewApplicationTag("app"))
+	_, err := client.GetToken(names.NewApplicationTag("app"))
 	c.Check(err, gc.ErrorMatches, `expected 1 result, got 2`)
 }
 
@@ -309,7 +309,7 @@ func (s *remoteRelationsSuite) TestImportRemoteEntity(c *gc.C) {
 		c.Check(id, gc.Equals, "")
 		c.Check(request, gc.Equals, "ImportRemoteEntities")
 		c.Check(arg, gc.DeepEquals, params.RemoteEntityArgs{
-			Args: []params.RemoteEntityArg{{ModelTag: coretesting.ModelTag.String(), Tag: "application-app", Token: "token"}}})
+			Args: []params.RemoteEntityArg{{Tag: "application-app", Token: "token"}}})
 		c.Assert(result, gc.FitsTypeOf, &params.ErrorResults{})
 		*(result.(*params.ErrorResults)) = params.ErrorResults{
 			Results: []params.ErrorResult{{
@@ -320,7 +320,7 @@ func (s *remoteRelationsSuite) TestImportRemoteEntity(c *gc.C) {
 		return nil
 	})
 	client := remoterelations.NewClient(apiCaller)
-	err := client.ImportRemoteEntity(coretesting.ModelTag.Id(), names.NewApplicationTag("app"), "token")
+	err := client.ImportRemoteEntity(names.NewApplicationTag("app"), "token")
 	c.Check(err, gc.ErrorMatches, "FAIL")
 	c.Check(callCount, gc.Equals, 1)
 }
@@ -336,7 +336,7 @@ func (s *remoteRelationsSuite) TestImportRemoteEntityCount(c *gc.C) {
 		return nil
 	})
 	client := remoterelations.NewClient(apiCaller)
-	err := client.ImportRemoteEntity(coretesting.ModelTag.Id(), names.NewApplicationTag("app"), "token")
+	err := client.ImportRemoteEntity(names.NewApplicationTag("app"), "token")
 	c.Check(err, gc.ErrorMatches, `expected 1 result, got 2`)
 }
 

--- a/apiserver/common/crossmodel/crossmodel.go
+++ b/apiserver/common/crossmodel/crossmodel.go
@@ -33,12 +33,11 @@ func PublishRelationChange(backend Backend, relationTag names.Tag, change params
 
 	// Look up the application on the remote side of this relation
 	// ie from the model which published this change.
-	applicationTag, err := backend.GetRemoteEntity(
-		names.NewModelTag(change.ApplicationId.ModelUUID), change.ApplicationId.Token)
+	applicationTag, err := backend.GetRemoteEntity(change.ApplicationToken)
 	if err != nil {
 		return errors.Trace(err)
 	}
-	logger.Debugf("application tag for remote id %+v is %v", change.ApplicationId, applicationTag)
+	logger.Debugf("application tag for token %+v is %v", change.ApplicationToken, applicationTag)
 
 	// If the remote model has destroyed the relation, do it here also.
 	if change.Life != params.Alive {
@@ -84,7 +83,7 @@ func PublishRelationChange(backend Backend, relationTag names.Tag, change params
 
 	for _, change := range change.ChangedUnits {
 		unitTag := names.NewUnitTag(fmt.Sprintf("%s/%v", applicationTag.Id(), change.UnitId))
-		logger.Debugf("changed unit tag for remote id %v is %v", change.UnitId, unitTag)
+		logger.Debugf("changed unit tag for unit id %v is %v", change.UnitId, unitTag)
 		ru, err := rel.RemoteUnit(unitTag.Id())
 		if err != nil {
 			return errors.Trace(err)

--- a/apiserver/common/crossmodel/interface.go
+++ b/apiserver/common/crossmodel/interface.go
@@ -36,9 +36,8 @@ type Backend interface {
 	// with the supplied name (which must be unique across all applications, local and remote).
 	AddRemoteApplication(state.AddRemoteApplicationParams) (RemoteApplication, error)
 
-	// GetRemoteEntity returns the tag of the entity associated with the given
-	// token and model.
-	GetRemoteEntity(names.ModelTag, string) (names.Tag, error)
+	// GetRemoteEntity returns the tag of the entity associated with the given token.
+	GetRemoteEntity(string) (names.Tag, error)
 
 	// ExportLocalEntity adds an entity to the remote entities collection,
 	// returning an opaque token that uniquely identifies the entity within
@@ -47,7 +46,7 @@ type Backend interface {
 
 	// ImportRemoteEntity adds an entity to the remote entities collection
 	// with the specified opaque token.
-	ImportRemoteEntity(sourceModel names.ModelTag, entity names.Tag, token string) error
+	ImportRemoteEntity(entity names.Tag, token string) error
 
 	// SaveIngressNetworks stores in state the ingress networks for the relation.
 	SaveIngressNetworks(relationKey string, cidrs []string) (RelationIngress, error)

--- a/apiserver/common/crossmodel/state.go
+++ b/apiserver/common/crossmodel/state.go
@@ -75,9 +75,9 @@ func (st stateShim) AddRemoteApplication(args state.AddRemoteApplicationParams) 
 	return remoteApplicationShim{a}, nil
 }
 
-func (st stateShim) GetRemoteEntity(model names.ModelTag, token string) (names.Tag, error) {
+func (st stateShim) GetRemoteEntity(token string) (names.Tag, error) {
 	r := st.State.RemoteEntities()
-	return r.GetRemoteEntity(model, token)
+	return r.GetRemoteEntity(token)
 }
 
 func (st stateShim) ExportLocalEntity(entity names.Tag) (string, error) {
@@ -85,9 +85,9 @@ func (st stateShim) ExportLocalEntity(entity names.Tag) (string, error) {
 	return r.ExportLocalEntity(entity)
 }
 
-func (st stateShim) ImportRemoteEntity(model names.ModelTag, entity names.Tag, token string) error {
+func (st stateShim) ImportRemoteEntity(entity names.Tag, token string) error {
 	r := st.State.RemoteEntities()
-	return r.ImportRemoteEntity(model, entity, token)
+	return r.ImportRemoteEntity(entity, token)
 }
 
 type RelationIngress state.RelationIngress

--- a/apiserver/facades/controller/crossmodelrelations/mock_test.go
+++ b/apiserver/facades/controller/crossmodelrelations/mock_test.go
@@ -68,13 +68,15 @@ func (st *mockState) EndpointsRelation(eps ...state.Endpoint) (common.Relation, 
 }
 
 func (st *mockState) AddRemoteApplication(params state.AddRemoteApplicationParams) (common.RemoteApplication, error) {
-	app := &mockRemoteApplication{consumerproxy: params.IsConsumerProxy}
+	app := &mockRemoteApplication{
+		sourceModelUUID: params.SourceModel.Id(),
+		consumerproxy:   params.IsConsumerProxy}
 	st.remoteApplications[params.Name] = app
 	return app, nil
 }
 
-func (st *mockState) ImportRemoteEntity(sourceModel names.ModelTag, entity names.Tag, token string) error {
-	st.MethodCall(st, "ImportRemoteEntity", sourceModel, entity, token)
+func (st *mockState) ImportRemoteEntity(entity names.Tag, token string) error {
+	st.MethodCall(st, "ImportRemoteEntity", entity, token)
 	if err := st.NextErr(); err != nil {
 		return err
 	}
@@ -98,8 +100,8 @@ func (st *mockState) ExportLocalEntity(entity names.Tag) (string, error) {
 	return token, nil
 }
 
-func (st *mockState) GetRemoteEntity(sourceModel names.ModelTag, token string) (names.Tag, error) {
-	st.MethodCall(st, "GetRemoteEntity", sourceModel, token)
+func (st *mockState) GetRemoteEntity(token string) (names.Tag, error) {
+	st.MethodCall(st, "GetRemoteEntity", token)
 	if err := st.NextErr(); err != nil {
 		return nil, err
 	}
@@ -219,7 +221,8 @@ func (u *mockRelationUnit) Settings() (map[string]interface{}, error) {
 type mockRemoteApplication struct {
 	common.RemoteApplication
 	testing.Stub
-	consumerproxy bool
+	consumerproxy   bool
+	sourceModelUUID string
 }
 
 func (r *mockRemoteApplication) IsConsumerProxy() bool {

--- a/apiserver/facades/controller/firewaller/firewaller.go
+++ b/apiserver/facades/controller/firewaller/firewaller.go
@@ -431,7 +431,7 @@ func (f *FirewallerAPIV4) MacaroonForRelations(args params.Entities) (params.Mac
 			result.Results[i].Error = common.ServerError(err)
 			continue
 		}
-		mac, err := f.st.GetMacaroon(names.NewModelTag(f.st.ModelUUID()), relationTag)
+		mac, err := f.st.GetMacaroon(relationTag)
 		if err != nil {
 			result.Results[i].Error = common.ServerError(err)
 			continue

--- a/apiserver/facades/controller/firewaller/mock_test.go
+++ b/apiserver/facades/controller/firewaller/mock_test.go
@@ -76,8 +76,8 @@ func (st *mockState) ControllerInfo(modelUUID string) ([]string, string, error) 
 	}
 }
 
-func (st *mockState) GetMacaroon(model names.ModelTag, entity names.Tag) (*macaroon.Macaroon, error) {
-	st.MethodCall(st, "GetMacaroon", model, entity)
+func (st *mockState) GetMacaroon(entity names.Tag) (*macaroon.Macaroon, error) {
+	st.MethodCall(st, "GetMacaroon", entity)
 	if err := st.NextErr(); err != nil {
 		return nil, err
 	}

--- a/apiserver/facades/controller/firewaller/state.go
+++ b/apiserver/facades/controller/firewaller/state.go
@@ -18,7 +18,7 @@ type State interface {
 
 	ModelUUID() string
 
-	GetMacaroon(model names.ModelTag, entity names.Tag) (*macaroon.Macaroon, error)
+	GetMacaroon(entity names.Tag) (*macaroon.Macaroon, error)
 
 	WatchOpenedPorts() state.StringsWatcher
 
@@ -39,9 +39,9 @@ func (st stateShim) ModelUUID() string {
 	return st.st.ModelUUID()
 }
 
-func (st stateShim) GetMacaroon(model names.ModelTag, entity names.Tag) (*macaroon.Macaroon, error) {
+func (st stateShim) GetMacaroon(entity names.Tag) (*macaroon.Macaroon, error) {
 	r := st.st.RemoteEntities()
-	return r.GetMacaroon(model, entity)
+	return r.GetMacaroon(entity)
 }
 
 func (st stateShim) FindEntity(tag names.Tag) (state.Entity, error) {

--- a/apiserver/facades/controller/remoterelations/mock_test.go
+++ b/apiserver/facades/controller/remoterelations/mock_test.go
@@ -72,8 +72,8 @@ func (st *mockState) AddRelation(eps ...state.Endpoint) (common.Relation, error)
 	return rel, nil
 }
 
-func (st *mockState) ImportRemoteEntity(sourceModel names.ModelTag, entity names.Tag, token string) error {
-	st.MethodCall(st, "ImportRemoteEntity", sourceModel, entity, token)
+func (st *mockState) ImportRemoteEntity(entity names.Tag, token string) error {
+	st.MethodCall(st, "ImportRemoteEntity", entity, token)
 	if err := st.NextErr(); err != nil {
 		return err
 	}
@@ -84,8 +84,8 @@ func (st *mockState) ImportRemoteEntity(sourceModel names.ModelTag, entity names
 	return nil
 }
 
-func (st *mockState) RemoveRemoteEntity(sourceModel names.ModelTag, entity names.Tag) error {
-	st.MethodCall(st, "RemoveRemoteEntity", sourceModel, entity)
+func (st *mockState) RemoveRemoteEntity(entity names.Tag) error {
+	st.MethodCall(st, "RemoveRemoteEntity", entity)
 	if err := st.NextErr(); err != nil {
 		return err
 	}
@@ -106,8 +106,8 @@ func (st *mockState) ExportLocalEntity(entity names.Tag) (string, error) {
 	return token, nil
 }
 
-func (st *mockState) GetRemoteEntity(sourceModel names.ModelTag, token string) (names.Tag, error) {
-	st.MethodCall(st, "GetRemoteEntity", sourceModel, token)
+func (st *mockState) GetRemoteEntity(token string) (names.Tag, error) {
+	st.MethodCall(st, "GetRemoteEntity", token)
 	if err := st.NextErr(); err != nil {
 		return nil, err
 	}
@@ -119,8 +119,8 @@ func (st *mockState) GetRemoteEntity(sourceModel names.ModelTag, token string) (
 	return nil, errors.NotFoundf("token %v", token)
 }
 
-func (st *mockState) GetToken(sourceModel names.ModelTag, entity names.Tag) (string, error) {
-	st.MethodCall(st, "GetToken", sourceModel, entity)
+func (st *mockState) GetToken(entity names.Tag) (string, error) {
+	st.MethodCall(st, "GetToken", entity)
 	if err := st.NextErr(); err != nil {
 		return "", err
 	}

--- a/apiserver/facades/controller/remoterelations/state.go
+++ b/apiserver/facades/controller/remoterelations/state.go
@@ -31,11 +31,10 @@ type RemoteRelationsState interface {
 	WatchRemoteRelations() state.StringsWatcher
 
 	// RemoveRemoteEntity removes the specified entity from the remote entities collection.
-	RemoveRemoteEntity(sourceModel names.ModelTag, entity names.Tag) error
+	RemoveRemoteEntity(entity names.Tag) error
 
-	// GetToken returns the token associated with the entity with the given tag
-	// and model.
-	GetToken(names.ModelTag, names.Tag) (string, error)
+	// GetToken returns the token associated with the entity with the given tag.
+	GetToken(names.Tag) (string, error)
 
 	// SaveMacaroon saves the given macaroon for the specified entity.
 	SaveMacaroon(entity names.Tag, mac *macaroon.Macaroon) error
@@ -46,14 +45,14 @@ type stateShim struct {
 	st *state.State
 }
 
-func (st stateShim) RemoveRemoteEntity(model names.ModelTag, entity names.Tag) error {
+func (st stateShim) RemoveRemoteEntity(entity names.Tag) error {
 	r := st.st.RemoteEntities()
-	return r.RemoveRemoteEntity(model, entity)
+	return r.RemoveRemoteEntity(entity)
 }
 
-func (st stateShim) GetToken(model names.ModelTag, entity names.Tag) (string, error) {
+func (st stateShim) GetToken(entity names.Tag) (string, error) {
 	r := st.st.RemoteEntities()
-	return r.GetToken(model, entity)
+	return r.GetToken(entity)
 }
 
 func (st stateShim) SaveMacaroon(entity names.Tag, mac *macaroon.Macaroon) error {

--- a/state/allcollections.go
+++ b/state/allcollections.go
@@ -427,13 +427,11 @@ func allCollections() collectionSchema {
 			// cross-model relations.
 			remoteEntitiesC: {
 				indexes: []mgo.Index{{
-					Key: []string{"model-uuid", "source-model-uuid", "token"},
+					Key: []string{"model-uuid", "token"},
 				}, {
-					Key: []string{"model-uuid", "source-model-uuid"},
+					Key: []string{"model-uuid"},
 				}},
 			},
-			// tokensC holds unique tokens for the model.
-			tokensC: {},
 			// externalControllersC holds connection information for other
 			// controllers hosting models involved in cross-model relations.
 			externalControllersC: {
@@ -533,7 +531,6 @@ const (
 	applicationOffersC   = "applicationOffers"
 	remoteApplicationsC  = "remoteApplications"
 	remoteEntitiesC      = "remoteEntities"
-	tokensC              = "tokens"
 	externalControllersC = "externalControllers"
 	relationIngressC     = "relationIngress"
 )

--- a/state/migration_internal_test.go
+++ b/state/migration_internal_test.go
@@ -187,7 +187,6 @@ func (s *MigrationSuite) TestKnownCollections(c *gc.C) {
 		//Cross Model Relations - TODO
 		remoteApplicationsC,
 		applicationOffersC,
-		tokensC,
 		remoteEntitiesC,
 		externalControllersC,
 		relationIngressC,

--- a/state/relation.go
+++ b/state/relation.go
@@ -202,12 +202,7 @@ func (r *Relation) removeOps(ignoreService string, departingUnitName string) ([]
 	if featureflag.Enabled(feature.CrossModelRelations) {
 		ops = append(ops, removeRelationIngressNetworksOps(r.st, r.doc.Key)...)
 		re := r.st.RemoteEntities()
-		modelTag := r.st.modelTag
-		token, err := re.GetToken(modelTag, r.Tag())
-		if err != nil && !errors.IsNotFound(err) {
-			return nil, errors.Trace(err)
-		}
-		tokenOps := re.removeRemoteEntityOps(modelTag, r.Tag(), token)
+		tokenOps := re.removeRemoteEntityOps(r.Tag())
 		ops = append(ops, tokenOps...)
 	}
 	cleanupOp := newCleanupOp(cleanupRelationSettings, fmt.Sprintf("r#%d#", r.Id()))

--- a/state/relation_test.go
+++ b/state/relation_test.go
@@ -394,9 +394,9 @@ func (s *RelationSuite) TestRemoveAlsoDeletesRemoteTokens(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	state.RemoveRelation(c, relation)
-	_, err = re.GetToken(s.State.ModelTag(), relation.Tag())
+	_, err = re.GetToken(relation.Tag())
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
-	_, err = re.GetRemoteEntity(s.State.ModelTag(), relToken)
+	_, err = re.GetRemoteEntity(relToken)
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 }
 

--- a/state/remoteapplication.go
+++ b/state/remoteapplication.go
@@ -159,7 +159,7 @@ func (s *RemoteApplication) URL() (string, bool) {
 // model to identify the service in future communications.
 func (s *RemoteApplication) Token() (string, error) {
 	r := s.st.RemoteEntities()
-	return r.GetToken(s.SourceModel(), s.Tag())
+	return r.GetToken(s.Tag())
 }
 
 // Tag returns a name identifying the application.
@@ -356,10 +356,6 @@ func (s *RemoteApplication) destroyOps() ([]txn.Op, error) {
 // asserts will be included in the operation on the application document.
 func (s *RemoteApplication) removeOps(asserts bson.D) ([]txn.Op, error) {
 	r := s.st.RemoteEntities()
-	token, err := r.GetToken(s.SourceModel(), s.Tag())
-	if err != nil && !errors.IsNotFound(err) {
-		return nil, err
-	}
 	ops := []txn.Op{
 		{
 			C:      remoteApplicationsC,
@@ -369,7 +365,7 @@ func (s *RemoteApplication) removeOps(asserts bson.D) ([]txn.Op, error) {
 		},
 		removeStatusOp(s.st, s.globalKey()),
 	}
-	tokenOps := r.removeRemoteEntityOps(s.SourceModel(), s.Tag(), token)
+	tokenOps := r.removeRemoteEntityOps(s.Tag())
 	ops = append(ops, tokenOps...)
 	return ops, nil
 }
@@ -739,9 +735,7 @@ func (st *State) AddRemoteApplication(args AddRemoteApplicationParams) (_ *Remot
 		}
 		// If we know the token, import it.
 		if args.Token != "" {
-			importRemoteEntityOps := st.RemoteEntities().importRemoteEntityOps(
-				args.SourceModel, app.Tag(), args.Token,
-			)
+			importRemoteEntityOps := st.RemoteEntities().importRemoteEntityOps(app.Tag(), args.Token)
 			ops = append(ops, importRemoteEntityOps...)
 		}
 		return ops, nil

--- a/state/remoteapplication_test.go
+++ b/state/remoteapplication_test.go
@@ -739,18 +739,18 @@ func (s *remoteApplicationSuite) TestDestroyWithRemoteTokens(c *gc.C) {
 	err = s.application.Destroy()
 	c.Assert(err, jc.ErrorIsNil)
 
-	_, err = re.GetToken(s.State.ModelTag(), s.application.Tag())
+	_, err = re.GetToken(s.application.Tag())
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
-	_, err = re.GetToken(s.State.ModelTag(), rel.Tag())
+	_, err = re.GetToken(rel.Tag())
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 
-	_, err = re.GetRemoteEntity(s.State.ModelTag(), "app-token")
+	_, err = re.GetRemoteEntity("app-token")
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 
 	err = rel.Refresh()
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 
-	_, err = re.GetRemoteEntity(s.State.ModelTag(), relToken)
+	_, err = re.GetRemoteEntity(relToken)
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 }
 

--- a/state/remoteentities_test.go
+++ b/state/remoteentities_test.go
@@ -35,7 +35,7 @@ func (s *RemoteEntitiesSuite) TestExportLocalEntity(c *gc.C) {
 	defer anotherState.Close()
 
 	re := anotherState.RemoteEntities()
-	expected, err := re.GetToken(s.State.ModelTag(), entity)
+	expected, err := re.GetToken(entity)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(token, gc.Equals, expected)
 }
@@ -58,7 +58,7 @@ func (s *RemoteEntitiesSuite) TestGetRemoteEntity(c *gc.C) {
 	defer anotherState.Close()
 
 	re := anotherState.RemoteEntities()
-	expected, err := re.GetRemoteEntity(s.State.ModelTag(), token)
+	expected, err := re.GetRemoteEntity(token)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(entity, gc.Equals, expected)
 }
@@ -78,7 +78,7 @@ func (s *RemoteEntitiesSuite) TestMacaroon(c *gc.C) {
 	defer anotherState.Close()
 
 	re = anotherState.RemoteEntities()
-	expected, err := re.GetMacaroon(s.State.ModelTag(), entity)
+	expected, err := re.GetMacaroon(entity)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(mac, jc.DeepEquals, expected)
 }
@@ -92,10 +92,10 @@ func (s *RemoteEntitiesSuite) TestRemoveRemoteEntity(c *gc.C) {
 	defer anotherState.Close()
 
 	re := anotherState.RemoteEntities()
-	err = re.RemoveRemoteEntity(s.State.ModelTag(), entity)
+	err = re.RemoveRemoteEntity(entity)
 	c.Assert(err, jc.ErrorIsNil)
 	re = s.State.RemoteEntities()
-	_, err = re.GetRemoteEntity(s.State.ModelTag(), token)
+	_, err = re.GetRemoteEntity(token)
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 }
 
@@ -103,7 +103,7 @@ func (s *RemoteEntitiesSuite) TestImportRemoteEntity(c *gc.C) {
 	re := s.State.RemoteEntities()
 	entity := names.NewApplicationTag("mysql")
 	token := utils.MustNewUUID().String()
-	err := re.ImportRemoteEntity(s.State.ModelTag(), entity, token)
+	err := re.ImportRemoteEntity(entity, token)
 	c.Assert(err, jc.ErrorIsNil)
 
 	anotherState, err := s.State.ForModel(s.State.ModelTag())
@@ -111,7 +111,7 @@ func (s *RemoteEntitiesSuite) TestImportRemoteEntity(c *gc.C) {
 	defer anotherState.Close()
 
 	re = anotherState.RemoteEntities()
-	expected, err := re.GetRemoteEntity(s.State.ModelTag(), token)
+	expected, err := re.GetRemoteEntity(token)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(entity, gc.Equals, expected)
 }
@@ -120,11 +120,11 @@ func (s *RemoteEntitiesSuite) TestImportRemoteEntityOverwrites(c *gc.C) {
 	re := s.State.RemoteEntities()
 	entity := names.NewApplicationTag("mysql")
 	token := utils.MustNewUUID().String()
-	err := re.ImportRemoteEntity(s.State.ModelTag(), entity, token)
+	err := re.ImportRemoteEntity(entity, token)
 	c.Assert(err, jc.ErrorIsNil)
 
 	anotherToken := utils.MustNewUUID().String()
-	err = re.ImportRemoteEntity(s.State.ModelTag(), entity, anotherToken)
+	err = re.ImportRemoteEntity(entity, anotherToken)
 	c.Assert(err, jc.ErrorIsNil)
 
 	anotherState, err := s.State.ForModel(s.State.ModelTag())
@@ -132,9 +132,9 @@ func (s *RemoteEntitiesSuite) TestImportRemoteEntityOverwrites(c *gc.C) {
 	defer anotherState.Close()
 
 	re = anotherState.RemoteEntities()
-	_, err = re.GetRemoteEntity(s.State.ModelTag(), token)
+	_, err = re.GetRemoteEntity(token)
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
-	expected, err := re.GetRemoteEntity(s.State.ModelTag(), anotherToken)
+	expected, err := re.GetRemoteEntity(anotherToken)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(entity, gc.Equals, expected)
 }
@@ -142,6 +142,6 @@ func (s *RemoteEntitiesSuite) TestImportRemoteEntityOverwrites(c *gc.C) {
 func (s *RemoteEntitiesSuite) TestImportRemoteEntityEmptyToken(c *gc.C) {
 	re := s.State.RemoteEntities()
 	entity := names.NewApplicationTag("mysql")
-	err := re.ImportRemoteEntity(s.State.ModelTag(), entity, "")
+	err := re.ImportRemoteEntity(entity, "")
 	c.Assert(err, jc.Satisfies, errors.IsNotValid)
 }

--- a/worker/firewaller/firewaller_test.go
+++ b/worker/firewaller/firewaller_test.go
@@ -738,11 +738,11 @@ func (s *InstanceModeSuite) TestRemoteRelationRequirerRoleConsumingSide(c *gc.C)
 		c.Check(request, gc.Equals, "PublishIngressNetworkChanges")
 		expected := params.IngressNetworksChanges{
 			Changes: []params.IngressNetworksChangeEvent{{
-				RelationId:      params.RemoteEntityId{ModelUUID: s.State.ModelUUID(), Token: relToken},
-				ApplicationId:   params.RemoteEntityId{ModelUUID: offeringModelTag.Id(), Token: appToken},
-				Networks:        []string{"10.0.0.4/32"},
-				IngressRequired: ingressRequired,
-				Macaroons:       macaroon.Slice{mac},
+				RelationToken:    relToken,
+				ApplicationToken: appToken,
+				Networks:         []string{"10.0.0.4/32"},
+				IngressRequired:  ingressRequired,
+				Macaroons:        macaroon.Slice{mac},
 			}},
 		}
 		expected.Changes[0].IngressRequired = ingressRequired
@@ -776,7 +776,7 @@ func (s *InstanceModeSuite) TestRemoteRelationRequirerRoleConsumingSide(c *gc.C)
 	c.Assert(err, jc.ErrorIsNil)
 	err = re.SaveMacaroon(rel.Tag(), mac)
 	c.Assert(err, jc.ErrorIsNil)
-	err = re.ImportRemoteEntity(offeringModelTag, app.Tag(), appToken)
+	err = re.ImportRemoteEntity(app.Tag(), appToken)
 	c.Assert(err, jc.ErrorIsNil)
 	ingressRequired = true
 
@@ -855,8 +855,8 @@ func (s *InstanceModeSuite) TestRemoteRelationProviderRoleConsumingSide(c *gc.C)
 			c.Check(request, gc.Equals, "WatchEgressAddressesForRelations")
 			expected := params.RemoteRelationArgs{
 				Args: []params.RemoteRelationArg{{
-					RemoteEntityId: params.RemoteEntityId{ModelUUID: s.State.ModelUUID(), Token: relToken},
-					Macaroons:      macaroon.Slice{mac},
+					Token:     relToken,
+					Macaroons: macaroon.Slice{mac},
 				}},
 			}
 			c.Check(arg, gc.DeepEquals, expected)
@@ -890,7 +890,7 @@ func (s *InstanceModeSuite) TestRemoteRelationProviderRoleConsumingSide(c *gc.C)
 	c.Assert(err, jc.ErrorIsNil)
 	err = re.SaveMacaroon(rel.Tag(), mac)
 	c.Assert(err, jc.ErrorIsNil)
-	err = re.ImportRemoteEntity(offeringModelTag, app.Tag(), appToken)
+	err = re.ImportRemoteEntity(app.Tag(), appToken)
 	c.Assert(err, jc.ErrorIsNil)
 
 	select {
@@ -932,9 +932,9 @@ func (s *InstanceModeSuite) TestRemoteRelationProviderRoleOffering(c *gc.C) {
 
 	// Export the relation details so the firewaller knows it's ready to be processed.
 	re := s.State.RemoteEntities()
-	err = re.ImportRemoteEntity(s.State.ModelTag(), rel.Tag(), relToken)
+	err = re.ImportRemoteEntity(rel.Tag(), relToken)
 	c.Assert(err, jc.ErrorIsNil)
-	err = re.ImportRemoteEntity(consumingModelTag, app.Tag(), appToken)
+	err = re.ImportRemoteEntity(app.Tag(), appToken)
 	c.Assert(err, jc.ErrorIsNil)
 
 	// No port changes yet.

--- a/worker/remoterelations/mock_test.go
+++ b/worker/remoterelations/mock_test.go
@@ -104,25 +104,22 @@ func (m *mockRelationsFacade) WatchRemoteApplicationRelations(application string
 	return m.remoteApplicationRelationsWatchers[application], nil
 }
 
-func (m *mockRelationsFacade) ExportEntities(entities []names.Tag) ([]params.RemoteEntityIdResult, error) {
+func (m *mockRelationsFacade) ExportEntities(entities []names.Tag) ([]params.TokenResult, error) {
 	m.stub.MethodCall(m, "ExportEntities", entities)
 	if err := m.stub.NextErr(); err != nil {
 		return nil, err
 	}
-	result := make([]params.RemoteEntityIdResult, len(entities))
+	result := make([]params.TokenResult, len(entities))
 	for i, e := range entities {
-		result[i] = params.RemoteEntityIdResult{
-			Result: &params.RemoteEntityId{
-				ModelUUID: "model-uuid",
-				Token:     "token-" + e.Id(),
-			},
+		result[i] = params.TokenResult{
+			Token: "token-" + e.Id(),
 		}
 	}
 	return result, nil
 }
 
-func (m *mockRelationsFacade) ImportRemoteEntity(sourceModelUUID string, entity names.Tag, token string) error {
-	m.stub.MethodCall(m, "ImportRemoteEntity", sourceModelUUID, entity, token)
+func (m *mockRelationsFacade) ImportRemoteEntity(entity names.Tag, token string) error {
+	m.stub.MethodCall(m, "ImportRemoteEntity", entity, token)
 	return m.stub.NextErr()
 }
 
@@ -131,8 +128,8 @@ func (m *mockRelationsFacade) SaveMacaroon(entity names.Tag, mac *macaroon.Macar
 	return m.stub.NextErr()
 }
 
-func (m *mockRelationsFacade) GetToken(modelUUID string, entity names.Tag) (string, error) {
-	m.stub.MethodCall(m, "GetToken", modelUUID, entity)
+func (m *mockRelationsFacade) GetToken(entity names.Tag) (string, error) {
+	m.stub.MethodCall(m, "GetToken", entity)
 	if err := m.stub.NextErr(); err != nil {
 		return "", err
 	}
@@ -285,11 +282,8 @@ func (m *mockRemoteRelationsFacade) RegisterRemoteRelations(relations ...params.
 	}
 	for i, rel := range relations {
 		result[i].Result = &params.RemoteRelationDetails{
-			RemoteEntityId: params.RemoteEntityId{
-				ModelUUID: "source-model-uuid",
-				Token:     "token-" + rel.OfferName,
-			},
-			Macaroon: mac,
+			Token:     "token-" + rel.OfferName,
+			Macaroons: macaroon.Slice{mac},
 		}
 	}
 	return result, nil


### PR DESCRIPTION
## Description of change

This PR removes the unnecessary RemoteEntityId struct used with cmr and instead uses just the token in messages exchanged between models. The model uuid is stored with each remote application entity so is not neeed elsewhere. The code is simpler now.

## QA steps

bootstrap and relate mediawiki and mysql in different models.
remove relation and check status
add relation again and verify
