### PR TITLE
Add client side for includes in bundles

### DIFF
--- a/cmd/juju/application/bundle.go
+++ b/cmd/juju/application/bundle.go
@@ -55,7 +55,7 @@ type deploymentLogger interface {
 // charm store client. The deployment is not transactional, and its progress is
 // notified using the given deployment logger.
 func deployBundle(
-	bundleFilePath string,
+	bundleDir string,
 	data *charm.BundleData,
 	channel csparams.Channel,
 	apiRoot DeployAPI,
@@ -71,14 +71,14 @@ func deployBundle(
 		return err
 	}
 	var verifyError error
-	if bundleFilePath == "" {
+	if bundleDir == "" {
 		verifyError = data.Verify(verifyConstraints, verifyStorage)
 	} else {
 		// Process includes in the bundle data.
-		if err := processBundleIncludes(bundleFilePath, data); err != nil {
+		if err := processBundleIncludes(bundleDir, data); err != nil {
 			return nil, errors.Annotate(err, "unable to process includes")
 		}
-		verifyError = data.VerifyLocal(bundleFilePath, verifyConstraints, verifyStorage)
+		verifyError = data.VerifyLocal(bundleDir, verifyConstraints, verifyStorage)
 	}
 	if verifyError != nil {
 		if verr, ok := verifyError.(*charm.VerificationError); ok {
@@ -116,7 +116,7 @@ func deployBundle(
 
 	// Instantiate the bundle handler.
 	h := &bundleHandler{
-		bundleDir:       bundleFilePath,
+		bundleDir:       bundleDir,
 		changes:         changes,
 		results:         make(map[string]string, numChanges),
 		channel:         channel,


### PR DESCRIPTION
There are times when deploying a bundle where the charm config is expecting more complicated config, such as a binary certificate, or a YAML config file. To make it easer to supply this configuration local bundlers are able to specify one of two new values for either options or annotations:
  include-file://filename
and
  include-base64://filename

The filename can be relative or absolute. If the path is relative, it is relative to the bundle file.

The file is read and used as the value for the specified key of the option or annotation.  If the underlying file is binary, then include-base64 should be used as it reads the file and base64 encodes the content.

The charms have to know that a particular value is base64 encoded content. This is one of the key missing parts that mojo adds that has been requested for default behaviour.

## QA steps

Deploy a local bundle that specifies some other files to be read for values.

## Documentation changes

Yes, this will need documentation additions for local bundles.
