### PR TITLE
Limit the number of cidrs in a cmr firewall rule

### DIFF
--- a/api/firewaller/firewaller.go
+++ b/api/firewaller/firewaller.go
@@ -238,3 +238,20 @@ func (c *Client) SetRelationStatus(relationKey string, status relation.Status, m
 	}
 	return results.OneError()
 }
+
+// FirewallRules returns the firewall rules for the specified known service names.
+func (c *Client) FirewallRules(knownServices ...string) ([]params.FirewallRule, error) {
+	args := params.KnownServiceArgs{
+		KnownServices: make([]params.KnownServiceValue, len(knownServices)),
+	}
+	for i, s := range knownServices {
+		args.KnownServices[i] = params.KnownServiceValue(s)
+	}
+
+	var results params.ListFirewallRulesResults
+	err := c.facade.FacadeCall("FirewallRules", args, &results)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return results.Rules, nil
+}

--- a/api/firewaller/firewaller_test.go
+++ b/api/firewaller/firewaller_test.go
@@ -217,3 +217,32 @@ func (s *firewallerSuite) TestSetRelationStatus(c *gc.C) {
 	c.Check(err, gc.ErrorMatches, "FAIL")
 	c.Check(callCount, gc.Equals, 1)
 }
+
+func (s *firewallerSuite) TestFirewallRules(c *gc.C) {
+	var callCount int
+	apiCaller := testing.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
+		c.Check(objType, gc.Equals, "Firewaller")
+		c.Check(version, gc.Equals, 0)
+		c.Check(id, gc.Equals, "")
+		c.Check(request, gc.Equals, "FirewallRules")
+		c.Assert(arg, gc.DeepEquals, params.KnownServiceArgs{
+			KnownServices: []params.KnownServiceValue{
+				params.JujuApplicationOfferRule, params.JujuControllerRule,
+			},
+		})
+		c.Assert(result, gc.FitsTypeOf, &params.ListFirewallRulesResults{})
+		*(result.(*params.ListFirewallRulesResults)) = params.ListFirewallRulesResults{
+			Rules: []params.FirewallRule{
+				{KnownService: params.JujuApplicationOfferRule, WhitelistCIDRS: []string{"10.0.0.0/16"}},
+			},
+		}
+		callCount++
+		return nil
+	})
+	client, err := firewaller.NewClient(apiCaller)
+	c.Assert(err, jc.ErrorIsNil)
+	result, err := client.FirewallRules("juju-application-offer", "juju-controller")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result, gc.HasLen, 1)
+	c.Check(callCount, gc.Equals, 1)
+}

--- a/apiserver/facades/client/firewallrules/firewallrules.go
+++ b/apiserver/facades/client/firewallrules/firewallrules.go
@@ -102,9 +102,6 @@ func (api *API) ListFirewallRules() (params.ListFirewallRulesResults, error) {
 	if err := api.checkCanRead(); err != nil {
 		return listResults, errors.Trace(err)
 	}
-	if err := api.check.ChangeAllowed(); err != nil {
-		return listResults, errors.Trace(err)
-	}
 	rules, err := api.backend.ListFirewallRules()
 	if err != nil {
 		return listResults, errors.Trace(err)

--- a/apiserver/facades/controller/firewaller/firewaller.go
+++ b/apiserver/facades/controller/firewaller/firewaller.go
@@ -472,3 +472,22 @@ func (f *FirewallerAPIV4) SetRelationsStatus(args params.SetStatus) (params.Erro
 	}
 	return result, nil
 }
+
+// FirewallRules returns the firewall rules for the specified well known service types.
+func (f *FirewallerAPIV4) FirewallRules(args params.KnownServiceArgs) (params.ListFirewallRulesResults, error) {
+	var result params.ListFirewallRulesResults
+	for _, knownService := range args.KnownServices {
+		rule, err := f.st.FirewallRule(state.WellKnownServiceType(knownService))
+		if err != nil && !errors.IsNotFound(err) {
+			return result, common.ServerError(err)
+		}
+		if err != nil {
+			continue
+		}
+		result.Rules = append(result.Rules, params.FirewallRule{
+			KnownService:   params.KnownServiceValue(knownService),
+			WhitelistCIDRS: rule.WhitelistCIDRs,
+		})
+	}
+	return result, nil
+}

--- a/apiserver/facades/controller/firewaller/firewaller_unit_test.go
+++ b/apiserver/facades/controller/firewaller/firewaller_unit_test.go
@@ -121,3 +121,16 @@ func (s *RemoteFirewallerSuite) TestSetRelationStatus(c *gc.C) {
 	c.Assert(result.Results[0].Error, gc.IsNil)
 	c.Assert(db2Relation.status, jc.DeepEquals, status.StatusInfo{Status: status.Suspended, Message: "a message"})
 }
+
+func (s *RemoteFirewallerSuite) TestFirewallRules(c *gc.C) {
+	s.st.firewallRules[state.JujuApplicationOfferRule] = &state.FirewallRule{
+		WellKnownService: state.JujuApplicationOfferRule,
+		WhitelistCIDRs:   []string{"192.168.0.0/16"},
+	}
+	result, err := s.api.FirewallRules(params.KnownServiceArgs{
+		KnownServices: []params.KnownServiceValue{params.JujuApplicationOfferRule, params.SSHRule}})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result.Rules, gc.HasLen, 1)
+	c.Assert(result.Rules[0].KnownService, gc.Equals, params.KnownServiceValue("juju-application-offer"))
+	c.Assert(result.Rules[0].WhitelistCIDRS, jc.SameContents, []string{"192.168.0.0/16"})
+}

