### PR TITLE
Rephrase error message when agent versions != client version.

### DIFF
--- a/cmd/juju/commands/bootstrap.go
+++ b/cmd/juju/commands/bootstrap.go
@@ -236,7 +236,7 @@ func (c *bootstrapCommand) Init(args []string) (err error) {
 		}
 	}
 	if c.AgentVersion != nil && (c.AgentVersion.Major != jujuversion.Current.Major || c.AgentVersion.Minor != jujuversion.Current.Minor) {
-		return errors.Errorf("this client can only bootstrap agents for %v.%v Juju versions", jujuversion.Current.Major, jujuversion.Current.Minor)
+		return errors.Errorf("this client can only bootstrap %v.%v agents", jujuversion.Current.Major, jujuversion.Current.Minor)
 	}
 
 	switch len(args) {

--- a/cmd/juju/commands/bootstrap.go
+++ b/cmd/juju/commands/bootstrap.go
@@ -236,7 +236,7 @@ func (c *bootstrapCommand) Init(args []string) (err error) {
 		}
 	}
 	if c.AgentVersion != nil && (c.AgentVersion.Major != jujuversion.Current.Major || c.AgentVersion.Minor != jujuversion.Current.Minor) {
-		return errors.New("requested agent version major.minor mismatch")
+		return errors.Errorf("this client can only bootstrap %v.%v+ agents", jujuversion.Current.Major, jujuversion.Current.Minor)
 	}
 
 	switch len(args) {

--- a/cmd/juju/commands/bootstrap.go
+++ b/cmd/juju/commands/bootstrap.go
@@ -236,7 +236,7 @@ func (c *bootstrapCommand) Init(args []string) (err error) {
 		}
 	}
 	if c.AgentVersion != nil && (c.AgentVersion.Major != jujuversion.Current.Major || c.AgentVersion.Minor != jujuversion.Current.Minor) {
-		return errors.Errorf("this client can only bootstrap %v.%v+ agents", jujuversion.Current.Major, jujuversion.Current.Minor)
+		return errors.Errorf("this client can only bootstrap agents for %v.%v Juju versions", jujuversion.Current.Major, jujuversion.Current.Minor)
 	}
 
 	switch len(args) {

--- a/cmd/juju/commands/bootstrap_test.go
+++ b/cmd/juju/commands/bootstrap_test.go
@@ -10,6 +10,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"regexp"
 	"runtime"
 	"sort"
 	"strings"
@@ -420,12 +421,12 @@ var bootstrapTests = []bootstrapTest{{
 	info:    "agent-version doesn't match client version major",
 	version: "1.3.3-saucy-ppc64el",
 	args:    []string{"--agent-version", "2.3.0"},
-	err:     `requested agent version major.minor mismatch`,
+	err:     regexp.QuoteMeta(`this client can only bootstrap 1.3+ agents`),
 }, {
 	info:    "agent-version doesn't match client version minor",
 	version: "1.3.3-saucy-ppc64el",
 	args:    []string{"--agent-version", "1.4.0"},
-	err:     `requested agent version major.minor mismatch`,
+	err:     regexp.QuoteMeta(`this client can only bootstrap 1.3+ agents`),
 }, {
 	info: "--clouds with --regions",
 	args: []string{"--clouds", "--regions", "aws"},

--- a/cmd/juju/commands/bootstrap_test.go
+++ b/cmd/juju/commands/bootstrap_test.go
@@ -421,12 +421,12 @@ var bootstrapTests = []bootstrapTest{{
 	info:    "agent-version doesn't match client version major",
 	version: "1.3.3-saucy-ppc64el",
 	args:    []string{"--agent-version", "2.3.0"},
-	err:     regexp.QuoteMeta(`this client can only bootstrap agents for 1.3 Juju versions`),
+	err:     regexp.QuoteMeta(`this client can only bootstrap 1.3 agents`),
 }, {
 	info:    "agent-version doesn't match client version minor",
 	version: "1.3.3-saucy-ppc64el",
 	args:    []string{"--agent-version", "1.4.0"},
-	err:     regexp.QuoteMeta(`this client can only bootstrap agents for 1.3 Juju versions`),
+	err:     regexp.QuoteMeta(`this client can only bootstrap 1.3 agents`),
 }, {
 	info: "--clouds with --regions",
 	args: []string{"--clouds", "--regions", "aws"},

--- a/cmd/juju/commands/bootstrap_test.go
+++ b/cmd/juju/commands/bootstrap_test.go
@@ -421,12 +421,12 @@ var bootstrapTests = []bootstrapTest{{
 	info:    "agent-version doesn't match client version major",
 	version: "1.3.3-saucy-ppc64el",
 	args:    []string{"--agent-version", "2.3.0"},
-	err:     regexp.QuoteMeta(`this client can only bootstrap 1.3+ agents`),
+	err:     regexp.QuoteMeta(`this client can only bootstrap agents for 1.3 Juju versions`),
 }, {
 	info:    "agent-version doesn't match client version minor",
 	version: "1.3.3-saucy-ppc64el",
 	args:    []string{"--agent-version", "1.4.0"},
-	err:     regexp.QuoteMeta(`this client can only bootstrap 1.3+ agents`),
+	err:     regexp.QuoteMeta(`this client can only bootstrap agents for 1.3 Juju versions`),
 }, {
 	info: "--clouds with --regions",
 	args: []string{"--clouds", "--regions", "aws"},


### PR DESCRIPTION
## Description of change

When bootstrapping controllers with agent version that is different from client version, we'd get a fairly obscure message:

$ juju bootstrap aws mycontroller --agent-version=2.2.3
ERROR requested agent version major.minor mismatch

To avoid surprises and headaches, this PR proposes to re-phrase this message in a user-friendly way:

$ juju bootstrap aws mycontroller --agent-version=2.2.3
ERROR this client can only bootstrap 2.3 agents


## QA steps

As per description above.

## Documentation changes

n/a

## Bug reference

n/a
