### PR TITLE
Remove model count based on cache.

### DIFF
--- a/cmd/modelcmd/base.go
+++ b/cmd/modelcmd/base.go
@@ -170,15 +170,7 @@ func (c *CommandBase) missingModelError(store jujuclient.ClientStore, controller
 			logger.Warningf("cannot reset current model: %v", err)
 		}
 	}
-	errorMessage := "model %q has been removed from the controller, run 'juju models' and switch to one of them."
-	modelInfoMessage := "\nThere are %d accessible models on controller %q."
-	models, err := store.AllModels(controllerName)
-	if err == nil {
-		modelInfoMessage = fmt.Sprintf(modelInfoMessage, len(models), controllerName)
-	} else {
-		modelInfoMessage = ""
-	}
-	return errors.Errorf(errorMessage+modelInfoMessage, modelName)
+	return errors.Errorf("model %q has been removed from the controller, run 'juju models' and switch to one of them.", modelName)
 }
 
 // NewAPIConnectionParams returns a juju.NewAPIConnectionParams with the

--- a/cmd/modelcmd/base_test.go
+++ b/cmd/modelcmd/base_test.go
@@ -64,7 +64,7 @@ func (s *BaseCommandSuite) assertUnknownModel(c *gc.C, current, expectedCurrent 
 	conn, err := baseCmd.NewAPIRoot()
 	c.Assert(conn, gc.IsNil)
 	msg := strings.Replace(err.Error(), "\n", "", -1)
-	c.Assert(msg, gc.Equals, `model "admin/badmodel" has been removed from the controller, run 'juju models' and switch to one of them.There are 1 accessible models on controller "foo".`)
+	c.Assert(msg, gc.Equals, `model "admin/badmodel" has been removed from the controller, run 'juju models' and switch to one of them.`)
 	c.Assert(s.store.Models["foo"].Models, gc.HasLen, 1)
 	c.Assert(s.store.Models["foo"].Models["admin/goodmodel"], gc.DeepEquals, jujuclient.ModelDetails{"deadbeef2"})
 	c.Assert(s.store.Models["foo"].CurrentModel, gc.Equals, expectedCurrent)


### PR DESCRIPTION
## Description of change

We were reporting redundant and incorrect information to the user when they were trying to access information about a 'currently in-focus' model that no longer exists. Since we are directing users to 'juju models', which will correctly display all accessible models on the current controller, there is no longer a need to tell users how many models were previously accessed to on this controller. This model count get quickly out of date, especially when models are being created/destroyed using different clients.

This PR removes misleading part of the error message.

## QA steps

1. [Client Machine A] bootstrap 
2. [Client Machine A] add model 'trial'
3. [Client Machine A] add model 'trial2' [this model is now 'in-focus' on this client machine, considered 'current']
4. [Client Machine B] destroy model 'trial2'
5. [Client Machine A] run 'juju status'

Expected error message:
WARNING cannot read current model: current model for controller <name> not found
ERROR model <full name for 'trial2' model> has been removed from the controller, run 'juju models' and switch to one of them.

## Documentation changes

If this error message has been mentioned in documents explicitly, it will need to be updated.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1693843
