### PR TITLE
import-filesystem: update help text

### DIFF
--- a/cmd/juju/storage/import.go
+++ b/cmd/juju/storage/import.go
@@ -56,9 +56,8 @@ that is in use by another Juju model.
 
 To import a filesystem, you must specify three things:
 
- - the storage pool, which identifies the storage provider
-   which manages the storage; and with which the storage
-   will be associated
+ - the storage provider which manages the storage, and with
+   which the storage will be associated
  - the storage provider ID for the filesystem, or
    volume that backs the filesystem
  - the storage name to assign to the filesystem,
@@ -75,7 +74,7 @@ Examples:
     juju import-filesystem ebs vol-123456 pgdata
 `
 	importFilesystemCommandAgs = `
-<storage-provider|pool> <filesystem|volume-id> <storage-name>
+<storage-provider> <provider-id> <storage-name>
 `
 )
 
@@ -92,7 +91,7 @@ type importFilesystemCommand struct {
 // Init implements Command.Init.
 func (c *importFilesystemCommand) Init(args []string) error {
 	if len(args) < 3 {
-		return errors.New("import-filesystem requires a storage pool, provider ID, and storage name")
+		return errors.New("import-filesystem requires a storage provider, provider ID, and storage name")
 	}
 	c.storagePool = args[0]
 	c.storageProviderId = args[1]

--- a/cmd/juju/storage/import_test.go
+++ b/cmd/juju/storage/import_test.go
@@ -35,7 +35,7 @@ var initErrorTests = []struct {
 	expectedErr string
 }{{
 	args:        []string{"foo", "bar"},
-	expectedErr: "import-filesystem requires a storage pool, provider ID, and storage name",
+	expectedErr: "import-filesystem requires a storage provider, provider ID, and storage name",
 }, {
 	args:        []string{"123", "foo", "bar"},
 	expectedErr: `pool name "123" not valid`,


### PR DESCRIPTION
## Description of change

Update the help text of import-filesystem based on feedback.

Use "storage provider" rather than "storage provider or pool". Right now it's using pools underneath, but only because we don't model storage sources (instantiations of a storage provider with alternative configurations).

Use "provider ID" to make it clear that it's a storage provider ID, and not a numeric volume or filesystem ID assigned by Juju.

## QA steps

1. juju import-filesystem -h
2. read and understand output

## Documentation changes

I don't think so, but: CC @pmatulis.

## Bug reference

None.