### PR TITLE
Add credential to controller for add-caas

### DIFF
--- a/api/cloud/cloud.go
+++ b/api/cloud/cloud.go
@@ -155,6 +155,24 @@ func (c *Client) Credentials(tags ...names.CloudCredentialTag) ([]params.CloudCr
 	return results.Results, nil
 }
 
+// AddCredential adds a credential to the controller with a given tag.
+// This can be a credential for a cloud that is not the same cloud as the controller's host.
+func (c *Client) AddCredential(tag string, credential jujucloud.Credential) error {
+	if bestVer := c.BestAPIVersion(); bestVer < 2 {
+		return errors.NotImplementedf("AddCredential() (need v2+, have v%d)", bestVer)
+	}
+	cloudCredential := params.CloudCredential{
+		AuthType:   string(credential.AuthType()),
+		Attributes: credential.Attributes(),
+	}
+	args := params.AddCredentialArgs{CredentialTag: tag, Credential: cloudCredential}
+	err := c.facade.FacadeCall("AddCredential", args, nil)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	return nil
+}
+
 func (c *Client) AddCloud(cloud jujucloud.Cloud) error {
 	if bestVer := c.BestAPIVersion(); bestVer < 2 {
 		return errors.NotImplementedf("AddCloud() (need v2+, have v%d)", bestVer)

--- a/api/cloud/cloud_test.go
+++ b/api/cloud/cloud_test.go
@@ -173,16 +173,17 @@ func (s *cloudSuite) TestUpdateCredentials(c *gc.C) {
 			c.Check(id, gc.Equals, "")
 			c.Check(request, gc.Equals, "UpdateCredentials")
 			c.Assert(result, gc.FitsTypeOf, &params.ErrorResults{})
-			c.Assert(a, jc.DeepEquals, params.TaggedCredentials{Credentials: []params.TaggedCredential{{
-				Tag: "cloudcred-foo_bob_bar",
-				Credential: params.CloudCredential{
-					AuthType: "userpass",
-					Attributes: map[string]string{
-						"username": "admin",
-						"password": "adm1n",
+			c.Assert(a, jc.DeepEquals, params.TaggedCredentials{
+				Credentials: []params.TaggedCredential{{
+					Tag: "cloudcred-foo_bob_bar",
+					Credential: params.CloudCredential{
+						AuthType: "userpass",
+						Attributes: map[string]string{
+							"username": "admin",
+							"password": "adm1n",
+						},
 					},
-				},
-			}}})
+				}}})
 			*result.(*params.ErrorResults) = params.ErrorResults{
 				Results: []params.ErrorResult{{}},
 			}

--- a/api/cloud/cloud_test.go
+++ b/api/cloud/cloud_test.go
@@ -344,3 +344,54 @@ func (s *cloudSuite) TestAddCloudV2API(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(called, jc.IsTrue)
 }
+
+func (s *cloudSuite) TestAddCredentialNotInV1API(c *gc.C) {
+	apiCaller := basetesting.BestVersionCaller{
+		APICallerFunc: basetesting.APICallerFunc(
+			func(objType string,
+				version int,
+				id, request string,
+				a, result interface{},
+			) error {
+				c.Check(objType, gc.Equals, "Cloud")
+				c.Check(id, gc.Equals, "")
+				c.Check(request, gc.Equals, "AddCredential")
+				return nil
+			},
+		),
+		BestVersion: 1,
+	}
+	client := cloudapi.NewClient(apiCaller)
+	err := client.AddCredential("cloudcred-acloud-user-credname",
+		cloud.NewCredential(cloud.UserPassAuthType, map[string]string{}))
+
+	c.Assert(err, gc.ErrorMatches, "AddCredential\\(\\).* not implemented")
+}
+
+func (s *cloudSuite) TestAddCredentialV2API(c *gc.C) {
+	var called bool
+	apiCaller := basetesting.BestVersionCaller{
+		APICallerFunc: basetesting.APICallerFunc(
+			func(objType string,
+				version int,
+				id, request string,
+				a, result interface{},
+			) error {
+				called = true
+				c.Check(objType, gc.Equals, "Cloud")
+				c.Check(id, gc.Equals, "")
+				c.Check(request, gc.Equals, "AddCredential")
+				return nil
+			},
+		),
+		BestVersion: 2,
+	}
+
+	client := cloudapi.NewClient(apiCaller)
+	err := client.AddCredential("cloudcred-acloud-user-credname",
+		cloud.NewCredential(cloud.UserPassAuthType,
+			map[string]string{}))
+
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(called, jc.IsTrue)
+}

--- a/api/cloud/cloud_test.go
+++ b/api/cloud/cloud_test.go
@@ -354,9 +354,6 @@ func (s *cloudSuite) TestAddCredentialNotInV1API(c *gc.C) {
 				id, request string,
 				a, result interface{},
 			) error {
-				c.Check(objType, gc.Equals, "Cloud")
-				c.Check(id, gc.Equals, "")
-				c.Check(request, gc.Equals, "AddCredential")
 				return nil
 			},
 		),
@@ -381,7 +378,12 @@ func (s *cloudSuite) TestAddCredentialV2API(c *gc.C) {
 				called = true
 				c.Check(objType, gc.Equals, "Cloud")
 				c.Check(id, gc.Equals, "")
-				c.Check(request, gc.Equals, "AddCredential")
+				c.Check(request, gc.Equals, "AddCredentials")
+				c.Assert(result, gc.FitsTypeOf, &params.ErrorResults{})
+				*result.(*params.ErrorResults) = params.ErrorResults{
+					Results: []params.ErrorResult{{}},
+				}
+
 				return nil
 			},
 		),

--- a/api/cloud/cloud_test.go
+++ b/api/cloud/cloud_test.go
@@ -173,7 +173,7 @@ func (s *cloudSuite) TestUpdateCredentials(c *gc.C) {
 			c.Check(id, gc.Equals, "")
 			c.Check(request, gc.Equals, "UpdateCredentials")
 			c.Assert(result, gc.FitsTypeOf, &params.ErrorResults{})
-			c.Assert(a, jc.DeepEquals, params.UpdateCloudCredentials{Credentials: []params.UpdateCloudCredential{{
+			c.Assert(a, jc.DeepEquals, params.TaggedCredentials{Credentials: []params.TaggedCredential{{
 				Tag: "cloudcred-foo_bob_bar",
 				Credential: params.CloudCredential{
 					AuthType: "userpass",

--- a/apiserver/facades/client/cloud/cloud.go
+++ b/apiserver/facades/client/cloud/cloud.go
@@ -191,8 +191,8 @@ func (api *CloudAPI) UserCredentials(args params.UserClouds) (params.StringsResu
 	return results, nil
 }
 
-// AddCredential adds a new credential.
-// In contrast to UpdateCredentials() below, the new credential can be
+// AddCredentials adds new credentials.
+// In contrast to UpdateCredentials() below, the new credentials can be
 // for a cloud that the controller does not manage (this is required
 // for CAAS models)
 func (api *CloudAPI) AddCredentials(args params.TaggedCredentials) (params.ErrorResults, error) {

--- a/apiserver/facades/client/cloud/cloud_test.go
+++ b/apiserver/facades/client/cloud/cloud_test.go
@@ -300,6 +300,22 @@ func (s *cloudSuite) TestAddCloudInV2(c *gc.C) {
 	})
 }
 
+func (s *cloudSuite) TestAddCredentialInV2(c *gc.C) {
+	s.authorizer.Tag = names.NewUserTag("admin")
+	paramsCloud := params.AddCredentialArgs{
+		CredentialTag: "cloudcred-fake_fake_fake",
+		Credential: params.CloudCredential{
+			AuthType:   "userpass",
+			Attributes: map[string]string{},
+		}}
+	err := s.apiv2.AddCredential(paramsCloud)
+	c.Assert(err, jc.ErrorIsNil)
+	s.backend.CheckCallNames(c, "ControllerTag", "UpdateCloudCredential")
+	s.backend.CheckCall(c, 1, "UpdateCloudCredential",
+		names.NewCloudCredentialTag("fake/fake/fake"),
+		cloud.NewCredential(cloud.UserPassAuthType, map[string]string{}))
+}
+
 type mockBackend struct {
 	gitjujutesting.Stub
 	cloud cloud.Cloud

--- a/apiserver/params/cloud.go
+++ b/apiserver/params/cloud.go
@@ -44,12 +44,6 @@ type CloudsResult struct {
 	Clouds map[string]Cloud `json:"clouds,omitempty"`
 }
 
-// AddCredentialArgs contains a credential to be added with its name
-type AddCredentialArgs struct {
-	Credential    CloudCredential `json:"credential"`
-	CredentialTag string          `json:"credential-tag"`
-}
-
 // CloudCredential contains a cloud credential
 // possibly with secrets redacted.
 type CloudCredential struct {
@@ -86,14 +80,13 @@ type UserClouds struct {
 	UserClouds []UserCloud `json:"user-clouds,omitempty"`
 }
 
-// UpdateCloudCredentials contains a set of tagged cloud credentials.
-type UpdateCloudCredentials struct {
-	Credentials []UpdateCloudCredential `json:"credentials,omitempty"`
+// TaggedCredentials contains a set of tagged cloud credentials.
+type TaggedCredentials struct {
+	Credentials []TaggedCredential `json:"credentials,omitempty"`
 }
 
-// UpdateCloudCredential contains a cloud credential and its tag,
-// for updating in state.
-type UpdateCloudCredential struct {
+// TaggedCredential contains a cloud credential and its tag.
+type TaggedCredential struct {
 	Tag        string          `json:"tag"`
 	Credential CloudCredential `json:"credential"`
 }

--- a/apiserver/params/cloud.go
+++ b/apiserver/params/cloud.go
@@ -44,6 +44,12 @@ type CloudsResult struct {
 	Clouds map[string]Cloud `json:"clouds,omitempty"`
 }
 
+// AddCredentialArgs contains a credential to be added with its name
+type AddCredentialArgs struct {
+	Credential    CloudCredential `json:"credential"`
+	CredentialTag string          `json:"credential-tag"`
+}
+
 // CloudCredential contains a cloud credential
 // possibly with secrets redacted.
 type CloudCredential struct {

--- a/cmd/juju/caas/add.go
+++ b/cmd/juju/caas/add.go
@@ -10,6 +10,7 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/gnuflag"
 	"github.com/juju/loggo"
+	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/api"
 	"github.com/juju/juju/api/base"
@@ -252,9 +253,10 @@ func (c *AddCAASCommand) addCredentialToController(apiClient CloudAPI, newCreden
 		return errors.Trace(err)
 	}
 
-	cloudCredTagString := fmt.Sprintf("cloudcred-%s_%s_%s", c.caasName, currentAccountDetails.User, credentialName)
+	cloudCredTag := names.NewCloudCredentialTag(fmt.Sprintf("%s/%s/%s",
+		c.caasName, currentAccountDetails.User, credentialName))
 
-	if err := apiClient.AddCredential(cloudCredTagString, newCredential); err != nil {
+	if err := apiClient.AddCredential(cloudCredTag.String(), newCredential); err != nil {
 		return errors.Trace(err)
 	}
 	return nil

--- a/cmd/juju/caas/add_test.go
+++ b/cmd/juju/caas/add_test.go
@@ -66,7 +66,7 @@ func (f *fakeCloudMetadataStore) WritePersonalCloudMetadata(cloudsMap map[string
 }
 
 type fakeCloudAPI struct {
-	caas.AddCloudAPI
+	caas.CloudAPI
 	jujutesting.Stub
 	authTypes   []cloud.AuthType
 	credentials []names.CloudCredentialTag
@@ -99,7 +99,7 @@ func (s *addCAASSuite) SetUpTest(c *gc.C) {
 
 func (s *addCAASSuite) makeCommand(c *gc.C, cloudTypeExists bool) *caas.AddCAASCommand {
 	return caas.NewAddCAASCommandForTest(s.store, &fakeAPIConnection{},
-		func(caller base.APICallCloser) caas.AddCloudAPI {
+		func(caller base.APICallCloser) caas.CloudAPI {
 			return s.fakeCloudAPI
 		},
 		func(caasType string) (caascfg.ClientConfigFunc, error) {


### PR DESCRIPTION
Adds sending the cloud credentials for a new CAAS to the controller.

Adds AddCredential API in cloud facade v2, which uses existing UpdateCredential state functionality.

Signed-off-by: Michael McCracken <mike.mccracken@canonical.com>
