### PR TITLE
Fix installing bash completions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -107,7 +107,7 @@ install-dependencies:
 # Install bash_completion
 install-etc:
 	@echo Installing bash completion
-	@sudo install -o root -g root -m 644 etc/bash_completion.d/juju-2.0 /usr/share/bash-completion/completions
+	@sudo install -o root -g root -m 644 etc/bash_completion.d/juju /usr/share/bash-completion/completions
 	@sudo install -o root -g root -m 644 etc/bash_completion.d/juju-version /usr/share/bash-completion/completions
 
 setup-lxd:


### PR DESCRIPTION
## Description of change

Installing bash completions via `make install-etc` as described in the readme fails with
```bash
install: cannot stat 'etc/bash_completion.d/juju-2.0': No such file or directory
make: *** [Makefile:110: install-etc] Error 1
```
And probably has been failing for a while.

This is because the file that was being referenced from the Makefile doesn't exist.

## QA steps

Run `make install-etc` before and after this PR

## Documentation changes

None

## Bug reference

I didn't find a relevant bug report in launchpad
