### PR TITLE
Handle constraint equality for bundle dry run

### DIFF
--- a/api/application/client.go
+++ b/api/application/client.go
@@ -554,7 +554,7 @@ func (c *Client) GetConstraints(applications ...string) ([]constraints.Value, er
 	}
 	for i, result := range results.Results {
 		if result.Error != nil {
-			return nil, errors.Annotatef(err, "unable to get constraints for %q", applications[i])
+			return nil, errors.Annotatef(result.Error, "unable to get constraints for %q", applications[i])
 		}
 		allConstraints = append(allConstraints, result.Constraints)
 	}

--- a/cmd/juju/application/bundle_test.go
+++ b/cmd/juju/application/bundle_test.go
@@ -860,6 +860,7 @@ func (s *BundleDeployCharmStoreSuite) TestDeployBundleApplicationUpgrade(c *gc.C
             up:
                 charm: vivid/upgrade-1
                 num_units: 1
+                constraints: mem=8G
     `)
 	c.Assert(err, jc.ErrorIsNil)
 	s.assertCharmsUploaded(c, "cs:vivid/upgrade-1", "cs:xenial/wordpress-42")
@@ -876,6 +877,7 @@ func (s *BundleDeployCharmStoreSuite) TestDeployBundleApplicationUpgrade(c *gc.C
             up:
                 charm: vivid/upgrade-2
                 num_units: 1
+                constraints: mem=8G
     `)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(stdOut, gc.Equals, ""+
@@ -888,7 +890,10 @@ func (s *BundleDeployCharmStoreSuite) TestDeployBundleApplicationUpgrade(c *gc.C
 
 	s.assertCharmsUploaded(c, "cs:vivid/upgrade-1", "cs:vivid/upgrade-2", "cs:xenial/wordpress-42")
 	s.assertApplicationsDeployed(c, map[string]serviceInfo{
-		"up": {charm: "cs:vivid/upgrade-2"},
+		"up": {
+			charm:       "cs:vivid/upgrade-2",
+			constraints: constraints.MustParse("mem=8G"),
+		},
 		"wordpress": {
 			charm:       "cs:xenial/wordpress-42",
 			config:      charm.Settings{"blog-title": "new title"},


### PR DESCRIPTION
The comparison of contraints was incorrect in the bundle deployment.

The struct equality was not sufficient, so we now use the string representation of the parsed constraints.

## QA steps
```
juju deploy hadoop-processing
# Wait until everything is stable. 
juju deploy hadoop-processing --dry-run
```
There should be no steps to update constraints.
