### PR TITLE
CI: Jujupy remove simpleenv

### DIFF
--- a/acceptancetests/add-missing-result-yaml-files.py
+++ b/acceptancetests/add-missing-result-yaml-files.py
@@ -129,6 +129,7 @@ def main(args):
             else:
                 s3_cmd(params)
 
+
 if __name__ == '__main__':
     parser = ArgumentParser()
     parser.add_argument('--dry-run', action='store_true')

--- a/acceptancetests/assess_heterogeneous_control.py
+++ b/acceptancetests/assess_heterogeneous_control.py
@@ -163,6 +163,7 @@ def test_control_heterogeneous(bs_manager, other, upload_tools):
         other.remove_machine(container_holder)
         wait_until_removed(other, container_holder)
 
+
 # suppress nosetests
 test_control_heterogeneous.__test__ = False
 

--- a/acceptancetests/assess_heterogeneous_control.py
+++ b/acceptancetests/assess_heterogeneous_control.py
@@ -13,7 +13,7 @@ from jujucharm import (
 from jujupy import (
     client_from_config,
     fake_juju_client,
-    SimpleEnvironment,
+    JujuData,
     )
 from deploy_stack import (
     BootstrapManager,
@@ -44,7 +44,7 @@ def prepare_dummy_env(client):
 def get_clients(initial, other, base_env, debug, agent_url):
     """Return the clients to use for testing."""
     if initial == 'FAKE':
-        environment = SimpleEnvironment.from_config(base_env)
+        environment = JujuData.from_config(base_env)
         client = fake_juju_client(env=environment)
         return client, client, client
     else:

--- a/acceptancetests/assess_log_rotation.py
+++ b/acceptancetests/assess_log_rotation.py
@@ -160,8 +160,8 @@ def check_expected_backup(key, logprefix, action_output):
     size = int(log["size"])
     if size > 30:
         raise LogRotateError(
-            "Backup log '%s' should be less than 30MB (as gzipped), but is %sMB." %
-            (log_name, size))
+            "Backup log '%s' should be less than 30MB (as gzipped), "
+            "but is %sMB." % (log_name, size))
 
     dt = matches.groups()[0]
     dt_pattern = "%Y-%m-%dT%H-%M-%S.%f"

--- a/acceptancetests/assess_lxd_space.py
+++ b/acceptancetests/assess_lxd_space.py
@@ -26,10 +26,8 @@ from __future__ import print_function
 import argparse
 import json
 import logging
-import os
 import sys
 
-from jujucharm import local_charm_path
 
 from deploy_stack import (
     BootstrapManager,
@@ -59,7 +57,7 @@ def assert_initial_spaces(client):
     if expected_spaces not in raw_output:
         raise JujuAssertionError(
             'Incorrect initial spaces status. Found: {}\nExpected: {}'.format(
-            raw_output, expected_spaces))
+                raw_output, expected_spaces))
     else:
         log.info('Initial spaces status is: {}.'.format(expected_spaces))
 
@@ -88,7 +86,9 @@ def assert_initial_subnets(client):
     if not subnets_dict:
         raise JujuAssertionError('No subnet can be Found.')
     else:
-        log.info('{} subnet(s) have been found.'.format(str(len(subnets_dict))))
+        log.info(
+            '{} subnet(s) have been found.'.format(
+                str(len(subnets_dict))))
 
 
 def add_space_with_existing_subnet(client, space_name):
