### PR TITLE
Destroy controller model list.

### DIFF
--- a/apiserver/common/modeldestroy.go
+++ b/apiserver/common/modeldestroy.go
@@ -53,6 +53,10 @@ func DestroyController(
 		for _, uuid := range uuids {
 			modelSt, release, err := st.GetBackend(uuid)
 			if err != nil {
+				if errors.IsNotFound(err) {
+					// Model is already in the process of being destroyed.
+					continue
+				}
 				return errors.Trace(err)
 			}
 			defer release()


### PR DESCRIPTION
## Description of change

Cis that frequently create and destroy models/controller see intermittent failures due to model flagged as removed but still considered as 'existing' under model destruction.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1729191
