### PR TITLE
Fix incorrect agent provisioning. (1705628)

### DIFF
--- a/api/provisioner/machine.go
+++ b/api/provisioner/machine.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 
 	"github.com/juju/errors"
+	"github.com/juju/version"
 	"gopkg.in/juju/names.v2"
 
 	apiwatcher "github.com/juju/juju/api/watcher"
@@ -26,6 +27,21 @@ type Machine struct {
 // Tag returns the machine's tag.
 func (m *Machine) Tag() names.Tag {
 	return m.tag
+}
+
+// ModelAgentVersion returns the agent version the machine's model is currently
+// running or an error.
+func (m *Machine) ModelAgentVersion() (*version.Number, error) {
+	mc, err := m.st.ModelConfig()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	if v, ok := mc.AgentVersion(); ok {
+		return &v, nil
+	}
+
+	return nil, errors.New("failed to get model's agent version.")
 }
 
 // MachineTag returns the identifier for the machine as the most specific type

--- a/worker/provisioner/provisioner_task.go
+++ b/worker/provisioner/provisioner_task.go
@@ -31,7 +31,6 @@ import (
 	"github.com/juju/juju/status"
 	"github.com/juju/juju/storage"
 	coretools "github.com/juju/juju/tools"
-	jujuversion "github.com/juju/juju/version"
 	"github.com/juju/juju/watcher"
 	"github.com/juju/juju/worker/catacomb"
 	"github.com/juju/juju/wrench"
@@ -681,8 +680,12 @@ func (task *provisionerTask) startMachines(machines []*apiprovisioner.Machine) e
 			arch = *pInfo.Constraints.Arch
 		}
 
+		v, err := m.ModelAgentVersion()
+		if err != nil {
+			return errors.Trace(err)
+		}
 		possibleTools, err := task.toolsFinder.FindTools(
-			jujuversion.Current,
+			*v,
 			pInfo.Series,
 			arch,
 		)


### PR DESCRIPTION
## Description of change

When adding a unit, the unit should run the same juju agent version as its
model. However, units were being added with the agent version of their
controller not their model. This fix corrects the error.

## QA steps

Bootstrap a controller with juju version 2.1.x.

```sh
juju bootstrap lxd bug_1705628
```

Deploy an application to the default model

```sh
juju deploy ubuntu -m default
```

Check the agent version of the running application

```sh
juju status --format=yaml | grep version -a5
```
The ubuntu appliction unit should be running version 2.1.x of jujud

Upgrade the controller to version 2.2.x or greater, then add an additional unit

```sh
juju upgrade-juju -m controller

juju add-unit ubuntu
```
Check the agent version of the newly added unit. It should be running the agent
version of the default model and not the agent version of the controller model.

## Documentation changes

N/A

## Bug reference

[lp#1705628](https://bugs.launchpad.net/juju/+bug/1705628)
