### PR TITLE
Remember the last logging config in the agent.conf file.

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -262,6 +262,11 @@ type Config interface {
 	// successfully run, which is also the same as the initially deployed version.
 	UpgradedToVersion() version.Number
 
+	// LoggingConfig returns the logging config for this agent. Initially this
+	// value is empty, but as the agent gets notified of model agent config
+	// changes this value is saved.
+	LoggingConfig() string
+
 	// Value returns the value associated with the key, or an empty string if
 	// the key is not found.
 	Value(key string) string
@@ -323,6 +328,9 @@ type configSetterOnly interface {
 	// SetMongoMemoryProfile sets the passed policy as the one to be
 	// used.
 	SetMongoMemoryProfile(mongo.MemoryProfile)
+
+	// SetLoggingConfig sets the logging config value for the agent.
+	SetLoggingConfig(string)
 }
 
 // LogFileName returns the filename for the Agent's log file.
@@ -379,6 +387,7 @@ type configInternal struct {
 	apiDetails         *connectionDetails
 	oldPassword        string
 	servingInfo        *params.StateServingInfo
+	loggingConfig      string
 	values             map[string]string
 	mongoVersion       string
 	mongoMemoryProfile string
@@ -590,6 +599,16 @@ func (c *configInternal) SetValue(key, value string) {
 	} else {
 		c.values[key] = value
 	}
+}
+
+// LoggingConfig implements Config.
+func (c *configInternal) LoggingConfig() string {
+	return c.loggingConfig
+}
+
+// SetLoggingConfig implements configSetterOnly.
+func (c *configInternal) SetLoggingConfig(value string) {
+	c.loggingConfig = value
 }
 
 func (c *configInternal) SetOldPassword(oldPassword string) {

--- a/agent/format-2.0.go
+++ b/agent/format-2.0.go
@@ -44,8 +44,9 @@ type format_2_0Serialization struct {
 	APIAddresses []string `yaml:"apiaddresses,omitempty"`
 	APIPassword  string   `yaml:"apipassword,omitempty"`
 
-	OldPassword string            `yaml:"oldpassword,omitempty"`
-	Values      map[string]string `yaml:"values"`
+	OldPassword   string            `yaml:"oldpassword,omitempty"`
+	LoggingConfig string            `yaml:"loggingconfig,omitempty"`
+	Values        map[string]string `yaml:"values"`
 
 	// Only controller machines have these next items set.
 	ControllerCert     string `yaml:"controllercert,omitempty"`
@@ -100,6 +101,7 @@ func (formatter_2_0) unmarshal(data []byte) (*configInternal, error) {
 		model:             modelTag,
 		caCert:            format.CACert,
 		oldPassword:       format.OldPassword,
+		loggingConfig:     format.LoggingConfig,
 		values:            format.Values,
 	}
 	if len(format.StateAddresses) > 0 {
@@ -173,6 +175,7 @@ func (formatter_2_0) marshal(config *configInternal) ([]byte, error) {
 		Model:             modelTag,
 		CACert:            string(config.caCert),
 		OldPassword:       config.oldPassword,
+		LoggingConfig:     config.loggingConfig,
 		Values:            config.values,
 	}
 	if config.servingInfo != nil {

--- a/agent/format-2.0_whitebox_test.go
+++ b/agent/format-2.0_whitebox_test.go
@@ -49,6 +49,22 @@ func (*format_2_0Suite) TestReadConfWithExisting2_0ConfigFileContents(c *gc.C) {
 	c.Assert(config.Jobs(), jc.DeepEquals, []multiwatcher.MachineJob{multiwatcher.JobManageModel})
 }
 
+func (*format_2_0Suite) TestMarshalUnmarshal(c *gc.C) {
+	loggingConfig := "juju=INFO;unit=INFO"
+	config := newTestConfig(c)
+	// configFilePath is not serialized as it is the location of the file.
+	config.configFilePath = ""
+	config.SetLoggingConfig(loggingConfig)
+
+	data, err := format_2_0.marshal(config)
+	c.Assert(err, jc.ErrorIsNil)
+	newConfig, err := format_2_0.unmarshal(data)
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Check(newConfig, gc.DeepEquals, config)
+	c.Check(newConfig.LoggingConfig(), gc.Equals, loggingConfig)
+}
+
 var agentConfig2_0Contents = `
 # format 2.0
 controller: controller-deadbeef-1bad-500d-9000-4b1d0d06f00d

--- a/agent/format.go
+++ b/agent/format.go
@@ -46,7 +46,7 @@ func registerFormat(format formatter) {
 //
 // When a new format version is introduced there is going to need to be some
 // refactoring around the config writing when provisioning a machine as the
-// controller may well understand a config format that the model does  not. So
+// controller may well understand a config format that the model does not. So
 // when generating the agent.conf for the model's machine, it needs to be
 // written out in a format that the model can understand. Right now it will be
 // written out in the format that the controller understands, and that will

--- a/agent/format.go
+++ b/agent/format.go
@@ -43,7 +43,14 @@ func registerFormat(format formatter) {
 // - Create a formatter for the new version (including a marshal() method);
 // - Call registerFormat in the new format's init() function.
 // - Change this to point to the new format;
-// - Remove the marshal() method from the old format;
+//
+// When a new format version is introduced there is going to need to be some
+// refactoring around the config writing when provisioning a machine as the
+// controller may well understand a config format that the model does  not. So
+// when generating the agent.conf for the model's machine, it needs to be
+// written out in a format that the model can understand. Right now it will be
+// written out in the format that the controller understands, and that will
+// not continue to be correct.
 
 // currentFormat holds the current agent config version's formatter.
 var currentFormat = format_2_0

--- a/cmd/jujud/agent/agent.go
+++ b/cmd/jujud/agent/agent.go
@@ -119,7 +119,7 @@ func (ch *agentConf) CurrentConfig() agent.Config {
 func setupAgentLogging(config agent.Config) {
 
 	if loggingOverride := config.Value(agent.LoggingOverride); loggingOverride != "" {
-		logger.Infof("setting logging override to %q", loggingOverride)
+		logger.Infof("logging override set for this agent: %q", loggingOverride)
 		loggo.DefaultContext().ResetLoggerLevels()
 		err := loggo.ConfigureLoggers(loggingOverride)
 		if err != nil {
@@ -132,7 +132,7 @@ func setupAgentLogging(config agent.Config) {
 		loggo.DefaultContext().ResetLoggerLevels()
 		err := loggo.ConfigureLoggers(loggingConfig)
 		if err != nil {
-			logger.Errorf("setting logging config %v", err)
+			logger.Errorf("problem setting logging config %v", err)
 		}
 	}
 

--- a/cmd/jujud/agent/agent.go
+++ b/cmd/jujud/agent/agent.go
@@ -12,6 +12,8 @@ import (
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
 	"github.com/juju/gnuflag"
+	"github.com/juju/loggo"
+	"github.com/juju/utils/featureflag"
 	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/agent"
@@ -112,4 +114,29 @@ func (ch *agentConf) CurrentConfig() agent.Config {
 	ch.mu.Lock()
 	defer ch.mu.Unlock()
 	return ch._config.Clone()
+}
+
+func setupAgentLogging(config agent.Config) {
+
+	if loggingOverride := config.Value(agent.LoggingOverride); loggingOverride != "" {
+		logger.Infof("setting logging override to %q", loggingOverride)
+		loggo.DefaultContext().ResetLoggerLevels()
+		err := loggo.ConfigureLoggers(loggingOverride)
+		if err != nil {
+			logger.Errorf("setting logging override %v", err)
+		}
+	} else if loggingConfig := config.LoggingConfig(); loggingConfig != "" {
+		logger.Infof("setting logging config to %q", loggingConfig)
+		// There should only be valid logging configuration strings saved
+		// in the logging config section in the agent.conf file.
+		loggo.DefaultContext().ResetLoggerLevels()
+		err := loggo.ConfigureLoggers(loggingConfig)
+		if err != nil {
+			logger.Errorf("setting logging config %v", err)
+		}
+	}
+
+	if flags := featureflag.String(); flags != "" {
+		logger.Warningf("developer feature flags enabled: %s", flags)
+	}
 }

--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -9,7 +9,6 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
-	"runtime"
 	"strconv"
 	"strings"
 	"sync"
@@ -24,7 +23,6 @@ import (
 	"github.com/juju/utils"
 	utilscert "github.com/juju/utils/cert"
 	"github.com/juju/utils/clock"
-	"github.com/juju/utils/featureflag"
 	"github.com/juju/utils/series"
 	"github.com/juju/utils/set"
 	"github.com/juju/utils/symlink"
@@ -231,15 +229,6 @@ func (a *machineAgentCmd) Init(args []string) error {
 		MaxSize:    300, // megabytes
 		MaxBackups: 2,
 		Compress:   true,
-	}
-
-	if loggingOverride := config.Value(agent.LoggingOverride); loggingOverride != "" {
-		logger.Infof("setting logging override to %q", loggingOverride)
-		loggo.DefaultContext().ResetLoggerLevels()
-		err := loggo.ConfigureLoggers(loggingOverride)
-		if err != nil {
-			logger.Errorf("setting logging override %v", err)
-		}
 	}
 
 	return nil
@@ -502,10 +491,8 @@ func (a *MachineAgent) Run(*cmd.Context) error {
 		return errors.Errorf("cannot read agent configuration: %v", err)
 	}
 
-	logger.Infof("machine agent %v start (%s [%s])", a.Tag(), jujuversion.Current, runtime.Compiler)
-	if flags := featureflag.String(); flags != "" {
-		logger.Warningf("developer feature flags enabled: %s", flags)
-	}
+	setupAgentLogging(a.CurrentConfig())
+
 	if err := introspection.WriteProfileFunctions(); err != nil {
 		// This isn't fatal, just annoying.
 		logger.Errorf("failed to write profile funcs: %v", err)
@@ -567,6 +554,12 @@ func (a *MachineAgent) makeEngineCreator(previousAgentVersion version.Number) fu
 			var reporter dependency.Reporter = engine
 			return a.startStateWorkers(st, reporter)
 		}
+		updateAgentConfLogging := func(loggingConfig string) error {
+			return a.AgentConfigWriter.ChangeConfig(func(setter agent.ConfigSetter) error {
+				setter.SetLoggingConfig(loggingConfig)
+				return nil
+			})
+		}
 		manifolds := machineManifolds(machine.ManifoldsConfig{
 			PreviousAgentVersion: previousAgentVersion,
 			Agent:                agent.APIHostPortsSetter{Agent: a},
@@ -585,6 +578,7 @@ func (a *MachineAgent) makeEngineCreator(previousAgentVersion version.Number) fu
 			ValidateMigration:    a.validateMigration,
 			PrometheusRegisterer: a.prometheusRegistry,
 			CentralHub:           a.centralHub,
+			UpdateLoggerConfig:   updateAgentConfLogging,
 		})
 		if err := dependency.Install(engine, manifolds); err != nil {
 			if err := worker.Stop(engine); err != nil {

--- a/cmd/jujud/agent/machine/manifolds.go
+++ b/cmd/jujud/agent/machine/manifolds.go
@@ -139,6 +139,10 @@ type ManifoldsConfig struct {
 
 	// DepEngineReporter is a dependency engine reporter.
 	DepEngineReporter dependency.Reporter
+
+	// UpdateLoggerConfig is a function that will save the specified
+	// config value as the logging config in the agent.conf file.
+	UpdateLoggerConfig func(string) error
 }
 
 // Manifolds returns a set of co-configured manifolds covering the
@@ -360,8 +364,9 @@ func Manifolds(config ManifoldsConfig) dependency.Manifolds {
 		// according to changes in environment config. We should only need
 		// one of these in a consolidated agent.
 		loggingConfigUpdaterName: ifNotMigrating(logger.Manifold(logger.ManifoldConfig{
-			AgentName:     agentName,
-			APICallerName: apiCallerName,
+			AgentName:       agentName,
+			APICallerName:   apiCallerName,
+			UpdateAgentFunc: config.UpdateLoggerConfig,
 		})),
 
 		// The diskmanager worker periodically lists block devices on the

--- a/cmd/jujud/agent/machine_test.go
+++ b/cmd/jujud/agent/machine_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/juju/cmd"
 	"github.com/juju/cmd/cmdtesting"
 	"github.com/juju/errors"
-	"github.com/juju/loggo"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils"
 	"github.com/juju/utils/arch"
@@ -125,29 +124,6 @@ func (s *MachineSuite) TestRunInvalidMachineId(c *gc.C) {
 	m, _, _ := s.primeAgent(c, state.JobHostUnits)
 	err := s.newAgent(c, m).Run(nil)
 	c.Assert(err, gc.ErrorMatches, "some error")
-}
-
-func (s *MachineSuite) TestLoggingOverride(c *gc.C) {
-	ctx := cmdtesting.Context(c)
-	agentConf := FakeAgentConfig{
-		values: map[string]string{agent.LoggingOverride: "test=trace"},
-	}
-	logger := s.newBufferedLogWriter()
-
-	a := NewMachineAgentCmd(
-		ctx,
-		NewTestMachineAgentFactory(&agentConf, logger, c.MkDir()),
-		agentConf,
-		agentConf,
-	)
-	// little hack to set the data that Init expects to already be set
-	a.(*machineAgentCmd).machineId = "42"
-
-	err := a.Init(nil)
-	c.Assert(err, gc.IsNil)
-
-	test := loggo.GetLogger("test")
-	c.Assert(test.LogLevel(), gc.Equals, loggo.TRACE)
 }
 
 func (s *MachineSuite) TestUseLumberjack(c *gc.C) {

--- a/cmd/jujud/agent/unit/manifolds.go
+++ b/cmd/jujud/agent/unit/manifolds.go
@@ -64,6 +64,10 @@ type ManifoldsConfig struct {
 	// PrometheusRegisterer is a prometheus.Registerer that may be used
 	// by workers to register Prometheus metric collectors.
 	PrometheusRegisterer prometheus.Registerer
+
+	// UpdateLoggerConfig is a function that will save the specified
+	// config value as the logging config in the agent.conf file.
+	UpdateLoggerConfig func(string) error
 }
 
 // Manifolds returns a set of co-configured manifolds covering the various
@@ -165,8 +169,9 @@ func Manifolds(config ManifoldsConfig) dependency.Manifolds {
 		// changes in environment config. We should only need one of
 		// these in a consolidated agent.
 		loggingConfigUpdaterName: ifNotMigrating(logger.Manifold(logger.ManifoldConfig{
-			AgentName:     agentName,
-			APICallerName: apiCallerName,
+			AgentName:       agentName,
+			APICallerName:   apiCallerName,
+			UpdateAgentFunc: config.UpdateLoggerConfig,
 		})),
 
 		// The api address updater is a leaf worker that rewrites agent config

--- a/cmd/jujud/agent/unit_test.go
+++ b/cmd/jujud/agent/unit_test.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/juju/cmd"
 	"github.com/juju/cmd/cmdtesting"
-	"github.com/juju/loggo"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils/arch"
 	"github.com/juju/utils/series"
@@ -338,26 +337,6 @@ func (s *UnitSuite) TestUnitAgentRunsAPIAddressUpdaterWorker(c *gc.C) {
 		}
 	}
 	c.Fatalf("timeout while waiting for agent config to change")
-}
-
-func (s *UnitSuite) TestLoggingOverride(c *gc.C) {
-	ctx, err := cmd.DefaultContext()
-	c.Assert(err, gc.IsNil)
-	agentConf := FakeAgentConfig{
-		values: map[string]string{agent.LoggingOverride: "test=trace"},
-	}
-
-	a := UnitAgent{
-		AgentConf: agentConf,
-		ctx:       ctx,
-		UnitName:  "mysql/25",
-	}
-
-	err = a.Init(nil)
-	c.Assert(err, gc.IsNil)
-
-	test := loggo.GetLogger("test")
-	c.Assert(test.LogLevel(), gc.Equals, loggo.TRACE)
 }
 
 func (s *UnitSuite) TestUseLumberjack(c *gc.C) {

--- a/worker/logger/logger.go
+++ b/worker/logger/logger.go
@@ -6,9 +6,9 @@ package logger
 import (
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
+	"gopkg.in/juju/names.v2"
 	worker "gopkg.in/juju/worker.v1"
 
-	"github.com/juju/juju/agent"
 	"github.com/juju/juju/api/logger"
 	"github.com/juju/juju/watcher"
 )
@@ -19,7 +19,7 @@ var log = loggo.GetLogger("juju.worker.logger")
 // environment watcher tells the agent that the value has changed.
 type Logger struct {
 	api            *logger.State
-	agentConfig    agent.Config
+	tag            names.Tag
 	updateCallback func(string) error
 	lastConfig     string
 	configOverride string
@@ -27,13 +27,13 @@ type Logger struct {
 
 // NewLogger returns a worker.Worker that uses the notify watcher returned
 // from the setup.
-func NewLogger(api *logger.State, agentConfig agent.Config, updateCallback func(string) error) (worker.Worker, error) {
+func NewLogger(api *logger.State, tag names.Tag, loggingOverride string, updateCallback func(string) error) (worker.Worker, error) {
 	logger := &Logger{
 		api:            api,
-		agentConfig:    agentConfig,
+		tag:            tag,
 		updateCallback: updateCallback,
 		lastConfig:     loggo.LoggerInfo(),
-		configOverride: agentConfig.Value(agent.LoggingOverride),
+		configOverride: loggingOverride,
 	}
 	log.Debugf("initial log config: %q", logger.lastConfig)
 
@@ -53,7 +53,7 @@ func (logger *Logger) setLogging() {
 		log.Debugf("overriding logging config with override from agent.conf %q", logger.configOverride)
 		loggingConfig = logger.configOverride
 	} else {
-		modelLoggingConfig, err := logger.api.LoggingConfig(logger.agentConfig.Tag())
+		modelLoggingConfig, err := logger.api.LoggingConfig(logger.tag)
 		if err != nil {
 			log.Errorf("%v", err)
 			return
@@ -88,7 +88,7 @@ func (logger *Logger) SetUp() (watcher.NotifyWatcher, error) {
 	// We need to set this up initially as the NotifyWorker sucks up the first
 	// event.
 	logger.setLogging()
-	return logger.api.WatchLoggingConfig(logger.agentConfig.Tag())
+	return logger.api.WatchLoggingConfig(logger.tag)
 }
 
 func (logger *Logger) Handle(_ <-chan struct{}) error {

--- a/worker/logger/manifold.go
+++ b/worker/logger/manifold.go
@@ -29,18 +29,20 @@ func Manifold(config ManifoldConfig) dependency.Manifold {
 			config.APICallerName,
 		},
 		Start: func(context dependency.Context) (worker.Worker, error) {
-			var agent agent.Agent
-			if err := context.Get(config.AgentName, &agent); err != nil {
+			var a agent.Agent
+			if err := context.Get(config.AgentName, &a); err != nil {
 				return nil, err
 			}
+			currentConfig := a.CurrentConfig()
+			loggingOverride := currentConfig.Value(agent.LoggingOverride)
+
 			var apiCaller base.APICaller
 			if err := context.Get(config.APICallerName, &apiCaller); err != nil {
 				return nil, err
 			}
 
-			currentConfig := agent.CurrentConfig()
 			loggerFacade := logger.NewState(apiCaller)
-			return NewLogger(loggerFacade, currentConfig, config.UpdateAgentFunc)
+			return NewLogger(loggerFacade, currentConfig.Tag(), loggingOverride, config.UpdateAgentFunc)
 		},
 	}
 }

--- a/worker/logger/manifold.go
+++ b/worker/logger/manifold.go
@@ -9,24 +9,38 @@ import (
 	"github.com/juju/juju/agent"
 	"github.com/juju/juju/api/base"
 	"github.com/juju/juju/api/logger"
-	"github.com/juju/juju/cmd/jujud/agent/engine"
 	"github.com/juju/juju/worker/dependency"
 )
 
 // ManifoldConfig defines the names of the manifolds on which a
 // Manifold will depend.
-type ManifoldConfig engine.AgentAPIManifoldConfig
+type ManifoldConfig struct {
+	AgentName       string
+	APICallerName   string
+	UpdateAgentFunc func(string) error
+}
 
 // Manifold returns a dependency manifold that runs a logger
 // worker, using the resource names defined in the supplied config.
 func Manifold(config ManifoldConfig) dependency.Manifold {
-	typedConfig := engine.AgentAPIManifoldConfig(config)
-	return engine.AgentAPIManifold(typedConfig, newWorker)
-}
+	return dependency.Manifold{
+		Inputs: []string{
+			config.AgentName,
+			config.APICallerName,
+		},
+		Start: func(context dependency.Context) (worker.Worker, error) {
+			var agent agent.Agent
+			if err := context.Get(config.AgentName, &agent); err != nil {
+				return nil, err
+			}
+			var apiCaller base.APICaller
+			if err := context.Get(config.APICallerName, &apiCaller); err != nil {
+				return nil, err
+			}
 
-// newWorker trivially wraps NewLogger to specialise a engine.AgentAPIManifold.
-var newWorker = func(a agent.Agent, apiCaller base.APICaller) (worker.Worker, error) {
-	currentConfig := a.CurrentConfig()
-	loggerFacade := logger.NewState(apiCaller)
-	return NewLogger(loggerFacade, currentConfig)
+			currentConfig := agent.CurrentConfig()
+			loggerFacade := logger.NewState(apiCaller)
+			return NewLogger(loggerFacade, currentConfig, config.UpdateAgentFunc)
+		},
+	}
 }


### PR DESCRIPTION
## Description of change

When agents currently restart they all start with --debug. This has two problems, one is that there is significant noise whenever an agent restarts and you are only interested in INFO or greater, and it is impossible to trace the dependency engine startup.

## QA steps

Bootstrap a new controller, and update the logging-config for the controller model.
SSH into one of the machines and look at the agent.conf file. It will have a logging-config value.
Restart the agent and observe it using that config to set up the logging when the agent starts.
