### PR TITLE
Expose all the sequences for a model.

### DIFF
--- a/api/modelconfig/modelconfig.go
+++ b/api/modelconfig/modelconfig.go
@@ -90,3 +90,13 @@ func (c *Client) SLALevel() (string, error) {
 	}
 	return result.Result, nil
 }
+
+// ModelSequences returns the internal sequences for the apiserver model endpoint.
+func (c *Client) ModelSequences() (map[string]int, error) {
+	result := params.ModelSequenceResult{}
+	err := c.facade.FacadeCall("ModelSequences", nil, &result)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return result.Sequences, nil
+}

--- a/api/modelconfig/modelconfig_test.go
+++ b/api/modelconfig/modelconfig_test.go
@@ -180,3 +180,31 @@ func (s *modelconfigSuite) TestGetSupport(c *gc.C) {
 	c.Assert(called, jc.IsTrue)
 	c.Assert(level, gc.Equals, "level")
 }
+
+func (s *modelconfigSuite) TestModelSequences(c *gc.C) {
+	sequences := map[string]int{
+		"first":  1,
+		"second": 2,
+	}
+
+	apiCaller := basetesting.APICallerFunc(
+		func(objType string,
+			version int,
+			id, request string,
+			a, result interface{},
+		) error {
+			c.Check(objType, gc.Equals, "ModelConfig")
+			c.Check(id, gc.Equals, "")
+			c.Check(request, gc.Equals, "ModelSequences")
+			c.Check(a, gc.IsNil)
+			c.Assert(result, gc.FitsTypeOf, &params.ModelSequenceResult{})
+			results := result.(*params.ModelSequenceResult)
+			results.Sequences = sequences
+			return nil
+		},
+	)
+	client := modelconfig.NewClient(apiCaller)
+	result, err := client.ModelSequences()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result, jc.DeepEquals, sequences)
+}

--- a/apiserver/allfacades.go
+++ b/apiserver/allfacades.go
@@ -194,7 +194,8 @@ func AllFacades() *facade.Registry {
 	reg("MigrationMinion", 1, migrationminion.NewFacade)
 	reg("MigrationTarget", 1, migrationtarget.NewFacade)
 
-	reg("ModelConfig", 1, modelconfig.NewFacade)
+	reg("ModelConfig", 1, modelconfig.NewFacadeV1)
+	reg("ModelConfig", 2, modelconfig.NewFacade)
 	reg("ModelManager", 2, modelmanager.NewFacadeV2)
 	reg("ModelManager", 3, modelmanager.NewFacadeV3)
 	reg("ModelManager", 4, modelmanager.NewFacadeV4)

--- a/apiserver/common/modelmanagerinterface.go
+++ b/apiserver/common/modelmanagerinterface.go
@@ -97,6 +97,7 @@ type Model interface {
 	AddUser(state.UserAccessSpec) (permission.UserAccess, error)
 	AutoConfigureContainerNetworking(environ environs.Environ) error
 	ModelConfigDefaultValues() (config.ModelDefaultAttributes, error)
+	AllSequences() (map[string]int, error)
 }
 
 var _ ModelManagerBackend = (*modelManagerStateShim)(nil)

--- a/apiserver/facades/client/modelconfig/backend.go
+++ b/apiserver/facades/client/modelconfig/backend.go
@@ -15,6 +15,7 @@ import (
 // allowing stubs to be created for testing.
 type Backend interface {
 	common.BlockGetter
+	AllSequences() (map[string]int, error)
 	ControllerTag() names.ControllerTag
 	ModelTag() names.ModelTag
 	ModelConfigValues() (config.ConfigValues, error)
@@ -26,6 +27,10 @@ type Backend interface {
 type stateShim struct {
 	*state.State
 	model *state.Model
+}
+
+func (st stateShim) AllSequences() (map[string]int, error) {
+	return st.model.AllSequences()
 }
 
 func (st stateShim) UpdateModelConfig(u map[string]interface{}, r []string, a ...state.ValidateConfigFunc) error {

--- a/apiserver/facades/client/modelmanager/modelmanager.go
+++ b/apiserver/facades/client/modelmanager/modelmanager.go
@@ -81,7 +81,7 @@ type ModelManagerAPI struct {
 	model       common.Model
 }
 
-// ModelManagerAPIV2 provides a way to wrap the different calls between
+// ModelManagerAPIV3 provides a way to wrap the different calls between
 // version 3 and version 4 of the model manager API
 type ModelManagerAPIV3 struct {
 	*ModelManagerAPI

--- a/apiserver/params/params.go
+++ b/apiserver/params/params.go
@@ -1112,3 +1112,8 @@ type DumpModelRequest struct {
 	Entities   []Entity `json:"entities"`
 	Simplified bool     `json:"simplified"`
 }
+
+// ModelSequenceResult contains the sequences for a single model.
+type ModelSequenceResult struct {
+	Sequences map[string]int `json:"sequences"`
+}

--- a/state/migration_export.go
+++ b/state/migration_export.go
@@ -217,16 +217,12 @@ type exporter struct {
 }
 
 func (e *exporter) sequences() error {
-	sequences, closer := e.st.db().GetCollection(sequenceC)
-	defer closer()
-
-	var docs []sequenceDoc
-	if err := sequences.Find(nil).All(&docs); err != nil {
+	sequences, err := e.dbModel.AllSequences()
+	if err != nil {
 		return errors.Trace(err)
 	}
-
-	for _, doc := range docs {
-		e.model.SetSequence(doc.Name, doc.Counter)
+	for name, value := range sequences {
+		e.model.SetSequence(name, value)
 	}
 	return nil
 }

--- a/state/sequence.go
+++ b/state/sequence.go
@@ -210,3 +210,23 @@ func (su *dbSeqUpdater) ensure(next int) error {
 	}
 	return errors.Trace(err)
 }
+
+// AllSequences returns all the sequences used in the database.
+// Used for exporting models, and providing through the API for bundle
+// deployment.
+func (m *Model) AllSequences() (map[string]int, error) {
+	sequences, closer := m.st.db().GetCollection(sequenceC)
+	defer closer()
+
+	result := make(map[string]int)
+
+	var docs []sequenceDoc
+	if err := sequences.Find(nil).All(&docs); err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	for _, doc := range docs {
+		result[doc.Name] = doc.Counter
+	}
+	return result, nil
+}


### PR DESCRIPTION
In order to give accurate feedback to the user deploying a bundle in dry-run mode, the processing code needs to create the unit numbers and machine numbers in a similar way to the way the apiserver will. To get the numbers right, we need to know what they are.

## QA steps

This will be hooked up in the bundle dry run branch.

## Documentation changes

Nothing user facing here.