### PR TITLE
2.2 force upgrade

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -268,8 +268,8 @@ func (c *Client) Close() error {
 
 // SetModelAgentVersion sets the model agent-version setting
 // to the given value.
-func (c *Client) SetModelAgentVersion(version version.Number, force bool) error {
-	args := params.SetModelAgentVersion{Version: version, Force: force}
+func (c *Client) SetModelAgentVersion(version version.Number, ignoreAgentVersions bool) error {
+	args := params.SetModelAgentVersion{Version: version, IgnoreAgentVersions: ignoreAgentVersions}
 	return c.facade.FacadeCall("SetModelAgentVersion", args, nil)
 }
 

--- a/api/client.go
+++ b/api/client.go
@@ -268,8 +268,8 @@ func (c *Client) Close() error {
 
 // SetModelAgentVersion sets the model agent-version setting
 // to the given value.
-func (c *Client) SetModelAgentVersion(version version.Number) error {
-	args := params.SetModelAgentVersion{Version: version}
+func (c *Client) SetModelAgentVersion(version version.Number, force bool) error {
+	args := params.SetModelAgentVersion{Version: version, Force: force}
 	return c.facade.FacadeCall("SetModelAgentVersion", args, nil)
 }
 

--- a/api/client_test.go
+++ b/api/client_test.go
@@ -527,7 +527,7 @@ func (s *clientSuite) TestSetModelAgentVersionDuringUpgrade(c *gc.C) {
 	_, err = s.State.EnsureUpgradeInfo(machine.Id(), agentVersion, nextVersion)
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = s.APIState.Client().SetModelAgentVersion(nextVersion)
+	err = s.APIState.Client().SetModelAgentVersion(nextVersion, false)
 
 	// Expect an error with a error code that indicates this specific
 	// situation. The client needs to be able to reliably identify

--- a/apiserver/client/backend.go
+++ b/apiserver/client/backend.go
@@ -69,7 +69,7 @@ type Backend interface {
 	ModelUUID() string
 	RemoveUserAccess(names.UserTag, names.Tag) error
 	SetAnnotations(state.GlobalEntity, map[string]string) error
-	SetModelAgentVersion(version.Number) error
+	SetModelAgentVersion(version.Number, bool) error
 	SetModelConstraints(constraints.Value) error
 	Unit(string) (Unit, error)
 	UpdateModelConfig(map[string]interface{}, []string, ...state.ValidateConfigFunc) error

--- a/apiserver/client/client.go
+++ b/apiserver/client/client.go
@@ -569,7 +569,7 @@ func (c *Client) SetModelAgentVersion(args params.SetModelAgentVersion) error {
 		}
 	}
 
-	return c.api.stateAccessor.SetModelAgentVersion(args.Version, args.Force)
+	return c.api.stateAccessor.SetModelAgentVersion(args.Version, args.IgnoreAgentVersions)
 }
 
 // AbortCurrentUpgrade aborts and archives the current upgrade

--- a/apiserver/client/client.go
+++ b/apiserver/client/client.go
@@ -569,7 +569,7 @@ func (c *Client) SetModelAgentVersion(args params.SetModelAgentVersion) error {
 		}
 	}
 
-	return c.api.stateAccessor.SetModelAgentVersion(args.Version, false)
+	return c.api.stateAccessor.SetModelAgentVersion(args.Version, args.Force)
 }
 
 // AbortCurrentUpgrade aborts and archives the current upgrade

--- a/apiserver/client/client.go
+++ b/apiserver/client/client.go
@@ -569,7 +569,7 @@ func (c *Client) SetModelAgentVersion(args params.SetModelAgentVersion) error {
 		}
 	}
 
-	return c.api.stateAccessor.SetModelAgentVersion(args.Version)
+	return c.api.stateAccessor.SetModelAgentVersion(args.Version, false)
 }
 
 // AbortCurrentUpgrade aborts and archives the current upgrade

