### PR TITLE
2.3 leadership logging

### DIFF
--- a/core/lease/client.go
+++ b/core/lease/client.go
@@ -36,6 +36,12 @@ type Client interface {
 	// expressed according to the Clock the client was configured with.
 	Leases() map[string]Info
 
+	// TODO (jam) 2017-10-31: Many callers of Leases() actually only tant
+	// exactly 1 lease, we should have a way to do a query to return exactly
+	// that lease, instead of having to read all of them to pull one out of the
+	// map. (Worst case it is implemented as exactly this, best case avoids
+	// reading lots of unused data.)
+
 	// Refresh reads all lease state from the database.
 	Refresh() error
 }

--- a/worker/lease/config.go
+++ b/worker/lease/config.go
@@ -42,6 +42,10 @@ type ManagerConfig struct {
 	// MaxSleep is the longest time the Manager should sleep before
 	// refreshing its client's leases and checking for expiries.
 	MaxSleep time.Duration
+
+	// EntityUUID is the entity that we are running this Manager for. Used for
+	// logging purposes.
+	EntityUUID string
 }
 
 // Validate returns an error if the configuration contains invalid information

--- a/worker/lease/manager.go
+++ b/worker/lease/manager.go
@@ -229,7 +229,7 @@ func (manager *Manager) handleCheck(check check) error {
 
 	var response error
 	if !found || info.Holder != check.holderName {
-		logger.Tracef("[%s] handling Check for lease %s on behalf of %s, not held", manager.logContext, check.leaseName)
+		logger.Tracef("[%s] handling Check for lease %s on behalf of %s, not held", manager.logContext, check.leaseName, check.holderName)
 		response = lease.ErrNotHeld
 	} else if check.trapdoorKey != nil {
 		response = info.Trapdoor(check.trapdoorKey)
@@ -276,7 +276,7 @@ func (manager *Manager) nextTick() <-chan time.Time {
 //
 // It will return only unrecoverable errors.
 func (manager *Manager) tick() error {
-	logger.Debugf("[%s] woke up to refresh and expire leases", manager.logContext)
+	logger.Tracef("[%s] waking up to refresh and expire leases", manager.logContext)
 	client := manager.config.Client
 	if err := client.Refresh(); err != nil {
 		return errors.Trace(err)

--- a/worker/lease/manager.go
+++ b/worker/lease/manager.go
@@ -4,7 +4,6 @@
 package lease
 
 import (
-	"runtime/debug"
 	"sort"
 	"time"
 
@@ -69,7 +68,6 @@ func NewManager(config ManagerConfig) (*Manager, error) {
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	logger.Debugf("[%s] creating manager %p for:\n%s", logContext, manager, string(debug.Stack()))
 	return manager, nil
 }
 


### PR DESCRIPTION
## Description of change

This is mostly just cleaning up the logging we do around leases. The biggest issue was that we had a DEBUG level message whenever we called nextTick() that made it sound like we were currently waking up to handle leases. When in actuality we were only scheduling a *potential* wakeup at some point in the future. Instead, we now have TRACE level logging any time anything causes the lease worker to wake up in its inner loop, and then a DEBUG level log when we actually wake up to refresh and expire leases.

It also adds a 'logContext' which is intended to be unique per Manager. I started by trying to use the first 6 digits of the Model/Controller UUID (which we also use in PingBatcher, so there is some precedent). The main caveat is that we actually seem to be running at least 2 Managers for some models.
And on the actually interesting model, we don't actually ever wake up to expire leases. Because we always schedule a time to expire at the min(leases.expiry). However if all of the agents are operating correctly, they will always ask to extend their lease before anything expires.

Only the "uninteresting" Managers that hold leases for longer than the configured 1min max sleep ever poll periodically.

## QA steps

```
juju bootstrap --debug lxd
juju deploy ubuntu u0 -n1
juju deploy ubuntu u1 -n1
juju deploy ubuntu u2 -n1
juju debug-log -m controller --include-model juju.worker.lease
```

You should see occasional log messages talking about 'juju.worker.lease' activity. You can also do:
```
juju model-config -m controller "logging-config=<root>=DEBUG;unit=DEBUG;juju.worker.lease=TRACE"
```

And see that the logging level changes, and starts describing some interesting events internally when we get hook changes.

## Documentation changes

This is mostly around internally better logging and more helpful log levels.

## Bug reference

[lp:1728902](https://bugs.launchpad.net/juju-core/+bug/1728902)