### PR TITLE
Add suspend/resume relation support

### DIFF
--- a/api/application/client.go
+++ b/api/application/client.go
@@ -18,6 +18,7 @@ import (
 	"github.com/juju/juju/charmstore"
 	"github.com/juju/juju/constraints"
 	"github.com/juju/juju/core/crossmodel"
+	"github.com/juju/juju/core/relation"
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/storage"
 )
@@ -485,6 +486,18 @@ func (c *Client) DestroyRelation(endpoints ...string) error {
 func (c *Client) DestroyRelationId(relationId int) error {
 	params := params.DestroyRelation{RelationId: relationId}
 	return c.facade.FacadeCall("DestroyRelation", params, nil)
+}
+
+// SetRelationStatus updates the status of the relation with the specified id.
+func (c *Client) SetRelationStatus(relationId int, status relation.Status) error {
+	args := params.RelationStatusArgs{
+		Args: []params.RelationStatusArg{{RelationId: relationId, Status: params.RelationStatusValue(status)}},
+	}
+	var results params.ErrorResults
+	if err := c.facade.FacadeCall("SetRelationStatus", args, &results); err != nil {
+		return errors.Trace(err)
+	}
+	return results.OneError()
 }
 
 // Consume adds a remote application to the model.

--- a/api/application/client_test.go
+++ b/api/application/client_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/juju/juju/charmstore"
 	"github.com/juju/juju/constraints"
 	"github.com/juju/juju/core/crossmodel"
+	"github.com/juju/juju/core/relation"
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/storage"
 	coretesting "github.com/juju/juju/testing"
@@ -508,6 +509,28 @@ func (s *applicationSuite) TestDestroyRelationId(c *gc.C) {
 		return nil
 	})
 	err := client.DestroyRelationId(123)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(called, jc.IsTrue)
+}
+
+func (s *applicationSuite) TestSetRelationStatus(c *gc.C) {
+	called := false
+	client := newClient(func(objType string, version int, id, request string, a, result interface{}) error {
+		c.Assert(request, gc.Equals, "SetRelationStatus")
+		c.Assert(a, jc.DeepEquals, params.RelationStatusArgs{
+			Args: []params.RelationStatusArg{{
+				RelationId: 123,
+				Status:     "suspended",
+			}},
+		})
+		c.Assert(result, gc.FitsTypeOf, &params.ErrorResults{})
+		*result.(*params.ErrorResults) = params.ErrorResults{
+			Results: []params.ErrorResult{{}},
+		}
+		called = true
+		return nil
+	})
+	err := client.SetRelationStatus(123, relation.Suspended)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(called, jc.IsTrue)
 }

