### PR TITLE
destroy-{model,controller}: fix --destroy-storage

### DIFF
--- a/cmd/juju/controller/export_test.go
+++ b/cmd/juju/controller/export_test.go
@@ -97,6 +97,7 @@ func NewEnableDestroyControllerCommandForTest(api removeBlocksAPI, store jujucli
 func NewDestroyCommandForTest(
 	api destroyControllerAPI,
 	clientapi destroyClientAPI,
+	storageAPI storageAPI,
 	store jujuclient.ClientStore,
 	apierr error,
 ) cmd.Command {
@@ -106,6 +107,7 @@ func NewDestroyCommandForTest(
 			clientapi: clientapi,
 			apierr:    apierr,
 		},
+		storageAPI: storageAPI,
 	}
 	cmd.SetClientStore(store)
 	return modelcmd.WrapController(

--- a/cmd/juju/model/export_test.go
+++ b/cmd/juju/model/export_test.go
@@ -67,14 +67,16 @@ func NewDumpDBCommandForTest(api DumpDBAPI, store jujuclient.ClientStore) cmd.Co
 // NewDestroyCommandForTest returns a DestroyCommand with the api provided as specified.
 func NewDestroyCommandForTest(
 	api DestroyModelAPI,
-	configApi ModelConfigAPI,
+	configAPI ModelConfigAPI,
+	storageAPI StorageAPI,
 	refreshFunc func(jujuclient.ClientStore, string) error, store jujuclient.ClientStore,
 	sleepFunc func(time.Duration),
 ) cmd.Command {
 	cmd := &destroyCommand{
-		api:       api,
-		configApi: configApi,
-		sleepFunc: sleepFunc,
+		api:        api,
+		configAPI:  configAPI,
+		storageAPI: storageAPI,
+		sleepFunc:  sleepFunc,
 	}
 	cmd.SetClientStore(store)
 	cmd.SetModelRefresh(refreshFunc)


### PR DESCRIPTION
## Description of change

When destroying a pre-2.3 controller or model, we
require the user to specify --destroy-storage to
avoid users accidentally destroying storage. The
older controller will destroy storage without
prompting the user, so the client does the check.

This commit updates destroy-model and destroy-controller
to first check if there is any storage in the model
or controller, and only require the user to specify
--destroy-storage if there is storage. If there is
no storage, then continue to destroy the controller.

## QA steps

1. juju bootstrap localhost (juju 2.2.4)
2. juju deploy postgresql --storage pgdata=tmpfs
3. juju destroy-model -y default
(should fail, saying that you must specify --destroy-storage)
4. juju destroy-controller -y localhost
(should fail, saying that you must specify --destroy-storage)
5. juju remove-application postgresql
(wait for postgresql/0 and machine to be removed. storage should be removed too, because it's machine-scoped)
6. juju destroy-model -y default
(should succeed, as there's no storage in the model)
7. juju destroy-controller -y localhost
(should succeed, as there's only the controller model remaining, and that has no storage)

## Documentation changes

None.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1711125