### PR TITLE
Stop workers when relation is suspended

### DIFF
--- a/apiserver/common/crossmodel/crossmodel.go
+++ b/apiserver/common/crossmodel/crossmodel.go
@@ -37,7 +37,7 @@ func PublishRelationChange(backend Backend, relationTag names.Tag, change params
 
 	// Update the relation suspended status.
 	currentStatus := rel.Suspended()
-	if change.Suspended != nil && currentStatus != *change.Suspended {
+	if !dyingOrDead && change.Suspended != nil && currentStatus != *change.Suspended {
 		if err := rel.SetSuspended(*change.Suspended); err != nil {
 			return errors.Trace(err)
 		}

--- a/apiserver/facades/controller/remoterelations/mock_test.go
+++ b/apiserver/facades/controller/remoterelations/mock_test.go
@@ -222,6 +222,7 @@ type mockRelation struct {
 	id                    int
 	key                   string
 	life                  state.Life
+	suspended             bool
 	units                 map[string]common.RelationUnit
 	remoteUnits           map[string]common.RelationUnit
 	endpoints             []state.Endpoint
@@ -255,7 +256,7 @@ func (r *mockRelation) Life() state.Life {
 
 func (r *mockRelation) Suspended() bool {
 	r.MethodCall(r, "Suspended")
-	return false
+	return r.suspended
 }
 
 func (r *mockRelation) Unit(unitId string) (common.RelationUnit, error) {

--- a/apiserver/facades/controller/remoterelations/remoterelations.go
+++ b/apiserver/facades/controller/remoterelations/remoterelations.go
@@ -190,9 +190,10 @@ func (api *RemoteRelationsAPI) remoteRelation(entity params.Entity) (*params.Rem
 		return nil, errors.Trace(err)
 	}
 	result := &params.RemoteRelation{
-		Id:   rel.Id(),
-		Life: params.Life(rel.Life().String()),
-		Key:  tag.Id(),
+		Id:        rel.Id(),
+		Life:      params.Life(rel.Life().String()),
+		Suspended: rel.Suspended(),
+		Key:       tag.Id(),
 	}
 	for _, ep := range rel.Endpoints() {
 		// Try looking up the info for the remote application.

--- a/apiserver/facades/controller/remoterelations/remoterelations_test.go
+++ b/apiserver/facades/controller/remoterelations/remoterelations_test.go
@@ -289,6 +289,7 @@ func (s *remoteRelationsSuite) TestRelations(c *gc.C) {
 	djangoRelationUnit := newMockRelationUnit()
 	djangoRelationUnit.settings["key"] = "value"
 	db2Relation := newMockRelation(123)
+	db2Relation.suspended = true
 	db2Relation.units["django/0"] = djangoRelationUnit
 	db2Relation.endpoints = []state.Endpoint{
 		{
@@ -320,9 +321,10 @@ func (s *remoteRelationsSuite) TestRelations(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.Results, jc.DeepEquals, []params.RemoteRelationResult{{
 		Result: &params.RemoteRelation{
-			Id:   123,
-			Life: "alive",
-			Key:  "db2:db django:db",
+			Id:        123,
+			Life:      "alive",
+			Suspended: true,
+			Key:       "db2:db django:db",
 			RemoteApplicationName: "db2",
 			RemoteEndpointName:    "data",
 			ApplicationName:       "django",

--- a/apiserver/params/crossmodel.go
+++ b/apiserver/params/crossmodel.go
@@ -170,6 +170,7 @@ type TokenResults struct {
 // the perspective of the local model.
 type RemoteRelation struct {
 	Life                  Life           `json:"life"`
+	Suspended             bool           `json:"suspended"`
 	Id                    int            `json:"id"`
 	Key                   string         `json:"key"`
 	ApplicationName       string         `json:"application-name"`

--- a/state/relation.go
+++ b/state/relation.go
@@ -482,8 +482,8 @@ func (r *Relation) RelatedEndpoints(applicationname string) ([]Endpoint, error) 
 
 // Unit returns a RelationUnit for the supplied unit.
 func (r *Relation) Unit(u *Unit) (*RelationUnit, error) {
-	const checkUnitLife = true
-	return r.unit(u.Name(), u.doc.Principal, u.IsPrincipal(), checkUnitLife)
+	const isLocalUnit = true
+	return r.unit(u.Name(), u.doc.Principal, u.IsPrincipal(), isLocalUnit)
 }
 
 // RemoteUnit returns a RelationUnit for the supplied unit
@@ -501,8 +501,8 @@ func (r *Relation) RemoteUnit(unitName string) (*RelationUnit, error) {
 	// relation, so all remote units are principals.
 	const principal = ""
 	const isPrincipal = true
-	const checkUnitLife = false
-	return r.unit(unitName, principal, isPrincipal, checkUnitLife)
+	const isLocalUnit = false
+	return r.unit(unitName, principal, isPrincipal, isLocalUnit)
 }
 
 // IsCrossModel returns whether this relation is a cross-model
@@ -523,7 +523,7 @@ func (r *Relation) unit(
 	unitName string,
 	principal string,
 	isPrincipal bool,
-	checkUnitLife bool,
+	isLocalUnit bool,
 ) (*RelationUnit, error) {
 	serviceName, err := names.UnitApplication(unitName)
 	if err != nil {
@@ -542,13 +542,13 @@ func (r *Relation) unit(
 		scope = fmt.Sprintf("%s#%s", scope, container)
 	}
 	return &RelationUnit{
-		st:            r.st,
-		relation:      r,
-		unitName:      unitName,
-		isPrincipal:   isPrincipal,
-		checkUnitLife: checkUnitLife,
-		endpoint:      ep,
-		scope:         scope,
+		st:          r.st,
+		relation:    r,
+		unitName:    unitName,
+		isPrincipal: isPrincipal,
+		isLocalUnit: isLocalUnit,
+		endpoint:    ep,
+		scope:       scope,
 	}, nil
 }
 

--- a/worker/firewaller/firewaller_test.go
+++ b/worker/firewaller/firewaller_test.go
@@ -1058,6 +1058,18 @@ func (s *InstanceModeSuite) TestRemoteRelationProviderRoleOffering(c *gc.C) {
 		network.MustNewIngressRule("tcp", 3306, 3306, "10.0.0.4/16"),
 	})
 
+	// And again when relation is suspended.
+	err = rel.SetSuspended(true)
+	c.Assert(err, jc.ErrorIsNil)
+	s.assertPorts(c, inst, m.Id(), nil)
+
+	// And again when relation is resumed.
+	err = rel.SetSuspended(false)
+	c.Assert(err, jc.ErrorIsNil)
+	s.assertPorts(c, inst, m.Id(), []network.IngressRule{
+		network.MustNewIngressRule("tcp", 3306, 3306, "10.0.0.4/16"),
+	})
+
 	// And again when relation is destroyed.
 	err = rel.Destroy()
 	c.Assert(err, jc.ErrorIsNil)

--- a/worker/remoterelations/mock_test.go
+++ b/worker/remoterelations/mock_test.go
@@ -200,9 +200,10 @@ func (m *mockRelationsFacade) Relations(keys []string) ([]params.RemoteRelationR
 	for i, key := range keys {
 		if rel, ok := m.relations[key]; ok {
 			result[i].Result = &params.RemoteRelation{
-				Id:   rel.id,
-				Life: rel.life,
-				Key:  keys[i],
+				Id:        rel.id,
+				Life:      rel.life,
+				Suspended: rel.suspended,
+				Key:       keys[i],
 			}
 			if epInfo, ok := m.relationsEndpoints[key]; ok {
 				result[i].Result.RemoteEndpointName = epInfo.remoteEndpointName
@@ -466,8 +467,9 @@ func (r *mockRemoteApplication) Life() params.Life {
 
 type mockRelation struct {
 	testing.Stub
-	id   int
-	life params.Life
+	id        int
+	life      params.Life
+	suspended bool
 }
 
 func newMockRelation(id int) *mockRelation {
@@ -485,4 +487,9 @@ func (r *mockRelation) Id() int {
 func (r *mockRelation) Life() params.Life {
 	r.MethodCall(r, "Life")
 	return r.life
+}
+
+func (r *mockRelation) Suspended() bool {
+	r.MethodCall(r, "Suspended")
+	return r.suspended
 }


### PR DESCRIPTION
## Description of change

When a relation is suspended, stop the workers which watch for unit settings changes. Leave the watcher for life/status changes active so that if/when the relation resumes, things can be restarted.

Similarly, the firewaller will immediately revoke ingress access for suspended relations. 

As a driveby, when a relation unit leaves scope, do not decrement the unit count if it is for the cross model end of a relation. We already did this on enter scope.

## QA steps

bootstrap a CMR scenario.
suspend a relation and ensure that the firewall ports on the offering side are closed and that the relation is properly suspended.
resume the relation and ensure that everything hooks up again as expected
suspend the relation and ensure it can be deleted while suspended, from either model