--- a/api/uniter/relation_test.go
+++ b/api/uniter/relation_test.go
@@ -65,7 +65,7 @@ func (s *relationSuite) TestRefresh(c *gc.C) {
 	err = s.stateRelation.Destroy()
 	c.Assert(err, jc.ErrorIsNil)
 	// Update status as well.
-	err = s.stateRelation.SetStatus(status.Revoked)
+	err = s.stateRelation.SetStatus(status.Suspended)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(s.apiRelation.Life(), gc.Equals, params.Alive)
 	c.Assert(s.apiRelation.Status(), gc.Equals, params.Joined)
@@ -73,14 +73,14 @@ func (s *relationSuite) TestRefresh(c *gc.C) {
 	err = s.apiRelation.Refresh()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(s.apiRelation.Life(), gc.Equals, params.Dying)
-	c.Assert(s.apiRelation.Status(), gc.Equals, params.Revoked)
+	c.Assert(s.apiRelation.Status(), gc.Equals, params.Suspended)
 
 	// Leave scope with mysqlUnit, so the relation will be removed.
 	err = myRelUnit.LeaveScope()
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Assert(s.apiRelation.Life(), gc.Equals, params.Dying)
-	c.Assert(s.apiRelation.Status(), gc.Equals, params.Revoked)
+	c.Assert(s.apiRelation.Status(), gc.Equals, params.Suspended)
 	err = s.apiRelation.Refresh()
 	c.Assert(err, jc.Satisfies, params.IsCodeUnauthorized)
 }

--- a/apiserver/allfacades.go
+++ b/apiserver/allfacades.go
@@ -127,7 +127,7 @@ func AllFacades() *facade.Registry {
 	reg("Application", 2, application.NewFacadeV4)
 	reg("Application", 3, application.NewFacadeV4)
 	reg("Application", 4, application.NewFacadeV4)
-	reg("Application", 5, application.NewFacade) // adds AttachStorage & UpdateApplicationSeries
+	reg("Application", 5, application.NewFacade) // adds AttachStorage & UpdateApplicationSeries & SetRelationStatus
 
 	reg("ApplicationScaler", 1, applicationscaler.NewAPI)
 	reg("Backups", 1, backups.NewFacade)

--- a/apiserver/common/crossmodel/interface.go
+++ b/apiserver/common/crossmodel/interface.go
@@ -88,6 +88,9 @@ type Relation interface {
 	// Status returns the relation's current status.
 	Status() status.Status
 
+	// SetStatus updates the relation's status.
+	SetStatus(status.Status) error
+
 	// Tag returns the relation's tag.
 	Tag() names.Tag
 

--- a/apiserver/facades/client/application/backend.go
+++ b/apiserver/facades/client/application/backend.go
@@ -14,6 +14,7 @@ import (
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/state"
+	"github.com/juju/juju/status"
 )
 
 // Backend defines the state functionality required by the application
@@ -37,9 +38,8 @@ type Backend interface {
 	Unit(string) (Unit, error)
 	SaveController(info crossmodel.ControllerInfo, modelUUID string) (ExternalController, error)
 	ControllerTag() names.ControllerTag
-	//	NewStorage() storage.Storage
-	//	GetOfferAccess(offer names.ApplicationOfferTag, user names.UserTag) (permission.Access, error)
 	Resources() (Resources, error)
+	OfferConnectionForRelation(string) (OfferConnection, error)
 }
 
 // BlockChecker defines the block-checking functionality required by
@@ -96,7 +96,9 @@ type Machine interface {
 // details on the methods, see the methods on state.Relation with
 // the same names.
 type Relation interface {
+	Tag() names.Tag
 	Destroy() error
+	SetStatus(status status.Status) error
 	Endpoint(string) (state.Endpoint, error)
 }
 
@@ -258,6 +260,12 @@ func (s stateShim) Unit(name string) (Unit, error) {
 
 func (s stateShim) Resources() (Resources, error) {
 	return s.State.Resources()
+}
+
+type OfferConnection interface{}
+
+func (s stateShim) OfferConnectionForRelation(key string) (OfferConnection, error) {
+	return s.State.OfferConnectionForRelation(key)
 }
 
 type stateApplicationShim struct {

--- a/apiserver/facades/client/applicationoffers/applicationoffers_test.go
+++ b/apiserver/facades/client/applicationoffers/applicationoffers_test.go
@@ -246,7 +246,7 @@ func (s *applicationOffersSuite) assertList(c *gc.C, expectedErr error) {
 					RelationId:     1,
 					Endpoint:       "db",
 					Username:       "fred",
-					Status:         "active",
+					Status:         "joined",
 				}},
 			},
 		},

--- a/apiserver/facades/client/applicationoffers/base.go
+++ b/apiserver/facades/client/applicationoffers/base.go
@@ -153,8 +153,6 @@ func (api *BaseAPI) applicationOffersFromModel(
 					SourceModelTag: names.NewModelTag(oc.SourceModelUUID()).String(),
 					Username:       oc.UserName(),
 					RelationId:     oc.RelationId(),
-					// TODO(wallyworld)
-					Status: "active",
 				}
 				rel, err := backend.KeyRelation(oc.RelationKey())
 				if err != nil {
@@ -165,6 +163,7 @@ func (api *BaseAPI) applicationOffersFromModel(
 					return nil, errors.Trace(err)
 				}
 				connDetails.Endpoint = ep.Name
+				connDetails.Status = string(rel.Status())
 				offer.Connections = append(offer.Connections, connDetails)
 			}
 		}

--- a/apiserver/facades/client/applicationoffers/mock_test.go
+++ b/apiserver/facades/client/applicationoffers/mock_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/permission"
 	"github.com/juju/juju/state"
+	"github.com/juju/juju/status"
 	"github.com/juju/juju/testing"
 )
 
@@ -254,6 +255,10 @@ type mockRelation struct {
 	crossmodel.Relation
 	id       int
 	endpoint state.Endpoint
+}
+
+func (m *mockRelation) Status() status.Status {
+	return status.Joined
 }
 
 func (m *mockRelation) Endpoint(appName string) (state.Endpoint, error) {

--- a/apiserver/facades/client/client/api_test.go
+++ b/apiserver/facades/client/client/api_test.go
@@ -311,6 +311,7 @@ var scenarioStatus = &params.FullStatus{
 			},
 			Interface: "logging",
 			Scope:     "container",
+			Status:    "joined",
 		},
 	},
 }

--- a/apiserver/facades/client/client/status.go
+++ b/apiserver/facades/client/client/status.go
@@ -813,6 +813,7 @@ func (context *statusContext) processRelations() []params.RelationStatus {
 			Interface: relationInterface,
 			Scope:     string(scope),
 			Endpoints: eps,
+			Status:    relation.Status().String(),
 		}
 		out = append(out, relStatus)
 	}

