### PR TITLE
Remove first party time-before caveat from cmr macaroons

### DIFF
--- a/apiserver/common/crossmodel/auth.go
+++ b/apiserver/common/crossmodel/auth.go
@@ -135,7 +135,6 @@ func (a *AuthContext) CheckLocalAccessRequest(details *offerPermissionCheck) ([]
 		checkers.DeclaredCaveat(sourcemodelKey, details.SourceModelUUID),
 		checkers.DeclaredCaveat(offeruuidKey, details.OfferUUID),
 		checkers.DeclaredCaveat(usernameKey, details.User),
-		checkers.TimeBeforeCaveat(a.clock.Now().Add(localOfferPermissionExpiryTime)),
 	}
 	if details.Relation != "" {
 		firstPartyCaveats = append(firstPartyCaveats, checkers.DeclaredCaveat(relationKey, details.Relation))
@@ -213,7 +212,6 @@ func (a *AuthContext) CreateConsumeOfferMacaroon(offer *params.ApplicationOfferD
 
 	return bakery.NewMacaroon("", nil,
 		[]checkers.Caveat{
-			checkers.TimeBeforeCaveat(expiryTime),
 			checkers.DeclaredCaveat(sourcemodelKey, sourceModelTag.Id()),
 			checkers.DeclaredCaveat(offeruuidKey, offer.OfferUUID),
 			checkers.DeclaredCaveat(usernameKey, username),
@@ -230,7 +228,6 @@ func (a *AuthContext) CreateRemoteRelationMacaroon(sourceModelUUID, offerUUID st
 
 	offerMacaroon, err := bakery.NewMacaroon("", nil,
 		[]checkers.Caveat{
-			checkers.TimeBeforeCaveat(expiryTime),
 			checkers.DeclaredCaveat(sourcemodelKey, sourceModelUUID),
 			checkers.DeclaredCaveat(offeruuidKey, offerUUID),
 			checkers.DeclaredCaveat(usernameKey, username),
@@ -324,7 +321,6 @@ func (a *authenticator) checkMacaroons(mac macaroon.Slice, requiredValues map[st
 			},
 			keys...,
 		),
-		checkers.TimeBeforeCaveat(a.clock.Now().Add(localOfferPermissionExpiryTime)),
 	})
 	if err != nil {
 		return nil, errors.Annotate(err, "cannot create macaroon")

--- a/apiserver/facades/client/applicationoffers/applicationoffers_test.go
+++ b/apiserver/facades/client/applicationoffers/applicationoffers_test.go
@@ -5,7 +5,6 @@ package applicationoffers_test
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
@@ -1120,11 +1119,10 @@ func (s *consumeSuite) TestConsumeDetailsWithPermission(c *gc.C) {
 	})
 	c.Assert(results.Results[0].Macaroon.Id(), gc.Equals, "")
 	cav := s.bakery.caveats[results.Results[0].Macaroon.Id()]
-	c.Check(cav, gc.HasLen, 4)
-	c.Check(strings.HasPrefix(cav[0].Condition, "time-before "), jc.IsTrue)
-	c.Check(cav[1].Condition, gc.Equals, "declared source-model-uuid deadbeef-0bad-400d-8000-4b1d0d06f00d")
-	c.Check(cav[2].Condition, gc.Equals, "declared offer-uuid hosted-mysql-uuid")
-	c.Check(cav[3].Condition, gc.Equals, "declared username someone")
+	c.Check(cav, gc.HasLen, 3)
+	c.Check(cav[0].Condition, gc.Equals, "declared source-model-uuid deadbeef-0bad-400d-8000-4b1d0d06f00d")
+	c.Check(cav[1].Condition, gc.Equals, "declared offer-uuid hosted-mysql-uuid")
+	c.Check(cav[2].Condition, gc.Equals, "declared username someone")
 }
 
 func (s *consumeSuite) TestConsumeDetailsDefaultEndpoint(c *gc.C) {

--- a/apiserver/facades/controller/crossmodelrelations/crossmodelrelations_test.go
+++ b/apiserver/facades/controller/crossmodelrelations/crossmodelrelations_test.go
@@ -5,7 +5,6 @@ package crossmodelrelations_test
 
 import (
 	"regexp"
-	"strings"
 
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
@@ -222,12 +221,11 @@ func (s *crossmodelRelationsSuite) assertRegisterRemoteRelations(c *gc.C) {
 		"offer-uuid":        "offer-uuid",
 	})
 	cav := result.Result.Macaroon.Caveats()
-	c.Check(cav, gc.HasLen, 5)
-	c.Check(strings.HasPrefix(cav[0].Id, "time-before "), jc.IsTrue)
-	c.Check(cav[1].Id, gc.Equals, "declared source-model-uuid deadbeef-0bad-400d-8000-4b1d0d06f00d")
-	c.Check(cav[2].Id, gc.Equals, "declared offer-uuid offer-uuid")
-	c.Check(cav[3].Id, gc.Equals, "declared username mary")
-	c.Check(cav[4].Id, gc.Equals, "declared relation-key offeredapp:local remote-apptoken:remote")
+	c.Check(cav, gc.HasLen, 4)
+	c.Check(cav[0].Id, gc.Equals, "declared source-model-uuid deadbeef-0bad-400d-8000-4b1d0d06f00d")
+	c.Check(cav[1].Id, gc.Equals, "declared offer-uuid offer-uuid")
+	c.Check(cav[2].Id, gc.Equals, "declared username mary")
+	c.Check(cav[3].Id, gc.Equals, "declared relation-key offeredapp:local remote-apptoken:remote")
 
 	expectedRemoteApp := s.st.remoteApplications["remote-apptoken"]
 	expectedRemoteApp.Stub = testing.Stub{} // don't care about api calls


### PR DESCRIPTION
## Description of change

Cross model macaroons were minted with a time-before first party caveat, but the bakery was also using expirable storage. We only need one method of time limited macaroon invalidation. Using the bakery expiration ensures we get a verification error and hence request a new discharge to mint a new macaroon.

## QA steps

Consume an offer.
Wait 5 minutes for the macaroon to expire.
relate to the offer and check that the cross model relation functions properly;
check logs for macaroon discharge

