### PR TITLE
Add delete offer command

### DIFF
--- a/api/applicationoffers/client.go
+++ b/api/applicationoffers/client.go
@@ -260,3 +260,29 @@ func (c *Client) GetConsumeDetails(urlStr string) (params.ConsumeOfferDetails, e
 		ControllerInfo: theOne.ControllerInfo,
 	}, nil
 }
+
+// DestroyOffers removes the specified application offers.
+func (c *Client) DestroyOffers(offerURLs ...string) error {
+	if len(offerURLs) == 0 {
+		return nil
+	}
+	args := params.DestroyApplicationOffers{
+		OfferURLs: make([]string, len(offerURLs)),
+	}
+	for i, url := range offerURLs {
+		if _, err := crossmodel.ParseApplicationURL(url); err != nil {
+			return errors.Trace(err)
+		}
+		args.OfferURLs[i] = url
+	}
+
+	var result params.ErrorResults
+	err := c.facade.FacadeCall("DestroyOffers", args, &result)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	if len(result.Results) != len(args.OfferURLs) {
+		return errors.Errorf("expected %d results, got %d", len(args.OfferURLs), len(result.Results))
+	}
+	return result.Combine()
+}

--- a/apiserver/facades/client/applicationoffers/mock_test.go
+++ b/apiserver/facades/client/applicationoffers/mock_test.go
@@ -306,6 +306,15 @@ func (m *mockApplicationOffers) ListOffers(filters ...jujucrossmodel.Application
 	return result, nil
 }
 
