### PR TITLE
GCE: Load legacy networks too

### DIFF
--- a/provider/gce/environ_network.go
+++ b/provider/gce/environ_network.go
@@ -93,6 +93,17 @@ func (e *environ) getMatchingSubnets(subnetIds IncludeSet, zones []string) ([]ne
 			))
 		}
 	}
+	// We have to include networks in 'LEGACY' mode that do not have subnetworks.
+	for _, netwk := range networks {
+		if netwk.IPv4Range != "" && subnetIds.Include(netwk.Name) {
+			results = append(results, makeSubnetInfo(
+				network.Id(netwk.Name),
+				network.Id(netwk.Name),
+				netwk.IPv4Range,
+				zones,
+			))
+		}
+	}
 	return results, nil
 }
 

--- a/provider/gce/environ_network_test.go
+++ b/provider/gce/environ_network_test.go
@@ -97,6 +97,13 @@ func (s *environNetSuite) TestGettingAllSubnets(c *gc.C) {
 		AvailabilityZones: []string{"a-zone", "b-zone"},
 		VLANTag:           0,
 		SpaceProviderId:   "",
+	}, {
+		ProviderId:        "legacy",
+		ProviderNetworkId: "legacy",
+		CIDR:              "10.240.0.0/16",
+		AvailabilityZones: []string{"a-zone", "b-zone"},
+		VLANTag:           0,
+		SpaceProviderId:   "",
 	}})
 }
 


### PR DESCRIPTION
## Description of change
Load legacy networks (ones without subnetworks) in GCE provider

## QA steps
Add a legacy network to GCE environ, see that juju subnets shows it.
