### PR TITLE
state: fetch lease managers lazily

### DIFF
--- a/state/leadership.go
+++ b/state/leadership.go
@@ -28,13 +28,21 @@ func leadershipSettingsKey(applicationId string) string {
 // LeadershipClaimer returns a leadership.Claimer for units and services in the
 // state's model.
 func (st *State) LeadershipClaimer() leadership.Claimer {
-	return leadershipClaimer{st.workers.leadershipManager()}
+	return leadershipClaimer{
+		lazyLeaseManager{func() *lease.Manager {
+			return st.workers.leadershipManager()
+		}},
+	}
 }
 
 // LeadershipChecker returns a leadership.Checker for units and services in the
 // state's model.
 func (st *State) LeadershipChecker() leadership.Checker {
-	return leadershipChecker{st.workers.leadershipManager()}
+	return leadershipChecker{
+		lazyLeaseManager{func() *lease.Manager {
+			return st.workers.leadershipManager()
+		}},
+	}
 }
 
 // buildTxnWithLeadership returns a transaction source that combines the supplied source
@@ -83,14 +91,14 @@ func (leadershipSecretary) CheckDuration(duration time.Duration) error {
 	return nil
 }
 
-// leadershipChecker implements leadership.Checker by wrapping a LeaseManager.
+// leadershipChecker implements leadership.Checker by wrapping a lease.Checker.
 type leadershipChecker struct {
-	manager *lease.Manager
+	checker corelease.Checker
 }
 
 // LeadershipCheck is part of the leadership.Checker interface.
 func (m leadershipChecker) LeadershipCheck(applicationname, unitName string) leadership.Token {
-	token := m.manager.Token(applicationname, unitName)
+	token := m.checker.Token(applicationname, unitName)
 	return leadershipToken{
 		applicationname: applicationname,
 		unitName:        unitName,
@@ -114,14 +122,14 @@ func (t leadershipToken) Check(out interface{}) error {
 	return errors.Trace(err)
 }
 
-// leadershipClaimer implements leadership.Claimer by wrappping a LeaseManager.
+// leadershipClaimer implements leadership.Claimer by wrappping a lease.Claimer.
 type leadershipClaimer struct {
-	manager *lease.Manager
+	claimer corelease.Claimer
 }
 
 // ClaimLeadership is part of the leadership.Claimer interface.
 func (m leadershipClaimer) ClaimLeadership(applicationname, unitName string, duration time.Duration) error {
-	err := m.manager.Claim(applicationname, unitName, duration)
+	err := m.claimer.Claim(applicationname, unitName, duration)
 	if errors.Cause(err) == corelease.ErrClaimDenied {
 		return leadership.ErrClaimDenied
 	}
@@ -130,6 +138,6 @@ func (m leadershipClaimer) ClaimLeadership(applicationname, unitName string, dur
 
 // BlockUntilLeadershipReleased is part of the leadership.Claimer interface.
 func (m leadershipClaimer) BlockUntilLeadershipReleased(applicationname string) error {
-	err := m.manager.WaitUntilExpired(applicationname)
+	err := m.claimer.WaitUntilExpired(applicationname)
 	return errors.Trace(err)
 }

--- a/state/lease/client.go
+++ b/state/lease/client.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/juju/juju/core/lease"
 	"github.com/juju/juju/mongo"
+	"github.com/juju/juju/wrench"
 )
 
 // NewClient returns a new Client using the supplied config, or an error. Any
@@ -178,6 +179,9 @@ func (client *client) Refresh() error {
 
 func (client *client) refresh(refreshGlobalTime bool) error {
 	client.logger.Tracef("refreshing")
+	if wrench.IsActive("lease", "refresh") {
+		return errors.New("wrench active")
+	}
 
 	collection, closer := client.config.Mongo.GetCollection(client.config.Collection)
 	defer closer()

--- a/state/singular.go
+++ b/state/singular.go
@@ -9,7 +9,8 @@ import (
 	"github.com/juju/errors"
 	"gopkg.in/juju/names.v2"
 
-	"github.com/juju/juju/core/lease"
+	corelease "github.com/juju/juju/core/lease"
+	"github.com/juju/juju/worker/lease"
 )
 
 // singularSecretary implements lease.Secretary to restrict claims to either
@@ -52,6 +53,8 @@ func (s singularSecretary) CheckDuration(duration time.Duration) error {
 
 // SingularClaimer returns a lease.Claimer representing the exclusive right to
 // manage the environment.
-func (st *State) SingularClaimer() lease.Claimer {
-	return st.workers.singularManager()
+func (st *State) SingularClaimer() corelease.Claimer {
+	return lazyLeaseManager{func() *lease.Manager {
+		return st.workers.singularManager()
+	}}
 }

--- a/state/singular_test.go
+++ b/state/singular_test.go
@@ -6,6 +6,7 @@ package state_test
 import (
 	"time"
 
+	gitjujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
@@ -96,4 +97,16 @@ func (s *SingularSuite) TestExpire(c *gc.C) {
 
 	err = claimer.Claim(s.modelTag.Id(), "machine-456", time.Minute)
 	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *SingularSuite) TestSingularClaimerRestarts(c *gc.C) {
+	claimer := s.State.SingularClaimer()
+
+	// SetClockForTesting will restart the workers, and
+	// will have replaced them by the time it returns.
+	s.State.SetClockForTesting(gitjujutesting.NewClock(time.Time{}))
+
+	err := claimer.Claim(s.modelTag.Id(), "machine-123", time.Minute)
+	c.Assert(err, jc.ErrorIsNil)
+
 }

--- a/state/workers.go
+++ b/state/workers.go
@@ -170,3 +170,25 @@ func (ws *workers) allModelManager(pool *StatePool) *storeManager {
 	})
 	return ws.allModelManager(pool)
 }
+
+// lazyLeaseManager wraps one of workers.singularManager or
+// workers.leadershipManager, and calls it in the method calls.
+// This enables the manager to use restarted lease managers.
+type lazyLeaseManager struct {
+	leaseManager func() *lease.Manager
+}
+
+// Claim is part of the lease.Claimer interface.
+func (l lazyLeaseManager) Claim(leaseName, holderName string, duration time.Duration) error {
+	return l.leaseManager().Claim(leaseName, holderName, duration)
+}
+
+// WaitUntilExpired is part of the lease.Claimer interface.
+func (l lazyLeaseManager) WaitUntilExpired(leaseName string) error {
+	return l.leaseManager().WaitUntilExpired(leaseName)
+}
+
+// Token is part of the lease.Checker interface.
+func (l lazyLeaseManager) Token(leaseName, holderName string) corelease.Token {
+	return l.leaseManager().Token(leaseName, holderName)
+}


### PR DESCRIPTION
## Description of change

If a consumer obtains a lease/leadership
claimer from State, it should reasonably
expect that the claimer is valid until
the State object is closed. Currently,
the claimers are forever broken once the
internal lease manager worker exits.

We change the claimers returned by State
to lazily fetch the internal worker,
so that a call to Claim, etc. will get
a new internal worker if the old one
exited due to an error.

## QA steps

1. juju bootstrap localhost
2. juju enable-ha
(wait)
3. for x in 0 1 2; do juju ssh $x "sudo mkdir /var/lib/juju/wrench && echo refresh | sudo tee /var/lib/juju/wrench/lease"; done
(wait for the is-responsible-flag workers to exit with a "lease manager stopped" error)
4. for x in 0 1 2; do juju ssh $x "sudo rm /var/lib/juju/wrench/lease"; done
(wait for is-responsible-flag to become happy again)

## Documentation changes

None.

## Bug reference

None.