### PR TITLE
state: allwatcher now reflects instance status changes

### DIFF
--- a/state/allwatcher.go
+++ b/state/allwatcher.go
@@ -1138,6 +1138,7 @@ func backingEntityIdForGlobalKey(modelUUID, key string) (multiwatcher.EntityId, 
 	id := key[2:]
 	switch key[0] {
 	case 'm':
+		id = strings.TrimSuffix(id, "#instance")
 		return (&multiwatcher.MachineInfo{
 			ModelUUID: modelUUID,
 			Id:        id,

--- a/state/allwatcher_internal_test.go
+++ b/state/allwatcher_internal_test.go
@@ -1132,7 +1132,7 @@ func (s *allWatcherStateSuite) TestStateWatcherTwoModels(c *gc.C) {
 				return 1
 			},
 		}, {
-			about: "statuses",
+			about: "machine agent status",
 			setUpState: func(st *State) int {
 				m, err := st.AddMachine("trusty", JobHostUnits)
 				c.Assert(err, jc.ErrorIsNil)
@@ -1152,6 +1152,26 @@ func (s *allWatcherStateSuite) TestStateWatcherTwoModels(c *gc.C) {
 					Since:   &now,
 				}
 				err = m.SetStatus(sInfo)
+				c.Assert(err, jc.ErrorIsNil)
+				return 1
+			},
+		}, {
+			about: "instance status",
+			setUpState: func(st *State) int {
+				m, err := st.AddMachine("trusty", JobHostUnits)
+				c.Assert(err, jc.ErrorIsNil)
+				c.Assert(m.Id(), gc.Equals, "0")
+				return 1
+			},
+			triggerEvent: func(st *State) int {
+				m, err := st.Machine("0")
+				c.Assert(err, jc.ErrorIsNil)
+				now := testing.ZeroTime()
+				m.SetInstanceStatus(status.StatusInfo{
+					Status:  status.Error,
+					Message: "pete tong",
+					Since:   &now,
+				})
 				c.Assert(err, jc.ErrorIsNil)
 				return 1
 			},


### PR DESCRIPTION
## Description of change

Due to a silly bug (and missing test coverage), instance status
changes were never reflected in the output from the allwatcher.

## QA steps

* Watch the allwatcher API output using a client (for [example](https://gist.github.com/mjs/43c83cc6e0e9d3b85d7f5f50f7e501c5))
* Add a machine to the model
* Observe that updates for the machine reflect instance status changes

## Documentation changes

N.A.

## Bug reference

Fixes https://bugs.launchpad.net/juju/+bug/1695335
