### PR TITLE
Reset password, api and apiserver layer.

### DIFF
--- a/api/facadeversions.go
+++ b/api/facadeversions.go
@@ -90,7 +90,7 @@ var facadeVersions = map[string]int{
 	"UnitAssigner":                 1,
 	"Uniter":                       6,
 	"Upgrader":                     1,
-	"UserManager":                  1,
+	"UserManager":                  2,
 	"VolumeAttachmentsWatcher":     2,
 }
 

--- a/api/usermanager/client_test.go
+++ b/api/usermanager/client_test.go
@@ -227,7 +227,7 @@ func (s *usermanagerSuite) TestResetPasswordResponseError(c *gc.C) {
 }
 
 func (s *usermanagerSuite) TestResetPassword(c *gc.C) {
-	key := []byte("not cats or dragons here")
+	key := []byte("no cats or dragons here")
 	apiCaller := apitesting.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
 		c.Assert(objType, gc.Equals, "UserManager")
 		c.Assert(request, gc.Equals, "ResetPassword")

--- a/api/usermanager/client_test.go
+++ b/api/usermanager/client_test.go
@@ -8,6 +8,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
+	apitesting "github.com/juju/juju/api/base/testing"
 	"github.com/juju/juju/api/usermanager"
 	"github.com/juju/juju/apiserver/params"
 	jujutesting "github.com/juju/juju/juju/testing"
@@ -214,4 +215,58 @@ func (s *usermanagerSuite) TestSetUserPasswordCanonical(c *gc.C) {
 func (s *usermanagerSuite) TestSetUserPasswordBadName(c *gc.C) {
 	err := s.usermanager.SetPassword("not!good", "new-password")
 	c.Assert(err, gc.ErrorMatches, `"not!good" is not a valid username`)
+}
+
+func (s *usermanagerSuite) TestResetPasswordResponseError(c *gc.C) {
+	apiCaller := apitesting.APICallerFunc(func(string, int, string, string, interface{}, interface{}) error {
+		return errors.New("boom")
+	})
+	client := usermanager.NewClient(apiCaller)
+	_, err := client.ResetPassword("foobar")
+	c.Assert(err, gc.ErrorMatches, "boom")
+}
+
+func (s *usermanagerSuite) TestResetPassword(c *gc.C) {
+	key := []byte("not cats or dragons here")
+	apiCaller := apitesting.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
+		c.Assert(objType, gc.Equals, "UserManager")
+		c.Assert(request, gc.Equals, "ResetPassword")
+		args, ok := arg.(params.Entities)
+		c.Assert(ok, jc.IsTrue)
+		c.Assert(args, gc.DeepEquals, params.Entities{
+			Entities: []params.Entity{{Tag: "user-foobar"}},
+		})
+
+		if results, k := result.(*params.AddUserResults); k {
+			keys := []params.AddUserResult{
+				{
+					Tag:       "user-foobar",
+					SecretKey: key,
+				},
+			}
+			results.Results = keys
+		}
+		return nil
+	})
+	client := usermanager.NewClient(apiCaller)
+	result, err := client.ResetPassword("foobar")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result, gc.DeepEquals, key)
+}
+
+func (s *usermanagerSuite) TestResetPasswordInvalidUsername(c *gc.C) {
+	_, err := s.usermanager.ResetPassword("not/valid")
+	c.Assert(err, gc.ErrorMatches, `invalid user name "not/valid"`)
+}
+
+func (s *usermanagerSuite) TestResetPasswordResultCount(c *gc.C) {
+	apiCaller := apitesting.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
+		if results, k := result.(*params.AddUserResults); k {
+			results.Results = make([]params.AddUserResult, 2)
+		}
+		return nil
+	})
+	client := usermanager.NewClient(apiCaller)
+	_, err := client.ResetPassword("foobar")
+	c.Assert(err, gc.ErrorMatches, "expected 1 result, got 2")
 }

