### PR TITLE
Add verbose option for 'make check'.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,13 @@ else
 	TEST_TIMEOUT := 1500s
 endif
 
+# Enable verbose testing for reporting.
+ifeq ($(VERBOSE_CHECK), 1)
+	CHECK_ARGS = -v
+else
+	CHECK_ARGS =
+endif
+
 define DEPENDENCIES
   ca-certificates
   bzip2
@@ -45,7 +52,7 @@ build: godeps
 	go build $(PROJECT)/...
 
 check: godeps
-	go test -test.timeout=$(TEST_TIMEOUT) $(PROJECT)/...
+	go test $(CHECK_ARGS) -test.timeout=$(TEST_TIMEOUT) $(PROJECT)/...
 
 install: godeps
 	go install -v $(PROJECT)/...


### PR DESCRIPTION
Add verbose option for check target.

This allows for better reporting when running unit tests in CI etc.