### PR TITLE
worker/diskmanager: ignore DeviceLinks ordering

### DIFF
--- a/worker/diskmanager/diskmanager.go
+++ b/worker/diskmanager/diskmanager.go
@@ -5,6 +5,7 @@ package diskmanager
 
 import (
 	"reflect"
+	"sort"
 	"time"
 
 	"github.com/juju/loggo"
@@ -55,6 +56,9 @@ func doWork(listf ListBlockDevicesFunc, b BlockDeviceSetter, old *[]storage.Bloc
 		return err
 	}
 	storage.SortBlockDevices(blockDevices)
+	for _, blockDevice := range blockDevices {
+		sort.Strings(blockDevice.DeviceLinks)
+	}
 	if reflect.DeepEqual(blockDevices, *old) {
 		logger.Tracef("no changes to block devices detected")
 		return nil


### PR DESCRIPTION
## Description of change

When checking if the block devices on the system have
changed in order to decide whether we need to republish
to state, we should disregard the order of the DeviceLinks
of block devices.

Backport of https://github.com/juju/juju/commit/f0b5ac4a715df4dff381a1b9d241229c6265dd22 and 39411ef61586787be903fa0b10d5b5b2ed15c778.

## QA steps

1. Bootstrap Juju on MAAS
2. Watch that the diskmanager publishes block devices, but does not repeat when block devices haven't changed
3. Add a disk to the machine (e.g. in my case I'm using virt-manager, so just add a virtual disk.)
4. Observe that changes are published once and only once.

## Documentation changes

None.

## Bug reference

Fixes https://bugs.launchpad.net/juju-core/+bug/1600539 for Juju 1.25.