### PR TITLE
migration: Don't create invalid relation scopes for subordinates on import

### DIFF
--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -21,7 +21,7 @@ github.com/juju/ansiterm	git	b99631de12cf04a906c1d4e4ec54fb86eae5863d	2016-09-07
 github.com/juju/blobstore	git	06056004b3d7b54bbb7984d830c537bad00fec21	2015-07-29T11:18:58Z
 github.com/juju/bundlechanges	git	cd189848b313df50084de692b05861210022cf81	2017-08-02T17:04:42Z
 github.com/juju/cmd	git	e47739aefe0adb68a401fcd371c0c92c8f6f8d99	2017-04-13T02:13:06Z
-github.com/juju/description	git	264ae46133b5a24cfc4f55717d4ed83bb2983b8f	2017-08-09T23:16:08Z
+github.com/juju/description	git	e2e5223696c2e296106798228dd595cbeb33ff82	2017-09-10T23:35:04Z
 github.com/juju/errors	git	1b5e39b83d1835fa480e0c2ddefb040ee82d58b3	2015-09-16T12:56:42Z
 github.com/juju/gnuflag	git	4e76c56581859c14d9d87e1ddbe29e1c0f10195f	2016-08-09T16:52:14Z
 github.com/juju/go-oracle-cloud	git	932a8cea00a1cd5cba3829a672c823955db674ae	2017-04-21T13:45:47Z

