### PR TITLE
Relate via

### DIFF
--- a/api/application/client.go
+++ b/api/application/client.go
@@ -469,9 +469,9 @@ func (c *Client) CharmRelations(application string) ([]string, error) {
 }
 
 // AddRelation adds a relation between the specified endpoints and returns the relation info.
-func (c *Client) AddRelation(endpoints ...string) (*params.AddRelationResults, error) {
+func (c *Client) AddRelation(endpoints, viaCIDRs []string) (*params.AddRelationResults, error) {
 	var addRelRes params.AddRelationResults
-	params := params.AddRelation{Endpoints: endpoints}
+	params := params.AddRelation{Endpoints: endpoints, ViaCIDRs: viaCIDRs}
 	err := c.facade.FacadeCall("AddRelation", params, &addRelRes)
 	return &addRelRes, err
 }

--- a/apiserver/common/firewall/egressaddresswatcher.go
+++ b/apiserver/common/firewall/egressaddresswatcher.go
@@ -107,7 +107,7 @@ func (w *EgressAddressWatcher) initialise() error {
 	if err != nil {
 		return err
 	}
-	w.knownEgress = set.NewStrings(cfg.EgressCidrs()...)
+	w.knownEgress = set.NewStrings(cfg.EgressSubnets()...)
 	return nil
 }
 
@@ -184,7 +184,7 @@ func (w *EgressAddressWatcher) loop() error {
 			if err != nil {
 				return err
 			}
-			egress := set.NewStrings(cfg.EgressCidrs()...)
+			egress := set.NewStrings(cfg.EgressSubnets()...)
 			// Have the egress addresses changed.
 			if egress.Size() != w.knownEgress.Size() ||
 				egress.Difference(w.knownEgress).Size() != 0 || w.knownEgress.Difference(egress).Size() != 0 {

--- a/apiserver/common/firewall/egressaddresswatcher_test.go
+++ b/apiserver/common/firewall/egressaddresswatcher_test.go
@@ -401,7 +401,7 @@ func (s *addressWatcherSuite) TestHandlesUnitGoneWhenMachineAddressChanges(c *gc
 }
 
 func (s *addressWatcherSuite) TestEgressAddressConfigured(c *gc.C) {
-	s.st.configAttrs["egress-cidrs"] = "10.0.0.1/16"
+	s.st.configAttrs["egress-subnets"] = "10.0.0.1/16"
 	rel := s.setupRelation(c, "54.1.2.3")
 	w, err := firewall.NewEgressAddressWatcher(s.st, rel, "django")
 	c.Assert(err, jc.ErrorIsNil)
@@ -421,13 +421,13 @@ func (s *addressWatcherSuite) TestEgressAddressConfigured(c *gc.C) {
 	wc.AssertNoChange()
 
 	// Change user configured egress addresses.
-	s.st.configAttrs["egress-cidrs"] = "192.168.0.1/16"
+	s.st.configAttrs["egress-subnets"] = "192.168.0.1/16"
 	s.st.modelWatcher.changes <- struct{}{}
 	wc.AssertChange("192.168.0.1/16")
 	wc.AssertNoChange()
 
 	// Reset user configured egress addresses.
-	s.st.configAttrs["egress-cidrs"] = ""
+	s.st.configAttrs["egress-subnets"] = ""
 	s.st.modelWatcher.changes <- struct{}{}
 	wc.AssertChange("54.1.2.3/32")
 	wc.AssertNoChange()

--- a/apiserver/common/firewall/firewall_test.go
+++ b/apiserver/common/firewall/firewall_test.go
@@ -47,6 +47,8 @@ func (s *FirewallSuite) SetUpTest(c *gc.C) {
 func (s *FirewallSuite) TestWatchEgressAddressesForRelations(c *gc.C) {
 	db2Relation := newMockRelation(123)
 	db2Relation.ruwApp = "django"
+	// Initial event.
+	db2Relation.ew.changes <- []string{}
 	db2Relation.endpoints = []state.Endpoint{
 		{
 			ApplicationName: "django",
@@ -103,6 +105,8 @@ func (s *FirewallSuite) TestWatchEgressAddressesForRelations(c *gc.C) {
 
 func (s *FirewallSuite) TestWatchEgressAddressesForRelationsIgnoresProvider(c *gc.C) {
 	db2Relation := newMockRelation(123)
+	// Initial event.
+	db2Relation.ew.changes <- []string{}
 	db2Relation.endpoints = []state.Endpoint{
 		{
 			ApplicationName: "db2",

--- a/apiserver/common/firewall/mock_test.go
+++ b/apiserver/common/firewall/mock_test.go
@@ -266,6 +266,7 @@ type mockRelation struct {
 	key       string
 	endpoints []state.Endpoint
 	ruw       *mockRelationUnitsWatcher
+	ew        *mockStringsWatcher
 	ruwApp    string
 	inScope   set.Strings
 }
@@ -274,6 +275,7 @@ func newMockRelation(id int) *mockRelation {
 	return &mockRelation{
 		id:      id,
 		ruw:     newMockRelationUnitsWatcher(),
+		ew:      newMockStringsWatcher(),
 		inScope: make(set.Strings),
 	}
 }
@@ -297,6 +299,10 @@ func (r *mockRelation) WatchUnits(applicationName string) (state.RelationUnitsWa
 
 func (r *mockRelation) UnitInScope(u firewall.Unit) (bool, error) {
 	return r.inScope.Contains(u.Name()), nil
+}
+
+func (r *mockRelation) WatchRelationEgressNetworks() state.StringsWatcher {
+	return r.ew
 }
 
 func newMockRelationUnitsWatcher() *mockRelationUnitsWatcher {

--- a/apiserver/common/firewall/state.go
+++ b/apiserver/common/firewall/state.go
@@ -49,6 +49,7 @@ type Relation interface {
 	WatchUnits(applicationName string) (state.RelationUnitsWatcher, error)
 	UnitInScope(Unit) (bool, error)
 	WatchRelationIngressNetworks() state.StringsWatcher
+	WatchRelationEgressNetworks() state.StringsWatcher
 }
 
 type relationShim struct {

--- a/apiserver/facades/client/application/application_unit_test.go
+++ b/apiserver/facades/client/application/application_unit_test.go
@@ -838,3 +838,15 @@ func (s *ApplicationSuite) TestApplicationUpdateSeriesPermissionDenied(c *gc.C) 
 	)
 	c.Assert(err, gc.ErrorMatches, "permission denied")
 }
+
+func (s *ApplicationSuite) TestRemoteRelationBadCIDR(c *gc.C) {
+	endpoints := []string{"wordpress", "hosted-mysql:nope"}
+	_, err := s.api.AddRelation(params.AddRelation{Endpoints: endpoints, ViaCIDRs: []string{"bad.cidr"}})
+	c.Assert(err, gc.ErrorMatches, `invalid CIDR address: bad.cidr`)
+}
+
+func (s *ApplicationSuite) TestRemoteRelationDisAllowedCIDR(c *gc.C) {
+	endpoints := []string{"wordpress", "hosted-mysql:nope"}
+	_, err := s.api.AddRelation(params.AddRelation{Endpoints: endpoints, ViaCIDRs: []string{"0.0.0.0/0"}})
+	c.Assert(err, gc.ErrorMatches, `CIDR "0.0.0.0/0" not allowed`)
+}

--- a/apiserver/facades/client/application/backend.go
+++ b/apiserver/facades/client/application/backend.go
@@ -40,6 +40,7 @@ type Backend interface {
 	ControllerTag() names.ControllerTag
 	Resources() (Resources, error)
 	OfferConnectionForRelation(string) (OfferConnection, error)
+	SaveEgressNetworks(relationKey string, cidrs []string) (state.RelationNetworks, error)
 }
 
 // BlockChecker defines the block-checking functionality required by
@@ -216,6 +217,11 @@ func (s stateShim) AddRelation(eps ...state.Endpoint) (Relation, error) {
 		return nil, err
 	}
 	return stateRelationShim{r}, nil
+}
+
+func (s stateShim) SaveEgressNetworks(relationKey string, cidrs []string) (state.RelationNetworks, error) {
+	api := state.NewRelationEgressNetworks(s.State)
+	return api.Save(relationKey, cidrs)
 }
 
 func (s stateShim) Charm(curl *charm.URL) (Charm, error) {

--- a/apiserver/facades/client/client/perm_test.go
+++ b/apiserver/facades/client/client/perm_test.go
@@ -191,7 +191,7 @@ func (s *permSuite) TestOperationPerm(c *gc.C) {
 }
 
 func opClientAddRelation(c *gc.C, st api.Connection, mst *state.State) (func(), error) {
-	_, err := application.NewClient(st).AddRelation("nosuch1", "nosuch2")
+	_, err := application.NewClient(st).AddRelation([]string{"nosuch1", "nosuch2"}, nil)
 	if params.IsCodeNotFound(err) {
 		err = nil
 	}

--- a/apiserver/params/params.go
+++ b/apiserver/params/params.go
@@ -115,6 +115,7 @@ type ErrorResult struct {
 // The endpoints specified are unordered.
 type AddRelation struct {
 	Endpoints []string `json:"endpoints"`
+	ViaCIDRs  []string `json:"via-cidrs,omitempty"`
 }
 
 // AddRelationResults holds the results of a AddRelation call. The Endpoints

--- a/cmd/juju/application/addremoterelation_test.go
+++ b/cmd/juju/application/addremoterelation_test.go
@@ -30,14 +30,14 @@ var _ = gc.Suite(&AddRemoteRelationSuiteNewAPI{})
 
 func (s *AddRemoteRelationSuiteNewAPI) SetUpTest(c *gc.C) {
 	s.baseAddRemoteRelationSuite.SetUpTest(c)
-	s.mockAPI.version = 3
+	s.mockAPI.version = 5
 }
 
 func (s *AddRemoteRelationSuiteNewAPI) TestAddRelationNoRemoteApplications(c *gc.C) {
 	err := s.runAddRelation(c, "applicationname2", "applicationname")
 	c.Assert(err, jc.ErrorIsNil)
 	s.mockAPI.CheckCallNames(c, "AddRelation", "Close")
-	s.mockAPI.CheckCall(c, 0, "AddRelation", []string{"applicationname2", "applicationname"})
+	s.mockAPI.CheckCall(c, 0, "AddRelation", []string{"applicationname2", "applicationname"}, []string(nil))
 }
 
 func (s *AddRemoteRelationSuiteNewAPI) TestAddRelationRemoteApplications(c *gc.C) {
@@ -56,7 +56,7 @@ func (s *AddRemoteRelationSuiteNewAPI) TestAddRelationToOneRemoteApplication(c *
 			ApplicationAlias: "applicationname2",
 			Macaroon:         s.mac,
 		})
-	s.mockAPI.CheckCall(c, 4, "AddRelation", []string{"applicationname", "applicationname2"})
+	s.mockAPI.CheckCall(c, 4, "AddRelation", []string{"applicationname", "applicationname2"}, []string(nil))
 }
 
 func (s *AddRemoteRelationSuiteNewAPI) TestAddRelationAnyRemoteApplication(c *gc.C) {
@@ -71,18 +71,26 @@ func (s *AddRemoteRelationSuiteNewAPI) TestAddRelationAnyRemoteApplication(c *gc
 			ApplicationAlias: "applicationname2",
 			Macaroon:         s.mac,
 		})
-	s.mockAPI.CheckCall(c, 4, "AddRelation", []string{"applicationname2", "applicationname"})
+	s.mockAPI.CheckCall(c, 4, "AddRelation", []string{"applicationname2", "applicationname"}, []string(nil))
 }
 
 func (s *AddRemoteRelationSuiteNewAPI) TestAddRelationFailure(c *gc.C) {
 	msg := "add relation failure"
-	s.mockAPI.addRelation = func(endpoints ...string) (*params.AddRelationResults, error) {
+	s.mockAPI.addRelation = func(endpoints, viaCIDRs []string) (*params.AddRelationResults, error) {
 		return nil, errors.New(msg)
 	}
 
 	err := s.runAddRelation(c, "othermodel.applicationname2", "applicationname")
 	c.Assert(err, gc.ErrorMatches, msg)
 	s.mockAPI.CheckCallNames(c, "BestAPIVersion", "GetConsumeDetails", "Consume", "Close", "AddRelation", "Close")
+}
+
+func (s *AddRemoteRelationSuiteNewAPI) TestAddedRelationVia(c *gc.C) {
+	err := s.runAddRelation(c, "othermodel.applicationname2", "applicationname", "--via", "192.168.1.0/16, 10.0.0.0/16")
+	c.Assert(err, jc.ErrorIsNil)
+	s.mockAPI.CheckCallNames(c, "BestAPIVersion", "GetConsumeDetails", "Consume", "Close", "AddRelation", "Close")
+	s.mockAPI.CheckCall(c, 4, "AddRelation",
+		[]string{"applicationname2", "applicationname"}, []string{"192.168.1.0/16", "10.0.0.0/16"})
 }
 
 func (s *AddRemoteRelationSuiteNewAPI) assertAddedRelation(c *gc.C, args ...string) {
@@ -107,6 +115,21 @@ func (s *AddRemoteRelationSuiteOldAPI) TestAddRelationRemoteApplications(c *gc.C
 func (s *AddRemoteRelationSuiteOldAPI) TestAddRelationToOneRemoteApplication(c *gc.C) {
 	err := s.runAddRelation(c, "applicationname", "othermodel.applicationname2")
 	c.Assert(err, gc.ErrorMatches, regexp.QuoteMeta("cannot add relation to othermodel.applicationname2: remote endpoints not supported"))
+}
+
+func (s *AddRemoteRelationSuiteOldAPI) TestAddRelationNoRemoteApplicationsVia(c *gc.C) {
+	err := s.runAddRelation(c, "applicationname", "applicationname2", "--via", "192.168.0.0/16")
+	c.Assert(err, gc.ErrorMatches, regexp.QuoteMeta("the --via option can only be used when relating to offers in a different model"))
+}
+
+func (s *AddRemoteRelationSuiteOldAPI) TestAddRelationViaBadCidr(c *gc.C) {
+	err := s.runAddRelation(c, "applicationname", "othermodel.applicationname2", "--via", "bad.cidr")
+	c.Assert(err, gc.ErrorMatches, regexp.QuoteMeta(`invalid CIDR address: bad.cidr`))
+}
+
+func (s *AddRemoteRelationSuiteOldAPI) TestAddRelationViaDisallowedCidr(c *gc.C) {
+	err := s.runAddRelation(c, "applicationname", "othermodel.applicationname2", "--via", "0.0.0.0/0")
+	c.Assert(err, gc.ErrorMatches, regexp.QuoteMeta(`CIDR "0.0.0.0/0" not allowed`))
 }
 
 // AddRelationValidationSuite has input validation tests.
@@ -161,7 +184,7 @@ func (s *baseAddRemoteRelationSuite) SetUpTest(c *gc.C) {
 	s.mac, err = macaroon.New(nil, "id", "loc")
 	c.Assert(err, jc.ErrorIsNil)
 	s.mockAPI = &mockAddRelationAPI{
-		addRelation: func(endpoints ...string) (*params.AddRelationResults, error) {
+		addRelation: func(endpoints, viaCIDRs []string) (*params.AddRelationResults, error) {
 			return nil, nil
 		},
 		mac: s.mac,
@@ -190,7 +213,7 @@ type mockAddRelationAPI struct {
 	jtesting.Stub
 
 	// addRelation can be defined by tests to test different add-relation outcomes.
-	addRelation func(endpoints ...string) (*params.AddRelationResults, error)
+	addRelation func(endpoints, viaCidrs []string) (*params.AddRelationResults, error)
 
 	// version can be overwritten by tests interested in different behaviour based on client version.
 	version int
@@ -198,9 +221,9 @@ type mockAddRelationAPI struct {
 	mac *macaroon.Macaroon
 }
 
-func (m *mockAddRelationAPI) AddRelation(endpoints ...string) (*params.AddRelationResults, error) {
-	m.AddCall("AddRelation", endpoints)
-	return m.addRelation(endpoints...)
+func (m *mockAddRelationAPI) AddRelation(endpoints, viaCIDRs []string) (*params.AddRelationResults, error) {
+	m.AddCall("AddRelation", endpoints, viaCIDRs)
+	return m.addRelation(endpoints, viaCIDRs)
 }
 
 func (m *mockAddRelationAPI) Close() error {

--- a/cmd/juju/application/bundle.go
+++ b/cmd/juju/application/bundle.go
@@ -511,7 +511,8 @@ func (h *bundleHandler) addMachine(id string, p bundlechanges.AddMachineParams) 
 func (h *bundleHandler) addRelation(id string, p bundlechanges.AddRelationParams) error {
 	ep1 := resolveRelation(p.Endpoint1, h.results)
 	ep2 := resolveRelation(p.Endpoint2, h.results)
-	_, err := h.api.AddRelation(ep1, ep2)
+	// TODO(wallyworld) - CMR support in bundles
+	_, err := h.api.AddRelation([]string{ep1, ep2}, nil)
 	if err == nil {
 		// A new relation has been established.
 		h.log.Infof("Related %q and %q", ep1, ep2)

--- a/cmd/juju/application/deploy.go
+++ b/cmd/juju/application/deploy.go
@@ -47,7 +47,7 @@ type CharmAdder interface {
 
 type ApplicationAPI interface {
 	AddMachines(machineParams []apiparams.AddMachineParams) ([]apiparams.AddMachinesResult, error)
-	AddRelation(endpoints ...string) (*apiparams.AddRelationResults, error)
+	AddRelation(endpoints, viaCIDRs []string) (*apiparams.AddRelationResults, error)
 	AddUnits(application.AddUnitsParams) ([]string, error)
 	Expose(application string) error
 	GetCharmURL(serviceName string) (*charm.URL, error)

--- a/cmd/juju/application/deploy_test.go
+++ b/cmd/juju/application/deploy_test.go
@@ -1402,7 +1402,7 @@ func (s *DeployUnitTestSuite) TestDeployBundle_OutputsCorrectMessage(c *gc.C) {
 		NumUnits:        1,
 	}).Returns([]string{"wordpress/0"}, error(nil))
 
-	fakeAPI.Call("AddRelation", "wordpress:db", "mysql:server").Returns(
+	fakeAPI.Call("AddRelation", []interface{}{"wordpress:db", "mysql:server"}, []interface{}{}).Returns(
 		&params.AddRelationResults{},
 		error(nil),
 	)
@@ -1577,8 +1577,8 @@ func (f *fakeDeployAPI) WatchAll() (*api.AllWatcher, error) {
 	return results[0].(*api.AllWatcher), jujutesting.TypeAssertError(results[1])
 }
 
-func (f *fakeDeployAPI) AddRelation(endpoints ...string) (*params.AddRelationResults, error) {
-	results := f.MethodCall(f, "AddRelation", variadicStringToInterface(endpoints...)...)
+func (f *fakeDeployAPI) AddRelation(endpoints, viaCIDRs []string) (*params.AddRelationResults, error) {
+	results := f.MethodCall(f, "AddRelation", stringToInterface(endpoints), stringToInterface(viaCIDRs))
 	return results[0].(*params.AddRelationResults), jujutesting.TypeAssertError(results[1])
 }
 
@@ -1622,7 +1622,7 @@ func (f *fakeDeployAPI) AddMachines(machineParams []params.AddMachineParams) ([]
 	return results[0].([]params.AddMachinesResult), jujutesting.TypeAssertError(results[0])
 }
 
-func variadicStringToInterface(args ...string) []interface{} {
+func stringToInterface(args []string) []interface{} {
 	interfaceArgs := make([]interface{}, len(args))
 	for i, a := range args {
 		interfaceArgs[i] = a

--- a/environs/config/config.go
+++ b/environs/config/config.go
@@ -550,10 +550,13 @@ func Validate(cfg, old *Config) error {
 	}
 
 	if v, ok := cfg.defined[EgressSubnets].(string); ok && v != "" {
-		addresses := strings.Split(v, ",")
-		for _, addr := range addresses {
-			if _, _, err := net.ParseCIDR(strings.TrimSpace(addr)); err != nil {
-				return errors.Annotatef(err, "invalid egress address: %v", addr)
+		cidrs := strings.Split(v, ",")
+		for _, cidr := range cidrs {
+			if _, _, err := net.ParseCIDR(strings.TrimSpace(cidr)); err != nil {
+				return errors.Annotatef(err, "invalid egress subnet: %v", cidr)
+			}
+			if cidr == "0.0.0.0/0" {
+				return errors.Errorf("CIDR %q not allowed", cidr)
 			}
 		}
 	}

--- a/environs/config/config.go
+++ b/environs/config/config.go
@@ -161,9 +161,9 @@ const (
 	// UpdateStatusHookInterval is how often to run the update-status hook.
 	UpdateStatusHookInterval = "update-status-hook-interval"
 
-	// EgressCidrs are the source addresses from which traffic from this model
+	// EgressSubnets are the source addresses from which traffic from this model
 	// originates if the model is deployed such that NAT or similar is in use.
-	EgressCidrs = "egress-cidrs"
+	EgressSubnets = "egress-subnets"
 
 	//
 	// Deprecated Settings Attributes
@@ -367,7 +367,7 @@ var defaultConfigValues = map[string]interface{}{
 	"test-mode":                false,
 	TransmitVendorMetricsKey:   true,
 	UpdateStatusHookInterval:   DefaultUpdateStatusHookInterval,
-	EgressCidrs:                "",
+	EgressSubnets:              "",
 
 	// Image and agent streams and URLs.
 	"image-stream":       "released",
@@ -549,7 +549,7 @@ func Validate(cfg, old *Config) error {
 		}
 	}
 
-	if v, ok := cfg.defined[EgressCidrs].(string); ok && v != "" {
+	if v, ok := cfg.defined[EgressSubnets].(string); ok && v != "" {
 		addresses := strings.Split(v, ",")
 		for _, addr := range addresses {
 			if _, _, err := net.ParseCIDR(strings.TrimSpace(addr)); err != nil {
@@ -1023,10 +1023,10 @@ func (c *Config) UpdateStatusHookInterval() time.Duration {
 	return val
 }
 
-// EgressCidrs are the source addresses from which traffic from this model
+// EgressSubnets are the source addresses from which traffic from this model
 // originates if the model is deployed such that NAT or similar is in use.
-func (c *Config) EgressCidrs() []string {
-	raw := c.asString(EgressCidrs)
+func (c *Config) EgressSubnets() []string {
+	raw := c.asString(EgressSubnets)
 	if raw == "" {
 		return []string{}
 	}
@@ -1149,7 +1149,7 @@ var alwaysOptional = schema.Defaults{
 	MaxActionResultsAge:          schema.Omit,
 	MaxActionResultsSize:         schema.Omit,
 	UpdateStatusHookInterval:     schema.Omit,
-	EgressCidrs:                  schema.Omit,
+	EgressSubnets:                schema.Omit,
 }
 
 func allowEmpty(attr string) bool {
@@ -1546,7 +1546,7 @@ data of the store. (default false)`,
 		Type:        environschema.Tstring,
 		Group:       environschema.EnvironGroup,
 	},
-	EgressCidrs: {
+	EgressSubnets: {
 		Description: "Source address(es) for traffic originating from this model",
 		Type:        environschema.Tstring,
 		Group:       environschema.EnvironGroup,

--- a/environs/config/config_test.go
+++ b/environs/config/config_test.go
@@ -1124,11 +1124,11 @@ func (s *ConfigSuite) TestUpdateStatusHookIntervalConfigValue(c *gc.C) {
 	c.Assert(cfg.UpdateStatusHookInterval(), gc.Equals, 30*time.Minute)
 }
 
-func (s *ConfigSuite) TestEgressCidrs(c *gc.C) {
+func (s *ConfigSuite) TestEgressSubnets(c *gc.C) {
 	cfg := newTestConfig(c, testing.Attrs{
-		"egress-cidrs": "10.0.0.1/32, 192.168.1.1/16",
+		"egress-subnets": "10.0.0.1/32, 192.168.1.1/16",
 	})
-	c.Assert(cfg.EgressCidrs(), gc.DeepEquals, []string{"10.0.0.1/32", "192.168.1.1/16"})
+	c.Assert(cfg.EgressSubnets(), gc.DeepEquals, []string{"10.0.0.1/32", "192.168.1.1/16"})
 }
 
 func (s *ConfigSuite) TestSchemaNoExtra(c *gc.C) {

--- a/state/relationunit.go
+++ b/state/relationunit.go
@@ -495,7 +495,7 @@ func (ru *RelationUnit) IngressAddress() (network.Address, error) {
 	if err != nil {
 		return network.Address{}, errors.Trace(err)
 	}
-	cidrs := cfg.EgressCidrs()
+	cidrs := cfg.EgressSubnets()
 	if len(cidrs) > 0 {
 		ip, _, err := net.ParseCIDR(cidrs[0])
 		if err != nil {

--- a/state/relationunit_test.go
+++ b/state/relationunit_test.go
@@ -869,8 +869,8 @@ func (s *RelationUnitSuite) TestIngressAddressRemoteRelationNoPublicAddr(c *gc.C
 	c.Assert(address, gc.DeepEquals, network.NewScopedAddress("1.2.3.4", network.ScopeCloudLocal))
 }
 
-func (s *RelationUnitSuite) TestIngressAddressRemoteRelationEgressCidrs(c *gc.C) {
-	err := s.State.UpdateModelConfig(map[string]interface{}{"egress-cidrs": "192.168.1.0/32"}, nil)
+func (s *RelationUnitSuite) TestIngressAddressRemoteRelationEgressSubnets(c *gc.C) {
+	err := s.State.UpdateModelConfig(map[string]interface{}{"egress-subnets": "192.168.1.0/32"}, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	prr := newRemoteProReqRelation(c, &s.ConnSuite)
 	err = prr.ru0.AssignToNewMachine()

--- a/state/watcher.go
+++ b/state/watcher.go
@@ -2921,9 +2921,15 @@ type relationNetworksWatcher struct {
 var _ Watcher = (*relationNetworksWatcher)(nil)
 
 // WatchRelationIngressNetworks starts and returns a StringsWatcher notifying
-// of changes to the relationNetworks collection for the relation.
+// of ingress changes to the relationNetworks collection for the relation.
 func (r *Relation) WatchRelationIngressNetworks() StringsWatcher {
 	return newrelationNetworksWatcher(r.st, r.Tag().Id(), ingress)
+}
+
+// WatchRelationEgressNetworks starts and returns a StringsWatcher notifying
+// of egress changes to the relationNetworks collection for the relation.
+func (r *Relation) WatchRelationEgressNetworks() StringsWatcher {
+	return newrelationNetworksWatcher(r.st, r.Tag().Id(), egress)
 }
 
 func newrelationNetworksWatcher(st modelBackend, relationKey, direction string) StringsWatcher {


### PR DESCRIPTION
## Description of change

We now support adding a remote relation and specifying the egress subnets from which outbound traffic will originate. This compliments the existing model wide config attribute "egress-subnets".

The first commit renames the model attribute "egress-cidrs" to "egress-subnets".
The second commit addes the --via support.

The UX is "juju add-relation foo bar --via cidr1,cidr2,..."

## QA steps

juju bootstrap aws dbctrl
juju deploy mysql
juju offer mysql:db

From behind a firewall or cgnat:
juju bootstrap lxd mwctrl
juju deploy mediawiki
juju relate mediawiki:db dbctrl:defauly.mysql --via <what's-my-ip>/32

check aws firewall ports and check that media wiki is operational
