### PR TITLE
Record offer status changes in the consuming model

### DIFF
--- a/api/remoterelations/remoterelations.go
+++ b/api/remoterelations/remoterelations.go
@@ -12,6 +12,7 @@ import (
 	"github.com/juju/juju/api/base"
 	apiwatcher "github.com/juju/juju/api/watcher"
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/status"
 	"github.com/juju/juju/watcher"
 )
 
@@ -259,6 +260,7 @@ func (c *Client) ConsumeRemoteRelationChange(change params.RemoteRelationChangeE
 	return results.OneError()
 }
 
+// ControllerAPIInfoForModel retrieves the controller API info for the specified model.
 func (c *Client) ControllerAPIInfoForModel(modelUUID string) (*api.Info, error) {
 	modelTag := names.NewModelTag(modelUUID)
 	args := params.Entities{[]params.Entity{{Tag: modelTag.String()}}}
@@ -279,4 +281,17 @@ func (c *Client) ControllerAPIInfoForModel(modelUUID string) (*api.Info, error) 
 		CACert:   result.CACert,
 		ModelTag: modelTag,
 	}, nil
+}
+
+// SetRemoteApplicationStatus sets the status for the specified remote application.
+func (c *Client) SetRemoteApplicationStatus(applicationName string, status status.Status, message string) error {
+	args := params.SetStatus{Entities: []params.EntityStatusArgs{
+		{Tag: names.NewApplicationTag(applicationName).String(), Status: status.String(), Info: message},
+	}}
+	var results params.ErrorResults
+	err := c.facade.FacadeCall("SetRemoteApplicationsStatus", args, &results)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	return results.OneError()
 }

--- a/apiserver/common/crossmodel/interface.go
+++ b/apiserver/common/crossmodel/interface.go
@@ -229,4 +229,7 @@ type RemoteApplication interface {
 
 	// Life returns the lifecycle state of the application.
 	Life() state.Life
+
+	// SetStatus sets the status of the remote application.
+	SetStatus(info status.StatusInfo) error
 }

--- a/apiserver/facades/controller/remoterelations/mock_test.go
+++ b/apiserver/facades/controller/remoterelations/mock_test.go
@@ -308,6 +308,7 @@ type mockRemoteApplication struct {
 	url           string
 	life          state.Life
 	status        status.Status
+	message       string
 	eps           []charm.Relation
 	consumerproxy bool
 }
@@ -361,6 +362,13 @@ func (r *mockRemoteApplication) SourceModel() names.ModelTag {
 func (r *mockRemoteApplication) Macaroon() (*macaroon.Macaroon, error) {
 	r.MethodCall(r, "Macaroon")
 	return macaroon.New(nil, "test", "")
+}
+
+func (r *mockRemoteApplication) SetStatus(info status.StatusInfo) error {
+	r.MethodCall(r, "SetStatus")
+	r.status = info.Status
+	r.message = info.Message
+	return nil
 }
 
 type mockApplication struct {

--- a/worker/remoterelations/remoterelations.go
+++ b/worker/remoterelations/remoterelations.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/juju/juju/api"
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/status"
 	"github.com/juju/juju/watcher"
 	"github.com/juju/juju/worker/catacomb"
 )
@@ -51,6 +52,10 @@ type RemoteModelRelationsFacade interface {
 	// WatchRelationSuspendedStatus starts a RelationStatusWatcher for watching the
 	// relations of each specified application in the remote model.
 	WatchRelationSuspendedStatus(arg params.RemoteEntityArg) (watcher.RelationStatusWatcher, error)
+
+	// WatchOfferStatus starts an OfferStatusWatcher for watching the status
+	// of the specified offer in the remote model.
+	WatchOfferStatus(arg params.OfferArg) (watcher.OfferStatusWatcher, error)
 }
 
 // RemoteRelationsFacade exposes remote relation functionality to a worker.
@@ -101,6 +106,9 @@ type RemoteRelationsFacade interface {
 
 	// ControllerAPIInfoForModel returns the controller api info for a model.
 	ControllerAPIInfoForModel(modelUUID string) (*api.Info, error)
+
+	// SetRemoteApplicationStatus sets the status for the specified remote application.
+	SetRemoteApplicationStatus(applicationName string, status status.Status, message string) error
 }
 
 type newRemoteRelationsFacadeFunc func(*api.Info) (RemoteModelRelationsFacadeCloser, error)


### PR DESCRIPTION
## Description of change

The remote relations worker watches for changes to the status of consumed offers and records those against the remote application so the data shows up in juju status.

## QA steps

Run up a CMR scenario and consume or relate to an offer. Check that juju status on the consuming model reflects the status of the offered application.