--- a/apiserver/client/client_test.go
+++ b/apiserver/client/client_test.go
@@ -257,8 +257,8 @@ func (s *serverSuite) TestSetModelAgentVersionForced(c *gc.C) {
 	s.assertModelVersion(c, s.State, currentVersion)
 	// But we can force it
 	args = params.SetModelAgentVersion{
-		Version: version.MustParse("7.8.6"),
-		Force: true,
+		Version:             version.MustParse("7.8.6"),
+		IgnoreAgentVersions: true,
 	}
 	err = s.client.SetModelAgentVersion(args)
 	c.Assert(err, jc.ErrorIsNil)

--- a/apiserver/client/perm_test.go
+++ b/apiserver/client/perm_test.go
@@ -424,7 +424,7 @@ func opClientSetModelAgentVersion(c *gc.C, st api.Connection, mst *state.State) 
 		return func() {}, err
 	}
 	ver := version.Number{Major: 1, Minor: 2, Patch: 3}
-	err = st.Client().SetModelAgentVersion(ver)
+	err = st.Client().SetModelAgentVersion(ver, false)
 	if err != nil {
 		return func() {}, err
 	}
@@ -433,7 +433,7 @@ func opClientSetModelAgentVersion(c *gc.C, st api.Connection, mst *state.State) 
 		oldAgentVersion, found := attrs["agent-version"]
 		if found {
 			versionString := oldAgentVersion.(string)
-			st.Client().SetModelAgentVersion(version.MustParse(versionString))
+			st.Client().SetModelAgentVersion(version.MustParse(versionString), false)
 		}
 	}, nil
 }

