### PR TITLE
Fixes lp#1721786: Ignore NotFound during for model lists.

### DIFF
--- a/apiserver/facades/client/controller/controller.go
+++ b/apiserver/facades/client/controller/controller.go
@@ -119,6 +119,10 @@ func (s *ControllerAPIv3) AllModels() (params.UserModelList, error) {
 	for _, modelUUID := range modelUUIDs {
 		st, release, err := s.statePool.Get(modelUUID)
 		if err != nil {
+			// This model could have been removed.
+			if errors.IsNotFound(err) {
+				continue
+			}
 			return result, errors.Trace(err)
 		}
 		defer release()
@@ -246,6 +250,10 @@ func (s *ControllerAPIv3) HostedModelConfigs() (params.HostedModelConfigsResults
 		}
 		st, release, err := s.statePool.Get(modelUUID)
 		if err != nil {
+			// This model could have been removed.
+			if errors.IsNotFound(err) {
+				continue
+			}
 			return result, errors.Trace(err)
 		}
 		defer release()

--- a/apiserver/facades/client/modelmanager/modelmanager.go
+++ b/apiserver/facades/client/modelmanager/modelmanager.go
@@ -695,6 +695,10 @@ func (m *ModelManagerAPI) ListModels(user params.Entity) (params.UserModelList, 
 	for _, modelUUID := range modelUUIDs {
 		st, release, err := m.state.GetBackend(modelUUID)
 		if err != nil {
+			// This model could have been removed.
+			if errors.IsNotFound(err) {
+				continue
+			}
 			return result, errors.Trace(err)
 		}
 		defer release()


### PR DESCRIPTION
## Description of change

We get a comprehensive model list that suits the criteria specified for listing. However, when we come to get model details, there is a chance that the model has been removed since the initial call.

This PR cater for this situation by ignoring NotFound errors. 

## Bug reference

https://bugs.launchpad.net/juju/+bug/1721786
