### PR TITLE
Go-1.9 is now default for juju 2.3

### DIFF
--- a/.ci/check-merge.groovy
+++ b/.ci/check-merge.groovy
@@ -64,7 +64,7 @@ node('juju-core-slave-b') {
 
                 sh(script: "${scripts_dir}/clean_lxd.py")
 
-                withEnv(["PATH+GO=/usr/lib/go-1.8/bin/"]) {
+                withEnv(["PATH+GO=/usr/lib/go-1.9/bin/"]) {
                     retcode = sh(
                         script: "${release_scripts}/make-pr-tarball.bash ${env.CHANGE_ID}",
                         returnStatus: true)

--- a/.ci/check-merge.groovy
+++ b/.ci/check-merge.groovy
@@ -64,7 +64,7 @@ node('juju-core-slave-b') {
 
                 sh(script: "${scripts_dir}/clean_lxd.py")
 
-                withEnv(["PATH+GO=/usr/lib/go-1.9/bin/"]) {
+                withEnv(["PATH+GO=/snap/bin/go"]) {
                     retcode = sh(
                         script: "${release_scripts}/make-pr-tarball.bash ${env.CHANGE_ID}",
                         returnStatus: true)

--- a/.ci/check-merge.groovy
+++ b/.ci/check-merge.groovy
@@ -64,7 +64,7 @@ node('juju-core-slave-b') {
 
                 sh(script: "${scripts_dir}/clean_lxd.py")
 
-                withEnv(["PATH+GO=/snap/bin/go"]) {
+                withEnv(["PATH+GO=/snap/bin/]) {
                     retcode = sh(
                         script: "${release_scripts}/make-pr-tarball.bash ${env.CHANGE_ID}",
                         returnStatus: true)

--- a/.ci/check-merge.groovy
+++ b/.ci/check-merge.groovy
@@ -109,7 +109,7 @@ node('juju-core-slave-b') {
                         withEnv(["JUJU_HOME=${cloud_city}"]){
                             sh("""
                             . $JUJU_HOME/juju-qa.jujuci && . $JUJU_HOME/ec2rc >2 /dev/null && \\
-                            ${scripts_dir}/run-unit-tests c4.4xlarge $xenial_ami --local "$tarfile" --use-tmpfs --use-ppa ppa:juju/golang --force-archive
+                            ${scripts_dir}/run-unit-tests c4.4xlarge $xenial_ami --local "$tarfile" --use-tmpfs --force-archive
                             """)
                         }
                     } catch(e) {

--- a/.ci/check-merge.groovy
+++ b/.ci/check-merge.groovy
@@ -64,7 +64,7 @@ node('juju-core-slave-b') {
 
                 sh(script: "${scripts_dir}/clean_lxd.py")
 
-                withEnv(["PATH+GO=/snap/bin/"]) {
+                withEnv(["PATH+GO=/snap/go/current/bin/"]) {
                     retcode = sh(
                         script: "${release_scripts}/make-pr-tarball.bash ${env.CHANGE_ID}",
                         returnStatus: true)

--- a/.ci/check-merge.groovy
+++ b/.ci/check-merge.groovy
@@ -64,7 +64,7 @@ node('juju-core-slave-b') {
 
                 sh(script: "${scripts_dir}/clean_lxd.py")
 
-                withEnv(["PATH+GO=/snap/bin/]) {
+                withEnv(["PATH+GO=/snap/bin/"]) {
                     retcode = sh(
                         script: "${release_scripts}/make-pr-tarball.bash ${env.CHANGE_ID}",
                         returnStatus: true)

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ else
 endif
 
 ifeq ($(shell uname -p | sed -r 's/.*(86|armel|armhf|aarch64|ppc64le|s390x).*/golang/'), golang)
-	GO_C = golang-1.8
+	GO_C = golang-1.9
 	INSTALL_FLAGS =
 else
 	GO_C = gccgo-4.9  gccgo-go
@@ -96,7 +96,7 @@ rebuild-dependencies.tsv: godeps
 # Install packages required to develop Juju and run tests. The stable
 # PPA includes the required mongodb-server binaries.
 install-dependencies:
-	@echo Adding juju PPAs for golang and juju
+	@echo Adding juju PPA for mongodb
 	@sudo apt-add-repository --yes ppa:juju/stable
 	@sudo apt-get update
 	@echo Installing dependencies
@@ -125,11 +125,8 @@ check-deps:
 	@echo "$(GOCHECK_COUNT) instances of gocheck not in test code"
 
 install-go:
-	@echo Adding juju PPAs for golang and juju
-	@sudo apt-add-repository -y ppa:juju/golang
-	@sudo apt-get update
-	@echo Installing $(GO_C)
-	@sudo apt-get -y install $(GO_C)
+	@echo Installing go-1.9 snap
+	@sudo snap install go --channel=1.9/stable
 
 .PHONY: build check install
 .PHONY: clean format simplify

--- a/Makefile
+++ b/Makefile
@@ -120,7 +120,7 @@ check-deps:
 
 install-go:
 	@echo Installing go-1.9 snap
-	@sudo snap install go --channel=1.9/stable
+	@sudo snap install go --channel=1.9/stable --classic
 
 .PHONY: build check install
 .PHONY: clean format simplify

--- a/Makefile
+++ b/Makefile
@@ -16,18 +16,12 @@ else
 	TEST_TIMEOUT := 1500s
 endif
 
-ifeq ($(shell uname -p | sed -r 's/.*(86|armel|armhf|aarch64|ppc64le|s390x).*/golang/'), golang)
-	GO_C = golang-1.9
-	INSTALL_FLAGS =
-else
-	GO_C = gccgo-4.9  gccgo-go
-	INSTALL_FLAGS = -gccgoflags=-static-libgo
-endif
+GO_C = golang-1.9
+INSTALL_FLAGS =
 
 define DEPENDENCIES
   ca-certificates
   bzip2
-  bzr
   distro-info-data
   git
   zip

--- a/README.md
+++ b/README.md
@@ -16,17 +16,14 @@ Getting started
 `juju` is written in Go (http://golang.org), a modern, compiled, statically typed,
 concurrent language. This document describes how to build `juju` from source.
 
-If you are looking for binary releases of `juju`, they are available from the Juju
-stable PPA, `https://launchpad.net/~juju/+archive/stable`, and can be installed with:
+If you are looking for binary releases of `juju`, they are available in the snap store
 
-    sudo apt-add-repository ppa:juju/stable
-    sudo apt-get update
-    sudo apt-get install juju
+    snap install juju --classic
     
 Installing Go
 --------------
 
-`Juju's` source code currently depends on Go 1.8. One of the easiest ways
+`Juju's` source code currently depends on Go 1.9. One of the easiest ways
 to install golang is from a snap. You may need to first install
 the [snap client](https://snapcraft.io/docs/core/install). Installing the golang
 snap package is then as easy as
@@ -37,7 +34,7 @@ You can read about the "classic" confinement policy [here](https://insights.ubun
 
 If you want to use `apt`, then you can add the [juju-golang PPA](https://launchpad.net/~juju/+archive/ubuntu/golang) and then run the following
 
-    sudo apt install golang-1.8
+    sudo apt install golang-1.9
 
 Alternatively, you can always follow the official [binary installation instructions](https://golang.org/doc/install#install)
 

--- a/acceptancetests/assess_lxd_space.py
+++ b/acceptancetests/assess_lxd_space.py
@@ -182,6 +182,9 @@ def assess_lxd_container_space(client):
     assert_initial_spaces(client)
     assert_initial_subnets(client)
     assert_added_space(client)
+    # With FAN now working, we need to explicitly set the model-config
+    # to local to test the old behavior
+    client.juju('model-config', 'container-networking-method=local')
     # Run juju deploy ubuntu --constraints "spaces=testspace"
     client.deploy(charm='ubuntu', constraints='spaces=testspace')
     client.wait_for_started()

--- a/acceptancetests/ec2-terminate-job-instances
+++ b/acceptancetests/ec2-terminate-job-instances
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 import os
-from deploy_stack import destroy_job_instances
+from substrate import destroy_job_instances
 
 if __name__ == '__main__':
     destroy_job_instances(os.environ['JOB_NAME'])

--- a/acceptancetests/run-unit-tests
+++ b/acceptancetests/run-unit-tests
@@ -179,7 +179,7 @@ if [[ "$INSTANCE_TYPE" != "lxc" && "$INSTANCE_TYPE" != "host" ]]; then
     done
     $FIXUP_SOURCES
 fi
-export PATH=/usr/lib/go-1.8/bin:$PATH
+export PATH=/usr/lib/go-1.9/bin:$PATH
 export DEBIAN_FRONTEND=noninteractive
 sudo apt-get update
 sudo apt-get install -y make gcc software-properties-common distro-info-data

--- a/acceptancetests/run-unit-tests
+++ b/acceptancetests/run-unit-tests
@@ -179,7 +179,7 @@ if [[ "$INSTANCE_TYPE" != "lxc" && "$INSTANCE_TYPE" != "host" ]]; then
     done
     $FIXUP_SOURCES
 fi
-export PATH=/usr/lib/go-1.9/bin:$PATH
+export PATH=/snap/bin/:$PATH
 export DEBIAN_FRONTEND=noninteractive
 sudo apt-get update
 sudo apt-get install -y make gcc software-properties-common distro-info-data

--- a/acceptancetests/run-unit-tests
+++ b/acceptancetests/run-unit-tests
@@ -153,7 +153,7 @@ if [[ "$USE_TMPFS" == "true" ]]; then
     fi
     sudo rm -rf /mnt/tmp/* || true
     export TMPDIR=/mnt/tmp
-fi
+	fi
 if [[ "$USE_MONGO32" == "true" ]]; then
     # Ensure juju 2.* uses the correct mongo.
     export JUJU_MONGOD=/usr/lib/juju/mongo3.2/bin/mongod
@@ -179,7 +179,7 @@ if [[ "$INSTANCE_TYPE" != "lxc" && "$INSTANCE_TYPE" != "host" ]]; then
     done
     $FIXUP_SOURCES
 fi
-export PATH=/snap/bin/:$PATH
+export PATH=/snap/go/current/bin/:$PATH
 export DEBIAN_FRONTEND=noninteractive
 sudo apt-get update
 sudo apt-get install -y make gcc software-properties-common distro-info-data

--- a/api/application/client.go
+++ b/api/application/client.go
@@ -639,6 +639,7 @@ func (c *Client) Consume(arg crossmodel.ConsumeApplicationArgs) (string, error) 
 	if arg.ControllerInfo != nil {
 		args.Args[0].ControllerInfo = &params.ExternalControllerInfo{
 			ControllerTag: arg.ControllerInfo.ControllerTag.String(),
+			Alias:         arg.ControllerInfo.Alias,
 			Addrs:         arg.ControllerInfo.Addrs,
 			CACert:        arg.ControllerInfo.CACert,
 		}

--- a/api/application/client_test.go
+++ b/api/application/client_test.go
@@ -511,6 +511,7 @@ func (s *applicationSuite) TestConsume(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	controllerInfo := &params.ExternalControllerInfo{
 		ControllerTag: coretesting.ControllerTag.String(),
+		Alias:         "controller-alias",
 		Addrs:         []string{"192.168.1.0"},
 		CACert:        coretesting.CACert,
 	}
@@ -547,6 +548,7 @@ func (s *applicationSuite) TestConsume(c *gc.C) {
 		Macaroon:         mac,
 		ControllerInfo: &crossmodel.ControllerInfo{
 			ControllerTag: coretesting.ControllerTag,
+			Alias:         "controller-alias",
 			Addrs:         controllerInfo.Addrs,
 			CACert:        controllerInfo.CACert,
 		},

--- a/api/applicationoffers/client.go
+++ b/api/applicationoffers/client.go
@@ -58,17 +58,24 @@ func (c *Client) Offer(modelUUID, application string, endpoints []string, offerN
 func (c *Client) ListOffers(filters ...crossmodel.ApplicationOfferFilter) ([]*crossmodel.ApplicationOfferDetails, error) {
 	var paramsFilter params.OfferFilters
 	for _, f := range filters {
-		// TODO(wallyworld) - include allowed users
 		filterTerm := params.OfferFilter{
-			ModelName:       f.ModelName,
-			OfferName:       f.OfferName,
-			ApplicationName: f.ApplicationName,
+			ModelName:           f.ModelName,
+			OfferName:           f.OfferName,
+			ApplicationName:     f.ApplicationName,
+			Endpoints:           make([]params.EndpointFilterAttributes, len(f.Endpoints)),
+			AllowedConsumerTags: make([]string, len(f.AllowedConsumers)),
+			ConnectedUserTags:   make([]string, len(f.ConnectedUsers)),
 		}
-		filterTerm.Endpoints = make([]params.EndpointFilterAttributes, len(f.Endpoints))
 		for i, ep := range f.Endpoints {
 			filterTerm.Endpoints[i].Name = ep.Name
 			filterTerm.Endpoints[i].Interface = ep.Interface
 			filterTerm.Endpoints[i].Role = ep.Role
+		}
+		for i, u := range f.AllowedConsumers {
+			filterTerm.AllowedConsumerTags[i] = names.NewUserTag(u).String()
+		}
+		for i, u := range f.ConnectedUsers {
+			filterTerm.ConnectedUserTags[i] = names.NewUserTag(u).String()
 		}
 		paramsFilter.Filters = append(paramsFilter.Filters, filterTerm)
 	}

--- a/api/applicationoffers/client_test.go
+++ b/api/applicationoffers/client_test.go
@@ -105,10 +105,12 @@ func (s *crossmodelMockSuite) TestList(c *gc.C) {
 	relations := []jujucrossmodel.EndpointFilterTerm{{Name: "endPointA", Interface: "http"}}
 
 	filter := jujucrossmodel.ApplicationOfferFilter{
-		OfferName: offerName,
-		Endpoints: relations,
+		OfferName:        offerName,
+		Endpoints:        relations,
+		ApplicationName:  "mysql",
+		AllowedConsumers: []string{"allowed"},
+		ConnectedUsers:   []string{"connected"},
 	}
-
 	called := false
 	since := time.Now()
 	apiCaller := basetesting.APICallerFunc(
@@ -132,6 +134,8 @@ func (s *crossmodelMockSuite) TestList(c *gc.C) {
 					Name:      "endPointA",
 					Interface: "http",
 				}},
+				AllowedConsumerTags: []string{"user-allowed"},
+				ConnectedUserTags:   []string{"user-connected"},
 			})
 
 			if results, ok := result.(*params.QueryApplicationOffersResults); ok {

--- a/api/facadeversions.go
+++ b/api/facadeversions.go
@@ -34,6 +34,7 @@ var facadeVersions = map[string]int{
 	"Deployer":                     1,
 	"DiskManager":                  2,
 	"EntityWatcher":                2,
+	"FanConfigurer":                1,
 	"FilesystemAttachmentsWatcher": 2,
 	"Firewaller":                   4,
 	"FirewallRules":                1,

--- a/api/fanconfigurer/facade.go
+++ b/api/fanconfigurer/facade.go
@@ -1,0 +1,46 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package fanconfigurer
+
+import (
+	"github.com/juju/juju/api/base"
+	apiwatcher "github.com/juju/juju/api/watcher"
+	"github.com/juju/juju/apiserver/common/networkingcommon"
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/network"
+	"github.com/juju/juju/watcher"
+)
+
+// Facade provides access to the FanConfigurer API facade.
+type Facade struct {
+	caller base.FacadeCaller
+}
+
+// NewFacade creates a new client-side FanConfigu	er facade.
+func NewFacade(caller base.APICaller) *Facade {
+	return &Facade{
+		caller: base.NewFacadeCaller(caller, "FanConfigurer"),
+	}
+}
+
+// WatchForFanConfigChanges return a NotifyWatcher waiting for the
+// fan configuration to change.
+func (f *Facade) WatchForFanConfigChanges() (watcher.NotifyWatcher, error) {
+	var result params.NotifyWatchResult
+	err := f.caller.FacadeCall("WatchForFanConfigChanges", nil, &result)
+	if err != nil {
+		return nil, err
+	}
+	return apiwatcher.NewNotifyWatcher(f.caller.RawAPICaller(), result), nil
+}
+
+// FanConfig returns the current fan configuration.
+func (f *Facade) FanConfig() (network.FanConfig, error) {
+	var result params.FanConfigResult
+	err := f.caller.FacadeCall("FanConfig", nil, &result)
+	if err != nil {
+		return nil, err
+	}
+	return networkingcommon.FanConfigResultToFanConfig(result)
+}

--- a/apiserver/allfacades.go
+++ b/apiserver/allfacades.go
@@ -15,6 +15,7 @@ import (
 	"github.com/juju/juju/apiserver/facades/agent/agent" // ModelUser Write
 	"github.com/juju/juju/apiserver/facades/agent/deployer"
 	"github.com/juju/juju/apiserver/facades/agent/diskmanager"
+	"github.com/juju/juju/apiserver/facades/agent/fanconfigurer"
 	"github.com/juju/juju/apiserver/facades/agent/hostkeyreporter"
 	"github.com/juju/juju/apiserver/facades/agent/keyupdater"
 	"github.com/juju/juju/apiserver/facades/agent/leadership"
@@ -150,6 +151,7 @@ func AllFacades() *facade.Registry {
 
 	reg("Deployer", 1, deployer.NewDeployerAPI)
 	reg("DiskManager", 2, diskmanager.NewDiskManagerAPI)
+	reg("FanConfigurer", 1, fanconfigurer.NewFanConfigurerAPI)
 	reg("Firewaller", 3, firewaller.NewStateFirewallerAPIV3)
 	reg("Firewaller", 4, firewaller.NewStateFirewallerAPIV4)
 	reg("FirewallRules", 1, firewallrules.NewFacade)

--- a/apiserver/common/modelmanagerinterface.go
+++ b/apiserver/common/modelmanagerinterface.go
@@ -95,6 +95,7 @@ type Model interface {
 	ControllerUUID() string
 	LastModelConnection(user names.UserTag) (time.Time, error)
 	AddUser(state.UserAccessSpec) (permission.UserAccess, error)
+	AutoConfigureContainerNetworking(environ environs.Environ) error
 }
 
 var _ ModelManagerBackend = (*modelManagerStateShim)(nil)

--- a/apiserver/common/networkingcommon/networkconfigapi.go
+++ b/apiserver/common/networkingcommon/networkconfigapi.go
@@ -7,6 +7,8 @@
 package networkingcommon
 
 import (
+	"net"
+
 	"github.com/juju/errors"
 	"gopkg.in/juju/names.v2"
 
@@ -86,6 +88,41 @@ func (api *NetworkConfigAPI) getOneMachineProviderNetworkConfig(m *state.Machine
 	return providerConfig, nil
 }
 
+// fixUpFanSubnets takes network config and updates FAN subnets with proper CIDR, providerId and providerSubnetId.
+// The method how fan overlay is cut into segments is described in network/fan.go.
+func (api *NetworkConfigAPI) fixUpFanSubnets(networkConfig []params.NetworkConfig) ([]params.NetworkConfig, error) {
+	subnets, err := api.st.AllSubnets()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	var fanSubnets []*state.Subnet
+	var fanCIDRs []*net.IPNet
+	for _, subnet := range subnets {
+		if subnet.FanOverlay() != "" {
+			fanSubnets = append(fanSubnets, subnet)
+			_, net, err := net.ParseCIDR(subnet.CIDR())
+			if err != nil {
+				return nil, errors.Trace(err)
+			}
+			fanCIDRs = append(fanCIDRs, net)
+		}
+	}
+	for i := range networkConfig {
+		localIp := net.ParseIP(networkConfig[i].Address)
+		for j, fanSubnet := range fanSubnets {
+			if fanCIDRs[j].Contains(localIp) {
+				networkConfig[i].CIDR = fanSubnet.CIDR()
+				networkConfig[i].ProviderId = string(fanSubnet.ProviderId())
+				networkConfig[i].ProviderSubnetId = string(fanSubnet.ProviderNetworkId())
+				break
+			}
+		}
+	}
+	logger.Tracef("Final network config after fixing up FAN subnets %+v", networkConfig)
+	return networkConfig, nil
+}
+
 func (api *NetworkConfigAPI) setOneMachineNetworkConfig(m *state.Machine, networkConfig []params.NetworkConfig) error {
 	devicesArgs, devicesAddrs := NetworkConfigsToStateArgs(networkConfig)
 
@@ -154,13 +191,18 @@ func (api *NetworkConfigAPI) SetObservedNetworkConfig(args params.SetMachineNetw
 	if err != nil {
 		return errors.Trace(err)
 	}
-	finalConfig := observedConfig
+	mergedConfig := observedConfig
 	if len(providerConfig) != 0 {
-		finalConfig = MergeProviderAndObservedNetworkConfigs(providerConfig, observedConfig)
-		logger.Tracef("merged observed and provider network config for machine %q: %+v", m.Id(), finalConfig)
+		mergedConfig = MergeProviderAndObservedNetworkConfigs(providerConfig, observedConfig)
+		logger.Tracef("merged observed and provider network config for machine %q: %+v", m.Id(), mergedConfig)
 	}
 
-	return api.setOneMachineNetworkConfig(m, finalConfig)
+	mergedConfig, err = api.fixUpFanSubnets(mergedConfig)
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	return api.setOneMachineNetworkConfig(m, mergedConfig)
 }
 
 func (api *NetworkConfigAPI) SetProviderNetworkConfig(args params.Entities) (params.ErrorResults, error) {

--- a/apiserver/common/networkingcommon/types.go
+++ b/apiserver/common/networkingcommon/types.go
@@ -465,3 +465,28 @@ func MachineNetworkInfoResultToNetworkInfoResult(inResult state.MachineNetworkIn
 		Info: infos,
 	}
 }
+
+func FanConfigToFanConfigResult(config network.FanConfig) params.FanConfigResult {
+	result := params.FanConfigResult{make([]params.FanConfigEntry, len(config))}
+	for i, entry := range config {
+		result.Fans[i] = params.FanConfigEntry{entry.Underlay.String(), entry.Overlay.String()}
+	}
+	return result
+}
+
+func FanConfigResultToFanConfig(config params.FanConfigResult) (network.FanConfig, error) {
+	rv := make(network.FanConfig, len(config.Fans))
+	for i, entry := range config.Fans {
+		_, ipnet, err := net.ParseCIDR(entry.Underlay)
+		if err != nil {
+			return nil, err
+		}
+		rv[i].Underlay = ipnet
+		_, ipnet, err = net.ParseCIDR(entry.Overlay)
+		if err != nil {
+			return nil, err
+		}
+		rv[i].Overlay = ipnet
+	}
+	return rv, nil
+}

--- a/apiserver/facades/agent/fanconfigurer/fanconfigurer.go
+++ b/apiserver/facades/agent/fanconfigurer/fanconfigurer.go
@@ -1,0 +1,79 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+package fanconfigurer
+
+import (
+	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/common/networkingcommon"
+	"github.com/juju/juju/apiserver/facade"
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/state"
+	"github.com/juju/juju/state/watcher"
+)
+
+// FanConfigurer defines the methods on fanconfigurer API endpoint.
+type FanConfigurer interface {
+	WatchForFanConfigChanges() (params.NotifyWatchResult, error)
+	FanConfig() (params.FanConfigResult, error)
+}
+
+type FanConfigurerAPI struct {
+	model     state.ModelAccessor
+	resources facade.Resources
+}
+
+var _ FanConfigurer = (*FanConfigurerAPI)(nil)
+
+// NewFanConfigurerAPI creates a new FanConfigurer API endpoint on server-side.
+func NewFanConfigurerAPI(st *state.State, resources facade.Resources, authorizer facade.Authorizer) (*FanConfigurerAPI, error) {
+	model, err := st.Model()
+	if err != nil {
+		return nil, err
+	}
+	return NewFanConfigurerAPIForModel(model, resources, authorizer)
+}
+
+func NewFanConfigurerAPIForModel(model state.ModelAccessor, resources facade.Resources, authorizer facade.Authorizer) (*FanConfigurerAPI, error) {
+	// Only machine agents have access to the fanconfigurer service.
+	if !authorizer.AuthMachineAgent() {
+		return nil, common.ErrPerm
+	}
+
+	return &FanConfigurerAPI{
+		model:     model,
+		resources: resources,
+	}, nil
+}
+
+// WatchForFanConfigChanges returns a NotifyWatcher that observes
+// changes to the FAN configuration.
+// so we use the regular error return.
+// TODO(wpk) 2017-09-21 We should use Model directly, and watch only for FanConfig changes.
+func (m *FanConfigurerAPI) WatchForFanConfigChanges() (params.NotifyWatchResult, error) {
+	result := params.NotifyWatchResult{}
+	watch := m.model.WatchForModelConfigChanges()
+	// Consume the initial event. Technically, API
+	// calls to Watch 'transmit' the initial event
+	// in the Watch response. But NotifyWatchers
+	// have no state to transmit.
+	if _, ok := <-watch.Changes(); ok {
+		result.NotifyWatcherId = m.resources.Register(watch)
+	} else {
+		return result, watcher.EnsureErr(watch)
+	}
+	return result, nil
+}
+
+// FanConfig returns current FAN configuration.
+func (m *FanConfigurerAPI) FanConfig() (params.FanConfigResult, error) {
+	result := params.FanConfigResult{}
+	config, err := m.model.ModelConfig()
+	if err != nil {
+		return result, err
+	}
+	fanConfig, err := config.FanConfig()
+	if err != nil {
+		return result, err
+	}
+	return networkingcommon.FanConfigToFanConfigResult(fanConfig), nil
+}

--- a/apiserver/facades/agent/fanconfigurer/fanconfigurer_test.go
+++ b/apiserver/facades/agent/fanconfigurer/fanconfigurer_test.go
@@ -1,0 +1,144 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package fanconfigurer_test
+
+import (
+	"github.com/juju/cmd/cmdtesting"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/names.v2"
+
+	"fmt"
+	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/facades/agent/fanconfigurer"
+	"github.com/juju/juju/apiserver/params"
+	apiservertesting "github.com/juju/juju/apiserver/testing"
+	"github.com/juju/juju/cmd/modelcmd"
+	"github.com/juju/juju/environs/bootstrap"
+	"github.com/juju/juju/environs/config"
+	"github.com/juju/juju/jujuclient"
+	"github.com/juju/juju/provider/dummy"
+	"github.com/juju/juju/state"
+	"github.com/juju/juju/testing"
+)
+
+type fanconfigurerSuite struct {
+	testing.BaseSuite
+	testingEnvConfig *config.Config
+}
+
+var _ = gc.Suite(&fanconfigurerSuite{})
+
+type fakeModelAccessor struct {
+	modelConfig      *config.Config
+	modelConfigError error
+}
+
+func (*fakeModelAccessor) WatchForModelConfigChanges() state.NotifyWatcher {
+	return apiservertesting.NewFakeNotifyWatcher()
+}
+
+func (f *fakeModelAccessor) ModelConfig() (*config.Config, error) {
+	if f.modelConfigError != nil {
+		return nil, f.modelConfigError
+	}
+	return f.modelConfig, nil
+}
+
+func (s *fanconfigurerSuite) TearDownTest(c *gc.C) {
+	dummy.Reset(c)
+	s.BaseSuite.TearDownTest(c)
+}
+
+func (s *fanconfigurerSuite) TestWatchSuccess(c *gc.C) {
+	resources := common.NewResources()
+	authorizer := apiservertesting.FakeAuthorizer{
+		Tag: names.NewMachineTag("0"),
+	}
+	s.AddCleanup(func(_ *gc.C) { resources.StopAll() })
+	e, err := fanconfigurer.NewFanConfigurerAPIForModel(
+		&fakeModelAccessor{},
+		resources,
+		authorizer,
+	)
+	c.Assert(err, jc.ErrorIsNil)
+	result, err := e.WatchForFanConfigChanges()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result, gc.DeepEquals, params.NotifyWatchResult{"1", nil})
+	c.Assert(resources.Count(), gc.Equals, 1)
+}
+
+func (s *fanconfigurerSuite) TestWatchAuthFailed(c *gc.C) {
+	resources := common.NewResources()
+	authorizer := apiservertesting.FakeAuthorizer{
+		Tag: names.NewUserTag("vito"),
+	}
+	s.AddCleanup(func(_ *gc.C) { resources.StopAll() })
+	_, err := fanconfigurer.NewFanConfigurerAPIForModel(
+		&fakeModelAccessor{},
+		resources,
+		authorizer,
+	)
+	c.Assert(err, gc.ErrorMatches, "permission denied")
+}
+
+func (s *fanconfigurerSuite) TestFanConfigSuccess(c *gc.C) {
+	resources := common.NewResources()
+	authorizer := apiservertesting.FakeAuthorizer{
+		Tag:        names.NewMachineTag("0"),
+		Controller: true,
+	}
+	s.AddCleanup(func(_ *gc.C) { resources.StopAll() })
+	testingEnvConfig := testingEnvConfig(c)
+	e, err := fanconfigurer.NewFanConfigurerAPIForModel(
+		&fakeModelAccessor{
+			modelConfig: testingEnvConfig,
+		},
+		resources,
+		authorizer,
+	)
+	c.Assert(err, jc.ErrorIsNil)
+	result, err := e.FanConfig()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result.Fans, gc.HasLen, 2)
+	c.Check(result.Fans[0].Underlay, gc.Equals, "10.100.0.0/16")
+	c.Check(result.Fans[0].Overlay, gc.Equals, "251.0.0.0/8")
+	c.Check(result.Fans[1].Underlay, gc.Equals, "192.168.0.0/16")
+	c.Check(result.Fans[1].Overlay, gc.Equals, "252.0.0.0/8")
+}
+
+func (s *fanconfigurerSuite) TestFanConfigFetchError(c *gc.C) {
+	resources := common.NewResources()
+	authorizer := apiservertesting.FakeAuthorizer{
+		Tag:        names.NewMachineTag("0"),
+		Controller: true,
+	}
+	s.AddCleanup(func(_ *gc.C) { resources.StopAll() })
+	e, err := fanconfigurer.NewFanConfigurerAPIForModel(
+		&fakeModelAccessor{
+			modelConfigError: fmt.Errorf("pow"),
+		},
+		nil,
+		authorizer,
+	)
+	c.Assert(err, jc.ErrorIsNil)
+	_, err = e.FanConfig()
+	c.Assert(err, gc.ErrorMatches, "pow")
+}
+
+func testingEnvConfig(c *gc.C) *config.Config {
+	env, err := bootstrap.Prepare(
+		modelcmd.BootstrapContext(cmdtesting.Context(c)),
+		jujuclient.NewMemStore(),
+		bootstrap.PrepareParams{
+			ControllerConfig: testing.FakeControllerConfig(),
+			ControllerName:   "dummycontroller",
+			ModelConfig:      dummy.SampleConfig().Merge(testing.Attrs{"fan-config": "10.100.0.0/16=251.0.0.0/8 192.168.0.0/16=252.0.0.0/8"}),
+			Cloud:            dummy.SampleCloudSpec(),
+			AdminSecret:      "admin-secret",
+		},
+	)
+	c.Assert(err, jc.ErrorIsNil)
+	return env.Config()
+}

--- a/apiserver/facades/agent/fanconfigurer/package_test.go
+++ b/apiserver/facades/agent/fanconfigurer/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package fanconfigurer_test
+
+import (
+	stdtesting "testing"
+
+	"github.com/juju/juju/testing"
+)
+
+func TestAll(t *stdtesting.T) {
+	testing.MgoTestPackage(t)
+}

--- a/apiserver/facades/agent/provisioner/provisioner.go
+++ b/apiserver/facades/agent/provisioner/provisioner.go
@@ -814,8 +814,8 @@ func (ctx *prepareOrGetContext) ProcessOneContainer(env environs.Environ, idx in
 
 	supportContainerAddresses := environs.SupportsContainerAddresses(env)
 	bridgePolicy := containerizer.BridgePolicy{
-		NetBondReconfigureDelay: env.Config().NetBondReconfigureDelay(),
-		UseLocalBridges:         !supportContainerAddresses,
+		NetBondReconfigureDelay:   env.Config().NetBondReconfigureDelay(),
+		ContainerNetworkingMethod: env.Config().ContainerNetworkingMethod(),
 	}
 
 	// TODO(jam): 2017-01-31 PopulateContainerLinkLayerDevices should really
@@ -965,8 +965,8 @@ type hostChangesContext struct {
 
 func (ctx *hostChangesContext) ProcessOneContainer(env environs.Environ, idx int, host, container *state.Machine) error {
 	bridgePolicy := containerizer.BridgePolicy{
-		NetBondReconfigureDelay: env.Config().NetBondReconfigureDelay(),
-		UseLocalBridges:         !environs.SupportsContainerAddresses(env),
+		NetBondReconfigureDelay:   env.Config().NetBondReconfigureDelay(),
+		ContainerNetworkingMethod: env.Config().ContainerNetworkingMethod(),
 	}
 	bridges, reconfigureDelay, err := bridgePolicy.FindMissingBridgesForContainer(host, container)
 	if err != nil {

--- a/apiserver/facades/client/application/application.go
+++ b/apiserver/facades/client/application/application.go
@@ -1227,6 +1227,7 @@ func (api *API) consumeOne(arg params.ConsumeApplicationArg) error {
 		if controllerTag.Id() != api.backend.ControllerTag().Id() {
 			if _, err = api.backend.SaveController(crossmodel.ControllerInfo{
 				ControllerTag: controllerTag,
+				Alias:         arg.ControllerInfo.Alias,
 				Addrs:         arg.ControllerInfo.Addrs,
 				CACert:        arg.ControllerInfo.CACert,
 			}, sourceModelTag.Id()); err != nil {

--- a/apiserver/facades/client/application/application.go
+++ b/apiserver/facades/client/application/application.go
@@ -479,7 +479,15 @@ func (api *API) getConfig(entity string) (map[string]interface{}, error) {
 		if err != nil {
 			return nil, err
 		}
-		return app.ConfigSettings()
+		settings, err := app.ConfigSettings()
+		if err != nil {
+			return nil, err
+		}
+		charm, _, err := app.Charm()
+		if err != nil {
+			return nil, err
+		}
+		return describe(settings, charm.Config()), nil
 	default:
 		return nil, errors.Errorf("unexpected tag type, expected application, got %s", kind)
 	}

--- a/apiserver/facades/client/application/application_test.go
+++ b/apiserver/facades/client/application/application_test.go
@@ -103,19 +103,24 @@ func (s *applicationSuite) makeAPI(c *gc.C) *application.API {
 
 func (s *applicationSuite) TestGetConfig(c *gc.C) {
 	fooConfig := map[string]interface{}{
-		"name":   "foo",
-		"answer": 42,
+		"title":       "foo",
+		"skill-level": 42,
 	}
+	dummy := s.Factory.MakeCharm(c, &factory.CharmParams{
+		Name: "dummy",
+	})
 	s.Factory.MakeApplication(c, &factory.ApplicationParams{
 		Name:     "foo",
+		Charm:    dummy,
 		Settings: fooConfig,
 	})
 	barConfig := map[string]interface{}{
-		"name": "bar",
-		"key":  "value",
+		"title":   "bar",
+		"outlook": "fantastic",
 	}
 	s.Factory.MakeApplication(c, &factory.ApplicationParams{
 		Name:     "bar",
+		Charm:    dummy,
 		Settings: barConfig,
 	})
 	results, err := s.applicationAPI.GetConfig(params.Entities{
@@ -134,9 +139,61 @@ func (s *applicationSuite) TestGetConfig(c *gc.C) {
 			}, {
 				Error: &params.Error{Message: `unexpected tag type, expected application, got user`},
 			}, {
-				Config: fooConfig,
+				Config: map[string]interface{}{
+					"outlook": map[string]interface{}{
+						"description": "No default outlook.",
+						"source":      "unset",
+						"type":        "string",
+					},
+					"skill-level": map[string]interface{}{
+						"description": "A number indicating skill.",
+						"source":      "user",
+						"type":        "int",
+						"value":       42,
+					},
+					"title": map[string]interface{}{
+						"default":     "My Title",
+						"description": "A descriptive title used for the application.",
+						"source":      "user",
+						"type":        "string",
+						"value":       "foo",
+					},
+					"username": map[string]interface{}{
+						"default":     "admin001",
+						"description": "The name of the initial account (given admin permissions).",
+						"source":      "default",
+						"type":        "string",
+						"value":       "admin001",
+					},
+				},
 			}, {
-				Config: barConfig,
+				Config: map[string]interface{}{
+					"outlook": map[string]interface{}{
+						"description": "No default outlook.",
+						"source":      "user",
+						"type":        "string",
+						"value":       "fantastic",
+					},
+					"skill-level": map[string]interface{}{
+						"description": "A number indicating skill.",
+						"source":      "unset",
+						"type":        "int",
+					},
+					"title": map[string]interface{}{
+						"default":     "My Title",
+						"description": "A descriptive title used for the application.",
+						"source":      "user",
+						"type":        "string",
+						"value":       "bar",
+					},
+					"username": map[string]interface{}{
+						"default":     "admin001",
+						"description": "The name of the initial account (given admin permissions).",
+						"source":      "default",
+						"type":        "string",
+						"value":       "admin001",
+					},
+				},
 			}, {
 				Error: &params.Error{Message: `application "wat" not found`, Code: "not found"},
 			},

--- a/apiserver/facades/client/application/application_unit_test.go
+++ b/apiserver/facades/client/application/application_unit_test.go
@@ -624,6 +624,7 @@ func (s *ApplicationSuite) TestConsumeFromExternalController(c *gc.C) {
 			Macaroon: mac,
 			ControllerInfo: &params.ExternalControllerInfo{
 				ControllerTag: names.NewControllerTag(controllerUUID).String(),
+				Alias:         "controller-alias",
 				CACert:        coretesting.CACert,
 				Addrs:         []string{"192.168.1.1:1234"},
 			},
@@ -644,6 +645,7 @@ func (s *ApplicationSuite) TestConsumeFromExternalController(c *gc.C) {
 	})
 	c.Assert(s.backend.controllers[coretesting.ModelTag.Id()], jc.DeepEquals, crossmodel.ControllerInfo{
 		ControllerTag: names.NewControllerTag(controllerUUID),
+		Alias:         "controller-alias",
 		CACert:        coretesting.CACert,
 		Addrs:         []string{"192.168.1.1:1234"},
 	})
@@ -665,6 +667,7 @@ func (s *ApplicationSuite) TestConsumeFromSameController(c *gc.C) {
 			Macaroon: mac,
 			ControllerInfo: &params.ExternalControllerInfo{
 				ControllerTag: coretesting.ControllerTag.String(),
+				Alias:         "controller-alias",
 				CACert:        coretesting.CACert,
 				Addrs:         []string{"192.168.1.1:1234"},
 			},

--- a/apiserver/facades/client/application/get.go
+++ b/apiserver/facades/client/application/get.go
@@ -12,6 +12,21 @@ import (
 
 // Get returns the configuration for a service.
 func (api *API) Get(args params.ApplicationGet) (params.ApplicationGetResults, error) {
+	return api.getApplicationSettings(args, describe)
+}
+
+// Get returns the configuration for a service.
+// This used the confusing "default" boolean to mean the value was set from
+// the charm defaults. Needs to be kept for backwards compatibility.
+func (api *APIv4) Get(args params.ApplicationGet) (params.ApplicationGetResults, error) {
+	return api.getApplicationSettings(args, describeV4)
+}
+
+// Get returns the configuration for a service.
+func (api *API) getApplicationSettings(
+	args params.ApplicationGet,
+	describe func(settings charm.Settings, config *charm.Config) map[string]interface{},
+) (params.ApplicationGetResults, error) {
 	if err := api.checkCanRead(); err != nil {
 		return params.ApplicationGetResults{}, err
 	}
@@ -50,6 +65,32 @@ func describe(settings charm.Settings, config *charm.Config) map[string]interfac
 		info := map[string]interface{}{
 			"description": option.Description,
 			"type":        option.Type,
+			"source":      "unset",
+		}
+		set := false
+		if value := settings[name]; value != nil {
+			set = true
+			info["value"] = value
+			info["source"] = "user"
+		}
+		if option.Default != nil {
+			info["default"] = option.Default
+			if !set {
+				info["value"] = option.Default
+				info["source"] = "default"
+			}
+		}
+		results[name] = info
+	}
+	return results
+}
+
+func describeV4(settings charm.Settings, config *charm.Config) map[string]interface{} {
+	results := make(map[string]interface{})
+	for name, option := range config.Options {
+		info := map[string]interface{}{
+			"description": option.Description,
+			"type":        option.Type,
 		}
 		if value := settings[name]; value != nil {
 			info["value"] = value
@@ -57,13 +98,7 @@ func describe(settings charm.Settings, config *charm.Config) map[string]interfac
 			if option.Default != nil {
 				info["value"] = option.Default
 			}
-		}
-		// There is a chance that a user will set a value
-		// that may still be equal to charm's default value for this setting.
-		// This needs to work for nil values too, i.e. charm did not set
-		// settings default and this setting is still not set/is nil on the deployed application.
-		if info["value"] == option.Default {
-			info["is_default"] = true
+			info["default"] = true
 		}
 		results[name] = info
 	}

--- a/apiserver/facades/client/application/get_test.go
+++ b/apiserver/facades/client/application/get_test.go
@@ -47,6 +47,26 @@ func (s *getSuite) SetUpTest(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 }
 
+func (s *getSuite) TestClientServiceGetSmoketestV4(c *gc.C) {
+	s.AddTestingApplication(c, "wordpress", s.AddTestingCharm(c, "wordpress"))
+	v4 := &application.APIv4{s.serviceAPI}
+	results, err := v4.Get(params.ApplicationGet{"wordpress"})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(results, gc.DeepEquals, params.ApplicationGetResults{
+		Application: "wordpress",
+		Charm:       "wordpress",
+		Config: map[string]interface{}{
+			"blog-title": map[string]interface{}{
+				"default":     true,
+				"description": "A descriptive title used for the blog.",
+				"type":        "string",
+				"value":       "My Title",
+			},
+		},
+		Series: "quantal",
+	})
+}
+
 func (s *getSuite) TestClientServiceGetSmoketest(c *gc.C) {
 	s.AddTestingApplication(c, "wordpress", s.AddTestingCharm(c, "wordpress"))
 	results, err := s.serviceAPI.Get(params.ApplicationGet{"wordpress"})
@@ -56,10 +76,11 @@ func (s *getSuite) TestClientServiceGetSmoketest(c *gc.C) {
 		Charm:       "wordpress",
 		Config: map[string]interface{}{
 			"blog-title": map[string]interface{}{
+				"default":     "My Title",
+				"description": "A descriptive title used for the blog.",
+				"source":      "default",
 				"type":        "string",
 				"value":       "My Title",
-				"description": "A descriptive title used for the blog.",
-				"is_default":  true,
 			},
 		},
 		Series: "quantal",
@@ -93,25 +114,28 @@ var getTests = []struct {
 	expect: params.ApplicationGetResults{
 		Config: map[string]interface{}{
 			"title": map[string]interface{}{
+				"default":     "My Title",
 				"description": "A descriptive title used for the application.",
+				"source":      "user",
 				"type":        "string",
 				"value":       "Look To Windward",
 			},
 			"outlook": map[string]interface{}{
 				"description": "No default outlook.",
+				"source":      "unset",
 				"type":        "string",
-				"is_default":  true,
 			},
 			"username": map[string]interface{}{
+				"default":     "admin001",
 				"description": "The name of the initial account (given admin permissions).",
+				"source":      "user",
 				"type":        "string",
 				"value":       "admin001",
-				"is_default":  true,
 			},
 			"skill-level": map[string]interface{}{
 				"description": "A number indicating skill.",
+				"source":      "unset",
 				"type":        "int",
-				"is_default":  true,
 			},
 		},
 		Series: "quantal",
@@ -132,23 +156,28 @@ var getTests = []struct {
 	expect: params.ApplicationGetResults{
 		Config: map[string]interface{}{
 			"title": map[string]interface{}{
+				"default":     "My Title",
 				"description": "A descriptive title used for the application.",
+				"source":      "default",
 				"type":        "string",
 				"value":       "My Title",
-				"is_default":  true,
 			},
 			"outlook": map[string]interface{}{
 				"description": "No default outlook.",
 				"type":        "string",
+				"source":      "user",
 				"value":       "phlegmatic",
 			},
 			"username": map[string]interface{}{
+				"default":     "admin001",
 				"description": "The name of the initial account (given admin permissions).",
+				"source":      "user",
 				"type":        "string",
 				"value":       "foobie",
 			},
 			"skill-level": map[string]interface{}{
 				"description": "A number indicating skill.",
+				"source":      "user",
 				"type":        "int",
 				// TODO(jam): 2013-08-28 bug #1217742
 				// we have to use float64() here, because the
@@ -192,7 +221,7 @@ func (s *getSuite) TestServiceGet(c *gc.C) {
 		client := apiapplication.NewClient(s.APIState)
 		got, err := client.Get(app.Name())
 		c.Assert(err, jc.ErrorIsNil)
-		c.Assert(*got, gc.DeepEquals, expect)
+		c.Assert(*got, jc.DeepEquals, expect)
 	}
 }
 
@@ -217,6 +246,7 @@ func (s *getSuite) TestGetMaxResolutionInt(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(got.Config["skill-level"], jc.DeepEquals, map[string]interface{}{
 		"description": "A number indicating skill.",
+		"source":      "user",
 		"type":        "int",
 		"value":       asFloat,
 	})

--- a/apiserver/facades/client/modelmanager/modelinfo_test.go
+++ b/apiserver/facades/client/modelmanager/modelinfo_test.go
@@ -1009,6 +1009,11 @@ func (m *mockModel) LastModelConnection(user names.UserTag) (time.Time, error) {
 	return time.Time{}, m.NextErr()
 }
 
+func (m *mockModel) AutoConfigureContainerNetworking(environ environs.Environ) error {
+	m.MethodCall(m, "AutoConfigureContainerNetworking", environ)
+	return m.NextErr()
+}
+
 type mockModelUser struct {
 	gitjujutesting.Stub
 	userName       string

--- a/apiserver/facades/client/modelmanager/modelmanager.go
+++ b/apiserver/facades/client/modelmanager/modelmanager.go
@@ -501,6 +501,13 @@ func (m *ModelManagerAPI) newIAASModel(
 	}
 	defer st.Close()
 
+	if err = model.AutoConfigureContainerNetworking(env); err != nil {
+		if errors.IsNotSupported(err) {
+			logger.Debugf("Not performing container networking autoconfiguration on a non-networking environment")
+		} else {
+			return nil, errors.Annotate(err, "Failed to perform container networking autoconfiguration")
+		}
+	}
 	if err = st.ReloadSpaces(env); err != nil {
 		if errors.IsNotSupported(err) {
 			logger.Debugf("Not performing spaces load on a non-networking environment")

--- a/apiserver/facades/controller/remoterelations/remoterelations.go
+++ b/apiserver/facades/controller/remoterelations/remoterelations.go
@@ -255,22 +255,17 @@ func (api *RemoteRelationsAPI) RemoteApplications(entities params.Entities) (par
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
-		status, err := remoteApp.Status()
-		if err != nil {
-			return nil, errors.Trace(err)
-		}
 		mac, err := remoteApp.Macaroon()
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
 		return &params.RemoteApplication{
-			Name:       remoteApp.Name(),
-			OfferUUID:  remoteApp.OfferUUID(),
-			Life:       params.Life(remoteApp.Life().String()),
-			Status:     status.Status.String(),
-			ModelUUID:  remoteApp.SourceModel().Id(),
-			Registered: remoteApp.IsConsumerProxy(),
-			Macaroon:   mac,
+			Name:            remoteApp.Name(),
+			OfferUUID:       remoteApp.OfferUUID(),
+			Life:            params.Life(remoteApp.Life().String()),
+			ModelUUID:       remoteApp.SourceModel().Id(),
+			IsConsumerProxy: remoteApp.IsConsumerProxy(),
+			Macaroon:        mac,
 		}, nil
 	}
 	for i, entity := range entities.Entities {

--- a/apiserver/params/crossmodel.go
+++ b/apiserver/params/crossmodel.go
@@ -210,17 +210,17 @@ type RemoteApplication struct {
 	OfferUUID string `json:"offer-uuid"`
 
 	// Life is the current lifecycle state of the application.
-	Life Life `json:"life"`
+	Life Life `json:"life,omitempty"`
 
 	// Status is the current status of the application.
-	Status string `json:"status"`
+	Status string `json:"status,omitempty"`
 
 	// ModelUUID is the UUId of the model hosting the application.
 	ModelUUID string `json:"model-uuid"`
 
-	// IsConsumerProxy returns the application is created
+	// IsConsumerProxy returns if the application is created
 	// from a registration operation by a consuming model.
-	Registered bool `json:"registered"`
+	IsConsumerProxy bool `json:"is-consumer-proxy"`
 
 	// Macaroon is used for authentication.
 	Macaroon *macaroon.Macaroon `json:"macaroon,omitempty"`

--- a/apiserver/params/crossmodel.go
+++ b/apiserver/params/crossmodel.go
@@ -35,7 +35,8 @@ type OfferFilter struct {
 	ApplicationDescription string                     `json:"application-description"`
 	ApplicationUser        string                     `json:"application-user"`
 	Endpoints              []EndpointFilterAttributes `json:"endpoints"`
-	AllowedUserTags        []string                   `json:"allowed-users"`
+	ConnectedUserTags      []string                   `json:"connected-users"`
+	AllowedConsumerTags    []string                   `json:"allowed-users"`
 }
 
 // ApplicationOfferDetails represents an application offering from an external model.

--- a/apiserver/params/crossmodel.go
+++ b/apiserver/params/crossmodel.go
@@ -564,6 +564,7 @@ const (
 // needed to make a connection to an external controller.
 type ExternalControllerInfo struct {
 	ControllerTag string   `json:"controller-tag"`
+	Alias         string   `json:"controller-alias"`
 	Addrs         []string `json:"addrs"`
 	CACert        string   `json:"ca-cert"`
 }

--- a/apiserver/params/network.go
+++ b/apiserver/params/network.go
@@ -705,3 +705,14 @@ type NetworkInfoParams struct {
 	RelationId *int     `json:"relation-id,omitempty"`
 	Bindings   []string `json:"bindings"`
 }
+
+// FanConfigEntry holds configuration for a single fan.
+type FanConfigEntry struct {
+	Underlay string `json:"underlay"`
+	Overlay  string `json:"overlay"`
+}
+
+// FanConfigResult holds configuration for all fans in a model
+type FanConfigResult struct {
+	Fans []FanConfigEntry `json:"fans"`
+}

--- a/cloud/fallback-public-cloud.yaml
+++ b/cloud/fallback-public-cloud.yaml
@@ -54,11 +54,17 @@ clouds:
     regions:
       us-east1:
         endpoint: https://www.googleapis.com
+      us-east4:
+        endpoint: https://www.googleapis.com
       us-central1:
         endpoint: https://www.googleapis.com
       us-west1:
         endpoint: https://www.googleapis.com
       europe-west1:
+        endpoint: https://www.googleapis.com
+      europe-west2:
+        endpoint: https://www.googleapis.com
+      europe-west3:
         endpoint: https://www.googleapis.com
       asia-east1:
         endpoint: https://www.googleapis.com
@@ -67,6 +73,8 @@ clouds:
       asia-southeast1:
         endpoint: https://www.googleapis.com
       australia-southeast1:
+        endpoint: https://www.googleapis.com
+      southamerica-east1:
         endpoint: https://www.googleapis.com
   azure:
     type: azure

--- a/cloud/fallback_public_cloud.go
+++ b/cloud/fallback_public_cloud.go
@@ -61,11 +61,17 @@ clouds:
     regions:
       us-east1:
         endpoint: https://www.googleapis.com
+      us-east4:
+        endpoint: https://www.googleapis.com
       us-central1:
         endpoint: https://www.googleapis.com
       us-west1:
         endpoint: https://www.googleapis.com
       europe-west1:
+        endpoint: https://www.googleapis.com
+      europe-west2:
+        endpoint: https://www.googleapis.com
+      europe-west3:
         endpoint: https://www.googleapis.com
       asia-east1:
         endpoint: https://www.googleapis.com
@@ -74,6 +80,8 @@ clouds:
       asia-southeast1:
         endpoint: https://www.googleapis.com
       australia-southeast1:
+        endpoint: https://www.googleapis.com
+      southamerica-east1:
         endpoint: https://www.googleapis.com
   azure:
     type: azure

--- a/cloudconfig/cloudinit/cloudinit_ubuntu.go
+++ b/cloudconfig/cloudinit/cloudinit_ubuntu.go
@@ -271,6 +271,8 @@ func (cfg *ubuntuCloudConfig) addRequiredPackages() {
 		"bridge-utils",
 		"cloud-utils",
 		"tmux",
+		// TODO(wpk) 2017-07-23 maybe we should do it in fanconfigurer?
+		"ubuntu-fan",
 	}
 
 	// The required packages need to come from the correct repo.

--- a/cloudconfig/containerinit/export_test.go
+++ b/cloudconfig/containerinit/export_test.go
@@ -8,4 +8,5 @@ var (
 	NetworkInterfacesFile          = &networkInterfacesFile
 	SystemNetworkInterfacesFile    = &systemNetworkInterfacesFile
 	NewCloudInitConfigWithNetworks = newCloudInitConfigWithNetworks
+	JujuNetplanFile                = &jujuNetplanFile
 )

--- a/cmd/juju/application/addrelation.go
+++ b/cmd/juju/application/addrelation.go
@@ -127,14 +127,6 @@ func (c *addRelationCommand) getOffersAPI(url *crossmodel.OfferURL) (application
 		return c.consumeDetailsAPI, nil
 	}
 
-	if url.Source == "" {
-		var err error
-		controllerName, err := c.ControllerName()
-		if err != nil {
-			return nil, errors.Trace(err)
-		}
-		url.Source = controllerName
-	}
 	root, err := c.CommandBase.NewAPIRoot(c.ClientStore(), url.Source, "")
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -153,6 +145,14 @@ func (c *addRelationCommand) Run(ctx *cmd.Context) error {
 		if client.BestAPIVersion() < 5 {
 			// old client does not have cross-model capability.
 			return errors.NotSupportedf("cannot add relation to %s: remote endpoints", c.remoteEndpoint.String())
+		}
+		if c.remoteEndpoint.Source == "" {
+			var err error
+			controllerName, err := c.ControllerName()
+			if err != nil {
+				return errors.Trace(err)
+			}
+			c.remoteEndpoint.Source = controllerName
 		}
 		if err := c.maybeConsumeOffer(client); err != nil {
 			return errors.Trace(err)
@@ -208,6 +208,7 @@ func (c *addRelationCommand) maybeConsumeOffer(targetClient applicationAddRelati
 		}
 		arg.ControllerInfo = &crossmodel.ControllerInfo{
 			ControllerTag: controllerTag,
+			Alias:         offerURL.Source,
 			Addrs:         consumeDetails.ControllerInfo.Addrs,
 			CACert:        consumeDetails.ControllerInfo.CACert,
 		}

--- a/cmd/juju/application/addremoterelation_test.go
+++ b/cmd/juju/application/addremoterelation_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/core/crossmodel"
 	jujutesting "github.com/juju/juju/juju/testing"
+	"github.com/juju/juju/testing"
 )
 
 const endpointSeparator = ":"
@@ -50,10 +51,16 @@ func (s *AddRemoteRelationSuiteNewAPI) TestAddRelationToOneRemoteApplication(c *
 		crossmodel.ConsumeApplicationArgs{
 			Offer: params.ApplicationOfferDetails{
 				OfferName: "hosted-mysql",
-				OfferURL:  "bob/prod.hosted-mysql",
+				OfferURL:  "kontroll:bob/prod.hosted-mysql",
 			},
 			ApplicationAlias: "applicationname2",
 			Macaroon:         s.mac,
+			ControllerInfo: &crossmodel.ControllerInfo{
+				ControllerTag: testing.ControllerTag,
+				Addrs:         []string{"192.168.1.0"},
+				Alias:         "kontroll",
+				CACert:        testing.CACert,
+			},
 		})
 	s.mockAPI.CheckCall(c, 4, "AddRelation", []string{"applicationname", "applicationname2"}, []string(nil))
 }
@@ -65,10 +72,16 @@ func (s *AddRemoteRelationSuiteNewAPI) TestAddRelationAnyRemoteApplication(c *gc
 		crossmodel.ConsumeApplicationArgs{
 			Offer: params.ApplicationOfferDetails{
 				OfferName: "hosted-mysql",
-				OfferURL:  "bob/prod.hosted-mysql",
+				OfferURL:  "kontroll:bob/prod.hosted-mysql",
 			},
 			ApplicationAlias: "applicationname2",
 			Macaroon:         s.mac,
+			ControllerInfo: &crossmodel.ControllerInfo{
+				ControllerTag: testing.ControllerTag,
+				Addrs:         []string{"192.168.1.0"},
+				Alias:         "kontroll",
+				CACert:        testing.CACert,
+			},
 		})
 	s.mockAPI.CheckCall(c, 4, "AddRelation", []string{"applicationname2", "applicationname"}, []string(nil))
 }
@@ -247,5 +260,11 @@ func (m *mockAddRelationAPI) GetConsumeDetails(url string) (params.ConsumeOfferD
 			OfferURL:  "bob/prod.hosted-mysql",
 		},
 		Macaroon: m.mac,
+		ControllerInfo: &params.ExternalControllerInfo{
+			ControllerTag: testing.ControllerTag.String(),
+			Addrs:         []string{"192.168.1.0"},
+			Alias:         "controller-alias",
+			CACert:        testing.CACert,
+		},
 	}, nil
 }

--- a/cmd/juju/application/consume.go
+++ b/cmd/juju/application/consume.go
@@ -162,6 +162,7 @@ func (c *consumeCommand) Run(ctx *cmd.Context) error {
 		}
 		arg.ControllerInfo = &crossmodel.ControllerInfo{
 			ControllerTag: controllerTag,
+			Alias:         consumeDetails.ControllerInfo.Alias,
 			Addrs:         consumeDetails.ControllerInfo.Addrs,
 			CACert:        consumeDetails.ControllerInfo.CACert,
 		}

--- a/cmd/juju/application/consume_test.go
+++ b/cmd/juju/application/consume_test.go
@@ -105,6 +105,7 @@ func (s *ConsumeSuite) assertSuccessModelDotApplication(c *gc.C, alias string) {
 			Macaroon:         mac,
 			ControllerInfo: &crossmodel.ControllerInfo{
 				ControllerTag: coretesting.ControllerTag,
+				Alias:         "controller-alias",
 				Addrs:         []string{"192.168.1:1234"},
 				CACert:        coretesting.CACert,
 			},
@@ -151,6 +152,7 @@ func (a *mockConsumeAPI) GetConsumeDetails(url string) (params.ConsumeOfferDetai
 		Macaroon: mac,
 		ControllerInfo: &params.ExternalControllerInfo{
 			ControllerTag: coretesting.ControllerTag.String(),
+			Alias:         "controller-alias",
 			Addrs:         []string{"192.168.1:1234"},
 			CACert:        coretesting.CACert,
 		},

--- a/cmd/juju/cloud/regions_test.go
+++ b/cmd/juju/cloud/regions_test.go
@@ -103,13 +103,17 @@ func (s *regionsSuite) TestListGCERegions(c *gc.C) {
 	out := cmdtesting.Stdout(ctx)
 	c.Assert(out, jc.DeepEquals, `
 us-east1
+us-east4
 us-central1
 us-west1
 europe-west1
+europe-west2
+europe-west3
 asia-east1
 asia-northeast1
 asia-southeast1
 australia-southeast1
+southamerica-east1
 
 `[1:])
 }
@@ -121,11 +125,17 @@ func (s *regionsSuite) TestListGCERegionsYaml(c *gc.C) {
 	c.Assert(out, jc.DeepEquals, `
 us-east1:
   endpoint: https://www.googleapis.com
+us-east4:
+  endpoint: https://www.googleapis.com
 us-central1:
   endpoint: https://www.googleapis.com
 us-west1:
   endpoint: https://www.googleapis.com
 europe-west1:
+  endpoint: https://www.googleapis.com
+europe-west2:
+  endpoint: https://www.googleapis.com
+europe-west3:
   endpoint: https://www.googleapis.com
 asia-east1:
   endpoint: https://www.googleapis.com
@@ -134,6 +144,8 @@ asia-northeast1:
 asia-southeast1:
   endpoint: https://www.googleapis.com
 australia-southeast1:
+  endpoint: https://www.googleapis.com
+southamerica-east1:
   endpoint: https://www.googleapis.com
 `[1:])
 }

--- a/cmd/juju/commands/bootstrap.go
+++ b/cmd/juju/commands/bootstrap.go
@@ -93,10 +93,16 @@ address.
 
 Private clouds may need to specify their own custom image metadata and
 tools/agent. Use '--metadata-source' whose value is a local directory.
-The value of '--agent-version' will become the default tools version to
-use in all models for this controller. The full binary version is accepted
-(e.g.: 2.0.1-xenial-amd64) but only the numeric version (e.g.: 2.0.1) is
-used. Otherwise, by default, the version used is that of the client.
+
+By default, the Juju version of the agent binary that is downloaded and 
+installed on all models for the new controller will be the same as that 
+of the Juju client used to perform the bootstrap.
+However, a user can specify a different agent version via '--agent-version' 
+option to bootstrap command. Juju will use this version for models' agents 
+as long as the client's version is from the same Juju release series.
+In other words, a 2.2.1 client can bootstrap any 2.2.x agents but cannot
+bootstrap any 2.0.x or 2.1.x agents.
+The agent version can be specified a simple numeric version, e.g. 2.2.4.
 
 Examples:
     juju bootstrap
@@ -106,7 +112,7 @@ Examples:
     juju bootstrap aws/us-east-1
     juju bootstrap google joe-us-east1
     juju bootstrap --config=~/config-rs.yaml rackspace joe-syd
-    juju bootstrap --config agent-version=1.25.3 aws joe-us-east-1
+    juju bootstrap --agent-version=2.2.4 aws joe-us-east-1
     juju bootstrap --config bootstrap-timeout=1200 azure joe-eastus
 
 See also:

--- a/cmd/juju/commands/bootstrap.go
+++ b/cmd/juju/commands/bootstrap.go
@@ -236,7 +236,7 @@ func (c *bootstrapCommand) Init(args []string) (err error) {
 		}
 	}
 	if c.AgentVersion != nil && (c.AgentVersion.Major != jujuversion.Current.Major || c.AgentVersion.Minor != jujuversion.Current.Minor) {
-		return errors.New("requested agent version major.minor mismatch")
+		return errors.Errorf("this client can only bootstrap %v.%v agents", jujuversion.Current.Major, jujuversion.Current.Minor)
 	}
 
 	switch len(args) {

--- a/cmd/juju/commands/bootstrap_test.go
+++ b/cmd/juju/commands/bootstrap_test.go
@@ -10,6 +10,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"regexp"
 	"runtime"
 	"sort"
 	"strings"
@@ -420,12 +421,12 @@ var bootstrapTests = []bootstrapTest{{
 	info:    "agent-version doesn't match client version major",
 	version: "1.3.3-saucy-ppc64el",
 	args:    []string{"--agent-version", "2.3.0"},
-	err:     `requested agent version major.minor mismatch`,
+	err:     regexp.QuoteMeta(`this client can only bootstrap 1.3 agents`),
 }, {
 	info:    "agent-version doesn't match client version minor",
 	version: "1.3.3-saucy-ppc64el",
 	args:    []string{"--agent-version", "1.4.0"},
-	err:     `requested agent version major.minor mismatch`,
+	err:     regexp.QuoteMeta(`this client can only bootstrap 1.3 agents`),
 }, {
 	info: "--clouds with --regions",
 	args: []string{"--clouds", "--regions", "aws"},

--- a/cmd/juju/commands/ssh.go
+++ b/cmd/juju/commands/ssh.go
@@ -28,6 +28,13 @@ The SSH host keys of the target are verified. The --no-host-key-checks option
 can be used to disable these checks. Use of this option is not recommended as
 it opens up the possibility of a man-in-the-middle attack.
 
+The default identity known to Juju and used by this command is ~/.ssh/id_rsa
+
+Options can be passed to the local OpenSSH client (ssh) on platforms 
+where it is available. This is done by inserting them between the target and 
+a possible remote command. Refer to the ssh man page for an explanation 
+of those options.
+
 Examples:
 Connect to machine 0:
 
@@ -44,6 +51,10 @@ Connect to a mysql unit:
 Connect to a jenkins unit as user jenkins:
 
     juju ssh jenkins@jenkins/0
+
+Connect to a mysql unit with an identity not known to juju (ssh option -i):
+
+    juju ssh mysql/0 -i ~/.ssh/my_private_key echo hello
 
 See also: 
     scp`
@@ -62,7 +73,7 @@ type sshCommand struct {
 func (c *sshCommand) Info() *cmd.Info {
 	return &cmd.Info{
 		Name:    "ssh",
-		Args:    "<[user@]target> [command]",
+		Args:    "<[user@]target> [openssh options] [command]",
 		Purpose: usageSSHSummary,
 		Doc:     usageSSHDetails,
 	}

--- a/cmd/juju/common/controller.go
+++ b/cmd/juju/common/controller.go
@@ -84,9 +84,9 @@ func WaitForAgentInitialisation(ctx *cmd.Context, c *modelcmd.ModelCommandBase, 
 	for attempt := attempts.Start(); attempt.Next(); apiAttempts++ {
 		err = tryAPI(c)
 		if err == nil {
-			ctx.Infof("Bootstrap complete, %q controller now available.", controllerName)
-			ctx.Infof("Controller machines are in the %q model.", bootstrap.ControllerModelName)
-			ctx.Infof("Initial model %q added.", hostedModelName)
+			ctx.Infof("Bootstrap complete, %q controller now available", controllerName)
+			ctx.Infof("Controller machines are in the %q model", bootstrap.ControllerModelName)
+			ctx.Infof("Initial model %q added", hostedModelName)
 			break
 		}
 		// As the API server is coming up, it goes through a number of steps.

--- a/cmd/juju/crossmodel/list_test.go
+++ b/cmd/juju/crossmodel/list_test.go
@@ -68,7 +68,8 @@ func (s *ListSuite) TestListError(c *gc.C) {
 }
 
 func (s *ListSuite) TestListFilterArgs(c *gc.C) {
-	_, err := s.runList(c, []string{"--interface", "mysql", "--application", "mysql-lite"})
+	_, err := s.runList(c, []string{
+		"--interface", "mysql", "--application", "mysql-lite", "--connected-user", "user", "--allowed-consumer", "consumer"})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(s.mockAPI.filters, gc.HasLen, 1)
 	c.Assert(s.mockAPI.filters[0], jc.DeepEquals, model.ApplicationOfferFilter{
@@ -78,6 +79,8 @@ func (s *ListSuite) TestListFilterArgs(c *gc.C) {
 		Endpoints: []model.EndpointFilterTerm{{
 			Interface: "mysql",
 		}},
+		ConnectedUsers:   []string{"user"},
+		AllowedConsumers: []string{"consumer"},
 	})
 }
 

--- a/cmd/jujud/agent/engine_test.go
+++ b/cmd/jujud/agent/engine_test.go
@@ -115,6 +115,7 @@ var (
 	notMigratingMachineWorkers = []string{
 		"api-address-updater",
 		"disk-manager",
+		"fan-configurer",
 		// "host-key-reporter", not stable, exits when done
 		"log-sender",
 		"logging-config-updater",

--- a/cmd/jujud/agent/machine/manifolds.go
+++ b/cmd/jujud/agent/machine/manifolds.go
@@ -35,6 +35,7 @@ import (
 	"github.com/juju/juju/worker/dependency"
 	"github.com/juju/juju/worker/deployer"
 	"github.com/juju/juju/worker/diskmanager"
+	"github.com/juju/juju/worker/fanconfigurer"
 	"github.com/juju/juju/worker/fortress"
 	"github.com/juju/juju/worker/gate"
 	"github.com/juju/juju/worker/hostkeyreporter"
@@ -433,12 +434,19 @@ func Manifolds(config ManifoldsConfig) dependency.Manifolds {
 			APICallerName: apiCallerName,
 		})),
 
+		fanConfigurerName: ifNotMigrating(fanconfigurer.Manifold(fanconfigurer.ManifoldConfig{
+			APICallerName: apiCallerName,
+			Clock:         config.Clock,
+		})),
+
 		// The machiner Worker will wait for the identified machine to become
 		// Dying and make it Dead; or until the machine becomes Dead by other
-		// means.
+		// means. This worker needs to be launched after fanconfigurer
+		// so that it reports interfaces created by it.
 		machinerName: ifNotMigrating(machiner.Manifold(machiner.ManifoldConfig{
-			AgentName:     agentName,
-			APICallerName: apiCallerName,
+			AgentName:         agentName,
+			APICallerName:     apiCallerName,
+			FanConfigurerName: fanConfigurerName,
 		})),
 
 		// The log sender is a leaf worker that sends log messages to some
@@ -568,4 +576,5 @@ const (
 	toolsVersionCheckerName  = "tools-version-checker"
 	machineActionName        = "machine-action-runner"
 	hostKeyReporterName      = "host-key-reporter"
+	fanConfigurerName        = "fan-configurer"
 )

--- a/cmd/jujud/agent/machine/manifolds_test.go
+++ b/cmd/jujud/agent/machine/manifolds_test.go
@@ -48,6 +48,7 @@ func (*ManifoldsSuite) TestManifoldNames(c *gc.C) {
 		"api-config-watcher",
 		"central-hub",
 		"disk-manager",
+		"fan-configurer",
 		"host-key-reporter",
 		"log-sender",
 		"logging-config-updater",

--- a/cmd/jujud/bootstrap.go
+++ b/cmd/jujud/bootstrap.go
@@ -286,6 +286,19 @@ func (c *BootstrapCommand) Run(_ *cmd.Context) error {
 	}
 	defer st.Close()
 
+	// Set up default container networking mode
+	model, err := st.Model()
+	if err != nil {
+		return err
+	}
+	if err = model.AutoConfigureContainerNetworking(env); err != nil {
+		if errors.IsNotSupported(err) {
+			logger.Debugf("Not performing container networking autoconfiguration on a non-networking environment")
+		} else {
+			return err
+		}
+	}
+
 	// Fetch spaces from substrate
 	if err = st.ReloadSpaces(env); err != nil {
 		if errors.IsNotSupported(err) {

--- a/core/crossmodel/externalcontroller.go
+++ b/core/crossmodel/externalcontroller.go
@@ -15,6 +15,9 @@ type ControllerInfo struct {
 	// ControllerTag holds tag for the controller.
 	ControllerTag names.ControllerTag
 
+	// Alias holds a (human friendly) alias for the controller.
+	Alias string
+
 	// Addrs holds the addresses and ports of the controller's API servers.
 	Addrs []string
 

--- a/core/crossmodel/interface.go
+++ b/core/crossmodel/interface.go
@@ -101,8 +101,11 @@ type ApplicationOfferFilter struct {
 	// Endpoint contains an endpoint filter criteria.
 	Endpoints []EndpointFilterTerm
 
-	// AllowedUsers are the users allowed to consume the application.
-	AllowedUsers []string
+	// AllowedConsumers are the users allowed to consume the offer.
+	AllowedConsumers []string
+
+	// ConnectedUsers are the users currently related to the offer.
+	ConnectedUsers []string
 }
 
 // EndpointFilterTerm represents a remote endpoint filter.

--- a/environs/bootstrap/bootstrap.go
+++ b/environs/bootstrap/bootstrap.go
@@ -390,7 +390,7 @@ func Bootstrap(ctx environs.BootstrapContext, environ environs.Environ, args Boo
 		return err
 	}
 
-	logger.Infof("Installing Juju agent on bootstrap instance")
+	ctx.Infof("Installing Juju agent on bootstrap instance")
 	publicKey, err := userPublicSigningKey()
 	if err != nil {
 		return err

--- a/environs/networking.go
+++ b/environs/networking.go
@@ -31,6 +31,10 @@ type Networking interface {
 	// by the provider for the environment.
 	Subnets(inst instance.Id, subnetIds []network.Id) ([]network.SubnetInfo, error)
 
+	// SuperSubnets returns information about aggregated subnets - eg. global CIDR
+	// for EC2 VPC.
+	SuperSubnets() ([]string, error)
+
 	// NetworkInterfaces requests information about the network
 	// interfaces on the given instance.
 	NetworkInterfaces(instId instance.Id) ([]network.InterfaceInfo, error)

--- a/featuretests/application_config_test.go
+++ b/featuretests/application_config_test.go
@@ -157,66 +157,67 @@ func (s *ApplicationConfigSuite) assertJujuConfigOutput(c *gc.C, jujuConfigOutpu
 	c.Assert(len(obtained), gc.Equals, len(s.settingKeys))
 	for name, aSetting := range expected {
 		c.Assert(s.settingKeys.Contains(name), jc.IsTrue)
-		c.Assert(obtained[name].Default, gc.Equals, aSetting.Default)
 		c.Assert(obtained[name].Value, gc.Equals, aSetting.Value)
+		c.Assert(obtained[name].Source, gc.Equals, aSetting.Source)
 	}
 }
 
 type configSetting struct {
-	Value   interface{}
-	Default bool
+	Value  interface{}
+	Source string
 }
 
 type settingsMap map[string]configSetting
 
 var (
 	initialConfig = settingsMap{
-		"booleandefault":   {true, true},
-		"booleannodefault": {nil, true},
-		"booleanoverwrite": {false, false},
-		"floatdefault":     {4.2, true},
-		"floatnodefault":   {nil, true},
-		"floatoverwrite":   {2.1, false},
-		"intdefault":       {42, true},
-		"intnodefault":     {nil, true},
-		"intoverwrite":     {1620, false},
-		"strdefault":       {"charm default", true},
-		"strnodefault":     {nil, true},
-		"stroverwrite":     {"test value", false},
+		"booleandefault":   {true, "default"},
+		"booleannodefault": {nil, "unset"},
+		"booleanoverwrite": {false, "user"},
+		"floatdefault":     {4.2, "default"},
+		"floatnodefault":   {nil, "unset"},
+		"floatoverwrite":   {2.1, "user"},
+		"intdefault":       {42, "default"},
+		"intnodefault":     {nil, "unset"},
+		"intoverwrite":     {1620, "user"},
+		"strdefault":       {"charm default", "default"},
+		"strnodefault":     {nil, "unset"},
+		"stroverwrite":     {"test value", "user"},
 	}
 	updatedConfig = settingsMap{
-		"booleandefault":   {false, false},
-		"booleannodefault": {true, false},
-		"booleanoverwrite": {true, true}, // this should be true since user-specified value is the same as default
-		"floatdefault":     {7.2, false},
-		"floatnodefault":   {10.2, false},
-		"floatoverwrite":   {11.1, true}, // this should be true since user-specified value is the same as default
-		"intdefault":       {22, false},
-		"intnodefault":     {11, false},
-		"intoverwrite":     {111, true}, // this should be true since user-specified value is the same as default
-		"strdefault":       {"not", false},
-		"strnodefault":     {"maybe", false},
-		"stroverwrite":     {"me", false},
+		"booleandefault":   {false, "user"},
+		"booleannodefault": {true, "user"},
+		"booleanoverwrite": {true, "user"}, // this should be true since user-specified value is the same as default
+		"floatdefault":     {7.2, "user"},
+		"floatnodefault":   {10.2, "user"},
+		"floatoverwrite":   {11.1, "user"}, // this should be true since user-specified value is the same as default
+		"intdefault":       {22, "user"},
+		"intnodefault":     {11, "user"},
+		"intoverwrite":     {111, "user"}, // this should be true since user-specified value is the same as default
+		"strdefault":       {"not", "user"},
+		"strnodefault":     {"maybe", "user"},
+		"stroverwrite":     {"me", "user"},
 	}
 	resetConfig = settingsMap{
-		"booleandefault":   {true, true},
-		"booleannodefault": {nil, true},
-		"booleanoverwrite": {true, true},
-		"floatdefault":     {4.2, true},
-		"floatnodefault":   {nil, true},
-		"floatoverwrite":   {11.1, true},
-		"intdefault":       {42, true},
-		"intnodefault":     {nil, true},
-		"intoverwrite":     {111, true},
-		"strdefault":       {"charm default", true},
-		"strnodefault":     {nil, true},
-		"stroverwrite":     {"overwrite me", true},
+		"booleandefault":   {true, "default"},
+		"booleannodefault": {nil, "unset"},
+		"booleanoverwrite": {true, "default"},
+		"floatdefault":     {4.2, "default"},
+		"floatnodefault":   {nil, "unset"},
+		"floatoverwrite":   {11.1, "default"},
+		"intdefault":       {42, "default"},
+		"intnodefault":     {nil, "unset"},
+		"intoverwrite":     {111, "default"},
+		"strdefault":       {"charm default", "default"},
+		"strnodefault":     {nil, "unset"},
+		"stroverwrite":     {"overwrite me", "default"},
 	}
 )
 
 type TestSetting struct {
-	Default     bool        `yaml:"is_default"`
+	Default     interface{} `yaml:"default"`
 	Description string      `yaml:"description"`
+	Source      string      `yaml:"source"`
 	Type        string      `yaml:"type"`
 	Value       interface{} `yaml:"value"`
 }

--- a/featuretests/cmdjuju_test.go
+++ b/featuretests/cmdjuju_test.go
@@ -98,20 +98,22 @@ charm: dummy
 settings:
   outlook:
     description: No default outlook.
-    is_default: true
+    source: unset
     type: string
   skill-level:
     description: A number indicating skill.
-    is_default: true
+    source: unset
     type: int
   title:
+    default: My Title
     description: A descriptive title used for the application.
-    is_default: true
+    source: default
     type: string
     value: My Title
   username:
+    default: admin001
     description: The name of the initial account (given admin permissions).
-    is_default: true
+    source: default
     type: string
     value: admin001
 `

--- a/network/containerizer/bridgepolicy.go
+++ b/network/containerizer/bridgepolicy.go
@@ -31,9 +31,12 @@ type BridgePolicy struct {
 	// one of the devices being bridged is a BondDevice. This exists because of
 	// https://bugs.launchpad.net/juju/+bug/1657579
 	NetBondReconfigureDelay int
-	// UseLocalBridges decides if we should use local-only bridges ("lxdbr0", "virbr0"),
-	// to handle unnamed space requests.
-	UseLocalBridges bool
+	// ContainerNetworkingMethod defines the way containers are networked.
+	// It's one of:
+	//  - fan
+	//  - provider
+	//  - local
+	ContainerNetworkingMethod string
 }
 
 // Machine describes either a host machine, or a container machine. Either way
@@ -61,13 +64,12 @@ var _ Container = (*state.Machine)(nil)
 // inferContainerSpaces tries to find a valid space for the container to be
 // on. This should only be used when the container itself doesn't have any
 // valid constraints on what spaces it should be in.
-// If UseLocalBridges is set we fall back to "" and use lxdbr0 as we probably
-// won't be able to get an IP on hosts space.
+// If ContainerNetworkingMethod is 'local' we fall back to "" and use lxdbr0.
 // If this machine is in a single space, then that space is used. Else, if
 // the machine has the default space, then that space is used.
 // If neither of those conditions is true, then we return an error.
 func (p *BridgePolicy) inferContainerSpaces(m Machine, containerId, defaultSpaceName string) (set.Strings, error) {
-	if p.UseLocalBridges {
+	if p.ContainerNetworkingMethod == "local" {
 		return set.NewStrings(""), nil
 	}
 	hostSpaces, err := m.AllSpaces()
@@ -232,7 +234,7 @@ func (b *BridgePolicy) FindMissingBridgesForContainer(m Machine, containerMachin
 	for spaceName, devices := range devicesPerSpace {
 		for _, device := range devices {
 			if device.Type() == state.BridgeDevice {
-				if !b.UseLocalBridges && skippedDeviceNames.Contains(device.Name()) {
+				if b.ContainerNetworkingMethod != "local" && skippedDeviceNames.Contains(device.Name()) {
 					continue
 				}
 				spacesFound.Add(spaceName)
@@ -300,6 +302,7 @@ func (b *BridgePolicy) FindMissingBridgesForContainer(m Machine, containerMachin
 		return nil, 0, errors.Errorf("host machine %q has no available device in space(s) %s",
 			m.Id(), network.QuoteSpaceSet(notFound))
 	}
+
 	hostToBridge := make([]network.DeviceToBridge, 0, len(hostDeviceNamesToBridge))
 	for _, hostName := range network.NaturallySortDeviceNames(hostDeviceNamesToBridge...) {
 		hostToBridge = append(hostToBridge, network.DeviceToBridge{
@@ -338,8 +341,20 @@ func (p *BridgePolicy) PopulateContainerLinkLayerDevices(m Machine, containerMac
 
 	for spaceName, hostDevices := range devicesPerSpace {
 		for _, hostDevice := range hostDevices {
+			var isFan bool
+			addresses, err := hostDevice.Addresses()
+			if err == nil && len(addresses) > 0 {
+				subnet, err := addresses[0].Subnet()
+				if err == nil {
+					if subnet.FanOverlay() != "" {
+						isFan = true
+					}
+				}
+
+			}
+			wantThisDevice := isFan == (p.ContainerNetworkingMethod == "fan")
 			deviceType, name := hostDevice.Type(), hostDevice.Name()
-			if deviceType == state.BridgeDevice && !skippedDeviceNames.Contains(name) {
+			if wantThisDevice && deviceType == state.BridgeDevice && !skippedDeviceNames.Contains(name) {
 				devicesByName[name] = hostDevice
 				bridgeDeviceNames = append(bridgeDeviceNames, name)
 				spacesFound.Add(spaceName)
@@ -347,8 +362,9 @@ func (p *BridgePolicy) PopulateContainerLinkLayerDevices(m Machine, containerMac
 		}
 	}
 	missingSpace := containerSpaces.Difference(spacesFound)
+
 	// Check if we are missing "" and can fill it in with a local bridge
-	if len(missingSpace) == 1 && missingSpace.Contains("") && p.UseLocalBridges {
+	if len(missingSpace) == 1 && missingSpace.Contains("") && p.ContainerNetworkingMethod == "local" {
 		localBridgeName := localBridgeForType[containerMachine.ContainerType()]
 		for _, hostDevice := range devicesPerSpace[""] {
 			name := hostDevice.Name()

--- a/network/containerizer/bridgepolicy.go
+++ b/network/containerizer/bridgepolicy.go
@@ -246,6 +246,10 @@ func (b *BridgePolicy) FindMissingBridgesForContainer(m Machine, containerMachin
 		// Nothing to do, just return success
 		return nil, 0, nil
 	}
+	if b.ContainerNetworkingMethod == "fan" {
+		return nil, 0, errors.Errorf("host machine %q has no available FAN devices in space(s) %s",
+			m.Id(), network.QuoteSpaceSet(notFound))
+	}
 	hostDeviceNamesToBridge := make([]string, 0)
 	for _, spaceName := range notFound.Values() {
 		hostDeviceNames := make([]string, 0)

--- a/network/containerizer/bridgepolicy_test.go
+++ b/network/containerizer/bridgepolicy_test.go
@@ -74,8 +74,8 @@ func (s *bridgePolicyStateSuite) SetUpTest(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.bridgePolicy = &containerizer.BridgePolicy{
-		NetBondReconfigureDelay: 13,
-		UseLocalBridges:         false,
+		NetBondReconfigureDelay:   13,
+		ContainerNetworkingMethod: "provider",
 	}
 }
 
@@ -601,8 +601,8 @@ func (s *bridgePolicyStateSuite) TestPopulateContainerLinkLayerDevicesNoLocal(c 
 	s.assertNoDevicesOnMachine(c, s.containerMachine)
 
 	bridgePolicy := &containerizer.BridgePolicy{
-		NetBondReconfigureDelay: 13,
-		UseLocalBridges:         false,
+		NetBondReconfigureDelay:   13,
+		ContainerNetworkingMethod: "provider",
 	}
 	err := bridgePolicy.PopulateContainerLinkLayerDevices(s.machine, s.containerMachine)
 	c.Assert(err.Error(), gc.Equals, `unable to find host bridge for space(s) "" for container "0/lxd/0"`)
@@ -619,8 +619,8 @@ func (s *bridgePolicyStateSuite) TestPopulateContainerLinkLayerDevicesUseLocal(c
 	s.assertNoDevicesOnMachine(c, s.containerMachine)
 
 	bridgePolicy := &containerizer.BridgePolicy{
-		NetBondReconfigureDelay: 13,
-		UseLocalBridges:         true,
+		NetBondReconfigureDelay:   13,
+		ContainerNetworkingMethod: "local",
 	}
 	err := bridgePolicy.PopulateContainerLinkLayerDevices(s.machine, s.containerMachine)
 	c.Assert(err, jc.ErrorIsNil)
@@ -716,18 +716,18 @@ func (s *bridgePolicyStateSuite) TestFindMissingBridgesForContainerNoSpaces(c *g
 	c.Check(reconfigureDelay, gc.Equals, 0)
 }
 
-func (s *bridgePolicyStateSuite) TestFindMissingBridgesForContainerUseLocalBridges(c *gc.C) {
+func (s *bridgePolicyStateSuite) TestFindMissingBridgesForContainerContainerNetworkingMethodLocal(c *gc.C) {
 	// There is a "default" and "dmz" space, our machine has 1 network
-	// interface, but is not part of a known space. We have UseLocalBridges
-	// set, which means we should fall back to using 'lxdbr0' instead of
+	// interface, but is not part of a known space. We have ContainerNetworkingMethod set to "local",
+	// which means we should fall back to using 'lxdbr0' instead of
 	// bridging the host device.
 	s.setupTwoSpaces(c)
 	s.createNICWithIP(c, s.machine, "ens3", "172.12.0.10/24")
 	s.createAllDefaultDevices(c, s.machine)
 	s.addContainerMachine(c)
 	bridgePolicy := &containerizer.BridgePolicy{
-		NetBondReconfigureDelay: 13,
-		UseLocalBridges:         true,
+		NetBondReconfigureDelay:   13,
+		ContainerNetworkingMethod: "local",
 	}
 	// No defined spaces for the container, no *known* spaces for the host
 	// machine. Triggers the fallback code to have us bridge all devices.
@@ -737,21 +737,21 @@ func (s *bridgePolicyStateSuite) TestFindMissingBridgesForContainerUseLocalBridg
 	c.Check(reconfigureDelay, gc.Equals, 0)
 }
 
-func (s *bridgePolicyStateSuite) TestFindMissingBridgesForContainerUseLocalBridgesDefinedHostSpace(c *gc.C) {
+func (s *bridgePolicyStateSuite) TestFindMissingBridgesForContainerContainerNetworkingMethodLocalDefinedHostSpace(c *gc.C) {
 	// There is a "default" and "dmz" space, our machine has 1 network
-	// interface, which is part of "default" space. We have UseLocalBridges
-	// set, which means we should fall back to using 'lxdbr0' instead of
+	// interface, but is not part of a known space. We have ContainerNetworkingMethod set to "local",
+	// which means we should fall back to using 'lxdbr0' instead of
 	// bridging the host device.
 	s.setupTwoSpaces(c)
 	s.createNICWithIP(c, s.machine, "eth0", "10.0.0.20/24")
 	s.createAllDefaultDevices(c, s.machine)
 	s.addContainerMachine(c)
 	bridgePolicy := &containerizer.BridgePolicy{
-		NetBondReconfigureDelay: 13,
-		UseLocalBridges:         true,
+		NetBondReconfigureDelay:   13,
+		ContainerNetworkingMethod: "local",
 	}
 	// No defined spaces for the container, host has spaces but we have
-	// UseLocalBridges set so we should fall back to lxdbr0
+	// ContainerNetworkingMethodLocal set so we should fall back to lxdbr0
 	missing, reconfigureDelay, err := bridgePolicy.FindMissingBridgesForContainer(s.machine, s.containerMachine)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(missing, jc.DeepEquals, []network.DeviceToBridge{})
@@ -769,7 +769,7 @@ func (s *bridgePolicyStateSuite) TestFindMissingBridgesForContainerUseLocalBridg
 	c.Check(containerDevice.ParentName(), gc.Equals, `m#0#d#lxdbr0`)
 }
 
-func (s *bridgePolicyStateSuite) TestFindMissingBridgesForContainerUseLocalBridgesNoAddress(c *gc.C) {
+func (s *bridgePolicyStateSuite) TestFindMissingBridgesForContainerContainerNetworkingMethodLocalNoAddress(c *gc.C) {
 	// We should only use 'lxdbr0' instead of bridging the host device.
 	s.setupTwoSpaces(c)
 	s.createNICWithIP(c, s.machine, "ens3", "172.12.0.10/24")
@@ -784,8 +784,8 @@ func (s *bridgePolicyStateSuite) TestFindMissingBridgesForContainerUseLocalBridg
 	c.Assert(err, jc.ErrorIsNil)
 	s.addContainerMachine(c)
 	bridgePolicy := &containerizer.BridgePolicy{
-		NetBondReconfigureDelay: 13,
-		UseLocalBridges:         true,
+		NetBondReconfigureDelay:   13,
+		ContainerNetworkingMethod: "local",
 	}
 	// No defined spaces for the container, no *known* spaces for the host
 	// machine. Triggers the fallback code to have us bridge all devices.

--- a/network/containerizer/bridgepolicy_test.go
+++ b/network/containerizer/bridgepolicy_test.go
@@ -1120,6 +1120,22 @@ func (s *bridgePolicyStateSuite) TestFindMissingBridgesForContainerVLANOnBond(c 
 	c.Check(reconfigureDelay, gc.Equals, 13)
 }
 
+func (s *bridgePolicyStateSuite) TestFindMissingBridgesForContainerNetworkingMethodFAN(c *gc.C) {
+	s.setupTwoSpaces(c)
+	s.createNICWithIP(c, s.machine, "eth0", "10.0.0.20/24")
+	s.addContainerMachine(c)
+	err := s.containerMachine.SetConstraints(constraints.Value{
+		Spaces: &[]string{"default"},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	bridgePolicy := &containerizer.BridgePolicy{
+		NetBondReconfigureDelay:   13,
+		ContainerNetworkingMethod: "fan",
+	}
+	_, _, err = bridgePolicy.FindMissingBridgesForContainer(s.machine, s.containerMachine)
+	c.Assert(err, gc.ErrorMatches, `host machine "0" has no available FAN devices in space\(s\) "default"`)
+}
+
 var bridgeNames = map[string]string{
 	"eno0":            "br-eno0",
 	"twelvechars0":    "br-twelvechars0",

--- a/network/fan.go
+++ b/network/fan.go
@@ -1,0 +1,86 @@
+package network
+
+import (
+	"encoding/binary"
+	"fmt"
+	"net"
+	"strings"
+
+	"github.com/juju/errors"
+)
+
+// FanConfigEntry defines a configuration for single fan.
+type FanConfigEntry struct {
+	Underlay *net.IPNet
+	Overlay  *net.IPNet
+}
+
+// FanConfig defines a set of fan configurations for the model.
+type FanConfig []FanConfigEntry
+
+// ParseFanConfig parses fan configuration from model-config in the format:
+// "underlay1=overlay1 underlay2=overlay2" eg. "172.16.0.0/16=253.0.0.0/8 10.0.0.0/12:254.0.0.0/7"
+func ParseFanConfig(line string) (config FanConfig, err error) {
+	if line == "" {
+		return nil, nil
+	}
+	entries := strings.Split(line, " ")
+	config = make([]FanConfigEntry, len(entries))
+	for i, line := range entries {
+		cidrs := strings.Split(line, "=")
+		if len(cidrs) != 2 {
+			return nil, fmt.Errorf("invalid FAN config entry: %v", line)
+		}
+		if _, config[i].Underlay, err = net.ParseCIDR(strings.TrimSpace(cidrs[0])); err != nil {
+			return nil, errors.Annotatef(err, "invalid address in FAN config")
+		}
+		if _, config[i].Overlay, err = net.ParseCIDR(strings.TrimSpace(cidrs[1])); err != nil {
+			return nil, errors.Annotatef(err, "invalid address in FAN config")
+		}
+		underlaySize, _ := config[i].Underlay.Mask.Size()
+		overlaySize, _ := config[i].Overlay.Mask.Size()
+		if underlaySize <= overlaySize {
+			return nil, fmt.Errorf("invalid FAN config, underlay mask must be larger than overlay: %s", line)
+		}
+	}
+	return config, nil
+}
+
+func (fc *FanConfig) String() (line string) {
+	configs := make([]string, len(*fc))
+	for i, fan := range *fc {
+		configs[i] = fmt.Sprintf("%s=%s", fan.Underlay.String(), fan.Overlay.String())
+	}
+	return strings.Join(configs, " ")
+}
+
+// CalculateOverlaySegment takes underlay CIDR and FAN config entry and
+// cuts the segment of overlay that corresponds to this underlay:
+// eg. for FAN 172.31/16 -> 243/8 and physical subnet 172.31.64/20
+// we get FAN subnet 243.64/12.
+func CalculateOverlaySegment(underlayCIDR string, fan FanConfigEntry) (*net.IPNet, error) {
+	_, underlayNet, err := net.ParseCIDR(underlayCIDR)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	subnetSize, _ := underlayNet.Mask.Size()
+	underlaySize, _ := fan.Underlay.Mask.Size()
+	if underlaySize <= subnetSize && fan.Underlay.Contains(underlayNet.IP) {
+		overlaySize, _ := fan.Overlay.Mask.Size()
+		newOverlaySize := overlaySize + (subnetSize - underlaySize)
+		fanSize := uint(underlaySize - overlaySize)
+		newFanIP := underlayNet.IP.To4()
+		for i := 0; i < 4; i++ {
+			newFanIP[i] &^= fan.Underlay.Mask[i]
+		}
+		numIp := binary.BigEndian.Uint32(newFanIP)
+		numIp <<= fanSize
+		binary.BigEndian.PutUint32(newFanIP, numIp)
+		for i := 0; i < 4; i++ {
+			newFanIP[i] += fan.Overlay.IP[i]
+		}
+		return &net.IPNet{IP: newFanIP, Mask: net.CIDRMask(newOverlaySize, 32)}, nil
+	} else {
+		return nil, nil
+	}
+}

--- a/network/fan_test.go
+++ b/network/fan_test.go
@@ -1,0 +1,107 @@
+package network_test
+
+import (
+	"net"
+
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/network"
+	"github.com/juju/juju/testing"
+)
+
+type FanConfigSuite struct {
+	testing.BaseSuite
+}
+
+var _ = gc.Suite(&FanConfigSuite{})
+
+func (*FanConfigSuite) TestFanConfigParseEmpty(c *gc.C) {
+	config, err := network.ParseFanConfig("")
+	c.Check(config, gc.IsNil)
+	c.Check(err, jc.ErrorIsNil)
+}
+
+func (*FanConfigSuite) TestFanConfigParseSingle(c *gc.C) {
+	input := "172.31.0.0/16=253.0.0.0/8"
+	config, err := network.ParseFanConfig(input)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(config, gc.HasLen, 1)
+	_, underlay, _ := net.ParseCIDR("172.31.0.0/16")
+	_, overlay, _ := net.ParseCIDR("253.0.0.0/8")
+	c.Check(config[0].Underlay, gc.DeepEquals, underlay)
+	c.Check(config[0].Overlay, gc.DeepEquals, overlay)
+	c.Check(config.String(), gc.Equals, input)
+}
+
+func (*FanConfigSuite) TestFanConfigParseMultiple(c *gc.C) {
+	input := "172.31.0.0/16=253.0.0.0/8 172.32.0.0/16=254.0.0.0/8"
+	config, err := network.ParseFanConfig(input)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(config, gc.HasLen, 2)
+	_, underlay0, _ := net.ParseCIDR("172.31.0.0/16")
+	_, overlay0, _ := net.ParseCIDR("253.0.0.0/8")
+	c.Check(config[0].Underlay, gc.DeepEquals, underlay0)
+	c.Check(config[0].Overlay, gc.DeepEquals, overlay0)
+	_, underlay1, _ := net.ParseCIDR("172.32.0.0/16")
+	_, overlay1, _ := net.ParseCIDR("254.0.0.0/8")
+	c.Check(config[1].Underlay, gc.DeepEquals, underlay1)
+	c.Check(config[1].Overlay, gc.DeepEquals, overlay1)
+	c.Check(config.String(), gc.Equals, input)
+}
+
+func (*FanConfigSuite) TestFanConfigErrors(c *gc.C) {
+	// Colonless garbage.
+	config, err := network.ParseFanConfig("172.31.0.0/16=253.0.0.0/8 foobar")
+	c.Check(config, gc.IsNil)
+	c.Check(err, gc.ErrorMatches, "invalid FAN config entry:.*")
+
+	// Invalid IP address.
+	config, err = network.ParseFanConfig("172.31.0.0/16=253.0.0.0/8 333.122.142.17/18=1.2.3.0/24")
+	c.Check(config, gc.IsNil)
+	c.Check(err, gc.ErrorMatches, "invalid address in FAN config:.*")
+	config, err = network.ParseFanConfig("172.31.0.0/16=253.0.0.0/8 1.2.3.0/24=333.122.142.17/18")
+	c.Check(config, gc.IsNil)
+	c.Check(err, gc.ErrorMatches, "invalid address in FAN config:.*")
+
+	// Underlay mask smaller than overlay.
+	config, err = network.ParseFanConfig("1.0.0.0/8=2.0.0.0/16")
+	c.Check(config, gc.IsNil)
+	c.Check(err, gc.ErrorMatches, "invalid FAN config, underlay mask must be larger than overlay:.*")
+}
+
+func (*FanConfigSuite) TestCalculateOverlaySegment(c *gc.C) {
+	config, err := network.ParseFanConfig("172.31.0.0/16=253.0.0.0/8 10.0.0.0/12=252.0.0.0/7")
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Regular case
+	net, err := network.CalculateOverlaySegment("172.31.16.0/20", config[0])
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(net, gc.NotNil)
+	c.Check(net.String(), gc.Equals, "253.16.0.0/12")
+
+	// Underlay outside of FAN scope
+	net, err = network.CalculateOverlaySegment("172.99.16.0/20", config[0])
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(net, gc.IsNil)
+
+	// Garbage in underlay
+	net, err = network.CalculateOverlaySegment("something", config[0])
+	c.Check(net, gc.IsNil)
+	c.Check(err, gc.ErrorMatches, "invalid CIDR address: something")
+
+	// Funky case
+	// We have overlay 252.0.0.0/7 underlay 10.0.0.0/12 and local underlay 10.2.224.0/19
+	// We need to transplant 19-12=7 bits out of local underlay to overlay
+	// 10.2.224.0/19 is 00001010.00000010.11100000.00000000
+	//  the bits we want to cut      **** ***
+	// 252.0.0.0/7   is 11111100.00000000.00000000.00000000
+	// After transplanting those 7 bits we get
+	//                  11111100.01011100.00000000.00000000
+	//                         * ******
+	// which is 252.92.0.0/14
+	net, err = network.CalculateOverlaySegment("10.2.224.0/19", config[1])
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(net, gc.NotNil)
+	c.Check(net.String(), gc.Equals, "252.92.0.0/14")
+}

--- a/network/netplan/activate.go
+++ b/network/netplan/activate.go
@@ -77,7 +77,7 @@ func BridgeAndActivate(params ActivationParams) (*ActivationResult, error) {
 	environ := os.Environ()
 	// TODO(wpk) 2017-06-21 Is there a way to verify that apply is finished?
 	// https://bugs.launchpad.net/netplan/+bug/1701436
-	command := fmt.Sprintf("%snetplan generate && netplan apply && sleep 3", params.RunPrefix)
+	command := fmt.Sprintf("%snetplan generate && netplan apply && sleep 10", params.RunPrefix)
 
 	result, err := scriptrunner.RunCommand(command, environ, params.Clock, params.Timeout)
 

--- a/network/netplan/netplan.go
+++ b/network/netplan/netplan.go
@@ -28,6 +28,7 @@ type Interface struct {
 	Gateway6    string      `yaml:"gateway6,omitempty"`
 	Nameservers Nameservers `yaml:"nameservers,omitempty"`
 	MTU         int         `yaml:"mtu,omitempty"`
+	Routes      []Route     `yaml:"routes,omitempty"`
 }
 type Ethernet struct {
 	Match     map[string]string `yaml:"match"`

--- a/network/netplan/netplan_test.go
+++ b/network/netplan/netplan_test.go
@@ -40,6 +40,10 @@ network:
       nameservers:
         search: [foo.local, bar.local]
         addresses: [8.8.8.8]
+      routes:
+      - to: 0.0.0.0/0
+        via: 11.0.0.1
+        metric: 3
     lom:
       match:
         driver: ixgbe
@@ -70,6 +74,7 @@ network:
 `[1:]
 	var np netplan.Netplan
 	err := netplan.Unmarshal([]byte(input), &np)
+	c.Check(err, jc.ErrorIsNil)
 	out, err := netplan.Marshal(np)
 	c.Check(err, jc.ErrorIsNil)
 	c.Check(string(out), gc.Equals, input)
@@ -92,6 +97,10 @@ network:
       nameservers:
         search: [foo.local, bar.local]
         addresses: [8.8.8.8]
+      routes:
+      - to: 100.0.0.0/8
+        via: 1.2.3.10
+        metric: 5
 `[1:]
 	expected := `
 network:
@@ -112,6 +121,10 @@ network:
       nameservers:
         search: [foo.local, bar.local]
         addresses: [8.8.8.8]
+      routes:
+      - to: 100.0.0.0/8
+        via: 1.2.3.10
+        metric: 5
 `[1:]
 	var np netplan.Netplan
 
@@ -146,6 +159,10 @@ network:
       nameservers:
         search: [foo.local, bar.local]
         addresses: [8.8.8.8]
+      routes:
+      - to: 100.0.0.0/8
+        via: 1.2.3.10
+        metric: 5
 `[1:]
 	var np netplan.Netplan
 	err := netplan.Unmarshal([]byte(input), &np)

--- a/provider/common/bootstrap.go
+++ b/provider/common/bootstrap.go
@@ -148,7 +148,7 @@ func BootstrapInstance(ctx environs.BootstrapContext, env environs.Environ, args
 	if args.CloudRegion != "" {
 		cloudRegion += "/" + args.CloudRegion
 	}
-	fmt.Fprintf(ctx.GetStderr(), "Launching controller instance(s) on %s...\n", cloudRegion)
+	ctx.Infof("Launching controller instance(s) on %s...", cloudRegion)
 	// Print instance status reports status changes during provisioning.
 	// Note the carriage returns, meaning subsequent prints are to the same
 	// line of stderr, not a new line.
@@ -191,7 +191,7 @@ func BootstrapInstance(ctx environs.BootstrapContext, env environs.Environ, args
 		padding := make([]string, 40-len(msg))
 		msg += strings.Join(padding, " ")
 	}
-	fmt.Fprintln(ctx.GetStderr(), msg)
+	ctx.Infof(msg)
 
 	finalize := func(ctx environs.BootstrapContext, icfg *instancecfg.InstanceConfig, opts environs.BootstrapDialOpts) error {
 		icfg.Bootstrap.BootstrapMachineInstanceId = result.Instance.Id()
@@ -268,6 +268,7 @@ var FinishBootstrap = func(
 	if err != nil {
 		return err
 	}
+	ctx.Infof("Connected to %v", addr)
 
 	sshOptions, cleanup, err := hostSSHOptions(addr)
 	if err != nil {
@@ -334,6 +335,7 @@ func ConfigureMachine(
 		return err
 	}
 	script := shell.DumpFileOnErrorScript(instanceConfig.CloudInitOutputLog) + configScript
+	ctx.Infof("Running machine configuration script...")
 	return sshinit.RunConfigureScript(script, sshinit.ConfigureParams{
 		Host:           "ubuntu@" + host,
 		Client:         client,

--- a/provider/dummy/environs.go
+++ b/provider/dummy/environs.go
@@ -265,6 +265,9 @@ type environ struct {
 	spacesMutex  sync.RWMutex
 }
 
+var _ environs.Environ = (*environ)(nil)
+var _ environs.Networking = (*environ)(nil)
+
 // discardOperations discards all Operations written to it.
 var discardOperations = make(chan Operation)
 
@@ -1716,4 +1719,9 @@ func (*environ) SSHAddresses(addresses []network.Address) ([]network.Address, er
 		}
 	}
 	return rv, nil
+}
+
+// SuperSubnets implements environs.SuperSubnets
+func (*environ) SuperSubnets() ([]string, error) {
+	return nil, errors.NotSupportedf("super subnets")
 }

--- a/provider/ec2/environ_vpc.go
+++ b/provider/ec2/environ_vpc.go
@@ -347,6 +347,14 @@ func getVPCRouteTables(apiClient vpcAPIClient, vpc *ec2.VPC) ([]ec2.RouteTable, 
 	return response.Tables, nil
 }
 
+func getVPCCIDR(apiClient vpcAPIClient, vpcID string) (string, error) {
+	vpc, err := getVPCByID(apiClient, vpcID)
+	if err != nil {
+		return "", err
+	}
+	return vpc.CIDRBlock, nil
+}
+
 func findVPCMainRouteTable(routeTables []ec2.RouteTable) (*ec2.RouteTable, error) {
 	var mainTable *ec2.RouteTable
 	for i, table := range routeTables {

--- a/provider/gce/environ.go
+++ b/provider/gce/environ.go
@@ -83,6 +83,9 @@ type environ struct {
 	namespace instance.Namespace
 }
 
+var _ environs.Environ = (*environ)(nil)
+var _ environs.NetworkingEnviron = (*environ)(nil)
+
 // Function entry points defined as variables so they can be overridden
 // for testing purposes.
 var (

--- a/provider/gce/environ_network.go
+++ b/provider/gce/environ_network.go
@@ -293,6 +293,11 @@ func (*environ) SSHAddresses(addresses []network.Address) ([]network.Address, er
 	}
 }
 
+// SuperSubnets implements environs.SuperSubnets
+func (*environ) SuperSubnets() ([]string, error) {
+	return nil, errors.NotSupportedf("super subnets")
+}
+
 func copyStrings(items []string) []string {
 	if items == nil {
 		return nil

--- a/provider/maas/environ.go
+++ b/provider/maas/environ.go
@@ -108,6 +108,7 @@ type maasEnviron struct {
 }
 
 var _ environs.Environ = (*maasEnviron)(nil)
+var _ environs.Networking = (*maasEnviron)(nil)
 
 // MaasCapabilities represents a function that gets the capabilities of a MAAS
 // installation.
@@ -2334,4 +2335,9 @@ func (*maasEnviron) AreSpacesRoutable(space1, space2 *environs.ProviderSpaceInfo
 // SSHAddresses implements environs.SSHAddresses.
 func (*maasEnviron) SSHAddresses(addresses []network.Address) ([]network.Address, error) {
 	return addresses, nil
+}
+
+// SuperSubnets implements environs.SuperSubnets
+func (*maasEnviron) SuperSubnets() ([]string, error) {
+	return nil, errors.NotSupportedf("super subnets")
 }

--- a/provider/openstack/provider.go
+++ b/provider/openstack/provider.go
@@ -296,6 +296,7 @@ type Environ struct {
 }
 
 var _ environs.Environ = (*Environ)(nil)
+var _ environs.NetworkingEnviron = (*Environ)(nil)
 var _ simplestreams.HasRegion = (*Environ)(nil)
 var _ instance.Distributor = (*Environ)(nil)
 var _ environs.InstanceTagger = (*Environ)(nil)
@@ -1772,6 +1773,11 @@ func (e *Environ) Spaces() ([]network.SpaceInfo, error) {
 // SupportsContainerAddresses is specified on environs.Networking.
 func (e *Environ) SupportsContainerAddresses() (bool, error) {
 	return false, errors.NotSupportedf("container address")
+}
+
+// SuperSubnets is specified on environs.Networking
+func (*Environ) SuperSubnets() ([]string, error) {
+	return nil, errors.NotSupportedf("super subnets")
 }
 
 // AllocateContainerAddresses is specified on environs.Networking.

--- a/provider/oracle/network/environ.go
+++ b/provider/oracle/network/environ.go
@@ -365,3 +365,8 @@ func (Environ) AreSpacesRoutable(space1, space2 *environs.ProviderSpaceInfo) (bo
 func (*Environ) SSHAddresses(addresses []network.Address) ([]network.Address, error) {
 	return addresses, nil
 }
+
+// SuperSubnets implements environs.SuperSubnets
+func (*Environ) SuperSubnets() ([]string, error) {
+	return nil, errors.NotSupportedf("super subnets")
+}

--- a/releasetests/build-juju-source.bash
+++ b/releasetests/build-juju-source.bash
@@ -1,6 +1,4 @@
 echo "Getting and updating juju-core dependencies to the required versions."
-env
-echo "Work directory is $WORK"
 GOPATH=$WORK go get -v github.com/rogpeppe/godeps
 GODEPS=$WORK/bin/godeps
 if [[ ! -f $GODEPS ]]; then

--- a/releasetests/build-juju-source.bash
+++ b/releasetests/build-juju-source.bash
@@ -1,4 +1,6 @@
 echo "Getting and updating juju-core dependencies to the required versions."
+env
+echo "Work directory is $WORK"
 GOPATH=$WORK go get -v github.com/rogpeppe/godeps
 GODEPS=$WORK/bin/godeps
 if [[ ! -f $GODEPS ]]; then

--- a/releasetests/crossbuild.py
+++ b/releasetests/crossbuild.py
@@ -14,7 +14,7 @@ from tempfile import mkdtemp
 import traceback
 
 
-GOLANG_VERSION = '1.8'
+GOLANG_VERSION = '1.9'
 CROSSCOMPILE_SOURCE = (
     'https://raw.githubusercontent.com'
     '/davecheney/golang-crosscompile/master/crosscompile.bash')
@@ -95,7 +95,7 @@ def setup_cross_building(build_dir, dry_run=False, verbose=False):
     sudo apt-get install winetricks wine innoextract dpkg-dev xvfb
     apt-get source golang-go={GOLANG_VERSION}*
     export GOROOT=/var/lib/jenkins/crossbuild/golang-{GOLANG_VERSION}
-    export GOROOT_BOOTSTRAP=/usr/lib/go-1.8/
+    export GOROOT_BOOTSTRAP=/usr/lib/go-1.9/
 
     # For sl90x, ppc64el, arm64
     go-crosscompile-build linux/$GOARCH

--- a/releasetests/make_release_notes.py
+++ b/releasetests/make_release_notes.py
@@ -100,7 +100,7 @@ your feedback and usage of juju.
 
 def get_lp_bug_tasks(script, milestone_name):
     """Return an iterators of Lp BugTasks,"""
-    lp = Launchpad.login_with(
+    lp = Launchpad.login_anonymously(
         script, service_root='https://api.launchpad.net', version='devel')
     if milestone_name.startswith('1.'):
         project = lp.projects['juju-core']

--- a/scripts/win-installer/setup.iss
+++ b/scripts/win-installer/setup.iss
@@ -2,7 +2,7 @@
 ; SEE THE DOCUMENTATION FOR DETAILS ON CREATING INNO SETUP SCRIPT FILES!
 
 #define MyAppName "Juju"
-#define MyAppVersion "2.3-alpha1"
+#define MyAppVersion "2.3-beta1"
 #define MyAppPublisher "Canonical, Ltd"
 #define MyAppURL "http://jujucharms.com/"
 #define MyAppExeName "juju.exe"

--- a/scripts/win-installer/setup.iss
+++ b/scripts/win-installer/setup.iss
@@ -2,7 +2,7 @@
 ; SEE THE DOCUMENTATION FOR DETAILS ON CREATING INNO SETUP SCRIPT FILES!
 
 #define MyAppName "Juju"
-#define MyAppVersion "2.3-beta1"
+#define MyAppVersion "2.3-beta2"
 #define MyAppPublisher "Canonical, Ltd"
 #define MyAppURL "http://jujucharms.com/"
 #define MyAppExeName "juju.exe"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: juju
-version: 2.3-alpha1
+version: 2.3-beta1
 summary: juju client
 description: Through the use of charms, juju provides you with shareable, re-usable, and repeatable expressions of devops best practices.
 confinement: classic

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: juju
-version: 2.3-beta1
+version: 2.3-beta2
 summary: juju client
 description: Through the use of charms, juju provides you with shareable, re-usable, and repeatable expressions of devops best practices.
 confinement: classic

--- a/state/containernetworking.go
+++ b/state/containernetworking.go
@@ -1,0 +1,93 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package state
+
+import (
+	"fmt"
+	"net"
+	"strings"
+
+	"github.com/juju/errors"
+
+	"github.com/juju/juju/environs"
+	"github.com/juju/juju/environs/config"
+)
+
+// AutoConfigureContainerNetworking tries to set up best container networking available
+// for the specific model if user hasn't set anything.
+func (m *Model) AutoConfigureContainerNetworking(environ environs.Environ) error {
+	netEnviron, ok := environs.SupportsNetworking(environ)
+	if !ok {
+		return errors.NotSupportedf("fan configuration in a non-networking environ")
+	}
+	modelConfig, err := m.ModelConfig()
+	if err != nil {
+		return err
+	}
+	updateAttrs := make(map[string]interface{})
+	fanConfigured, err := m.discoverFan(netEnviron, modelConfig, updateAttrs)
+	if err != nil {
+		return err
+	}
+
+	if modelConfig.ContainerNetworkingMethod() != "" {
+		// Do nothing, user has decided what to do
+	} else if ok, _ := netEnviron.SupportsContainerAddresses(); ok {
+		updateAttrs["container-networking-method"] = "provider"
+	} else if fanConfigured {
+		updateAttrs["container-networking-method"] = "fan"
+	} else {
+		updateAttrs["container-networking-method"] = "local"
+	}
+	err = m.st.UpdateModelConfig(updateAttrs, nil)
+	return err
+}
+
+func (m *Model) discoverFan(netEnviron environs.NetworkingEnviron, modelConfig *config.Config, updateAttrs map[string]interface{}) (bool, error) {
+	fanConfig, err := modelConfig.FanConfig()
+	if err != nil {
+		return false, err
+	}
+	if len(fanConfig) != 0 {
+		logger.Debugf("Not trying to autoconfigure FAN - configured already")
+		return false, nil
+	}
+	subnets, err := netEnviron.SuperSubnets()
+	if errors.IsNotSupported(err) || (err == nil && len(subnets) == 0) {
+		logger.Debugf("Not trying to autoconfigure FAN - SuperSubnets not supported or empty")
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	var outputTable []string
+
+	fanOverlays := []string{"252.0.0.0/8", "253.0.0.0/8", "254.0.0.0/8", "250.0.0.0/8", "251.0.0.0/8"}
+	fanOverlayForUnderlay := func(underlay string) string {
+		_, ipNet, err := net.ParseCIDR(underlay)
+		if err != nil {
+			return ""
+		}
+		if ones, _ := ipNet.Mask.Size(); ones <= 8 {
+			return ""
+		}
+		if len(fanOverlays) == 0 {
+			return ""
+		}
+		var overlay string
+		overlay, fanOverlays = fanOverlays[0], fanOverlays[1:]
+		return overlay
+	}
+	for _, subnet := range subnets {
+		overlay := fanOverlayForUnderlay(subnet)
+		if overlay != "" {
+			outputTable = append(outputTable, fmt.Sprintf("%s=%s", subnet, overlay))
+		}
+	}
+	if len(outputTable) > 0 {
+		updateAttrs["fan-config"] = strings.Join(outputTable, " ")
+		return true, nil
+	}
+	return false, nil
+}

--- a/state/externalcontroller.go
+++ b/state/externalcontroller.go
@@ -36,6 +36,9 @@ type externalControllerDoc struct {
 	// It is the controller UUID.
 	Id string `bson:"_id"`
 
+	// Alias holds an alias (human friendly) name for the controller.
+	Alias string `bson:"alias"`
+
 	// Addrs holds the host:port values for the external
 	// controller's API server.
 	Addrs []string `bson:"addresses"`
@@ -57,6 +60,7 @@ func (rc *externalController) Id() string {
 func (rc *externalController) ControllerInfo() crossmodel.ControllerInfo {
 	return crossmodel.ControllerInfo{
 		ControllerTag: names.NewControllerTag(rc.doc.Id),
+		Alias:         rc.doc.Alias,
 		Addrs:         rc.doc.Addrs,
 		CACert:        rc.doc.CACert,
 	}
@@ -84,6 +88,7 @@ func (ec *externalControllers) Save(controller crossmodel.ControllerInfo, modelU
 	}
 	doc := externalControllerDoc{
 		Id:     controller.ControllerTag.Id(),
+		Alias:  controller.Alias,
 		Addrs:  controller.Addrs,
 		CACert: controller.CACert,
 	}
@@ -110,6 +115,7 @@ func (ec *externalControllers) Save(controller crossmodel.ControllerInfo, modelU
 				Update: bson.D{
 					{"$set",
 						bson.D{{"addresses", doc.Addrs},
+							{"alias", doc.Alias},
 							{"cacert", doc.CACert},
 							{"models", models.Values()}},
 					},

--- a/state/externalcontroller_test.go
+++ b/state/externalcontroller_test.go
@@ -42,6 +42,7 @@ func (s *externalControllerSuite) TestSaveInvalidAddress(c *gc.C) {
 func (s *externalControllerSuite) TestSaveNoModels(c *gc.C) {
 	controllerInfo := crossmodel.ControllerInfo{
 		ControllerTag: testing.ControllerTag,
+		Alias:         "controller-alias",
 		Addrs:         []string{"192.168.1.0:1234", "10.0.0.1:1234"},
 		CACert:        testing.CACert,
 	}
@@ -62,6 +63,7 @@ func (s *externalControllerSuite) assertSavedControllerInfo(c *gc.C, modelUUIDs 
 	c.Assert(raw["_id"], gc.Equals, testing.ControllerTag.Id())
 	c.Assert(raw["addresses"], jc.SameContents, []interface{}{"192.168.1.0:1234", "10.0.0.1:1234"})
 	c.Assert(raw["cacert"], gc.Equals, testing.CACert)
+	c.Assert(raw["alias"], gc.Equals, "controller-alias")
 	var models []string
 	for _, m := range raw["models"].([]interface{}) {
 		models = append(models, m.(string))
@@ -72,6 +74,7 @@ func (s *externalControllerSuite) assertSavedControllerInfo(c *gc.C, modelUUIDs 
 func (s *externalControllerSuite) TestSave(c *gc.C) {
 	controllerInfo := crossmodel.ControllerInfo{
 		ControllerTag: testing.ControllerTag,
+		Alias:         "controller-alias",
 		Addrs:         []string{"192.168.1.0:1234", "10.0.0.1:1234"},
 		CACert:        testing.CACert,
 	}
@@ -87,6 +90,7 @@ func (s *externalControllerSuite) TestSave(c *gc.C) {
 func (s *externalControllerSuite) TestSaveIdempotent(c *gc.C) {
 	controllerInfo := crossmodel.ControllerInfo{
 		ControllerTag: testing.ControllerTag,
+		Alias:         "controller-alias",
 		Addrs:         []string{"192.168.1.0:1234", "10.0.0.1:1234"},
 		CACert:        testing.CACert,
 	}
@@ -103,6 +107,7 @@ func (s *externalControllerSuite) TestSaveIdempotent(c *gc.C) {
 func (s *externalControllerSuite) TestUpdateModels(c *gc.C) {
 	controllerInfo := crossmodel.ControllerInfo{
 		ControllerTag: testing.ControllerTag,
+		Alias:         "controller-alias",
 		Addrs:         []string{"192.168.1.0:1234", "10.0.0.1:1234"},
 		CACert:        testing.CACert,
 	}
@@ -118,6 +123,7 @@ func (s *externalControllerSuite) TestUpdateModels(c *gc.C) {
 func (s *externalControllerSuite) TestControllerForModel(c *gc.C) {
 	controllerInfo := crossmodel.ControllerInfo{
 		ControllerTag: testing.ControllerTag,
+		Alias:         "controller-alias",
 		Addrs:         []string{"192.168.1.0:1234", "10.0.0.1:1234"},
 		CACert:        testing.CACert,
 	}

--- a/state/machine.go
+++ b/state/machine.go
@@ -1458,7 +1458,7 @@ func (m *Machine) setPrivateAddressOps(providerAddresses []address, machineAddre
 	privateAddress := m.doc.PreferredPrivateAddress
 	// Always prefer an exact match if available.
 	checkScope := func(addr address) bool {
-		return network.ExactScopeMatch(addr.networkAddress(), network.ScopeMachineLocal, network.ScopeCloudLocal)
+		return network.ExactScopeMatch(addr.networkAddress(), network.ScopeMachineLocal, network.ScopeCloudLocal, network.ScopeFanLocal)
 	}
 	// Without an exact match, prefer a fallback match.
 	getAddr := func(addresses []address) network.Address {

--- a/state/machine_linklayerdevices.go
+++ b/state/machine_linklayerdevices.go
@@ -606,7 +606,6 @@ type LinkLayerDeviceAddress struct {
 // - ErrProviderIDNotUnique, when one or more specified ProviderIDs are not unique.
 func (m *Machine) SetDevicesAddresses(devicesAddresses ...LinkLayerDeviceAddress) (err error) {
 	defer errors.DeferredAnnotatef(&err, "cannot set link-layer device addresses of machine %q", m.doc.Id)
-
 	if len(devicesAddresses) == 0 {
 		logger.Debugf("no device addresses to set")
 		return nil

--- a/state/migration_export.go
+++ b/state/migration_export.go
@@ -1024,6 +1024,8 @@ func (e *exporter) subnets() error {
 			ProviderNetworkId: string(subnet.ProviderNetworkId()),
 			VLANTag:           subnet.VLANTag(),
 			SpaceName:         subnet.SpaceName(),
+			FanLocalUnderlay:  subnet.FanLocalUnderlay(),
+			FanOverlay:        subnet.FanOverlay(),
 		}
 		// TODO(babbageclunk): at the moment state.Subnet only stores
 		// one AZ.

--- a/state/migration_export_test.go
+++ b/state/migration_export_test.go
@@ -753,6 +753,8 @@ func (s *MigrationExportSuite) TestSubnets(c *gc.C) {
 		VLANTag:           64,
 		AvailabilityZone:  "bar",
 		SpaceName:         "bam",
+		FanLocalUnderlay:  "100.2.0.0/16",
+		FanOverlay:        "253.0.0.0/8",
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	_, err = s.State.AddSpace("bam", "", nil, true)
@@ -770,6 +772,8 @@ func (s *MigrationExportSuite) TestSubnets(c *gc.C) {
 	c.Assert(subnet.VLANTag(), gc.Equals, 64)
 	c.Assert(subnet.AvailabilityZones(), gc.DeepEquals, []string{"bar"})
 	c.Assert(subnet.SpaceName(), gc.Equals, "bam")
+	c.Assert(subnet.FanLocalUnderlay(), gc.Equals, "100.2.0.0/16")
+	c.Assert(subnet.FanOverlay(), gc.Equals, "253.0.0.0/8")
 }
 
 func (s *MigrationExportSuite) TestIPAddresses(c *gc.C) {

--- a/state/migration_import.go
+++ b/state/migration_import.go
@@ -1264,6 +1264,8 @@ func (i *importer) subnets() error {
 			ProviderNetworkId: network.Id(subnet.ProviderNetworkId()),
 			VLANTag:           subnet.VLANTag(),
 			SpaceName:         subnet.SpaceName(),
+			FanLocalUnderlay:  subnet.FanLocalUnderlay(),
+			FanOverlay:        subnet.FanOverlay(),
 		}
 		// TODO(babbageclunk): at the moment state.Subnet only stores
 		// one AZ.

--- a/state/migration_import_test.go
+++ b/state/migration_import_test.go
@@ -869,6 +869,8 @@ func (s *MigrationImportSuite) TestSubnets(c *gc.C) {
 		VLANTag:           64,
 		AvailabilityZone:  "bar",
 		SpaceName:         "bam",
+		FanLocalUnderlay:  "100.2.0.0/16",
+		FanOverlay:        "253.0.0.0/8",
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	_, err = s.State.AddSpace("bam", "", nil, true)
@@ -885,6 +887,8 @@ func (s *MigrationImportSuite) TestSubnets(c *gc.C) {
 	c.Assert(subnet.VLANTag(), gc.Equals, 64)
 	c.Assert(subnet.AvailabilityZone(), gc.Equals, "bar")
 	c.Assert(subnet.SpaceName(), gc.Equals, "bam")
+	c.Assert(subnet.FanLocalUnderlay(), gc.Equals, "100.2.0.0/16")
+	c.Assert(subnet.FanOverlay(), gc.Equals, "253.0.0.0/8")
 }
 
 func (s *MigrationImportSuite) TestIPAddress(c *gc.C) {

--- a/state/migration_internal_test.go
+++ b/state/migration_internal_test.go
@@ -617,6 +617,8 @@ func (s *MigrationSuite) TestSubnetDocFields(c *gc.C) {
 		"ProviderId",
 		"AvailabilityZone",
 		"ProviderNetworkId",
+		"FanLocalUnderlay",
+		"FanOverlay",
 	)
 	s.AssertExportedFields(c, subnetDoc{}, migrated.Union(ignored))
 }

--- a/state/offerconnections.go
+++ b/state/offerconnections.go
@@ -191,6 +191,23 @@ func (st *State) OfferConnectionForRelation(relationKey string) (*OfferConnectio
 	return newOfferConnection(st, &connDoc), nil
 }
 
+// OfferConnectionsForUser returns the offer connections for the specified user.
+func (st *State) OfferConnectionsForUser(username string) ([]*OfferConnection, error) {
+	offerConnectionCollection, closer := st.db().GetCollection(offerConnectionsC)
+	defer closer()
+
+	var connDocs []offerConnectionDoc
+	err := offerConnectionCollection.Find(bson.D{{"username", username}}).All(&connDocs)
+	if err != nil {
+		return nil, errors.Annotatef(err, "cannot get offer connection details for user %q", username)
+	}
+	conns := make([]*OfferConnection, len(connDocs))
+	for i, oc := range connDocs {
+		conns[i] = newOfferConnection(st, &oc)
+	}
+	return conns, nil
+}
+
 // RemoteConnectionStatus returns summary information about connections to the specified offer.
 func (st *State) RemoteConnectionStatus(offerUUID string) (*RemoteConnectionStatus, error) {
 	conns, err := st.OfferConnections(offerUUID)

--- a/state/offerconnections_test.go
+++ b/state/offerconnections_test.go
@@ -143,3 +143,27 @@ func (s *offerConnectionsSuite) TestOfferConnectionForRelation(c *gc.C) {
 	c.Assert(obtained.RelationKey(), gc.Equals, oc.RelationKey())
 	c.Assert(obtained.OfferUUID(), gc.Equals, oc.OfferUUID())
 }
+
+func (s *offerConnectionsSuite) TestOfferConnectionsForUser(c *gc.C) {
+	oc, err := s.State.AddOfferConnection(state.AddOfferConnectionParams{
+		SourceModelUUID: testing.ModelTag.Id(),
+		RelationId:      s.activeRel.Id(),
+		RelationKey:     s.activeRel.Tag().Id(),
+		Username:        "fred",
+		OfferUUID:       "offer-uuid",
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	anotherState, err := s.State.ForModel(s.IAASModel.ModelTag())
+	c.Assert(err, jc.ErrorIsNil)
+	defer anotherState.Close()
+
+	obtained, err := anotherState.OfferConnectionsForUser("mary")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(obtained, gc.HasLen, 0)
+	obtained, err = anotherState.OfferConnectionsForUser("fred")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(obtained, gc.HasLen, 1)
+	c.Assert(obtained[0].OfferUUID(), gc.Equals, oc.OfferUUID())
+	c.Assert(obtained[0].UserName(), gc.Equals, oc.UserName())
+}

--- a/state/presence/export_test.go
+++ b/state/presence/export_test.go
@@ -46,3 +46,10 @@ func (dr *directRecorder) Ping(modelUUID string, slot int64, fieldKey string, fi
 		})
 	return err
 }
+
+// ForceInc forces the PingBatcher to use $inc instead of $bit operations
+// This exists to test the code path that runs when using Mongo 2.4 and older.
+func (pb *PingBatcher) ForceUpdatesUsingInc() {
+	logger.Debugf("forcing $inc operations from (was %t)", pb.useInc)
+	pb.useInc = true
+}

--- a/state/presence/pingbatcher_test.go
+++ b/state/presence/pingbatcher_test.go
@@ -61,10 +61,7 @@ func (s *PingBatcherSuite) TearDownTest(c *gc.C) {
 	presence.RealPeriod()
 }
 
-func (s *PingBatcherSuite) TestRecordsPings(c *gc.C) {
-	pb := presence.NewPingBatcher(s.presence, time.Second)
-	defer assertStopped(c, pb)
-
+func (s *PingBatcherSuite) assertPingsRecorded(c *gc.C, pb *presence.PingBatcher) {
 	// UnixNano time rounded to 30s interval
 	slot := int64(1497960150)
 	c.Assert(pb.Ping("test-uuid", slot, "0", 8), jc.ErrorIsNil)
@@ -80,6 +77,18 @@ func (s *PingBatcherSuite) TestRecordsPings(c *gc.C) {
 		"0": int64(24),
 		"1": int64(129),
 	})
+}
+func (s *PingBatcherSuite) TestRecordsPings(c *gc.C) {
+	pb := presence.NewPingBatcher(s.presence, time.Second)
+	defer assertStopped(c, pb)
+	s.assertPingsRecorded(c, pb)
+}
+
+func (s *PingBatcherSuite) TestRecordsPingsUsingInc(c *gc.C) {
+	pb := presence.NewPingBatcher(s.presence, time.Second)
+	pb.ForceUpdatesUsingInc()
+	defer assertStopped(c, pb)
+	s.assertPingsRecorded(c, pb)
 }
 
 func (s *PingBatcherSuite) TestMultipleUUIDs(c *gc.C) {

--- a/state/remoteapplication_test.go
+++ b/state/remoteapplication_test.go
@@ -96,15 +96,14 @@ func (s *remoteApplicationSuite) SetUpTest(c *gc.C) {
 	mac, err := macaroon.New(nil, "test", "")
 	c.Assert(err, jc.ErrorIsNil)
 	s.application, err = s.State.AddRemoteApplication(state.AddRemoteApplicationParams{
-		Name:            "mysql",
-		URL:             "me/model.mysql",
-		SourceModel:     s.IAASModel.ModelTag(),
-		Token:           "app-token",
-		IsConsumerProxy: true,
-		Endpoints:       eps,
-		Spaces:          spaces,
-		Bindings:        bindings,
-		Macaroon:        mac,
+		Name:        "mysql",
+		URL:         "me/model.mysql",
+		SourceModel: s.IAASModel.ModelTag(),
+		Token:       "app-token",
+		Endpoints:   eps,
+		Spaces:      spaces,
+		Bindings:    bindings,
+		Macaroon:    mac,
 	})
 	c.Assert(err, jc.ErrorIsNil)
 }
@@ -124,15 +123,27 @@ func (s *remoteApplicationSuite) assertApplicationRelations(c *gc.C, svc *state.
 	return rels
 }
 
+func (s *remoteApplicationSuite) TestNoStatusForConsumerProxy(c *gc.C) {
+	application, err := s.State.AddRemoteApplication(state.AddRemoteApplicationParams{
+		Name:            "hosted-mysql",
+		URL:             "me/model.mysql",
+		SourceModel:     s.IAASModel.ModelTag(),
+		Token:           "app-token",
+		IsConsumerProxy: true,
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	_, err = application.Status()
+	c.Assert(err, jc.Satisfies, errors.IsNotFound)
+}
+
 func (s *remoteApplicationSuite) TestInitialStatus(c *gc.C) {
 	appStatus, err := s.application.Status()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(appStatus.Since, gc.NotNil)
 	appStatus.Since = nil
 	c.Assert(appStatus, gc.DeepEquals, status.StatusInfo{
-		Status:  status.Unknown,
-		Message: "waiting for remote connection",
-		Data:    map[string]interface{}{},
+		Status: status.Unknown,
+		Data:   map[string]interface{}{},
 	})
 }
 

--- a/state/spacesdiscovery_test.go
+++ b/state/spacesdiscovery_test.go
@@ -46,7 +46,7 @@ var twoSubnets = []network.SubnetInfo{
 	{
 		ProviderId:        "2",
 		AvailabilityZones: []string{"3", "4"},
-		CIDR:              "10.100.0.1/24",
+		CIDR:              "10.100.30.1/24",
 	},
 }
 
@@ -72,7 +72,7 @@ var fourSubnets = []network.SubnetInfo{
 	{
 		ProviderId:        "2",
 		AvailabilityZones: []string{"3", "4"},
-		CIDR:              "10.100.0.1/24",
+		CIDR:              "10.100.30.1/24",
 	},
 	{
 		ProviderId:        "3",
@@ -102,6 +102,32 @@ var spaceTwo = []network.SpaceInfo{
 }
 
 var twoSpaces = []network.SpaceInfo{spaceOne[0], spaceTwo[0]}
+
+var twoSubnetsAfterFAN = []network.SubnetInfo{
+	{
+		ProviderId:        "1",
+		AvailabilityZones: []string{"1", "2"},
+		CIDR:              "10.0.0.1/24",
+	},
+	{
+		ProviderId:        "2",
+		AvailabilityZones: []string{"3", "4"},
+		CIDR:              "10.100.30.1/24",
+	},
+	{
+		ProviderId:        "2-INFAN-10-100-30-0-24",
+		AvailabilityZones: []string{"3", "4"},
+		CIDR:              "253.30.0.0/16",
+	},
+}
+
+var spaceOneAfterFAN = []network.SpaceInfo{
+	{
+		Name:       "space1",
+		ProviderId: "1",
+		Subnets:    twoSubnetsAfterFAN,
+	},
+}
 
 func checkSubnetsEqual(c *gc.C, subnets []*state.Subnet, subnetInfos []network.SubnetInfo) {
 	c.Assert(len(subnetInfos), gc.Equals, len(subnets))
@@ -339,4 +365,39 @@ func (s *SpacesDiscoverySuite) TestReloadSpacesIdempotent(c *gc.C) {
 	spaces2, err := s.State.AllSpaces()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(spaces1, gc.DeepEquals, spaces2)
+}
+
+func (s *SpacesDiscoverySuite) TestReloadSubnetsWithFAN(c *gc.C) {
+	s.environ = networkedEnviron{
+		stub:           &testing.Stub{},
+		spaceDiscovery: false,
+		subnets:        twoSubnets,
+	}
+	s.usedEnviron = &s.environ
+
+	s.State.UpdateModelConfig(map[string]interface{}{"fan-config": "10.100.0.0/16=253.0.0.0/8"}, nil)
+	err := s.State.ReloadSpaces(s.usedEnviron)
+	c.Assert(err, jc.ErrorIsNil)
+
+	subnets, err := s.State.AllSubnets()
+	c.Assert(err, jc.ErrorIsNil)
+
+	checkSubnetsEqual(c, subnets, twoSubnetsAfterFAN)
+}
+
+func (s *SpacesDiscoverySuite) TestReloadSpacesWithFAN(c *gc.C) {
+	s.environ = networkedEnviron{
+		stub:           &testing.Stub{},
+		spaceDiscovery: true,
+		spaces:         spaceOne,
+	}
+	s.usedEnviron = &s.environ
+
+	s.State.UpdateModelConfig(map[string]interface{}{"fan-config": "10.100.0.0/16=253.0.0.0/8"}, nil)
+	err := s.State.ReloadSpaces(s.usedEnviron)
+	c.Assert(err, jc.ErrorIsNil)
+
+	spaces, err := s.State.AllSpaces()
+	c.Assert(err, jc.ErrorIsNil)
+	checkSpacesEqual(c, spaces, spaceOneAfterFAN)
 }

--- a/state/subnets.go
+++ b/state/subnets.go
@@ -38,6 +38,13 @@ type SubnetInfo struct {
 	// SpaceName is the name of the space the subnet is associated with. It
 	// can be empty if the subnet is not associated with a space yet.
 	SpaceName string
+
+	// FanUnderlay is the CIDR of the local underlaying fan network, it allows easy
+	// identification of the device the FAN is running on. Empty if not a FAN subnet.
+	FanLocalUnderlay string
+
+	// FanOverlay is the CIDR of the complete FAN setup. Empty if not a FAN subnet.
+	FanOverlay string
 }
 
 type Subnet struct {
@@ -56,8 +63,10 @@ type subnetDoc struct {
 	AvailabilityZone  string `bson:"availabilityzone,omitempty"`
 	// TODO: add IsPublic to SubnetArgs, add an IsPublic method and add
 	// IsPublic to migration import/export.
-	IsPublic  bool   `bson:"is-public,omitempty"`
-	SpaceName string `bson:"space-name,omitempty"`
+	IsPublic         bool   `bson:"is-public,omitempty"`
+	SpaceName        string `bson:"space-name,omitempty"`
+	FanLocalUnderlay string `bson:"fan-local-underlay,omitempty"`
+	FanOverlay       string `bson:"fan-overlay,omitempty"`
 }
 
 // Life returns whether the subnet is Alive, Dying or Dead.
@@ -78,6 +87,14 @@ func (s *Subnet) String() string {
 // GoString implements fmt.GoStringer.
 func (s *Subnet) GoString() string {
 	return s.String()
+}
+
+func (s *Subnet) FanOverlay() string {
+	return s.doc.FanOverlay
+}
+
+func (s *Subnet) FanLocalUnderlay() string {
+	return s.doc.FanLocalUnderlay
 }
 
 // EnsureDead sets the Life of the subnet to Dead, if it's Alive. If the subnet
@@ -249,6 +266,8 @@ func (st *State) newSubnetFromArgs(args SubnetInfo) (*Subnet, error) {
 		ProviderNetworkId: string(args.ProviderNetworkId),
 		AvailabilityZone:  args.AvailabilityZone,
 		SpaceName:         args.SpaceName,
+		FanLocalUnderlay:  args.FanLocalUnderlay,
+		FanOverlay:        args.FanOverlay,
 	}
 	subnet := &Subnet{doc: subDoc, st: st}
 	err := subnet.Validate()
@@ -270,6 +289,8 @@ func (st *State) addSubnetOps(args SubnetInfo) []txn.Op {
 		ProviderNetworkId: string(args.ProviderNetworkId),
 		AvailabilityZone:  args.AvailabilityZone,
 		SpaceName:         args.SpaceName,
+		FanLocalUnderlay:  args.FanLocalUnderlay,
+		FanOverlay:        args.FanOverlay,
 	}
 	ops := []txn.Op{
 		{

--- a/state/subnets_test.go
+++ b/state/subnets_test.go
@@ -27,6 +27,8 @@ func (s *SubnetSuite) TestAddSubnetSucceedsWithFullyPopulatedInfo(c *gc.C) {
 		AvailabilityZone:  "Timbuktu",
 		SpaceName:         "foo",
 		ProviderNetworkId: "wildbirds",
+		FanLocalUnderlay:  "10.0.0.0/8",
+		FanOverlay:        "172.16.0.0/16",
 	}
 
 	subnet, err := s.State.AddSubnet(subnetInfo)
@@ -48,6 +50,8 @@ func (s *SubnetSuite) assertSubnetMatchesInfo(c *gc.C, subnet *state.Subnet, inf
 	c.Assert(subnet.GoString(), gc.Equals, info.CIDR)
 	c.Assert(subnet.SpaceName(), gc.Equals, info.SpaceName)
 	c.Assert(subnet.ProviderNetworkId(), gc.Equals, info.ProviderNetworkId)
+	c.Assert(subnet.FanLocalUnderlay(), gc.Equals, info.FanLocalUnderlay)
+	c.Assert(subnet.FanOverlay(), gc.Equals, info.FanOverlay)
 }
 
 func (s *SubnetSuite) TestAddSubnetFailsWithEmptyCIDR(c *gc.C) {

--- a/version/version.go
+++ b/version/version.go
@@ -19,7 +19,7 @@ import (
 // The presence and format of this constant is very important.
 // The debian/rules build recipe uses this value for the version
 // number of the release package.
-const version = "2.3-alpha1"
+const version = "2.3-beta1"
 
 // The version that we switched over from old style numbering to new style.
 var switchOverVersion = semversion.MustParse("1.19.9")

--- a/version/version.go
+++ b/version/version.go
@@ -19,7 +19,7 @@ import (
 // The presence and format of this constant is very important.
 // The debian/rules build recipe uses this value for the version
 // number of the release package.
-const version = "2.3-beta1"
+const version = "2.3-beta2"
 
 // The version that we switched over from old style numbering to new style.
 var switchOverVersion = semversion.MustParse("1.19.9")

--- a/worker/fanconfigurer/fanconfigurer.go
+++ b/worker/fanconfigurer/fanconfigurer.go
@@ -1,0 +1,128 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package fanconfigurer
+
+import (
+	"fmt"
+	"os"
+	"sync"
+	"time"
+
+	"github.com/juju/errors"
+	"github.com/juju/loggo"
+	"github.com/juju/utils/clock"
+
+	"github.com/juju/juju/network"
+	"github.com/juju/juju/utils/scriptrunner"
+	"github.com/juju/juju/watcher"
+	"github.com/juju/juju/worker/catacomb"
+)
+
+var logger = loggo.GetLogger("juju.worker.fanconfigurer")
+
+type FanConfigurer struct {
+	catacomb catacomb.Catacomb
+	config   FanConfigurerConfig
+	clock    clock.Clock
+	mu       sync.Mutex
+	enabled  bool
+}
+
+type FanConfigurerFacade interface {
+	FanConfig() (network.FanConfig, error)
+	WatchForFanConfigChanges() (watcher.NotifyWatcher, error)
+}
+
+type FanConfigurerConfig struct {
+	Facade FanConfigurerFacade
+}
+
+// processNewConfig acts on a new fan config.
+func (fc *FanConfigurer) processNewConfig() error {
+	logger.Debugf("Processing new fan config")
+	fc.mu.Lock()
+	defer fc.mu.Unlock()
+
+	fanConfig, err := fc.config.Facade.FanConfig()
+	if err != nil {
+		return err
+	}
+	if len(fanConfig) == 0 {
+		logger.Debugf("Fan not enabled")
+		// TODO(wpk) 2017-08-05 We have to clean this up!
+		return nil
+	}
+
+	for i, fan := range fanConfig {
+		logger.Debugf("Adding config for %d: %s %s", i, fan.Underlay, fan.Overlay)
+		line := fmt.Sprintf("fanatic enable-fan -u %s -o %s", fan.Underlay, fan.Overlay)
+		result, err := scriptrunner.RunCommand(line, os.Environ(), fc.clock, 5000*time.Millisecond)
+		logger.Debugf("Launched %s - result %v %v %d", line, string(result.Stdout), string(result.Stderr), result.Code)
+		if err != nil {
+			return err
+		}
+	}
+	// TODO(wpk) 2017-09-28 Although officially not needed we do fanctl up -a just to be sure -
+	// fanatic sometimes fails to bring up interface because of some weird interactions with iptables.
+	result, err := scriptrunner.RunCommand("fanctl up -a", os.Environ(), fc.clock, 5000*time.Millisecond)
+	logger.Debugf("Launched fanctl up -a - result %v %v %d", string(result.Stdout), string(result.Stderr), result.Code)
+
+	return err
+}
+
+func NewFanConfigurer(config FanConfigurerConfig, clock clock.Clock) (*FanConfigurer, error) {
+	fc := &FanConfigurer{
+		config: config,
+		clock:  clock,
+	}
+	// We need to launch it once here to make sure that it's configured right away,
+	// so that machiner will have a proper fan device address to report back
+	// to controller.
+	err := fc.processNewConfig()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	err = catacomb.Invoke(catacomb.Plan{
+		Site: &fc.catacomb,
+		Work: fc.loop,
+	})
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return fc, nil
+}
+
+func (fc *FanConfigurer) loop() error {
+	configWatcher, err := fc.config.Facade.WatchForFanConfigChanges()
+	if err != nil {
+		return errors.Trace(err)
+	}
+	if err := fc.catacomb.Add(configWatcher); err != nil {
+		return errors.Trace(err)
+	}
+
+	for {
+		select {
+		case <-fc.catacomb.Dying():
+			return fc.catacomb.ErrDying()
+		case _, ok := <-configWatcher.Changes():
+			if !ok {
+				return errors.New("FAN configuration watcher closed")
+			}
+			if err = fc.processNewConfig(); err != nil {
+				return errors.Trace(err)
+			}
+		}
+	}
+}
+
+// Kill implements Worker.Kill()
+func (fc *FanConfigurer) Kill() {
+	fc.catacomb.Kill(nil)
+}
+
+// Wait implements Worker.Wait()
+func (fc *FanConfigurer) Wait() error {
+	return fc.catacomb.Wait()
+}

--- a/worker/fanconfigurer/manifold.go
+++ b/worker/fanconfigurer/manifold.go
@@ -1,0 +1,58 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package fanconfigurer
+
+import (
+	"github.com/juju/errors"
+	worker "gopkg.in/juju/worker.v1"
+
+	"github.com/juju/juju/api/base"
+	apifanconfigurer "github.com/juju/juju/api/fanconfigurer"
+	"github.com/juju/juju/worker/dependency"
+	"github.com/juju/utils/clock"
+)
+
+// ManifoldConfig defines the names of the manifolds on which a
+// Manifold will depend.
+type ManifoldConfig struct {
+	// These are the dependency resource names.
+	APICallerName string
+	Clock         clock.Clock
+}
+
+// Manifold returns a dependency manifold that runs a fan configurer
+// worker, using the resource names defined in the supplied config.
+func Manifold(config ManifoldConfig) dependency.Manifold {
+	return dependency.Manifold{
+		Inputs: []string{
+			config.APICallerName,
+		},
+		Output: func(in worker.Worker, out interface{}) error {
+			inWorker, _ := in.(*FanConfigurer)
+			if inWorker == nil {
+				return errors.Errorf("in should be a %T; got %T", inWorker, in)
+			}
+			switch outPointer := out.(type) {
+			case *bool:
+				*outPointer = true
+			default:
+				return errors.Errorf("out should be *bool; got %T", out)
+			}
+			return nil
+		},
+		Start: func(context dependency.Context) (worker.Worker, error) {
+			var apiCaller base.APICaller
+			if err := context.Get(config.APICallerName, &apiCaller); err != nil {
+				return nil, errors.Trace(err)
+			}
+
+			facade := apifanconfigurer.NewFacade(apiCaller)
+
+			fanconfigurer, err := NewFanConfigurer(FanConfigurerConfig{
+				Facade: facade,
+			}, config.Clock)
+			return fanconfigurer, errors.Annotate(err, "creating fanconfigurer orchestrator")
+		},
+	}
+}

--- a/worker/fanconfigurer/package_test.go
+++ b/worker/fanconfigurer/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package fanconfigurer_test
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func Test(t *testing.T) {
+	gc.TestingT(t)
+}

--- a/worker/firewaller/firewaller.go
+++ b/worker/firewaller/firewaller.go
@@ -1267,6 +1267,10 @@ func (fw *Firewaller) startRelation(rel *params.RemoteRelation, role charm.Relat
 	if err != nil {
 		return errors.Trace(err)
 	}
+	remoteAppResult := remoteApps[0]
+	if remoteAppResult.Error != nil {
+		return errors.Trace(err)
+	}
 
 	tag := names.NewRelationTag(rel.Key)
 	data := &remoteRelationData{
@@ -1294,7 +1298,7 @@ func (fw *Firewaller) startRelation(rel *params.RemoteRelation, role charm.Relat
 		return errors.Trace(err)
 	}
 
-	data.isOffer = remoteApps[0].Result.Registered
+	data.isOffer = remoteAppResult.Result.IsConsumerProxy
 	return fw.startRelationPoller(rel.Key, rel.RemoteApplicationName, data.relationReady)
 }
 

--- a/worker/remoterelations/mock_test.go
+++ b/worker/remoterelations/mock_test.go
@@ -201,7 +201,7 @@ func (m *mockRelationsFacade) Relations(keys []string) ([]params.RemoteRelationR
 			result[i].Result = &params.RemoteRelation{
 				Id:        rel.id,
 				Life:      rel.life,
-				Suspended: rel.suspended,
+				Suspended: rel.Suspended(),
 				Key:       keys[i],
 			}
 			if epInfo, ok := m.relationsEndpoints[key]; ok {
@@ -465,6 +465,7 @@ func (r *mockRemoteApplication) Life() params.Life {
 
 type mockRelation struct {
 	testing.Stub
+	sync.Mutex
 	id        int
 	life      params.Life
 	suspended bool
@@ -488,6 +489,14 @@ func (r *mockRelation) Life() params.Life {
 }
 
 func (r *mockRelation) Suspended() bool {
+	r.Lock()
+	defer r.Unlock()
 	r.MethodCall(r, "Suspended")
 	return r.suspended
+}
+
+func (r *mockRelation) SetSuspended(suspended bool) {
+	r.Lock()
+	defer r.Unlock()
+	r.suspended = suspended
 }

--- a/worker/remoterelations/mock_test.go
+++ b/worker/remoterelations/mock_test.go
@@ -166,13 +166,12 @@ func (m *mockRelationsFacade) RemoteApplications(names []string) ([]params.Remot
 		if app, ok := m.remoteApplications[name]; ok {
 			result[i] = params.RemoteApplicationResult{
 				Result: &params.RemoteApplication{
-					Name:       app.name,
-					OfferUUID:  app.offeruuid,
-					Life:       app.life,
-					Status:     app.status,
-					ModelUUID:  app.modelUUID,
-					Registered: app.registered,
-					Macaroon:   mac,
+					Name:            app.name,
+					OfferUUID:       app.offeruuid,
+					Life:            app.life,
+					ModelUUID:       app.modelUUID,
+					IsConsumerProxy: app.registered,
+					Macaroon:        mac,
 				},
 			}
 		} else {
@@ -402,7 +401,6 @@ type mockRemoteApplication struct {
 	offeruuid  string
 	url        string
 	life       params.Life
-	status     string
 	modelUUID  string
 	registered bool
 }

--- a/worker/remoterelations/remoterelations_test.go
+++ b/worker/remoterelations/remoterelations_test.go
@@ -439,7 +439,7 @@ func (s *remoteRelationsSuite) TestRemoteRelationSuspended(c *gc.C) {
 	s.stub.ResetCalls()
 
 	// First suspend the relation.
-	s.relationsFacade.relations["db2:db django:db"].suspended = true
+	s.relationsFacade.relations["db2:db django:db"].SetSuspended(true)
 	relWatcher, _ := s.relationsFacade.remoteApplicationRelationsWatcher("db2")
 	relWatcher.changes <- []string{"db2:db django:db"}
 
@@ -450,7 +450,7 @@ func (s *remoteRelationsSuite) TestRemoteRelationSuspended(c *gc.C) {
 	s.stub.ResetCalls()
 
 	// Now resume the relation.
-	s.relationsFacade.relations["db2:db django:db"].suspended = false
+	s.relationsFacade.relations["db2:db django:db"].SetSuspended(false)
 	relWatcher.changes <- []string{"db2:db django:db"}
 
 	mac, err := macaroon.New(nil, "test", "")


### PR DESCRIPTION
## Description of change\
Why is this change needed? This change allows us to build with go-1.9, which will be required for new changes going forward.

## QA steps

The merge jobs have been updated as part of the PR to build with go-1.9. The readme and other docs also now mention go-1.9. Once this PR passes, builds should be good to go.