### PR TITLE
juju offers supports filtering by user

### DIFF
--- a/api/applicationoffers/client.go
+++ b/api/applicationoffers/client.go
@@ -58,17 +58,24 @@ func (c *Client) Offer(modelUUID, application string, endpoints []string, offerN
 func (c *Client) ListOffers(filters ...crossmodel.ApplicationOfferFilter) ([]*crossmodel.ApplicationOfferDetails, error) {
 	var paramsFilter params.OfferFilters
 	for _, f := range filters {
-		// TODO(wallyworld) - include allowed users
 		filterTerm := params.OfferFilter{
-			ModelName:       f.ModelName,
-			OfferName:       f.OfferName,
-			ApplicationName: f.ApplicationName,
+			ModelName:           f.ModelName,
+			OfferName:           f.OfferName,
+			ApplicationName:     f.ApplicationName,
+			Endpoints:           make([]params.EndpointFilterAttributes, len(f.Endpoints)),
+			AllowedConsumerTags: make([]string, len(f.AllowedConsumers)),
+			ConnectedUserTags:   make([]string, len(f.ConnectedUsers)),
 		}
-		filterTerm.Endpoints = make([]params.EndpointFilterAttributes, len(f.Endpoints))
 		for i, ep := range f.Endpoints {
 			filterTerm.Endpoints[i].Name = ep.Name
 			filterTerm.Endpoints[i].Interface = ep.Interface
 			filterTerm.Endpoints[i].Role = ep.Role
+		}
+		for i, u := range f.AllowedConsumers {
+			filterTerm.AllowedConsumerTags[i] = names.NewUserTag(u).String()
+		}
+		for i, u := range f.ConnectedUsers {
+			filterTerm.ConnectedUserTags[i] = names.NewUserTag(u).String()
 		}
 		paramsFilter.Filters = append(paramsFilter.Filters, filterTerm)
 	}

--- a/api/applicationoffers/client_test.go
+++ b/api/applicationoffers/client_test.go
@@ -105,10 +105,12 @@ func (s *crossmodelMockSuite) TestList(c *gc.C) {
 	relations := []jujucrossmodel.EndpointFilterTerm{{Name: "endPointA", Interface: "http"}}
 
 	filter := jujucrossmodel.ApplicationOfferFilter{
-		OfferName: offerName,
-		Endpoints: relations,
+		OfferName:        offerName,
+		Endpoints:        relations,
+		ApplicationName:  "mysql",
+		AllowedConsumers: []string{"allowed"},
+		ConnectedUsers:   []string{"connected"},
 	}
-
 	called := false
 	since := time.Now()
 	apiCaller := basetesting.APICallerFunc(
@@ -132,6 +134,8 @@ func (s *crossmodelMockSuite) TestList(c *gc.C) {
 					Name:      "endPointA",
 					Interface: "http",
 				}},
+				AllowedConsumerTags: []string{"user-allowed"},
+				ConnectedUserTags:   []string{"user-connected"},
 			})
 
 			if results, ok := result.(*params.QueryApplicationOffersResults); ok {

--- a/apiserver/params/crossmodel.go
+++ b/apiserver/params/crossmodel.go
@@ -35,7 +35,8 @@ type OfferFilter struct {
 	ApplicationDescription string                     `json:"application-description"`
 	ApplicationUser        string                     `json:"application-user"`
 	Endpoints              []EndpointFilterAttributes `json:"endpoints"`
-	AllowedUserTags        []string                   `json:"allowed-users"`
+	ConnectedUserTags      []string                   `json:"connected-users"`
+	AllowedConsumerTags    []string                   `json:"allowed-users"`
 }
 
 // ApplicationOfferDetails represents an application offering from an external model.

--- a/cmd/juju/crossmodel/list_test.go
+++ b/cmd/juju/crossmodel/list_test.go
@@ -68,7 +68,8 @@ func (s *ListSuite) TestListError(c *gc.C) {
 }
 
 func (s *ListSuite) TestListFilterArgs(c *gc.C) {
-	_, err := s.runList(c, []string{"--interface", "mysql", "--application", "mysql-lite"})
+	_, err := s.runList(c, []string{
+		"--interface", "mysql", "--application", "mysql-lite", "--connected-user", "user", "--allowed-consumer", "consumer"})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(s.mockAPI.filters, gc.HasLen, 1)
 	c.Assert(s.mockAPI.filters[0], jc.DeepEquals, model.ApplicationOfferFilter{
@@ -78,6 +79,8 @@ func (s *ListSuite) TestListFilterArgs(c *gc.C) {
 		Endpoints: []model.EndpointFilterTerm{{
 			Interface: "mysql",
 		}},
+		ConnectedUsers:   []string{"user"},
+		AllowedConsumers: []string{"consumer"},
 	})
 }
 

--- a/core/crossmodel/interface.go
+++ b/core/crossmodel/interface.go
@@ -101,8 +101,11 @@ type ApplicationOfferFilter struct {
 	// Endpoint contains an endpoint filter criteria.
 	Endpoints []EndpointFilterTerm
 
-	// AllowedUsers are the users allowed to consume the application.
-	AllowedUsers []string
+	// AllowedConsumers are the users allowed to consume the offer.
+	AllowedConsumers []string
+
+	// ConnectedUsers are the users currently related to the offer.
+	ConnectedUsers []string
 }
 
 // EndpointFilterTerm represents a remote endpoint filter.

--- a/state/offerconnections.go
+++ b/state/offerconnections.go
@@ -191,6 +191,23 @@ func (st *State) OfferConnectionForRelation(relationKey string) (*OfferConnectio
 	return newOfferConnection(st, &connDoc), nil
 }
 
+// OfferConnectionsForUser returns the offer connections for the specified user.
+func (st *State) OfferConnectionsForUser(username string) ([]*OfferConnection, error) {
+	offerConnectionCollection, closer := st.db().GetCollection(offerConnectionsC)
+	defer closer()
+
+	var connDocs []offerConnectionDoc
+	err := offerConnectionCollection.Find(bson.D{{"username", username}}).All(&connDocs)
+	if err != nil {
+		return nil, errors.Annotatef(err, "cannot get offer connection details for user %q", username)
+	}
+	conns := make([]*OfferConnection, len(connDocs))
+	for i, oc := range connDocs {
+		conns[i] = newOfferConnection(st, &oc)
+	}
+	return conns, nil
+}
+
 // RemoteConnectionStatus returns summary information about connections to the specified offer.
 func (st *State) RemoteConnectionStatus(offerUUID string) (*RemoteConnectionStatus, error) {
 	conns, err := st.OfferConnections(offerUUID)

--- a/state/offerconnections_test.go
+++ b/state/offerconnections_test.go
@@ -143,3 +143,27 @@ func (s *offerConnectionsSuite) TestOfferConnectionForRelation(c *gc.C) {
 	c.Assert(obtained.RelationKey(), gc.Equals, oc.RelationKey())
 	c.Assert(obtained.OfferUUID(), gc.Equals, oc.OfferUUID())
 }
+
+func (s *offerConnectionsSuite) TestOfferConnectionsForUser(c *gc.C) {
+	oc, err := s.State.AddOfferConnection(state.AddOfferConnectionParams{
+		SourceModelUUID: testing.ModelTag.Id(),
+		RelationId:      s.activeRel.Id(),
+		RelationKey:     s.activeRel.Tag().Id(),
+		Username:        "fred",
+		OfferUUID:       "offer-uuid",
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	anotherState, err := s.State.ForModel(s.IAASModel.ModelTag())
+	c.Assert(err, jc.ErrorIsNil)
+	defer anotherState.Close()
+
+	obtained, err := anotherState.OfferConnectionsForUser("mary")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(obtained, gc.HasLen, 0)
+	obtained, err = anotherState.OfferConnectionsForUser("fred")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(obtained, gc.HasLen, 1)
+	c.Assert(obtained[0].OfferUUID(), gc.Equals, oc.OfferUUID())
+	c.Assert(obtained[0].UserName(), gc.Equals, oc.UserName())
+}


### PR DESCRIPTION
## Description of change

The juju offers command supports filtering by consumer and connected user, ie users who are allowed to consumer the offer or users who are connected to the offer.

## QA steps

bootstrap, create an offer, grant consumer to a user
make a connection to the offer
check that
$ juju offers --user fred
$ juju offers --consumer mary
behave as expected, and 
$ juju offers --user admin works out of the box without an explicit grant

## Documentation changes

CMR offers doc will be updated
