### PR TITLE
apiserver/facades/client/application: Removed StatePool usage

### DIFF
--- a/apiserver/facades/client/application/application.go
+++ b/apiserver/facades/client/application/application.go
@@ -8,6 +8,7 @@ package application
 
 import (
 	"fmt"
+
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	"github.com/juju/utils/featureflag"
@@ -47,8 +48,6 @@ type API struct {
 	authorizer facade.Authorizer
 	check      BlockChecker
 
-	statePool *state.StatePool
-
 	// TODO(axw) stateCharm only exists because I ran out
 	// of time unwinding all of the tendrils of state. We
 	// should pass a charm.Charm and charm.URL back into
@@ -71,7 +70,7 @@ func NewFacadeV4(ctx facade.Context) (*APIv4, error) {
 
 // NewFacade provides the signature required for facade registration.
 func NewFacade(ctx facade.Context) (*API, error) {
-	backend, err := NewStateBackend(ctx.State(), ctx.StatePool())
+	backend, err := NewStateBackend(ctx.State())
 	if err != nil {
 		return nil, errors.Annotate(err, "getting state")
 	}
@@ -80,7 +79,6 @@ func NewFacade(ctx facade.Context) (*API, error) {
 	return NewAPI(
 		backend,
 		ctx.Auth(),
-		ctx.StatePool(),
 		blockChecker,
 		stateCharm,
 		DeployApplication,
@@ -91,7 +89,6 @@ func NewFacade(ctx facade.Context) (*API, error) {
 func NewAPI(
 	backend Backend,
 	authorizer facade.Authorizer,
-	statePool *state.StatePool,
 	blockChecker BlockChecker,
 	stateCharm func(Charm) *state.Charm,
 	deployApplication func(ApplicationDeployer, DeployApplicationParams) (Application, error),
@@ -104,7 +101,6 @@ func NewAPI(
 		authorizer:            authorizer,
 		check:                 blockChecker,
 		stateCharm:            stateCharm,
-		statePool:             statePool,
 		deployApplicationFunc: deployApplication,
 	}, nil
 }

--- a/apiserver/facades/client/application/application_test.go
+++ b/apiserver/facades/client/application/application_test.go
@@ -85,12 +85,14 @@ func (s *applicationSuite) TearDownTest(c *gc.C) {
 func (s *applicationSuite) makeAPI(c *gc.C) *application.API {
 	resources := common.NewResources()
 	resources.RegisterNamed("dataDir", common.StringResource(c.MkDir()))
-	backend, err := application.NewStateBackend(s.State, s.StatePool)
+	backend, err := application.NewStateBackend(s.State)
 	c.Assert(err, jc.ErrorIsNil)
 	blockChecker := common.NewBlockChecker(s.State)
 	api, err := application.NewAPI(
-		backend, s.authorizer, s.BackingStatePool,
-		blockChecker, application.CharmToStateCharm,
+		backend,
+		s.authorizer,
+		blockChecker,
+		application.CharmToStateCharm,
 		application.DeployApplication,
 	)
 	c.Assert(err, jc.ErrorIsNil)

--- a/apiserver/facades/client/application/application_unit_test.go
+++ b/apiserver/facades/client/application/application_unit_test.go
@@ -136,7 +136,6 @@ func (s *ApplicationSuite) SetUpTest(c *gc.C) {
 	api, err := application.NewAPI(
 		&s.backend,
 		s.authorizer,
-		nil,
 		&s.blockChecker,
 		func(application.Charm) *state.Charm {
 			return &state.Charm{}

--- a/apiserver/facades/client/application/get_test.go
+++ b/apiserver/facades/client/application/get_test.go
@@ -34,12 +34,14 @@ func (s *getSuite) SetUpTest(c *gc.C) {
 	s.authorizer = apiservertesting.FakeAuthorizer{
 		Tag: s.AdminUserTag(c),
 	}
-	backend, err := application.NewStateBackend(s.State, s.StatePool)
+	backend, err := application.NewStateBackend(s.State)
 	c.Assert(err, jc.ErrorIsNil)
 	blockChecker := common.NewBlockChecker(s.State)
 	s.serviceAPI, err = application.NewAPI(
-		backend, s.authorizer, s.BackingStatePool,
-		blockChecker, application.CharmToStateCharm,
+		backend,
+		s.authorizer,
+		blockChecker,
+		application.CharmToStateCharm,
 		application.DeployApplication,
 	)
 	c.Assert(err, jc.ErrorIsNil)


### PR DESCRIPTION
## Description of change

StatePools were being passed around but never used.

## QA steps

Unit tests pass (trivial change - this is enough)

## Documentation changes

N.A.

## Bug reference

N.A.