### PR TITLE
Make status faster (in theory).

### DIFF
--- a/apiserver/client/export_test.go
+++ b/apiserver/client/export_test.go
@@ -13,12 +13,6 @@ var (
 	MatchSubnet     = matchSubnet
 )
 
-// Status exports
-var (
-	ProcessMachines   = processMachines
-	MakeMachineStatus = makeMachineStatus
-)
-
 func SetNewEnviron(c *Client, newEnviron func() (environs.Environ, error)) {
 	c.newEnviron = newEnviron
 }

--- a/apiserver/client/status.go
+++ b/apiserver/client/status.go
@@ -172,8 +172,14 @@ func (c *Client) FullStatus(args params.StatusParams) (params.FullStatus, error)
 	var noStatus params.FullStatus
 	var context statusContext
 	var err error
+	if context.model, err = c.api.stateAccessor.Model(); err != nil {
+		return noStatus, errors.Annotate(err, "could not fetch model")
+	}
+	if context.status, err = context.model.LoadModelStatus(); err != nil {
+		return noStatus, errors.Annotate(err, "could not load model status values")
+	}
 	if context.applications, context.units, context.latestCharms, err =
-		fetchAllApplicationsAndUnits(c.api.stateAccessor, len(args.Patterns) <= 0); err != nil {
+		fetchAllApplicationsAndUnits(c.api.stateAccessor, context.model, len(args.Patterns) <= 0); err != nil {
 		return noStatus, errors.Annotate(err, "could not fetch applications and units")
 	}
 	if featureflag.Enabled(feature.CrossModelRelations) {
@@ -295,13 +301,8 @@ func (c *Client) FullStatus(args params.StatusParams) (params.FullStatus, error)
 		return noStatus, errors.Annotate(err, "cannot determine model status")
 	}
 	return params.FullStatus{
-		Model: modelStatus,
-		Machines: processMachines(
-			context.machines,
-			context.ipAddresses,
-			context.spaces,
-			context.linkLayerDevices,
-		),
+		Model:              modelStatus,
+		Machines:           context.processMachines(),
 		Applications:       context.processApplications(),
 		RemoteApplications: context.processRemoteApplications(),
 		Relations:          context.processRelations(),
@@ -357,6 +358,8 @@ func (c *Client) modelStatus() (params.ModelStatusInfo, error) {
 }
 
 type statusContext struct {
+	model  *state.Model
+	status *state.ModelStatus
 	// machines: top-level machine id -> list of machines nested in
 	// this machine.
 	machines map[string][]*state.Machine
@@ -483,6 +486,7 @@ func fetchNetworkInterfaces(st Backend) (map[string][]*state.Address, map[string
 // a map from application name to unit name to unit, and a map from base charm URL to latest URL.
 func fetchAllApplicationsAndUnits(
 	st Backend,
+	model *state.Model,
 	matchAny bool,
 ) (map[string]*state.Application, map[string]map[string]*state.Unit, map[charm.URL]*state.Charm, error) {
 
@@ -493,21 +497,23 @@ func fetchAllApplicationsAndUnits(
 	if err != nil {
 		return nil, nil, nil, err
 	}
-	for _, s := range applications {
-		units, err := s.AllUnits()
-		if err != nil {
-			return nil, nil, nil, err
-		}
+	units, err := model.AllUnits()
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	for _, app := range applications {
 		appUnitMap := make(map[string]*state.Unit)
 		for _, u := range units {
-			appUnitMap[u.Name()] = u
+			if u.ApplicationName() == app.Name() {
+				appUnitMap[u.Name()] = u
+			}
 		}
 		if matchAny || len(appUnitMap) > 0 {
-			unitMap[s.Name()] = appUnitMap
-			appMap[s.Name()] = s
+			unitMap[app.Name()] = appUnitMap
+			appMap[app.Name()] = app
 			// Record the base URL for the application's charm so that
 			// the latest store revision can be looked up.
-			charmURL, _ := s.CharmURL()
+			charmURL, _ := app.CharmURL()
 			if charmURL.Schema == "cs" {
 				latestCharms[*charmURL.WithRevision(-1)] = nil
 			}
@@ -574,15 +580,10 @@ func (m machineAndContainers) Containers(id string) []*state.Machine {
 	return m[id][1:]
 }
 
-func processMachines(
-	idToMachines map[string][]*state.Machine,
-	idToIpAddresses map[string][]*state.Address,
-	idToDeviceToSpaces map[string]map[string]set.Strings,
-	idToLinkLayerDevices map[string][]*state.LinkLayerDevice,
-) map[string]params.MachineStatus {
+func (c *statusContext) processMachines() map[string]params.MachineStatus {
 	machinesMap := make(map[string]params.MachineStatus)
 	cache := make(map[string]params.MachineStatus)
-	for id, machines := range idToMachines {
+	for id, machines := range c.machines {
 
 		if len(machines) <= 0 {
 			continue
@@ -590,27 +591,18 @@ func processMachines(
 
 		// Element 0 is assumed to be the top-level machine.
 		tlMachine := machines[0]
-		hostStatus := makeMachineStatus(
-			tlMachine,
-			idToIpAddresses[tlMachine.Id()],
-			idToDeviceToSpaces[tlMachine.Id()],
-			idToLinkLayerDevices[tlMachine.Id()],
-		)
+		hostStatus := c.makeMachineStatus(tlMachine)
 		machinesMap[id] = hostStatus
 		cache[id] = hostStatus
 
 		for _, machine := range machines[1:] {
 			parent, ok := cache[state.ParentId(machine.Id())]
 			if !ok {
-				panic("We've broken an assumpution.")
+				logger.Errorf("programmer error, please file a bug, reference this whole log line: %q, %q", id, machine.Id())
+				continue
 			}
 
-			status := makeMachineStatus(
-				machine,
-				idToIpAddresses[machine.Id()],
-				idToDeviceToSpaces[machine.Id()],
-				idToLinkLayerDevices[machine.Id()],
-			)
+			status := c.makeMachineStatus(machine)
 			parent.Containers[machine.Id()] = status
 			cache[machine.Id()] = status
 		}
@@ -618,23 +610,24 @@ func processMachines(
 	return machinesMap
 }
 
-func makeMachineStatus(
-	machine *state.Machine,
-	ipAddresses []*state.Address,
-	spaces map[string]set.Strings,
-	linkLayerDevices []*state.LinkLayerDevice,
-) (status params.MachineStatus) {
+func (c *statusContext) makeMachineStatus(machine *state.Machine) (status params.MachineStatus) {
+	machineID := machine.Id()
+	ipAddresses := c.ipAddresses[machineID]
+	spaces := c.spaces[machineID]
+	linkLayerDevices := c.linkLayerDevices[machineID]
+
 	var err error
 	status.Id = machine.Id()
-	agentStatus := processMachine(machine)
+	agentStatus := c.processMachine(machine)
 	status.AgentStatus = agentStatus
 
 	status.Series = machine.Series()
 	status.Jobs = paramsJobsFromJobs(machine.Jobs())
 	status.WantsVote = machine.WantsVote()
 	status.HasVote = machine.HasVote()
-	sInfo, err := machine.InstanceStatus()
+	sInfo, err := c.status.MachineInstance(machineID)
 	populateStatusFromStatusInfoAndErr(&status.InstanceStatus, sInfo, err)
+	// TODO: fetch all instance data for machines in one go.
 	instid, err := machine.InstanceId()
 	if err == nil {
 		status.InstanceId = instid
@@ -710,6 +703,7 @@ func makeMachineStatus(
 			status.InstanceId = "error"
 		}
 	}
+	// TODO: preload all constraints.
 	constraints, err := machine.Constraints()
 	if err != nil {
 		if !errors.IsNotFound(err) {
@@ -718,6 +712,7 @@ func makeMachineStatus(
 	} else {
 		status.Constraints = constraints.String()
 	}
+	// TODO: preload all hardware characteristics.
 	hc, err := machine.HardwareCharacteristics()
 	if err != nil {
 		if !errors.IsNotFound(err) {
@@ -833,7 +828,11 @@ func (context *statusContext) processApplication(application *state.Application)
 	if application.IsPrincipal() {
 		processedStatus.Units = context.processUnits(units, applicationCharm.URL().String())
 	}
-	applicationStatus, err := application.Status()
+	var unitNames []string
+	for _, unit := range units {
+		unitNames = append(unitNames, unit.Name())
+	}
+	applicationStatus, err := context.status.Application(application.Name(), unitNames)
 	if err != nil {
 		processedStatus.Err = common.ServerError(err)
 		return processedStatus
@@ -851,20 +850,12 @@ func (context *statusContext) processApplication(application *state.Application)
 
 	versions := make([]status.StatusInfo, 0, len(units))
 	for _, unit := range units {
-		statuses, err := unit.WorkloadVersionHistory().StatusHistory(
-			status.StatusHistoryFilter{Size: 1},
-		)
+		workloadVersion, err := context.status.FullUnitWorkloadVersion(unit.Name())
 		if err != nil {
 			processedStatus.Err = common.ServerError(err)
 			return processedStatus
 		}
-		// Even though we fully expect there to be historical values there,
-		// even the first should be the empty string, the status history
-		// collection is not added to in a transactional manner, so it may be
-		// not there even though we'd really like it to be. Such is mongo.
-		if len(statuses) > 0 {
-			versions = append(versions, statuses[0])
-		}
+		versions = append(versions, workloadVersion)
 	}
 	if len(versions) > 0 {
 		sort.Sort(bySinceDescending(versions))
@@ -961,14 +952,14 @@ func (context *statusContext) processUnit(unit *state.Unit, applicationCharm str
 	if applicationCharm != "" && curl != nil && curl.String() != applicationCharm {
 		result.Charm = curl.String()
 	}
-	workloadVersion, err := unit.WorkloadVersion()
+	workloadVersion, err := context.status.UnitWorkloadVersion(unit.Name())
 	if err == nil {
 		result.WorkloadVersion = workloadVersion
 	} else {
 		logger.Debugf("error fetching workload version: %v", err)
 	}
 
-	processUnitAndAgentStatus(unit, &result)
+	result.AgentStatus, result.WorkloadStatus = context.processUnitAndAgentStatus(unit)
 
 	if subUnits := unit.SubordinateNames(); len(subUnits) > 0 {
 		result.Subordinates = make(map[string]params.UnitStatus)
@@ -1047,13 +1038,42 @@ type lifer interface {
 	Life() state.Life
 }
 
+// contextUnit overloads the AgentStatus and Status calls to use the cached
+// status values, and delegates everything else to the Unit.
+// TODO: cache presence as well.
+type contextUnit struct {
+	*state.Unit
+	context *statusContext
+}
+
+// AgentStatus implements UnitStatusGetter.
+func (c *contextUnit) AgentStatus() (status.StatusInfo, error) {
+	return c.context.status.UnitAgent(c.Name())
+}
+
+// Status implements UnitStatusGetter.
+func (c *contextUnit) Status() (status.StatusInfo, error) {
+	return c.context.status.UnitWorkload(c.Name())
+}
+
 // processUnitAndAgentStatus retrieves status information for both unit and unitAgents.
-func processUnitAndAgentStatus(unit *state.Unit, unitStatus *params.UnitStatus) {
-	unitStatus.AgentStatus, unitStatus.WorkloadStatus = processUnit(unit)
+func (c *statusContext) processUnitAndAgentStatus(unit *state.Unit) (agentStatus, workloadStatus params.DetailedStatus) {
+	wrapped := &contextUnit{unit, c}
+	agent, workload := common.UnitStatus(wrapped)
+	populateStatusFromStatusInfoAndErr(&agentStatus, agent.Status, agent.Err)
+	populateStatusFromStatusInfoAndErr(&workloadStatus, workload.Status, workload.Err)
+
+	agentStatus.Life = processLife(unit)
+
+	if t, err := unit.AgentTools(); err == nil {
+		agentStatus.Version = t.Version.Number.String()
+	}
+	return
 }
 
 // populateStatusFromStatusInfoAndErr creates AgentStatus from the typical output
 // of a status getter.
+// TODO: make this a function that just returns a type.
 func populateStatusFromStatusInfoAndErr(agent *params.DetailedStatus, statusInfo status.StatusInfo, err error) {
 	agent.Err = err
 	agent.Status = statusInfo.Status.String()
@@ -1062,30 +1082,30 @@ func populateStatusFromStatusInfoAndErr(agent *params.DetailedStatus, statusInfo
 	agent.Since = statusInfo.Since
 }
 
+// contextMachine overloads the Status call to use the cached status values,
+// and delegates everything else to the Machine.
+// TODO: cache presence as well.
+type contextMachine struct {
+	*state.Machine
+	context *statusContext
+}
+
+// Return the agent status for the machine.
+func (c *contextMachine) Status() (status.StatusInfo, error) {
+	return c.context.status.MachineAgent(c.Id())
+}
+
 // processMachine retrieves version and status information for the given machine.
 // It also returns deprecated legacy status information.
-func processMachine(machine *state.Machine) (out params.DetailedStatus) {
-	statusInfo, err := common.MachineStatus(machine)
+func (c *statusContext) processMachine(machine *state.Machine) (out params.DetailedStatus) {
+	wrapped := &contextMachine{machine, c}
+	statusInfo, err := common.MachineStatus(wrapped)
 	populateStatusFromStatusInfoAndErr(&out, statusInfo, err)
 
 	out.Life = processLife(machine)
 
 	if t, err := machine.AgentTools(); err == nil {
 		out.Version = t.Version.Number.String()
-	}
-	return
-}
-
-// processUnit retrieves version and status information for the given unit.
-func processUnit(unit *state.Unit) (agentStatus, workloadStatus params.DetailedStatus) {
-	agent, workload := common.UnitStatus(unit)
-	populateStatusFromStatusInfoAndErr(&agentStatus, agent.Status, agent.Err)
-	populateStatusFromStatusInfoAndErr(&workloadStatus, workload.Status, workload.Err)
-
-	agentStatus.Life = processLife(unit)
-
-	if t, err := unit.AgentTools(); err == nil {
-		agentStatus.Version = t.Version.Number.String()
 	}
 	return
 }

--- a/apiserver/client/status_test.go
+++ b/apiserver/client/status_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/juju/juju/api"
 	"github.com/juju/juju/apiserver/charmrevisionupdater"
 	"github.com/juju/juju/apiserver/charmrevisionupdater/testing"
-	"github.com/juju/juju/apiserver/client"
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/params"
 	apiservertesting "github.com/juju/juju/apiserver/testing"
@@ -82,38 +81,39 @@ type statusUnitTestSuite struct {
 func (s *statusUnitTestSuite) TestProcessMachinesWithOneMachineAndOneContainer(c *gc.C) {
 	host := s.Factory.MakeMachine(c, &factory.MachineParams{InstanceId: instance.Id("0")})
 	container := s.Factory.MakeMachineNested(c, host.Id(), nil)
-	machines := map[string][]*state.Machine{
-		host.Id(): {host, container},
-	}
 
-	// TODO(macgreagoir) Pass in more than nil
-	statuses := client.ProcessMachines(machines, nil, nil, nil)
-	c.Assert(statuses, gc.Not(gc.IsNil))
+	client := s.APIState.Client()
+	status, err := client.Status(nil)
+	c.Assert(err, jc.ErrorIsNil)
 
-	// TODO(macgreagoir) Pass in more than nil
-	containerStatus := client.MakeMachineStatus(container, nil, nil, nil)
-	c.Check(statuses[host.Id()].Containers[container.Id()].Id, gc.Equals, containerStatus.Id)
+	c.Check(status.Machines, gc.HasLen, 1)
+	mStatus, ok := status.Machines[host.Id()]
+	c.Check(ok, jc.IsTrue)
+	c.Check(mStatus.Containers, gc.HasLen, 1)
+
+	_, ok = mStatus.Containers[container.Id()]
+	c.Check(ok, jc.IsTrue)
 }
 
 func (s *statusUnitTestSuite) TestProcessMachinesWithEmbeddedContainers(c *gc.C) {
 	host := s.Factory.MakeMachine(c, &factory.MachineParams{InstanceId: instance.Id("1")})
+	s.Factory.MakeMachineNested(c, host.Id(), nil)
 	lxdHost := s.Factory.MakeMachineNested(c, host.Id(), nil)
-	machines := map[string][]*state.Machine{
-		host.Id(): {
-			host,
-			lxdHost,
-			s.Factory.MakeMachineNested(c, lxdHost.Id(), nil),
-			s.Factory.MakeMachineNested(c, host.Id(), nil),
-		},
-	}
+	s.Factory.MakeMachineNested(c, lxdHost.Id(), nil)
 
-	// TODO(macgreagoir) Pass in more than nil
-	statuses := client.ProcessMachines(machines, nil, nil, nil)
-	c.Assert(statuses, gc.Not(gc.IsNil))
+	client := s.APIState.Client()
+	status, err := client.Status(nil)
+	c.Assert(err, jc.ErrorIsNil)
 
-	hostContainer := statuses[host.Id()].Containers
-	c.Check(hostContainer, gc.HasLen, 2)
-	c.Check(hostContainer[lxdHost.Id()].Containers, gc.HasLen, 1)
+	c.Check(status.Machines, gc.HasLen, 1)
+	mStatus, ok := status.Machines[host.Id()]
+	c.Check(ok, jc.IsTrue)
+	c.Check(mStatus.Containers, gc.HasLen, 2)
+
+	mStatus, ok = mStatus.Containers[lxdHost.Id()]
+	c.Check(ok, jc.IsTrue)
+
+	c.Check(mStatus.Containers, gc.HasLen, 1)
 }
 
 var testUnits = []struct {

--- a/state/allcollections.go
+++ b/state/allcollections.go
@@ -246,8 +246,12 @@ func allCollections() collectionSchema {
 		// -----
 
 		// These collections hold information associated with applications.
-		charmsC:       {},
-		applicationsC: {},
+		charmsC: {},
+		applicationsC: {
+			indexes: []mgo.Index{{
+				Key: []string{"model-uuid", "name"},
+			}},
+		},
 		unitsC: {
 			indexes: []mgo.Index{{
 				Key: []string{"model-uuid", "application"},
@@ -285,9 +289,13 @@ func allCollections() collectionSchema {
 		// These collections hold information associated with machines.
 		containerRefsC: {},
 		instanceDataC:  {},
-		machinesC:      {},
-		rebootC:        {},
-		sshHostKeysC:   {},
+		machinesC: {
+			indexes: []mgo.Index{{
+				Key: []string{"model-uuid", "machineid"},
+			}},
+		},
+		rebootC:      {},
+		sshHostKeysC: {},
 
 		// This collection contains information from removed machines
 		// that needs to be cleaned up in the provider.
@@ -386,7 +394,11 @@ func allCollections() collectionSchema {
 
 		constraintsC:        {},
 		storageConstraintsC: {},
-		statusesC:           {},
+		statusesC: {
+			indexes: []mgo.Index{{
+				Key: []string{"model-uuid", "_id"},
+			}},
+		},
 		statusesHistoryC: {
 			rawAccess: true,
 			indexes: []mgo.Index{{

--- a/state/status.go
+++ b/state/status.go
@@ -60,21 +60,12 @@ func (m *ModelStatus) getDoc(key, badge string) (statusDocWithID, error) {
 	return doc, nil
 }
 
-func (m *ModelStatus) transform(doc statusDocWithID) status.StatusInfo {
-	return status.StatusInfo{
-		Status:  doc.Status,
-		Message: doc.StatusInfo,
-		Data:    utils.UnescapeKeys(doc.StatusData),
-		Since:   unixNanoToTime(doc.Updated),
-	}
-}
-
 func (m *ModelStatus) getStatus(key, badge string) (status.StatusInfo, error) {
 	doc, err := m.getDoc(key, badge)
 	if err != nil {
 		return status.StatusInfo{}, err
 	}
-	return m.transform(doc), nil
+	return doc.asStatusInfo(), nil
 }
 
 // Model returns the status of the model.
@@ -106,7 +97,7 @@ func (m *ModelStatus) Application(appName string, unitNames []string) (status.St
 		}
 
 	}
-	return m.transform(doc), nil
+	return doc.asStatusInfo(), nil
 }
 
 // MachineAgent returns the status of the machine agent.
@@ -176,6 +167,15 @@ type statusDocWithID struct {
 	StatusData map[string]interface{} `bson:"statusdata"`
 	Updated    int64                  `bson:"updated"`
 	NeverSet   bool                   `bson:"neverset"`
+}
+
+func (doc *statusDocWithID) asStatusInfo() status.StatusInfo {
+	return status.StatusInfo{
+		Status:  doc.Status,
+		Message: doc.StatusInfo,
+		Data:    utils.UnescapeKeys(doc.StatusData),
+		Since:   unixNanoToTime(doc.Updated),
+	}
 }
 
 // statusDoc represents a entity status in Mongodb.  The implicit

--- a/state/status_model_test.go
+++ b/state/status_model_test.go
@@ -15,8 +15,9 @@ import (
 
 type ModelStatusSuite struct {
 	ConnSuite
-	st    *state.State
-	model *state.Model
+	st      *state.State
+	model   *state.Model
+	factory *factory.Factory
 }
 
 var _ = gc.Suite(&ModelStatusSuite{})
@@ -27,6 +28,7 @@ func (s *ModelStatusSuite) SetUpTest(c *gc.C) {
 	m, err := s.st.Model()
 	c.Assert(err, jc.ErrorIsNil)
 	s.model = m
+	s.factory = factory.NewFactory(s.st)
 }
 
 func (s *ModelStatusSuite) TearDownTest(c *gc.C) {
@@ -84,7 +86,7 @@ func (s *ModelStatusSuite) TestGetSetStatusDying(c *gc.C) {
 	// Add a machine to the model to ensure it is non-empty
 	// when we destroy; this prevents the model from advancing
 	// directly to Dead.
-	factory.NewFactory(s.st).MakeMachine(c, nil)
+	s.factory.MakeMachine(c, nil)
 
 	err := s.model.Destroy()
 	c.Assert(err, jc.ErrorIsNil)
@@ -148,4 +150,138 @@ func (s *ModelStatusSuite) checkGetSetStatus(c *gc.C) {
 		},
 	})
 	c.Check(statusInfo.Since, gc.NotNil)
+}
+
+func (s *ModelStatusSuite) TestModelStatusForModel(c *gc.C) {
+	ms, err := s.model.LoadModelStatus()
+	c.Assert(err, jc.ErrorIsNil)
+
+	info, err := ms.Model()
+	c.Assert(err, jc.ErrorIsNil)
+
+	mInfo, err := s.model.Status()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(info, jc.DeepEquals, mInfo)
+}
+
+func (s *ModelStatusSuite) TestMachineStatus(c *gc.C) {
+	machine := s.factory.MakeMachine(c, nil)
+
+	ms, err := s.model.LoadModelStatus()
+	c.Assert(err, jc.ErrorIsNil)
+
+	msAgent, err := ms.MachineAgent(machine.Id())
+	c.Assert(err, jc.ErrorIsNil)
+	msInstance, err := ms.MachineInstance(machine.Id())
+	c.Assert(err, jc.ErrorIsNil)
+
+	mAgent, err := machine.Status()
+	c.Assert(err, jc.ErrorIsNil)
+	mInstance, err := machine.InstanceStatus()
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Assert(msAgent, jc.DeepEquals, mAgent)
+	c.Assert(msInstance, jc.DeepEquals, mInstance)
+}
+
+func (s *ModelStatusSuite) TestUnitStatus(c *gc.C) {
+	unit := s.factory.MakeUnit(c, nil)
+
+	c.Assert(unit.SetWorkloadVersion("42.1"), jc.ErrorIsNil)
+	c.Assert(unit.SetStatus(status.StatusInfo{Status: status.Active}), jc.ErrorIsNil)
+	c.Assert(unit.SetAgentStatus(status.StatusInfo{Status: status.Idle}), jc.ErrorIsNil)
+
+	ms, err := s.model.LoadModelStatus()
+	c.Assert(err, jc.ErrorIsNil)
+
+	msAgent, err := ms.UnitAgent(unit.Name())
+	c.Assert(err, jc.ErrorIsNil)
+	msWorkload, err := ms.UnitWorkload(unit.Name())
+	c.Assert(err, jc.ErrorIsNil)
+	msWorkloadVersion, err := ms.UnitWorkloadVersion(unit.Name())
+	c.Assert(err, jc.ErrorIsNil)
+
+	uAgent, err := unit.AgentStatus()
+	c.Assert(err, jc.ErrorIsNil)
+	uWorkload, err := unit.Status()
+	c.Assert(err, jc.ErrorIsNil)
+	uWorkloadVersion, err := unit.WorkloadVersion()
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Check(msAgent, jc.DeepEquals, uAgent)
+	c.Check(msWorkload, jc.DeepEquals, uWorkload)
+	c.Check(msWorkloadVersion, jc.DeepEquals, uWorkloadVersion)
+}
+
+func (s *ModelStatusSuite) TestUnitStatusWeirdness(c *gc.C) {
+	unit := s.factory.MakeUnit(c, nil)
+
+	// When the agent status is in error, we show the workload status
+	// as an error, and the agent as idle
+	c.Assert(unit.SetStatus(status.StatusInfo{Status: status.Active}), jc.ErrorIsNil)
+	c.Assert(unit.SetAgentStatus(status.StatusInfo{
+		Status:  status.Error,
+		Message: "OMG"}), jc.ErrorIsNil)
+
+	ms, err := s.model.LoadModelStatus()
+	c.Assert(err, jc.ErrorIsNil)
+
+	msAgent, err := ms.UnitAgent(unit.Name())
+	c.Assert(err, jc.ErrorIsNil)
+	msWorkload, err := ms.UnitWorkload(unit.Name())
+	c.Assert(err, jc.ErrorIsNil)
+
+	uAgent, err := unit.AgentStatus()
+	c.Assert(err, jc.ErrorIsNil)
+	uWorkload, err := unit.Status()
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Check(msAgent, jc.DeepEquals, uAgent)
+	c.Check(msWorkload, jc.DeepEquals, uWorkload)
+
+	c.Check(msAgent.Status, gc.Equals, status.Idle)
+	c.Check(msWorkload.Status, gc.Equals, status.Error)
+}
+
+func (s *ModelStatusSuite) TestApplicationStatus(c *gc.C) {
+	unit := s.factory.MakeUnit(c, nil)
+	app, err := unit.Application()
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = app.SetStatus(status.StatusInfo{Status: status.Active})
+	c.Assert(err, jc.ErrorIsNil)
+
+	aStatus, err := app.Status()
+	c.Assert(err, jc.ErrorIsNil)
+
+	ms, err := s.model.LoadModelStatus()
+	c.Assert(err, jc.ErrorIsNil)
+
+	msStatus, err := ms.Application(app.Name(), []string{unit.Name()})
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Assert(msStatus, jc.DeepEquals, aStatus)
+}
+
+func (s *ModelStatusSuite) TestApplicationStatusWeirdness(c *gc.C) {
+	unit0 := s.factory.MakeUnit(c, nil)
+	app, err := unit0.Application()
+	c.Assert(err, jc.ErrorIsNil)
+	unit1 := s.factory.MakeUnit(c, &factory.UnitParams{Application: app})
+
+	c.Assert(unit0.SetStatus(status.StatusInfo{Status: status.Active}), jc.ErrorIsNil)
+	c.Assert(unit1.SetStatus(status.StatusInfo{Status: status.Waiting}), jc.ErrorIsNil)
+
+	aStatus, err := app.Status()
+	c.Assert(err, jc.ErrorIsNil)
+
+	ms, err := s.model.LoadModelStatus()
+	c.Assert(err, jc.ErrorIsNil)
+
+	msStatus, err := ms.Application(app.Name(), []string{unit0.Name(), unit1.Name()})
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Derived status should be waiting.
+	c.Check(msStatus.Status, gc.Equals, status.Waiting)
+	c.Check(msStatus, jc.DeepEquals, aStatus)
 }

--- a/state/unitagent.go
+++ b/state/unitagent.go
@@ -43,6 +43,7 @@ func (u *UnitAgent) Status() (status.StatusInfo, error) {
 	// be in error state, but the state model more correctly records the agent
 	// itself as being in error. So we'll do that model translation here.
 	// TODO(fwereade): this should absolutely not be happpening in the model.
+	// TODO: when fixed, also fix code in status.go for UnitAgent.
 	if info.Status == status.Error {
 		return status.StatusInfo{
 			Status:  status.Idle,


### PR DESCRIPTION
juju status can be slow on big models in big controllers.

This branch attacks the problem from two different directions. Firstly the missing indices on the applications and machine collections. Both of these are fully loaded when status is executed. In controllers with many models the query would involve table scans.

Secondly when the apiserver code was iterating over the machines an units, each one had multiple calls to some value stored in the statuses collection. Instead of executing these queries one at a time, all the statuses for the model are loaded at once at the start of the status call.

This then reduces the number of calls for the status values by 2 per machine, and 3 per unit (or 4 per unit if SetStatus has never been called on the application. Also reduces the queries on statuses history by 1 per unit by making the full workload version status document available through the cache. As well as the status caching, a single query is made to the db for all the units in the model rather than one call per application.

So, for a model with 50 applications, 2500 units and 300 machines, this branch reduces the query count by 10648 (or 13148 if no app called SetStatus).

## QA steps

Run `juju status`
