### PR TITLE
worker/undertaker: don't ignore all errors

### DIFF
--- a/api/controller/legacy_test.go
+++ b/api/controller/legacy_test.go
@@ -99,7 +99,7 @@ func (s *legacySuite) TestDestroyController(c *gc.C) {
 	sysManager := s.OpenAPI(c)
 	defer sysManager.Close()
 	err := sysManager.DestroyController(false)
-	c.Assert(err, gc.ErrorMatches, `failed to destroy model: hosting 1 other models \(controller has hosted models\)`)
+	c.Assert(err, gc.ErrorMatches, `failed to destroy model: hosting 1 other model \(controller has hosted models\)`)
 }
 
 func (s *legacySuite) TestListBlockedModels(c *gc.C) {

--- a/apiserver/common/errors.go
+++ b/apiserver/common/errors.go
@@ -217,6 +217,8 @@ func ServerError(err error) *params.Error {
 		code = params.CodeHasAssignedUnits
 	case state.IsHasHostedModelsError(err):
 		code = params.CodeHasHostedModels
+	case state.IsModelNotEmptyError(err):
+		code = params.CodeModelNotEmpty
 	case isNoAddressSetError(err):
 		code = params.CodeNoAddressSet
 	case errors.IsNotProvisioned(err):
@@ -307,6 +309,8 @@ func RestoreError(err error) error {
 		// ...by parsing msg?
 		return err
 	case params.IsCodeHasHostedModels(err):
+		return err
+	case params.IsCodeModelNotEmpty(err):
 		return err
 	case params.IsCodeNoAddressSet(err):
 		// TODO(ericsnow) Handle isNoAddressSetError here.

--- a/apiserver/common/modeldestroy_test.go
+++ b/apiserver/common/modeldestroy_test.go
@@ -307,7 +307,7 @@ func (s *destroyTwoModelsSuite) TestDestroyControllerAfterNonControllerIsDestroy
 	otherFactory.MakeMachineNested(c, m.Id(), nil)
 
 	err := common.DestroyModel(s.modelManager, s.State.ModelTag())
-	c.Assert(err, gc.ErrorMatches, "failed to destroy model: hosting 1 other models")
+	c.Assert(err, gc.ErrorMatches, "failed to destroy model: hosting 1 other model")
 
 	needsCleanup, err := s.State.NeedsCleanup()
 	c.Assert(err, jc.ErrorIsNil)
@@ -319,7 +319,7 @@ func (s *destroyTwoModelsSuite) TestDestroyControllerAfterNonControllerIsDestroy
 	// The hosted model is Dying, not Dead; we cannot destroy
 	// the controller model until all hosted models are Dead.
 	err = common.DestroyModel(s.modelManager, s.State.ModelTag())
-	c.Assert(err, gc.ErrorMatches, "failed to destroy model: hosting 1 other models")
+	c.Assert(err, gc.ErrorMatches, "failed to destroy model: hosting 1 other model")
 
 	// Continue to take the hosted model down so we can
 	// destroy the controller model.
@@ -333,6 +333,8 @@ func (s *destroyTwoModelsSuite) TestDestroyControllerAfterNonControllerIsDestroy
 	otherEnv, err := s.otherState.Model()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(otherEnv.Life(), gc.Equals, state.Dead)
+	err = s.otherState.RemoveAllModelDocs()
+	c.Assert(err, jc.ErrorIsNil)
 
 	env, err := s.State.Model()
 	c.Assert(err, jc.ErrorIsNil)

--- a/apiserver/params/apierror.go
+++ b/apiserver/params/apierror.go
@@ -75,6 +75,7 @@ const (
 	CodeDead                      = "dead"
 	CodeHasAssignedUnits          = "machine has assigned units"
 	CodeHasHostedModels           = "controller has hosted models"
+	CodeModelNotEmpty             = "model not empty"
 	CodeMachineHasAttachedStorage = "machine has attached storage"
 	CodeNotProvisioned            = "not provisioned"
 	CodeNoAddressSet              = "no address set"
@@ -182,6 +183,10 @@ func IsCodeHasAssignedUnits(err error) bool {
 
 func IsCodeHasHostedModels(err error) bool {
 	return ErrCode(err) == CodeHasHostedModels
+}
+
+func IsCodeModelNotEmpty(err error) bool {
+	return ErrCode(err) == CodeModelNotEmpty
 }
 
 func IsCodeMachineHasAttachedStorage(err error) bool {

--- a/featuretests/api_undertaker_test.go
+++ b/featuretests/api_undertaker_test.go
@@ -80,7 +80,7 @@ func (s *undertakerSuite) TestStateProcessDyingEnviron(c *gc.C) {
 	c.Assert(env.Life(), gc.Equals, state.Dying)
 
 	err = undertakerClient.ProcessDyingModel()
-	c.Assert(err, gc.ErrorMatches, `model not empty, found 1 machine\(s\)`)
+	c.Assert(err, gc.ErrorMatches, `model not empty, found 1 machine \(model not empty\)`)
 }
 
 func (s *undertakerSuite) TestStateRemoveEnvironFails(c *gc.C) {

--- a/state/model.go
+++ b/state/model.go
@@ -5,6 +5,7 @@ package state
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/juju/errors"
 	jujutxn "github.com/juju/txn"
@@ -898,7 +899,11 @@ var errModelNotAlive = errors.New("model is no longer alive")
 type hasHostedModelsError int
 
 func (e hasHostedModelsError) Error() string {
-	return fmt.Sprintf("hosting %d other models", e)
+	s := ""
+	if e != 1 {
+		s = "s"
+	}
+	return fmt.Sprintf("hosting %d other model"+s, e)
 }
 
 func IsHasHostedModelsError(err error) bool {
@@ -1046,6 +1051,47 @@ func (m *Model) destroyOps(ensureNoHostedModels, ensureEmpty bool) ([]txn.Op, er
 	return append(prereqOps, ops...), nil
 }
 
+type modelNotEmptyError struct {
+	machines     int
+	applications int
+	volumes      int
+	filesystems  int
+}
+
+// Error is part of the error interface.
+func (e modelNotEmptyError) Error() string {
+	msg := "model not empty, found "
+	plural := func(n int, thing string) string {
+		s := fmt.Sprintf("%d %s", n, thing)
+		if n != 1 {
+			s += "s"
+		}
+		return s
+	}
+	var contains []string
+	if n := e.machines; n > 0 {
+		contains = append(contains, plural(n, "machine"))
+	}
+	if n := e.applications; n > 0 {
+		contains = append(contains, plural(n, "application"))
+	}
+	if n := e.volumes; n > 0 {
+		contains = append(contains, plural(n, "volume"))
+	}
+	if n := e.filesystems; n > 0 {
+		contains = append(contains, plural(n, "filesystem"))
+	}
+	return msg + strings.Join(contains, ", ")
+}
+
+// IsModelNotEmptyError reports whether or not the given error was caused
+// due to an operation requiring a model to be empty, where the model is
+// non-empty.
+func IsModelNotEmptyError(err error) bool {
+	_, ok := errors.Cause(err).(modelNotEmptyError)
+	return ok
+}
+
 // checkEmpty checks that the machine is empty of any entities that may
 // require external resource cleanup. If the model is not empty, then
 // an error will be returned.
@@ -1060,25 +1106,17 @@ func (m *Model) checkEmpty() error {
 		}
 		return errors.Annotatef(err, "getting entity references for model %s", m.UUID())
 	}
-	// These errors could be potentially swallowed as we re-try to destroy model.
-	// Let's, at least, log them for observation.
-	if n := len(doc.Machines); n > 0 {
-		logger.Infof("model is still not empty, has machines: %v", doc.Machines)
-		return errors.Errorf("model not empty, found %d machine(s)", n)
+
+	err := modelNotEmptyError{
+		machines:     len(doc.Machines),
+		applications: len(doc.Applications),
+		volumes:      len(doc.Volumes),
+		filesystems:  len(doc.Filesystems),
 	}
-	if n := len(doc.Applications); n > 0 {
-		logger.Infof("model is still not empty, has applications: %v", doc.Applications)
-		return errors.Errorf("model not empty, found %d application(s)", n)
+	if err == (modelNotEmptyError{}) {
+		return nil
 	}
-	if n := len(doc.Volumes); n > 0 {
-		logger.Infof("model is still not empty, has volumes: %v", doc.Volumes)
-		return errors.Errorf("model not empty, found %d volume(s)", n)
-	}
-	if n := len(doc.Filesystems); n > 0 {
-		logger.Infof("model is still not empty, has file systems: %v", doc.Filesystems)
-		return errors.Errorf("model not empty, found %d filesystem(s)", n)
-	}
-	return nil
+	return err
 }
 
 func addModelMachineRefOp(st *State, machineId string) txn.Op {

--- a/worker/undertaker/undertaker_test.go
+++ b/worker/undertaker/undertaker_test.go
@@ -119,9 +119,9 @@ func (s *UndertakerSuite) TestProcessDyingModelErrorRetried(c *gc.C) {
 		nil, // ModelInfo
 		nil, // SetStatus
 		nil, // WatchModelResources,
-		errors.New("meh, will retry"), // ProcessDyingModel,
+		&params.Error{Code: params.CodeHasHostedModels},
 		nil, // SetStatus
-		errors.New("will retry again"), // ProcessDyingModel,
+		&params.Error{Code: params.CodeModelNotEmpty},
 		nil, // SetStatus
 		nil, // ProcessDyingModel,
 		nil, // SetStatus
@@ -143,6 +143,26 @@ func (s *UndertakerSuite) TestProcessDyingModelErrorRetried(c *gc.C) {
 		"SetStatus",
 		"Destroy",
 		"RemoveModel",
+	)
+}
+
+func (s *UndertakerSuite) TestProcessDyingModelErrorFatal(c *gc.C) {
+	s.fix.errors = []error{
+		nil, // ModelInfo
+		nil, // SetStatus
+		nil, // WatchModelResources,
+		errors.New("nope"),
+	}
+	s.fix.dirty = true
+	stub := s.fix.run(c, func(w worker.Worker) {
+		err := workertest.CheckKilled(c, w)
+		c.Check(err, gc.ErrorMatches, "nope")
+	})
+	stub.CheckCallNames(c,
+		"ModelInfo",
+		"SetStatus",
+		"WatchModelResources",
+		"ProcessDyingModel",
 	)
 }
 


### PR DESCRIPTION
## Description of change

The undertaker was ignoring all errors when attempting
to transition a Dying model to Dead. This is wrong; we
should only ignore a couple of specific errors relating
to the contents of the model. After those errors are
received, we'll retry. Other errors should cause the
worker to restart.

## QA steps

Smoke test: bootstrap, add-machine, destroy-controller --destroy-all-models.

## Documentation changes

None.

## Bug reference

Possibly fixes https://bugs.launchpad.net/juju/+bug/1695894