### PR TITLE
Add egress-address to relation data

### DIFF
--- a/apiserver/common/crossmodel/state.go
+++ b/apiserver/common/crossmodel/state.go
@@ -125,7 +125,7 @@ type RelationNetworks state.RelationNetworks
 
 func (s stateShim) SaveIngressNetworks(relationKey string, cidrs []string) (RelationNetworks, error) {
 	api := state.NewRelationIngressNetworks(s.State)
-	return api.Save(relationKey, cidrs)
+	return api.Save(relationKey, false, cidrs)
 }
 
 type relationShim struct {

--- a/apiserver/common/firewall/egressaddresswatcher.go
+++ b/apiserver/common/firewall/egressaddresswatcher.go
@@ -182,7 +182,7 @@ func (w *EgressAddressWatcher) loop() error {
 				}
 			}
 			unitAddressesChanged = false
-			addresses = formatAsCIDR(addressSet.Values())
+			addresses = FormatAsCIDR(addressSet.Values())
 			out = w.out
 		}
 		userConfiguredEgressChanged = false
@@ -245,7 +245,8 @@ func (w *EgressAddressWatcher) loop() error {
 	}
 }
 
-func formatAsCIDR(addresses []string) []string {
+// FormatAsCIDR formats the specified IP address as a CIDR.
+func FormatAsCIDR(addresses []string) []string {
 	result := make([]string, len(addresses))
 	for i, a := range addresses {
 		cidr := a

--- a/apiserver/common/firewall/egressaddresswatcher.go
+++ b/apiserver/common/firewall/egressaddresswatcher.go
@@ -245,7 +245,8 @@ func (w *EgressAddressWatcher) loop() error {
 	}
 }
 
-// FormatAsCIDR formats the specified IP address as a CIDR.
+// FormatAsCIDR converts the specified IP addresses to
+// a slice of CIDRs.
 func FormatAsCIDR(addresses []string) []string {
 	result := make([]string, len(addresses))
 	for i, a := range addresses {

--- a/apiserver/facades/agent/uniter/uniter_test.go
+++ b/apiserver/facades/agent/uniter/uniter_test.go
@@ -1794,6 +1794,7 @@ func (s *uniterSuite) TestEnterScope(c *gc.C) {
 	c.Assert(readSettings, gc.DeepEquals, map[string]interface{}{
 		"private-address": "1.2.3.4",
 		"ingress-address": "1.2.3.4",
+		"egress-subnets":  []interface{}{"1.2.3.4/32"},
 	})
 }
 
@@ -2622,9 +2623,8 @@ func (s *uniterSuite) TestSLALevel(c *gc.C) {
 	c.Assert(result, jc.DeepEquals, params.StringResult{Result: "essential"})
 }
 
-func (s *uniterSuite) TestPrivateAddressWithRemoteRelation(c *gc.C) {
+func (s *uniterSuite) setupRemoteRelationScenario(c *gc.C) (names.Tag, *state.RelationUnit) {
 	s.makeRemoteWordpress(c)
-	thisUniter := s.makeMysqlUniter(c)
 
 	// Set mysql's addresses first.
 	err := s.machine1.SetProviderAddresses(
@@ -2641,8 +2641,15 @@ func (s *uniterSuite) TestPrivateAddressWithRemoteRelation(c *gc.C) {
 	relUnit, err := rel.Unit(s.mysqlUnit)
 	c.Assert(err, jc.ErrorIsNil)
 	s.assertInScope(c, relUnit, false)
+	return rel.Tag(), relUnit
+}
+
+func (s *uniterSuite) TestPrivateAddressWithRemoteRelation(c *gc.C) {
+	relTag, relUnit := s.setupRemoteRelationScenario(c)
+
+	thisUniter := s.makeMysqlUniter(c)
 	args := params.RelationUnits{RelationUnits: []params.RelationUnit{
-		{Relation: rel.Tag().String(), Unit: "unit-mysql-0"},
+		{Relation: relTag.String(), Unit: "unit-mysql-0"},
 	}}
 	result, err := thisUniter.EnterScope(args)
 	c.Assert(err, jc.ErrorIsNil)
@@ -2657,29 +2664,22 @@ func (s *uniterSuite) TestPrivateAddressWithRemoteRelation(c *gc.C) {
 	c.Assert(readSettings, gc.DeepEquals, map[string]interface{}{
 		"private-address": "4.3.2.1",
 		"ingress-address": "4.3.2.1",
+		"egress-subnets":  []interface{}{"4.3.2.1/32"},
 	})
 }
 
 func (s *uniterSuite) TestPrivateAddressWithRemoteRelationNoPublic(c *gc.C) {
-	s.makeRemoteWordpress(c)
-	thisUniter := s.makeMysqlUniter(c)
+	relTag, relUnit := s.setupRemoteRelationScenario(c)
 
-	// Set mysql's addresses first - no public address.
+	thisUniter := s.makeMysqlUniter(c)
+	// Set mysql's addresses - no public address.
 	err := s.machine1.SetProviderAddresses(
 		network.NewScopedAddress("1.2.3.4", network.ScopeCloudLocal),
 	)
 	c.Assert(err, jc.ErrorIsNil)
 
-	eps, err := s.State.InferEndpoints("mysql", "remote-wordpress")
-	c.Assert(err, jc.ErrorIsNil)
-	rel, err := s.State.AddRelation(eps...)
-	c.Assert(err, jc.ErrorIsNil)
-
-	relUnit, err := rel.Unit(s.mysqlUnit)
-	c.Assert(err, jc.ErrorIsNil)
-	s.assertInScope(c, relUnit, false)
 	args := params.RelationUnits{RelationUnits: []params.RelationUnit{
-		{Relation: rel.Tag().String(), Unit: "unit-mysql-0"},
+		{Relation: relTag.String(), Unit: "unit-mysql-0"},
 	}}
 	result, err := thisUniter.EnterScope(args)
 	c.Assert(err, jc.ErrorIsNil)
@@ -2694,6 +2694,65 @@ func (s *uniterSuite) TestPrivateAddressWithRemoteRelationNoPublic(c *gc.C) {
 	c.Assert(readSettings, gc.DeepEquals, map[string]interface{}{
 		"private-address": "1.2.3.4",
 		"ingress-address": "1.2.3.4",
+		"egress-subnets":  []interface{}{"1.2.3.4/32"},
+	})
+}
+
+func (s *uniterSuite) TestRelationEgressSubnets(c *gc.C) {
+	relTag, relUnit := s.setupRemoteRelationScenario(c)
+
+	// Check model attributes are overridden by setting up a value.
+	err := s.State.UpdateModelConfig(map[string]interface{}{"egress-subnets": "192.168.0.0/16"}, nil)
+	c.Assert(err, jc.ErrorIsNil)
+	egress := state.NewRelationEgressNetworks(s.State)
+	_, err = egress.Save(relTag.Id(), []string{"10.0.0.0/16"})
+	c.Assert(err, jc.ErrorIsNil)
+
+	thisUniter := s.makeMysqlUniter(c)
+	args := params.RelationUnits{RelationUnits: []params.RelationUnit{
+		{Relation: relTag.String(), Unit: "unit-mysql-0"},
+	}}
+	result, err := thisUniter.EnterScope(args)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result, gc.DeepEquals, params.ErrorResults{
+		Results: []params.ErrorResult{{Error: nil}},
+	})
+
+	// Verify the scope changes and settings.
+	s.assertInScope(c, relUnit, true)
+	readSettings, err := relUnit.ReadSettings(s.mysqlUnit.Name())
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(readSettings, gc.DeepEquals, map[string]interface{}{
+		"private-address": "4.3.2.1",
+		"ingress-address": "4.3.2.1",
+		"egress-subnets":  []interface{}{"10.0.0.0/16"},
+	})
+}
+
+func (s *uniterSuite) TestModelEgressSubnets(c *gc.C) {
+	relTag, relUnit := s.setupRemoteRelationScenario(c)
+
+	err := s.State.UpdateModelConfig(map[string]interface{}{"egress-subnets": "192.168.0.0/16"}, nil)
+	c.Assert(err, jc.ErrorIsNil)
+
+	thisUniter := s.makeMysqlUniter(c)
+	args := params.RelationUnits{RelationUnits: []params.RelationUnit{
+		{Relation: relTag.String(), Unit: "unit-mysql-0"},
+	}}
+	result, err := thisUniter.EnterScope(args)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result, gc.DeepEquals, params.ErrorResults{
+		Results: []params.ErrorResult{{Error: nil}},
+	})
+
+	// Verify the scope changes and settings.
+	s.assertInScope(c, relUnit, true)
+	readSettings, err := relUnit.ReadSettings(s.mysqlUnit.Name())
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(readSettings, gc.DeepEquals, map[string]interface{}{
+		"private-address": "4.3.2.1",
+		"ingress-address": "4.3.2.1",
+		"egress-subnets":  []interface{}{"192.168.0.0/16"},
 	})
 }
 

--- a/apiserver/facades/agent/uniter/uniter_test.go
+++ b/apiserver/facades/agent/uniter/uniter_test.go
@@ -2705,7 +2705,7 @@ func (s *uniterSuite) TestRelationEgressSubnets(c *gc.C) {
 	err := s.State.UpdateModelConfig(map[string]interface{}{"egress-subnets": "192.168.0.0/16"}, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	egress := state.NewRelationEgressNetworks(s.State)
-	_, err = egress.Save(relTag.Id(), []string{"10.0.0.0/16"})
+	_, err = egress.Save(relTag.Id(), false, []string{"10.0.0.0/16"})
 	c.Assert(err, jc.ErrorIsNil)
 
 	thisUniter := s.makeMysqlUniter(c)

--- a/apiserver/facades/client/application/backend.go
+++ b/apiserver/facades/client/application/backend.go
@@ -221,7 +221,7 @@ func (s stateShim) AddRelation(eps ...state.Endpoint) (Relation, error) {
 
 func (s stateShim) SaveEgressNetworks(relationKey string, cidrs []string) (state.RelationNetworks, error) {
 	api := state.NewRelationEgressNetworks(s.State)
-	return api.Save(relationKey, cidrs)
+	return api.Save(relationKey, false, cidrs)
 }
 
 func (s stateShim) Charm(curl *charm.URL) (Charm, error) {

--- a/state/export_test.go
+++ b/state/export_test.go
@@ -702,24 +702,6 @@ func RemoveRelation(c *gc.C, rel *Relation) {
 	c.Assert(err, jc.ErrorIsNil)
 }
 
-func IngressNetworks(rel *Relation) ([]string, error) {
-	relIngress := NewRelationIngressNetworks(rel.st)
-	doc, err := relIngress.networks(rel.Tag().Id())
-	if err != nil {
-		return nil, err
-	}
-	return doc.CIDRS, nil
-}
-
-func EgressNetworks(rel *Relation) ([]string, error) {
-	relEgress := NewRelationEgressNetworks(rel.st)
-	doc, err := relEgress.networks(rel.Tag().Id())
-	if err != nil {
-		return nil, err
-	}
-	return doc.CIDRS, nil
-}
-
 func AddVolumeOps(st *State, params VolumeParams, machineId string) ([]txn.Op, names.VolumeTag, error) {
 	im, err := st.IAASModel()
 	if err != nil {

--- a/state/relation_test.go
+++ b/state/relation_test.go
@@ -375,11 +375,17 @@ func (s *RelationSuite) TestRemoveAlsoDeletesNetworks(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	relIngress := state.NewRelationIngressNetworks(s.State)
-	_, err = relIngress.Save(relation.Tag().Id(), []string{"1.2.3.4/32", "4.3.2.1/16"})
+	_, err = relIngress.Save(relation.Tag().Id(), false, []string{"1.2.3.4/32", "4.3.2.1/16"})
 	c.Assert(err, jc.ErrorIsNil)
+	_, err = relIngress.Save(relation.Tag().Id(), true, []string{"1.2.3.4/32", "4.3.2.1/16"})
+	c.Assert(err, jc.ErrorIsNil)
+
 	relEgress := state.NewRelationEgressNetworks(s.State)
-	_, err = relEgress.Save(relation.Tag().Id(), []string{"1.2.3.4/32", "4.3.2.1/16"})
+	_, err = relEgress.Save(relation.Tag().Id(), false, []string{"1.2.3.4/32", "4.3.2.1/16"})
 	c.Assert(err, jc.ErrorIsNil)
+	_, err = relEgress.Save(relation.Tag().Id(), true, []string{"1.2.3.4/32", "4.3.2.1/16"})
+	c.Assert(err, jc.ErrorIsNil)
+
 	state.RemoveRelation(c, relation)
 	_, err = relIngress.Networks(relation.Tag().Id())
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)

--- a/state/relation_test.go
+++ b/state/relation_test.go
@@ -381,9 +381,9 @@ func (s *RelationSuite) TestRemoveAlsoDeletesNetworks(c *gc.C) {
 	_, err = relEgress.Save(relation.Tag().Id(), []string{"1.2.3.4/32", "4.3.2.1/16"})
 	c.Assert(err, jc.ErrorIsNil)
 	state.RemoveRelation(c, relation)
-	_, err = state.IngressNetworks(relation)
+	_, err = relIngress.Networks(relation.Tag().Id())
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
-	_, err = state.EgressNetworks(relation)
+	_, err = relEgress.Networks(relation.Tag().Id())
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 }
 

--- a/state/relationnetworks_test.go
+++ b/state/relationnetworks_test.go
@@ -58,12 +58,12 @@ func (s *relationEgressNetworksSuite) SetUpTest(c *gc.C) {
 }
 
 func (s *relationNetworksSuite) TestSaveMissingRelation(c *gc.C) {
-	_, err := s.relationNetworks.Save("wordpress:db something:database", []string{"192.168.1.0/32"})
+	_, err := s.relationNetworks.Save("wordpress:db something:database", false, []string{"192.168.1.0/32"})
 	c.Assert(err, gc.ErrorMatches, ".*"+regexp.QuoteMeta(`"wordpress:db something:database" not found`))
 }
 
 func (s *relationNetworksSuite) TestSaveInvalidAddress(c *gc.C) {
-	_, err := s.relationNetworks.Save("wordpress:db mysql:server", []string{"192.168.1"})
+	_, err := s.relationNetworks.Save("wordpress:db mysql:server", false, []string{"192.168.1"})
 	c.Assert(err, gc.ErrorMatches, regexp.QuoteMeta(`CIDR "192.168.1" not valid`))
 }
 
@@ -72,9 +72,9 @@ func (s *relationNetworksSuite) assertSavedIngressInfo(c *gc.C, relationKey stri
 	defer closer()
 
 	var raw bson.M
-	err := coll.FindId(fmt.Sprintf("%v:%v", relationKey, s.direction)).One(&raw)
+	err := coll.FindId(fmt.Sprintf("%v:%v:default", relationKey, s.direction)).One(&raw)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(raw["_id"], gc.Equals, fmt.Sprintf("%v:%v:%v", s.State.ModelUUID(), relationKey, s.direction))
+	c.Assert(raw["_id"], gc.Equals, fmt.Sprintf("%v:%v:%v:default", s.State.ModelUUID(), relationKey, s.direction))
 	var cidrs []string
 	for _, m := range raw["cidrs"].([]interface{}) {
 		cidrs = append(cidrs, m.(string))
@@ -83,17 +83,29 @@ func (s *relationNetworksSuite) assertSavedIngressInfo(c *gc.C, relationKey stri
 }
 
 func (s *relationNetworksSuite) TestSave(c *gc.C) {
-	rin, err := s.relationNetworks.Save("wordpress:db mysql:server", []string{"192.168.1.0/16"})
+	rin, err := s.relationNetworks.Save("wordpress:db mysql:server", false, []string{"192.168.1.0/16"})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(rin.RelationKey(), gc.Equals, "wordpress:db mysql:server")
 	c.Assert(rin.CIDRS(), jc.DeepEquals, []string{"192.168.1.0/16"})
 	s.assertSavedIngressInfo(c, "wordpress:db mysql:server", "192.168.1.0/16")
 }
 
-func (s *relationNetworksSuite) TestSaveIdempotent(c *gc.C) {
-	rin, err := s.relationNetworks.Save("wordpress:db mysql:server", []string{"192.168.1.0/16"})
+func (s *relationNetworksSuite) TestSaveAdminOverrides(c *gc.C) {
+	_, err := s.relationNetworks.Save("wordpress:db mysql:server", false, []string{"192.168.1.0/16"})
 	c.Assert(err, jc.ErrorIsNil)
-	rin, err = s.relationNetworks.Save("wordpress:db mysql:server", []string{"192.168.1.0/16"})
+	rin, err := s.relationNetworks.Save("wordpress:db mysql:server", true, []string{"10.2.0.0/16"})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(rin.RelationKey(), gc.Equals, "wordpress:db mysql:server")
+	c.Assert(rin.CIDRS(), jc.DeepEquals, []string{"10.2.0.0/16"})
+	result, err := s.relationNetworks.Networks("wordpress:db mysql:server")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result.CIDRS(), jc.DeepEquals, []string{"10.2.0.0/16"})
+}
+
+func (s *relationNetworksSuite) TestSaveIdempotent(c *gc.C) {
+	rin, err := s.relationNetworks.Save("wordpress:db mysql:server", false, []string{"192.168.1.0/16"})
+	c.Assert(err, jc.ErrorIsNil)
+	rin, err = s.relationNetworks.Save("wordpress:db mysql:server", false, []string{"192.168.1.0/16"})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(rin.RelationKey(), gc.Equals, "wordpress:db mysql:server")
 	c.Assert(rin.CIDRS(), jc.DeepEquals, []string{"192.168.1.0/16"})
@@ -101,7 +113,7 @@ func (s *relationNetworksSuite) TestSaveIdempotent(c *gc.C) {
 }
 
 func (s *relationNetworksSuite) TestNetworks(c *gc.C) {
-	_, err := s.relationNetworks.Save("wordpress:db mysql:server", []string{"192.168.1.0/16"})
+	_, err := s.relationNetworks.Save("wordpress:db mysql:server", false, []string{"192.168.1.0/16"})
 	c.Assert(err, jc.ErrorIsNil)
 	result, err := s.relationNetworks.Networks("wordpress:db mysql:server")
 	c.Assert(err, jc.ErrorIsNil)
@@ -111,15 +123,15 @@ func (s *relationNetworksSuite) TestNetworks(c *gc.C) {
 }
 
 func (s *relationNetworksSuite) TestUpdateCIDRs(c *gc.C) {
-	_, err := s.relationNetworks.Save("wordpress:db mysql:server", []string{"192.168.1.0/16"})
+	_, err := s.relationNetworks.Save("wordpress:db mysql:server", false, []string{"192.168.1.0/16"})
 	c.Assert(err, jc.ErrorIsNil)
-	_, err = s.relationNetworks.Save("wordpress:db mysql:server", []string{"10.0.0.1/16"})
+	_, err = s.relationNetworks.Save("wordpress:db mysql:server", false, []string{"10.0.0.1/16"})
 	c.Assert(err, jc.ErrorIsNil)
 	s.assertSavedIngressInfo(c, "wordpress:db mysql:server", "10.0.0.1/16")
 }
 
 func (s *relationIngressNetworksSuite) TestCrossContanination(c *gc.C) {
-	_, err := s.relationNetworks.Save("wordpress:db mysql:server", []string{"192.168.1.0/16"})
+	_, err := s.relationNetworks.Save("wordpress:db mysql:server", false, []string{"192.168.1.0/16"})
 	c.Assert(err, jc.ErrorIsNil)
 	egress := state.NewRelationEgressNetworks(s.State)
 	_, err = egress.Networks(s.relation.Tag().Id())
@@ -127,7 +139,7 @@ func (s *relationIngressNetworksSuite) TestCrossContanination(c *gc.C) {
 }
 
 func (s *relationEgressNetworksSuite) TestCrossContanination(c *gc.C) {
-	_, err := s.relationNetworks.Save("wordpress:db mysql:server", []string{"192.168.1.0/16"})
+	_, err := s.relationNetworks.Save("wordpress:db mysql:server", false, []string{"192.168.1.0/16"})
 	c.Assert(err, jc.ErrorIsNil)
 	ingress := state.NewRelationIngressNetworks(s.State)
 	_, err = ingress.Networks(s.relation.Tag().Id())

--- a/state/relationunit.go
+++ b/state/relationunit.go
@@ -6,7 +6,6 @@ package state
 import (
 	stderrors "errors"
 	"fmt"
-	"net"
 	"strings"
 
 	"github.com/juju/errors"
@@ -486,32 +485,6 @@ func (ru *RelationUnit) IngressAddress() (network.Address, error) {
 		return unit.PrivateAddress()
 	}
 
-	// If there's egress cidr's defined, we'll use that value.
-	// TODO(wallyworld) - this is an interim measure until network-get is updated.
-	// It's needed for postgresql which uses the value to set up the hba file.
-	// This substitution is only applicable where the user has set the ingress-cidrs
-	// model attribute, which is only relevant in the consuming model.
-	cfg, err := ru.st.ModelConfig()
-	if err != nil {
-		return network.Address{}, errors.Trace(err)
-	}
-	cidrs := cfg.EgressSubnets()
-	if len(cidrs) > 0 {
-		ip, _, err := net.ParseCIDR(cidrs[0])
-		if err != nil {
-			return network.Address{}, errors.Trace(err)
-		}
-		addrType := network.IPv4Address
-		if ip4 := ip.To4(); ip4 == nil {
-			addrType = network.IPv6Address
-		}
-		address := network.Address{
-			Value: ip.String(),
-			Type:  addrType,
-			Scope: network.ScopePublic,
-		}
-		return address, nil
-	}
 	address, err := unit.PublicAddress()
 	if err != nil {
 		// TODO(wallyworld) - it's ok to return a private address sometimes

--- a/state/relationunit_test.go
+++ b/state/relationunit_test.go
@@ -869,28 +869,6 @@ func (s *RelationUnitSuite) TestIngressAddressRemoteRelationNoPublicAddr(c *gc.C
 	c.Assert(address, gc.DeepEquals, network.NewScopedAddress("1.2.3.4", network.ScopeCloudLocal))
 }
 
-func (s *RelationUnitSuite) TestIngressAddressRemoteRelationEgressSubnets(c *gc.C) {
-	err := s.State.UpdateModelConfig(map[string]interface{}{"egress-subnets": "192.168.1.0/32"}, nil)
-	c.Assert(err, jc.ErrorIsNil)
-	prr := newRemoteProReqRelation(c, &s.ConnSuite)
-	err = prr.ru0.AssignToNewMachine()
-	c.Assert(err, jc.ErrorIsNil)
-	id, err := prr.ru0.AssignedMachineId()
-	c.Assert(err, jc.ErrorIsNil)
-	machine, err := s.State.Machine(id)
-	c.Assert(err, jc.ErrorIsNil)
-
-	err = machine.SetProviderAddresses(
-		network.NewScopedAddress("1.2.3.4", network.ScopeCloudLocal),
-		network.NewScopedAddress("4.3.2.1", network.ScopePublic),
-	)
-
-	address, err := prr.rru0.IngressAddress()
-	c.Assert(err, jc.ErrorIsNil)
-
-	c.Assert(address, gc.DeepEquals, network.NewScopedAddress("192.168.1.0", network.ScopePublic))
-}
-
 func (s *RelationUnitSuite) TestValidYes(c *gc.C) {
 	prr := newProReqRelation(c, &s.ConnSuite, charm.ScopeContainer)
 	rus := []*state.RelationUnit{prr.pru0, prr.pru1, prr.rru0, prr.rru1}

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -489,7 +489,7 @@ func (s *MultiModelStateSuite) TestWatchTwoModels(c *gc.C) {
 			},
 			triggerEvent: func(st *state.State) {
 				relIngress := state.NewRelationIngressNetworks(st)
-				_, err := relIngress.Save("wordpress:db mysql:database", []string{"1.2.3.4/32", "4.3.2.1/16"})
+				_, err := relIngress.Save("wordpress:db mysql:database", false, []string{"1.2.3.4/32", "4.3.2.1/16"})
 				c.Assert(err, jc.ErrorIsNil)
 			},
 		}, {
@@ -511,7 +511,7 @@ func (s *MultiModelStateSuite) TestWatchTwoModels(c *gc.C) {
 			},
 			triggerEvent: func(st *state.State) {
 				relIngress := state.NewRelationEgressNetworks(st)
-				_, err := relIngress.Save("wordpress:db mysql:database", []string{"1.2.3.4/32", "4.3.2.1/16"})
+				_, err := relIngress.Save("wordpress:db mysql:database", false, []string{"1.2.3.4/32", "4.3.2.1/16"})
 				c.Assert(err, jc.ErrorIsNil)
 			},
 		}, {
@@ -4766,19 +4766,25 @@ func (s *StateSuite) TestWatchRelationIngressNetworks(c *gc.C) {
 
 	// Initial ingress network creation.
 	relIngress := state.NewRelationIngressNetworks(s.State)
-	_, err := relIngress.Save(rel.Tag().Id(), []string{"1.2.3.4/32", "4.3.2.1/16"})
+	_, err := relIngress.Save(rel.Tag().Id(), false, []string{"1.2.3.4/32", "4.3.2.1/16"})
 	c.Assert(err, jc.ErrorIsNil)
 	wc.AssertChange("1.2.3.4/32", "4.3.2.1/16")
 	wc.AssertNoChange()
 
 	// Update value.
-	_, err = relIngress.Save(rel.Tag().Id(), []string{"1.2.3.4/32"})
+	_, err = relIngress.Save(rel.Tag().Id(), false, []string{"1.2.3.4/32"})
 	c.Assert(err, jc.ErrorIsNil)
 	wc.AssertChange("1.2.3.4/32")
 	wc.AssertNoChange()
 
+	// Update value, admin override.
+	_, err = relIngress.Save(rel.Tag().Id(), true, []string{"10.0.0.1/32"})
+	c.Assert(err, jc.ErrorIsNil)
+	wc.AssertChange("10.0.0.1/32")
+	wc.AssertNoChange()
+
 	// Same value.
-	_, err = relIngress.Save(rel.Tag().Id(), []string{"1.2.3.4/32"})
+	_, err = relIngress.Save(rel.Tag().Id(), true, []string{"10.0.0.1/32"})
 	c.Assert(err, jc.ErrorIsNil)
 	wc.AssertNoChange()
 
@@ -4803,7 +4809,7 @@ func (s *StateSuite) TestWatchRelationIngressNetworksIgnoresEgress(c *gc.C) {
 	wc.AssertNoChange()
 
 	relEgress := state.NewRelationEgressNetworks(s.State)
-	_, err := relEgress.Save(rel.Tag().Id(), []string{"1.2.3.4/32", "4.3.2.1/16"})
+	_, err := relEgress.Save(rel.Tag().Id(), false, []string{"1.2.3.4/32", "4.3.2.1/16"})
 	c.Assert(err, jc.ErrorIsNil)
 	wc.AssertNoChange()
 
@@ -4823,19 +4829,25 @@ func (s *StateSuite) TestWatchRelationEgressNetworks(c *gc.C) {
 
 	// Initial egress network creation.
 	relEgress := state.NewRelationEgressNetworks(s.State)
-	_, err := relEgress.Save(rel.Tag().Id(), []string{"1.2.3.4/32", "4.3.2.1/16"})
+	_, err := relEgress.Save(rel.Tag().Id(), false, []string{"1.2.3.4/32", "4.3.2.1/16"})
 	c.Assert(err, jc.ErrorIsNil)
 	wc.AssertChange("1.2.3.4/32", "4.3.2.1/16")
 	wc.AssertNoChange()
 
 	// Update value.
-	_, err = relEgress.Save(rel.Tag().Id(), []string{"1.2.3.4/32"})
+	_, err = relEgress.Save(rel.Tag().Id(), false, []string{"1.2.3.4/32"})
 	c.Assert(err, jc.ErrorIsNil)
 	wc.AssertChange("1.2.3.4/32")
 	wc.AssertNoChange()
 
+	// Update value, admin override.
+	_, err = relEgress.Save(rel.Tag().Id(), true, []string{"10.0.0.1/32"})
+	c.Assert(err, jc.ErrorIsNil)
+	wc.AssertChange("10.0.0.1/32")
+	wc.AssertNoChange()
+
 	// Same value.
-	_, err = relEgress.Save(rel.Tag().Id(), []string{"1.2.3.4/32"})
+	_, err = relEgress.Save(rel.Tag().Id(), true, []string{"10.0.0.1/32"})
 	c.Assert(err, jc.ErrorIsNil)
 	wc.AssertNoChange()
 
@@ -4860,7 +4872,7 @@ func (s *StateSuite) TestWatchRelationEgressNetworksIgnoresIngress(c *gc.C) {
 	wc.AssertNoChange()
 
 	relEgress := state.NewRelationIngressNetworks(s.State)
-	_, err := relEgress.Save(rel.Tag().Id(), []string{"1.2.3.4/32", "4.3.2.1/16"})
+	_, err := relEgress.Save(rel.Tag().Id(), false, []string{"1.2.3.4/32", "4.3.2.1/16"})
 	c.Assert(err, jc.ErrorIsNil)
 	wc.AssertNoChange()
 

--- a/worker/firewaller/firewaller_test.go
+++ b/worker/firewaller/firewaller_test.go
@@ -942,7 +942,7 @@ func (s *InstanceModeSuite) TestRemoteRelationProviderRoleOffering(c *gc.C) {
 
 	// Save a new ingress network against the relation.
 	rin := state.NewRelationIngressNetworks(s.State)
-	_, err = rin.Save(rel.Tag().Id(), []string{"10.0.0.4/16"})
+	_, err = rin.Save(rel.Tag().Id(), false, []string{"10.0.0.4/16"})
 	c.Assert(err, jc.ErrorIsNil)
 
 	//Ports opened.
@@ -954,11 +954,11 @@ func (s *InstanceModeSuite) TestRemoteRelationProviderRoleOffering(c *gc.C) {
 	c.Assert(s.mockClock.wait, gc.Equals, 3*time.Second)
 
 	// Change should be sent when ingress networks disappear.
-	_, err = rin.Save(rel.Tag().Id(), nil)
+	_, err = rin.Save(rel.Tag().Id(), false, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	s.assertPorts(c, inst, m.Id(), nil)
 
-	_, err = rin.Save(rel.Tag().Id(), []string{"10.0.0.4/16"})
+	_, err = rin.Save(rel.Tag().Id(), false, []string{"10.0.0.4/16"})
 	c.Assert(err, jc.ErrorIsNil)
 	s.assertPorts(c, inst, m.Id(), []network.IngressRule{
 		network.MustNewIngressRule("tcp", 3306, 3306, "10.0.0.4/16"),


### PR DESCRIPTION
## Description of change

Add egress-subnets to relation data.
Also delete some old incorrect code for determining the ingress-address.

The second commit adds an admin override option when saving relation networks. This sets up the state data model for later use, allowing an admin to control what ingress rules are used for a given relation.

## QA steps

smoke test CMR scenario
