### PR TITLE
Support removing a relation by its id

### DIFF
--- a/api/application/client.go
+++ b/api/application/client.go
@@ -463,6 +463,12 @@ func (c *Client) DestroyRelation(endpoints ...string) error {
 	return c.facade.FacadeCall("DestroyRelation", params, nil)
 }
 
+// DestroyRelationId removes the relation with the specified id.
+func (c *Client) DestroyRelationId(relationId int) error {
+	params := params.DestroyRelation{RelationId: relationId}
+	return c.facade.FacadeCall("DestroyRelation", params, nil)
+}
+
 // Consume adds a remote application to the model.
 func (c *Client) Consume(arg crossmodel.ConsumeApplicationArgs) (string, error) {
 	var consumeRes params.ErrorResults

--- a/api/application/client_test.go
+++ b/api/application/client_test.go
@@ -479,3 +479,35 @@ func (s *applicationSuite) TestConsume(c *gc.C) {
 	c.Assert(name, gc.Equals, "alias")
 	c.Assert(called, jc.IsTrue)
 }
+
+func (s *applicationSuite) TestDestroyRelation(c *gc.C) {
+	called := false
+	client := newClient(func(objType string, version int, id, request string, a, response interface{}) error {
+		c.Assert(request, gc.Equals, "DestroyRelation")
+		c.Assert(a, jc.DeepEquals, params.DestroyRelation{
+			Endpoints: []string{"ep1", "ep2"},
+		})
+		c.Assert(response, gc.IsNil)
+		called = true
+		return nil
+	})
+	err := client.DestroyRelation("ep1", "ep2")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(called, jc.IsTrue)
+}
+
+func (s *applicationSuite) TestDestroyRelationId(c *gc.C) {
+	called := false
+	client := newClient(func(objType string, version int, id, request string, a, response interface{}) error {
+		c.Assert(request, gc.Equals, "DestroyRelation")
+		c.Assert(a, jc.DeepEquals, params.DestroyRelation{
+			RelationId: 123,
+		})
+		c.Assert(response, gc.IsNil)
+		called = true
+		return nil
+	})
+	err := client.DestroyRelationId(123)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(called, jc.IsTrue)
+}

--- a/apiserver/allfacades.go
+++ b/apiserver/allfacades.go
@@ -124,7 +124,7 @@ func AllFacades() *facade.Registry {
 	reg("Application", 2, application.NewFacade)
 	reg("Application", 3, application.NewFacade)
 	reg("Application", 4, application.NewFacade)
-	reg("Application", 5, application.NewFacade) // adds AttachStorage
+	reg("Application", 5, application.NewFacade) // adds AttachStorage, remove relation by id
 
 	reg("ApplicationScaler", 1, applicationscaler.NewAPI)
 	reg("Backups", 1, backups.NewFacade)

--- a/apiserver/facades/client/application/application.go
+++ b/apiserver/facades/client/application/application.go
@@ -906,19 +906,28 @@ func (api *API) AddRelation(args params.AddRelation) (params.AddRelationResults,
 	return params.AddRelationResults{Endpoints: outEps}, nil
 }
 
-// DestroyRelation removes the relation between the specified endpoints.
-func (api *API) DestroyRelation(args params.DestroyRelation) error {
+// DestroyRelation removes the relation between the
+// specified endpoints or an id.
+func (api *API) DestroyRelation(args params.DestroyRelation) (err error) {
 	if err := api.checkCanWrite(); err != nil {
 		return err
 	}
 	if err := api.check.RemoveAllowed(); err != nil {
 		return errors.Trace(err)
 	}
-	eps, err := api.backend.InferEndpoints(args.Endpoints...)
-	if err != nil {
-		return err
+	var (
+		rel Relation
+		eps []state.Endpoint
+	)
+	if len(args.Endpoints) > 0 {
+		eps, err = api.backend.InferEndpoints(args.Endpoints...)
+		if err != nil {
+			return err
+		}
+		rel, err = api.backend.EndpointsRelation(eps...)
+	} else {
+		rel, err = api.backend.Relation(args.RelationId)
 	}
-	rel, err := api.backend.EndpointsRelation(eps...)
 	if err != nil {
 		return err
 	}

--- a/apiserver/facades/client/application/application_unit_test.go
+++ b/apiserver/facades/client/application/application_unit_test.go
@@ -229,6 +229,21 @@ func (s *ApplicationSuite) TestBlockRemoveDestroyRelation(c *gc.C) {
 	s.relation.CheckNoCalls(c)
 }
 
+func (s *ApplicationSuite) TestDestroyRelationId(c *gc.C) {
+	err := s.api.DestroyRelation(params.DestroyRelation{RelationId: 123})
+	c.Assert(err, jc.ErrorIsNil)
+	s.blockChecker.CheckCallNames(c, "RemoveAllowed")
+	s.backend.CheckCallNames(c, "ModelTag", "Relation")
+	s.backend.CheckCall(c, 1, "Relation", 123)
+	s.relation.CheckCallNames(c, "Destroy")
+}
+
+func (s *ApplicationSuite) TestDestroyRelationIdRelationNotFound(c *gc.C) {
+	s.backend.SetErrors(nil, errors.NotFoundf(`relation "123"`))
+	err := s.api.DestroyRelation(params.DestroyRelation{RelationId: 123})
+	c.Assert(err, gc.ErrorMatches, `relation "123" not found`)
+}
+
 func (s *ApplicationSuite) TestDestroyApplication(c *gc.C) {
 	results, err := s.api.DestroyApplication(params.Entities{
 		Entities: []params.Entity{

--- a/apiserver/facades/client/application/backend.go
+++ b/apiserver/facades/client/application/backend.go
@@ -32,6 +32,7 @@ type Backend interface {
 	AddRelation(...state.Endpoint) (Relation, error)
 	Charm(*charm.URL) (Charm, error)
 	EndpointsRelation(...state.Endpoint) (Relation, error)
+	Relation(int) (Relation, error)
 	InferEndpoints(...string) ([]state.Endpoint, error)
 	Machine(string) (Machine, error)
 	ModelTag() names.ModelTag
@@ -218,6 +219,14 @@ func (s stateShim) Charm(curl *charm.URL) (Charm, error) {
 
 func (s stateShim) EndpointsRelation(eps ...state.Endpoint) (Relation, error) {
 	r, err := s.State.EndpointsRelation(eps...)
+	if err != nil {
+		return nil, err
+	}
+	return stateRelationShim{r}, nil
+}
+
+func (s stateShim) Relation(id int) (Relation, error) {
+	r, err := s.State.Relation(id)
 	if err != nil {
 		return nil, err
 	}

--- a/apiserver/facades/client/application/mock_test.go
+++ b/apiserver/facades/client/application/mock_test.go
@@ -310,6 +310,17 @@ func (m *mockBackend) EndpointsRelation(endpoints ...state.Endpoint) (applicatio
 	return nil, errors.NotFoundf("relation")
 }
 
+func (m *mockBackend) Relation(id int) (application.Relation, error) {
+	m.MethodCall(m, "Relation", id)
+	if err := m.NextErr(); err != nil {
+		return nil, err
+	}
+	if m.relation != nil {
+		return m.relation, nil
+	}
+	return nil, errors.NotFoundf("relation")
+}
+
 func (m *mockBackend) UnitStorageAttachments(tag names.UnitTag) ([]state.StorageAttachment, error) {
 	m.MethodCall(m, "UnitStorageAttachments", tag)
 	if err := m.NextErr(); err != nil {

--- a/apiserver/params/params.go
+++ b/apiserver/params/params.go
@@ -124,9 +124,11 @@ type AddRelationResults struct {
 }
 
 // DestroyRelation holds the parameters for making the DestroyRelation call.
-// The endpoints specified are unordered.
+// A relation is identified by either endpoints or id.
+// The endpoints, if specified, are unordered.
 type DestroyRelation struct {
-	Endpoints []string `json:"endpoints"`
+	Endpoints  []string `json:"endpoints,omitempty"`
+	RelationId int      `json:"relation-id"`
 }
 
 // AddCharm holds the arguments for making an AddCharm API call.

--- a/cmd/juju/application/removerelation_test.go
+++ b/cmd/juju/application/removerelation_test.go
@@ -21,7 +21,7 @@ type RemoveRelationSuite struct {
 
 func (s *RemoveRelationSuite) SetUpTest(c *gc.C) {
 	s.IsolationSuite.SetUpTest(c)
-	s.mockAPI = &mockRemoveAPI{Stub: &testing.Stub{}}
+	s.mockAPI = &mockRemoveAPI{Stub: &testing.Stub{}, version: 6}
 	s.mockAPI.removeRelationFunc = func(endpoints ...string) error {
 		return s.mockAPI.NextErr()
 	}
@@ -39,19 +39,33 @@ func (s *RemoveRelationSuite) TestRemoveRelationWrongNumberOfArguments(c *gc.C) 
 	err := s.runRemoveRelation(c)
 	c.Assert(err, gc.ErrorMatches, "a relation must involve two applications")
 
-	// 1 argument
+	// 1 argument not an integer
 	err = s.runRemoveRelation(c, "application1")
-	c.Assert(err, gc.ErrorMatches, "a relation must involve two applications")
+	c.Assert(err, gc.ErrorMatches, `relation ID "application1" not valid`)
 
 	// More than 2 arguments
 	err = s.runRemoveRelation(c, "application1", "application2", "application3")
 	c.Assert(err, gc.ErrorMatches, "a relation must involve two applications")
 }
 
+func (s *RemoveRelationSuite) TestRemoveRelationIdOldServer(c *gc.C) {
+	s.mockAPI.version = 4
+	err := s.runRemoveRelation(c, "123")
+	c.Assert(err, gc.ErrorMatches, "removing a relation using its ID is not supported by this version of Juju")
+	s.mockAPI.CheckCall(c, 0, "Close")
+}
+
 func (s *RemoveRelationSuite) TestRemoveRelationSuccess(c *gc.C) {
 	err := s.runRemoveRelation(c, "application1", "application2")
 	c.Assert(err, jc.ErrorIsNil)
 	s.mockAPI.CheckCall(c, 0, "DestroyRelation", []string{"application1", "application2"})
+	s.mockAPI.CheckCall(c, 1, "Close")
+}
+
+func (s *RemoveRelationSuite) TestRemoveRelationIdSuccess(c *gc.C) {
+	err := s.runRemoveRelation(c, "123")
+	c.Assert(err, jc.ErrorIsNil)
+	s.mockAPI.CheckCall(c, 0, "DestroyRelationId", 123)
 	s.mockAPI.CheckCall(c, 1, "Close")
 }
 
@@ -74,6 +88,7 @@ func (s *RemoveRelationSuite) TestRemoveRelationBlocked(c *gc.C) {
 
 type mockRemoveAPI struct {
 	*testing.Stub
+	version            int
 	removeRelationFunc func(endpoints ...string) error
 }
 
@@ -85,4 +100,13 @@ func (s mockRemoveAPI) Close() error {
 func (s mockRemoveAPI) DestroyRelation(endpoints ...string) error {
 	s.MethodCall(s, "DestroyRelation", endpoints)
 	return s.removeRelationFunc(endpoints...)
+}
+
+func (s mockRemoveAPI) DestroyRelationId(relationId int) error {
+	s.MethodCall(s, "DestroyRelationId", relationId)
+	return nil
+}
+
+func (s mockRemoveAPI) BestAPIVersion() int {
+	return s.version
 }


### PR DESCRIPTION
## Description of change

When looking at relations to offers, only the relation id is known to the user. We need to provide a way for those relations to be removed. This PR adds support the the remove-relation command to allow a relation id to be used. The capability isn't CMR specific.

## QA steps

Deploy a CMR scenario.
Use juju status to find a relation id to remove
$ juju remove-relation <id>
Both consuming and offering sides should reflect broken relation.

## Documentation changes

juju remove-relation CLI doc needs updating.
