### PR TITLE
Ceaning up old command references in help.

### DIFF
--- a/cmd/juju/application/deploy.go
+++ b/cmd/juju/application/deploy.go
@@ -403,8 +403,7 @@ See also:
     spaces
     constraints
     add-unit
-    set-config
-    get-config
+    config
     set-constraints
     get-constraints
 `

--- a/cmd/juju/block/doc.go
+++ b/cmd/juju/block/doc.go
@@ -25,6 +25,7 @@ Commands that can be disabled are grouped based on logical operations as follows
     add-ssh-key
     add-user
     change-user-password
+    config
     deploy
     disable-user
     destroy-controller
@@ -33,6 +34,7 @@ Commands that can be disabled are grouped based on logical operations as follows
     enable-user
     expose
     import-ssh-key
+    model-config
     remove-application
     remove-machine
     remove-relation
@@ -41,13 +43,9 @@ Commands that can be disabled are grouped based on logical operations as follows
     resolved
     retry-provisioning
     run
-    set-config
     set-constraints
-    set-model-config
     sync-tools
     unexpose
-    unset-config
-    unset-model-config
     upgrade-charm
     upgrade-juju
 	`


### PR DESCRIPTION
## Description of change

Some commands referred to no longer existing commands, like set- and unset-config.
This PR removed these references.

## QA steps

'deploy' and 'block' command help no longer refers to non-existing commands.

## Documentation changes

Help documentation for 'block' and 'deploy' command changed.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1628155
