### PR TITLE
state: Add support for CAAS models

### DIFF
--- a/agent/agentbootstrap/bootstrap.go
+++ b/agent/agentbootstrap/bootstrap.go
@@ -109,6 +109,7 @@ func InitializeState(
 	ctlr, st, err := state.Initialize(state.InitializeParams{
 		Clock: clock.WallClock,
 		ControllerModelArgs: state.ModelArgs{
+			Type:                    state.ModelTypeIAAS,
 			Owner:                   adminUser,
 			Config:                  args.ControllerModelConfig,
 			Constraints:             args.ModelConstraints,
@@ -201,6 +202,7 @@ func InitializeState(
 	}
 
 	_, hostedModelState, err := st.NewModel(state.ModelArgs{
+		Type:                    state.ModelTypeIAAS,
 		Owner:                   adminUser,
 		Config:                  hostedModelConfig,
 		Constraints:             args.ModelConstraints,

--- a/apiserver/facades/client/modelmanager/modelmanager.go
+++ b/apiserver/facades/client/modelmanager/modelmanager.go
@@ -382,6 +382,7 @@ func (m *ModelManagerAPI) CreateModel(args params.ModelCreateArgs) (params.Model
 	// version, it is not supported, also check existing tools, and if we don't
 	// have tools for that version, also die.
 	model, st, err := m.state.NewModel(state.ModelArgs{
+		Type:            state.ModelTypeIAAS,
 		CloudName:       cloudTag.Id(),
 		CloudRegion:     cloudRegionName,
 		CloudCredential: cloudCredentialTag,

--- a/apiserver/facades/client/modelmanager/modelmanager_test.go
+++ b/apiserver/facades/client/modelmanager/modelmanager_test.go
@@ -237,6 +237,7 @@ func (s *modelManagerSuite) TestCreateModelArgs(c *gc.C) {
 	newModelArgs.StorageProviderRegistry = nil
 
 	c.Assert(newModelArgs, jc.DeepEquals, state.ModelArgs{
+		Type:        state.ModelTypeIAAS,
 		Owner:       names.NewUserTag("admin"),
 		CloudName:   "some-cloud",
 		CloudRegion: "qux",

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -19,9 +19,9 @@ github.com/joyent/gosdc	git	2f11feadd2d9891e92296a1077c3e2e56939547d	2014-05-24T
 github.com/joyent/gosign	git	0da0d5f1342065321c97812b1f4ac0c2b0bab56c	2014-05-24T00:07:34Z
 github.com/juju/ansiterm	git	b99631de12cf04a906c1d4e4ec54fb86eae5863d	2016-09-07T23:45:32Z
 github.com/juju/blobstore	git	06056004b3d7b54bbb7984d830c537bad00fec21	2015-07-29T11:18:58Z
-github.com/juju/bundlechanges	git	cd189848b313df50084de692b05861210022cf81	2017-08-02T17:04:42Z
+github.com/juju/bundlechanges	git	cd189848b313df50084de692b05861210022cf81	2017-07-31T02:12:50Z
 github.com/juju/cmd	git	ad2437ef0ef282ae26e482eb1e44c02532bae1ba	2017-06-22T12:53:07Z
-github.com/juju/description	git	a08158a2094914d9eb123bb4e19eb8c6d2c575ab	2017-08-11T02:30:02Z
+github.com/juju/description	git	fedf2abd05e6418e575dc2597ba2494bcc4024e1	2017-08-22T03:20:25Z
 github.com/juju/errors	git	1b5e39b83d1835fa480e0c2ddefb040ee82d58b3	2015-09-16T12:56:42Z
 github.com/juju/gnuflag	git	4e76c56581859c14d9d87e1ddbe29e1c0f10195f	2016-08-09T16:52:14Z
 github.com/juju/go-oracle-cloud	git	932a8cea00a1cd5cba3829a672c823955db674ae	2017-04-21T13:45:47Z
@@ -92,7 +92,7 @@ gopkg.in/errgo.v1	git	442357a80af5c6bf9b6d51ae791a39c3421004f3	2016-12-22T12:58:
 gopkg.in/goose.v2	git	54760fcc506e180a22bef75f111d5e0b7d9a7f41	2017-05-11T03:10:46Z
 gopkg.in/ini.v1	git	776aa739ce9373377cd16f526cdf06cb4c89b40f	2016-02-22T23:24:41Z
 gopkg.in/juju/blobstore.v2	git	51fa6e26128d74e445c72d3a91af555151cc3654	2016-01-25T02:37:03Z
-gopkg.in/juju/charm.v6-unstable	git	514bb811b021ebeb3e7ffcf1c267e9803968f59d	2017-07-31T13:20:58Z
+gopkg.in/juju/charm.v6-unstable	git	514bb811b021ebeb3e7ffcf1c267e9803968f59d	2017-07-28T19:41:00Z
 gopkg.in/juju/charmrepo.v2-unstable	git	e79aa298df89ea887c9bffec46063c24bfb730f7	2016-11-17T15:25:28Z
 gopkg.in/juju/charmstore.v5-unstable	git	fd1eef3002fc6b6daff5e97efab6f5056d22dcc7	2016-09-16T10:09:07Z
 gopkg.in/juju/environschema.v1	git	7359fc7857abe2b11b5b3e23811a9c64cb6b01e0	2015-11-04T11:58:10Z

--- a/provider/dummy/environs.go
+++ b/provider/dummy/environs.go
@@ -780,6 +780,7 @@ func (e *environ) Bootstrap(ctx environs.BootstrapContext, args environs.Bootstr
 				Clock:            clock.WallClock,
 				ControllerConfig: icfg.Controller.Config,
 				ControllerModelArgs: state.ModelArgs{
+					Type:                    state.ModelTypeIAAS,
 					Owner:                   adminUser,
 					Config:                  icfg.Bootstrap.ControllerModelConfig,
 					Constraints:             icfg.Bootstrap.BootstrapMachineConstraints,

--- a/state/annotations_test.go
+++ b/state/annotations_test.go
@@ -181,7 +181,10 @@ func (s *AnnotationsEnvSuite) createTestModel(c *gc.C) (*state.Model, *state.Sta
 	})
 	owner := names.NewUserTag("test@remote")
 	model, st, err := s.State.NewModel(state.ModelArgs{
-		CloudName: "dummy", CloudRegion: "dummy-region", Config: cfg, Owner: owner,
+		Type:        state.ModelTypeIAAS,
+		CloudName:   "dummy",
+		CloudRegion: "dummy-region",
+		Config:      cfg, Owner: owner,
 		StorageProviderRegistry: storage.StaticProviderRegistry{},
 	})
 	c.Assert(err, jc.ErrorIsNil)

--- a/state/binarystorage_test.go
+++ b/state/binarystorage_test.go
@@ -82,6 +82,7 @@ func (s *binaryStorageSuite) SetUpTest(c *gc.C) {
 	})
 	var err error
 	_, s.st, err = s.State.NewModel(state.ModelArgs{
+		Type:        state.ModelTypeIAAS,
 		CloudName:   "dummy",
 		CloudRegion: "dummy-region",
 		Config:      cfg,

--- a/state/block_test.go
+++ b/state/block_test.go
@@ -180,7 +180,11 @@ func (s *blockSuite) createTestModel(c *gc.C) (*state.Model, *state.State) {
 	})
 	owner := names.NewUserTag("test@remote")
 	env, st, err := s.State.NewModel(state.ModelArgs{
-		CloudName: "dummy", CloudRegion: "dummy-region", Config: cfg, Owner: owner,
+		Type:        state.ModelTypeIAAS,
+		CloudName:   "dummy",
+		CloudRegion: "dummy-region",
+		Config:      cfg,
+		Owner:       owner,
 		StorageProviderRegistry: storage.StaticProviderRegistry{},
 	})
 	c.Assert(err, jc.ErrorIsNil)

--- a/state/conn_test.go
+++ b/state/conn_test.go
@@ -116,7 +116,11 @@ func (s *ConnSuite) NewStateForModelNamed(c *gc.C, modelName string) *state.Stat
 	})
 	otherOwner := names.NewLocalUserTag("test-admin")
 	_, otherState, err := s.State.NewModel(state.ModelArgs{
-		CloudName: "dummy", CloudRegion: "dummy-region", Config: cfg, Owner: otherOwner,
+		Type:        state.ModelTypeIAAS,
+		CloudName:   "dummy",
+		CloudRegion: "dummy-region",
+		Config:      cfg,
+		Owner:       otherOwner,
 		StorageProviderRegistry: storage.StaticProviderRegistry{},
 	})
 

--- a/state/conn_wallclock_test.go
+++ b/state/conn_wallclock_test.go
@@ -118,7 +118,11 @@ func (s *ConnWithWallClockSuite) NewStateForModelNamed(c *gc.C, modelName string
 	})
 	otherOwner := names.NewLocalUserTag("test-admin")
 	_, otherState, err := s.State.NewModel(state.ModelArgs{
-		CloudName: "dummy", CloudRegion: "dummy-region", Config: cfg, Owner: otherOwner,
+		Type:        state.ModelTypeIAAS,
+		CloudName:   "dummy",
+		CloudRegion: "dummy-region",
+		Config:      cfg,
+		Owner:       otherOwner,
 		StorageProviderRegistry: storage.StaticProviderRegistry{},
 	})
 

--- a/state/initialize.go
+++ b/state/initialize.go
@@ -297,11 +297,13 @@ func (st *State) modelSetupOps(controllerUUID string, args ModelArgs, inherited 
 	}
 
 	// Create the default storage pools for the model.
-	defaultStoragePoolsOps, err := st.createDefaultStoragePoolsOps(args.StorageProviderRegistry)
-	if err != nil {
-		return nil, modelStatusDoc, errors.Trace(err)
+	if args.StorageProviderRegistry != nil {
+		defaultStoragePoolsOps, err := st.createDefaultStoragePoolsOps(args.StorageProviderRegistry)
+		if err != nil {
+			return nil, modelStatusDoc, errors.Trace(err)
+		}
+		ops = append(ops, defaultStoragePoolsOps...)
 	}
-	ops = append(ops, defaultStoragePoolsOps...)
 
 	// Create the final map of config attributes for the model.
 	// If we have ControllerInheritedConfig passed in, that means state
@@ -341,6 +343,7 @@ func (st *State) modelSetupOps(controllerUUID string, args ModelArgs, inherited 
 		createSettingsOp(settingsC, modelGlobalKey, modelCfg),
 		createModelEntityRefsOp(modelUUID),
 		createModelOp(
+			args.Type,
 			args.Owner,
 			args.Config.Name(),
 			modelUUID, controllerUUID,

--- a/state/initialize_test.go
+++ b/state/initialize_test.go
@@ -97,6 +97,7 @@ func (s *InitializeSuite) TestInitialize(c *gc.C) {
 		Clock:            clock.WallClock,
 		ControllerConfig: controllerCfg,
 		ControllerModelArgs: state.ModelArgs{
+			Type:                    state.ModelTypeIAAS,
 			Owner:                   owner,
 			Config:                  cfg,
 			CloudName:               "dummy",
@@ -194,6 +195,7 @@ func (s *InitializeSuite) TestInitializeWithInvalidCredentialType(c *gc.C) {
 		Clock:            clock.WallClock,
 		ControllerConfig: controllerCfg,
 		ControllerModelArgs: state.ModelArgs{
+			Type:                    state.ModelTypeIAAS,
 			CloudName:               "dummy",
 			Owner:                   owner,
 			Config:                  modelCfg,
@@ -231,6 +233,7 @@ func (s *InitializeSuite) TestInitializeWithControllerInheritedConfig(c *gc.C) {
 		Clock:            clock.WallClock,
 		ControllerConfig: controllerCfg,
 		ControllerModelArgs: state.ModelArgs{
+			Type:                    state.ModelTypeIAAS,
 			CloudName:               "dummy",
 			Owner:                   owner,
 			Config:                  cfg,
@@ -287,6 +290,7 @@ func (s *InitializeSuite) TestDoubleInitializeConfig(c *gc.C) {
 		Clock:            clock.WallClock,
 		ControllerConfig: controllerCfg,
 		ControllerModelArgs: state.ModelArgs{
+			Type:                    state.ModelTypeIAAS,
 			CloudName:               "dummy",
 			Owner:                   owner,
 			Config:                  cfg,
@@ -347,6 +351,7 @@ func (s *InitializeSuite) testBadModelConfig(c *gc.C, update map[string]interfac
 		Clock:            clock.WallClock,
 		ControllerConfig: controllerCfg,
 		ControllerModelArgs: state.ModelArgs{
+			Type:                    state.ModelTypeIAAS,
 			CloudName:               "dummy",
 			CloudRegion:             "dummy-region",
 			Owner:                   owner,
@@ -399,6 +404,7 @@ func (s *InitializeSuite) TestCloudConfigWithForbiddenValues(c *gc.C) {
 		Clock:            clock.WallClock,
 		ControllerConfig: controllerCfg,
 		ControllerModelArgs: state.ModelArgs{
+			Type:                    state.ModelTypeIAAS,
 			CloudName:               "dummy",
 			Owner:                   names.NewLocalUserTag("initialize-admin"),
 			Config:                  modelCfg,
@@ -441,6 +447,7 @@ func (s *InitializeSuite) TestInitializeWithCloudRegionConfig(c *gc.C) {
 		Clock:            clock.WallClock,
 		ControllerConfig: controllerCfg,
 		ControllerModelArgs: state.ModelArgs{
+			Type:                    state.ModelTypeIAAS,
 			CloudName:               "dummy",
 			Owner:                   owner,
 			Config:                  cfg,
@@ -503,6 +510,7 @@ func (s *InitializeSuite) TestInitializeWithCloudRegionMisses(c *gc.C) {
 		Clock:            clock.WallClock,
 		ControllerConfig: controllerCfg,
 		ControllerModelArgs: state.ModelArgs{
+			Type:                    state.ModelTypeIAAS,
 			CloudName:               "dummy",
 			Owner:                   owner,
 			Config:                  cfg,
@@ -561,6 +569,7 @@ func (s *InitializeSuite) TestInitializeWithCloudRegionHits(c *gc.C) {
 		Clock:            clock.WallClock,
 		ControllerConfig: controllerCfg,
 		ControllerModelArgs: state.ModelArgs{
+			Type:                    state.ModelTypeIAAS,
 			CloudName:               "dummy",
 			Owner:                   owner,
 			Config:                  cfg,

--- a/state/internal_test.go
+++ b/state/internal_test.go
@@ -72,6 +72,7 @@ func (s *internalStateSuite) SetUpTest(c *gc.C) {
 		Clock:            clock.WallClock,
 		ControllerConfig: controllerCfg,
 		ControllerModelArgs: ModelArgs{
+			Type:        ModelTypeIAAS,
 			CloudName:   "dummy",
 			CloudRegion: "dummy-region",
 			Owner:       s.owner,
@@ -118,6 +119,7 @@ func (s *internalStateSuite) newState(c *gc.C) *State {
 		"uuid": utils.MustNewUUID().String(),
 	})
 	_, st, err := s.state.NewModel(ModelArgs{
+		Type:        ModelTypeIAAS,
 		CloudName:   "dummy",
 		CloudRegion: "dummy-region",
 		Config:      cfg,

--- a/state/migration_export.go
+++ b/state/migration_export.go
@@ -95,6 +95,7 @@ func (st *State) exportImpl(cfg ExportConfig) (description.Model, error) {
 	}
 
 	args := description.ModelArgs{
+		Type:               string(dbModel.Type()),
 		Cloud:              dbModel.Cloud(),
 		CloudRegion:        dbModel.CloudRegion(),
 		Owner:              dbModel.Owner(),

--- a/state/migration_export_test.go
+++ b/state/migration_export_test.go
@@ -175,6 +175,7 @@ func (s *MigrationExportSuite) TestModelInfo(c *gc.C) {
 
 	dbModel, err := s.State.Model()
 	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(model.Type(), gc.Equals, string(dbModel.Type()))
 	c.Assert(model.Tag(), gc.Equals, dbModel.ModelTag())
 	c.Assert(model.Owner(), gc.Equals, dbModel.Owner())
 	dbModelCfg, err := dbModel.Config()

--- a/state/migration_import.go
+++ b/state/migration_import.go
@@ -68,6 +68,7 @@ func (st *State) Import(model description.Model) (_ *Model, _ *State, err error)
 		return nil, nil, errors.Trace(err)
 	}
 	args := ModelArgs{
+		Type:           ModelTypeIAAS,
 		CloudName:      model.Cloud(),
 		CloudRegion:    model.CloudRegion(),
 		Config:         cfg,

--- a/state/migration_import.go
+++ b/state/migration_import.go
@@ -62,13 +62,18 @@ func (st *State) Import(model description.Model) (_ *Model, _ *State, err error)
 		return nil, nil, errors.New("can't import models with remote applications")
 	}
 
+	modelType, err := ParseModelType(model.Type())
+	if err != nil {
+		return nil, nil, errors.Trace(err)
+	}
+
 	// Create the model.
 	cfg, err := config.New(config.NoDefaults, model.Config())
 	if err != nil {
 		return nil, nil, errors.Trace(err)
 	}
 	args := ModelArgs{
-		Type:           ModelTypeIAAS,
+		Type:           modelType,
 		CloudName:      model.Cloud(),
 		CloudRegion:    model.CloudRegion(),
 		Config:         cfg,

--- a/state/migration_import_test.go
+++ b/state/migration_import_test.go
@@ -125,6 +125,7 @@ func (s *MigrationImportSuite) TestNewModel(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	defer newSt.Close()
 
+	c.Assert(newModel.Type(), gc.Equals, original.Type())
 	c.Assert(newModel.Owner(), gc.Equals, original.Owner())
 	c.Assert(newModel.LatestToolsVersion(), gc.Equals, latestTools)
 	c.Assert(newModel.MigrationMode(), gc.Equals, state.MigrationModeImporting)

--- a/state/migration_internal_test.go
+++ b/state/migration_internal_test.go
@@ -222,6 +222,7 @@ func (s *MigrationSuite) TestModelDocFields(c *gc.C) {
 		// is created in the new controller (yay name changes).
 		"ControllerUUID",
 
+		"Type",
 		"MigrationMode",
 		"Owner",
 		"Cloud",

--- a/state/model.go
+++ b/state/model.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/juju/errors"
 	jujutxn "github.com/juju/txn"
+	"github.com/juju/utils/featureflag"
 	"github.com/juju/version"
 	"gopkg.in/juju/names.v2"
 	"gopkg.in/mgo.v2"
@@ -17,6 +18,7 @@ import (
 	jujucloud "github.com/juju/juju/cloud"
 	"github.com/juju/juju/constraints"
 	"github.com/juju/juju/environs/config"
+	"github.com/juju/juju/feature"
 	"github.com/juju/juju/permission"
 	"github.com/juju/juju/status"
 	"github.com/juju/juju/storage"
@@ -31,21 +33,30 @@ func modelKey(modelUUID string) string {
 	return fmt.Sprintf("%s#%s", modelGlobalKey, modelUUID)
 }
 
+// ModelType signals the type of a model - IAAS or CAAS
+type ModelType string
+
+const (
+	modelTypeNone = ModelType("")
+	ModelTypeIAAS = ModelType("iaas")
+	ModelTypeCAAS = ModelType("caas")
+)
+
 // MigrationMode specifies where the Model is with respect to migration.
 type MigrationMode string
 
 const (
 	// MigrationModeNone is the default mode for a model and reflects
 	// that it isn't involved with a model migration.
-	MigrationModeNone MigrationMode = ""
+	MigrationModeNone = MigrationMode("")
 
 	// MigrationModeExporting reflects a model that is in the process of being
 	// exported from one controller to another.
-	MigrationModeExporting MigrationMode = "exporting"
+	MigrationModeExporting = MigrationMode("exporting")
 
 	// MigrationModeImporting reflects a model that is being imported into a
 	// controller, but is not yet fully active.
-	MigrationModeImporting MigrationMode = "importing"
+	MigrationModeImporting = MigrationMode("importing")
 )
 
 // Model represents the state of a model.
@@ -56,9 +67,10 @@ type Model struct {
 
 // modelDoc represents the internal state of the model in MongoDB.
 type modelDoc struct {
-	UUID           string `bson:"_id"`
-	Name           string
-	Life           Life
+	UUID           string        `bson:"_id"`
+	Name           string        `bson:"name"`
+	Type           ModelType     `bson:"type"`
+	Life           Life          `bson:"life"`
 	Owner          string        `bson:"owner"`
 	ControllerUUID string        `bson:"controller-uuid"`
 	MigrationMode  MigrationMode `bson:"migration-mode"`
@@ -223,6 +235,9 @@ func (st *State) ModelActive(uuid string) (bool, error) {
 
 // ModelArgs is a params struct for creating a new model.
 type ModelArgs struct {
+	// Type specifies the general type of the model (IAAS or CAAS).
+	Type ModelType
+
 	// CloudName is the name of the cloud to which the model is deployed.
 	CloudName string
 
@@ -257,17 +272,29 @@ type ModelArgs struct {
 
 // Validate validates the ModelArgs.
 func (m ModelArgs) Validate() error {
+	if m.Type == modelTypeNone {
+		return errors.NotValidf("empty Type")
+	}
+	if m.Type == ModelTypeCAAS && !featureflag.Enabled(feature.CAAS) {
+		return errors.NotSupportedf("model type")
+	}
 	if m.Config == nil {
 		return errors.NotValidf("nil Config")
 	}
 	if !names.IsValidCloud(m.CloudName) {
 		return errors.NotValidf("Cloud Name %q", m.CloudName)
 	}
+	if m.Type == ModelTypeCAAS && m.CloudRegion != "" {
+		return errors.NotSupportedf("CAAS model with CloudRegion")
+	}
 	if m.Owner == (names.UserTag{}) {
 		return errors.NotValidf("empty Owner")
 	}
-	if m.StorageProviderRegistry == nil {
+	if m.StorageProviderRegistry == nil && m.Type == ModelTypeIAAS {
 		return errors.NotValidf("nil StorageProviderRegistry")
+	}
+	if m.StorageProviderRegistry != nil && m.Type == ModelTypeCAAS {
+		return errors.NotValidf("CAAS model with StorageProviderRegistry")
 	}
 	switch m.MigrationMode {
 	case MigrationModeNone, MigrationModeImporting:
@@ -306,9 +333,15 @@ func (st *State) NewModel(args ModelArgs) (_ *Model, _ *State, err error) {
 	if err != nil {
 		return nil, nil, errors.Trace(err)
 	}
-	assertCloudRegionOp, err := validateCloudRegion(controllerCloud, args.CloudRegion)
-	if err != nil {
-		return nil, nil, errors.Trace(err)
+
+	var prereqOps []txn.Op
+
+	if args.Type == ModelTypeIAAS {
+		assertCloudRegionOp, err := validateCloudRegion(controllerCloud, args.CloudRegion)
+		if err != nil {
+			return nil, nil, errors.Trace(err)
+		}
+		prereqOps = append(prereqOps, assertCloudRegionOp)
 	}
 
 	// Ensure that the cloud credential is valid, or if one is not
@@ -325,6 +358,7 @@ func (st *State) NewModel(args ModelArgs) (_ *Model, _ *State, err error) {
 	if err != nil {
 		return nil, nil, errors.Trace(err)
 	}
+	prereqOps = append(prereqOps, assertCloudCredentialOp)
 
 	if owner.IsLocal() {
 		if _, err := st.User(owner); err != nil {
@@ -358,10 +392,6 @@ func (st *State) NewModel(args ModelArgs) (_ *Model, _ *State, err error) {
 		return nil, nil, errors.Annotate(err, "failed to create new model")
 	}
 
-	prereqOps := []txn.Op{
-		assertCloudRegionOp,
-		assertCloudCredentialOp,
-	}
 	ops := append(prereqOps, modelOps...)
 	err = newSt.db().RunTransaction(ops)
 	if err == txn.ErrAborted {
@@ -526,6 +556,11 @@ func (m *Model) ControllerUUID() string {
 // Name returns the human friendly name of the model.
 func (m *Model) Name() string {
 	return m.doc.Name
+}
+
+// Type returns the human friendly name of the model.
+func (m *Model) Type() ModelType {
+	return m.doc.Type
 }
 
 // Cloud returns the name of the cloud to which the model is deployed.
@@ -1297,6 +1332,7 @@ func removeModelEntityRefOp(mb modelBackend, entityField, entityId string) txn.O
 // createModelOp returns the operation needed to create
 // an model document with the given name and UUID.
 func createModelOp(
+	modelType ModelType,
 	owner names.UserTag,
 	name, uuid, controllerUUID, cloudName, cloudRegion string,
 	cloudCredential names.CloudCredentialTag,
@@ -1304,6 +1340,7 @@ func createModelOp(
 	environVersion int,
 ) txn.Op {
 	doc := &modelDoc{
+		Type:            modelType,
 		UUID:            uuid,
 		Name:            name,
 		Life:            Alive,

--- a/state/model.go
+++ b/state/model.go
@@ -42,6 +42,17 @@ const (
 	ModelTypeCAAS = ModelType("caas")
 )
 
+// ParseModelType turns a valid model type string into a ModelType
+// constant.
+func ParseModelType(raw string) (ModelType, error) {
+	for _, typ := range []ModelType{ModelTypeIAAS, ModelTypeCAAS} {
+		if raw == string(typ) {
+			return typ, nil
+		}
+	}
+	return "", errors.NotValidf("model type %v", raw)
+}
+
 // MigrationMode specifies where the Model is with respect to migration.
 type MigrationMode string
 

--- a/state/modelconfig_test.go
+++ b/state/modelconfig_test.go
@@ -325,7 +325,11 @@ func (s *ModelConfigSourceSuite) TestNewModelConfigForksControllerValue(c *gc.C)
 	})
 	owner := names.NewUserTag("test@remote")
 	_, st, err := s.State.NewModel(state.ModelArgs{
-		Config: cfg, Owner: owner, CloudName: "dummy", CloudRegion: "nether-region",
+		Type:                    state.ModelTypeIAAS,
+		Config:                  cfg,
+		Owner:                   owner,
+		CloudName:               "dummy",
+		CloudRegion:             "nether-region",
 		StorageProviderRegistry: storage.StaticProviderRegistry{},
 	})
 	c.Assert(err, jc.ErrorIsNil)

--- a/state/modeluser_test.go
+++ b/state/modeluser_test.go
@@ -491,7 +491,11 @@ func (s *ModelUserSuite) newModelWithOwner(c *gc.C, owner names.UserTag) *state.
 		"uuid": uuidStr,
 	})
 	model, st, err := s.State.NewModel(state.ModelArgs{
-		CloudName: "dummy", CloudRegion: "dummy-region", Config: cfg, Owner: owner,
+		Type:        state.ModelTypeIAAS,
+		CloudName:   "dummy",
+		CloudRegion: "dummy-region",
+		Config:      cfg,
+		Owner:       owner,
 		StorageProviderRegistry: storage.StaticProviderRegistry{},
 	})
 	c.Assert(err, jc.ErrorIsNil)

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -4703,6 +4703,7 @@ func (s *SetAdminMongoPasswordSuite) TestSetAdminMongoPassword(c *gc.C) {
 		Clock:            clock.WallClock,
 		ControllerConfig: controllerCfg,
 		ControllerModelArgs: state.ModelArgs{
+			Type:                    state.ModelTypeIAAS,
 			CloudName:               "dummy",
 			Owner:                   owner,
 			Config:                  cfg,

--- a/state/testing/conn.go
+++ b/state/testing/conn.go
@@ -65,6 +65,7 @@ func InitializeWithArgs(c *gc.C, args InitializeArgs) (*state.Controller, *state
 		Clock:            args.Clock,
 		ControllerConfig: controllerCfg,
 		ControllerModelArgs: state.ModelArgs{
+			Type:        state.ModelTypeIAAS,
 			CloudName:   "dummy",
 			CloudRegion: "dummy-region",
 			Config:      args.InitialConfig,

--- a/state/upgrades_test.go
+++ b/state/upgrades_test.go
@@ -83,6 +83,7 @@ func (s *upgradesSuite) TestStripLocalUserDomainModels(c *gc.C) {
 
 	err = coll.Insert(
 		modelDoc{
+			Type:            ModelTypeIAAS,
 			UUID:            "0000-dead-beaf-0001",
 			Owner:           "user-admin@local",
 			Name:            "controller",
@@ -93,6 +94,7 @@ func (s *upgradesSuite) TestStripLocalUserDomainModels(c *gc.C) {
 			EnvironVersion:  0,
 		},
 		modelDoc{
+			Type:            ModelTypeIAAS,
 			UUID:            "0000-dead-beaf-0002",
 			Owner:           "user-mary@external",
 			Name:            "default",
@@ -112,6 +114,7 @@ func (s *upgradesSuite) TestStripLocalUserDomainModels(c *gc.C) {
 
 	expected := []bson.M{{
 		"_id":              "0000-dead-beaf-0001",
+		"type":             "iaas",
 		"owner":            "user-admin",
 		"cloud":            "cloud-aws",
 		"name":             "controller",
@@ -125,6 +128,7 @@ func (s *upgradesSuite) TestStripLocalUserDomainModels(c *gc.C) {
 		"environ-version":  0,
 	}, {
 		"_id":              "0000-dead-beaf-0002",
+		"type":             "iaas",
 		"owner":            "user-mary@external",
 		"cloud":            "cloud-aws",
 		"name":             "default",
@@ -981,6 +985,7 @@ func (s *upgradesSuite) makeModel(c *gc.C, name string, attr testing.Attrs) *Sta
 	m, err := s.state.Model()
 	c.Assert(err, jc.ErrorIsNil)
 	_, st, err := s.state.NewModel(ModelArgs{
+		Type:        ModelTypeIAAS,
 		CloudName:   "dummy",
 		CloudRegion: "dummy-region",
 		Config:      cfg,

--- a/testing/factory/factory.go
+++ b/testing/factory/factory.go
@@ -122,6 +122,7 @@ type MetricParams struct {
 }
 
 type ModelParams struct {
+	Type                    state.ModelType
 	Name                    string
 	Owner                   names.Tag
 	ConfigAttrs             testing.Attrs
@@ -610,6 +611,9 @@ func (factory *Factory) MakeModel(c *gc.C, params *ModelParams) *state.State {
 	if params == nil {
 		params = new(ModelParams)
 	}
+	if params.Type == state.ModelType("") {
+		params.Type = state.ModelTypeIAAS
+	}
 	if params.Name == "" {
 		params.Name = uniqueString("testenv")
 	}
@@ -640,6 +644,7 @@ func (factory *Factory) MakeModel(c *gc.C, params *ModelParams) *state.State {
 		"type": currentCfg.Type(),
 	}.Merge(params.ConfigAttrs))
 	_, st, err := factory.st.NewModel(state.ModelArgs{
+		Type:            params.Type,
 		CloudName:       params.CloudName,
 		CloudRegion:     params.CloudRegion,
 		CloudCredential: params.CloudCredential,


### PR DESCRIPTION
## Description of change

If the CAAS featureflag is enabled, allow models to be created of type "caas". The model type must be specified when creating a model.

Migration support for model type field has also been added. This doesn't mean that migrations will "just work" for CAAS models but these changes are required to support that anyway.

This change caused plenty of tedious fallout in tests throughout Juju.

## QA steps

(coming)

## Documentation changes

N.A.

## Bug reference

N.A.
