### PR TITLE
Allow for exact offer match in list-offers

### DIFF
--- a/cmd/juju/crossmodel/list_test.go
+++ b/cmd/juju/crossmodel/list_test.go
@@ -81,6 +81,17 @@ func (s *ListSuite) TestListFilterArgs(c *gc.C) {
 	})
 }
 
+func (s *ListSuite) TestListOfferArg(c *gc.C) {
+	_, err := s.runList(c, []string{"mysql-lite"})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(s.mockAPI.filters, gc.HasLen, 1)
+	c.Assert(s.mockAPI.filters[0], jc.DeepEquals, model.ApplicationOfferFilter{
+		OwnerName: "fred",
+		ModelName: "test",
+		OfferName: "^mysql-lite$",
+	})
+}
+
 func (s *ListSuite) TestListFormatError(c *gc.C) {
 	s.applications = append(s.applications, s.createOfferItem("zdi^%", "different_store", nil))
 

--- a/state/applicationoffers.go
+++ b/state/applicationoffers.go
@@ -391,8 +391,7 @@ func (s *applicationOffers) makeFilterTerm(filterTerm crossmodel.ApplicationOffe
 	}
 	// We match on partial names, eg "-sql"
 	if filterTerm.OfferName != "" {
-		name := regexp.QuoteMeta(filterTerm.OfferName)
-		filter = append(filter, bson.DocElem{"offer-name", bson.D{{"$regex", fmt.Sprintf(".*%s.*", name)}}})
+		filter = append(filter, bson.DocElem{"offer-name", bson.D{{"$regex", fmt.Sprintf(".*%s.*", filterTerm.OfferName)}}})
 	}
 	// We match descriptions by looking for containing terms.
 	if filterTerm.ApplicationDescription != "" {

--- a/state/applicationoffers_test.go
+++ b/state/applicationoffers_test.go
@@ -217,6 +217,24 @@ func (s *applicationOffersSuite) TestListOffersOneFilter(c *gc.C) {
 	c.Assert(offers[0], jc.DeepEquals, offer)
 }
 
+func (s *applicationOffersSuite) TestListOffersExact(c *gc.C) {
+	sd := state.NewApplicationOffers(s.State)
+	offer := s.createOffer(c, "offer1", "description for offer1")
+	s.createOffer(c, "offer2", "description for offer2")
+	s.createOffer(c, "offer3", "description for offer3")
+	offers, err := sd.ListOffers(crossmodel.ApplicationOfferFilter{
+		OfferName: "^offer1$",
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(len(offers), gc.Equals, 1)
+	c.Assert(offers[0], jc.DeepEquals, offer)
+	offers, err = sd.ListOffers(crossmodel.ApplicationOfferFilter{
+		OfferName: "^offer$",
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(len(offers), gc.Equals, 0)
+}
+
 func (s *applicationOffersSuite) TestListOffersFilterExcludes(c *gc.C) {
 	sd := state.NewApplicationOffers(s.State)
 	s.createOffer(c, "offer1", "description for offer1")


### PR DESCRIPTION
## Description of change

juju list-offers now takes a positional arg which is the offer to show

## QA steps

juju list-offers <offername>
verify that just the specified offer is shown
