### PR TITLE
Fixes lp#1729029: Keep list of types upto date.

### DIFF
--- a/cmd/juju/status/history.go
+++ b/cmd/juju/status/history.go
@@ -19,6 +19,7 @@ import (
 	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/juju/osenv"
 	"github.com/juju/juju/status"
+	"strings"
 )
 
 // TODO(peritto666) - add tests
@@ -47,13 +48,13 @@ This command will report the history of status changes for
 a given entity.
 The statuses are available for the following types.
 -type supports:
-    juju-unit: will show statuses for the unit's juju agent.
-    workload: will show statuses for the unit's workload.
-    unit: will show workload and juju agent combined for the specified unit.
-    juju-machine: will show statuses for machine's juju agent.
-    machine: will show statuses for machines.
-    juju-container: will show statuses for the container's juju agent.
     container: will show statuses for containers.
+    juju-container: will show statuses for the container's juju agent.
+    juju-machine: will show statuses for machine's juju agent.
+    juju-unit: will show statuses for the unit's juju agent.
+    machine: will show statuses for machines.
+    unit: will show workload and juju agent combined for the specified unit.
+    workload: will show statuses for the unit's workload.
  and sorted by time of occurrence.
  The default is unit.
 `
@@ -67,9 +68,17 @@ func (c *statusHistoryCommand) Info() *cmd.Info {
 	}
 }
 
+func supportedHistoryKinds() string {
+	supported := set.NewStrings()
+	for _, k := range status.AllHistoryKind() {
+		supported.Add(string(k))
+	}
+	return strings.Join(supported.SortedValues(), "|")
+}
+
 func (c *statusHistoryCommand) SetFlags(f *gnuflag.FlagSet) {
 	c.ModelCommandBase.SetFlags(f)
-	f.StringVar(&c.outputContent, "type", "unit", "Type of statuses to be displayed [agent|workload|combined|machine|machineInstance|container|containerinstance]")
+	f.StringVar(&c.outputContent, "type", "unit", fmt.Sprintf("Type of statuses to be displayed [%v]", supportedHistoryKinds()))
 	f.IntVar(&c.backlogSize, "n", 0, "Returns the last N logs (cannot be combined with --days or --date)")
 	f.IntVar(&c.backlogSizeDays, "days", 0, "Returns the logs for the past <days> days (cannot be combined with -n or --date)")
 	f.StringVar(&c.backlogDate, "from-date", "", "Returns logs for any date after the passed one, the expected date format is YYYY-MM-DD (cannot be combined with -n or --days)")

--- a/cmd/juju/status/history.go
+++ b/cmd/juju/status/history.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/juju/cmd"
@@ -19,7 +20,6 @@ import (
 	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/juju/osenv"
 	"github.com/juju/juju/status"
-	"strings"
 )
 
 // TODO(peritto666) - add tests

--- a/status/status_history.go
+++ b/status/status_history.go
@@ -193,8 +193,14 @@ func (k HistoryKind) Valid() bool {
 }
 
 // AllHistoryKind will return all valid HistoryKinds.
-func AllHistoryKind() []HistoryKind {
-	return []HistoryKind{KindUnit, KindUnitAgent, KindWorkload,
-		KindMachineInstance, KindMachine,
-		KindContainerInstance, KindContainer}
+func AllHistoryKind() map[HistoryKind]string {
+	return map[HistoryKind]string{
+		KindUnit:              "statuses for specified unit and its workload",
+		KindUnitAgent:         "statuses from the agent that is managing a unit",
+		KindWorkload:          "statuses for unit's workload",
+		KindMachineInstance:   "statuses that occur due to provisioning of a machine",
+		KindMachine:           "status of the agent that is managing a machine",
+		KindContainerInstance: "statuses from the agent that is managing containers",
+		KindContainer:         "statuses from the containers only and not their host machines",
+	}
 }

--- a/status/status_history.go
+++ b/status/status_history.go
@@ -151,8 +151,14 @@ func (h *History) SquashLogs(cycleSize int) History {
 
 // HistoryKind represents the possible types of
 // status history entries.
+//
 type HistoryKind string
 
+// IMPORTANT DEV NOTE: when changing this HistoryKind list in anyway, these may need to be revised:
+//
+// * HistoryKind.Valid()
+// * AllHistoryKind()
+// * command help for 'show-status-log' describing these kinds.
 const (
 	// KindUnit represents agent and workload combined.
 	KindUnit HistoryKind = "unit"
@@ -184,4 +190,11 @@ func (k HistoryKind) Valid() bool {
 		return true
 	}
 	return false
+}
+
+// AllHistoryKind will return all valid HistoryKinds.
+func AllHistoryKind() []HistoryKind {
+	return []HistoryKind{KindUnit, KindUnitAgent, KindWorkload,
+		KindMachineInstance, KindMachine,
+		KindContainerInstance, KindContainer}
 }


### PR DESCRIPTION
## Description of change

The list of valid types mentioned in show-status-log command help can easily become obsolete. The command help may or may not get updated in a timely manner.

This PR retrieves the list of valid types dynamically and leaves breadcrumbs for future development to ensure that type descriptions in this command are, at least, checked on any type modification.

I have also made type list in command help sorted in alphabetical order - easier read for end-users :D

## Bug reference

https://bugs.launchpad.net/juju/+bug/1729029