--- a/apiserver/allfacades.go
+++ b/apiserver/allfacades.go
@@ -230,7 +230,7 @@ func AllFacades() *facade.Registry {
 	reg("Uniter", 6, uniter.NewUniterAPI)
 
 	reg("Upgrader", 1, upgrader.NewUpgraderFacade)
-	reg("UserManager", 1, usermanager.NewUserManagerAPI)
+	reg("UserManager", 2, usermanager.NewUserManagerAPI)
 
 	if featureflag.Enabled(feature.CrossModelRelations) {
 		reg("ApplicationOffers", 1, applicationoffers.NewOffersAPI)

--- a/apiserver/facades/client/usermanager/usermanager.go
+++ b/apiserver/facades/client/usermanager/usermanager.go
@@ -383,3 +383,43 @@ func (api *UserManagerAPI) setPassword(arg params.EntityPassword) error {
 	}
 	return nil
 }
+
+// ResetPassword resets password for supplied users by
+// invalidating current passwords (if any) and generating
+// new random secret keys which will be returned.
+func (api *UserManagerAPI) ResetPassword(args params.Entities) (params.AddUserResults, error) {
+	var result params.AddUserResults
+
+	if err := api.check.ChangeAllowed(); err != nil {
+		return result, errors.Trace(err)
+	}
+
+	if len(args.Entities) == 0 {
+		return result, nil
+	}
+
+	isSuperUser, err := api.hasControllerAdminAccess()
+	if err != nil {
+		return result, errors.Trace(err)
+	}
+	if !isSuperUser {
+		return result, common.ErrPerm
+	}
+
+	result.Results = make([]params.AddUserResult, len(args.Entities))
+	for i, arg := range args.Entities {
+		result.Results[i] = params.AddUserResult{Tag: arg.Tag}
+		user, err := api.getUser(arg.Tag)
+		if err != nil {
+			result.Results[i].Error = common.ServerError(err)
+			continue
+		}
+		key, err := user.ResetPassword()
+		if err != nil {
+			result.Results[i].Error = common.ServerError(err)
+			continue
+		}
+		result.Results[i].SecretKey = key
+	}
+	return result, nil
+}

--- a/apiserver/facades/client/usermanager/usermanager_test.go
+++ b/apiserver/facades/client/usermanager/usermanager_test.go
@@ -821,3 +821,88 @@ func (s *userManagerSuite) TestRemoveUserBulkSharedModels(c *gc.C) {
 	c.Assert(alice.IsDeleted(), jc.IsTrue)
 
 }
+
+func (s *userManagerSuite) TestResetPassword(c *gc.C) {
+	alex := s.Factory.MakeUser(c, &factory.UserParams{Name: "alex", NoModelUser: true})
+	c.Assert(alex.PasswordValid("password"), jc.IsTrue)
+
+	args := params.Entities{Entities: []params.Entity{{Tag: alex.Tag().String()}}}
+	results, err := s.usermanager.ResetPassword(args)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(results.Results, gc.HasLen, 1)
+
+	err = alex.Refresh()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(results.Results[0].Tag, gc.DeepEquals, alex.Tag().String())
+	c.Assert(results.Results[0].SecretKey, gc.DeepEquals, alex.SecretKey())
+	c.Assert(alex.PasswordValid("password"), jc.IsFalse)
+}
+
+func (s *userManagerSuite) TestBlockResetPassword(c *gc.C) {
+	alex := s.Factory.MakeUser(c, &factory.UserParams{Name: "alex", NoModelUser: true})
+	args := params.Entities{Entities: []params.Entity{{Tag: alex.Tag().String()}}}
+	c.Assert(alex.PasswordValid("password"), jc.IsTrue)
+
+	s.BlockAllChanges(c, "TestBlockResetPassword")
+	_, err := s.usermanager.ResetPassword(args)
+	// Check that the call is blocked
+	s.AssertBlocked(c, err, "TestBlockResetPassword")
+
+	err = alex.Refresh()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(alex.PasswordValid("password"), jc.IsTrue)
+}
+
+func (s *userManagerSuite) TestResetPasswordForSelf(c *gc.C) {
+	alex, err := s.State.User(s.AdminUserTag(c))
+	c.Assert(err, jc.ErrorIsNil)
+	args := params.Entities{Entities: []params.Entity{{Tag: alex.Tag().String()}}}
+	c.Assert(alex.PasswordValid("dummy-secret"), jc.IsTrue)
+
+	results, err := s.usermanager.ResetPassword(args)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(results.Results, gc.HasLen, 1)
+
+	err = alex.Refresh()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(results.Results[0].Tag, gc.DeepEquals, alex.Tag().String())
+	c.Assert(results.Results[0].SecretKey, gc.DeepEquals, alex.SecretKey())
+	c.Assert(alex.PasswordValid("dummy-secret"), jc.IsFalse)
+}
+
+func (s *userManagerSuite) TestResetPasswordNotControllerAdmin(c *gc.C) {
+	alex := s.Factory.MakeUser(c, &factory.UserParams{Name: "alex", NoModelUser: true})
+	c.Assert(alex.PasswordValid("password"), jc.IsTrue)
+	usermanager, err := usermanager.NewUserManagerAPI(
+		s.State, s.resources, apiservertesting.FakeAuthorizer{Tag: alex.Tag()})
+	c.Assert(err, jc.ErrorIsNil)
+
+	args := params.Entities{Entities: []params.Entity{{Tag: alex.Tag().String()}}}
+	_, err = usermanager.ResetPassword(args)
+	c.Assert(err, gc.ErrorMatches, "permission denied")
+
+	err = alex.Refresh()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(alex.PasswordValid("password"), jc.IsTrue)
+}
+
+func (s *userManagerSuite) TestResetPasswordFail(c *gc.C) {
+	alex := s.Factory.MakeUser(c, &factory.UserParams{Name: "alex", NoModelUser: true, Disabled: true})
+	args := params.Entities{Entities: []params.Entity{
+		{Tag: "user-invalid"},
+		{Tag: alex.Tag().String()},
+	}}
+
+	results, err := s.usermanager.ResetPassword(args)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(results.Results, gc.DeepEquals, []params.AddUserResult{
+		params.AddUserResult{
+			Tag:   "user-invalid",
+			Error: common.ServerError(common.ErrPerm),
+		},
+		params.AddUserResult{
+			Tag:   alex.Tag().String(),
+			Error: common.ServerError(fmt.Errorf("cannot reset password for user \"alex\": user deactivated")),
+		},
+	})
+}

--- a/state/user.go
+++ b/state/user.go
@@ -552,8 +552,8 @@ func (u *User) ResetPassword() ([]byte, error) {
 		if u.IsDisabled() {
 			return nil, fmt.Errorf("user deactivated")
 		}
-
-		key, err := generateSecretKey()
+		var err error
+		key, err = generateSecretKey()
 		if err != nil {
 			return nil, errors.Trace(err)
 		}

--- a/state/user_test.go
+++ b/state/user_test.go
@@ -418,6 +418,7 @@ func (s *UserSuite) TestResetPassword(c *gc.C) {
 	key, err := u.ResetPassword()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(key, gc.Not(gc.DeepEquals), oldKey)
+	c.Assert(key, gc.NotNil)
 	c.Assert(u.SecretKey(), gc.DeepEquals, key)
 }
 


### PR DESCRIPTION
## Description of change

This PR introduces a new method on user manager facade to reset password. The intention for this method to be used both for resetting a maybe-forgotten user password by a controller user as well as for re-issuing a new registration key for a newly added user.
As a new method, facade version bump is required.
As a drive-by fix, I have also added a variable context scope in state layer to actually return a value :)

## QA steps

This functionality has not been plugged in into full-stack yet. All unit tests pass.

## Documentation changes

No user facing documentation changes are needed. However, GUI and other API clients may want to be aware of this new method. 

## Bug reference

Part of the work to provide a solution for https://bugs.launchpad.net/juju/+bug/1657187
