### PR TITLE
Change how offer information is printed in status and offers CLI

### DIFF
--- a/api/applicationoffers/client_test.go
+++ b/api/applicationoffers/client_test.go
@@ -142,8 +142,10 @@ func (s *crossmodelMockSuite) TestList(c *gc.C) {
 				results.Results = []params.ApplicationOfferDetails{{
 					ApplicationOffer: offer,
 					ApplicationName:  "db2-app",
-					CharmName:        "db2",
-					ConnectedCount:   3,
+					CharmURL:         "cs:db2-5",
+					Connections: []params.OfferConnection{
+						{SourceModelTag: testing.ModelTag.String(), Username: "fred", RelationId: 3, Endpoint: "db", Status: "active"},
+					},
 				}}
 			}
 			return nil
@@ -159,8 +161,10 @@ func (s *crossmodelMockSuite) TestList(c *gc.C) {
 			OfferName:       offerName,
 			Endpoints:       []charm.Relation{{Name: "endPointA"}},
 			ApplicationName: "db2-app",
-			CharmName:       "db2",
-			ConnectedCount:  3,
+			CharmURL:        "cs:db2-5",
+			Connections: []jujucrossmodel.OfferConnection{
+				{SourceModelUUID: testing.ModelTag.Id(), Username: "fred", RelationId: 3, Endpoint: "db", Status: "active"},
+			},
 		}}})
 }
 

