### PR TITLE
Refactor EnvironConfigGetter.CloudSpec()

### DIFF
--- a/api/agent/machine_test.go
+++ b/api/agent/machine_test.go
@@ -56,15 +56,18 @@ func (s *servingInfoSuite) TestStateServingInfo(c *gc.C) {
 	}
 	err := s.State.SetStateServingInfo(ssi)
 	c.Assert(err, jc.ErrorIsNil)
-	info, err := apiagent.NewState(st).StateServingInfo()
+	apiSt, err := apiagent.NewState(st)
+	c.Assert(err, jc.ErrorIsNil)
+	info, err := apiSt.StateServingInfo()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(info, jc.DeepEquals, expected)
 }
 
 func (s *servingInfoSuite) TestStateServingInfoPermission(c *gc.C) {
 	st, _ := s.OpenAPIAsNewMachine(c)
-
-	_, err := apiagent.NewState(st).StateServingInfo()
+	apiSt, err := apiagent.NewState(st)
+	c.Assert(err, jc.ErrorIsNil)
+	_, err = apiSt.StateServingInfo()
 	c.Assert(errors.Cause(err), gc.DeepEquals, &rpc.RequestError{
 		Message: "permission denied",
 		Code:    "unauthorized access",
@@ -81,8 +84,9 @@ func (s *servingInfoSuite) TestIsMaster(c *gc.C) {
 
 	st, _ := s.OpenAPIAsNewMachine(c, state.JobManageModel)
 	expected := true
-	result, err := apiagent.NewState(st).IsMaster()
-
+	apiSt, err := apiagent.NewState(st)
+	c.Assert(err, jc.ErrorIsNil)
+	result, err := apiSt.IsMaster()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.Equals, expected)
 	c.Assert(calledIsMaster, jc.IsTrue)
@@ -90,7 +94,9 @@ func (s *servingInfoSuite) TestIsMaster(c *gc.C) {
 
 func (s *servingInfoSuite) TestIsMasterPermission(c *gc.C) {
 	st, _ := s.OpenAPIAsNewMachine(c)
-	_, err := apiagent.NewState(st).IsMaster()
+	apiSt, err := apiagent.NewState(st)
+	c.Assert(err, jc.ErrorIsNil)
+	_, err = apiSt.IsMaster()
 	c.Assert(errors.Cause(err), gc.DeepEquals, &rpc.RequestError{
 		Message: "permission denied",
 		Code:    "unauthorized access",
@@ -112,12 +118,16 @@ func (s *machineSuite) SetUpTest(c *gc.C) {
 
 func (s *machineSuite) TestMachineEntity(c *gc.C) {
 	tag := names.NewMachineTag("42")
-	m, err := apiagent.NewState(s.st).Entity(tag)
+	apiSt, err := apiagent.NewState(s.st)
+	c.Assert(err, jc.ErrorIsNil)
+	m, err := apiSt.Entity(tag)
 	c.Assert(err, gc.ErrorMatches, "permission denied")
 	c.Assert(err, jc.Satisfies, params.IsCodeUnauthorized)
 	c.Assert(m, gc.IsNil)
 
-	m, err = apiagent.NewState(s.st).Entity(s.machine.Tag())
+	apiSt, err = apiagent.NewState(s.st)
+	c.Assert(err, jc.ErrorIsNil)
+	m, err = apiSt.Entity(s.machine.Tag())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(m.Tag(), gc.Equals, s.machine.Tag().String())
 	c.Assert(m.Life(), gc.Equals, params.Alive)
@@ -128,14 +138,18 @@ func (s *machineSuite) TestMachineEntity(c *gc.C) {
 	err = s.machine.Remove()
 	c.Assert(err, jc.ErrorIsNil)
 
-	m, err = apiagent.NewState(s.st).Entity(s.machine.Tag())
+	apiSt, err = apiagent.NewState(s.st)
+	c.Assert(err, jc.ErrorIsNil)
+	m, err = apiSt.Entity(s.machine.Tag())
 	c.Assert(err, gc.ErrorMatches, fmt.Sprintf("machine %s not found", s.machine.Id()))
 	c.Assert(err, jc.Satisfies, params.IsCodeNotFound)
 	c.Assert(m, gc.IsNil)
 }
 
 func (s *machineSuite) TestEntitySetPassword(c *gc.C) {
-	entity, err := apiagent.NewState(s.st).Entity(s.machine.Tag())
+	apiSt, err := apiagent.NewState(s.st)
+	c.Assert(err, jc.ErrorIsNil)
+	entity, err := apiSt.Entity(s.machine.Tag())
 	c.Assert(err, jc.ErrorIsNil)
 
 	err = entity.SetPassword("foo")
@@ -170,7 +184,9 @@ func (s *machineSuite) TestClearReboot(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(rFlag, jc.IsTrue)
 
-	entity, err := apiagent.NewState(s.st).Entity(s.machine.Tag())
+	apiSt, err := apiagent.NewState(s.st)
+	c.Assert(err, jc.ErrorIsNil)
+	entity, err := apiSt.Entity(s.machine.Tag())
 	c.Assert(err, jc.ErrorIsNil)
 
 	err = entity.ClearReboot()

--- a/api/agent/model_test.go
+++ b/api/agent/model_test.go
@@ -4,6 +4,7 @@
 package agent_test
 
 import (
+	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/api/agent"
@@ -23,8 +24,9 @@ func (s *modelSuite) SetUpTest(c *gc.C) {
 
 	stateAPI, _ := s.OpenAPIAsNewMachine(c)
 
-	agentAPI := agent.NewState(stateAPI)
+	agentAPI, err := agent.NewState(stateAPI)
 	c.Assert(agentAPI, gc.NotNil)
+	c.Assert(err, jc.ErrorIsNil)
 
 	s.ModelWatcherTests = apitesting.NewModelWatcherTests(
 		agentAPI, s.BackingState,

--- a/api/agent/state.go
+++ b/api/agent/state.go
@@ -29,14 +29,18 @@ type State struct {
 
 // NewState returns a version of the state that provides functionality
 // required by agent code.
-func NewState(caller base.APICaller) *State {
+func NewState(caller base.APICaller) (*State, error) {
+	modelTag, isModel := caller.ModelTag()
+	if !isModel {
+		return nil, errors.New("expected model specific API connection")
+	}
 	facadeCaller := base.NewFacadeCaller(caller, "Agent")
 	return &State{
 		facade:              facadeCaller,
 		ModelWatcher:        common.NewModelWatcher(facadeCaller),
-		CloudSpecAPI:        cloudspec.NewCloudSpecAPI(facadeCaller),
+		CloudSpecAPI:        cloudspec.NewCloudSpecAPI(facadeCaller, modelTag),
 		ControllerConfigAPI: common.NewControllerConfig(facadeCaller),
-	}
+	}, nil
 }
 
 func (st *State) getEntity(tag names.Tag) (*params.AgentGetEntitiesResult, error) {

--- a/api/agent/unit_test.go
+++ b/api/agent/unit_test.go
@@ -42,12 +42,15 @@ func (s *unitSuite) SetUpTest(c *gc.C) {
 
 func (s *unitSuite) TestUnitEntity(c *gc.C) {
 	tag := names.NewUnitTag("wordpress/1")
-	m, err := apiagent.NewState(s.st).Entity(tag)
+	apiSt, err := apiagent.NewState(s.st)
+	c.Assert(err, jc.ErrorIsNil)
+	m, err := apiSt.Entity(tag)
 	c.Assert(err, gc.ErrorMatches, "permission denied")
 	c.Assert(err, jc.Satisfies, params.IsCodeUnauthorized)
 	c.Assert(m, gc.IsNil)
 
-	m, err = apiagent.NewState(s.st).Entity(s.unit.Tag())
+	apiSt, err = apiagent.NewState(s.st)
+	m, err = apiSt.Entity(s.unit.Tag())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(m.Tag(), gc.Equals, s.unit.Tag().String())
 	c.Assert(m.Life(), gc.Equals, params.Alive)
@@ -58,7 +61,8 @@ func (s *unitSuite) TestUnitEntity(c *gc.C) {
 	err = s.unit.Remove()
 	c.Assert(err, jc.ErrorIsNil)
 
-	m, err = apiagent.NewState(s.st).Entity(s.unit.Tag())
+	apiSt, err = apiagent.NewState(s.st)
+	m, err = apiSt.Entity(s.unit.Tag())
 	c.Assert(err, gc.ErrorMatches, fmt.Sprintf("unit %q not found", s.unit.Name()))
 	c.Assert(err, jc.Satisfies, params.IsCodeNotFound)
 	c.Assert(m, gc.IsNil)

--- a/api/common/cloudspec/cloudspec.go
+++ b/api/common/cloudspec/cloudspec.go
@@ -16,20 +16,21 @@ import (
 // CloudSpecAPI provides common client-side API functions
 // to call into apiserver/common/cloudspec.CloudSpec.
 type CloudSpecAPI struct {
-	facade base.FacadeCaller
+	facade   base.FacadeCaller
+	modelTag names.ModelTag
 }
 
 // NewCloudSpecAPI creates a CloudSpecAPI using the provided
 // FacadeCaller.
-func NewCloudSpecAPI(facade base.FacadeCaller) *CloudSpecAPI {
-	return &CloudSpecAPI{facade}
+func NewCloudSpecAPI(facade base.FacadeCaller, modelTag names.ModelTag) *CloudSpecAPI {
+	return &CloudSpecAPI{facade, modelTag}
 }
 
-// CloudSpec returns the cloud specification for the model
-// with the given tag.
-func (api *CloudSpecAPI) CloudSpec(tag names.ModelTag) (environs.CloudSpec, error) {
+// CloudSpec returns the cloud specification for the model associated
+// with the API facade.
+func (api *CloudSpecAPI) CloudSpec() (environs.CloudSpec, error) {
 	var results params.CloudSpecResults
-	args := params.Entities{Entities: []params.Entity{{tag.String()}}}
+	args := params.Entities{Entities: []params.Entity{{api.modelTag.String()}}}
 	err := api.facade.FacadeCall("CloudSpec", args, &results)
 	if err != nil {
 		return environs.CloudSpec{}, err

--- a/api/common/cloudspec/cloudspec_test.go
+++ b/api/common/cloudspec/cloudspec_test.go
@@ -25,7 +25,7 @@ type CloudSpecSuite struct {
 }
 
 func (s *CloudSpecSuite) TestNewCloudSpecAPI(c *gc.C) {
-	api := cloudspec.NewCloudSpecAPI(nil)
+	api := cloudspec.NewCloudSpecAPI(nil, coretesting.ModelTag)
 	c.Check(api, gc.NotNil)
 }
 
@@ -54,8 +54,8 @@ func (s *CloudSpecSuite) TestCloudSpec(c *gc.C) {
 		}
 		return nil
 	}
-	api := cloudspec.NewCloudSpecAPI(&facadeCaller)
-	cloudSpec, err := api.CloudSpec(coretesting.ModelTag)
+	api := cloudspec.NewCloudSpecAPI(&facadeCaller, coretesting.ModelTag)
+	cloudSpec, err := api.CloudSpec()
 	c.Assert(err, jc.ErrorIsNil)
 
 	credential := cloud.NewCredential(
@@ -79,8 +79,8 @@ func (s *CloudSpecSuite) TestCloudSpecOverallError(c *gc.C) {
 	facadeCaller.FacadeCallFn = func(name string, args, response interface{}) error {
 		return expect
 	}
-	api := cloudspec.NewCloudSpecAPI(&facadeCaller)
-	_, err := api.CloudSpec(coretesting.ModelTag)
+	api := cloudspec.NewCloudSpecAPI(&facadeCaller, coretesting.ModelTag)
+	_, err := api.CloudSpec()
 	c.Assert(err, gc.Equals, expect)
 }
 
@@ -89,8 +89,8 @@ func (s *CloudSpecSuite) TestCloudSpecResultCountMismatch(c *gc.C) {
 	facadeCaller.FacadeCallFn = func(name string, args, response interface{}) error {
 		return nil
 	}
-	api := cloudspec.NewCloudSpecAPI(&facadeCaller)
-	_, err := api.CloudSpec(coretesting.ModelTag)
+	api := cloudspec.NewCloudSpecAPI(&facadeCaller, coretesting.ModelTag)
+	_, err := api.CloudSpec()
 	c.Assert(err, gc.ErrorMatches, "expected 1 result, got 0")
 }
 
@@ -107,8 +107,8 @@ func (s *CloudSpecSuite) TestCloudSpecResultError(c *gc.C) {
 		}
 		return nil
 	}
-	api := cloudspec.NewCloudSpecAPI(&facadeCaller)
-	_, err := api.CloudSpec(coretesting.ModelTag)
+	api := cloudspec.NewCloudSpecAPI(&facadeCaller, coretesting.ModelTag)
+	_, err := api.CloudSpec()
 	c.Assert(err, jc.Satisfies, params.IsCodeUnauthorized)
 	c.Assert(err, gc.ErrorMatches, "API request failed: dang")
 }
@@ -123,7 +123,7 @@ func (s *CloudSpecSuite) TestCloudSpecInvalidCloudSpec(c *gc.C) {
 		}}}
 		return nil
 	}
-	api := cloudspec.NewCloudSpecAPI(&facadeCaller)
-	_, err := api.CloudSpec(coretesting.ModelTag)
+	api := cloudspec.NewCloudSpecAPI(&facadeCaller, coretesting.ModelTag)
+	_, err := api.CloudSpec()
 	c.Assert(err, gc.ErrorMatches, "validating CloudSpec: empty Type not valid")
 }

--- a/api/controller/controller.go
+++ b/api/controller/controller.go
@@ -38,7 +38,6 @@ func NewClient(st base.APICallCloser) *Client {
 		facade:              backend,
 		ControllerConfigAPI: common.NewControllerConfig(backend),
 		ModelStatusAPI:      common.NewModelStatusAPI(backend),
-		CloudSpecAPI:        cloudspec.NewCloudSpecAPI(backend),
 	}
 }
 
@@ -64,6 +63,12 @@ func (c *Client) AllModels() ([]base.UserModel, error) {
 		}
 	}
 	return result, nil
+}
+
+// CloudSpec returns a CloudSpec for the specified model.
+func (c *Client) CloudSpec(modelTag names.ModelTag) (environs.CloudSpec, error) {
+	api := cloudspec.NewCloudSpecAPI(c.facade, modelTag)
+	return api.CloudSpec()
 }
 
 // ModelConfig returns all model settings for the

--- a/api/controller/http_test.go
+++ b/api/controller/http_test.go
@@ -12,8 +12,10 @@ import (
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
+	names "gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/api/base"
+	coretesting "github.com/juju/juju/testing"
 )
 
 // newHTTPFixture creates and returns an HTTP fixture to be used in order to
@@ -70,6 +72,11 @@ var _ base.APICallCloser = (*httpAPICallCloser)(nil)
 type httpAPICallCloser struct {
 	base.APICallCloser
 	url *url.URL
+}
+
+// ModelTag implements base.APICallCloser.
+func (*httpAPICallCloser) ModelTag() (names.ModelTag, bool) {
+	return coretesting.ModelTag, true
 }
 
 // BestFacadeVersion implements base.APICallCloser.

--- a/api/firewaller/firewaller.go
+++ b/api/firewaller/firewaller.go
@@ -27,13 +27,17 @@ type Client struct {
 }
 
 // NewClient creates a new client-side Firewaller API facade.
-func NewClient(caller base.APICaller) *Client {
+func NewClient(caller base.APICaller) (*Client, error) {
+	modelTag, isModel := caller.ModelTag()
+	if !isModel {
+		return nil, errors.New("expected model specific API connection")
+	}
 	facadeCaller := base.NewFacadeCaller(caller, firewallerFacade)
 	return &Client{
 		facade:       facadeCaller,
 		ModelWatcher: common.NewModelWatcher(facadeCaller),
-		CloudSpecAPI: cloudspec.NewCloudSpecAPI(facadeCaller),
-	}
+		CloudSpecAPI: cloudspec.NewCloudSpecAPI(facadeCaller, modelTag),
+	}, nil
 }
 
 // BestAPIVersion returns the API version that we were able to

--- a/api/firewaller/firewaller_test.go
+++ b/api/firewaller/firewaller_test.go
@@ -83,8 +83,10 @@ func (s *firewallerSuite) SetUpTest(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Create the firewaller API facade.
-	s.firewaller = firewaller.NewClient(s.st)
-	c.Assert(s.firewaller, gc.NotNil)
+	firewallerClient, err := firewaller.NewClient(s.st)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(firewallerClient, gc.NotNil)
+	s.firewaller = firewallerClient
 }
 
 func (s *firewallerSuite) TestWatchEgressAddressesForRelation(c *gc.C) {
@@ -105,8 +107,9 @@ func (s *firewallerSuite) TestWatchEgressAddressesForRelation(c *gc.C) {
 		callCount++
 		return nil
 	})
-	client := firewaller.NewClient(apiCaller)
-	_, err := client.WatchEgressAddressesForRelation(relationTag)
+	client, err := firewaller.NewClient(apiCaller)
+	c.Assert(err, jc.ErrorIsNil)
+	_, err = client.WatchEgressAddressesForRelation(relationTag)
 	c.Check(err, gc.ErrorMatches, "FAIL")
 	c.Check(callCount, gc.Equals, 1)
 }
@@ -129,8 +132,9 @@ func (s *firewallerSuite) TestWatchInressAddressesForRelation(c *gc.C) {
 		callCount++
 		return nil
 	})
-	client := firewaller.NewClient(apiCaller)
-	_, err := client.WatchIngressAddressesForRelation(relationTag)
+	client, err := firewaller.NewClient(apiCaller)
+	c.Assert(err, jc.ErrorIsNil)
+	_, err = client.WatchIngressAddressesForRelation(relationTag)
 	c.Check(err, gc.ErrorMatches, "FAIL")
 	c.Check(callCount, gc.Equals, 1)
 }
@@ -152,8 +156,9 @@ func (s *firewallerSuite) TestControllerAPIInfoForModel(c *gc.C) {
 		callCount++
 		return nil
 	})
-	client := firewaller.NewClient(apiCaller)
-	_, err := client.ControllerAPIInfoForModel(coretesting.ModelTag.Id())
+	client, err := firewaller.NewClient(apiCaller)
+	c.Assert(err, jc.ErrorIsNil)
+	_, err = client.ControllerAPIInfoForModel(coretesting.ModelTag.Id())
 	c.Check(err, gc.ErrorMatches, "FAIL")
 	c.Check(callCount, gc.Equals, 1)
 }
@@ -176,8 +181,9 @@ func (s *firewallerSuite) TestMacaroonForRelation(c *gc.C) {
 		callCount++
 		return nil
 	})
-	client := firewaller.NewClient(apiCaller)
-	_, err := client.MacaroonForRelation("mysql:db wordpress:db")
+	client, err := firewaller.NewClient(apiCaller)
+	c.Assert(err, jc.ErrorIsNil)
+	_, err = client.MacaroonForRelation("mysql:db wordpress:db")
 	c.Check(err, gc.ErrorMatches, "FAIL")
 	c.Check(callCount, gc.Equals, 1)
 }

--- a/apiserver/common/cloudspec/statehelpers.go
+++ b/apiserver/common/cloudspec/statehelpers.go
@@ -1,0 +1,46 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package cloudspec
+
+import (
+	"github.com/juju/errors"
+	names "gopkg.in/juju/names.v2"
+
+	"github.com/juju/juju/environs"
+	"github.com/juju/juju/state"
+	"github.com/juju/juju/state/stateenvirons"
+)
+
+// Pool describes an interface for retrieving State instances from a
+// collection.
+type Pool interface {
+	Get(string) (*state.State, state.StatePoolReleaser, error)
+}
+
+// MakeCloudSpecGetter returns a function which returns a CloudSpec
+// for a given model, using the given Pool.
+func MakeCloudSpecGetter(pool Pool) func(names.ModelTag) (environs.CloudSpec, error) {
+	return func(tag names.ModelTag) (environs.CloudSpec, error) {
+		st, release, err := pool.Get(tag.Id())
+		if err != nil {
+			return environs.CloudSpec{}, errors.Trace(err)
+		}
+		defer release()
+		return stateenvirons.EnvironConfigGetter{st}.CloudSpec()
+	}
+}
+
+// MakeCloudSpecGetterForModel returns a function which returns a
+// CloudSpec for a single model. Attempts to request a CloudSpec for
+// any other model other than the one associated with the given
+// state.State results in an error.
+func MakeCloudSpecGetterForModel(st *state.State) func(names.ModelTag) (environs.CloudSpec, error) {
+	configGetter := stateenvirons.EnvironConfigGetter{st}
+	return func(tag names.ModelTag) (environs.CloudSpec, error) {
+		if tag.Id() != st.ModelUUID() {
+			return environs.CloudSpec{}, errors.New("cannot get cloud spec for this model")
+		}
+		return configGetter.CloudSpec()
+	}
+}

--- a/apiserver/common/environ_config.go
+++ b/apiserver/common/environ_config.go
@@ -4,8 +4,6 @@
 package common
 
 import (
-	"gopkg.in/juju/names.v2"
-
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/config"
 )
@@ -14,7 +12,7 @@ import (
 // in a pluggable way.
 type EnvironConfigGetterFuncs struct {
 	ModelConfigFunc func() (*config.Config, error)
-	CloudSpecFunc   func(names.ModelTag) (environs.CloudSpec, error)
+	CloudSpecFunc   func() (environs.CloudSpec, error)
 }
 
 // ModelConfig implements EnvironConfigGetter.
@@ -23,6 +21,6 @@ func (f EnvironConfigGetterFuncs) ModelConfig() (*config.Config, error) {
 }
 
 // CloudSpec implements environs.EnvironConfigGetter.
-func (f EnvironConfigGetterFuncs) CloudSpec(model names.ModelTag) (environs.CloudSpec, error) {
-	return f.CloudSpecFunc(model)
+func (f EnvironConfigGetterFuncs) CloudSpec() (environs.CloudSpec, error) {
+	return f.CloudSpecFunc()
 }

--- a/apiserver/facades/client/cloud/instance_information.go
+++ b/apiserver/facades/client/cloud/instance_information.go
@@ -22,8 +22,8 @@ type cloudEnvironConfigGetter struct {
 }
 
 // CloudSpec implements environs.EnvironConfigGetter.
-func (g cloudEnvironConfigGetter) CloudSpec(tag names.ModelTag) (environs.CloudSpec, error) {
-	model, err := g.GetModel(tag)
+func (g cloudEnvironConfigGetter) CloudSpec() (environs.CloudSpec, error) {
+	model, err := g.Model()
 	if err != nil {
 		return environs.CloudSpec{}, errors.Trace(err)
 	}

--- a/apiserver/facades/client/machinemanager/instance_information.go
+++ b/apiserver/facades/client/machinemanager/instance_information.go
@@ -5,7 +5,6 @@ package machinemanager
 
 import (
 	"github.com/juju/errors"
-	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/params"
@@ -26,12 +25,12 @@ func instanceTypes(mm *MachineManagerAPI,
 	getEnviron environGetFunc,
 	cons params.ModelInstanceTypesConstraints,
 ) (params.InstanceTypesResults, error) {
-	model, err := mm.st.GetModel(mm.st.ModelTag())
+	model, err := mm.st.Model()
 	if err != nil {
 		return params.InstanceTypesResults{}, errors.Trace(err)
 	}
 
-	cloudSpec := func(tag names.ModelTag) (environs.CloudSpec, error) {
+	cloudSpec := func() (environs.CloudSpec, error) {
 		cloudName := model.Cloud()
 		regionName := model.CloudRegion()
 		credentialTag, _ := model.CloudCredential()

--- a/apiserver/facades/client/machinemanager/instance_information_test.go
+++ b/apiserver/facades/client/machinemanager/instance_information_test.go
@@ -89,7 +89,7 @@ func (*mockBackend) ModelTag() names.ModelTag {
 	return names.NewModelTag("beef1beef1-0000-0000-000011112222")
 }
 
-func (*mockBackend) GetModel(t names.ModelTag) (machinemanager.Model, error) {
+func (*mockBackend) Model() (machinemanager.Model, error) {
 	return &mockModel{}, nil
 }
 

--- a/apiserver/facades/client/machinemanager/machinemanager.go
+++ b/apiserver/facades/client/machinemanager/machinemanager.go
@@ -126,13 +126,13 @@ func (mm *MachineManagerAPI) addOneMachine(p params.AddMachineParams) (*state.Ma
 
 	var placementDirective string
 	if p.Placement != nil {
-		env, err := mm.st.Model()
+		model, err := mm.st.Model()
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
 		// For 1.21 we should support both UUID and name, and with 1.22
 		// just support UUID
-		if p.Placement.Scope != env.Name() && p.Placement.Scope != env.UUID() {
+		if p.Placement.Scope != model.Name() && p.Placement.Scope != model.UUID() {
 			return nil, fmt.Errorf("invalid model name %q", p.Placement.Scope)
 		}
 		placementDirective = p.Placement.Directive

--- a/apiserver/facades/client/machinemanager/machinemanager_test.go
+++ b/apiserver/facades/client/machinemanager/machinemanager_test.go
@@ -170,8 +170,8 @@ func (st *mockState) ModelConfig() (*config.Config, error) {
 	panic("not implemented")
 }
 
-func (st *mockState) Model() (*state.Model, error) {
-	panic("not implemented")
+func (st *mockState) Model() (machinemanager.Model, error) {
+	return &mockModel{}, nil
 }
 
 func (st *mockState) AddMachineInsideNewMachine(template, parentTemplate state.MachineTemplate, containerType instance.ContainerType) (*state.Machine, error) {
@@ -196,10 +196,6 @@ func (st *mockState) CloudCredential(tag names.CloudCredentialTag) (cloud.Creden
 
 func (st *mockState) Cloud(string) (cloud.Cloud, error) {
 	return cloud.Cloud{}, nil
-}
-
-func (st *mockState) GetModel(t names.ModelTag) (machinemanager.Model, error) {
-	return &mockModel{}, nil
 }
 
 func (st *mockState) Machine(id string) (machinemanager.Machine, error) {

--- a/apiserver/facades/client/machinemanager/state.go
+++ b/apiserver/facades/client/machinemanager/state.go
@@ -18,14 +18,13 @@ type stateInterface interface {
 
 	Machine(string) (Machine, error)
 	ModelConfig() (*config.Config, error)
-	Model() (*state.Model, error)
+	Model() (Model, error)
 	ModelTag() names.ModelTag
 	GetBlockForType(t state.BlockType) (state.Block, bool, error)
 	AddOneMachine(template state.MachineTemplate) (*state.Machine, error)
 	AddMachineInsideNewMachine(template, parentTemplate state.MachineTemplate, containerType instance.ContainerType) (*state.Machine, error)
 	AddMachineInsideMachine(template state.MachineTemplate, parentId string, containerType instance.ContainerType) (*state.Machine, error)
 
-	GetModel(names.ModelTag) (Model, error)
 	Cloud(string) (cloud.Cloud, error)
 	Clouds() (map[names.CloudTag]cloud.Cloud, error)
 	CloudCredentials(user names.UserTag, cloudName string) (map[string]cloud.Credential, error)
@@ -49,7 +48,7 @@ func (s stateShim) ModelConfig() (*config.Config, error) {
 	return s.State.ModelConfig()
 }
 
-func (s stateShim) Model() (*state.Model, error) {
+func (s stateShim) Model() (Model, error) {
 	return s.State.Model()
 }
 func (s stateShim) ModelTag() names.ModelTag {
@@ -72,20 +71,13 @@ func (s stateShim) AddMachineInsideMachine(template state.MachineTemplate, paren
 	return s.State.AddMachineInsideMachine(template, parentId, containerType)
 }
 
-func (s stateShim) GetModel(tag names.ModelTag) (Model, error) {
-	m, err := s.State.GetModel(tag)
-	if err != nil {
-		return nil, err
-	}
-	return m, nil
-}
-
 type Model interface {
+	Name() string
+	UUID() string
 	Cloud() string
 	CloudCredential() (names.CloudCredentialTag, bool)
 	CloudRegion() string
 	ModelTag() names.ModelTag
-
 	Config() (*config.Config, error)
 }
 

--- a/apiserver/facades/client/sshclient/facade_test.go
+++ b/apiserver/facades/client/sshclient/facade_test.go
@@ -127,7 +127,7 @@ func (s *facadeSuite) TestAllAddresses(c *gc.C) {
 	})
 	s.backend.stub.CheckCalls(c, []jujutesting.StubCall{
 		{"ModelConfig", nil},
-		{"CloudSpec", []interface{}{names.NewModelTag("deadbeef-0bad-400d-8000-4b1d0d06f00d")}},
+		{"CloudSpec", nil},
 		{"GetMachineForEntity", []interface{}{s.uOther}},
 		{"GetMachineForEntity", []interface{}{s.m0}},
 		{"GetMachineForEntity", []interface{}{s.uFoo}},
@@ -235,8 +235,8 @@ func (backend *mockBackend) GetSSHHostKeys(tag names.MachineTag) (state.SSHHostK
 	return nil, errors.New("machine not found")
 }
 
-func (backend *mockBackend) CloudSpec(tag names.ModelTag) (environs.CloudSpec, error) {
-	backend.stub.AddCall("CloudSpec", tag)
+func (backend *mockBackend) CloudSpec() (environs.CloudSpec, error) {
+	backend.stub.AddCall("CloudSpec")
 	return dummy.SampleCloudSpec(), nil
 }
 

--- a/apiserver/facades/client/sshclient/shim.go
+++ b/apiserver/facades/client/sshclient/shim.go
@@ -18,7 +18,7 @@ import (
 // Backend defines the State API used by the sshclient facade.
 type Backend interface {
 	ModelConfig() (*config.Config, error)
-	CloudSpec(names.ModelTag) (environs.CloudSpec, error)
+	CloudSpec() (environs.CloudSpec, error)
 	GetMachineForEntity(tag string) (SSHMachine, error)
 	GetSSHHostKeys(names.MachineTag) (state.SSHHostKeys, error)
 	ModelTag() names.ModelTag

--- a/apiserver/facades/controller/firewaller/firewaller.go
+++ b/apiserver/facades/controller/firewaller/firewaller.go
@@ -15,7 +15,6 @@ import (
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/state"
-	"github.com/juju/juju/state/stateenvirons"
 	"github.com/juju/juju/state/watcher"
 )
 
@@ -49,8 +48,11 @@ type FirewallerAPIV4 struct {
 // NewStateFirewallerAPIv3 creates a new server-side FirewallerAPIV3 facade.
 func NewStateFirewallerAPIV3(context facade.Context) (*FirewallerAPIV3, error) {
 	st := context.State()
-	environConfigGetter := stateenvirons.EnvironConfigGetter{st}
-	cloudSpecAPI := cloudspec.NewCloudSpec(environConfigGetter.CloudSpec, common.AuthFuncForTag(st.ModelTag()))
+
+	cloudSpecAPI := cloudspec.NewCloudSpec(
+		cloudspec.MakeCloudSpecGetterForModel(st),
+		common.AuthFuncForTag(st.ModelTag()),
+	)
 	return NewFirewallerAPI(stateShim{st: st, State: firewall.StateShim(st)}, context.Resources(), context.Auth(), cloudSpecAPI)
 }
 

--- a/apiserver/facades/controller/firewaller/firewaller_test.go
+++ b/apiserver/facades/controller/firewaller/firewaller_test.go
@@ -18,7 +18,6 @@ import (
 	"github.com/juju/juju/apiserver/params"
 	apiservertesting "github.com/juju/juju/apiserver/testing"
 	"github.com/juju/juju/state"
-	"github.com/juju/juju/state/stateenvirons"
 	statetesting "github.com/juju/juju/state/testing"
 )
 
@@ -37,8 +36,10 @@ func (s *firewallerSuite) SetUpTest(c *gc.C) {
 	_, err := s.State.AddSubnet(state.SubnetInfo{CIDR: "10.20.30.0/24"})
 	c.Assert(err, jc.ErrorIsNil)
 
-	environConfigGetter := stateenvirons.EnvironConfigGetter{s.State}
-	cloudSpecAPI := cloudspec.NewCloudSpec(environConfigGetter.CloudSpec, common.AuthFuncForTag(s.State.ModelTag()))
+	cloudSpecAPI := cloudspec.NewCloudSpec(
+		cloudspec.MakeCloudSpecGetterForModel(s.State),
+		common.AuthFuncForTag(s.State.ModelTag()),
+	)
 	// Create a firewaller API for the machine.
 	firewallerAPI, err := firewaller.NewFirewallerAPI(
 		firewaller.StateShim(s.State),

--- a/apiserver/testing/stub_network.go
+++ b/apiserver/testing/stub_network.go
@@ -447,7 +447,7 @@ func (sb *StubBacking) ModelTag() names.ModelTag {
 	return names.NewModelTag("dbeef-2f18-4fd2-967d-db9663db7bea")
 }
 
-func (sb *StubBacking) CloudSpec(names.ModelTag) (environs.CloudSpec, error) {
+func (sb *StubBacking) CloudSpec() (environs.CloudSpec, error) {
 	sb.MethodCall(sb, "CloudSpec")
 	if err := sb.NextErr(); err != nil {
 		return environs.CloudSpec{}, err

--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -770,7 +770,11 @@ var newEnvirons = environs.New
 func (a *MachineAgent) startAPIWorkers(apiConn api.Connection) (_ worker.Worker, outErr error) {
 	agentConfig := a.CurrentConfig()
 
-	entity, err := apiagent.NewState(apiConn).Entity(a.Tag())
+	apiSt, err := apiagent.NewState(apiConn)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	entity, err := apiSt.Entity(a.Tag())
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -812,7 +816,11 @@ func (a *MachineAgent) startAPIWorkers(apiConn api.Connection) (_ worker.Worker,
 
 		// Published image metadata for some providers are in simple streams.
 		// Providers that do not depend on simple streams do not need this worker.
-		env, err := environs.GetEnviron(apiagent.NewState(apiConn), newEnvirons)
+		apiSt, err := apiagent.NewState(apiConn)
+		if err != nil {
+			return nil, errors.Annotate(err, "getting API facade")
+		}
+		env, err := environs.GetEnviron(apiSt, newEnvirons)
 		if err != nil {
 			return nil, errors.Annotate(err, "getting environ")
 		}

--- a/cmd/jujud/agent/machine/servinginfo_setter.go
+++ b/cmd/jujud/agent/machine/servinginfo_setter.go
@@ -49,7 +49,10 @@ func ServingInfoSetterManifold(config ServingInfoSetterConfig) dependency.Manifo
 			if err := context.Get(config.APICallerName, &apiCaller); err != nil {
 				return nil, err
 			}
-			apiState := apiagent.NewState(apiCaller)
+			apiState, err := apiagent.NewState(apiCaller)
+			if err != nil {
+				return nil, errors.Trace(err)
+			}
 
 			// If the machine needs State, grab the state serving info
 			// over the API and write it to the agent configuration.

--- a/environs/environ.go
+++ b/environs/environ.go
@@ -5,7 +5,6 @@ package environs
 
 import (
 	"github.com/juju/errors"
-	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/environs/config"
 )
@@ -13,7 +12,7 @@ import (
 // EnvironConfigGetter exposes a model configuration to its clients.
 type EnvironConfigGetter interface {
 	ModelConfig() (*config.Config, error)
-	CloudSpec(names.ModelTag) (CloudSpec, error)
+	CloudSpec() (CloudSpec, error)
 }
 
 // NewEnvironFunc is the type of a function that, given a model config,
@@ -27,7 +26,7 @@ func GetEnviron(st EnvironConfigGetter, newEnviron NewEnvironFunc) (Environ, err
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	cloudSpec, err := st.CloudSpec(names.NewModelTag(modelConfig.UUID()))
+	cloudSpec, err := st.CloudSpec()
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/state/stateenvirons/config.go
+++ b/state/stateenvirons/config.go
@@ -19,11 +19,12 @@ type EnvironConfigGetter struct {
 }
 
 // CloudSpec implements environs.EnvironConfigGetter.
-func (g EnvironConfigGetter) CloudSpec(tag names.ModelTag) (environs.CloudSpec, error) {
-	model, err := g.GetModel(tag)
+func (g EnvironConfigGetter) CloudSpec() (environs.CloudSpec, error) {
+	model, err := g.Model()
 	if err != nil {
 		return environs.CloudSpec{}, errors.Trace(err)
 	}
+
 	cloudName := model.Cloud()
 	regionName := model.CloudRegion()
 	credentialTag, _ := model.CloudCredential()

--- a/state/stateenvirons/config_test.go
+++ b/state/stateenvirons/config_test.go
@@ -53,7 +53,7 @@ func (s *environSuite) TestCloudSpec(c *gc.C) {
 	defer st.Close()
 
 	emptyCredential.Label = "empty-credential"
-	cloudSpec, err := stateenvirons.EnvironConfigGetter{st}.CloudSpec(st.ModelTag())
+	cloudSpec, err := stateenvirons.EnvironConfigGetter{st}.CloudSpec()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cloudSpec, jc.DeepEquals, environs.CloudSpec{
 		Type:             "dummy",

--- a/worker/deployer/manifold.go
+++ b/worker/deployer/manifold.go
@@ -49,10 +49,13 @@ func (config ManifoldConfig) newWorker(a agent.Agent, apiCaller base.APICaller) 
 	// Get the machine agent's jobs.
 	// TODO(fwereade): this functionality should be on the
 	// deployer facade instead.
-	agentFacade := apiagent.NewState(apiCaller)
+	agentFacade, err := apiagent.NewState(apiCaller)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	entity, err := agentFacade.Entity(tag)
 	if err != nil {
-		return nil, err
+		return nil, errors.Trace(err)
 	}
 
 	var isUnitHoster bool

--- a/worker/environ/fixture_test.go
+++ b/worker/environ/fixture_test.go
@@ -54,10 +54,10 @@ func (context *runContext) SetConfig(c *gc.C, extraAttrs coretesting.Attrs) {
 }
 
 // CloudSpec is part of the environ.ConfigObserver interface.
-func (context *runContext) CloudSpec(tag names.ModelTag) (environs.CloudSpec, error) {
+func (context *runContext) CloudSpec() (environs.CloudSpec, error) {
 	context.mu.Lock()
 	defer context.mu.Unlock()
-	context.stub.AddCall("CloudSpec", tag)
+	context.stub.AddCall("CloudSpec")
 	if err := context.stub.NextErr(); err != nil {
 		return environs.CloudSpec{}, err
 	}

--- a/worker/environ/manifold.go
+++ b/worker/environ/manifold.go
@@ -32,8 +32,12 @@ func Manifold(config ManifoldConfig) dependency.Manifold {
 			if err := context.Get(config.APICallerName, &apiCaller); err != nil {
 				return nil, errors.Trace(err)
 			}
+			apiSt, err := agent.NewState(apiCaller)
+			if err != nil {
+				return nil, errors.Trace(err)
+			}
 			w, err := NewTracker(Config{
-				Observer:       agent.NewState(apiCaller),
+				Observer:       apiSt,
 				NewEnvironFunc: config.NewEnvironFunc,
 			})
 			if err != nil {

--- a/worker/firewaller/firewaller_test.go
+++ b/worker/firewaller/firewaller_test.go
@@ -99,8 +99,9 @@ func (s *firewallerBaseSuite) setUpTest(c *gc.C, firewallMode string) {
 	c.Assert(s.st, gc.NotNil)
 
 	// Create the API facades.
-	s.firewaller = apifirewaller.NewClient(s.st)
-	c.Assert(s.firewaller, gc.NotNil)
+	firewallerClient, err := apifirewaller.NewClient(s.st)
+	c.Assert(err, jc.ErrorIsNil)
+	s.firewaller = firewallerClient
 	s.remoteRelations = remoterelations.NewClient(s.st)
 	c.Assert(s.remoteRelations, gc.NotNil)
 }

--- a/worker/firewaller/shim.go
+++ b/worker/firewaller/shim.go
@@ -25,7 +25,10 @@ func NewRemoteRelationsFacade(apiCaller base.APICaller) (*remoterelations.Client
 
 // NewFirewallerFacade creates a firewaller API facade.
 func NewFirewallerFacade(apiCaller base.APICaller) (FirewallerAPI, error) {
-	facade := firewaller.NewClient(apiCaller)
+	facade, err := firewaller.NewClient(apiCaller)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	return facade, nil
 }
 

--- a/worker/identityfilewriter/manifold.go
+++ b/worker/identityfilewriter/manifold.go
@@ -4,8 +4,7 @@
 package identityfilewriter
 
 import (
-	"errors"
-
+	"github.com/juju/errors"
 	"gopkg.in/juju/names.v2"
 	"gopkg.in/juju/worker.v1"
 
@@ -39,11 +38,14 @@ func newWorker(a agent.Agent, apiCaller base.APICaller) (worker.Worker, error) {
 	}
 
 	// Get the machine agent's jobs.
-	entity, err := apiagent.NewState(apiCaller).Entity(tag)
+	apiSt, err := apiagent.NewState(apiCaller)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	entity, err := apiSt.Entity(tag)
 	if err != nil {
 		return nil, err
 	}
-
 	var isModelManager bool
 	for _, job := range entity.Jobs() {
 		if job == multiwatcher.JobManageModel {

--- a/worker/logforwarder/manifold.go
+++ b/worker/logforwarder/manifold.go
@@ -57,7 +57,10 @@ func Manifold(config ManifoldConfig) dependency.Manifold {
 				return nil, errors.Trace(err)
 			}
 
-			agentFacade := apiagent.NewState(apiCaller)
+			agentFacade, err := apiagent.NewState(apiCaller)
+			if err != nil {
+				return nil, errors.Trace(err)
+			}
 			controllerCfg, err := agentFacade.ControllerConfig()
 			if err != nil {
 				return nil, errors.Annotate(err, "cannot read controller config")

--- a/worker/machiner/manifold.go
+++ b/worker/machiner/manifold.go
@@ -41,7 +41,10 @@ func newWorker(a agent.Agent, apiCaller base.APICaller) (worker.Worker, error) {
 	// have completey separate workers.
 	//
 	// (With their own facades.)
-	agentFacade := apiagent.NewState(apiCaller)
+	agentFacade, err := apiagent.NewState(apiCaller)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	modelConfig, err := agentFacade.ModelConfig()
 	if err != nil {
 		return nil, errors.Errorf("cannot read environment config: %v", err)

--- a/worker/resumer/manifold.go
+++ b/worker/resumer/manifold.go
@@ -84,7 +84,10 @@ func Manifold(config ManifoldConfig) dependency.Manifold {
 // isModelManager returns whether the agent has JobManageModel,
 // or an error.
 func isModelManager(a agent.Agent, apiCaller base.APICaller) (bool, error) {
-	agentFacade := apiagent.NewState(apiCaller)
+	agentFacade, err := apiagent.NewState(apiCaller)
+	if err != nil {
+		return false, errors.Trace(err)
+	}
 	entity, err := agentFacade.Entity(a.CurrentConfig().Tag())
 	if err != nil {
 		return false, errors.Trace(err)

--- a/worker/resumer/manifold_test.go
+++ b/worker/resumer/manifold_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/juju/juju/api/base"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/state/multiwatcher"
+	coretesting "github.com/juju/juju/testing"
 	"github.com/juju/juju/worker/dependency"
 	dt "github.com/juju/juju/worker/dependency/testing"
 	resumer "github.com/juju/juju/worker/resumer"
@@ -302,4 +303,9 @@ func (f *fakeAPICaller) APICall(objType string, version int, id, request string,
 // BestFacadeVersion is part of the base.APICaller interface.
 func (*fakeAPICaller) BestFacadeVersion(facade string) int {
 	return 42
+}
+
+// ModelTag is part of the base.APICaller interface.
+func (*fakeAPICaller) ModelTag() (names.ModelTag, bool) {
+	return coretesting.ModelTag, true
 }

--- a/worker/storageprovisioner/manifold_machine_test.go
+++ b/worker/storageprovisioner/manifold_machine_test.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/juju/juju/agent"
 	"github.com/juju/juju/api"
-	apiagent "github.com/juju/juju/api/agent"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/cmd/jujud/agent/engine/enginetest"
 	"github.com/juju/juju/state/multiwatcher"
@@ -125,8 +124,4 @@ func (f *fakeAPIConn) APICall(objType string, version int, id, request string, a
 
 func (*fakeAPIConn) BestFacadeVersion(facade string) int {
 	return 42
-}
-
-func (f *fakeAPIConn) Agent() *apiagent.State {
-	return apiagent.NewState(f)
 }

--- a/worker/toolsversionchecker/manifold.go
+++ b/worker/toolsversionchecker/manifold.go
@@ -30,7 +30,10 @@ func Manifold(config ManifoldConfig) dependency.Manifold {
 }
 
 func newWorker(a agent.Agent, apiCaller base.APICaller) (worker.Worker, error) {
-	st := apiagent.NewState(apiCaller)
+	st, err := apiagent.NewState(apiCaller)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	isMM, err := isModelManager(a, st)
 	if err != nil {
 		return nil, errors.Trace(err)

--- a/worker/upgradesteps/manifold.go
+++ b/worker/upgradesteps/manifold.go
@@ -70,7 +70,10 @@ func Manifold(config ManifoldConfig) dependency.Manifold {
 
 			// Get the machine agent's jobs.
 			// TODO(fwereade): use appropriate facade!
-			agentFacade := apiagent.NewState(apiConn)
+			agentFacade, err := apiagent.NewState(apiConn)
+			if err != nil {
+				return nil, err
+			}
 			entity, err := agentFacade.Entity(tag)
 			if err != nil {
 				return nil, err


### PR DESCRIPTION
## Description of change

This surprisingly large change updates the `environs.EnvironConfigGetter` interface so the `CloudSpec` method no longer takes a model tag. This means that a single instance of an EnvironConfigGetter is now only ever responsible for a single model.

This change is required because it supports changes around `state.Model` creation. A `CloudSpec` method that takes a model tag encourages poor practices in `EnvironConfigGetter` implementations.

## QA steps

Just confirmed general functionality:
```
$ juju bootstrap lxd
$ juju add-model foo
$ juju deploy ubuntu
# wait...
$ juju remove-application ubuntu

# Check logs for issues
$ juju debug-log --replay -l ERROR
$ juju debug-log -m controller --replay -l ERROR

# Remove the controller
$ juju destroy-controller -y --destroy-all-models --destroy-storage lxd
```

## Documentation changes

N.A.

## Bug reference

N.A.

