### PR TITLE
Reset password, state layer.

### DIFF
--- a/state/user.go
+++ b/state/user.go
@@ -540,8 +540,8 @@ func (u *User) ensureNotDeleted() error {
 	return nil
 }
 
-// ResetPassword cleans up password related field.
-// It generates and returns a new user secret key.
+// ResetPassword clears the user's password (if there is one),
+// and generates a new secret key for the user.
 // This must be an active user.
 func (u *User) ResetPassword() ([]byte, error) {
 	var key []byte
@@ -581,12 +581,12 @@ func (u *User) ResetPassword() ([]byte, error) {
 		return nil, errors.Annotatef(err, "cannot reset password for user %q", u.Name())
 	}
 	u.doc.SecretKey = key
+	u.doc.PasswordHash = ""
+	u.doc.PasswordSalt = ""
 	return key, nil
 }
 
-// generateSecretKey generates a random, 32-byte secret key. This can be used
-// to obtain the controller's (self-signed) CA certificate
-// and set the user's password.
+// generateSecretKey generates a random, 32-byte secret key.
 func generateSecretKey() ([]byte, error) {
 	var secretKey [32]byte
 	if _, err := rand.Read(secretKey[:]); err != nil {

--- a/state/user_test.go
+++ b/state/user_test.go
@@ -457,4 +457,5 @@ func (s *UserSuite) TestResetPasswordIfPasswordSet(c *gc.C) {
 	key, err := u.ResetPassword()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(u.SecretKey(), gc.DeepEquals, key)
+	c.Assert(u.PasswordValid("anything"), jc.IsFalse)
 }

--- a/state/user_test.go
+++ b/state/user_test.go
@@ -408,3 +408,53 @@ func (s *UserSuite) TestSetPasswordClearsSecretKey(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(u.SecretKey(), gc.IsNil)
 }
+
+func (s *UserSuite) TestResetPassword(c *gc.C) {
+	u, err := s.State.AddUserWithSecretKey("bob", "display", "admin")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(u.SecretKey(), gc.HasLen, 32)
+	oldKey := u.SecretKey()
+
+	key, err := u.ResetPassword()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(key, gc.Not(gc.DeepEquals), oldKey)
+	c.Assert(u.SecretKey(), gc.DeepEquals, key)
+}
+
+func (s *UserSuite) TestResetPasswordFailIfDeactivated(c *gc.C) {
+	u, err := s.State.AddUser("bob", "display", "pass", "admin")
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = u.Disable()
+	c.Assert(err, jc.ErrorIsNil)
+
+	_, err = u.ResetPassword()
+	c.Assert(err, gc.ErrorMatches, `cannot reset password for user "bob": user deactivated`)
+	c.Assert(u.SecretKey(), gc.IsNil)
+}
+
+func (s *UserSuite) TestResetPasswordFailIfDeleted(c *gc.C) {
+	u, err := s.State.AddUser("bob", "display", "pass", "admin")
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = s.State.RemoveUser(u.Tag().(names.UserTag))
+	c.Assert(err, jc.ErrorIsNil)
+
+	_, err = u.ResetPassword()
+	c.Assert(err, gc.ErrorMatches, `cannot reset password for user "bob": user "bob" is permanently deleted`)
+	c.Assert(u.SecretKey(), gc.IsNil)
+}
+
+func (s *UserSuite) TestResetPasswordIfPasswordSet(c *gc.C) {
+	u, err := s.State.AddUser("bob", "display", "pass", "admin")
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = u.SetPassword("anything")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(u.PasswordValid("anything"), jc.IsTrue)
+	c.Assert(u.SecretKey(), gc.IsNil)
+
+	key, err := u.ResetPassword()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(u.SecretKey(), gc.DeepEquals, key)
+}


### PR DESCRIPTION
## Description of change

This is part of the functionality to provide controller admins with ability to reset user passwords/re-issue login tokens.

## QA steps

This is only one the layers, there is no full-stack funcationaliy yet. All unit tests pass.

## Documentation changes

n/a
This is an internal addition atm.

## Bug reference

Initial part for https://bugs.launchpad.net/juju/+bug/1657187