--- a/apiserver/common/crossmodel/interface.go
+++ b/apiserver/common/crossmodel/interface.go
@@ -95,6 +95,9 @@ type Relation interface {
 	// Endpoints returns the endpoints that constitute the relation.
 	Endpoints() []state.Endpoint
 
+	// Endpoint returns the endpoint of the relation for the named application.
+	Endpoint(appName string) (state.Endpoint, error)
+
 	// Unit returns a RelationUnit for the unit with the supplied ID.
 	Unit(unitId string) (RelationUnit, error)
 

--- a/apiserver/facades/client/client/api_test.go
+++ b/apiserver/facades/client/client/api_test.go
@@ -184,7 +184,7 @@ var scenarioStatus = &params.FullStatus{
 	},
 	Offers: map[string]params.ApplicationOfferStatus{
 		"hosted-mysql": {
-			ApplicationURL:  "admin/controller.hosted-mysql",
+			CharmURL:        "local:quantal/mysql-1",
 			ApplicationName: "mysql",
 			OfferName:       "hosted-mysql",
 			Endpoints: map[string]params.RemoteEndpoint{
@@ -193,13 +193,7 @@ var scenarioStatus = &params.FullStatus{
 					Interface: "mysql",
 					Role:      "provider",
 				}},
-			Connections: map[int]params.OfferConnectionStatus{
-				1: {
-					SourceModelTag: coretesting.ModelTag.String(),
-					Username:       "fred",
-					Status:         "active",
-					Endpoint:       "server",
-				}},
+			ConnectedCount: 1,
 		},
 	},
 	Applications: map[string]params.ApplicationStatus{

--- a/apiserver/facades/client/client/backend.go
+++ b/apiserver/facades/client/client/backend.go
@@ -43,7 +43,6 @@ type Backend interface {
 	AddRelation(...state.Endpoint) (*state.Relation, error)
 	AllApplications() ([]*state.Application, error)
 	AllApplicationOffers() ([]*crossmodel.ApplicationOffer, error)
-	AllOfferConnections() ([]*state.OfferConnection, error)
 	AllRemoteApplications() ([]*state.RemoteApplication, error)
 	AllMachines() ([]*state.Machine, error)
 	AllModelUUIDs() ([]string, error)
@@ -71,6 +70,7 @@ type Backend interface {
 	ModelTag() names.ModelTag
 	ModelUUID() string
 	RemoteApplication(string) (*state.RemoteApplication, error)
+	RemoteConnectionStatus(string) (*state.RemoteConnectionStatus, error)
 	RemoveUserAccess(names.UserTag, names.Tag) error
 	SetAnnotations(state.GlobalEntity, map[string]string) error
 	SetModelAgentVersion(version.Number) error

--- a/apiserver/params/crossmodel.go
+++ b/apiserver/params/crossmodel.go
@@ -55,9 +55,18 @@ type ApplicationOffer struct {
 // including details about how it has been deployed.
 type ApplicationOfferDetails struct {
 	ApplicationOffer
-	ApplicationName string `json:"application-name"`
-	CharmName       string `json:"charm-name"`
-	ConnectedCount  int    `json:"connected-count"`
+	ApplicationName string            `json:"application-name"`
+	CharmURL        string            `json:"charm-url"`
+	Connections     []OfferConnection `json:"connections,omitempty"`
+}
+
+// OfferConnection holds details about a connection to an offer.
+type OfferConnection struct {
+	SourceModelTag string `json:"source-model-tag"`
+	RelationId     int    `json:"relation-id"`
+	Username       string `json:"username"`
+	Endpoint       string `json:"endpoint"`
+	Status         string `json:"status"`
 }
 
 // ListApplicationOffersResults is a result of listing application offers.

--- a/apiserver/params/status.go
+++ b/apiserver/params/status.go
@@ -132,21 +132,12 @@ type RemoteApplicationStatus struct {
 
 // ApplicationOfferStatus holds status info about an application offer.
 type ApplicationOfferStatus struct {
-	Err             error                         `json:"err,omitempty"`
-	ApplicationURL  string                        `json:"application-url"`
-	OfferName       string                        `json:"offer-name"`
-	ApplicationName string                        `json:"application-name"`
-	Endpoints       map[string]RemoteEndpoint     `json:"endpoints"`
-	Connections     map[int]OfferConnectionStatus `json:"connections,omitempty"`
-}
-
-// OfferConnectionStatus holds status info about a connection to an offer.
-type OfferConnectionStatus struct {
-	Err            error  `json:"err,omitempty"`
-	SourceModelTag string `json:"source-model-tag"`
-	Username       string `json:"username"`
-	Endpoint       string `json:"endpoint"`
-	Status         string `json:"status"`
+	Err             error                     `json:"err,omitempty"`
+	OfferName       string                    `json:"offer-name"`
+	ApplicationName string                    `json:"application-name"`
+	CharmURL        string                    `json:"charm"`
+	Endpoints       map[string]RemoteEndpoint `json:"endpoints"`
+	ConnectedCount  int                       `json:"connected-count"`
 }
 
 // MeterStatus represents the meter status of a unit.

--- a/cmd/juju/crossmodel/listformatter.go
+++ b/cmd/juju/crossmodel/listformatter.go
@@ -8,25 +8,27 @@ import (
 	"io"
 	"sort"
 
+	"github.com/juju/ansiterm"
 	"github.com/juju/errors"
 
 	"github.com/juju/juju/cmd/output"
+	"github.com/juju/juju/core/relation"
 )
 
-// formatListTabular returns a tabular summary of remote application offers or
+// formatListSummary returns a tabular summary of remote application offers or
 // errors out if parameter is not of expected type.
-func formatListTabular(writer io.Writer, value interface{}) error {
+func formatListSummary(writer io.Writer, value interface{}) error {
 	offers, ok := value.(offeredApplications)
 	if !ok {
 		return errors.Errorf("expected value of type %T, got %T", offers, value)
 	}
-	return formatListEndpointsTabular(writer, offers)
+	return formatListEndpointsSummary(writer, offers)
 }
 
 type offerItems []ListOfferItem
 
-// formatListEndpointsTabular returns a tabular summary of listed applications' endpoints.
-func formatListEndpointsTabular(writer io.Writer, offers offeredApplications) error {
+// formatListEndpointsSummary returns a tabular summary of listed applications' endpoints.
+func formatListEndpointsSummary(writer io.Writer, offers offeredApplications) error {
 	tw := output.TabWriter(writer)
 	w := output.Wrapper{tw}
 
@@ -37,7 +39,7 @@ func formatListEndpointsTabular(writer io.Writer, offers offeredApplications) er
 	}
 	sort.Sort(allOffers)
 
-	w.Println("Application", "Charm", "Connected", "Store", "URL", "Endpoint", "Interface", "Role")
+	w.Println("Offer", "Application", "Charm", "Connected", "Store", "URL", "Endpoint", "Interface", "Role")
 	for _, offer := range allOffers {
 		// Sort endpoints alphabetically.
 		endpoints := []string{}
@@ -52,12 +54,14 @@ func formatListEndpointsTabular(writer io.Writer, offers offeredApplications) er
 			if i == 0 {
 				// As there is some information about offer and its endpoints,
 				// only display offer information once when the first endpoint is displayed.
-				w.Println(offer.ApplicationName, offer.CharmName, fmt.Sprint(offer.UsersCount), offer.Source, offer.Location, endpointName, endpoint.Interface, endpoint.Role)
+				connectedCount := len(offer.Connections)
+				w.Println(offer.OfferName, offer.ApplicationName, offer.CharmURL, fmt.Sprint(connectedCount),
+					offer.Source, offer.OfferURL, endpointName, endpoint.Interface, endpoint.Role)
 				continue
 			}
 			// Subsequent lines only need to display endpoint information.
 			// This will display less noise.
-			w.Println("", "", "", "", "", endpointName, endpoint.Interface, endpoint.Role)
+			w.Println("", "", "", "", "", "", endpointName, endpoint.Interface, endpoint.Role)
 		}
 	}
 	tw.Flush()
@@ -68,7 +72,88 @@ func (o offerItems) Len() int      { return len(o) }
 func (o offerItems) Swap(i, j int) { o[i], o[j] = o[j], o[i] }
 func (o offerItems) Less(i, j int) bool {
 	if o[i].Source == o[j].Source {
-		return o[i].ApplicationName < o[j].ApplicationName
+		return o[i].OfferName < o[j].OfferName
 	}
 	return o[i].Source < o[j].Source
+}
+
+func formatListTabular(writer io.Writer, value interface{}) error {
+	offers, ok := value.(offeredApplications)
+	if !ok {
+		return errors.Errorf("expected value of type %T, got %T", offers, value)
+	}
+	return formatListEndpointsTabular(writer, offers)
+}
+
+// formatListEndpointsTabular returns a tabular summary of listed applications' endpoints.
+func formatListEndpointsTabular(writer io.Writer, offers offeredApplications) error {
+	tw := output.TabWriter(writer)
+	w := output.Wrapper{tw}
+
+	// Sort offers by source then application name.
+	allOffers := offerItems{}
+	for _, offer := range offers {
+		allOffers = append(allOffers, offer)
+	}
+	sort.Sort(allOffers)
+
+	w.Println("Offer", "User", "Relation id", "Status", "Endpoint", "Interface", "Role")
+	for _, offer := range allOffers {
+		// Sort endpoints alphabetically.
+		endpoints := []string{}
+		for endpoint, _ := range offer.Endpoints {
+			endpoints = append(endpoints, endpoint)
+		}
+		sort.Strings(endpoints)
+
+		// Sort connections by relation id and username.
+		sort.Sort(byUserRelationId(offer.Connections))
+
+		for i, conn := range offer.Connections {
+			if i == 0 {
+				w.Print(offer.OfferName)
+			} else {
+				w.Print("")
+			}
+			endpoints := make(map[string]RemoteEndpoint)
+			for alias, ep := range offer.Endpoints {
+				aliasedEp := ep
+				aliasedEp.Name = alias
+				endpoints[ep.Name] = ep
+			}
+			connEp := endpoints[conn.Endpoint]
+			w.Print(conn.Username, conn.RelationId)
+			w.PrintColor(relationStatusColor(relation.Status(conn.Status)), conn.Status)
+			w.Println(connEp.Name, connEp.Interface, connEp.Role)
+		}
+	}
+	tw.Flush()
+	return nil
+}
+
+func relationStatusColor(status relation.Status) *ansiterm.Context {
+	switch status {
+	case relation.Active:
+		return output.GoodHighlight
+	case relation.Revoked:
+		return output.WarningHighlight
+	}
+	return nil
+}
+
+type byUserRelationId []offerConnectionStatus
+
+func (b byUserRelationId) Len() int {
+	return len(b)
+}
+
+func (b byUserRelationId) Less(i, j int) bool {
+	if b[i].Username == b[j].Username {
+		return b[i].RelationId < b[j].RelationId
+	}
+	return b[i].Username < b[j].Username
+}
+
+func (b byUserRelationId) Swap(i, j int) {
+	b[i], b[j] = b[j], b[i]
 }

--- a/cmd/juju/crossmodel/remoteendpoints.go
+++ b/cmd/juju/crossmodel/remoteendpoints.go
@@ -27,6 +27,9 @@ func (c *RemoteEndpointsCommandBase) NewRemoteEndpointsAPI(controllerName string
 // RemoteEndpoint defines the serialization behaviour of remote endpoints.
 // This is used in map-style yaml output where remote endpoint name is the key.
 type RemoteEndpoint struct {
+	// Name is the endpoint name.
+	Name string `yaml:"-" json:"-"`
+
 	// Interface is relation interface.
 	Interface string `yaml:"interface" json:"interface"`
 
@@ -42,7 +45,7 @@ func convertRemoteEndpoints(apiEndpoints ...params.RemoteEndpoint) map[string]Re
 	}
 	output := make(map[string]RemoteEndpoint, len(apiEndpoints))
 	for _, one := range apiEndpoints {
-		output[one.Name] = RemoteEndpoint{one.Interface, string(one.Role)}
+		output[one.Name] = RemoteEndpoint{one.Name, one.Interface, string(one.Role)}
 	}
 	return output
 }

--- a/cmd/juju/status/formatted.go
+++ b/cmd/juju/status/formatted.go
@@ -155,10 +155,11 @@ type offerStatusNoMarshal offerStatus
 
 type offerStatus struct {
 	Err             error                     `json:"-" yaml:",omitempty"`
-	ApplicationURL  string                    `json:"application-url" yaml:"application-url"`
-	ApplicationName string                    `json:"application-name" yaml:"application-name"`
+	OfferName       string                    `json:"-" yaml:",omitempty"`
+	ApplicationName string                    `json:"application" yaml:"application"`
+	CharmURL        string                    `json:"charm,omitempty" yaml:"charm,omitempty"`
+	ConnectedCount  int                       `json:"connected-count,omitempty" yaml:"connected-count,omitempty"`
 	Endpoints       map[string]remoteEndpoint `json:"endpoints" yaml:"endpoints"`
-	Connections     []offerConnectionStatus   `json:"connections" yaml:"connections"`
 }
 
 func (s offerStatus) MarshalJSON() ([]byte, error) {
@@ -173,15 +174,6 @@ func (s offerStatus) MarshalYAML() (interface{}, error) {
 		return errorStatus{s.Err.Error()}, nil
 	}
 	return offerStatusNoMarshal(s), nil
-}
-
-type offerConnectionStatus struct {
-	Err             error  `json:"-" yaml:",omitempty"`
-	SourceModelUUID string `json:"source-model-uuid" yaml:"source-model-uuid"`
-	Username        string `json:"username" yaml:"username"`
-	RelationId      int    `json:"relation-id" yaml:"relation-id"`
-	Endpoint        string `json:"endpoint" yaml:"endpoint"`
-	Status          string `json:"status" yaml:"status"`
 }
 
 type meterStatus struct {

--- a/cmd/juju/status/formatter.go
+++ b/cmd/juju/status/formatter.go
@@ -5,7 +5,6 @@ package status
 
 import (
 	"fmt"
-	"sort"
 	"strings"
 
 	"github.com/juju/utils/series"
@@ -290,8 +289,9 @@ func (sf *statusFormatter) getRemoteApplicationStatusInfo(application params.Rem
 func (sf *statusFormatter) formatOffer(name string, offer params.ApplicationOfferStatus) offerStatus {
 	out := offerStatus{
 		Err:             offer.Err,
-		ApplicationURL:  offer.ApplicationURL,
 		ApplicationName: offer.ApplicationName,
+		CharmURL:        offer.CharmURL,
+		ConnectedCount:  offer.ConnectedCount,
 	}
 	out.Endpoints = make(map[string]remoteEndpoint)
 	for alias, ep := range offer.Endpoints {
@@ -301,43 +301,7 @@ func (sf *statusFormatter) formatOffer(name string, offer params.ApplicationOffe
 			Role:      string(ep.Role),
 		}
 	}
-	for id, conn := range offer.Connections {
-		if conn.Err != nil {
-			out.Connections = append(out.Connections, offerConnectionStatus{Err: conn.Err})
-			continue
-		}
-		sourceModelUUID := "unknown"
-		if sourceModel, err := names.ParseModelTag(conn.SourceModelTag); err == nil {
-			sourceModelUUID = sourceModel.Id()
-		}
-		connStatus := offerConnectionStatus{
-			SourceModelUUID: sourceModelUUID,
-			RelationId:      id,
-			Username:        conn.Username,
-			Endpoint:        conn.Endpoint,
-			Status:          conn.Status,
-		}
-		out.Connections = append(out.Connections, connStatus)
-	}
-	sort.Sort(byUserRelationId(out.Connections))
 	return out
-}
-
-type byUserRelationId []offerConnectionStatus
-
-func (b byUserRelationId) Len() int {
-	return len(b)
-}
-
-func (b byUserRelationId) Less(i, j int) bool {
-	if b[i].Username == b[j].Username {
-		return b[i].RelationId < b[j].RelationId
-	}
-	return b[i].Username < b[j].Username
-}
-
-func (b byUserRelationId) Swap(i, j int) {
-	b[i], b[j] = b[j], b[i]
 }
 
 type unitFormatInfo struct {

--- a/cmd/juju/status/status_test.go
+++ b/cmd/juju/status/status_test.go
@@ -4102,8 +4102,8 @@ Machine  State    DNS       Inst id       Series   AZ          Message
 2        started  10.0.2.1  controller-2  quantal              
 3        started  10.0.3.1  controller-3  quantal              I am number three
 
-Offer         User  Relation id  Status  Endpoint  Interface  Role
-hosted-mysql  fred  3            active  server    mysql      provider
+Offer         Application  Charm  Rev  Connected  Endpoint  Interface  Role
+hosted-mysql  mysql        mysql  1    1          server    mysql      provider
 
 Relation provider      Requirer                   Interface  Type
 mysql:juju-info        logging:info               juju-info  subordinate

--- a/core/crossmodel/params.go
+++ b/core/crossmodel/params.go
@@ -19,15 +19,33 @@ type ApplicationOfferDetails struct {
 	// OfferURL is the URL where the offer can be located.
 	OfferURL string
 
-	// CharmName is a name of a charm for remote application.
-	CharmName string
+	// CharmURL is the URL of the charm for the remote application.
+	CharmURL string
 
 	// Endpoints are the charm endpoints supported by the application.
 	// TODO(wallyworld) - do not use charm.Relation here
 	Endpoints []charm.Relation
 
-	// ConnectedCount are the number of users that are consuming the application.
-	ConnectedCount int
+	// Connects are the connections to the offer.
+	Connections []OfferConnection
+}
+
+// OfferConnection holds details about a connection to an offer.
+type OfferConnection struct {
+	// SourceModelUUID is the UUID of the model hosting the offer.
+	SourceModelUUID string
+
+	// Username is the name of the user consuming the offer.
+	Username string
+
+	// RelationId is the id of the relation for this connection.
+	RelationId int
+
+	// Endpoint is the endpoint being connected to.
+	Endpoint string
+
+	// Status is the status of the offer connection.
+	Status string
 }
 
 // ApplicationOfferDetailsResult is a result of listing a remote application.

--- a/featuretests/cmd_juju_crossmodel_test.go
+++ b/featuretests/cmd_juju_crossmodel_test.go
@@ -50,17 +50,19 @@ func (s *crossmodelSuite) TestListEndpoints(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(ctx.Stdout.(*bytes.Buffer).String(), gc.Equals, `
 riak:
+  application: riakservice
   store: kontroll
-  charm: riak
-  url: admin/controller.riak
+  charm: local:quantal/riak-7
+  offer-url: admin/controller.riak
   endpoints:
     endpoint:
       interface: http
       role: provider
 varnish:
+  application: varnishservice
   store: kontroll
-  charm: varnish
-  url: admin/controller.varnish
+  charm: local:quantal/varnish-1
+  offer-url: admin/controller.varnish
   endpoints:
     webcache:
       interface: varnish

--- a/state/offerconnections.go
+++ b/state/offerconnections.go
@@ -157,15 +157,15 @@ func (st *State) AddOfferConnection(args AddOfferConnectionParams) (_ *OfferConn
 	return &OfferConnection{doc: offerConnectionDoc}, nil
 }
 
-// AllOfferConnections returns all the offer connections in the model.
-func (st *State) AllOfferConnections() (conns []*OfferConnection, err error) {
+// OfferConnections returns the offer connections for an offer.
+func (st *State) OfferConnections(offerUUID string) (conns []*OfferConnection, err error) {
 	offerConnectionCollection, closer := st.db().GetCollection(offerConnectionsC)
 	defer closer()
 
 	connDocs := []offerConnectionDoc{}
-	err = offerConnectionCollection.Find(bson.D{}).All(&connDocs)
+	err = offerConnectionCollection.Find(bson.D{{"offer-uuid", offerUUID}}).All(&connDocs)
 	if err != nil {
-		return nil, errors.Errorf("cannot get all offer connections")
+		return nil, errors.Errorf("cannot get the offer connections for %v", offerUUID)
 	}
 	for _, v := range connDocs {
 		conns = append(conns, newOfferConnection(st, &v))

--- a/state/offerconnections_test.go
+++ b/state/offerconnections_test.go
@@ -41,7 +41,7 @@ func (s *offerConnectionsSuite) TestAddOfferConnection(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(rc.ConnectionCount(), gc.Equals, 1)
 
-	all, err := anotherState.AllOfferConnections()
+	all, err := anotherState.OfferConnections("offer-uuid")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(all, gc.HasLen, 1)
 	c.Assert(all[0].SourceModelUUID(), gc.Equals, testing.ModelTag.Id())


### PR DESCRIPTION
## Description of change

The offer information as rendered in juju status and juju offers is changed.

juju status shows a summary of each offer (what used to be printed by juju offers)

juju offers now has 2 tabular formats:
- summary, which shows a one line summary of each offer like in status
- tabular (the default), which shows for each offer who is connected and the relation id

## QA steps

Run up a cmr scenario
Use the CLI and verify output:
juju status
juju offers
juju offers --format summary
juju offers --format yaml

