### PR TITLE
Remove post-up/pre-down from original interface when bridging

### DIFF
--- a/network/debinterfaces/bridge.go
+++ b/network/debinterfaces/bridge.go
@@ -19,6 +19,8 @@ var bridgeOnlyOptions = []string{
 	"dns-nameservers",
 	"dns-search",
 	"dns-sortlist",
+	"post-up",
+	"pre-down",
 }
 
 func pruneOptions(options []string, names ...string) []string {


### PR DESCRIPTION
## Description of change
We left post-up/pre-down on the original interface when bridging. This fixes this issue.

## QA steps
Have a host with  interface with static routes in pre-down/post-up in e/n/i, add a container on it, check if the routes were moved to proper bridge and removed from the interface

## Documentation changes
None

## Bug reference
Related to https://bugs.launchpad.net/juju/+bug/1709849