### PR TITLE
remote application on the offering side do not need status

### DIFF
--- a/apiserver/facades/controller/remoterelations/remoterelations.go
+++ b/apiserver/facades/controller/remoterelations/remoterelations.go
@@ -255,22 +255,17 @@ func (api *RemoteRelationsAPI) RemoteApplications(entities params.Entities) (par
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
-		status, err := remoteApp.Status()
-		if err != nil {
-			return nil, errors.Trace(err)
-		}
 		mac, err := remoteApp.Macaroon()
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
 		return &params.RemoteApplication{
-			Name:       remoteApp.Name(),
-			OfferUUID:  remoteApp.OfferUUID(),
-			Life:       params.Life(remoteApp.Life().String()),
-			Status:     status.Status.String(),
-			ModelUUID:  remoteApp.SourceModel().Id(),
-			Registered: remoteApp.IsConsumerProxy(),
-			Macaroon:   mac,
+			Name:            remoteApp.Name(),
+			OfferUUID:       remoteApp.OfferUUID(),
+			Life:            params.Life(remoteApp.Life().String()),
+			ModelUUID:       remoteApp.SourceModel().Id(),
+			IsConsumerProxy: remoteApp.IsConsumerProxy(),
+			Macaroon:        mac,
 		}, nil
 	}
 	for i, entity := range entities.Entities {

--- a/apiserver/params/crossmodel.go
+++ b/apiserver/params/crossmodel.go
@@ -210,17 +210,17 @@ type RemoteApplication struct {
 	OfferUUID string `json:"offer-uuid"`
 
 	// Life is the current lifecycle state of the application.
-	Life Life `json:"life"`
+	Life Life `json:"life,omitempty"`
 
 	// Status is the current status of the application.
-	Status string `json:"status"`
+	Status string `json:"status,omitempty"`
 
 	// ModelUUID is the UUId of the model hosting the application.
 	ModelUUID string `json:"model-uuid"`
 
-	// IsConsumerProxy returns the application is created
+	// IsConsumerProxy returns if the application is created
 	// from a registration operation by a consuming model.
-	Registered bool `json:"registered"`
+	IsConsumerProxy bool `json:"is-consumer-proxy"`
 
 	// Macaroon is used for authentication.
 	Macaroon *macaroon.Macaroon `json:"macaroon,omitempty"`

--- a/state/remoteapplication_test.go
+++ b/state/remoteapplication_test.go
@@ -96,15 +96,14 @@ func (s *remoteApplicationSuite) SetUpTest(c *gc.C) {
 	mac, err := macaroon.New(nil, "test", "")
 	c.Assert(err, jc.ErrorIsNil)
 	s.application, err = s.State.AddRemoteApplication(state.AddRemoteApplicationParams{
-		Name:            "mysql",
-		URL:             "me/model.mysql",
-		SourceModel:     s.IAASModel.ModelTag(),
-		Token:           "app-token",
-		IsConsumerProxy: true,
-		Endpoints:       eps,
-		Spaces:          spaces,
-		Bindings:        bindings,
-		Macaroon:        mac,
+		Name:        "mysql",
+		URL:         "me/model.mysql",
+		SourceModel: s.IAASModel.ModelTag(),
+		Token:       "app-token",
+		Endpoints:   eps,
+		Spaces:      spaces,
+		Bindings:    bindings,
+		Macaroon:    mac,
 	})
 	c.Assert(err, jc.ErrorIsNil)
 }
@@ -124,15 +123,27 @@ func (s *remoteApplicationSuite) assertApplicationRelations(c *gc.C, svc *state.
 	return rels
 }
 
+func (s *remoteApplicationSuite) TestNoStatusForConsumerProxy(c *gc.C) {
+	application, err := s.State.AddRemoteApplication(state.AddRemoteApplicationParams{
+		Name:            "hosted-mysql",
+		URL:             "me/model.mysql",
+		SourceModel:     s.IAASModel.ModelTag(),
+		Token:           "app-token",
+		IsConsumerProxy: true,
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	_, err = application.Status()
+	c.Assert(err, jc.Satisfies, errors.IsNotFound)
+}
+
 func (s *remoteApplicationSuite) TestInitialStatus(c *gc.C) {
 	appStatus, err := s.application.Status()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(appStatus.Since, gc.NotNil)
 	appStatus.Since = nil
 	c.Assert(appStatus, gc.DeepEquals, status.StatusInfo{
-		Status:  status.Unknown,
-		Message: "waiting for remote connection",
-		Data:    map[string]interface{}{},
+		Status: status.Unknown,
+		Data:   map[string]interface{}{},
 	})
 }
 

--- a/worker/firewaller/firewaller.go
+++ b/worker/firewaller/firewaller.go
@@ -1267,6 +1267,10 @@ func (fw *Firewaller) startRelation(rel *params.RemoteRelation, role charm.Relat
 	if err != nil {
 		return errors.Trace(err)
 	}
+	remoteAppResult := remoteApps[0]
+	if remoteAppResult.Error != nil {
+		return errors.Trace(err)
+	}
 
 	tag := names.NewRelationTag(rel.Key)
 	data := &remoteRelationData{
@@ -1294,7 +1298,7 @@ func (fw *Firewaller) startRelation(rel *params.RemoteRelation, role charm.Relat
 		return errors.Trace(err)
 	}
 
-	data.isOffer = remoteApps[0].Result.Registered
+	data.isOffer = remoteAppResult.Result.IsConsumerProxy
 	return fw.startRelationPoller(rel.Key, rel.RemoteApplicationName, data.relationReady)
 }
 

--- a/worker/remoterelations/mock_test.go
+++ b/worker/remoterelations/mock_test.go
@@ -166,13 +166,12 @@ func (m *mockRelationsFacade) RemoteApplications(names []string) ([]params.Remot
 		if app, ok := m.remoteApplications[name]; ok {
 			result[i] = params.RemoteApplicationResult{
 				Result: &params.RemoteApplication{
-					Name:       app.name,
-					OfferUUID:  app.offeruuid,
-					Life:       app.life,
-					Status:     app.status,
-					ModelUUID:  app.modelUUID,
-					Registered: app.registered,
-					Macaroon:   mac,
+					Name:            app.name,
+					OfferUUID:       app.offeruuid,
+					Life:            app.life,
+					ModelUUID:       app.modelUUID,
+					IsConsumerProxy: app.registered,
+					Macaroon:        mac,
 				},
 			}
 		} else {
@@ -402,7 +401,6 @@ type mockRemoteApplication struct {
 	offeruuid  string
 	url        string
 	life       params.Life
-	status     string
 	modelUUID  string
 	registered bool
 }


### PR DESCRIPTION
## Description of change

An early version of CMR created status for remote application proxies on the offering model.
This is not needed. Remove the status creation; nothing uses it.

## QA steps

smoke test a basic cmr scenario

