### PR TITLE
Model status api gains error.

### DIFF
--- a/api/base/types.go
+++ b/api/base/types.go
@@ -34,6 +34,7 @@ type ModelStatus struct {
 	Machines           []Machine
 	Volumes            []Volume
 	Filesystems        []Filesystem
+	Error              error
 }
 
 // Machine holds information about a machine in a juju model.

--- a/api/common/modelstatus.go
+++ b/api/common/modelstatus.go
@@ -25,6 +25,14 @@ func NewModelStatusAPI(facade base.FacadeCaller) *ModelStatusAPI {
 
 // ModelStatus returns a status summary for each model tag passed in.
 func (c *ModelStatusAPI) ModelStatus(tags ...names.ModelTag) ([]base.ModelStatus, error) {
+	// This call is used in both Controller and ModelManger facades.
+	// Luckily, prior to the signature change both of these facades were at version 3.
+	olderVersion := false
+	if bestVer := c.facade.BestAPIVersion(); bestVer < 4 {
+		logger.Debugf("calling older models status on v%d", bestVer)
+		olderVersion = true
+	}
+
 	result := params.ModelStatusResults{}
 	models := make([]params.Entity, len(tags))
 	for i, tag := range tags {
@@ -37,8 +45,40 @@ func (c *ModelStatusAPI) ModelStatus(tags ...names.ModelTag) ([]base.ModelStatus
 		return nil, err
 	}
 
-	results := make([]base.ModelStatus, len(result.Results))
-	for i, r := range result.Results {
+	if olderVersion {
+		// This caters for the fact that older version of base.ModelStatus
+		// did not have an Error field.
+		return c.processModelStatusResultsV3(result.Results)
+	}
+
+	return c.processModelStatusResults(result.Results)
+}
+
+func (c *ModelStatusAPI) processModelStatusResults(rs []params.ModelStatus) ([]base.ModelStatus, error) {
+	results := make([]base.ModelStatus, len(rs))
+	for i, r := range rs {
+		if r.Error != nil {
+			results[i].Error = errors.Trace(r.Error)
+			continue
+		}
+		model, err := names.ParseModelTag(r.ModelTag)
+		if err != nil {
+			results[i].Error = errors.Annotatef(err, "model tag %v", r.ModelTag)
+			continue
+		}
+		owner, err := names.ParseUserTag(r.OwnerTag)
+		if err != nil {
+			results[i].Error = errors.Annotatef(err, "owner tag %v", r.OwnerTag)
+			continue
+		}
+		results[i] = constructModelStatus(model, owner, r)
+	}
+	return results, nil
+}
+
+func (c *ModelStatusAPI) processModelStatusResultsV3(rs []params.ModelStatus) ([]base.ModelStatus, error) {
+	results := make([]base.ModelStatus, len(rs))
+	for i, r := range rs {
 		model, err := names.ParseModelTag(r.ModelTag)
 		if err != nil {
 			return nil, errors.Annotatef(err, "ModelTag %q at position %d", r.ModelTag, i)
@@ -47,50 +87,54 @@ func (c *ModelStatusAPI) ModelStatus(tags ...names.ModelTag) ([]base.ModelStatus
 		if err != nil {
 			return nil, errors.Annotatef(err, "OwnerTag %q at position %d", r.OwnerTag, i)
 		}
-
-		volumes := make([]base.Volume, len(r.Volumes))
-		for i, in := range r.Volumes {
-			volumes[i] = base.Volume{
-				Id:         in.Id,
-				ProviderId: in.ProviderId,
-				Status:     in.Status,
-				Detachable: in.Detachable,
-			}
-		}
-
-		filesystems := make([]base.Filesystem, len(r.Filesystems))
-		for i, in := range r.Filesystems {
-			filesystems[i] = base.Filesystem{
-				Id:         in.Id,
-				ProviderId: in.ProviderId,
-				Status:     in.Status,
-				Detachable: in.Detachable,
-			}
-		}
-
-		results[i] = base.ModelStatus{
-			UUID:               model.Id(),
-			Life:               string(r.Life),
-			Owner:              owner.Id(),
-			HostedMachineCount: r.HostedMachineCount,
-			ServiceCount:       r.ApplicationCount,
-			TotalMachineCount:  len(r.Machines),
-			Volumes:            volumes,
-			Filesystems:        filesystems,
-		}
-		results[i].Machines = make([]base.Machine, len(r.Machines))
-		for j, mm := range r.Machines {
-			if mm.Hardware != nil && mm.Hardware.Cores != nil {
-				results[i].CoreCount += int(*mm.Hardware.Cores)
-			}
-			results[i].Machines[j] = base.Machine{
-				Id:         mm.Id,
-				InstanceId: mm.InstanceId,
-				HasVote:    mm.HasVote,
-				WantsVote:  mm.WantsVote,
-				Status:     mm.Status,
-			}
-		}
+		results[i] = constructModelStatus(model, owner, r)
 	}
 	return results, nil
+}
+
+func constructModelStatus(model names.ModelTag, owner names.UserTag, r params.ModelStatus) base.ModelStatus {
+	volumes := make([]base.Volume, len(r.Volumes))
+	for i, in := range r.Volumes {
+		volumes[i] = base.Volume{
+			Id:         in.Id,
+			ProviderId: in.ProviderId,
+			Status:     in.Status,
+			Detachable: in.Detachable,
+		}
+	}
+
+	filesystems := make([]base.Filesystem, len(r.Filesystems))
+	for i, in := range r.Filesystems {
+		filesystems[i] = base.Filesystem{
+			Id:         in.Id,
+			ProviderId: in.ProviderId,
+			Status:     in.Status,
+			Detachable: in.Detachable,
+		}
+	}
+
+	result := base.ModelStatus{
+		UUID:               model.Id(),
+		Life:               string(r.Life),
+		Owner:              owner.Id(),
+		HostedMachineCount: r.HostedMachineCount,
+		ServiceCount:       r.ApplicationCount,
+		TotalMachineCount:  len(r.Machines),
+		Volumes:            volumes,
+		Filesystems:        filesystems,
+	}
+	result.Machines = make([]base.Machine, len(r.Machines))
+	for j, mm := range r.Machines {
+		if mm.Hardware != nil && mm.Hardware.Cores != nil {
+			result.CoreCount += int(*mm.Hardware.Cores)
+		}
+		result.Machines[j] = base.Machine{
+			Id:         mm.Id,
+			InstanceId: mm.InstanceId,
+			HasVote:    mm.HasVote,
+			WantsVote:  mm.WantsVote,
+			Status:     mm.Status,
+		}
+	}
+	return result
 }

--- a/api/common/modelstatus.go
+++ b/api/common/modelstatus.go
@@ -25,12 +25,6 @@ func NewModelStatusAPI(facade base.FacadeCaller) *ModelStatusAPI {
 
 // ModelStatus returns a status summary for each model tag passed in.
 func (c *ModelStatusAPI) ModelStatus(tags ...names.ModelTag) ([]base.ModelStatus, error) {
-	// This call is used in both Controller and ModelManger facades.
-	// Luckily, prior to the signature change both of these facades were at version 3.
-	if bestVer := c.facade.BestAPIVersion(); bestVer < 4 {
-		logger.Tracef("calling older models status on v%d", bestVer)
-	}
-
 	result := params.ModelStatusResults{}
 	models := make([]params.Entity, len(tags))
 	for i, tag := range tags {
@@ -56,12 +50,12 @@ func (c *ModelStatusAPI) processModelStatusResults(rs []params.ModelStatus) ([]b
 		}
 		model, err := names.ParseModelTag(r.ModelTag)
 		if err != nil {
-			results[i].Error = err
+			results[i].Error = errors.Trace(err)
 			continue
 		}
 		owner, err := names.ParseUserTag(r.OwnerTag)
 		if err != nil {
-			results[i].Error = err
+			results[i].Error = errors.Trace(err)
 			continue
 		}
 		results[i] = constructModelStatus(model, owner, r)

--- a/api/controller/legacy_test.go
+++ b/api/controller/legacy_test.go
@@ -15,7 +15,6 @@ import (
 	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/api"
-	"github.com/juju/juju/api/base"
 	"github.com/juju/juju/api/controller"
 	"github.com/juju/juju/apiserver"
 	commontesting "github.com/juju/juju/apiserver/common/testing"
@@ -288,24 +287,6 @@ func (s *legacySuite) TestAPIServerCanShutdownWithOutstandingNext(c *gc.C) {
 	case <-time.After(testing.LongWait):
 		c.Fatal("timed out")
 	}
-}
-
-func (s *legacySuite) TestModelStatus(c *gc.C) {
-	sysManager := s.OpenAPI(c)
-	defer sysManager.Close()
-	s.Factory.MakeMachine(c, nil)
-	modelTag := s.IAASModel.ModelTag()
-	results, err := sysManager.ModelStatus(modelTag)
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(results, jc.DeepEquals, []base.ModelStatus{{
-		UUID:               modelTag.Id(),
-		TotalMachineCount:  1,
-		HostedMachineCount: 1,
-		ServiceCount:       0,
-		Owner:              "admin",
-		Life:               string(params.Alive),
-		Machines:           []base.Machine{{Id: "0", InstanceId: "id-2", Status: "pending"}},
-	}})
 }
 
 func (s *legacySuite) TestGetControllerAccess(c *gc.C) {

--- a/api/modelmanager/modelmanager_test.go
+++ b/api/modelmanager/modelmanager_test.go
@@ -393,13 +393,10 @@ func (s *modelmanagerSuite) TestModelStatusEmpty(c *gc.C) {
 }
 
 func (s *modelmanagerSuite) TestModelStatusError(c *gc.C) {
-	apiCaller := basetesting.BestVersionCaller{
-		BestVersion: 3,
-		APICallerFunc: basetesting.APICallerFunc(
-			func(objType string, version int, id, request string, args, result interface{}) error {
-				return errors.New("model error")
-			}),
-	}
+	apiCaller := basetesting.APICallerFunc(
+		func(objType string, version int, id, request string, args, result interface{}) error {
+			return errors.New("model error")
+		})
 	client := modelmanager.NewClient(apiCaller)
 	out, err := client.ModelStatus(coretesting.ModelTag, coretesting.ModelTag)
 	c.Assert(err, gc.ErrorMatches, "model error")

--- a/api/modelmanager/modelmanager_test.go
+++ b/api/modelmanager/modelmanager_test.go
@@ -6,6 +6,7 @@ package modelmanager_test
 import (
 	"time"
 
+	"github.com/juju/errors"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
@@ -14,6 +15,7 @@ import (
 	"github.com/juju/juju/api/base"
 	basetesting "github.com/juju/juju/api/base/testing"
 	"github.com/juju/juju/api/modelmanager"
+	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/environs/config"
 	coretesting "github.com/juju/juju/testing"
@@ -325,37 +327,44 @@ func (s *modelmanagerSuite) TestUnsetModelDefaults(c *gc.C) {
 }
 
 func (s *modelmanagerSuite) TestModelStatus(c *gc.C) {
-	apiCaller := basetesting.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
-		c.Check(objType, gc.Equals, "ModelManager")
-		c.Check(id, gc.Equals, "")
-		c.Check(request, gc.Equals, "ModelStatus")
-		c.Check(arg, jc.DeepEquals, params.Entities{
-			[]params.Entity{{
-				Tag: coretesting.ModelTag.String(),
-			}},
-		})
-		c.Check(result, gc.FitsTypeOf, &params.ModelStatusResults{})
+	apiCaller := basetesting.BestVersionCaller{
+		BestVersion: 4,
+		APICallerFunc: func(objType string, version int, id, request string, arg, result interface{}) error {
+			c.Check(objType, gc.Equals, "ModelManager")
+			c.Check(id, gc.Equals, "")
+			c.Check(request, gc.Equals, "ModelStatus")
+			c.Check(arg, jc.DeepEquals, params.Entities{
+				[]params.Entity{
+					{Tag: coretesting.ModelTag.String()},
+					{Tag: coretesting.ModelTag.String()},
+				},
+			})
+			c.Check(result, gc.FitsTypeOf, &params.ModelStatusResults{})
 
-		out := result.(*params.ModelStatusResults)
-		out.Results = []params.ModelStatus{{
-			ModelTag:           coretesting.ModelTag.String(),
-			OwnerTag:           "user-glenda",
-			ApplicationCount:   3,
-			HostedMachineCount: 2,
-			Life:               "alive",
-			Machines: []params.ModelMachineInfo{{
-				Id:         "0",
-				InstanceId: "inst-ance",
-				Status:     "pending",
-			}},
-		}}
-		return nil
-	})
+			out := result.(*params.ModelStatusResults)
+			out.Results = []params.ModelStatus{
+				params.ModelStatus{
+					ModelTag:           coretesting.ModelTag.String(),
+					OwnerTag:           "user-glenda",
+					ApplicationCount:   3,
+					HostedMachineCount: 2,
+					Life:               "alive",
+					Machines: []params.ModelMachineInfo{{
+						Id:         "0",
+						InstanceId: "inst-ance",
+						Status:     "pending",
+					}},
+				},
+				params.ModelStatus{Error: common.ServerError(errors.New("model error"))},
+			}
+			return nil
+		},
+	}
 
 	client := modelmanager.NewClient(apiCaller)
-	results, err := client.ModelStatus(coretesting.ModelTag)
+	results, err := client.ModelStatus(coretesting.ModelTag, coretesting.ModelTag)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(results, jc.DeepEquals, []base.ModelStatus{{
+	c.Assert(results[0], jc.DeepEquals, base.ModelStatus{
 		UUID:               coretesting.ModelTag.Id(),
 		TotalMachineCount:  1,
 		HostedMachineCount: 2,
@@ -363,7 +372,38 @@ func (s *modelmanagerSuite) TestModelStatus(c *gc.C) {
 		Owner:              "glenda",
 		Life:               string(params.Alive),
 		Machines:           []base.Machine{{Id: "0", InstanceId: "inst-ance", Status: "pending"}},
-	}})
+	})
+	c.Assert(results[1].Error, gc.ErrorMatches, "model error")
+}
+
+func (s *modelmanagerSuite) TestModelStatusEmpty(c *gc.C) {
+	apiCaller := basetesting.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
+		c.Check(objType, gc.Equals, "ModelManager")
+		c.Check(id, gc.Equals, "")
+		c.Check(request, gc.Equals, "ModelStatus")
+		c.Check(result, gc.FitsTypeOf, &params.ModelStatusResults{})
+
+		return nil
+	})
+
+	client := modelmanager.NewClient(apiCaller)
+	results, err := client.ModelStatus()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(results, jc.DeepEquals, []base.ModelStatus{})
+}
+
+func (s *modelmanagerSuite) TestModelStatusError(c *gc.C) {
+	apiCaller := basetesting.BestVersionCaller{
+		BestVersion: 3,
+		APICallerFunc: basetesting.APICallerFunc(
+			func(objType string, version int, id, request string, args, result interface{}) error {
+				return errors.New("model error")
+			}),
+	}
+	client := modelmanager.NewClient(apiCaller)
+	out, err := client.ModelStatus(coretesting.ModelTag, coretesting.ModelTag)
+	c.Assert(err, gc.ErrorMatches, "model error")
+	c.Assert(out, gc.IsNil)
 }
 
 type dumpModelSuite struct {

--- a/apiserver/common/modelstatus.go
+++ b/apiserver/common/modelstatus.go
@@ -31,18 +31,16 @@ func NewModelStatusAPI(backend ModelManagerBackend, authorizer facade.Authorizer
 // ModelStatus returns a summary of the model.
 func (c *ModelStatusAPI) ModelStatus(req params.Entities) (params.ModelStatusResults, error) {
 	models := req.Entities
-	results := params.ModelStatusResults{}
-
 	status := make([]params.ModelStatus, len(models))
 	for i, model := range models {
 		modelStatus, err := c.modelStatus(model.Tag)
 		if err != nil {
-			return results, errors.Trace(err)
+			status[i].Error = ServerError(err)
+			continue
 		}
 		status[i] = modelStatus
 	}
-	results.Results = status
-	return results, nil
+	return params.ModelStatusResults{Results: status}, nil
 }
 
 func (c *ModelStatusAPI) modelStatus(tag string) (params.ModelStatus, error) {

--- a/apiserver/facades/client/controller/controller.go
+++ b/apiserver/facades/client/controller/controller.go
@@ -29,13 +29,8 @@ import (
 
 var logger = loggo.GetLogger("juju.apiserver.controller")
 
-// ControllerAPIv4 provides the v4 Controller API.
-type ControllerAPIv4 struct {
-	*ControllerAPIv3
-}
-
-// ControllerAPIv3 provides the v3 Controller API.
-type ControllerAPIv3 struct {
+// ControllerAPI provides the Controller API.
+type ControllerAPI struct {
 	*common.ControllerConfigAPI
 	*common.ModelStatusAPI
 	cloudspec.CloudSpecAPI
@@ -47,18 +42,43 @@ type ControllerAPIv3 struct {
 	resources  facade.Resources
 }
 
+// ControllerAPIv3 provides the v3 Controller API.
+type ControllerAPIv3 struct {
+	*ControllerAPI
+}
+
 // NewControllerAPIv4 creates a new ControllerAPIv4.
-func NewControllerAPIv4(ctx facade.Context) (*ControllerAPIv4, error) {
-	v3, err := NewControllerAPIv3(ctx)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	return &ControllerAPIv4{v3}, nil
+func NewControllerAPIv4(ctx facade.Context) (*ControllerAPI, error) {
+	st := ctx.State()
+	authorizer := ctx.Auth()
+	pool := ctx.StatePool()
+	resources := ctx.Resources()
+
+	return NewControllerAPI(
+		st,
+		pool,
+		authorizer,
+		resources,
+	)
 }
 
 // NewControllerAPIv3 creates a new ControllerAPIv3.
 func NewControllerAPIv3(ctx facade.Context) (*ControllerAPIv3, error) {
-	authorizer := ctx.Auth()
+	v4, err := NewControllerAPIv4(ctx)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return &ControllerAPIv3{v4}, nil
+}
+
+// NewControllerAPI creates a new api server endpoint for operations
+// on a controller.
+func NewControllerAPI(
+	st *state.State,
+	pool *state.StatePool,
+	authorizer facade.Authorizer,
+	resources facade.Resources,
+) (*ControllerAPI, error) {
 	if !authorizer.AuthClient() {
 		return nil, errors.Trace(common.ErrPerm)
 	}
@@ -67,33 +87,30 @@ func NewControllerAPIv3(ctx facade.Context) (*ControllerAPIv3, error) {
 	// we just do the type assertion to the UserTag.
 	apiUser, _ := authorizer.GetAuthTag().(names.UserTag)
 
-	st := ctx.State()
-
 	model, err := st.Model()
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-
-	return &ControllerAPIv3{
+	return &ControllerAPI{
 		ControllerConfigAPI: common.NewStateControllerConfig(st),
 		ModelStatusAPI: common.NewModelStatusAPI(
-			common.NewModelManagerBackend(model, ctx.StatePool()),
+			common.NewModelManagerBackend(model, pool),
 			authorizer,
 			apiUser,
 		),
 		CloudSpecAPI: cloudspec.NewCloudSpec(
-			cloudspec.MakeCloudSpecGetter(ctx.StatePool()),
+			cloudspec.MakeCloudSpecGetter(pool),
 			common.AuthFuncForTag(model.ModelTag()),
 		),
 		state:      st,
-		statePool:  ctx.StatePool(),
+		statePool:  pool,
 		authorizer: authorizer,
 		apiUser:    apiUser,
-		resources:  ctx.Resources(),
+		resources:  resources,
 	}, nil
 }
 
-func (s *ControllerAPIv3) checkHasAdmin() error {
+func (s *ControllerAPI) checkHasAdmin() error {
 	isAdmin, err := s.authorizer.HasPermission(permission.SuperuserAccess, s.state.ControllerTag())
 	if err != nil {
 		return errors.Trace(err)
@@ -104,9 +121,25 @@ func (s *ControllerAPIv3) checkHasAdmin() error {
 	return nil
 }
 
+// ModelStatus is a legacy method call to ensure that we preserve
+// backward compatibility.
+// TODO (anastasiamac 2017-10-26) This should be made obsolete/removed.
+func (s *ControllerAPIv3) ModelStatus(req params.Entities) (params.ModelStatusResults, error) {
+	results, err := s.ModelStatusAPI.ModelStatus(req)
+	if err != nil {
+		return params.ModelStatusResults{}, err
+	}
+	for _, r := range results.Results {
+		if r.Error != nil {
+			return params.ModelStatusResults{}, errors.Trace(r.Error)
+		}
+	}
+	return results, nil
+}
+
 // AllModels allows controller administrators to get the list of all the
 // models in the controller.
-func (s *ControllerAPIv3) AllModels() (params.UserModelList, error) {
+func (s *ControllerAPI) AllModels() (params.UserModelList, error) {
 	result := params.UserModelList{}
 	if err := s.checkHasAdmin(); err != nil {
 		return result, errors.Trace(err)
@@ -159,7 +192,7 @@ func (s *ControllerAPIv3) AllModels() (params.UserModelList, error) {
 // which have a block in place.  The resulting slice is sorted by environment
 // name, then owner. Callers must be controller administrators to retrieve the
 // list.
-func (s *ControllerAPIv3) ListBlockedModels() (params.ModelBlockInfoList, error) {
+func (s *ControllerAPI) ListBlockedModels() (params.ModelBlockInfoList, error) {
 	results := params.ModelBlockInfoList{}
 	if err := s.checkHasAdmin(); err != nil {
 		return results, errors.Trace(err)
@@ -205,7 +238,7 @@ func (s *ControllerAPIv3) ListBlockedModels() (params.ModelBlockInfoList, error)
 // ModelConfig returns the environment config for the controller
 // environment.  For information on the current environment, use
 // client.ModelGet
-func (s *ControllerAPIv3) ModelConfig() (params.ModelConfigResults, error) {
+func (s *ControllerAPI) ModelConfig() (params.ModelConfigResults, error) {
 	result := params.ModelConfigResults{}
 	if err := s.checkHasAdmin(); err != nil {
 		return result, errors.Trace(err)
@@ -233,7 +266,7 @@ func (s *ControllerAPIv3) ModelConfig() (params.ModelConfigResults, error) {
 // HostedModelConfigs returns all the information that the client needs in
 // order to connect directly with the host model's provider and destroy it
 // directly.
-func (s *ControllerAPIv3) HostedModelConfigs() (params.HostedModelConfigsResults, error) {
+func (s *ControllerAPI) HostedModelConfigs() (params.HostedModelConfigsResults, error) {
 	result := params.HostedModelConfigsResults{}
 	if err := s.checkHasAdmin(); err != nil {
 		return result, errors.Trace(err)
@@ -284,7 +317,7 @@ func (s *ControllerAPIv3) HostedModelConfigs() (params.HostedModelConfigsResults
 }
 
 // RemoveBlocks removes all the blocks in the controller.
-func (s *ControllerAPIv3) RemoveBlocks(args params.RemoveBlocksArgs) error {
+func (s *ControllerAPI) RemoveBlocks(args params.RemoveBlocksArgs) error {
 	if err := s.checkHasAdmin(); err != nil {
 		return errors.Trace(err)
 	}
@@ -298,7 +331,7 @@ func (s *ControllerAPIv3) RemoveBlocks(args params.RemoveBlocksArgs) error {
 // WatchAllModels starts watching events for all models in the
 // controller. The returned AllWatcherId should be used with Next on the
 // AllModelWatcher endpoint to receive deltas.
-func (c *ControllerAPIv3) WatchAllModels() (params.AllWatcherId, error) {
+func (c *ControllerAPI) WatchAllModels() (params.AllWatcherId, error) {
 	if err := c.checkHasAdmin(); err != nil {
 		return params.AllWatcherId{}, errors.Trace(err)
 	}
@@ -310,7 +343,7 @@ func (c *ControllerAPIv3) WatchAllModels() (params.AllWatcherId, error) {
 
 // GetControllerAccess returns the level of access the specifed users
 // have on the controller.
-func (c *ControllerAPIv3) GetControllerAccess(req params.Entities) (params.UserAccessResults, error) {
+func (c *ControllerAPI) GetControllerAccess(req params.Entities) (params.UserAccessResults, error) {
 	results := params.UserAccessResults{}
 	isAdmin, err := c.authorizer.HasPermission(permission.SuperuserAccess, c.state.ControllerTag())
 	if err != nil {
@@ -343,7 +376,7 @@ func (c *ControllerAPIv3) GetControllerAccess(req params.Entities) (params.UserA
 
 // InitiateMigration attempts to begin the migration of one or
 // more models to other controllers.
-func (c *ControllerAPIv3) InitiateMigration(reqArgs params.InitiateMigrationArgs) (
+func (c *ControllerAPI) InitiateMigration(reqArgs params.InitiateMigrationArgs) (
 	params.InitiateMigrationResults, error,
 ) {
 	out := params.InitiateMigrationResults{
@@ -366,7 +399,7 @@ func (c *ControllerAPIv3) InitiateMigration(reqArgs params.InitiateMigrationArgs
 	return out, nil
 }
 
-func (c *ControllerAPIv3) initiateOneMigration(spec params.MigrationSpec) (string, error) {
+func (c *ControllerAPI) initiateOneMigration(spec params.MigrationSpec) (string, error) {
 	modelTag, err := names.ParseModelTag(spec.ModelTag)
 	if err != nil {
 		return "", errors.Annotate(err, "model tag")
@@ -427,7 +460,7 @@ func (c *ControllerAPIv3) initiateOneMigration(spec params.MigrationSpec) (strin
 }
 
 // ModifyControllerAccess changes the model access granted to users.
-func (c *ControllerAPIv3) ModifyControllerAccess(args params.ModifyControllerAccessRequest) (params.ErrorResults, error) {
+func (c *ControllerAPI) ModifyControllerAccess(args params.ModifyControllerAccessRequest) (params.ErrorResults, error) {
 	result := params.ErrorResults{
 		Results: make([]params.ErrorResult, len(args.Changes)),
 	}

--- a/apiserver/facades/client/controller/controller.go
+++ b/apiserver/facades/client/controller/controller.go
@@ -129,9 +129,10 @@ func (s *ControllerAPIv3) ModelStatus(req params.Entities) (params.ModelStatusRe
 	if err != nil {
 		return params.ModelStatusResults{}, err
 	}
+
 	for _, r := range results.Results {
 		if r.Error != nil {
-			return params.ModelStatusResults{}, errors.Trace(r.Error)
+			return params.ModelStatusResults{Results: make([]params.ModelStatus, len(req.Entities))}, errors.Trace(r.Error)
 		}
 	}
 	return results, nil

--- a/apiserver/facades/client/controller/controller_test.go
+++ b/apiserver/facades/client/controller/controller_test.go
@@ -860,7 +860,7 @@ func (s *controllerSuite) TestModelStatusV3(c *gc.C) {
 		Tag: s.IAASModel.ModelTag().String(),
 	}}})
 	c.Assert(err, gc.ErrorMatches, `"bad-tag" is not a valid tag`)
-	c.Assert(results, gc.DeepEquals, params.ModelStatusResults{})
+	c.Assert(results, gc.DeepEquals, params.ModelStatusResults{Results: make([]params.ModelStatus, 2)})
 
 	// Check that we err out if a model errs even if some firsts in collection pass.
 	results, err = api.ModelStatus(params.Entities{[]params.Entity{{
@@ -869,7 +869,7 @@ func (s *controllerSuite) TestModelStatusV3(c *gc.C) {
 		Tag: "bad-tag",
 	}}})
 	c.Assert(err, gc.ErrorMatches, `"bad-tag" is not a valid tag`)
-	c.Assert(results, gc.DeepEquals, params.ModelStatusResults{})
+	c.Assert(results, gc.DeepEquals, params.ModelStatusResults{Results: make([]params.ModelStatus, 2)})
 
 	// Check that we return successfully if no errors.
 	results, err = api.ModelStatus(params.Entities{[]params.Entity{{

--- a/apiserver/facades/client/controller/destroy.go
+++ b/apiserver/facades/client/controller/destroy.go
@@ -35,7 +35,7 @@ func (s *ControllerAPIv3) DestroyController(args params.DestroyControllerArgs) e
 // attempt to do so. Otherwise, if the controller has any non-empty,
 // non-Dead hosted models, then an error with the code
 // params.CodeHasHostedModels will be transmitted.
-func (s *ControllerAPIv4) DestroyController(args params.DestroyControllerArgs) error {
+func (s *ControllerAPI) DestroyController(args params.DestroyControllerArgs) error {
 	return destroyController(s.state, s.statePool, s.authorizer, args)
 }
 

--- a/apiserver/facades/client/controller/destroy_test.go
+++ b/apiserver/facades/client/controller/destroy_test.go
@@ -32,7 +32,7 @@ type destroyControllerSuite struct {
 
 	authorizer apiservertesting.FakeAuthorizer
 	resources  *common.Resources
-	controller *controller.ControllerAPIv4
+	controller *controller.ControllerAPI
 
 	otherState     *state.State
 	otherModel     *state.Model

--- a/apiserver/facades/client/modelmanager/modelmanager.go
+++ b/apiserver/facades/client/modelmanager/modelmanager.go
@@ -1212,3 +1212,33 @@ func (m *ModelManagerAPI) makeRegionSpec(cloudTag, r string) (*environs.RegionSp
 	}
 	return rspec, nil
 }
+
+// ModelStatus is a legacy method call to ensure that we preserve
+// backward compatibility.
+// TODO (anastasiamac 2017-10-26) This should be made obsolete/removed.
+func (s *ModelManagerAPIV2) ModelStatus(req params.Entities) (params.ModelStatusResults, error) {
+	return s.ModelManagerAPI.oldModelStatus(req)
+}
+
+// ModelStatus is a legacy method call to ensure that we preserve
+// backward compatibility.
+// TODO (anastasiamac 2017-10-26) This should be made obsolete/removed.
+func (s *ModelManagerAPIV3) ModelStatus(req params.Entities) (params.ModelStatusResults, error) {
+	return s.ModelManagerAPI.oldModelStatus(req)
+}
+
+// ModelStatus is a legacy method call to ensure that we preserve
+// backward compatibility.
+// TODO (anastasiamac 2017-10-26) This should be made obsolete/removed.
+func (s *ModelManagerAPI) oldModelStatus(req params.Entities) (params.ModelStatusResults, error) {
+	results, err := s.ModelStatusAPI.ModelStatus(req)
+	if err != nil {
+		return params.ModelStatusResults{}, err
+	}
+	for _, r := range results.Results {
+		if r.Error != nil {
+			return params.ModelStatusResults{}, errors.Trace(r.Error)
+		}
+	}
+	return results, nil
+}

--- a/apiserver/facades/client/modelmanager/modelmanager.go
+++ b/apiserver/facades/client/modelmanager/modelmanager.go
@@ -1237,7 +1237,7 @@ func (s *ModelManagerAPI) oldModelStatus(req params.Entities) (params.ModelStatu
 	}
 	for _, r := range results.Results {
 		if r.Error != nil {
-			return params.ModelStatusResults{}, errors.Trace(r.Error)
+			return params.ModelStatusResults{Results: make([]params.ModelStatus, len(req.Entities))}, errors.Trace(r.Error)
 		}
 	}
 	return results, nil

--- a/apiserver/facades/client/modelmanager/modelmanager_test.go
+++ b/apiserver/facades/client/modelmanager/modelmanager_test.go
@@ -1582,6 +1582,94 @@ func (s *modelManagerStateSuite) TestModifyModelAccessInvalidAction(c *gc.C) {
 	c.Assert(result.OneError(), gc.ErrorMatches, expectedErr)
 }
 
+func (s *modelManagerSuite) TestModelStatusV2(c *gc.C) {
+	api := &modelmanager.ModelManagerAPIV2{
+		&modelmanager.ModelManagerAPIV3{s.api},
+	}
+	// Check that we err out immediately if a model errs.
+	results, err := api.ModelStatus(params.Entities{[]params.Entity{{
+		Tag: "bad-tag",
+	}, {
+		Tag: s.st.ModelTag().String(),
+	}}})
+	c.Assert(err, gc.ErrorMatches, `"bad-tag" is not a valid tag`)
+	c.Assert(results, gc.DeepEquals, params.ModelStatusResults{})
+
+	// Check that we err out if a model errs even if some firsts in collection pass.
+	results, err = api.ModelStatus(params.Entities{[]params.Entity{{
+		Tag: s.st.ModelTag().String(),
+	}, {
+		Tag: "bad-tag",
+	}}})
+	c.Assert(err, gc.ErrorMatches, `"bad-tag" is not a valid tag`)
+	c.Assert(results, gc.DeepEquals, params.ModelStatusResults{})
+
+	// Check that we return successfully if no errors.
+	results, err = api.ModelStatus(params.Entities{[]params.Entity{{
+		Tag: s.st.ModelTag().String(),
+	}}})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(results.Results, gc.HasLen, 1)
+}
+
+func (s *modelManagerSuite) TestModelStatusV3(c *gc.C) {
+	api := &modelmanager.ModelManagerAPIV3{s.api}
+
+	// Check that we err out immediately if a model errs.
+	results, err := api.ModelStatus(params.Entities{[]params.Entity{{
+		Tag: "bad-tag",
+	}, {
+		Tag: s.st.ModelTag().String(),
+	}}})
+	c.Assert(err, gc.ErrorMatches, `"bad-tag" is not a valid tag`)
+	c.Assert(results, gc.DeepEquals, params.ModelStatusResults{})
+
+	// Check that we err out if a model errs even if some firsts in collection pass.
+	results, err = api.ModelStatus(params.Entities{[]params.Entity{{
+		Tag: s.st.ModelTag().String(),
+	}, {
+		Tag: "bad-tag",
+	}}})
+	c.Assert(err, gc.ErrorMatches, `"bad-tag" is not a valid tag`)
+	c.Assert(results, gc.DeepEquals, params.ModelStatusResults{})
+
+	// Check that we return successfully if no errors.
+	results, err = api.ModelStatus(params.Entities{[]params.Entity{{
+		Tag: s.st.ModelTag().String(),
+	}}})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(results.Results, gc.HasLen, 1)
+}
+
+func (s *modelManagerSuite) TestModelStatus(c *gc.C) {
+	// Check that we don't err out immediately if a model errs.
+	results, err := s.api.ModelStatus(params.Entities{[]params.Entity{{
+		Tag: "bad-tag",
+	}, {
+		Tag: s.st.ModelTag().String(),
+	}}})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(results.Results, gc.HasLen, 2)
+	c.Assert(results.Results[0].Error, gc.ErrorMatches, `"bad-tag" is not a valid tag`)
+
+	// Check that we don't err out if a model errs even if some firsts in collection pass.
+	results, err = s.api.ModelStatus(params.Entities{[]params.Entity{{
+		Tag: s.st.ModelTag().String(),
+	}, {
+		Tag: "bad-tag",
+	}}})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(results.Results, gc.HasLen, 2)
+	c.Assert(results.Results[1].Error, gc.ErrorMatches, `"bad-tag" is not a valid tag`)
+
+	// Check that we return successfully if no errors.
+	results, err = s.api.ModelStatus(params.Entities{[]params.Entity{{
+		Tag: s.st.ModelTag().String(),
+	}}})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(results.Results, gc.HasLen, 1)
+}
+
 type fakeProvider struct {
 	environs.EnvironProvider
 }

--- a/apiserver/facades/client/modelmanager/modelmanager_test.go
+++ b/apiserver/facades/client/modelmanager/modelmanager_test.go
@@ -1593,7 +1593,7 @@ func (s *modelManagerSuite) TestModelStatusV2(c *gc.C) {
 		Tag: s.st.ModelTag().String(),
 	}}})
 	c.Assert(err, gc.ErrorMatches, `"bad-tag" is not a valid tag`)
-	c.Assert(results, gc.DeepEquals, params.ModelStatusResults{})
+	c.Assert(results, gc.DeepEquals, params.ModelStatusResults{Results: make([]params.ModelStatus, 2)})
 
 	// Check that we err out if a model errs even if some firsts in collection pass.
 	results, err = api.ModelStatus(params.Entities{[]params.Entity{{
@@ -1602,7 +1602,7 @@ func (s *modelManagerSuite) TestModelStatusV2(c *gc.C) {
 		Tag: "bad-tag",
 	}}})
 	c.Assert(err, gc.ErrorMatches, `"bad-tag" is not a valid tag`)
-	c.Assert(results, gc.DeepEquals, params.ModelStatusResults{})
+	c.Assert(results, gc.DeepEquals, params.ModelStatusResults{Results: make([]params.ModelStatus, 2)})
 
 	// Check that we return successfully if no errors.
 	results, err = api.ModelStatus(params.Entities{[]params.Entity{{
@@ -1622,7 +1622,7 @@ func (s *modelManagerSuite) TestModelStatusV3(c *gc.C) {
 		Tag: s.st.ModelTag().String(),
 	}}})
 	c.Assert(err, gc.ErrorMatches, `"bad-tag" is not a valid tag`)
-	c.Assert(results, gc.DeepEquals, params.ModelStatusResults{})
+	c.Assert(results, gc.DeepEquals, params.ModelStatusResults{Results: make([]params.ModelStatus, 2)})
 
 	// Check that we err out if a model errs even if some firsts in collection pass.
 	results, err = api.ModelStatus(params.Entities{[]params.Entity{{
@@ -1631,7 +1631,7 @@ func (s *modelManagerSuite) TestModelStatusV3(c *gc.C) {
 		Tag: "bad-tag",
 	}}})
 	c.Assert(err, gc.ErrorMatches, `"bad-tag" is not a valid tag`)
-	c.Assert(results, gc.DeepEquals, params.ModelStatusResults{})
+	c.Assert(results, gc.DeepEquals, params.ModelStatusResults{Results: make([]params.ModelStatus, 2)})
 
 	// Check that we return successfully if no errors.
 	results, err = api.ModelStatus(params.Entities{[]params.Entity{{

--- a/apiserver/params/controller.go
+++ b/apiserver/params/controller.go
@@ -51,6 +51,7 @@ type ModelStatus struct {
 	Machines           []ModelMachineInfo    `json:"machines,omitempty"`
 	Volumes            []ModelVolumeInfo     `json:"volumes,omitempty"`
 	Filesystems        []ModelFilesystemInfo `json:"filesystems,omitempty"`
+	Error              *Error                `json:"error,omitempty"`
 }
 
 // ModelStatusResults holds status information about a group of models.

--- a/cmd/juju/controller/killstatus.go
+++ b/cmd/juju/controller/killstatus.go
@@ -91,10 +91,6 @@ func newData(api destroyControllerAPI, controllerModelUUID string) (ctrData, []m
 		return ctrData{}, nil, errors.Trace(err)
 	}
 
-	// This is needed since return parameter may have an Error
-	// property in the later api versions, > 3.
-	newerAPI := api.BestAPIVersion() > 3
-
 	var hostedMachinesCount int
 	var servicesCount int
 	var volumeCount int
@@ -103,12 +99,15 @@ func newData(api destroyControllerAPI, controllerModelUUID string) (ctrData, []m
 	var aliveModelCount int
 	var ctrModelData modelData
 	for _, model := range status {
-		if newerAPI && model.Error != nil {
-			// This most likely occurred because a model was
-			// destroyed half-way through the call.
-			// Since we filter out models with life.Dead below, it's safe
-			// to assume that we want to filter these models here too.
-			continue
+		if model.Error != nil {
+			if errors.IsNotFound(model.Error) {
+				// This most likely occurred because a model was
+				// destroyed half-way through the call.
+				// Since we filter out models with life.Dead below, it's safe
+				// to assume that we want to filter these models here too.
+				continue
+			}
+			return ctrData{}, nil, errors.Trace(model.Error)
 		}
 		var persistentVolumeCount int
 		var persistentFilesystemCount int

--- a/cmd/juju/controller/listcontrollers.go
+++ b/cmd/juju/controller/listcontrollers.go
@@ -167,7 +167,7 @@ func (c *listControllersCommand) refreshControllerDetails(client ControllerAcces
 				// destroyed half-way through the call.
 				continue
 			}
-			return s.Error
+			return errors.Trace(s.Error)
 		}
 		machineCount += s.TotalMachineCount
 	}

--- a/cmd/juju/controller/showcontroller.go
+++ b/cmd/juju/controller/showcontroller.go
@@ -169,7 +169,7 @@ func (c *showControllerCommand) Run(ctx *cmd.Context) error {
 		for _, r := range modelStatusResults {
 			if r.Error != nil {
 				if !errors.IsNotFound(r.Error) {
-					details.Errors = append(details.Errors, r.Error)
+					details.Errors = append(details.Errors, r.Error.Error())
 				}
 				continue
 			}

--- a/cmd/juju/controller/showcontroller_test.go
+++ b/cmd/juju/controller/showcontroller_test.go
@@ -39,7 +39,6 @@ func (s *ShowControllerSuite) SetUpTest(c *gc.C) {
 				{Id: "3", InstanceId: "id-3", HasVote: false, WantsVote: false, Status: "active"},
 			},
 		},
-		apiVersion: 4,
 	}
 	s.api = func(controllerName string) controller.ControllerAccessAPI {
 		s.fakeController.controllerName = controllerName
@@ -369,7 +368,6 @@ func (s *ShowControllerSuite) assertShowController(c *gc.C, args ...string) {
 type fakeController struct {
 	controllerName string
 	machines       map[string][]base.Machine
-	apiVersion     int
 }
 
 func (*fakeController) GetControllerAccess(user string) (permission.Access, error) {
@@ -411,8 +409,4 @@ func (c *fakeController) AllModels() (result []base.UserModel, _ error) {
 
 func (*fakeController) Close() error {
 	return nil
-}
-
-func (f *fakeController) BestAPIVersion() int {
-	return f.apiVersion
 }

--- a/cmd/juju/controller/showcontroller_test.go
+++ b/cmd/juju/controller/showcontroller_test.go
@@ -39,6 +39,7 @@ func (s *ShowControllerSuite) SetUpTest(c *gc.C) {
 				{Id: "3", InstanceId: "id-3", HasVote: false, WantsVote: false, Status: "active"},
 			},
 		},
+		apiVersion: 4,
 	}
 	s.api = func(controllerName string) controller.ControllerAccessAPI {
 		s.fakeController.controllerName = controllerName
@@ -368,6 +369,7 @@ func (s *ShowControllerSuite) assertShowController(c *gc.C, args ...string) {
 type fakeController struct {
 	controllerName string
 	machines       map[string][]base.Machine
+	apiVersion     int
 }
 
 func (*fakeController) GetControllerAccess(user string) (permission.Access, error) {
@@ -409,4 +411,8 @@ func (c *fakeController) AllModels() (result []base.UserModel, _ error) {
 
 func (*fakeController) Close() error {
 	return nil
+}
+
+func (f *fakeController) BestAPIVersion() int {
+	return f.apiVersion
 }

--- a/cmd/juju/model/destroy.go
+++ b/cmd/juju/model/destroy.go
@@ -337,7 +337,7 @@ func newTimedModelStatus(ctx *cmd.Context, api DestroyModelAPI, tag names.ModelT
 			ctx.Infof("error finding model status: expected one result, got %d", l)
 			return nil
 		}
-		if api.BestAPIVersion() > 3 && status[0].Error != nil {
+		if status[0].Error != nil {
 			// This most likely occurred because a model was
 			// destroyed half-way through the call.
 			ctx.Infof("Could not get the model status from the API: %v.", err)
@@ -401,9 +401,12 @@ func handlePersistentStorageError(
 		return errors.Errorf("error finding model status: expected one result, got %d", l)
 	}
 	modelStatus := modelStatuses[0]
-	if api.BestAPIVersion() > 3 && modelStatus.Error != nil {
-		// This most likely occurred because a model was
-		// destroyed half-way through the call.
+	if modelStatus.Error != nil {
+		if errors.IsNotFound(modelStatus.Error) {
+			// This most likely occurred because a model was
+			// destroyed half-way through the call.
+			return nil
+		}
 		return errors.Annotate(err, "getting model status")
 	}
 


### PR DESCRIPTION
## Description of change

ModelStatus api call was accepting more than one model as an input but would err out the whole call if any of the models would err during processing. This is not consistent with our general expectations and conventions.
In order to successfully run through all the models, returning structs have gained an Error field.

ModelStatus call lives on both Controller and ModelManager facades. Although neither facade needed to have a version bump since we already did that for 2.3, the way that Controller facade was increased did not match our standard approach that is that older facades versions embed newer versions. Since this PR tests behavior of both versions, it needed to be fixed here.
