### PR TITLE
relation status watcher now a strings watcher, shared with watch relations

### DIFF
--- a/api/uniter/relation.go
+++ b/api/uniter/relation.go
@@ -23,6 +23,7 @@ type Relation struct {
 	tag      names.RelationTag
 	id       int
 	life     params.Life
+	status   params.RelationStatusValue
 	otherApp string
 }
 
@@ -49,6 +50,11 @@ func (r *Relation) Life() params.Life {
 	return r.life
 }
 
+// Status returns the relation's current status.
+func (r *Relation) Status() params.RelationStatusValue {
+	return r.status
+}
+
 // OtherApplication returns the name of the application on the other
 // end of the relation (from this unit's perspective).
 func (r *Relation) OtherApplication() string {
@@ -63,10 +69,11 @@ func (r *Relation) Refresh() error {
 	if err != nil {
 		return err
 	}
-	// NOTE: The life cycle information is the only
-	// thing that can change - id, tag and endpoint
+	// NOTE: The status and life cycle information are the only
+	// things that can change - id, tag and endpoint
 	// information are static.
 	r.life = result.Life
+	r.status = result.Status
 
 	return nil
 }

--- a/api/uniter/uniter.go
+++ b/api/uniter/uniter.go
@@ -206,6 +206,7 @@ func (st *State) Relation(relationTag names.RelationTag) (*Relation, error) {
 		id:       result.Id,
 		tag:      relationTag,
 		life:     result.Life,
+		status:   result.Status,
 		st:       st,
 		otherApp: result.OtherApplication,
 	}, nil
@@ -298,6 +299,7 @@ func (st *State) RelationById(id int) (*Relation, error) {
 		id:       result.Id,
 		tag:      relationTag,
 		life:     result.Life,
+		status:   result.Status,
 		st:       st,
 		otherApp: result.OtherApplication,
 	}, nil

--- a/api/watcher/watcher_test.go
+++ b/api/watcher/watcher_test.go
@@ -254,7 +254,7 @@ func (s *watcherSuite) TestWatchMachineStorage(c *gc.C) {
 	}
 }
 
