### PR TITLE
Fix wrong DNS name in certificates issued to HA controllers.

### DIFF
--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -459,7 +459,7 @@ func upgradeCertificateDNSNames(config agent.ConfigSetter) error {
 	}
 
 	update := false
-	requiredDNSNames := []string{"local", "juju-apiserver", "juju-mongodb"}
+	requiredDNSNames := []string{"local", "localhost", "juju-apiserver", "juju-mongodb"}
 	for _, dnsName := range requiredDNSNames {
 		if dnsNames.Contains(dnsName) {
 			continue


### PR DESCRIPTION
PR 7748 rebased upon 2.2.

lp:1710886.

Signed-off-by: José Pekkarinen <jose.pekkarinen@canonical.com>
