### PR TITLE
Include offers with no connections in list-offers --tabular

### DIFF
--- a/cmd/juju/crossmodel/listformatter.go
+++ b/cmd/juju/crossmodel/listformatter.go
@@ -78,10 +78,7 @@ func formatListEndpointsSummary(writer io.Writer, offers offeredApplications) er
 func (o offerItems) Len() int      { return len(o) }
 func (o offerItems) Swap(i, j int) { o[i], o[j] = o[j], o[i] }
 func (o offerItems) Less(i, j int) bool {
-	if o[i].Source == o[j].Source {
-		return o[i].OfferName < o[j].OfferName
-	}
-	return o[i].Source < o[j].Source
+	return o[i].OfferName < o[j].OfferName
 }
 
 func formatListTabular(writer io.Writer, value interface{}) error {
@@ -115,6 +112,11 @@ func formatListEndpointsTabular(writer io.Writer, offers offeredApplications) er
 
 		// Sort connections by relation id and username.
 		sort.Sort(byUserRelationId(offer.Connections))
+
+		// If there are no connections, print am empty row.
+		if len(offer.Connections) == 0 {
+			w.Println(offer.OfferName, "-", "", "", "", "", "", "")
+		}
 
 		for i, conn := range offer.Connections {
 			if i == 0 {


### PR DESCRIPTION
## Description of change

juju list-offers in tabular format (the default) shows relations/connections to offers, one relation per line. If there are no relations to any offers, no output was printed. We now print all offers by default - the offer name and a "-" in the next column if the offer has no connections.

A new flag --active-only is added to allow offers with no relations to be omitted from the output.

## QA steps

Run juju offers on a model with no offers, or no offers with any relations, or some offers with no relations.

## Documentation Changes

The new semantics of the list-offers command will need to be documented.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1723311
