### PR TITLE
Add ingress/egress info to network-get

### DIFF
--- a/apiserver/facades/agent/uniter/uniter.go
+++ b/apiserver/facades/agent/uniter/uniter.go
@@ -1848,7 +1848,13 @@ func (u *UniterAPI) NetworkInfo(args params.NetworkInfoParams) (params.NetworkIn
 
 	spaces := set.NewStrings()
 	bindingsToSpace := make(map[string]string)
+	bindingsToEgressSubnets := make(map[string][]string)
+	bindingsToIngressAddress := make(map[string]string)
 
+	modelCfg, err := u.st.ModelConfig()
+	if err != nil {
+		return params.NetworkInfoResults{}, err
+	}
 	for _, binding := range args.Bindings {
 		if boundSpace, err := unit.GetSpaceForBinding(binding); err != nil {
 			result.Results[binding] = params.NetworkInfoResult{Error: common.ServerError(err)}
@@ -1856,9 +1862,9 @@ func (u *UniterAPI) NetworkInfo(args params.NetworkInfoParams) (params.NetworkIn
 			spaces.Add(boundSpace)
 			bindingsToSpace[binding] = boundSpace
 		}
+		bindingsToEgressSubnets[binding] = modelCfg.EgressSubnets()
 	}
 
-	var defaultSpaceInfo *network.NetworkInfo
 	if args.RelationId != nil {
 		// We're in a relation context.
 		rel, err := u.st.Relation(*args.RelationId)
@@ -1869,37 +1875,57 @@ func (u *UniterAPI) NetworkInfo(args params.NetworkInfoParams) (params.NetworkIn
 		if err != nil {
 			return params.NetworkInfoResults{}, err
 		}
+
+		// Look for any relation specific egress subnets.
+		relEgress := state.NewRelationEgressNetworks(u.st)
+		egressSubnets, err := relEgress.Networks(rel.Tag().Id())
+		if err != nil && !errors.IsNotFound(err) {
+			return params.NetworkInfoResults{}, err
+		} else if err == nil {
+			cidrs := egressSubnets.CIDRS()
+			if len(cidrs) > 0 {
+				bindingsToEgressSubnets[endpoint.Name] = cidrs
+			}
+		}
+
 		boundSpace, err := unit.GetSpaceForBinding(endpoint.Name)
 		if err != nil && !errors.IsNotValid(err) {
 			return params.NetworkInfoResults{}, err
 		}
 		// If the endpoint for this relation is not bound to a space, or
-		// is bound to the default space, we need to set the address info
-		// for the default space to the correct cross model ingress address.
+		// is bound to the default space, we need to look up the ingress
+		// address info which is aware of cross model relations.
 		if boundSpace == environs.DefaultSpaceName || err != nil {
 			ru, err := u.getRelationUnit(canAccess, rel.Tag().String(), unitTag)
 			if err != nil {
 				return params.NetworkInfoResults{}, err
 			}
 			address, err := ru.IngressAddress()
-			logger.Debugf("address for relation %v is %v", rel.Tag().Id(), address)
-			spaces.Remove(environs.DefaultSpaceName)
-			defaultSpaceInfo = &network.NetworkInfo{
-				Addresses: []network.InterfaceAddress{{
-					Address: address.Value,
-				}},
+			if err != nil {
+				return params.NetworkInfoResults{}, err
 			}
+			bindingsToIngressAddress[endpoint.Name] = address.Value
 		}
 	}
 
 	networkInfos := machine.GetNetworkInfoForSpaces(spaces)
-	if defaultSpaceInfo != nil {
-		networkInfos[environs.DefaultSpaceName] = state.MachineNetworkInfoResult{
-			NetworkInfos: []network.NetworkInfo{*defaultSpaceInfo},
-		}
-	}
 	for binding, space := range bindingsToSpace {
-		result.Results[binding] = networkingcommon.MachineNetworkInfoResultToNetworkInfoResult(networkInfos[space])
+		// The binding address information based on link layer devices.
+		info := networkingcommon.MachineNetworkInfoResultToNetworkInfoResult(networkInfos[space])
+
+		// Set egress and ingress address information.
+		info.EgressSubnets = bindingsToEgressSubnets[binding]
+		// If there is no ingress address explicitly defined for a given binding,
+		// set the ingress address to the first binding address. This simplifies
+		// the processing charms need to do.
+		ingressAddress, ok := bindingsToIngressAddress[binding]
+		if !ok && len(info.Info[0].Addresses) > 0 {
+			ingressAddress = info.Info[0].Addresses[0].Address
+		}
+		if ingressAddress != "" {
+			info.IngressAddresses = []string{ingressAddress}
+		}
+		result.Results[binding] = info
 	}
 
 	return result, nil

--- a/apiserver/facades/agent/uniter/uniter_test.go
+++ b/apiserver/facades/agent/uniter/uniter_test.go
@@ -3656,7 +3656,7 @@ func (s *uniterNetworkInfoSuite) TestNetworkInfoForExplicitlyBoundEndpointAndDef
 			},
 		},
 		EgressSubnets:    []string{},
-		IngressAddresses: []string{"10.0.0.10"},
+		IngressAddresses: []string{"10.0.0.10", "10.0.0.11"},
 	}
 	// For the "admin-api" extra-binding we expect to see only interfaces from
 	// the "public" space.
@@ -3679,7 +3679,7 @@ func (s *uniterNetworkInfoSuite) TestNetworkInfoForExplicitlyBoundEndpointAndDef
 			},
 		},
 		EgressSubnets:    []string{},
