### PR TITLE
Remove the user/name index entry when model becomes dead.

### DIFF
--- a/state/modeluser_test.go
+++ b/state/modeluser_test.go
@@ -398,7 +398,7 @@ func (s *ModelUserSuite) TestDeadModelsForUser(c *gc.C) {
 	c.Assert(models, gc.HasLen, 1)
 	c.Assert(models[0].UUID(), gc.Equals, s.State.ModelUUID())
 
-	err = state.SetModelLifeDead(s.State, models[0].UUID())
+	err = models[0].SetDead()
 	c.Assert(err, jc.ErrorIsNil)
 	models, err = s.State.ModelsForUser(user.UserTag())
 	c.Assert(err, jc.ErrorIsNil)

--- a/state/pool.go
+++ b/state/pool.go
@@ -68,7 +68,7 @@ func (p *StatePool) Get(modelUUID string) (*State, StatePoolReleaser, error) {
 	if ok && item.remove {
 		// We don't want to allow increasing the refcount of a model
 		// that's been removed.
-		return nil, nil, errors.Errorf("model %v has been removed", modelUUID)
+		return nil, nil, errors.NewNotFound(nil, fmt.Sprintf("model %v has been removed", modelUUID))
 	}
 
 	p.sourceKey++

--- a/state/pool_test.go
+++ b/state/pool_test.go
@@ -6,6 +6,7 @@ package state_test
 import (
 	"fmt"
 
+	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
@@ -217,4 +218,5 @@ func (s *statePoolSuite) TestGetRemovedNotAllowed(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	_, _, err = s.Pool.Get(s.ModelUUID1)
 	c.Assert(err, gc.ErrorMatches, fmt.Sprintf("model %v has been removed", s.ModelUUID1))
+	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 }

--- a/state/state.go
+++ b/state/state.go
@@ -237,15 +237,14 @@ func (st *State) removeAllModelDocs(modelAssertion bson.D) error {
 	}
 
 	// Now remove remove the model.
-	env, err := st.Model()
+	model, err := st.Model()
 	if err != nil {
 		return errors.Trace(err)
 	}
-	id := userModelNameIndex(env.Owner().Id(), env.Name())
 	ops = []txn.Op{{
 		// Cleanup the owner:envName unique key.
 		C:      usermodelnameC,
-		Id:     id,
+		Id:     model.uniqueIndexID(),
 		Remove: true,
 	}, {
 		C:      modelEntityRefsC,

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -2618,7 +2618,9 @@ func (s *StateSuite) TestRemoveAllModelDocs(c *gc.C) {
 	userModelKey := s.insertFakeModelDocs(c, st)
 	s.checkUserModelNameExists(c, checkUserModelNameArgs{st: st, id: userModelKey, exists: true})
 
-	err := state.SetModelLifeDead(st, st.ModelUUID())
+	model, err := st.Model()
+	c.Assert(err, jc.ErrorIsNil)
+	err = model.SetDead()
 	c.Assert(err, jc.ErrorIsNil)
 
 	err = st.RemoveAllModelDocs()
@@ -2759,7 +2761,9 @@ func (s *StateSuite) TestRemoveAllModelDocsRemovesLogs(c *gc.C) {
 	st := s.Factory.MakeModel(c, nil)
 	defer st.Close()
 
-	err := state.SetModelLifeDead(st, st.ModelUUID())
+	model, err := st.Model()
+	c.Assert(err, jc.ErrorIsNil)
+	err = model.SetDead()
 	c.Assert(err, jc.ErrorIsNil)
 
 	writeLogs(c, st, 5)

--- a/state/undertaker.go
+++ b/state/undertaker.go
@@ -48,6 +48,11 @@ func (st *State) ProcessDyingModel() (err error) {
 				"life":          Dead,
 				"time-of-death": st.NowToTheSecond(),
 			}},
+		}, {
+			// Cleanup the owner:envName unique key.
+			C:      usermodelnameC,
+			Id:     model.uniqueIndexID(),
+			Remove: true,
 		}}
 		return ops, nil
 	}


### PR DESCRIPTION
There are two fixes here:
 - the state pool was not returning the right type of error
   now it returns a not found error
 - the user/name index value was being removed too late
   it is now removed when the model becomes dead rather
   than when all the docs are removed.

## QA steps
```
juju bootstrap lxd foo
juju add-model test
for i in $(seq 1 100); do echo $i; juju destroy-model test -y && echo $? && juju add-model test; done
```
Always adds immediately after, and no errors shown.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1709324