### PR TITLE
Add ability to specify `system_id` as a placment directive.

### DIFF
--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -30,7 +30,7 @@ github.com/juju/go4	git	40d72ab9641a2a8c36a9c46a51e28367115c8e59	2016-02-22T16:3
 github.com/juju/gojsonpointer	git	afe8b77aa08f272b49e01b82de78510c11f61500	2015-02-04T19:46:29Z
 github.com/juju/gojsonreference	git	f0d24ac5ee330baa21721cdff56d45e4ee42628e	2015-02-04T19:46:33Z
 github.com/juju/gojsonschema	git	e1ad140384f254c82f89450d9a7c8dd38a632838	2015-03-12T17:00:16Z
-github.com/juju/gomaasapi	git	38cd919ffb22103d167294b29b2c81653ece8eb2	2017-04-18T06:39:07Z
+github.com/juju/gomaasapi	git	91b8ec52c22ff67adf319b2872f0f128895d19cb	2017-11-02T06:39:07Z
 github.com/juju/httpprof	git	14bf14c307672fd2456bdbf35d19cf0ccd3cf565	2014-12-17T16:00:36Z
 github.com/juju/httprequest	git	266fd1e9debf09c037a63f074d099a2da4559ece	2016-10-06T15:09:09Z
 github.com/juju/idmclient	git	4dc25171f675da4206b71695d3fd80e519ad05c1	2017-02-09T16:27:49Z

