### PR TITLE
Renamed 'juju charm resources' to 'juju charm-resources'.

### DIFF
--- a/cmd/juju/charmcmd/charm.go
+++ b/cmd/juju/charmcmd/charm.go
@@ -27,17 +27,12 @@ func NewSuperCommand() *Command {
 		SuperCommand: *cmd.NewSuperCommand(
 			cmd.SuperCommandParams{
 				Name:        "charm",
-				Doc:         charmDoc,
+				Doc:         resource.DeprecatedSince + charmDoc,
 				UsagePrefix: "juju",
-				Purpose:     charmPurpose,
+				Purpose:     resource.Deprecated + charmPurpose,
 			},
 		),
 	}
-	// TODO (anastasiamac 2017-07-28) this needs to be renamed
-	// to something else, for eg. 'juju charm-resources',
-	// to comply with the new naming convention.
-	// This command was overlooked in general rename for Juju 2.x
 	charmCmd.Register(resource.NewListCharmResourcesCommand(nil))
-
 	return charmCmd
 }

--- a/cmd/juju/commands/main.go
+++ b/cmd/juju/commands/main.go
@@ -308,6 +308,8 @@ func registerCommands(r commandRegistry, ctx *cmd.Context) {
 
 	// Charm tool commands.
 	r.Register(newHelpToolCommand())
+	// TODO (anastasiamac 2017-08-1) This needs to be removed in Juju 3.x
+	// lp#1707836
 	r.Register(charmcmd.NewSuperCommand())
 
 	// Manage backups.
@@ -478,6 +480,7 @@ func registerCommands(r commandRegistry, ctx *cmd.Context) {
 			return resourceadapters.NewAPIClient(apiRoot)
 		},
 	}))
