### PR TITLE
Extract StatePool out of migration precheck shim

### DIFF
--- a/apiserver/facades/client/controller/controller.go
+++ b/apiserver/facades/client/controller/controller.go
@@ -397,7 +397,7 @@ func (c *ControllerAPIv3) initiateOneMigration(spec params.MigrationSpec) (strin
 	}
 
 	// Check if the migration is likely to succeed.
-	if err := runMigrationPrechecks(hostedState, c.statePool, &targetInfo); err != nil {
+	if err := runMigrationPrechecks(hostedState, c.statePool.SystemState(), &targetInfo); err != nil {
 		return "", errors.Trace(err)
 	}
 
@@ -453,9 +453,9 @@ func (c *ControllerAPIv3) ModifyControllerAccess(args params.ModifyControllerAcc
 // runMigrationPrechecks runs prechecks on the migration and updates
 // information in targetInfo as needed based on information
 // retrieved from the target controller.
-var runMigrationPrechecks = func(st *state.State, pool *state.StatePool, targetInfo *coremigration.TargetInfo) error {
+var runMigrationPrechecks = func(st, ctlrSt *state.State, targetInfo *coremigration.TargetInfo) error {
 	// Check model and source controller.
-	backend, err := migration.PrecheckShim(st, pool)
+	backend, err := migration.PrecheckShim(st)
 	if err != nil {
 		return errors.Annotate(err, "creating backend")
 	}
@@ -469,7 +469,7 @@ var runMigrationPrechecks = func(st *state.State, pool *state.StatePool, targetI
 		return errors.Annotate(err, "connect to target controller")
 	}
 	defer conn.Close()
-	modelInfo, err := makeModelInfo(st, pool.SystemState())
+	modelInfo, err := makeModelInfo(st, ctlrSt)
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/apiserver/facades/client/controller/export_test.go
+++ b/apiserver/facades/client/controller/export_test.go
@@ -13,7 +13,7 @@ type patcher interface {
 }
 
 func SetPrecheckResult(p patcher, err error) {
-	p.PatchValue(&runMigrationPrechecks, func(*state.State, *state.StatePool, *migration.TargetInfo) error {
+	p.PatchValue(&runMigrationPrechecks, func(*state.State, *state.State, *migration.TargetInfo) error {
 		return err
 	})
 }

--- a/apiserver/facades/controller/migrationmaster/facade.go
+++ b/apiserver/facades/controller/migrationmaster/facade.go
@@ -26,6 +26,7 @@ import (
 type API struct {
 	backend         Backend
 	precheckBackend migration.PrecheckBackend
+	pool            migration.Pool
 	authorizer      facade.Authorizer
 	resources       facade.Resources
 }
@@ -35,6 +36,7 @@ type API struct {
 func NewAPI(
 	backend Backend,
 	precheckBackend migration.PrecheckBackend,
+	pool migration.Pool,
 	resources facade.Resources,
 	authorizer facade.Authorizer,
 ) (*API, error) {
@@ -44,6 +46,7 @@ func NewAPI(
 	return &API{
 		backend:         backend,
 		precheckBackend: precheckBackend,
+		pool:            pool,
 		authorizer:      authorizer,
 		resources:       resources,
 	}, nil

--- a/apiserver/facades/controller/migrationmaster/facade_test.go
+++ b/apiserver/facades/controller/migrationmaster/facade_test.go
@@ -396,8 +396,13 @@ func (s *Suite) TestMinionReports(c *gc.C) {
 }
 
 func (s *Suite) makeAPI() (*migrationmaster.API, error) {
-	return migrationmaster.NewAPI(s.backend, new(failingPrecheckBackend),
-		s.resources, s.authorizer)
+	return migrationmaster.NewAPI(
+		s.backend,
+		new(failingPrecheckBackend),
+		nil, // pool
+		s.resources,
+		s.authorizer,
+	)
 }
 
 func (s *Suite) mustMakeAPI(c *gc.C) *migrationmaster.API {

--- a/apiserver/facades/controller/migrationmaster/shim.go
+++ b/apiserver/facades/controller/migrationmaster/shim.go
@@ -16,11 +16,17 @@ import (
 // NewFacade exists to provide the required signature for API
 // registration, converting st to backend.
 func NewFacade(ctx facade.Context) (*API, error) {
-	precheckBackend, err := migration.PrecheckShim(ctx.State(), ctx.StatePool())
+	precheckBackend, err := migration.PrecheckShim(ctx.State())
 	if err != nil {
 		return nil, errors.Annotate(err, "creating precheck backend")
 	}
-	return NewAPI(&backendShim{ctx.State()}, precheckBackend, ctx.Resources(), ctx.Auth())
+	return NewAPI(
+		&backendShim{ctx.State()},
+		precheckBackend,
+		migration.PoolShim(ctx.StatePool()),
+		ctx.Resources(),
+		ctx.Auth(),
+	)
 }
 
 // backendShim wraps a *state.State to implement Backend. It is

--- a/apiserver/facades/controller/migrationtarget/migrationtarget.go
+++ b/apiserver/facades/controller/migrationtarget/migrationtarget.go
@@ -83,12 +83,13 @@ func (api *API) Prechecks(model params.MigrationModelInfo) error {
 	if err != nil {
 		return errors.Trace(err)
 	}
-	backend, err := migration.PrecheckShim(api.state, api.pool)
+	backend, err := migration.PrecheckShim(api.state)
 	if err != nil {
 		return errors.Annotate(err, "creating backend")
 	}
 	return migration.TargetPrecheck(
 		backend,
+		migration.PoolShim(api.pool),
 		coremigration.ModelInfo{
 			UUID:                   model.UUID,
 			Name:                   model.Name,


### PR DESCRIPTION
## Description of change

A StatePool had been mixed with a State in the migration PrecheckShim for convenience but this is a little confusing and makes future changes harder.

This change also fixes the issue of Models being returned from AllModels() which referred to State instances which had been released. Instead, AllModelUUIDs() is now used in conjuction with a StatePool.

## QA steps

Confirmed that migrations still work:

```
$ juju bootstrap lxd source
# wait...
$ juju bootstrap lxd target
# wait...
$ juju switch source
$ juju add-model foo
$ juju deploy ubuntu
# wait...
$ juju migrate foo target
# wait... (check juju status to see progress)
$ juju switch target:foo
$ juju status
```


## Documentation changes

N.A.

## Bug reference

N.A.
