### PR TITLE
worker/diskmanager: ignore floppy disks

### DIFF
--- a/worker/diskmanager/lsblk_test.go
+++ b/worker/diskmanager/lsblk_test.go
@@ -44,6 +44,8 @@ KNAME="sda1" SIZE="254803968" LABEL="" UUID="7a62bd85-a350-4c09-8944-5b99bf2080c
 KNAME="sda2" SIZE="1024" LABEL="boot" UUID="" TYPE="disk"
 KNAME="sdb" SIZE="32017047552" LABEL="" UUID="" TYPE="disk"
 KNAME="sdb1" SIZE="32015122432" LABEL="media" UUID="2c1c701d-f2ce-43a4-b345-33e2e39f9503" FSTYPE="ext4" TYPE="disk"
+KNAME="fd0" SIZE="1024" TYPE="disk" MAJ:MIN="2:0"
+KNAME="fd1" SIZE="1024" TYPE="disk" MAJ:MIN="2:1"
 EOF`)
 
 	devices, err := diskmanager.ListBlockDevices()


### PR DESCRIPTION
## Description of change

The diskmanager worker should ignore floppy
disks when publishing block device info. Also
change the "could not check" message  to
DEBUG instead of INFO.                 

## QA steps

1. juju bootstrap azure
2. juju model-config -m controller logging-config="\<root\>=INFO"
3. juju debug-log -m controller
observe no log messages about fd0
previously there would be period messages saying that juju couldn't check if fd0 was in use, because there was no device corresponding to the file /dev/fd0

## Documentation changes

None.

## Bug reference

None.