### PR TITLE
Fix the invalid args in assess_cloud_display.py

### DIFF
--- a/acceptancetests/assess_cloud_display.py
+++ b/acceptancetests/assess_cloud_display.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+
 from __future__ import print_function
 
 from argparse import ArgumentParser
@@ -7,7 +8,7 @@ from copy import deepcopy
 from difflib import ndiff
 import os
 from pprint import pformat
-
+import sys
 import yaml
 
 from jujupy import client_from_config
@@ -105,7 +106,7 @@ def main():
     args = parser.parse_args()
     client = client_from_config(None, args.juju_bin)
     with client.env.make_juju_home(
-            client.env.juju_home, 'mytest', {}) as juju_home:
+            client.env.juju_home, 'mytest') as juju_home:
         client.env.juju_home = juju_home
         with open(get_home_path(client, 'public-clouds.yaml'), 'w') as f:
             f.write('')
@@ -123,4 +124,4 @@ def main():
 
 
 if __name__ == '__main__':
-    main()
+    sys.exit(main())


### PR DESCRIPTION
## Description of change
Fix the failure observed in cloud display test:

http://ci.jujucharms.com/job/clouds-display/

## QA steps
$ export JUJU_HOME=<path_to>/cloud-city
$ export JUJU_BIN=<path_to>/juju
$ ./assess_cloud_display.py $JUJU_HOME/example-clouds.yaml $JUJU_BIN

This change has been locally validated.

## Documentation changes
N/A

## Bug reference
N/A