### PR TITLE
Sub-ord deployment conditional, make sure target controller is running.

### DIFF
--- a/acceptancetests/assess_model_migration.py
+++ b/acceptancetests/assess_model_migration.py
@@ -588,7 +588,7 @@ def ensure_migration_rolls_back_on_failure(source_client, dest_client):
     controller.
     """
     test_model, application = deploy_simple_server_to_new_model(
-        source_client, 'rollmeback', deploy_subords=True)
+        source_client, 'rollmeback')
     if after_22beta4(source_client.version):
         test_model.juju(
             'migrate',

--- a/acceptancetests/assess_model_migration.py
+++ b/acceptancetests/assess_model_migration.py
@@ -381,21 +381,19 @@ def ensure_superuser_can_migrate_other_user_models(
 
 
 def deploy_simple_server_to_new_model(
-        client, model_name, resource_contents=None, deploy_subords=True):
+        client, model_name, resource_contents=None):
     # As per bug LP:1709773 deploy 2 primary apps and have a subordinate
     #  related to both
     new_model = client.add_model(client.env.clone(model_name))
     application = deploy_simple_resource_server(new_model, resource_contents)
-    if deploy_subords:
-        _, deploy_complete = new_model.deploy('cs:ubuntu')
-        new_model.wait_for(deploy_complete)
-        new_model.deploy('cs:ntp')
-        new_model.juju('add-relation', ('ntp', application))
-        new_model.juju('add-relation', ('ntp', 'ubuntu'))
-        # Need to wait for the subordinate charms too.
-        new_model.wait_for(AllApplicationActive())
-        new_model.wait_for(AllApplicationWorkloads())
-        new_model.juju('status', ())
+    _, deploy_complete = new_model.deploy('cs:ubuntu')
+    new_model.wait_for(deploy_complete)
+    new_model.deploy('cs:ntp')
+    new_model.juju('add-relation', ('ntp', application))
+    new_model.juju('add-relation', ('ntp', 'ubuntu'))
+    # Need to wait for the subordinate charms too.
+    new_model.wait_for(AllApplicationActive())
+    new_model.wait_for(AllApplicationWorkloads())
     assert_deployed_charm_is_responding(new_model, resource_contents)
 
     return new_model, application

--- a/acceptancetests/assess_model_migration_versions.py
+++ b/acceptancetests/assess_model_migration_versions.py
@@ -60,8 +60,7 @@ def assess_model_migration_versions(stable_bsm, devel_bsm, args):
             test_stable_model, application = deploy_simple_server_to_new_model(
                 stable_client,
                 'version-migration',
-                resource_contents,
-                deploy_subords=False)
+                resource_contents)
             migration_target_client = migrate_model_to_controller(
                 test_stable_model, devel_client)
             assert_model_migrated_successfully(

--- a/acceptancetests/assess_model_migration_versions.py
+++ b/acceptancetests/assess_model_migration_versions.py
@@ -17,8 +17,11 @@ from assess_model_migration import (
     assert_model_migrated_successfully,
     deploy_simple_server_to_new_model,
     migrate_model_to_controller,
-)
-from jujupy.client import get_stripped_version_number
+    )
+from jujupy.client import (
+    BaseCondition,
+    get_stripped_version_number,
+    )
 from deploy_stack import (
     BootstrapManager,
     client_from_config,
@@ -52,8 +55,13 @@ def assess_model_migration_versions(stable_bsm, devel_bsm, args):
             stable_client = stable_bsm.client
             devel_client = devel_bsm.client
             resource_contents = get_random_string()
+            # Possible stable version doesn't handle migration subords (a fixed
+            # bug in later versions.)
             test_stable_model, application = deploy_simple_server_to_new_model(
-                stable_client, 'version-migration', resource_contents)
+                stable_client,
+                'version-migration',
+                resource_contents,
+                deploy_subords=False)
             migration_target_client = migrate_model_to_controller(
                 test_stable_model, devel_client)
             assert_model_migrated_successfully(
@@ -62,10 +70,23 @@ def assess_model_migration_versions(stable_bsm, devel_bsm, args):
             # Deploy another devel controller and attempt migration to it.
             another_bsm = get_new_devel_bootstrap_manager(args, devel_bsm)
             with another_bsm.existing_booted_context(args.upload_tools):
+                another_bsm.client.get_controller_client().wait_for(
+                    AllMachinesRunning())
                 another_migration_client = migrate_model_to_controller(
                     migration_target_client, another_bsm.client)
                 assert_model_migrated_successfully(
                     another_migration_client, application, resource_contents)
+
+
+class AllMachinesRunning(BaseCondition):
+
+    def iter_blocking_state(self, status):
+        for machine_no, status in status.iter_machines():
+            if status['machine-status']['current'] != 'running':
+                yield 'machine-{}'.format(machine_no), 'not-running'
+
+    def do_raise(self, model_name, status):
+        raise Exception('Timed out waiting for machines to be "running".')
 
 
 def get_new_devel_bootstrap_manager(args, devel_bsm):


### PR DESCRIPTION
Deploying subordinate charms for the model-migration-versions tests was breaking it (as the 'stable' juju version might  not have the fix this was designed to test.)

It became apparent also that the 3rd migration attempt was happening before the target controller was ready. Added a check for that.

This has been tested locally and both model migration and model migration versions tests pass with these modifications.

Note:
As per PR comments, slight pivot: No more conditional deployment instead better debugging output when things go wrong.

This has been tested locally.