### PR TITLE
Check firewall rules when updating cmr network ingress

### DIFF
--- a/api/firewaller/firewaller.go
+++ b/api/firewaller/firewaller.go
@@ -13,6 +13,7 @@ import (
 	"github.com/juju/juju/api/common/cloudspec"
 	apiwatcher "github.com/juju/juju/api/watcher"
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/core/relation"
 	"github.com/juju/juju/watcher"
 	"gopkg.in/macaroon.v1"
 )
@@ -221,4 +222,19 @@ func (c *Client) MacaroonForRelation(relationKey string) (*macaroon.Macaroon, er
 		return nil, result.Error
 	}
 	return result.Result, nil
+}
+
+// SetRelationStatus sets the status for a given relation.
+func (c *Client) SetRelationStatus(relationKey string, status relation.Status, message string) error {
+	relationTag := names.NewRelationTag(relationKey)
+	args := params.SetStatus{Entities: []params.EntityStatusArgs{
+		{Tag: relationTag.String(), Status: status.String(), Info: message},
+	}}
+
+	var results params.ErrorResults
+	err := c.facade.FacadeCall("SetRelationsStatus", args, &results)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	return results.OneError()
 }

--- a/apiserver/common/crossmodel/crossmodel.go
+++ b/apiserver/common/crossmodel/crossmodel.go
@@ -5,12 +5,14 @@ package crossmodel
 
 import (
 	"fmt"
+	"net"
 
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/network"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/status"
 )
@@ -201,8 +203,69 @@ func PublishIngressNetworkChange(backend Backend, relationTag names.Tag, change 
 	}
 
 	logger.Debugf("relation %v requires ingress networks %v", rel, change.Networks)
+	if err := validateIngressNetworks(backend, change.Networks); err != nil {
+		return errors.Trace(err)
+	}
+
 	_, err = backend.SaveIngressNetworks(rel.Tag().Id(), change.Networks)
 	return err
