### PR TITLE
Don't try to create bridges for containers when using FAN

### DIFF
--- a/network/containerizer/bridgepolicy.go
+++ b/network/containerizer/bridgepolicy.go
@@ -246,6 +246,10 @@ func (b *BridgePolicy) FindMissingBridgesForContainer(m Machine, containerMachin
 		// Nothing to do, just return success
 		return nil, 0, nil
 	}
+	if b.ContainerNetworkingMethod == "fan" {
+		return nil, 0, errors.Errorf("host machine %q has no available FAN devices in space(s) %s",
+			m.Id(), network.QuoteSpaceSet(notFound))
+	}
 	hostDeviceNamesToBridge := make([]string, 0)
 	for _, spaceName := range notFound.Values() {
 		hostDeviceNames := make([]string, 0)

--- a/network/containerizer/bridgepolicy_test.go
+++ b/network/containerizer/bridgepolicy_test.go
@@ -1120,6 +1120,22 @@ func (s *bridgePolicyStateSuite) TestFindMissingBridgesForContainerVLANOnBond(c 
 	c.Check(reconfigureDelay, gc.Equals, 13)
 }
 
+func (s *bridgePolicyStateSuite) TestFindMissingBridgesForContainerNetworkingMethodFAN(c *gc.C) {
+	s.setupTwoSpaces(c)
+	s.createNICWithIP(c, s.machine, "eth0", "10.0.0.20/24")
+	s.addContainerMachine(c)
+	err := s.containerMachine.SetConstraints(constraints.Value{
+		Spaces: &[]string{"default"},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	bridgePolicy := &containerizer.BridgePolicy{
+		NetBondReconfigureDelay:   13,
+		ContainerNetworkingMethod: "fan",
+	}
+	_, _, err = bridgePolicy.FindMissingBridgesForContainer(s.machine, s.containerMachine)
+	c.Assert(err, gc.ErrorMatches, `host machine "0" has no available FAN devices in space\(s\) "default"`)
+}
+
 var bridgeNames = map[string]string{
 	"eno0":            "br-eno0",
 	"twelvechars0":    "br-twelvechars0",


### PR DESCRIPTION
## Description of change
When bridger policy is FAN we shouldn't try to create any bridges when creating a container

## QA steps
Run ./network/containerizer  TestFindMissingBridgesForContainerNetworkingMethodFAN unit test