### PR TITLE
Fixes lp#1628121:  add-storage usage in help.

### DIFF
--- a/cmd/juju/storage/add.go
+++ b/cmd/juju/storage/add.go
@@ -74,7 +74,7 @@ Examples:
     or
       juju add-storage u/0 data 
 `
-	addCommandAgs = `<unit name> <charm storage name>=[<storage constraints>]`
+	addCommandAgs = `<unit name> <charm storage name>[=<storage constraints>]`
 )
 
 // addCommand adds unit storage instances dynamically.

--- a/cmd/juju/storage/add.go
+++ b/cmd/juju/storage/add.go
@@ -74,13 +74,7 @@ Examples:
     or
       juju add-storage u/0 data 
 `
-	addCommandAgs = `
-<unit name> <storage directive> ...
-    where storage directive is 
-        <charm storage name>=<storage constraints> 
-    or
-        <charm storage name>
-`
+	addCommandAgs = `<unit name> <charm storage name>=[<storage constraints>]`
 )
 
 // addCommand adds unit storage instances dynamically.


### PR DESCRIPTION
## Description of change

Usage section of the help should be uniform and clear. The suggestion in the bug linked below presents 'usage' in a much clearer form.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1628121
