### PR TITLE
Remove debug logging

### DIFF
--- a/cmd/juju/commands/upgradejuju.go
+++ b/cmd/juju/commands/upgradejuju.go
@@ -369,7 +369,6 @@ func (c *upgradeJujuCommand) Run(ctx *cmd.Context) (err error) {
 				return block.ProcessBlockedError(err, block.BlockChange)
 			}
 		}
-		logger.Criticalf("**********   SetModelAgentVersion: %s %t", context.chosen.String(), c.IgnoreAgentVersions)
 		if err := client.SetModelAgentVersion(context.chosen, c.IgnoreAgentVersions); err != nil {
 			if params.IsCodeUpgradeInProgress(err) {
 				return errors.Errorf("%s\n\n"+


### PR DESCRIPTION
## Description of change

This was inadvertently committed with another change, but shouldn't be included in the output when upgrading Juju.

## QA steps

Bootstrap a 2.2.6 controller, then upgrade it to this version. No critical log message should be emitted.
