### PR TITLE
Reset user password, cli.

### DIFF
--- a/cmd/juju/user/change_password.go
+++ b/cmd/juju/user/change_password.go
@@ -33,8 +33,6 @@ on the specified controller. If no controller is specified,
 the current controller will be used.
 
 A controller administrator can also reset the password for another user.
-This will invalidate previously set user password (if any) or 
-previously issued registration tokens. 
 This will invalidate any password or registration string 
 that was previously issued, and issue a new registration string to be used with
 ` + "`juju register`" + `.  

--- a/cmd/juju/user/change_password.go
+++ b/cmd/juju/user/change_password.go
@@ -210,7 +210,7 @@ func (c *changePasswordCommand) updateClientStore(ctx *cmd.Context, password str
 		ctx.Infof("Password for %q has been %v.", c.User, c.changeOrResetString(true))
 	} else {
 		if c.accountDetails.Password != "" {
-			if password != "" {
+			if !c.Reset {
 				// Log back in with macaroon authentication, so we can
 				// discard the password without having to log back in
 				// immediately.

--- a/cmd/juju/user/change_password.go
+++ b/cmd/juju/user/change_password.go
@@ -29,13 +29,15 @@ The user is, by default, the current user. The latter can be confirmed with
 the ` + "`juju show-user`" + ` command.
 
 A controller administrator can change the password for another user 
-on the specified controller. If no controller is specified, current controller
-will be used.
+on the specified controller. If no controller is specified, 
+the current controller will be used.
 
 A controller administrator can also reset the password for another user.
 This will invalidate previously set user password (if any) or 
 previously issued registration tokens. 
-Succefull password reset will result in a new registration token. 
+This will invalidate any password or registration string 
+that was previously issued, and issue a new registration string to be used with
+` + "`juju register`" + `.  
 
 
 Examples:

--- a/cmd/juju/user/change_password.go
+++ b/cmd/juju/user/change_password.go
@@ -154,20 +154,17 @@ func (c *changePasswordCommand) prepareRun() error {
 		}
 		c.userTag = names.NewUserTag(c.accountDetails.User)
 		if !c.userTag.IsLocal() {
-			return errors.Errorf("cannot %v password for external user %q", c.changeOrResetString(), c.userTag)
+			return errors.Errorf("password for external user %q could not be %", c.changeOrResetString(), c.userTag)
 		}
 	}
 	return nil
 }
 
-func (c *changePasswordCommand) changeOrResetString(past ...bool) string {
+func (c *changePasswordCommand) changeOrResetString() string {
 	if c.Reset {
 		return "reset"
 	}
-	if len(past) != 0 && past[0] {
-		return "changed"
-	}
-	return "change"
+	return "changed"
 }
 
 func (c *changePasswordCommand) resetUserPassword(ctx *cmd.Context) error {
@@ -207,7 +204,7 @@ func (c *changePasswordCommand) updateUserPassword(ctx *cmd.Context) error {
 
 func (c *changePasswordCommand) updateClientStore(ctx *cmd.Context, password string) error {
 	if c.accountDetails == nil {
-		ctx.Infof("Password for %q has been %v.", c.User, c.changeOrResetString(true))
+		ctx.Infof("Password for %q has been %v.", c.User, c.changeOrResetString())
 	} else {
 		if c.accountDetails.Password != "" {
 			if !c.Reset {
@@ -223,7 +220,7 @@ func (c *changePasswordCommand) updateClientStore(ctx *cmd.Context, password str
 				// able to recover by running "juju login".
 				c.accountDetails.Password = ""
 				if err := c.ClientStore().UpdateAccount(c.controllerName, *c.accountDetails); err != nil {
-					return errors.Annotatef(err, "failed to %v client credentials", c.changeOrResetString())
+					return errors.Annotate(err, "failed to update client credentials")
 				}
 			} else {
 				if err := c.ClearControllerMacaroons(c.ClientStore(), c.controllerName); err != nil {
@@ -231,7 +228,7 @@ func (c *changePasswordCommand) updateClientStore(ctx *cmd.Context, password str
 				}
 			}
 		}
-		ctx.Infof("Your password has been %v.", c.changeOrResetString(true))
+		ctx.Infof("Your password has been %v.", c.changeOrResetString())
 	}
 	return nil
 }

--- a/cmd/juju/user/change_password.go
+++ b/cmd/juju/user/change_password.go
@@ -156,7 +156,7 @@ func (c *changePasswordCommand) prepareRun() error {
 		}
 		c.userTag = names.NewUserTag(c.accountDetails.User)
 		if !c.userTag.IsLocal() {
-			return errors.Errorf("password for external user %q could not be %", c.changeOrResetString(), c.userTag)
+			return errors.Errorf("password for external user %q could not be %v", c.userTag, c.changeOrResetString())
 		}
 	}
 	return nil

--- a/cmd/juju/user/change_password.go
+++ b/cmd/juju/user/change_password.go
@@ -187,7 +187,7 @@ func (c *changePasswordCommand) resetUserPassword(ctx *cmd.Context) error {
 		if c.accountDetails.Password != "" {
 			macaroonErr = c.ClearControllerMacaroons(c.ClientStore(), c.controllerName)
 			if macaroonErr != nil {
-				macaroonErr = errors.Annotatef(err, "could not clear macaroon")
+				macaroonErr = errors.Annotatef(err, "could not clear local credential cache")
 			} else {
 				ctx.Infof("Your password has been reset.")
 			}

--- a/cmd/juju/user/change_password_test.go
+++ b/cmd/juju/user/change_password_test.go
@@ -126,11 +126,11 @@ func (s *ChangePasswordCommandSuite) TestResetPassword(c *gc.C) {
 	context, _, err := s.run(c, "--reset")
 	c.Assert(err, jc.ErrorIsNil)
 	s.mockAPI.CheckCall(c, 0, "ResetPassword", "current-user")
-	c.Assert(cmdtesting.Stdout(context), gc.Matches, `
-New controller access token for this user is  (.+)
-`[1:])
-	c.Assert(cmdtesting.Stderr(context), gc.Equals, `
+	c.Assert(cmdtesting.Stdout(context), gc.Equals, "")
+	c.Assert(cmdtesting.Stderr(context), gc.Matches, `
 Your password has been reset.
+Please run:
+     juju register (.+)
 `[1:])
 }
 
@@ -152,11 +152,11 @@ func (s *ChangePasswordCommandSuite) TestResetOthersPassword(c *gc.C) {
 	context, _, err := s.run(c, "other", "--reset")
 	c.Assert(err, jc.ErrorIsNil)
 	s.mockAPI.CheckCall(c, 0, "ResetPassword", "other")
-	c.Assert(cmdtesting.Stdout(context), gc.Matches, `
-New controller access token for this user is  (.+)
-`[1:])
-	c.Assert(cmdtesting.Stderr(context), gc.Equals, `
+	c.Assert(cmdtesting.Stdout(context), gc.Equals, "")
+	c.Assert(cmdtesting.Stderr(context), gc.Matches, `
 Password for "other" has been reset.
+Ask the user to run:
+     juju register (.+)
 `[1:])
 }
 

--- a/featuretests/cmd_juju_user_test.go
+++ b/featuretests/cmd_juju_user_test.go
@@ -70,11 +70,11 @@ func (s *UserSuite) TestUserResetPasswordForSelf(c *gc.C) {
 	err = user.Refresh()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(user.PasswordValid("dummy-secret"), jc.IsFalse)
-	c.Assert(cmdtesting.Stdout(context), gc.Matches, `
-New controller access token for this user is  (.+)
-`[1:])
-	c.Assert(cmdtesting.Stderr(context), gc.Equals, `
+	c.Assert(cmdtesting.Stdout(context), gc.Equals, "")
+	c.Assert(cmdtesting.Stderr(context), gc.Matches, `
 Your password has been reset.
+Please run:
+     juju register (.+)
 `[1:])
 }
 
@@ -85,11 +85,11 @@ func (s *UserSuite) TestUserResetPasswordForOther(c *gc.C) {
 
 	context, err := s.RunUserCommand(c, "", "change-user-password", "--reset", username)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(cmdtesting.Stdout(context), gc.Matches, `
-New controller access token for this user is  (.+)
-`[1:])
-	c.Assert(cmdtesting.Stderr(context), gc.Equals, `
+	c.Assert(cmdtesting.Stdout(context), gc.Equals, "")
+	c.Assert(cmdtesting.Stderr(context), gc.Matches, `
 Password for "bob" has been reset.
+Ask the user to run:
+     juju register (.+)
 `[1:])
 }
 


### PR DESCRIPTION
## Description of change

This PR introduces --reset option on change-user-password command that enables controller admins to re-issue a controller access registration key for users.
This functionality can also be used when user forgot their password.

## QA steps

1. bootstrap
2. add user (note registration string)
3. change password for new user using --reset option (note different registration string issued)
4. login as new user using newer registration string.

## Documentation changes
Final, cli layer, for https://bugs.launchpad.net/juju/+bug/1657187

## Bug reference

Does this change fix a bug? Please add a link to it.
