### PR TITLE
Environ version upgrade step

### DIFF
--- a/upgrades/operations.go
+++ b/upgrades/operations.go
@@ -23,6 +23,7 @@ var stateUpgradeOperations = func() []Operation {
 		upgradeToVersion{version.MustParse("2.1.0"), stateStepsFor21()},
 		upgradeToVersion{version.MustParse("2.2.0"), stateStepsFor22()},
 		upgradeToVersion{version.MustParse("2.2.1"), stateStepsFor221()},
+		upgradeToVersion{version.MustParse("2.2.2"), stateStepsFor222()},
 		upgradeToVersion{version.MustParse("2.2.3"), stateStepsFor223()},
 	}
 	return steps

--- a/upgrades/steps_22.go
+++ b/upgrades/steps_22.go
@@ -53,13 +53,6 @@ func stateStepsFor22() []Step {
 				return context.State().SplitLogCollections()
 			},
 		},
-		&upgradeStep{
-			description: "add environ-version to model docs",
-			targets:     []Target{DatabaseMaster},
-			run: func(context Context) error {
-				return context.State().AddModelEnvironVersion()
-			},
-		},
 	}
 }
 

--- a/upgrades/steps_222.go
+++ b/upgrades/steps_222.go
@@ -1,0 +1,17 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package upgrades
+
+// stateStepsFor222 returns upgrade steps for Juju 2.2.2 that manipulate state directly.
+func stateStepsFor222() []Step {
+	return []Step{
+		&upgradeStep{
+			description: "add environ-version to model docs",
+			targets:     []Target{DatabaseMaster},
+			run: func(context Context) error {
+				return context.State().AddModelEnvironVersion()
+			},
+		},
+	}
+}

--- a/upgrades/steps_222_test.go
+++ b/upgrades/steps_222_test.go
@@ -1,0 +1,27 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package upgrades_test
+
+import (
+	jc "github.com/juju/testing/checkers"
+	"github.com/juju/version"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/testing"
+	"github.com/juju/juju/upgrades"
+)
+
+var v222 = version.MustParse("2.2.2")
+
+type steps222Suite struct {
+	testing.BaseSuite
+}
+
+var _ = gc.Suite(&steps223Suite{})
+
+func (s *steps222Suite) TestAddModelEnvironVersionStep(c *gc.C) {
+	step := findStateStep(c, v222, "add environ-version to model docs")
+	// Logic for step itself is tested in state package.
+	c.Assert(step.Targets(), jc.DeepEquals, []upgrades.Target{upgrades.DatabaseMaster})
+}

--- a/upgrades/steps_22_test.go
+++ b/upgrades/steps_22_test.go
@@ -77,9 +77,3 @@ func (s *steps22Suite) TestSplitLogStep(c *gc.C) {
 	// Logic for step itself is tested in state package.
 	c.Assert(step.Targets(), jc.DeepEquals, []upgrades.Target{upgrades.DatabaseMaster})
 }
-
-func (s *steps22Suite) TestAddModelEnvironVersionStep(c *gc.C) {
-	step := findStateStep(c, v220, "add environ-version to model docs")
-	// Logic for step itself is tested in state package.
-	c.Assert(step.Targets(), jc.DeepEquals, []upgrades.Target{upgrades.DatabaseMaster})
-}

--- a/upgrades/upgrade_test.go
+++ b/upgrades/upgrade_test.go
@@ -644,6 +644,7 @@ func (s *upgradeSuite) TestStateUpgradeOperationsVersions(c *gc.C) {
 		"2.1.0",
 		"2.2.0",
 		"2.2.1",
+		"2.2.2",
 		"2.2.3",
 	})
 }


### PR DESCRIPTION
## Description of change

The upgrade step to add the environ-version field to model docs needs to be a 2.2.2 step, not a 2.2.0 step.

## QA steps

bootstrap juju 2.1.x
upgrade to 2.2.3
ensure that model docs have the environ-version field set to 0

## Bug reference

https://bugs.launchpad.net/juju/+bug/1706535