### PR TITLE
state: migrate storage without owner

### DIFF
--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -21,7 +21,7 @@ github.com/juju/ansiterm	git	b99631de12cf04a906c1d4e4ec54fb86eae5863d	2016-09-07
 github.com/juju/blobstore	git	06056004b3d7b54bbb7984d830c537bad00fec21	2015-07-29T11:18:58Z
 github.com/juju/bundlechanges	git	cd189848b313df50084de692b05861210022cf81	2017-07-31T02:12:50Z
 github.com/juju/cmd	git	ad2437ef0ef282ae26e482eb1e44c02532bae1ba	2017-06-22T12:53:07Z
-github.com/juju/description	git	221dce7c83fe01dfe7467f6988b2c84940af5d71	2017-09-14T02:23:00Z
+github.com/juju/description	git	9677fa70af91e86e022a12d6092de62631c95bb9	2017-09-19T01:23:27Z
 github.com/juju/errors	git	1b5e39b83d1835fa480e0c2ddefb040ee82d58b3	2015-09-16T12:56:42Z
 github.com/juju/gnuflag	git	4e76c56581859c14d9d87e1ddbe29e1c0f10195f	2016-08-09T16:52:14Z
 github.com/juju/go-oracle-cloud	git	932a8cea00a1cd5cba3829a672c823955db674ae	2017-04-21T13:45:47Z

--- a/state/migration_export_test.go
+++ b/state/migration_export_test.go
@@ -101,7 +101,7 @@ func (s *MigrationBaseSuite) makeApplicationWithLeader(c *gc.C, applicationname 
 }
 
 func (s *MigrationBaseSuite) makeUnitWithStorage(c *gc.C) (*state.Application, *state.Unit, names.StorageTag) {
-	pool := "loop-pool"
+	pool := "modelscoped"
 	kind := "block"
 	// Create a default pool for block devices.
 	pm := poolmanager.New(state.NewStateSettings(s.State), storage.ChainedProviderRegistry{
@@ -1151,7 +1151,7 @@ func (s *MigrationExportSuite) TestStorage(c *gc.C) {
 	c.Assert(constraints, gc.HasLen, 2)
 	cons, found := constraints["data"]
 	c.Assert(found, jc.IsTrue)
-	c.Check(cons.Pool(), gc.Equals, "loop-pool")
+	c.Check(cons.Pool(), gc.Equals, "modelscoped")
 	c.Check(cons.Size(), gc.Equals, uint64(0x400))
 	c.Check(cons.Count(), gc.Equals, uint64(1))
 	cons, found = constraints["allecto"]

--- a/state/migration_import_test.go
+++ b/state/migration_import_test.go
@@ -1162,7 +1162,7 @@ func (s *MigrationImportSuite) TestStorage(c *gc.C) {
 	cons, err := app.StorageConstraints()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(cons, jc.DeepEquals, map[string]state.StorageConstraints{
-		"data":    {Pool: "loop-pool", Size: 0x400, Count: 1},
+		"data":    {Pool: "modelscoped", Size: 0x400, Count: 1},
 		"allecto": {Pool: "loop", Size: 0x400},
 	})
 
@@ -1182,6 +1182,20 @@ func (s *MigrationImportSuite) TestStorage(c *gc.C) {
 	attachments, err := newIM.StorageAttachments(storageTag)
 	c.Assert(attachments, gc.HasLen, 1)
 	c.Assert(attachments[0].Unit(), gc.Equals, u.UnitTag())
+}
+
+func (s *MigrationImportSuite) TestStorageDetached(c *gc.C) {
+	_, u, storageTag := s.makeUnitWithStorage(c)
+	err := u.Destroy()
+	c.Assert(err, jc.ErrorIsNil)
+	err = s.IAASModel.DetachStorage(storageTag, u.UnitTag())
+	c.Assert(err, jc.ErrorIsNil)
+	err = u.EnsureDead()
+	c.Assert(err, jc.ErrorIsNil)
+	err = u.Remove()
+	c.Assert(err, jc.ErrorIsNil)
+
+	s.importModel(c)
 }
 
 func (s *MigrationImportSuite) TestStorageInstanceConstraints(c *gc.C) {


### PR DESCRIPTION
## Description of change

Deal properly with migrating disowned/detached storage: don't try to increment refcounts for the (non-existent) owner.

Requires https://github.com/juju/description/pull/26

## QA steps

1. juju bootstrap localhost l2
2. juju bootstrap localhost l1
3. juju add-model foo
4. juju deploy cs:~axwalk/storagetest --storage fs=lxd,1G
5. juju remove-application storagetest
6. juju migrate foo l2
7. juju switch l2:foo
8. juju deploy cs:~axwalk/storagetest --attach-storage fs/0

## Documentation changes

None.

## Bug reference

None.