### PR TITLE
Move resource/cmd under cmd/juju/resource

### DIFF
--- a/cmd/juju/resource/deploy.go
+++ b/cmd/juju/resource/deploy.go
@@ -1,7 +1,7 @@
 // Copyright 2016 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package cmd
+package resource
 
 import (
 	"io"

--- a/cmd/juju/resource/deploy_test.go
+++ b/cmd/juju/resource/deploy_test.go
@@ -1,7 +1,7 @@
 // Copyright 2015 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package cmd
+package resource
 
 import (
 	"bytes"

--- a/cmd/juju/resource/export_test.go
+++ b/cmd/juju/resource/export_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/juju/juju/cmd/modelcmd"
 )
 
-func ListCharmResourcesCommandChannel(c *ListCharmResourcesCommand) string {
+func ListCharmResourcesCommandChannel(c modelcmd.Command) string {
 	return modelcmd.InnerCommand(c).(*ListCharmResourcesCommand).channel
 }
 

--- a/cmd/juju/resource/export_test.go
+++ b/cmd/juju/resource/export_test.go
@@ -1,7 +1,14 @@
-package cmd
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package resource
+
+import (
+	"github.com/juju/juju/cmd/modelcmd"
+)
 
 func ListCharmResourcesCommandChannel(c *ListCharmResourcesCommand) string {
-	return c.channel
+	return modelcmd.InnerCommand(c).(*ListCharmResourcesCommand).channel
 }
 
 func ShowServiceCommandTarget(c *ShowServiceCommand) string {
@@ -19,3 +26,7 @@ func UploadCommandService(c *UploadCommand) string {
 }
 
 var FormatServiceResources = formatServiceResources
+
+func SetResourceLister(c modelcmd.Command, lister ResourceLister) {
+	modelcmd.InnerCommand(c).(*ListCharmResourcesCommand).resourceLister = lister
+}

--- a/cmd/juju/resource/file.go
+++ b/cmd/juju/resource/file.go
@@ -1,7 +1,7 @@
 // Copyright 2016 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package cmd
+package resource
 
 import (
 	"fmt"

--- a/cmd/juju/resource/formatted.go
+++ b/cmd/juju/resource/formatted.go
@@ -1,7 +1,7 @@
 // Copyright 2015 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package cmd
+package resource
 
 import "time"
 

--- a/cmd/juju/resource/formatter.go
+++ b/cmd/juju/resource/formatter.go
@@ -1,7 +1,7 @@
 // Copyright 2015 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package cmd
+package resource
 
 import (
 	"fmt"

--- a/cmd/juju/resource/formatter_test.go
+++ b/cmd/juju/resource/formatter_test.go
@@ -1,7 +1,7 @@
 // Copyright 2015 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package cmd_test
+package resource_test
 
 import (
 	"strings"
@@ -13,8 +13,8 @@ import (
 	charmresource "gopkg.in/juju/charm.v6-unstable/resource"
 	"gopkg.in/juju/names.v2"
 
+	resourcecmd "github.com/juju/juju/cmd/juju/resource"
 	"github.com/juju/juju/resource"
-	resourcecmd "github.com/juju/juju/resource/cmd"
 )
 
 var _ = gc.Suite(&CharmFormatterSuite{})

--- a/cmd/juju/resource/list_charm_resources.go
+++ b/cmd/juju/resource/list_charm_resources.go
@@ -1,7 +1,7 @@
 // Copyright 2015 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package cmd
+package resource
 
 import (
 	"github.com/juju/cmd"
@@ -24,10 +24,9 @@ type ResourceLister interface {
 type ListCharmResourcesCommand struct {
 	modelcmd.ModelCommandBase
 
-	// ResourceLister is called by Run to list charm resources. The
-	// default implementation uses juju/juju/charmstore.Client, but
-	// it may be set to mock out the call to that method.
-	ResourceLister ResourceLister
+	// resourceLister is called by Run to list charm resources and
+	// uses juju/juju/charmstore.Client.
+	resourceLister ResourceLister
 
 	out     cmd.Output
 	channel string
@@ -36,10 +35,10 @@ type ListCharmResourcesCommand struct {
 
 // NewListCharmResourcesCommand returns a new command that lists resources defined
 // by a charm.
-func NewListCharmResourcesCommand() *ListCharmResourcesCommand {
+func NewListCharmResourcesCommand() modelcmd.ModelCommand {
 	var c ListCharmResourcesCommand
-	c.ResourceLister = &c
-	return &c
+	c.resourceLister = &c
+	return modelcmd.Wrap(&c)
 }
 
 var listCharmResourcesDoc = `
@@ -109,7 +108,7 @@ func (c *ListCharmResourcesCommand) Run(ctx *cmd.Context) error {
 		charms[i] = charmstore.CharmID{URL: id, Channel: csparams.Channel(c.channel)}
 	}
 
-	resources, err := c.ResourceLister.ListResources(charms)
+	resources, err := c.resourceLister.ListResources(charms)
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/cmd/juju/resource/list_charm_resources_test.go
+++ b/cmd/juju/resource/list_charm_resources_test.go
@@ -1,7 +1,7 @@
 // Copyright 2015 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package cmd_test
+package resource_test
 
 import (
 	"strings"
@@ -14,7 +14,7 @@ import (
 	charmresource "gopkg.in/juju/charm.v6-unstable/resource"
 
 	"github.com/juju/juju/charmstore"
-	resourcecmd "github.com/juju/juju/resource/cmd"
+	resourcecmd "github.com/juju/juju/cmd/juju/resource"
 )
 
 var _ = gc.Suite(&ListCharmSuite{})
@@ -70,7 +70,7 @@ func (s *ListCharmSuite) TestOkay(c *gc.C) {
 	s.client.ReturnListResources = [][]charmresource.Resource{resources}
 
 	command := resourcecmd.NewListCharmResourcesCommand()
-	command.ResourceLister = s.client
+	resourcecmd.SetResourceLister(command, s.client)
 	code, stdout, stderr := runCmd(c, command, "cs:a-charm")
 	c.Check(code, gc.Equals, 0)
 
@@ -96,7 +96,7 @@ func (s *ListCharmSuite) TestNoResources(c *gc.C) {
 	s.client.ReturnListResources = [][]charmresource.Resource{{}}
 
 	command := resourcecmd.NewListCharmResourcesCommand()
-	command.ResourceLister = s.client
+	resourcecmd.SetResourceLister(command, s.client)
 	code, stdout, stderr := runCmd(c, command, "cs:a-charm")
 	c.Check(code, gc.Equals, 0)
 
@@ -168,7 +168,7 @@ music     1
 	for format, expected := range formats {
 		c.Logf("checking format %q", format)
 		command := resourcecmd.NewListCharmResourcesCommand()
-		command.ResourceLister = s.client
+		resourcecmd.SetResourceLister(command, s.client)
 		args := []string{
 			"--format", format,
 			"cs:a-charm",
@@ -192,7 +192,7 @@ func (s *ListCharmSuite) TestChannelFlag(c *gc.C) {
 	}
 	s.client.ReturnListResources = [][]charmresource.Resource{resources}
 	command := resourcecmd.NewListCharmResourcesCommand()
-	command.ResourceLister = s.client
+	resourcecmd.SetResourceLister(command, s.client)
 
 	code, _, stderr := runCmd(c, command,
 		"--channel", "development",

--- a/cmd/juju/resource/output_tabular.go
+++ b/cmd/juju/resource/output_tabular.go
@@ -1,7 +1,7 @@
 // Copyright 2015 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package cmd
+package resource
 
 import (
 	"fmt"

--- a/cmd/juju/resource/output_tabular_test.go
+++ b/cmd/juju/resource/output_tabular_test.go
@@ -1,7 +1,7 @@
 // Copyright 2015 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package cmd_test
+package resource_test
 
 import (
 	"bytes"
@@ -12,8 +12,8 @@ import (
 	gc "gopkg.in/check.v1"
 	charmresource "gopkg.in/juju/charm.v6-unstable/resource"
 
+	resourcecmd "github.com/juju/juju/cmd/juju/resource"
 	"github.com/juju/juju/resource"
-	resourcecmd "github.com/juju/juju/resource/cmd"
 )
 
 var _ = gc.Suite(&CharmTabularSuite{})

--- a/cmd/juju/resource/package_test.go
+++ b/cmd/juju/resource/package_test.go
@@ -1,7 +1,7 @@
 // Copyright 2015 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package cmd_test
+package resource_test
 
 import (
 	"testing"

--- a/cmd/juju/resource/show_service.go
+++ b/cmd/juju/resource/show_service.go
@@ -1,7 +1,7 @@
 // Copyright 2015 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package cmd
+package resource
 
 import (
 	"github.com/juju/cmd"

--- a/cmd/juju/resource/show_service_test.go
+++ b/cmd/juju/resource/show_service_test.go
@@ -1,7 +1,7 @@
 // Copyright 2015 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package cmd_test
+package resource_test
 
 import (
 	"time"
@@ -14,8 +14,8 @@ import (
 	charmresource "gopkg.in/juju/charm.v6-unstable/resource"
 	"gopkg.in/juju/names.v2"
 
+	resourcecmd "github.com/juju/juju/cmd/juju/resource"
 	"github.com/juju/juju/resource"
-	resourcecmd "github.com/juju/juju/resource/cmd"
 )
 
 var _ = gc.Suite(&ShowServiceSuite{})

--- a/cmd/juju/resource/stub_test.go
+++ b/cmd/juju/resource/stub_test.go
@@ -1,7 +1,7 @@
 // Copyright 2015 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package cmd_test
+package resource_test
 
 import (
 	"io"

--- a/cmd/juju/resource/upload.go
+++ b/cmd/juju/resource/upload.go
@@ -1,7 +1,7 @@
 // Copyright 2015 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package cmd
+package resource
 
 import (
 	"io"

--- a/cmd/juju/resource/upload_test.go
+++ b/cmd/juju/resource/upload_test.go
@@ -1,7 +1,7 @@
 // Copyright 2015 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package cmd_test
+package resource_test
 
 import (
 	jujucmd "github.com/juju/cmd"
@@ -10,7 +10,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
-	resourcecmd "github.com/juju/juju/resource/cmd"
+	resourcecmd "github.com/juju/juju/cmd/juju/resource"
 )
 
 var _ = gc.Suite(&UploadSuite{})

--- a/cmd/juju/resource/util_test.go
+++ b/cmd/juju/resource/util_test.go
@@ -1,7 +1,7 @@
 // Copyright 2015 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package cmd_test
+package resource_test
 
 import (
 	"bytes"

--- a/component/all/resource.go
+++ b/component/all/resource.go
@@ -14,10 +14,10 @@ import (
 	"github.com/juju/juju/apiserver/facades/controller/charmrevisionupdater"
 	"github.com/juju/juju/cmd/juju/charmcmd"
 	"github.com/juju/juju/cmd/juju/commands"
+	resourcecmd "github.com/juju/juju/cmd/juju/resource"
 	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/resource"
 	internalclient "github.com/juju/juju/resource/api/private/client"
-	"github.com/juju/juju/resource/cmd"
 	"github.com/juju/juju/resource/context"
 	contextcmd "github.com/juju/juju/resource/context/cmd"
 	"github.com/juju/juju/resource/resourceadapters"
@@ -71,18 +71,18 @@ func (r resources) registerPublicCommands() {
 		return
 	}
 
-	charmcmd.RegisterSubCommand(cmd.NewListCharmResourcesCommand())
+	charmcmd.RegisterSubCommand(resourcecmd.NewListCharmResourcesCommand())
 
 	commands.RegisterEnvCommand(func() modelcmd.ModelCommand {
-		return cmd.NewUploadCommand(cmd.UploadDeps{
-			NewClient: func(c *cmd.UploadCommand) (cmd.UploadClient, error) {
+		return resourcecmd.NewUploadCommand(resourcecmd.UploadDeps{
+			NewClient: func(c *resourcecmd.UploadCommand) (resourcecmd.UploadClient, error) {
 				apiRoot, err := c.NewAPIRoot()
 				if err != nil {
 					return nil, errors.Trace(err)
 				}
 				return resourceadapters.NewAPIClient(apiRoot)
 			},
-			OpenResource: func(s string) (cmd.ReadSeekCloser, error) {
+			OpenResource: func(s string) (resourcecmd.ReadSeekCloser, error) {
 				return os.Open(s)
 			},
 		})
@@ -90,8 +90,8 @@ func (r resources) registerPublicCommands() {
 	})
 
 	commands.RegisterEnvCommand(func() modelcmd.ModelCommand {
-		return cmd.NewShowServiceCommand(cmd.ShowServiceDeps{
-			NewClient: func(c *cmd.ShowServiceCommand) (cmd.ShowServiceClient, error) {
+		return resourcecmd.NewShowServiceCommand(resourcecmd.ShowServiceDeps{
+			NewClient: func(c *resourcecmd.ShowServiceCommand) (resourcecmd.ShowServiceClient, error) {
 				apiRoot, err := c.NewAPIRoot()
 				if err != nil {
 					return nil, errors.Trace(err)

--- a/resource/resourceadapters/deploy.go
+++ b/resource/resourceadapters/deploy.go
@@ -12,8 +12,8 @@ import (
 
 	"github.com/juju/juju/api/base"
 	"github.com/juju/juju/charmstore"
+	resourcecmd "github.com/juju/juju/cmd/juju/resource"
 	"github.com/juju/juju/resource/api/client"
-	"github.com/juju/juju/resource/cmd"
 )
 
 // DeployResourcesFunc is the function type of DeployResources.
@@ -59,7 +59,7 @@ func DeployResources(
 		}
 	}
 
-	ids, err = cmd.DeployResources(cmd.DeployResourcesArgs{
+	ids, err = resourcecmd.DeployResources(resourcecmd.DeployResourcesArgs{
 		ApplicationID:      applicationID,
 		CharmID:            chID,
 		CharmStoreMacaroon: csMac,


### PR DESCRIPTION
## Description of change

This is the first bit of work to bring resources commands under common architecture breaking away from components' one.
This PR contains straightforward, mechanical move of resource/cmd to cmd/juju/resource. It also brings in the fix for a panic (lp#1699607).

The follow up PRs will address actually removing registration of these commands from components/all and registering them as all other juju commands; using an accessor function on the list resources commands for resource listener; adding feature tests subset.


## QA steps
All resources commands run the same - 'juju charm resources <charm>', 'juju resources <application>', 'juju resources <unit>', 'juju attach'.

## Documentation changes

n/as as this is an internal change

## Bug reference

First step to address: https://bugs.launchpad.net/juju/+bug/1706809
Brings in the fix into 2.3-alpha1 for: https://bugs.launchpad.net/juju/+bug/1699607 
