### PR TITLE
Fix  return of invalid json/yaml on empty list.

### DIFF
--- a/cmd/juju/space/list.go
+++ b/cmd/juju/space/list.go
@@ -83,7 +83,9 @@ func (c *ListCommand) Run(ctx *cmd.Context) error {
 		}
 		if len(spaces) == 0 {
 			ctx.Infof("no spaces to display")
-			return nil
+			if c.out.Name() == "tabular" {
+				return nil
+			}
 		}
 
 		if c.Short {

--- a/cmd/juju/space/list_test.go
+++ b/cmd/juju/space/list_test.go
@@ -276,6 +276,26 @@ func (s *ListSuite) TestRunWhenNoSpacesExistSucceeds(c *gc.C) {
 	s.api.CheckCall(c, 0, "ListSpaces")
 }
 
+func (s *ListSuite) TestRunWhenNoSpacesExistSucceedsWithProperFormat(c *gc.C) {
+	s.api.Spaces = s.api.Spaces[0:0]
+
+	s.AssertRunSucceeds(c,
+		`no spaces to display\n`,
+		"{\"spaces\":{}}\n", // json formatted stdout.
+		"--format=json",
+	)
+
+	s.AssertRunSucceeds(c,
+		`no spaces to display\n`,
+		"spaces: {}\n", // yaml formatted stdout.
+		"--format=yaml",
+	)
+
+	s.api.CheckCallNames(c, "ListSpaces", "Close", "ListSpaces", "Close")
+	s.api.CheckCall(c, 0, "ListSpaces")
+	s.api.CheckCall(c, 2, "ListSpaces")
+}
+
 func (s *ListSuite) TestRunWhenSpacesNotSupported(c *gc.C) {
 	s.api.SetErrors(errors.NewNotSupported(nil, "spaces not supported"))
 


### PR DESCRIPTION
## Description of change

The `juju spaces` command would fail to produce valid JSON when that format is requested and there are no available spaces to display. Basically `juju spaces` would produce an empty string which is invalid JSON.

## QA steps

Bootstrap a controller that uses a provider that supports the spaces. Delete any spaces. Then run `juju spaces --format=json`

You should receive

`{spaces: {}}\n` and not the empty string

## Documentation changes

No

## Bug reference

https://bugs.launchpad.net/juju/+bug/1708340