--- a/state/migration_export.go
+++ b/state/migration_export.go
@@ -1506,7 +1506,7 @@ func (e *exporter) addRemoteApplication(app *RemoteApplication) error {
 	url, _ := app.URL()
 	args := description.RemoteApplicationArgs{
 		Tag:             app.Tag().(names.ApplicationTag),
-		OfferName:       app.OfferName(),
+		OfferUUID:       app.OfferName(),
 		URL:             url,
 		SourceModel:     app.SourceModel(),
 		IsConsumerProxy: app.IsConsumerProxy(),
@@ -1527,8 +1527,6 @@ func (e *exporter) addRemoteApplication(app *RemoteApplication) error {
 			Name:      ep.Name,
 			Role:      string(ep.Role),
 			Interface: ep.Interface,
-			Limit:     ep.Limit,
-			Scope:     string(ep.Scope),
 		})
 	}
 	for _, space := range app.Spaces() {

--- a/state/migration_export_test.go
+++ b/state/migration_export_test.go
@@ -1401,7 +1401,7 @@ func (s *MigrationExportSuite) TestRemoteApplications(c *gc.C) {
 	app := model.RemoteApplications()[0]
 	c.Check(app.Tag(), gc.Equals, names.NewApplicationTag("gravy-rainbow"))
 	c.Check(app.Name(), gc.Equals, "gravy-rainbow")
-	c.Check(app.OfferName(), gc.Equals, "")
+	c.Check(app.OfferUUID(), gc.Equals, "")
 	c.Check(app.URL(), gc.Equals, "me/model.rainbow")
 	c.Check(app.SourceModelTag(), gc.Equals, s.State.ModelTag())
 	c.Check(app.IsConsumerProxy(), jc.IsFalse)
@@ -1415,21 +1415,15 @@ func (s *MigrationExportSuite) TestRemoteApplications(c *gc.C) {
 	ep := app.Endpoints()[0]
 	c.Check(ep.Name(), gc.Equals, "db")
 	c.Check(ep.Interface(), gc.Equals, "mysql")
-	c.Check(ep.Limit(), gc.Equals, 0)
 	c.Check(ep.Role(), gc.Equals, "provider")
-	c.Check(ep.Scope(), gc.Equals, "global")
 	ep = app.Endpoints()[1]
 	c.Check(ep.Name(), gc.Equals, "db-admin")
 	c.Check(ep.Interface(), gc.Equals, "mysql-root")
-	c.Check(ep.Limit(), gc.Equals, 5)
 	c.Check(ep.Role(), gc.Equals, "provider")
-	c.Check(ep.Scope(), gc.Equals, "global")
 	ep = app.Endpoints()[2]
 	c.Check(ep.Name(), gc.Equals, "logging")
 	c.Check(ep.Interface(), gc.Equals, "logging")
-	c.Check(ep.Limit(), gc.Equals, 0)
 	c.Check(ep.Role(), gc.Equals, "provider")
-	c.Check(ep.Scope(), gc.Equals, "global")
 
 	originalSpaces := dbApp.Spaces()
 	actualSpaces := app.Spaces()

--- a/state/migration_import.go
+++ b/state/migration_import.go
@@ -225,8 +225,8 @@ type importer struct {
 	model   description.Model
 	logger  loggo.Logger
 	// applicationUnits is populated at the end of loading the applications, and is a
-	// map of application name to units of that application.
-	applicationUnits map[string][]*Unit
+	// map of application name to the units of that application.
+	applicationUnits map[string]map[string]*Unit
 }
 
 func (i *importer) modelExtras() error {
@@ -693,10 +693,14 @@ func (i *importer) loadUnits() error {
 		return errors.Annotate(err, "cannot get all units")
 	}
 
-	result := make(map[string][]*Unit)
+	result := make(map[string]map[string]*Unit)
 	for _, doc := range docs {
-		units := result[doc.Application]
-		result[doc.Application] = append(units, newUnit(i.st, &doc))
+		units, found := result[doc.Application]
+		if !found {
+			units = make(map[string]*Unit)
+			result[doc.Application] = units
+		}
+		units[doc.Name] = newUnit(i.st, &doc)
 	}
 	i.applicationUnits = result
 	return nil
@@ -1089,7 +1093,11 @@ func (i *importer) relation(rel description.Relation) error {
 	// for each unit.
 	for _, endpoint := range rel.Endpoints() {
 		units := i.applicationUnits[endpoint.ApplicationName()]
-		for _, unit := range units {
+		for unitName, settings := range endpoint.AllSettings() {
+			unit, ok := units[unitName]
+			if !ok {
+				return errors.NotFoundf("unit %q", unitName)
+			}
 			ru, err := dbRelation.Unit(unit)
 			if err != nil {
 				return errors.Trace(err)
@@ -1103,7 +1111,7 @@ func (i *importer) relation(rel description.Relation) error {
 					Key: ruKey,
 				},
 			},
-				createSettingsOp(settingsC, ruKey, endpoint.Settings(unit.Name())),
+				createSettingsOp(settingsC, ruKey, settings),
 			)
 		}
 	}

--- a/state/migration_import_test.go
+++ b/state/migration_import_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils"
+	"github.com/juju/utils/arch"
 	"github.com/juju/version"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/charm.v6-unstable"
@@ -28,6 +29,7 @@ import (
 	"github.com/juju/juju/storage/provider"
 	coretesting "github.com/juju/juju/testing"
 	"github.com/juju/juju/testing/factory"
+	jujuversion "github.com/juju/juju/version"
 )
 
 type MigrationImportSuite struct {
@@ -1378,6 +1380,103 @@ func (s *MigrationImportSuite) TestApplicationsWithNilConfigValues(c *gc.C) {
 	importedSettings := state.GetApplicationSettings(newSt, importedApplication)
 	_, importedFound := importedSettings.Get("foo")
 	c.Assert(importedFound, jc.IsFalse)
+}
+
+func (s *MigrationImportSuite) TestOneSubordinateTwoGuvnors(c *gc.C) {
+	// Check that invalid relationscopes aren't created when importing
+	// a subordinate related to 2 principals.
+	wordpress := state.AddTestingService(c, s.State, "wordpress", state.AddTestingCharm(c, s.State, "wordpress"))
+	mysql := state.AddTestingService(c, s.State, "mysql", state.AddTestingCharm(c, s.State, "mysql"))
+	wordpress0 := s.Factory.MakeUnit(c, &factory.UnitParams{Application: wordpress})
+	mysql0 := s.Factory.MakeUnit(c, &factory.UnitParams{Application: mysql})
+
+	logging := s.AddTestingService(c, "logging", s.AddTestingCharm(c, "logging"))
+
+	addSubordinate := func(app *state.Application, unit *state.Unit) string {
+		eps, err := s.State.InferEndpoints(app.Name(), logging.Name())
+		c.Assert(err, jc.ErrorIsNil)
+		rel, err := s.State.AddRelation(eps...)
+		c.Assert(err, jc.ErrorIsNil)
+		pru, err := rel.Unit(unit)
+		c.Assert(err, jc.ErrorIsNil)
+		err = pru.EnterScope(nil)
+		c.Assert(err, jc.ErrorIsNil)
+		// Need to reload the doc to get the subordinates.
+		err = unit.Refresh()
+		c.Assert(err, jc.ErrorIsNil)
+		subordinates := unit.SubordinateNames()
+		c.Assert(subordinates, gc.HasLen, 1)
+		loggingUnit, err := s.State.Unit(subordinates[0])
+		c.Assert(err, jc.ErrorIsNil)
+		sub, err := rel.Unit(loggingUnit)
+		c.Assert(err, jc.ErrorIsNil)
+		err = sub.EnterScope(nil)
+		c.Assert(err, jc.ErrorIsNil)
+		return rel.String()
+	}
+
+	logMysqlKey := addSubordinate(mysql, mysql0)
+	logWpKey := addSubordinate(wordpress, wordpress0)
+
+	units, err := logging.AllUnits()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(units, gc.HasLen, 2)
+
+	for _, unit := range units {
+		app, err := unit.Application()
+		c.Assert(err, jc.ErrorIsNil)
+		agentTools := version.Binary{
+			Number: jujuversion.Current,
+			Arch:   arch.HostArch(),
+			Series: app.Series(),
+		}
+		err = unit.SetAgentVersion(agentTools)
+		c.Assert(err, jc.ErrorIsNil)
+	}
+
+	_, newSt := s.importModel(c)
+
+	logMysqlRel, err := newSt.KeyRelation(logMysqlKey)
+	c.Assert(err, jc.ErrorIsNil)
+	logWpRel, err := newSt.KeyRelation(logWpKey)
+	c.Assert(err, jc.ErrorIsNil)
+
+	mysqlLogUnit, err := newSt.Unit("logging/0")
+	c.Assert(err, jc.ErrorIsNil)
+	wpLogUnit, err := newSt.Unit("logging/1")
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Sanity checks
+	name, ok := mysqlLogUnit.PrincipalName()
+	c.Assert(ok, jc.IsTrue)
+	c.Assert(name, gc.Equals, "mysql/0")
+
+	name, ok = wpLogUnit.PrincipalName()
+	c.Assert(ok, jc.IsTrue)
+	c.Assert(name, gc.Equals, "wordpress/0")
+
+	checkScope := func(unit *state.Unit, rel *state.Relation, expected bool) {
+		ru, err := rel.Unit(unit)
+		c.Assert(err, jc.ErrorIsNil)
+		// Sanity check
+		valid, err := ru.Valid()
+		c.Assert(err, jc.ErrorIsNil)
+		c.Check(valid, gc.Equals, expected)
+
+		inscope, err := ru.InScope()
+		c.Assert(err, jc.ErrorIsNil)
+		c.Check(inscope, gc.Equals, expected)
+	}
+	// The WP logging unit shouldn't be in scope for the mysql-logging
+	// relation.
+	checkScope(wpLogUnit, logMysqlRel, false)
+	// Similarly, the mysql logging unit shouldn't be in scope for the
+	// wp-logging relation.
+	checkScope(mysqlLogUnit, logWpRel, false)
+
+	// But obviously the units should be in their relations.
+	checkScope(mysqlLogUnit, logMysqlRel, true)
+	checkScope(wpLogUnit, logWpRel, true)
 }
 
 // newModel replaces the uuid and name of the config attributes so we


### PR DESCRIPTION
## Description of change

Importing a model that had correct relation scopes for a subordinate with two principals would create invalid relaton scopes, which would cause problems if/when relations were removed after the import. (See bug below for more detail of problems.)

## QA steps

* Deploy a subordinate related to two principals, eg: 
```
ubuntu/0
  telegraf/0
mysql/0
  telegraf/1
```
* Removing and re-adding each relation (leaving time for the system to settle at each step) - the associated telegraf unit should go away and come back successfully.
* Migrate the model to another controller.
* Remove and re-add each relation as above - the telegraf units should be removed and recreated cleanly.

## Bug reference

Fixes https://bugs.launchpad.net/juju/+bug/1715794
