### PR TITLE
Add a few extra lines of logging at bootstrap time

### DIFF
--- a/cmd/juju/common/controller.go
+++ b/cmd/juju/common/controller.go
@@ -84,9 +84,9 @@ func WaitForAgentInitialisation(ctx *cmd.Context, c *modelcmd.ModelCommandBase, 
 	for attempt := attempts.Start(); attempt.Next(); apiAttempts++ {
 		err = tryAPI(c)
 		if err == nil {
-			ctx.Infof("Bootstrap complete, %q controller now available.", controllerName)
-			ctx.Infof("Controller machines are in the %q model.", bootstrap.ControllerModelName)
-			ctx.Infof("Initial model %q added.", hostedModelName)
+			ctx.Infof("Bootstrap complete, %q controller now available", controllerName)
+			ctx.Infof("Controller machines are in the %q model", bootstrap.ControllerModelName)
+			ctx.Infof("Initial model %q added", hostedModelName)
 			break
 		}
 		// As the API server is coming up, it goes through a number of steps.

--- a/environs/bootstrap/bootstrap.go
+++ b/environs/bootstrap/bootstrap.go
@@ -390,7 +390,7 @@ func Bootstrap(ctx environs.BootstrapContext, environ environs.Environ, args Boo
 		return err
 	}
 
-	logger.Infof("Installing Juju agent on bootstrap instance")
+	ctx.Infof("Installing Juju agent on bootstrap instance")
 	publicKey, err := userPublicSigningKey()
 	if err != nil {
 		return err

--- a/provider/common/bootstrap.go
+++ b/provider/common/bootstrap.go
@@ -148,7 +148,7 @@ func BootstrapInstance(ctx environs.BootstrapContext, env environs.Environ, args
 	if args.CloudRegion != "" {
 		cloudRegion += "/" + args.CloudRegion
 	}
-	fmt.Fprintf(ctx.GetStderr(), "Launching controller instance(s) on %s...\n", cloudRegion)
+	ctx.Infof("Launching controller instance(s) on %s...", cloudRegion)
 	// Print instance status reports status changes during provisioning.
 	// Note the carriage returns, meaning subsequent prints are to the same
 	// line of stderr, not a new line.
@@ -191,7 +191,7 @@ func BootstrapInstance(ctx environs.BootstrapContext, env environs.Environ, args
 		padding := make([]string, 40-len(msg))
 		msg += strings.Join(padding, " ")
 	}
-	fmt.Fprintln(ctx.GetStderr(), msg)
+	ctx.Infof(msg)
 
 	finalize := func(ctx environs.BootstrapContext, icfg *instancecfg.InstanceConfig, opts environs.BootstrapDialOpts) error {
 		icfg.Bootstrap.BootstrapMachineInstanceId = result.Instance.Id()
@@ -268,6 +268,7 @@ var FinishBootstrap = func(
 	if err != nil {
 		return err
 	}
+	ctx.Infof("Connected to %v", addr)
 
 	sshOptions, cleanup, err := hostSSHOptions(addr)
 	if err != nil {
@@ -334,6 +335,7 @@ func ConfigureMachine(
 		return err
 	}
 	script := shell.DumpFileOnErrorScript(instanceConfig.CloudInitOutputLog) + configScript
+	ctx.Infof("Running machine configuration script...")
 	return sshinit.RunConfigureScript(script, sshinit.ConfigureParams{
 		Host:           "ubuntu@" + host,
 		Client:         client,


### PR DESCRIPTION
## Description of change

Add a few extra lines of logging when bootstrapping.
Also make the lines consistent with respect to printing "." at the end.

## QA steps

$ juju bootstrap 
Creating Juju controller "foo" on lxd
Looking for packaged Juju agent version 2.3-alpha1 for amd64
No packaged binary found, preparing local Juju agent binary
Launching controller instance(s) on lxd...
 - juju-e5e34f-0 (arch=amd64)          
Installing Juju agent on bootstrap instance
Fetching Juju GUI 2.9.2
Waiting for address
Attempting to connect to 10.200.103.72:22
Connected to 10.200.103.72
Running machine configuration script...
Bootstrap agent now started
Contacting Juju controller at 10.200.103.72 to verify accessibility...
Bootstrap complete, "foo" controller now available
Controller machines are in the "controller" model
Initial model "default" added

## Bug reference

https://bugs.launchpad.net/juju/+bug/1716730
