### PR TITLE
RFC: Add CAAS cloud config to model defaults for default region

### DIFF
--- a/state/cloud.go
+++ b/state/cloud.go
@@ -126,9 +126,9 @@ func (st *State) Cloud(name string) (cloud.Cloud, error) {
 	return doc.toCloud(), nil
 }
 
-// AddCloud creates a cloud with the given name and details.
-// Note that the Config is deliberately ignored - it's only
-// relevant when bootstrapping.
+// AddCloud creates a cloud with the given name and details.  Note
+// that the Config and RegionConfig are deliberately ignored - they're
+// only relevant when bootstrapping.
 func (st *State) AddCloud(c cloud.Cloud) error {
 	if err := validateCloud(c); err != nil {
 		return errors.Annotate(err, "invalid cloud")


### PR DESCRIPTION
CAAS clouds are currently treated differently from IAAS clouds in the following ways:

1. you don't bootstrap onto one
2. the controller needs to have enough information to securely connect with the CAAS cloud from the outside.

IAAS cloud-specific config is stored in the client but not in the controller.
For CAAS we need to store cloud-specific config that is not a credential in the controller.

Model defaults seems like a good place for this. In order to not break possible pre-existing uses of the AddCloud call on the Cloud facade, we don't change AddCloud in this branch, instead we use SetModelDefaults for each region in the cloud, after we've added the cloud.

We need to do this for each region because model defaults are keyed by region`*`.

That's inappropriate because the controller has at least one non-CAAS cloud, and may have multiple CAAS clouds. So in this branch we just force every CAAS cloud to have one region called "default", and set the model defaults for each region in the AddCAASCommand.

`*` If we pass an empty region string to SetModelDefaults, it stores it as a controller-wide default ( see https://github.com/juju/juju/blob/develop/apiserver/facades/client/modelmanager/modelmanager.go#L1162 , which calls Model.UpdateModelConfigDefaultValues() with a nil rspec, which causes it to use 'controllerInheritedSettingsGlobalKey' as the settings doc's ID - here -
 https://github.com/juju/juju/blob/develop/state/modelconfig.go#L146 )
