### PR TITLE
apiserver: Removed remaining ForModel calls

### DIFF
--- a/apiserver/facades/client/controller/controller.go
+++ b/apiserver/facades/client/controller/controller.go
@@ -365,11 +365,11 @@ func (c *ControllerAPIv3) initiateOneMigration(spec params.MigrationSpec) (strin
 		return "", errors.NotFoundf("model")
 	}
 
-	hostedState, err := c.state.ForModel(modelTag)
+	hostedState, release, err := c.statePool.Get(modelTag.Id())
 	if err != nil {
 		return "", errors.Trace(err)
 	}
-	defer hostedState.Close()
+	defer release()
 
 	// Construct target info.
 	specTarget := spec.TargetInfo

--- a/apiserver/facades/controller/metricsmanager/metricsmanager_test.go
+++ b/apiserver/facades/controller/metricsmanager/metricsmanager_test.go
@@ -41,7 +41,7 @@ func (s *metricsManagerSuite) SetUpTest(c *gc.C) {
 		Controller: true,
 	}
 	s.clock = jujutesting.NewClock(time.Now())
-	manager, err := metricsmanager.NewMetricsManagerAPI(s.State, nil, s.authorizer, s.clock)
+	manager, err := metricsmanager.NewMetricsManagerAPI(s.State, nil, s.authorizer, s.StatePool, s.clock)
 	c.Assert(err, jc.ErrorIsNil)
 	s.metricsmanager = manager
 	meteredCharm := s.Factory.MakeCharm(c, &factory.CharmParams{Name: "metered", URL: "cs:quantal/metered"})
@@ -66,7 +66,8 @@ func (s *metricsManagerSuite) TestNewMetricsManagerAPIRefusesNonController(c *gc
 		anAuthoriser := s.authorizer
 		anAuthoriser.Controller = test.environManager
 		anAuthoriser.Tag = test.tag
-		endPoint, err := metricsmanager.NewMetricsManagerAPI(s.State, nil, anAuthoriser, jujutesting.NewClock(time.Now()))
+		endPoint, err := metricsmanager.NewMetricsManagerAPI(s.State, nil,
+			anAuthoriser, s.StatePool, jujutesting.NewClock(time.Now()))
 		if test.expectedError == "" {
 			c.Assert(err, jc.ErrorIsNil)
 			c.Assert(endPoint, gc.NotNil)


### PR DESCRIPTION
## Description of change

Two apiserver facades were still using ForModel. ForModel is slow and
resource hungry. It is better to use the apiserver's StatePool.

The affected facades are apiserver/facades/client/controller and
apiserver/facades/controller/metricsmanager.

## QA steps

This is a fairly safe change. Tested a model migration to be sure.

## Documentation changes

N.A.

## Bug reference

N.A.