--- a/apiserver/facades/controller/crossmodelrelations/mock_test.go
+++ b/apiserver/facades/controller/crossmodelrelations/mock_test.go
@@ -296,7 +296,7 @@ func (r *mockRelation) Life() state.Life {
 }
 
 func (r *mockRelation) Status() status.Status {
-	return status.Revoked
+	return status.Suspended
 }
 
 func (r *mockRelation) RemoteUnit(unitId string) (commoncrossmodel.RelationUnit, error) {

--- a/apiserver/facades/controller/remoterelations/mock_test.go
+++ b/apiserver/facades/controller/remoterelations/mock_test.go
@@ -253,6 +253,11 @@ func (r *mockRelation) Life() state.Life {
 	return r.life
 }
 
+func (r *mockRelation) Status() status.Status {
+	r.MethodCall(r, "Status")
+	return status.Joined
+}
+
 func (r *mockRelation) Unit(unitId string) (common.RelationUnit, error) {
 	r.MethodCall(r, "Unit", unitId)
 	if err := r.NextErr(); err != nil {

--- a/apiserver/params/params.go
+++ b/apiserver/params/params.go
@@ -131,6 +131,18 @@ type DestroyRelation struct {
 	RelationId int      `json:"relation-id"`
 }
 
+// RelationStatusArgs holds the parameters for updating the status
+// of one or more relations.
+type RelationStatusArgs struct {
+	Args []RelationStatusArg `json:"args"`
+}
+
+// RelationStatusArg holds the new status value for a relation.
+type RelationStatusArg struct {
+	RelationId int                 `json:"relation-id"`
+	Status     RelationStatusValue `json:"status"`
+}
+
 // AddCharm holds the arguments for making an AddCharm API call.
 type AddCharm struct {
 	URL     string `json:"url"`

--- a/apiserver/params/status.go
+++ b/apiserver/params/status.go
@@ -170,6 +170,7 @@ type RelationStatus struct {
 	Interface string           `json:"interface"`
 	Scope     string           `json:"scope"`
 	Endpoints []EndpointStatus `json:"endpoints"`
+	Status    string           `json:"status"`
 }
 
 // EndpointStatus holds status info about a single endpoint.
@@ -281,11 +282,11 @@ const (
 	Dead  Life = "dead"
 )
 
-// RelationStatusValue describes the status of a relation ("active" or "revoked").
+// RelationStatusValue describes the status of a relation.
 type RelationStatusValue relation.Status
 
 const (
-	Joined  RelationStatusValue = "joined"
-	Revoked RelationStatusValue = "revoked"
-	Broken  RelationStatusValue = "broken"
+	Joined    RelationStatusValue = "joined"
+	Suspended RelationStatusValue = "suspended"
+	Broken    RelationStatusValue = "broken"
 )

--- a/cmd/juju/application/export_test.go
+++ b/cmd/juju/application/export_test.go
@@ -82,6 +82,22 @@ func NewUpdateSeriesCommandForTest(
 	return modelcmd.Wrap(cmd)
 }
 
+// NewSuspendRelationCommandForTest returns a SuspendRelationCommand with the api provided as specified.
+func NewSuspendRelationCommandForTest(api SetRelationStatusAPI) modelcmd.ModelCommand {
+	cmd := &suspendRelationCommand{newAPIFunc: func() (SetRelationStatusAPI, error) {
+		return api, nil
+	}}
+	return modelcmd.Wrap(cmd)
+}
+
+// NewResumeRelationCommandForTest returns a ResumeRelationCommand with the api provided as specified.
+func NewResumeRelationCommandForTest(api SetRelationStatusAPI) modelcmd.ModelCommand {
+	cmd := &resumeRelationCommand{newAPIFunc: func() (SetRelationStatusAPI, error) {
+		return api, nil
+	}}
+	return modelcmd.Wrap(cmd)
+}
+
 type Patcher interface {
 	PatchValue(dest, value interface{})
 }

--- a/cmd/juju/application/resumerelation.go
+++ b/cmd/juju/application/resumerelation.go
@@ -1,0 +1,88 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package application
+
+import (
+	"strconv"
+
+	"github.com/juju/cmd"
+	"github.com/juju/errors"
+
+	"github.com/juju/juju/api/application"
+	"github.com/juju/juju/cmd/juju/block"
+	"github.com/juju/juju/cmd/modelcmd"
+	"github.com/juju/juju/core/relation"
+)
+
+var resumeHelpSummary = `
+Resumes a suspended relation to an application offer.`[1:]
+
+var resumeHelpDetails = `
+A relation between an application in another model and an offer in this model will be resumed. 
+The relation-joined and relation-changed hooks will be run for the relation, and the relation
+status will be set to joined. The relation is specified using its id.
+
+Examples:
+    juju resume-relation 123
+
+See also: 
+    add-relation
+    offers
+    remove-relation
+    suspend-relation`
+
+// NewResumeRelationCommand returns a command to resume a relation.
+func NewResumeRelationCommand() cmd.Command {
+	cmd := &resumeRelationCommand{}
+	cmd.newAPIFunc = func() (SetRelationStatusAPI, error) {
+		root, err := cmd.NewAPIRoot()
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		return application.NewClient(root), nil
+
+	}
+	return modelcmd.Wrap(cmd)
+}
+
+type resumeRelationCommand struct {
+	modelcmd.ModelCommandBase
+	RelationId int
+	newAPIFunc func() (SetRelationStatusAPI, error)
+}
+
+func (c *resumeRelationCommand) Info() *cmd.Info {
+	return &cmd.Info{
+		Name:    "resume-relation",
+		Args:    "<relation-id>",
+		Purpose: resumeHelpSummary,
+		Doc:     resumeHelpDetails,
+	}
+}
+
+func (c *resumeRelationCommand) Init(args []string) (err error) {
+	if len(args) == 1 {
+		if c.RelationId, err = strconv.Atoi(args[0]); err != nil || c.RelationId < 0 {
+			return errors.NotValidf("relation ID %q", args[0])
+		}
+		return nil
+	}
+	if len(args) == 0 {
+		return errors.New("no relation id specified")
+	}
+	return cmd.CheckEmpty(args[1:])
+}
+
+func (c *resumeRelationCommand) Run(_ *cmd.Context) error {
+	client, err := c.newAPIFunc()
+	if err != nil {
+		return err
+	}
+	defer client.Close()
+	if client.BestAPIVersion() < 5 {
+		return errors.New("resuming a relation is not supported by this version of Juju")
+	}
+	err = client.SetRelationStatus(c.RelationId, relation.Joined)
+	return block.ProcessBlockedError(err, block.BlockChange)
+}

--- a/cmd/juju/application/resumerelation_test.go
+++ b/cmd/juju/application/resumerelation_test.go
@@ -1,0 +1,101 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package application
+
+import (
+	"github.com/juju/cmd/cmdtesting"
+	"github.com/juju/errors"
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/core/relation"
+	coretesting "github.com/juju/juju/testing"
+)
+
+type ResumeRelationSuite struct {
+	testing.IsolationSuite
+	mockAPI *mockResumeAPI
+}
+
+func (s *ResumeRelationSuite) SetUpTest(c *gc.C) {
+	s.IsolationSuite.SetUpTest(c)
+	s.mockAPI = &mockResumeAPI{Stub: &testing.Stub{}, version: 6}
+	s.mockAPI.resumeRelationFunc = func(relationId int, status relation.Status) error {
+		return s.mockAPI.NextErr()
+	}
+}
+
+var _ = gc.Suite(&ResumeRelationSuite{})
+
+func (s *ResumeRelationSuite) runResumeRelation(c *gc.C, args ...string) error {
+	_, err := cmdtesting.RunCommand(c, NewResumeRelationCommandForTest(s.mockAPI), args...)
+	return err
+}
+
+func (s *ResumeRelationSuite) TestResumeRelationWrongNumberOfArguments(c *gc.C) {
+	// No arguments
+	err := s.runResumeRelation(c)
+	c.Assert(err, gc.ErrorMatches, "no relation id specified")
+
+	// 1 argument not an integer
+	err = s.runResumeRelation(c, "application1")
+	c.Assert(err, gc.ErrorMatches, `relation ID "application1" not valid`)
+
+	// More than 2 arguments
+	err = s.runResumeRelation(c, "123", "extra")
+	c.Assert(err, gc.ErrorMatches, `unrecognized args: \["extra"\]`)
+}
+
+func (s *ResumeRelationSuite) TestResumeRelationIdOldServer(c *gc.C) {
+	s.mockAPI.version = 4
+	err := s.runResumeRelation(c, "123")
+	c.Assert(err, gc.ErrorMatches, "resuming a relation is not supported by this version of Juju")
+	s.mockAPI.CheckCall(c, 0, "Close")
+}
+
+func (s *ResumeRelationSuite) TestResumeRelationSuccess(c *gc.C) {
+	err := s.runResumeRelation(c, "123")
+	c.Assert(err, jc.ErrorIsNil)
+	s.mockAPI.CheckCall(c, 0, "SetRelationStatus", 123, relation.Joined)
+	s.mockAPI.CheckCall(c, 1, "Close")
+}
+
+func (s *ResumeRelationSuite) TestResumeRelationFail(c *gc.C) {
+	msg := "fail resume-relation at API"
+	s.mockAPI.SetErrors(errors.New(msg))
+	err := s.runResumeRelation(c, "123")
+	c.Assert(err, gc.ErrorMatches, msg)
+	s.mockAPI.CheckCall(c, 0, "SetRelationStatus", 123, relation.Joined)
+	s.mockAPI.CheckCall(c, 1, "Close")
+}
+
+func (s *ResumeRelationSuite) TestResumeRelationBlocked(c *gc.C) {
+	s.mockAPI.SetErrors(common.OperationBlockedError("TestResumeRelationBlocked"))
+	err := s.runResumeRelation(c, "123")
+	coretesting.AssertOperationWasBlocked(c, err, ".*TestResumeRelationBlocked.*")
+	s.mockAPI.CheckCall(c, 0, "SetRelationStatus", 123, relation.Joined)
+	s.mockAPI.CheckCall(c, 1, "Close")
+}
+
+type mockResumeAPI struct {
+	*testing.Stub
+	version            int
+	resumeRelationFunc func(relationId int, status relation.Status) error
+}
+
+func (s mockResumeAPI) Close() error {
+	s.MethodCall(s, "Close")
+	return s.NextErr()
+}
+
+func (s mockResumeAPI) SetRelationStatus(relationId int, status relation.Status) error {
+	s.MethodCall(s, "SetRelationStatus", relationId, status)
+	return s.resumeRelationFunc(relationId, status)
+}
+
+func (s mockResumeAPI) BestAPIVersion() int {
+	return s.version
+}

--- a/cmd/juju/application/suspendrelation.go
+++ b/cmd/juju/application/suspendrelation.go
@@ -1,0 +1,95 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package application
+
+import (
+	"strconv"
+
+	"github.com/juju/cmd"
+	"github.com/juju/errors"
+
+	"github.com/juju/juju/api/application"
+	"github.com/juju/juju/cmd/juju/block"
+	"github.com/juju/juju/cmd/modelcmd"
+	"github.com/juju/juju/core/relation"
+)
+
+var suspendHelpSummary = `
+Suspends a relation to an application offer.`[1:]
+
+var suspendHelpDetails = `
+A relation between an application in another model and an offer in this model will be suspended. 
+The relation-departed and relation-broken hooks will be run for the relation, and the relation
+status will be set to suspended. The relation is specified using its id.
+
+Examples:
+    juju suspend-relation 123
+
+See also: 
+    add-relation
+    offers
+    remove-relation
+    resume-relation`
+
+// NewSuspendRelationCommand returns a command to suspend a relation.
+func NewSuspendRelationCommand() cmd.Command {
+	cmd := &suspendRelationCommand{}
+	cmd.newAPIFunc = func() (SetRelationStatusAPI, error) {
+		root, err := cmd.NewAPIRoot()
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		return application.NewClient(root), nil
+
+	}
+	return modelcmd.Wrap(cmd)
+}
+
+type suspendRelationCommand struct {
+	modelcmd.ModelCommandBase
+	RelationId int
+	newAPIFunc func() (SetRelationStatusAPI, error)
+}
+
+func (c *suspendRelationCommand) Info() *cmd.Info {
+	return &cmd.Info{
+		Name:    "suspend-relation",
+		Args:    "<relation-id>",
+		Purpose: suspendHelpSummary,
+		Doc:     suspendHelpDetails,
+	}
+}
+
+func (c *suspendRelationCommand) Init(args []string) (err error) {
+	if len(args) == 1 {
+		if c.RelationId, err = strconv.Atoi(args[0]); err != nil || c.RelationId < 0 {
+			return errors.NotValidf("relation ID %q", args[0])
+		}
+		return nil
+	}
+	if len(args) == 0 {
+		return errors.New("no relation id specified")
+	}
+	return cmd.CheckEmpty(args[1:])
+}
+
+// SetRelationStatusAPI defines the API methods that the suspend/resume relation commands use.
+type SetRelationStatusAPI interface {
+	Close() error
+	BestAPIVersion() int
+	SetRelationStatus(relationId int, status relation.Status) error
+}
+
+func (c *suspendRelationCommand) Run(_ *cmd.Context) error {
+	client, err := c.newAPIFunc()
+	if err != nil {
+		return err
+	}
+	defer client.Close()
+	if client.BestAPIVersion() < 5 {
+		return errors.New("suspending a relation is not supported by this version of Juju")
+	}
+	err = client.SetRelationStatus(c.RelationId, relation.Suspended)
+	return block.ProcessBlockedError(err, block.BlockChange)
+}

--- a/cmd/juju/application/suspendrelation_test.go
+++ b/cmd/juju/application/suspendrelation_test.go
@@ -1,0 +1,101 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package application
+
+import (
+	"github.com/juju/cmd/cmdtesting"
+	"github.com/juju/errors"
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/core/relation"
+	coretesting "github.com/juju/juju/testing"
+)
+
+type SuspendRelationSuite struct {
+	testing.IsolationSuite
+	mockAPI *mockSuspendAPI
+}
+
+func (s *SuspendRelationSuite) SetUpTest(c *gc.C) {
+	s.IsolationSuite.SetUpTest(c)
+	s.mockAPI = &mockSuspendAPI{Stub: &testing.Stub{}, version: 6}
+	s.mockAPI.suspendRelationFunc = func(relationId int, status relation.Status) error {
+		return s.mockAPI.NextErr()
+	}
+}
+
+var _ = gc.Suite(&SuspendRelationSuite{})
+
+func (s *SuspendRelationSuite) runSuspendRelation(c *gc.C, args ...string) error {
+	_, err := cmdtesting.RunCommand(c, NewSuspendRelationCommandForTest(s.mockAPI), args...)
+	return err
+}
+
+func (s *SuspendRelationSuite) TestSuspendRelationWrongNumberOfArguments(c *gc.C) {
+	// No arguments
+	err := s.runSuspendRelation(c)
+	c.Assert(err, gc.ErrorMatches, "no relation id specified")
+
+	// 1 argument not an integer
+	err = s.runSuspendRelation(c, "application1")
+	c.Assert(err, gc.ErrorMatches, `relation ID "application1" not valid`)
+
+	// More than 2 arguments
+	err = s.runSuspendRelation(c, "123", "extra")
+	c.Assert(err, gc.ErrorMatches, `unrecognized args: \["extra"\]`)
+}
+
+func (s *SuspendRelationSuite) TestSuspendRelationIdOldServer(c *gc.C) {
+	s.mockAPI.version = 4
+	err := s.runSuspendRelation(c, "123")
+	c.Assert(err, gc.ErrorMatches, "suspending a relation is not supported by this version of Juju")
+	s.mockAPI.CheckCall(c, 0, "Close")
+}
+
+func (s *SuspendRelationSuite) TestSuspendRelationSuccess(c *gc.C) {
+	err := s.runSuspendRelation(c, "123")
+	c.Assert(err, jc.ErrorIsNil)
+	s.mockAPI.CheckCall(c, 0, "SetRelationStatus", 123, relation.Suspended)
+	s.mockAPI.CheckCall(c, 1, "Close")
+}
+
+func (s *SuspendRelationSuite) TestSuspendRelationFail(c *gc.C) {
+	msg := "fail suspend-relation at API"
+	s.mockAPI.SetErrors(errors.New(msg))
+	err := s.runSuspendRelation(c, "123")
+	c.Assert(err, gc.ErrorMatches, msg)
+	s.mockAPI.CheckCall(c, 0, "SetRelationStatus", 123, relation.Suspended)
+	s.mockAPI.CheckCall(c, 1, "Close")
+}
+
+func (s *SuspendRelationSuite) TestSuspendRelationBlocked(c *gc.C) {
+	s.mockAPI.SetErrors(common.OperationBlockedError("TestSuspendRelationBlocked"))
+	err := s.runSuspendRelation(c, "123")
+	coretesting.AssertOperationWasBlocked(c, err, ".*TestSuspendRelationBlocked.*")
+	s.mockAPI.CheckCall(c, 0, "SetRelationStatus", 123, relation.Suspended)
+	s.mockAPI.CheckCall(c, 1, "Close")
+}
+
+type mockSuspendAPI struct {
+	*testing.Stub
+	version             int
+	suspendRelationFunc func(relationId int, status relation.Status) error
+}
+
+func (s mockSuspendAPI) Close() error {
+	s.MethodCall(s, "Close")
+	return s.NextErr()
+}
+
+func (s mockSuspendAPI) SetRelationStatus(relationId int, status relation.Status) error {
+	s.MethodCall(s, "SetRelationStatus", relationId, status)
+	return s.suspendRelationFunc(relationId, status)
+}
+
+func (s mockSuspendAPI) BestAPIVersion() int {
+	return s.version
+}

--- a/cmd/juju/commands/main.go
+++ b/cmd/juju/commands/main.go
@@ -279,6 +279,8 @@ func registerCommands(r commandRegistry, ctx *cmd.Context) {
 		r.Register(crossmodel.NewListEndpointsCommand())
 		r.Register(crossmodel.NewFindEndpointsCommand())
 		r.Register(application.NewConsumeCommand())
+		r.Register(application.NewSuspendRelationCommand())
+		r.Register(application.NewResumeRelationCommand())
 	}
 
 	// Destruction commands.

--- a/cmd/juju/commands/main_test.go
+++ b/cmd/juju/commands/main_test.go
@@ -558,7 +558,9 @@ var commandNamesBehindFlags = set.NewStrings(
 	"list-offers",
 	"offer",
 	"offers",
+	"resume-relation",
 	"show-endpoints",
+	"suspend-relation",
 )
 
 func (s *MainSuite) TestHelpCommands(c *gc.C) {

--- a/cmd/juju/crossmodel/listformatter.go
+++ b/cmd/juju/crossmodel/listformatter.go
@@ -123,7 +123,7 @@ func formatListEndpointsTabular(writer io.Writer, offers offeredApplications) er
 			}
 			connEp := endpoints[conn.Endpoint]
 			w.Print(conn.Username, conn.RelationId)
-			w.PrintColor(relationStatusColor(relation.Status(conn.Status)), conn.Status)
+			w.PrintColor(RelationStatusColor(relation.Status(conn.Status)), conn.Status)
 			w.Println(connEp.Name, connEp.Interface, connEp.Role)
 		}
 	}
@@ -131,11 +131,12 @@ func formatListEndpointsTabular(writer io.Writer, offers offeredApplications) er
 	return nil
 }
 
-func relationStatusColor(status relation.Status) *ansiterm.Context {
+// RelationStatusColor returns a context used to print the status with the relevant color.
+func RelationStatusColor(status relation.Status) *ansiterm.Context {
 	switch status {
 	case relation.Joined:
 		return output.GoodHighlight
-	case relation.Revoked:
+	case relation.Suspended:
 		return output.WarningHighlight
 	case relation.Broken:
 		return output.ErrorHighlight

--- a/cmd/juju/status/formatted.go
+++ b/cmd/juju/status/formatted.go
@@ -277,4 +277,5 @@ type relationStatus struct {
 	Requirer  string
 	Interface string
 	Type      string
+	Status    string
 }

--- a/cmd/juju/status/formatter.go
+++ b/cmd/juju/status/formatter.go
@@ -254,6 +254,7 @@ func (sf *statusFormatter) formatRelation(rel params.RelationStatus) relationSta
 		Requirer:  fmt.Sprintf("%s:%s", requirer.ApplicationName, requirer.Name),
 		Interface: rel.Interface,
 		Type:      relType,
+		Status:    rel.Status,
 	}
 	return out
 }

--- a/cmd/juju/status/output_tabular.go
+++ b/cmd/juju/status/output_tabular.go
@@ -16,8 +16,10 @@ import (
 	"gopkg.in/juju/charm.v6-unstable"
 	"gopkg.in/juju/charm.v6-unstable/hooks"
 
+	cmdcrossmodel "github.com/juju/juju/cmd/juju/crossmodel"
 	"github.com/juju/juju/cmd/output"
 	"github.com/juju/juju/core/crossmodel"
+	"github.com/juju/juju/core/relation"
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/status"
 )
@@ -195,9 +197,15 @@ func FormatTabular(writer io.Writer, forceColor bool, value interface{}) error {
 			}
 			return a.Provider < b.Provider
 		})
