### PR TITLE
apiserver/facades/client/client: Separate pool from state backend

### DIFF
--- a/apiserver/facades/client/client/statushistory_test.go
+++ b/apiserver/facades/client/client/statushistory_test.go
@@ -33,6 +33,7 @@ func (s *statusHistoryTestSuite) SetUpTest(c *gc.C) {
 	var err error
 	s.api, err = client.NewClient(
 		s.st,
+		nil, // pool
 		nil, // modelconfig API
 		nil, // resources
 		authorizer,


### PR DESCRIPTION
## Description of change

Merging the Pool and State backends was awkward and was making further changes more difficult than they needed to be.

## QA steps

The StatePool is used to prevent upgrades during migration so test that:

```
juju bootstrap lxd source
# wait...
juju bootstrap lxd target
# wait...
juju switch source
juju add-model foo
juju deploy ubuntu
# wait...
$ juju migrate foo target ; juju upgrade-juju -m controller --build-agent
Migration started with ID "a3bfdc5d-e567-467f-8afa-e8d394293036:0"
ERROR model "admin/foo" is exporting, upgrade blocked
```

The ERROR is desired and expected.

## Documentation changes

N.A.

## Bug reference

N.A.
