### PR TITLE
Add JUJU_VERSION to hook context

### DIFF
--- a/worker/uniter/runner/context/context.go
+++ b/worker/uniter/runner/context/context.go
@@ -23,6 +23,7 @@ import (
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/status"
+	"github.com/juju/juju/version"
 	"github.com/juju/juju/worker/uniter/runner/jujuc"
 )
 
@@ -589,6 +590,7 @@ func (context *HookContext) HookVars(paths Paths) ([]string, error) {
 		"JUJU_MACHINE_ID="+context.assignedMachineTag.Id(),
 		"JUJU_PRINCIPAL_UNIT="+context.principal,
 		"JUJU_AVAILABILITY_ZONE="+context.availabilityzone,
+		"JUJU_VERSION="+version.Current.String(),
 	)
 	if r, err := context.HookRelation(); err == nil {
 		vars = append(vars,

--- a/worker/uniter/runner/context/env_test.go
+++ b/worker/uniter/runner/context/env_test.go
@@ -14,9 +14,11 @@ import (
 	"github.com/juju/utils/keyvalues"
 	jujuos "github.com/juju/utils/os"
 	"github.com/juju/utils/proxy"
+	"github.com/juju/version"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/names.v2"
 
+	jujuversion "github.com/juju/juju/version"
 	"github.com/juju/juju/worker/uniter/runner/context"
 )
 
@@ -75,6 +77,7 @@ func (s *EnvSuite) getContext() (ctx *context.HookContext, expectVars []string) 
 			"JUJU_API_ADDRESSES=he.re:12345 the.re:23456",
 			"JUJU_MACHINE_ID=42",
 			"JUJU_AVAILABILITY_ZONE=some-zone",
+			"JUJU_VERSION=1.2.3",
 			"http_proxy=some-http-proxy",
 			"HTTP_PROXY=some-http-proxy",
 			"https_proxy=some-https-proxy",
@@ -111,6 +114,7 @@ func (s *EnvSuite) TestEnvSetsPath(c *gc.C) {
 
 func (s *EnvSuite) TestEnvWindows(c *gc.C) {
 	s.PatchValue(&jujuos.HostOS, func() jujuos.OSType { return jujuos.Windows })
+	s.PatchValue(&jujuversion.Current, version.MustParse("1.2.3"))
 	os.Setenv("Path", "foo;bar")
 	os.Setenv("PSModulePath", "ping;pong")
 	windowsVars := []string{
@@ -132,6 +136,7 @@ func (s *EnvSuite) TestEnvWindows(c *gc.C) {
 
 func (s *EnvSuite) TestEnvUbuntu(c *gc.C) {
 	s.PatchValue(&jujuos.HostOS, func() jujuos.OSType { return jujuos.Ubuntu })
+	s.PatchValue(&jujuversion.Current, version.MustParse("1.2.3"))
 	os.Setenv("PATH", "foo:bar")
 	ubuntuVars := []string{
 		"PATH=path-to-tools:foo:bar",


### PR DESCRIPTION
## Description of change

Some charms would like to know what version of Juju is being used when a hook is executed.
We add JUJU_VERSION to the hook context.

## QA steps

echo $JUJU_VERSION in a hook

## Documentation changes

Charm developer doc
