### PR TITLE
Fix wrong DNS name in certificates issued to HA controllers.

### DIFF
--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -419,7 +419,8 @@ func upgradeCertificateDNSNames(config agent.ConfigSetter) error {
 	}
 
 	update := false
-	requiredDNSNames := []string{"local", "juju-apiserver", "juju-mongodb"}
+	requiredDNSNames := []string{"localhost", "juju-apiserver",
+		"juju-mongodb"}
 	for _, dnsName := range requiredDNSNames {
 		if dnsNames.Contains(dnsName) {
 			continue


### PR DESCRIPTION
This PR fixes the DNS name issued in server certificate that prevents
a juju agent to connect properly to mongodb database when on an HA
environment.

lp:1710886

Signed-off-by: José Pekkarinen <jose.pekkarinen@canonical.com>
