### PR TITLE
Remove unused attributes from cmr model; refactor worker

### DIFF
--- a/api/applicationoffers/client.go
+++ b/api/applicationoffers/client.go
@@ -89,8 +89,6 @@ func convertListResultsToModel(items []params.ApplicationOfferDetails) []crossmo
 				Name:      ep.Name,
 				Role:      ep.Role,
 				Interface: ep.Interface,
-				Scope:     ep.Scope,
-				Limit:     ep.Limit,
 			}
 		}
 		result[i].Result = &crossmodel.ApplicationOfferDetails{

--- a/api/crossmodelrelations/crossmodelrelations.go
+++ b/api/crossmodelrelations/crossmodelrelations.go
@@ -107,7 +107,7 @@ func (c *Client) PublishRelationChange(change params.RemoteRelationChangeEvent) 
 	}
 	// Make the api call the first time.
 	err := apiCall()
-	if errors.IsNotFound(err) {
+	if err == nil || errors.IsNotFound(err) {
 		return errors.Trace(err)
 	}
 

--- a/apiserver/common/crossmodel/auth.go
+++ b/apiserver/common/crossmodel/auth.go
@@ -275,7 +275,7 @@ func (a *AuthContext) Authenticator(sourceModelUUID, offerURL string) *authentic
 }
 
 func (a *authenticator) checkMacaroons(mac macaroon.Slice, requiredValues map[string]string) (map[string]string, error) {
-	logger.Debugf("check macaroons with required attrs: %v", requiredValues)
+	logger.Debugf("check %d macaroons with required attrs: %v", len(mac), requiredValues)
 	for _, m := range mac {
 		logger.Debugf("- mac %s", m.Id())
 	}

--- a/apiserver/facades/client/application/application.go
+++ b/apiserver/facades/client/application/application.go
@@ -999,8 +999,6 @@ func (api *API) saveRemoteApplication(
 			Name:      ep.Name,
 			Role:      ep.Role,
 			Interface: ep.Interface,
-			Limit:     ep.Limit,
-			Scope:     ep.Scope,
 		}
 	}
 

--- a/apiserver/facades/client/application/application_test.go
+++ b/apiserver/facades/client/application/application_test.go
@@ -2440,14 +2440,17 @@ func (s *applicationSuite) checkEndpoints(c *gc.C, mysqlAppName string, endpoint
 		Limit:     1,
 		Scope:     "global",
 	})
-	c.Assert(endpoints[mysqlAppName], gc.DeepEquals, params.CharmRelation{
+	ep := params.CharmRelation{
 		Name:      "server",
 		Role:      "provider",
 		Interface: "mysql",
-		Optional:  false,
-		Limit:     0,
 		Scope:     "global",
-	})
+	}
+	// Remote applications don't use scope.
+	if mysqlAppName == "hosted-mysql" {
+		ep.Scope = ""
+	}
+	c.Assert(endpoints[mysqlAppName], gc.DeepEquals, ep)
 }
 
 func (s *applicationSuite) setupRelationScenario(c *gc.C) {
@@ -2560,7 +2563,7 @@ func (s *applicationSuite) setupRemoteApplication(c *gc.C) {
 				OfferName:              "hosted-mysql",
 				ApplicationDescription: "A pretty popular database",
 				Endpoints: []params.RemoteEndpoint{
-					{Name: "server", Interface: "mysql", Role: "provider", Scope: "global"},
+					{Name: "server", Interface: "mysql", Role: "provider"},
 				},
 			}},
 		},
@@ -2613,7 +2616,7 @@ func (s *applicationSuite) TestRemoteRelationNoMatchingEndpoint(c *gc.C) {
 				SourceModelTag: testing.ModelTag.String(),
 				OfferName:      "hosted-db2",
 				Endpoints: []params.RemoteEndpoint{
-					{Name: "database", Interface: "db2", Role: "provider", Scope: "global"},
+					{Name: "database", Interface: "db2", Role: "provider"},
 				},
 			}},
 		},

