### PR TITLE
Order resources list.

### DIFF
--- a/cmd/juju/resource/formatter.go
+++ b/cmd/juju/resource/formatter.go
@@ -5,6 +5,7 @@ package resource
 
 import (
 	"fmt"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -20,6 +21,10 @@ type charmResourcesFormatter struct {
 }
 
 func newCharmResourcesFormatter(resources []charmresource.Resource) *charmResourcesFormatter {
+	// It's a lot easier to read and to digest a list of resources
+	// when  they are ordered.
+	sort.Sort(resourceList(resources))
+
 	// Note that unlike the "juju status" code, we don't worry
 	// about "compatVersion".
 	crf := charmResourcesFormatter{
@@ -225,4 +230,23 @@ func resourceMap(resources []resource.Resource) map[string]resource.Resource {
 		m[res.Name] = res
 	}
 	return m
+}
+
+// resourceList is a convenience type enabling to sort
+// a collection of charmresource.Resource by Name.
+type resourceList []charmresource.Resource
+
+// Len implements sort.Interface
+func (m resourceList) Len() int {
+	return len(m)
+}
+
+// Less implements sort.Interface and sorts resources by Name.
+func (m resourceList) Less(i, j int) bool {
+	return m[i].Name < m[j].Name
+}
+
+// Swap implements sort.Interface
+func (m resourceList) Swap(i, j int) {
+	m[i], m[j] = m[j], m[i]
 }

--- a/cmd/juju/resource/list_charm_resources_test.go
+++ b/cmd/juju/resource/list_charm_resources_test.go
@@ -75,8 +75,8 @@ func (s *ListCharmSuite) TestOkay(c *gc.C) {
 
 	c.Check(stdout, gc.Equals, `
 Resource  Revision
-website   2
 music     1
+website   2
 
 `[1:])
 	c.Check(stderr, gc.Equals, "")
@@ -117,19 +117,11 @@ func (s *ListCharmSuite) TestOutputFormats(c *gc.C) {
 	formats := map[string]string{
 		"tabular": `
 Resource  Revision
-website   1
 music     1
+website   1
 
 `[1:],
 		"yaml": `
-- name: website
-  type: file
-  path: website.tgz
-  description: .tgz of your website
-  revision: 1
-  fingerprint: 73100f01cf258766906c34a30f9a486f07259c627ea0696d97c4582560447f59a6df4a7cf960708271a30324b1481ef4
-  size: 48
-  origin: store
 - name: music
   type: file
   path: music.mp3
@@ -138,25 +130,33 @@ music     1
   fingerprint: b0ea2a0f90267a8bd32848c65d7a61569a136f4e421b56127b6374b10a576d29e09294e620b4dcdee40f602115104bd5
   size: 48
   origin: store
+- name: website
+  type: file
+  path: website.tgz
+  description: .tgz of your website
+  revision: 1
+  fingerprint: 73100f01cf258766906c34a30f9a486f07259c627ea0696d97c4582560447f59a6df4a7cf960708271a30324b1481ef4
+  size: 48
+  origin: store
 `[1:],
 		"json": strings.Replace(""+
 			"["+
 			"  {"+
-			`    "name":"website",`+
-			`    "type":"file",`+
-			`    "path":"website.tgz",`+
-			`    "description":".tgz of your website",`+
-			`    "revision":1,`+
-			`    "fingerprint":"73100f01cf258766906c34a30f9a486f07259c627ea0696d97c4582560447f59a6df4a7cf960708271a30324b1481ef4",`+
-			`    "size":48,`+
-			`    "origin":"store"`+
-			"  },{"+
 			`    "name":"music",`+
 			`    "type":"file",`+
 			`    "path":"music.mp3",`+
 			`    "description":"mp3 of your backing vocals",`+
 			`    "revision":1,`+
 			`    "fingerprint":"b0ea2a0f90267a8bd32848c65d7a61569a136f4e421b56127b6374b10a576d29e09294e620b4dcdee40f602115104bd5",`+
+			`    "size":48,`+
+			`    "origin":"store"`+
+			"  },{"+
+			`    "name":"website",`+
+			`    "type":"file",`+
+			`    "path":"website.tgz",`+
+			`    "description":".tgz of your website",`+
+			`    "revision":1,`+
+			`    "fingerprint":"73100f01cf258766906c34a30f9a486f07259c627ea0696d97c4582560447f59a6df4a7cf960708271a30324b1481ef4",`+
 			`    "size":48,`+
 			`    "origin":"store"`+
 			"  }"+


### PR DESCRIPTION
## Description of change

Resources are returned in a map which means that display order is not guaranteed between runs.
This PR ensures that at presentation level, list of resources is always sorted by name in alphabetical order.

This is a pre-cursor to a PR that adds resources featuretest.

## QA steps

1. bootstrap
2. run 'juju charm resources' for a charm with multiple resources, several times
Expected output should be consistently ordered by name.

## Documentation changes

n/a

I could not find any juju documentation where 'juju charm resources' command had an output with more than one resource. If such pages exist, they may need to be updated.

## Bug reference

Contributes to https://bugs.launchpad.net/juju/+bug/1706809
