### PR TITLE
apiserver: fetch identity public key lazily

### DIFF
--- a/api/testing/macaroonsuite.go
+++ b/api/testing/macaroonsuite.go
@@ -68,6 +68,12 @@ func (s *MacaroonSuite) TearDownTest(c *gc.C) {
 	s.JujuConnSuite.TearDownTest(c)
 }
 
+// DischargerLocation returns the URL of the third party caveat
+// discharger.
+func (s *MacaroonSuite) DischargerLocation() string {
+	return s.discharger.Location()
+}
+
 // AddModelUser is a convenience function that adds an external
 // user to the current model. It will panic
 // if the user name is local.

--- a/apiserver/server_test.go
+++ b/apiserver/server_test.go
@@ -25,7 +25,6 @@ import (
 	"gopkg.in/macaroon-bakery.v1/bakery/checkers"
 	"gopkg.in/macaroon-bakery.v1/bakerytest"
 	"gopkg.in/macaroon-bakery.v1/httpbakery"
-	"gopkg.in/macaroon.v1"
 
 	"github.com/juju/juju/api"
 	apimachiner "github.com/juju/juju/api/machiner"
@@ -672,14 +671,9 @@ func newServerWithConfig(c *gc.C, statePool *state.StatePool, cfg apiserver.Serv
 	c.Assert(err, jc.ErrorIsNil)
 	srv, err := apiserver.NewServer(statePool, listener, cfg)
 	c.Assert(err, jc.ErrorIsNil)
-	// Use any old macaroon to ensure we don't attempt
-	// an anonymous login.
-	mac, err := macaroon.New(nil, "test", "")
-	c.Assert(err, jc.ErrorIsNil)
 	return &api.Info{
-		Addrs:     []string{fmt.Sprintf("localhost:%d", srv.Addr().Port)},
-		CACert:    coretesting.CACert,
-		Macaroons: []macaroon.Slice{{mac}},
+		Addrs:  []string{fmt.Sprintf("localhost:%d", srv.Addr().Port)},
+		CACert: coretesting.CACert,
 	}, srv
 }
 


### PR DESCRIPTION
If the identity server isn't available the first time
a remote user tries to log in, we don't want all
remote user logins to fail forever (or until the
API agent is restarted), so we don't try to
fetch the public key immediately, instead
relying on httpbakery.PublicKeyRing to do it
for us when needed.

To QA, bootstrap a controller with identity-url set to a
host that's not running a discharge server. Try to log
in to it as an external user; verify that this fails.
Then start up the discharge server and verify that
it's possible to log in.

Fixes https://bugs.launchpad.net/juju/+bug/1713048
