### PR TITLE
Add upgrade step for action pruning.

### DIFF
--- a/cmd/jujud/agent/machine_test.go
+++ b/cmd/jujud/agent/machine_test.go
@@ -1439,8 +1439,8 @@ func (s *MachineSuite) setUpNewModel(c *gc.C) (newSt *state.State, closer func()
 		ConfigAttrs: coretesting.Attrs{
 			"max-status-history-age":  "2h",
 			"max-status-history-size": "4M",
-			"max-action-age":          "2h",
-			"max-action-size":         "4M",
+			"max-action-results-age":  "2h",
+			"max-action-results-size": "4M",
 		},
 	})
 	return newSt, func() {

--- a/environs/config/config.go
+++ b/environs/config/config.go
@@ -149,13 +149,13 @@ const (
 	// collection can grow to before it is pruned, eg "5M"
 	MaxStatusHistorySize = "max-status-history-size"
 
-	// MaxActionAge is the maximum age of actions to keep when pruning, eg
+	// MaxActionResultsAge is the maximum age of actions to keep when pruning, eg
 	// "72h"
-	MaxActionAge = "max-action-age"
+	MaxActionResultsAge = "max-action-results-age"
 
-	// MaxActionSize is the maximum size the actions collection can
+	// MaxActionResultsSize is the maximum size the actions collection can
 	// grow to before it is pruned, eg "5M"
-	MaxActionSize = "max-action-size"
+	MaxActionResultsSize = "max-action-results-size"
 
 	// UpdateStatusHookInterval is how often to run the update-status hook.
 	UpdateStatusHookInterval = "update-status-hook-interval"
@@ -319,9 +319,9 @@ const (
 	// DefaultUpdateStatusHookInterval is the default value for UpdateStatusHookInterval
 	DefaultUpdateStatusHookInterval = "5m"
 
-	DefaultActionAge = "336h" // 2 weeks
+	DefaultActionResultsAge = "336h" // 2 weeks
 
-	DefaultActionSize = "5G"
+	DefaultActionResultsSize = "5G"
 )
 
 var defaultConfigValues = map[string]interface{}{
@@ -386,8 +386,8 @@ var defaultConfigValues = map[string]interface{}{
 	// Status history settings
 	MaxStatusHistoryAge:  DefaultStatusHistoryAge,
 	MaxStatusHistorySize: DefaultStatusHistorySize,
-	MaxActionAge:         DefaultActionAge,
-	MaxActionSize:        DefaultActionSize,
+	MaxActionResultsAge:  DefaultActionResultsAge,
+	MaxActionResultsSize: DefaultActionResultsSize,
 }
 
 // ConfigDefaults returns the config default values
@@ -537,13 +537,13 @@ func Validate(cfg, old *Config) error {
 		}
 	}
 
-	if v, ok := cfg.defined[MaxActionAge].(string); ok {
+	if v, ok := cfg.defined[MaxActionResultsAge].(string); ok {
 		if _, err := time.ParseDuration(v); err != nil {
 			return errors.Annotate(err, "invalid max action age in model configuration")
 		}
 	}
 
-	if v, ok := cfg.defined[MaxActionSize].(string); ok {
+	if v, ok := cfg.defined[MaxActionResultsSize].(string); ok {
 		if _, err := utils.ParseSize(v); err != nil {
 			return errors.Annotate(err, "invalid max action size in model configuration")
 		}
@@ -999,15 +999,15 @@ func (c *Config) MaxStatusHistorySizeMB() uint {
 	return uint(val)
 }
 
-func (c *Config) MaxActionAge() time.Duration {
+func (c *Config) MaxActionResultsAge() time.Duration {
 	// Value has already been validated.
-	val, _ := time.ParseDuration(c.mustString(MaxActionAge))
+	val, _ := time.ParseDuration(c.mustString(MaxActionResultsAge))
 	return val
 }
 
-func (c *Config) MaxActionSizeMB() uint {
+func (c *Config) MaxActionResultsSizeMB() uint {
 	// Value has already been validated.
-	val, _ := utils.ParseSize(c.mustString(MaxActionSize))
+	val, _ := utils.ParseSize(c.mustString(MaxActionResultsSize))
 	return uint(val)
 }
 
@@ -1134,8 +1134,8 @@ var alwaysOptional = schema.Defaults{
 	NetBondReconfigureDelayKey:   schema.Omit,
 	MaxStatusHistoryAge:          schema.Omit,
 	MaxStatusHistorySize:         schema.Omit,
-	MaxActionAge:                 schema.Omit,
-	MaxActionSize:                schema.Omit,
+	MaxActionResultsAge:          schema.Omit,
+	MaxActionResultsSize:         schema.Omit,
 	UpdateStatusHookInterval:     schema.Omit,
 }
 
@@ -1518,12 +1518,12 @@ data of the store. (default false)`,
 		Type:        environschema.Tstring,
 		Group:       environschema.EnvironGroup,
 	},
-	MaxActionAge: {
+	MaxActionResultsAge: {
 		Description: "The maximum age for action entries before they are pruned, in human-readable time format",
 		Type:        environschema.Tstring,
 		Group:       environschema.EnvironGroup,
 	},
-	MaxActionSize: {
+	MaxActionResultsSize: {
 		Description: "The maximum size for the action collection, in human-readable memory format",
 		Type:        environschema.Tstring,
 		Group:       environschema.EnvironGroup,

--- a/upgrades/backend.go
+++ b/upgrades/backend.go
@@ -28,6 +28,7 @@ type StateBackend interface {
 	RemoveNilValueApplicationSettings() error
 	AddControllerLogCollectionsSizeSettings() error
 	AddStatusHistoryPruneSettings() error
+	AddActionPruneSettings() error
 	AddStorageInstanceConstraints() error
 	SplitLogCollections() error
 	AddUpdateStatusHookSettings() error
@@ -105,6 +106,10 @@ func (s stateBackend) AddControllerLogCollectionsSizeSettings() error {
 
 func (s stateBackend) AddStatusHistoryPruneSettings() error {
 	return state.AddStatusHistoryPruneSettings(s.st)
+}
+
+func (s stateBackend) AddActionPruneSettings() error {
+	return state.AddActionPruneSettings(s.st)
 }
 
 func (s stateBackend) AddUpdateStatusHookSettings() error {

--- a/upgrades/operations.go
+++ b/upgrades/operations.go
@@ -23,6 +23,7 @@ var stateUpgradeOperations = func() []Operation {
 		upgradeToVersion{version.MustParse("2.1.0"), stateStepsFor21()},
 		upgradeToVersion{version.MustParse("2.2.0"), stateStepsFor22()},
 		upgradeToVersion{version.MustParse("2.2.1"), stateStepsFor221()},
+		upgradeToVersion{version.MustParse("2.2.3"), stateStepsFor223()},
 	}
 	return steps
 }

--- a/upgrades/steps_223.go
+++ b/upgrades/steps_223.go
@@ -1,0 +1,17 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package upgrades
+
+// stateStepsFor223 returns upgrade steps for Juju 2.2.3 that manipulate state directly.
+func stateStepsFor223() []Step {
+	return []Step{
+		&upgradeStep{
+			description: "add max-action-age and max-action-size config settings",
+			targets:     []Target{DatabaseMaster},
+			run: func(context Context) error {
+				return context.State().AddActionPruneSettings()
+			},
+		},
+	}
+}

--- a/upgrades/steps_223_test.go
+++ b/upgrades/steps_223_test.go
@@ -1,0 +1,27 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package upgrades_test
+
+import (
+	jc "github.com/juju/testing/checkers"
+	"github.com/juju/version"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/testing"
+	"github.com/juju/juju/upgrades"
+)
+
+var v223 = version.MustParse("2.2.3")
+
+type steps223Suite struct {
+	testing.BaseSuite
+}
+
+var _ = gc.Suite(&steps223Suite{})
+
+func (s *steps223Suite) TestAddActionPruneSettings(c *gc.C) {
+	step := findStateStep(c, v223, "add max-action-age and max-action-size config settings")
+	// Logic for step itself is tested in state package.
+	c.Assert(step.Targets(), jc.DeepEquals, []upgrades.Target{upgrades.DatabaseMaster})
+}

--- a/upgrades/upgrade_test.go
+++ b/upgrades/upgrade_test.go
@@ -644,6 +644,7 @@ func (s *upgradeSuite) TestStateUpgradeOperationsVersions(c *gc.C) {
 		"2.1.0",
 		"2.2.0",
 		"2.2.1",
+		"2.2.3",
 	})
 }
 

--- a/worker/actionpruner/worker.go
+++ b/worker/actionpruner/worker.go
@@ -27,7 +27,7 @@ func NewFacade(caller base.APICaller) pruner.Facade {
 
 func (w *Worker) loop() error {
 	return w.Work(func(config *config.Config) (time.Duration, uint) {
-		return config.MaxActionAge(), config.MaxActionSizeMB()
+		return config.MaxActionResultsAge(), config.MaxActionResultsSizeMB()
 	})
 }
 


### PR DESCRIPTION
## Description of change

`Action` collection pruning settings were added to the database but a state upgrade step was not added. Those upgrading would see errors that indicate they are missing data that should have been read from configuration settings.

## QA steps

Upgrade a controller from a previous version to 2.2.3 and [verify that action pruning is working](https://github.com/juju/juju/pull/7658)

Also you may run the command:

```bash
juju model-config | grep results
```

You should receive the following output:

```bash
max-action-results-age       default  336h
max-action-results-size      default  5G
```

## Documentation changes

yes, we must change the model configuration names to reflect the update.

## Bug reference

N/A
