### PR TITLE
providers: set default storage provider

### DIFF
--- a/environs/config/config.go
+++ b/environs/config/config.go
@@ -113,6 +113,9 @@ const (
 	// The default block storage source.
 	StorageDefaultBlockSourceKey = "storage-default-block-source"
 
+	// The default filesystem storage source.
+	StorageDefaultFilesystemSourceKey = "storage-default-filesystem-source"
+
 	// ResourceTagsKey is an optional list or space-separated string
 	// of k=v pairs, defining the tags for ResourceTags.
 	ResourceTagsKey = "resource-tags"
@@ -994,6 +997,13 @@ func (c *Config) StorageDefaultBlockSource() (string, bool) {
 	return bs, bs != ""
 }
 
+// StorageDefaultFilesystemSource returns the default filesystem
+// storage source for the environment.
+func (c *Config) StorageDefaultFilesystemSource() (string, bool) {
+	bs := c.asString(StorageDefaultFilesystemSourceKey)
+	return bs, bs != ""
+}
+
 // ResourceTags returns a set of tags to set on environment resources
 // that Juju creates and manages, if the provider supports them. These
 // tags have no special meaning to Juju, but may be used for existing
@@ -1158,7 +1168,8 @@ var alwaysOptional = schema.Defaults{
 
 	// Storage related config.
 	// Environ providers will specify their own defaults.
-	StorageDefaultBlockSourceKey: schema.Omit,
+	StorageDefaultBlockSourceKey:      schema.Omit,
+	StorageDefaultFilesystemSourceKey: schema.Omit,
 
 	"firewall-mode":              schema.Omit,
 	"logging-config":             schema.Omit,
@@ -1531,6 +1542,11 @@ global or per instance security groups.`,
 	},
 	StorageDefaultBlockSourceKey: {
 		Description: "The default block storage source for the model",
+		Type:        environschema.Tstring,
+		Group:       environschema.EnvironGroup,
+	},
+	StorageDefaultFilesystemSourceKey: {
+		Description: "The default filesystem storage source for the model",
 		Type:        environschema.Tstring,
 		Group:       environschema.EnvironGroup,
 	},

--- a/provider/azure/environprovider.go
+++ b/provider/azure/environprovider.go
@@ -142,7 +142,15 @@ func (prov *azureEnvironProvider) PrepareConfig(args environs.PrepareConfigParam
 	if err := validateCloudSpec(args.Cloud); err != nil {
 		return nil, errors.Annotate(err, "validating cloud spec")
 	}
-	return args.Config, nil
+	// Set the default block-storage source.
+	attrs := make(map[string]interface{})
+	if _, ok := args.Config.StorageDefaultBlockSource(); !ok {
+		attrs[config.StorageDefaultBlockSourceKey] = azureStorageProviderType
+	}
+	if len(attrs) == 0 {
+		return args.Config, nil
+	}
+	return args.Config.Apply(attrs)
 }
 
 func validateCloudSpec(spec environs.CloudSpec) error {

--- a/provider/lxd/provider.go
+++ b/provider/lxd/provider.go
@@ -79,7 +79,15 @@ func (p *environProvider) PrepareConfig(args environs.PrepareConfigParams) (*con
 	if err != nil {
 		return nil, errors.Annotate(err, "validating cloud spec")
 	}
-	return args.Config, nil
+	// Set the default filesystem-storage source.
+	attrs := make(map[string]interface{})
+	if _, ok := args.Config.StorageDefaultFilesystemSource(); !ok {
+		attrs[config.StorageDefaultFilesystemSourceKey] = lxdStorageProviderType
+	}
+	if len(attrs) == 0 {
+		return args.Config, nil
+	}
+	return args.Config.Apply(attrs)
 }
 
 // Validate implements environs.EnvironProvider.

--- a/provider/oracle/export_test.go
+++ b/provider/oracle/export_test.go
@@ -6,8 +6,8 @@ package oracle
 import "github.com/juju/juju/storage"
 
 var (
-	DefaultTypes               = []storage.ProviderType{oracleStorageProvideType}
-	DefaultStorageProviderType = oracleStorageProvideType
+	DefaultTypes               = []storage.ProviderType{DefaultStorageProviderType}
+	DefaultStorageProviderType = oracleStorageProviderType
 	OracleVolumeType           = oracleVolumeType
 	OracleLatencyPool          = latencyPool
 	OracleCloudSchema          = cloudSchema

--- a/provider/oracle/storage.go
+++ b/provider/oracle/storage.go
@@ -12,7 +12,7 @@ import (
 )
 
 const (
-	oracleStorageProvideType = storage.ProviderType("oracle")
+	oracleStorageProviderType = storage.ProviderType("oracle")
 
 	// maxVolumeSizeInGB represents the maximum size in GiB for
 	// a single volume. For more information please see:
@@ -74,7 +74,7 @@ func (o *OracleEnviron) canAccessStorageAPI() (bool, error) {
 // StorageProviderTypes implements storage.ProviderRegistry.
 func (o *OracleEnviron) StorageProviderTypes() ([]storage.ProviderType, error) {
 	if access, err := o.canAccessStorageAPI(); access {
-		return []storage.ProviderType{oracleStorageProvideType}, nil
+		return []storage.ProviderType{oracleStorageProviderType}, nil
 	} else {
 		return nil, errors.Trace(err)
 	}
@@ -86,7 +86,7 @@ func (o *OracleEnviron) StorageProvider(t storage.ProviderType) (storage.Provide
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	if access && t == oracleStorageProvideType {
+	if access && t == oracleStorageProviderType {
 		return &storageProvider{
 			env: o,
 			api: o.client,

--- a/provider/oracle/storage_provider.go
+++ b/provider/oracle/storage_provider.go
@@ -62,7 +62,7 @@ func (s storageProvider) Releasable() bool {
 
 // DefaultPools  is defined on the storage.Provider interface.
 func (s storageProvider) DefaultPools() []*storage.Config {
-	latencyPool, _ := storage.NewConfig("oracle-latency", oracleStorageProvideType, map[string]interface{}{
+	latencyPool, _ := storage.NewConfig("oracle-latency", oracleStorageProviderType, map[string]interface{}{
 		oracleVolumeType: latencyPool,
 	})
 	return []*storage.Config{latencyPool}

--- a/state/filesystem_test.go
+++ b/state/filesystem_test.go
@@ -41,14 +41,24 @@ func (s *FilesystemStateSuite) TestAddServiceNoPoolNoDefaultWithUnits(c *gc.C) {
 	s.testAddServiceDefaultPool(c, "rootfs", 1)
 }
 
+func (s *FilesystemStateSuite) TestAddServiceNoPoolDefaultFilesystem(c *gc.C) {
+	// no pool specified, default filesystem configured: use default
+	// filesystem.
+	err := s.State.UpdateModelConfig(map[string]interface{}{
+		"storage-default-filesystem-source": "machinescoped",
+	}, nil)
+	c.Assert(err, jc.ErrorIsNil)
+	s.testAddServiceDefaultPool(c, "machinescoped", 0)
+}
+
 func (s *FilesystemStateSuite) TestAddServiceNoPoolDefaultBlock(c *gc.C) {
 	// no pool specified, default block configured: use default
 	// block with managed fs on top.
 	err := s.State.UpdateModelConfig(map[string]interface{}{
-		"storage-default-block-source": "machinescoped",
+		"storage-default-block-source": "modelscoped-block",
 	}, nil)
 	c.Assert(err, jc.ErrorIsNil)
-	s.testAddServiceDefaultPool(c, "machinescoped", 0)
+	s.testAddServiceDefaultPool(c, "modelscoped-block", 0)
 }
 
 func (s *FilesystemStateSuite) testAddServiceDefaultPool(c *gc.C, expectedPool string, numUnits int) {

--- a/state/storage.go
+++ b/state/storage.go
@@ -1843,11 +1843,17 @@ func defaultStoragePool(cfg *config.Config, kind storage.StorageKind, cons Stora
 			return rootfsPool, nil
 		}
 
-		// TODO(axw) add env configuration for default
-		// filesystem source, prefer that.
-		defaultPool, ok := cfg.StorageDefaultBlockSource()
+		// If a filesystem source is specified in config,
+		// use that; otherwise if a block source is specified,
+		// use that and create a filesystem within.
+		defaultPool, ok := cfg.StorageDefaultFilesystemSource()
 		if !ok {
-			defaultPool = rootfsPool
+			defaultPool, ok = cfg.StorageDefaultBlockSource()
+			if !ok {
+				// No filesystem or block source,
+				// so just use rootfs.
+				defaultPool = rootfsPool
+			}
 		}
 		return defaultPool, nil
 	}


### PR DESCRIPTION
## Description of change

Update the Azure, LXD, and Oracle providers
to set the default block/filesystem storage
sources for new models.

Introduce the storage-default-filesystem-source
model config for the LXD provider, which sets it
to "lxd" by default. This config trumps
storage-default-block-source for filesystem
storage.

## QA steps

1. juju bootstrap localhost
2. juju deploy cs:~axwalk/storagetest --storage fs=1G
3. juju storage
storage should be using lxd provider

repeat for azure and oracle

## Documentation changes

None.

## Bug reference

Fixes https://bugs.launchpad.net/juju/+bug/1705961