+	r.Register(resource.NewCharmResourcesCommand(nil))
 
 	// Commands registered elsewhere.
 	for _, newCommand := range registeredCommands {

--- a/cmd/juju/commands/main_test.go
+++ b/cmd/juju/commands/main_test.go
@@ -450,6 +450,7 @@ var commandNames = []string{
 	"list-agreements",
 	"list-backups",
 	"list-cached-images",
+	"list-charm-resources",
 	"list-clouds",
 	"list-controllers",
 	"list-credentials",

--- a/cmd/juju/commands/main_test.go
+++ b/cmd/juju/commands/main_test.go
@@ -412,6 +412,7 @@ var commandNames = []string{
 	"cancel-action",
 	"change-user-password",
 	"charm",
+	"charm-resources",
 	"clouds",
 	"collect-metrics",
 	"config",

--- a/cmd/juju/resource/charmresources.go
+++ b/cmd/juju/resource/charmresources.go
@@ -32,6 +32,7 @@ func NewCharmResourcesCommand(resourceLister ResourceLister) modelcmd.ModelComma
 func (c *CharmResourcesCommand) Info() *cmd.Info {
 	i := c.baseInfo()
 	i.Name = "charm-resources"
+	i.Aliases = []string{"list-charm-resources"}
 	return i
 }
 
@@ -108,17 +109,13 @@ func (c *baseCharmResourcesCommand) baseInit(args []string) error {
 func (c *baseCharmResourcesCommand) baseRun(ctx *cmd.Context) error {
 	// TODO(ericsnow) Adjust this to the charm store.
 
-	charmURLs, err := resolveCharms([]string{c.charm})
+	charmURL, err := resolveCharm(c.charm)
 	if err != nil {
 		return errors.Trace(err)
 	}
+	charm := charmstore.CharmID{URL: charmURL, Channel: csparams.Channel(c.channel)}
 
-	charms := make([]charmstore.CharmID, len(charmURLs))
-	for i, id := range charmURLs {
-		charms[i] = charmstore.CharmID{URL: id, Channel: csparams.Channel(c.channel)}
-	}
-
-	resources, err := c.resourceLister.ListResources(charms)
+	resources, err := c.resourceLister.ListResources([]charmstore.CharmID{charm})
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -168,18 +165,6 @@ func (c *baseCharmResourcesCommand) ListResources(ids []charmstore.CharmID) ([][
 		return nil, errors.Trace(err)
 	}
 	return client.ListResources(ids)
-}
-
-func resolveCharms(charms []string) ([]*charm.URL, error) {
-	var charmURLs []*charm.URL
-	for _, raw := range charms {
-		charmURL, err := resolveCharm(raw)
-		if err != nil {
-			return nil, errors.Trace(err)
-		}
-		charmURLs = append(charmURLs, charmURL)
-	}
-	return charmURLs, nil
 }
 
 func resolveCharm(raw string) (*charm.URL, error) {

--- a/cmd/juju/resource/charmresources.go
+++ b/cmd/juju/resource/charmresources.go
@@ -1,0 +1,196 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package resource
+
+import (
+	"github.com/juju/cmd"
+	"github.com/juju/errors"
+	"github.com/juju/gnuflag"
+	"gopkg.in/juju/charm.v6-unstable"
+	charmresource "gopkg.in/juju/charm.v6-unstable/resource"
+	csparams "gopkg.in/juju/charmrepo.v2-unstable/csclient/params"
+
+	"github.com/juju/juju/charmstore"
+	"github.com/juju/juju/cmd/modelcmd"
+)
+
+// CharmResourcesCommand implements the "juju charm-resources" command.
+type CharmResourcesCommand struct {
+	baseCharmResourcesCommand
+}
+
+// NewCharmResourcesCommand returns a new command that lists resources defined
+// by a charm.
+func NewCharmResourcesCommand(resourceLister ResourceLister) modelcmd.ModelCommand {
+	var c CharmResourcesCommand
+	c.setResourceLister(resourceLister)
+	return modelcmd.Wrap(&c)
+}
+
+// Info implements cmd.Command.
+func (c *CharmResourcesCommand) Info() *cmd.Info {
+	i := c.baseInfo()
+	i.Name = "charm-resources"
+	return i
+}
+
+// SetFlags implements cmd.Command.
+func (c *CharmResourcesCommand) SetFlags(f *gnuflag.FlagSet) {
+	c.setBaseFlags(f)
+}
+
+// Init implements cmd.Command.
+func (c *CharmResourcesCommand) Init(args []string) error {
+	return c.baseInit(args)
+}
+
+// Run implements cmd.Command.
+func (c *CharmResourcesCommand) Run(ctx *cmd.Context) error {
+	return c.baseRun(ctx)
+}
+
+// CharmResourceLister lists resources for the given charm ids.
+type ResourceLister interface {
+	ListResources(ids []charmstore.CharmID) ([][]charmresource.Resource, error)
+}
+
+type baseCharmResourcesCommand struct {
+	modelcmd.ModelCommandBase
+
+	// resourceLister is called by Run to list charm resources and
+	// uses juju/juju/charmstore.Client.
+	resourceLister ResourceLister
+
+	out     cmd.Output
+	channel string
+	charm   string
+}
+
+func (b *baseCharmResourcesCommand) setResourceLister(resourceLister ResourceLister) {
+	if resourceLister == nil {
+		resourceLister = b
+	}
+	b.resourceLister = resourceLister
+}
+
+func (c *baseCharmResourcesCommand) baseInfo() *cmd.Info {
+	return &cmd.Info{
+		Args:    "<charm>",
+		Purpose: "Display the resources for a charm in the charm store.",
+		Doc:     charmResourcesDoc,
+	}
+}
+
+func (c *baseCharmResourcesCommand) setBaseFlags(f *gnuflag.FlagSet) {
+	c.ModelCommandBase.SetFlags(f)
+	defaultFormat := "tabular"
+	c.out.AddFlags(f, defaultFormat, map[string]cmd.Formatter{
+		"tabular": FormatCharmTabular,
+		"yaml":    cmd.FormatYaml,
+		"json":    cmd.FormatJson,
+	})
+	f.StringVar(&c.channel, "channel", "stable", "the charmstore channel of the charm")
+}
+
+func (c *baseCharmResourcesCommand) baseInit(args []string) error {
+	if len(args) == 0 {
+		return errors.New("missing charm")
+	}
+	c.charm = args[0]
+
+	if err := cmd.CheckEmpty(args[1:]); err != nil {
+		return errors.Trace(err)
+	}
+	return nil
+}
+
+func (c *baseCharmResourcesCommand) baseRun(ctx *cmd.Context) error {
+	// TODO(ericsnow) Adjust this to the charm store.
+
+	charmURLs, err := resolveCharms([]string{c.charm})
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	charms := make([]charmstore.CharmID, len(charmURLs))
+	for i, id := range charmURLs {
+		charms[i] = charmstore.CharmID{URL: id, Channel: csparams.Channel(c.channel)}
+	}
+
+	resources, err := c.resourceLister.ListResources(charms)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	if len(resources) != 1 {
+		return errors.New("got bad data from charm store")
+	}
+	res := resources[0]
+
+	if len(res) == 0 && c.out.Name() == "tabular" {
+		ctx.Infof("No resources to display.")
+		return nil
+	}
+
+	// Note that we do not worry about c.CompatVersion
+	// for show-charm-resources...
+	formatter := newCharmResourcesFormatter(resources[0])
+	formatted := formatter.format()
+	return c.out.Write(ctx, formatted)
+}
+
+var charmResourcesDoc = `
+This command will report the resources for a charm in the charm store.
+
+<charm> can be a charm URL, or an unambiguously condensed form of it,
+just like the deploy command. So the following forms will be accepted:
+
+For cs:trusty/mysql
+  mysql
+  trusty/mysql
+
+For cs:~user/trusty/mysql
+  cs:~user/mysql
+
+Where the series is not supplied, the series from your local host is used.
+Thus the above examples imply that the local series is trusty.
+`
+
+// ListCharmResources implements CharmResourceLister by getting the charmstore client
+// from the command's ModelCommandBase.
+func (c *baseCharmResourcesCommand) ListResources(ids []charmstore.CharmID) ([][]charmresource.Resource, error) {
+	bakeryClient, err := c.BakeryClient()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	client, err := charmstore.NewCustomClient(bakeryClient, nil)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return client.ListResources(ids)
+}
+
+func resolveCharms(charms []string) ([]*charm.URL, error) {
+	var charmURLs []*charm.URL
+	for _, raw := range charms {
+		charmURL, err := resolveCharm(raw)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		charmURLs = append(charmURLs, charmURL)
+	}
+	return charmURLs, nil
+}
+
+func resolveCharm(raw string) (*charm.URL, error) {
+	charmURL, err := charm.ParseURL(raw)
+	if err != nil {
+		return charmURL, errors.Trace(err)
+	}
+
+	if charmURL.Series == "bundle" {
+		return charmURL, errors.Errorf("charm bundles are not supported")
+	}
+
+	return charmURL, nil
+}

--- a/cmd/juju/resource/charmresources_test.go
+++ b/cmd/juju/resource/charmresources_test.go
@@ -41,6 +41,7 @@ func (s *CharmResourcesSuite) TestInfo(c *gc.C) {
 		Name:    "charm-resources",
 		Args:    "<charm>",
 		Purpose: "Display the resources for a charm in the charm store.",
+		Aliases: []string{"list-charm-resources"},
 		Doc: `
 This command will report the resources for a charm in the charm store.
 

--- a/cmd/juju/resource/charmresources_test.go
+++ b/cmd/juju/resource/charmresources_test.go
@@ -17,32 +17,31 @@ import (
 	resourcecmd "github.com/juju/juju/cmd/juju/resource"
 )
 
-var _ = gc.Suite(&ListCharmSuite{})
+var _ = gc.Suite(&CharmResourcesSuite{})
 
-type ListCharmSuite struct {
+type CharmResourcesSuite struct {
 	testing.IsolationSuite
 
 	stub   *testing.Stub
 	client *stubCharmStore
 }
 
-func (s *ListCharmSuite) SetUpTest(c *gc.C) {
+func (s *CharmResourcesSuite) SetUpTest(c *gc.C) {
 	s.IsolationSuite.SetUpTest(c)
 
 	s.stub = &testing.Stub{}
 	s.client = &stubCharmStore{stub: s.stub}
 }
 
-func (s *ListCharmSuite) TestInfo(c *gc.C) {
-	var command resourcecmd.ListCharmResourcesCommand
+func (s *CharmResourcesSuite) TestInfo(c *gc.C) {
+	var command resourcecmd.CharmResourcesCommand
 	info := command.Info()
 
 	c.Check(info, jc.DeepEquals, &jujucmd.Info{
-		Name:    "resources",
+		Name:    "charm-resources",
 		Args:    "<charm>",
-		Purpose: "DEPRECATED: Display the resources for a charm in the charm store.",
-		Doc: `This command is DEPRECATED from Juju 2.3.x
-
+		Purpose: "Display the resources for a charm in the charm store.",
+		Doc: `
 This command will report the resources for a charm in the charm store.
 
 <charm> can be a charm URL, or an unambiguously condensed form of it,
@@ -58,11 +57,10 @@ For cs:~user/trusty/mysql
 Where the series is not supplied, the series from your local host is used.
 Thus the above examples imply that the local series is trusty.
 `,
-		Aliases: []string{"list-resources"},
 	})
 }
 
-func (s *ListCharmSuite) TestOkay(c *gc.C) {
+func (s *CharmResourcesSuite) TestOkay(c *gc.C) {
 	resources := newCharmResources(c,
 		"website:.tgz of your website",
 		"music:mp3 of your backing vocals",
@@ -70,7 +68,7 @@ func (s *ListCharmSuite) TestOkay(c *gc.C) {
 	resources[0].Revision = 2
 	s.client.ReturnListResources = [][]charmresource.Resource{resources}
 
-	command := resourcecmd.NewListCharmResourcesCommand(s.client)
+	command := resourcecmd.NewCharmResourcesCommand(s.client)
 	code, stdout, stderr := runCmd(c, command, "cs:a-charm")
 	c.Check(code, gc.Equals, 0)
 
@@ -92,10 +90,10 @@ website   2
 	})
 }
 
-func (s *ListCharmSuite) TestNoResources(c *gc.C) {
+func (s *CharmResourcesSuite) TestNoResources(c *gc.C) {
 	s.client.ReturnListResources = [][]charmresource.Resource{{}}
 
-	command := resourcecmd.NewListCharmResourcesCommand(s.client)
+	command := resourcecmd.NewCharmResourcesCommand(s.client)
 	code, stdout, stderr := runCmd(c, command, "cs:a-charm")
 	c.Check(code, gc.Equals, 0)
 
@@ -104,7 +102,7 @@ func (s *ListCharmSuite) TestNoResources(c *gc.C) {
 	s.stub.CheckCallNames(c, "ListResources")
 }
 
-func (s *ListCharmSuite) TestOutputFormats(c *gc.C) {
+func (s *CharmResourcesSuite) TestOutputFormats(c *gc.C) {
 	fp1, err := charmresource.GenerateFingerprint(strings.NewReader("abc"))
 	c.Assert(err, jc.ErrorIsNil)
 	fp2, err := charmresource.GenerateFingerprint(strings.NewReader("xyz"))
@@ -166,7 +164,7 @@ website   1
 	}
 	for format, expected := range formats {
 		c.Logf("checking format %q", format)
-		command := resourcecmd.NewListCharmResourcesCommand(s.client)
+		command := resourcecmd.NewCharmResourcesCommand(s.client)
 		args := []string{
 			"--format", format,
 			"cs:a-charm",
@@ -179,7 +177,7 @@ website   1
 	}
 }
 
-func (s *ListCharmSuite) TestChannelFlag(c *gc.C) {
+func (s *CharmResourcesSuite) TestChannelFlag(c *gc.C) {
 	fp1, err := charmresource.GenerateFingerprint(strings.NewReader("abc"))
 	c.Assert(err, jc.ErrorIsNil)
 	fp2, err := charmresource.GenerateFingerprint(strings.NewReader("xyz"))
@@ -189,7 +187,7 @@ func (s *ListCharmSuite) TestChannelFlag(c *gc.C) {
 		charmRes(c, "music", ".mp3", "mp3 of your backing vocals", string(fp2.Bytes())),
 	}
 	s.client.ReturnListResources = [][]charmresource.Resource{resources}
-	command := resourcecmd.NewListCharmResourcesCommand(s.client)
+	command := resourcecmd.NewCharmResourcesCommand(s.client)
 
 	code, _, stderr := runCmd(c, command,
 		"--channel", "development",
@@ -198,5 +196,5 @@ func (s *ListCharmSuite) TestChannelFlag(c *gc.C) {
 
 	c.Check(code, gc.Equals, 0)
 	c.Check(stderr, gc.Equals, "")
-	c.Check(resourcecmd.ListCharmResourcesCommandChannel(command), gc.Equals, "development")
+	c.Check(resourcecmd.CharmResourcesCommandChannel(command), gc.Equals, "development")
 }

--- a/cmd/juju/resource/export_test.go
+++ b/cmd/juju/resource/export_test.go
@@ -11,6 +11,10 @@ func ListCharmResourcesCommandChannel(c modelcmd.Command) string {
 	return modelcmd.InnerCommand(c).(*ListCharmResourcesCommand).channel
 }
 
+func CharmResourcesCommandChannel(c modelcmd.Command) string {
+	return modelcmd.InnerCommand(c).(*CharmResourcesCommand).channel
+}
+
 func ShowServiceCommandTarget(c *ShowServiceCommand) string {
 	return c.target
 }

--- a/cmd/juju/resource/list_charm_resources.go
+++ b/cmd/juju/resource/list_charm_resources.go
@@ -5,168 +5,51 @@ package resource
 
 import (
 	"github.com/juju/cmd"
-	"github.com/juju/errors"
 	"github.com/juju/gnuflag"
-	"gopkg.in/juju/charm.v6-unstable"
-	charmresource "gopkg.in/juju/charm.v6-unstable/resource"
-	csparams "gopkg.in/juju/charmrepo.v2-unstable/csclient/params"
 
-	"github.com/juju/juju/charmstore"
 	"github.com/juju/juju/cmd/modelcmd"
 )
 
-// CharmResourceLister lists resources for the given charm ids.
-type ResourceLister interface {
-	ListResources(ids []charmstore.CharmID) ([][]charmresource.Resource, error)
-}
+const (
+	Deprecated      = "DEPRECATED: "
+	DeprecatedSince = "This command is DEPRECATED from Juju 2.3.x\n"
+)
 
 // ListCharmResourcesCommand implements the "juju charm resources" command.
 type ListCharmResourcesCommand struct {
-	modelcmd.ModelCommandBase
-
-	// resourceLister is called by Run to list charm resources and
-	// uses juju/juju/charmstore.Client.
-	resourceLister ResourceLister
-
-	out     cmd.Output
-	channel string
-	charm   string
+	baseCharmResourcesCommand
 }
 
 // NewListCharmResourcesCommand returns a new command that lists resources defined
 // by a charm.
 func NewListCharmResourcesCommand(resourceLister ResourceLister) modelcmd.ModelCommand {
 	var c ListCharmResourcesCommand
-	if resourceLister == nil {
-		resourceLister = &c
-	}
-	c.resourceLister = resourceLister
+	c.setResourceLister(resourceLister)
 	return modelcmd.Wrap(&c)
 }
 
-var listCharmResourcesDoc = `
-This command will report the resources for a charm in the charm store.
-
-<charm> can be a charm URL, or an unambiguously condensed form of it,
-just like the deploy command. So the following forms will be accepted:
-
-For cs:trusty/mysql
-  mysql
-  trusty/mysql
-
-For cs:~user/trusty/mysql
-  cs:~user/mysql
-
-Where the series is not supplied, the series from your local host is used.
-Thus the above examples imply that the local series is trusty.
-`
-
 // Info implements cmd.Command.
 func (c *ListCharmResourcesCommand) Info() *cmd.Info {
-	return &cmd.Info{
-		Name:    "resources",
-		Args:    "<charm>",
-		Purpose: "Display the resources for a charm in the charm store.",
-		Doc:     listCharmResourcesDoc,
-		Aliases: []string{"list-resources"},
-	}
+	i := c.baseInfo()
+	i.Name = "resources"
+	i.Aliases = []string{"list-resources"}
+	i.Doc = DeprecatedSince + i.Doc
+	i.Purpose = Deprecated + i.Purpose
+	return i
 }
 
 // SetFlags implements cmd.Command.
 func (c *ListCharmResourcesCommand) SetFlags(f *gnuflag.FlagSet) {
-	c.ModelCommandBase.SetFlags(f)
-	defaultFormat := "tabular"
-	c.out.AddFlags(f, defaultFormat, map[string]cmd.Formatter{
-		"tabular": FormatCharmTabular,
-		"yaml":    cmd.FormatYaml,
-		"json":    cmd.FormatJson,
-	})
-	f.StringVar(&c.channel, "channel", "stable", "the charmstore channel of the charm")
+	c.setBaseFlags(f)
 }
 
 // Init implements cmd.Command.
 func (c *ListCharmResourcesCommand) Init(args []string) error {
-	if len(args) == 0 {
-		return errors.New("missing charm")
-	}
-	c.charm = args[0]
-
-	if err := cmd.CheckEmpty(args[1:]); err != nil {
-		return errors.Trace(err)
-	}
-	return nil
+	return c.baseInit(args)
 }
 
 // Run implements cmd.Command.
 func (c *ListCharmResourcesCommand) Run(ctx *cmd.Context) error {
-	// TODO(ericsnow) Adjust this to the charm store.
-
-	charmURLs, err := resolveCharms([]string{c.charm})
-	if err != nil {
-		return errors.Trace(err)
-	}
-
-	charms := make([]charmstore.CharmID, len(charmURLs))
-	for i, id := range charmURLs {
-		charms[i] = charmstore.CharmID{URL: id, Channel: csparams.Channel(c.channel)}
-	}
-
-	resources, err := c.resourceLister.ListResources(charms)
-	if err != nil {
-		return errors.Trace(err)
-	}
-	if len(resources) != 1 {
-		return errors.New("got bad data from charm store")
-	}
-	res := resources[0]
-
-	if len(res) == 0 && c.out.Name() == "tabular" {
-		ctx.Infof("No resources to display.")
-		return nil
-	}
-
-	// Note that we do not worry about c.CompatVersion
-	// for show-charm-resources...
-	formatter := newCharmResourcesFormatter(resources[0])
-	formatted := formatter.format()
-	return c.out.Write(ctx, formatted)
-}
-
-// ListCharmResources implements CharmResourceLister by getting the charmstore client
-// from the command's ModelCommandBase.
-func (c *ListCharmResourcesCommand) ListResources(ids []charmstore.CharmID) ([][]charmresource.Resource, error) {
-	bakeryClient, err := c.BakeryClient()
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	client, err := charmstore.NewCustomClient(bakeryClient, nil)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	return client.ListResources(ids)
-}
-
-func resolveCharms(charms []string) ([]*charm.URL, error) {
-	var charmURLs []*charm.URL
-	for _, raw := range charms {
-		charmURL, err := resolveCharm(raw)
-		if err != nil {
-			return nil, errors.Trace(err)
-		}
-		charmURLs = append(charmURLs, charmURL)
-	}
-	return charmURLs, nil
-}
-
-func resolveCharm(raw string) (*charm.URL, error) {
-	charmURL, err := charm.ParseURL(raw)
-	if err != nil {
-		return charmURL, errors.Trace(err)
-	}
-
-	if charmURL.Series == "bundle" {
-		return charmURL, errors.Errorf("charm bundles are not supported")
-	}
-
-	return charmURL, nil
+	ctx.Warningf(DeprecatedSince)
+	return c.baseRun(ctx)
 }

--- a/cmd/juju/resource/list_charm_resources.go
+++ b/cmd/juju/resource/list_charm_resources.go
@@ -12,7 +12,7 @@ import (
 
 const (
 	Deprecated      = "DEPRECATED: "
-	DeprecatedSince = "This command is DEPRECATED from Juju 2.3.x\n"
+	DeprecatedSince = "This command is DEPRECATED since Juju 2.3.x, please use 'juju charm-resources' instead.\n"
 )
 
 // ListCharmResourcesCommand implements the "juju charm resources" command.

--- a/cmd/juju/resource/list_charm_resources_test.go
+++ b/cmd/juju/resource/list_charm_resources_test.go
@@ -41,7 +41,7 @@ func (s *ListCharmSuite) TestInfo(c *gc.C) {
 		Name:    "resources",
 		Args:    "<charm>",
 		Purpose: "DEPRECATED: Display the resources for a charm in the charm store.",
-		Doc: `This command is DEPRECATED from Juju 2.3.x
+		Doc: `This command is DEPRECATED since Juju 2.3.x, please use 'juju charm-resources' instead.
 
 This command will report the resources for a charm in the charm store.
 

--- a/featuretests/cmd_juju_resources_test.go
+++ b/featuretests/cmd_juju_resources_test.go
@@ -64,7 +64,7 @@ func (s *ResourcesCmdSuite) SetUpTest(c *gc.C) {
 
 // This test only verifies that component-based resources commands don't panic.
 func (s *ResourcesCmdSuite) TestResourcesCommands(c *gc.C) {
-	// check "juju charm resources..."
+	// check "juju charm-resources..."
 	s.runCharmResourcesCommand(c)
 
 	// check "juju resources <application>"
@@ -99,7 +99,7 @@ Resource  Revision
 }
 
 func (s *ResourcesCmdSuite) runCharmResourcesCommand(c *gc.C) {
-	context, err := cmdtesting.RunCommand(c, resource.NewListCharmResourcesCommand(s.client), s.charmName)
+	context, err := cmdtesting.RunCommand(c, resource.NewCharmResourcesCommand(s.client), s.charmName)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cmdtesting.Stderr(context), gc.Equals, "")
 	c.Assert(cmdtesting.Stdout(context), gc.Equals, `


### PR DESCRIPTION
## Description of change

'juju charm resources' was not compliant with Juju standard naming convention for commands.

This PR deprecates 'juju charm' and 'juju charm resources' commands for backward compatibility but adds a warning to their output.

The PR introduces a new top level command 'juju charm-resources'. 

It was not possible to simply alias older commands as our aliases can only be one word.

## QA steps

1. 'juju charm' and 'juju charm resources' (and aliased 'juju charm list-resources') still work as before but now output a deprecated message as well.
2. 'juju charm-resources' works as 'juju charm resources' did.

## Documentation changes

All references to 'juju charm resources' need to be updated to 'juju charm-resources'.
Command list will still contain 'juju charm resources'.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1707564