-		outputHeaders("Relation provider", "Requirer", "Interface", "Type")
+		outputHeaders("Relation provider", "Requirer", "Interface", "Type", "Message")
 		for _, r := range fs.Relations {
-			p(r.Provider, r.Requirer, r.Interface, r.Type)
+			status := ""
+			if r.Status != string(relation.Joined) {
+				status = r.Status
+			}
+			w.Print(r.Provider, r.Requirer, r.Interface, r.Type)
+			w.PrintColor(cmdcrossmodel.RelationStatusColor(relation.Status(status)), status)
+			w.Println()
 		}
 	}
 

--- a/core/relation/status.go
+++ b/core/relation/status.go
@@ -13,7 +13,7 @@ const (
 	// Broken is the status for when a relation life goes to Dead.
 	Broken Status = "broken"
 
-	// Revoked is used to signify that a relation is temporarily broken pending
-	// action to unrevoke it.
-	Revoked Status = "revoked"
+	// Suspended is used to signify that a relation is temporarily broken pending
+	// action to resume it.
+	Suspended Status = "suspended"
 )

--- a/state/application_test.go
+++ b/state/application_test.go
@@ -2392,7 +2392,7 @@ func (s *ApplicationSuite) TestWatchRelations(c *gc.C) {
 	wpxWatcherC.AssertChange(relx.String())
 	wpxWatcherC.AssertNoChange()
 
-	err = relx.SetStatus(status.Revoked)
+	err = relx.SetStatus(status.Suspended)
 	c.Assert(err, jc.ErrorIsNil)
 	wpxWatcherC.AssertChange(relx.String())
 	wpxWatcherC.AssertNoChange()

--- a/state/offerconnections.go
+++ b/state/offerconnections.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/juju/errors"
 	"gopkg.in/juju/names.v2"
+	"gopkg.in/mgo.v2"
 	"gopkg.in/mgo.v2/bson"
 	"gopkg.in/mgo.v2/txn"
 )
