### PR TITLE
Include the traceback at DEBUG level

### DIFF
--- a/worker/dependency/engine.go
+++ b/worker/dependency/engine.go
@@ -5,6 +5,7 @@ package dependency
 
 import (
 	"math/rand"
+	"strings"
 	"time"
 
 	"github.com/juju/errors"
@@ -493,6 +494,10 @@ func (engine *Engine) gotStarted(name string, worker worker.Worker, resourceLog 
 	}
 }
 
+type stackTracer interface {
+	StackTrace() []string
+}
+
 // gotStopped updates the engine to reflect the demise of (or failure to create)
 // a worker. It must only be called from the loop goroutine.
 func (engine *Engine) gotStopped(name string, err error, resourceLog []resourceAccess) {
@@ -544,6 +549,9 @@ func (engine *Engine) gotStopped(name string, err error, resourceLog []resourceA
 		default:
 			// Something went wrong but we don't know what. Try again soon.
 			logger.Errorf("%q manifold worker returned unexpected error: %v", name, err)
+			if tracer, ok := err.(stackTracer); ok {
+				logger.Debugf("stack trace:\n%s", strings.Join(tracer.StackTrace(), "\n"))
+			}
 			engine.requestStart(name, engine.config.ErrorDelay)
 		}
 	}


### PR DESCRIPTION
## Description of change

If we have an error that includes a stack trace, include that in the log
output at DEBUG level. Otherwise when we have a worker fail with a Panic() it is very hard for us to figure out where the actual Panic() occurred for us to fix it.

## QA steps

When you have a worker failure, you should be able to do:
```
juju model-config -m controller logging-config="<root>=?;juju.worker.dependency=DEBUG"
```
and it will include the stack trace of the panic.

## Documentation changes

We could include this as an operational support item for Juju.

## Bug reference


[lp:1722810](https://bugs.launchpad.net/juju/+bug/1722810)

