### PR TITLE
Rename local to localhost in DNS name.

### DIFF
--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -459,7 +459,7 @@ func upgradeCertificateDNSNames(config agent.ConfigSetter) error {
 	}
 
 	update := false
-	requiredDNSNames := []string{"local", "juju-apiserver", "juju-mongodb"}
+	requiredDNSNames := []string{"localhost", "juju-apiserver", "juju-mongodb"}
 	for _, dnsName := range requiredDNSNames {
 		if dnsNames.Contains(dnsName) {
 			continue

--- a/cmd/jujud/agent/machine_test.go
+++ b/cmd/jujud/agent/machine_test.go
@@ -1119,7 +1119,7 @@ func (s *MachineSuite) testCertificateDNSUpdated(c *gc.C, a *MachineAgent) {
 	stateInfo, _ := a.CurrentConfig().StateServingInfo()
 	srvCert, _, err := cert.ParseCertAndKey(stateInfo.Cert, stateInfo.PrivateKey)
 	c.Assert(err, jc.ErrorIsNil)
-	expectedDnsNames := set.NewStrings("local", "juju-apiserver", "juju-mongodb")
+	expectedDnsNames := set.NewStrings("localhost", "juju-apiserver", "juju-mongodb")
 	certDnsNames := set.NewStrings(srvCert.DNSNames...)
 	c.Check(expectedDnsNames.Difference(certDnsNames).IsEmpty(), jc.IsTrue)
 


### PR DESCRIPTION
A long standing issue where the DNS names added to the certificate added local, but failed to add localhost.

## QA steps

Bootstrap a local provider.

## Bug reference

pad.lv/1710886
