### PR TITLE
Fix confusing message when running commands on non-existing receivers.

### DIFF
--- a/apiserver/common/action.go
+++ b/apiserver/common/action.go
@@ -43,15 +43,15 @@ func TagToActionReceiverFn(findEntity func(names.Tag) (state.Entity, error)) fun
 	return func(tag string) (state.ActionReceiver, error) {
 		receiverTag, err := names.ParseTag(tag)
 		if err != nil {
-			return nil, ErrBadId
+			return nil, errors.NotValidf("%s", tag)
 		}
 		entity, err := findEntity(receiverTag)
 		if err != nil {
-			return nil, ErrBadId
+			return nil, errors.NotFoundf("%s", receiverTag)
 		}
 		receiver, ok := entity.(state.ActionReceiver)
 		if !ok {
-			return nil, ErrBadId
+			return nil, errors.NotImplementedf("action receiver interface on entity %s", tag)
 		}
 		return receiver, nil
 	}

--- a/apiserver/common/action_test.go
+++ b/apiserver/common/action_test.go
@@ -42,18 +42,18 @@ func (s *actionsSuite) TestTagToActionReceiverFn(c *gc.C) {
 		result: stubActionReceiver,
 	}, {
 		tag: "unit-invalid-0",
-		err: common.ErrBadId,
+		err: errors.NotImplementedf("action receiver interface on entity unit-invalid-0"),
 	}, {
 		tag: "unit-flustered-0",
-		err: common.ErrBadId,
+		err: errors.NotFoundf("unit-flustered-0"),
 	}, {
 		tag: "notatag",
-		err: common.ErrBadId,
+		err: errors.NotValidf("notatag"),
 	}} {
 		c.Logf("test %d", i)
 		receiver, err := tagFn(test.tag)
 		if test.err != nil {
-			c.Check(err, gc.Equals, test.err)
+			c.Check(err.Error(), gc.Equals, test.err.Error())
 			c.Check(receiver, gc.IsNil)
 		} else {
 			c.Assert(err, jc.ErrorIsNil)
@@ -226,7 +226,7 @@ func (s *actionsSuite) TestWatchOneActionReceiverNotifications(c *gc.C) {
 		watcherId string
 	}{{
 		tag: names.NewMachineTag("0"),
-		err: "id not found",
+		err: "machine-0 not found",
 	}, {
 		tag:       names.NewMachineTag("1"),
 		watcherId: "bambalam",

--- a/apiserver/common/errors.go
+++ b/apiserver/common/errors.go
@@ -239,6 +239,8 @@ func ServerError(err error) *params.Error {
 		code = params.CodeBadRequest
 	case errors.IsMethodNotAllowed(err):
 		code = params.CodeMethodNotAllowed
+	case errors.IsNotImplemented(err):
+		code = params.CodeNotImplemented
 	case state.IsIncompatibleSeriesError(err):
 		code = params.CodeIncompatibleSeries
 	default:

--- a/apiserver/facades/client/action/action_test.go
+++ b/apiserver/facades/client/action/action_test.go
@@ -243,9 +243,8 @@ func (s *actionSuite) TestEnqueue(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(res.Results, gc.HasLen, 4)
 
-	expectedError := &params.Error{Message: "id not found", Code: "not found"}
 	emptyActionTag := names.ActionTag{}
-	c.Assert(res.Results[0].Error, gc.DeepEquals, expectedError)
+	c.Assert(res.Results[0].Error, gc.DeepEquals, &params.Error{Message: fmt.Sprintf("%s not valid", arg.Actions[0].Receiver), Code: ""})
 	c.Assert(res.Results[0].Action, gc.IsNil)
 
 	c.Assert(res.Results[1].Error, gc.IsNil)
@@ -253,7 +252,8 @@ func (s *actionSuite) TestEnqueue(c *gc.C) {
 	c.Assert(res.Results[1].Action.Receiver, gc.Equals, s.wordpressUnit.Tag().String())
 	c.Assert(res.Results[1].Action.Tag, gc.Not(gc.Equals), emptyActionTag)
 
-	c.Assert(res.Results[2].Error, gc.DeepEquals, expectedError)
+	errorString := fmt.Sprintf("action receiver interface on entity %s not implemented", arg.Actions[2].Receiver)
+	c.Assert(res.Results[2].Error, gc.DeepEquals, &params.Error{Message: errorString, Code: "not implemented"})
 	c.Assert(res.Results[2].Action, gc.IsNil)
 
 	c.Assert(res.Results[3].Error, gc.ErrorMatches, "no action name given")

--- a/cmd/juju/commands/run.go
+++ b/cmd/juju/commands/run.go
@@ -238,18 +238,17 @@ func (c *runCommand) Run(ctx *cmd.Context) error {
 	actionsToQuery := []actionQuery{}
 	for _, result := range runResults {
 		if result.Error != nil {
-			fmt.Fprintf(ctx.GetStderr(), "couldn't queue one action: %v", result.Error)
+			fmt.Fprintf(ctx.GetStderr(), "couldn't queue one action: %v\n", result.Error)
 			continue
 		}
 		actionTag, err := names.ParseActionTag(result.Action.Tag)
 		if err != nil {
-			fmt.Fprintf(ctx.GetStderr(), "got invalid action tag %v for receiver %v", result.Action.Tag, result.Action.Receiver)
+			fmt.Fprintf(ctx.GetStderr(), "got invalid action tag %v for receiver %v\n", result.Action.Tag, result.Action.Receiver)
 			continue
 		}
-
 		receiverTag, err := names.ActionReceiverFromTag(result.Action.Receiver)
 		if err != nil {
-			fmt.Fprintf(ctx.GetStderr(), "got invalid action receiver tag %v for action %v", result.Action.Receiver, result.Action.Tag)
+			fmt.Fprintf(ctx.GetStderr(), "got invalid action receiver tag %v for action %v\n", result.Action.Receiver, result.Action.Tag)
 			continue
 		}
 		var receiverType string


### PR DESCRIPTION
## Description of change

When issuing a `juju run` command with a non-existing receiver (e.g. unit, machine), juju would respond a with confusing and improperly formatted error message. This commit formats the error more clearly while adding additional information for identifying the missing receiver. 

See referenced bug.

## QA steps

run:

`juju run --unit postgresql/0 hostname`

you should see:

`couldn't queue one action: id not foundERROR no actions were successfully enqueued, aborting`

Apply commit and run the command. You should now see:

```
couldn't queue one action: unit-postgres-0 not found
ERROR no actions were successfully enqueued, aborting
```

## Documentation changes

N/A

## Bug reference

https://bugs.launchpad.net/juju/+bug/1721298
