### PR TITLE
Remove various state.Model constructors

### DIFF
--- a/apiserver/common/crossmodel/interface.go
+++ b/apiserver/common/crossmodel/interface.go
@@ -21,6 +21,9 @@ type Backend interface {
 	// ModelTag the tag of the model on which we are operating.
 	ModelTag() names.ModelTag
 
+	// AllModelUUIDs returns the UUIDs of all models in the controller.
+	AllModelUUIDs() ([]string, error)
+
 	// ControllerTag the tag of the controller in which we are operating.
 	ControllerTag() names.ControllerTag
 

--- a/apiserver/common/modeldestroy.go
+++ b/apiserver/common/modeldestroy.go
@@ -46,16 +46,17 @@ func DestroyController(
 		)
 	}
 	if destroyHostedModels {
-		models, err := st.AllModels()
+		uuids, err := st.AllModelUUIDs()
 		if err != nil {
 			return errors.Trace(err)
 		}
-		for _, model := range models {
-			modelSt, err := st.ForModel(model.ModelTag())
-			defer modelSt.Close()
+		for _, uuid := range uuids {
+			modelSt, release, err := st.GetBackend(uuid)
 			if err != nil {
 				return errors.Trace(err)
 			}
+			defer release()
+
 			check := NewBlockChecker(modelSt)
 			if err = check.DestroyAllowed(); err != nil {
 				return errors.Trace(err)

--- a/apiserver/common/modeldestroy.go
+++ b/apiserver/common/modeldestroy.go
@@ -37,14 +37,11 @@ func DestroyController(
 	destroyStorage *bool,
 ) error {
 	modelTag := st.ModelTag()
-	controllerModel, err := st.ControllerModel()
-	if err != nil {
-		return errors.Trace(err)
-	}
-	if modelTag != controllerModel.ModelTag() {
+	controllerModelTag := st.ControllerModelTag()
+	if modelTag != controllerModelTag {
 		return errors.Errorf(
 			"expected state for controller model UUID %v, got %v",
-			controllerModel.ModelTag().Id(),
+			controllerModelTag.Id(),
 			modelTag.Id(),
 		)
 	}

--- a/apiserver/common/modeldestroy_test.go
+++ b/apiserver/common/modeldestroy_test.go
@@ -97,7 +97,7 @@ func (s *destroyModelSuite) TestDestroyController(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.modelManager.CheckCalls(c, []jtesting.StubCall{
-		{"ControllerModel", nil},
+		{"ControllerModelTag", nil},
 		{"GetBlockForType", []interface{}{state.DestroyBlock}},
 		{"GetBlockForType", []interface{}{state.RemoveBlock}},
 		{"GetBlockForType", []interface{}{state.ChangeBlock}},
@@ -114,7 +114,7 @@ func (s *destroyModelSuite) TestDestroyControllerReleaseStorage(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.modelManager.CheckCalls(c, []jtesting.StubCall{
-		{"ControllerModel", nil},
+		{"ControllerModelTag", nil},
 		{"GetBlockForType", []interface{}{state.DestroyBlock}},
 		{"GetBlockForType", []interface{}{state.RemoveBlock}},
 		{"GetBlockForType", []interface{}{state.ChangeBlock}},
@@ -132,7 +132,7 @@ func (s *destroyModelSuite) TestDestroyControllerDestroyHostedModels(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.modelManager.CheckCalls(c, []jtesting.StubCall{
-		{"ControllerModel", nil},
+		{"ControllerModelTag", nil},
 		{"AllModels", nil},
 
 		{"ForModel", []interface{}{s.modelManager.models[0].tag}},
@@ -190,9 +190,14 @@ func (m *mockModelManager) AllModels() ([]common.Model, error) {
 	return models, m.NextErr()
 }
 
-func (m *mockModelManager) ControllerModel() (common.Model, error) {
-	m.MethodCall(m, "ControllerModel")
-	return m.models[0], m.NextErr()
+func (m *mockModelManager) ControllerModelUUID() string {
+	m.MethodCall(m, "ControllerModelUUID")
+	return m.models[0].UUID()
+}
+
+func (m *mockModelManager) ControllerModelTag() names.ModelTag {
+	m.MethodCall(m, "ControllerModelTag")
+	return m.models[0].ModelTag()
 }
 
 func (m *mockModelManager) ModelTag() names.ModelTag {

--- a/apiserver/common/modeldestroy_test.go
+++ b/apiserver/common/modeldestroy_test.go
@@ -133,14 +133,14 @@ func (s *destroyModelSuite) TestDestroyControllerDestroyHostedModels(c *gc.C) {
 
 	s.modelManager.CheckCalls(c, []jtesting.StubCall{
 		{"ControllerModelTag", nil},
-		{"AllModels", nil},
+		{"AllModelUUIDs", nil},
 
-		{"ForModel", []interface{}{s.modelManager.models[0].tag}},
+		{"GetBackend", []interface{}{s.modelManager.models[0].tag.Id()}},
 		{"GetBlockForType", []interface{}{state.DestroyBlock}},
 		{"GetBlockForType", []interface{}{state.RemoveBlock}},
 		{"GetBlockForType", []interface{}{state.ChangeBlock}},
 
-		{"ForModel", []interface{}{s.modelManager.models[1].tag}},
+		{"GetBackend", []interface{}{s.modelManager.models[1].tag.Id()}},
 		{"GetBlockForType", []interface{}{state.DestroyBlock}},
 		{"GetBlockForType", []interface{}{state.RemoveBlock}},
 		{"GetBlockForType", []interface{}{state.ChangeBlock}},
@@ -149,8 +149,6 @@ func (s *destroyModelSuite) TestDestroyControllerDestroyHostedModels(c *gc.C) {
 		{"GetBlockForType", []interface{}{state.RemoveBlock}},
 		{"GetBlockForType", []interface{}{state.ChangeBlock}},
 		{"Model", nil},
-		{"Close", nil},
-		{"Close", nil},
 	})
 	s.modelManager.models[0].CheckCalls(c, []jtesting.StubCall{
 		{"Destroy", []interface{}{state.DestroyModelParams{
@@ -181,15 +179,6 @@ type mockModelManager struct {
 	models []*mockModel
 }
 
-func (m *mockModelManager) AllModels() ([]common.Model, error) {
-	m.MethodCall(m, "AllModels")
-	models := make([]common.Model, len(m.models))
-	for i, model := range m.models {
-		models[i] = model
-	}
-	return models, m.NextErr()
-}
-
 func (m *mockModelManager) ControllerModelUUID() string {
 	m.MethodCall(m, "ControllerModelUUID")
 	return m.models[0].UUID()
@@ -209,14 +198,23 @@ func (m *mockModelManager) GetBlockForType(t state.BlockType) (state.Block, bool
 	return nil, false, m.NextErr()
 }
 
+func (m *mockModelManager) AllModelUUIDs() ([]string, error) {
+	m.MethodCall(m, "AllModelUUIDs")
+	var out []string
+	for _, model := range m.models {
+		out = append(out, model.UUID())
+	}
+	return out, nil
+}
+
 func (m *mockModelManager) Model() (common.Model, error) {
 	m.MethodCall(m, "Model")
 	return m.models[0], m.NextErr()
 }
 
-func (m *mockModelManager) ForModel(tag names.ModelTag) (common.ModelManagerBackend, error) {
-	m.MethodCall(m, "ForModel", tag)
-	return m, m.NextErr()
+func (m *mockModelManager) GetBackend(uuid string) (common.ModelManagerBackend, func() bool, error) {
+	m.MethodCall(m, "GetBackend", uuid)
+	return m, func() bool { return true }, m.NextErr()
 }
 
 func (m *mockModelManager) Close() error {
@@ -232,6 +230,10 @@ type mockModel struct {
 
 func (m *mockModel) ModelTag() names.ModelTag {
 	return m.tag
+}
+
+func (m *mockModel) UUID() string {
+	return m.tag.Id()
 }
 
 func (m *mockModel) Destroy(args state.DestroyModelParams) error {

--- a/apiserver/common/modelmanagerinterface.go
+++ b/apiserver/common/modelmanagerinterface.go
@@ -33,7 +33,8 @@ type ModelManagerBackend interface {
 	NewModel(state.ModelArgs) (Model, ModelManagerBackend, error)
 
 	ComposeNewModelConfig(modelAttr map[string]interface{}, regionSpec *environs.RegionSpec) (map[string]interface{}, error)
-	ControllerModel() (Model, error)
+	ControllerModelUUID() string
+	ControllerModelTag() names.ModelTag
 	ControllerConfig() (controller.Config, error)
 	ForModel(tag names.ModelTag) (ModelManagerBackend, error)
 	GetModel(names.ModelTag) (Model, error)
@@ -105,15 +106,6 @@ type modelManagerStateShim struct {
 // state, which implements ModelManagerBackend.
 func NewModelManagerBackend(st *state.State) ModelManagerBackend {
 	return modelManagerStateShim{st}
-}
-
-// ControllerModel implements ModelManagerBackend.
-func (st modelManagerStateShim) ControllerModel() (Model, error) {
-	m, err := st.State.ControllerModel()
-	if err != nil {
-		return nil, err
-	}
-	return modelShim{m}, nil
 }
 
 // NewModel implements ModelManagerBackend.

--- a/apiserver/common/modelmanagerinterface.go
+++ b/apiserver/common/modelmanagerinterface.go
@@ -29,7 +29,7 @@ type ModelManagerBackend interface {
 	state.CloudAccessor
 
 	ModelUUID() string
-	ModelsForUser(names.UserTag) ([]string, error)
+	ModelUUIDsForUser(names.UserTag) ([]string, error)
 	IsControllerAdmin(user names.UserTag) (bool, error)
 	NewModel(state.ModelArgs) (Model, ModelManagerBackend, error)
 	Model() (Model, error)

--- a/apiserver/common/modelmanagerinterface.go
+++ b/apiserver/common/modelmanagerinterface.go
@@ -215,26 +215,3 @@ func (st modelManagerStateShim) AllVolumes() ([]state.Volume, error) {
 	}
 	return model.AllVolumes()
 }
-
-// BackendPool provides access to a pool of ModelManagerBackends.
-type BackendPool interface {
-	Get(modelUUID string) (ModelManagerBackend, func(), error)
-}
-
-// NewBackendPool returns a BackendPool wrapping the passed StatePool.
-func NewBackendPool(pool *state.StatePool) BackendPool {
-	return &statePoolShim{pool: pool}
-}
-
-type statePoolShim struct {
-	pool *state.StatePool
-}
-
-// Get implements BackendPool.
-func (p *statePoolShim) Get(modelUUID string) (ModelManagerBackend, func(), error) {
-	st, releaser, err := p.pool.Get(modelUUID)
-	closer := func() {
-		releaser()
-	}
-	return NewModelManagerBackend(st, p.pool), closer, err
-}

--- a/apiserver/common/modelmanagerinterface.go
+++ b/apiserver/common/modelmanagerinterface.go
@@ -29,7 +29,7 @@ type ModelManagerBackend interface {
 	state.CloudAccessor
 
 	ModelUUID() string
-	ModelsForUser(names.UserTag) ([]*state.UserModel, error)
+	ModelsForUser(names.UserTag) ([]string, error)
 	IsControllerAdmin(user names.UserTag) (bool, error)
 	NewModel(state.ModelArgs) (Model, ModelManagerBackend, error)
 

--- a/apiserver/facades/client/application/application.go
+++ b/apiserver/facades/client/application/application.go
@@ -54,7 +54,7 @@ type API struct {
 
 // NewFacade provides the signature required for facade registration.
 func NewFacade(ctx facade.Context) (*API, error) {
-	backend, err := NewStateBackend(ctx.State())
+	backend, err := NewStateBackend(ctx.State(), ctx.StatePool())
 	if err != nil {
 		return nil, errors.Annotate(err, "getting state")
 	}

--- a/apiserver/facades/client/application/application_test.go
+++ b/apiserver/facades/client/application/application_test.go
@@ -85,7 +85,7 @@ func (s *applicationSuite) TearDownTest(c *gc.C) {
 func (s *applicationSuite) makeAPI(c *gc.C) *application.API {
 	resources := common.NewResources()
 	resources.RegisterNamed("dataDir", common.StringResource(c.MkDir()))
-	backend, err := application.NewStateBackend(s.State)
+	backend, err := application.NewStateBackend(s.State, s.StatePool)
 	c.Assert(err, jc.ErrorIsNil)
 	blockChecker := common.NewBlockChecker(s.State)
 	api, err := application.NewAPI(

--- a/apiserver/facades/client/application/get_test.go
+++ b/apiserver/facades/client/application/get_test.go
@@ -34,7 +34,7 @@ func (s *getSuite) SetUpTest(c *gc.C) {
 	s.authorizer = apiservertesting.FakeAuthorizer{
 		Tag: s.AdminUserTag(c),
 	}
-	backend, err := application.NewStateBackend(s.State)
+	backend, err := application.NewStateBackend(s.State, s.StatePool)
 	c.Assert(err, jc.ErrorIsNil)
 	blockChecker := common.NewBlockChecker(s.State)
 	s.serviceAPI, err = application.NewAPI(

--- a/apiserver/facades/client/application/mock_test.go
+++ b/apiserver/facades/client/application/mock_test.go
@@ -451,13 +451,6 @@ func (m *mockBackend) ModelTag() names.ModelTag {
 	return names.NewModelTag(m.modelUUID)
 }
 
-func (m *mockBackend) AllModels() ([]application.Model, error) {
-	if len(m.allmodels) > 0 {
-		return m.allmodels, nil
-	}
-	return []application.Model{m.model}, nil
-}
-
 type mockBlockChecker struct {
 	jtesting.Stub
 }

--- a/apiserver/facades/client/applicationoffers/access_test.go
+++ b/apiserver/facades/client/applicationoffers/access_test.go
@@ -75,13 +75,14 @@ func (s *offerAccessSuite) revoke(c *gc.C, user names.UserTag, access params.Off
 }
 
 func (s *offerAccessSuite) setupOffer(modelUUID, modelName, owner, offerName string) {
-	s.mockState.allmodels = []applicationoffers.Model{
-		&mockModel{uuid: modelUUID, name: modelName, owner: owner}}
+	model := &mockModel{uuid: modelUUID, name: modelName, owner: owner}
+	s.mockState.allmodels = []applicationoffers.Model{model}
 	st := &mockState{
 		modelUUID:         modelUUID,
 		applicationOffers: make(map[string]jujucrossmodel.ApplicationOffer),
 		users:             set.NewStrings(),
 		accessPerms:       make(map[offerAccess]permission.Access),
+		model:             model,
 	}
 	s.mockStatePool.st[modelUUID] = st
 	st.applicationOffers[offerName] = jujucrossmodel.ApplicationOffer{}

--- a/apiserver/facades/client/applicationoffers/applicationoffers.go
+++ b/apiserver/facades/client/applicationoffers/applicationoffers.go
@@ -83,8 +83,10 @@ func NewOffersAPI(ctx facade.Context) (*OffersAPI, error) {
 	return createOffersAPI(
 		GetApplicationOffers,
 		environFromModel,
-		GetStateAccess(ctx.State(), ctx.StatePool()),
-		GetStatePool(ctx.StatePool()), ctx.Auth(), ctx.Resources(),
+		GetStateAccess(ctx.State()),
+		GetStatePool(ctx.StatePool()),
+		ctx.Auth(),
+		ctx.Resources(),
 		authContext.(*commoncrossmodel.AuthContext),
 	)
 }
@@ -380,7 +382,7 @@ func (api *OffersAPI) FindApplicationOffers(filters params.OfferFilters) (params
 			return result, errors.Trace(err)
 		}
 		for _, uuid := range uuids {
-			m, release, err := api.ControllerModel.GetModel(uuid)
+			m, release, err := api.StatePool.GetModel(uuid)
 			if err != nil {
 				return result, errors.Trace(err)
 			}

--- a/apiserver/facades/client/applicationoffers/applicationoffers.go
+++ b/apiserver/facades/client/applicationoffers/applicationoffers.go
@@ -375,11 +375,16 @@ func (api *OffersAPI) FindApplicationOffers(filters params.OfferFilters) (params
 	// any models the user can see and query across those.
 	// If there's more than one filter term, each must specify a model.
 	if len(filters.Filters) == 1 && filters.Filters[0].ModelName == "" {
-		allModels, err := api.ControllerModel.AllModels()
+		uuids, err := api.ControllerModel.AllModelUUIDs()
 		if err != nil {
 			return result, errors.Trace(err)
 		}
-		for _, m := range allModels {
+		for _, uuid := range uuids {
+			m, release, err := api.ControllerModel.GetModel(uuid)
+			if err != nil {
+				return result, errors.Trace(err)
+			}
+			defer release()
 			modelFilter := filters.Filters[0]
 			modelFilter.ModelName = m.Name()
 			modelFilter.OwnerName = m.Owner().Name()

--- a/apiserver/facades/client/applicationoffers/applicationoffers.go
+++ b/apiserver/facades/client/applicationoffers/applicationoffers.go
@@ -83,7 +83,7 @@ func NewOffersAPI(ctx facade.Context) (*OffersAPI, error) {
 	return createOffersAPI(
 		GetApplicationOffers,
 		environFromModel,
-		GetStateAccess(ctx.State()),
+		GetStateAccess(ctx.State(), ctx.StatePool()),
 		GetStatePool(ctx.StatePool()), ctx.Auth(), ctx.Resources(),
 		authContext.(*commoncrossmodel.AuthContext),
 	)

--- a/apiserver/facades/client/applicationoffers/applicationoffers_test.go
+++ b/apiserver/facades/client/applicationoffers/applicationoffers_test.go
@@ -449,12 +449,12 @@ func (s *applicationOffersSuite) TestShowErrorMsgMultipleURLs(c *gc.C) {
 		return nil, nil
 	}
 	s.mockState.model = &mockModel{uuid: testing.ModelTag.Id(), name: "prod", owner: "fred"}
-	s.mockState.allmodels = []applicationoffers.Model{
-		s.mockState.model,
-		&mockModel{uuid: "uuid2", name: "test", owner: "fred"},
+	anotherModel := &mockModel{uuid: "uuid2", name: "test", owner: "fred"}
+	s.mockStatePool.st["uuid2"] = &mockState{
+		modelUUID: "uuid2",
+		model:     anotherModel,
 	}
-	anotherState := &mockState{modelUUID: "uuid2"}
-	s.mockStatePool.st["uuid2"] = anotherState
+	s.mockState.allmodels = []applicationoffers.Model{s.mockState.model, anotherModel}
 
 	found, err := s.api.ApplicationOffers(filter)
 	c.Assert(err, jc.ErrorIsNil)
@@ -497,11 +497,12 @@ func (s *applicationOffersSuite) TestShowFoundMultiple(c *gc.C) {
 		"test": &mockApplication{
 			charm: ch, curl: charm.MustParseURL("db2-2"), bindings: map[string]string{"db": "myspace"}},
 	}
-	s.mockState.model = &mockModel{uuid: testing.ModelTag.Id(), name: "prod", owner: "fred"}
-	s.mockState.allmodels = []applicationoffers.Model{
-		s.mockState.model,
-		&mockModel{uuid: "uuid2", name: "test", owner: "mary"},
-	}
+
+	model := &mockModel{uuid: testing.ModelTag.Id(), name: "prod", owner: "fred"}
+	anotherModel := &mockModel{uuid: "uuid2", name: "test", owner: "mary"}
+
+	s.mockState.model = model
+	s.mockState.allmodels = []applicationoffers.Model{model, anotherModel}
 	s.mockState.connStatus = &mockConnectionStatus{count: 5}
 	s.mockState.spaces["myspace"] = &mockSpace{
 		name:       "myspace",
@@ -532,6 +533,7 @@ func (s *applicationOffersSuite) TestShowFoundMultiple(c *gc.C) {
 		users:       set.NewStrings(),
 		accessPerms: make(map[offerAccess]permission.Access),
 		spaces:      make(map[string]applicationoffers.Space),
+		model:       anotherModel,
 	}
 	anotherState.applications = map[string]crossmodel.Application{
 		"testagain": &mockApplication{
@@ -1048,10 +1050,11 @@ func (s *consumeSuite) setupOffer() {
 	modelUUID := testing.ModelTag.Id()
 	offerName := "hosted-mysql"
 
-	s.mockState.allmodels = []applicationoffers.Model{
-		&mockModel{uuid: modelUUID, name: "prod", owner: "fred"}}
+	model := &mockModel{uuid: modelUUID, name: "prod", owner: "fred"}
+	s.mockState.allmodels = []applicationoffers.Model{model}
 	st := &mockState{
 		modelUUID:         modelUUID,
+		model:             model,
 		applications:      make(map[string]crossmodel.Application),
 		applicationOffers: make(map[string]jujucrossmodel.ApplicationOffer),
 		users:             set.NewStrings(),

--- a/apiserver/facades/client/applicationoffers/base.go
+++ b/apiserver/facades/client/applicationoffers/base.go
@@ -71,7 +71,7 @@ func (api *BaseAPI) modelForName(modelName, ownerName string) (Model, bool, erro
 		return nil, false, errors.Trace(err)
 	}
 	for _, uuid := range uuids {
-		m, release, err := api.ControllerModel.GetModel(uuid)
+		m, release, err := api.StatePool.GetModel(uuid)
 		if err != nil {
 			return nil, false, errors.Trace(err)
 		}

--- a/apiserver/facades/client/applicationoffers/base.go
+++ b/apiserver/facades/client/applicationoffers/base.go
@@ -66,11 +66,16 @@ func (api *BaseAPI) modelForName(modelName, ownerName string) (Model, bool, erro
 		ownerName = user.Id()
 	}
 	var model Model
-	models, err := api.ControllerModel.AllModels()
+	uuids, err := api.ControllerModel.AllModelUUIDs()
 	if err != nil {
-		return nil, false, err
+		return nil, false, errors.Trace(err)
 	}
-	for _, m := range models {
+	for _, uuid := range uuids {
+		m, release, err := api.ControllerModel.GetModel(uuid)
+		if err != nil {
+			return nil, false, errors.Trace(err)
+		}
+		defer release()
 		if m.Name() == modelName && m.Owner().Id() == ownerName {
 			model = m
 			break

--- a/apiserver/facades/client/applicationoffers/state.go
+++ b/apiserver/facades/client/applicationoffers/state.go
@@ -43,7 +43,6 @@ func (pool statePoolShim) Get(modelUUID string) (Backend, func(), error) {
 	return &stateShim{
 		st:      st,
 		Backend: commoncrossmodel.GetBackend(st),
-		pool:    pool.StatePool,
 	}, func() { release() }, nil
 }
 
@@ -62,8 +61,6 @@ type Backend interface {
 	Charm(*charm.URL) (commoncrossmodel.Charm, error)
 	ApplicationOffer(name string) (*crossmodel.ApplicationOffer, error)
 	Model() (Model, error)
-	AllModelUUIDs() ([]string, error)
-	ModelTag() names.ModelTag
 	RemoteConnectionStatus(offerName string) (RemoteConnectionStatus, error)
 	Space(string) (Space, error)
 

--- a/apiserver/facades/client/client/backend.go
+++ b/apiserver/facades/client/client/backend.go
@@ -4,6 +4,7 @@
 package client
 
 import (
+	"github.com/juju/errors"
 	"github.com/juju/version"
 	"gopkg.in/juju/charm.v6-unstable"
 	"gopkg.in/juju/names.v2"
@@ -45,9 +46,9 @@ type Backend interface {
 	AllOfferConnections() ([]*state.OfferConnection, error)
 	AllRemoteApplications() ([]*state.RemoteApplication, error)
 	AllMachines() ([]*state.Machine, error)
+	AllModelUUIDs() ([]string, error)
 	AllIPAddresses() ([]*state.Address, error)
 	AllLinkLayerDevices() ([]*state.LinkLayerDevice, error)
-	AllModels() ([]*state.Model, error)
 	AllRelations() ([]*state.Relation, error)
 	Annotations(state.GlobalEntity) (map[string]string, error)
 	APIHostPorts() ([][]network.HostPort, error)
@@ -57,12 +58,12 @@ type Backend interface {
 	ControllerTag() names.ControllerTag
 	EndpointsRelation(...state.Endpoint) (*state.Relation, error)
 	FindEntity(names.Tag) (state.Entity, error)
-	ForModel(tag names.ModelTag) (*state.State, error)
 	InferEndpoints(...string) ([]state.Endpoint, error)
 	IsController() bool
 	LatestMigration() (state.ModelMigration, error)
 	LatestPlaceholderCharm(*charm.URL) (*state.Charm, error)
 	Machine(string) (*state.Machine, error)
+	GetModel(string) (*state.Model, func() bool, error)
 	Model() (*state.Model, error)
 	ModelConfig() (*config.Config, error)
 	ModelConfigValues() (config.ConfigValues, error)
@@ -80,12 +81,13 @@ type Backend interface {
 	Watch(params state.WatchParams) *state.Multiwatcher
 }
 
-func NewStateBackend(st *state.State) Backend {
-	return stateShim{st}
+func NewStateBackend(st *state.State, pool *state.StatePool) Backend {
+	return stateShim{st, pool}
 }
 
 type stateShim struct {
 	*state.State
+	pool *state.StatePool
 }
 
 func (s stateShim) Unit(name string) (Unit, error) {
@@ -99,4 +101,18 @@ func (s stateShim) Unit(name string) (Unit, error) {
 func (s stateShim) AllApplicationOffers() ([]*crossmodel.ApplicationOffer, error) {
 	offers := state.NewApplicationOffers(s.State)
 	return offers.AllApplicationOffers()
+}
+
+func (s stateShim) GetModel(uuid string) (*state.Model, func() bool, error) {
+	st, release, err := s.pool.Get(uuid)
+	if err != nil {
+		return nil, nil, errors.Trace(err)
+	}
+
+	model, err := st.Model()
+	if err != nil {
+		return nil, nil, errors.Trace(err)
+	}
+
+	return model, release, nil
 }

--- a/apiserver/facades/client/client/client_test.go
+++ b/apiserver/facades/client/client/client_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/juju/juju/agent"
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/facade"
+	"github.com/juju/juju/apiserver/facade/facadetest"
 	"github.com/juju/juju/apiserver/facades/client/client"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/apiserver/testing"
@@ -60,7 +61,13 @@ func (s *serverSuite) SetUpTest(c *gc.C) {
 }
 
 func (s *serverSuite) authClientForState(c *gc.C, st *state.State, auth facade.Authorizer) *client.Client {
-	apiserverClient, err := client.NewFacade(st, common.NewResources(), auth)
+	context := &facadetest.Context{
+		State_:     st,
+		StatePool_: s.StatePool,
+		Auth_:      auth,
+		Resources_: common.NewResources(),
+	}
+	apiserverClient, err := client.NewFacade(context)
 	c.Assert(err, jc.ErrorIsNil)
 	s.newEnviron = func() (environs.Environ, error) {
 		return environs.GetEnviron(stateenvirons.EnvironConfigGetter{st}, environs.New)

--- a/apiserver/facades/client/cloud/backend.go
+++ b/apiserver/facades/client/cloud/backend.go
@@ -16,8 +16,9 @@ type Backend interface {
 	Cloud(cloudName string) (cloud.Cloud, error)
 	CloudCredentials(user names.UserTag, cloudName string) (map[string]cloud.Credential, error)
 	CloudCredential(tag names.CloudCredentialTag) (cloud.Credential, error)
-	ControllerModel() (Model, error)
+	Model() (Model, error)
 	ControllerTag() names.ControllerTag
+	ControllerModelTag() names.ModelTag
 	ModelTag() names.ModelTag
 	ModelConfig() (*config.Config, error)
 	UpdateCloudCredential(names.CloudCredentialTag, cloud.Credential) error
@@ -40,8 +41,8 @@ func NewStateBackend(st *state.State) Backend {
 	return stateShim{st}
 }
 
-func (s stateShim) ControllerModel() (Model, error) {
-	m, err := s.State.ControllerModel()
+func (s stateShim) Model() (Model, error) {
+	m, err := s.State.Model()
 	if err != nil {
 		return nil, err
 	}

--- a/apiserver/facades/client/cloud/instance_information.go
+++ b/apiserver/facades/client/cloud/instance_information.go
@@ -45,12 +45,7 @@ func instanceTypes(api *CloudAPI,
 	environGet environGetFunc,
 	cons params.CloudInstanceTypesConstraints,
 ) (params.InstanceTypesResults, error) {
-	c, err := api.backend.ControllerModel()
-	if err != nil {
-		return params.InstanceTypesResults{}, errors.Trace(err)
-	}
-	modelTag := c.ModelTag()
-	m, err := api.backend.GetModel(modelTag)
+	m, err := api.backend.GetModel(api.backend.ControllerModelTag())
 	if err != nil {
 		return params.InstanceTypesResults{}, errors.Trace(err)
 	}

--- a/apiserver/facades/client/controller/controller.go
+++ b/apiserver/facades/client/controller/controller.go
@@ -141,9 +141,6 @@ func (s *ControllerAPIv3) AllModels() (params.UserModelList, error) {
 		result.UserModels = append(result.UserModels, userModel)
 	}
 
-	// Sort the resulting sequence by environment name, then owner.
-	sort.Sort(orderedUserModels(result.UserModels))
-
 	return result, nil
 }
 
@@ -292,33 +289,6 @@ func (c *ControllerAPIv3) WatchAllModels() (params.AllWatcherId, error) {
 	return params.AllWatcherId{
 		AllWatcherId: c.resources.Register(w),
 	}, nil
-}
-
-type orderedBlockInfo []params.ModelBlockInfo
-
-func (o orderedBlockInfo) Len() int {
-	return len(o)
-}
-
-func (o orderedBlockInfo) Less(i, j int) bool {
-	if o[i].Name < o[j].Name {
-		return true
-	}
-	if o[i].Name > o[j].Name {
-		return false
-	}
-
-	if o[i].OwnerTag < o[j].OwnerTag {
-		return true
-	}
-	if o[i].OwnerTag > o[j].OwnerTag {
-		return false
-	}
-
-	// Unreachable based on the rules of there not being duplicate
-	// environments of the same name for the same owner, but return false
-	// instead of panicing.
-	return false
 }
 
 // GetControllerAccess returns the level of access the specifed users
@@ -635,17 +605,13 @@ func ChangeControllerAccess(accessor *state.State, apiUser, targetUserTag names.
 	}
 }
 
-func (o orderedBlockInfo) Swap(i, j int) {
-	o[i], o[j] = o[j], o[i]
-}
+type orderedBlockInfo []params.ModelBlockInfo
 
-type orderedUserModels []params.UserModel
-
-func (o orderedUserModels) Len() int {
+func (o orderedBlockInfo) Len() int {
 	return len(o)
 }
 
-func (o orderedUserModels) Less(i, j int) bool {
+func (o orderedBlockInfo) Less(i, j int) bool {
 	if o[i].Name < o[j].Name {
 		return true
 	}
@@ -666,6 +632,6 @@ func (o orderedUserModels) Less(i, j int) bool {
 	return false
 }
 
-func (o orderedUserModels) Swap(i, j int) {
+func (o orderedBlockInfo) Swap(i, j int) {
 	o[i], o[j] = o[j], o[i]
 }

--- a/apiserver/facades/client/controller/controller.go
+++ b/apiserver/facades/client/controller/controller.go
@@ -74,7 +74,6 @@ func NewControllerAPIv3(ctx facade.Context) (*ControllerAPIv3, error) {
 		ControllerConfigAPI: common.NewStateControllerConfig(st),
 		ModelStatusAPI: common.NewModelStatusAPI(
 			common.NewModelManagerBackend(st, ctx.StatePool()),
-			common.NewBackendPool(ctx.StatePool()),
 			authorizer,
 			apiUser,
 		),

--- a/apiserver/facades/client/controller/controller_test.go
+++ b/apiserver/facades/client/controller/controller_test.go
@@ -262,6 +262,7 @@ func (s *controllerSuite) TestModelConfigFromNonController(c *gc.C) {
 	controller, err := controller.NewControllerAPIv4(
 		facadetest.Context{
 			State_:     st,
+			StatePool_: s.statePool,
 			Resources_: common.NewResources(),
 			Auth_:      authorizer,
 		})

--- a/apiserver/facades/client/controller/destroy.go
+++ b/apiserver/facades/client/controller/destroy.go
@@ -26,7 +26,7 @@ func (s *ControllerAPIv3) DestroyController(args params.DestroyControllerArgs) e
 	}
 	destroyStorage := true
 	args.DestroyStorage = &destroyStorage
-	return destroyController(s.state, s.authorizer, args)
+	return destroyController(s.state, s.statePool, s.authorizer, args)
 }
 
 // DestroyController destroys the controller.
@@ -36,11 +36,12 @@ func (s *ControllerAPIv3) DestroyController(args params.DestroyControllerArgs) e
 // non-Dead hosted models, then an error with the code
 // params.CodeHasHostedModels will be transmitted.
 func (s *ControllerAPIv4) DestroyController(args params.DestroyControllerArgs) error {
-	return destroyController(s.state, s.authorizer, args)
+	return destroyController(s.state, s.statePool, s.authorizer, args)
 }
 
 func destroyController(
 	st *state.State,
+	pool *state.StatePool,
 	authorizer facade.Authorizer,
 	args params.DestroyControllerArgs,
 ) error {
@@ -59,7 +60,7 @@ func destroyController(
 	// models but set the controller to dying to prevent new
 	// models sneaking in. If we are not destroying hosted models,
 	// this will fail if any hosted models are found.
-	backend := common.NewModelManagerBackend(st)
+	backend := common.NewModelManagerBackend(st, pool)
 	return errors.Trace(common.DestroyController(
 		backend, args.DestroyModels, args.DestroyStorage,
 	))

--- a/apiserver/facades/client/controller/destroy_test.go
+++ b/apiserver/facades/client/controller/destroy_test.go
@@ -34,10 +34,9 @@ type destroyControllerSuite struct {
 	resources  *common.Resources
 	controller *controller.ControllerAPIv4
 
-	otherState          *state.State
-	otherEnvOwner       names.UserTag
-	otherModelUUID      string
-	modelManagerBackend common.ModelManagerBackend
+	otherState     *state.State
+	otherEnvOwner  names.UserTag
+	otherModelUUID string
 }
 
 var _ = gc.Suite(&destroyControllerSuite{})
@@ -57,6 +56,7 @@ func (s *destroyControllerSuite) SetUpTest(c *gc.C) {
 	controller, err := controller.NewControllerAPIv4(
 		facadetest.Context{
 			State_:     s.State,
+			StatePool_: s.StatePool,
 			Resources_: s.resources,
 			Auth_:      s.authorizer,
 		})
@@ -73,7 +73,6 @@ func (s *destroyControllerSuite) SetUpTest(c *gc.C) {
 	})
 	s.AddCleanup(func(c *gc.C) { s.otherState.Close() })
 	s.otherModelUUID = s.otherState.ModelUUID()
-	s.modelManagerBackend = common.NewModelManagerBackend(s.State)
 }
 
 func (s *destroyControllerSuite) TestDestroyControllerKillErrsOnHostedEnvsWithBlocks(c *gc.C) {
@@ -137,7 +136,7 @@ func (s *destroyControllerSuite) TestDestroyControllerLeavesBlocksIfNotKillAll(c
 }
 
 func (s *destroyControllerSuite) TestDestroyControllerNoHostedEnvs(c *gc.C) {
-	err := common.DestroyModel(common.NewModelManagerBackend(s.otherState), nil)
+	err := common.DestroyModel(common.NewModelManagerBackend(s.otherState, s.StatePool), nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	err = s.controller.DestroyController(params.DestroyControllerArgs{})
@@ -149,7 +148,7 @@ func (s *destroyControllerSuite) TestDestroyControllerNoHostedEnvs(c *gc.C) {
 }
 
 func (s *destroyControllerSuite) TestDestroyControllerErrsOnNoHostedEnvsWithBlock(c *gc.C) {
-	err := common.DestroyModel(common.NewModelManagerBackend(s.otherState), nil)
+	err := common.DestroyModel(common.NewModelManagerBackend(s.otherState, s.StatePool), nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.BlockDestroyModel(c, "TestBlockDestroyModel")
@@ -163,7 +162,7 @@ func (s *destroyControllerSuite) TestDestroyControllerErrsOnNoHostedEnvsWithBloc
 }
 
 func (s *destroyControllerSuite) TestDestroyControllerNoHostedEnvsWithBlockFail(c *gc.C) {
-	err := common.DestroyModel(common.NewModelManagerBackend(s.otherState), nil)
+	err := common.DestroyModel(common.NewModelManagerBackend(s.otherState, s.StatePool), nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.BlockDestroyModel(c, "TestBlockDestroyModel")
@@ -228,6 +227,7 @@ func (s *destroyControllerSuite) TestDestroyControllerDestroyStorageSpecified(c 
 func (s *destroyControllerSuite) TestDestroyControllerDestroyStorageNotSpecifiedV3(c *gc.C) {
 	controller, err := controller.NewControllerAPIv3(facadetest.Context{
 		State_:     s.State,
+		StatePool_: s.StatePool,
 		Resources_: s.resources,
 		Auth_:      s.authorizer,
 	})
@@ -258,6 +258,7 @@ func (s *destroyControllerSuite) TestDestroyControllerDestroyStorageNotSpecified
 func (s *destroyControllerSuite) TestDestroyControllerDestroyStorageSpecifiedV3(c *gc.C) {
 	controller, err := controller.NewControllerAPIv3(facadetest.Context{
 		State_:     s.State,
+		StatePool_: s.StatePool,
 		Resources_: s.resources,
 		Auth_:      s.authorizer,
 	})

--- a/apiserver/facades/client/controller/export_test.go
+++ b/apiserver/facades/client/controller/export_test.go
@@ -13,7 +13,7 @@ type patcher interface {
 }
 
 func SetPrecheckResult(p patcher, err error) {
-	p.PatchValue(&runMigrationPrechecks, func(*state.State, *state.State, *migration.TargetInfo) error {
+	p.PatchValue(&runMigrationPrechecks, func(*state.State, *state.StatePool, *migration.TargetInfo) error {
 		return err
 	})
 }

--- a/apiserver/facades/client/controller/export_test.go
+++ b/apiserver/facades/client/controller/export_test.go
@@ -13,7 +13,7 @@ type patcher interface {
 }
 
 func SetPrecheckResult(p patcher, err error) {
-	p.PatchValue(&runMigrationPrechecks, func(*state.State, *migration.TargetInfo) error {
+	p.PatchValue(&runMigrationPrechecks, func(*state.State, *state.State, *migration.TargetInfo) error {
 		return err
 	})
 }

--- a/apiserver/facades/client/modelmanager/modelinfo_test.go
+++ b/apiserver/facades/client/modelmanager/modelinfo_test.go
@@ -143,14 +143,14 @@ func (s *modelInfoSuite) SetUpTest(c *gc.C) {
 	}
 
 	var err error
-	s.modelmanager, err = modelmanager.NewModelManagerAPI(s.st, s.ctlrSt, nil, nil, &s.authorizer)
+	s.modelmanager, err = modelmanager.NewModelManagerAPI(s.st, s.ctlrSt, nil, &s.authorizer)
 	c.Assert(err, jc.ErrorIsNil)
 }
 
 func (s *modelInfoSuite) setAPIUser(c *gc.C, user names.UserTag) {
 	s.authorizer.Tag = user
 	var err error
-	s.modelmanager, err = modelmanager.NewModelManagerAPI(s.st, s.ctlrSt, nil, nil, s.authorizer)
+	s.modelmanager, err = modelmanager.NewModelManagerAPI(s.st, s.ctlrSt, nil, s.authorizer)
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -1041,13 +1041,4 @@ func (m *mockMigration) StartTime() time.Time {
 
 func (m *mockMigration) EndTime() time.Time {
 	return m.end
-}
-
-type mockPool struct {
-	st *mockState
-}
-
-func (p *mockPool) Get(modelUUID string) (common.ModelManagerBackend, func(), error) {
-	p.st.MethodCall(p, "Get", modelUUID)
-	return p.st, func() {}, p.st.NextErr()
 }

--- a/apiserver/facades/client/modelmanager/modelinfo_test.go
+++ b/apiserver/facades/client/modelmanager/modelinfo_test.go
@@ -590,7 +590,7 @@ func (st *mockState) ExportPartial(state.ExportConfig) (description.Model, error
 	return st.Export()
 }
 
-func (st *mockState) ModelsForUser(user names.UserTag) ([]*state.UserModel, error) {
+func (st *mockState) ModelsForUser(user names.UserTag) ([]string, error) {
 	st.MethodCall(st, "ModelsForUser", user)
 	return nil, st.NextErr()
 }

--- a/apiserver/facades/client/modelmanager/modelinfo_test.go
+++ b/apiserver/facades/client/modelmanager/modelinfo_test.go
@@ -604,8 +604,8 @@ func (st *mockState) GetModel(modelUUID string) (common.Model, func() bool, erro
 	return st.model, func() bool { return true }, st.NextErr()
 }
 
-func (st *mockState) ModelsForUser(user names.UserTag) ([]string, error) {
-	st.MethodCall(st, "ModelsForUser", user)
+func (st *mockState) ModelUUIDsForUser(user names.UserTag) ([]string, error) {
+	st.MethodCall(st, "ModelUUIDsForUser", user)
 	return nil, st.NextErr()
 }
 

--- a/apiserver/facades/client/modelmanager/modelmanager.go
+++ b/apiserver/facades/client/modelmanager/modelmanager.go
@@ -101,14 +101,15 @@ var (
 // NewFacadeV4 is used for API registration.
 func NewFacadeV4(ctx facade.Context) (*ModelManagerAPI, error) {
 	st := ctx.State()
-	ctlrSt := ctx.StatePool().SystemState()
-	auth := ctx.Auth()
 	pool := ctx.StatePool()
+	ctlrSt := pool.SystemState()
+	auth := ctx.Auth()
 	configGetter := stateenvirons.EnvironConfigGetter{st}
 
 	return NewModelManagerAPI(
-		common.NewModelManagerBackend(st),
-		common.NewModelManagerBackend(ctlrSt),
+		// XXX normalise this?
+		common.NewModelManagerBackend(st, pool),
+		common.NewModelManagerBackend(ctlrSt, pool),
 		common.NewBackendPool(pool),
 		configGetter,
 		auth,

--- a/apiserver/facades/client/modelmanager/modelmanager.go
+++ b/apiserver/facades/client/modelmanager/modelmanager.go
@@ -575,7 +575,7 @@ func (m *ModelManagerAPI) ListModels(user params.Entity) (params.UserModelList, 
 		return result, errors.Trace(err)
 	}
 
-	modelUUIDs, err := m.state.ModelsForUser(userTag)
+	modelUUIDs, err := m.state.ModelUUIDsForUser(userTag)
 	if err != nil {
 		return result, errors.Trace(err)
 	}

--- a/apiserver/facades/client/modelmanager/modelmanager_test.go
+++ b/apiserver/facades/client/modelmanager/modelmanager_test.go
@@ -748,7 +748,7 @@ func (s *modelManagerStateSuite) setAPIUser(c *gc.C, user names.UserTag) {
 	modelmanager, err := modelmanager.NewModelManagerAPI(
 		common.NewModelManagerBackend(s.State, s.StatePool),
 		common.NewModelManagerBackend(s.State, s.StatePool),
-		nil,
+		common.NewBackendPool(s.StatePool),
 		stateenvirons.EnvironConfigGetter{s.State},
 		s.authoriser,
 	)

--- a/apiserver/facades/client/modelmanager/modelmanager_test.go
+++ b/apiserver/facades/client/modelmanager/modelmanager_test.go
@@ -746,8 +746,8 @@ func (s *modelManagerStateSuite) SetUpTest(c *gc.C) {
 func (s *modelManagerStateSuite) setAPIUser(c *gc.C, user names.UserTag) {
 	s.authoriser.Tag = user
 	modelmanager, err := modelmanager.NewModelManagerAPI(
-		common.NewModelManagerBackend(s.State),
-		common.NewModelManagerBackend(s.State),
+		common.NewModelManagerBackend(s.State, s.StatePool),
+		common.NewModelManagerBackend(s.State, s.StatePool),
 		nil,
 		stateenvirons.EnvironConfigGetter{s.State},
 		s.authoriser,
@@ -760,8 +760,8 @@ func (s *modelManagerStateSuite) TestNewAPIAcceptsClient(c *gc.C) {
 	anAuthoriser := s.authoriser
 	anAuthoriser.Tag = names.NewUserTag("external@remote")
 	endPoint, err := modelmanager.NewModelManagerAPI(
-		common.NewModelManagerBackend(s.State),
-		common.NewModelManagerBackend(s.State),
+		common.NewModelManagerBackend(s.State, s.StatePool),
+		common.NewModelManagerBackend(s.State, s.StatePool),
 		nil, nil, anAuthoriser,
 	)
 	c.Assert(err, jc.ErrorIsNil)
@@ -772,8 +772,8 @@ func (s *modelManagerStateSuite) TestNewAPIRefusesNonClient(c *gc.C) {
 	anAuthoriser := s.authoriser
 	anAuthoriser.Tag = names.NewUnitTag("mysql/0")
 	endPoint, err := modelmanager.NewModelManagerAPI(
-		common.NewModelManagerBackend(s.State),
-		common.NewModelManagerBackend(s.State),
+		common.NewModelManagerBackend(s.State, s.StatePool),
+		common.NewModelManagerBackend(s.State, s.StatePool),
 		nil, nil, anAuthoriser,
 	)
 	c.Assert(endPoint, gc.IsNil)
@@ -992,8 +992,8 @@ func (s *modelManagerStateSuite) TestDestroyOwnModel(c *gc.C) {
 	defer pool.Close()
 
 	s.modelmanager, err = modelmanager.NewModelManagerAPI(
-		common.NewModelManagerBackend(st),
-		common.NewModelManagerBackend(s.State),
+		common.NewModelManagerBackend(st, s.StatePool),
+		common.NewModelManagerBackend(s.State, s.StatePool),
 		common.NewBackendPool(pool),
 		nil, s.authoriser,
 	)
@@ -1028,8 +1028,8 @@ func (s *modelManagerStateSuite) TestAdminDestroysOtherModel(c *gc.C) {
 
 	s.authoriser.Tag = s.AdminUserTag(c)
 	s.modelmanager, err = modelmanager.NewModelManagerAPI(
-		common.NewModelManagerBackend(st),
-		common.NewModelManagerBackend(s.State),
+		common.NewModelManagerBackend(st, s.StatePool),
+		common.NewModelManagerBackend(s.State, s.StatePool),
 		common.NewBackendPool(pool),
 		nil, s.authoriser,
 	)
@@ -1060,8 +1060,8 @@ func (s *modelManagerStateSuite) TestDestroyModelErrors(c *gc.C) {
 	defer st.Close()
 
 	s.modelmanager, err = modelmanager.NewModelManagerAPI(
-		common.NewModelManagerBackend(st),
-		common.NewModelManagerBackend(s.State),
+		common.NewModelManagerBackend(st, s.StatePool),
+		common.NewModelManagerBackend(s.State, s.StatePool),
 		nil, nil, s.authoriser,
 	)
 	c.Assert(err, jc.ErrorIsNil)

--- a/apiserver/facades/client/modelmanager/modelmanager_test.go
+++ b/apiserver/facades/client/modelmanager/modelmanager_test.go
@@ -54,6 +54,7 @@ func createArgs(owner names.UserTag) params.ModelCreateArgs {
 type modelManagerSuite struct {
 	gitjujutesting.IsolationSuite
 	st         *mockState
+	ctlrSt     *mockState
 	pool       *mockPool
 	authoriser apiservertesting.FakeAuthorizer
 	api        *modelmanager.ModelManagerAPI
@@ -78,32 +79,34 @@ func (s *modelManagerSuite) SetUpTest(c *gc.C) {
 		},
 	}
 
+	controllerModel := &mockModel{
+		owner: names.NewUserTag("admin"),
+		life:  state.Alive,
+		cfg:   cfg,
+		status: status.StatusInfo{
+			Status: status.Available,
+			Since:  &time.Time{},
+		},
+		users: []*mockModelUser{{
+			userName: "admin",
+			access:   permission.AdminAccess,
+		}, {
+			userName: "add-model",
+			access:   permission.AdminAccess,
+		}, {
+
+			userName: "otheruser",
+			access:   permission.WriteAccess,
+		}},
+	}
+
 	s.st = &mockState{
 		block: -1,
 		cloud: dummyCloud,
 		clouds: map[names.CloudTag]cloud.Cloud{
 			names.NewCloudTag("some-cloud"): dummyCloud,
 		},
-		controllerModel: &mockModel{
-			owner: names.NewUserTag("admin"),
-			life:  state.Alive,
-			cfg:   cfg,
-			status: status.StatusInfo{
-				Status: status.Available,
-				Since:  &time.Time{},
-			},
-			users: []*mockModelUser{{
-				userName: "admin",
-				access:   permission.AdminAccess,
-			}, {
-				userName: "add-model",
-				access:   permission.AdminAccess,
-			}, {
-
-				userName: "otheruser",
-				access:   permission.WriteAccess,
-			}},
-		},
+		controllerModel: controllerModel,
 		model: &mockModel{
 			owner: names.NewUserTag("admin"),
 			life:  state.Alive,
@@ -142,18 +145,27 @@ func (s *modelManagerSuite) SetUpTest(c *gc.C) {
 		},
 		modelConfig: coretesting.ModelConfig(c),
 	}
+	s.ctlrSt = &mockState{
+		model:           controllerModel,
+		controllerModel: controllerModel,
+		cred:            cloud.NewEmptyCredential(),
+		cloud:           dummyCloud,
+		clouds: map[names.CloudTag]cloud.Cloud{
+			names.NewCloudTag("some-cloud"): dummyCloud,
+		},
+	}
 	s.authoriser = apiservertesting.FakeAuthorizer{
 		Tag: names.NewUserTag("admin"),
 	}
 	s.pool = &mockPool{s.st}
-	api, err := modelmanager.NewModelManagerAPI(s.st, s.pool, nil, s.authoriser)
+	api, err := modelmanager.NewModelManagerAPI(s.st, s.ctlrSt, s.pool, nil, s.authoriser)
 	c.Assert(err, jc.ErrorIsNil)
 	s.api = api
 }
 
 func (s *modelManagerSuite) setAPIUser(c *gc.C, user names.UserTag) {
 	s.authoriser.Tag = user
-	mm, err := modelmanager.NewModelManagerAPI(s.st, s.pool, nil, s.authoriser)
+	mm, err := modelmanager.NewModelManagerAPI(s.st, s.ctlrSt, s.pool, nil, s.authoriser)
 	c.Assert(err, jc.ErrorIsNil)
 	s.api = mm
 }
@@ -187,7 +199,6 @@ func (s *modelManagerSuite) TestCreateModelArgs(c *gc.C) {
 		"ControllerTag",
 		"ModelUUID",
 		"ControllerTag",
-		"ControllerModel",
 		"Cloud",
 		"CloudCredential",
 		"ControllerConfig",
@@ -258,7 +269,7 @@ func (s *modelManagerSuite) TestCreateModelArgsWithCloud(c *gc.C) {
 }
 
 func (s *modelManagerSuite) TestCreateModelArgsWithCloudNotFound(c *gc.C) {
-	s.st.SetErrors(nil, errors.NotFoundf("cloud"))
+	s.st.SetErrors(errors.NotFoundf("cloud"))
 	args := params.ModelCreateArgs{
 		Name:     "foo",
 		OwnerTag: "user-admin",
@@ -326,7 +337,7 @@ func (s *modelManagerSuite) TestCreateModelNoDefaultCredentialNonAdmin(c *gc.C) 
 }
 
 func (s *modelManagerSuite) TestCreateModelUnknownCredential(c *gc.C) {
-	s.st.SetErrors(nil, nil, errors.NotFoundf("credential"))
+	s.st.SetErrors(nil, errors.NotFoundf("credential"))
 	args := params.ModelCreateArgs{
 		Name:               "foo",
 		OwnerTag:           "user-admin",
@@ -736,6 +747,7 @@ func (s *modelManagerStateSuite) setAPIUser(c *gc.C, user names.UserTag) {
 	s.authoriser.Tag = user
 	modelmanager, err := modelmanager.NewModelManagerAPI(
 		common.NewModelManagerBackend(s.State),
+		common.NewModelManagerBackend(s.State),
 		nil,
 		stateenvirons.EnvironConfigGetter{s.State},
 		s.authoriser,
@@ -748,7 +760,9 @@ func (s *modelManagerStateSuite) TestNewAPIAcceptsClient(c *gc.C) {
 	anAuthoriser := s.authoriser
 	anAuthoriser.Tag = names.NewUserTag("external@remote")
 	endPoint, err := modelmanager.NewModelManagerAPI(
-		common.NewModelManagerBackend(s.State), nil, nil, anAuthoriser,
+		common.NewModelManagerBackend(s.State),
+		common.NewModelManagerBackend(s.State),
+		nil, nil, anAuthoriser,
 	)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(endPoint, gc.NotNil)
@@ -758,7 +772,9 @@ func (s *modelManagerStateSuite) TestNewAPIRefusesNonClient(c *gc.C) {
 	anAuthoriser := s.authoriser
 	anAuthoriser.Tag = names.NewUnitTag("mysql/0")
 	endPoint, err := modelmanager.NewModelManagerAPI(
-		common.NewModelManagerBackend(s.State), nil, nil, anAuthoriser,
+		common.NewModelManagerBackend(s.State),
+		common.NewModelManagerBackend(s.State),
+		nil, nil, anAuthoriser,
 	)
 	c.Assert(endPoint, gc.IsNil)
 	c.Assert(err, gc.ErrorMatches, "permission denied")
@@ -977,6 +993,7 @@ func (s *modelManagerStateSuite) TestDestroyOwnModel(c *gc.C) {
 
 	s.modelmanager, err = modelmanager.NewModelManagerAPI(
 		common.NewModelManagerBackend(st),
+		common.NewModelManagerBackend(s.State),
 		common.NewBackendPool(pool),
 		nil, s.authoriser,
 	)
@@ -1012,6 +1029,7 @@ func (s *modelManagerStateSuite) TestAdminDestroysOtherModel(c *gc.C) {
 	s.authoriser.Tag = s.AdminUserTag(c)
 	s.modelmanager, err = modelmanager.NewModelManagerAPI(
 		common.NewModelManagerBackend(st),
+		common.NewModelManagerBackend(s.State),
 		common.NewBackendPool(pool),
 		nil, s.authoriser,
 	)
@@ -1042,7 +1060,9 @@ func (s *modelManagerStateSuite) TestDestroyModelErrors(c *gc.C) {
 	defer st.Close()
 
 	s.modelmanager, err = modelmanager.NewModelManagerAPI(
-		common.NewModelManagerBackend(st), nil, nil, s.authoriser,
+		common.NewModelManagerBackend(st),
+		common.NewModelManagerBackend(s.State),
+		nil, nil, s.authoriser,
 	)
 	c.Assert(err, jc.ErrorIsNil)
 

--- a/apiserver/facades/client/modelmanager/modelmanager_test.go
+++ b/apiserver/facades/client/modelmanager/modelmanager_test.go
@@ -205,14 +205,13 @@ func (s *modelManagerSuite) TestCreateModelArgs(c *gc.C) {
 		"ComposeNewModelConfig",
 		"NewModel",
 		"ReloadSpaces",
-		"ForModel",
+		"GetBackend",
 		"Model",
 		"LastModelConnection",
 		"LastModelConnection",
 		"LastModelConnection",
 		"AllMachines",
 		"LatestMigration",
-		"Close",
 		"Close",
 	)
 

--- a/apiserver/facades/client/usermanager/usermanager.go
+++ b/apiserver/facades/client/usermanager/usermanager.go
@@ -125,8 +125,7 @@ func (api *UserManagerAPI) RemoveUser(entities params.Entities) (params.ErrorRes
 		return deletions, errors.Trace(err)
 	}
 
-	// Get a handle on the controller model.
-	controllerModel, err := api.state.ControllerModel()
+	controllerOwner, err := api.state.ControllerOwner()
 	if err != nil {
 		return deletions, errors.Trace(err)
 	}
@@ -150,7 +149,7 @@ func (api *UserManagerAPI) RemoveUser(entities params.Entities) (params.ErrorRes
 			continue
 		}
 
-		if controllerModel.Owner().Id() == user.Id() {
+		if controllerOwner.Id() == user.Id() {
 			deletions.Results[i].Error = common.ServerError(
 				errors.Errorf("cannot delete controller owner %q", user.Name()))
 			continue

--- a/apiserver/facades/controller/migrationmaster/shim.go
+++ b/apiserver/facades/controller/migrationmaster/shim.go
@@ -15,16 +15,12 @@ import (
 
 // NewFacade exists to provide the required signature for API
 // registration, converting st to backend.
-func NewFacade(
-	st *state.State,
-	resources facade.Resources,
-	authorizer facade.Authorizer,
-) (*API, error) {
-	precheckBackend, err := migration.PrecheckShim(st)
+func NewFacade(ctx facade.Context) (*API, error) {
+	precheckBackend, err := migration.PrecheckShim(ctx.State(), ctx.StatePool())
 	if err != nil {
 		return nil, errors.Annotate(err, "creating precheck backend")
 	}
-	return NewAPI(&backendShim{st}, precheckBackend, resources, authorizer)
+	return NewAPI(&backendShim{ctx.State()}, precheckBackend, ctx.Resources(), ctx.Auth())
 }
 
 // backendShim wraps a *state.State to implement Backend. It is

--- a/apiserver/facades/controller/migrationtarget/migrationtarget.go
+++ b/apiserver/facades/controller/migrationtarget/migrationtarget.go
@@ -83,7 +83,7 @@ func (api *API) Prechecks(model params.MigrationModelInfo) error {
 	if err != nil {
 		return errors.Trace(err)
 	}
-	backend, err := migration.PrecheckShim(api.state)
+	backend, err := migration.PrecheckShim(api.state, api.pool)
 	if err != nil {
 		return errors.Annotate(err, "creating backend")
 	}

--- a/apiserver/gui.go
+++ b/apiserver/gui.go
@@ -398,7 +398,7 @@ func modelInfoFromPath(path string, st *state.State, pool *state.StatePool) (uui
 		return "", "", ""
 	}
 	user, modelName = parts[1], parts[2]
-	modelUUIDs, err := st.ModelsForUser(names.NewUserTag(user))
+	modelUUIDs, err := st.ModelUUIDsForUser(names.NewUserTag(user))
 	if err != nil {
 		return "", "", ""
 	}

--- a/apiserver/introspection.go
+++ b/apiserver/introspection.go
@@ -6,7 +6,7 @@ package apiserver
 import (
 	"net/http"
 
-	"github.com/juju/errors"
+	names "gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/params"
@@ -55,15 +55,11 @@ func (h introspectionHandler) checkAuth(r *http.Request) error {
 		return nil
 	}
 
-	controllerModel, err := st.ControllerModel()
-	if err != nil {
-		return errors.Trace(err)
-	}
 	ok, err = common.HasPermission(
 		st.UserPermission,
 		entity.Tag(),
 		permission.ReadAccess,
-		controllerModel.ModelTag(),
+		names.NewModelTag(st.ControllerModelUUID()),
 	)
 	if err != nil {
 		return err

--- a/cmd/juju/commands/upgradejuju_test.go
+++ b/cmd/juju/commands/upgradejuju_test.go
@@ -928,12 +928,8 @@ func (a *fakeUpgradeJujuAPI) patch(s *UpgradeJujuSuite) {
 }
 
 func (a *fakeUpgradeJujuAPI) ModelConfig() (map[string]interface{}, error) {
-	controllerModel, err := a.st.ControllerModel()
-	if err != nil {
-		return make(map[string]interface{}), err
-	}
 	return map[string]interface{}{
-		"uuid": controllerModel.UUID(),
+		"uuid": a.st.ControllerModelUUID(),
 	}, nil
 }
 

--- a/cmd/jujud/dumplogs/dumplogs.go
+++ b/cmd/jujud/dumplogs/dumplogs.go
@@ -121,14 +121,14 @@ func (c *dumpLogsCommand) Run(ctx *cmd.Context) error {
 	}
 	defer st0.Close()
 
-	envs, err := st0.AllModels()
+	modelUUIDs, err := st0.AllModelUUIDs()
 	if err != nil {
 		return errors.Annotate(err, "failed to look up models")
 	}
-	for _, env := range envs {
-		err := c.dumpLogsForEnv(ctx, st0, env.ModelTag())
+	for _, modelUUID := range modelUUIDs {
+		err := c.dumpLogsForEnv(ctx, st0, names.NewModelTag(modelUUID))
 		if err != nil {
-			return errors.Annotatef(err, "failed to dump logs for model %s", env.UUID())
+			return errors.Annotatef(err, "failed to dump logs for model %s", modelUUID)
 		}
 	}
 

--- a/featuretests/cmd_juju_upgrade_test.go
+++ b/featuretests/cmd_juju_upgrade_test.go
@@ -89,7 +89,7 @@ func (s *cmdUpgradeSuite) run(c *gc.C, args ...string) *cmd.Context {
 }
 
 func (s *cmdUpgradeSuite) assertHostModelAgentVersion(c *gc.C, desiredAgentVersion string) {
-	modelUUIDs, err := s.State.ModelsForUser(s.hostedModelUserTag)
+	modelUUIDs, err := s.State.ModelUUIDsForUser(s.hostedModelUserTag)
 	c.Assert(err, jc.ErrorIsNil)
 
 	var desiredModel *state.Model

--- a/featuretests/cmd_juju_upgrade_test.go
+++ b/featuretests/cmd_juju_upgrade_test.go
@@ -89,13 +89,16 @@ func (s *cmdUpgradeSuite) run(c *gc.C, args ...string) *cmd.Context {
 }
 
 func (s *cmdUpgradeSuite) assertHostModelAgentVersion(c *gc.C, desiredAgentVersion string) {
-	userModels, err := s.State.ModelsForUser(s.hostedModelUserTag)
+	modelUUIDs, err := s.State.ModelsForUser(s.hostedModelUserTag)
 	c.Assert(err, jc.ErrorIsNil)
 
-	var desiredModel *state.UserModel
-	for _, m := range userModels {
-		if m.Name() == s.hostedModel {
-			desiredModel = m
+	var desiredModel *state.Model
+	for _, modelUUID := range modelUUIDs {
+		model, release, err := s.StatePool.GetModel(modelUUID)
+		c.Assert(err, jc.ErrorIsNil)
+		defer release()
+		if model.Name() == s.hostedModel {
+			desiredModel = model
 		}
 	}
 	c.Assert(desiredModel, gc.NotNil)

--- a/juju/testing/conn.go
+++ b/juju/testing/conn.go
@@ -93,6 +93,7 @@ type JujuConnSuite struct {
 
 	ControllerConfig   controller.Config
 	State              *state.State
+	StatePool          *state.StatePool
 	IAASModel          *state.IAASModel
 	Environ            environs.Environ
 	APIState           api.Connection
@@ -396,6 +397,9 @@ func (s *JujuConnSuite) setUpConn(c *gc.C) {
 
 	s.State, err = newState(s.ControllerConfig.ControllerUUID(), environ, s.BackingState.MongoConnectionInfo())
 	c.Assert(err, jc.ErrorIsNil)
+
+	s.StatePool = state.NewStatePool(s.State)
+	s.AddCleanup(func(*gc.C) { s.StatePool.Close() })
 
 	s.IAASModel, err = s.State.IAASModel()
 	c.Assert(err, jc.ErrorIsNil)

--- a/juju/testing/conn.go
+++ b/juju/testing/conn.go
@@ -147,9 +147,9 @@ func (s *JujuConnSuite) Reset(c *gc.C) {
 }
 
 func (s *JujuConnSuite) AdminUserTag(c *gc.C) names.UserTag {
-	model, err := s.State.ControllerModel()
+	owner, err := s.State.ControllerOwner()
 	c.Assert(err, jc.ErrorIsNil)
-	return model.Owner()
+	return owner
 }
 
 func (s *JujuConnSuite) MongoInfo(c *gc.C) *mongo.MongoInfo {

--- a/migration/precheck_shim.go
+++ b/migration/precheck_shim.go
@@ -12,13 +12,14 @@ import (
 )
 
 // PrecheckShim wraps a *state.State to implement PrecheckBackend.
-func PrecheckShim(st *state.State) (PrecheckBackend, error) {
+func PrecheckShim(st *state.State, pool *state.StatePool) (PrecheckBackend, error) {
 	rSt, err := st.Resources()
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
 	return &precheckShim{
 		State:       st,
+		pool:        pool,
 		resourcesSt: rSt,
 	}, nil
 }
@@ -27,6 +28,7 @@ func PrecheckShim(st *state.State) (PrecheckBackend, error) {
 // inspection.
 type precheckShim struct {
 	*state.State
+	pool        *state.StatePool
 	resourcesSt state.Resources
 }
 
@@ -41,12 +43,21 @@ func (s *precheckShim) Model() (PrecheckModel, error) {
 
 // AllModels implements PrecheckBackend.
 func (s *precheckShim) AllModels() ([]PrecheckModel, error) {
-	models, err := s.State.AllModels()
+	modelUUIDs, err := s.State.AllModelUUIDs()
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	out := make([]PrecheckModel, 0, len(models))
-	for _, model := range models {
+	out := make([]PrecheckModel, 0, len(modelUUIDs))
+	for _, modelUUID := range modelUUIDs {
+		st, release, err := s.pool.Get(modelUUID)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		defer release()
+		model, err := st.Model()
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
 		out = append(out, model)
 	}
 	return out, nil

--- a/migration/precheck_shim.go
+++ b/migration/precheck_shim.go
@@ -107,11 +107,7 @@ func (s *precheckShim) ListPendingResources(app string) ([]resource.Resource, er
 
 // ControllerBackend implements PrecheckBackend.
 func (s *precheckShim) ControllerBackend() (PrecheckBackendCloser, error) {
-	model, err := s.State.ControllerModel()
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	st, err := s.State.ForModel(model.ModelTag())
+	st, err := s.State.ForModel(s.State.ControllerModelTag())
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/state/allwatcher.go
+++ b/state/allwatcher.go
@@ -1330,20 +1330,20 @@ func (b *allModelWatcherStateBacking) Unwatch(in chan<- watcher.Change) {
 
 // GetAll fetches all items that we want to watch from the state.
 func (b *allModelWatcherStateBacking) GetAll(all *multiwatcherStore) error {
-	models, err := b.st.AllModels()
+	modelUUIDs, err := b.st.AllModelUUIDs()
 	if err != nil {
 		return errors.Annotate(err, "error loading models")
 	}
-	for _, m := range models {
-		if err := b.loadAllWatcherEntitiesForModel(m, all); err != nil {
+	for _, modelUUID := range modelUUIDs {
+		if err := b.loadAllWatcherEntitiesForModel(modelUUID, all); err != nil {
 			return errors.Trace(err)
 		}
 	}
 	return nil
 }
 
-func (b *allModelWatcherStateBacking) loadAllWatcherEntitiesForModel(m *Model, all *multiwatcherStore) error {
-	st, releaser, err := b.stPool.Get(m.UUID())
+func (b *allModelWatcherStateBacking) loadAllWatcherEntitiesForModel(modelUUID string, all *multiwatcherStore) error {
+	st, releaser, err := b.stPool.Get(modelUUID)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -1351,7 +1351,7 @@ func (b *allModelWatcherStateBacking) loadAllWatcherEntitiesForModel(m *Model, a
 
 	err = loadAllWatcherEntities(st, b.collectionByName, all)
 	if err != nil {
-		return errors.Annotatef(err, "error loading entities for model %v", m.UUID())
+		return errors.Annotatef(err, "error loading entities for model %v", modelUUID)
 	}
 	return nil
 }

--- a/state/binarystorage.go
+++ b/state/binarystorage.go
@@ -23,13 +23,8 @@ func (st *State) ToolsStorage() (binarystorage.StorageCloser, error) {
 	}
 	// This is a hosted model. Hosted models have their own tools
 	// catalogue, which we combine with the controller's.
-	controllerModel, err := st.ControllerModel()
-	if err != nil {
-		modelStorage.Close()
-		return nil, errors.Trace(err)
-	}
 	controllerStorage := newBinaryStorageCloser(
-		st.database, toolsmetadataC, controllerModel.UUID(),
+		st.database, toolsmetadataC, st.ControllerModelUUID(),
 	)
 	storage, err := binarystorage.NewLayeredStorage(modelStorage, controllerStorage)
 	if err != nil {
@@ -46,11 +41,7 @@ func (st *State) ToolsStorage() (binarystorage.StorageCloser, error) {
 // GUIStorage returns a new binarystorage.StorageCloser that stores GUI archive
 // metadata in the "juju" database "guimetadata" collection.
 func (st *State) GUIStorage() (binarystorage.StorageCloser, error) {
-	controllerModel, err := st.ControllerModel()
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	return newBinaryStorageCloser(st.database, guimetadataC, controllerModel.UUID()), nil
+	return newBinaryStorageCloser(st.database, guimetadataC, st.ControllerModelUUID()), nil
 }
 
 func newBinaryStorageCloser(db Database, collectionName, uuid string) binarystorage.StorageCloser {

--- a/state/binarystorage_test.go
+++ b/state/binarystorage_test.go
@@ -62,9 +62,9 @@ func testAgentTools(c *gc.C, obj tooler, agent string) {
 type binaryStorageSuite struct {
 	ConnSuite
 
-	controllerUUID string
-	modelUUID      string
-	st             *state.State
+	controllerModelUUID string
+	modelUUID           string
+	st                  *state.State
 }
 
 var _ = gc.Suite(&binaryStorageSuite{})
@@ -72,10 +72,7 @@ var _ = gc.Suite(&binaryStorageSuite{})
 func (s *binaryStorageSuite) SetUpTest(c *gc.C) {
 	s.ConnSuite.SetUpTest(c)
 
-	// Store the controller UUID.
-	model, err := s.State.ControllerModel()
-	c.Assert(err, jc.ErrorIsNil)
-	s.controllerUUID = model.UUID()
+	s.controllerModelUUID = s.State.ControllerModelUUID()
 
 	// Create a new model and store its UUID.
 	s.modelUUID = utils.MustNewUUID().String()
@@ -83,6 +80,7 @@ func (s *binaryStorageSuite) SetUpTest(c *gc.C) {
 		"name": "new-model",
 		"uuid": s.modelUUID,
 	})
+	var err error
 	_, s.st, err = s.State.NewModel(state.ModelArgs{
 		CloudName:   "dummy",
 		CloudRegion: "dummy-region",
@@ -115,7 +113,7 @@ func (s *binaryStorageSuite) TestGUIArchiveStorage(c *gc.C) {
 }
 
 func (s *binaryStorageSuite) TestGUIArchiveStorageParams(c *gc.C) {
-	s.testStorageParams(c, "guimetadata", []string{s.controllerUUID}, s.st.GUIStorage)
+	s.testStorageParams(c, "guimetadata", []string{s.controllerModelUUID}, s.st.GUIStorage)
 }
 
 func (s *binaryStorageSuite) testStorage(c *gc.C, collName string, openStorage storageOpener) {

--- a/state/controller_test.go
+++ b/state/controller_test.go
@@ -52,9 +52,7 @@ func (s *ControllerSuite) TestNewState(c *gc.C) {
 func (s *ControllerSuite) TestControllerConfig(c *gc.C) {
 	cfg, err := s.State.ControllerConfig()
 	c.Assert(err, jc.ErrorIsNil)
-	m, err := s.State.ControllerModel()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(cfg["controller-uuid"], gc.Equals, m.ControllerUUID())
+	c.Assert(cfg["controller-uuid"], gc.Equals, s.State.ControllerUUID())
 }
 
 func (s *ControllerSuite) TestPing(c *gc.C) {

--- a/state/life.go
+++ b/state/life.go
@@ -68,8 +68,7 @@ func isAlive(mb modelBackend, collName string, id interface{}) (bool, error) {
 }
 
 func isAliveWithSession(coll mongo.Collection, id interface{}) (bool, error) {
-	n, err := coll.Find(bson.D{{"_id", id}, {"life", Alive}}).Count()
-	return n == 1, err
+	return checkLifeWithSession(coll, id, bson.DocElem{"life", Alive})
 }
 
 func isNotDead(mb modelBackend, collName string, id interface{}) (bool, error) {
@@ -79,6 +78,16 @@ func isNotDead(mb modelBackend, collName string, id interface{}) (bool, error) {
 }
 
 func isNotDeadWithSession(coll mongo.Collection, id interface{}) (bool, error) {
-	n, err := coll.Find(bson.D{{"_id", id}, {"life", bson.D{{"$ne", Dead}}}}).Count()
+	return checkLifeWithSession(coll, id, bson.DocElem{"life", bson.D{{"$ne", Dead}}})
+}
+
+func isDead(mb modelBackend, collName string, id interface{}) (bool, error) {
+	coll, closer := mb.db().GetCollection(collName)
+	defer closer()
+	return checkLifeWithSession(coll, id, bson.DocElem{"life", Dead})
+}
+
+func checkLifeWithSession(coll mongo.Collection, id interface{}, sel bson.DocElem) (bool, error) {
+	n, err := coll.Find(bson.D{{"_id", id}, sel}).Count()
 	return n == 1, err
 }

--- a/state/model.go
+++ b/state/model.go
@@ -165,19 +165,6 @@ type modelEntityRefsDoc struct {
 	Filesystems []string `bson:"filesystems"`
 }
 
-// ControllerModel returns the model that was bootstrapped.
-// This is the only model that can have controller machines.
-// The owner of this model is also considered "special", in that
-// they are the only user that is able to create other users (until we
-// have more fine grained permissions), and they cannot be disabled.
-func (st *State) ControllerModel() (*Model, error) {
-	ssinfo, err := st.ControllerInfo()
-	if err != nil {
-		return nil, errors.Annotate(err, "could not get controller info")
-	}
-	return st.GetModel(ssinfo.ModelTag)
-}
-
 // Model returns the model entity.
 func (st *State) Model() (*Model, error) {
 	return st.GetModel(st.modelTag)

--- a/state/model.go
+++ b/state/model.go
@@ -182,6 +182,7 @@ func (st *State) GetModel(tag names.ModelTag) (*Model, error) {
 }
 
 // AllModelUUIDs returns the UUIDs for all models in the controller.
+// Results are sorted by (name, owner).
 func (st *State) AllModelUUIDs() ([]string, error) {
 	models, closer := st.db().GetCollection(modelsC)
 	defer closer()

--- a/state/model_test.go
+++ b/state/model_test.go
@@ -296,38 +296,6 @@ func (s *ModelSuite) TestMeterStatus(c *gc.C) {
 	c.Assert(ms.Info, gc.Equals, "info setting 2")
 }
 
-func (s *ModelSuite) TestControllerModel(c *gc.C) {
-	model, err := s.State.ControllerModel()
-	c.Assert(err, jc.ErrorIsNil)
-
-	expectedTag := names.NewModelTag(model.UUID())
-	c.Assert(model.Tag(), gc.Equals, expectedTag)
-	c.Assert(model.ControllerTag(), gc.Equals, s.State.ControllerTag())
-	c.Assert(model.Name(), gc.Equals, "testenv")
-	c.Assert(model.Owner(), gc.Equals, s.Owner)
-	c.Assert(model.Life(), gc.Equals, state.Alive)
-}
-
-func (s *ModelSuite) TestControllerModelAccessibleFromOtherModels(c *gc.C) {
-	cfg, _ := s.createTestModelConfig(c)
-	_, st, err := s.State.NewModel(state.ModelArgs{
-		CloudName:   "dummy",
-		CloudRegion: "dummy-region",
-		Config:      cfg,
-		Owner:       names.NewUserTag("test@remote"),
-		StorageProviderRegistry: storage.StaticProviderRegistry{},
-	})
-	c.Assert(err, jc.ErrorIsNil)
-	defer st.Close()
-
-	model, err := st.ControllerModel()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(model.Tag(), gc.Equals, s.modelTag)
-	c.Assert(model.Name(), gc.Equals, "testenv")
-	c.Assert(model.Owner(), gc.Equals, s.Owner)
-	c.Assert(model.Life(), gc.Equals, state.Alive)
-}
-
 func (s *ModelSuite) TestConfigForControllerModel(c *gc.C) {
 	otherState := s.Factory.MakeModel(c, &factory.ModelParams{Name: "other"})
 	defer otherState.Close()

--- a/state/model_test.go
+++ b/state/model_test.go
@@ -1034,22 +1034,19 @@ func assertObtainedUsersMatchExpectedUsers(c *gc.C, obtainedUsers, expectedUsers
 	}
 }
 
-func (s *ModelSuite) TestAllModels(c *gc.C) {
-	s.Factory.MakeModel(c, &factory.ModelParams{
-		Name: "test", Owner: names.NewUserTag("bob@remote")}).Close()
-	s.Factory.MakeModel(c, &factory.ModelParams{
-		Name: "test", Owner: names.NewUserTag("mary@remote")}).Close()
-	envs, err := s.State.AllModels()
+func (s *ModelSuite) TestAllModelUUIDs(c *gc.C) {
+	st1 := s.Factory.MakeModel(c, nil)
+	defer st1.Close()
+
+	st2 := s.Factory.MakeModel(c, nil)
+	defer st2.Close()
+
+	obtained, err := s.State.AllModelUUIDs()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(envs, gc.HasLen, 3)
-	var obtained []string
-	for _, model := range envs {
-		obtained = append(obtained, fmt.Sprintf("%s/%s", model.Owner().Id(), model.Name()))
-	}
 	expected := []string{
-		"bob@remote/test",
-		"mary@remote/test",
-		"test-admin/testenv",
+		s.State.ModelUUID(),
+		st1.ModelUUID(),
+		st2.ModelUUID(),
 	}
 	c.Assert(obtained, jc.DeepEquals, expected)
 }

--- a/state/modelmigration.go
+++ b/state/modelmigration.go
@@ -739,11 +739,7 @@ func jsonToMacaroons(raw string) ([]macaroon.Slice, error) {
 }
 
 func checkTargetController(st *State, targetControllerTag names.ControllerTag) error {
-	currentController, err := st.ControllerModel()
-	if err != nil {
-		return errors.Annotate(err, "failed to load existing controller model")
-	}
-	if targetControllerTag == currentController.ControllerTag() {
+	if targetControllerTag.Id() == st.ControllerUUID() {
 		return errors.New("model already attached to target controller")
 	}
 	return nil

--- a/state/modeluser.go
+++ b/state/modeluser.go
@@ -170,10 +170,10 @@ func (st *State) removeModelUser(user names.UserTag) error {
 	return nil
 }
 
-// ModelsForUser returns a list of models that the user
-// is able to access.
+// ModelUUIDsForUser returns a list of models that the user is able to
+// access.
 // Results are sorted by (name, owner).
-func (st *State) ModelsForUser(user names.UserTag) ([]string, error) {
+func (st *State) ModelUUIDsForUser(user names.UserTag) ([]string, error) {
 	// Consider the controller permissions overriding Model permission, for
 	// this case the only relevant one is superuser.
 	// The mgo query below wont work for superuser case because it needs at

--- a/state/modeluser.go
+++ b/state/modeluser.go
@@ -212,7 +212,6 @@ func (st *State) ModelsForUser(user names.UserTag) ([]string, error) {
 	defer close()
 	query := modelsColl.Find(bson.M{
 		"_id":            bson.M{"$in": modelUUIDs},
-		"life":           bson.M{"$ne": Dead},
 		"migration-mode": bson.M{"$ne": MigrationModeImporting},
 	}).Sort("name", "owner").Select(bson.M{"_id": 1})
 

--- a/state/modeluser.go
+++ b/state/modeluser.go
@@ -170,85 +170,62 @@ func (st *State) removeModelUser(user names.UserTag) error {
 	return nil
 }
 
-// UserModel contains information about an model that a
-// user has access to.
-type UserModel struct {
-	*Model
-	User names.UserTag
-}
-
-// LastConnection returns the last time the user has connected to the
-// model.
-func (e *UserModel) LastConnection() (time.Time, error) {
-	db, dbCloser := e.modelDatabase()
-	defer dbCloser()
-	lastConnections, lastConnCloser := db.GetRawCollection(modelUserLastConnectionC)
-	defer lastConnCloser()
-
-	lastConnDoc := modelUserLastConnectionDoc{}
-	id := ensureModelUUID(e.ModelTag().Id(), strings.ToLower(e.User.Id()))
-	err := lastConnections.FindId(id).Select(bson.D{{"last-connection", 1}}).One(&lastConnDoc)
-	if (err != nil && err != mgo.ErrNotFound) || lastConnDoc.LastConnection.IsZero() {
-		return time.Time{}, errors.Trace(NeverConnectedError(e.User.Id()))
-	}
-
-	return lastConnDoc.LastConnection, nil
-}
-
-// allUserModels returns a list of all models with the user they belong to.
-func (st *State) allUserModels() ([]*UserModel, error) {
-	models, err := st.AllModels()
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	var result []*UserModel
-	for _, model := range models {
-		result = append(result, &UserModel{Model: model, User: model.Owner()})
-	}
-	return result, nil
-}
-
 // ModelsForUser returns a list of models that the user
 // is able to access.
-func (st *State) ModelsForUser(user names.UserTag) ([]*UserModel, error) {
+func (st *State) ModelsForUser(user names.UserTag) ([]string, error) {
 	// Consider the controller permissions overriding Model permission, for
 	// this case the only relevant one is superuser.
 	// The mgo query below wont work for superuser case because it needs at
 	// least one model user per model.
 	access, err := st.UserAccess(user, st.controllerTag)
-	if err == nil && access.Access == permission.SuperuserAccess {
-		return st.allUserModels()
-	}
 	if err != nil && !errors.IsNotFound(err) {
 		return nil, errors.Trace(err)
 	}
-	// Since there are no groups at this stage, the simplest way to get all
-	// the models that a particular user can see is to look through the
-	// model user collection. A raw collection is required to support
-	// queries across multiple models.
-	modelUsers, userCloser := st.db().GetRawCollection(modelUsersC)
-	defer userCloser()
 
-	var userSlice []userAccessDoc
-	err = modelUsers.Find(bson.D{{"user", user.Id()}}).Select(bson.D{{"object-uuid", 1}, {"_id", 1}}).All(&userSlice)
-	if err != nil {
-		return nil, err
-	}
-
-	var result []*UserModel
-	for _, doc := range userSlice {
-		modelTag := names.NewModelTag(doc.ObjectUUID)
-		model, err := st.GetModel(modelTag)
+	var modelUUIDs []string
+	if access.Access == permission.SuperuserAccess {
+		var err error
+		modelUUIDs, err = st.AllModelUUIDs()
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
+	} else {
+		// Since there are no groups at this stage, the simplest way to get all
+		// the models that a particular user can see is to look through the
+		// model user collection. A raw collection is required to support
+		// queries across multiple models.
+		modelUsers, userCloser := st.db().GetRawCollection(modelUsersC)
+		defer userCloser()
 
-		if model.Life() != Dead && model.MigrationMode() != MigrationModeImporting {
-			result = append(result, &UserModel{Model: model, User: user})
+		var userSlice []userAccessDoc
+		err := modelUsers.Find(bson.D{{"user", user.Id()}}).Select(bson.D{{"object-uuid", 1}, {"_id", 1}}).All(&userSlice)
+		if err != nil {
+			return nil, err
+		}
+		for _, doc := range userSlice {
+			modelUUIDs = append(modelUUIDs, doc.ObjectUUID)
 		}
 	}
 
-	return result, nil
+	modelsColl, close := st.db().GetCollection(modelsC)
+	defer close()
+	query := modelsColl.Find(bson.M{
+		"_id":            bson.M{"$in": modelUUIDs},
+		"life":           bson.M{"$ne": Dead},
+		"migration-mode": bson.M{"$ne": MigrationModeImporting},
+	}).Select(bson.M{"_id": 1})
+
+	var docs []bson.M
+	err = query.All(&docs)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	var out []string
+	for _, doc := range docs {
+		out = append(out, doc["_id"].(string))
+	}
+	return out, nil
 }
 
 // IsControllerAdmin returns true if the user specified has Super User Access.

--- a/state/modeluser_test.go
+++ b/state/modeluser_test.go
@@ -392,20 +392,6 @@ func (s *ModelUserSuite) TestModelsForUser(c *gc.C) {
 	c.Assert(st.Close(), jc.ErrorIsNil)
 }
 
-func (s *ModelUserSuite) TestDeadModelsForUser(c *gc.C) {
-	user := s.Factory.MakeUser(c, nil)
-	models, err := s.State.ModelsForUser(user.UserTag())
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(models, jc.DeepEquals, []string{s.State.ModelUUID()})
-
-	err = state.SetModelLifeDead(s.State, models[0])
-	c.Assert(err, jc.ErrorIsNil)
-
-	models, err = s.State.ModelsForUser(user.UserTag())
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(models, gc.HasLen, 0)
-}
-
 func (s *ModelUserSuite) TestImportingModelsForUser(c *gc.C) {
 	user := s.Factory.MakeUser(c, nil)
 	models, err := s.State.ModelsForUser(user.UserTag())

--- a/state/modeluser_test.go
+++ b/state/modeluser_test.go
@@ -361,23 +361,23 @@ func (s *ModelUserSuite) TestUpdateLastConnectionTwoModelUsers(c *gc.C) {
 	c.Assert(when.After(now) || when.Equal(now), jc.IsTrue)
 }
 
-func (s *ModelUserSuite) TestModelsForUserNone(c *gc.C) {
+func (s *ModelUserSuite) TestModelUUIDsForUserNone(c *gc.C) {
 	tag := names.NewUserTag("non-existent@remote")
-	models, err := s.State.ModelsForUser(tag)
+	models, err := s.State.ModelUUIDsForUser(tag)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(models, gc.HasLen, 0)
 }
 
-func (s *ModelUserSuite) TestModelsForUserNewLocalUser(c *gc.C) {
+func (s *ModelUserSuite) TestModelUUIDsForUserNewLocalUser(c *gc.C) {
 	user := s.Factory.MakeUser(c, &factory.UserParams{NoModelUser: true})
-	models, err := s.State.ModelsForUser(user.UserTag())
+	models, err := s.State.ModelUUIDsForUser(user.UserTag())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(models, gc.HasLen, 0)
 }
 
-func (s *ModelUserSuite) TestModelsForUser(c *gc.C) {
+func (s *ModelUserSuite) TestModelUUIDsForUser(c *gc.C) {
 	user := s.Factory.MakeUser(c, nil)
-	models, err := s.State.ModelsForUser(user.UserTag())
+	models, err := s.State.ModelUUIDsForUser(user.UserTag())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(models, jc.DeepEquals, []string{s.State.ModelUUID()})
 
@@ -392,9 +392,9 @@ func (s *ModelUserSuite) TestModelsForUser(c *gc.C) {
 	c.Assert(st.Close(), jc.ErrorIsNil)
 }
 
-func (s *ModelUserSuite) TestImportingModelsForUser(c *gc.C) {
+func (s *ModelUserSuite) TestImportingModelUUIDsForUser(c *gc.C) {
 	user := s.Factory.MakeUser(c, nil)
-	models, err := s.State.ModelsForUser(user.UserTag())
+	models, err := s.State.ModelUUIDsForUser(user.UserTag())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(models, jc.DeepEquals, []string{s.State.ModelUUID()})
 
@@ -403,30 +403,30 @@ func (s *ModelUserSuite) TestImportingModelsForUser(c *gc.C) {
 	err = model.SetMigrationMode(state.MigrationModeImporting)
 	c.Assert(err, jc.ErrorIsNil)
 
-	models, err = s.State.ModelsForUser(user.UserTag())
+	models, err = s.State.ModelUUIDsForUser(user.UserTag())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(models, gc.HasLen, 0)
 }
 
-func (s *ModelUserSuite) TestModelsForUserModelOwner(c *gc.C) {
+func (s *ModelUserSuite) TestModelUUIDsForUserModelOwner(c *gc.C) {
 	owner := names.NewUserTag("external@remote")
 	model := s.newModelWithOwner(c, owner)
 
-	models, err := s.State.ModelsForUser(owner)
+	models, err := s.State.ModelUUIDsForUser(owner)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(models, jc.DeepEquals, []string{model.UUID()})
 }
 
-func (s *ModelUserSuite) TestModelsForUserOfNewModel(c *gc.C) {
+func (s *ModelUserSuite) TestModelUUIDsForUserOfNewModel(c *gc.C) {
 	userTag := names.NewUserTag("external@remote")
 	model := s.newModelWithUser(c, userTag)
 
-	models, err := s.State.ModelsForUser(userTag)
+	models, err := s.State.ModelUUIDsForUser(userTag)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(models, jc.DeepEquals, []string{model.UUID()})
 }
 
-func (s *ModelUserSuite) TestModelsForUserMultiple(c *gc.C) {
+func (s *ModelUserSuite) TestModelUUIDsForUserMultiple(c *gc.C) {
 	userTag := names.NewUserTag("external@remote")
 	expected := []string{
 		s.newModelWithUser(c, userTag).UUID(),
@@ -436,7 +436,7 @@ func (s *ModelUserSuite) TestModelsForUserMultiple(c *gc.C) {
 		s.newModelWithOwner(c, userTag).UUID(),
 	}
 
-	models, err := s.State.ModelsForUser(userTag)
+	models, err := s.State.ModelUUIDsForUser(userTag)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(models, jc.SameContents, expected)
 }

--- a/state/modeluser_test.go
+++ b/state/modeluser_test.go
@@ -5,7 +5,6 @@ package state_test
 
 import (
 	"fmt"
-	"sort"
 
 	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
@@ -380,12 +379,14 @@ func (s *ModelUserSuite) TestModelsForUser(c *gc.C) {
 	user := s.Factory.MakeUser(c, nil)
 	models, err := s.State.ModelsForUser(user.UserTag())
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(models, gc.HasLen, 1)
-	c.Assert(models[0].UUID(), gc.Equals, s.State.ModelUUID())
-	st, err := s.State.ForModel(models[0].ModelTag())
+	c.Assert(models, jc.DeepEquals, []string{s.State.ModelUUID()})
+
+	modelTag := names.NewModelTag(models[0])
+	st, err := s.State.ForModel(modelTag)
 	c.Assert(err, jc.ErrorIsNil)
-	modelUser, err := s.State.UserAccess(user.UserTag(), models[0].ModelTag())
-	when, err := st.LastModelConnection(modelUser.UserTag)
+
+	access, err := s.State.UserAccess(user.UserTag(), modelTag)
+	when, err := st.LastModelConnection(access.UserTag)
 	c.Assert(err, jc.Satisfies, state.IsNeverConnectedError)
 	c.Assert(when.IsZero(), jc.IsTrue)
 	c.Assert(st.Close(), jc.ErrorIsNil)
@@ -395,11 +396,11 @@ func (s *ModelUserSuite) TestDeadModelsForUser(c *gc.C) {
 	user := s.Factory.MakeUser(c, nil)
 	models, err := s.State.ModelsForUser(user.UserTag())
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(models, gc.HasLen, 1)
-	c.Assert(models[0].UUID(), gc.Equals, s.State.ModelUUID())
+	c.Assert(models, jc.DeepEquals, []string{s.State.ModelUUID()})
 
-	err = state.SetModelLifeDead(s.State, models[0].UUID())
+	err = state.SetModelLifeDead(s.State, models[0])
 	c.Assert(err, jc.ErrorIsNil)
+
 	models, err = s.State.ModelsForUser(user.UserTag())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(models, gc.HasLen, 0)
@@ -409,95 +410,49 @@ func (s *ModelUserSuite) TestImportingModelsForUser(c *gc.C) {
 	user := s.Factory.MakeUser(c, nil)
 	models, err := s.State.ModelsForUser(user.UserTag())
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(models, gc.HasLen, 1)
-	c.Assert(models[0].UUID(), gc.Equals, s.State.ModelUUID())
+	c.Assert(models, jc.DeepEquals, []string{s.State.ModelUUID()})
 
-	err = models[0].SetMigrationMode(state.MigrationModeImporting)
+	model, err := s.State.Model()
 	c.Assert(err, jc.ErrorIsNil)
+	err = model.SetMigrationMode(state.MigrationModeImporting)
+	c.Assert(err, jc.ErrorIsNil)
+
 	models, err = s.State.ModelsForUser(user.UserTag())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(models, gc.HasLen, 0)
 }
 
-func (s *ModelUserSuite) newEnvWithOwner(c *gc.C, name string, owner names.UserTag) *state.Model {
-	// Don't use the factory to call MakeModel because it may at some
-	// time in the future be modified to do additional things.  Instead call
-	// the state method directly to create an model to make sure that
-	// the owner is able to access the model.
-	uuid, err := utils.NewUUID()
-	c.Assert(err, jc.ErrorIsNil)
-	cfg := testing.CustomModelConfig(c, testing.Attrs{
-		"name": name,
-		"uuid": uuid.String(),
-	})
-	model, st, err := s.State.NewModel(state.ModelArgs{
-		CloudName: "dummy", CloudRegion: "dummy-region", Config: cfg, Owner: owner,
-		StorageProviderRegistry: storage.StaticProviderRegistry{},
-	})
-	c.Assert(err, jc.ErrorIsNil)
-	defer st.Close()
-	return model
-}
-
-func (s *ModelUserSuite) TestModelsForUserEnvOwner(c *gc.C) {
+func (s *ModelUserSuite) TestModelsForUserModelOwner(c *gc.C) {
 	owner := names.NewUserTag("external@remote")
-	model := s.newEnvWithOwner(c, "test-model", owner)
+	model := s.newModelWithOwner(c, owner)
 
 	models, err := s.State.ModelsForUser(owner)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(models, gc.HasLen, 1)
-	s.checkSameModel(c, models[0].Model, model)
+	c.Assert(models, jc.DeepEquals, []string{model.UUID()})
 }
 
-func (s *ModelUserSuite) checkSameModel(c *gc.C, env1, env2 *state.Model) {
-	c.Check(env1.Name(), gc.Equals, env2.Name())
-	c.Check(env1.UUID(), gc.Equals, env2.UUID())
-}
-
-func (s *ModelUserSuite) newEnvWithUser(c *gc.C, name string, user names.UserTag) *state.Model {
-	envState := s.Factory.MakeModel(c, &factory.ModelParams{Name: name})
-	defer envState.Close()
-	newEnv, err := envState.Model()
-	c.Assert(err, jc.ErrorIsNil)
-
-	_, err = envState.AddModelUser(
-		envState.ModelUUID(),
-		state.UserAccessSpec{
-			User: user, CreatedBy: newEnv.Owner(),
-			Access: permission.ReadAccess,
-		})
-	c.Assert(err, jc.ErrorIsNil)
-	return newEnv
-}
-
-func (s *ModelUserSuite) TestModelsForUserOfNewEnv(c *gc.C) {
+func (s *ModelUserSuite) TestModelsForUserOfNewModel(c *gc.C) {
 	userTag := names.NewUserTag("external@remote")
-	model := s.newEnvWithUser(c, "test-model", userTag)
+	model := s.newModelWithUser(c, userTag)
 
 	models, err := s.State.ModelsForUser(userTag)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(models, gc.HasLen, 1)
-	s.checkSameModel(c, models[0].Model, model)
+	c.Assert(models, jc.DeepEquals, []string{model.UUID()})
 }
 
 func (s *ModelUserSuite) TestModelsForUserMultiple(c *gc.C) {
 	userTag := names.NewUserTag("external@remote")
-	expected := []*state.Model{
-		s.newEnvWithUser(c, "user1", userTag),
-		s.newEnvWithUser(c, "user2", userTag),
-		s.newEnvWithUser(c, "user3", userTag),
-		s.newEnvWithOwner(c, "owner1", userTag),
-		s.newEnvWithOwner(c, "owner2", userTag),
+	expected := []string{
+		s.newModelWithUser(c, userTag).UUID(),
+		s.newModelWithUser(c, userTag).UUID(),
+		s.newModelWithUser(c, userTag).UUID(),
+		s.newModelWithOwner(c, userTag).UUID(),
+		s.newModelWithOwner(c, userTag).UUID(),
 	}
-	sort.Sort(UUIDOrder(expected))
 
 	models, err := s.State.ModelsForUser(userTag)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(models, gc.HasLen, len(expected))
-	sort.Sort(userUUIDOrder(models))
-	for i := range expected {
-		s.checkSameModel(c, models[i].Model, expected[i])
-	}
+	c.Assert(models, jc.SameContents, expected)
 }
 
 func (s *ModelUserSuite) TestIsControllerAdmin(c *gc.C) {
@@ -536,16 +491,40 @@ func (s *ModelUserSuite) TestIsControllerAdminFromOtherState(c *gc.C) {
 	c.Assert(isAdmin, jc.IsTrue)
 }
 
-// UUIDOrder is used to sort the models into a stable order
-type UUIDOrder []*state.Model
+func (s *ModelUserSuite) newModelWithOwner(c *gc.C, owner names.UserTag) *state.Model {
+	// Don't use the factory to call MakeModel because it may at some
+	// time in the future be modified to do additional things.  Instead call
+	// the state method directly to create an model to make sure that
+	// the owner is able to access the model.
+	uuid, err := utils.NewUUID()
+	c.Assert(err, jc.ErrorIsNil)
+	uuidStr := uuid.String()
 
-func (a UUIDOrder) Len() int           { return len(a) }
-func (a UUIDOrder) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
-func (a UUIDOrder) Less(i, j int) bool { return a[i].UUID() < a[j].UUID() }
+	cfg := testing.CustomModelConfig(c, testing.Attrs{
+		"name": uuidStr[:8],
+		"uuid": uuidStr,
+	})
+	model, st, err := s.State.NewModel(state.ModelArgs{
+		CloudName: "dummy", CloudRegion: "dummy-region", Config: cfg, Owner: owner,
+		StorageProviderRegistry: storage.StaticProviderRegistry{},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	defer st.Close()
+	return model
+}
 
-// userUUIDOrder is used to sort the UserModels into a stable order
-type userUUIDOrder []*state.UserModel
+func (s *ModelUserSuite) newModelWithUser(c *gc.C, user names.UserTag) *state.Model {
+	st := s.Factory.MakeModel(c, nil)
+	defer st.Close()
+	newEnv, err := st.Model()
+	c.Assert(err, jc.ErrorIsNil)
 
-func (a userUUIDOrder) Len() int           { return len(a) }
-func (a userUUIDOrder) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
-func (a userUUIDOrder) Less(i, j int) bool { return a[i].UUID() < a[j].UUID() }
+	_, err = st.AddModelUser(
+		st.ModelUUID(),
+		state.UserAccessSpec{
+			User: user, CreatedBy: newEnv.Owner(),
+			Access: permission.ReadAccess,
+		})
+	c.Assert(err, jc.ErrorIsNil)
+	return newEnv
+}

--- a/state/pool.go
+++ b/state/pool.go
@@ -108,6 +108,22 @@ func (p *StatePool) Get(modelUUID string) (*State, StatePoolReleaser, error) {
 	return st, releaser, nil
 }
 
+// GetModel is a convenience method for getting a Model for a State.
+func (p *StatePool) GetModel(modelUUID string) (*Model, StatePoolReleaser, error) {
+	st, release, err := p.Get(modelUUID)
+	if err != nil {
+		return nil, nil, errors.Trace(err)
+	}
+
+	model, err := st.Model()
+	if err != nil {
+		release()
+		return nil, nil, errors.Trace(err)
+	}
+
+	return model, release, nil
+}
+
 // release indicates that the client has finished using the State. If the
 // state has been marked for removal, it will be closed and removed
 // when the final Release is done; if there are no references, it will be

--- a/state/state.go
+++ b/state/state.go
@@ -786,14 +786,6 @@ func (st *State) AllMachines() ([]*Machine, error) {
 	return st.allMachines(machinesCollection)
 }
 
-// AllMachinesFor returns all machines for the model represented
-// by the given modeluuid
-func (st *State) AllMachinesFor(modelUUID string) ([]*Machine, error) {
-	machinesCollection, closer := st.db().GetCollectionFor(modelUUID, machinesC)
-	defer closer()
-	return st.allMachines(machinesCollection)
-}
-
 type machineDocSlice []machineDoc
 
 func (ms machineDocSlice) Len() int      { return len(ms) }

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -112,6 +112,20 @@ func (s *StateSuite) TestIsController(c *gc.C) {
 	c.Assert(st2.IsController(), jc.IsFalse)
 }
 
+func (s *StateSuite) TestControllerOwner(c *gc.C) {
+	owner, err := s.State.ControllerOwner()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(owner, gc.Equals, s.Owner)
+
+	// Check that other models return the same controller owner.
+	otherSt := s.Factory.MakeModel(c, nil)
+	defer otherSt.Close()
+
+	owner2, err := otherSt.ControllerOwner()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(owner2, gc.Equals, s.Owner)
+}
+
 func (s *StateSuite) TestUserModelNameIndex(c *gc.C) {
 	index := state.UserModelNameIndex("BoB", "testing")
 	c.Assert(index, gc.Equals, "bob:testing")

--- a/state/undertaker.go
+++ b/state/undertaker.go
@@ -25,12 +25,16 @@ func (st *State) ProcessDyingModel() (err error) {
 		}
 
 		if st.IsController() {
-			models, err := st.AllModels()
+			modelUUIDs, err := st.AllModelUUIDs()
 			if err != nil {
 				return nil, errors.Trace(err)
 			}
-			for _, model := range models {
-				if model.UUID() != st.ModelUUID() && model.Life() != Dead {
+			for _, modelUUID := range modelUUIDs {
+				dead, err := isDead(st, modelsC, modelUUID)
+				if err != nil {
+					return nil, errors.Trace(err)
+				}
+				if modelUUID != st.ModelUUID() && !dead {
 					return nil, errors.Errorf("one or more hosted models are not yet dead")
 				}
 			}

--- a/state/upgrades.go
+++ b/state/upgrades.go
@@ -670,13 +670,13 @@ func AddStatusHistoryPruneSettings(st *State) error {
 	coll, closer := st.db().GetRawCollection(settingsC)
 	defer closer()
 
-	models, err := st.AllModels()
+	uuids, err := st.AllModelUUIDs()
 	if err != nil {
 		return errors.Trace(err)
 	}
 	var ids []string
-	for _, m := range models {
-		ids = append(ids, m.UUID()+":e")
+	for _, uuid := range uuids {
+		ids = append(ids, uuid+":e")
 	}
 
 	iter := coll.Find(bson.M{"_id": bson.M{"$in": ids}}).Iter()
@@ -709,13 +709,13 @@ func AddUpdateStatusHookSettings(st *State) error {
 	coll, closer := st.db().GetRawCollection(settingsC)
 	defer closer()
 
-	models, err := st.AllModels()
+	uuids, err := st.AllModelUUIDs()
 	if err != nil {
 		return errors.Trace(err)
 	}
 	var ids []string
-	for _, m := range models {
-		ids = append(ids, m.UUID()+":e")
+	for _, uuid := range uuids {
+		ids = append(ids, uuid+":e")
 	}
 
 	iter := coll.Find(bson.M{"_id": bson.M{"$in": ids}}).Iter()

--- a/state/user.go
+++ b/state/user.go
@@ -473,11 +473,11 @@ func (u *User) Disable() error {
 	if err := u.ensureNotDeleted(); err != nil {
 		return errors.Annotate(err, "cannot disable")
 	}
-	environment, err := u.st.ControllerModel()
+	owner, err := u.st.ControllerOwner()
 	if err != nil {
 		return errors.Trace(err)
 	}
-	if u.doc.Name == environment.Owner().Name() {
+	if u.doc.Name == owner.Name() {
 		return errors.Unauthorizedf("cannot disable controller model owner")
 	}
 	return errors.Annotatef(u.setDeactivated(true), "cannot disable user %q", u.Name())

--- a/worker/upgradesteps/worker.go
+++ b/worker/upgradesteps/worker.go
@@ -338,7 +338,9 @@ func (w *upgradesteps) runUpgradeSteps(agentConfig agent.ConfigSetter) error {
 	var upgradeErr error
 	w.machine.SetStatus(status.Started, fmt.Sprintf("upgrading to %v", w.toVersion), nil)
 
-	stBackend := upgrades.NewStateBackend(w.st)
+	pool := state.NewStatePool(w.st)
+	defer pool.Close()
+	stBackend := upgrades.NewStateBackend(w.st, pool)
 	context := upgrades.NewContext(agentConfig, w.apiConn, stBackend)
 	logger.Infof("starting upgrade from %v to %v for %q", w.fromVersion, w.toVersion, w.tag)
 


### PR DESCRIPTION
## Description of change

This change makes most of the steps so that `state.Model` instances can only be created from `state.State` associated to that model. There were many ways to create a `state.Model` from *any* `State` which meant that the `Model` referred to a `state.State` associated with the wrong model. This is dangerous - requiring great care - and limits what can be done by `Model` instances.

Much functionality will soon be moved onto `state.Model`, requiring that the `state.State` it references is the correct one.

Change highlights:

- `State.ControllerModel()` has been replaced by `State.ControllerModelTag()` and `State.ControllerModelUUID()`
- `State.AllModels()` has been replaced by `State.AllModelUUIDs()`
- `State.ModelsForUser()` now returns UUIDs instead of `UserModels`. `state.UserModel` no longer exists.
- Fixed a bug in `State.ModelsForUser()` where dead or importing models could be reported for admin users.
- Access to `Model` instances is now done via `state.State` in most cases. Added a `StatePool.GetModel()` helper as a convenience.
- Many changes in the apiserver package resulted as fallout from the above. This resulted in most calls to `State.ForModel()` being removed (bug 1698702)

There is still one `state.Model` constructor to remove: `state.State.GetModel()`. This will be done in the next PR - this one was getting big enough.

## QA steps

Confirmed that core model, controller and migration functionality worked:

```
$ juju bootstrap lxd source
# wait
$ juju bootstrap lxd target
# wait
$ juju switch source
$ juju add-model foo
$ juju deploy ubuntu
# wait
$ juju migrate foo target
# wait
$ juju debug-log -m source:controller -l ERROR # check controller logs for errors
$ juju debug-log -m target:controller -l ERROR # check controller logs for errors
$ juju destroy-controller -y --destroy-all-models source
$ juju destroy-controller -y --destroy-all-models target
```

## Documentation changes

N.A. - internal only

## Bug reference

Drive-by changes fixed https://bugs.launchpad.net/juju/+bug/1698702

