### PR TITLE
Support firewall icmp rules

### DIFF
--- a/network/portrange_test.go
+++ b/network/portrange_test.go
@@ -93,6 +93,11 @@ func (*PortRangeSuite) TestStrings(c *gc.C) {
 		gc.Equals,
 		"80-100/tcp",
 	)
+	c.Assert(
+		network.PortRange{-1, -1, "ICMP"}.String(),
+		gc.Equals,
+		"icmp",
+	)
 }
 
 func (*PortRangeSuite) TestValidate(c *gc.C) {
@@ -139,7 +144,11 @@ func (*PortRangeSuite) TestValidate(c *gc.C) {
 	}, {
 		"invalid protocol",
 		network.PortRange{80, 80, "some protocol"},
-		`invalid protocol "some protocol", expected "tcp" or "udp"`,
+		`invalid protocol "some protocol", expected "tcp", "udp", or "icmp"`,
+	}, {
+		"invalid icmp port",
+		network.PortRange{1, 1, "icmp"},
+		`protocol "icmp" doesn't support any ports; got "1"`,
 	}}
 
 	for i, t := range testCases {
@@ -240,6 +249,23 @@ func (*PortRangeSuite) TestParsePortRangeDefaultProtocol(c *gc.C) {
 	c.Check(portRange.Protocol, gc.Equals, "tcp")
 	c.Check(portRange.FromPort, gc.Equals, 80)
 	c.Check(portRange.ToPort, gc.Equals, 80)
+}
+
+func (*PortRangeSuite) TestParseIcmpProtocol(c *gc.C) {
+	portRange, err := network.ParsePortRange("icmp")
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Check(portRange.Protocol, gc.Equals, "icmp")
+	c.Check(portRange.FromPort, gc.Equals, -1)
+	c.Check(portRange.ToPort, gc.Equals, -1)
+}
+
+func (*PortRangeSuite) TestParseIcmpProtocolRoundTrip(c *gc.C) {
+	portRange, err := network.ParsePortRange("icmp")
+	c.Assert(err, jc.ErrorIsNil)
+	portRangeStr := portRange.String()
+
+	c.Check(portRangeStr, gc.Equals, "icmp")
 }
 
 func (*PortRangeSuite) TestParsePortRangeRoundTrip(c *gc.C) {

--- a/state/ports_test.go
+++ b/state/ports_test.go
@@ -106,6 +106,22 @@ func (s *PortsDocSuite) TestOpenAndClosePorts(c *gc.C) {
 		},
 		expected: "",
 	}, {
+		about:    "open and close icmp",
+		existing: nil,
+		open: &state.PortRange{
+			FromPort: -1,
+			ToPort:   -1,
+			UnitName: s.unit1.Name(),
+			Protocol: "ICMP",
+		},
+		close: &state.PortRange{
+			FromPort: -1,
+			ToPort:   -1,
+			UnitName: s.unit1.Name(),
+			Protocol: "ICMP",
+		},
+		expected: "",
+	}, {
 		about: "try to close part of a port range",
 		existing: []state.PortRange{{
 			FromPort: 100,
@@ -297,6 +313,22 @@ func (s *PortsDocSuite) TestAllPortRanges(c *gc.C) {
 	c.Assert(ranges, gc.HasLen, 1)
 
 	c.Assert(ranges[network.PortRange{100, 200, "TCP"}], gc.Equals, s.unit1.Name())
+}
+
+func (s *PortsDocSuite) TestICMP(c *gc.C) {
+	portRange := state.PortRange{
+		FromPort: -1,
+		ToPort:   -1,
+		UnitName: s.unit1.Name(),
+		Protocol: "ICMP",
+	}
+	err := s.portsWithoutSubnet.OpenPorts(portRange)
+	c.Assert(err, jc.ErrorIsNil)
+
+	ranges := s.portsWithoutSubnet.AllPortRanges()
+	c.Assert(ranges, gc.HasLen, 1)
+
+	c.Assert(ranges[network.PortRange{-1, -1, "ICMP"}], gc.Equals, s.unit1.Name())
 }
 
 func (s *PortsDocSuite) TestOpenInvalidRange(c *gc.C) {
@@ -587,6 +619,10 @@ func (p *PortRangeSuite) TestPortRangeString(c *gc.C) {
 	c.Assert(state.PortRange{"wordpress/0", 80, 100, "TCP"}.String(),
 		gc.Equals,
 		`80-100/tcp ("wordpress/0")`,
+	)
+	c.Assert(state.PortRange{"wordpress/0", -1, -1, "ICMP"}.String(),
+		gc.Equals,
+		`icmp ("wordpress/0")`,
 	)
 }
 

--- a/worker/uniter/runner/context/ports_test.go
+++ b/worker/uniter/runner/context/ports_test.go
@@ -56,7 +56,7 @@ func (s *PortsSuite) TestValidatePortRange(c *gc.C) {
 		about:     "invalid protocol - 1-65535/foo",
 		proto:     "foo",
 		ports:     []int{1, 65535},
-		expectErr: `invalid protocol "foo", expected "tcp" or "udp"`,
+		expectErr: `invalid protocol "foo", expected "tcp", "udp", or "icmp"`,
 	}, {
 		about: "valid range - 100-200/udp",
 		proto: "UDP",
@@ -164,7 +164,7 @@ func (s *PortsSuite) TestTryOpenPorts(c *gc.C) {
 	}, {
 		about:     "invalid protocol - 10-20/foo",
 		proto:     "foo",
-		expectErr: `invalid protocol "foo", expected "tcp" or "udp"`,
+		expectErr: `invalid protocol "foo", expected "tcp", "udp", or "icmp"`,
 	}, {
 		about:         "open a new range (no machine ports yet)",
 		expectPending: makePendingPorts("tcp", 10, 20, true),
@@ -226,7 +226,7 @@ func (s *PortsSuite) TestTryClosePorts(c *gc.C) {
 	}, {
 		about:     "invalid protocol - 10-20/foo",
 		proto:     "foo",
-		expectErr: `invalid protocol "foo", expected "tcp" or "udp"`,
+		expectErr: `invalid protocol "foo", expected "tcp", "udp", or "icmp"`,
 	}, {
 		about:         "close a new range (no machine ports yet; ignored)",
 		expectPending: map[context.PortRange]context.PortRangeInfo{},


### PR DESCRIPTION
## Description of change

open/close-port hook tools and the Juju firewaller now support ICMP rules. So a charm can specify it wants to allow ICMP access to its host machine.

## QA steps

Deploy the ubuntu charm (on aws)
juju run --unit ubuntu/0 "open-port icmp"

check that the sec group has the icmp rule added
close port and check that the rule is deleted.

## Documentation changes

Charm hook tools doc needs updating.