### PR TITLE
Mv model config to mmodel receiver

### DIFF
--- a/agent/agentbootstrap/bootstrap_test.go
+++ b/agent/agentbootstrap/bootstrap_test.go
@@ -231,8 +231,12 @@ LXC_BRIDGE="ignored"`[1:])
 
 	// Check that controller model configuration has been added, and
 	// model constraints set.
-	newModelCfg, err := st.ModelConfig()
+	model, err = st.Model()
 	c.Assert(err, jc.ErrorIsNil)
+
+	newModelCfg, err := model.ModelConfig()
+	c.Assert(err, jc.ErrorIsNil)
+
 	// Add in the cloud attributes.
 	expectedCfg, err := config.New(config.UseDefaults, modelAttrs)
 	c.Assert(err, jc.ErrorIsNil)
@@ -259,7 +263,7 @@ LXC_BRIDGE="ignored"`[1:])
 	c.Assert(hostedModel.Name(), gc.Equals, "hosted")
 	c.Assert(hostedModel.CloudRegion(), gc.Equals, "dummy-region")
 	c.Assert(hostedModel.EnvironVersion(), gc.Equals, 123)
-	hostedCfg, err := hostedModelSt.ModelConfig()
+	hostedCfg, err := hostedModel.ModelConfig()
 	c.Assert(err, jc.ErrorIsNil)
 	_, hasUnexpected := hostedCfg.AllAttrs()["not-for-hosted"]
 	c.Assert(hasUnexpected, jc.IsFalse)

--- a/api/agent/machine_test.go
+++ b/api/agent/machine_test.go
@@ -173,7 +173,7 @@ func (s *machineSuite) TestEntitySetPassword(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	info.Tag = tag
 	info.Password = "foo-12345678901234567890"
-	err = tryOpenState(s.State.ModelTag(), s.State.ControllerTag(), info)
+	err = tryOpenState(s.IAASModel.ModelTag(), s.State.ControllerTag(), info)
 	c.Assert(errors.Cause(err), jc.Satisfies, errors.IsUnauthorized)
 }
 

--- a/api/agent/model_test.go
+++ b/api/agent/model_test.go
@@ -29,6 +29,6 @@ func (s *modelSuite) SetUpTest(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.ModelWatcherTests = apitesting.NewModelWatcherTests(
-		agentAPI, s.BackingState,
+		agentAPI, s.BackingState, s.IAASModel.Model,
 	)
 }

