### PR TITLE
No longer cache model count on controller in client store.

### DIFF
--- a/cmd/juju/backups/restore_test.go
+++ b/cmd/juju/backups/restore_test.go
@@ -252,9 +252,8 @@ func (s *restoreSuite) TestRestoreReboostrapWritesUpdatedControllerInfo(c *gc.C)
 		ControllerUUID: "deadbeef-1bad-500d-9000-4b1d0d06f00d",
 		APIEndpoints:   []string{"10.0.0.1:17777"},
 		AgentVersion:   version.Current.String(),
-		// We won't get correct model and machine counts until
+		// We won't get correct machine count until
 		// we connect properly eventually.
-		ModelCount:             nil,
 		MachineCount:           nil,
 		ControllerMachineCount: 1,
 	})

--- a/cmd/juju/commands/bootstrap.go
+++ b/cmd/juju/commands/bootstrap.go
@@ -616,7 +616,6 @@ See `[1:] + "`juju kill-controller`" + `.`)
 			PublicDNSName:          newStringIfNonEmpty(config.controller.AutocertDNSName()),
 			MachineCount:           newInt(1),
 			ControllerMachineCount: newInt(1),
-			ModelCount:             newInt(2), // controller model + default model
 		}); err != nil {
 		return errors.Annotate(err, "saving bootstrap endpoint address")
 	}

--- a/cmd/juju/commands/bootstrap_test.go
+++ b/cmd/juju/commands/bootstrap_test.go
@@ -490,7 +490,6 @@ func (s *BootstrapSuite) TestBootstrapDefaultControllerName(c *gc.C) {
 	c.Assert(currentController, gc.Equals, "dummy-cloud-region-1")
 	details, err := s.store.ControllerByName(currentController)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(*details.ModelCount, gc.Equals, 2)
 	c.Assert(*details.MachineCount, gc.Equals, 1)
 	c.Assert(details.AgentVersion, gc.Equals, jujuversion.Current.String())
 }
@@ -534,7 +533,6 @@ func (s *BootstrapSuite) TestBootstrapSetsControllerDetails(c *gc.C) {
 	c.Assert(currentController, gc.Equals, "devcontroller")
 	details, err := s.store.ControllerByName(currentController)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(*details.ModelCount, gc.Equals, 2)
 	c.Assert(*details.MachineCount, gc.Equals, 1)
 	c.Assert(details.AgentVersion, gc.Equals, jujuversion.Current.String())
 }

--- a/cmd/juju/controller/listcontrollers.go
+++ b/cmd/juju/controller/listcontrollers.go
@@ -160,8 +160,6 @@ func (c *listControllersCommand) refreshControllerDetails(client ControllerAcces
 		return err
 	}
 
-	modelCount := len(allModels)
-	details.ModelCount = &modelCount
 	machineCount := 0
 	for _, s := range modelStatus {
 		machineCount += s.TotalMachineCount

--- a/cmd/juju/controller/listcontrollers_test.go
+++ b/cmd/juju/controller/listcontrollers_test.go
@@ -49,8 +49,8 @@ func (s *ListControllersSuite) TestListControllers(c *gc.C) {
 Use --refresh flag with this command to see the latest information.
 
 Controller           Model             User   Access     Cloud/Region        Models  Machines  HA  Version
-aws-test             admin/controller  -      -          aws/us-east-1            2         5   -  2.0.1      
-mallards*            my-model          admin  superuser  mallards/mallards1       -         -   -  (unknown)  
+aws-test             admin/controller  -      -          aws/us-east-1            1         5   -  2.0.1      
+mallards*            my-model          admin  superuser  mallards/mallards1       2         -   -  (unknown)  
 mark-test-prodstack  -                 admin  (unknown)  prodstack                -         -   -  (unknown)  
 
 `[1:]
