### PR TITLE
Update charm storage test to handle persistent storage type.

### DIFF
--- a/acceptancetests/assess_storage.py
+++ b/acceptancetests/assess_storage.py
@@ -82,13 +82,19 @@ def wait_for_storage_detach(client, storage_id, interval, timeout):
     """
     Due to the asynchronous nature of Juju, detaching a persistent storage
     takes some time.
-    This function will wait then check if the status of a specific storage
-    unit changed to detached. Once detached status detected, waiting stops.
+    This function will wait then check if the status of a specific persistent
+    storage unit changed to detached. Once detached, waiting stops.
     """
     for ignored in until_timeout(timeout):
         time.sleep(interval)
         storage_output = json.loads(client.list_storage())
-        storage_status = storage_output['volumes']['2']['status']['current']
+        try:
+            index = [elem for elem in storage_output['volumes'].keys()
+                if storage_output['volumes'][elem]['storage'] == storage_id][0]
+        except IndexError:
+            log.info('Volume index for {} cannot be found.'.format(storage_id))
+            break
+        storage_status = storage_output['volumes'][index]['status']['current']
         if storage_status == 'detached':
             break
 


### PR DESCRIPTION
## Description of change
Persistent Storage has been introduced into Juju 2.3 therefore relevant test scripts need to be updated to handle this new type. Key points are:
1. If there is any persistent storage unit attached to an application, remove application will not remove that storage, it will be detached instead.
2. A persistent storage unit must be detached before removal.
3. If the current controller has any persistent storage unit left behind, destroy controller will fail.

## QA steps
AWS run:
$ export ENV=parallel-aws
$ export JUJU_BIN=<path_to>/bin/juju
$ cd <path_to>/juju/acceptancetests
$ ./assess_storage.py $ENV $JUJU_BIN

This change has been locally tested.

## Documentation changes
N/A

## Bug reference
N/A
