### PR TITLE
Register resource commands as per convention.

### DIFF
--- a/cmd/juju/charmcmd/charm.go
+++ b/cmd/juju/charmcmd/charm.go
@@ -5,14 +5,9 @@ package charmcmd
 
 import (
 	"github.com/juju/cmd"
+
+	"github.com/juju/juju/cmd/juju/resource"
 )
-
-var registeredSubCommands []cmd.Command
-
-// RegisterSubCommand registers the given command as a "juju charm" subcommand.
-func RegisterSubCommand(c cmd.Command) {
-	registeredSubCommands = append(registeredSubCommands, c)
-}
 
 var charmDoc = `
 "juju charm" is the the juju CLI equivalent of the "charm" command used
@@ -38,14 +33,11 @@ func NewSuperCommand() *Command {
 			},
 		),
 	}
-
-	// Sub-commands may be registered directly here, like so:
-	//charmCmd.Register(newXXXCommand())
-
-	// ...or externally via RegisterSubCommand().
-	for _, command := range registeredSubCommands {
-		charmCmd.Register(command)
-	}
+	// TODO (anastasiamac 2017-07-28) this needs to be renamed
+	// to something else, for eg. 'juju charm-resources',
+	// to comply with the new naming convention.
+	// This command was overlooked in general rename for Juju 2.x
+	charmCmd.Register(resource.NewListCharmResourcesCommand(nil))
 
 	return charmCmd
 }

--- a/component/all/resource.go
+++ b/component/all/resource.go
@@ -4,18 +4,12 @@
 package all
 
 import (
-	"os"
-
 	jujucmd "github.com/juju/cmd"
 	"github.com/juju/errors"
 	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/api/base"
 	"github.com/juju/juju/apiserver/facades/controller/charmrevisionupdater"
-	"github.com/juju/juju/cmd/juju/charmcmd"
-	"github.com/juju/juju/cmd/juju/commands"
-	resourcecmd "github.com/juju/juju/cmd/juju/resource"
-	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/resource"
 	internalclient "github.com/juju/juju/resource/api/private/client"
 	"github.com/juju/juju/resource/context"
@@ -41,8 +35,6 @@ func (r resources) registerForServer() error {
 // RegisterForClient is the top-level registration method
 // for the component in a "juju" command context.
 func (r resources) registerForClient() error {
-	r.registerPublicCommands()
-
 	// needed for help-tool
 	r.registerHookContextCommands()
 	return nil
@@ -62,44 +54,6 @@ func (resources) registerState() {
 	if !markRegistered(resource.ComponentName, "state") {
 		return
 	}
-}
-
-// registerPublicCommands adds the resources-related commands
-// to the "juju" supercommand.
-func (r resources) registerPublicCommands() {
-	if !markRegistered(resource.ComponentName, "public-commands") {
-		return
-	}
-
-	charmcmd.RegisterSubCommand(resourcecmd.NewListCharmResourcesCommand(nil))
-
-	commands.RegisterEnvCommand(func() modelcmd.ModelCommand {
-		return resourcecmd.NewUploadCommand(resourcecmd.UploadDeps{
-			NewClient: func(c *resourcecmd.UploadCommand) (resourcecmd.UploadClient, error) {
-				apiRoot, err := c.NewAPIRoot()
-				if err != nil {
-					return nil, errors.Trace(err)
-				}
-				return resourceadapters.NewAPIClient(apiRoot)
-			},
-			OpenResource: func(s string) (resourcecmd.ReadSeekCloser, error) {
-				return os.Open(s)
-			},
-		})
-
-	})
-
-	commands.RegisterEnvCommand(func() modelcmd.ModelCommand {
-		return resourcecmd.NewShowServiceCommand(resourcecmd.ShowServiceDeps{
-			NewClient: func(c *resourcecmd.ShowServiceCommand) (resourcecmd.ShowServiceClient, error) {
-				apiRoot, err := c.NewAPIRoot()
-				if err != nil {
-					return nil, errors.Trace(err)
-				}
-				return resourceadapters.NewAPIClient(apiRoot)
-			},
-		})
-	})
 }
 
 func (r resources) registerHookContext() {


### PR DESCRIPTION
## Description of change

This PR moves registration of resource commands - 'juju attach' and 'juju resources' - into common framework.

## QA steps

All unit tests run successfully. 'juju attach' and 'juju resources' are in the list of 'juju help commands' and behave as previously.

## Documentation changes

n/a as this is a refactoring exercise.

## Bug reference

Contributes to fixing https://bugs.launchpad.net/juju/+bug/1706809
