### PR TITLE
Workers don't error if remote controllers are no longer available

### DIFF
--- a/worker/remoterelations/manifold.go
+++ b/worker/remoterelations/manifold.go
@@ -5,7 +5,8 @@ package remoterelations
 
 import (
 	"github.com/juju/errors"
-	worker "gopkg.in/juju/worker.v1"
+	"github.com/juju/utils/clock"
+	"gopkg.in/juju/worker.v1"
 
 	"github.com/juju/juju/agent"
 	"github.com/juju/juju/api"
@@ -68,6 +69,7 @@ func (config ManifoldConfig) start(context dependency.Context) (worker.Worker, e
 		ModelUUID:                agent.CurrentConfig().Model().Id(),
 		RelationsFacade:          facade,
 		NewRemoteModelFacadeFunc: remoteRelationsFacadeForModelFunc(config.NewControllerConnection),
+		Clock: clock.WallClock,
 	})
 	if err != nil {
 		return nil, errors.Trace(err)

--- a/worker/remoterelations/remoteapplicationworker.go
+++ b/worker/remoterelations/remoteapplicationworker.go
@@ -6,7 +6,7 @@ package remoterelations
 import (
 	"github.com/juju/errors"
 	"gopkg.in/juju/names.v2"
-	worker "gopkg.in/juju/worker.v1"
+	"gopkg.in/juju/worker.v1"
 	"gopkg.in/macaroon.v1"
 
 	"github.com/juju/juju/apiserver/params"
@@ -59,34 +59,6 @@ type relation struct {
 	localEndpoint      params.RemoteEndpoint
 	remoteEndpointName string
 	macaroon           *macaroon.Macaroon
-}
-
-func newRemoteApplicationWorker(
-	relationsWatcher watcher.StringsWatcher,
-	localModelUUID string,
-	remoteApplication params.RemoteApplication,
-	newRemoteModelRelationsFacadeFunc newRemoteRelationsFacadeFunc,
-	facade RemoteRelationsFacade,
-) (worker.Worker, error) {
-	w := &remoteApplicationWorker{
-		relationsWatcher:                  relationsWatcher,
-		offerUUID:                         remoteApplication.OfferUUID,
-		applicationName:                   remoteApplication.Name,
-		localModelUUID:                    localModelUUID,
-		remoteModelUUID:                   remoteApplication.ModelUUID,
-		isConsumerProxy:                   remoteApplication.IsConsumerProxy,
-		offerMacaroon:                     remoteApplication.Macaroon,
-		localRelationChanges:              make(chan params.RemoteRelationChangeEvent),
-		remoteRelationChanges:             make(chan params.RemoteRelationChangeEvent),
-		localModelFacade:                  facade,
-		newRemoteModelRelationsFacadeFunc: newRemoteModelRelationsFacadeFunc,
-	}
-	err := catacomb.Invoke(catacomb.Plan{
-		Site: &w.catacomb,
-		Work: w.loop,
-		Init: []worker.Worker{relationsWatcher},
-	})
-	return w, err
 }
 
 // Kill is defined on worker.Worker

--- a/worker/remoterelations/remoterelations.go
+++ b/worker/remoterelations/remoterelations.go
@@ -5,11 +5,13 @@ package remoterelations
 
 import (
 	"io"
+	"time"
 
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
+	"github.com/juju/utils/clock"
 	"gopkg.in/juju/names.v2"
-	worker "gopkg.in/juju/worker.v1"
+	"gopkg.in/juju/worker.v1"
 	"gopkg.in/macaroon.v1"
 
 	"github.com/juju/juju/api"
@@ -108,6 +110,7 @@ type Config struct {
 	ModelUUID                string
 	RelationsFacade          RemoteRelationsFacade
 	NewRemoteModelFacadeFunc newRemoteRelationsFacadeFunc
+	Clock                    clock.Clock
 }
 
 // Validate returns an error if config cannot drive a Worker.
@@ -121,6 +124,9 @@ func (config Config) Validate() error {
 	if config.NewRemoteModelFacadeFunc == nil {
 		return errors.NotValidf("nil Remote Model Facade func")
 	}
+	if config.Clock == nil {
+		return errors.NotValidf("nil Clock")
+	}
 	return nil
 }
 
@@ -131,13 +137,23 @@ func New(config Config) (*Worker, error) {
 	}
 
 	w := &Worker{
-		config:             config,
-		logger:             logger,
-		applicationWorkers: make(map[string]worker.Worker),
+		config: config,
+		logger: logger,
+		runner: worker.NewRunner(worker.RunnerParams{
+			Clock: config.Clock,
+
+			// One of the remote application workers failing should not
+			// prevent the others from running.
+			IsFatal: func(error) bool { return false },
+
+			// For any failures, try again in 1 minute.
+			RestartDelay: time.Minute,
+		}),
 	}
 	err := catacomb.Invoke(catacomb.Plan{
 		Site: &w.catacomb,
 		Work: w.loop,
+		Init: []worker.Worker{w.runner},
 	})
 	return w, errors.Trace(err)
 }
@@ -149,9 +165,7 @@ type Worker struct {
 	config   Config
 	logger   loggo.Logger
 
-	// applicationWorkers holds a worker for each
-	// remote application being watched.
-	applicationWorkers map[string]worker.Worker
+	runner *worker.Runner
 }
 
 // Kill is defined on worker.Worker.
@@ -206,51 +220,58 @@ func (w *Worker) handleApplicationChanges(applicationIds []string) error {
 		if result.Error != nil {
 			// The the remote application has been removed, stop its worker.
 			if params.IsCodeNotFound(result.Error) {
-				if err := w.killApplicationWorker(name); err != nil {
+				if err := w.runner.StopWorker(name); err != nil {
 					return err
 				}
 				continue
 			}
 			return errors.Annotatef(err, "querying remote application %q", name)
 		}
-		if _, ok := w.applicationWorkers[name]; ok {
+		if _, err := w.runner.Worker(name, w.catacomb.Dying()); err == nil {
 			// TODO(wallyworld): handle application dying or dead.
 			// As of now, if the worker is already running, that's all we need.
 			continue
 		}
 		relationsWatcher, err := w.config.RelationsFacade.WatchRemoteApplicationRelations(name)
 		if errors.IsNotFound(err) {
-			if err := w.killApplicationWorker(name); err != nil {
+			if err := w.runner.StopWorker(name); err != nil {
 				return err
 			}
 			continue
 		} else if err != nil {
 			return errors.Annotatef(err, "watching relations for remote application %q", name)
 		}
-		logger.Debugf("started watcher for remote application %q", name)
-		appWorker, err := newRemoteApplicationWorker(
-			relationsWatcher,
-			w.config.ModelUUID,
-			*result.Result,
-			w.config.NewRemoteModelFacadeFunc,
-			w.config.RelationsFacade,
-		)
-		if err != nil {
-			return errors.Trace(err)
-		}
-		if err := w.catacomb.Add(appWorker); err != nil {
-			return errors.Trace(err)
-		}
-		w.applicationWorkers[name] = appWorker
-	}
-	return nil
-}
 
-func (w *Worker) killApplicationWorker(name string) error {
-	appWorker, ok := w.applicationWorkers[name]
-	if ok {
-		delete(w.applicationWorkers, name)
-		return worker.Stop(appWorker)
+		remoteApp := *result.Result
+		startFunc := func() (worker.Worker, error) {
+			appWorker := &remoteApplicationWorker{
+				relationsWatcher:                  relationsWatcher,
+				offerUUID:                         remoteApp.OfferUUID,
+				applicationName:                   remoteApp.Name,
+				localModelUUID:                    w.config.ModelUUID,
+				remoteModelUUID:                   remoteApp.ModelUUID,
+				isConsumerProxy:                   remoteApp.IsConsumerProxy,
+				offerMacaroon:                     remoteApp.Macaroon,
+				localRelationChanges:              make(chan params.RemoteRelationChangeEvent),
+				remoteRelationChanges:             make(chan params.RemoteRelationChangeEvent),
+				localModelFacade:                  w.config.RelationsFacade,
+				newRemoteModelRelationsFacadeFunc: w.config.NewRemoteModelFacadeFunc,
+			}
+			if err := catacomb.Invoke(catacomb.Plan{
+				Site: &appWorker.catacomb,
+				Work: appWorker.loop,
+				Init: []worker.Worker{relationsWatcher},
+			}); err != nil {
+				return nil, errors.Trace(err)
+			}
+			return appWorker, nil
+		}
+
+		logger.Debugf("starting watcher for remote application %q", name)
+		// Start the application worker to watch for things like new relations.
+		if err := w.runner.StartWorker(name, startFunc); err != nil {
+			return errors.Annotate(err, "error starting remote application worker")
+		}
 	}
 	return nil
 }

--- a/worker/remoterelations/remoterelationsworker.go
+++ b/worker/remoterelations/remoterelationsworker.go
@@ -6,7 +6,7 @@ package remoterelations
 import (
 	"github.com/juju/errors"
 	"gopkg.in/juju/names.v2"
-	worker "gopkg.in/juju/worker.v1"
+	"gopkg.in/juju/worker.v1"
 
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/watcher"


### PR DESCRIPTION
## Description of change

Make it so that if a particular controller in a cmr dies, workers (remote relation and firewaller) continue to operate properly for any other controllers / local controller. Solution involves a little refactoring / moving of existing methods.

## QA steps

Internal changes.
Test by deploying mysql in one controller, and then
bootstrap another controller and deploy and relate mediawiki to mysql
bootstrap yet another controller and deploy and mediawiki
kill second controller
relate mediawiki in 3rd still running controller to mysql
check logs and operation of remote relation

## Bug reference

https://bugs.launchpad.net/juju/+bug/1723067