+}
+
+func validateIngressNetworks(backend Backend, networks []string) error {
+	if len(networks) == 0 {
+		return nil
+	}
+
+	// Check that the required ingress is allowed.
+	rule, err := backend.FirewallRule(state.JujuApplicationOfferRule)
+	if err != nil && !errors.IsNotFound(err) {
+		return errors.Trace(err)
+	}
+	if errors.IsNotFound(err) {
+		return nil
+	}
+	var whitelistCIDRs, blacklistCIDRs, requestedCIDRs []*net.IPNet
+	if err := parseCIDRs(&whitelistCIDRs, rule.WhitelistCIDRs); err != nil {
+		return errors.Trace(err)
+	}
+	if err := parseCIDRs(&blacklistCIDRs, rule.BlacklistCIDRs); err != nil {
+		return errors.Trace(err)
+	}
+	if err := parseCIDRs(&requestedCIDRs, networks); err != nil {
+		return errors.Trace(err)
+	}
+	if len(whitelistCIDRs) > 0 {
+		for _, n := range requestedCIDRs {
+			if !network.SubnetInAnyRange(whitelistCIDRs, n) {
+				return &params.Error{
+					Code:    params.CodeForbidden,
+					Message: fmt.Sprintf("subnet %v not in firewall whitelist", n),
+				}
+			}
+		}
+	}
+	if len(blacklistCIDRs) > 0 {
+		for _, n := range requestedCIDRs {
+			if network.SubnetInAnyRange(whitelistCIDRs, n) {
+				return &params.Error{
+					Code:    params.CodeForbidden,
+					Message: fmt.Sprintf("subnet %v in firewall blacklist", n),
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func parseCIDRs(cidrs *[]*net.IPNet, values []string) error {
+	for _, cidrStr := range values {
+		if _, ipNet, err := net.ParseCIDR(cidrStr); err != nil {
+			return err
+		} else {
+			*cidrs = append(*cidrs, ipNet)
+		}
+	}
+	return nil
 }
 
 type relationGetter interface {

--- a/apiserver/common/crossmodel/interface.go
+++ b/apiserver/common/crossmodel/interface.go
@@ -74,6 +74,9 @@ type Backend interface {
 
 	// ApplicationOfferForUUID returns the application offer for the UUID.
 	ApplicationOfferForUUID(offerUUID string) (*crossmodel.ApplicationOffer, error)
+
+	// FirewallRule returns the firewall rule for the specified service.
+	FirewallRule(service state.WellKnownServiceType) (*state.FirewallRule, error)
 }
 
 // Relation provides access a relation in global state.

--- a/apiserver/common/crossmodel/state.go
+++ b/apiserver/common/crossmodel/state.go
@@ -154,6 +154,11 @@ func (s stateShim) IngressNetworks(relationKey string) (state.RelationNetworks, 
 	return api.Networks(relationKey)
 }
 
+func (s stateShim) FirewallRule(service state.WellKnownServiceType) (*state.FirewallRule, error) {
+	api := state.NewFirewallRules(s.State)
+	return api.Rule(service)
+}
+
 type relationShim struct {
 	*state.Relation
 	st *state.State

--- a/apiserver/common/firewall/state.go
+++ b/apiserver/common/firewall/state.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/state"
+	"github.com/juju/juju/status"
 )
 
 // State provides the subset of global state required by the
@@ -45,6 +46,7 @@ func (st stateShim) KeyRelation(key string) (Relation, error) {
 }
 
 type Relation interface {
+	status.StatusSetter
 	Endpoints() []state.Endpoint
 	WatchUnits(applicationName string) (state.RelationUnitsWatcher, error)
 	UnitInScope(Unit) (bool, error)

--- a/apiserver/facades/controller/crossmodelrelations/mock_test.go
+++ b/apiserver/facades/controller/crossmodelrelations/mock_test.go
@@ -47,6 +47,8 @@ type mockState struct {
 	offerConnections      map[int]*mockOfferConnection
 	offerConnectionsByKey map[string]*mockOfferConnection
 	remoteEntities        map[names.Tag]string
+	firewallRules         map[state.WellKnownServiceType]*state.FirewallRule
+	ingressNetworks       map[string][]string
 }
 
 func newMockState() *mockState {
@@ -57,6 +59,8 @@ func newMockState() *mockState {
 		remoteEntities:        make(map[names.Tag]string),
 		offerConnections:      make(map[int]*mockOfferConnection),
 		offerConnectionsByKey: make(map[string]*mockOfferConnection),
+		firewallRules:         make(map[state.WellKnownServiceType]*state.FirewallRule),
+		ingressNetworks:       make(map[string][]string),
 	}
 }
 
@@ -102,6 +106,18 @@ func (st *mockState) AddOfferConnection(arg state.AddOfferConnectionParams) (cro
 	st.offerConnections[arg.RelationId] = oc
 	st.offerConnectionsByKey[arg.RelationKey] = oc
 	return oc, nil
+}
+
+func (st *mockState) FirewallRule(service state.WellKnownServiceType) (*state.FirewallRule, error) {
+	if r, ok := st.firewallRules[service]; ok {
+		return r, nil
+	}
+	return nil, errors.NotFoundf("firewall rule for %v", service)
+}
+
+func (st *mockState) SaveIngressNetworks(relationKey string, cidrs []string) (state.RelationNetworks, error) {
+	st.ingressNetworks[relationKey] = cidrs
+	return nil, nil
 }
 
 func (st *mockState) OfferConnectionForRelation(relationKey string) (crossmodelrelations.OfferConnection, error) {

--- a/apiserver/facades/controller/firewaller/firewaller_unit_test.go
+++ b/apiserver/facades/controller/firewaller/firewaller_unit_test.go
@@ -16,6 +16,7 @@ import (
 	apiservertesting "github.com/juju/juju/apiserver/testing"
 	"github.com/juju/juju/core/crossmodel"
 	"github.com/juju/juju/state"
+	"github.com/juju/juju/status"
 	coretesting "github.com/juju/juju/testing"
 )
 
@@ -103,4 +104,20 @@ func (s *RemoteFirewallerSuite) TestMacaroonForRelations(c *gc.C) {
 	c.Assert(result.Results, gc.HasLen, 1)
 	c.Assert(result.Results[0].Error, gc.IsNil)
 	c.Assert(result.Results[0].Result, jc.DeepEquals, mac)
+}
+
+func (s *RemoteFirewallerSuite) TestSetRelationStatus(c *gc.C) {
+	db2Relation := newMockRelation(123)
+	s.st.relations["remote-db2:db django:db"] = db2Relation
+	entity := names.NewRelationTag("remote-db2:db django:db")
+	result, err := s.api.SetRelationsStatus(
+		params.SetStatus{Entities: []params.EntityStatusArgs{{
+			Tag:    entity.String(),
+			Status: "suspended",
+			Info:   "a message",
+		}}})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result.Results, gc.HasLen, 1)
+	c.Assert(result.Results[0].Error, gc.IsNil)
+	c.Assert(db2Relation.status, jc.DeepEquals, status.StatusInfo{Status: status.Suspended, Message: "a message"})
 }

--- a/apiserver/facades/controller/firewaller/mock_test.go
+++ b/apiserver/facades/controller/firewaller/mock_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/state"
+	"github.com/juju/juju/status"
 	coretesting "github.com/juju/juju/testing"
 )
 
@@ -206,6 +207,7 @@ type mockRelation struct {
 	ruw       *mockRelationUnitsWatcher
 	ruwApp    string
 	inScope   set.Strings
+	status    status.StatusInfo
 }
 
 func newMockRelation(id int) *mockRelation {
@@ -225,6 +227,11 @@ func (r *mockRelation) WatchRelationIngressNetworks() state.StringsWatcher {
 	w := newMockStringsWatcher()
 	w.changes <- []string{"1.2.3.4/32"}
 	return w
+}
+
+func (r *mockRelation) SetStatus(info status.StatusInfo) error {
+	r.status = info
+	return nil
 }
 
 func newMockRelationUnitsWatcher() *mockRelationUnitsWatcher {

--- a/apiserver/params/apierror.go
+++ b/apiserver/params/apierror.go
@@ -259,3 +259,7 @@ func IsRedirect(err error) bool {
 func IsCodeIncompatibleSeries(err error) bool {
 	return ErrCode(err) == CodeIncompatibleSeries
 }
+
+func IsCodeForbidden(err error) bool {
+	return ErrCode(err) == CodeForbidden
+}

--- a/cmd/juju/status/output_tabular.go
+++ b/cmd/juju/status/output_tabular.go
@@ -199,15 +199,13 @@ func FormatTabular(writer io.Writer, forceColor bool, value interface{}) error {
 		})
 		outputHeaders("Relation provider", "Requirer", "Interface", "Type", "Message")
 		for _, r := range fs.Relations {
-			statusMessage := ""
+			w.Print(r.Provider, r.Requirer, r.Interface, r.Type)
 			if r.Status != string(relation.Joined) {
-				statusMessage = r.Status
+				w.PrintColor(cmdcrossmodel.RelationStatusColor(relation.Status(r.Status)), r.Status)
 				if r.Message != "" {
-					statusMessage = statusMessage + " - " + r.Message
+					w.Print(" - " + r.Message)
 				}
 			}
-			w.Print(r.Provider, r.Requirer, r.Interface, r.Type)
-			w.PrintColor(cmdcrossmodel.RelationStatusColor(relation.Status(r.Status)), statusMessage)
 			w.Println()
 		}
 	}

--- a/cmd/juju/status/status_test.go
+++ b/cmd/juju/status/status_test.go
@@ -4113,9 +4113,9 @@ Offer         Application  Charm  Rev  Connected  Endpoint  Interface  Role
 hosted-mysql  mysql        mysql  1    1          server    mysql      provider
 
 Relation provider      Requirer                   Interface  Type         Message
-mysql:juju-info        logging:info               juju-info  subordinate             
+mysql:juju-info        logging:info               juju-info  subordinate  
 mysql:server           wordpress:db               mysql      regular      suspended  
-wordpress:logging-dir  logging:logging-directory  logging    subordinate             
+wordpress:logging-dir  logging:logging-directory  logging    subordinate  
 
 `[1:]
 	c.Assert(string(stdout), gc.Equals, expected)

--- a/core/relation/status.go
+++ b/core/relation/status.go
@@ -6,6 +6,10 @@ package relation
 // Status describes the status of a relation.
 type Status string
 
+func (s Status) String() string {
+	return string(s)
+}
+
 const (
 	// Joined is the normal status for a healthy, alive relation.
 	Joined Status = "joined"

--- a/network/network.go
+++ b/network/network.go
@@ -576,3 +576,31 @@ func QuoteSpaces(vals []string) string {
 func QuoteSpaceSet(vals set.Strings) string {
 	return QuoteSpaces(vals.SortedValues())
 }
+
+// firstLastAddresses returns the first and last addresses of the subnet.
+func firstLastAddresses(subnet *net.IPNet) (net.IP, net.IP) {
+	firstIP := subnet.IP
+	lastIP := make([]byte, len(firstIP))
+	copy(lastIP, firstIP)
+
+	for i, b := range lastIP {
+		lastIP[i] = b ^ (^subnet.Mask[i])
+	}
+	return firstIP, lastIP
+}
+
+func cidrContains(cidr *net.IPNet, subnet *net.IPNet) bool {
+	first, last := firstLastAddresses(subnet)
+	return cidr.Contains(first) && cidr.Contains(last)
+}
+
+// SubnetInAnyRange returns true if the subnet's address range is fully
+// contained in any of the specified subnet blocks.
+func SubnetInAnyRange(cidrs []*net.IPNet, subnet *net.IPNet) bool {
+	for _, cidr := range cidrs {
+		if cidrContains(cidr, subnet) {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Description of change

The firewaller facade will now check whether the requested ingress satisfies any defined firewall rules in the offering model. If there's an issue, the consuming side will set an error status on the relation. The ingress check will fail if:
- any of the requested ingress subnets are inside the blacklist subnets
- all of the requested ingress subnets are not inside the whitelist subnets

## QA steps

Deploy mysql, make offer
$ juju set-firewall-rule juju-application-offer --whitelist 1.2.3.4/32

On consuming model, deploy mediawiki and attempt to relate
$ juju relate mediawiki:db somemodel.mysql

Check that status shows the mediawiki-mysql relation is in error with a firewall message
