### PR TITLE
migrations: Add CheckMachines method to MigrationTarget facade

### DIFF
--- a/api/migrationtarget/client.go
+++ b/api/migrationtarget/client.go
@@ -227,3 +227,19 @@ func (c *Client) AdoptResources(modelUUID string) error {
 func (c *Client) CACert() (string, error) {
 	return common.NewAPIAddresser(c.caller).CACert()
 }
+
+// CheckMachines compares the machines in state with the ones reported
+// by the provider and reports any discrepancies.
+func (c *Client) CheckMachines(modelUUID string) ([]error, error) {
+	var result params.ErrorResults
+	args := params.ModelArgs{names.NewModelTag(modelUUID).String()}
+	err := c.caller.FacadeCall("CheckMachines", args, &result)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	var results []error
+	for _, res := range result.Results {
+		results = append(results, errors.Errorf(res.Error.Message))
+	}
+	return results, nil
+}

--- a/apiserver/migrationtarget/migrationtarget.go
+++ b/apiserver/migrationtarget/migrationtarget.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/juju/errors"
+	"github.com/juju/utils/set"
 	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/apiserver/common"
@@ -222,4 +223,71 @@ func (api *API) AdoptResources(args params.AdoptResourcesArgs) error {
 		return errors.Trace(err)
 	}
 	return errors.Trace(env.AdoptResources(model.ControllerUUID(), args.SourceControllerVersion))
+}
+
+// CheckMachines compares the machines in state with the ones reported
+// by the provider and reports any discrepancies.
+func (api *API) CheckMachines(args params.ModelArgs) (params.ErrorResults, error) {
+	var empty params.ErrorResults
+	model, err := api.getModel(args.ModelTag)
+	if err != nil {
+		return empty, errors.Trace(err)
+	}
+	st, release, err := api.pool.Get(model.UUID())
+	if err != nil {
+		return empty, errors.Trace(err)
+	}
+	defer release()
+
+	machines, err := st.AllMachines()
+	if err != nil {
+		return empty, errors.Trace(err)
+	}
+	machinesByInstance := make(map[string]string)
+	for _, machine := range machines {
+		if machine.IsContainer() {
+			// Containers don't correspond to instances at the
+			// provider level.
+			continue
+		}
+		instanceId, err := machine.InstanceId()
+		if err != nil {
+			return empty, errors.Annotatef(
+				err, "getting instance id for machine %s", machine.Id())
+		}
+		machinesByInstance[string(instanceId)] = machine.Id()
+	}
+
+	env, err := api.getEnviron(st)
+	if err != nil {
+		return empty, errors.Trace(err)
+	}
+	instances, err := env.AllInstances()
+	if err != nil {
+		return empty, errors.Trace(err)
+	}
+
+	var results []params.ErrorResult
+
+	instanceIds := set.NewStrings()
+	for _, instance := range instances {
+		id := string(instance.Id())
+		instanceIds.Add(id)
+		if _, found := machinesByInstance[id]; !found {
+			results = append(results, errorResult("no machine with instance %q", id))
+		}
+	}
+
+	for instanceId, name := range machinesByInstance {
+		if !instanceIds.Contains(instanceId) {
+			results = append(results, errorResult(
+				"couldn't find instance %q for machine %s", instanceId, name))
+		}
+	}
+
+	return params.ErrorResults{Results: results}, nil
+}
+
+func errorResult(format string, args ...interface{}) params.ErrorResult {
+	return params.ErrorResult{Error: common.ServerError(errors.Errorf(format, args...))}
 }

