### PR TITLE
Refactor code used for address info in relation data and network-get

### DIFF
--- a/apiserver/common/firewall/egressaddresswatcher.go
+++ b/apiserver/common/firewall/egressaddresswatcher.go
@@ -4,8 +4,6 @@
 package firewall
 
 import (
-	"net"
-
 	"github.com/juju/errors"
 	"github.com/juju/utils/set"
 	"gopkg.in/juju/worker.v1"
@@ -182,7 +180,7 @@ func (w *EgressAddressWatcher) loop() error {
 				}
 			}
 			unitAddressesChanged = false
-			addresses = FormatAsCIDR(addressSet.Values())
+			addresses = network.FormatAsCIDR(addressSet.Values())
 			out = w.out
 		}
 		userConfiguredEgressChanged = false
@@ -243,26 +241,6 @@ func (w *EgressAddressWatcher) loop() error {
 		}
 
 	}
-}
-
-// FormatAsCIDR converts the specified IP addresses to
-// a slice of CIDRs.
-func FormatAsCIDR(addresses []string) []string {
-	result := make([]string, len(addresses))
-	for i, a := range addresses {
-		cidr := a
-		// If address is not already a cidr, add a /32 (ipv4) or /128 (ipv6).
-		if _, _, err := net.ParseCIDR(a); err != nil {
-			ip := net.ParseIP(a)
-			if ip.To4() != nil {
-				cidr = a + "/32"
-			} else {
-				cidr = a + "/128"
-			}
-		}
-		result[i] = cidr
-	}
-	return result
 }
 
 func (w *EgressAddressWatcher) unitAddress(unit Unit) (string, bool, error) {

--- a/network/network.go
+++ b/network/network.go
@@ -604,3 +604,23 @@ func SubnetInAnyRange(cidrs []*net.IPNet, subnet *net.IPNet) bool {
 	}
 	return false
 }
+
+// FormatAsCIDR converts the specified IP addresses to
+// a slice of CIDRs.
+func FormatAsCIDR(addresses []string) []string {
+	result := make([]string, len(addresses))
+	for i, a := range addresses {
+		cidr := a
+		// If address is not already a cidr, add a /32 (ipv4) or /128 (ipv6).
+		if _, _, err := net.ParseCIDR(a); err != nil {
+			ip := net.ParseIP(a)
+			if ip.To4() != nil {
+				cidr = a + "/32"
+			} else {
+				cidr = a + "/128"
+			}
+		}
+		result[i] = cidr
+	}
+	return result
+}

--- a/state/relationunit.go
+++ b/state/relationunit.go
@@ -17,6 +17,7 @@ import (
 	"gopkg.in/mgo.v2/bson"
 	"gopkg.in/mgo.v2/txn"
 
+	"github.com/juju/juju/environs"
 	"github.com/juju/juju/network"
 )
 
@@ -475,57 +476,80 @@ func (ru *RelationUnit) ReadSettings(uname string) (m map[string]interface{}, er
 	return node.Map(), nil
 }
 
