### PR TITLE
Update govmomi, vsphere provider internals

### DIFF
--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -79,7 +79,7 @@ github.com/prometheus/common	git	dd586c1c5abb0be59e60f942c22af711a2008cb4	2016-0
 github.com/prometheus/procfs	git	abf152e5f3e97f2fafac028d2cc06c1feb87ffa5	2016-04-11T19:08:41Z
 github.com/rogpeppe/fastuuid	git	6724a57986aff9bff1a1770e9347036def7c89f6	2015-01-06T09:32:20Z
 github.com/satori/uuid	git	5bf94b69c6b68ee1b541973bb8e1144db23a194b	2017-03-21T23:07:31Z
-github.com/vmware/govmomi	git	c0c7ce63df7edd78e713257b924c89d9a2dac119	2016-06-30T15:37:42Z
+github.com/vmware/govmomi	git	17b8c9ccb7f8c7b015d44c4ea39305c970a7bf31	2017-09-05T23:36:42Z
 golang.org/x/crypto	git	96846453c37f0876340a66a47f3f75b1f3a6cd2d	2017-04-21T04:31:20Z
 golang.org/x/net	git	ea47fc708ee3e20177f3ca3716217c4ab75942cb	2015-08-29T23:03:18Z
 golang.org/x/oauth2	git	11c60b6f71a6ad48ed6f93c65fa4c6f9b1b5b46a	2015-03-25T02:00:22Z

