### PR TITLE
remove-{application,unit}: introduce --destroy-storage flag

### DIFF
--- a/api/application/client_test.go
+++ b/api/application/client_test.go
@@ -29,7 +29,11 @@ type applicationSuite struct {
 var _ = gc.Suite(&applicationSuite{})
 
 func newClient(f basetesting.APICallerFunc) *application.Client {
-	return application.NewClient(f)
+	return application.NewClient(basetesting.BestVersionCaller{f, 5})
+}
+
+func newClientV4(f basetesting.APICallerFunc) *application.Client {
+	return application.NewClient(basetesting.BestVersionCaller{f, 4})
 }
 
 func (s *applicationSuite) TestSetServiceMetricCredentials(c *gc.C) {
@@ -331,6 +335,36 @@ func (s *applicationSuite) TestDestroyApplications(c *gc.C) {
 	}}
 	client := newClient(func(objType string, version int, id, request string, a, response interface{}) error {
 		c.Assert(request, gc.Equals, "DestroyApplication")
+		c.Assert(a, jc.DeepEquals, params.DestroyApplicationsParams{
+			Applications: []params.DestroyApplicationParams{
+				{ApplicationTag: "application-foo"},
+				{ApplicationTag: "application-bar"},
+			},
+		})
+		c.Assert(response, gc.FitsTypeOf, &params.DestroyApplicationResults{})
+		out := response.(*params.DestroyApplicationResults)
+		*out = params.DestroyApplicationResults{expectedResults}
+		return nil
+	})
+	results, err := client.DestroyApplications(application.DestroyApplicationsParams{
+		Applications: []string{"foo", "bar"},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(results, jc.DeepEquals, expectedResults)
+}
+
+func (s *applicationSuite) TestDestroyApplicationsV4(c *gc.C) {
+	expectedResults := []params.DestroyApplicationResult{{
+		Error: &params.Error{Message: "boo"},
+	}, {
+		Info: &params.DestroyApplicationInfo{
+			DestroyedStorage: []params.Entity{{Tag: "storage-pgdata-0"}},
+			DetachedStorage:  []params.Entity{{Tag: "storage-pgdata-1"}},
+			DestroyedUnits:   []params.Entity{{Tag: "unit-bar-1"}},
+		},
+	}}
+	client := newClientV4(func(objType string, version int, id, request string, a, response interface{}) error {
+		c.Assert(request, gc.Equals, "DestroyApplication")
 		c.Assert(a, jc.DeepEquals, params.Entities{
 			Entities: []params.Entity{
 				{Tag: "application-foo"},
@@ -342,7 +376,9 @@ func (s *applicationSuite) TestDestroyApplications(c *gc.C) {
 		*out = params.DestroyApplicationResults{expectedResults}
 		return nil
 	})
-	results, err := client.DestroyApplications("foo", "bar")
+	results, err := client.DestroyApplications(application.DestroyApplicationsParams{
+		Applications: []string{"foo", "bar"},
+	})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, jc.DeepEquals, expectedResults)
 }
@@ -351,7 +387,9 @@ func (s *applicationSuite) TestDestroyApplicationsArity(c *gc.C) {
 	client := newClient(func(objType string, version int, id, request string, a, response interface{}) error {
 		return nil
 	})
-	_, err := client.DestroyApplications("foo")
+	_, err := client.DestroyApplications(application.DestroyApplicationsParams{
+		Applications: []string{"foo"},
+	})
 	c.Assert(err, gc.ErrorMatches, `expected 1 result\(s\), got 0`)
 }
 
@@ -366,7 +404,9 @@ func (s *applicationSuite) TestDestroyApplicationsInvalidIds(c *gc.C) {
 		*out = params.DestroyApplicationResults{expectedResults[1:]}
 		return nil
 	})
-	results, err := client.DestroyApplications("!", "foo")
+	results, err := client.DestroyApplications(application.DestroyApplicationsParams{
+		Applications: []string{"!", "foo"},
+	})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, jc.DeepEquals, expectedResults)
 }
@@ -382,6 +422,35 @@ func (s *applicationSuite) TestDestroyUnits(c *gc.C) {
 	}}
 	client := newClient(func(objType string, version int, id, request string, a, response interface{}) error {
 		c.Assert(request, gc.Equals, "DestroyUnit")
+		c.Assert(a, jc.DeepEquals, params.DestroyUnitsParams{
+			Units: []params.DestroyUnitParams{
+				{UnitTag: "unit-foo-0"},
+				{UnitTag: "unit-bar-1"},
+			},
+		})
+		c.Assert(response, gc.FitsTypeOf, &params.DestroyUnitResults{})
+		out := response.(*params.DestroyUnitResults)
+		*out = params.DestroyUnitResults{expectedResults}
+		return nil
+	})
+	results, err := client.DestroyUnits(application.DestroyUnitsParams{
+		Units: []string{"foo/0", "bar/1"},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(results, jc.DeepEquals, expectedResults)
+}
+
+func (s *applicationSuite) TestDestroyUnitsV4(c *gc.C) {
+	expectedResults := []params.DestroyUnitResult{{
+		Error: &params.Error{Message: "boo"},
+	}, {
+		Info: &params.DestroyUnitInfo{
+			DestroyedStorage: []params.Entity{{Tag: "storage-pgdata-0"}},
+			DetachedStorage:  []params.Entity{{Tag: "storage-pgdata-1"}},
+		},
+	}}
+	client := newClientV4(func(objType string, version int, id, request string, a, response interface{}) error {
+		c.Assert(request, gc.Equals, "DestroyUnit")
 		c.Assert(a, jc.DeepEquals, params.Entities{
 			Entities: []params.Entity{
 				{Tag: "unit-foo-0"},
@@ -393,7 +462,9 @@ func (s *applicationSuite) TestDestroyUnits(c *gc.C) {
 		*out = params.DestroyUnitResults{expectedResults}
 		return nil
 	})
-	results, err := client.DestroyUnits("foo/0", "bar/1")
+	results, err := client.DestroyUnits(application.DestroyUnitsParams{
+		Units: []string{"foo/0", "bar/1"},
+	})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, jc.DeepEquals, expectedResults)
 }
@@ -402,7 +473,9 @@ func (s *applicationSuite) TestDestroyUnitsArity(c *gc.C) {
 	client := newClient(func(objType string, version int, id, request string, a, response interface{}) error {
 		return nil
 	})
-	_, err := client.DestroyUnits("foo/0")
+	_, err := client.DestroyUnits(application.DestroyUnitsParams{
+		Units: []string{"foo/0"},
+	})
 	c.Assert(err, gc.ErrorMatches, `expected 1 result\(s\), got 0`)
 }
 
@@ -417,7 +490,9 @@ func (s *applicationSuite) TestDestroyUnitsInvalidIds(c *gc.C) {
 		*out = params.DestroyUnitResults{expectedResults[1:]}
 		return nil
 	})
-	results, err := client.DestroyUnits("!", "foo/0")
+	results, err := client.DestroyUnits(application.DestroyUnitsParams{
+		Units: []string{"!", "foo/0"},
+	})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, jc.DeepEquals, expectedResults)
 }

--- a/apiserver/facades/client/application/application_unit_test.go
+++ b/apiserver/facades/client/application/application_unit_test.go
@@ -280,10 +280,10 @@ func (s *ApplicationSuite) TestDestroyRelationIdRelationNotFound(c *gc.C) {
 }
 
 func (s *ApplicationSuite) TestDestroyApplication(c *gc.C) {
-	results, err := s.api.DestroyApplication(params.Entities{
-		Entities: []params.Entity{
-			{Tag: "application-postgresql"},
-		},
+	results, err := s.api.DestroyApplication(params.DestroyApplicationsParams{
+		Applications: []params.DestroyApplicationParams{{
+			ApplicationTag: "application-postgresql",
+		}},
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results.Results, gc.HasLen, 1)
@@ -301,13 +301,64 @@ func (s *ApplicationSuite) TestDestroyApplication(c *gc.C) {
 			},
 		},
 	})
+
+	s.backend.CheckCallNames(c,
+		"ModelTag",
+		"RemoteApplication",
+		"Application",
+		"UnitStorageAttachments",
+		"StorageInstance",
+		"StorageInstance",
+		"StorageInstanceFilesystem",
+		"StorageInstanceFilesystem",
+		"UnitStorageAttachments",
+		"ApplyOperation",
+	)
+	s.backend.CheckCall(c, 9, "ApplyOperation", &state.DestroyApplicationOperation{})
+}
+
+func (s *ApplicationSuite) TestDestroyApplicationDestroyStorage(c *gc.C) {
+	results, err := s.api.DestroyApplication(params.DestroyApplicationsParams{
+		Applications: []params.DestroyApplicationParams{{
+			ApplicationTag: "application-postgresql",
+			DestroyStorage: true,
+		}},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(results.Results, gc.HasLen, 1)
+	c.Assert(results.Results[0], jc.DeepEquals, params.DestroyApplicationResult{
+		Info: &params.DestroyApplicationInfo{
+			DestroyedUnits: []params.Entity{
+				{Tag: "unit-postgresql-0"},
+				{Tag: "unit-postgresql-1"},
+			},
+			DestroyedStorage: []params.Entity{
+				{Tag: "storage-pgdata-0"},
+				{Tag: "storage-pgdata-1"},
+			},
+		},
+	})
+
+	s.backend.CheckCallNames(c,
+		"ModelTag",
+		"RemoteApplication",
+		"Application",
+		"UnitStorageAttachments",
+		"StorageInstance",
+		"StorageInstance",
+		"UnitStorageAttachments",
+		"ApplyOperation",
+	)
+	s.backend.CheckCall(c, 7, "ApplyOperation", &state.DestroyApplicationOperation{
+		DestroyStorage: true,
+	})
 }
 
 func (s *ApplicationSuite) TestDestroyApplicationNotFound(c *gc.C) {
 	delete(s.backend.applications, "postgresql")
-	results, err := s.api.DestroyApplication(params.Entities{
-		Entities: []params.Entity{
-			{Tag: "application-postgresql"},
+	results, err := s.api.DestroyApplication(params.DestroyApplicationsParams{
+		Applications: []params.DestroyApplicationParams{
+			{ApplicationTag: "application-postgresql"},
 		},
 	})
 	c.Assert(err, jc.ErrorIsNil)
@@ -321,10 +372,13 @@ func (s *ApplicationSuite) TestDestroyApplicationNotFound(c *gc.C) {
 }
 
 func (s *ApplicationSuite) TestDestroyUnit(c *gc.C) {
-	results, err := s.api.DestroyUnit(params.Entities{
-		Entities: []params.Entity{
-			{Tag: "unit-postgresql-0"},
-			{Tag: "unit-postgresql-1"},
+	results, err := s.api.DestroyUnit(params.DestroyUnitsParams{
+		Units: []params.DestroyUnitParams{
+			{UnitTag: "unit-postgresql-0"},
+			{
+				UnitTag:        "unit-postgresql-1",
+				DestroyStorage: true,
+			},
 		},
 	})
 	c.Assert(err, jc.ErrorIsNil)
@@ -341,6 +395,25 @@ func (s *ApplicationSuite) TestDestroyUnit(c *gc.C) {
 	}, {
 		Info: &params.DestroyUnitInfo{},
 	}})
+
+	s.backend.CheckCallNames(c,
+		"ModelTag",
+		"Unit",
+		"UnitStorageAttachments",
+		"StorageInstance",
+		"StorageInstance",
+		"StorageInstanceFilesystem",
+		"StorageInstanceFilesystem",
+		"ApplyOperation",
+
+		"Unit",
+		"UnitStorageAttachments",
+		"ApplyOperation",
+	)
+	s.backend.CheckCall(c, 7, "ApplyOperation", &state.DestroyUnitOperation{})
+	s.backend.CheckCall(c, 10, "ApplyOperation", &state.DestroyUnitOperation{
+		DestroyStorage: true,
+	})
 }
 
 func (s *ApplicationSuite) TestDeployAttachStorage(c *gc.C) {

--- a/apiserver/facades/client/application/backend.go
+++ b/apiserver/facades/client/application/backend.go
@@ -25,6 +25,7 @@ type Backend interface {
 
 	AllModelUUIDs() ([]string, error)
 	Application(string) (Application, error)
+	ApplyOperation(state.ModelOperation) error
 	AddApplication(state.AddApplicationArgs) (Application, error)
 	RemoteApplication(string) (RemoteApplication, error)
 	AddRemoteApplication(state.AddRemoteApplicationParams) (RemoteApplication, error)
@@ -65,6 +66,7 @@ type Application interface {
 	ConfigSettings() (charm.Settings, error)
 	Constraints() (constraints.Value, error)
 	Destroy() error
+	DestroyOperation() *state.DestroyApplicationOperation
 	Endpoints() ([]state.Endpoint, error)
 	IsPrincipal() bool
 	Series() string
@@ -112,6 +114,7 @@ type Relation interface {
 type Unit interface {
 	UnitTag() names.UnitTag
 	Destroy() error
+	DestroyOperation() *state.DestroyUnitOperation
 	IsPrincipal() bool
 	Life() state.Life
 

--- a/apiserver/facades/client/application/mock_test.go
+++ b/apiserver/facades/client/application/mock_test.go
@@ -129,9 +129,9 @@ func (a *mockApplication) SetCharm(cfg state.SetCharmConfig) error {
 	return a.NextErr()
 }
 
-func (a *mockApplication) Destroy() error {
-	a.MethodCall(a, "Destroy")
-	return a.NextErr()
+func (a *mockApplication) DestroyOperation() *state.DestroyApplicationOperation {
+	a.MethodCall(a, "DestroyOperation")
+	return &state.DestroyApplicationOperation{}
 }
 
 func (a *mockApplication) AddUnit(args state.AddUnitParams) (application.Unit, error) {
@@ -458,6 +458,11 @@ func (m *mockBackend) Application(name string) (application.Application, error) 
 	return app, nil
 }
 
+func (m *mockBackend) ApplyOperation(op state.ModelOperation) error {
+	m.MethodCall(m, "ApplyOperation", op)
+	return m.NextErr()
+}
+
 type mockExternalController struct {
 	uuid string
 	info crossmodel.ControllerInfo
@@ -563,9 +568,9 @@ func (u *mockUnit) IsPrincipal() bool {
 	return true
 }
 
-func (u *mockUnit) Destroy() error {
-	u.MethodCall(u, "Destroy")
-	return u.NextErr()
+func (u *mockUnit) DestroyOperation() *state.DestroyUnitOperation {
+	u.MethodCall(u, "DestroyOperation")
+	return &state.DestroyUnitOperation{}
 }
 
 func (u *mockUnit) AssignWithPolicy(policy state.AssignmentPolicy) error {

--- a/apiserver/facades/client/client/perm_test.go
+++ b/apiserver/facades/client/client/perm_test.go
@@ -361,7 +361,9 @@ func opClientDestroyServiceUnits(c *gc.C, st api.Connection, mst *state.State) (
 }
 
 func opClientDestroyUnit(c *gc.C, st api.Connection, mst *state.State) (func(), error) {
-	_, err := application.NewClient(st).DestroyUnits("wordpress/99")
+	_, err := application.NewClient(st).DestroyUnits(application.DestroyUnitsParams{
+		Units: []string{"wordpress/99"},
+	})
 	return func() {}, err
 }
 
@@ -374,7 +376,9 @@ func opClientServiceDestroy(c *gc.C, st api.Connection, mst *state.State) (func(
 }
 
 func opClientDestroyApplication(c *gc.C, st api.Connection, mst *state.State) (func(), error) {
-	_, err := application.NewClient(st).DestroyApplications("non-existent")
+	_, err := application.NewClient(st).DestroyApplications(application.DestroyApplicationsParams{
+		Applications: []string{"non-existent"},
+	})
 	return func() {}, err
 }
 

--- a/apiserver/params/params.go
+++ b/apiserver/params/params.go
@@ -442,14 +442,48 @@ type AddApplicationUnits struct {
 	AttachStorage   []string              `json:"attach-storage,omitempty"`
 }
 
-// DestroyApplicationUnits holds parameters for the DestroyUnits call.
+// DestroyApplicationUnits holds parameters for the deprecated
+// Application.DestroyUnits call.
 type DestroyApplicationUnits struct {
 	UnitNames []string `json:"unit-names"`
 }
 
-// ApplicationDestroy holds the parameters for making the application Destroy call.
+// DestroyUnitsParams holds bulk parameters for the Application.DestroyUnit call.
+type DestroyUnitsParams struct {
+	Units []DestroyUnitParams `json:"units"`
+}
+
+// DestroyUnitParams holds parameters for the Application.DestroyUnit call.
+type DestroyUnitParams struct {
+	// UnitTag holds the tag of the unit to destroy.
+	UnitTag string `json:"unit-tag"`
+
+	// DestroyStorage controls whether or not storage
+	// attached to the unit should be destroyed.
+	DestroyStorage bool `json:"destroy-storage,omitempty"`
+}
+
+// ApplicationDestroy holds the parameters for making the deprecated
+// Application.Destroy call.
 type ApplicationDestroy struct {
 	ApplicationName string `json:"application"`
+}
+
+// DestroyApplicationsParams holds bulk parameters for the
+// Application.DestroyApplication call.
+type DestroyApplicationsParams struct {
+	Applications []DestroyApplicationParams `json:"applications"`
+}
+
+// DestroyApplicationParams holds parameters for the
+// Application.DestroyApplication call.
+type DestroyApplicationParams struct {
+	// ApplicationTag holds the tag of the application to destroy.
+	ApplicationTag string `json:"application-tag"`
+
+	// DestroyStorage controls whether or not storage attached to
+	// units of the application should be destroyed.
+	DestroyStorage bool `json:"destroy-storage,omitempty"`
 }
 
 // Creds holds credentials for identifying an entity.

--- a/state/modeloperation.go
+++ b/state/modeloperation.go
@@ -1,0 +1,38 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package state
+
+import (
+	"gopkg.in/mgo.v2/txn"
+)
+
+// ModelOperation is a high-level model operation,
+// encapsulating the logic required to apply a change
+// to a model.
+type ModelOperation interface {
+	// Build builds the low-level database transaction operations required
+	// to apply the change. If the transaction operations fail (e.g. due
+	// to concurrent changes), then Build may be called again. The attempt
+	// number, starting at zero, is passed in.
+	//
+	// Build is treated as a jujutxn.TransactionSource, so the errors
+	// in the jujutxn package may be returned by Build to influence
+	// transaction execution.
+	Build(attempt int) ([]txn.Op, error)
+
+	// Done is called after the operation is run, whether it succeeds or
+	// not. The result of running the operation is passed in, and the Done
+	// method may annotate the error; or run additional, non-transactional
+	// logic depending on the outcome.
+	Done(error) error
+}
+
+// ApplyOperation applies a given ModelOperation to the model.
+//
+// NOTE(axw) when all model-specific types and methods are moved
+// to Model, then this should move also.
+func (st *State) ApplyOperation(op ModelOperation) error {
+	err := st.db().Run(op.Build)
+	return op.Done(err)
+}

--- a/state/unit_test.go
+++ b/state/unit_test.go
@@ -462,7 +462,7 @@ func (s *UnitSuite) TestRemoveUnitMachineThrashed(c *gc.C) {
 	// retries.
 	defer state.SetTestHooks(c, s.State, flip, flop, flip).Check()
 
-	c.Assert(target.Destroy(), gc.ErrorMatches, "state changing too quickly; try again soon")
+	c.Assert(target.Destroy(), gc.ErrorMatches, `cannot destroy unit "wordpress/1": state changing too quickly; try again soon`)
 }
 
 func (s *UnitSuite) TestRemoveUnitMachineRetryVoter(c *gc.C) {


### PR DESCRIPTION
Add a --destroy-storage flag to the remove-unit and
remove-application commands. When this flag is
specified, the attached storage will be destroyed,
rather than detached.

---

We introduce state.ModelOperation, implementations of
which encapsulate the logic for building operations
for making changes to a model. Two implementations
are provided, for destroying units and applications.
Separating the building of operations from their
execution allows for customisation of the operations.
We could alternatively use parameter structs, as we
do elsewhere, but the approach taken should enable
us to work towards composable operations, as described
below.

For now, operations can only be executed in isolation,
via state.State.ApplyOperation. This is due to several
limitations:

 - It is unsafe to compose mgo/txn ops arbitrarily.
   We currently compose mgo/txn ops across collections,
   which is unsafe, but the changes are made in a way
   as to limit the damage of interrupted transactions,
   and these static compositions are tested.
 - There is an upper limit on how many operations can
   be safely included in a mgo/txn transaction, which
   we do sometimes reach.

Eventually, if/when we move to an alternative replication
mechanism such as Raft, then we can look at making these
operations composable. For example, it would make sense
to compose hypothetical AddApplication and Addunit
operations, making the "NumUnit" logic in AddApplication
redundant. This would enable us to move more of the
business logic out of the state package, keeping it
focused on model-checking.