### PR TITLE
destroy-model: destroy/release storage flags

### DIFF
--- a/api/facadeversions.go
+++ b/api/facadeversions.go
@@ -61,7 +61,7 @@ var facadeVersions = map[string]int{
 	"MigrationStatusWatcher":       1,
 	"MigrationTarget":              1,
 	"ModelConfig":                  1,
-	"ModelManager":                 3,
+	"ModelManager":                 4,
 	"ModelUpgrader":                1,
 	"NotifyWatcher":                1,
 	"Payloads":                     1,

--- a/api/modelmanager/package_test.go
+++ b/api/modelmanager/package_test.go
@@ -4,11 +4,11 @@
 package modelmanager_test
 
 import (
-	stdtesting "testing"
+	"testing"
 
-	"github.com/juju/juju/testing"
+	gc "gopkg.in/check.v1"
 )
 
-func TestAll(t *stdtesting.T) {
-	testing.MgoTestPackage(t)
+func TestAll(t *testing.T) {
+	gc.TestingT(t)
 }

--- a/apiserver/allfacades.go
+++ b/apiserver/allfacades.go
@@ -180,6 +180,7 @@ func AllFacades() *facade.Registry {
 	reg("ModelConfig", 1, modelconfig.NewFacade)
 	reg("ModelManager", 2, modelmanager.NewFacadeV2)
 	reg("ModelManager", 3, modelmanager.NewFacadeV3)
+	reg("ModelManager", 4, modelmanager.NewFacadeV4)
 	reg("ModelUpgrader", 1, modelupgrader.NewStateFacade)
 
 	reg("Payloads", 1, payloads.NewFacade)

--- a/apiserver/common/modeldestroy.go
+++ b/apiserver/common/modeldestroy.go
@@ -77,11 +77,12 @@ func DestroyController(
 
 // DestroyModel sets the model to Dying, such that the model's resources will
 // be destroyed and the model removed from the controller.
-func DestroyModel(st ModelManagerBackend) error {
-	// TODO(axw) make this a parameter.
-	destroyStorage := true
+func DestroyModel(
+	st ModelManagerBackend,
+	destroyStorage *bool,
+) error {
 	return destroyModel(st, state.DestroyModelParams{
-		DestroyStorage: &destroyStorage,
+		DestroyStorage: destroyStorage,
 	})
 }
 

--- a/apiserver/facades/client/controller/destroy_test.go
+++ b/apiserver/facades/client/controller/destroy_test.go
@@ -137,7 +137,7 @@ func (s *destroyControllerSuite) TestDestroyControllerLeavesBlocksIfNotKillAll(c
 }
 
 func (s *destroyControllerSuite) TestDestroyControllerNoHostedEnvs(c *gc.C) {
-	err := common.DestroyModel(common.NewModelManagerBackend(s.otherState))
+	err := common.DestroyModel(common.NewModelManagerBackend(s.otherState), nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	err = s.controller.DestroyController(params.DestroyControllerArgs{})
@@ -149,7 +149,7 @@ func (s *destroyControllerSuite) TestDestroyControllerNoHostedEnvs(c *gc.C) {
 }
 
 func (s *destroyControllerSuite) TestDestroyControllerErrsOnNoHostedEnvsWithBlock(c *gc.C) {
-	err := common.DestroyModel(common.NewModelManagerBackend(s.otherState))
+	err := common.DestroyModel(common.NewModelManagerBackend(s.otherState), nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.BlockDestroyModel(c, "TestBlockDestroyModel")
@@ -163,7 +163,7 @@ func (s *destroyControllerSuite) TestDestroyControllerErrsOnNoHostedEnvsWithBloc
 }
 
 func (s *destroyControllerSuite) TestDestroyControllerNoHostedEnvsWithBlockFail(c *gc.C) {
-	err := common.DestroyModel(common.NewModelManagerBackend(s.otherState))
+	err := common.DestroyModel(common.NewModelManagerBackend(s.otherState), nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.BlockDestroyModel(c, "TestBlockDestroyModel")

--- a/apiserver/facades/client/modelmanager/modelinfo_test.go
+++ b/apiserver/facades/client/modelmanager/modelinfo_test.go
@@ -551,6 +551,7 @@ type mockState struct {
 	blockMsg        string
 	block           state.BlockType
 	migration       *mockMigration
+	modelConfig     *config.Config
 }
 
 type fakeModelDescription struct {
@@ -820,6 +821,16 @@ func (st *mockState) LatestMigration() (state.ModelMigration, error) {
 func (st *mockState) SetModelMeterStatus(level, message string) error {
 	st.MethodCall(st, "SetModelMeterStatus", level, message)
 	return st.NextErr()
+}
+
+func (st *mockState) ModelConfig() (*config.Config, error) {
+	st.MethodCall(st, "ModelConfig")
+	return st.modelConfig, st.NextErr()
+}
+
+func (st *mockState) MetricsManager() (*state.MetricsManager, error) {
+	st.MethodCall(st, "MetricsManager")
+	return nil, errors.New("nope")
 }
 
 type mockBlock struct {

--- a/apiserver/params/model.go
+++ b/apiserver/params/model.go
@@ -286,3 +286,21 @@ const (
 	ModelReadAccess  UserAccessPermission = "read"
 	ModelWriteAccess UserAccessPermission = "write"
 )
+
+// DestroyModelsParams holds the arguments for destroying models.
+type DestroyModelsParams struct {
+	Models []DestroyModelParams `json:"models"`
+}
+
+// DestroyModelParams holds the arguments for destroying a model.
+type DestroyModelParams struct {
+	// ModelTag is the tag of the model to destroy.
+	ModelTag string `json:"model-tag"`
+
+	// DestroyStorage controls whether or not storage in the model.
+	//
+	// This is ternary: nil, false, or true. If nil and there is persistent
+	// storage in the model, an error with the code
+	// params.CodeHasPersistentStorage will be returned.
+	DestroyStorage *bool `json:"destroy-storage,omitempty"`
+}

--- a/cmd/juju/controller/destroy.go
+++ b/cmd/juju/controller/destroy.go
@@ -125,8 +125,8 @@ func (c *destroyCommand) Info() *cmd.Info {
 func (c *destroyCommand) SetFlags(f *gnuflag.FlagSet) {
 	c.destroyCommandBase.SetFlags(f)
 	f.BoolVar(&c.destroyModels, "destroy-all-models", false, "Destroy all hosted models in the controller")
-	f.BoolVar(&c.destroyStorage, "destroy-storage", false, "Destroy all storage managed by the controller")
-	f.BoolVar(&c.releaseStorage, "release-storage", false, "Release all storage from management of the controller, without destroying them")
+	f.BoolVar(&c.destroyStorage, "destroy-storage", false, "Destroy all storage instances managed by the controller")
+	f.BoolVar(&c.releaseStorage, "release-storage", false, "Release all storage instances from management of the controller, without destroying them")
 }
 
 // Init implements Command.Init.
@@ -173,7 +173,7 @@ to confirm that you want to destroy the storage along
 with the controller.
 
 If instead you want to keep the storage, you must first
-upgrade the controller.
+upgrade the controller to version 2.3 or greater.
 
 `)
 			return cmd.ErrSilent

--- a/cmd/juju/controller/destroy_test.go
+++ b/cmd/juju/controller/destroy_test.go
@@ -379,7 +379,7 @@ to confirm that you want to destroy the storage along
 with the controller.
 
 If instead you want to keep the storage, you must first
-upgrade the controller.
+upgrade the controller to version 2.3 or greater.
 
 `)
 }

--- a/cmd/juju/controller/kill_test.go
+++ b/cmd/juju/controller/kill_test.go
@@ -557,10 +557,12 @@ func (s *KillSuite) TestFmtEnvironStatus(c *gc.C) {
 		string(params.Dying),
 		8,
 		1,
+		2,
+		1,
 		0,
 		0,
 	}
 
 	out := controller.FmtModelStatus(data)
-	c.Assert(out, gc.Equals, "\towner/envname (dying), 8 machines, 1 application")
+	c.Assert(out, gc.Equals, "\towner/envname (dying), 8 machines, 1 application, 2 volumes, 1 filesystem")
 }

--- a/cmd/juju/controller/killstatus.go
+++ b/cmd/juju/controller/killstatus.go
@@ -16,10 +16,12 @@ import (
 )
 
 type ctrData struct {
-	UUID               string
-	HostedModelCount   int
-	HostedMachineCount int
-	ServiceCount       int
+	UUID                 string
+	HostedModelCount     int
+	HostedMachineCount   int
+	ServiceCount         int
+	TotalVolumeCount     int
+	TotalFilesystemCount int
 
 	// Model contains controller model data
 	Model modelData
@@ -33,6 +35,8 @@ type modelData struct {
 
 	HostedMachineCount        int
 	ServiceCount              int
+	VolumeCount               int
+	FilesystemCount           int
 	PersistentVolumeCount     int
 	PersistentFilesystemCount int
 }
@@ -89,6 +93,8 @@ func newData(api destroyControllerAPI, controllerModelUUID string) (ctrData, []m
 
 	var hostedMachinesCount int
 	var servicesCount int
+	var volumeCount int
+	var filesystemCount int
 	var modelsData []modelData
 	var aliveModelCount int
 	var ctrModelData modelData
@@ -112,6 +118,8 @@ func newData(api destroyControllerAPI, controllerModelUUID string) (ctrData, []m
 			model.Life,
 			model.HostedMachineCount,
 			model.ServiceCount,
+			len(model.Volumes),
+			len(model.Filesystems),
 			persistentVolumeCount,
 			persistentFilesystemCount,
 		}
@@ -127,6 +135,8 @@ func newData(api destroyControllerAPI, controllerModelUUID string) (ctrData, []m
 		}
 		hostedMachinesCount += model.HostedMachineCount
 		servicesCount += model.ServiceCount
+		volumeCount += modelData.VolumeCount
+		filesystemCount += modelData.FilesystemCount
 	}
 
 	ctrFinalStatus := ctrData{
@@ -134,6 +144,8 @@ func newData(api destroyControllerAPI, controllerModelUUID string) (ctrData, []m
 		aliveModelCount,
 		hostedMachinesCount,
 		servicesCount,
+		volumeCount,
+		filesystemCount,
 		ctrModelData,
 	}
 
@@ -182,6 +194,14 @@ func fmtCtrStatus(data ctrData) string {
 		out += fmt.Sprintf(", %d application%s", serviceNo, s(serviceNo))
 	}
 
+	if n := data.TotalVolumeCount; n > 0 {
+		out += fmt.Sprintf(", %d volume%s", n, s(n))
+	}
+
+	if n := data.TotalFilesystemCount; n > 0 {
+		out += fmt.Sprintf(", %d filesystem%s", n, s(n))
+	}
+
 	return out
 }
 
@@ -194,6 +214,14 @@ func fmtModelStatus(data modelData) string {
 
 	if serviceNo := data.ServiceCount; serviceNo > 0 {
 		out += fmt.Sprintf(", %d application%s", serviceNo, s(serviceNo))
+	}
+
+	if n := data.VolumeCount; n > 0 {
+		out += fmt.Sprintf(", %d volume%s", n, s(n))
+	}
+
+	if n := data.FilesystemCount; n > 0 {
+		out += fmt.Sprintf(", %d filesystem%s", n, s(n))
 	}
 
 	return out


### PR DESCRIPTION
## Description of change

Add --destroy-storage and --release-storage flags
to the destroy-model command. If the user specifies
neither, and there is persistent storage remaining,
then the destruction fails and they will be prompted
to choose one of the methods of storage removal.

The ModelManager API client and server facade have
both been updated accordingly. The facde has been
bumped to version 4. If a new client calls
destroy-model against an older server, they will be
forced to use --destroy-storage, as the old server
does not complain if there is any persistent storage
remaining. If an old client calls destroy-model on
the new controller, it will destroy the storage as
before.

## QA steps

See https://github.com/juju/juju/pull/7676, s/destroy-controller/destroy-model/g

## Documentation changes

Yes, destroy-model has grown two new flags that we'll need to document.

## Bug reference

None.