### PR TITLE
Uniter reacts to relation suspended flag; new suspending/joining states

### DIFF
--- a/api/crossmodelrelations/crossmodelrelations.go
+++ b/api/crossmodelrelations/crossmodelrelations.go
@@ -397,9 +397,9 @@ func (c *Client) WatchEgressAddressesForRelation(remoteRelationArg params.Remote
 	return w, nil
 }
 
-// WatchRelationStatus starts a RelationStatusWatcher for watching the life and
-// status of the specified relation in the remote model.
-func (c *Client) WatchRelationStatus(arg params.RemoteEntityArg) (watcher.RelationStatusWatcher, error) {
+// WatchRelationSuspendedStatus starts a RelationStatusWatcher for watching the life and
+// suspended status of the specified relation in the remote model.
+func (c *Client) WatchRelationSuspendedStatus(arg params.RemoteEntityArg) (watcher.RelationStatusWatcher, error) {
 	args := params.RemoteEntityArgs{Args: []params.RemoteEntityArg{arg}}
 	// Use any previously cached discharge macaroons.
 	if ms, ok := c.getCachedMacaroon("watch relation status", arg.Token); ok {
@@ -408,7 +408,7 @@ func (c *Client) WatchRelationStatus(arg params.RemoteEntityArg) (watcher.Relati
 
 	var results params.RelationStatusWatchResults
 	apiCall := func() error {
-		if err := c.facade.FacadeCall("WatchRelationsStatus", args, &results); err != nil {
+		if err := c.facade.FacadeCall("WatchRelationsSuspendedStatus", args, &results); err != nil {
 			return errors.Trace(err)
 		}
 		if len(results.Results) != 1 {

--- a/api/crossmodelrelations/crossmodelrelations_test.go
+++ b/api/crossmodelrelations/crossmodelrelations_test.go
@@ -430,10 +430,10 @@ func (s *CrossModelRelationsSuite) TestWatchRelationStatus(c *gc.C) {
 		c.Check(id, gc.Equals, "")
 		c.Check(arg, jc.DeepEquals, params.RemoteEntityArgs{Args: []params.RemoteEntityArg{{
 			Token: remoteRelationToken, Macaroons: macaroon.Slice{mac}}}})
-		c.Check(request, gc.Equals, "WatchRelationsStatus")
+		c.Check(request, gc.Equals, "WatchRelationsSuspendedStatus")
 		c.Assert(result, gc.FitsTypeOf, &params.RelationStatusWatchResults{})
 		*(result.(*params.RelationStatusWatchResults)) = params.RelationStatusWatchResults{
-			Results: []params.RelationStatusWatchResult{{
+			Results: []params.RelationLifeSuspendedStatusWatchResult{{
 				Error: &params.Error{Message: "FAIL"},
 			}},
 		}
@@ -441,7 +441,7 @@ func (s *CrossModelRelationsSuite) TestWatchRelationStatus(c *gc.C) {
 		return nil
 	})
 	client := crossmodelrelations.NewClientWithCache(apiCaller, s.cache)
-	_, err = client.WatchRelationStatus(params.RemoteEntityArg{
+	_, err = client.WatchRelationSuspendedStatus(params.RemoteEntityArg{
 		Token:     remoteRelationToken,
 		Macaroons: macaroon.Slice{mac},
 	})
@@ -451,7 +451,7 @@ func (s *CrossModelRelationsSuite) TestWatchRelationStatus(c *gc.C) {
 	different, err := macaroon.New(nil, "different", "")
 	c.Assert(err, jc.ErrorIsNil)
 	s.cache.Upsert("token", macaroon.Slice{mac})
-	_, err = client.WatchRelationStatus(params.RemoteEntityArg{
+	_, err = client.WatchRelationSuspendedStatus(params.RemoteEntityArg{
 		Token:     remoteRelationToken,
 		Macaroons: macaroon.Slice{different},
 	})
@@ -483,7 +483,7 @@ func (s *CrossModelRelationsSuite) TestWatchRelationStatusDischargeRequired(c *g
 			dischargeMac = argParam.Args[0].Macaroons
 		}
 		*(result.(*params.RelationStatusWatchResults)) = params.RelationStatusWatchResults{
-			Results: []params.RelationStatusWatchResult{{Error: resultErr}},
+			Results: []params.RelationLifeSuspendedStatusWatchResult{{Error: resultErr}},
 		}
 		callCount++
 		return nil
@@ -491,7 +491,7 @@ func (s *CrossModelRelationsSuite) TestWatchRelationStatusDischargeRequired(c *g
 	acquirer := &mockDischargeAcquirer{}
 	callerWithBakery := testing.APICallerWithBakery(apiCaller, acquirer)
 	client := crossmodelrelations.NewClientWithCache(callerWithBakery, s.cache)
-	_, err := client.WatchRelationStatus(params.RemoteEntityArg{Token: "token"})
+	_, err := client.WatchRelationSuspendedStatus(params.RemoteEntityArg{Token: "token"})
 	c.Check(callCount, gc.Equals, 2)
 	c.Check(err, gc.ErrorMatches, "FAIL")
 	c.Assert(dischargeMac, gc.HasLen, 2)

--- a/api/uniter/relation.go
+++ b/api/uniter/relation.go
@@ -56,6 +56,12 @@ func (r *Relation) Suspended() bool {
 	return r.suspended
 }
 
+// UpdateSuspended updates the in memory value of the
+// relation's suspended attribute.
+func (r *Relation) UpdateSuspended(suspended bool) {
+	r.suspended = suspended
+}
+
 // OtherApplication returns the name of the application on the other
 // end of the relation (from this unit's perspective).
 func (r *Relation) OtherApplication() string {

--- a/api/uniter/relation_test.go
+++ b/api/uniter/relation_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/juju/juju/api/uniter"
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/core/relation"
 	"github.com/juju/juju/status"
 )
 
@@ -51,7 +52,7 @@ func (s *relationSuite) TestOtherApplication(c *gc.C) {
 
 func (s *relationSuite) TestRefresh(c *gc.C) {
 	c.Assert(s.apiRelation.Life(), gc.Equals, params.Alive)
-	c.Assert(s.apiRelation.Status(), gc.Equals, params.Joined)
+	c.Assert(s.apiRelation.Suspended(), jc.IsTrue)
 
 	// EnterScope with mysqlUnit, so the relation will be set to dying
 	// when destroyed later.
@@ -64,25 +65,33 @@ func (s *relationSuite) TestRefresh(c *gc.C) {
 	// Destroy it - should set it to dying.
 	err = s.stateRelation.Destroy()
 	c.Assert(err, jc.ErrorIsNil)
-	// Update status as well.
-	err = s.stateRelation.SetStatus(status.StatusInfo{Status: status.Suspended})
+	// Update suspended as well.
+	err = s.stateRelation.SetSuspended(false)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(s.apiRelation.Life(), gc.Equals, params.Alive)
-	c.Assert(s.apiRelation.Status(), gc.Equals, params.Joined)
+	c.Assert(s.apiRelation.Suspended(), jc.IsTrue)
 
 	err = s.apiRelation.Refresh()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(s.apiRelation.Life(), gc.Equals, params.Dying)
-	c.Assert(s.apiRelation.Status(), gc.Equals, params.Suspended)
+	c.Assert(s.apiRelation.Suspended(), jc.IsFalse)
 
 	// Leave scope with mysqlUnit, so the relation will be removed.
 	err = myRelUnit.LeaveScope()
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Assert(s.apiRelation.Life(), gc.Equals, params.Dying)
-	c.Assert(s.apiRelation.Status(), gc.Equals, params.Suspended)
+	c.Assert(s.apiRelation.Suspended(), jc.IsFalse)
 	err = s.apiRelation.Refresh()
 	c.Assert(err, jc.Satisfies, params.IsCodeUnauthorized)
+}
+
+func (s *relationSuite) TestSetStatus(c *gc.C) {
+	err := s.apiRelation.SetStatus(relation.Suspended)
+	c.Assert(err, jc.ErrorIsNil)
+	relStatus, err := s.stateRelation.Status()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(relStatus.Status, gc.Equals, status.Suspended)
 }
 
 func (s *relationSuite) TestEndpoint(c *gc.C) {

--- a/api/uniter/relation_test.go
+++ b/api/uniter/relation_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/core/relation"
 	"github.com/juju/juju/status"
+	"time"
 )
 
 type relationSuite struct {
@@ -87,7 +88,9 @@ func (s *relationSuite) TestRefresh(c *gc.C) {
 }
 
 func (s *relationSuite) TestSetStatus(c *gc.C) {
-	err := s.apiRelation.SetStatus(relation.Suspended)
+	err := s.State.LeadershipClaimer().ClaimLeadership("wordpress", "wordpress/0", time.Minute)
+	c.Assert(err, jc.ErrorIsNil)
+	err = s.apiRelation.SetStatus(relation.Suspended)
 	c.Assert(err, jc.ErrorIsNil)
 	relStatus, err := s.stateRelation.Status()
 	c.Assert(err, jc.ErrorIsNil)

--- a/api/uniter/relationunit_test.go
+++ b/api/uniter/relationunit_test.go
@@ -41,6 +41,8 @@ func (m *commonRelationSuiteMixin) SetUpTest(c *gc.C, s uniterSuite) {
 
 	// Add a relation, used by both this suite and relationSuite.
 	m.stateRelation = s.addRelation(c, "wordpress", "mysql")
+	err := m.stateRelation.SetSuspended(true)
+	c.Assert(err, jc.ErrorIsNil)
 }
 
 func (s *relationUnitSuite) SetUpTest(c *gc.C) {

--- a/api/uniter/unit.go
+++ b/api/uniter/unit.go
@@ -11,7 +11,6 @@ import (
 	"github.com/juju/juju/api/common"
 	apiwatcher "github.com/juju/juju/api/watcher"
 	"github.com/juju/juju/apiserver/params"
-	"github.com/juju/juju/core/relation"
 	"github.com/juju/juju/status"
 	"github.com/juju/juju/watcher"
 )
@@ -650,8 +649,8 @@ type RelationStatus struct {
 	// Tag is the relation tag.
 	Tag names.RelationTag
 
-	// Status is the status of the relation.
-	Status relation.Status
+	// Suspended is true if the relation is suspended.
+	Suspended bool
 
 	// InScope is true if the relation unit is in scope.
 	InScope bool
@@ -682,9 +681,9 @@ func (u *Unit) RelationsStatus() ([]RelationStatus, error) {
 			return nil, err
 		}
 		statusResult = append(statusResult, RelationStatus{
-			Tag:     tag,
-			InScope: result.InScope,
-			Status:  relation.Status(result.Status),
+			Tag:       tag,
+			InScope:   result.InScope,
+			Suspended: result.Suspended,
 		})
 	}
 	return statusResult, nil

--- a/api/uniter/unit_test.go
+++ b/api/uniter/unit_test.go
@@ -19,7 +19,6 @@ import (
 	"github.com/juju/juju/api/uniter"
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/params"
-	"github.com/juju/juju/core/relation"
 	jujutesting "github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/state"
@@ -659,7 +658,7 @@ func (s *unitSuite) TestApplicationNameAndTag(c *gc.C) {
 	c.Assert(s.apiUnit.ApplicationTag(), gc.Equals, s.wordpressApplication.Tag())
 }
 
-func (s *unitSuite) TestRelationStatus(c *gc.C) {
+func (s *unitSuite) TestRelationSuspended(c *gc.C) {
 	relationStatus, err := s.apiUnit.RelationsStatus()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(relationStatus, gc.HasLen, 0)
@@ -668,22 +667,22 @@ func (s *unitSuite) TestRelationStatus(c *gc.C) {
 	relationStatus, err = s.apiUnit.RelationsStatus()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(relationStatus, gc.DeepEquals, []uniter.RelationStatus{{
-		Tag:     rel1.Tag().(names.RelationTag),
-		InScope: true,
-		Status:  relation.Joined,
+		Tag:       rel1.Tag().(names.RelationTag),
+		InScope:   true,
+		Suspended: false,
 	}})
 
 	rel2 := s.addRelationSuspended(c, "wordpress", "logging", s.wordpressUnit)
 	relationStatus, err = s.apiUnit.RelationsStatus()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(relationStatus, jc.SameContents, []uniter.RelationStatus{{
-		Tag:     rel1.Tag().(names.RelationTag),
-		InScope: true,
-		Status:  relation.Joined,
+		Tag:       rel1.Tag().(names.RelationTag),
+		InScope:   true,
+		Suspended: false,
 	}, {
-		Tag:     rel2.Tag().(names.RelationTag),
-		InScope: false,
-		Status:  relation.Suspended,
+		Tag:       rel2.Tag().(names.RelationTag),
+		InScope:   false,
+		Suspended: true,
 	}})
 }
 

--- a/api/uniter/uniter.go
+++ b/api/uniter/uniter.go
@@ -14,6 +14,7 @@ import (
 	"github.com/juju/juju/api/common"
 	apiwatcher "github.com/juju/juju/api/watcher"
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/core/relation"
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/watcher"
 )
@@ -114,6 +115,17 @@ func (st *State) relation(relationTag, unitTag names.Tag) (params.RelationResult
 	return result.Results[0], nil
 }
 
+func (st *State) setRelationStatus(id int, status relation.Status) error {
+	args := params.RelationStatusArgs{
+		Args: []params.RelationStatusArg{{RelationId: id, Status: params.RelationStatusValue(status)}},
+	}
+	var results params.ErrorResults
+	if err := st.facade.FacadeCall("SetRelationStatus", args, &results); err != nil {
+		return errors.Trace(err)
+	}
+	return results.OneError()
+}
+
 // getOneAction retrieves a single Action from the controller.
 func (st *State) getOneAction(tag *names.ActionTag) (params.ActionResult, error) {
 	nothing := params.ActionResult{}
@@ -203,12 +215,12 @@ func (st *State) Relation(relationTag names.RelationTag) (*Relation, error) {
 		return nil, err
 	}
 	return &Relation{
-		id:       result.Id,
-		tag:      relationTag,
-		life:     result.Life,
-		status:   result.Status,
-		st:       st,
-		otherApp: result.OtherApplication,
+		id:        result.Id,
+		tag:       relationTag,
+		life:      result.Life,
+		suspended: result.Suspended,
+		st:        st,
+		otherApp:  result.OtherApplication,
 	}, nil
 }
 
@@ -296,12 +308,12 @@ func (st *State) RelationById(id int) (*Relation, error) {
 	}
 	relationTag := names.NewRelationTag(result.Key)
 	return &Relation{
-		id:       result.Id,
-		tag:      relationTag,
-		life:     result.Life,
-		status:   result.Status,
-		st:       st,
-		otherApp: result.OtherApplication,
+		id:        result.Id,
+		tag:       relationTag,
+		life:      result.Life,
+		suspended: result.Suspended,
+		st:        st,
+		otherApp:  result.OtherApplication,
 	}, nil
 }
 

--- a/api/uniter/uniter_test.go
+++ b/api/uniter/uniter_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/juju/juju/api/uniter"
 	"github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/state"
-	"github.com/juju/juju/status"
 )
 
 // NOTE: This suite is intended for embedding into other suites,
@@ -118,7 +117,7 @@ func (s *uniterSuite) addRelatedApplication(c *gc.C, firstApp, relatedApp string
 func (s *uniterSuite) addRelationSuspended(c *gc.C, firstApp, relatedApp string, unit *state.Unit) *state.Relation {
 	s.AddTestingApplication(c, relatedApp, s.AddTestingCharm(c, relatedApp))
 	rel := s.addRelation(c, firstApp, relatedApp)
-	err := rel.SetStatus(status.StatusInfo{Status: status.Suspended})
+	err := rel.SetSuspended(true)
 	c.Assert(err, jc.ErrorIsNil)
 	return rel
 }

--- a/api/watcher/watcher_test.go
+++ b/api/watcher/watcher_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/juju/juju/core/crossmodel"
 	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/core/migration"
-	"github.com/juju/juju/core/relation"
 	"github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/permission"
 	"github.com/juju/juju/state"
@@ -254,7 +253,9 @@ func (s *watcherSuite) TestWatchMachineStorage(c *gc.C) {
 	}
 }
 
-func (s *watcherSuite) assertRelationStatusWatchResult(c *gc.C, rel *state.Relation, expectedLife life.Value, expectedStatus relation.Status) {
+func (s *watcherSuite) assertSetupRelationStatusWatch(
+	c *gc.C, rel *state.Relation,
+) (func(life life.Value, suspended bool), func()) {
 	// Export the relation so it can be found with a token.
 	re := s.State.RemoteEntities()
 	token, err := re.ExportLocalEntity(rel.Tag())
@@ -303,14 +304,14 @@ func (s *watcherSuite) assertRelationStatusWatchResult(c *gc.C, rel *state.Relat
 
 	// Start watching for a relation change.
 	client := crossmodelrelations.NewClient(s.stateAPI)
-	w, err := client.WatchRelationStatus(params.RemoteEntityArg{
+	w, err := client.WatchRelationSuspendedStatus(params.RemoteEntityArg{
 		Token:     token,
 		Macaroons: macaroon.Slice{mac},
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	defer func() {
+	stop := func() {
 		c.Assert(worker.Stop(w), jc.ErrorIsNil)
-	}()
+	}
 
 	assertNoChange := func() {
 		s.BackingState.StartSync()
@@ -321,15 +322,14 @@ func (s *watcherSuite) assertRelationStatusWatchResult(c *gc.C, rel *state.Relat
 		}
 	}
 
-	assertChange := func(life life.Value, status relation.Status) {
+	assertChange := func(life life.Value, suspended bool) {
 		s.BackingState.StartSync()
 		select {
 		case changes, ok := <-w.Changes():
-			c.Assert(ok, jc.IsTrue)
-			c.Assert(changes, gc.HasLen, 1)
+			c.Check(ok, jc.IsTrue)
+			c.Check(changes, gc.HasLen, 1)
 			c.Check(changes[0].Life, gc.Equals, life)
-			c.Check(changes[0].Status, gc.Equals, status)
-			c.Check(changes[0].StatusMessage, gc.Equals, "")
+			c.Check(changes[0].Suspended, gc.Equals, suspended)
 		case <-time.After(coretesting.LongWait):
 			c.Fatalf("watcher didn't emit an event")
 		}
@@ -337,12 +337,8 @@ func (s *watcherSuite) assertRelationStatusWatchResult(c *gc.C, rel *state.Relat
 	}
 
 	// Initial event.
-	assertChange(life.Alive, relation.Joined)
-
-	// Now change the relation, should trigger the watcher.
-	err = rel.Destroy()
-	c.Assert(err, jc.ErrorIsNil)
-	assertChange(expectedLife, expectedStatus)
+	assertChange(life.Alive, false)
+	return assertChange, stop
 }
 
 func (s *watcherSuite) TestRelationStatusWatcher(c *gc.C) {
@@ -364,7 +360,20 @@ func (s *watcherSuite) TestRelationStatusWatcher(c *gc.C) {
 	err = relUnit.EnterScope(nil)
 	c.Assert(err, jc.ErrorIsNil)
 
-	s.assertRelationStatusWatchResult(c, rel, life.Dying, relation.Joined)
+	assertChange, stop := s.assertSetupRelationStatusWatch(c, rel)
+	defer stop()
+
+	err = rel.SetSuspended(true)
+	c.Assert(err, jc.ErrorIsNil)
+	assertChange(life.Alive, true)
+
+	err = rel.SetSuspended(false)
+	c.Assert(err, jc.ErrorIsNil)
+	assertChange(life.Alive, false)
+
+	err = rel.Destroy()
+	c.Assert(err, jc.ErrorIsNil)
+	assertChange(life.Dying, false)
 }
 
 func (s *watcherSuite) TestRelationStatusWatcherDeadRelation(c *gc.C) {
@@ -376,7 +385,12 @@ func (s *watcherSuite) TestRelationStatusWatcherDeadRelation(c *gc.C) {
 	rel, err := s.State.AddRelation(eps...)
 	c.Assert(err, jc.ErrorIsNil)
 
-	s.assertRelationStatusWatchResult(c, rel, life.Dead, relation.Broken)
+	assertChange, stop := s.assertSetupRelationStatusWatch(c, rel)
+	defer stop()
+
+	err = rel.Destroy()
+	c.Assert(err, jc.ErrorIsNil)
+	assertChange(life.Dead, false)
 }
 
 type migrationSuite struct {

--- a/apiserver/common/crossmodel/crossmodel.go
+++ b/apiserver/common/crossmodel/crossmodel.go
@@ -41,20 +41,17 @@ func PublishRelationChange(backend Backend, relationTag names.Tag, change params
 		if err := rel.SetSuspended(*change.Suspended); err != nil {
 			return errors.Trace(err)
 		}
-		if *change.Suspended {
-			if err := rel.SetStatus(status.StatusInfo{
-				Status:  status.Suspending,
-				Message: "suspending after update from remote model",
-			}); err != nil && !errors.IsNotValid(err) {
-				return errors.Trace(err)
-			}
-		} else {
-			if err := rel.SetStatus(status.StatusInfo{
-				Status:  status.Joining,
-				Message: "resuming after update from remote model",
-			}); err != nil && !errors.IsNotValid(err) {
-				return errors.Trace(err)
-			}
+		newStatus := status.Suspending
+		action := "suspending"
+		if !*change.Suspended {
+			newStatus = status.Joining
+			action = "resuming"
+		}
+		if err := rel.SetStatus(status.StatusInfo{
+			Status:  newStatus,
+			Message: action + " after update from remote model",
+		}); err != nil && !errors.IsNotValid(err) {
+			return errors.Trace(err)
 		}
 	}
 

--- a/apiserver/common/crossmodel/crossmodel.go
+++ b/apiserver/common/crossmodel/crossmodel.go
@@ -35,18 +35,24 @@ func PublishRelationChange(backend Backend, relationTag names.Tag, change params
 		return errors.Trace(err)
 	}
 
-	// Update the relation status if necessary.
-	relStatus := status.Status(change.Status)
-	if relStatus != "" {
-		currentStatus, err := rel.Status()
-		if err != nil {
+	// Update the relation suspended status.
+	currentStatus := rel.Suspended()
+	if change.Suspended != nil && currentStatus != *change.Suspended {
+		if err := rel.SetSuspended(*change.Suspended); err != nil {
 			return errors.Trace(err)
 		}
-		if currentStatus.Status != relStatus || currentStatus.Message != change.StatusMessage {
+		if *change.Suspended {
 			if err := rel.SetStatus(status.StatusInfo{
-				Status:  relStatus,
-				Message: change.StatusMessage,
-			}); err != nil {
+				Status:  status.Suspending,
+				Message: "suspending after update from remote model",
+			}); err != nil && !errors.IsNotValid(err) {
+				return errors.Trace(err)
+			}
+		} else {
+			if err := rel.SetStatus(status.StatusInfo{
+				Status:  status.Joining,
+				Message: "resuming after update from remote model",
+			}); err != nil && !errors.IsNotValid(err) {
 				return errors.Trace(err)
 			}
 		}
@@ -272,27 +278,22 @@ type relationGetter interface {
 	KeyRelation(string) (Relation, error)
 }
 
-// GetRelationStatusChange returns a status change struct for a specified relation key.
-func GetRelationStatusChange(st relationGetter, key string) (*params.RelationStatusChange, error) {
+// GetRelationLifeSuspendedStatusChange returns a life/suspended status change
+// struct for a specified relation key.
+func GetRelationLifeSuspendedStatusChange(st relationGetter, key string) (*params.RelationLifeSuspendedStatusChange, error) {
 	rel, err := st.KeyRelation(key)
 	if errors.IsNotFound(err) {
-		return &params.RelationStatusChange{
-			Key:    key,
-			Life:   params.Dead,
-			Status: params.Broken,
+		return &params.RelationLifeSuspendedStatusChange{
+			Key:  key,
+			Life: params.Dead,
 		}, nil
 	}
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	relStatus, err := rel.Status()
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	return &params.RelationStatusChange{
-		Key:           key,
-		Life:          params.Life(rel.Life().String()),
-		Status:        params.RelationStatusValue(relStatus.Status),
-		StatusMessage: relStatus.Message,
+	return &params.RelationLifeSuspendedStatusChange{
+		Key:       key,
+		Life:      params.Life(rel.Life().String()),
+		Suspended: rel.Suspended(),
 	}, nil
 }

--- a/apiserver/common/crossmodel/interface.go
+++ b/apiserver/common/crossmodel/interface.go
@@ -113,9 +113,15 @@ type Relation interface {
 	// specified application in the relation.
 	WatchUnits(applicationName string) (state.RelationUnitsWatcher, error)
 
-	// WatchLifeStatus returns a watcher that notifies of changes to the life
-	// or status of the relation.
-	WatchLifeStatus() state.StringsWatcher
+	// WatchLifeSuspendedStatus returns a watcher that notifies of changes to the life
+	// or suspended status of the relation.
+	WatchLifeSuspendedStatus() state.StringsWatcher
+
+	// Suspended returns the suspended status of the relation.
+	Suspended() bool
+
+	// SetSuspended sets the suspended status of the relation.
+	SetSuspended(bool) error
 }
 
 // RelationUnit provides access to the settings of a single unit in a relation,

--- a/apiserver/facades/agent/uniter/uniter.go
+++ b/apiserver/facades/agent/uniter/uniter.go
@@ -27,6 +27,7 @@ import (
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/multiwatcher"
 	"github.com/juju/juju/state/watcher"
+	"github.com/juju/juju/status"
 	"github.com/juju/utils/set"
 )
 
@@ -1071,12 +1072,8 @@ func (u *UniterAPI) RelationsStatus(args params.Entities) (params.RelationUnitSt
 	oneRelationUnitStatus := func(rel *state.Relation, unit *state.Unit) (params.RelationUnitStatus, error) {
 		rus := params.RelationUnitStatus{
 			RelationTag: rel.Tag().String(),
+			Suspended:   rel.Suspended(),
 		}
-		relStatus, err := rel.Status()
-		if err != nil {
-			return params.RelationUnitStatus{}, errors.Trace(err)
-		}
-		rus.Status = params.RelationStatusValue(relStatus.Status)
 		ru, err := rel.Unit(unit)
 		if err != nil {
 			return params.RelationUnitStatus{}, errors.Trace(err)
@@ -1427,6 +1424,31 @@ func (u *UniterAPI) WatchRelationUnits(args params.RelationUnits) (params.Relati
 	return result, nil
 }
 
+// SetRelationStatus updates the status of the specified relations.
+func (u *UniterAPI) SetRelationStatus(args params.RelationStatusArgs) (params.ErrorResults, error) {
+	var statusResults params.ErrorResults
+
+	changeOne := func(arg params.RelationStatusArg) error {
+		rel, err := u.st.Relation(arg.RelationId)
+		if errors.IsNotFound(err) {
+			return common.ErrPerm
+		} else if err != nil {
+			return errors.Trace(err)
+		}
+		return rel.SetStatus(status.StatusInfo{
+			Status:  status.Status(arg.Status),
+			Message: arg.Message,
+		})
+	}
+	results := make([]params.ErrorResult, len(args.Args))
+	for i, arg := range args.Args {
+		err := changeOne(arg)
+		results[i].Error = common.ServerError(err)
+	}
+	statusResults.Results = results
+	return statusResults, nil
+}
+
 // WatchUnitAddresses returns a NotifyWatcher for observing changes
 // to each unit's addresses.
 func (u *UniterAPI) WatchUnitAddresses(args params.Entities) (params.NotifyWatchResults, error) {
@@ -1535,15 +1557,11 @@ func (u *UniterAPI) prepareRelationResult(rel *state.Relation, unit *state.Unit)
 	for _, otherEp := range otherEndpoints {
 		otherAppName = otherEp.ApplicationName
 	}
-	relStatus, err := rel.Status()
-	if err != nil {
-		return nothing, err
-	}
 	return params.RelationResult{
-		Id:     rel.Id(),
-		Key:    rel.String(),
-		Life:   params.Life(rel.Life().String()),
-		Status: params.RelationStatusValue(relStatus.Status),
+		Id:        rel.Id(),
+		Key:       rel.String(),
+		Life:      params.Life(rel.Life().String()),
+		Suspended: rel.Suspended(),
 		Endpoint: multiwatcher.Endpoint{
 			ApplicationName: ep.ApplicationName,
 			Relation:        multiwatcher.NewCharmRelation(ep.Relation),

--- a/apiserver/facades/agent/uniter/uniter.go
+++ b/apiserver/facades/agent/uniter/uniter.go
@@ -1428,6 +1428,8 @@ func (u *UniterAPI) WatchRelationUnits(args params.RelationUnits) (params.Relati
 func (u *UniterAPI) SetRelationStatus(args params.RelationStatusArgs) (params.ErrorResults, error) {
 	var statusResults params.ErrorResults
 
+	// TODO(wallyworld) - the token should be passed to SetStatus() but the
+	// interface method doesn't allow for that yet.
 	checker := u.st.LeadershipChecker()
 	token := checker.LeadershipCheck(u.unit.ApplicationName(), u.unit.Name())
 	if err := token.Check(nil); err != nil {

--- a/apiserver/facades/agent/uniter/uniter_test.go
+++ b/apiserver/facades/agent/uniter/uniter_test.go
@@ -278,7 +278,7 @@ func (s *uniterSuite) TestLife(c *gc.C) {
 	c.Assert(rel.Life(), gc.Equals, state.Alive)
 	relStatus, err := rel.Status()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(relStatus.Status, gc.Equals, status.Joined)
+	c.Assert(relStatus.Status, gc.Equals, status.Joining)
 
 	// Make the wordpressUnit dead.
 	err = s.wordpressUnit.EnsureDead()
@@ -1677,16 +1677,14 @@ func (s *uniterSuite) TestRelation(c *gc.C) {
 	}}
 	result, err := s.uniter.Relation(args)
 	c.Assert(err, jc.ErrorIsNil)
-	relStatus, err := rel.Status()
-	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, params.RelationResults{
 		Results: []params.RelationResult{
 			{Error: apiservertesting.ErrUnauthorized},
 			{
-				Id:     rel.Id(),
-				Key:    rel.String(),
-				Life:   params.Life(rel.Life().String()),
-				Status: params.RelationStatusValue(relStatus.Status),
+				Id:        rel.Id(),
+				Key:       rel.String(),
+				Life:      params.Life(rel.Life().String()),
+				Suspended: rel.Suspended(),
 				Endpoint: multiwatcher.Endpoint{
 					ApplicationName: wpEp.ApplicationName,
 					Relation:        multiwatcher.NewCharmRelation(wpEp.Relation),
@@ -1718,16 +1716,14 @@ func (s *uniterSuite) TestRelationById(c *gc.C) {
 	}
 	result, err := s.uniter.RelationById(args)
 	c.Assert(err, jc.ErrorIsNil)
-	relStatus, err := rel.Status()
-	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, params.RelationResults{
 		Results: []params.RelationResult{
 			{Error: apiservertesting.ErrUnauthorized},
 			{
-				Id:     rel.Id(),
-				Key:    rel.String(),
-				Life:   params.Life(rel.Life().String()),
-				Status: params.RelationStatusValue(relStatus.Status),
+				Id:        rel.Id(),
+				Key:       rel.String(),
+				Life:      params.Life(rel.Life().String()),
+				Suspended: rel.Suspended(),
 				Endpoint: multiwatcher.Endpoint{
 					ApplicationName: wpEp.ApplicationName,
 					Relation:        multiwatcher.NewCharmRelation(wpEp.Relation),
@@ -1933,7 +1929,7 @@ func (s *uniterSuite) TestLeaveScope(c *gc.C) {
 	c.Assert(readSettings, gc.DeepEquals, settings)
 }
 
-func (s *uniterSuite) TestRelationsStatus(c *gc.C) {
+func (s *uniterSuite) TestRelationsSuspended(c *gc.C) {
 	rel := s.addRelation(c, "wordpress", "mysql")
 	relUnit, err := rel.Unit(s.wordpressUnit)
 	c.Assert(err, jc.ErrorIsNil)
@@ -1942,7 +1938,7 @@ func (s *uniterSuite) TestRelationsStatus(c *gc.C) {
 
 	s.AddTestingApplication(c, "logging", s.AddTestingCharm(c, "logging"))
 	rel2 := s.addRelation(c, "wordpress", "logging")
-	err = rel2.SetStatus(status.StatusInfo{Status: status.Suspended})
+	err = rel2.SetSuspended(true)
 	c.Assert(err, jc.ErrorIsNil)
 
 	args := params.Entities{
@@ -1960,11 +1956,11 @@ func (s *uniterSuite) TestRelationsStatus(c *gc.C) {
 			{RelationResults: []params.RelationUnitStatus{{
 				RelationTag: rel.Tag().String(),
 				InScope:     true,
-				Status:      params.Joined,
+				Suspended:   false,
 			}, {
 				RelationTag: rel2.Tag().String(),
 				InScope:     false,
-				Status:      params.Suspended,
+				Suspended:   true,
 			}},
 			},
 			{Error: apiservertesting.ErrUnauthorized},
@@ -1983,6 +1979,47 @@ func (s *uniterSuite) TestRelationsStatus(c *gc.C) {
 	err = relUnit.PrepareLeaveScope()
 	c.Assert(err, jc.ErrorIsNil)
 	check()
+}
+
+func (s *uniterSuite) TestSetRelationsStatus(c *gc.C) {
+	rel := s.addRelation(c, "wordpress", "mysql")
+	relUnit, err := rel.Unit(s.wordpressUnit)
+	c.Assert(err, jc.ErrorIsNil)
+	err = relUnit.EnterScope(nil)
+	c.Assert(err, jc.ErrorIsNil)
+
+	s.AddTestingApplication(c, "logging", s.AddTestingCharm(c, "logging"))
+	rel2 := s.addRelation(c, "wordpress", "logging")
+	err = rel2.SetSuspended(true)
+	c.Assert(err, jc.ErrorIsNil)
+
+	args := params.RelationStatusArgs{
+		Args: []params.RelationStatusArg{
+			{0, params.Suspended, "message"},
+			{1, params.Broken, ""},
+			{RelationId: 4},
+		},
+	}
+	expect := params.ErrorResults{
+		Results: []params.ErrorResult{
+			{},
+			{},
+			{Error: apiservertesting.ErrUnauthorized},
+		},
+	}
+	check := func(rel *state.Relation, expectedStatus status.Status, expectedMessage string) {
+		err = rel.Refresh()
+		c.Assert(err, jc.ErrorIsNil)
+		relStatus, err := rel.Status()
+		c.Assert(err, jc.ErrorIsNil)
+		c.Assert(relStatus.Status, gc.Equals, expectedStatus)
+		c.Assert(relStatus.Message, gc.Equals, expectedMessage)
+	}
+	result, err := s.uniter.SetRelationStatus(args)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result, gc.DeepEquals, expect)
+	check(rel, status.Suspended, "message")
+	check(rel2, status.Broken, "")
 }
 
 func (s *uniterSuite) TestReadSettings(c *gc.C) {

--- a/apiserver/facades/client/application/application.go
+++ b/apiserver/facades/client/application/application.go
@@ -1048,6 +1048,9 @@ func (api *API) SetRelationsSuspended(args params.RelationSuspendedArgs) (params
 		if err != nil {
 			return errors.Trace(err)
 		}
+		if rel.Suspended() == arg.Suspended {
+			return nil
+		}
 		_, err = api.backend.OfferConnectionForRelation(rel.Tag().Id())
 		if errors.IsNotFound(err) {
 			return errors.Errorf("cannot set suspend status for %q which is not associated with an offer", rel.Tag().Id())
@@ -1057,10 +1060,9 @@ func (api *API) SetRelationsSuspended(args params.RelationSuspendedArgs) (params
 			return errors.Trace(err)
 		}
 
-		// TODO(wallyworld) - keep until followup PR so things keep working
-		statusValue := status.Joined
+		statusValue := status.Joining
 		if arg.Suspended {
-			statusValue = status.Suspended
+			statusValue = status.Suspending
 		}
 		return rel.SetStatus(status.StatusInfo{
 			Status: status.Status(statusValue),

--- a/apiserver/facades/client/application/application_unit_test.go
+++ b/apiserver/facades/client/application/application_unit_test.go
@@ -416,7 +416,39 @@ func (s *ApplicationSuite) TestSetRelationSuspended(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results.OneError(), gc.IsNil)
 	c.Assert(s.relation.suspended, jc.IsTrue)
-	c.Assert(s.relation.status, gc.Equals, status.Suspended)
+	c.Assert(s.relation.status, gc.Equals, status.Suspending)
+}
+
+func (s *ApplicationSuite) TestSetRelationSuspendedNoOp(c *gc.C) {
+	s.backend.offerConnections["wordpress:db mysql:db"] = &mockOfferConnection{}
+	s.relation.suspended = true
+	s.relation.status = status.Error
+	results, err := s.api.SetRelationsSuspended(params.RelationSuspendedArgs{
+		Args: []params.RelationSuspendedArg{{
+			RelationId: 123,
+			Suspended:  true,
+		}},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(results.OneError(), gc.IsNil)
+	c.Assert(s.relation.suspended, jc.IsTrue)
+	c.Assert(s.relation.status, gc.Equals, status.Error)
+}
+
+func (s *ApplicationSuite) TestSetRelationSuspendedFalse(c *gc.C) {
+	s.backend.offerConnections["wordpress:db mysql:db"] = &mockOfferConnection{}
+	s.relation.suspended = true
+	s.relation.status = status.Error
+	results, err := s.api.SetRelationsSuspended(params.RelationSuspendedArgs{
+		Args: []params.RelationSuspendedArg{{
+			RelationId: 123,
+			Suspended:  false,
+		}},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(results.OneError(), gc.IsNil)
+	c.Assert(s.relation.suspended, jc.IsFalse)
+	c.Assert(s.relation.status, gc.Equals, status.Joining)
 }
 
 func (s *ApplicationSuite) TestSetNonOfferRelationStatus(c *gc.C) {

--- a/apiserver/facades/client/application/backend.go
+++ b/apiserver/facades/client/application/backend.go
@@ -102,6 +102,7 @@ type Relation interface {
 	Destroy() error
 	Endpoint(string) (state.Endpoint, error)
 	SetSuspended(bool) error
+	Suspended() bool
 }
 
 // Unit defines a subset of the functionality provided by the

--- a/apiserver/facades/client/application/mock_test.go
+++ b/apiserver/facades/client/application/mock_test.go
@@ -537,6 +537,11 @@ func (r *mockRelation) SetSuspended(suspended bool) error {
 	return r.NextErr()
 }
 
+func (r *mockRelation) Suspended() bool {
+	r.MethodCall(r, "Suspended")
+	return r.suspended
+}
+
 func (r *mockRelation) Destroy() error {
 	r.MethodCall(r, "Destroy")
 	return r.NextErr()

--- a/apiserver/facades/client/client/api_test.go
+++ b/apiserver/facades/client/client/api_test.go
@@ -310,7 +310,7 @@ var scenarioStatus = &params.FullStatus{
 			Interface: "logging",
 			Scope:     "container",
 			Status: params.DetailedStatus{
-				Status: "joined",
+				Status: "joining",
 				Info:   "",
 				Data:   make(map[string]interface{}),
 			},

--- a/apiserver/facades/controller/crossmodelrelations/crossmodelrelations.go
+++ b/apiserver/facades/controller/crossmodelrelations/crossmodelrelations.go
@@ -59,7 +59,7 @@ func NewStateCrossModelRelationsAPI(ctx facade.Context) (*CrossModelRelationsAPI
 		firewall.StateShim(ctx.State(), model),
 		ctx.Resources(), ctx.Auth(), authCtxt.(*commoncrossmodel.AuthContext),
 		firewall.WatchEgressAddressesForRelations,
-		watchRelationLifeStatus,
+		watchRelationLifeSuspendedStatus,
 	)
 }
 
@@ -349,21 +349,21 @@ func (api *CrossModelRelationsAPI) RelationUnitSettings(relationUnits params.Rem
 	return results, nil
 }
 
-func watchRelationLifeStatus(st CrossModelRelationsState, tag names.RelationTag) (state.StringsWatcher, error) {
+func watchRelationLifeSuspendedStatus(st CrossModelRelationsState, tag names.RelationTag) (state.StringsWatcher, error) {
 	relation, err := st.KeyRelation(tag.Id())
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	return relation.WatchLifeStatus(), nil
+	return relation.WatchLifeSuspendedStatus(), nil
 }
 
-// WatchRelationsStatus starts a RelationStatusWatcher for
-// watching the life and status of a relation.
-func (api *CrossModelRelationsAPI) WatchRelationsStatus(
+// WatchRelationsSuspendedStatus starts a RelationStatusWatcher for
+// watching the life and suspended status of a relation.
+func (api *CrossModelRelationsAPI) WatchRelationsSuspendedStatus(
 	remoteRelationArgs params.RemoteEntityArgs,
 ) (params.RelationStatusWatchResults, error) {
 	results := params.RelationStatusWatchResults{
-		Results: make([]params.RelationStatusWatchResult, len(remoteRelationArgs.Args)),
+		Results: make([]params.RelationLifeSuspendedStatusWatchResult, len(remoteRelationArgs.Args)),
 	}
 
 	for i, arg := range remoteRelationArgs.Args {
@@ -387,9 +387,9 @@ func (api *CrossModelRelationsAPI) WatchRelationsStatus(
 			continue
 		}
 		results.Results[i].RelationStatusWatcherId = api.resources.Register(w)
-		changesParams := make([]params.RelationStatusChange, len(changes))
+		changesParams := make([]params.RelationLifeSuspendedStatusChange, len(changes))
 		for j, key := range changes {
-			change, err := commoncrossmodel.GetRelationStatusChange(api.st, key)
+			change, err := commoncrossmodel.GetRelationLifeSuspendedStatusChange(api.st, key)
 			if err != nil {
 				results.Results[i].Error = common.ServerError(err)
 				changesParams = nil

--- a/apiserver/facades/controller/crossmodelrelations/mock_test.go
+++ b/apiserver/facades/controller/crossmodelrelations/mock_test.go
@@ -280,9 +280,12 @@ func (m *mockModel) Owner() names.UserTag {
 type mockRelation struct {
 	commoncrossmodel.Relation
 	testing.Stub
-	id    int
-	key   string
-	units map[string]commoncrossmodel.RelationUnit
+	id        int
+	key       string
+	suspended bool
+	status    status.Status
+	message   string
+	units     map[string]commoncrossmodel.RelationUnit
 }
 
 func newMockRelation(id int) *mockRelation {
@@ -311,8 +314,22 @@ func (r *mockRelation) Life() state.Life {
 	return state.Alive
 }
 
-func (r *mockRelation) Status() (status.StatusInfo, error) {
-	return status.StatusInfo{Status: status.Suspended}, nil
+func (r *mockRelation) SetStatus(statusInfo status.StatusInfo) error {
+	r.MethodCall(r, "SetStatus")
+	r.status = statusInfo.Status
+	r.message = statusInfo.Message
+	return nil
+}
+
+func (r *mockRelation) SetSuspended(suspended bool) error {
+	r.MethodCall(r, "SetSuspended")
+	r.suspended = suspended
+	return nil
+}
+
+func (r *mockRelation) Suspended() bool {
+	r.MethodCall(r, "Suspended")
+	return r.suspended
 }
 
 func (r *mockRelation) RemoteUnit(unitId string) (commoncrossmodel.RelationUnit, error) {

--- a/apiserver/facades/controller/remoterelations/mock_test.go
+++ b/apiserver/facades/controller/remoterelations/mock_test.go
@@ -253,9 +253,9 @@ func (r *mockRelation) Life() state.Life {
 	return r.life
 }
 
-func (r *mockRelation) Status() (status.StatusInfo, error) {
-	r.MethodCall(r, "Status")
-	return status.StatusInfo{Status: status.Joined}, nil
+func (r *mockRelation) Suspended() bool {
+	r.MethodCall(r, "Suspended")
+	return false
 }
 
 func (r *mockRelation) Unit(unitId string) (common.RelationUnit, error) {

--- a/apiserver/params/crossmodel.go
+++ b/apiserver/params/crossmodel.go
@@ -323,11 +323,8 @@ type RemoteRelationChangeEvent struct {
 	// Life is the current lifecycle state of the relation.
 	Life Life `json:"life"`
 
-	// Status is the current status of the relation.
-	Status RelationStatusValue `json:"status"`
-
-	// StatusMessage is the status message for the relation.
-	StatusMessage string `json:"status-message"`
+	// Suspended is the current suspended status of the relation.
+	Suspended *bool `json:"suspended,omitempty"`
 
 	// ChangedUnits maps unit tokens to relation unit changes.
 	ChangedUnits []RemoteRelationUnitChange `json:"changed-units,omitempty"`
@@ -340,33 +337,31 @@ type RemoteRelationChangeEvent struct {
 	Macaroons macaroon.Slice `json:"macaroons,omitempty"`
 }
 
-// RelationStatusChange describes the life and status of a relation.
-type RelationStatusChange struct {
+// RelationLifeSuspendedStatusChange describes the life
+// and suspended status of a relation.
+type RelationLifeSuspendedStatusChange struct {
 	// Key is the relation key of the changed relation.
 	Key string `json:"key"`
 
 	// Life is the life of the relation.
 	Life Life `json:"life"`
 
-	// Status is the status of the relation.
-	Status RelationStatusValue `json:"status"`
-
-	// StatusMessage is the status message.
-	StatusMessage string `json:"status-message"`
+	// Suspended is the suspended status of the relation.
+	Suspended bool `json:"suspended"`
 }
 
-// RelationStatusWatchResult holds a RelationStatusWatcher id, baseline state
+// RelationLifeSuspendedStatusWatchResult holds a RelationStatusWatcher id, baseline state
 // (in the Changes field), and an error (if any).
-type RelationStatusWatchResult struct {
-	RelationStatusWatcherId string                 `json:"watcher-id"`
-	Changes                 []RelationStatusChange `json:"changes"`
-	Error                   *Error                 `json:"error,omitempty"`
+type RelationLifeSuspendedStatusWatchResult struct {
+	RelationStatusWatcherId string                              `json:"watcher-id"`
+	Changes                 []RelationLifeSuspendedStatusChange `json:"changes"`
+	Error                   *Error                              `json:"error,omitempty"`
 }
 
 // RelationStatusWatchResults holds the results for any API call which ends up
 // returning a list of RelationStatusWatchers.
 type RelationStatusWatchResults struct {
-	Results []RelationStatusWatchResult `json:"results"`
+	Results []RelationLifeSuspendedStatusWatchResult `json:"results"`
 }
 
 // IngressNetworksChanges holds a set of IngressNetworksChangeEvent structures.

--- a/apiserver/params/internal.go
+++ b/apiserver/params/internal.go
@@ -317,7 +317,7 @@ type RelationResults struct {
 type RelationResult struct {
 	Error            *Error                `json:"error,omitempty"`
 	Life             Life                  `json:"life"`
-	Status           RelationStatusValue   `json:"status,omitempty"`
+	Suspended        bool                  `json:"bool,omitempty"`
 	Id               int                   `json:"id"`
 	Key              string                `json:"key"`
 	Endpoint         multiwatcher.Endpoint `json:"endpoint"`
@@ -584,12 +584,12 @@ type RelationUnitsWatchResults struct {
 	Results []RelationUnitsWatchResult `json:"results"`
 }
 
-// RelationUnitStatusResult holds details about scope and status
-// for a relation unit.
+// RelationUnitStatusResult holds details about scope
+// and suspended status for a relation unit.
 type RelationUnitStatus struct {
-	RelationTag string              `json:"relation-tag"`
-	InScope     bool                `json:"in-scope"`
-	Status      RelationStatusValue `json:"status"`
+	RelationTag string `json:"relation-tag"`
+	InScope     bool   `json:"in-scope"`
+	Suspended   bool   `json:"suspended"`
 }
 
 // RelationUnitStatusResult holds details about scope and status for

--- a/apiserver/watcher.go
+++ b/apiserver/watcher.go
@@ -247,19 +247,19 @@ func newRelationStatusWatcher(context facade.Context) (facade.Facade, error) {
 // Next returns when a change has occured to an entity of the
 // collection being watched since the most recent call to Next
 // or the Watch call that created the srvRelationStatusWatcher.
-func (w *srvRelationStatusWatcher) Next() (params.RelationStatusWatchResult, error) {
+func (w *srvRelationStatusWatcher) Next() (params.RelationLifeSuspendedStatusWatchResult, error) {
 	if changes, ok := <-w.watcher.Changes(); ok {
-		changesParams := make([]params.RelationStatusChange, len(changes))
+		changesParams := make([]params.RelationLifeSuspendedStatusChange, len(changes))
 		for i, key := range changes {
-			change, err := crossmodel.GetRelationStatusChange(crossmodel.GetBackend(w.st), key)
+			change, err := crossmodel.GetRelationLifeSuspendedStatusChange(crossmodel.GetBackend(w.st), key)
 			if err != nil {
-				return params.RelationStatusWatchResult{
+				return params.RelationLifeSuspendedStatusWatchResult{
 					Error: common.ServerError(err),
 				}, nil
 			}
 			changesParams[i] = *change
 		}
-		return params.RelationStatusWatchResult{
+		return params.RelationLifeSuspendedStatusWatchResult{
 			Changes: changesParams,
 		}, nil
 	}
@@ -267,7 +267,7 @@ func (w *srvRelationStatusWatcher) Next() (params.RelationStatusWatchResult, err
 	if err == nil {
 		err = common.ErrStoppedWatcher
 	}
-	return params.RelationStatusWatchResult{}, err
+	return params.RelationLifeSuspendedStatusWatchResult{}, err
 }
 
 // srvMachineStorageIdsWatcher defines the API wrapping a state.StringsWatcher

--- a/provider/vsphere/internal/vsphereclient/createvm_test.go
+++ b/provider/vsphere/internal/vsphereclient/createvm_test.go
@@ -452,7 +452,7 @@ func findStubCall(c *gc.C, calls []testing.StubCall, name string) testing.StubCa
 			return call
 		}
 	}
-	c.Fatal("failed to find call %q", name)
+	c.Fatalf("failed to find call %q", name)
 	panic("unreachable")
 }
 

--- a/state/application_test.go
+++ b/state/application_test.go
@@ -2392,7 +2392,7 @@ func (s *ApplicationSuite) TestWatchRelations(c *gc.C) {
 	wpxWatcherC.AssertChange(relx.String())
 	wpxWatcherC.AssertNoChange()
 
-	err = relx.SetStatus(status.StatusInfo{Status: status.Suspended})
+	err = relx.SetSuspended(true)
 	c.Assert(err, jc.ErrorIsNil)
 	wpxWatcherC.AssertChange(relx.String())
 	wpxWatcherC.AssertNoChange()

--- a/state/migration_export_test.go
+++ b/state/migration_export_test.go
@@ -616,7 +616,7 @@ func (s *MigrationExportSuite) TestRelations(c *gc.C) {
 
 	// Make sure there is a status.
 	status := exRel.Status()
-	c.Check(status.Value(), gc.Equals, "joined")
+	c.Check(status.Value(), gc.Equals, "joining")
 }
 
 func (s *MigrationExportSuite) TestSubordinateRelations(c *gc.C) {

--- a/state/migration_import_test.go
+++ b/state/migration_import_test.go
@@ -694,7 +694,7 @@ func (s *MigrationImportSuite) TestRelations(c *gc.C) {
 
 	relStatus, err := rels[0].Status()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(relStatus.Status, gc.Equals, status.Joined)
+	c.Assert(relStatus.Status, gc.Equals, status.Joining)
 
 	ru, err = rels[0].Unit(units[0])
 	c.Assert(err, jc.ErrorIsNil)

--- a/state/relation.go
+++ b/state/relation.go
@@ -116,7 +116,6 @@ func (r *Relation) Status() (status.StatusInfo, error) {
 
 // SetStatus sets the status of the relation.
 func (r *Relation) SetStatus(statusInfo status.StatusInfo) error {
-	logger.Criticalf("SET STATUS: %+v", statusInfo)
 	currentStatus, err := r.Status()
 	if err != nil {
 		return errors.Trace(err)

--- a/state/relation_test.go
+++ b/state/relation_test.go
@@ -475,7 +475,7 @@ func (s *RelationSuite) TestRemoveNoFeatureFlag(c *gc.C) {
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 }
 
-func (s *RelationSuite) TestWatchLifeStatus(c *gc.C) {
+func (s *RelationSuite) TestWatchLifeSuspendedStatus(c *gc.C) {
 	rel := s.setupRelationStatus(c)
 	mysql, err := s.State.Application("mysql")
 	c.Assert(err, jc.ErrorIsNil)
@@ -489,14 +489,14 @@ func (s *RelationSuite) TestWatchLifeStatus(c *gc.C) {
 	err = relUnit.EnterScope(nil)
 	c.Assert(err, jc.ErrorIsNil)
 
-	w := rel.WatchLifeStatus()
+	w := rel.WatchLifeSuspendedStatus()
 	defer testing.AssertStop(c, w)
 	wc := testing.NewStringsWatcherC(c, s.State, w)
 	// Initial event.
 	wc.AssertChange(rel.Tag().Id())
 	wc.AssertNoChange()
 
-	err = rel.SetStatus(status.StatusInfo{Status: status.Suspended})
+	err = rel.SetSuspended(true)
 	c.Assert(err, jc.ErrorIsNil)
 	wc.AssertChange(rel.Tag().Id())
 	wc.AssertNoChange()
@@ -507,7 +507,7 @@ func (s *RelationSuite) TestWatchLifeStatus(c *gc.C) {
 	wc.AssertNoChange()
 }
 
-func (s *RelationSuite) TestWatchLifeStatusDead(c *gc.C) {
+func (s *RelationSuite) TestWatchLifeSuspendedStatusDead(c *gc.C) {
 	// Create a pair of services and a relation between them.
 	s.AddTestingApplication(c, "mysql", s.AddTestingCharm(c, "mysql"))
 	s.AddTestingApplication(c, "wordpress", s.AddTestingCharm(c, "wordpress"))
@@ -516,7 +516,7 @@ func (s *RelationSuite) TestWatchLifeStatusDead(c *gc.C) {
 	rel, err := s.State.AddRelation(eps...)
 	c.Assert(err, jc.ErrorIsNil)
 
-	w := rel.WatchLifeStatus()
+	w := rel.WatchLifeSuspendedStatus()
 	defer testing.AssertStop(c, w)
 	wc := testing.NewStringsWatcherC(c, s.State, w)
 	wc.AssertChange(rel.Tag().Id())
@@ -538,7 +538,7 @@ func (s *RelationSuite) setupRelationStatus(c *gc.C) *state.Relation {
 	c.Assert(err, jc.ErrorIsNil)
 	relStatus, err := rel.Status()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(relStatus.Status, gc.Equals, status.Joined)
+	c.Assert(relStatus.Status, gc.Equals, status.Joining)
 	ao := state.NewApplicationOffers(s.State)
 	offer, err := ao.AddOffer(crossmodel.AddApplicationOfferArgs{
 		OfferName:       "hosted-mysql",

--- a/state/state.go
+++ b/state/state.go
@@ -991,7 +991,7 @@ func (st *State) addPeerRelationsOps(applicationname string, peers map[string]ch
 			Life:      Alive,
 		}
 		relationStatusDoc := statusDoc{
-			Status:    status.Joined,
+			Status:    status.Joining,
 			ModelUUID: st.ModelUUID(),
 			Updated:   now.UnixNano(),
 		}
@@ -1834,7 +1834,7 @@ func (st *State) AddRelation(eps ...Endpoint) (r *Relation, err error) {
 			Life:      Alive,
 		}
 		relationStatusDoc := statusDoc{
-			Status:    status.Joined,
+			Status:    status.Joining,
 			ModelUUID: st.ModelUUID(),
 			Updated:   now.UnixNano(),
 		}

--- a/status/status.go
+++ b/status/status.go
@@ -186,11 +186,18 @@ const (
 const (
 	// Status values specific to relations.
 
+	// Joining is used to signify that a relation should become joined soon.
+	Joining Status = "joining"
+
 	// Joined is the normal status for a healthy, alive relation.
 	Joined Status = "joined"
 
 	// Broken is the status for when a relation life goes to Dead.
 	Broken Status = "broken"
+
+	// Suspended is used to signify that a relation will be temporarily broken
+	// pending action to resume it.
+	Suspending Status = "suspending"
 
 	// Suspended is used to signify that a relation is temporarily broken pending
 	// action to resume it.

--- a/watcher/relationstatus.go
+++ b/watcher/relationstatus.go
@@ -5,7 +5,6 @@ package watcher
 
 import (
 	"github.com/juju/juju/core/life"
-	"github.com/juju/juju/core/relation"
 )
 
 // RelationStatusChange describes changes to some relation.
@@ -13,17 +12,15 @@ type RelationStatusChange struct {
 	// Key is the relation key of the changed relation.
 	Key string
 
-	// Status is the status of the relation, eg joined.
-	Status relation.Status
-
-	// StatusMessage is the status message.
-	StatusMessage string
+	// Suspended is the suspended status of the relation.
+	Suspended bool
 
 	// Life is the relation life value, eg Alive.
 	Life life.Value
 }
 
-// RelationStatusChannel is a channel used to notify of changes to a relation's status.
+// RelationStatusChannel is a channel used to notify of changes to
+// a relation's life or suspended status.
 type RelationStatusChannel <-chan []RelationStatusChange
 
 // RelationStatusWatcher conveniently ties a RelationStatusChannel to the

--- a/worker/remoterelations/mock_test.go
+++ b/worker/remoterelations/mock_test.go
@@ -316,10 +316,10 @@ func (m *mockRemoteRelationsFacade) relationsStatusWatcher(key string) (*mockRel
 	return w, ok
 }
 
-func (m *mockRemoteRelationsFacade) WatchRelationStatus(arg params.RemoteEntityArg) (watcher.RelationStatusWatcher, error) {
+func (m *mockRemoteRelationsFacade) WatchRelationSuspendedStatus(arg params.RemoteEntityArg) (watcher.RelationStatusWatcher, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	m.stub.MethodCall(m, "WatchRelationStatus", arg.Token, arg.Macaroons)
+	m.stub.MethodCall(m, "WatchRelationSuspendedStatus", arg.Token, arg.Macaroons)
 	if err := m.stub.NextErr(); err != nil {
 		return nil, err
 	}

--- a/worker/remoterelations/remoteapplicationworker.go
+++ b/worker/remoterelations/remoteapplicationworker.go
@@ -321,7 +321,7 @@ func (w *remoteApplicationWorker) processNewConsumingRelation(
 		return errors.Trace(err)
 	}
 
-	remoteRelationsWatcher, err := w.remoteModelFacade.WatchRelationStatus(params.RemoteEntityArg{
+	remoteRelationsWatcher, err := w.remoteModelFacade.WatchRelationSuspendedStatus(params.RemoteEntityArg{
 		Token:     relationToken,
 		Macaroons: macaroon.Slice{mac},
 	})

--- a/worker/remoterelations/remoterelations.go
+++ b/worker/remoterelations/remoterelations.go
@@ -46,9 +46,9 @@ type RemoteModelRelationsFacade interface {
 	// RelationUnitSettings returns the relation unit settings for the given relation units in the remote model.
 	RelationUnitSettings([]params.RemoteRelationUnit) ([]params.SettingsResult, error)
 
-	// WatchRemoteApplicationRelations starts a RelationStatusWatcher for watching the
+	// WatchRelationSuspendedStatus starts a RelationStatusWatcher for watching the
 	// relations of each specified application in the remote model.
-	WatchRelationStatus(arg params.RemoteEntityArg) (watcher.RelationStatusWatcher, error)
+	WatchRelationSuspendedStatus(arg params.RemoteEntityArg) (watcher.RelationStatusWatcher, error)
 }
 
 // RemoteRelationsFacade exposes remote relation functionality to a worker.

--- a/worker/remoterelations/remoterelations_test.go
+++ b/worker/remoterelations/remoterelations_test.go
@@ -176,7 +176,7 @@ func (s *remoteRelationsSuite) assertRemoteRelationsWorkers(c *gc.C) worker.Work
 		{"ImportRemoteEntity", []interface{}{names.NewApplicationTag("db2"), "token-offer-db2-uuid"}},
 		{"WatchLocalRelationUnits", []interface{}{"db2:db django:db"}},
 		{"WatchRelationUnits", []interface{}{"token-db2:db django:db", macaroon.Slice{apiMac}}},
-		{"WatchRelationStatus", []interface{}{"token-db2:db django:db", macaroon.Slice{apiMac}}},
+		{"WatchRelationSuspendedStatus", []interface{}{"token-db2:db django:db", macaroon.Slice{apiMac}}},
 	}
 	s.waitForWorkerStubCalls(c, expected)
 
@@ -367,12 +367,14 @@ func (s *remoteRelationsSuite) TestRemoteRelationsDyingConsumes(c *gc.C) {
 		Life: life.Dying,
 	}}
 
+	suspended := false
 	expected := []jujutesting.StubCall{
 		{"ConsumeRemoteRelationChange", []interface{}{
 			params.RemoteRelationChangeEvent{
 				Life:             params.Dying,
 				ApplicationToken: "token-offer-db2-uuid",
 				RelationToken:    "token-db2:db django:db",
+				Suspended:        &suspended,
 			},
 		}},
 	}

--- a/worker/remoterelations/remoterelationsworker.go
+++ b/worker/remoterelations/remoterelationsworker.go
@@ -98,12 +98,12 @@ func (w *remoteRelationsWorker) relationUnitsChangeEvent(
 ) (*params.RemoteRelationChangeEvent, error) {
 	logger.Debugf("update relation status for %v", w.relationTag)
 
+	suspended := change.Suspended
 	event := &params.RemoteRelationChangeEvent{
 		RelationToken:    w.remoteRelationToken,
 		ApplicationToken: w.applicationToken,
 		Life:             params.Life(change.Life),
-		Status:           params.RelationStatusValue(change.Status),
-		StatusMessage:    change.StatusMessage,
+		Suspended:        &suspended,
 	}
 	return event, nil
 }

--- a/worker/uniter/operation/runhook.go
+++ b/worker/uniter/operation/runhook.go
@@ -190,11 +190,7 @@ func (rh *runHook) afterHook(state State) (_ bool, err error) {
 			return hasRunStatusSet && err == nil, err
 		}
 		rel, err := ctx.Relation(rh.info.RelationId)
-		if err != nil {
-			return false, err
-		}
-		suspended, err := rel.Suspended()
-		if suspended && err == nil {
+		if err == nil && rel.Suspended() {
 			err = rel.SetStatus(relation.Suspended)
 		}
 	}

--- a/worker/uniter/operation/runhook_test.go
+++ b/worker/uniter/operation/runhook_test.go
@@ -10,6 +10,7 @@ import (
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/charm.v6-unstable/hooks"
 
+	"github.com/juju/juju/core/relation"
 	"github.com/juju/juju/worker/uniter/hook"
 	"github.com/juju/juju/worker/uniter/operation"
 	"github.com/juju/juju/worker/uniter/runner/context"
@@ -564,6 +565,61 @@ func (s *RunHookSuite) TestCommitSuccess_Start_Preserve(c *gc.C) {
 			},
 		)
 	}
+}
+
+func (s *RunHookSuite) assertCommitSuccess_RelationBroken_SetStatus(c *gc.C, suspended, leader bool) {
+	ctx := &MockContext{
+		isLeader: leader,
+		relation: &MockRelation{
+			suspended: suspended,
+		},
+	}
+	runnerFactory := &MockRunnerFactory{
+		MockNewHookRunner: &MockNewHookRunner{
+			runner: &MockRunner{
+				MockRunHook: &MockRunHook{},
+				context:     ctx,
+			},
+		},
+	}
+	callbacks := &ExecuteHookCallbacks{
+		PrepareHookCallbacks:    NewPrepareHookCallbacks(),
+		MockNotifyHookCompleted: &MockNotify{},
+	}
+	factory := operation.NewFactory(operation.FactoryParams{
+		RunnerFactory: runnerFactory,
+		Callbacks:     callbacks,
+	})
+	op, err := factory.NewRunHook(hook.Info{Kind: hooks.RelationBroken})
+	c.Assert(err, jc.ErrorIsNil)
+
+	_, err = op.Prepare(operation.State{})
+	c.Assert(err, jc.ErrorIsNil)
+
+	newState, err := op.Execute(operation.State{})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(newState, gc.DeepEquals, &operation.State{
+		Kind: operation.RunHook,
+		Step: operation.Done,
+		Hook: &hook.Info{Kind: hooks.RelationBroken},
+	})
+	if suspended && leader {
+		c.Assert(ctx.relation.status, gc.Equals, relation.Suspended)
+	} else {
+		c.Assert(ctx.relation.status, gc.Equals, relation.Status(""))
+	}
+}
+
+func (s *RunHookSuite) TestCommitSuccess_RelationBroken_SetStatus(c *gc.C) {
+	s.assertCommitSuccess_RelationBroken_SetStatus(c, true, true)
+}
+
+func (s *RunHookSuite) TestCommitSuccess_RelationBroken_SetStatusNotLeader(c *gc.C) {
+	s.assertCommitSuccess_RelationBroken_SetStatus(c, true, false)
+}
+
+func (s *RunHookSuite) TestCommitSuccess_RelationBroken_SetStatusNotSuspended(c *gc.C) {
+	s.assertCommitSuccess_RelationBroken_SetStatus(c, false, true)
 }
 
 func (s *RunHookSuite) testQueueHook_BlankSlate(c *gc.C, cause hooks.Kind) {

--- a/worker/uniter/operation/util_test.go
+++ b/worker/uniter/operation/util_test.go
@@ -316,8 +316,8 @@ type MockRelation struct {
 	status    relation.Status
 }
 
-func (mock *MockRelation) Suspended() (bool, error) {
-	return mock.suspended, nil
+func (mock *MockRelation) Suspended() bool {
+	return mock.suspended
 }
 
 func (mock *MockRelation) SetStatus(status relation.Status) error {

--- a/worker/uniter/operation/util_test.go
+++ b/worker/uniter/operation/util_test.go
@@ -10,6 +10,7 @@ import (
 	corecharm "gopkg.in/juju/charm.v6-unstable"
 	"gopkg.in/juju/charm.v6-unstable/hooks"
 
+	"github.com/juju/juju/core/relation"
 	"github.com/juju/juju/worker/uniter/charm"
 	"github.com/juju/juju/worker/uniter/hook"
 	"github.com/juju/juju/worker/uniter/operation"
@@ -263,6 +264,8 @@ type MockContext struct {
 	actionData      *context.ActionData
 	setStatusCalled bool
 	status          jujuc.StatusInfo
+	isLeader        bool
+	relation        *MockRelation
 }
 
 func (mock *MockContext) ActionData() (*context.ActionData, error) {
@@ -297,6 +300,29 @@ func (mock *MockContext) UnitStatus() (*jujuc.StatusInfo, error) {
 func (mock *MockContext) Prepare() error {
 	mock.MethodCall(mock, "Prepare")
 	return mock.NextErr()
+}
+
+func (mock *MockContext) IsLeader() (bool, error) {
+	return mock.isLeader, nil
+}
+
+func (mock *MockContext) Relation(id int) (jujuc.ContextRelation, error) {
+	return mock.relation, nil
+}
+
+type MockRelation struct {
+	jujuc.ContextRelation
+	suspended bool
+	status    relation.Status
+}
+
+func (mock *MockRelation) Suspended() (bool, error) {
+	return mock.suspended, nil
+}
+
+func (mock *MockRelation) SetStatus(status relation.Status) error {
+	mock.status = status
+	return nil
 }
 
 type MockRunAction struct {

--- a/worker/uniter/relation/relationer.go
+++ b/worker/uniter/relation/relationer.go
@@ -6,18 +6,21 @@ package relation
 import (
 	"fmt"
 
+	"github.com/juju/errors"
 	"gopkg.in/juju/charm.v6-unstable/hooks"
 
 	apiuniter "github.com/juju/juju/api/uniter"
+	"github.com/juju/juju/core/relation"
 	"github.com/juju/juju/worker/uniter/hook"
 	"github.com/juju/juju/worker/uniter/runner/context"
 )
 
 // Relationer manages a unit's presence in a relation.
 type Relationer struct {
-	ru    *apiuniter.RelationUnit
-	dir   *StateDir
-	dying bool
+	ru        *apiuniter.RelationUnit
+	dir       *StateDir
+	dying     bool
+	suspended bool
 }
 
 // NewRelationer creates a new Relationer. The unit will not join the
@@ -52,6 +55,7 @@ func (r *Relationer) Join() error {
 	if r.dying {
 		panic("dying relationer must not join!")
 	}
+	r.suspended = false
 	// We need to make sure the state directory exists before we join the
 	// relation, lest a subsequent ReadAllStateDirs report local state that
 	// doesn't include relations recorded in remote state.
@@ -66,12 +70,13 @@ func (r *Relationer) Join() error {
 // SetDying informs the relationer that the unit is departing the relation,
 // and that the only hooks it should send henceforth are -departed hooks,
 // until the relation is empty, followed by a -broken hook.
-func (r *Relationer) SetDying() error {
+func (r *Relationer) SetDying(suspended bool) error {
 	if r.IsImplicit() {
 		r.dying = true
 		return r.die()
 	}
 	r.dying = true
+	r.suspended = suspended
 	return nil
 }
 
@@ -105,7 +110,15 @@ func (r *Relationer) CommitHook(hi hook.Info) error {
 		panic("implicit relations must not run hooks")
 	}
 	if hi.Kind == hooks.RelationBroken {
-		return r.die()
+		err := r.die()
+		if err != nil {
+			return errors.Trace(err)
+		}
+		rel := r.ru.Relation()
+		if r.suspended {
+			return rel.SetStatus(relation.Suspended)
+		}
+		return nil
 	}
 	return r.dir.Write(hi)
 }

--- a/worker/uniter/relation/relationer_test.go
+++ b/worker/uniter/relation/relationer_test.go
@@ -21,7 +21,6 @@ import (
 	jujutesting "github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/state"
-	"github.com/juju/juju/status"
 	coretesting "github.com/juju/juju/testing"
 	"github.com/juju/juju/worker/uniter/hook"
 	"github.com/juju/juju/worker/uniter/relation"
@@ -246,7 +245,7 @@ func (s *RelationerSuite) TestPrepareCommitHooks(c *gc.C) {
 	assertMembers(map[string]int64{"u/1": 7, "u/2": 3})
 }
 
-func (s *RelationerSuite) assertSetDying(c *gc.C, suspended bool) {
+func (s *RelationerSuite) TestSetDying(c *gc.C) {
 	ru1, u := s.AddRelationUnit(c, "u/1")
 	settings := map[string]interface{}{"unit": "settings"}
 	err := ru1.EnterScope(settings)
@@ -256,7 +255,7 @@ func (s *RelationerSuite) assertSetDying(c *gc.C, suspended bool) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Change Life to Dying check the results.
-	err = r.SetDying(suspended)
+	err = r.SetDying()
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Check that we cannot rejoin the relation.
@@ -279,21 +278,6 @@ func (s *RelationerSuite) assertSetDying(c *gc.C, suspended bool) {
 	c.Assert(err, jc.ErrorIsNil)
 	err = u.Refresh()
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
-	relStatus, err := ru1.Relation().Status()
-	c.Assert(err, jc.ErrorIsNil)
-	if suspended {
-		c.Assert(relStatus.Status, gc.Equals, status.Suspended)
-	} else {
-		c.Assert(relStatus.Status, gc.Equals, status.Joining)
-	}
-}
-
-func (s *RelationerSuite) TestSetDying(c *gc.C) {
-	s.assertSetDying(c, false)
-}
-
-func (s *RelationerSuite) TestSetDyingSuspended(c *gc.C) {
-	s.assertSetDying(c, true)
 }
 
 type stopper interface {
@@ -356,7 +340,7 @@ func (s *RelationerImplicitSuite) TestImplicitRelationer(c *gc.C) {
 	c.Assert(f, gc.PanicMatches, "implicit relations must not run hooks")
 
 	// Set it to Dying; check that the dir is removed immediately.
-	err = r.SetDying(false)
+	err = r.SetDying()
 	c.Assert(err, jc.ErrorIsNil)
 	path := strconv.Itoa(rel.Id())
 	ft.Removed{path}.Check(c, relsDir)

--- a/worker/uniter/relation/relationer_test.go
+++ b/worker/uniter/relation/relationer_test.go
@@ -21,6 +21,7 @@ import (
 	jujutesting "github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/state"
+	"github.com/juju/juju/status"
 	coretesting "github.com/juju/juju/testing"
 	"github.com/juju/juju/worker/uniter/hook"
 	"github.com/juju/juju/worker/uniter/relation"
@@ -245,7 +246,7 @@ func (s *RelationerSuite) TestPrepareCommitHooks(c *gc.C) {
 	assertMembers(map[string]int64{"u/1": 7, "u/2": 3})
 }
 
-func (s *RelationerSuite) TestSetDying(c *gc.C) {
+func (s *RelationerSuite) assertSetDying(c *gc.C, suspended bool) {
 	ru1, u := s.AddRelationUnit(c, "u/1")
 	settings := map[string]interface{}{"unit": "settings"}
 	err := ru1.EnterScope(settings)
@@ -255,7 +256,7 @@ func (s *RelationerSuite) TestSetDying(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Change Life to Dying check the results.
-	err = r.SetDying()
+	err = r.SetDying(suspended)
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Check that we cannot rejoin the relation.
@@ -278,6 +279,21 @@ func (s *RelationerSuite) TestSetDying(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	err = u.Refresh()
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
+	relStatus, err := ru1.Relation().Status()
+	c.Assert(err, jc.ErrorIsNil)
+	if suspended {
+		c.Assert(relStatus.Status, gc.Equals, status.Suspended)
+	} else {
+		c.Assert(relStatus.Status, gc.Equals, status.Joining)
+	}
+}
+
+func (s *RelationerSuite) TestSetDying(c *gc.C) {
+	s.assertSetDying(c, false)
+}
+
+func (s *RelationerSuite) TestSetDyingSuspended(c *gc.C) {
+	s.assertSetDying(c, true)
 }
 
 type stopper interface {
@@ -340,7 +356,7 @@ func (s *RelationerImplicitSuite) TestImplicitRelationer(c *gc.C) {
 	c.Assert(f, gc.PanicMatches, "implicit relations must not run hooks")
 
 	// Set it to Dying; check that the dir is removed immediately.
-	err = r.SetDying()
+	err = r.SetDying(false)
 	c.Assert(err, jc.ErrorIsNil)
 	path := strconv.Itoa(rel.Id())
 	ft.Removed{path}.Check(c, relsDir)

--- a/worker/uniter/relation/relations.go
+++ b/worker/uniter/relation/relations.go
@@ -388,11 +388,12 @@ func (r *relations) GetInfo() map[int]*context.RelationInfo {
 
 func (r *relations) update(remote map[int]remotestate.RelationSnapshot) error {
 	for id, relationSnapshot := range remote {
-		if _, found := r.relationers[id]; found {
+		if rel, found := r.relationers[id]; found {
 			// We've seen this relation before. The only changes
 			// we care about are to the lifecycle state or status,
 			// and to the member settings versions. We handle
 			// differences in settings in nextRelationHook.
+			rel.ru.Relation().UpdateSuspended(relationSnapshot.Suspended)
 			if relationSnapshot.Life == params.Dying || relationSnapshot.Suspended {
 				if err := r.setDying(id); err != nil {
 					return errors.Trace(err)

--- a/worker/uniter/relation/relations.go
+++ b/worker/uniter/relation/relations.go
@@ -394,7 +394,7 @@ func (r *relations) update(remote map[int]remotestate.RelationSnapshot) error {
 			// and to the member settings versions. We handle
 			// differences in settings in nextRelationHook.
 			if relationSnapshot.Life == params.Dying || relationSnapshot.Suspended {
-				if err := r.setDying(id, relationSnapshot.Suspended); err != nil {
+				if err := r.setDying(id); err != nil {
 					return errors.Trace(err)
 				}
 			}
@@ -516,12 +516,12 @@ func (r *relations) add(rel *uniter.Relation, dir *StateDir) (err error) {
 // setDying notifies the relationer identified by the supplied id that the
 // only hook executions to be requested should be those necessary to cleanly
 // exit the relation.
-func (r *relations) setDying(id int, suspended bool) error {
+func (r *relations) setDying(id int) error {
 	relationer, found := r.relationers[id]
 	if !found {
 		return nil
 	}
-	if err := relationer.SetDying(suspended); err != nil {
+	if err := relationer.SetDying(); err != nil {
 		return errors.Trace(err)
 	}
 	if relationer.IsImplicit() {

--- a/worker/uniter/remotestate/mock_test.go
+++ b/worker/uniter/remotestate/mock_test.go
@@ -191,7 +191,7 @@ type mockUnit struct {
 	life                  params.Life
 	resolved              params.ResolvedMode
 	series                string
-	service               mockService
+	application           mockApplication
 	unitWatcher           *mockNotifyWatcher
 	addressesWatcher      *mockNotifyWatcher
 	configSettingsWatcher *mockNotifyWatcher
@@ -213,7 +213,7 @@ func (u *mockUnit) Resolved() params.ResolvedMode {
 }
 
 func (u *mockUnit) Application() (remotestate.Application, error) {
-	return &u.service, nil
+	return &u.application, nil
 }
 
 func (u *mockUnit) Series() string {
@@ -248,48 +248,48 @@ func (u *mockUnit) WatchRelations() (watcher.StringsWatcher, error) {
 	return u.relationsWatcher, nil
 }
 
-type mockService struct {
+type mockApplication struct {
 	tag                   names.ApplicationTag
 	life                  params.Life
 	curl                  *charm.URL
 	charmModifiedVersion  int
 	forceUpgrade          bool
-	serviceWatcher        *mockNotifyWatcher
+	applicationWatcher    *mockNotifyWatcher
 	leaderSettingsWatcher *mockNotifyWatcher
 }
 
-func (s *mockService) CharmModifiedVersion() (int, error) {
+func (s *mockApplication) CharmModifiedVersion() (int, error) {
 	return s.charmModifiedVersion, nil
 }
 
-func (s *mockService) CharmURL() (*charm.URL, bool, error) {
+func (s *mockApplication) CharmURL() (*charm.URL, bool, error) {
 	return s.curl, s.forceUpgrade, nil
 }
 
-func (s *mockService) Life() params.Life {
+func (s *mockApplication) Life() params.Life {
 	return s.life
 }
 
-func (s *mockService) Refresh() error {
+func (s *mockApplication) Refresh() error {
 	return nil
 }
 
-func (s *mockService) Tag() names.ApplicationTag {
+func (s *mockApplication) Tag() names.ApplicationTag {
 	return s.tag
 }
 
-func (s *mockService) Watch() (watcher.NotifyWatcher, error) {
-	return s.serviceWatcher, nil
+func (s *mockApplication) Watch() (watcher.NotifyWatcher, error) {
+	return s.applicationWatcher, nil
 }
 
-func (s *mockService) WatchLeadershipSettings() (watcher.NotifyWatcher, error) {
+func (s *mockApplication) WatchLeadershipSettings() (watcher.NotifyWatcher, error) {
 	return s.leaderSettingsWatcher, nil
 }
 
 type mockRelation struct {
-	id     int
-	life   params.Life
-	status params.RelationStatusValue
+	id        int
+	life      params.Life
+	suspended bool
 }
 
 func (r *mockRelation) Id() int {
@@ -300,8 +300,8 @@ func (r *mockRelation) Life() params.Life {
 	return r.life
 }
 
-func (r *mockRelation) Status() params.RelationStatusValue {
-	return r.status
+func (r *mockRelation) Suspended() bool {
+	return r.suspended
 }
 
 type mockLeadershipTracker struct {

--- a/worker/uniter/remotestate/mock_test.go
+++ b/worker/uniter/remotestate/mock_test.go
@@ -304,6 +304,10 @@ func (r *mockRelation) Suspended() bool {
 	return r.suspended
 }
 
+func (r *mockRelation) UpdateSuspended(suspended bool) {
+	r.suspended = suspended
+}
+
 type mockLeadershipTracker struct {
 	leadership.Tracker
 	claimTicket  mockTicket

--- a/worker/uniter/remotestate/snapshot.go
+++ b/worker/uniter/remotestate/snapshot.go
@@ -74,9 +74,9 @@ type Snapshot struct {
 }
 
 type RelationSnapshot struct {
-	Life    params.Life
-	Status  params.RelationStatusValue
-	Members map[string]int64
+	Life      params.Life
+	Suspended bool
+	Members   map[string]int64
 }
 
 // StorageSnapshot has information relating to a storage

--- a/worker/uniter/remotestate/state.go
+++ b/worker/uniter/remotestate/state.go
@@ -70,6 +70,7 @@ type Relation interface {
 	Id() int
 	Life() params.Life
 	Suspended() bool
+	UpdateSuspended(bool)
 }
 
 func NewAPIState(st *uniter.State) State {

--- a/worker/uniter/remotestate/state.go
+++ b/worker/uniter/remotestate/state.go
@@ -69,7 +69,7 @@ type Application interface {
 type Relation interface {
 	Id() int
 	Life() params.Life
-	Status() params.RelationStatusValue
+	Suspended() bool
 }
 
 func NewAPIState(st *uniter.State) State {

--- a/worker/uniter/remotestate/watcher_test.go
+++ b/worker/uniter/remotestate/watcher_test.go
@@ -39,12 +39,12 @@ func (s *WatcherSuite) SetUpTest(c *gc.C) {
 		unit: mockUnit{
 			tag:  names.NewUnitTag("mysql/0"),
 			life: params.Alive,
-			service: mockService{
+			application: mockApplication{
 				tag:                   names.NewApplicationTag("mysql"),
 				life:                  params.Alive,
 				curl:                  charm.MustParseURL("cs:trusty/mysql"),
 				charmModifiedVersion:  5,
-				serviceWatcher:        newMockNotifyWatcher(),
+				applicationWatcher:    newMockNotifyWatcher(),
 				leaderSettingsWatcher: newMockNotifyWatcher(),
 			},
 			unitWatcher:           newMockNotifyWatcher(),
@@ -115,8 +115,8 @@ func (s *WatcherSuite) TestInitialSignal(c *gc.C) {
 	s.st.unit.configSettingsWatcher.changes <- struct{}{}
 	s.st.unit.storageWatcher.changes <- []string{}
 	s.st.unit.actionWatcher.changes <- []string{}
-	s.st.unit.service.serviceWatcher.changes <- struct{}{}
-	s.st.unit.service.leaderSettingsWatcher.changes <- struct{}{}
+	s.st.unit.application.applicationWatcher.changes <- struct{}{}
+	s.st.unit.application.leaderSettingsWatcher.changes <- struct{}{}
 	s.st.unit.relationsWatcher.changes <- []string{}
 	s.leadership.claimTicket.ch <- struct{}{}
 	assertNotifyEvent(c, s.watcher.RemoteStateChanged(), "waiting for remote state change")
@@ -128,8 +128,8 @@ func signalAll(st *mockState, l *mockLeadershipTracker) {
 	st.unit.configSettingsWatcher.changes <- struct{}{}
 	st.unit.storageWatcher.changes <- []string{}
 	st.unit.actionWatcher.changes <- []string{}
-	st.unit.service.serviceWatcher.changes <- struct{}{}
-	st.unit.service.leaderSettingsWatcher.changes <- struct{}{}
+	st.unit.application.applicationWatcher.changes <- struct{}{}
+	st.unit.application.leaderSettingsWatcher.changes <- struct{}{}
 	st.unit.relationsWatcher.changes <- []string{}
 	l.claimTicket.ch <- struct{}{}
 }
@@ -143,9 +143,9 @@ func (s *WatcherSuite) TestSnapshot(c *gc.C) {
 		Life:                  s.st.unit.life,
 		Relations:             map[int]remotestate.RelationSnapshot{},
 		Storage:               map[names.StorageTag]remotestate.StorageSnapshot{},
-		CharmModifiedVersion:  s.st.unit.service.charmModifiedVersion,
-		CharmURL:              s.st.unit.service.curl,
-		ForceCharmUpgrade:     s.st.unit.service.forceUpgrade,
+		CharmModifiedVersion:  s.st.unit.application.charmModifiedVersion,
+		CharmURL:              s.st.unit.application.curl,
+		ForceCharmUpgrade:     s.st.unit.application.forceUpgrade,
 		ResolvedMode:          s.st.unit.resolved,
 		ConfigVersion:         2, // config settings and addresses
 		LeaderSettingsVersion: 1,
@@ -190,12 +190,12 @@ func (s *WatcherSuite) TestRemoteStateChanged(c *gc.C) {
 	s.st.unit.storageWatcher.changes <- []string{}
 	assertOneChange()
 
-	s.st.unit.service.forceUpgrade = true
-	s.st.unit.service.serviceWatcher.changes <- struct{}{}
+	s.st.unit.application.forceUpgrade = true
+	s.st.unit.application.applicationWatcher.changes <- struct{}{}
 	assertOneChange()
 	c.Assert(s.watcher.Snapshot().ForceCharmUpgrade, jc.IsTrue)
 
-	s.st.unit.service.leaderSettingsWatcher.changes <- struct{}{}
+	s.st.unit.application.leaderSettingsWatcher.changes <- struct{}{}
 	assertOneChange()
 	c.Assert(s.watcher.Snapshot().LeaderSettingsVersion, gc.Equals, initial.LeaderSettingsVersion+1)
 
@@ -443,7 +443,7 @@ func (s *WatcherSuite) TestRelationsChanged(c *gc.C) {
 
 	relationTag := names.NewRelationTag("mysql:peer")
 	s.st.relations[relationTag] = &mockRelation{
-		id: 123, life: params.Alive, status: params.Joined,
+		id: 123, life: params.Alive, suspended: false,
 	}
 	s.st.relationUnitsWatchers[relationTag] = newMockRelationUnitsWatcher()
 	s.st.unit.relationsWatcher.changes <- []string{relationTag.Id()}
@@ -460,9 +460,9 @@ func (s *WatcherSuite) TestRelationsChanged(c *gc.C) {
 		jc.DeepEquals,
 		map[int]remotestate.RelationSnapshot{
 			123: {
-				Life:    params.Alive,
-				Status:  params.Joined,
-				Members: map[string]int64{"mysql/1": 1, "mysql/2": 2},
+				Life:      params.Alive,
+				Suspended: false,
+				Members:   map[string]int64{"mysql/1": 1, "mysql/2": 2},
 			},
 		},
 	)
@@ -483,13 +483,13 @@ func (s *WatcherSuite) TestRelationsChanged(c *gc.C) {
 	c.Assert(s.st.relationUnitsWatchers[relationTag].Stopped(), jc.IsTrue)
 }
 
-func (s *WatcherSuite) TestRelationsRevoked(c *gc.C) {
+func (s *WatcherSuite) TestRelationsSuspended(c *gc.C) {
 	signalAll(s.st, s.leadership)
 	assertNotifyEvent(c, s.watcher.RemoteStateChanged(), "waiting for remote state change")
 
 	relationTag := names.NewRelationTag("mysql:db wordpress:db")
 	s.st.relations[relationTag] = &mockRelation{
-		id: 123, life: params.Alive, status: params.Joined,
+		id: 123, life: params.Alive, suspended: false,
 	}
 	s.st.relationUnitsWatchers[relationTag] = newMockRelationUnitsWatcher()
 	s.st.unit.relationsWatcher.changes <- []string{relationTag.Id()}
@@ -499,10 +499,10 @@ func (s *WatcherSuite) TestRelationsRevoked(c *gc.C) {
 	}
 	assertNotifyEvent(c, s.watcher.RemoteStateChanged(), "waiting for remote state change")
 
-	s.st.relations[relationTag].status = params.Suspended
+	s.st.relations[relationTag].suspended = true
 	s.st.unit.relationsWatcher.changes <- []string{relationTag.Id()}
 	assertNotifyEvent(c, s.watcher.RemoteStateChanged(), "waiting for remote state change")
-	c.Assert(s.watcher.Snapshot().Relations[123].Status, gc.Equals, params.Suspended)
+	c.Assert(s.watcher.Snapshot().Relations[123].Suspended, jc.IsTrue)
 	c.Assert(s.st.relationUnitsWatchers[relationTag].Stopped(), jc.IsTrue)
 }
 

--- a/worker/uniter/runner/context/relation.go
+++ b/worker/uniter/runner/context/relation.go
@@ -81,11 +81,8 @@ func (ctx *ContextRelation) WriteSettings() (err error) {
 }
 
 // Suspended returns true if the relation is suspended.
-func (ctx *ContextRelation) Suspended() (bool, error) {
-	if err := ctx.ru.Relation().Refresh(); err != nil {
-		return false, err
-	}
-	return ctx.ru.Relation().Suspended(), nil
+func (ctx *ContextRelation) Suspended() bool {
+	return ctx.ru.Relation().Suspended()
 }
 
 // SetStatus sets the relation's status.

--- a/worker/uniter/runner/context/relation.go
+++ b/worker/uniter/runner/context/relation.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/juju/juju/api/uniter"
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/core/relation"
 	"github.com/juju/juju/worker/uniter/runner/jujuc"
 )
 
@@ -77,4 +78,17 @@ func (ctx *ContextRelation) WriteSettings() (err error) {
 		err = ctx.settings.Write()
 	}
 	return
+}
+
+// Suspended returns true if the relation is suspended.
+func (ctx *ContextRelation) Suspended() (bool, error) {
+	if err := ctx.ru.Relation().Refresh(); err != nil {
+		return false, err
+	}
+	return ctx.ru.Relation().Suspended(), nil
+}
+
+// SetStatus sets the relation's status.
+func (ctx *ContextRelation) SetStatus(status relation.Status) error {
+	return ctx.ru.Relation().SetStatus(status)
 }

--- a/worker/uniter/runner/context/relation_test.go
+++ b/worker/uniter/runner/context/relation_test.go
@@ -188,9 +188,9 @@ func (s *ContextRelationSuite) TestSuspended(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	ctx := context.NewContextRelation(s.apiRelUnit, nil)
-	suspended, err := ctx.Suspended()
+	err = s.apiRelUnit.Relation().Refresh()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(suspended, jc.IsTrue)
+	c.Assert(ctx.Suspended(), jc.IsTrue)
 }
 
 func (s *ContextRelationSuite) TestSetStatus(c *gc.C) {

--- a/worker/uniter/runner/context/relation_test.go
+++ b/worker/uniter/runner/context/relation_test.go
@@ -4,6 +4,8 @@
 package context_test
 
 import (
+	"time"
+
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils"
 	gc "gopkg.in/check.v1"
@@ -12,14 +14,16 @@ import (
 	"github.com/juju/juju/api"
 	apiuniter "github.com/juju/juju/api/uniter"
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/core/relation"
 	"github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/state"
+	"github.com/juju/juju/status"
 	"github.com/juju/juju/worker/uniter/runner/context"
 )
 
 type ContextRelationSuite struct {
 	testing.JujuConnSuite
-	svc *state.Application
+	app *state.Application
 	rel *state.Relation
 	ru  *state.RelationUnit
 
@@ -42,12 +46,12 @@ func (s *ContextRelationSuite) SetUpTest(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	ch := s.AddTestingCharm(c, "riak")
-	s.svc = s.AddTestingApplication(c, "u", ch)
-	rels, err := s.svc.Relations()
+	s.app = s.AddTestingApplication(c, "u", ch)
+	rels, err := s.app.Relations()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(rels, gc.HasLen, 1)
 	s.rel = rels[0]
-	unit, err := s.svc.AddUnit(state.AddUnitParams{})
+	unit, err := s.app.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	err = unit.AssignToMachine(machine)
 	s.ru, err = s.rel.Unit(unit)
@@ -73,7 +77,7 @@ func (s *ContextRelationSuite) SetUpTest(c *gc.C) {
 }
 
 func (s *ContextRelationSuite) TestMemberCaching(c *gc.C) {
-	unit, err := s.svc.AddUnit(state.AddUnitParams{})
+	unit, err := s.app.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	ru, err := s.rel.Unit(unit)
 	c.Assert(err, jc.ErrorIsNil)
@@ -105,7 +109,7 @@ func (s *ContextRelationSuite) TestMemberCaching(c *gc.C) {
 }
 
 func (s *ContextRelationSuite) TestNonMemberCaching(c *gc.C) {
-	unit, err := s.svc.AddUnit(state.AddUnitParams{})
+	unit, err := s.app.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	ru, err := s.rel.Unit(unit)
 	c.Assert(err, jc.ErrorIsNil)
@@ -175,4 +179,30 @@ func convertMap(settingsMap map[string]interface{}) params.Settings {
 		result[k] = v.(string)
 	}
 	return result
+}
+
+func (s *ContextRelationSuite) TestSuspended(c *gc.C) {
+	_, err := s.app.AddUnit(state.AddUnitParams{})
+	c.Assert(err, jc.ErrorIsNil)
+	err = s.rel.SetSuspended(true)
+	c.Assert(err, jc.ErrorIsNil)
+
+	ctx := context.NewContextRelation(s.apiRelUnit, nil)
+	suspended, err := ctx.Suspended()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(suspended, jc.IsTrue)
+}
+
+func (s *ContextRelationSuite) TestSetStatus(c *gc.C) {
+	_, err := s.app.AddUnit(state.AddUnitParams{})
+	c.Assert(err, jc.ErrorIsNil)
+	err = s.State.LeadershipClaimer().ClaimLeadership("u", "u/0", time.Minute)
+	c.Assert(err, jc.ErrorIsNil)
+
+	ctx := context.NewContextRelation(s.apiRelUnit, nil)
+	err = ctx.SetStatus(relation.Suspended)
+	c.Assert(err, jc.ErrorIsNil)
+	relStatus, err := s.rel.Status()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(relStatus.Status, gc.Equals, status.Suspended)
 }

--- a/worker/uniter/runner/jujuc/context.go
+++ b/worker/uniter/runner/jujuc/context.go
@@ -267,7 +267,7 @@ type ContextRelation interface {
 	ReadSettings(unit string) (params.Settings, error)
 
 	// Suspended returns true if the relation is suspended.
-	Suspended() (bool, error)
+	Suspended() bool
 
 	// SetStatus sets the relation's status.
 	SetStatus(relation.Status) error

--- a/worker/uniter/runner/jujuc/context.go
+++ b/worker/uniter/runner/jujuc/context.go
@@ -14,6 +14,7 @@ import (
 	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/core/relation"
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/storage"
 )
@@ -264,6 +265,12 @@ type ContextRelation interface {
 
 	// ReadSettings returns the settings of any remote unit in the relation.
 	ReadSettings(unit string) (params.Settings, error)
+
+	// Suspended returns true if the relation is suspended.
+	Suspended() (bool, error)
+
+	// SetStatus sets the relation's status.
+	SetStatus(relation.Status) error
 }
 
 // ContextStorageAttachment expresses the capabilities of a hook with

--- a/worker/uniter/runner/jujuc/testing/relation.go
+++ b/worker/uniter/runner/jujuc/testing/relation.go
@@ -10,6 +10,7 @@ import (
 	"github.com/juju/errors"
 
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/core/relation"
 	"github.com/juju/juju/worker/uniter/runner/jujuc"
 )
 
@@ -107,4 +108,14 @@ func (r *ContextRelation) ReadSettings(name string) (params.Settings, error) {
 		return nil, fmt.Errorf("unknown unit %s", name)
 	}
 	return s.Map(), nil
+}
+
+// Suspended implements jujuc.ContextRelation.
+func (r *ContextRelation) Suspended() (bool, error) {
+	return true, nil
+}
+
+// SetStatus implements jujuc.ContextRelation.
+func (r *ContextRelation) SetStatus(status relation.Status) error {
+	return nil
 }

--- a/worker/uniter/runner/jujuc/testing/relation.go
+++ b/worker/uniter/runner/jujuc/testing/relation.go
@@ -111,8 +111,8 @@ func (r *ContextRelation) ReadSettings(name string) (params.Settings, error) {
 }
 
 // Suspended implements jujuc.ContextRelation.
-func (r *ContextRelation) Suspended() (bool, error) {
-	return true, nil
+func (r *ContextRelation) Suspended() bool {
+	return true
 }
 
 // SetStatus implements jujuc.ContextRelation.


### PR DESCRIPTION
## Description of change

The uniter now listens to the relation suspended flag to determine if a relation needs to be suspended, rather than status itself. Two new status values are introduced - "joining" and "suspending". When the CLI updates a relation status flag, the status changes to one of the above values; when the uniter has processed the change, it then sets "suspended" or "joined" accordingly. A relation status also starts out as "joining" until the uniter first runs the necessary hooks.

## QA steps

Bootstrap a CMR scenario, mediawiki related to mysql in another model.
watch juju status on the mediawiki model
in the mysql model:
suspend the remote relation
observe the status change in the watch status to suspending and then suspended, relation becomes broken
resume the remote relation
observe the status change in the watch status to joining and then joined, relation becomes ok again
for both the above, listing offers in mysql model reflects the correct status
