### PR TITLE
Apply test_on_controller method to add capability of run against existing controller.

### DIFF
--- a/acceptancetests/assess_lxd_space.py
+++ b/acceptancetests/assess_lxd_space.py
@@ -22,16 +22,17 @@
 """
 
 from __future__ import print_function
-
-import os
-import sys
+import argparse
 import json
 import logging
-import argparse
-
+import os
+import sys
 from jujucharm import local_charm_path
-from deploy_stack import BootstrapManager
 
+from deploy_stack import (
+    BootstrapManager,
+    test_on_controller,
+    )
 from utility import (
     JujuAssertionError,
     add_basic_testing_arguments,
@@ -156,9 +157,8 @@ def assert_app_status(client, charm_name, expected):
 
     if app_status != expected:
         raise JujuAssertionError(
-            'App status is incorrect. '\
-            'Found: {}\nExpected: {}\n.'.format(
-            app_status, expected))
+            'App status is incorrect. '
+            'Found: {}; Expected: {}'.format(app_status, expected))
     else:
         log.info('The current status of app {} is: {}; Expected: {}'.format(
         charm_name, app_status, expected))
@@ -199,8 +199,7 @@ def main(argv=None):
         # it's meaningless to run it on other substrates.
         log.error('Incorrect substrate, should be AWS.')
         sys.exit(1)
-    with bs_manager.booted_context(args.upload_tools):
-        assess_lxd_container_space(bs_manager.client)
+    test_on_controller(assess_lxd_container_space, args)
     return 0
 
 

--- a/acceptancetests/assess_persistent_storage.py
+++ b/acceptancetests/assess_persistent_storage.py
@@ -9,9 +9,11 @@ import logging
 import sys
 import time
 
-from deploy_stack import BootstrapManager
+from deploy_stack import (
+    BootstrapManager,
+    test_on_controller,
+    )
 from jujucharm import local_charm_path
-
 from utility import (
     until_timeout,
     JujuAssertionError,
@@ -415,8 +417,7 @@ def main(argv=None):
         # PR7635 is for persistent storage feature on lxd.
         log.error('Incorrect substrate, must be AWS.')
         sys.exit(1)
-    with bs_manager.booted_context(args.upload_tools):
-        assess_persistent_storage(bs_manager.client)
+    test_on_controller(assess_persistent_storage, args)
     return 0
 
 


### PR DESCRIPTION
## Description of change
As the featured introduced by PR https://github.com/juju/juju/pull/7684, update test scripts to take advantages of this new method.

assess_lxd_space.py and assess_persistent_storage.py are being used as examples to test it in current Jenkins CI environment.

The tests now have ability to:
a) run against an existing controller, and
b) run independently (freshly bootstrap a controller by the test script itself).

## QA steps
$ export ENV=parallel-aws
$ export JUJU_BIN=<path_to>/bin/juju

a) Run against an existing controller:
$ juju bootstrap aws test
$ cd <path_to>/juju/acceptancetests
$ ./assess_lxd_space.py $ENV $JUJU_BIN --existing "test"

b) Run independently:
$ cd <path_to>/juju/acceptancetests
$ ./assess_lxd_space.py $ENV $JUJU_BIN

This change has been locally tested.

## Documentation changes
N/A

## Bug reference
N/A