### PR TITLE
Move UpdateModelConfigDefaultValues method to state.Model receiver.

### DIFF
--- a/apiserver/common/modelmanagerinterface.go
+++ b/apiserver/common/modelmanagerinterface.go
@@ -101,22 +101,28 @@ var _ ModelManagerBackend = (*modelManagerStateShim)(nil)
 
 type modelManagerStateShim struct {
 	*state.State
-	pool *state.StatePool
+	model *state.Model
+	pool  *state.StatePool
 }
 
 // NewModelManagerBackend returns a modelManagerStateShim wrapping the passed
 // state, which implements ModelManagerBackend.
-func NewModelManagerBackend(st *state.State, pool *state.StatePool) ModelManagerBackend {
-	return modelManagerStateShim{st, pool}
+func NewModelManagerBackend(m *state.Model, pool *state.StatePool) ModelManagerBackend {
+	return modelManagerStateShim{m.State(), m, pool}
 }
 
 // NewModel implements ModelManagerBackend.
 func (st modelManagerStateShim) NewModel(args state.ModelArgs) (Model, ModelManagerBackend, error) {
-	m, otherState, err := st.State.NewModel(args)
+	otherModel, otherState, err := st.State.NewModel(args)
 	if err != nil {
 		return nil, nil, err
 	}
-	return modelShim{m}, modelManagerStateShim{otherState, st.pool}, nil
+	return modelShim{otherModel}, modelManagerStateShim{otherState, otherModel, st.pool}, nil
+}
+
+// UpdateModelConfigDefaultValues implements the ModelManagerBackend method.
+func (st modelManagerStateShim) UpdateModelConfigDefaultValues(update map[string]interface{}, remove []string, regionSpec *environs.RegionSpec) error {
+	return st.model.UpdateModelConfigDefaultValues(update, remove, regionSpec)
 }
 
 // GetBackend implements ModelManagerBackend.
@@ -125,7 +131,11 @@ func (st modelManagerStateShim) GetBackend(modelUUID string) (ModelManagerBacken
 	if err != nil {
 		return nil, nil, errors.Trace(err)
 	}
-	return modelManagerStateShim{otherState, st.pool}, release, nil
+	otherModel, err := otherState.Model()
+	if err != nil {
+		return nil, nil, err
+	}
+	return modelManagerStateShim{otherState, otherModel, st.pool}, release, nil
 }
 
 // GetModel implements ModelManagerBackend.

--- a/apiserver/facades/client/controller/controller.go
+++ b/apiserver/facades/client/controller/controller.go
@@ -68,7 +68,8 @@ func NewControllerAPIv3(ctx facade.Context) (*ControllerAPIv3, error) {
 	apiUser, _ := authorizer.GetAuthTag().(names.UserTag)
 
 	st := ctx.State()
-	m, err := st.Model()
+
+	model, err := st.Model()
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -76,13 +77,13 @@ func NewControllerAPIv3(ctx facade.Context) (*ControllerAPIv3, error) {
 	return &ControllerAPIv3{
 		ControllerConfigAPI: common.NewStateControllerConfig(st),
 		ModelStatusAPI: common.NewModelStatusAPI(
-			common.NewModelManagerBackend(st, ctx.StatePool()),
+			common.NewModelManagerBackend(model, ctx.StatePool()),
 			authorizer,
 			apiUser,
 		),
 		CloudSpecAPI: cloudspec.NewCloudSpec(
 			cloudspec.MakeCloudSpecGetter(ctx.StatePool()),
-			common.AuthFuncForTag(m.ModelTag()),
+			common.AuthFuncForTag(model.ModelTag()),
 		),
 		state:      st,
 		statePool:  ctx.StatePool(),

--- a/apiserver/facades/client/controller/destroy.go
+++ b/apiserver/facades/client/controller/destroy.go
@@ -56,11 +56,16 @@ func destroyController(
 		return errors.Trace(err)
 	}
 
+	model, err := st.Model()
+	if err != nil {
+		return errors.Trace(err)
+	}
+
 	// If we are destroying models, we need to tolerate living
 	// models but set the controller to dying to prevent new
 	// models sneaking in. If we are not destroying hosted models,
 	// this will fail if any hosted models are found.
-	backend := common.NewModelManagerBackend(st, pool)
+	backend := common.NewModelManagerBackend(model, pool)
 	return errors.Trace(common.DestroyController(
 		backend, args.DestroyModels, args.DestroyStorage,
 	))

--- a/apiserver/facades/client/controller/destroy_test.go
+++ b/apiserver/facades/client/controller/destroy_test.go
@@ -35,6 +35,7 @@ type destroyControllerSuite struct {
 	controller *controller.ControllerAPIv4
 
 	otherState     *state.State
+	otherModel     *state.Model
 	otherEnvOwner  names.UserTag
 	otherModelUUID string
 }
@@ -73,6 +74,9 @@ func (s *destroyControllerSuite) SetUpTest(c *gc.C) {
 	})
 	s.AddCleanup(func(c *gc.C) { s.otherState.Close() })
 	s.otherModelUUID = s.otherState.ModelUUID()
+
+	s.otherModel, err = s.otherState.Model()
+	c.Assert(err, jc.ErrorIsNil)
 }
 
 func (s *destroyControllerSuite) TestDestroyControllerKillErrsOnHostedEnvsWithBlocks(c *gc.C) {
@@ -136,7 +140,7 @@ func (s *destroyControllerSuite) TestDestroyControllerLeavesBlocksIfNotKillAll(c
 }
 
 func (s *destroyControllerSuite) TestDestroyControllerNoHostedEnvs(c *gc.C) {
-	err := common.DestroyModel(common.NewModelManagerBackend(s.otherState, s.StatePool), nil)
+	err := common.DestroyModel(common.NewModelManagerBackend(s.otherModel, s.StatePool), nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	err = s.controller.DestroyController(params.DestroyControllerArgs{})
@@ -148,7 +152,7 @@ func (s *destroyControllerSuite) TestDestroyControllerNoHostedEnvs(c *gc.C) {
 }
 
 func (s *destroyControllerSuite) TestDestroyControllerErrsOnNoHostedEnvsWithBlock(c *gc.C) {
-	err := common.DestroyModel(common.NewModelManagerBackend(s.otherState, s.StatePool), nil)
+	err := common.DestroyModel(common.NewModelManagerBackend(s.otherModel, s.StatePool), nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.BlockDestroyModel(c, "TestBlockDestroyModel")
@@ -162,7 +166,7 @@ func (s *destroyControllerSuite) TestDestroyControllerErrsOnNoHostedEnvsWithBloc
 }
 
 func (s *destroyControllerSuite) TestDestroyControllerNoHostedEnvsWithBlockFail(c *gc.C) {
-	err := common.DestroyModel(common.NewModelManagerBackend(s.otherState, s.StatePool), nil)
+	err := common.DestroyModel(common.NewModelManagerBackend(s.otherModel, s.StatePool), nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.BlockDestroyModel(c, "TestBlockDestroyModel")

--- a/apiserver/facades/client/modelmanager/modelmanager.go
+++ b/apiserver/facades/client/modelmanager/modelmanager.go
@@ -112,9 +112,19 @@ func NewFacadeV4(ctx facade.Context) (*ModelManagerAPI, error) {
 
 	configGetter := stateenvirons.EnvironConfigGetter{st, model}
 
+	m, err := st.Model()
+	if err != nil {
+		return nil, err
+	}
+
+	ctlrModel, err := ctlrSt.Model()
+	if err != nil {
+		return nil, err
+	}
+
 	return NewModelManagerAPI(
-		common.NewModelManagerBackend(st, pool),
-		common.NewModelManagerBackend(ctlrSt, pool),
+		common.NewModelManagerBackend(m, pool),
+		common.NewModelManagerBackend(ctlrModel, pool),
 		configGetter,
 		auth,
 	)

--- a/apiserver/facades/client/modelmanager/modelmanager_test.go
+++ b/apiserver/facades/client/modelmanager/modelmanager_test.go
@@ -855,8 +855,8 @@ func (s *modelManagerStateSuite) SetUpTest(c *gc.C) {
 func (s *modelManagerStateSuite) setAPIUser(c *gc.C, user names.UserTag) {
 	s.authoriser.Tag = user
 	modelmanager, err := modelmanager.NewModelManagerAPI(
-		common.NewModelManagerBackend(s.State, s.StatePool),
-		common.NewModelManagerBackend(s.State, s.StatePool),
+		common.NewModelManagerBackend(s.IAASModel.Model, s.StatePool),
+		common.NewModelManagerBackend(s.IAASModel.Model, s.StatePool),
 		stateenvirons.EnvironConfigGetter{s.State, s.IAASModel.Model},
 		s.authoriser,
 	)
@@ -868,8 +868,8 @@ func (s *modelManagerStateSuite) TestNewAPIAcceptsClient(c *gc.C) {
 	anAuthoriser := s.authoriser
 	anAuthoriser.Tag = names.NewUserTag("external@remote")
 	endPoint, err := modelmanager.NewModelManagerAPI(
-		common.NewModelManagerBackend(s.State, s.StatePool),
-		common.NewModelManagerBackend(s.State, s.StatePool),
+		common.NewModelManagerBackend(s.IAASModel.Model, s.StatePool),
+		common.NewModelManagerBackend(s.IAASModel.Model, s.StatePool),
 		nil, anAuthoriser,
 	)
 	c.Assert(err, jc.ErrorIsNil)
@@ -880,8 +880,8 @@ func (s *modelManagerStateSuite) TestNewAPIRefusesNonClient(c *gc.C) {
 	anAuthoriser := s.authoriser
 	anAuthoriser.Tag = names.NewUnitTag("mysql/0")
 	endPoint, err := modelmanager.NewModelManagerAPI(
-		common.NewModelManagerBackend(s.State, s.StatePool),
-		common.NewModelManagerBackend(s.State, s.StatePool),
+		common.NewModelManagerBackend(s.IAASModel.Model, s.StatePool),
+		common.NewModelManagerBackend(s.IAASModel.Model, s.StatePool),
 		nil, anAuthoriser,
 	)
 	c.Assert(endPoint, gc.IsNil)
@@ -1096,10 +1096,12 @@ func (s *modelManagerStateSuite) TestDestroyOwnModel(c *gc.C) {
 	st, err := s.State.ForModel(names.NewModelTag(m.UUID))
 	c.Assert(err, jc.ErrorIsNil)
 	defer st.Close()
+	model, err := st.Model()
+	c.Assert(err, jc.ErrorIsNil)
 
 	s.modelmanager, err = modelmanager.NewModelManagerAPI(
-		common.NewModelManagerBackend(st, s.StatePool),
-		common.NewModelManagerBackend(s.State, s.StatePool),
+		common.NewModelManagerBackend(model, s.StatePool),
+		common.NewModelManagerBackend(s.IAASModel.Model, s.StatePool),
 		nil, s.authoriser,
 	)
 	c.Assert(err, jc.ErrorIsNil)
@@ -1113,7 +1115,7 @@ func (s *modelManagerStateSuite) TestDestroyOwnModel(c *gc.C) {
 	c.Assert(results.Results, gc.HasLen, 1)
 	c.Assert(results.Results[0].Error, gc.IsNil)
 
-	model, err := st.Model()
+	model, err = st.Model()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(model.Life(), gc.Not(gc.Equals), state.Alive)
 }
@@ -1128,11 +1130,13 @@ func (s *modelManagerStateSuite) TestAdminDestroysOtherModel(c *gc.C) {
 	st, err := s.State.ForModel(names.NewModelTag(m.UUID))
 	c.Assert(err, jc.ErrorIsNil)
 	defer st.Close()
+	model, err := st.Model()
+	c.Assert(err, jc.ErrorIsNil)
 
 	s.authoriser.Tag = s.AdminUserTag(c)
 	s.modelmanager, err = modelmanager.NewModelManagerAPI(
-		common.NewModelManagerBackend(st, s.StatePool),
-		common.NewModelManagerBackend(s.State, s.StatePool),
+		common.NewModelManagerBackend(model, s.StatePool),
+		common.NewModelManagerBackend(s.IAASModel.Model, s.StatePool),
 		nil, s.authoriser,
 	)
 	c.Assert(err, jc.ErrorIsNil)
@@ -1147,7 +1151,7 @@ func (s *modelManagerStateSuite) TestAdminDestroysOtherModel(c *gc.C) {
 	c.Assert(results.Results[0].Error, gc.IsNil)
 
 	s.authoriser.Tag = owner
-	model, err := st.Model()
+	model, err = st.Model()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(model.Life(), gc.Not(gc.Equals), state.Alive)
 }
@@ -1160,10 +1164,12 @@ func (s *modelManagerStateSuite) TestDestroyModelErrors(c *gc.C) {
 	st, err := s.State.ForModel(names.NewModelTag(m.UUID))
 	c.Assert(err, jc.ErrorIsNil)
 	defer st.Close()
+	model, err := st.Model()
+	c.Assert(err, jc.ErrorIsNil)
 
 	s.modelmanager, err = modelmanager.NewModelManagerAPI(
-		common.NewModelManagerBackend(st, s.StatePool),
-		common.NewModelManagerBackend(s.State, s.StatePool),
+		common.NewModelManagerBackend(model, s.StatePool),
+		common.NewModelManagerBackend(s.IAASModel.Model, s.StatePool),
 		nil, s.authoriser,
 	)
 	c.Assert(err, jc.ErrorIsNil)
@@ -1197,7 +1203,7 @@ func (s *modelManagerStateSuite) TestDestroyModelErrors(c *gc.C) {
 	}})
 
 	s.setAPIUser(c, owner)
-	model, err := st.Model()
+	model, err = st.Model()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(model.Life(), gc.Equals, state.Alive)
 }

--- a/featuretests/cmd_juju_model_test.go
+++ b/featuretests/cmd_juju_model_test.go
@@ -130,7 +130,7 @@ func (s *cmdModelSuite) TestModelConfigReset(c *gc.C) {
 }
 
 func (s *cmdModelSuite) TestModelDefaultsGet(c *gc.C) {
-	err := s.State.UpdateModelConfigDefaultValues(map[string]interface{}{"special": "known"}, nil, nil)
+	err := s.IAASModel.UpdateModelConfigDefaultValues(map[string]interface{}{"special": "known"}, nil, nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	context := s.run(c, "model-defaults", "special")
@@ -142,7 +142,7 @@ special    -        known
 }
 
 func (s *cmdModelSuite) TestModelDefaultsGetRegion(c *gc.C) {
-	err := s.State.UpdateModelConfigDefaultValues(map[string]interface{}{"special": "known"}, nil, &environs.RegionSpec{"dummy", "dummy-region"})
+	err := s.IAASModel.UpdateModelConfigDefaultValues(map[string]interface{}{"special": "known"}, nil, &environs.RegionSpec{"dummy", "dummy-region"})
 	c.Assert(err, jc.ErrorIsNil)
 
 	context := s.run(c, "model-defaults", "dummy-region", "special")
@@ -174,7 +174,7 @@ func (s *cmdModelSuite) TestModelDefaultsSetRegion(c *gc.C) {
 }
 
 func (s *cmdModelSuite) TestModelDefaultsReset(c *gc.C) {
-	err := s.State.UpdateModelConfigDefaultValues(map[string]interface{}{"special": "known"}, nil, nil)
+	err := s.IAASModel.UpdateModelConfigDefaultValues(map[string]interface{}{"special": "known"}, nil, nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.run(c, "model-defaults", "--reset", "special")
@@ -185,7 +185,7 @@ func (s *cmdModelSuite) TestModelDefaultsReset(c *gc.C) {
 }
 
 func (s *cmdModelSuite) TestModelDefaultsResetRegion(c *gc.C) {
-	err := s.State.UpdateModelConfigDefaultValues(map[string]interface{}{"special": "known"}, nil, &environs.RegionSpec{"dummy", "dummy-region"})
+	err := s.IAASModel.UpdateModelConfigDefaultValues(map[string]interface{}{"special": "known"}, nil, &environs.RegionSpec{"dummy", "dummy-region"})
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.run(c, "model-defaults", "dummy-region", "--reset", "special")

--- a/state/model.go
+++ b/state/model.go
@@ -1292,6 +1292,12 @@ func (m *Model) getEntityRefs() (*modelEntityRefsDoc, error) {
 	return &doc, nil
 }
 
+// (TODO) externalreality: Temporary method to access state from model while
+// factoring Model concerns out from state.
+func (model *Model) State() *State {
+	return model.st
+}
+
 // checkModelEntityRefsEmpty checks that the model is empty of any entities
 // that may require external resource cleanup. If the model is not empty,
 // then an error will be returned; otherwise txn.Ops are returned to assert

--- a/state/modelconfig.go
+++ b/state/modelconfig.go
@@ -137,7 +137,7 @@ func (st *State) modelConfigValues(modelCfg attrValues) (config.ConfigValues, er
 }
 
 // UpdateModelConfigDefaultValues updates the inherited settings used when creating a new model.
-func (st *State) UpdateModelConfigDefaultValues(attrs map[string]interface{}, removed []string, regionSpec *environs.RegionSpec) error {
+func (model *Model) UpdateModelConfigDefaultValues(attrs map[string]interface{}, removed []string, regionSpec *environs.RegionSpec) error {
 	var key string
 
 	if regionSpec != nil {
@@ -145,13 +145,13 @@ func (st *State) UpdateModelConfigDefaultValues(attrs map[string]interface{}, re
 	} else {
 		key = controllerInheritedSettingsGlobalKey
 	}
-	settings, err := readSettings(st.db(), globalSettingsC, key)
+	settings, err := readSettings(model.st.db(), globalSettingsC, key)
 	if err != nil {
 		if !errors.IsNotFound(err) {
 			return errors.Trace(err)
 		}
 		// We haven't created settings for this region yet.
-		_, err := createSettings(st.db(), globalSettingsC, key, attrs)
+		_, err := createSettings(model.st.db(), globalSettingsC, key, attrs)
 		if err != nil {
 			return errors.Trace(err)
 		}

--- a/state/modelconfig_test.go
+++ b/state/modelconfig_test.go
@@ -436,13 +436,13 @@ func (s *ModelConfigSourceSuite) TestUpdateModelConfigDefaults(c *gc.C) {
 		"http-proxy":  "http://http-proxy",
 		"https-proxy": "https://https-proxy",
 	}
-	err := s.State.UpdateModelConfigDefaultValues(attrs, nil, nil)
+	err := s.IAASModel.UpdateModelConfigDefaultValues(attrs, nil, nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	attrs = map[string]interface{}{
 		"apt-mirror": "http://different-mirror",
 	}
-	err = s.State.UpdateModelConfigDefaultValues(attrs, []string{"http-proxy", "https-proxy"}, nil)
+	err = s.IAASModel.UpdateModelConfigDefaultValues(attrs, []string{"http-proxy", "https-proxy"}, nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	info := statetesting.NewMongoInfo()
@@ -494,7 +494,7 @@ func (s *ModelConfigSourceSuite) TestUpdateModelConfigRegionDefaults(c *gc.C) {
 	rspec, err := environs.NewRegionSpec("dummy", "dummy-region")
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = s.State.UpdateModelConfigDefaultValues(attrs, nil, rspec)
+	err = s.IAASModel.UpdateModelConfigDefaultValues(attrs, nil, rspec)
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Then check in another state.
@@ -537,7 +537,7 @@ func (s *ModelConfigSourceSuite) TestUpdateModelConfigRegionDefaults(c *gc.C) {
 	c.Assert(cfg, jc.DeepEquals, expectedValues)
 
 	// remove the dummy-region setting
-	err = s.State.UpdateModelConfigDefaultValues(nil, []string{"no-proxy"}, rspec)
+	err = s.IAASModel.UpdateModelConfigDefaultValues(nil, []string{"no-proxy"}, rspec)
 
 	// and check again
 	cfg, err = anotherState.ModelConfigDefaultValues()
@@ -575,7 +575,7 @@ func (s *ModelConfigSourceSuite) TestUpdateModelConfigDefaultValuesUnknownRegion
 
 	// We add this to the unused-region which has not been created in mongo
 	// yet.
-	err = s.State.UpdateModelConfigDefaultValues(attrs, nil, rspec)
+	err = s.IAASModel.UpdateModelConfigDefaultValues(attrs, nil, rspec)
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Then check config.


### PR DESCRIPTION
## Description of change

CAAS Refactor. Move `UpdateModelConfigDefaultValues` from `state.State` to `state.Model` 