### PR TITLE
Disallow self-reset and preserve old facade version.

### DIFF
--- a/apiserver/allfacades.go
+++ b/apiserver/allfacades.go
@@ -240,7 +240,8 @@ func AllFacades() *facade.Registry {
 	reg("Uniter", 7, uniter.NewUniterAPI)
 
 	reg("Upgrader", 1, upgrader.NewUpgraderFacade)
-	reg("UserManager", 2, usermanager.NewUserManagerAPI)
+	reg("UserManager", 1, usermanager.NewUserManagerAPI)
+	reg("UserManager", 2, usermanager.NewUserManagerAPI) // Adds ResetPassword
 
 	regRaw("AllWatcher", 1, NewAllWatcher, reflect.TypeOf((*SrvAllWatcher)(nil)))
 	// Note: AllModelWatcher uses the same infrastructure as AllWatcher

--- a/apiserver/facades/client/usermanager/usermanager.go
+++ b/apiserver/facades/client/usermanager/usermanager.go
@@ -387,6 +387,7 @@ func (api *UserManagerAPI) setPassword(arg params.EntityPassword) error {
 // ResetPassword resets password for supplied users by
 // invalidating current passwords (if any) and generating
 // new random secret keys which will be returned.
+// Users cannot reset their own password.
 func (api *UserManagerAPI) ResetPassword(args params.Entities) (params.AddUserResults, error) {
 	var result params.AddUserResults
 
@@ -411,7 +412,7 @@ func (api *UserManagerAPI) ResetPassword(args params.Entities) (params.AddUserRe
 			result.Results[i].Error = common.ServerError(err)
 			continue
 		}
-		if isSuperUser || api.apiUser == user.Tag() {
+		if isSuperUser && api.apiUser != user.Tag() {
 			key, err := user.ResetPassword()
 			if err != nil {
 				result.Results[i].Error = common.ServerError(err)

--- a/apiserver/facades/client/usermanager/usermanager_test.go
+++ b/apiserver/facades/client/usermanager/usermanager_test.go
@@ -895,9 +895,13 @@ func (s *userManagerSuite) TestResetPasswordControllerAdminForSelf(c *gc.C) {
 
 	err = alex.Refresh()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(results.Results[0].Tag, gc.DeepEquals, alex.Tag().String())
-	c.Assert(results.Results[0].SecretKey, gc.DeepEquals, alex.SecretKey())
-	c.Assert(alex.PasswordValid("dummy-secret"), jc.IsFalse)
+	c.Assert(results.Results, gc.DeepEquals, []params.AddUserResult{
+		params.AddUserResult{
+			Tag:   alex.Tag().String(),
+			Error: common.ServerError(common.ErrPerm),
+		},
+	})
+	c.Assert(alex.PasswordValid("dummy-secret"), jc.IsTrue)
 }
 
 func (s *userManagerSuite) TestResetPasswordNotControllerAdmin(c *gc.C) {
@@ -922,8 +926,8 @@ func (s *userManagerSuite) TestResetPasswordNotControllerAdmin(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results.Results, gc.DeepEquals, []params.AddUserResult{
 		params.AddUserResult{
-			Tag:       alex.Tag().String(),
-			SecretKey: alex.SecretKey(),
+			Tag:   alex.Tag().String(),
+			Error: common.ServerError(common.ErrPerm),
 		},
 		params.AddUserResult{
 			Tag:   barb.Tag().String(),
@@ -931,7 +935,7 @@ func (s *userManagerSuite) TestResetPasswordNotControllerAdmin(c *gc.C) {
 		},
 	})
 
-	c.Assert(alex.PasswordValid("password"), jc.IsFalse)
+	c.Assert(alex.PasswordValid("password"), jc.IsTrue)
 	c.Assert(barb.PasswordValid("password"), jc.IsTrue)
 }
 

--- a/featuretests/cmd_juju_user_test.go
+++ b/featuretests/cmd_juju_user_test.go
@@ -65,17 +65,18 @@ func (s *UserSuite) TestUserResetPasswordForSelf(c *gc.C) {
 	user, err := s.State.User(s.AdminUserTag(c))
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(user.PasswordValid("dummy-secret"), jc.IsTrue)
+
+	// Should not be able to reset own password
 	context, err := s.RunUserCommand(c, "", "change-user-password", "--reset")
 	c.Assert(err, jc.ErrorIsNil)
-	err = user.Refresh()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(user.PasswordValid("dummy-secret"), jc.IsFalse)
 	c.Assert(cmdtesting.Stdout(context), gc.Equals, "")
 	c.Assert(cmdtesting.Stderr(context), gc.Matches, `
-Your password has been reset.
-Please run:
-     juju register (.+)
-`[1:])
+You cannot reset your own password.
+If you want to change it, please call `[1:]+"`juju change-user-password`"+` without --reset option.
+`)
+	err = user.Refresh()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(user.PasswordValid("dummy-secret"), jc.IsTrue)
 }
 
 func (s *UserSuite) TestUserResetPasswordForOther(c *gc.C) {


### PR DESCRIPTION
## Description of change

Users are no longer allowed to reset their own password. If a user wants to have anew password, they can use normal "change password" workflow. Unit test are adjusted accordingly.

This PR also ensures that there exist a previous facade version for backward compatibility.

## QA steps

1. bootstrap
2. run 'juju change-user-password --reset' or 'juju change-user-password --reset <your user name>'
3. Either command in 2 should be disallowed.

## Documentation changes
n/a

## Bug reference
n/a
