### PR TITLE
Uset SetModels in commands that deal with model list.

### DIFF
--- a/cmd/juju/controller/register.go
+++ b/cmd/juju/controller/register.go
@@ -158,15 +158,8 @@ func (c *registerCommand) run(ctx *cmd.Context) error {
 	if err != nil {
 		return errors.Trace(err)
 	}
-	for _, model := range models {
-		owner := names.NewUserTag(model.Owner)
-		if err := c.store.UpdateModel(
-			controllerName,
-			jujuclient.JoinOwnerModelName(owner, model.Name),
-			jujuclient.ModelDetails{model.UUID},
-		); err != nil {
-			return errors.Annotate(err, "storing model details")
-		}
+	if err := c.SetControllerModels(c.store, controllerName, models); err != nil {
+		return errors.Annotate(err, "storing model details")
 	}
 	if err := c.store.SetCurrentController(controllerName); err != nil {
 		return errors.Trace(err)

--- a/cmd/juju/user/login.go
+++ b/cmd/juju/user/login.go
@@ -242,15 +242,8 @@ use "juju unregister %s" to remove the existing controller.`[1:], c.domain, c.co
 	if err != nil {
 		return errors.Trace(err)
 	}
-	for _, model := range models {
-		owner := names.NewUserTag(model.Owner)
-		if err := store.UpdateModel(
-			c.controllerName,
-			jujuclient.JoinOwnerModelName(owner, model.Name),
-			jujuclient.ModelDetails{model.UUID},
-		); err != nil {
-			return errors.Annotate(err, "storing model details")
-		}
+	if err := c.SetControllerModels(store, c.controllerName, models); err != nil {
+		return errors.Annotate(err, "storing model details")
 	}
 	fmt.Fprintf(
 		ctx.Stderr, "Welcome, %s. You are now logged into %q.\n",

--- a/cmd/modelcmd/base.go
+++ b/cmd/modelcmd/base.go
@@ -277,13 +277,22 @@ func (c *CommandBase) doRefreshModels(store jujuclient.ClientStore, controllerNa
 	if err != nil {
 		return errors.Trace(err)
 	}
+	if err := c.SetControllerModels(store, controllerName, models); err != nil {
+		return errors.Trace(err)
+	}
+	return nil
+}
+
+func (c *CommandBase) SetControllerModels(store jujuclient.ClientStore, controllerName string, models []base.UserModel) error {
+	modelsToStore := make(map[string]jujuclient.ModelDetails, len(models))
 	for _, model := range models {
 		modelDetails := jujuclient.ModelDetails{model.UUID}
 		owner := names.NewUserTag(model.Owner)
 		modelName := jujuclient.JoinOwnerModelName(owner, model.Name)
-		if err := store.UpdateModel(controllerName, modelName, modelDetails); err != nil {
-			return errors.Trace(err)
-		}
+		modelsToStore[modelName] = modelDetails
+	}
+	if err := store.SetModels(controllerName, modelsToStore); err != nil {
+		return errors.Trace(err)
 	}
 	return nil
 }

--- a/cmd/modelcmd/clientstore.go
+++ b/cmd/modelcmd/clientstore.go
@@ -60,6 +60,19 @@ func (s QualifyingClientStore) UpdateModel(controllerName, modelName string, det
 }
 
 // Implements jujuclient.ModelUpdater.
+func (s QualifyingClientStore) SetModels(controllerName string, models map[string]jujuclient.ModelDetails) error {
+	qualified := make(map[string]jujuclient.ModelDetails, len(models))
+	for name, details := range models {
+		modelName, err := s.QualifiedModelName(controllerName, name)
+		if err != nil {
+			return errors.Annotatef(err, "updating model %q", name)
+		}
+		qualified[modelName] = details
+	}
+	return s.ClientStore.SetModels(controllerName, models)
+}
+
+// Implements jujuclient.ModelUpdater.
 func (s QualifyingClientStore) SetCurrentModel(controllerName, modelName string) error {
 	modelName, err := s.QualifiedModelName(controllerName, modelName)
 	if err != nil {

--- a/jujuclient/file.go
+++ b/jujuclient/file.go
@@ -466,8 +466,9 @@ func (s *store) ModelByName(controllerName, modelName string) (*ModelDetails, er
 	controllerModels, ok := all[controllerName]
 	if !ok {
 		return nil, errors.NotFoundf(
-			"models for controller %s",
+			"model %s:%s",
 			controllerName,
+			modelName,
 		)
 	}
 	details, ok := controllerModels.Models[modelName]

--- a/jujuclient/mem.go
+++ b/jujuclient/mem.go
@@ -205,12 +205,10 @@ func (c *MemStore) SetModels(controller string, models map[string]ModelDetails) 
 	if err := ValidateControllerName(controller); err != nil {
 		return err
 	}
-	modelNames := set.NewStrings()
 	for modelName, details := range models {
 		if err := ValidateModel(modelName, details); err != nil {
 			return errors.Trace(err)
 		}
-		modelNames.Add(modelName)
 	}
 
 	controllerModels, ok := c.Models[controller]
@@ -218,6 +216,7 @@ func (c *MemStore) SetModels(controller string, models map[string]ModelDetails) 
 		controllerModels = &ControllerModels{
 			Models: make(map[string]ModelDetails),
 		}
+		c.Models[controller] = controllerModels
 	}
 	controllerModels.Models = models
 	if _, ok := models[controllerModels.CurrentModel]; !ok {
@@ -319,7 +318,7 @@ func (c *MemStore) ModelByName(controller, model string) (*ModelDetails, error) 
 	}
 	controllerModels, ok := c.Models[controller]
 	if !ok {
-		return nil, errors.NotFoundf("models for controller %s", controller)
+		return nil, errors.NotFoundf("model %s:%s", controller, model)
 	}
 	details, ok := controllerModels.Models[model]
 	if !ok {

--- a/jujuclient/models_test.go
+++ b/jujuclient/models_test.go
@@ -32,13 +32,13 @@ func (s *ModelsSuite) TestModelByNameNoFile(c *gc.C) {
 	err := os.Remove(jujuclient.JujuModelsPath())
 	c.Assert(err, jc.ErrorIsNil)
 	details, err := s.store.ModelByName("not-found", "admin/admin")
-	c.Assert(err, gc.ErrorMatches, "models for controller not-found not found")
+	c.Assert(err, gc.ErrorMatches, "model not-found:admin/admin not found")
 	c.Assert(details, gc.IsNil)
 }
 
 func (s *ModelsSuite) TestModelByNameControllerNotFound(c *gc.C) {
 	details, err := s.store.ModelByName("not-found", "admin/admin")
-	c.Assert(err, gc.ErrorMatches, "models for controller not-found not found")
+	c.Assert(err, gc.ErrorMatches, "model not-found:admin/admin not found")
 	c.Assert(details, gc.IsNil)
 }
 


### PR DESCRIPTION
## Description of change

Updated commands like login and register to use store.SetModels as they are getting full model list. Also changed RefreshModels to use store.SetModels. Previously, these commands would make individual calls for each model in the obtained list meaning that models were either added or updated in store but never removed. To do this properly, QualifyingClientStore also had to gain SetModels method from jujuclient.ModelUpdater.

Since mem version of store is used in tests, it also needed a fix to ensure controller models are overwritten.

As a drive-by: when requesting ModelByName, we used to report if controller had no models. Since user is asking for a specific model, in the instances when controller has no models, it is more relevant to say that "the model you wanted is not found" even if the controller has no models.


## QA steps

For mem store: all unit tests pass.
For file store:
1. bootstrap
2. add user
3. login or register as that user
4. models client store shows correct info

## Documentation changes

n/a - internal change

## Bug reference

n/a
