### PR TITLE
Add DeriveAvailabilityZone to the common.ZonedEnviron interface.

### DIFF
--- a/provider/common/availabilityzones.go
+++ b/provider/common/availabilityzones.go
@@ -31,6 +31,16 @@ type ZonedEnviron interface {
 	// zones for the specified instances. The error returned follows the same
 	// rules as Environ.Instances.
 	InstanceAvailabilityZoneNames(ids []instance.Id) ([]string, error)
+
+	// DeriveAvailabilityZone attempts to derive an availability zone from
+	// the specified StartInstanceParams.
+	//
+	// The parameters for starting an instance may imply (or explicitly
+	// specify) an availability zone, e.g. due to placement, or due to the
+	// attachment of existing volumes. If there is no such restriction,
+	// then DeriveAvailabilityZone should return an empty string to
+	// indicate that the caller should choose an availability zone.
+	DeriveAvailabilityZone(args environs.StartInstanceParams) (string, error)
 }
 
 // AvailabilityZoneInstances describes an availability zone and

--- a/provider/common/mock_test.go
+++ b/provider/common/mock_test.go
@@ -103,11 +103,13 @@ func (env *mockEnviron) StorageProvider(t jujustorage.ProviderType) (jujustorage
 
 type availabilityZonesFunc func() ([]common.AvailabilityZone, error)
 type instanceAvailabilityZoneNamesFunc func([]instance.Id) ([]string, error)
+type deriveAvailabilityZoneFunc func(environs.StartInstanceParams) (string, error)
 
 type mockZonedEnviron struct {
 	mockEnviron
 	availabilityZones             availabilityZonesFunc
 	instanceAvailabilityZoneNames instanceAvailabilityZoneNamesFunc
+	deriveAvailabilityZone        deriveAvailabilityZoneFunc
 }
 
 func (env *mockZonedEnviron) AvailabilityZones() ([]common.AvailabilityZone, error) {
@@ -116,6 +118,10 @@ func (env *mockZonedEnviron) AvailabilityZones() ([]common.AvailabilityZone, err
 
 func (env *mockZonedEnviron) InstanceAvailabilityZoneNames(ids []instance.Id) ([]string, error) {
 	return env.instanceAvailabilityZoneNames(ids)
+}
+
+func (env *mockZonedEnviron) DeriveAvailabilityZone(args environs.StartInstanceParams) (string, error) {
+	return env.deriveAvailabilityZone(args)
 }
 
 type mockInstance struct {

--- a/provider/dummy/environs.go
+++ b/provider/dummy/environs.go
@@ -1307,16 +1307,30 @@ func (env *environ) AvailabilityZones() ([]common.AvailabilityZone, error) {
 	return []common.AvailabilityZone{
 		azShim{"zone1", true},
 		azShim{"zone2", false},
+		azShim{"zone3", false},
+		azShim{"zone4", true},
 	}, nil
 }
 
 // InstanceAvailabilityZoneNames implements environs.ZonedEnviron.
 func (env *environ) InstanceAvailabilityZoneNames(ids []instance.Id) ([]string, error) {
-	// TODO(dimitern): Fix this properly.
 	if err := env.checkBroken("InstanceAvailabilityZoneNames"); err != nil {
 		return nil, errors.NotSupportedf("instance availability zones")
 	}
-	return []string{"zone1"}, nil
+	returnValue := make([]string, len(ids))
+	for i, _ := range ids {
+		if i%2 == 0 {
+			returnValue[i] = "zone1"
+		} else {
+			returnValue[i] = "zone4"
+		}
+	}
+	return returnValue, nil
+}
+
+// DeriveAvailabilityZone is part of the common.ZonedEnviron interface.
+func (env *environ) DeriveAvailabilityZone(args environs.StartInstanceParams) (string, error) {
+	return "", nil
 }
 
 // Subnets implements environs.Environ.Subnets.

--- a/provider/gce/environ_availzones.go
+++ b/provider/gce/environ_availzones.go
@@ -54,6 +54,18 @@ func (env *environ) InstanceAvailabilityZoneNames(ids []instance.Id) ([]string, 
 	return results, err
 }
 
+// DeriveAvailabilityZone is part of the common.ZonedEnviron interface.
+func (env *environ) DeriveAvailabilityZone(args environs.StartInstanceParams) (string, error) {
+	// TODO (HML) 16-Oct-2017
+	// startInstanceAvailabilityZones will change to startInstanceAvailabilityZone with
+	// the Provisioner Parallelization.
+	availabilityZones, err := env.startInstanceAvailabilityZones(args)
+	if err != nil {
+		return "", errors.Trace(err)
+	}
+	return availabilityZones[0], nil
+}
+
 func (env *environ) availZone(name string) (*google.AvailabilityZone, error) {
 	zones, err := env.gce.AvailabilityZones(env.cloud.Region)
 	if err != nil {

--- a/provider/maas/environ.go
+++ b/provider/maas/environ.go
@@ -580,6 +580,15 @@ func (e *maasEnviron) InstanceAvailabilityZoneNames(ids []instance.Id) ([]string
 	return zones, nil
 }
 
+// DeriveAvailabilityZone is part of the common.ZonedEnviron interface.
+func (e *maasEnviron) DeriveAvailabilityZone(args environs.StartInstanceParams) (string, error) {
+	placement, err := e.parsePlacement(args.Placement)
+	if err != nil {
+		return "", err
+	}
+	return placement.zoneName, nil
+}
+
 type maasPlacement struct {
 	nodeName string
 	zoneName string

--- a/provider/maas/environ_whitebox_test.go
+++ b/provider/maas/environ_whitebox_test.go
@@ -700,6 +700,29 @@ func (s *environSuite) TestPrecheckNodePlacement(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 }
 
+func (s *environSuite) TestDeriveAvailabilityZone(c *gc.C) {
+	s.testMAASObject.TestServer.AddZone("zone1", "the grass is greener in zone1")
+	env := s.makeEnviron()
+	zone, err := env.DeriveAvailabilityZone(environs.StartInstanceParams{Placement: "zone=zone1"})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(zone, gc.Equals, "zone1")
+}
+
+func (s *environSuite) TestDeriveAvailabilityZoneUnknown(c *gc.C) {
+	s.testMAASObject.TestServer.AddZone("zone1", "the grass is greener in zone1")
+	env := s.makeEnviron()
+	zone, err := env.DeriveAvailabilityZone(environs.StartInstanceParams{Placement: "zone=zone2"})
+	c.Assert(err, gc.ErrorMatches, `invalid availability zone "zone2"`)
+	c.Assert(zone, gc.Equals, "")
+}
+
+func (s *environSuite) TestDeriveAvailabilityZoneInvalidPlacement(c *gc.C) {
+	env := s.makeEnviron()
+	zone, err := env.DeriveAvailabilityZone(environs.StartInstanceParams{Placement: "notzone=anything"})
+	c.Assert(err, gc.ErrorMatches, "unknown placement directive: notzone=anything")
+	c.Assert(zone, gc.Equals, "")
+}
+
 func (s *environSuite) TestStartInstanceAvailZone(c *gc.C) {
 	// Add a node for the started instance.
 	s.newNode(c, "thenode1", "host1", map[string]interface{}{"zone": "test-available"})

--- a/provider/openstack/provider.go
+++ b/provider/openstack/provider.go
@@ -572,6 +572,18 @@ type openstackPlacement struct {
 	availabilityZone nova.AvailabilityZone
 }
 
+// DeriveAvailabilityZone is part of the common.ZonedEnviron interface.
+func (e *Environ) DeriveAvailabilityZone(args environs.StartInstanceParams) (string, error) {
+	// ToDo (HML) 16-Oct-2017
+	// startInstanceAvailabilityZones will change to startInstanceAvailabilityZone with
+	// the Provisioner Parallelization.
+	availabilityZones, err := e.startInstanceAvailabilityZones(args)
+	if err != nil {
+		return "", errors.Trace(err)
+	}
+	return availabilityZones[0], nil
+}
+
 func (e *Environ) parsePlacement(placement string) (*openstackPlacement, error) {
 	pos := strings.IndexRune(placement, '=')
 	if pos == -1 {

--- a/provider/vsphere/environ_availzones.go
+++ b/provider/vsphere/environ_availzones.go
@@ -93,6 +93,27 @@ func (env *sessionEnviron) InstanceAvailabilityZoneNames(ids []instance.Id) ([]s
 	return results, err
 }
 
+// DeriveAvailabilityZone is part of the common.ZonedEnviron interface.
+func (env *environ) DeriveAvailabilityZone(args environs.StartInstanceParams) (names string, err error) {
+	err = env.withSession(func(env *sessionEnviron) error {
+		names, err = env.DeriveAvailabilityZone(args)
+		return err
+	})
+	return names, err
+}
+
+// DeriveAvailabilityZone is part of the common.ZonedEnviron interface.
+func (env *sessionEnviron) DeriveAvailabilityZone(args environs.StartInstanceParams) (string, error) {
+	// TODO (HML) 16-Oct-2017
+	// parseAvailabilityZones will change to parseAvailabilityZone with
+	// the Provisioner Parallelization.
+	zones, err := env.parseAvailabilityZones(args)
+	if err != nil {
+		return "", err
+	}
+	return zones[0], nil
+}
+
 func (env *sessionEnviron) availZone(name string) (common.AvailabilityZone, error) {
 	zones, err := env.AvailabilityZones()
 	if err != nil {


### PR DESCRIPTION
## Description of change

To be used for availability zone placement verification and hints in the parallelized
provisioner.

## QA steps

Unit tests

## Documentation changes

N/A

## Bug reference

Part of the work for: https://bugs.launchpad.net/juju/+bug/1692493