--- a/api/apiclient_test.go
+++ b/api/apiclient_test.go
@@ -166,7 +166,7 @@ func (s *apiclientSuite) TestOpen(c *gc.C) {
 	c.Assert(st.Addr(), gc.Equals, info.Addrs[0])
 	modelTag, ok := st.ModelTag()
 	c.Assert(ok, jc.IsTrue)
-	c.Assert(modelTag, gc.Equals, s.State.ModelTag())
+	c.Assert(modelTag, gc.Equals, s.IAASModel.ModelTag())
 
 	remoteVersion, versionSet := st.ServerVersion()
 	c.Assert(versionSet, jc.IsTrue)
@@ -192,7 +192,7 @@ func (s *apiclientSuite) TestOpenHonorsModelTag(c *gc.C) {
 	c.Check(params.ErrCode(err), gc.Equals, params.CodeModelNotFound)
 
 	// Now set it to the right tag, and we should succeed.
-	info.ModelTag = s.State.ModelTag()
+	info.ModelTag = s.IAASModel.ModelTag()
 	st, err := api.Open(info, api.DialOpts{})
 	c.Assert(err, jc.ErrorIsNil)
 	st.Close()

--- a/api/backups/download_test.go
+++ b/api/backups/download_test.go
@@ -11,6 +11,7 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/backups"
 	"github.com/juju/juju/testing"
 )
@@ -22,12 +23,16 @@ type downloadSuite struct {
 var _ = gc.Suite(&downloadSuite{})
 
 func (s *downloadSuite) TestSuccessfulRequest(c *gc.C) {
-	store := backups.NewStorage(s.State)
+	db := struct {
+		*state.State
+		*state.Model
+	}{s.State, s.IAASModel.Model}
+	store := backups.NewStorage(db)
 	defer store.Close()
 	backupsState := backups.NewBackups(store)
 
 	r := strings.NewReader("<compressed archive data>")
-	meta, err := backups.NewMetadataState(s.State, "0", "xenial")
+	meta, err := backups.NewMetadataState(db, "0", "xenial")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(meta.CACert, gc.Equals, testing.CACert)
 	c.Assert(meta.CAPrivateKey, gc.Equals, testing.CAKey)

--- a/api/client_test.go
+++ b/api/client_test.go
@@ -143,7 +143,9 @@ func (s *clientSuite) TestAddLocalCharmOtherModel(c *gc.C) {
 func (s *clientSuite) otherModel(c *gc.C) (*state.State, api.Connection) {
 	otherSt := s.Factory.MakeModel(c, nil)
 	info := s.APIInfo(c)
-	info.ModelTag = otherSt.ModelTag()
+	model, err := otherSt.Model()
+	c.Assert(err, jc.ErrorIsNil)
+	info.ModelTag = model.ModelTag()
 	apiState, err := api.Open(info, api.DefaultDialOpts())
 	c.Assert(err, jc.ErrorIsNil)
 	return otherSt, apiState
@@ -514,7 +516,7 @@ func (s *clientSuite) TestSetModelAgentVersionDuringUpgrade(c *gc.C) {
 	// This is an integration test which ensure that a test with the
 	// correct error code is seen by the client from the
 	// SetModelAgentVersion call when an upgrade is in progress.
-	envConfig, err := s.State.ModelConfig()
+	envConfig, err := s.IAASModel.ModelConfig()
 	c.Assert(err, jc.ErrorIsNil)
 	agentVersion, ok := envConfig.AgentVersion()
 	c.Assert(ok, jc.IsTrue)

--- a/api/controller/legacy_test.go
+++ b/api/controller/legacy_test.go
@@ -294,7 +294,7 @@ func (s *legacySuite) TestModelStatus(c *gc.C) {
 	sysManager := s.OpenAPI(c)
 	defer sysManager.Close()
 	s.Factory.MakeMachine(c, nil)
-	modelTag := s.State.ModelTag()
+	modelTag := s.IAASModel.ModelTag()
 	results, err := sysManager.ModelStatus(modelTag)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, jc.DeepEquals, []base.ModelStatus{{

--- a/api/firewaller/state_test.go
+++ b/api/firewaller/state_test.go
@@ -22,7 +22,7 @@ var _ = gc.Suite(&stateSuite{})
 
 func (s *stateSuite) SetUpTest(c *gc.C) {
 	s.firewallerSuite.SetUpTest(c)
-	s.ModelWatcherTests = apitesting.NewModelWatcherTests(s.firewaller, s.BackingState)
+	s.ModelWatcherTests = apitesting.NewModelWatcherTests(s.firewaller, s.BackingState, s.IAASModel.Model)
 }
 
 func (s *stateSuite) TearDownTest(c *gc.C) {

--- a/api/http_test.go
+++ b/api/http_test.go
@@ -182,7 +182,9 @@ func (s *httpSuite) TestControllerMachineAuthForHostedModel(c *gc.C) {
 	apiInfo := s.APIInfo(c)
 	apiInfo.Tag = m.Tag()
 	apiInfo.Password = password
-	apiInfo.ModelTag = hostedState.ModelTag()
+	hostedModel, err := hostedState.Model()
+	c.Assert(err, jc.ErrorIsNil)
+	apiInfo.ModelTag = hostedModel.ModelTag()
 	apiInfo.Nonce = nonce
 	conn, err := api.Open(apiInfo, api.DialOpts{})
 	c.Assert(err, jc.ErrorIsNil)

--- a/api/keymanager/client_test.go
+++ b/api/keymanager/client_test.go
@@ -71,7 +71,7 @@ func clientError(message string) *params.Error {
 }
 
 func (s *keymanagerSuite) assertModelKeys(c *gc.C, expected []string) {
-	envConfig, err := s.State.ModelConfig()
+	envConfig, err := s.IAASModel.ModelConfig()
 	c.Assert(err, jc.ErrorIsNil)
 	keys := envConfig.AuthorizedKeys()
 	c.Assert(keys, gc.Equals, strings.Join(expected, "\n"))

--- a/api/provisioner/provisioner_test.go
+++ b/api/provisioner/provisioner_test.go
@@ -78,7 +78,7 @@ func (s *provisionerSuite) SetUpTest(c *gc.C) {
 	s.provisioner = provisioner.NewState(s.st)
 	c.Assert(s.provisioner, gc.NotNil)
 
-	s.ModelWatcherTests = apitesting.NewModelWatcherTests(s.provisioner, s.BackingState)
+	s.ModelWatcherTests = apitesting.NewModelWatcherTests(s.provisioner, s.BackingState, s.IAASModel.Model)
 	s.APIAddresserTests = apitesting.NewAPIAddresserTests(s.provisioner, s.BackingState)
 }
 

--- a/api/pubsub/pubsub_test.go
+++ b/api/pubsub/pubsub_test.go
@@ -165,7 +165,7 @@ func (s *PubSubIntegrationSuite) connect(c *gc.C) apipubsub.MessageWriter {
 	info := &api.Info{
 		Addrs:    []string{s.address},
 		CACert:   coretesting.CACert,
-		ModelTag: s.State.ModelTag(),
+		ModelTag: s.IAASModel.ModelTag(),
 		Tag:      s.machineTag,
 		Password: s.password,
 		Nonce:    s.nonce,

--- a/api/state_macaroon_test.go
+++ b/api/state_macaroon_test.go
@@ -90,7 +90,7 @@ func (s *macaroonLoginSuite) TestConnectStream(c *gc.C) {
 	defer conn.Close()
 	connectURL, err := url.Parse(catcher.location)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(connectURL.Path, gc.Equals, "/model/"+s.State.ModelTag().Id()+"/path")
+	c.Assert(connectURL.Path, gc.Equals, "/model/"+s.IAASModel.ModelTag().Id()+"/path")
 	c.Assert(dischargeCount, gc.Equals, 1)
 }
 

--- a/api/testing/environwatcher.go
+++ b/api/testing/environwatcher.go
@@ -21,20 +21,23 @@ type ModelWatcherFacade interface {
 type ModelWatcherTests struct {
 	facade ModelWatcherFacade
 	state  *state.State
+	model  *state.Model
 }
 
 func NewModelWatcherTests(
 	facade ModelWatcherFacade,
 	st *state.State,
+	m *state.Model,
 ) *ModelWatcherTests {
 	return &ModelWatcherTests{
 		facade: facade,
 		state:  st,
+		model:  m,
 	}
 }
 
 func (s *ModelWatcherTests) TestModelConfig(c *gc.C) {
-	envConfig, err := s.state.ModelConfig()
+	envConfig, err := s.model.ModelConfig()
 	c.Assert(err, jc.ErrorIsNil)
 
 	conf, err := s.facade.ModelConfig()
@@ -44,7 +47,7 @@ func (s *ModelWatcherTests) TestModelConfig(c *gc.C) {
 }
 
 func (s *ModelWatcherTests) TestWatchForModelConfigChanges(c *gc.C) {
-	envConfig, err := s.state.ModelConfig()
+	envConfig, err := s.model.ModelConfig()
 	c.Assert(err, jc.ErrorIsNil)
 
 	w, err := s.facade.WatchForModelConfigChanges()

--- a/api/uniter/state_test.go
+++ b/api/uniter/state_test.go
@@ -25,11 +25,11 @@ var _ = gc.Suite(&stateSuite{})
 func (s *stateSuite) SetUpTest(c *gc.C) {
 	s.uniterSuite.SetUpTest(c)
 	s.APIAddresserTests = apitesting.NewAPIAddresserTests(s.uniter, s.BackingState)
-	s.ModelWatcherTests = apitesting.NewModelWatcherTests(s.uniter, s.BackingState)
+	s.ModelWatcherTests = apitesting.NewModelWatcherTests(s.uniter, s.BackingState, s.IAASModel.Model)
 }
 
 func (s *stateSuite) TestProviderType(c *gc.C) {
-	cfg, err := s.State.ModelConfig()
+	cfg, err := s.IAASModel.ModelConfig()
 	c.Assert(err, jc.ErrorIsNil)
 
 	providerType, err := s.uniter.ProviderType()

--- a/api/watcher/watcher_test.go
+++ b/api/watcher/watcher_test.go
@@ -195,7 +195,7 @@ func (s *watcherSuite) TestWatchMachineStorage(c *gc.C) {
 
 	var results params.MachineStorageIdsWatchResults
 	args := params.Entities{Entities: []params.Entity{{
-		Tag: s.State.ModelTag().String(),
+		Tag: s.IAASModel.ModelTag().String(),
 	}}}
 	err := s.stateAPI.APICall(
 		"StorageProvisioner",
@@ -293,7 +293,7 @@ func (s *watcherSuite) assertRelationStatusWatchResult(c *gc.C, rel *state.Relat
 		Store:    store,
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	mac, err := bakery.NewMacaroon(fmt.Sprintf("%v %v", s.State.ModelTag(), rel.Tag()), nil,
+	mac, err := bakery.NewMacaroon(fmt.Sprintf("%v %v", s.IAASModel.ModelTag(), rel.Tag()), nil,
 		[]checkers.Caveat{
 			checkers.DeclaredCaveat("source-model-uuid", s.State.ModelUUID()),
 			checkers.DeclaredCaveat("relation-key", rel.String()),
@@ -409,7 +409,11 @@ func (s *migrationSuite) TestMigrationStatusWatcher(c *gc.C) {
 	apiInfo := s.APIInfo(c)
 	apiInfo.Tag = m.Tag()
 	apiInfo.Password = password
-	apiInfo.ModelTag = hostedState.ModelTag()
+
+	hostedModel, err := hostedState.Model()
+	c.Assert(err, jc.ErrorIsNil)
+
+	apiInfo.ModelTag = hostedModel.ModelTag()
 	apiInfo.Nonce = nonce
 
 	apiConn, err := api.Open(apiInfo, api.DialOpts{})

--- a/apiserver/admin_test.go
+++ b/apiserver/admin_test.go
@@ -87,7 +87,7 @@ func (s *loginSuite) TestBadLogin(c *gc.C) {
 	// called with user-admin permissions automatically.
 	info, srv := newServer(c, s.pool)
 	defer assertStop(c, srv)
-	info.ModelTag = s.State.ModelTag()
+	info.ModelTag = s.IAASModel.ModelTag()
 
 	adminUser := s.AdminUserTag(c)
 
@@ -142,7 +142,7 @@ func (s *loginSuite) TestBadLogin(c *gc.C) {
 func (s *loginSuite) TestLoginAsDeactivatedUser(c *gc.C) {
 	info, srv := newServer(c, s.pool)
 	defer assertStop(c, srv)
-	info.ModelTag = s.State.ModelTag()
+	info.ModelTag = s.IAASModel.ModelTag()
 
 	st := s.openAPIWithoutLogin(c, info)
 	password := "password"
@@ -411,7 +411,7 @@ func (s *loginSuite) TestUsersAreNotRateLimited(c *gc.C) {
 
 	info.Tag = s.AdminUserTag(c)
 	info.Password = "dummy-secret"
-	info.ModelTag = s.State.ModelTag()
+	info.ModelTag = s.IAASModel.ModelTag()
 
 	delayChan, cleanup := apiserver.DelayLogins()
 	defer cleanup()
@@ -438,7 +438,7 @@ func (s *loginSuite) TestUsersAreNotRateLimited(c *gc.C) {
 func (s *loginSuite) TestNonModelUserLoginFails(c *gc.C) {
 	info, srv := newServer(c, s.pool)
 	defer assertStop(c, srv)
-	info.ModelTag = s.State.ModelTag()
+	info.ModelTag = s.IAASModel.ModelTag()
 	user := s.Factory.MakeUser(c, &factory.UserParams{Password: "dummy-password", NoModelUser: true})
 	ctag := names.NewControllerTag(s.State.ControllerUUID())
 	err := s.State.RemoveUserAccess(user.UserTag(), ctag)
@@ -499,7 +499,7 @@ func (s *loginSuite) TestFailedLoginDuringMaintenance(c *gc.C) {
 	}
 	info, srv := newServerWithConfig(c, s.pool, cfg)
 	defer assertStop(c, srv)
-	info.ModelTag = s.State.ModelTag()
+	info.ModelTag = s.IAASModel.ModelTag()
 
 	checkLogin := func(tag names.Tag) {
 		st := s.openAPIWithoutLogin(c, info)
@@ -517,7 +517,7 @@ func (s *baseLoginSuite) checkLoginWithValidator(c *gc.C, validator apiserver.Lo
 	cfg.Validator = validator
 	info, srv := newServerWithConfig(c, s.pool, cfg)
 	defer assertStop(c, srv)
-	info.ModelTag = s.State.ModelTag()
+	info.ModelTag = s.IAASModel.ModelTag()
 
 	st := s.openAPIWithoutLogin(c, info)
 
@@ -551,7 +551,7 @@ func (s *loginSuite) TestAnonymousModelLogin(c *gc.C) {
 	info, srv := newServer(c, s.pool)
 	defer assertStop(c, srv)
 
-	info.ModelTag = s.State.ModelTag()
+	info.ModelTag = s.IAASModel.ModelTag()
 	conn := s.openAPIWithoutLogin(c, info)
 
 	var result params.LoginResult
@@ -562,7 +562,7 @@ func (s *loginSuite) TestAnonymousModelLogin(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.UserInfo, gc.IsNil)
 	c.Assert(result.ControllerTag, gc.Equals, s.State.ControllerTag().String())
-	c.Assert(result.ModelTag, gc.Equals, s.State.ModelTag().String())
+	c.Assert(result.ModelTag, gc.Equals, s.IAASModel.ModelTag().String())
 	c.Assert(result.Facades, jc.DeepEquals, []params.FacadeVersions{
 		{Name: "CrossModelRelations", Versions: []int{1}},
 		{Name: "RelationStatusWatcher", Versions: []int{1}},
@@ -596,21 +596,21 @@ func (s *loginSuite) TestControllerModel(c *gc.C) {
 	info, srv := newServer(c, s.pool)
 	defer assertStop(c, srv)
 
-	info.ModelTag = s.State.ModelTag()
+	info.ModelTag = s.IAASModel.ModelTag()
 	st := s.openAPIWithoutLogin(c, info)
 
 	adminUser := s.AdminUserTag(c)
 	err := st.Login(adminUser, "dummy-secret", "", nil)
 	c.Assert(err, jc.ErrorIsNil)
 
-	s.assertRemoteModel(c, st, s.State.ModelTag())
+	s.assertRemoteModel(c, st, s.IAASModel.ModelTag())
 }
 
 func (s *loginSuite) TestControllerModelBadCreds(c *gc.C) {
 	info, srv := newServer(c, s.pool)
 	defer assertStop(c, srv)
 
-	info.ModelTag = s.State.ModelTag()
+	info.ModelTag = s.IAASModel.ModelTag()
 	st := s.openAPIWithoutLogin(c, info)
 
 	adminUser := s.AdminUserTag(c)
@@ -659,12 +659,14 @@ func (s *loginSuite) TestOtherModel(c *gc.C) {
 		Owner: modelOwner.UserTag(),
 	})
 	defer modelState.Close()
-	info.ModelTag = modelState.ModelTag()
+	model, err := modelState.Model()
+	c.Assert(err, jc.ErrorIsNil)
+	info.ModelTag = model.ModelTag()
 	st := s.openAPIWithoutLogin(c, info)
 
-	err := st.Login(modelOwner.UserTag(), "password", "", nil)
+	err = st.Login(modelOwner.UserTag(), "password", "", nil)
 	c.Assert(err, jc.ErrorIsNil)
-	s.assertRemoteModel(c, st, modelState.ModelTag())
+	s.assertRemoteModel(c, st, model.ModelTag())
 }
 
 func (s *loginSuite) TestMachineLoginOtherModel(c *gc.C) {
@@ -689,10 +691,12 @@ func (s *loginSuite) TestMachineLoginOtherModel(c *gc.C) {
 		Nonce: "nonce",
 	})
 
-	info.ModelTag = modelState.ModelTag()
+	model, err := modelState.Model()
+	c.Assert(err, jc.ErrorIsNil)
+	info.ModelTag = model.ModelTag()
 	st := s.openAPIWithoutLogin(c, info)
 
-	err := st.Login(machine.Tag(), password, "nonce", nil)
+	err = st.Login(machine.Tag(), password, "nonce", nil)
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -712,13 +716,15 @@ func (s *loginSuite) TestMachineLoginOtherModelNotProvisioned(c *gc.C) {
 	f2 := factory.NewFactory(modelState)
 	machine, password := f2.MakeUnprovisionedMachineReturningPassword(c, &factory.MachineParams{})
 
-	info.ModelTag = modelState.ModelTag()
+	model, err := modelState.Model()
+	c.Assert(err, jc.ErrorIsNil)
+	info.ModelTag = model.ModelTag()
 	st := s.openAPIWithoutLogin(c, info)
 
 	// If the agent attempts Login before the provisioner has recorded
 	// the machine's nonce in state, then the agent should get back an
 	// error with code "not provisioned".
-	err := st.Login(machine.Tag(), password, "nonce", nil)
+	err = st.Login(machine.Tag(), password, "nonce", nil)
 	c.Assert(err, gc.ErrorMatches, `machine 0 not provisioned \(not provisioned\)`)
 	c.Assert(err, jc.Satisfies, params.IsCodeNotProvisioned)
 }
@@ -733,10 +739,12 @@ func (s *loginSuite) TestOtherModelFromController(c *gc.C) {
 
 	modelState := s.Factory.MakeModel(c, nil)
 	defer modelState.Close()
-	info.ModelTag = modelState.ModelTag()
+	model, err := modelState.Model()
+	c.Assert(err, jc.ErrorIsNil)
+	info.ModelTag = model.ModelTag()
 	st := s.openAPIWithoutLogin(c, info)
 
-	err := st.Login(machine.Tag(), password, "nonce", nil)
+	err = st.Login(machine.Tag(), password, "nonce", nil)
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -756,13 +764,15 @@ func (s *loginSuite) TestOtherModelFromControllerOtherNotProvisioned(c *gc.C) {
 	workloadMachine, _ := f2.MakeUnprovisionedMachineReturningPassword(c, &factory.MachineParams{})
 	c.Assert(managerMachine.Tag(), gc.Equals, workloadMachine.Tag())
 
-	info.ModelTag = hostedModelState.ModelTag()
+	hostedModel, err := hostedModelState.Model()
+	c.Assert(err, jc.ErrorIsNil)
+	info.ModelTag = hostedModel.ModelTag()
 	st := s.openAPIWithoutLogin(c, info)
 
 	// The fact that the machine with the same tag in the hosted
 	// model is unprovisioned should not cause the login to fail
 	// with "not provisioned", because the passwords don't match.
-	err := st.Login(managerMachine.Tag(), password, "nonce", nil)
+	err = st.Login(managerMachine.Tag(), password, "nonce", nil)
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -774,10 +784,13 @@ func (s *loginSuite) TestOtherModelWhenNotController(c *gc.C) {
 
 	modelState := s.Factory.MakeModel(c, nil)
 	defer modelState.Close()
-	info.ModelTag = modelState.ModelTag()
+
+	model, err := modelState.Model()
+	c.Assert(err, jc.ErrorIsNil)
+	info.ModelTag = model.ModelTag()
 	st := s.openAPIWithoutLogin(c, info)
 
-	err := st.Login(machine.Tag(), password, "nonce", nil)
+	err = st.Login(machine.Tag(), password, "nonce", nil)
 	assertPermissionDenied(c, err)
 }
 
@@ -802,7 +815,7 @@ func (s *loginSuite) loginLocalUser(c *gc.C, info *api.Info) (*state.User, param
 func (s *loginSuite) TestLoginResultLocalUser(c *gc.C) {
 	info, srv := newServer(c, s.pool)
 	defer assertStop(c, srv)
-	info.ModelTag = s.State.ModelTag()
+	info.ModelTag = s.IAASModel.ModelTag()
 
 	user, result := s.loginLocalUser(c, info)
 	c.Check(result.UserInfo.Identity, gc.Equals, user.Tag().String())
@@ -813,7 +826,7 @@ func (s *loginSuite) TestLoginResultLocalUser(c *gc.C) {
 func (s *loginSuite) TestLoginResultLocalUserEveryoneCreateOnlyNonLocal(c *gc.C) {
 	info, srv := newServer(c, s.pool)
 	defer assertStop(c, srv)
-	info.ModelTag = s.State.ModelTag()
+	info.ModelTag = s.IAASModel.ModelTag()
 
 	setEveryoneAccess(c, s.State, s.AdminUserTag(c), permission.AddModelAccess)
 
@@ -879,7 +892,7 @@ func (s *loginSuite) TestLoginUpdatesLastLoginAndConnection(c *gc.C) {
 	c.Assert(lastLogin.After(startTime), jc.IsTrue)
 
 	// The model user is also updated.
-	modelUser, err := s.State.UserAccess(user.UserTag(), s.State.ModelTag())
+	modelUser, err := s.State.UserAccess(user.UserTag(), s.IAASModel.ModelTag())
 	c.Assert(err, jc.ErrorIsNil)
 	when, err := s.Model.LastModelConnection(modelUser.UserTag)
 	c.Assert(err, jc.ErrorIsNil)
@@ -1073,7 +1086,7 @@ func (s *macaroonLoginSuite) testRemoteUserLoginToModelWithExplicitAccess(c *gc.
 
 	info, srv := newServerWithConfig(c, s.pool, cfg)
 	defer assertStop(c, srv)
-	info.ModelTag = s.State.ModelTag()
+	info.ModelTag = s.IAASModel.ModelTag()
 
 	// If we have a remote user which has explict model access, but neither
 	// controller access nor 'everyone' access, the user will have access

--- a/apiserver/apiserver_test.go
+++ b/apiserver/apiserver_test.go
@@ -100,7 +100,7 @@ func (s *apiserverBaseSuite) openAPIAs(c *gc.C, srv *apiserver.Server, tag names
 	apiInfo.Password = password
 	apiInfo.Nonce = nonce
 	if !controllerOnly {
-		apiInfo.ModelTag = s.State.ModelTag()
+		apiInfo.ModelTag = s.IAASModel.ModelTag()
 	}
 	conn, err := api.Open(apiInfo, api.DialOpts{})
 	c.Assert(err, jc.ErrorIsNil)

--- a/apiserver/backup_test.go
+++ b/apiserver/backup_test.go
@@ -38,7 +38,7 @@ func (s *backupsCommonSuite) SetUpTest(c *gc.C) {
 
 	s.fake = &backupstesting.FakeBackups{}
 	s.PatchValue(apiserver.NewBackups,
-		func(st *state.State) (backups.Backups, io.Closer) {
+		func(st *state.State, m *state.Model) (backups.Backups, io.Closer) {
 			return s.fake, ioutil.NopCloser(nil)
 		},
 	)

--- a/apiserver/common/controllerconfig_test.go
+++ b/apiserver/common/controllerconfig_test.go
@@ -98,17 +98,21 @@ func (*controllerConfigSuite) TestControllerInfo(c *gc.C) {
 type controllerInfoSuite struct {
 	jujutesting.JujuConnSuite
 
-	localModel *state.State
+	localState *state.State
+	localModel *state.Model
 }
 
 var _ = gc.Suite(&controllerInfoSuite{})
 
 func (s *controllerInfoSuite) SetUpTest(c *gc.C) {
 	s.JujuConnSuite.SetUpTest(c)
-	s.localModel = s.Factory.MakeModel(c, nil)
+	s.localState = s.Factory.MakeModel(c, nil)
 	s.AddCleanup(func(*gc.C) {
-		s.localModel.Close()
+		s.localState.Close()
 	})
+	model, err := s.localState.Model()
+	c.Assert(err, jc.ErrorIsNil)
+	s.localModel = model
 }
 
 func (s *controllerInfoSuite) TestControllerInfoLocalModel(c *gc.C) {

--- a/apiserver/common/crossmodel/state.go
+++ b/apiserver/common/crossmodel/state.go
@@ -47,6 +47,8 @@ func GetBackend(st *state.State) stateShim {
 	return stateShim{State: st, Model: model}
 }
 
+// TODO - CAAS(ericclaudejones): This should contain state alone, model will be
+// removed once all relevant methods are moved from state to model.
 type stateShim struct {
 	*state.State
 	*state.Model

--- a/apiserver/common/firewall/state.go
+++ b/apiserver/common/firewall/state.go
@@ -29,12 +29,15 @@ type State interface {
 }
 
 // TODO(wallyworld) - for tests, remove when remaining firewaller tests become unit tests.
-func StateShim(st *state.State) stateShim {
-	return stateShim{st}
+func StateShim(st *state.State, m *state.Model) stateShim {
+	return stateShim{st, m}
 }
 
+// TODO - CAAS(ericclaudejones): This should contain state alone, model will be
+// removed once all relevant methods are moved from state to model.
 type stateShim struct {
 	*state.State
+	*state.Model
 }
 
 func (st stateShim) KeyRelation(key string) (Relation, error) {

--- a/apiserver/common/modelmanagerinterface.go
+++ b/apiserver/common/modelmanagerinterface.go
@@ -215,3 +215,22 @@ func (st modelManagerStateShim) AllVolumes() ([]state.Volume, error) {
 	}
 	return model.AllVolumes()
 }
+
+// ModelConfig returns the underlying model's config. Exposed here to satisfy the
+// ModelBackend interface.
+func (st modelManagerStateShim) ModelConfig() (*config.Config, error) {
+	model, err := st.State.Model()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return model.ModelConfig()
+}
+
+// [TODO: Eric Claude Jones] This method ignores an error for the purpose of
+// expediting refactoring for CAAS features (we are avoiding changing method
+// signatures so that refactoring doesn't spiral out of control). This method
+// should be deleted immediately upon the removal of the ModelTag method from
+// state.State.
+func (st modelManagerStateShim) ModelTag() names.ModelTag {
+	return names.NewModelTag(st.ModelUUID())
+}

--- a/apiserver/common/modelstatus_test.go
+++ b/apiserver/common/modelstatus_test.go
@@ -85,7 +85,7 @@ func (s *modelStatusSuite) TestModelStatusNonAuth(c *gc.C) {
 			Auth_:      anAuthoriser,
 		})
 	c.Assert(err, jc.ErrorIsNil)
-	controllerModelTag := s.State.ModelTag().String()
+	controllerModelTag := s.IAASModel.ModelTag().String()
 
 	req := params.Entities{
 		Entities: []params.Entity{{Tag: controllerModelTag}},
@@ -111,8 +111,10 @@ func (s *modelStatusSuite) TestModelStatusOwnerAllowed(c *gc.C) {
 		})
 	c.Assert(err, jc.ErrorIsNil)
 
+	model, err := st.Model()
+	c.Assert(err, jc.ErrorIsNil)
 	req := params.Entities{
-		Entities: []params.Entity{{Tag: st.ModelTag().String()}},
+		Entities: []params.Entity{{Tag: model.ModelTag().String()}},
 	}
 	_, err = endpoint.ModelStatus(req)
 	c.Assert(err, jc.ErrorIsNil)
@@ -167,8 +169,11 @@ func (s *modelStatusSuite) TestModelStatus(c *gc.C) {
 		Charm: otherFactory.MakeCharm(c, nil),
 	})
 
-	controllerModelTag := s.State.ModelTag().String()
-	hostedModelTag := otherSt.ModelTag().String()
+	otherModel, err := otherSt.Model()
+	c.Assert(err, jc.ErrorIsNil)
+
+	controllerModelTag := s.IAASModel.ModelTag().String()
+	hostedModelTag := otherModel.ModelTag().String()
 
 	req := params.Entities{
 		Entities: []params.Entity{{Tag: controllerModelTag}, {Tag: hostedModelTag}},

--- a/apiserver/common/networkingcommon/networkconfigapi.go
+++ b/apiserver/common/networkingcommon/networkconfigapi.go
@@ -52,8 +52,12 @@ func (api *NetworkConfigAPI) getOneMachineProviderNetworkConfig(m *state.Machine
 		return nil, errors.Trace(err)
 	}
 
+	model, err := api.st.Model()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	netEnviron, err := NetworkingEnvironFromModelConfig(
-		stateenvirons.EnvironConfigGetter{api.st},
+		stateenvirons.EnvironConfigGetter{api.st, model},
 	)
 	if errors.IsNotSupported(err) {
 		logger.Infof("provider network config not supported: %v", err)

--- a/apiserver/common/networkingcommon/shims.go
+++ b/apiserver/common/networkingcommon/shims.go
@@ -5,6 +5,7 @@ package networkingcommon
 
 import (
 	"github.com/juju/errors"
+	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/network"
@@ -82,15 +83,22 @@ func (s *spaceShim) Subnets() ([]BackingSubnet, error) {
 	return subnets, nil
 }
 
-func NewStateShim(st *state.State) *stateShim {
-	return &stateShim{stateenvirons.EnvironConfigGetter{st}, st}
+func NewStateShim(st *state.State) (*stateShim, error) {
+	m, err := st.Model()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return &stateShim{stateenvirons.EnvironConfigGetter{st, m}, st, m}, nil
 }
 
 // stateShim forwards and adapts state.State methods to Backing
 // method.
+// TODO - CAAS(ericclaudejones): This should contain state and stateenvirons alone, model will be
+// removed once all relevant methods are moved from state to model.
 type stateShim struct {
 	stateenvirons.EnvironConfigGetter
 	st *state.State
+	m  *state.Model
 }
 
 func (s *stateShim) AddSpace(name string, providerId network.Id, subnetIds []string, public bool) error {
@@ -148,4 +156,8 @@ func (s *stateShim) AvailabilityZones() ([]providercommon.AvailabilityZone, erro
 
 func (s *stateShim) SetAvailabilityZones(zones []providercommon.AvailabilityZone) error {
 	return nil
+}
+
+func (s *stateShim) ModelTag() names.ModelTag {
+	return s.m.ModelTag()
 }

--- a/apiserver/common/testing/modelwatcher.go
+++ b/apiserver/common/testing/modelwatcher.go
@@ -36,7 +36,10 @@ func NewModelWatcherTest(
 // envWatcher.  This allows other tests that embed this type to have
 // more than just the default test.
 func (s *ModelWatcherTest) AssertModelConfig(c *gc.C, envWatcher ModelWatcher) {
-	envConfig, err := s.st.ModelConfig()
+	model, err := s.st.Model()
+	c.Assert(err, jc.ErrorIsNil)
+
+	envConfig, err := model.ModelConfig()
 	c.Assert(err, jc.ErrorIsNil)
 
 	result, err := envWatcher.ModelConfig()

--- a/apiserver/common/tools_test.go
+++ b/apiserver/common/tools_test.go
@@ -55,7 +55,7 @@ func (s *toolsSuite) TestTools(c *gc.C) {
 		}, nil
 	}
 	tg := common.NewToolsGetter(
-		s.State, stateenvirons.EnvironConfigGetter{s.State}, s.State, sprintfURLGetter("tools:%s"), getCanRead,
+		s.State, stateenvirons.EnvironConfigGetter{s.State, s.IAASModel.Model}, s.State, sprintfURLGetter("tools:%s"), getCanRead,
 	)
 	c.Assert(tg, gc.NotNil)
 
@@ -86,7 +86,7 @@ func (s *toolsSuite) TestToolsError(c *gc.C) {
 		return nil, fmt.Errorf("splat")
 	}
 	tg := common.NewToolsGetter(
-		s.State, stateenvirons.EnvironConfigGetter{s.State}, s.State, sprintfURLGetter("%s"), getCanRead,
+		s.State, stateenvirons.EnvironConfigGetter{s.State, s.IAASModel.Model}, s.State, sprintfURLGetter("%s"), getCanRead,
 	)
 	args := params.Entities{
 		Entities: []params.Entity{{Tag: "machine-42"}},
@@ -181,7 +181,7 @@ func (s *toolsSuite) TestFindTools(c *gc.C) {
 		return envtoolsList, nil
 	})
 	toolsFinder := common.NewToolsFinder(
-		stateenvirons.EnvironConfigGetter{s.State}, &mockToolsStorage{metadata: storageMetadata}, sprintfURLGetter("tools:%s"),
+		stateenvirons.EnvironConfigGetter{s.State, s.IAASModel.Model}, &mockToolsStorage{metadata: storageMetadata}, sprintfURLGetter("tools:%s"),
 	)
 	result, err := toolsFinder.FindTools(params.FindToolsParams{
 		MajorVersion: 123,
@@ -209,7 +209,7 @@ func (s *toolsSuite) TestFindToolsNotFound(c *gc.C) {
 	s.PatchValue(common.EnvtoolsFindTools, func(e environs.Environ, major, minor int, stream string, filter coretools.Filter) (list coretools.List, err error) {
 		return nil, errors.NotFoundf("tools")
 	})
-	toolsFinder := common.NewToolsFinder(stateenvirons.EnvironConfigGetter{s.State}, s.State, sprintfURLGetter("%s"))
+	toolsFinder := common.NewToolsFinder(stateenvirons.EnvironConfigGetter{s.State, s.IAASModel.Model}, s.State, sprintfURLGetter("%s"))
 	result, err := toolsFinder.FindTools(params.FindToolsParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.Error, jc.Satisfies, params.IsCodeNotFound)
@@ -253,7 +253,7 @@ func (s *toolsSuite) testFindToolsExact(c *gc.C, t common.ToolsStorageGetter, in
 		}
 		return nil, errors.NotFoundf("tools")
 	})
-	toolsFinder := common.NewToolsFinder(stateenvirons.EnvironConfigGetter{s.State}, t, sprintfURLGetter("tools:%s"))
+	toolsFinder := common.NewToolsFinder(stateenvirons.EnvironConfigGetter{s.State, s.IAASModel.Model}, t, sprintfURLGetter("tools:%s"))
 	result, err := toolsFinder.FindTools(params.FindToolsParams{
 		Number:       jujuversion.Current,
 		MajorVersion: -1,
@@ -277,7 +277,7 @@ func (s *toolsSuite) TestFindToolsToolsStorageError(c *gc.C) {
 		called = true
 		return nil, errors.NotFoundf("tools")
 	})
-	toolsFinder := common.NewToolsFinder(stateenvirons.EnvironConfigGetter{s.State}, &mockToolsStorage{
+	toolsFinder := common.NewToolsFinder(stateenvirons.EnvironConfigGetter{s.State, s.IAASModel.Model}, &mockToolsStorage{
 		err: errors.New("AllMetadata failed"),
 	}, sprintfURLGetter("tools:%s"))
 	result, err := toolsFinder.FindTools(params.FindToolsParams{

--- a/apiserver/facades/agent/agent/agent.go
+++ b/apiserver/facades/agent/agent/agent.go
@@ -43,14 +43,19 @@ func NewAgentAPIV2(st *state.State, resources facade.Resources, auth facade.Auth
 	getCanChange := func() (common.AuthFunc, error) {
 		return auth.AuthOwner, nil
 	}
+
+	model, err := st.Model()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	return &AgentAPIV2{
 		PasswordChanger:     common.NewPasswordChanger(st, getCanChange),
 		RebootFlagClearer:   common.NewRebootFlagClearer(st, getCanChange),
-		ModelWatcher:        common.NewModelWatcher(st, resources, auth),
+		ModelWatcher:        common.NewModelWatcher(model, resources, auth),
 		ControllerConfigAPI: common.NewStateControllerConfig(st),
 		CloudSpecAPI: cloudspec.NewCloudSpec(
 			cloudspec.MakeCloudSpecGetterForModel(st),
-			common.AuthFuncForTag(st.ModelTag()),
+			common.AuthFuncForTag(model.ModelTag()),
 		),
 		st:        st,
 		auth:      auth,

--- a/apiserver/facades/agent/keyupdater/authorisedkeys_test.go
+++ b/apiserver/facades/agent/keyupdater/authorisedkeys_test.go
@@ -75,7 +75,7 @@ func (s *authorisedKeysSuite) TestWatchAuthorisedKeysNothing(c *gc.C) {
 func (s *authorisedKeysSuite) setAuthorizedKeys(c *gc.C, keys string) {
 	err := s.State.UpdateModelConfig(map[string]interface{}{"authorized-keys": keys}, nil)
 	c.Assert(err, jc.ErrorIsNil)
-	envConfig, err := s.State.ModelConfig()
+	envConfig, err := s.IAASModel.ModelConfig()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(envConfig.AuthorizedKeys(), gc.Equals, keys)
 }

--- a/apiserver/facades/agent/logger/logger_test.go
+++ b/apiserver/facades/agent/logger/logger_test.go
@@ -75,7 +75,7 @@ func (s *loggerSuite) TestWatchLoggingConfigNothing(c *gc.C) {
 func (s *loggerSuite) setLoggingConfig(c *gc.C, loggingConfig string) {
 	err := s.State.UpdateModelConfig(map[string]interface{}{"logging-config": loggingConfig}, nil)
 	c.Assert(err, jc.ErrorIsNil)
-	envConfig, err := s.State.ModelConfig()
+	envConfig, err := s.IAASModel.ModelConfig()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(envConfig.LoggingConfig(), gc.Equals, loggingConfig)
 }

--- a/apiserver/facades/agent/metricsender/metricsender_test.go
+++ b/apiserver/facades/agent/metricsender/metricsender_test.go
@@ -27,6 +27,14 @@ type MetricSenderSuite struct {
 	clock       clock.Clock
 }
 
+// TODO(externalreality): This may go away once the separation of
+// responsibilities between state.State and the different model types become
+// visible in the code.
+type TestSenderBackend struct {
+	*state.State
+	*state.Model
+}
+
 var _ = gc.Suite(&MetricSenderSuite{})
 
 var _ metricsender.MetricSender = (*testing.MockSender)(nil)
@@ -80,7 +88,7 @@ func (s *MetricSenderSuite) TestSendMetrics(c *gc.C) {
 	unsent1 := s.Factory.MakeMetric(c, &factory.MetricParams{Unit: s.credUnit, Time: &now})
 	unsent2 := s.Factory.MakeMetric(c, &factory.MetricParams{Unit: s.meteredUnit, Time: &now})
 	s.Factory.MakeMetric(c, &factory.MetricParams{Unit: s.credUnit, Sent: true, Time: &now})
-	err := metricsender.SendMetrics(s.State, &sender, s.clock, 10, true)
+	err := metricsender.SendMetrics(TestSenderBackend{s.State, s.IAASModel.Model}, &sender, s.clock, 10, true)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(sender.Data, gc.HasLen, 1)
 	c.Assert(sender.Data[0], gc.HasLen, 2)
@@ -101,7 +109,7 @@ func (s *MetricSenderSuite) TestSendingHandlesModelMeterStatus(c *gc.C) {
 	s.Factory.MakeMetric(c, &factory.MetricParams{Unit: s.credUnit, Time: &now})
 	s.Factory.MakeMetric(c, &factory.MetricParams{Unit: s.meteredUnit, Time: &now})
 	s.Factory.MakeMetric(c, &factory.MetricParams{Unit: s.credUnit, Sent: true, Time: &now})
-	err := metricsender.SendMetrics(s.State, &sender, s.clock, 10, true)
+	err := metricsender.SendMetrics(TestSenderBackend{s.State, s.IAASModel.Model}, &sender, s.clock, 10, true)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(sender.Data, gc.HasLen, 1)
 	c.Assert(sender.Data[0], gc.HasLen, 2)
@@ -119,7 +127,7 @@ func (s *MetricSenderSuite) TestSendingHandlesEmptyModelMeterStatus(c *gc.C) {
 	s.Factory.MakeMetric(c, &factory.MetricParams{Unit: s.credUnit, Time: &now})
 	s.Factory.MakeMetric(c, &factory.MetricParams{Unit: s.meteredUnit, Time: &now})
 	s.Factory.MakeMetric(c, &factory.MetricParams{Unit: s.credUnit, Sent: true, Time: &now})
-	err := metricsender.SendMetrics(s.State, &sender, s.clock, 10, true)
+	err := metricsender.SendMetrics(TestSenderBackend{s.State, s.IAASModel.Model}, &sender, s.clock, 10, true)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(sender.Data, gc.HasLen, 1)
 	c.Assert(sender.Data[0], gc.HasLen, 2)
@@ -143,7 +151,7 @@ func (s *MetricSenderSuite) TestSendMetricsAbort(c *gc.C) {
 	sender.IgnoreBatches(metrics[0:2]...)
 
 	// Send 4 batches per POST.
-	err := metricsender.SendMetrics(s.State, sender, s.clock, 4, true)
+	err := metricsender.SendMetrics(TestSenderBackend{s.State, s.IAASModel.Model}, sender, s.clock, 4, true)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(sender.Data, gc.HasLen, 4)
 
@@ -171,7 +179,7 @@ func (s *MetricSenderSuite) TestHoldMetrics(c *gc.C) {
 	unsent1 := s.Factory.MakeMetric(c, &factory.MetricParams{Unit: s.credUnit, Time: &now})
 	unsent2 := s.Factory.MakeMetric(c, &factory.MetricParams{Unit: s.meteredUnit, Time: &now})
 	s.Factory.MakeMetric(c, &factory.MetricParams{Unit: s.credUnit, Sent: true, Time: &now})
-	err := metricsender.SendMetrics(s.State, &sender, s.clock, 10, false)
+	err := metricsender.SendMetrics(TestSenderBackend{s.State, s.IAASModel.Model}, &sender, s.clock, 10, false)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(sender.Data, gc.HasLen, 1)
 	c.Assert(sender.Data[0], gc.HasLen, 1)
@@ -195,7 +203,7 @@ func (s *MetricSenderSuite) TestHoldMetricsSetsMeterStatus(c *gc.C) {
 	unsent1 := s.Factory.MakeMetric(c, &factory.MetricParams{Unit: s.credUnit, Time: &now})
 	s.Factory.MakeMetric(c, &factory.MetricParams{Unit: s.meteredUnit, Time: &now})
 	s.Factory.MakeMetric(c, &factory.MetricParams{Unit: s.credUnit, Sent: true, Time: &now})
-	err = metricsender.SendMetrics(s.State, &sender, s.clock, 10, false)
+	err = metricsender.SendMetrics(TestSenderBackend{s.State, s.IAASModel.Model}, &sender, s.clock, 10, false)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(sender.Data, gc.HasLen, 1)
 	c.Assert(sender.Data[0], gc.HasLen, 1)
@@ -218,7 +226,7 @@ func (s *MetricSenderSuite) TestSendBulkMetrics(c *gc.C) {
 	for i := 0; i < 100; i++ {
 		s.Factory.MakeMetric(c, &factory.MetricParams{Unit: s.credUnit, Time: &now})
 	}
-	err := metricsender.SendMetrics(s.State, &sender, s.clock, 10, true)
+	err := metricsender.SendMetrics(TestSenderBackend{s.State, s.IAASModel.Model}, &sender, s.clock, 10, true)
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Assert(sender.Data, gc.HasLen, 10)
@@ -234,7 +242,7 @@ func (s *MetricSenderSuite) TestDontSendWithNopSender(c *gc.C) {
 	for i := 0; i < 3; i++ {
 		s.Factory.MakeMetric(c, &factory.MetricParams{Unit: s.credUnit, Sent: false, Time: &now})
 	}
-	err := metricsender.SendMetrics(s.State, metricsender.NopSender{}, s.clock, 10, true)
+	err := metricsender.SendMetrics(TestSenderBackend{s.State, s.IAASModel.Model}, metricsender.NopSender{}, s.clock, 10, true)
 	c.Assert(err, jc.ErrorIsNil)
 	sent, err := s.State.CountOfSentMetrics()
 	c.Assert(err, jc.ErrorIsNil)
@@ -247,7 +255,7 @@ func (s *MetricSenderSuite) TestFailureIncrementsConsecutiveFailures(c *gc.C) {
 	for i := 0; i < 3; i++ {
 		s.Factory.MakeMetric(c, &factory.MetricParams{Unit: s.credUnit, Sent: false, Time: &now})
 	}
-	err := metricsender.SendMetrics(s.State, sender, s.clock, 1, true)
+	err := metricsender.SendMetrics(TestSenderBackend{s.State, s.IAASModel.Model}, sender, s.clock, 1, true)
 	c.Assert(err, gc.ErrorMatches, "something went wrong")
 	mm, err := s.State.MetricsManager()
 	c.Assert(err, jc.ErrorIsNil)
@@ -263,7 +271,7 @@ func (s *MetricSenderSuite) TestFailuresResetOnSuccessfulSend(c *gc.C) {
 	for i := 0; i < 3; i++ {
 		s.Factory.MakeMetric(c, &factory.MetricParams{Unit: s.credUnit, Sent: false, Time: &now})
 	}
-	err = metricsender.SendMetrics(s.State, metricsender.NopSender{}, s.clock, 10, true)
+	err = metricsender.SendMetrics(TestSenderBackend{s.State, s.IAASModel.Model}, metricsender.NopSender{}, s.clock, 10, true)
 	c.Assert(err, jc.ErrorIsNil)
 	mm, err = s.State.MetricsManager()
 	c.Assert(err, jc.ErrorIsNil)

--- a/apiserver/facades/agent/metricsender/sender_test.go
+++ b/apiserver/facades/agent/metricsender/sender_test.go
@@ -68,7 +68,7 @@ func (s *SenderSuite) TestHTTPSender(c *gc.C) {
 		metrics[i] = s.Factory.MakeMetric(c, &factory.MetricParams{Unit: s.unit, Sent: false, Time: &now})
 	}
 	var sender metricsender.HTTPSender
-	err := metricsender.SendMetrics(s.State, &sender, s.clock, 10, true)
+	err := metricsender.SendMetrics(TestSenderBackend{s.State, s.IAASModel.Model}, &sender, s.clock, 10, true)
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Assert(receiverChan, gc.HasLen, metricCount)
@@ -149,7 +149,7 @@ func (s *SenderSuite) TestErrorCodes(c *gc.C) {
 			batches[i] = s.Factory.MakeMetric(c, &factory.MetricParams{Unit: s.unit, Sent: false, Time: &now})
 		}
 		var sender metricsender.HTTPSender
-		err := metricsender.SendMetrics(s.State, &sender, s.clock, 10, true)
+		err := metricsender.SendMetrics(TestSenderBackend{s.State, s.IAASModel.Model}, &sender, s.clock, 10, true)
 		c.Assert(err, gc.ErrorMatches, test.expectedErr)
 		for _, batch := range batches {
 			m, err := s.State.MetricBatch(batch.UUID())
@@ -178,7 +178,7 @@ func (s *SenderSuite) TestMeterStatus(c *gc.C) {
 	c.Assert(status.Code, gc.Equals, state.MeterNotSet)
 
 	var sender metricsender.HTTPSender
-	err = metricsender.SendMetrics(s.State, &sender, s.clock, 10, true)
+	err = metricsender.SendMetrics(TestSenderBackend{s.State, s.IAASModel.Model}, &sender, s.clock, 10, true)
 	c.Assert(err, jc.ErrorIsNil)
 
 	status, err = s.unit.GetMeterStatus()
@@ -223,7 +223,7 @@ func (s *SenderSuite) TestMeterStatusInvalid(c *gc.C) {
 	}
 
 	var sender metricsender.HTTPSender
-	err := metricsender.SendMetrics(s.State, &sender, s.clock, 10, true)
+	err := metricsender.SendMetrics(TestSenderBackend{s.State, s.IAASModel.Model}, &sender, s.clock, 10, true)
 	c.Assert(err, jc.ErrorIsNil)
 
 	status, err := unit1.GetMeterStatus()
@@ -245,7 +245,7 @@ func (s *SenderSuite) TestGracePeriodResponse(c *gc.C) {
 	cleanup := s.startServer(c, testHandler(c, nil, nil, 47*time.Hour))
 	defer cleanup()
 	var sender metricsender.HTTPSender
-	err := metricsender.SendMetrics(s.State, &sender, s.clock, 10, true)
+	err := metricsender.SendMetrics(TestSenderBackend{s.State, s.IAASModel.Model}, &sender, s.clock, 10, true)
 	c.Assert(err, jc.ErrorIsNil)
 	mm, err := s.State.MetricsManager()
 	c.Assert(err, jc.ErrorIsNil)
@@ -258,7 +258,7 @@ func (s *SenderSuite) TestNegativeGracePeriodResponse(c *gc.C) {
 	cleanup := s.startServer(c, testHandler(c, nil, nil, -47*time.Hour))
 	defer cleanup()
 	var sender metricsender.HTTPSender
-	err := metricsender.SendMetrics(s.State, &sender, s.clock, 10, true)
+	err := metricsender.SendMetrics(TestSenderBackend{s.State, s.IAASModel.Model}, &sender, s.clock, 10, true)
 	c.Assert(err, jc.ErrorIsNil)
 	mm, err := s.State.MetricsManager()
 	c.Assert(err, jc.ErrorIsNil)
@@ -271,7 +271,7 @@ func (s *SenderSuite) TestZeroGracePeriodResponse(c *gc.C) {
 	cleanup := s.startServer(c, testHandler(c, nil, nil, 0))
 	defer cleanup()
 	var sender metricsender.HTTPSender
-	err := metricsender.SendMetrics(s.State, &sender, s.clock, 10, true)
+	err := metricsender.SendMetrics(TestSenderBackend{s.State, s.IAASModel.Model}, &sender, s.clock, 10, true)
 	c.Assert(err, jc.ErrorIsNil)
 	mm, err := s.State.MetricsManager()
 	c.Assert(err, jc.ErrorIsNil)

--- a/apiserver/facades/agent/provisioner/provisioninginfo.go
+++ b/apiserver/facades/agent/provisioner/provisioninginfo.go
@@ -129,7 +129,7 @@ func (p *ProvisionerAPI) machineVolumeParams(
 	if len(volumeAttachments) == 0 {
 		return nil, nil, nil
 	}
-	modelConfig, err := p.st.ModelConfig()
+	modelConfig, err := p.m.ModelConfig()
 	if err != nil {
 		return nil, nil, errors.Trace(err)
 	}
@@ -222,7 +222,7 @@ func (p *ProvisionerAPI) machineTags(m *state.Machine, jobs []multiwatcher.Machi
 	}
 	sort.Strings(unitNames)
 
-	cfg, err := p.st.ModelConfig()
+	cfg, err := p.m.ModelConfig()
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/apiserver/facades/agent/proxyupdater/model.go
+++ b/apiserver/facades/agent/proxyupdater/model.go
@@ -10,5 +10,9 @@ import (
 
 // NewAPI creates a new API server-side facade with a state.State backing.
 func NewAPI(st *state.State, res facade.Resources, auth facade.Authorizer) (*ProxyUpdaterAPI, error) {
-	return NewAPIWithBacking(&stateShim{st: st}, res, auth)
+	m, err := st.Model()
+	if err != nil {
+		return nil, err
+	}
+	return NewAPIWithBacking(&stateShim{st: st, m: m}, res, auth)
 }

--- a/apiserver/facades/agent/proxyupdater/shims.go
+++ b/apiserver/facades/agent/proxyupdater/shims.go
@@ -10,12 +10,15 @@ import (
 )
 
 // stateShim forwards and adapts state.State methods to Backend
+// TODO - CAAS(ericclaudejones): This should contain state alone, model will be
+// removed once all relevant methods are moved from state to model.
 type stateShim struct {
 	st *state.State
+	m  *state.Model
 }
 
 func (s *stateShim) ModelConfig() (*config.Config, error) {
-	return s.st.ModelConfig()
+	return s.m.ModelConfig()
 }
 
 func (s *stateShim) APIHostPorts() ([][]network.HostPort, error) {
@@ -27,5 +30,5 @@ func (s *stateShim) WatchAPIHostPorts() state.NotifyWatcher {
 }
 
 func (s *stateShim) WatchForModelConfigChanges() state.NotifyWatcher {
-	return s.st.WatchForModelConfigChanges()
+	return s.m.WatchForModelConfigChanges()
 }

--- a/apiserver/facades/agent/retrystrategy/retrystrategy_test.go
+++ b/apiserver/facades/agent/retrystrategy/retrystrategy_test.go
@@ -121,7 +121,7 @@ func (s *retryStrategySuite) TestRetryStrategy(c *gc.C) {
 func (s *retryStrategySuite) setRetryStrategy(c *gc.C, automaticallyRetryHooks bool) {
 	err := s.State.UpdateModelConfig(map[string]interface{}{"automatically-retry-hooks": automaticallyRetryHooks}, nil)
 	c.Assert(err, jc.ErrorIsNil)
-	envConfig, err := s.State.ModelConfig()
+	envConfig, err := s.IAASModel.ModelConfig()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(envConfig.AutomaticallyRetryHooks(), gc.Equals, automaticallyRetryHooks)
 }

--- a/apiserver/facades/agent/storageprovisioner/shim.go
+++ b/apiserver/facades/agent/storageprovisioner/shim.go
@@ -87,6 +87,8 @@ type Backend interface {
 	SetVolumeAttachmentInfo(names.MachineTag, names.VolumeTag, state.VolumeAttachmentInfo) error
 }
 
+// TODO - CAAS(ericclaudejones): This should contain state alone, model will be
+// removed once all relevant methods are moved from state to model.
 type stateShim struct {
 	*state.State
 	*state.IAASModel

--- a/apiserver/facades/agent/storageprovisioner/storageprovisioner_test.go
+++ b/apiserver/facades/agent/storageprovisioner/storageprovisioner_test.go
@@ -870,7 +870,7 @@ func (s *provisionerSuite) TestWatchVolumes(c *gc.C) {
 
 	args := params.Entities{Entities: []params.Entity{
 		{"machine-0"},
-		{s.State.ModelTag().String()},
+		{s.IAASModel.ModelTag().String()},
 		{"environ-adb650da-b77b-4ee8-9cbb-d57a9a592847"},
 		{"machine-1"},
 		{"machine-42"}},
@@ -910,7 +910,7 @@ func (s *provisionerSuite) TestWatchVolumeAttachments(c *gc.C) {
 
 	args := params.Entities{Entities: []params.Entity{
 		{"machine-0"},
-		{s.State.ModelTag().String()},
+		{s.IAASModel.ModelTag().String()},
 		{"environ-adb650da-b77b-4ee8-9cbb-d57a9a592847"},
 		{"machine-1"},
 		{"machine-42"}},
@@ -971,7 +971,7 @@ func (s *provisionerSuite) TestWatchFilesystems(c *gc.C) {
 
 	args := params.Entities{Entities: []params.Entity{
 		{"machine-0"},
-		{s.State.ModelTag().String()},
+		{s.IAASModel.ModelTag().String()},
 		{"environ-adb650da-b77b-4ee8-9cbb-d57a9a592847"},
 		{"machine-1"},
 		{"machine-42"}},
@@ -1016,7 +1016,7 @@ func (s *provisionerSuite) TestWatchFilesystemAttachments(c *gc.C) {
 
 	args := params.Entities{Entities: []params.Entity{
 		{"machine-0"},
-		{s.State.ModelTag().String()},
+		{s.IAASModel.ModelTag().String()},
 		{"environ-adb650da-b77b-4ee8-9cbb-d57a9a592847"},
 		{"machine-1"},
 		{"machine-42"}},

--- a/apiserver/facades/agent/uniter/uniter_test.go
+++ b/apiserver/facades/agent/uniter/uniter_test.go
@@ -1742,7 +1742,7 @@ func (s *uniterSuite) TestRelationById(c *gc.C) {
 }
 
 func (s *uniterSuite) TestProviderType(c *gc.C) {
-	cfg, err := s.State.ModelConfig()
+	cfg, err := s.IAASModel.ModelConfig()
 	c.Assert(err, jc.ErrorIsNil)
 
 	result, err := s.uniter.ProviderType()

--- a/apiserver/facades/agent/upgrader/upgrader_test.go
+++ b/apiserver/facades/agent/upgrader/upgrader_test.go
@@ -303,7 +303,7 @@ func (s *upgraderSuite) bumpDesiredAgentVersion(c *gc.C) version.Number {
 	newer.Patch++
 	err := s.State.SetModelAgentVersion(newer.Number)
 	c.Assert(err, jc.ErrorIsNil)
-	cfg, err := s.State.ModelConfig()
+	cfg, err := s.IAASModel.ModelConfig()
 	c.Assert(err, jc.ErrorIsNil)
 	vers, ok := cfg.AgentVersion()
 	c.Assert(ok, jc.IsTrue)

--- a/apiserver/facades/client/action/action.go
+++ b/apiserver/facades/client/action/action.go
@@ -17,6 +17,7 @@ import (
 // ActionAPI implements the client API for interacting with Actions
 type ActionAPI struct {
 	state      *state.State
+	model      *state.Model
 	resources  facade.Resources
 	authorizer facade.Authorizer
 	check      *common.BlockChecker
@@ -28,8 +29,14 @@ func NewActionAPI(st *state.State, resources facade.Resources, authorizer facade
 		return nil, common.ErrPerm
 	}
 
+	m, err := st.Model()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
 	return &ActionAPI{
 		state:      st,
+		model:      m,
 		resources:  resources,
 		authorizer: authorizer,
 		check:      common.NewBlockChecker(st),
@@ -37,7 +44,7 @@ func NewActionAPI(st *state.State, resources facade.Resources, authorizer facade
 }
 
 func (a *ActionAPI) checkCanRead() error {
-	canRead, err := a.authorizer.HasPermission(permission.ReadAccess, a.state.ModelTag())
+	canRead, err := a.authorizer.HasPermission(permission.ReadAccess, a.model.ModelTag())
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -48,7 +55,7 @@ func (a *ActionAPI) checkCanRead() error {
 }
 
 func (a *ActionAPI) checkCanWrite() error {
-	canWrite, err := a.authorizer.HasPermission(permission.WriteAccess, a.state.ModelTag())
+	canWrite, err := a.authorizer.HasPermission(permission.WriteAccess, a.model.ModelTag())
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -59,7 +66,7 @@ func (a *ActionAPI) checkCanWrite() error {
 }
 
 func (a *ActionAPI) checkCanAdmin() error {
-	canAdmin, err := a.authorizer.HasPermission(permission.AdminAccess, a.state.ModelTag())
+	canAdmin, err := a.authorizer.HasPermission(permission.AdminAccess, a.model.ModelTag())
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/apiserver/facades/client/annotations/client.go
+++ b/apiserver/facades/client/annotations/client.go
@@ -14,6 +14,10 @@ import (
 	"github.com/juju/juju/state"
 )
 
+var getState = func(st *state.State, m *state.Model) annotationAccess {
+	return stateShim{st, m}
+}
+
 // Annotations defines the methods on the service API end point.
 type Annotations interface {
 	Get(args params.Entities) params.AnnotationsGetResults
@@ -36,12 +40,13 @@ func NewAPI(
 	if !authorizer.AuthClient() {
 		return nil, common.ErrPerm
 	}
-	model, err := st.Model()
+	m, err := st.Model()
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
+
 	return &API{
-		access:     &stateShim{st, model},
+		access:     getState(st, m),
 		authorizer: authorizer,
 	}, nil
 }

--- a/apiserver/facades/client/annotations/state.go
+++ b/apiserver/facades/client/annotations/state.go
@@ -16,6 +16,9 @@ type annotationAccess interface {
 	SetAnnotations(entity state.GlobalEntity, annotations map[string]string) error
 }
 
+// TODO - CAAS(externalreality): After all relevant methods are moved from
+// state.State to state.Model this stateShim will likely embed only state.Model
+// and will be renamed.
 type stateShim struct {
 	// TODO(menn0) - once FindEntity goes to Model, the embedded State
 	// can go from here. The ModelTag method below can also go.
@@ -23,6 +26,6 @@ type stateShim struct {
 	*state.Model
 }
 
-func (s *stateShim) ModelTag() names.ModelTag {
+func (s stateShim) ModelTag() names.ModelTag {
 	return s.Model.ModelTag()
 }

--- a/apiserver/facades/client/application/application_test.go
+++ b/apiserver/facades/client/application/application_test.go
@@ -2110,7 +2110,7 @@ func (s *applicationSuite) TestApplicationDestroy(c *gc.C) {
 	s.AddTestingApplication(c, "dummy-application", s.AddTestingCharm(c, "dummy"))
 	_, err := s.State.AddRemoteApplication(state.AddRemoteApplicationParams{
 		Name:        "remote-application",
-		SourceModel: s.State.ModelTag(),
+		SourceModel: s.IAASModel.ModelTag(),
 		Token:       "t0",
 	})
 	c.Assert(err, jc.ErrorIsNil)

--- a/apiserver/facades/client/application/backend.go
+++ b/apiserver/facades/client/application/backend.go
@@ -134,6 +134,8 @@ type Resources interface {
 	RemovePendingAppResources(string, map[string]string) error
 }
 
+// TODO - CAAS(ericclaudejones): This should contain state alone, model will be
+// removed once all relevant methods are moved from state to model.
 type stateShim struct {
 	*state.State
 	*state.IAASModel

--- a/apiserver/facades/client/application/charmstore.go
+++ b/apiserver/facades/client/application/charmstore.go
@@ -71,9 +71,13 @@ func AddCharmWithAuthorization(st *state.State, args params.AddCharmWithAuthoriz
 	if err != nil {
 		return err
 	}
-	modelConfig, err := st.ModelConfig()
+	model, err := st.Model()
 	if err != nil {
-		return err
+		return errors.Trace(err)
+	}
+	modelConfig, err := model.ModelConfig()
+	if err != nil {
+		return errors.Trace(err)
 	}
 	repo = config.SpecializeCharmRepo(repo, modelConfig).(*charmrepo.CharmStore)
 
@@ -262,7 +266,11 @@ func charmArchiveStoragePath(curl *charm.URL) (string, error) {
 func ResolveCharms(st *state.State, args params.ResolveCharms) (params.ResolveCharmResults, error) {
 	var results params.ResolveCharmResults
 
-	envConfig, err := st.ModelConfig()
+	model, err := st.Model()
+	if err != nil {
+		return params.ResolveCharmResults{}, errors.Trace(err)
+	}
+	envConfig, err := model.ModelConfig()
 	if err != nil {
 		return params.ResolveCharmResults{}, err
 	}

--- a/apiserver/facades/client/applicationoffers/applicationoffers.go
+++ b/apiserver/facades/client/applicationoffers/applicationoffers.go
@@ -71,7 +71,11 @@ func NewOffersAPI(ctx facade.Context) (*OffersAPI, error) {
 			return nil, errors.Trace(err)
 		}
 		defer releaser()
-		g := stateenvirons.EnvironConfigGetter{st}
+		model, err := st.Model()
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		g := stateenvirons.EnvironConfigGetter{st, model}
 		env, err := environs.GetEnviron(g, environs.New)
 		if err != nil {
 			return nil, errors.Trace(err)

--- a/apiserver/facades/client/backups/mock_test.go
+++ b/apiserver/facades/client/backups/mock_test.go
@@ -3,12 +3,23 @@
 
 package backups_test
 
-import "github.com/juju/juju/state"
+import (
+	"gopkg.in/juju/names.v2"
 
+	"github.com/juju/juju/state"
+)
+
+// TODO - CAAS(ericclaudejones): This should contain state alone, model will be
+// removed once all relevant methods are moved from state to model.
 type stateShim struct {
 	*state.State
+	*state.Model
 }
 
 func (s *stateShim) MachineSeries(id string) (string, error) {
 	return "xenial", nil
+}
+
+func (s *stateShim) ControllerTag() names.ControllerTag {
+	return s.State.ControllerTag()
 }

--- a/apiserver/facades/client/block/client.go
+++ b/apiserver/facades/client/block/client.go
@@ -45,14 +45,19 @@ func NewAPI(
 		return nil, common.ErrPerm
 	}
 
+	m, err := st.Model()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
 	return &API{
-		access:     getState(st),
+		access:     getState(st, m),
 		authorizer: authorizer,
 	}, nil
 }
 
-var getState = func(st *state.State) blockAccess {
-	return stateShim{st}
+var getState = func(st *state.State, m *state.Model) blockAccess {
+	return stateShim{st, m}
 }
 
 func (a *API) checkCanRead() error {

--- a/apiserver/facades/client/block/state.go
+++ b/apiserver/facades/client/block/state.go
@@ -16,6 +16,9 @@ type blockAccess interface {
 	ModelTag() names.ModelTag
 }
 
+// TODO - CAAS(ericclaudejones): This should contain state alone, model will be
+// removed once all relevant methods are moved from state to model.
 type stateShim struct {
 	*state.State
+	*state.Model
 }

--- a/apiserver/facades/client/charms/client.go
+++ b/apiserver/facades/client/charms/client.go
@@ -48,10 +48,27 @@ func NewFacade(ctx facade.Context) (*API, error) {
 		return nil, common.ErrPerm
 	}
 
+	st := ctx.State()
+	m, err := st.Model()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
 	return &API{
 		authorizer: authorizer,
-		backend:    ctx.State(),
+		backend:    getState(st, m),
 	}, nil
+}
+
+// TODO - CAAS(ericclaudejones): This should contain state alone, model will be
+// removed once all relevant methods are moved from state to model.
+type stateShim struct {
+	*state.State
+	*state.Model
+}
+
+var getState = func(st *state.State, m *state.Model) backend {
+	return stateShim{st, m}
 }
 
 // CharmInfo returns information about the requested charm.

--- a/apiserver/facades/client/client/backend.go
+++ b/apiserver/facades/client/client/backend.go
@@ -89,6 +89,8 @@ type Unit interface {
 	AgentHistory() status.StatusHistoryGetter
 }
 
+// TODO - CAAS(ericclaudejones): This should contain state alone, model will be
+// removed once all relevant methods are moved from state to model.
 type stateShim struct {
 	*state.State
 	model *state.Model
@@ -129,4 +131,21 @@ func (p *poolShim) GetModel(uuid string) (*state.Model, func(), error) {
 		return nil, nil, errors.Trace(err)
 	}
 	return model, func() { release() }, nil
+}
+
+func (s stateShim) ModelConfig() (*config.Config, error) {
+	model, err := s.State.Model()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	cfg, err := model.Config()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	return cfg, nil
+}
+
+func (st stateShim) ModelTag() names.ModelTag {
+	return names.NewModelTag(st.State.ModelUUID())
 }

--- a/apiserver/facades/client/client/client.go
+++ b/apiserver/facades/client/client/client.go
@@ -128,14 +128,15 @@ func NewFacade(ctx facade.Context) (*Client, error) {
 	}
 
 	urlGetter := common.NewToolsURLGetter(st.ModelUUID(), st)
-	configGetter := stateenvirons.EnvironConfigGetter{st}
+	configGetter := stateenvirons.EnvironConfigGetter{st, model}
 	statusSetter := common.NewStatusSetter(st, common.AuthAlways())
 	toolsFinder := common.NewToolsFinder(configGetter, st, urlGetter)
 	newEnviron := func() (environs.Environ, error) {
 		return environs.GetEnviron(configGetter, environs.New)
 	}
 	blockChecker := common.NewBlockChecker(st)
-	modelConfigAPI, err := modelconfig.NewModelConfigAPI(st, authorizer)
+	backend := modelconfig.NewStateBackend(st)
+	modelConfigAPI, err := modelconfig.NewModelConfigAPI(backend, authorizer)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/apiserver/facades/client/client/client_test.go
+++ b/apiserver/facades/client/client/client_test.go
@@ -69,8 +69,12 @@ func (s *serverSuite) authClientForState(c *gc.C, st *state.State, auth facade.A
 	}
 	apiserverClient, err := client.NewFacade(context)
 	c.Assert(err, jc.ErrorIsNil)
+
+	m, err := st.Model()
+	c.Assert(err, jc.ErrorIsNil)
+
 	s.newEnviron = func() (environs.Environ, error) {
-		return environs.GetEnviron(stateenvirons.EnvironConfigGetter{st}, environs.New)
+		return environs.GetEnviron(stateenvirons.EnvironConfigGetter{st, m}, environs.New)
 	}
 	client.SetNewEnviron(apiserverClient, func() (environs.Environ, error) {
 		return s.newEnviron()
@@ -88,7 +92,7 @@ func (s *serverSuite) clientForState(c *gc.C, st *state.State) *client.Client {
 func (s *serverSuite) TestModelInfo(c *gc.C) {
 	model, err := s.State.Model()
 	c.Assert(err, jc.ErrorIsNil)
-	conf, _ := s.State.ModelConfig()
+	conf, _ := s.IAASModel.ModelConfig()
 	// Model info is available to read-only users.
 	client := s.authClientForState(c, s.State, testing.FakeAuthorizer{
 		Tag:        names.NewUserTag("read"),
@@ -118,7 +122,7 @@ func (s *serverSuite) TestModelInfo(c *gc.C) {
 
 func (s *serverSuite) TestModelUsersInfo(c *gc.C) {
 	testAdmin := s.AdminUserTag(c)
-	owner, err := s.State.UserAccess(testAdmin, s.State.ModelTag())
+	owner, err := s.State.UserAccess(testAdmin, s.IAASModel.ModelTag())
 	c.Assert(err, jc.ErrorIsNil)
 
 	localUser1 := s.makeLocalModelUser(c, "ralphdoe", "Ralph Doe")
@@ -206,13 +210,15 @@ func (a ByUserName) Less(i, j int) bool { return a[i].Result.UserName < a[j].Res
 func (s *serverSuite) makeLocalModelUser(c *gc.C, username, displayname string) permission.UserAccess {
 	// factory.MakeUser will create an ModelUser for a local user by defalut
 	user := s.Factory.MakeUser(c, &factory.UserParams{Name: username, DisplayName: displayname})
-	modelUser, err := s.State.UserAccess(user.UserTag(), s.State.ModelTag())
+	modelUser, err := s.State.UserAccess(user.UserTag(), s.IAASModel.ModelTag())
 	c.Assert(err, jc.ErrorIsNil)
 	return modelUser
 }
 
 func (s *serverSuite) assertModelVersion(c *gc.C, st *state.State, expected string) {
-	modelConfig, err := st.ModelConfig()
+	m, err := st.Model()
+	c.Assert(err, jc.ErrorIsNil)
+	modelConfig, err := m.ModelConfig()
 	c.Assert(err, jc.ErrorIsNil)
 	agentVersion, found := modelConfig.AllAttrs()["agent-version"]
 	c.Assert(found, jc.IsTrue)
@@ -326,7 +332,7 @@ func (s *serverSuite) assertSetEnvironAgentVersion(c *gc.C) {
 	}
 	err := s.client.SetModelAgentVersion(args)
 	c.Assert(err, jc.ErrorIsNil)
-	modelConfig, err := s.State.ModelConfig()
+	modelConfig, err := s.IAASModel.ModelConfig()
 	c.Assert(err, jc.ErrorIsNil)
 	agentVersion, found := modelConfig.AllAttrs()["agent-version"]
 	c.Assert(found, jc.IsTrue)

--- a/apiserver/facades/client/client/instanceconfig.go
+++ b/apiserver/facades/client/client/instanceconfig.go
@@ -23,7 +23,11 @@ import (
 // is exposed for testing purposes.
 // TODO(rog) fix environs/manual tests so they do not need to call this, or move this elsewhere.
 func InstanceConfig(st *state.State, machineId, nonce, dataDir string) (*instancecfg.InstanceConfig, error) {
-	modelConfig, err := st.ModelConfig()
+	model, err := st.Model()
+	if err != nil {
+		return nil, errors.Annotate(err, "getting state model")
+	}
+	modelConfig, err := model.ModelConfig()
 	if err != nil {
 		return nil, errors.Annotate(err, "getting model config")
 	}
@@ -48,12 +52,8 @@ func InstanceConfig(st *state.State, machineId, nonce, dataDir string) (*instanc
 	if !ok {
 		return nil, errors.New("no agent version set in model configuration")
 	}
-	environment, err := st.Model()
-	if err != nil {
-		return nil, errors.Annotate(err, "getting state model")
-	}
-	urlGetter := common.NewToolsURLGetter(environment.UUID(), st)
-	configGetter := stateenvirons.EnvironConfigGetter{st}
+	urlGetter := common.NewToolsURLGetter(model.UUID(), st)
+	configGetter := stateenvirons.EnvironConfigGetter{st, model}
 	toolsFinder := common.NewToolsFinder(configGetter, st, urlGetter)
 	findToolsResult, err := toolsFinder.FindTools(params.FindToolsParams{
 		Number:       agentVersion,
@@ -84,7 +84,7 @@ func InstanceConfig(st *state.State, machineId, nonce, dataDir string) (*instanc
 	apiInfo := &api.Info{
 		Addrs:    apiAddrs.SortedValues(),
 		CACert:   st.CACert(),
-		ModelTag: st.ModelTag(),
+		ModelTag: model.ModelTag(),
 	}
 
 	auth := authentication.NewAuthenticator(st.MongoConnectionInfo(), apiInfo)

--- a/apiserver/facades/client/client/status_test.go
+++ b/apiserver/facades/client/client/status_test.go
@@ -329,9 +329,12 @@ func (s *statusUnitTestSuite) TestMigrationInProgress(c *gc.C) {
 	state2 := s.Factory.MakeModel(c, nil)
 	defer state2.Close()
 
+	model2, err := state2.Model()
+	c.Assert(err, jc.ErrorIsNil)
+
 	// Get API connection to hosted model.
 	apiInfo := s.APIInfo(c)
-	apiInfo.ModelTag = state2.ModelTag()
+	apiInfo.ModelTag = model2.ModelTag()
 	conn, err := api.Open(apiInfo, api.DialOpts{})
 	c.Assert(err, jc.ErrorIsNil)
 	client := conn.Client()

--- a/apiserver/facades/client/cloud/backend.go
+++ b/apiserver/facades/client/cloud/backend.go
@@ -31,6 +31,20 @@ func NewStateBackend(st *state.State) Backend {
 	return stateShim{st}
 }
 
+func (s stateShim) ModelConfig() (*config.Config, error) {
+	model, err := s.State.Model()
+	if err != nil {
+		return nil, err
+	}
+
+	cfg, err := model.ModelConfig()
+	if err != nil {
+		return nil, err
+	}
+
+	return cfg, nil
+}
+
 func (s stateShim) Model() (Model, error) {
 	m, err := s.State.Model()
 	if err != nil {

--- a/apiserver/facades/client/controller/controller.go
+++ b/apiserver/facades/client/controller/controller.go
@@ -68,6 +68,11 @@ func NewControllerAPIv3(ctx facade.Context) (*ControllerAPIv3, error) {
 	apiUser, _ := authorizer.GetAuthTag().(names.UserTag)
 
 	st := ctx.State()
+	m, err := st.Model()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
 	return &ControllerAPIv3{
 		ControllerConfigAPI: common.NewStateControllerConfig(st),
 		ModelStatusAPI: common.NewModelStatusAPI(
@@ -77,7 +82,7 @@ func NewControllerAPIv3(ctx facade.Context) (*ControllerAPIv3, error) {
 		),
 		CloudSpecAPI: cloudspec.NewCloudSpec(
 			cloudspec.MakeCloudSpecGetter(ctx.StatePool()),
-			common.AuthFuncForTag(st.ModelTag()),
+			common.AuthFuncForTag(m.ModelTag()),
 		),
 		state:      st,
 		statePool:  ctx.StatePool(),
@@ -498,7 +503,7 @@ func makeModelInfo(st, ctlrSt *state.State) (coremigration.ModelInfo, error) {
 	}
 
 	// Retrieve agent version for the model.
-	conf, err := st.ModelConfig()
+	conf, err := model.ModelConfig()
 	if err != nil {
 		return empty, errors.Trace(err)
 	}

--- a/apiserver/facades/client/firewallrules/backend.go
+++ b/apiserver/facades/client/firewallrules/backend.go
@@ -25,6 +25,8 @@ type BlockChecker interface {
 	ChangeAllowed() error
 }
 
+// TODO - CAAS(ericclaudejones): This should contain state alone, model will be
+// removed once all relevant methods are moved from state to model.
 type stateShim struct {
 	*state.State
 	*state.IAASModel

--- a/apiserver/facades/client/imagemetadatamanager/state.go
+++ b/apiserver/facades/client/imagemetadatamanager/state.go
@@ -4,6 +4,7 @@
 package imagemetadatamanager
 
 import (
+	"github.com/juju/errors"
 	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/environs/config"
@@ -41,4 +42,19 @@ func (s stateShim) SaveMetadata(m []cloudimagemetadata.Metadata) error {
 
 func (s stateShim) DeleteMetadata(imageId string) error {
 	return s.State.CloudImageMetadataStorage.DeleteMetadata(imageId)
+}
+
+// ModelConfig implements the metadataAccess method as an expedient until the
+// State is replaced with its underlying Model.
+func (s stateShim) ModelConfig() (*config.Config, error) {
+	model, err := s.State.Model()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	cfg, err := model.Config()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	return cfg, nil
 }

--- a/apiserver/facades/client/keymanager/keymanager_test.go
+++ b/apiserver/facades/client/keymanager/keymanager_test.go
@@ -87,7 +87,11 @@ func (s *keyManagerSuite) setAuthorisedKeys(c *gc.C, keys string) {
 func (s *keyManagerSuite) setAuthorisedKeysForModel(c *gc.C, st *state.State, keys string) {
 	err := st.UpdateModelConfig(map[string]interface{}{"authorized-keys": keys}, nil)
 	c.Assert(err, jc.ErrorIsNil)
-	modelConfig, err := st.ModelConfig()
+
+	m, err := st.Model()
+	c.Assert(err, jc.ErrorIsNil)
+
+	modelConfig, err := m.ModelConfig()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(modelConfig.AuthorizedKeys(), gc.Equals, keys)
 }
@@ -160,7 +164,10 @@ func (s *keyManagerSuite) assertModelKeys(c *gc.C, expected []string) {
 }
 
 func (s *keyManagerSuite) assertKeysForModel(c *gc.C, st *state.State, expected []string) {
-	envConfig, err := st.ModelConfig()
+	m, err := st.Model()
+	c.Assert(err, jc.ErrorIsNil)
+
+	envConfig, err := m.ModelConfig()
 	c.Assert(err, jc.ErrorIsNil)
 	keys := envConfig.AuthorizedKeys()
 	c.Assert(keys, gc.Equals, strings.Join(expected, "\n"))
@@ -211,10 +218,14 @@ func (s *keyManagerSuite) TestAddKeysSuperUser(c *gc.C) {
 }
 
 func (s *keyManagerSuite) TestAddKeysModelAdmin(c *gc.C) {
-	otherModel := s.Factory.MakeModel(c, nil)
-	defer otherModel.Close()
+	otherState := s.Factory.MakeModel(c, nil)
+	defer otherState.Close()
+
+	otherModel, err := otherState.Model()
+	c.Assert(err, jc.ErrorIsNil)
+
 	user := s.Factory.MakeUser(c, &factory.UserParams{Name: "admin" + otherModel.ModelTag().String()})
-	s.assertAddKeys(c, otherModel, user.UserTag(), true)
+	s.assertAddKeys(c, otherState, user.UserTag(), true)
 }
 
 func (s *keyManagerSuite) TestAddKeysModelOwner(c *gc.C) {
@@ -311,10 +322,14 @@ func (s *keyManagerSuite) TestDeleteKeysSuperUser(c *gc.C) {
 }
 
 func (s *keyManagerSuite) TestDeleteKeysModelAdmin(c *gc.C) {
-	otherModel := s.Factory.MakeModel(c, nil)
-	defer otherModel.Close()
+	otherState := s.Factory.MakeModel(c, nil)
+	defer otherState.Close()
+
+	otherModel, err := otherState.Model()
+	c.Assert(err, jc.ErrorIsNil)
+
 	user := s.Factory.MakeUser(c, &factory.UserParams{Name: "admin" + otherModel.ModelTag().String()})
-	s.assertDeleteKeys(c, otherModel, user.UserTag(), true)
+	s.assertDeleteKeys(c, otherState, user.UserTag(), true)
 }
 
 func (s *keyManagerSuite) TestDeleteKeysModelOwner(c *gc.C) {
@@ -494,10 +509,14 @@ func (s *keyManagerSuite) TestImportKeysSuperUser(c *gc.C) {
 }
 
 func (s *keyManagerSuite) TestImportKeysModelAdmin(c *gc.C) {
-	otherModel := s.Factory.MakeModel(c, nil)
-	defer otherModel.Close()
+	otherState := s.Factory.MakeModel(c, nil)
+	defer otherState.Close()
+
+	otherModel, err := otherState.Model()
+	c.Assert(err, jc.ErrorIsNil)
+
 	user := s.Factory.MakeUser(c, &factory.UserParams{Name: "admin" + otherModel.ModelTag().String()})
-	s.assertImportKeys(c, otherModel, user.UserTag(), true)
+	s.assertImportKeys(c, otherState, user.UserTag(), true)
 }
 
 func (s *keyManagerSuite) TestImportKeysModelOwner(c *gc.C) {

--- a/apiserver/facades/client/modelconfig/backend.go
+++ b/apiserver/facades/client/modelconfig/backend.go
@@ -27,6 +27,15 @@ type stateShim struct {
 	*state.State
 }
 
+func (st stateShim) ModelTag() names.ModelTag {
+	m, err := st.State.Model()
+	if err != nil {
+		return names.NewModelTag(st.State.ModelUUID())
+	}
+
+	return m.ModelTag()
+}
+
 // NewStateBackend creates a backend for the facade to use.
 func NewStateBackend(st *state.State) Backend {
 	return stateShim{st}

--- a/apiserver/facades/client/modelmanager/modelmanager.go
+++ b/apiserver/facades/client/modelmanager/modelmanager.go
@@ -104,7 +104,13 @@ func NewFacadeV4(ctx facade.Context) (*ModelManagerAPI, error) {
 	pool := ctx.StatePool()
 	ctlrSt := pool.SystemState()
 	auth := ctx.Auth()
-	configGetter := stateenvirons.EnvironConfigGetter{st}
+
+	model, err := st.Model()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	configGetter := stateenvirons.EnvironConfigGetter{st, model}
 
 	return NewModelManagerAPI(
 		common.NewModelManagerBackend(st, pool),

--- a/apiserver/facades/client/spaces/spaces.go
+++ b/apiserver/facades/client/spaces/spaces.go
@@ -38,7 +38,11 @@ type spacesAPI struct {
 // NewAPI creates a new Space API server-side facade with a
 // state.State backing.
 func NewAPI(st *state.State, res facade.Resources, auth facade.Authorizer) (API, error) {
-	return newAPIWithBacking(networkingcommon.NewStateShim(st), res, auth)
+	stateShim, err := networkingcommon.NewStateShim(st)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return newAPIWithBacking(stateShim, res, auth)
 }
 
 // newAPIWithBacking creates a new server-side Spaces API facade with

--- a/apiserver/facades/client/sshclient/shim.go
+++ b/apiserver/facades/client/sshclient/shim.go
@@ -36,7 +36,11 @@ type SSHMachine interface {
 
 // NewFacade wraps New to express the supplied *state.State as a Backend.
 func NewFacade(st *state.State, res facade.Resources, auth facade.Authorizer) (*Facade, error) {
-	return New(&backend{stateenvirons.EnvironConfigGetter{st}}, res, auth)
+	m, err := st.Model()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return New(&backend{stateenvirons.EnvironConfigGetter{st, m}}, res, auth)
 }
 
 type backend struct {

--- a/apiserver/facades/client/storage/shim.go
+++ b/apiserver/facades/client/storage/shim.go
@@ -168,6 +168,8 @@ var getState = func(st *state.State) (storageAccess, error) {
 	return stateShim{State: st, IAASModel: im}, nil
 }
 
+// TODO - CAAS(ericclaudejones): This should contain state alone, model will be
+// removed once all relevant methods are moved from state to model.
 type stateShim struct {
 	*state.State
 	*state.IAASModel
@@ -191,7 +193,7 @@ func (s stateShim) UnitAssignedMachine(tag names.UnitTag) (names.MachineTag, err
 // ModelName returns the name of Juju environment,
 // or an error if environment configuration is not retrievable.
 func (s stateShim) ModelName() (string, error) {
-	cfg, err := s.State.ModelConfig()
+	cfg, err := s.IAASModel.ModelConfig()
 	if err != nil {
 		return "", errors.Trace(err)
 	}

--- a/apiserver/facades/client/subnets/subnets.go
+++ b/apiserver/facades/client/subnets/subnets.go
@@ -43,7 +43,11 @@ type subnetsAPI struct {
 // NewAPI creates a new Subnets API server-side facade with a
 // state.State backing.
 func NewAPI(st *state.State, res facade.Resources, auth facade.Authorizer) (SubnetsAPI, error) {
-	return newAPIWithBacking(networkingcommon.NewStateShim(st), res, auth)
+	stateshim, err := networkingcommon.NewStateShim(st)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return newAPIWithBacking(stateshim, res, auth)
 }
 
 func (api *subnetsAPI) checkCanRead() error {

--- a/apiserver/facades/controller/actionpruner/pruner.go
+++ b/apiserver/facades/controller/actionpruner/pruner.go
@@ -13,12 +13,18 @@ import (
 type API struct {
 	*common.ModelWatcher
 	st         *state.State
+	model      *state.Model
 	authorizer facade.Authorizer
 }
 
 func NewAPI(st *state.State, r facade.Resources, auth facade.Authorizer) (*API, error) {
+	m, err := st.Model()
+	if err != nil {
+		return nil, err
+	}
+
 	return &API{
-		ModelWatcher: common.NewModelWatcher(st, r, auth),
+		ModelWatcher: common.NewModelWatcher(m, r, auth),
 		st:           st,
 		authorizer:   auth,
 	}, nil

--- a/apiserver/facades/controller/crossmodelrelations/crossmodelrelations.go
+++ b/apiserver/facades/controller/crossmodelrelations/crossmodelrelations.go
@@ -46,13 +46,17 @@ type CrossModelRelationsAPI struct {
 // backed by global state.
 func NewStateCrossModelRelationsAPI(ctx facade.Context) (*CrossModelRelationsAPI, error) {
 	authCtxt := ctx.Resources().Get("offerAccessAuthContext").(common.ValueResource).Value
+	model, err := ctx.State().Model()
+	if err != nil {
+		return nil, err
+	}
 
 	return NewCrossModelRelationsAPI(
 		stateShim{
 			st:      ctx.State(),
 			Backend: commoncrossmodel.GetBackend(ctx.State()),
 		},
-		firewall.StateShim(ctx.State()),
+		firewall.StateShim(ctx.State(), model),
 		ctx.Resources(), ctx.Auth(), authCtxt.(*commoncrossmodel.AuthContext),
 		firewall.WatchEgressAddressesForRelations,
 		watchRelationLifeStatus,

--- a/apiserver/facades/controller/crossmodelrelations/state.go
+++ b/apiserver/facades/controller/crossmodelrelations/state.go
@@ -27,6 +27,8 @@ type CrossModelRelationsState interface {
 	OfferConnectionForRelation(string) (OfferConnection, error)
 }
 
+// TODO - CAAS(ericclaudejones): This should contain state alone, model will be
+// removed once all relevant methods are moved from state to model.
 type stateShim struct {
 	common.Backend
 	st *state.State

--- a/apiserver/facades/controller/firewaller/firewaller.go
+++ b/apiserver/facades/controller/firewaller/firewaller.go
@@ -50,11 +50,16 @@ type FirewallerAPIV4 struct {
 func NewStateFirewallerAPIV3(context facade.Context) (*FirewallerAPIV3, error) {
 	st := context.State()
 
+	m, err := st.Model()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
 	cloudSpecAPI := cloudspec.NewCloudSpec(
 		cloudspec.MakeCloudSpecGetterForModel(st),
-		common.AuthFuncForTag(st.ModelTag()),
+		common.AuthFuncForTag(m.ModelTag()),
 	)
-	return NewFirewallerAPI(stateShim{st: st, State: firewall.StateShim(st)}, context.Resources(), context.Auth(), cloudSpecAPI)
+	return NewFirewallerAPI(stateShim{st: st, State: firewall.StateShim(st, m)}, context.Resources(), context.Auth(), cloudSpecAPI)
 }
 
 // NewStateFirewallerAPIv4 creates a new server-side FirewallerAPIV4 facade.

--- a/apiserver/facades/controller/firewaller/firewaller_test.go
+++ b/apiserver/facades/controller/firewaller/firewaller_test.go
@@ -38,11 +38,11 @@ func (s *firewallerSuite) SetUpTest(c *gc.C) {
 
 	cloudSpecAPI := cloudspec.NewCloudSpec(
 		cloudspec.MakeCloudSpecGetterForModel(s.State),
-		common.AuthFuncForTag(s.State.ModelTag()),
+		common.AuthFuncForTag(s.IAASModel.ModelTag()),
 	)
 	// Create a firewaller API for the machine.
 	firewallerAPI, err := firewaller.NewFirewallerAPI(
-		firewaller.StateShim(s.State),
+		firewaller.StateShim(s.State, s.IAASModel.Model),
 		s.resources,
 		s.authorizer,
 		cloudSpecAPI,
@@ -54,7 +54,10 @@ func (s *firewallerSuite) SetUpTest(c *gc.C) {
 
 func (s *firewallerSuite) TestFirewallerFailsWithNonEnvironManagerUser(c *gc.C) {
 	constructor := func(st *state.State, res facade.Resources, auth facade.Authorizer) error {
-		_, err := firewaller.NewFirewallerAPI(firewaller.StateShim(st), res, auth, nil)
+		m, err := st.Model()
+		c.Assert(err, jc.ErrorIsNil)
+
+		_, err = firewaller.NewFirewallerAPI(firewaller.StateShim(st, m), res, auth, nil)
 		return err
 	}
 	s.testFirewallerFailsWithNonEnvironManagerUser(c, constructor)

--- a/apiserver/facades/controller/firewaller/state.go
+++ b/apiserver/facades/controller/firewaller/state.go
@@ -26,8 +26,8 @@ type State interface {
 }
 
 // TODO(wallyworld) - for tests, remove when remaining firewaller tests become unit tests.
-func StateShim(st *state.State) stateShim {
-	return stateShim{st: st, State: firewall.StateShim(st)}
+func StateShim(st *state.State, m *state.Model) stateShim {
+	return stateShim{st: st, State: firewall.StateShim(st, m)}
 }
 
 type stateShim struct {

--- a/apiserver/facades/controller/imagemetadata/state.go
+++ b/apiserver/facades/controller/imagemetadata/state.go
@@ -29,3 +29,12 @@ type stateShim struct {
 func (s stateShim) SaveMetadata(m []cloudimagemetadata.Metadata) error {
 	return s.State.CloudImageMetadataStorage.SaveMetadata(m)
 }
+
+func (st stateShim) ModelConfig() (*config.Config, error) {
+	m, err := st.Model()
+	if err != nil {
+		return nil, err
+	}
+
+	return m.ModelConfig()
+}

--- a/apiserver/facades/controller/instancepoller/export_test.go
+++ b/apiserver/facades/controller/instancepoller/export_test.go
@@ -10,7 +10,7 @@ type Patcher interface {
 }
 
 func PatchState(p Patcher, st StateInterface) {
-	p.PatchValue(&getState, func(*state.State) StateInterface {
+	p.PatchValue(&getState, func(*state.State, *state.Model) StateInterface {
 		return st
 	})
 }

--- a/apiserver/facades/controller/instancepoller/instancepoller.go
+++ b/apiserver/facades/controller/instancepoller/instancepoller.go
@@ -6,6 +6,7 @@ package instancepoller
 import (
 	"fmt"
 
+	"github.com/juju/errors"
 	"github.com/juju/utils/clock"
 	"gopkg.in/juju/names.v2"
 
@@ -37,13 +38,18 @@ func NewFacade(
 	resources facade.Resources,
 	authorizer facade.Authorizer,
 ) (*InstancePollerAPI, error) {
-	return NewInstancePollerAPI(st, resources, authorizer, clock.WallClock)
+	m, err := st.Model()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return NewInstancePollerAPI(st, m, resources, authorizer, clock.WallClock)
 }
 
 // NewInstancePollerAPI creates a new server-side InstancePoller API
 // facade.
 func NewInstancePollerAPI(
 	st *state.State,
+	m *state.Model,
 	resources facade.Resources,
 	authorizer facade.Authorizer,
 	clock clock.Clock,
@@ -54,7 +60,7 @@ func NewInstancePollerAPI(
 		return nil, common.ErrPerm
 	}
 	accessMachine := common.AuthFuncForTagKind(names.MachineTagKind)
-	sti := getState(st)
+	sti := getState(st, m)
 
 	// Life() is supported for machines.
 	lifeGetter := common.NewLifeGetter(

--- a/apiserver/facades/controller/instancepoller/instancepoller_test.go
+++ b/apiserver/facades/controller/instancepoller/instancepoller_test.go
@@ -56,7 +56,7 @@ func (s *InstancePollerSuite) SetUpTest(c *gc.C) {
 
 	var err error
 	s.clock = jujutesting.NewClock(time.Now())
-	s.api, err = instancepoller.NewInstancePollerAPI(nil, s.resources, s.authoriser, s.clock)
+	s.api, err = instancepoller.NewInstancePollerAPI(nil, nil, s.resources, s.authoriser, s.clock)
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.machineEntities = params.Entities{
@@ -99,7 +99,7 @@ func (s *InstancePollerSuite) SetUpTest(c *gc.C) {
 func (s *InstancePollerSuite) TestNewInstancePollerAPIRequiresEnvironManager(c *gc.C) {
 	anAuthoriser := s.authoriser
 	anAuthoriser.Controller = false
-	api, err := instancepoller.NewInstancePollerAPI(nil, s.resources, anAuthoriser, s.clock)
+	api, err := instancepoller.NewInstancePollerAPI(nil, nil, s.resources, anAuthoriser, s.clock)
 	c.Assert(api, gc.IsNil)
 	c.Assert(err, gc.ErrorMatches, "permission denied")
 }

--- a/apiserver/facades/controller/instancepoller/state.go
+++ b/apiserver/facades/controller/instancepoller/state.go
@@ -36,14 +36,17 @@ type StateInterface interface {
 	Machine(id string) (StateMachine, error)
 }
 
+// TODO - CAAS(ericclaudejones): This should contain state alone, model will be
+// removed once all relevant methods are moved from state to model.
 type stateShim struct {
 	*state.State
+	*state.Model
 }
 
 func (s stateShim) Machine(id string) (StateMachine, error) {
 	return s.State.Machine(id)
 }
 
-var getState = func(st *state.State) StateInterface {
-	return stateShim{st}
+var getState = func(st *state.State, m *state.Model) StateInterface {
+	return stateShim{st, m}
 }

--- a/apiserver/facades/controller/metricsmanager/metricsmanager_test.go
+++ b/apiserver/facades/controller/metricsmanager/metricsmanager_test.go
@@ -85,7 +85,7 @@ func (s *metricsManagerSuite) TestCleanupOldMetrics(c *gc.C) {
 	oldMetric := s.Factory.MakeMetric(c, &factory.MetricParams{Unit: s.unit, Sent: true, DeleteTime: &oldTime, Metrics: []state.Metric{metric}})
 	newMetric := s.Factory.MakeMetric(c, &factory.MetricParams{Unit: s.unit, Sent: true, DeleteTime: &newTime, Metrics: []state.Metric{metric}})
 	args := params.Entities{Entities: []params.Entity{
-		{s.State.ModelTag().String()},
+		{s.IAASModel.ModelTag().String()},
 	}}
 	result, err := s.metricsmanager.CleanupOldMetrics(args)
 	c.Assert(err, jc.ErrorIsNil)
@@ -111,7 +111,7 @@ func (s *metricsManagerSuite) TestCleanupOldMetricsInvalidArg(c *gc.C) {
 func (s *metricsManagerSuite) TestCleanupArgsIndependent(c *gc.C) {
 	args := params.Entities{Entities: []params.Entity{
 		{"invalid"},
-		{s.State.ModelTag().String()},
+		{s.IAASModel.ModelTag().String()},
 	}}
 	result, err := s.metricsmanager.CleanupOldMetrics(args)
 	c.Assert(result.Results, gc.HasLen, 2)
@@ -129,7 +129,7 @@ func (s *metricsManagerSuite) TestSendMetrics(c *gc.C) {
 	s.Factory.MakeMetric(c, &factory.MetricParams{Unit: s.unit, Sent: true, Time: &now, Metrics: []state.Metric{metric}})
 	unsent := s.Factory.MakeMetric(c, &factory.MetricParams{Unit: s.unit, Sent: false, Time: &now, Metrics: []state.Metric{metric}})
 	args := params.Entities{Entities: []params.Entity{
-		{s.State.ModelTag().String()},
+		{s.IAASModel.ModelTag().String()},
 	}}
 	result, err := s.metricsmanager.SendMetrics(args)
 	c.Assert(err, jc.ErrorIsNil)
@@ -155,7 +155,7 @@ func (s *metricsManagerSuite) TestSendOldMetricsInvalidArg(c *gc.C) {
 func (s *metricsManagerSuite) TestSendArgsIndependent(c *gc.C) {
 	args := params.Entities{Entities: []params.Entity{
 		{"invalid"},
-		{s.State.ModelTag().String()},
+		{s.IAASModel.ModelTag().String()},
 	}}
 	result, err := s.metricsmanager.SendMetrics(args)
 	c.Assert(result.Results, gc.HasLen, 2)
@@ -173,12 +173,12 @@ func (s *metricsManagerSuite) TestMeterStatusOnConsecutiveErrors(c *gc.C) {
 	s.Factory.MakeMetric(c, &factory.MetricParams{Unit: s.unit, Sent: false, Time: &now, Metrics: []state.Metric{metric}})
 	metricsmanager.PatchSender(&sender)
 	args := params.Entities{Entities: []params.Entity{
-		{s.State.ModelTag().String()},
+		{s.IAASModel.ModelTag().String()},
 	}}
 	result, err := s.metricsmanager.SendMetrics(args)
 	c.Assert(err, jc.ErrorIsNil)
 	expectedError := params.ErrorResult{Error: apiservertesting.PrefixedError(
-		fmt.Sprintf("failed to send metrics for %s: ", s.State.ModelTag()),
+		fmt.Sprintf("failed to send metrics for %s: ", s.IAASModel.ModelTag()),
 		"an error")}
 	c.Assert(result.Results[0], jc.DeepEquals, expectedError)
 	mm, err := s.State.MetricsManager()
@@ -193,7 +193,7 @@ func (s *metricsManagerSuite) TestMeterStatusSuccessfulSend(c *gc.C) {
 	s.Factory.MakeMetric(c, &factory.MetricParams{Unit: s.unit, Sent: false, Time: &pastTime, Metrics: []state.Metric{metric}})
 	metricsmanager.PatchSender(&sender)
 	args := params.Entities{Entities: []params.Entity{
-		{s.State.ModelTag().String()},
+		{s.IAASModel.ModelTag().String()},
 	}}
 	result, err := s.metricsmanager.SendMetrics(args)
 	c.Assert(err, jc.ErrorIsNil)
@@ -207,7 +207,7 @@ func (s *metricsManagerSuite) TestLastSuccessfulNotChangedIfNothingToSend(c *gc.
 	var sender testing.MockSender
 	metricsmanager.PatchSender(&sender)
 	args := params.Entities{Entities: []params.Entity{
-		{s.State.ModelTag().String()},
+		{s.IAASModel.ModelTag().String()},
 	}}
 	result, err := s.metricsmanager.SendMetrics(args)
 	c.Assert(err, jc.ErrorIsNil)
@@ -291,7 +291,7 @@ func (s *metricsManagerSuite) TestSendMetricsMachineMetrics(c *gc.C) {
 	var sender testing.MockSender
 	metricsmanager.PatchSender(&sender)
 	args := params.Entities{Entities: []params.Entity{
-		{s.State.ModelTag().String()},
+		{s.IAASModel.ModelTag().String()},
 	}}
 	result, err := s.metricsmanager.SendMetrics(args)
 	c.Assert(err, jc.ErrorIsNil)

--- a/apiserver/facades/controller/migrationmaster/shim.go
+++ b/apiserver/facades/controller/migrationmaster/shim.go
@@ -55,7 +55,12 @@ func (s *backendShim) ModelOwner() (names.UserTag, error) {
 
 // AgentVersion implements Backend.
 func (s *backendShim) AgentVersion() (version.Number, error) {
-	cfg, err := s.ModelConfig()
+	m, err := s.Model()
+	if err != nil {
+		return version.Zero, errors.Trace(err)
+	}
+
+	cfg, err := m.ModelConfig()
 	if err != nil {
 		return version.Zero, errors.Trace(err)
 	}

--- a/apiserver/facades/controller/migrationtarget/migrationtarget_test.go
+++ b/apiserver/facades/controller/migrationtarget/migrationtarget_test.go
@@ -249,8 +249,11 @@ func (s *Suite) TestAdoptResources(c *gc.C) {
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
+	m, err := st.Model()
+	c.Assert(err, jc.ErrorIsNil)
+
 	err = api.AdoptResources(params.AdoptResourcesArgs{
-		ModelTag:                st.ModelTag().String(),
+		ModelTag:                m.ModelTag().String(),
 		SourceControllerVersion: version.MustParse("3.2.1"),
 	})
 	c.Assert(err, jc.ErrorIsNil)
@@ -278,8 +281,10 @@ func (s *Suite) TestCheckMachinesInstancesMissing(c *gc.C) {
 	}
 	api := s.mustNewAPIWithEnviron(c, &env)
 
+	model, err := st.Model()
+	c.Assert(err, jc.ErrorIsNil)
 	results, err := api.CheckMachines(
-		params.ModelArgs{ModelTag: st.ModelTag().String()})
+		params.ModelArgs{ModelTag: model.ModelTag().String()})
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Assert(results.Results, gc.HasLen, 1)
@@ -303,8 +308,10 @@ func (s *Suite) TestCheckMachinesExtraInstances(c *gc.C) {
 	}
 	api := s.mustNewAPIWithEnviron(c, &env)
 
+	model, err := st.Model()
+	c.Assert(err, jc.ErrorIsNil)
 	results, err := api.CheckMachines(
-		params.ModelArgs{ModelTag: st.ModelTag().String()})
+		params.ModelArgs{ModelTag: model.ModelTag().String()})
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Assert(results.Results, gc.HasLen, 1)
@@ -318,9 +325,10 @@ func (s *Suite) TestCheckMachinesErrorGettingInstances(c *gc.C) {
 	env := mockEnviron{Stub: &testing.Stub{}}
 	env.SetErrors(errors.Errorf("kablooie"))
 	api := s.mustNewAPIWithEnviron(c, &env)
-
+	model, err := st.Model()
+	c.Assert(err, jc.ErrorIsNil)
 	results, err := api.CheckMachines(
-		params.ModelArgs{ModelTag: st.ModelTag().String()})
+		params.ModelArgs{ModelTag: model.ModelTag().String()})
 	c.Assert(err, gc.ErrorMatches, "kablooie")
 	c.Assert(results, gc.DeepEquals, params.ErrorResults{})
 }
@@ -346,9 +354,10 @@ func (s *Suite) TestCheckMachinesSuccess(c *gc.C) {
 		},
 	}
 	api := s.mustNewAPIWithEnviron(c, &env)
-
+	model, err := st.Model()
+	c.Assert(err, jc.ErrorIsNil)
 	results, err := api.CheckMachines(
-		params.ModelArgs{ModelTag: st.ModelTag().String()})
+		params.ModelArgs{ModelTag: model.ModelTag().String()})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, gc.DeepEquals, params.ErrorResults{})
 }
@@ -368,9 +377,10 @@ func (s *Suite) TestCheckMachinesHandlesContainers(c *gc.C) {
 		instances: []*mockInstance{{id: "birds"}},
 	}
 	api := s.mustNewAPIWithEnviron(c, &env)
-
+	model, err := st.Model()
+	c.Assert(err, jc.ErrorIsNil)
 	results, err := api.CheckMachines(
-		params.ModelArgs{ModelTag: st.ModelTag().String()})
+		params.ModelArgs{ModelTag: model.ModelTag().String()})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, gc.DeepEquals, params.ErrorResults{})
 }
@@ -393,8 +403,10 @@ func (s *Suite) TestCheckMachinesHandlesManual(c *gc.C) {
 	}
 	api := s.mustNewAPIWithEnviron(c, &env)
 
+	model, err := st.Model()
+	c.Assert(err, jc.ErrorIsNil)
 	results, err := api.CheckMachines(
-		params.ModelArgs{ModelTag: st.ModelTag().String()})
+		params.ModelArgs{ModelTag: model.ModelTag().String()})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, gc.DeepEquals, params.ErrorResults{})
 }
@@ -441,7 +453,7 @@ func (s *Suite) makeExportedModel(c *gc.C) (string, []byte) {
 }
 
 func (s *Suite) controllerVersion(c *gc.C) version.Number {
-	cfg, err := s.State.ModelConfig()
+	cfg, err := s.IAASModel.ModelConfig()
 	c.Assert(err, jc.ErrorIsNil)
 	vers, ok := cfg.AgentVersion()
 	c.Assert(ok, jc.IsTrue)

--- a/apiserver/facades/controller/remoterelations/state.go
+++ b/apiserver/facades/controller/remoterelations/state.go
@@ -40,6 +40,8 @@ type RemoteRelationsState interface {
 	SaveMacaroon(entity names.Tag, mac *macaroon.Macaroon) error
 }
 
+// TODO - CAAS(ericclaudejones): This should contain state alone, model will be
+// removed once all relevant methods are moved from state to model.
 type stateShim struct {
 	common.Backend
 	st *state.State

--- a/apiserver/facades/controller/singular/singular.go
+++ b/apiserver/facades/controller/singular/singular.go
@@ -17,7 +17,20 @@ import (
 
 // NewExternalFacade is for API registration.
 func NewExternalFacade(st *state.State, _ facade.Resources, auth facade.Authorizer) (*Facade, error) {
-	return NewFacade(st, auth)
+	m, err := st.Model()
+	if err != nil {
+		return nil, err
+	}
+
+	backend := getBackend(st, m)
+	return NewFacade(backend, auth)
+}
+
+var getBackend = func(st *state.State, m *state.Model) Backend {
+	return struct {
+		*state.State
+		*state.Model
+	}{st, m}
 }
 
 // Backend supplies capabilities required by a Facade.

--- a/apiserver/facades/controller/statushistory/pruner.go
+++ b/apiserver/facades/controller/statushistory/pruner.go
@@ -19,8 +19,13 @@ type API struct {
 
 // NewAPI returns an API Instance.
 func NewAPI(st *state.State, r facade.Resources, auth facade.Authorizer) (*API, error) {
+	m, err := st.Model()
+	if err != nil {
+		return nil, err
+	}
+
 	return &API{
-		ModelWatcher: common.NewModelWatcher(st, r, auth),
+		ModelWatcher: common.NewModelWatcher(m, r, auth),
 		st:           st,
 		authorizer:   auth,
 	}, nil

--- a/apiserver/facades/controller/undertaker/state.go
+++ b/apiserver/facades/controller/undertaker/state.go
@@ -42,12 +42,19 @@ type State interface {
 	ModelUUID() string
 }
 
+// TODO - CAAS(ericclaudejones): This should contain state alone, model will be
+// removed once all relevant methods are moved from state to model.
 type stateShim struct {
 	*state.State
+	model *state.Model
 }
 
 func (s *stateShim) Model() (Model, error) {
 	return s.State.Model()
+}
+
+func (s *stateShim) ModelConfig() (*config.Config, error) {
+	return s.model.Config()
 }
 
 // Model defines the needed methods of state.Model for

--- a/apiserver/facades/controller/undertaker/undertaker.go
+++ b/apiserver/facades/controller/undertaker/undertaker.go
@@ -23,7 +23,12 @@ type UndertakerAPI struct {
 
 // NewUndertakerAPI creates a new instance of the undertaker API.
 func NewUndertakerAPI(st *state.State, resources facade.Resources, authorizer facade.Authorizer) (*UndertakerAPI, error) {
-	return newUndertakerAPI(&stateShim{st}, resources, authorizer)
+	m, err := st.Model()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	return newUndertakerAPI(&stateShim{st, m}, resources, authorizer)
 }
 
 func newUndertakerAPI(st State, resources facade.Resources, authorizer facade.Authorizer) (*UndertakerAPI, error) {

--- a/apiserver/rest_test.go
+++ b/apiserver/rest_test.go
@@ -152,13 +152,13 @@ func (s *restSuite) TestGetRemoteApplicationIcon(c *gc.C) {
 	otherModelState := s.setupOtherModel(c)
 	_, err = otherModelState.AddRemoteApplication(state.AddRemoteApplicationParams{
 		Name:        "remote-app",
-		SourceModel: s.State.ModelTag(),
+		SourceModel: s.IAASModel.ModelTag(),
 		OfferUUID:   offer.OfferUUID,
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	_, err = otherModelState.AddRemoteApplication(state.AddRemoteApplicationParams{
 		Name:        "notfound-remote-app",
-		SourceModel: s.State.ModelTag(),
+		SourceModel: s.IAASModel.ModelTag(),
 		OfferUUID:   offer2.OfferUUID,
 	})
 	c.Assert(err, jc.ErrorIsNil)

--- a/apiserver/root.go
+++ b/apiserver/root.go
@@ -46,6 +46,7 @@ type objectKey struct {
 // uses to dispatch API calls appropriately.
 type apiHandler struct {
 	state     *state.State
+	model     *state.Model
 	rpcConn   *rpc.Conn
 	resources *common.Resources
 	entity    state.Entity
@@ -65,8 +66,13 @@ var _ = (*apiHandler)(nil)
 
 // newAPIHandler returns a new apiHandler.
 func newAPIHandler(srv *Server, st *state.State, rpcConn *rpc.Conn, modelUUID string, serverHost string) (*apiHandler, error) {
+	m, err := st.Model()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	r := &apiHandler{
 		state:      st,
+		model:      m,
 		resources:  common.NewResources(),
 		rpcConn:    rpcConn,
 		modelUUID:  modelUUID,

--- a/apiserver/server_test.go
+++ b/apiserver/server_test.go
@@ -79,7 +79,7 @@ func (s *serverSuite) TestStop(c *gc.C) {
 		Nonce:    "fake_nonce",
 		Addrs:    []string{address},
 		CACert:   coretesting.CACert,
-		ModelTag: s.State.ModelTag(),
+		ModelTag: s.IAASModel.ModelTag(),
 	}
 	st, err := api.Open(apiInfo, fastDialOpts)
 	c.Assert(err, jc.ErrorIsNil)
@@ -124,7 +124,7 @@ func (s *serverSuite) TestAPIServerCanListenOnBothIPv4AndIPv6(c *gc.C) {
 		Nonce:    "fake_nonce",
 		Addrs:    []string{net.JoinHostPort("127.0.0.1", portString)},
 		CACert:   coretesting.CACert,
-		ModelTag: s.State.ModelTag(),
+		ModelTag: s.IAASModel.ModelTag(),
 	}
 	ipv4State, err := api.Open(apiInfo, fastDialOpts)
 	c.Assert(err, jc.ErrorIsNil)
@@ -210,7 +210,7 @@ func (s *serverSuite) TestNewServerDoesNotAccessState(c *gc.C) {
 	st, err := state.Open(state.OpenParams{
 		Clock:              clock.WallClock,
 		ControllerTag:      s.State.ControllerTag(),
-		ControllerModelTag: s.State.ModelTag(),
+		ControllerModelTag: s.IAASModel.ModelTag(),
 		MongoInfo:          mongoInfo,
 		MongoDialOpts:      dialOpts,
 	})

--- a/cmd/juju/commands/sshkeys_test.go
+++ b/cmd/juju/commands/sshkeys_test.go
@@ -72,13 +72,13 @@ func (s *keySuiteBase) setAuthorizedKeys(c *gc.C, keys ...string) {
 	keyString := strings.Join(keys, "\n")
 	err := s.State.UpdateModelConfig(map[string]interface{}{"authorized-keys": keyString}, nil)
 	c.Assert(err, jc.ErrorIsNil)
-	envConfig, err := s.State.ModelConfig()
+	envConfig, err := s.IAASModel.ModelConfig()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(envConfig.AuthorizedKeys(), gc.Equals, keyString)
 }
 
 func (s *keySuiteBase) assertEnvironKeys(c *gc.C, expected ...string) {
-	envConfig, err := s.State.ModelConfig()
+	envConfig, err := s.IAASModel.ModelConfig()
 	c.Assert(err, jc.ErrorIsNil)
 	keys := envConfig.AuthorizedKeys()
 	c.Assert(keys, gc.Equals, strings.Join(expected, "\n"))

--- a/cmd/jujud/agent/agenttest/agent.go
+++ b/cmd/jujud/agent/agenttest/agent.go
@@ -183,7 +183,10 @@ func (s *AgentSuite) PrimeStateAgentVersion(c *gc.C, tag names.Tag, password str
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(tools1, gc.DeepEquals, agentTools)
 
-	conf := s.WriteStateAgentConfig(c, tag, password, vers, s.State.ModelTag())
+	model, err := s.State.Model()
+	c.Assert(err, jc.ErrorIsNil)
+
+	conf := s.WriteStateAgentConfig(c, tag, password, vers, model.ModelTag())
 	s.primeAPIHostPorts(c)
 	return conf, agentTools
 }

--- a/cmd/jujud/bootstrap_test.go
+++ b/cmd/jujud/bootstrap_test.go
@@ -410,7 +410,10 @@ func (s *BootstrapSuite) TestInitializeEnvironment(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(&cons, jc.Satisfies, constraints.IsEmpty)
 
-	cfg, err := st.ModelConfig()
+	m, err := st.Model()
+	c.Assert(err, jc.ErrorIsNil)
+
+	cfg, err := m.ModelConfig()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cfg.AuthorizedKeys(), gc.Equals, s.bootstrapParams.ControllerModelConfig.AuthorizedKeys()+"\npublic-key")
 }
@@ -455,7 +458,10 @@ func (s *BootstrapSuite) TestInitializeEnvironmentToolsNotFound(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	defer st.Close()
 
-	cfg, err = st.ModelConfig()
+	m, err := st.Model()
+	c.Assert(err, jc.ErrorIsNil)
+
+	cfg, err = m.ModelConfig()
 	c.Assert(err, jc.ErrorIsNil)
 	vers, ok := cfg.AgentVersion()
 	c.Assert(ok, jc.IsTrue)

--- a/cmd/jujud/reboot/reboot_test.go
+++ b/cmd/jujud/reboot/reboot_test.go
@@ -81,7 +81,7 @@ func (s *RebootSuite) SetUpTest(c *gc.C) {
 		CACert:            coretesting.CACert,
 		Password:          "fake",
 		Controller:        s.State.ControllerTag(),
-		Model:             s.State.ModelTag(),
+		Model:             s.IAASModel.ModelTag(),
 		MongoVersion:      mongo.Mongo24,
 	}
 	s.st, _ = s.OpenAPIAsNewMachine(c)

--- a/environs/environ_test.go
+++ b/environs/environ_test.go
@@ -21,7 +21,7 @@ var _ = gc.Suite(&environSuite{})
 func (s *environSuite) TestGetEnvironment(c *gc.C) {
 	env, err := stateenvirons.GetNewEnvironFunc(environs.New)(s.State)
 	c.Assert(err, jc.ErrorIsNil)
-	config, err := s.State.ModelConfig()
+	config, err := s.IAASModel.ModelConfig()
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Check(env.Config().UUID(), jc.DeepEquals, config.UUID())

--- a/environs/jujutest/livetests.go
+++ b/environs/jujutest/livetests.go
@@ -615,7 +615,7 @@ func (t *LiveTests) TestBootstrapAndDeploy(c *gc.C) {
 
 	// Check that the agent version has made it through the
 	// bootstrap process (it's optional in the config.Config)
-	cfg, err := st.ModelConfig()
+	cfg, err := model.ModelConfig()
 	c.Assert(err, jc.ErrorIsNil)
 	agentVersion, ok := cfg.AgentVersion()
 	c.Check(ok, jc.IsTrue)

--- a/featuretests/api_model_test.go
+++ b/featuretests/api_model_test.go
@@ -64,7 +64,7 @@ func (s *apiEnvironmentSuite) TestRevokeModel(c *gc.C) {
 	mm := modelmanager.NewClient(s.OpenControllerAPI(c))
 	defer mm.Close()
 
-	modelUser, err := s.State.UserAccess(user.UserTag, s.State.ModelTag())
+	modelUser, err := s.State.UserAccess(user.UserTag, s.IAASModel.ModelTag())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(modelUser, gc.Not(gc.DeepEquals), permission.UserAccess{})
 
@@ -72,7 +72,7 @@ func (s *apiEnvironmentSuite) TestRevokeModel(c *gc.C) {
 	err = mm.RevokeModel(user.UserName, "read", model.UUID())
 	c.Assert(err, jc.ErrorIsNil)
 
-	modelUser, err = s.State.UserAccess(user.UserTag, s.State.ModelTag())
+	modelUser, err = s.State.UserAccess(user.UserTag, s.IAASModel.ModelTag())
 	c.Assert(errors.IsNotFound(err), jc.IsTrue)
 	c.Assert(modelUser, gc.DeepEquals, permission.UserAccess{})
 }
@@ -116,8 +116,12 @@ func (s *apiEnvironmentSuite) TestUploadToolsOtherEnvironment(c *gc.C) {
 	// setup other environment
 	otherState := s.Factory.MakeModel(c, nil)
 	defer otherState.Close()
+
+	otherModel, err := otherState.Model()
+	c.Assert(err, jc.ErrorIsNil)
+
 	info := s.APIInfo(c)
-	info.ModelTag = otherState.ModelTag()
+	info.ModelTag = otherModel.ModelTag()
 	otherAPIState, err := api.Open(info, api.DefaultDialOpts())
 	c.Assert(err, jc.ErrorIsNil)
 	defer otherAPIState.Close()

--- a/featuretests/api_undertaker_test.go
+++ b/featuretests/api_undertaker_test.go
@@ -19,6 +19,7 @@ import (
 	coretesting "github.com/juju/juju/testing"
 	"github.com/juju/juju/testing/factory"
 	"github.com/juju/juju/watcher/watchertest"
+	"gopkg.in/juju/names.v2"
 )
 
 // TODO(fwereade) 2016-03-17 lp:1558668
@@ -183,7 +184,7 @@ func (s *undertakerSuite) hostedAPI(c *gc.C) (*undertaker.Client, *state.State) 
 	info.Tag = machine.Tag()
 	info.Password = password
 	info.Nonce = "fake_nonce"
-	info.ModelTag = otherState.ModelTag()
+	info.ModelTag = names.NewModelTag(otherState.ModelUUID())
 
 	otherAPIState, err := api.Open(info, api.DefaultDialOpts())
 	c.Assert(err, jc.ErrorIsNil)

--- a/featuretests/cmd_juju_model_test.go
+++ b/featuretests/cmd_juju_model_test.go
@@ -52,7 +52,7 @@ func (s *cmdModelSuite) TestGrantModelCmdStack(c *gc.C) {
 	c.Assert(obtained, gc.Equals, expected)
 
 	user := names.NewUserTag(username)
-	modelUser, err := s.State.UserAccess(user, s.State.ModelTag())
+	modelUser, err := s.State.UserAccess(user, s.IAASModel.ModelTag())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(modelUser.UserName, gc.Equals, user.Id())
 	c.Assert(modelUser.CreatedBy.Id(), gc.Equals, s.AdminUserTag(c).Id())
@@ -79,7 +79,7 @@ func (s *cmdModelSuite) TestRevokeModelCmdStack(c *gc.C) {
 	c.Assert(obtained, gc.Equals, expected)
 
 	user := names.NewUserTag(username)
-	modelUser, err := s.State.UserAccess(user, s.State.ModelTag())
+	modelUser, err := s.State.UserAccess(user, s.IAASModel.ModelTag())
 	c.Assert(errors.IsNotFound(err), jc.IsTrue)
 	c.Assert(modelUser, gc.DeepEquals, permission.UserAccess{})
 }
@@ -89,7 +89,7 @@ func (s *cmdModelSuite) TestModelUsersCmd(c *gc.C) {
 	username := "bar@ubuntuone"
 	context := s.run(c, "grant", username, "read", "controller")
 	user := names.NewUserTag(username)
-	modelUser, err := s.State.UserAccess(user, s.State.ModelTag())
+	modelUser, err := s.State.UserAccess(user, s.IAASModel.ModelTag())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(modelUser, gc.NotNil)
 
@@ -239,7 +239,7 @@ func (s *cmdModelSuite) TestDumpModelDB(c *gc.C) {
 }
 
 func (s *cmdModelSuite) assertModelValue(c *gc.C, key string, expected interface{}) {
-	modelConfig, err := s.State.ModelConfig()
+	modelConfig, err := s.IAASModel.ModelConfig()
 	c.Assert(err, jc.ErrorIsNil)
 	value, found := modelConfig.AllAttrs()[key]
 	c.Assert(found, jc.IsTrue)
@@ -247,7 +247,7 @@ func (s *cmdModelSuite) assertModelValue(c *gc.C, key string, expected interface
 }
 
 func (s *cmdModelSuite) assertModelValueMissing(c *gc.C, key string) {
-	modelConfig, err := s.State.ModelConfig()
+	modelConfig, err := s.IAASModel.ModelConfig()
 	c.Assert(err, jc.ErrorIsNil)
 	_, found := modelConfig.AllAttrs()[key]
 	c.Assert(found, jc.IsFalse)

--- a/juju/testing/conn.go
+++ b/juju/testing/conn.go
@@ -163,7 +163,9 @@ func (s *JujuConnSuite) APIInfo(c *gc.C) *api.Info {
 	c.Assert(err, jc.ErrorIsNil)
 	apiInfo.Tag = s.AdminUserTag(c)
 	apiInfo.Password = "dummy-secret"
-	apiInfo.ModelTag = s.State.ModelTag()
+	model, err := s.State.Model()
+	c.Assert(err, jc.ErrorIsNil)
+	apiInfo.ModelTag = model.ModelTag()
 	return apiInfo
 }
 
@@ -717,6 +719,8 @@ func (s *JujuConnSuite) AgentConfigForTag(c *gc.C, tag names.Tag) agent.ConfigSe
 	c.Assert(err, jc.ErrorIsNil)
 	paths := agent.DefaultPaths
 	paths.DataDir = s.DataDir()
+	model, err := s.State.Model()
+	c.Assert(err, jc.ErrorIsNil)
 	config, err := agent.NewAgentConfig(
 		agent.AgentConfigParams{
 			Paths:             paths,
@@ -728,7 +732,7 @@ func (s *JujuConnSuite) AgentConfigForTag(c *gc.C, tag names.Tag) agent.ConfigSe
 			APIAddresses:      s.APIInfo(c).Addrs,
 			CACert:            testing.CACert,
 			Controller:        s.State.ControllerTag(),
-			Model:             s.State.ModelTag(),
+			Model:             model.ModelTag(),
 		})
 	c.Assert(err, jc.ErrorIsNil)
 	return config

--- a/migration/precheck_shim.go
+++ b/migration/precheck_shim.go
@@ -46,10 +46,15 @@ func (s *precheckShim) IsMigrationActive(modelUUID string) (bool, error) {
 
 // AgentVersion implements PrecheckBackend.
 func (s *precheckShim) AgentVersion() (version.Number, error) {
-	cfg, err := s.State.ModelConfig()
+	model, err := s.State.Model()
 	if err != nil {
 		return version.Zero, errors.Trace(err)
 	}
+	cfg, err := model.ModelConfig()
+	if err != nil {
+		return version.Zero, errors.Trace(err)
+	}
+
 	vers, ok := cfg.AgentVersion()
 	if !ok {
 		return version.Zero, errors.New("no model agent version")

--- a/state/address.go
+++ b/state/address.go
@@ -29,7 +29,11 @@ func (st *State) controllerAddresses() ([]string, error) {
 
 	var machines mongo.Collection
 	var closer SessionCloser
-	if st.ModelTag() == cinfo.ModelTag {
+	model, err := st.Model()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	if model.ModelTag() == cinfo.ModelTag {
 		machines, closer = st.db().GetCollection(machinesC)
 	} else {
 		machines, closer = st.db().GetCollectionFor(cinfo.ModelTag.Id(), machinesC)

--- a/state/allwatcher.go
+++ b/state/allwatcher.go
@@ -122,7 +122,12 @@ func (e *backingModel) isNotFoundAndModelDead(err error) bool {
 }
 
 func (e *backingModel) updated(st *State, store *multiwatcherStore, id string) error {
-	cfg, err := st.ModelConfig()
+	m, err := st.Model()
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	cfg, err := m.ModelConfig()
 	if e.isNotFoundAndModelDead(err) {
 		// Treat it as if the model is removed.
 		return e.removed(store, e.UUID, e.UUID, st)

--- a/state/allwatcher_internal_test.go
+++ b/state/allwatcher_internal_test.go
@@ -643,6 +643,8 @@ func (s *allWatcherStateSuite) TestChangeBlocks(c *gc.C) {
 			blockId := st.docID("0")
 			blockType := DestroyBlock.ToParams()
 			blockMsg := "woot"
+			m, err := st.Model()
+			c.Assert(err, jc.ErrorIsNil)
 			return changeTestCase{
 				about: "no change if block is not in backing",
 				initialContents: []multiwatcher.EntityInfo{&multiwatcher.BlockInfo{
@@ -650,7 +652,7 @@ func (s *allWatcherStateSuite) TestChangeBlocks(c *gc.C) {
 					Id:        blockId,
 					Type:      blockType,
 					Message:   blockMsg,
-					Tag:       st.ModelTag().String(),
+					Tag:       m.ModelTag().String(),
 				}},
 				change: watcher.Change{
 					C:  blocksC,
@@ -661,7 +663,7 @@ func (s *allWatcherStateSuite) TestChangeBlocks(c *gc.C) {
 					Id:        blockId,
 					Type:      blockType,
 					Message:   blockMsg,
-					Tag:       st.ModelTag().String(),
+					Tag:       m.ModelTag().String(),
 				}},
 			}
 		},
@@ -672,7 +674,8 @@ func (s *allWatcherStateSuite) TestChangeBlocks(c *gc.C) {
 			c.Assert(err, jc.ErrorIsNil)
 			c.Assert(found, jc.IsTrue)
 			blockId := b.Id()
-
+			m, err := st.Model()
+			c.Assert(err, jc.ErrorIsNil)
 			return changeTestCase{
 				about: "block is added if it's in backing but not in Store",
 				change: watcher.Change{
@@ -685,7 +688,7 @@ func (s *allWatcherStateSuite) TestChangeBlocks(c *gc.C) {
 						Id:        st.localID(blockId),
 						Type:      b.Type().ToParams(),
 						Message:   b.Message(),
-						Tag:       st.ModelTag().String(),
+						Tag:       m.ModelTag().String(),
 					}}}
 		},
 		func(c *gc.C, st *State) changeTestCase {
@@ -1602,7 +1605,10 @@ func (s *allModelWatcherStateSuite) TestModelSettings(c *gc.C) {
 	setModelConfigAttr(c, s.state, "http-proxy", "http://invalid")
 	setModelConfigAttr(c, s.state, "foo", "bar")
 
-	cfg, err := s.state.ModelConfig()
+	m, err := s.state.Model()
+	c.Assert(err, jc.ErrorIsNil)
+
+	cfg, err := m.ModelConfig()
 	c.Assert(err, jc.ErrorIsNil)
 	expectedModelSettings := cfg.AllAttrs()
 	expectedModelSettings["http-proxy"] = "http://invalid"

--- a/state/backups/export_test.go
+++ b/state/backups/export_test.go
@@ -36,9 +36,8 @@ var _ filestorage.DocStorage = (*backupsDocStorage)(nil)
 var _ filestorage.RawFileStorage = (*backupBlobStorage)(nil)
 
 func getBackupDBWrapper(st *state.State) *storageDBWrapper {
-	modelUUID := st.ModelTag().Id()
 	db := st.MongoSession().DB(storageDBName)
-	return newStorageDBWrapper(db, storageMetaName, modelUUID)
+	return newStorageDBWrapper(db, storageMetaName, st.ModelUUID())
 }
 
 // NewBackupID creates a new backup ID based on the metadata.

--- a/state/backups/restore_test.go
+++ b/state/backups/restore_test.go
@@ -230,7 +230,8 @@ func (r *RestoreSuite) TestNewConnection(c *gc.C) {
 	) state.NewPolicyFunc {
 		return nil
 	})
-	st, err = newStateConnection(st.ControllerTag(), st.ModelTag(), statetesting.NewMongoInfo())
+
+	st, err = newStateConnection(st.ControllerTag(), names.NewModelTag(st.ModelUUID()), statetesting.NewMongoInfo())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(st.Close(), jc.ErrorIsNil)
 }

--- a/state/block_test.go
+++ b/state/block_test.go
@@ -51,7 +51,9 @@ func (s *blockSuite) assertModelHasBlock(c *gc.C, st *state.State, t state.Block
 	c.Assert(block.Type(), gc.Equals, t)
 	tag, err := block.Tag()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(tag, gc.Equals, st.ModelTag())
+	m, err := st.Model()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(tag, gc.Equals, m.ModelTag())
 	c.Assert(block.Message(), gc.Equals, msg)
 }
 

--- a/state/cleanup_test.go
+++ b/state/cleanup_test.go
@@ -116,7 +116,7 @@ func (s *CleanupSuite) TestCleanupRemoteApplicationWithRelations(c *gc.C) {
 	}
 	remoteApp, err := s.State.AddRemoteApplication(state.AddRemoteApplicationParams{
 		Name:        "mysql",
-		SourceModel: s.State.ModelTag(),
+		SourceModel: s.IAASModel.ModelTag(),
 		Token:       "t0",
 		Endpoints:   mysqlEps,
 	})

--- a/state/configvalidator_test.go
+++ b/state/configvalidator_test.go
@@ -84,7 +84,7 @@ func (s *ConfigValidatorSuite) TestUpdateModelConfigFailsOnConfigValidateError(c
 
 func (s *ConfigValidatorSuite) TestUpdateModelConfigUpdatesState(c *gc.C) {
 	s.updateModelConfig(c)
-	stateCfg, err := s.State.ModelConfig()
+	stateCfg, err := s.IAASModel.ModelConfig()
 	c.Assert(err, jc.ErrorIsNil)
 	newValidCfg, err := mockValidCfg()
 	c.Assert(err, jc.ErrorIsNil)

--- a/state/conn_test.go
+++ b/state/conn_test.go
@@ -49,7 +49,7 @@ func (cs *ConnSuite) SetUpTest(c *gc.C) {
 
 	cs.StateSuite.SetUpTest(c)
 
-	cs.modelTag = cs.State.ModelTag()
+	cs.modelTag = cs.IAASModel.ModelTag()
 
 	jujuDB := cs.MgoSuite.Session.DB("juju")
 	cs.annotations = jujuDB.C("annotations")

--- a/state/conn_wallclock_test.go
+++ b/state/conn_wallclock_test.go
@@ -51,7 +51,7 @@ func (cs *ConnWithWallClockSuite) SetUpTest(c *gc.C) {
 
 	cs.StateWithWallClockSuite.SetUpTest(c)
 
-	cs.modelTag = cs.State.ModelTag()
+	cs.modelTag = cs.IAASModel.ModelTag()
 
 	jujuDB := cs.MgoSuite.Session.DB("juju")
 	cs.annotations = jujuDB.C("annotations")

--- a/state/controller_test.go
+++ b/state/controller_test.go
@@ -42,7 +42,7 @@ func (s *ControllerSuite) TestControllerAndModelConfigInitialisation(c *gc.C) {
 }
 
 func (s *ControllerSuite) TestNewState(c *gc.C) {
-	st, err := s.Controller.NewState(s.State.ModelTag())
+	st, err := s.Controller.NewState(s.IAASModel.ModelTag())
 	c.Assert(err, jc.ErrorIsNil)
 	defer st.Close()
 	c.Check(st.ModelUUID(), gc.Equals, s.State.ModelUUID())

--- a/state/filesystem.go
+++ b/state/filesystem.go
@@ -1074,7 +1074,7 @@ func (im *IAASModel) newFilesystemOps(doc filesystemDoc, status statusDoc) []txn
 
 func (im *IAASModel) filesystemParamsWithDefaults(params FilesystemParams, machineId string) (FilesystemParams, error) {
 	if params.Pool == "" {
-		modelConfig, err := im.st.ModelConfig()
+		modelConfig, err := im.ModelConfig()
 		if err != nil {
 			return FilesystemParams{}, errors.Trace(err)
 		}

--- a/state/initialize_test.go
+++ b/state/initialize_test.go
@@ -1,4 +1,4 @@
-// Copyright 2013 Canonical Ltd.
+// Copyright Canonical Ltd. 2013
 // Licensed under the AGPLv3, see LICENCE file for details.
 
 package state_test
@@ -26,6 +26,7 @@ type InitializeSuite struct {
 	gitjujutesting.MgoSuite
 	testing.BaseSuite
 	State *state.State
+	Model *state.Model
 }
 
 var _ = gc.Suite(&InitializeSuite{})
@@ -55,6 +56,10 @@ func (s *InitializeSuite) openState(c *gc.C, modelTag names.ModelTag) {
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	s.State = st
+
+	m, err := st.Model()
+	c.Assert(err, jc.ErrorIsNil)
+	s.Model = m
 }
 
 func (s *InitializeSuite) TearDownTest(c *gc.C) {
@@ -119,7 +124,9 @@ func (s *InitializeSuite) TestInitialize(c *gc.C) {
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(st, gc.NotNil)
-	modelTag := st.ModelTag()
+	m, err := st.Model()
+	c.Assert(err, jc.ErrorIsNil)
+	modelTag := m.ModelTag()
 	c.Assert(modelTag.Id(), gc.Equals, uuid)
 
 	err = st.Close()
@@ -130,7 +137,7 @@ func (s *InitializeSuite) TestInitialize(c *gc.C) {
 
 	s.openState(c, modelTag)
 
-	cfg, err = s.State.ModelConfig()
+	cfg, err = s.Model.ModelConfig()
 	c.Assert(err, jc.ErrorIsNil)
 	expected := cfg.AllAttrs()
 	for k, v := range config.ConfigDefaults() {
@@ -250,7 +257,9 @@ func (s *InitializeSuite) TestInitializeWithControllerInheritedConfig(c *gc.C) {
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(st, gc.NotNil)
-	modelTag := st.ModelTag()
+	m, err := st.Model()
+	c.Assert(err, jc.ErrorIsNil)
+	modelTag := m.ModelTag()
 	c.Assert(modelTag.Id(), gc.Equals, uuid)
 
 	err = st.Close()
@@ -273,7 +282,7 @@ func (s *InitializeSuite) TestInitializeWithControllerInheritedConfig(c *gc.C) {
 	}
 	// Config as read from state has resources tags coerced to a map.
 	expected["resource-tags"] = map[string]string{}
-	cfg, err = s.State.ModelConfig()
+	cfg, err = s.Model.ModelConfig()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cfg.AllAttrs(), jc.DeepEquals, expected)
 }
@@ -376,12 +385,12 @@ func (s *InitializeSuite) testBadModelConfig(c *gc.C, update map[string]interfac
 	st.Close()
 	ctlr.Close()
 
-	s.openState(c, st.ModelTag())
+	s.openState(c, names.NewModelTag(st.ModelUUID()))
 	err = s.State.UpdateModelConfig(update, remove)
 	c.Assert(err, gc.ErrorMatches, expect)
 
 	// ModelConfig remains inviolate.
-	cfg, err := s.State.ModelConfig()
+	cfg, err := s.Model.ModelConfig()
 	c.Assert(err, jc.ErrorIsNil)
 	goodWithDefaults, err := config.New(config.UseDefaults, good.AllAttrs())
 	c.Assert(err, jc.ErrorIsNil)
@@ -464,7 +473,9 @@ func (s *InitializeSuite) TestInitializeWithCloudRegionConfig(c *gc.C) {
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(st, gc.NotNil)
-	modelTag := st.ModelTag()
+	m, err := st.Model()
+	c.Assert(err, jc.ErrorIsNil)
+	modelTag := m.ModelTag()
 	c.Assert(modelTag.Id(), gc.Equals, uuid)
 
 	err = st.Close()
@@ -528,7 +539,9 @@ func (s *InitializeSuite) TestInitializeWithCloudRegionMisses(c *gc.C) {
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(st, gc.NotNil)
-	modelTag := st.ModelTag()
+	m, err := st.Model()
+	c.Assert(err, jc.ErrorIsNil)
+	modelTag := m.ModelTag()
 	c.Assert(modelTag.Id(), gc.Equals, uuid)
 
 	err = st.Close()
@@ -587,7 +600,9 @@ func (s *InitializeSuite) TestInitializeWithCloudRegionHits(c *gc.C) {
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(st, gc.NotNil)
-	modelTag := st.ModelTag()
+	m, err := st.Model()
+	c.Assert(err, jc.ErrorIsNil)
+	modelTag := m.ModelTag()
 	c.Assert(modelTag.Id(), gc.Equals, uuid)
 
 	err = st.Close()

--- a/state/interface_test.go
+++ b/state/interface_test.go
@@ -40,10 +40,9 @@ var (
 	_ AgentEntity = (*Machine)(nil)
 	_ AgentEntity = (*Unit)(nil)
 
-	_ ModelAccessor = (*State)(nil)
-
-	_ UnitsWatcher = (*Machine)(nil)
-	_ UnitsWatcher = (*Application)(nil)
+	_ ModelAccessor = (*Model)(nil)
+	_ UnitsWatcher  = (*Machine)(nil)
+	_ UnitsWatcher  = (*Application)(nil)
 
 	_ ModelMachinesWatcher = (*State)(nil)
 

--- a/state/machine.go
+++ b/state/machine.go
@@ -369,7 +369,12 @@ func (m *Machine) IsManual() (bool, error) {
 	// case we need to check if its provider type is "manual".
 	// We also check for "null", which is an alias for manual.
 	if m.doc.Id == "0" {
-		cfg, err := m.st.ModelConfig()
+		model, err := m.st.Model()
+		if err != nil {
+			return false, errors.Trace(err)
+		}
+
+		cfg, err := model.ModelConfig()
 		if err != nil {
 			return false, err
 		}

--- a/state/machine_test.go
+++ b/state/machine_test.go
@@ -229,7 +229,7 @@ func (s *MachineSuite) TestMachineIsManager(c *gc.C) {
 }
 
 func (s *MachineSuite) TestMachineIsManualBootstrap(c *gc.C) {
-	cfg, err := s.State.ModelConfig()
+	cfg, err := s.IAASModel.ModelConfig()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cfg.Type(), gc.Not(gc.Equals), "null")
 	c.Assert(s.machine.Id(), gc.Equals, "1")

--- a/state/migration_export_test.go
+++ b/state/migration_export_test.go
@@ -201,7 +201,7 @@ func (s *MigrationExportSuite) TestModelUsers(c *gc.C) {
 	// Make sure we have some last connection times for the admin user,
 	// and create a few other users.
 	lastConnection := state.NowToTheSecond(s.State)
-	owner, err := s.State.UserAccess(s.Owner, s.State.ModelTag())
+	owner, err := s.State.UserAccess(s.Owner, s.IAASModel.ModelTag())
 	c.Assert(err, jc.ErrorIsNil)
 	err = state.UpdateModelUserLastConnection(s.State, owner, lastConnection)
 	c.Assert(err, jc.ErrorIsNil)
@@ -1341,7 +1341,7 @@ func (s *MigrationExportSuite) TestRemoteApplications(c *gc.C) {
 	dbApp, err := s.State.AddRemoteApplication(state.AddRemoteApplicationParams{
 		Name:        "gravy-rainbow",
 		URL:         "me/model.rainbow",
-		SourceModel: s.State.ModelTag(),
+		SourceModel: s.IAASModel.ModelTag(),
 		Token:       "charisma",
 		OfferUUID:   "offer-uuid",
 		Endpoints: []charm.Relation{{
@@ -1417,7 +1417,7 @@ func (s *MigrationExportSuite) TestRemoteApplications(c *gc.C) {
 	c.Check(app.Name(), gc.Equals, "gravy-rainbow")
 	c.Check(app.OfferUUID(), gc.Equals, "offer-uuid")
 	c.Check(app.URL(), gc.Equals, "me/model.rainbow")
-	c.Check(app.SourceModelTag(), gc.Equals, s.State.ModelTag())
+	c.Check(app.SourceModelTag(), gc.Equals, s.IAASModel.ModelTag())
 	c.Check(app.IsConsumerProxy(), jc.IsFalse)
 	c.Check(app.Bindings(), gc.DeepEquals, map[string]string{
 		"db":       "private",

--- a/state/migration_import_test.go
+++ b/state/migration_import_test.go
@@ -1336,7 +1336,7 @@ func (s *MigrationImportSuite) TestRemoteApplications(c *gc.C) {
 	_, err := s.State.AddRemoteApplication(state.AddRemoteApplicationParams{
 		Name:        "gravy-rainbow",
 		URL:         "me/model.rainbow",
-		SourceModel: s.State.ModelTag(),
+		SourceModel: s.IAASModel.ModelTag(),
 		Token:       "charisma",
 		Endpoints: []charm.Relation{{
 			Interface: "mysql",

--- a/state/model_test.go
+++ b/state/model_test.go
@@ -1212,7 +1212,9 @@ func (s *ModelSuite) TestListUsersTwoModels(c *gc.C) {
 func addModelUsers(c *gc.C, st *state.State) (expected []permission.UserAccess) {
 	// get the model owner
 	testAdmin := names.NewUserTag("test-admin")
-	owner, err := st.UserAccess(testAdmin, st.ModelTag())
+	m, err := st.Model()
+	c.Assert(err, jc.ErrorIsNil)
+	owner, err := st.UserAccess(testAdmin, m.ModelTag())
 	c.Assert(err, jc.ErrorIsNil)
 
 	f := factory.NewFactory(st)

--- a/state/modelconfig.go
+++ b/state/modelconfig.go
@@ -19,10 +19,9 @@ var disallowedModelConfigAttrs = [...]string{
 	"ca-private-key",
 }
 
-// ModelConfig returns the complete config for the model represented
-// by this state.
-func (st *State) ModelConfig() (*config.Config, error) {
-	return getModelConfig(st.db())
+// ModelConfig returns the complete config for the model
+func (m *Model) ModelConfig() (*config.Config, error) {
+	return getModelConfig(m.st.db())
 }
 
 func getModelConfig(db Database) (*config.Config, error) {
@@ -176,7 +175,12 @@ func (st *State) UpdateModelConfigDefaultValues(attrs map[string]interface{}, re
 // ModelConfigValues returns the config values for the model represented
 // by this state.
 func (st *State) ModelConfigValues() (config.ConfigValues, error) {
-	cfg, err := st.ModelConfig()
+	m, err := st.Model()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	cfg, err := m.ModelConfig()
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -323,7 +327,12 @@ func (st *State) UpdateModelConfig(updateAttrs map[string]interface{}, removeAtt
 	}
 
 	// Get the existing model config from state.
-	oldConfig, err := st.ModelConfig()
+	m, err := st.Model()
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	oldConfig, err := m.ModelConfig()
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/state/modelconfig_test.go
+++ b/state/modelconfig_test.go
@@ -97,13 +97,13 @@ func (s *ModelConfigSuite) TestModelConfig(c *gc.C) {
 		"authorized-keys": "different-keys",
 		"arbitrary-key":   "shazam!",
 	}
-	cfg, err := s.State.ModelConfig()
+	cfg, err := s.IAASModel.ModelConfig()
 	c.Assert(err, jc.ErrorIsNil)
 	err = s.State.UpdateModelConfig(attrs, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	cfg, err = cfg.Apply(attrs)
 	c.Assert(err, jc.ErrorIsNil)
-	oldCfg, err := s.State.ModelConfig()
+	oldCfg, err := s.IAASModel.ModelConfig()
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Assert(oldCfg, jc.DeepEquals, cfg)
@@ -203,7 +203,7 @@ func (s *ModelConfigSuite) TestUpdateModelConfigRemoveInherited(c *gc.C) {
 
 	err = s.State.UpdateModelConfig(nil, []string{"apt-mirror", "arbitrary-key", "providerAttr", "whimsy-key"})
 	c.Assert(err, jc.ErrorIsNil)
-	cfg, err := s.State.ModelConfig()
+	cfg, err := s.IAASModel.ModelConfig()
 	c.Assert(err, jc.ErrorIsNil)
 	allAttrs := cfg.AllAttrs()
 	c.Assert(allAttrs["apt-mirror"], gc.Equals, "http://cloud-mirror")
@@ -232,7 +232,7 @@ func (s *ModelConfigSuite) TestUpdateModelConfigCoerce(c *gc.C) {
 	}
 	c.Assert(tagsMap, gc.DeepEquals, expectedTags)
 
-	cfg, err := s.State.ModelConfig()
+	cfg, err := s.IAASModel.ModelConfig()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cfg.AllAttrs()["resource-tags"], gc.DeepEquals, expectedTags)
 }
@@ -251,7 +251,7 @@ func (s *ModelConfigSuite) TestUpdateModelConfigPreferredOverRemove(c *gc.C) {
 		"providerAttr": "pork",
 	}, []string{"apt-mirror", "arbitrary-key"})
 	c.Assert(err, jc.ErrorIsNil)
-	cfg, err := s.State.ModelConfig()
+	cfg, err := s.IAASModel.ModelConfig()
 	c.Assert(err, jc.ErrorIsNil)
 	allAttrs := cfg.AllAttrs()
 	c.Assert(allAttrs["apt-mirror"], gc.Equals, "http://another-mirror")
@@ -294,13 +294,13 @@ func (s *ModelConfigSourceSuite) TestModelConfigWhenSetOverridesControllerValue(
 	err := s.State.UpdateModelConfig(attrs, nil)
 	c.Assert(err, jc.ErrorIsNil)
 
-	cfg, err := s.State.ModelConfig()
+	cfg, err := s.IAASModel.ModelConfig()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cfg.AllAttrs()["apt-mirror"], gc.Equals, "http://anothermirror")
 }
 
 func (s *ModelConfigSourceSuite) TestControllerModelConfigForksControllerValue(c *gc.C) {
-	modelCfg, err := s.State.ModelConfig()
+	modelCfg, err := s.IAASModel.ModelConfig()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(modelCfg.AllAttrs()["apt-mirror"], gc.Equals, "http://cloud-mirror")
 
@@ -311,7 +311,7 @@ func (s *ModelConfigSourceSuite) TestControllerModelConfigForksControllerValue(c
 	_, err = localControllerSettings.Write()
 	c.Assert(err, jc.ErrorIsNil)
 
-	modelCfg, err = s.State.ModelConfig()
+	modelCfg, err = s.IAASModel.ModelConfig()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(modelCfg.AllAttrs()["apt-mirror"], gc.Equals, "http://cloud-mirror")
 }
@@ -335,7 +335,9 @@ func (s *ModelConfigSourceSuite) TestNewModelConfigForksControllerValue(c *gc.C)
 	c.Assert(err, jc.ErrorIsNil)
 	defer st.Close()
 
-	modelCfg, err := st.ModelConfig()
+	m, err := st.Model()
+
+	modelCfg, err := m.ModelConfig()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(modelCfg.AllAttrs()["apt-mirror"], gc.Equals, "http://mirror")
 
@@ -346,7 +348,7 @@ func (s *ModelConfigSourceSuite) TestNewModelConfigForksControllerValue(c *gc.C)
 	_, err = localCloudSettings.Write()
 	c.Assert(err, jc.ErrorIsNil)
 
-	modelCfg, err = st.ModelConfig()
+	modelCfg, err = m.ModelConfig()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(modelCfg.AllAttrs()["apt-mirror"], gc.Equals, "http://mirror")
 }
@@ -379,7 +381,7 @@ func (s *ModelConfigSourceSuite) assertModelConfigValues(c *gc.C, modelCfg *conf
 }
 
 func (s *ModelConfigSourceSuite) TestModelConfigValues(c *gc.C) {
-	modelCfg, err := s.State.ModelConfig()
+	modelCfg, err := s.IAASModel.ModelConfig()
 	c.Assert(err, jc.ErrorIsNil)
 	modelAttributes := set.NewStrings("name", "apt-mirror", "logging-config", "authorized-keys", "resource-tags")
 	s.assertModelConfigValues(c, modelCfg, modelAttributes, set.NewStrings("http-proxy"))
@@ -392,7 +394,7 @@ func (s *ModelConfigSourceSuite) TestModelConfigUpdateSource(c *gc.C) {
 	}
 	err := s.State.UpdateModelConfig(attrs, nil)
 	c.Assert(err, jc.ErrorIsNil)
-	modelCfg, err := s.State.ModelConfig()
+	modelCfg, err := s.IAASModel.ModelConfig()
 	c.Assert(err, jc.ErrorIsNil)
 	modelAttributes := set.NewStrings("name", "http-proxy", "logging-config", "authorized-keys", "resource-tags")
 	s.assertModelConfigValues(c, modelCfg, modelAttributes, set.NewStrings("apt-mirror"))

--- a/state/modeluser_test.go
+++ b/state/modeluser_test.go
@@ -52,7 +52,7 @@ func (s *ModelUserSuite) TestAddModelUser(c *gc.C) {
 	c.Assert(err, jc.Satisfies, state.IsNeverConnectedError)
 	c.Assert(when.IsZero(), jc.IsTrue)
 
-	modelUser, err = s.State.UserAccess(user.UserTag(), s.State.ModelTag())
+	modelUser, err = s.State.UserAccess(user.UserTag(), s.IAASModel.ModelTag())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(modelUser.UserID, gc.Equals, fmt.Sprintf("%s:validusername", s.modelTag.Id()))
 	c.Assert(modelUser.Object, gc.Equals, s.modelTag)
@@ -86,7 +86,7 @@ func (s *ModelUserSuite) TestAddReadOnlyModelUser(c *gc.C) {
 	c.Assert(modelUser.Access, gc.Equals, permission.ReadAccess)
 
 	// Make sure that it is set when we read the user out.
-	modelUser, err = s.State.UserAccess(user.UserTag(), s.State.ModelTag())
+	modelUser, err = s.State.UserAccess(user.UserTag(), s.IAASModel.ModelTag())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(modelUser.UserName, gc.Equals, "validusername")
 	c.Assert(modelUser.Access, gc.Equals, permission.ReadAccess)
@@ -112,7 +112,7 @@ func (s *ModelUserSuite) TestAddReadWriteModelUser(c *gc.C) {
 	c.Assert(modelUser.Access, gc.Equals, permission.WriteAccess)
 
 	// Make sure that it is set when we read the user out.
-	modelUser, err = s.State.UserAccess(user.UserTag(), s.State.ModelTag())
+	modelUser, err = s.State.UserAccess(user.UserTag(), s.IAASModel.ModelTag())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(modelUser.UserName, gc.Equals, "validusername")
 	c.Assert(modelUser.Access, gc.Equals, permission.WriteAccess)
@@ -138,7 +138,7 @@ func (s *ModelUserSuite) TestAddAdminModelUser(c *gc.C) {
 	c.Assert(modelUser.Access, gc.Equals, permission.AdminAccess)
 
 	// Make sure that it is set when we read the user out.
-	modelUser, err = s.State.UserAccess(user.UserTag(), s.State.ModelTag())
+	modelUser, err = s.State.UserAccess(user.UserTag(), s.IAASModel.ModelTag())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(modelUser.UserName, gc.Equals, "validusername")
 	c.Assert(modelUser.Access, gc.Equals, permission.AdminAccess)
@@ -177,9 +177,9 @@ func (s *ModelUserSuite) TestSetAccessModelUser(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(modelUser.Access, gc.Equals, permission.AdminAccess)
 
-	s.State.SetUserAccess(modelUser.UserTag, s.State.ModelTag(), permission.ReadAccess)
+	s.State.SetUserAccess(modelUser.UserTag, s.IAASModel.ModelTag(), permission.ReadAccess)
 
-	modelUser, err = s.State.UserAccess(user.UserTag(), s.State.ModelTag())
+	modelUser, err = s.State.UserAccess(user.UserTag(), s.IAASModel.ModelTag())
 	c.Assert(modelUser.Access, gc.Equals, permission.ReadAccess)
 }
 
@@ -218,14 +218,20 @@ func (s *ModelUserSuite) TestCaseInsensitiveLookupInMultiEnvirons(c *gc.C) {
 		f := factory.NewFactory(st1)
 		expectedUser := f.MakeModelUser(c, &factory.ModelUserParams{User: usernames[0]})
 
+		m1, err := st1.Model()
+		c.Assert(err, jc.ErrorIsNil)
+
+		m2, err := st2.Model()
+		c.Assert(err, jc.ErrorIsNil)
+
 		// assert case insensitive lookup for each username
 		for _, username := range usernames {
 			userTag := names.NewUserTag(username)
-			obtainedUser, err := st1.UserAccess(userTag, st1.ModelTag())
+			obtainedUser, err := st1.UserAccess(userTag, m1.ModelTag())
 			c.Assert(err, jc.ErrorIsNil)
 			c.Assert(obtainedUser, gc.DeepEquals, expectedUser)
 
-			_, err = st2.UserAccess(userTag, st2.ModelTag())
+			_, err = st2.UserAccess(userTag, m2.ModelTag())
 			c.Assert(errors.IsNotFound(err), jc.IsTrue)
 		}
 	}
@@ -276,19 +282,19 @@ func (s *ModelUserSuite) TestAddModelNoCreatedByUserFails(c *gc.C) {
 
 func (s *ModelUserSuite) TestRemoveModelUser(c *gc.C) {
 	user := s.Factory.MakeUser(c, &factory.UserParams{Name: "validUsername"})
-	_, err := s.State.UserAccess(user.UserTag(), s.State.ModelTag())
+	_, err := s.State.UserAccess(user.UserTag(), s.IAASModel.ModelTag())
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = s.State.RemoveUserAccess(user.UserTag(), s.State.ModelTag())
+	err = s.State.RemoveUserAccess(user.UserTag(), s.IAASModel.ModelTag())
 	c.Assert(err, jc.ErrorIsNil)
 
-	_, err = s.State.UserAccess(user.UserTag(), s.State.ModelTag())
+	_, err = s.State.UserAccess(user.UserTag(), s.IAASModel.ModelTag())
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 }
 
 func (s *ModelUserSuite) TestRemoveModelUserFails(c *gc.C) {
 	user := s.Factory.MakeUser(c, &factory.UserParams{NoModelUser: true})
-	err := s.State.RemoveUserAccess(user.UserTag(), s.State.ModelTag())
+	err := s.State.RemoveUserAccess(user.UserTag(), s.IAASModel.ModelTag())
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 }
 
@@ -296,7 +302,7 @@ func (s *ModelUserSuite) TestUpdateLastConnection(c *gc.C) {
 	now := state.NowToTheSecond(s.State)
 	createdBy := s.Factory.MakeUser(c, &factory.UserParams{Name: "createdby"})
 	user := s.Factory.MakeUser(c, &factory.UserParams{Name: "validusername", Creator: createdBy.Tag()})
-	modelUser, err := s.State.UserAccess(user.UserTag(), s.State.ModelTag())
+	modelUser, err := s.State.UserAccess(user.UserTag(), s.IAASModel.ModelTag())
 	c.Assert(err, jc.ErrorIsNil)
 	err = s.Model.UpdateLastModelConnection(user.UserTag())
 	c.Assert(err, jc.ErrorIsNil)
@@ -313,7 +319,7 @@ func (s *ModelUserSuite) TestUpdateLastConnectionTwoModelUsers(c *gc.C) {
 	// Create a user and add them to the inital model.
 	createdBy := s.Factory.MakeUser(c, &factory.UserParams{Name: "createdby"})
 	user := s.Factory.MakeUser(c, &factory.UserParams{Name: "validusername", Creator: createdBy.Tag()})
-	modelUser, err := s.State.UserAccess(user.UserTag(), s.State.ModelTag())
+	modelUser, err := s.State.UserAccess(user.UserTag(), s.IAASModel.ModelTag())
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Create a second model and add the same user to this.

--- a/state/offerconnections_test.go
+++ b/state/offerconnections_test.go
@@ -33,7 +33,7 @@ func (s *offerConnectionsSuite) TestAddOfferConnection(c *gc.C) {
 	c.Assert(oc.OfferUUID(), gc.Equals, "offer-uuid")
 	c.Assert(oc.UserName(), gc.Equals, "fred")
 
-	anotherState, err := s.State.ForModel(s.State.ModelTag())
+	anotherState, err := s.State.ForModel(s.IAASModel.ModelTag())
 	c.Assert(err, jc.ErrorIsNil)
 	defer anotherState.Close()
 
@@ -62,7 +62,7 @@ func (s *offerConnectionsSuite) TestAddOfferConnectionTwice(c *gc.C) {
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
-	anotherState, err := s.State.ForModel(s.State.ModelTag())
+	anotherState, err := s.State.ForModel(s.IAASModel.ModelTag())
 	c.Assert(err, jc.ErrorIsNil)
 	defer anotherState.Close()
 
@@ -86,7 +86,7 @@ func (s *offerConnectionsSuite) TestOfferConnectionForRelation(c *gc.C) {
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
-	anotherState, err := s.State.ForModel(s.State.ModelTag())
+	anotherState, err := s.State.ForModel(s.IAASModel.ModelTag())
 	c.Assert(err, jc.ErrorIsNil)
 	defer anotherState.Close()
 

--- a/state/policy.go
+++ b/state/policy.go
@@ -101,7 +101,12 @@ func (st *State) constraintsValidator() (constraints.Validator, error) {
 		return nil, errors.Annotate(err, "getting model")
 	}
 	if region := model.CloudRegion(); region != "" {
-		cfg, err := st.ModelConfig()
+		m, err := st.Model()
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+
+		cfg, err := m.ModelConfig()
 		if err != nil {
 			return nil, errors.Trace(err)
 		}

--- a/state/remoteapplication_test.go
+++ b/state/remoteapplication_test.go
@@ -98,7 +98,7 @@ func (s *remoteApplicationSuite) SetUpTest(c *gc.C) {
 	s.application, err = s.State.AddRemoteApplication(state.AddRemoteApplicationParams{
 		Name:            "mysql",
 		URL:             "me/model.mysql",
-		SourceModel:     s.State.ModelTag(),
+		SourceModel:     s.IAASModel.ModelTag(),
 		Token:           "app-token",
 		IsConsumerProxy: true,
 		Endpoints:       eps,
@@ -211,7 +211,7 @@ func (s *remoteApplicationSuite) TestURL(c *gc.C) {
 	// Add another remote application without a URL.
 	app, err := s.State.AddRemoteApplication(state.AddRemoteApplicationParams{
 		Name:        "mysql1",
-		SourceModel: s.State.ModelTag(),
+		SourceModel: s.IAASModel.ModelTag(),
 		Token:       "app-token",
 	})
 	c.Assert(err, jc.ErrorIsNil)
@@ -343,7 +343,7 @@ func (s *remoteApplicationSuite) TestAddRelationBothRemote(c *gc.C) {
 		},
 	}
 	_, err := s.State.AddRemoteApplication(state.AddRemoteApplicationParams{
-		Name: "wordpress", Endpoints: wpep, SourceModel: s.State.ModelTag()})
+		Name: "wordpress", Endpoints: wpep, SourceModel: s.IAASModel.ModelTag()})
 	c.Assert(err, jc.ErrorIsNil)
 	eps, err := s.State.InferEndpoints("wordpress", "mysql")
 	c.Assert(err, jc.ErrorIsNil)
@@ -360,13 +360,13 @@ func (s *remoteApplicationSuite) TestInferEndpointsWrongScope(c *gc.C) {
 
 func (s *remoteApplicationSuite) TestAddRemoteApplicationErrors(c *gc.C) {
 	_, err := s.State.AddRemoteApplication(state.AddRemoteApplicationParams{
-		Name: "haha/borken", SourceModel: s.State.ModelTag()})
+		Name: "haha/borken", SourceModel: s.IAASModel.ModelTag()})
 	c.Assert(err, gc.ErrorMatches, `cannot add remote application "haha/borken": name "haha/borken" not valid`)
 	_, err = s.State.RemoteApplication("haha/borken")
 	c.Assert(err, gc.ErrorMatches, `remote application name "haha/borken" not valid`)
 
 	_, err = s.State.AddRemoteApplication(state.AddRemoteApplicationParams{
-		Name: "borken", URL: "haha/borken", SourceModel: s.State.ModelTag()})
+		Name: "borken", URL: "haha/borken", SourceModel: s.IAASModel.ModelTag()})
 	c.Assert(err, gc.ErrorMatches,
 		`cannot add remote application "borken": validating offered application URL: `+
 			`application offer URL is missing application`,
@@ -396,7 +396,7 @@ func (s *remoteApplicationSuite) TestParamsValidateChecksBindings(c *gc.C) {
 	args := state.AddRemoteApplicationParams{
 		Name:        "mysql",
 		URL:         "me/model.mysql",
-		SourceModel: s.State.ModelTag(),
+		SourceModel: s.IAASModel.ModelTag(),
 		Token:       "app-token",
 		Endpoints:   eps,
 		Spaces:      spaces,
@@ -413,7 +413,7 @@ func (s *remoteApplicationSuite) TestParamsValidateChecksBindings(c *gc.C) {
 
 func (s *remoteApplicationSuite) TestAddRemoteApplication(c *gc.C) {
 	foo, err := s.State.AddRemoteApplication(state.AddRemoteApplicationParams{
-		Name: "foo", OfferUUID: "offer-uuid", URL: "me/model.foo", SourceModel: s.State.ModelTag()})
+		Name: "foo", OfferUUID: "offer-uuid", URL: "me/model.foo", SourceModel: s.IAASModel.ModelTag()})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(foo.Name(), gc.Equals, "foo")
 	c.Assert(foo.IsConsumerProxy(), jc.IsFalse)
@@ -425,12 +425,12 @@ func (s *remoteApplicationSuite) TestAddRemoteApplication(c *gc.C) {
 	c.Assert(ok, jc.IsTrue)
 	c.Assert(url, gc.Equals, "me/model.foo")
 	c.Assert(foo.IsConsumerProxy(), jc.IsFalse)
-	c.Assert(foo.SourceModel().Id(), gc.Equals, s.State.ModelTag().Id())
+	c.Assert(foo.SourceModel().Id(), gc.Equals, s.IAASModel.ModelTag().Id())
 }
 
 func (s *remoteApplicationSuite) TestAddRemoteApplicationFromConsumer(c *gc.C) {
 	foo, err := s.State.AddRemoteApplication(state.AddRemoteApplicationParams{
-		Name: "foo", SourceModel: s.State.ModelTag(), IsConsumerProxy: true})
+		Name: "foo", SourceModel: s.IAASModel.ModelTag(), IsConsumerProxy: true})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(foo.IsConsumerProxy(), jc.IsTrue)
 	foo, err = s.State.RemoteApplication("foo")
@@ -445,7 +445,7 @@ func (s *remoteApplicationSuite) TestAddEndpoints(c *gc.C) {
 		{Name: "ep2", Role: charm.RoleProvider, Scope: charm.ScopeGlobal, Limit: 1},
 	}
 	foo, err := s.State.AddRemoteApplication(state.AddRemoteApplicationParams{
-		Name: "foo", OfferUUID: "offer-uuid", SourceModel: s.State.ModelTag(),
+		Name: "foo", OfferUUID: "offer-uuid", SourceModel: s.IAASModel.ModelTag(),
 		Endpoints: origEps,
 	})
 	c.Assert(err, jc.ErrorIsNil)
@@ -483,7 +483,7 @@ func (s *remoteApplicationSuite) TestAddEndpointsConflicting(c *gc.C) {
 		{Name: "ep2", Role: charm.RoleProvider, Scope: charm.ScopeGlobal, Limit: 1},
 	}
 	foo, err := s.State.AddRemoteApplication(state.AddRemoteApplicationParams{
-		Name: "foo", OfferUUID: "offer-uuid", SourceModel: s.State.ModelTag(),
+		Name: "foo", OfferUUID: "offer-uuid", SourceModel: s.IAASModel.ModelTag(),
 		Endpoints: origEps,
 	})
 	c.Assert(err, jc.ErrorIsNil)
@@ -503,7 +503,7 @@ func (s *remoteApplicationSuite) TestAddEndpointsConcurrentOneDeleted(c *gc.C) {
 		{Name: "ep2", Role: charm.RoleProvider, Scope: charm.ScopeGlobal, Limit: 1},
 	}
 	foo, err := s.State.AddRemoteApplication(state.AddRemoteApplicationParams{
-		Name: "foo", OfferUUID: "offer-uuid", SourceModel: s.State.ModelTag(),
+		Name: "foo", OfferUUID: "offer-uuid", SourceModel: s.IAASModel.ModelTag(),
 		Endpoints: origEps,
 	})
 	c.Assert(err, jc.ErrorIsNil)
@@ -517,7 +517,7 @@ func (s *remoteApplicationSuite) TestAddEndpointsConcurrentOneDeleted(c *gc.C) {
 		err := foo.Destroy()
 		c.Assert(err, jc.ErrorIsNil)
 		_, err = s.State.AddRemoteApplication(state.AddRemoteApplicationParams{
-			Name: "foo", OfferUUID: "offer-uuid", SourceModel: s.State.ModelTag(),
+			Name: "foo", OfferUUID: "offer-uuid", SourceModel: s.IAASModel.ModelTag(),
 			Endpoints: reducedEps,
 		})
 		c.Assert(err, jc.ErrorIsNil)
@@ -557,7 +557,7 @@ func (s *remoteApplicationSuite) TestAddEndpointsConcurrentConflictingOneAdded(c
 		{Name: "ep2", Role: charm.RoleProvider, Scope: charm.ScopeGlobal, Limit: 1},
 	}
 	foo, err := s.State.AddRemoteApplication(state.AddRemoteApplicationParams{
-		Name: "foo", OfferUUID: "offer-uuid", SourceModel: s.State.ModelTag(),
+		Name: "foo", OfferUUID: "offer-uuid", SourceModel: s.IAASModel.ModelTag(),
 		Endpoints: origEps,
 	})
 	c.Assert(err, jc.ErrorIsNil)
@@ -587,7 +587,7 @@ func (s *remoteApplicationSuite) TestAddEndpointsConcurrentDifferentOneAdded(c *
 		{Name: "ep2", Role: charm.RoleProvider, Scope: charm.ScopeGlobal, Limit: 1},
 	}
 	foo, err := s.State.AddRemoteApplication(state.AddRemoteApplicationParams{
-		Name: "foo", OfferUUID: "offer-uuid", SourceModel: s.State.ModelTag(),
+		Name: "foo", OfferUUID: "offer-uuid", SourceModel: s.IAASModel.ModelTag(),
 		Endpoints: origEps,
 	})
 	c.Assert(err, jc.ErrorIsNil)
@@ -855,7 +855,7 @@ func (s *remoteApplicationSuite) TestAllRemoteApplications(c *gc.C) {
 	c.Assert(len(applications), gc.Equals, 1)
 
 	_, err = s.State.AddRemoteApplication(state.AddRemoteApplicationParams{
-		Name: "another", SourceModel: s.State.ModelTag()})
+		Name: "another", SourceModel: s.IAASModel.ModelTag()})
 	c.Assert(err, jc.ErrorIsNil)
 	applications, err = s.State.AllRemoteApplications()
 	c.Assert(err, jc.ErrorIsNil)
@@ -878,7 +878,7 @@ func (s *remoteApplicationSuite) TestAddApplicationModelDying(c *gc.C) {
 	err = model.Destroy(state.DestroyModelParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	_, err = s.State.AddRemoteApplication(state.AddRemoteApplicationParams{
-		Name: "s1", SourceModel: s.State.ModelTag()})
+		Name: "s1", SourceModel: s.IAASModel.ModelTag()})
 	c.Assert(err, gc.ErrorMatches, `cannot add remote application "s1": model is no longer alive`)
 }
 
@@ -887,7 +887,7 @@ func (s *remoteApplicationSuite) TestAddApplicationSameLocalExists(c *gc.C) {
 	_, err := s.State.AddApplication(state.AddApplicationArgs{Name: "s1", Charm: charm})
 	c.Assert(err, jc.ErrorIsNil)
 	_, err = s.State.AddRemoteApplication(state.AddRemoteApplicationParams{
-		Name: "s1", SourceModel: s.State.ModelTag()})
+		Name: "s1", SourceModel: s.IAASModel.ModelTag()})
 	c.Assert(err, gc.ErrorMatches, `cannot add remote application "s1": local application with same name already exists`)
 }
 
@@ -901,16 +901,16 @@ func (s *remoteApplicationSuite) TestAddApplicationLocalAddedAfterInitial(c *gc.
 		c.Assert(err, jc.ErrorIsNil)
 	}).Check()
 	_, err := s.State.AddRemoteApplication(state.AddRemoteApplicationParams{
-		Name: "s1", SourceModel: s.State.ModelTag()})
+		Name: "s1", SourceModel: s.IAASModel.ModelTag()})
 	c.Assert(err, gc.ErrorMatches, `cannot add remote application "s1": local application with same name already exists`)
 }
 
 func (s *remoteApplicationSuite) TestAddApplicationSameRemoteExists(c *gc.C) {
 	_, err := s.State.AddRemoteApplication(state.AddRemoteApplicationParams{
-		Name: "s1", SourceModel: s.State.ModelTag()})
+		Name: "s1", SourceModel: s.IAASModel.ModelTag()})
 	c.Assert(err, jc.ErrorIsNil)
 	_, err = s.State.AddRemoteApplication(state.AddRemoteApplicationParams{
-		Name: "s1", SourceModel: s.State.ModelTag()})
+		Name: "s1", SourceModel: s.IAASModel.ModelTag()})
 	c.Assert(err, gc.ErrorMatches, `cannot add remote application "s1": remote application already exists`)
 }
 
@@ -920,11 +920,11 @@ func (s *remoteApplicationSuite) TestAddApplicationRemoteAddedAfterInitial(c *gc
 	// before the transaction is run.
 	defer state.SetBeforeHooks(c, s.State, func() {
 		_, err := s.State.AddRemoteApplication(state.AddRemoteApplicationParams{
-			Name: "s1", SourceModel: s.State.ModelTag()})
+			Name: "s1", SourceModel: s.IAASModel.ModelTag()})
 		c.Assert(err, jc.ErrorIsNil)
 	}).Check()
 	_, err := s.State.AddRemoteApplication(state.AddRemoteApplicationParams{
-		Name: "s1", SourceModel: s.State.ModelTag()})
+		Name: "s1", SourceModel: s.IAASModel.ModelTag()})
 	c.Assert(err, gc.ErrorMatches, `cannot add remote application "s1": remote application already exists`)
 }
 
@@ -939,7 +939,7 @@ func (s *remoteApplicationSuite) TestAddApplicationModelDiesAfterInitial(c *gc.C
 		c.Assert(err, jc.ErrorIsNil)
 	}).Check()
 	_, err := s.State.AddRemoteApplication(state.AddRemoteApplicationParams{
-		Name: "s1", SourceModel: s.State.ModelTag()})
+		Name: "s1", SourceModel: s.IAASModel.ModelTag()})
 	c.Assert(err, gc.ErrorMatches, `cannot add remote application "s1": model "testenv" is no longer alive`)
 }
 
@@ -951,7 +951,7 @@ func (s *remoteApplicationSuite) TestWatchRemoteApplications(c *gc.C) {
 	wc.AssertNoChange()
 
 	db2, err := s.State.AddRemoteApplication(state.AddRemoteApplicationParams{
-		Name: "db2", SourceModel: s.State.ModelTag()})
+		Name: "db2", SourceModel: s.IAASModel.ModelTag()})
 	c.Assert(err, jc.ErrorIsNil)
 	wc.AssertChangeInSingleEvent("db2")
 	wc.AssertNoChange()

--- a/state/remoteentities_test.go
+++ b/state/remoteentities_test.go
@@ -30,7 +30,7 @@ func (s *RemoteEntitiesSuite) TestExportLocalEntity(c *gc.C) {
 	entity := names.NewApplicationTag("mysql")
 	token := s.assertExportLocalEntity(c, entity)
 
-	anotherState, err := s.State.ForModel(s.State.ModelTag())
+	anotherState, err := s.State.ForModel(s.IAASModel.ModelTag())
 	c.Assert(err, jc.ErrorIsNil)
 	defer anotherState.Close()
 
@@ -53,7 +53,7 @@ func (s *RemoteEntitiesSuite) TestGetRemoteEntity(c *gc.C) {
 	entity := names.NewApplicationTag("mysql")
 	token := s.assertExportLocalEntity(c, entity)
 
-	anotherState, err := s.State.ForModel(s.State.ModelTag())
+	anotherState, err := s.State.ForModel(s.IAASModel.ModelTag())
 	c.Assert(err, jc.ErrorIsNil)
 	defer anotherState.Close()
 
@@ -73,7 +73,7 @@ func (s *RemoteEntitiesSuite) TestMacaroon(c *gc.C) {
 	err = re.SaveMacaroon(entity, mac)
 	c.Assert(err, jc.ErrorIsNil)
 
-	anotherState, err := s.State.ForModel(s.State.ModelTag())
+	anotherState, err := s.State.ForModel(s.IAASModel.ModelTag())
 	c.Assert(err, jc.ErrorIsNil)
 	defer anotherState.Close()
 
@@ -87,7 +87,7 @@ func (s *RemoteEntitiesSuite) TestRemoveRemoteEntity(c *gc.C) {
 	entity := names.NewApplicationTag("mysql")
 	token := s.assertExportLocalEntity(c, entity)
 
-	anotherState, err := s.State.ForModel(s.State.ModelTag())
+	anotherState, err := s.State.ForModel(s.IAASModel.ModelTag())
 	c.Assert(err, jc.ErrorIsNil)
 	defer anotherState.Close()
 
@@ -106,7 +106,7 @@ func (s *RemoteEntitiesSuite) TestImportRemoteEntity(c *gc.C) {
 	err := re.ImportRemoteEntity(entity, token)
 	c.Assert(err, jc.ErrorIsNil)
 
-	anotherState, err := s.State.ForModel(s.State.ModelTag())
+	anotherState, err := s.State.ForModel(s.IAASModel.ModelTag())
 	c.Assert(err, jc.ErrorIsNil)
 	defer anotherState.Close()
 
@@ -127,7 +127,7 @@ func (s *RemoteEntitiesSuite) TestImportRemoteEntityOverwrites(c *gc.C) {
 	err = re.ImportRemoteEntity(entity, anotherToken)
 	c.Assert(err, jc.ErrorIsNil)
 
-	anotherState, err := s.State.ForModel(s.State.ModelTag())
+	anotherState, err := s.State.ForModel(s.IAASModel.ModelTag())
 	c.Assert(err, jc.ErrorIsNil)
 	defer anotherState.Close()
 

--- a/state/state.go
+++ b/state/state.go
@@ -468,12 +468,6 @@ func (st *State) getSingularLeaseClient() (lease.Client, error) {
 	return client, nil
 }
 
-// ModelTag() returns the model tag for the model controlled by
-// this state instance.
-func (st *State) ModelTag() names.ModelTag {
-	return st.modelTag
-}
-
 // ModelUUID returns the model UUID for the model
 // controlled by this state instance.
 func (st *State) ModelUUID() string {
@@ -877,13 +871,13 @@ func (st *State) FindEntity(tag names.Tag) (Entity, error) {
 	case names.ApplicationTag:
 		return st.Application(id)
 	case names.ModelTag:
-		env, err := st.Model()
+		model, err := st.Model()
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
 		// Return an invalid entity error if the requested model is not
 		// the current one.
-		if id != env.UUID() {
+		if id != model.UUID() {
 			if utils.IsValidUUIDString(id) {
 				return nil, errors.NotFoundf("model %q", id)
 			}
@@ -891,23 +885,23 @@ func (st *State) FindEntity(tag names.Tag) (Entity, error) {
 			// We should not accept model tags that do not match the
 			// model's UUID. We accept anything for now, to cater
 			// both for past usage, and for potentially supporting aliases.
-			logger.Warningf("model-tag does not match current model UUID: %q != %q", id, env.UUID())
-			conf, err := st.ModelConfig()
+			logger.Warningf("model-tag does not match current model UUID: %q != %q", id, model.UUID())
+			conf, err := model.ModelConfig()
 			if err != nil {
 				logger.Warningf("ModelConfig failed: %v", err)
 			} else if id != conf.Name() {
 				logger.Warningf("model-tag does not match current model name: %q != %q", id, conf.Name())
 			}
 		}
-		return env, nil
+		return model, nil
 	case names.RelationTag:
 		return st.KeyRelation(id)
 	case names.ActionTag:
-		env, err := st.Model()
+		model, err := st.Model()
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
-		return env.ActionByTag(tag)
+		return model.ActionByTag(tag)
 	case names.CharmTag:
 		if url, err := charm.ParseURL(id); err != nil {
 			logger.Warningf("Parsing charm URL %q failed: %v", id, err)

--- a/state/stateenvirons/config_test.go
+++ b/state/stateenvirons/config_test.go
@@ -32,7 +32,7 @@ func (s *environSuite) TestGetNewEnvironFunc(c *gc.C) {
 	stateenvirons.GetNewEnvironFunc(newEnviron)(s.State)
 	c.Assert(calls, gc.Equals, 1)
 
-	cfg, err := s.State.ModelConfig()
+	cfg, err := s.IAASModel.ModelConfig()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(callArgs.Config, jc.DeepEquals, cfg)
 }
@@ -52,8 +52,11 @@ func (s *environSuite) TestCloudSpec(c *gc.C) {
 	})
 	defer st.Close()
 
+	m, err := st.Model()
+	c.Assert(err, jc.ErrorIsNil)
+
 	emptyCredential.Label = "empty-credential"
-	cloudSpec, err := stateenvirons.EnvironConfigGetter{st}.CloudSpec()
+	cloudSpec, err := stateenvirons.EnvironConfigGetter{st, m}.CloudSpec()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cloudSpec, jc.DeepEquals, environs.CloudSpec{
 		Type:             "dummy",

--- a/state/storage.go
+++ b/state/storage.go
@@ -1755,7 +1755,7 @@ var ErrNoDefaultStoragePool = fmt.Errorf("no storage pool specifed and no defaul
 // addDefaultStorageConstraints fills in default constraint values, replacing any empty/missing values
 // in the specified constraints.
 func addDefaultStorageConstraints(im *IAASModel, allCons map[string]StorageConstraints, charmMeta *charm.Meta) error {
-	conf, err := im.st.ModelConfig()
+	conf, err := im.ModelConfig()
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -1924,7 +1924,7 @@ func (im *IAASModel) addStorageForUnitOps(
 
 		// Populate missing configuration parameters with defaults.
 		if cons.Pool == "" || cons.Size == 0 {
-			modelConfig, err := im.st.ModelConfig()
+			modelConfig, err := im.ModelConfig()
 			if err != nil {
 				return nil, errors.Trace(err)
 			}

--- a/state/unit.go
+++ b/state/unit.go
@@ -1230,9 +1230,13 @@ func (u *Unit) WaitAgentPresence(timeout time.Duration) (err error) {
 func (u *Unit) SetAgentPresence() (*presence.Pinger, error) {
 	presenceCollection := u.st.getPresenceCollection()
 	recorder := u.st.getPingBatcher()
-	p := presence.NewPinger(presenceCollection, u.st.ModelTag(), u.globalAgentKey(),
+	model, err := u.st.Model()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	p := presence.NewPinger(presenceCollection, model.ModelTag(), u.globalAgentKey(),
 		func() presence.PingRecorder { return u.st.getPingBatcher() })
-	err := p.Start()
+	err = p.Start()
 	if err != nil {
 		return nil, err
 	}

--- a/state/upgrades_test.go
+++ b/state/upgrades_test.go
@@ -1034,12 +1034,16 @@ func (s *upgradesSuite) TestAddUpdateStatusHookSettings(c *gc.C) {
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
-	cfg1, err := m1.ModelConfig()
+	model1, err := m1.Model()
+	c.Assert(err, jc.ErrorIsNil)
+	cfg1, err := model1.ModelConfig()
 	c.Assert(err, jc.ErrorIsNil)
 	expected1 := cfg1.AllAttrs()
 	expected1["resource-tags"] = ""
 
-	cfg2, err := m2.ModelConfig()
+	model2, err := m2.Model()
+	c.Assert(err, jc.ErrorIsNil)
+	cfg2, err := model2.ModelConfig()
 	c.Assert(err, jc.ErrorIsNil)
 	expected2 := cfg2.AllAttrs()
 	expected2["update-status-hook-interval"] = "5m"
@@ -1814,12 +1818,16 @@ func (s *upgradesSuite) checkAddPruneSettings(c *gc.C, ageProp, sizeProp, defaul
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
-	cfg1, err := m1.ModelConfig()
+	model1, err := m1.Model()
+	c.Assert(err, jc.ErrorIsNil)
+	cfg1, err := model1.ModelConfig()
 	c.Assert(err, jc.ErrorIsNil)
 	expected1 := cfg1.AllAttrs()
 	expected1["resource-tags"] = ""
 
-	cfg2, err := m2.ModelConfig()
+	model2, err := m2.Model()
+	c.Assert(err, jc.ErrorIsNil)
+	cfg2, err := model2.ModelConfig()
 	c.Assert(err, jc.ErrorIsNil)
 	expected2 := cfg2.AllAttrs()
 	expected2[ageProp] = defaultAge

--- a/state/user_test.go
+++ b/state/user_test.go
@@ -234,10 +234,10 @@ func (s *UserSuite) TestRemoveUserRemovesUserAccess(c *gc.C) {
 	// Assert user exists and can authenticate.
 	c.Assert(user.PasswordValid("so sekrit"), jc.IsTrue)
 
-	s.State.SetUserAccess(user.UserTag(), s.State.ModelTag(), permission.AdminAccess)
+	s.State.SetUserAccess(user.UserTag(), s.IAASModel.ModelTag(), permission.AdminAccess)
 	s.State.SetUserAccess(user.UserTag(), s.State.ControllerTag(), permission.SuperuserAccess)
 
-	uam, err := s.State.UserAccess(user.UserTag(), s.State.ModelTag())
+	uam, err := s.State.UserAccess(user.UserTag(), s.IAASModel.ModelTag())
 	c.Check(err, jc.ErrorIsNil)
 	c.Check(uam.Access, gc.Equals, permission.AdminAccess)
 
@@ -254,7 +254,7 @@ func (s *UserSuite) TestRemoveUserRemovesUserAccess(c *gc.C) {
 	err = s.State.RemoveUser(user.UserTag())
 	c.Check(err, jc.ErrorIsNil)
 
-	uam, err = s.State.UserAccess(user.UserTag(), s.State.ModelTag())
+	uam, err = s.State.UserAccess(user.UserTag(), s.IAASModel.ModelTag())
 	c.Check(err, gc.ErrorMatches, fmt.Sprintf("user %q is permanently deleted", user.UserTag().Name()))
 
 	uac, err = s.State.UserAccess(user.UserTag(), s.State.ControllerTag())

--- a/state/volume.go
+++ b/state/volume.go
@@ -866,7 +866,7 @@ func (im *IAASModel) newVolumeOps(doc volumeDoc, status statusDoc) []txn.Op {
 
 func (im *IAASModel) volumeParamsWithDefaults(params VolumeParams, machineId string) (VolumeParams, error) {
 	if params.Pool == "" {
-		modelConfig, err := im.st.ModelConfig()
+		modelConfig, err := im.ModelConfig()
 		if err != nil {
 			return VolumeParams{}, errors.Trace(err)
 		}

--- a/state/watcher.go
+++ b/state/watcher.go
@@ -1687,8 +1687,8 @@ func (st *State) WatchRestoreInfoChanges() NotifyWatcher {
 
 // WatchForModelConfigChanges returns a NotifyWatcher waiting for the Model
 // Config to change.
-func (st *State) WatchForModelConfigChanges() NotifyWatcher {
-	return newEntityWatcher(st, settingsC, st.docID(modelGlobalKey))
+func (model *Model) WatchForModelConfigChanges() NotifyWatcher {
+	return newEntityWatcher(model.st, settingsC, model.st.docID(modelGlobalKey))
 }
 
 // WatchModelEntityReferences returns a NotifyWatcher waiting for the Model

--- a/state/workers.go
+++ b/state/workers.go
@@ -30,6 +30,7 @@ const (
 // workers when they fail.
 type workers struct {
 	state *State
+	//	model *Model
 	*worker.Runner
 }
 
@@ -50,7 +51,7 @@ func newWorkers(st *State) (*workers, error) {
 		return watcher.New(st.getTxnLogCollection()), nil
 	})
 	ws.StartWorker(presenceWorker, func() (worker.Worker, error) {
-		return presence.NewWatcher(st.getPresenceCollection(), st.ModelTag()), nil
+		return presence.NewWatcher(st.getPresenceCollection(), st.modelTag), nil
 	})
 	ws.StartWorker(pingBatcherWorker, func() (worker.Worker, error) {
 		return presence.NewPingBatcher(st.getPresenceCollection(), pingFlushInterval), nil

--- a/testing/factory/factory.go
+++ b/testing/factory/factory.go
@@ -21,6 +21,7 @@ import (
 	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/constraints"
+	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/permission"
@@ -614,8 +615,9 @@ func (factory *Factory) MakeRelation(c *gc.C, params *RelationParams) *state.Rel
 // filling in sane defaults for missing values. If params is nil,
 // defaults are used for all values.
 //
-// By default the new model shares the same owner as the calling
-// Factory's model.
+// By default the new model shares the same owner as the calling Factory's
+// model. TODO(ericclaudejones) MakeModel should return the model itself rather
+// than the state.
 func (factory *Factory) MakeModel(c *gc.C, params *ModelParams) *state.State {
 	if params == nil {
 		params = new(ModelParams)
@@ -642,8 +644,7 @@ func (factory *Factory) MakeModel(c *gc.C, params *ModelParams) *state.State {
 	}
 	// It only makes sense to make an model with the same provider
 	// as the initial model, or things will break elsewhere.
-	currentCfg, err := factory.st.ModelConfig()
-	c.Assert(err, jc.ErrorIsNil)
+	currentCfg := factory.currentCfg(c)
 
 	uuid, err := utils.NewUUID()
 	c.Assert(err, jc.ErrorIsNil)
@@ -678,4 +679,14 @@ func (factory *Factory) MakeSpace(c *gc.C, params *SpaceParams) *state.Space {
 	space, err := factory.st.AddSpace(params.Name, params.ProviderID, params.Subnets, params.IsPublic)
 	c.Assert(err, jc.ErrorIsNil)
 	return space
+}
+
+func (factory *Factory) currentCfg(c *gc.C) *config.Config {
+	model, err := factory.st.Model()
+	c.Assert(err, jc.ErrorIsNil)
+
+	currentCfg, err := model.ModelConfig()
+	c.Assert(err, jc.ErrorIsNil)
+
+	return currentCfg
 }

--- a/testing/factory/factory_test.go
+++ b/testing/factory/factory_test.go
@@ -96,7 +96,7 @@ func (s *factorySuite) TestMakeUserParams(c *gc.C) {
 	c.Assert(err, jc.Satisfies, state.IsNeverLoggedInError)
 	c.Assert(savedLastLogin, gc.Equals, lastLogin)
 
-	_, err = s.State.UserAccess(user.UserTag(), s.State.ModelTag())
+	_, err = s.State.UserAccess(user.UserTag(), s.IAASModel.ModelTag())
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -131,7 +131,7 @@ func (s *factorySuite) TestMakeUserNoModelUser(c *gc.C) {
 
 	_, err := s.State.User(user.UserTag())
 	c.Assert(err, jc.ErrorIsNil)
-	_, err = s.State.UserAccess(user.UserTag(), s.State.ModelTag())
+	_, err = s.State.UserAccess(user.UserTag(), s.IAASModel.ModelTag())
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 }
 
@@ -172,7 +172,7 @@ func (s *factorySuite) TestMakeModelUserParams(c *gc.C) {
 		DisplayName: "Foo Bar",
 	})
 
-	saved, err := s.State.UserAccess(modelUser.UserTag, s.State.ModelTag())
+	saved, err := s.State.UserAccess(modelUser.UserTag, s.IAASModel.ModelTag())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(saved.Object.Id(), gc.Equals, modelUser.Object.Id())
 	c.Assert(saved.UserName, gc.Equals, "foobar")
@@ -189,7 +189,7 @@ func (s *factorySuite) TestMakeModelUserInvalidCreatedBy(c *gc.C) {
 	}
 
 	c.Assert(invalidFunc, gc.PanicMatches, `interface conversion: .*`)
-	saved, err := s.State.UserAccess(names.NewLocalUserTag("bob"), s.State.ModelTag())
+	saved, err := s.State.UserAccess(names.NewLocalUserTag("bob"), s.IAASModel.ModelTag())
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 	c.Assert(saved, gc.DeepEquals, permission.UserAccess{})
 }
@@ -202,7 +202,7 @@ func (s *factorySuite) TestMakeModelUserNonLocalUser(c *gc.C) {
 		CreatedBy:   creator.UserTag(),
 	})
 
-	saved, err := s.State.UserAccess(modelUser.UserTag, s.State.ModelTag())
+	saved, err := s.State.UserAccess(modelUser.UserTag, s.IAASModel.ModelTag())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(saved.Object.Id(), gc.Equals, modelUser.Object.Id())
 	c.Assert(saved.UserName, gc.Equals, "foobar@ubuntuone")
@@ -509,7 +509,10 @@ func (s *factorySuite) TestMakeModelNil(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(env.Owner(), gc.Equals, origEnv.Owner())
 
-	cfg, err := st.ModelConfig()
+	m, err := st.Model()
+	c.Assert(err, jc.ErrorIsNil)
+
+	cfg, err := m.ModelConfig()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cfg.AllAttrs()["default-series"], gc.Equals, "xenial")
 }
@@ -533,7 +536,9 @@ func (s *factorySuite) TestMakeModel(c *gc.C) {
 	c.Assert(env.UUID() == s.State.ModelUUID(), jc.IsFalse)
 	c.Assert(env.Owner(), gc.Equals, owner.UserTag())
 
-	cfg, err := st.ModelConfig()
+	m, err := st.Model()
+	c.Assert(err, jc.ErrorIsNil)
+	cfg, err := m.ModelConfig()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cfg.AllAttrs()["default-series"], gc.Equals, "precise")
 }

--- a/worker/provisioner/provisioner_test.go
+++ b/worker/provisioner/provisioner_test.go
@@ -137,7 +137,7 @@ func (s *CommonProvisionerSuite) SetUpTest(c *gc.C) {
 	dummy.Listen(op)
 	s.op = op
 
-	cfg, err := s.State.ModelConfig()
+	cfg, err := s.IAASModel.ModelConfig()
 	c.Assert(err, jc.ErrorIsNil)
 	s.cfg = cfg
 

--- a/worker/upgradesteps/worker_test.go
+++ b/worker/upgradesteps/worker_test.go
@@ -421,7 +421,7 @@ func (s *UpgradeSuite) openStateForUpgrade() (*state.State, error) {
 	st, err := state.Open(state.OpenParams{
 		Clock:              clock.WallClock,
 		ControllerTag:      s.State.ControllerTag(),
-		ControllerModelTag: s.State.ModelTag(),
+		ControllerModelTag: s.IAASModel.ModelTag(),
 		MongoInfo:          mongoInfo,
 		MongoDialOpts:      mongotest.DialOpts(),
 		NewPolicy:          newPolicy,
@@ -557,7 +557,7 @@ func (s *UpgradeSuite) makeExpectedUpgradeLogs(retryCount int, target string, ex
 }
 
 func (s *UpgradeSuite) assertEnvironAgentVersion(c *gc.C, expected version.Number) {
-	envConfig, err := s.State.ModelConfig()
+	envConfig, err := s.IAASModel.ModelConfig()
 	c.Assert(err, jc.ErrorIsNil)
 	agentVersion, ok := envConfig.AgentVersion()
 	c.Assert(ok, jc.IsTrue)


### PR DESCRIPTION
**Why is this change needed?**

To separate model configuration from state.State to aid in CAAS development.

**How do we verify that the change works?**

N/A

**Does it affect current user workflow? CLI? API?**

No

**Bug reference**

N/A
