### PR TITLE
provider/azure: filter common deployment

### DIFF
--- a/provider/azure/environ.go
+++ b/provider/azure/environ.go
@@ -1422,6 +1422,13 @@ func (env *azureEnviron) allInstances(
 	azureInstances := make([]*azureInstance, 0, len(*deploymentsResult.Value))
 	for _, deployment := range *deploymentsResult.Value {
 		name := to.String(deployment.Name)
+		if _, err := names.ParseMachineTag(name); err != nil {
+			// Deployments we create for Juju machines are named
+			// with the machine tag. We also create a "common"
+			// deployment, so this will exclude that VM and any
+			// other stray deployment resources.
+			continue
+		}
 		if deployment.Properties == nil || deployment.Properties.Dependencies == nil {
 			continue
 		}

--- a/provider/azure/environ_test.go
+++ b/provider/azure/environ_test.go
@@ -1193,6 +1193,30 @@ func (s *environSuite) TestAllInstancesResourceGroupNotFound(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 }
 
+func (s *environSuite) TestAllInstancesIgnoresCommonDeployment(c *gc.C) {
+	env := s.openEnviron(c)
+
+	dependencies := []resources.Dependency{{
+		ID: to.StringPtr("whatever"),
+	}}
+	deployments := []resources.DeploymentExtended{{
+		// common deployment should be ignored
+		Name: to.StringPtr("common"),
+		Properties: &resources.DeploymentPropertiesExtended{
+			ProvisioningState: to.StringPtr("Succeeded"),
+			Dependencies:      &dependencies,
+		},
+	}}
+	result := resources.DeploymentListResult{Value: &deployments}
+	s.sender = azuretesting.Senders{
+		s.makeSender("/deployments", result),
+	}
+
+	instances, err := env.AllInstances()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(instances, gc.HasLen, 0)
+}
+
 func (s *environSuite) TestStopInstancesNotFound(c *gc.C) {
 	env := s.openEnviron(c)
 	sender0 := mocks.NewSender()


### PR DESCRIPTION
## Description of change

AllInstances was incorrectly returning the
"common" deployment we create for holding
common resources. We change the AllInstances
so that it filters out any deployment whose
name does not match the machine tag format.

## QA steps

1. juju bootstrap azure azure1 && juju add-model foo
2. juju bootstrap azure azure2
3. juju switch azure1 && juju migrate foo azure2

## Documentation changes

None.

## Bug reference

Fixes https://bugs.launchpad.net/juju/+bug/1713372