### PR TITLE
Use juju-mongodb and juju-apiserver for connections to respective services.

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -814,7 +814,7 @@ func (c *configInternal) APIInfo() (*api.Info, bool) {
 		// TODO(macgreagoir) IPv6. Ubuntu still always provides IPv4
 		// loopback, and when/if this changes localhost should resolve
 		// to IPv6 loopback in any case (lp:1644009). Review.
-		localAPIAddr := net.JoinHostPort("localhost", strconv.Itoa(port))
+		localAPIAddr := net.JoinHostPort("juju-apiserver", strconv.Itoa(port))
 		newAddrs := []string{localAPIAddr}
 		for _, addr := range addrs {
 			if addr != localAPIAddr {
@@ -842,7 +842,7 @@ func (c *configInternal) MongoInfo() (info *mongo.MongoInfo, ok bool) {
 	// TODO(macgreagoir) IPv6. Ubuntu still always provides IPv4 loopback,
 	// and when/if this changes localhost should resolve to IPv6 loopback
 	// in any case (lp:1644009). Review.
-	addr := net.JoinHostPort("localhost", strconv.Itoa(ssi.StatePort))
+	addr := net.JoinHostPort("juju-mongodb", strconv.Itoa(ssi.StatePort))
 	return &mongo.MongoInfo{
 		Info: mongo.Info{
 			Addrs:  []string{addr},

--- a/cloudconfig/instancecfg/instancecfg.go
+++ b/cloudconfig/instancecfg/instancecfg.go
@@ -452,7 +452,7 @@ func (cfg *InstanceConfig) stateHostAddrs() []string {
 	var hosts []string
 	if cfg.Bootstrap != nil {
 		hosts = append(hosts, net.JoinHostPort(
-			"localhost", strconv.Itoa(cfg.Bootstrap.StateServingInfo.StatePort)),
+			"juju-mongodb", strconv.Itoa(cfg.Bootstrap.StateServingInfo.StatePort)),
 		)
 	}
 	if cfg.Controller != nil {
@@ -465,7 +465,7 @@ func (cfg *InstanceConfig) APIHostAddrs() []string {
 	var hosts []string
 	if cfg.Bootstrap != nil {
 		hosts = append(hosts, net.JoinHostPort(
-			"localhost", strconv.Itoa(cfg.Bootstrap.StateServingInfo.APIPort)),
+			"juju-apiserver", strconv.Itoa(cfg.Bootstrap.StateServingInfo.APIPort)),
 		)
 	}
 	if cfg.APIInfo != nil {
@@ -477,7 +477,7 @@ func (cfg *InstanceConfig) APIHostAddrs() []string {
 func (cfg *InstanceConfig) APIHosts() []string {
 	var hosts []string
 	if cfg.Bootstrap != nil {
-		hosts = append(hosts, "localhost")
+		hosts = append(hosts, "juju-apiserver")
 	}
 	if cfg.APIInfo != nil {
 		for _, addr := range cfg.APIInfo.Addrs {

--- a/cmd/jujud/bootstrap.go
+++ b/cmd/jujud/bootstrap.go
@@ -17,6 +17,7 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/gnuflag"
 	"github.com/juju/loggo"
+	"github.com/juju/utils"
 	"github.com/juju/utils/arch"
 	"github.com/juju/utils/series"
 	"github.com/juju/utils/ssh"
@@ -234,6 +235,9 @@ func (c *BootstrapCommand) Run(_ *cmd.Context) error {
 		return err
 	}
 
+	// Extend hosts file with juju-mongodb and juju-apiserver names
+	utils.AddHostnames([]byte("juju-apiserver juju-mongodb"))
+
 	if err := c.startMongo(addrs, agentConfig); err != nil {
 		return errors.Annotate(err, "failed to start mongo")
 	}
@@ -345,7 +349,7 @@ func (c *BootstrapCommand) startMongo(addrs []network.Address, agentConfig agent
 	// and when/if this changes localhost should resolve to IPv6 loopback
 	// in any case (lp:1644009). Review.
 	dialInfo.Addrs = []string{
-		net.JoinHostPort("localhost", fmt.Sprint(servingInfo.StatePort)),
+		net.JoinHostPort("juju-mongodb", fmt.Sprint(servingInfo.StatePort)),
 	}
 
 	logger.Debugf("calling ensureMongoServer")

--- a/mongo/open.go
+++ b/mongo/open.go
@@ -153,7 +153,7 @@ func DialInfo(info Info, opts DialOpts) (*mgo.DialInfo, error) {
 			}()
 		}
 
-		addr := server.TCPAddr().String()
+		addr := server.String()
 		c, err := net.DialTimeout("tcp", addr, opts.Timeout)
 		if err != nil {
 			logger.Warningf("mongodb connection failed, will retry: %v", err)


### PR DESCRIPTION
This pull request depends on PR: https://github.com/juju/utils/pull/285

It starts using the right names instead of localhosts to connect to mongo and api server
in the core code, however, it requires some tool to append hostnames to /etc/hosts to
resolv connectivity during bootstrap, hence I added it in utils/network.go.

lp:1710886.

Signed-off-by: José Pekkarinen <jose.pekkarinen@canonical.com>

