### PR TITLE
2.2 bundle include fixes

### DIFF
--- a/cmd/juju/application/bundle.go
+++ b/cmd/juju/application/bundle.go
@@ -897,6 +897,8 @@ func isErrRelationExists(err error) bool {
 func processBundleIncludes(baseDir string, data *charm.BundleData) error {
 
 	for app, appData := range data.Applications {
+		// A bundle isn't valid if there are no applications, and applications must
+		// specify a charm at least, so we know appData must be non-nil.
 		for key, value := range appData.Options {
 			result, processed, err := processValue(baseDir, value)
 			if err != nil {
@@ -918,6 +920,9 @@ func processBundleIncludes(baseDir string, data *charm.BundleData) error {
 	}
 
 	for machine, machineData := range data.Machines {
+		if machineData == nil {
+			continue
+		}
 		for key, value := range machineData.Annotations {
 			result, processed, err := processValue(baseDir, value)
 			if err != nil {

--- a/cmd/juju/application/bundle.go
+++ b/cmd/juju/application/bundle.go
@@ -341,6 +341,9 @@ func (h *bundleHandler) addService(
 	}
 	resources := make(map[string]string)
 	for resName, path := range p.LocalResources {
+		if !filepath.IsAbs(path) {
+			path = filepath.Clean(filepath.Join(h.bundleDir, path))
+		}
 		resources[resName] = path
 	}
 	for resName, revision := range p.Resources {

--- a/cmd/juju/application/bundle.go
+++ b/cmd/juju/application/bundle.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/juju/bundlechanges"
+	"github.com/juju/cmd"
 	"github.com/juju/errors"
 	"github.com/juju/utils"
 	"gopkg.in/juju/charm.v6-unstable"
@@ -61,7 +62,7 @@ func deployBundle(
 	bundleConfigFile string,
 	channel csparams.Channel,
 	apiRoot DeployAPI,
-	log deploymentLogger,
+	ctx *cmd.Context,
 	bundleStorage map[string]map[string]storage.Constraints,
 ) (map[*charm.URL]*macaroon.Macaroon, error) {
 
@@ -78,6 +79,10 @@ func deployBundle(
 	}
 	var verifyError error
 	if bundleDir == "" {
+		// Process includes in the bundle data.
+		if err := processBundleIncludes(ctx.Dir, data); err != nil {
+			return nil, errors.Annotate(err, "unable to process includes")
+		}
 		verifyError = data.Verify(verifyConstraints, verifyStorage)
 	} else {
 		// Process includes in the bundle data.
@@ -128,7 +133,7 @@ func deployBundle(
 		channel:         channel,
 		api:             apiRoot,
 		bundleStorage:   bundleStorage,
-		log:             log,
+		ctx:             ctx,
 		data:            data,
 		unitStatus:      unitStatus,
 		ignoredMachines: make(map[string]bool, len(data.Applications)),
@@ -211,9 +216,10 @@ type bundleHandler struct {
 	// in the bundle itself.
 	bundleStorage map[string]map[string]storage.Constraints
 
-	// log is used to output messages to the user, so that the user can keep
-	// track of the bundle deployment progress.
-	log deploymentLogger
+	// ctx is the command context, which is used to output messages to the
+	// user, so that the user can keep track of the bundle deployment
+	// progress.
+	ctx *cmd.Context
 
 	// data is the original bundle data that we want to deploy.
 	data *charm.BundleData
@@ -388,7 +394,7 @@ func (h *bundleHandler) addService(
 
 	// Deploy the application.
 	logger.Debugf("application %s is deploying (charm %s)", p.Application, ch)
-	h.log.Infof("Deploying charm %q", ch)
+	h.ctx.Infof("Deploying charm %q", ch)
 	if err := api.Deploy(application.DeployArgs{
 		CharmID:          chID,
 		Cons:             cons,
@@ -400,7 +406,7 @@ func (h *bundleHandler) addService(
 		EndpointBindings: p.EndpointBindings,
 	}); err == nil {
 		for resName := range resNames2IDs {
-			h.log.Infof("added resource %s", resName)
+			h.ctx.Infof("added resource %s", resName)
 		}
 		return nil
 	} else if !isErrServiceExists(err) {
@@ -423,7 +429,7 @@ func (h *bundleHandler) addService(
 			// by the application Deploy call above.
 			return errors.Annotatef(err, "cannot update options for application %q", p.Application)
 		}
-		h.log.Infof("configuration updated for application %s", p.Application)
+		h.ctx.Infof("configuration updated for application %s", p.Application)
 	}
 	// Update application constraints.
 	if p.Constraints != "" {
@@ -431,7 +437,7 @@ func (h *bundleHandler) addService(
 			// This should never happen, as the bundle is already verified.
 			return errors.Annotatef(err, "cannot update constraints for application %q", p.Application)
 		}
-		h.log.Infof("constraints applied for application %s", p.Application)
+		h.ctx.Infof("constraints applied for application %s", p.Application)
 	}
 	return nil
 }
@@ -468,7 +474,7 @@ func (h *bundleHandler) addMachine(id string, p bundlechanges.AddMachineParams) 
 		default:
 			msg = strings.Join(notify[:svcLen-1], ", ") + " and " + notify[svcLen-1]
 		}
-		h.log.Infof("avoid creating other machines to host %s units", msg)
+		h.ctx.Infof("avoid creating other machines to host %s units", msg)
 		return nil
 	}
 	cons, err := constraints.Parse(p.Constraints)
@@ -486,7 +492,7 @@ func (h *bundleHandler) addMachine(id string, p bundlechanges.AddMachineParams) 
 		// placement directives as lxd.
 		if ct == "lxc" {
 			if !h.warnedLXC {
-				h.log.Infof("Bundle has one or more containers specified as lxc. lxc containers are deprecated in Juju 2.0. lxd containers will be deployed instead.")
+				h.ctx.Infof("Bundle has one or more containers specified as lxc. lxc containers are deprecated in Juju 2.0. lxd containers will be deployed instead.")
 				h.warnedLXC = true
 			}
 			ct = string(instance.LXD)
@@ -529,7 +535,7 @@ func (h *bundleHandler) addRelation(id string, p bundlechanges.AddRelationParams
 	_, err := h.api.AddRelation(ep1, ep2)
 	if err == nil {
 		// A new relation has been established.
-		h.log.Infof("Related %q and %q", ep1, ep2)
+		h.ctx.Infof("Related %q and %q", ep1, ep2)
 		return nil
 	}
 	if isErrRelationExists(err) {
@@ -557,7 +563,7 @@ func (h *bundleHandler) addUnit(id string, p bundlechanges.AddUnitParams) error 
 			} else {
 				msg = fmt.Sprintf("%d units already present", num)
 			}
-			h.log.Infof("avoid adding new units to application %s: %s", application, msg)
+			h.ctx.Infof("avoid adding new units to application %s: %s", application, msg)
 		}
 		return nil
 	}
@@ -603,7 +609,7 @@ func (h *bundleHandler) exposeService(id string, p bundlechanges.ExposeParams) e
 	if err := h.api.Expose(application); err != nil {
 		return errors.Annotatef(err, "cannot expose application %s", application)
 	}
-	h.log.Infof("application %s exposed", application)
+	h.ctx.Infof("application %s exposed", application)
 	return nil
 }
 
@@ -832,7 +838,7 @@ func (h *bundleHandler) upgradeCharm(
 		return errors.Annotatef(err, "cannot retrieve info for application %q", applicationName)
 	}
 	if existing.String() == id {
-		h.log.Infof("reusing application %s (charm: %s)", applicationName, id)
+		h.ctx.Infof("reusing application %s (charm: %s)", applicationName, id)
 		return nil
 	}
 	url, err := charm.ParseURL(id)
@@ -874,9 +880,9 @@ func (h *bundleHandler) upgradeCharm(
 	if err := h.api.SetCharm(cfg); err != nil {
 		return errors.Annotatef(err, "cannot upgrade charm to %q", id)
 	}
-	h.log.Infof("upgraded charm for existing application %s (from %s to %s)", applicationName, existing, id)
+	h.ctx.Infof("upgraded charm for existing application %s (from %s to %s)", applicationName, existing, id)
 	for resName := range resNames2IDs {
-		h.log.Infof("added resource %s", resName)
+		h.ctx.Infof("added resource %s", resName)
 	}
 	return nil
 }

--- a/cmd/juju/application/bundle_test.go
+++ b/cmd/juju/application/bundle_test.go
@@ -1560,6 +1560,7 @@ func (*ProcessIncludesSuite) TestBundleReplacements(c *gc.C) {
         machines:
             1:
                 annotations: {foo: bar, baz: "include-file://machine" }
+            2:
     `
 
 	baseDir := c.MkDir()

--- a/cmd/juju/application/bundle_test.go
+++ b/cmd/juju/application/bundle_test.go
@@ -232,9 +232,6 @@ func (s *BundleDeployCharmStoreSuite) TestDeployBundleLocalPath(c *gc.C) {
 }
 
 func (s *BundleDeployCharmStoreSuite) TestDeployBundleLocalResources(c *gc.C) {
-	dir := c.MkDir()
-	testcharms.Repo.ClonedDir(dir, "dummy-resource")
-	path := filepath.Join(dir, "mybundle")
 	data := `
         series: quantal
         applications:
@@ -243,12 +240,11 @@ func (s *BundleDeployCharmStoreSuite) TestDeployBundleLocalResources(c *gc.C) {
                 series: quantal
                 num_units: 1
                 resources:
-                  dummy: %s
+                  dummy: ./dummy-resource/dummy-resource.zip
     `
-	data = fmt.Sprintf(data, filepath.Join(dir, "dummy-resource", "dummy-resource.zip"))
-	err := ioutil.WriteFile(path, []byte(data), 0644)
-	c.Assert(err, jc.ErrorIsNil)
-	_, err = runDeploy(c, path)
+	dir := s.makeBundleDir(c, data)
+	testcharms.Repo.ClonedDir(dir, "dummy-resource")
+	_, err := runDeploy(c, dir)
 	c.Assert(err, jc.ErrorIsNil)
 	s.assertCharmsUploaded(c, "local:quantal/dummy-resource-0")
 	s.assertApplicationsDeployed(c, map[string]serviceInfo{
@@ -402,15 +398,19 @@ func (s *BundleDeployCharmStoreSuite) Client() *csclient.Client {
 // local repository and then deploy it. It returns the bundle deployment output
 // and error.
 func (s *BundleDeployCharmStoreSuite) DeployBundleYAML(c *gc.C, content string, extraArgs ...string) (string, error) {
+	bundlePath := s.makeBundleDir(c, content)
+	args := append([]string{bundlePath}, extraArgs...)
+	return runDeploy(c, args...)
+}
+
+func (s *BundleDeployCharmStoreSuite) makeBundleDir(c *gc.C, content string) string {
 	bundlePath := filepath.Join(c.MkDir(), "example")
 	c.Assert(os.Mkdir(bundlePath, 0777), jc.ErrorIsNil)
-	defer os.RemoveAll(bundlePath)
 	err := ioutil.WriteFile(filepath.Join(bundlePath, "bundle.yaml"), []byte(content), 0644)
 	c.Assert(err, jc.ErrorIsNil)
 	err = ioutil.WriteFile(filepath.Join(bundlePath, "README.md"), []byte("README"), 0644)
 	c.Assert(err, jc.ErrorIsNil)
-	args := append([]string{bundlePath}, extraArgs...)
-	return runDeploy(c, args...)
+	return bundlePath
 }
 
 var deployBundleErrorsTests = []struct {
@@ -426,7 +426,7 @@ var deployBundleErrorsTests = []struct {
                 num_units: 1
     `,
 	err: `the provided bundle has the following errors:
-charm path in application "mysql" does not exist: mysql`,
+charm path in application "mysql" does not exist: .*mysql`,
 }, {
 	about: "charm store charm not found",
 	content: `

--- a/cmd/juju/application/bundle_test.go
+++ b/cmd/juju/application/bundle_test.go
@@ -240,10 +240,13 @@ func (s *BundleDeployCharmStoreSuite) TestDeployBundleLocalResources(c *gc.C) {
                 series: quantal
                 num_units: 1
                 resources:
-                  dummy: ./dummy-resource/dummy-resource.zip
+                  dummy: ./dummy-resource.zip
     `
 	dir := s.makeBundleDir(c, data)
 	testcharms.Repo.ClonedDir(dir, "dummy-resource")
+	c.Assert(
+		ioutil.WriteFile(filepath.Join(dir, "dummy-resource.zip"), []byte("zip file"), 0644),
+		jc.ErrorIsNil)
 	_, err := runDeploy(c, dir)
 	c.Assert(err, jc.ErrorIsNil)
 	s.assertCharmsUploaded(c, "local:quantal/dummy-resource-0")

--- a/cmd/juju/application/deploy.go
+++ b/cmd/juju/application/deploy.go
@@ -764,28 +764,27 @@ func (c *DeployCommand) maybePredeployedLocalCharm() (deployFn, error) {
 
 func (c *DeployCommand) maybeReadLocalBundle() (deployFn, error) {
 	bundleFile := c.CharmOrBundle
-	var (
-		bundleFilePath                string
-		resolveRelativeBundleFilePath bool
-	)
+	var bundleDir string
+	isDir := false
+	resolveDir := false
 
 	bundleData, err := charmrepo.ReadBundleFile(bundleFile)
 	if err != nil {
 		// We may have been given a local bundle archive or exploded directory.
-		bundle, url, pathErr := charmrepo.NewBundleAtPath(bundleFile)
+		bundle, _, pathErr := charmrepo.NewBundleAtPath(bundleFile)
 		if charmrepo.IsInvalidPathError(pathErr) {
 			return nil, errors.Errorf(""+
 				"The charm or bundle %q is ambiguous.\n"+
 				"To deploy a local charm or bundle, run `juju deploy ./%[1]s`.\n"+
 				"To deploy a charm or bundle from the store, run `juju deploy cs:%[1]s`.",
-				c.CharmOrBundle,
+				bundleFile,
 			)
 		}
 		if pathErr != nil {
 			// If the bundle files existed but we couldn't read them,
 			// then return that error rather than trying to interpret
 			// as a charm.
-			if info, statErr := os.Stat(c.CharmOrBundle); statErr == nil {
+			if info, statErr := os.Stat(bundleFile); statErr == nil {
 				if info.IsDir() {
 					if _, ok := pathErr.(*charmrepo.NotFoundError); !ok {
 						return nil, pathErr
@@ -798,12 +797,12 @@ func (c *DeployCommand) maybeReadLocalBundle() (deployFn, error) {
 		}
 
 		bundleData = bundle.Data()
-		bundleFile = url.String()
 		if info, err := os.Stat(bundleFile); err == nil && info.IsDir() {
-			bundleFilePath = bundleFile
+			resolveDir = true
+			isDir = true
 		}
 	} else {
-		resolveRelativeBundleFilePath = true
+		resolveDir = true
 	}
 
 	if err := c.validateBundleFlags(); err != nil {
@@ -811,15 +810,21 @@ func (c *DeployCommand) maybeReadLocalBundle() (deployFn, error) {
 	}
 
 	return func(ctx *cmd.Context, apiRoot DeployAPI) error {
-		// For local bundles, we extract the local path of the bundle
-		// directory.
-		if resolveRelativeBundleFilePath {
-			bundleFilePath = filepath.Dir(ctx.AbsPath(bundleFile))
+		if resolveDir {
+			if isDir {
+				// If we get to here bundleFile is a directory, in which case
+				// we should use the absolute path as the bundFilePath, or it is
+				// an archive, in which case we should pass the empty string.
+				bundleDir = ctx.AbsPath(bundleFile)
+			} else {
+				// If the bundle is defined with just a yaml file, the bundle
+				// path is the directory that holds the file.
+				bundleDir = filepath.Dir(ctx.AbsPath(bundleFile))
+			}
 		}
-
 		return errors.Trace(c.deployBundle(
 			ctx,
-			bundleFilePath,
+			bundleDir,
 			bundleData,
 			c.Channel,
 			apiRoot,


### PR DESCRIPTION
This branch addresses two bugs found in processing bundles, and one that hadn't yet been found.

When the local processing of the include directives came across a machine without a machineSpec, which would happen if nothing was specified, it paniced.

Also, when a bundle was processed as a directory, not a file, then the bundleDir was empty rather than the directory specified. This meant that the bundle was considered a charmstore bundle, not a local bundle, so Verify was called on the bundle rather than VerifyLocal. This would have meant that local resources would fail validation.

## QA steps

```
# Have a local bundle directory (needs bundle.yaml and README.md)
# Make sure there is a machine defined with nothing extra.
juju deploy .
```

## Bug reference

pad.lv/1716462 and pad.lv/1716482
