### PR TITLE
Resource lister refactor.

### DIFF
--- a/cmd/juju/resource/export_test.go
+++ b/cmd/juju/resource/export_test.go
@@ -26,7 +26,3 @@ func UploadCommandService(c *UploadCommand) string {
 }
 
 var FormatServiceResources = formatServiceResources
-
-func SetResourceLister(c modelcmd.Command, lister ResourceLister) {
-	modelcmd.InnerCommand(c).(*ListCharmResourcesCommand).resourceLister = lister
-}

--- a/cmd/juju/resource/list_charm_resources.go
+++ b/cmd/juju/resource/list_charm_resources.go
@@ -35,9 +35,12 @@ type ListCharmResourcesCommand struct {
 
 // NewListCharmResourcesCommand returns a new command that lists resources defined
 // by a charm.
-func NewListCharmResourcesCommand() modelcmd.ModelCommand {
+func NewListCharmResourcesCommand(resourceLister ResourceLister) modelcmd.ModelCommand {
 	var c ListCharmResourcesCommand
-	c.resourceLister = &c
+	if resourceLister == nil {
+		resourceLister = &c
+	}
+	c.resourceLister = resourceLister
 	return modelcmd.Wrap(&c)
 }
 

--- a/cmd/juju/resource/list_charm_resources_test.go
+++ b/cmd/juju/resource/list_charm_resources_test.go
@@ -69,8 +69,7 @@ func (s *ListCharmSuite) TestOkay(c *gc.C) {
 	resources[0].Revision = 2
 	s.client.ReturnListResources = [][]charmresource.Resource{resources}
 
-	command := resourcecmd.NewListCharmResourcesCommand()
-	resourcecmd.SetResourceLister(command, s.client)
+	command := resourcecmd.NewListCharmResourcesCommand(s.client)
 	code, stdout, stderr := runCmd(c, command, "cs:a-charm")
 	c.Check(code, gc.Equals, 0)
 
@@ -95,8 +94,7 @@ music     1
 func (s *ListCharmSuite) TestNoResources(c *gc.C) {
 	s.client.ReturnListResources = [][]charmresource.Resource{{}}
 
-	command := resourcecmd.NewListCharmResourcesCommand()
-	resourcecmd.SetResourceLister(command, s.client)
+	command := resourcecmd.NewListCharmResourcesCommand(s.client)
 	code, stdout, stderr := runCmd(c, command, "cs:a-charm")
 	c.Check(code, gc.Equals, 0)
 
@@ -167,8 +165,7 @@ music     1
 	}
 	for format, expected := range formats {
 		c.Logf("checking format %q", format)
-		command := resourcecmd.NewListCharmResourcesCommand()
-		resourcecmd.SetResourceLister(command, s.client)
+		command := resourcecmd.NewListCharmResourcesCommand(s.client)
 		args := []string{
 			"--format", format,
 			"cs:a-charm",
@@ -191,8 +188,7 @@ func (s *ListCharmSuite) TestChannelFlag(c *gc.C) {
 		charmRes(c, "music", ".mp3", "mp3 of your backing vocals", string(fp2.Bytes())),
 	}
 	s.client.ReturnListResources = [][]charmresource.Resource{resources}
-	command := resourcecmd.NewListCharmResourcesCommand()
-	resourcecmd.SetResourceLister(command, s.client)
+	command := resourcecmd.NewListCharmResourcesCommand(s.client)
 
 	code, _, stderr := runCmd(c, command,
 		"--channel", "development",

--- a/component/all/resource.go
+++ b/component/all/resource.go
@@ -71,7 +71,7 @@ func (r resources) registerPublicCommands() {
 		return
 	}
 
-	charmcmd.RegisterSubCommand(resourcecmd.NewListCharmResourcesCommand())
+	charmcmd.RegisterSubCommand(resourcecmd.NewListCharmResourcesCommand(nil))
 
 	commands.RegisterEnvCommand(func() modelcmd.ModelCommand {
 		return resourcecmd.NewUploadCommand(resourcecmd.UploadDeps{


### PR DESCRIPTION
## Description of change

This PR changes constructor for list charm resources command to accept a ResourceLister. 
It is needed to ensure that we can test the command easily without test patching.

## QA steps

All unit tests still pass and 'juju charm resources...' command does not panic.

## Documentation changes

n/a as it is an internal change.

## Bug reference

Progress PR for https://bugs.launchpad.net/juju/+bug/1706809
