### PR TITLE
Display active and total connection counts in offer status

### DIFF
--- a/api/applicationoffers/client.go
+++ b/api/applicationoffers/client.go
@@ -12,6 +12,7 @@ import (
 	"github.com/juju/juju/api/base"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/core/crossmodel"
+	"github.com/juju/juju/core/relation"
 	"github.com/juju/juju/permission"
 )
 
@@ -108,7 +109,7 @@ func convertListResultsToModel(items []params.ApplicationOfferDetails) ([]crossm
 				Username:        oc.Username,
 				Endpoint:        oc.Endpoint,
 				RelationId:      oc.RelationId,
-				Status:          oc.Status.Status.String(),
+				Status:          relation.Status(oc.Status.Status),
 				Message:         oc.Status.Info,
 				Since:           oc.Status.Since,
 				IngressSubnets:  oc.IngressSubnets,

--- a/apiserver/facades/client/client/api_test.go
+++ b/apiserver/facades/client/client/api_test.go
@@ -191,7 +191,8 @@ var scenarioStatus = &params.FullStatus{
 					Interface: "mysql",
 					Role:      "provider",
 				}},
-			ConnectedCount: 1,
+			ActiveConnectedCount: 0,
+			TotalConnectedCount:  1,
 		},
 	},
 	Applications: map[string]params.ApplicationStatus{
@@ -441,6 +442,7 @@ func (s *baseSuite) setUpScenario(c *gc.C) (entities []names.Tag) {
 		Username:        "fred",
 		OfferUUID:       offer.OfferUUID,
 		RelationId:      mwRel.Id(),
+		RelationKey:     mwRel.Tag().Id(),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 

--- a/apiserver/facades/client/client/status.go
+++ b/apiserver/facades/client/client/status.go
@@ -594,7 +594,8 @@ func fetchOffers(st Backend, applications map[string]*state.Application) (map[st
 			offerInfo.err = err
 			continue
 		} else if err == nil {
-			offerInfo.connectedCount = rc.ConnectionCount()
+			offerInfo.totalConnectedCount = rc.TotalConnectionCount()
+			offerInfo.activeConnectedCount = rc.ActiveConnectionCount()
 		}
 		offersMap[offer.OfferName] = offerInfo
 	}
@@ -965,21 +966,23 @@ func (context *statusContext) processRemoteApplication(application *state.Remote
 
 type offerStatus struct {
 	crossmodel.ApplicationOffer
-	err            error
-	charmURL       string
-	connectedCount int
+	err                  error
+	charmURL             string
+	activeConnectedCount int
+	totalConnectedCount  int
 }
 
 func (context *statusContext) processOffers() map[string]params.ApplicationOfferStatus {
 	offers := make(map[string]params.ApplicationOfferStatus)
 	for name, offer := range context.offers {
 		offerStatus := params.ApplicationOfferStatus{
-			Err:             offer.err,
-			ApplicationName: offer.ApplicationName,
-			OfferName:       offer.OfferName,
-			CharmURL:        offer.charmURL,
-			Endpoints:       make(map[string]params.RemoteEndpoint),
-			ConnectedCount:  offer.connectedCount,
+			Err:                  offer.err,
+			ApplicationName:      offer.ApplicationName,
+			OfferName:            offer.OfferName,
+			CharmURL:             offer.charmURL,
+			Endpoints:            make(map[string]params.RemoteEndpoint),
+			ActiveConnectedCount: offer.activeConnectedCount,
+			TotalConnectedCount:  offer.totalConnectedCount,
 		}
 		for name, ep := range offer.Endpoints {
 			offerStatus.Endpoints[name] = params.RemoteEndpoint{

--- a/apiserver/params/status.go
+++ b/apiserver/params/status.go
@@ -132,12 +132,13 @@ type RemoteApplicationStatus struct {
 
 // ApplicationOfferStatus holds status info about an application offer.
 type ApplicationOfferStatus struct {
-	Err             error                     `json:"err,omitempty"`
-	OfferName       string                    `json:"offer-name"`
-	ApplicationName string                    `json:"application-name"`
-	CharmURL        string                    `json:"charm"`
-	Endpoints       map[string]RemoteEndpoint `json:"endpoints"`
-	ConnectedCount  int                       `json:"connected-count"`
+	Err                  error                     `json:"err,omitempty"`
+	OfferName            string                    `json:"offer-name"`
+	ApplicationName      string                    `json:"application-name"`
+	CharmURL             string                    `json:"charm"`
+	Endpoints            map[string]RemoteEndpoint `json:"endpoints"`
+	ActiveConnectedCount int                       `json:"active-connected-count"`
+	TotalConnectedCount  int                       `json:"total-connected-count"`
 }
 
 // MeterStatus represents the meter status of a unit.

--- a/cmd/juju/crossmodel/list.go
+++ b/cmd/juju/crossmodel/list.go
@@ -261,7 +261,7 @@ func convertOfferToListItem(url *crossmodel.ApplicationURL, offer crossmodel.App
 			RelationId:      conn.RelationId,
 			Endpoint:        conn.Endpoint,
 			Status: offerConnectionStatus{
-				Current: conn.Status,
+				Current: conn.Status.String(),
 				Message: conn.Message,
 				Since:   friendlyDuration(conn.Since),
 			},

--- a/cmd/juju/crossmodel/list_test.go
+++ b/cmd/juju/crossmodel/list_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/juju/juju/cmd/juju/crossmodel"
 	model "github.com/juju/juju/core/crossmodel"
+	"github.com/juju/juju/core/relation"
 )
 
 type ListSuite struct {
@@ -89,7 +90,7 @@ func (s *ListSuite) TestListFormatError(c *gc.C) {
 
 func (s *ListSuite) TestListSummary(c *gc.C) {
 	// For summary output, we don't care about the content, just the count.
-	conns1 := []model.OfferConnection{{}, {}, {}}
+	conns1 := []model.OfferConnection{{Status: relation.Joined}, {}, {}}
 	conns2 := []model.OfferConnection{{}, {}}
 	// Insert in random order to check sorting.
 	s.applications = append(s.applications, model.ApplicationOfferDetailsResult{Result: s.createOfferItem("zdiff-db2", "differentstore", conns1)})
@@ -100,11 +101,11 @@ func (s *ListSuite) TestListSummary(c *gc.C) {
 		[]string{"--format", "summary"},
 		`
 Offer       Application     Charm     Connected  Store           URL                                  Endpoint  Interface  Role
-zdiff-db2   app-zdiff-db2   cs:db2-5  3          differentstore  differentstore:fred/model.zdiff-db2  log       http       provider
+zdiff-db2   app-zdiff-db2   cs:db2-5  1/3        differentstore  differentstore:fred/model.zdiff-db2  log       http       provider
                                                                                                       mysql     db2        requirer
-hosted-db2  app-hosted-db2  cs:db2-5  0          myctrl          myctrl:fred/model.hosted-db2         log       http       provider
+hosted-db2  app-hosted-db2  cs:db2-5  0/0        myctrl          myctrl:fred/model.hosted-db2         log       http       provider
                                                                                                       mysql     db2        requirer
-adiff-db2   app-adiff-db2   cs:db2-5  2          vendor          vendor:fred/model.adiff-db2          log       http       provider
+adiff-db2   app-adiff-db2   cs:db2-5  0/2        vendor          vendor:fred/model.adiff-db2          log       http       provider
                                                                                                       mysql     db2        requirer
 
 `[1:],
@@ -121,7 +122,7 @@ func (s *ListSuite) TestListWithErrors(c *gc.C) {
 		[]string{"--format", "summary"},
 		`
 Offer       Application     Charm     Connected  Store   URL                           Endpoint  Interface  Role
-hosted-db2  app-hosted-db2  cs:db2-5  0          myctrl  myctrl:fred/model.hosted-db2  log       http       provider
+hosted-db2  app-hosted-db2  cs:db2-5  0/0        myctrl  myctrl:fred/model.hosted-db2  log       http       provider
                                                                                        mysql     db2        requirer
 
 `[1:],

--- a/cmd/juju/crossmodel/listformatter.go
+++ b/cmd/juju/crossmodel/listformatter.go
@@ -54,8 +54,15 @@ func formatListEndpointsSummary(writer io.Writer, offers offeredApplications) er
 			if i == 0 {
 				// As there is some information about offer and its endpoints,
 				// only display offer information once when the first endpoint is displayed.
-				connectedCount := len(offer.Connections)
-				w.Println(offer.OfferName, offer.ApplicationName, offer.CharmURL, fmt.Sprint(connectedCount),
+				totalConnectedCount := len(offer.Connections)
+				activeConnectedCount := 0
+				for _, conn := range offer.Connections {
+					if conn.Status.Current == relation.Joined.String() {
+						activeConnectedCount++
+					}
+				}
+				w.Println(offer.OfferName, offer.ApplicationName, offer.CharmURL,
+					fmt.Sprintf("%v/%v", activeConnectedCount, totalConnectedCount),
 					offer.Source, offer.OfferURL, endpointName, endpoint.Interface, endpoint.Role)
 				continue
 			}

--- a/cmd/juju/status/formatted.go
+++ b/cmd/juju/status/formatted.go
@@ -154,12 +154,13 @@ func (s remoteApplicationStatus) MarshalYAML() (interface{}, error) {
 type offerStatusNoMarshal offerStatus
 
 type offerStatus struct {
-	Err             error                     `json:"-" yaml:",omitempty"`
-	OfferName       string                    `json:"-" yaml:",omitempty"`
-	ApplicationName string                    `json:"application" yaml:"application"`
-	CharmURL        string                    `json:"charm,omitempty" yaml:"charm,omitempty"`
-	ConnectedCount  int                       `json:"connected-count,omitempty" yaml:"connected-count,omitempty"`
-	Endpoints       map[string]remoteEndpoint `json:"endpoints" yaml:"endpoints"`
+	Err                  error                     `json:"-" yaml:",omitempty"`
+	OfferName            string                    `json:"-" yaml:",omitempty"`
+	ApplicationName      string                    `json:"application" yaml:"application"`
+	CharmURL             string                    `json:"charm,omitempty" yaml:"charm,omitempty"`
+	TotalConnectedCount  int                       `json:"total-connected-count,omitempty" yaml:"total-connected-count,omitempty"`
+	ActiveConnectedCount int                       `json:"active-connected-count,omitempty" yaml:"active-connected-count,omitempty"`
+	Endpoints            map[string]remoteEndpoint `json:"endpoints" yaml:"endpoints"`
 }
 
 func (s offerStatus) MarshalJSON() ([]byte, error) {

--- a/cmd/juju/status/formatter.go
+++ b/cmd/juju/status/formatter.go
@@ -290,10 +290,11 @@ func (sf *statusFormatter) getRemoteApplicationStatusInfo(application params.Rem
 
 func (sf *statusFormatter) formatOffer(name string, offer params.ApplicationOfferStatus) offerStatus {
 	out := offerStatus{
-		Err:             offer.Err,
-		ApplicationName: offer.ApplicationName,
-		CharmURL:        offer.CharmURL,
-		ConnectedCount:  offer.ConnectedCount,
+		Err:                  offer.Err,
+		ApplicationName:      offer.ApplicationName,
+		CharmURL:             offer.CharmURL,
+		ActiveConnectedCount: offer.ActiveConnectedCount,
+		TotalConnectedCount:  offer.TotalConnectedCount,
 	}
 	out.Endpoints = make(map[string]remoteEndpoint)
 	for alias, ep := range offer.Endpoints {

--- a/cmd/juju/status/output_tabular.go
+++ b/cmd/juju/status/output_tabular.go
@@ -245,7 +245,8 @@ func printOffers(tw *ansiterm.TabWriter, offers map[string]offerStatus) error {
 					return errors.Trace(err)
 				}
 				w.Println(offerName, offer.ApplicationName, curl.Name, fmt.Sprint(curl.Revision),
-					fmt.Sprint(offer.ConnectedCount), endpointName, endpoint.Interface, endpoint.Role)
+					fmt.Sprintf("%v/%v", offer.ActiveConnectedCount, offer.TotalConnectedCount),
+					endpointName, endpoint.Interface, endpoint.Role)
 				continue
 			}
 			// Subsequent lines only need to display endpoint information.

--- a/cmd/juju/status/status_test.go
+++ b/cmd/juju/status/status_test.go
@@ -3305,6 +3305,7 @@ func (oc addOfferConnection) step(c *gc.C, ctx *context) {
 		OfferUUID:       offer.OfferUUID,
 		Username:        oc.username,
 		RelationId:      rel.Id(),
+		RelationKey:     rel.Tag().Id(),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 }
@@ -4110,7 +4111,7 @@ Machine  State    DNS       Inst id       Series   AZ          Message
 3        started  10.0.3.1  controller-3  quantal              I am number three
 
 Offer         Application  Charm  Rev  Connected  Endpoint  Interface  Role
-hosted-mysql  mysql        mysql  1    1          server    mysql      provider
+hosted-mysql  mysql        mysql  1    1/1        server    mysql      provider
 
 Relation provider      Requirer                   Interface  Type         Message
 mysql:juju-info        logging:info               juju-info  subordinate  

--- a/core/crossmodel/params.go
+++ b/core/crossmodel/params.go
@@ -4,8 +4,11 @@
 package crossmodel
 
 import (
-	"gopkg.in/juju/charm.v6-unstable"
 	"time"
+
+	"gopkg.in/juju/charm.v6-unstable"
+
+	"github.com/juju/juju/core/relation"
 )
 
 // ApplicationOfferDetails represents a remote application used when vendor
@@ -46,7 +49,7 @@ type OfferConnection struct {
 	Endpoint string
 
 	// Status is the status of the offer connection.
-	Status string
+	Status relation.Status
 
 	// Message is the status message of the offer connection.
 	Message string

--- a/state/allwatcher.go
+++ b/state/allwatcher.go
@@ -579,7 +579,8 @@ func (app *backingRemoteApplication) updateOfferInfo(st *State, store *multiwatc
 	if err != nil {
 		return errors.Trace(err)
 	}
-	offerInfo.ConnectedCount = remoteConnection.ConnectionCount()
+	offerInfo.TotalConnectedCount = remoteConnection.TotalConnectionCount()
+	offerInfo.ActiveConnectedCount = remoteConnection.ActiveConnectionCount()
 	store.Update(offerInfo)
 	return nil
 }
@@ -637,7 +638,8 @@ func updateOfferInfo(st *State, offerInfo *multiwatcher.ApplicationOfferInfo) er
 	if err != nil {
 		return errors.Trace(err)
 	}
-	offerInfo.ConnectedCount = remoteConnection.ConnectionCount()
+	offerInfo.TotalConnectedCount = remoteConnection.TotalConnectionCount()
+	offerInfo.ActiveConnectedCount = remoteConnection.ActiveConnectionCount()
 	return nil
 }
 

--- a/state/multiwatcher/multiwatcher.go
+++ b/state/multiwatcher/multiwatcher.go
@@ -223,12 +223,13 @@ func (i *RemoteApplicationInfo) EntityId() EntityId {
 // ApplicationOfferInfo holds the information about an application offer that is
 // tracked by multiwatcherStore.
 type ApplicationOfferInfo struct {
-	ModelUUID       string `json:"model-uuid"`
-	OfferName       string `json:"offer-name"`
-	OfferUUID       string `json:"offer-uuid"`
-	ApplicationName string `json:"application-name"`
-	CharmName       string `json:"charm-name"`
-	ConnectedCount  int    `json:"connected-count"`
+	ModelUUID            string `json:"model-uuid"`
+	OfferName            string `json:"offer-name"`
+	OfferUUID            string `json:"offer-uuid"`
+	ApplicationName      string `json:"application-name"`
+	CharmName            string `json:"charm-name"`
+	TotalConnectedCount  int    `json:"total-connected-count"`
+	ActiveConnectedCount int    `json:"active-connected-count"`
 }
 
 // EntityId returns a unique identifier for an application offer across models.

--- a/state/offerconnections_test.go
+++ b/state/offerconnections_test.go
@@ -7,31 +7,67 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
+	"fmt"
 	"github.com/juju/errors"
 	"github.com/juju/juju/state"
+	"github.com/juju/juju/status"
 	"github.com/juju/juju/testing"
 )
 
 type offerConnectionsSuite struct {
 	ConnSuite
+
+	suspendedRel *state.Relation
+	activeRel    *state.Relation
 }
 
 var _ = gc.Suite(&offerConnectionsSuite{})
 
+func (s *offerConnectionsSuite) SetUpTest(c *gc.C) {
+	s.ConnSuite.SetUpTest(c)
+	s.AddTestingApplication(c, "mysql", s.AddTestingCharm(c, "mysql"))
+	wpCh := s.AddTestingCharm(c, "wordpress")
+	s.AddTestingApplication(c, "wordpress", wpCh)
+	s.AddTestingApplication(c, "wordpress2", wpCh)
+
+	eps, err := s.State.InferEndpoints("wordpress", "mysql")
+	c.Assert(err, jc.ErrorIsNil)
+	s.activeRel, err = s.State.AddRelation(eps...)
+	c.Assert(err, jc.ErrorIsNil)
+	err = s.activeRel.SetStatus(status.StatusInfo{Status: status.Joined})
+	c.Assert(err, jc.ErrorIsNil)
+
+	eps, err = s.State.InferEndpoints("wordpress2", "mysql")
+	c.Assert(err, jc.ErrorIsNil)
+	s.suspendedRel, err = s.State.AddRelation(eps...)
+	c.Assert(err, jc.ErrorIsNil)
+	err = s.suspendedRel.SetStatus(status.StatusInfo{Status: status.Suspended})
+	c.Assert(err, jc.ErrorIsNil)
+}
+
 func (s *offerConnectionsSuite) TestAddOfferConnection(c *gc.C) {
 	oc, err := s.State.AddOfferConnection(state.AddOfferConnectionParams{
 		SourceModelUUID: testing.ModelTag.Id(),
-		RelationId:      1,
-		RelationKey:     "rel-key",
+		RelationId:      s.suspendedRel.Id(),
+		RelationKey:     s.suspendedRel.Tag().Id(),
 		Username:        "fred",
 		OfferUUID:       "offer-uuid",
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(oc.SourceModelUUID(), gc.Equals, testing.ModelTag.Id())
-	c.Assert(oc.RelationId(), gc.Equals, 1)
-	c.Assert(oc.RelationKey(), gc.Equals, "rel-key")
+	c.Assert(oc.RelationId(), gc.Equals, s.suspendedRel.Id())
+	c.Assert(oc.RelationKey(), gc.Equals, s.suspendedRel.Tag().Id())
 	c.Assert(oc.OfferUUID(), gc.Equals, "offer-uuid")
 	c.Assert(oc.UserName(), gc.Equals, "fred")
+
+	_, err = s.State.AddOfferConnection(state.AddOfferConnectionParams{
+		SourceModelUUID: testing.ModelTag.Id(),
+		RelationId:      s.activeRel.Id(),
+		RelationKey:     s.activeRel.Tag().Id(),
+		Username:        "fred",
+		OfferUUID:       "offer-uuid",
+	})
+	c.Assert(err, jc.ErrorIsNil)
 
 	anotherState, err := s.State.ForModel(s.IAASModel.ModelTag())
 	c.Assert(err, jc.ErrorIsNil)
@@ -39,24 +75,33 @@ func (s *offerConnectionsSuite) TestAddOfferConnection(c *gc.C) {
 
 	rc, err := anotherState.RemoteConnectionStatus("offer-uuid")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(rc.ConnectionCount(), gc.Equals, 1)
+	c.Assert(rc.TotalConnectionCount(), gc.Equals, 2)
+	c.Assert(rc.ActiveConnectionCount(), gc.Equals, 1)
 
 	all, err := anotherState.OfferConnections("offer-uuid")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(all, gc.HasLen, 1)
+	c.Assert(all, gc.HasLen, 2)
 	c.Assert(all[0].SourceModelUUID(), gc.Equals, testing.ModelTag.Id())
-	c.Assert(all[0].RelationId(), gc.Equals, 1)
-	c.Assert(all[0].RelationKey(), gc.Equals, "rel-key")
+	c.Assert(all[0].RelationId(), gc.Equals, s.suspendedRel.Id())
+	c.Assert(all[0].RelationKey(), gc.Equals, s.suspendedRel.Tag().Id())
 	c.Assert(all[0].OfferUUID(), gc.Equals, "offer-uuid")
 	c.Assert(all[0].UserName(), gc.Equals, "fred")
-	c.Assert(all[0].String(), gc.Equals, `connection to "offer-uuid" by "fred" for relation 1`)
+	c.Assert(all[0].String(),
+		gc.Equals, fmt.Sprintf(`connection to "offer-uuid" by "fred" for relation %d`, s.suspendedRel.Id()))
+	c.Assert(all[1].SourceModelUUID(), gc.Equals, testing.ModelTag.Id())
+	c.Assert(all[1].RelationId(), gc.Equals, s.activeRel.Id())
+	c.Assert(all[1].RelationKey(), gc.Equals, s.activeRel.Tag().Id())
+	c.Assert(all[1].OfferUUID(), gc.Equals, "offer-uuid")
+	c.Assert(all[1].UserName(), gc.Equals, "fred")
+	c.Assert(all[1].String(),
+		gc.Equals, fmt.Sprintf(`connection to "offer-uuid" by "fred" for relation %d`, s.activeRel.Id()))
 }
 
 func (s *offerConnectionsSuite) TestAddOfferConnectionTwice(c *gc.C) {
 	_, err := s.State.AddOfferConnection(state.AddOfferConnectionParams{
 		SourceModelUUID: testing.ModelTag.Id(),
-		RelationId:      1,
-		RelationKey:     "rel-key",
+		RelationId:      s.activeRel.Id(),
+		RelationKey:     s.activeRel.Tag().Id(),
 		Username:        "fred",
 		OfferUUID:       "offer-uuid",
 	})
@@ -66,10 +111,10 @@ func (s *offerConnectionsSuite) TestAddOfferConnectionTwice(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	defer anotherState.Close()
 
-	_, err = anotherState.AddOfferConnection(state.AddOfferConnectionParams{
+	_, err = s.State.AddOfferConnection(state.AddOfferConnectionParams{
 		SourceModelUUID: testing.ModelTag.Id(),
-		RelationId:      1,
-		RelationKey:     "rel-key",
+		RelationId:      s.activeRel.Id(),
+		RelationKey:     s.activeRel.Tag().Id(),
 		Username:        "fred",
 		OfferUUID:       "offer-uuid",
 	})
@@ -79,8 +124,8 @@ func (s *offerConnectionsSuite) TestAddOfferConnectionTwice(c *gc.C) {
 func (s *offerConnectionsSuite) TestOfferConnectionForRelation(c *gc.C) {
 	oc, err := s.State.AddOfferConnection(state.AddOfferConnectionParams{
 		SourceModelUUID: testing.ModelTag.Id(),
-		RelationId:      1,
-		RelationKey:     "rel-key",
+		RelationId:      s.activeRel.Id(),
+		RelationKey:     s.activeRel.Tag().Id(),
 		Username:        "fred",
 		OfferUUID:       "offer-uuid",
 	})
@@ -92,7 +137,7 @@ func (s *offerConnectionsSuite) TestOfferConnectionForRelation(c *gc.C) {
 
 	_, err = anotherState.OfferConnectionForRelation("some-key")
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
-	obtained, err := anotherState.OfferConnectionForRelation("rel-key")
+	obtained, err := anotherState.OfferConnectionForRelation(s.activeRel.Tag().Id())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(obtained.RelationId(), gc.Equals, oc.RelationId())
 	c.Assert(obtained.RelationKey(), gc.Equals, oc.RelationKey())

--- a/state/relation_test.go
+++ b/state/relation_test.go
@@ -445,18 +445,19 @@ func (s *RelationSuite) TestRemoveAlsoDeletesRemoteOfferConnections(c *gc.C) {
 	_, err = s.State.AddOfferConnection(state.AddOfferConnectionParams{
 		SourceModelUUID: coretesting.ModelTag.Id(),
 		RelationId:      relation.Id(),
+		RelationKey:     relation.Tag().Id(),
 		Username:        "fred",
 		OfferUUID:       "offer-uuid",
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	rc, err := s.State.RemoteConnectionStatus("offer-uuid")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(rc.ConnectionCount(), gc.Equals, 1)
+	c.Assert(rc.TotalConnectionCount(), gc.Equals, 1)
 
 	state.RemoveRelation(c, relation)
 	rc, err = s.State.RemoteConnectionStatus("offer-uuid")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(rc.ConnectionCount(), gc.Equals, 0)
+	c.Assert(rc.TotalConnectionCount(), gc.Equals, 0)
 }
 
 func (s *RelationSuite) TestRemoveNoFeatureFlag(c *gc.C) {

--- a/state/remoteapplication_test.go
+++ b/state/remoteapplication_test.go
@@ -767,20 +767,21 @@ func (s *remoteApplicationSuite) TestDestroyWithOfferConnections(c *gc.C) {
 	_, err = s.State.AddOfferConnection(state.AddOfferConnectionParams{
 		SourceModelUUID: coretesting.ModelTag.Id(),
 		RelationId:      rel.Id(),
+		RelationKey:     rel.Tag().Id(),
 		Username:        "fred",
 		OfferUUID:       "offer-uuid",
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	rc, err := s.State.RemoteConnectionStatus("offer-uuid")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(rc.ConnectionCount(), gc.Equals, 1)
+	c.Assert(rc.TotalConnectionCount(), gc.Equals, 1)
 
 	err = s.application.Destroy()
 	c.Assert(err, jc.ErrorIsNil)
 
 	rc, err = s.State.RemoteConnectionStatus("offer-uuid")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(rc.ConnectionCount(), gc.Equals, 0)
+	c.Assert(rc.TotalConnectionCount(), gc.Equals, 0)
 }
 
 func (s *remoteApplicationSuite) TestDestroyWithReferencedRelation(c *gc.C) {


### PR DESCRIPTION
## Description of change

When displaying Juju offers, either via status or offers --format summary, we now show the number of active connections and total connections.

## QA steps

Deploy a cmr scenario with a few offer connections.
Suspend a relation.
run juju status and juju offers --format summary
Ensure the connected counts are correct

