### PR TITLE
state: upgrade leases before starting manager

### DIFF
--- a/state/upgrades.go
+++ b/state/upgrades.go
@@ -1212,52 +1212,53 @@ func migrateModelLeasesToGlobalTime(st *State) error {
 	coll, closer := st.db().GetCollection(leasesC)
 	defer closer()
 
-	var doc struct {
-		DocID     string `bson:"_id"`
-		Type      string `bson:"type"`
-		Namespace string `bson:"namespace"`
-		Name      string `bson:"name"`
-		Holder    string `bson:"holder"`
-		Expiry    int64  `bson:"expiry"`
-		Writer    string `bson:"writer"`
-	}
-
 	// Find all old lease/clock-skew documents, remove them
 	// and create replacement lease docs in the new format.
 	//
 	// Replacement leases are created with a duration of a
 	// minute, relative to the global time epoch.
-	var ops []txn.Op
-	iter := coll.Find(bson.D{{"type", bson.D{{"$exists", true}}}}).Iter()
-	for iter.Next(&doc) {
-		ops = append(ops, txn.Op{
-			C:      leasesC,
-			Id:     st.localID(doc.DocID),
-			Assert: txn.DocExists,
-			Remove: true,
-		})
-		if doc.Type != "lease" {
-			continue
+	err := st.db().Run(func(int) ([]txn.Op, error) {
+		var doc struct {
+			DocID     string `bson:"_id"`
+			Type      string `bson:"type"`
+			Namespace string `bson:"namespace"`
+			Name      string `bson:"name"`
+			Holder    string `bson:"holder"`
+			Expiry    int64  `bson:"expiry"`
+			Writer    string `bson:"writer"`
 		}
-		claimOps, err := lease.ClaimLeaseOps(
-			doc.Namespace,
-			doc.Name,
-			doc.Holder,
-			doc.Writer,
-			coll.Name(),
-			globalclock.GlobalEpoch(),
-			initialLeaderClaimTime,
-		)
-		if err != nil {
-			return errors.Trace(err)
+
+		var ops []txn.Op
+		iter := coll.Find(bson.D{{"type", bson.D{{"$exists", true}}}}).Iter()
+		defer iter.Close()
+		for iter.Next(&doc) {
+			ops = append(ops, txn.Op{
+				C:      coll.Name(),
+				Id:     st.localID(doc.DocID),
+				Assert: txn.DocExists,
+				Remove: true,
+			})
+			if doc.Type != "lease" {
+				continue
+			}
+			claimOps, err := lease.ClaimLeaseOps(
+				doc.Namespace,
+				doc.Name,
+				doc.Holder,
+				doc.Writer,
+				coll.Name(),
+				globalclock.GlobalEpoch(),
+				initialLeaderClaimTime,
+			)
+			if err != nil {
+				return nil, errors.Trace(err)
+			}
+			ops = append(ops, claimOps...)
 		}
-		ops = append(ops, claimOps...)
-	}
-	if err := iter.Close(); err != nil {
-		return errors.Trace(err)
-	}
-	if ops == nil {
-		return nil
-	}
-	return st.db().RunTransaction(ops)
+		if err := iter.Close(); err != nil {
+			return nil, errors.Trace(err)
+		}
+		return ops, nil
+	})
+	return errors.Annotate(err, "upgrading legacy lease documents")
 }


### PR DESCRIPTION
## Description of change

Since the lease managers are started when you
open a State object, they may be in use before
the lease upgrade step runs. This can lead to
errors, since the lease manager will choke upon
seeing the old lease documents.

To work around this, we upgrade the lease docs
just prior to starting the lease manager. When
we extract the lease managers from State, we
can drop this bit of code and rely on the upgrade
step. The upgrade step has been left in place
for this purpose.

## QA steps

1. juju bootstrap (with a juju from before lease changes - 698a34c22f2176a6de8cd24c5ea4aa5b11637069)
2. add a bunch of models
3. juju upgrade-juju -m controller (with juju from this branch)
4. confirm operational with "juju status"
5. confirm there are no "corrupt lease document" errors in the log

## Documentation changes

None.

## Bug reference

Fixes https://bugs.launchpad.net/juju/+bug/1728972