@@ -202,7 +202,7 @@ func (s *ListControllersSuite) TestListControllersJson(c *gc.C) {
 				Cloud:          "aws",
 				CloudRegion:    "us-east-1",
 				AgentVersion:   "2.0.1",
-				ModelCount:     intPtr(2),
+				ModelCount:     intPtr(1),
 				MachineCount:   intPtr(5),
 			},
 			"mallards": {
@@ -215,6 +215,7 @@ func (s *ListControllersSuite) TestListControllersJson(c *gc.C) {
 				CACert:         "this-is-another-ca-cert",
 				Cloud:          "mallards",
 				CloudRegion:    "mallards1",
+				ModelCount:     intPtr(2),
 			},
 			"mark-test-prodstack": {
 				ControllerUUID: "this-is-a-uuid",

--- a/cmd/juju/controller/listcontrollersconverters.go
+++ b/cmd/juju/controller/listcontrollersconverters.go
@@ -97,6 +97,11 @@ func (c *listControllersCommand) convertControllerDetails(storeControllers map[s
 				}
 			}
 		}
+		models, err := c.store.AllModels(controllerName)
+		if err != nil && !errors.IsNotFound(err) {
+			addError("models", controllerName, err)
+		}
+		modelCount := len(models)
 
 		item := ControllerItem{
 			ModelName:      modelName,
@@ -113,8 +118,8 @@ func (c *listControllersCommand) convertControllerDetails(storeControllers map[s
 		if details.MachineCount != nil && *details.MachineCount > 0 {
 			item.MachineCount = details.MachineCount
 		}
-		if details.ModelCount != nil && *details.ModelCount > 0 {
-			item.ModelCount = details.ModelCount
+		if modelCount > 0 {
+			item.ModelCount = &modelCount
 		}
 		if details.ControllerMachineCount > 0 {
 			item.ControllerMachines = &ControllerMachines{

--- a/cmd/juju/controller/showcontroller.go
+++ b/cmd/juju/controller/showcontroller.go
@@ -165,9 +165,6 @@ func (c *showControllerCommand) Run(ctx *cmd.Context) error {
 		}
 		c.convertControllerForShow(&details, controllerName, one, access, allModels, modelStatus)
 		controllers[controllerName] = details
-		// Refresh local store for this controller
-		modelCount := len(allModels)
-		one.ModelCount = &modelCount
 		machineCount := 0
 		for _, s := range modelStatus {
 			machineCount += s.TotalMachineCount

--- a/cmd/juju/romulus/showwallet/show_wallet_test.go
+++ b/cmd/juju/romulus/showwallet/show_wallet_test.go
@@ -175,11 +175,8 @@ func newMockClientStore() jujuclient.ClientStore {
 }
 
 func (s *mockClientStore) AllControllers() (map[string]jujuclient.ControllerDetails, error) {
-	n := 3
 	return map[string]jujuclient.ControllerDetails{
-		"c": jujuclient.ControllerDetails{
-			ModelCount: &n,
-		},
+		"c": jujuclient.ControllerDetails{},
 	}, nil
 }
 

--- a/cmd/juju/romulus/sla/sla_test.go
+++ b/cmd/juju/romulus/sla/sla_test.go
@@ -242,11 +242,8 @@ func (s *supportCommandSuite) newMockClientStore() jujuclient.ClientStore {
 }
 
 func (s *mockClientStore) AllControllers() (map[string]jujuclient.ControllerDetails, error) {
-	n := 3
 	return map[string]jujuclient.ControllerDetails{
-		"c": jujuclient.ControllerDetails{
-			ModelCount: &n,
-		},
+		"c": jujuclient.ControllerDetails{},
 	}, nil
 }
 

--- a/featuretests/cmd_juju_controller_test.go
+++ b/featuretests/cmd_juju_controller_test.go
@@ -78,7 +78,7 @@ func (s *cmdControllerSuite) TestControllerListCommand(c *gc.C) {
 Use --refresh flag with this command to see the latest information.
 
 Controller  Model       User   Access     Cloud/Region        Models  Machines  HA  Version
-kontroll*   controller  admin  superuser  dummy/dummy-region       -         -   -  (unknown)  
+kontroll*   controller  admin  superuser  dummy/dummy-region       1         -   -  (unknown)  
 
 `[1:]
 	c.Assert(cmdtesting.Stdout(context), gc.Equals, expectedOutput)

--- a/juju/api.go
+++ b/juju/api.go
@@ -241,6 +241,7 @@ type UpdateControllerParams struct {
 	PublicDNSName *string
 
 	// ModelCount (when set) is the number of models visible to the user.
+	// TODO (anastasiamac) is this now needed since we no longer store controller models count?
 	ModelCount *int
 
 	// ControllerMachineCount (when set) is the total number of controller machines in the environment.
@@ -288,9 +289,6 @@ func updateControllerDetailsFromLogin(
 	newDetails.AgentVersion = params.AgentVersion
 	newDetails.APIEndpoints = hostPorts
 	newDetails.DNSCache = params.DNSCache
-	if params.ModelCount != nil {
-		newDetails.ModelCount = params.ModelCount
-	}
 	if params.MachineCount != nil {
 		newDetails.MachineCount = params.MachineCount
 	}

--- a/juju/api.go
+++ b/juju/api.go
@@ -240,10 +240,6 @@ type UpdateControllerParams struct {
 	// PublicDNSName (when set) holds the public host name of the controller.
 	PublicDNSName *string
 
-	// ModelCount (when set) is the number of models visible to the user.
-	// TODO (anastasiamac) is this now needed since we no longer store controller models count?
-	ModelCount *int
-
 	// ControllerMachineCount (when set) is the total number of controller machines in the environment.
 	ControllerMachineCount *int
 

--- a/jujuclient/interface.go
+++ b/jujuclient/interface.go
@@ -58,11 +58,6 @@ type ControllerDetails struct {
 	// does not need to hit the server.
 	ActiveControllerMachineCount int `yaml:"active-controller-machine-count"`
 
-	// ModelCount is the number of models to which a user has access.
-	// It is cached here so under normal usage list-controllers
-	// does not need to hit the server.
-	ModelCount *int `yaml:"model-count,omitempty"`
-
 	// MachineCount is the number of machines in all models to
 	// which a user has access. It is cached here so under normal
 	// usage list-controllers does not need to hit the server.


### PR DESCRIPTION
## Description of change

It is now redundant and incorrect to keep controller model count in controller section of client side.
This information when needed, for 'controllers' and 'show-controller' commands output, is deduced from models collection contained in model section.

All references to ControllerDetails.ModelCount have been removed from the code. Added a test in jujuclient package to read old version of controllers file with model-count, update it with new information without model-count ensuring nothing breaks.

Question to reviewer :D It seems that ModelCount in api.go is now then redundant too... I have left a TODO at its declaration and would appreciate a 2nd opinion.

## QA steps

1. bootstrap
Client side controllers file should not have model-count
2. add a model
3. run 'show-controller'
4. run 'controllers'
[Model count displayed should be 3, prior to this PR was 2.
This is happening because show-controller updated client side models store and list-controllers read from it instead of having its own copy.]

## Documentation changes

n/a - internal change

## Bug reference

n/a
