### PR TITLE
migration: set model.Type now that 2.2 is exporting a v4 Model

### DIFF
--- a/state/migration_export.go
+++ b/state/migration_export.go
@@ -22,6 +22,8 @@ import (
 	"github.com/juju/juju/storage/poolmanager"
 )
 
+const iaasModel = "iaas"
+
 // ExportConfig allows certain aspects of the model to be skipped
 // during the export. The intent of this is to be able to get a partial
 // export to support other API calls, like status.
@@ -91,6 +93,7 @@ func (st *State) exportImpl(cfg ExportConfig) (description.Model, error) {
 	}
 
 	args := description.ModelArgs{
+		Type:               iaasModel,
 		Cloud:              dbModel.Cloud(),
 		CloudRegion:        dbModel.CloudRegion(),
 		Owner:              dbModel.Owner(),

--- a/state/migration_export.go
+++ b/state/migration_export.go
@@ -22,7 +22,10 @@ import (
 	"github.com/juju/juju/storage/poolmanager"
 )
 
-const iaasModel = "iaas"
+const (
+	iaasModel               = "iaas"
+	maxStatusHistoryEntries = 20
+)
 
 // ExportConfig allows certain aspects of the model to be skipped
 // during the export. The intent of this is to be able to get a partial
@@ -1371,8 +1374,11 @@ func (e *exporter) statusArgs(globalKey string) (description.StatusArgs, error) 
 
 func (e *exporter) statusHistoryArgs(globalKey string) []description.StatusArgs {
 	history := e.statusHistory[globalKey]
-	result := make([]description.StatusArgs, len(history))
 	e.logger.Tracef("found %d status history docs for %s", len(history), globalKey)
+	if len(history) > maxStatusHistoryEntries {
+		history = history[:maxStatusHistoryEntries]
+	}
+	result := make([]description.StatusArgs, len(history))
 	for i, doc := range history {
 		result[i] = description.StatusArgs{
 			Value:   string(doc.Status),

--- a/state/migration_export_test.go
+++ b/state/migration_export_test.go
@@ -171,6 +171,7 @@ func (s *MigrationExportSuite) TestModelInfo(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(model.Tag(), gc.Equals, dbModel.ModelTag())
 	c.Assert(model.Owner(), gc.Equals, dbModel.Owner())
+	c.Assert(model.Type(), gc.Equals, "iaas")
 	dbModelCfg, err := dbModel.Config()
 	c.Assert(err, jc.ErrorIsNil)
 	modelAttrs := dbModelCfg.AllAttrs()

--- a/state/migration_export_test.go
+++ b/state/migration_export_test.go
@@ -1333,3 +1333,17 @@ func (s *MigrationExportSuite) TestModelStatus(c *gc.C) {
 	c.Check(model.Status().Value(), gc.Equals, "available")
 	c.Check(model.StatusHistory(), gc.HasLen, 1)
 }
+
+func (s *MigrationExportSuite) TestTooManyStatusHistories(c *gc.C) {
+	// Check that we cap the history entries at 20.
+	machine := s.Factory.MakeMachine(c, nil)
+	s.primeStatusHistory(c, machine, status.Started, 21)
+
+	model, err := s.State.Export()
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Assert(model.Machines(), gc.HasLen, 1)
+	history := model.Machines()[0].StatusHistory()
+	c.Assert(history, gc.HasLen, 20)
+	s.checkStatusHistory(c, history, status.Started)
+}


### PR DESCRIPTION
## Description of change

The description dependency was updated on the 2.2 branch (such that it
now exports v4 models). For correctness sake we should be setting the model type
(although I will also change the 2.3 branch to accept a blank model type so that migrating
from a 2.2.5 or .6 controller to a 2.3 one will work).

Includes a driveby to limit status history entries to 20 in exported models.

## QA steps

Bootstrap a 2.3-beta1 controller (B) and a 2.2 branch one with this change in it (A).
Migrate a model from A to B. It should succeed, and there shouldn't be an error about
blank model types.

## Bug reference

Part of the fix for https://bugs.launchpad.net/juju/+bug/1728486