-// IngressAddress returns the address that should be set as
-// `private-address` in the settings for the this unit in the context
-// of this relation. Generally this will be the cloud-local address of
-// the unit, but if this is a cross-model relation then it will be the
-// public address. If this is cross-model and there's no public
-// address for the unit, return an error.
-func (ru *RelationUnit) IngressAddress() (network.Address, error) {
-	unit, err := ru.st.Unit(ru.unitName)
-	if err != nil {
-		return network.Address{}, errors.Trace(err)
-	}
-	if crossmodel, err := ru.relation.IsCrossModel(); err != nil {
-		return network.Address{}, errors.Trace(err)
-	} else if !crossmodel {
-		space, err := unit.GetSpaceForBinding(ru.endpoint.Name)
-		if err != nil {
-			return network.Address{}, errors.Trace(err)
-		}
-		m, err := unit.machine()
-		if err != nil {
-			return network.Address{}, errors.Trace(err)
-		}
-		networkInfos := m.GetNetworkInfoForSpaces(set.NewStrings(space))
-		info, ok := networkInfos[space]
-		if !ok || len(info.NetworkInfos) == 0 || len(info.NetworkInfos[0].Addresses) == 0 {
-			privateAddress, err := unit.PrivateAddress()
-			if err == nil {
-				logger.Warningf("Can't find an address for default binding space %q, falling back to units' private address %q", space, privateAddress.String())
-			}
-			return privateAddress, err
-		}
-		boundAddress := network.NewAddress(info.NetworkInfos[0].Addresses[0].Address)
-		logger.Debugf("Found an address for a default binding for an app - %v", boundAddress.String())
-		return boundAddress, nil
+// NetworksForRelation returns the ingress and egress addresses for a relation and unit.
+// The ingress addresses depend on if the relation is cross model and whether the
+// relation endpoint is bound to a space.
+func NetworksForRelation(
+	binding string, unit *Unit, rel *Relation, defaultEgress []string,
+) (boundSpace string, ingress []string, egress []string, _ error) {
+	st := unit.st
+
+	relEgress := NewRelationEgressNetworks(st)
+	egressSubnets, err := relEgress.Networks(rel.Tag().Id())
+	if err != nil && !errors.IsNotFound(err) {
+		return "", nil, nil, errors.Trace(err)
+	} else if err == nil {
+		egress = egressSubnets.CIDRS()
+	} else {
+		egress = defaultEgress
 	}
 
-	address, err := unit.PublicAddress()
-	if err != nil {
-		// TODO(wallyworld) - it's ok to return a private address sometimes
-		// TODO return an error when it's not possible to use the private address
-		logger.Warningf("no public address available for unit %q in cross model relation %q , using private address", unit.Name(), ru.relation)
-		return unit.PrivateAddress()
+	boundSpace, err = unit.GetSpaceForBinding(binding)
+	if err != nil && !errors.IsNotValid(err) {
+		return "", nil, nil, errors.Trace(err)
 	}
-	if address.Scope != network.ScopePublic {
-		logger.Debugf(
-			"no public address for unit %q in cross-model relation %q",
-			unit.Name(),
-			ru.relation,
-		)
+	// If the endpoint for this relation is not bound to a space, or
+	// is bound to the default space, we need to look up the ingress
+	// address info which is aware of cross model relations.
+	if boundSpace == environs.DefaultSpaceName || err != nil {
+		crossmodel, err := rel.IsCrossModel()
+		if err != nil {
+			return "", nil, nil, errors.Trace(err)
+		}
+		if crossmodel {
+			address, err := unit.PublicAddress()
+			if err != nil {
+				// TODO(wallyworld) - it's ok to return a private address sometimes
+				// TODO return an error when it's not possible to use the private address
+				logger.Warningf(
+					"no public address for unit %q in cross model relation %q, using private address",
+					unit.Name(), rel)
+				address, err = unit.PrivateAddress()
+				if err != nil {
+					return "", nil, nil, errors.Trace(err)
+				}
+			}
+			ingress = []string{address.Value}
+		}
 	}
-	return address, nil
+	if len(ingress) == 0 {
+		// We don't yet have an ingress address, so pick one from the space to
+		// which the endpoint is bound.
+		machineID, err := unit.AssignedMachineId()
+		if err != nil {
+			return "", nil, nil, errors.Trace(err)
+		}
+
+		machine, err := st.Machine(machineID)
+		if err != nil {
+			return "", nil, nil, errors.Trace(err)
+		}
+
+		networkInfos := machine.GetNetworkInfoForSpaces(set.NewStrings(boundSpace))
+		// The binding address information based on link layer devices.
+		for _, nwInfo := range networkInfos[boundSpace].NetworkInfos {
+			for _, addr := range nwInfo.Addresses {
+				ingress = append(ingress, addr.Address)
+			}
+
+		}
+	}
+
+	// If no egress subnets defined, We default to the ingress address.
+	if len(egress) == 0 && len(ingress) > 0 {
+		egress = network.FormatAsCIDR([]string{ingress[0]})
+	}
+	return boundSpace, ingress, egress, nil
 }
 
 // unitKey returns a string, based on the relation and the supplied unit name,


### PR DESCRIPTION
## Description of change

The set up of networking information for relation data and network get is reworked to be compatible with more use cases. The code is also consolidated so that a common method is used by network-get and relation data.

The algorithm becomes:
- if an endpoint is bound to a space, always provide an ingress address from that space, cmr or not
- otherwise, for cmr provide a public address if available

The egress subnets were also fixed so that for both relation data and network-get, the default value if nothing else is defined becomes ingress-address/32

## QA steps

Deploy and test cmr on lxd and aws. beta2 will provide an opportunity for more extensive field testing.

