### PR TITLE
Move Annotations functionality from State to Model

### DIFF
--- a/apiserver/facades/client/annotations/state.go
+++ b/apiserver/facades/client/annotations/state.go
@@ -10,28 +10,19 @@ import (
 )
 
 type annotationAccess interface {
-	FindEntity(tag names.Tag) (state.Entity, error)
-	GetAnnotations(entity state.GlobalEntity) (map[string]string, error)
-	SetAnnotations(entity state.GlobalEntity, annotations map[string]string) error
 	ModelTag() names.ModelTag
+	FindEntity(tag names.Tag) (state.Entity, error)
+	Annotations(entity state.GlobalEntity) (map[string]string, error)
+	SetAnnotations(entity state.GlobalEntity, annotations map[string]string) error
 }
 
 type stateShim struct {
-	state *state.State
+	// TODO(menn0) - once FindEntity goes to Model, the embedded State
+	// can go from here. The ModelTag method below can also go.
+	*state.State
+	*state.Model
 }
 
-func (s stateShim) FindEntity(tag names.Tag) (state.Entity, error) {
-	return s.state.FindEntity(tag)
-}
-
-func (s stateShim) GetAnnotations(entity state.GlobalEntity) (map[string]string, error) {
-	return s.state.Annotations(entity)
-}
-
-func (s stateShim) SetAnnotations(entity state.GlobalEntity, annotations map[string]string) error {
-	return s.state.SetAnnotations(entity, annotations)
-}
-
-func (s stateShim) ModelTag() names.ModelTag {
-	return s.state.ModelTag()
+func (s *stateShim) ModelTag() names.ModelTag {
+	return s.Model.ModelTag()
 }

--- a/apiserver/facades/client/client/backend.go
+++ b/apiserver/facades/client/client/backend.go
@@ -87,6 +87,15 @@ type Unit interface {
 
 type stateShim struct {
 	*state.State
+	model *state.Model
+}
+
+func (s *stateShim) Annotations(entity state.GlobalEntity) (map[string]string, error) {
+	return s.model.Annotations(entity)
+}
+
+func (s *stateShim) SetAnnotations(entity state.GlobalEntity, ann map[string]string) error {
+	return s.model.SetAnnotations(entity, ann)
 }
 
 func (s *stateShim) Unit(name string) (Unit, error) {

--- a/apiserver/facades/client/client/client.go
+++ b/apiserver/facades/client/client/client.go
@@ -122,6 +122,11 @@ func NewFacade(ctx facade.Context) (*Client, error) {
 	resources := ctx.Resources()
 	authorizer := ctx.Auth()
 
+	model, err := st.Model()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
 	urlGetter := common.NewToolsURLGetter(st.ModelUUID(), st)
 	configGetter := stateenvirons.EnvironConfigGetter{st}
 	statusSetter := common.NewStatusSetter(st, common.AuthAlways())
@@ -136,7 +141,7 @@ func NewFacade(ctx facade.Context) (*Client, error) {
 	}
 	addresser := common.NewAPIAddresser(st, resources)
 	return NewClient(
-		&stateShim{st},
+		&stateShim{st, model},
 		&poolShim{ctx.StatePool()},
 		modelConfigAPI,
 		resources,

--- a/cmd/juju/application/bundle_test.go
+++ b/cmd/juju/application/bundle_test.go
@@ -964,7 +964,7 @@ func (s *BundleDeployCharmStoreSuite) TestDeployBundleMachineAttributes(c *gc.C)
 	expectedCons, err := constraints.Parse("cores=4 mem=4G")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cons, jc.DeepEquals, expectedCons)
-	ann, err := s.State.Annotations(m)
+	ann, err := s.IAASModel.Annotations(m)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(ann, jc.DeepEquals, map[string]string{"foo": "bar"})
 }
@@ -1226,7 +1226,7 @@ func (s *BundleDeployCharmStoreSuite) TestDeployBundleAnnotations(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	svc, err := s.State.Application("django")
 	c.Assert(err, jc.ErrorIsNil)
-	ann, err := s.State.Annotations(svc)
+	ann, err := s.IAASModel.Annotations(svc)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(ann, jc.DeepEquals, map[string]string{
 		"key1": "value1",
@@ -1234,7 +1234,7 @@ func (s *BundleDeployCharmStoreSuite) TestDeployBundleAnnotations(c *gc.C) {
 	})
 	m, err := s.State.Machine("0")
 	c.Assert(err, jc.ErrorIsNil)
-	ann, err = s.State.Annotations(m)
+	ann, err = s.IAASModel.Annotations(m)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(ann, jc.DeepEquals, map[string]string{"foo": "bar"})
 
@@ -1253,13 +1253,13 @@ func (s *BundleDeployCharmStoreSuite) TestDeployBundleAnnotations(c *gc.C) {
                 annotations: {answer: 42}
     `)
 	c.Assert(err, jc.ErrorIsNil)
-	ann, err = s.State.Annotations(svc)
+	ann, err = s.IAASModel.Annotations(svc)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(ann, jc.DeepEquals, map[string]string{
 		"key1": "new value!",
 		"key2": "value2",
 	})
-	ann, err = s.State.Annotations(m)
+	ann, err = s.IAASModel.Annotations(m)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(ann, jc.DeepEquals, map[string]string{
 		"foo":    "bar",

--- a/state/allwatcher_internal_test.go
+++ b/state/allwatcher_internal_test.go
@@ -58,6 +58,8 @@ type allWatcherBaseSuite struct {
 // all(Model)WatcherStateBacking.GetAll.
 func (s *allWatcherBaseSuite) setUpScenario(c *gc.C, st *State, units int, includeOffers bool) (entities entityInfoSlice) {
 	modelUUID := st.ModelUUID()
+	model, err := st.Model()
+	c.Assert(err, jc.ErrorIsNil)
 	add := func(e multiwatcher.EntityInfo) {
 		entities = append(entities, e)
 	}
@@ -129,7 +131,7 @@ func (s *allWatcherBaseSuite) setUpScenario(c *gc.C, st *State, units int, inclu
 		},
 	})
 	pairs := map[string]string{"x": "12", "y": "99"}
-	err = st.SetAnnotations(wordpress, pairs)
+	err = model.SetAnnotations(wordpress, pairs)
 	c.Assert(err, jc.ErrorIsNil)
 	add(&multiwatcher.AnnotationInfo{
 		ModelUUID:   modelUUID,
@@ -194,7 +196,7 @@ func (s *allWatcherBaseSuite) setUpScenario(c *gc.C, st *State, units int, inclu
 			},
 		})
 		pairs := map[string]string{"name": fmt.Sprintf("bar %d", i)}
-		err = st.SetAnnotations(wu, pairs)
+		err = model.SetAnnotations(wu, pairs)
 		c.Assert(err, jc.ErrorIsNil)
 		add(&multiwatcher.AnnotationInfo{
 			ModelUUID:   modelUUID,
@@ -1139,7 +1141,10 @@ func (s *allWatcherStateSuite) TestStateWatcherTwoModels(c *gc.C) {
 				m, err := st.Machine("0")
 				c.Assert(err, jc.ErrorIsNil)
 
-				err = st.SetAnnotations(m, map[string]string{"foo": "bar"})
+				model, err := st.Model()
+				c.Assert(err, jc.ErrorIsNil)
+
+				err = model.SetAnnotations(m, map[string]string{"foo": "bar"})
 				c.Assert(err, jc.ErrorIsNil)
 				return 1
 			},
@@ -2014,7 +2019,9 @@ func testChangeAnnotations(c *gc.C, runChangeTests func(*gc.C, []changeTestFunc)
 		func(c *gc.C, st *State) changeTestCase {
 			m, err := st.AddMachine("quantal", JobHostUnits)
 			c.Assert(err, jc.ErrorIsNil)
-			err = st.SetAnnotations(m, map[string]string{"foo": "bar", "arble": "baz"})
+			model, err := st.Model()
+			c.Assert(err, jc.ErrorIsNil)
+			err = model.SetAnnotations(m, map[string]string{"foo": "bar", "arble": "baz"})
 			c.Assert(err, jc.ErrorIsNil)
 
 			return changeTestCase{
@@ -2033,7 +2040,9 @@ func testChangeAnnotations(c *gc.C, runChangeTests func(*gc.C, []changeTestFunc)
 		func(c *gc.C, st *State) changeTestCase {
 			m, err := st.AddMachine("quantal", JobHostUnits)
 			c.Assert(err, jc.ErrorIsNil)
-			err = st.SetAnnotations(m, map[string]string{
+			model, err := st.Model()
+			c.Assert(err, jc.ErrorIsNil)
+			err = model.SetAnnotations(m, map[string]string{
 				"arble":  "khroomph",
 				"pretty": "",
 				"new":    "attr",

--- a/state/migration_export_test.go
+++ b/state/migration_export_test.go
@@ -57,9 +57,7 @@ type MigrationBaseSuite struct {
 }
 
 func (s *MigrationBaseSuite) setLatestTools(c *gc.C, latestTools version.Number) {
-	dbModel, err := s.State.Model()
-	c.Assert(err, jc.ErrorIsNil)
-	err = dbModel.UpdateLatestToolsVersion(latestTools)
+	err := s.Model.UpdateLatestToolsVersion(latestTools)
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -155,9 +153,7 @@ func (s *MigrationExportSuite) checkStatusHistory(c *gc.C, history []description
 }
 
 func (s *MigrationExportSuite) TestModelInfo(c *gc.C) {
-	stModel, err := s.State.Model()
-	c.Assert(err, jc.ErrorIsNil)
-	err = s.State.SetAnnotations(stModel, testAnnotations)
+	err := s.Model.SetAnnotations(s.Model, testAnnotations)
 	c.Assert(err, jc.ErrorIsNil)
 	latestTools := version.MustParse("2.0.1")
 	s.setLatestTools(c, latestTools)
@@ -167,18 +163,16 @@ func (s *MigrationExportSuite) TestModelInfo(c *gc.C) {
 	fooSeq := s.setRandSequenceValue(c, "application-foo")
 	s.State.SwitchBlockOn(state.ChangeBlock, "locked down")
 	environVersion := 123
-	err = stModel.SetEnvironVersion(environVersion)
+	err = s.Model.SetEnvironVersion(environVersion)
 	c.Assert(err, jc.ErrorIsNil)
 
 	model, err := s.State.Export()
 	c.Assert(err, jc.ErrorIsNil)
 
-	dbModel, err := s.State.Model()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(model.Type(), gc.Equals, string(dbModel.Type()))
-	c.Assert(model.Tag(), gc.Equals, dbModel.ModelTag())
-	c.Assert(model.Owner(), gc.Equals, dbModel.Owner())
-	dbModelCfg, err := dbModel.Config()
+	c.Assert(model.Type(), gc.Equals, string(s.Model.Type()))
+	c.Assert(model.Tag(), gc.Equals, s.Model.ModelTag())
+	c.Assert(model.Owner(), gc.Equals, s.Model.Owner())
+	dbModelCfg, err := s.Model.Config()
 	c.Assert(err, jc.ErrorIsNil)
 	modelAttrs := dbModelCfg.AllAttrs()
 	modelCfg := model.Config()
@@ -287,7 +281,8 @@ func (s *MigrationExportSuite) assertMachinesMigrated(c *gc.C, cons constraints.
 		Constraints: cons,
 	})
 	nested := s.Factory.MakeMachineNested(c, machine1.Id(), nil)
-	err := s.State.SetAnnotations(machine1, testAnnotations)
+
+	err := s.Model.SetAnnotations(machine1, testAnnotations)
 	c.Assert(err, jc.ErrorIsNil)
 	s.primeStatusHistory(c, machine1, status.Started, addedHistoryCount)
 
@@ -393,7 +388,7 @@ func (s *MigrationExportSuite) assertMigrateApplications(c *gc.C, cons constrain
 	c.Assert(err, jc.ErrorIsNil)
 	err = application.SetMetricCredentials([]byte("sekrit"))
 	c.Assert(err, jc.ErrorIsNil)
-	err = s.State.SetAnnotations(application, testAnnotations)
+	err = s.Model.SetAnnotations(application, testAnnotations)
 	c.Assert(err, jc.ErrorIsNil)
 	s.primeStatusHistory(c, application, status.Active, addedHistoryCount)
 
@@ -452,7 +447,7 @@ func (s *MigrationExportSuite) TestUnits(c *gc.C) {
 		err = unit.SetWorkloadVersion(version)
 		c.Assert(err, jc.ErrorIsNil)
 	}
-	err = s.State.SetAnnotations(unit, testAnnotations)
+	err = s.Model.SetAnnotations(unit, testAnnotations)
 	c.Assert(err, jc.ErrorIsNil)
 	s.primeStatusHistory(c, unit, status.Active, addedHistoryCount)
 	s.primeStatusHistory(c, unit.Agent(), status.Idle, addedHistoryCount)

--- a/state/migration_import.go
+++ b/state/migration_import.go
@@ -251,7 +251,7 @@ func (i *importer) modelExtras() error {
 	}
 
 	if annotations := i.model.Annotations(); len(annotations) > 0 {
-		if err := i.st.SetAnnotations(i.dbModel, annotations); err != nil {
+		if err := i.im.SetAnnotations(i.dbModel, annotations); err != nil {
 			return errors.Trace(err)
 		}
 	}
@@ -430,7 +430,7 @@ func (i *importer) machine(m description.Machine) error {
 
 	machine := newMachine(i.st, mdoc)
 	if annotations := m.Annotations(); len(annotations) > 0 {
-		if err := i.st.SetAnnotations(machine, annotations); err != nil {
+		if err := i.im.SetAnnotations(machine, annotations); err != nil {
 			return errors.Trace(err)
 		}
 	}
@@ -781,7 +781,7 @@ func (i *importer) application(a description.Application) error {
 	}
 
 	if annotations := a.Annotations(); len(annotations) > 0 {
-		if err := i.st.SetAnnotations(app, annotations); err != nil {
+		if err := i.im.SetAnnotations(app, annotations); err != nil {
 			return errors.Trace(err)
 		}
 	}
@@ -948,7 +948,7 @@ func (i *importer) unit(s description.Application, u description.Unit) error {
 
 	unit := newUnit(i.st, udoc)
 	if annotations := u.Annotations(); len(annotations) > 0 {
-		if err := i.st.SetAnnotations(unit, annotations); err != nil {
+		if err := i.im.SetAnnotations(unit, annotations); err != nil {
 			return errors.Trace(err)
 		}
 	}

--- a/state/testing/suite.go
+++ b/state/testing/suite.go
@@ -26,8 +26,9 @@ type StateSuite struct {
 	testing.BaseSuite
 	NewPolicy                 state.NewPolicyFunc
 	Controller                *state.Controller
-	State                     *state.State
 	StatePool                 *state.StatePool
+	State                     *state.State
+	Model                     *state.Model
 	IAASModel                 *state.IAASModel
 	Owner                     names.UserTag
 	Factory                   *factory.Factory
@@ -70,9 +71,14 @@ func (s *StateSuite) SetUpTest(c *gc.C) {
 	s.StatePool = state.NewStatePool(s.State)
 	s.AddCleanup(func(*gc.C) { s.StatePool.Close() })
 
+	model, err := s.State.Model()
+	c.Assert(err, jc.ErrorIsNil)
+	s.Model = model
+
 	im, err := s.State.IAASModel()
 	c.Assert(err, jc.ErrorIsNil)
 	s.IAASModel = im
+
 	s.Factory = factory.NewFactory(s.State)
 }
 

--- a/state/testing/suite_wallclock.go
+++ b/state/testing/suite_wallclock.go
@@ -28,6 +28,7 @@ type StateWithWallClockSuite struct {
 	NewPolicy                 state.NewPolicyFunc
 	Controller                *state.Controller
 	State                     *state.State
+	Model                     *state.Model
 	IAASModel                 *state.IAASModel
 	Owner                     names.UserTag
 	Factory                   *factory.Factory
@@ -57,6 +58,10 @@ func (s *StateWithWallClockSuite) SetUpTest(c *gc.C) {
 		s.State.Close()
 		s.Controller.Close()
 	})
+
+	model, err := s.State.Model()
+	c.Assert(err, jc.ErrorIsNil)
+	s.Model = model
 
 	im, err := s.State.IAASModel()
 	c.Assert(err, jc.ErrorIsNil)


### PR DESCRIPTION
## Description of change

This is part of a larger effort to move functionality from State to Model/IAASModel. To make streamline testing in this and future PRs, a Model for the controller model has been added to a couple of base test suites.

## QA steps

Unit tests pass.

## Documentation changes

N.A.

## Bug reference

N.A.