### PR TITLE
cmd: Add check-connection to jujud

### DIFF
--- a/cmd/jujud/agent/checkconnection.go
+++ b/cmd/jujud/agent/checkconnection.go
@@ -1,0 +1,89 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package agent
+
+import (
+	"io"
+
+	"github.com/juju/cmd"
+	"github.com/juju/errors"
+	"gopkg.in/juju/names.v2"
+
+	"github.com/juju/juju/agent"
+	"github.com/juju/juju/api"
+	"github.com/juju/juju/cmd/jujud/util"
+	"github.com/juju/juju/worker/apicaller"
+)
+
+// ConnectFunc describes what we need to check whether the connection
+// details are set up correctly for the specified agent.
+type ConnectFunc func(agent.Agent) (io.Closer, error)
+
+// ReallyConnect really connects to the API specified in the agent
+// config. It's extracted so tests can pass something else in.
+func ReallyConnect(a agent.Agent) (io.Closer, error) {
+	return apicaller.ScaryConnect(a, api.Open)
+}
+
+type checkConnectionCommand struct {
+	cmd.CommandBase
+	agentName string
+	config    AgentConf
+	connect   ConnectFunc
+}
+
+// NewCheckConnectionCommand returns a command that will test
+// connecting to the API with details from the agent's config.
+func NewCheckConnectionCommand(config AgentConf, connect ConnectFunc) cmd.Command {
+	return &checkConnectionCommand{
+		config:  config,
+		connect: connect,
+	}
+}
+
+// Info is part of cmd.Command.
+func (c *checkConnectionCommand) Info() *cmd.Info {
+	return &cmd.Info{
+		Name:    "check-connection",
+		Args:    "<agent-name>",
+		Purpose: "check connection to the API server",
+	}
+}
+
+// Init is part of cmd.Command.
+func (c *checkConnectionCommand) Init(args []string) error {
+	if len(args) == 0 {
+		return &util.FatalError{"agent-name argument is required"}
+	}
+	agentName, args := args[0], args[1:]
+	tag, err := names.ParseTag(agentName)
+	if err != nil {
+		return errors.Annotatef(err, "agent-name")
+	}
+	if tag.Kind() != "machine" && tag.Kind() != "unit" {
+		return &util.FatalError{"agent-name must be a machine or unit tag"}
+	}
+	if err := cmd.CheckEmpty(args); err != nil {
+		return err
+	}
+	err = c.config.ReadConfig(agentName)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	c.agentName = agentName
+	return nil
+}
+
+// Run is part of cmd.Command.
+func (c *checkConnectionCommand) Run(ctx *cmd.Context) error {
+	conn, err := c.connect(c.config)
+	if err != nil {
+		return errors.Annotatef(err, "checking connection for %s", c.agentName)
+	}
+	err = conn.Close()
+	if err != nil {
+		return errors.Annotatef(err, "closing connection for %s", c.agentName)
+	}
+	return nil
+}

