### PR TITLE
Fixes lp#1607161: image metadata help updated from Juju 1.x desc.

### DIFF
--- a/cmd/plugins/juju-metadata/imagemetadata.go
+++ b/cmd/plugins/juju-metadata/imagemetadata.go
@@ -176,10 +176,10 @@ Image metadata files have been written to:
 For Juju to use this metadata, the files need to be put into the
 image metadata search path. There are 2 options:
 
-1. For local access - use the --metadata-source parameter when bootstrapping:
-   juju bootstrap [...] --metadata-source %s
+1. For local access, use the --metadata-source parameter when bootstrapping:
+   juju bootstrap --metadata-source %s [...]
 
-2. For remote access - use image-metadata-url attribute for model configuration. 
+2. For remote access, use image-metadata-url attribute for model configuration. 
 To set it as a default for any model or for the controller model, 
 it needs to be supplied as part of --model-default to 'juju bootstrap' command.
 See 'bootstrap' help for more details.

--- a/cmd/plugins/juju-metadata/imagemetadata.go
+++ b/cmd/plugins/juju-metadata/imagemetadata.go
@@ -176,13 +176,17 @@ Image metadata files have been written to:
 For Juju to use this metadata, the files need to be put into the
 image metadata search path. There are 2 options:
 
-1. Use the --metadata-source parameter when bootstrapping:
-   juju bootstrap --metadata-source %s
+1. For local access - use the --metadata-source parameter when bootstrapping:
+   juju bootstrap [...] --metadata-source %s
 
-2. Use image-metadata-url in $JUJU_DATA/environments.yaml
-(if $JUJU_DATA is not set it will try $XDG_DATA_HOME/juju and
-if not set either default to ~/.local/share/juju)
-Configure a http server to serve the contents of
+2. For remote access - use image-metadata-url attribute for model configuration. 
+To set it as a default for any model or for the controller model, 
+it needs to be supplied as part of --model-default to 'juju bootstrap' command.
+See 'bootstrap' help for more details.
+For configuration for a particular model, set it as --image-metadata-url on
+'juju model-config'. See 'model-config' help for more details.
+Regardless of where this attribute is used, it expects a reachable URL. 
+You need to configure a http server to serve the contents of
 %s
 and set the value of image-metadata-url accordingly.
 `


### PR DESCRIPTION
## Description of change

We had a very outdated description of the world, from Juju 1.x...
This PR updated the text and also made a distinction between serving image metadata from local vs from a remote location. 

## Bug reference

https://bugs.launchpad.net/juju/+bug/1607161
