### PR TITLE
Inherit FAN subnet space from underlay

### DIFF
--- a/state/migration_import_test.go
+++ b/state/migration_import_test.go
@@ -869,6 +869,38 @@ func (s *MigrationImportSuite) TestSubnets(c *gc.C) {
 		VLANTag:           64,
 		AvailabilityZone:  "bar",
 		SpaceName:         "bam",
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	_, err = s.State.AddSpace("bam", "", nil, true)
+	c.Assert(err, jc.ErrorIsNil)
+
+	_, newSt := s.importModel(c)
+
+	subnet, err := newSt.Subnet(original.CIDR())
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Assert(subnet.CIDR(), gc.Equals, "10.0.0.0/24")
+	c.Assert(subnet.ProviderId(), gc.Equals, network.Id("foo"))
+	c.Assert(subnet.ProviderNetworkId(), gc.Equals, network.Id("elm"))
+	c.Assert(subnet.VLANTag(), gc.Equals, 64)
+	c.Assert(subnet.AvailabilityZone(), gc.Equals, "bar")
+	c.Assert(subnet.SpaceName(), gc.Equals, "bam")
+	c.Assert(subnet.FanLocalUnderlay(), gc.Equals, "")
+	c.Assert(subnet.FanOverlay(), gc.Equals, "")
+}
+
+func (s *MigrationImportSuite) TestSubnetsWithFan(c *gc.C) {
+	_, err := s.State.AddSubnet(state.SubnetInfo{
+		CIDR:      "100.2.0.0/16",
+		SpaceName: "bam",
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	original, err := s.State.AddSubnet(state.SubnetInfo{
+		CIDR:              "10.0.0.0/24",
+		ProviderId:        network.Id("foo"),
+		ProviderNetworkId: network.Id("elm"),
+		VLANTag:           64,
+		AvailabilityZone:  "bar",
 		FanLocalUnderlay:  "100.2.0.0/16",
 		FanOverlay:        "253.0.0.0/8",
 	})

--- a/state/spaces.go
+++ b/state/spaces.go
@@ -65,12 +65,12 @@ func (s *Space) Subnets() (results []*Subnet, err error) {
 	iter := subnetsCollection.Find(bson.D{{"space-name", name}, bson.DocElem{"fan-local-underlay", bson.D{{"$exists", false}}}}).Iter()
 	defer iter.Close()
 	for iter.Next(&doc) {
-		subnet := &Subnet{s.st, doc}
+		subnet := &Subnet{s.st, doc, name}
 		results = append(results, subnet)
 		// ...and then add them explicitly as descendants of underlay network.
-		iter := subnetsCollection.Find(bson.D{{"fan-local-underlay", doc.CIDR}}).Iter()
-		for iter.Next(&doc) {
-			subnet := &Subnet{s.st, doc}
+		childIter := subnetsCollection.Find(bson.D{{"fan-local-underlay", doc.CIDR}}).Iter()
+		for childIter.Next(&doc) {
+			subnet := &Subnet{s.st, doc, name}
 			results = append(results, subnet)
 		}
 	}

--- a/state/spaces.go
+++ b/state/spaces.go
@@ -61,11 +61,18 @@ func (s *Space) Subnets() (results []*Subnet, err error) {
 	defer closer()
 
 	var doc subnetDoc
-	iter := subnetsCollection.Find(bson.D{{"space-name", name}}).Iter()
+	// We ignore space-name field for FAN subnets...
+	iter := subnetsCollection.Find(bson.D{{"space-name", name}, bson.DocElem{"fan-local-underlay", bson.D{{"$exists", false}}}}).Iter()
 	defer iter.Close()
 	for iter.Next(&doc) {
 		subnet := &Subnet{s.st, doc}
 		results = append(results, subnet)
+		// ...and then add them explicitly as descendants of underlay network.
+		iter := subnetsCollection.Find(bson.D{{"fan-local-underlay", doc.CIDR}}).Iter()
+		for iter.Next(&doc) {
+			subnet := &Subnet{s.st, doc}
+			results = append(results, subnet)
+		}
 	}
 	if err := iter.Err(); err != nil {
 		return nil, err
@@ -106,7 +113,7 @@ func (st *State) AddSpace(name string, providerId network.Id, subnets []string, 
 		ops = append(ops, txn.Op{
 			C:      subnetsC,
 			Id:     subnetId,
-			Assert: txn.DocExists,
+			Assert: bson.D{bson.DocElem{"fan-local-underlay", bson.D{{"$exists", false}}}},
 			Update: bson.D{{"$set", bson.D{{"space-name", name}}}},
 		})
 	}
@@ -116,8 +123,12 @@ func (st *State) AddSpace(name string, providerId network.Id, subnets []string, 
 			return nil, errors.AlreadyExistsf("space %q", name)
 		}
 		for _, subnetId := range subnets {
-			if _, err := st.Subnet(subnetId); errors.IsNotFound(err) {
+			subnet, err := st.Subnet(subnetId)
+			if errors.IsNotFound(err) {
 				return nil, err
+			}
+			if subnet.FanLocalUnderlay() != "" {
+				return nil, errors.Errorf("Can't set space for FAN subnet %q - it's always inherited from underlay", subnet.CIDR())
 			}
 		}
 		if err := newSpace.Refresh(); err != nil {

--- a/state/subnets.go
+++ b/state/subnets.go
@@ -175,6 +175,12 @@ func (s *Subnet) AvailabilityZone() string {
 // SpaceName returns the space the subnet is associated with. If the subnet is
 // not associated with a space it will be the empty string.
 func (s *Subnet) SpaceName() string {
+	if s.doc.FanLocalUnderlay != "" {
+		underlay, err := s.st.Subnet(s.doc.FanLocalUnderlay)
+		if err == nil {
+			return underlay.SpaceName()
+		}
+	}
 	return s.doc.SpaceName
 }
 

--- a/state/subnets_test.go
+++ b/state/subnets_test.go
@@ -20,6 +20,14 @@ type SubnetSuite struct {
 var _ = gc.Suite(&SubnetSuite{})
 
 func (s *SubnetSuite) TestAddSubnetSucceedsWithFullyPopulatedInfo(c *gc.C) {
+	fanOverlaySubnetInfo := state.SubnetInfo{
+		ProviderId: "foo2",
+		CIDR:       "10.0.0.0/8",
+		SpaceName:  "foo",
+	}
+	subnet, err := s.State.AddSubnet(fanOverlaySubnetInfo)
+	c.Assert(err, jc.ErrorIsNil)
+	s.assertSubnetMatchesInfo(c, subnet, fanOverlaySubnetInfo)
 	subnetInfo := state.SubnetInfo{
 		ProviderId:        "foo",
 		CIDR:              "192.168.1.0/24",
@@ -31,7 +39,7 @@ func (s *SubnetSuite) TestAddSubnetSucceedsWithFullyPopulatedInfo(c *gc.C) {
 		FanOverlay:        "172.16.0.0/16",
 	}
 
-	subnet, err := s.State.AddSubnet(subnetInfo)
+	subnet, err = s.State.AddSubnet(subnetInfo)
 	c.Assert(err, jc.ErrorIsNil)
 	s.assertSubnetMatchesInfo(c, subnet, subnetInfo)
 
@@ -260,6 +268,7 @@ func (s *SubnetSuite) TestAllSubnets(c *gc.C) {
 		{CIDR: "8.8.8.0/24", SpaceName: "bar"},
 		{CIDR: "10.0.2.0/24", ProviderId: "foo"},
 		{CIDR: "2001:db8::/64", AvailabilityZone: "zone1"},
+		{CIDR: "253.0.0.0/8", SpaceName: "notreally", FanLocalUnderlay: "8.8.8.0/24"},
 	}
 
 	for _, info := range subnetInfos {
@@ -272,9 +281,14 @@ func (s *SubnetSuite) TestAllSubnets(c *gc.C) {
 	c.Assert(subnets, gc.HasLen, len(subnetInfos))
 
 	for i, subnet := range subnets {
-		c.Assert(subnet.CIDR(), gc.Equals, subnetInfos[i].CIDR)
-		c.Assert(subnet.ProviderId(), gc.Equals, subnetInfos[i].ProviderId)
-		c.Assert(subnet.SpaceName(), gc.Equals, subnetInfos[i].SpaceName)
-		c.Assert(subnet.AvailabilityZone(), gc.Equals, subnetInfos[i].AvailabilityZone)
+		c.Check(subnet.CIDR(), gc.Equals, subnetInfos[i].CIDR)
+		c.Check(subnet.ProviderId(), gc.Equals, subnetInfos[i].ProviderId)
+		if subnet.FanLocalUnderlay() == "" {
+			c.Check(subnet.SpaceName(), gc.Equals, subnetInfos[i].SpaceName)
+		} else {
+			// Special case
+			c.Check(subnet.SpaceName(), gc.Equals, "bar")
+		}
+		c.Check(subnet.AvailabilityZone(), gc.Equals, subnetInfos[i].AvailabilityZone)
 	}
 }


### PR DESCRIPTION
## Description of change
FAN subnet should always have the same space as underlaying subnet

## QA steps
1. Bootstrap controller in AWS VPC with a few subnets
2. juju add-space foo (one of the regular subnets)
3. verify with juju subnets and juju spaces that the FAN subnet linked to the subnet added to foo is also in foo
4. juju add-space foo2 (fan subnet) -> it should fail with error message that FAN subnet space is always inherited

## Bug reference
http://pad.lv/1722661
