### PR TITLE
Adding machine to update-series.

### DIFF
--- a/api/application/client.go
+++ b/api/application/client.go
@@ -243,11 +243,11 @@ func (c *Client) Update(args params.ApplicationUpdate) error {
 
 // UpdateApplicationSeries updates the application series in the db.
 func (c *Client) UpdateApplicationSeries(appName, series string, force bool) error {
-	args := params.ApplicationUpdateSeriesArgs{
-		Args: []params.ApplicationUpdateSeriesArg{{
-			ApplicationName: appName,
-			Force:           force,
-			Series:          series,
+	args := params.UpdateSeriesArgs{
+		Args: []params.UpdateSeriesArg{{
+			Entity: params.Entity{Tag: names.NewApplicationTag(appName).String()},
+			Force:  force,
+			Series: series,
 		}},
 	}
 

--- a/api/machinemanager/machinemanager.go
+++ b/api/machinemanager/machinemanager.go
@@ -117,3 +117,21 @@ func (client *Client) destroyMachines(method string, machines []string) ([]param
 	}
 	return allResults, nil
 }
+
+// UpdateMachineSeries updates the series of the machine in the db.
+func (client *Client) UpdateMachineSeries(machineName, series string, force bool) error {
+	args := params.UpdateSeriesArgs{
+		Args: []params.UpdateSeriesArg{{
+			Entity: params.Entity{Tag: names.NewMachineTag(machineName).String()},
+			Series: series,
+			Force:  force,
+		}},
+	}
+
+	results := new(params.ErrorResults)
+	err := client.facade.FacadeCall("UpdateMachineSeries", args, results)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	return results.OneError()
+}

--- a/apiserver/facades/client/application/application.go
+++ b/apiserver/facades/client/application/application.go
@@ -375,7 +375,7 @@ func (api *API) Update(args params.ApplicationUpdate) error {
 
 // UpdateApplicationSeries updates the application series. Series for
 // subordinates updated too.
-func (api *API) UpdateApplicationSeries(args params.ApplicationUpdateSeriesArgs) (params.ErrorResults, error) {
+func (api *API) UpdateApplicationSeries(args params.UpdateSeriesArgs) (params.ErrorResults, error) {
 	if err := api.checkCanWrite(); err != nil {
 		return params.ErrorResults{}, err
 	}
@@ -392,20 +392,24 @@ func (api *API) UpdateApplicationSeries(args params.ApplicationUpdateSeriesArgs)
 	return results, nil
 }
 
-func (api *API) updateOneApplicationSeries(arg params.ApplicationUpdateSeriesArg) error {
+func (api *API) updateOneApplicationSeries(arg params.UpdateSeriesArg) error {
 	if arg.Series == "" {
 		return &params.Error{
 			Message: "series missing from args",
 			Code:    params.CodeBadRequest,
 		}
 	}
-	app, err := api.backend.Application(arg.ApplicationName)
+	applicationTag, err := names.ParseApplicationTag(arg.Entity.Tag)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	app, err := api.backend.Application(applicationTag.Id())
 	if err != nil {
 		return errors.Trace(err)
 	}
 	if !app.IsPrincipal() {
 		return &params.Error{
-			Message: fmt.Sprintf("%q is a subordinate application, update-series not supported", arg.ApplicationName),
+			Message: fmt.Sprintf("%q is a subordinate application, update-series not supported", applicationTag.Id()),
 			Code:    params.CodeNotSupported,
 		}
 	}

--- a/apiserver/facades/client/machinemanager/state.go
+++ b/apiserver/facades/client/machinemanager/state.go
@@ -43,8 +43,10 @@ type Model interface {
 type Machine interface {
 	Destroy() error
 	ForceDestroy() error
+	Series() string
 	Units() ([]Unit, error)
 	SetKeepInstance(keepInstance bool) error
+	UpdateMachineSeries(string, bool) error
 }
 
 type stateShim struct {

--- a/apiserver/params/params.go
+++ b/apiserver/params/params.go
@@ -251,18 +251,22 @@ type ApplicationUpdate struct {
 	Constraints     *constraints.Value `json:"constraints,omitempty"`
 }
 
-// ApplicationUpdateSeriesParams holds the parameters for updating the series for the
-// application to use in the future. Only known by facade version 5 and greater.
-type ApplicationUpdateSeriesArg struct {
-	ApplicationName string `json:"application"`
-	Force           bool   `json:"force"`
-	Series          string `json:"series"`
+// UpdateSeriesArg holds the parameters for updating the series for the
+// specified application or machine. For Application, only known by facade
+// version 5 and greater. For MachineManger, only known by facade version
+// 4 or greater.
+type UpdateSeriesArg struct {
+	Entity Entity `json:"tag"`
+	Force  bool   `json:"force"`
+	Series string `json:"series"`
 }
 
-// ApplicationUpdateSeriesArgs holds the parameters for updating the series
-// of one or more applications.
-type ApplicationUpdateSeriesArgs struct {
-	Args []ApplicationUpdateSeriesArg `json:"args"`
+// UpdateSeriesArgs holds the parameters for updating the series
+// of one or more applications or machines. For Application, only known
+// by facade version 5 and greater. For MachineManger, only known by facade
+// version 4 or greater.
+type UpdateSeriesArgs struct {
+	Args []UpdateSeriesArg `json:"args"`
 }
 
 // ApplicationSetCharm sets the charm for a given application.

--- a/cmd/juju/application/export_test.go
+++ b/cmd/juju/application/export_test.go
@@ -72,10 +72,12 @@ func NewConsumeCommandForTest(
 }
 
 func NewUpdateSeriesCommandForTest(
-	api updateSeriesAPI,
+	appAPI updateApplicationSeriesAPI,
+	machAPI updateMachineSeriesAPI,
 ) modelcmd.ModelCommand {
 	cmd := &updateSeriesCommand{
-		updateSeriesClient: api,
+		updateApplicationSeriesClient: appAPI,
+		updateMachineSeriesClient:     machAPI,
 	}
 	return modelcmd.Wrap(cmd)
 }

--- a/featuretests/cmd_juju_updateseries_test.go
+++ b/featuretests/cmd_juju_updateseries_test.go
@@ -15,7 +15,7 @@ type cmdUpdateSeriesSuite struct {
 	jujutesting.JujuConnSuite
 }
 
-func (s *cmdUpdateSeriesSuite) TestUpdateSeries(c *gc.C) {
+func (s *cmdUpdateSeriesSuite) TestUpdateApplicationSeries(c *gc.C) {
 	charm := s.Factory.MakeCharm(c, &factory.CharmParams{Name: "multi-series", URL: "local:quantal/multi-series-1"})
 	app := s.Factory.MakeApplication(c, &factory.ApplicationParams{Charm: charm})
 	_ = s.Factory.MakeUnit(c, &factory.UnitParams{Application: app, SetCharmURL: true})
@@ -24,4 +24,14 @@ func (s *cmdUpdateSeriesSuite) TestUpdateSeries(c *gc.C) {
 	err := app.Refresh()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(app.Series(), gc.Equals, "trusty")
+}
+
+func (s *cmdUpdateSeriesSuite) TestUpdateMachineSeries(c *gc.C) {
+	charm := s.Factory.MakeCharm(c, &factory.CharmParams{Name: "multi-series", URL: "local:quantal/multi-series-1"})
+	app := s.Factory.MakeApplication(c, &factory.ApplicationParams{Charm: charm})
+	_ = s.Factory.MakeUnit(c, &factory.UnitParams{Application: app, SetCharmURL: true})
+	runCommandExpectSuccess(c, "update-series", "0", "trusty")
+	machine, err := s.State.Machine("0")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(machine.Series(), gc.Equals, "trusty")
 }

--- a/state/application.go
+++ b/state/application.go
@@ -1065,9 +1065,11 @@ func (a *Application) UpdateApplicationSeries(series string, force bool) (err er
 
 		//Create the transaction operations
 		ops := []txn.Op{{
-			C:      applicationsC,
-			Id:     a.doc.DocID,
-			Assert: bson.D{{"charmurl", a.doc.CharmURL}, {"unitcount", a.doc.UnitCount}},
+			C:  applicationsC,
+			Id: a.doc.DocID,
+			Assert: bson.D{{"life", Alive},
+				{"charmurl", a.doc.CharmURL},
+				{"unitcount", a.doc.UnitCount}},
 			Update: bson.D{{"$set", bson.D{{"series", series}}}},
 		}}
 		if err != nil {
@@ -1075,16 +1077,19 @@ func (a *Application) UpdateApplicationSeries(series string, force bool) (err er
 		}
 		if unit != nil {
 			ops = append(ops, txn.Op{
-				C:      unitsC,
-				Id:     unit.doc.DocID,
-				Assert: bson.D{{"subordinates", unit.SubordinateNames()}},
+				C:  unitsC,
+				Id: unit.doc.DocID,
+				Assert: bson.D{{"life", Alive},
+					{"subordinates", unit.SubordinateNames()}},
 			})
 		}
 		for _, sub := range subApps {
 			ops = append(ops, txn.Op{
-				C:      applicationsC,
-				Id:     sub.doc.DocID,
-				Assert: bson.D{{"charmurl", sub.doc.CharmURL}, {"unitcount", sub.doc.UnitCount}},
+				C:  applicationsC,
+				Id: sub.doc.DocID,
+				Assert: bson.D{{"life", Alive},
+					{"charmurl", sub.doc.CharmURL},
+					{"unitcount", sub.doc.UnitCount}},
 				Update: bson.D{{"$set", bson.D{{"series", series}}}},
 			})
 		}
@@ -1105,8 +1110,8 @@ func (a *Application) VerifySupportedSeries(series string, force bool) error {
 	_, seriesSupportedErr := charm.SeriesForCharm(series, ch.Meta().Series)
 	if seriesSupportedErr != nil && !force {
 		return &ErrIncompatibleSeries{
-			seriesList: ch.Meta().Series,
-			series:     series,
+			SeriesList: ch.Meta().Series,
+			Series:     series,
 		}
 	}
 	return nil

--- a/state/application_test.go
+++ b/state/application_test.go
@@ -1182,7 +1182,6 @@ func (s *ApplicationSuite) TestUpdateApplicationSeriesSecondSubordinateIncompati
 
 	err = app.UpdateApplicationSeries("yakkety", false)
 	c.Assert(err, jc.Satisfies, state.IsIncompatibleSeriesError)
-	//c.Assert(err, jc.ErrorIsNil)
 	assertApplicationSeriesUpdate(c, app, "precise")
 	assertApplicationSeriesUpdate(c, subApp, "precise")
 

--- a/state/errors.go
+++ b/state/errors.go
@@ -138,13 +138,13 @@ func IsParentDeviceHasChildrenError(err interface{}) bool {
 // ErrIncompatibleSeries is a standard error to indicate that the series
 // requested is not compatible with the charm of the application.
 type ErrIncompatibleSeries struct {
-	seriesList []string
-	series     string
+	SeriesList []string
+	Series     string
 }
 
 func (e *ErrIncompatibleSeries) Error() string {
 	return fmt.Sprintf("series %q not supported by charm, supported series are: %s",
-		e.series, strings.Join(e.seriesList, ","))
+		e.Series, strings.Join(e.SeriesList, ","))
 }
 
 // IsIncompatibleSeriesError returns if the given error or its cause is


### PR DESCRIPTION
## Description of change

This is a follow on to PR 7677 to add machine series update to the update-series command.  The series in the machine and unit docs are updated provided that the series is supposed by the unit's charm.  The --force flag may be used if the series is not supported by a unit's charm.  If the machine
has no units, there series information will be still be updated. 

Firing off the changed-config hook will follow on.

## QA steps

1. Deploy two charms, one a subordinate. It's recommended to have 1 series supported by the principal charm not supported by the subordinate.
2. juju update-series ; where the series is supported by both the principal and subordinates. This should succeed.
3. juju update-series ; where the series is supported by the principal and not the subordinate. This should fail.
4. juju update-series --force; where the series is supported by the principal and not the subordinate. This should succeed.
5. juju update-series ; where the series is not supported by the principal. This should fail.
6. juju update-series --force; where the series is not supported by the principal. This should succeed.

At any time, the series to be used by an machine can be found in the output of "juju status <machine_name>"

## Documentation changes

Yes, the online list of commands needs to be updated.

## Bug reference

This is a planned project, however a feature request bug was filed as well:
https://bugs.launchpad.net/juju/+bug/1704135