### PR TITLE
Consistent message when unit has no resources.

### DIFF
--- a/cmd/juju/resource/show_service.go
+++ b/cmd/juju/resource/show_service.go
@@ -159,7 +159,8 @@ func (c *ShowServiceCommand) formatServiceResources(ctx *cmd.Context, sr resourc
 }
 
 func (c *ShowServiceCommand) formatUnitResources(ctx *cmd.Context, unit, service string, sr resource.ServiceResources) error {
-	if len(sr.UnitResources) == 0 {
+	resources := unitResources(unit, service, sr)
+	if len(resources) == 0 {
 		ctx.Infof(noResources)
 		return nil
 	}
@@ -172,13 +173,7 @@ func (c *ShowServiceCommand) formatUnitResources(ctx *cmd.Context, unit, service
 		return c.out.Write(ctx, FormattedUnitDetails(formatted))
 	}
 
-	resources, err := unitResources(unit, service, sr)
-	if err != nil {
-		return errors.Trace(err)
-	}
-
 	res := make([]FormattedUnitResource, len(resources))
-
 	for i, r := range resources {
 		res[i] = FormattedUnitResource(FormatSvcResource(r))
 	}
@@ -187,14 +182,14 @@ func (c *ShowServiceCommand) formatUnitResources(ctx *cmd.Context, unit, service
 
 }
 
-func unitResources(unit, service string, v resource.ServiceResources) ([]resource.Resource, error) {
-	for _, res := range v.UnitResources {
+func unitResources(unit, service string, sr resource.ServiceResources) []resource.Resource {
+	if len(sr.UnitResources) == 0 {
+		return nil
+	}
+	for _, res := range sr.UnitResources {
 		if res.Tag.Id() == unit {
-			return res.Resources, nil
+			return res.Resources
 		}
 	}
-	// TODO(natefinch): we need to differentiate between a unit with no
-	// resources and a unit that doesn't exist. This requires a serverside
-	// change.
-	return nil, nil
+	return nil
 }

--- a/featuretests/cmd_juju_resources_test.go
+++ b/featuretests/cmd_juju_resources_test.go
@@ -83,13 +83,8 @@ upload-resource   upload       -
 	// check "juju resources <unit>"
 	context, err = runCommand(c, "resources", s.unitOneName)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(cmdtesting.Stderr(context), gc.Equals, "")
-	c.Assert(cmdtesting.Stdout(context), jc.Contains, `
-[Unit]
-Resource  Revision
-
-`[1:],
-	)
+	c.Assert(cmdtesting.Stderr(context), gc.Equals, "No resources to display.\n")
+	c.Assert(cmdtesting.Stdout(context), gc.Equals, "")
 
 	// check "juju attach-resource"
 	context, err = runCommand(c, "attach-resource", s.appOneName, "install-resource=oops")


### PR DESCRIPTION
## Description of change

We are displaying empty table when application has resources but unit does not.

## QA steps

1. bootstrap
2. deploy application with resources
3. run 'juju resources <unit name>

Expected output 

No resources to display.

instead of 

[Unit]
Resource  Revision

## Documentation changes

If there is documentation for 'juju resources <unit name>' that displays empty table as a result, the output needs to be changed to contain message "No resources to display.".  

## Bug reference

https://bugs.launchpad.net/juju/+bug/1707560
