### PR TITLE
relation status implemented as struct rather than relation field

### DIFF
--- a/api/applicationoffers/client.go
+++ b/api/applicationoffers/client.go
@@ -108,7 +108,9 @@ func convertListResultsToModel(items []params.ApplicationOfferDetails) ([]crossm
 				Username:        oc.Username,
 				Endpoint:        oc.Endpoint,
 				RelationId:      oc.RelationId,
-				Status:          oc.Status,
+				Status:          oc.Status.Status.String(),
+				Message:         oc.Status.Info,
+				Since:           oc.Status.Since,
 				IngressSubnets:  oc.IngressSubnets,
 			})
 		}

--- a/api/applicationoffers/client_test.go
+++ b/api/applicationoffers/client_test.go
@@ -5,6 +5,7 @@ package applicationoffers_test
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
@@ -109,6 +110,7 @@ func (s *crossmodelMockSuite) TestList(c *gc.C) {
 	}
 
 	called := false
+	since := time.Now()
 	apiCaller := basetesting.APICallerFunc(
 		func(objType string,
 			version int,
@@ -145,7 +147,7 @@ func (s *crossmodelMockSuite) TestList(c *gc.C) {
 					CharmURL:         "cs:db2-5",
 					Connections: []params.OfferConnection{
 						{SourceModelTag: testing.ModelTag.String(), Username: "fred", RelationId: 3,
-							Endpoint: "db", Status: "active",
+							Endpoint: "db", Status: params.EntityStatus{Status: "joined", Info: "message", Since: &since},
 							IngressSubnets: []string{"10.0.0.0/8"},
 						},
 					},
@@ -167,7 +169,7 @@ func (s *crossmodelMockSuite) TestList(c *gc.C) {
 			CharmURL:        "cs:db2-5",
 			Connections: []jujucrossmodel.OfferConnection{
 				{SourceModelUUID: testing.ModelTag.Id(), Username: "fred", RelationId: 3,
-					Endpoint: "db", Status: "active",
+					Endpoint: "db", Status: "joined", Message: "message", Since: &since,
 					IngressSubnets: []string{"10.0.0.0/8"},
 				},
 			},

--- a/api/uniter/relation_test.go
+++ b/api/uniter/relation_test.go
@@ -65,7 +65,7 @@ func (s *relationSuite) TestRefresh(c *gc.C) {
 	err = s.stateRelation.Destroy()
 	c.Assert(err, jc.ErrorIsNil)
 	// Update status as well.
-	err = s.stateRelation.SetStatus(status.Suspended)
+	err = s.stateRelation.SetStatus(status.StatusInfo{Status: status.Suspended})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(s.apiRelation.Life(), gc.Equals, params.Alive)
 	c.Assert(s.apiRelation.Status(), gc.Equals, params.Joined)

--- a/api/uniter/unit.go
+++ b/api/uniter/unit.go
@@ -644,13 +644,14 @@ func (u *Unit) RequestReboot() error {
 	return result.OneError()
 }
 
-// JoinedRelations returns the tags of the relations the unit has joined.
-func (u *Unit) JoinedRelations() ([]names.RelationTag, error) {
+// RelationsInScopeOrSuspended returns the tags of the relations the unit has joined
+// and entered scope, or the relation is suspended.
+func (u *Unit) RelationsInScopeOrSuspended() ([]names.RelationTag, error) {
 	var results params.StringsResults
 	args := params.Entities{
 		Entities: []params.Entity{{Tag: u.tag.String()}},
 	}
-	err := u.st.facade.FacadeCall("JoinedRelations", args, &results)
+	err := u.st.facade.FacadeCall("RelationsInScopeOrSuspended", args, &results)
 	if err != nil {
 		return nil, err
 	}

--- a/api/uniter/unit.go
+++ b/api/uniter/unit.go
@@ -11,6 +11,7 @@ import (
 	"github.com/juju/juju/api/common"
 	apiwatcher "github.com/juju/juju/api/watcher"
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/core/relation"
 	"github.com/juju/juju/status"
 	"github.com/juju/juju/watcher"
 )
@@ -644,14 +645,26 @@ func (u *Unit) RequestReboot() error {
 	return result.OneError()
 }
 
-// RelationsInScopeOrSuspended returns the tags of the relations the unit has joined
+// RelationStatus holds information about a relation's scope and status.
+type RelationStatus struct {
+	// Tag is the relation tag.
+	Tag names.RelationTag
+
+	// Status is the status of the relation.
+	Status relation.Status
+
+	// InScope is true if the relation unit is in scope.
+	InScope bool
+}
+
+// RelationsInScope returns the tags of the relations the unit has joined
 // and entered scope, or the relation is suspended.
-func (u *Unit) RelationsInScopeOrSuspended() ([]names.RelationTag, error) {
-	var results params.StringsResults
+func (u *Unit) RelationsStatus() ([]RelationStatus, error) {
 	args := params.Entities{
 		Entities: []params.Entity{{Tag: u.tag.String()}},
 	}
-	err := u.st.facade.FacadeCall("RelationsInScopeOrSuspended", args, &results)
+	var results params.RelationUnitStatusResults
+	err := u.st.facade.FacadeCall("RelationsStatus", args, &results)
 	if err != nil {
 		return nil, err
 	}
@@ -662,15 +675,19 @@ func (u *Unit) RelationsInScopeOrSuspended() ([]names.RelationTag, error) {
 	if result.Error != nil {
 		return nil, result.Error
 	}
-	var relTags []names.RelationTag
-	for _, rel := range result.Result {
-		tag, err := names.ParseRelationTag(rel)
+	var statusResult []RelationStatus
+	for _, result := range result.RelationResults {
+		tag, err := names.ParseRelationTag(result.RelationTag)
 		if err != nil {
 			return nil, err
 		}
-		relTags = append(relTags, tag)
+		statusResult = append(statusResult, RelationStatus{
+			Tag:     tag,
+			InScope: result.InScope,
+			Status:  relation.Status(result.Status),
+		})
 	}
-	return relTags, nil
+	return statusResult, nil
 }
 
 // MeterStatus returns the meter status of the unit.

--- a/api/uniter/unit_test.go
+++ b/api/uniter/unit_test.go
@@ -658,22 +658,22 @@ func (s *unitSuite) TestApplicationNameAndTag(c *gc.C) {
 	c.Assert(s.apiUnit.ApplicationTag(), gc.Equals, s.wordpressApplication.Tag())
 }
 
-func (s *unitSuite) TestJoinedRelations(c *gc.C) {
-	joinedRelations, err := s.apiUnit.JoinedRelations()
+func (s *unitSuite) TestRelationsInScopeOrSuspended(c *gc.C) {
+	activeRelations, err := s.apiUnit.RelationsInScopeOrSuspended()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(joinedRelations, gc.HasLen, 0)
+	c.Assert(activeRelations, gc.HasLen, 0)
 
 	rel1, _, _ := s.addRelatedApplication(c, "wordpress", "monitoring", s.wordpressUnit)
-	joinedRelations, err = s.apiUnit.JoinedRelations()
+	activeRelations, err = s.apiUnit.RelationsInScopeOrSuspended()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(joinedRelations, gc.DeepEquals, []names.RelationTag{
+	c.Assert(activeRelations, gc.DeepEquals, []names.RelationTag{
 		rel1.Tag().(names.RelationTag),
 	})
 
-	rel2, _, _ := s.addRelatedApplication(c, "wordpress", "logging", s.wordpressUnit)
-	joinedRelations, err = s.apiUnit.JoinedRelations()
+	rel2 := s.addRelationSuspended(c, "wordpress", "logging", s.wordpressUnit)
+	activeRelations, err = s.apiUnit.RelationsInScopeOrSuspended()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(joinedRelations, jc.SameContents, []names.RelationTag{
+	c.Assert(activeRelations, jc.SameContents, []names.RelationTag{
 		rel1.Tag().(names.RelationTag),
 		rel2.Tag().(names.RelationTag),
 	})

--- a/api/uniter/uniter_test.go
+++ b/api/uniter/uniter_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/juju/juju/api/uniter"
 	"github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/state"
+	"github.com/juju/juju/status"
 )
 
 // NOTE: This suite is intended for embedding into other suites,
@@ -112,6 +113,14 @@ func (s *uniterSuite) addRelatedApplication(c *gc.C, firstApp, relatedApp string
 	relatedUnit, err := s.State.Unit(relatedApp + "/0")
 	c.Assert(err, jc.ErrorIsNil)
 	return rel, relatedApplication, relatedUnit
+}
+
+func (s *uniterSuite) addRelationSuspended(c *gc.C, firstApp, relatedApp string, unit *state.Unit) *state.Relation {
+	s.AddTestingApplication(c, relatedApp, s.AddTestingCharm(c, relatedApp))
+	rel := s.addRelation(c, firstApp, relatedApp)
+	err := rel.SetStatus(status.StatusInfo{Status: status.Suspended})
+	c.Assert(err, jc.ErrorIsNil)
+	return rel
 }
 
 func (s *uniterSuite) assertInScope(c *gc.C, relUnit *state.RelationUnit, inScope bool) {

--- a/api/watcher/watcher.go
+++ b/api/watcher/watcher.go
@@ -347,9 +347,10 @@ func (w *relationStatusWatcher) loop(initialChanges []params.RelationStatusChang
 		result := make([]watcher.RelationStatusChange, len(changes))
 		for i, ch := range changes {
 			result[i] = watcher.RelationStatusChange{
-				Key:    ch.Key,
-				Life:   life.Value(ch.Life),
-				Status: relation.Status(ch.Status),
+				Key:           ch.Key,
+				Life:          life.Value(ch.Life),
+				Status:        relation.Status(ch.Status),
+				StatusMessage: ch.StatusMessage,
 			}
 		}
 		return result

--- a/api/watcher/watcher_test.go
+++ b/api/watcher/watcher_test.go
@@ -329,6 +329,7 @@ func (s *watcherSuite) assertRelationStatusWatchResult(c *gc.C, rel *state.Relat
 			c.Assert(changes, gc.HasLen, 1)
 			c.Check(changes[0].Life, gc.Equals, life)
 			c.Check(changes[0].Status, gc.Equals, status)
+			c.Check(changes[0].StatusMessage, gc.Equals, "")
 		case <-time.After(coretesting.LongWait):
 			c.Fatalf("watcher didn't emit an event")
 		}

--- a/apiserver/common/crossmodel/crossmodel.go
+++ b/apiserver/common/crossmodel/crossmodel.go
@@ -35,8 +35,16 @@ func PublishRelationChange(backend Backend, relationTag names.Tag, change params
 
 	// Update the relation status if necessary.
 	relStatus := status.Status(change.Status)
-	if rel.Status() != relStatus && relStatus != "" {
-		if err := rel.SetStatus(relStatus); err != nil {
+	currentStatus, err := rel.Status()
+	if err != nil {
+		return errors.Trace(err)
+	}
+	if relStatus != "" && (currentStatus.Status != relStatus ||
+		currentStatus.Message != change.StatusMessage) {
+		if err := rel.SetStatus(status.StatusInfo{
+			Status:  relStatus,
+			Message: change.StatusMessage,
+		}); err != nil {
 			return errors.Trace(err)
 		}
 	}
@@ -213,9 +221,14 @@ func GetRelationStatusChange(st relationGetter, key string) (*params.RelationSta
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
+	relStatus, err := rel.Status()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	return &params.RelationStatusChange{
-		Key:    key,
-		Life:   params.Life(rel.Life().String()),
-		Status: params.RelationStatusValue(rel.Status()),
+		Key:           key,
+		Life:          params.Life(rel.Life().String()),
+		Status:        params.RelationStatusValue(relStatus.Status),
+		StatusMessage: relStatus.Message,
 	}, nil
 }

--- a/apiserver/common/crossmodel/crossmodel.go
+++ b/apiserver/common/crossmodel/crossmodel.go
@@ -35,17 +35,18 @@ func PublishRelationChange(backend Backend, relationTag names.Tag, change params
 
 	// Update the relation status if necessary.
 	relStatus := status.Status(change.Status)
-	currentStatus, err := rel.Status()
-	if err != nil {
-		return errors.Trace(err)
-	}
-	if relStatus != "" && (currentStatus.Status != relStatus ||
-		currentStatus.Message != change.StatusMessage) {
-		if err := rel.SetStatus(status.StatusInfo{
-			Status:  relStatus,
-			Message: change.StatusMessage,
-		}); err != nil {
+	if relStatus != "" {
+		currentStatus, err := rel.Status()
+		if err != nil {
 			return errors.Trace(err)
+		}
+		if currentStatus.Status != relStatus || currentStatus.Message != change.StatusMessage {
+			if err := rel.SetStatus(status.StatusInfo{
+				Status:  relStatus,
+				Message: change.StatusMessage,
+			}); err != nil {
+				return errors.Trace(err)
+			}
 		}
 	}
 

--- a/apiserver/common/crossmodel/interface.go
+++ b/apiserver/common/crossmodel/interface.go
@@ -78,6 +78,8 @@ type Backend interface {
 
 // Relation provides access a relation in global state.
 type Relation interface {
+	status.StatusGetter
+	status.StatusSetter
 	// Destroy ensures that the relation will be removed at some point; if
 	// no units are currently in scope, it will be removed immediately.
 	Destroy() error
@@ -87,12 +89,6 @@ type Relation interface {
 
 	// Life returns the relation's current life state.
 	Life() state.Life
-
-	// Status returns the relation's current status.
-	Status() status.Status
-
-	// SetStatus updates the relation's status.
-	SetStatus(status.Status) error
 
 	// Tag returns the relation's tag.
 	Tag() names.Tag

--- a/apiserver/common/crossmodel/interface.go
+++ b/apiserver/common/crossmodel/interface.go
@@ -110,9 +110,9 @@ type Relation interface {
 	// specified application in the relation.
 	WatchUnits(applicationName string) (state.RelationUnitsWatcher, error)
 
-	// WatchStatus returns a watcher that notifies of changes to the life
+	// WatchLifeStatus returns a watcher that notifies of changes to the life
 	// or status of the relation.
-	WatchStatus() state.StringsWatcher
+	WatchLifeStatus() state.StringsWatcher
 }
 
 // RelationUnit provides access to the settings of a single unit in a relation,

--- a/apiserver/facades/agent/uniter/uniter.go
+++ b/apiserver/facades/agent/uniter/uniter.go
@@ -1015,10 +1015,16 @@ func (u *UniterAPI) RelationById(args params.RelationIds) (params.RelationResult
 	return result, nil
 }
 
-// JoinedRelations returns the tags of all relations for which each supplied unit
-// has entered scope. It should be called RelationsInScope, but it's not convenient
-// to make that change until we have versioned APIs.
-func (u *UniterAPI) JoinedRelations(args params.Entities) (params.StringsResults, error) {
+// RelationsInScopeOrSuspended returns the tags of all relations for which each supplied unit
+// has entered scope.
+// TODO(wallyworld) - this API is replaced by RelationsInScopeOrSuspended
+func (u *UniterAPIV6) JoinedRelations(args params.Entities) (params.StringsResults, error) {
+	return u.UniterAPI.RelationsInScopeOrSuspended(args)
+}
+
+// RelationsInScopeOrSuspended returns the tags of all relations for which each supplied unit
+// has entered scope, or the relation is suspended.
+func (u *UniterAPI) RelationsInScopeOrSuspended(args params.Entities) (params.StringsResults, error) {
 	result := params.StringsResults{
 		Results: make([]params.StringsResult, len(args.Entities)),
 	}
@@ -1040,7 +1046,7 @@ func (u *UniterAPI) JoinedRelations(args params.Entities) (params.StringsResults
 			var unit *state.Unit
 			unit, err = u.getUnit(tag)
 			if err == nil {
-				result.Results[i].Result, err = relationsInScopeTags(unit)
+				result.Results[i].Result, err = relationsInScopeOrSuspendedTags(unit)
 			}
 		}
 		result.Results[i].Error = common.ServerError(err)
@@ -1596,8 +1602,8 @@ func convertRelationSettings(settings map[string]interface{}) (params.Settings, 
 	return result, nil
 }
 
-func relationsInScopeTags(unit *state.Unit) ([]string, error) {
-	relations, err := unit.RelationsInScope()
+func relationsInScopeOrSuspendedTags(unit *state.Unit) ([]string, error) {
+	relations, err := unit.RelationsInScopeOrSuspended()
 	if err != nil {
 		return nil, err
 	}

--- a/apiserver/facades/agent/uniter/uniter.go
+++ b/apiserver/facades/agent/uniter/uniter.go
@@ -1458,11 +1458,15 @@ func (u *UniterAPI) prepareRelationResult(rel *state.Relation, unit *state.Unit)
 	for _, otherEp := range otherEndpoints {
 		otherAppName = otherEp.ApplicationName
 	}
+	relStatus, err := rel.Status()
+	if err != nil {
+		return nothing, err
+	}
 	return params.RelationResult{
 		Id:     rel.Id(),
 		Key:    rel.String(),
 		Life:   params.Life(rel.Life().String()),
-		Status: params.RelationStatusValue(rel.Status()),
+		Status: params.RelationStatusValue(relStatus.Status),
 		Endpoint: multiwatcher.Endpoint{
 			ApplicationName: ep.ApplicationName,
 			Relation:        multiwatcher.NewCharmRelation(ep.Relation),

--- a/apiserver/facades/agent/uniter/uniter.go
+++ b/apiserver/facades/agent/uniter/uniter.go
@@ -1015,16 +1015,10 @@ func (u *UniterAPI) RelationById(args params.RelationIds) (params.RelationResult
 	return result, nil
 }
 
-// RelationsInScopeOrSuspended returns the tags of all relations for which each supplied unit
+// JoinedRelations returns the tags of all relations for which each supplied unit
 // has entered scope.
-// TODO(wallyworld) - this API is replaced by RelationsInScopeOrSuspended
+// TODO(wallyworld) - this API is replaced by RelationsStatus
 func (u *UniterAPIV6) JoinedRelations(args params.Entities) (params.StringsResults, error) {
-	return u.UniterAPI.RelationsInScopeOrSuspended(args)
-}
-
-// RelationsInScopeOrSuspended returns the tags of all relations for which each supplied unit
-// has entered scope, or the relation is suspended.
-func (u *UniterAPI) RelationsInScopeOrSuspended(args params.Entities) (params.StringsResults, error) {
 	result := params.StringsResults{
 		Results: make([]params.StringsResult, len(args.Entities)),
 	}
@@ -1046,7 +1040,77 @@ func (u *UniterAPI) RelationsInScopeOrSuspended(args params.Entities) (params.St
 			var unit *state.Unit
 			unit, err = u.getUnit(tag)
 			if err == nil {
-				result.Results[i].Result, err = relationsInScopeOrSuspendedTags(unit)
+				result.Results[i].Result, err = relationsInScopeTags(unit)
+			}
+		}
+		result.Results[i].Error = common.ServerError(err)
+	}
+	return result, nil
+}
+
+// RelationsStatus returns for each unit the corresponding relation and status information.
+func (u *UniterAPI) RelationsStatus(args params.Entities) (params.RelationUnitStatusResults, error) {
+	result := params.RelationUnitStatusResults{
+		Results: make([]params.RelationUnitStatusResult, len(args.Entities)),
+	}
+	if len(args.Entities) == 0 {
+		return result, nil
+	}
+	canRead, err := u.accessUnit()
+	if err != nil {
+		return params.RelationUnitStatusResults{}, err
+	}
+
+	oneRelationUnitStatus := func(rel *state.Relation, unit *state.Unit) (params.RelationUnitStatus, error) {
+		rus := params.RelationUnitStatus{
+			RelationTag: rel.Tag().String(),
+		}
+		relStatus, err := rel.Status()
+		if err != nil {
+			return params.RelationUnitStatus{}, errors.Trace(err)
+		}
+		rus.Status = params.RelationStatusValue(relStatus.Status)
+		ru, err := rel.Unit(unit)
+		if err != nil {
+			return params.RelationUnitStatus{}, errors.Trace(err)
+		}
+		inScope, err := ru.InScope()
+		if err != nil {
+			return params.RelationUnitStatus{}, errors.Trace(err)
+		}
+		rus.InScope = inScope
+		return rus, nil
+	}
+
+	relationResults := func(unit *state.Unit) ([]params.RelationUnitStatus, error) {
+		var ruStatus []params.RelationUnitStatus
+		app, err := unit.Application()
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		relations, err := app.Relations()
+		for _, rel := range relations {
+			rus, err := oneRelationUnitStatus(rel, unit)
+			if err != nil {
+				return nil, errors.Trace(err)
+			}
+			ruStatus = append(ruStatus, rus)
+		}
+		return ruStatus, nil
+	}
+
+	for i, entity := range args.Entities {
+		tag, err := names.ParseUnitTag(entity.Tag)
+		if err != nil {
+			result.Results[i].Error = common.ServerError(common.ErrPerm)
+			continue
+		}
+		err = common.ErrPerm
+		if canRead(tag) {
+			var unit *state.Unit
+			unit, err = u.getUnit(tag)
+			if err == nil {
+				result.Results[i].RelationResults, err = relationResults(unit)
 			}
 		}
 		result.Results[i].Error = common.ServerError(err)
@@ -1602,8 +1666,8 @@ func convertRelationSettings(settings map[string]interface{}) (params.Settings, 
 	return result, nil
 }
 
-func relationsInScopeOrSuspendedTags(unit *state.Unit) ([]string, error) {
-	relations, err := unit.RelationsInScopeOrSuspended()
+func relationsInScopeTags(unit *state.Unit) ([]string, error) {
+	relations, err := unit.RelationsInScope()
 	if err != nil {
 		return nil, err
 	}

--- a/apiserver/facades/agent/uniter/uniter_test.go
+++ b/apiserver/facades/agent/uniter/uniter_test.go
@@ -1933,7 +1933,7 @@ func (s *uniterSuite) TestLeaveScope(c *gc.C) {
 	c.Assert(readSettings, gc.DeepEquals, settings)
 }
 
-func (s *uniterSuite) TestRelationsInScopeOrSuspended(c *gc.C) {
+func (s *uniterSuite) TestRelationsStatus(c *gc.C) {
 	rel := s.addRelation(c, "wordpress", "mysql")
 	relUnit, err := rel.Unit(s.wordpressUnit)
 	c.Assert(err, jc.ErrorIsNil)
@@ -1955,9 +1955,18 @@ func (s *uniterSuite) TestRelationsInScopeOrSuspended(c *gc.C) {
 			{rel.Tag().String()},
 		},
 	}
-	expect := params.StringsResults{
-		Results: []params.StringsResult{
-			{Result: []string{rel.Tag().String(), rel2.Tag().String()}},
+	expect := params.RelationUnitStatusResults{
+		Results: []params.RelationUnitStatusResult{
+			{RelationResults: []params.RelationUnitStatus{{
+				RelationTag: rel.Tag().String(),
+				InScope:     true,
+				Status:      params.Joined,
+			}, {
+				RelationTag: rel2.Tag().String(),
+				InScope:     false,
+				Status:      params.Suspended,
+			}},
+			},
 			{Error: apiservertesting.ErrUnauthorized},
 			{Error: apiservertesting.ErrUnauthorized},
 			{Error: apiservertesting.ErrUnauthorized},
@@ -1966,7 +1975,7 @@ func (s *uniterSuite) TestRelationsInScopeOrSuspended(c *gc.C) {
 		},
 	}
 	check := func() {
-		result, err := s.uniter.RelationsInScopeOrSuspended(args)
+		result, err := s.uniter.RelationsStatus(args)
 		c.Assert(err, jc.ErrorIsNil)
 		c.Assert(result, gc.DeepEquals, expect)
 	}

--- a/apiserver/facades/agent/uniter/uniter_test.go
+++ b/apiserver/facades/agent/uniter/uniter_test.go
@@ -276,7 +276,9 @@ func (s *uniterSuite) TestLife(c *gc.C) {
 	err = relUnit.EnterScope(nil)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(rel.Life(), gc.Equals, state.Alive)
-	c.Assert(rel.Status(), gc.Equals, status.Joined)
+	relStatus, err := rel.Status()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(relStatus.Status, gc.Equals, status.Joined)
 
 	// Make the wordpressUnit dead.
 	err = s.wordpressUnit.EnsureDead()
@@ -1675,6 +1677,8 @@ func (s *uniterSuite) TestRelation(c *gc.C) {
 	}}
 	result, err := s.uniter.Relation(args)
 	c.Assert(err, jc.ErrorIsNil)
+	relStatus, err := rel.Status()
+	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, params.RelationResults{
 		Results: []params.RelationResult{
 			{Error: apiservertesting.ErrUnauthorized},
@@ -1682,7 +1686,7 @@ func (s *uniterSuite) TestRelation(c *gc.C) {
 				Id:     rel.Id(),
 				Key:    rel.String(),
 				Life:   params.Life(rel.Life().String()),
-				Status: params.RelationStatusValue(rel.Status()),
+				Status: params.RelationStatusValue(relStatus.Status),
 				Endpoint: multiwatcher.Endpoint{
 					ApplicationName: wpEp.ApplicationName,
 					Relation:        multiwatcher.NewCharmRelation(wpEp.Relation),
@@ -1714,6 +1718,8 @@ func (s *uniterSuite) TestRelationById(c *gc.C) {
 	}
 	result, err := s.uniter.RelationById(args)
 	c.Assert(err, jc.ErrorIsNil)
+	relStatus, err := rel.Status()
+	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, params.RelationResults{
 		Results: []params.RelationResult{
 			{Error: apiservertesting.ErrUnauthorized},
@@ -1721,7 +1727,7 @@ func (s *uniterSuite) TestRelationById(c *gc.C) {
 				Id:     rel.Id(),
 				Key:    rel.String(),
 				Life:   params.Life(rel.Life().String()),
-				Status: params.RelationStatusValue(rel.Status()),
+				Status: params.RelationStatusValue(relStatus.Status),
 				Endpoint: multiwatcher.Endpoint{
 					ApplicationName: wpEp.ApplicationName,
 					Relation:        multiwatcher.NewCharmRelation(wpEp.Relation),

--- a/apiserver/facades/client/application/application.go
+++ b/apiserver/facades/client/application/application.go
@@ -1055,7 +1055,10 @@ func (api *API) SetRelationStatus(args params.RelationStatusArgs) (params.ErrorR
 		if err != nil {
 			return errors.Trace(err)
 		}
-		return rel.SetStatus(status.Status(arg.Status))
+		return rel.SetStatus(status.StatusInfo{
+			Status:  status.Status(arg.Status),
+			Message: arg.Message,
+		})
 	}
 	results := make([]params.ErrorResult, len(args.Args))
 	for i, arg := range args.Args {

--- a/apiserver/facades/client/application/application_unit_test.go
+++ b/apiserver/facades/client/application/application_unit_test.go
@@ -411,11 +411,13 @@ func (s *ApplicationSuite) TestSetRelationStatus(c *gc.C) {
 		Args: []params.RelationStatusArg{{
 			RelationId: 123,
 			Status:     params.Joined,
+			Message:    "a message",
 		}},
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results.OneError(), gc.IsNil)
 	c.Assert(s.relation.status, gc.Equals, status.Joined)
+	c.Assert(s.relation.message, gc.Equals, "a message")
 }
 
 func (s *ApplicationSuite) TestSetNonOfferRelationStatus(c *gc.C) {

--- a/apiserver/facades/client/application/backend.go
+++ b/apiserver/facades/client/application/backend.go
@@ -97,9 +97,9 @@ type Machine interface {
 // details on the methods, see the methods on state.Relation with
 // the same names.
 type Relation interface {
+	status.StatusSetter
 	Tag() names.Tag
 	Destroy() error
-	SetStatus(status status.Status) error
 	Endpoint(string) (state.Endpoint, error)
 }
 

--- a/apiserver/facades/client/application/mock_test.go
+++ b/apiserver/facades/client/application/mock_test.go
@@ -516,16 +516,18 @@ type mockRelation struct {
 	application.Relation
 	jtesting.Stub
 
-	tag    names.Tag
-	status status.Status
+	tag     names.Tag
+	status  status.Status
+	message string
 }
 
 func (r *mockRelation) Tag() names.Tag {
 	return r.tag
 }
 
-func (r *mockRelation) SetStatus(status status.Status) error {
-	r.status = status
+func (r *mockRelation) SetStatus(status status.StatusInfo) error {
+	r.status = status.Status
+	r.message = status.Message
 	return nil
 }
 

--- a/apiserver/facades/client/applicationoffers/applicationoffers_test.go
+++ b/apiserver/facades/client/applicationoffers/applicationoffers_test.go
@@ -246,7 +246,7 @@ func (s *applicationOffersSuite) assertList(c *gc.C, expectedErr error) {
 					RelationId:     1,
 					Endpoint:       "db",
 					Username:       "fred",
-					Status:         "joined",
+					Status:         params.EntityStatus{Status: "joined"},
 					IngressSubnets: []string{"192.168.1.0/32", "10.0.0.0/8"},
 				}},
 			},

--- a/apiserver/facades/client/applicationoffers/base.go
+++ b/apiserver/facades/client/applicationoffers/base.go
@@ -162,8 +162,17 @@ func (api *BaseAPI) applicationOffersFromModel(
 				if err != nil {
 					return nil, errors.Trace(err)
 				}
+				relStatus, err := rel.Status()
+				if err != nil {
+					return nil, errors.Trace(err)
+				}
 				connDetails.Endpoint = ep.Name
-				connDetails.Status = string(rel.Status())
+				connDetails.Status = params.EntityStatus{
+					Status: relStatus.Status,
+					Info:   relStatus.Message,
+					Data:   relStatus.Data,
+					Since:  relStatus.Since,
+				}
 				relIngress, err := backend.IngressNetworks(oc.RelationKey())
 				if err != nil {
 					return nil, errors.Trace(err)

--- a/apiserver/facades/client/applicationoffers/mock_test.go
+++ b/apiserver/facades/client/applicationoffers/mock_test.go
@@ -257,8 +257,8 @@ type mockRelation struct {
 	endpoint state.Endpoint
 }
 
-func (m *mockRelation) Status() status.Status {
-	return status.Joined
+func (m *mockRelation) Status() (status.StatusInfo, error) {
+	return status.StatusInfo{Status: status.Joined}, nil
 }
 
 func (m *mockRelation) Endpoint(appName string) (state.Endpoint, error) {

--- a/apiserver/facades/client/client/api_test.go
+++ b/apiserver/facades/client/client/api_test.go
@@ -309,7 +309,11 @@ var scenarioStatus = &params.FullStatus{
 			},
 			Interface: "logging",
 			Scope:     "container",
-			Status:    "joined",
+			Status: params.DetailedStatus{
+				Status: "joined",
+				Info:   "",
+				Data:   make(map[string]interface{}),
+			},
 		},
 	},
 }

--- a/apiserver/facades/client/client/client_test.go
+++ b/apiserver/facades/client/client/client_test.go
@@ -465,6 +465,10 @@ func clearSinceTimes(status *params.FullStatus) {
 		machine.InstanceStatus.Since = nil
 		status.Machines[id] = machine
 	}
+	for id, rel := range status.Relations {
+		rel.Status.Since = nil
+		status.Relations[id] = rel
+	}
 	status.Model.ModelStatus.Since = nil
 }
 

--- a/apiserver/facades/client/client/status.go
+++ b/apiserver/facades/client/client/status.go
@@ -809,8 +809,9 @@ func (context *statusContext) processRelations() []params.RelationStatus {
 			Interface: relationInterface,
 			Scope:     string(scope),
 			Endpoints: eps,
-			Status:    relation.Status().String(),
 		}
+		rStatus, err := relation.Status()
+		populateStatusFromStatusInfoAndErr(&relStatus.Status, rStatus, err)
 		out = append(out, relStatus)
 	}
 	return out

--- a/apiserver/facades/controller/crossmodelrelations/crossmodelrelations.go
+++ b/apiserver/facades/controller/crossmodelrelations/crossmodelrelations.go
@@ -55,7 +55,7 @@ func NewStateCrossModelRelationsAPI(ctx facade.Context) (*CrossModelRelationsAPI
 		firewall.StateShim(ctx.State()),
 		ctx.Resources(), ctx.Auth(), authCtxt.(*commoncrossmodel.AuthContext),
 		firewall.WatchEgressAddressesForRelations,
-		watchRelationStatus,
+		watchRelationLifeStatus,
 	)
 }
 
@@ -345,12 +345,12 @@ func (api *CrossModelRelationsAPI) RelationUnitSettings(relationUnits params.Rem
 	return results, nil
 }
 
-func watchRelationStatus(st CrossModelRelationsState, tag names.RelationTag) (state.StringsWatcher, error) {
+func watchRelationLifeStatus(st CrossModelRelationsState, tag names.RelationTag) (state.StringsWatcher, error) {
 	relation, err := st.KeyRelation(tag.Id())
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	return relation.WatchStatus(), nil
+	return relation.WatchLifeStatus(), nil
 }
 
 // WatchRelationsStatus starts a RelationStatusWatcher for

--- a/apiserver/facades/controller/crossmodelrelations/mock_test.go
+++ b/apiserver/facades/controller/crossmodelrelations/mock_test.go
@@ -295,8 +295,8 @@ func (r *mockRelation) Life() state.Life {
 	return state.Alive
 }
 
-func (r *mockRelation) Status() status.Status {
-	return status.Suspended
+func (r *mockRelation) Status() (status.StatusInfo, error) {
+	return status.StatusInfo{Status: status.Suspended}, nil
 }
 
 func (r *mockRelation) RemoteUnit(unitId string) (commoncrossmodel.RelationUnit, error) {

--- a/apiserver/facades/controller/remoterelations/mock_test.go
+++ b/apiserver/facades/controller/remoterelations/mock_test.go
@@ -253,9 +253,9 @@ func (r *mockRelation) Life() state.Life {
 	return r.life
 }
 
-func (r *mockRelation) Status() status.Status {
+func (r *mockRelation) Status() (status.StatusInfo, error) {
 	r.MethodCall(r, "Status")
-	return status.Joined
+	return status.StatusInfo{Status: status.Joined}, nil
 }
 
 func (r *mockRelation) Unit(unitId string) (common.RelationUnit, error) {

--- a/apiserver/params/crossmodel.go
+++ b/apiserver/params/crossmodel.go
@@ -62,12 +62,12 @@ type ApplicationOfferDetails struct {
 
 // OfferConnection holds details about a connection to an offer.
 type OfferConnection struct {
-	SourceModelTag string   `json:"source-model-tag"`
-	RelationId     int      `json:"relation-id"`
-	Username       string   `json:"username"`
-	Endpoint       string   `json:"endpoint"`
-	Status         string   `json:"status"`
-	IngressSubnets []string `json:"ingress-subnets"`
+	SourceModelTag string       `json:"source-model-tag"`
+	RelationId     int          `json:"relation-id"`
+	Username       string       `json:"username"`
+	Endpoint       string       `json:"endpoint"`
+	Status         EntityStatus `json:"status"`
+	IngressSubnets []string     `json:"ingress-subnets"`
 }
 
 // ListApplicationOffersResults is a result of listing application offers.
@@ -326,6 +326,9 @@ type RemoteRelationChangeEvent struct {
 	// Status is the current status of the relation.
 	Status RelationStatusValue `json:"status"`
 
+	// StatusMessage is the status message for the relation.
+	StatusMessage string `json:"status-message"`
+
 	// ChangedUnits maps unit tokens to relation unit changes.
 	ChangedUnits []RemoteRelationUnitChange `json:"changed-units,omitempty"`
 
@@ -347,6 +350,9 @@ type RelationStatusChange struct {
 
 	// Status is the status of the relation.
 	Status RelationStatusValue `json:"status"`
+
+	// StatusMessage is the status message.
+	StatusMessage string `json:"status-message"`
 }
 
 // RelationStatusWatchResult holds a RelationStatusWatcher id, baseline state

--- a/apiserver/params/internal.go
+++ b/apiserver/params/internal.go
@@ -584,6 +584,27 @@ type RelationUnitsWatchResults struct {
 	Results []RelationUnitsWatchResult `json:"results"`
 }
 
+// RelationUnitStatusResult holds details about scope and status
+// for a relation unit.
+type RelationUnitStatus struct {
+	RelationTag string              `json:"relation-tag"`
+	InScope     bool                `json:"in-scope"`
+	Status      RelationStatusValue `json:"status"`
+}
+
+// RelationUnitStatusResult holds details about scope and status for
+// relation units, and an error.
+type RelationUnitStatusResult struct {
+	RelationResults []RelationUnitStatus `json:"results"`
+	Error           *Error               `json:"error,omitempty"`
+}
+
+// RelationUnitStatusResults holds the results of a
+// uniter RelationStatus API call.
+type RelationUnitStatusResults struct {
+	Results []RelationUnitStatusResult `json:"results"`
+}
+
 // MachineStorageIdsWatchResult holds a MachineStorageIdsWatcher id,
 // changes and an error (if any).
 type MachineStorageIdsWatchResult struct {

--- a/apiserver/params/params.go
+++ b/apiserver/params/params.go
@@ -142,6 +142,7 @@ type RelationStatusArgs struct {
 type RelationStatusArg struct {
 	RelationId int                 `json:"relation-id"`
 	Status     RelationStatusValue `json:"status"`
+	Message    string              `json:"message"`
 }
 
 // AddCharm holds the arguments for making an AddCharm API call.

--- a/apiserver/params/status.go
+++ b/apiserver/params/status.go
@@ -170,7 +170,7 @@ type RelationStatus struct {
 	Interface string           `json:"interface"`
 	Scope     string           `json:"scope"`
 	Endpoints []EndpointStatus `json:"endpoints"`
-	Status    string           `json:"status"`
+	Status    DetailedStatus   `json:"status"`
 }
 
 // EndpointStatus holds status info about a single endpoint.

--- a/cmd/juju/crossmodel/list_test.go
+++ b/cmd/juju/crossmodel/list_test.go
@@ -137,19 +137,19 @@ func (s *ListSuite) TestListTabular(c *gc.C) {
 			Username:        "mary",
 			RelationId:      2,
 			Endpoint:        "db",
-			Status:          "active",
+			Status:          "joined",
 		}, {
 			SourceModelUUID: "model-uuid2",
 			Username:        "fred",
 			RelationId:      1,
 			Endpoint:        "server",
-			Status:          "active",
+			Status:          "joined",
 		}, {
 			SourceModelUUID: "model-uuid3",
 			Username:        "mary",
 			RelationId:      1,
 			Endpoint:        "server",
-			Status:          "active",
+			Status:          "joined",
 			IngressSubnets:  []string{"192.168.0.1/32", "10.0.0.0/8"},
 		},
 	}
@@ -159,7 +159,7 @@ func (s *ListSuite) TestListTabular(c *gc.C) {
 			Username:        "mary",
 			RelationId:      3,
 			Endpoint:        "db",
-			Status:          "active",
+			Status:          "joined",
 		},
 	}
 	// Insert in random order to check sorting.
@@ -178,10 +178,10 @@ func (s *ListSuite) TestListTabular(c *gc.C) {
 		[]string{"--format", "tabular"},
 		`
 Offer      User  Relation id  Status  Endpoint  Interface  Role      Ingress subnets
-zdiff-db2  fred  1            active  server    mysql      provider  
-           mary  1            active  server    mysql      provider  192.168.0.1/32,10.0.0.0/8
-           mary  2            active  db        db2        provider  
-adiff-db2  mary  3            active  db        db2        provider  
+zdiff-db2  fred  1            joined  server    mysql      provider  
+           mary  1            joined  server    mysql      provider  192.168.0.1/32,10.0.0.0/8
+           mary  2            joined  db        db2        provider  
+adiff-db2  mary  3            joined  db        db2        provider  
 
 `[1:],
 		"",
@@ -196,13 +196,14 @@ func (s *ListSuite) TestListYAML(c *gc.C) {
 		{
 			SourceModelUUID: "model-uuid",
 			Username:        "mary",
-			Status:          "active",
+			Status:          "joined",
 			Endpoint:        "db",
 		},
 		{
 			SourceModelUUID: "another-model-uuid",
 			Username:        "fred",
-			Status:          "active",
+			Status:          "error",
+			Message:         "firewall issue",
 			RelationId:      2,
 			Endpoint:        "http",
 			IngressSubnets:  []string{"192.168.0.1/32", "10.0.0.0/8"},
@@ -227,12 +228,15 @@ hosted-db2:
     username: mary
     relation-id: 0
     endpoint: db
-    status: active
+    status:
+      current: joined
   - source-model-uuid: another-model-uuid
     username: fred
     relation-id: 2
     endpoint: http
-    status: active
+    status:
+      current: error
+      message: firewall issue
     ingress-subnets:
     - 192.168.0.1/32
     - 10.0.0.0/8

--- a/cmd/juju/crossmodel/listformatter.go
+++ b/cmd/juju/crossmodel/listformatter.go
@@ -50,7 +50,6 @@ func formatListEndpointsSummary(writer io.Writer, offers offeredApplications) er
 		sort.Strings(endpoints)
 
 		for i, endpointName := range endpoints {
-
 			endpoint := offer.Endpoints[endpointName]
 			if i == 0 {
 				// As there is some information about offer and its endpoints,
@@ -124,7 +123,7 @@ func formatListEndpointsTabular(writer io.Writer, offers offeredApplications) er
 			}
 			connEp := endpoints[conn.Endpoint]
 			w.Print(conn.Username, conn.RelationId)
-			w.PrintColor(RelationStatusColor(relation.Status(conn.Status)), conn.Status)
+			w.PrintColor(RelationStatusColor(relation.Status(conn.Status.Current)), conn.Status.Current)
 			w.Println(connEp.Name, connEp.Interface, connEp.Role, strings.Join(conn.IngressSubnets, ","))
 		}
 	}
@@ -139,13 +138,13 @@ func RelationStatusColor(status relation.Status) *ansiterm.Context {
 		return output.GoodHighlight
 	case relation.Suspended:
 		return output.WarningHighlight
-	case relation.Broken:
+	case relation.Broken, relation.Error:
 		return output.ErrorHighlight
 	}
 	return nil
 }
 
-type byUserRelationId []offerConnectionStatus
+type byUserRelationId []offerConnectionDetails
 
 func (b byUserRelationId) Len() int {
 	return len(b)

--- a/cmd/juju/status/formatted.go
+++ b/cmd/juju/status/formatted.go
@@ -278,4 +278,5 @@ type relationStatus struct {
 	Interface string
 	Type      string
 	Status    string
+	Message   string
 }

--- a/cmd/juju/status/formatter.go
+++ b/cmd/juju/status/formatter.go
@@ -254,7 +254,8 @@ func (sf *statusFormatter) formatRelation(rel params.RelationStatus) relationSta
 		Requirer:  fmt.Sprintf("%s:%s", requirer.ApplicationName, requirer.Name),
 		Interface: rel.Interface,
 		Type:      relType,
-		Status:    rel.Status,
+		Status:    rel.Status.Status,
+		Message:   rel.Status.Info,
 	}
 	return out
 }

--- a/cmd/juju/status/output_tabular.go
+++ b/cmd/juju/status/output_tabular.go
@@ -199,12 +199,15 @@ func FormatTabular(writer io.Writer, forceColor bool, value interface{}) error {
 		})
 		outputHeaders("Relation provider", "Requirer", "Interface", "Type", "Message")
 		for _, r := range fs.Relations {
-			status := ""
+			statusMessage := ""
 			if r.Status != string(relation.Joined) {
-				status = r.Status
+				statusMessage = r.Status
+				if r.Message != "" {
+					statusMessage = statusMessage + " - " + r.Message
+				}
 			}
 			w.Print(r.Provider, r.Requirer, r.Interface, r.Type)
-			w.PrintColor(cmdcrossmodel.RelationStatusColor(relation.Status(status)), status)
+			w.PrintColor(cmdcrossmodel.RelationStatusColor(relation.Status(r.Status)), statusMessage)
 			w.Println()
 		}
 	}

--- a/cmd/juju/status/status_test.go
+++ b/cmd/juju/status/status_test.go
@@ -3604,7 +3604,11 @@ func (rs relateServices) step(c *gc.C, ctx *context) {
 	c.Assert(err, jc.ErrorIsNil)
 	rel, err := ctx.st.AddRelation(eps...)
 	c.Assert(err, jc.ErrorIsNil)
-	err = rel.SetStatus(status.Status(rs.status))
+	s := rs.status
+	if s == "" {
+		s = "joined"
+	}
+	err = rel.SetStatus(status.StatusInfo{Status: status.Status(s)})
 	c.Assert(err, jc.ErrorIsNil)
 }
 

--- a/core/crossmodel/params.go
+++ b/core/crossmodel/params.go
@@ -5,6 +5,7 @@ package crossmodel
 
 import (
 	"gopkg.in/juju/charm.v6-unstable"
+	"time"
 )
 
 // ApplicationOfferDetails represents a remote application used when vendor
@@ -46,6 +47,12 @@ type OfferConnection struct {
 
 	// Status is the status of the offer connection.
 	Status string
+
+	// Message is the status message of the offer connection.
+	Message string
+
+	// Since is when the status value was last changed.
+	Since *time.Time
 
 	// IngressSubnets is the list of subnets from which traffic will originate.
 	IngressSubnets []string

--- a/core/relation/status.go
+++ b/core/relation/status.go
@@ -16,4 +16,7 @@ const (
 	// Suspended is used to signify that a relation is temporarily broken pending
 	// action to resume it.
 	Suspended Status = "suspended"
+
+	// Error is used to signify that the relation is in an error state.
+	Error Status = "error"
 )

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -21,7 +21,7 @@ github.com/juju/ansiterm	git	b99631de12cf04a906c1d4e4ec54fb86eae5863d	2016-09-07
 github.com/juju/blobstore	git	06056004b3d7b54bbb7984d830c537bad00fec21	2015-07-29T11:18:58Z
 github.com/juju/bundlechanges	git	cd189848b313df50084de692b05861210022cf81	2017-07-31T02:12:50Z
 github.com/juju/cmd	git	ad2437ef0ef282ae26e482eb1e44c02532bae1ba	2017-06-22T12:53:07Z
-github.com/juju/description	git	f9168b66462caa818dadb8923e8de51cb22bae4c	2017-08-24T12:06:32Z
+github.com/juju/description	git	364612564ea78c1defaf0165085d2790f527e2de	2017-09-06T13:34:20Z
 github.com/juju/errors	git	1b5e39b83d1835fa480e0c2ddefb040ee82d58b3	2015-09-16T12:56:42Z
 github.com/juju/gnuflag	git	4e76c56581859c14d9d87e1ddbe29e1c0f10195f	2016-08-09T16:52:14Z
 github.com/juju/go-oracle-cloud	git	932a8cea00a1cd5cba3829a672c823955db674ae	2017-04-21T13:45:47Z

--- a/state/application_test.go
+++ b/state/application_test.go
@@ -2392,7 +2392,7 @@ func (s *ApplicationSuite) TestWatchRelations(c *gc.C) {
 	wpxWatcherC.AssertChange(relx.String())
 	wpxWatcherC.AssertNoChange()
 
-	err = relx.SetStatus(status.Suspended)
+	err = relx.SetStatus(status.StatusInfo{Status: status.Suspended})
 	c.Assert(err, jc.ErrorIsNil)
 	wpxWatcherC.AssertChange(relx.String())
 	wpxWatcherC.AssertNoChange()

--- a/state/migration_export.go
+++ b/state/migration_export.go
@@ -902,6 +902,12 @@ func (e *exporter) relations() error {
 			Id:  relation.Id(),
 			Key: relation.String(),
 		})
+		globalKey := relation.globalScope()
+		statusArgs, err := e.statusArgs(globalKey)
+		if err != nil {
+			return errors.Annotatef(err, "status for relation %v", relation.Id())
+		}
+		exRelation.SetStatus(statusArgs)
 		for _, ep := range relation.Endpoints() {
 			exEndPoint := exRelation.AddEndpoint(description.EndpointArgs{
 				ApplicationName: ep.ApplicationName,

--- a/state/migration_export_test.go
+++ b/state/migration_export_test.go
@@ -613,6 +613,10 @@ func (s *MigrationExportSuite) TestRelations(c *gc.C) {
 	}
 	checkEndpoint(exEps[0], mysql_0.Name(), msEp, mysqlSettings)
 	checkEndpoint(exEps[1], wordpress_0.Name(), wpEp, wordpressSettings)
+
+	// Make sure there is a status.
+	status := exRel.Status()
+	c.Check(status.Value(), gc.Equals, "joined")
 }
 
 func (s *MigrationExportSuite) TestSubordinateRelations(c *gc.C) {

--- a/state/migration_import.go
+++ b/state/migration_import.go
@@ -1096,6 +1096,10 @@ func (i *importer) relation(rel description.Relation) error {
 			Insert: relationDoc,
 		},
 	}
+	if rel.Status() != nil {
+		status := i.makeStatusDoc(rel.Status())
+		ops = append(ops, createStatusOp(i.im.mb, relationGlobalScope(rel.Id()), status))
+	}
 
 	dbRelation := newRelation(i.st, relationDoc)
 	// Add an op that adds the relation scope document for each
@@ -1136,7 +1140,6 @@ func (i *importer) makeRelationDoc(rel description.Relation) *relationDoc {
 		Id:        rel.Id(),
 		Endpoints: make([]Endpoint, len(endpoints)),
 		Life:      Alive,
-		Status:    status.Joined,
 	}
 	for i, ep := range endpoints {
 		doc.Endpoints[i] = Endpoint{

--- a/state/migration_import_test.go
+++ b/state/migration_import_test.go
@@ -692,6 +692,10 @@ func (s *MigrationImportSuite) TestRelations(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(units, gc.HasLen, 1)
 
+	relStatus, err := rels[0].Status()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(relStatus.Status, gc.Equals, status.Joined)
+
 	ru, err = rels[0].Unit(units[0])
 	c.Assert(err, jc.ErrorIsNil)
 

--- a/state/migration_internal_test.go
+++ b/state/migration_internal_test.go
@@ -442,7 +442,6 @@ func (s *MigrationSuite) TestRelationDocFields(c *gc.C) {
 		"Key",
 		"Id",
 		"Endpoints",
-		"Status",
 		// Life isn't exported, only alive.
 		"Life",
 		// UnitCount isn't explicitly exported, but defined by the stored

--- a/state/relation_test.go
+++ b/state/relation_test.go
@@ -498,7 +498,7 @@ func (s *RelationSuite) TestWatchLifeStatus(c *gc.C) {
 	wc.AssertChange(rel.Tag().Id())
 	wc.AssertNoChange()
 
-	err = rel.SetStatus(status.Suspended)
+	err = rel.SetStatus(status.StatusInfo{Status: status.Suspended})
 	c.Assert(err, jc.ErrorIsNil)
 	wc.AssertChange(rel.Tag().Id())
 	wc.AssertNoChange()
@@ -538,12 +538,21 @@ func (s *RelationSuite) TestStatus(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	rel, err := s.State.AddRelation(wordpressEP, mysqlEP)
 	c.Assert(err, jc.ErrorIsNil)
-	relStatus := rel.Status()
-	c.Assert(relStatus, gc.Equals, status.Joined)
-	err = rel.SetStatus(status.Suspended)
+	relStatus, err := rel.Status()
 	c.Assert(err, jc.ErrorIsNil)
-	err = rel.Refresh()
+	c.Assert(relStatus.Status, gc.Equals, status.Joined)
+	err = rel.SetStatus(status.StatusInfo{
+		Status:  status.Suspended,
+		Message: "for a while",
+	})
 	c.Assert(err, jc.ErrorIsNil)
-	relStatus = rel.Status()
-	c.Assert(relStatus, gc.Equals, status.Suspended)
+	relStatus, err = rel.Status()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(relStatus.Since, gc.NotNil)
+	relStatus.Since = nil
+	c.Assert(relStatus, jc.DeepEquals, status.StatusInfo{
+		Status:  status.Suspended,
+		Message: "for a while",
+		Data:    map[string]interface{}{},
+	})
 }

--- a/state/relation_test.go
+++ b/state/relation_test.go
@@ -491,7 +491,7 @@ func (s *RelationSuite) TestWatchLifeStatus(c *gc.C) {
 	err = relUnit.EnterScope(nil)
 	c.Assert(err, jc.ErrorIsNil)
 
-	w := rel.WatchStatus()
+	w := rel.WatchLifeStatus()
 	defer testing.AssertStop(c, w)
 	wc := testing.NewStringsWatcherC(c, s.State, w)
 	// Initial event.
@@ -518,7 +518,7 @@ func (s *RelationSuite) TestWatchLifeStatusDead(c *gc.C) {
 	rel, err := s.State.AddRelation(eps...)
 	c.Assert(err, jc.ErrorIsNil)
 
-	w := rel.WatchStatus()
+	w := rel.WatchLifeStatus()
 	defer testing.AssertStop(c, w)
 	wc := testing.NewStringsWatcherC(c, s.State, w)
 	wc.AssertChange(rel.Tag().Id())

--- a/state/unit.go
+++ b/state/unit.go
@@ -690,25 +690,17 @@ func (u *Unit) RelationsJoined() ([]*Relation, error) {
 	})
 }
 
-// RelationsInScopeOrSuspended returns the relations for which the unit has entered scope
-// and not left it, as well as any suspended relations.
-func (u *Unit) RelationsInScopeOrSuspended() ([]*Relation, error) {
+// RelationsInScope returns the relations for which the unit has entered scope
+// and not left it.
+func (u *Unit) RelationsInScope() ([]*Relation, error) {
 	return u.relations(func(ru *RelationUnit) (bool, error) {
-		relStatus, err := ru.Relation().Status()
-		if err != nil {
-			return false, errors.Trace(err)
-		}
-		inScope, err := ru.InScope()
-		if err != nil {
-			return false, errors.Trace(err)
-		}
-		return inScope || relStatus.Status != status.Broken, nil
+		return ru.InScope()
 	})
 }
 
 type relationPredicate func(ru *RelationUnit) (bool, error)
 
-// relations implements RelationsJoined and RelationsInScopeOrSuspended.
+// relations implements RelationsJoined and RelationsInScope.
 func (u *Unit) relations(predicate relationPredicate) ([]*Relation, error) {
 	candidates, err := applicationRelations(u.st, u.doc.Application)
 	if err != nil {

--- a/state/unit_test.go
+++ b/state/unit_test.go
@@ -1513,24 +1513,17 @@ func (s *UnitSuite) TestRelations(c *gc.C) {
 		c.Assert(err, jc.ErrorIsNil)
 		assertEquals(actual, expect)
 	}
-	assertRelationsInScopeOrSuspended := func(unit *state.Unit, expect ...*state.Relation) {
-		actual, err := unit.RelationsInScopeOrSuspended()
+	assertRelationsInScope := func(unit *state.Unit, expect ...*state.Relation) {
+		actual, err := unit.RelationsInScope()
 		c.Assert(err, jc.ErrorIsNil)
 		assertEquals(actual, expect)
 	}
 	assertRelations := func(unit *state.Unit, expect ...*state.Relation) {
-		assertRelationsInScopeOrSuspended(unit, expect...)
+		assertRelationsInScope(unit, expect...)
 		assertRelationsJoined(unit, expect...)
 	}
 	assertRelations(wordpress0)
 	assertRelations(mysql0)
-
-	err = rel.SetStatus(status.StatusInfo{Status: status.Suspended})
-	c.Assert(err, jc.ErrorIsNil)
-	assertRelationsJoined(mysql0)
-	assertRelationsInScopeOrSuspended(mysql0, rel)
-	err = rel.SetStatus(status.StatusInfo{Status: status.Joined})
-	c.Assert(err, jc.ErrorIsNil)
 
 	mysql0ru, err := rel.Unit(mysql0)
 	c.Assert(err, jc.ErrorIsNil)
@@ -1549,7 +1542,7 @@ func (s *UnitSuite) TestRelations(c *gc.C) {
 	err = mysql0ru.PrepareLeaveScope()
 	c.Assert(err, jc.ErrorIsNil)
 	assertRelations(wordpress0, rel)
-	assertRelationsInScopeOrSuspended(mysql0, rel)
+	assertRelationsInScope(mysql0, rel)
 	assertRelationsJoined(mysql0)
 }
 

--- a/state/unit_test.go
+++ b/state/unit_test.go
@@ -1513,17 +1513,24 @@ func (s *UnitSuite) TestRelations(c *gc.C) {
 		c.Assert(err, jc.ErrorIsNil)
 		assertEquals(actual, expect)
 	}
-	assertRelationsInScope := func(unit *state.Unit, expect ...*state.Relation) {
-		actual, err := unit.RelationsInScope()
+	assertRelationsInScopeOrSuspended := func(unit *state.Unit, expect ...*state.Relation) {
+		actual, err := unit.RelationsInScopeOrSuspended()
 		c.Assert(err, jc.ErrorIsNil)
 		assertEquals(actual, expect)
 	}
 	assertRelations := func(unit *state.Unit, expect ...*state.Relation) {
-		assertRelationsInScope(unit, expect...)
+		assertRelationsInScopeOrSuspended(unit, expect...)
 		assertRelationsJoined(unit, expect...)
 	}
 	assertRelations(wordpress0)
 	assertRelations(mysql0)
+
+	err = rel.SetStatus(status.StatusInfo{Status: status.Suspended})
+	c.Assert(err, jc.ErrorIsNil)
+	assertRelationsJoined(mysql0)
+	assertRelationsInScopeOrSuspended(mysql0, rel)
+	err = rel.SetStatus(status.StatusInfo{Status: status.Joined})
+	c.Assert(err, jc.ErrorIsNil)
 
 	mysql0ru, err := rel.Unit(mysql0)
 	c.Assert(err, jc.ErrorIsNil)
@@ -1542,7 +1549,7 @@ func (s *UnitSuite) TestRelations(c *gc.C) {
 	err = mysql0ru.PrepareLeaveScope()
 	c.Assert(err, jc.ErrorIsNil)
 	assertRelations(wordpress0, rel)
-	assertRelationsInScope(mysql0, rel)
+	assertRelationsInScopeOrSuspended(mysql0, rel)
 	assertRelationsJoined(mysql0)
 }
 

--- a/state/watcher.go
+++ b/state/watcher.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"reflect"
 	"regexp"
-	"strconv"
 	"strings"
 	"time"
 
@@ -402,31 +401,9 @@ func watchApplicationRelations(backend modelBackend, applicationName string) Str
 		}
 		return strings.HasPrefix(k, prefix) || strings.Contains(k, infix)
 	}
-	statusFilter := func(id interface{}) bool {
-		scope, err := backend.strictLocalID(id.(string))
-		if err != nil {
-			return false
-		}
-		relId, err := relationIdFromScope(scope)
-		if err != nil {
-			return false
-		}
-		relColl, closer := backend.db().GetCollection(relationsC)
-		defer closer()
-		var doc relationIdDoc
-		err = relColl.Find(bson.D{{"id", relId}}).One(&doc)
-		if err != nil {
-			return false
-		}
-		k, err := backend.strictLocalID(doc.DocId)
-		if err != nil {
-			return false
-		}
-		return strings.HasPrefix(k, prefix) || strings.Contains(k, infix)
-	}
-
 	members := bson.D{{"endpoints.applicationname", applicationName}}
-	return newRelationStatusWatcher(backend, members, filter, statusFilter)
+	lw := newLifecycleWatcher(backend, relationsC, members, filter, nil)
+	return newRelationLifeStatusWatcher(backend, lw)
 }
 
 // WatchModelMachines returns a StringsWatcher that notifies of changes to
@@ -1118,265 +1095,294 @@ func (w *relationUnitsWatcher) loop() (err error) {
 	}
 }
 
-type lifeStatus struct {
-	life   Life
-	status status.Status
-}
-
-// relationStatusWatcher sends notifications when the life or status
-// of the specified relations change.
-type relationStatusWatcher struct {
-	commonWatcher
-	lifeWatcher         StringsWatcher
-	knownLifeStatusById map[string]lifeStatus
-	out                 chan []string
-
-	// key filters are used to filter changes based on the
-	// relation key, ie life changes from the relation collection
-	relationKeyMatch  bson.D
-	relationKeyFilter func(key interface{}) bool
-
-	// status filter is used to filter changes based on the
-	// relation id number, ie status changes from the status collection
-	relationStatusFilter func(key interface{}) bool
-}
-
-// WatchStatus returns a watcher that notifies of changes to the life
+// WatchLifeStatus returns a watcher that notifies of changes to the life
 // or status of the relation.
-func (r *Relation) WatchStatus() StringsWatcher {
-	keyFilter := func(id interface{}) bool {
+func (r *Relation) WatchLifeStatus() StringsWatcher {
+	filter := func(id interface{}) bool {
 		k, err := r.st.strictLocalID(id.(string))
 		if err != nil {
 			return false
 		}
 		return k == r.Tag().Id()
 	}
-	statusFilter := func(id interface{}) bool {
-		k, err := r.st.strictLocalID(id.(string))
-		if err != nil {
-			return false
-		}
-		return k == relationGlobalScope(r.Id())
-	}
-	return newRelationStatusWatcher(r.st, nil, keyFilter, statusFilter)
+	members := bson.D{{"id", r.Id()}}
+	lw := newLifecycleWatcher(r.st, relationsC, members, filter, nil)
+
+	return newRelationLifeStatusWatcher(r.st, lw)
 }
 
-func newRelationStatusWatcher(backend modelBackend,
-	relationKeyMatch bson.D,
-	relationKeyFilter func(key interface{}) bool,
-	relationStatusFilter func(key interface{}) bool,
-) StringsWatcher {
-	w := &relationStatusWatcher{
-		commonWatcher:        newCommonWatcher(backend),
-		lifeWatcher:          newLifecycleWatcher(backend, relationsC, relationKeyMatch, relationKeyFilter, nil),
-		out:                  make(chan []string),
-		relationKeyMatch:     relationKeyMatch,
-		relationKeyFilter:    relationKeyFilter,
-		relationStatusFilter: relationStatusFilter,
-		knownLifeStatusById:  make(map[string]lifeStatus),
+// relationLifeStatusWatcher sends notifications of changes to the life or
+// status of specific relations.
+type relationLifeStatusWatcher struct {
+	commonWatcher
+	lifeWatcher StringsWatcher
+	out         chan []string
+
+	// statusWatchers holds status watchers keyed on relation id.
+	statusWatchers map[int]StringsWatcher
+
+	// relationKeys maps global relation scope id to relation key.
+	relationKeys map[string]string
+
+	// statusOut is the channel used to receive status changes.
+	statusOut chan []string
+}
+
+// newRelationLifeStatusWatcher creates a watcher that sends changes when the specified
+// lifeWatcher fires, or when relations which are alive according the the life watcher
+// change status.
+func newRelationLifeStatusWatcher(backend modelBackend, lifeWatcher StringsWatcher) *relationLifeStatusWatcher {
+	w := &relationLifeStatusWatcher{
+		commonWatcher:  newCommonWatcher(backend),
+		lifeWatcher:    lifeWatcher,
+		statusWatchers: make(map[int]StringsWatcher),
+		relationKeys:   make(map[string]string),
+		statusOut:      make(chan []string),
+		out:            make(chan []string),
 	}
 	go func() {
-		defer w.tomb.Done()
-		defer close(w.out)
-		defer watcher.Stop(w.lifeWatcher, &w.tomb)
+		defer w.finish()
 		w.tomb.Kill(w.loop())
 	}()
 	return w
 }
 
-// Changes returns a channel that will receive the changes to
-// relation life or status. The first event on the
-// channel holds the initial state of the relations.
-func (w *relationStatusWatcher) Changes() <-chan []string {
+func (w *relationLifeStatusWatcher) finish() {
+	watcher.Stop(w.lifeWatcher, &w.tomb)
+	for _, sw := range w.statusWatchers {
+		watcher.Stop(sw, &w.tomb)
+	}
+	close(w.out)
+	w.tomb.Done()
+}
+
+func (w *relationLifeStatusWatcher) Changes() <-chan []string {
 	return w.out
 }
 
-type relationIdDoc struct {
-	DocId      string `bson:"_id"`
-	RelationId int    `bson:"id"`
-	Life       Life   `bson:"life"`
+type relationLifeDoc struct {
+	DocId string `bson:"_id"`
+	Life  Life   `bson:"life"`
+	Id    int    `bson:"id"`
 }
 
-type relationStatusDoc struct {
+var relationLifeFields = bson.D{{"_id", 1}, {"life", 1}, {"id", 1}}
+
+// lifeChanged starts or stops status watchers for relations with the
+// specified keys, according to whether the relation is alive or not.
+func (w *relationLifeStatusWatcher) lifeChanged(keys []string) error {
+	relColl, closer := w.db.GetCollection(relationsC)
+	defer closer()
+
+	iter := relColl.Find(bson.D{{"_id", bson.D{{"$in", keys}}}}).Select(relationLifeFields).Iter()
+	var doc relationLifeDoc
+	for iter.Next(&doc) {
+		rid := relationGlobalScope(doc.Id)
+		switch doc.Life {
+		case Alive, Dying:
+			if _, ok := w.statusWatchers[doc.Id]; ok {
+				continue
+			}
+			members := bson.D{{"_id", rid}}
+			statusFilter := func(id interface{}) bool {
+				k, err := w.backend.strictLocalID(id.(string))
+				if err != nil {
+					return false
+				}
+				return k == rid
+			}
+			sw := newStatusWatcher(w.backend, members, statusFilter, w.statusOut)
+			// Consume initial event
+			<-sw.Changes()
+			w.statusWatchers[doc.Id] = sw
+			w.relationKeys[rid] = w.backend.localID(doc.DocId)
+		default:
+			sw, ok := w.statusWatchers[doc.Id]
+			if ok {
+				watcher.Stop(sw, &w.tomb)
+				delete(w.statusWatchers, doc.Id)
+				delete(w.relationKeys, rid)
+			}
+		}
+	}
+	return iter.Close()
+}
+
+func (w *relationLifeStatusWatcher) loop() (err error) {
+	var (
+		sentInitial bool
+		out         chan<- []string
+	)
+	changes := make(set.Strings)
+	for {
+		select {
+		case <-w.watcher.Dead():
+			return stateWatcherDeadError(w.watcher.Err())
+		case <-w.tomb.Dying():
+			return tomb.ErrDying
+		case keys, ok := <-w.lifeWatcher.Changes():
+			// Relation life has changed.
+			if !ok {
+				return watcher.EnsureErr(w.lifeWatcher)
+			}
+			if err = w.lifeChanged(keys); err != nil {
+				return err
+			}
+			for _, key := range keys {
+				changes.Add(key)
+			}
+		case rids, ok := <-w.statusOut:
+			// Relation status has changed.
+			if !ok {
+				return tomb.ErrDying
+			}
+			// Status changes are the global key of the relation.
+			// Look up the relation key.
+			for _, rid := range rids {
+				if key, ok := w.relationKeys[rid]; ok {
+					changes.Add(key)
+				}
+			}
+		case out <- changes.Values():
+			sentInitial = true
+			changes = make(set.Strings)
+			out = nil
+		}
+		if !sentInitial || changes.Size() > 0 {
+			out = w.out
+		}
+	}
+}
+
+// statusWatcher sends notifications when the status of entities change.
+type statusWatcher struct {
+	commonWatcher
+	knownStatus map[string]status.Status
+	out         chan []string
+
+	// members is used to select the initial set of interesting entities.
+	members bson.D
+
+	// filter is used to exclude events not affecting interesting entities.
+	filter func(interface{}) bool
+}
+
+func newStatusWatcher(backend modelBackend,
+	members bson.D,
+	filter func(key interface{}) bool,
+	changes chan []string,
+) StringsWatcher {
+	w := &statusWatcher{
+		commonWatcher: newCommonWatcher(backend),
+		out:           changes,
+		filter:        filter,
+		members:       members,
+		knownStatus:   make(map[string]status.Status),
+	}
+	if changes == nil {
+		w.out = make(chan []string)
+	}
+	go func() {
+		defer w.tomb.Done()
+		if changes == nil {
+			defer close(w.out)
+		}
+		w.tomb.Kill(w.loop())
+	}()
+	return w
+}
+
+// Changes returns the event channel for the statusWatcher.
+func (w *statusWatcher) Changes() <-chan []string {
+	return w.out
+}
+
+type statusValueDoc struct {
 	Id     string        `bson:"_id"`
 	Status status.Status `bson:"status"`
 }
 
-var (
-	idFields     = bson.D{{"_id", 1}, {"id", 1}, {"life", 1}}
-	statusFields = bson.D{{"_id", 1}, {"status", 1}}
-)
+var statusFields = bson.D{{"_id", 1}, {"status", 1}}
 
-func (w *relationStatusWatcher) initial() (_ set.Strings, err error) {
+func (w *statusWatcher) initial() (set.Strings, error) {
 	statusColl, closer := w.db.GetCollection(statusesC)
 	defer closer()
-	relColl, closer := w.db.GetCollection(relationsC)
-	defer closer()
 
-	// Find the relations we care about watching.
-	var idDoc relationIdDoc
-	iter := relColl.Find(w.relationKeyMatch).Select(idFields).Iter()
-	defer func() {
-		err2 := iter.Close()
-		if err != nil {
-			err = err2
-		}
-	}()
+	// Find the entities we care about watching.
+	var doc statusValueDoc
+	iter := statusColl.Find(w.members).Select(statusFields).Iter()
 
-	// For each relation we care about, find the initial life and status.
-	keys := make(set.Strings)
-	for iter.Next(&idDoc) {
+	// For each entity we care about, find the initial status.
+	ids := make(set.Strings)
+	for iter.Next(&doc) {
 		// If no members criteria is specified, use the filter
 		// to reject any unsuitable initial elements.
-		if w.relationKeyMatch == nil && !w.relationKeyFilter(idDoc.DocId) {
+		if w.members == nil && !w.filter(doc.Id) {
 			continue
 		}
-		key := w.backend.localID(idDoc.DocId)
-		keys.Add(key)
-
-		if idDoc.Life != Dead {
-			var doc relationStatusDoc
-			scope := relationGlobalScope(idDoc.RelationId)
-			if err := statusColl.FindId(scope).One(&doc); err != nil {
-				return nil, errors.Trace(err)
-			}
-			w.knownLifeStatusById[scope] = lifeStatus{idDoc.Life, doc.Status}
-		}
+		id := w.backend.localID(doc.Id)
+		ids.Add(id)
+		w.knownStatus[id] = doc.Status
 	}
-	return keys, nil
+	return ids, iter.Close()
 }
 
-func (w *relationStatusWatcher) mergeLife(keys set.Strings, changed []string) (err error) {
-	relColl, closer := w.db.GetCollection(relationsC)
-	defer closer()
-
-	deadKeys := set.NewStrings(changed...)
-	iter := relColl.Find(bson.D{{"_id", bson.D{{"$in", changed}}}}).Select(idFields).Iter()
-	var doc relationIdDoc
-	for iter.Next(&doc) {
-		key := w.backend.localID(doc.DocId)
-		deadKeys.Remove(key)
-		relId := relationGlobalScope(doc.RelationId)
-		knownLifeStatus, known := w.knownLifeStatusById[relId]
-		gone := doc.Life == Dead
-		switch {
-		case known && gone:
-			delete(w.knownLifeStatusById, relId)
-		case known && doc.Life != knownLifeStatus.life:
-			knownLifeStatus.life = doc.Life
-			w.knownLifeStatusById[relId] = knownLifeStatus
-		default:
-			continue
-		}
-		keys.Add(key)
-	}
-	if err := iter.Close(); err != nil {
-		return err
-	}
-
-	for _, k := range deadKeys.Values() {
-		keys.Add(k)
-	}
-	return nil
-}
-
-func (w *relationStatusWatcher) merge(keys set.Strings, updates map[interface{}]bool) (err error) {
+func (w *statusWatcher) merge(ids set.Strings, updates map[interface{}]bool) (err error) {
 	statusColl, closer := w.db.GetCollection(statusesC)
 	defer closer()
 
-	// Separate keys into those thought to exist and those known to be removed.
+	// Separate ids into those existing and those known to be removed.
 	var changed []string
-	latestLifeStatusById := make(map[string]lifeStatus)
+	gone := make(set.Strings)
+	latest := make(map[string]status.Status)
 	for docID, exists := range updates {
 		switch docID := docID.(type) {
 		case string:
 			if exists {
 				changed = append(changed, docID)
 			} else {
-				id := w.backend.localID(docID)
-				latestLifeStatusById[id] = lifeStatus{Dead, status.Broken}
+				gone.Add(w.backend.localID(docID))
 			}
 		default:
 			return errors.Errorf("id is not of type string, got %T", docID)
 		}
 	}
 
-	// Collect life and status from keys thought to exist. Any that don't actually
-	// exist are ignored (we'll hear about them in the next set of updates --
-	// all that's actually happened in that situation is that the watcher
-	// events have lagged a little behind reality).
 	iter := statusColl.Find(bson.D{{"_id", bson.D{{"$in", changed}}}}).Select(statusFields).Iter()
-	var doc relationStatusDoc
+	var doc statusValueDoc
 	for iter.Next(&doc) {
-		id := w.backend.localID(doc.Id)
-		latestLifeStatusById[id] = lifeStatus{Alive, doc.Status}
+		latest[w.backend.localID(doc.Id)] = doc.Status
 	}
 	if err := iter.Close(); err != nil {
 		return err
 	}
 
-	// Now correlate the changes.
-	relColl, closer := w.db.GetCollection(relationsC)
-	defer closer()
-	for id, newLifeStatus := range latestLifeStatusById {
-
-		// Look up the relation key and life based on the global scope value
-		// obtained from the changed status record.
-		relId, err := relationIdFromScope(id)
-		if err != nil {
-			return errors.Trace(err)
-		}
-		var (
-			doc relationIdDoc
-			key string
-		)
-		err = relColl.Find(bson.D{{"id", relId}}).One(&doc)
-		if err == nil {
-			newLifeStatus.life = doc.Life
-			key = w.backend.localID(doc.DocId)
-		} else if err == mgo.ErrNotFound {
-			newLifeStatus.life = Dead
-		} else {
-			return errors.Trace(err)
-		}
-
-		gone := newLifeStatus.life == Dead || newLifeStatus.status == status.Broken
-		oldLifeStatus, known := w.knownLifeStatusById[id]
+	// Add to ids any whose status value is known to have changed.
+	// Don't send events for deleted/removed status entities.
+	for id, newStatus := range latest {
+		gone := gone.Contains(id)
+		oldStatus, known := w.knownStatus[id]
 		switch {
-		case known && gone:
-			delete(w.knownLifeStatusById, id)
-			if key == "" {
-				continue
-			}
 		case !known && !gone:
-			w.knownLifeStatusById[id] = newLifeStatus
-		case known && (newLifeStatus.life != oldLifeStatus.life || newLifeStatus.status != oldLifeStatus.status):
-			w.knownLifeStatusById[id] = newLifeStatus
+			w.knownStatus[id] = newStatus
+		case known && gone:
+			delete(w.knownStatus, id)
+			continue
+		case known && newStatus != oldStatus:
+			w.knownStatus[id] = newStatus
 		default:
 			continue
 		}
-		keys.Add(key)
+		ids.Add(id)
 	}
 	return nil
 }
 
-func relationIdFromScope(scope string) (int, error) {
-	// Scope is of the form "r#<id>"
-	if !strings.HasPrefix(scope, "r#") {
-		return 0, errors.NotValidf("relation scope %q", scope)
-	}
-	return strconv.Atoi(scope[2:])
-}
-
-func (w *relationStatusWatcher) loop() error {
+func (w *statusWatcher) loop() error {
 	in := make(chan watcher.Change)
-	w.watcher.WatchCollectionWithFilter(statusesC, in, w.relationStatusFilter)
+	w.watcher.WatchCollectionWithFilter(statusesC, in, w.filter)
 	defer w.watcher.UnwatchCollection(statusesC, in)
-
-	// Consume initial life event.
-	<-w.lifeWatcher.Changes()
-
-	keys, err := w.initial()
+	ids, err := w.initial()
 	if err != nil {
 		return err
 	}
@@ -1387,30 +1393,20 @@ func (w *relationStatusWatcher) loop() error {
 			return tomb.ErrDying
 		case <-w.watcher.Dead():
 			return stateWatcherDeadError(w.watcher.Err())
-		case lifeChanges, ok := <-w.lifeWatcher.Changes():
-			if !ok {
-				return watcher.EnsureErr(w.lifeWatcher)
-			}
-			if err := w.mergeLife(keys, lifeChanges); err != nil {
-				return err
-			}
-			if !keys.IsEmpty() {
-				out = w.out
-			}
 		case ch := <-in:
 			latest, ok := collect(ch, in, w.tomb.Dying())
 			if !ok {
 				return tomb.ErrDying
 			}
-			if err := w.merge(keys, latest); err != nil {
+			if err := w.merge(ids, latest); err != nil {
 				return err
 			}
-			if !keys.IsEmpty() {
+			if !ids.IsEmpty() {
 				out = w.out
 			}
-		case out <- keys.Values():
+		case out <- ids.Values():
 			out = nil
-			keys = make(set.Strings)
+			ids = make(set.Strings)
 		}
 	}
 }

--- a/state/watcher.go
+++ b/state/watcher.go
@@ -418,7 +418,7 @@ func watchApplicationRelations(backend modelBackend, applicationName string) Str
 		if err != nil {
 			return false
 		}
-		k, err := backend.strictLocalID(doc.Id)
+		k, err := backend.strictLocalID(doc.DocId)
 		if err != nil {
 			return false
 		}
@@ -1192,7 +1192,7 @@ func (w *relationStatusWatcher) Changes() <-chan []string {
 }
 
 type relationIdDoc struct {
-	Id         string `bson:"_id"`
+	DocId      string `bson:"_id"`
 	RelationId int    `bson:"id"`
 	Life       Life   `bson:"life"`
 }
@@ -1228,10 +1228,10 @@ func (w *relationStatusWatcher) initial() (_ set.Strings, err error) {
 	for iter.Next(&idDoc) {
 		// If no members criteria is specified, use the filter
 		// to reject any unsuitable initial elements.
-		if w.relationKeyMatch == nil && !w.relationKeyFilter(idDoc.Id) {
+		if w.relationKeyMatch == nil && !w.relationKeyFilter(idDoc.DocId) {
 			continue
 		}
-		key := w.backend.localID(idDoc.Id)
+		key := w.backend.localID(idDoc.DocId)
 		keys.Add(key)
 
 		if idDoc.Life != Dead {
@@ -1254,7 +1254,7 @@ func (w *relationStatusWatcher) mergeLife(keys set.Strings, changed []string) (e
 	iter := relColl.Find(bson.D{{"_id", bson.D{{"$in", changed}}}}).Select(idFields).Iter()
 	var doc relationIdDoc
 	for iter.Next(&doc) {
-		key := w.backend.localID(doc.Id)
+		key := w.backend.localID(doc.DocId)
 		deadKeys.Remove(key)
 		relId := relationGlobalScope(doc.RelationId)
 		knownLifeStatus, known := w.knownLifeStatusById[relId]
@@ -1333,7 +1333,7 @@ func (w *relationStatusWatcher) merge(keys set.Strings, updates map[interface{}]
 		err = relColl.Find(bson.D{{"id", relId}}).One(&doc)
 		if err == nil {
 			newLifeStatus.life = doc.Life
-			key = w.backend.localID(doc.Id)
+			key = w.backend.localID(doc.DocId)
 		} else if err == mgo.ErrNotFound {
 			newLifeStatus.life = Dead
 		} else {

--- a/watcher/relationstatus.go
+++ b/watcher/relationstatus.go
@@ -13,8 +13,11 @@ type RelationStatusChange struct {
 	// Key is the relation key of the changed relation.
 	Key string
 
-	// Status is the status of the relation, eg Active.
+	// Status is the status of the relation, eg joined.
 	Status relation.Status
+
+	// StatusMessage is the status message.
+	StatusMessage string
 
 	// Life is the relation life value, eg Alive.
 	Life life.Value

--- a/worker/remoterelations/remoterelationsworker.go
+++ b/worker/remoterelations/remoterelationsworker.go
@@ -103,6 +103,7 @@ func (w *remoteRelationsWorker) relationUnitsChangeEvent(
 		ApplicationToken: w.applicationToken,
 		Life:             params.Life(change.Life),
 		Status:           params.RelationStatusValue(change.Status),
+		StatusMessage:    change.StatusMessage,
 	}
 	return event, nil
 }

--- a/worker/uniter/relation/relations.go
+++ b/worker/uniter/relation/relations.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/juju/juju/api/uniter"
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/core/relation"
 	"github.com/juju/juju/worker/uniter/hook"
 	"github.com/juju/juju/worker/uniter/operation"
 	"github.com/juju/juju/worker/uniter/remotestate"
@@ -112,18 +113,23 @@ func NewRelations(st *uniter.State, tag names.UnitTag, charmDir, relationsDir st
 // the corresponding relations. It's only expected to be called while a
 // *relations is being created.
 func (r *relations) init() error {
-	activeRelationTags, err := r.unit.RelationsInScopeOrSuspended()
+	relationStatus, err := r.unit.RelationsStatus()
 	if err != nil {
 		return errors.Trace(err)
 	}
 	// Keep the relations ordered for reliable testing.
 	var orderedIds []int
 	activeRelations := make(map[int]*uniter.Relation)
-	for _, tag := range activeRelationTags {
-		relation, err := r.st.Relation(tag)
+	relationStatusValues := make(map[int]relation.Status)
+	for _, rs := range relationStatus {
+		if !rs.InScope {
+			continue
+		}
+		relation, err := r.st.Relation(rs.Tag)
 		if err != nil {
 			return errors.Trace(err)
 		}
+		relationStatusValues[relation.Id()] = rs.Status
 		activeRelations[relation.Id()] = relation
 		orderedIds = append(orderedIds, relation.Id())
 	}
@@ -136,8 +142,14 @@ func (r *relations) init() error {
 			if err := r.add(rel, dir); err != nil {
 				return errors.Trace(err)
 			}
-		} else if err := dir.Remove(); err != nil {
-			return errors.Trace(err)
+		} else {
+			switch relationStatusValues[id] {
+			case relation.Joined, relation.Suspended, relation.Error:
+			default:
+				if err := dir.Remove(); err != nil {
+					return errors.Trace(err)
+				}
+			}
 		}
 	}
 	for _, id := range orderedIds {

--- a/worker/uniter/relation/relations.go
+++ b/worker/uniter/relation/relations.go
@@ -144,6 +144,8 @@ func (r *relations) init() error {
 			}
 		} else {
 			switch relationStatusValues[id] {
+			// Relations which are not broken, eg just suspended or in error, may
+			// become active again so we keep the local state.
 			case relation.Joined, relation.Suspended, relation.Error:
 			default:
 				if err := dir.Remove(); err != nil {

--- a/worker/uniter/relation/relations.go
+++ b/worker/uniter/relation/relations.go
@@ -112,19 +112,19 @@ func NewRelations(st *uniter.State, tag names.UnitTag, charmDir, relationsDir st
 // the corresponding relations. It's only expected to be called while a
 // *relations is being created.
 func (r *relations) init() error {
-	joinedRelationTags, err := r.unit.JoinedRelations()
+	activeRelationTags, err := r.unit.RelationsInScopeOrSuspended()
 	if err != nil {
 		return errors.Trace(err)
 	}
 	// Keep the relations ordered for reliable testing.
 	var orderedIds []int
-	joinedRelations := make(map[int]*uniter.Relation)
-	for _, tag := range joinedRelationTags {
+	activeRelations := make(map[int]*uniter.Relation)
+	for _, tag := range activeRelationTags {
 		relation, err := r.st.Relation(tag)
 		if err != nil {
 			return errors.Trace(err)
 		}
-		joinedRelations[relation.Id()] = relation
+		activeRelations[relation.Id()] = relation
 		orderedIds = append(orderedIds, relation.Id())
 	}
 	knownDirs, err := ReadAllStateDirs(r.relationsDir)
@@ -132,7 +132,7 @@ func (r *relations) init() error {
 		return errors.Trace(err)
 	}
 	for id, dir := range knownDirs {
-		if rel, ok := joinedRelations[id]; ok {
+		if rel, ok := activeRelations[id]; ok {
 			if err := r.add(rel, dir); err != nil {
 				return errors.Trace(err)
 			}
@@ -141,7 +141,7 @@ func (r *relations) init() error {
 		}
 	}
 	for _, id := range orderedIds {
-		rel := joinedRelations[id]
+		rel := activeRelations[id]
 		if _, ok := knownDirs[id]; ok {
 			continue
 		}

--- a/worker/uniter/relation/relations_test.go
+++ b/worker/uniter/relation/relations_test.go
@@ -125,7 +125,7 @@ func (s *relationsSuite) setupRelations(c *gc.C) relation.Relations {
 	apiCaller := mockAPICaller(c, &numCalls,
 		uniterAPICall("Refresh", unitEntity, params.UnitRefreshResults{Results: []params.UnitRefreshResult{{Life: params.Alive, Resolved: params.ResolvedNone, Series: "quantal"}}}, nil),
 		uniterAPICall("GetPrincipal", unitEntity, params.StringBoolResults{Results: []params.StringBoolResult{{Result: "", Ok: false}}}, nil),
-		uniterAPICall("JoinedRelations", unitEntity, params.StringsResults{Results: []params.StringsResult{{Result: []string{}}}}, nil),
+		uniterAPICall("RelationsInScopeOrSuspended", unitEntity, params.StringsResults{Results: []params.StringsResult{{Result: []string{}}}}, nil),
 	)
 	st := uniter.NewState(apiCaller, unitTag)
 	r, err := relation.NewRelations(st, unitTag, s.stateDir, s.relationsDir, abort)
@@ -165,7 +165,7 @@ func (s *relationsSuite) TestNewRelationsWithExistingRelations(c *gc.C) {
 	apiCaller := mockAPICaller(c, &numCalls,
 		uniterAPICall("Refresh", unitEntity, params.UnitRefreshResults{Results: []params.UnitRefreshResult{{Life: params.Alive, Resolved: params.ResolvedNone, Series: "quantal"}}}, nil),
 		uniterAPICall("GetPrincipal", unitEntity, params.StringBoolResults{Results: []params.StringBoolResult{{Result: "", Ok: false}}}, nil),
-		uniterAPICall("JoinedRelations", unitEntity, params.StringsResults{Results: []params.StringsResult{{Result: []string{"relation-wordpress:db mysql:db"}}}}, nil),
+		uniterAPICall("RelationsInScopeOrSuspended", unitEntity, params.StringsResults{Results: []params.StringsResult{{Result: []string{"relation-wordpress:db mysql:db"}}}}, nil),
 		uniterAPICall("Relation", relationUnits, relationResults, nil),
 		uniterAPICall("Relation", relationUnits, relationResults, nil),
 		uniterAPICall("Watch", unitEntity, params.NotifyWatchResults{Results: []params.NotifyWatchResult{{NotifyWatcherId: "1"}}}, nil),
@@ -195,7 +195,7 @@ func (s *relationsSuite) TestNextOpNothing(c *gc.C) {
 	apiCaller := mockAPICaller(c, &numCalls,
 		uniterAPICall("Refresh", unitEntity, params.UnitRefreshResults{Results: []params.UnitRefreshResult{{Life: params.Alive, Resolved: params.ResolvedNone, Series: "quantal"}}}, nil),
 		uniterAPICall("GetPrincipal", unitEntity, params.StringBoolResults{Results: []params.StringBoolResult{{Result: "", Ok: false}}}, nil),
-		uniterAPICall("JoinedRelations", unitEntity, params.StringsResults{Results: []params.StringsResult{{Result: []string{}}}}, nil),
+		uniterAPICall("RelationsInScopeOrSuspended", unitEntity, params.StringsResults{Results: []params.StringsResult{{Result: []string{}}}}, nil),
 	)
 	st := uniter.NewState(apiCaller, unitTag)
 	r, err := relation.NewRelations(st, unitTag, s.stateDir, s.relationsDir, abort)
@@ -233,7 +233,7 @@ func relationJoinedAPICalls() []apiCall {
 	apiCalls := []apiCall{
 		uniterAPICall("Refresh", unitEntity, params.UnitRefreshResults{Results: []params.UnitRefreshResult{{Life: params.Alive, Resolved: params.ResolvedNone, Series: "quantal"}}}, nil),
 		uniterAPICall("GetPrincipal", unitEntity, params.StringBoolResults{Results: []params.StringBoolResult{{Result: "", Ok: false}}}, nil),
-		uniterAPICall("JoinedRelations", unitEntity, params.StringsResults{Results: []params.StringsResult{{Result: []string{}}}}, nil),
+		uniterAPICall("RelationsInScopeOrSuspended", unitEntity, params.StringsResults{Results: []params.StringsResult{{Result: []string{}}}}, nil),
 		uniterAPICall("RelationById", params.RelationIds{RelationIds: []int{1}}, relationResults, nil),
 		uniterAPICall("Relation", relationUnits, relationResults, nil),
 		uniterAPICall("Relation", relationUnits, relationResults, nil),
@@ -543,7 +543,7 @@ func (s *relationsSuite) TestImplicitRelationNoHooks(c *gc.C) {
 	apiCalls := []apiCall{
 		uniterAPICall("Refresh", unitEntity, params.UnitRefreshResults{Results: []params.UnitRefreshResult{{Life: params.Alive, Resolved: params.ResolvedNone, Series: "quantal"}}}, nil),
 		uniterAPICall("GetPrincipal", unitEntity, params.StringBoolResults{Results: []params.StringBoolResult{{Result: "", Ok: false}}}, nil),
-		uniterAPICall("JoinedRelations", unitEntity, params.StringsResults{Results: []params.StringsResult{{Result: []string{}}}}, nil),
+		uniterAPICall("RelationsInScopeOrSuspended", unitEntity, params.StringsResults{Results: []params.StringsResult{{Result: []string{}}}}, nil),
 		uniterAPICall("RelationById", params.RelationIds{RelationIds: []int{1}}, relationResults, nil),
 		uniterAPICall("Relation", relationUnits, relationResults, nil),
 		uniterAPICall("Relation", relationUnits, relationResults, nil),
@@ -632,7 +632,7 @@ func subSubRelationAPICalls() []apiCall {
 	return []apiCall{
 		uniterAPICall("Refresh", nrpeUnitEntity, params.UnitRefreshResults{Results: []params.UnitRefreshResult{{Life: params.Alive, Resolved: params.ResolvedNone, Series: "quantal"}}}, nil),
 		uniterAPICall("GetPrincipal", nrpeUnitEntity, params.StringBoolResults{Results: []params.StringBoolResult{{Result: "unit-wordpress-0", Ok: true}}}, nil),
-		uniterAPICall("JoinedRelations", nrpeUnitEntity, joinedRelationsResults, nil),
+		uniterAPICall("RelationsInScopeOrSuspended", nrpeUnitEntity, joinedRelationsResults, nil),
 		uniterAPICall("Relation", relationUnits1, relationResults1, nil),
 		uniterAPICall("Relation", relationUnits2, relationResults2, nil),
 		uniterAPICall("Relation", relationUnits1, relationResults1, nil),


### PR DESCRIPTION
## Description of change

Relation status was being modelled as a field in the state relation doc.
We now model it like for other entities as an entry in the statuses collection.

Most of the changes are mechanical, but the state relation status watcher needed to be rewritten to account for needed to get its data from 2 collections.

The juju/description  repo has been modified to model status the new way and the dep for this pr is updated. The juju/decription is https://github.com/juju/description/pull/22

The second commit, https://github.com/juju/juju/pull/7831/commits/24bdeb80b5c2ec359a9177fda4433157d211e083, fixes an issue that came up in testing. When the uniter is initialising, it needs to treat any suspended relations as still active, not just those in scope. Otherwise it attempts to incorrectly remove the unit state dir.

## QA steps

Run up a cmr scenario.
Set status for relation on offering side to suspended.
Ensure relation on consuming side is broken.
Set relation to resumed. See that consuming relation recovers.
Delete relation on offering side. 
Relation on consuming side is removed.

