### PR TITLE
Remove support for firewall blacklists

### DIFF
--- a/api/firewallrules/client.go
+++ b/api/firewallrules/client.go
@@ -24,7 +24,7 @@ func NewClient(st base.APICallCloser) *Client {
 }
 
 // SetFirewallRule creates or updates a firewall rule.
-func (c *Client) SetFirewallRule(service string, whiteListCidrs, blackListCidrs []string) error {
+func (c *Client) SetFirewallRule(service string, whiteListCidrs []string) error {
 	serviceValue := params.KnownServiceValue(service)
 	if err := serviceValue.Validate(); err != nil {
 		return errors.Trace(err)
@@ -32,9 +32,9 @@ func (c *Client) SetFirewallRule(service string, whiteListCidrs, blackListCidrs 
 
 	args := params.FirewallRuleArgs{
 		Args: []params.FirewallRule{
-			{KnownService: serviceValue,
+			{
+				KnownService:   serviceValue,
 				WhitelistCIDRS: whiteListCidrs,
-				BlacklistCIDRS: blackListCidrs,
 			}},
 	}
 	var results params.ErrorResults

--- a/api/firewallrules/client_test.go
+++ b/api/firewallrules/client_test.go
@@ -39,7 +39,6 @@ func (s *FirewallRulesSuite) TestSetFirewallRule(c *gc.C) {
 			rule := args.Args[0]
 			c.Assert(rule.KnownService, gc.Equals, params.SSHRule)
 			c.Assert(rule.WhitelistCIDRS, jc.DeepEquals, []string{"192.168.1.0/32"})
-			c.Assert(rule.BlacklistCIDRS, jc.DeepEquals, []string{"10.0.0.0/8"})
 
 			if results, ok := result.(*params.ErrorResults); ok {
 				results.Results = []params.ErrorResult{{
@@ -49,7 +48,7 @@ func (s *FirewallRulesSuite) TestSetFirewallRule(c *gc.C) {
 		})
 
 	client := firewallrules.NewClient(apiCaller)
-	err := client.SetFirewallRule("ssh", []string{"192.168.1.0/32"}, []string{"10.0.0.0/8"})
+	err := client.SetFirewallRule("ssh", []string{"192.168.1.0/32"})
 	c.Assert(err, gc.ErrorMatches, "fail")
 }
 
@@ -67,7 +66,7 @@ func (s *FirewallRulesSuite) TestSetFirewallRuleFacadeCallError(c *gc.C) {
 			return errors.New(msg)
 		})
 	client := firewallrules.NewClient(apiCaller)
-	err := client.SetFirewallRule("ssh", nil, nil)
+	err := client.SetFirewallRule("ssh", nil)
 	c.Assert(errors.Cause(err), gc.ErrorMatches, msg)
 }
 
@@ -83,7 +82,7 @@ func (s *FirewallRulesSuite) TestSetFirewallRuleInvalid(c *gc.C) {
 		})
 
 	client := firewallrules.NewClient(apiCaller)
-	err := client.SetFirewallRule("foo", []string{"192.168.1.0/32"}, []string{"10.0.0.0/8"})
+	err := client.SetFirewallRule("foo", []string{"192.168.1.0/32"})
 	c.Assert(err, gc.ErrorMatches, `known service "foo" not valid`)
 }
 
@@ -106,7 +105,6 @@ func (s *FirewallRulesSuite) TestList(c *gc.C) {
 				results.Rules = []params.FirewallRule{{
 					KnownService:   params.SSHRule,
 					WhitelistCIDRS: []string{"192.168.1.0/32"},
-					BlacklistCIDRS: []string{"10.0.0.0/8"},
 				}}
 			}
 			return nil
@@ -119,7 +117,6 @@ func (s *FirewallRulesSuite) TestList(c *gc.C) {
 	c.Assert(results, jc.DeepEquals, []params.FirewallRule{{
 		KnownService:   params.SSHRule,
 		WhitelistCIDRS: []string{"192.168.1.0/32"},
-		BlacklistCIDRS: []string{"10.0.0.0/8"},
 	}})
 }
 

--- a/apiserver/common/crossmodel/crossmodel.go
+++ b/apiserver/common/crossmodel/crossmodel.go
@@ -227,11 +227,8 @@ func validateIngressNetworks(backend Backend, networks []string) error {
 	if errors.IsNotFound(err) {
 		return nil
 	}
-	var whitelistCIDRs, blacklistCIDRs, requestedCIDRs []*net.IPNet
+	var whitelistCIDRs, requestedCIDRs []*net.IPNet
 	if err := parseCIDRs(&whitelistCIDRs, rule.WhitelistCIDRs); err != nil {
-		return errors.Trace(err)
-	}
-	if err := parseCIDRs(&blacklistCIDRs, rule.BlacklistCIDRs); err != nil {
 		return errors.Trace(err)
 	}
 	if err := parseCIDRs(&requestedCIDRs, networks); err != nil {
@@ -243,16 +240,6 @@ func validateIngressNetworks(backend Backend, networks []string) error {
 				return &params.Error{
 					Code:    params.CodeForbidden,
 					Message: fmt.Sprintf("subnet %v not in firewall whitelist", n),
-				}
-			}
-		}
-	}
-	if len(blacklistCIDRs) > 0 {
-		for _, n := range requestedCIDRs {
-			if network.SubnetInAnyRange(whitelistCIDRs, n) {
-				return &params.Error{
-					Code:    params.CodeForbidden,
-					Message: fmt.Sprintf("subnet %v in firewall blacklist", n),
 				}
 			}
 		}

--- a/apiserver/facades/client/firewallrules/firewallrules.go
+++ b/apiserver/facades/client/firewallrules/firewallrules.go
@@ -89,7 +89,6 @@ func (api *API) SetFirewallRules(args params.FirewallRuleArgs) (params.ErrorResu
 		err := api.backend.SaveFirewallRule(state.FirewallRule{
 			WellKnownService: state.WellKnownServiceType(arg.KnownService),
 			WhitelistCIDRs:   arg.WhitelistCIDRS,
-			BlacklistCIDRs:   arg.BlacklistCIDRS,
 		})
 		results[i].Error = common.ServerError(err)
 	}
@@ -115,7 +114,6 @@ func (api *API) ListFirewallRules() (params.ListFirewallRulesResults, error) {
 		listResults.Rules[i] = params.FirewallRule{
 			KnownService:   params.KnownServiceValue(r.WellKnownService),
 			WhitelistCIDRS: r.WhitelistCIDRs,
-			BlacklistCIDRS: r.BlacklistCIDRs,
 		}
 	}
 	return listResults, nil

--- a/apiserver/facades/client/firewallrules/firewallrules_test.go
+++ b/apiserver/facades/client/firewallrules/firewallrules_test.go
@@ -70,7 +70,6 @@ func (s *FirewallRulesSuite) TestSetFirewallRules(c *gc.C) {
 		Args: []params.FirewallRule{{
 			KnownService:   "juju-controller",
 			WhitelistCIDRS: []string{"1.2.3.4/8"},
-			BlacklistCIDRS: []string{"4.3.2.1/8"},
 		}},
 	})
 	c.Assert(err, jc.ErrorIsNil)
@@ -78,7 +77,6 @@ func (s *FirewallRulesSuite) TestSetFirewallRules(c *gc.C) {
 	c.Assert(s.backend.rules["juju-controller"], jc.DeepEquals, state.FirewallRule{
 		WellKnownService: state.JujuControllerRule,
 		WhitelistCIDRs:   []string{"1.2.3.4/8"},
-		BlacklistCIDRs:   []string{"4.3.2.1/8"},
 	})
 }
 
@@ -88,7 +86,6 @@ func (s *FirewallRulesSuite) TestSetFirewallRulesPermission(c *gc.C) {
 		Args: []params.FirewallRule{{
 			KnownService:   "juju-controller",
 			WhitelistCIDRS: []string{"1.2.3.4/8"},
-			BlacklistCIDRS: []string{"4.3.2.1/8"},
 		}},
 	})
 	c.Assert(err, gc.ErrorMatches, ".*permission denied.*")
@@ -101,7 +98,6 @@ func (s *FirewallRulesSuite) TestSetFirewallRulesBlocked(c *gc.C) {
 		Args: []params.FirewallRule{{
 			KnownService:   "juju-controller",
 			WhitelistCIDRS: []string{"1.2.3.4/8"},
-			BlacklistCIDRS: []string{"4.3.2.1/8"},
 		}},
 	})
 	c.Assert(err, gc.ErrorMatches, "blocked")
@@ -116,7 +112,6 @@ func (s *FirewallRulesSuite) TestListFirewallRules(c *gc.C) {
 		Rules: []params.FirewallRule{{
 			KnownService:   params.JujuApplicationOfferRule,
 			WhitelistCIDRS: []string{"1.2.3.4/8"},
-			BlacklistCIDRS: []string{"4.3.2.1/8"},
 		}}})
 }
 

