### PR TITLE
New cross model macaroon authenticator component

### DIFF
--- a/apiserver/common/crossmodel/auth.go
+++ b/apiserver/common/crossmodel/auth.go
@@ -7,13 +7,24 @@ import (
 	"time"
 
 	"github.com/juju/errors"
+	"github.com/juju/utils/clock"
+	"gopkg.in/errgo.v1"
+	"gopkg.in/juju/names.v2"
 	"gopkg.in/macaroon-bakery.v1/bakery"
+	"gopkg.in/macaroon-bakery.v1/bakery/checkers"
+	"gopkg.in/macaroon.v1"
+	"gopkg.in/yaml.v2"
 
+	"github.com/juju/juju/apiserver/authentication"
+	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/permission"
 	"github.com/juju/juju/state"
 )
 
 // NewBakery returns a bakery used for minting macaroons used
 // in cross model relations.
+// TODO(wallyworld) - this will be removed next PR
 func NewBakery(st *state.State) (*bakery.Service, error) {
 	store, err := st.NewBakeryStorage()
 	if err != nil {
@@ -26,4 +37,327 @@ func NewBakery(st *state.State) (*bakery.Service, error) {
 		Location: "juju model " + st.ModelUUID(),
 		Store:    store,
 	})
+}
+
+const (
+	usernameKey    = "username"
+	offerurlKey    = "offer-url"
+	sourcemodelKey = "source-model-uuid"
+	relationKey    = "relation-key"
+
+	offerPermissionCaveat          = "has-offer-permission"
+	localOfferPermissionExpiryTime = 2 * time.Minute
+)
+
+// AuthContext is used to validate macaroons used to access
+// application offers.
+type AuthContext struct {
+	pool StatePool
+
+	clock                             clock.Clock
+	localOfferThirdPartyBakeryService authentication.BakeryService
+	localOfferBakeryService           authentication.ExpirableStorageBakeryService
+
+	offerAccessEndpoint string
+}
+
+// NewAuthContext creates a new authentication context for checking
+// macaroons used with application offer requests.
+func NewAuthContext(
+	pool StatePool,
+	localOfferThirdPartyBakeryService authentication.BakeryService,
+	localOfferBakeryService authentication.ExpirableStorageBakeryService,
+) (*AuthContext, error) {
+	ctxt := &AuthContext{
+		pool:  pool,
+		clock: clock.WallClock,
+		localOfferBakeryService:           localOfferBakeryService,
+		localOfferThirdPartyBakeryService: localOfferThirdPartyBakeryService,
+	}
+	return ctxt, nil
+}
+
+// WithClock creates a new authentication context
+// using the specified clock.
+func (a *AuthContext) WithClock(clock clock.Clock) *AuthContext {
+	ctxtCopy := *a
+	ctxtCopy.clock = clock
+	return &ctxtCopy
+}
+
+// WithDischargeURL create an auth context based on this context and used
+// to perform third party discharges at the specified URL.
+func (a *AuthContext) WithDischargeURL(offerAccessEndpoint string) *AuthContext {
+	ctxtCopy := *a
+	ctxtCopy.offerAccessEndpoint = offerAccessEndpoint
+	return &ctxtCopy
+}
+
+// ThirdPartyBakeryService returns the third party bakery service.
+func (a *AuthContext) ThirdPartyBakeryService() authentication.BakeryService {
+	return a.localOfferThirdPartyBakeryService
+}
+
+// CheckOfferAccessCaveat checks that the specified caveat required to be satisfied
+// to gain access to an offer is valid, and returns the attributes return to check
+// that the caveat is satisfied.
+func (a *AuthContext) CheckOfferAccessCaveat(caveat string) (*offerPermissionCheck, error) {
+	op, rest, err := checkers.ParseCaveat(caveat)
+	if err != nil {
+		return nil, errors.Annotatef(err, "cannot parse caveat %q", caveat)
+	}
+	if op != offerPermissionCaveat {
+		return nil, checkers.ErrCaveatNotRecognized
+	}
+	var details offerPermissionCheck
+	err = yaml.Unmarshal([]byte(rest), &details)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	logger.Debugf("offer access caveat details: %+v", details)
+	if !names.IsValidModel(details.SourceModelUUID) {
+		return nil, errors.NotValidf("source-model-uuid %q", details.SourceModelUUID)
+	}
+	if !names.IsValidUser(details.User) {
+		return nil, errors.NotValidf("username %q", details.User)
+	}
+	if err := permission.ValidateOfferAccess(permission.Access(details.Permission)); err != nil {
+		return nil, errors.NotValidf("permission %q", details.Permission)
+	}
+	return &details, nil
+}
+
+// CheckLocalAccessRequest checks that the user in the specified permission
+// check details has consume access to the offer in the details.
+// It returns an error with a *bakery.VerificationError cause if the macaroon
+// verification failed. If the macaroon is valid, CheckLocalAccessRequest
+// returns a list of caveats to add to the discharge macaroon.
+func (a *AuthContext) CheckLocalAccessRequest(details *offerPermissionCheck) ([]checkers.Caveat, error) {
+	logger.Debugf("authenticate local offer access: %+v", details)
+	st, releaser, err := a.pool.Get(details.SourceModelUUID)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	defer releaser()
+	if err := a.checkOfferAccess(st, details.User, details.Offer); err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	firstPartyCaveats := []checkers.Caveat{
+		checkers.DeclaredCaveat(sourcemodelKey, details.SourceModelUUID),
+		checkers.DeclaredCaveat(offerurlKey, details.Offer),
+		checkers.DeclaredCaveat(usernameKey, details.User),
+		checkers.TimeBeforeCaveat(a.clock.Now().Add(localOfferPermissionExpiryTime)),
+	}
+	if details.Relation != "" {
+		firstPartyCaveats = append(firstPartyCaveats, checkers.DeclaredCaveat(relationKey, details.Relation))
+	}
+	return firstPartyCaveats, nil
+}
+
+func (a *AuthContext) checkOfferAccess(st Backend, username, offerName string) error {
+	userTag := names.NewUserTag(username)
+	isAdmin, err := a.hasControllerAdminAccess(st, userTag)
+	if err != nil {
+		return common.ErrPerm
+	}
+	if isAdmin {
+		return nil
+	}
+	isAdmin, err = a.hasModelAdminAccess(st, userTag)
+	if err != nil {
+		return common.ErrPerm
+	}
+	if isAdmin {
+		return nil
+	}
+	access, err := st.GetOfferAccess(names.NewApplicationOfferTag(offerName), userTag)
+	if err != nil && !errors.IsNotFound(err) {
+		return common.ErrPerm
+	}
+	if !access.EqualOrGreaterOfferAccessThan(permission.ConsumeAccess) {
+		return common.ErrPerm
+	}
+	return nil
+}
+
+func (api *AuthContext) hasControllerAdminAccess(st Backend, userTag names.UserTag) (bool, error) {
+	isAdmin, err := common.HasPermission(st.UserPermission, userTag, permission.SuperuserAccess, st.ControllerTag())
+	if errors.IsNotFound(err) {
+		return false, nil
+	}
+	return isAdmin, err
+}
+
+func (api *AuthContext) hasModelAdminAccess(st Backend, userTag names.UserTag) (bool, error) {
+	isAdmin, err := common.HasPermission(st.UserPermission, userTag, permission.AdminAccess, st.ModelTag())
+	if errors.IsNotFound(err) {
+		return false, nil
+	}
+	return isAdmin, err
+}
+
+func (a *AuthContext) offerPermissionYaml(sourceModelUUID, username, offerURL, relationKey string, permission permission.Access) (string, error) {
+	out, err := yaml.Marshal(offerPermissionCheck{
+		SourceModelUUID: sourceModelUUID,
+		User:            username,
+		Offer:           offerURL,
+		Relation:        relationKey,
+		Permission:      string(permission),
+	})
+	if err != nil {
+		return "", err
+	}
+	return string(out), nil
+}
+
+// CreateConsumeOfferMacaroon creates a macaroon that authorises access to the specified offer.
+func (a *AuthContext) CreateConsumeOfferMacaroon(offer *params.ApplicationOffer, username string) (*macaroon.Macaroon, error) {
+	sourceModelTag, err := names.ParseModelTag(offer.SourceModelTag)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	expiryTime := a.clock.Now().Add(localOfferPermissionExpiryTime)
+	bakery, err := a.localOfferBakeryService.ExpireStorageAt(expiryTime)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	return bakery.NewMacaroon("", nil,
+		[]checkers.Caveat{
+			checkers.TimeBeforeCaveat(expiryTime),
+			checkers.DeclaredCaveat(sourcemodelKey, sourceModelTag.Id()),
+			checkers.DeclaredCaveat(offerurlKey, offer.OfferURL),
+			checkers.DeclaredCaveat(usernameKey, username),
+		})
+}
+
+// CreateRemoteRelationMacaroon creates a macaroon that authorises access to the specified relation.
+func (a *AuthContext) CreateRemoteRelationMacaroon(sourceModelUUID, offerURL string, username string, rel names.Tag) (*macaroon.Macaroon, error) {
+	expiryTime := a.clock.Now().Add(localOfferPermissionExpiryTime)
+	bakery, err := a.localOfferBakeryService.ExpireStorageAt(expiryTime)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	offerMacaroon, err := bakery.NewMacaroon("", nil,
+		[]checkers.Caveat{
+			checkers.TimeBeforeCaveat(expiryTime),
+			checkers.DeclaredCaveat(sourcemodelKey, sourceModelUUID),
+			checkers.DeclaredCaveat(offerurlKey, offerURL),
+			checkers.DeclaredCaveat(usernameKey, username),
+			checkers.DeclaredCaveat(relationKey, rel.Id()),
+		})
+	return offerMacaroon, err
+}
+
+type offerPermissionCheck struct {
+	SourceModelUUID string `yaml:"source-model-uuid"`
+	User            string `yaml:"username"`
+	Offer           string `yaml:"offer-url"`
+	Relation        string `yaml:"relation-key"`
+	Permission      string `yaml:"permission"`
+}
+
+type authenticator struct {
+	clock  clock.Clock
+	bakery authentication.ExpirableStorageBakeryService
+	ctxt   *AuthContext
+
+	sourceModelUUID string
+	offerURL        string
+
+	// offerAccessEndpoint holds the URL of the trusted third party
+	// that is used to address the has-offer-permission third party caveat.
+	offerAccessEndpoint string
+}
+
+// Authenticator returns an instance used to authenticate macaroons used to
+// access the spcified offer.
+func (a *AuthContext) Authenticator(sourceModelUUID, offerURL string) *authenticator {
+	auth := &authenticator{
+		clock:               a.clock,
+		bakery:              a.localOfferBakeryService,
+		ctxt:                a,
+		sourceModelUUID:     sourceModelUUID,
+		offerURL:            offerURL,
+		offerAccessEndpoint: a.offerAccessEndpoint,
+	}
+	return auth
+}
+
+func (a *authenticator) checkMacaroons(mac macaroon.Slice, requiredValues map[string]string) (map[string]string, error) {
+	logger.Debugf("check macaroons with required attrs: %v", requiredValues)
+	for _, m := range mac {
+		logger.Debugf("- mac %s", m.Id())
+	}
+	declared := checkers.InferDeclared(mac)
+	logger.Debugf("check macaroons with declared attrs: %v", declared)
+	username, ok := declared[usernameKey]
+	if !ok {
+		return nil, common.ErrPerm
+	}
+	relation := declared[relationKey]
+	attrs, err := a.bakery.CheckAny([]macaroon.Slice{mac}, requiredValues, checkers.TimeBefore)
+	if err == nil {
+		logger.Debugf("macaroon check ok, attr: %v", attrs)
+		return attrs, nil
+	}
+
+	if _, ok := errgo.Cause(err).(*bakery.VerificationError); !ok {
+		logger.Debugf("macaroon verification failed: %+v", err)
+		return nil, common.ErrPerm
+	}
+
+	logger.Debugf("generating discharge macaroon because: %v", err)
+	cause := err
+	authYaml, err := a.ctxt.offerPermissionYaml(a.sourceModelUUID, username, a.offerURL, relation, permission.ConsumeAccess)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	expiryTime := a.ctxt.clock.Now().Add(localOfferPermissionExpiryTime)
+	bakery, err := a.bakery.ExpireStorageAt(expiryTime)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	keys := []string{usernameKey}
+	for k := range requiredValues {
+		keys = append(keys, k)
+	}
+	m, err := bakery.NewMacaroon("", nil, []checkers.Caveat{
+		checkers.NeedDeclaredCaveat(
+			checkers.Caveat{
+				Location:  a.offerAccessEndpoint,
+				Condition: offerPermissionCaveat + " " + authYaml,
+			},
+			keys...,
+		),
+		checkers.TimeBeforeCaveat(a.clock.Now().Add(localOfferPermissionExpiryTime)),
+	})
+	if err != nil {
+		return nil, errors.Annotate(err, "cannot create macaroon")
+	}
+	return nil, &common.DischargeRequiredError{
+		Cause:    cause,
+		Macaroon: m,
+	}
+}
+
+// CheckOfferMacaroons verifies that the specified macaroons allow access to the offer.
+func (a *authenticator) CheckOfferMacaroons(offerURL string, mac macaroon.Slice) (map[string]string, error) {
+	requiredValues := map[string]string{
+		sourcemodelKey: a.sourceModelUUID,
+		offerurlKey:    offerURL,
+	}
+	return a.checkMacaroons(mac, requiredValues)
+}
+
+// CheckRelationMacaroons verifies that the specified macaroons allow access to the relation.
+func (a *authenticator) CheckRelationMacaroons(relationTag names.Tag, mac macaroon.Slice) error {
+	requiredValues := map[string]string{
+		sourcemodelKey: a.sourceModelUUID,
+		relationKey:    relationTag.Id(),
+	}
+	_, err := a.checkMacaroons(mac, requiredValues)
+	return err
 }