@@ -100,15 +100,16 @@ def add_space_with_existing_subnet(client, space_name):
     subnet_cidr = subnets_cidr_list[0]
     # Bug 1704105, merge_stderr=True is required.
     client.get_juju_output(
-        'add-space', space_name, subnet_cidr, include_e=False, merge_stderr=True)
+        'add-space', space_name, subnet_cidr,
+        include_e=False, merge_stderr=True)
     return (space_name, subnet_cidr)
 
 
 def assert_added_space(client):
     """Validate if configurations in new added space are as expected.
        Five checkpoints:
-       1. After new space is added, juju spaces --format json should give output
-          in json format, in comparison to no space exists.
+       1. After new space is added, juju spaces --format json should give
+          output in json format, in comparison to no space exists.
        2. Total number of space should be 1.
        3. The name of new added space should be the same as specified.
        4. Total number of subnet CIDR from this new added space should be 1.
@@ -130,19 +131,19 @@ def assert_added_space(client):
     if len(space_output['spaces'].keys()) != 1:
         raise JujuAssertionError(
             'Incorrect number of space(s). Found: {}; Expected: 1.'.format(
-            str(len(space_output['spaces'].keys()))))
+                str(len(space_output['spaces'].keys()))))
     elif space_output['spaces'].keys()[0] != space_name:
         raise JujuAssertionError(
             'Incorrect space name. Found: {}; Expected: {}.'.format(
-            space_output['spaces'].keys()[0], space_name))
+                space_output['spaces'].keys()[0], space_name))
     elif len(space_output['spaces'][space_name].keys()) != 1:
         raise JujuAssertionError(
             'Incorrect number of CIDR(s). Found: {}; Expected: 1.'.format(
-            str(len(space_output['spaces'][space_name].keys()))))
+                str(len(space_output['spaces'][space_name].keys()))))
     elif space_output['spaces'][space_name].keys()[0] != subnet_cidr:
         raise JujuAssertionError(
             'Incorrect CIDR name. Found: {}; Expected: {}.'.format(
-            space_output['spaces'][space_name].keys()[0], subnet_cidr))
+                space_output['spaces'][space_name].keys()[0], subnet_cidr))
     log.info('New added space {} has been validated.'.format(space_name))
 
 
@@ -155,7 +156,8 @@ def assert_app_status(client, charm_name, expected):
     log.info('Checking current status of app {}.'.format(charm_name))
     status_output = json.loads(
         client.get_juju_output('status', '--format', 'json', include_e=False))
-    app_status = status_output['applications'][charm_name]['application-status']['current']
+    app_status = status_output[
+        'applications'][charm_name]['application-status']['current']
 
     if app_status != expected:
         raise JujuAssertionError(
@@ -163,7 +165,7 @@ def assert_app_status(client, charm_name, expected):
             'Found: {}; Expected: {}'.format(app_status, expected))
     else:
         log.info('The current status of app {} is: {}; Expected: {}'.format(
-        charm_name, app_status, expected))
+            charm_name, app_status, expected))
 
 
 def parse_args(argv):

--- a/acceptancetests/assess_model_migration.py
+++ b/acceptancetests/assess_model_migration.py
@@ -495,7 +495,8 @@ def migrate_model_to_controller(
         try:
             source_client.juju(
                 'show-model',
-                get_full_model_name(migration_target_client, include_user_name),
+                get_full_model_name(
+                    migration_target_client, include_user_name),
                 include_e=False)
         except:
             log.info('Ignoring failed output.')

--- a/acceptancetests/assess_persistent_storage.py
+++ b/acceptancetests/assess_persistent_storage.py
@@ -66,11 +66,13 @@ def get_storage_property(client, storage_id):
     else:
         storage_type = storage_output['storage'][storage_id]['kind']
         # Be careful, the type of persistent_setting's value is boolean.
-        persistent_setting = storage_output['storage'][storage_id]['persistent']
+        persistent_setting = storage_output[
+            'storage'][storage_id]['persistent']
         if storage_type == 'block':
             pool_storage = storage_output['volumes']['0']['storage']
             pool_setting = storage_output['volumes']['0']['pool']
-            storage_status = storage_output['volumes']['0']['status']['current']
+            storage_status = storage_output[
+                'volumes']['0']['status']['current']
         elif storage_type == 'filesystem':
             pool_storage = storage_output['filesystems']['0/0']['storage']
             pool_setting = storage_output['filesystems']['0/0']['pool']
@@ -78,7 +80,8 @@ def get_storage_property(client, storage_id):
         else:
             raise JujuAssertionError(
                 'Incorrect storage type. '
-                'Found: {}\nExpected: block or filesystem'.format(storage_type))
+                'Found: {}\nExpected: block or filesystem'.format(
+                    storage_type))
     return (
         storage_list, storage_type,
         persistent_setting, pool_storage, pool_setting, storage_status)
@@ -89,9 +92,12 @@ def assert_app_status(client, charm_name, expected):
     log.info('Checking current status of app {}.'.format(charm_name))
     status_output = json.loads(
         client.get_juju_output('status', '--format', 'json', include_e=False))
-    app_status = status_output['applications'][charm_name]['application-status']['current']
+    app_status = status_output[
+        'applications'][charm_name]['application-status']['current']
     assert_equal(
-        error_msg='App status is incorrect.', found=app_status, expected=expected)
+        error_msg='App status is incorrect.',
+        found=app_status,
+        expected=expected)
     log.info('The current status of app {} is: {}; Expected: {}'.format(
         charm_name, app_status, expected))
 
@@ -108,7 +114,8 @@ def assert_storage_count(storage_list, expected):
 
 def assert_single_blk_existence(storage_list, storage_id):
     log.info(
-        'Checking existence of single block device storage.'.format(storage_id))
+        'Checking existence of single block device storage.'.format(
+            storage_id))
     if storage_id not in storage_list:
         raise JujuAssertionError(
             '{} missing from storage list.'.format(storage_id))
@@ -129,20 +136,24 @@ def assert_single_blk_removal(storage_list, storage_id):
 def assert_persistent_setting(storage_id, found, expected):
     log.info(
         'Checking persistent setting of storage unit {}.'.format(storage_id))
-    err_msg = 'Incorrect value of persistent setting on storage unit {}.'.format(storage_id)
+    err_msg = 'Incorrect persistent setting value on storage unit {}.'.format(
+        storage_id)
     assert_equal(error_msg=err_msg, found=found, expected=expected)
     log.info(
         'Persistent setting of storage unit {}, '
         'Found: {}; Expected: {}.'.format(storage_id, found, expected))
 
 
-def assert_storage_status(found_id, expected_id, found_status, expected_status):
+def assert_storage_status(
+        found_id, expected_id, found_status, expected_status):
     log.info(
         'Checking the status of storage {} in volumes.'.format(expected_id))
     volume_err_msg = '{} missing from volumes.'.format(expected_id)
-    assert_equal(error_msg=volume_err_msg, found=found_id, expected=expected_id)
+    assert_equal(
+        error_msg=volume_err_msg, found=found_id, expected=expected_id)
     status_err_msg = 'Incorrect status for {}.'.format(found_id)
-    assert_equal(error_msg=status_err_msg, found=found_status, expected=expected_status)
+    assert_equal(
+        error_msg=status_err_msg, found=found_status, expected=expected_status)
     log.info(
         'The current status of storage {} in volumes is: {}; '
         'Expected: {}.'.format(found_id, found_status, expected_status))
@@ -153,7 +164,8 @@ def assert_app_removal_msg(client, charm_name):
     # Bug 1704105: https://bugs.launchpad.net/juju/+bug/1704105
     # merge_stderr=True is required
     app_removal_output = client.get_juju_output(
-        'remove-application', charm_name, '--show-log', include_e=False, merge_stderr=True)
+        'remove-application', charm_name, '--show-log',
+        include_e=False, merge_stderr=True)
     remove_app_output_check = False
     for line in app_removal_output.split('\n'):
         if 'will remove unit {}'.format(charm_name) in line:
@@ -182,8 +194,9 @@ def assert_single_fs_removal_msg(single_fs_id, app_removal_output):
             'remove-application output message.'.format(single_fs_id))
     else:
         log.info(
-            'Remove single filesystem storage {} output message check: {}'.format(
-            single_fs_id, remove_single_fs_output_check))
+            'Remove single filesystem storage {} '
+            'output message check: {}'.format(
+                single_fs_id, remove_single_fs_output_check))
 
 
 def assert_single_blk_detach_msg(single_blk_id, app_removal_output):
@@ -199,8 +212,9 @@ def assert_single_blk_detach_msg(single_blk_id, app_removal_output):
             'remove-application output message.'.format(single_blk_id))
     else:
         log.info(
-            'Detach single block device storage {} output message check: {}'.format(
-            single_blk_id, detach_single_blk_output_check))
+            'Detach single block device storage {} '
+            'output message check: {}'.format(
+                single_blk_id, detach_single_blk_output_check))
 
 
 def assess_charm_deploy_single_block_and_filesystem_storage(client):
@@ -226,7 +240,8 @@ def assess_charm_deploy_single_block_and_filesystem_storage(client):
     log.info(
         '{} is going to be deployed with 1 ebs block storage unit and '
         '1 rootfs filesystem storage unit.'.format(charm_name))
-    # Run juju deploy dummy-storage --storage single-blk=ebs --storage single-fs=rootfs
+    # Run juju deploy dummy-storage --storage single-blk=ebs
+    #    --storage single-fs=rootfs
     client.deploy(charm_path, storage=['single-blk=ebs', 'single-fs=rootfs'])
     client.wait_for_started()
     client.wait_for_workloads()
@@ -237,7 +252,7 @@ def assess_charm_deploy_single_block_and_filesystem_storage(client):
     assert_storage_count(storage_list=storage_list, expected=2)
     log.info(
         'Following storage units have been found:\n{}'.format(
-        '\n'.join(storage_list)))
+            '\n'.join(storage_list)))
     try:
         single_fs_id = [elem for elem in storage_list
                         if elem.startswith('single-fs')][0]
@@ -247,11 +262,16 @@ def assess_charm_deploy_single_block_and_filesystem_storage(client):
         single_blk_id = [elem for elem in storage_list
                          if elem.startswith('single-blk')][0]
     except IndexError:
-        raise JujuAssertionError('Name mismatch on Single block device storage.')
+        raise JujuAssertionError(
+            'Name mismatch on Single block device storage.')
     log.info('Check name and total number of storage unit: PASSED.')
     # check type, persistent setting and pool of single block storage unit
-    storage_list, storage_type, persistent_setting, pool_storage, pool_setting,\
-    storage_status = get_storage_property(client, storage_id=single_blk_id)
+    storage_list, \
+        storage_type, \
+        persistent_setting,\
+        pool_storage, \
+        pool_setting,\
+        storage_status = get_storage_property(client, storage_id=single_blk_id)
     if storage_type != 'block':
         raise JujuAssertionError(
             'Incorrect type for single block device storage detected '
@@ -261,12 +281,17 @@ def assess_charm_deploy_single_block_and_filesystem_storage(client):
         storage_id=single_blk_id, found=persistent_setting, expected=True)
 
     if (pool_storage != single_blk_id) and (pool_setting != 'ebs'):
-        raise JujuAssertionError('Incorrect volumes detected '
-            '- {} with {}.'.format(pool_storage, pool_setting))
+        raise JujuAssertionError(
+            'Incorrect volumes detected - {} with {}.'.format(
+                pool_storage, pool_setting))
     log.info('Check properties of single block device storage unit: PASSED.')
     # check type, persistent setting and pool of single filesystem storage unit
-    storage_list, storage_type, persistent_setting, pool_storage, pool_setting,\
-    storage_status = get_storage_property(client, storage_id=single_fs_id)
+    storage_list, \
+        storage_type, \
+        persistent_setting, \
+        pool_storage, \
+        pool_setting, \
+        storage_status = get_storage_property(client, storage_id=single_fs_id)
     if storage_type != 'filesystem':
         raise JujuAssertionError(
             'Incorrect type for single filesystem storage detected '
@@ -276,8 +301,9 @@ def assess_charm_deploy_single_block_and_filesystem_storage(client):
         storage_id=single_fs_id, found=persistent_setting, expected=False)
 
     if (pool_storage != single_fs_id) and (pool_setting != 'rootfs'):
-        raise JujuAssertionError('Incorrect filesystems detected '
-            '- {} with {}.'.format(pool_storage, pool_setting))
+        raise JujuAssertionError(
+            'Incorrect filesystems detected - {} with {}.'.format(
+                pool_storage, pool_setting))
     log.info('Check properties of single filesystem storage unit: PASSED.')
     return (single_fs_id, single_blk_id)
 
@@ -293,7 +319,8 @@ def assess_charm_removal_single_block_and_filesystem_storage(client):
            > The output should states that there is a persistent storage unit.
            > The application should be removed successfully.
        - Check charm storage units once the removal is done.
-           > The filesystem storage unit (rootfs)should be removed successfully.
+           > The filesystem storage unit (rootfs) should be
+               removed successfully.
            > The block device storage unit (ebs) should remain and detached,
 
        :param client: ModelClient object to deploy the charm on.
@@ -315,14 +342,18 @@ def assess_charm_removal_single_block_and_filesystem_storage(client):
     if single_fs_id in storage_list:
         raise JujuAssertionError(
             '{} should be removed along with remove-application.'.format(
-            single_fs_id))
+                single_fs_id))
     assert_single_blk_existence(
         storage_list=storage_list, storage_id=single_blk_id)
     log.info(
         'Check existence of persistent storage {} '
         'after remove-application: PASSED'.format(single_blk_id))
-    storage_list, storage_type, persistent_setting, pool_storage, pool_setting,\
-    storage_status = get_storage_property(client, storage_id=single_blk_id)
+    storage_list, \
+        storage_type, \
+        persistent_setting, \
+        pool_storage, \
+        pool_setting, \
+        storage_status = get_storage_property(client, storage_id=single_blk_id)
     assert_storage_status(
         found_id=pool_storage, expected_id=single_blk_id,
         found_status=storage_status, expected_status='detached')
@@ -337,7 +368,8 @@ def assess_deploy_charm_with_existing_storage_and_removal(client):
 
        Steps taken to the test:
        - Run assess_charm_removal_single_block_and_filesystem_storage(client)
-       - Deploy charm dummy-storage with existing detached storage single_blk_id
+       - Deploy charm dummy-storage with existing detached storage
+           single_blk_id
        - Check charm status, should be active once the deploy is completed.
        - Check storage status, single_blk_id should show as attached
 
@@ -359,8 +391,12 @@ def assess_deploy_charm_with_existing_storage_and_removal(client):
     client.wait_for_started()
     client.wait_for_workloads()
     assert_app_status(client, charm_name=charm_name, expected='active')
-    storage_list, storage_type, persistent_setting, pool_storage, pool_setting,\
-    storage_status = get_storage_property(client, storage_id=single_blk_id)
+    storage_list, \
+        storage_type, \
+        persistent_setting, \
+        pool_storage, \
+        pool_setting, \
+        storage_status = get_storage_property(client, storage_id=single_blk_id)
     assert_storage_count(storage_list=storage_list, expected=1)
     assert_single_blk_existence(
         storage_list=storage_list, storage_id=single_blk_id)
@@ -398,12 +434,15 @@ def parse_args(argv):
 
 
 def assess_persistent_storage(client):
-    """Functional dependencies. Because the whole test is one user scenario,
-       the assess functions are connected. e.g.:
-       assess_deploy_charm_with_existing_storage_and_removal(client) depends on
-       assess_charm_removal_single_block_and_filesystem_storage(client) which
-       depends on assess_charm_deploy_single_block_and_filesystem_storage(client).
-       Therefore only the last assess function need to be called."""
+    """Functional test for persistent storage features
+    Because the whole test is one user scenario,
+    the assess functions are connected. e.g.:
+      assess_deploy_charm_with_existing_storage_and_removal(client) depends on
+      assess_charm_removal_single_block_and_filesystem_storage(client) which
+      depends on
+      assess_charm_deploy_single_block_and_filesystem_storage(client).
+    Therefore only the last assess function need to be called.
+    """
     assess_deploy_charm_with_existing_storage_and_removal(client)
 
 

--- a/acceptancetests/assess_sla.py
+++ b/acceptancetests/assess_sla.py
@@ -36,7 +36,7 @@ def list_sla(client):
 
 def assert_sla_state(client, expected_state):
     sla_state = list_sla(client)
-    if not expected_state in sla_state:
+    if expected_state not in sla_state:
         raise JujuAssertionError(
             'Found: {}\nExpected: {}'.format(sla_state, expected_state))
 

--- a/acceptancetests/assess_storage.py
+++ b/acceptancetests/assess_storage.py
@@ -102,7 +102,8 @@ def wait_for_storage_detach(client, storage_id, interval, timeout):
         time.sleep(interval)
         storage_output = json.loads(client.list_storage())
         try:
-            index = [elem for elem in storage_output['volumes'].keys()
+            index = [
+                elem for elem in storage_output['volumes'].keys()
                 if storage_output['volumes'][elem]['storage'] == storage_id][0]
         except IndexError:
             log.info('Volume index for {} cannot be found.'.format(storage_id))

--- a/acceptancetests/assess_user_grant_revoke.py
+++ b/acceptancetests/assess_user_grant_revoke.py
@@ -387,5 +387,6 @@ def main(argv=None):
         assess_user_grant_revoke(bs_manager.client)
     return 0
 
+
 if __name__ == '__main__':
     sys.exit(main())

--- a/acceptancetests/clean_prodstack.py
+++ b/acceptancetests/clean_prodstack.py
@@ -7,23 +7,26 @@ import json
 import logging
 import subprocess
 
+
 def get_current_controller_and_models():
     """Get Models name from current Controller, as well as Controller name.
        Returns:
        ctrl_name: a string for current Controller name
        model_list: a list for name of Models under the current Controller"""
 
-    ctrl_output = json.loads(subprocess.check_output(['juju', 'controllers', '--format', 'json']))
+    ctrl_output = json.loads(
+        subprocess.check_output(['juju', 'controllers', '--format', 'json']))
     ctrl_name = ctrl_output['current-controller']
-    model_output = json.loads(subprocess.check_output(['juju', 'models', '--format', 'json']))
+    model_output = json.loads(
+        subprocess.check_output(['juju', 'models', '--format', 'json']))
     model_list = [m['name'] for m in model_output['models']]
     if not model_list:
         logging.error('No model has been found, exit.')
         sys.exit(1)
     logging.info(
         'Models under the Controller {} are:\n{}'.format(
-        ctrl_name,
-        '\n'.join(model_list)))
+            ctrl_name,
+            '\n'.join(model_list)))
     return (ctrl_name, model_list)
 
 
@@ -31,7 +34,7 @@ def get_reserved_machine_ipaddress():
     """Machines (nova servers) associated to Models from current Controller
        will be reserved, as they are either in use or orchestrating services.
        Returns:
