### PR TITLE
Better error message when re-registering the same controller.

### DIFF
--- a/cmd/juju/controller/register.go
+++ b/cmd/juju/controller/register.go
@@ -323,7 +323,13 @@ func (c *registerCommand) updateController(
 	}
 	for name, ctl := range all {
 		if ctl.ControllerUUID == controllerDetails.ControllerUUID {
-			// TODO(rogpeppe) lp#1614010 Succeed but override the account details in this case?
+			ctx.Warningf("This controller has already been registered on this client as %q.", name)
+			ctx.Warningf("To login user %q run 'juju login -u %v -c %v'.", accountDetails.User, accountDetails.User, name)
+			ctx.Warningf("To update controller details and login as user %q:", accountDetails.User)
+			ctx.Warningf("    1. run 'juju unregister %v'", name)
+			ctx.Warningf("    2. request from your controller admin another registration string, i.e")
+			ctx.Warningf("       output from 'juju change-user-password %v --reset'", accountDetails.User)
+			ctx.Warningf("    3. re-run 'juju register' with the registration from (2) above.")
 			return errors.Errorf("controller is already registered as %q", name)
 		}
 	}


### PR DESCRIPTION
## Description of change

Currently, when user runs a 'juju register' command on a client where this controller already registered, we err out saying that.
It causes confusion in some scenarios, where another user used the same client. For example, we bootstrapped, added a user, were told to run 'register', ran it but got an error. What now?

This PR proposes to clarify error message and suggest possible solutions to the user.  

## QA steps

1. Bootstrap a controller as "mycontroller"
2. Add user "other"
3. Run registration string as suggested in 2

Expected output:
WARNING This controller has already been registered on this client as "mycontroller".                                                                                                            
WARNING To login user "other" run 'juju login -u other -c mycontroller'.                                                                                                                         
WARNING To update controller details and login as user "other":                                                                                                                                  
WARNING     1. run 'juju unregister mycontroller'
WARNING     2. request from your controller admin another registration string, i.e
WARNING        output from 'juju change-user-password other --reset'
WARNING     3. re-run 'juju register' with the registration from (2) above.


## Documentation changes
n/a

## Bug reference

https://bugs.launchpad.net/juju/+bug/1614010 talks about update controller details. However, while investigating solutions for this bug, it was decided that it would not be clean to "just" update controller details on this client, just as it would not be nice to make an assumption whether the new user should replace a user used to register this controller on this client before.
