### PR TITLE
commands/resolved: Added a new alias 'resolve'

### DIFF
--- a/cmd/juju/commands/main_test.go
+++ b/cmd/juju/commands/main_test.go
@@ -502,6 +502,7 @@ var commandNames = []string{
 	"remove-unit",
 	"remove-user",
 	"resolved",
+	"resolve",
 	"resources",
 	"restore-backup",
 	"resume-relation",

--- a/cmd/juju/commands/resolved.go
+++ b/cmd/juju/commands/resolved.go
@@ -29,6 +29,7 @@ func (c *resolvedCommand) Info() *cmd.Info {
 		Name:    "resolved",
 		Args:    "<unit>",
 		Purpose: "Marks unit errors resolved and re-executes failed hooks.",
+		Aliases: []string{"resolve"},
 	}
 }
 


### PR DESCRIPTION
## Description of change

Juju uses verb command names:
```
deploy
config
attach
allocate
grant
```
```juju resolved``` is different and it's very natural for most users to expect to call ```juju resolve```
This pr add resolve as an alias for resolved.
## QA steps

```juju help resolve```

## Documentation changes

juju resolve can now be called.

## Does it affect current user workflow? CLI? API?

juju resolve can now be called.

## Bug reference