-       ip_pool: a list stores ip address of nova servers from Models in 
+       ip_pool: a list stores ip address of nova servers from Models in
                 current Controller."""
 
     ip_pool = []
@@ -50,7 +53,7 @@ def get_reserved_machine_ipaddress():
         # Models and Controllers, therefore need to be reserved
         logging.info(
             'DO NOT touch servers associated to these ip address:\n{}'.format(
-            '\n'.join(ip_pool)))
+                '\n'.join(ip_pool)))
     else:
         logging.info(
             'No ip address has been found, free to delete all nova servers.')
@@ -120,7 +123,7 @@ def get_target_server_list():
 
 
 def destroy_nova_server():
-    """Using nova delete to remove leftover servers gathered from 
+    """Using nova delete to remove leftover servers gathered from
        get_target_server_list()
        Returns: None"""
 
@@ -133,11 +136,11 @@ def destroy_nova_server():
                 stderr=subprocess.STDOUT)
             logging.info(
                 'nova server {} has been deleted.'.format(
-                target_nova_server_dict[key]))
+                    target_nova_server_dict[key]))
         except subprocess.CalledProcessError:
             logging.warning(
                 'Failed to delete {}, manual check required.'.format(
-                target_nova_server_dict[key]))
+                    target_nova_server_dict[key]))
 
 
 def main():

--- a/acceptancetests/clean_resources.py
+++ b/acceptancetests/clean_resources.py
@@ -21,7 +21,7 @@ def get_regions():
     try:
         with open(cloud_list, 'r') as stream:
             try:
-                data = yaml.load(stream) 
+                data = yaml.load(stream)
             except yaml.YAMLError as yaml_err:
                 raise yaml_err
             # extract all AWS regions, align with juju regions <cloud>
@@ -42,16 +42,16 @@ def get_security_groups(grp, instgrp, region):
     instance_groups = dict(instgrp)
     logging.info(
         '{} instance groups found on {}\n{}'.format(
-        str(len(instance_groups)),
-        region,
-        '\n'.join(instance_groups)))
+            str(len(instance_groups)),
+            region,
+            '\n'.join(instance_groups)))
     non_instance_groups = dict(
         (k, v) for k, v in all_groups.items() if k not in instance_groups)
     logging.info(
         '{} non-instance groups found on {}\n{}'.format(
-        str(len(non_instance_groups)),
-        region,
-        '\n'.join(non_instance_groups)))
+            str(len(non_instance_groups)),
+            region,
+            '\n'.join(non_instance_groups)))
     return (all_groups, non_instance_groups)
 
 
@@ -59,28 +59,28 @@ def remove_detached_interfaces(non_instgrp, substrate, region):
     """Remove detached interfaces from non-instance security groups"""
     # TO DO: Would be better to loop non_instgrp.keys() to get detailed output
     logging.info(
-        'Detached interfaces will be deleted in region {} ' \
+        'Detached interfaces will be deleted in region {} '
         'from {} non-instance security groups\n{}'.format(
-        region,
-        str(len(non_instgrp.keys())),
-        '\n'.join(non_instgrp.keys())))
+            region,
+            str(len(non_instgrp.keys())),
+            '\n'.join(non_instgrp.keys())))
     try:
         unclean = substrate.delete_detached_interfaces(
             non_instgrp.keys())
         logging.info(
-            'Detached interfaces have been deleted in region {} ' \
+            'Detached interfaces have been deleted in region {} '
             'from {} non-instance security groups\n{}'.format(
-            region,
-            str(len(non_instgrp.keys())),
-            '\n'.join(non_instgrp.keys())))
+                region,
+                str(len(non_instgrp.keys())),
+                '\n'.join(non_instgrp.keys())))
         logging.info(
             'Unable to clean {} groups from {}'.format(
-            str(len(unclean)), region))
+                str(len(unclean)), region))
     except:
         logging.info(
             'Unable to clean non-instance groups in region {} from\n{}'.format(
-            region,
-            '\n'.join(non_instgrp.keys())))
+                region,
+                '\n'.join(non_instgrp.keys())))
     return unclean
 
 
