### PR TITLE
remote-relations: fix add/remove/add relation

### DIFF
--- a/cmd/juju/status/output_tabular.go
+++ b/cmd/juju/status/output_tabular.go
@@ -90,7 +90,9 @@ func FormatTabular(writer io.Writer, forceColor bool, value interface{}) error {
 				store = "unknown"
 				urlPath = app.OfferURL
 			}
-			p(appName, app.StatusInfo.Current, store, urlPath)
+			w.Print(appName)
+			w.PrintStatus(app.StatusInfo.Current)
+			p(store, urlPath)
 		}
 		tw.Flush()
 	}

--- a/state/relationunit.go
+++ b/state/relationunit.go
@@ -101,13 +101,13 @@ func (ru *RelationUnit) EnterScope(settings map[string]interface{}) error {
 			Id:     ru.unitName,
 			Assert: isAliveDoc,
 		})
-		ops = append(ops, txn.Op{
-			C:      relationsC,
-			Id:     relationDocID,
-			Assert: isAliveDoc,
-			Update: bson.D{{"$inc", bson.D{{"unitcount", 1}}}},
-		})
 	}
+	ops = append(ops, txn.Op{
+		C:      relationsC,
+		Id:     relationDocID,
+		Assert: isAliveDoc,
+		Update: bson.D{{"$inc", bson.D{{"unitcount", 1}}}},
+	})
 
 	// * Create the unit settings in this relation, if they do not already
 	//   exist; or completely overwrite them if they do. This must happen
@@ -322,14 +322,12 @@ func (ru *RelationUnit) LeaveScope() error {
 			Remove: true,
 		}}
 		if ru.relation.doc.Life == Alive {
-			if ru.isLocalUnit {
-				ops = append(ops, txn.Op{
-					C:      relationsC,
-					Id:     ru.relation.doc.DocID,
-					Assert: bson.D{{"life", Alive}},
-					Update: bson.D{{"$inc", bson.D{{"unitcount", -1}}}},
-				})
-			}
+			ops = append(ops, txn.Op{
+				C:      relationsC,
+				Id:     ru.relation.doc.DocID,
+				Assert: bson.D{{"life", Alive}},
+				Update: bson.D{{"$inc", bson.D{{"unitcount", -1}}}},
+			})
 		} else if ru.relation.doc.UnitCount > 1 {
 			ops = append(ops, txn.Op{
 				C:      relationsC,

--- a/worker/remoterelations/remoterelations_test.go
+++ b/worker/remoterelations/remoterelations_test.go
@@ -281,7 +281,10 @@ func (s *remoteRelationsSuite) TestRemoteRelationsDying(c *gc.C) {
 			break
 		}
 	}
-	c.Assert(unitsWatcher.killed(), jc.IsTrue)
+	// We keep the relation units watcher alive when the relation
+	// goes to Dying; they're only stopped when the relation is
+	// finally removed.
+	c.Assert(unitsWatcher.killed(), jc.IsFalse)
 	mac, err := macaroon.New(nil, "apimac", "")
 	c.Assert(err, jc.ErrorIsNil)
 	expected := []jujutesting.StubCall{
@@ -315,18 +318,8 @@ func (s *remoteRelationsSuite) TestLocalRelationsRemoved(c *gc.C) {
 		}
 	}
 	c.Assert(unitsWatcher.killed(), jc.IsTrue)
-	mac, err := macaroon.New(nil, "apimac", "")
-	c.Assert(err, jc.ErrorIsNil)
 	expected := []jujutesting.StubCall{
 		{"Relations", []interface{}{[]string{"db2:db django:db"}}},
-		{"PublishRelationChange", []interface{}{
-			params.RemoteRelationChangeEvent{
-				Life:             params.Dying,
-				ApplicationToken: "token-django",
-				RelationToken:    "token-db2:db django:db",
-				Macaroons:        macaroon.Slice{mac},
-			},
-		}},
 	}
 	s.waitForWorkerStubCalls(c, expected)
 }

--- a/worker/uniter/relation/relationer.go
+++ b/worker/uniter/relation/relationer.go
@@ -6,6 +6,7 @@ package relation
 import (
 	"fmt"
 
+	"github.com/juju/errors"
 	"gopkg.in/juju/charm.v6-unstable/hooks"
 
 	apiuniter "github.com/juju/juju/api/uniter"
@@ -79,7 +80,7 @@ func (r *Relationer) SetDying() error {
 // relation scope, and removes the local relation state directory.
 func (r *Relationer) die() error {
 	if err := r.ru.LeaveScope(); err != nil {
-		return err
+		return errors.Annotatef(err, "leaving scope of relation %q", r.ru.Relation())
 	}
 	return r.dir.Remove()
 }


### PR DESCRIPTION
## Description of change

Fix two issues with removal of remote relations:

 - refcount remote units in relations the same as
   for local units. This ensures that, at a minimum,
   the relation scope documents do not get orphaned,
   and prevents the relation from being removed too
   early
 - when a remote relation is Dying, don't stop its
   remote relation workers; this can prevent the
   propagation of relation unit departures. Instead,
   stop the workers when the relation is *removed*

Also, as a drive-by, add colourisation to the SAAS
entries' status in "juju status".

## QA steps

`
juju bootstrap localhost l1 & juju bootstrap localhost l2
juju deploy -m l1:default mediawiki & juju deploy -m l2:default mysql
sleep 10s
juju switch l2
juju offer mysql:db
juju switch l1
juju relate mediawiki:db l2:admin/default.mysql
`

Then:

1. juju remove-relation -m l1:default mediawiki:db mysql:db
(check the hooks fire, relation removed)
2. juju relate -m l1:default mediawiki:db mysql:db
(check relation re-added, hooks fire)
3. juju remove-relation -m l2:default <relation-id-from-offer>
(check the hooks fire, relation removed)
4. juju relate -m l1:default mediawiki:db mysql:db
(check relation re-added, hooks fire)

## Documentation changes

None.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1727162