### PR TITLE
WIP: State: Add type field to application

### DIFF
--- a/api/uniter/uniter_test.go
+++ b/api/uniter/uniter_test.go
@@ -76,6 +76,7 @@ func (s *uniterSuite) addMachineBoundAppCharmAndUnit(c *gc.C, appName string, bi
 
 	app, err := s.State.AddApplication(state.AddApplicationArgs{
 		Name:             appName,
+		Type:             state.ApplicationTypeIAAS,
 		Charm:            charm,
 		EndpointBindings: bindings,
 	})

--- a/apiserver/facades/agent/uniter/uniter_test.go
+++ b/apiserver/facades/agent/uniter/uniter_test.go
@@ -3162,6 +3162,7 @@ func (s *uniterNetworkConfigSuite) SetUpTest(c *gc.C) {
 	var err error
 	s.base.wordpress, err = s.base.State.AddApplication(state.AddApplicationArgs{
 		Name:  "wordpress",
+		Type:  state.ApplicationTypeIAAS,
 		Charm: s.base.wpCharm,
 		EndpointBindings: map[string]string{
 			"db":        "internal", // relation name
@@ -3428,6 +3429,7 @@ func (s *uniterNetworkInfoSuite) SetUpTest(c *gc.C) {
 	var err error
 	s.base.wordpress, err = s.base.State.AddApplication(state.AddApplicationArgs{
 		Name:  "wordpress",
+		Type:  state.ApplicationTypeIAAS,
 		Charm: s.base.wpCharm,
 		EndpointBindings: map[string]string{
 			"db":        "internal",   // relation name

--- a/apiserver/facades/client/action/run_test.go
+++ b/apiserver/facades/client/action/run_test.go
@@ -57,22 +57,22 @@ func (s *runSuite) addUnit(c *gc.C, service *state.Application) *state.Unit {
 
 func (s *runSuite) TestGetAllUnitNames(c *gc.C) {
 	charm := s.AddTestingCharm(c, "dummy")
-	magic, err := s.State.AddApplication(state.AddApplicationArgs{Name: "magic", Charm: charm})
+	magic, err := s.State.AddApplication(state.AddApplicationArgs{Name: "magic", Type: state.ApplicationTypeIAAS, Charm: charm})
 	s.addUnit(c, magic)
 	s.addUnit(c, magic)
 
-	notAssigned, err := s.State.AddApplication(state.AddApplicationArgs{Name: "not-assigned", Charm: charm})
+	notAssigned, err := s.State.AddApplication(state.AddApplicationArgs{Name: "not-assigned", Type: state.ApplicationTypeIAAS, Charm: charm})
 	c.Assert(err, jc.ErrorIsNil)
 	_, err = notAssigned.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 
-	_, err = s.State.AddApplication(state.AddApplicationArgs{Name: "no-units", Charm: charm})
+	_, err = s.State.AddApplication(state.AddApplicationArgs{Name: "no-units", Type: state.ApplicationTypeIAAS, Charm: charm})
 	c.Assert(err, jc.ErrorIsNil)
 
-	wordpress, err := s.State.AddApplication(state.AddApplicationArgs{Name: "wordpress", Charm: s.AddTestingCharm(c, "wordpress")})
+	wordpress, err := s.State.AddApplication(state.AddApplicationArgs{Name: "wordpress", Type: state.ApplicationTypeIAAS, Charm: s.AddTestingCharm(c, "wordpress")})
 	c.Assert(err, jc.ErrorIsNil)
 	wordpress0 := s.addUnit(c, wordpress)
-	_, err = s.State.AddApplication(state.AddApplicationArgs{Name: "logging", Charm: s.AddTestingCharm(c, "logging")})
+	_, err = s.State.AddApplication(state.AddApplicationArgs{Name: "logging", Type: state.ApplicationTypeIAAS, Charm: s.AddTestingCharm(c, "logging")})
 	c.Assert(err, jc.ErrorIsNil)
 
 	eps, err := s.State.InferEndpoints("logging", "wordpress")
@@ -196,7 +196,7 @@ func (s *runSuite) TestRunMachineAndService(c *gc.C) {
 	s.addMachine(c)
 
 	charm := s.AddTestingCharm(c, "dummy")
-	magic, err := s.State.AddApplication(state.AddApplicationArgs{Name: "magic", Charm: charm})
+	magic, err := s.State.AddApplication(state.AddApplicationArgs{Name: "magic", Type: state.ApplicationTypeIAAS, Charm: charm})
 	c.Assert(err, jc.ErrorIsNil)
 	s.addUnit(c, magic)
 	s.addUnit(c, magic)

--- a/apiserver/facades/client/application/application.go
+++ b/apiserver/facades/client/application/application.go
@@ -249,8 +249,18 @@ func deployApplication(
 		attachStorage[i] = tag
 	}
 
+	modelType, err := backend.ModelType()
+	if err != nil {
+		return errors.Trace(err)
+	}
+	applicationType := state.ApplicationTypeIAAS
+	if modelType == state.ModelTypeCAAS {
+		applicationType = state.ApplicationTypeCAAS
+	}
+
 	_, err = deployApplicationFunc(backend, DeployApplicationParams{
 		ApplicationName:  args.ApplicationName,
+		Type:             applicationType,
 		Series:           args.Series,
 		Charm:            stateCharm(ch),
 		Channel:          csparams.Channel(args.Channel),

--- a/apiserver/facades/client/application/application_test.go
+++ b/apiserver/facades/client/application/application_test.go
@@ -307,6 +307,8 @@ func (s *applicationSuite) TestApplicationDeployDefaultFilesystemStorage(c *gc.C
 		Results: []params.ErrorResult{{Error: nil}},
 	})
 	app := apiservertesting.AssertPrincipalServiceDeployed(c, s.State, "application", curl, false, ch, cons)
+
+	c.Assert(app.Type(), gc.Equals, state.ApplicationTypeIAAS)
 	storageConstraintsOut, err := app.StorageConstraints()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(storageConstraintsOut, gc.DeepEquals, map[string]state.StorageConstraints{

--- a/apiserver/facades/client/application/application_unit_test.go
+++ b/apiserver/facades/client/application/application_unit_test.go
@@ -146,6 +146,12 @@ func (s *ApplicationSuite) SetUpTest(c *gc.C) {
 			"pgdata/0": {detachable: true},
 			"pgdata/1": {detachable: false},
 		},
+		model: mockModel{
+			uuid:      utils.MustNewUUID().String(),
+			name:      "mockmodel",
+			owner:     "admin",
+			modelType: state.ModelTypeIAAS,
+		},
 	}
 	s.blockChecker = mockBlockChecker{}
 	api, err := application.NewAPI(

--- a/apiserver/facades/client/application/backend.go
+++ b/apiserver/facades/client/application/backend.go
@@ -34,6 +34,7 @@ type Backend interface {
 	Relation(int) (Relation, error)
 	InferEndpoints(...string) ([]state.Endpoint, error)
 	Machine(string) (Machine, error)
+	ModelType() (state.ModelType, error)
 	ModelTag() names.ModelTag
 	Unit(string) (Unit, error)
 	SaveController(info crossmodel.ControllerInfo, modelUUID string) (ExternalController, error)
@@ -127,6 +128,7 @@ type Model interface {
 	Tag() names.Tag
 	Name() string
 	Owner() names.UserTag
+	Type() state.ModelType
 }
 
 // Resources defines a subset of the functionality provided by the
@@ -266,6 +268,14 @@ func (s stateShim) Unit(name string) (Unit, error) {
 		return nil, err
 	}
 	return stateUnitShim{u, s.State}, nil
+}
+
+func (s stateShim) ModelType() (state.ModelType, error) {
+	m, err := s.State.Model()
+	if err != nil {
+		return state.ModelTypeIAAS, err
+	}
+	return m.Type(), nil
 }
 
 func (s stateShim) Resources() (Resources, error) {

--- a/apiserver/facades/client/application/deploy.go
+++ b/apiserver/facades/client/application/deploy.go
@@ -24,6 +24,7 @@ import (
 // charm.
 type DeployApplicationParams struct {
 	ApplicationName string
+	Type            state.ApplicationType
 	Series          string
 	Charm           *state.Charm
 	Channel         csparams.Channel
@@ -72,6 +73,7 @@ func DeployApplication(st ApplicationDeployer, args DeployApplicationParams) (Ap
 
 	asa := state.AddApplicationArgs{
 		Name:             args.ApplicationName,
+		Type:             args.Type,
 		Series:           args.Series,
 		Charm:            args.Charm,
 		Channel:          args.Channel,

--- a/apiserver/facades/client/application/deploy_test.go
+++ b/apiserver/facades/client/application/deploy_test.go
@@ -50,6 +50,7 @@ func (s *DeployLocalSuite) TestDeployMinimal(c *gc.C) {
 	app, err := application.DeployApplication(stateDeployer{s.State},
 		application.DeployApplicationParams{
 			ApplicationName: "bob",
+			Type:            state.ApplicationTypeIAAS,
 			Charm:           s.charm,
 		})
 	c.Assert(err, jc.ErrorIsNil)
@@ -65,6 +66,7 @@ func (s *DeployLocalSuite) TestDeploySeries(c *gc.C) {
 	_, err := application.DeployApplication(&f,
 		application.DeployApplicationParams{
 			ApplicationName: "bob",
+			Type:            state.ApplicationTypeIAAS,
 			Charm:           s.charm,
 			Series:          "aseries",
 		})
@@ -81,6 +83,7 @@ func (s *DeployLocalSuite) TestDeployWithImplicitBindings(c *gc.C) {
 	app, err := application.DeployApplication(stateDeployer{s.State},
 		application.DeployApplicationParams{
 			ApplicationName:  "bob",
+			Type:             state.ApplicationTypeIAAS,
 			Charm:            wordpressCharm,
 			EndpointBindings: nil,
 		})
@@ -136,6 +139,7 @@ func (s *DeployLocalSuite) TestDeployWithSomeSpecifiedBindings(c *gc.C) {
 	app, err := application.DeployApplication(stateDeployer{s.State},
 		application.DeployApplicationParams{
 			ApplicationName: "bob",
+			Type:            state.ApplicationTypeIAAS,
 			Charm:           wordpressCharm,
 			EndpointBindings: map[string]string{
 				"":   "public",
@@ -172,6 +176,7 @@ func (s *DeployLocalSuite) TestDeployWithBoundRelationNamesAndExtraBindingsNames
 	app, err := application.DeployApplication(stateDeployer{s.State},
 		application.DeployApplicationParams{
 			ApplicationName: "bob",
+			Type:            state.ApplicationTypeIAAS,
 			Charm:           wordpressCharm,
 			EndpointBindings: map[string]string{
 				"":          "public",
@@ -209,6 +214,7 @@ func (s *DeployLocalSuite) TestDeployWithInvalidSpace(c *gc.C) {
 	app, err := application.DeployApplication(stateDeployer{s.State},
 		application.DeployApplicationParams{
 			ApplicationName: "bob",
+			Type:            state.ApplicationTypeIAAS,
 			Charm:           wordpressCharm,
 			EndpointBindings: map[string]string{
 				"":   "public",
@@ -235,6 +241,7 @@ func (s *DeployLocalSuite) TestDeployWithInvalidBinding(c *gc.C) {
 	app, err := application.DeployApplication(stateDeployer{s.State},
 		application.DeployApplicationParams{
 			ApplicationName: "bob",
+			Type:            state.ApplicationTypeIAAS,
 			Charm:           wordpressCharm,
 			EndpointBindings: map[string]string{
 				"":      "public",
@@ -257,6 +264,7 @@ func (s *DeployLocalSuite) TestDeployResources(c *gc.C) {
 	_, err := application.DeployApplication(&f,
 		application.DeployApplicationParams{
 			ApplicationName: "bob",
+			Type:            state.ApplicationTypeIAAS,
 			Charm:           s.charm,
 			EndpointBindings: map[string]string{
 				"": "public",
@@ -274,6 +282,7 @@ func (s *DeployLocalSuite) TestDeploySettings(c *gc.C) {
 	app, err := application.DeployApplication(stateDeployer{s.State},
 		application.DeployApplicationParams{
 			ApplicationName: "bob",
+			Type:            state.ApplicationTypeIAAS,
 			Charm:           s.charm,
 			ConfigSettings: charm.Settings{
 				"title":       "banana cupcakes",
@@ -291,6 +300,7 @@ func (s *DeployLocalSuite) TestDeploySettingsError(c *gc.C) {
 	_, err := application.DeployApplication(stateDeployer{s.State},
 		application.DeployApplicationParams{
 			ApplicationName: "bob",
+			Type:            state.ApplicationTypeIAAS,
 			Charm:           s.charm,
 			ConfigSettings: charm.Settings{
 				"skill-level": 99.01,
@@ -308,6 +318,7 @@ func (s *DeployLocalSuite) TestDeployConstraints(c *gc.C) {
 	app, err := application.DeployApplication(stateDeployer{s.State},
 		application.DeployApplicationParams{
 			ApplicationName: "bob",
+			Type:            state.ApplicationTypeIAAS,
 			Charm:           s.charm,
 			Constraints:     serviceCons,
 		})
@@ -322,6 +333,7 @@ func (s *DeployLocalSuite) TestDeployNumUnits(c *gc.C) {
 	_, err := application.DeployApplication(&f,
 		application.DeployApplicationParams{
 			ApplicationName: "bob",
+			Type:            state.ApplicationTypeIAAS,
 			Charm:           s.charm,
 			Constraints:     serviceCons,
 			NumUnits:        2,
@@ -341,6 +353,7 @@ func (s *DeployLocalSuite) TestDeployForceMachineId(c *gc.C) {
 	_, err := application.DeployApplication(&f,
 		application.DeployApplicationParams{
 			ApplicationName: "bob",
+			Type:            state.ApplicationTypeIAAS,
 			Charm:           s.charm,
 			Constraints:     serviceCons,
 			NumUnits:        1,
@@ -363,6 +376,7 @@ func (s *DeployLocalSuite) TestDeployForceMachineIdWithContainer(c *gc.C) {
 	_, err := application.DeployApplication(&f,
 		application.DeployApplicationParams{
 			ApplicationName: "bob",
+			Type:            state.ApplicationTypeIAAS,
 			Charm:           s.charm,
 			Constraints:     serviceCons,
 			NumUnits:        1,
@@ -390,6 +404,7 @@ func (s *DeployLocalSuite) TestDeploy(c *gc.C) {
 	_, err := application.DeployApplication(&f,
 		application.DeployApplicationParams{
 			ApplicationName: "bob",
+			Type:            state.ApplicationTypeIAAS,
 			Charm:           s.charm,
 			Constraints:     serviceCons,
 			NumUnits:        4,
@@ -411,6 +426,7 @@ func (s *DeployLocalSuite) TestDeployWithFewerPlacement(c *gc.C) {
 	_, err := application.DeployApplication(&f,
 		application.DeployApplicationParams{
 			ApplicationName: "bob",
+			Type:            state.ApplicationTypeIAAS,
 			Charm:           s.charm,
 			Constraints:     serviceCons,
 			NumUnits:        3,

--- a/apiserver/facades/client/application/mock_test.go
+++ b/apiserver/facades/client/application/mock_test.go
@@ -43,21 +43,30 @@ type mockNoNetworkEnviron struct {
 }
 
 type mockModel struct {
-	uuid  string
-	name  string
-	owner string
+	uuid      string
+	name      string
+	owner     string
+	modelType state.ModelType
 }
 
 func (m *mockModel) ModelTag() names.ModelTag {
 	return names.NewModelTag(m.uuid)
 }
 
-func (m *mockModel) Name() string {
+func (m mockModel) Tag() names.Tag {
+	return m.ModelTag()
+}
+
+func (m mockModel) Name() string {
 	return m.name
 }
 
-func (m *mockModel) Owner() names.UserTag {
+func (m mockModel) Owner() names.UserTag {
 	return names.NewUserTag(m.owner)
+}
+
+func (m mockModel) Type() state.ModelType {
+	return m.modelType
 }
 
 type mockCharm struct {
@@ -266,6 +275,10 @@ type mockBackend struct {
 	storageInstances           map[string]*mockStorage
 	storageInstanceFilesystems map[string]*mockFilesystem
 	controllers                map[string]crossmodel.ControllerInfo
+}
+
+func (m *mockBackend) ModelType() (state.ModelType, error) {
+	return state.ModelTypeIAAS, nil
 }
 
 func (m *mockBackend) ControllerTag() names.ControllerTag {

--- a/apiserver/facades/controller/charmrevisionupdater/testing/suite.go
+++ b/apiserver/facades/controller/charmrevisionupdater/testing/suite.go
@@ -119,7 +119,7 @@ func (s *CharmSuite) AddCharmWithRevision(c *gc.C, charmName string, rev int) *s
 func (s *CharmSuite) AddService(c *gc.C, charmName, serviceName string) {
 	ch, ok := s.charms[charmName]
 	c.Assert(ok, jc.IsTrue)
-	_, err := s.jcSuite.State.AddApplication(state.AddApplicationArgs{Name: serviceName, Charm: ch})
+	_, err := s.jcSuite.State.AddApplication(state.AddApplicationArgs{Name: serviceName, Type: state.ApplicationTypeIAAS, Charm: ch})
 	c.Assert(err, jc.ErrorIsNil)
 }
 

--- a/apiserver/rest_test.go
+++ b/apiserver/rest_test.go
@@ -119,6 +119,7 @@ func (s *restSuite) TestGetRemoteApplicationIcon(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	_, err = s.State.AddApplication(state.AddApplicationArgs{
 		Name:  "mysql",
+		Type:  state.ApplicationTypeIAAS,
 		Charm: mysqlCh,
 	})
 	c.Assert(err, jc.ErrorIsNil)
@@ -138,6 +139,7 @@ func (s *restSuite) TestGetRemoteApplicationIcon(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	_, err = s.State.AddApplication(state.AddApplicationArgs{
 		Name:  "dummy",
+		Type:  state.ApplicationTypeIAAS,
 		Charm: dummyCh,
 	})
 	c.Assert(err, jc.ErrorIsNil)

--- a/cmd/juju/status/status_test.go
+++ b/cmd/juju/status/status_test.go
@@ -3228,7 +3228,7 @@ type addService struct {
 func (as addService) step(c *gc.C, ctx *context) {
 	ch, ok := ctx.charms[as.charm]
 	c.Assert(ok, jc.IsTrue)
-	svc, err := ctx.st.AddApplication(state.AddApplicationArgs{Name: as.name, Charm: ch})
+	svc, err := ctx.st.AddApplication(state.AddApplicationArgs{Name: as.name, Type: state.ApplicationTypeIAAS, Charm: ch})
 	c.Assert(err, jc.ErrorIsNil)
 	if svc.IsPrincipal() {
 		err = svc.SetConstraints(as.cons)

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -21,7 +21,7 @@ github.com/juju/ansiterm	git	b99631de12cf04a906c1d4e4ec54fb86eae5863d	2016-09-07
 github.com/juju/blobstore	git	06056004b3d7b54bbb7984d830c537bad00fec21	2015-07-29T11:18:58Z
 github.com/juju/bundlechanges	git	cd189848b313df50084de692b05861210022cf81	2017-07-31T02:12:50Z
 github.com/juju/cmd	git	ad2437ef0ef282ae26e482eb1e44c02532bae1ba	2017-06-22T12:53:07Z
-github.com/juju/description	git	9677fa70af91e86e022a12d6092de62631c95bb9	2017-09-19T01:23:27Z
+github.com/juju/description	git	5ad33323a9206cc42b7e4a43257915ea21ffaac1	2017-09-20T23:29:39Z
 github.com/juju/errors	git	1b5e39b83d1835fa480e0c2ddefb040ee82d58b3	2015-09-16T12:56:42Z
 github.com/juju/gnuflag	git	4e76c56581859c14d9d87e1ddbe29e1c0f10195f	2016-08-09T16:52:14Z
 github.com/juju/go-oracle-cloud	git	932a8cea00a1cd5cba3829a672c823955db674ae	2017-04-21T13:45:47Z

--- a/environs/jujutest/livetests.go
+++ b/environs/jujutest/livetests.go
@@ -657,7 +657,7 @@ func (t *LiveTests) TestBootstrapAndDeploy(c *gc.C) {
 	url := testcharms.Repo.ClonedURL(repoDir, mtools0.Version.Series, "dummy")
 	sch, err := jujutesting.PutCharm(st, url, &charmrepo.LocalRepository{Path: repoDir}, false)
 	c.Assert(err, jc.ErrorIsNil)
-	svc, err := st.AddApplication(state.AddApplicationArgs{Name: "dummy", Charm: sch})
+	svc, err := st.AddApplication(state.AddApplicationArgs{Name: "dummy", Type: state.ApplicationTypeIAAS, Charm: sch})
 	c.Assert(err, jc.ErrorIsNil)
 	unit, err := svc.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)

--- a/featuretests/application_config_test.go
+++ b/featuretests/application_config_test.go
@@ -45,6 +45,7 @@ func (s *ApplicationConfigSuite) SetUpTest(c *gc.C) {
 	// Deploy application with custom config overwriting desired settings.
 	app, err := s.State.AddApplication(state.AddApplicationArgs{
 		Name:             s.appName,
+		Type:             state.ApplicationTypeIAAS,
 		Charm:            s.charm,
 		EndpointBindings: nil,
 		Settings: map[string]interface{}{

--- a/featuretests/charm_upgrade_test.go
+++ b/featuretests/charm_upgrade_test.go
@@ -31,6 +31,7 @@ func (s *CharmUpgradeSuite) SetUpTest(c *gc.C) {
 	var err error
 	s.appOne, err = s.State.AddApplication(state.AddApplicationArgs{
 		Name:  s.appOneName,
+		Type:  state.ApplicationTypeIAAS,
 		Charm: charmOne,
 	})
 	c.Assert(err, jc.ErrorIsNil)
@@ -42,6 +43,7 @@ func (s *CharmUpgradeSuite) SetUpTest(c *gc.C) {
 	charmTwo := s.AddTestingCharm(c, "upgrade-charm2")
 	appTwo, err := s.State.AddApplication(state.AddApplicationArgs{
 		Name:  s.appTwoName,
+		Type:  state.ApplicationTypeIAAS,
 		Charm: charmTwo,
 	})
 	c.Assert(err, jc.ErrorIsNil)

--- a/featuretests/cmd_juju_crossmodel_test.go
+++ b/featuretests/cmd_juju_crossmodel_test.go
@@ -273,6 +273,7 @@ func (s *crossmodelSuite) TestAddRelationSameControllerSameOwner(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	_, err = otherModel.AddApplication(state.AddApplicationArgs{
 		Name:  "mysql",
+		Type:  state.ApplicationTypeIAAS,
 		Charm: ch,
 	})
 	c.Assert(err, jc.ErrorIsNil)
@@ -304,6 +305,7 @@ func (s *crossmodelSuite) addOtherModelApplication(c *gc.C) *state.State {
 	c.Assert(err, jc.ErrorIsNil)
 	_, err = otherModel.AddApplication(state.AddApplicationArgs{
 		Name:  "mysql",
+		Type:  state.ApplicationTypeIAAS,
 		Charm: ch,
 	})
 

--- a/juju/testing/conn.go
+++ b/juju/testing/conn.go
@@ -696,20 +696,20 @@ func (s *JujuConnSuite) AddTestingCharm(c *gc.C, name string) *state.Charm {
 }
 
 func (s *JujuConnSuite) AddTestingApplication(c *gc.C, name string, ch *state.Charm) *state.Application {
-	app, err := s.State.AddApplication(state.AddApplicationArgs{Name: name, Charm: ch})
+	app, err := s.State.AddApplication(state.AddApplicationArgs{Name: name, Type: state.ApplicationTypeIAAS, Charm: ch})
 	c.Assert(err, jc.ErrorIsNil)
 	return app
 
 }
 
 func (s *JujuConnSuite) AddTestingApplicationWithStorage(c *gc.C, name string, ch *state.Charm, storage map[string]state.StorageConstraints) *state.Application {
-	app, err := s.State.AddApplication(state.AddApplicationArgs{Name: name, Charm: ch, Storage: storage})
+	app, err := s.State.AddApplication(state.AddApplicationArgs{Name: name, Type: state.ApplicationTypeIAAS, Charm: ch, Storage: storage})
 	c.Assert(err, jc.ErrorIsNil)
 	return app
 }
 
 func (s *JujuConnSuite) AddTestingApplicationWithBindings(c *gc.C, name string, ch *state.Charm, bindings map[string]string) *state.Application {
-	app, err := s.State.AddApplication(state.AddApplicationArgs{Name: name, Charm: ch, EndpointBindings: bindings})
+	app, err := s.State.AddApplication(state.AddApplicationArgs{Name: name, Type: state.ApplicationTypeIAAS, Charm: ch, EndpointBindings: bindings})
 	c.Assert(err, jc.ErrorIsNil)
 	return app
 }

--- a/network/containerizer/bridgepolicy_test.go
+++ b/network/containerizer/bridgepolicy_test.go
@@ -37,6 +37,7 @@ func addApplication(c *gc.C, st *state.State, series, name string, ch *state.Cha
 	c.Assert(ch, gc.NotNil)
 	service, err := st.AddApplication(state.AddApplicationArgs{
 		Name:             name,
+		Type:             state.ApplicationTypeIAAS,
 		Series:           series,
 		Charm:            ch,
 		EndpointBindings: bindings,

--- a/state/application.go
+++ b/state/application.go
@@ -31,25 +31,50 @@ type Application struct {
 	doc applicationDoc
 }
 
+// ApplicationType encodes the type of an application: IAAS or CAAS.
+type ApplicationType string
+
+const (
+	applicationTypeNone = ApplicationType("")
+	ApplicationTypeIAAS = ApplicationType("iaas")
+	ApplicationTypeCAAS = ApplicationType("caas")
+)
+
+// ParseApplicationType turns a valid application type string into a ApplicationType
+// constant.
+func ParseApplicationType(raw string) (ApplicationType, error) {
+	for _, typ := range []ApplicationType{ApplicationTypeIAAS, ApplicationTypeCAAS} {
+		if raw == string(typ) {
+			return typ, nil
+		}
+	}
+	return "", errors.NotValidf("application type %v", raw)
+}
+
+func (at ApplicationType) String() string {
+	return string(at)
+}
+
 // applicationDoc represents the internal state of an application in MongoDB.
 // Note the correspondence with ApplicationInfo in apiserver.
 type applicationDoc struct {
-	DocID                string     `bson:"_id"`
-	Name                 string     `bson:"name"`
-	ModelUUID            string     `bson:"model-uuid"`
-	Series               string     `bson:"series"`
-	Subordinate          bool       `bson:"subordinate"`
-	CharmURL             *charm.URL `bson:"charmurl"`
-	Channel              string     `bson:"cs-channel"`
-	CharmModifiedVersion int        `bson:"charmmodifiedversion"`
-	ForceCharm           bool       `bson:"forcecharm"`
-	Life                 Life       `bson:"life"`
-	UnitCount            int        `bson:"unitcount"`
-	RelationCount        int        `bson:"relationcount"`
-	Exposed              bool       `bson:"exposed"`
-	MinUnits             int        `bson:"minunits"`
-	TxnRevno             int64      `bson:"txn-revno"`
-	MetricCredentials    []byte     `bson:"metric-credentials"`
+	DocID                string          `bson:"_id"`
+	Name                 string          `bson:"name"`
+	Type                 ApplicationType `bson:"type"`
+	ModelUUID            string          `bson:"model-uuid"`
+	Series               string          `bson:"series"`
+	Subordinate          bool            `bson:"subordinate"`
+	CharmURL             *charm.URL      `bson:"charmurl"`
+	Channel              string          `bson:"cs-channel"`
+	CharmModifiedVersion int             `bson:"charmmodifiedversion"`
+	ForceCharm           bool            `bson:"forcecharm"`
+	Life                 Life            `bson:"life"`
+	UnitCount            int             `bson:"unitcount"`
+	RelationCount        int             `bson:"relationcount"`
+	Exposed              bool            `bson:"exposed"`
+	MinUnits             int             `bson:"minunits"`
+	TxnRevno             int64           `bson:"txn-revno"`
+	MetricCredentials    []byte          `bson:"metric-credentials"`
 }
 
 func newApplication(st *State, doc *applicationDoc) *Application {
@@ -68,6 +93,11 @@ func (a *Application) IsRemote() bool {
 // Name returns the application name.
 func (a *Application) Name() string {
 	return a.doc.Name
+}
+
+// Type returns the type of the application.
+func (a *Application) Type() ApplicationType {
+	return a.doc.Type
 }
 
 // Tag returns a name identifying the application.

--- a/state/application_test.go
+++ b/state/application_test.go
@@ -197,6 +197,7 @@ func (s *ApplicationSuite) TestSetCharmUpdatesBindings(c *gc.C) {
 
 	service, err := s.State.AddApplication(state.AddApplicationArgs{
 		Name:  "yoursql",
+		Type:  state.ApplicationTypeIAAS,
 		Charm: oldCharm,
 		EndpointBindings: map[string]string{
 			"":       "db",

--- a/state/charm_test.go
+++ b/state/charm_test.go
@@ -175,6 +175,7 @@ func (s *CharmSuite) TestReferenceDyingCharm(c *gc.C) {
 
 	args := state.AddApplicationArgs{
 		Name:  "blah",
+		Type:  state.ApplicationTypeIAAS,
 		Charm: s.charm,
 	}
 	_, err := s.State.AddApplication(args)
@@ -189,6 +190,7 @@ func (s *CharmSuite) TestReferenceDyingCharmRace(c *gc.C) {
 
 	args := state.AddApplicationArgs{
 		Name:  "blah",
+		Type:  state.ApplicationTypeIAAS,
 		Charm: s.charm,
 	}
 	_, err := s.State.AddApplication(args)

--- a/state/constraintsvalidation_test.go
+++ b/state/constraintsvalidation_test.go
@@ -282,6 +282,7 @@ func (s *applicationConstraintsSuite) TestAddApplicationInvalidConstraints(c *gc
 	cons := constraints.MustParse("virt-type=blah")
 	_, err := s.State.AddApplication(state.AddApplicationArgs{
 		Name:        s.applicationName,
+		Type:        state.ApplicationTypeIAAS,
 		Series:      "",
 		Charm:       s.testCharm,
 		Constraints: cons,
@@ -293,6 +294,7 @@ func (s *applicationConstraintsSuite) TestAddApplicationValidConstraints(c *gc.C
 	cons := constraints.MustParse("virt-type=kvm")
 	service, err := s.State.AddApplication(state.AddApplicationArgs{
 		Name:        s.applicationName,
+		Type:        state.ApplicationTypeIAAS,
 		Series:      "",
 		Charm:       s.testCharm,
 		Constraints: cons,

--- a/state/export_test.go
+++ b/state/export_test.go
@@ -178,6 +178,7 @@ func addTestingApplication(c *gc.C, st *State, series, name string, ch *Charm, b
 	c.Assert(ch, gc.NotNil)
 	app, err := st.AddApplication(AddApplicationArgs{
 		Name:             name,
+		Type:             ApplicationTypeIAAS,
 		Series:           series,
 		Charm:            ch,
 		EndpointBindings: bindings,

--- a/state/filesystem_test.go
+++ b/state/filesystem_test.go
@@ -26,7 +26,7 @@ func (s *FilesystemStateSuite) TestAddServiceInvalidPool(c *gc.C) {
 	storage := map[string]state.StorageConstraints{
 		"data": makeStorageCons("invalid-pool", 1024, 1),
 	}
-	_, err := s.State.AddApplication(state.AddApplicationArgs{Name: "storage-filesystem", Charm: ch, Storage: storage})
+	_, err := s.State.AddApplication(state.AddApplicationArgs{Name: "storage-filesystem", Type: state.ApplicationTypeIAAS, Charm: ch, Storage: storage})
 	c.Assert(err, gc.ErrorMatches, `.* pool "invalid-pool" not found`)
 }
 
@@ -59,6 +59,7 @@ func (s *FilesystemStateSuite) testAddServiceDefaultPool(c *gc.C, expectedPool s
 
 	args := state.AddApplicationArgs{
 		Name:     "storage-filesystem",
+		Type:     state.ApplicationTypeIAAS,
 		Charm:    ch,
 		Storage:  storage,
 		NumUnits: numUnits,

--- a/state/migration_export.go
+++ b/state/migration_export.go
@@ -677,6 +677,7 @@ func (e *exporter) addApplication(ctx addApplicationContext) error {
 
 	args := description.ApplicationArgs{
 		Tag:                  application.ApplicationTag(),
+		Type:                 application.doc.Type.String(),
 		Series:               application.doc.Series,
 		Subordinate:          application.doc.Subordinate,
 		CharmURL:             application.doc.CharmURL.String(),

--- a/state/migration_export_test.go
+++ b/state/migration_export_test.go
@@ -400,6 +400,7 @@ func (s *MigrationExportSuite) assertMigrateApplications(c *gc.C, cons constrain
 
 	exported := applications[0]
 	c.Assert(exported.Name(), gc.Equals, application.Name())
+	c.Assert(exported.Type(), gc.Equals, string(application.Type()))
 	c.Assert(exported.Tag(), gc.Equals, application.ApplicationTag())
 	c.Assert(exported.Series(), gc.Equals, application.Series())
 	c.Assert(exported.Annotations(), jc.DeepEquals, testAnnotations)

--- a/state/migration_import.go
+++ b/state/migration_import.go
@@ -996,8 +996,14 @@ func (i *importer) makeApplicationDoc(s description.Application) (*applicationDo
 		return nil, errors.Trace(err)
 	}
 
+	applicationType, err := ParseApplicationType(s.Type())
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
 	return &applicationDoc{
 		Name:                 s.Name(),
+		Type:                 applicationType,
 		Series:               s.Series(),
 		Subordinate:          s.Subordinate(),
 		CharmURL:             charmURL,

--- a/state/migration_import_test.go
+++ b/state/migration_import_test.go
@@ -453,6 +453,7 @@ func (s *MigrationImportSuite) TestApplications(c *gc.C) {
 	imported := importedApplications[0]
 
 	c.Assert(imported.ApplicationTag(), gc.Equals, exported.ApplicationTag())
+	c.Assert(imported.Type(), gc.Equals, exported.Type())
 	c.Assert(imported.Series(), gc.Equals, exported.Series())
 	c.Assert(imported.IsExposed(), gc.Equals, exported.IsExposed())
 	c.Assert(imported.MetricCredentials(), jc.DeepEquals, exported.MetricCredentials())

--- a/state/migration_internal_test.go
+++ b/state/migration_internal_test.go
@@ -363,6 +363,7 @@ func (s *MigrationSuite) TestApplicationDocFields(c *gc.C) {
 	)
 	migrated := set.NewStrings(
 		"Name",
+		"Type",
 		"Series",
 		"Subordinate",
 		"CharmURL",

--- a/state/model.go
+++ b/state/model.go
@@ -571,7 +571,7 @@ func (m *Model) Name() string {
 	return m.doc.Name
 }
 
-// Type returns the human friendly name of the model.
+// Type returns the type of the model.
 func (m *Model) Type() ModelType {
 	return m.doc.Type
 }

--- a/state/model_test.go
+++ b/state/model_test.go
@@ -631,6 +631,7 @@ func (s *ModelSuite) TestDestroyControllerAndHostedModelsWithResources(c *gc.C) 
 
 	args := state.AddApplicationArgs{
 		Name:  service.Name(),
+		Type:  state.ApplicationTypeIAAS,
 		Charm: ch,
 	}
 	service, err = otherSt.AddApplication(args)
@@ -995,6 +996,7 @@ func (s *ModelSuite) TestProcessDyingModelWithMachinesAndServicesNoOp(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	args := state.AddApplicationArgs{
 		Name:  service.Name(),
+		Type:  state.ApplicationTypeIAAS,
 		Charm: ch,
 	}
 	service, err = st.AddApplication(args)

--- a/state/prechecker_test.go
+++ b/state/prechecker_test.go
@@ -165,6 +165,7 @@ func (s *PrecheckerSuite) TestPrecheckAddApplication(c *gc.C) {
 	ch := s.AddTestingCharm(c, "storage-block")
 	app, err := s.State.AddApplication(state.AddApplicationArgs{
 		Name:     "storage-block",
+		Type:     state.ApplicationTypeIAAS,
 		Charm:    ch,
 		NumUnits: 1,
 		Storage: map[string]state.StorageConstraints{
@@ -218,6 +219,7 @@ func (s *PrecheckerSuite) TestPrecheckAddApplication(c *gc.C) {
 
 	_, err = s.State.AddApplication(state.AddApplicationArgs{
 		Name:     "storage-block-the-second",
+		Type:     state.ApplicationTypeIAAS,
 		Charm:    ch,
 		NumUnits: 1,
 		Placement: []*instance.Placement{{

--- a/state/remoteapplication_test.go
+++ b/state/remoteapplication_test.go
@@ -884,7 +884,7 @@ func (s *remoteApplicationSuite) TestAddApplicationModelDying(c *gc.C) {
 
 func (s *remoteApplicationSuite) TestAddApplicationSameLocalExists(c *gc.C) {
 	charm := s.AddTestingCharm(c, "dummy")
-	_, err := s.State.AddApplication(state.AddApplicationArgs{Name: "s1", Charm: charm})
+	_, err := s.State.AddApplication(state.AddApplicationArgs{Name: "s1", Type: state.ApplicationTypeIAAS, Charm: charm})
 	c.Assert(err, jc.ErrorIsNil)
 	_, err = s.State.AddRemoteApplication(state.AddRemoteApplicationParams{
 		Name: "s1", SourceModel: s.IAASModel.ModelTag()})
@@ -897,7 +897,7 @@ func (s *remoteApplicationSuite) TestAddApplicationLocalAddedAfterInitial(c *gc.
 	// there is no conflict initially but a local application is added
 	// before the transaction is run.
 	defer state.SetBeforeHooks(c, s.State, func() {
-		_, err := s.State.AddApplication(state.AddApplicationArgs{Name: "s1", Charm: charm})
+		_, err := s.State.AddApplication(state.AddApplicationArgs{Name: "s1", Type: state.ApplicationTypeIAAS, Charm: charm})
 		c.Assert(err, jc.ErrorIsNil)
 	}).Check()
 	_, err := s.State.AddRemoteApplication(state.AddRemoteApplicationParams{

--- a/state/storage_dynamicadd_test.go
+++ b/state/storage_dynamicadd_test.go
@@ -30,7 +30,11 @@ func (s *storageAddSuite) setupMultipleStoragesForAdd(c *gc.C) *state.Unit {
 		"multi1to10": makeStorageCons("persistent-block", 0, 3),
 	}
 	charm := s.AddTestingCharm(c, "storage-block2")
-	service, err := s.State.AddApplication(state.AddApplicationArgs{Name: "storage-block2", Charm: charm, Storage: storageCons})
+	service, err := s.State.AddApplication(state.AddApplicationArgs{
+		Name:    "storage-block2",
+		Type:    state.ApplicationTypeIAAS,
+		Charm:   charm,
+		Storage: storageCons})
 	c.Assert(err, jc.ErrorIsNil)
 	u, err := service.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)

--- a/state/storage_test.go
+++ b/state/storage_test.go
@@ -385,7 +385,7 @@ var _ = gc.Suite(&StorageStateSuite{})
 
 func (s *StorageStateSuite) TestAddServiceStorageConstraintsDefault(c *gc.C) {
 	ch := s.AddTestingCharm(c, "storage-block")
-	storageBlock, err := s.State.AddApplication(state.AddApplicationArgs{Name: "storage-block", Charm: ch})
+	storageBlock, err := s.State.AddApplication(state.AddApplicationArgs{Name: "storage-block", Type: state.ApplicationTypeIAAS, Charm: ch})
 	c.Assert(err, jc.ErrorIsNil)
 	constraints, err := storageBlock.StorageConstraints()
 	c.Assert(err, jc.ErrorIsNil)
@@ -403,7 +403,7 @@ func (s *StorageStateSuite) TestAddServiceStorageConstraintsDefault(c *gc.C) {
 	})
 
 	ch = s.AddTestingCharm(c, "storage-filesystem")
-	storageFilesystem, err := s.State.AddApplication(state.AddApplicationArgs{Name: "storage-filesystem", Charm: ch})
+	storageFilesystem, err := s.State.AddApplication(state.AddApplicationArgs{Name: "storage-filesystem", Type: state.ApplicationTypeIAAS, Charm: ch})
 	c.Assert(err, jc.ErrorIsNil)
 	constraints, err = storageFilesystem.StorageConstraints()
 	c.Assert(err, jc.ErrorIsNil)
@@ -419,7 +419,7 @@ func (s *StorageStateSuite) TestAddServiceStorageConstraintsDefault(c *gc.C) {
 func (s *StorageStateSuite) TestAddServiceStorageConstraintsValidation(c *gc.C) {
 	ch := s.AddTestingCharm(c, "storage-block2")
 	addService := func(storage map[string]state.StorageConstraints) (*state.Application, error) {
-		return s.State.AddApplication(state.AddApplicationArgs{Name: "storage-block2", Charm: ch, Storage: storage})
+		return s.State.AddApplication(state.AddApplicationArgs{Name: "storage-block2", Type: state.ApplicationTypeIAAS, Charm: ch, Storage: storage})
 	}
 	assertErr := func(storage map[string]state.StorageConstraints, expect string) {
 		_, err := addService(storage)
@@ -451,7 +451,7 @@ func (s *StorageStateSuite) assertAddServiceStorageConstraintsDefaults(c *gc.C, 
 		c.Assert(err, jc.ErrorIsNil)
 	}
 	ch := s.AddTestingCharm(c, "storage-block")
-	app, err := s.State.AddApplication(state.AddApplicationArgs{Name: "storage-block2", Charm: ch, Storage: cons})
+	app, err := s.State.AddApplication(state.AddApplicationArgs{Name: "storage-block2", Type: state.ApplicationTypeIAAS, Charm: ch, Storage: cons})
 	c.Assert(err, jc.ErrorIsNil)
 	savedCons, err := app.StorageConstraints()
 	c.Assert(err, jc.ErrorIsNil)
@@ -523,7 +523,7 @@ func (s *StorageStateSuite) TestAddServiceStorageConstraintsDefaultSizeFromCharm
 		"multi2up":   makeStorageCons("loop", 2048, 2),
 	}
 	ch := s.AddTestingCharm(c, "storage-block2")
-	app, err := s.State.AddApplication(state.AddApplicationArgs{Name: "storage-block2", Charm: ch, Storage: storageCons})
+	app, err := s.State.AddApplication(state.AddApplicationArgs{Name: "storage-block2", Type: state.ApplicationTypeIAAS, Charm: ch, Storage: storageCons})
 	c.Assert(err, jc.ErrorIsNil)
 	savedCons, err := app.StorageConstraints()
 	c.Assert(err, jc.ErrorIsNil)
@@ -533,7 +533,7 @@ func (s *StorageStateSuite) TestAddServiceStorageConstraintsDefaultSizeFromCharm
 func (s *StorageStateSuite) TestProviderFallbackToType(c *gc.C) {
 	ch := s.AddTestingCharm(c, "storage-block")
 	addService := func(storage map[string]state.StorageConstraints) (*state.Application, error) {
-		return s.State.AddApplication(state.AddApplicationArgs{Name: "storage-block", Charm: ch, Storage: storage})
+		return s.State.AddApplication(state.AddApplicationArgs{Name: "storage-block", Type: state.ApplicationTypeIAAS, Charm: ch, Storage: storage})
 	}
 	storageCons := map[string]state.StorageConstraints{
 		"data": makeStorageCons("loop", 1024, 1),
@@ -850,6 +850,7 @@ func (s *StorageStateSuite) TestAddApplicationAttachStorage(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	app2, err := s.State.AddApplication(state.AddApplicationArgs{
 		Name:   "secondwind",
+		Type:   state.ApplicationTypeIAAS,
 		Series: app.Series(),
 		Charm:  ch,
 		Storage: map[string]state.StorageConstraints{
@@ -882,6 +883,7 @@ func (s *StorageStateSuite) TestAddApplicationAttachStorageMultipleUnits(c *gc.C
 	ch, _, _ := app.Charm()
 	_, err := s.State.AddApplication(state.AddApplicationArgs{
 		Name:          "secondwind",
+		Type:          state.ApplicationTypeIAAS,
 		Series:        app.Series(),
 		Charm:         ch,
 		AttachStorage: []names.StorageTag{storageTag},
@@ -913,6 +915,7 @@ func (s *StorageStateSuite) TestAddApplicationAttachStorageTooMany(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	_, err = s.State.AddApplication(state.AddApplicationArgs{
 		Name:   "secondwind",
+		Type:   state.ApplicationTypeIAAS,
 		Series: app.Series(),
 		Charm:  ch,
 		Storage: map[string]state.StorageConstraints{

--- a/state/unit_assignment_test.go
+++ b/state/unit_assignment_test.go
@@ -21,7 +21,8 @@ var _ = gc.Suite(&UnitAssignmentSuite{})
 func (s *UnitAssignmentSuite) testAddServiceUnitAssignment(c *gc.C) (*state.Application, []state.UnitAssignment) {
 	charm := s.AddTestingCharm(c, "dummy")
 	svc, err := s.State.AddApplication(state.AddApplicationArgs{
-		Name: "dummy", Charm: charm, NumUnits: 2,
+		Name: "dummy", Type: state.ApplicationTypeIAAS,
+		Charm: charm, NumUnits: 2,
 		Placement: []*instance.Placement{{s.State.ModelUUID(), "abc"}},
 	})
 	c.Assert(err, jc.ErrorIsNil)
@@ -80,6 +81,7 @@ func (s *UnitAssignmentSuite) TestAssignUnitWithPlacementMakesContainerInNewMach
 	placement := instance.Placement{Scope: "lxd"}
 	svc, err := s.State.AddApplication(state.AddApplicationArgs{
 		Name:      "dummy",
+		Type:      state.ApplicationTypeIAAS,
 		Charm:     charm,
 		NumUnits:  1,
 		Placement: []*instance.Placement{&placement},

--- a/state/volume_test.go
+++ b/state/volume_test.go
@@ -85,7 +85,7 @@ func (s *VolumeStateSuite) TestAddServiceInvalidPool(c *gc.C) {
 	storage := map[string]state.StorageConstraints{
 		"data": makeStorageCons("invalid-pool", 1024, 1),
 	}
-	_, err := s.State.AddApplication(state.AddApplicationArgs{Name: "storage-block", Charm: ch, Storage: storage})
+	_, err := s.State.AddApplication(state.AddApplicationArgs{Name: "storage-block", Type: state.ApplicationTypeIAAS, Charm: ch, Storage: storage})
 	c.Assert(err, gc.ErrorMatches, `.* pool "invalid-pool" not found`)
 }
 
@@ -94,7 +94,7 @@ func (s *VolumeStateSuite) TestAddServiceNoUserDefaultPool(c *gc.C) {
 	storage := map[string]state.StorageConstraints{
 		"data": makeStorageCons("", 1024, 1),
 	}
-	app, err := s.State.AddApplication(state.AddApplicationArgs{Name: "storage-block", Charm: ch, Storage: storage})
+	app, err := s.State.AddApplication(state.AddApplicationArgs{Name: "storage-block", Type: state.ApplicationTypeIAAS, Charm: ch, Storage: storage})
 	c.Assert(err, jc.ErrorIsNil)
 	cons, err := app.StorageConstraints()
 	c.Assert(err, jc.ErrorIsNil)

--- a/testing/factory/factory.go
+++ b/testing/factory/factory.go
@@ -449,6 +449,7 @@ func (factory *Factory) MakeApplication(c *gc.C, params *ApplicationParams) *sta
 
 	application, err := factory.st.AddApplication(state.AddApplicationArgs{
 		Name:        params.Name,
+		Type:        state.ApplicationTypeIAAS,
 		Charm:       params.Charm,
 		Settings:    charm.Settings(params.Settings),
 		Storage:     params.Storage,


### PR DESCRIPTION
## Description of change

Add type field to Application doc, distinguishing between IAAS and CAAS applications.

Blocked because we first need to merge https://github.com/juju/description/pull/27 and update dependencies here with the resulting commit.

## QA steps

Basic bootstrap/deploy functionality check creates an application and gets at these changes.

## Documentation changes

No effects on workflow.