-func (s *watcherSuite) assertRelationStatusWatchResult(c *gc.C, rel *state.Relation, expected life.Value) {
+func (s *watcherSuite) assertRelationStatusWatchResult(c *gc.C, rel *state.Relation, expectedLife life.Value, expectedStatus relation.Status) {
 	// Export the relation so it can be found with a token.
 	re := s.State.RemoteEntities()
 	token, err := re.ExportLocalEntity(rel.Tag())
@@ -336,12 +336,12 @@ func (s *watcherSuite) assertRelationStatusWatchResult(c *gc.C, rel *state.Relat
 	}
 
 	// Initial event.
-	assertChange(life.Alive, "")
+	assertChange(life.Alive, relation.Joined)
 
 	// Now change the relation, should trigger the watcher.
 	err = rel.Destroy()
 	c.Assert(err, jc.ErrorIsNil)
-	assertChange(expected, "")
+	assertChange(expectedLife, expectedStatus)
 }
 
 func (s *watcherSuite) TestRelationStatusWatcher(c *gc.C) {
@@ -363,7 +363,7 @@ func (s *watcherSuite) TestRelationStatusWatcher(c *gc.C) {
 	err = relUnit.EnterScope(nil)
 	c.Assert(err, jc.ErrorIsNil)
 
-	s.assertRelationStatusWatchResult(c, rel, life.Dying)
+	s.assertRelationStatusWatchResult(c, rel, life.Dying, relation.Joined)
 }
 
 func (s *watcherSuite) TestRelationStatusWatcherDeadRelation(c *gc.C) {
@@ -375,7 +375,7 @@ func (s *watcherSuite) TestRelationStatusWatcherDeadRelation(c *gc.C) {
 	rel, err := s.State.AddRelation(eps...)
 	c.Assert(err, jc.ErrorIsNil)
 
-	s.assertRelationStatusWatchResult(c, rel, life.Dead)
+	s.assertRelationStatusWatchResult(c, rel, life.Dead, relation.Broken)
 }
 
 type migrationSuite struct {

--- a/apiserver/common/crossmodel/interface.go
+++ b/apiserver/common/crossmodel/interface.go
@@ -85,6 +85,9 @@ type Relation interface {
 	// Life returns the relation's current life state.
 	Life() state.Life
 
+	// Status returns the relation's current status.
+	Status() status.Status
+
 	// Tag returns the relation's tag.
 	Tag() names.Tag
 
@@ -107,7 +110,7 @@ type Relation interface {
 
 	// WatchStatus returns a watcher that notifies of changes to the life
 	// or status of the relation.
-	WatchStatus() state.RelationStatusWatcher
+	WatchStatus() state.StringsWatcher
 }
 
 // RelationUnit provides access to the settings of a single unit in a relation,

--- a/apiserver/facades/agent/uniter/uniter.go
+++ b/apiserver/facades/agent/uniter/uniter.go
@@ -1360,9 +1360,10 @@ func (u *UniterAPI) prepareRelationResult(rel *state.Relation, unit *state.Unit)
 		otherAppName = otherEp.ApplicationName
 	}
 	return params.RelationResult{
-		Id:   rel.Id(),
-		Key:  rel.String(),
-		Life: params.Life(rel.Life().String()),
+		Id:     rel.Id(),
+		Key:    rel.String(),
+		Life:   params.Life(rel.Life().String()),
+		Status: params.RelationStatusValue(rel.Status()),
 		Endpoint: multiwatcher.Endpoint{
 			ApplicationName: ep.ApplicationName,
 			Relation:        multiwatcher.NewCharmRelation(ep.Relation),

--- a/apiserver/facades/agent/uniter/uniter_test.go
+++ b/apiserver/facades/agent/uniter/uniter_test.go
@@ -275,6 +275,7 @@ func (s *uniterSuite) TestLife(c *gc.C) {
 	err = relUnit.EnterScope(nil)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(rel.Life(), gc.Equals, state.Alive)
+	c.Assert(rel.Status(), gc.Equals, status.Joined)
 
 	// Make the wordpressUnit dead.
 	err = s.wordpressUnit.EnsureDead()
@@ -1677,9 +1678,10 @@ func (s *uniterSuite) TestRelation(c *gc.C) {
 		Results: []params.RelationResult{
 			{Error: apiservertesting.ErrUnauthorized},
 			{
-				Id:   rel.Id(),
-				Key:  rel.String(),
-				Life: params.Life(rel.Life().String()),
+				Id:     rel.Id(),
+				Key:    rel.String(),
+				Life:   params.Life(rel.Life().String()),
+				Status: params.RelationStatusValue(rel.Status()),
 				Endpoint: multiwatcher.Endpoint{
 					ApplicationName: wpEp.ApplicationName,
 					Relation:        multiwatcher.NewCharmRelation(wpEp.Relation),
@@ -1715,9 +1717,10 @@ func (s *uniterSuite) TestRelationById(c *gc.C) {
 		Results: []params.RelationResult{
 			{Error: apiservertesting.ErrUnauthorized},
 			{
-				Id:   rel.Id(),
-				Key:  rel.String(),
-				Life: params.Life(rel.Life().String()),
+				Id:     rel.Id(),
+				Key:    rel.String(),
+				Life:   params.Life(rel.Life().String()),
+				Status: params.RelationStatusValue(rel.Status()),
 				Endpoint: multiwatcher.Endpoint{
 					ApplicationName: wpEp.ApplicationName,
 					Relation:        multiwatcher.NewCharmRelation(wpEp.Relation),

--- a/apiserver/facades/controller/crossmodelrelations/mock_test.go
+++ b/apiserver/facades/controller/crossmodelrelations/mock_test.go
@@ -21,8 +21,8 @@ import (
 	"github.com/juju/juju/apiserver/facades/controller/crossmodelrelations"
 	"github.com/juju/juju/core/crossmodel"
 	"github.com/juju/juju/state"
+	"github.com/juju/juju/status"
 	coretesting "github.com/juju/juju/testing"
-	"github.com/juju/juju/watcher"
 )
 
 type mockStatePool struct {
@@ -243,10 +243,10 @@ func (w *mockWatcher) Stopped() bool {
 
 type mockRelationStatusWatcher struct {
 	*mockWatcher
-	changes chan []watcher.RelationStatusChange
+	changes chan []string
 }
 
-func (w *mockRelationStatusWatcher) Changes() <-chan []watcher.RelationStatusChange {
+func (w *mockRelationStatusWatcher) Changes() <-chan []string {
 	return w.changes
 }
 
@@ -289,6 +289,14 @@ func (r *mockRelation) Tag() names.Tag {
 func (r *mockRelation) Destroy() error {
 	r.MethodCall(r, "Destroy")
 	return r.NextErr()
+}
+
+func (r *mockRelation) Life() state.Life {
+	return state.Alive
+}
+
+func (r *mockRelation) Status() status.Status {
+	return status.Revoked
 }
 
 func (r *mockRelation) RemoteUnit(unitId string) (commoncrossmodel.RelationUnit, error) {

--- a/apiserver/params/internal.go
+++ b/apiserver/params/internal.go
@@ -317,6 +317,7 @@ type RelationResults struct {
 type RelationResult struct {
 	Error            *Error                `json:"error,omitempty"`
 	Life             Life                  `json:"life"`
+	Status           RelationStatusValue   `json:"status,omitempty"`
 	Id               int                   `json:"id"`
 	Key              string                `json:"key"`
 	Endpoint         multiwatcher.Endpoint `json:"endpoint"`

--- a/apiserver/params/status.go
+++ b/apiserver/params/status.go
@@ -285,6 +285,7 @@ const (
 type RelationStatusValue relation.Status
 
 const (
-	Active  RelationStatusValue = "active"
+	Joined  RelationStatusValue = "joined"
 	Revoked RelationStatusValue = "revoked"
+	Broken  RelationStatusValue = "broken"
 )

--- a/cmd/juju/crossmodel/listformatter.go
+++ b/cmd/juju/crossmodel/listformatter.go
@@ -133,10 +133,12 @@ func formatListEndpointsTabular(writer io.Writer, offers offeredApplications) er
 
 func relationStatusColor(status relation.Status) *ansiterm.Context {
 	switch status {
-	case relation.Active:
+	case relation.Joined:
 		return output.GoodHighlight
 	case relation.Revoked:
 		return output.WarningHighlight
+	case relation.Broken:
+		return output.ErrorHighlight
 	}
 	return nil
 }

--- a/core/relation/status.go
+++ b/core/relation/status.go
@@ -7,6 +7,13 @@ package relation
 type Status string
 
 const (
-	Active  Status = "active"
+	// Joined is the normal status for a healthy, alive relation.
+	Joined Status = "joined"
+
+	// Broken is the status for when a relation life goes to Dead.
+	Broken Status = "broken"
+
+	// Revoked is used to signify that a relation is temporarily broken pending
+	// action to unrevoke it.
 	Revoked Status = "revoked"
 )

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -21,7 +21,7 @@ github.com/juju/ansiterm	git	b99631de12cf04a906c1d4e4ec54fb86eae5863d	2016-09-07
 github.com/juju/blobstore	git	06056004b3d7b54bbb7984d830c537bad00fec21	2015-07-29T11:18:58Z
 github.com/juju/bundlechanges	git	cd189848b313df50084de692b05861210022cf81	2017-07-31T02:12:50Z
 github.com/juju/cmd	git	ad2437ef0ef282ae26e482eb1e44c02532bae1ba	2017-06-22T12:53:07Z
-github.com/juju/description	git	fedf2abd05e6418e575dc2597ba2494bcc4024e1	2017-08-22T03:20:25Z
+github.com/juju/description	git	f9168b66462caa818dadb8923e8de51cb22bae4c	2017-08-24T12:06:32Z
 github.com/juju/errors	git	1b5e39b83d1835fa480e0c2ddefb040ee82d58b3	2015-09-16T12:56:42Z
 github.com/juju/gnuflag	git	4e76c56581859c14d9d87e1ddbe29e1c0f10195f	2016-08-09T16:52:14Z
 github.com/juju/go-oracle-cloud	git	932a8cea00a1cd5cba3829a672c823955db674ae	2017-04-21T13:45:47Z

--- a/state/application_test.go
+++ b/state/application_test.go
@@ -2392,6 +2392,11 @@ func (s *ApplicationSuite) TestWatchRelations(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	wpxWatcherC.AssertChange(relx.String())
 	wpxWatcherC.AssertNoChange()
+
+	err = relx.SetStatus(status.Revoked)
+	c.Assert(err, jc.ErrorIsNil)
+	wpxWatcherC.AssertChange(relx.String())
+	wpxWatcherC.AssertNoChange()
 }
 
 func removeAllUnits(c *gc.C, s *state.Application) {

--- a/state/migration_import.go
+++ b/state/migration_import.go
@@ -1136,6 +1136,7 @@ func (i *importer) makeRelationDoc(rel description.Relation) *relationDoc {
 		Id:        rel.Id(),
 		Endpoints: make([]Endpoint, len(endpoints)),
 		Life:      Alive,
+		Status:    status.Joined,
 	}
 	for i, ep := range endpoints {
 		doc.Endpoints[i] = Endpoint{

--- a/state/migration_internal_test.go
+++ b/state/migration_internal_test.go
@@ -436,6 +436,7 @@ func (s *MigrationSuite) TestRelationDocFields(c *gc.C) {
 		"Key",
 		"Id",
 		"Endpoints",
+		"Status",
 		// Life isn't exported, only alive.
 		"Life",
 		// UnitCount isn't explicitly exported, but defined by the stored

--- a/state/state.go
+++ b/state/state.go
@@ -993,6 +993,7 @@ func (st *State) addPeerRelationsOps(applicationname string, peers map[string]ch
 			Id:        relId,
 			Endpoints: eps,
 			Life:      Alive,
+			Status:    status.Joined,
 		}
 		ops = append(ops, txn.Op{
 			C:      relationsC,
@@ -1833,6 +1834,7 @@ func (st *State) AddRelation(eps ...Endpoint) (r *Relation, err error) {
 			Id:        id,
 			Endpoints: eps,
 			Life:      Alive,
+			Status:    status.Joined,
 		}
 		ops = append(ops, txn.Op{
 			C:      relationsC,

--- a/state/testing/watcher.go
+++ b/state/testing/watcher.go
@@ -11,10 +11,7 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/apiserver/params"
-	"github.com/juju/juju/core/life"
-	"github.com/juju/juju/core/relation"
 	"github.com/juju/juju/testing"
-	"github.com/juju/juju/watcher"
 )
 
 type Stopper interface {
@@ -307,75 +304,6 @@ func (c RelationUnitsWatcherC) AssertChange(changed []string, departed []string)
 }
 
 func (c RelationUnitsWatcherC) AssertClosed() {
-	select {
-	case _, ok := <-c.Watcher.Changes():
-		c.Assert(ok, jc.IsFalse)
-	default:
-		c.Fatalf("watcher not closed")
-	}
-}
-
-// RelationStatusWatcherC embeds a gocheck.C and adds methods to help
-// verify the behaviour of any watcher that uses a <-chan
-// params.RelationStatusChange.
-type RelationStatusWatcherC struct {
-	*gc.C
-	State   SyncStarter
-	Watcher RelationStatusWatcher
-}
-
-// NewRelationStatusWatcherC returns a RelationStatusWatcherC that
-// checks for aggressive event coalescence.
-func NewRelationStatusWatcherC(c *gc.C, st SyncStarter, w RelationStatusWatcher) RelationStatusWatcherC {
-	return RelationStatusWatcherC{
-		C:       c,
-		State:   st,
-		Watcher: w,
-	}
-}
-
-type RelationStatusWatcher interface {
-	Stop() error
-	Changes() <-chan []watcher.RelationStatusChange
-}
-
-func (c RelationStatusWatcherC) AssertNoChange() {
-	c.State.StartSync()
-	select {
-	case actual, ok := <-c.Watcher.Changes():
-		c.Fatalf("watcher sent unexpected change: (%v, %v)", actual, ok)
-	case <-time.After(testing.ShortWait):
-	}
-}
-
-func (c RelationStatusWatcherC) AssertOneChange() {
-	c.State.StartSync()
-	select {
-	case _, ok := <-c.Watcher.Changes():
-		c.Assert(ok, jc.IsTrue)
-	case <-time.After(testing.LongWait):
-		c.Fatalf("watcher did not send change")
-	}
-	c.AssertNoChange()
-}
-
-// AssertChange asserts the given changes was reported by the watcher,
-// but does not assume there are no following changes.
-func (c RelationStatusWatcherC) AssertChange(life life.Value, status relation.Status) {
-	c.State.StartSync()
-	timeout := time.After(testing.LongWait)
-	select {
-	case actual, ok := <-c.Watcher.Changes():
-		c.Assert(ok, jc.IsTrue)
-		c.Assert(actual, gc.HasLen, 1)
-		c.Assert(actual[0].Life, gc.Equals, life)
-		c.Assert(actual[0].Status, gc.Equals, status)
-	case <-timeout:
-		c.Fatalf("watcher did not send change")
-	}
-}
-
-func (c RelationStatusWatcherC) AssertClosed() {
 	select {
 	case _, ok := <-c.Watcher.Changes():
 		c.Assert(ok, jc.IsFalse)

--- a/status/status.go
+++ b/status/status.go
@@ -184,6 +184,20 @@ const (
 )
 
 const (
+	// Status values specific to relations.
+
+	// Joined is the normal status for a healthy, alive relation.
+	Joined Status = "joined"
+
+	// Broken is the status for when a relation life goes to Dead.
+	Broken Status = "broken"
+
+	// Revoked is used to signify that a relation is temporarily broken pending
+	// action to unrevoke it.
+	Revoked Status = "revoked"
+)
+
+const (
 	// Status values that are common to several entities.
 
 	// Destroying indicates that the entity is being destroyed.

--- a/worker/uniter/remotestate/mock_test.go
+++ b/worker/uniter/remotestate/mock_test.go
@@ -282,8 +282,9 @@ func (s *mockService) WatchLeadershipSettings() (watcher.NotifyWatcher, error) {
 }
 
 type mockRelation struct {
-	id   int
-	life params.Life
+	id     int
+	life   params.Life
+	status params.RelationStatusValue
 }
 
 func (r *mockRelation) Id() int {
@@ -292,6 +293,10 @@ func (r *mockRelation) Id() int {
 
 func (r *mockRelation) Life() params.Life {
 	return r.life
+}
+
+func (r *mockRelation) Status() params.RelationStatusValue {
+	return r.status
 }
 
 type mockLeadershipTracker struct {

--- a/worker/uniter/remotestate/snapshot.go
+++ b/worker/uniter/remotestate/snapshot.go
@@ -72,6 +72,7 @@ type Snapshot struct {
 
 type RelationSnapshot struct {
 	Life    params.Life
+	Status  params.RelationStatusValue
 	Members map[string]int64
 }
 

--- a/worker/uniter/remotestate/state.go
+++ b/worker/uniter/remotestate/state.go
@@ -68,6 +68,7 @@ type Application interface {
 type Relation interface {
 	Id() int
 	Life() params.Life
+	Status() params.RelationStatusValue
 }
 
 func NewAPIState(st *uniter.State) State {

--- a/worker/uniter/remotestate/watcher.go
+++ b/worker/uniter/remotestate/watcher.go
@@ -558,6 +558,7 @@ func (w *RemoteStateWatcher) relationsChanged(keys []string) error {
 			if _, ok := w.relations[relationTag]; ok {
 				relationSnapshot := w.current.Relations[rel.Id()]
 				relationSnapshot.Life = rel.Life()
+				relationSnapshot.Status = rel.Status()
 				w.current.Relations[rel.Id()] = relationSnapshot
 				continue
 			}
@@ -587,6 +588,7 @@ func (w *RemoteStateWatcher) watchRelationUnits(
 ) error {
 	relationSnapshot := RelationSnapshot{
 		Life:    rel.Life(),
+		Status:  rel.Status(),
 		Members: make(map[string]int64),
 	}
 	select {


### PR DESCRIPTION
## Description of change

The state relation status watcher is changed to a strings watcher and the bespoke watcher removed. This then allows the 2 relations watchers to be consolidated to use the single shared state watcher:
application -> WatchRelations
relation -> WatchStatus

A whole bunch of code is deleted as a result.

Both of the above watchers now return the keys of any relation that has a life or status change. Infrastructure that uses the above has been tweaked accordingly. We also introduce status to the relation data model.

A followup PR will use the new watcher behaviour in the uniter to react to relation status changes.

## QA steps

No visible change. Smoke test cmr and non-cmr deployments.

