### PR TITLE
storage: add "Provider.Releasable()" method

### DIFF
--- a/featuretests/storage_test.go
+++ b/featuretests/storage_test.go
@@ -248,6 +248,8 @@ modelscoped:
   provider: modelscoped
 modelscoped-block:
   provider: modelscoped-block
+modelscoped-unreleasable:
+  provider: modelscoped-unreleasable
 rootfs:
   provider: rootfs
 static:
@@ -262,15 +264,16 @@ func (s *cmdStorageSuite) TestListPoolsTabular(c *gc.C) {
 	stdout, _, err := runPoolList(c)
 	c.Assert(err, jc.ErrorIsNil)
 	expected := `
-Name               Provider           Attrs
-block              loop               it=works
-loop               loop               
-machinescoped      machinescoped      
-modelscoped        modelscoped        
-modelscoped-block  modelscoped-block  
-rootfs             rootfs             
-static             static             
-tmpfs              tmpfs              
+Name                      Provider                  Attrs
+block                     loop                      it=works
+loop                      loop                      
+machinescoped             machinescoped             
+modelscoped               modelscoped               
+modelscoped-block         modelscoped-block         
+modelscoped-unreleasable  modelscoped-unreleasable  
+rootfs                    rootfs                    
+static                    static                    
+tmpfs                     tmpfs                     
 
 `[1:]
 	c.Assert(stdout, gc.Equals, expected)

--- a/provider/azure/storage.go
+++ b/provider/azure/storage.go
@@ -101,6 +101,16 @@ func (e *azureStorageProvider) Dynamic() bool {
 	return true
 }
 
+// Releasable is part of the Provider interface.
+func (e *azureStorageProvider) Releasable() bool {
+	// NOTE(axw) Azure storage is currently tied to a model, and cannot
+	// be released or imported. To support releasing and importing, we'll
+	// need several things:
+	//  - for the provider to use managed disks
+	//  - for Azure to support moving managed disks between resource groups
+	return false
+}
+
 // DefaultPools is part of the Provider interface.
 func (e *azureStorageProvider) DefaultPools() []*storage.Config {
 	return nil

--- a/provider/ec2/ebs.go
+++ b/provider/ec2/ebs.go
@@ -219,6 +219,11 @@ func (e *ebsProvider) Dynamic() bool {
 	return true
 }
 
+// Releasable is defined on the Provider interface.
+func (*ebsProvider) Releasable() bool {
+	return true
+}
+
 // DefaultPools is defined on the Provider interface.
 func (e *ebsProvider) DefaultPools() []*storage.Config {
 	ssdPool, _ := storage.NewConfig("ebs-ssd", EBS_ProviderType, map[string]interface{}{

--- a/provider/gce/disks.go
+++ b/provider/gce/disks.go
@@ -56,6 +56,10 @@ func (g *storageProvider) Dynamic() bool {
 	return true
 }
 
+func (e *storageProvider) Releasable() bool {
+	return true
+}
+
 func (g *storageProvider) DefaultPools() []*storage.Config {
 	// TODO(perrito666) Add explicit pools.
 	return nil

--- a/provider/lxd/storage.go
+++ b/provider/lxd/storage.go
@@ -150,6 +150,11 @@ func (e *lxdStorageProvider) Dynamic() bool {
 	return true
 }
 
+// Releasable is defined on the Provider interface.
+func (*lxdStorageProvider) Releasable() bool {
+	return true
+}
+
 // DefaultPools is part of the Provider interface.
 func (e *lxdStorageProvider) DefaultPools() []*storage.Config {
 	zfsPool, _ := storage.NewConfig("lxd-zfs", lxdStorageProviderType, map[string]interface{}{

--- a/provider/maas/volumes.go
+++ b/provider/maas/volumes.go
@@ -114,6 +114,11 @@ func (maasStorageProvider) Dynamic() bool {
 	return false
 }
 
+// Releasable is defined on the Provider interface.
+func (maasStorageProvider) Releasable() bool {
+	return false
+}
+
 // DefaultPools is defined on the Provider interface.
 func (maasStorageProvider) DefaultPools() []*storage.Config {
 	return nil

--- a/provider/openstack/cinder.go
+++ b/provider/openstack/cinder.go
@@ -146,6 +146,11 @@ func (p *cinderProvider) Dynamic() bool {
 	return true
 }
 
+// Releasable is defined on the Provider interface.
+func (*cinderProvider) Releasable() bool {
+	return true
+}
+
 // DefaultPools implements storage.Provider.
 func (p *cinderProvider) DefaultPools() []*storage.Config {
 	return nil

--- a/provider/oracle/storage_provider.go
+++ b/provider/oracle/storage_provider.go
@@ -54,6 +54,12 @@ func (s storageProvider) Dynamic() bool {
 	return true
 }
 
+// Releasable is defined on the Provider interface.
+func (s storageProvider) Releasable() bool {
+	// TODO(axw) support releasing Oracle storage volumes.
+	return false
+}
+
 // DefaultPools  is defined on the storage.Provider interface.
 func (s storageProvider) DefaultPools() []*storage.Config {
 	latencyPool, _ := storage.NewConfig("oracle-latency", oracleStorageProvideType, map[string]interface{}{

--- a/state/filesystem.go
+++ b/state/filesystem.go
@@ -520,6 +520,13 @@ func (f *filesystem) Detachable() bool {
 	return f.doc.MachineId == ""
 }
 
+func (f *filesystem) pool() string {
+	if f.doc.Info != nil {
+		return f.doc.Info.Pool
+	}
+	return f.doc.Params.Pool
+}
+
 // isDetachableFilesystemPool reports whether or not the given
 // storage pool will create a filesystem that is not inherently
 // bound to a machine, and therefore can be detached.

--- a/state/volume.go
+++ b/state/volume.go
@@ -473,12 +473,23 @@ func isDetachableVolumeTag(db Database, tag names.VolumeTag) (bool, error) {
 	if err != nil {
 		return false, errors.Trace(err)
 	}
-	return doc.MachineId == "", nil
+	return detachableVolumeDoc(&doc), nil
 }
 
 // Detachable reports whether or not the volume is detachable.
 func (v *volume) Detachable() bool {
-	return v.doc.MachineId == ""
+	return detachableVolumeDoc(&v.doc)
+}
+
+func (v *volume) pool() string {
+	if v.doc.Info != nil {
+		return v.doc.Info.Pool
+	}
+	return v.doc.Params.Pool
+}
+
+func detachableVolumeDoc(doc *volumeDoc) bool {
+	return doc.MachineId == ""
 }
 
 // isDetachableVolumePool reports whether or not the given storage

--- a/storage/interface.go
+++ b/storage/interface.go
@@ -72,6 +72,11 @@ type Provider interface {
 	// created at the time a machine is provisioned.
 	Dynamic() bool
 
+	// Releasable reports whether or not the storage provider is capable
+	// of releasing dynamic storage, with either ReleaseVolumes or
+	// ReleaseFilesystems.
+	Releasable() bool
+
 	// DefaultPools returns the default storage pools for this provider,
 	// to register in each new model.
 	DefaultPools() []*Config

--- a/storage/provider/dummy/common.go
+++ b/storage/provider/dummy/common.go
@@ -14,10 +14,17 @@ func StorageProviders() storage.ProviderRegistry {
 			"modelscoped": &StorageProvider{
 				StorageScope: storage.ScopeEnviron,
 				IsDynamic:    true,
+				IsReleasable: true,
+			},
+			"modelscoped-unreleasable": &StorageProvider{
+				StorageScope: storage.ScopeEnviron,
+				IsDynamic:    true,
+				IsReleasable: false,
 			},
 			"modelscoped-block": &StorageProvider{
 				StorageScope: storage.ScopeEnviron,
 				IsDynamic:    true,
+				IsReleasable: true,
 				SupportsFunc: func(k storage.StorageKind) bool {
 					return k == storage.StorageKindBlock
 				},

--- a/storage/provider/dummy/provider.go
+++ b/storage/provider/dummy/provider.go
@@ -25,6 +25,10 @@ type StorageProvider struct {
 	// dynamic provisioning.
 	IsDynamic bool
 
+	// IsReleasable defines whether or not the provider reports that it
+	// supports releasing storage.
+	IsReleasable bool
+
 	// DefaultPools_ will be returned by DefaultPools.
 	DefaultPools_ []*storage.Config
 
@@ -91,6 +95,12 @@ func (p *StorageProvider) Scope() storage.Scope {
 func (p *StorageProvider) Dynamic() bool {
 	p.MethodCall(p, "Dynamic")
 	return p.IsDynamic
+}
+
+// Releasable is defined on storage.Provider.
+func (p *StorageProvider) Releasable() bool {
+	p.MethodCall(p, "Releasable")
+	return p.IsReleasable
 }
 
 // DefaultPool is defined on storage.Provider.

--- a/storage/provider/loop.go
+++ b/storage/provider/loop.go
@@ -84,6 +84,11 @@ func (*loopProvider) Dynamic() bool {
 	return true
 }
 
+// Releasable is defined on the Provider interface.
+func (*loopProvider) Releasable() bool {
+	return false
+}
+
 // DefaultPools is defined on the Provider interface.
 func (*loopProvider) DefaultPools() []*storage.Config {
 	return nil

--- a/storage/provider/rootfs.go
+++ b/storage/provider/rootfs.go
@@ -81,6 +81,11 @@ func (*rootfsProvider) Dynamic() bool {
 	return true
 }
 
+// Releasable is defined on the Provider interface.
+func (*rootfsProvider) Releasable() bool {
+	return false
+}
+
 // DefaultPools is defined on the Provider interface.
 func (*rootfsProvider) DefaultPools() []*storage.Config {
 	return nil

--- a/storage/provider/tmpfs.go
+++ b/storage/provider/tmpfs.go
@@ -83,6 +83,11 @@ func (*tmpfsProvider) Dynamic() bool {
 	return true
 }
 
+// Releasable is defined on the Provider interface.
+func (*tmpfsProvider) Releasable() bool {
+	return false
+}
+
 // DefaultPools is defined on the Provider interface.
 func (*tmpfsProvider) DefaultPools() []*storage.Config {
 	return nil


### PR DESCRIPTION
## Description of change

Add the Provider.Releasable() method, which
reports whether the storage provider supports
releasing storage. This is used in state to
prevent marking storage as "releasing", when
releasing that storage is not possible.

Currently, the Azure and Oracle storage
providers are the only two that do not
support releasing storage. Support for
Oracle should be introduced soon; support
for Azure is dependent on upstream changes.

## QA steps

1. juju bootstrap azure
2. juju deploy cs:~axwalk/storagetest --storage fs=azure,1G
(wait)
3. juju remove-storage --no-destroy --force fs/0
(should fail, saying the storage cannot be released)
4. juju destroy-controller -y --destroy-all-models --release-storage
(should fail, saying the storage cannot be released)
5. juju destroy-controller -y --destroy-all-models --destroy-storage
(should succeed, with storage destroyed)

## Documentation changes

None.

## Bug reference

None.