### PR TITLE
Updated add-user help to clarify where the user is stored.

### DIFF
--- a/cmd/juju/user/add.go
+++ b/cmd/juju/user/add.go
@@ -22,9 +22,12 @@ import (
 var usageSummary = `
 Adds a Juju user to a controller.`[1:]
 
-const usageDetails = "A `juju register` command will be printed, which must be executed by the" + `
-user to complete the registration process. The user's details are stored
-within the shared model, and will be removed when the model is destroyed.
+const usageDetails = `The user's details are stored within the controller and
+will be removed when the controller is destroyed.
+
+A user unique registration string will be printed. This registration string 
+must be used by the newly added user as supplied to 
+complete the registration process. 
 
 Some machine providers will require the user to be in possession of certain
 credentials in order to create a model.


### PR DESCRIPTION
## Description of change

`add-user` help had an outdated information.

## QA steps

`juju help add-user` has updated information.

## Documentation changes

Command help was updated.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1709800
