### PR TITLE
There is no reason I can see to explicitly create 'txns'

### DIFF
--- a/state/allcollections.go
+++ b/state/allcollections.go
@@ -51,9 +51,8 @@ func allCollections() collectionSchema {
 
 		txnsC: {
 			// This collection is used exclusively by mgo/txn to record transactions.
-			global:         true,
-			rawAccess:      true,
-			explicitCreate: &mgo.CollectionInfo{},
+			global:    true,
+			rawAccess: true,
 			indexes: []mgo.Index{{
 				// The "s" field is used in queries
 				// by mgo/txn.Runner.ResumeAll.


### PR DESCRIPTION
## Description of change

We need explicit creation for txns.log because it is a capped
collection, but we don't get anything for doing it for txns (we don't
set any parameters.)

This was impacting me running with a Mongo 3.4 because supposedly db.createCollection("foo") is supposed to fail if "foo" already exists. What I can't figure out is how the test suite passes at all, because I see it doing db.createCollection("txns") on *every* StateSuite.SetUpTest, and when I do that manually with mongo 3.2 it breaks. It also breaks when I run the test suite on Mongo 3.4, but not with 3.2.

## QA steps

No visible impact, but slightly better if we try to run with Mongo 3.4 (which is a goal for the next cycle)

## Documentation changes

None

## Bug reference

None