### PR TITLE
google: add new regions

### DIFF
--- a/cloud/fallback-public-cloud.yaml
+++ b/cloud/fallback-public-cloud.yaml
@@ -54,11 +54,17 @@ clouds:
     regions:
       us-east1:
         endpoint: https://www.googleapis.com
+      us-east4:
+        endpoint: https://www.googleapis.com
       us-central1:
         endpoint: https://www.googleapis.com
       us-west1:
         endpoint: https://www.googleapis.com
       europe-west1:
+        endpoint: https://www.googleapis.com
+      europe-west2:
+        endpoint: https://www.googleapis.com
+      europe-west3:
         endpoint: https://www.googleapis.com
       asia-east1:
         endpoint: https://www.googleapis.com
@@ -67,6 +73,8 @@ clouds:
       asia-southeast1:
         endpoint: https://www.googleapis.com
       australia-southeast1:
+        endpoint: https://www.googleapis.com
+      southamerica-east1:
         endpoint: https://www.googleapis.com
   azure:
     type: azure

--- a/cloud/fallback_public_cloud.go
+++ b/cloud/fallback_public_cloud.go
@@ -61,11 +61,17 @@ clouds:
     regions:
       us-east1:
         endpoint: https://www.googleapis.com
+      us-east4:
+        endpoint: https://www.googleapis.com
       us-central1:
         endpoint: https://www.googleapis.com
       us-west1:
         endpoint: https://www.googleapis.com
       europe-west1:
+        endpoint: https://www.googleapis.com
+      europe-west2:
+        endpoint: https://www.googleapis.com
+      europe-west3:
         endpoint: https://www.googleapis.com
       asia-east1:
         endpoint: https://www.googleapis.com
@@ -74,6 +80,8 @@ clouds:
       asia-southeast1:
         endpoint: https://www.googleapis.com
       australia-southeast1:
+        endpoint: https://www.googleapis.com
+      southamerica-east1:
         endpoint: https://www.googleapis.com
   azure:
     type: azure

--- a/cmd/juju/cloud/regions_test.go
+++ b/cmd/juju/cloud/regions_test.go
@@ -103,13 +103,17 @@ func (s *regionsSuite) TestListGCERegions(c *gc.C) {
 	out := cmdtesting.Stdout(ctx)
 	c.Assert(out, jc.DeepEquals, `
 us-east1
+us-east4
 us-central1
 us-west1
 europe-west1
+europe-west2
+europe-west3
 asia-east1
 asia-northeast1
 asia-southeast1
 australia-southeast1
+southamerica-east1
 
 `[1:])
 }
@@ -121,11 +125,17 @@ func (s *regionsSuite) TestListGCERegionsYaml(c *gc.C) {
 	c.Assert(out, jc.DeepEquals, `
 us-east1:
   endpoint: https://www.googleapis.com
+us-east4:
+  endpoint: https://www.googleapis.com
 us-central1:
   endpoint: https://www.googleapis.com
 us-west1:
   endpoint: https://www.googleapis.com
 europe-west1:
+  endpoint: https://www.googleapis.com
+europe-west2:
+  endpoint: https://www.googleapis.com
+europe-west3:
   endpoint: https://www.googleapis.com
 asia-east1:
   endpoint: https://www.googleapis.com
@@ -134,6 +144,8 @@ asia-northeast1:
 asia-southeast1:
   endpoint: https://www.googleapis.com
 australia-southeast1:
+  endpoint: https://www.googleapis.com
+southamerica-east1:
   endpoint: https://www.googleapis.com
 `[1:])
 }


### PR DESCRIPTION
## Description of change

Add new Google Compute Engine regions:
  us-east4
  europe-west2
  europe-west3
  southamerica-east1

## QA steps

1. juju bootstrap google/us-east4
2. for x in europe-west2 europe-west3 southamerica-east1; do juju add-model foo-$x $x && juju deploy ubuntu; done
3. check that ubuntu deploys correctly in each
4. confirm with "gcloud compute instances list" that there's a VM in each of the specified regions

## Documentation changes

None.

## Bug reference

Fixes https://bugs.launchpad.net/juju/+bug/1690413