### PR TITLE
Use offer-uuid to look up offer permissions and send messages between models

### DIFF
--- a/api/application/client_test.go
+++ b/api/application/client_test.go
@@ -426,6 +426,7 @@ func (s *applicationSuite) TestConsume(c *gc.C) {
 	offer := params.ApplicationOffer{
 		SourceModelTag:         "source model",
 		OfferName:              "an offer",
+		OfferUUID:              "offer-uuid",
 		OfferURL:               "offer url",
 		ApplicationDescription: "description",
 		Endpoints:              []params.RemoteEndpoint{{Name: "endpoint"}},

--- a/api/applicationoffers/client_test.go
+++ b/api/applicationoffers/client_test.go
@@ -136,6 +136,7 @@ func (s *crossmodelMockSuite) TestList(c *gc.C) {
 				offer := params.ApplicationOffer{
 					OfferURL:  url,
 					OfferName: offerName,
+					OfferUUID: offerName + "-uuid",
 					Endpoints: endpoints,
 				}
 				results.Results = []params.ApplicationOfferDetails{{

--- a/api/crossmodelrelations/crossmodelrelations_test.go
+++ b/api/crossmodelrelations/crossmodelrelations_test.go
@@ -153,7 +153,7 @@ func (s *CrossModelRelationsSuite) TestRegisterRemoteRelations(c *gc.C) {
 		c.Check(arg, gc.DeepEquals, params.RegisterRemoteRelationArgs{
 			Relations: []params.RegisterRemoteRelationArg{{
 				RelationToken: "token",
-				OfferName:     "offeredapp",
+				OfferUUID:     "offer-uuid",
 				Macaroons:     macaroon.Slice{mac}}}})
 		c.Assert(result, gc.FitsTypeOf, &params.RegisterRemoteRelationResults{})
 		*(result.(*params.RegisterRemoteRelationResults)) = params.RegisterRemoteRelationResults{
@@ -167,7 +167,7 @@ func (s *CrossModelRelationsSuite) TestRegisterRemoteRelations(c *gc.C) {
 	client := crossmodelrelations.NewClientWithCache(apiCaller, s.cache)
 	result, err := client.RegisterRemoteRelations(params.RegisterRemoteRelationArg{
 		RelationToken: "token",
-		OfferName:     "offeredapp",
+		OfferUUID:     "offer-uuid",
 		Macaroons:     macaroon.Slice{mac},
 	})
 	c.Check(err, jc.ErrorIsNil)
@@ -180,7 +180,7 @@ func (s *CrossModelRelationsSuite) TestRegisterRemoteRelations(c *gc.C) {
 	s.cache.Upsert("token", macaroon.Slice{mac})
 	result, err = client.RegisterRemoteRelations(params.RegisterRemoteRelationArg{
 		RelationToken: "token",
-		OfferName:     "offeredapp",
+		OfferUUID:     "offer-uuid",
 		Macaroons:     macaroon.Slice{different},
 	})
 	c.Check(err, jc.ErrorIsNil)
@@ -234,7 +234,7 @@ func (s *CrossModelRelationsSuite) TestRegisterRemoteRelationDischargeRequired(c
 	client := crossmodelrelations.NewClientWithCache(callerWithBakery, s.cache)
 	result, err := client.RegisterRemoteRelations(params.RegisterRemoteRelationArg{
 		RelationToken: "token",
-		OfferName:     "offeredapp"})
+		OfferUUID:     "offer-uuid"})
 	c.Check(err, jc.ErrorIsNil)
 	c.Check(callCount, gc.Equals, 2)
 	c.Assert(result, gc.HasLen, 1)

--- a/api/watcher/watcher_test.go
+++ b/api/watcher/watcher_test.go
@@ -263,14 +263,14 @@ func (s *watcherSuite) assertRelationStatusWatchResult(c *gc.C, rel *state.Relat
 	// Create the offer connection details.
 	s.Factory.MakeUser(c, &factory.UserParams{Name: "fred"})
 	offers := state.NewApplicationOffers(s.State)
-	_, err = offers.AddOffer(crossmodel.AddApplicationOfferArgs{
+	offer, err := offers.AddOffer(crossmodel.AddApplicationOfferArgs{
 		OfferName:       "hosted-mysql",
 		ApplicationName: "mysql",
 		Owner:           "admin",
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	_, err = s.State.AddOfferConnection(state.AddOfferConnectionParams{
-		OfferName:       "hosted-mysql",
+		OfferUUID:       offer.OfferUUID,
 		Username:        "fred",
 		RelationKey:     rel.String(),
 		RelationId:      rel.Id(),

--- a/apiserver/authhttp_test.go
+++ b/apiserver/authhttp_test.go
@@ -237,10 +237,10 @@ func (s *authHTTPSuite) authRequest(c *gc.C, p httpRequestParams) *http.Response
 }
 
 func (s *authHTTPSuite) setupOtherModel(c *gc.C) *state.State {
-	envState := s.Factory.MakeModel(c, nil)
-	s.AddCleanup(func(*gc.C) { envState.Close() })
+	modelState := s.Factory.MakeModel(c, nil)
+	s.AddCleanup(func(*gc.C) { modelState.Close() })
 	user := s.Factory.MakeUser(c, nil)
-	_, err := envState.AddModelUser(envState.ModelUUID(),
+	_, err := modelState.AddModelUser(modelState.ModelUUID(),
 		state.UserAccessSpec{
 			User:      user.UserTag(),
 			CreatedBy: s.userTag,
@@ -248,8 +248,8 @@ func (s *authHTTPSuite) setupOtherModel(c *gc.C) *state.State {
 	c.Assert(err, jc.ErrorIsNil)
 	s.userTag = user.UserTag()
 	s.password = "password"
-	s.modelUUID = envState.ModelUUID()
-	return envState
+	s.modelUUID = modelState.ModelUUID()
+	return modelState
 }
 
 func (s *authHTTPSuite) uploadRequest(c *gc.C, uri string, contentType, path string) *http.Response {

--- a/apiserver/common/crossmodel/interface.go
+++ b/apiserver/common/crossmodel/interface.go
@@ -8,6 +8,7 @@ import (
 	"gopkg.in/juju/names.v2"
 	"gopkg.in/macaroon.v1"
 
+	"github.com/juju/juju/core/crossmodel"
 	"github.com/juju/juju/permission"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/status"
@@ -35,7 +36,7 @@ type Backend interface {
 	Application(string) (Application, error)
 
 	// GetOfferAccess gets the access permission for the specified user on an offer.
-	GetOfferAccess(offer names.ApplicationOfferTag, user names.UserTag) (permission.Access, error)
+	GetOfferAccess(offerUUID string, user names.UserTag) (permission.Access, error)
 
 	// UserPermission returns the access permission for the passed subject and target.
 	UserPermission(subject names.UserTag, target names.Tag) (permission.Access, error)
@@ -67,6 +68,9 @@ type Backend interface {
 
 	// SaveIngressNetworks stores in state the ingress networks for the relation.
 	SaveIngressNetworks(relationKey string, cidrs []string) (RelationIngress, error)
+
+	// ApplicationOfferForUUID returns the application offer for the UUID.
+	ApplicationOfferForUUID(offerUUID string) (*crossmodel.ApplicationOffer, error)
 }
 
 // Relation provides access a relation in global state.
@@ -180,8 +184,8 @@ type RemoteApplication interface {
 	// URL returns the remote application URL, at which it is offered.
 	URL() (string, bool)
 
-	// OfferName returns the name the offering side has given to the remote application..
-	OfferName() string
+	// OfferUUID returns the UUID of the offer.
+	OfferUUID() string
 
 	// SourceModel returns the tag of the model hosting the remote application.
 	SourceModel() names.ModelTag

--- a/apiserver/common/crossmodel/mock_test.go
+++ b/apiserver/common/crossmodel/mock_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/juju/juju/apiserver/authentication"
 	"github.com/juju/juju/apiserver/common/crossmodel"
+	jujucrossmodel "github.com/juju/juju/core/crossmodel"
 	"github.com/juju/juju/permission"
 	coretesting "github.com/juju/juju/testing"
 )
@@ -42,6 +43,10 @@ type mockState struct {
 	permissions map[string]permission.Access
 }
 
+func (m *mockState) ApplicationOfferForUUID(offerUUID string) (*jujucrossmodel.ApplicationOffer, error) {
+	return &jujucrossmodel.ApplicationOffer{OfferUUID: offerUUID}, nil
+}
+
 func (m *mockState) UserPermission(subject names.UserTag, target names.Tag) (permission.Access, error) {
 	perm, ok := m.permissions[target.Id()+":"+subject.Id()]
 	if !ok {
@@ -50,8 +55,8 @@ func (m *mockState) UserPermission(subject names.UserTag, target names.Tag) (per
 	return perm, nil
 }
 
-func (m *mockState) GetOfferAccess(offer names.ApplicationOfferTag, user names.UserTag) (permission.Access, error) {
-	perm, ok := m.permissions[offer.Id()+":"+user.Id()]
+func (m *mockState) GetOfferAccess(offerUUID string, user names.UserTag) (permission.Access, error) {
+	perm, ok := m.permissions[offerUUID+":"+user.Id()]
 	if !ok {
 		return permission.NoAccess, nil
 	}

--- a/apiserver/common/crossmodel/state.go
+++ b/apiserver/common/crossmodel/state.go
@@ -7,6 +7,7 @@ import (
 	"github.com/juju/errors"
 	"gopkg.in/juju/names.v2"
 
+	"github.com/juju/juju/core/crossmodel"
 	"github.com/juju/juju/state"
 )
 
@@ -114,6 +115,10 @@ func (st stateShim) ExportLocalEntity(entity names.Tag) (string, error) {
 func (st stateShim) ImportRemoteEntity(entity names.Tag, token string) error {
 	r := st.State.RemoteEntities()
 	return r.ImportRemoteEntity(entity, token)
+}
+
+func (st stateShim) ApplicationOfferForUUID(offerUUID string) (*crossmodel.ApplicationOffer, error) {
+	return state.NewApplicationOffers(st.State).ApplicationOfferForUUID(offerUUID)
 }
 
 type RelationIngress state.RelationIngress

--- a/apiserver/facades/agent/uniter/uniter_test.go
+++ b/apiserver/facades/agent/uniter/uniter_test.go
@@ -2703,7 +2703,7 @@ func (s *uniterSuite) makeRemoteWordpress(c *gc.C) {
 		Name:            "remote-wordpress",
 		SourceModel:     names.NewModelTag("source-model"),
 		IsConsumerProxy: true,
-		OfferName:       "chapo",
+		OfferUUID:       "offer-uuid",
 		Endpoints: []charm.Relation{{
 			Interface: "mysql",
 			Limit:     1,

--- a/apiserver/facades/client/application/application.go
+++ b/apiserver/facades/client/application/application.go
@@ -1018,7 +1018,7 @@ func (api *API) saveRemoteApplication(
 
 	return api.backend.AddRemoteApplication(state.AddRemoteApplicationParams{
 		Name:        applicationName,
-		OfferName:   offer.OfferName,
+		OfferUUID:   offer.OfferUUID,
 		URL:         offer.OfferURL,
 		SourceModel: sourceModelTag,
 		Endpoints:   remoteEps,

--- a/apiserver/facades/client/application/application_test.go
+++ b/apiserver/facades/client/application/application_test.go
@@ -2561,6 +2561,7 @@ func (s *applicationSuite) setupRemoteApplication(c *gc.C) {
 			{ApplicationOffer: params.ApplicationOffer{
 				SourceModelTag:         testing.ModelTag.String(),
 				OfferName:              "hosted-mysql",
+				OfferUUID:              "hosted-mysql-uuid",
 				ApplicationDescription: "A pretty popular database",
 				Endpoints: []params.RemoteEndpoint{
 					{Name: "server", Interface: "mysql", Role: "provider"},
@@ -2615,6 +2616,7 @@ func (s *applicationSuite) TestRemoteRelationNoMatchingEndpoint(c *gc.C) {
 			{ApplicationOffer: params.ApplicationOffer{
 				SourceModelTag: testing.ModelTag.String(),
 				OfferName:      "hosted-db2",
+				OfferUUID:      "hosted-db2-uuid",
 				Endpoints: []params.RemoteEndpoint{
 					{Name: "database", Interface: "db2", Role: "provider"},
 				},

--- a/apiserver/facades/client/application/application_unit_test.go
+++ b/apiserver/facades/client/application/application_unit_test.go
@@ -368,6 +368,7 @@ func (s *ApplicationSuite) TestConsumeIdempotent(c *gc.C) {
 				ApplicationOffer: params.ApplicationOffer{
 					SourceModelTag:         coretesting.ModelTag.String(),
 					OfferName:              "hosted-mysql",
+					OfferUUID:              "hosted-mysql-uuid",
 					ApplicationDescription: "a database",
 					Endpoints:              []params.RemoteEndpoint{{Name: "database", Interface: "mysql", Role: "provider"}},
 					OfferURL:               "othermodel.hosted-mysql",
@@ -382,7 +383,7 @@ func (s *ApplicationSuite) TestConsumeIdempotent(c *gc.C) {
 	c.Assert(obtained, jc.DeepEquals, &mockRemoteApplication{
 		name:           "hosted-mysql",
 		sourceModelTag: coretesting.ModelTag,
-		offerName:      "hosted-mysql",
+		offerUUID:      "hosted-mysql-uuid",
 		offerURL:       "othermodel.hosted-mysql",
 		endpoints: []state.Endpoint{
 			{ApplicationName: "hosted-mysql", Relation: charm.Relation{Name: "database", Interface: "mysql", Role: "provider"}}},
@@ -398,6 +399,7 @@ func (s *ApplicationSuite) TestConsumeFromExternalController(c *gc.C) {
 			ApplicationOffer: params.ApplicationOffer{
 				SourceModelTag:         coretesting.ModelTag.String(),
 				OfferName:              "hosted-mysql",
+				OfferUUID:              "hosted-mysql-uuid",
 				ApplicationDescription: "a database",
 				Endpoints:              []params.RemoteEndpoint{{Name: "database", Interface: "mysql", Role: "provider"}},
 				OfferURL:               "othermodel.hosted-mysql",
@@ -417,7 +419,7 @@ func (s *ApplicationSuite) TestConsumeFromExternalController(c *gc.C) {
 	c.Assert(obtained, jc.DeepEquals, &mockRemoteApplication{
 		name:           "hosted-mysql",
 		sourceModelTag: coretesting.ModelTag,
-		offerName:      "hosted-mysql",
+		offerUUID:      "hosted-mysql-uuid",
 		offerURL:       "othermodel.hosted-mysql",
 		endpoints: []state.Endpoint{
 			{ApplicationName: "hosted-mysql", Relation: charm.Relation{Name: "database", Interface: "mysql", Role: "provider"}}},
@@ -438,6 +440,7 @@ func (s *ApplicationSuite) TestConsumeFromSameController(c *gc.C) {
 			ApplicationOffer: params.ApplicationOffer{
 				SourceModelTag:         coretesting.ModelTag.String(),
 				OfferName:              "hosted-mysql",
+				OfferUUID:              "hosted-mysql-uuid",
 				ApplicationDescription: "a database",
 				Endpoints:              []params.RemoteEndpoint{{Name: "database", Interface: "mysql", Role: "provider"}},
 				OfferURL:               "othermodel.hosted-mysql",
@@ -480,6 +483,7 @@ func (s *ApplicationSuite) TestConsumeIncludesSpaceInfo(c *gc.C) {
 			ApplicationOffer: params.ApplicationOffer{
 				SourceModelTag:         coretesting.ModelTag.String(),
 				OfferName:              "hosted-mysql",
+				OfferUUID:              "hosted-mysql-uuid",
 				ApplicationDescription: "a database",
 				Endpoints:              []params.RemoteEndpoint{{Name: "server", Interface: "mysql", Role: "provider"}},
 				OfferURL:               "othermodel.hosted-mysql",
@@ -535,6 +539,7 @@ func (s *ApplicationSuite) TestConsumeRemoteAppExistsDifferentSourceModel(c *gc.
 		ApplicationOffer: params.ApplicationOffer{
 			SourceModelTag:         coretesting.ModelTag.String(),
 			OfferName:              "hosted-mysql",
+			OfferUUID:              "hosted-mysql-uuid",
 			ApplicationDescription: "a database",
 			Endpoints:              []params.RemoteEndpoint{{Name: "database", Interface: "mysql", Role: "provider"}},
 			OfferURL:               "othermodel.hosted-mysql",
@@ -561,6 +566,7 @@ func (s *ApplicationSuite) assertConsumeWithNoSpacesInfoAvailable(c *gc.C) {
 			ApplicationOffer: params.ApplicationOffer{
 				SourceModelTag:         coretesting.ModelTag.String(),
 				OfferName:              "hosted-mysql",
+				OfferUUID:              "hosted-mysql-uuid",
 				ApplicationDescription: "a database",
 				Endpoints:              []params.RemoteEndpoint{{Name: "database", Interface: "mysql", Role: "provider"}},
 				OfferURL:               "othermodel.hosted-mysql",

--- a/apiserver/facades/client/application/mock_test.go
+++ b/apiserver/facades/client/application/mock_test.go
@@ -146,7 +146,7 @@ type mockRemoteApplication struct {
 	endpoints      []state.Endpoint
 	bindings       map[string]string
 	spaces         []state.RemoteSpace
-	offerName      string
+	offerUUID      string
 	offerURL       string
 	mac            *macaroon.Macaroon
 }
@@ -350,7 +350,7 @@ func (m *mockBackend) AddRemoteApplication(args state.AddRemoteApplicationParams
 	app := &mockRemoteApplication{
 		name:           args.Name,
 		sourceModelTag: args.SourceModel,
-		offerName:      args.OfferName,
+		offerUUID:      args.OfferUUID,
 		offerURL:       args.URL,
 		bindings:       args.Bindings,
 		mac:            args.Macaroon,

--- a/apiserver/facades/client/applicationoffers/access_test.go
+++ b/apiserver/facades/client/applicationoffers/access_test.go
@@ -85,7 +85,7 @@ func (s *offerAccessSuite) setupOffer(modelUUID, modelName, owner, offerName str
 		model:             model,
 	}
 	s.mockStatePool.st[modelUUID] = st
-	st.applicationOffers[offerName] = jujucrossmodel.ApplicationOffer{}
+	st.applicationOffers[offerName] = jujucrossmodel.ApplicationOffer{OfferUUID: offerName + "-uuid"}
 }
 
 func (s *offerAccessSuite) TestGrantMissingUserFails(c *gc.C) {
@@ -117,7 +117,7 @@ func (s *offerAccessSuite) TestRevokeAdminLeavesReadAccess(c *gc.C) {
 	err = s.revoke(c, user, params.OfferConsumeAccess, "test.someoffer")
 	c.Assert(err, jc.ErrorIsNil)
 
-	access, err := st.GetOfferAccess(offer, user)
+	access, err := st.GetOfferAccess(offer.Id()+"-uuid", user)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(access, gc.Equals, permission.ReadAccess)
 }
@@ -135,7 +135,7 @@ func (s *offerAccessSuite) TestRevokeReadRemovesPermission(c *gc.C) {
 	err = s.revoke(c, user, params.OfferReadAccess, "test.someoffer")
 	c.Assert(err, gc.IsNil)
 
-	_, err = st.GetOfferAccess(offer, user)
+	_, err = st.GetOfferAccess(offer.Id()+"-uuid", user)
 	c.Assert(errors.IsNotFound(err), jc.IsTrue)
 }
 
@@ -148,7 +148,7 @@ func (s *offerAccessSuite) TestRevokeMissingUser(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, `could not revoke offer access: offer user "bob" does not exist`)
 
 	offer := names.NewApplicationOfferTag("someoffer")
-	_, err = st.GetOfferAccess(offer, user)
+	_, err = st.GetOfferAccess(offer.Id()+"-uuid", user)
 	c.Assert(errors.IsNotFound(err), jc.IsTrue)
 }
 
@@ -178,7 +178,7 @@ func (s *offerAccessSuite) assertGrantOfferAddUser(c *gc.C, user names.UserTag) 
 	c.Assert(err, jc.ErrorIsNil)
 
 	offer := names.NewApplicationOfferTag("someoffer")
-	access, err := st.GetOfferAccess(offer, user)
+	access, err := st.GetOfferAccess(offer.Id()+"-uuid", user)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(access, gc.Equals, permission.ReadAccess)
 }
@@ -204,7 +204,7 @@ func (s *offerAccessSuite) TestGrantOfferSuperUser(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	offer := names.NewApplicationOfferTag("someoffer")
-	access, err := st.GetOfferAccess(offer, other)
+	access, err := st.GetOfferAccess(offer.Id()+"-uuid", other)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(access, gc.Equals, permission.ReadAccess)
 }
@@ -225,7 +225,7 @@ func (s *offerAccessSuite) TestGrantIncreaseAccess(c *gc.C) {
 	err = s.grant(c, user, params.OfferConsumeAccess, "other/test.someoffer")
 	c.Assert(err, jc.ErrorIsNil)
 
-	access, err := st.GetOfferAccess(offer, user)
+	access, err := st.GetOfferAccess(offer.Id()+"-uuid", user)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(access, gc.Equals, permission.ConsumeAccess)
 }
@@ -287,7 +287,7 @@ func (s *offerAccessSuite) TestGrantToOfferAdminAccess(c *gc.C) {
 	err = s.grant(c, other, params.OfferReadAccess, "foobar/test.someoffer")
 	c.Assert(err, jc.ErrorIsNil)
 
-	access, err := st.GetOfferAccess(offer, other)
+	access, err := st.GetOfferAccess(offer.Id()+"-uuid", other)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(access, gc.Equals, permission.ReadAccess)
 }

--- a/apiserver/facades/client/applicationoffers/applicationoffers_test.go
+++ b/apiserver/facades/client/applicationoffers/applicationoffers_test.go
@@ -226,6 +226,7 @@ func (s *applicationOffersSuite) assertList(c *gc.C, expectedErr error) {
 					SourceModelTag:         testing.ModelTag.String(),
 					ApplicationDescription: "description",
 					OfferName:              "hosted-db2",
+					OfferUUID:              "hosted-db2-uuid",
 					OfferURL:               "fred/prod.hosted-db2",
 					Endpoints:              []params.RemoteEndpoint{{Name: "db"}},
 					Bindings:               map[string]string{"db2": "myspace"},
@@ -340,6 +341,7 @@ func (s *applicationOffersSuite) TestShow(c *gc.C) {
 			ApplicationDescription: "description",
 			OfferURL:               "fred/prod.hosted-db2",
 			OfferName:              "hosted-db2",
+			OfferUUID:              "hosted-db2-uuid",
 			Endpoints:              []params.RemoteEndpoint{{Name: "db"}},
 			Bindings:               map[string]string{"db2": "myspace"},
 			Spaces: []params.RemoteSpace{
@@ -383,6 +385,7 @@ func (s *applicationOffersSuite) TestShowPermission(c *gc.C) {
 			ApplicationDescription: "description",
 			OfferURL:               "fred/prod.hosted-db2",
 			OfferName:              "hosted-db2",
+			OfferUUID:              "hosted-db2-uuid",
 			Endpoints:              []params.RemoteEndpoint{{Name: "db"}},
 			Bindings:               map[string]string{"db2": "myspace"},
 			Spaces: []params.RemoteSpace{
@@ -471,6 +474,7 @@ func (s *applicationOffersSuite) TestShowFoundMultiple(c *gc.C) {
 		ApplicationName:        name,
 		ApplicationDescription: "description",
 		OfferName:              "hosted-" + name,
+		OfferUUID:              "hosted-" + name + "-uuid",
 		Endpoints:              map[string]charm.Relation{"db": {Name: "db"}},
 	}
 
@@ -480,6 +484,7 @@ func (s *applicationOffersSuite) TestShowFoundMultiple(c *gc.C) {
 		ApplicationName:        name2,
 		ApplicationDescription: "description2",
 		OfferName:              "hosted-" + name2,
+		OfferUUID:              "hosted-" + name2 + "-uuid",
 		Endpoints:              map[string]charm.Relation{"db2": {Name: "db2"}},
 	}
 
@@ -563,6 +568,7 @@ func (s *applicationOffersSuite) TestShowFoundMultiple(c *gc.C) {
 			SourceModelTag:         testing.ModelTag.String(),
 			ApplicationDescription: "description",
 			OfferName:              "hosted-" + name,
+			OfferUUID:              "hosted-" + name + "-uuid",
 			OfferURL:               url,
 			Access:                 "read",
 			Endpoints:              []params.RemoteEndpoint{{Name: "db"}},
@@ -578,6 +584,7 @@ func (s *applicationOffersSuite) TestShowFoundMultiple(c *gc.C) {
 			SourceModelTag:         "model-uuid2",
 			ApplicationDescription: "description2",
 			OfferName:              "hosted-" + name2,
+			OfferUUID:              "hosted-" + name2 + "-uuid",
 			OfferURL:               url2,
 			Access:                 "consume",
 			Endpoints:              []params.RemoteEndpoint{{Name: "db2"}}},
@@ -622,6 +629,7 @@ func (s *applicationOffersSuite) TestFind(c *gc.C) {
 			SourceModelTag:         testing.ModelTag.String(),
 			ApplicationDescription: "description",
 			OfferName:              "hosted-db2",
+			OfferUUID:              "hosted-db2-uuid",
 			OfferURL:               "fred/prod.hosted-db2",
 			Endpoints:              []params.RemoteEndpoint{{Name: "db"}},
 			Bindings:               map[string]string{"db2": "myspace"},
@@ -657,6 +665,7 @@ func (s *applicationOffersSuite) TestFindPermission(c *gc.C) {
 			SourceModelTag:         testing.ModelTag.String(),
 			ApplicationDescription: "description",
 			OfferName:              "hosted-db2",
+			OfferUUID:              "hosted-db2-uuid",
 			OfferURL:               "fred/prod.hosted-db2",
 			Endpoints:              []params.RemoteEndpoint{{Name: "db"}},
 			Bindings:               map[string]string{"db2": "myspace"},
@@ -699,18 +708,21 @@ func (s *applicationOffersSuite) TestFindRequiresFilter(c *gc.C) {
 func (s *applicationOffersSuite) TestFindMulti(c *gc.C) {
 	db2Offer := jujucrossmodel.ApplicationOffer{
 		OfferName:              "hosted-db2",
+		OfferUUID:              "hosted-db2-uuid",
 		ApplicationName:        "db2",
 		ApplicationDescription: "db2 description",
 		Endpoints:              map[string]charm.Relation{"db": {Name: "db2"}},
 	}
 	mysqlOffer := jujucrossmodel.ApplicationOffer{
 		OfferName:              "hosted-mysql",
+		OfferUUID:              "hosted-mysql-uuid",
 		ApplicationName:        "mysql",
 		ApplicationDescription: "mysql description",
 		Endpoints:              map[string]charm.Relation{"db": {Name: "mysql"}},
 	}
 	postgresqlOffer := jujucrossmodel.ApplicationOffer{
 		OfferName:              "hosted-postgresql",
+		OfferUUID:              "hosted-postgresql-uuid",
 		ApplicationName:        "postgresql",
 		ApplicationDescription: "postgresql description",
 		Endpoints:              map[string]charm.Relation{"db": {Name: "postgresql"}},
@@ -831,6 +843,7 @@ func (s *applicationOffersSuite) TestFindMulti(c *gc.C) {
 				SourceModelTag:         testing.ModelTag.String(),
 				ApplicationDescription: "db2 description",
 				OfferName:              "hosted-db2",
+				OfferUUID:              "hosted-db2-uuid",
 				OfferURL:               "fred/prod.hosted-db2",
 				Access:                 "consume",
 				Endpoints:              []params.RemoteEndpoint{{Name: "db"}},
@@ -847,6 +860,7 @@ func (s *applicationOffersSuite) TestFindMulti(c *gc.C) {
 				SourceModelTag:         "model-uuid2",
 				ApplicationDescription: "mysql description",
 				OfferName:              "hosted-mysql",
+				OfferUUID:              "hosted-mysql-uuid",
 				OfferURL:               "mary/another.hosted-mysql",
 				Access:                 "read",
 				Endpoints:              []params.RemoteEndpoint{{Name: "db"}},
@@ -855,6 +869,7 @@ func (s *applicationOffersSuite) TestFindMulti(c *gc.C) {
 				SourceModelTag:         "model-uuid2",
 				ApplicationDescription: "postgresql description",
 				OfferName:              "hosted-postgresql",
+				OfferUUID:              "hosted-postgresql-uuid",
 				OfferURL:               "mary/another.hosted-postgresql",
 				Access:                 "admin",
 				Endpoints:              []params.RemoteEndpoint{{Name: "db"}},
@@ -987,6 +1002,7 @@ func (s *consumeSuite) TestConsumeDetailsWithPermission(c *gc.C) {
 		SourceModelTag:         "model-deadbeef-0bad-400d-8000-4b1d0d06f00d",
 		OfferURL:               "fred/prod.hosted-mysql",
 		OfferName:              "hosted-mysql",
+		OfferUUID:              "hosted-mysql-uuid",
 		ApplicationDescription: "a database",
 		Endpoints:              []params.RemoteEndpoint{{Name: "server", Role: "provider", Interface: "mysql"}},
 		Bindings:               map[string]string{"database": "myspace"},
@@ -1009,7 +1025,7 @@ func (s *consumeSuite) TestConsumeDetailsWithPermission(c *gc.C) {
 	c.Check(cav, gc.HasLen, 4)
 	c.Check(strings.HasPrefix(cav[0].Condition, "time-before "), jc.IsTrue)
 	c.Check(cav[1].Condition, gc.Equals, "declared source-model-uuid deadbeef-0bad-400d-8000-4b1d0d06f00d")
-	c.Check(cav[2].Condition, gc.Equals, "declared offer-url fred/prod.hosted-mysql")
+	c.Check(cav[2].Condition, gc.Equals, "declared offer-uuid hosted-mysql-uuid")
 	c.Check(cav[3].Condition, gc.Equals, "declared username someone")
 }
 
@@ -1039,6 +1055,7 @@ func (s *consumeSuite) TestConsumeDetailsDefaultEndpoint(c *gc.C) {
 		SourceModelTag:         "model-deadbeef-0bad-400d-8000-4b1d0d06f00d",
 		OfferURL:               "fred/prod.hosted-mysql",
 		OfferName:              "hosted-mysql",
+		OfferUUID:              "hosted-mysql-uuid",
 		ApplicationDescription: "a database",
 		Endpoints:              []params.RemoteEndpoint{{Name: "server", Role: "provider", Interface: "mysql"}},
 		Bindings:               map[string]string{"database": ""},
@@ -1066,6 +1083,7 @@ func (s *consumeSuite) setupOffer() {
 		ApplicationName:        "mysql",
 		ApplicationDescription: "a database",
 		OfferName:              offerName,
+		OfferUUID:              offerName + "-uuid",
 		Endpoints: map[string]charm.Relation{
 			"server": {Name: "database", Interface: "mysql", Role: "provider", Scope: "global"}},
 	}

--- a/apiserver/facades/client/applicationoffers/base.go
+++ b/apiserver/facades/client/applicationoffers/base.go
@@ -120,7 +120,7 @@ func (api *BaseAPI) applicationOffersFromModel(
 		// If the user is not a model admin, they need at least read
 		// access on an offer to see it.
 		if !isAdmin {
-			if userAccess, err = api.checkOfferAccess(backend, appOffer.OfferName, requiredAccess); err != nil {
+			if userAccess, err = api.checkOfferAccess(backend, appOffer.OfferUUID, requiredAccess); err != nil {
 				return nil, errors.Trace(err)
 			}
 			if userAccess == permission.NoAccess {
@@ -141,7 +141,7 @@ func (api *BaseAPI) applicationOffersFromModel(
 		// Only admins can see some sensitive details of the offer.
 		if isAdmin {
 			curl, _ := app.CharmURL()
-			status, err := backend.RemoteConnectionStatus(offer.OfferName)
+			status, err := backend.RemoteConnectionStatus(offer.OfferUUID)
 			if err != nil {
 				logger.Warningf("cannot get offer connection status: %v", err)
 				continue
@@ -157,9 +157,9 @@ func (api *BaseAPI) applicationOffersFromModel(
 
 // checkOfferAccess returns the level of access the authenticated user has to the offer,
 // so long as it is greater than the requested perm.
-func (api *BaseAPI) checkOfferAccess(backend Backend, offerName string, perm permission.Access) (permission.Access, error) {
+func (api *BaseAPI) checkOfferAccess(backend Backend, offerUUID string, perm permission.Access) (permission.Access, error) {
 	apiUser := api.Authorizer.GetAuthTag().(names.UserTag)
-	access, err := backend.GetOfferAccess(names.NewApplicationOfferTag(offerName), apiUser)
+	access, err := backend.GetOfferAccess(offerUUID, apiUser)
 	if err != nil && !errors.IsNotFound(err) {
 		return permission.NoAccess, errors.Trace(err)
 	}
@@ -321,6 +321,7 @@ func (api *BaseAPI) makeOfferParams(backend Backend, offer *jujucrossmodel.Appli
 	result := params.ApplicationOffer{
 		SourceModelTag:         backend.ModelTag().String(),
 		OfferName:              offer.OfferName,
+		OfferUUID:              offer.OfferUUID,
 		ApplicationDescription: offer.ApplicationDescription,
 		Access:                 string(access),
 	}

--- a/apiserver/facades/client/applicationoffers/base_test.go
+++ b/apiserver/facades/client/applicationoffers/base_test.go
@@ -63,6 +63,7 @@ func (s *baseSuite) SetUpTest(c *gc.C) {
 func (s *baseSuite) addApplication(c *gc.C, name string) jujucrossmodel.ApplicationOffer {
 	return jujucrossmodel.ApplicationOffer{
 		OfferName:              "offer-" + name,
+		OfferUUID:              "offer-" + name + "-uuid",
 		ApplicationName:        name,
 		Endpoints:              map[string]charm.Relation{"db": {Name: "db"}},
 		ApplicationDescription: "applicaion description",
@@ -75,6 +76,7 @@ func (s *baseSuite) setupOffers(c *gc.C, filterAppName string) {
 
 	anOffer := jujucrossmodel.ApplicationOffer{
 		OfferName:              offerName,
+		OfferUUID:              offerName + "-uuid",
 		ApplicationName:        applicationName,
 		ApplicationDescription: "description",
 		Endpoints:              map[string]charm.Relation{"db": {Name: "db2"}},

--- a/apiserver/facades/client/applicationoffers/state.go
+++ b/apiserver/facades/client/applicationoffers/state.go
@@ -195,8 +195,8 @@ type modelShim struct {
 	*state.Model
 }
 
-func (s *stateShim) RemoteConnectionStatus(offerName string) (RemoteConnectionStatus, error) {
-	status, err := s.st.RemoteConnectionStatus(offerName)
+func (s *stateShim) RemoteConnectionStatus(offerUUID string) (RemoteConnectionStatus, error) {
+	status, err := s.st.RemoteConnectionStatus(offerUUID)
 	return &remoteConnectionStatusShim{status}, err
 }
 

--- a/apiserver/facades/client/client/api_test.go
+++ b/apiserver/facades/client/client/api_test.go
@@ -400,7 +400,7 @@ func (s *baseSuite) setUpScenario(c *gc.C) (entities []names.Tag) {
 
 	_, err = s.State.AddRemoteApplication(state.AddRemoteApplicationParams{
 		Name:        "remote-db2",
-		OfferName:   "hosted-db2",
+		OfferUUID:   "offer-uuid",
 		URL:         "admin/prod.db2",
 		SourceModel: coretesting.ModelTag,
 		Endpoints: []charm.Relation{
@@ -432,7 +432,7 @@ func (s *baseSuite) setUpScenario(c *gc.C) (entities []names.Tag) {
 	mwRel, err := s.State.AddRelation(eps...)
 	c.Assert(err, jc.ErrorIsNil)
 	offers := state.NewApplicationOffers(s.State)
-	_, err = offers.AddOffer(crossmodel.AddApplicationOfferArgs{
+	offer, err := offers.AddOffer(crossmodel.AddApplicationOfferArgs{
 		OfferName:       "hosted-mysql",
 		ApplicationName: "mysql",
 		Owner:           "admin",
@@ -442,7 +442,7 @@ func (s *baseSuite) setUpScenario(c *gc.C) (entities []names.Tag) {
 	_, err = s.State.AddOfferConnection(state.AddOfferConnectionParams{
 		SourceModelUUID: coretesting.ModelTag.Id(),
 		Username:        "fred",
-		OfferName:       "hosted-mysql",
+		OfferUUID:       offer.OfferUUID,
 		RelationId:      mwRel.Id(),
 	})
 	c.Assert(err, jc.ErrorIsNil)

--- a/apiserver/facades/client/client/client_test.go
+++ b/apiserver/facades/client/client/client_test.go
@@ -696,7 +696,7 @@ func (s *clientSuite) TestClientWatchAllAdminPermission(c *gc.C) {
 	// Include a remote app that needs admin access to see.
 	_, err = s.State.AddRemoteApplication(state.AddRemoteApplicationParams{
 		Name:        "remote-db2",
-		OfferName:   "hosted-db2",
+		OfferUUID:   "offer-uuid",
 		URL:         "admin/prod.db2",
 		SourceModel: coretesting.ModelTag,
 		Endpoints: []charm.Relation{
@@ -765,6 +765,7 @@ func (s *clientSuite) TestClientWatchAllAdminPermission(c *gc.C) {
 		Entity: &multiwatcher.RemoteApplicationInfo{
 			Name:           "remote-db2",
 			ModelUUID:      s.State.ModelUUID(),
+			OfferUUID:      "offer-uuid",
 			ApplicationURL: "admin/prod.db2",
 			Life:           "alive",
 			Status: multiwatcher.StatusInfo{

--- a/apiserver/facades/controller/crossmodelrelations/mock_test.go
+++ b/apiserver/facades/controller/crossmodelrelations/mock_test.go
@@ -43,7 +43,7 @@ type mockState struct {
 	relations             map[string]*mockRelation
 	remoteApplications    map[string]*mockRemoteApplication
 	applications          map[string]*mockApplication
-	offers                []crossmodel.ApplicationOffer
+	offers                map[string]*crossmodel.ApplicationOffer
 	offerConnections      map[int]*mockOfferConnection
 	offerConnectionsByKey map[string]*mockOfferConnection
 	remoteEntities        map[names.Tag]string
@@ -60,8 +60,12 @@ func newMockState() *mockState {
 	}
 }
 
-func (st *mockState) ListOffers(filter ...crossmodel.ApplicationOfferFilter) ([]crossmodel.ApplicationOffer, error) {
-	return st.offers, nil
+func (st *mockState) ApplicationOfferForUUID(offerUUID string) (*crossmodel.ApplicationOffer, error) {
+	offer, ok := st.offers[offerUUID]
+	if !ok {
+		return nil, errors.NotFoundf("offer %v", offerUUID)
+	}
+	return offer, nil
 }
 
 func (st *mockState) ModelUUID() string {
@@ -93,7 +97,7 @@ func (st *mockState) AddOfferConnection(arg state.AddOfferConnectionParams) (cro
 		relationId:      arg.RelationId,
 		relationKey:     arg.RelationKey,
 		username:        arg.Username,
-		offerName:       arg.OfferName,
+		offerUUID:       arg.OfferUUID,
 	}
 	st.offerConnections[arg.RelationId] = oc
 	st.offerConnectionsByKey[arg.RelationKey] = oc
@@ -356,11 +360,11 @@ type mockOfferConnection struct {
 	relationId      int
 	relationKey     string
 	username        string
-	offerName       string
+	offerUUID       string
 }
 
-func (m *mockOfferConnection) OfferName() string {
-	return m.offerName
+func (m *mockOfferConnection) OfferUUID() string {
+	return m.offerUUID
 }
 
 type mockRelationUnit struct {

--- a/apiserver/facades/controller/crossmodelrelations/state.go
+++ b/apiserver/facades/controller/crossmodelrelations/state.go
@@ -16,9 +16,6 @@ import (
 type CrossModelRelationsState interface {
 	common.Backend
 
-	// ListOffers returns the application offers matching any one of the filter terms.
-	ListOffers(filter ...crossmodel.ApplicationOfferFilter) ([]crossmodel.ApplicationOffer, error)
-
 	// Model returns the model entity.
 	Model() (Model, error)
 
@@ -35,9 +32,9 @@ type stateShim struct {
 	st *state.State
 }
 
-func (st stateShim) ListOffers(filter ...crossmodel.ApplicationOfferFilter) ([]crossmodel.ApplicationOffer, error) {
+func (st stateShim) ApplicationOfferForUUID(offerUUID string) (*crossmodel.ApplicationOffer, error) {
 	oa := state.NewApplicationOffers(st.st)
-	return oa.ListOffers(filter...)
+	return oa.ApplicationOfferForUUID(offerUUID)
 }
 
 func (st stateShim) AddOfferConnection(arg state.AddOfferConnectionParams) (OfferConnection, error) {
@@ -58,5 +55,5 @@ func (st stateShim) Model() (Model, error) {
 }
 
 type OfferConnection interface {
-	OfferName() string
+	OfferUUID() string
 }

--- a/apiserver/facades/controller/remoterelations/mock_test.go
+++ b/apiserver/facades/controller/remoterelations/mock_test.go
@@ -317,9 +317,9 @@ func (r *mockRemoteApplication) Name() string {
 	return r.name
 }
 
-func (r *mockRemoteApplication) OfferName() string {
-	r.MethodCall(r, "OfferName")
-	return r.alias
+func (r *mockRemoteApplication) OfferUUID() string {
+	r.MethodCall(r, "OfferUUID")
+	return r.name + "-uuid"
 }
 
 func (r *mockRemoteApplication) Tag() names.Tag {

--- a/apiserver/facades/controller/remoterelations/remoterelations.go
+++ b/apiserver/facades/controller/remoterelations/remoterelations.go
@@ -264,7 +264,7 @@ func (api *RemoteRelationsAPI) RemoteApplications(entities params.Entities) (par
 		}
 		return &params.RemoteApplication{
 			Name:       remoteApp.Name(),
-			OfferName:  remoteApp.OfferName(),
+			OfferUUID:  remoteApp.OfferUUID(),
 			Life:       params.Life(remoteApp.Life().String()),
 			Status:     status.Status.String(),
 			ModelUUID:  remoteApp.SourceModel().Id(),

--- a/apiserver/facades/controller/remoterelations/remoterelations_test.go
+++ b/apiserver/facades/controller/remoterelations/remoterelations_test.go
@@ -275,7 +275,7 @@ func (s *remoteRelationsSuite) TestRemoteApplications(c *gc.C) {
 	c.Assert(result.Results, jc.DeepEquals, []params.RemoteApplicationResult{{
 		Result: &params.RemoteApplication{
 			Name:      "django",
-			OfferName: "django-alias",
+			OfferUUID: "django-uuid",
 			Life:      "alive",
 			ModelUUID: "model-uuid",
 			Macaroon:  mac,

--- a/apiserver/params/crossmodel.go
+++ b/apiserver/params/crossmodel.go
@@ -41,6 +41,7 @@ type OfferFilter struct {
 // ApplicationOffer represents an application offering from an external model.
 type ApplicationOffer struct {
 	SourceModelTag         string            `json:"source-model-tag"`
+	OfferUUID              string            `json:"offer-uuid"`
 	OfferURL               string            `json:"offer-url"`
 	OfferName              string            `json:"offer-name"`
 	ApplicationDescription string            `json:"application-description"`
@@ -186,8 +187,8 @@ type RemoteApplication struct {
 	// Name is the name of the application.
 	Name string `json:"name"`
 
-	// OfferName is the name of the application on the offering side.
-	OfferName string `json:"offer-name"`
+	// OfferUUID is the uuid of the application offer.
+	OfferUUID string `json:"offer-uuid"`
 
 	// Life is the current lifecycle state of the application.
 	Life Life `json:"life"`
@@ -393,8 +394,8 @@ type RegisterRemoteRelationArg struct {
 	// endpoint is bound to in the remote model.
 	RemoteSpace RemoteSpace `json:"remote-space"`
 
-	// OfferName is the name of the application offer from the local model.
-	OfferName string `json:"offer-name"`
+	// OfferUUID is the UUID of the offer.
+	OfferUUID string `json:"offer-uuid"`
 
 	// LocalEndpointName is the name of the endpoint in the local model.
 	LocalEndpointName string `json:"local-endpoint-name"`

--- a/apiserver/rest.go
+++ b/apiserver/rest.go
@@ -89,9 +89,8 @@ func (h *modelRestHandler) processRemoteApplication(r *http.Request, w http.Resp
 		return errors.NotSupportedf("attribute %v on entity %v", attribute, name)
 	}
 
-	// TODO(wallyworld) - for now, offername corresponds to the remoteApp name in the source model
 	// Get the backend state for the source model so we can lookup the app in that model to get the charm details.
-	offer := remoteApp.OfferName()
+	offerUUID := remoteApp.OfferUUID()
 	sourceModelUUID := remoteApp.SourceModel().Id()
 	sourceSt, releaser, err := h.ctxt.srv.statePool.Get(sourceModelUUID)
 	if err != nil {
@@ -99,7 +98,12 @@ func (h *modelRestHandler) processRemoteApplication(r *http.Request, w http.Resp
 	}
 	defer releaser()
 
-	app, err := sourceSt.Application(offer)
+	offers := state.NewApplicationOffers(sourceSt)
+	offer, err := offers.ApplicationOfferForUUID(offerUUID)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	app, err := sourceSt.Application(offer.ApplicationName)
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/cmd/juju/status/status_test.go
+++ b/cmd/juju/status/status_test.go
@@ -3298,9 +3298,11 @@ type addOfferConnection struct {
 func (oc addOfferConnection) step(c *gc.C, ctx *context) {
 	rel, err := ctx.st.KeyRelation(oc.relationKey)
 	c.Assert(err, jc.ErrorIsNil)
+	offer, err := state.NewApplicationOffers(ctx.st).ApplicationOffer(oc.name)
+	c.Assert(err, jc.ErrorIsNil)
 	_, err = ctx.st.AddOfferConnection(state.AddOfferConnectionParams{
 		SourceModelUUID: oc.sourceModelUUID,
-		OfferName:       oc.name,
+		OfferUUID:       offer.OfferUUID,
 		Username:        oc.username,
 		RelationId:      rel.Id(),
 	})

--- a/core/crossmodel/interface.go
+++ b/core/crossmodel/interface.go
@@ -13,6 +13,9 @@ import (
 // ApplicationOffer holds the details of an application offered
 // by this model.
 type ApplicationOffer struct {
+	// OfferUUID is the UUID of the offer.
+	OfferUUID string
+
 	// OfferName is the name of the offer.
 	OfferName string
 
@@ -125,6 +128,9 @@ type ApplicationOffers interface {
 
 	// ApplicationOffer returns the named application offer.
 	ApplicationOffer(offerName string) (*ApplicationOffer, error)
+
+	// ApplicationOfferForUUID returns the application offer with the UUID.
+	ApplicationOfferForUUID(offerUUID string) (*ApplicationOffer, error)
 
 	// ListOffers returns the offers satisfying the specified filter.
 	ListOffers(filter ...ApplicationOfferFilter) ([]ApplicationOffer, error)

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -21,7 +21,7 @@ github.com/juju/ansiterm	git	b99631de12cf04a906c1d4e4ec54fb86eae5863d	2016-09-07
 github.com/juju/blobstore	git	06056004b3d7b54bbb7984d830c537bad00fec21	2015-07-29T11:18:58Z
 github.com/juju/bundlechanges	git	cd189848b313df50084de692b05861210022cf81	2017-08-02T17:04:42Z
 github.com/juju/cmd	git	ad2437ef0ef282ae26e482eb1e44c02532bae1ba	2017-06-22T12:53:07Z
-github.com/juju/description	git	264ae46133b5a24cfc4f55717d4ed83bb2983b8f	2017-08-09T23:16:08Z
+github.com/juju/description	git	a08158a2094914d9eb123bb4e19eb8c6d2c575ab	2017-08-11T02:30:02Z
 github.com/juju/errors	git	1b5e39b83d1835fa480e0c2ddefb040ee82d58b3	2015-09-16T12:56:42Z
 github.com/juju/gnuflag	git	4e76c56581859c14d9d87e1ddbe29e1c0f10195f	2016-08-09T16:52:14Z
 github.com/juju/go-oracle-cloud	git	932a8cea00a1cd5cba3829a672c823955db674ae	2017-04-21T13:45:47Z

--- a/featuretests/cmd_juju_crossmodel_test.go
+++ b/featuretests/cmd_juju_crossmodel_test.go
@@ -412,12 +412,13 @@ func (s *crossmodelSuite) assertOfferGrant(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Check the default access levels.
-	offerTag := names.NewApplicationOfferTag("riak")
+	offer, err := state.NewApplicationOffers(s.State).ApplicationOffer("riak")
+	c.Assert(err, jc.ErrorIsNil)
 	userTag := names.NewUserTag("everyone@external")
-	access, err := s.State.GetOfferAccess(offerTag, userTag)
+	access, err := s.State.GetOfferAccess(offer.OfferUUID, userTag)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(access, gc.Equals, permission.ReadAccess)
-	access, err = s.State.GetOfferAccess(offerTag, names.NewUserTag("admin"))
+	access, err = s.State.GetOfferAccess(offer.OfferUUID, names.NewUserTag("admin"))
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(access, gc.Equals, permission.AdminAccess)
 
@@ -425,7 +426,7 @@ func (s *crossmodelSuite) assertOfferGrant(c *gc.C) {
 	s.Factory.MakeUser(c, &factory.UserParams{Name: "bob"})
 	_, err = cmdtesting.RunCommand(c, model.NewGrantCommand(), "bob", "consume", "admin/controller.riak")
 	c.Assert(err, jc.ErrorIsNil)
-	access, err = s.State.GetOfferAccess(offerTag, names.NewUserTag("bob"))
+	access, err = s.State.GetOfferAccess(offer.OfferUUID, names.NewUserTag("bob"))
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(access, gc.Equals, permission.ConsumeAccess)
 
@@ -437,12 +438,13 @@ func (s *crossmodelSuite) TestOfferGrant(c *gc.C) {
 
 func (s *crossmodelSuite) TestOfferRevoke(c *gc.C) {
 	s.assertOfferGrant(c)
-	offerTag := names.NewApplicationOfferTag("riak")
 
 	// Revoke consume access.
 	_, err := cmdtesting.RunCommand(c, model.NewRevokeCommand(), "bob", "consume", "admin/controller.riak")
 	c.Assert(err, jc.ErrorIsNil)
-	access, err := s.State.GetOfferAccess(offerTag, names.NewUserTag("bob"))
+	offer, err := state.NewApplicationOffers(s.State).ApplicationOffer("riak")
+	c.Assert(err, jc.ErrorIsNil)
+	access, err := s.State.GetOfferAccess(offer.OfferUUID, names.NewUserTag("bob"))
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(access, gc.Equals, permission.ReadAccess)
 }

--- a/state/applicationofferuser.go
+++ b/state/applicationofferuser.go
@@ -14,11 +14,7 @@ import (
 )
 
 // GetOfferAccess gets the access permission for the specified user on an offer.
-func (st *State) GetOfferAccess(offer names.ApplicationOfferTag, user names.UserTag) (permission.Access, error) {
-	offerUUID, err := applicationOfferUUID(st, offer.Name)
-	if err != nil {
-		return "", errors.Trace(err)
-	}
+func (st *State) GetOfferAccess(offerUUID string, user names.UserTag) (permission.Access, error) {
 	perm, err := st.userPermission(applicationOfferKey(offerUUID), userGlobalKey(userAccessID(user)))
 	if err != nil {
 		return "", errors.Trace(err)

--- a/state/export_test.go
+++ b/state/export_test.go
@@ -24,7 +24,6 @@ import (
 	"gopkg.in/mgo.v2/bson"
 	"gopkg.in/mgo.v2/txn"
 
-	"github.com/juju/juju/core/crossmodel"
 	"github.com/juju/juju/core/lease"
 	"github.com/juju/juju/mongo"
 	"github.com/juju/juju/mongo/utils"
@@ -113,14 +112,6 @@ func newRunnerForHooks(st *State) jujutxn.Runner {
 	runner := jujutxn.NewRunner(jujutxn.RunnerParams{Database: db.raw})
 	db.runner = runner
 	return runner
-}
-
-func OfferForName(sd crossmodel.ApplicationOffers, name string) (*applicationOfferDoc, error) {
-	return sd.(*applicationOffers).offerForName(name)
-}
-
-func MakeApplicationOffer(sd crossmodel.ApplicationOffers, offer *applicationOfferDoc) (*crossmodel.ApplicationOffer, error) {
-	return sd.(*applicationOffers).makeApplicationOffer(*offer)
 }
 
 // SetPolicy updates the State's policy field to the

--- a/state/migration_export.go
+++ b/state/migration_export.go
@@ -1511,7 +1511,7 @@ func (e *exporter) addRemoteApplication(app *RemoteApplication) error {
 	url, _ := app.URL()
 	args := description.RemoteApplicationArgs{
 		Tag:             app.Tag().(names.ApplicationTag),
-		OfferName:       app.OfferName(),
+		OfferUUID:       app.OfferUUID(),
 		URL:             url,
 		SourceModel:     app.SourceModel(),
 		IsConsumerProxy: app.IsConsumerProxy(),
@@ -1532,8 +1532,6 @@ func (e *exporter) addRemoteApplication(app *RemoteApplication) error {
 			Name:      ep.Name,
 			Role:      string(ep.Role),
 			Interface: ep.Interface,
-			Limit:     ep.Limit,
-			Scope:     string(ep.Scope),
 		})
 	}
 	for _, space := range app.Spaces() {

--- a/state/migration_export_test.go
+++ b/state/migration_export_test.go
@@ -1337,6 +1337,7 @@ func (s *MigrationExportSuite) TestRemoteApplications(c *gc.C) {
 		URL:         "me/model.rainbow",
 		SourceModel: s.State.ModelTag(),
 		Token:       "charisma",
+		OfferUUID:   "offer-uuid",
 		Endpoints: []charm.Relation{{
 			Interface: "mysql",
 			Name:      "db",
@@ -1408,7 +1409,7 @@ func (s *MigrationExportSuite) TestRemoteApplications(c *gc.C) {
 	app := model.RemoteApplications()[0]
 	c.Check(app.Tag(), gc.Equals, names.NewApplicationTag("gravy-rainbow"))
 	c.Check(app.Name(), gc.Equals, "gravy-rainbow")
-	c.Check(app.OfferName(), gc.Equals, "")
+	c.Check(app.OfferUUID(), gc.Equals, "offer-uuid")
 	c.Check(app.URL(), gc.Equals, "me/model.rainbow")
 	c.Check(app.SourceModelTag(), gc.Equals, s.State.ModelTag())
 	c.Check(app.IsConsumerProxy(), jc.IsFalse)
@@ -1422,21 +1423,15 @@ func (s *MigrationExportSuite) TestRemoteApplications(c *gc.C) {
 	ep := app.Endpoints()[0]
 	c.Check(ep.Name(), gc.Equals, "db")
 	c.Check(ep.Interface(), gc.Equals, "mysql")
-	c.Check(ep.Limit(), gc.Equals, 0)
 	c.Check(ep.Role(), gc.Equals, "provider")
-	c.Check(ep.Scope(), gc.Equals, "global")
 	ep = app.Endpoints()[1]
 	c.Check(ep.Name(), gc.Equals, "db-admin")
 	c.Check(ep.Interface(), gc.Equals, "mysql-root")
-	c.Check(ep.Limit(), gc.Equals, 5)
 	c.Check(ep.Role(), gc.Equals, "provider")
-	c.Check(ep.Scope(), gc.Equals, "global")
 	ep = app.Endpoints()[2]
 	c.Check(ep.Name(), gc.Equals, "logging")
 	c.Check(ep.Interface(), gc.Equals, "logging")
-	c.Check(ep.Limit(), gc.Equals, 0)
 	c.Check(ep.Role(), gc.Equals, "provider")
-	c.Check(ep.Scope(), gc.Equals, "global")
 
 	originalSpaces := dbApp.Spaces()
 	actualSpaces := app.Spaces()

--- a/state/multiwatcher/multiwatcher.go
+++ b/state/multiwatcher/multiwatcher.go
@@ -205,6 +205,7 @@ func (i *ApplicationInfo) EntityId() EntityId {
 type RemoteApplicationInfo struct {
 	ModelUUID      string     `json:"model-uuid"`
 	Name           string     `json:"name"`
+	OfferUUID      string     `json:"offer-uuid"`
 	ApplicationURL string     `json:"application-url"`
 	Life           Life       `json:"life"`
 	Status         StatusInfo `json:"status"`
@@ -224,6 +225,7 @@ func (i *RemoteApplicationInfo) EntityId() EntityId {
 type ApplicationOfferInfo struct {
 	ModelUUID       string `json:"model-uuid"`
 	OfferName       string `json:"offer-name"`
+	OfferUUID       string `json:"offer-uuid"`
 	ApplicationName string `json:"application-name"`
 	CharmName       string `json:"charm-name"`
 	ConnectedCount  int    `json:"connected-count"`

--- a/state/offerconnections_test.go
+++ b/state/offerconnections_test.go
@@ -24,20 +24,20 @@ func (s *offerConnectionsSuite) TestAddOfferConnection(c *gc.C) {
 		RelationId:      1,
 		RelationKey:     "rel-key",
 		Username:        "fred",
-		OfferName:       "mysql",
+		OfferUUID:       "offer-uuid",
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(oc.SourceModelUUID(), gc.Equals, testing.ModelTag.Id())
 	c.Assert(oc.RelationId(), gc.Equals, 1)
 	c.Assert(oc.RelationKey(), gc.Equals, "rel-key")
-	c.Assert(oc.OfferName(), gc.Equals, "mysql")
+	c.Assert(oc.OfferUUID(), gc.Equals, "offer-uuid")
 	c.Assert(oc.UserName(), gc.Equals, "fred")
 
 	anotherState, err := s.State.ForModel(s.State.ModelTag())
 	c.Assert(err, jc.ErrorIsNil)
 	defer anotherState.Close()
 
-	rc, err := anotherState.RemoteConnectionStatus("mysql")
+	rc, err := anotherState.RemoteConnectionStatus("offer-uuid")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(rc.ConnectionCount(), gc.Equals, 1)
 
@@ -47,9 +47,9 @@ func (s *offerConnectionsSuite) TestAddOfferConnection(c *gc.C) {
 	c.Assert(all[0].SourceModelUUID(), gc.Equals, testing.ModelTag.Id())
 	c.Assert(all[0].RelationId(), gc.Equals, 1)
 	c.Assert(all[0].RelationKey(), gc.Equals, "rel-key")
-	c.Assert(all[0].OfferName(), gc.Equals, "mysql")
+	c.Assert(all[0].OfferUUID(), gc.Equals, "offer-uuid")
 	c.Assert(all[0].UserName(), gc.Equals, "fred")
-	c.Assert(all[0].String(), gc.Equals, `connection to "mysql" by "fred" for relation 1`)
+	c.Assert(all[0].String(), gc.Equals, `connection to "offer-uuid" by "fred" for relation 1`)
 }
 
 func (s *offerConnectionsSuite) TestAddOfferConnectionTwice(c *gc.C) {
@@ -58,7 +58,7 @@ func (s *offerConnectionsSuite) TestAddOfferConnectionTwice(c *gc.C) {
 		RelationId:      1,
 		RelationKey:     "rel-key",
 		Username:        "fred",
-		OfferName:       "mysql",
+		OfferUUID:       "offer-uuid",
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -71,7 +71,7 @@ func (s *offerConnectionsSuite) TestAddOfferConnectionTwice(c *gc.C) {
 		RelationId:      1,
 		RelationKey:     "rel-key",
 		Username:        "fred",
-		OfferName:       "mysql",
+		OfferUUID:       "offer-uuid",
 	})
 	c.Assert(err, jc.Satisfies, errors.IsAlreadyExists)
 }

--- a/state/relation_test.go
+++ b/state/relation_test.go
@@ -296,7 +296,7 @@ func (s *RelationSuite) TestIsCrossModelYup(c *gc.C) {
 		Name:            "remote-wordpress",
 		SourceModel:     names.NewModelTag("source-model"),
 		IsConsumerProxy: true,
-		OfferName:       "chapo",
+		OfferUUID:       "offer-uuid",
 		Endpoints: []charm.Relation{{
 			Interface: "mysql",
 			Limit:     1,
@@ -409,7 +409,7 @@ func (s *RelationSuite) TestRemoveAlsoDeletesRemoteOfferConnections(c *gc.C) {
 		Name:            "remote-wordpress",
 		SourceModel:     names.NewModelTag("source-model"),
 		IsConsumerProxy: true,
-		OfferName:       "chapo",
+		OfferUUID:       "offer-uuid",
 		Endpoints: []charm.Relation{{
 			Interface: "mysql",
 			Limit:     1,
@@ -432,15 +432,15 @@ func (s *RelationSuite) TestRemoveAlsoDeletesRemoteOfferConnections(c *gc.C) {
 		SourceModelUUID: coretesting.ModelTag.Id(),
 		RelationId:      relation.Id(),
 		Username:        "fred",
-		OfferName:       "mysql",
+		OfferUUID:       "offer-uuid",
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	rc, err := s.State.RemoteConnectionStatus("mysql")
+	rc, err := s.State.RemoteConnectionStatus("offer-uuid")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(rc.ConnectionCount(), gc.Equals, 1)
 
 	state.RemoveRelation(c, relation)
-	rc, err = s.State.RemoteConnectionStatus("mysql")
+	rc, err = s.State.RemoteConnectionStatus("offer-uuid")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(rc.ConnectionCount(), gc.Equals, 0)
 }

--- a/state/remoteapplication.go
+++ b/state/remoteapplication.go
@@ -35,7 +35,7 @@ type RemoteApplication struct {
 type remoteApplicationDoc struct {
 	DocID           string              `bson:"_id"`
 	Name            string              `bson:"name"`
-	OfferName       string              `bson:"offer-name"`
+	OfferUUID       string              `bson:"offer-uuid"`
 	URL             string              `bson:"url,omitempty"`
 	SourceModelUUID string              `bson:"source-model-uuid"`
 	Endpoints       []remoteEndpointDoc `bson:"endpoints"`
@@ -143,9 +143,9 @@ func (s *RemoteApplication) Name() string {
 	return s.doc.Name
 }
 
-// OfferName returns the name on te offering side.
-func (s *RemoteApplication) OfferName() string {
-	return s.doc.OfferName
+// OfferUUID returns the offer UUID.
+func (s *RemoteApplication) OfferUUID() string {
+	return s.doc.OfferUUID
 }
 
 // URL returns the remote service URL, and a boolean indicating whether or not
@@ -561,8 +561,8 @@ type AddRemoteApplicationParams struct {
 	// match the application name in the URL, or the name in the remote model.
 	Name string
 
-	// OfferName is the name the offering side has given to the remote application.
-	OfferName string
+	// OfferUUID is the UUID of the offer.
+	OfferUUID string
 
 	// URL is either empty, or the URL that the remote application was offered
 	// with on the hosting model.
@@ -650,7 +650,7 @@ func (st *State) AddRemoteApplication(args AddRemoteApplicationParams) (_ *Remot
 	appDoc := &remoteApplicationDoc{
 		DocID:           applicationID,
 		Name:            args.Name,
-		OfferName:       args.OfferName,
+		OfferUUID:       args.OfferUUID,
 		SourceModelUUID: args.SourceModel.Id(),
 		URL:             args.URL,
 		Bindings:        args.Bindings,

--- a/state/remoteapplication_test.go
+++ b/state/remoteapplication_test.go
@@ -413,14 +413,14 @@ func (s *remoteApplicationSuite) TestParamsValidateChecksBindings(c *gc.C) {
 
 func (s *remoteApplicationSuite) TestAddRemoteApplication(c *gc.C) {
 	foo, err := s.State.AddRemoteApplication(state.AddRemoteApplicationParams{
-		Name: "foo", OfferName: "bar", URL: "me/model.foo", SourceModel: s.State.ModelTag()})
+		Name: "foo", OfferUUID: "offer-uuid", URL: "me/model.foo", SourceModel: s.State.ModelTag()})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(foo.Name(), gc.Equals, "foo")
 	c.Assert(foo.IsConsumerProxy(), jc.IsFalse)
 	foo, err = s.State.RemoteApplication("foo")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(foo.Name(), gc.Equals, "foo")
-	c.Assert(foo.OfferName(), gc.Equals, "bar")
+	c.Assert(foo.OfferUUID(), gc.Equals, "offer-uuid")
 	url, ok := foo.URL()
 	c.Assert(ok, jc.IsTrue)
 	c.Assert(url, gc.Equals, "me/model.foo")
@@ -445,7 +445,7 @@ func (s *remoteApplicationSuite) TestAddEndpoints(c *gc.C) {
 		{Name: "ep2", Role: charm.RoleProvider, Scope: charm.ScopeGlobal, Limit: 1},
 	}
 	foo, err := s.State.AddRemoteApplication(state.AddRemoteApplicationParams{
-		Name: "foo", OfferName: "bar", SourceModel: s.State.ModelTag(),
+		Name: "foo", OfferUUID: "offer-uuid", SourceModel: s.State.ModelTag(),
 		Endpoints: origEps,
 	})
 	c.Assert(err, jc.ErrorIsNil)
@@ -483,7 +483,7 @@ func (s *remoteApplicationSuite) TestAddEndpointsConflicting(c *gc.C) {
 		{Name: "ep2", Role: charm.RoleProvider, Scope: charm.ScopeGlobal, Limit: 1},
 	}
 	foo, err := s.State.AddRemoteApplication(state.AddRemoteApplicationParams{
-		Name: "foo", OfferName: "bar", SourceModel: s.State.ModelTag(),
+		Name: "foo", OfferUUID: "offer-uuid", SourceModel: s.State.ModelTag(),
 		Endpoints: origEps,
 	})
 	c.Assert(err, jc.ErrorIsNil)
@@ -503,7 +503,7 @@ func (s *remoteApplicationSuite) TestAddEndpointsConcurrentOneDeleted(c *gc.C) {
 		{Name: "ep2", Role: charm.RoleProvider, Scope: charm.ScopeGlobal, Limit: 1},
 	}
 	foo, err := s.State.AddRemoteApplication(state.AddRemoteApplicationParams{
-		Name: "foo", OfferName: "bar", SourceModel: s.State.ModelTag(),
+		Name: "foo", OfferUUID: "offer-uuid", SourceModel: s.State.ModelTag(),
 		Endpoints: origEps,
 	})
 	c.Assert(err, jc.ErrorIsNil)
@@ -517,7 +517,7 @@ func (s *remoteApplicationSuite) TestAddEndpointsConcurrentOneDeleted(c *gc.C) {
 		err := foo.Destroy()
 		c.Assert(err, jc.ErrorIsNil)
 		_, err = s.State.AddRemoteApplication(state.AddRemoteApplicationParams{
-			Name: "foo", OfferName: "bar", SourceModel: s.State.ModelTag(),
+			Name: "foo", OfferUUID: "offer-uuid", SourceModel: s.State.ModelTag(),
 			Endpoints: reducedEps,
 		})
 		c.Assert(err, jc.ErrorIsNil)
@@ -557,7 +557,7 @@ func (s *remoteApplicationSuite) TestAddEndpointsConcurrentConflictingOneAdded(c
 		{Name: "ep2", Role: charm.RoleProvider, Scope: charm.ScopeGlobal, Limit: 1},
 	}
 	foo, err := s.State.AddRemoteApplication(state.AddRemoteApplicationParams{
-		Name: "foo", OfferName: "bar", SourceModel: s.State.ModelTag(),
+		Name: "foo", OfferUUID: "offer-uuid", SourceModel: s.State.ModelTag(),
 		Endpoints: origEps,
 	})
 	c.Assert(err, jc.ErrorIsNil)
@@ -587,7 +587,7 @@ func (s *remoteApplicationSuite) TestAddEndpointsConcurrentDifferentOneAdded(c *
 		{Name: "ep2", Role: charm.RoleProvider, Scope: charm.ScopeGlobal, Limit: 1},
 	}
 	foo, err := s.State.AddRemoteApplication(state.AddRemoteApplicationParams{
-		Name: "foo", OfferName: "bar", SourceModel: s.State.ModelTag(),
+		Name: "foo", OfferUUID: "offer-uuid", SourceModel: s.State.ModelTag(),
 		Endpoints: origEps,
 	})
 	c.Assert(err, jc.ErrorIsNil)
@@ -768,17 +768,17 @@ func (s *remoteApplicationSuite) TestDestroyWithOfferConnections(c *gc.C) {
 		SourceModelUUID: coretesting.ModelTag.Id(),
 		RelationId:      rel.Id(),
 		Username:        "fred",
-		OfferName:       "mysql",
+		OfferUUID:       "offer-uuid",
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	rc, err := s.State.RemoteConnectionStatus("mysql")
+	rc, err := s.State.RemoteConnectionStatus("offer-uuid")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(rc.ConnectionCount(), gc.Equals, 1)
 
 	err = s.application.Destroy()
 	c.Assert(err, jc.ErrorIsNil)
 
-	rc, err = s.State.RemoteConnectionStatus("mysql")
+	rc, err = s.State.RemoteConnectionStatus("offer-uuid")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(rc.ConnectionCount(), gc.Equals, 0)
 }

--- a/state/useraccess.go
+++ b/state/useraccess.go
@@ -150,7 +150,11 @@ func (st *State) UserPermission(subject names.UserTag, target names.Tag) (permis
 		}
 		return access.Access, nil
 	case names.ApplicationOfferTagKind:
-		return st.GetOfferAccess(target.(names.ApplicationOfferTag), subject)
+		offerUUID, err := applicationOfferUUID(st, target.Id())
+		if err != nil {
+			return "", errors.Trace(err)
+		}
+		return st.GetOfferAccess(offerUUID, subject)
 	default:
 		return "", errors.NotValidf("%q as a target", target.Kind())
 	}

--- a/worker/remoterelations/mock_test.go
+++ b/worker/remoterelations/mock_test.go
@@ -167,7 +167,7 @@ func (m *mockRelationsFacade) RemoteApplications(names []string) ([]params.Remot
 			result[i] = params.RemoteApplicationResult{
 				Result: &params.RemoteApplication{
 					Name:       app.name,
-					OfferName:  app.offername,
+					OfferUUID:  app.offeruuid,
 					Life:       app.life,
 					Status:     app.status,
 					ModelUUID:  app.modelUUID,
@@ -284,7 +284,7 @@ func (m *mockRemoteRelationsFacade) RegisterRemoteRelations(relations ...params.
 	}
 	for i, rel := range relations {
 		result[i].Result = &params.RemoteRelationDetails{
-			Token:    "token-" + rel.OfferName,
+			Token:    "token-" + rel.OfferUUID,
 			Macaroon: mac,
 		}
 	}
@@ -398,7 +398,7 @@ func (w *mockStringsWatcher) Changes() watcher.StringsChannel {
 type mockRemoteApplication struct {
 	testing.Stub
 	name       string
-	offername  string
+	offeruuid  string
 	url        string
 	life       params.Life
 	status     string
@@ -444,7 +444,7 @@ func (w *mockRelationStatusWatcher) Changes() watcher.RelationStatusChannel {
 
 func newMockRemoteApplication(name, url string) *mockRemoteApplication {
 	return &mockRemoteApplication{
-		name: name, url: url, life: params.Alive, offername: "offer-" + name,
+		name: name, url: url, life: params.Alive, offeruuid: "offer-" + name + "-uuid",
 		modelUUID: "remote-model-uuid",
 	}
 }

--- a/worker/remoterelations/remoteapplicationworker.go
+++ b/worker/remoterelations/remoteapplicationworker.go
@@ -25,8 +25,7 @@ type remoteApplicationWorker struct {
 
 	// These attribute are relevant to dealing with a specific
 	// remote application proxy.
-	// TODO(wallyworld) - change to offer UUID
-	offerName             string
+	offerUUID             string
 	applicationName       string // name of the remote application proxy in the local model
 	localModelUUID        string // uuid of the model hosting the local application
 	remoteModelUUID       string // uuid of the model hosting the remote offer
@@ -70,7 +69,7 @@ func newRemoteApplicationWorker(
 ) (worker.Worker, error) {
 	w := &remoteApplicationWorker{
 		relationsWatcher:                  relationsWatcher,
-		offerName:                         remoteApplication.OfferName,
+		offerUUID:                         remoteApplication.OfferUUID,
 		applicationName:                   remoteApplication.Name,
 		localModelUUID:                    localModelUUID,
 		remoteModelUUID:                   remoteApplication.ModelUUID,
@@ -242,7 +241,7 @@ func (w *remoteApplicationWorker) processNewConsumingRelation(
 	applicationTag := names.NewApplicationTag(remoteRelation.ApplicationName)
 	relationTag := names.NewRelationTag(key)
 	applicationToken, remoteAppToken, relationToken, mac, err := w.registerRemoteRelation(
-		applicationTag, relationTag, w.offerName,
+		applicationTag, relationTag, w.offerUUID,
 		remoteRelation.Endpoint, remoteRelation.RemoteEndpointName)
 	if err != nil {
 		return errors.Annotatef(err, "registering application %v and relation %v", remoteRelation.ApplicationName, relationTag.Id())
@@ -360,8 +359,7 @@ func (w *remoteApplicationWorker) processNewConsumingRelation(
 }
 
 func (w *remoteApplicationWorker) registerRemoteRelation(
-	applicationTag, relationTag names.Tag,
-	remoteApplicationOfferName string,
+	applicationTag, relationTag names.Tag, offerUUID string,
 	localEndpointInfo params.RemoteEndpoint, remoteEndpointName string,
 ) (applicationToken, offeringAppToken, relationToken string, _ *macaroon.Macaroon, _ error) {
 	logger.Debugf("register remote relation %v", relationTag.Id())
@@ -390,7 +388,7 @@ func (w *remoteApplicationWorker) registerRemoteRelation(
 		ApplicationToken:  applicationToken,
 		SourceModelTag:    names.NewModelTag(w.localModelUUID).String(),
 		RelationToken:     relationToken,
-		OfferName:         remoteApplicationOfferName,
+		OfferUUID:         offerUUID,
 		RemoteEndpoint:    localEndpointInfo,
 		LocalEndpointName: remoteEndpointName,
 	}

--- a/worker/remoterelations/remoterelations_test.go
+++ b/worker/remoterelations/remoterelations_test.go
@@ -168,12 +168,12 @@ func (s *remoteRelationsSuite) assertRemoteRelationsWorkers(c *gc.C) worker.Work
 				Role:      "requires",
 				Interface: "db2",
 			},
-			OfferName:         "offer-db2",
+			OfferUUID:         "offer-db2-uuid",
 			LocalEndpointName: "data",
 			Macaroons:         macaroon.Slice{mac},
 		}}}},
 		{"SaveMacaroon", []interface{}{relTag, apiMac}},
-		{"ImportRemoteEntity", []interface{}{names.NewApplicationTag("db2"), "token-offer-db2"}},
+		{"ImportRemoteEntity", []interface{}{names.NewApplicationTag("db2"), "token-offer-db2-uuid"}},
 		{"WatchLocalRelationUnits", []interface{}{"db2:db django:db"}},
 		{"WatchRelationUnits", []interface{}{"token-db2:db django:db", macaroon.Slice{apiMac}}},
 		{"WatchRelationStatus", []interface{}{"token-db2:db django:db", macaroon.Slice{apiMac}}},
@@ -345,7 +345,7 @@ func (s *remoteRelationsSuite) TestRemoteRelationsChangedConsumes(c *gc.C) {
 		{"ConsumeRemoteRelationChange", []interface{}{
 			params.RemoteRelationChangeEvent{
 				Life:             params.Alive,
-				ApplicationToken: "token-offer-db2",
+				ApplicationToken: "token-offer-db2-uuid",
 				RelationToken:    "token-db2:db django:db",
 				ChangedUnits: []params.RemoteRelationUnitChange{{
 					UnitId:   1,
@@ -373,7 +373,7 @@ func (s *remoteRelationsSuite) TestRemoteRelationsDyingConsumes(c *gc.C) {
 		{"ConsumeRemoteRelationChange", []interface{}{
 			params.RemoteRelationChangeEvent{
 				Life:             params.Dying,
-				ApplicationToken: "token-offer-db2",
+				ApplicationToken: "token-offer-db2-uuid",
 				RelationToken:    "token-db2:db django:db",
 			},
 		}},


### PR DESCRIPTION
## Description of change

Use the UUID of the offer instead of the name to:
- communicate between models
- add as a first party caveat to macaroons
- look up access permission

## QA steps

Run up a cmr scenario
Ensure relation works
Add user, grant permission
Ensure added user can relate to the offer
