### PR TITLE
network-get hook tool becomes relation aware

### DIFF
--- a/api/facadeversions.go
+++ b/api/facadeversions.go
@@ -88,7 +88,7 @@ var facadeVersions = map[string]int{
 	"Subnets":                      2,
 	"Undertaker":                   1,
 	"UnitAssigner":                 1,
-	"Uniter":                       6,
+	"Uniter":                       7,
 	"Upgrader":                     1,
 	"UserManager":                  2,
 	"VolumeAttachmentsWatcher":     2,

--- a/api/uniter/relationunit.go
+++ b/api/uniter/relationunit.go
@@ -40,16 +40,6 @@ func (ru *RelationUnit) Endpoint() Endpoint {
 	return ru.endpoint
 }
 
-// PrivateAddress returns the private address of the unit and whether
-// it is valid.
-//
-// NOTE: This differs from state.RelationUnit.PrivateAddress() by
-// returning an error instead of a bool, because it needs to make an
-// API call.
-func (ru *RelationUnit) PrivateAddress() (string, error) {
-	return ru.unit.PrivateAddress()
-}
-
 // EnterScope ensures that the unit has entered its scope in the relation.
 // When the unit has already entered its relation scope, EnterScope will report
 // success but make no changes to state.

--- a/api/uniter/relationunit_test.go
+++ b/api/uniter/relationunit_test.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/juju/juju/api/uniter"
 	"github.com/juju/juju/apiserver/params"
-	"github.com/juju/juju/network"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/watcher/watchertest"
 )
@@ -88,23 +87,6 @@ func (s *relationUnitSuite) TestEndpoint(c *gc.C) {
 			Scope:     "global",
 		},
 	})
