### PR TITLE
Upgrade step for new model "type" field

### DIFF
--- a/state/upgrades_test.go
+++ b/state/upgrades_test.go
@@ -1765,6 +1765,33 @@ func (s *upgradesSuite) TestAddModelEnvironVersion(c *gc.C) {
 	)
 }
 
+func (s *upgradesSuite) TestAddModelType(c *gc.C) {
+	models, closer := s.state.db().GetRawCollection(modelsC)
+	defer closer()
+
+	err := models.RemoveId(s.state.ModelUUID())
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = models.Insert(
+		bson.M{
+			"_id": "deadbeef-0bad-400d-8000-4b1d0d06f00d",
+		}, bson.M{
+			"_id":  "deadbeef-0bad-400d-8000-4b1d0d06f00e",
+			"type": "caas",
+		})
+	c.Assert(err, jc.ErrorIsNil)
+
+	expectedModels := []bson.M{{
+		"_id":  "deadbeef-0bad-400d-8000-4b1d0d06f00d",
+		"type": "iaas",
+	}, {
+		"_id":  "deadbeef-0bad-400d-8000-4b1d0d06f00e",
+		"type": "caas",
+	}}
+	s.assertUpgradedData(c, AddModelType,
+		expectUpgradedData{models, expectedModels})
+}
+
 func (s *upgradesSuite) checkAddPruneSettings(c *gc.C, ageProp, sizeProp, defaultAge, defaultSize string, updateFunc func(st *State) error) {
 	settingsColl, settingsCloser := s.state.db().GetRawCollection(settingsC)
 	defer settingsCloser()

--- a/upgrades/backend.go
+++ b/upgrades/backend.go
@@ -31,6 +31,7 @@ type StateBackend interface {
 	AddUpdateStatusHookSettings() error
 	CorrectRelationUnitCounts() error
 	AddModelEnvironVersion() error
+	AddModelType() error
 }
 
 // Model is an interface providing access to the details of a model within the
@@ -115,6 +116,10 @@ func (s stateBackend) CorrectRelationUnitCounts() error {
 
 func (s stateBackend) AddModelEnvironVersion() error {
 	return state.AddModelEnvironVersion(s.st)
+}
+
+func (s stateBackend) AddModelType() error {
+	return state.AddModelType(s.st)
 }
 
 type modelShim struct {

--- a/upgrades/operations.go
+++ b/upgrades/operations.go
@@ -25,6 +25,7 @@ var stateUpgradeOperations = func() []Operation {
 		upgradeToVersion{version.MustParse("2.2.1"), stateStepsFor221()},
 		upgradeToVersion{version.MustParse("2.2.2"), stateStepsFor222()},
 		upgradeToVersion{version.MustParse("2.2.3"), stateStepsFor223()},
+		upgradeToVersion{version.MustParse("2.3.0"), stateStepsFor23()},
 	}
 	return steps
 }

--- a/upgrades/steps_23.go
+++ b/upgrades/steps_23.go
@@ -1,0 +1,17 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package upgrades
+
+// stateStepsFor23 returns upgrade steps for Juju 2.3.0 that manipulate state directly.
+func stateStepsFor23() []Step {
+	return []Step{
+		&upgradeStep{
+			description: "add a 'type' field to model documents",
+			targets:     []Target{DatabaseMaster},
+			run: func(context Context) error {
+				return context.State().AddModelType()
+			},
+		},
+	}
+}

--- a/upgrades/steps_23_test.go
+++ b/upgrades/steps_23_test.go
@@ -1,0 +1,27 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package upgrades_test
+
+import (
+	jc "github.com/juju/testing/checkers"
+	"github.com/juju/version"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/testing"
+	"github.com/juju/juju/upgrades"
+)
+
+var v23 = version.MustParse("2.3.0")
+
+type steps23Suite struct {
+	testing.BaseSuite
+}
+
+var _ = gc.Suite(&steps23Suite{})
+
+func (s *steps23Suite) TestAddModelType(c *gc.C) {
+	step := findStateStep(c, v23, "add a 'type' field to model documents")
+	// Logic for step itself is tested in state package.
+	c.Assert(step.Targets(), jc.DeepEquals, []upgrades.Target{upgrades.DatabaseMaster})
+}

--- a/upgrades/upgrade_test.go
+++ b/upgrades/upgrade_test.go
@@ -641,6 +641,7 @@ func (s *upgradeSuite) TestStateUpgradeOperationsVersions(c *gc.C) {
 		"2.2.1",
 		"2.2.2",
 		"2.2.3",
+		"2.3.0",
 	})
 }
 


### PR DESCRIPTION
## Description of change

Pre-existing model documents should be given a "type" field of value
"iaas". This should have been done as part of a previous PR but had
been forgotten.

## QA steps

1. Bootstrap with Juju 2.2.2
2. Use mongo shell to confirm models don't have "type" fields.
3. Build Juju using this branch.
4. juju upgrade-juju -m controller --build-agent
5. Use mongo shell to confirm models now have a "type" field with a
   value of "iaas".

## Documentation changes

N.A.

## Bug reference

N.A.
