### PR TITLE
CAAS: preserve CAData when reading cloud config from kubeconfig

### DIFF
--- a/caas/clientconfig/k8s.go
+++ b/caas/clientconfig/k8s.go
@@ -61,7 +61,7 @@ func cloudsFromConfig(config *clientcmdapi.Config) (map[string]CloudConfig, erro
 	rv := map[string]CloudConfig{}
 	for name, cluster := range config.Clusters {
 		attrs := map[string]interface{}{}
-		attrs["CAData"] = cluster.CertificateAuthorityData
+		attrs["CAData"] = string(cluster.CertificateAuthorityData)
 
 		rv[name] = CloudConfig{
 			Endpoint:   cluster.Server,

--- a/caas/clientconfig/k8s_test.go
+++ b/caas/clientconfig/k8s_test.go
@@ -156,7 +156,7 @@ func (s *k8sConfigSuite) TestGetSingleConfig(c *gc.C) {
 			Clouds: map[string]caascfg.CloudConfig{
 				"the-cluster": caascfg.CloudConfig{
 					Endpoint:   "https://1.1.1.1:8888",
-					Attributes: map[string]interface{}{"CAData": []uint8("A")}}},
+					Attributes: map[string]interface{}{"CAData": "A"}}},
 			Credentials: map[string]cloud.Credential{
 				"the-user": cloud.NewCredential(
 					cloud.UserPassAuthType,
@@ -185,10 +185,10 @@ func (s *k8sConfigSuite) TestGetMultiConfig(c *gc.C) {
 			Clouds: map[string]caascfg.CloudConfig{
 				"default-cluster": caascfg.CloudConfig{
 					Endpoint:   "https://10.10.10.10:1010",
-					Attributes: map[string]interface{}{"CAData": []uint8(nil)}},
+					Attributes: map[string]interface{}{"CAData": ""}},
 				"the-cluster": caascfg.CloudConfig{
 					Endpoint:   "https://1.1.1.1:8888",
-					Attributes: map[string]interface{}{"CAData": []uint8("A")}}},
+					Attributes: map[string]interface{}{"CAData": "A"}}},
 			Credentials: map[string]cloud.Credential{
 				"default-user": cloud.NewCredential(
 					cloud.UserPassAuthType,

--- a/caas/clientconfig/k8s_test.go
+++ b/caas/clientconfig/k8s_test.go
@@ -40,6 +40,7 @@ kind: Config
 clusters:
 - cluster:
     server: https://1.1.1.1:8888
+    certificate-authority-data: QQ==
   name: the-cluster
 contexts:
 - context:
@@ -60,6 +61,7 @@ kind: Config
 clusters:
 - cluster:
     server: https://1.1.1.1:8888
+    certificate-authority-data: QQ==
   name: the-cluster
 - cluster:
     server: https://10.10.10.10:1010
@@ -154,7 +156,7 @@ func (s *k8sConfigSuite) TestGetSingleConfig(c *gc.C) {
 			Clouds: map[string]caascfg.CloudConfig{
 				"the-cluster": caascfg.CloudConfig{
 					Endpoint:   "https://1.1.1.1:8888",
-					Attributes: map[string]interface{}{"CAData": []uint8(nil)}}},
+					Attributes: map[string]interface{}{"CAData": []uint8("A")}}},
 			Credentials: map[string]cloud.Credential{
 				"the-user": cloud.NewCredential(
 					cloud.UserPassAuthType,
@@ -186,7 +188,7 @@ func (s *k8sConfigSuite) TestGetMultiConfig(c *gc.C) {
 					Attributes: map[string]interface{}{"CAData": []uint8(nil)}},
 				"the-cluster": caascfg.CloudConfig{
 					Endpoint:   "https://1.1.1.1:8888",
-					Attributes: map[string]interface{}{"CAData": []uint8(nil)}}},
+					Attributes: map[string]interface{}{"CAData": []uint8("A")}}},
 			Credentials: map[string]cloud.Credential{
 				"default-user": cloud.NewCredential(
 					cloud.UserPassAuthType,

--- a/cmd/juju/caas/add_test.go
+++ b/cmd/juju/caas/add_test.go
@@ -23,9 +23,10 @@ import (
 
 type addCAASSuite struct {
 	jujutesting.IsolationSuite
-	fakeCloudAPI      *fakeCloudAPI
-	store             *fakeCloudMetadataStore
-	fakeK8SConfigFunc caascfg.ClientConfigFunc
+	fakeCloudAPI        *fakeCloudAPI
+	store               *fakeCloudMetadataStore
+	fileCredentialStore *fakeCredentialStore
+	fakeK8SConfigFunc   caascfg.ClientConfigFunc
 }
 
 var _ = gc.Suite(&addCAASSuite{})
@@ -150,11 +151,12 @@ func (s *addCAASSuite) SetUpTest(c *gc.C) {
 	s.store.Call("PublicCloudMetadata", []string(nil)).Returns(initialCloudMap, false, nil)
 	newCloudMap["mrcloud"] = mrCloud
 	s.store.Call("WritePersonalCloudMetadata", initialCloudMap).Returns(nil)
-	s.PatchValue(&caas.NewFileCredentialStore, func() jujuclient.CredentialStore { return fakeCredentialStore{} })
 }
 
 func (s *addCAASSuite) makeCommand(c *gc.C, cloudTypeExists bool, emptyClientConfig bool) *caas.AddCAASCommand {
-	addcmd := caas.NewAddCAASCommandForTest(s.store, &fakeAPIConnection{},
+	addcmd := caas.NewAddCAASCommandForTest(s.store,
+		&fakeCredentialStore{},
+		&fakeAPIConnection{},
 		func(caller base.APICallCloser) caas.CloudAPI {
 			return s.fakeCloudAPI
 		},

--- a/cmd/juju/commands/main.go
+++ b/cmd/juju/commands/main.go
@@ -459,7 +459,7 @@ func registerCommands(r commandRegistry, ctx *cmd.Context) {
 
 	// CAAS commands
 	if featureflag.Enabled(feature.CAAS) {
-		r.Register(modelcmd.Wrap(caas.NewAddCAASCommand(&cloudToCommandAdapter{})))
+		r.Register(caas.NewAddCAASCommand(&cloudToCommandAdapter{}))
 	}
 
 	// Juju GUI commands.


### PR DESCRIPTION
kubeconfig files can have the certificate authority for a cluster encoded inline.
This should be saved as cloud config on the Cloud we generate from the defined cluster.

This PR adds that, in the three lines at add.go:157-159.

Most of the rest is changes to enable testing that the value is actually set in the resulting cloud.

The changes in k8s_test.go check that the caas clientconfig code does actually read the data if included - the code worked as it was, but the old test might have hidden a bug.

