### PR TITLE
state: destroying model removes application offers

### DIFF
--- a/state/allcollections.go
+++ b/state/allcollections.go
@@ -424,10 +424,15 @@ func allCollections() collectionSchema {
 
 		// Cross model relations collections.
 		applicationOffersC: {
-			indexes: []mgo.Index{{Key: []string{"model-uuid", "url"}}},
+			indexes: []mgo.Index{
+				{Key: []string{"model-uuid", "_id"}},
+				{Key: []string{"model-uuid", "application-name"}},
+			},
 		},
 		offerConnectionsC: {
-			indexes: []mgo.Index{{Key: []string{"model-uuid", "offer-name"}}},
+			indexes: []mgo.Index{
+				{Key: []string{"model-uuid", "offer-uuid"}},
+			},
 		},
 		remoteApplicationsC: {},
 		// remoteEntitiesC holds information about entities involved in

--- a/state/cleanup.go
+++ b/state/cleanup.go
@@ -336,7 +336,9 @@ func (st *State) removeApplicationsForDyingModel() (err error) {
 	iter := applications.Find(sel).Iter()
 	defer closeIter(iter, &err, "reading application document")
 	for iter.Next(&application.doc) {
-		if err := application.Destroy(); err != nil {
+		op := application.DestroyOperation()
+		op.RemoveOffers = true
+		if err := st.ApplyOperation(op); err != nil {
 			return errors.Trace(err)
 		}
 	}


### PR DESCRIPTION
## Description of change

Extend DestroyApplicationOperation with a flag
that allows the application to be destroyed
even when it has offers, removing the offers
at the same time as the application is removed.

The flag is set when running the application
removal cleanup that is scheduled when a model
is destroyed.

## QA steps

1. juju bootstrap localhost
2. juju deploy mysql
3. juju offer mysql:db
4. juju destroy-model -y default

Model should be destroyed cleanly.

## Documentation changes

None.

## Bug reference

Fixes https://bugs.launchpad.net/juju/+bug/1724673