--- a/apiserver/facades/client/applicationoffers/applicationoffers_test.go
+++ b/apiserver/facades/client/applicationoffers/applicationoffers_test.go
@@ -988,7 +988,7 @@ func (s *consumeSuite) TestConsumeDetailsWithPermission(c *gc.C) {
 		OfferURL:               "fred/prod.hosted-mysql",
 		OfferName:              "hosted-mysql",
 		ApplicationDescription: "a database",
-		Endpoints:              []params.RemoteEndpoint{{Name: "server", Role: "provider", Interface: "mysql", Limit: 0, Scope: "global"}},
+		Endpoints:              []params.RemoteEndpoint{{Name: "server", Role: "provider", Interface: "mysql"}},
 		Bindings:               map[string]string{"database": "myspace"},
 		Spaces: []params.RemoteSpace{
 			{
@@ -1040,7 +1040,7 @@ func (s *consumeSuite) TestConsumeDetailsDefaultEndpoint(c *gc.C) {
 		OfferURL:               "fred/prod.hosted-mysql",
 		OfferName:              "hosted-mysql",
 		ApplicationDescription: "a database",
-		Endpoints:              []params.RemoteEndpoint{{Name: "server", Role: "provider", Interface: "mysql", Limit: 0, Scope: "global"}},
+		Endpoints:              []params.RemoteEndpoint{{Name: "server", Role: "provider", Interface: "mysql"}},
 		Bindings:               map[string]string{"database": ""},
 		Access:                 "consume",
 	})
@@ -1126,7 +1126,7 @@ func (s *consumeSuite) TestRemoteApplicationInfo(c *gc.C) {
 			SourceModelLabel: "prod",
 			IconURLPath:      "rest/1.0/remote-application/hosted-mysql/icon",
 			Endpoints: []params.RemoteEndpoint{
-				{Name: "server", Role: "provider", Interface: "mysql", Limit: 0, Scope: "global"}},
+				{Name: "server", Role: "provider", Interface: "mysql"}},
 		}},
 		{
 			Error: &params.Error{Message: `application offer "unknown" not found`, Code: "not found"},

--- a/apiserver/facades/client/applicationoffers/base.go
+++ b/apiserver/facades/client/applicationoffers/base.go
@@ -331,8 +331,6 @@ func (api *BaseAPI) makeOfferParams(backend Backend, offer *jujucrossmodel.Appli
 			Name:      alias,
 			Interface: ep.Interface,
 			Role:      ep.Role,
-			Scope:     ep.Scope,
-			Limit:     ep.Limit,
 		})
 		spaceName, ok := appBindings[ep.Name]
 		if !ok {

--- a/apiserver/facades/client/client/api_test.go
+++ b/apiserver/facades/client/client/api_test.go
@@ -174,7 +174,6 @@ var scenarioStatus = &params.FullStatus{
 				Name:      "database",
 				Interface: "db2",
 				Role:      "provider",
-				Scope:     "global",
 			}},
 			Relations: map[string][]string{},
 			Status: params.DetailedStatus{

--- a/apiserver/facades/client/client/status.go
+++ b/apiserver/facades/client/client/status.go
@@ -964,7 +964,6 @@ func (context *statusContext) processRemoteApplication(application *state.Remote
 			Name:      ep.Name,
 			Interface: ep.Interface,
 			Role:      ep.Role,
-			Scope:     ep.Scope,
 		}
 	}
 	status.Life = processLife(application)
@@ -999,7 +998,6 @@ func (context *statusContext) processOffers() map[string]params.ApplicationOffer
 				Name:      ep.Name,
 				Interface: ep.Interface,
 				Role:      ep.Role,
-				Limit:     ep.Limit,
 			}
 		}
 		offers[name] = offerStatus

--- a/apiserver/facades/controller/crossmodelrelations/crossmodelrelations.go
+++ b/apiserver/facades/controller/crossmodelrelations/crossmodelrelations.go
@@ -220,10 +220,8 @@ func (api *CrossModelRelationsAPI) registerRemoteRelation(relation params.Regist
 		ApplicationName: uniqueRemoteApplicationName,
 		Relation: charm.Relation{
 			Name:      relation.RemoteEndpoint.Name,
-			Scope:     relation.RemoteEndpoint.Scope,
 			Interface: relation.RemoteEndpoint.Interface,
 			Role:      relation.RemoteEndpoint.Role,
-			Limit:     relation.RemoteEndpoint.Limit,
 		},
 	}
 

--- a/apiserver/facades/controller/remoterelations/remoterelations.go
+++ b/apiserver/facades/controller/remoterelations/remoterelations.go
@@ -215,8 +215,6 @@ func (api *RemoteRelationsAPI) remoteRelation(entity params.Entity) (*params.Rem
 				Name:      ep.Name,
 				Interface: ep.Interface,
 				Role:      ep.Role,
-				Scope:     ep.Scope,
-				Limit:     ep.Limit,
 			}
 			continue
 		}

