### PR TITLE
React to error, don't swallow it.

### DIFF
--- a/apiserver/common/crossmodel/state.go
+++ b/apiserver/common/crossmodel/state.go
@@ -23,6 +23,9 @@ type statePoolShim struct {
 
 func (p *statePoolShim) Get(modelUUID string) (Backend, func(), error) {
 	st, releaser, err := p.StatePool.Get(modelUUID)
+	if err != nil {
+		return stateShim{}, func() {}, err
+	}
 	closer := func() {
 		releaser()
 	}

--- a/apiserver/common/crossmodel/state.go
+++ b/apiserver/common/crossmodel/state.go
@@ -24,7 +24,7 @@ type statePoolShim struct {
 func (p *statePoolShim) Get(modelUUID string) (Backend, func(), error) {
 	st, releaser, err := p.StatePool.Get(modelUUID)
 	if err != nil {
-		return stateShim{}, func() {}, err
+		return nil, func() {}, err
 	}
 	closer := func() {
 		releaser()


### PR DESCRIPTION
## Description of change

State pool Get and GetModel errors should not be swallowed. 
An error in this line would cause the next line to misbehave unexpectedly.

