### PR TITLE
provider/azure: fix volume detachment

### DIFF
--- a/provider/azure/storage.go
+++ b/provider/azure/storage.go
@@ -564,11 +564,7 @@ func (v *azureVolumeSource) detachVolume(
 			continue
 		}
 		dataDisks = append(dataDisks[:i], dataDisks[i+1:]...)
-		if len(dataDisks) == 0 {
-			vm.StorageProfile.DataDisks = nil
-		} else {
-			*vm.StorageProfile.DataDisks = dataDisks
-		}
+		vm.StorageProfile.DataDisks = &dataDisks
 		return true
 	}
 	return false


### PR DESCRIPTION
## Description of change

When detaching the final volume from an Azure
machine, we were setting the VM's data disks field
to nil, rather than a pointer to an empty slice.
This was apparently ignored by Azure, so the data
disk remained attached. Setting the field so it
is a pointer to an empty slice causes the field
to be marshalled, and Azure detaches the disk.

## QA steps

1. juju bootstrap azure
2. juju deploy cs:~axwalk/storagetest --storage fs=azure,10G
(wait)
3. juju detach-storage fs/0
(wait until "detached", then check in Azure portal that the disk is detached from the VM)
4. juju destroy-controller -y

## Documentation changes

None.

## Bug reference

None.