### PR TITLE
Adding API methods to allow for DistributionGroup data to be used in the provisioner.

### DIFF
--- a/api/facadeversions.go
+++ b/api/facadeversions.go
@@ -69,7 +69,7 @@ var facadeVersions = map[string]int{
 	"Payloads":                     1,
 	"PayloadsHookContext":          1,
 	"Pinger":                       1,
-	"Provisioner":                  4,
+	"Provisioner":                  5,
 	"ProxyUpdater":                 1,
 	"Reboot":                       2,
 	"RelationStatusWatcher":        1,

--- a/apiserver/allfacades.go
+++ b/apiserver/allfacades.go
@@ -204,6 +204,7 @@ func AllFacades() *facade.Registry {
 	reg("Pinger", 1, NewPinger)
 	reg("Provisioner", 3, provisioner.NewProvisionerAPI)
 	reg("Provisioner", 4, provisioner.NewProvisionerAPI)
+	reg("Provisioner", 5, provisioner.NewProvisionerAPIV5) // v5 adds DistributionGroupByMachineId()
 	reg("ProxyUpdater", 1, proxyupdater.NewAPI)
 	reg("Reboot", 2, reboot.NewRebootAPI)
 	reg("RemoteRelations", 1, remoterelations.NewStateRemoteRelationsAPI)

--- a/apiserver/facades/agent/provisioner/provisioner_test.go
+++ b/apiserver/facades/agent/provisioner/provisioner_test.go
@@ -1007,7 +1007,123 @@ func (s *withoutControllerSuite) TestDistributionGroupMachineAgentAuth(c *gc.C) 
 	})
 }
 
-func (s *withoutControllerSuite) TestConstraints(c *gc.C) {
+func (s *withoutControllerSuite) TestDistributionGroupByMachineId(c *gc.C) {
+	addUnits := func(name string, machines ...*state.Machine) (units []*state.Unit) {
+		app := s.AddTestingApplication(c, name, s.AddTestingCharm(c, name))
+		for _, m := range machines {
+			unit, err := app.AddUnit(state.AddUnitParams{})
+			c.Assert(err, jc.ErrorIsNil)
+			err = unit.AssignToMachine(m)
+			c.Assert(err, jc.ErrorIsNil)
+			units = append(units, unit)
+		}
+		return units
+	}
+	setProvisioned := func(id string) {
+		m, err := s.State.Machine(id)
+		c.Assert(err, jc.ErrorIsNil)
+		err = m.SetProvisioned(instance.Id("machine-"+id+"-inst"), "nonce", nil)
+		c.Assert(err, jc.ErrorIsNil)
+	}
+
+	_ = addUnits("mysql", s.machines[0], s.machines[3])[0]
+	wordpressUnits := addUnits("wordpress", s.machines[0], s.machines[1], s.machines[2])
+
+	// Unassign wordpress/1 from machine-1.
+	// The unit should not show up in the results.
+	err := wordpressUnits[1].UnassignFromMachine()
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Provision machines 1, 2 and 3. Machine-0 remains
+	// unprovisioned.
+	setProvisioned("1")
+	setProvisioned("2")
+	setProvisioned("3")
+
+	// Add a few controllers, provision two of them.
+	_, err = s.State.EnableHA(3, constraints.Value{}, "quantal", nil)
+	c.Assert(err, jc.ErrorIsNil)
+	setProvisioned("5")
+	setProvisioned("7")
+
+	args := params.Entities{Entities: []params.Entity{
+		{Tag: s.machines[0].Tag().String()},
+		{Tag: s.machines[1].Tag().String()},
+		{Tag: s.machines[2].Tag().String()},
+		{Tag: s.machines[3].Tag().String()},
+		{Tag: "machine-5"},
+	}}
+	provisionerV5 := provisioner.ProvisionerAPIV5{s.provisioner}
+	result, err := provisionerV5.DistributionGroupByMachineId(args)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result, gc.DeepEquals, params.StringsResults{
+		Results: []params.StringsResult{
+			{Result: []string{"2", "3"}},
+			{Result: []string{}},
+			{Result: []string{"0"}},
+			{Result: []string{"0"}},
+			{Result: []string{"6", "7"}},
+		},
+	})
+}
+
+func (s *withoutControllerSuite) TestDistributionGroupByMachineIdEnvironManagerAuth(c *gc.C) {
+	args := params.Entities{Entities: []params.Entity{
+		{Tag: "machine-0"},
+		{Tag: "machine-42"},
+		{Tag: "machine-0-lxd-99"},
+		{Tag: "unit-foo-0"},
+		{Tag: "application-bar"},
+	}}
+	provisionerV5 := provisioner.ProvisionerAPIV5{s.provisioner}
+	result, err := provisionerV5.DistributionGroupByMachineId(args)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result, gc.DeepEquals, params.StringsResults{
+		Results: []params.StringsResult{
+			// environ manager may access any top-level machines.
+			{Result: []string{}, Error: nil},
+			{Result: nil, Error: apiservertesting.NotFoundError("machine 42")},
+			// only a machine agent for the container or its
+			// parent may access it.
+			{Result: nil, Error: apiservertesting.ErrUnauthorized},
+			// non-machines always unauthorized
+			{Result: nil, Error: apiservertesting.ErrUnauthorized},
+			{Result: nil, Error: apiservertesting.ErrUnauthorized},
+		},
+	})
+}
+
+func (s *withoutControllerSuite) TestDistributionGroupByMachineIdMachineAgentAuth(c *gc.C) {
+	anAuthorizer := s.authorizer
+	anAuthorizer.Tag = names.NewMachineTag("1")
+	anAuthorizer.Controller = false
+	provisionerV5, err := provisioner.NewProvisionerAPIV5(s.State, s.resources, anAuthorizer)
+	c.Check(err, jc.ErrorIsNil)
+	args := params.Entities{Entities: []params.Entity{
+		{Tag: "machine-0"},
+		{Tag: "machine-1"},
+		{Tag: "machine-42"},
+		{Tag: "machine-0-lxd-99"},
+		{Tag: "machine-1-lxd-99"},
+		{Tag: "machine-1-lxd-99-lxd-100"},
+	}}
+	result, err := provisionerV5.DistributionGroupByMachineId(args)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result, gc.DeepEquals, params.StringsResults{
+		Results: []params.StringsResult{
+			{Result: nil, Error: apiservertesting.ErrUnauthorized},
+			{Result: []string{}, Error: nil},
+			{Result: nil, Error: apiservertesting.ErrUnauthorized},
+			// only a machine agent for the container or its
+			// parent may access it.
+			{Result: nil, Error: apiservertesting.ErrUnauthorized},
+			{Result: nil, Error: apiservertesting.NotFoundError("machine 1/lxd/99")},
+			{Result: nil, Error: apiservertesting.ErrUnauthorized},
+		},
+	})
+}
+
+func (s *provisionerSuite) TestConstraints(c *gc.C) {
 	// Add a machine with some constraints.
 	cons := constraints.MustParse("cores=123", "mem=8G")
 	template := state.MachineTemplate{

--- a/state/distribution.go
+++ b/state/distribution.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 
 	"github.com/juju/errors"
+	"github.com/juju/utils/set"
 
 	"github.com/juju/juju/instance"
 )
@@ -70,4 +71,25 @@ func ServiceInstances(st *State, application string) ([]instance.Id, error) {
 		}
 	}
 	return instanceIds, nil