+func (m *mockApplicationOffers) Remove(name string) error {
+	_, ok := m.st.applicationOffers[name]
+	if !ok {
+		return errors.NotFoundf("application offer %q", name)
+	}
+	delete(m.st.applicationOffers, name)
+	return nil
+}
+
 type offerAccess struct {
 	user      names.UserTag
 	offerUUID string

--- a/apiserver/params/crossmodel.go
+++ b/apiserver/params/crossmodel.go
@@ -90,6 +90,12 @@ type AddApplicationOffer struct {
 	Endpoints              map[string]string `json:"endpoints"`
 }
 
+// DestroyApplicationOffers holds parameters for the DestroyOffers call.
+type DestroyApplicationOffers struct {
+	OfferURLs []string `json:"offer-urls"`
+	Force     bool     `json:"force,omitempty"`
+}
+
 // RemoteEndpoint represents a remote application endpoint.
 type RemoteEndpoint struct {
 	Name      string             `json:"name"`

--- a/cmd/juju/commands/main.go
+++ b/cmd/juju/commands/main.go
@@ -276,6 +276,7 @@ func registerCommands(r commandRegistry, ctx *cmd.Context) {
 
 	// Cross model relations commands.
 	r.Register(crossmodel.NewOfferCommand())
+	r.Register(crossmodel.NewRemoveOfferCommand())
 	r.Register(crossmodel.NewShowOfferedEndpointCommand())
 	r.Register(crossmodel.NewListEndpointsCommand())
 	r.Register(crossmodel.NewFindEndpointsCommand())

--- a/cmd/juju/commands/main_test.go
+++ b/cmd/juju/commands/main_test.go
@@ -495,6 +495,7 @@ var commandNames = []string{
 	"remove-cloud",
 	"remove-credential",
 	"remove-machine",
+	"remove-offer",
 	"remove-relation",
 	"remove-ssh-key",
 	"remove-storage",

--- a/cmd/juju/crossmodel/export_test.go
+++ b/cmd/juju/crossmodel/export_test.go
@@ -62,3 +62,11 @@ func NewFindEndpointsCommandForTest(store jujuclient.ClientStore, api FindAPI) c
 	aCmd.SetClientStore(store)
 	return modelcmd.WrapController(aCmd)
 }
+
+func NewRemoveCommandForTest(store jujuclient.ClientStore, api RemoveAPI) cmd.Command {
+	aCmd := &removeCommand{newAPIFunc: func(controllerName string) (RemoveAPI, error) {
+		return api, nil
+	}}
+	aCmd.SetClientStore(store)
+	return modelcmd.WrapController(aCmd)
+}

--- a/cmd/juju/crossmodel/remove.go
+++ b/cmd/juju/crossmodel/remove.go
@@ -1,0 +1,107 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package crossmodel
+
+import (
+	"github.com/juju/cmd"
+	"github.com/juju/errors"
+
+	"github.com/juju/juju/api/applicationoffers"
+	"github.com/juju/juju/cmd/juju/block"
+	"github.com/juju/juju/cmd/modelcmd"
+	"github.com/juju/juju/core/crossmodel"
+)
+
+// NewRemoveOfferCommand returns a command used to remove a specified offer.
+func NewRemoveOfferCommand() cmd.Command {
+	removeCmd := &removeCommand{}
+	removeCmd.newAPIFunc = func(controllerName string) (RemoveAPI, error) {
+		return removeCmd.NewApplicationOffersAPI(controllerName)
+	}
+	return modelcmd.WrapController(removeCmd)
+}
+
+type removeCommand struct {
+	modelcmd.ControllerCommandBase
+	newAPIFunc  func(string) (RemoveAPI, error)
+	offers      []string
+	offerSource string
+}
+
+const destroyOfferDoc = `
+Remove one or more application offers.
+
+Examples:
+
+    juju remove-offer prod.model/hosted-mysql
+
+See also:
+    find-endpoints
+    offer
+`
+
+// Info implements Command.Info.
+func (c *removeCommand) Info() *cmd.Info {
+	return &cmd.Info{
+		Name:    "remove-offer",
+		Args:    "<offer-url> ...",
+		Purpose: "Removes one or more offers specified by their URL.",
+		Doc:     destroyOfferDoc,
+	}
+}
+
+// Init implements Command.Init.
+func (c *removeCommand) Init(args []string) error {
+	if len(args) == 0 {
+		return errors.Errorf("no offers specified")
+	}
+	for _, urlStr := range args {
+		url, err := crossmodel.ParseApplicationURL(urlStr)
+		if err != nil {
+			return errors.Trace(err)
+		}
+		if c.offerSource == "" {
+			c.offerSource = url.Source
+		}
+		if c.offerSource != url.Source {
+			return errors.New("all offer URLs must use the same controller")
+		}
+	}
+	c.offers = args
+	return nil
+}
+
+// RemoveAPI defines the API methods that the remove offer command uses.
+type RemoveAPI interface {
+	Close() error
+	DestroyOffers(offerURLs ...string) error
+}
+
+// NewApplicationOffersAPI returns an application offers api.
+func (c *removeCommand) NewApplicationOffersAPI(controllerName string) (*applicationoffers.Client, error) {
+	root, err := c.CommandBase.NewAPIRoot(c.ClientStore(), controllerName, "")
+	if err != nil {
+		return nil, err
+	}
+	return applicationoffers.NewClient(root), nil
+}
+
+// Run implements Command.Run.
+func (c *removeCommand) Run(ctx *cmd.Context) error {
+	if c.offerSource == "" {
+		controllerName, err := c.ControllerName()
+		if err != nil {
+			return errors.Trace(err)
+		}
+		c.offerSource = controllerName
+	}
+	api, err := c.newAPIFunc(c.offerSource)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	defer api.Close()
+
+	err = api.DestroyOffers(c.offers...)
+	return block.ProcessBlockedError(err, block.BlockRemove)
+}

--- a/cmd/juju/crossmodel/remove_test.go
+++ b/cmd/juju/crossmodel/remove_test.go
@@ -1,0 +1,73 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package crossmodel_test
+
+import (
+	"strings"
+
+	"github.com/juju/cmd"
+	"github.com/juju/cmd/cmdtesting"
+	"github.com/juju/errors"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/cmd/juju/crossmodel"
+)
+
+type removeSuite struct {
+	BaseCrossModelSuite
+	mockAPI *mockRemoveAPI
+}
+
+var _ = gc.Suite(&removeSuite{})
+
+func (s *removeSuite) SetUpTest(c *gc.C) {
+	s.BaseCrossModelSuite.SetUpTest(c)
+	s.mockAPI = &mockRemoveAPI{}
+}
+
+func (s *removeSuite) runRemove(c *gc.C, args ...string) (*cmd.Context, error) {
+	return cmdtesting.RunCommand(c, crossmodel.NewRemoveCommandForTest(s.store, s.mockAPI), args...)
+}
+
+func (s *removeSuite) TestRemoveURLError(c *gc.C) {
+	_, err := s.runRemove(c, "fred/model.foo/db2")
+	c.Assert(err, gc.ErrorMatches, "application offer URL has invalid form.*")
+}
+
+func (s *removeSuite) TestRemoveInconsistentControllers(c *gc.C) {
+	_, err := s.runRemove(c, "ctrl:fred/model.db2", "ctrl2:fred/model.db2")
+	c.Assert(err, gc.ErrorMatches, "all offer URLs must use the same controller")
+}
+
+func (s *removeSuite) TestRemoveApiError(c *gc.C) {
+	s.mockAPI.msg = "fail"
+	_, err := s.runRemove(c, "fred/model.db2")
+	c.Assert(err, gc.ErrorMatches, ".*fail.*")
+}
+
+func (s *removeSuite) TestRemove(c *gc.C) {
+	s.mockAPI.expectedURLs = []string{"fred/model.db2", "mary/model.db2"}
+	_, err := s.runRemove(c, "fred/model.db2", "mary/model.db2")
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+type mockRemoveAPI struct {
+	msg          string
+	expectedURLs []string
+}
+
+func (s mockRemoveAPI) Close() error {
+	return nil
+}
+
+func (s mockRemoveAPI) DestroyOffers(offerURLs ...string) error {
+	if s.msg != "" {
+		return errors.New(s.msg)
+	}
+	if strings.Join(s.expectedURLs, ",") != strings.Join(offerURLs, ",") {
+		return errors.New("mismatched URLs")
+	}
+	return nil
+}

--- a/featuretests/cmd_juju_crossmodel_test.go
+++ b/featuretests/cmd_juju_crossmodel_test.go
@@ -70,6 +70,25 @@ varnish:
 `[1:])
 }
 
+func (s *crossmodelSuite) TestRemove(c *gc.C) {
+	ch := s.AddTestingCharm(c, "riak")
+	s.AddTestingApplication(c, "riakservice", ch)
+	ch = s.AddTestingCharm(c, "varnish")
+	s.AddTestingApplication(c, "varnishservice", ch)
+
+	_, err := cmdtesting.RunCommand(c, crossmodel.NewOfferCommand(),
+		"riakservice:endpoint", "riak")
+	c.Assert(err, jc.ErrorIsNil)
+
+	_, err = cmdtesting.RunCommand(c, crossmodel.NewRemoveOfferCommand(),
+		"admin/controller.riak")
+	c.Assert(err, jc.ErrorIsNil)
+
+	_, err = cmdtesting.RunCommand(c, crossmodel.NewShowOfferedEndpointCommand(),
+		"admin/controller.riak")
+	c.Assert(err, gc.ErrorMatches, `application offer "admin/controller\.riak" not found`)
+}
+
 func (s *crossmodelSuite) TestShow(c *gc.C) {
 	ch := s.AddTestingCharm(c, "riak")
 	s.AddTestingApplication(c, "riakservice", ch)


### PR DESCRIPTION
## Description of change

Add a command to remove an offer.
Offers to be removed are specified by their URLs. For now, all URLs must be on the same controller.
As a drive by, fix the remove offer backend to handle apps with peer relations.

## QA steps

Create an offer and check it can be deleted.
