### PR TITLE
Ignore not found models on destroy and backup.

### DIFF
--- a/state/backups/backups_linux.go
+++ b/state/backups/backups_linux.go
@@ -277,6 +277,10 @@ func (b *backups) Restore(backupId string, dbInfo *DBInfo, args RestoreArgs) (na
 	for _, modelUUID := range modelUUIDs {
 		st, release, err := pool.Get(modelUUID)
 		if err != nil {
+			// This model could have been removed.
+			if errors.IsNotFound(err) {
+				continue
+			}
 			return nil, errors.Trace(err)
 		}
 		defer release()

--- a/state/backups/backups_linux.go
+++ b/state/backups/backups_linux.go
@@ -277,10 +277,6 @@ func (b *backups) Restore(backupId string, dbInfo *DBInfo, args RestoreArgs) (na
 	for _, modelUUID := range modelUUIDs {
 		st, release, err := pool.Get(modelUUID)
 		if err != nil {
-			// This model could have been removed.
-			if errors.IsNotFound(err) {
-				continue
-			}
 			return nil, errors.Trace(err)
 		}
 		defer release()

--- a/state/cleanup.go
+++ b/state/cleanup.go
@@ -215,6 +215,10 @@ func (st *State) cleanupModelsForDyingController(cleanupArgs []bson.Raw) (err er
 	for _, modelUUID := range modelUUIDs {
 		st, release, err := pool.Get(modelUUID)
 		if err != nil {
+			// This model could have been removed.
+			if errors.IsNotFound(err) {
+				continue
+			}
 			return errors.Trace(err)
 		}
 		defer release()

--- a/state/model.go
+++ b/state/model.go
@@ -1143,6 +1143,10 @@ func (m *Model) destroyOps(
 
 			st, release, err := pool.Get(modelUUID)
 			if err != nil {
+				// This model could have been removed.
+				if errors.IsNotFound(err) {
+					continue
+				}
 				return nil, errors.Trace(err)
 			}
 			defer release()


### PR DESCRIPTION
## Description of change

There are several circumtances under which behavior described in the linked bug can occur. Specifically, anywhere where we have a list of models but any model can be destroyed while we are iterating over the list.
We have addressed the actual listing of models. This PR addresses model destruction and backup.

## Bug reference
https://bugs.launchpad.net/juju/+bug/1721786