@@ -89,19 +89,19 @@ def remove_security_groups(unclean, grp, non_instgrp, substrate, region):
     for group_id in unclean:
         logging.info(
             'Cannot delete {} from {}'.format(
-            grp[group_id], region))
+                grp[group_id], region))
         non_instgrp.pop(group_id, None)
     try:
         substrate.destroy_security_groups(non_instgrp.values())
         logging.info(
             '{} non-instance groups have been deleted from {}\n{}'.format(
-            len(non_instgrp.values()),
-            region,
-            '\n'.join(non_instgrp.values())))
+                len(non_instgrp.values()),
+                region,
+                '\n'.join(non_instgrp.values())))
     except:
         logging.info(
             'Failed to delete groups {} from {}'.format(
-            non_instgrp.values(), region))
+                non_instgrp.values(), region))
 
 
 def clean(args):
@@ -109,12 +109,13 @@ def clean(args):
     selected_regions = get_regions()
     logging.info(
         'The target regions for cleaning job are \n{}'.format(
-        '\n'.join(selected_regions)))
+            '\n'.join(selected_regions)))
     for region in selected_regions:
         with AWSAccount.from_boot_config(env, region=region) as substrate:
             if substrate is None:
                 logging.info(
-                    'Skipping {}, substrate object returns NoneType'.format(region))
+                    'Skipping {}, substrate object returns NoneType'.format(
+                        region))
                 continue
             logging.info(
                 'Cleaning resources in {}.'.format(substrate.region))

--- a/acceptancetests/clean_resources.py
+++ b/acceptancetests/clean_resources.py
@@ -5,7 +5,7 @@ import os
 import yaml
 
 from argparse import ArgumentParser
-from jujupy import SimpleEnvironment
+from jujupy import JujuData
 from substrate import AWSAccount
 
 
@@ -105,7 +105,7 @@ def remove_security_groups(unclean, grp, non_instgrp, substrate, region):
 
 
 def clean(args):
