### PR TITLE
Include relation ingress subnets in list-offers output

### DIFF
--- a/api/applicationoffers/client.go
+++ b/api/applicationoffers/client.go
@@ -109,6 +109,7 @@ func convertListResultsToModel(items []params.ApplicationOfferDetails) ([]crossm
 				Endpoint:        oc.Endpoint,
 				RelationId:      oc.RelationId,
 				Status:          oc.Status,
+				IngressSubnets:  oc.IngressSubnets,
 			})
 		}
 	}

--- a/api/applicationoffers/client_test.go
+++ b/api/applicationoffers/client_test.go
@@ -144,7 +144,10 @@ func (s *crossmodelMockSuite) TestList(c *gc.C) {
 					ApplicationName:  "db2-app",
 					CharmURL:         "cs:db2-5",
 					Connections: []params.OfferConnection{
-						{SourceModelTag: testing.ModelTag.String(), Username: "fred", RelationId: 3, Endpoint: "db", Status: "active"},
+						{SourceModelTag: testing.ModelTag.String(), Username: "fred", RelationId: 3,
+							Endpoint: "db", Status: "active",
+							IngressSubnets: []string{"10.0.0.0/8"},
+						},
 					},
 				}}
 			}
@@ -163,7 +166,10 @@ func (s *crossmodelMockSuite) TestList(c *gc.C) {
 			ApplicationName: "db2-app",
 			CharmURL:        "cs:db2-5",
 			Connections: []jujucrossmodel.OfferConnection{
-				{SourceModelUUID: testing.ModelTag.Id(), Username: "fred", RelationId: 3, Endpoint: "db", Status: "active"},
+				{SourceModelUUID: testing.ModelTag.Id(), Username: "fred", RelationId: 3,
+					Endpoint: "db", Status: "active",
+					IngressSubnets: []string{"10.0.0.0/8"},
+				},
 			},
 		}}})
 }

