### PR TITLE
Added resources commands sanity check.

### DIFF
--- a/cmd/juju/resource/formatter.go
+++ b/cmd/juju/resource/formatter.go
@@ -23,7 +23,7 @@ type charmResourcesFormatter struct {
 func newCharmResourcesFormatter(resources []charmresource.Resource) *charmResourcesFormatter {
 	// It's a lot easier to read and to digest a list of resources
 	// when  they are ordered.
-	sort.Sort(resourceList(resources))
+	sort.Sort(charmResourceList(resources))
 
 	// Note that unlike the "juju status" code, we don't worry
 	// about "compatVersion".
@@ -232,9 +232,28 @@ func resourceMap(resources []resource.Resource) map[string]resource.Resource {
 	return m
 }
 
-// resourceList is a convenience type enabling to sort
+// charmResourceList is a convenience type enabling to sort
 // a collection of charmresource.Resource by Name.
-type resourceList []charmresource.Resource
+type charmResourceList []charmresource.Resource
+
+// Len implements sort.Interface
+func (m charmResourceList) Len() int {
+	return len(m)
+}
+
+// Less implements sort.Interface and sorts resources by Name.
+func (m charmResourceList) Less(i, j int) bool {
+	return m[i].Name < m[j].Name
+}
+
+// Swap implements sort.Interface
+func (m charmResourceList) Swap(i, j int) {
+	m[i], m[j] = m[j], m[i]
+}
+
+// resourceList is a convenience type enabling to sort
+// a collection of resource.Resource by Name.
+type resourceList []resource.Resource
 
 // Len implements sort.Interface
 func (m resourceList) Len() int {

--- a/cmd/juju/resource/show_service.go
+++ b/cmd/juju/resource/show_service.go
@@ -4,6 +4,8 @@
 package resource
 
 import (
+	"sort"
+
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
 	"github.com/juju/gnuflag"
@@ -114,6 +116,14 @@ func (c *ShowServiceCommand) Run(ctx *cmd.Context) error {
 		return errors.Errorf("bad data returned from server")
 	}
 	v := vals[0]
+
+	// It's a lot easier to read and to digest a list of resources
+	// when  they are ordered.
+	sort.Sort(charmResourceList(v.CharmStoreResources))
+	sort.Sort(resourceList(v.Resources))
+	for _, u := range v.UnitResources {
+		sort.Sort(resourceList(u.Resources))
+	}
 
 	if unit == "" {
 		return c.formatServiceResources(ctx, v)

--- a/cmd/juju/resource/show_service_test.go
+++ b/cmd/juju/resource/show_service_test.go
@@ -176,8 +176,8 @@ func (s *ShowServiceSuite) TestRun(c *gc.C) {
 [Service]
 Resource  Supplied by  Revision
 openjdk   charmstore   7
-website   upload       -
 rsc1234   charmstore   15
+website   upload       -
 website2  Bill User    2012-12-12T12:12
 
 [Updates Available]

--- a/featuretests/package_test.go
+++ b/featuretests/package_test.go
@@ -55,6 +55,7 @@ func init() {
 	gc.Suite(&crossmodelSuite{})
 	gc.Suite(&ApplicationConfigSuite{})
 	gc.Suite(&CharmUpgradeSuite{})
+	gc.Suite(&ResourcesCmdSuite{})
 
 	// TODO (anastasiamac 2016-07-19) Bug#1603585
 	// These tests cannot run on windows - they require a bootstrapped controller.


### PR DESCRIPTION
## Description of change

This is a basic sanity check, desired for test coverage. 
Historically, resources commands where not tested for full-stack connectivity. This omission caused several slippages during refactoring and improvements of juju commands.
With the addition of a basic feature test, these slippages should no longer occur.
This test does not test the actual functionality and behavior of the commands. It traverses full stack to ensure all components are wired in.

## QA steps

Feature test runs successfully.

## Documentation changes

n/a, internal change

## Bug reference

Final part for https://bugs.launchpad.net/juju/+bug/1706809
