### PR TITLE
destroy-controller: destroy/release storage flags

### DIFF
--- a/api/base/types.go
+++ b/api/base/types.go
@@ -32,6 +32,8 @@ type ModelStatus struct {
 	HostedMachineCount int
 	ServiceCount       int
 	Machines           []Machine
+	Volumes            []Volume
+	Filesystems        []Filesystem
 }
 
 // Machine holds information about a machine in a juju model.
@@ -76,4 +78,20 @@ type UserInfo struct {
 	DisplayName    string
 	LastConnection *time.Time
 	Access         string
+}
+
+// Volume holds information about a volume in a juju model.
+type Volume struct {
+	Id         string
+	ProviderId string
+	Status     string
+	Detachable bool
+}
+
+// Filesystem holds information about a filesystem in a juju model.
+type Filesystem struct {
+	Id         string
+	ProviderId string
+	Status     string
+	Detachable bool
 }

--- a/api/common/modelstatus.go
+++ b/api/common/modelstatus.go
@@ -48,6 +48,26 @@ func (c *ModelStatusAPI) ModelStatus(tags ...names.ModelTag) ([]base.ModelStatus
 			return nil, errors.Annotatef(err, "OwnerTag %q at position %d", r.OwnerTag, i)
 		}
 
+		volumes := make([]base.Volume, len(r.Volumes))
+		for i, in := range r.Volumes {
+			volumes[i] = base.Volume{
+				Id:         in.Id,
+				ProviderId: in.ProviderId,
+				Status:     in.Status,
+				Detachable: in.Detachable,
+			}
+		}
+
+		filesystems := make([]base.Filesystem, len(r.Filesystems))
+		for i, in := range r.Filesystems {
+			filesystems[i] = base.Filesystem{
+				Id:         in.Id,
+				ProviderId: in.ProviderId,
+				Status:     in.Status,
+				Detachable: in.Detachable,
+			}
+		}
+
 		results[i] = base.ModelStatus{
 			UUID:               model.Id(),
 			Life:               string(r.Life),
@@ -55,6 +75,8 @@ func (c *ModelStatusAPI) ModelStatus(tags ...names.ModelTag) ([]base.ModelStatus
 			HostedMachineCount: r.HostedMachineCount,
 			ServiceCount:       r.ApplicationCount,
 			TotalMachineCount:  len(r.Machines),
+			Volumes:            volumes,
+			Filesystems:        filesystems,
 		}
 		results[i].Machines = make([]base.Machine, len(r.Machines))
 		for j, mm := range r.Machines {

--- a/api/controller/legacy_test.go
+++ b/api/controller/legacy_test.go
@@ -98,7 +98,7 @@ func (s *legacySuite) TestDestroyController(c *gc.C) {
 
 	sysManager := s.OpenAPI(c)
 	defer sysManager.Close()
-	err := sysManager.DestroyController(false)
+	err := sysManager.DestroyController(controller.DestroyControllerParams{})
 	c.Assert(err, gc.ErrorMatches, `failed to destroy model: hosting 1 other models \(controller has hosted models\)`)
 }
 

--- a/api/facadeversions.go
+++ b/api/facadeversions.go
@@ -28,7 +28,7 @@ var facadeVersions = map[string]int{
 	"Cleaner":                      2,
 	"Client":                       1,
 	"Cloud":                        2,
-	"Controller":                   3,
+	"Controller":                   4,
 	"CrossModelRelations":          1,
 	"Deployer":                     1,
 	"DiskManager":                  2,

--- a/apiserver/allfacades.go
+++ b/apiserver/allfacades.go
@@ -136,7 +136,10 @@ func AllFacades() *facade.Registry {
 	if featureflag.Enabled(feature.CAAS) {
 		reg("Cloud", 2, cloud.NewFacadeV2)
 	}
-	reg("Controller", 3, controller.NewControllerAPI)
+
+	reg("Controller", 3, controller.NewControllerAPIv3)
+	reg("Controller", 4, controller.NewControllerAPIv4)
+
 	reg("Deployer", 1, deployer.NewDeployerAPI)
 	reg("DiskManager", 2, diskmanager.NewDiskManagerAPI)
 	reg("Firewaller", 3, firewaller.NewStateFirewallerAPIV3)

--- a/apiserver/common/errors.go
+++ b/apiserver/common/errors.go
@@ -217,6 +217,8 @@ func ServerError(err error) *params.Error {
 		code = params.CodeHasAssignedUnits
 	case state.IsHasHostedModelsError(err):
 		code = params.CodeHasHostedModels
+	case state.IsHasPersistentStorageError(err):
+		code = params.CodeHasPersistentStorage
 	case isNoAddressSetError(err):
 		code = params.CodeNoAddressSet
 	case errors.IsNotProvisioned(err):
@@ -309,6 +311,8 @@ func RestoreError(err error) error {
 		// ...by parsing msg?
 		return err
 	case params.IsCodeHasHostedModels(err):
+		return err
+	case params.IsCodeHasPersistentStorage(err):
 		return err
 	case params.IsCodeNoAddressSet(err):
 		// TODO(ericsnow) Handle isNoAddressSetError here.

--- a/apiserver/common/modeldestroy.go
+++ b/apiserver/common/modeldestroy.go
@@ -6,7 +6,6 @@ package common
 import (
 	"github.com/juju/errors"
 	"github.com/juju/utils/clock"
-	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/apiserver/facades/agent/metricsender"
 	"github.com/juju/juju/state"
@@ -28,42 +27,28 @@ var sendMetrics = func(st metricsender.ModelBackend) error {
 	return errors.Trace(err)
 }
 
-// DestroyModelIncludingHosted sets the model to dying. Cleanup jobs then destroy
-// all services and non-manager, non-manual machine instances in the specified
-// model. This function assumes that all necessary authentication checks
-// have been done. If the model is a controller hosting other
-// models, they will also be destroyed.
-func DestroyModelIncludingHosted(st ModelManagerBackend, systemTag names.ModelTag) error {
-	return destroyModel(st, systemTag, true)
-}
-
-// DestroyModel sets the environment to dying. Cleanup jobs then destroy
-// all services and non-manager, non-manual machine instances in the specified
-// model. This function assumes that all necessary authentication checks
-// have been done. An error will be returned if this model is a
-// controller hosting other model.
-func DestroyModel(st ModelManagerBackend, modelTag names.ModelTag) error {
-	return destroyModel(st, modelTag, false)
-}
-
-func destroyModel(st ModelManagerBackend, modelTag names.ModelTag, destroyHostedModels bool) error {
-	var err error
-	if modelTag != st.ModelTag() {
-		if st, err = st.ForModel(modelTag); err != nil {
-			return errors.Trace(err)
-		}
-		defer st.Close()
+// DestroyController sets the controller model to Dying and, if requested,
+// schedules cleanups so that all of the hosted models are destroyed, or
+// otherwise returns an error indicating that there are hosted models
+// remaining.
+func DestroyController(
+	st ModelManagerBackend,
+	destroyHostedModels bool,
+	destroyStorage *bool,
+) error {
+	modelTag := st.ModelTag()
+	controllerModel, err := st.ControllerModel()
+	if err != nil {
+		return errors.Trace(err)
 	}
-
+	if modelTag != controllerModel.ModelTag() {
+		return errors.Errorf(
+			"expected state for controller model UUID %v, got %v",
+			controllerModel.ModelTag().Id(),
+			modelTag.Id(),
+		)
+	}
 	if destroyHostedModels {
-		// Check we are operating on the controller state.
-		controllerModel, err := st.ControllerModel()
-		if err != nil {
-			return errors.Trace(err)
-		}
-		if modelTag != controllerModel.ModelTag() {
-			return errors.Errorf("expected controller model UUID %v, got %v", modelTag.Id(), controllerModel.ModelTag().Id())
-		}
 		models, err := st.AllModels()
 		if err != nil {
 			return errors.Trace(err)
@@ -83,23 +68,34 @@ func destroyModel(st ModelManagerBackend, modelTag names.ModelTag, destroyHosted
 				logger.Errorf("failed to send leftover metrics: %v", err)
 			}
 		}
-	} else {
-		check := NewBlockChecker(st)
-		if err = check.DestroyAllowed(); err != nil {
-			return errors.Trace(err)
-		}
+	}
+	return destroyModel(st, state.DestroyModelParams{
+		DestroyHostedModels: destroyHostedModels,
+		DestroyStorage:      destroyStorage,
+	})
+}
+
+// DestroyModel sets the model to Dying, such that the model's resources will
+// be destroyed and the model removed from the controller.
+func DestroyModel(st ModelManagerBackend) error {
+	// TODO(axw) make this a parameter.
+	destroyStorage := true
+	return destroyModel(st, state.DestroyModelParams{
+		DestroyStorage: &destroyStorage,
+	})
+}
+
+func destroyModel(st ModelManagerBackend, args state.DestroyModelParams) error {
+	check := NewBlockChecker(st)
+	if err := check.DestroyAllowed(); err != nil {
+		return errors.Trace(err)
 	}
 
 	model, err := st.Model()
 	if err != nil {
 		return errors.Trace(err)
 	}
-
-	destroyStorage := true
-	if err := model.Destroy(state.DestroyModelParams{
-		DestroyHostedModels: destroyHostedModels,
-		DestroyStorage:      &destroyStorage,
-	}); err != nil {
+	if err := model.Destroy(args); err != nil {
 		return errors.Trace(err)
 	}
 

--- a/apiserver/common/modelmanagerinterface.go
+++ b/apiserver/common/modelmanagerinterface.go
@@ -50,6 +50,8 @@ type ModelManagerBackend interface {
 	UserAccess(names.UserTag, names.Tag) (permission.UserAccess, error)
 	AllMachines() (machines []Machine, err error)
 	AllApplications() (applications []Application, err error)
+	AllFilesystems() ([]state.Filesystem, error)
+	AllVolumes() ([]state.Volume, error)
 	ControllerUUID() string
 	ControllerTag() names.ControllerTag
 	Export() (description.Model, error)
@@ -213,6 +215,22 @@ func (st modelManagerStateShim) AllApplications() ([]Application, error) {
 		all[i] = applicationShim{a}
 	}
 	return all, nil
+}
+
+func (st modelManagerStateShim) AllFilesystems() ([]state.Filesystem, error) {
+	model, err := st.State.IAASModel()
+	if err != nil {
+		return nil, err
+	}
+	return model.AllFilesystems()
+}
+
+func (st modelManagerStateShim) AllVolumes() ([]state.Volume, error) {
+	model, err := st.State.IAASModel()
+	if err != nil {
+		return nil, err
+	}
+	return model.AllVolumes()
 }
 
 // BackendPool provides access to a pool of ModelManagerBackends.

--- a/apiserver/common/modelstatus_test.go
+++ b/apiserver/common/modelstatus_test.go
@@ -23,7 +23,7 @@ import (
 type modelStatusSuite struct {
 	statetesting.StateSuite
 
-	controller *controller.ControllerAPI
+	controller *controller.ControllerAPIv4
 	resources  *common.Resources
 	authorizer apiservertesting.FakeAuthorizer
 	pool       *state.StatePool
@@ -49,7 +49,7 @@ func (s *modelStatusSuite) SetUpTest(c *gc.C) {
 	s.pool = state.NewStatePool(s.State)
 	s.AddCleanup(func(*gc.C) { s.pool.Close() })
 
-	controller, err := controller.NewControllerAPI(
+	controller, err := controller.NewControllerAPIv4(
 		facadetest.Context{
 			State_:     s.State,
 			Resources_: s.resources,
@@ -68,7 +68,7 @@ func (s *modelStatusSuite) TestModelStatusNonAuth(c *gc.C) {
 	anAuthoriser := apiservertesting.FakeAuthorizer{
 		Tag: user.Tag(),
 	}
-	endpoint, err := controller.NewControllerAPI(
+	endpoint, err := controller.NewControllerAPIv4(
 		facadetest.Context{
 			State_:     s.State,
 			Resources_: s.resources,
@@ -92,7 +92,7 @@ func (s *modelStatusSuite) TestModelStatusOwnerAllowed(c *gc.C) {
 	}
 	st := s.Factory.MakeModel(c, &factory.ModelParams{Owner: owner.Tag()})
 	defer st.Close()
-	endpoint, err := controller.NewControllerAPI(
+	endpoint, err := controller.NewControllerAPIv4(
 		facadetest.Context{
 			State_:     s.State,
 			Resources_: s.resources,

--- a/apiserver/common/modelstatus_test.go
+++ b/apiserver/common/modelstatus_test.go
@@ -4,6 +4,7 @@
 package common_test
 
 import (
+	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
@@ -13,9 +14,15 @@ import (
 	"github.com/juju/juju/apiserver/facades/client/controller"
 	"github.com/juju/juju/apiserver/params"
 	apiservertesting "github.com/juju/juju/apiserver/testing"
+	"github.com/juju/juju/constraints"
+	"github.com/juju/juju/environs"
+	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/instance"
+	"github.com/juju/juju/provider/dummy"
 	"github.com/juju/juju/state"
 	statetesting "github.com/juju/juju/state/testing"
+	"github.com/juju/juju/storage"
+	"github.com/juju/juju/storage/provider"
 	"github.com/juju/juju/testing"
 	"github.com/juju/juju/testing/factory"
 )
@@ -36,6 +43,9 @@ func (s *modelStatusSuite) SetUpTest(c *gc.C) {
 	s.InitialConfig = testing.CustomModelConfig(c, testing.Attrs{
 		"name": "controller",
 	})
+	s.NewPolicy = func(*state.State) state.Policy {
+		return statePolicy{}
+	}
 
 	s.StateSuite.SetUpTest(c)
 	s.resources = common.NewResources()
@@ -124,9 +134,28 @@ func (s *modelStatusSuite) TestModelStatus(c *gc.C) {
 		Jobs:            []state.MachineJob{state.JobManageModel},
 		Characteristics: &instance.HardwareCharacteristics{CpuCores: &eight},
 		InstanceId:      "id-4",
+		Volumes: []state.MachineVolumeParams{{
+			Volume: state.VolumeParams{
+				Pool: "modelscoped",
+				Size: 123,
+			},
+		}},
 	})
 	s.Factory.MakeMachine(c, &factory.MachineParams{
-		Jobs: []state.MachineJob{state.JobHostUnits}, InstanceId: "id-5"})
+		Jobs:       []state.MachineJob{state.JobHostUnits},
+		InstanceId: "id-5",
+		Filesystems: []state.MachineFilesystemParams{{
+			Filesystem: state.FilesystemParams{
+				Pool: "modelscoped",
+				Size: 123,
+			},
+		}, {
+			Filesystem: state.FilesystemParams{
+				Pool: "machinescoped",
+				Size: 123,
+			},
+		}},
+	})
 	s.Factory.MakeApplication(c, &factory.ApplicationParams{
 		Charm: s.Factory.MakeCharm(c, nil),
 	})
@@ -163,6 +192,14 @@ func (s *modelStatusSuite) TestModelStatus(c *gc.C) {
 			{Id: "0", Hardware: &params.MachineHardware{Cores: &eight}, InstanceId: "id-4", Status: "pending", WantsVote: true},
 			{Id: "1", Hardware: stdHw, InstanceId: "id-5", Status: "pending"},
 		},
+		Volumes: []params.ModelVolumeInfo{{
+			Id: "0", Status: "pending", Detachable: true,
+		}},
+		Filesystems: []params.ModelFilesystemInfo{{
+			Id: "0", Status: "pending", Detachable: true,
+		}, {
+			Id: "1/1", Status: "pending", Detachable: false,
+		}},
 	}, {
 		ModelTag:           hostedModelTag,
 		HostedMachineCount: 2,
@@ -174,4 +211,33 @@ func (s *modelStatusSuite) TestModelStatus(c *gc.C) {
 			{Id: "1", Hardware: stdHw, InstanceId: "id-9", Status: "pending"},
 		},
 	}})
+}
+
+type statePolicy struct{}
+
+func (statePolicy) Prechecker() (environs.InstancePrechecker, error) {
+	return nil, errors.NotImplementedf("Prechecker")
+}
+
+func (statePolicy) ConfigValidator() (config.Validator, error) {
+	return nil, errors.NotImplementedf("ConfigValidator")
+}
+
+func (statePolicy) ConstraintsValidator() (constraints.Validator, error) {
+	return nil, errors.NotImplementedf("ConstraintsValidator")
+}
+
+func (statePolicy) InstanceDistributor() (instance.Distributor, error) {
+	return nil, errors.NotImplementedf("InstanceDistributor")
+}
+
+func (statePolicy) StorageProviderRegistry() (storage.ProviderRegistry, error) {
+	return storage.ChainedProviderRegistry{
+		dummy.StorageProviders(),
+		provider.CommonStorageProviders(),
+	}, nil
+}
+
+func (statePolicy) ProviderConfigSchemaSource() (config.ConfigSchemaSource, error) {
+	return nil, errors.NotImplementedf("ConfigSchemaSource")
 }

--- a/apiserver/facades/client/controller/controller.go
+++ b/apiserver/facades/client/controller/controller.go
@@ -31,25 +31,13 @@ import (
 
 var logger = loggo.GetLogger("juju.apiserver.controller")
 
-// Controller defines the methods on the controller API end point.
-type Controller interface {
-	AllModels() (params.UserModelList, error)
-	DestroyController(args params.DestroyControllerArgs) error
-	ModelConfig() (params.ModelConfigResults, error)
-	HostedModelConfigs() (params.HostedModelConfigsResults, error)
-	GetControllerAccess(params.Entities) (params.UserAccessResults, error)
-	ControllerConfig() (params.ControllerConfigResult, error)
-	ListBlockedModels() (params.ModelBlockInfoList, error)
-	RemoveBlocks(args params.RemoveBlocksArgs) error
-	WatchAllModels() (params.AllWatcherId, error)
-	ModelStatus(params.Entities) (params.ModelStatusResults, error)
-	InitiateMigration(params.InitiateMigrationArgs) (params.InitiateMigrationResults, error)
-	ModifyControllerAccess(params.ModifyControllerAccessRequest) (params.ErrorResults, error)
+// ControllerAPIv4 provides the v4 Controller API.
+type ControllerAPIv4 struct {
+	*ControllerAPIv3
 }
 
-// ControllerAPI implements the environment manager interface and is
-// the concrete implementation of the api end point.
-type ControllerAPI struct {
+// ControllerAPIv3 provides the v3 Controller API.
+type ControllerAPIv3 struct {
 	*common.ControllerConfigAPI
 	*common.ModelStatusAPI
 	cloudspec.CloudSpecAPI
@@ -61,11 +49,17 @@ type ControllerAPI struct {
 	resources  facade.Resources
 }
 
-var _ Controller = (*ControllerAPI)(nil)
+// NewControllerAPIv4 creates a new ControllerAPIv4.
+func NewControllerAPIv4(ctx facade.Context) (*ControllerAPIv4, error) {
+	v3, err := NewControllerAPIv3(ctx)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return &ControllerAPIv4{v3}, nil
+}
 
-// NewControllerAPI creates a new api server endpoint for managing
-// environments.
-func NewControllerAPI(ctx facade.Context) (*ControllerAPI, error) {
+// NewControllerAPIv3 creates a new ControllerAPIv3.
+func NewControllerAPIv3(ctx facade.Context) (*ControllerAPIv3, error) {
 	authorizer := ctx.Auth()
 	if !authorizer.AuthClient() {
 		return nil, errors.Trace(common.ErrPerm)
@@ -77,7 +71,7 @@ func NewControllerAPI(ctx facade.Context) (*ControllerAPI, error) {
 
 	st := ctx.State()
 	environConfigGetter := stateenvirons.EnvironConfigGetter{st}
-	return &ControllerAPI{
+	return &ControllerAPIv3{
 		ControllerConfigAPI: common.NewStateControllerConfig(st),
 		ModelStatusAPI: common.NewModelStatusAPI(
 			common.NewModelManagerBackend(st),
@@ -94,7 +88,7 @@ func NewControllerAPI(ctx facade.Context) (*ControllerAPI, error) {
 	}, nil
 }
 
-func (s *ControllerAPI) checkHasAdmin() error {
+func (s *ControllerAPIv3) checkHasAdmin() error {
 	isAdmin, err := s.authorizer.HasPermission(permission.SuperuserAccess, s.state.ControllerTag())
 	if err != nil {
 		return errors.Trace(err)
@@ -107,7 +101,7 @@ func (s *ControllerAPI) checkHasAdmin() error {
 
 // AllModels allows controller administrators to get the list of all the
 // models in the controller.
-func (s *ControllerAPI) AllModels() (params.UserModelList, error) {
+func (s *ControllerAPIv3) AllModels() (params.UserModelList, error) {
 	result := params.UserModelList{}
 	if err := s.checkHasAdmin(); err != nil {
 		return result, errors.Trace(err)
@@ -168,7 +162,7 @@ func (s *ControllerAPI) AllModels() (params.UserModelList, error) {
 // which have a block in place.  The resulting slice is sorted by environment
 // name, then owner. Callers must be controller administrators to retrieve the
 // list.
-func (s *ControllerAPI) ListBlockedModels() (params.ModelBlockInfoList, error) {
+func (s *ControllerAPIv3) ListBlockedModels() (params.ModelBlockInfoList, error) {
 	results := params.ModelBlockInfoList{}
 	if err := s.checkHasAdmin(); err != nil {
 		return results, errors.Trace(err)
@@ -213,7 +207,7 @@ func (s *ControllerAPI) ListBlockedModels() (params.ModelBlockInfoList, error) {
 // ModelConfig returns the environment config for the controller
 // environment.  For information on the current environment, use
 // client.ModelGet
-func (s *ControllerAPI) ModelConfig() (params.ModelConfigResults, error) {
+func (s *ControllerAPIv3) ModelConfig() (params.ModelConfigResults, error) {
 	result := params.ModelConfigResults{}
 	if err := s.checkHasAdmin(); err != nil {
 		return result, errors.Trace(err)
@@ -241,7 +235,7 @@ func (s *ControllerAPI) ModelConfig() (params.ModelConfigResults, error) {
 // HostedModelConfigs returns all the information that the client needs in
 // order to connect directly with the host model's provider and destroy it
 // directly.
-func (s *ControllerAPI) HostedModelConfigs() (params.HostedModelConfigsResults, error) {
+func (s *ControllerAPIv3) HostedModelConfigs() (params.HostedModelConfigsResults, error) {
 	result := params.HostedModelConfigsResults{}
 	if err := s.checkHasAdmin(); err != nil {
 		return result, errors.Trace(err)
@@ -282,7 +276,7 @@ func (s *ControllerAPI) HostedModelConfigs() (params.HostedModelConfigsResults, 
 }
 
 // RemoveBlocks removes all the blocks in the controller.
-func (s *ControllerAPI) RemoveBlocks(args params.RemoveBlocksArgs) error {
+func (s *ControllerAPIv3) RemoveBlocks(args params.RemoveBlocksArgs) error {
 	if err := s.checkHasAdmin(); err != nil {
 		return errors.Trace(err)
 	}
@@ -296,7 +290,7 @@ func (s *ControllerAPI) RemoveBlocks(args params.RemoveBlocksArgs) error {
 // WatchAllModels starts watching events for all models in the
 // controller. The returned AllWatcherId should be used with Next on the
 // AllModelWatcher endpoint to receive deltas.
-func (c *ControllerAPI) WatchAllModels() (params.AllWatcherId, error) {
+func (c *ControllerAPIv3) WatchAllModels() (params.AllWatcherId, error) {
 	if err := c.checkHasAdmin(); err != nil {
 		return params.AllWatcherId{}, errors.Trace(err)
 	}
@@ -335,7 +329,7 @@ func (o orderedBlockInfo) Less(i, j int) bool {
 
 // GetControllerAccess returns the level of access the specifed users
 // have on the controller.
-func (c *ControllerAPI) GetControllerAccess(req params.Entities) (params.UserAccessResults, error) {
+func (c *ControllerAPIv3) GetControllerAccess(req params.Entities) (params.UserAccessResults, error) {
 	results := params.UserAccessResults{}
 	isAdmin, err := c.authorizer.HasPermission(permission.SuperuserAccess, c.state.ControllerTag())
 	if err != nil {
@@ -368,7 +362,7 @@ func (c *ControllerAPI) GetControllerAccess(req params.Entities) (params.UserAcc
 
 // InitiateMigration attempts to begin the migration of one or
 // more models to other controllers.
-func (c *ControllerAPI) InitiateMigration(reqArgs params.InitiateMigrationArgs) (
+func (c *ControllerAPIv3) InitiateMigration(reqArgs params.InitiateMigrationArgs) (
 	params.InitiateMigrationResults, error,
 ) {
 	out := params.InitiateMigrationResults{
@@ -391,7 +385,7 @@ func (c *ControllerAPI) InitiateMigration(reqArgs params.InitiateMigrationArgs) 
 	return out, nil
 }
 
-func (c *ControllerAPI) initiateOneMigration(spec params.MigrationSpec) (string, error) {
+func (c *ControllerAPIv3) initiateOneMigration(spec params.MigrationSpec) (string, error) {
 	modelTag, err := names.ParseModelTag(spec.ModelTag)
 	if err != nil {
 		return "", errors.Annotate(err, "model tag")
@@ -450,7 +444,7 @@ func (c *ControllerAPI) initiateOneMigration(spec params.MigrationSpec) (string,
 }
 
 // ModifyControllerAccess changes the model access granted to users.
-func (c *ControllerAPI) ModifyControllerAccess(args params.ModifyControllerAccessRequest) (params.ErrorResults, error) {
+func (c *ControllerAPIv3) ModifyControllerAccess(args params.ModifyControllerAccessRequest) (params.ErrorResults, error) {
 	result := params.ErrorResults{
 		Results: make([]params.ErrorResult, len(args.Changes)),
 	}

--- a/apiserver/facades/client/controller/controller_test.go
+++ b/apiserver/facades/client/controller/controller_test.go
@@ -37,7 +37,7 @@ type controllerSuite struct {
 	statetesting.StateSuite
 
 	statePool  *state.StatePool
-	controller *controller.ControllerAPI
+	controller *controller.ControllerAPIv4
 	resources  *common.Resources
 	authorizer apiservertesting.FakeAuthorizer
 }
@@ -66,7 +66,7 @@ func (s *controllerSuite) SetUpTest(c *gc.C) {
 		AdminTag: s.Owner,
 	}
 
-	controller, err := controller.NewControllerAPI(
+	controller, err := controller.NewControllerAPIv4(
 		facadetest.Context{
 			State_:     s.State,
 			StatePool_: s.statePool,
@@ -83,7 +83,7 @@ func (s *controllerSuite) TestNewAPIRefusesNonClient(c *gc.C) {
 	anAuthoriser := apiservertesting.FakeAuthorizer{
 		Tag: names.NewUnitTag("mysql/0"),
 	}
-	endPoint, err := controller.NewControllerAPI(
+	endPoint, err := controller.NewControllerAPIv4(
 		facadetest.Context{
 			State_:     s.State,
 			Resources_: s.resources,
@@ -259,7 +259,7 @@ func (s *controllerSuite) TestModelConfigFromNonController(c *gc.C) {
 		Tag:      s.Owner,
 		AdminTag: s.Owner,
 	}
-	controller, err := controller.NewControllerAPI(
+	controller, err := controller.NewControllerAPIv4(
 		facadetest.Context{
 			State_:     st,
 			Resources_: common.NewResources(),
@@ -288,7 +288,7 @@ func (s *controllerSuite) TestControllerConfigFromNonController(c *gc.C) {
 	defer st.Close()
 
 	authorizer := &apiservertesting.FakeAuthorizer{Tag: s.Owner}
-	controller, err := controller.NewControllerAPI(
+	controller, err := controller.NewControllerAPIv4(
 		facadetest.Context{
 			State_:     st,
 			Resources_: common.NewResources(),
@@ -789,7 +789,7 @@ func (s *controllerSuite) TestGetControllerAccessPermissions(c *gc.C) {
 	anAuthoriser := apiservertesting.FakeAuthorizer{
 		Tag: user.Tag(),
 	}
-	endpoint, err := controller.NewControllerAPI(
+	endpoint, err := controller.NewControllerAPIv4(
 		facadetest.Context{
 			State_:     s.State,
 			Resources_: s.resources,

--- a/apiserver/facades/client/controller/destroy.go
+++ b/apiserver/facades/client/controller/destroy.go
@@ -7,36 +7,51 @@ import (
 	"github.com/juju/errors"
 
 	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/permission"
+	"github.com/juju/juju/state"
 )
 
-// DestroyController will attempt to destroy the controller. If the args
-// specify the removal of blocks or the destruction of the models, this
-// method will attempt to do so.
+// DestroyController destroys the controller.
 //
-// If the controller has any non-Dead hosted models, then an error with
-// the code params.CodeHasHostedModels will be transmitted, regardless of
-// the value of the DestroyModels parameter. This is to inform the client
-// that it should wait for hosted models to be completely cleaned up
-// before proceeding.
-func (s *ControllerAPI) DestroyController(args params.DestroyControllerArgs) error {
-	hasPermission, err := s.authorizer.HasPermission(permission.SuperuserAccess, s.state.ControllerTag())
+// The v3 implementation of DestroyController ignores the DestroyStorage
+// field of the arguments, and unconditionally destroys all storage in
+// the controller.
+//
+// See ControllerAPIv4.DestroyController for more details.
+func (s *ControllerAPIv3) DestroyController(args params.DestroyControllerArgs) error {
+	if args.DestroyStorage != nil {
+		return errors.New("destroy-storage unexpected on the v3 API")
+	}
+	destroyStorage := true
+	args.DestroyStorage = &destroyStorage
+	return destroyController(s.state, s.authorizer, args)
+}
+
+// DestroyController destroys the controller.
+//
+// If the args specify the destruction of the models, this method will
+// attempt to do so. Otherwise, if the controller has any non-empty,
+// non-Dead hosted models, then an error with the code
+// params.CodeHasHostedModels will be transmitted.
+func (s *ControllerAPIv4) DestroyController(args params.DestroyControllerArgs) error {
+	return destroyController(s.state, s.authorizer, args)
+}
+
+func destroyController(
+	st *state.State,
+	authorizer facade.Authorizer,
+	args params.DestroyControllerArgs,
+) error {
+	hasPermission, err := authorizer.HasPermission(permission.SuperuserAccess, st.ControllerTag())
 	if err != nil {
 		return errors.Trace(err)
 	}
 	if !hasPermission {
 		return errors.Trace(common.ErrPerm)
 	}
-
-	st := common.NewModelManagerBackend(s.state)
-	controllerModel, err := st.ControllerModel()
-	if err != nil {
-		return errors.Trace(err)
-	}
-	systemTag := controllerModel.ModelTag()
-
-	if err = s.ensureNotBlocked(args); err != nil {
+	if err := ensureNotBlocked(st); err != nil {
 		return errors.Trace(err)
 	}
 
@@ -44,23 +59,19 @@ func (s *ControllerAPI) DestroyController(args params.DestroyControllerArgs) err
 	// models but set the controller to dying to prevent new
 	// models sneaking in. If we are not destroying hosted models,
 	// this will fail if any hosted models are found.
-	if args.DestroyModels {
-		return errors.Trace(common.DestroyModelIncludingHosted(st, systemTag))
-	}
-	if err := common.DestroyModel(st, systemTag); err != nil {
-		return errors.Trace(err)
-	}
-	return nil
+	backend := common.NewModelManagerBackend(st)
+	return errors.Trace(common.DestroyController(
+		backend, args.DestroyModels, args.DestroyStorage,
+	))
 }
 
-func (s *ControllerAPI) ensureNotBlocked(args params.DestroyControllerArgs) error {
+func ensureNotBlocked(st *state.State) error {
 	// If there are blocks let the user know.
-	blocks, err := s.state.AllBlocksForController()
+	blocks, err := st.AllBlocksForController()
 	if err != nil {
 		logger.Debugf("Unable to get blocks for controller: %s", err)
 		return errors.Trace(err)
 	}
-
 	if len(blocks) > 0 {
 		return common.OperationBlockedError("found blocks in controller models")
 	}

--- a/apiserver/facades/client/modelmanager/modelinfo_test.go
+++ b/apiserver/facades/client/modelmanager/modelinfo_test.go
@@ -582,6 +582,16 @@ func (st *mockState) AllApplications() ([]common.Application, error) {
 	return nil, st.NextErr()
 }
 
+func (st *mockState) AllVolumes() ([]state.Volume, error) {
+	st.MethodCall(st, "AllVolumes")
+	return nil, st.NextErr()
+}
+
+func (st *mockState) AllFilesystems() ([]state.Filesystem, error) {
+	st.MethodCall(st, "AllFilesystems")
+	return nil, st.NextErr()
+}
+
 func (st *mockState) IsControllerAdmin(user names.UserTag) (bool, error) {
 	st.MethodCall(st, "IsControllerAdmin", user)
 	if st.controllerModel == nil {

--- a/apiserver/facades/client/modelmanager/modelmanager.go
+++ b/apiserver/facades/client/modelmanager/modelmanager.go
@@ -588,7 +588,12 @@ func (m *ModelManagerAPI) DestroyModels(args params.Entities) (params.ErrorResul
 		if err := m.authCheck(model.Owner()); err != nil {
 			return errors.Trace(err)
 		}
-		return errors.Trace(common.DestroyModel(m.state, tag))
+		st, releaser, err := m.pool.Get(tag.Id())
+		if err != nil {
+			return errors.Trace(err)
+		}
+		defer releaser()
+		return errors.Trace(common.DestroyModel(st))
 	}
 
 	for i, arg := range args.Entities {

--- a/apiserver/params/apierror.go
+++ b/apiserver/params/apierror.go
@@ -75,6 +75,7 @@ const (
 	CodeDead                      = "dead"
 	CodeHasAssignedUnits          = "machine has assigned units"
 	CodeHasHostedModels           = "controller has hosted models"
+	CodeHasPersistentStorage      = "controller/model has persistent storage"
 	CodeMachineHasAttachedStorage = "machine has attached storage"
 	CodeStorageAttached           = "storage is attached"
 	CodeNotProvisioned            = "not provisioned"
@@ -183,6 +184,10 @@ func IsCodeHasAssignedUnits(err error) bool {
 
 func IsCodeHasHostedModels(err error) bool {
 	return ErrCode(err) == CodeHasHostedModels
+}
+
+func IsCodeHasPersistentStorage(err error) bool {
+	return ErrCode(err) == CodeHasPersistentStorage
 }
 
 func IsCodeMachineHasAttachedStorage(err error) bool {

--- a/apiserver/params/controller.go
+++ b/apiserver/params/controller.go
@@ -9,6 +9,14 @@ type DestroyControllerArgs struct {
 	// should be destroyed as well. If this is not specified, and there are
 	// other hosted models, the destruction of the controller will fail.
 	DestroyModels bool `json:"destroy-models"`
+
+	// DestroyStorage controls whether or not storage in the model (and
+	// hosted models, if DestroyModels is true) should be destroyed.
+	//
+	// This is ternary: nil, false, or true. If nil and there is persistent
+	// storage in the model (or hosted models), an error with the code
+	// params.CodeHasPersistentStorage will be returned.
+	DestroyStorage *bool `json:"destroy-storage,omitempty"`
 }
 
 // ModelBlockInfo holds information about an model and its

--- a/apiserver/params/controller.go
+++ b/apiserver/params/controller.go
@@ -43,12 +43,14 @@ type RemoveBlocksArgs struct {
 
 // ModelStatus holds information about the status of a juju model.
 type ModelStatus struct {
-	ModelTag           string             `json:"model-tag"`
-	Life               Life               `json:"life"`
-	HostedMachineCount int                `json:"hosted-machine-count"`
-	ApplicationCount   int                `json:"application-count"`
-	OwnerTag           string             `json:"owner-tag"`
-	Machines           []ModelMachineInfo `json:"machines,omitempty"`
+	ModelTag           string                `json:"model-tag"`
+	Life               Life                  `json:"life"`
+	HostedMachineCount int                   `json:"hosted-machine-count"`
+	ApplicationCount   int                   `json:"application-count"`
+	OwnerTag           string                `json:"owner-tag"`
+	Machines           []ModelMachineInfo    `json:"machines,omitempty"`
+	Volumes            []ModelVolumeInfo     `json:"volumes,omitempty"`
+	Filesystems        []ModelFilesystemInfo `json:"filesystems,omitempty"`
 }
 
 // ModelStatusResults holds status information about a group of models.

--- a/apiserver/params/model.go
+++ b/apiserver/params/model.go
@@ -218,6 +218,22 @@ type MachineHardware struct {
 	AvailabilityZone *string   `json:"availability-zone,omitempty"`
 }
 
+// ModelVolumeInfo holds information about a volume in a model.
+type ModelVolumeInfo struct {
+	Id         string `json:"id"`
+	ProviderId string `json:"provider-id,omitempty"`
+	Status     string `json:"status,omitempty"`
+	Detachable bool   `json:"detachable,omitempty"`
+}
+
+// ModelFilesystemInfo holds information about a filesystem in a model.
+type ModelFilesystemInfo struct {
+	Id         string `json:"id"`
+	ProviderId string `json:"provider-id,omitempty"`
+	Status     string `json:"status,omitempty"`
+	Detachable bool   `json:"detachable,omitempty"`
+}
+
 // ModelUserInfo holds information on a user who has access to a
 // model. Owners of a model can see this information for all users
 // who have access, so it should not include sensitive information.

--- a/cmd/juju/controller/destroy_test.go
+++ b/cmd/juju/controller/destroy_test.go
@@ -55,13 +55,17 @@ type baseDestroySuite struct {
 // fakeDestroyAPI mocks out the controller API
 type fakeDestroyAPI struct {
 	gitjujutesting.Stub
-	cloud        environs.CloudSpec
-	env          map[string]interface{}
-	destroyAll   bool
-	blocks       []params.ModelBlockInfo
-	envStatus    map[string]base.ModelStatus
-	allModels    []base.UserModel
-	hostedConfig []apicontroller.HostedConfig
+	cloud          environs.CloudSpec
+	env            map[string]interface{}
+	blocks         []params.ModelBlockInfo
+	envStatus      map[string]base.ModelStatus
+	allModels      []base.UserModel
+	hostedConfig   []apicontroller.HostedConfig
+	bestAPIVersion int
+}
+
+func (f *fakeDestroyAPI) BestAPIVersion() int {
+	return f.bestAPIVersion
 }
 
 func (f *fakeDestroyAPI) Close() error {
@@ -93,9 +97,8 @@ func (f *fakeDestroyAPI) HostedModelConfigs() ([]apicontroller.HostedConfig, err
 	return f.hostedConfig, nil
 }
 
-func (f *fakeDestroyAPI) DestroyController(destroyAll bool) error {
-	f.MethodCall(f, "DestroyController", destroyAll)
-	f.destroyAll = destroyAll
+func (f *fakeDestroyAPI) DestroyController(args apicontroller.DestroyControllerParams) error {
+	f.MethodCall(f, "DestroyController", args)
 	return f.NextErr()
 }
 
@@ -156,8 +159,9 @@ func (s *baseDestroySuite) SetUpTest(c *gc.C) {
 	s.clientapi = &fakeDestroyAPIClient{}
 	owner := names.NewUserTag("owner")
 	s.api = &fakeDestroyAPI{
-		cloud:     dummy.SampleCloudSpec(),
-		envStatus: map[string]base.ModelStatus{},
+		cloud:          dummy.SampleCloudSpec(),
+		envStatus:      map[string]base.ModelStatus{},
+		bestAPIVersion: 4,
 	}
 	s.apierror = nil
 
@@ -288,7 +292,6 @@ func (s *DestroySuite) TestDestroyCannotConnectToAPI(c *gc.C) {
 func (s *DestroySuite) TestDestroy(c *gc.C) {
 	_, err := s.runDestroyCommand(c, "test1", "-y")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(s.api.destroyAll, jc.IsFalse)
 	c.Assert(s.clientapi.destroycalled, jc.IsFalse)
 	checkControllerRemovedFromStore(c, "test1", s.store)
 }
@@ -296,7 +299,6 @@ func (s *DestroySuite) TestDestroy(c *gc.C) {
 func (s *DestroySuite) TestDestroyAlias(c *gc.C) {
 	_, err := s.runDestroyCommand(c, "test1", "-y")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(s.api.destroyAll, jc.IsFalse)
 	c.Assert(s.clientapi.destroycalled, jc.IsFalse)
 	checkControllerRemovedFromStore(c, "test1", s.store)
 }
@@ -304,8 +306,50 @@ func (s *DestroySuite) TestDestroyAlias(c *gc.C) {
 func (s *DestroySuite) TestDestroyWithDestroyAllModelsFlag(c *gc.C) {
 	_, err := s.runDestroyCommand(c, "test1", "-y", "--destroy-all-models")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(s.api.destroyAll, jc.IsTrue)
+	s.api.CheckCallNames(c, "DestroyController", "AllModels", "ModelStatus", "ModelStatus", "Close")
+	s.api.CheckCall(c, 0, "DestroyController", apicontroller.DestroyControllerParams{
+		DestroyModels: true,
+	})
 	checkControllerRemovedFromStore(c, "test1", s.store)
+}
+
+func (s *DestroySuite) TestDestroyWithDestroyDestroyStorageFlag(c *gc.C) {
+	_, err := s.runDestroyCommand(c, "test1", "-y", "--destroy-storage")
+	c.Assert(err, jc.ErrorIsNil)
+	destroyStorage := true
+	s.api.CheckCall(c, 0, "DestroyController", apicontroller.DestroyControllerParams{
+		DestroyStorage: &destroyStorage,
+	})
+}
+
+func (s *DestroySuite) TestDestroyWithDestroyReleaseStorageFlag(c *gc.C) {
+	_, err := s.runDestroyCommand(c, "test1", "-y", "--release-storage")
+	c.Assert(err, jc.ErrorIsNil)
+	destroyStorage := false
+	s.api.CheckCall(c, 0, "DestroyController", apicontroller.DestroyControllerParams{
+		DestroyStorage: &destroyStorage,
+	})
+}
+
+func (s *DestroySuite) TestDestroyWithDestroyDestroyReleaseStorageFlagsMutuallyExclusive(c *gc.C) {
+	_, err := s.runDestroyCommand(c, "test1", "-y", "--destroy-storage", "--release-storage")
+	c.Assert(err, gc.ErrorMatches, "--destroy-storage and --release-storage cannot both be specified")
+}
+
+func (s *DestroySuite) TestDestroyWithDestroyDestroyStorageFlagUnspecifiedOldController(c *gc.C) {
+	s.api.bestAPIVersion = 3
+	ctx, err := s.runDestroyCommand(c, "test1", "-y")
+	c.Assert(err, gc.Equals, cmd.ErrSilent)
+	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, `this juju controller only supports destroying storage
+
+Please run the the command again with --destroy-storage,
+to confirm that you want to destroy the storage along
+with the controller.
+
+If instead you want to keep the storage, you must first
+upgrade the controller.
+
+`)
 }
 
 func (s *DestroySuite) TestDestroyControllerGetFails(c *gc.C) {
@@ -321,7 +365,6 @@ func (s *DestroySuite) TestFailedDestroyController(c *gc.C) {
 	s.api.SetErrors(errors.New("permission denied"))
 	_, err := s.runDestroyCommand(c, "test1", "-y")
 	c.Assert(err, gc.ErrorMatches, "cannot destroy controller: permission denied")
-	c.Assert(s.api.destroyAll, jc.IsFalse)
 	checkControllerExistsInStore(c, "test1", s.store)
 }
 

--- a/cmd/juju/controller/kill.go
+++ b/cmd/juju/controller/kill.go
@@ -12,6 +12,7 @@ import (
 	"github.com/juju/gnuflag"
 	"github.com/juju/utils/clock"
 
+	"github.com/juju/juju/api/controller"
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/environs"
@@ -125,8 +126,12 @@ func (c *killCommand) Run(ctx *cmd.Context) error {
 		return environs.Destroy(controllerName, controllerEnviron, store)
 	}
 
-	// Attempt to destroy the controller and all environments.
-	err = api.DestroyController(true)
+	// Attempt to destroy the controller and all models and storage.
+	destroyStorage := true
+	err = api.DestroyController(controller.DestroyControllerParams{
+		DestroyModels:  true,
+		DestroyStorage: &destroyStorage,
+	})
 	if err != nil {
 		ctx.Infof("Unable to destroy controller through the API: %s\nDestroying through provider", err)
 		return environs.Destroy(controllerName, controllerEnviron, store)

--- a/cmd/juju/controller/kill_test.go
+++ b/cmd/juju/controller/kill_test.go
@@ -372,7 +372,7 @@ func (s *KillSuite) TestKillCannotConnectToAPISucceeds(c *gc.C) {
 func (s *KillSuite) TestKillWithAPIConnection(c *gc.C) {
 	_, err := s.runKillCommand(c, "test1", "-y")
 	c.Assert(err, jc.ErrorIsNil)
-	s.api.CheckCallNames(c, "DestroyController", "AllModels", "ModelStatus", "ModelStatus", "Close")
+	s.api.CheckCallNames(c, "DestroyController", "AllModels", "ModelStatus", "Close")
 	destroyStorage := true
 	s.api.CheckCall(c, 0, "DestroyController", apicontroller.DestroyControllerParams{
 		DestroyModels:  true,
@@ -540,11 +540,10 @@ func (s *KillSuite) TestControllerStatus(c *gc.C) {
 
 func (s *KillSuite) TestFmtControllerStatus(c *gc.C) {
 	data := controller.CtrData{
-		"uuid",
-		string(params.Alive),
-		3,
-		20,
-		8,
+		UUID:               "uuid",
+		HostedModelCount:   3,
+		HostedMachineCount: 20,
+		ServiceCount:       8,
 	}
 	out := controller.FmtCtrStatus(data)
 	c.Assert(out, gc.Equals, "Waiting on 3 models, 20 machines, 8 applications")
@@ -558,6 +557,8 @@ func (s *KillSuite) TestFmtEnvironStatus(c *gc.C) {
 		string(params.Dying),
 		8,
 		1,
+		0,
+		0,
 	}
 
 	out := controller.FmtModelStatus(data)


### PR DESCRIPTION
## Description of change

Add --destroy-storage and --release-storage flags
to the destroy-controller command. If the user
specifies neither, and there is persistent storage
remaining, then the destruction fails and they
will be prompted to choose one of the methods of
storage removal.

The Controller API client and server facade have
both been updated accordingly. The Controller API
has been bumped to version 4. If a new client
calls destroy-controller against an older server,
they will be forced to use --destroy-storage, as
the old server does not complain if there is any
persistent storage remaining. If an old client
calls destroy-controller on the new controller,
it will destroy the storage as before.

## QA steps

(old server, new client)
1. juju bootstrap localhost (with juju 2.2.2)
2. juju destroy-controller -y localhost (with client from this branch)
(should fail, saying you have to use --destroy-storage)
3. juju destroy-controller -y localhost --destroy-storage
(should succeed)

(new server, old client)
1. juju bootstrap localhost && juju deploy postgresql --storage pgdata=lxd (with this branch)
2. juju destroy-controller -y localhost --destroy-all-models (with 2.2.2 client)
(should succeed and destroy storage)

(new server, new client)
1. juju bootstrap localhost && juju deploy postgresql --storage pgdata=lxd
2. juju destroy-controller -y localhost --destroy-all-models
(should fail, saying you must choose either --destroy-storage or --release-storage)
3. juju destroy-controller -y localhost --destroy-all-models --destroy-storage
(should succeed, and storage should be destroyed)

same as last scenario, but with --release-storage, and the LXD storage volume should not be destroyed

## Documentation changes

Yes, we need to document this new command behaviour.

## Bug reference

None.