@@ -180,8 +181,11 @@ func (st *State) OfferConnectionForRelation(relationKey string) (*OfferConnectio
 
 	var connDoc offerConnectionDoc
 	err := offerConnectionCollection.Find(bson.D{{"relation-key", relationKey}}).One(&connDoc)
+	if err == mgo.ErrNotFound {
+		return nil, errors.NotFoundf("offer connection for relation %q", relationKey)
+	}
 	if err != nil {
-		return nil, errors.Errorf("cannot get offer connection details for relation %q", relationKey)
+		return nil, errors.Annotatef(err, "cannot get offer connection details for relation %q", relationKey)
 	}
 	return newOfferConnection(st, &connDoc), nil
 }

--- a/state/offerconnections_test.go
+++ b/state/offerconnections_test.go
@@ -75,3 +75,26 @@ func (s *offerConnectionsSuite) TestAddOfferConnectionTwice(c *gc.C) {
 	})
 	c.Assert(err, jc.Satisfies, errors.IsAlreadyExists)
 }
+
+func (s *offerConnectionsSuite) TestOfferConnectionForRelation(c *gc.C) {
+	oc, err := s.State.AddOfferConnection(state.AddOfferConnectionParams{
+		SourceModelUUID: testing.ModelTag.Id(),
+		RelationId:      1,
+		RelationKey:     "rel-key",
+		Username:        "fred",
+		OfferUUID:       "offer-uuid",
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	anotherState, err := s.State.ForModel(s.State.ModelTag())
+	c.Assert(err, jc.ErrorIsNil)
+	defer anotherState.Close()
+
+	_, err = anotherState.OfferConnectionForRelation("some-key")
+	c.Assert(err, jc.Satisfies, errors.IsNotFound)
+	obtained, err := anotherState.OfferConnectionForRelation("rel-key")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(obtained.RelationId(), gc.Equals, oc.RelationId())
+	c.Assert(obtained.RelationKey(), gc.Equals, oc.RelationKey())
+	c.Assert(obtained.OfferUUID(), gc.Equals, oc.OfferUUID())
+}

--- a/state/relation_test.go
+++ b/state/relation_test.go
@@ -487,7 +487,7 @@ func (s *RelationSuite) TestWatchLifeStatus(c *gc.C) {
 	wc.AssertChange(rel.Tag().Id())
 	wc.AssertNoChange()
 
-	err = rel.SetStatus(status.Revoked)
+	err = rel.SetStatus(status.Suspended)
 	c.Assert(err, jc.ErrorIsNil)
 	wc.AssertChange(rel.Tag().Id())
 	wc.AssertNoChange()
@@ -529,10 +529,10 @@ func (s *RelationSuite) TestStatus(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	relStatus := rel.Status()
 	c.Assert(relStatus, gc.Equals, status.Joined)
-	err = rel.SetStatus(status.Revoked)
+	err = rel.SetStatus(status.Suspended)
 	c.Assert(err, jc.ErrorIsNil)
 	err = rel.Refresh()
 	c.Assert(err, jc.ErrorIsNil)
 	relStatus = rel.Status()
-	c.Assert(relStatus, gc.Equals, status.Revoked)
+	c.Assert(relStatus, gc.Equals, status.Suspended)
 }

--- a/status/status.go
+++ b/status/status.go
@@ -192,9 +192,9 @@ const (
 	// Broken is the status for when a relation life goes to Dead.
 	Broken Status = "broken"
 
-	// Revoked is used to signify that a relation is temporarily broken pending
-	// action to unrevoke it.
-	Revoked Status = "revoked"
+	// Suspended is used to signify that a relation is temporarily broken pending
+	// action to resume it.
+	Suspended Status = "suspended"
 )
 
 const (

--- a/worker/remoterelations/relationunitsworker.go
+++ b/worker/remoterelations/relationunitsworker.go
@@ -127,7 +127,6 @@ func (w *relationUnitsWorker) relationUnitsChangeEvent(
 	// Construct the event to send to the remote model.
 	event := &params.RemoteRelationChangeEvent{
 		RelationToken:    w.remoteRelationToken,
-		Life:             params.Alive,
 		ApplicationToken: w.applicationToken,
 		Macaroons:        macaroon.Slice{w.macaroon},
 		DepartedUnits:    make([]int, len(change.Departed)),

--- a/worker/remoterelations/remoterelations_test.go
+++ b/worker/remoterelations/remoterelations_test.go
@@ -308,7 +308,6 @@ func (s *remoteRelationsSuite) TestLocalRelationsChangedNotifies(c *gc.C) {
 				Unit:     "unit-unit-1"}}}},
 		{"PublishRelationChange", []interface{}{
 			params.RemoteRelationChangeEvent{
-				Life:             params.Alive,
 				ApplicationToken: "token-django",
 				RelationToken:    "token-db2:db django:db",
 				ChangedUnits: []params.RemoteRelationUnitChange{{
@@ -344,7 +343,6 @@ func (s *remoteRelationsSuite) TestRemoteRelationsChangedConsumes(c *gc.C) {
 				Macaroons:     macaroon.Slice{mac}}}}},
 		{"ConsumeRemoteRelationChange", []interface{}{
 			params.RemoteRelationChangeEvent{
-				Life:             params.Alive,
 				ApplicationToken: "token-offer-db2-uuid",
 				RelationToken:    "token-db2:db django:db",
 				ChangedUnits: []params.RemoteRelationUnitChange{{

--- a/worker/uniter/relation/state.go
+++ b/worker/uniter/relation/state.go
@@ -184,6 +184,12 @@ func (d *StateDir) Ensure() error {
 	return os.MkdirAll(d.path, 0755)
 }
 
+// Exists returns true if the directory for this state exists.
+func (d *StateDir) Exists() bool {
+	_, err := os.Stat(d.path)
+	return err == nil
+}
+
 // Write atomically writes to disk the relation state change in hi.
 // It must be called after the respective hook was executed successfully.
 // Write doesn't validate hi but guarantees that successive writes of

--- a/worker/uniter/relation/state_test.go
+++ b/worker/uniter/relation/state_test.go
@@ -38,8 +38,12 @@ func (s *StateDirSuite) TestReadStateDirEmpty(c *gc.C) {
 	_, err = os.Stat(reldir)
 	c.Assert(err, jc.Satisfies, os.IsNotExist)
 
+	exists := dir.Exists()
+	c.Assert(exists, jc.IsFalse)
 	err = dir.Ensure()
 	c.Assert(err, jc.ErrorIsNil)
+	exists = dir.Exists()
+	c.Assert(exists, jc.IsTrue)
 	fi, err := os.Stat(reldir)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(fi, jc.Satisfies, os.FileInfo.IsDir)


### PR DESCRIPTION
## Description of change

Cross model relations to application offers can be suspended/resumed.
$ juju suspend-relation 123
$ juju resume-relation 123

A suspended relation will have the departed/broken hooks run but the relation remains in the model with the status "suspended". Similarly, a resumed relation will run the joined/changed hooks and the relation status becomes "joined".

## QA steps

Deploy a CMR scenario, mediawiki, mysql
On mysql model:
$ juju suspend-relation 1
verify that relation breaks, hooks are run using show-status-log, check list-offers shows suspended
$ juju resume-relation 1
verify that relation is repaired, hooks are run, list-offers shows joined

