### PR TITLE
Fixes lp#1705112: unit agent runs upgrade steps worker.

### DIFF
--- a/cmd/jujud/agent/engine_test.go
+++ b/cmd/jujud/agent/engine_test.go
@@ -82,6 +82,10 @@ var (
 		"migration-inactive-flag",
 		"migration-minion",
 		"upgrader",
+		"upgrade-steps-flag",
+		"upgrade-steps-gate",
+		"upgrade-check-gate",
+		"upgrade-check-flag",
 	}
 	notMigratingUnitWorkers = []string{
 		"api-address-updater",

--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -582,7 +582,7 @@ func (a *MachineAgent) makeEngineCreator(previousAgentVersion version.Number) fu
 			CentralHub:           a.centralHub,
 			PubSubReporter:       pubsubReporter,
 			UpdateLoggerConfig:   updateAgentConfLogging,
-			Reporter: func(apiConn api.Connection) (upgradesteps.StatusSetter, error) {
+			NewAgentStatusSetter: func(apiConn api.Connection) (upgradesteps.StatusSetter, error) {
 				return a.machine(apiConn)
 			},
 		})

--- a/cmd/jujud/agent/machine/manifolds.go
+++ b/cmd/jujud/agent/machine/manifolds.go
@@ -152,8 +152,8 @@ type ManifoldsConfig struct {
 	// config value as the logging config in the agent.conf file.
 	UpdateLoggerConfig func(string) error
 
-	// Reporter provides upgradesteps.StatusSetter.
-	Reporter func(apiConn api.Connection) (upgradesteps.StatusSetter, error)
+	// NewAgentStatusSetter provides upgradesteps.StatusSetter.
+	NewAgentStatusSetter func(apiConn api.Connection) (upgradesteps.StatusSetter, error)
 }
 
 // Manifolds returns a set of co-configured manifolds covering the
@@ -342,7 +342,7 @@ func Manifolds(config ManifoldsConfig) dependency.Manifolds {
 			UpgradeStepsGateName: upgradeStepsGateName,
 			OpenStateForUpgrade:  config.OpenStateForUpgrade,
 			PreUpgradeSteps:      config.PreUpgradeSteps,
-			Reporter:             config.Reporter,
+			NewAgentStatusSetter: config.NewAgentStatusSetter,
 		}),
 
 		// The migration workers collaborate to run migrations;

--- a/cmd/jujud/agent/machine/manifolds.go
+++ b/cmd/jujud/agent/machine/manifolds.go
@@ -151,6 +151,9 @@ type ManifoldsConfig struct {
 	// UpdateLoggerConfig is a function that will save the specified
 	// config value as the logging config in the agent.conf file.
 	UpdateLoggerConfig func(string) error
+
+	// Reporter provides upgradesteps.StatusSetter.
+	Reporter func(apiConn api.Connection) (upgradesteps.StatusSetter, error)
 }
 
 // Manifolds returns a set of co-configured manifolds covering the
@@ -339,6 +342,7 @@ func Manifolds(config ManifoldsConfig) dependency.Manifolds {
 			UpgradeStepsGateName: upgradeStepsGateName,
 			OpenStateForUpgrade:  config.OpenStateForUpgrade,
 			PreUpgradeSteps:      config.PreUpgradeSteps,
+			Reporter:             config.Reporter,
 		}),
 
 		// The migration workers collaborate to run migrations;

--- a/cmd/jujud/agent/unit.go
+++ b/cmd/jujud/agent/unit.go
@@ -17,12 +17,10 @@ import (
 	"gopkg.in/tomb.v1"
 
 	"github.com/juju/juju/agent"
-	"github.com/juju/juju/api"
 	"github.com/juju/juju/api/base"
 	"github.com/juju/juju/api/uniter"
 	"github.com/juju/juju/cmd/jujud/agent/unit"
 	cmdutil "github.com/juju/juju/cmd/jujud/util"
-	"github.com/juju/juju/status"
 	"github.com/juju/juju/upgrades"
 	jworker "github.com/juju/juju/worker"
 	"github.com/juju/juju/worker/dependency"
@@ -180,9 +178,6 @@ func (a *UnitAgent) APIWorkers() (worker.Worker, error) {
 		PreUpgradeSteps:      a.preUpgradeSteps,
 		UpgradeStepsLock:     a.upgradeComplete,
 		UpgradeCheckLock:     a.initialUpgradeCheckComplete,
-		Reporter: func(apiConn api.Connection) (upgradesteps.StatusSetter, error) {
-			return a, nil
-		},
 	})
 
 	config := dependency.EngineConfig{
@@ -247,10 +242,5 @@ func (a *UnitAgent) validateMigration(apiCaller base.APICaller) error {
 		return errors.Errorf("model mismatch when validating: got %q, expected %q",
 			newModelUUID, curModelUUID)
 	}
-	return nil
-}
-
-// SetStatus implements upgradesteps.StatusSetter
-func (a *UnitAgent) SetStatus(setableStatus status.Status, info string, data map[string]interface{}) error {
 	return nil
 }

