### PR TITLE
worker/cleaner: make the cleaner run periodically

### DIFF
--- a/cmd/jujud/agent/model/manifolds.go
+++ b/cmd/jujud/agent/model/manifolds.go
@@ -297,6 +297,7 @@ func Manifolds(config ManifoldsConfig) dependency.Manifolds {
 		})),
 		stateCleanerName: ifNotMigrating(cleaner.Manifold(cleaner.ManifoldConfig{
 			APICallerName: apiCallerName,
+			ClockName:     clockName,
 		})),
 		statusHistoryPrunerName: ifNotMigrating(pruner.Manifold(pruner.ManifoldConfig{
 			APICallerName: apiCallerName,

--- a/worker/cleaner/cleaner.go
+++ b/worker/cleaner/cleaner.go
@@ -4,12 +4,23 @@
 package cleaner
 
 import (
+	"time"
+
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
+	"github.com/juju/utils/clock"
 	worker "gopkg.in/juju/worker.v1"
 
 	"github.com/juju/juju/watcher"
+	"github.com/juju/juju/worker/catacomb"
 )
+
+// period is the amount of time to wait before running cleanups,
+// since the last time they were run. It is necessary to run
+// cleanups periodically because Cleanup will not return an
+// error if a specific cleanup fails, and the watcher will not
+// be triggered unless a new cleanup is added.
+const period = 30 * time.Second
 
 var logger = loggo.GetLogger("juju.worker.cleaner")
 
@@ -20,35 +31,67 @@ type StateCleaner interface {
 
 // Cleaner is responsible for cleaning up the state.
 type Cleaner struct {
-	st StateCleaner
+	catacomb catacomb.Catacomb
+	st       StateCleaner
+	watcher  watcher.NotifyWatcher
+	clock    clock.Clock
 }
 
 // NewCleaner returns a worker.Worker that runs state.Cleanup()
-// if the CleanupWatcher signals documents marked for deletion.
-func NewCleaner(st StateCleaner) (worker.Worker, error) {
-	w, err := watcher.NewNotifyWorker(watcher.NotifyConfig{
-		Handler: &Cleaner{st: st},
-	})
+// periodically, and whenever the CleanupWatcher signals documents
+// marked for deletion.
+func NewCleaner(st StateCleaner, clock clock.Clock) (worker.Worker, error) {
+	watcher, err := st.WatchCleanups()
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	return w, nil
-}
-
-func (c *Cleaner) SetUp() (watcher.NotifyWatcher, error) {
-	return c.st.WatchCleanups()
-}
-
-func (c *Cleaner) Handle(_ <-chan struct{}) error {
-	if err := c.st.Cleanup(); err != nil {
-		logger.Errorf("cannot cleanup state: %v", err)
+	c := Cleaner{
+		st:      st,
+		watcher: watcher,
+		clock:   clock,
 	}
-	// We do not return the err from Cleanup, because we don't want to stop
-	// the loop as a failure
-	return nil
+	if err := catacomb.Invoke(catacomb.Plan{
+		Site: &c.catacomb,
+		Work: c.loop,
+		Init: []worker.Worker{watcher},
+	}); err != nil {
+		return nil, errors.Trace(err)
+	}
+	return &c, nil
 }
 
-func (c *Cleaner) TearDown() error {
-	// Nothing to cleanup, only state is the watcher
-	return nil
+func (c *Cleaner) loop() error {
+	timer := c.clock.NewTimer(period)
+	defer timer.Stop()
+	for {
+		select {
+		case <-c.catacomb.Dying():
+			return c.catacomb.ErrDying()
+		case _, ok := <-c.watcher.Changes():
+			if !ok {
+				return errors.New("change channel closed")
+			}
+		case <-timer.Chan():
+		}
+		err := c.st.Cleanup()
+		if err != nil {
+			// We don't exit if a cleanup fails, we just
+			// retry after when the timer fires. This
+			// enables us to retry cleanups that fail due
+			// to a transient failure, even when there
+			// are no new cleanups added.
+			logger.Errorf("cannot cleanup state: %v", err)
+		}
+		timer.Reset(period)
+	}
+}
+
+// Kill is part of the worker.Worker interface.
+func (c *Cleaner) Kill() {
+	c.catacomb.Kill(nil)
+}
+
+// Wait is part of the worker.Worker interface.
+func (c *Cleaner) Wait() error {
+	return c.catacomb.Wait()
 }

--- a/worker/cleaner/manifold.go
+++ b/worker/cleaner/manifold.go
@@ -5,29 +5,54 @@ package cleaner
 
 import (
 	"github.com/juju/errors"
+	"github.com/juju/utils/clock"
 	worker "gopkg.in/juju/worker.v1"
 
 	"github.com/juju/juju/api/base"
 	"github.com/juju/juju/api/cleaner"
-	"github.com/juju/juju/cmd/jujud/agent/engine"
 	"github.com/juju/juju/worker/dependency"
 )
 
 // ManifoldConfig describes the resources used by the cleanup worker.
-type ManifoldConfig engine.APIManifoldConfig
+type ManifoldConfig struct {
+	APICallerName string
+	ClockName     string
+}
+
+// Validate is called by start to check for bad configuration.
+func (config ManifoldConfig) Validate() error {
+	if config.APICallerName == "" {
+		return errors.NotValidf("empty APICallerName")
+	}
+	if config.ClockName == "" {
+		return errors.NotValidf("empty ClockName")
+	}
+	return nil
+}
 
 // Manifold returns a Manifold that encapsulates the cleanup worker.
 func Manifold(config ManifoldConfig) dependency.Manifold {
-	return engine.APIManifold(
-		engine.APIManifoldConfig(config),
-		manifoldStart,
-	)
+	return dependency.Manifold{
+		Inputs: []string{config.APICallerName, config.ClockName},
+		Start:  config.start,
+	}
 }
 
-// manifoldStart creates a cleaner worker, given a base.APICaller.
-func manifoldStart(apiCaller base.APICaller) (worker.Worker, error) {
+// start is a StartFunc for a Worker manifold.
+func (config ManifoldConfig) start(context dependency.Context) (worker.Worker, error) {
+	if err := config.Validate(); err != nil {
+		return nil, errors.Trace(err)
+	}
+	var apiCaller base.APICaller
+	if err := context.Get(config.APICallerName, &apiCaller); err != nil {
+		return nil, errors.Trace(err)
+	}
+	var clock clock.Clock
+	if err := context.Get(config.ClockName, &clock); err != nil {
+		return nil, errors.Trace(err)
+	}
 	api := cleaner.NewAPI(apiCaller)
-	w, err := NewCleaner(api)
+	w, err := NewCleaner(api, clock)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}


### PR DESCRIPTION
## Description of change

The State.Cleanup method does not return any error
if a cleanup fails, and the worker wouldn't retry it anyway,
unless another cleanup came along. The documentation
for State.Cleanup explicitly states:

> "It should be called periodically by at least one element of the system."

We make the cleaner worker run 30 seconds after cleanups
are run, unless the watcher triggers first. This guarantees
that failed cleanups will be retried every 30 seconds, even
if there are no other cleanups scheduled.

## QA steps

smoke test:
1. juju bootstrap
2. juju add-machine
3. juju destroy-model -y default
4. juju destroy-controller -y default

## Documentation changes

None.

## Bug reference

No directly related bugs. Found the issue while investigating possible causes of https://bugs.launchpad.net/juju/+bug/1695894.