### PR TITLE
WIP: Remove ModelUUID method from State. 

### DIFF
--- a/api/client_test.go
+++ b/api/client_test.go
@@ -141,14 +141,12 @@ func (s *clientSuite) TestAddLocalCharmOtherModel(c *gc.C) {
 }
 
 func (s *clientSuite) otherModel(c *gc.C) (*state.State, api.Connection) {
-	otherSt := s.Factory.MakeModel(c, nil)
+	model := s.Factory.MakeModel(c, nil)
 	info := s.APIInfo(c)
-	model, err := otherSt.Model()
-	c.Assert(err, jc.ErrorIsNil)
 	info.ModelTag = model.ModelTag()
 	apiState, err := api.Open(info, api.DefaultDialOpts())
 	c.Assert(err, jc.ErrorIsNil)
-	return otherSt, apiState
+	return model.State(), apiState
 }
 
 func (s *clientSuite) TestAddLocalCharmError(c *gc.C) {

--- a/api/controller/legacy_test.go
+++ b/api/controller/legacy_test.go
@@ -49,9 +49,9 @@ func (s *legacySuite) OpenAPI(c *gc.C) *controller.Client {
 func (s *legacySuite) TestAllModels(c *gc.C) {
 	owner := names.NewUserTag("user@remote")
 	s.Factory.MakeModel(c, &factory.ModelParams{
-		Name: "first", Owner: owner}).Close()
+		Name: "first", Owner: owner}).CloseDBConnection()
 	s.Factory.MakeModel(c, &factory.ModelParams{
-		Name: "second", Owner: owner}).Close()
+		Name: "second", Owner: owner}).CloseDBConnection()
 
 	sysManager := s.OpenAPI(c)
 	defer sysManager.Close()
@@ -92,9 +92,9 @@ func (s *legacySuite) TestControllerConfig(c *gc.C) {
 }
 
 func (s *legacySuite) TestDestroyController(c *gc.C) {
-	st := s.Factory.MakeModel(c, &factory.ModelParams{Name: "foo"})
-	factory.NewFactory(st).MakeMachine(c, nil) // make it non-empty
-	st.Close()
+	m := s.Factory.MakeModel(c, &factory.ModelParams{Name: "foo"})
+	factory.NewFactory(m.State()).MakeMachine(c, nil) // make it non-empty
+	m.CloseDBConnection()
 
 	sysManager := s.OpenAPI(c)
 	defer sysManager.Close()

--- a/api/http_test.go
+++ b/api/http_test.go
@@ -174,16 +174,14 @@ func (s *httpSuite) TestControllerMachineAuthForHostedModel(c *gc.C) {
 		Jobs:  []state.MachineJob{state.JobManageModel},
 		Nonce: nonce,
 	})
-	hostedState := s.Factory.MakeModel(c, nil)
-	defer hostedState.Close()
+	hostedModel := s.Factory.MakeModel(c, nil)
+	defer hostedModel.CloseDBConnection()
 
 	// Connect to the hosted model using the credentials of the
 	// controller machine.
 	apiInfo := s.APIInfo(c)
 	apiInfo.Tag = m.Tag()
 	apiInfo.Password = password
-	hostedModel, err := hostedState.Model()
-	c.Assert(err, jc.ErrorIsNil)
 	apiInfo.ModelTag = hostedModel.ModelTag()
 	apiInfo.Nonce = nonce
 	conn, err := api.Open(apiInfo, api.DialOpts{})

