### PR TITLE
add-storage: report IDs of added storage

### DIFF
--- a/api/storage/client.go
+++ b/api/storage/client.go
@@ -139,8 +139,11 @@ func (c *Client) ListFilesystems(machines []string) ([]params.FilesystemDetailsL
 }
 
 // AddToUnit adds specified storage to desired units.
-func (c *Client) AddToUnit(storages []params.StorageAddParams) ([]params.ErrorResult, error) {
-	out := params.ErrorResults{}
+//
+// NOTE(axw) for old controllers, the results will only
+// contain errors.
+func (c *Client) AddToUnit(storages []params.StorageAddParams) ([]params.AddStorageResult, error) {
+	out := params.AddStorageResults{}
 	in := params.StoragesAddParams{Storages: storages}
 	err := c.facade.FacadeCall("AddToUnit", in, &out)
 	if err != nil {

--- a/api/storage/client_test.go
+++ b/api/storage/client_test.go
@@ -517,10 +517,13 @@ func (s *storageMockSuite) TestAddToUnit(c *gc.C) {
 
 	storageN := 3
 	expectedError := common.ServerError(errors.NotValidf("storage directive"))
-	one := func(u, s string, attrs params.StorageConstraints) params.ErrorResult {
-		result := params.ErrorResult{}
+	expectedDetails := &params.AddStorageDetails{[]string{"a/0", "b/1"}}
+	one := func(u, s string, attrs params.StorageConstraints) params.AddStorageResult {
+		result := params.AddStorageResult{}
 		if s == errOut {
 			result.Error = expectedError
+		} else {
+			result.Result = expectedDetails
 		}
 		return result
 	}
@@ -540,8 +543,8 @@ func (s *storageMockSuite) TestAddToUnit(c *gc.C) {
 			c.Assert(args.Storages, gc.HasLen, storageN)
 			c.Assert(args.Storages, gc.DeepEquals, unitStorages)
 
-			if results, k := result.(*params.ErrorResults); k {
-				out := []params.ErrorResult{}
+			if results, k := result.(*params.AddStorageResults); k {
+				out := []params.AddStorageResult{}
 				for _, s := range args.Storages {
 					out = append(out, one(s.UnitTag, s.StorageName, s.Constraints))
 				}
@@ -554,10 +557,10 @@ func (s *storageMockSuite) TestAddToUnit(c *gc.C) {
 	r, err := storageClient.AddToUnit(unitStorages)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(r, gc.HasLen, storageN)
-	expected := []params.ErrorResult{
-		{nil},
-		{expectedError},
-		{nil},
+	expected := []params.AddStorageResult{
+		{Result: expectedDetails},
+		{Error: expectedError},
+		{Result: expectedDetails},
 	}
 	c.Assert(r, jc.SameContents, expected)
 }

--- a/apiserver/facades/agent/uniter/state.go
+++ b/apiserver/facades/agent/uniter/state.go
@@ -26,7 +26,7 @@ type storageStateInterface interface {
 	WatchFilesystemAttachment(names.MachineTag, names.FilesystemTag) state.NotifyWatcher
 	WatchVolumeAttachment(names.MachineTag, names.VolumeTag) state.NotifyWatcher
 	WatchBlockDevices(names.MachineTag) state.NotifyWatcher
-	AddStorageForUnit(tag names.UnitTag, name string, cons state.StorageConstraints) error
+	AddStorageForUnit(tag names.UnitTag, name string, cons state.StorageConstraints) ([]names.StorageTag, error)
 	UnitStorageConstraints(u names.UnitTag) (map[string]state.StorageConstraints, error)
 	BlockDevices(names.MachineTag) ([]state.BlockDeviceInfo, error)
 }

--- a/apiserver/facades/agent/uniter/storage.go
+++ b/apiserver/facades/agent/uniter/storage.go
@@ -364,7 +364,7 @@ func (a *StorageAPI) AddUnitStorage(
 			continue
 		}
 
-		err = a.st.AddStorageForUnit(u, one.StorageName, oneCons)
+		_, err = a.st.AddStorageForUnit(u, one.StorageName, oneCons)
 		if err != nil {
 			result[i] = storageErr(err, one.StorageName, one.UnitTag)
 		}

--- a/apiserver/facades/agent/uniter/storage_test.go
+++ b/apiserver/facades/agent/uniter/storage_test.go
@@ -534,8 +534,8 @@ func (m *mockStorageState) WatchBlockDevices(mtag names.MachineTag) state.Notify
 	return m.watchBlockDevices(mtag)
 }
 
-func (m *mockStorageState) AddStorageForUnit(tag names.UnitTag, name string, cons state.StorageConstraints) error {
-	return m.addUnitStorage(tag, name, cons)
+func (m *mockStorageState) AddStorageForUnit(tag names.UnitTag, name string, cons state.StorageConstraints) ([]names.StorageTag, error) {
+	return nil, m.addUnitStorage(tag, name, cons)
 }
 
 func (m *mockStorageState) UnitStorageConstraints(u names.UnitTag) (map[string]state.StorageConstraints, error) {

--- a/apiserver/facades/client/storage/base_test.go
+++ b/apiserver/facades/client/storage/base_test.go
@@ -237,9 +237,9 @@ func (s *baseStorageSuite) constructState() *mockState {
 			return []state.Filesystem{s.filesystem}, nil
 		},
 		modelName: "storagetest",
-		addStorageForUnit: func(u names.UnitTag, name string, cons state.StorageConstraints) error {
+		addStorageForUnit: func(u names.UnitTag, name string, cons state.StorageConstraints) ([]names.StorageTag, error) {
 			s.stub.AddCall(addStorageForUnitCall)
-			return nil
+			return nil, nil
 		},
 		getBlockForType: func(t state.BlockType) (state.Block, bool, error) {
 			s.stub.AddCall(getBlockForTypeCall, t)

--- a/apiserver/facades/client/storage/mock_test.go
+++ b/apiserver/facades/client/storage/mock_test.go
@@ -60,7 +60,7 @@ type mockState struct {
 	machineFilesystemAttachments        func(machine names.MachineTag) ([]state.FilesystemAttachment, error)
 	filesystemAttachments               func(filesystem names.FilesystemTag) ([]state.FilesystemAttachment, error)
 	allFilesystems                      func() ([]state.Filesystem, error)
-	addStorageForUnit                   func(u names.UnitTag, name string, cons state.StorageConstraints) error
+	addStorageForUnit                   func(u names.UnitTag, name string, cons state.StorageConstraints) ([]names.StorageTag, error)
 	getBlockForType                     func(t state.BlockType) (state.Block, bool, error)
 	blockDevices                        func(names.MachineTag) ([]state.BlockDeviceInfo, error)
 	destroyStorageInstance              func(names.StorageTag, bool) error
@@ -162,7 +162,7 @@ func (st *mockState) Filesystem(tag names.FilesystemTag) (state.Filesystem, erro
 	return st.filesystem(tag)
 }
 
-func (st *mockState) AddStorageForUnit(u names.UnitTag, name string, cons state.StorageConstraints) error {
+func (st *mockState) AddStorageForUnit(u names.UnitTag, name string, cons state.StorageConstraints) ([]names.StorageTag, error) {
 	return st.addStorageForUnit(u, name, cons)
 }
 

--- a/apiserver/facades/client/storage/shim.go
+++ b/apiserver/facades/client/storage/shim.go
@@ -133,7 +133,7 @@ type storageAccess interface {
 	Filesystem(tag names.FilesystemTag) (state.Filesystem, error)
 
 	// AddStorageForUnit is required for storage add functionality.
-	AddStorageForUnit(tag names.UnitTag, name string, cons state.StorageConstraints) error
+	AddStorageForUnit(tag names.UnitTag, name string, cons state.StorageConstraints) ([]names.StorageTag, error)
 
 	// GetBlockForType is required to block operations.
 	GetBlockForType(t state.BlockType) (state.Block, bool, error)

--- a/apiserver/params/storage.go
+++ b/apiserver/params/storage.go
@@ -846,3 +846,21 @@ type ImportStorageDetails struct {
 	// assigned to the imported storage entity.
 	StorageTag string `json:"storage-tag"`
 }
+
+// AddStorageResults contains the results of adding storage to units.
+type AddStorageResults struct {
+	Results []AddStorageResult `json:"results"`
+}
+
+// AddStorageResult contains the result of adding storage to a unit.
+type AddStorageResult struct {
+	Result *AddStorageDetails `json:"result,omitempty"`
+	Error  *Error             `json:"error,omitempty"`
+}
+
+// AddStorageDetails contains the details of added storage.
+type AddStorageDetails struct {
+	// StorageTags contains the string representation of the storage tags
+	// of the added storage instances.
+	StorageTags []string `json:"storage-tags"`
+}

--- a/featuretests/storage_test.go
+++ b/featuretests/storage_test.go
@@ -494,8 +494,8 @@ func (s *cmdStorageSuite) TestStorageAddToUnitSuccess(c *gc.C) {
 
 	context, err := runAddToUnit(c, u, "allecto=1")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(cmdtesting.Stdout(context), gc.Equals, "added \"allecto\"\n")
-	c.Assert(cmdtesting.Stderr(context), gc.Equals, "")
+	c.Assert(cmdtesting.Stdout(context), gc.Equals, "")
+	c.Assert(cmdtesting.Stderr(context), gc.Equals, "added storage allecto/1 to storage-block/0\n")
 
 	instancesAfter, err := s.IAASModel.AllStorageInstances()
 	c.Assert(err, jc.ErrorIsNil)
@@ -521,7 +521,7 @@ func (s *cmdStorageSuite) TestStorageAddToUnitUnitDoesntExist(c *gc.C) {
 	context, err := runAddToUnit(c, "fluffyunit/0", "allecto=1")
 	c.Assert(errors.Cause(err), gc.ErrorMatches, "cmd: error out silently")
 	c.Assert(cmdtesting.Stdout(context), gc.Equals, "")
-	c.Assert(cmdtesting.Stderr(context), gc.Equals, "failed to add \"allecto\": unit \"fluffyunit/0\" not found\n")
+	c.Assert(cmdtesting.Stderr(context), gc.Equals, "failed to add storage \"allecto\" to fluffyunit/0: unit \"fluffyunit/0\" not found\n")
 }
 
 func (s *cmdStorageSuite) TestStorageAddToUnitCollapseUnitErrors(c *gc.C) {
@@ -551,7 +551,7 @@ func (s *cmdStorageSuite) TestStorageAddToUnitStorageDoesntExist(c *gc.C) {
 	c.Assert(errors.Cause(err), gc.ErrorMatches, "cmd: error out silently")
 	c.Assert(cmdtesting.Stdout(context), gc.Equals, "")
 	c.Assert(cmdtesting.Stderr(context), gc.Equals,
-		`failed to add "nonstorage": adding "nonstorage" storage to storage-block/0: charm storage "nonstorage" not found`+"\n",
+		`failed to add storage "nonstorage" to storage-block/0: adding "nonstorage" storage to storage-block/0: charm storage "nonstorage" not found`+"\n",
 	)
 
 	instancesAfter, err := s.IAASModel.AllStorageInstances()
@@ -585,8 +585,7 @@ storage-filesystem/0  data/0  filesystem                     pending
 
 	context, err = runAddToUnit(c, u, "data=modelscoped-block,1G")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(cmdtesting.Stdout(context), gc.Equals, "added \"data\"\n")
-	c.Assert(cmdtesting.Stderr(context), gc.Equals, "")
+	c.Assert(cmdtesting.Stderr(context), gc.Equals, "added storage data/1 to storage-filesystem/0\n")
 
 	instancesAfter, err := s.IAASModel.AllStorageInstances()
 	c.Assert(err, jc.ErrorIsNil)

--- a/state/application.go
+++ b/state/application.go
@@ -819,7 +819,7 @@ func (a *Application) upgradeStorageOps(
 				// cosntraints.
 				countMin = int(cons.Count)
 			}
-			unitOps, err := im.addUnitStorageOps(
+			_, unitOps, err := im.addUnitStorageOps(
 				meta, u, name, cons, countMin,
 			)
 			if err != nil {
@@ -1268,7 +1268,7 @@ func (a *Application) addUnitOpsWithCons(args applicationAddUnitOpsArgs) (string
 		}
 		machineAssignable = pu
 	}
-	storageOps, storageCounts, numStorageAttachments, err := createStorageOps(
+	storageOps, storageTags, numStorageAttachments, err := createStorageOps(
 		im,
 		unitTag,
 		charm.Meta(),
@@ -1299,9 +1299,10 @@ func (a *Application) addUnitOpsWithCons(args applicationAddUnitOpsArgs) (string
 		}
 		storageOps = append(storageOps, ops...)
 		numStorageAttachments++
-		storageCounts[si.StorageName()]++
+		storageTags[si.StorageName()] = append(storageTags[si.StorageName()], storageTag)
 	}
-	for name, count := range storageCounts {
+	for name, tags := range storageTags {
+		count := len(tags)
 		charmStorage := charm.Meta().Storage[name]
 		if err := validateCharmStorageCountChange(charmStorage, 0, count); err != nil {
 			return "", nil, errors.Trace(err)

--- a/state/migration_import_test.go
+++ b/state/migration_import_test.go
@@ -1218,7 +1218,7 @@ func (s *MigrationImportSuite) TestStorageInstanceConstraints(c *gc.C) {
 func (s *MigrationImportSuite) TestStorageInstanceConstraintsFallback(c *gc.C) {
 	_, u, storageTag0 := s.makeUnitWithStorage(c)
 
-	err := s.IAASModel.AddStorageForUnit(u.UnitTag(), "allecto", state.StorageConstraints{
+	_, err := s.IAASModel.AddStorageForUnit(u.UnitTag(), "allecto", state.StorageConstraints{
 		Count: 3,
 		Size:  1234,
 		Pool:  "modelscoped",


### PR DESCRIPTION
## Description of change

When running the "juju add-storage" command,
report the IDs of storage added for consistency
with other commands, and so the user does not
have to match them up manually.

## QA steps

1. juju bootstrap localhost
2. juju deploy cs:~axwalk/storagetest
3. juju add-storage storagetest/0 fs
should get a message with the ID of the storage instance added ("fs/0")

do the same, but bootstrap with an older juju. should just get the storage name "fs"

## Documentation changes

Maybe need to update examples? @pmatulis 

## Bug reference

None.