--- a/apiserver/facades/client/firewallrules/mock_test.go
+++ b/apiserver/facades/client/firewallrules/mock_test.go
@@ -43,7 +43,6 @@ func (m *mockBackend) ListFirewallRules() ([]*state.FirewallRule, error) {
 		{
 			WellKnownService: state.JujuApplicationOfferRule,
 			WhitelistCIDRs:   []string{"1.2.3.4/8"},
-			BlacklistCIDRs:   []string{"4.3.2.1/8"},
 		},
 	}, nil
 }

--- a/apiserver/params/firewall.go
+++ b/apiserver/params/firewall.go
@@ -25,9 +25,6 @@ type FirewallRule struct {
 
 	// WhitelistCIDRS is the ist of subnets allowed access.
 	WhitelistCIDRS []string `json:"whitelist-cidrs,omitempty"`
-
-	// BlacklistCIDRS is the ist of subnets denied access.
-	BlacklistCIDRS []string `json:"blacklist-cidrs,omitempty"`
 }
 
 // KnownServiceValue describes a well known service for which a

--- a/cmd/juju/firewall/listformatter.go
+++ b/cmd/juju/firewall/listformatter.go
@@ -16,7 +16,6 @@ import (
 type firewallRule struct {
 	KnownService   string   `yaml:"known-service" json:"known-service"`
 	WhitelistCIDRS []string `yaml:"whitelist-subnets,omitempty" json:"whitelist-subnets,omitempty"`
-	BlacklistCIDRS []string `yaml:"blacklist-subnets,omitempty" json:"blacklist-subnets,omitempty"`
 }
 
 type firewallRules []firewallRule
@@ -43,9 +42,9 @@ func formatFirewallRulesTabular(writer io.Writer, rules firewallRules) {
 
 	sort.Sort(rules)
 
-	w.Println("Service", "Whitelist subnets", "Blacklist subnets")
+	w.Println("Service", "Whitelist subnets")
 	for _, rule := range rules {
-		w.Println(rule.KnownService, strings.Join(rule.WhitelistCIDRS, ","), strings.Join(rule.BlacklistCIDRS, ","))
+		w.Println(rule.KnownService, strings.Join(rule.WhitelistCIDRS, ","))
 	}
 	tw.Flush()
 }

--- a/cmd/juju/firewall/listrules.go
+++ b/cmd/juju/firewall/listrules.go
@@ -95,7 +95,6 @@ func (c *listFirewallRulesCommand) Run(ctx *cmd.Context) error {
 		rules[i] = firewallRule{
 			KnownService:   string(r.KnownService),
 			WhitelistCIDRS: r.WhitelistCIDRS,
-			BlacklistCIDRS: r.BlacklistCIDRS,
 		}
 	}
 	return c.out.Write(ctx, rules)

--- a/cmd/juju/firewall/listrules_test.go
+++ b/cmd/juju/firewall/listrules_test.go
@@ -31,7 +31,6 @@ func (s *ListSuite) SetUpTest(c *gc.C) {
 			{
 				KnownService:   "ssh",
 				WhitelistCIDRS: []string{"192.168.1.0/16", "10.0.0.0/8"},
-				BlacklistCIDRS: []string{"10.1.0.0/16"},
 			}, {
 				KnownService:   "juju-controller",
 				WhitelistCIDRS: []string{"10.2.0.0/16"},
@@ -51,9 +50,9 @@ func (s *ListSuite) TestListTabular(c *gc.C) {
 		c,
 		[]string{"--format", "tabular"},
 		`
-Service          Whitelist subnets          Blacklist subnets
-juju-controller  10.2.0.0/16                
-ssh              192.168.1.0/16,10.0.0.0/8  10.1.0.0/16
+Service          Whitelist subnets
+juju-controller  10.2.0.0/16
+ssh              192.168.1.0/16,10.0.0.0/8
 
 `[1:],
 		"",
@@ -69,8 +68,6 @@ func (s *ListSuite) TestListYAML(c *gc.C) {
   whitelist-subnets:
   - 192.168.1.0/16
   - 10.0.0.0/8
-  blacklist-subnets:
-  - 10.1.0.0/16
 - known-service: juju-controller
   whitelist-subnets:
   - 10.2.0.0/16

--- a/featuretests/cmd_juju_firewallrules_test.go
+++ b/featuretests/cmd_juju_firewallrules_test.go
@@ -19,7 +19,7 @@ type FirewallRulesSuite struct {
 }
 
 func (s *FirewallRulesSuite) TestFirewallRules(c *gc.C) {
-	_, err := cmdtesting.RunCommand(c, firewall.NewSetFirewallRuleCommand(), "ssh", "--whitelist", "192.168.1.0/16", "--blacklist", "10.0.0.0/8")
+	_, err := cmdtesting.RunCommand(c, firewall.NewSetFirewallRuleCommand(), "ssh", "--whitelist", "192.168.1.0/16")
 	c.Assert(err, jc.ErrorIsNil)
 	ctx, err := cmdtesting.RunCommand(c, firewall.NewListFirewallRulesCommand(), "--format", "yaml")
 	c.Assert(err, jc.ErrorIsNil)
@@ -27,7 +27,5 @@ func (s *FirewallRulesSuite) TestFirewallRules(c *gc.C) {
 - known-service: ssh
   whitelist-subnets:
   - 192.168.1.0/16
-  blacklist-subnets:
-  - 10.0.0.0/8
 `[1:])
 }


### PR DESCRIPTION
## Description of change

Remove support for firewall rule blacklists as we won't support that first up.

## QA steps

Test CMR with firewall rule whitelists.

