### PR TITLE
Add offer info to status

### DIFF
--- a/apiserver/facades/client/client/backend.go
+++ b/apiserver/facades/client/client/backend.go
@@ -9,6 +9,7 @@ import (
 	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/constraints"
+	"github.com/juju/juju/core/crossmodel"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/network"
@@ -40,6 +41,8 @@ type Backend interface {
 	AddOneMachine(state.MachineTemplate) (*state.Machine, error)
 	AddRelation(...state.Endpoint) (*state.Relation, error)
 	AllApplications() ([]*state.Application, error)
+	AllApplicationOffers() ([]*crossmodel.ApplicationOffer, error)
+	AllOfferConnections() ([]*state.OfferConnection, error)
 	AllRemoteApplications() ([]*state.RemoteApplication, error)
 	AllMachines() ([]*state.Machine, error)
 	AllIPAddresses() ([]*state.Address, error)
@@ -66,6 +69,7 @@ type Backend interface {
 	ModelConstraints() (constraints.Value, error)
 	ModelTag() names.ModelTag
 	ModelUUID() string
+	RemoteApplication(string) (*state.RemoteApplication, error)
 	RemoveUserAccess(names.UserTag, names.Tag) error
 	SetAnnotations(state.GlobalEntity, map[string]string) error
 	SetModelAgentVersion(version.Number) error
@@ -90,4 +94,9 @@ func (s stateShim) Unit(name string) (Unit, error) {
 		return nil, err
 	}
 	return u, nil
+}
+
+func (s stateShim) AllApplicationOffers() ([]*crossmodel.ApplicationOffer, error) {
+	offers := state.NewApplicationOffers(s.State)
+	return offers.AllApplicationOffers()
 }

--- a/apiserver/facades/client/client/client.go
+++ b/apiserver/facades/client/client/client.go
@@ -99,6 +99,22 @@ func (c *Client) checkCanWrite() error {
 	return nil
 }
 
+func (c *Client) checkIsAdmin() error {
+	isAdmin, err := c.api.auth.HasPermission(permission.SuperuserAccess, c.api.stateAccessor.ControllerTag())
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	isModelAdmin, err := c.api.auth.HasPermission(permission.AdminAccess, c.api.stateAccessor.ModelTag())
+	if err != nil {
+		return errors.Trace(err)
+	}
+	if !isModelAdmin && !isAdmin {
+		return common.ErrPerm
+	}
+	return nil
+}
+
 // NewFacade provides the required signature for facade registration.
 func NewFacade(st *state.State, resources facade.Resources, authorizer facade.Authorizer) (*Client, error) {
 	urlGetter := common.NewToolsURLGetter(st.ModelUUID(), st)

--- a/apiserver/facades/client/client/status.go
+++ b/apiserver/facades/client/client/status.go
@@ -603,7 +603,8 @@ func fetchOfferConnections(st Backend) (map[int]*state.OfferConnection, error) {
 	return connMap, nil
 }
 
-// fetchRelations returns a map of all relations keyed by application name.
+// fetchRelations returns a map of all relations keyed by application name,
+// and another map keyed by id..
 //
 // This structure is useful for processApplicationRelations() which needs
 // to have the relations for each application. Reading them once here

--- a/apiserver/facades/client/client/status.go
+++ b/apiserver/facades/client/client/status.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/core/crossmodel"
 	"github.com/juju/juju/feature"
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/state"
@@ -177,9 +178,20 @@ func (c *Client) FullStatus(args params.StatusParams) (params.FullStatus, error)
 		return noStatus, errors.Annotate(err, "could not fetch applications and units")
 	}
 	if featureflag.Enabled(feature.CrossModelRelations) {
-		if context.remoteApplications, err =
-			fetchRemoteApplications(c.api.stateAccessor); err != nil {
+		if context.consumerRemoteApplications, err =
+			fetchConsumerRemoteApplications(c.api.stateAccessor); err != nil {
 			return noStatus, errors.Annotate(err, "could not fetch remote applications")
+		}
+		// Only admins can see offer details.
+		if err := c.checkIsAdmin(); err == nil {
+			if context.offerConnections, err =
+				fetchOfferConnections(c.api.stateAccessor); err != nil {
+				return noStatus, errors.Annotate(err, "could not fetch offer connections")
+			}
+			if context.offers, err =
+				fetchOffers(c.api.stateAccessor); err != nil {
+				return noStatus, errors.Annotate(err, "could not fetch application offers")
+			}
 		}
 	}
 	if context.machines, err = fetchMachines(c.api.stateAccessor, nil); err != nil {
@@ -190,7 +202,7 @@ func (c *Client) FullStatus(args params.StatusParams) (params.FullStatus, error)
 		fetchNetworkInterfaces(c.api.stateAccessor); err != nil {
 		return noStatus, errors.Annotate(err, "could not fetch IP addresses and link layer devices")
 	}
-	if context.relations, err = fetchRelations(c.api.stateAccessor); err != nil {
+	if context.relations, context.relationsById, err = fetchRelations(c.api.stateAccessor); err != nil {
 		return noStatus, errors.Annotate(err, "could not fetch relations")
 	}
 	if len(context.applications) > 0 {
@@ -200,7 +212,9 @@ func (c *Client) FullStatus(args params.StatusParams) (params.FullStatus, error)
 	}
 
 	logger.Debugf("Applications: %v", context.applications)
-	logger.Debugf("Remote applications: %v", context.remoteApplications)
+	logger.Debugf("Remote applications: %v", context.consumerRemoteApplications)
+	logger.Debugf("Offers: %v", context.offers)
+	logger.Debugf("Offer connections: %v", context.offerConnections)
 
 	if len(args.Patterns) > 0 {
 		predicate := BuildPredicateFor(args.Patterns)
@@ -304,6 +318,7 @@ func (c *Client) FullStatus(args params.StatusParams) (params.FullStatus, error)
 		),
 		Applications:       context.processApplications(),
 		RemoteApplications: context.processRemoteApplications(),
+		Offers:             context.processOffers(),
 		Relations:          context.processRelations(),
 	}, nil
 }
@@ -374,11 +389,19 @@ type statusContext struct {
 	applications map[string]*state.Application
 
 	// remote applications: application name -> application
-	remoteApplications map[string]*state.RemoteApplication
-	relations          map[string][]*state.Relation
-	units              map[string]map[string]*state.Unit
-	latestCharms       map[charm.URL]*state.Charm
-	leaders            map[string]string
+	consumerRemoteApplications map[string]*state.RemoteApplication
+
+	// offers: offer name -> offer
+	offers map[string]offerStatus
+
+	// offerConnections: relationId -> offer connection
+	offerConnections map[int]*state.OfferConnection
+
+	relations     map[string][]*state.Relation
+	relationsById map[int]*state.Relation
+	units         map[string]map[string]*state.Unit
+	latestCharms  map[charm.URL]*state.Charm
+	leaders       map[string]string
 }
 
 // fetchMachines returns a map from top level machine id to machines, where machines[0] is the host
@@ -527,8 +550,8 @@ func fetchAllApplicationsAndUnits(
 	return appMap, unitMap, latestCharms, nil
 }
 
-// fetchRemoteApplications returns a map from application name to remote application.
-func fetchRemoteApplications(st Backend) (map[string]*state.RemoteApplication, error) {
+// fetchConsumerRemoteApplications returns a map from application name to remote application.
+func fetchConsumerRemoteApplications(st Backend) (map[string]*state.RemoteApplication, error) {
 	appMap := make(map[string]*state.RemoteApplication)
 	applications, err := st.AllRemoteApplications()
 	if err != nil {
@@ -543,24 +566,79 @@ func fetchRemoteApplications(st Backend) (map[string]*state.RemoteApplication, e
 	return appMap, nil
 }
 
+// fetchOfferConnections returns a map from relation id to offer connection.
+func fetchOffers(st Backend) (map[string]offerStatus, error) {
+	offersMap := make(map[string]offerStatus)
+	offers, err := st.AllApplicationOffers()
+	if err != nil {
+		return nil, err
+	}
+	model, err := st.Model()
+	if err != nil {
+		return nil, err
+	}
+	for _, offer := range offers {
+		offersMap[offer.OfferName] = offerStatus{
+			ApplicationOffer: crossmodel.ApplicationOffer{
+				OfferName:       offer.OfferName,
+				ApplicationName: offer.ApplicationName,
+				Endpoints:       offer.Endpoints,
+			},
+			ApplicationURL: crossmodel.MakeURL(model.Owner().Name(), model.Name(), offer.OfferName, ""),
+		}
+	}
+	return offersMap, nil
+}
+
+// fetchOfferConnections returns a map from relation id to offer connection.
+func fetchOfferConnections(st Backend) (map[int]*state.OfferConnection, error) {
+	connMap := make(map[int]*state.OfferConnection)
+	conns, err := st.AllOfferConnections()
+	if err != nil {
+		return nil, err
+	}
+	for _, c := range conns {
+		connMap[c.RelationId()] = c
+	}
+	return connMap, nil
+}
+
 // fetchRelations returns a map of all relations keyed by application name.
 //
 // This structure is useful for processApplicationRelations() which needs
 // to have the relations for each application. Reading them once here
 // avoids the repeated DB hits to retrieve the relations for each
 // application that used to happen in processApplicationRelations().
-func fetchRelations(st Backend) (map[string][]*state.Relation, error) {
+func fetchRelations(st Backend) (map[string][]*state.Relation, map[int]*state.Relation, error) {
 	relations, err := st.AllRelations()
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	out := make(map[string][]*state.Relation)
+	outById := make(map[int]*state.Relation)
 	for _, relation := range relations {
+		outById[relation.Id()] = relation
+		// If either end of the relation is a remote application
+		// on the offering side, exclude it here.
+		isRemote := false
+		for _, ep := range relation.Endpoints() {
+			if app, err := st.RemoteApplication(ep.ApplicationName); err == nil {
+				if app.IsConsumerProxy() {
+					isRemote = true
+					break
+				}
+			} else if !errors.IsNotFound(err) {
+				return nil, nil, err
+			}
+		}
+		if isRemote {
+			continue
+		}
 		for _, ep := range relation.Endpoints() {
 			out[ep.ApplicationName] = append(out[ep.ApplicationName], relation)
 		}
 	}
-	return out, nil
+	return out, outById, nil
 }
 
 func processMachines(
@@ -865,15 +943,15 @@ func (context *statusContext) processApplication(application *state.Application)
 
 func (context *statusContext) processRemoteApplications() map[string]params.RemoteApplicationStatus {
 	applicationsMap := make(map[string]params.RemoteApplicationStatus)
-	for _, s := range context.remoteApplications {
-		applicationsMap[s.Name()] = context.processRemoteApplication(s)
+	for _, app := range context.consumerRemoteApplications {
+		applicationsMap[app.Name()] = context.processRemoteApplication(app)
 	}
 	return applicationsMap
 }
 
 func (context *statusContext) processRemoteApplication(application *state.RemoteApplication) (status params.RemoteApplicationStatus) {
 	status.ApplicationURL, _ = application.URL()
-	status.ApplicationName = application.Name()
+	status.OfferName = application.Name()
 	eps, err := application.Endpoints()
 	if err != nil {
 		status.Err = err
@@ -897,6 +975,67 @@ func (context *statusContext) processRemoteApplication(application *state.Remote
 	}
 	applicationStatus, err := application.Status()
 	populateStatusFromStatusInfoAndErr(&status.Status, applicationStatus, err)
+	return status
+}
+
+type offerStatus struct {
+	crossmodel.ApplicationOffer
+	ApplicationURL string
+}
+
+func (context *statusContext) processOffers() map[string]params.ApplicationOfferStatus {
+	offers := make(map[string]params.ApplicationOfferStatus)
+	for name, offer := range context.offers {
+		offerStatus := params.ApplicationOfferStatus{
+			ApplicationName: offer.ApplicationName,
+			OfferName:       offer.OfferName,
+			ApplicationURL:  offer.ApplicationURL,
+			Endpoints:       make(map[string]params.RemoteEndpoint),
+			Connections:     make(map[int]params.OfferConnectionStatus),
+		}
+		for name, ep := range offer.Endpoints {
+			offerStatus.Endpoints[name] = params.RemoteEndpoint{
+				Name:      ep.Name,
+				Interface: ep.Interface,
+				Role:      ep.Role,
+				Limit:     ep.Limit,
+			}
+		}
+		offers[name] = offerStatus
+	}
+	for relId, conn := range context.offerConnections {
+		connStatus := context.processOfferConnection(conn)
+		offer, ok := offers[conn.OfferName()]
+		if !ok {
+			continue
+		}
+		offer.Connections[relId] = connStatus
+		offers[conn.OfferName()] = offer
+	}
+	return offers
+}
+
+func (context *statusContext) processOfferConnection(conn *state.OfferConnection) (status params.OfferConnectionStatus) {
+	status.SourceModelTag = names.NewModelTag(conn.SourceModelUUID()).String()
+	status.Username = conn.UserName()
+	rel, ok := context.relationsById[conn.RelationId()]
+	if !ok {
+		status.Err = errors.NotFoundf("relation id %d", conn.RelationId())
+		return
+	}
+	offer, ok := context.offers[conn.OfferName()]
+	if !ok {
+		status.Err = errors.NotFoundf("application offer %s", conn.OfferName())
+		return
+	}
+	ep, err := rel.Endpoint(offer.ApplicationName)
+	if err != nil {
+		status.Err = err
+		return
+	}
+	status.Endpoint = ep.Name
+	// TODO(wallyworld)
+	status.Status = "active"
 	return status
 }
 

--- a/apiserver/facades/client/client/status_test.go
+++ b/apiserver/facades/client/client/status_test.go
@@ -51,6 +51,7 @@ func (s *statusSuite) TestFullStatus(c *gc.C) {
 	c.Check(status.Model.SLA, gc.Equals, "essential")
 	c.Check(status.Applications, gc.HasLen, 0)
 	c.Check(status.RemoteApplications, gc.HasLen, 0)
+	c.Check(status.Offers, gc.HasLen, 0)
 	c.Check(status.Machines, gc.HasLen, 1)
 	resultMachine, ok := status.Machines[machine.Id()]
 	if !ok {

--- a/apiserver/facades/controller/crossmodelrelations/crossmodelrelations.go
+++ b/apiserver/facades/controller/crossmodelrelations/crossmodelrelations.go
@@ -265,9 +265,10 @@ func (api *CrossModelRelationsAPI) registerRemoteRelation(relation params.Regist
 		logger.Debugf("added relation %v to model %v", localRel.Tag().Id(), api.st.ModelUUID())
 	}
 	_, err = api.st.AddOfferConnection(state.AddOfferConnectionParams{
-		Username:   username,
-		OfferName:  relation.OfferName,
-		RelationId: localRel.Id(),
+		SourceModelUUID: sourceModelTag.Id(),
+		Username:        username,
+		OfferName:       relation.OfferName,
+		RelationId:      localRel.Id(),
 	})
 	if err != nil && !errors.IsAlreadyExists(err) {
 		return nil, errors.Annotate(err, "adding offer connection details")

--- a/apiserver/facades/controller/crossmodelrelations/crossmodelrelations_test.go
+++ b/apiserver/facades/controller/crossmodelrelations/crossmodelrelations_test.go
@@ -178,9 +178,10 @@ func (s *crossmodelRelationsSuite) assertRegisterRemoteRelations(c *gc.C) {
 	c.Assert(s.st.offerConnections, gc.HasLen, 1)
 	offerConnection := s.st.offerConnections[0]
 	c.Assert(offerConnection, jc.DeepEquals, &mockOfferConnection{
-		relationId: 0,
-		username:   "mary",
-		offerName:  "offered",
+		sourcemodelUUID: coretesting.ModelTag.Id(),
+		relationId:      0,
+		username:        "mary",
+		offerName:       "offered",
 	})
 }
 

--- a/apiserver/facades/controller/crossmodelrelations/mock_test.go
+++ b/apiserver/facades/controller/crossmodelrelations/mock_test.go
@@ -74,9 +74,10 @@ func (st *mockState) AddOfferConnection(arg state.AddOfferConnectionParams) (cro
 		return nil, errors.AlreadyExistsf("offer connection for relation %d", arg.RelationId)
 	}
 	oc := &mockOfferConnection{
-		relationId: arg.RelationId,
-		username:   arg.Username,
-		offerName:  arg.OfferName,
+		sourcemodelUUID: arg.SourceModelUUID,
+		relationId:      arg.RelationId,
+		username:        arg.Username,
+		offerName:       arg.OfferName,
 	}
 	st.offerConnections[arg.RelationId] = oc
 	return oc, nil
@@ -325,9 +326,10 @@ func (a *mockApplication) Life() state.Life {
 }
 
 type mockOfferConnection struct {
-	relationId int
-	username   string
-	offerName  string
+	sourcemodelUUID string
+	relationId      int
+	username        string
+	offerName       string
 }
 
 type mockRelationUnit struct {

--- a/apiserver/params/status.go
+++ b/apiserver/params/status.go
@@ -26,6 +26,7 @@ type FullStatus struct {
 	Machines           map[string]MachineStatus           `json:"machines"`
 	Applications       map[string]ApplicationStatus       `json:"applications"`
 	RemoteApplications map[string]RemoteApplicationStatus `json:"remote-applications"`
+	Offers             map[string]ApplicationOfferStatus  `json:"offers"`
 	Relations          []RelationStatus                   `json:"relations"`
 }
 
@@ -120,13 +121,32 @@ type ApplicationStatus struct {
 
 // RemoteApplicationStatus holds status info about a remote application.
 type RemoteApplicationStatus struct {
-	Err             error               `json:"err,omitempty"`
-	ApplicationURL  string              `json:"application-url"`
-	ApplicationName string              `json:"application-name"`
-	Endpoints       []RemoteEndpoint    `json:"endpoints"`
-	Life            string              `json:"life"`
-	Relations       map[string][]string `json:"relations"`
-	Status          DetailedStatus      `json:"status"`
+	Err            error               `json:"err,omitempty"`
+	ApplicationURL string              `json:"application-url"`
+	OfferName      string              `json:"offer-name"`
+	Endpoints      []RemoteEndpoint    `json:"endpoints"`
+	Life           string              `json:"life"`
+	Relations      map[string][]string `json:"relations"`
+	Status         DetailedStatus      `json:"status"`
+}
+
+// ApplicationOfferStatus holds status info about an application offer.
+type ApplicationOfferStatus struct {
+	Err             error                         `json:"err,omitempty"`
+	ApplicationURL  string                        `json:"application-url"`
+	OfferName       string                        `json:"offer-name"`
+	ApplicationName string                        `json:"application-name"`
+	Endpoints       map[string]RemoteEndpoint     `json:"endpoints"`
+	Connections     map[int]OfferConnectionStatus `json:"connections,omitempty"`
+}
+
+// OfferConnectionStatus holds status info about a connection to an offer.
+type OfferConnectionStatus struct {
+	Err            error  `json:"err,omitempty"`
+	SourceModelTag string `json:"source-model-tag"`
+	Username       string `json:"username"`
+	Endpoint       string `json:"endpoint"`
+	Status         string `json:"status"`
 }
 
 // MeterStatus represents the meter status of a unit.

--- a/cmd/juju/status/formatted.go
+++ b/cmd/juju/status/formatted.go
@@ -18,6 +18,7 @@ type formattedStatus struct {
 	Machines           map[string]machineStatus           `json:"machines"`
 	Applications       map[string]applicationStatus       `json:"applications"`
 	RemoteApplications map[string]remoteApplicationStatus `json:"application-endpoints,omitempty" yaml:"application-endpoints,omitempty"`
+	Offers             map[string]offerStatus             `json:"offers,omitempty" yaml:"offers,omitempty"`
 }
 
 type formattedMachineStatus struct {
@@ -119,6 +120,7 @@ func (s applicationStatus) MarshalYAML() (interface{}, error) {
 }
 
 type remoteEndpoint struct {
+	Name      string `json:"-" yaml:"-"`
 	Interface string `json:"interface" yaml:"interface"`
 	Role      string `json:"role" yaml:"role"`
 }
@@ -146,6 +148,39 @@ func (s remoteApplicationStatus) MarshalYAML() (interface{}, error) {
 		return errorStatus{s.Err.Error()}, nil
 	}
 	return remoteApplicationStatusNoMarshal(s), nil
+}
+
+type offerStatusNoMarshal offerStatus
+
+type offerStatus struct {
+	Err             error                     `json:"-" yaml:",omitempty"`
+	ApplicationURL  string                    `json:"application-url" yaml:"application-url"`
+	ApplicationName string                    `json:"application-name" yaml:"application-name"`
+	Endpoints       map[string]remoteEndpoint `json:"endpoints" yaml:"endpoints"`
+	Connections     []offerConnectionStatus   `json:"connections" yaml:"connections"`
+}
+
+func (s offerStatus) MarshalJSON() ([]byte, error) {
+	if s.Err != nil {
+		return json.Marshal(errorStatus{s.Err.Error()})
+	}
+	return json.Marshal(offerStatusNoMarshal(s))
+}
+
+func (s offerStatus) MarshalYAML() (interface{}, error) {
+	if s.Err != nil {
+		return errorStatus{s.Err.Error()}, nil
+	}
+	return offerStatusNoMarshal(s), nil
+}
+
+type offerConnectionStatus struct {
+	Err             error  `json:"-" yaml:",omitempty"`
+	SourceModelUUID string `json:"source-model-uuid" yaml:"source-model-uuid"`
+	Username        string `json:"username" yaml:"username"`
+	RelationId      int    `json:"relation-id" yaml:"relation-id"`
+	Endpoint        string `json:"endpoint" yaml:"endpoint"`
+	Status          string `json:"status" yaml:"status"`
 }
 
 type meterStatus struct {

--- a/core/crossmodel/interface.go
+++ b/core/crossmodel/interface.go
@@ -131,6 +131,9 @@ type ApplicationOffers interface {
 
 	// Remove removes the application offer at the specified URL.
 	Remove(offerName string) error
+
+	// AllApplicationOffers returns all application offers in the model.
+	AllApplicationOffers() (offers []*ApplicationOffer, _ error)
 }
 
 // RemoteApplication represents a remote application.

--- a/state/allwatcher_internal_test.go
+++ b/state/allwatcher_internal_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	jc "github.com/juju/testing/checkers"
+	"github.com/juju/utils"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/charm.v6-unstable"
 	"gopkg.in/juju/names.v2"
@@ -371,9 +372,10 @@ func addTestingApplicationOffer(
 	// Add the requested number of connections.
 	for i := 0; i < connected; i++ {
 		_, err := st.AddOfferConnection(AddOfferConnectionParams{
-			RelationId: i,
-			Username:   "fred",
-			OfferName:  offerName,
+			SourceModelUUID: utils.MustNewUUID().String(),
+			RelationId:      i,
+			Username:        "fred",
+			OfferName:       offerName,
 		})
 		c.Assert(err, jc.ErrorIsNil)
 	}
@@ -3669,9 +3671,10 @@ func testChangeApplicationOffers(c *gc.C, runChangeTests func(*gc.C, []changeTes
 			addTestingRemoteApplication(
 				c, st, "remote-wordpress", "", "hosted-mysql", mysqlRelations, true)
 			_, err := st.AddOfferConnection(AddOfferConnectionParams{
-				RelationId: 0,
-				Username:   "fred",
-				OfferName:  initialApplicationOfferInfo.OfferName,
+				SourceModelUUID: utils.MustNewUUID().String(),
+				RelationId:      0,
+				Username:        "fred",
+				OfferName:       initialApplicationOfferInfo.OfferName,
 			})
 			c.Assert(err, jc.ErrorIsNil)
 

--- a/state/applicationoffers.go
+++ b/state/applicationoffers.go
@@ -110,6 +110,26 @@ func (s *applicationOffers) ApplicationOffer(offerName string) (*crossmodel.Appl
 	return s.makeApplicationOffer(*offerDoc)
 }
 
+// AllApplicationOffers returns all application offers in the model.
+func (s *applicationOffers) AllApplicationOffers() (offers []*crossmodel.ApplicationOffer, _ error) {
+	applicationOffersCollection, closer := s.st.db().GetCollection(applicationOffersC)
+	defer closer()
+
+	var docs []applicationOfferDoc
+	err := applicationOffersCollection.Find(bson.D{}).All(&docs)
+	if err != nil {
+		return nil, errors.Errorf("cannot get all application offers")
+	}
+	for _, doc := range docs {
+		offer, err := s.makeApplicationOffer(doc)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		offers = append(offers, offer)
+	}
+	return offers, nil
+}
+
 // Remove deletes the application offer for offerName immediately.
 func (s *applicationOffers) Remove(offerName string) (err error) {
 	defer errors.DeferredAnnotatef(&err, "cannot delete application offer %q", offerName)

--- a/state/applicationoffers_test.go
+++ b/state/applicationoffers_test.go
@@ -155,6 +155,35 @@ func (s *applicationOffersSuite) TestApplicationOffer(c *gc.C) {
 	c.Assert(*offer, jc.DeepEquals, expectedOffer)
 }
 
+func (s *applicationOffersSuite) TestAllApplicationOffers(c *gc.C) {
+	eps := map[string]string{"db": "server", "db-admin": "server-admin"}
+	sd := state.NewApplicationOffers(s.State)
+	owner := s.Factory.MakeUser(c, nil)
+	anOffer := s.createDefaultOffer(c)
+	args := crossmodel.AddApplicationOfferArgs{
+		OfferName:              "another-mysql",
+		ApplicationName:        "mysql",
+		ApplicationDescription: "mysql is a db server",
+		Endpoints:              eps,
+		Owner:                  owner.Name(),
+		HasRead:                []string{"everyone@external"},
+	}
+	anotherOffer, err := sd.AddOffer(args)
+	c.Assert(err, jc.ErrorIsNil)
+
+	offers, err := sd.AllApplicationOffers()
+	c.Assert(err, jc.ErrorIsNil)
+	// Ensure ordering doesn't matter.
+	offersMap := make(map[string]*crossmodel.ApplicationOffer)
+	for _, offer := range offers {
+		offersMap[offer.OfferName] = offer
+	}
+	c.Assert(offersMap, jc.DeepEquals, map[string]*crossmodel.ApplicationOffer{
+		anOffer.OfferName:      &anOffer,
+		anotherOffer.OfferName: anotherOffer,
+	})
+}
+
 func (s *applicationOffersSuite) TestListOffersAll(c *gc.C) {
 	sd := state.NewApplicationOffers(s.State)
 	offer := s.createDefaultOffer(c)

--- a/state/offerconnections_test.go
+++ b/state/offerconnections_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/juju/errors"
 	"github.com/juju/juju/state"
+	"github.com/juju/juju/testing"
 )
 
 type offerConnectionsSuite struct {
@@ -19,11 +20,13 @@ var _ = gc.Suite(&offerConnectionsSuite{})
 
 func (s *offerConnectionsSuite) TestAddOfferConnection(c *gc.C) {
 	oc, err := s.State.AddOfferConnection(state.AddOfferConnectionParams{
-		RelationId: 1,
-		Username:   "fred",
-		OfferName:  "mysql",
+		SourceModelUUID: testing.ModelTag.Id(),
+		RelationId:      1,
+		Username:        "fred",
+		OfferName:       "mysql",
 	})
 	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(oc.SourceModelUUID(), gc.Equals, testing.ModelTag.Id())
 	c.Assert(oc.RelationId(), gc.Equals, 1)
 	c.Assert(oc.OfferName(), gc.Equals, "mysql")
 	c.Assert(oc.UserName(), gc.Equals, "fred")
@@ -39,6 +42,7 @@ func (s *offerConnectionsSuite) TestAddOfferConnection(c *gc.C) {
 	all, err := anotherState.AllOfferConnections()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(all, gc.HasLen, 1)
+	c.Assert(all[0].SourceModelUUID(), gc.Equals, testing.ModelTag.Id())
 	c.Assert(all[0].RelationId(), gc.Equals, 1)
 	c.Assert(all[0].OfferName(), gc.Equals, "mysql")
 	c.Assert(all[0].UserName(), gc.Equals, "fred")
@@ -47,9 +51,10 @@ func (s *offerConnectionsSuite) TestAddOfferConnection(c *gc.C) {
 
 func (s *offerConnectionsSuite) TestAddOfferConnectionTwice(c *gc.C) {
 	_, err := s.State.AddOfferConnection(state.AddOfferConnectionParams{
-		RelationId: 1,
-		Username:   "fred",
-		OfferName:  "mysql",
+		SourceModelUUID: testing.ModelTag.Id(),
+		RelationId:      1,
+		Username:        "fred",
+		OfferName:       "mysql",
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -58,9 +63,10 @@ func (s *offerConnectionsSuite) TestAddOfferConnectionTwice(c *gc.C) {
 	defer anotherState.Close()
 
 	_, err = anotherState.AddOfferConnection(state.AddOfferConnectionParams{
-		RelationId: 1,
-		Username:   "fred",
-		OfferName:  "mysql",
+		SourceModelUUID: testing.ModelTag.Id(),
+		RelationId:      1,
+		Username:        "fred",
+		OfferName:       "mysql",
 	})
 	c.Assert(err, jc.Satisfies, errors.IsAlreadyExists)
 }

--- a/state/relation_test.go
+++ b/state/relation_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/testing"
+	coretesting "github.com/juju/juju/testing"
 	"github.com/juju/juju/testing/factory"
 )
 
@@ -428,9 +429,10 @@ func (s *RelationSuite) TestRemoveAlsoDeletesRemoteOfferConnections(c *gc.C) {
 
 	// Add a offer connection record so we can check it is cleaned up.
 	_, err = s.State.AddOfferConnection(state.AddOfferConnectionParams{
-		RelationId: relation.Id(),
-		Username:   "fred",
-		OfferName:  "mysql",
+		SourceModelUUID: coretesting.ModelTag.Id(),
+		RelationId:      relation.Id(),
+		Username:        "fred",
+		OfferName:       "mysql",
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	rc, err := s.State.RemoteConnectionStatus("mysql")

--- a/state/remoteapplication_test.go
+++ b/state/remoteapplication_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/testing"
 	"github.com/juju/juju/status"
+	coretesting "github.com/juju/juju/testing"
 )
 
 type remoteApplicationSuite struct {
@@ -764,9 +765,10 @@ func (s *remoteApplicationSuite) TestDestroyWithOfferConnections(c *gc.C) {
 
 	// Add a offer connection record so we can check it is cleaned up.
 	_, err = s.State.AddOfferConnection(state.AddOfferConnectionParams{
-		RelationId: rel.Id(),
-		Username:   "fred",
-		OfferName:  "mysql",
+		SourceModelUUID: coretesting.ModelTag.Id(),
+		RelationId:      rel.Id(),
+		Username:        "fred",
+		OfferName:       "mysql",
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	rc, err := s.State.RemoteConnectionStatus("mysql")

--- a/worker/firewaller/firewaller_test.go
+++ b/worker/firewaller/firewaller_test.go
@@ -5,6 +5,7 @@ package firewaller_test
 
 import (
 	"reflect"
+	"sync/atomic"
 	"time"
 
 	"github.com/juju/testing"
@@ -845,9 +846,9 @@ func (s *InstanceModeSuite) TestRemoteRelationProviderRoleConsumingSide(c *gc.C)
 	c.Assert(err, jc.ErrorIsNil)
 	watched := make(chan bool)
 	var relToken string
-	callCount := 0
+	callCount := int32(0)
 	apiCaller := basetesting.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
-		switch callCount {
+		switch atomic.LoadInt32(&callCount) {
 		case 0:
 			c.Check(objType, gc.Equals, "CrossModelRelations")
 			c.Check(version, gc.Equals, 0)
@@ -868,7 +869,7 @@ func (s *InstanceModeSuite) TestRemoteRelationProviderRoleConsumingSide(c *gc.C)
 		default:
 			c.Check(objType, gc.Equals, "StringsWatcher")
 		}
-		callCount++
+		atomic.AddInt32(&callCount, 1)
 		return nil
 	})
 


### PR DESCRIPTION
## Description of change

When run on the offering model, juju status now displays information about offers and what connections there are to those offers.
We also add to the offer connection entity in state the source model uuid so that can be passed to status also.

## QA steps

Run a cmr scenario and run status on the offering model.
Model    Controller  Cloud/Region         Version       SLA
default  ian         localhost/localhost  2.3-alpha1.1  unsupported

App    Version  Status  Scale  Charm  Store       Rev  OS      Notes
mysql  5.7.19   active      1  mysql  jujucharms   57  ubuntu  

Unit      Workload  Agent  Machine  Public address  Ports     Message
mysql/0*  active    idle   0        10.200.103.104  3306/tcp  Ready

Machine  State    DNS             Inst id        Series  AZ  Message
0        started  10.200.103.104  juju-e593b5-0  xenial      Running

Offer  User   Relation id  Status  Endpoint  Interface  Role
mysql  admin  1            active  db        mysql      provider
mysql  admin  2            active  db        mysql      provider

Relation  Provides  Consumes  Type
cluster   mysql     mysql     peer