--- a/apiserver/common/crossmodel/auth.go
+++ b/apiserver/common/crossmodel/auth.go
@@ -277,6 +277,10 @@ func (a *AuthContext) Authenticator(sourceModelUUID, offerUUID string) *authenti
 func (a *authenticator) checkMacaroons(mac macaroon.Slice, requiredValues map[string]string) (map[string]string, error) {
 	logger.Debugf("check %d macaroons with required attrs: %v", len(mac), requiredValues)
 	for _, m := range mac {
+		if m == nil {
+			logger.Warningf("unexpected nil cross model macaroon")
+			continue
+		}
 		logger.Debugf("- mac %s", m.Id())
 	}
 	declared := checkers.InferDeclared(mac)

--- a/apiserver/common/crossmodel/interface.go
+++ b/apiserver/common/crossmodel/interface.go
@@ -67,7 +67,10 @@ type Backend interface {
 	ImportRemoteEntity(entity names.Tag, token string) error
 
 	// SaveIngressNetworks stores in state the ingress networks for the relation.
-	SaveIngressNetworks(relationKey string, cidrs []string) (RelationNetworks, error)
+	SaveIngressNetworks(relationKey string, cidrs []string) (state.RelationNetworks, error)
+
+	// Networks returns the networks for the specified relation.
+	IngressNetworks(relationKey string) (state.RelationNetworks, error)
 
 	// ApplicationOfferForUUID returns the application offer for the UUID.
 	ApplicationOfferForUUID(offerUUID string) (*crossmodel.ApplicationOffer, error)

--- a/apiserver/common/crossmodel/state.go
+++ b/apiserver/common/crossmodel/state.go
@@ -121,11 +121,14 @@ func (st stateShim) ApplicationOfferForUUID(offerUUID string) (*crossmodel.Appli
 	return state.NewApplicationOffers(st.State).ApplicationOfferForUUID(offerUUID)
 }
 
-type RelationNetworks state.RelationNetworks
-
-func (s stateShim) SaveIngressNetworks(relationKey string, cidrs []string) (RelationNetworks, error) {
+func (s stateShim) SaveIngressNetworks(relationKey string, cidrs []string) (state.RelationNetworks, error) {
 	api := state.NewRelationIngressNetworks(s.State)
 	return api.Save(relationKey, false, cidrs)
+}
+
+func (s stateShim) IngressNetworks(relationKey string) (state.RelationNetworks, error) {
+	api := state.NewRelationIngressNetworks(s.State)
+	return api.Networks(relationKey)
 }
 
 type relationShim struct {

--- a/apiserver/facades/agent/uniter/uniter_test.go
+++ b/apiserver/facades/agent/uniter/uniter_test.go
@@ -1794,7 +1794,7 @@ func (s *uniterSuite) TestEnterScope(c *gc.C) {
 	c.Assert(readSettings, gc.DeepEquals, map[string]interface{}{
 		"private-address": "1.2.3.4",
 		"ingress-address": "1.2.3.4",
-		"egress-subnets":  []interface{}{"1.2.3.4/32"},
+		"egress-subnets":  "1.2.3.4/32",
 	})
 }
 
@@ -2664,7 +2664,7 @@ func (s *uniterSuite) TestPrivateAddressWithRemoteRelation(c *gc.C) {
 	c.Assert(readSettings, gc.DeepEquals, map[string]interface{}{
 		"private-address": "4.3.2.1",
 		"ingress-address": "4.3.2.1",
-		"egress-subnets":  []interface{}{"4.3.2.1/32"},
+		"egress-subnets":  "4.3.2.1/32",
 	})
 }
 
@@ -2694,7 +2694,7 @@ func (s *uniterSuite) TestPrivateAddressWithRemoteRelationNoPublic(c *gc.C) {
 	c.Assert(readSettings, gc.DeepEquals, map[string]interface{}{
 		"private-address": "1.2.3.4",
 		"ingress-address": "1.2.3.4",
-		"egress-subnets":  []interface{}{"1.2.3.4/32"},
+		"egress-subnets":  "1.2.3.4/32",
 	})
 }
 
@@ -2705,7 +2705,7 @@ func (s *uniterSuite) TestRelationEgressSubnets(c *gc.C) {
 	err := s.State.UpdateModelConfig(map[string]interface{}{"egress-subnets": "192.168.0.0/16"}, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	egress := state.NewRelationEgressNetworks(s.State)
-	_, err = egress.Save(relTag.Id(), false, []string{"10.0.0.0/16"})
+	_, err = egress.Save(relTag.Id(), false, []string{"10.0.0.0/16", "10.1.2.0/8"})
 	c.Assert(err, jc.ErrorIsNil)
 
 	thisUniter := s.makeMysqlUniter(c)
@@ -2725,7 +2725,7 @@ func (s *uniterSuite) TestRelationEgressSubnets(c *gc.C) {
 	c.Assert(readSettings, gc.DeepEquals, map[string]interface{}{
 		"private-address": "4.3.2.1",
 		"ingress-address": "4.3.2.1",
-		"egress-subnets":  []interface{}{"10.0.0.0/16"},
+		"egress-subnets":  "10.0.0.0/16,10.1.2.0/8",
 	})
 }
 
@@ -2752,7 +2752,7 @@ func (s *uniterSuite) TestModelEgressSubnets(c *gc.C) {
 	c.Assert(readSettings, gc.DeepEquals, map[string]interface{}{
 		"private-address": "4.3.2.1",
 		"ingress-address": "4.3.2.1",
-		"egress-subnets":  []interface{}{"192.168.0.0/16"},
+		"egress-subnets":  "192.168.0.0/16",
 	})
 }
 

--- a/apiserver/facades/client/applicationoffers/applicationoffers_test.go
+++ b/apiserver/facades/client/applicationoffers/applicationoffers_test.go
@@ -247,6 +247,7 @@ func (s *applicationOffersSuite) assertList(c *gc.C, expectedErr error) {
 					Endpoint:       "db",
 					Username:       "fred",
 					Status:         "joined",
+					IngressSubnets: []string{"192.168.1.0/32", "10.0.0.0/8"},
 				}},
 			},
 		},

--- a/apiserver/facades/client/applicationoffers/base.go
+++ b/apiserver/facades/client/applicationoffers/base.go
@@ -164,6 +164,11 @@ func (api *BaseAPI) applicationOffersFromModel(
 				}
 				connDetails.Endpoint = ep.Name
 				connDetails.Status = string(rel.Status())
+				relIngress, err := backend.IngressNetworks(oc.RelationKey())
+				if err != nil {
+					return nil, errors.Trace(err)
+				}
+				connDetails.IngressSubnets = relIngress.CIDRS()
 				offer.Connections = append(offer.Connections, connDetails)
 			}
 		}

--- a/apiserver/facades/client/applicationoffers/mock_test.go
+++ b/apiserver/facades/client/applicationoffers/mock_test.go
@@ -398,6 +398,18 @@ func (m *mockState) OfferConnections(offerUUID string) ([]applicationoffers.Offe
 	return m.connections, nil
 }
 
+type mockRelationNetworks struct {
+	state.RelationNetworks
+}
+
+func (m *mockRelationNetworks) CIDRS() []string {
+	return []string{"192.168.1.0/32", "10.0.0.0/8"}
+}
+
+func (m *mockState) IngressNetworks(relationKey string) (state.RelationNetworks, error) {
+	return &mockRelationNetworks{}, nil
+}
+
 func (m *mockState) GetOfferAccess(offerUUID string, user names.UserTag) (permission.Access, error) {
 	access, ok := m.accessPerms[offerAccess{user: user, offerUUID: offerUUID}]
 	if !ok {

--- a/apiserver/params/crossmodel.go
+++ b/apiserver/params/crossmodel.go
@@ -62,11 +62,12 @@ type ApplicationOfferDetails struct {
 
 // OfferConnection holds details about a connection to an offer.
 type OfferConnection struct {
-	SourceModelTag string `json:"source-model-tag"`
-	RelationId     int    `json:"relation-id"`
-	Username       string `json:"username"`
-	Endpoint       string `json:"endpoint"`
-	Status         string `json:"status"`
+	SourceModelTag string   `json:"source-model-tag"`
+	RelationId     int      `json:"relation-id"`
+	Username       string   `json:"username"`
+	Endpoint       string   `json:"endpoint"`
+	Status         string   `json:"status"`
+	IngressSubnets []string `json:"ingress-subnets"`
 }
 
 // ListApplicationOffersResults is a result of listing application offers.

--- a/cmd/juju/crossmodel/list.go
+++ b/cmd/juju/crossmodel/list.go
@@ -212,11 +212,12 @@ type ListOfferItem struct {
 type offeredApplications map[string]ListOfferItem
 
 type offerConnectionStatus struct {
-	SourceModelUUID string `json:"source-model-uuid" yaml:"source-model-uuid"`
-	Username        string `json:"username" yaml:"username"`
-	RelationId      int    `json:"relation-id" yaml:"relation-id"`
-	Endpoint        string `json:"endpoint" yaml:"endpoint"`
-	Status          string `json:"status" yaml:"status"`
+	SourceModelUUID string   `json:"source-model-uuid" yaml:"source-model-uuid"`
+	Username        string   `json:"username" yaml:"username"`
+	RelationId      int      `json:"relation-id" yaml:"relation-id"`
+	Endpoint        string   `json:"endpoint" yaml:"endpoint"`
+	Status          string   `json:"status" yaml:"status"`
+	IngressSubnets  []string `json:"ingress-subnets,omitempty" yaml:"ingress-subnets,omitempty"`
 }
 
 func formatApplicationOfferDetails(store string, all []crossmodel.ApplicationOfferDetails) (offeredApplications, error) {
@@ -252,6 +253,7 @@ func convertOfferToListItem(url *crossmodel.ApplicationURL, offer crossmodel.App
 			RelationId:      conn.RelationId,
 			Endpoint:        conn.Endpoint,
 			Status:          conn.Status,
+			IngressSubnets:  conn.IngressSubnets,
 		})
 	}
 	return item

--- a/cmd/juju/crossmodel/list_test.go
+++ b/cmd/juju/crossmodel/list_test.go
@@ -150,6 +150,7 @@ func (s *ListSuite) TestListTabular(c *gc.C) {
 			RelationId:      1,
 			Endpoint:        "server",
 			Status:          "active",
+			IngressSubnets:  []string{"192.168.0.1/32", "10.0.0.0/8"},
 		},
 	}
 	conns2 := []model.OfferConnection{
@@ -176,11 +177,11 @@ func (s *ListSuite) TestListTabular(c *gc.C) {
 		c,
 		[]string{"--format", "tabular"},
 		`
-Offer      User  Relation id  Status  Endpoint  Interface  Role
-zdiff-db2  fred  1            active  server    mysql      provider
-           mary  1            active  server    mysql      provider
-           mary  2            active  db        db2        provider
-adiff-db2  mary  3            active  db        db2        provider
+Offer      User  Relation id  Status  Endpoint  Interface  Role      Ingress subnets
+zdiff-db2  fred  1            active  server    mysql      provider  
+           mary  1            active  server    mysql      provider  192.168.0.1/32,10.0.0.0/8
+           mary  2            active  db        db2        provider  
+adiff-db2  mary  3            active  db        db2        provider  
 
 `[1:],
 		"",
@@ -204,6 +205,7 @@ func (s *ListSuite) TestListYAML(c *gc.C) {
 			Status:          "active",
 			RelationId:      2,
 			Endpoint:        "http",
+			IngressSubnets:  []string{"192.168.0.1/32", "10.0.0.0/8"},
 		},
 	}
 
@@ -231,6 +233,9 @@ hosted-db2:
     relation-id: 2
     endpoint: http
     status: active
+    ingress-subnets:
+    - 192.168.0.1/32
+    - 10.0.0.0/8
 `[1:],
 		"",
 	)

--- a/cmd/juju/crossmodel/listformatter.go
+++ b/cmd/juju/crossmodel/listformatter.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"sort"
+	"strings"
 
 	"github.com/juju/ansiterm"
 	"github.com/juju/errors"
@@ -97,7 +98,7 @@ func formatListEndpointsTabular(writer io.Writer, offers offeredApplications) er
 	}
 	sort.Sort(allOffers)
 
-	w.Println("Offer", "User", "Relation id", "Status", "Endpoint", "Interface", "Role")
+	w.Println("Offer", "User", "Relation id", "Status", "Endpoint", "Interface", "Role", "Ingress subnets")
 	for _, offer := range allOffers {
 		// Sort endpoints alphabetically.
 		endpoints := []string{}
@@ -124,7 +125,7 @@ func formatListEndpointsTabular(writer io.Writer, offers offeredApplications) er
 			connEp := endpoints[conn.Endpoint]
 			w.Print(conn.Username, conn.RelationId)
 			w.PrintColor(RelationStatusColor(relation.Status(conn.Status)), conn.Status)
-			w.Println(connEp.Name, connEp.Interface, connEp.Role)
+			w.Println(connEp.Name, connEp.Interface, connEp.Role, strings.Join(conn.IngressSubnets, ","))
 		}
 	}
 	tw.Flush()

--- a/core/crossmodel/params.go
+++ b/core/crossmodel/params.go
@@ -46,6 +46,9 @@ type OfferConnection struct {
 
 	// Status is the status of the offer connection.
 	Status string
+
+	// IngressSubnets is the list of subnets from which traffic will originate.
+	IngressSubnets []string
 }
 
 // ApplicationOfferDetailsResult is a result of listing a remote application.


### PR DESCRIPTION
## Description of change

When listing offers and showing connections to those offers, we now include any relation ingress subnets in the output. Relation ingress subnets are those from which workload traffic will originate for a specified relation.
Also include a driveby fix for egress subnets in relation settings.

## QA steps

Run up a cmr scenario, using relate --via
$ juju offers
check that the expected subnet is included in the offers output