--- a/apiserver/facades/controller/remoterelations/remoterelations_test.go
+++ b/apiserver/facades/controller/remoterelations/remoterelations_test.go
@@ -331,8 +331,6 @@ func (s *remoteRelationsSuite) TestRelations(c *gc.C) {
 				Name:      "db",
 				Role:      "provides",
 				Interface: "db2",
-				Limit:     1,
-				Scope:     "global",
 			}},
 	}})
 	s.st.CheckCalls(c, []testing.StubCall{

--- a/apiserver/params/crossmodel.go
+++ b/apiserver/params/crossmodel.go
@@ -81,11 +81,10 @@ type AddApplicationOffer struct {
 
 // RemoteEndpoint represents a remote application endpoint.
 type RemoteEndpoint struct {
-	Name      string              `json:"name"`
-	Role      charm.RelationRole  `json:"role"`
-	Interface string              `json:"interface"`
-	Limit     int                 `json:"limit"`
-	Scope     charm.RelationScope `json:"scope"`
+	Name      string             `json:"name"`
+	Role      charm.RelationRole `json:"role"`
+	Interface string             `json:"interface"`
+	Limit     int                `json:"limit"`
 }
 
 // RemoteSpace represents a space in some remote model.

--- a/featuretests/cmd_juju_crossmodel_test.go
+++ b/featuretests/cmd_juju_crossmodel_test.go
@@ -220,8 +220,7 @@ func (s *crossmodelSuite) TestAddRelationFromURL(c *gc.C) {
 			ApplicationName: "hosted-mysql",
 			Relation: charm.Relation{Name: "server",
 				Role:      "provider",
-				Interface: "mysql",
-				Scope:     "global"},
+				Interface: "mysql"},
 		},
 	})
 }
@@ -248,8 +247,7 @@ func (s *crossmodelSuite) assertAddRelationSameControllerSuccess(c *gc.C, otherM
 			ApplicationName: "hosted-mysql",
 			Relation: charm.Relation{Name: "database",
 				Role:      "provider",
-				Interface: "mysql",
-				Scope:     "global"},
+				Interface: "mysql"},
 		},
 	})
 }

--- a/state/remoteapplication_test.go
+++ b/state/remoteapplication_test.go
@@ -653,7 +653,7 @@ func (s *remoteApplicationSuite) TestAddRemoteRelationWrongScope(c *gc.C) {
 		},
 	}
 	_, err := s.State.AddRelation(ep1, ep2)
-	c.Assert(err, gc.ErrorMatches, `cannot add relation "logging:logging-client mysql:logging": both endpoints must be globally scoped for remote relations`)
+	c.Assert(err, gc.ErrorMatches, `cannot add relation "logging:logging-client mysql:logging": local endpoint must be globally scoped for remote relations`)
 }
 
 func (s *remoteApplicationSuite) TestAddRemoteRelationLocalFirst(c *gc.C) {

--- a/worker/firewaller/firewaller.go
+++ b/worker/firewaller/firewaller.go
@@ -329,6 +329,10 @@ func (fw *Firewaller) publishNetworkChanged(change *remoteRelationNetworkChange)
 		return errors.Annotatef(err, "cannot get api info for model %v", relData.remoteModelUUID)
 	}
 	mac, err := fw.firewallerApi.MacaroonForRelation(relData.tag.Id())
+	if params.IsCodeNotFound(err) {
+		// Relation has gone, nothing to do.
+		return nil
+	}
 	if err != nil {
 		return errors.Annotatef(err, "cannot get macaroon for %v", relData.tag.Id())
 	}

--- a/worker/remoterelations/remoterelations_test.go
+++ b/worker/remoterelations/remoterelations_test.go
@@ -141,8 +141,6 @@ func (s *remoteRelationsSuite) assertRemoteRelationsWorkers(c *gc.C) worker.Work
 			Name:      "db2",
 			Role:      "requires",
 			Interface: "db2",
-			Limit:     1,
-			Scope:     "global",
 		},
 		remoteEndpointName: "data",
 	}
@@ -169,8 +167,6 @@ func (s *remoteRelationsSuite) assertRemoteRelationsWorkers(c *gc.C) worker.Work
 				Name:      "db2",
 				Role:      "requires",
 				Interface: "db2",
-				Limit:     1,
-				Scope:     "global",
 			},
 			OfferName:         "offer-db2",
 			LocalEndpointName: "data",
@@ -426,8 +422,6 @@ func (s *remoteRelationsSuite) TestRegisteredApplicationNotRegistered(c *gc.C) {
 			Name:      "db2",
 			Role:      "requires",
 			Interface: "db2",
-			Limit:     1,
-			Scope:     "global",
 		},
 		remoteEndpointName: "data",
 	}
@@ -437,8 +431,6 @@ func (s *remoteRelationsSuite) TestRegisteredApplicationNotRegistered(c *gc.C) {
 
 	expected = []jujutesting.StubCall{
 		{"Relations", []interface{}{[]string{"db2:db django:db"}}},
-		{"GetToken", []interface{}{names.NewRelationTag("db2:db django:db")}},
-		{"GetToken", []interface{}{names.NewApplicationTag("django")}},
 	}
 	s.waitForWorkerStubCalls(c, expected)
 }


### PR DESCRIPTION
## Description of change

For remote relation endpoints, we don't need to keep track of Limit or Scope, so remove those attributes.
Clean up the remote relations worker to remove unnecessary code.
Move various relation attributes to the right place so multiple remote relations are handled properly.

## QA steps

Run up a cmr scenario.
Delete and re-create relations.
Add a second app and relate.
Ensure that all works.