--- a/cmd/jujud/agent/checkconnection_test.go
+++ b/cmd/jujud/agent/checkconnection_test.go
@@ -1,0 +1,74 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package agent_test
+
+import (
+	"io"
+
+	"github.com/juju/errors"
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/agent"
+	agentcmd "github.com/juju/juju/cmd/jujud/agent"
+)
+
+type checkConnectionSuite struct {
+	testing.IsolationSuite
+}
+
+var _ = gc.Suite(&checkConnectionSuite{})
+
+func (s *checkConnectionSuite) TestInitChecksTag(c *gc.C) {
+	cmd := agentcmd.NewCheckConnectionCommand(nil, nil)
+	err := cmd.Init(nil)
+	c.Assert(err, gc.ErrorMatches, "agent-name argument is required")
+	err = cmd.Init([]string{"aloy"})
+	c.Assert(err, gc.ErrorMatches, `agent-name: "aloy" is not a valid tag`)
+	err = cmd.Init([]string{"user-eleuthia"})
+	c.Assert(err, gc.ErrorMatches, `agent-name must be a machine or unit tag`)
+	err = cmd.Init([]string{"unit-demeter-0", "minerva"})
+	c.Assert(err, gc.ErrorMatches, `unrecognized args: \["minerva"\]`)
+}
+
+func (s *checkConnectionSuite) TestRunComplainsAboutConnectionErrors(c *gc.C) {
+	cmd := agentcmd.NewCheckConnectionCommand(newAgentConf(),
+		func(a agent.Agent) (io.Closer, error) {
+			return nil, errors.Errorf("hartz-timor swarm detected")
+		})
+	c.Assert(cmd.Init([]string{"unit-artemis-5"}), jc.ErrorIsNil)
+	err := cmd.Run(nil)
+	c.Assert(err, gc.ErrorMatches, "checking connection for unit-artemis-5: hartz-timor swarm detected")
+}
+
+func (s *checkConnectionSuite) TestRunClosesConnection(c *gc.C) {
+	cmd := agentcmd.NewCheckConnectionCommand(newAgentConf(),
+		func(a agent.Agent) (io.Closer, error) {
+			return &mockConnection{}, nil
+		})
+	c.Assert(cmd.Init([]string{"unit-artemis-5"}), jc.ErrorIsNil)
+	err := cmd.Run(nil)
+	c.Assert(err, gc.ErrorMatches, "closing connection for unit-artemis-5: seal integrity check failed")
+}
+
+func newAgentConf() *mockAgentConf {
+	return &mockAgentConf{stub: &testing.Stub{}}
+}
+
+type mockAgentConf struct {
+	agentcmd.AgentConf
+	stub *testing.Stub
+}
+
+func (c *mockAgentConf) ReadConfig(tag string) error {
+	c.stub.AddCall("ReadConfig", tag)
+	return c.stub.NextErr()
+}
+
+type mockConnection struct{}
+
+func (c *mockConnection) Close() error {
+	return errors.Errorf("seal integrity check failed")
+}

--- a/cmd/jujud/main.go
+++ b/cmd/jujud/main.go
@@ -181,6 +181,7 @@ func jujuDMain(args []string, ctx *cmd.Context) (code int, err error) {
 	jujud.Register(unitAgent)
 
 	jujud.Register(NewUpgradeMongoCommand())
+	jujud.Register(agentcmd.NewCheckConnectionCommand(agentConf, agentcmd.ReallyConnect))
 
 	code = cmd.Main(jujud, ctx, args[1:])
 	return code, nil

--- a/cmd/jujud/main.go
+++ b/cmd/jujud/main.go
@@ -181,7 +181,7 @@ func jujuDMain(args []string, ctx *cmd.Context) (code int, err error) {
 	jujud.Register(unitAgent)
 
 	jujud.Register(NewUpgradeMongoCommand())
-	jujud.Register(agentcmd.NewCheckConnectionCommand(agentConf, agentcmd.ReallyConnect))
+	jujud.Register(agentcmd.NewCheckConnectionCommand(agentConf, agentcmd.ConnectAsAgent))
 
 	code = cmd.Main(jujud, ctx, args[1:])
 	return code, nil


### PR DESCRIPTION
## Description of change

This takes an agent name and checks whether a connection can be made
to the API server from that agent's config. It will be used in the 1.25
upgrade process to confirm that the controller is accessible from all
of the agent machines once the config files have been rewritten (analogous
to the migration minions checking connectivity in a model migration).

## QA steps

* Bootstrap and add a model, and deploy an application.
* SSH to the application machine and run (from `/var/lib/juju`):
```
sudo tools/<agent>/jujud check-connection <agent-name>
```
* It should succeed (return 0, no output).
* Pass in a non-existent agent name, you should get an error about not finding the config and non-zero return.
* Edit the config file to make it incorrect in some way (by changing `apipassword` or `apiservers`, for example), you should get sensible error messages.

## Documentation changes

This isn't really intended for users - it will be called from the upgrade tool, so there's no need for documentation.