+}
+
+// ApplicationMachines returns the machine IDs of machines which have
+// the specified application listed as a principal.
+func ApplicationMachines(st *State, application string) ([]string, error) {
+	machines, err := st.AllMachines()
+	if err != nil {
+		return nil, err
+	}
+	applicationName := unitAppName(application)
+	var machineIds []string
+	for _, machine := range machines {
+		principalSet := set.NewStrings()
+		for _, principal := range machine.Principals() {
+			principalSet.Add(unitAppName(principal))
+		}
+		if principalSet.Contains(applicationName) {
+			machineIds = append(machineIds, machine.Id())
+		}
+	}
+	return machineIds, nil
 }

--- a/state/distribution_test.go
+++ b/state/distribution_test.go
@@ -180,3 +180,64 @@ func (s *InstanceDistributorSuite) TestDistributeInstancesNoPolicy(c *gc.C) {
 	_, err = unit.AssignToCleanMachine()
 	c.Assert(err, jc.ErrorIsNil)
 }
+
+type ApplicationMachinesSuite struct {
+	ConnSuite
+	wordpress *state.Application
+	mysql     *state.Application
+	machines  []*state.Machine
+}
+
+var _ = gc.Suite(&ApplicationMachinesSuite{})
+
+func (s *ApplicationMachinesSuite) SetUpTest(c *gc.C) {
+	s.ConnSuite.SetUpTest(c)
+
+	s.wordpress = s.AddTestingApplication(
+		c,
+		"wordpress",
+		s.AddTestingCharm(c, "wordpress"),
+	)
+	s.mysql = s.AddTestingApplication(
+		c,
+		"mysql",
+		s.AddTestingCharm(c, "mysql"),
+	)
+
+	s.machines = make([]*state.Machine, 5)
+	for i := range s.machines {
+		var err error
+		s.machines[i], err = s.State.AddOneMachine(state.MachineTemplate{
+			Series: "quantal",
+			Jobs:   []state.MachineJob{state.JobHostUnits},
+		})
+		c.Assert(err, jc.ErrorIsNil)
+	}
+
+	for _, i := range []int{0, 1, 4} {
+		unit, err := s.wordpress.AddUnit(state.AddUnitParams{})
+		c.Assert(err, jc.ErrorIsNil)
+		err = unit.AssignToMachine(s.machines[i])
+		c.Assert(err, jc.ErrorIsNil)
+	}
+	for _, i := range []int{2, 3} {
+		unit, err := s.mysql.AddUnit(state.AddUnitParams{})
+		c.Assert(err, jc.ErrorIsNil)
+		err = unit.AssignToMachine(s.machines[i])
+		c.Assert(err, jc.ErrorIsNil)
+	}
+}
+
+func (s *ApplicationMachinesSuite) TestApplicationMachines(c *gc.C) {
+	machines, err := state.ApplicationMachines(s.State, "mysql")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(machines, gc.DeepEquals, []string{"2", "3"})
+
+	machines, err = state.ApplicationMachines(s.State, "wordpress")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(machines, gc.DeepEquals, []string{"0", "1", "4"})
+
+	machines, err = state.ApplicationMachines(s.State, "fred")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(len(machines), gc.Equals, 0)
+}


### PR DESCRIPTION
## Description of change

To parallelizing the provisioner, choosing an availability zone for a new instance will need to move 
from the providers to the provisioner.  This PR provides methods for DistributionGroup data to be
retrieved from within the provisioner for use in choosing the appropriate availability zone for a
new machine.

## QA steps

Run unit tests.

## Documentation changes

No

## Bug reference

https://bugs.launchpad.net/juju/+bug/1692493