### PR TITLE
Add new option to remove-machine to tell the provisioner not to stop the instance

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -190,6 +190,21 @@ func (c *Client) ForceDestroyMachines(machines ...string) error {
 	return c.facade.FacadeCall("DestroyMachines", params, nil)
 }
 
+// DestroyMachinesWithParams removes a given set of machines and all associated units.
+//
+// NOTE(wallyworld) this exists only for backwards compatibility, when MachineManager
+// facade v4 is not available. The MachineManager.DestroyMachinesWithParams method
+// should be preferred.
+//
+// TODO(wallyworld) 2017-03-16 #1673323
+// Drop this in Juju 3.0.
+func (c *Client) DestroyMachinesWithParams(force, keep bool, machines ...string) error {
+	if keep {
+		return errors.NotSupportedf("destroy machine with keep-instance=true")
+	}
+	return c.DestroyMachines(machines...)
+}
+
 // GetModelConstraints returns the constraints for the model.
 func (c *Client) GetModelConstraints() (constraints.Value, error) {
 	results := new(params.GetConstraintsResults)

--- a/api/facadeversions.go
+++ b/api/facadeversions.go
@@ -47,7 +47,7 @@ var facadeVersions = map[string]int{
 	"LogForwarding":                1,
 	"Logger":                       1,
 	"MachineActions":               1,
-	"MachineManager":               3,
+	"MachineManager":               4,
 	"MachineUndertaker":            1,
 	"Machiner":                     1,
 	"MeterStatus":                  1,

--- a/api/machinemanager/machinemanager.go
+++ b/api/machinemanager/machinemanager.go
@@ -53,12 +53,6 @@ func (client *Client) ForceDestroyMachines(machines ...string) ([]params.Destroy
 // is determined by the force and keep parameters.
 // TODO(wallyworld) - for Juju 3.0, this should be the preferred api to use.
 func (client *Client) DestroyMachinesWithParams(force, keep bool, machines ...string) ([]params.DestroyMachineResult, error) {
-	if !keep {
-		if force {
-			return client.ForceDestroyMachines(machines...)
-		}
-		return client.DestroyMachines(machines...)
-	}
 	args := params.DestroyMachinesParams{
 		Force:       force,
 		Keep:        keep,

--- a/api/provisioner/provisioner_test.go
+++ b/api/provisioner/provisioner_test.go
@@ -357,6 +357,16 @@ func (s *provisionerSuite) TestSeries(c *gc.C) {
 	c.Assert(series, gc.Equals, "quantal")
 }
 
+func (s *provisionerSuite) TestKeepInstance(c *gc.C) {
+	err := s.machine.SetKeepInstance(true)
+	c.Assert(err, jc.ErrorIsNil)
+	apiMachine, err := s.provisioner.Machine(s.machine.Tag().(names.MachineTag))
+	c.Assert(err, jc.ErrorIsNil)
+	keep, err := apiMachine.KeepInstance()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(keep, jc.IsTrue)
+}
+
 func (s *provisionerSuite) TestDistributionGroup(c *gc.C) {
 	apiMachine, err := s.provisioner.Machine(s.machine.Tag().(names.MachineTag))
 	c.Assert(err, jc.ErrorIsNil)

--- a/apiserver/allfacades.go
+++ b/apiserver/allfacades.go
@@ -151,7 +151,8 @@ func AllFacades() *facade.Registry {
 	reg("MachineActions", 1, machineactions.NewExternalFacade)
 
 	reg("MachineManager", 2, machinemanager.NewMachineManagerAPI)
-	reg("MachineManager", 3, machinemanager.NewMachineManagerAPI) // Version 3 adds DestroyMachine and ForceDestroyMachine.
+	reg("MachineManager", 3, machinemanager.NewMachineManagerAPI)   // Version 3 adds DestroyMachine and ForceDestroyMachine.
+	reg("MachineManager", 4, machinemanager.NewMachineManagerAPIV4) // Version 4 adds DestroyMachineWithParams.
 
 	reg("MachineUndertaker", 1, machineundertaker.NewFacade)
 	reg("Machiner", 1, machine.NewMachinerAPI)

--- a/apiserver/machinemanager/machinemanager.go
+++ b/apiserver/machinemanager/machinemanager.go
@@ -205,7 +205,6 @@ func (mm *MachineManagerAPI) ForceDestroyMachine(args params.Entities) (params.D
 
 // DestroyMachineWithParams removes a set of machines from the model.
 func (mm *MachineManagerAPIV4) DestroyMachineWithParams(args params.DestroyMachinesParams) (params.DestroyMachineResults, error) {
-	logger.Criticalf("%+v", args)
 	entities := params.Entities{Entities: make([]params.Entity, len(args.MachineTags))}
 	for i, tag := range args.MachineTags {
 		entities.Entities[i].Tag = tag

--- a/apiserver/machinemanager/machinemanager.go
+++ b/apiserver/machinemanager/machinemanager.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 
 	"github.com/juju/errors"
+	"github.com/juju/loggo"
 	"github.com/juju/utils/set"
 	"gopkg.in/juju/names.v2"
 
@@ -19,6 +20,8 @@ import (
 	"github.com/juju/juju/state"
 )
 
+var logger = loggo.GetLogger("juju.apiserver.machinemanager")
+
 // MachineManagerAPI provides access to the MachineManager API facade.
 type MachineManagerAPI struct {
 	st         stateInterface
@@ -26,8 +29,26 @@ type MachineManagerAPI struct {
 	check      *common.BlockChecker
 }
 
+type MachineManagerAPIV4 struct {
+	*MachineManagerAPI
+}
+
 var getState = func(st *state.State) stateInterface {
 	return stateShim{st}
+}
+
+// NewMachineManagerAPIV4 creates a new server-side MachineManager API facade.
+func NewMachineManagerAPIV4(
+	st *state.State,
+	resources facade.Resources,
+	authorizer facade.Authorizer,
+) (*MachineManagerAPIV4, error) {
+
+	machineManagerAPI, err := NewMachineManagerAPI(st, resources, authorizer)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return &MachineManagerAPIV4{machineManagerAPI}, nil
 }
 
 // NewMachineManagerAPI creates a new server-side MachineManager API facade.
@@ -174,15 +195,25 @@ func (mm *MachineManagerAPI) addOneMachine(p params.AddMachineParams) (*state.Ma
 
 // DestroyMachine removes a set of machines from the model.
 func (mm *MachineManagerAPI) DestroyMachine(args params.Entities) (params.DestroyMachineResults, error) {
-	return mm.destroyMachine(args, false)
+	return mm.destroyMachine(args, false, false)
 }
 
 // ForceDestroyMachine forcibly removes a set of machines from the model.
 func (mm *MachineManagerAPI) ForceDestroyMachine(args params.Entities) (params.DestroyMachineResults, error) {
-	return mm.destroyMachine(args, true)
+	return mm.destroyMachine(args, true, false)
 }
 
-func (mm *MachineManagerAPI) destroyMachine(args params.Entities, force bool) (params.DestroyMachineResults, error) {
+// DestroyMachineWithParams removes a set of machines from the model.
+func (mm *MachineManagerAPIV4) DestroyMachineWithParams(args params.DestroyMachinesParams) (params.DestroyMachineResults, error) {
+	logger.Criticalf("%+v", args)
+	entities := params.Entities{Entities: make([]params.Entity, len(args.MachineTags))}
+	for i, tag := range args.MachineTags {
+		entities.Entities[i].Tag = tag
+	}
+	return mm.destroyMachine(entities, args.Force, args.Keep)
+}
+
+func (mm *MachineManagerAPI) destroyMachine(args params.Entities, force, keep bool) (params.DestroyMachineResults, error) {
 	if err := mm.checkCanWrite(); err != nil {
 		return params.DestroyMachineResults{}, err
 	}
@@ -197,6 +228,12 @@ func (mm *MachineManagerAPI) destroyMachine(args params.Entities, force bool) (p
 		machine, err := mm.st.Machine(machineTag.Id())
 		if err != nil {
 			return nil, err
+		}
+		if keep {
+			logger.Infof("destroy machine %v but keep instance", machineTag.Id())
+			if err := machine.SetKeepInstance(keep); err != nil {
+				return nil, err
+			}
 		}
 		var info params.DestroyMachineInfo
 		units, err := machine.Units()

--- a/apiserver/machinemanager/machinemanager_test.go
+++ b/apiserver/machinemanager/machinemanager_test.go
@@ -141,6 +141,31 @@ func (s *MachineManagerSuite) TestDestroyMachine(c *gc.C) {
 	})
 }
 
+func (s *MachineManagerSuite) TestDestroyMachineWithParams(c *gc.C) {
+	apiV4 := machinemanager.MachineManagerAPIV4{s.api}
+	results, err := apiV4.DestroyMachineWithParams(params.DestroyMachinesParams{
+		Keep:        true,
+		Force:       true,
+		MachineTags: []string{"machine-0"},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(results, jc.DeepEquals, params.DestroyMachineResults{
+		Results: []params.DestroyMachineResult{{
+			Info: &params.DestroyMachineInfo{
+				DestroyedUnits: []params.Entity{
+					{"unit-foo-0"},
+					{"unit-foo-1"},
+					{"unit-foo-2"},
+				},
+				DestroyedStorage: []params.Entity{
+					{"storage-disks-0"},
+					{"storage-disks-1"},
+				},
+			},
+		}},
+	})
+}
+
 type mockState struct {
 	calls    int
 	machines []state.MachineTemplate
@@ -247,6 +272,10 @@ func (m *mockMachine) Destroy() error {
 }
 
 func (m *mockMachine) ForceDestroy() error {
+	return nil
+}
+
+func (m *mockMachine) SetKeepInstance(keep bool) error {
 	return nil
 }
 

--- a/apiserver/machinemanager/state.go
+++ b/apiserver/machinemanager/state.go
@@ -91,6 +91,7 @@ type Machine interface {
 	Destroy() error
 	ForceDestroy() error
 	Units() ([]Unit, error)
+	SetKeepInstance(bool) error
 }
 
 type machineShim struct {

--- a/apiserver/params/params.go
+++ b/apiserver/params/params.go
@@ -201,9 +201,18 @@ type AddMachinesResult struct {
 }
 
 // DestroyMachines holds parameters for the DestroyMachines call.
+// This is the legacy params struct used with the client facade.
+// TODO(wallyworld) - remove in Juju 3.0
 type DestroyMachines struct {
 	MachineNames []string `json:"machine-names"`
 	Force        bool     `json:"force"`
+}
+
+// DestroyMachinesParams holds parameters for the DestroyMachinesWithParams call.
+type DestroyMachinesParams struct {
+	MachineTags []string `json:"machine-tags"`
+	Force       bool     `json:"force,omitempty"`
+	Keep        bool     `json:"keep,omitempty"`
 }
 
 // ApplicationsDeploy holds the parameters for deploying one or more applications.

--- a/apiserver/provisioner/provisioner.go
+++ b/apiserver/provisioner/provisioner.go
@@ -348,6 +348,33 @@ func (p *ProvisionerAPI) Series(args params.Entities) (params.StringResults, err
 	return result, nil
 }
 
+// KeepInstance returns the keep-instance value for each given machine entity.
+func (p *ProvisionerAPI) KeepInstance(args params.Entities) (params.BoolResults, error) {
+	result := params.BoolResults{
+
+		Results: make([]params.BoolResult, len(args.Entities)),
+	}
+	canAccess, err := p.getAuthFunc()
+	if err != nil {
+		return result, err
+	}
+	for i, entity := range args.Entities {
+		tag, err := names.ParseMachineTag(entity.Tag)
+		if err != nil {
+			result.Results[i].Error = common.ServerError(common.ErrPerm)
+			continue
+		}
+		machine, err := p.getMachine(canAccess, tag)
+		if err == nil {
+			keep, err := machine.KeepInstance()
+			result.Results[i].Result = keep
+			result.Results[i].Error = common.ServerError(err)
+		}
+		result.Results[i].Error = common.ServerError(err)
+	}
+	return result, nil
+}
+
 // DistributionGroup returns, for each given machine entity,
 // a slice of instance.Ids that belong to the same distribution
 // group as that machine. This information may be used to

--- a/apiserver/provisioner/provisioner_test.go
+++ b/apiserver/provisioner/provisioner_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/juju/juju/status"
 	"github.com/juju/juju/storage/poolmanager"
 	coretesting "github.com/juju/juju/testing"
+	"github.com/juju/juju/testing/factory"
 )
 
 func TestPackage(t *stdtesting.T) {
@@ -792,9 +793,7 @@ func (s *withoutControllerSuite) TestInstanceStatus(c *gc.C) {
 
 func (s *withoutControllerSuite) TestSeries(c *gc.C) {
 	// Add a machine with different series.
-	foobarMachine, err := s.State.AddMachine("foobar", state.JobHostUnits)
-	c.Assert(err, jc.ErrorIsNil)
-
+	foobarMachine := s.Factory.MakeMachine(c, &factory.MachineParams{Series: "foobar"})
 	args := params.Entities{Entities: []params.Entity{
 		{Tag: s.machines[0].Tag().String()},
 		{Tag: foobarMachine.Tag().String()},
@@ -819,11 +818,8 @@ func (s *withoutControllerSuite) TestSeries(c *gc.C) {
 
 func (s *withoutControllerSuite) TestKeepInstance(c *gc.C) {
 	// Add a machine with keep-instance = true.
-	foobarMachine, err := s.State.AddMachine("foobar", state.JobHostUnits)
-	c.Assert(err, jc.ErrorIsNil)
-	err = foobarMachine.SetProvisioned("1234", "nonce", nil)
-	c.Assert(err, jc.ErrorIsNil)
-	err = foobarMachine.SetKeepInstance(true)
+	foobarMachine := s.Factory.MakeMachine(c, &factory.MachineParams{InstanceId: "1234"})
+	err := foobarMachine.SetKeepInstance(true)
 	c.Assert(err, jc.ErrorIsNil)
 
 	args := params.Entities{Entities: []params.Entity{

--- a/apiserver/provisioner/provisioninginfo.go
+++ b/apiserver/provisioner/provisioninginfo.go
@@ -206,6 +206,8 @@ func (p *ProvisionerAPI) machineTags(m *state.Machine, jobs []multiwatcher.Machi
 	if len(unitNames) > 0 {
 		machineTags[tags.JujuUnitsDeployed] = strings.Join(unitNames, " ")
 	}
+	machineId := fmt.Sprintf("%s-%s", cfg.Name(), m.Tag().String())
+	machineTags[tags.JujuMachine] = machineId
 	return machineTags, nil
 }
 

--- a/apiserver/provisioner/provisioninginfo_test.go
+++ b/apiserver/provisioner/provisioninginfo_test.go
@@ -59,6 +59,7 @@ func (s *withoutControllerSuite) TestProvisioningInfoWithStorage(c *gc.C) {
 				Tags: map[string]string{
 					tags.JujuController: coretesting.ControllerTag.Id(),
 					tags.JujuModel:      coretesting.ModelTag.Id(),
+					tags.JujuMachine:    "controller-machine-0",
 				},
 			}},
 			{Result: &params.ProvisioningInfo{
@@ -70,6 +71,7 @@ func (s *withoutControllerSuite) TestProvisioningInfoWithStorage(c *gc.C) {
 				Tags: map[string]string{
 					tags.JujuController: coretesting.ControllerTag.Id(),
 					tags.JujuModel:      coretesting.ModelTag.Id(),
+					tags.JujuMachine:    "controller-machine-5",
 				},
 				Volumes: []params.VolumeParams{{
 					VolumeTag:  "volume-0",
@@ -147,6 +149,7 @@ func (s *withoutControllerSuite) TestProvisioningInfoWithSingleNegativeAndPositi
 				Tags: map[string]string{
 					tags.JujuController: coretesting.ControllerTag.Id(),
 					tags.JujuModel:      coretesting.ModelTag.Id(),
+					tags.JujuMachine:    "controller-machine-5",
 				},
 				SubnetsToZones: map[string][]string{
 					"subnet-1": []string{"zone1"},
@@ -215,6 +218,7 @@ func (s *withoutControllerSuite) TestProvisioningInfoWithEndpointBindings(c *gc.
 				Tags: map[string]string{
 					tags.JujuController:    coretesting.ControllerTag.Id(),
 					tags.JujuModel:         coretesting.ModelTag.Id(),
+					tags.JujuMachine:       "controller-machine-5",
 					tags.JujuUnitsDeployed: wordpressUnit.Name(),
 				},
 				// Ensure space names are translated to provider IDs, where
@@ -303,6 +307,7 @@ func (s *withoutControllerSuite) TestStorageProviderFallbackToType(c *gc.C) {
 				Tags: map[string]string{
 					tags.JujuController: coretesting.ControllerTag.Id(),
 					tags.JujuModel:      coretesting.ModelTag.Id(),
+					tags.JujuMachine:    "controller-machine-5",
 				},
 				Volumes: []params.VolumeParams{{
 					VolumeTag:  "volume-1",
@@ -356,6 +361,7 @@ func (s *withoutControllerSuite) TestProvisioningInfoPermissions(c *gc.C) {
 				Tags: map[string]string{
 					tags.JujuController: coretesting.ControllerTag.Id(),
 					tags.JujuModel:      coretesting.ModelTag.Id(),
+					tags.JujuMachine:    "controller-machine-0",
 				},
 			}},
 			{Error: apiservertesting.NotFoundError("machine 0/lxd/0")},

--- a/cmd/juju/machine/add.go
+++ b/cmd/juju/machine/add.go
@@ -159,6 +159,7 @@ type AddMachineAPI interface {
 	AddMachines([]params.AddMachineParams) ([]params.AddMachinesResult, error)
 	Close() error
 	ForceDestroyMachines(machines ...string) error
+	DestroyMachinesWithParams(force, keep bool, machines ...string) error
 	ModelUUID() (string, bool)
 	ProvisioningScript(params.ProvisioningScriptParams) (script string, err error)
 }

--- a/cmd/juju/machine/add_test.go
+++ b/cmd/juju/machine/add_test.go
@@ -255,6 +255,10 @@ func (f *fakeAddMachineAPI) ForceDestroyMachines(machines ...string) error {
 	return errors.NotImplementedf("ForceDestroyMachines")
 }
 
+func (f *fakeAddMachineAPI) DestroyMachinesWithParams(force, keep bool, machines ...string) error {
+	return errors.NotImplementedf("ForceDestroyMachinesWithParams")
+}
+
 func (f *fakeAddMachineAPI) ProvisioningScript(params.ProvisioningScriptParams) (script string, err error) {
 	return "", errors.NotImplementedf("ProvisioningScript")
 }

--- a/cmd/juju/machine/export_test.go
+++ b/cmd/juju/machine/export_test.go
@@ -6,6 +6,7 @@ package machine
 import (
 	"github.com/juju/cmd"
 
+	"github.com/juju/juju/api"
 	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/storage"
 )
@@ -45,9 +46,10 @@ type RemoveCommand struct {
 }
 
 // NewRemoveCommand returns an RemoveCommand with the api provided as specified.
-func NewRemoveCommandForTest(api RemoveMachineAPI) (cmd.Command, *RemoveCommand) {
+func NewRemoveCommandForTest(apiRoot api.Connection, machineAPI RemoveMachineAPI) (cmd.Command, *RemoveCommand) {
 	cmd := &removeCommand{
-		api: api,
+		apiRoot:    apiRoot,
+		machineAPI: machineAPI,
 	}
 	return modelcmd.Wrap(cmd), &RemoveCommand{cmd}
 }

--- a/cmd/juju/machine/remove_test.go
+++ b/cmd/juju/machine/remove_test.go
@@ -9,6 +9,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/api"
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/cmd/juju/machine"
@@ -17,7 +18,8 @@ import (
 
 type RemoveMachineSuite struct {
 	testing.FakeJujuXDGDataHomeSuite
-	fake *fakeRemoveMachineAPI
+	fake          *fakeRemoveMachineAPI
+	apiConnection *mockAPIConnection
 }
 
 var _ = gc.Suite(&RemoveMachineSuite{})
@@ -25,10 +27,13 @@ var _ = gc.Suite(&RemoveMachineSuite{})
 func (s *RemoveMachineSuite) SetUpTest(c *gc.C) {
 	s.FakeJujuXDGDataHomeSuite.SetUpTest(c)
 	s.fake = &fakeRemoveMachineAPI{}
+	s.apiConnection = &mockAPIConnection{
+		bestFacadeVersion: 4,
+	}
 }
 
 func (s *RemoveMachineSuite) run(c *gc.C, args ...string) (*cmd.Context, error) {
-	remove, _ := machine.NewRemoveCommandForTest(s.fake)
+	remove, _ := machine.NewRemoveCommandForTest(s.apiConnection, s.fake)
 	return cmdtesting.RunCommand(c, remove, args...)
 }
 
@@ -37,6 +42,7 @@ func (s *RemoveMachineSuite) TestInit(c *gc.C) {
 		args        []string
 		machines    []string
 		force       bool
+		keep        bool
 		errorString string
 	}{
 		{
@@ -56,6 +62,10 @@ func (s *RemoveMachineSuite) TestInit(c *gc.C) {
 			machines: []string{"1", "2"},
 			force:    true,
 		}, {
+			args:     []string{"--keep-instance", "1", "2"},
+			machines: []string{"1", "2"},
+			keep:     true,
+		}, {
 			args:        []string{"lxd"},
 			errorString: `invalid machine id "lxd"`,
 		}, {
@@ -64,11 +74,12 @@ func (s *RemoveMachineSuite) TestInit(c *gc.C) {
 		},
 	} {
 		c.Logf("test %d", i)
-		wrappedCommand, removeCmd := machine.NewRemoveCommandForTest(s.fake)
+		wrappedCommand, removeCmd := machine.NewRemoveCommandForTest(s.apiConnection, s.fake)
 		err := cmdtesting.InitCommand(wrappedCommand, test.args)
 		if test.errorString == "" {
 			c.Check(err, jc.ErrorIsNil)
 			c.Check(removeCmd.Force, gc.Equals, test.force)
+			c.Check(removeCmd.KeepInstance, gc.Equals, test.keep)
 			c.Check(removeCmd.MachineIds, jc.DeepEquals, test.machines)
 		} else {
 			c.Check(err, gc.ErrorMatches, test.errorString)
@@ -107,11 +118,30 @@ removing machine 2/lxd/1
 `[1:])
 }
 
+func (s *RemoveMachineSuite) TestRemoveOutputKeep(c *gc.C) {
+	ctx, err := s.run(c, "--keep-instance", "1", "2")
+	c.Assert(err, jc.ErrorIsNil)
+	stderr := cmdtesting.Stderr(ctx)
+	c.Assert(stderr, gc.Equals, `
+removing machine 1 (but retaining cloud instance)
+removing machine 2 (but retaining cloud instance)
+`[1:])
+}
+
 func (s *RemoveMachineSuite) TestRemoveForce(c *gc.C) {
 	_, err := s.run(c, "--force", "1", "2/lxd/1")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(s.fake.forced, jc.IsTrue)
+	c.Assert(s.fake.keep, jc.IsFalse)
 	c.Assert(s.fake.machines, jc.DeepEquals, []string{"1", "2/lxd/1"})
+}
+
+func (s *RemoveMachineSuite) TestRemoveKeep(c *gc.C) {
+	_, err := s.run(c, "--keep-instance", "1", "2")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(s.fake.forced, jc.IsFalse)
+	c.Assert(s.fake.keep, jc.IsTrue)
+	c.Assert(s.fake.machines, jc.DeepEquals, []string{"1", "2"})
 }
 
 func (s *RemoveMachineSuite) TestBlockedError(c *gc.C) {
@@ -128,8 +158,15 @@ func (s *RemoveMachineSuite) TestForceBlockedError(c *gc.C) {
 	testing.AssertOperationWasBlocked(c, err, ".*TestForceBlockedError.*")
 }
 
+func (s *RemoveMachineSuite) TestOldFacadeRemoveKeep(c *gc.C) {
+	s.apiConnection.bestFacadeVersion = 3
+	_, err := s.run(c, "--keep-instance", "1")
+	c.Assert(err, gc.ErrorMatches, "this version of Juju doesn't support --keep-instance")
+}
+
 type fakeRemoveMachineAPI struct {
 	forced      bool
+	keep        bool
 	machines    []string
 	removeError error
 	results     []params.DestroyMachineResult
@@ -149,6 +186,12 @@ func (f *fakeRemoveMachineAPI) ForceDestroyMachines(machines ...string) ([]param
 	return f.destroyMachines(machines)
 }
 
+func (f *fakeRemoveMachineAPI) DestroyMachinesWithParams(force, keep bool, machines ...string) ([]params.DestroyMachineResult, error) {
+	f.forced = force
+	f.keep = keep
+	return f.destroyMachines(machines)
+}
+
 func (f *fakeRemoveMachineAPI) destroyMachines(machines []string) ([]params.DestroyMachineResult, error) {
 	f.machines = machines
 	if f.removeError != nil || f.results != nil {
@@ -159,4 +202,13 @@ func (f *fakeRemoveMachineAPI) destroyMachines(machines []string) ([]params.Dest
 		results[i].Info = &params.DestroyMachineInfo{}
 	}
 	return results, nil
+}
+
+type mockAPIConnection struct {
+	api.Connection
+	bestFacadeVersion int
+}
+
+func (m *mockAPIConnection) BestFacadeVersion(name string) int {
+	return m.bestFacadeVersion
 }

--- a/environs/tags/tags.go
+++ b/environs/tags/tags.go
@@ -35,6 +35,11 @@ const (
 	// the service or unit that owns the Juju storage instance
 	// that an IaaS storage resource is assigned to.
 	JujuStorageOwner = JujuTagPrefix + "storage-owner"
+
+	// JujuMachine is the tag name used for identifying
+	// the model and machine id corresponding to the
+	// provisioned machine instance.
+	JujuMachine = JujuTagPrefix + "machine-id"
 )
 
 // ResourceTagger is an interface that can provide resource tags.

--- a/state/machine.go
+++ b/state/machine.go
@@ -215,6 +215,10 @@ type instanceData struct {
 	CpuPower   *uint64     `bson:"cpupower,omitempty"`
 	Tags       *[]string   `bson:"tags,omitempty"`
 	AvailZone  *string     `bson:"availzone,omitempty"`
+
+	// KeepInstance is set to true if, on machine removal from Juju,
+	// the cloud instance should be retained.
+	KeepInstance bool `bson:"keep-instance,omitempty"`
 }
 
 func hardwareCharacteristics(instData instanceData) *instance.HardwareCharacteristics {
@@ -275,6 +279,34 @@ func (m *Machine) Life() Life {
 // Jobs returns the responsibilities that must be fulfilled by m's agent.
 func (m *Machine) Jobs() []MachineJob {
 	return m.doc.Jobs
+}
+
+// SetKeepInstance sets whether the cloud machine instance
+// will be retained when the machine is removed from Juju.
+// This is only relevant if an instance exists.
+func (m *Machine) SetKeepInstance(keepInstance bool) error {
+	ops := []txn.Op{{
+		C:      instanceDataC,
+		Id:     m.doc.DocID,
+		Assert: txn.DocExists,
+		Update: bson.D{{"$set", bson.D{{"keep-instance", keepInstance}}}},
+	}}
+	if err := m.st.runTransaction(ops); err != nil {
+		// If instance doc doesn't exist, that's ok; there's nothing to keep,
+		// but that's not an error we care about.
+		return errors.Annotatef(onAbort(err, nil), "cannot set KeepInstance on machine %v", m)
+	}
+	return nil
+}
+
+// KeepInstance reports whether a machine, when removed from
+// Juju, will cause the corresponding cloud instance to be stopped.
+func (m *Machine) KeepInstance() (bool, error) {
+	instData, err := getInstanceData(m.st, m.Id())
+	if err != nil {
+		return false, err
+	}
+	return instData.KeepInstance, nil
 }
 
 // WantsVote reports whether the machine is a controller
@@ -1155,6 +1187,16 @@ func (m *Machine) SetProvisioned(id instance.Id, nonce string, characteristics *
 
 	if id == "" || nonce == "" {
 		return fmt.Errorf("instance id and nonce cannot be empty")
+	}
+
+	coll, closer := m.st.getRawCollection(instanceDataC)
+	defer closer()
+	count, err := coll.Find(bson.D{{"instanceid", id}}).Count()
+	if err != nil {
+		return errors.Trace(err)
+	}
+	if count > 0 {
+		logger.Warningf("duplicate instance id %q already saved", id)
 	}
 
 	if characteristics == nil {

--- a/state/machine_test.go
+++ b/state/machine_test.go
@@ -5,6 +5,7 @@ package state_test
 
 import (
 	"sort"
+	"strings"
 
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
@@ -29,6 +30,7 @@ import (
 	"github.com/juju/juju/storage/poolmanager"
 	"github.com/juju/juju/storage/provider"
 	coretesting "github.com/juju/juju/testing"
+	"github.com/juju/juju/testing/factory"
 )
 
 type MachineSuite struct {
@@ -109,6 +111,19 @@ func (s *MachineSuite) TestSetUnsetRebootFlag(c *gc.C) {
 	rebootFlag, err = s.machine.GetRebootFlag()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(rebootFlag, jc.IsFalse)
+}
+
+func (s *MachineSuite) TestSetKeepInstance(c *gc.C) {
+	err := s.machine.SetProvisioned("1234", "nonce", nil)
+	c.Assert(err, jc.ErrorIsNil)
+	err = s.machine.SetKeepInstance(true)
+	c.Assert(err, jc.ErrorIsNil)
+
+	m, err := s.State.Machine(s.machine.Id())
+	c.Assert(err, jc.ErrorIsNil)
+	keep, err := m.KeepInstance()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(keep, jc.IsTrue)
 }
 
 func (s *MachineSuite) TestAddMachineInsideMachineModelDying(c *gc.C) {
@@ -934,6 +949,28 @@ func (s *MachineSuite) TestMachineSetCheckProvisioned(c *gc.C) {
 
 	// Check it with invalid nonce.
 	c.Assert(s.machine.CheckProvisioned("not-really"), jc.IsFalse)
+}
+
+func (s *MachineSuite) TestSetProvisionedDupInstanceId(c *gc.C) {
+	var logWriter loggo.TestWriter
+	c.Assert(loggo.RegisterWriter("dupe-test", &logWriter), gc.IsNil)
+	s.AddCleanup(func(*gc.C) {
+		loggo.RemoveWriter("dupe-test")
+	})
+
+	err := s.machine.SetProvisioned("umbrella/0", "fake_nonce", nil)
+	c.Assert(err, jc.ErrorIsNil)
+
+	anotherMachine, _ := s.Factory.MakeUnprovisionedMachineReturningPassword(c, &factory.MachineParams{})
+	err = anotherMachine.SetProvisioned("umbrella/0", "another_nonce", nil)
+	c.Assert(err, jc.ErrorIsNil)
+	found := false
+	for _, le := range logWriter.Log() {
+		if found = strings.Contains(le.Message, "duplicate instance id"); found == true {
+			break
+		}
+	}
+	c.Assert(found, jc.IsTrue)
 }
 
 func (s *MachineSuite) TestMachineSetInstanceInfoFailureDoesNotProvision(c *gc.C) {

--- a/state/migration_internal_test.go
+++ b/state/migration_internal_test.go
@@ -315,7 +315,12 @@ func (s *MigrationSuite) TestMachineDocFields(c *gc.C) {
 }
 
 func (s *MigrationSuite) TestInstanceDataFields(c *gc.C) {
-	fields := set.NewStrings(
+	ignored := set.NewStrings(
+		// KeepInstance is only set when a machine is
+		// dying/dead (to be removed).
+		"KeepInstance",
+	)
+	migrated := set.NewStrings(
 		// DocID is the env + machine id
 		"DocID",
 		"MachineId",
@@ -332,7 +337,7 @@ func (s *MigrationSuite) TestInstanceDataFields(c *gc.C) {
 		"Tags",
 		"AvailZone",
 	)
-	s.AssertExportedFields(c, instanceData{}, fields)
+	s.AssertExportedFields(c, instanceData{}, migrated.Union(ignored))
 }
 
 func (s *MigrationSuite) TestApplicationDocFields(c *gc.C) {


### PR DESCRIPTION
## Description of change

Sometimes MAAS will fail a machine deployment after already telling Juju it will succeed. This can result in Juju having 2 machines in the model with the same instance id (one running, one not). Removing the bad machine in Juju then kills the good machine in MAAS.

Without significant MAAS/Juju changes, this issue cannot be fully fixed. Instead this PR adds some tooling to make things easier to deal with:
1. new "machine-id" instance tag to reflect the juju machine id (enables the user to correlate a cloud instance with the juju machine record)
2. log a warning when we write a duplicate instance id
3. a new argument to juju remove-machine: --keep-instance

When --keep-instance is used, the machine is removed from Juju but the provisioner will not call StopInstance() in the cloud, hence the cloud machine will be left running. This allows a failed machine which happens to have a duplicate instance id to be removed from Juju without stopping a cloud instance belonging to a different Juju machine.

## QA steps

bootstrap
add some machines (with and without units)
check the machine tags to see they include the new machine id tag
on an empty machine:
juju remove-machine --keep-instance
(verify that the machine is removed from juju but not killed in the cloud)
on a machine with units:
juju remove-machine --keep-instance --force
(verify that the machine is removed from juju but not killed in the cloud)

bootstrap juju 2.2
add a machine
juju remove-machine --keep-instance
-> error that juju doesn't support --keep-instance

## Documentation changes

The new --keep-instance argument to remove-machine needs to be documented.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1671588