### PR TITLE
2.2 into develop

### DIFF
--- a/apiserver/facades/client/client/backend.go
+++ b/apiserver/facades/client/client/backend.go
@@ -36,6 +36,7 @@ type Backend interface {
 	AllIPAddresses() ([]*state.Address, error)
 	AllLinkLayerDevices() ([]*state.LinkLayerDevice, error)
 	AllRelations() ([]*state.Relation, error)
+	AllSubnets() ([]*state.Subnet, error)
 	Annotations(state.GlobalEntity) (map[string]string, error)
 	APIHostPorts() ([][]network.HostPort, error)
 	Application(string) (*state.Application, error)
@@ -61,7 +62,6 @@ type Backend interface {
 	SetAnnotations(state.GlobalEntity, map[string]string) error
 	SetModelAgentVersion(version.Number) error
 	SetModelConstraints(constraints.Value) error
-	Subnet(string) (*state.Subnet, error)
 	Unit(string) (Unit, error)
 	UpdateModelConfig(map[string]interface{}, []string, ...state.ValidateConfigFunc) error
 	Watch(params state.WatchParams) *state.Multiwatcher

--- a/apiserver/facades/client/client/status.go
+++ b/apiserver/facades/client/client/status.go
@@ -436,6 +436,16 @@ func fetchMachines(st Backend, machineIds set.Strings) (map[string][]*state.Mach
 func fetchNetworkInterfaces(st Backend) (map[string][]*state.Address, map[string]map[string]set.Strings, map[string][]*state.LinkLayerDevice, error) {
 	ipAddresses := make(map[string][]*state.Address)
 	spaces := make(map[string]map[string]set.Strings)
+	subnets, err := st.AllSubnets()
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	subnetsByCIDR := make(map[string]*state.Subnet)
+	for _, subnet := range subnets {
+		subnetsByCIDR[subnet.CIDR()] = subnet
+	}
+	// For every machine, track what devices have addresses so we can filter linklayerdevices later
+	devicesWithAddresses := make(map[string]set.Strings)
 	ipAddrs, err := st.AllIPAddresses()
 	if err != nil {
 		return nil, nil, nil, err
@@ -446,26 +456,27 @@ func fetchNetworkInterfaces(st Backend) (map[string][]*state.Address, map[string
 		}
 		machineID := ipAddr.MachineID()
 		ipAddresses[machineID] = append(ipAddresses[machineID], ipAddr)
-		subnet, err := st.Subnet(ipAddr.SubnetCIDR())
-		if errors.IsNotFound(err) {
-			// No worries; no subnets means no spaces.
-			continue
-		} else if err != nil {
-			return nil, nil, nil, err
+		if subnet, ok := subnetsByCIDR[ipAddr.SubnetCIDR()]; ok {
+			if spaceName := subnet.SpaceName(); spaceName != "" {
+				devices, ok := spaces[machineID]
+				if !ok {
+					devices = make(map[string]set.Strings)
+					spaces[machineID] = devices
+				}
+				deviceName := ipAddr.DeviceName()
+				spacesSet, ok := devices[deviceName]
+				if !ok {
+					spacesSet = make(set.Strings)
+					devices[deviceName] = spacesSet
+				}
+				spacesSet.Add(spaceName)
+			}
 		}
-		if spaceName := subnet.SpaceName(); spaceName != "" {
-			devices, ok := spaces[machineID]
-			if !ok {
-				devices = make(map[string]set.Strings)
-				spaces[machineID] = devices
-			}
-			deviceName := ipAddr.DeviceName()
-			spacesSet, ok := devices[deviceName]
-			if !ok {
-				spacesSet = make(set.Strings)
-				devices[deviceName] = spacesSet
-			}
-			spacesSet.Add(spaceName)
+		deviceSet, ok := devicesWithAddresses[machineID]
+		if ok {
+			deviceSet.Add(ipAddr.DeviceName())
+		} else {
+			devicesWithAddresses[machineID] = set.NewStrings(ipAddr.DeviceName())
 		}
 	}
 
@@ -478,16 +489,18 @@ func fetchNetworkInterfaces(st Backend) (map[string][]*state.Address, map[string
 		if llDev.IsLoopbackDevice() {
 			continue
 		}
-		addrs, err := llDev.Addresses()
-		if err != nil {
-			return nil, nil, nil, err
+		machineID := llDev.MachineID()
+		machineDevs, ok := devicesWithAddresses[machineID]
+		if !ok {
+			// This machine ID doesn't seem to have any devices with IP Addresses
+			continue
 		}
-		// We don't want to see bond slaves or bridge ports, only the
-		// IP-addressed devices.
-		if len(addrs) > 0 {
-			machineID := llDev.MachineID()
-			linkLayerDevices[machineID] = append(linkLayerDevices[machineID], llDev)
+		if !machineDevs.Contains(llDev.Name()) {
+			// this device did not have any IP Addresses
+			continue
 		}
+		// This device had an IP Address, so include it in the list of devices for this machine
+		linkLayerDevices[machineID] = append(linkLayerDevices[machineID], llDev)
 	}
 
 	return ipAddresses, spaces, linkLayerDevices, nil

--- a/state/allcollections.go
+++ b/state/allcollections.go
@@ -343,9 +343,13 @@ func allCollections() collectionSchema {
 		subnetsC:              {},
 		linkLayerDevicesC:     {},
 		linkLayerDevicesRefsC: {},
-		ipAddressesC:          {},
-		endpointBindingsC:     {},
-		openedPortsC:          {},
+		ipAddressesC: {
+			indexes: []mgo.Index{{
+				Key: []string{"model-uuid", "machine-id", "device-name"},
+			}},
+		},
+		endpointBindingsC: {},
+		openedPortsC:      {},
 
 		// -----
 

--- a/worker/dependency/engine.go
+++ b/worker/dependency/engine.go
@@ -5,6 +5,7 @@ package dependency
 
 import (
 	"math/rand"
+	"strings"
 	"time"
 
 	"github.com/juju/errors"
@@ -493,6 +494,10 @@ func (engine *Engine) gotStarted(name string, worker worker.Worker, resourceLog 
 	}
 }
 
+type stackTracer interface {
+	StackTrace() []string
+}
+
 // gotStopped updates the engine to reflect the demise of (or failure to create)
 // a worker. It must only be called from the loop goroutine.
 func (engine *Engine) gotStopped(name string, err error, resourceLog []resourceAccess) {
@@ -544,6 +549,9 @@ func (engine *Engine) gotStopped(name string, err error, resourceLog []resourceA
 		default:
 			// Something went wrong but we don't know what. Try again soon.
 			logger.Errorf("%q manifold worker returned unexpected error: %v", name, err)
+			if tracer, ok := err.(stackTracer); ok {
+				logger.Debugf("stack trace:\n%s", strings.Join(tracer.StackTrace(), "\n"))
+			}
 			engine.requestStart(name, engine.config.ErrorDelay)
 		}
 	}

--- a/worker/firewaller/firewaller.go
+++ b/worker/firewaller/firewaller.go
@@ -870,6 +870,10 @@ func (fw *Firewaller) flushInstancePorts(machined *machineData, toOpen, toClose 
 	}
 	machineId := machined.tag.Id()
 	instanceId, err := m.InstanceId()
+	if params.IsCodeNotProvisioned(err) {
+		// Not provisioned yet, so nothing to do for this instance
+		return nil
+	}
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Description of change

Bring in the recent fixes that landed on the 2.2 branch into 2.3.
This includes:
 * performance improvement for "juju status"
 * firewaller shouldn't abort on a NotProvisioned instance
 * include the ability to get StackTrace when workers exit due to a panic()

## QA steps

See the individual merges.

## Documentation changes

None

## Bug reference

[lp:1722617](https://bugs.launchpad.net/juju/+bug/1722617)
[lp:1722813](https://bugs.launchpad.net/juju/+bug/1722813)
[lp:1722810](https://bugs.launchpad.net/juju/+bug/1722810)