--- a/apiserver/facades/controller/firewaller/mock_test.go
+++ b/apiserver/facades/controller/firewaller/mock_test.go
@@ -39,6 +39,7 @@ type mockState struct {
 	macaroons      map[names.Tag]*macaroon.Macaroon
 	relations      map[string]*mockRelation
 	controllerInfo map[string]*mockControllerInfo
+	firewallRules  map[state.WellKnownServiceType]*state.FirewallRule
 	subnetsWatcher *mockStringsWatcher
 	modelWatcher   *mockNotifyWatcher
 	configAttrs    map[string]interface{}
@@ -51,6 +52,7 @@ func newMockState(modelUUID string) *mockState {
 		remoteEntities: make(map[names.Tag]string),
 		macaroons:      make(map[names.Tag]*macaroon.Macaroon),
 		controllerInfo: make(map[string]*mockControllerInfo),
+		firewallRules:  make(map[state.WellKnownServiceType]*state.FirewallRule),
 		subnetsWatcher: newMockStringsWatcher(),
 		modelWatcher:   newMockNotifyWatcher(),
 		configAttrs:    coretesting.FakeConfig(),
@@ -108,6 +110,14 @@ func (st *mockState) FindEntity(tag names.Tag) (state.Entity, error) {
 	st.MethodCall(st, "FindEntity")
 	// TODO - implement when remaining firewaller tests become unit tests
 	return nil, errors.NotImplementedf("FindEntity")
+}
+
+func (st *mockState) FirewallRule(service state.WellKnownServiceType) (*state.FirewallRule, error) {
+	r, ok := st.firewallRules[service]
+	if !ok {
+		return nil, errors.NotFoundf("firewall rule for %q", service)
+	}
+	return r, nil
 }
 
 type mockWatcher struct {

--- a/apiserver/facades/controller/firewaller/state.go
+++ b/apiserver/facades/controller/firewaller/state.go
@@ -23,6 +23,8 @@ type State interface {
 	WatchOpenedPorts() state.StringsWatcher
 
 	FindEntity(tag names.Tag) (state.Entity, error)
+
+	FirewallRule(service state.WellKnownServiceType) (*state.FirewallRule, error)
 }
 
 // TODO(wallyworld) - for tests, remove when remaining firewaller tests become unit tests.
@@ -50,4 +52,9 @@ func (st stateShim) FindEntity(tag names.Tag) (state.Entity, error) {
 
 func (st stateShim) WatchOpenedPorts() state.StringsWatcher {
 	return st.st.WatchOpenedPorts()
+}
+
+func (s stateShim) FirewallRule(service state.WellKnownServiceType) (*state.FirewallRule, error) {
+	api := state.NewFirewallRules(s.st)
+	return api.Rule(service)
 }

--- a/apiserver/params/firewall.go
+++ b/apiserver/params/firewall.go
@@ -27,6 +27,12 @@ type FirewallRule struct {
 	WhitelistCIDRS []string `json:"whitelist-cidrs,omitempty"`
 }
 
+// KnownServiceArgs holds the parameters for retrieving firewall rules.
+type KnownServiceArgs struct {
+	// KnownServices are the well known services for a firewall rule.
+	KnownServices []KnownServiceValue `json:"known-services"`
+}
+
 // KnownServiceValue describes a well known service for which a
 // firewall rule can be set up.
 type KnownServiceValue string

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -1,5 +1,6 @@
 github.com/Azure/azure-sdk-for-go	git	03719f665513a71a89cf687d260c39a120ac00e7	2017-08-22T19:53:18Z
 github.com/Azure/go-autorest	git	10cfe58defab0c9a33be1f7b3ee656857670b509	2017-08-16T17:19:00Z
+github.com/EvilSuperstars/go-cidrman	git	4e5a4a63d9b78757b4891b8de60be2606d8972ee	2017-02-11T23:11:53Z
 github.com/ajstarks/svgo	git	89e3ac64b5b3e403a5e7c35ea4f98d45db7b4518	2014-10-04T21:11:59Z
 github.com/altoros/gosigma	git	31228935eec685587914528585da4eb9b073c76d	2015-04-08T14:52:32Z
 github.com/beorn7/perks	git	3ac7bf7a47d159a033b107610db8a1b6575507a4	2016-02-29T21:34:45Z

--- a/worker/firewaller/firewaller.go
+++ b/worker/firewaller/firewaller.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/EvilSuperstars/go-cidrman"
 	"github.com/juju/errors"
 	"github.com/juju/utils/clock"
 	"github.com/juju/utils/set"
@@ -41,6 +42,7 @@ type FirewallerAPI interface {
 	ControllerAPIInfoForModel(modelUUID string) (*api.Info, error)
 	MacaroonForRelation(relationKey string) (*macaroon.Macaroon, error)
 	SetRelationStatus(relationKey string, status relation.Status, message string) error
+	FirewallRules(serviceNames ...string) ([]params.FirewallRule, error)
 }
 
 // CrossModelFirewallerFacade exposes firewaller functionality on the
@@ -792,10 +794,14 @@ func (fw *Firewaller) gatherIngressRules(machines ...*machineData) ([]network.In
 	return want, nil
 }
 
+// TODO(wallyworld) - consider making this configurable.
+const maxAllowedCIDRS = 20
+
 func (fw *Firewaller) updateForRemoteRelationIngress(appTag names.ApplicationTag, cidrs set.Strings) error {
 	logger.Debugf("finding egress rules for %v", appTag)
 	// Now create the rules for any remote relations of which the
 	// unit's application is a part.
+	newCidrs := make(set.Strings)
 	for _, data := range fw.relationIngress {
 		if data.localApplicationTag != appTag {
 			continue
@@ -804,8 +810,43 @@ func (fw *Firewaller) updateForRemoteRelationIngress(appTag names.ApplicationTag
 			continue
 		}
 		for _, cidr := range data.networks.Values() {
-			cidrs.Add(cidr)
+			newCidrs.Add(cidr)
 		}
+	}
+	// If we have too many CIDRs to create a rule for, consolidate.
+	// If a firewall rule with a whitelist of CIDRs has been set up,
+	// use that, else open to the world.
+	if newCidrs.Size() > maxAllowedCIDRS {
+		// First, try and merge the cidrs.
+		merged, err := cidrman.MergeCIDRs(newCidrs.Values())
+		if err != nil {
+			return errors.Trace(err)
+		}
+		newCidrs = set.NewStrings(merged...)
+	}
+
+	// If there's still too many after merging, look for any firewall whitelist.
+	if newCidrs.Size() > maxAllowedCIDRS {
+		newCidrs = make(set.Strings)
+		rules, err := fw.firewallerApi.FirewallRules("juju-application-offer")
+		if err != nil {
+			return errors.Trace(err)
+		}
+		if len(rules) > 0 {
+			rule := rules[0]
+			if len(rule.WhitelistCIDRS) > 0 {
+				for _, cidr := range rule.WhitelistCIDRS {
+					newCidrs.Add(cidr)
+				}
+			}
+		}
+		// No relevant firewall rule exists, so go public.
+		if newCidrs.Size() == 0 {
+			newCidrs.Add("0.0.0.0/0")
+		}
+	}
+	for _, cidr := range newCidrs.Values() {
+		cidrs.Add(cidr)
 	}
 	return nil
 }


### PR DESCRIPTION
## Description of change

For cross model offers with a large number of relations, we may end up creating a firewall rule with a cidr list that is prohibitively large. We limit the cidr list to a size of 20. If larger, we fallback to the whitelist from the juju-application-offer firewall rule (if set). Otherwise, just open to the world (0.0.0.0/0).

## QA steps

Smoke test cmr to ensure no regression.

## Documentation changes

Already documented.