--- a/apiserver/migrationtarget/migrationtarget.go
+++ b/apiserver/migrationtarget/migrationtarget.go
@@ -229,11 +229,11 @@ func (api *API) AdoptResources(args params.AdoptResourcesArgs) error {
 // by the provider and reports any discrepancies.
 func (api *API) CheckMachines(args params.ModelArgs) (params.ErrorResults, error) {
 	var empty params.ErrorResults
-	model, err := api.getModel(args.ModelTag)
+	tag, err := names.ParseModelTag(args.ModelTag)
 	if err != nil {
 		return empty, errors.Trace(err)
 	}
-	st, release, err := api.pool.Get(model.UUID())
+	st, release, err := api.pool.Get(tag.Id())
 	if err != nil {
 		return empty, errors.Trace(err)
 	}
@@ -248,6 +248,11 @@ func (api *API) CheckMachines(args params.ModelArgs) (params.ErrorResults, error
 		if machine.IsContainer() {
 			// Containers don't correspond to instances at the
 			// provider level.
+			continue
+		}
+		if manual, err := machine.IsManual(); err != nil {
+			return empty, errors.Trace(err)
+		} else if manual {
 			continue
 		}
 		instanceId, err := machine.InstanceId()

--- a/apiserver/migrationtarget/migrationtarget_test.go
+++ b/apiserver/migrationtarget/migrationtarget_test.go
@@ -373,6 +373,30 @@ func (s *Suite) TestCheckMachinesHandlesContainers(c *gc.C) {
 	c.Assert(results, gc.DeepEquals, params.ErrorResults{})
 }
 
+func (s *Suite) TestCheckMachinesHandlesManual(c *gc.C) {
+	st := s.Factory.MakeModel(c, nil)
+	defer st.Close()
+
+	fact := factory.NewFactory(st)
+	fact.MakeMachine(c, &factory.MachineParams{
+		InstanceId: "birds",
+	})
+	fact.MakeMachine(c, &factory.MachineParams{
+		Nonce: "manual:flibbertigibbert",
+	})
+
+	env := mockEnviron{
+		Stub:      &testing.Stub{},
+		instances: []*mockInstance{{id: "birds"}},
+	}
+	api := s.mustNewAPIWithEnviron(c, &env)
+
+	results, err := api.CheckMachines(
+		params.ModelArgs{ModelTag: st.ModelTag().String()})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(results, gc.DeepEquals, params.ErrorResults{})
+}
+
 func (s *Suite) newAPI(environFunc stateenvirons.NewEnvironFunc) (*migrationtarget.API, error) {
 	ctx := facadetest.Context{
 		State_:     s.State,

--- a/apiserver/migrationtarget/migrationtarget_test.go
+++ b/apiserver/migrationtarget/migrationtarget_test.go
@@ -22,11 +22,13 @@ import (
 	"github.com/juju/juju/apiserver/params"
 	apiservertesting "github.com/juju/juju/apiserver/testing"
 	"github.com/juju/juju/environs"
+	"github.com/juju/juju/instance"
 	"github.com/juju/juju/provider/dummy"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/stateenvirons"
 	statetesting "github.com/juju/juju/state/testing"
 	jujutesting "github.com/juju/juju/testing"
+	"github.com/juju/juju/testing/factory"
 )
 
 type Suite struct {
@@ -70,13 +72,13 @@ func (s *Suite) TestFacadeRegistered(c *gc.C) {
 
 func (s *Suite) TestNotUser(c *gc.C) {
 	s.authorizer.Tag = names.NewMachineTag("0")
-	_, _, err := s.newAPI(nil)
+	_, err := s.newAPI(nil)
 	c.Assert(errors.Cause(err), gc.Equals, common.ErrPerm)
 }
 
 func (s *Suite) TestNotControllerAdmin(c *gc.C) {
 	s.authorizer.Tag = names.NewUserTag("jrandomuser")
-	_, _, err := s.newAPI(nil)
+	_, err := s.newAPI(nil)
 	c.Assert(errors.Cause(err), gc.Equals, common.ErrPerm)
 }
 
@@ -239,12 +241,11 @@ func (s *Suite) TestAdoptResources(c *gc.C) {
 	defer st.Close()
 
 	env := mockEnviron{Stub: &testing.Stub{}}
-	api, ctx, err := s.newAPI(func(envSt *state.State) (environs.Environ, error) {
+	api, err := s.newAPI(func(envSt *state.State) (environs.Environ, error) {
 		c.Assert(envSt.ModelUUID(), gc.Equals, st.ModelUUID())
 		return &env, nil
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	defer ctx.StatePool().Close()
 
 	err = api.AdoptResources(params.AdoptResourcesArgs{
 		ModelTag:                st.ModelTag().String(),
@@ -256,7 +257,123 @@ func (s *Suite) TestAdoptResources(c *gc.C) {
 	env.Stub.CheckCall(c, 0, "AdoptResources", st.ControllerUUID(), version.MustParse("3.2.1"))
 }
 
-func (s *Suite) newAPI(environFunc stateenvirons.NewEnvironFunc) (*migrationtarget.API, *facadetest.Context, error) {
+func (s *Suite) TestCheckMachinesInstancesMissing(c *gc.C) {
+	st := s.Factory.MakeModel(c, nil)
+	defer st.Close()
+
+	fact := factory.NewFactory(st)
+	fact.MakeMachine(c, &factory.MachineParams{
+		InstanceId: "wind-up",
+	})
+	m := fact.MakeMachine(c, &factory.MachineParams{
+		InstanceId: "birds",
+	})
+	c.Assert(m.Id(), gc.Equals, "1")
+
+	env := mockEnviron{
+		Stub:      &testing.Stub{},
+		instances: []*mockInstance{{id: "wind-up"}},
+	}
+	api := s.mustNewAPIWithEnviron(c, &env)
+
+	results, err := api.CheckMachines(
+		params.ModelArgs{ModelTag: st.ModelTag().String()})
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Assert(results.Results, gc.HasLen, 1)
+	c.Assert(results.Results[0].Error, gc.ErrorMatches, `couldn't find instance "birds" for machine 1`)
+}
+
+func (s *Suite) TestCheckMachinesExtraInstances(c *gc.C) {
+	st := s.Factory.MakeModel(c, nil)
+	defer st.Close()
+
+	fact := factory.NewFactory(st)
+	fact.MakeMachine(c, &factory.MachineParams{
+		InstanceId: "judith",
+	})
+	env := mockEnviron{
+		Stub: &testing.Stub{},
+		instances: []*mockInstance{
+			{id: "judith"},
+			{id: "analyse"},
+		},
+	}
+	api := s.mustNewAPIWithEnviron(c, &env)
+
+	results, err := api.CheckMachines(
+		params.ModelArgs{ModelTag: st.ModelTag().String()})
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Assert(results.Results, gc.HasLen, 1)
+	c.Assert(results.Results[0].Error, gc.ErrorMatches, `no machine with instance "analyse"`)
+}
+
+func (s *Suite) TestCheckMachinesErrorGettingInstances(c *gc.C) {
+	st := s.Factory.MakeModel(c, nil)
+	defer st.Close()
+
+	env := mockEnviron{Stub: &testing.Stub{}}
+	env.SetErrors(errors.Errorf("kablooie"))
+	api := s.mustNewAPIWithEnviron(c, &env)
+
+	results, err := api.CheckMachines(
+		params.ModelArgs{ModelTag: st.ModelTag().String()})
+	c.Assert(err, gc.ErrorMatches, "kablooie")
+	c.Assert(results, gc.DeepEquals, params.ErrorResults{})
+}
+
+func (s *Suite) TestCheckMachinesSuccess(c *gc.C) {
+	st := s.Factory.MakeModel(c, nil)
+	defer st.Close()
+
+	fact := factory.NewFactory(st)
+	fact.MakeMachine(c, &factory.MachineParams{
+		InstanceId: "eriatarka",
+	})
+	m := fact.MakeMachine(c, &factory.MachineParams{
+		InstanceId: "volta",
+	})
+	c.Assert(m.Id(), gc.Equals, "1")
+
+	env := mockEnviron{
+		Stub: &testing.Stub{},
+		instances: []*mockInstance{
+			{id: "volta"},
+			{id: "eriatarka"},
+		},
+	}
+	api := s.mustNewAPIWithEnviron(c, &env)
+
+	results, err := api.CheckMachines(
+		params.ModelArgs{ModelTag: st.ModelTag().String()})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(results, gc.DeepEquals, params.ErrorResults{})
+}
+
+func (s *Suite) TestCheckMachinesHandlesContainers(c *gc.C) {
+	st := s.Factory.MakeModel(c, nil)
+	defer st.Close()
+
+	fact := factory.NewFactory(st)
+	m := fact.MakeMachine(c, &factory.MachineParams{
+		InstanceId: "birds",
+	})
+	fact.MakeMachineNested(c, m.Id(), nil)
+
+	env := mockEnviron{
+		Stub:      &testing.Stub{},
+		instances: []*mockInstance{{id: "birds"}},
+	}
+	api := s.mustNewAPIWithEnviron(c, &env)
+
+	results, err := api.CheckMachines(
+		params.ModelArgs{ModelTag: st.ModelTag().String()})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(results, gc.DeepEquals, params.ErrorResults{})
+}
+
+func (s *Suite) newAPI(environFunc stateenvirons.NewEnvironFunc) (*migrationtarget.API, error) {
 	ctx := facadetest.Context{
 		State_:     s.State,
 		Resources_: s.resources,
@@ -264,11 +381,20 @@ func (s *Suite) newAPI(environFunc stateenvirons.NewEnvironFunc) (*migrationtarg
 		StatePool_: state.NewStatePool(s.State),
 	}
 	api, err := migrationtarget.NewAPI(ctx, environFunc)
-	return api, &ctx, err
+	s.AddCleanup(func(*gc.C) { ctx.StatePool().Close() })
+	return api, err
 }
 
 func (s *Suite) mustNewAPI(c *gc.C) *migrationtarget.API {
-	api, _, err := s.newAPI(nil)
+	api, err := s.newAPI(nil)
+	c.Assert(err, jc.ErrorIsNil)
+	return api
+}
+
+func (s *Suite) mustNewAPIWithEnviron(c *gc.C, env environs.Environ) *migrationtarget.API {
+	api, err := s.newAPI(func(*state.State) (environs.Environ, error) {
+		return env, nil
+	})
 	c.Assert(err, jc.ErrorIsNil)
 	return api
 }
@@ -299,9 +425,29 @@ func (s *Suite) controllerVersion(c *gc.C) version.Number {
 type mockEnviron struct {
 	environs.Environ
 	*testing.Stub
+
+	instances []*mockInstance
 }
 
 func (e *mockEnviron) AdoptResources(controllerUUID string, sourceVersion version.Number) error {
 	e.MethodCall(e, "AdoptResources", controllerUUID, sourceVersion)
 	return e.NextErr()
+}
+
+func (e *mockEnviron) AllInstances() ([]instance.Instance, error) {
+	e.MethodCall(e, "AllInstances")
+	results := make([]instance.Instance, len(e.instances))
+	for i, instance := range e.instances {
+		results[i] = instance
+	}
+	return results, e.NextErr()
+}
+
+type mockInstance struct {
+	instance.Instance
+	id string
+}
+
+func (i *mockInstance) Id() instance.Id {
+	return instance.Id(i.id)
 }

--- a/worker/migrationmaster/worker_test.go
+++ b/worker/migrationmaster/worker_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/juju/juju/api"
 	"github.com/juju/juju/api/base"
 	"github.com/juju/juju/api/common"
+	servercommon "github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/params"
 	coremigration "github.com/juju/juju/core/migration"
 	"github.com/juju/juju/migration"
@@ -91,6 +92,12 @@ var (
 	}
 	activateCall = jujutesting.StubCall{
 		"MigrationTarget.Activate",
+		[]interface{}{
+			params.ModelArgs{ModelTag: modelTag.String()},
+		},
+	}
+	checkMachinesCall = jujutesting.StubCall{
+		"MigrationTarget.CheckMachines",
 		[]interface{}{
 			params.ModelArgs{ModelTag: modelTag.String()},
 		},
@@ -253,6 +260,7 @@ func (s *Suite) TestSuccessfulMigration(c *gc.C) {
 			{"facade.WatchMinionReports", nil},
 			{"facade.MinionReports", nil},
 			apiOpenControllerCall,
+			checkMachinesCall,
 			activateCall,
 			apiCloseCall,
 			{"facade.SetPhase", []interface{}{coremigration.SUCCESS}},
@@ -540,6 +548,61 @@ func (s *Suite) TestVALIDATIONFailedAgent(c *gc.C) {
 			{"facade.MinionReports", nil},
 		},
 		abortCalls,
+	))
+}
+
+func (s *Suite) TestVALIDATIONCheckMachinesOneError(c *gc.C) {
+	s.facade.queueStatus(s.makeStatus(coremigration.VALIDATION))
+	s.facade.queueMinionReports(makeMinionReports(coremigration.VALIDATION))
+
+	s.connection.machineErrs = []string{"been so strange"}
+	s.checkWorkerReturns(c, migrationmaster.ErrInactive)
+	s.stub.CheckCalls(c, joinCalls(
+		watchStatusLockdownCalls,
+		[]jujutesting.StubCall{
+			{"facade.WatchMinionReports", nil},
+			{"facade.MinionReports", nil},
+			apiOpenControllerCall,
+			checkMachinesCall,
+			apiCloseCall,
+		},
+		abortCalls,
+	))
+}
+
+func (s *Suite) TestVALIDATIONCheckMachinesSeveralErrors(c *gc.C) {
+	s.facade.queueStatus(s.makeStatus(coremigration.VALIDATION))
+	s.facade.queueMinionReports(makeMinionReports(coremigration.VALIDATION))
+	s.connection.machineErrs = []string{"been so strange", "lit up"}
+	s.checkWorkerReturns(c, migrationmaster.ErrInactive)
+	s.stub.CheckCalls(c, joinCalls(
+		watchStatusLockdownCalls,
+		[]jujutesting.StubCall{
+			{"facade.WatchMinionReports", nil},
+			{"facade.MinionReports", nil},
+			apiOpenControllerCall,
+			checkMachinesCall,
+			apiCloseCall,
+		},
+		abortCalls,
+	))
+}
+
+func (s *Suite) TestVALIDATIONCheckMachinesOtherError(c *gc.C) {
+	s.facade.queueStatus(s.makeStatus(coremigration.VALIDATION))
+	s.facade.queueMinionReports(makeMinionReports(coremigration.VALIDATION))
+	s.connection.checkMachineErr = errors.Errorf("something went bang")
+
+	s.checkWorkerReturns(c, s.connection.checkMachineErr)
+	s.stub.CheckCalls(c, joinCalls(
+		watchStatusLockdownCalls,
+		[]jujutesting.StubCall{
+			{"facade.WatchMinionReports", nil},
+			{"facade.MinionReports", nil},
+			apiOpenControllerCall,
+			checkMachinesCall,
+			apiCloseCall,
+		},
 	))
 }
 
@@ -1175,14 +1238,17 @@ type stubConnection struct {
 
 	latestLogErr  error
 	latestLogTime time.Time
+
+	machineErrs     []string
+	checkMachineErr error
 }
 
 func (c *stubConnection) BestFacadeVersion(string) int {
 	return 1
 }
 
-func (c *stubConnection) APICall(objType string, version int, id, request string, params, response interface{}) error {
-	c.stub.AddCall(objType+"."+request, params)
+func (c *stubConnection) APICall(objType string, version int, id, request string, args, response interface{}) error {
+	c.stub.AddCall(objType+"."+request, args)
 
 	if objType == "MigrationTarget" {
 		switch request {
@@ -1198,6 +1264,14 @@ func (c *stubConnection) APICall(objType string, version int, id, request string
 			// from the API it will have a timezone attached.
 			*responseTime = c.latestLogTime.In(time.UTC)
 			return c.latestLogErr
+		case "CheckMachines":
+			results := response.(*params.ErrorResults)
+			for _, msg := range c.machineErrs {
+				results.Results = append(results.Results, params.ErrorResult{
+					Error: servercommon.ServerError(errors.Errorf(msg)),
+				})
+			}
+			return c.checkMachineErr
 		}
 	}
 	return errors.New("unexpected API call")

--- a/worker/migrationmaster/worker_test.go
+++ b/worker/migrationmaster/worker_test.go
@@ -568,6 +568,11 @@ func (s *Suite) TestVALIDATIONCheckMachinesOneError(c *gc.C) {
 		},
 		abortCalls,
 	))
+	lastMessages := s.facade.statuses[len(s.facade.statuses)-2:]
+	c.Assert(lastMessages, gc.DeepEquals, []string{
+		"machine sanity check failed, 1 error found",
+		"aborted, removing model from target controller",
+	})
 }
 
 func (s *Suite) TestVALIDATIONCheckMachinesSeveralErrors(c *gc.C) {
@@ -586,6 +591,11 @@ func (s *Suite) TestVALIDATIONCheckMachinesSeveralErrors(c *gc.C) {
 		},
 		abortCalls,
 	))
+	lastMessages := s.facade.statuses[len(s.facade.statuses)-2:]
+	c.Assert(lastMessages, gc.DeepEquals, []string{
+		"machine sanity check failed, 2 errors found",
+		"aborted, removing model from target controller",
+	})
 }
 
 func (s *Suite) TestVALIDATIONCheckMachinesOtherError(c *gc.C) {
@@ -1075,6 +1085,8 @@ type stubMasterFacade struct {
 	minionReportsErr      error
 
 	exportedResources []coremigration.SerializedModelResource
+
+	statuses []string
 }
 
 func (f *stubMasterFacade) triggerWatcher() {
@@ -1185,6 +1197,7 @@ func (f *stubMasterFacade) SetPhase(phase coremigration.Phase) error {
 }
 
 func (f *stubMasterFacade) SetStatusMessage(message string) error {
+	f.statuses = append(f.statuses, message)
 	return nil
 }
 


### PR DESCRIPTION
## Description of change

This adds a sanity-check method on the target controller so that we can confirm after the migration that the state machines match up with the provider instances. It's being added for use primarily in 1.25 upgrades, but I've added a call to it from the migration master worker to ensure that it works.

## QA steps

* Bootstrap two controllers A and B.
* Create model A:m, and deploy some applications to it.
* Migrate m to controller B.
* The migration should succeed - the log will include a message in the validation phase reporting "checking machines in migrated model".
