### PR TITLE
Ignore model constraints with direct placement

### DIFF
--- a/state/addmachine.go
+++ b/state/addmachine.go
@@ -231,9 +231,12 @@ func (st *State) effectiveMachineTemplate(p MachineTemplate, allowController boo
 		return tmpl, errors.New("cannot specify a nonce without an instance id")
 	}
 
-	p.Constraints, err = st.resolveMachineConstraints(p.Constraints)
-	if err != nil {
-		return tmpl, err
+	// We ignore all constraints if there's a placement directive.
+	if p.Placement == "" {
+		p.Constraints, err = st.resolveMachineConstraints(p.Constraints)
+		if err != nil {
+			return tmpl, err
+		}
 	}
 
 	if len(p.Jobs) == 0 {

--- a/state/prechecker_test.go
+++ b/state/prechecker_test.go
@@ -47,11 +47,11 @@ func (s *PrecheckerSuite) SetUpTest(c *gc.C) {
 
 func (s *PrecheckerSuite) TestPrecheckInstance(c *gc.C) {
 	// PrecheckInstance should be called with the specified
-	// series and placement, and the specified constraints
+	// series and no placement, and the specified constraints
 	// merged with the model constraints, when attempting
 	// to create an instance.
 	envCons := constraints.MustParse("mem=4G")
-	placement := "abc123"
+	placement := ""
 	template, err := s.addOneMachine(c, envCons, placement)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(s.prechecker.precheckInstanceSeries, gc.Equals, template.Series)
@@ -60,6 +60,21 @@ func (s *PrecheckerSuite) TestPrecheckInstance(c *gc.C) {
 	cons, err := validator.Merge(envCons, template.Constraints)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(s.prechecker.precheckInstanceConstraints, gc.DeepEquals, cons)
+}
+
+func (s *PrecheckerSuite) TestPrecheckInstanceWithPlacement(c *gc.C) {
+	// PrecheckInstance should be called with the specified
+	// series and placement. If placement is provided all
+	// model constraints should be ignored, otherwise they
+	// should be merged with provided constraints, when
+	// attempting to create an instance
+	envCons := constraints.MustParse("mem=4G")
+	placement := "abc123"
+	template, err := s.addOneMachine(c, envCons, placement)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(s.prechecker.precheckInstanceSeries, gc.Equals, template.Series)
+	c.Assert(s.prechecker.precheckInstancePlacement, gc.Equals, placement)
+	c.Assert(s.prechecker.precheckInstanceConstraints, gc.DeepEquals, template.Constraints)
 }
 
 func (s *PrecheckerSuite) TestPrecheckErrors(c *gc.C) {

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -941,6 +941,26 @@ func (s *StateSuite) TestAddMachineExtraConstraints(c *gc.C) {
 	c.Assert(mcons, gc.DeepEquals, expectedCons)
 }
 
+func (s *StateSuite) TestAddMachinePlacementIgnoresModelConstraints(c *gc.C) {
+	err := s.State.SetModelConstraints(constraints.MustParse("mem=4G tags=foo"))
+	c.Assert(err, jc.ErrorIsNil)
+	oneJob := []state.MachineJob{state.JobHostUnits}
+	m, err := s.State.AddOneMachine(state.MachineTemplate{
+		Series:    "quantal",
+		Jobs:      oneJob,
+		Placement: "theplacement",
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(m.Id(), gc.Equals, "0")
+	c.Assert(m.Series(), gc.Equals, "quantal")
+	c.Assert(m.Placement(), gc.Equals, "theplacement")
+	c.Assert(m.Jobs(), gc.DeepEquals, oneJob)
+	expectedCons := constraints.MustParse("")
+	mcons, err := m.Constraints()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(mcons, gc.DeepEquals, expectedCons)
+}
+
 func (s *StateSuite) TestAddMachineWithVolumes(c *gc.C) {
 	pm := poolmanager.New(state.NewStateSettings(s.State), provider.CommonStorageProviders())
 	_, err := pm.Create("loop-pool", provider.LoopProviderType, map[string]interface{}{})


### PR DESCRIPTION
## Description of change
When providing a specific placement with deploy/add-unit --to X or add-machine X we want to ignore model constraints

## QA steps
On MAAS:
juju set-model-constraints tags=foobar
juju add-machine name_of_an_existing_machine_without_foobar_tag

This should add this machine to juju, whereas on older version there should be an error in status saying that there's no machine matching name=...., tags=foobar

## Documentation changes
None

## Bug reference
https://bugs.launchpad.net/juju/+bug/1706688