### PR TITLE
Add --destroy-storage when destroy_model() called.

### DIFF
--- a/acceptancetests/jujupy/client.py
+++ b/acceptancetests/jujupy/client.py
@@ -1993,8 +1993,9 @@ class ModelClient:
 
     def destroy_model(self):
         exit_status, _ = self.juju(
-            'destroy-model', ('{}:{}'.format(self.env.controller.name,
-                                             self.env.environment), '-y',),
+            'destroy-model',
+            ('{}:{}'.format(self.env.controller.name, self.env.environment),
+            '-y', '--destroy-storage',),
             include_e=False, timeout=get_teardown_timeout(self))
         return exit_status
 


### PR DESCRIPTION
## Description of change
According to the latest development of persistent storage feature in Juju 2.3, if there is a persistent type of storage in models, and if the storage for some reason didn't / couldn't be removed by the script (bug, error, crash, etc.), --destroy-storage is required in destroy-model process.

## QA steps
Using assess_persistent_storage.py as an example:
https://github.com/juju/juju/blob/develop/acceptancetests/assess_persistent_storage.py

Comment out persistent storage removal section (between line 419 and 425), run the script against an existing controller.
Without this change, the script will fail in destroy model process, result the current test model being left behind. With the change, the model can be successfully destroyed.

This change has been locally tested.

## Documentation changes
N/A

## Bug reference
N/A