--- a/apiserver/modelmanager/modelmanager_test.go
+++ b/apiserver/modelmanager/modelmanager_test.go
@@ -827,7 +827,7 @@ func (s *modelManagerStateSuite) TestCreateModelSameAgentVersion(c *gc.C) {
 }
 
 func (s *modelManagerStateSuite) TestCreateModelBadAgentVersion(c *gc.C) {
-	err := s.BackingState.SetModelAgentVersion(coretesting.FakeVersionNumber)
+	err := s.BackingState.SetModelAgentVersion(coretesting.FakeVersionNumber, false)
 	c.Assert(err, jc.ErrorIsNil)
 
 	admin := s.AdminUserTag(c)

--- a/apiserver/params/model.go
+++ b/apiserver/params/model.go
@@ -111,6 +111,7 @@ type UnsetModelDefaults struct {
 // SetModelAgentVersion client API call.
 type SetModelAgentVersion struct {
 	Version version.Number `json:"version"`
+	Force   bool           `json:"force,omitempty"`
 }
 
 // ModelMigrationStatus holds information about the progress of a (possibly

--- a/apiserver/params/model.go
+++ b/apiserver/params/model.go
@@ -110,8 +110,8 @@ type UnsetModelDefaults struct {
 // SetModelAgentVersion contains the arguments for
 // SetModelAgentVersion client API call.
 type SetModelAgentVersion struct {
-	Version version.Number `json:"version"`
-	Force   bool           `json:"force,omitempty"`
+	Version             version.Number `json:"version"`
+	IgnoreAgentVersions bool           `json:"force,omitempty"`
 }
 
 // ModelMigrationStatus holds information about the progress of a (possibly

--- a/apiserver/upgrader/upgrader_test.go
+++ b/apiserver/upgrader/upgrader_test.go
@@ -301,7 +301,7 @@ func (s *upgraderSuite) bumpDesiredAgentVersion(c *gc.C) version.Number {
 	s.rawMachine.SetAgentVersion(current)
 	newer := current
 	newer.Patch++
-	err := s.State.SetModelAgentVersion(newer.Number)
+	err := s.State.SetModelAgentVersion(newer.Number, false)
 	c.Assert(err, jc.ErrorIsNil)
 	cfg, err := s.State.ModelConfig()
 	c.Assert(err, jc.ErrorIsNil)

--- a/cmd/juju/commands/upgradejuju.go
+++ b/cmd/juju/commands/upgradejuju.go
@@ -78,6 +78,10 @@ type upgradeJujuCommand struct {
 	ResetPrevious bool
 	AssumeYes     bool
 
+	// Force is used to allow an admin to request an agent version without waiting for all agents to be at the right
+	// version.
+	Force bool
+
 	// minMajorUpgradeVersion maps known major numbers to
 	// the minimum version that can be upgraded to that
 	// major version.  For example, users must be running
@@ -101,6 +105,8 @@ func (c *upgradeJujuCommand) SetFlags(f *gnuflag.FlagSet) {
 	f.BoolVar(&c.ResetPrevious, "reset-previous-upgrade", false, "Clear the previous (incomplete) upgrade status (use with care)")
 	f.BoolVar(&c.AssumeYes, "y", false, "Answer 'yes' to confirmation prompts")
 	f.BoolVar(&c.AssumeYes, "yes", false, "")
+	f.BoolVar(&c.Force, "force", false,
+		"Don't check if all agents have already reached the current version (old controllers will ignore this flag see juju-force-upgrade)")
 }
 
 func (c *upgradeJujuCommand) Init(args []string) error {

--- a/cmd/juju/commands/upgradejuju.go
+++ b/cmd/juju/commands/upgradejuju.go
@@ -78,9 +78,9 @@ type upgradeJujuCommand struct {
 	ResetPrevious bool
 	AssumeYes     bool
 
-	// Force is used to allow an admin to request an agent version without waiting for all agents to be at the right
+	// IgnoreAgentVersions is used to allow an admin to request an agent version without waiting for all agents to be at the right
 	// version.
-	Force bool
+	IgnoreAgentVersions bool
 
 	// minMajorUpgradeVersion maps known major numbers to
 	// the minimum version that can be upgraded to that
@@ -105,7 +105,7 @@ func (c *upgradeJujuCommand) SetFlags(f *gnuflag.FlagSet) {
 	f.BoolVar(&c.ResetPrevious, "reset-previous-upgrade", false, "Clear the previous (incomplete) upgrade status (use with care)")
 	f.BoolVar(&c.AssumeYes, "y", false, "Answer 'yes' to confirmation prompts")
 	f.BoolVar(&c.AssumeYes, "yes", false, "")
-	f.BoolVar(&c.Force, "force", false,
+	f.BoolVar(&c.IgnoreAgentVersions, "ignore-agent-versions", false,
 		"Don't check if all agents have already reached the current version (old controllers will ignore this flag see juju-force-upgrade)")
 }
 
@@ -176,7 +176,7 @@ type upgradeJujuAPI interface {
 	FindTools(majorVersion, minorVersion int, series, arch string) (result params.FindToolsResult, err error)
 	UploadTools(r io.ReadSeeker, vers version.Binary, additionalSeries ...string) (coretools.List, error)
 	AbortCurrentUpgrade() error
-	SetModelAgentVersion(version version.Number) error
+	SetModelAgentVersion(version version.Number, ignoreAgentVersion bool) error
 	Close() error
 }
 
@@ -369,7 +369,8 @@ func (c *upgradeJujuCommand) Run(ctx *cmd.Context) (err error) {
 				return block.ProcessBlockedError(err, block.BlockChange)
 			}
 		}
-		if err := client.SetModelAgentVersion(context.chosen); err != nil {
+		logger.Criticalf("**********   SetModelAgentVersion: %s %t", context.chosen.String(), c.IgnoreAgentVersions)
+		if err := client.SetModelAgentVersion(context.chosen, c.IgnoreAgentVersions); err != nil {
 			if params.IsCodeUpgradeInProgress(err) {
 				return errors.Errorf("%s\n\n"+
 					"Please wait for the upgrade to complete or if there was a problem with\n"+

--- a/cmd/juju/commands/upgradejuju_test.go
+++ b/cmd/juju/commands/upgradejuju_test.go
@@ -498,6 +498,7 @@ func (s *UpgradeJujuSuite) TestUpgradeJujuWithImplicitUploadNewerClient(c *gc.C)
 	c.Assert(fakeAPI.tools, gc.Not(gc.HasLen), 0)
 	c.Assert(fakeAPI.tools[0].Version.Number, gc.Equals, version.MustParse("1.100.0.1"))
 	c.Assert(fakeAPI.modelAgentVersion, gc.Equals, fakeAPI.tools[0].Version.Number)
+	c.Assert(fakeAPI.ignoreAgentVersions, jc.IsFalse)
 }
 
 func (s *UpgradeJujuSuite) TestUpgradeJujuWithImplicitUploadNonController(c *gc.C) {
@@ -518,6 +519,7 @@ func (s *UpgradeJujuSuite) TestUpgradeJujuWithImplicitUploadNonController(c *gc.
 	cmd := newUpgradeJujuCommand(nil)
 	_, err := cmdtesting.RunCommand(c, cmd)
 	c.Assert(err, gc.ErrorMatches, "no more recent supported versions available")
+	c.Assert(fakeAPI.ignoreAgentVersions, jc.IsFalse)
 }
 
 func (s *UpgradeJujuSuite) TestBlockUpgradeJujuWithRealUpload(c *gc.C) {
@@ -546,6 +548,30 @@ func (s *UpgradeJujuSuite) TestFailUploadOnNonController(c *gc.C) {
 	cmd := newUpgradeJujuCommand(nil)
 	_, err := cmdtesting.RunCommand(c, cmd, "--build-agent", "-m", "dummy-model")
 	c.Assert(err, gc.ErrorMatches, "--build-agent can only be used with the controller model")
+}
+
+func (s *UpgradeJujuSuite) TestUpgradeJujuWithIgnoreAgentVersions(c *gc.C) {
+	s.Reset(c)
+	fakeAPI := &fakeUpgradeJujuAPINoState{
+		name:           "dummy-model",
+		uuid:           "deadbeef-0bad-400d-8000-4b1d0d06f00d",
+		controllerUUID: "deadbeef-1bad-500d-9000-4b1d0d06f00d",
+		agentVersion:   "1.99.99",
+	}
+	s.PatchValue(&getUpgradeJujuAPI, func(*upgradeJujuCommand) (upgradeJujuAPI, error) {
+		return fakeAPI, nil
+	})
+	s.PatchValue(&getModelConfigAPI, func(*upgradeJujuCommand) (modelConfigAPI, error) {
+		return fakeAPI, nil
+	})
+	s.PatchValue(&jujuversion.Current, version.MustParse("1.100.0"))
+	cmd := newUpgradeJujuCommand(nil)
+	_, err := cmdtesting.RunCommand(c, cmd, "--ignore-agent-versions")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(fakeAPI.tools, gc.Not(gc.HasLen), 0)
+	c.Assert(fakeAPI.tools[0].Version.Number, gc.Equals, version.MustParse("1.100.0.1"))
+	c.Assert(fakeAPI.modelAgentVersion, gc.Equals, fakeAPI.tools[0].Version.Number)
+	c.Assert(fakeAPI.ignoreAgentVersions, jc.IsTrue)
 }
 
 type DryRunTest struct {
@@ -857,6 +883,7 @@ func (s *UpgradeJujuSuite) TestResetPreviousUpgrade(c *gc.C) {
 			expectedVersion = fakeAPI.nextVersion.Number
 		}
 		c.Assert(fakeAPI.setVersionCalledWith, gc.Equals, expectedVersion)
+		c.Assert(fakeAPI.setIgnoreCalledWith, gc.Equals, false)
 	}
 
 	const expectUpgrade = true
@@ -903,6 +930,7 @@ type fakeUpgradeJujuAPI struct {
 	setVersionErr             error
 	abortCurrentUpgradeCalled bool
 	setVersionCalledWith      version.Number
+	setIgnoreCalledWith       bool
 	tools                     []string
 	findToolsCalled           bool
 }
@@ -911,6 +939,7 @@ func (a *fakeUpgradeJujuAPI) reset() {
 	a.setVersionErr = nil
 	a.abortCurrentUpgradeCalled = false
 	a.setVersionCalledWith = version.Number{}
+	a.setIgnoreCalledWith = false
 	a.tools = []string{}
 	a.findToolsCalled = false
 }
@@ -972,8 +1001,9 @@ func (a *fakeUpgradeJujuAPI) AbortCurrentUpgrade() error {
 	return nil
 }
 
-func (a *fakeUpgradeJujuAPI) SetModelAgentVersion(v version.Number) error {
+func (a *fakeUpgradeJujuAPI) SetModelAgentVersion(v version.Number, ignoreAgentVersions bool) error {
 	a.setVersionCalledWith = v
+	a.setIgnoreCalledWith = ignoreAgentVersions
 	return a.setVersionErr
 }
 
@@ -984,12 +1014,13 @@ func (a *fakeUpgradeJujuAPI) Close() error {
 // Mock an API with no state
 type fakeUpgradeJujuAPINoState struct {
 	upgradeJujuAPI
-	name              string
-	uuid              string
-	controllerUUID    string
-	agentVersion      string
-	tools             coretools.List
-	modelAgentVersion version.Number
+	name                string
+	uuid                string
+	controllerUUID      string
+	agentVersion        string
+	tools               coretools.List
+	modelAgentVersion   version.Number
+	ignoreAgentVersions bool
 }
 
 func (a *fakeUpgradeJujuAPINoState) Close() error {
@@ -1016,8 +1047,9 @@ func (a *fakeUpgradeJujuAPINoState) UploadTools(r io.ReadSeeker, vers version.Bi
 	return a.tools, nil
 }
 
-func (a *fakeUpgradeJujuAPINoState) SetModelAgentVersion(version version.Number) error {
+func (a *fakeUpgradeJujuAPINoState) SetModelAgentVersion(version version.Number, ignoreAgentVersions bool) error {
 	a.modelAgentVersion = version
+	a.ignoreAgentVersions = ignoreAgentVersions
 	return nil
 }
 

--- a/cmd/jujud/agent/machine_test.go
+++ b/cmd/jujud/agent/machine_test.go
@@ -523,7 +523,7 @@ func (s *MachineSuite) testUpgradeRequest(c *gc.C, agent runner, tag string, cur
 	newVers.Patch++
 	newTools := envtesting.AssertUploadFakeToolsVersions(
 		c, s.DefaultToolsStorage, s.Environ.Config().AgentStream(), s.Environ.Config().AgentStream(), newVers)[0]
-	err := s.State.SetModelAgentVersion(newVers.Number)
+	err := s.State.SetModelAgentVersion(newVers.Number, true)
 	c.Assert(err, jc.ErrorIsNil)
 	err = runWithTimeout(agent)
 	envtesting.CheckUpgraderReadyError(c, err, &upgrader.UpgradeReadyError{

--- a/scripts/force-upgrade/main.go
+++ b/scripts/force-upgrade/main.go
@@ -1,0 +1,111 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/juju/errors"
+	"github.com/juju/gnuflag"
+	"github.com/juju/loggo"
+	"github.com/juju/utils/clock"
+	"github.com/juju/version"
+	"gopkg.in/juju/names.v2"
+
+	"github.com/juju/juju/agent"
+	"github.com/juju/juju/mongo"
+	"github.com/juju/juju/state"
+	jversion "github.com/juju/juju/version"
+)
+
+var logger = loggo.GetLogger("forceagentversion")
+
+func checkErr(label string, err error) {
+	if err != nil {
+		logger.Errorf("%s: %s", label, err)
+		os.Exit(1)
+	}
+}
+
+const dataDir = "/var/lib/juju"
+
+func getState() (*state.State, error) {
+	tag, err := getCurrentMachineTag(dataDir)
+	if err != nil {
+		return nil, errors.Annotate(err, "finding machine tag")
+	}
+
+	logger.Infof("current machine tag: %s", tag)
+
+	config, err := getConfig(tag)
+	if err != nil {
+		return nil, errors.Annotate(err, "loading agent config")
+	}
+
+	mongoInfo, available := config.MongoInfo()
+	if !available {
+		return nil, errors.New("mongo info not available from agent config")
+	}
+	st, err := state.Open(state.OpenParams{
+		Clock:              clock.WallClock,
+		ControllerTag:      config.Controller(),
+		ControllerModelTag: config.Model(),
+		MongoInfo:          mongoInfo,
+		MongoDialOpts:      mongo.DefaultDialOpts(),
+	})
+	if err != nil {
+		return nil, errors.Annotate(err, "opening state connection")
+	}
+	return st, nil
+}
+
+func getCurrentMachineTag(datadir string) (names.MachineTag, error) {
+	var empty names.MachineTag
+	values, err := filepath.Glob(filepath.Join(datadir, "agents", "machine-*"))
+	if err != nil {
+		return empty, errors.Annotate(err, "problem globbing")
+	}
+	switch len(values) {
+	case 0:
+		return empty, errors.Errorf("no machines found")
+	case 1:
+		return names.ParseMachineTag(filepath.Base(values[0]))
+	default:
+		return empty, errors.Errorf("too many options: %v", values)
+	}
+}
+
+func getConfig(tag names.MachineTag) (agent.ConfigSetterWriter, error) {
+	path := agent.ConfigPath("/var/lib/juju", tag)
+	return agent.ReadConfig(path)
+}
+
+func main() {
+	loggo.GetLogger("").SetLogLevel(loggo.TRACE)
+	gnuflag.Usage = func() {
+		fmt.Printf("Usage: %s <model-uuid> <version>\n", os.Args[0])
+		os.Exit(1)
+	}
+
+	gnuflag.Parse(true)
+
+	args := gnuflag.Args()
+	if len(args) < 2 {
+		gnuflag.Usage()
+	}
+
+	modelUUID := args[0]
+	agentVersion := version.MustParse(args[1])
+	if agentVersion.Compare(jversion.Current) < 0 {
+		// Force the client to think it is at least as new as the desired version
+		jversion.Current = agentVersion
+	}
+
+	st, err := getState()
+	checkErr("getting state connection", err)
+	defer st.Close()
+
+	modelSt, err := st.ForModel(names.NewModelTag(modelUUID))
+	checkErr("open model", err)
+	checkErr("set model agent version", modelSt.SetModelAgentVersion(agentVersion, true))
+}

--- a/scripts/juju-force-upgrade/main.go
+++ b/scripts/juju-force-upgrade/main.go
@@ -1,3 +1,6 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
 package main
 
 import (
@@ -18,7 +21,7 @@ import (
 	jversion "github.com/juju/juju/version"
 )
 
-var logger = loggo.GetLogger("forceagentversion")
+var logger = loggo.GetLogger("juju.forceupgrade")
 
 func checkErr(label string, err error) {
 	if err != nil {

--- a/state/state.go
+++ b/state/state.go
@@ -650,7 +650,7 @@ func IsUpgradeInProgressError(err error) bool {
 // given version, only if the model is in a stable state (all agents are
 // running the current version). If this is a hosted model, newVersion
 // cannot be higher than the controller version.
-func (st *State) SetModelAgentVersion(newVersion version.Number) (err error) {
+func (st *State) SetModelAgentVersion(newVersion version.Number, force bool) (err error) {
 	if newVersion.Compare(jujuversion.Current) > 0 && !st.IsController() {
 		return errors.Errorf("a hosted model cannot have a higher version than the server model: %s > %s",
 			newVersion.String(),
@@ -676,8 +676,10 @@ func (st *State) SetModelAgentVersion(newVersion version.Number) (err error) {
 			return nil, jujutxn.ErrNoOperations
 		}
 
-		if err := st.checkCanUpgrade(currentVersion, newVersion.String()); err != nil {
-			return nil, errors.Trace(err)
+		if !force {
+			if err := st.checkCanUpgrade(currentVersion, newVersion.String()); err != nil {
+				return nil, errors.Trace(err)
+			}
 		}
 
 		ops := []txn.Op{

--- a/state/state.go
+++ b/state/state.go
@@ -650,7 +650,7 @@ func IsUpgradeInProgressError(err error) bool {
 // given version, only if the model is in a stable state (all agents are
 // running the current version). If this is a hosted model, newVersion
 // cannot be higher than the controller version.
-func (st *State) SetModelAgentVersion(newVersion version.Number, force bool) (err error) {
+func (st *State) SetModelAgentVersion(newVersion version.Number, ignoreAgentVersions bool) (err error) {
 	if newVersion.Compare(jujuversion.Current) > 0 && !st.IsController() {
 		return errors.Errorf("a hosted model cannot have a higher version than the server model: %s > %s",
 			newVersion.String(),
@@ -676,7 +676,7 @@ func (st *State) SetModelAgentVersion(newVersion version.Number, force bool) (er
 			return nil, jujutxn.ErrNoOperations
 		}
 
-		if !force {
+		if !ignoreAgentVersions {
 			if err := st.checkCanUpgrade(currentVersion, newVersion.String()); err != nil {
 				return nil, errors.Trace(err)
 			}

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -3711,7 +3711,7 @@ func (s *StateSuite) TestSetModelAgentVersionExcessiveContention(c *gc.C) {
 	assertAgentVersion(c, s.State, currentVersion)
 }
 
-func (s *StateSuite) TestSetModelAgentVerisonMixedVersions(c *gc.C) {
+func (s *StateSuite) TestSetModelAgentVersionMixedVersions(c *gc.C) {
 	_, currentVersion := s.prepareAgentVersionTests(c, s.State)
 	machine, err := s.State.Machine("0")
 	c.Assert(err, jc.ErrorIsNil)

--- a/worker/upgradesteps/worker.go
+++ b/worker/upgradesteps/worker.go
@@ -273,7 +273,7 @@ func (w *upgradesteps) prepareForUpgrade() (*state.UpgradeInfo, error) {
 		if w.isMaster {
 			logger.Errorf("downgrading model agent version to %v due to aborted upgrade",
 				w.fromVersion)
-			if rollbackErr := w.st.SetModelAgentVersion(w.fromVersion); rollbackErr != nil {
+			if rollbackErr := w.st.SetModelAgentVersion(w.fromVersion, true); rollbackErr != nil {
 				logger.Errorf("rollback failed: %v", rollbackErr)
 				return nil, errors.Annotate(rollbackErr, "failed to roll back desired agent version")
 			}

--- a/worker/upgradesteps/worker_test.go
+++ b/worker/upgradesteps/worker_test.go
@@ -256,7 +256,7 @@ func (s *UpgradeSuite) TestAbortWhenOtherControllerDoesntStartUpgrade(c *gc.C) {
 	// This test checks when a controller is upgrading and one of
 	// the other controllers doesn't signal it is ready in time.
 
-	err := s.State.SetModelAgentVersion(jujuversion.Current)
+	err := s.State.SetModelAgentVersion(jujuversion.Current, false)
 	c.Assert(err, jc.ErrorIsNil)
 
 	// The master controller in this scenario is functionally tested


### PR DESCRIPTION
## Description of change
This addresses an issue that has come up a few times, where we are asking people to upgrade their Controller, but they are unable to because of some agents that aren't working properly.

It does 3 primary things:

1. Update the State code to allow an override so we will skip the agent version check.
2. Update the API to expose it so that new Controllers can be triggered by new Juju clients (juju upgrade-juju --ignore-agent-versions)
3. Brings in Tim's 'force-upgrade' script as something you can run directly on controllers for when their current version is to old.


## QA steps

```
$ juju bootstrap lxd
$ juju deploy ubuntu
$ juju ssh ubuntu/0 "sudo service jujud-unit-ubuntu-0 stop"
$ juju upgrade-juju
$ juju upgrade-juju # should fail because unit-ubuntu-0 didn't get upgraded
$ juju upgrade-juju --ignore-agent-versions # should succeed
```

## Documentation changes

The flag should be documented, along with when it is appropriate to use it.

## Bug reference

[lp:1726893](https://bugs.launchpad.net/juju/+bug/1726893)