--- a/apiserver/common/crossmodel/auth_test.go
+++ b/apiserver/common/crossmodel/auth_test.go
@@ -1,0 +1,431 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package crossmodel_test
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	"github.com/juju/utils"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/names.v2"
+	"gopkg.in/macaroon-bakery.v1/bakery"
+	"gopkg.in/macaroon-bakery.v1/bakery/checkers"
+	"gopkg.in/macaroon.v1"
+
+	"github.com/juju/juju/apiserver/authentication"
+	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/common/crossmodel"
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/permission"
+	coretesting "github.com/juju/juju/testing"
+)
+
+var _ = gc.Suite(&authSuite{})
+
+type authSuite struct {
+	coretesting.BaseSuite
+
+	bakery        authentication.ExpirableStorageBakeryService
+	mockStatePool *mockStatePool
+}
+
+func (s *authSuite) SetUpTest(c *gc.C) {
+	s.BaseSuite.SetUpTest(c)
+
+	key, err := bakery.GenerateKey()
+	c.Assert(err, jc.ErrorIsNil)
+	bakery, err := bakery.NewService(bakery.NewServiceParams{
+		Locator: bakery.PublicKeyLocatorMap{
+			"http://thirdparty": &key.Public,
+		},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	s.bakery = &mockBakeryService{bakery}
+	s.mockStatePool = &mockStatePool{st: make(map[string]crossmodel.Backend)}
+}
+
+func (s *authSuite) TestCheckValidCaveat(c *gc.C) {
+	authContext, err := crossmodel.NewAuthContext(s.mockStatePool, s.bakery, s.bakery)
+	c.Assert(err, jc.ErrorIsNil)
+	uuid := utils.MustNewUUID()
+	permCheckDetails := fmt.Sprintf(`
+source-model-uuid: %v
+username: mary
+offer-url: prod.mysql
+relation-key: mediawiki:db mysql:server
+permission: consume
+`[1:], uuid)
+	opc, err := authContext.CheckOfferAccessCaveat("has-offer-permission " + permCheckDetails)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(opc.SourceModelUUID, gc.Equals, uuid.String())
+	c.Assert(opc.User, gc.Equals, "mary")
+	c.Assert(opc.Offer, gc.Equals, "prod.mysql")
+	c.Assert(opc.Relation, gc.Equals, "mediawiki:db mysql:server")
+	c.Assert(opc.Permission, gc.Equals, "consume")
+}
+
+func (s *authSuite) TestCheckInvalidCaveatId(c *gc.C) {
+	authContext, err := crossmodel.NewAuthContext(s.mockStatePool, s.bakery, s.bakery)
+	c.Assert(err, jc.ErrorIsNil)
+	uuid := utils.MustNewUUID()
+	permCheckDetails := fmt.Sprintf(`
+source-model-uuid: %v
+username: mary
+offer-url: prod.mysql
+relation-key: mediawiki:db mysql:server
+permission: consume
+`[1:], uuid)
+	_, err = authContext.CheckOfferAccessCaveat("different-caveat " + permCheckDetails)
+	c.Assert(err, gc.ErrorMatches, ".*caveat not recognized.*")
+}
+
+func (s *authSuite) TestCheckInvalidCaveatContents(c *gc.C) {
+	authContext, err := crossmodel.NewAuthContext(s.mockStatePool, s.bakery, s.bakery)
+	c.Assert(err, jc.ErrorIsNil)
+	permCheckDetails := `
+source-model-uuid: invalid
+username: mary
+offer-url: prod.mysql
+relation-key: mediawiki:db mysql:server
+permission: consume
+`[1:]
+	_, err = authContext.CheckOfferAccessCaveat("has-offer-permission " + permCheckDetails)
+	c.Assert(err, gc.ErrorMatches, `source-model-uuid "invalid" not valid`)
+}
+
+func (s *authSuite) TestCheckLocalAccessRequest(c *gc.C) {
+	uuid := utils.MustNewUUID()
+	st := &mockState{
+		tag: names.NewModelTag(uuid.String()),
+		permissions: map[string]permission.Access{
+			"prod.hosted-mysql:mary": permission.ConsumeAccess,
+		},
+	}
+	s.mockStatePool.st[uuid.String()] = st
+	authContext, err := crossmodel.NewAuthContext(s.mockStatePool, s.bakery, s.bakery)
+	c.Assert(err, jc.ErrorIsNil)
+	permCheckDetails := fmt.Sprintf(`
+source-model-uuid: %v
+username: mary
+offer-url: prod.hosted-mysql
+relation-key: mediawiki:db mysql:server
+permission: consume
+`[1:], uuid)
+	opc, err := authContext.CheckOfferAccessCaveat("has-offer-permission " + permCheckDetails)
+	c.Assert(err, jc.ErrorIsNil)
+	cav, err := authContext.CheckLocalAccessRequest(opc)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(cav, gc.HasLen, 5)
+	c.Assert(cav[0].Condition, gc.Equals, "declared source-model-uuid "+uuid.String())
+	c.Assert(cav[1].Condition, gc.Equals, "declared offer-url prod.hosted-mysql")
+	c.Assert(cav[2].Condition, gc.Equals, "declared username mary")
+	c.Assert(strings.HasPrefix(cav[3].Condition, "time-before"), jc.IsTrue)
+	c.Assert(cav[4].Condition, gc.Equals, "declared relation-key mediawiki:db mysql:server")
+}
+
+func (s *authSuite) TestCheckLocalAccessRequestControllerAdmin(c *gc.C) {
+	uuid := utils.MustNewUUID()
+	st := &mockState{
+		tag: names.NewModelTag(uuid.String()),
+		permissions: map[string]permission.Access{
+			coretesting.ControllerTag.Id() + ":mary": permission.SuperuserAccess,
+		},
+	}
+	s.mockStatePool.st[uuid.String()] = st
+	authContext, err := crossmodel.NewAuthContext(s.mockStatePool, s.bakery, s.bakery)
+	c.Assert(err, jc.ErrorIsNil)
+	permCheckDetails := fmt.Sprintf(`
+source-model-uuid: %v
+username: mary
+offer-url: prod.hosted-mysql
+relation-key: mediawiki:db mysql:server
+permission: consume
+`[1:], uuid)
+	opc, err := authContext.CheckOfferAccessCaveat("has-offer-permission " + permCheckDetails)
+	c.Assert(err, jc.ErrorIsNil)
+	_, err = authContext.CheckLocalAccessRequest(opc)
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *authSuite) TestCheckLocalAccessRequestModelAdmin(c *gc.C) {
+	uuid := utils.MustNewUUID()
+	st := &mockState{
+		tag: names.NewModelTag(uuid.String()),
+		permissions: map[string]permission.Access{
+			uuid.String() + ":mary": permission.AdminAccess,
+		},
+	}
+	s.mockStatePool.st[uuid.String()] = st
+	authContext, err := crossmodel.NewAuthContext(s.mockStatePool, s.bakery, s.bakery)
+	c.Assert(err, jc.ErrorIsNil)
+	permCheckDetails := fmt.Sprintf(`
+source-model-uuid: %v
+username: mary
+offer-url: prod.hosted-mysql
+relation-key: mediawiki:db mysql:server
+permission: consume
+`[1:], uuid)
+	opc, err := authContext.CheckOfferAccessCaveat("has-offer-permission " + permCheckDetails)
+	c.Assert(err, jc.ErrorIsNil)
+	_, err = authContext.CheckLocalAccessRequest(opc)
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *authSuite) TestCheckLocalAccessRequestNoPermission(c *gc.C) {
+	uuid := utils.MustNewUUID()
+	st := &mockState{
+		tag:         names.NewModelTag(uuid.String()),
+		permissions: make(map[string]permission.Access),
+	}
+	s.mockStatePool.st[uuid.String()] = st
+	authContext, err := crossmodel.NewAuthContext(s.mockStatePool, s.bakery, s.bakery)
+	c.Assert(err, jc.ErrorIsNil)
+	permCheckDetails := fmt.Sprintf(`
+source-model-uuid: %v
+username: mary
+offer-url: prod.hosted-mysql
+relation-key: mediawiki:db mysql:server
+permission: consume
+`[1:], uuid)
+	opc, err := authContext.CheckOfferAccessCaveat("has-offer-permission " + permCheckDetails)
+	c.Assert(err, jc.ErrorIsNil)
+	_, err = authContext.CheckLocalAccessRequest(opc)
+	c.Assert(err, gc.ErrorMatches, "permission denied")
+}
+
+func (s *authSuite) TestCreateConsumeOfferMacaroon(c *gc.C) {
+	authContext, err := crossmodel.NewAuthContext(s.mockStatePool, s.bakery, s.bakery)
+	c.Assert(err, jc.ErrorIsNil)
+	offer := &params.ApplicationOffer{
+		SourceModelTag: coretesting.ModelTag.String(),
+		OfferURL:       "prod.hosted-mysql",
+	}
+	mac, err := authContext.CreateConsumeOfferMacaroon(offer, "mary")
+	c.Assert(err, jc.ErrorIsNil)
+	cav := mac.Caveats()
+	c.Assert(cav, gc.HasLen, 4)
+	c.Assert(strings.HasPrefix(cav[0].Id, "time-before"), jc.IsTrue)
+	c.Assert(cav[1].Id, gc.Equals, "declared source-model-uuid "+coretesting.ModelTag.Id())
+	c.Assert(cav[2].Id, gc.Equals, "declared offer-url prod.hosted-mysql")
+	c.Assert(cav[3].Id, gc.Equals, "declared username mary")
+}
+
+func (s *authSuite) TestCreateRemoteRelationMacaroon(c *gc.C) {
+	authContext, err := crossmodel.NewAuthContext(s.mockStatePool, s.bakery, s.bakery)
+	c.Assert(err, jc.ErrorIsNil)
+	mac, err := authContext.CreateRemoteRelationMacaroon(
+		coretesting.ModelTag.Id(), "prod.hosted-mysql", "mary", names.NewRelationTag("mediawiki:db mysql:server"))
+	c.Assert(err, jc.ErrorIsNil)
+	cav := mac.Caveats()
+	c.Assert(cav, gc.HasLen, 5)
+	c.Assert(strings.HasPrefix(cav[0].Id, "time-before"), jc.IsTrue)
+	c.Assert(cav[1].Id, gc.Equals, "declared source-model-uuid "+coretesting.ModelTag.Id())
+	c.Assert(cav[2].Id, gc.Equals, "declared offer-url prod.hosted-mysql")
+	c.Assert(cav[3].Id, gc.Equals, "declared username mary")
+	c.Assert(cav[4].Id, gc.Equals, "declared relation-key mediawiki:db mysql:server")
+}
+
+func (s *authSuite) TestCheckOfferMacaroons(c *gc.C) {
+	authContext, err := crossmodel.NewAuthContext(s.mockStatePool, s.bakery, s.bakery)
+	c.Assert(err, jc.ErrorIsNil)
+	mac, err := s.bakery.NewMacaroon("", nil, []checkers.Caveat{
+		checkers.DeclaredCaveat("username", "mary"),
+		checkers.DeclaredCaveat("offer-url", "prod.hosted-mysql"),
+		checkers.DeclaredCaveat("source-model-uuid", coretesting.ModelTag.Id()),
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	attr, err := authContext.Authenticator(
+		coretesting.ModelTag.Id(), "prod.hosted-mysql").CheckOfferMacaroons(
+		"prod.hosted-mysql",
+		macaroon.Slice{mac},
+	)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(attr, gc.HasLen, 3)
+	c.Assert(attr, jc.DeepEquals, map[string]string{
+		"username":          "mary",
+		"offer-url":         "prod.hosted-mysql",
+		"source-model-uuid": coretesting.ModelTag.Id(),
+	})
+}
+
+func (s *authSuite) TestCheckOfferMacaroonsWrongOffer(c *gc.C) {
+	authContext, err := crossmodel.NewAuthContext(s.mockStatePool, s.bakery, s.bakery)
+	c.Assert(err, jc.ErrorIsNil)
+	mac, err := s.bakery.NewMacaroon("", nil, []checkers.Caveat{
+		checkers.DeclaredCaveat("username", "mary"),
+		checkers.DeclaredCaveat("offer-url", "prod.hosted-mysql"),
+		checkers.DeclaredCaveat("source-model-uuid", coretesting.ModelTag.Id()),
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	_, err = authContext.Authenticator(
+		coretesting.ModelTag.Id(), "prod.hosted-mysql").CheckOfferMacaroons(
+		"prod.another",
+		macaroon.Slice{mac},
+	)
+	c.Assert(
+		err,
+		gc.ErrorMatches,
+		`.*caveat "declared offer-url prod.hosted-mysql" not satisfied: got offer-url="prod.another", expected "prod.hosted-mysql"`)
+}
+
+func (s *authSuite) TestCheckOfferMacaroonsNoUser(c *gc.C) {
+	authContext, err := crossmodel.NewAuthContext(s.mockStatePool, s.bakery, s.bakery)
+	c.Assert(err, jc.ErrorIsNil)
+	mac, err := s.bakery.NewMacaroon("", nil, []checkers.Caveat{
+		checkers.DeclaredCaveat("offer-url", "prod.hosted-mysql"),
+		checkers.DeclaredCaveat("source-model-uuid", coretesting.ModelTag.Id()),
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	_, err = authContext.Authenticator(
+		coretesting.ModelTag.Id(), "prod.hosted-mysql").CheckOfferMacaroons(
+		"prod.hosted-mysql",
+		macaroon.Slice{mac},
+	)
+	c.Assert(err, gc.ErrorMatches, "permission denied")
+}
+
+func (s *authSuite) TestCheckOfferMacaroonsExpired(c *gc.C) {
+	authContext, err := crossmodel.NewAuthContext(s.mockStatePool, s.bakery, s.bakery)
+	c.Assert(err, jc.ErrorIsNil)
+	clock := testing.NewClock(time.Now().Add(-10 * time.Minute))
+	authContext = authContext.WithClock(clock)
+	offer := &params.ApplicationOffer{
+		SourceModelTag: coretesting.ModelTag.String(),
+		OfferURL:       "prod.hosted-mysql",
+	}
+	mac, err := authContext.CreateConsumeOfferMacaroon(offer, "mary")
+	c.Assert(err, jc.ErrorIsNil)
+
+	_, err = authContext.Authenticator(
+		coretesting.ModelTag.Id(), "prod.hosted-mysql").CheckOfferMacaroons(
+		"prod.hosted-mysql",
+		macaroon.Slice{mac},
+	)
+	c.Assert(err, gc.ErrorMatches, ".*macaroon has expired")
+}
+
+func (s *authSuite) TestCheckOfferMacaroonsDischargeRequired(c *gc.C) {
+	authContext, err := crossmodel.NewAuthContext(s.mockStatePool, s.bakery, s.bakery)
+	c.Assert(err, jc.ErrorIsNil)
+	clock := testing.NewClock(time.Now().Add(-10 * time.Minute))
+	authContext = authContext.WithClock(clock)
+	authContext = authContext.WithDischargeURL("http://thirdparty")
+	offer := &params.ApplicationOffer{
+		SourceModelTag: coretesting.ModelTag.String(),
+		OfferURL:       "prod.hosted-mysql",
+	}
+	mac, err := authContext.CreateConsumeOfferMacaroon(offer, "mary")
+	c.Assert(err, jc.ErrorIsNil)
+
+	_, err = authContext.Authenticator(
+		coretesting.ModelTag.Id(), "prod.hosted-mysql").CheckOfferMacaroons(
+		"prod.hosted-mysql",
+		macaroon.Slice{mac},
+	)
+	dischargeErr, ok := err.(*common.DischargeRequiredError)
+	c.Assert(ok, jc.IsTrue)
+	cav := dischargeErr.Macaroon.Caveats()
+	c.Assert(cav, gc.HasLen, 2)
+	c.Assert(cav[0].Location, gc.Equals, "http://thirdparty")
+}
+
+func (s *authSuite) TestCheckRelationMacaroons(c *gc.C) {
+	authContext, err := crossmodel.NewAuthContext(s.mockStatePool, s.bakery, s.bakery)
+	c.Assert(err, jc.ErrorIsNil)
+	relationTag := names.NewRelationTag("mediawiki:db mysql:server")
+	mac, err := s.bakery.NewMacaroon("", nil, []checkers.Caveat{
+		checkers.DeclaredCaveat("username", "mary"),
+		checkers.DeclaredCaveat("relation-key", relationTag.Id()),
+		checkers.DeclaredCaveat("source-model-uuid", coretesting.ModelTag.Id()),
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	err = authContext.Authenticator(
+		coretesting.ModelTag.Id(), "prod.hosted-mysql").CheckRelationMacaroons(
+		relationTag,
+		macaroon.Slice{mac},
+	)
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *authSuite) TestCheckRelationMacaroonsWrongRelation(c *gc.C) {
+	authContext, err := crossmodel.NewAuthContext(s.mockStatePool, s.bakery, s.bakery)
+	c.Assert(err, jc.ErrorIsNil)
+	mac, err := s.bakery.NewMacaroon("", nil, []checkers.Caveat{
+		checkers.DeclaredCaveat("username", "mary"),
+		checkers.DeclaredCaveat("relation-key", names.NewRelationTag("mediawiki:db mysql:server").Id()),
+		checkers.DeclaredCaveat("source-model-uuid", coretesting.ModelTag.Id()),
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	err = authContext.Authenticator(
+		coretesting.ModelTag.Id(), "prod.hosted-mysql").CheckRelationMacaroons(
+		names.NewRelationTag("app:db offer:db"),
+		macaroon.Slice{mac},
+	)
+	c.Assert(
+		err,
+		gc.ErrorMatches,
+		`.*caveat "declared relation-key mediawiki:db mysql:server" not satisfied: got relation-key="app:db offer:db", expected "mediawiki:db mysql:server"`)
+}
+
+func (s *authSuite) TestCheckRelationMacaroonsNoUser(c *gc.C) {
+	authContext, err := crossmodel.NewAuthContext(s.mockStatePool, s.bakery, s.bakery)
+	c.Assert(err, jc.ErrorIsNil)
+	relationTag := names.NewRelationTag("mediawiki:db mysql:server")
+	mac, err := s.bakery.NewMacaroon("", nil, []checkers.Caveat{
+		checkers.DeclaredCaveat("relation-key", relationTag.Id()),
+		checkers.DeclaredCaveat("source-model-uuid", coretesting.ModelTag.Id()),
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	err = authContext.Authenticator(
+		coretesting.ModelTag.Id(), "prod.hosted-mysql").CheckRelationMacaroons(
+		relationTag,
+		macaroon.Slice{mac},
+	)
+	c.Assert(err, gc.ErrorMatches, "permission denied")
+}
+
+func (s *authSuite) TestCheckRelationMacaroonsExpired(c *gc.C) {
+	authContext, err := crossmodel.NewAuthContext(s.mockStatePool, s.bakery, s.bakery)
+	c.Assert(err, jc.ErrorIsNil)
+	clock := testing.NewClock(time.Now().Add(-10 * time.Minute))
+	authContext = authContext.WithClock(clock)
+	relationTag := names.NewRelationTag("mediawiki:db mysql:server")
+	mac, err := authContext.CreateRemoteRelationMacaroon(
+		coretesting.ModelTag.Id(), "prod.offer", "mary", relationTag)
+	c.Assert(err, jc.ErrorIsNil)
+
+	_, err = authContext.Authenticator(
+		coretesting.ModelTag.Id(), "prod.hosted-mysql").CheckOfferMacaroons(
+		"prod.hosted-mysql",
+		macaroon.Slice{mac},
+	)
+	c.Assert(err, gc.ErrorMatches, ".*macaroon has expired")
+}
+
+func (s *authSuite) TestCheckRelationMacaroonsDischargeRequired(c *gc.C) {
+	authContext, err := crossmodel.NewAuthContext(s.mockStatePool, s.bakery, s.bakery)
+	c.Assert(err, jc.ErrorIsNil)
+	clock := testing.NewClock(time.Now().Add(-10 * time.Minute))
+	authContext = authContext.WithClock(clock)
+	authContext = authContext.WithDischargeURL("http://thirdparty")
+	relationTag := names.NewRelationTag("mediawiki:db mysql:server")
+	mac, err := authContext.CreateRemoteRelationMacaroon(
+		coretesting.ModelTag.Id(), "prod.offer", "mary", relationTag)
+	c.Assert(err, jc.ErrorIsNil)
+
+	_, err = authContext.Authenticator(
+		coretesting.ModelTag.Id(), "prod.hosted-mysql").CheckOfferMacaroons(
+		"prod.hosted-mysql",
+		macaroon.Slice{mac},
+	)
+	dischargeErr, ok := err.(*common.DischargeRequiredError)
+	c.Assert(ok, jc.IsTrue)
+	cav := dischargeErr.Macaroon.Caveats()
+	c.Assert(cav, gc.HasLen, 2)
+	c.Assert(cav[0].Location, gc.Equals, "http://thirdparty")
+}

--- a/apiserver/common/crossmodel/mock_test.go
+++ b/apiserver/common/crossmodel/mock_test.go
@@ -1,0 +1,67 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package crossmodel_test
+
+import (
+	"time"
+
+	"github.com/juju/errors"
+	"gopkg.in/juju/names.v2"
+	"gopkg.in/macaroon-bakery.v1/bakery"
+
+	"github.com/juju/juju/apiserver/authentication"
+	"github.com/juju/juju/apiserver/common/crossmodel"
+	"github.com/juju/juju/permission"
+	coretesting "github.com/juju/juju/testing"
+)
+
+type mockBakeryService struct {
+	*bakery.Service
+}
+
+func (m *mockBakeryService) ExpireStorageAt(time.Time) (authentication.ExpirableStorageBakeryService, error) {
+	return m, nil
+}
+
+type mockStatePool struct {
+	st map[string]crossmodel.Backend
+}
+
+func (st *mockStatePool) Get(modelUUID string) (crossmodel.Backend, func(), error) {
+	backend, ok := st.st[modelUUID]
+	if !ok {
+		return nil, nil, errors.NotFoundf("model for uuid %s", modelUUID)
+	}
+	return backend, func() {}, nil
+}
+
+type mockState struct {
+	crossmodel.Backend
+	tag         names.ModelTag
+	permissions map[string]permission.Access
+}
+
+func (m *mockState) UserPermission(subject names.UserTag, target names.Tag) (permission.Access, error) {
+	perm, ok := m.permissions[target.Id()+":"+subject.Id()]
+	if !ok {
+		return permission.NoAccess, nil
+	}
+	return perm, nil
+}
+
+func (m *mockState) GetOfferAccess(offer names.ApplicationOfferTag, user names.UserTag) (permission.Access, error) {
+	perm, ok := m.permissions[offer.Id()+":"+user.Id()]
+	if !ok {
+		return permission.NoAccess, nil
+	}
+	return perm, nil
+}
+
+func (m *mockState) ControllerTag() names.ControllerTag {
+	return coretesting.ControllerTag
+}
+
+func (m *mockState) ModelTag() names.ModelTag {
+	return m.tag
+}

--- a/apiserver/common/crossmodel/package_test.go
+++ b/apiserver/common/crossmodel/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package crossmodel_test
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func TestAll(t *testing.T) {
+	gc.TestingT(t)
+}

--- a/cloudconfig/cloudinit/cloudinit_centos.go
+++ b/cloudconfig/cloudinit/cloudinit_centos.go
@@ -8,13 +8,10 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/juju/utils/featureflag"
 	"github.com/juju/utils/packaging"
 	"github.com/juju/utils/packaging/config"
 	"github.com/juju/utils/proxy"
 	"gopkg.in/yaml.v2"
-
-	"github.com/juju/juju/feature"
 )
 
 //PackageHelper is the interface for configuring specific parameter of the package manager
@@ -236,9 +233,6 @@ func (cfg *centOSCloudConfig) AddPackageCommands(
 func (cfg *centOSCloudConfig) addRequiredPackages() {
 
 	packages := cfg.helper.getRequiredPackages()
-	if featureflag.Enabled(feature.DeveloperMode) {
-		packages = append(packages, "socat")
-	}
 
 	// The required packages need to come from the correct repo.
 	// For CentOS 7, this requires an rpm cloud archive be up.

--- a/cloudconfig/cloudinit/cloudinit_ubuntu.go
+++ b/cloudconfig/cloudinit/cloudinit_ubuntu.go
@@ -10,13 +10,10 @@ import (
 
 	"github.com/juju/errors"
 	"github.com/juju/utils"
-	"github.com/juju/utils/featureflag"
 	"github.com/juju/utils/packaging"
 	"github.com/juju/utils/packaging/config"
 	"github.com/juju/utils/proxy"
 	"gopkg.in/yaml.v2"
-
-	"github.com/juju/juju/feature"
 )
 
 // ubuntuCloudConfig is the cloudconfig type specific to Ubuntu machines
@@ -274,9 +271,6 @@ func (cfg *ubuntuCloudConfig) addRequiredPackages() {
 		"bridge-utils",
 		"cloud-utils",
 		"tmux",
-	}
-	if featureflag.Enabled(feature.DeveloperMode) {
-		packages = append(packages, "socat")
 	}
 
 	// The required packages need to come from the correct repo.

--- a/state/applicationofferuser.go
+++ b/state/applicationofferuser.go
@@ -13,7 +13,7 @@ import (
 	"github.com/juju/juju/permission"
 )
 
-// GetOfferAccess gets the access permission for the specifed user on an offer.
+// GetOfferAccess gets the access permission for the specified user on an offer.
 func (st *State) GetOfferAccess(offer names.ApplicationOfferTag, user names.UserTag) (permission.Access, error) {
 	offerUUID, err := applicationOfferUUID(st, offer.Name)
 	if err != nil {

--- a/state/offerconnections_test.go
+++ b/state/offerconnections_test.go
@@ -22,12 +22,14 @@ func (s *offerConnectionsSuite) TestAddOfferConnection(c *gc.C) {
 	oc, err := s.State.AddOfferConnection(state.AddOfferConnectionParams{
 		SourceModelUUID: testing.ModelTag.Id(),
 		RelationId:      1,
+		RelationKey:     "rel-key",
 		Username:        "fred",
 		OfferName:       "mysql",
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(oc.SourceModelUUID(), gc.Equals, testing.ModelTag.Id())
 	c.Assert(oc.RelationId(), gc.Equals, 1)
+	c.Assert(oc.RelationKey(), gc.Equals, "rel-key")
 	c.Assert(oc.OfferName(), gc.Equals, "mysql")
 	c.Assert(oc.UserName(), gc.Equals, "fred")
 
@@ -44,6 +46,7 @@ func (s *offerConnectionsSuite) TestAddOfferConnection(c *gc.C) {
 	c.Assert(all, gc.HasLen, 1)
 	c.Assert(all[0].SourceModelUUID(), gc.Equals, testing.ModelTag.Id())
 	c.Assert(all[0].RelationId(), gc.Equals, 1)
+	c.Assert(all[0].RelationKey(), gc.Equals, "rel-key")
 	c.Assert(all[0].OfferName(), gc.Equals, "mysql")
 	c.Assert(all[0].UserName(), gc.Equals, "fred")
 	c.Assert(all[0].String(), gc.Equals, `connection to "mysql" by "fred" for relation 1`)
@@ -53,6 +56,7 @@ func (s *offerConnectionsSuite) TestAddOfferConnectionTwice(c *gc.C) {
 	_, err := s.State.AddOfferConnection(state.AddOfferConnectionParams{
 		SourceModelUUID: testing.ModelTag.Id(),
 		RelationId:      1,
+		RelationKey:     "rel-key",
 		Username:        "fred",
 		OfferName:       "mysql",
 	})
@@ -65,6 +69,7 @@ func (s *offerConnectionsSuite) TestAddOfferConnectionTwice(c *gc.C) {
 	_, err = anotherState.AddOfferConnection(state.AddOfferConnectionParams{
 		SourceModelUUID: testing.ModelTag.Id(),
 		RelationId:      1,
+		RelationKey:     "rel-key",
 		Username:        "fred",
 		OfferName:       "mysql",
 	})

--- a/worker/remoterelations/relationunitsworker.go
+++ b/worker/remoterelations/relationunitsworker.go
@@ -30,7 +30,7 @@ type relationUnitsWorker struct {
 	changes     chan<- params.RemoteRelationChangeEvent
 
 	applicationToken    string
-	macaroon            *macaroon.Macaroon
+	macaroons           macaroon.Slice
 	remoteRelationToken string
 
 	unitSettingsFunc relationUnitsSettingsFunc
@@ -39,7 +39,7 @@ type relationUnitsWorker struct {
 func newRelationUnitsWorker(
 	relationTag names.RelationTag,
 	applicationToken string,
-	macaroon *macaroon.Macaroon,
+	macaroons macaroon.Slice,
 	remoteRelationToken string,
 	ruw watcher.RelationUnitsWatcher,
 	changes chan<- params.RemoteRelationChangeEvent,
@@ -48,7 +48,7 @@ func newRelationUnitsWorker(
 	w := &relationUnitsWorker{
 		relationTag:         relationTag,
 		applicationToken:    applicationToken,
-		macaroon:            macaroon,
+		macaroons:           macaroons,
 		remoteRelationToken: remoteRelationToken,
 		ruw:                 ruw,
 		changes:             changes,
@@ -129,7 +129,7 @@ func (w *relationUnitsWorker) relationUnitsChangeEvent(
 		RelationToken:    w.remoteRelationToken,
 		Life:             params.Alive,
 		ApplicationToken: w.applicationToken,
-		Macaroons:        macaroon.Slice{w.macaroon},
+		Macaroons:        w.macaroons,
 		DepartedUnits:    make([]int, len(change.Departed)),
 	}
 	for i, u := range change.Departed {


### PR DESCRIPTION
## Description of change

A new authentication component is added which will be used to create and discharge macaroons required to access cross model offers. This PR introduces the component - the following PR wires it up.
The authenticator is responsible for minting macaroons used to access offers and relations to those offers, as well as validating those macaroons, and creating discharge mararoons upon validating that a user has access to an offer.

A chunk of this PR is a bit of refactoring of the common cross model Backend interfaces so that related facades can use the common infrastructure when things are wired up next PR.

Macaroons are given an expiry time of 2 minutes, which should be sufficient to set up a cross model relation before the macaroon needs to be discharged again.

We also add relation-key to the offer connection details record in state - this will also be used next PR. The remote relation worker also uses a macaroon slice to hold onto working copies of the macaroons used.

As a drive by, no longer apt install socat during cloud-init as we no longer use it.

## QA steps

None in this PR - QA is done in the next PR when everything is wired up.
