### PR TITLE
Clarify bootstrap help re:agent-version.

### DIFF
--- a/cmd/juju/commands/bootstrap.go
+++ b/cmd/juju/commands/bootstrap.go
@@ -93,10 +93,16 @@ address.
 
 Private clouds may need to specify their own custom image metadata and
 tools/agent. Use '--metadata-source' whose value is a local directory.
-The value of '--agent-version' will become the default tools version to
-use in all models for this controller. The full binary version is accepted
-(e.g.: 2.0.1-xenial-amd64) but only the numeric version (e.g.: 2.0.1) is
-used. Otherwise, by default, the version used is that of the client.
+
+By default, the Juju version of the bootstrapping client is the version of the
+tools agent that is downloaded and installed for all models on this controller.
+However, a user can specify a different agent version via '--agent-version' 
+option to bootstrap command. Juju will use this version for models' agents 
+as long as the client's version is from the same Juju release series.
+In other words, a 2.0.1 client can bootstrap any 2.0.x agents but cannot
+bootstrap any 1.25.x or 2.1.x agents.
+The agent version can be a simple numeric version, e.g. 2.0.1,
+or a full binary version, e.g. 2.0.1-xenial-amd64. 
 
 Examples:
     juju bootstrap
@@ -106,7 +112,7 @@ Examples:
     juju bootstrap aws/us-east-1
     juju bootstrap google joe-us-east1
     juju bootstrap --config=~/config-rs.yaml rackspace joe-syd
-    juju bootstrap --config agent-version=1.25.3 aws joe-us-east-1
+    juju bootstrap --agent-version=2.0.3 aws joe-us-east-1
     juju bootstrap --config bootstrap-timeout=1200 azure joe-eastus
 
 See also:

--- a/cmd/juju/commands/bootstrap.go
+++ b/cmd/juju/commands/bootstrap.go
@@ -94,15 +94,15 @@ address.
 Private clouds may need to specify their own custom image metadata and
 tools/agent. Use '--metadata-source' whose value is a local directory.
 
-By default, the Juju version of the bootstrapping client is the version of the
-tools agent that is downloaded and installed for all models on this controller.
+By default, the Juju version of the agent binary that is downloaded and 
+installed on all models for the new controller will be the same as that 
+of the Juju client used to perform the bootstrap.
 However, a user can specify a different agent version via '--agent-version' 
 option to bootstrap command. Juju will use this version for models' agents 
 as long as the client's version is from the same Juju release series.
-In other words, a 2.0.1 client can bootstrap any 2.0.x agents but cannot
-bootstrap any 1.25.x or 2.1.x agents.
-The agent version can be a simple numeric version, e.g. 2.0.1,
-or a full binary version, e.g. 2.0.1-xenial-amd64. 
+In other words, a 2.2.1 client can bootstrap any 2.2.x agents but cannot
+bootstrap any 2.0.x or 2.1.x agents.
+The agent version can be specified a simple numeric version, e.g. 2.2.4.
 
 Examples:
     juju bootstrap
@@ -112,7 +112,7 @@ Examples:
     juju bootstrap aws/us-east-1
     juju bootstrap google joe-us-east1
     juju bootstrap --config=~/config-rs.yaml rackspace joe-syd
-    juju bootstrap --agent-version=2.0.3 aws joe-us-east-1
+    juju bootstrap --agent-version=2.2.4 aws joe-us-east-1
     juju bootstrap --config bootstrap-timeout=1200 azure joe-eastus
 
 See also:


### PR DESCRIPTION
## Description of change

There has been a user confusion around what option combination will allow bootstrap to use different agent version for models that a controller will create.

This PR re-phrases the paragraph and cleans up the example.

## QA steps
'juju help bootstrap', last paragraph about agent-version is clear and unambiguous.

## Documentation changes
n/a

## Bug reference
https://bugs.launchpad.net/juju/+bug/1674764
