### PR TITLE
Models command also updates client store.

### DIFF
--- a/cmd/juju/controller/listmodels_test.go
+++ b/cmd/juju/controller/listmodels_test.go
@@ -248,6 +248,7 @@ func (s *ModelsSuite) TestModelsNonOwner(c *gc.C) {
 }
 
 func (s *ModelsSuite) TestAllModels(c *gc.C) {
+	c.Assert(s.store.Models["fake"].Models, gc.HasLen, 0)
 	context, err := cmdtesting.RunCommand(c, s.newCommand(), "--all")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(s.api.all, jc.IsTrue)
@@ -259,6 +260,11 @@ func (s *ModelsSuite) TestAllModels(c *gc.C) {
 		"carlotta/test-model2         dummy         active      write   2015-03-01\n"+
 		"daiwik@external/test-model3  dummy         destroying  -       never connected\n"+
 		"\n")
+	c.Assert(s.store.Models["fake"].Models, gc.DeepEquals, map[string]jujuclient.ModelDetails{
+		"admin/test-model1":           jujuclient.ModelDetails{"test-model1-UUID"},
+		"carlotta/test-model2":        jujuclient.ModelDetails{"test-model2-UUID"},
+		"daiwik@external/test-model3": jujuclient.ModelDetails{"test-model3-UUID"},
+	})
 }
 
 func (s *ModelsSuite) TestAllModelsNoneCurrent(c *gc.C) {
@@ -306,6 +312,7 @@ func (s *ModelsSuite) TestModelsMachineInfo(c *gc.C) {
 }
 
 func (s *ModelsSuite) TestAllModelsWithOneUnauthorised(c *gc.C) {
+	c.Assert(s.store.Models["fake"].Models, gc.HasLen, 0)
 	s.api.denyAccess = true
 	context, err := cmdtesting.RunCommand(c, s.newCommand())
 	c.Assert(err, jc.ErrorIsNil)
@@ -316,6 +323,10 @@ func (s *ModelsSuite) TestAllModelsWithOneUnauthorised(c *gc.C) {
 		"test-model1*          dummy         active  read    2015-03-20\n"+
 		"carlotta/test-model2  dummy         active  write   2015-03-01\n"+
 		"\n")
+	c.Assert(s.store.Models["fake"].Models, gc.DeepEquals, map[string]jujuclient.ModelDetails{
+		"admin/test-model1":    jujuclient.ModelDetails{"test-model1-UUID"},
+		"carlotta/test-model2": jujuclient.ModelDetails{"test-model2-UUID"},
+	})
 }
 
 func (s *ModelsSuite) TestUnrecognizedArg(c *gc.C) {

--- a/jujuclient/mem.go
+++ b/jujuclient/mem.go
@@ -297,7 +297,7 @@ func (c *MemStore) CurrentModel(controller string) (string, error) {
 	}
 	controllerModels, ok := c.Models[controller]
 	if !ok {
-		return "", errors.NotFoundf("models for controller %s", controller)
+		return "", errors.NotFoundf("current model for controller %s", controller)
 	}
 	if controllerModels.CurrentModel == "" {
 		return "", errors.NotFoundf("current model for controller %s", controller)

--- a/jujuclient/mem.go
+++ b/jujuclient/mem.go
@@ -238,7 +238,7 @@ func (c *MemStore) SetCurrentModel(controllerName, modelName string) error {
 	}
 	controllerModels, ok := c.Models[controllerName]
 	if !ok {
-		return errors.NotFoundf("models for controller %s", controllerName)
+		return errors.NotFoundf("model %s:%s", controllerName, modelName)
 	}
 	if _, ok := controllerModels.Models[modelName]; !ok {
 		return errors.NotFoundf("model %s:%s", controllerName, modelName)


### PR DESCRIPTION
## Description of change

'models' command gets the list of all models that user can view. This is the best place to update client side cache for controller models. This PR adds client side store update for this command.

This PR also simplifies logic of parsing models from one struct to another avoiding iterating over collection more than once.

As a drive-by, mem store implementation of CurrentModel is now in syn with file implementation behavior and now correctly reports "no current model found" even if there are no models stored for controller. Previously, "no models on controller" was reported.

## QA steps

1. bootstrap
2. manually add a model to your client side store
3. run 'models'
4. check your client store - it should contain only models created by bootstrap

## Documentation changes

n/a - internal change

## Bug reference

n/a
