### PR TITLE
2.2 status ip address fix 1722617

### DIFF
--- a/apiserver/client/backend.go
+++ b/apiserver/client/backend.go
@@ -46,6 +46,7 @@ type Backend interface {
 	AllLinkLayerDevices() ([]*state.LinkLayerDevice, error)
 	AllModels() ([]*state.Model, error)
 	AllRelations() ([]*state.Relation, error)
+	AllSubnets() ([]*state.Subnet, error)
 	Annotations(state.GlobalEntity) (map[string]string, error)
 	APIHostPorts() ([][]network.HostPort, error)
 	Application(string) (*state.Application, error)
@@ -70,7 +71,6 @@ type Backend interface {
 	SetAnnotations(state.GlobalEntity, map[string]string) error
 	SetModelAgentVersion(version.Number) error
 	SetModelConstraints(constraints.Value) error
-	Subnet(string) (*state.Subnet, error)
 	Unit(string) (Unit, error)
 	UpdateModelConfig(map[string]interface{}, []string, ...state.ValidateConfigFunc) error
 	Watch(params state.WatchParams) *state.Multiwatcher

--- a/apiserver/client/status.go
+++ b/apiserver/client/status.go
@@ -416,37 +416,6 @@ func fetchMachines(st Backend, machineIds set.Strings) (map[string][]*state.Mach
 	return v, nil
 }
 
-// subnetLookup caches the results of looking up specific subnets by CIDR
-type subnetLookup struct {
-	st      Backend
-	seen    map[string]*state.Subnet
-	missing map[string]bool
-}
-
-func NewSubnetLookup(st Backend) *subnetLookup {
-	return &subnetLookup{
-		st:      st,
-		seen:    make(map[string]*state.Subnet),
-		missing: make(map[string]bool),
-	}
-}
-
-func (sl *subnetLookup) Lookup(cidr string) (*state.Subnet, error) {
-	if subnet, ok := sl.seen[cidr]; ok {
-		return subnet, nil
-	}
-	if _, ok := sl.missing[cidr]; ok {
-		return nil, nil
-	}
-	subnet, err := sl.st.Subnet(cidr)
-	if errors.IsNotFound(err) {
-		sl.missing[cidr] = true
-		return nil, nil
-	}
-	sl.seen[cidr] = subnet
-	return subnet, nil
-}
-
 // fetchNetworkInterfaces returns maps from machine id to ip.addresses, machine
 // id to a map of interface names from space names, and machine id to
 // linklayerdevices.
@@ -456,7 +425,14 @@ func (sl *subnetLookup) Lookup(cidr string) (*state.Subnet, error) {
 func fetchNetworkInterfaces(st Backend) (map[string][]*state.Address, map[string]map[string]set.Strings, map[string][]*state.LinkLayerDevice, error) {
 	ipAddresses := make(map[string][]*state.Address)
 	spaces := make(map[string]map[string]set.Strings)
-	subnetLookup := NewSubnetLookup(st)
+	subnets, err := st.AllSubnets()
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	subnetsByCIDR := make(map[string]*state.Subnet)
+	for _, subnet := range subnets {
+		subnetsByCIDR[subnet.CIDR()] = subnet
+	}
 	// For every machine, track what devices have addresses so we can filter linklayerdevices later
 	devicesWithAddresses := make(map[string]set.Strings)
 	ipAddrs, err := st.AllIPAddresses()
@@ -469,26 +445,21 @@ func fetchNetworkInterfaces(st Backend) (map[string][]*state.Address, map[string
 		}
 		machineID := ipAddr.MachineID()
 		ipAddresses[machineID] = append(ipAddresses[machineID], ipAddr)
-		subnet, err := subnetLookup.Lookup(ipAddr.SubnetCIDR())
-		if subnet == nil && err == nil {
-			// No worries; no subnets means no spaces.
-			continue
-		} else if err != nil {
-			return nil, nil, nil, err
-		}
-		if spaceName := subnet.SpaceName(); spaceName != "" {
-			devices, ok := spaces[machineID]
-			if !ok {
-				devices = make(map[string]set.Strings)
-				spaces[machineID] = devices
+		if subnet, ok := subnetsByCIDR[ipAddr.SubnetCIDR()]; ok {
+			if spaceName := subnet.SpaceName(); spaceName != "" {
+				devices, ok := spaces[machineID]
+				if !ok {
+					devices = make(map[string]set.Strings)
+					spaces[machineID] = devices
+				}
+				deviceName := ipAddr.DeviceName()
+				spacesSet, ok := devices[deviceName]
+				if !ok {
+					spacesSet = make(set.Strings)
+					devices[deviceName] = spacesSet
+				}
+				spacesSet.Add(spaceName)
 			}
-			deviceName := ipAddr.DeviceName()
-			spacesSet, ok := devices[deviceName]
-			if !ok {
-				spacesSet = make(set.Strings)
-				devices[deviceName] = spacesSet
-			}
-			spacesSet.Add(spaceName)
 		}
 		deviceSet, ok := devicesWithAddresses[machineID]
 		if ok {

--- a/state/allcollections.go
+++ b/state/allcollections.go
@@ -345,13 +345,13 @@ func allCollections() collectionSchema {
 		subnetsC:              {},
 		linkLayerDevicesC:     {},
 		linkLayerDevicesRefsC: {},
-		ipAddressesC:          {
+		ipAddressesC: {
 			indexes: []mgo.Index{{
 				Key: []string{"model-uuid", "machine-id", "device-name"},
 			}},
 		},
-		endpointBindingsC:     {},
-		openedPortsC:          {},
+		endpointBindingsC: {},
+		openedPortsC:      {},
 
 		// -----
 

--- a/state/allcollections.go
+++ b/state/allcollections.go
@@ -345,7 +345,11 @@ func allCollections() collectionSchema {
 		subnetsC:              {},
 		linkLayerDevicesC:     {},
 		linkLayerDevicesRefsC: {},
-		ipAddressesC:          {},
+		ipAddressesC:          {
+			indexes: []mgo.Index{{
+				Key: []string{"model-uuid", "machine-id", "device-name"},
+			}},
+		},
 		endpointBindingsC:     {},
 		openedPortsC:          {},
 

--- a/state/linklayerdevices.go
+++ b/state/linklayerdevices.go
@@ -484,6 +484,8 @@ func (dev *LinkLayerDevice) Addresses() ([]*Address, error) {
 		allAddresses = append(allAddresses, newIPAddress(dev.st, *resultDoc))
 	}
 
+	// NOTE (jam) 2017-10-10: There is no index on ip.addresses for (model-uuid, machine-id, device-name)
+	// so this is going to do a table scan
 	findQuery := findAddressesQuery(dev.doc.MachineID, dev.doc.Name)
 	if err := dev.st.forEachIPAddressDoc(findQuery, callbackFunc); err != nil {
 		return nil, errors.Trace(err)

--- a/state/linklayerdevices.go
+++ b/state/linklayerdevices.go
@@ -484,8 +484,6 @@ func (dev *LinkLayerDevice) Addresses() ([]*Address, error) {
 		allAddresses = append(allAddresses, newIPAddress(dev.st, *resultDoc))
 	}
 
-	// NOTE (jam) 2017-10-10: There is no index on ip.addresses for (model-uuid, machine-id, device-name)
-	// so this is going to do a table scan
 	findQuery := findAddressesQuery(dev.doc.MachineID, dev.doc.Name)
 	if err := dev.st.forEachIPAddressDoc(findQuery, callbackFunc); err != nil {
 		return nil, errors.Trace(err)


### PR DESCRIPTION
## Description of change

"juju status" is slower than it needs to be, one of the things we noticed was that we hit the 'ip.addresses' table far more than we should.

It turns out the recent work to update the formatting so that 'juju status' can separate out the individual devices and spaces was interacting with the database in a bad way. It was effectively table scanning the ip.addresses table for every device on every machine to check if that device had any ip addresses. We can cache most of that information internally, but we should add an index anyway so that when we *do* want to go from LLD to Addresses we can do so with an index, rather than a table scan.

## QA steps

There should be no change in the output of `juju status --format=yaml`. But it should return much faster when there are many machine with many devices and many IP addresses.

## Documentation changes

None

## Bug reference

[lp:1722617](https://bugs.launchpad.net/juju/+bug/1722617)