### PR TITLE
Include the SLA info in Client.ModelInfo API response.

### DIFF
--- a/apiserver/facades/client/client/client.go
+++ b/apiserver/facades/client/client/client.go
@@ -492,6 +492,10 @@ func (c *Client) ModelInfo() (params.ModelInfo, error) {
 	if tag, ok := model.CloudCredential(); ok {
 		info.CloudCredentialTag = tag.String()
 	}
+	info.SLA = &params.ModelSLAInfo{
+		Level: model.SLALevel(),
+		Owner: model.SLAOwner(),
+	}
 	return info, nil
 }
 

--- a/apiserver/facades/client/client/client_test.go
+++ b/apiserver/facades/client/client/client_test.go
@@ -87,6 +87,8 @@ func (s *serverSuite) TestModelInfo(c *gc.C) {
 		Tag:        names.NewUserTag("read"),
 		Controller: true,
 	})
+	err = model.SetSLA("advanced", "who", []byte(""))
+	c.Assert(err, jc.ErrorIsNil)
 	info, err := client.ModelInfo()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(info.DefaultSeries, gc.Equals, config.PreferredSeries(conf))
@@ -98,6 +100,10 @@ func (s *serverSuite) TestModelInfo(c *gc.C) {
 	c.Assert(info.Life, gc.Equals, params.Alive)
 	expectedAgentVersion, _ := conf.AgentVersion()
 	c.Assert(info.AgentVersion, gc.DeepEquals, &expectedAgentVersion)
+	c.Assert(info.SLA, gc.DeepEquals, &params.ModelSLAInfo{
+		Level: "advanced",
+		Owner: "who",
+	})
 	// The controller UUID is not returned by the ModelInfo endpoint on the
 	// Client facade.
 	c.Assert(info.ControllerUUID, gc.Equals, "")


### PR DESCRIPTION
This change is needed so that SLA info can easily be displayed in the Juju GUI.
QA: check the response to Client.ModelInfo API.

