### PR TITLE
Save an alias for the offering controller when consuming

### DIFF
--- a/api/application/client.go
+++ b/api/application/client.go
@@ -639,6 +639,7 @@ func (c *Client) Consume(arg crossmodel.ConsumeApplicationArgs) (string, error) 
 	if arg.ControllerInfo != nil {
 		args.Args[0].ControllerInfo = &params.ExternalControllerInfo{
 			ControllerTag: arg.ControllerInfo.ControllerTag.String(),
+			Alias:         arg.ControllerInfo.Alias,
 			Addrs:         arg.ControllerInfo.Addrs,
 			CACert:        arg.ControllerInfo.CACert,
 		}

--- a/api/application/client_test.go
+++ b/api/application/client_test.go
@@ -511,6 +511,7 @@ func (s *applicationSuite) TestConsume(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	controllerInfo := &params.ExternalControllerInfo{
 		ControllerTag: coretesting.ControllerTag.String(),
+		Alias:         "controller-alias",
 		Addrs:         []string{"192.168.1.0"},
 		CACert:        coretesting.CACert,
 	}
@@ -547,6 +548,7 @@ func (s *applicationSuite) TestConsume(c *gc.C) {
 		Macaroon:         mac,
 		ControllerInfo: &crossmodel.ControllerInfo{
 			ControllerTag: coretesting.ControllerTag,
+			Alias:         "controller-alias",
 			Addrs:         controllerInfo.Addrs,
 			CACert:        controllerInfo.CACert,
 		},

--- a/apiserver/facades/client/application/application.go
+++ b/apiserver/facades/client/application/application.go
@@ -1227,6 +1227,7 @@ func (api *API) consumeOne(arg params.ConsumeApplicationArg) error {
 		if controllerTag.Id() != api.backend.ControllerTag().Id() {
 			if _, err = api.backend.SaveController(crossmodel.ControllerInfo{
 				ControllerTag: controllerTag,
+				Alias:         arg.ControllerInfo.Alias,
 				Addrs:         arg.ControllerInfo.Addrs,
 				CACert:        arg.ControllerInfo.CACert,
 			}, sourceModelTag.Id()); err != nil {

--- a/apiserver/facades/client/application/application_unit_test.go
+++ b/apiserver/facades/client/application/application_unit_test.go
@@ -624,6 +624,7 @@ func (s *ApplicationSuite) TestConsumeFromExternalController(c *gc.C) {
 			Macaroon: mac,
 			ControllerInfo: &params.ExternalControllerInfo{
 				ControllerTag: names.NewControllerTag(controllerUUID).String(),
+				Alias:         "controller-alias",
 				CACert:        coretesting.CACert,
 				Addrs:         []string{"192.168.1.1:1234"},
 			},
@@ -644,6 +645,7 @@ func (s *ApplicationSuite) TestConsumeFromExternalController(c *gc.C) {
 	})
 	c.Assert(s.backend.controllers[coretesting.ModelTag.Id()], jc.DeepEquals, crossmodel.ControllerInfo{
 		ControllerTag: names.NewControllerTag(controllerUUID),
+		Alias:         "controller-alias",
 		CACert:        coretesting.CACert,
 		Addrs:         []string{"192.168.1.1:1234"},
 	})
@@ -665,6 +667,7 @@ func (s *ApplicationSuite) TestConsumeFromSameController(c *gc.C) {
 			Macaroon: mac,
 			ControllerInfo: &params.ExternalControllerInfo{
 				ControllerTag: coretesting.ControllerTag.String(),
+				Alias:         "controller-alias",
 				CACert:        coretesting.CACert,
 				Addrs:         []string{"192.168.1.1:1234"},
 			},

--- a/apiserver/params/crossmodel.go
+++ b/apiserver/params/crossmodel.go
@@ -564,6 +564,7 @@ const (
 // needed to make a connection to an external controller.
 type ExternalControllerInfo struct {
 	ControllerTag string   `json:"controller-tag"`
+	Alias         string   `json:"controller-alias"`
 	Addrs         []string `json:"addrs"`
 	CACert        string   `json:"ca-cert"`
 }

--- a/cmd/juju/application/addrelation.go
+++ b/cmd/juju/application/addrelation.go
@@ -127,14 +127,6 @@ func (c *addRelationCommand) getOffersAPI(url *crossmodel.OfferURL) (application
 		return c.consumeDetailsAPI, nil
 	}
 
-	if url.Source == "" {
-		var err error
-		controllerName, err := c.ControllerName()
-		if err != nil {
-			return nil, errors.Trace(err)
-		}
-		url.Source = controllerName
-	}
 	root, err := c.CommandBase.NewAPIRoot(c.ClientStore(), url.Source, "")
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -153,6 +145,14 @@ func (c *addRelationCommand) Run(ctx *cmd.Context) error {
 		if client.BestAPIVersion() < 5 {
 			// old client does not have cross-model capability.
 			return errors.NotSupportedf("cannot add relation to %s: remote endpoints", c.remoteEndpoint.String())
+		}
+		if c.remoteEndpoint.Source == "" {
+			var err error
+			controllerName, err := c.ControllerName()
+			if err != nil {
+				return errors.Trace(err)
+			}
+			c.remoteEndpoint.Source = controllerName
 		}
 		if err := c.maybeConsumeOffer(client); err != nil {
 			return errors.Trace(err)
@@ -208,6 +208,7 @@ func (c *addRelationCommand) maybeConsumeOffer(targetClient applicationAddRelati
 		}
 		arg.ControllerInfo = &crossmodel.ControllerInfo{
 			ControllerTag: controllerTag,
+			Alias:         offerURL.Source,
 			Addrs:         consumeDetails.ControllerInfo.Addrs,
 			CACert:        consumeDetails.ControllerInfo.CACert,
 		}

--- a/cmd/juju/application/addremoterelation_test.go
+++ b/cmd/juju/application/addremoterelation_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/core/crossmodel"
 	jujutesting "github.com/juju/juju/juju/testing"
+	"github.com/juju/juju/testing"
 )
 
 const endpointSeparator = ":"
@@ -50,10 +51,16 @@ func (s *AddRemoteRelationSuiteNewAPI) TestAddRelationToOneRemoteApplication(c *
 		crossmodel.ConsumeApplicationArgs{
 			Offer: params.ApplicationOfferDetails{
 				OfferName: "hosted-mysql",
-				OfferURL:  "bob/prod.hosted-mysql",
+				OfferURL:  "kontroll:bob/prod.hosted-mysql",
 			},
 			ApplicationAlias: "applicationname2",
 			Macaroon:         s.mac,
+			ControllerInfo: &crossmodel.ControllerInfo{
+				ControllerTag: testing.ControllerTag,
+				Addrs:         []string{"192.168.1.0"},
+				Alias:         "kontroll",
+				CACert:        testing.CACert,
+			},
 		})
 	s.mockAPI.CheckCall(c, 4, "AddRelation", []string{"applicationname", "applicationname2"}, []string(nil))
 }
@@ -65,10 +72,16 @@ func (s *AddRemoteRelationSuiteNewAPI) TestAddRelationAnyRemoteApplication(c *gc
 		crossmodel.ConsumeApplicationArgs{
 			Offer: params.ApplicationOfferDetails{
 				OfferName: "hosted-mysql",
-				OfferURL:  "bob/prod.hosted-mysql",
+				OfferURL:  "kontroll:bob/prod.hosted-mysql",
 			},
 			ApplicationAlias: "applicationname2",
 			Macaroon:         s.mac,
+			ControllerInfo: &crossmodel.ControllerInfo{
+				ControllerTag: testing.ControllerTag,
+				Addrs:         []string{"192.168.1.0"},
+				Alias:         "kontroll",
+				CACert:        testing.CACert,
+			},
 		})
 	s.mockAPI.CheckCall(c, 4, "AddRelation", []string{"applicationname2", "applicationname"}, []string(nil))
 }
@@ -247,5 +260,11 @@ func (m *mockAddRelationAPI) GetConsumeDetails(url string) (params.ConsumeOfferD
 			OfferURL:  "bob/prod.hosted-mysql",
 		},
 		Macaroon: m.mac,
+		ControllerInfo: &params.ExternalControllerInfo{
+			ControllerTag: testing.ControllerTag.String(),
+			Addrs:         []string{"192.168.1.0"},
+			Alias:         "controller-alias",
+			CACert:        testing.CACert,
+		},
 	}, nil
 }

--- a/cmd/juju/application/consume.go
+++ b/cmd/juju/application/consume.go
@@ -162,6 +162,7 @@ func (c *consumeCommand) Run(ctx *cmd.Context) error {
 		}
 		arg.ControllerInfo = &crossmodel.ControllerInfo{
 			ControllerTag: controllerTag,
+			Alias:         consumeDetails.ControllerInfo.Alias,
 			Addrs:         consumeDetails.ControllerInfo.Addrs,
 			CACert:        consumeDetails.ControllerInfo.CACert,
 		}

--- a/cmd/juju/application/consume_test.go
+++ b/cmd/juju/application/consume_test.go
@@ -105,6 +105,7 @@ func (s *ConsumeSuite) assertSuccessModelDotApplication(c *gc.C, alias string) {
 			Macaroon:         mac,
 			ControllerInfo: &crossmodel.ControllerInfo{
 				ControllerTag: coretesting.ControllerTag,
+				Alias:         "controller-alias",
 				Addrs:         []string{"192.168.1:1234"},
 				CACert:        coretesting.CACert,
 			},
@@ -151,6 +152,7 @@ func (a *mockConsumeAPI) GetConsumeDetails(url string) (params.ConsumeOfferDetai
 		Macaroon: mac,
 		ControllerInfo: &params.ExternalControllerInfo{
 			ControllerTag: coretesting.ControllerTag.String(),
+			Alias:         "controller-alias",
 			Addrs:         []string{"192.168.1:1234"},
 			CACert:        coretesting.CACert,
 		},

--- a/core/crossmodel/externalcontroller.go
+++ b/core/crossmodel/externalcontroller.go
@@ -15,6 +15,9 @@ type ControllerInfo struct {
 	// ControllerTag holds tag for the controller.
 	ControllerTag names.ControllerTag
 
+	// Alias holds a (human friendly) alias for the controller.
+	Alias string
+
 	// Addrs holds the addresses and ports of the controller's API servers.
 	Addrs []string
 

--- a/state/externalcontroller.go
+++ b/state/externalcontroller.go
@@ -36,6 +36,9 @@ type externalControllerDoc struct {
 	// It is the controller UUID.
 	Id string `bson:"_id"`
 
+	// Alias holds an alias (human friendly) name for the controller.
+	Alias string `bson:"alias"`
+
 	// Addrs holds the host:port values for the external
 	// controller's API server.
 	Addrs []string `bson:"addresses"`
@@ -57,6 +60,7 @@ func (rc *externalController) Id() string {
 func (rc *externalController) ControllerInfo() crossmodel.ControllerInfo {
 	return crossmodel.ControllerInfo{
 		ControllerTag: names.NewControllerTag(rc.doc.Id),
+		Alias:         rc.doc.Alias,
 		Addrs:         rc.doc.Addrs,
 		CACert:        rc.doc.CACert,
 	}
@@ -84,6 +88,7 @@ func (ec *externalControllers) Save(controller crossmodel.ControllerInfo, modelU
 	}
 	doc := externalControllerDoc{
 		Id:     controller.ControllerTag.Id(),
+		Alias:  controller.Alias,
 		Addrs:  controller.Addrs,
 		CACert: controller.CACert,
 	}
@@ -110,6 +115,7 @@ func (ec *externalControllers) Save(controller crossmodel.ControllerInfo, modelU
 				Update: bson.D{
 					{"$set",
 						bson.D{{"addresses", doc.Addrs},
+							{"alias", doc.Alias},
 							{"cacert", doc.CACert},
 							{"models", models.Values()}},
 					},

--- a/state/externalcontroller_test.go
+++ b/state/externalcontroller_test.go
@@ -42,6 +42,7 @@ func (s *externalControllerSuite) TestSaveInvalidAddress(c *gc.C) {
 func (s *externalControllerSuite) TestSaveNoModels(c *gc.C) {
 	controllerInfo := crossmodel.ControllerInfo{
 		ControllerTag: testing.ControllerTag,
+		Alias:         "controller-alias",
 		Addrs:         []string{"192.168.1.0:1234", "10.0.0.1:1234"},
 		CACert:        testing.CACert,
 	}
@@ -62,6 +63,7 @@ func (s *externalControllerSuite) assertSavedControllerInfo(c *gc.C, modelUUIDs 
 	c.Assert(raw["_id"], gc.Equals, testing.ControllerTag.Id())
 	c.Assert(raw["addresses"], jc.SameContents, []interface{}{"192.168.1.0:1234", "10.0.0.1:1234"})
 	c.Assert(raw["cacert"], gc.Equals, testing.CACert)
+	c.Assert(raw["alias"], gc.Equals, "controller-alias")
 	var models []string
 	for _, m := range raw["models"].([]interface{}) {
 		models = append(models, m.(string))
@@ -72,6 +74,7 @@ func (s *externalControllerSuite) assertSavedControllerInfo(c *gc.C, modelUUIDs 
 func (s *externalControllerSuite) TestSave(c *gc.C) {
 	controllerInfo := crossmodel.ControllerInfo{
 		ControllerTag: testing.ControllerTag,
+		Alias:         "controller-alias",
 		Addrs:         []string{"192.168.1.0:1234", "10.0.0.1:1234"},
 		CACert:        testing.CACert,
 	}
@@ -87,6 +90,7 @@ func (s *externalControllerSuite) TestSave(c *gc.C) {
 func (s *externalControllerSuite) TestSaveIdempotent(c *gc.C) {
 	controllerInfo := crossmodel.ControllerInfo{
 		ControllerTag: testing.ControllerTag,
+		Alias:         "controller-alias",
 		Addrs:         []string{"192.168.1.0:1234", "10.0.0.1:1234"},
 		CACert:        testing.CACert,
 	}
@@ -103,6 +107,7 @@ func (s *externalControllerSuite) TestSaveIdempotent(c *gc.C) {
 func (s *externalControllerSuite) TestUpdateModels(c *gc.C) {
 	controllerInfo := crossmodel.ControllerInfo{
 		ControllerTag: testing.ControllerTag,
+		Alias:         "controller-alias",
 		Addrs:         []string{"192.168.1.0:1234", "10.0.0.1:1234"},
 		CACert:        testing.CACert,
 	}
@@ -118,6 +123,7 @@ func (s *externalControllerSuite) TestUpdateModels(c *gc.C) {
 func (s *externalControllerSuite) TestControllerForModel(c *gc.C) {
 	controllerInfo := crossmodel.ControllerInfo{
 		ControllerTag: testing.ControllerTag,
+		Alias:         "controller-alias",
 		Addrs:         []string{"192.168.1.0:1234", "10.0.0.1:1234"},
 		CACert:        testing.CACert,
 	}


### PR DESCRIPTION
## Description of change

When consuming an offer, and hence recording the external controller information, we record as an alias in the external controller record the controller name. This isn't used (yet), but it will be when we allow editing of external controller addresses/cert. We want to get this in before release to avoid upgrade issues.

## QA steps

Smoke test CMR scenario.

