### PR TITLE
provider/azure: use managed disks

### DIFF
--- a/provider/azure/environ.go
+++ b/provider/azure/environ.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/arm/compute"
+	"github.com/Azure/azure-sdk-for-go/arm/disk"
 	"github.com/Azure/azure-sdk-for-go/arm/network"
 	"github.com/Azure/azure-sdk-for-go/arm/resources/resources"
 	"github.com/Azure/azure-sdk-for-go/arm/storage"
@@ -65,7 +66,7 @@ const (
 	// used for controller machines.
 	controllerAvailabilitySet = "juju-controller"
 
-	computeAPIVersion = "2016-03-30"
+	computeAPIVersion = "2016-04-30-preview"
 	networkAPIVersion = "2017-03-01"
 	storageAPIVersion = "2016-12-01"
 )
@@ -100,6 +101,7 @@ type azureEnviron struct {
 	authorizer *cloudSpecAuth
 
 	compute            compute.ManagementClient
+	disk               disk.ManagementClient
 	resources          resources.ManagementClient
 	storage            storage.ManagementClient
 	network            network.ManagementClient
@@ -109,7 +111,7 @@ type azureEnviron struct {
 	mu                     sync.Mutex
 	config                 *azureModelConfig
 	instanceTypes          map[string]instances.InstanceType
-	storageAccount         *storage.Account
+	storageAccount         **storage.Account
 	storageAccountKey      *storage.AccountKey
 	commonResourcesCreated bool
 }
@@ -171,11 +173,13 @@ func (env *azureEnviron) initEnviron() error {
 	}
 
 	env.compute = compute.NewWithBaseURI(env.cloud.Endpoint, env.subscriptionId)
+	env.disk = disk.NewWithBaseURI(env.cloud.Endpoint, env.subscriptionId)
 	env.resources = resources.NewWithBaseURI(env.cloud.Endpoint, env.subscriptionId)
 	env.storage = storage.NewWithBaseURI(env.cloud.Endpoint, env.subscriptionId)
 	env.network = network.NewWithBaseURI(env.cloud.Endpoint, env.subscriptionId)
 	clients := map[string]*autorest.Client{
 		"azure.compute":   &env.compute.Client,
+		"azure.disk":      &env.disk.Client,
 		"azure.resources": &env.resources.Client,
 		"azure.storage":   &env.storage.Client,
 		"azure.network":   &env.network.Client,
@@ -249,7 +253,6 @@ func (env *azureEnviron) initResourceGroup(controllerUUID string, controller boo
 		names.NewControllerTag(controllerUUID),
 		env.config,
 	)
-	storageAccountType := env.config.storageAccountType
 	env.mu.Unlock()
 
 	logger.Debugf("creating resource group %q", env.resourceGroup)
@@ -267,29 +270,28 @@ func (env *azureEnviron) initResourceGroup(controllerUUID string, controller boo
 		// e.g. those made by the firewaller. For the controller model,
 		// we fold the creation of these resources into the bootstrap
 		// machine's deployment.
-		if err := env.createCommonResourceDeployment(
-			tags, storageAccountType, nil,
-		); err != nil {
+		if err := env.createCommonResourceDeployment(tags, nil); err != nil {
 			return errors.Trace(err)
 		}
 	}
+
+	// New models are not given a storage account. Initialise the
+	// storage account pointer to a pointer to a nil pointer, so
+	// "getStorageAccount" avoids making an API call.
+	env.storageAccount = new(*storage.Account)
+
 	return nil
 }
 
 func (env *azureEnviron) createCommonResourceDeployment(
 	tags map[string]string,
-	storageAccountType string,
 	rules []network.SecurityRule,
+	commonResources ...armtemplates.Resource,
 ) error {
 	const apiPort = -1
-	commonResources := networkTemplateResources(
+	commonResources = append(commonResources, networkTemplateResources(
 		env.location, tags, apiPort, rules,
-	)
-	commonResources = append(commonResources, storageAccountTemplateResource(
-		env.location, tags,
-		env.storageAccountName,
-		storageAccountType,
-	))
+	)...)
 
 	// We perform this deployment asynchronously, to avoid blocking
 	// the "juju add-model" command; Create is called synchronously.
@@ -579,19 +581,12 @@ func (env *azureEnviron) createVirtualMachine(
 	if createCommonResources {
 		// We're starting the bootstrap machine, so we will create the
 		// common resources in the same deployment.
-		commonResources := networkTemplateResources(env.location, envTags, apiPort, nil)
-		commonResources = append(commonResources, storageAccountTemplateResource(
-			env.location, envTags,
-			env.storageAccountName, storageAccountType,
-		))
-		resources = append(resources, commonResources...)
+		resources = append(resources,
+			networkTemplateResources(env.location, envTags, apiPort, nil)...,
+		)
 		nicDependsOn = append(nicDependsOn, fmt.Sprintf(
 			`[resourceId('Microsoft.Network/virtualNetworks', '%s')]`,
 			internalNetworkName,
-		))
-		vmDependsOn = append(vmDependsOn, fmt.Sprintf(
-			`[resourceId('Microsoft.Storage/storageAccounts', '%s')]`,
-			env.storageAccountName,
 		))
 	} else {
 		// Wait for the common resource deployment to complete.
@@ -602,6 +597,17 @@ func (env *azureEnviron) createVirtualMachine(
 		}
 	}
 
+	maybeStorageAccount, err := env.getStorageAccount()
+	if errors.IsNotFound(err) {
+		// Only models created prior to Juju 2.3 will have a storage
+		// account. Juju 2.3 onwards exclusively uses managed disks
+		// for all new models, and handles both managed and unmanaged
+		// disks for upgraded models.
+		maybeStorageAccount = nil
+	} else if err != nil {
+		return errors.Trace(err)
+	}
+
 	osProfile, seriesOS, err := newOSProfile(
 		vmName, instanceConfig,
 		env.provider.config.RandomWindowsAdminPassword,
@@ -610,7 +616,12 @@ func (env *azureEnviron) createVirtualMachine(
 	if err != nil {
 		return errors.Annotate(err, "creating OS profile")
 	}
-	storageProfile, err := newStorageProfile(vmName, env.storageAccountName, instanceSpec)
+	storageProfile, err := newStorageProfile(
+		vmName,
+		maybeStorageAccount,
+		storageAccountType,
+		instanceSpec,
+	)
 	if err != nil {
 		return errors.Annotate(err, "creating storage profile")
 	}
@@ -627,12 +638,32 @@ func (env *azureEnviron) createVirtualMachine(
 			`[resourceId('Microsoft.Compute/availabilitySets','%s')]`,
 			availabilitySetName,
 		)
+		var availabilitySetProperties interface{}
+		if maybeStorageAccount == nil {
+			// This model uses managed disks; we must create
+			// the availability set as "aligned" to support
+			// them.
+			availabilitySetProperties = &compute.AvailabilitySetProperties{
+				// Managed means the availability set is
+				// "aligned", allowing managed disks to be
+				// used.
+				Managed: to.BoolPtr(true),
+
+				// Azure complains when the fault domain count
+				// is not specified, even though it is meant
+				// to be optional and default to the maximum.
+				// The maximum depends on the location, and
+				// there is no API to query it.
+				PlatformFaultDomainCount: to.Int32Ptr(maxFaultDomains(env.location)),
+			}
+		}
 		resources = append(resources, armtemplates.Resource{
 			APIVersion: computeAPIVersion,
 			Type:       "Microsoft.Compute/availabilitySets",
 			Name:       availabilitySetName,
 			Location:   env.location,
 			Tags:       envTags,
+			Properties: availabilitySetProperties,
 		})
 		availabilitySetSubResource = &compute.SubResource{
 			ID: to.StringPtr(availabilitySetId),
@@ -768,6 +799,32 @@ func (env *azureEnviron) createVirtualMachine(
 	return nil
 }
 
+// maxFaultDomains returns the maximum number of fault domains for the
+// given location/region. The numbers were taken from
+// https://docs.microsoft.com/en-au/azure/virtual-machines/windows/manage-availability,
+// as at 31 August 2017.
+func maxFaultDomains(location string) int32 {
+	// From the page linked in the doc comment:
+	// "The number of fault domains for managed availability sets varies
+	// by region - either two or three per region."
+	//
+	// We record those that at the time of writing have 3. Anything
+	// else has at least 2, so we just assume 2.
+	switch location {
+	case
+		"eastus",
+		"eastus2",
+		"westus",
+		"centralus",
+		"northcentralus",
+		"southcentralus",
+		"northeurope",
+		"westeurope":
+		return 3
+	}
+	return 2
+}
+
 // waitCommonResourcesCreated waits for the "common" deployment to complete.
 func (env *azureEnviron) waitCommonResourcesCreated() error {
 	env.mu.Lock()
@@ -775,10 +832,38 @@ func (env *azureEnviron) waitCommonResourcesCreated() error {
 	if env.commonResourcesCreated {
 		return nil
 	}
-	if err := env.waitCommonResourcesCreatedLocked(); err != nil {
+	deployment, err := env.waitCommonResourcesCreatedLocked()
+	if err != nil {
 		return errors.Trace(err)
 	}
 	env.commonResourcesCreated = true
+	if deployment != nil {
+		// Check if the common deployment created
+		// a storage account. If it didn't, we can
+		// avoid a query for the storage account.
+		var hasStorageAccount bool
+		if deployment.Properties.Providers != nil {
+			for _, p := range *deployment.Properties.Providers {
+				if to.String(p.Namespace) != "Microsoft.Storage" {
+					continue
+				}
+				if p.ResourceTypes == nil {
+					continue
+				}
+				for _, rt := range *p.ResourceTypes {
+					if to.String(rt.ResourceType) != "storageAccounts" {
+						continue
+					}
+					hasStorageAccount = true
+					break
+				}
+				break
+			}
+		}
+		if !hasStorageAccount {
+			env.storageAccount = new(*storage.Account)
+		}
+	}
 	return nil
 }
 
@@ -786,7 +871,7 @@ type deploymentIncompleteError struct {
 	error
 }
 
-func (env *azureEnviron) waitCommonResourcesCreatedLocked() error {
+func (env *azureEnviron) waitCommonResourcesCreatedLocked() (*resources.DeploymentExtended, error) {
 	deploymentsClient := resources.DeploymentsClient{env.resources}
 
 	// Release the lock while we're waiting, to avoid blocking others.
@@ -797,6 +882,7 @@ func (env *azureEnviron) waitCommonResourcesCreatedLocked() error {
 	// for the "common" deployment to be in one of the terminal
 	// states. The deployment typically takes only around 30 seconds,
 	// but we allow for a longer duration to be defensive.
+	var deployment *resources.DeploymentExtended
 	waitDeployment := func() error {
 		result, err := deploymentsClient.Get(env.resourceGroup, "common")
 		if err != nil {
@@ -818,6 +904,7 @@ func (env *azureEnviron) waitCommonResourcesCreatedLocked() error {
 		if state == "Succeeded" {
 			// The deployment has succeeded, so the resources are
 			// ready for use.
+			deployment = &result
 			return nil
 		}
 		err = errors.Errorf("common resource deployment status is %q", state)
@@ -828,7 +915,7 @@ func (env *azureEnviron) waitCommonResourcesCreatedLocked() error {
 		}
 		return err
 	}
-	return retry.Call(retry.CallArgs{
+	if err := retry.Call(retry.CallArgs{
 		Func: waitDeployment,
 		IsFatalError: func(err error) bool {
 			_, ok := err.(deploymentIncompleteError)
@@ -838,7 +925,10 @@ func (env *azureEnviron) waitCommonResourcesCreatedLocked() error {
 		Delay:       5 * time.Second,
 		MaxDuration: 5 * time.Minute,
 		Clock:       env.provider.config.RetryClock,
-	})
+	}); err != nil {
+		return nil, errors.Trace(err)
+	}
+	return deployment, nil
 }
 
 // createAvailabilitySet creates the availability set for a machine to use
@@ -883,7 +973,8 @@ func availabilitySetName(
 // based on the series and chosen instance spec.
 func newStorageProfile(
 	vmName string,
-	storageAccountName string,
+	maybeStorageAccount *storage.Account,
+	storageAccountType string,
 	instanceSpec *instances.InstanceSpec,
 ) (*compute.StorageProfile, error) {
 	logger.Debugf("creating storage profile for %q", vmName)
@@ -897,23 +988,27 @@ func newStorageProfile(
 	sku := urnParts[2]
 	version := urnParts[3]
 
-	osDisksRoot := fmt.Sprintf(
-		`reference(resourceId('Microsoft.Storage/storageAccounts', '%s'), '%s').primaryEndpoints.blob`,
-		storageAccountName, storageAPIVersion,
-	)
 	osDiskName := vmName
-	osDiskURI := fmt.Sprintf(
-		`[concat(%s, '%s/%s%s')]`,
-		osDisksRoot, osDiskVHDContainer, osDiskName, vhdExtension,
-	)
 	osDiskSizeGB := mibToGB(instanceSpec.InstanceType.RootDisk)
 	osDisk := &compute.OSDisk{
 		Name:         to.StringPtr(osDiskName),
 		CreateOption: compute.FromImage,
 		Caching:      compute.ReadWrite,
-		Vhd:          &compute.VirtualHardDisk{URI: to.StringPtr(osDiskURI)},
 		DiskSizeGB:   to.Int32Ptr(int32(osDiskSizeGB)),
 	}
+
+	if maybeStorageAccount == nil {
+		// This model uses managed disks.
+		osDisk.ManagedDisk = &compute.ManagedDiskParameters{
+			StorageAccountType: compute.StorageAccountTypes(storageAccountType),
+		}
+	} else {
+		// This model uses unmanaged disks.
+		osDiskVhdRoot := blobContainerURL(maybeStorageAccount, osDiskVHDContainer)
+		vhdURI := osDiskVhdRoot + osDiskName + vhdExtension
+		osDisk.Vhd = &compute.VirtualHardDisk{to.StringPtr(vhdURI)}
+	}
+
 	return &compute.StorageProfile{
 		ImageReference: &compute.ImageReference{
 			Publisher: to.StringPtr(publisher),
@@ -1033,14 +1128,8 @@ func (env *azureEnviron) StopInstances(ids ...instance.Id) error {
 		return nil
 	}
 
-	maybeStorageClient, err := env.getStorageClient()
-	if errors.IsNotFound(err) {
-		// It is possible, if unlikely, that the first deployment for a
-		// hosted model will fail or be canceled before the model's
-		// storage account is created. We must therefore cater for the
-		// account being missing or incomplete here.
-		maybeStorageClient = nil
-	} else if err != nil {
+	maybeStorageClient, _, err := env.maybeGetStorageClient()
+	if err != nil {
 		return errors.Trace(err)
 	}
 
@@ -1125,6 +1214,7 @@ func (env *azureEnviron) deleteVirtualMachine(
 	publicIPAddresses []network.PublicIPAddress,
 ) error {
 	vmClient := compute.VirtualMachinesClient{env.compute}
+	diskClient := disk.DisksClient{env.disk}
 	nicClient := network.InterfacesClient{env.network}
 	nsgClient := network.SecurityGroupsClient{env.network}
 	securityRuleClient := network.SecurityRulesClient{env.network}
@@ -1138,10 +1228,9 @@ func (env *azureEnviron) deleteVirtualMachine(
 	logger.Debugf("- deleting virtual machine (%s)", vmName)
 	vmResultCh, errCh := vmClient.Delete(env.resourceGroup, vmName, nil)
 	if result, err := <-vmResultCh, <-errCh; err != nil {
-		if isNotFoundResponse(result.Response) {
-			return errors.NotFoundf("virtual machine %q", vmName)
+		if !isNotFoundResponse(result.Response) {
+			return errors.Annotate(err, "deleting virtual machine")
 		}
-		return errors.Annotate(err, "deleting virtual machine")
 	}
 
 	if maybeStorageClient != nil {
@@ -1151,6 +1240,15 @@ func (env *azureEnviron) deleteVirtualMachine(
 		vhdBlob := vhdContainer.Blob(vmName)
 		_, err := vhdBlob.DeleteIfExists(nil)
 		return errors.Annotate(err, "deleting OS VHD")
+	} else {
+		// Delete the managed OS disk.
+		logger.Debugf("- deleting OS disk (%s)", vmName)
+		resultCh, errCh := diskClient.Delete(env.resourceGroup, vmName, nil)
+		if result, err := <-resultCh, <-errCh; err != nil {
+			if !isNotFoundResponse(result.Response) {
+				return errors.Annotate(err, "deleting OS disk")
+			}
+		}
 	}
 
 	logger.Debugf("- deleting security rules (%s)", vmName)
@@ -1167,10 +1265,9 @@ func (env *azureEnviron) deleteVirtualMachine(
 		logger.Tracef("deleting NIC %q", nicName)
 		resultCh, errCh := nicClient.Delete(env.resourceGroup, nicName, nil)
 		if result, err := <-resultCh, <-errCh; err != nil {
-			if isNotFoundResponse(result) {
-				return errors.NotFoundf("NIC %q", nicName)
+			if !isNotFoundResponse(result) {
+				return errors.Annotate(err, "deleting NIC")
 			}
-			return errors.Annotate(err, "deleting NIC")
 		}
 	}
 
@@ -1180,10 +1277,9 @@ func (env *azureEnviron) deleteVirtualMachine(
 		logger.Tracef("deleting public IP %q", pipName)
 		resultCh, errCh := pipClient.Delete(env.resourceGroup, pipName, nil)
 		if result, err := <-resultCh, <-errCh; err != nil {
-			if isNotFoundResponse(result) {
-				return errors.NotFoundf("public IP %q", pipName)
+			if !isNotFoundResponse(result) {
+				return errors.Annotate(err, "deleting public IP")
 			}
-			return errors.Annotate(err, "deleting public IP")
 		}
 	}
 
@@ -1191,10 +1287,9 @@ func (env *azureEnviron) deleteVirtualMachine(
 	logger.Debugf("- deleting deployment (%s)", vmName)
 	resultCh, errCh := deploymentsClient.Delete(env.resourceGroup, vmName, nil)
 	if result, err := <-resultCh, <-errCh; err != nil {
-		if isNotFoundResponse(result) {
-			return errors.NotFoundf("deployment %q", vmName)
+		if !isNotFoundResponse(result) {
+			return errors.Annotate(err, "deleting deployment")
 		}
-		return errors.Annotate(err, "deleting deployment")
 	}
 	return nil
 }
@@ -1589,20 +1684,37 @@ func (env *azureEnviron) getInstanceTypesLocked() (map[string]instances.Instance
 	return instanceTypes, nil
 }
 
+// maybeGetStorageClient returns the environment's storage client if it
+// has one, and nil if it does not.
+func (env *azureEnviron) maybeGetStorageClient() (internalazurestorage.Client, *storage.Account, error) {
+	storageClient, storageAccount, err := env.getStorageClient()
+	if errors.IsNotFound(err) {
+		// Only models created prior to Juju 2.3 will have a storage
+		// account. Juju 2.3 onwards exclusively uses managed disks
+		// for all new models, and handles both managed and unmanaged
+		// disks for upgraded models.
+		storageClient = nil
+		storageAccount = nil
+	} else if err != nil {
+		return nil, nil, errors.Trace(err)
+	}
+	return storageClient, storageAccount, nil
+}
+
 // getStorageClient queries the storage account key, and uses it to construct
 // a new storage client.
-func (env *azureEnviron) getStorageClient() (internalazurestorage.Client, error) {
+func (env *azureEnviron) getStorageClient() (internalazurestorage.Client, *storage.Account, error) {
 	env.mu.Lock()
 	defer env.mu.Unlock()
-	storageAccount, err := env.getStorageAccountLocked(false)
+	storageAccount, err := env.getStorageAccountLocked()
 	if err != nil {
-		return nil, errors.Annotate(err, "getting storage account")
+		return nil, nil, errors.Annotate(err, "getting storage account")
 	}
 	storageAccountKey, err := env.getStorageAccountKeyLocked(
 		to.String(storageAccount.Name), false,
 	)
 	if err != nil {
-		return nil, errors.Annotate(err, "getting storage account key")
+		return nil, nil, errors.Annotate(err, "getting storage account key")
 	}
 	client, err := getStorageClient(
 		env.provider.config.NewStorageClient,
@@ -1611,33 +1723,40 @@ func (env *azureEnviron) getStorageClient() (internalazurestorage.Client, error)
 		storageAccountKey,
 	)
 	if err != nil {
-		return nil, errors.Annotate(err, "getting storage client")
+		return nil, nil, errors.Annotate(err, "getting storage client")
 	}
-	return client, nil
+	return client, storageAccount, nil
 }
 
 // getStorageAccount returns the storage account for this environment's
-// resource group. If refresh is true, cached details will be refreshed.
-func (env *azureEnviron) getStorageAccount(refresh bool) (*storage.Account, error) {
+// resource group.
+func (env *azureEnviron) getStorageAccount() (*storage.Account, error) {
 	env.mu.Lock()
 	defer env.mu.Unlock()
-	return env.getStorageAccountLocked(refresh)
+	return env.getStorageAccountLocked()
 }
 
-func (env *azureEnviron) getStorageAccountLocked(refresh bool) (*storage.Account, error) {
-	if !refresh && env.storageAccount != nil {
-		return env.storageAccount, nil
+func (env *azureEnviron) getStorageAccountLocked() (*storage.Account, error) {
+	if env.storageAccount != nil {
+		if *env.storageAccount == nil {
+			return nil, errors.NotFoundf("storage account")
+		}
+		return *env.storageAccount, nil
 	}
 	client := storage.AccountsClient{env.storage}
 	account, err := client.GetProperties(env.resourceGroup, env.storageAccountName)
 	if err != nil {
 		if isNotFoundResponse(account.Response) {
+			// Remember that the account was not found
+			// by storing a pointer to a nil pointer.
+			env.storageAccount = new(*storage.Account)
 			return nil, errors.NewNotFound(err, fmt.Sprintf("storage account not found"))
 		}
-		return nil, errors.Annotate(err, "getting storage account")
+		return nil, errors.Trace(err)
 	}
-	env.storageAccount = &account
-	return env.storageAccount, nil
+	env.storageAccount = new(*storage.Account)
+	*env.storageAccount = &account
+	return &account, nil
 }
 
 // getStorageAccountKeysLocked returns a storage account key for this

--- a/provider/azure/storage.go
+++ b/provider/azure/storage.go
@@ -5,9 +5,12 @@ package azure
 
 import (
 	"fmt"
+	"path"
 	"strings"
+	"sync"
 
 	"github.com/Azure/azure-sdk-for-go/arm/compute"
+	"github.com/Azure/azure-sdk-for-go/arm/disk"
 	armstorage "github.com/Azure/azure-sdk-for-go/arm/storage"
 	azurestorage "github.com/Azure/azure-sdk-for-go/storage"
 	"github.com/Azure/go-autorest/autorest/to"
@@ -23,6 +26,10 @@ import (
 
 const (
 	azureStorageProviderType = "azure"
+
+	accountTypeAttr        = "account-type"
+	accountTypeStandardLRS = "Standard_LRS"
+	accountTypePremiumLRS  = "Premium_LRS"
 
 	// volumeSizeMaxGiB is the maximum disk size (in gibibytes) for Azure disks.
 	//
@@ -61,22 +68,33 @@ type azureStorageProvider struct {
 
 var _ storage.Provider = (*azureStorageProvider)(nil)
 
-var azureStorageConfigFields = schema.Fields{}
+var azureStorageConfigFields = schema.Fields{
+	accountTypeAttr: schema.OneOf(
+		schema.Const(accountTypeStandardLRS),
+		schema.Const(accountTypePremiumLRS),
+	),
+}
 
 var azureStorageConfigChecker = schema.FieldMap(
 	azureStorageConfigFields,
-	schema.Defaults{},
+	schema.Defaults{
+		accountTypeAttr: accountTypeStandardLRS,
+	},
 )
 
 type azureStorageConfig struct {
+	storageType disk.StorageAccountTypes
 }
 
 func newAzureStorageConfig(attrs map[string]interface{}) (*azureStorageConfig, error) {
-	_, err := azureStorageConfigChecker.Coerce(attrs, nil)
+	coerced, err := azureStorageConfigChecker.Coerce(attrs, nil)
 	if err != nil {
 		return nil, errors.Annotate(err, "validating Azure storage config")
 	}
-	azureStorageConfig := &azureStorageConfig{}
+	attrs = coerced.(map[string]interface{})
+	azureStorageConfig := &azureStorageConfig{
+		storageType: disk.StorageAccountTypes(attrs[accountTypeAttr].(string)),
+	}
 	return azureStorageConfig, nil
 }
 
@@ -105,23 +123,29 @@ func (e *azureStorageProvider) Dynamic() bool {
 func (e *azureStorageProvider) Releasable() bool {
 	// NOTE(axw) Azure storage is currently tied to a model, and cannot
 	// be released or imported. To support releasing and importing, we'll
-	// need several things:
-	//  - for the provider to use managed disks
-	//  - for Azure to support moving managed disks between resource groups
+	// need Azure to support moving managed disks between resource groups.
 	return false
 }
 
 // DefaultPools is part of the Provider interface.
 func (e *azureStorageProvider) DefaultPools() []*storage.Config {
-	return nil
+	premiumPool, _ := storage.NewConfig("azure-premium", azureStorageProviderType, map[string]interface{}{
+		accountTypeAttr: accountTypePremiumLRS,
+	})
+	return []*storage.Config{premiumPool}
 }
 
 // VolumeSource is part of the Provider interface.
 func (e *azureStorageProvider) VolumeSource(cfg *storage.Config) (storage.VolumeSource, error) {
-	if err := e.ValidateConfig(cfg); err != nil {
+	// Check to see if the environment has a storage account,
+	// which means it uses unmanaged disks. All models created
+	// before Juju 2.3 will have a storage account already, so
+	// it's safe to do the check up front.
+	maybeStorageClient, maybeStorageAccount, err := e.env.maybeGetStorageClient()
+	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	return &azureVolumeSource{e.env}, nil
+	return &azureVolumeSource{e.env, maybeStorageAccount, maybeStorageClient}, nil
 }
 
 // FilesystemSource is part of the Provider interface.
@@ -130,34 +154,96 @@ func (e *azureStorageProvider) FilesystemSource(providerConfig *storage.Config) 
 }
 
 type azureVolumeSource struct {
-	env *azureEnviron
+	env                 *azureEnviron
+	maybeStorageAccount *armstorage.Account
+	maybeStorageClient  internalazurestorage.Client
 }
 
 // CreateVolumes is specified on the storage.VolumeSource interface.
 func (v *azureVolumeSource) CreateVolumes(params []storage.VolumeParams) (_ []storage.CreateVolumesResult, err error) {
-
-	// First, validate the params before we use them.
 	results := make([]storage.CreateVolumesResult, len(params))
-	var instanceIds []instance.Id
 	for i, p := range params {
 		if err := v.ValidateVolumeParams(p); err != nil {
 			results[i].Error = err
 			continue
 		}
-		instanceIds = append(instanceIds, p.Attachment.InstanceId)
 	}
-	if len(instanceIds) == 0 {
+	if v.maybeStorageClient == nil {
+		v.createManagedDiskVolumes(params, results)
 		return results, nil
 	}
-	virtualMachines, err := v.virtualMachines(instanceIds)
-	if err != nil {
-		return nil, errors.Annotate(err, "getting virtual machines")
+	return results, v.createUnmanagedDiskVolumes(params, results)
+}
+
+// createManagedDiskVolumes creates volumes with associated managed disks.
+func (v *azureVolumeSource) createManagedDiskVolumes(params []storage.VolumeParams, results []storage.CreateVolumesResult) {
+	for i, p := range params {
+		if results[i].Error != nil {
+			continue
+		}
+		volume, err := v.createManagedDiskVolume(p)
+		if err != nil {
+			results[i].Error = err
+			continue
+		}
+		results[i].Volume = volume
 	}
-	storageAccount, err := v.env.getStorageAccount(false)
+}
+
+// createManagedDiskVolume creates a managed disk.
+func (v *azureVolumeSource) createManagedDiskVolume(p storage.VolumeParams) (*storage.Volume, error) {
+	cfg, err := newAzureStorageConfig(p.Attributes)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
 
+	diskName := p.Tag.String()
+	sizeInGib := mibToGib(p.Size)
+	diskModel := disk.Model{
+		Name:     to.StringPtr(diskName),
+		Location: to.StringPtr(v.env.location),
+		Tags:     to.StringMapPtr(p.ResourceTags),
+		Properties: &disk.Properties{
+			AccountType:  cfg.storageType,
+			CreationData: &disk.CreationData{CreateOption: disk.Empty},
+			DiskSizeGB:   to.Int32Ptr(int32(sizeInGib)),
+		},
+	}
+
+	diskClient := disk.DisksClient{v.env.disk}
+	resultCh, errCh := diskClient.CreateOrUpdate(v.env.resourceGroup, diskName, diskModel, nil)
+	result, err := <-resultCh, <-errCh
+	if err != nil {
+		return nil, errors.Annotatef(err, "creating disk for volume %q", p.Tag.Id())
+	}
+
+	volume := storage.Volume{
+		p.Tag,
+		storage.VolumeInfo{
+			VolumeId:   diskName,
+			Size:       gibToMib(uint64(to.Int32(result.DiskSizeGB))),
+			Persistent: true,
+		},
+	}
+	return &volume, nil
+}
+
+// createUnmanagedDiskVolumes creates volumes with associated unmanaged disks (blobs).
+func (v *azureVolumeSource) createUnmanagedDiskVolumes(params []storage.VolumeParams, results []storage.CreateVolumesResult) error {
+	var instanceIds []instance.Id
+	for i, p := range params {
+		if results[i].Error != nil {
+			continue
+		}
+		instanceIds = append(instanceIds, p.Attachment.InstanceId)
+	}
+	if len(instanceIds) == 0 {
+		return nil
+	}
+	virtualMachines, err := v.virtualMachines(instanceIds)
+	if err != nil {
+		return errors.Annotate(err, "getting virtual machines")
+	}
 	// Update VirtualMachine objects in-memory,
 	// and then perform the updates all at once.
 	for i, p := range params {
@@ -172,9 +258,7 @@ func (v *azureVolumeSource) CreateVolumes(params []storage.VolumeParams) (_ []st
 			results[i].Error = vm.err
 			continue
 		}
-		volume, volumeAttachment, err := v.createVolume(
-			vm.vm, p, storageAccount,
-		)
+		volume, volumeAttachment, err := v.createUnmanagedDiskVolume(vm.vm, p)
 		if err != nil {
 			results[i].Error = err
 			vm.err = err
@@ -186,7 +270,7 @@ func (v *azureVolumeSource) CreateVolumes(params []storage.VolumeParams) (_ []st
 
 	updateResults, err := v.updateVirtualMachines(virtualMachines, instanceIds)
 	if err != nil {
-		return nil, errors.Annotate(err, "updating virtual machines")
+		return errors.Annotate(err, "updating virtual machines")
 	}
 	for i, err := range updateResults {
 		if results[i].Error != nil || err == nil {
@@ -196,69 +280,75 @@ func (v *azureVolumeSource) CreateVolumes(params []storage.VolumeParams) (_ []st
 		results[i].Volume = nil
 		results[i].VolumeAttachment = nil
 	}
-	return results, nil
+	return nil
 }
 
-// createVolume updates the provided VirtualMachine's StorageProfile with the
-// parameters for creating a new data disk. We don't actually interact with
-// the Azure API until after all changes to the VirtualMachine are made.
-func (v *azureVolumeSource) createVolume(
+// createUnmanagedDiskVolume updates the provided VirtualMachine's
+// StorageProfile with the parameters for creating a new unmanaged
+// data disk. We don't actually interact with the Azure API until
+// after all changes to the VirtualMachine are made.
+func (v *azureVolumeSource) createUnmanagedDiskVolume(
 	vm *compute.VirtualMachine,
 	p storage.VolumeParams,
-	storageAccount *armstorage.Account,
 ) (*storage.Volume, *storage.VolumeAttachment, error) {
 
-	lun, err := nextAvailableLUN(vm)
-	if err != nil {
-		return nil, nil, errors.Annotate(err, "choosing LUN")
-	}
-
-	dataDisksRoot := dataDiskVhdRoot(storageAccount)
-	dataDiskName := p.Tag.String()
-	vhdURI := dataDisksRoot + dataDiskName + vhdExtension
-
+	diskName := p.Tag.String()
 	sizeInGib := mibToGib(p.Size)
-	dataDisk := compute.DataDisk{
-		Lun:          to.Int32Ptr(lun),
-		DiskSizeGB:   to.Int32Ptr(int32(sizeInGib)),
-		Name:         to.StringPtr(dataDiskName),
-		Vhd:          &compute.VirtualHardDisk{to.StringPtr(vhdURI)},
-		Caching:      compute.ReadWrite,
-		CreateOption: compute.Empty,
+	volumeAttachment, err := v.addDataDisk(
+		vm, diskName,
+		p.Tag,
+		p.Attachment.Machine,
+		compute.Empty,
+		to.Int32Ptr(int32(sizeInGib)),
+	)
+	if err != nil {
+		return nil, nil, errors.Trace(err)
 	}
-
-	var dataDisks []compute.DataDisk
-	if vm.StorageProfile.DataDisks != nil {
-		dataDisks = *vm.StorageProfile.DataDisks
-	}
-	dataDisks = append(dataDisks, dataDisk)
-	vm.StorageProfile.DataDisks = &dataDisks
-
 	// Data disks associate VHDs to machines. In Juju's storage model,
 	// the VHD is the volume and the disk is the volume attachment.
 	volume := storage.Volume{
 		p.Tag,
 		storage.VolumeInfo{
-			VolumeId: dataDiskName,
-			Size:     gibToMib(sizeInGib),
-			// We don't currently support persistent volumes in
-			// Azure, as it requires removal of "comp=media" when
-			// deleting VMs, complicating cleanup.
+			VolumeId:   diskName,
+			Size:       gibToMib(sizeInGib),
 			Persistent: true,
 		},
 	}
-	volumeAttachment := storage.VolumeAttachment{
-		p.Tag,
-		p.Attachment.Machine,
-		storage.VolumeAttachmentInfo{
-			BusAddress: diskBusAddress(lun),
-		},
-	}
-	return &volume, &volumeAttachment, nil
+	return &volume, volumeAttachment, nil
 }
 
 // ListVolumes is specified on the storage.VolumeSource interface.
 func (v *azureVolumeSource) ListVolumes() ([]string, error) {
+	if v.maybeStorageClient == nil {
+		return v.listManagedDiskVolumes()
+	}
+	return v.listUnmanagedDiskVolumes()
+}
+
+func (v *azureVolumeSource) listManagedDiskVolumes() ([]string, error) {
+	var volumeIds []string
+	diskClient := disk.DisksClient{v.env.disk}
+	list, err := diskClient.List()
+	if err != nil {
+		return nil, errors.Annotate(err, "listing disks")
+	}
+	for list.Value != nil {
+		for _, disk := range *list.Value {
+			diskName := to.String(disk.Name)
+			if _, err := names.ParseVolumeTag(diskName); err != nil {
+				continue
+			}
+			volumeIds = append(volumeIds, diskName)
+		}
+		list, err = diskClient.ListNextResults(list)
+		if err != nil {
+			return nil, errors.Annotate(err, "listing disks")
+		}
+	}
+	return volumeIds, nil
+}
+
+func (v *azureVolumeSource) listUnmanagedDiskVolumes() ([]string, error) {
 	blobs, err := v.listBlobs()
 	if err != nil {
 		return nil, errors.Annotate(err, "listing volumes")
@@ -276,11 +366,7 @@ func (v *azureVolumeSource) ListVolumes() ([]string, error) {
 
 // listBlobs returns a list of blobs in the data-disk container.
 func (v *azureVolumeSource) listBlobs() ([]internalazurestorage.Blob, error) {
-	client, err := v.env.getStorageClient()
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	blobsClient := client.GetBlobService()
+	blobsClient := v.maybeStorageClient.GetBlobService()
 	vhdContainer := blobsClient.GetContainerReference(dataDiskVHDContainer)
 	// TODO(axw) consider taking a set of IDs and computing the
 	//           longest common prefix to pass in the parameters
@@ -299,6 +385,40 @@ func (v *azureVolumeSource) listBlobs() ([]internalazurestorage.Blob, error) {
 
 // DescribeVolumes is specified on the storage.VolumeSource interface.
 func (v *azureVolumeSource) DescribeVolumes(volumeIds []string) ([]storage.DescribeVolumesResult, error) {
+	if v.maybeStorageClient == nil {
+		return v.describeManagedDiskVolumes(volumeIds)
+	}
+	return v.describeUnmanagedDiskVolumes(volumeIds)
+}
+
+func (v *azureVolumeSource) describeManagedDiskVolumes(volumeIds []string) ([]storage.DescribeVolumesResult, error) {
+	diskClient := disk.DisksClient{v.env.disk}
+	results := make([]storage.DescribeVolumesResult, len(volumeIds))
+	var wg sync.WaitGroup
+	for i, volumeId := range volumeIds {
+		wg.Add(1)
+		go func(i int, volumeId string) {
+			defer wg.Done()
+			disk, err := diskClient.Get(v.env.resourceGroup, volumeId)
+			if err != nil {
+				if isNotFoundResponse(disk.Response) {
+					err = errors.NotFoundf("disk %s", volumeId)
+				}
+				results[i].Error = err
+				return
+			}
+			results[i].VolumeInfo = &storage.VolumeInfo{
+				VolumeId:   volumeId,
+				Size:       gibToMib(uint64(to.Int32(disk.DiskSizeGB))),
+				Persistent: true,
+			}
+		}(i, volumeId)
+	}
+	wg.Wait()
+	return results, nil
+}
+
+func (v *azureVolumeSource) describeUnmanagedDiskVolumes(volumeIds []string) ([]storage.DescribeVolumesResult, error) {
 	blobs, err := v.listBlobs()
 	if err != nil {
 		return nil, errors.Annotate(err, "listing volumes")
@@ -333,23 +453,55 @@ func (v *azureVolumeSource) DescribeVolumes(volumeIds []string) ([]storage.Descr
 
 // DestroyVolumes is specified on the storage.VolumeSource interface.
 func (v *azureVolumeSource) DestroyVolumes(volumeIds []string) ([]error, error) {
-	client, err := v.env.getStorageClient()
-	if err != nil {
-		return nil, errors.Trace(err)
+	if v.maybeStorageClient == nil {
+		return v.destroyManagedDiskVolumes(volumeIds)
 	}
-	blobsClient := client.GetBlobService()
+	return v.destroyUnmanagedDiskVolumes(volumeIds)
+}
+
+func (v *azureVolumeSource) destroyManagedDiskVolumes(volumeIds []string) ([]error, error) {
+	diskClient := disk.DisksClient{v.env.disk}
+	return foreachVolume(volumeIds, func(volumeId string) error {
+		resultCh, errCh := diskClient.Delete(v.env.resourceGroup, volumeId, nil)
+		if result, err := <-resultCh, <-errCh; err != nil && !isNotFoundResponse(result.Response) {
+			return errors.Annotatef(err, "deleting disk %q", volumeId)
+		}
+		return nil
+	}), nil
+}
+
+func (v *azureVolumeSource) destroyUnmanagedDiskVolumes(volumeIds []string) ([]error, error) {
+	blobsClient := v.maybeStorageClient.GetBlobService()
 	vhdContainer := blobsClient.GetContainerReference(dataDiskVHDContainer)
-	results := make([]error, len(volumeIds))
-	for i, volumeId := range volumeIds {
+	return foreachVolume(volumeIds, func(volumeId string) error {
 		vhdBlob := vhdContainer.Blob(volumeId + vhdExtension)
-		_, results[i] = vhdBlob.DeleteIfExists(nil)
+		_, err := vhdBlob.DeleteIfExists(nil)
+		return errors.Annotatef(err, "deleting blob %q", vhdBlob.Name())
+	}), nil
+}
+
+func foreachVolume(volumeIds []string, f func(string) error) []error {
+	results := make([]error, len(volumeIds))
+	var wg sync.WaitGroup
+	for i, volumeId := range volumeIds {
+		wg.Add(1)
+		go func(i int, volumeId string) {
+			defer wg.Done()
+			results[i] = f(volumeId)
+		}(i, volumeId)
 	}
-	return results, nil
+	wg.Wait()
+	return results
 }
 
 // ReleaseVolumes is specified on the storage.VolumeSource interface.
 func (v *azureVolumeSource) ReleaseVolumes(volumeIds []string) ([]error, error) {
-	return nil, errors.NotImplementedf("ReleaseVolumes")
+	// Releasing volumes is not supported, see azureStorageProvider.Releasable.
+	//
+	// When managed disks can be moved between resource groups, we may want to
+	// support releasing unmanaged disks. We'll need to create a managed disk
+	// from the blob, and then release that.
+	return nil, errors.NotSupportedf("ReleaseVolumes")
 }
 
 // ValidateVolumeParams is specified on the storage.VolumeSource interface.
@@ -378,10 +530,6 @@ func (v *azureVolumeSource) AttachVolumes(attachParams []storage.VolumeAttachmen
 	if err != nil {
 		return nil, errors.Annotate(err, "getting virtual machines")
 	}
-	storageAccount, err := v.env.getStorageAccount(false)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
 
 	// Update VirtualMachine objects in-memory,
 	// and then perform the updates all at once.
@@ -399,9 +547,7 @@ func (v *azureVolumeSource) AttachVolumes(attachParams []storage.VolumeAttachmen
 			results[i].Error = vm.err
 			continue
 		}
-		volumeAttachment, updated, err := v.attachVolume(
-			vm.vm, p, storageAccount,
-		)
+		volumeAttachment, updated, err := v.attachVolume(vm.vm, p)
 		if err != nil {
 			results[i].Error = err
 			vm.err = err
@@ -435,27 +581,16 @@ func (v *azureVolumeSource) AttachVolumes(attachParams []storage.VolumeAttachmen
 func (v *azureVolumeSource) attachVolume(
 	vm *compute.VirtualMachine,
 	p storage.VolumeAttachmentParams,
-	storageAccount *armstorage.Account,
 ) (_ *storage.VolumeAttachment, updated bool, _ error) {
-
-	storageAccount, err := v.env.getStorageAccount(false)
-	if err != nil {
-		return nil, false, errors.Trace(err)
-	}
-
-	dataDisksRoot := dataDiskVhdRoot(storageAccount)
-	dataDiskName := p.VolumeId
-	vhdURI := dataDisksRoot + dataDiskName + vhdExtension
 
 	var dataDisks []compute.DataDisk
 	if vm.StorageProfile.DataDisks != nil {
 		dataDisks = *vm.StorageProfile.DataDisks
 	}
+
+	diskName := p.VolumeId
 	for _, disk := range dataDisks {
-		if to.String(disk.Name) != p.VolumeId {
-			continue
-		}
-		if to.String(disk.Vhd.URI) != vhdURI {
+		if to.String(disk.Name) != diskName {
 			continue
 		}
 		// Disk is already attached.
@@ -469,29 +604,61 @@ func (v *azureVolumeSource) attachVolume(
 		return volumeAttachment, false, nil
 	}
 
+	volumeAttachment, err := v.addDataDisk(vm, diskName, p.Volume, p.Machine, compute.Attach, nil)
+	if err != nil {
+		return nil, false, errors.Trace(err)
+	}
+	return volumeAttachment, true, nil
+}
+
+func (v *azureVolumeSource) addDataDisk(
+	vm *compute.VirtualMachine,
+	diskName string,
+	volumeTag names.VolumeTag,
+	machineTag names.MachineTag,
+	createOption compute.DiskCreateOptionTypes,
+	diskSizeGB *int32,
+) (*storage.VolumeAttachment, error) {
+
 	lun, err := nextAvailableLUN(vm)
 	if err != nil {
-		return nil, false, errors.Annotate(err, "choosing LUN")
+		return nil, errors.Annotate(err, "choosing LUN")
 	}
 
 	dataDisk := compute.DataDisk{
 		Lun:          to.Int32Ptr(lun),
-		Name:         to.StringPtr(dataDiskName),
-		Vhd:          &compute.VirtualHardDisk{to.StringPtr(vhdURI)},
+		Name:         to.StringPtr(diskName),
 		Caching:      compute.ReadWrite,
-		CreateOption: compute.Attach,
+		CreateOption: createOption,
+		DiskSizeGB:   diskSizeGB,
+	}
+	if v.maybeStorageAccount == nil {
+		// This model uses managed disks.
+		diskResourceID := v.diskResourceID(diskName)
+		dataDisk.ManagedDisk = &compute.ManagedDiskParameters{
+			ID: to.StringPtr(diskResourceID),
+		}
+	} else {
+		// This model uses unmanaged disks.
+		dataDisksRoot := dataDiskVhdRoot(v.maybeStorageAccount)
+		vhdURI := dataDisksRoot + diskName + vhdExtension
+		dataDisk.Vhd = &compute.VirtualHardDisk{to.StringPtr(vhdURI)}
+	}
+
+	var dataDisks []compute.DataDisk
+	if vm.StorageProfile.DataDisks != nil {
+		dataDisks = *vm.StorageProfile.DataDisks
 	}
 	dataDisks = append(dataDisks, dataDisk)
 	vm.StorageProfile.DataDisks = &dataDisks
 
-	volumeAttachment := storage.VolumeAttachment{
-		p.Volume,
-		p.Machine,
+	return &storage.VolumeAttachment{
+		volumeTag,
+		machineTag,
 		storage.VolumeAttachmentInfo{
 			BusAddress: diskBusAddress(lun),
 		},
-	}
-	return &volumeAttachment, true, nil
+	}, nil
 }
 
 // DetachVolumes is specified on the storage.VolumeSource interface.
@@ -507,10 +674,6 @@ func (v *azureVolumeSource) DetachVolumes(attachParams []storage.VolumeAttachmen
 	virtualMachines, err := v.virtualMachines(instanceIds)
 	if err != nil {
 		return nil, errors.Annotate(err, "getting virtual machines")
-	}
-	storageAccount, err := v.env.getStorageAccount(false)
-	if err != nil {
-		return nil, errors.Annotate(err, "getting storage account")
 	}
 
 	// Update VirtualMachine objects in-memory,
@@ -529,7 +692,7 @@ func (v *azureVolumeSource) DetachVolumes(attachParams []storage.VolumeAttachmen
 			results[i] = vm.err
 			continue
 		}
-		if v.detachVolume(vm.vm, p, storageAccount) {
+		if v.detachVolume(vm.vm, p) {
 			changed[p.InstanceId] = true
 		}
 	}
@@ -555,12 +718,7 @@ func (v *azureVolumeSource) DetachVolumes(attachParams []storage.VolumeAttachmen
 func (v *azureVolumeSource) detachVolume(
 	vm *compute.VirtualMachine,
 	p storage.VolumeAttachmentParams,
-	storageAccount *armstorage.Account,
 ) (updated bool) {
-
-	dataDisksRoot := dataDiskVhdRoot(storageAccount)
-	dataDiskName := p.VolumeId
-	vhdURI := dataDisksRoot + dataDiskName + vhdExtension
 
 	var dataDisks []compute.DataDisk
 	if vm.StorageProfile.DataDisks != nil {
@@ -570,14 +728,25 @@ func (v *azureVolumeSource) detachVolume(
 		if to.String(disk.Name) != p.VolumeId {
 			continue
 		}
-		if to.String(disk.Vhd.URI) != vhdURI {
-			continue
-		}
 		dataDisks = append(dataDisks[:i], dataDisks[i+1:]...)
 		vm.StorageProfile.DataDisks = &dataDisks
 		return true
 	}
 	return false
+}
+
+// diskResourceID returns the full resource ID for a disk, given its name.
+func (v *azureVolumeSource) diskResourceID(name string) string {
+	return path.Join(
+		"/subscriptions",
+		v.env.subscriptionId,
+		"resourceGroups",
+		v.env.resourceGroup,
+		"providers",
+		"Microsoft.Compute",
+		"disks",
+		name,
+	)
 }
 
 type maybeVirtualMachine struct {

--- a/provider/azure/storage_test.go
+++ b/provider/azure/storage_test.go
@@ -8,8 +8,11 @@ import (
 	"net/http"
 
 	"github.com/Azure/azure-sdk-for-go/arm/compute"
+	"github.com/Azure/azure-sdk-for-go/arm/disk"
 	armstorage "github.com/Azure/azure-sdk-for-go/arm/storage"
 	azurestorage "github.com/Azure/azure-sdk-for-go/storage"
+	autorestazure "github.com/Azure/go-autorest/autorest/azure"
+	"github.com/Azure/go-autorest/autorest/mocks"
 	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
@@ -59,21 +62,33 @@ func (s *storageSuite) SetUpTest(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 }
 
-func (s *storageSuite) volumeSource(c *gc.C, attrs ...testing.Attrs) storage.VolumeSource {
+func (s *storageSuite) volumeSource(c *gc.C, legacy bool, attrs ...testing.Attrs) storage.VolumeSource {
 	storageConfig, err := storage.NewConfig("azure", "azure", nil)
 	c.Assert(err, jc.ErrorIsNil)
 
+	s.sender = azuretesting.Senders{}
+	if legacy {
+		s.sender = append(s.sender, s.accountSender(), s.accountKeysSender())
+	} else {
+		s.sender = append(s.sender, s.accountNotFoundSender())
+	}
 	volumeSource, err := s.provider.VolumeSource(storageConfig)
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Force an explicit refresh of the access token, so it isn't done
 	// implicitly during the tests.
-	s.sender = azuretesting.Senders{
-		tokenRefreshSender(),
-	}
+	s.sender = azuretesting.Senders{tokenRefreshSender()}
 	err = azure.ForceVolumeSourceTokenRefresh(volumeSource)
 	c.Assert(err, jc.ErrorIsNil)
 	return volumeSource
+}
+
+func (s *storageSuite) accountNotFoundSender() *mocks.Sender {
+	sender := mocks.NewSender()
+	sender.AppendResponse(mocks.NewResponseWithStatus(
+		"storage account not found", http.StatusNotFound,
+	))
+	return sender
 }
 
 func (s *storageSuite) accountSender() *azuretesting.MockSender {
@@ -112,7 +127,7 @@ func (s *storageSuite) accountKeysSender() *azuretesting.MockSender {
 }
 
 func (s *storageSuite) TestVolumeSource(c *gc.C) {
-	vs := s.volumeSource(c)
+	vs := s.volumeSource(c, false)
 	c.Assert(vs, gc.NotNil)
 }
 
@@ -139,6 +154,102 @@ func (s *storageSuite) TestScope(c *gc.C) {
 }
 
 func (s *storageSuite) TestCreateVolumes(c *gc.C) {
+	makeVolumeParams := func(volume, machine string, size uint64) storage.VolumeParams {
+		return storage.VolumeParams{
+			Tag:          names.NewVolumeTag(volume),
+			Size:         size,
+			Provider:     "azure",
+			ResourceTags: map[string]string{"foo": "bar"},
+			Attachment: &storage.VolumeAttachmentParams{
+				AttachmentParams: storage.AttachmentParams{
+					Provider:   "azure",
+					Machine:    names.NewMachineTag(machine),
+					InstanceId: instance.Id("machine-" + machine),
+				},
+				Volume: names.NewVolumeTag(volume),
+			},
+		}
+	}
+	params := []storage.VolumeParams{
+		makeVolumeParams("0", "0", 1),
+		makeVolumeParams("1", "1", 1025),
+		makeVolumeParams("2", "0", 1024),
+	}
+
+	makeSender := func(name string, sizeGB int32) *azuretesting.MockSender {
+		sender := azuretesting.NewSenderWithValue(&disk.Model{
+			Name: to.StringPtr(name),
+			Properties: &disk.Properties{
+				DiskSizeGB: to.Int32Ptr(sizeGB),
+			},
+		})
+		sender.PathPattern = `.*/Microsoft\.Compute/disks/` + name
+		return sender
+	}
+
+	volumeSource := s.volumeSource(c, false)
+	s.requests = nil
+	s.sender = azuretesting.Senders{
+		makeSender("volume-0", 32),
+		makeSender("volume-1", 2),
+		makeSender("volume-2", 1),
+	}
+
+	results, err := volumeSource.CreateVolumes(params)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(results, gc.HasLen, len(params))
+	c.Check(results[0].Error, jc.ErrorIsNil)
+	c.Check(results[1].Error, jc.ErrorIsNil)
+	c.Check(results[2].Error, jc.ErrorIsNil)
+
+	// Attachments are deferred.
+	c.Check(results[0].VolumeAttachment, gc.IsNil)
+	c.Check(results[1].VolumeAttachment, gc.IsNil)
+	c.Check(results[2].VolumeAttachment, gc.IsNil)
+
+	makeVolume := func(id string, size uint64) *storage.Volume {
+		return &storage.Volume{
+			Tag: names.NewVolumeTag(id),
+			VolumeInfo: storage.VolumeInfo{
+				Size:       size,
+				VolumeId:   "volume-" + id,
+				Persistent: true,
+			},
+		}
+	}
+	c.Check(results[0].Volume, jc.DeepEquals, makeVolume("0", 32*1024))
+	c.Check(results[1].Volume, jc.DeepEquals, makeVolume("1", 2*1024))
+	c.Check(results[2].Volume, jc.DeepEquals, makeVolume("2", 1*1024))
+
+	// Validate HTTP request bodies.
+	c.Assert(s.requests, gc.HasLen, 3)
+	c.Assert(s.requests[0].Method, gc.Equals, "PUT") // create volume-0
+	c.Assert(s.requests[1].Method, gc.Equals, "PUT") // create volume-1
+	c.Assert(s.requests[2].Method, gc.Equals, "PUT") // create volume-2
+
+	makeDisk := func(name string, size int32) *disk.Model {
+		tags := map[string]*string{
+			"foo": to.StringPtr("bar"),
+		}
+		return &disk.Model{
+			Name:     to.StringPtr(name),
+			Location: to.StringPtr("westus"),
+			Tags:     &tags,
+			Properties: &disk.Properties{
+				AccountType: disk.StorageAccountTypes("Standard_LRS"),
+				DiskSizeGB:  to.Int32Ptr(size),
+				CreationData: &disk.CreationData{
+					CreateOption: "Empty",
+				},
+			},
+		}
+	}
+	assertRequestBody(c, s.requests[0], makeDisk("volume-0", 1))
+	assertRequestBody(c, s.requests[1], makeDisk("volume-1", 2))
+	assertRequestBody(c, s.requests[2], makeDisk("volume-2", 1))
+}
+
+func (s *storageSuite) TestCreateVolumesLegacy(c *gc.C) {
 	// machine-1 has a single data disk with LUN 0.
 	machine1DataDisks := []compute.DataDisk{{Lun: to.Int32Ptr(0)}}
 	// machine-2 has 32 data disks; no LUNs free.
@@ -200,10 +311,11 @@ func (s *storageSuite) TestCreateVolumes(c *gc.C) {
 	updateVirtualMachine0Sender.PathPattern = `.*/Microsoft\.Compute/virtualMachines/machine-0`
 	updateVirtualMachine1Sender := azuretesting.NewSenderWithValue(&compute.VirtualMachine{})
 	updateVirtualMachine1Sender.PathPattern = `.*/Microsoft\.Compute/virtualMachines/machine-1`
-	volumeSource := s.volumeSource(c)
+
+	volumeSource := s.volumeSource(c, true)
+	s.requests = nil
 	s.sender = azuretesting.Senders{
 		virtualMachinesSender,
-		s.accountSender(),
 		updateVirtualMachine0Sender,
 		updateVirtualMachine1Sender,
 	}
@@ -218,12 +330,39 @@ func (s *storageSuite) TestCreateVolumes(c *gc.C) {
 	c.Check(results[3].Error, gc.ErrorMatches, "instance machine-42 not found")
 	c.Check(results[4].Error, gc.ErrorMatches, "choosing LUN: all LUNs are in use")
 
+	makeVolume := func(id string, size uint64) *storage.Volume {
+		return &storage.Volume{
+			Tag: names.NewVolumeTag(id),
+			VolumeInfo: storage.VolumeInfo{
+				Size:       size,
+				VolumeId:   "volume-" + id,
+				Persistent: true,
+			},
+		}
+	}
+	c.Check(results[0].Volume, jc.DeepEquals, makeVolume("0", 1024))
+	c.Check(results[1].Volume, jc.DeepEquals, makeVolume("1", 2048))
+	c.Check(results[2].Volume, jc.DeepEquals, makeVolume("2", 1024))
+
+	// Attachments created at the same time.
+	makeVolumeAttachment := func(volumeId, machineId string, lun int) *storage.VolumeAttachment {
+		return &storage.VolumeAttachment{
+			Volume:  names.NewVolumeTag(volumeId),
+			Machine: names.NewMachineTag(machineId),
+			VolumeAttachmentInfo: storage.VolumeAttachmentInfo{
+				BusAddress: fmt.Sprintf("scsi@5:0.0.%d", lun),
+			},
+		}
+	}
+	c.Check(results[0].VolumeAttachment, jc.DeepEquals, makeVolumeAttachment("0", "0", 0))
+	c.Check(results[1].VolumeAttachment, jc.DeepEquals, makeVolumeAttachment("1", "1", 1))
+	c.Check(results[2].VolumeAttachment, jc.DeepEquals, makeVolumeAttachment("2", "0", 1))
+
 	// Validate HTTP request bodies.
-	c.Assert(s.requests, gc.HasLen, 4)
+	c.Assert(s.requests, gc.HasLen, 3)
 	c.Assert(s.requests[0].Method, gc.Equals, "GET") // list virtual machines
-	c.Assert(s.requests[1].Method, gc.Equals, "GET") // list storage accounts
-	c.Assert(s.requests[2].Method, gc.Equals, "PUT") // update machine-0
-	c.Assert(s.requests[3].Method, gc.Equals, "PUT") // update machine-1
+	c.Assert(s.requests[1].Method, gc.Equals, "PUT") // update machine-0
+	c.Assert(s.requests[2].Method, gc.Equals, "PUT") // update machine-1
 
 	machine0DataDisks := []compute.DataDisk{{
 		Lun:        to.Int32Ptr(0),
@@ -247,7 +386,7 @@ func (s *storageSuite) TestCreateVolumes(c *gc.C) {
 		CreateOption: compute.Empty,
 	}}
 	virtualMachines[0].StorageProfile.DataDisks = &machine0DataDisks
-	assertRequestBody(c, s.requests[2], &virtualMachines[0])
+	assertRequestBody(c, s.requests[1], &virtualMachines[0])
 
 	machine1DataDisks = append(machine1DataDisks, compute.DataDisk{
 		Lun:        to.Int32Ptr(1),
@@ -260,10 +399,30 @@ func (s *storageSuite) TestCreateVolumes(c *gc.C) {
 		Caching:      compute.ReadWrite,
 		CreateOption: compute.Empty,
 	})
-	assertRequestBody(c, s.requests[3], &virtualMachines[1])
+	assertRequestBody(c, s.requests[2], &virtualMachines[1])
 }
 
 func (s *storageSuite) TestListVolumes(c *gc.C) {
+	volumeSource := s.volumeSource(c, false)
+	disks := []disk.Model{{
+		Name: to.StringPtr("volume-0"),
+	}, {
+		Name: to.StringPtr("machine-0"),
+	}, {
+		Name: to.StringPtr("volume-1"),
+	}}
+	volumeSender := azuretesting.NewSenderWithValue(&disk.ListType{
+		Value: &disks,
+	})
+	volumeSender.PathPattern = `.*/Microsoft\.Compute/disks`
+	s.sender = azuretesting.Senders{volumeSender}
+
+	volumeIds, err := volumeSource.ListVolumes()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(volumeIds, jc.SameContents, []string{"volume-0", "volume-1"})
+}
+
+func (s *storageSuite) TestListVolumesLegacy(c *gc.C) {
 	blob0 := &azuretesting.MockStorageBlob{
 		Name_: "volume-0.vhd",
 		Properties_: azurestorage.BlobProperties{
@@ -284,11 +443,7 @@ func (s *storageSuite) TestListVolumes(c *gc.C) {
 	}
 	s.datavhdsContainer.Blobs_ = []internalazurestorage.Blob{blob1, blob0, junkBlob, volumeBlob}
 
-	volumeSource := s.volumeSource(c)
-	s.sender = azuretesting.Senders{
-		s.accountSender(),
-		s.accountKeysSender(),
-	}
+	volumeSource := s.volumeSource(c, true)
 	volumeIds, err := volumeSource.ListVolumes()
 	c.Assert(err, jc.ErrorIsNil)
 	s.storageClient.CheckCallNames(c, "NewClient", "GetContainerReference")
@@ -302,22 +457,60 @@ func (s *storageSuite) TestListVolumes(c *gc.C) {
 }
 
 func (s *storageSuite) TestListVolumesErrors(c *gc.C) {
-	volumeSource := s.volumeSource(c)
-	s.sender = azuretesting.Senders{
-		s.accountSender(),
-		s.accountKeysSender(),
-	}
-
-	s.storageClient.SetErrors(errors.New("no client for you"))
+	volumeSource := s.volumeSource(c, false)
+	sender := mocks.NewSender()
+	sender.SetError(errors.New("no disks for you"))
+	s.sender = azuretesting.Senders{sender}
 	_, err := volumeSource.ListVolumes()
-	c.Assert(err, gc.ErrorMatches, "listing volumes: getting storage client: no client for you")
+	c.Assert(err, gc.ErrorMatches, "listing disks: .*: no disks for you")
+}
 
+func (s *storageSuite) TestListVolumesErrorsLegacy(c *gc.C) {
+	volumeSource := s.volumeSource(c, true)
 	s.datavhdsContainer.SetErrors(errors.New("no blobs for you"))
-	_, err = volumeSource.ListVolumes()
+	_, err := volumeSource.ListVolumes()
 	c.Assert(err, gc.ErrorMatches, "listing volumes: listing blobs: no blobs for you")
 }
 
 func (s *storageSuite) TestDescribeVolumes(c *gc.C) {
+	volumeSource := s.volumeSource(c, false)
+	volumeSender := azuretesting.NewSenderWithValue(&disk.Model{
+		Properties: &disk.Properties{
+			DiskSizeGB: to.Int32Ptr(1024),
+		},
+	})
+	volumeSender.PathPattern = `.*/Microsoft\.Compute/disks/volume-0`
+	s.sender = azuretesting.Senders{volumeSender}
+
+	results, err := volumeSource.DescribeVolumes([]string{"volume-0"})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(results, jc.DeepEquals, []storage.DescribeVolumesResult{{
+		VolumeInfo: &storage.VolumeInfo{
+			VolumeId:   "volume-0",
+			Size:       1024 * 1024,
+			Persistent: true,
+		},
+	}})
+}
+
+func (s *storageSuite) TestDescribeVolumesNotFound(c *gc.C) {
+	volumeSource := s.volumeSource(c, false)
+	volumeSender := mocks.NewSender()
+	response := mocks.NewResponseWithBodyAndStatus(
+		mocks.NewBody("{}"),
+		http.StatusNotFound,
+		"disk not found",
+	)
+	volumeSender.AppendResponse(response)
+	s.sender = azuretesting.Senders{volumeSender}
+	results, err := volumeSource.DescribeVolumes([]string{"volume-42"})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(results, gc.HasLen, 1)
+	c.Assert(results[0].Error, jc.Satisfies, errors.IsNotFound)
+	c.Assert(results[0].Error, gc.ErrorMatches, `disk volume-42 not found`)
+}
+
+func (s *storageSuite) TestDescribeVolumesLegacy(c *gc.C) {
 	blob0 := &azuretesting.MockStorageBlob{
 		Name_: "volume-0.vhd",
 		Properties_: azurestorage.BlobProperties{
@@ -332,11 +525,7 @@ func (s *storageSuite) TestDescribeVolumes(c *gc.C) {
 	}
 	s.datavhdsContainer.Blobs_ = []internalazurestorage.Blob{blob1, blob0}
 
-	volumeSource := s.volumeSource(c)
-	s.sender = azuretesting.Senders{
-		s.accountSender(),
-		s.accountKeysSender(),
-	}
+	volumeSource := s.volumeSource(c, true)
 	results, err := volumeSource.DescribeVolumes([]string{"volume-0", "volume-1", "volume-0", "volume-42"})
 	c.Assert(err, jc.ErrorIsNil)
 	s.storageClient.CheckCallNames(c, "NewClient", "GetContainerReference")
@@ -368,6 +557,34 @@ func (s *storageSuite) TestDescribeVolumes(c *gc.C) {
 }
 
 func (s *storageSuite) TestDestroyVolumes(c *gc.C) {
+	volumeSource := s.volumeSource(c, false)
+
+	volume0Sender := azuretesting.NewSenderWithValue(&autorestazure.ServiceError{})
+	volume0Sender.PathPattern = `.*/Microsoft\.Compute/disks/volume-0`
+	s.sender = azuretesting.Senders{volume0Sender}
+
+	results, err := volumeSource.DestroyVolumes([]string{"volume-0"})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(results, gc.HasLen, 1)
+	c.Assert(results[0], jc.ErrorIsNil)
+}
+
+func (s *storageSuite) TestDestroyVolumesNotFound(c *gc.C) {
+	volumeSource := s.volumeSource(c, false)
+
+	volume42Sender := mocks.NewSender()
+	volume42Sender.AppendResponse(mocks.NewResponseWithStatus(
+		"disk not found", http.StatusNotFound,
+	))
+	s.sender = azuretesting.Senders{volume42Sender}
+
+	results, err := volumeSource.DestroyVolumes([]string{"volume-42"})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(results, gc.HasLen, 1)
+	c.Assert(results[0], jc.ErrorIsNil)
+}
+
+func (s *storageSuite) TestDestroyVolumesLegacy(c *gc.C) {
 	blob0 := &azuretesting.MockStorageBlob{
 		Name_: "volume-0.vhd",
 	}
@@ -376,11 +593,7 @@ func (s *storageSuite) TestDestroyVolumes(c *gc.C) {
 	}
 	s.datavhdsContainer.Blobs_ = []internalazurestorage.Blob{blob0, blob1}
 
-	volumeSource := s.volumeSource(c)
-	s.sender = azuretesting.Senders{
-		s.accountSender(),
-		s.accountKeysSender(),
-	}
+	volumeSource := s.volumeSource(c, true)
 	results, err := volumeSource.DestroyVolumes([]string{"volume-0", "volume-42"})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, gc.HasLen, 2)
@@ -394,6 +607,14 @@ func (s *storageSuite) TestDestroyVolumes(c *gc.C) {
 }
 
 func (s *storageSuite) TestAttachVolumes(c *gc.C) {
+	s.testAttachVolumes(c, false)
+}
+
+func (s *storageSuite) TestAttachVolumesLegacy(c *gc.C) {
+	s.testAttachVolumes(c, true)
+}
+
+func (s *storageSuite) testAttachVolumes(c *gc.C, legacy bool) {
 	// machine-1 has a single data disk with LUN 0.
 	machine1DataDisks := []compute.DataDisk{{
 		Lun:  to.Int32Ptr(0),
@@ -465,10 +686,11 @@ func (s *storageSuite) TestAttachVolumes(c *gc.C) {
 	virtualMachinesSender.PathPattern = `.*/Microsoft\.Compute/virtualMachines`
 	updateVirtualMachine0Sender := azuretesting.NewSenderWithValue(&compute.VirtualMachine{})
 	updateVirtualMachine0Sender.PathPattern = `.*/Microsoft\.Compute/virtualMachines/machine-0`
-	volumeSource := s.volumeSource(c)
+
+	volumeSource := s.volumeSource(c, legacy)
+	s.requests = nil
 	s.sender = azuretesting.Senders{
 		virtualMachinesSender,
-		s.accountSender(),
 		updateVirtualMachine0Sender,
 	}
 
@@ -483,63 +705,67 @@ func (s *storageSuite) TestAttachVolumes(c *gc.C) {
 	c.Check(results[4].Error, gc.ErrorMatches, "choosing LUN: all LUNs are in use")
 
 	// Validate HTTP request bodies.
-	c.Assert(s.requests, gc.HasLen, 3)
+	c.Assert(s.requests, gc.HasLen, 2)
 	c.Assert(s.requests[0].Method, gc.Equals, "GET") // list virtual machines
-	c.Assert(s.requests[1].Method, gc.Equals, "GET") // list storage accounts
-	c.Assert(s.requests[2].Method, gc.Equals, "PUT") // update machine-0
+	c.Assert(s.requests[1].Method, gc.Equals, "PUT") // update machine-0
+
+	makeVhd := func(volumeName string) *compute.VirtualHardDisk {
+		if !legacy {
+			return nil
+		}
+		return &compute.VirtualHardDisk{URI: to.StringPtr(fmt.Sprintf(
+			"https://%s.blob.storage.azurestack.local/datavhds/%s.vhd",
+			storageAccountName, volumeName,
+		))}
+	}
+	makeManagedDisk := func(volumeName string) *compute.ManagedDiskParameters {
+		if legacy {
+			return nil
+		}
+		return &compute.ManagedDiskParameters{
+			ID: to.StringPtr("/subscriptions/22222222-2222-2222-2222-222222222222/resourceGroups/juju-testenv-model-deadbeef-0bad-400d-8000-4b1d0d06f00d/providers/Microsoft.Compute/disks/" + volumeName),
+		}
+	}
 
 	machine0DataDisks := []compute.DataDisk{{
-		Lun:  to.Int32Ptr(0),
-		Name: to.StringPtr("volume-0"),
-		Vhd: &compute.VirtualHardDisk{URI: to.StringPtr(fmt.Sprintf(
-			"https://%s.blob.storage.azurestack.local/datavhds/volume-0.vhd",
-			storageAccountName,
-		))},
+		Lun:          to.Int32Ptr(0),
+		Name:         to.StringPtr("volume-0"),
+		Vhd:          makeVhd("volume-0"),
+		ManagedDisk:  makeManagedDisk("volume-0"),
 		Caching:      compute.ReadWrite,
 		CreateOption: compute.Attach,
 	}, {
-		Lun:  to.Int32Ptr(1),
-		Name: to.StringPtr("volume-2"),
-		Vhd: &compute.VirtualHardDisk{URI: to.StringPtr(fmt.Sprintf(
-			"https://%s.blob.storage.azurestack.local/datavhds/volume-2.vhd",
-			storageAccountName,
-		))},
+		Lun:          to.Int32Ptr(1),
+		Name:         to.StringPtr("volume-2"),
+		Vhd:          makeVhd("volume-2"),
+		ManagedDisk:  makeManagedDisk("volume-2"),
 		Caching:      compute.ReadWrite,
 		CreateOption: compute.Attach,
 	}}
+
 	virtualMachines[0].StorageProfile.DataDisks = &machine0DataDisks
-	assertRequestBody(c, s.requests[2], &virtualMachines[0])
+	assertRequestBody(c, s.requests[1], &virtualMachines[0])
 }
 
 func (s *storageSuite) TestDetachVolumes(c *gc.C) {
+	s.testDetachVolumes(c, false)
+}
+
+func (s *storageSuite) TestDetachVolumesLegacy(c *gc.C) {
+	s.testDetachVolumes(c, true)
+}
+
+func (s *storageSuite) testDetachVolumes(c *gc.C, legacy bool) {
 	// machine-0 has a three data disks: volume-0, volume-1 and volume-2
 	machine0DataDisks := []compute.DataDisk{{
 		Lun:  to.Int32Ptr(0),
 		Name: to.StringPtr("volume-0"),
-		Vhd: &compute.VirtualHardDisk{
-			URI: to.StringPtr(fmt.Sprintf(
-				"https://%s.blob.storage.azurestack.local/datavhds/volume-0.vhd",
-				storageAccountName,
-			)),
-		},
 	}, {
 		Lun:  to.Int32Ptr(1),
 		Name: to.StringPtr("volume-1"),
-		Vhd: &compute.VirtualHardDisk{
-			URI: to.StringPtr(fmt.Sprintf(
-				"https://%s.blob.storage.azurestack.local/datavhds/volume-1.vhd",
-				storageAccountName,
-			)),
-		},
 	}, {
 		Lun:  to.Int32Ptr(2),
 		Name: to.StringPtr("volume-2"),
-		Vhd: &compute.VirtualHardDisk{
-			URI: to.StringPtr(fmt.Sprintf(
-				"https://%s.blob.storage.azurestack.local/datavhds/volume-2.vhd",
-				storageAccountName,
-			)),
-		},
 	}}
 
 	makeParams := func(volume, machine string) storage.VolumeAttachmentParams {
@@ -579,10 +805,11 @@ func (s *storageSuite) TestDetachVolumes(c *gc.C) {
 	virtualMachinesSender.PathPattern = `.*/Microsoft\.Compute/virtualMachines`
 	updateVirtualMachine0Sender := azuretesting.NewSenderWithValue(&compute.VirtualMachine{})
 	updateVirtualMachine0Sender.PathPattern = `.*/Microsoft\.Compute/virtualMachines/machine-0`
-	volumeSource := s.volumeSource(c)
+
+	volumeSource := s.volumeSource(c, legacy)
+	s.requests = nil
 	s.sender = azuretesting.Senders{
 		virtualMachinesSender,
-		s.accountSender(),
 		updateVirtualMachine0Sender,
 	}
 
@@ -596,17 +823,16 @@ func (s *storageSuite) TestDetachVolumes(c *gc.C) {
 	c.Check(results[3], gc.ErrorMatches, "instance machine-42 not found")
 
 	// Validate HTTP request bodies.
-	c.Assert(s.requests, gc.HasLen, 3)
+	c.Assert(s.requests, gc.HasLen, 2)
 	c.Assert(s.requests[0].Method, gc.Equals, "GET") // list virtual machines
-	c.Assert(s.requests[1].Method, gc.Equals, "GET") // list storage accounts
-	c.Assert(s.requests[2].Method, gc.Equals, "PUT") // update machine-0
+	c.Assert(s.requests[1].Method, gc.Equals, "PUT") // update machine-0
 
 	machine0DataDisks = []compute.DataDisk{
 		machine0DataDisks[0],
 		machine0DataDisks[2],
 	}
 	virtualMachines[0].StorageProfile.DataDisks = &machine0DataDisks
-	assertRequestBody(c, s.requests[2], &virtualMachines[0])
+	assertRequestBody(c, s.requests[1], &virtualMachines[0])
 }
 
 func (s *storageSuite) TestDetachVolumesFinal(c *gc.C) {
@@ -646,10 +872,11 @@ func (s *storageSuite) TestDetachVolumesFinal(c *gc.C) {
 	virtualMachinesSender.PathPattern = `.*/Microsoft\.Compute/virtualMachines`
 	updateVirtualMachine0Sender := azuretesting.NewSenderWithValue(&compute.VirtualMachine{})
 	updateVirtualMachine0Sender.PathPattern = `.*/Microsoft\.Compute/virtualMachines/machine-0`
-	volumeSource := s.volumeSource(c)
+
+	volumeSource := s.volumeSource(c, false)
+	s.requests = nil
 	s.sender = azuretesting.Senders{
 		virtualMachinesSender,
-		s.accountSender(),
 		updateVirtualMachine0Sender,
 	}
 
@@ -659,12 +886,11 @@ func (s *storageSuite) TestDetachVolumesFinal(c *gc.C) {
 	c.Assert(results[0], jc.ErrorIsNil)
 
 	// Validate HTTP request bodies.
-	c.Assert(s.requests, gc.HasLen, 3)
+	c.Assert(s.requests, gc.HasLen, 2)
 	c.Assert(s.requests[0].Method, gc.Equals, "GET") // list virtual machines
-	c.Assert(s.requests[1].Method, gc.Equals, "GET") // list storage accounts
-	c.Assert(s.requests[2].Method, gc.Equals, "PUT") // update machine-0
+	c.Assert(s.requests[1].Method, gc.Equals, "PUT") // update machine-0
 
 	machine0DataDisks = []compute.DataDisk{}
 	virtualMachines[0].StorageProfile.DataDisks = &machine0DataDisks
-	assertRequestBody(c, s.requests[2], &virtualMachines[0])
+	assertRequestBody(c, s.requests[1], &virtualMachines[0])
 }

--- a/provider/azure/upgrades.go
+++ b/provider/azure/upgrades.go
@@ -71,9 +71,11 @@ func (step commonDeploymentUpgradeStep) Run() error {
 	env.mu.Lock()
 	storageAccountType := env.config.storageAccountType
 	env.mu.Unlock()
-	return env.createCommonResourceDeployment(
-		nil, storageAccountType, rules,
-	)
+	return env.createCommonResourceDeployment(nil, rules, storageAccountTemplateResource(
+		env.location, nil,
+		env.storageAccountName,
+		storageAccountType,
+	))
 }
 
 func isControllerEnviron(env *azureEnviron) (bool, error) {


### PR DESCRIPTION
## Description of change

This is a major change to the Azure provider,
to use managed disks. To use managed disks,
VMs must be placed in "aligned" availability
sets. Because of that, models support either
the old unmanaged disks or new managed disks,
but never both. Models created before this
change will continue to use unmanaged disks,
and new models will use managed disks.

The azure storage provider now has an optional
"account-type" attribute, which is the storage
account type: Standard_LRS or Premium_LRS.
The default is Standard_LRS. A defualt pool,
azure-premium, is added, with account-type set
to Premium_LRS.

For now, the model config's storage-account-type
only affects the storage type used for the root
disk of VMs in managed disk models. It continues
to affect all storage in unmanaged disk models.

## QA steps

1. juju bootstrap azure
2. juju deploy postgresql --storage pgdata=azure-premium,100G
3. juju deploy postgresql pg2 --storage pgdata=azure,100G
4. juju remove-unit pg2
5. juju add-unit pg2 --attach-storage=pgdata/1

Also, bootstrap with an older Juju, then upgrade with this branch, and check the old stuff still works, and new models work as they do with a freshly bootstrapped controller.

## Documentation changes

None.

## Bug reference

None.