### PR TITLE
propagate host's AZ to containers

### DIFF
--- a/api/facadeversions.go
+++ b/api/facadeversions.go
@@ -68,7 +68,7 @@ var facadeVersions = map[string]int{
 	"Payloads":                     1,
 	"PayloadsHookContext":          1,
 	"Pinger":                       1,
-	"Provisioner":                  3,
+	"Provisioner":                  4,
 	"ProxyUpdater":                 1,
 	"Reboot":                       2,
 	"RelationStatusWatcher":        1,

--- a/api/provisioner/machine.go
+++ b/api/provisioner/machine.go
@@ -227,6 +227,27 @@ func (m *Machine) Series() (string, error) {
 	return result.Result, nil
 }
 
+// AvailabilityZone returns an underlying provider's availability zone
+// for a machine
+func (m *Machine) AvailabilityZone() (string, error) {
+	var results params.StringResults
+	args := params.Entities{
+		Entities: []params.Entity{{Tag: m.tag.String()}},
+	}
+	err := m.st.facade.FacadeCall("AvailabilityZone", args, &results)
+	if err != nil {
+		return "", err
+	}
+	if len(results.Results) != 1 {
+		return "", fmt.Errorf("expected 1 result, got %d", len(results.Results))
+	}
+	result := results.Results[0]
+	if result.Error != nil {
+		return "", result.Error
+	}
+	return result.Result, nil
+}
+
 // DistributionGroup returns a slice of instance.Ids
 // that belong to the same distribution group as this
 // Machine. The provisioner may use this information

--- a/apiserver/allfacades.go
+++ b/apiserver/allfacades.go
@@ -198,6 +198,7 @@ func AllFacades() *facade.Registry {
 
 	reg("Pinger", 1, NewPinger)
 	reg("Provisioner", 3, provisioner.NewProvisionerAPI)
+	reg("Provisioner", 4, provisioner.NewProvisionerAPI)
 	reg("ProxyUpdater", 1, proxyupdater.NewAPI)
 	reg("Reboot", 2, reboot.NewRebootAPI)
 

--- a/apiserver/facades/agent/provisioner/provisioner_test.go
+++ b/apiserver/facades/agent/provisioner/provisioner_test.go
@@ -818,6 +818,41 @@ func (s *withoutControllerSuite) TestSeries(c *gc.C) {
 	})
 }
 
