### PR TITLE
List and show- controllers update client store.

### DIFF
--- a/cmd/juju/controller/listcontrollers.go
+++ b/cmd/juju/controller/listcontrollers.go
@@ -134,6 +134,11 @@ func (c *listControllersCommand) refreshControllerDetails(client ControllerAcces
 	if err != nil {
 		return err
 	}
+	// Update client store.
+	if err := c.SetControllerModels(c.store, controllerName, allModels); err != nil {
+		return errors.Trace(err)
+	}
+
 	var controllerModelUUID string
 	modelTags := make([]names.ModelTag, len(allModels))
 	for i, m := range allModels {

--- a/cmd/juju/controller/package_test.go
+++ b/cmd/juju/controller/package_test.go
@@ -82,14 +82,14 @@ controllers:
     models:
       controller:
         uuid: ghi
-    current-model: controller
+    current-model: admin/controller
   mallards:
     models:
       model0:
         uuid: abc
       my-model:
         uuid: def
-    current-model: my-model
+    current-model: admin/my-model
 `
 
 const testAccountsYaml = `

--- a/cmd/juju/controller/showcontroller.go
+++ b/cmd/juju/controller/showcontroller.go
@@ -144,6 +144,12 @@ func (c *showControllerCommand) Run(ctx *cmd.Context) error {
 			details.Errors = append(details.Errors, err.Error())
 			continue
 		}
+		// Update client store.
+		if err := c.SetControllerModels(c.store, controllerName, allModels); err != nil {
+			details.Errors = append(details.Errors, err.Error())
+			continue
+		}
+
 		modelTags := make([]names.ModelTag, len(allModels))
 		var controllerModelUUID string
 		for i, m := range allModels {

--- a/cmd/juju/controller/showcontroller_test.go
+++ b/cmd/juju/controller/showcontroller_test.go
@@ -31,11 +31,6 @@ var _ = gc.Suite(&ShowControllerSuite{})
 func (s *ShowControllerSuite) SetUpTest(c *gc.C) {
 	s.baseControllerSuite.SetUpTest(c)
 	s.fakeController = &fakeController{
-		modelNames: map[string]string{
-			"abc": "model0",
-			"def": "my-model",
-			"ghi": "controller",
-		},
 		machines: map[string][]base.Machine{
 			"ghi": {
 				{Id: "0", InstanceId: "id-0", HasVote: false, WantsVote: true, Status: "active"},
@@ -45,8 +40,8 @@ func (s *ShowControllerSuite) SetUpTest(c *gc.C) {
 			},
 		},
 	}
-	s.api = func(controllerNamee string) controller.ControllerAccessAPI {
-		s.fakeController.controllerName = controllerNamee
+	s.api = func(controllerName string) controller.ControllerAccessAPI {
+		s.fakeController.controllerName = controllerName
 		return s.fakeController
 	}
 }
@@ -60,7 +55,7 @@ func (s *ShowControllerSuite) TestShowOneControllerOneInStore(c *gc.C) {
     cloud: mallards
     agent-version: 999.99.99
 `
-	s.fakeController.store = s.createTestClientStore(c)
+	s.createTestClientStore(c)
 
 	s.expectedOutput = `
 mallards:
@@ -71,7 +66,7 @@ mallards:
     cloud: mallards
     agent-version: 999.99.99
   models:
-    model0:
+    controller:
       uuid: abc
       machine-count: 2
       core-count: 4
@@ -79,7 +74,7 @@ mallards:
       uuid: def
       machine-count: 2
       core-count: 4
-  current-model: my-model
+  current-model: admin/my-model
   account:
     user: admin
     access: superuser
@@ -97,7 +92,7 @@ func (s *ShowControllerSuite) TestShowControllerWithPasswords(c *gc.C) {
     cloud: mallards
     agent-version: 999.99.99
 `
-	s.fakeController.store = s.createTestClientStore(c)
+	s.createTestClientStore(c)
 
 	s.expectedOutput = `
 mallards:
@@ -108,7 +103,7 @@ mallards:
     cloud: mallards
     agent-version: 999.99.99
   models:
-    model0:
+    controller:
       uuid: abc
       machine-count: 2
       core-count: 4
@@ -116,7 +111,7 @@ mallards:
       uuid: def
       machine-count: 2
       core-count: 4
-  current-model: my-model
+  current-model: admin/my-model
   account:
     user: admin
     access: superuser
@@ -149,7 +144,6 @@ func (s *ShowControllerSuite) TestShowControllerWithBootstrapConfig(c *gc.C) {
 		CloudRegion:   "mallards1",
 		CloudEndpoint: "http://mallards.local/MAAS",
 	}
-	s.fakeController.store = store
 
 	s.expectedOutput = `
 mallards:
@@ -161,7 +155,7 @@ mallards:
     region: mallards1
     agent-version: 999.99.99
   models:
-    model0:
+    controller:
       uuid: abc
       machine-count: 2
       core-count: 4
@@ -169,7 +163,7 @@ mallards:
       uuid: def
       machine-count: 2
       core-count: 4
-  current-model: my-model
+  current-model: admin/my-model
   account:
     user: admin
     access: superuser
@@ -179,7 +173,7 @@ mallards:
 }
 
 func (s *ShowControllerSuite) TestShowOneControllerManyInStore(c *gc.C) {
-	s.fakeController.store = s.createTestClientStore(c)
+	s.createTestClientStore(c)
 
 	s.expectedOutput = `
 aws-test:
@@ -205,7 +199,7 @@ aws-test:
       uuid: ghi
       machine-count: 2
       core-count: 4
-  current-model: controller
+  current-model: admin/controller
   account:
     user: admin
     access: superuser
@@ -214,7 +208,7 @@ aws-test:
 }
 
 func (s *ShowControllerSuite) TestShowSomeControllerMoreInStore(c *gc.C) {
-	s.fakeController.store = s.createTestClientStore(c)
+	s.createTestClientStore(c)
 	s.expectedOutput = `
 aws-test:
   details:
@@ -239,7 +233,7 @@ aws-test:
       uuid: ghi
       machine-count: 2
       core-count: 4
-  current-model: controller
+  current-model: admin/controller
   account:
     user: admin
     access: superuser
@@ -259,25 +253,25 @@ mark-test-prodstack:
 }
 
 func (s *ShowControllerSuite) TestShowControllerJsonOne(c *gc.C) {
-	s.fakeController.store = s.createTestClientStore(c)
+	s.createTestClientStore(c)
 
 	s.expectedOutput = `
-{"aws-test":{"details":{"uuid":"this-is-the-aws-test-uuid","api-endpoints":["this-is-aws-test-of-many-api-endpoints"],"ca-cert":"this-is-aws-test-ca-cert","cloud":"aws","region":"us-east-1","agent-version":"999.99.99"},"controller-machines":{"0":{"instance-id":"id-0","ha-status":"ha-pending"},"1":{"instance-id":"id-1","ha-status":"down, lost connection"},"2":{"instance-id":"id-2","ha-status":"ha-enabled"}},"models":{"controller":{"uuid":"ghi","machine-count":2,"core-count":4}},"current-model":"controller","account":{"user":"admin","access":"superuser"}}}
+{"aws-test":{"details":{"uuid":"this-is-the-aws-test-uuid","api-endpoints":["this-is-aws-test-of-many-api-endpoints"],"ca-cert":"this-is-aws-test-ca-cert","cloud":"aws","region":"us-east-1","agent-version":"999.99.99"},"controller-machines":{"0":{"instance-id":"id-0","ha-status":"ha-pending"},"1":{"instance-id":"id-1","ha-status":"down, lost connection"},"2":{"instance-id":"id-2","ha-status":"ha-enabled"}},"models":{"controller":{"uuid":"ghi","machine-count":2,"core-count":4}},"current-model":"admin/controller","account":{"user":"admin","access":"superuser"}}}
 `[1:]
 
 	s.assertShowController(c, "--format", "json", "aws-test")
 }
 
 func (s *ShowControllerSuite) TestShowControllerJsonMany(c *gc.C) {
-	s.fakeController.store = s.createTestClientStore(c)
+	s.createTestClientStore(c)
 	s.expectedOutput = `
-{"aws-test":{"details":{"uuid":"this-is-the-aws-test-uuid","api-endpoints":["this-is-aws-test-of-many-api-endpoints"],"ca-cert":"this-is-aws-test-ca-cert","cloud":"aws","region":"us-east-1","agent-version":"999.99.99"},"controller-machines":{"0":{"instance-id":"id-0","ha-status":"ha-pending"},"1":{"instance-id":"id-1","ha-status":"down, lost connection"},"2":{"instance-id":"id-2","ha-status":"ha-enabled"}},"models":{"controller":{"uuid":"ghi","machine-count":2,"core-count":4}},"current-model":"controller","account":{"user":"admin","access":"superuser"}},"mark-test-prodstack":{"details":{"uuid":"this-is-a-uuid","api-endpoints":["this-is-one-of-many-api-endpoints"],"ca-cert":"this-is-a-ca-cert","cloud":"prodstack","agent-version":"999.99.99"},"account":{"user":"admin","access":"superuser"}}}
+{"aws-test":{"details":{"uuid":"this-is-the-aws-test-uuid","api-endpoints":["this-is-aws-test-of-many-api-endpoints"],"ca-cert":"this-is-aws-test-ca-cert","cloud":"aws","region":"us-east-1","agent-version":"999.99.99"},"controller-machines":{"0":{"instance-id":"id-0","ha-status":"ha-pending"},"1":{"instance-id":"id-1","ha-status":"down, lost connection"},"2":{"instance-id":"id-2","ha-status":"ha-enabled"}},"models":{"controller":{"uuid":"ghi","machine-count":2,"core-count":4}},"current-model":"admin/controller","account":{"user":"admin","access":"superuser"}},"mark-test-prodstack":{"details":{"uuid":"this-is-a-uuid","api-endpoints":["this-is-one-of-many-api-endpoints"],"ca-cert":"this-is-a-ca-cert","cloud":"prodstack","agent-version":"999.99.99"},"account":{"user":"admin","access":"superuser"}}}
 `[1:]
 	s.assertShowController(c, "--format", "json", "aws-test", "mark-test-prodstack")
 }
 
 func (s *ShowControllerSuite) TestShowControllerReadFromStoreErr(c *gc.C) {
-	s.fakeController.store = s.createTestClientStore(c)
+	s.createTestClientStore(c)
 
 	msg := "fail getting controller"
 	errStore := jujuclienttesting.NewStubStore()
@@ -291,12 +285,11 @@ func (s *ShowControllerSuite) TestShowControllerReadFromStoreErr(c *gc.C) {
 
 func (s *ShowControllerSuite) TestShowControllerNoArgs(c *gc.C) {
 	store := s.createTestClientStore(c)
-	s.fakeController.store = store
+	store.CurrentControllerName = "aws-test"
 
 	s.expectedOutput = `
-{"aws-test":{"details":{"uuid":"this-is-the-aws-test-uuid","api-endpoints":["this-is-aws-test-of-many-api-endpoints"],"ca-cert":"this-is-aws-test-ca-cert","cloud":"aws","region":"us-east-1","agent-version":"999.99.99"},"controller-machines":{"0":{"instance-id":"id-0","ha-status":"ha-pending"},"1":{"instance-id":"id-1","ha-status":"down, lost connection"},"2":{"instance-id":"id-2","ha-status":"ha-enabled"}},"models":{"controller":{"uuid":"ghi","machine-count":2,"core-count":4}},"current-model":"controller","account":{"user":"admin","access":"superuser"}}}
+{"aws-test":{"details":{"uuid":"this-is-the-aws-test-uuid","api-endpoints":["this-is-aws-test-of-many-api-endpoints"],"ca-cert":"this-is-aws-test-ca-cert","cloud":"aws","region":"us-east-1","agent-version":"999.99.99"},"controller-machines":{"0":{"instance-id":"id-0","ha-status":"ha-pending"},"1":{"instance-id":"id-1","ha-status":"down, lost connection"},"2":{"instance-id":"id-2","ha-status":"ha-enabled"}},"models":{"controller":{"uuid":"ghi","machine-count":2,"core-count":4}},"current-model":"admin/controller","account":{"user":"admin","access":"superuser"}}}
 `[1:]
-	store.CurrentControllerName = "aws-test"
 	s.assertShowController(c, "--format", "json")
 }
 
@@ -326,7 +319,6 @@ func (s *ShowControllerSuite) TestShowControllerUnrecognizedOptionFlag(c *gc.C) 
 
 func (s *ShowControllerSuite) TestShowControllerRefreshesStore(c *gc.C) {
 	store := s.createTestClientStore(c)
-	s.fakeController.store = store
 	_, err := s.runShowController(c, "aws-test")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(store.Controllers["aws-test"].ControllerMachineCount, gc.Equals, 3)
@@ -336,6 +328,26 @@ func (s *ShowControllerSuite) TestShowControllerRefreshesStore(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(store.Controllers["aws-test"].ControllerMachineCount, gc.Equals, 3)
 	c.Check(store.Controllers["aws-test"].ActiveControllerMachineCount, gc.Equals, 2)
+}
+
+func (s *ShowControllerSuite) TestShowControllerRefreshesStoreModels(c *gc.C) {
+	store := s.createTestClientStore(c)
+	c.Assert(store.Models["mallards"], gc.DeepEquals, &jujuclient.ControllerModels{
+		CurrentModel: "admin/my-model",
+		Models: map[string]jujuclient.ModelDetails{
+			"model0":   jujuclient.ModelDetails{ModelUUID: "abc"},
+			"my-model": jujuclient.ModelDetails{ModelUUID: "def"},
+		},
+	})
+	_, err := s.runShowController(c, "mallards")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(store.Models["mallards"], gc.DeepEquals, &jujuclient.ControllerModels{
+		CurrentModel: "admin/my-model",
+		Models: map[string]jujuclient.ModelDetails{
+			"admin/controller": jujuclient.ModelDetails{ModelUUID: "abc"},
+			"admin/my-model":   jujuclient.ModelDetails{ModelUUID: "def"},
+		},
+	})
 }
 
 func (s *ShowControllerSuite) runShowController(c *gc.C, args ...string) (*cmd.Context, error) {
@@ -355,8 +367,6 @@ func (s *ShowControllerSuite) assertShowController(c *gc.C, args ...string) {
 
 type fakeController struct {
 	controllerName string
-	store          jujuclient.ClientStore
-	modelNames     map[string]string
 	machines       map[string][]base.Machine
 }
 
@@ -381,20 +391,20 @@ func (c *fakeController) ModelStatus(models ...names.ModelTag) (result []base.Mo
 }
 
 func (c *fakeController) AllModels() (result []base.UserModel, _ error) {
-	all, err := c.store.AllModels(c.controllerName)
-	if errors.IsNotFound(err) {
+	models := map[string][]base.UserModel{
+		"aws-test": []base.UserModel{
+			base.UserModel{Name: "controller", UUID: "ghi", Owner: "admin"},
+		},
+		"mallards": []base.UserModel{
+			base.UserModel{Name: "controller", UUID: "abc", Owner: "admin"},
+			base.UserModel{Name: "my-model", UUID: "def", Owner: "admin"},
+		},
+	}
+	all, exists := models[c.controllerName]
+	if !exists {
 		return result, nil
 	}
-	if err != nil {
-		return nil, err
-	}
-	for _, m := range all {
-		result = append(result, base.UserModel{
-			UUID: m.ModelUUID,
-			Name: c.modelNames[m.ModelUUID],
-		})
-	}
-	return result, nil
+	return all, nil
 }
 
 func (*fakeController) Close() error {


### PR DESCRIPTION
## Description of change

Both 'controllers --refresh' and 'show-controller' get full models list for a given controller. Use this as an opportunity to update client store.

Whilst the updates on th commands are straightforward, most of the movement proposed in this PR is in the test since tests were setup in such a way that client side store was re-used to supply data "coming" from the API. Here we separate API data from store data to check that the store is updated.

## QA steps

1. Bootstrap
2. modify store file to contain some non-existent models
3. Run 'controllers --refresh', check store has been updated to contain only existent models
4. repeat step 2 
5. run 'show-controller' for bootstrapped model and check that the store has been updated correctly 

## Documentation changes

n/a - internal change

## Bug reference
n/a
