### PR TITLE
state/statemetrics: Fix up backend interfaces

### DIFF
--- a/state/statemetrics/mock_test.go
+++ b/state/statemetrics/mock_test.go
@@ -37,6 +37,19 @@ func (m *mockStatePool) Get(modelUUID string) (statemetrics.State, state.StatePo
 	panic("model not found")
 }
 
+func (m *mockStatePool) GetModel(modelUUID string) (statemetrics.Model, state.StatePoolReleaser, error) {
+	m.MethodCall(m, "GetModel", modelUUID)
+	if err := m.NextErr(); err != nil {
+		return nil, nil, err
+	}
+	for _, m := range m.system.models {
+		if m.tag.Id() == modelUUID {
+			return m, func() bool { return true }, nil
+		}
+	}
+	panic("model not found")
+}
+
 type mockState struct {
 	statemetrics.State
 
@@ -45,14 +58,14 @@ type mockState struct {
 	users  []*mockUser
 }
 
-func (m *mockState) AllModels() ([]statemetrics.Model, error) {
-	m.MethodCall(m, "AllModels")
+func (m *mockState) AllModelUUIDs() ([]string, error) {
+	m.MethodCall(m, "AllModelsUUIDs")
 	if err := m.NextErr(); err != nil {
 		return nil, err
 	}
-	out := make([]statemetrics.Model, len(m.models))
+	out := make([]string, len(m.models))
 	for i, m := range m.models {
-		out[i] = m
+		out[i] = m.tag.Id()
 	}
 	return out, nil
 }


### PR DESCRIPTION
## Description of change

Don't conflate the State and StatePool backends. Also rework AllModels to AllModelUUIDs to avoid giving out Model instances which refer to released State instances.

## QA steps

Tests pass. Basic bootstrap and deploy works.

## Documentation changes

N.A.

## Bug reference

N.A.
