### PR TITLE
Consuming model records reason for suspending a relation

### DIFF
--- a/api/uniter/relation_test.go
+++ b/api/uniter/relation_test.go
@@ -67,7 +67,7 @@ func (s *relationSuite) TestRefresh(c *gc.C) {
 	err = s.stateRelation.Destroy()
 	c.Assert(err, jc.ErrorIsNil)
 	// Update suspended as well.
-	err = s.stateRelation.SetSuspended(false)
+	err = s.stateRelation.SetSuspended(false, "")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(s.apiRelation.Life(), gc.Equals, params.Alive)
 	c.Assert(s.apiRelation.Suspended(), jc.IsTrue)

--- a/api/uniter/relationunit_test.go
+++ b/api/uniter/relationunit_test.go
@@ -41,7 +41,7 @@ func (m *commonRelationSuiteMixin) SetUpTest(c *gc.C, s uniterSuite) {
 
 	// Add a relation, used by both this suite and relationSuite.
 	m.stateRelation = s.addRelation(c, "wordpress", "mysql")
-	err := m.stateRelation.SetSuspended(true)
+	err := m.stateRelation.SetSuspended(true, "")
 	c.Assert(err, jc.ErrorIsNil)
 }
 

--- a/api/uniter/uniter_test.go
+++ b/api/uniter/uniter_test.go
@@ -117,7 +117,7 @@ func (s *uniterSuite) addRelatedApplication(c *gc.C, firstApp, relatedApp string
 func (s *uniterSuite) addRelationSuspended(c *gc.C, firstApp, relatedApp string, unit *state.Unit) *state.Relation {
 	s.AddTestingApplication(c, relatedApp, s.AddTestingCharm(c, relatedApp))
 	rel := s.addRelation(c, firstApp, relatedApp)
-	err := rel.SetSuspended(true)
+	err := rel.SetSuspended(true, "")
 	c.Assert(err, jc.ErrorIsNil)
 	return rel
 }

--- a/api/watcher/watcher.go
+++ b/api/watcher/watcher.go
@@ -349,9 +349,10 @@ func (w *relationStatusWatcher) loop(initialChanges []params.RelationLifeSuspend
 		result := make([]watcher.RelationStatusChange, len(changes))
 		for i, ch := range changes {
 			result[i] = watcher.RelationStatusChange{
-				Key:       ch.Key,
-				Life:      life.Value(ch.Life),
-				Suspended: ch.Suspended,
+				Key:             ch.Key,
+				Life:            life.Value(ch.Life),
+				Suspended:       ch.Suspended,
+				SuspendedReason: ch.SuspendedReason,
 			}
 		}
 		return result

--- a/apiserver/common/crossmodel/interface.go
+++ b/apiserver/common/crossmodel/interface.go
@@ -120,8 +120,11 @@ type Relation interface {
 	// Suspended returns the suspended status of the relation.
 	Suspended() bool
 
+	// SuspendedReason returns the reason why the relation is suspended.
+	SuspendedReason() string
+
 	// SetSuspended sets the suspended status of the relation.
-	SetSuspended(bool) error
+	SetSuspended(bool, string) error
 }
 
 // RelationUnit provides access to the settings of a single unit in a relation,

--- a/apiserver/facades/agent/uniter/uniter_test.go
+++ b/apiserver/facades/agent/uniter/uniter_test.go
@@ -1943,7 +1943,7 @@ func (s *uniterSuite) TestRelationsSuspended(c *gc.C) {
 
 	s.AddTestingApplication(c, "logging", s.AddTestingCharm(c, "logging"))
 	rel2 := s.addRelation(c, "wordpress", "logging")
-	err = rel2.SetSuspended(true)
+	err = rel2.SetSuspended(true, "")
 	c.Assert(err, jc.ErrorIsNil)
 
 	args := params.Entities{
@@ -2013,7 +2013,7 @@ func (s *uniterSuite) TestSetRelationsStatusLeader(c *gc.C) {
 
 	s.AddTestingApplication(c, "logging", s.AddTestingCharm(c, "logging"))
 	rel2 := s.addRelation(c, "wordpress", "logging")
-	err = rel2.SetSuspended(true)
+	err = rel2.SetSuspended(true, "")
 	c.Assert(err, jc.ErrorIsNil)
 	err = rel.SetStatus(status.StatusInfo{Status: status.Suspending, Message: ""})
 	c.Assert(err, jc.ErrorIsNil)

--- a/apiserver/facades/client/application/application.go
+++ b/apiserver/facades/client/application/application.go
@@ -1108,7 +1108,11 @@ func (api *API) SetRelationsSuspended(args params.RelationSuspendedArgs) (params
 		if errors.IsNotFound(err) {
 			return errors.Errorf("cannot set suspend status for %q which is not associated with an offer", rel.Tag().Id())
 		}
-		err = rel.SetSuspended(arg.Suspended)
+		message := arg.Message
+		if !arg.Suspended {
+			message = ""
+		}
+		err = rel.SetSuspended(arg.Suspended, message)
 		if err != nil {
 			return errors.Trace(err)
 		}

--- a/apiserver/facades/client/application/application_unit_test.go
+++ b/apiserver/facades/client/application/application_unit_test.go
@@ -490,6 +490,7 @@ func (s *ApplicationSuite) TestSetRelationSuspended(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results.OneError(), gc.IsNil)
 	c.Assert(s.relation.suspended, jc.IsTrue)
+	c.Assert(s.relation.suspendedReason, gc.Equals, "message")
 	c.Assert(s.relation.status, gc.Equals, status.Suspending)
 	c.Assert(s.relation.message, gc.Equals, "message")
 }
@@ -513,6 +514,7 @@ func (s *ApplicationSuite) TestSetRelationSuspendedNoOp(c *gc.C) {
 func (s *ApplicationSuite) TestSetRelationSuspendedFalse(c *gc.C) {
 	s.backend.offerConnections["wordpress:db mysql:db"] = &mockOfferConnection{}
 	s.relation.suspended = true
+	s.relation.suspendedReason = "reason"
 	s.relation.status = status.Error
 	results, err := s.api.SetRelationsSuspended(params.RelationSuspendedArgs{
 		Args: []params.RelationSuspendedArg{{
@@ -523,6 +525,7 @@ func (s *ApplicationSuite) TestSetRelationSuspendedFalse(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results.OneError(), gc.IsNil)
 	c.Assert(s.relation.suspended, jc.IsFalse)
+	c.Assert(s.relation.suspendedReason, gc.Equals, "")
 	c.Assert(s.relation.status, gc.Equals, status.Joining)
 }
 

--- a/apiserver/facades/client/application/backend.go
+++ b/apiserver/facades/client/application/backend.go
@@ -103,8 +103,9 @@ type Relation interface {
 	Tag() names.Tag
 	Destroy() error
 	Endpoint(string) (state.Endpoint, error)
-	SetSuspended(bool) error
+	SetSuspended(bool, string) error
 	Suspended() bool
+	SuspendedReason() string
 }
 
 // Unit defines a subset of the functionality provided by the

--- a/apiserver/facades/client/application/mock_test.go
+++ b/apiserver/facades/client/application/mock_test.go
@@ -521,10 +521,11 @@ type mockRelation struct {
 	application.Relation
 	jtesting.Stub
 
-	tag       names.Tag
-	status    status.Status
-	message   string
-	suspended bool
+	tag             names.Tag
+	status          status.Status
+	message         string
+	suspended       bool
+	suspendedReason string
 }
 
 func (r *mockRelation) Tag() names.Tag {
@@ -538,15 +539,21 @@ func (r *mockRelation) SetStatus(status status.StatusInfo) error {
 	return r.NextErr()
 }
 
-func (r *mockRelation) SetSuspended(suspended bool) error {
+func (r *mockRelation) SetSuspended(suspended bool, reason string) error {
 	r.MethodCall(r, "SetSuspended")
 	r.suspended = suspended
+	r.suspendedReason = reason
 	return r.NextErr()
 }
 
 func (r *mockRelation) Suspended() bool {
 	r.MethodCall(r, "Suspended")
 	return r.suspended
+}
+
+func (r *mockRelation) SuspendedReason() string {
+	r.MethodCall(r, "SuspendedReason")
+	return r.suspendedReason
 }
 
 func (r *mockRelation) Destroy() error {

--- a/apiserver/facades/controller/crossmodelrelations/mock_test.go
+++ b/apiserver/facades/controller/crossmodelrelations/mock_test.go
@@ -280,12 +280,13 @@ func (m *mockModel) Owner() names.UserTag {
 type mockRelation struct {
 	commoncrossmodel.Relation
 	testing.Stub
-	id        int
-	key       string
-	suspended bool
-	status    status.Status
-	message   string
-	units     map[string]commoncrossmodel.RelationUnit
+	id              int
+	key             string
+	suspended       bool
+	suspendedReason string
+	status          status.Status
+	message         string
+	units           map[string]commoncrossmodel.RelationUnit
 }
 
 func newMockRelation(id int) *mockRelation {
@@ -321,15 +322,21 @@ func (r *mockRelation) SetStatus(statusInfo status.StatusInfo) error {
 	return nil
 }
 
-func (r *mockRelation) SetSuspended(suspended bool) error {
+func (r *mockRelation) SetSuspended(suspended bool, reason string) error {
 	r.MethodCall(r, "SetSuspended")
 	r.suspended = suspended
+	r.suspendedReason = reason
 	return nil
 }
 
 func (r *mockRelation) Suspended() bool {
 	r.MethodCall(r, "Suspended")
 	return r.suspended
+}
+
+func (r *mockRelation) SuspendedReason() string {
+	r.MethodCall(r, "SuspendedReason")
+	return r.suspendedReason
 }
 
 func (r *mockRelation) RemoteUnit(unitId string) (commoncrossmodel.RelationUnit, error) {

--- a/apiserver/params/crossmodel.go
+++ b/apiserver/params/crossmodel.go
@@ -327,6 +327,8 @@ type RemoteRelationChangeEvent struct {
 	// Suspended is the current suspended status of the relation.
 	Suspended *bool `json:"suspended,omitempty"`
 
+	SuspendedReason string `json:"suspended-reason,omitempty"`
+
 	// ChangedUnits maps unit tokens to relation unit changes.
 	ChangedUnits []RemoteRelationUnitChange `json:"changed-units,omitempty"`
 
@@ -349,6 +351,9 @@ type RelationLifeSuspendedStatusChange struct {
 
 	// Suspended is the suspended status of the relation.
 	Suspended bool `json:"suspended"`
+
+	// SuspendedReason is an optional message to explain why suspended is true.
+	SuspendedReason string `json:"suspended-reason"`
 }
 
 // RelationLifeSuspendedStatusWatchResult holds a RelationStatusWatcher id, baseline state

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -21,7 +21,7 @@ github.com/juju/ansiterm	git	b99631de12cf04a906c1d4e4ec54fb86eae5863d	2016-09-07
 github.com/juju/blobstore	git	06056004b3d7b54bbb7984d830c537bad00fec21	2015-07-29T11:18:58Z
 github.com/juju/bundlechanges	git	cd189848b313df50084de692b05861210022cf81	2017-07-31T02:12:50Z
 github.com/juju/cmd	git	ad2437ef0ef282ae26e482eb1e44c02532bae1ba	2017-06-22T12:53:07Z
-github.com/juju/description	git	b322b32e476ddce9a408adc4ec1488710a0c4c08	2017-09-25T16:26:11Z
+github.com/juju/description	git	fc3fd7dfc2ebcda03985d7b741596bb42bc9a666	2017-09-27T13:38:51Z
 github.com/juju/errors	git	1b5e39b83d1835fa480e0c2ddefb040ee82d58b3	2015-09-16T12:56:42Z
 github.com/juju/gnuflag	git	4e76c56581859c14d9d87e1ddbe29e1c0f10195f	2016-08-09T16:52:14Z
 github.com/juju/go-oracle-cloud	git	932a8cea00a1cd5cba3829a672c823955db674ae	2017-04-21T13:45:47Z

--- a/state/application_test.go
+++ b/state/application_test.go
@@ -2465,7 +2465,7 @@ func (s *ApplicationSuite) TestWatchRelations(c *gc.C) {
 	wpxWatcherC.AssertChange(relx.String())
 	wpxWatcherC.AssertNoChange()
 
-	err = relx.SetSuspended(true)
+	err = relx.SetSuspended(true, "")
 	c.Assert(err, jc.ErrorIsNil)
 	wpxWatcherC.AssertChange(relx.String())
 	wpxWatcherC.AssertNoChange()

--- a/state/migration_internal_test.go
+++ b/state/migration_internal_test.go
@@ -443,6 +443,7 @@ func (s *MigrationSuite) TestRelationDocFields(c *gc.C) {
 		"Id",
 		"Endpoints",
 		"Suspended",
+		"SuspendedReason",
 		// Life isn't exported, only alive.
 		"Life",
 		// UnitCount isn't explicitly exported, but defined by the stored

--- a/state/relation_test.go
+++ b/state/relation_test.go
@@ -496,7 +496,7 @@ func (s *RelationSuite) TestWatchLifeSuspendedStatus(c *gc.C) {
 	wc.AssertChange(rel.Tag().Id())
 	wc.AssertNoChange()
 
-	err = rel.SetSuspended(true)
+	err = rel.SetSuspended(true, "reason")
 	c.Assert(err, jc.ErrorIsNil)
 	wc.AssertChange(rel.Tag().Id())
 	wc.AssertNoChange()
@@ -593,28 +593,45 @@ func (s *RelationSuite) TestSetSuspend(c *gc.C) {
 	// Suspend doesn't need an offer connection to be there.
 	state.RemoveOfferConnectionsForRelation(c, rel)
 	c.Assert(rel.Suspended(), jc.IsFalse)
-	err := rel.SetSuspended(true)
+	err := rel.SetSuspended(true, "reason")
 	c.Assert(err, jc.ErrorIsNil)
 	rel, err = s.State.Relation(rel.Id())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(rel.Suspended(), jc.IsTrue)
+	c.Assert(rel.SuspendedReason(), gc.Equals, "reason")
+}
+
+func (s *RelationSuite) TestSetSuspendFalse(c *gc.C) {
+	rel := s.setupRelationStatus(c)
+	// Suspend doesn't need an offer connection to be there.
+	state.RemoveOfferConnectionsForRelation(c, rel)
+	c.Assert(rel.Suspended(), jc.IsFalse)
+	err := rel.SetSuspended(true, "reason")
+	c.Assert(err, jc.ErrorIsNil)
+	err = rel.SetSuspended(false, "reason")
+	c.Assert(err, gc.ErrorMatches, "cannot set suspended reason if not suspended")
+	err = rel.SetSuspended(false, "")
+	c.Assert(err, jc.ErrorIsNil)
+	rel, err = s.State.Relation(rel.Id())
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(rel.Suspended(), jc.IsFalse)
 }
 
 func (s *RelationSuite) TestResumeRelationNoConsumeAccess(c *gc.C) {
 	rel := s.setupRelationStatus(c)
-	err := rel.SetSuspended(true)
+	err := rel.SetSuspended(true, "reason")
 	c.Assert(err, jc.ErrorIsNil)
 	err = s.State.UpdateOfferAccess(
 		names.NewApplicationOfferTag("hosted-mysql"), names.NewUserTag("fred"), permission.ReadAccess)
 	c.Assert(err, jc.ErrorIsNil)
-	err = rel.SetSuspended(false)
+	err = rel.SetSuspended(false, "")
 	c.Assert(err, gc.ErrorMatches,
 		`cannot resume relation "wordpress:db mysql:server" where user "fred" does not have consume permission`)
 }
 
 func (s *RelationSuite) TestResumeRelationNoConsumeAccessRace(c *gc.C) {
 	rel := s.setupRelationStatus(c)
-	err := rel.SetSuspended(true)
+	err := rel.SetSuspended(true, "reason")
 	c.Assert(err, jc.ErrorIsNil)
 
 	defer state.SetBeforeHooks(c, s.State, func() {
@@ -623,7 +640,7 @@ func (s *RelationSuite) TestResumeRelationNoConsumeAccessRace(c *gc.C) {
 		c.Assert(err, jc.ErrorIsNil)
 	}).Check()
 
-	err = rel.SetSuspended(false)
+	err = rel.SetSuspended(false, "")
 	c.Assert(err, gc.ErrorMatches,
 		`cannot resume relation "wordpress:db mysql:server" where user "fred" does not have consume permission`)
 }

--- a/watcher/relationstatus.go
+++ b/watcher/relationstatus.go
@@ -15,6 +15,9 @@ type RelationStatusChange struct {
 	// Suspended is the suspended status of the relation.
 	Suspended bool
 
+	// SuspendedReason is an optional message to explain why suspend is true.
+	SuspendedReason string
+
 	// Life is the relation life value, eg Alive.
 	Life life.Value
 }

--- a/worker/firewaller/firewaller_test.go
+++ b/worker/firewaller/firewaller_test.go
@@ -1059,12 +1059,12 @@ func (s *InstanceModeSuite) TestRemoteRelationProviderRoleOffering(c *gc.C) {
 	})
 
 	// And again when relation is suspended.
-	err = rel.SetSuspended(true)
+	err = rel.SetSuspended(true, "")
 	c.Assert(err, jc.ErrorIsNil)
 	s.assertPorts(c, inst, m.Id(), nil)
 
 	// And again when relation is resumed.
-	err = rel.SetSuspended(false)
+	err = rel.SetSuspended(false, "")
 	c.Assert(err, jc.ErrorIsNil)
 	s.assertPorts(c, inst, m.Id(), []network.IngressRule{
 		network.MustNewIngressRule("tcp", 3306, 3306, "10.0.0.4/16"),

--- a/worker/remoterelations/remoterelationsworker.go
+++ b/worker/remoterelations/remoterelationsworker.go
@@ -104,6 +104,7 @@ func (w *remoteRelationsWorker) relationUnitsChangeEvent(
 		ApplicationToken: w.applicationToken,
 		Life:             params.Life(change.Life),
 		Suspended:        &suspended,
+		SuspendedReason:  change.SuspendedReason,
 	}
 	return event, nil
 }

--- a/worker/uniter/runner/context/relation_test.go
+++ b/worker/uniter/runner/context/relation_test.go
@@ -184,7 +184,7 @@ func convertMap(settingsMap map[string]interface{}) params.Settings {
 func (s *ContextRelationSuite) TestSuspended(c *gc.C) {
 	_, err := s.app.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
-	err = s.rel.SetSuspended(true)
+	err = s.rel.SetSuspended(true, "")
 	c.Assert(err, jc.ErrorIsNil)
 
 	ctx := context.NewContextRelation(s.apiRelUnit, nil)


### PR DESCRIPTION
## Description of change

When the admin of an offer suspends a cross model relation, the reason they give is now propagated to the consuming model and recorded in the status message.

## QA steps

Deploy a cmr scenario
suspend a relation with a message
observe the message appears in status on the consuming side

