### PR TITLE
Update controller models count when models collection is changed.

### DIFF
--- a/jujuclient/modelsfile_test.go
+++ b/jujuclient/modelsfile_test.go
@@ -65,6 +65,16 @@ var testControllerModels = map[string]*jujuclient.ControllerModels{
 	},
 }
 
+const testControllerModelsYaml = `
+controllers:
+  ctrl:
+    uuid: this-is-the-ctrl-test-uuid
+    model-count: 1
+  kontroll:
+    uuid: this-is-kontroll-uuid
+    model-count: 2
+`
+
 var kontrollAdminModelDetails = jujuclient.ModelDetails{"abc"}
 var kontrollMyModelModelDetails = jujuclient.ModelDetails{"def"}
 var ctrlAdminModelDetails = jujuclient.ModelDetails{"ghi"}
@@ -107,6 +117,13 @@ func (s *ModelsFileSuite) TestMigrateLegacyLocal(c *gc.C) {
 
 func writeTestModelsFile(c *gc.C) {
 	err := jujuclient.WriteModelsFile(testControllerModels)
+	c.Assert(err, jc.ErrorIsNil)
+
+	// we also need corresponding controllers file since
+	// some model operations will affect stored controllers data.
+	controllers, err := jujuclient.ParseControllers([]byte(testControllerModelsYaml))
+	c.Assert(err, jc.ErrorIsNil)
+	err = jujuclient.WriteControllersFile(controllers)
 	c.Assert(err, jc.ErrorIsNil)
 }
 


### PR DESCRIPTION
## Description of change

This is the 1st PR in the series that will keep client side cache reasonably upto date.
This PR ensures that controller models count, stored in controllers' part of the store, is kept upto date whenever models side of the store is updated.

A drive-by removal of a workaround to allow upgrade-abiltiy between 2.0 beta versions. Now deemed redundant. 

## QA steps

No user facing changes. However, steps for development verification:
1. bootstrap
2. note model-count value for bootstrapped controller in controllers file
3. add a model
4. model-count for that controller should reflect actual model count (could either be checked in the file directly or by running 'juju controllers'

## Documentation changes

n/a

## Bug reference

n/a
