### PR TITLE
Don't allow non-simple types for unknown attributes

### DIFF
--- a/environs/config/config.go
+++ b/environs/config/config.go
@@ -1282,6 +1282,21 @@ func (cfg *Config) ValidateUnknownAttrs(extrafields schema.Fields, defaults sche
 				}
 			}
 			result[name] = value
+			// The only allowed types for unknown attributes are string, int, float and bool
+			switch value.(type) {
+			case string:
+				continue
+			case int:
+				continue
+			case bool:
+				continue
+			case float32:
+				continue
+			case float64:
+				continue
+			default:
+				return nil, fmt.Errorf("%s: unknown type (%q)", name, value)
+			}
 		}
 	}
 	return result, nil

--- a/environs/config/config_test.go
+++ b/environs/config/config_test.go
@@ -890,6 +890,20 @@ func (s *ConfigSuite) TestValidateUnknownAttrs(c *gc.C) {
 	fields["known"] = schema.Int()
 	_, err = cfg.ValidateUnknownAttrs(fields, defaults)
 	c.Assert(err, gc.ErrorMatches, `known: expected int, got string\("this"\)`)
+
+	// Completely unknown attr, not-simple field type: failure.
+	cfg, err = config.New(config.UseDefaults, map[string]interface{}{
+		"name":       "myenv",
+		"type":       "other",
+		"uuid":       testing.ModelTag.Id(),
+		"extra-info": "official extra user data",
+		"known":      "this",
+		"unknown":    "that",
+		"mapAttr":    map[string]string{"foo": "bar"},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	_, err = cfg.ValidateUnknownAttrs(nil, nil)
+	c.Assert(err.Error(), gc.Equals, `mapAttr: unknown type (map["foo":"bar"])`)
 }
 
 type testAttr struct {


### PR DESCRIPTION
## Description of change
For unknown attributes we only allow string, bool and int. 

## QA steps
echo -e "foo:\n  bar:baz" >> /tmp/foo.yaml; juju model-config /tmp/foo.yaml

## Documentation changes
None

## Bug reference
https://bugs.launchpad.net/juju/+bug/1727709