### PR TITLE
Add-Model for CAAS Clouds

### DIFF
--- a/apiserver/facades/client/modelmanager/modelmanager_test.go
+++ b/apiserver/facades/client/modelmanager/modelmanager_test.go
@@ -241,15 +241,15 @@ func (s *modelManagerSuite) TestCreateModelArgs(c *gc.C) {
 		"ControllerTag",
 		"Cloud",
 		"CloudCredential",
-		"ControllerConfig",
 		"ComposeNewModelConfig",
+		"ControllerConfig",
 		"NewModel",
 		"ReloadSpaces",
+		"Close",
 		"GetBackend",
 		"Model",
 		"AllMachines",
 		"LatestMigration",
-		"Close",
 	)
 
 	// Check that Model.LastModelConnection is called three times
@@ -410,13 +410,12 @@ func (s *modelManagerSuite) TestCreateCAASModelArgs(c *gc.C) {
 		"ControllerTag",
 		"Cloud",
 		"CloudCredential",
-		"ControllerConfig",
 		"NewModel",
+		"Close",
 		"GetBackend",
 		"Model",
 		"AllMachines",
 		"LatestMigration",
-		"Close",
 	)
 
 	// Check that Model.LastModelConnection is called just twice

--- a/cloud/clouds.go
+++ b/cloud/clouds.go
@@ -195,6 +195,14 @@ type region struct {
 	StorageEndpoint  string `yaml:"storage-endpoint,omitempty"`
 }
 
+var caasCloudTypes = map[string]bool{
+	"kubernetes": true,
+}
+
+func CloudIsCAAS(cloud Cloud) bool {
+	return caasCloudTypes[cloud.Type]
+}
+
 // CloudByName returns the cloud with the specified name.
 // If there exists no cloud with the specified name, an
 // error satisfying errors.IsNotFound will be returned.

--- a/state/iaasmodel.go
+++ b/state/iaasmodel.go
@@ -13,7 +13,7 @@ type IAASModel struct {
 
 	mb modelBackend
 
-	// TODO(jsing): This should be removed once things
+	// TODO(caas): This should be removed once things
 	// have been sufficiently untangled.
 	st *State
 }
@@ -30,7 +30,7 @@ func (m *Model) IAASModel() (*IAASModel, error) {
 
 // IAASModel returns an Infrastructure-As-A-Service (IAAS) model.
 //
-// TODO(menn0): This is a convenience helper only and will go away
+// TODO(caas): This is a convenience helper only and will go away
 // once most model related functionality has been moved from State to
 // Model/IAASModel. Model.IAASModel() should be preferred where-ever
 // possible.

--- a/state/model.go
+++ b/state/model.go
@@ -328,12 +328,14 @@ func (st *State) NewModel(args ModelArgs) (_ *Model, _ *State, err error) {
 	if err := args.Validate(); err != nil {
 		return nil, nil, errors.Trace(err)
 	}
-	// For now, the model cloud must be the same as the controller cloud.
+
 	controllerInfo, err := st.ControllerInfo()
 	if err != nil {
 		return nil, nil, errors.Trace(err)
 	}
-	if controllerInfo.CloudName != args.CloudName {
+
+	// For IAAS Models, the model cloud must be the same as the controller cloud.
+	if args.Type == ModelTypeIAAS && controllerInfo.CloudName != args.CloudName {
 		return nil, nil, errors.NewNotValid(
 			nil, fmt.Sprintf("controller cloud %s does not match model cloud %s", controllerInfo.CloudName, args.CloudName))
 	}


### PR DESCRIPTION
Adds the ability to create a new model in a CAAS cloud that has been
registered to an existing controller.

Creates a minimal model config, does not currently use existing
modelmanager modelconfigcreator, which has some IAAS-specific parts.

Adds CloudIsCAAS function to the cloud package to have one location to
determine if a cloud is a CAAS cloud type based on the type string
(which may be e.g. "kubernetes" or "dcos" etc)

Changes NewModel to not require CAAS model clouds to match the
controller's cloud, because the controller will be on an IAAS cloud in
the initial version of CAAS support. Eventually we may bootstrap a
controller onto the CAAS cloud itself.

Changes some TODOs which reference (unfortunately) former contributors.


## QA steps
If you've added a CAAS cloud with `JUJU_DEV_FEATURE_FLAGS=caas,cross-model,developer-mode juju --debug add-caas kubernetes myk8scloud`

then this will add a model to that cloud:
```
JUJU_DEV_FEATURE_FLAGS=caas,cross-model,developer-mode juju --debug add-model caastester myk8scloud
```
verify that it's there with `juju models`.

## Documentation changes

Will require doc changes to "add-model" command once we remove the feature flag.