### PR TITLE
anonymous logins now use special username

### DIFF
--- a/apiserver/admin_test.go
+++ b/apiserver/admin_test.go
@@ -554,7 +554,9 @@ func (s *loginSuite) TestAnonymousModelLogin(c *gc.C) {
 	conn := s.openAPIWithoutLogin(c, info)
 
 	var result params.LoginResult
-	request := &params.LoginRequest{}
+	request := &params.LoginRequest{
+		AuthTag: names.NewUserTag("jujuanonymous").String(),
+	}
 	err := conn.APICall("Admin", 3, "", "Login", request, &result)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.UserInfo, gc.IsNil)
@@ -578,7 +580,9 @@ func (s *loginSuite) TestAnonymousControllerLogin(c *gc.C) {
 	conn := s.openAPIWithoutLogin(c, info)
 
 	var result params.LoginResult
-	request := &params.LoginRequest{}
+	request := &params.LoginRequest{
+		AuthTag: names.NewUserTag("jujuanonymous").String(),
+	}
 	err := conn.APICall("Admin", 3, "", "Login", request, &result)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.UserInfo, gc.IsNil)

--- a/apiserver/authentication/user.go
+++ b/apiserver/authentication/user.go
@@ -43,6 +43,9 @@ type UserAuthenticator struct {
 const (
 	usernameKey = "username"
 
+	// AnonymousUsername is used when making anonymous login requests.
+	AnonymousUsername = "jujuanonymous"
+
 	// LocalLoginInteractionTimeout is how long a user has to complete
 	// an interactive login before it is expired.
 	LocalLoginInteractionTimeout = 2 * time.Minute

--- a/worker/firewaller/shim.go
+++ b/worker/firewaller/shim.go
@@ -7,6 +7,7 @@ import (
 	"io"
 
 	"github.com/juju/errors"
+	"gopkg.in/juju/names.v2"
 	"gopkg.in/juju/worker.v1"
 
 	"github.com/juju/juju/api"
@@ -14,6 +15,7 @@ import (
 	"github.com/juju/juju/api/crossmodelrelations"
 	"github.com/juju/juju/api/firewaller"
 	"github.com/juju/juju/api/remoterelations"
+	"github.com/juju/juju/apiserver/authentication"
 	"github.com/juju/juju/worker/apicaller"
 )
 
@@ -50,6 +52,7 @@ func crossmodelFirewallerFacadeFunc(
 	connectionFunc apicaller.NewExternalControllerConnectionFunc,
 ) newCrossModelFacadeFunc {
 	return func(apiInfo *api.Info) (CrossModelFirewallerFacadeCloser, error) {
+		apiInfo.Tag = names.NewUserTag(authentication.AnonymousUsername)
 		conn, err := connectionFunc(apiInfo)
 		if err != nil {
 			return nil, errors.Trace(err)

--- a/worker/remoterelations/shim.go
+++ b/worker/remoterelations/shim.go
@@ -7,12 +7,14 @@ import (
 	"io"
 
 	"github.com/juju/errors"
+	"gopkg.in/juju/names.v2"
 	worker "gopkg.in/juju/worker.v1"
 
 	"github.com/juju/juju/api"
 	"github.com/juju/juju/api/base"
 	"github.com/juju/juju/api/crossmodelrelations"
 	"github.com/juju/juju/api/remoterelations"
+	"github.com/juju/juju/apiserver/authentication"
 	"github.com/juju/juju/worker/apicaller"
 )
 
@@ -43,6 +45,7 @@ func remoteRelationsFacadeForModelFunc(
 	connectionFunc apicaller.NewExternalControllerConnectionFunc,
 ) newRemoteRelationsFacadeFunc {
 	return func(apiInfo *api.Info) (RemoteModelRelationsFacadeCloser, error) {
+		apiInfo.Tag = names.NewUserTag(authentication.AnonymousUsername)
 		conn, err := connectionFunc(apiInfo)
 		if err != nil {
 			return nil, errors.Trace(err)


### PR DESCRIPTION
## Description of change

apiserver login was changed to allow anonymous logins. Anonymous logins were determined by username and macaroons being empty. However, this broke client like the GUI which expected logins with no username to return a discharge error.

We introduce a special username "jujuanonymous". This is used to request an anonymous login.

## QA steps

Smoke test normal bootstrap and GUI usage.
Smoke test CMR scenario.
