### PR TITLE
Driveby to get machines in bulk instead of individually for processing

### DIFF
--- a/api/deployer/deployer.go
+++ b/api/deployer/deployer.go
@@ -32,7 +32,7 @@ func NewState(caller base.APICaller) *State {
 
 // unitLife returns the lifecycle state of the given unit.
 func (st *State) unitLife(tag names.UnitTag) (params.Life, error) {
-	return common.Life(st.facade, tag)
+	return common.OneLife(st.facade, tag)
 }
 
 // Unit returns the unit with the given tag.

--- a/api/deployer/unit.go
+++ b/api/deployer/unit.go
@@ -35,7 +35,7 @@ func (u *Unit) Life() params.Life {
 
 // Refresh updates the cached local copy of the unit's data.
 func (u *Unit) Refresh() error {
-	life, err := common.Life(u.st.facade, u.tag)
+	life, err := common.OneLife(u.st.facade, u.tag)
 	if err != nil {
 		return err
 	}

--- a/api/firewaller/firewaller.go
+++ b/api/firewaller/firewaller.go
@@ -54,7 +54,7 @@ func (c *Client) ModelTag() (names.ModelTag, bool) {
 
 // life requests the life cycle of the given entity from the server.
 func (c *Client) life(tag names.Tag) (params.Life, error) {
-	return common.Life(c.facade, tag)
+	return common.OneLife(c.facade, tag)
 }
 
 // Unit provides access to methods of a state.Unit through the facade.

--- a/api/instancepoller/instancepoller.go
+++ b/api/instancepoller/instancepoller.go
@@ -38,7 +38,7 @@ func NewAPI(caller base.APICaller) *API {
 // Machine provides access to methods of a state.Machine through the
 // facade.
 func (api *API) Machine(tag names.MachineTag) (*Machine, error) {
-	life, err := common.Life(api.facade, tag)
+	life, err := common.OneLife(api.facade, tag)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/api/instancepoller/machine.go
+++ b/api/instancepoller/machine.go
@@ -46,7 +46,7 @@ func (m *Machine) Life() params.Life {
 
 // Refresh updates the cached local copy of the machine's data.
 func (m *Machine) Refresh() error {
-	life, err := common.Life(m.facade, m.tag)
+	life, err := common.OneLife(m.facade, m.tag)
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/api/machiner/machiner.go
+++ b/api/machiner/machiner.go
@@ -31,7 +31,7 @@ func NewState(caller base.APICaller) *State {
 
 // machineLife requests the lifecycle of the given machine from the server.
 func (st *State) machineLife(tag names.MachineTag) (params.Life, error) {
-	return common.Life(st.facade, tag)
+	return common.OneLife(st.facade, tag)
 }
 
 // Machine provides access to methods of a state.Machine through the facade.

--- a/api/provisioner/provisioner_test.go
+++ b/api/provisioner/provisioner_test.go
@@ -82,22 +82,30 @@ func (s *provisionerSuite) SetUpTest(c *gc.C) {
 	s.APIAddresserTests = apitesting.NewAPIAddresserTests(s.provisioner, s.BackingState)
 }
 
-func (s *provisionerSuite) TestMachineTagAndId(c *gc.C) {
-	apiMachine, err := s.provisioner.Machine(names.NewMachineTag("42"))
-	c.Assert(err, gc.ErrorMatches, "machine 42 not found")
-	c.Assert(err, jc.Satisfies, params.IsCodeNotFound)
-	c.Assert(apiMachine, gc.IsNil)
-
-	// TODO(dfc) fix this type assertion
-	apiMachine, err = s.provisioner.Machine(s.machine.Tag().(names.MachineTag))
+func (s *provisionerSuite) assertGetOneMachine(c *gc.C, tag names.MachineTag) *provisioner.Machine {
+	result, err := s.provisioner.Machines(tag)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(apiMachine.Tag(), gc.Equals, s.machine.Tag())
-	c.Assert(apiMachine.Id(), gc.Equals, s.machine.Id())
+	c.Assert(len(result), gc.Equals, 1)
+	c.Assert(result[0].Err, gc.IsNil)
+	return result[0].Machine
+}
+
+func (s *provisionerSuite) TestMachinesTagAndId(c *gc.C) {
+	result, err := s.provisioner.Machines(names.NewMachineTag("42"), s.machine.MachineTag())
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(len(result), gc.Equals, 2)
+
+	c.Assert(result[0].Err, gc.ErrorMatches, "machine 42 not found")
+	c.Assert(result[0].Err, jc.Satisfies, params.IsCodeNotFound)
+	c.Assert(result[0].Machine, gc.IsNil)
+
+	c.Assert(result[1].Err, gc.IsNil)
+	c.Assert(result[1].Machine.Tag(), gc.Equals, s.machine.Tag())
+	c.Assert(result[1].Machine.Id(), gc.Equals, s.machine.Id())
 }
 
 func (s *provisionerSuite) TestGetSetStatus(c *gc.C) {
-	apiMachine, err := s.provisioner.Machine(s.machine.Tag().(names.MachineTag))
-	c.Assert(err, jc.ErrorIsNil)
+	apiMachine := s.assertGetOneMachine(c, s.machine.MachineTag())
 
 	machineStatus, info, err := apiMachine.Status()
 	c.Assert(err, jc.ErrorIsNil)
@@ -117,9 +125,7 @@ func (s *provisionerSuite) TestGetSetStatus(c *gc.C) {
 }
 
 func (s *provisionerSuite) TestGetSetInstanceStatus(c *gc.C) {
-	apiMachine, err := s.provisioner.Machine(s.machine.Tag().(names.MachineTag))
-	c.Assert(err, jc.ErrorIsNil)
-
+	apiMachine := s.assertGetOneMachine(c, s.machine.MachineTag())
 	instanceStatus, info, err := apiMachine.InstanceStatus()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(instanceStatus, gc.Equals, status.Pending)
@@ -136,10 +142,8 @@ func (s *provisionerSuite) TestGetSetInstanceStatus(c *gc.C) {
 }
 
 func (s *provisionerSuite) TestGetSetStatusWithData(c *gc.C) {
-	apiMachine, err := s.provisioner.Machine(s.machine.Tag().(names.MachineTag))
-	c.Assert(err, jc.ErrorIsNil)
-
-	err = apiMachine.SetStatus(status.Error, "blah", map[string]interface{}{"foo": "bar"})
+	apiMachine := s.assertGetOneMachine(c, s.machine.MachineTag())
+	err := apiMachine.SetStatus(status.Error, "blah", map[string]interface{}{"foo": "bar"})
 	c.Assert(err, jc.ErrorIsNil)
 
 	machineStatus, info, err := apiMachine.Status()
@@ -163,12 +167,12 @@ func (s *provisionerSuite) TestMachinesWithTransientErrors(c *gc.C) {
 	}
 	err = machine.SetInstanceStatus(sInfo)
 	c.Assert(err, jc.ErrorIsNil)
-	machines, info, err := s.provisioner.MachinesWithTransientErrors()
+	result, err := s.provisioner.MachinesWithTransientErrors()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(machines, gc.HasLen, 1)
-	c.Assert(machines[0].Id(), gc.Equals, "1")
-	c.Assert(info, gc.HasLen, 1)
-	c.Assert(info[0], gc.DeepEquals, params.StatusResult{
+	c.Assert(result, gc.HasLen, 1)
+
+	c.Assert(result[0].Machine.Id(), gc.Equals, "1")
+	c.Assert(result[0].Status, gc.DeepEquals, params.StatusResult{
 		Id:     "1",
 		Life:   "alive",
 		Status: "provisioning error",
@@ -183,7 +187,7 @@ func (s *provisionerSuite) TestEnsureDeadAndRemove(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(otherMachine.Life(), gc.Equals, state.Alive)
 
-	apiMachine, err := s.provisioner.Machine(otherMachine.Tag().(names.MachineTag))
+	apiMachine := s.assertGetOneMachine(c, otherMachine.MachineTag())
 	c.Assert(err, jc.ErrorIsNil)
 
 	err = apiMachine.Remove()
@@ -211,8 +215,7 @@ func (s *provisionerSuite) TestEnsureDeadAndRemove(c *gc.C) {
 	c.Assert(err, jc.Satisfies, params.IsCodeNotFound)
 
 	// Now try to EnsureDead machine 0 - should fail.
-	apiMachine, err = s.provisioner.Machine(s.machine.Tag().(names.MachineTag))
-	c.Assert(err, jc.ErrorIsNil)
+	apiMachine = s.assertGetOneMachine(c, s.machine.MachineTag())
 	err = apiMachine.EnsureDead()
 	c.Assert(err, gc.ErrorMatches, "machine 0 is required by the model")
 }
@@ -221,8 +224,7 @@ func (s *provisionerSuite) TestMarkForRemoval(c *gc.C) {
 	machine, err := s.State.AddMachine("xenial", state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)
 
-	apiMachine, err := s.provisioner.Machine(machine.Tag().(names.MachineTag))
-	c.Assert(err, jc.ErrorIsNil)
+	apiMachine := s.assertGetOneMachine(c, machine.MachineTag())
 
 	err = apiMachine.MarkForRemoval()
 	c.Assert(err, gc.ErrorMatches, "cannot remove machine 1: machine is not dead")
@@ -244,8 +246,7 @@ func (s *provisionerSuite) TestRefreshAndLife(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(otherMachine.Life(), gc.Equals, state.Alive)
 
-	apiMachine, err := s.provisioner.Machine(otherMachine.Tag().(names.MachineTag))
-	c.Assert(err, jc.ErrorIsNil)
+	apiMachine := s.assertGetOneMachine(c, otherMachine.MachineTag())
 	c.Assert(apiMachine.Life(), gc.Equals, params.Alive)
 
 	err = apiMachine.EnsureDead()
@@ -276,8 +277,7 @@ func (s *provisionerSuite) TestSetInstanceInfo(c *gc.C) {
 	notProvisionedMachine, err := s.State.AddOneMachine(template)
 	c.Assert(err, jc.ErrorIsNil)
 
-	apiMachine, err := s.provisioner.Machine(notProvisionedMachine.Tag().(names.MachineTag))
-	c.Assert(err, jc.ErrorIsNil)
+	apiMachine := s.assertGetOneMachine(c, notProvisionedMachine.MachineTag())
 
 	instanceId, err := apiMachine.InstanceId()
 	c.Assert(err, jc.Satisfies, params.IsCodeNotProvisioned)
@@ -313,8 +313,7 @@ func (s *provisionerSuite) TestSetInstanceInfo(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, `cannot record provisioning info for "i-wont": cannot set instance data for machine "1": already set`)
 
 	// Now try to get machine 0's instance id.
-	apiMachine, err = s.provisioner.Machine(s.machine.Tag().(names.MachineTag))
-	c.Assert(err, jc.ErrorIsNil)
+	apiMachine = s.assertGetOneMachine(c, s.machine.MachineTag())
 	instanceId, err = apiMachine.InstanceId()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(instanceId, gc.Equals, instance.Id("i-manager"))
@@ -344,15 +343,13 @@ func (s *provisionerSuite) TestSeries(c *gc.C) {
 	foobarMachine, err := s.State.AddMachine("foobar", state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)
 
-	apiMachine, err := s.provisioner.Machine(foobarMachine.Tag().(names.MachineTag))
-	c.Assert(err, jc.ErrorIsNil)
+	apiMachine := s.assertGetOneMachine(c, foobarMachine.MachineTag())
 	series, err := apiMachine.Series()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(series, gc.Equals, "foobar")
 
 	// Now try machine 0.
-	apiMachine, err = s.provisioner.Machine(s.machine.Tag().(names.MachineTag))
-	c.Assert(err, jc.ErrorIsNil)
+	apiMachine = s.assertGetOneMachine(c, s.machine.MachineTag())
 	series, err = apiMachine.Series()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(series, gc.Equals, "quantal")
@@ -367,8 +364,7 @@ func (s *provisionerSuite) TestAvailabilityZone(c *gc.C) {
 	notProvisionedMachine, err := s.State.AddOneMachine(template)
 	c.Assert(err, jc.ErrorIsNil)
 
-	apiMachine, err := s.provisioner.Machine(notProvisionedMachine.Tag().(names.MachineTag))
-	c.Assert(err, jc.ErrorIsNil)
+	apiMachine := s.assertGetOneMachine(c, notProvisionedMachine.MachineTag())
 
 	instanceId, err := apiMachine.InstanceId()
 	c.Assert(err, jc.Satisfies, params.IsCodeNotProvisioned)
@@ -391,24 +387,21 @@ func (s *provisionerSuite) TestAvailabilityZone(c *gc.C) {
 func (s *provisionerSuite) TestKeepInstance(c *gc.C) {
 	err := s.machine.SetKeepInstance(true)
 	c.Assert(err, jc.ErrorIsNil)
-	apiMachine, err := s.provisioner.Machine(s.machine.Tag().(names.MachineTag))
-	c.Assert(err, jc.ErrorIsNil)
+	apiMachine := s.assertGetOneMachine(c, s.machine.MachineTag())
 	keep, err := apiMachine.KeepInstance()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(keep, jc.IsTrue)
 }
 
 func (s *provisionerSuite) TestDistributionGroup(c *gc.C) {
-	apiMachine, err := s.provisioner.Machine(s.machine.Tag().(names.MachineTag))
-	c.Assert(err, jc.ErrorIsNil)
+	apiMachine := s.assertGetOneMachine(c, s.machine.MachineTag())
 	instances, err := apiMachine.DistributionGroup()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(instances, gc.DeepEquals, []instance.Id{"i-manager"})
 
 	machine1, err := s.State.AddMachine("quantal", state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)
-	apiMachine, err = s.provisioner.Machine(machine1.Tag().(names.MachineTag))
-	c.Assert(err, jc.ErrorIsNil)
+	apiMachine = s.assertGetOneMachine(c, machine1.MachineTag())
 	wordpress := s.AddTestingApplication(c, "wordpress", s.AddTestingCharm(c, "wordpress"))
 
 	err = apiMachine.SetInstanceInfo("i-d", "fake", nil, nil, nil, nil)
@@ -433,8 +426,7 @@ func (s *provisionerSuite) TestDistributionGroup(c *gc.C) {
 func (s *provisionerSuite) TestDistributionGroupMachineNotFound(c *gc.C) {
 	stateMachine, err := s.State.AddMachine("quantal", state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)
-	apiMachine, err := s.provisioner.Machine(stateMachine.Tag().(names.MachineTag))
-	c.Assert(err, jc.ErrorIsNil)
+	apiMachine := s.assertGetOneMachine(c, stateMachine.MachineTag())
 	err = apiMachine.EnsureDead()
 	c.Assert(err, jc.ErrorIsNil)
 	err = apiMachine.Remove()
@@ -468,8 +460,7 @@ func (s *provisionerSuite) TestProvisioningInfo(c *gc.C) {
 	}
 	machine, err := s.State.AddOneMachine(template)
 	c.Assert(err, jc.ErrorIsNil)
-	apiMachine, err := s.provisioner.Machine(machine.Tag().(names.MachineTag))
-	c.Assert(err, jc.ErrorIsNil)
+	apiMachine := s.assertGetOneMachine(c, machine.MachineTag())
 	provisioningInfo, err := apiMachine.ProvisioningInfo()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(provisioningInfo.Series, gc.Equals, template.Series)
@@ -484,8 +475,7 @@ func (s *provisionerSuite) TestProvisioningInfo(c *gc.C) {
 func (s *provisionerSuite) TestProvisioningInfoMachineNotFound(c *gc.C) {
 	stateMachine, err := s.State.AddMachine("quantal", state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)
-	apiMachine, err := s.provisioner.Machine(stateMachine.Tag().(names.MachineTag))
-	c.Assert(err, jc.ErrorIsNil)
+	apiMachine := s.assertGetOneMachine(c, stateMachine.MachineTag())
 	err = apiMachine.EnsureDead()
 	c.Assert(err, jc.ErrorIsNil)
 	err = apiMachine.Remove()
@@ -497,8 +487,7 @@ func (s *provisionerSuite) TestProvisioningInfoMachineNotFound(c *gc.C) {
 }
 
 func (s *provisionerSuite) TestWatchContainers(c *gc.C) {
-	apiMachine, err := s.provisioner.Machine(s.machine.Tag().(names.MachineTag))
-	c.Assert(err, jc.ErrorIsNil)
+	apiMachine := s.assertGetOneMachine(c, s.machine.MachineTag())
 
 	// Add one LXD container.
 	template := state.MachineTemplate{
@@ -534,8 +523,7 @@ func (s *provisionerSuite) TestWatchContainers(c *gc.C) {
 }
 
 func (s *provisionerSuite) TestWatchContainersAcceptsSupportedContainers(c *gc.C) {
-	apiMachine, err := s.provisioner.Machine(s.machine.Tag().(names.MachineTag))
-	c.Assert(err, jc.ErrorIsNil)
+	apiMachine := s.assertGetOneMachine(c, s.machine.MachineTag())
 
 	for _, ctype := range instance.ContainerTypes {
 		w, err := apiMachine.WatchContainers(ctype)
@@ -545,10 +533,9 @@ func (s *provisionerSuite) TestWatchContainersAcceptsSupportedContainers(c *gc.C
 }
 
 func (s *provisionerSuite) TestWatchContainersErrors(c *gc.C) {
-	apiMachine, err := s.provisioner.Machine(s.machine.Tag().(names.MachineTag))
-	c.Assert(err, jc.ErrorIsNil)
+	apiMachine := s.assertGetOneMachine(c, s.machine.MachineTag())
 
-	_, err = apiMachine.WatchContainers(instance.NONE)
+	_, err := apiMachine.WatchContainers(instance.NONE)
 	c.Assert(err, gc.ErrorMatches, `unsupported container type "none"`)
 
 	_, err = apiMachine.WatchContainers("")
@@ -630,9 +617,8 @@ func (s *provisionerSuite) TestContainerConfig(c *gc.C) {
 }
 
 func (s *provisionerSuite) TestSetSupportedContainers(c *gc.C) {
-	apiMachine, err := s.provisioner.Machine(s.machine.Tag().(names.MachineTag))
-	c.Assert(err, jc.ErrorIsNil)
-	err = apiMachine.SetSupportedContainers(instance.LXD, instance.KVM)
+	apiMachine := s.assertGetOneMachine(c, s.machine.MachineTag())
+	err := apiMachine.SetSupportedContainers(instance.LXD, instance.KVM)
 	c.Assert(err, jc.ErrorIsNil)
 
 	err = s.machine.Refresh()
@@ -643,9 +629,8 @@ func (s *provisionerSuite) TestSetSupportedContainers(c *gc.C) {
 }
 
 func (s *provisionerSuite) TestSupportsNoContainers(c *gc.C) {
-	apiMachine, err := s.provisioner.Machine(s.machine.Tag().(names.MachineTag))
-	c.Assert(err, jc.ErrorIsNil)
-	err = apiMachine.SupportsNoContainers()
+	apiMachine := s.assertGetOneMachine(c, s.machine.MachineTag())
+	err := apiMachine.SupportsNoContainers()
 	c.Assert(err, jc.ErrorIsNil)
 
 	err = s.machine.Refresh()

--- a/api/uniter/uniter.go
+++ b/api/uniter/uniter.go
@@ -89,7 +89,7 @@ func (st *State) Facade() base.FacadeCaller {
 
 // life requests the lifecycle of the given entity from the server.
 func (st *State) life(tag names.Tag) (params.Life, error) {
-	return common.Life(st.facade, tag)
+	return common.OneLife(st.facade, tag)
 }
 
 // relation requests relation information from the server.

--- a/worker/provisioner/container_initialisation_test.go
+++ b/worker/provisioner/container_initialisation_test.go
@@ -96,8 +96,12 @@ func (s *ContainerSetupSuite) setupContainerWorker(c *gc.C, tag names.MachineTag
 		RestartDelay:  jworker.RestartDelay,
 	})
 	pr := apiprovisioner.NewState(s.st)
-	machine, err := pr.Machine(tag)
+	result, err := pr.Machines(tag)
 	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(len(result), gc.Equals, 1)
+	c.Assert(result[0].Err, gc.IsNil)
+	machine := result[0].Machine
+
 	err = machine.SetSupportedContainers(instance.ContainerTypes...)
 	c.Assert(err, jc.ErrorIsNil)
 	cfg := s.AgentConfigForTag(c, tag)

--- a/worker/provisioner/provisioner.go
+++ b/worker/provisioner/provisioner.go
@@ -340,11 +340,16 @@ func (p *containerProvisioner) getMachine() (*apiprovisioner.Machine, error) {
 		if !ok {
 			return nil, errors.Errorf("expected names.MachineTag, got %T", tag)
 		}
-		var err error
-		if p.machine, err = p.st.Machine(machineTag); err != nil {
+		result, err := p.st.Machines(machineTag)
+		if err != nil {
+			logger.Errorf("error retrieving %s from state", machineTag)
+			return nil, err
+		}
+		if result[0].Err != nil {
 			logger.Errorf("%s is not in state", machineTag)
 			return nil, err
 		}
+		p.machine = result[0].Machine
 	}
 	return p.machine, nil
 }

--- a/worker/provisioner/provisioner_test.go
+++ b/worker/provisioner/provisioner_test.go
@@ -1110,12 +1110,12 @@ func (s *ProvisionerSuite) TestDyingMachines(c *gc.C) {
 
 type mockMachineGetter struct{}
 
-func (*mockMachineGetter) Machine(names.MachineTag) (*apiprovisioner.Machine, error) {
+func (*mockMachineGetter) Machines(...names.MachineTag) ([]apiprovisioner.MachineResult, error) {
 	return nil, fmt.Errorf("error")
 }
 
-func (*mockMachineGetter) MachinesWithTransientErrors() ([]*apiprovisioner.Machine, []params.StatusResult, error) {
-	return nil, nil, fmt.Errorf("error")
+func (*mockMachineGetter) MachinesWithTransientErrors() ([]apiprovisioner.MachineStatusResult, error) {
+	return nil, fmt.Errorf("error")
 }
 
 func (s *ProvisionerSuite) TestMachineErrorsRetainInstances(c *gc.C) {


### PR DESCRIPTION
in the provisioner.

## Description of change

Fixing a TODO in the code.  This will reduce the number API calls made by the provisioner.
Added a Machines() method to get apiprovisioner.Machine in bulk.  Modified common.Life
to accept bulk arguments.  Added common.OneLife to facilitate getting Life for a single 
entity.

## QA steps

Unit tests updated.  Bootstrap a cloud using machines and deploy a bundle or multiple units of a charm at once.

## Documentation changes

N/A

## Bug reference

N/A