+func (s *withoutControllerSuite) TestAvailabilityZone(c *gc.C) {
+	availabilityZone := "ru-north-siberia"
+	emptyAz := ""
+	hcWithAZ := instance.HardwareCharacteristics{AvailabilityZone: &availabilityZone}
+	hcWithEmptyAZ := instance.HardwareCharacteristics{AvailabilityZone: &emptyAz}
+	hcWithNilAz := instance.HardwareCharacteristics{AvailabilityZone: nil}
+
+	// add machines with different availability zones: string, empty string, nil
+	azMachine, _ := s.Factory.MakeMachineReturningPassword(c, &factory.MachineParams{
+		Characteristics: &hcWithAZ,
+	})
+
+	emptyAzMachine, _ := s.Factory.MakeMachineReturningPassword(c, &factory.MachineParams{
+		Characteristics: &hcWithEmptyAZ,
+	})
+
+	nilAzMachine, _ := s.Factory.MakeMachineReturningPassword(c, &factory.MachineParams{
+		Characteristics: &hcWithNilAz,
+	})
+	args := params.Entities{Entities: []params.Entity{
+		{Tag: azMachine.Tag().String()},
+		{Tag: emptyAzMachine.Tag().String()},
+		{Tag: nilAzMachine.Tag().String()},
+	}}
+	result, err := s.provisioner.AvailabilityZone(args)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result, gc.DeepEquals, params.StringResults{
+		Results: []params.StringResult{
+			{Result: availabilityZone},
+			{Result: emptyAz},
+			{Result: emptyAz},
+		},
+	})
+}
+
 func (s *withoutControllerSuite) TestKeepInstance(c *gc.C) {
 	// Add a machine with keep-instance = true.
 	foobarMachine := s.Factory.MakeMachine(c, &factory.MachineParams{InstanceId: "1234"})

--- a/container/interface.go
+++ b/container/interface.go
@@ -11,8 +11,9 @@ import (
 )
 
 const (
-	ConfigModelUUID = "model-uuid"
-	ConfigLogDir    = "log-dir"
+	ConfigModelUUID        = "model-uuid"
+	ConfigLogDir           = "log-dir"
+	ConfigAvailabilityZone = "availability-zone"
 )
 
 // ManagerConfig contains the initialization parameters for the ContainerManager.

--- a/featuretests/juju_container_az_test.go
+++ b/featuretests/juju_container_az_test.go
@@ -1,0 +1,54 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package featuretests
+
+import (
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/instance"
+	jujutesting "github.com/juju/juju/juju/testing"
+	"github.com/juju/juju/testing/factory"
+)
+
+type containerAZSuite struct {
+	jujutesting.JujuConnSuite
+}
+
+func (s *containerAZSuite) TestContainerAvailabilityZone(c *gc.C) {
+	availabilityZone := "ru-north-siberia"
+	azMachine := s.Factory.MakeMachine(c, &factory.MachineParams{
+		Characteristics: &instance.HardwareCharacteristics{AvailabilityZone: &availabilityZone},
+	})
+
+	retAvailabilityZone, err := azMachine.AvailabilityZone()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(availabilityZone, gc.Equals, retAvailabilityZone)
+
+	// now add a container to that machine
+	container := s.Factory.MakeMachineNested(c, azMachine.Id(), nil)
+	c.Assert(err, jc.ErrorIsNil)
+
+	containerAvailabilityZone, err := container.AvailabilityZone()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(availabilityZone, gc.Equals, containerAvailabilityZone)
+}
+
+func (s *containerAZSuite) TestContainerNilAvailabilityZone(c *gc.C) {
+	azMachine := s.Factory.MakeMachine(c, &factory.MachineParams{
+		Characteristics: &instance.HardwareCharacteristics{AvailabilityZone: nil},
+	})
+
+	retAvailabilityZone, err := azMachine.AvailabilityZone()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert("", gc.Equals, retAvailabilityZone)
+
+	// now add a container to that machine
+	container := s.Factory.MakeMachineNested(c, azMachine.Id(), nil)
+	c.Assert(err, jc.ErrorIsNil)
+
+	containerAvailabilityZone, err := container.AvailabilityZone()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert("", gc.Equals, containerAvailabilityZone)
+}

--- a/testing/factory/factory.go
+++ b/testing/factory/factory.go
@@ -348,6 +348,10 @@ func (factory *Factory) makeMachineReturningPassword(c *gc.C, params *MachinePar
 		Filesystems: params.Filesystems,
 		Constraints: params.Constraints,
 	}
+
+	if params.Characteristics != nil {
+		machineTemplate.HardwareCharacteristics = *params.Characteristics
+	}
 	machine, err := factory.st.AddOneMachine(machineTemplate)
 	c.Assert(err, jc.ErrorIsNil)
 	if setProvisioned {

--- a/worker/provisioner/container_initialisation.go
+++ b/worker/provisioner/container_initialisation.go
@@ -263,6 +263,13 @@ func (cs *ContainerSetup) getContainerArtifacts(
 		return nil, nil, nil, err
 	}
 
+	availabilityZone, err := cs.machine.AvailabilityZone()
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	// pass host machine's availability zone to the container manager config
+	managerConfig[container.ConfigAvailabilityZone] = availabilityZone
+
 	switch containerType {
 	case instance.KVM:
 		manager, err := kvm.NewContainerManager(managerConfig)

--- a/worker/provisioner/container_initialisation_test.go
+++ b/worker/provisioner/container_initialisation_test.go
@@ -340,7 +340,7 @@ func (s *ContainerSetupSuite) TestContainerInitialised(c *gc.C) {
 	}
 }
 
-func (s *ContainerSetupSuite) TestContainerInitLockError(c *gc.C) {
+func (s *ContainerSetupSuite) TestContainerInitInstDataError(c *gc.C) {
 	spec := mutex.Spec{
 		Name:  s.lockName,
 		Clock: clock.WallClock,
@@ -374,7 +374,7 @@ func (s *ContainerSetupSuite) TestContainerInitLockError(c *gc.C) {
 	abort := make(chan struct{})
 	close(abort)
 	err = handler.Handle(abort, []string{"0/lxd/0"})
-	c.Assert(err, gc.ErrorMatches, ".*failed to acquire initialization lock:.*")
+	c.Assert(err, gc.ErrorMatches, ".*initialising container infrastructure on host machine: instance data for machine.*not found")
 
 }
 


### PR DESCRIPTION
## Description of change

pad.lv/1684325

Currently a provider-specific AZ is not propagated to containers
deployed on any provider - during container creation an empty
HardwareCharacteristics struct is initialized by a container manager.

It is important for certain applications to have this value exposed as
an environment variable in a hook context so that they can be
configured to be aware of physical placement with respect to failure
domains.

Given that provisioner has an ability to query machine state via
an apiserver facade, it is possible to get an availability zone for a
machine with a given tag. For that a new API call is introduced to query
that information.

## QA steps

http://paste.ubuntu.com/25411705/

## Documentation changes

Creates a new facade call AvailabilityZone which allows to query that field from hardware characteristics stored in state for a machine identified by a given tag.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1684325
https://bugs.launchpad.net/charm-ceph-osd/+bug/1684330