--- a/apiserver/authhttp_test.go
+++ b/apiserver/authhttp_test.go
@@ -237,12 +237,11 @@ func (s *authHTTPSuite) authRequest(c *gc.C, p httpRequestParams) *http.Response
 }
 
 func (s *authHTTPSuite) setupOtherModel(c *gc.C) *state.State {
-	modelState := s.Factory.MakeModel(c, nil)
-	s.AddCleanup(func(*gc.C) { modelState.Close() })
-	model, err := modelState.Model()
-	c.Assert(err, jc.ErrorIsNil)
+	model := s.Factory.MakeModel(c, nil)
+	s.AddCleanup(func(*gc.C) { model.State().Close() })
+
 	user := s.Factory.MakeUser(c, nil)
-	_, err = model.AddUser(
+	_, err := model.AddUser(
 		state.UserAccessSpec{
 			User:      user.UserTag(),
 			CreatedBy: s.userTag,
@@ -250,8 +249,8 @@ func (s *authHTTPSuite) setupOtherModel(c *gc.C) *state.State {
 	c.Assert(err, jc.ErrorIsNil)
 	s.userTag = user.UserTag()
 	s.password = "password"
-	s.modelUUID = modelState.ModelUUID()
-	return modelState
+	s.modelUUID = model.UUID()
+	return model.State()
 }
 
 func (s *authHTTPSuite) uploadRequest(c *gc.C, uri string, contentType, path string) *http.Response {

--- a/apiserver/charms_test.go
+++ b/apiserver/charms_test.go
@@ -419,10 +419,9 @@ func (s *charmsSuite) TestMigrateCharm(c *gc.C) {
 	_, err := s.State.SetUserAccess(s.userTag, controllerTag, permission.SuperuserAccess)
 	c.Assert(err, jc.ErrorIsNil)
 
-	newSt := s.Factory.MakeModel(c, nil)
-	defer newSt.Close()
-	importedModel, err := newSt.Model()
-	c.Assert(err, jc.ErrorIsNil)
+	importedModel := s.Factory.MakeModel(c, nil)
+	defer importedModel.CloseDBConnection()
+
 	err = importedModel.SetMigrationMode(state.MigrationModeImporting)
 	c.Assert(err, jc.ErrorIsNil)
 	s.extraHeaders = map[string]string{
@@ -438,7 +437,7 @@ func (s *charmsSuite) TestMigrateCharm(c *gc.C) {
 	s.assertUploadResponse(c, resp, expectedURL.String())
 
 	// The charm was added to the migrated model.
-	_, err = newSt.Charm(expectedURL)
+	_, err = importedModel.State().Charm(expectedURL)
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -448,9 +447,9 @@ func (s *charmsSuite) TestMigrateCharmNotMigrating(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	migratedModel := s.Factory.MakeModel(c, nil)
-	defer migratedModel.Close()
+	defer migratedModel.CloseDBConnection()
 	s.extraHeaders = map[string]string{
-		params.MigrationModelHTTPHeader: migratedModel.ModelUUID(),
+		params.MigrationModelHTTPHeader: migratedModel.UUID(),
 	}
 
 	// The default user is just a normal user, not a controller admin

--- a/apiserver/common/controllerconfig_test.go
+++ b/apiserver/common/controllerconfig_test.go
@@ -106,13 +106,12 @@ var _ = gc.Suite(&controllerInfoSuite{})
 
 func (s *controllerInfoSuite) SetUpTest(c *gc.C) {
 	s.JujuConnSuite.SetUpTest(c)
-	s.localState = s.Factory.MakeModel(c, nil)
+
 	s.AddCleanup(func(*gc.C) {
 		s.localState.Close()
 	})
-	model, err := s.localState.Model()
-	c.Assert(err, jc.ErrorIsNil)
-	s.localModel = model
+	s.localModel = s.Factory.MakeModel(c, nil)
+	s.localState = s.localModel.State()
 }
 
 func (s *controllerInfoSuite) TestControllerInfoLocalModel(c *gc.C) {

--- a/apiserver/facades/client/backups/backups_test.go
+++ b/apiserver/facades/client/backups/backups_test.go
@@ -74,10 +74,8 @@ func (s *backupsSuite) TestNewAPINotAuthorized(c *gc.C) {
 }
 
 func (s *backupsSuite) TestNewAPIHostedEnvironmentFails(c *gc.C) {
-	otherState := factory.NewFactory(s.State).MakeModel(c, nil)
-	defer otherState.Close()
-	otherModel, err := otherState.Model()
-	c.Assert(err, jc.ErrorIsNil)
-	_, err = backupsAPI.NewAPI(&stateShim{otherState, otherModel}, s.resources, s.authorizer)
+	otherModel := factory.NewFactory(s.State).MakeModel(c, nil)
+	defer otherModel.CloseDBConnection()
+	_, err := backupsAPI.NewAPI(&stateShim{otherModel.State(), otherModel}, s.resources, s.authorizer)
 	c.Check(err, gc.ErrorMatches, "backups are not supported for hosted models")
 }

--- a/apiserver/facades/client/client/status_test.go
+++ b/apiserver/facades/client/client/status_test.go
@@ -326,11 +326,8 @@ func (s *statusUnitTestSuite) TestWorkloadVersionOkWithUnset(c *gc.C) {
 func (s *statusUnitTestSuite) TestMigrationInProgress(c *gc.C) {
 
 	// Create a host model because controller models can't be migrated.
-	state2 := s.Factory.MakeModel(c, nil)
-	defer state2.Close()
-
-	model2, err := state2.Model()
-	c.Assert(err, jc.ErrorIsNil)
+	model2 := s.Factory.MakeModel(c, nil)
+	defer model2.CloseDBConnection()
 
 	// Get API connection to hosted model.
 	apiInfo := s.APIInfo(c)
@@ -352,7 +349,7 @@ func (s *statusUnitTestSuite) TestMigrationInProgress(c *gc.C) {
 	checkMigStatus("")
 
 	// Start it migrating.
-	mig, err := state2.CreateMigration(state.MigrationSpec{
+	mig, err := model2.State().CreateMigration(state.MigrationSpec{
 		InitiatedBy: names.NewUserTag("admin"),
 		TargetInfo: migration.TargetInfo{
 			ControllerTag: names.NewControllerTag(utils.MustNewUUID().String()),

--- a/apiserver/facades/client/controller/destroy_test.go
+++ b/apiserver/facades/client/controller/destroy_test.go
@@ -71,7 +71,7 @@ func (s *destroyControllerSuite) SetUpTest(c *gc.C) {
 		ConfigAttrs: testing.Attrs{
 			"controller": false,
 		},
-	})
+	}).State()
 	s.AddCleanup(func(c *gc.C) { s.otherState.Close() })
 	s.otherModelUUID = s.otherState.ModelUUID()
 

--- a/apiserver/facades/client/highavailability/highavailability_test.go
+++ b/apiserver/facades/client/highavailability/highavailability_test.go
@@ -357,10 +357,10 @@ func (s *clientSuite) TestEnableHAErrors(c *gc.C) {
 }
 
 func (s *clientSuite) TestEnableHAHostedEnvErrors(c *gc.C) {
-	st2 := s.Factory.MakeModel(c, &factory.ModelParams{ConfigAttrs: coretesting.Attrs{"controller": false}})
-	defer st2.Close()
+	model2 := s.Factory.MakeModel(c, &factory.ModelParams{ConfigAttrs: coretesting.Attrs{"controller": false}})
+	defer model2.CloseDBConnection()
 
-	haServer, err := highavailability.NewHighAvailabilityAPI(st2, s.resources, s.authoriser)
+	haServer, err := highavailability.NewHighAvailabilityAPI(model2.State(), s.resources, s.authoriser)
 	c.Assert(err, jc.ErrorIsNil)
 
 	enableHAResult, err := enableHA(c, haServer, 3, constraints.MustParse("mem=4G"), defaultSeries, nil)
@@ -371,7 +371,7 @@ func (s *clientSuite) TestEnableHAHostedEnvErrors(c *gc.C) {
 	c.Assert(enableHAResult.Removed, gc.HasLen, 0)
 	c.Assert(enableHAResult.Converted, gc.HasLen, 0)
 
-	machines, err := st2.AllMachines()
+	machines, err := model2.State().AllMachines()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(machines, gc.HasLen, 0)
 }

--- a/apiserver/facades/client/keymanager/keymanager_test.go
+++ b/apiserver/facades/client/keymanager/keymanager_test.go
@@ -218,21 +218,18 @@ func (s *keyManagerSuite) TestAddKeysSuperUser(c *gc.C) {
 }
 
 func (s *keyManagerSuite) TestAddKeysModelAdmin(c *gc.C) {
-	otherState := s.Factory.MakeModel(c, nil)
-	defer otherState.Close()
-
-	otherModel, err := otherState.Model()
-	c.Assert(err, jc.ErrorIsNil)
+	otherModel := s.Factory.MakeModel(c, nil)
+	defer otherModel.CloseDBConnection()
 
 	user := s.Factory.MakeUser(c, &factory.UserParams{Name: "admin" + otherModel.ModelTag().String()})
-	s.assertAddKeys(c, otherState, user.UserTag(), true)
+	s.assertAddKeys(c, otherModel.State(), user.UserTag(), true)
 }
 
 func (s *keyManagerSuite) TestAddKeysModelOwner(c *gc.C) {
 	user := s.Factory.MakeUser(c, nil)
 	otherModel := s.Factory.MakeModel(c, &factory.ModelParams{Owner: user.UserTag()})
-	defer otherModel.Close()
-	s.assertAddKeys(c, otherModel, user.UserTag(), true)
+	defer otherModel.CloseDBConnection()
+	s.assertAddKeys(c, otherModel.State(), user.UserTag(), true)
 }
 
 func (s *keyManagerSuite) TestAddKeysNonAuthorised(c *gc.C) {
@@ -322,21 +319,18 @@ func (s *keyManagerSuite) TestDeleteKeysSuperUser(c *gc.C) {
 }
 
 func (s *keyManagerSuite) TestDeleteKeysModelAdmin(c *gc.C) {
-	otherState := s.Factory.MakeModel(c, nil)
-	defer otherState.Close()
-
-	otherModel, err := otherState.Model()
-	c.Assert(err, jc.ErrorIsNil)
+	otherModel := s.Factory.MakeModel(c, nil)
+	defer otherModel.CloseDBConnection()
 
 	user := s.Factory.MakeUser(c, &factory.UserParams{Name: "admin" + otherModel.ModelTag().String()})
-	s.assertDeleteKeys(c, otherState, user.UserTag(), true)
+	s.assertDeleteKeys(c, otherModel.State(), user.UserTag(), true)
 }
 
 func (s *keyManagerSuite) TestDeleteKeysModelOwner(c *gc.C) {
 	user := s.Factory.MakeUser(c, nil)
 	otherModel := s.Factory.MakeModel(c, &factory.ModelParams{Owner: user.UserTag()})
-	defer otherModel.Close()
-	s.assertDeleteKeys(c, otherModel, user.UserTag(), true)
+	defer otherModel.CloseDBConnection()
+	s.assertDeleteKeys(c, otherModel.State(), user.UserTag(), true)
 }
 
 func (s *keyManagerSuite) TestDeleteKeysNonAuthorised(c *gc.C) {
@@ -509,21 +503,18 @@ func (s *keyManagerSuite) TestImportKeysSuperUser(c *gc.C) {
 }
 
 func (s *keyManagerSuite) TestImportKeysModelAdmin(c *gc.C) {
-	otherState := s.Factory.MakeModel(c, nil)
-	defer otherState.Close()
-
-	otherModel, err := otherState.Model()
-	c.Assert(err, jc.ErrorIsNil)
+	otherModel := s.Factory.MakeModel(c, nil)
+	defer otherModel.CloseDBConnection()
 
 	user := s.Factory.MakeUser(c, &factory.UserParams{Name: "admin" + otherModel.ModelTag().String()})
-	s.assertImportKeys(c, otherState, user.UserTag(), true)
+	s.assertImportKeys(c, otherModel.State(), user.UserTag(), true)
 }
 
 func (s *keyManagerSuite) TestImportKeysModelOwner(c *gc.C) {
 	user := s.Factory.MakeUser(c, nil)
 	otherModel := s.Factory.MakeModel(c, &factory.ModelParams{Owner: user.UserTag()})
-	defer otherModel.Close()
-	s.assertImportKeys(c, otherModel, user.UserTag(), true)
+	defer otherModel.CloseDBConnection()
+	s.assertImportKeys(c, otherModel.State(), user.UserTag(), true)
 }
 
 func (s *keyManagerSuite) TestImportKeysNonAuthorised(c *gc.C) {

--- a/apiserver/facades/client/modelmanager/modelmanager_test.go
+++ b/apiserver/facades/client/modelmanager/modelmanager_test.go
@@ -1234,14 +1234,11 @@ func (s *modelManagerStateSuite) revoke(c *gc.C, user names.UserTag, access para
 
 func (s *modelManagerStateSuite) TestGrantMissingUserFails(c *gc.C) {
 	s.setAPIUser(c, s.AdminUserTag(c))
-	st := s.Factory.MakeModel(c, nil)
-	defer st.Close()
-
-	m, err := st.Model()
-	c.Assert(err, jc.ErrorIsNil)
+	m := s.Factory.MakeModel(c, nil)
+	defer m.CloseDBConnection()
 
 	user := names.NewLocalUserTag("foobar")
-	err = s.grant(c, user, params.ModelReadAccess, m.ModelTag())
+	err := s.grant(c, user, params.ModelReadAccess, m.ModelTag())
 	expectedErr := `could not grant model access: user "foobar" does not exist locally: user "foobar" not found`
 	c.Assert(err, gc.ErrorMatches, expectedErr)
 }
@@ -1280,30 +1277,24 @@ func (s *modelManagerStateSuite) TestRevokeReadRemovesModelUser(c *gc.C) {
 
 func (s *modelManagerStateSuite) TestRevokeModelMissingUser(c *gc.C) {
 	s.setAPIUser(c, s.AdminUserTag(c))
-	st := s.Factory.MakeModel(c, nil)
-	defer st.Close()
-
-	m, err := st.Model()
-	c.Assert(err, jc.ErrorIsNil)
+	m := s.Factory.MakeModel(c, nil)
+	defer m.CloseDBConnection()
 
 	user := names.NewUserTag("bob")
-	err = s.revoke(c, user, params.ModelReadAccess, m.ModelTag())
+	err := s.revoke(c, user, params.ModelReadAccess, m.ModelTag())
 	c.Assert(err, gc.ErrorMatches, `could not revoke model access: model user "bob" does not exist`)
 
-	_, err = st.UserAccess(user, m.ModelTag())
+	_, err = m.State().UserAccess(user, m.ModelTag())
 	c.Assert(errors.IsNotFound(err), jc.IsTrue)
 }
 
 func (s *modelManagerStateSuite) TestGrantOnlyGreaterAccess(c *gc.C) {
 	user := s.Factory.MakeUser(c, &factory.UserParams{Name: "foobar", NoModelUser: true})
 	s.setAPIUser(c, s.AdminUserTag(c))
-	st := s.Factory.MakeModel(c, nil)
-	defer st.Close()
+	m := s.Factory.MakeModel(c, nil)
+	defer m.CloseDBConnection()
 
-	m, err := st.Model()
-	c.Assert(err, jc.ErrorIsNil)
-
-	err = s.grant(c, user.UserTag(), params.ModelReadAccess, m.ModelTag())
+	err := s.grant(c, user.UserTag(), params.ModelReadAccess, m.ModelTag())
 	c.Assert(err, jc.ErrorIsNil)
 
 	err = s.grant(c, user.UserTag(), params.ModelReadAccess, m.ModelTag())
@@ -1331,138 +1322,119 @@ func (s *modelManagerStateSuite) TestGrantModelAddLocalUser(c *gc.C) {
 	user := s.Factory.MakeUser(c, &factory.UserParams{Name: "foobar", NoModelUser: true})
 	apiUser := s.AdminUserTag(c)
 	s.setAPIUser(c, apiUser)
-	st := s.Factory.MakeModel(c, nil)
-	defer st.Close()
+	m := s.Factory.MakeModel(c, nil)
+	defer m.CloseDBConnection()
 
-	m, err := st.Model()
+	err := s.grant(c, user.UserTag(), params.ModelReadAccess, m.ModelTag())
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = s.grant(c, user.UserTag(), params.ModelReadAccess, m.ModelTag())
-	c.Assert(err, jc.ErrorIsNil)
-
-	modelUser, err := st.UserAccess(user.UserTag(), m.ModelTag())
+	modelUser, err := m.State().UserAccess(user.UserTag(), m.ModelTag())
 	c.Assert(err, jc.ErrorIsNil)
 	s.assertNewUser(c, modelUser, user.UserTag(), apiUser)
 	c.Assert(modelUser.Access, gc.Equals, permission.ReadAccess)
 	s.setAPIUser(c, user.UserTag())
-	s.assertModelAccess(c, st)
+	s.assertModelAccess(c, m.State())
 }
 
 func (s *modelManagerStateSuite) TestGrantModelAddRemoteUser(c *gc.C) {
 	userTag := names.NewUserTag("foobar@ubuntuone")
 	apiUser := s.AdminUserTag(c)
 	s.setAPIUser(c, apiUser)
-	st := s.Factory.MakeModel(c, nil)
-	defer st.Close()
+	m := s.Factory.MakeModel(c, nil)
+	defer m.CloseDBConnection()
 
-	m, err := st.Model()
+	err := s.grant(c, userTag, params.ModelReadAccess, m.ModelTag())
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = s.grant(c, userTag, params.ModelReadAccess, m.ModelTag())
-	c.Assert(err, jc.ErrorIsNil)
-
-	modelUser, err := st.UserAccess(userTag, m.ModelTag())
+	modelUser, err := m.State().UserAccess(userTag, m.ModelTag())
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.assertNewUser(c, modelUser, userTag, apiUser)
 	c.Assert(modelUser.Access, gc.Equals, permission.ReadAccess)
 	s.setAPIUser(c, userTag)
-	s.assertModelAccess(c, st)
+	s.assertModelAccess(c, m.State())
 }
 
 func (s *modelManagerStateSuite) TestGrantModelAddAdminUser(c *gc.C) {
 	user := s.Factory.MakeUser(c, &factory.UserParams{Name: "foobar", NoModelUser: true})
 	apiUser := s.AdminUserTag(c)
 	s.setAPIUser(c, apiUser)
-	st := s.Factory.MakeModel(c, nil)
-	defer st.Close()
+	m := s.Factory.MakeModel(c, nil)
+	defer m.CloseDBConnection()
 
-	m, err := st.Model()
-	c.Assert(err, jc.ErrorIsNil)
+	err := s.grant(c, user.UserTag(), params.ModelWriteAccess, m.ModelTag())
 
-	err = s.grant(c, user.UserTag(), params.ModelWriteAccess, m.ModelTag())
-
-	modelUser, err := st.UserAccess(user.UserTag(), m.ModelTag())
+	modelUser, err := m.State().UserAccess(user.UserTag(), m.ModelTag())
 	c.Assert(err, jc.ErrorIsNil)
 	s.assertNewUser(c, modelUser, user.UserTag(), apiUser)
 	c.Assert(modelUser.Access, gc.Equals, permission.WriteAccess)
 	s.setAPIUser(c, user.UserTag())
-	s.assertModelAccess(c, st)
+	s.assertModelAccess(c, m.State())
 }
 
 func (s *modelManagerStateSuite) TestGrantModelIncreaseAccess(c *gc.C) {
 	s.setAPIUser(c, s.AdminUserTag(c))
-	st := s.Factory.MakeModel(c, nil)
-	defer st.Close()
-	stFactory := factory.NewFactory(st)
+	m := s.Factory.MakeModel(c, nil)
+	defer m.CloseDBConnection()
+	stFactory := factory.NewFactory(m.State())
 	user := stFactory.MakeModelUser(c, &factory.ModelUserParams{Access: permission.ReadAccess})
 
-	m, err := st.Model()
+	err := s.grant(c, user.UserTag, params.ModelWriteAccess, m.ModelTag())
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = s.grant(c, user.UserTag, params.ModelWriteAccess, m.ModelTag())
-	c.Assert(err, jc.ErrorIsNil)
-
-	modelUser, err := st.UserAccess(user.UserTag, m.ModelTag())
+	modelUser, err := m.State().UserAccess(user.UserTag, m.ModelTag())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(modelUser.Access, gc.Equals, permission.WriteAccess)
 }
 
 func (s *modelManagerStateSuite) TestGrantToModelNoAccess(c *gc.C) {
 	s.setAPIUser(c, s.AdminUserTag(c))
-	st := s.Factory.MakeModel(c, nil)
-	defer st.Close()
-
-	m, err := st.Model()
-	c.Assert(err, jc.ErrorIsNil)
+	m := s.Factory.MakeModel(c, nil)
+	defer m.CloseDBConnection()
 
 	apiUser := names.NewUserTag("bob@remote")
 	s.setAPIUser(c, apiUser)
 
 	other := names.NewUserTag("other@remote")
-	err = s.grant(c, other, params.ModelReadAccess, m.ModelTag())
+	err := s.grant(c, other, params.ModelReadAccess, m.ModelTag())
 	c.Assert(err, gc.ErrorMatches, "permission denied")
 }
 
 func (s *modelManagerStateSuite) TestGrantToModelReadAccess(c *gc.C) {
 	s.setAPIUser(c, s.AdminUserTag(c))
-	st := s.Factory.MakeModel(c, nil)
-	defer st.Close()
+	m := s.Factory.MakeModel(c, nil)
+	defer m.CloseDBConnection()
 
 	apiUser := names.NewUserTag("bob@remote")
 	s.setAPIUser(c, apiUser)
 
-	stFactory := factory.NewFactory(st)
+	stFactory := factory.NewFactory(m.State())
 	stFactory.MakeModelUser(c, &factory.ModelUserParams{
 		User: apiUser.Id(), Access: permission.ReadAccess})
 
 	other := names.NewUserTag("other@remote")
-	m, err := st.Model()
-	c.Assert(err, jc.ErrorIsNil)
 
-	err = s.grant(c, other, params.ModelReadAccess, m.ModelTag())
+	err := s.grant(c, other, params.ModelReadAccess, m.ModelTag())
 	c.Assert(err, gc.ErrorMatches, "permission denied")
 }
 
 func (s *modelManagerStateSuite) TestGrantToModelWriteAccess(c *gc.C) {
 	s.setAPIUser(c, s.AdminUserTag(c))
-	st := s.Factory.MakeModel(c, nil)
-	defer st.Close()
+	m := s.Factory.MakeModel(c, nil)
+	defer m.CloseDBConnection()
 
 	apiUser := names.NewUserTag("admin@remote")
 	s.setAPIUser(c, apiUser)
-	stFactory := factory.NewFactory(st)
+	stFactory := factory.NewFactory(m.State())
 	stFactory.MakeModelUser(c, &factory.ModelUserParams{
 		User: apiUser.Id(), Access: permission.AdminAccess})
 
 	other := names.NewUserTag("other@remote")
-	m, err := st.Model()
+
+	err := s.grant(c, other, params.ModelReadAccess, m.ModelTag())
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = s.grant(c, other, params.ModelReadAccess, m.ModelTag())
-	c.Assert(err, jc.ErrorIsNil)
-
-	modelUser, err := st.UserAccess(other, m.ModelTag())
+	modelUser, err := m.State().UserAccess(other, m.ModelTag())
 	c.Assert(err, jc.ErrorIsNil)
 	s.assertNewUser(c, modelUser, other, apiUser)
 	c.Assert(modelUser.Access, gc.Equals, permission.ReadAccess)

--- a/apiserver/facades/client/usermanager/usermanager_test.go
+++ b/apiserver/facades/client/usermanager/usermanager_test.go
@@ -63,8 +63,8 @@ func (s *userManagerSuite) TestNewUserManagerAPIRefusesNonClient(c *gc.C) {
 }
 
 func (s *userManagerSuite) assertAddUser(c *gc.C, access params.UserAccessPermission, sharedModelTags []string) {
-	sharedModelState := s.Factory.MakeModel(c, nil)
-	defer sharedModelState.Close()
+	sharedModel := s.Factory.MakeModel(c, nil)
+	defer sharedModel.CloseDBConnection()
 
 	args := params.AddUsers{
 		Users: []params.AddUser{{

--- a/apiserver/utils_test.go
+++ b/apiserver/utils_test.go
@@ -30,7 +30,7 @@ func (s *utilsSuite) TestValidateEmpty(c *gc.C) {
 			statePool: s.pool,
 		})
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(uuid, gc.Equals, s.State.ModelUUID())
+	c.Assert(uuid, gc.Equals, s.Model.UUID())
 }
 
 func (s *utilsSuite) TestValidateEmptyStrict(c *gc.C) {
@@ -46,21 +46,21 @@ func (s *utilsSuite) TestValidateController(c *gc.C) {
 	uuid, err := validateModelUUID(
 		validateArgs{
 			statePool: s.pool,
-			modelUUID: s.State.ModelUUID(),
+			modelUUID: s.Model.UUID(),
 		})
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(uuid, gc.Equals, s.State.ModelUUID())
+	c.Assert(uuid, gc.Equals, s.Model.UUID())
 }
 
 func (s *utilsSuite) TestValidateControllerStrict(c *gc.C) {
 	uuid, err := validateModelUUID(
 		validateArgs{
 			statePool: s.pool,
-			modelUUID: s.State.ModelUUID(),
+			modelUUID: s.Model.UUID(),
 			strict:    true,
 		})
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(uuid, gc.Equals, s.State.ModelUUID())
+	c.Assert(uuid, gc.Equals, s.Model.UUID())
 }
 
 func (s *utilsSuite) TestValidateBadModelUUID(c *gc.C) {
@@ -73,26 +73,25 @@ func (s *utilsSuite) TestValidateBadModelUUID(c *gc.C) {
 }
 
 func (s *utilsSuite) TestValidateOtherModel(c *gc.C) {
-	envState := s.Factory.MakeModel(c, nil)
-	defer envState.Close()
+	envModel := s.Factory.MakeModel(c, nil)
+	defer envModel.CloseDBConnection()
 
 	uuid, err := validateModelUUID(
 		validateArgs{
 			statePool: s.pool,
-			modelUUID: envState.ModelUUID(),
+			modelUUID: envModel.UUID(),
 		})
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(uuid, gc.Equals, envState.ModelUUID())
+	c.Assert(uuid, gc.Equals, envModel.UUID())
 }
 
 func (s *utilsSuite) TestValidateOtherModelControllerOnly(c *gc.C) {
-	envState := s.Factory.MakeModel(c, nil)
-	defer envState.Close()
-
+	envModel := s.Factory.MakeModel(c, nil)
+	defer envModel.CloseDBConnection()
 	_, err := validateModelUUID(
 		validateArgs{
 			statePool:           s.pool,
-			modelUUID:           envState.ModelUUID(),
+			modelUUID:           envModel.UUID(),
 			controllerModelOnly: true,
 		})
 	c.Assert(err, gc.ErrorMatches, `requested model ".*" is not the controller model`)

--- a/cmd/juju/status/status_test.go
+++ b/cmd/juju/status/status_test.go
@@ -3826,11 +3826,11 @@ func (s *StatusSuite) setupMigrationTest(c *gc.C) *state.State {
 	const statusText = "foo bar"
 
 	f := factory.NewFactory(s.BackingState)
-	hostedSt := f.MakeModel(c, &factory.ModelParams{
+	hostedModel := f.MakeModel(c, &factory.ModelParams{
 		Name: hostedModelName,
 	})
 
-	mig, err := hostedSt.CreateMigration(state.MigrationSpec{
+	mig, err := hostedModel.State().CreateMigration(state.MigrationSpec{
 		InitiatedBy: names.NewUserTag("admin"),
 		TargetInfo: migration.TargetInfo{
 			ControllerTag: names.NewControllerTag(utils.MustNewUUID().String()),
@@ -3844,7 +3844,7 @@ func (s *StatusSuite) setupMigrationTest(c *gc.C) *state.State {
 	err = mig.SetStatusMessage(statusText)
 	c.Assert(err, jc.ErrorIsNil)
 
-	return hostedSt
+	return hostedModel.State()
 }
 
 type fakeAPIClient struct {

--- a/cmd/jujud/agent/machine_test.go
+++ b/cmd/jujud/agent/machine_test.go
@@ -1417,7 +1417,7 @@ func (s *MachineSuite) TestModelWorkersRespectSingularResponsibilityFlag(c *gc.C
 
 func (s *MachineSuite) setUpNewModel(c *gc.C) (newSt *state.State, closer func()) {
 	// Create a new environment, tests can now watch if workers start for it.
-	newSt = s.Factory.MakeModel(c, &factory.ModelParams{
+	newModel := s.Factory.MakeModel(c, &factory.ModelParams{
 		ConfigAttrs: coretesting.Attrs{
 			"max-status-history-age":  "2h",
 			"max-status-history-size": "4M",
@@ -1425,8 +1425,8 @@ func (s *MachineSuite) setUpNewModel(c *gc.C) (newSt *state.State, closer func()
 			"max-action-results-size": "4M",
 		},
 	})
-	return newSt, func() {
-		err := newSt.Close()
+	return newModel.State(), func() {
+		err := newModel.CloseDBConnection()
 		c.Check(err, jc.ErrorIsNil)
 	}
 }

--- a/featuretests/api_model_test.go
+++ b/featuretests/api_model_test.go
@@ -114,11 +114,8 @@ func lastConnPointer(c *gc.C, mod *state.Model, modelUser permission.UserAccess)
 
 func (s *apiEnvironmentSuite) TestUploadToolsOtherEnvironment(c *gc.C) {
 	// setup other environment
-	otherState := s.Factory.MakeModel(c, nil)
-	defer otherState.Close()
-
-	otherModel, err := otherState.Model()
-	c.Assert(err, jc.ErrorIsNil)
+	otherModel := s.Factory.MakeModel(c, nil)
+	defer otherModel.CloseDBConnection()
 
 	info := s.APIInfo(c)
 	info.ModelTag = otherModel.ModelTag()
@@ -140,7 +137,7 @@ func (s *apiEnvironmentSuite) TestUploadToolsOtherEnvironment(c *gc.C) {
 	c.Assert(toolsList, gc.HasLen, 1)
 	c.Assert(toolsList[0].SHA256, gc.Equals, checksum)
 
-	toolStrg, err := otherState.ToolsStorage()
+	toolStrg, err := otherModel.State().ToolsStorage()
 	defer toolStrg.Close()
 	c.Assert(err, jc.ErrorIsNil)
 	meta, closer, err := toolStrg.Open(vers)

--- a/featuretests/api_undertaker_test.go
+++ b/featuretests/api_undertaker_test.go
@@ -168,7 +168,7 @@ func (s *undertakerSuite) TestHostedRemoveEnviron(c *gc.C) {
 }
 
 func (s *undertakerSuite) hostedAPI(c *gc.C) (*undertaker.Client, *state.State) {
-	otherState := s.Factory.MakeModel(c, &factory.ModelParams{Name: "hosted-env"})
+	otherModel := s.Factory.MakeModel(c, &factory.ModelParams{Name: "hosted-env"})
 
 	password, err := utils.RandomPassword()
 	c.Assert(err, jc.ErrorIsNil)
@@ -184,7 +184,7 @@ func (s *undertakerSuite) hostedAPI(c *gc.C) (*undertaker.Client, *state.State) 
 	info.Tag = machine.Tag()
 	info.Password = password
 	info.Nonce = "fake_nonce"
-	info.ModelTag = names.NewModelTag(otherState.ModelUUID())
+	info.ModelTag = names.NewModelTag(otherModel.UUID())
 
 	otherAPIState, err := api.Open(info, api.DefaultDialOpts())
 	c.Assert(err, jc.ErrorIsNil)
@@ -193,5 +193,5 @@ func (s *undertakerSuite) hostedAPI(c *gc.C) (*undertaker.Client, *state.State) 
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(undertakerClient, gc.NotNil)
 
-	return undertakerClient, otherState
+	return undertakerClient, otherModel.State()
 }

--- a/featuretests/cmd_juju_crossmodel_test.go
+++ b/featuretests/cmd_juju_crossmodel_test.go
@@ -347,7 +347,7 @@ func (s *crossmodelSuite) TestAddRelationSameControllerSameOwner(c *gc.C) {
 	s.AddTestingApplication(c, "wordpress", ch)
 
 	otherModel := s.Factory.MakeModel(c, &factory.ModelParams{Name: "othermodel"})
-	s.AddCleanup(func(*gc.C) { otherModel.Close() })
+	s.AddCleanup(func(*gc.C) { otherModel.CloseDBConnection() })
 
 	mysql := testcharms.Repo.CharmDir("mysql")
 	ident := fmt.Sprintf("%s-%d", mysql.Meta().Name, mysql.Revision())
@@ -357,14 +357,14 @@ func (s *crossmodelSuite) TestAddRelationSameControllerSameOwner(c *gc.C) {
 		charmrepo.NewCharmStoreParams{},
 		testcharms.Repo.Path())
 	c.Assert(err, jc.ErrorIsNil)
-	ch, err = jujutesting.PutCharm(otherModel, curl, repo, false)
+	ch, err = jujutesting.PutCharm(otherModel.State(), curl, repo, false)
 	c.Assert(err, jc.ErrorIsNil)
-	_, err = otherModel.AddApplication(state.AddApplicationArgs{
+	_, err = otherModel.State().AddApplication(state.AddApplicationArgs{
 		Name:  "mysql",
 		Charm: ch,
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	offersAPi := state.NewApplicationOffers(otherModel)
+	offersAPi := state.NewApplicationOffers(otherModel.State())
 	_, err = offersAPi.AddOffer(jujucrossmodel.AddApplicationOfferArgs{
 		OfferName:       "hosted-mysql",
 		ApplicationName: "mysql",
@@ -378,7 +378,7 @@ func (s *crossmodelSuite) TestAddRelationSameControllerSameOwner(c *gc.C) {
 func (s *crossmodelSuite) addOtherModelApplication(c *gc.C) *state.State {
 	otherOwner := s.Factory.MakeUser(c, &factory.UserParams{Name: "otheruser"})
 	otherModel := s.Factory.MakeModel(c, &factory.ModelParams{Name: "othermodel", Owner: otherOwner.Tag()})
-	s.AddCleanup(func(*gc.C) { otherModel.Close() })
+	s.AddCleanup(func(*gc.C) { otherModel.CloseDBConnection() })
 
 	mysql := testcharms.Repo.CharmDir("mysql")
 	ident := fmt.Sprintf("%s-%d", mysql.Meta().Name, mysql.Revision())
@@ -388,14 +388,14 @@ func (s *crossmodelSuite) addOtherModelApplication(c *gc.C) *state.State {
 		charmrepo.NewCharmStoreParams{},
 		testcharms.Repo.Path())
 	c.Assert(err, jc.ErrorIsNil)
-	ch, err := jujutesting.PutCharm(otherModel, curl, repo, false)
+	ch, err := jujutesting.PutCharm(otherModel.State(), curl, repo, false)
 	c.Assert(err, jc.ErrorIsNil)
-	_, err = otherModel.AddApplication(state.AddApplicationArgs{
+	_, err = otherModel.State().AddApplication(state.AddApplicationArgs{
 		Name:  "mysql",
 		Charm: ch,
 	})
 
-	offersAPi := state.NewApplicationOffers(otherModel)
+	offersAPi := state.NewApplicationOffers(otherModel.State())
 	_, err = offersAPi.AddOffer(jujucrossmodel.AddApplicationOfferArgs{
 		OfferName:       "hosted-mysql",
 		ApplicationName: "mysql",
@@ -403,7 +403,7 @@ func (s *crossmodelSuite) addOtherModelApplication(c *gc.C) *state.State {
 		Owner:           otherOwner.Name(),
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	return otherModel
+	return otherModel.State()
 }
 
 func (s *crossmodelSuite) runJujuCommndWithStdin(c *gc.C, stdin io.Reader, args ...string) {

--- a/featuretests/cmd_juju_dumplogs_test.go
+++ b/featuretests/cmd_juju_dumplogs_test.go
@@ -43,11 +43,11 @@ func (s *dumpLogsCommandSuite) TestRun(c *gc.C) {
 	s.PrimeStateAgent(c, m.Tag(), password)
 
 	//  Create multiple environments and add some logs for each.
-	st1 := s.Factory.MakeModel(c, nil)
-	defer st1.Close()
-	st2 := s.Factory.MakeModel(c, nil)
-	defer st2.Close()
-	states := []*state.State{s.State, st1, st2}
+	m1 := s.Factory.MakeModel(c, nil)
+	defer m1.CloseDBConnection()
+	m2 := s.Factory.MakeModel(c, nil)
+	defer m2.CloseDBConnection()
+	states := []*state.State{s.State, m1.State(), m2.State()}
 
 	t := time.Date(2015, 11, 4, 3, 2, 1, 0, time.UTC)
 	for _, st := range states {

--- a/state/address_test.go
+++ b/state/address_test.go
@@ -64,9 +64,9 @@ func (s *ControllerAddressesSuite) TestControllerEnv(c *gc.C) {
 }
 
 func (s *ControllerAddressesSuite) TestOtherEnv(c *gc.C) {
-	st := s.Factory.MakeModel(c, nil)
-	defer st.Close()
-	addresses, err := st.Addresses()
+	model := s.Factory.MakeModel(c, nil)
+	defer model.CloseDBConnection()
+	addresses, err := model.State().Addresses()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(addresses, jc.SameContents, []string{"10.0.1.2:1234"})
 }

--- a/state/block_test.go
+++ b/state/block_test.go
@@ -162,15 +162,15 @@ func (s *blockSuite) TestRemoveAllBlocksForControllerNoBlocks(c *gc.C) {
 }
 
 func (s *blockSuite) TestModelUUID(c *gc.C) {
-	st := s.Factory.MakeModel(c, nil)
-	defer st.Close()
-	err := st.SwitchBlockOn(state.ChangeBlock, "blocktest")
+	m := s.Factory.MakeModel(c, nil)
+	defer m.CloseDBConnection()
+	err := m.State().SwitchBlockOn(state.ChangeBlock, "blocktest")
 	c.Assert(err, jc.ErrorIsNil)
 
-	blocks, err := st.AllBlocks()
+	blocks, err := m.State().AllBlocks()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(len(blocks), gc.Equals, 1)
-	c.Assert(blocks[0].ModelUUID(), gc.Equals, st.ModelUUID())
+	c.Assert(blocks[0].ModelUUID(), gc.Equals, m.UUID())
 }
 
 func (s *blockSuite) createTestModel(c *gc.C) (*state.Model, *state.State) {

--- a/state/cleanup_test.go
+++ b/state/cleanup_test.go
@@ -142,11 +142,9 @@ func (s *CleanupSuite) TestCleanupControllerModels(c *gc.C) {
 	s.assertDoesNotNeedCleanup(c)
 
 	// Create a non-empty hosted model.
-	otherSt := s.Factory.MakeModel(c, nil)
-	defer otherSt.Close()
-	factory.NewFactory(otherSt).MakeApplication(c, nil)
-	otherEnv, err := otherSt.Model()
-	c.Assert(err, jc.ErrorIsNil)
+	otherModel := s.Factory.MakeModel(c, nil)
+	defer otherModel.CloseDBConnection()
+	factory.NewFactory(otherModel.State()).MakeApplication(c, nil)
 
 	s.assertDoesNotNeedCleanup(c)
 
@@ -163,9 +161,9 @@ func (s *CleanupSuite) TestCleanupControllerModels(c *gc.C) {
 	// models, the other to destroy the controller model's
 	// applications.
 	s.assertCleanupCount(c, 1)
-	err = otherEnv.Refresh()
+	err = otherModel.Refresh()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(otherEnv.Life(), gc.Equals, state.Dying)
+	c.Assert(otherModel.Life(), gc.Equals, state.Dying)
 
 	s.assertDoesNotNeedCleanup(c)
 }

--- a/state/collection_test.go
+++ b/state/collection_test.go
@@ -141,9 +141,9 @@ func (s *collectionSuite) TestModelStateCollection(c *gc.C) {
 	// 2 models with machines in each.
 	m0 := s.Factory.MakeMachine(c, nil)
 	s.Factory.MakeMachine(c, nil)
-	st1 := s.Factory.MakeModel(c, nil)
-	defer st1.Close()
-	f1 := factory.NewFactory(st1)
+	m1 := s.Factory.MakeModel(c, nil)
+	defer m1.CloseDBConnection()
+	f1 := factory.NewFactory(m1.State())
 	otherM0 := f1.MakeMachine(c, &factory.MachineParams{Series: "trusty"})
 
 	// Ensure that the first machine in each model have overlapping ids
@@ -152,7 +152,7 @@ func (s *collectionSuite) TestModelStateCollection(c *gc.C) {
 
 	machines0, closer := state.GetCollection(s.State, state.MachinesC)
 	defer closer()
-	machines1, closer := state.GetCollection(st1, state.MachinesC)
+	machines1, closer := state.GetCollection(m1.State(), state.MachinesC)
 	defer closer()
 
 	machinesSnapshot := newCollectionSnapshot(c, machines0.Writeable().Underlying())

--- a/state/initialize_test.go
+++ b/state/initialize_test.go
@@ -1,4 +1,4 @@
-// Copyright Canonical Ltd. 2013
+// Copyright 2013 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
 package state_test
@@ -57,9 +57,8 @@ func (s *InitializeSuite) openState(c *gc.C, modelTag names.ModelTag) {
 	c.Assert(err, jc.ErrorIsNil)
 	s.State = st
 
-	m, err := st.Model()
+	s.Model, err = st.Model()
 	c.Assert(err, jc.ErrorIsNil)
-	s.Model = m
 }
 
 func (s *InitializeSuite) TearDownTest(c *gc.C) {

--- a/state/internal_test.go
+++ b/state/internal_test.go
@@ -37,6 +37,7 @@ type internalStateSuite struct {
 	testing.BaseSuite
 	controller *Controller
 	state      *State
+	model      *Model
 	owner      names.UserTag
 	modelCount int
 }
@@ -99,6 +100,9 @@ func (s *internalStateSuite) SetUpTest(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	s.controller = ctlr
 	s.state = st
+	m, err := s.state.Model()
+	c.Assert(err, jc.ErrorIsNil)
+	s.model = m
 	s.AddCleanup(func(*gc.C) {
 		s.state.Close()
 		s.controller.Close()

--- a/state/logs_test.go
+++ b/state/logs_test.go
@@ -228,13 +228,15 @@ func (s *LogsSuite) TestPruneLogsBySize(c *gc.C) {
 	startingLogsS0 := 10
 	s.generateLogs(c, s0, now, startingLogsS0)
 
-	s1 := s.Factory.MakeModel(c, nil)
-	defer s1.Close()
+	m1 := s.Factory.MakeModel(c, nil)
+	defer m1.CloseDBConnection()
+	s1 := m1.State()
 	startingLogsS1 := 10000
 	s.generateLogs(c, s1, now, startingLogsS1)
 
-	s2 := s.Factory.MakeModel(c, nil)
-	defer s2.Close()
+	m2 := s.Factory.MakeModel(c, nil)
+	defer m2.CloseDBConnection()
+	s2 := m2.State()
 	startingLogsS2 := 12000
 	s.generateLogs(c, s2, now, startingLogsS2)
 

--- a/state/model.go
+++ b/state/model.go
@@ -197,6 +197,16 @@ func (st *State) Model() (*Model, error) {
 	return model, nil
 }
 
+// CloseDBConnection closes a Model's connection to the database.
+func (model *Model) CloseDBConnection() error {
+	return model.st.Close()
+}
+
+// State return the model's state.
+func (model *Model) State() *State {
+	return model.st
+}
+
 // AllModelUUIDs returns the UUIDs for all models in the controller.
 // Results are sorted by (name, owner).
 func (st *State) AllModelUUIDs() ([]string, error) {
@@ -1290,12 +1300,6 @@ func (m *Model) getEntityRefs() (*modelEntityRefsDoc, error) {
 		return nil, errors.Annotatef(err, "getting entity references for model %s", m.UUID())
 	}
 	return &doc, nil
-}
-
-// (TODO) externalreality: Temporary method to access state from model while
-// factoring Model concerns out from state.
-func (model *Model) State() *State {
-	return model.st
 }
 
 // checkModelEntityRefsEmpty checks that the model is empty of any entities

--- a/state/model_test.go
+++ b/state/model_test.go
@@ -332,25 +332,21 @@ func (s *ModelSuite) TestModelActiveNoModel(c *gc.C) {
 }
 
 func (s *ModelSuite) TestModelActiveImporting(c *gc.C) {
-	st := s.Factory.MakeModel(c, nil)
-	defer st.Close()
-	model, err := st.Model()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(model.SetMigrationMode(state.MigrationModeImporting), jc.ErrorIsNil)
+	m := s.Factory.MakeModel(c, nil)
+	defer m.CloseDBConnection()
+	c.Assert(m.SetMigrationMode(state.MigrationModeImporting), jc.ErrorIsNil)
 
-	modelActive, err := s.State.ModelActive(model.UUID())
+	modelActive, err := s.State.ModelActive(m.UUID())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(modelActive, jc.IsFalse)
 }
 
 func (s *ModelSuite) TestModelActiveExporting(c *gc.C) {
-	st := s.Factory.MakeModel(c, nil)
-	defer st.Close()
-	model, err := st.Model()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(model.SetMigrationMode(state.MigrationModeExporting), jc.ErrorIsNil)
+	m := s.Factory.MakeModel(c, nil)
+	defer m.CloseDBConnection()
+	c.Assert(m.SetMigrationMode(state.MigrationModeExporting), jc.ErrorIsNil)
 
-	modelActive, err := s.State.ModelActive(model.UUID())
+	modelActive, err := s.State.ModelActive(m.UUID())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(modelActive, jc.IsTrue)
 }
@@ -440,10 +436,8 @@ func (s *ModelSuite) TestMeterStatus(c *gc.C) {
 }
 
 func (s *ModelSuite) TestConfigForOtherModel(c *gc.C) {
-	otherState := s.Factory.MakeModel(c, &factory.ModelParams{Name: "other"})
-	defer otherState.Close()
-	otherModel, err := otherState.Model()
-	c.Assert(err, jc.ErrorIsNil)
+	otherModel := s.Factory.MakeModel(c, &factory.ModelParams{Name: "other"})
+	defer otherModel.CloseDBConnection()
 
 	// Obtain another instance of the model via the StatePool
 	model, release, err := s.StatePool.GetModel(otherModel.UUID())
@@ -508,14 +502,12 @@ func (s *ModelSuite) TestModelConfigSameModelAsState(c *gc.C) {
 }
 
 func (s *ModelSuite) TestModelConfigDifferentModelThanState(c *gc.C) {
-	otherState := s.Factory.MakeModel(c, nil)
-	defer otherState.Close()
-	model, err := otherState.Model()
-	c.Assert(err, jc.ErrorIsNil)
-	cfg, err := model.Config()
+	otherModel := s.Factory.MakeModel(c, nil)
+	defer otherModel.CloseDBConnection()
+	cfg, err := otherModel.Config()
 	c.Assert(err, jc.ErrorIsNil)
 	uuid := cfg.UUID()
-	c.Assert(uuid, gc.Equals, model.UUID())
+	c.Assert(uuid, gc.Equals, otherModel.UUID())
 	c.Assert(uuid, gc.Not(gc.Equals), s.State.ModelUUID())
 }
 
@@ -527,46 +519,41 @@ func (s *ModelSuite) TestDestroyControllerModel(c *gc.C) {
 }
 
 func (s *ModelSuite) TestDestroyOtherModel(c *gc.C) {
-	st2 := s.Factory.MakeModel(c, nil)
-	defer st2.Close()
-	model, err := st2.Model()
-	c.Assert(err, jc.ErrorIsNil)
-	err = model.Destroy(state.DestroyModelParams{})
+	m2 := s.Factory.MakeModel(c, nil)
+	defer m2.CloseDBConnection()
+	err := m2.Destroy(state.DestroyModelParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	// Destroying an empty model also removes the name index doc.
-	c.Assert(model.UniqueIndexExists(), jc.IsFalse)
+	c.Assert(m2.UniqueIndexExists(), jc.IsFalse)
 }
 
 func (s *ModelSuite) TestDestroyControllerNonEmptyModelFails(c *gc.C) {
-	st2 := s.Factory.MakeModel(c, nil)
-	defer st2.Close()
-	factory.NewFactory(st2).MakeApplication(c, nil)
+	m2 := s.Factory.MakeModel(c, nil)
+	defer m2.CloseDBConnection()
+	factory.NewFactory(m2.State()).MakeApplication(c, nil)
 
-	model, err := s.State.Model()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(model.Destroy(state.DestroyModelParams{}), gc.ErrorMatches, "failed to destroy model: hosting 1 other model")
+	c.Assert(s.IAASModel.Destroy(state.DestroyModelParams{}), gc.ErrorMatches, "failed to destroy model: hosting 1 other model")
 }
 
 func (s *ModelSuite) TestDestroyControllerEmptyModel(c *gc.C) {
-	st2 := s.Factory.MakeModel(c, nil)
-	defer st2.Close()
+	m2 := s.Factory.MakeModel(c, nil)
+	defer m2.CloseDBConnection()
 
-	controllerModel, err := s.State.Model()
-	c.Assert(err, jc.ErrorIsNil)
+	controllerModel := s.IAASModel
+
 	c.Assert(controllerModel.Destroy(state.DestroyModelParams{}), jc.ErrorIsNil)
 	c.Assert(controllerModel.Refresh(), jc.ErrorIsNil)
 	c.Assert(controllerModel.Life(), gc.Equals, state.Dying)
 
-	hostedModel, err := st2.Model()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Logf("model %s, life %s", hostedModel.UUID(), hostedModel.Life())
-	c.Assert(hostedModel.Life(), gc.Equals, state.Dead)
+	m2.Refresh()
+	c.Logf("model %s, life %s", m2.UUID(), m2.Life())
+	c.Assert(m2.Life(), gc.Equals, state.Dead)
 }
 
 func (s *ModelSuite) TestDestroyControllerAndHostedModels(c *gc.C) {
-	st2 := s.Factory.MakeModel(c, nil)
-	defer st2.Close()
-	factory.NewFactory(st2).MakeApplication(c, nil)
+	m2 := s.Factory.MakeModel(c, nil)
+	defer m2.CloseDBConnection()
+	factory.NewFactory(m2.State()).MakeApplication(c, nil)
 
 	controllerModel, err := s.State.Model()
 	c.Assert(err, jc.ErrorIsNil)
@@ -576,36 +563,34 @@ func (s *ModelSuite) TestDestroyControllerAndHostedModels(c *gc.C) {
 		DestroyStorage:      &destroyStorage,
 	}), jc.ErrorIsNil)
 
-	model, err := s.State.Model()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(model.Life(), gc.Equals, state.Dying)
+	controllerModel.Refresh()
+	c.Assert(controllerModel.Life(), gc.Equals, state.Dying)
 
 	assertNeedsCleanup(c, s.State)
 	assertCleanupRuns(c, s.State)
 
 	// Cleanups for hosted model enqueued by controller model cleanups.
-	assertNeedsCleanup(c, st2)
-	assertCleanupRuns(c, st2)
+	assertNeedsCleanup(c, m2.State())
+	assertCleanupRuns(c, m2.State())
 
-	model2, err := st2.Model()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(model2.Life(), gc.Equals, state.Dying)
+	m2.Refresh()
+	c.Assert(m2.Life(), gc.Equals, state.Dying)
+	c.Assert(m2.State().ProcessDyingModel(), jc.ErrorIsNil)
 
-	c.Assert(st2.ProcessDyingModel(), jc.ErrorIsNil)
-
-	c.Assert(model2.Refresh(), jc.ErrorIsNil)
-	c.Assert(model2.Life(), gc.Equals, state.Dead)
-	err = st2.RemoveAllModelDocs()
+	c.Assert(m2.Refresh(), jc.ErrorIsNil)
+	c.Assert(m2.Life(), gc.Equals, state.Dead)
+	err = m2.State().RemoveAllModelDocs()
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Assert(s.State.ProcessDyingModel(), jc.ErrorIsNil)
-	c.Assert(model.Refresh(), jc.ErrorIsNil)
-	c.Assert(model2.Life(), gc.Equals, state.Dead)
+	c.Assert(controllerModel.Refresh(), jc.ErrorIsNil)
+	c.Assert(m2.Life(), gc.Equals, state.Dead)
 }
 
 func (s *ModelSuite) TestDestroyControllerAndHostedModelsWithResources(c *gc.C) {
-	otherSt := s.Factory.MakeModel(c, nil)
-	defer otherSt.Close()
+	otherModel := s.Factory.MakeModel(c, nil)
+	defer otherModel.CloseDBConnection()
+	otherSt := otherModel.State()
 
 	assertModel := func(model *state.Model, st *state.State, life state.Life, expectedMachines, expectedServices int) {
 		c.Assert(model.Refresh(), jc.ErrorIsNil)
@@ -620,10 +605,7 @@ func (s *ModelSuite) TestDestroyControllerAndHostedModelsWithResources(c *gc.C) 
 		c.Assert(services, gc.HasLen, expectedServices)
 	}
 
-	// add some machines and services
-	otherModel, err := otherSt.Model()
-	c.Assert(err, jc.ErrorIsNil)
-	_, err = otherSt.AddMachine("quantal", state.JobHostUnits)
+	_, err := otherSt.AddMachine("quantal", state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)
 	service := s.Factory.MakeApplication(c, nil)
 	ch, _, err := service.Charm()
@@ -672,12 +654,12 @@ func (s *ModelSuite) TestDestroyControllerAndHostedModelsWithResources(c *gc.C) 
 }
 
 func (s *ModelSuite) TestDestroyControllerAndHostedModelsWithPersistentStorage(c *gc.C) {
-	otherSt := s.Factory.MakeModel(c, nil)
-	defer otherSt.Close()
+	otherModel := s.Factory.MakeModel(c, nil)
+	defer otherModel.CloseDBConnection()
 
 	// Add a unit with persistent storage, which will prevent Destroy
 	// from succeeding on account of DestroyStorage being nil.
-	otherFactory := factory.NewFactory(otherSt)
+	otherFactory := factory.NewFactory(otherModel.State())
 	otherFactory.MakeUnit(c, &factory.UnitParams{
 		Application: otherFactory.MakeApplication(c, &factory.ApplicationParams{
 			Charm: otherFactory.MakeCharm(c, &factory.CharmParams{
@@ -699,12 +681,12 @@ func (s *ModelSuite) TestDestroyControllerAndHostedModelsWithPersistentStorage(c
 }
 
 func (s *ModelSuite) TestDestroyControllerEmptyModelRace(c *gc.C) {
-	defer s.Factory.MakeModel(c, nil).Close()
+	defer s.Factory.MakeModel(c, nil).CloseDBConnection()
 
 	// Simulate an empty model being added just before the
 	// remove txn is called.
 	defer state.SetBeforeHooks(c, s.State, func() {
-		s.Factory.MakeModel(c, nil).Close()
+		s.Factory.MakeModel(c, nil).CloseDBConnection()
 	}).Check()
 
 	model, err := s.State.Model()
@@ -713,39 +695,35 @@ func (s *ModelSuite) TestDestroyControllerEmptyModelRace(c *gc.C) {
 }
 
 func (s *ModelSuite) TestDestroyControllerRemoveEmptyAddNonEmptyModel(c *gc.C) {
-	st2 := s.Factory.MakeModel(c, nil)
-	defer st2.Close()
+	m2 := s.Factory.MakeModel(c, nil)
+	defer m2.CloseDBConnection()
 
 	// Simulate an empty model being removed, and a new non-empty
 	// model being added, just before the remove txn is called.
 	defer state.SetBeforeHooks(c, s.State, func() {
 		// Destroy the empty model, which should move it right
 		// along to Dead, and then remove it.
-		model, err := st2.Model()
-		c.Assert(err, jc.ErrorIsNil)
-		c.Assert(model.Destroy(state.DestroyModelParams{}), jc.ErrorIsNil)
-		err = st2.RemoveAllModelDocs()
+		c.Assert(m2.Destroy(state.DestroyModelParams{}), jc.ErrorIsNil)
+		err := m2.State().RemoveAllModelDocs()
 		c.Assert(err, jc.ErrorIsNil)
 
 		// Add a new, non-empty model. This should still prevent
 		// the controller from being destroyed.
-		st3 := s.Factory.MakeModel(c, nil)
-		defer st3.Close()
-		factory.NewFactory(st3).MakeApplication(c, nil)
+		m3 := s.Factory.MakeModel(c, nil)
+		defer m3.CloseDBConnection()
+		factory.NewFactory(m3.State()).MakeApplication(c, nil)
 	}).Check()
 
-	model, err := s.State.Model()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(model.Destroy(state.DestroyModelParams{}), gc.ErrorMatches, "failed to destroy model: hosting 1 other model")
+	c.Assert(s.IAASModel.Destroy(state.DestroyModelParams{}), gc.ErrorMatches, "failed to destroy model: hosting 1 other model")
 }
 
 func (s *ModelSuite) TestDestroyControllerNonEmptyModelRace(c *gc.C) {
 	// Simulate an empty model being added just before the
 	// remove txn is called.
 	defer state.SetBeforeHooks(c, s.State, func() {
-		st := s.Factory.MakeModel(c, nil)
-		defer st.Close()
-		factory.NewFactory(st).MakeApplication(c, nil)
+		m := s.Factory.MakeModel(c, nil)
+		defer m.CloseDBConnection()
+		factory.NewFactory(m.State()).MakeApplication(c, nil)
 	}).Check()
 
 	model, err := s.State.Model()
@@ -898,10 +876,9 @@ func (s *ModelSuite) TestDestroyModelReleaseStorageUnreleasable(c *gc.C) {
 }
 
 func (s *ModelSuite) TestDestroyModelAddServiceConcurrently(c *gc.C) {
-	st := s.Factory.MakeModel(c, nil)
-	defer st.Close()
-	m, err := st.Model()
-	c.Assert(err, jc.ErrorIsNil)
+	m := s.Factory.MakeModel(c, nil)
+	defer m.CloseDBConnection()
+	st := m.State()
 
 	defer state.SetBeforeHooks(c, st, func() {
 		factory.NewFactory(st).MakeApplication(c, nil)
@@ -913,10 +890,9 @@ func (s *ModelSuite) TestDestroyModelAddServiceConcurrently(c *gc.C) {
 }
 
 func (s *ModelSuite) TestDestroyModelAddMachineConcurrently(c *gc.C) {
-	st := s.Factory.MakeModel(c, nil)
-	defer st.Close()
-	m, err := st.Model()
-	c.Assert(err, jc.ErrorIsNil)
+	m := s.Factory.MakeModel(c, nil)
+	defer m.CloseDBConnection()
+	st := m.State()
 
 	defer state.SetBeforeHooks(c, st, func() {
 		factory.NewFactory(st).MakeMachine(c, nil)
@@ -928,10 +904,8 @@ func (s *ModelSuite) TestDestroyModelAddMachineConcurrently(c *gc.C) {
 }
 
 func (s *ModelSuite) TestDestroyModelEmpty(c *gc.C) {
-	st := s.Factory.MakeModel(c, nil)
-	defer st.Close()
-	m, err := st.Model()
-	c.Assert(err, jc.ErrorIsNil)
+	m := s.Factory.MakeModel(c, nil)
+	defer m.CloseDBConnection()
 
 	c.Assert(m.Destroy(state.DestroyModelParams{}), jc.ErrorIsNil)
 	c.Assert(m.Refresh(), jc.ErrorIsNil)
@@ -943,9 +917,9 @@ func (s *ModelSuite) TestProcessDyingServerModelTransitionDyingToDead(c *gc.C) {
 }
 
 func (s *ModelSuite) TestProcessDyingHostedModelTransitionDyingToDead(c *gc.C) {
-	st := s.Factory.MakeModel(c, nil)
-	defer st.Close()
-	s.assertDyingModelTransitionDyingToDead(c, st)
+	m := s.Factory.MakeModel(c, nil)
+	defer m.CloseDBConnection()
+	s.assertDyingModelTransitionDyingToDead(c, m.State())
 }
 
 func (s *ModelSuite) assertDyingModelTransitionDyingToDead(c *gc.C, st *state.State) {
@@ -978,16 +952,16 @@ func (s *ModelSuite) assertDyingModelTransitionDyingToDead(c *gc.C, st *state.St
 }
 
 func (s *ModelSuite) TestProcessDyingModelWithMachinesAndServicesNoOp(c *gc.C) {
-	st := s.Factory.MakeModel(c, nil)
-	defer st.Close()
+	m := s.Factory.MakeModel(c, nil)
+	defer m.CloseDBConnection()
+	st := m.State()
 
 	// calling ProcessDyingModel on a live environ should fail.
-	err := st.ProcessDyingModel()
+	err := m.State().ProcessDyingModel()
 	c.Assert(err, gc.ErrorMatches, "model is not dying")
 
 	// add some machines and services
-	model, err := st.Model()
-	c.Assert(err, jc.ErrorIsNil)
+
 	_, err = st.AddMachine("quantal", state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)
 	service := s.Factory.MakeApplication(c, nil)
@@ -1001,8 +975,8 @@ func (s *ModelSuite) TestProcessDyingModelWithMachinesAndServicesNoOp(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	assertModel := func(life state.Life, expectedMachines, expectedServices int) {
-		c.Assert(model.Refresh(), jc.ErrorIsNil)
-		c.Assert(model.Life(), gc.Equals, life)
+		c.Assert(m.Refresh(), jc.ErrorIsNil)
+		c.Assert(m.Life(), gc.Equals, life)
 
 		machines, err := st.AllMachines()
 		c.Assert(err, jc.ErrorIsNil)
@@ -1022,21 +996,18 @@ func (s *ModelSuite) TestProcessDyingModelWithMachinesAndServicesNoOp(c *gc.C) {
 		c.Assert(err, gc.ErrorMatches, `model not empty, found 1 machine, 1 application`)
 	}).Check()
 
-	c.Assert(model.Refresh(), jc.ErrorIsNil)
-	c.Assert(model.Destroy(state.DestroyModelParams{}), jc.ErrorIsNil)
+	c.Assert(m.Refresh(), jc.ErrorIsNil)
+	c.Assert(m.Destroy(state.DestroyModelParams{}), jc.ErrorIsNil)
 }
 
 func (s *ModelSuite) TestProcessDyingModelWithVolumeBackedFilesystems(c *gc.C) {
-	st := s.Factory.MakeModel(c, nil)
-	defer st.Close()
+	m := s.Factory.MakeModel(c, nil)
+	defer m.CloseDBConnection()
 
-	model, err := st.Model()
+	imodel, err := m.IAASModel()
 	c.Assert(err, jc.ErrorIsNil)
 
-	imodel, err := model.IAASModel()
-	c.Assert(err, jc.ErrorIsNil)
-
-	machine, err := st.AddOneMachine(state.MachineTemplate{
+	machine, err := m.State().AddOneMachine(state.MachineTemplate{
 		Series: "quantal",
 		Jobs:   []state.MachineJob{state.JobHostUnits},
 		Filesystems: []state.MachineFilesystemParams{{
@@ -1073,22 +1044,19 @@ func (s *ModelSuite) TestProcessDyingModelWithVolumeBackedFilesystems(c *gc.C) {
 
 	// The filesystem will be gone, but the volume is persistent and should
 	// not have been removed.
-	err = st.ProcessDyingModel()
+	err = m.State().ProcessDyingModel()
 	c.Assert(err, jc.Satisfies, state.IsModelNotEmptyError)
 	c.Assert(err, gc.ErrorMatches, `model not empty, found 1 volume, 1 filesystem`)
 }
 
 func (s *ModelSuite) TestProcessDyingModelWithVolumes(c *gc.C) {
-	st := s.Factory.MakeModel(c, nil)
-	defer st.Close()
+	m := s.Factory.MakeModel(c, nil)
+	defer m.CloseDBConnection()
 
-	model, err := st.Model()
+	imodel, err := m.IAASModel()
 	c.Assert(err, jc.ErrorIsNil)
 
-	imodel, err := model.IAASModel()
-	c.Assert(err, jc.ErrorIsNil)
-
-	machine, err := st.AddOneMachine(state.MachineTemplate{
+	machine, err := m.State().AddOneMachine(state.MachineTemplate{
 		Series: "quantal",
 		Jobs:   []state.MachineJob{state.JobHostUnits},
 		Volumes: []state.MachineVolumeParams{{
@@ -1122,16 +1090,16 @@ func (s *ModelSuite) TestProcessDyingModelWithVolumes(c *gc.C) {
 
 	// The volume is persistent and should not have been removed along with
 	// the machine it was attached to.
-	err = st.ProcessDyingModel()
+	err = m.State().ProcessDyingModel()
 	c.Assert(err, jc.Satisfies, state.IsModelNotEmptyError)
 	c.Assert(err, gc.ErrorMatches, `model not empty, found 1 volume`)
 }
 
 func (s *ModelSuite) TestProcessDyingControllerModelWithHostedModelsNoOp(c *gc.C) {
 	// Add a non-empty model to the controller.
-	st := s.Factory.MakeModel(c, nil)
-	defer st.Close()
-	factory.NewFactory(st).MakeApplication(c, nil)
+	m := s.Factory.MakeModel(c, nil)
+	defer m.CloseDBConnection()
+	factory.NewFactory(m.State()).MakeApplication(c, nil)
 
 	controllerModel, err := s.State.Model()
 	c.Assert(err, jc.ErrorIsNil)
@@ -1182,14 +1150,12 @@ func (s *ModelSuite) TestListUsersTwoModels(c *gc.C) {
 	model, err := s.State.Model()
 	c.Assert(err, jc.ErrorIsNil)
 
-	otherModelState := s.Factory.MakeModel(c, nil)
-	defer otherModelState.Close()
-	otherModel, err := otherModelState.Model()
-	c.Assert(err, jc.ErrorIsNil)
+	otherModel := s.Factory.MakeModel(c, nil)
+	defer otherModel.CloseDBConnection()
 
 	// Add users to both models
 	expectedUsers := addModelUsers(c, s.State)
-	expectedUsersOtherModel := addModelUsers(c, otherModelState)
+	expectedUsersOtherModel := addModelUsers(c, otherModel.State())
 
 	// test that only the expected users are listed for each model
 	obtainedUsers, err := model.Users()
@@ -1239,18 +1205,18 @@ func assertObtainedUsersMatchExpectedUsers(c *gc.C, obtainedUsers, expectedUsers
 }
 
 func (s *ModelSuite) TestAllModelUUIDs(c *gc.C) {
-	st1 := s.Factory.MakeModel(c, nil)
-	defer st1.Close()
+	m1 := s.Factory.MakeModel(c, nil)
+	defer m1.CloseDBConnection()
 
-	st2 := s.Factory.MakeModel(c, nil)
-	defer st2.Close()
+	m2 := s.Factory.MakeModel(c, nil)
+	defer m2.CloseDBConnection()
 
 	obtained, err := s.State.AllModelUUIDs()
 	c.Assert(err, jc.ErrorIsNil)
 	expected := []string{
 		s.State.ModelUUID(),
-		st1.ModelUUID(),
-		st2.ModelUUID(),
+		m1.UUID(),
+		m2.UUID(),
 	}
 	c.Assert(obtained, jc.DeepEquals, expected)
 }
@@ -1258,36 +1224,30 @@ func (s *ModelSuite) TestAllModelUUIDs(c *gc.C) {
 func (s *ModelSuite) TestHostedModelCount(c *gc.C) {
 	c.Assert(state.HostedModelCount(c, s.State), gc.Equals, 0)
 
-	st1 := s.Factory.MakeModel(c, nil)
-	defer st1.Close()
+	m1 := s.Factory.MakeModel(c, nil)
+	defer m1.CloseDBConnection()
 	c.Assert(state.HostedModelCount(c, s.State), gc.Equals, 1)
 
-	st2 := s.Factory.MakeModel(c, nil)
-	defer st2.Close()
+	m2 := s.Factory.MakeModel(c, nil)
+	defer m2.CloseDBConnection()
 	c.Assert(state.HostedModelCount(c, s.State), gc.Equals, 2)
 
-	model1, err := st1.Model()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(model1.Destroy(state.DestroyModelParams{}), jc.ErrorIsNil)
-	c.Assert(st1.RemoveAllModelDocs(), jc.ErrorIsNil)
+	c.Assert(m1.Destroy(state.DestroyModelParams{}), jc.ErrorIsNil)
+	c.Assert(m1.State().RemoveAllModelDocs(), jc.ErrorIsNil)
 	c.Assert(state.HostedModelCount(c, s.State), gc.Equals, 1)
 
-	model2, err := st2.Model()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(model2.Destroy(state.DestroyModelParams{}), jc.ErrorIsNil)
-	c.Assert(st2.RemoveAllModelDocs(), jc.ErrorIsNil)
+	c.Assert(m2.Destroy(state.DestroyModelParams{}), jc.ErrorIsNil)
+	c.Assert(m2.State().RemoveAllModelDocs(), jc.ErrorIsNil)
 	c.Assert(state.HostedModelCount(c, s.State), gc.Equals, 0)
 }
 
 func (s *ModelSuite) TestNewModelEnvironVersion(c *gc.C) {
 	v := 123
-	st := s.Factory.MakeModel(c, &factory.ModelParams{
+	m := s.Factory.MakeModel(c, &factory.ModelParams{
 		EnvironVersion: v,
 	})
-	defer st.Close()
+	defer m.CloseDBConnection()
 
-	m, err := st.Model()
-	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(m.EnvironVersion(), gc.Equals, v)
 }
 

--- a/state/modelconfig.go
+++ b/state/modelconfig.go
@@ -19,7 +19,7 @@ var disallowedModelConfigAttrs = [...]string{
 	"ca-private-key",
 }
 
-// ModelConfig returns the complete config for the model
+// ModelConfig returns the complete config for the model.
 func (m *Model) ModelConfig() (*config.Config, error) {
 	return getModelConfig(m.st.db())
 }

--- a/state/modelconfig_test.go
+++ b/state/modelconfig_test.go
@@ -336,6 +336,7 @@ func (s *ModelConfigSourceSuite) TestNewModelConfigForksControllerValue(c *gc.C)
 	defer st.Close()
 
 	m, err := st.Model()
+	c.Assert(err, jc.ErrorIsNil)
 
 	modelCfg, err := m.ModelConfig()
 	c.Assert(err, jc.ErrorIsNil)

--- a/state/modelmigration_test.go
+++ b/state/modelmigration_test.go
@@ -37,7 +37,7 @@ func (s *MigrationSuite) SetUpTest(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Create a hosted model to migrate.
-	s.State2 = s.Factory.MakeModel(c, nil)
+	s.State2 = s.Factory.MakeModel(c, nil).State()
 	s.AddCleanup(func(*gc.C) { s.State2.Close() })
 
 	targetControllerTag := names.NewControllerTag(utils.MustNewUUID().String())
@@ -110,7 +110,7 @@ func (s *MigrationSuite) TestIsMigrationActive(c *gc.C) {
 
 func (s *MigrationSuite) TestIdSequencesAreIndependent(c *gc.C) {
 	st2 := s.State2
-	st3 := s.Factory.MakeModel(c, nil)
+	st3 := s.Factory.MakeModel(c, nil).State()
 	s.AddCleanup(func(*gc.C) { st3.Close() })
 
 	mig2, err := st2.CreateMigration(s.stdSpec)
@@ -534,7 +534,7 @@ func (s *MigrationSuite) TestWatchForMigrationMultiModel(c *gc.C) {
 
 	// Create another hosted model to migrate and watch for
 	// migrations.
-	State3 := s.Factory.MakeModel(c, nil)
+	State3 := s.Factory.MakeModel(c, nil).State()
 	s.AddCleanup(func(*gc.C) { State3.Close() })
 	_, wc3 := s.createMigrationWatcher(c, State3)
 	wc3.AssertOneChange()
@@ -608,7 +608,7 @@ func (s *MigrationSuite) TestWatchMigrationStatusMultiModel(c *gc.C) {
 
 	// Create another hosted model to migrate and watch for
 	// migrations.
-	State3 := s.Factory.MakeModel(c, nil)
+	State3 := s.Factory.MakeModel(c, nil).State()
 	s.AddCleanup(func(*gc.C) { State3.Close() })
 	_, wc3 := s.createStatusWatcher(c, State3)
 	wc3.AssertOneChange() // initial event
@@ -752,7 +752,7 @@ func (s *MigrationSuite) TestWatchMinionReportsMultiModel(c *gc.C) {
 	mig, wc := s.createMigAndWatchReports(c, s.State2)
 	wc.AssertOneChange() // initial event
 
-	State3 := s.Factory.MakeModel(c, nil)
+	State3 := s.Factory.MakeModel(c, nil).State()
 	s.AddCleanup(func(*gc.C) { State3.Close() })
 	mig3, wc3 := s.createMigAndWatchReports(c, State3)
 	wc3.AssertOneChange() // initial event

--- a/state/policy.go
+++ b/state/policy.go
@@ -101,12 +101,7 @@ func (st *State) constraintsValidator() (constraints.Validator, error) {
 		return nil, errors.Annotate(err, "getting model")
 	}
 	if region := model.CloudRegion(); region != "" {
-		m, err := st.Model()
-		if err != nil {
-			return nil, errors.Trace(err)
-		}
-
-		cfg, err := m.ModelConfig()
+		cfg, err := model.ModelConfig()
 		if err != nil {
 			return nil, errors.Trace(err)
 		}

--- a/state/pool_test.go
+++ b/state/pool_test.go
@@ -28,11 +28,11 @@ func (s *statePoolSuite) SetUpTest(c *gc.C) {
 	s.StateSuite.SetUpTest(c)
 	s.ModelUUID = s.State.ModelUUID()
 
-	s.State1 = s.Factory.MakeModel(c, nil)
+	s.State1 = s.Factory.MakeModel(c, nil).State()
 	s.AddCleanup(func(*gc.C) { s.State1.Close() })
 	s.ModelUUID1 = s.State1.ModelUUID()
 
-	s.State2 = s.Factory.MakeModel(c, nil)
+	s.State2 = s.Factory.MakeModel(c, nil).State()
 	s.AddCleanup(func(*gc.C) { s.State2.Close() })
 	s.ModelUUID2 = s.State2.ModelUUID()
 

--- a/state/sequence_test.go
+++ b/state/sequence_test.go
@@ -43,7 +43,7 @@ func (s *sequenceSuite) TestMultipleSequences(c *gc.C) {
 
 func (s *sequenceSuite) TestSequenceWithMultipleEnvs(c *gc.C) {
 	state1 := s.State
-	state2 := s.Factory.MakeModel(c, nil)
+	state2 := s.Factory.MakeModel(c, nil).State()
 	defer state2.Close()
 
 	s.incAndCheck(c, state1, "foo", 0)

--- a/state/sshhostkeys_test.go
+++ b/state/sshhostkeys_test.go
@@ -44,7 +44,7 @@ func (s *SSHHostKeysSuite) TestModelIsolation(c *gc.C) {
 	keysA := state.SSHHostKeys{"rsaA", "dsaA"}
 	c.Assert(stA.SetSSHHostKeys(tagA, keysA), jc.ErrorIsNil)
 
-	stB := s.Factory.MakeModel(c, nil)
+	stB := s.Factory.MakeModel(c, nil).State()
 	defer stB.Close()
 	factoryB := factory.NewFactory(stB)
 	tagB := factoryB.MakeMachine(c, nil).MachineTag()

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -111,7 +111,7 @@ func (s *StateSuite) TestOpenControllerTwice(c *gc.C) {
 
 func (s *StateSuite) TestIsController(c *gc.C) {
 	c.Assert(s.State.IsController(), jc.IsTrue)
-	st2 := s.Factory.MakeModel(c, nil)
+	st2 := s.Factory.MakeModel(c, nil).State()
 	defer st2.Close()
 	c.Assert(st2.IsController(), jc.IsFalse)
 }
@@ -122,7 +122,7 @@ func (s *StateSuite) TestControllerOwner(c *gc.C) {
 	c.Assert(owner, gc.Equals, s.Owner)
 
 	// Check that other models return the same controller owner.
-	otherSt := s.Factory.MakeModel(c, nil)
+	otherSt := s.Factory.MakeModel(c, nil).State()
 	defer otherSt.Close()
 
 	owner2, err := otherSt.ControllerOwner()
@@ -323,10 +323,8 @@ func (s *MultiModelStateSuite) SetUpTest(c *gc.C) {
 		validator.RegisterUnsupported([]string{constraints.CpuPower})
 		return validator, nil
 	}
-	s.OtherState = s.Factory.MakeModel(c, nil)
-	m, err := s.OtherState.Model()
-	c.Assert(err, jc.ErrorIsNil)
-	s.OtherModel = m
+	s.OtherModel = s.Factory.MakeModel(c, nil)
+	s.OtherState = s.OtherModel.State()
 }
 
 func (s *MultiModelStateSuite) TearDownTest(c *gc.C) {
@@ -919,7 +917,7 @@ func (s *StateSuite) TestAddMachine(c *gc.C) {
 	check(m[0], "0", "quantal", allJobs)
 	check(m[1], "1", "blahblah", oneJob)
 
-	st2 := s.Factory.MakeModel(c, nil)
+	st2 := s.Factory.MakeModel(c, nil).State()
 	defer st2.Close()
 	_, err = st2.AddMachine("quantal", state.JobManageModel)
 	c.Assert(err, gc.ErrorMatches, "cannot add a new machine: controller jobs specified but not allowed")
@@ -2071,23 +2069,21 @@ func (s *StateSuite) TestWatchModelsBulkEvents(c *gc.C) {
 	alive := s.model
 
 	// Dying model...
-	st1 := s.Factory.MakeModel(c, nil)
-	defer st1.Close()
+	m1 := s.Factory.MakeModel(c, nil)
+	defer m1.CloseDBConnection()
+	st1 := m1.State()
 	// Add a service so Destroy doesn't advance to Dead.
 	app := factory.NewFactory(st1).MakeApplication(c, nil)
-	dying, err := st1.Model()
-	c.Assert(err, jc.ErrorIsNil)
-	err = dying.Destroy(state.DestroyModelParams{})
+	dying := m1
+	err := dying.Destroy(state.DestroyModelParams{})
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Add an empty model, destroy and remove it; we should
 	// never see it reported.
-	st2 := s.Factory.MakeModel(c, nil)
-	defer st2.Close()
-	model2, err := st2.Model()
-	c.Assert(err, jc.ErrorIsNil)
+	model2 := s.Factory.MakeModel(c, nil)
+	defer model2.CloseDBConnection()
 	c.Assert(model2.Destroy(state.DestroyModelParams{}), jc.ErrorIsNil)
-	err = st2.RemoveAllModelDocs()
+	err = model2.State().RemoveAllModelDocs()
 	c.Assert(err, jc.ErrorIsNil)
 
 	// All except the removed model are reported in initial event.
@@ -2115,16 +2111,16 @@ func (s *StateSuite) TestWatchModelsLifecycle(c *gc.C) {
 	wc.AssertNoChange()
 
 	// Add a non-empty model: reported.
-	st1 := s.Factory.MakeModel(c, nil)
-	defer st1.Close()
+	model := s.Factory.MakeModel(c, nil)
+	defer model.CloseDBConnection()
+	st1 := model.State()
 	app := factory.NewFactory(st1).MakeApplication(c, nil)
-	model, err := st1.Model()
-	c.Assert(err, jc.ErrorIsNil)
+
 	wc.AssertChange(model.UUID())
 	wc.AssertNoChange()
 
 	// Make it Dying: reported.
-	err = model.Destroy(state.DestroyModelParams{})
+	err := model.Destroy(state.DestroyModelParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	wc.AssertChange(model.UUID())
 	wc.AssertNoChange()
@@ -2686,7 +2682,7 @@ func (s *StateSuite) TestRemoveAllModelDocs(c *gc.C) {
 }
 
 func (s *StateSuite) TestRemoveAllModelDocsAliveEnvFails(c *gc.C) {
-	st := s.Factory.MakeModel(c, nil)
+	st := s.Factory.MakeModel(c, nil).State()
 	defer st.Close()
 
 	err := st.RemoveAllModelDocs()
@@ -2694,7 +2690,7 @@ func (s *StateSuite) TestRemoveAllModelDocsAliveEnvFails(c *gc.C) {
 }
 
 func (s *StateSuite) TestRemoveImportingModelDocsFailsActive(c *gc.C) {
-	st := s.Factory.MakeModel(c, nil)
+	st := s.Factory.MakeModel(c, nil).State()
 	defer st.Close()
 
 	err := st.RemoveImportingModelDocs()
@@ -2702,11 +2698,11 @@ func (s *StateSuite) TestRemoveImportingModelDocsFailsActive(c *gc.C) {
 }
 
 func (s *StateSuite) TestRemoveImportingModelDocsFailsExporting(c *gc.C) {
-	st := s.Factory.MakeModel(c, nil)
-	defer st.Close()
-	model, err := st.Model()
-	c.Assert(err, jc.ErrorIsNil)
-	err = model.SetMigrationMode(state.MigrationModeExporting)
+	model := s.Factory.MakeModel(c, nil)
+	defer model.CloseDBConnection()
+	st := model.State()
+
+	err := model.SetMigrationMode(state.MigrationModeExporting)
 	c.Assert(err, jc.ErrorIsNil)
 
 	err = st.RemoveImportingModelDocs()
@@ -2714,15 +2710,13 @@ func (s *StateSuite) TestRemoveImportingModelDocsFailsExporting(c *gc.C) {
 }
 
 func (s *StateSuite) TestRemoveImportingModelDocsImporting(c *gc.C) {
-	st := s.Factory.MakeModel(c, nil)
-	defer st.Close()
+	m := s.Factory.MakeModel(c, nil)
+	defer m.CloseDBConnection()
+	st := m.State()
 	userModelKey := s.insertFakeModelDocs(c, st)
 	c.Assert(state.HostedModelCount(c, st), gc.Equals, 1)
 
-	m, err := st.Model()
-	c.Assert(err, jc.ErrorIsNil)
-
-	err = m.SetMigrationMode(state.MigrationModeImporting)
+	err := m.SetMigrationMode(state.MigrationModeImporting)
 	c.Assert(err, jc.ErrorIsNil)
 
 	err = s.model.SetMigrationMode(state.MigrationModeImporting)
@@ -2742,7 +2736,7 @@ func (s *StateSuite) TestRemoveImportingModelDocsImporting(c *gc.C) {
 }
 
 func (s *StateSuite) TestRemoveExportingModelDocsFailsActive(c *gc.C) {
-	st := s.Factory.MakeModel(c, nil)
+	st := s.Factory.MakeModel(c, nil).State()
 	defer st.Close()
 
 	err := st.RemoveExportingModelDocs()
@@ -2750,29 +2744,25 @@ func (s *StateSuite) TestRemoveExportingModelDocsFailsActive(c *gc.C) {
 }
 
 func (s *StateSuite) TestRemoveExportingModelDocsFailsImporting(c *gc.C) {
-	st := s.Factory.MakeModel(c, nil)
-	defer st.Close()
+	model := s.Factory.MakeModel(c, nil)
+	defer model.CloseDBConnection()
 
-	model, err := st.Model()
+	err := model.SetMigrationMode(state.MigrationModeImporting)
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = model.SetMigrationMode(state.MigrationModeImporting)
-	c.Assert(err, jc.ErrorIsNil)
-
-	err = st.RemoveExportingModelDocs()
+	err = model.State().RemoveExportingModelDocs()
 	c.Assert(err, gc.ErrorMatches, "can't remove model: model not being exported for migration")
 }
 
 func (s *StateSuite) TestRemoveExportingModelDocsExporting(c *gc.C) {
-	st := s.Factory.MakeModel(c, nil)
-	defer st.Close()
+	model := s.Factory.MakeModel(c, nil)
+	defer model.CloseDBConnection()
+	st := model.State()
+
 	userModelKey := s.insertFakeModelDocs(c, st)
 	c.Assert(state.HostedModelCount(c, s.State), gc.Equals, 1)
 
-	model, err := st.Model()
-	c.Assert(err, jc.ErrorIsNil)
-
-	err = model.SetMigrationMode(state.MigrationModeExporting)
+	err := model.SetMigrationMode(state.MigrationModeExporting)
 	c.Assert(err, jc.ErrorIsNil)
 
 	err = st.RemoveExportingModelDocs()
@@ -2791,13 +2781,11 @@ func (s *StateSuite) TestRemoveExportingModelDocsExporting(c *gc.C) {
 }
 
 func (s *StateSuite) TestRemoveExportingModelDocsRemovesLogs(c *gc.C) {
-	st := s.Factory.MakeModel(c, nil)
-	defer st.Close()
+	model := s.Factory.MakeModel(c, nil)
+	defer model.CloseDBConnection()
+	st := model.State()
 
-	model, err := st.Model()
-	c.Assert(err, jc.ErrorIsNil)
-
-	err = model.SetMigrationMode(state.MigrationModeExporting)
+	err := model.SetMigrationMode(state.MigrationModeExporting)
 	c.Assert(err, jc.ErrorIsNil)
 
 	writeLogs(c, st, 5)
@@ -2811,13 +2799,11 @@ func (s *StateSuite) TestRemoveExportingModelDocsRemovesLogs(c *gc.C) {
 }
 
 func (s *StateSuite) TestRemoveImportingModelDocsRemovesLogs(c *gc.C) {
-	st := s.Factory.MakeModel(c, nil)
-	defer st.Close()
+	model := s.Factory.MakeModel(c, nil)
+	defer model.CloseDBConnection()
+	st := model.State()
 
-	model, err := st.Model()
-	c.Assert(err, jc.ErrorIsNil)
-
-	err = model.SetMigrationMode(state.MigrationModeImporting)
+	err := model.SetMigrationMode(state.MigrationModeImporting)
 	c.Assert(err, jc.ErrorIsNil)
 
 	writeLogs(c, st, 5)
@@ -2831,12 +2817,11 @@ func (s *StateSuite) TestRemoveImportingModelDocsRemovesLogs(c *gc.C) {
 }
 
 func (s *StateSuite) TestRemoveAllModelDocsRemovesLogs(c *gc.C) {
-	st := s.Factory.MakeModel(c, nil)
-	defer st.Close()
+	model := s.Factory.MakeModel(c, nil)
+	defer model.CloseDBConnection()
+	st := model.State()
 
-	model, err := st.Model()
-	c.Assert(err, jc.ErrorIsNil)
-	err = model.SetDead()
+	err := model.SetDead()
 	c.Assert(err, jc.ErrorIsNil)
 
 	writeLogs(c, st, 5)
@@ -2850,13 +2835,11 @@ func (s *StateSuite) TestRemoveAllModelDocsRemovesLogs(c *gc.C) {
 }
 
 func (s *StateSuite) TestRemoveExportingModelDocsRemovesLogTrackers(c *gc.C) {
-	st := s.Factory.MakeModel(c, nil)
-	defer st.Close()
+	model := s.Factory.MakeModel(c, nil)
+	defer model.CloseDBConnection()
+	st := model.State()
 
-	model, err := st.Model()
-	c.Assert(err, jc.ErrorIsNil)
-
-	err = model.SetMigrationMode(state.MigrationModeExporting)
+	err := model.SetMigrationMode(state.MigrationModeExporting)
 	c.Assert(err, jc.ErrorIsNil)
 
 	t1 := state.NewLastSentLogTracker(st, model.UUID(), "go-away")
@@ -3731,7 +3714,7 @@ func (s *StateSuite) TestSetEnvironAgentVersionOnOtherEnviron(c *gc.C) {
 	s.PatchValue(&arch.HostArch, func() string { return current.Arch })
 	s.PatchValue(&series.MustHostSeries, func() string { return current.Series })
 
-	otherSt := s.Factory.MakeModel(c, nil)
+	otherSt := s.Factory.MakeModel(c, nil).State()
 	defer otherSt.Close()
 
 	higher := version.MustParseBinary("1.25.0-trusty-amd64")

--- a/state/stateenvirons/config_test.go
+++ b/state/stateenvirons/config_test.go
@@ -44,19 +44,16 @@ func (s *environSuite) TestCloudSpec(c *gc.C) {
 	err := s.State.UpdateCloudCredential(tag, emptyCredential)
 	c.Assert(err, jc.ErrorIsNil)
 
-	st := s.Factory.MakeModel(c, &factory.ModelParams{
+	m := s.Factory.MakeModel(c, &factory.ModelParams{
 		Name:            "foo",
 		CloudName:       "dummy",
 		CloudCredential: tag,
 		Owner:           owner,
 	})
-	defer st.Close()
-
-	m, err := st.Model()
-	c.Assert(err, jc.ErrorIsNil)
+	defer m.CloseDBConnection()
 
 	emptyCredential.Label = "empty-credential"
-	cloudSpec, err := stateenvirons.EnvironConfigGetter{st, m}.CloudSpec()
+	cloudSpec, err := stateenvirons.EnvironConfigGetter{m.State(), m}.CloudSpec()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cloudSpec, jc.DeepEquals, environs.CloudSpec{
 		Type:             "dummy",

--- a/state/status_history_test.go
+++ b/state/status_history_test.go
@@ -56,7 +56,7 @@ func (s *StatusHistorySuite) TestPruneStatusBySizeOnlyForController(c *gc.C) {
 	clock := testing.NewClock(coretesting.NonZeroTime())
 	err := s.State.SetClockForTesting(clock)
 	c.Assert(err, jc.ErrorIsNil)
-	st := s.Factory.MakeModel(c, &factory.ModelParams{})
+	st := s.Factory.MakeModel(c, &factory.ModelParams{}).State()
 	defer st.Close()
 
 	localFactory := factory.NewFactory(st)

--- a/state/status_model_test.go
+++ b/state/status_model_test.go
@@ -24,10 +24,9 @@ var _ = gc.Suite(&ModelStatusSuite{})
 
 func (s *ModelStatusSuite) SetUpTest(c *gc.C) {
 	s.ConnSuite.SetUpTest(c)
-	s.st = s.Factory.MakeModel(c, nil)
-	m, err := s.st.Model()
-	c.Assert(err, jc.ErrorIsNil)
-	s.model = m
+	s.model = s.Factory.MakeModel(c, nil)
+
+	s.st = s.model.State()
 	s.factory = factory.NewFactory(s.st)
 }
 

--- a/state/storage_test.go
+++ b/state/storage_test.go
@@ -1245,7 +1245,7 @@ var blackPool = mustStorageConfig("black", "lancashire", map[string]interface{}{
 func (s *StorageStateSuite) TestNewModelDefaultPools(c *gc.C) {
 	st := s.Factory.MakeModel(c, &factory.ModelParams{
 		StorageProviderRegistry: testingStorageProviders,
-	})
+	}).State()
 	s.AddCleanup(func(*gc.C) { st.Close() })
 
 	// When a model is created, it is populated with the default

--- a/testing/factory/factory.go
+++ b/testing/factory/factory.go
@@ -616,9 +616,7 @@ func (factory *Factory) MakeRelation(c *gc.C, params *RelationParams) *state.Rel
 // defaults are used for all values.
 //
 // By default the new model shares the same owner as the calling Factory's
-// model. TODO(ericclaudejones) MakeModel should return the model itself rather
-// than the state.
-func (factory *Factory) MakeModel(c *gc.C, params *ModelParams) *state.State {
+func (factory *Factory) MakeModel(c *gc.C, params *ModelParams) *state.Model {
 	if params == nil {
 		params = new(ModelParams)
 	}
@@ -653,7 +651,7 @@ func (factory *Factory) MakeModel(c *gc.C, params *ModelParams) *state.State {
 		"uuid": uuid.String(),
 		"type": currentCfg.Type(),
 	}.Merge(params.ConfigAttrs))
-	_, st, err := factory.st.NewModel(state.ModelArgs{
+	model, _, err := factory.st.NewModel(state.ModelArgs{
 		Type:            params.Type,
 		CloudName:       params.CloudName,
 		CloudRegion:     params.CloudRegion,
@@ -664,7 +662,7 @@ func (factory *Factory) MakeModel(c *gc.C, params *ModelParams) *state.State {
 		EnvironVersion:          params.EnvironVersion,
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	return st
+	return model
 }
 
 // MakeSpace will create a new space with the specified params. If the space

--- a/testing/factory/factory_test.go
+++ b/testing/factory/factory_test.go
@@ -497,20 +497,15 @@ func (s *factorySuite) TestMakeMetric(c *gc.C) {
 }
 
 func (s *factorySuite) TestMakeModelNil(c *gc.C) {
-	st := s.Factory.MakeModel(c, nil)
-	defer st.Close()
+	m := s.Factory.MakeModel(c, nil)
+	defer m.CloseDBConnection()
 
-	env, err := st.Model()
-	c.Assert(err, jc.ErrorIsNil)
 	re := regexp.MustCompile(`^testenv-\d+$`)
-	c.Assert(re.MatchString(env.Name()), jc.IsTrue)
-	c.Assert(env.UUID() == s.State.ModelUUID(), jc.IsFalse)
+	c.Assert(re.MatchString(m.Name()), jc.IsTrue)
+	c.Assert(m.UUID() == s.IAASModel.UUID(), jc.IsFalse)
 	origEnv, err := s.State.Model()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(env.Owner(), gc.Equals, origEnv.Owner())
-
-	m, err := st.Model()
-	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(m.Owner(), gc.Equals, origEnv.Owner())
 
 	cfg, err := m.ModelConfig()
 	c.Assert(err, jc.ErrorIsNil)
@@ -527,17 +522,13 @@ func (s *factorySuite) TestMakeModel(c *gc.C) {
 		ConfigAttrs: testing.Attrs{"default-series": "precise"},
 	}
 
-	st := s.Factory.MakeModel(c, params)
-	defer st.Close()
+	m := s.Factory.MakeModel(c, params)
+	defer m.CloseDBConnection()
 
-	env, err := st.Model()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(env.Name(), gc.Equals, "foo")
-	c.Assert(env.UUID() == s.State.ModelUUID(), jc.IsFalse)
-	c.Assert(env.Owner(), gc.Equals, owner.UserTag())
+	c.Assert(m.Name(), gc.Equals, "foo")
+	c.Assert(m.UUID() == s.IAASModel.UUID(), jc.IsFalse)
+	c.Assert(m.Owner(), gc.Equals, owner.UserTag())
 
-	m, err := st.Model()
-	c.Assert(err, jc.ErrorIsNil)
 	cfg, err := m.ModelConfig()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cfg.AllAttrs()["default-series"], gc.Equals, "precise")


### PR DESCRIPTION
## Description of change

CAAS Refactoring: Remove ModelUUID method from State. In all cases, we use UUID method on Model itself. This is in line with the idea of completely separating the concepts of Model and State.