### PR TITLE
User to model

### DIFF
--- a/apiserver/admin.go
+++ b/apiserver/admin.go
@@ -615,8 +615,14 @@ func (u *modelUserEntity) LastLogin() (time.Time, error) {
 	// the local user last login time.
 	var err error
 	var t time.Time
+
+	model, err := u.st.Model()
+	if err != nil {
+		return t, errors.Trace(err)
+	}
+
 	if !permission.IsEmptyUserAccess(u.modelUser) {
-		t, err = u.st.LastModelConnection(u.modelUser.UserTag)
+		t, err = model.LastModelConnection(u.modelUser.UserTag)
 	} else {
 		err = state.NeverConnectedError("controller user")
 	}
@@ -641,7 +647,12 @@ func (u *modelUserEntity) UpdateLastLogin() error {
 			return errors.NotValidf("%s as model user", u.modelUser.Object.Kind())
 		}
 
-		err = u.st.UpdateLastModelConnection(u.modelUser.UserTag)
+		model, err := u.st.Model()
+		if err != nil {
+			return errors.Trace(err)
+		}
+
+		err = model.UpdateLastModelConnection(u.modelUser.UserTag)
 	}
 
 	if u.user != nil {

--- a/apiserver/admin_test.go
+++ b/apiserver/admin_test.go
@@ -440,7 +440,7 @@ func (s *loginSuite) TestNonModelUserLoginFails(c *gc.C) {
 	info.ModelTag = s.State.ModelTag()
 	user := s.Factory.MakeUser(c, &factory.UserParams{Password: "dummy-password", NoModelUser: true})
 	ctag := names.NewControllerTag(s.State.ControllerUUID())
-	err := s.Model.RemoveUserAccess(user.UserTag(), ctag)
+	err := s.State.RemoveUserAccess(user.UserTag(), ctag)
 	c.Assert(err, jc.ErrorIsNil)
 	info.Password = "dummy-password"
 	info.Tag = user.UserTag()

--- a/apiserver/admin_test.go
+++ b/apiserver/admin_test.go
@@ -440,7 +440,7 @@ func (s *loginSuite) TestNonModelUserLoginFails(c *gc.C) {
 	info.ModelTag = s.State.ModelTag()
 	user := s.Factory.MakeUser(c, &factory.UserParams{Password: "dummy-password", NoModelUser: true})
 	ctag := names.NewControllerTag(s.State.ControllerUUID())
-	err := s.State.RemoveUserAccess(user.UserTag(), ctag)
+	err := s.Model.RemoveUserAccess(user.UserTag(), ctag)
 	c.Assert(err, jc.ErrorIsNil)
 	info.Password = "dummy-password"
 	info.Tag = user.UserTag()
@@ -880,7 +880,7 @@ func (s *loginSuite) TestLoginUpdatesLastLoginAndConnection(c *gc.C) {
 	// The model user is also updated.
 	modelUser, err := s.State.UserAccess(user.UserTag(), s.State.ModelTag())
 	c.Assert(err, jc.ErrorIsNil)
-	when, err := s.State.LastModelConnection(modelUser.UserTag)
+	when, err := s.Model.LastModelConnection(modelUser.UserTag)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(when, gc.NotNil)
 	c.Assert(when.After(startTime), jc.IsTrue)

--- a/apiserver/authhttp_test.go
+++ b/apiserver/authhttp_test.go
@@ -239,8 +239,10 @@ func (s *authHTTPSuite) authRequest(c *gc.C, p httpRequestParams) *http.Response
 func (s *authHTTPSuite) setupOtherModel(c *gc.C) *state.State {
 	modelState := s.Factory.MakeModel(c, nil)
 	s.AddCleanup(func(*gc.C) { modelState.Close() })
+	model, err := modelState.Model()
+	c.Assert(err, jc.ErrorIsNil)
 	user := s.Factory.MakeUser(c, nil)
-	_, err := modelState.AddModelUser(modelState.ModelUUID(),
+	_, err = model.AddUser(
 		state.UserAccessSpec{
 			User:      user.UserTag(),
 			CreatedBy: s.userTag,

--- a/apiserver/charms_test.go
+++ b/apiserver/charms_test.go
@@ -416,7 +416,7 @@ func (s *charmsSuite) TestNonLocalCharmUploadWithRevisionOverride(c *gc.C) {
 
 func (s *charmsSuite) TestMigrateCharm(c *gc.C) {
 	controllerTag := names.NewControllerTag(s.ControllerConfig.ControllerUUID())
-	_, err := s.State.SetUserAccess(s.userTag, controllerTag, permission.SuperuserAccess)
+	_, err := s.Model.SetUserAccess(s.userTag, controllerTag, permission.SuperuserAccess)
 	c.Assert(err, jc.ErrorIsNil)
 
 	newSt := s.Factory.MakeModel(c, nil)
@@ -444,7 +444,7 @@ func (s *charmsSuite) TestMigrateCharm(c *gc.C) {
 
 func (s *charmsSuite) TestMigrateCharmNotMigrating(c *gc.C) {
 	controllerTag := names.NewControllerTag(s.ControllerConfig.ControllerUUID())
-	_, err := s.State.SetUserAccess(s.userTag, controllerTag, permission.SuperuserAccess)
+	_, err := s.Model.SetUserAccess(s.userTag, controllerTag, permission.SuperuserAccess)
 	c.Assert(err, jc.ErrorIsNil)
 
 	migratedModel := s.Factory.MakeModel(c, nil)

--- a/apiserver/charms_test.go
+++ b/apiserver/charms_test.go
@@ -416,7 +416,7 @@ func (s *charmsSuite) TestNonLocalCharmUploadWithRevisionOverride(c *gc.C) {
 
 func (s *charmsSuite) TestMigrateCharm(c *gc.C) {
 	controllerTag := names.NewControllerTag(s.ControllerConfig.ControllerUUID())
-	_, err := s.Model.SetUserAccess(s.userTag, controllerTag, permission.SuperuserAccess)
+	_, err := s.State.SetUserAccess(s.userTag, controllerTag, permission.SuperuserAccess)
 	c.Assert(err, jc.ErrorIsNil)
 
 	newSt := s.Factory.MakeModel(c, nil)
@@ -444,7 +444,7 @@ func (s *charmsSuite) TestMigrateCharm(c *gc.C) {
 
 func (s *charmsSuite) TestMigrateCharmNotMigrating(c *gc.C) {
 	controllerTag := names.NewControllerTag(s.ControllerConfig.ControllerUUID())
-	_, err := s.Model.SetUserAccess(s.userTag, controllerTag, permission.SuperuserAccess)
+	_, err := s.State.SetUserAccess(s.userTag, controllerTag, permission.SuperuserAccess)
 	c.Assert(err, jc.ErrorIsNil)
 
 	migratedModel := s.Factory.MakeModel(c, nil)

--- a/apiserver/common/crossmodel/state.go
+++ b/apiserver/common/crossmodel/state.go
@@ -39,7 +39,12 @@ func GetStatePool(pool *state.StatePool) StatePool {
 
 // GetBackend wraps a State to provide a Backend interface implementation.
 func GetBackend(st *state.State) stateShim {
-	return stateShim{State: st}
+	model, err := st.Model()
+	if err != nil {
+		logger.Errorf("called GetBackend on a State with no Model.")
+		return stateShim{}
+	}
+	return stateShim{State: st, Model: model}
 }
 
 type stateShim struct {

--- a/apiserver/common/crossmodel/state.go
+++ b/apiserver/common/crossmodel/state.go
@@ -26,7 +26,11 @@ func (p *statePoolShim) Get(modelUUID string) (Backend, func(), error) {
 	closer := func() {
 		releaser()
 	}
-	return stateShim{st}, closer, err
+	model, err := st.Model()
+	if err != nil {
+		return stateShim{}, closer, err
+	}
+	return stateShim{st, model}, closer, err
 }
 
 func GetStatePool(pool *state.StatePool) StatePool {
@@ -40,6 +44,7 @@ func GetBackend(st *state.State) stateShim {
 
 type stateShim struct {
 	*state.State
+	*state.Model
 }
 
 func (st stateShim) KeyRelation(key string) (Relation, error) {
@@ -48,6 +53,19 @@ func (st stateShim) KeyRelation(key string) (Relation, error) {
 		return nil, errors.Trace(err)
 	}
 	return relationShim{r, st.State}, nil
+}
+
+// ControllerTag returns the tag of the controller in which we are operating.
+// This is a temporary transitional step. Eventually code using
+// crossmodel.Backend will only need to be passed a state.Model.
+func (st stateShim) ControllerTag() names.ControllerTag {
+	return st.Model.ControllerTag()
+}
+
+// ControllerTag returns the tag of the controller in which we are operating.
+// This is a temporary transitional step.
+func (st stateShim) ModelTag() names.ModelTag {
+	return st.Model.ModelTag()
 }
 
 type applicationShim struct {

--- a/apiserver/common/modelmanagerinterface.go
+++ b/apiserver/common/modelmanagerinterface.go
@@ -46,7 +46,6 @@ type ModelManagerBackend interface {
 	Unit(name string) (*state.Unit, error)
 	ModelTag() names.ModelTag
 	ModelConfig() (*config.Config, error)
-	AddModelUser(string, state.UserAccessSpec) (permission.UserAccess, error)
 	AddControllerUser(state.UserAccessSpec) (permission.UserAccess, error)
 	RemoveUserAccess(names.UserTag, names.Tag) error
 	UserAccess(names.UserTag, names.Tag) (permission.UserAccess, error)
@@ -61,7 +60,6 @@ type ModelManagerBackend interface {
 	SetUserAccess(subject names.UserTag, target names.Tag, access permission.Access) (permission.UserAccess, error)
 	SetModelMeterStatus(string, string) error
 	ReloadSpaces(environ environs.Environ) error
-	LastModelConnection(user names.UserTag) (time.Time, error)
 	LatestMigration() (state.ModelMigration, error)
 	DumpAll() (map[string]interface{}, error)
 	Close() error
@@ -95,6 +93,8 @@ type Model interface {
 	Name() string
 	UUID() string
 	ControllerUUID() string
+	LastModelConnection(user names.UserTag) (time.Time, error)
+	AddUser(state.UserAccessSpec) (permission.UserAccess, error)
 }
 
 var _ ModelManagerBackend = (*modelManagerStateShim)(nil)

--- a/apiserver/facades/client/client/backend.go
+++ b/apiserver/facades/client/client/backend.go
@@ -26,7 +26,6 @@ type Backend interface {
 	AddControllerUser(state.UserAccessSpec) (permission.UserAccess, error)
 	AddMachineInsideMachine(state.MachineTemplate, string, instance.ContainerType) (*state.Machine, error)
 	AddMachineInsideNewMachine(template, parentTemplate state.MachineTemplate, containerType instance.ContainerType) (*state.Machine, error)
-	AddModelUser(string, state.UserAccessSpec) (permission.UserAccess, error)
 	AddOneMachine(state.MachineTemplate) (*state.Machine, error)
 	AddRelation(...state.Endpoint) (*state.Relation, error)
 	AllApplications() ([]*state.Application, error)
@@ -68,6 +67,11 @@ type Backend interface {
 	Watch(params state.WatchParams) *state.Multiwatcher
 }
 
+// Model contains the state.Model methods used in this package.
+type Model interface {
+	AddUser(state.UserAccessSpec) (permission.UserAccess, error)
+}
+
 // Pool contains the StatePool functionality used in this package.
 type Pool interface {
 	GetModel(string) (*state.Model, func(), error)
@@ -104,6 +108,10 @@ func (s *stateShim) Unit(name string) (Unit, error) {
 		return nil, err
 	}
 	return u, nil
+}
+
+func (s *stateShim) Watch(params state.WatchParams) *state.Multiwatcher {
+	return s.State.Watch(params)
 }
 
 func (s *stateShim) AllApplicationOffers() ([]*crossmodel.ApplicationOffer, error) {

--- a/apiserver/facades/client/client/client.go
+++ b/apiserver/facades/client/client/client.go
@@ -529,7 +529,11 @@ func (c *Client) ModelInfo() (params.ModelInfo, error) {
 }
 
 func modelInfo(st *state.State, user permission.UserAccess) (params.ModelUserInfo, error) {
-	return common.ModelUserInfo(user, st)
+	model, err := st.Model()
+	if err != nil {
+		return params.ModelUserInfo{}, errors.Trace(err)
+	}
+	return common.ModelUserInfo(user, model)
 }
 
 // ModelUserInfo returns information on all users in the model.

--- a/apiserver/facades/client/client/client_test.go
+++ b/apiserver/facades/client/client/client_test.go
@@ -180,7 +180,12 @@ func (s *serverSuite) TestModelUsersInfo(c *gc.C) {
 }
 
 func lastConnPointer(c *gc.C, modelUser permission.UserAccess, st *state.State) *time.Time {
-	lastConn, err := st.LastModelConnection(modelUser.UserTag)
+	model, err := st.Model()
+	if err != nil {
+		c.Fatal(err)
+	}
+
+	lastConn, err := model.LastModelConnection(modelUser.UserTag)
 	if err != nil {
 		if state.IsNeverConnectedError(err) {
 			return nil

--- a/apiserver/facades/client/controller/controller.go
+++ b/apiserver/facades/client/controller/controller.go
@@ -130,7 +130,7 @@ func (s *ControllerAPIv3) AllModels() (params.UserModelList, error) {
 			},
 		}
 
-		lastConn, err := st.LastModelConnection(s.apiUser)
+		lastConn, err := model.LastModelConnection(s.apiUser)
 		if err != nil {
 			if !state.IsNeverConnectedError(err) {
 				return result, errors.Trace(err)

--- a/apiserver/facades/client/controller/controller_test.go
+++ b/apiserver/facades/client/controller/controller_test.go
@@ -108,7 +108,10 @@ func (s *controllerSuite) TestAllModels(c *gc.C) {
 	st := s.Factory.MakeModel(c, &factory.ModelParams{
 		Name: "user", Owner: remoteUserTag})
 	defer st.Close()
-	st.AddModelUser(st.ModelUUID(),
+	model, err := st.Model()
+	c.Assert(err, jc.ErrorIsNil)
+
+	model.AddUser(
 		state.UserAccessSpec{
 			User:        admin.UserTag(),
 			CreatedBy:   remoteUserTag,

--- a/apiserver/facades/client/modelmanager/modelinfo_test.go
+++ b/apiserver/facades/client/modelmanager/modelinfo_test.go
@@ -210,10 +210,6 @@ func (s *modelInfoSuite) TestModelInfo(c *gc.C) {
 		{"ModelUUID", nil},
 		{"GetBackend", []interface{}{s.st.model.cfg.UUID()}},
 		{"Model", nil},
-		{"LastModelConnection", []interface{}{names.NewUserTag("admin")}},
-		{"LastModelConnection", []interface{}{names.NewLocalUserTag("bob")}},
-		{"LastModelConnection", []interface{}{names.NewLocalUserTag("charlotte")}},
-		{"LastModelConnection", []interface{}{names.NewLocalUserTag("mary")}},
 		{"AllMachines", nil},
 		{"LatestMigration", nil},
 	})
@@ -237,6 +233,10 @@ func (s *modelInfoSuite) TestModelInfo(c *gc.C) {
 		{"ModelTag", nil},
 		{"ModelTag", nil},
 		{"ModelTag", nil},
+		{"LastModelConnection", []interface{}{names.NewUserTag("admin")}},
+		{"LastModelConnection", []interface{}{names.NewLocalUserTag("bob")}},
+		{"LastModelConnection", []interface{}{names.NewLocalUserTag("charlotte")}},
+		{"LastModelConnection", []interface{}{names.NewLocalUserTag("mary")}},
 	})
 }
 

--- a/apiserver/facades/client/modelmanager/modelinfo_test.go
+++ b/apiserver/facades/client/modelmanager/modelinfo_test.go
@@ -723,7 +723,6 @@ func (st *mockState) AddControllerUser(spec state.UserAccessSpec) (permission.Us
 	return permission.UserAccess{}, st.NextErr()
 }
 
-
 func (st *mockState) UserAccess(tag names.UserTag, target names.Tag) (permission.UserAccess, error) {
 	st.MethodCall(st, "ModelUser", tag, target)
 	for _, user := range st.users {
@@ -1009,6 +1008,7 @@ func (m *mockModel) LastModelConnection(user names.UserTag) (time.Time, error) {
 	m.MethodCall(m, "LastModelConnection", user)
 	return time.Time{}, m.NextErr()
 }
+
 type mockModelUser struct {
 	gitjujutesting.Stub
 	userName       string

--- a/apiserver/facades/client/modelmanager/modelinfo_test.go
+++ b/apiserver/facades/client/modelmanager/modelinfo_test.go
@@ -718,20 +718,11 @@ func (st *mockState) Close() error {
 	return st.NextErr()
 }
 
-func (st *mockState) AddModelUser(modelUUID string, spec state.UserAccessSpec) (permission.UserAccess, error) {
-	st.MethodCall(st, "AddModelUser", modelUUID, spec)
-	return permission.UserAccess{}, st.NextErr()
-}
-
 func (st *mockState) AddControllerUser(spec state.UserAccessSpec) (permission.UserAccess, error) {
 	st.MethodCall(st, "AddControllerUser", spec)
 	return permission.UserAccess{}, st.NextErr()
 }
 
-func (st *mockState) RemoveModelUser(tag names.UserTag) error {
-	st.MethodCall(st, "RemoveModelUser", tag)
-	return st.NextErr()
-}
 
 func (st *mockState) UserAccess(tag names.UserTag, target names.Tag) (permission.UserAccess, error) {
 	st.MethodCall(st, "ModelUser", tag, target)
@@ -746,11 +737,6 @@ func (st *mockState) UserAccess(tag names.UserTag, target names.Tag) (permission
 		return user, nil
 	}
 	return permission.UserAccess{}, st.NextErr()
-}
-
-func (st *mockState) LastModelConnection(user names.UserTag) (time.Time, error) {
-	st.MethodCall(st, "LastModelConnection", user)
-	return time.Time{}, st.NextErr()
 }
 
 func (st *mockState) RemoveUserAccess(subject names.UserTag, target names.Tag) error {
@@ -1015,6 +1001,14 @@ func (m *mockModel) MigrationMode() state.MigrationMode {
 	return m.migrationStatus
 }
 
+func (m *mockModel) AddUser(spec state.UserAccessSpec) (permission.UserAccess, error) {
+	m.MethodCall(m, "AddUser", spec)
+	return permission.UserAccess{}, m.NextErr()
+}
+func (m *mockModel) LastModelConnection(user names.UserTag) (time.Time, error) {
+	m.MethodCall(m, "LastModelConnection", user)
+	return time.Time{}, m.NextErr()
+}
 type mockModelUser struct {
 	gitjujutesting.Stub
 	userName       string

--- a/apiserver/facades/client/modelmanager/modelmanager_test.go
+++ b/apiserver/facades/client/modelmanager/modelmanager_test.go
@@ -205,13 +205,20 @@ func (s *modelManagerSuite) TestCreateModelArgs(c *gc.C) {
 		"ReloadSpaces",
 		"GetBackend",
 		"Model",
-		"LastModelConnection",
-		"LastModelConnection",
-		"LastModelConnection",
 		"AllMachines",
 		"LatestMigration",
 		"Close",
 	)
+
+	// Check that Model.LastModelConnection is called three times
+	// without making the test depend on other calls to Model
+	n := 0
+	for _, call := range s.st.model.Calls() {
+		if call.FuncName == "LastModelConnection" {
+			n = n + 1
+		}
+	}
+	c.Assert(n, gc.Equals, 3)
 
 	// We cannot predict the UUID, because it's generated,
 	// so we just extract it and ensure that it's not the
@@ -1187,7 +1194,7 @@ func (s *modelManagerStateSuite) TestGrantOnlyGreaterAccess(c *gc.C) {
 func (s *modelManagerStateSuite) assertNewUser(c *gc.C, modelUser permission.UserAccess, userTag, creatorTag names.UserTag) {
 	c.Assert(modelUser.UserTag, gc.Equals, userTag)
 	c.Assert(modelUser.CreatedBy, gc.Equals, creatorTag)
-	_, err := s.State.LastModelConnection(modelUser.UserTag)
+	_, err := s.Model.LastModelConnection(modelUser.UserTag)
 	c.Assert(err, jc.Satisfies, state.IsNeverConnectedError)
 }
 

--- a/apiserver/introspection_test.go
+++ b/apiserver/introspection_test.go
@@ -37,9 +37,10 @@ func (s *introspectionSuite) url(c *gc.C) string {
 
 func (s *introspectionSuite) TestAccess(c *gc.C) {
 	s.testAccess(c, "user-admin", "dummy-secret")
+	model, err := s.BackingState.Model()
+	c.Assert(err, jc.ErrorIsNil)
 
-	_, err := s.BackingState.AddModelUser(
-		s.BackingState.ModelTag().Id(),
+	_, err = model.AddUser(
 		state.UserAccessSpec{
 			User:      names.NewUserTag("bob"),
 			CreatedBy: names.NewUserTag("admin"),

--- a/featuretests/api_model_test.go
+++ b/featuretests/api_model_test.go
@@ -51,7 +51,7 @@ func (s *apiEnvironmentSuite) TestGrantModel(c *gc.C) {
 	modelUser, err := s.State.UserAccess(user, model.ModelTag())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(modelUser.UserName, gc.Equals, user.Id())
-	lastConn, err := s.State.LastModelConnection(modelUser.UserTag)
+	lastConn, err := s.Model.LastModelConnection(modelUser.UserTag)
 	c.Assert(err, jc.Satisfies, state.IsNeverConnectedError)
 	c.Assert(lastConn.IsZero(), jc.IsTrue)
 }
@@ -91,18 +91,18 @@ func (s *apiEnvironmentSuite) TestEnvironmentUserInfo(c *gc.C) {
 			UserName:       owner.UserName,
 			DisplayName:    owner.DisplayName,
 			Access:         "admin",
-			LastConnection: lastConnPointer(c, s.State, owner),
+			LastConnection: lastConnPointer(c, mod, owner),
 		}, {
 			UserName:       "bobjohns@ubuntuone",
 			DisplayName:    "Bob Johns",
 			Access:         "admin",
-			LastConnection: lastConnPointer(c, s.State, modelUser),
+			LastConnection: lastConnPointer(c, mod, modelUser),
 		},
 	})
 }
 
-func lastConnPointer(c *gc.C, st *state.State, modelUser permission.UserAccess) *time.Time {
-	lastConn, err := st.LastModelConnection(modelUser.UserTag)
+func lastConnPointer(c *gc.C, mod *state.Model, modelUser permission.UserAccess) *time.Time {
+	lastConn, err := mod.LastModelConnection(modelUser.UserTag)
 	if err != nil {
 		if state.IsNeverConnectedError(err) {
 			return nil

--- a/featuretests/cmd_juju_model_test.go
+++ b/featuretests/cmd_juju_model_test.go
@@ -56,7 +56,7 @@ func (s *cmdModelSuite) TestGrantModelCmdStack(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(modelUser.UserName, gc.Equals, user.Id())
 	c.Assert(modelUser.CreatedBy.Id(), gc.Equals, s.AdminUserTag(c).Id())
-	lastConn, err := s.State.LastModelConnection(modelUser.UserTag)
+	lastConn, err := s.Model.LastModelConnection(modelUser.UserTag)
 	c.Assert(err, jc.Satisfies, state.IsNeverConnectedError)
 	c.Assert(lastConn.IsZero(), jc.IsTrue)
 }

--- a/juju/testing/conn.go
+++ b/juju/testing/conn.go
@@ -94,6 +94,7 @@ type JujuConnSuite struct {
 	ControllerConfig   controller.Config
 	State              *state.State
 	StatePool          *state.StatePool
+	Model              *state.Model
 	IAASModel          *state.IAASModel
 	Environ            environs.Environ
 	APIState           api.Connection
@@ -400,6 +401,9 @@ func (s *JujuConnSuite) setUpConn(c *gc.C) {
 
 	s.StatePool = state.NewStatePool(s.State)
 	s.AddCleanup(func(*gc.C) { s.StatePool.Close() })
+
+	s.Model, err = s.State.Model()
+	c.Assert(err, jc.ErrorIsNil)
 
 	s.IAASModel, err = s.State.IAASModel()
 	c.Assert(err, jc.ErrorIsNil)

--- a/state/export_test.go
+++ b/state/export_test.go
@@ -484,7 +484,12 @@ func MakeActionIdConverter(st *State) func(string) (string, error) {
 }
 
 func UpdateModelUserLastConnection(st *State, e permission.UserAccess, when time.Time) error {
-	return st.updateLastModelConnection(e.UserTag, when)
+	model, err := st.Model()
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	return model.updateLastModelConnection(e.UserTag, when)
 }
 
 func RemoveEndpointBindingsForService(c *gc.C, app *Application) {

--- a/state/migration_export_test.go
+++ b/state/migration_export_test.go
@@ -207,7 +207,7 @@ func (s *MigrationExportSuite) TestModelUsers(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	bobTag := names.NewUserTag("bob@external")
-	bob, err := s.State.AddModelUser(s.State.ModelUUID(), state.UserAccessSpec{
+	bob, err := s.Model.AddUser(state.UserAccessSpec{
 		User:      bobTag,
 		CreatedBy: s.Owner,
 		Access:    permission.ReadAccess,

--- a/state/migration_import.go
+++ b/state/migration_import.go
@@ -341,7 +341,7 @@ func (i *importer) modelUsers() error {
 		if lastConnection.IsZero() {
 			continue
 		}
-		err := i.st.updateLastModelConnection(user.Name(), lastConnection)
+		err := i.dbModel.updateLastModelConnection(user.Name(), lastConnection)
 		if err != nil {
 			return errors.Trace(err)
 		}

--- a/state/migration_import_test.go
+++ b/state/migration_import_test.go
@@ -185,7 +185,7 @@ func (s *MigrationImportSuite) newModelUser(c *gc.C, name string, readOnly bool,
 	if readOnly {
 		access = permission.ReadAccess
 	}
-	user, err := s.State.AddModelUser(s.State.ModelUUID(), state.UserAccessSpec{
+	user, err := s.Model.AddUser(state.UserAccessSpec{
 		User:      names.NewUserTag(name),
 		CreatedBy: s.Owner,
 		Access:    access,
@@ -205,14 +205,14 @@ func (s *MigrationImportSuite) AssertUserEqual(c *gc.C, newUser, oldUser permiss
 	c.Assert(newUser.DateCreated, gc.Equals, oldUser.DateCreated)
 	c.Assert(newUser.Access, gc.Equals, newUser.Access)
 
-	connTime, err := s.State.LastModelConnection(oldUser.UserTag)
+	connTime, err := s.Model.LastModelConnection(oldUser.UserTag)
 	if state.IsNeverConnectedError(err) {
-		_, err := s.State.LastModelConnection(newUser.UserTag)
+		_, err := s.Model.LastModelConnection(newUser.UserTag)
 		// The new user should also return an error for last connection.
 		c.Assert(err, jc.Satisfies, state.IsNeverConnectedError)
 	} else {
 		c.Assert(err, jc.ErrorIsNil)
-		newTime, err := s.State.LastModelConnection(newUser.UserTag)
+		newTime, err := s.Model.LastModelConnection(newUser.UserTag)
 		c.Assert(err, jc.ErrorIsNil)
 		c.Assert(newTime, gc.Equals, connTime)
 	}

--- a/state/modeluser_test.go
+++ b/state/modeluser_test.go
@@ -33,8 +33,7 @@ func (s *ModelUserSuite) TestAddModelUser(c *gc.C) {
 			NoModelUser: true,
 		})
 	createdBy := s.Factory.MakeUser(c, &factory.UserParams{Name: "createdby"})
-	modelUser, err := s.State.AddModelUser(
-		s.State.ModelUUID(),
+	modelUser, err := s.Model.AddUser(
 		state.UserAccessSpec{
 			User:      user.UserTag(),
 			CreatedBy: createdBy.UserTag(),
@@ -49,7 +48,7 @@ func (s *ModelUserSuite) TestAddModelUser(c *gc.C) {
 	c.Assert(modelUser.Access, gc.Equals, permission.WriteAccess)
 	c.Assert(modelUser.CreatedBy.Id(), gc.Equals, "createdby")
 	c.Assert(modelUser.DateCreated.Equal(now) || modelUser.DateCreated.After(now), jc.IsTrue)
-	when, err := s.State.LastModelConnection(modelUser.UserTag)
+	when, err := s.Model.LastModelConnection(modelUser.UserTag)
 	c.Assert(err, jc.Satisfies, state.IsNeverConnectedError)
 	c.Assert(when.IsZero(), jc.IsTrue)
 
@@ -62,7 +61,7 @@ func (s *ModelUserSuite) TestAddModelUser(c *gc.C) {
 	c.Assert(modelUser.Access, gc.Equals, permission.WriteAccess)
 	c.Assert(modelUser.CreatedBy.Id(), gc.Equals, "createdby")
 	c.Assert(modelUser.DateCreated.Equal(now) || modelUser.DateCreated.After(now), jc.IsTrue)
-	when, err = s.State.LastModelConnection(modelUser.UserTag)
+	when, err = s.Model.LastModelConnection(modelUser.UserTag)
 	c.Assert(err, jc.Satisfies, state.IsNeverConnectedError)
 	c.Assert(when.IsZero(), jc.IsTrue)
 }
@@ -74,8 +73,7 @@ func (s *ModelUserSuite) TestAddReadOnlyModelUser(c *gc.C) {
 			NoModelUser: true,
 		})
 	createdBy := s.Factory.MakeUser(c, &factory.UserParams{Name: "createdby"})
-	modelUser, err := s.State.AddModelUser(
-		s.State.ModelUUID(),
+	modelUser, err := s.Model.AddUser(
 		state.UserAccessSpec{
 			User:      user.UserTag(),
 			CreatedBy: createdBy.UserTag(),
@@ -101,8 +99,7 @@ func (s *ModelUserSuite) TestAddReadWriteModelUser(c *gc.C) {
 			NoModelUser: true,
 		})
 	createdBy := s.Factory.MakeUser(c, &factory.UserParams{Name: "createdby"})
-	modelUser, err := s.State.AddModelUser(
-		s.State.ModelUUID(),
+	modelUser, err := s.Model.AddUser(
 		state.UserAccessSpec{
 			User:      user.UserTag(),
 			CreatedBy: createdBy.UserTag(),
@@ -128,8 +125,7 @@ func (s *ModelUserSuite) TestAddAdminModelUser(c *gc.C) {
 			NoModelUser: true,
 		})
 	createdBy := s.Factory.MakeUser(c, &factory.UserParams{Name: "createdby"})
-	modelUser, err := s.State.AddModelUser(
-		s.State.ModelUUID(),
+	modelUser, err := s.Model.AddUser(
 		state.UserAccessSpec{
 			User:      user.UserTag(),
 			CreatedBy: createdBy.UserTag(),
@@ -155,8 +151,7 @@ func (s *ModelUserSuite) TestDefaultAccessModelUser(c *gc.C) {
 			NoModelUser: true,
 		})
 	createdBy := s.Factory.MakeUser(c, &factory.UserParams{Name: "createdby"})
-	modelUser, err := s.State.AddModelUser(
-		s.State.ModelUUID(),
+	modelUser, err := s.Model.AddUser(
 		state.UserAccessSpec{
 			User:      user.UserTag(),
 			CreatedBy: createdBy.UserTag(),
@@ -173,8 +168,7 @@ func (s *ModelUserSuite) TestSetAccessModelUser(c *gc.C) {
 			NoModelUser: true,
 		})
 	createdBy := s.Factory.MakeUser(c, &factory.UserParams{Name: "createdby"})
-	modelUser, err := s.State.AddModelUser(
-		s.State.ModelUUID(),
+	modelUser, err := s.Model.AddUser(
 		state.UserAccessSpec{
 			User:      user.UserTag(),
 			CreatedBy: createdBy.UserTag(),
@@ -193,8 +187,7 @@ func (s *ModelUserSuite) TestCaseUserNameVsId(c *gc.C) {
 	model, err := s.State.Model()
 	c.Assert(err, jc.ErrorIsNil)
 
-	user, err := s.State.AddModelUser(
-		s.State.ModelUUID(),
+	user, err := s.Model.AddUser(
 		state.UserAccessSpec{
 			User:      names.NewUserTag("Bob@RandomProvider"),
 			CreatedBy: model.Owner(),
@@ -210,8 +203,7 @@ func (s *ModelUserSuite) TestCaseSensitiveModelUserErrors(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	s.Factory.MakeModelUser(c, &factory.ModelUserParams{User: "Bob@ubuntuone"})
 
-	_, err = s.State.AddModelUser(
-		s.State.ModelUUID(),
+	_, err = s.Model.AddUser(
 		state.UserAccessSpec{
 			User:      names.NewUserTag("boB@ubuntuone"),
 			CreatedBy: model.Owner(),
@@ -262,8 +254,7 @@ func (s *ModelUserSuite) TestAddModelDisplayName(c *gc.C) {
 
 func (s *ModelUserSuite) TestAddModelNoUserFails(c *gc.C) {
 	createdBy := s.Factory.MakeUser(c, &factory.UserParams{Name: "createdby"})
-	_, err := s.State.AddModelUser(
-		s.State.ModelUUID(),
+	_, err := s.Model.AddUser(
 		state.UserAccessSpec{
 			User:      names.NewLocalUserTag("validusername"),
 			CreatedBy: createdBy.UserTag(),
@@ -274,8 +265,7 @@ func (s *ModelUserSuite) TestAddModelNoUserFails(c *gc.C) {
 
 func (s *ModelUserSuite) TestAddModelNoCreatedByUserFails(c *gc.C) {
 	user := s.Factory.MakeUser(c, &factory.UserParams{Name: "validusername"})
-	_, err := s.State.AddModelUser(
-		s.State.ModelUUID(),
+	_, err := s.Model.AddUser(
 		state.UserAccessSpec{
 			User:      user.UserTag(),
 			CreatedBy: names.NewLocalUserTag("createdby"),
@@ -308,9 +298,9 @@ func (s *ModelUserSuite) TestUpdateLastConnection(c *gc.C) {
 	user := s.Factory.MakeUser(c, &factory.UserParams{Name: "validusername", Creator: createdBy.Tag()})
 	modelUser, err := s.State.UserAccess(user.UserTag(), s.State.ModelTag())
 	c.Assert(err, jc.ErrorIsNil)
-	err = s.State.UpdateLastModelConnection(user.UserTag())
+	err = s.Model.UpdateLastModelConnection(user.UserTag())
 	c.Assert(err, jc.ErrorIsNil)
-	when, err := s.State.LastModelConnection(modelUser.UserTag)
+	when, err := s.Model.LastModelConnection(modelUser.UserTag)
 	c.Assert(err, jc.ErrorIsNil)
 	// It is possible that the update is done over a second boundary, so we need
 	// to check for after now as well as equal.
@@ -329,8 +319,9 @@ func (s *ModelUserSuite) TestUpdateLastConnectionTwoModelUsers(c *gc.C) {
 	// Create a second model and add the same user to this.
 	st2 := s.Factory.MakeModel(c, nil)
 	defer st2.Close()
-	modelUser2, err := st2.AddModelUser(
-		st2.ModelUUID(),
+	model2, err := st2.Model()
+	c.Assert(err, jc.ErrorIsNil)
+	modelUser2, err := model2.AddUser(
 		state.UserAccessSpec{
 			User:      user.UserTag(),
 			CreatedBy: createdBy.UserTag(),
@@ -342,21 +333,21 @@ func (s *ModelUserSuite) TestUpdateLastConnectionTwoModelUsers(c *gc.C) {
 	// separate last connections.
 
 	// Connect modelUser and get last connection.
-	err = s.State.UpdateLastModelConnection(user.UserTag())
+	err = s.Model.UpdateLastModelConnection(user.UserTag())
 	c.Assert(err, jc.ErrorIsNil)
-	when, err := s.State.LastModelConnection(modelUser.UserTag)
+	when, err := s.Model.LastModelConnection(modelUser.UserTag)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(when.After(now) || when.Equal(now), jc.IsTrue)
 
 	// Try to get last connection for modelUser2. As they have never connected,
 	// we expect to get an error.
-	_, err = st2.LastModelConnection(modelUser2.UserTag)
+	_, err = model2.LastModelConnection(modelUser2.UserTag)
 	c.Assert(err, gc.ErrorMatches, `never connected: "validusername"`)
 
 	// Connect modelUser2 and get last connection.
-	err = s.State.UpdateLastModelConnection(modelUser2.UserTag)
+	err = s.Model.UpdateLastModelConnection(modelUser2.UserTag)
 	c.Assert(err, jc.ErrorIsNil)
-	when, err = s.State.LastModelConnection(modelUser2.UserTag)
+	when, err = s.Model.LastModelConnection(modelUser2.UserTag)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(when.After(now) || when.Equal(now), jc.IsTrue)
 }
@@ -386,7 +377,7 @@ func (s *ModelUserSuite) TestModelUUIDsForUser(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	access, err := s.State.UserAccess(user.UserTag(), modelTag)
-	when, err := st.LastModelConnection(access.UserTag)
+	when, err := s.Model.LastModelConnection(access.UserTag)
 	c.Assert(err, jc.Satisfies, state.IsNeverConnectedError)
 	c.Assert(when.IsZero(), jc.IsTrue)
 	c.Assert(st.Close(), jc.ErrorIsNil)
@@ -509,8 +500,7 @@ func (s *ModelUserSuite) newModelWithUser(c *gc.C, user names.UserTag) *state.Mo
 	newEnv, err := st.Model()
 	c.Assert(err, jc.ErrorIsNil)
 
-	_, err = st.AddModelUser(
-		st.ModelUUID(),
+	_, err = newEnv.AddUser(
 		state.UserAccessSpec{
 			User: user, CreatedBy: newEnv.Owner(),
 			Access: permission.ReadAccess,

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -2594,8 +2594,7 @@ func (s *StateSuite) insertFakeModelDocs(c *gc.C, st *state.State) string {
 
 	// Add a model user whose permissions should get removed
 	// when the model is.
-	_, err = s.State.AddModelUser(
-		s.State.ModelUUID(),
+	_, err = s.Model.AddUser(
 		state.UserAccessSpec{
 			User:      names.NewUserTag("amelia@external"),
 			CreatedBy: s.Owner,

--- a/state/statemetrics/mock_test.go
+++ b/state/statemetrics/mock_test.go
@@ -72,7 +72,7 @@ type mockState struct {
 }
 
 func (m *mockState) AllModelUUIDs() ([]string, error) {
-	m.MethodCall(m, "AllModelsUUIDs")
+	m.MethodCall(m, "AllModelUUIDs")
 	if err := m.NextErr(); err != nil {
 		return nil, err
 	}

--- a/state/useraccess.go
+++ b/state/useraccess.go
@@ -39,16 +39,16 @@ type userAccessTarget struct {
 	globalKey string
 }
 
-// AddModelUser adds a new user for the model identified by modelUUID to the database.
-func (st *State) AddModelUser(modelUUID string, spec UserAccessSpec) (permission.UserAccess, error) {
+// AddUser adds a new user for the model to the database.
+func (m *Model) AddUser(spec UserAccessSpec) (permission.UserAccess, error) {
 	if err := permission.ValidateModelAccess(spec.Access); err != nil {
 		return permission.UserAccess{}, errors.Annotate(err, "adding model user")
 	}
 	target := userAccessTarget{
-		uuid:      modelUUID,
+		uuid:      m.UUID(),
 		globalKey: modelGlobalKey,
 	}
-	return st.addUserAccess(spec, target)
+	return m.st.addUserAccess(spec, target)
 }
 
 // AddControllerUser adds a new user for the curent controller to the database.

--- a/testing/factory/factory.go
+++ b/testing/factory/factory.go
@@ -192,7 +192,9 @@ func (factory *Factory) MakeUser(c *gc.C, params *UserParams) *state.User {
 		params.Name, params.DisplayName, params.Password, creatorUserTag.Name())
 	c.Assert(err, jc.ErrorIsNil)
 	if !params.NoModelUser {
-		_, err := factory.st.AddModelUser(factory.st.ModelUUID(), state.UserAccessSpec{
+		model, err := factory.st.Model()
+		c.Assert(err, jc.ErrorIsNil)
+		_, err = model.AddUser(state.UserAccessSpec{
 			User:        user.UserTag(),
 			CreatedBy:   names.NewUserTag(user.CreatedBy()),
 			DisplayName: params.DisplayName,
@@ -230,8 +232,11 @@ func (factory *Factory) MakeModelUser(c *gc.C, params *ModelUserParams) permissi
 		c.Assert(err, jc.ErrorIsNil)
 		params.CreatedBy = env.Owner()
 	}
+	model, err := factory.st.Model()
+	c.Assert(err, jc.ErrorIsNil)
+
 	createdByUserTag := params.CreatedBy.(names.UserTag)
-	modelUser, err := factory.st.AddModelUser(factory.st.ModelUUID(), state.UserAccessSpec{
+	modelUser, err := model.AddUser(state.UserAccessSpec{
 		User:        names.NewUserTag(params.User),
 		CreatedBy:   createdByUserTag,
 		DisplayName: params.DisplayName,


### PR DESCRIPTION
## Description of change

Part of refactoring to support a clearer separation of functionality between State, Model, IAASModel and CAASModel.

Moves model-specific user-related functionality from State to Model.

Renames State.AddModelUser(modeluuid, spec) to Model.AddUser(spec)


## QA steps

1. run unit test suite
2. bootstrap controller, add a user, show the user, grant them new privileges.

## Documentation changes

No user-visible changes.
