### PR TITLE
Remove old service reference.

### DIFF
--- a/worker/uniter/runner/jujuc/status-set.go
+++ b/worker/uniter/runner/jujuc/status-set.go
@@ -48,7 +48,6 @@ var validStatus = []status.Status{
 
 func (c *StatusSetCommand) SetFlags(f *gnuflag.FlagSet) {
 	f.BoolVar(&c.service, "application", false, "set this status for the application to which the unit belongs if the unit is the leader")
-	f.BoolVar(&c.service, "service", false, "set this status for the application to which the unit belongs if the unit is the leader")
 }
 
 func (c *StatusSetCommand) Init(args []string) error {

--- a/worker/uniter/runner/jujuc/status-set.go
+++ b/worker/uniter/runner/jujuc/status-set.go
@@ -14,10 +14,10 @@ import (
 // StatusSetCommand implements the status-set command.
 type StatusSetCommand struct {
 	cmd.CommandBase
-	ctx     Context
-	status  string
-	message string
-	service bool
+	ctx         Context
+	status      string
+	message     string
+	application bool
 }
 
 // NewStatusSetCommand makes a jujuc status-set command.
@@ -47,7 +47,7 @@ var validStatus = []status.Status{
 }
 
 func (c *StatusSetCommand) SetFlags(f *gnuflag.FlagSet) {
-	f.BoolVar(&c.service, "application", false, "set this status for the application to which the unit belongs if the unit is the leader")
+	f.BoolVar(&c.application, "application", false, "set this status for the application to which the unit belongs if the unit is the leader")
 }
 
 func (c *StatusSetCommand) Init(args []string) error {
@@ -77,7 +77,7 @@ func (c *StatusSetCommand) Run(ctx *cmd.Context) error {
 		Status: c.status,
 		Info:   c.message,
 	}
-	if c.service {
+	if c.application {
 		return c.ctx.SetApplicationStatus(statusInfo)
 	}
 	return c.ctx.SetUnitStatus(statusInfo)

--- a/worker/uniter/runner/jujuc/status-set_test.go
+++ b/worker/uniter/runner/jujuc/status-set_test.go
@@ -58,7 +58,7 @@ func (s *statusSetSuite) TestHelp(c *gc.C) {
 		"set status information\n" +
 		"\n" +
 		"Options:\n" +
-		"--service, --application  (= false)\n" +
+		"--application  (= false)\n" +
 		"    set this status for the application to which the unit belongs if the unit is the leader\n" +
 		"\n" +
 		"Details:\n" +
@@ -95,7 +95,6 @@ func (s *statusSetSuite) TestServiceStatus(c *gc.C) {
 	for i, args := range [][]string{
 		[]string{"--application", "maintenance", "doing some work"},
 		[]string{"--application", "active", ""},
-		[]string{"--service", "maintenance", "doing some work"},
 	} {
 		c.Logf("test %d: %#v", i, args)
 		hctx := s.GetStatusHookContext(c)


### PR DESCRIPTION
## Description of change

Hook 'status-set' accepted both --service and --application as a parameter for an application.
This is a historic renaming weight. Juju 2.3 is a great time to support only --application.

## QA steps

1. juju run --unit ubuntu/0 'status-set --help' 
[Should only display application as an option]

## Documentation changes
'status-set' help updated.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1626110
