### PR TITLE
Added model-default as alias to model-defaults.

### DIFF
--- a/cmd/juju/commands/main_test.go
+++ b/cmd/juju/commands/main_test.go
@@ -474,6 +474,7 @@ var commandNames = []string{
 	"metrics",
 	"migrate",
 	"model-config",
+	"model-default",
 	"model-defaults",
 	"models",
 	"payloads",

--- a/cmd/juju/model/defaultscommand.go
+++ b/cmd/juju/model/defaultscommand.go
@@ -126,6 +126,7 @@ func (c *defaultsCommand) Info() *cmd.Info {
 		Doc:     modelDefaultsHelpDoc,
 		Name:    "model-defaults",
 		Purpose: modelDefaultsSummary,
+		Aliases: []string{"model-default"},
 	}
 }
 


### PR DESCRIPTION
## Description of change

For usability, this PR adds an alias to 'model-defaults' command - 'model-default', singular. 

## QA steps

1. 'juju help commands' lists 'model-default' as well.
2. running 'juju model-default <model-config-param=param-value>' has the same effect as running 'juju model-defaults <model-config-param=param-value>'. 

## Documentation changes

A command alias has been added.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1656216
