### PR TITLE
state: introduce DestroyModelParams

### DIFF
--- a/apiserver/common/modelmanagerinterface.go
+++ b/apiserver/common/modelmanagerinterface.go
@@ -84,8 +84,7 @@ type Model interface {
 	CloudCredential() (names.CloudCredentialTag, bool)
 	CloudRegion() string
 	Users() ([]permission.UserAccess, error)
-	Destroy() error
-	DestroyIncludingHosted() error
+	Destroy(state.DestroyModelParams) error
 	SLALevel() string
 	SLAOwner() string
 	MigrationMode() state.MigrationMode

--- a/apiserver/facades/client/modelmanager/modelinfo_test.go
+++ b/apiserver/facades/client/modelmanager/modelinfo_test.go
@@ -943,13 +943,8 @@ func (m *mockModel) Users() ([]permission.UserAccess, error) {
 	return users, nil
 }
 
-func (m *mockModel) Destroy() error {
-	m.MethodCall(m, "Destroy")
-	return m.NextErr()
-}
-
-func (m *mockModel) DestroyIncludingHosted() error {
-	m.MethodCall(m, "DestroyIncludingHosted")
+func (m *mockModel) Destroy(args state.DestroyModelParams) error {
+	m.MethodCall(m, "Destroy", args)
 	return m.NextErr()
 }
 

--- a/apiserver/facades/controller/undertaker/state.go
+++ b/apiserver/facades/controller/undertaker/state.go
@@ -66,8 +66,4 @@ type Model interface {
 
 	// UUID returns the universally unique identifier of the model.
 	UUID() string
-
-	// Destroy sets the model's lifecycle to Dying, preventing
-	// addition of services or machines to state.
-	Destroy() error
 }

--- a/apiserver/server_test.go
+++ b/apiserver/server_test.go
@@ -584,7 +584,7 @@ func (s *serverSuite) TestClosesStateFromPool(c *gc.C) {
 	conn.Close()
 
 	// When the model goes away the API server should ensure st gets closed.
-	err = model.Destroy()
+	err = model.Destroy(state.DestroyModelParams{})
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.State.StartSync()

--- a/cmd/jujud/agent/machine_test.go
+++ b/cmd/jujud/agent/machine_test.go
@@ -1397,7 +1397,7 @@ func (s *MachineSuite) TestDyingModelCleanedUp(c *gc.C) {
 		watch := model.Watch()
 		defer workertest.CleanKill(c, watch)
 
-		err = model.Destroy()
+		err = model.Destroy(state.DestroyModelParams{})
 		c.Assert(err, jc.ErrorIsNil)
 		for {
 			select {

--- a/featuretests/api_undertaker_test.go
+++ b/featuretests/api_undertaker_test.go
@@ -73,11 +73,11 @@ func (s *undertakerSuite) TestStateProcessDyingEnviron(c *gc.C) {
 	err = undertakerClient.ProcessDyingModel()
 	c.Assert(err, gc.ErrorMatches, "model is not dying")
 
-	env, err := s.State.Model()
+	model, err := s.State.Model()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(env.Destroy(), jc.ErrorIsNil)
-	c.Assert(env.Refresh(), jc.ErrorIsNil)
-	c.Assert(env.Life(), gc.Equals, state.Dying)
+	c.Assert(model.Destroy(state.DestroyModelParams{}), jc.ErrorIsNil)
+	c.Assert(model.Refresh(), jc.ErrorIsNil)
+	c.Assert(model.Life(), gc.Equals, state.Dying)
 
 	err = undertakerClient.ProcessDyingModel()
 	c.Assert(err, gc.ErrorMatches, `model not empty, found 1 machine\(s\)`)
@@ -115,18 +115,18 @@ func (s *undertakerSuite) TestHostedProcessDyingEnviron(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, "model is not dying")
 
 	factory.NewFactory(otherSt).MakeApplication(c, nil)
-	env, err := otherSt.Model()
+	model, err := otherSt.Model()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(env.Destroy(), jc.ErrorIsNil)
-	c.Assert(env.Refresh(), jc.ErrorIsNil)
-	c.Assert(env.Life(), gc.Equals, state.Dying)
+	c.Assert(model.Destroy(state.DestroyModelParams{}), jc.ErrorIsNil)
+	c.Assert(model.Refresh(), jc.ErrorIsNil)
+	c.Assert(model.Life(), gc.Equals, state.Dying)
 
 	err = otherSt.Cleanup()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(undertakerClient.ProcessDyingModel(), jc.ErrorIsNil)
 
-	c.Assert(env.Refresh(), jc.ErrorIsNil)
-	c.Assert(env.Life(), gc.Equals, state.Dead)
+	c.Assert(model.Refresh(), jc.ErrorIsNil)
+	c.Assert(model.Life(), gc.Equals, state.Dead)
 }
 
 func (s *undertakerSuite) TestWatchModelResources(c *gc.C) {
@@ -150,9 +150,9 @@ func (s *undertakerSuite) TestHostedRemoveEnviron(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, "can't remove model: model not dead")
 
 	factory.NewFactory(otherSt).MakeApplication(c, nil)
-	env, err := otherSt.Model()
+	model, err := otherSt.Model()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(env.Destroy(), jc.ErrorIsNil)
+	c.Assert(model.Destroy(state.DestroyModelParams{}), jc.ErrorIsNil)
 
 	// Aborts on dying environ.
 	err = undertakerClient.RemoveModel()

--- a/featuretests/cmd_juju_controller_test.go
+++ b/featuretests/cmd_juju_controller_test.go
@@ -152,7 +152,7 @@ func (s *cmdControllerSuite) TestListDeadModels(c *gc.C) {
 	defer st.Close()
 	m, err := st.Model()
 	c.Assert(err, jc.ErrorIsNil)
-	err = m.Destroy()
+	err = m.Destroy(state.DestroyModelParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	now := time.Now()
 	sInfo := status.StatusInfo{

--- a/state/annotations_test.go
+++ b/state/annotations_test.go
@@ -147,18 +147,18 @@ func (s *AnnotationsEnvSuite) SetUpTest(c *gc.C) {
 	})
 }
 
-func (s *AnnotationsEnvSuite) TestSetAnnotationsDestroyedEnvironment(c *gc.C) {
-	env, st := s.createTestEnv(c)
+func (s *AnnotationsEnvSuite) TestSetAnnotationsDestroyedModel(c *gc.C) {
+	model, st := s.createTestModel(c)
 	defer st.Close()
 
 	key := "key"
 	expected := "oops"
 	annts := map[string]string{key: expected}
-	err := st.SetAnnotations(env, annts)
+	err := st.SetAnnotations(model, annts)
 	c.Assert(err, jc.ErrorIsNil)
-	assertAnnotation(c, st, env, key, expected)
+	assertAnnotation(c, st, model, key, expected)
 
-	err = env.Destroy()
+	err = model.Destroy(state.DestroyModelParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	err = st.RemoveAllModelDocs()
 	c.Assert(err, jc.ErrorIsNil)
@@ -167,12 +167,12 @@ func (s *AnnotationsEnvSuite) TestSetAnnotationsDestroyedEnvironment(c *gc.C) {
 
 	expected = "fail"
 	annts[key] = expected
-	err = s.State.SetAnnotations(env, annts)
+	err = s.State.SetAnnotations(model, annts)
 	c.Assert(errors.Cause(err), gc.ErrorMatches, ".*model not found.*")
 	c.Assert(err, gc.ErrorMatches, ".*cannot update annotations.*")
 }
 
-func (s *AnnotationsEnvSuite) createTestEnv(c *gc.C) (*state.Model, *state.State) {
+func (s *AnnotationsEnvSuite) createTestModel(c *gc.C) (*state.Model, *state.State) {
 	uuid, err := utils.NewUUID()
 	c.Assert(err, jc.ErrorIsNil)
 	cfg := testing.CustomModelConfig(c, testing.Attrs{
@@ -180,10 +180,10 @@ func (s *AnnotationsEnvSuite) createTestEnv(c *gc.C) (*state.Model, *state.State
 		"uuid": uuid.String(),
 	})
 	owner := names.NewUserTag("test@remote")
-	env, st, err := s.State.NewModel(state.ModelArgs{
+	model, st, err := s.State.NewModel(state.ModelArgs{
 		CloudName: "dummy", CloudRegion: "dummy-region", Config: cfg, Owner: owner,
 		StorageProviderRegistry: storage.StaticProviderRegistry{},
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	return env, st
+	return model, st
 }

--- a/state/cleanup_test.go
+++ b/state/cleanup_test.go
@@ -151,9 +151,11 @@ func (s *CleanupSuite) TestCleanupControllerModels(c *gc.C) {
 
 	// Destroy the controller and check the model is unaffected, but a
 	// cleanup for the model and applications has been scheduled.
-	controllerEnv, err := s.State.Model()
+	controllerModel, err := s.State.Model()
 	c.Assert(err, jc.ErrorIsNil)
-	err = controllerEnv.DestroyIncludingHosted()
+	err = controllerModel.Destroy(state.DestroyModelParams{
+		DestroyHostedModels: true,
+	})
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Two cleanups should be scheduled. One to destroy the hosted
@@ -193,9 +195,9 @@ func (s *CleanupSuite) TestCleanupModelMachines(c *gc.C) {
 	s.assertDoesNotNeedCleanup(c)
 
 	// Destroy model, check cleanup queued.
-	env, err := s.State.Model()
+	model, err := s.State.Model()
 	c.Assert(err, jc.ErrorIsNil)
-	err = env.Destroy()
+	err = model.Destroy(state.DestroyModelParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	s.assertNeedsCleanup(c)
 
@@ -230,7 +232,7 @@ func (s *CleanupSuite) TestCleanupModelApplications(c *gc.C) {
 	// unaffected, but a cleanup for the application has been scheduled.
 	model, err := s.State.Model()
 	c.Assert(err, jc.ErrorIsNil)
-	err = model.Destroy()
+	err = model.Destroy(state.DestroyModelParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	s.assertNeedsCleanup(c)
 	s.assertCleanupRuns(c)

--- a/state/machine.go
+++ b/state/machine.go
@@ -742,7 +742,7 @@ func (m *Machine) assertNoPersistentStorage() (bson.D, error) {
 	attachments := make(set.Tags)
 	for _, v := range m.doc.Volumes {
 		tag := names.NewVolumeTag(v)
-		detachable, err := isDetachableVolumeTag(im, tag)
+		detachable, err := isDetachableVolumeTag(im.mb.db(), tag)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
@@ -752,7 +752,7 @@ func (m *Machine) assertNoPersistentStorage() (bson.D, error) {
 	}
 	for _, f := range m.doc.Filesystems {
 		tag := names.NewFilesystemTag(f)
-		detachable, err := isDetachableFilesystemTag(im, tag)
+		detachable, err := isDetachableFilesystemTag(im.mb.db(), tag)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}

--- a/state/machine_test.go
+++ b/state/machine_test.go
@@ -115,7 +115,7 @@ func (s *MachineSuite) TestSetUnsetRebootFlag(c *gc.C) {
 func (s *MachineSuite) TestAddMachineInsideMachineModelDying(c *gc.C) {
 	model, err := s.State.Model()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(model.Destroy(), jc.ErrorIsNil)
+	c.Assert(model.Destroy(state.DestroyModelParams{}), jc.ErrorIsNil)
 
 	_, err = s.State.AddMachineInsideMachine(state.MachineTemplate{
 		Series: "quantal",

--- a/state/migration_import_test.go
+++ b/state/migration_import_test.go
@@ -773,7 +773,7 @@ func (s *MigrationImportSuite) TestDestroyModelWithApplication(c *gc.C) {
 }
 
 func (s *MigrationImportSuite) assertDestroyModelAdvancesLife(c *gc.C, m *state.Model, life state.Life) {
-	err := m.Destroy()
+	err := m.Destroy(state.DestroyModelParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	err = m.Refresh()
 	c.Assert(err, jc.ErrorIsNil)

--- a/state/modelmigration_test.go
+++ b/state/modelmigration_test.go
@@ -226,7 +226,7 @@ func (s *MigrationSuite) TestCreateMigrationWhenModelNotAlive(c *gc.C) {
 	// Set the hosted model to Dying.
 	model, err := s.State2.Model()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(model.Destroy(), jc.ErrorIsNil)
+	c.Assert(model.Destroy(state.DestroyModelParams{}), jc.ErrorIsNil)
 
 	mig, err := s.State2.CreateMigration(s.stdSpec)
 	c.Check(mig, gc.IsNil)

--- a/state/remoteapplication_test.go
+++ b/state/remoteapplication_test.go
@@ -842,11 +842,11 @@ func (s *remoteApplicationSuite) TestAllRemoteApplications(c *gc.C) {
 	c.Assert(names[1], gc.Equals, "mysql")
 }
 
-func (s *remoteApplicationSuite) TestAddApplicationEnvironmentDying(c *gc.C) {
-	// Check that applications cannot be added if the environment is initially Dying.
+func (s *remoteApplicationSuite) TestAddApplicationModelDying(c *gc.C) {
+	// Check that applications cannot be added if the model is initially Dying.
 	model, err := s.State.Model()
 	c.Assert(err, jc.ErrorIsNil)
-	err = model.Destroy()
+	err = model.Destroy(state.DestroyModelParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	_, err = s.State.AddRemoteApplication(state.AddRemoteApplicationParams{
 		Name: "s1", SourceModel: s.State.ModelTag()})
@@ -899,14 +899,14 @@ func (s *remoteApplicationSuite) TestAddApplicationRemoteAddedAfterInitial(c *gc
 	c.Assert(err, gc.ErrorMatches, `cannot add remote application "s1": remote application already exists`)
 }
 
-func (s *remoteApplicationSuite) TestAddApplicationEnvironDiesAfterInitial(c *gc.C) {
+func (s *remoteApplicationSuite) TestAddApplicationModelDiesAfterInitial(c *gc.C) {
 	// Check that a application with a name conflict cannot be added if
 	// there is no conflict initially but a remote application is added
 	// before the transaction is run.
 	defer state.SetBeforeHooks(c, s.State, func() {
 		model, err := s.State.Model()
 		c.Assert(err, jc.ErrorIsNil)
-		err = model.Destroy()
+		err = model.Destroy(state.DestroyModelParams{})
 		c.Assert(err, jc.ErrorIsNil)
 	}).Check()
 	_, err := s.State.AddRemoteApplication(state.AddRemoteApplicationParams{

--- a/state/status_model_test.go
+++ b/state/status_model_test.go
@@ -86,14 +86,14 @@ func (s *ModelStatusSuite) TestGetSetStatusDying(c *gc.C) {
 	// directly to Dead.
 	factory.NewFactory(s.st).MakeMachine(c, nil)
 
-	err := s.model.Destroy()
+	err := s.model.Destroy(state.DestroyModelParams{})
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.checkGetSetStatus(c)
 }
 
 func (s *ModelStatusSuite) TestGetSetStatusDead(c *gc.C) {
-	err := s.model.Destroy()
+	err := s.model.Destroy(state.DestroyModelParams{})
 	c.Assert(err, jc.ErrorIsNil)
 
 	// NOTE: it would be more technically correct to reject status updates
@@ -103,7 +103,7 @@ func (s *ModelStatusSuite) TestGetSetStatusDead(c *gc.C) {
 }
 
 func (s *ModelStatusSuite) TestGetSetStatusGone(c *gc.C) {
-	err := s.model.Destroy()
+	err := s.model.Destroy(state.DestroyModelParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	err = s.st.RemoveAllModelDocs()
 	c.Assert(err, jc.ErrorIsNil)

--- a/state/undertaker.go
+++ b/state/undertaker.go
@@ -36,7 +36,11 @@ func (st *State) ProcessDyingModel() (err error) {
 			}
 		}
 
-		if err := model.checkEmpty(); err != nil {
+		modelEntityRefsDoc, err := model.getEntityRefs()
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		if _, err := checkModelEntityRefsEmpty(modelEntityRefsDoc); err != nil {
 			return nil, errors.Trace(err)
 		}
 


### PR DESCRIPTION
## Description of change

We consolidate Model.Destroy and Model.DestroyIncludingHosted
into a single method, Model.Destroy, and introduce the
DestoryModelParams struct to control its behaviour. There are
two fields for now:

 - DestroyHostedModels. If this is true, then the behaviour
   is the same as the removed Model.DestroyIncludingHosted
   method; otherwise the behaviour is the same as the replaced
   Model.Destroy method.
 - DestroyStorage. If this is nil, and there is any persistent
   storage in the model, then destroying the model will fail
   with an error that satisfies state.IsHasPersistentStorageError.
   If the field's value is true, then all storage will be
   destroyed. If the field's value is false, then the storage
   will be released/disassociated from the model/controller.

To implement these changes, we have to extend the cleanup doc
with cleanup-specific arguments.

To check whether storage is persistent in hosted models, we
have had to change various volume and filesystem query functions
to operate on a database, instead of a state object. This
avoids an expensive State.ForModel call.

In a followup we'll extend the API and CLI to force the user to choose
between destroying or releasing storage when using the destroy-model
and destroy-controller commands.

## QA steps

1. juju bootstrap localhost
2. juju deploy postgresql --storage pgdata=lxd
3. juju destroy-controller -y localhost --destroy-all-models

Controller should be destroyed, along with storage, as before.

## Documentation changes

Not yet.

## Bug reference

None.