### PR TITLE
Fix AdoptResources for nova networking

### DIFF
--- a/provider/openstack/legacy_firewaller.go
+++ b/provider/openstack/legacy_firewaller.go
@@ -177,8 +177,16 @@ func (c *legacyNovaFirewaller) UpdateGroupController(controllerUUID string) erro
 	if err != nil {
 		return errors.Trace(err)
 	}
+	re, err := regexp.Compile(c.jujuGroupRegexp())
+	if err != nil {
+		return errors.Trace(err)
+	}
+
 	var failed []string
 	for _, group := range groups {
+		if !re.MatchString(group.Name) {
+			continue
+		}
 		err := c.updateGroupControllerUUID(&group, controllerUUID)
 		if err != nil {
 			logger.Errorf("error updating controller for security group %s: %v", group.Id, err)

--- a/provider/openstack/local_test.go
+++ b/provider/openstack/local_test.go
@@ -30,6 +30,7 @@ import (
 	"gopkg.in/goose.v2/neutron"
 	"gopkg.in/goose.v2/nova"
 	"gopkg.in/goose.v2/testservices/hook"
+	"gopkg.in/goose.v2/testservices/identityservice"
 	"gopkg.in/goose.v2/testservices/neutronservice"
 	"gopkg.in/goose.v2/testservices/novaservice"
 	"gopkg.in/goose.v2/testservices/openstackservice"
@@ -69,8 +70,6 @@ type ProviderSuite struct {
 }
 
 var _ = gc.Suite(&ProviderSuite{})
-var _ = gc.Suite(&localHTTPSServerSuite{})
-var _ = gc.Suite(&noSwiftSuite{})
 
 func (s *ProviderSuite) SetUpTest(c *gc.C) {
 	s.restoreTimeouts = envtesting.PatchAttemptStrategies(openstack.ShortAttempt, openstack.StorageAttempt)
@@ -106,6 +105,9 @@ func registerLocalTests() {
 			TestConfig: config,
 		},
 	})
+	gc.Suite(&noNeutronSuite{
+		cred: cred,
+	})
 }
 
 // localServer is used to spin up a local Openstack service double.
@@ -117,13 +119,15 @@ type localServer struct {
 	UseTLS          bool
 }
 
-type newOpenstackFunc func(*identity.Credentials, identity.AuthMode, bool) (*novaservice.Nova, *neutronservice.Neutron, []string)
+type newOpenstackFunc func(*identity.Credentials, identity.AuthMode, bool) (*openstackservice.Openstack, []string)
 
 func (s *localServer) start(
 	c *gc.C, cred *identity.Credentials, newOpenstackFunc newOpenstackFunc,
 ) {
 	var logMsg []string
-	s.Nova, s.Neutron, logMsg = newOpenstackFunc(cred, identity.AuthUserPass, s.UseTLS)
+	s.Openstack, logMsg = newOpenstackFunc(cred, identity.AuthUserPass, s.UseTLS)
+	s.Nova = s.Openstack.Nova
+	s.Neutron = s.Openstack.Neutron
 	for _, msg := range logMsg {
 		c.Logf("%v", msg)
 	}
@@ -1682,6 +1686,8 @@ type localHTTPSServerSuite struct {
 	env   environs.Environ
 }
 
+var _ = gc.Suite(&localHTTPSServerSuite{})
+
 func (s *localHTTPSServerSuite) SetUpSuite(c *gc.C) {
 	s.BaseSuite.SetUpSuite(c)
 	overrideCinderProvider(c, &s.CleanupSuite, &mockAdapter{})
@@ -2548,6 +2554,131 @@ func (s *localServerSuite) TestUpdateGroupController(c *gc.C) {
 	))
 }
 
+// noNeutronSuite is a clone of localServerSuite which hacks the local
+// openstack to remove the neutron service from the auth response -
+// this causes the client to switch to nova networking.
+type noNeutronSuite struct {
+	coretesting.BaseSuite
+	cred                 *identity.Credentials
+	srv                  localServer
+	env                  environs.Environ
+	toolsMetadataStorage envstorage.Storage
+	imageMetadataStorage envstorage.Storage
+	storageAdapter       *mockAdapter
+}
+
+func (s *noNeutronSuite) SetUpSuite(c *gc.C) {
+	s.BaseSuite.SetUpSuite(c)
+	restoreFinishBootstrap := envtesting.DisableFinishBootstrap()
+	s.AddCleanup(func(*gc.C) { restoreFinishBootstrap() })
+	c.Logf("Running local tests")
+}
+
+func (s *noNeutronSuite) SetUpTest(c *gc.C) {
+	s.BaseSuite.SetUpTest(c)
+	s.srv.start(c, s.cred, newNovaNetworkingOpenstackService)
+
+	userPass, ok := s.srv.Openstack.Identity.(*identityservice.UserPass)
+	c.Assert(ok, jc.IsTrue)
+	// Ensure that there's nothing returned with a type of "network",
+	// so that we switch over to nova networking.
+	cleanup := userPass.RegisterControlPoint("authorisation", func(sc hook.ServiceControl, args ...interface{}) error {
+		res, ok := args[0].(*identityservice.AccessResponse)
+		c.Assert(ok, jc.IsTrue)
+		var filtered []identityservice.V2Service
+		for _, service := range res.Access.ServiceCatalog {
+			if service.Type != "network" {
+				filtered = append(filtered, service)
+			}
+		}
+		res.Access.ServiceCatalog = filtered
+		return nil
+	})
+	s.AddCleanup(func(c *gc.C) { cleanup() })
+
+	cl := client.NewClient(s.cred, identity.AuthUserPass, nil)
+	err := cl.Authenticate()
+	c.Assert(err, jc.ErrorIsNil)
+	containerURL, err := cl.MakeServiceURL("object-store", "", nil)
+	c.Assert(err, jc.ErrorIsNil)
+	attrs := coretesting.FakeConfig().Merge(coretesting.Attrs{
+		"name":               "sample-no-neutron",
+		"type":               "openstack",
+		"auth-mode":          "userpass",
+		"agent-version":      coretesting.FakeVersionNumber.String(),
+		"agent-metadata-url": containerURL + "/juju-dist-test/tools",
+		"image-metadata-url": containerURL + "/juju-dist-test",
+		"authorized-keys":    "fakekey",
+	})
+	s.PatchValue(&jujuversion.Current, coretesting.FakeVersionNumber)
+	// For testing, we create a storage instance to which is uploaded tools and image metadata.
+	env, err := bootstrap.Prepare(
+		envtesting.BootstrapContext(c),
+		jujuclient.NewMemStore(),
+		prepareParams(attrs, s.cred),
+	)
+	c.Assert(err, jc.ErrorIsNil)
+	s.env = env
+	s.toolsMetadataStorage = openstack.MetadataStorage(s.env)
+	// Put some fake metadata in place so that tests that are simply
+	// starting instances without any need to check if those instances
+	// are running can find the metadata.
+	envtesting.UploadFakeTools(c, s.toolsMetadataStorage, s.env.Config().AgentStream(), s.env.Config().AgentStream())
+	s.imageMetadataStorage = openstack.ImageMetadataStorage(s.env)
+	openstack.UseTestImageData(s.imageMetadataStorage, s.cred)
+	s.storageAdapter = makeMockAdapter()
+	overrideCinderProvider(c, &s.CleanupSuite, s.storageAdapter)
+}
+
+func (s *noNeutronSuite) TearDownTest(c *gc.C) {
+	if s.imageMetadataStorage != nil {
+		openstack.RemoveTestImageData(s.imageMetadataStorage)
+	}
+	if s.toolsMetadataStorage != nil {
+		envtesting.RemoveFakeToolsMetadata(c, s.toolsMetadataStorage)
+	}
+	s.srv.stop()
+	s.BaseSuite.TearDownTest(c)
+}
+
+func (s *noNeutronSuite) TestUpdateGroupControllerNoNeutron(c *gc.C) {
+	client := openstack.GetNovaClient(s.env)
+	_, err := client.CreateSecurityGroup("unrelated", "you know, for tests!")
+	c.Assert(err, jc.ErrorIsNil)
+	err = bootstrapEnv(c, s.env)
+	c.Assert(err, jc.ErrorIsNil)
+
+	groupNamesBefore := set.NewStrings(getNovaSecurityGroupNames(c, client)...)
+	c.Assert(groupNamesBefore, gc.DeepEquals, set.NewStrings(
+		"default",
+		"unrelated",
+		"juju-deadbeef-1bad-500d-9000-4b1d0d06f00d-deadbeef-0bad-400d-8000-4b1d0d06f00d",
+		"juju-deadbeef-1bad-500d-9000-4b1d0d06f00d-deadbeef-0bad-400d-8000-4b1d0d06f00d-0",
+	))
+
+	firewaller := openstack.GetFirewaller(s.env)
+	err = firewaller.UpdateGroupController("aabbccdd-eeee-ffff-0000-0123456789ab")
+	c.Assert(err, jc.ErrorIsNil)
+
+	groupNamesAfter := set.NewStrings(getNovaSecurityGroupNames(c, client)...)
+	c.Assert(groupNamesAfter, gc.DeepEquals, set.NewStrings(
+		"default",
+		"unrelated",
+		"juju-aabbccdd-eeee-ffff-0000-0123456789ab-deadbeef-0bad-400d-8000-4b1d0d06f00d",
+		"juju-aabbccdd-eeee-ffff-0000-0123456789ab-deadbeef-0bad-400d-8000-4b1d0d06f00d-0",
+	))
+}
+
+func getNovaSecurityGroupNames(c *gc.C, client *nova.Client) []string {
+	groups, err := client.ListSecurityGroups()
+	c.Assert(err, jc.ErrorIsNil)
+	var names []string
+	for _, group := range groups {
+		names = append(names, group.Name)
+	}
+	return names
+}
+
 func prepareParams(attrs map[string]interface{}, cred *identity.Credentials) bootstrap.PrepareParams {
 	return bootstrap.PrepareParams{
 		ControllerConfig: coretesting.FakeControllerConfig(),
@@ -2588,6 +2719,8 @@ type noSwiftSuite struct {
 	srv  localServer
 	env  environs.Environ
 }
+
+var _ = gc.Suite(&noSwiftSuite{})
 
 func (s *noSwiftSuite) SetUpSuite(c *gc.C) {
 	s.BaseSuite.SetUpSuite(c)
@@ -2664,18 +2797,24 @@ func (s *noSwiftSuite) TestBootstrap(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 }
 
-func newFullOpenstackService(cred *identity.Credentials, auth identity.AuthMode, useTSL bool) (*novaservice.Nova, *neutronservice.Neutron, []string) {
+func newFullOpenstackService(cred *identity.Credentials, auth identity.AuthMode, useTSL bool) (*openstackservice.Openstack, []string) {
 	service, logMsg := openstackservice.New(cred, auth, useTSL)
 	service.UseNeutronNetworking()
 	service.SetupHTTP(nil)
-	return service.Nova, service.Neutron, logMsg
+	return service, logMsg
 }
 
-func newNovaOnlyOpenstackService(cred *identity.Credentials, auth identity.AuthMode, useTSL bool) (*novaservice.Nova, *neutronservice.Neutron, []string) {
+func newNovaOnlyOpenstackService(cred *identity.Credentials, auth identity.AuthMode, useTSL bool) (*openstackservice.Openstack, []string) {
 	service, logMsg := openstackservice.NewNoSwift(cred, auth, useTSL)
 	service.UseNeutronNetworking()
 	service.SetupHTTP(nil)
-	return service.Nova, service.Neutron, logMsg
+	return service, logMsg
+}
+
+func newNovaNetworkingOpenstackService(cred *identity.Credentials, auth identity.AuthMode, useTSL bool) (*openstackservice.Openstack, []string) {
+	service, logMsg := openstackservice.New(cred, auth, useTSL)
+	service.SetupHTTP(nil)
+	return service, logMsg
 }
 
 func bootstrapEnv(c *gc.C, env environs.Environ) error {


### PR DESCRIPTION
## Description of change

legacyNovaFirewaller.UpdateGroupController wasn't filtering the groups
to those that matched its regex, so it was failing in the replace
step. This would prevent migrations from finishing on Canonistack or any
other Openstack using nova networking - the model would be running fine
on the target controller (and the machine and unit agents would be talking to 
the model on the target), but would not be removed from the source.

## QA steps

* Bootstrap 2 controllers A and B on an Openstack using Nova networking.
* Add a model m to A.
* Migrate it to B.
* The model is removed from A.

## Bug reference
Fixes https://bugs.launchpad.net/juju/+bug/1717860
