### PR TITLE
Hosted models may error individually.

### DIFF
--- a/cmd/juju/controller/kill.go
+++ b/cmd/juju/controller/kill.go
@@ -182,6 +182,14 @@ func (c *killCommand) DirectDestroyRemaining(ctx *cmd.Context, api destroyContro
 		logger.Errorf("unable to retrieve hosted model config: %v", err)
 	}
 	for _, model := range hostedConfig {
+		if model.Error != nil {
+			// We can only display model name here since
+			// the error coming from api can be anything
+			// including the parsing of the model owner tag.
+			// Only model name is guaranteed to be set in the result
+			// when an error is returned.
+			ctx.Infof("Could not kill %s directly: %v", model.Name, model.Error)
+		}
 		ctx.Infof("Killing %s/%s directly", model.Owner.Id(), model.Name)
 		cfg, err := config.New(config.NoDefaults, model.Config)
 		if err != nil {

--- a/cmd/juju/controller/kill.go
+++ b/cmd/juju/controller/kill.go
@@ -189,6 +189,7 @@ func (c *killCommand) DirectDestroyRemaining(ctx *cmd.Context, api destroyContro
 			// Only model name is guaranteed to be set in the result
 			// when an error is returned.
 			ctx.Infof("Could not kill %s directly: %v", model.Name, model.Error)
+			continue
 		}
 		ctx.Infof("Killing %s/%s directly", model.Owner.Id(), model.Name)
 		cfg, err := config.New(config.NoDefaults, model.Config)

--- a/cmd/juju/controller/kill.go
+++ b/cmd/juju/controller/kill.go
@@ -188,7 +188,8 @@ func (c *killCommand) DirectDestroyRemaining(ctx *cmd.Context, api destroyContro
 			// including the parsing of the model owner tag.
 			// Only model name is guaranteed to be set in the result
 			// when an error is returned.
-			ctx.Infof("Could not kill %s directly: %v", model.Name, model.Error)
+			hasErrors = true
+			logger.Errorf("could not kill %s directly: %v", model.Name, model.Error)
 			continue
 		}
 		ctx.Infof("Killing %s/%s directly", model.Owner.Id(), model.Name)


### PR DESCRIPTION
## Description of change

Depending on the logic flow and circumstances, kill controller command may list hosted models. Juju iterates over this list to deal with each model directly. However, the api call may return an error for an individual model.
