### PR TITLE
Fixes lp#1536230: Update create-backup help.

### DIFF
--- a/cmd/juju/backups/create.go
+++ b/cmd/juju/backups/create.go
@@ -29,19 +29,12 @@ backup's unique ID.  You may provide a note to associate with the backup.
 
 The backup archive and associated metadata are stored remotely by juju.
 
-The --download option may be used without the --filename option.  In
-that case, the backup archive will be stored in the current working
-directory with a name matching juju-backup-<date>-<time>.tar.gz.
-
-WARNING: Remotely stored backups will be lost when the model is
+WARNING: 
+Remotely stored backups will be lost when the model is
 destroyed.  Furthermore, the remotely backup is not guaranteed to be
 available.
 
-Therefore, you should use the --download or --filename options, or use:
-
-    juju download-backups
-
-to get a local copy of the backup archive.
+Therefore, you should get a local copy of the backup archive.
 This local copy can then be used to restore an model even if that
 model was already destroyed or is otherwise unavailable.
 `

--- a/cmd/juju/backups/create.go
+++ b/cmd/juju/backups/create.go
@@ -29,18 +29,9 @@ backup's unique ID.  You may provide a note to associate with the backup.
 
 The backup archive and associated metadata are stored remotely by juju.
 
-WARNING: 
-Remotely stored backups will be lost when the model is
-destroyed.  Furthermore, the remotely backup is not guaranteed to be
-available.
-
-Therefore, you should use --filename option or use:
-
-    juju download-backup
-
-to get a local copy of the backup archive.
-This local copy can then be used to restore an model even if that
-model was already destroyed or is otherwise unavailable.
+See also:
+    backups
+    download-backup
 `
 
 // NewCreateCommand returns a command used to create backups.

--- a/cmd/juju/backups/create.go
+++ b/cmd/juju/backups/create.go
@@ -34,7 +34,11 @@ Remotely stored backups will be lost when the model is
 destroyed.  Furthermore, the remotely backup is not guaranteed to be
 available.
 
-Therefore, you should get a local copy of the backup archive.
+Therefore, you should use --filename option or use:
+
+    juju download-backup
+
+to get a local copy of the backup archive.
 This local copy can then be used to restore an model even if that
 model was already destroyed or is otherwise unavailable.
 `

--- a/cmd/juju/backups/create.go
+++ b/cmd/juju/backups/create.go
@@ -24,10 +24,12 @@ const (
 )
 
 const createDoc = `
-create-backup requests that juju create a backup of its state and print the
+create-backup requests that Juju creates a backup of its state and prints the
 backup's unique ID.  You may provide a note to associate with the backup.
 
-The backup archive and associated metadata are stored remotely by juju.
+The backup archive and associated metadata are stored remotely by Juju, but
+will also be copied locally unless --no-download is supplied. To access the
+remote backups, see 'juju download-backup'.
 
 See also:
     backups


### PR DESCRIPTION
## Description of change

create-backup command was changed without updating its help.
This PR removes description of long obsolete --download option as well as updates a mentioning of now renamed 'download-backups' command. 

## QA steps

'juju help create-backups' makes sense for current behavior.

## Documentation changes

n/a

## Bug reference

https://bugs.launchpad.net/juju/+bug/1536230
