### PR TITLE
Offer list user details

### DIFF
--- a/api/application/client.go
+++ b/api/application/client.go
@@ -631,9 +631,9 @@ func (c *Client) Consume(arg crossmodel.ConsumeApplicationArgs) (string, error) 
 	var consumeRes params.ErrorResults
 	args := params.ConsumeApplicationArgs{
 		Args: []params.ConsumeApplicationArg{{
-			ApplicationOffer: arg.ApplicationOffer,
-			ApplicationAlias: arg.ApplicationAlias,
-			Macaroon:         arg.Macaroon,
+			ApplicationOfferDetails: arg.Offer,
+			ApplicationAlias:        arg.ApplicationAlias,
+			Macaroon:                arg.Macaroon,
 		}},
 	}
 	if arg.ControllerInfo != nil {
@@ -653,7 +653,7 @@ func (c *Client) Consume(arg crossmodel.ConsumeApplicationArgs) (string, error) 
 	if err := consumeRes.Results[0].Error; err != nil {
 		return "", errors.Trace(err)
 	}
-	localName := arg.ApplicationOffer.OfferName
+	localName := arg.Offer.OfferName
 	if arg.ApplicationAlias != "" {
 		localName = arg.ApplicationAlias
 	}

--- a/api/application/client_test.go
+++ b/api/application/client_test.go
@@ -499,7 +499,7 @@ func (s *applicationSuite) TestDestroyUnitsInvalidIds(c *gc.C) {
 }
 
 func (s *applicationSuite) TestConsume(c *gc.C) {
-	offer := params.ApplicationOffer{
+	offer := params.ApplicationOfferDetails{
 		SourceModelTag:         "source model",
 		OfferName:              "an offer",
 		OfferUUID:              "offer-uuid",
@@ -528,10 +528,10 @@ func (s *applicationSuite) TestConsume(c *gc.C) {
 			c.Assert(ok, jc.IsTrue)
 			c.Assert(args.Args, jc.DeepEquals, []params.ConsumeApplicationArg{
 				{
-					ApplicationAlias: "alias",
-					ApplicationOffer: offer,
-					Macaroon:         mac,
-					ControllerInfo:   controllerInfo,
+					ApplicationAlias:        "alias",
+					ApplicationOfferDetails: offer,
+					Macaroon:                mac,
+					ControllerInfo:          controllerInfo,
 				},
 			})
 			if results, ok := result.(*params.ErrorResults); ok {
@@ -542,7 +542,7 @@ func (s *applicationSuite) TestConsume(c *gc.C) {
 		})
 	client := application.NewClient(apiCaller)
 	name, err := client.Consume(crossmodel.ConsumeApplicationArgs{
-		ApplicationOffer: offer,
+		Offer:            offer,
 		ApplicationAlias: "alias",
 		Macaroon:         mac,
 		ControllerInfo: &crossmodel.ControllerInfo{

--- a/api/applicationoffers/client.go
+++ b/api/applicationoffers/client.go
@@ -55,7 +55,7 @@ func (c *Client) Offer(modelUUID, application string, endpoints []string, offerN
 
 // ListOffers gets all remote applications that have been offered from this Juju model.
 // Each returned application satisfies at least one of the the specified filters.
-func (c *Client) ListOffers(filters ...crossmodel.ApplicationOfferFilter) ([]crossmodel.ApplicationOfferDetailsResult, error) {
+func (c *Client) ListOffers(filters ...crossmodel.ApplicationOfferFilter) ([]*crossmodel.ApplicationOfferDetails, error) {
 	var paramsFilter params.OfferFilters
 	for _, f := range filters {
 		// TODO(wallyworld) - include allowed users
@@ -73,48 +73,65 @@ func (c *Client) ListOffers(filters ...crossmodel.ApplicationOfferFilter) ([]cro
 		paramsFilter.Filters = append(paramsFilter.Filters, filterTerm)
 	}
 
-	applicationOffers := params.ListApplicationOffersResults{}
-	err := c.facade.FacadeCall("ListApplicationOffers", paramsFilter, &applicationOffers)
+	offers := params.QueryApplicationOffersResults{}
+	err := c.facade.FacadeCall("ListApplicationOffers", paramsFilter, &offers)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	return convertListResultsToModel(applicationOffers.Results)
+	return convertOffersResultsToModel(offers.Results)
 }
 
-func convertListResultsToModel(items []params.ApplicationOfferDetails) ([]crossmodel.ApplicationOfferDetailsResult, error) {
-	result := make([]crossmodel.ApplicationOfferDetailsResult, len(items))
+func convertOffersResultsToModel(items []params.ApplicationOfferAdminDetails) ([]*crossmodel.ApplicationOfferDetails, error) {
+	result := make([]*crossmodel.ApplicationOfferDetails, len(items))
+	var err error
 	for i, one := range items {
-		eps := make([]charm.Relation, len(one.Endpoints))
-		for i, ep := range one.Endpoints {
-			eps[i] = charm.Relation{
-				Name:      ep.Name,
-				Role:      ep.Role,
-				Interface: ep.Interface,
-			}
+		if result[i], err = offerParamsToDetails(one); err != nil {
+			return nil, errors.Trace(err)
 		}
-		result[i].Result = &crossmodel.ApplicationOfferDetails{
-			ApplicationName: one.ApplicationName,
-			OfferName:       one.OfferName,
-			CharmURL:        one.CharmURL,
-			OfferURL:        one.OfferURL,
-			Endpoints:       eps,
+	}
+	return result, nil
+}
+
+func offerParamsToDetails(offer params.ApplicationOfferAdminDetails) (*crossmodel.ApplicationOfferDetails, error) {
+	eps := make([]charm.Relation, len(offer.Endpoints))
+	for i, ep := range offer.Endpoints {
+		eps[i] = charm.Relation{
+			Name:      ep.Name,
+			Role:      ep.Role,
+			Interface: ep.Interface,
 		}
-		for _, oc := range one.Connections {
-			modelTag, err := names.ParseModelTag(oc.SourceModelTag)
-			if err != nil {
-				return nil, errors.Trace(err)
-			}
-			result[i].Result.Connections = append(result[i].Result.Connections, crossmodel.OfferConnection{
-				SourceModelUUID: modelTag.Id(),
-				Username:        oc.Username,
-				Endpoint:        oc.Endpoint,
-				RelationId:      oc.RelationId,
-				Status:          relation.Status(oc.Status.Status),
-				Message:         oc.Status.Info,
-				Since:           oc.Status.Since,
-				IngressSubnets:  oc.IngressSubnets,
-			})
+	}
+	result := &crossmodel.ApplicationOfferDetails{
+		ApplicationName:        offer.ApplicationName,
+		ApplicationDescription: offer.ApplicationDescription,
+		OfferName:              offer.OfferName,
+		CharmURL:               offer.CharmURL,
+		OfferURL:               offer.OfferURL,
+		Endpoints:              eps,
+		Access:                 permission.Access(offer.Access),
+	}
+	for _, oc := range offer.Connections {
+		modelTag, err := names.ParseModelTag(oc.SourceModelTag)
+		if err != nil {
+			return nil, errors.Trace(err)
 		}
+		result.Connections = append(result.Connections, crossmodel.OfferConnection{
+			SourceModelUUID: modelTag.Id(),
+			Username:        oc.Username,
+			Endpoint:        oc.Endpoint,
+			RelationId:      oc.RelationId,
+			Status:          relation.Status(oc.Status.Status),
+			Message:         oc.Status.Info,
+			Since:           oc.Status.Since,
+			IngressSubnets:  oc.IngressSubnets,
+		})
+	}
+	for _, u := range offer.Users {
+		result.Users = append(result.Users, crossmodel.OfferUserDetails{
+			UserName:    u.UserName,
+			DisplayName: u.DisplayName,
+			Access:      permission.Access(u.Access),
+		})
 	}
 	return result, nil
 }
@@ -169,37 +186,37 @@ func (c *Client) modifyOfferUser(action params.OfferAction, user, access string,
 }
 
 // ApplicationOffer returns offered remote application details for a given URL.
-func (c *Client) ApplicationOffer(urlStr string) (params.ApplicationOffer, error) {
+func (c *Client) ApplicationOffer(urlStr string) (*crossmodel.ApplicationOfferDetails, error) {
 
 	url, err := crossmodel.ParseOfferURL(urlStr)
 	if err != nil {
-		return params.ApplicationOffer{}, errors.Trace(err)
+		return nil, errors.Trace(err)
 	}
 	if url.Source != "" {
-		return params.ApplicationOffer{}, errors.NotSupportedf("query for non-local application offers")
+		return nil, errors.NotSupportedf("query for non-local application offers")
 	}
 
 	found := params.ApplicationOffersResults{}
 
 	err = c.facade.FacadeCall("ApplicationOffers", params.OfferURLs{[]string{urlStr}}, &found)
 	if err != nil {
-		return params.ApplicationOffer{}, errors.Trace(err)
+		return nil, errors.Trace(err)
 	}
 
 	result := found.Results
 	if len(result) != 1 {
-		return params.ApplicationOffer{}, errors.Errorf("expected to find one result for url %q but found %d", url, len(result))
+		return nil, errors.Errorf("expected to find one result for url %q but found %d", url, len(result))
 	}
 
 	theOne := result[0]
 	if theOne.Error != nil {
-		return params.ApplicationOffer{}, errors.Trace(theOne.Error)
+		return nil, errors.Trace(theOne.Error)
 	}
-	return *theOne.Result, nil
+	return offerParamsToDetails(*theOne.Result)
 }
 
 // FindApplicationOffers returns all application offers matching the supplied filter.
-func (c *Client) FindApplicationOffers(filters ...crossmodel.ApplicationOfferFilter) ([]params.ApplicationOffer, error) {
+func (c *Client) FindApplicationOffers(filters ...crossmodel.ApplicationOfferFilter) ([]*crossmodel.ApplicationOfferDetails, error) {
 	// We need at least one filter. The default filter will list all local applications.
 	if len(filters) == 0 {
 		return nil, errors.New("at least one filter must be specified")
@@ -220,12 +237,12 @@ func (c *Client) FindApplicationOffers(filters ...crossmodel.ApplicationOfferFil
 		paramsFilter.Filters = append(paramsFilter.Filters, filterTerm)
 	}
 
-	out := params.FindApplicationOffersResults{}
-	err := c.facade.FacadeCall("FindApplicationOffers", paramsFilter, &out)
+	offers := params.QueryApplicationOffersResults{}
+	err := c.facade.FacadeCall("FindApplicationOffers", paramsFilter, &offers)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	return out.Results, nil
+	return convertOffersResultsToModel(offers.Results)
 }
 
 // GetConsumeDetails returns details necessary to consue an offer at a given URL.

--- a/api/applicationoffers/client.go
+++ b/api/applicationoffers/client.go
@@ -108,7 +108,6 @@ func offerParamsToDetails(offer params.ApplicationOfferAdminDetails) (*crossmode
 		CharmURL:               offer.CharmURL,
 		OfferURL:               offer.OfferURL,
 		Endpoints:              eps,
-		Access:                 permission.Access(offer.Access),
 	}
 	for _, oc := range offer.Connections {
 		modelTag, err := names.ParseModelTag(oc.SourceModelTag)

--- a/api/applicationoffers/client_test.go
+++ b/api/applicationoffers/client_test.go
@@ -136,16 +136,16 @@ func (s *crossmodelMockSuite) TestList(c *gc.C) {
 			})
 
 			if results, ok := result.(*params.QueryApplicationOffersResults); ok {
-				offer := params.ApplicationOffer{
+				offer := params.ApplicationOfferDetails{
 					OfferURL:  url,
 					OfferName: offerName,
 					OfferUUID: offerName + "-uuid",
 					Endpoints: endpoints,
 				}
 				results.Results = []params.ApplicationOfferAdminDetails{{
-					ApplicationOffer: offer,
-					ApplicationName:  "db2-app",
-					CharmURL:         "cs:db2-5",
+					ApplicationOfferDetails: offer,
+					ApplicationName:         "db2-app",
+					CharmURL:                "cs:db2-5",
 					Connections: []params.OfferConnection{
 						{SourceModelTag: testing.ModelTag.String(), Username: "fred", RelationId: 3,
 							Endpoint: "db", Status: params.EntityStatus{Status: "joined", Info: "message", Since: &since},
@@ -263,7 +263,7 @@ func (s *crossmodelMockSuite) TestShow(c *gc.C) {
 			if offers, ok := result.(*params.ApplicationOffersResults); ok {
 				offers.Results = []params.ApplicationOfferResult{
 					{Result: &params.ApplicationOfferAdminDetails{
-						ApplicationOffer: params.ApplicationOffer{
+						ApplicationOfferDetails: params.ApplicationOfferDetails{
 							ApplicationDescription: desc,
 							Endpoints:              endpoints,
 							OfferURL:               url,
@@ -381,7 +381,7 @@ func (s *crossmodelMockSuite) TestShowMultiple(c *gc.C) {
 			if offers, ok := result.(*params.ApplicationOffersResults); ok {
 				offers.Results = []params.ApplicationOfferResult{
 					{Result: &params.ApplicationOfferAdminDetails{
-						ApplicationOffer: params.ApplicationOffer{
+						ApplicationOfferDetails: params.ApplicationOfferDetails{
 							ApplicationDescription: desc,
 							Endpoints:              endpoints,
 							OfferURL:               url,
@@ -390,7 +390,7 @@ func (s *crossmodelMockSuite) TestShowMultiple(c *gc.C) {
 						},
 					}},
 					{Result: &params.ApplicationOfferAdminDetails{
-						ApplicationOffer: params.ApplicationOffer{
+						ApplicationOfferDetails: params.ApplicationOfferDetails{
 							ApplicationDescription: desc,
 							Endpoints:              endpoints,
 							OfferURL:               url,
@@ -495,14 +495,14 @@ func (s *crossmodelMockSuite) TestFind(c *gc.C) {
 			})
 
 			if results, ok := result.(*params.QueryApplicationOffersResults); ok {
-				offer := params.ApplicationOffer{
+				offer := params.ApplicationOfferDetails{
 					OfferURL:  url,
 					OfferName: offerName,
 					Endpoints: endpoints,
 					Access:    access,
 				}
 				results.Results = []params.ApplicationOfferAdminDetails{{
-					ApplicationOffer: offer,
+					ApplicationOfferDetails: offer,
 					Users: []params.OfferUserDetails{
 						{UserName: "fred", DisplayName: "Fred", Access: "consume"},
 					},
@@ -592,7 +592,7 @@ func (s *crossmodelMockSuite) TestFindFacadeCallError(c *gc.C) {
 }
 
 func (s *crossmodelMockSuite) TestGetConsumeDetails(c *gc.C) {
-	offer := params.ApplicationOffer{
+	offer := params.ApplicationOfferDetails{
 		SourceModelTag:         "source model",
 		OfferName:              "an offer",
 		OfferURL:               "offer url",

--- a/api/applicationoffers/client_test.go
+++ b/api/applicationoffers/client_test.go
@@ -18,7 +18,6 @@ import (
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/params"
 	jujucrossmodel "github.com/juju/juju/core/crossmodel"
-	"github.com/juju/juju/permission"
 	"github.com/juju/juju/testing"
 )
 
@@ -141,6 +140,9 @@ func (s *crossmodelMockSuite) TestList(c *gc.C) {
 					OfferName: offerName,
 					OfferUUID: offerName + "-uuid",
 					Endpoints: endpoints,
+					Users: []params.OfferUserDetails{
+						{UserName: "fred", DisplayName: "Fred", Access: "consume"},
+					},
 				}
 				results.Results = []params.ApplicationOfferAdminDetails{{
 					ApplicationOfferDetails: offer,
@@ -151,9 +153,6 @@ func (s *crossmodelMockSuite) TestList(c *gc.C) {
 							Endpoint: "db", Status: params.EntityStatus{Status: "joined", Info: "message", Since: &since},
 							IngressSubnets: []string{"10.0.0.0/8"},
 						},
-					},
-					Users: []params.OfferUserDetails{
-						{UserName: "fred", DisplayName: "Fred", Access: "consume"},
 					},
 				}}
 			}
@@ -268,7 +267,9 @@ func (s *crossmodelMockSuite) TestShow(c *gc.C) {
 							Endpoints:              endpoints,
 							OfferURL:               url,
 							OfferName:              offerName,
-							Access:                 access,
+							Users: []params.OfferUserDetails{
+								{UserName: "fred", DisplayName: "Fred", Access: access},
+							},
 						},
 						ApplicationName: "db2-app",
 						CharmURL:        "cs:db2-5",
@@ -277,9 +278,6 @@ func (s *crossmodelMockSuite) TestShow(c *gc.C) {
 								Endpoint: "db", Status: params.EntityStatus{Status: "joined", Info: "message", Since: &since},
 								IngressSubnets: []string{"10.0.0.0/8"},
 							},
-						},
-						Users: []params.OfferUserDetails{
-							{UserName: "fred", DisplayName: "Fred", Access: "consume"},
 						},
 					}},
 				}
@@ -300,15 +298,14 @@ func (s *crossmodelMockSuite) TestShow(c *gc.C) {
 		ApplicationName:        "db2-app",
 		ApplicationDescription: "IBM DB2 Express Server Edition is an entry level database system",
 		CharmURL:               "cs:db2-5",
-		Access:                 "consume",
+		Users: []jujucrossmodel.OfferUserDetails{
+			{UserName: "fred", DisplayName: "Fred", Access: "consume"},
+		},
 		Connections: []jujucrossmodel.OfferConnection{
 			{SourceModelUUID: testing.ModelTag.Id(), Username: "fred", RelationId: 3,
 				Endpoint: "db", Status: "joined", Message: "message", Since: &since,
 				IngressSubnets: []string{"10.0.0.0/8"},
 			},
-		},
-		Users: []jujucrossmodel.OfferUserDetails{
-			{UserName: "fred", DisplayName: "Fred", Access: "consume"},
 		},
 	})
 }
@@ -358,8 +355,6 @@ func (s *crossmodelMockSuite) TestShowMultiple(c *gc.C) {
 		{Name: "log", Interface: "http", Role: charm.RoleRequirer},
 	}
 	offerName := "hosted-db2"
-	access := "consume"
-
 	called := false
 
 	apiCaller := basetesting.APICallerFunc(
@@ -386,7 +381,6 @@ func (s *crossmodelMockSuite) TestShowMultiple(c *gc.C) {
 							Endpoints:              endpoints,
 							OfferURL:               url,
 							OfferName:              offerName,
-							Access:                 access,
 						},
 					}},
 					{Result: &params.ApplicationOfferAdminDetails{
@@ -395,7 +389,6 @@ func (s *crossmodelMockSuite) TestShowMultiple(c *gc.C) {
 							Endpoints:              endpoints,
 							OfferURL:               url,
 							OfferName:              offerName,
-							Access:                 access,
 						},
 					}}}
 			}
@@ -456,7 +449,6 @@ func (s *crossmodelMockSuite) TestFind(c *gc.C) {
 	offerName := "hosted-db2"
 	ownerName := "owner"
 	modelName := "model"
-	access := "consume"
 	url := fmt.Sprintf("fred/model.%s", offerName)
 	endpoints := []params.RemoteEndpoint{{Name: "endPointA"}}
 	relations := []jujucrossmodel.EndpointFilterTerm{{Name: "endPointA", Interface: "http"}}
@@ -499,13 +491,12 @@ func (s *crossmodelMockSuite) TestFind(c *gc.C) {
 					OfferURL:  url,
 					OfferName: offerName,
 					Endpoints: endpoints,
-					Access:    access,
-				}
-				results.Results = []params.ApplicationOfferAdminDetails{{
-					ApplicationOfferDetails: offer,
 					Users: []params.OfferUserDetails{
 						{UserName: "fred", DisplayName: "Fred", Access: "consume"},
 					},
+				}
+				results.Results = []params.ApplicationOfferAdminDetails{{
+					ApplicationOfferDetails: offer,
 				}}
 			}
 			return nil
@@ -522,7 +513,6 @@ func (s *crossmodelMockSuite) TestFind(c *gc.C) {
 		Users: []jujucrossmodel.OfferUserDetails{
 			{UserName: "fred", DisplayName: "Fred", Access: "consume"},
 		},
-		Access: permission.Access(access),
 	}})
 }
 

--- a/apiserver/common/crossmodel/auth.go
+++ b/apiserver/common/crossmodel/auth.go
@@ -200,7 +200,7 @@ func (a *AuthContext) offerPermissionYaml(sourceModelUUID, username, offerURL, r
 }
 
 // CreateConsumeOfferMacaroon creates a macaroon that authorises access to the specified offer.
-func (a *AuthContext) CreateConsumeOfferMacaroon(offer *params.ApplicationOffer, username string) (*macaroon.Macaroon, error) {
+func (a *AuthContext) CreateConsumeOfferMacaroon(offer *params.ApplicationOfferDetails, username string) (*macaroon.Macaroon, error) {
 	sourceModelTag, err := names.ParseModelTag(offer.SourceModelTag)
 	if err != nil {
 		return nil, errors.Trace(err)

--- a/apiserver/common/crossmodel/auth_test.go
+++ b/apiserver/common/crossmodel/auth_test.go
@@ -201,7 +201,7 @@ permission: consume
 func (s *authSuite) TestCreateConsumeOfferMacaroon(c *gc.C) {
 	authContext, err := crossmodel.NewAuthContext(s.mockStatePool, s.bakery, s.bakery)
 	c.Assert(err, jc.ErrorIsNil)
-	offer := &params.ApplicationOffer{
+	offer := &params.ApplicationOfferDetails{
 		SourceModelTag: coretesting.ModelTag.String(),
 		OfferUUID:      "mysql-uuid",
 	}
@@ -294,7 +294,7 @@ func (s *authSuite) TestCheckOfferMacaroonsExpired(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	clock := testing.NewClock(time.Now().Add(-10 * time.Minute))
 	authContext = authContext.WithClock(clock)
-	offer := &params.ApplicationOffer{
+	offer := &params.ApplicationOfferDetails{
 		SourceModelTag: coretesting.ModelTag.String(),
 		OfferURL:       "mysql-uuid",
 	}
@@ -315,7 +315,7 @@ func (s *authSuite) TestCheckOfferMacaroonsDischargeRequired(c *gc.C) {
 	clock := testing.NewClock(time.Now().Add(-10 * time.Minute))
 	authContext = authContext.WithClock(clock)
 	authContext = authContext.WithDischargeURL("http://thirdparty")
-	offer := &params.ApplicationOffer{
+	offer := &params.ApplicationOfferDetails{
 		SourceModelTag: coretesting.ModelTag.String(),
 		OfferURL:       "mysql-uuid",
 	}

--- a/apiserver/facades/client/application/application.go
+++ b/apiserver/facades/client/application/application.go
@@ -1239,7 +1239,7 @@ func (api *API) consumeOne(arg params.ConsumeApplicationArg) error {
 	if appName == "" {
 		appName = arg.OfferName
 	}
-	_, err = api.saveRemoteApplication(sourceModelTag, appName, arg.ApplicationOffer, arg.Macaroon)
+	_, err = api.saveRemoteApplication(sourceModelTag, appName, arg.ApplicationOfferDetails, arg.Macaroon)
 	return err
 }
 
@@ -1248,7 +1248,7 @@ func (api *API) consumeOne(arg params.ConsumeApplicationArg) error {
 func (api *API) saveRemoteApplication(
 	sourceModelTag names.ModelTag,
 	applicationName string,
-	offer params.ApplicationOffer,
+	offer params.ApplicationOfferDetails,
 	mac *macaroon.Macaroon,
 ) (RemoteApplication, error) {
 	remoteEps := make([]charm.Relation, len(offer.Endpoints))

--- a/apiserver/facades/client/application/application_test.go
+++ b/apiserver/facades/client/application/application_test.go
@@ -2682,7 +2682,7 @@ func (s *applicationSuite) TestAddAlreadyAddedRelation(c *gc.C) {
 func (s *applicationSuite) setupRemoteApplication(c *gc.C) {
 	results, err := s.applicationAPI.Consume(params.ConsumeApplicationArgs{
 		Args: []params.ConsumeApplicationArg{
-			{ApplicationOffer: params.ApplicationOffer{
+			{ApplicationOfferDetails: params.ApplicationOfferDetails{
 				SourceModelTag:         testing.ModelTag.String(),
 				OfferName:              "hosted-mysql",
 				OfferUUID:              "hosted-mysql-uuid",
@@ -2750,7 +2750,7 @@ func (s *applicationSuite) TestRemoteRelationInvalidEndpoint(c *gc.C) {
 func (s *applicationSuite) TestRemoteRelationNoMatchingEndpoint(c *gc.C) {
 	results, err := s.applicationAPI.Consume(params.ConsumeApplicationArgs{
 		Args: []params.ConsumeApplicationArg{
-			{ApplicationOffer: params.ApplicationOffer{
+			{ApplicationOfferDetails: params.ApplicationOfferDetails{
 				SourceModelTag: testing.ModelTag.String(),
 				OfferName:      "hosted-db2",
 				OfferUUID:      "hosted-db2-uuid",

--- a/apiserver/facades/client/application/application_unit_test.go
+++ b/apiserver/facades/client/application/application_unit_test.go
@@ -582,7 +582,7 @@ func (s *ApplicationSuite) TestConsumeIdempotent(c *gc.C) {
 	for i := 0; i < 2; i++ {
 		results, err := s.api.Consume(params.ConsumeApplicationArgs{
 			Args: []params.ConsumeApplicationArg{{
-				ApplicationOffer: params.ApplicationOffer{
+				ApplicationOfferDetails: params.ApplicationOfferDetails{
 					SourceModelTag:         coretesting.ModelTag.String(),
 					OfferName:              "hosted-mysql",
 					OfferUUID:              "hosted-mysql-uuid",
@@ -613,7 +613,7 @@ func (s *ApplicationSuite) TestConsumeFromExternalController(c *gc.C) {
 	controllerUUID := utils.MustNewUUID().String()
 	results, err := s.api.Consume(params.ConsumeApplicationArgs{
 		Args: []params.ConsumeApplicationArg{{
-			ApplicationOffer: params.ApplicationOffer{
+			ApplicationOfferDetails: params.ApplicationOfferDetails{
 				SourceModelTag:         coretesting.ModelTag.String(),
 				OfferName:              "hosted-mysql",
 				OfferUUID:              "hosted-mysql-uuid",
@@ -654,7 +654,7 @@ func (s *ApplicationSuite) TestConsumeFromSameController(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	results, err := s.api.Consume(params.ConsumeApplicationArgs{
 		Args: []params.ConsumeApplicationArg{{
-			ApplicationOffer: params.ApplicationOffer{
+			ApplicationOfferDetails: params.ApplicationOfferDetails{
 				SourceModelTag:         coretesting.ModelTag.String(),
 				OfferName:              "hosted-mysql",
 				OfferUUID:              "hosted-mysql-uuid",
@@ -697,7 +697,7 @@ func (s *ApplicationSuite) TestConsumeIncludesSpaceInfo(c *gc.C) {
 	results, err := s.api.Consume(params.ConsumeApplicationArgs{
 		Args: []params.ConsumeApplicationArg{{
 			ApplicationAlias: "beirut",
-			ApplicationOffer: params.ApplicationOffer{
+			ApplicationOfferDetails: params.ApplicationOfferDetails{
 				SourceModelTag:         coretesting.ModelTag.String(),
 				OfferName:              "hosted-mysql",
 				OfferUUID:              "hosted-mysql-uuid",
@@ -753,7 +753,7 @@ func (s *ApplicationSuite) TestConsumeIncludesSpaceInfo(c *gc.C) {
 
 func (s *ApplicationSuite) TestConsumeRemoteAppExistsDifferentSourceModel(c *gc.C) {
 	arg := params.ConsumeApplicationArg{
-		ApplicationOffer: params.ApplicationOffer{
+		ApplicationOfferDetails: params.ApplicationOfferDetails{
 			SourceModelTag:         coretesting.ModelTag.String(),
 			OfferName:              "hosted-mysql",
 			OfferUUID:              "hosted-mysql-uuid",
@@ -780,7 +780,7 @@ func (s *ApplicationSuite) TestConsumeRemoteAppExistsDifferentSourceModel(c *gc.
 func (s *ApplicationSuite) assertConsumeWithNoSpacesInfoAvailable(c *gc.C) {
 	results, err := s.api.Consume(params.ConsumeApplicationArgs{
 		Args: []params.ConsumeApplicationArg{{
-			ApplicationOffer: params.ApplicationOffer{
+			ApplicationOfferDetails: params.ApplicationOfferDetails{
 				SourceModelTag:         coretesting.ModelTag.String(),
 				OfferName:              "hosted-mysql",
 				OfferUUID:              "hosted-mysql-uuid",

--- a/apiserver/facades/client/applicationoffers/access_test.go
+++ b/apiserver/facades/client/applicationoffers/access_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
-	"github.com/juju/utils/set"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/names.v2"
 
@@ -80,7 +79,7 @@ func (s *offerAccessSuite) setupOffer(modelUUID, modelName, owner, offerName str
 	st := &mockState{
 		modelUUID:         modelUUID,
 		applicationOffers: make(map[string]jujucrossmodel.ApplicationOffer),
-		users:             set.NewStrings(),
+		users:             make(map[string]applicationoffers.User),
 		accessPerms:       make(map[offerAccess]permission.Access),
 		model:             model,
 	}
@@ -107,7 +106,7 @@ func (s *offerAccessSuite) TestGrantMissingOfferFails(c *gc.C) {
 func (s *offerAccessSuite) TestRevokeAdminLeavesReadAccess(c *gc.C) {
 	s.setupOffer("uuid", "test", "admin", "someoffer")
 	st := s.mockStatePool.st["uuid"]
-	st.(*mockState).users.Add("foobar")
+	st.(*mockState).users["foobar"] = &mockUser{"foobar"}
 
 	user := names.NewUserTag("foobar")
 	offer := names.NewApplicationOfferTag("someoffer")
@@ -125,7 +124,7 @@ func (s *offerAccessSuite) TestRevokeAdminLeavesReadAccess(c *gc.C) {
 func (s *offerAccessSuite) TestRevokeReadRemovesPermission(c *gc.C) {
 	s.setupOffer("uuid", "test", "admin", "someoffer")
 	st := s.mockStatePool.st["uuid"]
-	st.(*mockState).users.Add("foobar")
+	st.(*mockState).users["foobar"] = &mockUser{"foobar"}
 
 	user := names.NewUserTag("foobar")
 	offer := names.NewApplicationOfferTag("someoffer")
@@ -155,7 +154,7 @@ func (s *offerAccessSuite) TestRevokeMissingUser(c *gc.C) {
 func (s *offerAccessSuite) TestGrantOnlyGreaterAccess(c *gc.C) {
 	s.setupOffer("uuid", "test", "admin", "someoffer")
 	st := s.mockStatePool.st["uuid"]
-	st.(*mockState).users.Add("foobar")
+	st.(*mockState).users["foobar"] = &mockUser{"foobar"}
 
 	user := names.NewUserTag("foobar")
 	err := s.grant(c, user, params.OfferReadAccess, "test.someoffer")
@@ -168,8 +167,8 @@ func (s *offerAccessSuite) TestGrantOnlyGreaterAccess(c *gc.C) {
 func (s *offerAccessSuite) assertGrantOfferAddUser(c *gc.C, user names.UserTag) {
 	s.setupOffer("uuid", "test", "superuser-bob", "someoffer")
 	st := s.mockStatePool.st["uuid"]
-	st.(*mockState).users.Add("other")
-	st.(*mockState).users.Add(user.Name())
+	st.(*mockState).users["other"] = &mockUser{"other"}
+	st.(*mockState).users[user.Name()] = &mockUser{user.Name()}
 
 	apiUser := names.NewUserTag("superuser-bob")
 	s.authorizer.Tag = apiUser
@@ -194,7 +193,7 @@ func (s *offerAccessSuite) TestGrantOfferAddRemoteUser(c *gc.C) {
 func (s *offerAccessSuite) TestGrantOfferSuperUser(c *gc.C) {
 	s.setupOffer("uuid", "test", "superuser-bob", "someoffer")
 	st := s.mockStatePool.st["uuid"]
-	st.(*mockState).users.Add("other")
+	st.(*mockState).users["other"] = &mockUser{"other"}
 
 	user := names.NewUserTag("superuser-bob")
 	s.authorizer.Tag = user
@@ -212,7 +211,7 @@ func (s *offerAccessSuite) TestGrantOfferSuperUser(c *gc.C) {
 func (s *offerAccessSuite) TestGrantIncreaseAccess(c *gc.C) {
 	s.setupOffer("uuid", "test", "other", "someoffer")
 	st := s.mockStatePool.st["uuid"]
-	st.(*mockState).users.Add("other")
+	st.(*mockState).users["other"] = &mockUser{"other"}
 
 	user := names.NewUserTag("other")
 	s.authorizer.Tag = user
@@ -233,8 +232,8 @@ func (s *offerAccessSuite) TestGrantIncreaseAccess(c *gc.C) {
 func (s *offerAccessSuite) TestGrantToOfferNoAccess(c *gc.C) {
 	s.setupOffer("uuid", "test", "bob@remote", "someoffer")
 	st := s.mockStatePool.st["uuid"]
-	st.(*mockState).users.Add("other")
-	st.(*mockState).users.Add("bob")
+	st.(*mockState).users["other"] = &mockUser{"other"}
+	st.(*mockState).users["bob"] = &mockUser{"bob"}
 
 	user := names.NewUserTag("bob@remote")
 	s.authorizer.Tag = user
@@ -247,8 +246,8 @@ func (s *offerAccessSuite) TestGrantToOfferNoAccess(c *gc.C) {
 func (s *offerAccessSuite) assertGrantToOffer(c *gc.C, userAccess permission.Access) {
 	s.setupOffer("uuid", "test", "bob@remote", "someoffer")
 	st := s.mockStatePool.st["uuid"]
-	st.(*mockState).users.Add("other")
-	st.(*mockState).users.Add("bob")
+	st.(*mockState).users["other"] = &mockUser{"other"}
+	st.(*mockState).users["bob"] = &mockUser{"bob"}
 
 	user := names.NewUserTag("bob@remote")
 	s.authorizer.Tag = user
@@ -273,8 +272,8 @@ func (s *offerAccessSuite) TestGrantToOfferConsumeAccess(c *gc.C) {
 func (s *offerAccessSuite) TestGrantToOfferAdminAccess(c *gc.C) {
 	s.setupOffer("uuid", "test", "foobar", "someoffer")
 	st := s.mockStatePool.st["uuid"]
-	st.(*mockState).users.Add("other")
-	st.(*mockState).users.Add("foobar")
+	st.(*mockState).users["other"] = &mockUser{"other"}
+	st.(*mockState).users["foobar"] = &mockUser{"foobar"}
 
 	user := names.NewUserTag("foobar")
 	s.authorizer.Tag = user

--- a/apiserver/facades/client/applicationoffers/applicationoffers.go
+++ b/apiserver/facades/client/applicationoffers/applicationoffers.go
@@ -445,7 +445,7 @@ func (api *OffersAPI) GetConsumeDetails(args params.OfferURLs) (params.ConsumeOf
 			continue
 		}
 		offer := result.Result
-		offerDetails := &offer.ApplicationOffer
+		offerDetails := &offer.ApplicationOfferDetails
 		results[i].Offer = offerDetails
 		results[i].ControllerInfo = controllerInfo
 		offerMacaroon, err := api.authContext.CreateConsumeOfferMacaroon(offerDetails, api.Authorizer.GetAuthTag().Id())

--- a/apiserver/facades/client/applicationoffers/applicationoffers_test.go
+++ b/apiserver/facades/client/applicationoffers/applicationoffers_test.go
@@ -225,7 +225,7 @@ func (s *applicationOffersSuite) assertList(c *gc.C, expectedErr error) {
 	c.Assert(found, jc.DeepEquals, params.QueryApplicationOffersResults{
 		[]params.ApplicationOfferAdminDetails{
 			{
-				ApplicationOffer: params.ApplicationOffer{
+				ApplicationOfferDetails: params.ApplicationOfferDetails{
 					SourceModelTag:         testing.ModelTag.String(),
 					ApplicationDescription: "description",
 					OfferName:              "hosted-db2",
@@ -352,7 +352,7 @@ func (s *applicationOffersSuite) assertShow(c *gc.C, url string, expected []para
 func (s *applicationOffersSuite) TestShow(c *gc.C) {
 	expected := []params.ApplicationOfferResult{{
 		Result: &params.ApplicationOfferAdminDetails{
-			ApplicationOffer: params.ApplicationOffer{
+			ApplicationOfferDetails: params.ApplicationOfferDetails{
 				SourceModelTag:         testing.ModelTag.String(),
 				ApplicationDescription: "description",
 				OfferURL:               "fred/prod.hosted-db2",
@@ -408,7 +408,7 @@ func (s *applicationOffersSuite) TestShowPermission(c *gc.C) {
 	s.authorizer.Tag = user
 	expected := []params.ApplicationOfferResult{{
 		Result: &params.ApplicationOfferAdminDetails{
-			ApplicationOffer: params.ApplicationOffer{
+			ApplicationOfferDetails: params.ApplicationOfferDetails{
 				SourceModelTag:         testing.ModelTag.String(),
 				ApplicationDescription: "description",
 				OfferURL:               "fred/prod.hosted-db2",
@@ -592,7 +592,7 @@ func (s *applicationOffersSuite) TestShowFoundMultiple(c *gc.C) {
 	}
 	c.Assert(results, jc.DeepEquals, []params.ApplicationOfferAdminDetails{
 		{
-			ApplicationOffer: params.ApplicationOffer{
+			ApplicationOfferDetails: params.ApplicationOfferDetails{
 				SourceModelTag:         testing.ModelTag.String(),
 				ApplicationDescription: "description",
 				OfferName:              "hosted-" + name,
@@ -610,7 +610,7 @@ func (s *applicationOffersSuite) TestShowFoundMultiple(c *gc.C) {
 				},
 			},
 		}, {
-			ApplicationOffer: params.ApplicationOffer{
+			ApplicationOfferDetails: params.ApplicationOfferDetails{
 				SourceModelTag:         "model-uuid2",
 				ApplicationDescription: "description2",
 				OfferName:              "hosted-" + name2,
@@ -657,7 +657,7 @@ func (s *applicationOffersSuite) TestFind(c *gc.C) {
 	s.authorizer.Tag = names.NewUserTag("admin")
 	expected := []params.ApplicationOfferAdminDetails{
 		{
-			ApplicationOffer: params.ApplicationOffer{
+			ApplicationOfferDetails: params.ApplicationOfferDetails{
 				SourceModelTag:         testing.ModelTag.String(),
 				ApplicationDescription: "description",
 				OfferName:              "hosted-db2",
@@ -704,7 +704,7 @@ func (s *applicationOffersSuite) TestFindPermission(c *gc.C) {
 	s.authorizer.Tag = user
 	expected := []params.ApplicationOfferAdminDetails{
 		{
-			ApplicationOffer: params.ApplicationOffer{
+			ApplicationOfferDetails: params.ApplicationOfferDetails{
 				SourceModelTag:         testing.ModelTag.String(),
 				ApplicationDescription: "description",
 				OfferName:              "hosted-db2",
@@ -902,7 +902,7 @@ func (s *applicationOffersSuite) TestFindMulti(c *gc.C) {
 	c.Assert(found, jc.DeepEquals, params.QueryApplicationOffersResults{
 		[]params.ApplicationOfferAdminDetails{
 			{
-				ApplicationOffer: params.ApplicationOffer{
+				ApplicationOfferDetails: params.ApplicationOfferDetails{
 					SourceModelTag:         testing.ModelTag.String(),
 					ApplicationDescription: "db2 description",
 					OfferName:              "hosted-db2",
@@ -921,7 +921,7 @@ func (s *applicationOffersSuite) TestFindMulti(c *gc.C) {
 				},
 			},
 			{
-				ApplicationOffer: params.ApplicationOffer{
+				ApplicationOfferDetails: params.ApplicationOfferDetails{
 					SourceModelTag:         "model-uuid2",
 					ApplicationDescription: "mysql description",
 					OfferName:              "hosted-mysql",
@@ -932,7 +932,7 @@ func (s *applicationOffersSuite) TestFindMulti(c *gc.C) {
 				},
 			},
 			{
-				ApplicationOffer: params.ApplicationOffer{
+				ApplicationOfferDetails: params.ApplicationOfferDetails{
 					SourceModelTag:         "model-uuid2",
 					ApplicationDescription: "postgresql description",
 					OfferName:              "hosted-postgresql",
@@ -1068,7 +1068,7 @@ func (s *consumeSuite) TestConsumeDetailsWithPermission(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results.Results, gc.HasLen, 1)
 	c.Assert(results.Results[0].Error, gc.IsNil)
-	c.Assert(results.Results[0].Offer, jc.DeepEquals, &params.ApplicationOffer{
+	c.Assert(results.Results[0].Offer, jc.DeepEquals, &params.ApplicationOfferDetails{
 		SourceModelTag:         "model-deadbeef-0bad-400d-8000-4b1d0d06f00d",
 		OfferURL:               "fred/prod.hosted-mysql",
 		OfferName:              "hosted-mysql",
@@ -1121,7 +1121,7 @@ func (s *consumeSuite) TestConsumeDetailsDefaultEndpoint(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results.Results, gc.HasLen, 1)
 	c.Assert(results.Results[0].Error, gc.IsNil)
-	c.Assert(results.Results[0].Offer, jc.DeepEquals, &params.ApplicationOffer{
+	c.Assert(results.Results[0].Offer, jc.DeepEquals, &params.ApplicationOfferDetails{
 		SourceModelTag:         "model-deadbeef-0bad-400d-8000-4b1d0d06f00d",
 		OfferURL:               "fred/prod.hosted-mysql",
 		OfferName:              "hosted-mysql",

--- a/apiserver/facades/client/applicationoffers/base.go
+++ b/apiserver/facades/client/applicationoffers/base.go
@@ -136,7 +136,7 @@ func (api *BaseAPI) applicationOffersFromModel(
 			continue
 		}
 		offer := params.ApplicationOfferAdminDetails{
-			ApplicationOffer: *offerParams,
+			ApplicationOfferDetails: *offerParams,
 		}
 		// Only admins can see some sensitive details of the offer.
 		if isAdmin {
@@ -364,7 +364,7 @@ func makeOfferFilterFromParams(filter params.OfferFilter) jujucrossmodel.Applica
 }
 
 func (api *BaseAPI) makeOfferParams(backend Backend, offer *jujucrossmodel.ApplicationOffer, access permission.Access) (
-	*params.ApplicationOffer, crossmodel.Application, error,
+	*params.ApplicationOfferDetails, crossmodel.Application, error,
 ) {
 	app, err := backend.Application(offer.ApplicationName)
 	if err != nil {
@@ -374,7 +374,7 @@ func (api *BaseAPI) makeOfferParams(backend Backend, offer *jujucrossmodel.Appli
 	if err != nil {
 		return nil, nil, errors.Trace(err)
 	}
-	result := params.ApplicationOffer{
+	result := params.ApplicationOfferDetails{
 		SourceModelTag:         backend.ModelTag().String(),
 		OfferName:              offer.OfferName,
 		OfferUUID:              offer.OfferUUID,

--- a/apiserver/facades/client/applicationoffers/base_test.go
+++ b/apiserver/facades/client/applicationoffers/base_test.go
@@ -6,7 +6,6 @@ package applicationoffers_test
 import (
 	jtesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
-	"github.com/juju/utils/set"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/charm.v6-unstable"
 	"gopkg.in/juju/names.v2"
@@ -53,7 +52,7 @@ func (s *baseSuite) SetUpTest(c *gc.C) {
 	s.env = &mockEnviron{}
 	s.mockState = &mockState{
 		modelUUID:         coretesting.ModelTag.Id(),
-		users:             set.NewStrings(),
+		users:             make(map[string]applicationoffers.User),
 		applicationOffers: make(map[string]jujucrossmodel.ApplicationOffer),
 		accessPerms:       make(map[offerAccess]permission.Access),
 		spaces:            make(map[string]applicationoffers.Space),

--- a/apiserver/facades/client/applicationoffers/state.go
+++ b/apiserver/facades/client/applicationoffers/state.go
@@ -62,10 +62,12 @@ type Backend interface {
 	Model() (Model, error)
 	OfferConnections(string) ([]OfferConnection, error)
 	Space(string) (Space, error)
+	User(names.UserTag) (User, error)
 
 	CreateOfferAccess(offer names.ApplicationOfferTag, user names.UserTag, access permission.Access) error
 	UpdateOfferAccess(offer names.ApplicationOfferTag, user names.UserTag, access permission.Access) error
 	RemoveOfferAccess(offer names.ApplicationOfferTag, user names.UserTag) error
+	GetOfferUsers(offerUUID string) (map[string]permission.Access, error)
 }
 
 var GetStateAccess = func(st *state.State) Backend {
@@ -96,9 +98,9 @@ func (s stateShim) RemoveOfferAccess(offer names.ApplicationOfferTag, user names
 	return s.st.RemoveOfferAccess(offer, user)
 }
 
-// func (s stateShim) NewStorage() storage.Storage {
-// 	return storage.NewStorage(s.st.ModelUUID(), s.st.MongoSession())
-// }
+func (s stateShim) GetOfferUsers(offerUUID string) (map[string]permission.Access, error) {
+	return s.st.GetOfferUsers(offerUUID)
+}
 
 func (s *stateShim) Space(name string) (Space, error) {
 	sp, err := s.st.Space(name)
@@ -215,4 +217,16 @@ type OfferConnection interface {
 
 type offerConnectionShim struct {
 	*state.OfferConnection
+}
+
+func (s *stateShim) User(tag names.UserTag) (User, error) {
+	return s.st.User(tag)
+}
+
+type User interface {
+	DisplayName() string
+}
+
+type userShim struct {
+	*state.User
 }

--- a/apiserver/params/crossmodel.go
+++ b/apiserver/params/crossmodel.go
@@ -40,15 +40,15 @@ type OfferFilter struct {
 
 // ApplicationOfferDetails represents an application offering from an external model.
 type ApplicationOfferDetails struct {
-	SourceModelTag         string            `json:"source-model-tag"`
-	OfferUUID              string            `json:"offer-uuid"`
-	OfferURL               string            `json:"offer-url"`
-	OfferName              string            `json:"offer-name"`
-	ApplicationDescription string            `json:"application-description"`
-	Endpoints              []RemoteEndpoint  `json:"endpoints"`
-	Spaces                 []RemoteSpace     `json:"spaces"`
-	Bindings               map[string]string `json:"bindings"`
-	Access                 string            `json:"access"`
+	SourceModelTag         string             `json:"source-model-tag"`
+	OfferUUID              string             `json:"offer-uuid"`
+	OfferURL               string             `json:"offer-url"`
+	OfferName              string             `json:"offer-name"`
+	ApplicationDescription string             `json:"application-description"`
+	Endpoints              []RemoteEndpoint   `json:"endpoints,omitempty"`
+	Spaces                 []RemoteSpace      `json:"spaces,omitempty"`
+	Bindings               map[string]string  `json:"bindings,omitempty"`
+	Users                  []OfferUserDetails `json:"users,omitempty"`
 }
 
 // OfferUserDetails represents an offer consumer and their permission on the offer.
@@ -62,10 +62,9 @@ type OfferUserDetails struct {
 // including details about how it has been deployed.
 type ApplicationOfferAdminDetails struct {
 	ApplicationOfferDetails
-	ApplicationName string             `json:"application-name"`
-	CharmURL        string             `json:"charm-url"`
-	Connections     []OfferConnection  `json:"connections,omitempty"`
-	Users           []OfferUserDetails `json:"users,omitempty"`
+	ApplicationName string            `json:"application-name"`
+	CharmURL        string            `json:"charm-url"`
+	Connections     []OfferConnection `json:"connections,omitempty"`
 }
 
 // OfferConnection holds details about a connection to an offer.

--- a/apiserver/params/crossmodel.go
+++ b/apiserver/params/crossmodel.go
@@ -38,8 +38,8 @@ type OfferFilter struct {
 	AllowedUserTags        []string                   `json:"allowed-users"`
 }
 
-// ApplicationOffer represents an application offering from an external model.
-type ApplicationOffer struct {
+// ApplicationOfferDetails represents an application offering from an external model.
+type ApplicationOfferDetails struct {
 	SourceModelTag         string            `json:"source-model-tag"`
 	OfferUUID              string            `json:"offer-uuid"`
 	OfferURL               string            `json:"offer-url"`
@@ -61,7 +61,7 @@ type OfferUserDetails struct {
 // ApplicationOfferAdminDetails represents an application offering,
 // including details about how it has been deployed.
 type ApplicationOfferAdminDetails struct {
-	ApplicationOffer
+	ApplicationOfferDetails
 	ApplicationName string             `json:"application-name"`
 	CharmURL        string             `json:"charm-url"`
 	Connections     []OfferConnection  `json:"connections,omitempty"`
@@ -146,7 +146,7 @@ type OfferURLs struct {
 // ConsumeApplicationArg holds the arguments for consuming a remote application.
 type ConsumeApplicationArg struct {
 	// The offer to be consumed.
-	ApplicationOffer
+	ApplicationOfferDetails
 
 	// Macaroon is used for authentication.
 	Macaroon *macaroon.Macaroon `json:"macaroon,omitempty"`
@@ -493,9 +493,9 @@ type RemoteApplicationInfoResults struct {
 // ConsumeOfferDetails contains the details necessary to
 // consume an application offer.
 type ConsumeOfferDetails struct {
-	Offer          *ApplicationOffer       `json:"offer,omitempty"`
-	Macaroon       *macaroon.Macaroon      `json:"macaroon,omitempty"`
-	ControllerInfo *ExternalControllerInfo `json:"external-controller,omitempty"`
+	Offer          *ApplicationOfferDetails `json:"offer,omitempty"`
+	Macaroon       *macaroon.Macaroon       `json:"macaroon,omitempty"`
+	ControllerInfo *ExternalControllerInfo  `json:"external-controller,omitempty"`
 }
 
 // ConsumeOfferDetailsResult contains the details necessary to

--- a/apiserver/params/crossmodel.go
+++ b/apiserver/params/crossmodel.go
@@ -51,13 +51,21 @@ type ApplicationOffer struct {
 	Access                 string            `json:"access"`
 }
 
-// ApplicationOfferDetails represents an application offering,
+// OfferUserDetails represents an offer consumer and their permission on the offer.
+type OfferUserDetails struct {
+	UserName    string `json:"user"`
+	DisplayName string `json:"display-name"`
+	Access      string `json:"access"`
+}
+
+// ApplicationOfferAdminDetails represents an application offering,
 // including details about how it has been deployed.
-type ApplicationOfferDetails struct {
+type ApplicationOfferAdminDetails struct {
 	ApplicationOffer
-	ApplicationName string            `json:"application-name"`
-	CharmURL        string            `json:"charm-url"`
-	Connections     []OfferConnection `json:"connections,omitempty"`
+	ApplicationName string             `json:"application-name"`
+	CharmURL        string             `json:"charm-url"`
+	Connections     []OfferConnection  `json:"connections,omitempty"`
+	Users           []OfferUserDetails `json:"users,omitempty"`
 }
 
 // OfferConnection holds details about a connection to an offer.
@@ -70,10 +78,10 @@ type OfferConnection struct {
 	IngressSubnets []string     `json:"ingress-subnets"`
 }
 
-// ListApplicationOffersResults is a result of listing application offers.
-type ListApplicationOffersResults struct {
+// QueryApplicationOffersResults is a result of searching application offers.
+type QueryApplicationOffersResults struct {
 	// Results contains application offers matching each filter.
-	Results []ApplicationOfferDetails `json:"results"`
+	Results []ApplicationOfferAdminDetails `json:"results"`
 }
 
 // AddApplicationOffers is used when adding offers to a application directory.
@@ -113,16 +121,11 @@ type RemoteSpace struct {
 	Subnets            []Subnet               `json:"subnets"`
 }
 
-// FindApplicationOffersResults is a result of finding remote application offers.
-type FindApplicationOffersResults struct {
-	// Results contains application offers matching each filter.
-	Results []ApplicationOffer `json:"results"`
-}
-
-// ApplicationOfferResult is a result of listing a remote application offer.
+// ApplicationOfferResult is a result of querying a remote
+// application offer based on its URL.
 type ApplicationOfferResult struct {
 	// Result contains application offer information.
-	Result *ApplicationOffer `json:"result,omitempty"`
+	Result *ApplicationOfferAdminDetails `json:"result,omitempty"`
 
 	// Error contains related error.
 	Error *Error `json:"error,omitempty"`

--- a/cmd/juju/application/addrelation.go
+++ b/cmd/juju/application/addrelation.go
@@ -197,7 +197,7 @@ func (c *addRelationCommand) maybeConsumeOffer(targetClient applicationAddRelati
 	// Consume is idempotent so even if the offer has been consumed previously,
 	// it's safe to do so again.
 	arg := crossmodel.ConsumeApplicationArgs{
-		ApplicationOffer: *consumeDetails.Offer,
+		Offer:            *consumeDetails.Offer,
 		ApplicationAlias: c.remoteEndpoint.ApplicationName,
 		Macaroon:         consumeDetails.Macaroon,
 	}

--- a/cmd/juju/application/addremoterelation_test.go
+++ b/cmd/juju/application/addremoterelation_test.go
@@ -48,7 +48,7 @@ func (s *AddRemoteRelationSuiteNewAPI) TestAddRelationToOneRemoteApplication(c *
 	s.mockAPI.CheckCall(c, 1, "GetConsumeDetails", "othermodel.applicationname2")
 	s.mockAPI.CheckCall(c, 2, "Consume",
 		crossmodel.ConsumeApplicationArgs{
-			ApplicationOffer: params.ApplicationOffer{
+			Offer: params.ApplicationOfferDetails{
 				OfferName: "hosted-mysql",
 				OfferURL:  "bob/prod.hosted-mysql",
 			},
@@ -63,7 +63,7 @@ func (s *AddRemoteRelationSuiteNewAPI) TestAddRelationAnyRemoteApplication(c *gc
 	s.mockAPI.CheckCall(c, 1, "GetConsumeDetails", "othermodel.applicationname2")
 	s.mockAPI.CheckCall(c, 2, "Consume",
 		crossmodel.ConsumeApplicationArgs{
-			ApplicationOffer: params.ApplicationOffer{
+			Offer: params.ApplicationOfferDetails{
 				OfferName: "hosted-mysql",
 				OfferURL:  "bob/prod.hosted-mysql",
 			},
@@ -242,7 +242,7 @@ func (m *mockAddRelationAPI) Consume(arg crossmodel.ConsumeApplicationArgs) (str
 func (m *mockAddRelationAPI) GetConsumeDetails(url string) (params.ConsumeOfferDetails, error) {
 	m.AddCall("GetConsumeDetails", url)
 	return params.ConsumeOfferDetails{
-		Offer: &params.ApplicationOffer{
+		Offer: &params.ApplicationOfferDetails{
 			OfferName: "hosted-mysql",
 			OfferURL:  "bob/prod.hosted-mysql",
 		},

--- a/cmd/juju/application/consume.go
+++ b/cmd/juju/application/consume.go
@@ -151,7 +151,7 @@ func (c *consumeCommand) Run(ctx *cmd.Context) error {
 	defer targetClient.Close()
 
 	arg := crossmodel.ConsumeApplicationArgs{
-		ApplicationOffer: *consumeDetails.Offer,
+		Offer:            *consumeDetails.Offer,
 		ApplicationAlias: c.applicationAlias,
 		Macaroon:         consumeDetails.Macaroon,
 	}

--- a/cmd/juju/application/consume_test.go
+++ b/cmd/juju/application/consume_test.go
@@ -100,7 +100,7 @@ func (s *ConsumeSuite) assertSuccessModelDotApplication(c *gc.C, alias string) {
 	s.mockAPI.CheckCalls(c, []testing.StubCall{
 		{"GetConsumeDetails", []interface{}{"bob/booster.uke"}},
 		{"Consume", []interface{}{crossmodel.ConsumeApplicationArgs{
-			ApplicationOffer: params.ApplicationOffer{OfferName: "an offer", OfferURL: "ctrl:bob/booster.uke"},
+			Offer:            params.ApplicationOfferDetails{OfferName: "an offer", OfferURL: "ctrl:bob/booster.uke"},
 			ApplicationAlias: alias,
 			Macaroon:         mac,
 			ControllerInfo: &crossmodel.ControllerInfo{
@@ -147,7 +147,7 @@ func (a *mockConsumeAPI) GetConsumeDetails(url string) (params.ConsumeOfferDetai
 		return params.ConsumeOfferDetails{}, err
 	}
 	return params.ConsumeOfferDetails{
-		Offer:    &params.ApplicationOffer{OfferName: "an offer", OfferURL: "bob/booster.uke"},
+		Offer:    &params.ApplicationOfferDetails{OfferName: "an offer", OfferURL: "bob/booster.uke"},
 		Macaroon: mac,
 		ControllerInfo: &params.ExternalControllerInfo{
 			ControllerTag: coretesting.ControllerTag.String(),

--- a/cmd/juju/crossmodel/find_test.go
+++ b/cmd/juju/crossmodel/find_test.go
@@ -133,9 +133,8 @@ master:fred/model.hosted-db2:
       interface: http
       role: provider
   users:
-    fred:
-      user: fred
-      display-name: Fred
+    bob:
+      display-name: Bob
       access: consume
 `[1:],
 	)
@@ -218,9 +217,8 @@ func (s mockFindAPI) FindApplicationOffers(filters ...jujucrossmodel.Application
 			{Name: "log", Interface: "http", Role: charm.RoleProvider},
 			{Name: "db2", Interface: "http", Role: charm.RoleRequirer},
 		},
-		Access: "consume",
 		Users: []jujucrossmodel.OfferUserDetails{{
-			UserName: "fred", DisplayName: "Fred", Access: "consume",
+			UserName: "bob", DisplayName: "Bob", Access: "consume",
 		}},
 	}}, nil
 }

--- a/cmd/juju/crossmodel/list_test.go
+++ b/cmd/juju/crossmodel/list_test.go
@@ -229,7 +229,6 @@ hosted-db2:
     - 10.0.0.0/8
   users:
     fred:
-      user: fred
       display-name: Fred
       access: consume
 `[1:],

--- a/cmd/juju/crossmodel/remoteendpoints.go
+++ b/cmd/juju/crossmodel/remoteendpoints.go
@@ -4,8 +4,9 @@
 package crossmodel
 
 import (
+	"gopkg.in/juju/charm.v6-unstable"
+
 	"github.com/juju/juju/api/applicationoffers"
-	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/cmd/modelcmd"
 )
 
@@ -39,7 +40,7 @@ type RemoteEndpoint struct {
 
 // convertRemoteEndpoints takes any number of api-formatted remote applications' endpoints and
 // creates a collection of ui-formatted endpoints.
-func convertRemoteEndpoints(apiEndpoints ...params.RemoteEndpoint) map[string]RemoteEndpoint {
+func convertRemoteEndpoints(apiEndpoints ...charm.Relation) map[string]RemoteEndpoint {
 	if len(apiEndpoints) == 0 {
 		return nil
 	}

--- a/cmd/juju/crossmodel/show.go
+++ b/cmd/juju/crossmodel/show.go
@@ -8,7 +8,6 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/gnuflag"
 
-	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/core/crossmodel"
 )
@@ -113,33 +112,43 @@ func (c *showCommand) Run(ctx *cmd.Context) (err error) {
 // ShowAPI defines the API methods that cross model show command uses.
 type ShowAPI interface {
 	Close() error
-	ApplicationOffer(url string) (params.ApplicationOffer, error)
+	ApplicationOffer(url string) (*crossmodel.ApplicationOfferDetails, error)
+}
+
+type OfferUser struct {
+	UserName    string `yaml:"user" json:"user"`
+	DisplayName string `yaml:"display-name,omitempty" json:"display-name,omitempty"`
+	Access      string `yaml:"access" json:"access"`
 }
 
 // ShowOfferedApplication defines the serialization behaviour of an application offer.
 // This is used in map-style yaml output where remote application name is the key.
 type ShowOfferedApplication struct {
+	// Description is the user entered description.
+	Description string `yaml:"description,omitempty" json:"description,omitempty"`
+
 	// Access is the level of access the user has on the offer.
 	Access string `yaml:"access" json:"access"`
 
 	// Endpoints list of offered application endpoints.
 	Endpoints map[string]RemoteEndpoint `yaml:"endpoints" json:"endpoints"`
 
-	// Description is the user entered description.
-	Description string `yaml:"description,omitempty" json:"description,omitempty"`
+	// Users are the users who can access the offer.
+	Users map[string]OfferUser `yaml:"users,omitempty" json:"users,omitempty"`
 }
 
 // convertOffers takes any number of api-formatted remote applications and
 // creates a collection of ui-formatted offers.
-func convertOffers(store string, offers ...params.ApplicationOffer) (map[string]ShowOfferedApplication, error) {
+func convertOffers(store string, offers ...*crossmodel.ApplicationOfferDetails) (map[string]ShowOfferedApplication, error) {
 	if len(offers) == 0 {
 		return nil, nil
 	}
 	output := make(map[string]ShowOfferedApplication, len(offers))
 	for _, one := range offers {
 		app := ShowOfferedApplication{
-			Access:    one.Access,
+			Access:    string(one.Access),
 			Endpoints: convertRemoteEndpoints(one.Endpoints...),
+			Users:     convertUsers(one.Users...),
 		}
 		if one.ApplicationDescription != "" {
 			app.Description = one.ApplicationDescription
@@ -154,4 +163,15 @@ func convertOffers(store string, offers ...params.ApplicationOffer) (map[string]
 		output[url.String()] = app
 	}
 	return output, nil
+}
+
+func convertUsers(users ...crossmodel.OfferUserDetails) map[string]OfferUser {
+	if len(users) == 0 {
+		return nil
+	}
+	output := make(map[string]OfferUser, len(users))
+	for _, one := range users {
+		output[one.UserName] = OfferUser{one.UserName, one.DisplayName, string(one.Access)}
+	}
+	return output
 }

--- a/cmd/juju/crossmodel/show_test.go
+++ b/cmd/juju/crossmodel/show_test.go
@@ -63,9 +63,8 @@ test-master:fred/model.db2:
       interface: http
       role: provider
   users:
-    fred:
-      user: fred
-      display-name: Fred
+    bob:
+      display-name: Bob
       access: consume
 `[1:],
 	)
@@ -171,9 +170,8 @@ func (s mockShowAPI) ApplicationOffer(url string) (*jujucrossmodel.ApplicationOf
 			{Name: "log", Interface: "http", Role: charm.RoleProvider},
 			{Name: "db2", Interface: "http", Role: charm.RoleRequirer},
 		},
-		Access: "consume",
 		Users: []jujucrossmodel.OfferUserDetails{{
-			UserName: "fred", DisplayName: "Fred", Access: "consume",
+			UserName: "bob", DisplayName: "Bob", Access: "consume",
 		}},
 	}, nil
 }

--- a/core/crossmodel/interface.go
+++ b/core/crossmodel/interface.go
@@ -60,8 +60,8 @@ type AddApplicationOfferArgs struct {
 
 // ConsumeApplicationArgs contains parameters used to consume an offer.
 type ConsumeApplicationArgs struct {
-	// The offer to be consumed.
-	ApplicationOffer params.ApplicationOffer
+	// Offer is the offer to be consumed.
+	Offer params.ApplicationOfferDetails
 
 	// Macaroon is used for authentication.
 	Macaroon *macaroon.Macaroon

--- a/core/crossmodel/params.go
+++ b/core/crossmodel/params.go
@@ -36,9 +36,6 @@ type ApplicationOfferDetails struct {
 	// TODO(wallyworld) - do not use charm.Relation here
 	Endpoints []charm.Relation
 
-	// Access is the level of access to the offer of the current user.
-	Access permission.Access
-
 	// Connects are the connections to the offer.
 	Connections []OfferConnection
 

--- a/core/crossmodel/params.go
+++ b/core/crossmodel/params.go
@@ -9,16 +9,22 @@ import (
 	"gopkg.in/juju/charm.v6-unstable"
 
 	"github.com/juju/juju/core/relation"
+	"github.com/juju/juju/permission"
 )
 
-// ApplicationOfferDetails represents a remote application used when vendor
-// lists their own applications.
+// ApplicationOfferAdminDetails represents the details about an
+// application offer. Depending on the access permission of the
+// user making the API call, and whether the call is "find" or "list",
+// not all fields will be populated.
 type ApplicationOfferDetails struct {
 	// OfferName is the name of the offer
 	OfferName string
 
 	// ApplicationName is the application name to which the offer pertains.
 	ApplicationName string
+
+	// ApplicationDescription is the application description.
+	ApplicationDescription string
 
 	// OfferURL is the URL where the offer can be located.
 	OfferURL string
@@ -30,8 +36,26 @@ type ApplicationOfferDetails struct {
 	// TODO(wallyworld) - do not use charm.Relation here
 	Endpoints []charm.Relation
 
+	// Access is the level of access to the offer of the current user.
+	Access permission.Access
+
 	// Connects are the connections to the offer.
 	Connections []OfferConnection
+
+	// Users are the users able to access the offer.
+	Users []OfferUserDetails
+}
+
+// OfferUserDetails holds the details about a user's access to an offer.
+type OfferUserDetails struct {
+	// UserName is the username of the user.
+	UserName string
+
+	// DisplayName is the display name of the user.
+	DisplayName string
+
+	// Access is the level of access to the offer.
+	Access permission.Access
 }
 
 // OfferConnection holds details about a connection to an offer.
@@ -59,13 +83,4 @@ type OfferConnection struct {
 
 	// IngressSubnets is the list of subnets from which traffic will originate.
 	IngressSubnets []string
-}
-
-// ApplicationOfferDetailsResult is a result of listing a remote application.
-type ApplicationOfferDetailsResult struct {
-	// Result contains remote application information.
-	Result *ApplicationOfferDetails
-
-	// Error contains error related to this item.
-	Error error
 }

--- a/featuretests/cmd_juju_crossmodel_test.go
+++ b/featuretests/cmd_juju_crossmodel_test.go
@@ -58,6 +58,14 @@ riak:
     endpoint:
       interface: http
       role: provider
+  users:
+    admin:
+      user: admin
+      display-name: admin
+      access: admin
+    everyone@external:
+      user: everyone@external
+      access: read
 varnish:
   application: varnishservice
   store: kontroll
@@ -67,6 +75,14 @@ varnish:
     webcache:
       interface: varnish
       role: provider
+  users:
+    admin:
+      user: admin
+      display-name: admin
+      access: admin
+    everyone@external:
+      user: everyone@external
+      access: read
 `[1:])
 }
 
@@ -108,12 +124,20 @@ func (s *crossmodelSuite) TestShow(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(ctx.Stdout.(*bytes.Buffer).String(), gc.Equals, `
 kontroll:admin/controller.varnish:
+  description: Another popular database
   access: admin
   endpoints:
     webcache:
       interface: varnish
       role: provider
-  description: Another popular database
+  users:
+    admin:
+      user: admin
+      display-name: admin
+      access: admin
+    everyone@external:
+      user: everyone@external
+      access: read
 `[1:])
 }
 
@@ -130,6 +154,11 @@ kontroll:otheruser/othermodel.hosted-mysql:
     database:
       interface: mysql
       role: provider
+  users:
+    otheruser:
+      user: otheruser
+      display-name: display name-9
+      access: admin
 `[1:])
 }
 
@@ -158,12 +187,28 @@ kontroll:admin/controller.riak:
     endpoint:
       interface: http
       role: provider
+  users:
+    admin:
+      user: admin
+      display-name: admin
+      access: admin
+    everyone@external:
+      user: everyone@external
+      access: read
 kontroll:admin/controller.varnish:
   access: admin
   endpoints:
     webcache:
       interface: varnish
       role: provider
+  users:
+    admin:
+      user: admin
+      display-name: admin
+      access: admin
+    everyone@external:
+      user: everyone@external
+      access: read
 `[1:])
 }
 
@@ -180,6 +225,11 @@ kontroll:otheruser/othermodel.hosted-mysql:
     database:
       interface: mysql
       role: provider
+  users:
+    otheruser:
+      user: otheruser
+      display-name: display name-6
+      access: admin
 `[1:])
 }
 
@@ -196,18 +246,39 @@ kontroll:admin/controller.riak:
     endpoint:
       interface: http
       role: provider
+  users:
+    admin:
+      user: admin
+      display-name: admin
+      access: admin
+    everyone@external:
+      user: everyone@external
+      access: read
 kontroll:admin/controller.varnish:
   access: admin
   endpoints:
     webcache:
       interface: varnish
       role: provider
+  users:
+    admin:
+      user: admin
+      display-name: admin
+      access: admin
+    everyone@external:
+      user: everyone@external
+      access: read
 kontroll:otheruser/othermodel.hosted-mysql:
   access: admin
   endpoints:
     database:
       interface: mysql
       role: provider
+  users:
+    otheruser:
+      user: otheruser
+      display-name: display name-4
+      access: admin
 `[1:])
 }
 

--- a/featuretests/cmd_juju_crossmodel_test.go
+++ b/featuretests/cmd_juju_crossmodel_test.go
@@ -60,11 +60,9 @@ riak:
       role: provider
   users:
     admin:
-      user: admin
       display-name: admin
       access: admin
     everyone@external:
-      user: everyone@external
       access: read
 varnish:
   application: varnishservice
@@ -77,11 +75,9 @@ varnish:
       role: provider
   users:
     admin:
-      user: admin
       display-name: admin
       access: admin
     everyone@external:
-      user: everyone@external
       access: read
 `[1:])
 }
@@ -132,11 +128,9 @@ kontroll:admin/controller.varnish:
       role: provider
   users:
     admin:
-      user: admin
       display-name: admin
       access: admin
     everyone@external:
-      user: everyone@external
       access: read
 `[1:])
 }
@@ -147,7 +141,9 @@ func (s *crossmodelSuite) TestShowOtherModel(c *gc.C) {
 	ctx, err := cmdtesting.RunCommand(c, crossmodel.NewShowOfferedEndpointCommand(),
 		"otheruser/othermodel.hosted-mysql", "--format", "yaml")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(ctx.Stdout.(*bytes.Buffer).String(), gc.Equals, `
+	otherUser, err := s.State.User(names.NewUserTag("otheruser"))
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(ctx.Stdout.(*bytes.Buffer).String(), gc.Equals, fmt.Sprintf(`
 kontroll:otheruser/othermodel.hosted-mysql:
   access: admin
   endpoints:
@@ -155,11 +151,13 @@ kontroll:otheruser/othermodel.hosted-mysql:
       interface: mysql
       role: provider
   users:
-    otheruser:
-      user: otheruser
-      display-name: display name-9
+    admin:
+      display-name: admin
       access: admin
-`[1:])
+    otheruser:
+      display-name: %s
+      access: admin
+`, otherUser.DisplayName())[1:])
 }
 
 func (s *crossmodelSuite) setupOffers(c *gc.C) {
@@ -189,11 +187,9 @@ kontroll:admin/controller.riak:
       role: provider
   users:
     admin:
-      user: admin
       display-name: admin
       access: admin
     everyone@external:
-      user: everyone@external
       access: read
 kontroll:admin/controller.varnish:
   access: admin
@@ -203,11 +199,9 @@ kontroll:admin/controller.varnish:
       role: provider
   users:
     admin:
-      user: admin
       display-name: admin
       access: admin
     everyone@external:
-      user: everyone@external
       access: read
 `[1:])
 }
@@ -218,7 +212,9 @@ func (s *crossmodelSuite) TestFindOtherModel(c *gc.C) {
 	ctx, err := cmdtesting.RunCommand(c, crossmodel.NewFindEndpointsCommand(),
 		"otheruser/othermodel", "--format", "yaml")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(ctx.Stdout.(*bytes.Buffer).String(), gc.Equals, `
+	otherUser, err := s.State.User(names.NewUserTag("otheruser"))
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(ctx.Stdout.(*bytes.Buffer).String(), gc.Equals, fmt.Sprintf(`
 kontroll:otheruser/othermodel.hosted-mysql:
   access: admin
   endpoints:
@@ -226,11 +222,13 @@ kontroll:otheruser/othermodel.hosted-mysql:
       interface: mysql
       role: provider
   users:
-    otheruser:
-      user: otheruser
-      display-name: display name-6
+    admin:
+      display-name: admin
       access: admin
-`[1:])
+    otheruser:
+      display-name: %s
+      access: admin
+`, otherUser.DisplayName())[1:])
 }
 
 func (s *crossmodelSuite) TestFindAllModels(c *gc.C) {
@@ -239,7 +237,9 @@ func (s *crossmodelSuite) TestFindAllModels(c *gc.C) {
 
 	ctx, err := cmdtesting.RunCommand(c, crossmodel.NewFindEndpointsCommand(), "kontroll:", "--format", "yaml")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(ctx.Stdout.(*bytes.Buffer).String(), gc.Equals, `
+	otherUser, err := s.State.User(names.NewUserTag("otheruser"))
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(ctx.Stdout.(*bytes.Buffer).String(), gc.Equals, fmt.Sprintf(`
 kontroll:admin/controller.riak:
   access: admin
   endpoints:
@@ -248,11 +248,9 @@ kontroll:admin/controller.riak:
       role: provider
   users:
     admin:
-      user: admin
       display-name: admin
       access: admin
     everyone@external:
-      user: everyone@external
       access: read
 kontroll:admin/controller.varnish:
   access: admin
@@ -262,11 +260,9 @@ kontroll:admin/controller.varnish:
       role: provider
   users:
     admin:
-      user: admin
       display-name: admin
       access: admin
     everyone@external:
-      user: everyone@external
       access: read
 kontroll:otheruser/othermodel.hosted-mysql:
   access: admin
@@ -275,11 +271,13 @@ kontroll:otheruser/othermodel.hosted-mysql:
       interface: mysql
       role: provider
   users:
-    otheruser:
-      user: otheruser
-      display-name: display name-4
+    admin:
+      display-name: admin
       access: admin
-`[1:])
+    otheruser:
+      display-name: %s
+      access: admin
+`, otherUser.DisplayName())[1:])
 }
 
 func (s *crossmodelSuite) TestAddRelationFromURL(c *gc.C) {
@@ -493,6 +491,9 @@ kontroll:otheruser/othermodel.hosted-mysql:
     database:
       interface: mysql
       role: provider
+  users:
+    test:
+      access: read
 `[1:])
 }
 

--- a/state/applicationoffers.go
+++ b/state/applicationoffers.go
@@ -109,7 +109,7 @@ func (s *applicationOffers) ApplicationOffer(offerName string) (*crossmodel.Appl
 	return s.makeApplicationOffer(*offerDoc)
 }
 
-// ApplicationOffer returns the application offer for the UUID.
+// ApplicationOfferForUUID returns the application offer for the UUID.
 func (s *applicationOffers) ApplicationOfferForUUID(offerUUID string) (*crossmodel.ApplicationOffer, error) {
 	offerDoc, err := s.offerQuery(bson.D{{"offer-uuid", offerUUID}})
 	if err != nil {

--- a/state/applicationofferuser.go
+++ b/state/applicationofferuser.go
@@ -22,6 +22,19 @@ func (st *State) GetOfferAccess(offerUUID string, user names.UserTag) (permissio
 	return perm.access(), nil
 }
 
+// GetOfferUsers gets the access permissions on an offer.
+func (st *State) GetOfferUsers(offerUUID string) (map[string]permission.Access, error) {
+	perms, err := st.usersPermissions(applicationOfferKey(offerUUID))
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	result := make(map[string]permission.Access)
+	for _, p := range perms {
+		result[userIDFromGlobalKey(p.doc.SubjectGlobalKey)] = p.access()
+	}
+	return result, nil
+}
+
 // CreateOfferAccess creates a new access permission for a user on an offer.
 func (st *State) CreateOfferAccess(offer names.ApplicationOfferTag, user names.UserTag, access permission.Access) error {
 	if err := permission.ValidateOfferAccess(access); err != nil {

--- a/state/user.go
+++ b/state/user.go
@@ -31,6 +31,11 @@ func userGlobalKey(userID string) string {
 	return fmt.Sprintf("%s#%s", userGlobalKeyPrefix, userID)
 }
 
+func userIDFromGlobalKey(key string) string {
+	prefix := userGlobalKeyPrefix + "#"
+	return strings.TrimPrefix(key, prefix)
+}
+
 func (st *State) checkUserExists(name string) (bool, error) {
 	users, closer := st.db().GetCollection(usersC)
 	defer closer()


### PR DESCRIPTION
## Description of change

The show/list/find offer commands display the users and access permissions on the offer(s) for yaml format (assuming the user running the command is admin). Some params / data structs were consolidated in the process to reduce the number of structs used and have the api methods not return params structs.

The second commit separately performs a rename of params.ApplicationOffer.

## QA steps

Create an offer
Run show/list/find and check the output
