### PR TITLE
provider/openstack: implement ReleaseVolumes

### DIFF
--- a/provider/openstack/cinder_test.go
+++ b/provider/openstack/cinder_test.go
@@ -331,6 +331,66 @@ func (s *cinderVolumeSourceSuite) TestDestroyVolumesAttached(c *gc.C) {
 	}})
 }
 
+func (s *cinderVolumeSourceSuite) TestReleaseVolumes(c *gc.C) {
+	mockAdapter := &mockAdapter{}
+	volSource := openstack.NewCinderVolumeSource(mockAdapter)
+	errs, err := volSource.ReleaseVolumes([]string{mockVolId})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(errs, jc.DeepEquals, []error{nil})
+	metadata := map[string]string{
+		"juju-controller-uuid": "",
+		"juju-model-uuid":      "",
+	}
+	mockAdapter.CheckCalls(c, []gitjujutesting.StubCall{
+		{"GetVolume", []interface{}{mockVolId}},
+		{"SetVolumeMetadata", []interface{}{mockVolId, metadata}},
+	})
+}
+
+func (s *cinderVolumeSourceSuite) TestReleaseVolumesAttached(c *gc.C) {
+	mockAdapter := &mockAdapter{
+		getVolume: func(volId string) (*cinder.Volume, error) {
+			return &cinder.Volume{
+				ID:     volId,
+				Status: "in-use",
+			}, nil
+		},
+	}
+
+	volSource := openstack.NewCinderVolumeSource(mockAdapter)
+	errs, err := volSource.ReleaseVolumes([]string{mockVolId})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(errs, gc.HasLen, 1)
+	c.Assert(errs[0], gc.ErrorMatches, `cannot release volume "0": volume still in-use`)
+	mockAdapter.CheckCalls(c, []gitjujutesting.StubCall{{
+		"GetVolume", []interface{}{mockVolId},
+	}})
+}
+
+func (s *cinderVolumeSourceSuite) TestReleaseVolumesDetaching(c *gc.C) {
+	statuses := []string{"detaching", "available"}
+
+	mockAdapter := &mockAdapter{
+		getVolume: func(volId string) (*cinder.Volume, error) {
+			c.Assert(statuses, gc.Not(gc.HasLen), 0)
+			status := statuses[0]
+			statuses = statuses[1:]
+			return &cinder.Volume{
+				ID:     volId,
+				Status: status,
+			}, nil
+		},
+	}
+
+	volSource := openstack.NewCinderVolumeSource(mockAdapter)
+	errs, err := volSource.ReleaseVolumes([]string{mockVolId})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(errs, gc.HasLen, 1)
+	c.Assert(errs[0], jc.ErrorIsNil)
+	c.Assert(statuses, gc.HasLen, 0)
+	mockAdapter.CheckCallNames(c, "GetVolume", "GetVolume", "SetVolumeMetadata")
+}
+
 func (s *cinderVolumeSourceSuite) TestDetachVolumes(c *gc.C) {
 	const mockServerId2 = mockServerId + "2"
 

--- a/provider/openstack/provider.go
+++ b/provider/openstack/provider.go
@@ -1590,7 +1590,7 @@ func (e *Environ) destroyControllerManagedEnvirons(controllerUUID string) error 
 			return errors.Annotate(err, "listing volumes")
 		}
 		volIds := volumeInfoToVolumeIds(cinderToJujuVolumeInfos(volumes))
-		errs := destroyVolumes(cinder.storageAdapter, volIds)
+		errs := foreachVolume(cinder.storageAdapter, volIds, destroyVolume)
 		for i, err := range errs {
 			if err == nil {
 				continue


### PR DESCRIPTION
## Description of change

Implement the VolumeSource.ReleaseVolumes method
for Cinder. This enables Cinder volumes to be
released from an OpenStack model, so they can
be imported into another controller/model.

## QA steps

1. juju bootstrap openstack
2. juju deploy cs:~axwalk/storagetest --storage fs=cinder,1G
(wait for storage to be attached)
3. juju remove-storage --force --no-destroy fs/0
(wait for storage to disappear from `juju storage` output)
4. juju destroy-controller
5. use "cinder list" and "cinder show" to check that the volume is still there, but has the controller/model UUIDs cleared)

## Documentation changes

None.

## Bug reference

None.