--- a/cmd/jujud/agent/unit/manifolds.go
+++ b/cmd/jujud/agent/unit/manifolds.go
@@ -202,7 +202,7 @@ func Manifolds(config ManifoldsConfig) dependency.Manifolds {
 			},
 			PreUpgradeSteps: config.PreUpgradeSteps,
 			NewAgentStatusSetter: func(apiConn api.Connection) (upgradesteps.StatusSetter, error) {
-				return noopStatusSetter{}, nil
+				return &noopStatusSetter{}, nil
 			},
 		}),
 

--- a/cmd/jujud/agent/unit/manifolds.go
+++ b/cmd/jujud/agent/unit/manifolds.go
@@ -9,6 +9,7 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/utils/clock"
 	"github.com/juju/utils/voyeur"
+	"github.com/juju/version"
 	"github.com/prometheus/client_golang/prometheus"
 
 	coreagent "github.com/juju/juju/agent"
@@ -16,6 +17,7 @@ import (
 	"github.com/juju/juju/api/base"
 	msapi "github.com/juju/juju/api/meterstatus"
 	"github.com/juju/juju/cmd/jujud/agent/engine"
+	"github.com/juju/juju/state"
 	"github.com/juju/juju/utils/proxy"
 	"github.com/juju/juju/worker"
 	"github.com/juju/juju/worker/agent"
@@ -24,6 +26,7 @@ import (
 	"github.com/juju/juju/worker/apiconfigwatcher"
 	"github.com/juju/juju/worker/dependency"
 	"github.com/juju/juju/worker/fortress"
+	"github.com/juju/juju/worker/gate"
 	"github.com/juju/juju/worker/leadership"
 	"github.com/juju/juju/worker/logger"
 	"github.com/juju/juju/worker/logsender"
@@ -37,6 +40,7 @@ import (
 	"github.com/juju/juju/worker/retrystrategy"
 	"github.com/juju/juju/worker/uniter"
 	"github.com/juju/juju/worker/upgrader"
+	"github.com/juju/juju/worker/upgradesteps"
 )
 
 // ManifoldsConfig allows specialisation of the result of Manifolds.
@@ -68,6 +72,28 @@ type ManifoldsConfig struct {
 	// UpdateLoggerConfig is a function that will save the specified
 	// config value as the logging config in the agent.conf file.
 	UpdateLoggerConfig func(string) error
+
+	// PreviousAgentVersion passes through the version the unit
+	// agent was running before the current restart.
+	PreviousAgentVersion version.Number
+
+	// UpgradeStepsLock is passed to the upgrade steps gate to
+	// coordinate workers that shouldn't do anything until the
+	// upgrade-steps worker is done.
+	UpgradeStepsLock gate.Lock
+
+	// UpgradeCheckLock is passed to the upgrade check gate to
+	// coordinate workers that shouldn't do anything until the
+	// upgrader worker completes it's first check.
+	UpgradeCheckLock gate.Lock
+
+	// PreUpgradeSteps is a function that is used by the upgradesteps
+	// worker to ensure that conditions are OK for an upgrade to
+	// proceed.
+	PreUpgradeSteps func(*state.State, coreagent.Config, bool, bool) error
+
+	// Reporter provides upgradesteps.StatusSetter.
+	Reporter func(apiConn api.Connection) (upgradesteps.StatusSetter, error)
 }
 
 // Manifolds returns a set of co-configured manifolds covering the various
@@ -127,6 +153,29 @@ func Manifolds(config ManifoldsConfig) dependency.Manifolds {
 			LogSource:     config.LogSource,
 		}),
 
+		// The upgrade steps gate is used to coordinate workers which
+		// shouldn't do anything until the upgrade-steps worker has
+		// finished running any required upgrade steps. The flag of
+		// similar name is used to implement the isFullyUpgraded func
+		// that keeps upgrade concerns out of unrelated manifolds.
+		upgradeStepsGateName: gate.ManifoldEx(config.UpgradeStepsLock),
+		upgradeStepsFlagName: gate.FlagManifold(gate.FlagManifoldConfig{
+			GateName:  upgradeStepsGateName,
+			NewWorker: gate.NewFlagWorker,
+		}),
+
+		// The upgrade check gate is used to coordinate workers which
+		// shouldn't do anything until the upgrader worker has
+		// completed its first check for a new tools version to
+		// upgrade to. The flag of similar name is used to implement
+		// the isFullyUpgraded func that keeps upgrade concerns out of
+		// unrelated manifolds.
+		upgradeCheckGateName: gate.ManifoldEx(config.UpgradeCheckLock),
+		upgradeCheckFlagName: gate.FlagManifold(gate.FlagManifoldConfig{
+			GateName:  upgradeCheckGateName,
+			NewWorker: gate.NewFlagWorker,
+		}),
+
 		// The upgrader is a leaf worker that returns a specific error type
 		// recognised by the unit agent, causing other workers to be stopped
 		// and the agent to be restarted running the new tools. We should only
@@ -134,8 +183,27 @@ func Manifolds(config ManifoldsConfig) dependency.Manifolds {
 		// careful about behavioural differences, and interactions with the
 		// upgradesteps worker.
 		upgraderName: upgrader.Manifold(upgrader.ManifoldConfig{
-			AgentName:     agentName,
-			APICallerName: apiCallerName,
+			AgentName:            agentName,
+			APICallerName:        apiCallerName,
+			UpgradeStepsGateName: upgradeStepsGateName,
+			UpgradeCheckGateName: upgradeCheckGateName,
+			PreviousAgentVersion: config.PreviousAgentVersion,
+		}),
+
+		// The upgradesteps worker runs soon after the unit agent
+		// starts and runs any steps required to upgrade to the
+		// running jujud version. Once upgrade steps have run, the
+		// upgradesteps gate is unlocked and the worker exits.
+		upgradeStepsName: upgradesteps.Manifold(upgradesteps.ManifoldConfig{
+			AgentName:            agentName,
+			APICallerName:        apiCallerName,
+			UpgradeStepsGateName: upgradeStepsGateName,
+			// Realistically,  units should not open state for any reason.
+			OpenStateForUpgrade: func() (*state.State, error) {
+				return nil, errors.New("unit agent cannot open state")
+			},
+			PreUpgradeSteps: config.PreUpgradeSteps,
+			Reporter:        config.Reporter,
 		}),
 
 		// The migration workers collaborate to run migrations;
@@ -283,7 +351,13 @@ const (
 	apiConfigWatcherName = "api-config-watcher"
 	apiCallerName        = "api-caller"
 	logSenderName        = "log-sender"
+
 	upgraderName         = "upgrader"
+	upgradeStepsName     = "upgrade-steps-runner"
+	upgradeStepsGateName = "upgrade-steps-gate"
+	upgradeStepsFlagName = "upgrade-steps-flag"
+	upgradeCheckGateName = "upgrade-check-gate"
+	upgradeCheckFlagName = "upgrade-check-flag"
 
 	migrationFortressName     = "migration-fortress"
 	migrationInactiveFlagName = "migration-inactive-flag"

--- a/cmd/jujud/agent/unit/manifolds_test.go
+++ b/cmd/jujud/agent/unit/manifolds_test.go
@@ -53,6 +53,11 @@ func (s *ManifoldsSuite) TestManifoldNames(c *gc.C) {
 		"meter-status",
 		"metric-collect",
 		"metric-sender",
+		"upgrade-steps-flag",
+		"upgrade-steps-runner",
+		"upgrade-steps-gate",
+		"upgrade-check-gate",
+		"upgrade-check-flag",
 	}
 	keys := make([]string, 0, len(manifolds))
 	for k := range manifolds {
@@ -72,11 +77,16 @@ func (*ManifoldsSuite) TestMigrationGuards(c *gc.C) {
 		"migration-fortress",
 		"migration-minion",
 		"migration-inactive-flag",
+		"upgrade-steps-gate",
+		"upgrade-check-flag",
+		"upgrade-steps-runner",
+		"upgrade-steps-flag",
+		"upgrade-check-gate",
 	)
 	config := unit.ManifoldsConfig{}
 	manifolds := unit.Manifolds(config)
 	for name, manifold := range manifolds {
-		c.Logf(name)
+		c.Logf("%v [%v]", name, manifold.Inputs)
 		if !exempt.Contains(name) {
 			checkContains(c, manifold.Inputs, "migration-inactive-flag")
 			checkContains(c, manifold.Inputs, "migration-fortress")


### PR DESCRIPTION
## Description of change

Juju has 2 workers responsible for the agent upgrade.
One worker downloads new agent binary and restarts the agent.
2nd worker runs on a startup of the agent after the upgrade and runs all necessary steps required for the upgrade to complete. It is also responsible for updating agent configuration files on successful completion.

Historically, Juju ran this 2nd worker against both unit and machine agent. However, from Juju 2, this worker was not run against unit agents. It was not immediately apparent as there are currently no upgrade steps that needed to be run against a unit agent in Juju 2.x. Consequently, this oversight was picked up when unit agent configuration file was examined after an upgrade and was found to still contain the original pre-upgrade agent version.

This PR ensures that "upgrade steps" worker is run by unit agents too.

During one of the briefing discussions while looking for a solution to the bug, there has been a desire expressed to minimise changes to upgrade step worker code itself. Some worker changes were unavoidable: 

* internal tag had to change from names.MachineTag to names.Tag to cater for possibility that this could be a unit agents;
* checks for a wrench needed to be modified  to include "unit-agent" as well as existing "machine-agent".

## QA steps

1. bootstrap 2.2 controller
2. deploy 'ubuntu' into 'default' model
3. switch to 'controller' model and upgrade it to 2.3
4. switch to 'default' model and upgrade it to 2.3
5. unit agents configuration file contain correct upgradedToVersion

Before this patch, unit agent config file was not updated after upgrade and still showed original 2.2 version.

## Documentation changes

n/a

## Bug reference

https://bugs.launchpad.net/juju/+bug/1705112