--- a/provider/maas/constraints_test.go
+++ b/provider/maas/constraints_test.go
@@ -232,7 +232,7 @@ func (suite *environSuite) TestAcquireNode(c *gc.C) {
 	env := suite.makeEnviron()
 	suite.testMAASObject.TestServer.NewNode(`{"system_id": "node0", "hostname": "host0"}`)
 
-	_, err := env.acquireNode("", "", constraints.Value{}, nil, nil)
+	_, err := env.acquireNode("", "", "", constraints.Value{}, nil, nil)
 
 	c.Check(err, jc.ErrorIsNil)
 	operations := suite.testMAASObject.TestServer.NodeOperations()
@@ -250,7 +250,7 @@ func (suite *environSuite) TestAcquireNodeByName(c *gc.C) {
 	env := suite.makeEnviron()
 	suite.testMAASObject.TestServer.NewNode(`{"system_id": "node0", "hostname": "host0"}`)
 
-	_, err := env.acquireNode("host0", "", constraints.Value{}, nil, nil)
+	_, err := env.acquireNode("host0", "", "", constraints.Value{}, nil, nil)
 
 	c.Check(err, jc.ErrorIsNil)
 	operations := suite.testMAASObject.TestServer.NodeOperations()
@@ -271,7 +271,7 @@ func (suite *environSuite) TestAcquireNodeTakesConstraintsIntoAccount(c *gc.C) {
 	)
 	constraints := constraints.Value{Arch: stringp("arm"), Mem: uint64p(1024)}
 
-	_, err := env.acquireNode("", "", constraints, nil, nil)
+	_, err := env.acquireNode("", "", "", constraints, nil, nil)
 
 	c.Check(err, jc.ErrorIsNil)
 	requestValues := suite.testMAASObject.TestServer.NodeOperationRequestValues()
@@ -344,7 +344,7 @@ func (suite *environSuite) TestAcquireNodePassedAgentName(c *gc.C) {
 	env := suite.makeEnviron()
 	suite.testMAASObject.TestServer.NewNode(`{"system_id": "node0", "hostname": "host0"}`)
 
-	_, err := env.acquireNode("", "", constraints.Value{}, nil, nil)
+	_, err := env.acquireNode("", "", "", constraints.Value{}, nil, nil)
 
 	c.Check(err, jc.ErrorIsNil)
 	requestValues := suite.testMAASObject.TestServer.NodeOperationRequestValues()
@@ -358,7 +358,7 @@ func (suite *environSuite) TestAcquireNodePassesPositiveAndNegativeTags(c *gc.C)
 	suite.testMAASObject.TestServer.NewNode(`{"system_id": "node0", "tag_names": "tag1,tag3"}`)
 
 	_, err := env.acquireNode(
-		"", "",
+		"", "", "",
 		constraints.Value{Tags: stringslicep("tag1", "^tag2", "tag3", "^tag4")},
 		nil, nil,
 	)
@@ -377,7 +377,7 @@ func (suite *environSuite) TestAcquireNodePassesPositiveAndNegativeSpaces(c *gc.
 	suite.testMAASObject.TestServer.NewNode(`{"system_id": "node0"}`)
 
 	_, err := env.acquireNode(
-		"", "",
+		"", "", "",
 		constraints.Value{Spaces: stringslicep("space-1", "^space-2", "space-3", "^space-4")},
 		nil, nil,
 	)
@@ -410,7 +410,7 @@ func (suite *environSuite) TestAcquireNodeDisambiguatesNamedLabelsFromIndexedUpT
 	suite.testMAASObject.TestServer.NewNode(`{"system_id": "node0"}`)
 
 	_, err := env.acquireNode(
-		"", "",
+		"", "", "",
 		constraints.Value{Spaces: stringslicep("space-1", "^space-2", "space-3", "^space-4")},
 		[]interfaceBinding{{"0", "first-clash"}, {"1", "final-clash"}},
 		nil,
@@ -447,7 +447,7 @@ func (suite *environSuite) TestAcquireNodeStorage(c *gc.C) {
 		server.NewSpace(spaceJSON(gomaasapi.CreateSpace{Name: "space-1"}))
 		server.NewNode(`{"system_id": "node0", "hostname": "host0"}`)
 		suite.addSubnet(c, 1, 1, "node0")
-		_, err := env.acquireNode("", "", constraints.Value{}, nil, test.volumes)
+		_, err := env.acquireNode("", "", "", constraints.Value{}, nil, test.volumes)
 		c.Check(err, jc.ErrorIsNil)
 		requestValues := server.NodeOperationRequestValues()
 		nodeRequestValues, found := requestValues["node0"]
@@ -548,7 +548,7 @@ func (suite *environSuite) TestAcquireNodeInterfaces(c *gc.C) {
 		suite.addSubnetWithSpace(c, 7, 7, "bar", "node1")
 		env := suite.makeEnviron()
 		server.NewNode(`{"system_id": "node0", "hostname": "host0"}`)
-		_, err := env.acquireNode("", "", cons, test.interfaces, nil)
+		_, err := env.acquireNode("", "", "", cons, test.interfaces, nil)
 		if test.expectedError != "" {
 			c.Check(err, gc.ErrorMatches, test.expectedError)
 			c.Check(err, jc.Satisfies, errors.IsNotValid)
@@ -582,7 +582,7 @@ func (suite *environSuite) TestAcquireNodeConvertsSpaceNames(c *gc.C) {
 	}
 	env := suite.makeEnviron()
 	server.NewNode(`{"system_id": "node0", "hostname": "host0"}`)
-	_, err := env.acquireNode("", "", cons, nil, nil)
+	_, err := env.acquireNode("", "", "", cons, nil, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	requestValues := server.NodeOperationRequestValues()
 	nodeRequestValues, found := requestValues["node0"]
@@ -599,7 +599,7 @@ func (suite *environSuite) TestAcquireNodeTranslatesSpaceNames(c *gc.C) {
 	}
 	env := suite.makeEnviron()
 	server.NewNode(`{"system_id": "node0", "hostname": "host0"}`)
-	_, err := env.acquireNode("", "", cons, nil, nil)
+	_, err := env.acquireNode("", "", "", cons, nil, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	requestValues := server.NodeOperationRequestValues()
 	nodeRequestValues, found := requestValues["node0"]
@@ -616,6 +616,6 @@ func (suite *environSuite) TestAcquireNodeUnrecognisedSpace(c *gc.C) {
 	}
 	env := suite.makeEnviron()
 	server.NewNode(`{"system_id": "node0", "hostname": "host0"}`)
-	_, err := env.acquireNode("", "", cons, nil, nil)
+	_, err := env.acquireNode("", "", "", cons, nil, nil)
 	c.Assert(err, gc.ErrorMatches, `unrecognised space in constraint "baz"`)
 }

--- a/provider/maas/maas2_environ_whitebox_test.go
+++ b/provider/maas/maas2_environ_whitebox_test.go
@@ -377,7 +377,7 @@ func (suite *maas2EnvironSuite) TestAcquireNodePassedAgentName(c *gc.C) {
 	suite.setupFakeTools(c)
 	env = suite.makeEnviron(c, nil)
 
-	_, err := env.acquireNode2("", "", constraints.Value{}, nil, nil)
+	_, err := env.acquireNode2("", "", "", constraints.Value{}, nil, nil)
 
 	c.Check(err, jc.ErrorIsNil)
 }
@@ -390,7 +390,7 @@ func (suite *maas2EnvironSuite) TestAcquireNodePassesPositiveAndNegativeTags(c *
 	}
 	env, _ = suite.injectControllerWithSpacesAndCheck(c, nil, expected)
 	_, err := env.acquireNode2(
-		"", "",
+		"", "", "",
 		constraints.Value{Tags: stringslicep("tag1", "^tag2", "tag3", "^tag4")},
 		nil, nil,
 	)
@@ -433,7 +433,7 @@ func (suite *maas2EnvironSuite) TestAcquireNodePassesPositiveAndNegativeSpaces(c
 	env, _ := suite.injectControllerWithSpacesAndCheck(c, getFourSpaces(), expected)
 
 	_, err := env.acquireNode2(
-		"", "",
+		"", "", "",
 		constraints.Value{Spaces: stringslicep("space-1", "^space-2", "space-3", "^space-4")},
 		nil, nil,
 	)
@@ -446,7 +446,7 @@ func (suite *maas2EnvironSuite) TestAcquireNodeDisambiguatesNamedLabelsFromIndex
 	suite.PatchValue(&numericLabelLimit, shortLimit)
 
 	_, err := env.acquireNode2(
-		"", "",
+		"", "", "",
 		constraints.Value{Spaces: stringslicep("space-1", "^space-2", "space-3", "^space-4")},
 		[]interfaceBinding{{"0", "first-clash"}, {"1", "final-clash"}},
 		nil,
@@ -500,7 +500,7 @@ func (suite *maas2EnvironSuite) TestAcquireNodeStorage(c *gc.C) {
 			return test.expected
 		}
 		env = suite.makeEnviron(c, nil)
-		_, err := env.acquireNode2("", "", constraints.Value{}, nil, test.volumes)
+		_, err := env.acquireNode2("", "", "", constraints.Value{}, nil, test.volumes)
 		c.Check(err, jc.ErrorIsNil)
 	}
 }
@@ -611,7 +611,7 @@ func (suite *maas2EnvironSuite) TestAcquireNodeInterfaces(c *gc.C) {
 		getPositives = func() []gomaasapi.InterfaceSpec {
 			return test.expectedPositives
 		}
-		_, err := env.acquireNode2("", "", cons, test.interfaces, nil)
+		_, err := env.acquireNode2("", "", "", cons, test.interfaces, nil)
 		if test.expectedError != "" {
 			c.Check(err, gc.ErrorMatches, test.expectedError)
 			c.Check(err, jc.Satisfies, errors.IsNotValid)
@@ -645,7 +645,7 @@ func (suite *maas2EnvironSuite) TestAcquireNodeConvertsSpaceNames(c *gc.C) {
 	cons := constraints.Value{
 		Spaces: stringslicep("foo", "^bar"),
 	}
-	_, err := env.acquireNode2("", "", cons, nil, nil)
+	_, err := env.acquireNode2("", "", "", cons, nil, nil)
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -658,7 +658,7 @@ func (suite *maas2EnvironSuite) TestAcquireNodeTranslatesSpaceNames(c *gc.C) {
 	cons := constraints.Value{
 		Spaces: stringslicep("foo-1", "^bar-3"),
 	}
-	_, err := env.acquireNode2("", "", cons, nil, nil)
+	_, err := env.acquireNode2("", "", "", cons, nil, nil)
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -668,7 +668,7 @@ func (suite *maas2EnvironSuite) TestAcquireNodeUnrecognisedSpace(c *gc.C) {
 	cons := constraints.Value{
 		Spaces: stringslicep("baz"),
 	}
-	_, err := env.acquireNode2("", "", cons, nil, nil)
+	_, err := env.acquireNode2("", "", "", cons, nil, nil)
 	c.Assert(err, gc.ErrorMatches, `unrecognised space in constraint "baz"`)
 }
 


### PR DESCRIPTION
## Description of change

Add ability to specify `system_id` as a placement directive when bootstrapping to a `MAAS`.

See referenced bug.

## QA steps

1. Get a hold of a MAAS
2. Use `maas-cli` to determine the system Id(s) of some adequate nodes.
3. Bootstrap controllers to the various node specifying them by system_id, for example:

```
juju bootstrap $MY_MAAS_PROVIDER mainmaass-controller --to system-id=$MY_MAAS_NODE_ID
```
4. juju should report that it is bootstrapping to the provided system_id. For example:

```
Launching controller instance(s) on <$MY_MAAS_PROVIDER>...
 - <$MY_MAAS_NODE_ID> (arch=amd64 mem=8G cores=4)  

```

## Documentation changes

Yes, users should be made aware of the fact that they can use `system_id(s)` as a placement directive when bootstrapping for `MAAS` providers.

## Does it affect current user workflow? CLI? API?

It should not affect existing workflows.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1709995
