### PR TITLE
Reset password, api version check.

### DIFF
--- a/cmd/juju/user/change_password.go
+++ b/cmd/juju/user/change_password.go
@@ -118,8 +118,8 @@ func (c *changePasswordCommand) Run(ctx *cmd.Context) error {
 			return errors.Trace(err)
 		}
 		c.api = api
+		defer c.api.Close()
 	}
-	defer c.api.Close()
 
 	if c.Reset {
 		if c.api.BestAPIVersion() < 2 {

--- a/cmd/juju/user/change_password.go
+++ b/cmd/juju/user/change_password.go
@@ -103,6 +103,7 @@ func (c *changePasswordCommand) Init(args []string) error {
 type ChangePasswordAPI interface {
 	SetPassword(username, password string) error
 	ResetPassword(username string) ([]byte, error)
+	BestAPIVersion() int
 	Close() error
 }
 
@@ -117,10 +118,13 @@ func (c *changePasswordCommand) Run(ctx *cmd.Context) error {
 			return errors.Trace(err)
 		}
 		c.api = api
-		defer c.api.Close()
 	}
+	defer c.api.Close()
 
 	if c.Reset {
+		if c.api.BestAPIVersion() < 2 {
+			return errors.NotSupportedf("on this juju controller, reset password")
+		}
 		return c.resetUserPassword(ctx)
 	}
 	return c.updateUserPassword(ctx)

--- a/cmd/juju/user/change_password_test.go
+++ b/cmd/juju/user/change_password_test.go
@@ -29,7 +29,7 @@ var _ = gc.Suite(&ChangePasswordCommandSuite{})
 
 func (s *ChangePasswordCommandSuite) SetUpTest(c *gc.C) {
 	s.BaseSuite.SetUpTest(c)
-	s.mockAPI = &mockChangePasswordAPI{}
+	s.mockAPI = &mockChangePasswordAPI{version: 2}
 	s.store = s.BaseSuite.store
 }
 
@@ -125,7 +125,11 @@ func (s *ChangePasswordCommandSuite) TestResetPassword(c *gc.C) {
 	s.mockAPI.key = []byte("no cats or dragons")
 	context, _, err := s.run(c, "--reset")
 	c.Assert(err, jc.ErrorIsNil)
-	s.mockAPI.CheckCall(c, 0, "ResetPassword", "current-user")
+	s.mockAPI.CheckCalls(c, []testing.StubCall{
+		{"BestAPIVersion", nil},
+		{"ResetPassword", []interface{}{"current-user"}},
+		{"Close", nil},
+	})
 	c.Assert(cmdtesting.Stdout(context), gc.Equals, "")
 	c.Assert(cmdtesting.Stderr(context), gc.Matches, `
 Your password has been reset.
@@ -138,7 +142,11 @@ func (s *ChangePasswordCommandSuite) TestResetPasswordFail(c *gc.C) {
 	s.mockAPI.SetErrors(errors.New("failed to do something"))
 	context, _, err := s.run(c, "--reset")
 	c.Assert(err, gc.ErrorMatches, "failed to do something")
-	s.mockAPI.CheckCall(c, 0, "ResetPassword", "current-user")
+	s.mockAPI.CheckCalls(c, []testing.StubCall{
+		{"BestAPIVersion", nil},
+		{"ResetPassword", []interface{}{"current-user"}},
+		{"Close", nil},
+	})
 	// TODO (anastasiamac 2017-08-17)
 	// should probably warn user that something did not go well enough
 	c.Assert(cmdtesting.Stdout(context), gc.Equals, "")
@@ -151,7 +159,11 @@ func (s *ChangePasswordCommandSuite) TestResetOthersPassword(c *gc.C) {
 	s.mockAPI.key = []byte("no cats or dragons")
 	context, _, err := s.run(c, "other", "--reset")
 	c.Assert(err, jc.ErrorIsNil)
-	s.mockAPI.CheckCall(c, 0, "ResetPassword", "other")
+	s.mockAPI.CheckCalls(c, []testing.StubCall{
+		{"BestAPIVersion", nil},
+		{"ResetPassword", []interface{}{"other"}},
+		{"Close", nil},
+	})
 	c.Assert(cmdtesting.Stdout(context), gc.Equals, "")
 	c.Assert(cmdtesting.Stderr(context), gc.Matches, `
 Password for "other" has been reset.
@@ -160,9 +172,22 @@ Ask the user to run:
 `[1:])
 }
 
+func (s *ChangePasswordCommandSuite) TestResetPasswordOldAPI(c *gc.C) {
+	s.mockAPI.version = 1
+	context, _, err := s.run(c, "--reset")
+	c.Assert(err, gc.ErrorMatches, "on this juju controller, reset password not supported")
+	s.mockAPI.CheckCalls(c, []testing.StubCall{
+		{"BestAPIVersion", nil},
+		{"Close", nil},
+	})
+	c.Assert(cmdtesting.Stdout(context), gc.Equals, "")
+	c.Assert(cmdtesting.Stderr(context), gc.Equals, "")
+}
+
 type mockChangePasswordAPI struct {
 	testing.Stub
-	key []byte
+	key     []byte
+	version int
 }
 
 func (m *mockChangePasswordAPI) SetPassword(username, password string) error {
@@ -175,8 +200,14 @@ func (m *mockChangePasswordAPI) ResetPassword(username string) ([]byte, error) {
 	return m.key, m.NextErr()
 }
 
-func (*mockChangePasswordAPI) Close() error {
+func (m *mockChangePasswordAPI) Close() error {
+	m.MethodCall(m, "Close")
 	return nil
+}
+
+func (m *mockChangePasswordAPI) BestAPIVersion() int {
+	m.MethodCall(m, "BestAPIVersion")
+	return m.version
 }
 
 type mockAPIConnection struct {

--- a/cmd/juju/user/change_password_test.go
+++ b/cmd/juju/user/change_password_test.go
@@ -128,7 +128,6 @@ func (s *ChangePasswordCommandSuite) TestResetPassword(c *gc.C) {
 	s.mockAPI.CheckCalls(c, []testing.StubCall{
 		{"BestAPIVersion", nil},
 		{"ResetPassword", []interface{}{"current-user"}},
-		{"Close", nil},
 	})
 	c.Assert(cmdtesting.Stdout(context), gc.Equals, "")
 	c.Assert(cmdtesting.Stderr(context), gc.Matches, `
@@ -145,7 +144,6 @@ func (s *ChangePasswordCommandSuite) TestResetPasswordFail(c *gc.C) {
 	s.mockAPI.CheckCalls(c, []testing.StubCall{
 		{"BestAPIVersion", nil},
 		{"ResetPassword", []interface{}{"current-user"}},
-		{"Close", nil},
 	})
 	// TODO (anastasiamac 2017-08-17)
 	// should probably warn user that something did not go well enough
@@ -162,7 +160,6 @@ func (s *ChangePasswordCommandSuite) TestResetOthersPassword(c *gc.C) {
 	s.mockAPI.CheckCalls(c, []testing.StubCall{
 		{"BestAPIVersion", nil},
 		{"ResetPassword", []interface{}{"other"}},
-		{"Close", nil},
 	})
 	c.Assert(cmdtesting.Stdout(context), gc.Equals, "")
 	c.Assert(cmdtesting.Stderr(context), gc.Matches, `
@@ -178,7 +175,6 @@ func (s *ChangePasswordCommandSuite) TestResetPasswordOldAPI(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, "on this juju controller, reset password not supported")
 	s.mockAPI.CheckCalls(c, []testing.StubCall{
 		{"BestAPIVersion", nil},
-		{"Close", nil},
 	})
 	c.Assert(cmdtesting.Stdout(context), gc.Equals, "")
 	c.Assert(cmdtesting.Stderr(context), gc.Equals, "")


### PR DESCRIPTION
## Description of change

Reset password functionality was only introduced on UserManager v2. This means that older juju controllers will not be able to provide this functionality when used with later clients.

This PR adds an API version check and ensures that api conection is closed after the command has run. Tests have been added and adjusted accordingly.

## QA steps

1. Bootstrap an older version of Juju
2. Using newer client (develop tip), try to call 'change-user-password' with --reset option.

## Documentation changes

n/a

## Bug reference

n/a
