### PR TITLE
Model firewall rules in state

### DIFF
--- a/state/allcollections.go
+++ b/state/allcollections.go
@@ -440,6 +440,9 @@ func allCollections() collectionSchema {
 		// relationNetworksC holds required ingress or egress cidrs for remote relations.
 		relationNetworksC: {},
 
+		// firewallRulesC holds firewall rules for defined service types.
+		firewallRulesC: {},
+
 		// ----------------------
 
 		// Raw-access collections
@@ -543,4 +546,5 @@ const (
 	remoteEntitiesC      = "remoteEntities"
 	externalControllersC = "externalControllers"
 	relationNetworksC    = "relationNetworks"
+	firewallRulesC       = "firewallRules"
 )

--- a/state/firewallrules.go
+++ b/state/firewallrules.go
@@ -1,0 +1,182 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package state
+
+import (
+	"net"
+
+	"github.com/juju/errors"
+	"gopkg.in/mgo.v2"
+	"gopkg.in/mgo.v2/bson"
+	"gopkg.in/mgo.v2/txn"
+)
+
+// FirewallRule instances describe the ingress networks
+// whitelist/blacklist for a given well known service.
+// Primarily, whitelisting allowed ingress subnets is the
+// main use case. However, blacklisting subnets is useful
+// to allow restrictions placed on incoming traffic for
+// cross model relations, where the source of traffic is
+// requested from the consuming side.
+// WellKnownService is either a well known internet service
+// (currently just SSH) or a Juju defined value.
+// Supported values are:
+// - ssh
+// - juju-controller
+// - juju-application-offer
+type FirewallRule struct {
+	// WellKnownService is the known service for the firewall rules entity.
+	WellKnownService WellKnownServiceType
+
+	// BlacklistCIDR is the blacklist CIDRs for the rule.
+	BlacklistCIDRs []string
+
+	// WhitelistCIDRS is the whitelist CIDRs for the rule.
+	WhitelistCIDRs []string
+}
+
+type firewallRulesDoc struct {
+	Id               string   `bson:"_id"`
+	WellKnownService string   `bson:"known-service"`
+	BlacklistCIDRS   []string `bson:"blacklist-cidrs"`
+	WhitelistCIDRS   []string `bson:"whitelist-cidrs"`
+}
+
+func (r *firewallRulesDoc) toRule() *FirewallRule {
+	return &FirewallRule{
+		WellKnownService: WellKnownServiceType(r.WellKnownService),
+		WhitelistCIDRs:   r.WhitelistCIDRS,
+		BlacklistCIDRs:   r.BlacklistCIDRS,
+	}
+}
+
+// FirewallRuler instances provide access to firewall rules in state.
+type FirewallRuler interface {
+	Save(service WellKnownServiceType, whiteListCidrs, blackListCidrs []string) (FirewallRule, error)
+	Rule(service WellKnownServiceType) (FirewallRule, error)
+	AllRules() ([]FirewallRule, error)
+}
+
+const (
+	// SSHRule is a rule for SSH connections.
+	SSHRule = WellKnownServiceType("ssh")
+
+	// JujuControllerRule is a rule for connections to the Juju controller.
+	JujuControllerRule = WellKnownServiceType("juju-controller")
+
+	// JujuApplicationOfferRule is a rule for connections to a Juju offer.
+	JujuApplicationOfferRule = WellKnownServiceType("juju-application-offer")
+)
+
+// WellKnownServiceType defines a service for which firewall rules may be applied.
+type WellKnownServiceType string
+
+func (v WellKnownServiceType) validate() error {
+	switch v {
+	case SSHRule, JujuControllerRule, JujuApplicationOfferRule:
+		return nil
+	}
+	return errors.NotValidf("well known service type %q", v)
+}
+
+type firewallRulesState struct {
+	st *State
+}
+
+// NewFirewallRules creates a FirewallRule instance backed by a state.
+func NewFirewallRules(st *State) *firewallRulesState {
+	return &firewallRulesState{st: st}
+}
+
+// Save stores the specified firewall rules.
+func (fw *firewallRulesState) Save(service WellKnownServiceType, whiteListCidrs, blackListCidrs []string) (*FirewallRule, error) {
+	if err := service.validate(); err != nil {
+		return nil, errors.Trace(err)
+	}
+	for _, cidr := range append(whiteListCidrs, blackListCidrs...) {
+		if _, _, err := net.ParseCIDR(cidr); err != nil {
+			return nil, errors.NotValidf("CIDR %q", cidr)
+		}
+	}
+	doc := firewallRulesDoc{
+		Id:               string(service),
+		WellKnownService: string(service),
+		WhitelistCIDRS:   whiteListCidrs,
+		BlacklistCIDRS:   blackListCidrs,
+	}
+	buildTxn := func(int) ([]txn.Op, error) {
+		model, err := fw.st.Model()
+		if err != nil {
+			return nil, errors.Annotate(err, "failed to load model")
+		}
+		if err := checkModelActive(fw.st); err != nil {
+			return nil, errors.Trace(err)
+		}
+
+		_, err = fw.Rule(service)
+		if err != nil && !errors.IsNotFound(err) {
+			return nil, errors.Trace(err)
+		}
+		var ops []txn.Op
+		if err == nil {
+			ops = []txn.Op{{
+				C:      firewallRulesC,
+				Id:     string(service),
+				Assert: txn.DocExists,
+				Update: bson.D{
+					{"$set", bson.D{{"whitelist-cidrs", whiteListCidrs}}},
+					{"$set", bson.D{{"blacklist-cidrs", blackListCidrs}}},
+				},
+			}, model.assertActiveOp()}
+		} else {
+			doc.WhitelistCIDRS = whiteListCidrs
+			doc.BlacklistCIDRS = blackListCidrs
+			ops = []txn.Op{{
+				C:      firewallRulesC,
+				Id:     doc.Id,
+				Assert: txn.DocMissing,
+				Insert: doc,
+			}, model.assertActiveOp()}
+		}
+		return ops, nil
+	}
+	if err := fw.st.db().Run(buildTxn); err != nil {
+		return nil, errors.Annotate(err, "failed to create firewall rules")
+	}
+
+	return doc.toRule(), nil
+}
+
+// Rule returns the firewall rule for the specified service.
+func (fw *firewallRulesState) Rule(service WellKnownServiceType) (*FirewallRule, error) {
+	coll, closer := fw.st.db().GetCollection(firewallRulesC)
+	defer closer()
+
+	var doc firewallRulesDoc
+	err := coll.FindId(string(service)).One(&doc)
+	if err == mgo.ErrNotFound {
+		return nil, errors.NotFoundf("firewall rules for service %v", service)
+	}
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return doc.toRule(), nil
+}
+
+// AllRules returns all the firewall rules.
+func (fw *firewallRulesState) AllRules() ([]*FirewallRule, error) {
+	coll, closer := fw.st.db().GetCollection(firewallRulesC)
+	defer closer()
+
+	var docs []firewallRulesDoc
+	err := coll.Find(nil).All(&docs)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	result := make([]*FirewallRule, len(docs))
+	for i, doc := range docs {
+		result[i] = doc.toRule()
+	}
+	return result, nil
+}

--- a/state/firewallrules_test.go
+++ b/state/firewallrules_test.go
@@ -1,0 +1,126 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package state_test
+
+import (
+	"regexp"
+
+	"github.com/juju/errors"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/mgo.v2/bson"
+
+	"github.com/juju/juju/state"
+)
+
+type FirewallRulesSuite struct {
+	ConnSuite
+}
+
+var _ = gc.Suite(&FirewallRulesSuite{})
+
+func (s *FirewallRulesSuite) TestSaveInvalidWhitelistCIDR(c *gc.C) {
+	rules := state.NewFirewallRules(s.State)
+	_, err := rules.Save(state.JujuControllerRule, []string{"192.168.1"}, nil)
+	c.Assert(err, gc.ErrorMatches, regexp.QuoteMeta(`CIDR "192.168.1" not valid`))
+}
+
+func (s *FirewallRulesSuite) TestSaveInvalidBlacklistCIDR(c *gc.C) {
+	rules := state.NewFirewallRules(s.State)
+	_, err := rules.Save(state.JujuControllerRule, []string{"10.0.0.0/8"}, []string{"192.168.1"})
+	c.Assert(err, gc.ErrorMatches, regexp.QuoteMeta(`CIDR "192.168.1" not valid`))
+}
+
+func (s *FirewallRulesSuite) assertSavedRules(c *gc.C, service state.WellKnownServiceType, expectedWhitelist, expectedBlacklist []string) {
+	coll, closer := state.GetCollection(s.State, "firewallRules")
+	defer closer()
+
+	var raw bson.M
+	err := coll.FindId(string(service)).One(&raw)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(raw["known-service"], gc.Equals, string(service))
+	var cidrs []string
+	for _, m := range raw["whitelist-cidrs"].([]interface{}) {
+		cidrs = append(cidrs, m.(string))
+	}
+	c.Assert(cidrs, jc.SameContents, expectedWhitelist)
+	cidrs = nil
+	for _, m := range raw["blacklist-cidrs"].([]interface{}) {
+		cidrs = append(cidrs, m.(string))
+	}
+	c.Assert(cidrs, jc.SameContents, expectedBlacklist)
+}
+
+func (s *FirewallRulesSuite) TestSaveInvalid(c *gc.C) {
+	rules := state.NewFirewallRules(s.State)
+	_, err := rules.Save("foo", []string{"192.168.1.0/16"}, []string{"10.0.0.0/8"})
+	c.Assert(err, jc.Satisfies, errors.IsNotValid)
+	c.Assert(err, gc.ErrorMatches, `well known service type "foo" not valid`)
+}
+
+func (s *FirewallRulesSuite) TestSave(c *gc.C) {
+	rules := state.NewFirewallRules(s.State)
+	r, err := rules.Save(state.SSHRule, []string{"192.168.1.0/16"}, []string{"10.0.0.0/8"})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(r.WellKnownService, gc.Equals, state.SSHRule)
+	c.Assert(r.WhitelistCIDRs, jc.DeepEquals, []string{"192.168.1.0/16"})
+	c.Assert(r.BlacklistCIDRs, jc.DeepEquals, []string{"10.0.0.0/8"})
+	s.assertSavedRules(c, state.SSHRule, []string{"192.168.1.0/16"}, []string{"10.0.0.0/8"})
+}
+
+func (s *FirewallRulesSuite) TestSaveIdempotent(c *gc.C) {
+	rules := state.NewFirewallRules(s.State)
+	r, err := rules.Save(state.SSHRule, []string{"192.168.1.0/16"}, []string{"10.0.0.0/8"})
+	c.Assert(err, jc.ErrorIsNil)
+	r, err = rules.Save(state.SSHRule, []string{"192.168.1.0/16"}, []string{"10.0.0.0/8"})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(r.WellKnownService, gc.Equals, state.SSHRule)
+	c.Assert(r.WhitelistCIDRs, jc.DeepEquals, []string{"192.168.1.0/16"})
+	c.Assert(r.BlacklistCIDRs, jc.DeepEquals, []string{"10.0.0.0/8"})
+	s.assertSavedRules(c, state.SSHRule, []string{"192.168.1.0/16"}, []string{"10.0.0.0/8"})
+}
+
+func (s *FirewallRulesSuite) TestRule(c *gc.C) {
+	rules := state.NewFirewallRules(s.State)
+	_, err := rules.Save(state.JujuApplicationOfferRule, []string{"192.168.1.0/16"}, []string{"10.0.0.0/8"})
+	c.Assert(err, jc.ErrorIsNil)
+	result, err := rules.Rule(state.JujuApplicationOfferRule)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result.WhitelistCIDRs, jc.DeepEquals, []string{"192.168.1.0/16"})
+	c.Assert(result.BlacklistCIDRs, jc.DeepEquals, []string{"10.0.0.0/8"})
+	_, err = rules.Rule(state.JujuControllerRule)
+	c.Assert(err, jc.Satisfies, errors.IsNotFound)
+}
+
+func (s *FirewallRulesSuite) TestAllRules(c *gc.C) {
+	rules := state.NewFirewallRules(s.State)
+	_, err := rules.Save(state.JujuApplicationOfferRule, []string{"192.168.1.0/16"}, []string{"10.0.0.0/8"})
+	c.Assert(err, jc.ErrorIsNil)
+	_, err = rules.Save(state.JujuControllerRule, []string{"192.168.2.0/16"}, nil)
+	c.Assert(err, jc.ErrorIsNil)
+	result, err := rules.AllRules()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result, gc.HasLen, 2)
+	appRuleIndex := 0
+	ctrlRuleIndex := 1
+	if result[0].WellKnownService == state.JujuControllerRule {
+		appRuleIndex = 1
+		ctrlRuleIndex = 0
+	}
+	c.Assert(result[appRuleIndex].WellKnownService, gc.Equals, state.JujuApplicationOfferRule)
+	c.Assert(result[appRuleIndex].WhitelistCIDRs, jc.DeepEquals, []string{"192.168.1.0/16"})
+	c.Assert(result[appRuleIndex].BlacklistCIDRs, jc.DeepEquals, []string{"10.0.0.0/8"})
+	c.Assert(result[ctrlRuleIndex].WellKnownService, gc.Equals, state.JujuControllerRule)
+	c.Assert(result[ctrlRuleIndex].WhitelistCIDRs, jc.DeepEquals, []string{"192.168.2.0/16"})
+	c.Assert(result[ctrlRuleIndex].BlacklistCIDRs, jc.DeepEquals, []string{})
+}
+
+func (s *FirewallRulesSuite) TestUpdate(c *gc.C) {
+	rules := state.NewFirewallRules(s.State)
+	_, err := rules.Save(state.JujuApplicationOfferRule, []string{"192.168.1.0/16"}, []string{"10.0.0.0/8"})
+	c.Assert(err, jc.ErrorIsNil)
+	_, err = rules.Save(state.JujuApplicationOfferRule, []string{"192.168.2.0/16"}, nil)
+	c.Assert(err, jc.ErrorIsNil)
+	s.assertSavedRules(c, state.JujuApplicationOfferRule, []string{"192.168.2.0/16"}, nil)
+}

--- a/state/migration_internal_test.go
+++ b/state/migration_internal_test.go
@@ -191,6 +191,7 @@ func (s *MigrationSuite) TestKnownCollections(c *gc.C) {
 		remoteEntitiesC,
 		externalControllersC,
 		relationNetworksC,
+		firewallRulesC,
 	)
 
 	envCollections := set.NewStrings()


### PR DESCRIPTION
## Description of change

Firewall rules are modelled to allow restrictions to be placed on incoming connections to a Juju model. The restrictions may be applied to a well known internet service like SSH, or a Juju defined service like connecting to a controller or to a remote offer. The currently supported services are:
- ssh
- juju controller connections
- connections to workloads defined by juju application offers

Note that the rules are globally applied to a given service - there's no scope to have fine grained rules on a per offer basis for example; rules are applied equally to all application offers.

## QA steps

No QA at this stage - just infrastructure.