### PR TITLE
Trigger the config-changed hook when a unit's series changes.

### DIFF
--- a/api/uniter/export_test.go
+++ b/api/uniter/export_test.go
@@ -35,7 +35,13 @@ func PatchUnitResponse(p testing.Patcher, u *Unit, expectedRequest string, respo
 
 // CreateUnit creates uniter.Unit for tests.
 func CreateUnit(st *State, tag names.UnitTag) *Unit {
-	return &Unit{st, tag, params.Alive}
+	return &Unit{
+		st:           st,
+		tag:          tag,
+		life:         params.Alive,
+		resolvedMode: params.ResolvedNone,
+		series:       "trusty",
+	}
 }
 
 var NewStateV4 = newStateForVersionFn(4)

--- a/api/uniter/uniter.go
+++ b/api/uniter/uniter.go
@@ -145,15 +145,15 @@ func (st *State) getOneAction(tag *names.ActionTag) (params.ActionResult, error)
 
 // Unit provides access to methods of a state.Unit through the facade.
 func (st *State) Unit(tag names.UnitTag) (*Unit, error) {
-	life, err := st.life(tag)
+	unit := &Unit{
+		tag: tag,
+		st:  st,
+	}
+	err := unit.Refresh()
 	if err != nil {
 		return nil, err
 	}
-	return &Unit{
-		tag:  tag,
-		life: life,
-		st:   st,
-	}, nil
+	return unit, nil
 }
 
 // Application returns an application state by tag.

--- a/apiserver/facades/agent/uniter/uniter_test.go
+++ b/apiserver/facades/agent/uniter/uniter_test.go
@@ -558,7 +558,7 @@ func (s *uniterSuite) TestAvailabilityZone(c *gc.C) {
 	})
 }
 
-func (s *uniterSuite) TestResolved(c *gc.C) {
+func (s *uniterSuite) TestResolvedAPIV6(c *gc.C) {
 	err := s.wordpressUnit.SetResolved(state.ResolvedRetryHooks)
 	c.Assert(err, jc.ErrorIsNil)
 	mode := s.wordpressUnit.Resolved()
@@ -2802,6 +2802,36 @@ func (s *uniterSuite) TestV5RelationById(c *gc.C) {
 			},
 		},
 	})
