### PR TITLE
Switch to directly bit setting instead of $inc for PingBatcher.

### DIFF
--- a/state/presence/pingbatcher.go
+++ b/state/presence/pingbatcher.go
@@ -296,7 +296,6 @@ func (pb *PingBatcher) flush() error {
 	docCount := 0
 	fieldCount := 0
 	t := time.Now()
-	slots := make(map[int64]bool)
 	for docId, slot := range next {
 		docCount++
 		var fields bson.D
@@ -322,7 +321,6 @@ func (pb *PingBatcher) flush() error {
 			// the rest of Pings records the first 6 characters of
 			// model-uuids, so we include that here if we are TRACEing.
 			uuids.Add(docId[:6])
-			slots[slot.Slot] = true
 		}
 	}
 	// usually we should only be processing 1 slot

--- a/state/presence/presence.go
+++ b/state/presence/presence.go
@@ -557,8 +557,8 @@ func (w *Watcher) lookupUnknownSeqs(unknownSeqs []int64, dead map[int64]bool, se
 			remaining = nil
 		}
 		docIds := make([]string, len(batch))
-		for _, seq := range batch {
-			docIds = append(docIds, docIDInt64(w.modelUUID, seq))
+		for i, seq := range batch {
+			docIds[i] = docIDInt64(w.modelUUID, seq)
 		}
 		query := beingsC.Find(bson.M{"_id": bson.M{"$in": docIds}})
 		// We don't need the _id returned, as its just a way to lookup the seq,


### PR DESCRIPTION
## Description of change

This addresses both bug #1699678 (use bit set operations) and bug #1703675 (handle upsert failing with duplicate keys).

We switch from using bulk.Run() which doesn't handle E11000 to just
directly calling collection.Upsert() which automatically handles Upsert
duplicate key failures. We also ensure it is absolutely safe to retry by
switching from $inc operations to using $bit...or operations.

Tests still pass. I tried writing a test that would trigger the issue,
but even with 1000 concurrent PingBatcher I could not get them to
race against Mongo. In the field it seems to only happen when mongo
is starting to fail under load for other reasons.

Also addresses bug #1718340 which is just that we were passing a lot of empty document IDs to a query.

## QA steps

Run an HA controller. Trigger a lot of load on the controller, and you should not see errors and PingBatcher getting restarted.

## Documentation changes

No

## Bug reference

[lp:1703675](https://bugs.launchpad.net/juju/+bug/1703675)
[lp:1699678](https://bugs.launchpad.net/juju/+bug/1699678)
[lp:1718340](https://bugs.launchpad.net/juju/+bug/1718340)