### PR TITLE
Prevent removal of application if used by an offer; prevent removal of an offer if there are connections

### DIFF
--- a/state/application.go
+++ b/state/application.go
@@ -200,6 +200,14 @@ func (a *Application) destroyOps() ([]txn.Op, error) {
 		return nil, errors.Trace(err)
 	}
 	ops = append(ops, resOps...)
+
+	// We can't delete an application if it is being offered.
+	zeroOffers, err := zeroApplicationOffersRefOp(a.st, a.Name())
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	ops = append(ops, zeroOffers)
+
 	// If the application has no units, and all its known relations will be
 	// removed, the application can also be removed.
 	if a.doc.UnitCount == 0 && a.doc.RelationCount == removeCount {
@@ -1375,6 +1383,52 @@ func (a *Application) addUnitOpsWithCons(args applicationAddUnitOpsArgs) (string
 	probablyUpdateStatusHistory(a.st.db(), agentGlobalKey, agentStatusDoc)
 	probablyUpdateStatusHistory(a.st.db(), globalWorkloadVersionKey(name), workloadVersionDoc)
 	return name, ops, nil
+}
+
+// applicationOffersRefCountKey returns a key for refcounting offers
+// for the specified application. Each time an offer is created, the
+// refcount is incremented, and the opposite happens on removal.
+func applicationOffersRefCountKey(appName string) string {
+	return fmt.Sprintf("offer#%s", appName)
+}
+
+// incApplicationOffersRefOp returns a txn.Op that increments the reference
+// count for an application offer.
+func incApplicationOffersRefOp(mb modelBackend, appName string) (txn.Op, error) {
+	refcounts, closer := mb.db().GetCollection(refcountsC)
+	defer closer()
+	offerRefCountKey := applicationOffersRefCountKey(appName)
+	incRefOp, err := nsRefcounts.CreateOrIncRefOp(refcounts, offerRefCountKey, 1)
+	return incRefOp, errors.Trace(err)
+}
+
+// zeroApplicationOffersRefOp returns a txn.Op that ensures that the offer
+// refcount remains at zero, and an error if it is not zero to start with.
+func zeroApplicationOffersRefOp(mb modelBackend, appName string) (txn.Op, error) {
+	refcounts, closer := mb.db().GetCollection(refcountsC)
+	defer closer()
+	key := applicationOffersRefCountKey(appName)
+	op, current, err := nsRefcounts.CurrentOp(refcounts, key)
+	if err != nil {
+		return op, errors.Trace(err)
+	}
+	if current > 0 {
+		return op, errors.Errorf("application is used by %d offer%s", current, plural(current))
+	}
+	return op, nil
+}
+
+// decApplicationOffersRefOp returns a txn.Op that decrements the reference
+// count for an application offer.
+func decApplicationOffersRefOp(mb modelBackend, appName string) (txn.Op, error) {
+	refcounts, closer := mb.db().GetCollection(refcountsC)
+	defer closer()
+	offerRefCountKey := applicationOffersRefCountKey(appName)
+	decRefOp, _, err := nsRefcounts.DyingDecRefOp(refcounts, offerRefCountKey)
+	if err != nil {
+		return txn.Op{}, errors.Trace(err)
+	}
+	return decRefOp, nil
 }
 
 // incUnitCountOp returns the operation to increment the application's unit count.

--- a/state/application_test.go
+++ b/state/application_test.go
@@ -19,6 +19,7 @@ import (
 	"gopkg.in/mgo.v2/txn"
 
 	"github.com/juju/juju/constraints"
+	"github.com/juju/juju/core/crossmodel"
 	"github.com/juju/juju/resource/resourcetesting"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/testing"
@@ -1190,13 +1191,13 @@ func (s *ApplicationSuite) TestUpdateApplicationSeriesSecondSubordinateIncompati
 	assertApplicationSeriesUpdate(c, subApp2, "precise")
 }
 
-func assertNoSettingsRef(c *gc.C, st *state.State, svcName string, sch *state.Charm) {
-	_, err := state.ServiceSettingsRefCount(st, svcName, sch.URL())
+func assertNoSettingsRef(c *gc.C, st *state.State, appName string, sch *state.Charm) {
+	_, err := state.ApplicationSettingsRefCount(st, appName, sch.URL())
 	c.Assert(errors.Cause(err), jc.Satisfies, errors.IsNotFound)
 }
 
-func assertSettingsRef(c *gc.C, st *state.State, svcName string, sch *state.Charm, refcount int) {
-	rc, err := state.ServiceSettingsRefCount(st, svcName, sch.URL())
+func assertSettingsRef(c *gc.C, st *state.State, appName string, sch *state.Charm, refcount int) {
+	rc, err := state.ApplicationSettingsRefCount(st, appName, sch.URL())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(rc, gc.Equals, refcount)
 }
@@ -1206,23 +1207,23 @@ func (s *ApplicationSuite) TestSettingsRefCountWorks(c *gc.C) {
 	// properly reference counted.
 	oldCh := s.AddConfigCharm(c, "wordpress", emptyConfig, 1)
 	newCh := s.AddConfigCharm(c, "wordpress", emptyConfig, 2)
-	svcName := "mywp"
+	appName := "mywp"
 
 	// Both refcounts are zero initially.
-	assertNoSettingsRef(c, s.State, svcName, oldCh)
-	assertNoSettingsRef(c, s.State, svcName, newCh)
+	assertNoSettingsRef(c, s.State, appName, oldCh)
+	assertNoSettingsRef(c, s.State, appName, newCh)
 
 	// app is using oldCh, so its settings refcount is incremented.
-	app := s.AddTestingApplication(c, svcName, oldCh)
-	assertSettingsRef(c, s.State, svcName, oldCh, 1)
-	assertNoSettingsRef(c, s.State, svcName, newCh)
+	app := s.AddTestingApplication(c, appName, oldCh)
+	assertSettingsRef(c, s.State, appName, oldCh, 1)
+	assertNoSettingsRef(c, s.State, appName, newCh)
 
 	// Changing to the same charm does not change the refcount.
 	cfg := state.SetCharmConfig{Charm: oldCh}
 	err := app.SetCharm(cfg)
 	c.Assert(err, jc.ErrorIsNil)
-	assertSettingsRef(c, s.State, svcName, oldCh, 1)
-	assertNoSettingsRef(c, s.State, svcName, newCh)
+	assertSettingsRef(c, s.State, appName, oldCh, 1)
+	assertNoSettingsRef(c, s.State, appName, newCh)
 
 	// Changing from oldCh to newCh causes the refcount of oldCh's
 	// settings to be decremented, while newCh's settings is
@@ -1231,15 +1232,15 @@ func (s *ApplicationSuite) TestSettingsRefCountWorks(c *gc.C) {
 	cfg = state.SetCharmConfig{Charm: newCh}
 	err = app.SetCharm(cfg)
 	c.Assert(err, jc.ErrorIsNil)
-	assertNoSettingsRef(c, s.State, svcName, oldCh)
-	assertSettingsRef(c, s.State, svcName, newCh, 1)
+	assertNoSettingsRef(c, s.State, appName, oldCh)
+	assertSettingsRef(c, s.State, appName, newCh, 1)
 
 	// The same but newCh swapped with oldCh.
 	cfg = state.SetCharmConfig{Charm: oldCh}
 	err = app.SetCharm(cfg)
 	c.Assert(err, jc.ErrorIsNil)
-	assertSettingsRef(c, s.State, svcName, oldCh, 1)
-	assertNoSettingsRef(c, s.State, svcName, newCh)
+	assertSettingsRef(c, s.State, appName, oldCh, 1)
+	assertNoSettingsRef(c, s.State, appName, newCh)
 
 	// Adding a unit without a charm URL set does not affect the
 	// refcount.
@@ -1247,8 +1248,8 @@ func (s *ApplicationSuite) TestSettingsRefCountWorks(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	curl, ok := u.CharmURL()
 	c.Assert(ok, jc.IsFalse)
-	assertSettingsRef(c, s.State, svcName, oldCh, 1)
-	assertNoSettingsRef(c, s.State, svcName, newCh)
+	assertSettingsRef(c, s.State, appName, oldCh, 1)
+	assertNoSettingsRef(c, s.State, appName, newCh)
 
 	// Setting oldCh as the units charm URL increments oldCh, which is
 	// used by app as well, hence 2.
@@ -1257,27 +1258,27 @@ func (s *ApplicationSuite) TestSettingsRefCountWorks(c *gc.C) {
 	curl, ok = u.CharmURL()
 	c.Assert(ok, jc.IsTrue)
 	c.Assert(curl, gc.DeepEquals, oldCh.URL())
-	assertSettingsRef(c, s.State, svcName, oldCh, 2)
-	assertNoSettingsRef(c, s.State, svcName, newCh)
+	assertSettingsRef(c, s.State, appName, oldCh, 2)
+	assertNoSettingsRef(c, s.State, appName, newCh)
 
 	// A dead unit does not decrement the refcount.
 	err = u.EnsureDead()
 	c.Assert(err, jc.ErrorIsNil)
-	assertSettingsRef(c, s.State, svcName, oldCh, 2)
-	assertNoSettingsRef(c, s.State, svcName, newCh)
+	assertSettingsRef(c, s.State, appName, oldCh, 2)
+	assertNoSettingsRef(c, s.State, appName, newCh)
 
 	// Once the unit is removed, refcount is decremented.
 	err = u.Remove()
 	c.Assert(err, jc.ErrorIsNil)
-	assertSettingsRef(c, s.State, svcName, oldCh, 1)
-	assertNoSettingsRef(c, s.State, svcName, newCh)
+	assertSettingsRef(c, s.State, appName, oldCh, 1)
+	assertNoSettingsRef(c, s.State, appName, newCh)
 
-	// Finally, after the service is destroyed and removed (since the
+	// Finally, after the application is destroyed and removed (since the
 	// last unit's gone), the refcount is again decremented.
 	err = app.Destroy()
 	c.Assert(err, jc.ErrorIsNil)
-	assertNoSettingsRef(c, s.State, svcName, oldCh)
-	assertNoSettingsRef(c, s.State, svcName, newCh)
+	assertNoSettingsRef(c, s.State, appName, oldCh)
+	assertNoSettingsRef(c, s.State, appName, newCh)
 
 	// Having studiously avoided triggering cleanups throughout,
 	// invoke them now and check that the charms are cleaned up
@@ -1342,6 +1343,78 @@ func (s *ApplicationSuite) TestSettingsRefRemoveRace(c *gc.C) {
 	assertSettingsRef(c, s.State, appName, newCh, 1)
 }
 
+func assertNoOffersRef(c *gc.C, st *state.State, appName string) {
+	_, err := state.ApplicationOffersRefCount(st, appName)
+	c.Assert(errors.Cause(err), jc.Satisfies, errors.IsNotFound)
+}
+
+func assertOffersRef(c *gc.C, st *state.State, appName string, refcount int) {
+	rc, err := state.ApplicationOffersRefCount(st, appName)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(rc, gc.Equals, refcount)
+}
+
+func (s *ApplicationSuite) TestOffersRefCountWorks(c *gc.C) {
+	// Refcounts are zero initially.
+	assertNoOffersRef(c, s.State, "mysql")
+
+	ao := state.NewApplicationOffers(s.State)
+	_, err := ao.AddOffer(crossmodel.AddApplicationOfferArgs{
+		OfferName:       "hosted-mysql",
+		ApplicationName: "mysql",
+		Endpoints:       map[string]string{"server": "server"},
+		Owner:           s.Owner.Id(),
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	assertOffersRef(c, s.State, "mysql", 1)
+
+	_, err = ao.AddOffer(crossmodel.AddApplicationOfferArgs{
+		OfferName:       "mysql-offer",
+		ApplicationName: "mysql",
+		Endpoints:       map[string]string{"server": "server"},
+		Owner:           s.Owner.Id(),
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	assertOffersRef(c, s.State, "mysql", 2)
+
+	// Once the offer is removed, refcount is decremented.
+	err = ao.Remove("hosted-mysql")
+	c.Assert(err, jc.ErrorIsNil)
+	assertOffersRef(c, s.State, "mysql", 1)
+
+	// Trying to destroy the app while there is an offer fails.
+	err = s.mysql.Destroy()
+	c.Assert(err, gc.ErrorMatches, `cannot destroy application "mysql": application is used by 1 offer`)
+	assertOffersRef(c, s.State, "mysql", 1)
+
+	// Remove the last offer and the app can be destroyed.
+	err = ao.Remove("mysql-offer")
+	c.Assert(err, jc.ErrorIsNil)
+	assertNoOffersRef(c, s.State, "mysql")
+
+	err = s.mysql.Destroy()
+	c.Assert(err, jc.ErrorIsNil)
+	assertNoOffersRef(c, s.State, "mysql")
+}
+
+func (s *ApplicationSuite) TestOffersRefRace(c *gc.C) {
+	addOffer := func() {
+		ao := state.NewApplicationOffers(s.State)
+		_, err := ao.AddOffer(crossmodel.AddApplicationOfferArgs{
+			OfferName:       "hosted-mysql",
+			ApplicationName: "mysql",
+			Endpoints:       map[string]string{"server": "server"},
+			Owner:           s.Owner.Id(),
+		})
+		c.Assert(err, jc.ErrorIsNil)
+	}
+	defer state.SetBeforeHooks(c, s.State, addOffer).Check()
+
+	err := s.mysql.Destroy()
+	c.Assert(err, gc.ErrorMatches, `cannot destroy application "mysql": application is used by 1 offer`)
+	assertOffersRef(c, s.State, "mysql", 1)
+}
+
 const mysqlBaseMeta = `
 name: mysql
 summary: "Database engine"
@@ -1359,8 +1432,8 @@ peers:
   loadbalancer: phony
 `
 
-func (s *ApplicationSuite) assertApplicationRelations(c *gc.C, svc *state.Application, expectedKeys ...string) []*state.Relation {
-	rels, err := svc.Relations()
+func (s *ApplicationSuite) assertApplicationRelations(c *gc.C, app *state.Application, expectedKeys ...string) []*state.Relation {
+	rels, err := app.Relations()
 	c.Assert(err, jc.ErrorIsNil)
 	if len(rels) == 0 {
 		return nil

--- a/state/applicationoffers.go
+++ b/state/applicationoffers.go
@@ -9,6 +9,7 @@ import (
 	"sort"
 
 	"github.com/juju/errors"
+	jujutxn "github.com/juju/txn"
 	"github.com/juju/utils"
 	"gopkg.in/juju/charm.v6-unstable"
 	"gopkg.in/juju/names.v2"
@@ -143,24 +144,55 @@ func (s *applicationOffers) AllApplicationOffers() (offers []*crossmodel.Applica
 // Remove deletes the application offer for offerName immediately.
 func (s *applicationOffers) Remove(offerName string) (err error) {
 	defer errors.DeferredAnnotatef(&err, "cannot delete application offer %q", offerName)
-	err = s.st.db().RunTransaction(s.removeOps(offerName))
-	if err == txn.ErrAborted {
-		// Already deleted.
-		return nil
+	buildTxn := func(attempt int) ([]txn.Op, error) {
+		offer, err := s.ApplicationOffer(offerName)
+		if errors.IsNotFound(err) {
+			return nil, jujutxn.ErrNoOperations
+		}
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		conns, err := s.st.OfferConnections(offer.OfferUUID)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		if len(conns) > 0 {
+			return nil, errors.Errorf("offer has %d relation%s", len(conns), plural(len(conns)))
+		}
+		ops, err := s.removeOps(offerName)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		return ops, nil
 	}
-	return err
+	err = s.st.db().Run(buildTxn)
+	return errors.Trace(err)
 }
 
 // removeOps returns the operations required to remove the record for offerName.
-func (s *applicationOffers) removeOps(offerName string) []txn.Op {
+func (s *applicationOffers) removeOps(offerName string) ([]txn.Op, error) {
+	offer, err := s.ApplicationOffer(offerName)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	decRefOp, err := decApplicationOffersRefOp(s.st, offer.ApplicationName)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	zeroRelCount := bson.D{{"relationcount", 0}}
+	zeroOp := txn.Op{
+		C:      applicationsC,
+		Id:     offer.ApplicationName,
+		Assert: zeroRelCount,
+	}
+
 	return []txn.Op{
 		{
 			C:      applicationOffersC,
 			Id:     offerName,
 			Assert: txn.DocExists,
 			Remove: true,
-		},
-	}
+		}, decRefOp, zeroOp}, nil
 }
 
 var errDuplicateApplicationOffer = errors.Errorf("application offer already exists")
@@ -219,6 +251,10 @@ func (s *applicationOffers) AddOffer(offerArgs crossmodel.AddApplicationOfferArg
 				return nil, errDuplicateApplicationOffer
 			}
 		}
+		incRefOp, err := incApplicationOffersRefOp(s.st, offerArgs.ApplicationName)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
 		ops := []txn.Op{
 			model.assertActiveOp(),
 			{
@@ -227,6 +263,7 @@ func (s *applicationOffers) AddOffer(offerArgs crossmodel.AddApplicationOfferArg
 				Assert: txn.DocMissing,
 				Insert: doc,
 			},
+			incRefOp,
 		}
 		return ops, nil
 	}
@@ -274,6 +311,18 @@ func (s *applicationOffers) UpdateOffer(offerArgs crossmodel.AddApplicationOffer
 		return nil, errors.Trace(err)
 	}
 	doc := s.makeApplicationOfferDoc(s.st, offer.OfferUUID, offerArgs)
+	var refOps []txn.Op
+	if offerArgs.ApplicationName != offer.ApplicationName {
+		incRefOp, err := incApplicationOffersRefOp(s.st, offerArgs.ApplicationName)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		decRefOp, err := decApplicationOffersRefOp(s.st, offer.ApplicationName)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		refOps = append(refOps, incRefOp, decRefOp)
+	}
 	buildTxn := func(attempt int) ([]txn.Op, error) {
 		// If we've tried once already and failed, check that
 		// environment may have been destroyed.
@@ -297,6 +346,7 @@ func (s *applicationOffers) UpdateOffer(offerArgs crossmodel.AddApplicationOffer
 				Update: bson.M{"$set": doc},
 			},
 		}
+		ops = append(ops, refOps...)
 		return ops, nil
 	}
 	err = s.st.db().Run(buildTxn)

--- a/state/export_test.go
+++ b/state/export_test.go
@@ -127,11 +127,19 @@ func (doc *MachineDoc) String() string {
 	return m.String()
 }
 
-func ServiceSettingsRefCount(st *State, appName string, curl *charm.URL) (int, error) {
+func ApplicationSettingsRefCount(st *State, appName string, curl *charm.URL) (int, error) {
 	refcounts, closer := st.db().GetCollection(refcountsC)
 	defer closer()
 
 	key := applicationSettingsKey(appName, curl)
+	return nsRefcounts.read(refcounts, key)
+}
+
+func ApplicationOffersRefCount(st *State, appName string) (int, error) {
+	refcounts, closer := st.db().GetCollection(refcountsC)
+	defer closer()
+
+	key := applicationOffersRefCountKey(appName)
 	return nsRefcounts.read(refcounts, key)
 }
 


### PR DESCRIPTION
## Description of change

When removing an application, do not allow if there's an offer for that application.
When removing an offer, do not allow if there are connections to the offer.

## QA steps

bootstrap and create an offer for an app
juju remove-application app
-> error message
Can't QA offer deletion until there is a CLI command for it.