### PR TITLE
Handle subordinates with multiple principals.

### DIFF
--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -21,7 +21,7 @@ github.com/juju/ansiterm	git	b99631de12cf04a906c1d4e4ec54fb86eae5863d	2016-09-07
 github.com/juju/blobstore	git	06056004b3d7b54bbb7984d830c537bad00fec21	2015-07-29T11:18:58Z
 github.com/juju/bundlechanges	git	cd189848b313df50084de692b05861210022cf81	2017-08-02T17:04:42Z
 github.com/juju/cmd	git	e47739aefe0adb68a401fcd371c0c92c8f6f8d99	2017-04-13T02:13:06Z
-github.com/juju/description	git	b764a15740dbcb800ec894fedd41cc0a37826419	2017-07-06T03:32:20Z
+github.com/juju/description	git	264ae46133b5a24cfc4f55717d4ed83bb2983b8f	2017-08-09T23:16:08Z
 github.com/juju/errors	git	1b5e39b83d1835fa480e0c2ddefb040ee82d58b3	2015-09-16T12:56:42Z
 github.com/juju/gnuflag	git	4e76c56581859c14d9d87e1ddbe29e1c0f10195f	2016-08-09T16:52:14Z
 github.com/juju/go-oracle-cloud	git	932a8cea00a1cd5cba3829a672c823955db674ae	2017-04-21T13:45:47Z

--- a/state/allcollections.go
+++ b/state/allcollections.go
@@ -393,7 +393,7 @@ func allCollections() collectionSchema {
 				Key: []string{"model-uuid", "globalkey", "updated"},
 			}, {
 				// used for migration and model-specific pruning
-				Key: []string{"model-uuid", "-updated"},
+				Key: []string{"model-uuid", "-updated", "_id"},
 			}, {
 				// used for global pruning (after size check)
 				Key: []string{"-updated"},

--- a/state/allcollections.go
+++ b/state/allcollections.go
@@ -393,7 +393,7 @@ func allCollections() collectionSchema {
 				Key: []string{"model-uuid", "globalkey", "updated"},
 			}, {
 				// used for migration and model-specific pruning
-				Key: []string{"model-uuid", "-updated", "_id"},
+				Key: []string{"model-uuid", "-updated", "-_id"},
 			}, {
 				// used for global pruning (after size check)
 				Key: []string{"-updated"},

--- a/state/migration_export.go
+++ b/state/migration_export.go
@@ -914,6 +914,17 @@ func (e *exporter) relations() error {
 				if err != nil {
 					return errors.Trace(err)
 				}
+				valid, err := ru.Valid()
+				if err != nil {
+					return errors.Trace(err)
+				}
+				if !valid {
+					// It doesn't make sense for this application to have a
+					// relations scope for this endpoint. For example the
+					// situation where we have a subordinate charm related to
+					// two different principals.
+					continue
+				}
 				key := ru.key()
 				if !relationScopes.Contains(key) {
 					return errors.Errorf("missing relation scope for %s and %s", relation, unit.Name())

--- a/state/migration_export_test.go
+++ b/state/migration_export_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/juju/description"
 	jc "github.com/juju/testing/checkers"
+	"github.com/juju/utils/arch"
 	"github.com/juju/version"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/charm.v6-unstable"
@@ -32,6 +33,7 @@ import (
 	"github.com/juju/juju/storage/poolmanager"
 	"github.com/juju/juju/storage/provider"
 	"github.com/juju/juju/testing/factory"
+	jujuversion "github.com/juju/juju/version"
 )
 
 // Constraints stores megabytes by default for memory and root disk.
@@ -610,6 +612,66 @@ func (s *MigrationExportSuite) TestRelations(c *gc.C) {
 	}
 	checkEndpoint(exEps[0], mysql_0.Name(), msEp, mysqlSettings)
 	checkEndpoint(exEps[1], wordpress_0.Name(), wpEp, wordpressSettings)
+}
+
+func (s *MigrationExportSuite) TestSubordinateRelations(c *gc.C) {
+	wordpress := state.AddTestingService(c, s.State, "wordpress", state.AddTestingCharm(c, s.State, "wordpress"))
+	mysql := state.AddTestingService(c, s.State, "mysql", state.AddTestingCharm(c, s.State, "mysql"))
+	wordpress_0 := s.Factory.MakeUnit(c, &factory.UnitParams{Application: wordpress})
+	mysql_0 := s.Factory.MakeUnit(c, &factory.UnitParams{Application: mysql})
+
+	logging := s.AddTestingService(c, "logging", s.AddTestingCharm(c, "logging"))
+
+	addSubordinate := func(app *state.Application, unit *state.Unit) {
+		eps, err := s.State.InferEndpoints(app.Name(), logging.Name())
+		c.Assert(err, jc.ErrorIsNil)
+		rel, err := s.State.AddRelation(eps...)
+		c.Assert(err, jc.ErrorIsNil)
+		pru, err := rel.Unit(unit)
+		c.Assert(err, jc.ErrorIsNil)
+		err = pru.EnterScope(nil)
+		c.Assert(err, jc.ErrorIsNil)
+		// Need to reload the doc to get the subordinates.
+		err = unit.Refresh()
+		c.Assert(err, jc.ErrorIsNil)
+		subordinates := unit.SubordinateNames()
+		c.Assert(subordinates, gc.HasLen, 1)
+		loggingUnit, err := s.State.Unit(subordinates[0])
+		c.Assert(err, jc.ErrorIsNil)
+		sub, err := rel.Unit(loggingUnit)
+		c.Assert(err, jc.ErrorIsNil)
+		err = sub.EnterScope(nil)
+		c.Assert(err, jc.ErrorIsNil)
+	}
+
+	addSubordinate(mysql, mysql_0)
+	addSubordinate(wordpress, wordpress_0)
+
+	setTools := func(unit *state.Unit) {
+		app, err := unit.Application()
+		c.Assert(err, jc.ErrorIsNil)
+		agentTools := version.Binary{
+			Number: jujuversion.Current,
+			Arch:   arch.HostArch(),
+			Series: app.Series(),
+		}
+		err = unit.SetAgentVersion(agentTools)
+		c.Assert(err, jc.ErrorIsNil)
+	}
+
+	units, err := logging.AllUnits()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(units, gc.HasLen, 2)
+
+	for _, unit := range units {
+		setTools(unit)
+	}
+
+	model, err := s.State.Export()
+	c.Assert(err, jc.ErrorIsNil)
+
+	rels := model.Relations()
+	c.Assert(rels, gc.HasLen, 2)
 }
 
 func (s *MigrationExportSuite) TestSpaces(c *gc.C) {


### PR DESCRIPTION
The state.Export function was failing in situations where there was a subordinate application related to more than one principal. This is a common situation in production deployments.

## QA steps

Deploy the following to a model:

```
$ juju deploy prometheus
$ juju deploy haproxy
$ juju deploy nrpe-external-master --series xenial --force
$ juju relate nrpe-external-master prometheus
$ juju relate nrpe-external-master haproxy
# wait until all deployed
$ juju dump-model
```
