### PR TITLE
Fix the API break with application config

### DIFF
--- a/apiserver/facades/client/application/application.go
+++ b/apiserver/facades/client/application/application.go
@@ -487,7 +487,6 @@ func (api *API) getConfig(entity string) (map[string]interface{}, error) {
 		if err != nil {
 			return nil, err
 		}
-		logger.Criticalf("charm.Config(): %#v", charm.Config())
 		return describe(settings, charm.Config()), nil
 	default:
 		return nil, errors.Errorf("unexpected tag type, expected application, got %s", kind)

--- a/apiserver/facades/client/application/application.go
+++ b/apiserver/facades/client/application/application.go
@@ -479,7 +479,16 @@ func (api *API) getConfig(entity string) (map[string]interface{}, error) {
 		if err != nil {
 			return nil, err
 		}
-		return app.ConfigSettings()
+		settings, err := app.ConfigSettings()
+		if err != nil {
+			return nil, err
+		}
+		charm, _, err := app.Charm()
+		if err != nil {
+			return nil, err
+		}
+		logger.Criticalf("charm.Config(): %#v", charm.Config())
+		return describe(settings, charm.Config()), nil
 	default:
 		return nil, errors.Errorf("unexpected tag type, expected application, got %s", kind)
 	}

--- a/apiserver/facades/client/application/application_test.go
+++ b/apiserver/facades/client/application/application_test.go
@@ -103,19 +103,24 @@ func (s *applicationSuite) makeAPI(c *gc.C) *application.API {
 
 func (s *applicationSuite) TestGetConfig(c *gc.C) {
 	fooConfig := map[string]interface{}{
-		"name":   "foo",
-		"answer": 42,
+		"title":       "foo",
+		"skill-level": 42,
 	}
+	dummy := s.Factory.MakeCharm(c, &factory.CharmParams{
+		Name: "dummy",
+	})
 	s.Factory.MakeApplication(c, &factory.ApplicationParams{
 		Name:     "foo",
+		Charm:    dummy,
 		Settings: fooConfig,
 	})
 	barConfig := map[string]interface{}{
-		"name": "bar",
-		"key":  "value",
+		"title":   "bar",
+		"outlook": "fantastic",
 	}
 	s.Factory.MakeApplication(c, &factory.ApplicationParams{
 		Name:     "bar",
+		Charm:    dummy,
 		Settings: barConfig,
 	})
 	results, err := s.applicationAPI.GetConfig(params.Entities{
@@ -134,9 +139,61 @@ func (s *applicationSuite) TestGetConfig(c *gc.C) {
 			}, {
 				Error: &params.Error{Message: `unexpected tag type, expected application, got user`},
 			}, {
-				Config: fooConfig,
+				Config: map[string]interface{}{
+					"outlook": map[string]interface{}{
+						"description": "No default outlook.",
+						"source":      "unset",
+						"type":        "string",
+					},
+					"skill-level": map[string]interface{}{
+						"description": "A number indicating skill.",
+						"source":      "user",
+						"type":        "int",
+						"value":       42,
+					},
+					"title": map[string]interface{}{
+						"default":     "My Title",
+						"description": "A descriptive title used for the application.",
+						"source":      "user",
+						"type":        "string",
+						"value":       "foo",
+					},
+					"username": map[string]interface{}{
+						"default":     "admin001",
+						"description": "The name of the initial account (given admin permissions).",
+						"source":      "default",
+						"type":        "string",
+						"value":       "admin001",
+					},
+				},
 			}, {
-				Config: barConfig,
+				Config: map[string]interface{}{
+					"outlook": map[string]interface{}{
+						"description": "No default outlook.",
+						"source":      "user",
+						"type":        "string",
+						"value":       "fantastic",
+					},
+					"skill-level": map[string]interface{}{
+						"description": "A number indicating skill.",
+						"source":      "unset",
+						"type":        "int",
+					},
+					"title": map[string]interface{}{
+						"default":     "My Title",
+						"description": "A descriptive title used for the application.",
+						"source":      "user",
+						"type":        "string",
+						"value":       "bar",
+					},
+					"username": map[string]interface{}{
+						"default":     "admin001",
+						"description": "The name of the initial account (given admin permissions).",
+						"source":      "default",
+						"type":        "string",
+						"value":       "admin001",
+					},
+				},
 			}, {
 				Error: &params.Error{Message: `application "wat" not found`, Code: "not found"},
 			},

--- a/apiserver/facades/client/application/get.go
+++ b/apiserver/facades/client/application/get.go
@@ -12,6 +12,21 @@ import (
 
 // Get returns the configuration for a service.
 func (api *API) Get(args params.ApplicationGet) (params.ApplicationGetResults, error) {
+	return api.getApplicationSettings(args, describe)
+}
+
+// Get returns the configuration for a service.
+// This used the confusing "default" boolean to mean the value was set from
+// the charm defaults. Needs to be kept for backwards compatibility.
+func (api *APIv4) Get(args params.ApplicationGet) (params.ApplicationGetResults, error) {
+	return api.getApplicationSettings(args, describeV4)
+}
+
+// Get returns the configuration for a service.
+func (api *API) getApplicationSettings(
+	args params.ApplicationGet,
+	describe func(settings charm.Settings, config *charm.Config) map[string]interface{},
+) (params.ApplicationGetResults, error) {
 	if err := api.checkCanRead(); err != nil {
 		return params.ApplicationGetResults{}, err
 	}
@@ -50,6 +65,32 @@ func describe(settings charm.Settings, config *charm.Config) map[string]interfac
 		info := map[string]interface{}{
 			"description": option.Description,
 			"type":        option.Type,
+			"source":      "unset",
+		}
+		set := false
+		if value := settings[name]; value != nil {
+			set = true
+			info["value"] = value
+			info["source"] = "user"
+		}
+		if option.Default != nil {
+			info["default"] = option.Default
+			if !set {
+				info["value"] = option.Default
+				info["source"] = "default"
+			}
+		}
+		results[name] = info
+	}
+	return results
+}
+
+func describeV4(settings charm.Settings, config *charm.Config) map[string]interface{} {
+	results := make(map[string]interface{})
+	for name, option := range config.Options {
+		info := map[string]interface{}{
+			"description": option.Description,
+			"type":        option.Type,
 		}
 		if value := settings[name]; value != nil {
 			info["value"] = value
@@ -57,13 +98,7 @@ func describe(settings charm.Settings, config *charm.Config) map[string]interfac
 			if option.Default != nil {
 				info["value"] = option.Default
 			}
-		}
-		// There is a chance that a user will set a value
-		// that may still be equal to charm's default value for this setting.
-		// This needs to work for nil values too, i.e. charm did not set
-		// settings default and this setting is still not set/is nil on the deployed application.
-		if info["value"] == option.Default {
-			info["is_default"] = true
+			info["default"] = true
 		}
 		results[name] = info
 	}

--- a/apiserver/facades/client/application/get_test.go
+++ b/apiserver/facades/client/application/get_test.go
@@ -47,6 +47,26 @@ func (s *getSuite) SetUpTest(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 }
 
+func (s *getSuite) TestClientServiceGetSmoketestV4(c *gc.C) {
+	s.AddTestingApplication(c, "wordpress", s.AddTestingCharm(c, "wordpress"))
+	v4 := &application.APIv4{s.serviceAPI}
+	results, err := v4.Get(params.ApplicationGet{"wordpress"})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(results, gc.DeepEquals, params.ApplicationGetResults{
+		Application: "wordpress",
+		Charm:       "wordpress",
+		Config: map[string]interface{}{
+			"blog-title": map[string]interface{}{
+				"default":     true,
+				"description": "A descriptive title used for the blog.",
+				"type":        "string",
+				"value":       "My Title",
+			},
+		},
+		Series: "quantal",
+	})
+}
+
 func (s *getSuite) TestClientServiceGetSmoketest(c *gc.C) {
 	s.AddTestingApplication(c, "wordpress", s.AddTestingCharm(c, "wordpress"))
 	results, err := s.serviceAPI.Get(params.ApplicationGet{"wordpress"})

--- a/apiserver/facades/client/application/get_test.go
+++ b/apiserver/facades/client/application/get_test.go
@@ -56,10 +56,11 @@ func (s *getSuite) TestClientServiceGetSmoketest(c *gc.C) {
 		Charm:       "wordpress",
 		Config: map[string]interface{}{
 			"blog-title": map[string]interface{}{
+				"default":     "My Title",
+				"description": "A descriptive title used for the blog.",
+				"source":      "default",
 				"type":        "string",
 				"value":       "My Title",
-				"description": "A descriptive title used for the blog.",
-				"is_default":  true,
 			},
 		},
 		Series: "quantal",
@@ -93,25 +94,28 @@ var getTests = []struct {
 	expect: params.ApplicationGetResults{
 		Config: map[string]interface{}{
 			"title": map[string]interface{}{
+				"default":     "My Title",
 				"description": "A descriptive title used for the application.",
+				"source":      "user",
 				"type":        "string",
 				"value":       "Look To Windward",
 			},
 			"outlook": map[string]interface{}{
 				"description": "No default outlook.",
+				"source":      "unset",
 				"type":        "string",
-				"is_default":  true,
 			},
 			"username": map[string]interface{}{
+				"default":     "admin001",
 				"description": "The name of the initial account (given admin permissions).",
+				"source":      "user",
 				"type":        "string",
 				"value":       "admin001",
-				"is_default":  true,
 			},
 			"skill-level": map[string]interface{}{
 				"description": "A number indicating skill.",
+				"source":      "unset",
 				"type":        "int",
-				"is_default":  true,
 			},
 		},
 		Series: "quantal",
@@ -132,23 +136,28 @@ var getTests = []struct {
 	expect: params.ApplicationGetResults{
 		Config: map[string]interface{}{
 			"title": map[string]interface{}{
+				"default":     "My Title",
 				"description": "A descriptive title used for the application.",
+				"source":      "default",
 				"type":        "string",
 				"value":       "My Title",
-				"is_default":  true,
 			},
 			"outlook": map[string]interface{}{
 				"description": "No default outlook.",
 				"type":        "string",
+				"source":      "user",
 				"value":       "phlegmatic",
 			},
 			"username": map[string]interface{}{
+				"default":     "admin001",
 				"description": "The name of the initial account (given admin permissions).",
+				"source":      "user",
 				"type":        "string",
 				"value":       "foobie",
 			},
 			"skill-level": map[string]interface{}{
 				"description": "A number indicating skill.",
+				"source":      "user",
 				"type":        "int",
 				// TODO(jam): 2013-08-28 bug #1217742
 				// we have to use float64() here, because the
@@ -192,7 +201,7 @@ func (s *getSuite) TestServiceGet(c *gc.C) {
 		client := apiapplication.NewClient(s.APIState)
 		got, err := client.Get(app.Name())
 		c.Assert(err, jc.ErrorIsNil)
-		c.Assert(*got, gc.DeepEquals, expect)
+		c.Assert(*got, jc.DeepEquals, expect)
 	}
 }
 
@@ -217,6 +226,7 @@ func (s *getSuite) TestGetMaxResolutionInt(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(got.Config["skill-level"], jc.DeepEquals, map[string]interface{}{
 		"description": "A number indicating skill.",
+		"source":      "user",
 		"type":        "int",
 		"value":       asFloat,
 	})

--- a/featuretests/application_config_test.go
+++ b/featuretests/application_config_test.go
@@ -157,66 +157,67 @@ func (s *ApplicationConfigSuite) assertJujuConfigOutput(c *gc.C, jujuConfigOutpu
 	c.Assert(len(obtained), gc.Equals, len(s.settingKeys))
 	for name, aSetting := range expected {
 		c.Assert(s.settingKeys.Contains(name), jc.IsTrue)
-		c.Assert(obtained[name].Default, gc.Equals, aSetting.Default)
 		c.Assert(obtained[name].Value, gc.Equals, aSetting.Value)
+		c.Assert(obtained[name].Source, gc.Equals, aSetting.Source)
 	}
 }
 
 type configSetting struct {
-	Value   interface{}
-	Default bool
+	Value  interface{}
+	Source string
 }
 
 type settingsMap map[string]configSetting
 
 var (
 	initialConfig = settingsMap{
-		"booleandefault":   {true, true},
-		"booleannodefault": {nil, true},
-		"booleanoverwrite": {false, false},
-		"floatdefault":     {4.2, true},
-		"floatnodefault":   {nil, true},
-		"floatoverwrite":   {2.1, false},
-		"intdefault":       {42, true},
-		"intnodefault":     {nil, true},
-		"intoverwrite":     {1620, false},
-		"strdefault":       {"charm default", true},
-		"strnodefault":     {nil, true},
-		"stroverwrite":     {"test value", false},
+		"booleandefault":   {true, "default"},
+		"booleannodefault": {nil, "unset"},
+		"booleanoverwrite": {false, "user"},
+		"floatdefault":     {4.2, "default"},
+		"floatnodefault":   {nil, "unset"},
+		"floatoverwrite":   {2.1, "user"},
+		"intdefault":       {42, "default"},
+		"intnodefault":     {nil, "unset"},
+		"intoverwrite":     {1620, "user"},
+		"strdefault":       {"charm default", "default"},
+		"strnodefault":     {nil, "unset"},
+		"stroverwrite":     {"test value", "user"},
 	}
 	updatedConfig = settingsMap{
-		"booleandefault":   {false, false},
-		"booleannodefault": {true, false},
-		"booleanoverwrite": {true, true}, // this should be true since user-specified value is the same as default
-		"floatdefault":     {7.2, false},
-		"floatnodefault":   {10.2, false},
-		"floatoverwrite":   {11.1, true}, // this should be true since user-specified value is the same as default
-		"intdefault":       {22, false},
-		"intnodefault":     {11, false},
-		"intoverwrite":     {111, true}, // this should be true since user-specified value is the same as default
-		"strdefault":       {"not", false},
-		"strnodefault":     {"maybe", false},
-		"stroverwrite":     {"me", false},
+		"booleandefault":   {false, "user"},
+		"booleannodefault": {true, "user"},
+		"booleanoverwrite": {true, "user"}, // this should be true since user-specified value is the same as default
+		"floatdefault":     {7.2, "user"},
+		"floatnodefault":   {10.2, "user"},
+		"floatoverwrite":   {11.1, "user"}, // this should be true since user-specified value is the same as default
+		"intdefault":       {22, "user"},
+		"intnodefault":     {11, "user"},
+		"intoverwrite":     {111, "user"}, // this should be true since user-specified value is the same as default
+		"strdefault":       {"not", "user"},
+		"strnodefault":     {"maybe", "user"},
+		"stroverwrite":     {"me", "user"},
 	}
 	resetConfig = settingsMap{
-		"booleandefault":   {true, true},
-		"booleannodefault": {nil, true},
-		"booleanoverwrite": {true, true},
-		"floatdefault":     {4.2, true},
-		"floatnodefault":   {nil, true},
-		"floatoverwrite":   {11.1, true},
-		"intdefault":       {42, true},
-		"intnodefault":     {nil, true},
-		"intoverwrite":     {111, true},
-		"strdefault":       {"charm default", true},
-		"strnodefault":     {nil, true},
-		"stroverwrite":     {"overwrite me", true},
+		"booleandefault":   {true, "default"},
+		"booleannodefault": {nil, "unset"},
+		"booleanoverwrite": {true, "default"},
+		"floatdefault":     {4.2, "default"},
+		"floatnodefault":   {nil, "unset"},
+		"floatoverwrite":   {11.1, "default"},
+		"intdefault":       {42, "default"},
+		"intnodefault":     {nil, "unset"},
+		"intoverwrite":     {111, "default"},
+		"strdefault":       {"charm default", "default"},
+		"strnodefault":     {nil, "unset"},
+		"stroverwrite":     {"overwrite me", "default"},
 	}
 )
 
 type TestSetting struct {
-	Default     bool        `yaml:"is_default"`
+	Default     interface{} `yaml:"default"`
 	Description string      `yaml:"description"`
+	Source      string      `yaml:"source"`
 	Type        string      `yaml:"type"`
 	Value       interface{} `yaml:"value"`
 }

--- a/featuretests/cmdjuju_test.go
+++ b/featuretests/cmdjuju_test.go
@@ -98,20 +98,22 @@ charm: dummy
 settings:
   outlook:
     description: No default outlook.
-    is_default: true
+    source: unset
     type: string
   skill-level:
     description: A number indicating skill.
-    is_default: true
+    source: unset
     type: int
   title:
+    default: My Title
     description: A descriptive title used for the application.
-    is_default: true
+    source: default
     type: string
     value: My Title
   username:
+    default: admin001
     description: The name of the initial account (given admin permissions).
-    is_default: true
+    source: default
     type: string
     value: admin001
 `


### PR DESCRIPTION
The Application.Get method was updated to change the "default" boolean returned value to "is_default".

However this was done on the main facade without adding a method to the v4 backwards compatible shim to keep the old behaviour for old callers.

While making this change, it became apparent that there was no way for the user to know whether or not a value was set if it matched the default.

This new code removes "is_default", and adds "source", which is one of "unset", "default", "user", and the new key "default" which is the charm default value.

## QA steps

deploy something
then "juju config <appname>"