-}
-
-func (s *relationUnitSuite) TestPrivateAddress(c *gc.C) {
-	_, apiRelUnit := s.getRelationUnits(c)
-
-	// Try getting it first without an address set.
-	address, err := apiRelUnit.PrivateAddress()
-	c.Assert(err, gc.ErrorMatches, `"unit-wordpress-0" has no private address set`)
-
-	// Set an address and try again.
-	err = s.wordpressMachine.SetProviderAddresses(
-		network.NewScopedAddress("1.2.3.4", network.ScopeCloudLocal),
-	)
-	c.Assert(err, jc.ErrorIsNil)
-	address, err = apiRelUnit.PrivateAddress()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(address, gc.Equals, "1.2.3.4")
 }
 
 func (s *relationUnitSuite) TestEnterScopeSuccessfully(c *gc.C) {

--- a/api/uniter/storage_test.go
+++ b/api/uniter/storage_test.go
@@ -21,7 +21,7 @@ type storageSuite struct {
 	coretesting.BaseSuite
 }
 
-const expectedVersion = 6
+const expectedVersion = 7
 
 func (s *storageSuite) TestUnitStorageAttachments(c *gc.C) {
 	storageAttachmentIds := []params.StorageAttachmentId{{

--- a/api/uniter/unit.go
+++ b/api/uniter/unit.go
@@ -740,39 +740,13 @@ func (u *Unit) AddStorage(constraints map[string][]params.StorageConstraints) er
 	return results.Combine()
 }
 
-// NetworkConfig requests network config information for the unit and the given
-// bindingName.
-func (u *Unit) NetworkConfig(bindingName string) ([]params.NetworkConfig, error) {
-	var results params.UnitNetworkConfigResults
-	args := params.UnitsNetworkConfig{
-		Args: []params.UnitNetworkConfig{{
-			BindingName: bindingName,
-			UnitTag:     u.tag.String(),
-		}},
-	}
-
-	err := u.st.facade.FacadeCall("NetworkConfig", args, &results)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-
-	if len(results.Results) != 1 {
-		return nil, fmt.Errorf("expected 1 result, got %d", len(results.Results))
-	}
-
-	result := results.Results[0]
-	if result.Error != nil {
-		return nil, result.Error
-	}
-
-	return result.Config, nil
-}
-
-func (u *Unit) NetworkInfo(bindings []string) (map[string]params.NetworkInfoResult, error) {
+// NetworkInfo returns network interfaces/addresses for specified bindings.
+func (u *Unit) NetworkInfo(bindings []string, relationId *int) (map[string]params.NetworkInfoResult, error) {
 	var results params.NetworkInfoResults
 	args := params.NetworkInfoParams{
-		Unit:     u.tag.String(),
-		Bindings: bindings,
+		Unit:       u.tag.String(),
+		Bindings:   bindings,
+		RelationId: relationId,
 	}
 
 	err := u.st.facade.FacadeCall("NetworkInfo", args, &results)

--- a/api/uniter/uniter.go
+++ b/api/uniter/uniter.go
@@ -69,12 +69,12 @@ func newStateForVersionFn(version int) func(base.APICaller, names.UnitTag) *Stat
 	}
 }
 
-// newStateV6 creates a new client-side Uniter facade, version 6
-var newStateV6 = newStateForVersionFn(6)
+// newStateV7 creates a new client-side Uniter facade, version 7
+var newStateV7 = newStateForVersionFn(7)
 
 // NewState creates a new client-side Uniter facade.
 // Defined like this to allow patching during tests.
-var NewState = newStateV6
+var NewState = newStateV7
 
 // BestAPIVersion returns the API version that we were able to
 // determine is supported by both the client and the API Server.

--- a/api/uniter/unitstorage_test.go
+++ b/api/uniter/unitstorage_test.go
@@ -21,7 +21,7 @@ type unitStorageSuite struct {
 
 var _ = gc.Suite(&unitStorageSuite{})
 
-const expectedAPIVersion = 6
+const expectedAPIVersion = 7
 
 func (s *unitStorageSuite) createTestUnit(c *gc.C, t string, apiCaller basetesting.APICallerFunc) *uniter.Unit {
 	tag := names.NewUnitTag(t)

--- a/apiserver/allfacades.go
+++ b/apiserver/allfacades.go
@@ -231,7 +231,8 @@ func AllFacades() *facade.Registry {
 
 	reg("Uniter", 4, uniter.NewUniterAPIV4)
 	reg("Uniter", 5, uniter.NewUniterAPIV5)
-	reg("Uniter", 6, uniter.NewUniterAPI)
+	reg("Uniter", 6, uniter.NewUniterAPIV6)
+	reg("Uniter", 7, uniter.NewUniterAPI)
 
 	reg("Upgrader", 1, upgrader.NewUpgraderFacade)
 	reg("UserManager", 2, usermanager.NewUserManagerAPI)

--- a/apiserver/params/network.go
+++ b/apiserver/params/network.go
@@ -389,7 +389,7 @@ func NetworkHostsPorts(hpm [][]HostPort) [][]network.HostPort {
 
 // TODO (wpk) Uniter.NetworkConfig API is obsolete, use NetworkInfo instead
 // UnitsNetworkConfig holds the parameters for calling Uniter.NetworkConfig()
-// API.
+// API. We need to retain until V4 of the Uniter API is removed.
 type UnitsNetworkConfig struct {
 	Args []UnitNetworkConfig `json:"args"`
 }
@@ -699,6 +699,7 @@ type NetworkInfoResults struct {
 
 // NetworkInfoParams holds a name of the unit and list of bindings for which we want to get NetworkInfos.
 type NetworkInfoParams struct {
-	Unit     string   `json:"unit"`
-	Bindings []string `json:"bindings"`
+	Unit       string   `json:"unit"`
+	RelationId *int     `json:"relation-id,omitempty"`
+	Bindings   []string `json:"bindings"`
 }

--- a/state/relationunit.go
+++ b/state/relationunit.go
@@ -469,13 +469,13 @@ func (ru *RelationUnit) ReadSettings(uname string) (m map[string]interface{}, er
 	return node.Map(), nil
 }
 
-// SettingsAddress returns the address that should be set as
+// IngressAddress returns the address that should be set as
 // `private-address` in the settings for the this unit in the context
 // of this relation. Generally this will be the cloud-local address of
 // the unit, but if this is a cross-model relation then it will be the
 // public address. If this is cross-model and there's no public
 // address for the unit, return an error.
-func (ru *RelationUnit) SettingsAddress() (network.Address, error) {
+func (ru *RelationUnit) IngressAddress() (network.Address, error) {
 	unit, err := ru.st.Unit(ru.unitName)
 	if err != nil {
 		return network.Address{}, errors.Trace(err)

--- a/state/relationunit_test.go
+++ b/state/relationunit_test.go
@@ -811,7 +811,7 @@ func (s *RelationUnitSuite) assertNoScopeChange(c *gc.C, ws ...*state.RelationSc
 	}
 }
 
-func (s *RelationUnitSuite) TestSettingsAddress(c *gc.C) {
+func (s *RelationUnitSuite) TestIngressAddress(c *gc.C) {
 	prr := newProReqRelation(c, &s.ConnSuite, charm.ScopeGlobal)
 	err := prr.pu0.AssignToNewMachine()
 	c.Assert(err, jc.ErrorIsNil)
@@ -825,13 +825,13 @@ func (s *RelationUnitSuite) TestSettingsAddress(c *gc.C) {
 		network.NewScopedAddress("4.3.2.1", network.ScopePublic),
 	)
 
-	address, err := prr.pru0.SettingsAddress()
+	address, err := prr.pru0.IngressAddress()
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Assert(address, gc.DeepEquals, network.NewScopedAddress("1.2.3.4", network.ScopeCloudLocal))
 }
 
-func (s *RelationUnitSuite) TestSettingsAddressRemoteRelation(c *gc.C) {
+func (s *RelationUnitSuite) TestIngressAddressRemoteRelation(c *gc.C) {
 	prr := newRemoteProReqRelation(c, &s.ConnSuite)
 	err := prr.ru0.AssignToNewMachine()
 	c.Assert(err, jc.ErrorIsNil)
@@ -845,13 +845,13 @@ func (s *RelationUnitSuite) TestSettingsAddressRemoteRelation(c *gc.C) {
 		network.NewScopedAddress("4.3.2.1", network.ScopePublic),
 	)
 
-	address, err := prr.rru0.SettingsAddress()
+	address, err := prr.rru0.IngressAddress()
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Assert(address, gc.DeepEquals, network.NewScopedAddress("4.3.2.1", network.ScopePublic))
 }
 
-func (s *RelationUnitSuite) TestSettingsAddressRemoteRelationNoPublicAddr(c *gc.C) {
+func (s *RelationUnitSuite) TestIngressAddressRemoteRelationNoPublicAddr(c *gc.C) {
 	prr := newRemoteProReqRelation(c, &s.ConnSuite)
 	err := prr.ru0.AssignToNewMachine()
 	c.Assert(err, jc.ErrorIsNil)
@@ -864,12 +864,12 @@ func (s *RelationUnitSuite) TestSettingsAddressRemoteRelationNoPublicAddr(c *gc.
 		network.NewScopedAddress("1.2.3.4", network.ScopeCloudLocal),
 	)
 
-	address, err := prr.rru0.SettingsAddress()
+	address, err := prr.rru0.IngressAddress()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(address, gc.DeepEquals, network.NewScopedAddress("1.2.3.4", network.ScopeCloudLocal))
 }
 
-func (s *RelationUnitSuite) TestSettingsAddressRemoteRelationEgressCidrs(c *gc.C) {
+func (s *RelationUnitSuite) TestIngressAddressRemoteRelationEgressCidrs(c *gc.C) {
 	err := s.State.UpdateModelConfig(map[string]interface{}{"egress-cidrs": "192.168.1.0/32"}, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	prr := newRemoteProReqRelation(c, &s.ConnSuite)
@@ -885,7 +885,7 @@ func (s *RelationUnitSuite) TestSettingsAddressRemoteRelationEgressCidrs(c *gc.C
 		network.NewScopedAddress("4.3.2.1", network.ScopePublic),
 	)
 
-	address, err := prr.rru0.SettingsAddress()
+	address, err := prr.rru0.IngressAddress()
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Assert(address, gc.DeepEquals, network.NewScopedAddress("192.168.1.0", network.ScopePublic))

--- a/state/unit.go
+++ b/state/unit.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/juju/juju/constraints"
 	"github.com/juju/juju/core/actions"
+	"github.com/juju/juju/environs"
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/state/presence"
@@ -2561,6 +2562,7 @@ func (g *HistoryGetter) StatusHistory(filter status.StatusHistoryFilter) ([]stat
 	return statusHistory(args)
 }
 
+// GetSpaceForBinding returns the space name associated with the specified endpoint.
 func (u *Unit) GetSpaceForBinding(bindingName string) (string, error) {
 	app, err := u.Application()
 	if err != nil {
@@ -2574,10 +2576,10 @@ func (u *Unit) GetSpaceForBinding(bindingName string) (string, error) {
 	boundSpace, known := bindings[bindingName]
 	if !known {
 		// If default binding is not explicitly defined we'll use default space
-		if bindingName == "" {
-			return "", nil
+		if bindingName == environs.DefaultSpaceName {
+			return environs.DefaultSpaceName, nil
 		}
-		return "", errors.Errorf("binding name %q not defined by the unit's charm", bindingName)
+		return "", errors.NewNotValid(nil, fmt.Sprintf("binding name %q not defined by the unit's charm", bindingName))
 	}
 	return boundSpace, nil
 }

--- a/worker/uniter/relation/relations_test.go
+++ b/worker/uniter/relation/relations_test.go
@@ -78,7 +78,7 @@ func mockAPICaller(c *gc.C, callNumber *int32, apiCalls ...apiCall) apitesting.A
 			c.Check(index < len(apiCalls), jc.IsTrue)
 			call := apiCalls[index]
 			c.Logf("request %d, %s", index, request)
-			c.Check(version, gc.Equals, 6)
+			c.Check(version, gc.Equals, 7)
 			c.Check(id, gc.Equals, "")
 			c.Check(request, gc.Equals, call.request)
 			c.Check(arg, jc.DeepEquals, call.args)

--- a/worker/uniter/runner/context/context.go
+++ b/worker/uniter/runner/context/context.go
@@ -795,11 +795,6 @@ func (ctx *HookContext) killCharmHook() error {
 	}
 }
 
-// NetworkConfig returns the network config for the given bindingName.
-func (ctx *HookContext) NetworkConfig(bindingName string) ([]params.NetworkConfig, error) {
-	return ctx.unit.NetworkConfig(bindingName)
-}
-
 // UnitWorkloadVersion returns the version of the workload reported by
 // the current unit.
 func (ctx *HookContext) UnitWorkloadVersion() (string, error) {
@@ -839,5 +834,9 @@ func (ctx *HookContext) SetUnitWorkloadVersion(version string) error {
 
 // NetworkInfo returns the network info for the given bindingNames.
 func (ctx *HookContext) NetworkInfo(bindingNames []string) (map[string]params.NetworkInfoResult, error) {
-	return ctx.unit.NetworkInfo(bindingNames)
+	var relId *int
+	if ctx.relationId != -1 {
+		relId = &ctx.relationId
+	}
+	return ctx.unit.NetworkInfo(bindingNames, relId)
 }

--- a/worker/uniter/runner/context/context_test.go
+++ b/worker/uniter/runner/context/context_test.go
@@ -96,7 +96,7 @@ func (s *InterfaceSuite) TestUnitNetworkInfo(c *gc.C) {
 	netInfo, err := ctx.NetworkInfo([]string{"unknown"})
 	c.Check(err, jc.ErrorIsNil)
 	c.Check(netInfo, gc.DeepEquals, map[string]params.NetworkInfoResult{
-		"unknown": params.NetworkInfoResult{
+		"unknown": {
 			Error: &params.Error{
 				Message: "binding name \"unknown\" not defined by the unit's charm",
 			},
@@ -395,7 +395,7 @@ func (s *InterfaceSuite) TestRequestRebootNowNoProcess(c *gc.C) {
 
 func (s *InterfaceSuite) TestStorageAddConstraints(c *gc.C) {
 	expected := map[string][]params.StorageConstraints{
-		"data": []params.StorageConstraints{
+		"data": {
 			params.StorageConstraints{},
 		},
 	}
@@ -409,7 +409,7 @@ var two = uint64(2)
 
 func (s *InterfaceSuite) TestStorageAddConstraintsSameStorage(c *gc.C) {
 	expected := map[string][]params.StorageConstraints{
-		"data": []params.StorageConstraints{
+		"data": {
 			params.StorageConstraints{},
 			params.StorageConstraints{Count: &two},
 		},
@@ -423,8 +423,8 @@ func (s *InterfaceSuite) TestStorageAddConstraintsSameStorage(c *gc.C) {
 
 func (s *InterfaceSuite) TestStorageAddConstraintsDifferentStorage(c *gc.C) {
 	expected := map[string][]params.StorageConstraints{
-		"data": []params.StorageConstraints{params.StorageConstraints{}},
-		"diff": []params.StorageConstraints{
+		"data": {params.StorageConstraints{}},
+		"diff": {
 			params.StorageConstraints{Count: &two}},
 	}
 

--- a/worker/uniter/runner/jujuc/restricted.go
+++ b/worker/uniter/runner/jujuc/restricted.go
@@ -64,11 +64,6 @@ func (*RestrictedContext) ClosePorts(protocol string, fromPort, toPort int) erro
 // OpenedPorts implements jujuc.Context.
 func (*RestrictedContext) OpenedPorts() []network.PortRange { return nil }
 
-// NetworkConfig implements jujuc.Context.
-func (*RestrictedContext) NetworkConfig(bindingName string) ([]params.NetworkConfig, error) {
-	return nil, ErrRestrictedContext
-}
-
 // NetworkInfo implements jujuc.Context.
 func (*RestrictedContext) NetworkInfo(bindingNames []string) (map[string]params.NetworkInfoResult, error) {
 	return map[string]params.NetworkInfoResult{}, ErrRestrictedContext


### PR DESCRIPTION
## Description of change

The time has come to make the network-get hook tool relation aware. If network-get is called in the context of a relation, and the relation endpoint is not bound to a space, or is bound to the default space, the address returned is in the context of that relation, and may be either a cloud local or public address depending on whether it is a cross model relation or not.

We also rename relation unit SettingsAddress() to IngressAddress() to better reflect its purpose. And we add a new relation settings "ingress-address" value which is preferred over "private-address".
Some old code is also deleted.

As a drive by, remove old code, and add a missing unit test for NetworkInfo.

## QA steps

Charms will need to be updated to stop calling unit-get "private-address" in order to benefit from this PR. For now, just do a smoke test.

## Bug reference

Partially fixes:
https://bugs.launchpad.net/juju/+bug/1711238