+}
+
+func (s *uniterSuite) TestRefresh(c *gc.C) {
+	args := params.Entities{
+		Entities: []params.Entity{
+			{s.wordpressUnit.Tag().String()},
+			{s.mysqlUnit.Tag().String()},
+			{s.mysql.Tag().String()},
+			{s.machine0.Tag().String()},
+			{"some-word"},
+		},
+	}
+	expect := params.UnitRefreshResults{
+		Results: []params.UnitRefreshResult{
+			{Life: params.Alive, Resolved: params.ResolvedNone, Series: "quantal"},
+			{Error: apiservertesting.ErrUnauthorized},
+			{Error: apiservertesting.ErrUnauthorized},
+			{Error: apiservertesting.ErrUnauthorized},
+			{Error: apiservertesting.ErrUnauthorized},
+		},
+	}
+	results, err := s.uniter.Refresh(args)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(results, gc.DeepEquals, expect)
+}
+
+func (s *uniterSuite) TestRefreshNoArgs(c *gc.C) {
+	results, err := s.uniter.Refresh(params.Entities{Entities: []params.Entity{}})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(results, gc.DeepEquals, params.UnitRefreshResults{Results: []params.UnitRefreshResult{}})
 }
 
 type unitMetricBatchesSuite struct {

--- a/apiserver/params/internal.go
+++ b/apiserver/params/internal.go
@@ -783,3 +783,18 @@ type ResourceUploadResult struct {
 	// Timestamp indicates when the resource was added to the model.
 	Timestamp time.Time `json:"timestamp"`
 }
+
+// UnitRefreshResult is used to return the latest values for attributes
+// on a unit.
+type UnitRefreshResult struct {
+	Life     Life
+	Resolved ResolvedMode
+	Series   string
+	Error    *Error
+}
+
+// UnitRefreshResults holds the results for any API call which ends
+// up returning a list of UnitRefreshResult.
+type UnitRefreshResults struct {
+	Results []UnitRefreshResult
+}

--- a/worker/uniter/relation/relations_test.go
+++ b/worker/uniter/relation/relations_test.go
@@ -123,7 +123,7 @@ func (s *relationsSuite) setupRelations(c *gc.C) relation.Relations {
 	var numCalls int32
 	unitEntity := params.Entities{Entities: []params.Entity{{Tag: "unit-wordpress-0"}}}
 	apiCaller := mockAPICaller(c, &numCalls,
-		uniterAPICall("Life", unitEntity, params.LifeResults{Results: []params.LifeResult{{Life: params.Alive}}}, nil),
+		uniterAPICall("Refresh", unitEntity, params.UnitRefreshResults{Results: []params.UnitRefreshResult{{Life: params.Alive, Resolved: params.ResolvedNone, Series: "quantal"}}}, nil),
 		uniterAPICall("GetPrincipal", unitEntity, params.StringBoolResults{Results: []params.StringBoolResult{{Result: "", Ok: false}}}, nil),
 		uniterAPICall("JoinedRelations", unitEntity, params.StringsResults{Results: []params.StringsResult{{Result: []string{}}}}, nil),
 	)
@@ -163,7 +163,7 @@ func (s *relationsSuite) TestNewRelationsWithExistingRelations(c *gc.C) {
 	}
 
 	apiCaller := mockAPICaller(c, &numCalls,
-		uniterAPICall("Life", unitEntity, params.LifeResults{Results: []params.LifeResult{{Life: params.Alive}}}, nil),
+		uniterAPICall("Refresh", unitEntity, params.UnitRefreshResults{Results: []params.UnitRefreshResult{{Life: params.Alive, Resolved: params.ResolvedNone, Series: "quantal"}}}, nil),
 		uniterAPICall("GetPrincipal", unitEntity, params.StringBoolResults{Results: []params.StringBoolResult{{Result: "", Ok: false}}}, nil),
 		uniterAPICall("JoinedRelations", unitEntity, params.StringsResults{Results: []params.StringsResult{{Result: []string{"relation-wordpress:db mysql:db"}}}}, nil),
 		uniterAPICall("Relation", relationUnits, relationResults, nil),
@@ -193,7 +193,7 @@ func (s *relationsSuite) TestNextOpNothing(c *gc.C) {
 	var numCalls int32
 	unitEntity := params.Entities{Entities: []params.Entity{{Tag: "unit-wordpress-0"}}}
 	apiCaller := mockAPICaller(c, &numCalls,
-		uniterAPICall("Life", unitEntity, params.LifeResults{Results: []params.LifeResult{{Life: params.Alive}}}, nil),
+		uniterAPICall("Refresh", unitEntity, params.UnitRefreshResults{Results: []params.UnitRefreshResult{{Life: params.Alive, Resolved: params.ResolvedNone, Series: "quantal"}}}, nil),
 		uniterAPICall("GetPrincipal", unitEntity, params.StringBoolResults{Results: []params.StringBoolResult{{Result: "", Ok: false}}}, nil),
 		uniterAPICall("JoinedRelations", unitEntity, params.StringsResults{Results: []params.StringsResult{{Result: []string{}}}}, nil),
 	)
@@ -231,7 +231,7 @@ func relationJoinedAPICalls() []apiCall {
 		{Relation: "relation-wordpress.db#mysql.db", Unit: "unit-wordpress-0"},
 	}}
 	apiCalls := []apiCall{
-		uniterAPICall("Life", unitEntity, params.LifeResults{Results: []params.LifeResult{{Life: params.Alive}}}, nil),
+		uniterAPICall("Refresh", unitEntity, params.UnitRefreshResults{Results: []params.UnitRefreshResult{{Life: params.Alive, Resolved: params.ResolvedNone, Series: "quantal"}}}, nil),
 		uniterAPICall("GetPrincipal", unitEntity, params.StringBoolResults{Results: []params.StringBoolResult{{Result: "", Ok: false}}}, nil),
 		uniterAPICall("JoinedRelations", unitEntity, params.StringsResults{Results: []params.StringsResult{{Result: []string{}}}}, nil),
 		uniterAPICall("RelationById", params.RelationIds{RelationIds: []int{1}}, relationResults, nil),
@@ -541,7 +541,7 @@ func (s *relationsSuite) TestImplicitRelationNoHooks(c *gc.C) {
 		{Relation: "relation-wordpress.juju-info#juju-info.juju-info", Unit: "unit-wordpress-0"},
 	}}
 	apiCalls := []apiCall{
-		uniterAPICall("Life", unitEntity, params.LifeResults{Results: []params.LifeResult{{Life: params.Alive}}}, nil),
+		uniterAPICall("Refresh", unitEntity, params.UnitRefreshResults{Results: []params.UnitRefreshResult{{Life: params.Alive, Resolved: params.ResolvedNone, Series: "quantal"}}}, nil),
 		uniterAPICall("GetPrincipal", unitEntity, params.StringBoolResults{Results: []params.StringBoolResult{{Result: "", Ok: false}}}, nil),
 		uniterAPICall("JoinedRelations", unitEntity, params.StringsResults{Results: []params.StringsResult{{Result: []string{}}}}, nil),
 		uniterAPICall("RelationById", params.RelationIds{RelationIds: []int{1}}, relationResults, nil),
@@ -630,7 +630,7 @@ func subSubRelationAPICalls() []apiCall {
 	}
 
 	return []apiCall{
-		uniterAPICall("Life", nrpeUnitEntity, params.LifeResults{Results: []params.LifeResult{{Life: params.Alive}}}, nil),
+		uniterAPICall("Refresh", nrpeUnitEntity, params.UnitRefreshResults{Results: []params.UnitRefreshResult{{Life: params.Alive, Resolved: params.ResolvedNone, Series: "quantal"}}}, nil),
 		uniterAPICall("GetPrincipal", nrpeUnitEntity, params.StringBoolResults{Results: []params.StringBoolResult{{Result: "unit-wordpress-0", Ok: true}}}, nil),
 		uniterAPICall("JoinedRelations", nrpeUnitEntity, joinedRelationsResults, nil),
 		uniterAPICall("Relation", relationUnits1, relationResults1, nil),

--- a/worker/uniter/remotestate/mock_test.go
+++ b/worker/uniter/remotestate/mock_test.go
@@ -190,6 +190,7 @@ type mockUnit struct {
 	tag                   names.UnitTag
 	life                  params.Life
 	resolved              params.ResolvedMode
+	series                string
 	service               mockService
 	unitWatcher           *mockNotifyWatcher
 	addressesWatcher      *mockNotifyWatcher
@@ -207,12 +208,16 @@ func (u *mockUnit) Refresh() error {
 	return nil
 }
 
-func (u *mockUnit) Resolved() (params.ResolvedMode, error) {
-	return u.resolved, nil
+func (u *mockUnit) Resolved() params.ResolvedMode {
+	return u.resolved
 }
 
 func (u *mockUnit) Application() (remotestate.Application, error) {
 	return &u.service, nil
+}
+
+func (u *mockUnit) Series() string {
+	return u.series
 }
 
 func (u *mockUnit) Tag() names.UnitTag {

--- a/worker/uniter/remotestate/snapshot.go
+++ b/worker/uniter/remotestate/snapshot.go
@@ -68,6 +68,9 @@ type Snapshot struct {
 	// Commands is the list of IDs of commands to be
 	// executed by this unit.
 	Commands []string
+
+	// Series is the current series running on the unit
+	Series string
 }
 
 type RelationSnapshot struct {

--- a/worker/uniter/remotestate/state.go
+++ b/worker/uniter/remotestate/state.go
@@ -33,8 +33,9 @@ type State interface {
 type Unit interface {
 	Life() params.Life
 	Refresh() error
-	Resolved() (params.ResolvedMode, error)
+	Resolved() params.ResolvedMode
 	Application() (Application, error)
+	Series() string
 	Tag() names.UnitTag
 	Watch() (watcher.NotifyWatcher, error)
 	WatchAddresses() (watcher.NotifyWatcher, error)

--- a/worker/uniter/remotestate/watcher.go
+++ b/worker/uniter/remotestate/watcher.go
@@ -478,14 +478,11 @@ func (w *RemoteStateWatcher) unitChanged() error {
 	if err := w.unit.Refresh(); err != nil {
 		return errors.Trace(err)
 	}
-	resolved, err := w.unit.Resolved()
-	if err != nil {
-		return errors.Trace(err)
-	}
 	w.mu.Lock()
 	defer w.mu.Unlock()
 	w.current.Life = w.unit.Life()
-	w.current.ResolvedMode = resolved
+	w.current.ResolvedMode = w.unit.Resolved()
+	w.current.Series = w.unit.Series()
 	return nil
 }
 

--- a/worker/uniter/remotestate/watcher_test.go
+++ b/worker/uniter/remotestate/watcher_test.go
@@ -150,6 +150,7 @@ func (s *WatcherSuite) TestSnapshot(c *gc.C) {
 		ConfigVersion:         2, // config settings and addresses
 		LeaderSettingsVersion: 1,
 		Leader:                true,
+		Series:                "",
 	})
 }
 
@@ -167,6 +168,16 @@ func (s *WatcherSuite) TestRemoteStateChanged(c *gc.C) {
 	s.st.unit.unitWatcher.changes <- struct{}{}
 	assertOneChange()
 	c.Assert(s.watcher.Snapshot().Life, gc.Equals, params.Dying)
+
+	s.st.unit.series = "trusty"
+	s.st.unit.unitWatcher.changes <- struct{}{}
+	assertOneChange()
+	c.Assert(s.watcher.Snapshot().Series, gc.Equals, "trusty")
+
+	s.st.unit.resolved = params.ResolvedRetryHooks
+	s.st.unit.unitWatcher.changes <- struct{}{}
+	assertOneChange()
+	c.Assert(s.watcher.Snapshot().ResolvedMode, gc.Equals, params.ResolvedRetryHooks)
 
 	s.st.unit.addressesWatcher.changes <- struct{}{}
 	assertOneChange()

--- a/worker/uniter/resolver.go
+++ b/worker/uniter/resolver.go
@@ -260,7 +260,8 @@ func (s *uniterResolver) nextOp(
 		return opFactory.NewUpgrade(remoteState.CharmURL)
 	}
 
-	if localState.ConfigVersion != remoteState.ConfigVersion {
+	if localState.ConfigVersion != remoteState.ConfigVersion ||
+		localState.Series != remoteState.Series {
 		return opFactory.NewRunHook(hook.Info{Kind: hooks.ConfigChanged})
 	}
 

--- a/worker/uniter/resolver/interface.go
+++ b/worker/uniter/resolver/interface.go
@@ -94,4 +94,8 @@ type LocalState struct {
 	// This is used to prevent us re running actions requested by the
 	// controller.
 	CompletedActions map[string]struct{}
+
+	// Series is the current series running on the unit from remotestate.Snapshot
+	// for which a config-changed hook has been committed.
+	Series string
 }

--- a/worker/uniter/resolver/opfactory.go
+++ b/worker/uniter/resolver/opfactory.go
@@ -112,8 +112,10 @@ func (s *resolverOpFactory) wrapHookOp(op operation.Operation, info hook.Info) o
 	switch info.Kind {
 	case hooks.ConfigChanged:
 		v := s.RemoteState.ConfigVersion
+		series := s.RemoteState.Series
 		op = onCommitWrapper{op, func() {
 			s.LocalState.ConfigVersion = v
+			s.LocalState.Series = series
 		}}
 	case hooks.LeaderSettingsChanged:
 		v := s.RemoteState.LeaderSettingsVersion

--- a/worker/uniter/resolver/opfactory_test.go
+++ b/worker/uniter/resolver/opfactory_test.go
@@ -83,11 +83,13 @@ func (s *ResolverOpFactorySuite) testConfigChanged(
 	f := resolver.NewResolverOpFactory(s.opFactory)
 	f.RemoteState.ConfigVersion = 1
 	f.RemoteState.UpdateStatusVersion = 3
+	f.RemoteState.Series = "trusty"
 
 	op, err := f.NewRunHook(hook.Info{Kind: hooks.ConfigChanged})
 	c.Assert(err, jc.ErrorIsNil)
 	f.RemoteState.ConfigVersion = 2
 	f.RemoteState.UpdateStatusVersion = 4
+	f.RemoteState.Series = "xenial"
 
 	_, err = op.Commit(operation.State{})
 	c.Assert(err, jc.ErrorIsNil)
@@ -97,6 +99,7 @@ func (s *ResolverOpFactorySuite) testConfigChanged(
 	// was constructed.
 	c.Assert(f.LocalState.ConfigVersion, gc.Equals, 1)
 	c.Assert(f.LocalState.UpdateStatusVersion, gc.Equals, 3)
+	c.Assert(f.LocalState.Series, gc.Equals, "trusty")
 }
 
 func (s *ResolverOpFactorySuite) TestLeaderSettingsChanged(c *gc.C) {

--- a/worker/uniter/resolver_test.go
+++ b/worker/uniter/resolver_test.go
@@ -109,6 +109,39 @@ func (s *resolverSuite) TestNotStartedNotInstalled(c *gc.C) {
 	c.Assert(op.String(), gc.Equals, "run install hook")
 }
 
+func (s *resolverSuite) TestSeriesChanged(c *gc.C) {
+	localState := resolver.LocalState{
+		CharmModifiedVersion: s.charmModifiedVersion,
+		CharmURL:             s.charmURL,
+		Series:               s.charmURL.Series,
+		State: operation.State{
+			Kind:      operation.Continue,
+			Installed: true,
+			Started:   true,
+		},
+	}
+	s.remoteState.Series = "trusty"
+	op, err := s.resolver.NextOp(localState, s.remoteState, s.opFactory)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(op.String(), gc.Equals, "run config-changed hook")
+}
+
+func (s *resolverSuite) TestSeriesChangedBlank(c *gc.C) {
+	localState := resolver.LocalState{
+		CharmModifiedVersion: s.charmModifiedVersion,
+		CharmURL:             s.charmURL,
+		State: operation.State{
+			Kind:      operation.Continue,
+			Installed: true,
+			Started:   true,
+		},
+	}
+	s.remoteState.Series = "trusty"
+	op, err := s.resolver.NextOp(localState, s.remoteState, s.opFactory)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(op.String(), gc.Equals, "run config-changed hook")
+}
+
 func (s *resolverSuite) TestHookErrorDoesNotStartRetryTimerIfShouldRetryFalse(c *gc.C) {
 	s.resolverConfig.ShouldRetryHooks = false
 	s.resolver = uniter.NewUniterResolver(s.resolverConfig)


### PR DESCRIPTION
## Description of change

This is the follow on to PR 7776, as part of the series update work. 

## QA steps

Beyond the unit tests, after PR 7776 has landed as well, use the juju update-series <machine> <series> command and check that the config-changed hook has been run for unit(s) on the machine.

## Documentation changes

n/a

## Bug reference

This is a planned project, however a feature request bug was filed as well:
https://bugs.launchpad.net/juju/+bug/1704135