-		IngressAddresses: []string{"8.8.8.10"},
+		IngressAddresses: []string{"8.8.8.10", "8.8.4.10", "8.8.4.11"},
 	}
 
 	// For the "db-client" extra-binding we expect to see interfaces from default

--- a/apiserver/params/network.go
+++ b/apiserver/params/network.go
@@ -689,7 +689,7 @@ type NetworkInfo struct {
 // NetworkInfoResult holds either and error or a list of NetworkInfos for given binding.
 type NetworkInfoResult struct {
 	Error            *Error        `json:"error,omitempty" yaml:"error,omitempty"`
-	Info             []NetworkInfo `json:"network-info" yaml:"info"`
+	Info             []NetworkInfo `json:"bind-addresses,omitempty" yaml:"bind-addresses,omitempty"`
 	EgressSubnets    []string      `json:"egress-subnets,omitempty" yaml:"egress-subnets,omitempty"`
 	IngressAddresses []string      `json:"ingress-addresses,omitempty" yaml:"ingress-addresses,omitempty"`
 }

--- a/apiserver/params/network.go
+++ b/apiserver/params/network.go
@@ -688,8 +688,10 @@ type NetworkInfo struct {
 
 // NetworkInfoResult holds either and error or a list of NetworkInfos for given binding.
 type NetworkInfoResult struct {
-	Error *Error        `json:"error,omitempty" yaml:"error,omitempty"`
-	Info  []NetworkInfo `json:"network-info" yaml:"info"`
+	Error            *Error        `json:"error,omitempty" yaml:"error,omitempty"`
+	Info             []NetworkInfo `json:"network-info" yaml:"info"`
+	EgressSubnets    []string      `json:"egress-subnets,omitempty" yaml:"egress-subnets,omitempty"`
+	IngressAddresses []string      `json:"ingress-addresses,omitempty" yaml:"ingress-addresses,omitempty"`
 }
 
 // NetworkInfoResults holds a mapping from binding name to NetworkInfoResult.

--- a/state/machine_linklayerdevices.go
+++ b/state/machine_linklayerdevices.go
@@ -1218,7 +1218,7 @@ func (m *Machine) GetNetworkInfoForSpaces(spaces set.Strings) map[string](Machin
 	}
 
 	// For a spaceless environment we won't find a subnet that's linked to privateAddress,
-	// we have to work around that and at least return minimal information for --primary-address.
+	// we have to work around that and at least return minimal information.
 	if r, filledPrivateAddress := results[environs.DefaultSpaceName]; !filledPrivateAddress && spaces.Contains(environs.DefaultSpaceName) {
 		r.NetworkInfos = []network.NetworkInfo{{
 			Addresses: []network.InterfaceAddress{{

--- a/worker/uniter/runner/context/context.go
+++ b/worker/uniter/runner/context/context.go
@@ -832,11 +832,11 @@ func (ctx *HookContext) SetUnitWorkloadVersion(version string) error {
 	return result.OneError()
 }
 
-// NetworkInfo returns the network info for the given bindingNames.
-func (ctx *HookContext) NetworkInfo(bindingNames []string) (map[string]params.NetworkInfoResult, error) {
+// NetworkInfo returns the network info for the given bindings on the given relation.
+func (ctx *HookContext) NetworkInfo(bindingNames []string, relationId int) (map[string]params.NetworkInfoResult, error) {
 	var relId *int
-	if ctx.relationId != -1 {
-		relId = &ctx.relationId
+	if relationId != -1 {
+		relId = &relationId
 	}
 	return ctx.unit.NetworkInfo(bindingNames, relId)
 }

--- a/worker/uniter/runner/context/context_test.go
+++ b/worker/uniter/runner/context/context_test.go
@@ -93,7 +93,7 @@ func (s *InterfaceSuite) TestUnitNetworkInfo(c *gc.C) {
 	// of the cases are tested separately for network-get, api/uniter, and
 	// apiserver/uniter, respectively.
 	ctx := s.GetContext(c, -1, "")
-	netInfo, err := ctx.NetworkInfo([]string{"unknown"})
+	netInfo, err := ctx.NetworkInfo([]string{"unknown"}, -1)
 	c.Check(err, jc.ErrorIsNil)
 	c.Check(netInfo, gc.DeepEquals, map[string]params.NetworkInfoResult{
 		"unknown": {

--- a/worker/uniter/runner/jujuc/context.go
+++ b/worker/uniter/runner/jujuc/context.go
@@ -160,8 +160,8 @@ type ContextNetworking interface {
 	// protocol, then by number.
 	OpenedPorts() []network.PortRange
 
-	// NetworkInfo returns detailed information about interfaces for specified bindings
-	NetworkInfo(bindingNames []string) (map[string]params.NetworkInfoResult, error)
+	// NetworkInfo returns the network info for the given bindings on the given relation.
+	NetworkInfo(bindingNames []string, relationId int) (map[string]params.NetworkInfoResult, error)
 }
 
 // ContextLeadership is the part of a hook context related to the

--- a/worker/uniter/runner/jujuc/network-get.go
+++ b/worker/uniter/runner/jujuc/network-get.go
@@ -16,26 +16,46 @@ type NetworkGetCommand struct {
 	cmd.CommandBase
 	ctx Context
 
-	bindingName    string
+	RelationId      int
+	relationIdProxy gnuflag.Value
+
+	bindingName string
+
+	bindAddress    bool
+	ingressAddress bool
+	egressSubnets  bool
+	keys           []string
+
+	// deprecated
 	primaryAddress bool
 
 	out cmd.Output
 }
 
-func NewNetworkGetCommand(ctx Context) (cmd.Command, error) {
+func NewNetworkGetCommand(ctx Context) (_ cmd.Command, err error) {
 	cmd := &NetworkGetCommand{ctx: ctx}
+	cmd.relationIdProxy, err = newRelationIdValue(ctx, &cmd.RelationId)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
 	return cmd, nil
 }
 
 // Info is part of the cmd.Command interface.
 func (c *NetworkGetCommand) Info() *cmd.Info {
-	args := "<binding-name> --primary-address"
+	args := "<binding-name> [--ingress-address] [--bind-address] [--egress-subnets]"
 	doc := `
 network-get returns the network config for a given binding name. By default
 it returns the list of interfaces and associated addresses in the space for
-the binding.
-If --primary-address flag is specified then only single IP address is
-returned that the local unit should advertise as its endpoint to its peers.
+the binding, as well as the ingress address for the binding. If defined, any
+egress subnets are also returned.
+If one of the following flags are specified, just that value is returned.
+If more then one flag is specified, a map of values is returned.
+    --bind-address: the address the local unit should listen on to serve connections, as well
+                    as the address that should be advertised to its peers.
+    --ingress-address: the address the local unit should advertise as being used for incoming connections.
+    --egress_subnets: subnets (in CIDR notation) from which traffic on this relation will originate.
 `
 	return &cmd.Info{
 		Name:    "network-get",
@@ -48,8 +68,19 @@ returned that the local unit should advertise as its endpoint to its peers.
 // SetFlags is part of the cmd.Command interface.
 func (c *NetworkGetCommand) SetFlags(f *gnuflag.FlagSet) {
 	c.out.AddFlags(f, "smart", cmd.DefaultFormatters)
-	f.BoolVar(&c.primaryAddress, "primary-address", false, "get the primary address for the binding")
+	f.BoolVar(&c.primaryAddress, "primary-address", false, "(deprecated) get the primary address for the binding")
+	f.BoolVar(&c.bindAddress, "bind-address", false, "get the address for the binding on which the unit should listen")
+	f.BoolVar(&c.ingressAddress, "ingress-address", false, "get the ingress address for the binding")
+	f.BoolVar(&c.egressSubnets, "egress-subnets", false, "get the egress subnets for the binding")
+	f.Var(c.relationIdProxy, "r", "specify a relation by id")
+	f.Var(c.relationIdProxy, "relation", "")
 }
+
+const (
+	bindAddressKey    = "bind-address"
+	ingressAddressKey = "ingress-address"
+	egressSubnetsKey  = "egress-subnets"
+)
 
 // Init is part of the cmd.Command interface.
 func (c *NetworkGetCommand) Init(args []string) error {
@@ -60,12 +91,21 @@ func (c *NetworkGetCommand) Init(args []string) error {
 	if c.bindingName == "" {
 		return fmt.Errorf("no binding name specified")
 	}
+	if c.bindAddress {
+		c.keys = append(c.keys, bindAddressKey)
+	}
+	if c.ingressAddress {
+		c.keys = append(c.keys, ingressAddressKey)
+	}
+	if c.egressSubnets {
+		c.keys = append(c.keys, egressSubnetsKey)
+	}
 
 	return cmd.CheckEmpty(args[1:])
 }
 
 func (c *NetworkGetCommand) Run(ctx *cmd.Context) error {
-	netInfo, err := c.ctx.NetworkInfo([]string{c.bindingName})
+	netInfo, err := c.ctx.NetworkInfo([]string{c.bindingName}, c.RelationId)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -78,12 +118,43 @@ func (c *NetworkGetCommand) Run(ctx *cmd.Context) error {
 		return errors.Trace(ni.Error)
 	}
 
-	if c.primaryAddress {
-		if len(ni.Info[0].Addresses) == 0 {
-			return fmt.Errorf("No addresses attached to space for binding %q", c.bindingName)
-		}
-		return c.out.Write(ctx, ni.Info[0].Addresses[0].Address)
-	} else {
+	// If no specific attributes asked for,
+	// print everything we know.
+	if !c.primaryAddress && len(c.keys) == 0 {
 		return c.out.Write(ctx, ni)
 	}
+
+	// Backwards compatibility - we just want the primary address.
+	if c.primaryAddress {
+		if len(ni.Info[0].Addresses) == 0 {
+			return fmt.Errorf("no addresses attached to space for binding %q", c.bindingName)
+		}
+		return c.out.Write(ctx, ni.Info[0].Addresses[0].Address)
+	}
+
+	// If we want just a single value, print that, else
+	// print a map of the values asked for.
+	keyValues := make(map[string]interface{})
+	if c.egressSubnets {
+		keyValues[egressSubnetsKey] = ni.EgressSubnets
+	}
+	if c.ingressAddress {
+		var ingressAddress string
+		if len(ni.IngressAddresses) == 0 {
+			if len(ni.Info[0].Addresses) == 0 {
+				return fmt.Errorf("no addresses attached to space for binding %q", c.bindingName)
+			}
+			ingressAddress = ni.Info[0].Addresses[0].Address
+		} else {
+			ingressAddress = ni.IngressAddresses[0]
+		}
+		keyValues[ingressAddressKey] = ingressAddress
+	}
+	if c.bindAddress {
+		keyValues[bindAddressKey] = ni.Info[0].Addresses[0].Address
+	}
+	if len(c.keys) == 1 {
+		return c.out.Write(ctx, keyValues[c.keys[0]])
+	}
+	return c.out.Write(ctx, keyValues)
 }

--- a/worker/uniter/runner/jujuc/network-get.go
+++ b/worker/uniter/runner/jujuc/network-get.go
@@ -51,7 +51,7 @@ it returns the list of interfaces and associated addresses in the space for
 the binding, as well as the ingress address for the binding. If defined, any
 egress subnets are also returned.
 If one of the following flags are specified, just that value is returned.
-If more then one flag is specified, a map of values is returned.
+If more than one flag is specified, a map of values is returned.
     --bind-address: the address the local unit should listen on to serve connections, as well
                     as the address that should be advertised to its peers.
     --ingress-address: the address the local unit should advertise as being used for incoming connections.
@@ -126,6 +126,9 @@ func (c *NetworkGetCommand) Run(ctx *cmd.Context) error {
 
 	// Backwards compatibility - we just want the primary address.
 	if c.primaryAddress {
+		if c.ingressAddress || c.egressSubnets || c.bindAddress {
+			return fmt.Errorf("--primary-address must be the only flag specified")
+		}
 		if len(ni.Info[0].Addresses) == 0 {
 			return fmt.Errorf("no addresses attached to space for binding %q", c.bindingName)
 		}

--- a/worker/uniter/runner/jujuc/network-get_test.go
+++ b/worker/uniter/runner/jujuc/network-get_test.go
@@ -143,7 +143,7 @@ func (s *NetworkGetSuite) TestNetworkGet(c *gc.C) {
 		code:    1,
 		out:     `no network config found for binding "valid-no-config"`,
 	}, {
-		summary: "API server returns no config for this binding, no --primary-address",
+		summary: "API server returns no config for this binding, no address args",
 		args:    []string{"valid-no-config"},
 		code:    1,
 		out:     `no network config found for binding "valid-no-config"`,
@@ -161,7 +161,7 @@ ingress-address: 10.20.1.42`[1:],
 		summary: "explicitly bound, extra-binding name given without extra args",
 		args:    []string{"known-extra"},
 		out: `
-info:
+bind-addresses:
 - macaddress: "00:11:22:33:44:22"
   interfacename: eth2
   addresses:
@@ -177,7 +177,7 @@ info:
 		summary: "explicitly bound relation name given without extra args",
 		args:    []string{"known-relation"},
 		out: `
-info:
+bind-addresses:
 - macaddress: "00:11:22:33:44:00"
   interfacename: eth0
   addresses:
@@ -197,10 +197,10 @@ info:
 		args:    []string{"known-unbound", "--ingress-address"},
 		out:     "10.33.1.8",
 	}, {
-		summary: "no user requested binding falls back to primary address, without --primary-address",
+		summary: "no user requested binding falls back to primary address, without address args",
 		args:    []string{"known-unbound"},
 		out: `
-info:
+bind-addresses:
 - macaddress: "00:11:22:33:44:33"
   interfacename: eth3
   addresses:
@@ -219,7 +219,7 @@ ingress-address: 100.1.2.3`[1:],
 		summary: "explicit ingress and egress information, no extra args",
 		args:    []string{"ingress-egress"},
 		out: `
-info:
+bind-addresses:
 - macaddress: "00:11:22:33:44:33"
   interfacename: eth3
   addresses:

--- a/worker/uniter/runner/jujuc/restricted.go
+++ b/worker/uniter/runner/jujuc/restricted.go
@@ -65,7 +65,7 @@ func (*RestrictedContext) ClosePorts(protocol string, fromPort, toPort int) erro
 func (*RestrictedContext) OpenedPorts() []network.PortRange { return nil }
 
 // NetworkInfo implements jujuc.Context.
-func (*RestrictedContext) NetworkInfo(bindingNames []string) (map[string]params.NetworkInfoResult, error) {
+func (*RestrictedContext) NetworkInfo(bindingNames []string, relationId int) (map[string]params.NetworkInfoResult, error) {
 	return map[string]params.NetworkInfoResult{}, ErrRestrictedContext
 }
 

--- a/worker/uniter/runner/jujuc/testing/networking.go
+++ b/worker/uniter/runner/jujuc/testing/networking.go
@@ -104,8 +104,8 @@ func (c *ContextNetworking) OpenedPorts() []network.PortRange {
 }
 
 // NetworkInfo implements jujuc.ContextNetworking.
-func (c *ContextNetworking) NetworkInfo(bindingNames []string) (map[string]params.NetworkInfoResult, error) {
-	c.stub.AddCall("NetworkInfo", bindingNames)
+func (c *ContextNetworking) NetworkInfo(bindingNames []string, relationId int) (map[string]params.NetworkInfoResult, error) {
+	c.stub.AddCall("NetworkInfo", bindingNames, relationId)
 	if err := c.stub.NextErr(); err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/worker/uniter/runner/jujuc/unit-get.go
+++ b/worker/uniter/runner/jujuc/unit-get.go
@@ -50,7 +50,7 @@ func (c *UnitGetCommand) Run(ctx *cmd.Context) error {
 	var value string
 	var err error
 	if c.Key == "private-address" {
-		networkInfos, err := c.ctx.NetworkInfo([]string{""})
+		networkInfos, err := c.ctx.NetworkInfo([]string{""}, -1)
 		if err == nil {
 			if networkInfos[""].Error != nil {
 				err = errors.Trace(networkInfos[""].Error)


### PR DESCRIPTION
## Description of change

The network-get hook tool now prints ingress and egress information about the relation 
The --primary-address arg is deprecated in favour of 3 new args:
--ingress-address (the address the local unit should advertise for incoming connections)
--binding-address (the address the local unit should use to listen on)
--egress-subnets (subnets from which outgoing traffic from the local unit originates)

Without args, a full yaml data structure is printed, eg
`$ network-get db -r 1`
`info:`
`- macaddress: "00:11:22:33:44:33"`
`  interfacename: eth3`
`  addresses:`
`  - address: 10.33.1.8`
`    cidr: 10.33.1.8/24`
`egress-subnets:`
`- 192.168.1.0/8`
`- 10.0.0.0/8`
`ingress-addresses:`
`- 100.1.2.3`
`- 100.4.3.2`

Note that for backwards compatibility, binding addresses are in the info block, which also contains other link layer data like MAC address etc.

Similar to how --primary-address behaves, if --ingress-address or --binding-address is specified, a single value is printed.

$ network-get db -r 1 --ingress-address
100.1.2.3

$ network-get db -r 1 --binding-address
10.33.1.8

## QA steps

Run up a cmr scenario in aws; mysql in one model, mediawiki in another.
juju run network-get to check the output
- in cmr relation context -> ingress-address is public address of machine
- no relation context or non cmr relation -> ingress address is private address of machine
- set egress subnets, check these are printed when present
