### PR TITLE
Allow underscores in cloud names

### DIFF
--- a/cmd/juju/cloud/add.go
+++ b/cmd/juju/cloud/add.go
@@ -12,6 +12,7 @@ import (
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
 	"github.com/juju/gnuflag"
+	"gopkg.in/juju/names.v2"
 	"gopkg.in/yaml.v2"
 
 	"github.com/juju/juju/cloud"
@@ -108,6 +109,9 @@ func (c *AddCloudCommand) SetFlags(f *gnuflag.FlagSet) {
 func (c *AddCloudCommand) Init(args []string) (err error) {
 	if len(args) > 0 {
 		c.Cloud = args[0]
+		if ok := names.IsValidCloud(c.Cloud); !ok {
+			return errors.NotValidf("cloud name %q", c.Cloud)
+		}
 	}
 	if len(args) > 1 {
 		if c.CloudFile != args[1] && c.CloudFile != "" {

--- a/cmd/juju/commands/bootstrap.go
+++ b/cmd/juju/commands/bootstrap.go
@@ -18,6 +18,7 @@ import (
 	"github.com/juju/utils/featureflag"
 	"github.com/juju/version"
 	"gopkg.in/juju/charm.v6-unstable"
+	"gopkg.in/juju/names.v2"
 
 	jujucloud "github.com/juju/juju/cloud"
 	"github.com/juju/juju/cmd/juju/common"
@@ -240,6 +241,9 @@ func (c *bootstrapCommand) Init(args []string) (err error) {
 	c.Cloud = args[0]
 	if i := strings.IndexRune(c.Cloud, '/'); i > 0 {
 		c.Cloud, c.Region = c.Cloud[:i], c.Cloud[i+1:]
+	}
+	if ok := names.IsValidCloud(c.Cloud); !ok {
+		return errors.NotValidf("cloud name %q", c.Cloud)
 	}
 	if len(args) > 1 {
 		c.controllerName = args[1]

--- a/cmd/juju/commands/bootstrap_interactive.go
+++ b/cmd/juju/commands/bootstrap_interactive.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/juju/errors"
+	"gopkg.in/juju/names.v2"
 
 	jujucloud "github.com/juju/juju/cloud"
 	"github.com/juju/juju/cmd/juju/common"
@@ -56,6 +57,9 @@ func queryCloud(clouds []string, defCloud string, scanner *bufio.Scanner, w io.W
 	}
 	if cloud == "" {
 		return defCloud, nil
+	}
+	if ok := names.IsValidCloud(cloud); !ok {
+		return "", errors.NotValidf("cloud name %q", cloud)
 	}
 
 	cloudName, ok := interact.FindMatch(cloud, clouds)

--- a/cmd/juju/commands/bootstrap_interactive_test.go
+++ b/cmd/juju/commands/bootstrap_interactive_test.go
@@ -102,6 +102,16 @@ func (BSInteractSuite) TestQueryCloudDefault(c *gc.C) {
 	c.Assert(cloud, gc.Equals, "local")
 }
 
+func (BSInteractSuite) TestInvalidCloud(c *gc.C) {
+	input := "bad^cloud\n"
+
+	scanner := bufio.NewScanner(strings.NewReader(input))
+	clouds := []string{"books", "local", "bad^cloud"}
+
+	_, err := queryCloud(clouds, "local", scanner, ioutil.Discard)
+	c.Assert(err, gc.ErrorMatches, `cloud name "bad\^cloud" not valid`)
+}
+
 func (BSInteractSuite) TestQueryRegion(c *gc.C) {
 	input := "mars-west1\n"
 

--- a/cmd/juju/commands/bootstrap_test.go
+++ b/cmd/juju/commands/bootstrap_test.go
@@ -445,6 +445,11 @@ func (s *BootstrapSuite) TestRunCloudNameUnknown(c *gc.C) {
 	c.Check(err, gc.ErrorMatches, `unknown cloud "unknown", please try "juju update-clouds"`)
 }
 
+func (s *BootstrapSuite) TestRunBadCloudName(c *gc.C) {
+	_, err := cmdtesting.RunCommand(c, s.newBootstrapCommand(), "bad^cloud", "my-controller")
+	c.Check(err, gc.ErrorMatches, `cloud name "bad\^cloud" not valid`)
+}
+
 func (s *BootstrapSuite) TestCheckProviderProvisional(c *gc.C) {
 	err := checkProviderType("devcontroller")
 	c.Assert(err, jc.ErrorIsNil)

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -97,7 +97,7 @@ gopkg.in/juju/charmrepo.v2-unstable	git	e79aa298df89ea887c9bffec46063c24bfb730f7
 gopkg.in/juju/charmstore.v5-unstable	git	fd1eef3002fc6b6daff5e97efab6f5056d22dcc7	2016-09-16T10:09:07Z
 gopkg.in/juju/environschema.v1	git	7359fc7857abe2b11b5b3e23811a9c64cb6b01e0	2015-11-04T11:58:10Z
 gopkg.in/juju/jujusvg.v2	git	d82160011935ef79fc7aca84aba2c6f74700fe75	2016-06-09T10:52:15Z
-gopkg.in/juju/names.v2	git	0f8ae7499c60de56e4cb4c5eabe2d504615a18ca	2017-05-15T22:48:47Z
+gopkg.in/juju/names.v2	git	73ecf03dfbe6f8baf83d719144fb822ae37cfad7	2017-08-14T04:04:30Z
 gopkg.in/juju/worker.v1	git	6965b9d826717287bb002e02d1fd4d079978083e	2017-03-08T00:24:58Z
 gopkg.in/macaroon-bakery.v1	git	469b44e6f1f9479e115c8ae879ef80695be624d5	2016-06-22T12:14:21Z
 gopkg.in/macaroon.v1	git	ab3940c6c16510a850e1c2dd628b919f0f3f1464	2015-01-21T11:42:31Z


### PR DESCRIPTION
## Description of change

Cloud names do not support having "_" in them. This messes up bootstrap if the user has chosen to create a cloud with an "_" in the name. The PR pulls in an updated names.v2 dep which fixes the issue.

Also add extra validation to add-cloud to reject invalid cloud names.

Also do a drive by cleanup of unused code.

## QA steps

Bootstrap using a cloud with "_" in the name.

## Documentation changes

From what I can see, no existing doc mentions cloud names having "_".

## Bug reference

https://bugs.launchpad.net/juju/+bug/1709665
