### PR TITLE
Record details against relations to offers, eg username

### DIFF
--- a/apiserver/facades/client/applicationoffers/applicationoffers.go
+++ b/apiserver/facades/client/applicationoffers/applicationoffers.go
@@ -441,12 +441,13 @@ func (api *OffersAPI) GetConsumeDetails(args params.ApplicationURLs) (params.Con
 				continue
 			}
 			results[i].ControllerInfo = controllerInfo
-			// TODO(wallyworld) - wind back expiry time and add refresh
+			// TODO(wallyworld) - wind back expiry time and implement a local discharge URL
 			offerMacaroon, err := api.bakery.NewMacaroon("", nil,
 				[]checkers.Caveat{
 					checkers.TimeBeforeCaveat(time.Now().Add(365 * 24 * time.Hour)),
 					checkers.DeclaredCaveat("source-model-uuid", sourceModelTag.Id()),
 					checkers.DeclaredCaveat("offer-url", offer.OfferURL),
+					checkers.DeclaredCaveat("username", api.Authorizer.GetAuthTag().Id()),
 				})
 			if err != nil {
 				results[i].Error = common.ServerError(err)

--- a/apiserver/facades/client/applicationoffers/applicationoffers_test.go
+++ b/apiserver/facades/client/applicationoffers/applicationoffers_test.go
@@ -5,6 +5,7 @@ package applicationoffers_test
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
@@ -12,6 +13,7 @@ import (
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/charm.v6-unstable"
 	"gopkg.in/juju/names.v2"
+	"gopkg.in/macaroon-bakery.v1/bakery/checkers"
 
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/facades/client/applicationoffers"
@@ -33,7 +35,7 @@ var _ = gc.Suite(&applicationOffersSuite{})
 
 func (s *applicationOffersSuite) SetUpTest(c *gc.C) {
 	s.baseSuite.SetUpTest(c)
-	s.bakery = &mockBakeryService{}
+	s.bakery = &mockBakeryService{caveats: make(map[string][]checkers.Caveat)}
 	s.applicationOffers = &stubApplicationOffers{}
 	getApplicationOffers := func(interface{}) jujucrossmodel.ApplicationOffers {
 		return s.applicationOffers
@@ -910,7 +912,7 @@ var _ = gc.Suite(&consumeSuite{})
 
 func (s *consumeSuite) SetUpTest(c *gc.C) {
 	s.baseSuite.SetUpTest(c)
-	s.bakery = &mockBakeryService{}
+	s.bakery = &mockBakeryService{caveats: make(map[string][]checkers.Caveat)}
 	getApplicationOffers := func(st interface{}) jujucrossmodel.ApplicationOffers {
 		return &mockApplicationOffers{st: st.(*mockState)}
 	}
@@ -996,6 +998,12 @@ func (s *consumeSuite) TestConsumeDetailsWithPermission(c *gc.C) {
 		CACert:        testing.CACert,
 	})
 	c.Assert(results.Results[0].Macaroon.Id(), gc.Equals, "")
+	cav := s.bakery.caveats[results.Results[0].Macaroon.Id()]
+	c.Check(cav, gc.HasLen, 4)
+	c.Check(strings.HasPrefix(cav[0].Condition, "time-before "), jc.IsTrue)
+	c.Check(cav[1].Condition, gc.Equals, "declared source-model-uuid deadbeef-0bad-400d-8000-4b1d0d06f00d")
+	c.Check(cav[2].Condition, gc.Equals, "declared offer-url fred/prod.hosted-mysql")
+	c.Check(cav[3].Condition, gc.Equals, "declared username someone")
 }
 
 func (s *consumeSuite) TestConsumeDetailsDefaultEndpoint(c *gc.C) {

--- a/apiserver/facades/client/applicationoffers/mock_test.go
+++ b/apiserver/facades/client/applicationoffers/mock_test.go
@@ -403,9 +403,11 @@ func (st *mockStatePool) Get(modelUUID string) (applicationoffers.Backend, func(
 type mockBakeryService struct {
 	authentication.BakeryService
 	jtesting.Stub
+	caveats map[string][]checkers.Caveat
 }
 
 func (s *mockBakeryService) NewMacaroon(id string, key []byte, caveats []checkers.Caveat) (*macaroon.Macaroon, error) {
 	s.MethodCall(s, "NewMacaroon", id, key, caveats)
+	s.caveats[id] = caveats
 	return macaroon.New(nil, id, "")
 }

--- a/apiserver/facades/client/client/api_test.go
+++ b/apiserver/facades/client/client/api_test.go
@@ -378,10 +378,11 @@ func (s *baseSuite) setUpScenario(c *gc.C) (entities []names.Tag) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	_, err = s.State.AddRemoteApplication(state.AddRemoteApplicationParams{
-		Name:        "remote-db2",
-		OfferName:   "hosted-db2",
-		URL:         "admin/prod.db2",
-		SourceModel: coretesting.ModelTag,
+		Name:            "remote-db2",
+		OfferName:       "hosted-db2",
+		URL:             "admin/prod.db2",
+		SourceModel:     coretesting.ModelTag,
+		IsConsumerProxy: true,
 		Endpoints: []charm.Relation{
 			{
 				Name:      "database",

--- a/apiserver/facades/client/client/client_test.go
+++ b/apiserver/facades/client/client/client_test.go
@@ -756,7 +756,6 @@ func (s *clientSuite) TestClientWatchAllAdminPermission(c *gc.C) {
 			Life:           "alive",
 			Status: multiwatcher.StatusInfo{
 				Current: status.Unknown,
-				Message: "waiting for remote connection",
 			},
 		},
 	}) {

--- a/apiserver/facades/controller/crossmodelrelations/state.go
+++ b/apiserver/facades/controller/crossmodelrelations/state.go
@@ -21,6 +21,10 @@ type CrossModelRelationsState interface {
 
 	// Model returns the model entity.
 	Model() (Model, error)
+
+	// AddOfferConnection creates a new offer connection record, which records details about a
+	// relation made from a remote model to an offer in the local model.
+	AddOfferConnection(state.AddOfferConnectionParams) (OfferConnection, error)
 }
 
 type stateShim struct {
@@ -33,6 +37,10 @@ func (st stateShim) ListOffers(filter ...crossmodel.ApplicationOfferFilter) ([]c
 	return oa.ListOffers(filter...)
 }
 
+func (st stateShim) AddOfferConnection(arg state.AddOfferConnectionParams) (OfferConnection, error) {
+	return st.st.AddOfferConnection(arg)
+}
+
 type Model interface {
 	Name() string
 	Owner() names.UserTag
@@ -41,3 +49,5 @@ type Model interface {
 func (st stateShim) Model() (Model, error) {
 	return st.st.Model()
 }
+
+type OfferConnection interface{}

--- a/cmd/juju/status/status_test.go
+++ b/cmd/juju/status/status_test.go
@@ -2799,7 +2799,7 @@ var statusTests = []testCase{
 		addAliveUnit{"wordpress", "1"},
 
 		addCharm{"mysql"},
-		addRemoteApplication{name: "hosted-mysql", url: "me/model.mysql", charm: "mysql", endpoints: []string{"server"}},
+		addRemoteApplication{name: "hosted-mysql", url: "me/model.mysql", charm: "mysql", endpoints: []string{"server"}, isConsumerProxy: true},
 		relateServices{"wordpress", "hosted-mysql"},
 
 		expect{
@@ -3238,10 +3238,11 @@ func (as addService) step(c *gc.C, ctx *context) {
 }
 
 type addRemoteApplication struct {
-	name      string
-	url       string
-	charm     string
-	endpoints []string
+	name            string
+	url             string
+	charm           string
+	endpoints       []string
+	isConsumerProxy bool
 }
 
 func (as addRemoteApplication) step(c *gc.C, ctx *context) {
@@ -3257,10 +3258,11 @@ func (as addRemoteApplication) step(c *gc.C, ctx *context) {
 		endpoints = append(endpoints, r)
 	}
 	_, err := ctx.st.AddRemoteApplication(state.AddRemoteApplicationParams{
-		Name:        as.name,
-		URL:         as.url,
-		SourceModel: coretesting.ModelTag,
-		Endpoints:   endpoints,
+		Name:            as.name,
+		URL:             as.url,
+		SourceModel:     coretesting.ModelTag,
+		Endpoints:       endpoints,
+		IsConsumerProxy: as.isConsumerProxy,
 	})
 	c.Assert(err, jc.ErrorIsNil)
 }

--- a/state/allcollections.go
+++ b/state/allcollections.go
@@ -422,6 +422,9 @@ func allCollections() collectionSchema {
 			applicationOffersC: {
 				indexes: []mgo.Index{{Key: []string{"model-uuid", "url"}}},
 			},
+			offerConnectionsC: {
+				indexes: []mgo.Index{{Key: []string{"model-uuid", "offer-name"}}},
+			},
 			remoteApplicationsC: {},
 			// remoteEntitiesC holds information about entities involved in
 			// cross-model relations.
@@ -530,6 +533,7 @@ const (
 	// Cross model relations
 	applicationOffersC   = "applicationOffers"
 	remoteApplicationsC  = "remoteApplications"
+	offerConnectionsC    = "applicationOfferConnections"
 	remoteEntitiesC      = "remoteEntities"
 	externalControllersC = "externalControllers"
 	relationIngressC     = "relationIngress"

--- a/state/allwatcher_internal_test.go
+++ b/state/allwatcher_internal_test.go
@@ -347,7 +347,6 @@ func addTestingRemoteApplication(
 		Life:           multiwatcher.Life(rs.Life().String()),
 		Status: multiwatcher.StatusInfo{
 			Current: "unknown",
-			Message: "waiting for remote connection",
 			Data:    map[string]interface{}{},
 		},
 	}
@@ -369,6 +368,15 @@ func addTestingApplicationOffer(
 		Endpoints:       eps,
 	})
 	c.Assert(err, jc.ErrorIsNil)
+	// Add the requested number of connections.
+	for i := 0; i < connected; i++ {
+		_, err := st.AddOfferConnection(AddOfferConnectionParams{
+			RelationId: i,
+			Username:   "fred",
+			OfferName:  offerName,
+		})
+		c.Assert(err, jc.ErrorIsNil)
+	}
 	return offer, multiwatcher.ApplicationOfferInfo{
 		ModelUUID:       st.ModelUUID(),
 		OfferName:       offerName,
@@ -3660,6 +3668,12 @@ func testChangeApplicationOffers(c *gc.C, runChangeTests func(*gc.C, []changeTes
 			initialApplicationOfferInfo := applicationOfferInfo
 			addTestingRemoteApplication(
 				c, st, "remote-wordpress", "", "hosted-mysql", mysqlRelations, true)
+			_, err := st.AddOfferConnection(AddOfferConnectionParams{
+				RelationId: 0,
+				Username:   "fred",
+				OfferName:  initialApplicationOfferInfo.OfferName,
+			})
+			c.Assert(err, jc.ErrorIsNil)
 
 			applicationOfferInfo.ConnectedCount = 1
 			return changeTestCase{

--- a/state/migration_internal_test.go
+++ b/state/migration_internal_test.go
@@ -187,6 +187,7 @@ func (s *MigrationSuite) TestKnownCollections(c *gc.C) {
 		//Cross Model Relations - TODO
 		remoteApplicationsC,
 		applicationOffersC,
+		offerConnectionsC,
 		remoteEntitiesC,
 		externalControllersC,
 		relationIngressC,

--- a/state/offerconnections.go
+++ b/state/offerconnections.go
@@ -1,0 +1,164 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package state
+
+import (
+	"fmt"
+
+	"github.com/juju/errors"
+	"gopkg.in/mgo.v2/bson"
+	"gopkg.in/mgo.v2/txn"
+)
+
+// OfferConnection represents the state of an relation
+// to an offer hosted in this model.
+type OfferConnection struct {
+	st  *State
+	doc offerConnectionDoc
+}
+
+// offerConnectionDoc represents the internal state of an offer connection in MongoDB.
+type offerConnectionDoc struct {
+	DocID      string `bson:"_id"`
+	RelationId int    `bson:"relation-id"`
+	OfferName  string `bson:"offer-name"`
+	UserName   string `bson:"username"`
+}
+
+func newOfferConnection(st *State, doc *offerConnectionDoc) *OfferConnection {
+	app := &OfferConnection{
+		st:  st,
+		doc: *doc,
+	}
+	return app
+}
+
+// OfferName returns the offer name.
+func (oc *OfferConnection) OfferName() string {
+	return oc.doc.OfferName
+}
+
+// UserName returns the name of the user who created this connection.
+func (oc *OfferConnection) UserName() string {
+	return oc.doc.UserName
+}
+
+// RelationId is the id of the relation to which this connection pertains.
+func (oc *OfferConnection) RelationId() int {
+	return oc.doc.RelationId
+}
+
+func removeOfferConnectionsForRelationOps(relId int) []txn.Op {
+	op := txn.Op{
+		C:      offerConnectionsC,
+		Id:     fmt.Sprintf("%d", relId),
+		Remove: true,
+	}
+	return []txn.Op{op}
+}
+
+// String returns the details of the connection.
+func (oc *OfferConnection) String() string {
+	return fmt.Sprintf("connection to %q by %q for relation %d", oc.doc.OfferName, oc.doc.UserName, oc.doc.RelationId)
+}
+
+// AddOfferConnectionParams contains the parameters for adding an offer connection
+// to the model.
+type AddOfferConnectionParams struct {
+	// OfferName is the name of the offer.
+	OfferName string
+
+	// Username is the name of the user who created this connection.
+	Username string
+
+	// RelationId is the id of the relation to which this offer pertains.
+	RelationId int
+}
+
+// AddOfferConnection creates a new offer connection record, which records details about a
+// relation made from a remote model to an offer in the local model.
+func (st *State) AddOfferConnection(args AddOfferConnectionParams) (_ *OfferConnection, err error) {
+	defer errors.DeferredAnnotatef(&err, "cannot add offer record for %q", args.OfferName)
+
+	model, err := st.Model()
+	if err != nil {
+		return nil, errors.Trace(err)
+	} else if model.Life() != Alive {
+		return nil, errors.Errorf("model is no longer alive")
+	}
+
+	// Create the application addition operations.
+	offerConnectionDoc := offerConnectionDoc{
+		OfferName:  args.OfferName,
+		UserName:   args.Username,
+		RelationId: args.RelationId,
+		DocID:      fmt.Sprintf("%d", args.RelationId),
+	}
+	buildTxn := func(attempt int) ([]txn.Op, error) {
+		// If we've tried once already and failed, check that
+		// model may have been destroyed.
+		if attempt > 0 {
+			if err := checkModelActive(st); err != nil {
+				return nil, errors.Trace(err)
+			}
+			return nil, errors.AlreadyExistsf("offer connection for relation id %d", args.RelationId)
+		}
+		ops := []txn.Op{
+			model.assertActiveOp(),
+			{
+				C:      offerConnectionsC,
+				Id:     offerConnectionDoc.DocID,
+				Assert: txn.DocMissing,
+				Insert: &offerConnectionDoc,
+			},
+		}
+		return ops, nil
+	}
+	if err = st.db().Run(buildTxn); err != nil {
+		return nil, errors.Trace(err)
+	}
+	return &OfferConnection{doc: offerConnectionDoc}, nil
+}
+
+// AllOfferConnections returns all the offer connections in the model.
+func (st *State) AllOfferConnections() (conns []*OfferConnection, err error) {
+	offerConnectionCollection, closer := st.db().GetCollection(offerConnectionsC)
+	defer closer()
+
+	connDocs := []offerConnectionDoc{}
+	err = offerConnectionCollection.Find(bson.D{}).All(&connDocs)
+	if err != nil {
+		return nil, errors.Errorf("cannot get all offer connections")
+	}
+	for _, v := range connDocs {
+		conns = append(conns, newOfferConnection(st, &v))
+	}
+	return conns, nil
+}
+
+// RemoteConnectionStatus returns summary information about connections to the specified offer.
+func (st *State) RemoteConnectionStatus(offerName string) (*RemoteConnectionStatus, error) {
+	offerConnectionCollection, closer := st.db().GetCollection(offerConnectionsC)
+	defer closer()
+
+	count, err := offerConnectionCollection.Find(bson.D{{"offer-name", offerName}}).Count()
+	if err != nil {
+		return nil, errors.Errorf("cannot get remote connection status for offer %q", offerName)
+	}
+	return &RemoteConnectionStatus{
+		count: count,
+	}, nil
+}
+
+// RemoteConnectionStatus holds summary information about connections
+// to an application offer.
+type RemoteConnectionStatus struct {
+	count int
+}
+
+// ConnectionCount returns the number of remote applications
+// related to an offer.
+func (r *RemoteConnectionStatus) ConnectionCount() int {
+	return r.count
+}

--- a/state/offerconnections_test.go
+++ b/state/offerconnections_test.go
@@ -1,0 +1,66 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package state_test
+
+import (
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/errors"
+	"github.com/juju/juju/state"
+)
+
+type offerConnectionsSuite struct {
+	ConnSuite
+}
+
+var _ = gc.Suite(&offerConnectionsSuite{})
+
+func (s *offerConnectionsSuite) TestAddOfferConnection(c *gc.C) {
+	oc, err := s.State.AddOfferConnection(state.AddOfferConnectionParams{
+		RelationId: 1,
+		Username:   "fred",
+		OfferName:  "mysql",
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(oc.RelationId(), gc.Equals, 1)
+	c.Assert(oc.OfferName(), gc.Equals, "mysql")
+	c.Assert(oc.UserName(), gc.Equals, "fred")
+
+	anotherState, err := s.State.ForModel(s.State.ModelTag())
+	c.Assert(err, jc.ErrorIsNil)
+	defer anotherState.Close()
+
+	rc, err := anotherState.RemoteConnectionStatus("mysql")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(rc.ConnectionCount(), gc.Equals, 1)
+
+	all, err := anotherState.AllOfferConnections()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(all, gc.HasLen, 1)
+	c.Assert(all[0].RelationId(), gc.Equals, 1)
+	c.Assert(all[0].OfferName(), gc.Equals, "mysql")
+	c.Assert(all[0].UserName(), gc.Equals, "fred")
+	c.Assert(all[0].String(), gc.Equals, `connection to "mysql" by "fred" for relation 1`)
+}
+
+func (s *offerConnectionsSuite) TestAddOfferConnectionTwice(c *gc.C) {
+	_, err := s.State.AddOfferConnection(state.AddOfferConnectionParams{
+		RelationId: 1,
+		Username:   "fred",
+		OfferName:  "mysql",
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	anotherState, err := s.State.ForModel(s.State.ModelTag())
+	c.Assert(err, jc.ErrorIsNil)
+	defer anotherState.Close()
+
+	_, err = anotherState.AddOfferConnection(state.AddOfferConnectionParams{
+		RelationId: 1,
+		Username:   "fred",
+		OfferName:  "mysql",
+	})
+	c.Assert(err, jc.Satisfies, errors.IsAlreadyExists)
+}

--- a/state/relation.go
+++ b/state/relation.go
@@ -204,6 +204,8 @@ func (r *Relation) removeOps(ignoreService string, departingUnitName string) ([]
 		re := r.st.RemoteEntities()
 		tokenOps := re.removeRemoteEntityOps(r.Tag())
 		ops = append(ops, tokenOps...)
+		offerOps := removeOfferConnectionsForRelationOps(r.Id())
+		ops = append(ops, offerOps...)
 	}
 	cleanupOp := newCleanupOp(cleanupRelationSettings, fmt.Sprintf("r#%d#", r.Id()))
 	return append(ops, cleanupOp), nil

--- a/state/remoteapplication.go
+++ b/state/remoteapplication.go
@@ -692,10 +692,14 @@ func (st *State) AddRemoteApplication(args AddRemoteApplicationParams) (_ *Remot
 	}
 	appDoc.Spaces = spaces
 	app := newRemoteApplication(st, appDoc)
+	statusInfo := ""
+	if args.IsConsumerProxy {
+		statusInfo = "waiting for remote connection"
+	}
 	statusDoc := statusDoc{
 		ModelUUID:  st.ModelUUID(),
 		Status:     status.Unknown,
-		StatusInfo: "waiting for remote connection",
+		StatusInfo: statusInfo,
 		Updated:    time.Now().UnixNano(),
 	}
 
@@ -796,30 +800,4 @@ func (st *State) AllRemoteApplications() (applications []*RemoteApplication, err
 		applications = append(applications, newRemoteApplication(st, &v))
 	}
 	return applications, nil
-}
-
-// RemoteConnectionStatus returns summary information about connections to the specified offer.
-func (st *State) RemoteConnectionStatus(offerName string) (*RemoteConnectionStatus, error) {
-	applicationsCollection, closer := st.db().GetCollection(remoteApplicationsC)
-	defer closer()
-
-	count, err := applicationsCollection.Find(bson.D{{"offer-name", offerName}}).Count()
-	if err != nil {
-		return nil, errors.Errorf("cannot get remote connection status for offer %q", offerName)
-	}
-	return &RemoteConnectionStatus{
-		count: count,
-	}, nil
-}
-
-// RemoteConnectionStatus holds summary information about connections
-// to an application offer.
-type RemoteConnectionStatus struct {
-	count int
-}
-
-// ConnectionCount returns the number of remote applications
-// related to an offer.
-func (r *RemoteConnectionStatus) ConnectionCount() int {
-	return r.count
 }


### PR DESCRIPTION
## Description of change

Introduce a new collection to hold details about connections to offers. There's a 1:1 between the relation and the offer connection records. For now we just store user name of the person making the connection.

The user name to store comes from the macaroon when the relation is registered, so extend the macaroon to add user name. Also add some missing tests.

The RemoteConnectionStatus logic is moved to use the new offers connection data.

As a driveby, fix the status message on remote applications so that only the offer side shows the "waiting for connections" message.

## QA steps

Run up a cmr scenario - mediawiki -> mysql
juju offers on the mysql model shows connection count 1
add model, deploy mediawiki, relate to mysql offer
juju offers on the mysql model shows connection count 2
remove one of the mediawiki relations
juju offers on the mysql model shows connection count 1