--- a/provider/vsphere/client.go
+++ b/provider/vsphere/client.go
@@ -4,11 +4,12 @@
 package vsphere
 
 import (
+	"context"
 	"net/url"
 
+	"github.com/vmware/govmomi/object"
 	"github.com/vmware/govmomi/vim25/mo"
 	"github.com/vmware/govmomi/vim25/types"
-	"golang.org/x/net/context"
 
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/provider/vsphere/internal/vsphereclient"
@@ -22,8 +23,10 @@ type Client interface {
 	Close(context.Context) error
 	ComputeResources(context.Context) ([]*mo.ComputeResource, error)
 	CreateVirtualMachine(context.Context, vsphereclient.CreateVirtualMachineParams) (*mo.VirtualMachine, error)
+	Datastores(context.Context) ([]*mo.Datastore, error)
+	DeleteDatastoreFile(context.Context, string) error
 	DestroyVMFolder(context.Context, string) error
-	EnsureVMFolder(context.Context, string) error
+	EnsureVMFolder(context.Context, string) (*object.Folder, error)
 	MoveVMFolderInto(context.Context, string, string) error
 	MoveVMsInto(context.Context, string, ...types.ManagedObjectReference) error
 	RemoveVirtualMachines(context.Context, string) error

--- a/provider/vsphere/environ.go
+++ b/provider/vsphere/environ.go
@@ -146,10 +146,11 @@ func (env *sessionEnviron) Bootstrap(
 }
 
 func (env *sessionEnviron) ensureVMFolder(controllerUUID string) error {
-	return env.client.EnsureVMFolder(env.ctx, path.Join(
+	_, err := env.client.EnsureVMFolder(env.ctx, path.Join(
 		controllerFolderName(controllerUUID),
 		env.modelFolderName(),
 	))
+	return errors.Trace(err)
 }
 
 //this variable is exported, because it has to be rewritten in external unit tests

--- a/provider/vsphere/init.go
+++ b/provider/vsphere/init.go
@@ -4,12 +4,12 @@
 package vsphere
 
 import (
+	"context"
 	"net/url"
 	"time"
 
 	"github.com/juju/mutex"
 	"github.com/juju/utils/clock"
-	"golang.org/x/net/context"
 
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/provider/vsphere/internal/vsphereclient"

--- a/provider/vsphere/internal/vsphereclient/createvm_test.go
+++ b/provider/vsphere/internal/vsphereclient/createvm_test.go
@@ -90,6 +90,7 @@ func (s *clientSuite) TestCreateVirtualMachine(c *gc.C) {
 		retrievePropertiesStubCall("FakeHostFolder"),
 		testing.StubCall{"ImportVApp", []interface{}{&types.VirtualMachineImportSpec{
 			ConfigSpec: types.VirtualMachineConfigSpec{
+				Name: "vm-name",
 				ExtraConfig: []types.BaseOptionValue{
 					&types.OptionValue{Key: "k", Value: "v"},
 				},
@@ -211,6 +212,7 @@ func (s *clientSuite) TestCreateVirtualMachineExternalNetworkSpecified(c *gc.C) 
 
 	s.roundTripper.CheckCall(c, 12, "ImportVApp", &types.VirtualMachineImportSpec{
 		ConfigSpec: types.VirtualMachineConfigSpec{
+			Name: "vm-name",
 			ExtraConfig: []types.BaseOptionValue{
 				&types.OptionValue{Key: "k", Value: "v"},
 			},
@@ -254,6 +256,7 @@ func (s *clientSuite) TestCreateVirtualMachineExternalNetworkSpecifiedDVPortgrou
 	// the DVS's UUID. This bumps the ImportVApp position by one.
 	s.roundTripper.CheckCall(c, 13, "ImportVApp", &types.VirtualMachineImportSpec{
 		ConfigSpec: types.VirtualMachineConfigSpec{
+			Name: "vm-name",
 			ExtraConfig: []types.BaseOptionValue{
 				&types.OptionValue{Key: "k", Value: "v"},
 			},

--- a/provider/vsphere/internal/vsphereclient/mock_test.go
+++ b/provider/vsphere/internal/vsphereclient/mock_test.go
@@ -4,26 +4,77 @@
 package vsphereclient
 
 import (
+	"context"
+
+	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	"github.com/juju/testing"
 	"github.com/juju/utils"
-	"github.com/pkg/errors"
 	"github.com/vmware/govmomi/vim25/methods"
 	"github.com/vmware/govmomi/vim25/soap"
 	"github.com/vmware/govmomi/vim25/types"
-	"golang.org/x/net/context"
 )
 
 var logger = loggo.GetLogger("vsphereclient")
 
+var (
+	lease = types.ManagedObjectReference{
+		Type:  "Lease",
+		Value: "FakeLease",
+	}
+	reconfigVMTask = types.ManagedObjectReference{
+		Type:  "Task",
+		Value: "ReconfigVMTask",
+	}
+	destroyTask = types.ManagedObjectReference{
+		Type:  "Task",
+		Value: "DestroyTask",
+	}
+	moveIntoFolderTask = types.ManagedObjectReference{
+		Type:  "Task",
+		Value: "MoveIntoFolder",
+	}
+	powerOffVMTask = types.ManagedObjectReference{
+		Type:  "Task",
+		Value: "PowerOffVM",
+	}
+	powerOnVMTask = types.ManagedObjectReference{
+		Type:  "Task",
+		Value: "PowerOnVM",
+	}
+	cloneVMTask = types.ManagedObjectReference{
+		Type:  "Task",
+		Value: "CloneVM",
+	}
+	searchDatastoreTask = types.ManagedObjectReference{
+		Type:  "Task",
+		Value: "SearchDatastore",
+	}
+	deleteDatastoreFileTask = types.ManagedObjectReference{
+		Type:  "Task",
+		Value: "DeleteDatastoreFile",
+	}
+	moveDatastoreFileTask = types.ManagedObjectReference{
+		Type:  "Task",
+		Value: "MoveDatastoreFile",
+	}
+	extendVirtualDiskTask = types.ManagedObjectReference{
+		Type:  "Task",
+		Value: "ExtendVirtualDisk",
+	}
+)
+
 type mockRoundTripper struct {
 	testing.Stub
 
-	serverURL     string
-	roundTrip     func(ctx context.Context, req, res soap.HasFault) error
-	contents      map[string][]types.ObjectContent
-	collectors    map[string]*collector
-	leaseProgress chan int32
+	serverURL        string
+	roundTrip        func(ctx context.Context, req, res soap.HasFault) error
+	contents         map[string][]types.ObjectContent
+	collectors       map[string]*collector
+	leaseProgress    chan int32
+	importVAppResult types.ManagedObjectReference
+	taskError        map[types.ManagedObjectReference]*types.LocalizedMethodFault
+	taskResult       map[types.ManagedObjectReference]types.AnyType
 }
 
 func (r *mockRoundTripper) RoundTrip(ctx context.Context, req, res soap.HasFault) error {
@@ -33,31 +84,6 @@ func (r *mockRoundTripper) RoundTrip(ctx context.Context, req, res soap.HasFault
 
 	if r.roundTrip != nil {
 		return r.roundTrip(ctx, req, res)
-	}
-
-	lease := types.ManagedObjectReference{
-		Type:  "Lease",
-		Value: "FakeLease",
-	}
-	reconfigVMTask := types.ManagedObjectReference{
-		Type:  "Task",
-		Value: "ReconfigVMTask",
-	}
-	destroyTask := types.ManagedObjectReference{
-		Type:  "Task",
-		Value: "DestroyTask",
-	}
-	moveIntoFolderTask := types.ManagedObjectReference{
-		Type:  "Task",
-		Value: "MoveIntoFolder",
-	}
-	powerOffVMTask := types.ManagedObjectReference{
-		Type:  "Task",
-		Value: "PowerOffVM",
-	}
-	powerOnVMTask := types.ManagedObjectReference{
-		Type:  "Task",
-		Value: "PowerOnVM",
 	}
 
 	switch res := res.(type) {
@@ -82,6 +108,9 @@ func (r *mockRoundTripper) RoundTrip(ctx context.Context, req, res soap.HasFault
 	case *methods.PowerOnVM_TaskBody:
 		r.MethodCall(r, "PowerOnVM_Task")
 		res.Res = &types.PowerOnVM_TaskResponse{powerOnVMTask}
+	case *methods.CloneVM_TaskBody:
+		r.MethodCall(r, "CloneVM_Task")
+		res.Res = &types.CloneVM_TaskResponse{cloneVMTask}
 	case *methods.CreateFolderBody:
 		r.MethodCall(r, "CreateFolder")
 		res.Res = &types.CreateFolderResponse{}
@@ -97,13 +126,37 @@ func (r *mockRoundTripper) RoundTrip(ctx context.Context, req, res soap.HasFault
 						Size:     14,
 					},
 				},
-				ImportSpec: &types.VirtualMachineImportSpec{},
+				ImportSpec: &types.VirtualMachineImportSpec{
+					ConfigSpec: types.VirtualMachineConfigSpec{
+						Name: "vm-name",
+					},
+				},
 			},
 		}
 	case *methods.ImportVAppBody:
 		req := req.(*methods.ImportVAppBody).Req
 		r.MethodCall(r, "ImportVApp", req.Spec)
 		res.Res = &types.ImportVAppResponse{lease}
+	case *methods.SearchDatastore_TaskBody:
+		req := req.(*methods.SearchDatastore_TaskBody).Req
+		r.MethodCall(r, "SearchDatastore", req.DatastorePath, req.SearchSpec)
+		res.Res = &types.SearchDatastore_TaskResponse{searchDatastoreTask}
+	case *methods.DeleteDatastoreFile_TaskBody:
+		req := req.(*methods.DeleteDatastoreFile_TaskBody).Req
+		r.MethodCall(r, "DeleteDatastoreFile", req.Name)
+		res.Res = &types.DeleteDatastoreFile_TaskResponse{deleteDatastoreFileTask}
+	case *methods.MoveDatastoreFile_TaskBody:
+		req := req.(*methods.MoveDatastoreFile_TaskBody).Req
+		r.MethodCall(r, "MoveDatastoreFile", req.SourceName, req.DestinationName, req.Force)
+		res.Res = &types.MoveDatastoreFile_TaskResponse{moveDatastoreFileTask}
+	case *methods.MakeDirectoryBody:
+		req := req.(*methods.MakeDirectoryBody).Req
+		r.MethodCall(r, "MakeDirectory", req.Name)
+		res.Res = &types.MakeDirectoryResponse{}
+	case *methods.ExtendVirtualDisk_TaskBody:
+		req := req.(*methods.ExtendVirtualDisk_TaskBody).Req
+		r.MethodCall(r, "ExtendVirtualDisk", req.Name, req.NewCapacityKb)
+		res.Res = &types.ExtendVirtualDisk_TaskResponse{extendVirtualDiskTask}
 	case *methods.CreatePropertyCollectorBody:
 		r.MethodCall(r, "CreatePropertyCollector")
 		uuid := utils.MustNewUUID().String()
@@ -144,6 +197,7 @@ func (r *mockRoundTripper) RoundTrip(ctx context.Context, req, res soap.HasFault
 			changes = []types.PropertyChange{{
 				Name: "info",
 				Val: types.HttpNfcLeaseInfo{
+					Entity: r.importVAppResult,
 					DeviceUrl: []types.HttpNfcLeaseDeviceUrl{
 						types.HttpNfcLeaseDeviceUrl{
 							ImportKey: "key1",
@@ -156,12 +210,21 @@ func (r *mockRoundTripper) RoundTrip(ctx context.Context, req, res soap.HasFault
 				Val:  types.HttpNfcLeaseStateReady,
 			}}
 		} else {
+			task := collector.filter.ObjectSet[0].Obj
+			taskState := types.TaskInfoStateSuccess
+			taskResult := r.taskResult[task]
+			taskError := r.taskError[task]
+			if taskError != nil {
+				taskState = types.TaskInfoStateError
+			}
 			changes = []types.PropertyChange{{
 				Name: "info",
 				Op:   types.PropertyChangeOpAssign,
 				Val: types.TaskInfo{
 					Entity: &types.ManagedObjectReference{},
-					State:  types.TaskInfoStateSuccess,
+					State:  taskState,
+					Result: taskResult,
+					Error:  taskError,
 				},
 			}}
 		}

--- a/provider/vsphere/upgrades.go
+++ b/provider/vsphere/upgrades.go
@@ -99,7 +99,7 @@ func (step modelFoldersUpgradeStep) Run() error {
 			controllerFolderName(step.controllerUUID),
 			env.modelFolderName(),
 		)
-		if err := env.client.EnsureVMFolder(env.ctx, modelFolderPath); err != nil {
+		if _, err := env.client.EnsureVMFolder(env.ctx, modelFolderPath); err != nil {
 			return errors.Annotate(err, "creating model folder")
 		}
 


### PR DESCRIPTION
## Description of change

Update to the latest vmware/govmomi, which
has a few signature changes, e.g. updating
to use the standard "context" package. We
also update some existing internals and
introduce new vsphereclient Client methods
for use in an upcoming PR.

## QA steps

1. juju bootstrap vsphere
2. juju add-machine
3. juju add-machine --series=xenial
(ensure machines are created successfully)
4. juju destroy-controller -y vsphere --destroy-all-models

## Documentation changes

None.

## Bug reference

None.