### PR TITLE
Honor existing machine definitions during bundle deploy

### DIFF
--- a/cmd/juju/application/bundle.go
+++ b/cmd/juju/application/bundle.go
@@ -472,7 +472,7 @@ func (h *bundleHandler) addMachine(id string, p bundlechanges.AddMachineParams) 
 	for _, application := range services {
 		for _, toMach := range h.data.Applications[application].To {
 			if targetMach, ok := machinesMap[toMach]; ok {
-				if ! machinesProvided[targetMach] {
+				if !machinesProvided[targetMach] {
 					h.results[id] = targetMach
 					machinesProvided[targetMach] = true
 					msg = application

--- a/cmd/juju/application/bundle.go
+++ b/cmd/juju/application/bundle.go
@@ -468,6 +468,20 @@ func (h *bundleHandler) addMachine(id string, p bundlechanges.AddMachineParams) 
 		h.log.Infof("avoid creating other machines to host %s units", msg)
 		return nil
 	}
+	// Check if machine mapping was provided for services
+	for _, application := range services {
+		for _, toMach := range h.data.Applications[application].To {
+			if targetMach, ok := machinesMap[toMach]; ok {
+				if ! machinesProvided[targetMach] {
+					h.results[id] = targetMach
+					machinesProvided[targetMach] = true
+					msg = application
+					h.log.Infof("Assigned existing (pre-created) machine: %s to host: %s units", targetMach, msg)
+					return nil
+				}
+			}
+		}
+	}
 	cons, err := constraints.Parse(p.Constraints)
 	if err != nil {
 		// This should never happen, as the bundle is already verified.

--- a/cmd/juju/application/deploy.go
+++ b/cmd/juju/application/deploy.go
@@ -756,7 +756,7 @@ func (c *DeployCommand) parseMachines() error {
 			return errors.New(parseMachinesErrorPrefix + "Found multiple = in binding. Did you forget to space-separate the binding list?")
 		}
 		mapping[lmachine] = tmachine
-       }
+	}
 	machinesMap = mapping
 	machinesProvided = make(map[string]bool)
 	return nil


### PR DESCRIPTION
This is a patch from https://launchpad.net/~radw, https://bugs.launchpad.net/juju-core/+bug/1567169/comments/15

This patch has limitation, only works when bundle is specified as a file. I
managed to install Canonical Kubernetes Distribution bundle on pre-created
machines using Manual cloud. I hope it will be useful for other cases as well.

I'm creating a PR here for discussion and possible inclusion of this feature in
a upcoming Juju release.

Thanks!

Signed-off-by: Adam Stokes <battlemidget@users.noreply.github.com>

## Please provide the following details to expedite Pull Request review:

----

## Description of change

Why is this change needed?

Adds support for reusing existing machines when juju deploy bundle

## QA steps

How do we verify that the change works?
juju deploy somebundle.yaml --machines "0=0 1=1 2=2"

## Documentation changes

Does it affect current user workflow? CLI? API?
This will add an additional cli argument

## Bug reference

Does this change fix a bug? Please add a link to it.
https://bugs.launchpad.net/juju-core/+bug/1567169
