### PR TITLE
Rename 'attach' to 'attach-resource'.

### DIFF
--- a/cmd/juju/commands/main_test.go
+++ b/cmd/juju/commands/main_test.go
@@ -402,6 +402,7 @@ var commandNames = []string{
 	"agree",
 	"agreements",
 	"attach",
+	"attach-resource",
 	"attach-storage",
 	"autoload-credentials",
 	"backups",

--- a/cmd/juju/resource/upload.go
+++ b/cmd/juju/resource/upload.go
@@ -54,13 +54,14 @@ func NewUploadCommand(deps UploadDeps) modelcmd.ModelCommand {
 // Info implements cmd.Command.Info
 func (c *UploadCommand) Info() *cmd.Info {
 	return &cmd.Info{
-		Name:    "attach",
+		Name:    "attach-resource",
 		Args:    "application name=file",
 		Purpose: "Upload a file as a resource for an application.",
 		Doc: `
 This command uploads a file from your local disk to the juju controller to be
 used as a resource for an application.
 `,
+		Aliases: []string{"attach"},
 	}
 }
 

--- a/cmd/juju/resource/upload_test.go
+++ b/cmd/juju/resource/upload_test.go
@@ -90,13 +90,14 @@ func (s *UploadSuite) TestInfo(c *gc.C) {
 	info := command.Info()
 
 	c.Check(info, jc.DeepEquals, &jujucmd.Info{
-		Name:    "attach",
+		Name:    "attach-resource",
 		Args:    "application name=file",
 		Purpose: "Upload a file as a resource for an application.",
 		Doc: `
 This command uploads a file from your local disk to the juju controller to be
 used as a resource for an application.
 `,
+		Aliases: []string{"attach"},
 	})
 }
 

--- a/featuretests/cmd_juju_resources_test.go
+++ b/featuretests/cmd_juju_resources_test.go
@@ -92,7 +92,7 @@ Resource  Revision
 	)
 
 	// check "juju attach"
-	context, err = runCommand(c, "attach", s.appOneName, "install-resource=oops")
+	context, err = runCommand(c, "attach-resource", s.appOneName, "install-resource=oops")
 	c.Assert(err, gc.ErrorMatches, "cmd: error out silently")
 	c.Assert(cmdtesting.Stderr(context), jc.Contains, `ERROR failed to upload resource "install-resource": open oops: no such file or directory`)
 	c.Assert(cmdtesting.Stdout(context), gc.Equals, "")

--- a/featuretests/cmd_juju_resources_test.go
+++ b/featuretests/cmd_juju_resources_test.go
@@ -91,7 +91,7 @@ Resource  Revision
 `[1:],
 	)
 
-	// check "juju attach"
+	// check "juju attach-resource"
 	context, err = runCommand(c, "attach-resource", s.appOneName, "install-resource=oops")
 	c.Assert(err, gc.ErrorMatches, "cmd: error out silently")
 	c.Assert(cmdtesting.Stderr(context), jc.Contains, `ERROR failed to upload resource "install-resource": open oops: no such file or directory`)


### PR DESCRIPTION
## Description of change

This command was overlooked in major rename effort that occurred on a cusp of Juju 2.x.
This is needed to comply with standard naming convention and to add clarity to command intent.

Previous command name 'attach' is now an alias for 'attach-resource' for backward compatibility.

## QA steps

1. 'juju help commands' has both 'attach' and 'attach-resource'
2. running 'juju attach-resource' yields the same result as running 'juju attach'

## Documentation changes

Yes!
All references to 'juju attach' in documentation should be changed to 'juju attach-resource'.

## Bug reference

Part of https://bugs.launchpad.net/juju/+bug/1707564
