### PR TITLE
migration: Allow blank model type when importing

### DIFF
--- a/state/migration_import.go
+++ b/state/migration_import.go
@@ -62,9 +62,14 @@ func (st *State) Import(model description.Model) (_ *Model, _ *State, err error)
 		return nil, nil, errors.New("can't import models with remote applications")
 	}
 
-	modelType, err := ParseModelType(model.Type())
-	if err != nil {
-		return nil, nil, errors.Trace(err)
+	// Unfortunately a version was released that exports v4 models
+	// with the Type field blank. Treat this as IAAS.
+	modelType := ModelTypeIAAS
+	if model.Type() != "" {
+		modelType, err = ParseModelType(model.Type())
+		if err != nil {
+			return nil, nil, errors.Trace(err)
+		}
 	}
 
 	// Create the model.

--- a/state/migration_import_test.go
+++ b/state/migration_import_test.go
@@ -1560,6 +1560,30 @@ func (s *MigrationImportSuite) TestOneSubordinateTwoGuvnors(c *gc.C) {
 	checkScope(wpLogUnit, logWpRel, true)
 }
 
+func (s *MigrationImportSuite) TestImportingModelWithBlankType(c *gc.C) {
+	model, err := s.State.Export()
+	c.Assert(err, jc.ErrorIsNil)
+
+	newConfig := model.Config()
+	newConfig["uuid"] = "aabbccdd-1234-8765-abcd-0123456789ab"
+	newConfig["name"] = "something-new"
+	noTypeModel := description.NewModel(description.ModelArgs{
+		Type:               "",
+		Owner:              model.Owner(),
+		Config:             newConfig,
+		LatestToolsVersion: model.LatestToolsVersion(),
+		EnvironVersion:     model.EnvironVersion(),
+		Blocks:             model.Blocks(),
+		Cloud:              model.Cloud(),
+		CloudRegion:        model.CloudRegion(),
+	})
+	imported, newSt, err := s.State.Import(noTypeModel)
+	c.Assert(err, jc.ErrorIsNil)
+	defer newSt.Close()
+
+	c.Assert(imported.Type(), gc.Equals, state.ModelTypeIAAS)
+}
+
 // newModel replaces the uuid and name of the config attributes so we
 // can use all the other data to validate imports. An owner and name of the
 // model are unique together in a controller.


### PR DESCRIPTION
## Description of change

Interpret this as IAAS. In versions 2.2.5 and 2.2.6, the model is
exported as v4 but with a blank model type. Accept these models as
valid, otherwise migration from a 2.2.5 controller to a 2.3 one will
fail.

## QA steps

Bootstrap a 2.2.5 controller (A) and a 2.3 one with this change (B).
Migrating a model from A to B should succeed.

## Bug reference

Part of fixing https://bugs.launchpad.net/juju/+bug/1728486
