### PR TITLE
state: Create IAASModel from Model

### DIFF
--- a/state/iaasmodel.go
+++ b/state/iaasmodel.go
@@ -3,12 +3,45 @@
 
 package state
 
-// IAASModel contains data that is specific to an
-// Infrastructure-As-A-Service (IAAS) model.
+import "github.com/juju/errors"
+
+// IAASModel contains functionality that is specific to an
+// Infrastructure-As-A-Service (IAAS) model. It embeds a Model so that
+// all generic Model functionality is also available.
 type IAASModel struct {
+	*Model
+
 	mb modelBackend
 
 	// TODO(jsing): This should be removed once things
 	// have been sufficiently untangled.
 	st *State
+}
+
+// IAASModel returns an Infrastructure-As-A-Service (IAAS) model.
+func (m *Model) IAASModel() (*IAASModel, error) {
+	// TODO: error when model type is not IAAS.
+	return &IAASModel{
+		Model: m,
+		mb:    m.st,
+		st:    m.st,
+	}, nil
+}
+
+// IAASModel returns an Infrastructure-As-A-Service (IAAS) model.
+//
+// TODO(menn0): This is a convenience helper only and will go away
+// once most model related functionality has been moved from State to
+// Model/IAASModel. Model.IAASModel() should be preferred where-ever
+// possible.
+func (st *State) IAASModel() (*IAASModel, error) {
+	m, err := st.Model()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	im, err := m.IAASModel()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return im, nil
 }

--- a/state/state.go
+++ b/state/state.go
@@ -2315,11 +2315,3 @@ func (st *State) SetClockForTesting(clock clock.Clock) error {
 	}
 	return nil
 }
-
-// IAASModel returns an Infrastructure-As-A-Service (IAAS) model.
-func (st *State) IAASModel() (*IAASModel, error) {
-	return &IAASModel{
-		mb: st,
-		st: st,
-	}, nil
-}


### PR DESCRIPTION
## Description of change

The preferred way of creating an IAASModel is now from a Model rather
than State. State.IAASModel() will eventually go away.

IAASModel now embeds a Model so that all generic model functionality
as well as IAAS specific functionality is available through the one
type.

## QA steps

This is a relatively safe change. Simple bootstrap, deploy, destroy.

## Documentation changes

N.A.

## Bug reference

N.A.
