### PR TITLE
Fix clean up issue in deploy_stack.py when --existing enabled.

### DIFF
--- a/acceptancetests/deploy_stack.py
+++ b/acceptancetests/deploy_stack.py
@@ -1071,7 +1071,10 @@ class BootstrapManager:
                 artifacts_dir = os.path.join(self.log_dir,
                                              client.env.environment)
                 if not os.path.exists(artifacts_dir):
-                    os.makedirs(artifacts_dir)
+                    try:
+                        os.makedirs(artifacts_dir)
+                    except OSError:
+                        pass
                 dump_env_logs_known_hosts(
                     client, artifacts_dir, runtime_config, known_hosts)
 

--- a/acceptancetests/deploy_stack.py
+++ b/acceptancetests/deploy_stack.py
@@ -1070,7 +1070,8 @@ class BootstrapManager:
                     runtime_config = None
                 artifacts_dir = os.path.join(self.log_dir,
                                              client.env.environment)
-                os.makedirs(artifacts_dir)
+                if not os.path.exists(artifacts_dir):
+                    os.makedirs(artifacts_dir)
                 dump_env_logs_known_hosts(
                     client, artifacts_dir, runtime_config, known_hosts)
 

--- a/acceptancetests/deploy_stack.py
+++ b/acceptancetests/deploy_stack.py
@@ -8,6 +8,7 @@ try:
     from contextlib import nested
 except ImportError:
     from contextlib import ExitStack as nested
+import errno
 import glob
 import logging
 import os
@@ -1070,11 +1071,11 @@ class BootstrapManager:
                     runtime_config = None
                 artifacts_dir = os.path.join(self.log_dir,
                                              client.env.environment)
-                if not os.path.exists(artifacts_dir):
-                    try:
-                        os.makedirs(artifacts_dir)
-                    except OSError:
-                        pass
+                try:
+                    os.makedirs(artifacts_dir)
+                except OSError as e:
+                    if e.errno != errno.EEXIST:
+                        raise
                 dump_env_logs_known_hosts(
                     client, artifacts_dir, runtime_config, known_hosts)
 


### PR DESCRIPTION
## Description of change
As the featured introduced by PR7684:
https://github.com/juju/juju/pull/7684

when append --existing "current" to a test script, clean up failed at the end of run.

It's caused by the natural behaviour of this feature - the existing controller,
therefore existing folders in $JUJU_DATA.

This change is a fix to this issue.

Note: this change does not address "ValueError: too many values to unpack",
it's a different issue and it doesn't affect the clean up.

## QA steps
a). Set credentials and environments ($ENV, $JUJU_BIN, $JUJU_DATA), bootstrap a controller on AWS
b). Modify test script (using assess_lxd_space.py as an example):
`+ from deploy_stack import test_on_controller`
`- with bs_manager.booted_context(args.upload_tools):`
`- assess_lxd_container_space(bs_manager.client)`
`+ test_on_controller(assess_lxd_container_space, args)`
c). Run this test multiple times (3 times at least):
`$ ./assess_lxd_space.py $ENV $JUJU_BIN $JUJU_DATA --existing "current"`
d) Run `juju models`, only "controller" model and "default" model should exist.

This change has been locally validated.

## Documentation changes
N/A

## Bug reference
N/A
