### PR TITLE
Allow bundles to deploy to existing machines.

### DIFF
--- a/cmd/juju/application/deploy_test.go
+++ b/cmd/juju/application/deploy_test.go
@@ -107,6 +107,18 @@ var initErrorTests = []struct {
 	}, {
 		args: []string{"charm", "--attach-storage", "foo/0", "-n", "2"},
 		err:  `--attach-storage cannot be used with -n`,
+	}, {
+		args: []string{"bundle", "--bundle-machine", "foo"},
+		err:  `invalid value "foo" for flag --bundle-machine: expected key=value format`,
+	}, {
+		args: []string{"bundle", "--bundle-machine", "foo=bar"},
+		err:  `--bundle-machine value "foo=bar", first value be a top level machine id`,
+	}, {
+		args: []string{"bundle", "--bundle-machine", "2=bar"},
+		err:  `--bundle-machine value "2=bar", second value be a top level machine id`,
+	}, {
+		args: []string{"bundle", "--bundle-machine", "2=-3"},
+		err:  `--bundle-machine value "2=-3", second value be a top level machine id`,
 	},
 }
 
@@ -114,7 +126,7 @@ func (s *DeploySuite) TestInitErrors(c *gc.C) {
 	for i, t := range initErrorTests {
 		c.Logf("test %d", i)
 		err := cmdtesting.InitCommand(NewDeployCommand(), t.args)
-		c.Assert(err, gc.ErrorMatches, t.err)
+		c.Check(err, gc.ErrorMatches, t.err)
 	}
 }
 


### PR DESCRIPTION
There are two main uses for targeting existing machines:
 * using a manual provider
 * reusing existing machines

## QA steps
```
$ juju deploy hadoop-processing
# wait until fully deployed
$ juju deploy spark-processing --dry-run
# notice the creation of five machines
$ juju deploy spark-processing --dry-run --use-existing-machines
# notice no new machines created, units target existing machines
$ juju deploy spark-processing --dry-run  --bundle-machine 2=3 --bundle-machine 3=2 --bundle-machine 4=4
# notice two new machines created for spark, and zookeeper deployed to existing machines
# note also that zookeeper/0 deploys to machine 3, and zookeeper/1 to machine 2.
```

## Documentation changes

Yes, documentation will need to be updated with examples.

## Bug reference

https://bugs.launchpad.net/juju-core/+bug/1567169
