### PR TITLE
Fixes lp#1728559: Updated help to reflect new world.

### DIFF
--- a/cmd/juju/crossmodel/show.go
+++ b/cmd/juju/crossmodel/show.go
@@ -14,16 +14,30 @@ import (
 )
 
 const showCommandDoc = `
-Show extended information about an offered application.
-
-This command is aimed for a user who wants to see more detail about what’s offered behind a particular URL.
+This command is intended to enable users to learn more about the
+application offered from a particular URL. In addition to the URL of
+the offer, extra information is provided from the readme file of the
+charm being offered.
 
 Examples:
-   $ juju show-offer fred/prod.db2
-   $ juju show-offer anothercontroller:fred/prod.db2
+To show the extended information for the application 'prod' offered
+from the model 'default' on the same Juju controller:
+
+     juju show-offer default.prod
+
+The supplied URL can also include a username where offers require them. This will be given as part of the URL retrieved from the
+'juju find-offers' command. To show information for the application
+'prod' from the model 'default' as the user 'admin':
+
+    juju show-offer admin/default.prod
+
+To show the information regarding the application 'prod' offered from
+the model 'default' on an accessible controller named 'controller':
+
+    juju show-offer controller:default.prod
 
 See also:
-   find-offers
+  find-offers
 `
 
 type showCommand struct {
@@ -57,7 +71,8 @@ func (c *showCommand) Init(args []string) (err error) {
 func (c *showCommand) Info() *cmd.Info {
 	return &cmd.Info{
 		Name:    "show-offer",
-		Purpose: "Shows offered applications' endpoints details.",
+		Args:    "[<controller>:]<offer url>",
+		Purpose: "Shows extended information about the offered application.",
 		Doc:     showCommandDoc,
 	}
 }

--- a/cmd/juju/crossmodel/show.go
+++ b/cmd/juju/crossmodel/show.go
@@ -25,9 +25,10 @@ from the model 'default' on the same Juju controller:
 
      juju show-offer default.prod
 
-The supplied URL can also include a username where offers require them. This will be given as part of the URL retrieved from the
+The supplied URL can also include a username where offers require them. 
+This will be given as part of the URL retrieved from the
 'juju find-offers' command. To show information for the application
-'prod' from the model 'default' as the user 'admin':
+'prod' from the model 'default' from the user 'admin':
 
     juju show-offer admin/default.prod
 


### PR DESCRIPTION
## Description of change

Help on show-offer was outdated. This PR updates help to reflect current reality.

## QA steps

'juju help show-offer' makes sense and should look like this: https://pastebin.canonical.com/202240/

## Bug reference

https://bugs.launchpad.net/juju/+bug/1728559
