### PR TITLE
Always use public address for ingress address for cmr

### DIFF
--- a/state/relationunit.go
+++ b/state/relationunit.go
@@ -489,7 +489,7 @@ func (ru *RelationUnit) IngressAddress() (network.Address, error) {
 	if crossmodel, err := ru.relation.IsCrossModel(); err != nil {
 		return network.Address{}, errors.Trace(err)
 	} else if !crossmodel {
-		space, err := unit.GetSpaceForBinding("")
+		space, err := unit.GetSpaceForBinding(ru.endpoint.Name)
 		if err != nil {
 			return network.Address{}, errors.Trace(err)
 		}

--- a/state/relationunit_test.go
+++ b/state/relationunit_test.go
@@ -897,7 +897,7 @@ func (s *RelationUnitSuite) TestIngressAddressWithSpaces(c *gc.C) {
 	address, err := prr.pru0.IngressAddress()
 	c.Assert(err, jc.ErrorIsNil)
 
-	c.Assert(address, gc.DeepEquals, network.NewAddress("2.2.3.4"))
+	c.Assert(address, gc.DeepEquals, addresses[0])
 }
 
 func (s *RelationUnitSuite) TestIngressAddressRemoteRelation(c *gc.C) {

--- a/testing/factory/factory.go
+++ b/testing/factory/factory.go
@@ -91,12 +91,13 @@ type MachineParams struct {
 
 // ApplicationParams is used when specifying parameters for a new application.
 type ApplicationParams struct {
-	Name        string
-	Charm       *state.Charm
-	Status      *status.StatusInfo
-	Settings    map[string]interface{}
-	Storage     map[string]state.StorageConstraints
-	Constraints constraints.Value
+	Name             string
+	Charm            *state.Charm
+	Status           *status.StatusInfo
+	Settings         map[string]interface{}
+	Storage          map[string]state.StorageConstraints
+	Constraints      constraints.Value
+	EndpointBindings map[string]string
 }
 
 // UnitParams are used to create units.
@@ -448,12 +449,13 @@ func (factory *Factory) MakeApplication(c *gc.C, params *ApplicationParams) *sta
 	}
 
 	application, err := factory.st.AddApplication(state.AddApplicationArgs{
-		Name:        params.Name,
-		Charm:       params.Charm,
-		Settings:    charm.Settings(params.Settings),
-		Storage:     params.Storage,
-		Constraints: params.Constraints,
-		Resources:   resourceMap,
+		Name:             params.Name,
+		Charm:            params.Charm,
+		Settings:         charm.Settings(params.Settings),
+		Storage:          params.Storage,
+		Constraints:      params.Constraints,
+		Resources:        resourceMap,
+		EndpointBindings: params.EndpointBindings,
 	})
 	c.Assert(err, jc.ErrorIsNil)
 


### PR DESCRIPTION
## Description of change

There was an inconsistency between the ingress address as put into relation data, vs what was obtained for network-get. Regardless of whether the endpoint is bound to a space, the public address is always used for the ingress address.

A second fix ensures that any space binding is used when adding address info to relation data.

## QA steps

Deploy CMR scenario where mysql endpoint is bound to a space. Ensure that mediawiki can connect.

## Documentation changes

None.

