### PR TITLE
BUG 1707248: Add filter based on user's project id to ListFloatingIPs…

### DIFF
--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -94,7 +94,7 @@ google.golang.org/cloud	git	f20d6dcccb44ed49de45ae3703312cb46e627db1	2015-03-19T
 gopkg.in/amz.v3	git	8c3190dff075bf5442c9eedbf8f8ed6144a099e7	2016-12-15T13:08:49Z
 gopkg.in/check.v1	git	4f90aeace3a26ad7021961c297b22c42160c7b25	2016-01-05T16:49:36Z
 gopkg.in/errgo.v1	git	442357a80af5c6bf9b6d51ae791a39c3421004f3	2016-12-22T12:58:16Z
-gopkg.in/goose.v2	git	54760fcc506e180a22bef75f111d5e0b7d9a7f41	2017-05-11T03:10:46Z
+gopkg.in/goose.v2	git	7eb5c96ccec1c7617badcb4098313bdb90e654bf	2017-10-31T22:15:48Z
 gopkg.in/ini.v1	git	776aa739ce9373377cd16f526cdf06cb4c89b40f	2016-02-22T23:24:41Z
 gopkg.in/juju/blobstore.v2	git	51fa6e26128d74e445c72d3a91af555151cc3654	2016-01-25T02:37:03Z
 gopkg.in/juju/charm.v6-unstable	git	514bb811b021ebeb3e7ffcf1c267e9803968f59d	2017-07-28T19:41:00Z


### PR DESCRIPTION
## Description of change

Add filter based on user's project id to ListFloatingIPsV2() call in AllocatePublicIP().
If OpenStack admin credential's are used with juju, it's possible to retrieve 
fips in a different project from the one specified in the credentials.

Note: this commit updates the go-goose library dependency.  So it also includes fixes for
bugs: 1728725 and 1722551.

## QA steps

1. user test1 has Admin privileges in the OpenStack and has primary project "tenant-one"
1. user test2 is member of project "tenant-two"
1. user test2 creates FIPs in project "tenant-two", not used.
1. credentials given to juju are test1, test1_password, tenant-one and RegionOne.
1. bootstrap with --config use-floating-ip=true.
1. a new fip should be allocated for use by the controller in OpenStack project "tenant-one"

## Documentation changes

N/A

## Bug reference

https://bugs.launchpad.net/juju/+bug/1707248