### PR TITLE
upgrades: Remove unnecessary StatePool usage

### DIFF
--- a/upgrades/backend.go
+++ b/upgrades/backend.go
@@ -41,13 +41,12 @@ type Model interface {
 }
 
 // NewStateBackend returns a new StateBackend using a *state.State object.
-func NewStateBackend(st *state.State, pool *state.StatePool) StateBackend {
-	return stateBackend{st, pool}
+func NewStateBackend(st *state.State) StateBackend {
+	return stateBackend{st}
 }
 
 type stateBackend struct {
-	st   *state.State
-	pool *state.StatePool
+	st *state.State
 }
 
 func (s stateBackend) ControllerUUID() string {

--- a/worker/upgradesteps/worker.go
+++ b/worker/upgradesteps/worker.go
@@ -338,9 +338,7 @@ func (w *upgradesteps) runUpgradeSteps(agentConfig agent.ConfigSetter) error {
 	var upgradeErr error
 	w.machine.SetStatus(status.Started, fmt.Sprintf("upgrading to %v", w.toVersion), nil)
 
-	pool := state.NewStatePool(w.st)
-	defer pool.Close()
-	stBackend := upgrades.NewStateBackend(w.st, pool)
+	stBackend := upgrades.NewStateBackend(w.st)
 	context := upgrades.NewContext(agentConfig, w.apiConn, stBackend)
 	logger.Infof("starting upgrade from %v to %v for %q", w.fromVersion, w.toVersion, w.tag)
 


### PR DESCRIPTION
## Description of change

A StatePool was being passed in to the NewStateBackend that is no longer used.

## QA steps

Code compiles and unit tests still pass (trivial change).

## Documentation changes

N.A.

## Bug reference

N.A.