### PR TITLE
Add K8s config file reading to add-caas

### DIFF
--- a/caas/clientconfig/k8s.go
+++ b/caas/clientconfig/k8s.go
@@ -14,6 +14,7 @@ import (
 
 var logger = loggo.GetLogger("juju.caas.clientconfig")
 
+// K8SClientConfig parses Kubernetes client configuration from the default location or $KUBECONFIG.
 func K8SClientConfig() (*ClientConfig, error) {
 
 	configPath := getKubeConfigPath()
@@ -77,17 +78,17 @@ func credentialsFromConfig(config *clientcmdapi.Config) (map[string]cloud.Creden
 		var hasCert bool
 		attrs := map[string]string{}
 		if len(user.ClientCertificateData) > 0 {
-			attrs["ClientCertificateData"] = string(user.ClientCertificateData[:])
+			attrs["ClientCertificateData"] = string(user.ClientCertificateData)
 			hasCert = true
 		}
 		if len(user.ClientKeyData) > 0 {
-			attrs["ClientKeyData"] = string(user.ClientKeyData[:])
+			attrs["ClientKeyData"] = string(user.ClientKeyData)
 		}
 
 		var authType cloud.AuthType
 		if user.Token != "" {
 			if user.Username != "" || user.Password != "" {
-				logger.Warningf("Invalid AuthInfo: '%s' has both Token and User/Pass: skipping", name)
+				logger.Warningf("invalid AuthInfo: '%s' has both Token and User/Pass: skipping", name)
 				continue
 			}
 			attrs["Token"] = user.Token
@@ -110,7 +111,7 @@ func credentialsFromConfig(config *clientcmdapi.Config) (map[string]cloud.Creden
 		} else if hasCert {
 			authType = cloud.CertificateAuthType
 		} else {
-			logger.Warningf("Unsupported configuration for AuthInfo '%s'", name)
+			logger.Warningf("unsupported configuration for AuthInfo '%s'", name)
 		}
 
 		rv[name] = cloud.NewCredential(authType, attrs)

--- a/caas/clientconfig/k8s.go
+++ b/caas/clientconfig/k8s.go
@@ -4,11 +4,10 @@ import (
 	"os"
 	"path/filepath"
 
-	"k8s.io/client-go/tools/clientcmd"
-	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
-
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
+	"k8s.io/client-go/tools/clientcmd"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 
 	"github.com/juju/juju/cloud"
 )

--- a/caas/clientconfig/k8s.go
+++ b/caas/clientconfig/k8s.go
@@ -14,10 +14,7 @@ import (
 
 var logger = loggo.GetLogger("juju.caas.clientconfig")
 
-type K8SClientConfigReader struct {
-}
-
-func (r *K8SClientConfigReader) GetClientConfig() (*ClientConfig, error) {
+func K8SClientConfig() (*ClientConfig, error) {
 
 	configPath := getKubeConfigPath()
 

--- a/caas/clientconfig/k8s.go
+++ b/caas/clientconfig/k8s.go
@@ -1,0 +1,131 @@
+package caas
+
+import (
+	"os"
+	"path/filepath"
+
+	"k8s.io/client-go/tools/clientcmd"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+
+	"github.com/juju/errors"
+	"github.com/juju/loggo"
+
+	"github.com/juju/juju/cloud"
+)
+
+var logger = loggo.GetLogger("juju.caas.clientconfig")
+
+type K8SClientConfigReader struct {
+}
+
+func (r *K8SClientConfigReader) GetClientConfig() (*ClientConfig, error) {
+
+	configPath := getKubeConfigPath()
+
+	config, err := clientcmd.LoadFromFile(configPath)
+	if err != nil {
+		return nil, errors.Annotatef(err, "failed to read kubernetes config from '%s'", configPath)
+	}
+	contexts, err := contextsFromConfig(config)
+	if err != nil {
+		return nil, errors.Annotate(err, "failed to read contexts from kubernetes config.")
+	}
+
+	clouds, err := cloudsFromConfig(config)
+	if err != nil {
+		return nil, errors.Annotate(err, "failed to read clouds from kubernetes config.")
+	}
+
+	credentials, err := credentialsFromConfig(config)
+	if err != nil {
+		return nil, errors.Annotate(err, "failed to read credentials from kubernetes config.")
+	}
+
+	return &ClientConfig{
+		Type:           "kubernetes",
+		Contexts:       contexts,
+		CurrentContext: config.CurrentContext,
+		Clouds:         clouds,
+		Credentials:    credentials,
+	}, nil
+}
+
+func contextsFromConfig(config *clientcmdapi.Config) (map[string]Context, error) {
+	rv := map[string]Context{}
+	for name, ctx := range config.Contexts {
+		rv[name] = Context{
+			CredentialName: ctx.AuthInfo,
+			CloudName:      ctx.Cluster,
+		}
+	}
+	return rv, nil
+}
+
+func cloudsFromConfig(config *clientcmdapi.Config) (map[string]CloudConfig, error) {
+	rv := map[string]CloudConfig{}
+	for name, cluster := range config.Clusters {
+		attrs := map[string]interface{}{}
+		attrs["CAData"] = cluster.CertificateAuthorityData
+
+		rv[name] = CloudConfig{
+			Endpoint:   cluster.Server,
+			Attributes: attrs,
+		}
+	}
+	return rv, nil
+}
+
+func credentialsFromConfig(config *clientcmdapi.Config) (map[string]cloud.Credential, error) {
+	rv := map[string]cloud.Credential{}
+	for name, user := range config.AuthInfos {
+		var hasCert bool
+		attrs := map[string]string{}
+		if len(user.ClientCertificateData) > 0 {
+			attrs["ClientCertificateData"] = string(user.ClientCertificateData[:])
+			hasCert = true
+		}
+		if len(user.ClientKeyData) > 0 {
+			attrs["ClientKeyData"] = string(user.ClientKeyData[:])
+		}
+
+		var authType cloud.AuthType
+		if user.Token != "" {
+			if user.Username != "" || user.Password != "" {
+				logger.Warningf("Invalid AuthInfo: '%s' has both Token and User/Pass: skipping", name)
+				continue
+			}
+			attrs["Token"] = user.Token
+			if hasCert {
+				authType = cloud.OAuth2WithCertAuthType
+			} else {
+				authType = cloud.OAuth2AuthType
+			}
+		} else if user.Username != "" {
+			if user.Password == "" {
+				logger.Warningf("empty password")
+			}
+			attrs["Username"] = user.Username
+			attrs["Password"] = user.Password
+			if hasCert {
+				authType = cloud.UserPassWithCertAuthType
+			} else {
+				authType = cloud.UserPassAuthType
+			}
+		} else if hasCert {
+			authType = cloud.CertificateAuthType
+		} else {
+			logger.Warningf("Unsupported configuration for AuthInfo '%s'", name)
+		}
+
+		rv[name] = cloud.NewCredential(authType, attrs)
+	}
+	return rv, nil
+}
+
+func getKubeConfigPath() string {
+	envPath := os.Getenv("KUBECONFIG")
+	if envPath == "" {
+		return filepath.Join(os.Getenv("HOME"), "/.kube/config")
+	}
+	return envPath
+}

--- a/caas/clientconfig/k8s.go
+++ b/caas/clientconfig/k8s.go
@@ -2,7 +2,6 @@ package caas
 
 import (
 	"os"
-	"path/filepath"
 
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
@@ -120,9 +119,9 @@ func credentialsFromConfig(config *clientcmdapi.Config) (map[string]cloud.Creden
 }
 
 func getKubeConfigPath() string {
-	envPath := os.Getenv("KUBECONFIG")
+	envPath := os.Getenv(clientcmd.RecommendedConfigPathEnvVar)
 	if envPath == "" {
-		return filepath.Join(os.Getenv("HOME"), "/.kube/config")
+		return clientcmd.RecommendedHomeFile
 	}
 	return envPath
 }

--- a/caas/clientconfig/k8s_test.go
+++ b/caas/clientconfig/k8s_test.go
@@ -17,7 +17,6 @@ import (
 
 type k8sConfigSuite struct {
 	testing.IsolationSuite
-	reader caascfg.K8SClientConfigReader
 }
 
 var _ = gc.Suite(&k8sConfigSuite{})
@@ -125,7 +124,7 @@ func (s *k8sConfigSuite) TestGetEmptyConfig(c *gc.C) {
 	defer tempFile.Close()
 	defer os.Remove(tempFile.Name())
 
-	cfg, err := s.reader.GetClientConfig()
+	cfg, err := caascfg.K8SClientConfig()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cfg, jc.DeepEquals,
 		&caascfg.ClientConfig{
@@ -142,7 +141,7 @@ func (s *k8sConfigSuite) TestGetSingleConfig(c *gc.C) {
 	defer tempFile.Close()
 	defer os.Remove(tempFile.Name())
 
-	cfg, err := s.reader.GetClientConfig()
+	cfg, err := caascfg.K8SClientConfig()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cfg, jc.DeepEquals,
 		&caascfg.ClientConfig{
@@ -169,7 +168,7 @@ func (s *k8sConfigSuite) TestGetMultiConfig(c *gc.C) {
 	defer tempFile.Close()
 	defer os.Remove(tempFile.Name())
 
-	cfg, err := s.reader.GetClientConfig()
+	cfg, err := caascfg.K8SClientConfig()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cfg, jc.DeepEquals,
 		&caascfg.ClientConfig{

--- a/caas/clientconfig/k8s_test.go
+++ b/caas/clientconfig/k8s_test.go
@@ -1,0 +1,212 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package caas_test
+
+import (
+	"io/ioutil"
+	"os"
+
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	caascfg "github.com/juju/juju/caas/clientconfig"
+	"github.com/juju/juju/cloud"
+	"github.com/juju/testing"
+)
+
+type k8sConfigSuite struct {
+	testing.IsolationSuite
+	reader caascfg.K8SClientConfigReader
+}
+
+var _ = gc.Suite(&k8sConfigSuite{})
+
+var (
+	emptyConfig = `
+apiVersion: v1
+kind: Config
+clusters: []
+contexts: []
+current-context: ""
+preferences: {}
+users: []
+`
+
+	singleConfig = `
+apiVersion: v1
+kind: Config
+clusters:
+- cluster:
+    server: https://1.1.1.1:8888
+  name: the-cluster
+contexts:
+- context:
+    cluster: the-cluster
+    user: the-user
+  name: the-context
+current-context: the-context
+preferences: {}
+users:
+- name: the-user
+  user:
+    password: thepassword
+    username: theuser
+`
+	multiConfig = `
+apiVersion: v1
+kind: Config
+clusters:
+- cluster:
+    server: https://1.1.1.1:8888
+  name: the-cluster
+- cluster:
+    server: https://10.10.10.10:1010
+  name: default-cluster
+contexts:
+- context:
+    cluster: the-cluster
+    user: the-user
+  name: the-context
+- context:
+    cluster: default-cluster
+    user: default-user
+  name: default-context
+current-context: default-context
+preferences: {}
+users:
+- name: the-user
+  user:
+    client-certificate-data: QQ==
+    client-key-data: Qg==
+- name: default-user
+  user:
+    password: defaultpassword
+    username: defaultuser
+- name: third-user
+  user:
+    token: "atoken"
+- name: fourth-user
+  user:
+    client-certificate-data: QQ==
+    client-key-data: Qg==
+    token: "tokenwithcerttoken"
+- name: fifth-user
+  user:
+    client-certificate-data: QQ==
+    client-key-data: Qg==
+    username: "fifth-user"
+    password: "userpasscertpass"
+ 
+`
+)
+
+// writeTempKubeConfig writes yaml to a temp file and sets the
+// KUBECONFIG environment variable so that the clientconfig code reads
+// it instead of the default.
+// The caller must close and remove the returned file.
+func writeTempKubeConfig(c *gc.C, data string) *os.File {
+	caasFile, err := ioutil.TempFile("", "caasFile")
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = ioutil.WriteFile(caasFile.Name(), []byte(data), 0644)
+	if err != nil {
+		caasFile.Close()
+		os.Remove(caasFile.Name())
+		c.Fatal(err.Error())
+	}
+	os.Setenv("KUBECONFIG", caasFile.Name())
+
+	return caasFile
+}
+
+func (s *k8sConfigSuite) TestGetEmptyConfig(c *gc.C) {
+	tempFile := writeTempKubeConfig(c, emptyConfig)
+	defer tempFile.Close()
+	defer os.Remove(tempFile.Name())
+
+	cfg, err := s.reader.GetClientConfig()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(cfg, jc.DeepEquals,
+		&caascfg.ClientConfig{
+			Type:           "kubernetes",
+			Contexts:       map[string]caascfg.Context{},
+			CurrentContext: "",
+			Clouds:         map[string]caascfg.CloudConfig{},
+			Credentials:    map[string]cloud.Credential{},
+		})
+}
+
+func (s *k8sConfigSuite) TestGetSingleConfig(c *gc.C) {
+	tempFile := writeTempKubeConfig(c, singleConfig)
+	defer tempFile.Close()
+	defer os.Remove(tempFile.Name())
+
+	cfg, err := s.reader.GetClientConfig()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(cfg, jc.DeepEquals,
+		&caascfg.ClientConfig{
+
+			Type: "kubernetes",
+			Contexts: map[string]caascfg.Context{
+				"the-context": caascfg.Context{
+					CloudName:      "the-cluster",
+					CredentialName: "the-user"}},
+			CurrentContext: "the-context",
+			Clouds: map[string]caascfg.CloudConfig{
+				"the-cluster": caascfg.CloudConfig{
+					Endpoint:   "https://1.1.1.1:8888",
+					Attributes: map[string]interface{}{"CAData": []uint8(nil)}}},
+			Credentials: map[string]cloud.Credential{
+				"the-user": cloud.NewCredential(
+					cloud.UserPassAuthType,
+					map[string]string{"Username": "theuser", "Password": "thepassword"})},
+		})
+}
+
+func (s *k8sConfigSuite) TestGetMultiConfig(c *gc.C) {
+	tempFile := writeTempKubeConfig(c, multiConfig)
+	defer tempFile.Close()
+	defer os.Remove(tempFile.Name())
+
+	cfg, err := s.reader.GetClientConfig()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(cfg, jc.DeepEquals,
+		&caascfg.ClientConfig{
+
+			Type: "kubernetes",
+			Contexts: map[string]caascfg.Context{
+				"default-context": caascfg.Context{
+					CloudName:      "default-cluster",
+					CredentialName: "default-user"},
+				"the-context": caascfg.Context{
+					CloudName:      "the-cluster",
+					CredentialName: "the-user"},
+			},
+			CurrentContext: "default-context",
+			Clouds: map[string]caascfg.CloudConfig{
+				"default-cluster": caascfg.CloudConfig{
+					Endpoint:   "https://10.10.10.10:1010",
+					Attributes: map[string]interface{}{"CAData": []uint8(nil)}},
+				"the-cluster": caascfg.CloudConfig{
+					Endpoint:   "https://1.1.1.1:8888",
+					Attributes: map[string]interface{}{"CAData": []uint8(nil)}}},
+			Credentials: map[string]cloud.Credential{
+				"default-user": cloud.NewCredential(
+					cloud.UserPassAuthType,
+					map[string]string{"Username": "defaultuser", "Password": "defaultpassword"}),
+				"the-user": cloud.NewCredential(
+					cloud.CertificateAuthType,
+					map[string]string{"ClientCertificateData": "A", "ClientKeyData": "B"}),
+				"third-user": cloud.NewCredential(
+					cloud.OAuth2AuthType,
+					map[string]string{"Token": "atoken"}),
+				"fourth-user": cloud.NewCredential(
+					cloud.OAuth2WithCertAuthType,
+					map[string]string{"ClientCertificateData": "A", "ClientKeyData": "B", "Token": "tokenwithcerttoken"}),
+				"fifth-user": cloud.NewCredential(
+					cloud.UserPassWithCertAuthType,
+					map[string]string{"ClientCertificateData": "A", "ClientKeyData": "B", "Username": "fifth-user", "Password": "userpasscertpass"}),
+			},
+		})
+}

--- a/caas/clientconfig/package_test.go
+++ b/caas/clientconfig/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package caas_test
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func Test(t *testing.T) {
+	gc.TestingT(t)
+}

--- a/caas/clientconfig/types.go
+++ b/caas/clientconfig/types.go
@@ -1,0 +1,45 @@
+package caas
+
+import (
+	"github.com/juju/errors"
+
+	"github.com/juju/juju/cloud"
+)
+
+type ClientConfig struct {
+	Type           string
+	Contexts       map[string]Context
+	CurrentContext string
+	Clouds         map[string]CloudConfig
+	Credentials    map[string]cloud.Credential
+}
+
+type Context struct {
+	CloudName      string
+	CredentialName string
+}
+
+type CloudConfig struct {
+	Endpoint   string
+	Attributes map[string]interface{}
+}
+
+// If existing CAAS cloud has Cluster_A and User_A, here's what happens when we try to define a new CAAS cloud:
+
+// Cluster_B, User_B: New Cloud & new Credential for that cloud
+// Cluster B, User A: New Cloud & New Credential for that cloud (duplicate is necessary)
+// Cluster_A, User_A: error. already exists.
+// Cluster_A, User_B: No new Cloud, new Credential for the cloud.
+
+type ClientConfigReader interface {
+	GetClientConfig() (*ClientConfig, error)
+}
+
+func NewClientConfigReader(cloudType string) (ClientConfigReader, error) {
+	switch cloudType {
+	case "kubernetes":
+		return &K8SClientConfigReader{}, nil
+	default:
+		return nil, errors.Errorf("Cannot read local config: unsupported cloud type '%s'", cloudType)
+	}
+}

--- a/caas/clientconfig/types.go
+++ b/caas/clientconfig/types.go
@@ -31,14 +31,12 @@ type CloudConfig struct {
 // Cluster_A, User_A: error. already exists.
 // Cluster_A, User_B: No new Cloud, new Credential for the cloud.
 
-type ClientConfigReader interface {
-	GetClientConfig() (*ClientConfig, error)
-}
+type ClientConfigFunc func() (*ClientConfig, error)
 
-func NewClientConfigReader(cloudType string) (ClientConfigReader, error) {
+func NewClientConfigReader(cloudType string) (ClientConfigFunc, error) {
 	switch cloudType {
 	case "kubernetes":
-		return &K8SClientConfigReader{}, nil
+		return K8SClientConfig, nil
 	default:
 		return nil, errors.Errorf("Cannot read local config: unsupported cloud type '%s'", cloudType)
 	}

--- a/caas/clientconfig/types.go
+++ b/caas/clientconfig/types.go
@@ -31,8 +31,10 @@ type CloudConfig struct {
 // Cluster_A, User_A: error. already exists.
 // Cluster_A, User_B: No new Cloud, new Credential for the cloud.
 
+// ClientConfigFunc is a function that returns a ClientConfig. Functions of this type should be available for each supported CAAS framework, e.g. Kubernetes.
 type ClientConfigFunc func() (*ClientConfig, error)
 
+// NewClientConfigReader returns a function of type ClientConfigFunc to read the client config for a given cloud type.
 func NewClientConfigReader(cloudType string) (ClientConfigFunc, error) {
 	switch cloudType {
 	case "kubernetes":

--- a/caas/clientconfig/types.go
+++ b/caas/clientconfig/types.go
@@ -6,6 +6,10 @@ import (
 	"github.com/juju/juju/cloud"
 )
 
+// ClientConfig - a set of cloud endpoint info and user credentials
+// Clouds and user Credentials are joined by
+// Contexts. There should always be a valid Context with same name as
+// the CurrentContext string.
 type ClientConfig struct {
 	Type           string
 	Contexts       map[string]Context
@@ -14,11 +18,13 @@ type ClientConfig struct {
 	Credentials    map[string]cloud.Credential
 }
 
+// Context joins Clouds and Credentials.
 type Context struct {
 	CloudName      string
 	CredentialName string
 }
 
+// CloudConfig stores information about how to connect to a Cloud.
 type CloudConfig struct {
 	Endpoint   string
 	Attributes map[string]interface{}

--- a/cloud/clouds.go
+++ b/cloud/clouds.go
@@ -39,11 +39,17 @@ const (
 	// UserPassAuthType is an authentication type using a username and password.
 	UserPassAuthType AuthType = "userpass"
 
+	// UserPassAuthType is an authentication type using a username and password and a client certificate
+	UserPassWithCertAuthType AuthType = "userpasswithcert"
+
 	// OAuth1AuthType is an authentication type using oauth1.
 	OAuth1AuthType AuthType = "oauth1"
 
 	// OAuth2AuthType is an authentication type using oauth2.
 	OAuth2AuthType AuthType = "oauth2"
+
+	// OAuth2WithCertAuthType is an authentication type using oauth2 and a client certificate
+	OAuth2WithCertAuthType AuthType = "oauth2withcert"
 
 	// JSONFileAuthType is an authentication type that takes a path to
 	// a JSON file.

--- a/cmd/juju/caas/add.go
+++ b/cmd/juju/caas/add.go
@@ -63,7 +63,7 @@ type AddCAASCommand struct {
 	cloudMetadataStore    CloudMetadataStore
 	apiRoot               api.Connection
 	newCloudAPI           func(base.APICallCloser) AddCloudAPI
-	newClientConfigReader func(string) (caascfg.ClientConfigReader, error)
+	newClientConfigReader func(string) (caascfg.ClientConfigFunc, error)
 }
 
 // NewAddCAASCommand returns a command to add caas information.
@@ -73,12 +73,12 @@ func NewAddCAASCommand(cloudMetadataStore CloudMetadataStore) *AddCAASCommand {
 		newCloudAPI: func(caller base.APICallCloser) AddCloudAPI {
 			return cloudapi.NewClient(caller)
 		},
-		newClientConfigReader: func(caasType string) (caascfg.ClientConfigReader, error) {
+		newClientConfigReader: func(caasType string) (caascfg.ClientConfigFunc, error) {
 			return caascfg.NewClientConfigReader(caasType)
 		},
 	}
 }
-func NewAddCAASCommandForTest(cloudMetadataStore CloudMetadataStore, apiRoot api.Connection, newCloudAPIFunc func(base.APICallCloser) AddCloudAPI, newClientConfigReaderFunc func(string) (caascfg.ClientConfigReader, error)) *AddCAASCommand {
+func NewAddCAASCommandForTest(cloudMetadataStore CloudMetadataStore, apiRoot api.Connection, newCloudAPIFunc func(base.APICallCloser) AddCloudAPI, newClientConfigReaderFunc func(string) (caascfg.ClientConfigFunc, error)) *AddCAASCommand {
 	return &AddCAASCommand{
 		cloudMetadataStore:    cloudMetadataStore,
 		apiRoot:               apiRoot,
@@ -134,12 +134,12 @@ func (c *AddCAASCommand) Run(ctxt *cmd.Context) error {
 		return errors.Trace(err)
 	}
 
-	reader, err := c.newClientConfigReader(c.caasType)
+	clientConfigFunc, err := c.newClientConfigReader(c.caasType)
 	if err != nil {
 		return errors.Trace(err)
 	}
 
-	caasConfig, err := reader.GetClientConfig()
+	caasConfig, err := clientConfigFunc()
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/cmd/juju/caas/add.go
+++ b/cmd/juju/caas/add.go
@@ -104,16 +104,15 @@ func (c *AddCAASCommand) SetFlags(f *gnuflag.FlagSet) {
 
 // Init populates the command with the args from the command line.
 func (c *AddCAASCommand) Init(args []string) (err error) {
-	if len(args) > 0 {
-		c.caasType = args[0]
+	if len(args) == 0 {
+		return errors.Errorf("missing CAAS type and CAAS name.")
 	}
-	if len(args) > 1 {
-		c.caasName = args[1]
+	if len(args) == 1 {
+		return errors.Errorf("missing CAAS name.")
 	}
-	if len(args) > 2 {
-		return cmd.CheckEmpty(args[2:])
-	}
-	return nil
+	c.caasType = args[0]
+	c.caasName = args[1]
+	return cmd.CheckEmpty(args[2:])
 }
 
 func (c *AddCAASCommand) newAPIRoot() (api.Connection, error) {

--- a/cmd/juju/caas/add.go
+++ b/cmd/juju/caas/add.go
@@ -9,14 +9,19 @@ import (
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
 	"github.com/juju/gnuflag"
+	"github.com/juju/loggo"
 
+	"github.com/juju/juju/api"
 	"github.com/juju/juju/api/base"
 	cloudapi "github.com/juju/juju/api/cloud"
+	caascfg "github.com/juju/juju/caas/clientconfig"
 	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/cmd/juju/common"
 	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/jujuclient"
 )
+
+var logger = loggo.GetLogger("juju.cmd.juju.caas")
 
 type CloudMetadataStore interface {
 	ParseCloudMetadataFile(path string) (map[string]cloud.Cloud, error)
@@ -46,18 +51,19 @@ See also:
 type AddCAASCommand struct {
 	modelcmd.ModelCommandBase
 
-	// CAASName is the name of the caas to add.
-	CAASName string
+	// caasName is the name of the caas to add.
+	caasName string
 
 	// CAASType is the type of CAAS being added
-	CAASType string
+	caasType string
 
 	// Context is the name of the context (k8s) or credential to import
-	Context string
+	context string
 
-	clientStore        jujuclient.ClientStore
-	cloudMetadataStore CloudMetadataStore
-	newCloudAPI        func(base.APICallCloser) AddCloudAPI
+	cloudMetadataStore    CloudMetadataStore
+	apiRoot               api.Connection
+	newCloudAPI           func(base.APICallCloser) AddCloudAPI
+	newClientConfigReader func(string) (caascfg.ClientConfigReader, error)
 }
 
 // NewAddCAASCommand returns a command to add caas information.
@@ -67,6 +73,17 @@ func NewAddCAASCommand(cloudMetadataStore CloudMetadataStore) *AddCAASCommand {
 		newCloudAPI: func(caller base.APICallCloser) AddCloudAPI {
 			return cloudapi.NewClient(caller)
 		},
+		newClientConfigReader: func(caasType string) (caascfg.ClientConfigReader, error) {
+			return caascfg.NewClientConfigReader(caasType)
+		},
+	}
+}
+func NewAddCAASCommandForTest(cloudMetadataStore CloudMetadataStore, apiRoot api.Connection, newCloudAPIFunc func(base.APICallCloser) AddCloudAPI, newClientConfigReaderFunc func(string) (caascfg.ClientConfigReader, error)) *AddCAASCommand {
+	return &AddCAASCommand{
+		cloudMetadataStore:    cloudMetadataStore,
+		apiRoot:               apiRoot,
+		newCloudAPI:           newCloudAPIFunc,
+		newClientConfigReader: newClientConfigReaderFunc,
 	}
 }
 
@@ -88,10 +105,10 @@ func (c *AddCAASCommand) SetFlags(f *gnuflag.FlagSet) {
 // Init populates the command with the args from the command line.
 func (c *AddCAASCommand) Init(args []string) (err error) {
 	if len(args) > 0 {
-		c.CAASType = args[0]
+		c.caasType = args[0]
 	}
 	if len(args) > 1 {
-		c.CAASName = args[1]
+		c.caasName = args[1]
 	}
 	if len(args) > 2 {
 		return cmd.CheckEmpty(args[2:])
@@ -99,19 +116,48 @@ func (c *AddCAASCommand) Init(args []string) (err error) {
 	return nil
 }
 
-// Run executes the add caas command, adding a caas based on a passed-in yaml
-// file or interactive queries.
+func (c *AddCAASCommand) newAPIRoot() (api.Connection, error) {
+	if c.apiRoot != nil {
+		return c.apiRoot, nil
+	}
+	return c.NewControllerAPIRoot()
+}
+
 func (c *AddCAASCommand) Run(ctxt *cmd.Context) error {
-	api, err := c.NewControllerAPIRoot()
+	api, err := c.newAPIRoot()
 	if err != nil {
 		return errors.Trace(err)
 	}
 	defer api.Close()
 
+	if err := c.verifyName(c.caasName); err != nil {
+		return errors.Trace(err)
+	}
+
+	reader, err := c.newClientConfigReader(c.caasType)
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	caasConfig, err := reader.GetClientConfig()
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	if len(caasConfig.Contexts) == 0 {
+		return errors.Errorf("No CAAS cluster definitions found in config")
+	}
+	defaultContext := caasConfig.Contexts[caasConfig.CurrentContext]
+
+	defaultCredential := caasConfig.Credentials[defaultContext.CredentialName]
+	defaultCloud := caasConfig.Clouds[defaultContext.CloudName]
+
 	newCloud := cloud.Cloud{
-		Name:      c.CAASName,
-		Type:      c.CAASType,
-		AuthTypes: []cloud.AuthType{cloud.UserPassAuthType},
+		Name:     c.caasName,
+		Type:     c.caasType,
+		Endpoint: defaultCloud.Endpoint,
+
+		AuthTypes: []cloud.AuthType{defaultCredential.AuthType()},
 	}
 
 	if err := addCloudToLocal(c.cloudMetadataStore, newCloud); err != nil {
@@ -119,9 +165,15 @@ func (c *AddCAASCommand) Run(ctxt *cmd.Context) error {
 	}
 
 	cloudClient := c.newCloudAPI(api)
+
 	if err := addCloudToController(cloudClient, newCloud); err != nil {
 		return errors.Trace(err)
 	}
+
+	if err := addCredentialToLocal(c.caasName, defaultCredential, defaultContext.CredentialName); err != nil {
+		return errors.Trace(err)
+	}
+
 	return nil
 }
 
@@ -170,6 +222,19 @@ func addCloudToLocal(cloudMetadataStore CloudMetadataStore, newCloud cloud.Cloud
 
 func addCloudToController(apiClient AddCloudAPI, newCloud cloud.Cloud) error {
 	err := apiClient.AddCloud(newCloud)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	return nil
+}
+
+func addCredentialToLocal(cloudName string, newCredential cloud.Credential, credentialName string) error {
+	store := jujuclient.NewFileCredentialStore()
+	newCredentials := &cloud.CloudCredential{
+		AuthCredentials: make(map[string]cloud.Credential),
+	}
+	newCredentials.AuthCredentials[credentialName] = newCredential
+	err := store.UpdateCredential(cloudName, *newCredentials)
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/cmd/juju/caas/add_test.go
+++ b/cmd/juju/caas/add_test.go
@@ -8,6 +8,8 @@ import (
 	"github.com/juju/cmd/cmdtesting"
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
+	jujutesting "github.com/juju/testing"
+	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/api"
@@ -15,8 +17,6 @@ import (
 	caascfg "github.com/juju/juju/caas/clientconfig"
 	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/cmd/juju/caas"
-	jujutesting "github.com/juju/testing"
-	gc "gopkg.in/check.v1"
 )
 
 type addCAASSuite struct {
@@ -137,4 +137,16 @@ func (s *addCAASSuite) TestAddNameClash(c *gc.C) {
 	cmd := s.makeCommand(c, true)
 	_, err := s.runCommand(c, cmd, "kubernetes", "mrcloud")
 	c.Assert(err, gc.ErrorMatches, `"mrcloud" is the name of a public cloud`)
+}
+
+func (s *addCAASSuite) TestMissingName(c *gc.C) {
+	cmd := s.makeCommand(c, true)
+	_, err := s.runCommand(c, cmd, "kubernetes")
+	c.Assert(err, gc.ErrorMatches, `missing CAAS name.`)
+}
+
+func (s *addCAASSuite) TestMissingArgs(c *gc.C) {
+	cmd := s.makeCommand(c, true)
+	_, err := s.runCommand(c, cmd)
+	c.Assert(err, gc.ErrorMatches, `missing CAAS type and CAAS name.`)
 }

--- a/cmd/juju/caas/add_test.go
+++ b/cmd/juju/caas/add_test.go
@@ -1,0 +1,145 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package caas_test
+
+import (
+	"github.com/juju/cmd"
+	"github.com/juju/cmd/cmdtesting"
+	"github.com/juju/errors"
+	"github.com/juju/loggo"
+	"gopkg.in/juju/names.v2"
+
+	"github.com/juju/juju/api"
+	"github.com/juju/juju/api/base"
+	caascfg "github.com/juju/juju/caas/clientconfig"
+	"github.com/juju/juju/cloud"
+	"github.com/juju/juju/cmd/juju/caas"
+	jujutesting "github.com/juju/testing"
+	gc "gopkg.in/check.v1"
+)
+
+type addCAASSuite struct {
+	jujutesting.IsolationSuite
+	fakeCloudAPI    *fakeCloudAPI
+	store           *fakeCloudMetadataStore
+	k8sConfigReader *fakeK8SClientConfigReader
+}
+
+var _ = gc.Suite(&addCAASSuite{})
+
+type fakeAPIConnection struct {
+	api.Connection
+}
+
+func (*fakeAPIConnection) Close() error {
+	return nil
+}
+
+type fakeCloudMetadataStore struct {
+	*jujutesting.CallMocker
+}
+
+func (f *fakeCloudMetadataStore) ParseCloudMetadataFile(path string) (map[string]cloud.Cloud, error) {
+	results := f.MethodCall(f, "ParseCloudMetadataFile", path)
+	return results[0].(map[string]cloud.Cloud), jujutesting.TypeAssertError(results[1])
+}
+
+func (f *fakeCloudMetadataStore) ParseOneCloud(data []byte) (cloud.Cloud, error) {
+	results := f.MethodCall(f, "ParseOneCloud", data)
+	return results[0].(cloud.Cloud), jujutesting.TypeAssertError(results[1])
+}
+
+func (f *fakeCloudMetadataStore) PublicCloudMetadata(searchPaths ...string) (result map[string]cloud.Cloud, fallbackUsed bool, _ error) {
+	results := f.MethodCall(f, "PublicCloudMetadata", searchPaths)
+	return results[0].(map[string]cloud.Cloud), results[1].(bool), jujutesting.TypeAssertError(results[2])
+}
+
+func (f *fakeCloudMetadataStore) PersonalCloudMetadata() (map[string]cloud.Cloud, error) {
+	results := f.MethodCall(f, "PersonalCloudMetadata")
+	return results[0].(map[string]cloud.Cloud), jujutesting.TypeAssertError(results[1])
+}
+
+func (f *fakeCloudMetadataStore) WritePersonalCloudMetadata(cloudsMap map[string]cloud.Cloud) error {
+	results := f.MethodCall(f, "WritePersonalCloudMetadata", cloudsMap)
+	return jujutesting.TypeAssertError(results[0])
+}
+
+type fakeCloudAPI struct {
+	caas.AddCloudAPI
+	jujutesting.Stub
+	authTypes   []cloud.AuthType
+	credentials []names.CloudCredentialTag
+}
+
+type fakeK8SClientConfigReader struct {
+	*jujutesting.Stub
+}
+
+func (f *fakeK8SClientConfigReader) GetClientConfig() (*caascfg.ClientConfig, error) {
+	return &caascfg.ClientConfig{}, nil
+}
+
+func (s *addCAASSuite) SetUpTest(c *gc.C) {
+	s.IsolationSuite.SetUpTest(c)
+	s.fakeCloudAPI = &fakeCloudAPI{
+		authTypes: []cloud.AuthType{
+			cloud.EmptyAuthType,
+			cloud.AccessKeyAuthType,
+		},
+		credentials: []names.CloudCredentialTag{
+			names.NewCloudCredentialTag("cloud/admin/default"),
+			names.NewCloudCredentialTag("aws/other/secrets"),
+		},
+	}
+	var logger loggo.Logger
+	s.store = &fakeCloudMetadataStore{CallMocker: jujutesting.NewCallMocker(logger)}
+	s.store.Call("PublicCloudMetadata", []string(nil)).Returns(map[string]cloud.Cloud{
+		"mrcloud": cloud.Cloud{
+			Name: "mrcloud",
+			Type: "kubernetes"},
+	}, false, nil)
+	s.k8sConfigReader = &fakeK8SClientConfigReader{}
+}
+
+func (s *addCAASSuite) makeCommand(c *gc.C) *caas.AddCAASCommand {
+	return caas.NewAddCAASCommandForTest(s.store, &fakeAPIConnection{},
+		func(caller base.APICallCloser) caas.AddCloudAPI {
+			return s.fakeCloudAPI
+		},
+		func(caasType string) (caascfg.ClientConfigReader, error) {
+			if s.k8sConfigReader == nil {
+				return nil, errors.Errorf("unsupported cloud type '%s'", caasType)
+			}
+			return s.k8sConfigReader, nil
+		},
+	)
+}
+
+func (s *addCAASSuite) runCommand(c *gc.C, cmd *caas.AddCAASCommand, args ...string) (*cmd.Context, error) {
+	return cmdtesting.RunCommand(c, cmd, args...)
+}
+
+func (s *addCAASSuite) TestAddExtraArg(c *gc.C) {
+	cmd := s.makeCommand(c)
+	_, err := s.runCommand(c, cmd, "kubernetes", "caasname", "extra")
+	c.Assert(err, gc.ErrorMatches, `unrecognized args: \["extra"\]`)
+}
+
+func (s *addCAASSuite) TestAddKnownTypeNoData(c *gc.C) {
+	cmd := s.makeCommand(c)
+	_, err := s.runCommand(c, cmd, "kubernetes", "caasname")
+	c.Assert(err, gc.ErrorMatches, `No CAAS cluster definitions found in config`)
+}
+func (s *addCAASSuite) TestAddUnknownType(c *gc.C) {
+	s.k8sConfigReader = nil
+	cmd := s.makeCommand(c)
+	_, err := s.runCommand(c, cmd, "ducttape", "caasname")
+	c.Assert(err, gc.ErrorMatches, `unsupported cloud type 'ducttape'`)
+}
+
+func (s *addCAASSuite) TestAddNameClash(c *gc.C) {
+	cmd := s.makeCommand(c)
+	_, err := s.runCommand(c, cmd, "kubernetes", "mrcloud")
+	c.Assert(err, gc.ErrorMatches, `"mrcloud" is the name of a public cloud`)
+}

--- a/cmd/juju/caas/package_test.go
+++ b/cmd/juju/caas/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package caas_test
+
+import (
+	stdtesting "testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func TestPackage(t *stdtesting.T) {
+	gc.TestingT(t)
+}

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -107,3 +107,4 @@ gopkg.in/natefinch/npipe.v2	git	c1b8fa8bdccecb0b8db834ee0b92fdbcfa606dd6	2016-06
 gopkg.in/retry.v1	git	01631078ef2fdce601e38cfe5f527fab24c9a6d2	2017-05-31T09:12:38Z
 gopkg.in/tomb.v1	git	dd632973f1e7218eb1089048e0798ec9ae7dceb8	2014-10-24T13:56:13Z
 gopkg.in/yaml.v2	git	1be3d31502d6eabc0dd7ce5b0daab022e14a5538	2017-07-12T05:45:46Z
+k8s.io/client-go	git	e121606b0d09b2e1c467183ee46217fa85a6b672	2017-02-13T17:46:50Z


### PR DESCRIPTION
Still behind the 'caas' feature flag.

Add support for reading kubeconfig files, either at `~/.kube/config` or `$KUBECONFIG`.
Stores a Cloud for the cluster referred to by the current context in the config file, both locally and on the current controller. Stores a Credential for the user referred to by the current context, but only stores it locally. Saving to the controller will be in a future branch, after adding API for adding new credentials to an existing controller that do not match the controller's host cloud.

Currently supports the three auth types that are [documented](https://kubernetes.io/docs/tasks/access-application-cluster/authenticate-across-clusters-kubeconfig) as
being supported by kubeconfig files:
1. user/pass
2. token
3. cert/key (can be combined with 1 & 2)

Token is an oauth2 token.
Adds types to cloud.AuthType for userpass-with-cert and oauth2-token-with-cert.

Also includes changes to earlier add-cloud work for testing.

Signed-off-by: Michael McCracken <mike.mccracken@canonical.com>
