### PR TITLE
Provider vsphere bootstrap zone

### DIFF
--- a/provider/common/mock_test.go
+++ b/provider/common/mock_test.go
@@ -6,8 +6,6 @@ package common_test
 import (
 	"io"
 
-	"github.com/juju/juju/cloudconfig/instancecfg"
-	"github.com/juju/juju/constraints"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/environs/simplestreams"
@@ -16,12 +14,11 @@ import (
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/provider/common"
 	jujustorage "github.com/juju/juju/storage"
-	"github.com/juju/juju/tools"
 )
 
 type allInstancesFunc func() ([]instance.Instance, error)
 type instancesFunc func([]instance.Id) ([]instance.Instance, error)
-type startInstanceFunc func(string, constraints.Value, []string, tools.List, *instancecfg.InstanceConfig) (instance.Instance, *instance.HardwareCharacteristics, []network.InterfaceInfo, error)
+type startInstanceFunc func(environs.StartInstanceParams) (instance.Instance, *instance.HardwareCharacteristics, []network.InterfaceInfo, error)
 type stopInstancesFunc func([]instance.Id) error
 type getToolsSourcesFunc func() ([]simplestreams.DataSource, error)
 type configFunc func() *config.Config
@@ -53,13 +50,7 @@ func (env *mockEnviron) Instances(ids []instance.Id) ([]instance.Instance, error
 }
 
 func (env *mockEnviron) StartInstance(args environs.StartInstanceParams) (*environs.StartInstanceResult, error) {
-	inst, hw, networkInfo, err := env.startInstance(
-		args.Placement,
-		args.Constraints,
-		nil,
-		args.Tools,
-		args.InstanceConfig,
-	)
+	inst, hw, networkInfo, err := env.startInstance(args)
 	if err != nil {
 		return nil, err
 	}

--- a/provider/gce/environ.go
+++ b/provider/gce/environ.go
@@ -27,7 +27,7 @@ type gceConnection interface {
 	// and returns it.
 	Instance(id, zone string) (google.Instance, error)
 	Instances(prefix string, statuses ...string) ([]google.Instance, error)
-	AddInstance(spec google.InstanceSpec, zones ...string) (*google.Instance, error)
+	AddInstance(spec google.InstanceSpec, zone string) (*google.Instance, error)
 	RemoveInstances(prefix string, ids ...string) error
 	UpdateMetadata(key, value string, ids ...string) error
 

--- a/provider/gce/environ_availzones_test.go
+++ b/provider/gce/environ_availzones_test.go
@@ -4,12 +4,10 @@
 package gce_test
 
 import (
-	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/instance"
-	"github.com/juju/juju/provider/common"
 	"github.com/juju/juju/provider/gce"
 	"github.com/juju/juju/provider/gce/google"
 	"github.com/juju/juju/storage"
@@ -76,115 +74,6 @@ func (s *environAZSuite) TestInstanceAvailabilityZoneNamesAPIs(c *gc.C) {
 	}})
 }
 
-func (s *environAZSuite) TestStartInstanceAvailabilityZones(c *gc.C) {
-	s.FakeCommon.AZInstances = []common.AvailabilityZoneInstances{
-		{ZoneName: "az2",
-			Instances: []instance.Id{s.Instance.Id()}},
-		{ZoneName: "az3",
-			Instances: []instance.Id{},
-		}}
-
-	zones, err := gce.StartInstanceAvailabilityZones(s.Env, s.StartInstArgs)
-	c.Assert(err, jc.ErrorIsNil)
-	c.Check(zones, jc.DeepEquals, []string{"az2", "az3"})
-}
-
-func (s *environAZSuite) TestStartInstanceAvailabilityZoneParam(c *gc.C) {
-	s.FakeConn.Zones = []google.AvailabilityZone{
-		google.NewZone("az1", google.StatusDown, "", ""),
-		google.NewZone("az2", google.StatusUp, "", ""),
-		google.NewZone("az3", google.StatusUp, "", ""),
-	}
-	s.StartInstArgs.AvailabilityZone = "az3"
-
-	zones, err := gce.StartInstanceAvailabilityZones(s.Env, s.StartInstArgs)
-	c.Assert(err, jc.ErrorIsNil)
-
-	// Prior to the introduction of StartInstanceParams.AvailabilityZone
-	// "az2" would have been chosen as the availability zone by the provider.
-	// Ensure that the new value is taking precedence.
-	c.Check(zones, jc.DeepEquals, []string{"az3"})
-}
-
-func (s *environAZSuite) TestStartInstanceAvailabilityZonesPlacement(c *gc.C) {
-	s.StartInstArgs.Placement = "zone=a-zone"
-	s.FakeConn.Zones = []google.AvailabilityZone{
-		google.NewZone("a-zone", google.StatusUp, "", ""),
-	}
-
-	zones, err := gce.StartInstanceAvailabilityZones(s.Env, s.StartInstArgs)
-	c.Assert(err, jc.ErrorIsNil)
-
-	c.Check(zones, jc.DeepEquals, []string{"a-zone"})
-}
-
-func (s *environAZSuite) TestStartInstanceAvailabilityZonesPlacementAPI(c *gc.C) {
-	s.StartInstArgs.Placement = "zone=a-zone"
-	s.FakeConn.Zones = []google.AvailabilityZone{
-		google.NewZone("a-zone", google.StatusUp, "", ""),
-	}
-
-	_, err := gce.StartInstanceAvailabilityZones(s.Env, s.StartInstArgs)
-	c.Assert(err, jc.ErrorIsNil)
-
-	s.FakeEnviron.CheckCalls(c, []gce.FakeCall{})
-	s.FakeCommon.CheckCalls(c, []gce.FakeCall{})
-	c.Check(s.FakeConn.Calls, gc.HasLen, 1)
-	c.Check(s.FakeConn.Calls[0].FuncName, gc.Equals, "AvailabilityZones")
-	c.Check(s.FakeConn.Calls[0].Region, gc.Equals, "us-east1")
-}
-
-func (s *environAZSuite) TestStartInstanceAvailabilityZonesPlacementUnavailable(c *gc.C) {
-	s.StartInstArgs.Placement = "zone=a-zone"
-	s.FakeConn.Zones = []google.AvailabilityZone{
-		google.NewZone("a-zone", google.StatusDown, "", ""),
-	}
-
-	_, err := gce.StartInstanceAvailabilityZones(s.Env, s.StartInstArgs)
-
-	c.Check(err, gc.ErrorMatches, `.*availability zone "a-zone" is DOWN`)
-}
-
-func (s *environAZSuite) TestStartInstanceAvailabilityZonesNoneFound(c *gc.C) {
-	_, err := gce.StartInstanceAvailabilityZones(s.Env, s.StartInstArgs)
-
-	c.Check(err, jc.Satisfies, errors.IsNotFound)
-}
-
-func (s *environAZSuite) TestStartInstanceAvailabilityZonesVolumeAttachments(c *gc.C) {
-	s.StartInstArgs.VolumeAttachments = []storage.VolumeAttachmentParams{{
-		VolumeId: "home-zone--c930380d-8337-4bf5-b07a-9dbb5ae771e4",
-	}}
-
-	zones, err := gce.StartInstanceAvailabilityZones(s.Env, s.StartInstArgs)
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(zones, jc.DeepEquals, []string{"home-zone"})
-}
-
-func (s *environAZSuite) TestStartInstanceAvailabilityZonesVolumeAttachmentsDifferentZones(c *gc.C) {
-	s.StartInstArgs.VolumeAttachments = []storage.VolumeAttachmentParams{{
-		VolumeId: "home-zone--c930380d-8337-4bf5-b07a-9dbb5ae771e4",
-	}, {
-		VolumeId: "away-zone--c930380d-8337-4bf5-b07a-9dbb5ae771e4",
-	}}
-
-	_, err := gce.StartInstanceAvailabilityZones(s.Env, s.StartInstArgs)
-	c.Assert(err, gc.ErrorMatches, `cannot attach volumes from multiple availability zones: home-zone--c930380d-8337-4bf5-b07a-9dbb5ae771e4 is in home-zone, away-zone--c930380d-8337-4bf5-b07a-9dbb5ae771e4 is in away-zone`)
-}
-
-func (s *environAZSuite) TestStartInstanceAvailabilityZonesVolumeAttachmentsConflictsPlacement(c *gc.C) {
-	s.StartInstArgs.Placement = "zone=away-zone"
-	s.FakeConn.Zones = []google.AvailabilityZone{
-		google.NewZone("away-zone", google.StatusUp, "", ""),
-	}
-	s.StartInstArgs.VolumeAttachments = []storage.VolumeAttachmentParams{{
-		VolumeId: "home-zone--c930380d-8337-4bf5-b07a-9dbb5ae771e4",
-	}}
-
-	_, err := gce.StartInstanceAvailabilityZones(s.Env, s.StartInstArgs)
-	c.Assert(err, gc.ErrorMatches, `cannot create instance with placement "zone=away-zone", as this will prevent attaching the requested disks in zone "home-zone"`)
-}
-
 func (s *environAZSuite) TestDeriveAvailabilityZone(c *gc.C) {
 	s.StartInstArgs.Placement = "zone=test-available"
 	s.FakeConn.Zones = []google.AvailabilityZone{
@@ -235,6 +124,27 @@ func (s *environAZSuite) TestDeriveAvailabilityZoneConflictsVolume(c *gc.C) {
 		VolumeId: "az2--c930380d-8337-4bf5-b07a-9dbb5ae771e4",
 	}}
 	zone, err := s.Env.DeriveAvailabilityZone(s.StartInstArgs)
-	c.Assert(err, gc.ErrorMatches, `cannot create instance with placement "zone=az1", as this will prevent attaching the requested disks in zone "az2"`)
+	c.Assert(err, gc.ErrorMatches, `cannot create instance with placement "zone=az1": cannot create instance in zone "az1", as this will prevent attaching the requested disks in zone "az2"`)
 	c.Assert(zone, gc.Equals, "")
+}
+
+func (s *environAZSuite) TestDeriveAvailabilityZoneVolumeAttachments(c *gc.C) {
+	s.StartInstArgs.VolumeAttachments = []storage.VolumeAttachmentParams{{
+		VolumeId: "home-zone--c930380d-8337-4bf5-b07a-9dbb5ae771e4",
+	}}
+
+	zone, err := s.Env.DeriveAvailabilityZone(s.StartInstArgs)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(zone, gc.Equals, "home-zone")
+}
+
+func (s *environAZSuite) TestDeriveAvailabilityZoneVolumeAttachmentsDifferentZones(c *gc.C) {
+	s.StartInstArgs.VolumeAttachments = []storage.VolumeAttachmentParams{{
+		VolumeId: "home-zone--c930380d-8337-4bf5-b07a-9dbb5ae771e4",
+	}, {
+		VolumeId: "away-zone--c930380d-8337-4bf5-b07a-9dbb5ae771e4",
+	}}
+
+	_, err := s.Env.DeriveAvailabilityZone(s.StartInstArgs)
+	c.Assert(err, gc.ErrorMatches, `cannot attach volumes from multiple availability zones: home-zone--c930380d-8337-4bf5-b07a-9dbb5ae771e4 is in home-zone, away-zone--c930380d-8337-4bf5-b07a-9dbb5ae771e4 is in away-zone`)
 }

--- a/provider/gce/export_test.go
+++ b/provider/gce/export_test.go
@@ -30,10 +30,6 @@ func ExposeInstEnv(inst *environInstance) *environ {
 	return inst.env
 }
 
-func StartInstanceAvailabilityZones(env *environ, args environs.StartInstanceParams) ([]string, error) {
-	return env.startInstanceAvailabilityZones(args)
-}
-
 func ExposeEnvConfig(env *environ) *environConfig {
 	return env.ecfg
 }

--- a/provider/gce/google/conn_instance.go
+++ b/provider/gce/google/conn_instance.go
@@ -13,49 +13,44 @@ import (
 
 // addInstance sends a request to GCE to add a new instance to the
 // connection's project, with the provided instance data and machine
-// type. Each of the provided zones is attempted and the first available
-// zone is where the instance is provisioned. If no zones are available
-// then an error is returned. The instance that was passed in is updated
-// with the new instance's data upon success. The call blocks until the
-// instance is created or the request fails.
+// type. The instance that was passed in is updated with the new
+// instance's data upon success. The call blocks until the instance
+// is created or the request fails.
 // TODO(ericsnow) Return a new inst.
-func (gce *Connection) addInstance(requestedInst *compute.Instance, machineType string, zones []string) error {
-	for _, zoneName := range zones {
-		var waitErr error
-		inst := *requestedInst
-		inst.MachineType = formatMachineType(zoneName, machineType)
-		err := gce.raw.AddInstance(gce.projectID, zoneName, &inst)
-		if isWaitError(err) {
-			waitErr = err
-		} else if err != nil {
-			// We are guaranteed the insert failed at the point.
-			return errors.Annotate(err, "sending new instance request")
-		}
-
-		// Check if the instance was created.
-		realized, err := gce.raw.GetInstance(gce.projectID, zoneName, inst.Name)
-		if err != nil {
-			if waitErr == nil {
-				return errors.Trace(err)
-			}
-			// Try the next zone.
-			logger.Errorf("failed to get new instance in zone %q: %v", zoneName, waitErr)
-			return errors.Wrap(waitErr, environs.ErrAvailabilityZoneFailed)
-		}
-
-		// Success!
-		*requestedInst = *realized
-		return nil
+func (gce *Connection) addInstance(requestedInst *compute.Instance, machineType string, zone string) error {
+	var waitErr error
+	inst := *requestedInst
+	inst.MachineType = formatMachineType(zone, machineType)
+	err := gce.raw.AddInstance(gce.projectID, zone, &inst)
+	if isWaitError(err) {
+		waitErr = err
+	} else if err != nil {
+		// We are guaranteed the insert failed at the point.
+		return errors.Annotate(err, "sending new instance request")
 	}
-	return errors.Errorf("not able to provision in any zone")
+
+	// Check if the instance was created.
+	realized, err := gce.raw.GetInstance(gce.projectID, zone, inst.Name)
+	if err != nil {
+		if waitErr == nil {
+			return errors.Trace(err)
+		}
+		// Try the next zone.
+		logger.Errorf("failed to get new instance in zone %q: %v", zone, waitErr)
+		return errors.Wrap(waitErr, environs.ErrAvailabilityZoneFailed)
+	}
+
+	// Success!
+	*requestedInst = *realized
+	return nil
 }
 
 // AddInstance creates a new instance based on the spec's data and
 // returns it. The instance will be created using the provided
-// connection and in one of the provided zones.
-func (gce *Connection) AddInstance(spec InstanceSpec, zones ...string) (*Instance, error) {
+// connection and in the provided zone.
+func (gce *Connection) AddInstance(spec InstanceSpec, zone string) (*Instance, error) {
 	raw := spec.raw()
-	if err := gce.addInstance(raw, spec.Type, zones); err != nil {
+	if err := gce.addInstance(raw, spec.Type, zone); err != nil {
 		return nil, errors.Trace(err)
 	}
 

--- a/provider/gce/google/conn_instance_test.go
+++ b/provider/gce/google/conn_instance_test.go
@@ -16,8 +16,7 @@ func (s *connSuite) TestConnectionSimpleAddInstance(c *gc.C) {
 	s.FakeConn.Instance = &s.RawInstanceFull
 
 	inst := &s.RawInstance
-	zones := []string{"a-zone"}
-	err := google.ConnAddInstance(s.Conn, inst, "mtype", zones)
+	err := google.ConnAddInstance(s.Conn, inst, "mtype", "a-zone")
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Check(inst, jc.DeepEquals, &s.RawInstanceFull)
@@ -29,8 +28,7 @@ func (s *connSuite) TestConnectionSimpleAddInstanceAPI(c *gc.C) {
 	expected.MachineType = "zones/a-zone/machineTypes/mtype"
 
 	inst := &s.RawInstance
-	zones := []string{"a-zone"}
-	err := google.ConnAddInstance(s.Conn, inst, "mtype", zones)
+	err := google.ConnAddInstance(s.Conn, inst, "mtype", "a-zone")
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Check(s.FakeConn.Calls, gc.HasLen, 2)
@@ -112,8 +110,7 @@ func (s *connSuite) TestConnectionAddInstanceFailed(c *gc.C) {
 	failure := errors.New("unknown")
 	s.FakeConn.Err = failure
 
-	zones := []string{"a-zone"}
-	err := google.ConnAddInstance(s.Conn, &s.RawInstance, "mtype", zones)
+	err := google.ConnAddInstance(s.Conn, &s.RawInstance, "mtype", "a-zone")
 
 	c.Check(errors.Cause(err), gc.Equals, failure)
 }
@@ -124,8 +121,7 @@ func (s *connSuite) TestConnectionAddInstanceWaitFailed(c *gc.C) {
 	failure := s.NewWaitError(nil, errors.New("unknown"))
 	s.FakeConn.Err = failure
 
-	zones := []string{"a-zone"}
-	err := google.ConnAddInstance(s.Conn, &s.RawInstance, "mtype", zones)
+	err := google.ConnAddInstance(s.Conn, &s.RawInstance, "mtype", "a-zone")
 
 	c.Check(errors.Cause(err), gc.Equals, failure)
 }
@@ -137,8 +133,7 @@ func (s *connSuite) TestConnectionAddInstanceGetFailed(c *gc.C) {
 	s.FakeConn.Err = failure
 	s.FakeConn.FailOnCall = 1
 
-	zones := []string{"a-zone"}
-	err := google.ConnAddInstance(s.Conn, &s.RawInstance, "mtype", zones)
+	err := google.ConnAddInstance(s.Conn, &s.RawInstance, "mtype", "a-zone")
 
 	c.Check(errors.Cause(err), gc.Equals, failure)
 	c.Check(s.FakeConn.Calls, gc.HasLen, 2)

--- a/provider/gce/google/export_test.go
+++ b/provider/gce/google/export_test.go
@@ -53,8 +53,8 @@ func NewNetInterface(spec NetworkSpec, name string) *compute.NetworkInterface {
 	return spec.newInterface(name)
 }
 
-func ConnAddInstance(conn *Connection, inst *compute.Instance, mtype string, zones []string) error {
-	return conn.addInstance(inst, mtype, zones)
+func ConnAddInstance(conn *Connection, inst *compute.Instance, mtype string, zone string) error {
+	return conn.addInstance(inst, mtype, zone)
 }
 
 func ConnRemoveInstance(conn *Connection, id, zone string) error {

--- a/provider/gce/testing_test.go
+++ b/provider/gce/testing_test.go
@@ -471,7 +471,6 @@ type fakeConnCall struct {
 	ID               string
 	IDs              []string
 	ZoneName         string
-	ZoneNames        []string
 	Prefix           string
 	Statuses         []string
 	InstanceSpec     google.InstanceSpec
@@ -539,11 +538,11 @@ func (fc *fakeConn) Instances(prefix string, statuses ...string) ([]google.Insta
 	return fc.Insts, fc.err()
 }
 
-func (fc *fakeConn) AddInstance(spec google.InstanceSpec, zones ...string) (*google.Instance, error) {
+func (fc *fakeConn) AddInstance(spec google.InstanceSpec, zone string) (*google.Instance, error) {
 	fc.Calls = append(fc.Calls, fakeConnCall{
 		FuncName:     "AddInstance",
 		InstanceSpec: spec,
-		ZoneNames:    zones,
+		ZoneName:     zone,
 	})
 	return fc.Inst, fc.err()
 }

--- a/provider/maas/maas2_environ_whitebox_test.go
+++ b/provider/maas/maas2_environ_whitebox_test.go
@@ -154,13 +154,7 @@ func (suite *maas2EnvironSuite) TestInstancesPartialResult(c *gc.C) {
 }
 
 func (suite *maas2EnvironSuite) TestAvailabilityZones(c *gc.C) {
-	controller := &fakeController{
-		zones: []gomaasapi.Zone{
-			&fakeZone{name: "mossack"},
-			&fakeZone{name: "fonseca"},
-		},
-	}
-	env := suite.makeEnviron(c, controller)
+	env := suite.makeEnviron(c, newFakeController())
 	result, err := env.AvailabilityZones()
 	c.Assert(err, jc.ErrorIsNil)
 	expectedZones := set.NewStrings("mossack", "fonseca")

--- a/provider/maas/maas2_test.go
+++ b/provider/maas/maas2_test.go
@@ -86,7 +86,13 @@ type fakeController struct {
 }
 
 func newFakeController() *fakeController {
-	return &fakeController{Stub: &testing.Stub{}}
+	return &fakeController{
+		Stub: &testing.Stub{},
+		zones: []gomaasapi.Zone{
+			&fakeZone{name: "mossack"},
+			&fakeZone{name: "fonseca"},
+		},
+	}
 }
 
 func newFakeControllerWithErrors(errors ...error) *fakeController {
@@ -96,7 +102,9 @@ func newFakeControllerWithErrors(errors ...error) *fakeController {
 }
 
 func newFakeControllerWithFiles(files ...gomaasapi.File) *fakeController {
-	return &fakeController{Stub: &testing.Stub{}, files: files}
+	controller := newFakeController()
+	controller.files = files
+	return controller
 }
 
 func (c *fakeController) Devices(args gomaasapi.DevicesArgs) ([]gomaasapi.Device, error) {

--- a/provider/openstack/local_test.go
+++ b/provider/openstack/local_test.go
@@ -1407,7 +1407,7 @@ func (t *localServerSuite) TestPrecheckInstanceAvailZonesConflictsVolume(c *gc.C
 		Placement:         "zone=az2",
 		VolumeAttachments: []storage.VolumeAttachmentParams{{VolumeId: "foo"}},
 	})
-	c.Assert(err, gc.ErrorMatches, `cannot create instance with placement "zone=az2", as this will prevent attaching the requested disks in zone "az1"`)
+	c.Assert(err, gc.ErrorMatches, `cannot create instance with placement "zone=az2": cannot create instance in zone "az2", as this will prevent attaching the requested disks in zone "az1"`)
 }
 
 func (t *localServerSuite) TestDeriveAvailabilityZone(c *gc.C) {
@@ -1513,7 +1513,7 @@ func (t *localServerSuite) TestDeriveAvailabilityZoneConflictsVolume(c *gc.C) {
 			Placement:         "zone=az2",
 			VolumeAttachments: []storage.VolumeAttachmentParams{{VolumeId: "foo"}},
 		})
-	c.Assert(err, gc.ErrorMatches, `cannot create instance with placement "zone=az2", as this will prevent attaching the requested disks in zone "az1"`)
+	c.Assert(err, gc.ErrorMatches, `cannot create instance with placement "zone=az2": cannot create instance in zone "az2", as this will prevent attaching the requested disks in zone "az1"`)
 	c.Assert(zone, gc.Equals, "")
 }
 
@@ -2098,8 +2098,8 @@ func (t *localServerSuite) TestStartInstanceWithUnknownAZError(c *gc.C) {
 	)
 	defer cleanup()
 	_, err = testing.StartInstanceWithParams(t.env, "1", environs.StartInstanceParams{
-		ControllerUUID: t.ControllerUUID,
-		Placement:      "zone=az2",
+		ControllerUUID:   t.ControllerUUID,
+		AvailabilityZone: "az2",
 	})
 	c.Assert(err, gc.ErrorMatches, "(?s).*Some unknown error.*")
 }
@@ -2118,9 +2118,6 @@ func (t *localServerSuite) testStartInstanceWithParamsDeriveAZ(
 }
 
 func (t *localServerSuite) TestStartInstanceVolumeAttachmentsAvailZone(c *gc.C) {
-	err := bootstrapEnv(c, t.env)
-	c.Assert(err, jc.ErrorIsNil)
-
 	t.srv.Nova.SetAvailabilityZones(
 		nova.AvailabilityZone{
 			Name: "az1",
@@ -2141,6 +2138,8 @@ func (t *localServerSuite) TestStartInstanceVolumeAttachmentsAvailZone(c *gc.C) 
 			},
 		},
 	)
+	err := bootstrapEnv(c, t.env)
+	c.Assert(err, jc.ErrorIsNil)
 
 	_, err = t.storageAdapter.CreateVolume(cinder.CreateVolumeVolumeParams{
 		Size:             123,
@@ -2221,9 +2220,9 @@ func (t *localServerSuite) TestStartInstanceVolumeAttachmentsAvailZoneConflictsP
 	_, err = testing.StartInstanceWithParams(t.env, "1", environs.StartInstanceParams{
 		ControllerUUID:    t.ControllerUUID,
 		VolumeAttachments: []storage.VolumeAttachmentParams{{VolumeId: "foo"}},
-		Placement:         "zone=az2",
+		AvailabilityZone:  "az2",
 	})
-	c.Assert(err, gc.ErrorMatches, `cannot create instance with placement "zone=az2", as this will prevent attaching the requested disks in zone "az1"`)
+	c.Assert(err, gc.ErrorMatches, `cannot create instance in zone "az2", as this will prevent attaching the requested disks in zone "az1"`)
 }
 
 func (t *localServerSuite) TestInstanceTags(c *gc.C) {

--- a/provider/vsphere/environ_availzones_test.go
+++ b/provider/vsphere/environ_availzones_test.go
@@ -81,3 +81,14 @@ func (s *environAvailzonesSuite) TestDeriveAvailabilityZoneUnknown(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, `availability zone "test-unknown" not found`)
 	c.Assert(zone, gc.Equals, "")
 }
+
+func (s *environAvailzonesSuite) TestDeriveAvailabilityZoneInvalidPlacement(c *gc.C) {
+	c.Assert(s.env, gc.Implements, new(common.ZonedEnviron))
+	zonedEnviron := s.env.(common.ZonedEnviron)
+
+	zone, err := zonedEnviron.DeriveAvailabilityZone(environs.StartInstanceParams{
+		Placement: "invalid-placement",
+	})
+	c.Assert(err, gc.ErrorMatches, `unknown placement directive: invalid-placement`)
+	c.Assert(zone, gc.Equals, "")
+}

--- a/provider/vsphere/environ_broker.go
+++ b/provider/vsphere/environ_broker.go
@@ -162,13 +162,6 @@ func (env *sessionEnviron) newRawInstance(
 		cons.RootDisk = &minRootDisk
 	}
 
-	// Identify which zones may be used, taking into
-	// account placement directives.
-	zone, err := env.parseAvailabilityZone(args)
-	if err != nil {
-		return nil, nil, errors.Trace(err)
-	}
-
 	// Download and extract the OVA file. If we're bootstrapping we use
 	// a temporary directory, otherwise we cache the image for future use.
 	updateProgressInterval := startInstanceUpdateProgressInterval
@@ -209,10 +202,10 @@ func (env *sessionEnviron) newRawInstance(
 	}
 
 	// Attempt to create a VM in each of the AZs in turn.
-	logger.Debugf("attempting to create VM in availability zone %s", zone)
-	availZone, err := env.availZone(zone)
+	logger.Debugf("attempting to create VM in availability zone %s", args.AvailabilityZone)
+	availZone, err := env.availZone(args.AvailabilityZone)
 	if err != nil {
-		logger.Warningf("failed to get availability zone %s: %s", zone, err)
+		logger.Warningf("failed to get availability zone %s: %s", args.AvailabilityZone, err)
 
 		return nil, nil, errors.Wrap(err, environs.ErrAvailabilityZoneFailed)
 	}
@@ -220,7 +213,7 @@ func (env *sessionEnviron) newRawInstance(
 
 	vm, err := env.client.CreateVirtualMachine(env.ctx, createVMArgs)
 	if err != nil {
-		logger.Warningf("failed to create instance in availability zone %s: %s", zone, err)
+		logger.Warningf("failed to create instance in availability zone %s: %s", args.AvailabilityZone, err)
 
 		return nil, nil, errors.Wrap(err, environs.ErrAvailabilityZoneFailed)
 	}

--- a/provider/vsphere/environ_broker_test.go
+++ b/provider/vsphere/environ_broker_test.go
@@ -62,11 +62,11 @@ func (s *environBrokerSuite) createStartInstanceArgs(c *gc.C) environs.StartInst
 	tools := setInstanceConfigTools(c, instanceConfig)
 
 	return environs.StartInstanceParams{
-		ControllerUUID: instanceConfig.Controller.Config.ControllerUUID(),
-		InstanceConfig: instanceConfig,
-		Tools:          tools,
-		Constraints:    cons,
-		Placement:      "zone=z1",
+		AvailabilityZone: "z1",
+		ControllerUUID:   instanceConfig.Controller.Config.ControllerUUID(),
+		InstanceConfig:   instanceConfig,
+		Tools:            tools,
+		Constraints:      cons,
 		StatusCallback: func(status status.Status, info string, data map[string]interface{}) error {
 			s.statusCallbackStub.AddCall("StatusCallback", status, info, data)
 			return s.statusCallbackStub.NextErr()
@@ -278,16 +278,9 @@ func (s *environBrokerSuite) TestStartInstanceDefaultDiskSizeIsUsedForSmallConst
 	c.Assert(*res.Hardware.RootDisk, gc.Equals, common.MinRootDiskSizeGiB("trusty")*uint64(1024))
 }
 
-func (s *environBrokerSuite) TestStartInstanceInvalidPlacement(c *gc.C) {
-	startInstArgs := s.createStartInstanceArgs(c)
-	startInstArgs.Placement = "someInvalidPlacement"
-	_, err := s.env.StartInstance(startInstArgs)
-	c.Assert(err, gc.ErrorMatches, "unknown placement directive: .*")
-}
-
 func (s *environBrokerSuite) TestStartInstanceSelectZone(c *gc.C) {
 	startInstArgs := s.createStartInstanceArgs(c)
-	startInstArgs.Placement = "zone=z2"
+	startInstArgs.AvailabilityZone = "z2"
 	_, err := s.env.StartInstance(startInstArgs)
 	c.Assert(err, jc.ErrorIsNil)
 

--- a/worker/provisioner/container_initialisation_test.go
+++ b/worker/provisioner/container_initialisation_test.go
@@ -36,6 +36,7 @@ import (
 	"github.com/juju/juju/watcher"
 	jworker "github.com/juju/juju/worker"
 	"github.com/juju/juju/worker/provisioner"
+	"github.com/juju/juju/worker/workertest"
 )
 
 type ContainerSetupSuite struct {
@@ -84,7 +85,7 @@ func (s *ContainerSetupSuite) SetUpTest(c *gc.C) {
 
 func (s *ContainerSetupSuite) TearDownTest(c *gc.C) {
 	if s.p != nil {
-		stop(c, s.p)
+		workertest.CleanKill(c, s.p)
 	}
 	s.CommonProvisionerSuite.TearDownTest(c)
 }

--- a/worker/provisioner/kvm-broker_test.go
+++ b/worker/provisioner/kvm-broker_test.go
@@ -32,6 +32,7 @@ import (
 	coretesting "github.com/juju/juju/testing"
 	jujuversion "github.com/juju/juju/version"
 	"github.com/juju/juju/worker/provisioner"
+	"github.com/juju/juju/worker/workertest"
 )
 
 type kvmSuite struct {
@@ -336,12 +337,12 @@ func (s *kvmProvisionerSuite) newKvmProvisioner(c *gc.C) provisioner.Provisioner
 
 func (s *kvmProvisionerSuite) TestProvisionerStartStop(c *gc.C) {
 	p := s.newKvmProvisioner(c)
-	stop(c, p)
+	workertest.CleanKill(c, p)
 }
 
 func (s *kvmProvisionerSuite) TestDoesNotStartEnvironMachines(c *gc.C) {
 	p := s.newKvmProvisioner(c)
-	defer stop(c, p)
+	defer workertest.CleanKill(c, p)
 
 	// Check that an instance is not provisioned when the machine is created.
 	_, err := s.State.AddMachine(series.LatestLts(), state.JobHostUnits)
@@ -352,7 +353,7 @@ func (s *kvmProvisionerSuite) TestDoesNotStartEnvironMachines(c *gc.C) {
 
 func (s *kvmProvisionerSuite) TestDoesNotHaveRetryWatcher(c *gc.C) {
 	p := s.newKvmProvisioner(c)
-	defer stop(c, p)
+	defer workertest.CleanKill(c, p)
 
 	w, err := provisioner.GetRetryWatcher(p)
 	c.Assert(w, gc.IsNil)
@@ -374,7 +375,7 @@ func (s *kvmProvisionerSuite) TestContainerStartedAndStopped(c *gc.C) {
 		c.Skip("Test only enabled on amd64, see bug lp:1572145")
 	}
 	p := s.newKvmProvisioner(c)
-	defer stop(c, p)
+	defer workertest.CleanKill(c, p)
 
 	container := s.addContainer(c)
 
@@ -394,7 +395,7 @@ func (s *kvmProvisionerSuite) TestContainerStartedAndStopped(c *gc.C) {
 
 func (s *kvmProvisionerSuite) TestKVMProvisionerObservesConfigChanges(c *gc.C) {
 	p := s.newKvmProvisioner(c)
-	defer stop(c, p)
+	defer workertest.CleanKill(c, p)
 	s.assertProvisionerObservesConfigChanges(c, p)
 }
 

--- a/worker/provisioner/provisioner_task.go
+++ b/worker/provisioner/provisioner_task.go
@@ -6,6 +6,7 @@ package provisioner
 import (
 	"fmt"
 	"sort"
+	"strings"
 	"sync"
 	"time"
 
@@ -14,7 +15,7 @@ import (
 	"github.com/juju/utils/set"
 	"github.com/juju/version"
 	"gopkg.in/juju/names.v2"
-	worker "gopkg.in/juju/worker.v1"
+	"gopkg.in/juju/worker.v1"
 
 	apiprovisioner "github.com/juju/juju/api/provisioner"
 	"github.com/juju/juju/apiserver/common/networkingcommon"
@@ -38,7 +39,6 @@ import (
 	"github.com/juju/juju/watcher"
 	"github.com/juju/juju/worker/catacomb"
 	"github.com/juju/juju/wrench"
-	"strings"
 )
 
 type ProvisionerTask interface {
@@ -886,22 +886,16 @@ func (task *provisionerTask) startMachines(machines []*apiprovisioner.Machine) e
 		return err
 	}
 
-	wg := sync.WaitGroup{}
+	var wg sync.WaitGroup
 	errMachines := make([]error, len(machines))
-
 	for i, m := range machines {
-		// Make sure we shouldn't be stopping before we start the next machine
-		select {
-		case <-task.catacomb.Dying():
-			return task.catacomb.ErrDying()
-		default:
-		}
-
 		if machineDistributionGroups[i].Err != nil {
-			task.setErrorStatus("fetching distribution groups for machine %q: %v", m, machineDistributionGroups[i].Err)
+			task.setErrorStatus(
+				"fetching distribution groups for machine %q: %v",
+				m, machineDistributionGroups[i].Err,
+			)
 			continue
 		}
-
 		wg.Add(1)
 		go func(machine *apiprovisioner.Machine, dg []string, index int) {
 			defer wg.Done()
@@ -913,6 +907,11 @@ func (task *provisionerTask) startMachines(machines []*apiprovisioner.Machine) e
 	}
 
 	wg.Wait()
+	select {
+	case <-task.catacomb.Dying():
+		return task.catacomb.ErrDying()
+	default:
+	}
 	var errorStrings []string
 	for _, err := range errMachines {
 		if err != nil {


### PR DESCRIPTION
## Description of change

The vsphere provider was failing to bootstrap due to recent provisioner changes. The vsphere provider was essentially expecting a zone to be passed in, whereas the other providers were still going through all zones to cover bootstrap.

We update provider/common.Bootstrap to attempt all "available" availability zones, if no zone is specified, or derivable. Not all providers have been updated yet to remove the now-redundant code to support bootstrap.

## QA steps

1. juju bootsrap vsphere
(should go through each of the zones until it finds one that works)
2. juju bootstrap vsphere --to zone=foo
(should attempt only zone foo)

ditto for gce and openstack providers

## Documentation changes

None.

## Bug reference

None.