### PR TITLE
migration: Allow exporting a relation with no status

### DIFF
--- a/state/export_test.go
+++ b/state/export_test.go
@@ -557,6 +557,13 @@ func ResetMigrationMode(c *gc.C, st *State) {
 	c.Assert(err, jc.ErrorIsNil)
 }
 
+func RemoveRelationStatus(c *gc.C, rel *Relation) {
+	st := rel.st
+	ops := []txn.Op{removeStatusOp(st, rel.globalScope())}
+	err := st.db().RunTransaction(ops)
+	c.Assert(err, jc.ErrorIsNil)
+}
+
 // PrimeUnitStatusHistory will add count history elements, advancing the test clock by
 // one second for each entry.
 func PrimeUnitStatusHistory(

--- a/state/migration_export.go
+++ b/state/migration_export.go
@@ -909,10 +909,11 @@ func (e *exporter) relations() error {
 		})
 		globalKey := relation.globalScope()
 		statusArgs, err := e.statusArgs(globalKey)
-		if err != nil {
+		if err == nil {
+			exRelation.SetStatus(statusArgs)
+		} else if !errors.IsNotFound(err) {
 			return errors.Annotatef(err, "status for relation %v", relation.Id())
 		}
-		exRelation.SetStatus(statusArgs)
 
 		isRemote := false
 		for _, ep := range relation.Endpoints() {


### PR DESCRIPTION
## Description of change

If a model has been migrated from a controller of a Juju version before
relation.Status was introduced, relations won't have status
records. This would cause the export to fail and a migration to be aborted.
Allow the model to be migrated even if no status is found. (We can't
easily add a relation status at import time if the incoming model doesn't 
have one because it's not clear what the status should be.)

## QA steps

Bootstrap a 2.2.6 controller (A) and two controllers with this change (B and C).
Add model m to A.
Deploy mysql and wordpress to A and relate them.
Migrate m to B, and then migrate it to C - it should migrate successfully.

## Bug reference

Fixes https://bugs.launchpad.net/juju/+bug/1729488
