### PR TITLE
resources: Clean up pending resources after a failed deployment

### DIFF
--- a/apiserver/application/backend.go
+++ b/apiserver/application/backend.go
@@ -37,6 +37,7 @@ type Backend interface {
 	StorageInstance(names.StorageTag) (state.StorageInstance, error)
 	UnitStorageAttachments(names.UnitTag) ([]state.StorageAttachment, error)
 	GetOfferAccess(offer names.ApplicationOfferTag, user names.UserTag) (permission.Access, error)
+	Resources() (Resources, error)
 }
 
 // BlockChecker defines the block-checking functionality required by
@@ -118,6 +119,13 @@ type Model interface {
 	Owner() names.UserTag
 }
 
+// Resources defines a subset of the functionality provided by the
+// state.Resources type, as required by the application facade. See
+// the state.Resources type for details on the methods.
+type Resources interface {
+	RemovePendingAppResources(string, map[string]string) error
+}
+
 type stateShim struct {
 	*state.State
 }
@@ -197,6 +205,10 @@ func (s stateShim) AllModels() ([]Model, error) {
 		result[i] = stateModelShim{m}
 	}
 	return result, nil
+}
+
+func (s stateShim) Resources() (Resources, error) {
+	return s.State.Resources()
 }
 
 type stateApplicationShim struct {

--- a/apiserver/resources/base_test.go
+++ b/apiserver/resources/base_test.go
@@ -99,8 +99,8 @@ func (s *stubDataStore) ListResources(service string) (resource.ServiceResources
 	return s.ReturnListResources, nil
 }
 
-func (s *stubDataStore) AddPendingResource(service, userID string, chRes charmresource.Resource, r io.Reader) (string, error) {
-	s.stub.AddCall("AddPendingResource", service, userID, chRes, r)
+func (s *stubDataStore) AddPendingResource(service, userID string, chRes charmresource.Resource) (string, error) {
+	s.stub.AddCall("AddPendingResource", service, userID, chRes)
 	if err := s.stub.NextErr(); err != nil {
 		return "", errors.Trace(err)
 	}

--- a/apiserver/resources/facade.go
+++ b/apiserver/resources/facade.go
@@ -4,8 +4,6 @@
 package resources
 
 import (
-	"io"
-
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	"gopkg.in/juju/charm.v6-unstable"
@@ -34,7 +32,7 @@ type Backend interface {
 	// "pending" state. It will stay pending (and unavailable) until
 	// it is resolved. The returned ID is used to identify the pending
 	// resources when resolving it.
-	AddPendingResource(applicationID, userID string, chRes charmresource.Resource, r io.Reader) (string, error)
+	AddPendingResource(applicationID, userID string, chRes charmresource.Resource) (string, error)
 }
 
 // CharmStore exposes the functionality of the charm store as needed here.
@@ -318,8 +316,7 @@ func resolveStoreResource(res charmresource.Resource, storeResources map[string]
 
 func (f Facade) addPendingResource(applicationID string, chRes charmresource.Resource) (pendingID string, err error) {
 	userID := ""
-	var reader io.Reader
-	pendingID, err = f.store.AddPendingResource(applicationID, userID, chRes, reader)
+	pendingID, err = f.store.AddPendingResource(applicationID, userID, chRes)
 	if err != nil {
 		return "", errors.Annotatef(err, "while adding pending resource info for %q", chRes.Name)
 	}

--- a/apiserver/resources/server_addpending_test.go
+++ b/apiserver/resources/server_addpending_test.go
@@ -37,7 +37,7 @@ func (s *AddPendingResourcesSuite) TestNoURL(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.stub.CheckCallNames(c, "AddPendingResource")
-	s.stub.CheckCall(c, 0, "AddPendingResource", "a-application", "", res1.Resource, nil)
+	s.stub.CheckCall(c, 0, "AddPendingResource", "a-application", "", res1.Resource)
 	c.Check(result, jc.DeepEquals, params.AddPendingResourcesResult{
 		PendingIDs: []string{
 			id1,
@@ -74,7 +74,7 @@ func (s *AddPendingResourcesSuite) TestWithURLUpToDate(c *gc.C) {
 	c.Assert(result.Error, gc.IsNil)
 
 	s.stub.CheckCallNames(c, "newCSClient", "ListResources", "AddPendingResource")
-	s.stub.CheckCall(c, 2, "AddPendingResource", "a-application", "", res1.Resource, nil)
+	s.stub.CheckCall(c, 2, "AddPendingResource", "a-application", "", res1.Resource)
 	c.Check(result, jc.DeepEquals, params.AddPendingResourcesResult{
 		PendingIDs: []string{
 			id1,
@@ -113,7 +113,7 @@ func (s *AddPendingResourcesSuite) TestWithURLMismatchComplete(c *gc.C) {
 	c.Assert(result.Error, gc.IsNil)
 
 	s.stub.CheckCallNames(c, "newCSClient", "ListResources", "AddPendingResource")
-	s.stub.CheckCall(c, 2, "AddPendingResource", "a-application", "", res1.Resource, nil)
+	s.stub.CheckCall(c, 2, "AddPendingResource", "a-application", "", res1.Resource)
 	c.Check(result, jc.DeepEquals, params.AddPendingResourcesResult{
 		PendingIDs: []string{
 			id1,
@@ -161,7 +161,7 @@ func (s *AddPendingResourcesSuite) TestWithURLMismatchIncomplete(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.stub.CheckCallNames(c, "newCSClient", "ListResources", "ResourceInfo", "AddPendingResource")
-	s.stub.CheckCall(c, 3, "AddPendingResource", "a-application", "", expected, nil)
+	s.stub.CheckCall(c, 3, "AddPendingResource", "a-application", "", expected)
 	c.Check(result, jc.DeepEquals, params.AddPendingResourcesResult{
 		PendingIDs: []string{
 			id1,
@@ -204,7 +204,7 @@ func (s *AddPendingResourcesSuite) TestWithURLNoRevision(c *gc.C) {
 	c.Assert(result.Error, gc.IsNil)
 
 	s.stub.CheckCallNames(c, "newCSClient", "ListResources", "AddPendingResource")
-	s.stub.CheckCall(c, 2, "AddPendingResource", "a-application", "", res1.Resource, nil)
+	s.stub.CheckCall(c, 2, "AddPendingResource", "a-application", "", res1.Resource)
 	c.Check(result, jc.DeepEquals, params.AddPendingResourcesResult{
 		PendingIDs: []string{
 			id1,
@@ -240,7 +240,7 @@ func (s *AddPendingResourcesSuite) TestLocalCharm(c *gc.C) {
 	c.Assert(result.Error, gc.IsNil)
 
 	s.stub.CheckCallNames(c, "AddPendingResource")
-	s.stub.CheckCall(c, 0, "AddPendingResource", "a-application", "", expected, nil)
+	s.stub.CheckCall(c, 0, "AddPendingResource", "a-application", "", expected)
 	c.Check(result, jc.DeepEquals, params.AddPendingResourcesResult{
 		PendingIDs: []string{
 			id1,
@@ -280,7 +280,7 @@ func (s *AddPendingResourcesSuite) TestWithURLUpload(c *gc.C) {
 	c.Assert(result.Error, gc.IsNil)
 
 	s.stub.CheckCallNames(c, "newCSClient", "ListResources", "AddPendingResource")
-	s.stub.CheckCall(c, 2, "AddPendingResource", "a-application", "", res1.Resource, nil)
+	s.stub.CheckCall(c, 2, "AddPendingResource", "a-application", "", res1.Resource)
 	c.Check(result, jc.DeepEquals, params.AddPendingResourcesResult{
 		PendingIDs: []string{
 			id1,
@@ -316,7 +316,7 @@ func (s *AddPendingResourcesSuite) TestUnknownResource(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.stub.CheckCallNames(c, "newCSClient", "ListResources", "AddPendingResource")
-	s.stub.CheckCall(c, 2, "AddPendingResource", "a-application", "", res1.Resource, nil)
+	s.stub.CheckCall(c, 2, "AddPendingResource", "a-application", "", res1.Resource)
 	c.Check(result, jc.DeepEquals, params.AddPendingResourcesResult{
 		PendingIDs: []string{
 			id1,

--- a/migration/precheck.go
+++ b/migration/precheck.go
@@ -299,15 +299,6 @@ func checkApplications(backend PrecheckBackend) error {
 		if err != nil {
 			return errors.Trace(err)
 		}
-
-		resources, err := backend.ListPendingResources(app.Name())
-		if err != nil {
-			return errors.Annotate(err, "checking resources")
-		}
-		if len(resources) > 0 {
-			resName := resources[0].Name
-			return errors.Errorf("resource %q is pending for application %s", resName, app.Name())
-		}
 	}
 	return nil
 }

--- a/migration/precheck_test.go
+++ b/migration/precheck_test.go
@@ -77,14 +77,13 @@ func (*SourcePrecheckSuite) TestPendingResources(c *gc.C) {
 		resourcetesting.NewResource(c, nil, "blob", "foo", "body").Resource,
 	}
 	err := migration.SourcePrecheck(backend)
-	c.Assert(err, gc.ErrorMatches, `resource "blob" is pending for application foo`)
-}
-
-func (*SourcePrecheckSuite) TestPendingResourcesError(c *gc.C) {
-	backend := newHappyBackend()
-	backend.pendingResourcesErr = errors.New("blam")
-	err := migration.SourcePrecheck(backend)
-	c.Assert(err, gc.ErrorMatches, `checking resources: blam`)
+	// Pending resources shouldn't prevent a migration. If they exist
+	// alongside an application, they're remains of a previous failed
+	// deploy that haven't been cleaned up (see lp:1705730). If they
+	// exist without an application that indicates an impending
+	// application deployment - the migration exporter won't migrate
+	// pending resources.
+	c.Assert(err, jc.ErrorIsNil)
 }
 
 func (*SourcePrecheckSuite) TestImportingModel(c *gc.C) {

--- a/resource/api/client/client.go
+++ b/resource/api/client/client.go
@@ -199,10 +199,9 @@ func newAddPendingResourcesArgs(applicationID string, chID charmstore.CharmID, c
 	return args, nil
 }
 
-// AddPendingResource sends the provided resource blob up to Juju
-// without making it available yet. For example, AddPendingResource()
-// is used before the application is deployed.
-func (c Client) AddPendingResource(applicationID string, res charmresource.Resource, filename string, reader io.ReadSeeker) (pendingID string, err error) {
+// UploadPendingResource sends the provided resource blob up to Juju
+// and makes it available.
+func (c Client) UploadPendingResource(applicationID string, res charmresource.Resource, filename string, reader io.ReadSeeker) (pendingID string, err error) {
 	ids, err := c.AddPendingResources(AddPendingResourcesArgs{
 		ApplicationID: applicationID,
 		Resources:     []charmresource.Resource{res},

--- a/resource/api/client/client_upload_test.go
+++ b/resource/api/client/client_upload_test.go
@@ -123,7 +123,7 @@ func (s *UploadSuite) TestPendingResourceOkay(c *gc.C) {
 	s.facade.pendingIDs = []string{expected}
 	cl := client.NewClient(s.facade, s, s.facade)
 
-	uploadID, err := cl.AddPendingResource("a-application", res[0].Resource, "file.zip", reader)
+	uploadID, err := cl.UploadPendingResource("a-application", res[0].Resource, "file.zip", reader)
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.stub.CheckCallNames(c,
@@ -158,7 +158,7 @@ func (s *UploadSuite) TestPendingResourceNoFile(c *gc.C) {
 	s.facade.pendingIDs = []string{expected}
 	cl := client.NewClient(s.facade, s, s.facade)
 
-	uploadID, err := cl.AddPendingResource("a-application", res[0].Resource, "file.zip", nil)
+	uploadID, err := cl.UploadPendingResource("a-application", res[0].Resource, "file.zip", nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.stub.CheckCallNames(c,
@@ -172,7 +172,7 @@ func (s *UploadSuite) TestPendingResourceBadService(c *gc.C) {
 	s.facade.FacadeCallFn = nil
 	cl := client.NewClient(s.facade, s, s.facade)
 
-	_, err := cl.AddPendingResource("???", res[0].Resource, "file.zip", nil)
+	_, err := cl.UploadPendingResource("???", res[0].Resource, "file.zip", nil)
 
 	c.Check(err, gc.ErrorMatches, `.*invalid application.*`)
 	s.stub.CheckNoCalls(c)
@@ -187,7 +187,7 @@ func (s *UploadSuite) TestPendingResourceBadRequest(c *gc.C) {
 	failure := errors.New("<failure>")
 	s.stub.SetErrors(nil, failure)
 
-	_, err := cl.AddPendingResource("a-application", chRes, "file.zip", reader)
+	_, err := cl.UploadPendingResource("a-application", chRes, "file.zip", reader)
 
 	c.Check(errors.Cause(err), gc.Equals, failure)
 	s.stub.CheckCallNames(c, "FacadeCall", "Read")
@@ -202,7 +202,7 @@ func (s *UploadSuite) TestPendingResourceRequestFailed(c *gc.C) {
 	failure := errors.New("<failure>")
 	s.stub.SetErrors(nil, nil, nil, nil, failure)
 
-	_, err := cl.AddPendingResource("a-application", res[0].Resource, "file.zip", reader)
+	_, err := cl.UploadPendingResource("a-application", res[0].Resource, "file.zip", reader)
 
 	c.Check(errors.Cause(err), gc.Equals, failure)
 	s.stub.CheckCallNames(c,

--- a/resource/cmd/deploy.go
+++ b/resource/cmd/deploy.go
@@ -21,8 +21,8 @@ type DeployClient interface {
 	// AddPendingResources adds pending metadata for store-based resources.
 	AddPendingResources(applicationID string, chID charmstore.CharmID, csMac *macaroon.Macaroon, resources []charmresource.Resource) (ids []string, err error)
 
-	// AddPendingResource uploads data and metadata for a pending resource for the given application.
-	AddPendingResource(applicationID string, resource charmresource.Resource, filename string, r io.ReadSeeker) (id string, err error)
+	// UploadPendingResource uploads data and metadata for a pending resource for the given application.
+	UploadPendingResource(applicationID string, resource charmresource.Resource, filename string, r io.ReadSeeker) (id string, err error)
 }
 
 // DeployResourcesArgs holds the arguments to DeployResources().
@@ -188,7 +188,7 @@ func (d deployUploader) uploadFile(resourcename, filename string) (id string, er
 		Origin: charmresource.OriginUpload,
 	}
 
-	id, err = d.client.AddPendingResource(d.applicationID, res, filename, f)
+	id, err = d.client.UploadPendingResource(d.applicationID, res, filename, f)
 	if err != nil {
 		return "", errors.Trace(err)
 	}

--- a/resource/cmd/deploy_test.go
+++ b/resource/cmd/deploy_test.go
@@ -119,7 +119,7 @@ func (s DeploySuite) TestUploadFilesOnly(c *gc.C) {
 		"store":  "id-store",
 	})
 
-	s.stub.CheckCallNames(c, "Stat", "AddPendingResources", "Open", "AddPendingResource")
+	s.stub.CheckCallNames(c, "Stat", "AddPendingResources", "Open", "UploadPendingResource")
 	expectedStore := []charmresource.Resource{
 		{
 			Meta:     du.resources["store"],
@@ -134,7 +134,7 @@ func (s DeploySuite) TestUploadFilesOnly(c *gc.C) {
 		Meta:   du.resources["upload"],
 		Origin: charmresource.OriginUpload,
 	}
-	s.stub.CheckCall(c, 3, "AddPendingResource", "mysql", expectedUpload, "foobar.txt", deps.ReadSeekCloser)
+	s.stub.CheckCall(c, 3, "UploadPendingResource", "mysql", expectedUpload, "foobar.txt", deps.ReadSeekCloser)
 }
 
 func (s DeploySuite) TestUploadRevisionsOnly(c *gc.C) {
@@ -230,7 +230,7 @@ func (s DeploySuite) TestUploadFilesAndRevisions(c *gc.C) {
 		"store":  "id-store",
 	})
 
-	s.stub.CheckCallNames(c, "Stat", "AddPendingResources", "Open", "AddPendingResource")
+	s.stub.CheckCallNames(c, "Stat", "AddPendingResources", "Open", "UploadPendingResource")
 	expectedStore := []charmresource.Resource{
 		{
 			Meta:     du.resources["store"],
@@ -245,7 +245,7 @@ func (s DeploySuite) TestUploadFilesAndRevisions(c *gc.C) {
 		Meta:   du.resources["upload"],
 		Origin: charmresource.OriginUpload,
 	}
-	s.stub.CheckCall(c, 3, "AddPendingResource", "mysql", expectedUpload, "foobar.txt", deps.ReadSeekCloser)
+	s.stub.CheckCall(c, 3, "UploadPendingResource", "mysql", expectedUpload, "foobar.txt", deps.ReadSeekCloser)
 }
 
 func (s DeploySuite) TestUploadUnexpectedResourceFile(c *gc.C) {
@@ -340,8 +340,8 @@ func (s uploadDeps) AddPendingResources(applicationID string, charmID charmstore
 	return ids, nil
 }
 
-func (s uploadDeps) AddPendingResource(applicationID string, resource charmresource.Resource, filename string, r io.ReadSeeker) (id string, err error) {
-	s.stub.AddCall("AddPendingResource", applicationID, resource, filename, r)
+func (s uploadDeps) UploadPendingResource(applicationID string, resource charmresource.Resource, filename string, r io.ReadSeeker) (id string, err error) {
+	s.stub.AddCall("UploadPendingResource", applicationID, resource, filename, r)
 	if err := s.stub.NextErr(); err != nil {
 		return "", err
 	}

--- a/resource/opened.go
+++ b/resource/opened.go
@@ -5,39 +5,9 @@ package resource
 
 import (
 	"io"
-	"strings"
 
 	"github.com/juju/errors"
 )
-
-type multiError []error
-
-func (m multiError) Error() string {
-	messages := make([]string, len(m))
-	for i, err := range m {
-		messages[i] = err.Error()
-	}
-	return strings.Join(messages, ", and also ")
-}
-
-// CombineErrors converts a set of errors (which might be nil) into
-// one. If there are no errors, this returns an untyped nil, and if
-// there's one error it's passed through directly.
-func CombineErrors(errs ...error) error {
-	merr := make(multiError, 0, len(errs))
-	for _, err := range errs {
-		if err != nil {
-			merr = append(merr, err)
-		}
-	}
-	if len(merr) == 0 {
-		return nil
-	}
-	if len(merr) == 1 {
-		return merr[0]
-	}
-	return merr
-}
 
 // Opened provides both the resource info and content.
 type Opened struct {
@@ -55,9 +25,7 @@ func (o Opened) Content() Content {
 }
 
 func (o Opened) Close() error {
-	var err1 error
-	err2 := errors.Trace(o.ReadCloser.Close())
-	return CombineErrors(err1, err2)
+	return errors.Trace(o.ReadCloser.Close())
 }
 
 // Opener exposes the functionality for opening a resource.

--- a/state/resources.go
+++ b/state/resources.go
@@ -53,6 +53,11 @@ type Resources interface {
 	// service to the provided values.
 	SetCharmStoreResources(applicationID string, info []charmresource.Resource, lastPolled time.Time) error
 
+	// RemovePendingAppResources removes any pending application-level
+	// resources for the named application. This is used to clean up
+	// resources for a failed application deployment.
+	RemovePendingAppResources(applicationID string, pendingIDs map[string]string) error
+
 	// TODO(ericsnow) Move this down to ResourcesPersistence.
 
 	// NewResolvePendingResourcesOps generates mongo transaction operations

--- a/state/resources.go
+++ b/state/resources.go
@@ -26,7 +26,7 @@ type Resources interface {
 	// "pending" state. It will stay pending (and unavailable) until
 	// it is resolved. The returned ID is used to identify the pending
 	// resources when resolving it.
-	AddPendingResource(applicationID, userID string, chRes charmresource.Resource, r io.Reader) (string, error)
+	AddPendingResource(applicationID, userID string, chRes charmresource.Resource) (string, error)
 
 	// GetResource returns the identified resource.
 	GetResource(applicationID, name string) (resource.Resource, error)

--- a/state/resources_persistence_test.go
+++ b/state/resources_persistence_test.go
@@ -596,6 +596,32 @@ func (s *ResourcePersistenceSuite) TestRemoveResourcesCleansUpUniqueStoragePaths
 	c.Assert(cleanups[0].Insert.(*cleanupDoc).Prefix, gc.Equals, appResource.storagePath)
 }
 
+func (s *ResourcePersistenceSuite) TestRemovePendingAppResources(c *gc.C) {
+	_, appDoc1 := newPersistenceResource(c, "appa", "yipyip")
+	appDoc1.DocID += "#pending-freewifi"
+	appDoc1.PendingID = "freewifi"
+	appResource2, appDoc2 := newPersistenceResource(c, "appa", "momo")
+	appDoc2.DocID += "#pending-parallax"
+	appDoc2.PendingID = "parallax"
+	_, unitDoc := newPersistenceUnitResource(c, "appa", "appa/0", "momo")
+	unitDoc.DocID += "#pending-parallax"
+	unitDoc.PendingID = "parallax"
+	s.base.ReturnAll = []resourceDoc{appDoc1, appDoc2, unitDoc}
+	p := NewResourcePersistence(s.base)
+
+	ops, err := p.NewRemovePendingAppResourcesOps("appa", map[string]string{"momo": "parallax"})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(ops, gc.HasLen, 2)
+	c.Assert(ops[0], gc.DeepEquals, txn.Op{
+		C:      resourcesC,
+		Id:     appDoc2.DocID,
+		Remove: true,
+	})
+	c.Assert(ops[1].Insert, gc.Not(gc.IsNil))
+	c.Assert(ops[1].Insert.(*cleanupDoc).Kind, gc.Equals, cleanupResourceBlob)
+	c.Assert(ops[1].Insert.(*cleanupDoc).Prefix, gc.Equals, appResource2.storagePath)
+}
+
 func newPersistenceUnitResources(c *gc.C, serviceID, unitID string, resources []resource.Resource) ([]resource.Resource, []resourceDoc) {
 	var unitResources []resource.Resource
 	var docs []resourceDoc

--- a/state/resources_state_resource.go
+++ b/state/resources_state_resource.go
@@ -55,6 +55,11 @@ type resourcePersistence interface {
 	// NewResolvePendingResourceOps generates mongo transaction operations
 	// to set the identified resource as active.
 	NewResolvePendingResourceOps(resID, pendingID string) ([]txn.Op, error)
+
+	// RemovePendingAppResources removes any pending application-level
+	// resources for an application. This is typically used in cleanup
+	// for a failed application deployment.
+	RemovePendingAppResources(applicationID string, pendingIDs map[string]string) error
 }
 
 type resourceStorage interface {
@@ -117,6 +122,13 @@ func (st resourceState) ListPendingResources(applicationID string) ([]resource.R
 		return nil, errors.Trace(err)
 	}
 	return resources, err
+}
+
+// RemovePendingResources removes the pending application-level
+// resources for a specific application, normally in the case that the
+// application couln't be deployed.
+func (st resourceState) RemovePendingAppResources(applicationID string, pendingIDs map[string]string) error {
+	return errors.Trace(st.persist.RemovePendingAppResources(applicationID, pendingIDs))
 }
 
 // GetResource returns the resource data for the identified resource.

--- a/state/resources_state_resource.go
+++ b/state/resources_state_resource.go
@@ -193,14 +193,14 @@ func (st resourceState) SetUnitResource(unitName, userID string, chRes charmreso
 }
 
 // AddPendingResource stores the resource in the Juju model.
-func (st resourceState) AddPendingResource(applicationID, userID string, chRes charmresource.Resource, r io.Reader) (pendingID string, err error) {
+func (st resourceState) AddPendingResource(applicationID, userID string, chRes charmresource.Resource) (pendingID string, err error) {
 	pendingID, err = newPendingID()
 	if err != nil {
 		return "", errors.Annotate(err, "could not generate resource ID")
 	}
 	logger.Debugf("adding pending resource %q for application %q (ID: %s)", chRes.Name, applicationID, pendingID)
 
-	if _, err := st.setResource(pendingID, applicationID, userID, chRes, r); err != nil {
+	if _, err := st.setResource(pendingID, applicationID, userID, chRes, nil); err != nil {
 		return "", errors.Trace(err)
 	}
 

--- a/state/state.go
+++ b/state/state.go
@@ -992,6 +992,7 @@ type AddApplicationArgs struct {
 // they will be created automatically.
 func (st *State) AddApplication(args AddApplicationArgs) (_ *Application, err error) {
 	defer errors.DeferredAnnotatef(&err, "cannot add application %q", args.Name)
+
 	// Sanity checks.
 	if !names.IsValidApplication(args.Name) {
 		return nil, errors.Errorf("invalid name")

--- a/testing/factory/factory.go
+++ b/testing/factory/factory.go
@@ -431,7 +431,7 @@ func (factory *Factory) MakeApplication(c *gc.C, params *ApplicationParams) *sta
 		pendingID, err := rSt.AddPendingResource(params.Name, "", charmresource.Resource{
 			Meta:   res,
 			Origin: charmresource.OriginUpload,
-		}, nil)
+		})
 		c.Assert(err, jc.ErrorIsNil)
 		resourceMap[name] = pendingID
 	}


### PR DESCRIPTION
## Description of change

The deploy command creates pending resources for an application before creating the application, and links them to the application using pending IDs. These are used to resolve the resources during 
application creation. If the application creation fails for some reason (like validation), these pending resources need to be removed.

Since there is validation at the API level as well as in `state.AddApplication` the cleanup needs to be done in the API code.

The pending resources were causing migration prechecks to fail. I've removed the check - pending resources for an application that exists indicate that there was a previous failed deployment, but that shouldn't prevent migration. The pending resources won't be migrated.

Includes some driveby changes to make some of the resources code a little easier to follow.
* Distinguish adding a pending charmstore resource and uploading a local pending resource.
* Remove an `io.Reader` argument that is only ever passed nil.
* Remove some vestigial code left from an earlier refactoring.

## QA steps

* Create a new model.
* Deploy an application that uses resources (e.g. ~cmars/mattermost) with options that will cause the deployment to fail - using `--to <nonexistent machine>` works.
* Check that there are no pending resources in the resources collection: `db.resources.find().pretty()` should return nothing.

## Bug reference

Fixes https://bugs.launchpad.net/juju/+bug/1705730
