### PR TITLE
Added note about standard ssh options.

### DIFF
--- a/cmd/juju/commands/ssh.go
+++ b/cmd/juju/commands/ssh.go
@@ -28,10 +28,12 @@ The SSH host keys of the target are verified. The --no-host-key-checks option
 can be used to disable these checks. Use of this option is not recommended as
 it opens up the possibility of a man-in-the-middle attack.
 
-Options specific to ssh can be provided as well. In fact, any arguments passed 
-after the target will be passed directly on to OpenSSH 
-(on platforms where it is available). 
-Refer to the ssh man page for an explanation of those options.
+The default identity known to Juju and used by this command is ~/.ssh/id_rsa
+
+Options can be passed to the local OpenSSH client (ssh) on platforms 
+where it is available. This is done by inserting them between the target and 
+a possible remote command. Refer to the ssh man page for an explanation 
+of those options.
 
 Examples:
 Connect to machine 0:
@@ -50,11 +52,9 @@ Connect to a jenkins unit as user jenkins:
 
     juju ssh jenkins@jenkins/0
 
-Pass extra options to SSH:
+Connect to a mysql unit with an identity not known to juju (ssh option -i):
 
-    juju ssh mysql/0 -i SPECIAL_IDENTITY_FILE echo hello
-
-(not 'juju ssh -i SPECIAL_IDENTITY_FILE mysql/0 echo hello') 
+    juju ssh mysql/0 -i ~/.ssh/my_private_key echo hello
 
 See also: 
     scp`
@@ -73,7 +73,7 @@ type sshCommand struct {
 func (c *sshCommand) Info() *cmd.Info {
 	return &cmd.Info{
 		Name:    "ssh",
-		Args:    "<[user@]target> [command]",
+		Args:    "<[user@]target> [openssh options] [command]",
 		Purpose: usageSSHSummary,
 		Doc:     usageSSHDetails,
 	}

--- a/cmd/juju/commands/ssh.go
+++ b/cmd/juju/commands/ssh.go
@@ -28,6 +28,9 @@ The SSH host keys of the target are verified. The --no-host-key-checks option
 can be used to disable these checks. Use of this option is not recommended as
 it opens up the possibility of a man-in-the-middle attack.
 
+Options specific to ssh can be provided as well. Refer to the ssh man
+page for an explanation of those options.
+
 Examples:
 Connect to machine 0:
 

--- a/cmd/juju/commands/ssh.go
+++ b/cmd/juju/commands/ssh.go
@@ -28,8 +28,10 @@ The SSH host keys of the target are verified. The --no-host-key-checks option
 can be used to disable these checks. Use of this option is not recommended as
 it opens up the possibility of a man-in-the-middle attack.
 
-Options specific to ssh can be provided as well. Refer to the ssh man
-page for an explanation of those options.
+Options specific to ssh can be provided as well. In fact, any arguments passed 
+after the target will be passed directly on to OpenSSH 
+(on platforms where it is available). 
+Refer to the ssh man page for an explanation of those options.
 
 Examples:
 Connect to machine 0:
@@ -47,6 +49,12 @@ Connect to a mysql unit:
 Connect to a jenkins unit as user jenkins:
 
     juju ssh jenkins@jenkins/0
+
+Pass extra options to SSH:
+
+    juju ssh mysql/0 -i SPECIAL_IDENTITY_FILE echo hello
+
+(not 'juju ssh -i SPECIAL_IDENTITY_FILE echo hello') 
 
 See also: 
     scp`

--- a/cmd/juju/commands/ssh.go
+++ b/cmd/juju/commands/ssh.go
@@ -54,7 +54,7 @@ Pass extra options to SSH:
 
     juju ssh mysql/0 -i SPECIAL_IDENTITY_FILE echo hello
 
-(not 'juju ssh -i SPECIAL_IDENTITY_FILE echo hello') 
+(not 'juju ssh -i SPECIAL_IDENTITY_FILE mysql/0 echo hello') 
 
 See also: 
     scp`


### PR DESCRIPTION
## Description of change

Users were not aware that standard 'ssh' options could also be provided to 'juju ssh' command.
Added a paragraph to a command help, similar in wording to 'juju scp'.

## QA steps

'juju help ssh' mentions standard ssh options and man.

## Documentation changes

n/a

## Bug reference
https://bugs.launchpad.net/juju/+bug/1718775
