### PR TITLE
provider/oracle: release/import volume support

### DIFF
--- a/provider/oracle/environ_test.go
+++ b/provider/oracle/environ_test.go
@@ -68,7 +68,7 @@ func (e *environSuite) TestInstanceAvailabilityZoneNamesWithErrors(c *gc.C) {
 		environs.OpenParams{
 			Config: testing.ModelConfig(c),
 		},
-		oracletesting.FakeEnvironAPI{
+		&oracletesting.FakeEnvironAPI{
 			FakeInstancer: oracletesting.FakeInstancer{
 				InstanceErr: errors.New("FakeInstanceErr"),
 			},
@@ -86,7 +86,7 @@ func (e *environSuite) TestInstanceAvailabilityZoneNamesWithErrors(c *gc.C) {
 		environs.OpenParams{
 			Config: testing.ModelConfig(c),
 		},
-		oracletesting.FakeEnvironAPI{
+		&oracletesting.FakeEnvironAPI{
 			FakeInstance: oracletesting.FakeInstance{
 				AllErr: errors.New("FakeInstanceErr"),
 			},
@@ -115,7 +115,7 @@ func (e *environSuite) TestPrepareForBootstrapWithErrors(c *gc.C) {
 		environs.OpenParams{
 			Config: testing.ModelConfig(c),
 		},
-		oracletesting.FakeEnvironAPI{
+		&oracletesting.FakeEnvironAPI{
 			FakeAuthenticater: oracletesting.FakeAuthenticater{
 				AuthenticateErr: errors.New("FakeAuthenticateErr"),
 			},
@@ -180,7 +180,7 @@ func (e *environSuite) TestCreateWithErrors(c *gc.C) {
 		environs.OpenParams{
 			Config: testing.ModelConfig(c),
 		},
-		oracletesting.FakeEnvironAPI{
+		&oracletesting.FakeEnvironAPI{
 			FakeAuthenticater: oracletesting.FakeAuthenticater{
 				AuthenticateErr: errors.New("FakeAuthenticateErr"),
 			},

--- a/provider/oracle/images_test.go
+++ b/provider/oracle/images_test.go
@@ -29,7 +29,7 @@ func (i imageSuite) TestGetImageNameWithErrors(c *gc.C) {
 	_, err := oracle.GetImageName(oracletesting.DefaultEnvironAPI, "")
 	c.Assert(err, gc.NotNil)
 
-	_, err = oracle.GetImageName(oracletesting.FakeEnvironAPI{
+	_, err = oracle.GetImageName(&oracletesting.FakeEnvironAPI{
 		FakeImager: oracletesting.FakeImager{
 			AllErr: errors.New("FakeImageListErr"),
 		}}, "0")
@@ -44,7 +44,7 @@ func (i imageSuite) TestCheckImageList(c *gc.C) {
 }
 
 func (i imageSuite) TestCheckImageListWithErrors(c *gc.C) {
-	_, err := oracle.CheckImageList(oracletesting.FakeEnvironAPI{
+	_, err := oracle.CheckImageList(&oracletesting.FakeEnvironAPI{
 		FakeImager: oracletesting.FakeImager{
 			AllErr: errors.New("FakeImageListErr"),
 		},

--- a/provider/oracle/testing/fakestorageapi.go
+++ b/provider/oracle/testing/fakestorageapi.go
@@ -7,6 +7,7 @@ import (
 	"github.com/juju/go-oracle-cloud/api"
 	"github.com/juju/go-oracle-cloud/common"
 	"github.com/juju/go-oracle-cloud/response"
+	"github.com/juju/testing"
 
 	"github.com/juju/juju/provider/oracle"
 )
@@ -22,6 +23,8 @@ func (f FakeComposer) ComposeName(name string) string {
 
 // FakeStorageVolume implements the common.StorageVolumeAPI
 type FakeStorageVolume struct {
+	testing.Stub
+
 	StorageVolume    response.StorageVolume
 	StorageVolumeErr error
 	Create           response.StorageVolume
@@ -35,19 +38,28 @@ type FakeStorageVolume struct {
 
 var _ oracle.StorageAPI = (*FakeStorageAPI)(nil)
 
-func (f FakeStorageVolume) AllStorageVolumes([]api.Filter) (response.AllStorageVolumes, error) {
+func (f *FakeStorageVolume) AllStorageVolumes(filter []api.Filter) (response.AllStorageVolumes, error) {
+	f.MethodCall(f, "AllStorageVolumes", filter)
 	return f.All, f.AllErr
 }
-func (f FakeStorageVolume) StorageVolumeDetails(string) (response.StorageVolume, error) {
+
+func (f *FakeStorageVolume) StorageVolumeDetails(name string) (response.StorageVolume, error) {
+	f.MethodCall(f, "StorageVolumeDetails", name)
 	return f.StorageVolume, f.StorageVolumeErr
 }
-func (f FakeStorageVolume) CreateStorageVolume(api.StorageVolumeParams) (response.StorageVolume, error) {
+
+func (f *FakeStorageVolume) CreateStorageVolume(params api.StorageVolumeParams) (response.StorageVolume, error) {
+	f.MethodCall(f, "CreateStorageVolume", params)
 	return f.Create, f.CreateErr
 }
-func (f FakeStorageVolume) DeleteStorageVolume(string) error {
+
+func (f *FakeStorageVolume) DeleteStorageVolume(name string) error {
+	f.MethodCall(f, "DeleteStorageVolume", name)
 	return f.DeleteErr
 }
-func (f FakeStorageVolume) UpdateStorageVolume(api.StorageVolumeParams, string) (response.StorageVolume, error) {
+
+func (f *FakeStorageVolume) UpdateStorageVolume(params api.StorageVolumeParams, name string) (response.StorageVolume, error) {
+	f.MethodCall(f, "UpdateStorageVolume", params, name)
 	return f.Update, f.UpdateErr
 }
 
@@ -142,7 +154,7 @@ var (
 				Quota:            nil,
 				Readonly:         false,
 				Shared:           false,
-				Size:             10,
+				Size:             10485760,
 				Snapshot:         nil,
 				Snapshot_account: "",
 				Snapshot_id:      "",


### PR DESCRIPTION
## Description of change

Add support for releasing and import volumes from/into
an Oracle model. Tags are removed and added respectively.

## QA steps

1. juju bootstrap oracle
2. juju deploy cs:~axwalk/storagetest --storage fs=oracle,1G
3. juju remove-storage --no-destroy fs/0
(wait, check it's still in console)
4. juju import-filesystem oracle \<volume-id\> fs
(should be imported as fs/1)
5. juju attach-storage storagetest/0 fs/1
(wait, should attach correctly)
6. juju destroy-controller -y oracle --destroy-all-models --destroy-storage

## Documentation changes

None.

## Bug reference

None.