-    env = SimpleEnvironment.from_config(args.env)
+    env = JujuData.from_config(args.env)
     selected_regions = get_regions()
     logging.info(
         'The target regions for cleaning job are \n{}'.format(

--- a/acceptancetests/deploy_stack.py
+++ b/acceptancetests/deploy_stack.py
@@ -47,7 +47,6 @@ from remote import (
     winrm,
 )
 from substrate import (
-    destroy_job_instances,
     has_nova_instance,
     LIBVIRT_DOMAIN_RUNNING,
     resolve_remote_dns_names,

--- a/acceptancetests/deploy_stack.py
+++ b/acceptancetests/deploy_stack.py
@@ -34,7 +34,7 @@ from jujupy import (
     get_machine_dns_name,
     jes_home_path,
     NoProvider,
-    SimpleEnvironment,
+    JujuData,
     temp_bootstrap_env,
     )
 from jujupy.client import (
@@ -769,7 +769,7 @@ class BootstrapManager:
 
         # GZ 2016-08-11: Move this logic into client_from_config maybe?
         if args.juju_bin == 'FAKE':
-            env = SimpleEnvironment.from_config(args.env)
+            env = JujuData.from_config(args.env)
             client = fake_juju_client(env=env)
         else:
             client = client_from_config(args.env, args.juju_bin,

--- a/acceptancetests/gotesttarfile.py
+++ b/acceptancetests/gotesttarfile.py
@@ -120,6 +120,7 @@ def go_test_package(package, go_cmd, gopath, verbose=False):
         murder_mongo()
     return returncode
 
+
 # suppress nosetests
 go_test_package.__test__ = False
 

--- a/acceptancetests/industrial_test.py
+++ b/acceptancetests/industrial_test.py
@@ -30,7 +30,6 @@ from jujupy.client import (
     get_machine_dns_name,
     LXC_MACHINE,
     LXD_MACHINE,
-    uniquify_local,
     )
 from substrate import (
     make_substrate_manager as real_make_substrate_manager,
@@ -211,7 +210,6 @@ class IndustrialTest:
         if new_agent_url is not None:
             new_client.env.update_config(
                 {'tools-metadata-url': new_agent_url})
-        uniquify_local(new_client.env)
         return cls(old_client, new_client, stage_attempts)
 
     def __init__(self, old_client, new_client, stage_attempts):

--- a/acceptancetests/jujupy/__init__.py
+++ b/acceptancetests/jujupy/__init__.py
@@ -22,13 +22,11 @@ from jujupy.client import (
     NameNotAccepted,
     NoProvider,
     parse_new_state_server_from_error,
-    SimpleEnvironment,
     SoftDeadlineExceeded,
     Status,
     temp_bootstrap_env,
     _temp_env,
     TypeNotAccepted,
-    uniquify_local,
     )
 from jujupy.configuration import (
     get_juju_data,
@@ -74,11 +72,9 @@ __all__ = [
     'NoProvider',
     'NoSuchEnvironment',
     'parse_new_state_server_from_error',
-    'SimpleEnvironment',
     'SoftDeadlineExceeded',
     'Status',
     'temp_bootstrap_env',
     '_temp_env',
     'TypeNotAccepted',
-    'uniquify_local',
     ]

--- a/acceptancetests/jujupy/client.py
+++ b/acceptancetests/jujupy/client.py
@@ -1299,7 +1299,7 @@ class Juju2Backend:
             current = json.loads(self.get_juju_output(
                 'models', ('--format', 'json'), set(),
                 juju_data_dir, model=None).decode('ascii'))
-        except subprocess.CalledProcessError as e:
+        except subprocess.CalledProcessError:
             raise NoActiveControllers(
                 'No active controller for {}'.format(juju_data_dir))
         try:
@@ -1313,7 +1313,7 @@ class Juju2Backend:
             current = json.loads(self.get_juju_output(
                 'controllers', ('--format', 'json'), set(),
                 juju_data_dir, model=None).decode('ascii'))
-        except subprocess.CalledProcessError as e:
+        except subprocess.CalledProcessError:
             raise NoActiveControllers(
                 'No active controller for {}'.format(juju_data_dir))
         try:
@@ -1328,7 +1328,7 @@ class Juju2Backend:
             current = json.loads(self.get_juju_output(
                 'controllers', ('--format', 'json'), set(),
                 juju_data_dir, model=None).decode('ascii'))
-        except subprocess.CalledProcessError as e:
+        except subprocess.CalledProcessError:
             raise NoActiveControllers(
                 'No active controller for {}'.format(juju_data_dir))
         return current['controllers'][controller]['user']

--- a/acceptancetests/jujupy/tests/test_client.py
+++ b/acceptancetests/jujupy/tests/test_client.py
@@ -30,7 +30,6 @@ from jujupy.configuration import (
     get_bootstrap_config_path,
     get_environments_path,
     get_jenv_path,
-    NoSuchEnvironment,
     )
 from jujupy import (
     fake_juju_client,
@@ -70,10 +69,8 @@ from jujupy.client import (
     NameNotAccepted,
     NoActiveModel,
     NoopCondition,
-    NoProvider,
     parse_new_state_server_from_error,
     ProvisioningError,
-    SimpleEnvironment,
     SoftDeadlineExceeded,
     Status,
     StatusError,
@@ -85,7 +82,6 @@ from jujupy.client import (
     temp_bootstrap_env,
     temp_yaml_file,
     TypeNotAccepted,
-    uniquify_local,
     UnitError,
     WaitMachineNotPresent,
     WaitApplicationNotPresent
@@ -472,16 +468,6 @@ class TestModelClient(ClientTest):
         client = ModelClient(env, '1.25', 'full_path')
         self.assertIs(env, client.env)
 
-    def test_convert_to_juju_data(self):
-        env = SimpleEnvironment('foo', {'type': 'bar'}, 'baz')
-        with patch.object(JujuData, 'load_yaml'):
-            client = ModelClient(env, '1.25', 'full_path')
-            client.env.load_yaml.assert_called_once_with()
-        self.assertIsInstance(client.env, JujuData)
-        self.assertEqual(client.env.environment, 'foo')
-        self.assertEqual(client.env._config, {'type': 'bar'})
-        self.assertEqual(client.env.juju_home, 'baz')
-
     def test_get_version(self):
         value = ' 5.6 \n'.encode('ascii')
         with patch('subprocess.check_output', return_value=value) as vsn:
@@ -511,13 +497,6 @@ class TestModelClient(ClientTest):
         with patch.object(client, '_upgrade_juju') as juju_mock:
             client.upgrade_juju()
         juju_mock.assert_called_with(('--agent-version', '2.0'))
-
-    def test_upgrade_juju_local(self):
-        client = ModelClient(
-            JujuData('foo', {'type': 'local'}), '2.0-betaX', None)
-        with patch.object(client, '_upgrade_juju') as juju_mock:
-            client.upgrade_juju()
-        juju_mock.assert_called_with(('--agent-version', '2.0',))
 
     def test_upgrade_juju_no_force_version(self):
         client = ModelClient(
@@ -1279,7 +1258,7 @@ class TestModelClient(ClientTest):
 
     def test_deploy_storage(self):
         env = ModelClient(
-            SimpleEnvironment('foo', {'type': 'local'}), '1.234-76', None)
+            JujuData('foo', {'type': 'local'}), '1.234-76', None)
         with patch_juju_call(env) as mock_juju:
             env.deploy('mondogb', storage='rootfs,1G')
         mock_juju.assert_called_with(
@@ -1287,7 +1266,7 @@ class TestModelClient(ClientTest):
 
     def test_deploy_constraints(self):
         env = ModelClient(
-            SimpleEnvironment('foo', {'type': 'local'}), '1.234-76', None)
+            JujuData('foo', {'type': 'local'}), '1.234-76', None)
         with patch_juju_call(env) as mock_juju:
             env.deploy('mondogb', constraints='virt-type=kvm')
         mock_juju.assert_called_with(
@@ -3754,54 +3733,6 @@ class TestModelClient(ClientTest):
         self.assertRaises(ValueError, client.switch)
 
 
-class TestUniquifyLocal(TestCase):
-
-    def test_uniquify_local_empty(self):
-        env = SimpleEnvironment('foo', {'type': 'local'})
-        uniquify_local(env)
-        self.assertEqual(env._config, {
-            'type': 'local',
-            'api-port': 17071,
-            'state-port': 37018,
-            'storage-port': 8041,
-            'syslog-port': 6515,
-        })
-
-    def test_uniquify_local_preset(self):
-        env = SimpleEnvironment('foo', {
-            'type': 'local',
-            'api-port': 17071,
-            'state-port': 37018,
-            'storage-port': 8041,
-            'syslog-port': 6515,
-        })
-        uniquify_local(env)
-        self.assertEqual(env._config, {
-            'type': 'local',
-            'api-port': 17072,
-            'state-port': 37019,
-            'storage-port': 8042,
-            'syslog-port': 6516,
-        })
-
-    def test_uniquify_nonlocal(self):
-        env = SimpleEnvironment('foo', {
-            'type': 'nonlocal',
-            'api-port': 17071,
-            'state-port': 37018,
-            'storage-port': 8041,
-            'syslog-port': 6515,
-        })
-        uniquify_local(env)
-        self.assertEqual(env._config, {
-            'type': 'nonlocal',
-            'api-port': 17071,
-            'state-port': 37018,
-            'storage-port': 8041,
-            'syslog-port': 6515,
-        })
-
-
 @contextmanager
 def bootstrap_context(client=None):
     # Avoid unnecessary syscalls.
@@ -3876,7 +3807,7 @@ class TestTempBootstrapEnv(FakeHomeTestCase):
         return ModelClient(env, '1.24-fake', 'fake-juju-path')
 
     def test_no_config_mangling_side_effect(self):
-        env = SimpleEnvironment('qux', {'type': 'local'})
+        env = JujuData('qux', {'type': 'local'})
         client = self.get_client(env)
         with bootstrap_context(client) as fake_home:
             with temp_bootstrap_env(fake_home, client):
@@ -3884,7 +3815,7 @@ class TestTempBootstrapEnv(FakeHomeTestCase):
         self.assertEqual(env.provider, 'local')
 
     def test_temp_bootstrap_env_environment(self):
-        env = SimpleEnvironment('qux', {'type': 'local'})
+        env = JujuData('qux', {'type': 'not-local'}, juju_home='')
         with bootstrap_context() as fake_home:
             client = self.get_client(env)
             with temp_bootstrap_env(fake_home, client):
@@ -3896,16 +3827,13 @@ class TestTempBootstrapEnv(FakeHomeTestCase):
                 expected_target = os.path.realpath(
                     get_jenv_path(temp_home, 'qux'))
                 self.assertEqual(symlink_target, expected_target)
-                config = yaml.safe_load(
-                    open(get_environments_path(temp_home)))
+                with open(get_environments_path(temp_home)) as content:
+                    config = yaml.safe_load(content.read())
                 self.assertEqual(
                     config, {
                         'environments': {
                             'qux': {
-                                'type': 'local',
-                                'root-dir': get_local_root(
-                                    fake_home,
-                                    client.env),
+                                'type': 'not-local',
                                 'test-mode': True,
                                 'name': 'qux',
                             }
@@ -3914,7 +3842,7 @@ class TestTempBootstrapEnv(FakeHomeTestCase):
                 stub_bootstrap(client)
 
     def test_temp_bootstrap_env_provides_dir(self):
-        env = SimpleEnvironment('qux', {'type': 'local'})
+        env = JujuData('qux', {'type': 'local'})
         client = self.get_client(env)
         juju_home = os.path.join(self.home_dir, 'asdf')
 
@@ -3929,7 +3857,7 @@ class TestTempBootstrapEnv(FakeHomeTestCase):
         self.assertEqual(temp_home, juju_home)
 
     def test_temp_bootstrap_env_no_set_home(self):
-        env = SimpleEnvironment('qux', {'type': 'local'})
+        env = JujuData('qux', {'type': 'local'})
         client = self.get_client(env)
         os.environ['JUJU_HOME'] = 'foo'
         os.environ['JUJU_DATA'] = 'bar'
@@ -3939,17 +3867,18 @@ class TestTempBootstrapEnv(FakeHomeTestCase):
                 self.assertEqual(os.environ['JUJU_DATA'], 'bar')
 
     def test_output(self):
-        env = SimpleEnvironment('qux', {'type': 'local'})
+        env = JujuData('qux', {'type': 'local'})
         client = self.get_client(env)
         with bootstrap_context(client) as fake_home:
             with temp_bootstrap_env(fake_home, client):
                 stub_bootstrap(client)
             jenv_path = get_jenv_path(fake_home, 'qux')
             self.assertFalse(os.path.islink(jenv_path))
-            self.assertEqual(open(jenv_path).read(), 'Bogus jenv')
+            with open(jenv_path) as contents:
+                self.assertEqual(contents.read(), 'Bogus jenv')
 
     def test_rename_on_exception(self):
-        env = SimpleEnvironment('qux', {'type': 'local'})
+        env = JujuData('qux', {'type': 'local'})
         client = self.get_client(env)
         with bootstrap_context(client) as fake_home:
             with self.assertRaisesRegexp(Exception, 'test-rename'):
@@ -3958,10 +3887,11 @@ class TestTempBootstrapEnv(FakeHomeTestCase):
                     raise Exception('test-rename')
             jenv_path = get_jenv_path(os.environ['JUJU_HOME'], 'qux')
             self.assertFalse(os.path.islink(jenv_path))
-            self.assertEqual(open(jenv_path).read(), 'Bogus jenv')
+            with open(jenv_path) as content:
+                self.assertEqual(content.read(), 'Bogus jenv')
 
     def test_exception_no_jenv(self):
-        env = SimpleEnvironment('qux', {'type': 'local'})
+        env = JujuData('qux', {'type': 'local'})
         client = self.get_client(env)
         with bootstrap_context(client) as fake_home:
             with self.assertRaisesRegexp(Exception, 'test-rename'):
@@ -3972,21 +3902,11 @@ class TestTempBootstrapEnv(FakeHomeTestCase):
             jenv_path = get_jenv_path(os.environ['JUJU_HOME'], 'qux')
             self.assertFalse(os.path.lexists(jenv_path))
 
-    def test_check_space_local_lxc(self):
-        env = SimpleEnvironment('qux', {'type': 'local'})
-        with bootstrap_context() as fake_home:
-            client = self.get_client(env)
-            with patch('jujupy.client.check_free_disk_space') as mock_cfds:
-                with temp_bootstrap_env(fake_home, client):
-                    stub_bootstrap(client)
-        self.assertEqual(mock_cfds.mock_calls, [
-            call(os.path.join(fake_home, 'qux'), 8000000, 'MongoDB files'),
-            call('/var/lib/lxc', 2000000, 'LXC containers'),
-        ])
-
     def test_check_space_local_kvm(self):
-        env = SimpleEnvironment('qux', {'type': 'local', 'container': 'kvm'})
         with bootstrap_context() as fake_home:
+            env = JujuData(
+                'qux',
+                {'type': 'local', 'container': 'kvm'})
             client = self.get_client(env)
             with patch('jujupy.client.check_free_disk_space') as mock_cfds:
                 with temp_bootstrap_env(fake_home, client):
@@ -3997,7 +3917,7 @@ class TestTempBootstrapEnv(FakeHomeTestCase):
         ])
 
     def test_error_on_jenv(self):
-        env = SimpleEnvironment('qux', {'type': 'local'})
+        env = JujuData('qux', {'type': 'local'})
         client = self.get_client(env)
         with bootstrap_context(client) as fake_home:
             jenv_path = get_jenv_path(fake_home, 'qux')
@@ -4009,7 +3929,7 @@ class TestTempBootstrapEnv(FakeHomeTestCase):
                     stub_bootstrap(client)
 
     def test_not_permanent(self):
-        env = SimpleEnvironment('qux', {'type': 'local'})
+        env = JujuData('qux', {'type': 'local'})
         client = self.get_client(env)
         with bootstrap_context(client) as fake_home:
             client.env.juju_home = fake_home
@@ -4027,7 +3947,7 @@ class TestTempBootstrapEnv(FakeHomeTestCase):
                             jes_home_path(fake_home, client.env.environment))
 
     def test_permanent(self):
-        env = SimpleEnvironment('qux', {'type': 'local'})
+        env = JujuData('qux', {'type': 'local'})
         client = self.get_client(env)
         with bootstrap_context(client) as fake_home:
             client.env.juju_home = fake_home
@@ -5106,294 +5026,6 @@ class TestController(TestCase):
         self.assertEqual('ctrl', controller.name)
 
 
-class TestSimpleEnvironment(TestCase):
-
-    def test_init(self):
-        controller = Mock()
-        with temp_dir() as juju_home:
-            juju_data = SimpleEnvironment(
-                'foo', {'enable_os_upgrade': False},
-                juju_home=juju_home, controller=controller,
-                bootstrap_to='zone=baz')
-            self.assertEqual(juju_home, juju_data.juju_home)
-            self.assertIs(controller, juju_data.controller)
-            self.assertEqual('zone=baz', juju_data.bootstrap_to)
-
-    def test_default_controller(self):
-        default = SimpleEnvironment('foo')
-        self.assertEqual('foo', default.controller.name)
-
-    def test_clone(self):
-        orig = SimpleEnvironment('foo', {'type': 'bar'}, 'myhome')
-        orig.local = 'local1'
-        orig.kvm = 'kvm1'
-        orig.maas = 'maas1'
-        orig.joyent = 'joyent1'
-        orig.user_name = 'user1'
-        orig.bootstrap_to = 'zonea'
-        copy = orig.clone()
-        self.assertIs(SimpleEnvironment, type(copy))
-        self.assertIsNot(orig, copy)
-        self.assertEqual(copy.environment, 'foo')
-        self.assertIsNot(orig._config, copy._config)
-        self.assertEqual({'type': 'bar'}, copy._config)
-        self.assertEqual('myhome', copy.juju_home)
-        self.assertEqual('local1', copy.local)
-        self.assertEqual('kvm1', copy.kvm)
-        self.assertEqual('maas1', copy.maas)
-        self.assertEqual('joyent1', copy.joyent)
-        self.assertEqual('user1', copy.user_name)
-        self.assertEqual('zonea', copy.bootstrap_to)
-        self.assertIs(orig.controller, copy.controller)
-
-    def test_clone_model_name(self):
-        orig = SimpleEnvironment('foo', {'type': 'bar', 'name': 'oldname'},
-                                 'myhome')
-        copy = orig.clone(model_name='newname')
-        self.assertEqual('newname', copy.environment)
-        self.assertEqual('newname', copy.get_option('name'))
-
-    def test_set_model_name(self):
-        env = SimpleEnvironment('foo', {})
-        env.set_model_name('bar')
-        self.assertEqual(env.environment, 'bar')
-        self.assertEqual(env.controller.name, 'bar')
-        self.assertEqual(env.get_option('name'), 'bar')
-
-    def test_set_model_name_not_controller(self):
-        env = SimpleEnvironment('foo', {})
-        env.set_model_name('bar', set_controller=False)
-        self.assertEqual(env.environment, 'bar')
-        self.assertEqual(env.controller.name, 'foo')
-        self.assertEqual(env.get_option('name'), 'bar')
-
-    def test_local_from_config(self):
-        env = SimpleEnvironment('local', {'type': 'openstack'})
-        self.assertFalse(env.local, 'Does not respect config type.')
-        env = SimpleEnvironment('local', {'type': 'local'})
-        self.assertTrue(env.local, 'Does not respect config type.')
-
-    def test_kvm_from_config(self):
-        env = SimpleEnvironment('local', {'type': 'local'})
-        self.assertFalse(env.kvm, 'Does not respect config type.')
-        env = SimpleEnvironment('local',
-                                {'type': 'local', 'container': 'kvm'})
-        self.assertTrue(env.kvm, 'Does not respect config type.')
-
-    def test_from_config(self):
-        with temp_config():
-            env = SimpleEnvironment.from_config('foo')
-            self.assertIs(SimpleEnvironment, type(env))
-            self.assertEqual({'type': 'local'}, env._config)
-
-    def test_from_bogus_config(self):
-        with temp_config():
-            with self.assertRaises(NoSuchEnvironment):
-                SimpleEnvironment.from_config('bar')
-
-    def test_from_config_none(self):
-        with temp_config():
-            os.environ['JUJU_ENV'] = 'foo'
-            # GZ 2015-10-15: Currently default_env calls the juju on path here.
-            with patch('jujupy.configuration.default_env', autospec=True,
-                       return_value='foo') as cde_mock:
-                env = SimpleEnvironment.from_config(None)
-            self.assertEqual(env.environment, 'foo')
-            cde_mock.assert_called_once_with()
-
-    def test_juju_home(self):
-        env = SimpleEnvironment('foo')
-        self.assertIs(None, env.juju_home)
-        env = SimpleEnvironment('foo', juju_home='baz')
-        self.assertEqual('baz', env.juju_home)
-
-    def test_make_jes_home(self):
-        with temp_dir() as juju_home:
-            with SimpleEnvironment('foo').make_jes_home(
-                    juju_home, 'bar', {'baz': 'qux'}) as jes_home:
-                pass
-            with open(get_environments_path(jes_home)) as env_file:
-                env = yaml.safe_load(env_file)
-        self.assertEqual(env, {'baz': 'qux'})
-        self.assertEqual(jes_home, jes_home_path(juju_home, 'bar'))
-
-    def test_make_jes_home_clean_existing(self):
-        env = SimpleEnvironment('foo')
-        with temp_dir() as juju_home:
-            with env.make_jes_home(juju_home, 'bar',
-                                   {'baz': 'qux'}) as jes_home:
-                foo_path = os.path.join(jes_home, 'foo')
-                with open(foo_path, 'w') as foo:
-                    foo.write('foo')
-                self.assertTrue(os.path.isfile(foo_path))
-            with env.make_jes_home(juju_home, 'bar',
-                                   {'baz': 'qux'}) as jes_home:
-                self.assertFalse(os.path.exists(foo_path))
-
-    def test_discard_option(self):
-        env = SimpleEnvironment('foo', {'type': 'foo', 'bar': 'baz'})
-        discarded = env.discard_option('bar')
-        self.assertEqual('baz', discarded)
-        self.assertEqual({'type': 'foo'}, env._config)
-
-    def test_discard_option_not_present(self):
-        env = SimpleEnvironment('foo', {'type': 'foo'})
-        discarded = env.discard_option('bar')
-        self.assertIs(None, discarded)
-        self.assertEqual({'type': 'foo'}, env._config)
-
-    def test_get_option(self):
-        env = SimpleEnvironment('foo', {'type': 'azure', 'foo': 'bar'})
-        self.assertEqual(env.get_option('foo'), 'bar')
-        self.assertIs(env.get_option('baz'), None)
-
-    def test_get_option_sentinel(self):
-        env = SimpleEnvironment('foo', {'type': 'azure', 'foo': 'bar'})
-        sentinel = object()
-        self.assertIs(env.get_option('baz', sentinel), sentinel)
-
-    def test_make_jes_home_copy_public_clouds(self):
-        file_name = 'public-clouds.yaml'
-        env = SimpleEnvironment('foo')
-        test_string = 'Test string for: {}'.format(file_name)
-        with temp_dir() as juju_home:
-            with open(os.path.join(juju_home, file_name), 'w') as file:
-                file.write(test_string)
-            with env.make_jes_home(juju_home, 'bar',
-                                   {'baz': 'qux'}) as jes_home:
-                with open(os.path.join(jes_home, file_name)) as file:
-                    contents = file.readlines()
-        self.assertEqual([test_string], contents)
-
-    def test_update_config(self):
-        env = SimpleEnvironment('foo', {'type': 'azure'})
-        env.update_config({'bar': 'baz', 'qux': 'quxx'})
-        self.assertEqual(env._config, {
-            'type': 'azure', 'bar': 'baz', 'qux': 'quxx'})
-
-    def test_update_config_region(self):
-        env = SimpleEnvironment('foo', {'type': 'azure'})
-        env.update_config({'region': 'foo1'})
-        self.assertEqual(env._config, {
-            'type': 'azure', 'location': 'foo1'})
-        self.assertEqual('WARNING Using set_region to set region to "foo1".\n',
-                         self.log_stream.getvalue())
-
-    def test_update_config_type(self):
-        env = SimpleEnvironment('foo', {'type': 'azure'})
-        env.update_config({'type': 'foo1'})
-        self.assertEqual(env.provider, 'foo1')
-        self.assertEqual('WARNING Setting type is not 2.x compatible.\n',
-                         self.log_stream.getvalue())
-
-    def test_provider(self):
-        env = SimpleEnvironment('foo', {'type': 'provider1'})
-        self.assertEqual('provider1', env.provider)
-
-    def test_provider_no_provider(self):
-        env = SimpleEnvironment('foo', {'foo': 'bar'})
-        with self.assertRaisesRegexp(NoProvider, 'No provider specified.'):
-            env.provider
-
-    def test_get_region(self):
-        self.assertEqual(
-            'bar', SimpleEnvironment(
-                'foo', {'type': 'foo', 'region': 'bar'}, 'home').get_region())
-
-    def test_get_region_old_azure(self):
-        self.assertEqual('northeu', SimpleEnvironment('foo', {
-            'type': 'azure', 'location': 'North EU'}, 'home').get_region())
-
-    def test_get_region_azure_arm(self):
-        self.assertEqual('bar', SimpleEnvironment('foo', {
-            'type': 'azure', 'location': 'bar', 'tenant-id': 'baz'},
-            'home').get_region())
-
-    def test_get_region_joyent(self):
-        self.assertEqual('bar', SimpleEnvironment('foo', {
-            'type': 'joyent', 'sdc-url': 'https://bar.api.joyentcloud.com'},
-            'home').get_region())
-
-    def test_get_region_lxd(self):
-        self.assertEqual('localhost', SimpleEnvironment(
-            'foo', {'type': 'lxd'}, 'home').get_region())
-
-    def test_get_region_lxd_specified(self):
-        self.assertEqual('foo', SimpleEnvironment(
-            'foo', {'type': 'lxd', 'region': 'foo'}, 'home').get_region())
-
-    def test_get_region_maas(self):
-        self.assertIs(None, SimpleEnvironment('foo', {
-            'type': 'maas', 'region': 'bar',
-        }, 'home').get_region())
-
-    def test_get_region_manual(self):
-        self.assertEqual('baz', SimpleEnvironment('foo', {
-            'type': 'manual', 'region': 'bar',
-            'bootstrap-host': 'baz'}, 'home').get_region())
-
-    def test_set_region(self):
-        env = SimpleEnvironment('foo', {'type': 'bar'}, 'home')
-        env.set_region('baz')
-        self.assertEqual(env.get_option('region'), 'baz')
-        self.assertEqual(env.get_region(), 'baz')
-
-    def test_set_region_no_provider(self):
-        env = SimpleEnvironment('foo', {}, 'home')
-        env.set_region('baz')
-        self.assertEqual(env.get_option('region'), 'baz')
-
-    def test_set_region_joyent(self):
-        env = SimpleEnvironment('foo', {'type': 'joyent'}, 'home')
-        env.set_region('baz')
-        self.assertEqual(env.get_option('sdc-url'),
-                         'https://baz.api.joyentcloud.com')
-        self.assertEqual(env.get_region(), 'baz')
-
-    def test_set_region_azure(self):
-        env = SimpleEnvironment('foo', {'type': 'azure'}, 'home')
-        env.set_region('baz')
-        self.assertEqual(env.get_option('location'), 'baz')
-        self.assertEqual(env.get_region(), 'baz')
-
-    def test_set_region_lxd(self):
-        env = SimpleEnvironment('foo', {'type': 'lxd'}, 'home')
-        env.set_region('baz')
-        self.assertEqual(env.get_option('region'), 'baz')
-
-    def test_set_region_manual(self):
-        env = SimpleEnvironment('foo', {'type': 'manual'}, 'home')
-        env.set_region('baz')
-        self.assertEqual(env.get_option('bootstrap-host'), 'baz')
-        self.assertEqual(env.get_region(), 'baz')
-
-    def test_set_region_maas(self):
-        env = SimpleEnvironment('foo', {'type': 'maas'}, 'home')
-        with self.assertRaisesRegexp(ValueError,
-                                     'Only None allowed for maas.'):
-            env.set_region('baz')
-        env.set_region(None)
-        self.assertIs(env.get_region(), None)
-
-    def test_get_cloud_credentials_returns_config(self):
-        env = SimpleEnvironment(
-            'foo', {'type': 'ec2', 'region': 'foo'}, 'home')
-        env.credentials = {'credentials': {
-            'aws': {'credentials': {'aws': True}},
-            'azure': {'credentials': {'azure': True}},
-            }}
-        self.assertEqual(env._config, env.get_cloud_credentials())
-
-    def test_dump_yaml(self):
-        env = SimpleEnvironment('baz', {'type': 'qux'}, 'home')
-        with temp_dir() as path:
-            env.dump_yaml(path, {'foo': 'bar'})
-            self.assertItemsEqual(
-                ['environments.yaml'], os.listdir(path))
-            with open(os.path.join(path, 'environments.yaml')) as f:
-                self.assertEqual({'foo': 'bar'}, yaml.safe_load(f))
-
-
 class TestJujuData(TestCase):
 
     def test_init(self):
@@ -5468,6 +5100,13 @@ class TestJujuData(TestCase):
                         bootstrap_to='zonea', cloud_name='cloudname')
         orig.credentials = {'secret': 'password'}
         orig.clouds = {'name': {'meta': 'data'}}
+        orig.local = 'local1'
+        orig.kvm = 'kvm1'
+        orig.maas = 'maas1'
+        orig.joyent = 'joyent1'
+        orig.user_name = 'user1'
+        orig.bootstrap_to = 'zonea'
+
         copy = orig.clone()
         self.assertIs(JujuData, type(copy))
         self.assertIsNot(orig, copy)
@@ -5481,6 +5120,22 @@ class TestJujuData(TestCase):
         self.assertIsNot(orig.clouds, copy.clouds)
         self.assertEqual(orig.clouds, copy.clouds)
         self.assertEqual('cloudname', copy._cloud_name)
+        self.assertEqual({'type': 'bar'}, copy._config)
+        self.assertEqual('myhome', copy.juju_home)
+        self.assertEqual('local1', copy.local)
+        self.assertEqual('kvm1', copy.kvm)
+        self.assertEqual('maas1', copy.maas)
+        self.assertEqual('joyent1', copy.joyent)
+        self.assertEqual('user1', copy.user_name)
+        self.assertEqual('zonea', copy.bootstrap_to)
+        self.assertIs(orig.controller, copy.controller)
+
+    def test_set_model_name(self):
+        env = JujuData('foo', {}, juju_home='')
+        env.set_model_name('bar')
+        self.assertEqual(env.environment, 'bar')
+        self.assertEqual(env.controller.name, 'bar')
+        self.assertEqual(env.get_option('name'), 'bar')
 
     def test_clone_model_name(self):
         orig = JujuData('foo', {'type': 'bar', 'name': 'oldname'}, 'myhome')
@@ -5489,6 +5144,18 @@ class TestJujuData(TestCase):
         copy = orig.clone(model_name='newname')
         self.assertEqual('newname', copy.environment)
         self.assertEqual('newname', copy.get_option('name'))
+
+    def test_discard_option(self):
+        env = JujuData('foo', {'type': 'foo', 'bar': 'baz'}, juju_home='')
+        discarded = env.discard_option('bar')
+        self.assertEqual('baz', discarded)
+        self.assertEqual({'type': 'foo'}, env._config)
+
+    def test_discard_option_not_present(self):
+        env = JujuData('foo', {'type': 'foo'}, juju_home='')
+        discarded = env.discard_option('bar')
+        self.assertIs(None, discarded)
+        self.assertEqual({'type': 'foo'}, env._config)
 
     def test_update_config(self):
         env = JujuData('foo', {'type': 'azure'}, juju_home='')
@@ -5731,73 +5398,88 @@ class TestJujuData(TestCase):
             data = JujuData('baz', {'type': 'qux'}, path)
             data.load_yaml()
 
+    def test_get_option(self):
+        env = JujuData('foo', {'type': 'azure', 'foo': 'bar'}, juju_home='')
+        self.assertEqual(env.get_option('foo'), 'bar')
+        self.assertIs(env.get_option('baz'), None)
+
+    def test_get_option_sentinel(self):
+        env = JujuData('foo', {'type': 'azure', 'foo': 'bar'}, juju_home='')
+        sentinel = object()
+        self.assertIs(env.get_option('baz', sentinel), sentinel)
+
 
 class TestDescribeSubstrate(TestCase):
 
+    def setUp(self):
+        super(TestDescribeSubstrate, self).setUp()
+        # JujuData expects a JUJU_HOME or HOME env as it gets juju_home_path
+        os.environ['HOME'] = '/tmp/jujupy-tests/'
+
     def test_local_lxc(self):
-        env = SimpleEnvironment('foo', {
+        env = JujuData('foo', {
             'type': 'local',
             })
         self.assertEqual(describe_substrate(env), 'LXC (local)')
-        env = SimpleEnvironment('foo', {
+        env = JujuData('foo', {
             'type': 'local',
             'container': 'lxc',
             })
         self.assertEqual(describe_substrate(env), 'LXC (local)')
 
     def test_local_kvm(self):
-        env = SimpleEnvironment('foo', {
+        env = JujuData('foo', {
             'type': 'local',
             'container': 'kvm',
             })
         self.assertEqual(describe_substrate(env), 'KVM (local)')
 
     def test_openstack(self):
-        env = SimpleEnvironment('foo', {
+        env = JujuData('foo', {
             'type': 'openstack',
             'auth-url': 'foo',
             })
         self.assertEqual(describe_substrate(env), 'Openstack')
 
     def test_canonistack(self):
-        env = SimpleEnvironment('foo', {
+        env = JujuData('foo', {
             'type': 'openstack',
             'auth-url': 'https://keystone.canonistack.canonical.com:443/v2.0/',
             })
         self.assertEqual(describe_substrate(env), 'Canonistack')
 
     def test_aws(self):
-        env = SimpleEnvironment('foo', {
+        env = JujuData('foo', {
             'type': 'ec2',
             })
         self.assertEqual(describe_substrate(env), 'AWS')
 
     def test_rackspace(self):
-        env = SimpleEnvironment('foo', {
+        env = JujuData('foo', {
             'type': 'rackspace',
             })
         self.assertEqual(describe_substrate(env), 'Rackspace')
 
     def test_joyent(self):
-        env = SimpleEnvironment('foo', {
+        env = JujuData('foo', {
             'type': 'joyent',
             })
         self.assertEqual(describe_substrate(env), 'Joyent')
 
     def test_azure(self):
-        env = SimpleEnvironment('foo', {
+        env = JujuData('foo', {
             'type': 'azure',
             })
         self.assertEqual(describe_substrate(env), 'Azure')
 
     def test_maas(self):
-        env = SimpleEnvironment('foo', {
+        env = JujuData('foo', {
             'type': 'maas',
             })
         self.assertEqual(describe_substrate(env), 'MAAS')
 
     def test_bar(self):
-        env = SimpleEnvironment('foo', {
+        env = JujuData('foo', {
             'type': 'bar',
             })
         self.assertEqual(describe_substrate(env), 'bar')

--- a/acceptancetests/quickstart_deploy.py
+++ b/acceptancetests/quickstart_deploy.py
@@ -78,5 +78,6 @@ def main():
         print('%s (%s)' % (e, type(e).__name__))
         sys.exit(1)
 
+
 if __name__ == '__main__':
     main()

--- a/acceptancetests/run_chaos_monkey.py
+++ b/acceptancetests/run_chaos_monkey.py
@@ -90,5 +90,6 @@ def main():
     run_while_healthy_or_timeout(monkey_runner)
     logging.info("Chaos Monkey Complete.")
 
+
 if __name__ == '__main__':
     main()

--- a/acceptancetests/run_deploy_job_wr.py
+++ b/acceptancetests/run_deploy_job_wr.py
@@ -37,5 +37,6 @@ def main():
             '--s3-config', s3_config, '-v',
             ])
 
+
 if __name__ == '__main__':
     main()

--- a/acceptancetests/start_libvirt_domain.py
+++ b/acceptancetests/start_libvirt_domain.py
@@ -14,5 +14,6 @@ def main():
     status_msg = start_libvirt_domain(args.URI, args.domain)
     print("%s" % status_msg)
 
+
 if __name__ == '__main__':
     main()

--- a/acceptancetests/stop_libvirt_domain.py
+++ b/acceptancetests/stop_libvirt_domain.py
@@ -14,5 +14,6 @@ def main():
     status_msg = stop_libvirt_domain(args.URI, args.domain)
     print("%s" % status_msg)
 
+
 if __name__ == '__main__':
     main()

--- a/acceptancetests/substrate.py
+++ b/acceptancetests/substrate.py
@@ -110,7 +110,7 @@ class AWSAccount:
     @classmethod
     @contextmanager
     def from_boot_config(cls, boot_config, region=None):
-        """Create an AWSAccount from a SimpleEnvironment or JujuData."""
+        """Create an AWSAccount from a JujuData object."""
         config = get_config(boot_config)
         euca_environ = get_euca_env(config)
         if region is None:
@@ -282,7 +282,7 @@ class OpenStackAccount:
     @classmethod
     @contextmanager
     def from_boot_config(cls, boot_config):
-        """Create an OpenStackAccount from a SimpleEnvironment or JujuData."""
+        """Create an OpenStackAccount from a JujuData object."""
         config = get_config(boot_config)
         yield cls(
             config['username'], config['password'], config['tenant-name'],
@@ -350,7 +350,7 @@ class JoyentAccount:
     def from_boot_config(cls, boot_config):
         """Create a ContextManager for a JoyentAccount.
 
-         Using a SimpleEnvironment or JujuData, the private key is written to
+         Using a JujuData object, the private key is written to
          a tmp file. Then, the Joyent client is inited with the path to the
          tmp key. The key is removed when done.
          """

--- a/acceptancetests/tests/test_deploy_stack.py
+++ b/acceptancetests/tests/test_deploy_stack.py
@@ -52,7 +52,6 @@ from deploy_stack import (
     update_env,
     wait_for_state_server_to_shutdown,
     error_if_unclean,
-    test_on_controller
     )
 from jujupy import (
     fake_juju_client,

--- a/acceptancetests/upload_jenkins_job.py
+++ b/acceptancetests/upload_jenkins_job.py
@@ -14,7 +14,7 @@ from boto.s3.connection import S3Connection
 import requests
 from requests.auth import HTTPBasicAuth
 
-from jujuci import(
+from jujuci import (
     get_build_data,
     add_credential_args,
     get_credentials,
@@ -374,6 +374,7 @@ def main(argv=None):
         print('Uploading the latest test result.')
         print('WARNING: latest can be a moving target.')
         uploader.upload_last_completed_test_result()
+
 
 if __name__ == '__main__':
     sys.exit(main(sys.argv[1:]))

--- a/acceptancetests/write_industrial_test_metadata.py
+++ b/acceptancetests/write_industrial_test_metadata.py
@@ -5,7 +5,7 @@ import json
 from jujupy.client import (
     describe_substrate,
     ModelClient,
-    SimpleEnvironment,
+    JujuData,
     )
 
 
@@ -26,7 +26,7 @@ def make_metadata(buildvars_path, env_name):
     :param env_name: Name of the environment being used.
     """
     old_version = ModelClient.get_version()
-    env = SimpleEnvironment.from_config(env_name)
+    env = JujuData.from_config(env_name)
     with open(buildvars_path) as buildvars_file:
         buildvars = json.load(buildvars_file)
     metadata = {


### PR DESCRIPTION
Remove any reference to SimpleEnvironment.

SimpleEnvironment is from Juju 1 days and is no longer needed as there is JujuData.
This branch also removes some un-used cruft (parts that deal with 'local' provider) but doesn't remove all of it. There is more cruft to remove in up-coming branches.