### PR TITLE
When removing consume permission from an offer, relations are set to suspended

### DIFF
--- a/api/application/client.go
+++ b/api/application/client.go
@@ -18,7 +18,6 @@ import (
 	"github.com/juju/juju/charmstore"
 	"github.com/juju/juju/constraints"
 	"github.com/juju/juju/core/crossmodel"
-	"github.com/juju/juju/core/relation"
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/storage"
 )
@@ -488,13 +487,13 @@ func (c *Client) DestroyRelationId(relationId int) error {
 	return c.facade.FacadeCall("DestroyRelation", params, nil)
 }
 
-// SetRelationStatus updates the status of the relation with the specified id.
-func (c *Client) SetRelationStatus(relationId int, status relation.Status) error {
-	args := params.RelationStatusArgs{
-		Args: []params.RelationStatusArg{{RelationId: relationId, Status: params.RelationStatusValue(status)}},
+// SetRelationSuspended updates the suspended status of the relation with the specified id.
+func (c *Client) SetRelationSuspended(relationId int, suspended bool) error {
+	args := params.RelationSuspendedArgs{
+		Args: []params.RelationSuspendedArg{{RelationId: relationId, Suspended: suspended}},
 	}
 	var results params.ErrorResults
-	if err := c.facade.FacadeCall("SetRelationStatus", args, &results); err != nil {
+	if err := c.facade.FacadeCall("SetRelationsSuspended", args, &results); err != nil {
 		return errors.Trace(err)
 	}
 	return results.OneError()

--- a/api/application/client_test.go
+++ b/api/application/client_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/juju/juju/charmstore"
 	"github.com/juju/juju/constraints"
 	"github.com/juju/juju/core/crossmodel"
-	"github.com/juju/juju/core/relation"
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/storage"
 	coretesting "github.com/juju/juju/testing"
@@ -513,14 +512,14 @@ func (s *applicationSuite) TestDestroyRelationId(c *gc.C) {
 	c.Assert(called, jc.IsTrue)
 }
 
-func (s *applicationSuite) TestSetRelationStatus(c *gc.C) {
+func (s *applicationSuite) TestSetRelationSuspended(c *gc.C) {
 	called := false
 	client := newClient(func(objType string, version int, id, request string, a, result interface{}) error {
-		c.Assert(request, gc.Equals, "SetRelationStatus")
-		c.Assert(a, jc.DeepEquals, params.RelationStatusArgs{
-			Args: []params.RelationStatusArg{{
+		c.Assert(request, gc.Equals, "SetRelationsSuspended")
+		c.Assert(a, jc.DeepEquals, params.RelationSuspendedArgs{
+			Args: []params.RelationSuspendedArg{{
 				RelationId: 123,
-				Status:     "suspended",
+				Suspended:  true,
 			}},
 		})
 		c.Assert(result, gc.FitsTypeOf, &params.ErrorResults{})
@@ -530,7 +529,7 @@ func (s *applicationSuite) TestSetRelationStatus(c *gc.C) {
 		called = true
 		return nil
 	})
-	err := client.SetRelationStatus(123, relation.Suspended)
+	err := client.SetRelationSuspended(123, true)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(called, jc.IsTrue)
 }

--- a/apiserver/facades/client/application/application.go
+++ b/apiserver/facades/client/application/application.go
@@ -1033,8 +1033,8 @@ func (api *API) DestroyRelation(args params.DestroyRelation) (err error) {
 	return rel.Destroy()
 }
 
-// SetRelationStatus updates the status of the specified relations.
-func (api *API) SetRelationStatus(args params.RelationStatusArgs) (params.ErrorResults, error) {
+// SetRelationsSuspended sets the suspended status of the specified relations.
+func (api *API) SetRelationsSuspended(args params.RelationSuspendedArgs) (params.ErrorResults, error) {
 	var statusResults params.ErrorResults
 	if err := api.checkCanWrite(); err != nil {
 		return statusResults, errors.Trace(err)
@@ -1043,21 +1043,27 @@ func (api *API) SetRelationStatus(args params.RelationStatusArgs) (params.ErrorR
 		return statusResults, errors.Trace(err)
 	}
 
-	changeOne := func(arg params.RelationStatusArg) error {
+	changeOne := func(arg params.RelationSuspendedArg) error {
 		rel, err := api.backend.Relation(arg.RelationId)
 		if err != nil {
 			return errors.Trace(err)
 		}
 		_, err = api.backend.OfferConnectionForRelation(rel.Tag().Id())
 		if errors.IsNotFound(err) {
-			return errors.Errorf("cannot set status for %q which is not associated with an offer", rel.Tag().Id())
+			return errors.Errorf("cannot set suspend status for %q which is not associated with an offer", rel.Tag().Id())
 		}
+		err = rel.SetSuspended(arg.Suspended)
 		if err != nil {
 			return errors.Trace(err)
 		}
+
+		// TODO(wallyworld) - keep until followup PR so things keep working
+		statusValue := status.Joined
+		if arg.Suspended {
+			statusValue = status.Suspended
+		}
 		return rel.SetStatus(status.StatusInfo{
-			Status:  status.Status(arg.Status),
-			Message: arg.Message,
+			Status: status.Status(statusValue),
 		})
 	}
 	results := make([]params.ErrorResult, len(args.Args))

--- a/apiserver/facades/client/application/application_unit_test.go
+++ b/apiserver/facades/client/application/application_unit_test.go
@@ -405,39 +405,38 @@ func (s *ApplicationSuite) TestAddUnitsAttachStorageInvalidStorageTag(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, `"volume-0" is not a valid storage tag`)
 }
 
-func (s *ApplicationSuite) TestSetRelationStatus(c *gc.C) {
+func (s *ApplicationSuite) TestSetRelationSuspended(c *gc.C) {
 	s.backend.offerConnections["wordpress:db mysql:db"] = &mockOfferConnection{}
-	results, err := s.api.SetRelationStatus(params.RelationStatusArgs{
-		Args: []params.RelationStatusArg{{
+	results, err := s.api.SetRelationsSuspended(params.RelationSuspendedArgs{
+		Args: []params.RelationSuspendedArg{{
 			RelationId: 123,
-			Status:     params.Joined,
-			Message:    "a message",
+			Suspended:  true,
 		}},
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results.OneError(), gc.IsNil)
-	c.Assert(s.relation.status, gc.Equals, status.Joined)
-	c.Assert(s.relation.message, gc.Equals, "a message")
+	c.Assert(s.relation.suspended, jc.IsTrue)
+	c.Assert(s.relation.status, gc.Equals, status.Suspended)
 }
 
 func (s *ApplicationSuite) TestSetNonOfferRelationStatus(c *gc.C) {
 	s.backend.relations[123].tag = names.NewRelationTag("mediawiki:db mysql:db")
-	results, err := s.api.SetRelationStatus(params.RelationStatusArgs{
-		Args: []params.RelationStatusArg{{
+	results, err := s.api.SetRelationsSuspended(params.RelationSuspendedArgs{
+		Args: []params.RelationSuspendedArg{{
 			RelationId: 123,
-			Status:     params.Joined,
+			Suspended:  true,
 		}},
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(results.OneError(), gc.ErrorMatches, `cannot set status for "mediawiki:db mysql:db" which is not associated with an offer`)
+	c.Assert(results.OneError(), gc.ErrorMatches, `cannot set suspend status for "mediawiki:db mysql:db" which is not associated with an offer`)
 }
 
-func (s *ApplicationSuite) TestBlockSetRelationStatus(c *gc.C) {
+func (s *ApplicationSuite) TestBlockSetRelationSuspended(c *gc.C) {
 	s.blockChecker.SetErrors(errors.New("blocked"))
-	_, err := s.api.SetRelationStatus(params.RelationStatusArgs{
-		Args: []params.RelationStatusArg{{
+	_, err := s.api.SetRelationsSuspended(params.RelationSuspendedArgs{
+		Args: []params.RelationSuspendedArg{{
 			RelationId: 123,
-			Status:     params.Joined,
+			Suspended:  true,
 		}},
 	})
 	c.Assert(err, gc.ErrorMatches, "blocked")
@@ -445,7 +444,7 @@ func (s *ApplicationSuite) TestBlockSetRelationStatus(c *gc.C) {
 	s.relation.CheckNoCalls(c)
 }
 
-func (s *ApplicationSuite) TestSetRelationStatusPermissionDenied(c *gc.C) {
+func (s *ApplicationSuite) TestSetRelationSuspendedPermissionDenied(c *gc.C) {
 	s.authorizer.Tag = names.NewUserTag("fred")
 	api, err := application.NewAPI(
 		&s.backend,
@@ -459,10 +458,10 @@ func (s *ApplicationSuite) TestSetRelationStatusPermissionDenied(c *gc.C) {
 		},
 	)
 	c.Assert(err, jc.ErrorIsNil)
-	_, err = api.SetRelationStatus(params.RelationStatusArgs{
-		Args: []params.RelationStatusArg{{
+	_, err = api.SetRelationsSuspended(params.RelationSuspendedArgs{
+		Args: []params.RelationSuspendedArg{{
 			RelationId: 123,
-			Status:     params.Joined,
+			Suspended:  true,
 		}},
 	})
 	c.Assert(err, gc.ErrorMatches, "permission denied")

--- a/apiserver/facades/client/application/backend.go
+++ b/apiserver/facades/client/application/backend.go
@@ -101,6 +101,7 @@ type Relation interface {
 	Tag() names.Tag
 	Destroy() error
 	Endpoint(string) (state.Endpoint, error)
+	SetSuspended(bool) error
 }
 
 // Unit defines a subset of the functionality provided by the

--- a/apiserver/facades/client/application/mock_test.go
+++ b/apiserver/facades/client/application/mock_test.go
@@ -516,9 +516,9 @@ type mockRelation struct {
 	application.Relation
 	jtesting.Stub
 
-	tag     names.Tag
-	status  status.Status
-	message string
+	tag       names.Tag
+	status    status.Status
+	suspended bool
 }
 
 func (r *mockRelation) Tag() names.Tag {
@@ -526,9 +526,15 @@ func (r *mockRelation) Tag() names.Tag {
 }
 
 func (r *mockRelation) SetStatus(status status.StatusInfo) error {
+	r.MethodCall(r, "SetStatus")
 	r.status = status.Status
-	r.message = status.Message
-	return nil
+	return r.NextErr()
+}
+
+func (r *mockRelation) SetSuspended(suspended bool) error {
+	r.MethodCall(r, "SetSuspended")
+	r.suspended = suspended
+	return r.NextErr()
 }
 
 func (r *mockRelation) Destroy() error {

--- a/apiserver/params/params.go
+++ b/apiserver/params/params.go
@@ -145,6 +145,18 @@ type RelationStatusArg struct {
 	Message    string              `json:"message"`
 }
 
+// RelationSuspendedArgs holds the parameters for setting
+// the suspended status of one or more relations.
+type RelationSuspendedArgs struct {
+	Args []RelationSuspendedArg `json:"args"`
+}
+
+// RelationSuspendedArg holds the new suspended status value for a relation.
+type RelationSuspendedArg struct {
+	RelationId int  `json:"relation-id"`
+	Suspended  bool `json:"suspended"`
+}
+
 // AddCharm holds the arguments for making an AddCharm API call.
 type AddCharm struct {
 	URL     string `json:"url"`

--- a/cmd/juju/application/export_test.go
+++ b/cmd/juju/application/export_test.go
@@ -83,16 +83,16 @@ func NewUpdateSeriesCommandForTest(
 }
 
 // NewSuspendRelationCommandForTest returns a SuspendRelationCommand with the api provided as specified.
-func NewSuspendRelationCommandForTest(api SetRelationStatusAPI) modelcmd.ModelCommand {
-	cmd := &suspendRelationCommand{newAPIFunc: func() (SetRelationStatusAPI, error) {
+func NewSuspendRelationCommandForTest(api SetRelationSuspendedAPI) modelcmd.ModelCommand {
+	cmd := &suspendRelationCommand{newAPIFunc: func() (SetRelationSuspendedAPI, error) {
 		return api, nil
 	}}
 	return modelcmd.Wrap(cmd)
 }
 
 // NewResumeRelationCommandForTest returns a ResumeRelationCommand with the api provided as specified.
-func NewResumeRelationCommandForTest(api SetRelationStatusAPI) modelcmd.ModelCommand {
-	cmd := &resumeRelationCommand{newAPIFunc: func() (SetRelationStatusAPI, error) {
+func NewResumeRelationCommandForTest(api SetRelationSuspendedAPI) modelcmd.ModelCommand {
+	cmd := &resumeRelationCommand{newAPIFunc: func() (SetRelationSuspendedAPI, error) {
 		return api, nil
 	}}
 	return modelcmd.Wrap(cmd)

--- a/cmd/juju/application/resumerelation.go
+++ b/cmd/juju/application/resumerelation.go
@@ -12,7 +12,6 @@ import (
 	"github.com/juju/juju/api/application"
 	"github.com/juju/juju/cmd/juju/block"
 	"github.com/juju/juju/cmd/modelcmd"
-	"github.com/juju/juju/core/relation"
 )
 
 var resumeHelpSummary = `
@@ -35,7 +34,7 @@ See also:
 // NewResumeRelationCommand returns a command to resume a relation.
 func NewResumeRelationCommand() cmd.Command {
 	cmd := &resumeRelationCommand{}
-	cmd.newAPIFunc = func() (SetRelationStatusAPI, error) {
+	cmd.newAPIFunc = func() (SetRelationSuspendedAPI, error) {
 		root, err := cmd.NewAPIRoot()
 		if err != nil {
 			return nil, errors.Trace(err)
@@ -49,7 +48,7 @@ func NewResumeRelationCommand() cmd.Command {
 type resumeRelationCommand struct {
 	modelcmd.ModelCommandBase
 	RelationId int
-	newAPIFunc func() (SetRelationStatusAPI, error)
+	newAPIFunc func() (SetRelationSuspendedAPI, error)
 }
 
 func (c *resumeRelationCommand) Info() *cmd.Info {
@@ -83,6 +82,6 @@ func (c *resumeRelationCommand) Run(_ *cmd.Context) error {
 	if client.BestAPIVersion() < 5 {
 		return errors.New("resuming a relation is not supported by this version of Juju")
 	}
-	err = client.SetRelationStatus(c.RelationId, relation.Joined)
+	err = client.SetRelationSuspended(c.RelationId, false)
 	return block.ProcessBlockedError(err, block.BlockChange)
 }

--- a/cmd/juju/application/suspendrelation.go
+++ b/cmd/juju/application/suspendrelation.go
@@ -12,7 +12,6 @@ import (
 	"github.com/juju/juju/api/application"
 	"github.com/juju/juju/cmd/juju/block"
 	"github.com/juju/juju/cmd/modelcmd"
-	"github.com/juju/juju/core/relation"
 )
 
 var suspendHelpSummary = `
@@ -35,7 +34,7 @@ See also:
 // NewSuspendRelationCommand returns a command to suspend a relation.
 func NewSuspendRelationCommand() cmd.Command {
 	cmd := &suspendRelationCommand{}
-	cmd.newAPIFunc = func() (SetRelationStatusAPI, error) {
+	cmd.newAPIFunc = func() (SetRelationSuspendedAPI, error) {
 		root, err := cmd.NewAPIRoot()
 		if err != nil {
 			return nil, errors.Trace(err)
@@ -49,7 +48,7 @@ func NewSuspendRelationCommand() cmd.Command {
 type suspendRelationCommand struct {
 	modelcmd.ModelCommandBase
 	RelationId int
-	newAPIFunc func() (SetRelationStatusAPI, error)
+	newAPIFunc func() (SetRelationSuspendedAPI, error)
 }
 
 func (c *suspendRelationCommand) Info() *cmd.Info {
@@ -74,11 +73,11 @@ func (c *suspendRelationCommand) Init(args []string) (err error) {
 	return cmd.CheckEmpty(args[1:])
 }
 
-// SetRelationStatusAPI defines the API methods that the suspend/resume relation commands use.
-type SetRelationStatusAPI interface {
+// SetRelationSuspendedAPI defines the API methods that the suspend/resume relation commands use.
+type SetRelationSuspendedAPI interface {
 	Close() error
 	BestAPIVersion() int
-	SetRelationStatus(relationId int, status relation.Status) error
+	SetRelationSuspended(relationId int, suspended bool) error
 }
 
 func (c *suspendRelationCommand) Run(_ *cmd.Context) error {
@@ -90,6 +89,6 @@ func (c *suspendRelationCommand) Run(_ *cmd.Context) error {
 	if client.BestAPIVersion() < 5 {
 		return errors.New("suspending a relation is not supported by this version of Juju")
 	}
-	err = client.SetRelationStatus(c.RelationId, relation.Suspended)
+	err = client.SetRelationSuspended(c.RelationId, true)
 	return block.ProcessBlockedError(err, block.BlockChange)
 }

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -21,7 +21,7 @@ github.com/juju/ansiterm	git	b99631de12cf04a906c1d4e4ec54fb86eae5863d	2016-09-07
 github.com/juju/blobstore	git	06056004b3d7b54bbb7984d830c537bad00fec21	2015-07-29T11:18:58Z
 github.com/juju/bundlechanges	git	cd189848b313df50084de692b05861210022cf81	2017-07-31T02:12:50Z
 github.com/juju/cmd	git	ad2437ef0ef282ae26e482eb1e44c02532bae1ba	2017-06-22T12:53:07Z
-github.com/juju/description	git	364612564ea78c1defaf0165085d2790f527e2de	2017-09-06T13:34:20Z
+github.com/juju/description	git	221dce7c83fe01dfe7467f6988b2c84940af5d71	2017-09-14T02:23:00Z
 github.com/juju/errors	git	1b5e39b83d1835fa480e0c2ddefb040ee82d58b3	2015-09-16T12:56:42Z
 github.com/juju/gnuflag	git	4e76c56581859c14d9d87e1ddbe29e1c0f10195f	2016-08-09T16:52:14Z
 github.com/juju/go-oracle-cloud	git	932a8cea00a1cd5cba3829a672c823955db674ae	2017-04-21T13:45:47Z

--- a/state/export_test.go
+++ b/state/export_test.go
@@ -501,6 +501,13 @@ func RemoveEndpointBindingsForService(c *gc.C, app *Application) {
 	c.Assert(err, jc.ErrorIsNil)
 }
 
+func RemoveOfferConnectionsForRelation(c *gc.C, rel *Relation) {
+	removeOps := removeOfferConnectionsForRelationOps(rel.Id())
+	txnError := rel.st.db().RunTransaction(removeOps)
+	err := onAbort(txnError, nil) // ignore ErrAborted as it asserts DocExists
+	c.Assert(err, jc.ErrorIsNil)
+}
+
 func RelationCount(app *Application) int {
 	return app.doc.RelationCount
 }

--- a/state/migration_internal_test.go
+++ b/state/migration_internal_test.go
@@ -442,6 +442,7 @@ func (s *MigrationSuite) TestRelationDocFields(c *gc.C) {
 		"Key",
 		"Id",
 		"Endpoints",
+		"Suspended",
 		// Life isn't exported, only alive.
 		"Life",
 		// UnitCount isn't explicitly exported, but defined by the stored

--- a/state/modeluser.go
+++ b/state/modeluser.go
@@ -238,3 +238,21 @@ func (st *State) IsControllerAdmin(user names.UserTag) (bool, error) {
 	}
 	return ua.Access == permission.SuperuserAccess, nil
 }
+
+func (st *State) isControllerOrModelAdmin(user names.UserTag) (bool, error) {
+	isAdmin, err := st.IsControllerAdmin(user)
+	if err != nil {
+		return false, errors.Trace(err)
+	}
+	if isAdmin {
+		return true, nil
+	}
+	ua, err := st.UserAccess(user, names.NewModelTag(st.modelUUID()))
+	if errors.IsNotFound(err) {
+		return false, nil
+	}
+	if err != nil {
+		return false, errors.Trace(err)
+	}
+	return ua.Access == permission.AdminAccess, nil
+}

--- a/worker/provisioner/provisioner_task.go
+++ b/worker/provisioner/provisioner_task.go
@@ -199,16 +199,16 @@ func (task *provisionerTask) processMachinesWithTransientErrors() error {
 	var pending []*apiprovisioner.Machine
 	for _, result := range results {
 		if result.Status.Error != nil {
-			logger.Errorf("cannot retry provisioning of machine %q: %v", result.Machine.Id, result.Status.Error)
+			logger.Errorf("cannot retry provisioning of machine %q: %v", result.Machine.Id(), result.Status.Error)
 			continue
 		}
 		machine := result.Machine
 		if err := machine.SetStatus(status.Pending, "", nil); err != nil {
-			logger.Errorf("cannot reset status of machine %q: %v", machine.Id, err)
+			logger.Errorf("cannot reset status of machine %q: %v", machine.Id(), err)
 			continue
 		}
 		if err := machine.SetInstanceStatus(status.Provisioning, "", nil); err != nil {
-			logger.Errorf("cannot reset instance status of machine %q: %v", machine.Id, err)
+			logger.Errorf("cannot reset instance status of machine %q: %v", machine.Id(), err)
 			continue
 		}
 		task.machines[machine.Tag().String()] = machine


### PR DESCRIPTION
## Description of change

When consume access is revoked on an offer for a user, any relations to that offer by that user are set to suspended. This is a new flag on the relation which will drive the uniter to act in a followup PR.

The suspend/resume CLI is also updated to set the new suspended flag.
To retain existing behaviour, the relation status is also set.

Relies on this description PR to land https://github.com/juju/description/pull/25

## QA steps

Deploy a cmr scenario, create an offer
Add a user, grant that user consume access to an offer
As that user, create a connection to the offer
As the admin, remove consume permission
Check that the relation state shows suspended in mongo
As the admin, try and resume the relation -> error because no consume permission