### PR TITLE
migrations: ensure units have relation scopes in precheck

### DIFF
--- a/migration/precheck.go
+++ b/migration/precheck.go
@@ -31,6 +31,7 @@ type PrecheckBackend interface {
 	IsMigrationActive(string) (bool, error)
 	AllMachines() ([]PrecheckMachine, error)
 	AllApplications() ([]PrecheckApplication, error)
+	AllRelations() ([]PrecheckRelation, error)
 	ControllerBackend() (PrecheckBackendCloser, error)
 	CloudCredential(tag names.CloudCredentialTag) (cloud.Credential, error)
 	ListPendingResources(string) ([]resource.Resource, error)
@@ -92,6 +93,20 @@ type PrecheckUnit interface {
 	AgentStatus() (status.StatusInfo, error)
 	Status() (status.StatusInfo, error)
 	AgentPresence() (bool, error)
+}
+
+// PrecheckRelation describes the state interface for relations needed
+// for prechecks.
+type PrecheckRelation interface {
+	Endpoints() []state.Endpoint
+	Unit(PrecheckUnit) (PrecheckRelationUnit, error)
+}
+
+// PrecheckRelationUnit describes the interface for relation units
+// needed for migration prechecks.
+type PrecheckRelationUnit interface {
+	Valid() (bool, error)
+	InScope() (bool, error)
 }
 
 // SourcePrecheck checks the state of the source controller to make

--- a/migration/precheck_shim.go
+++ b/migration/precheck_shim.go
@@ -88,6 +88,18 @@ func (s *precheckShim) AllApplications() ([]PrecheckApplication, error) {
 	return out, nil
 }
 
+func (s *precheckShim) AllRelations() ([]PrecheckRelation, error) {
+	rels, err := s.State.AllRelations()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	var out []PrecheckRelation
+	for _, rel := range rels {
+		out = append(out, &precheckRelationShim{rel})
+	}
+	return out, nil
+}
+
 // ListPendingResources implements PrecheckBackend.
 func (s *precheckShim) ListPendingResources(app string) ([]resource.Resource, error) {
 	resources, err := s.resourcesSt.ListPendingResources(app)
@@ -147,4 +159,22 @@ func (s *precheckAppShim) AllUnits() ([]PrecheckUnit, error) {
 		out = append(out, unit)
 	}
 	return out, nil
+}
+
+// precheckRelationShim implements PrecheckRelation.
+type precheckRelationShim struct {
+	*state.Relation
+}
+
+// Unit implements PreCheckRelation.
+func (s *precheckRelationShim) Unit(pu PrecheckUnit) (PrecheckRelationUnit, error) {
+	u, ok := pu.(*state.Unit)
+	if !ok {
+		return nil, errors.Errorf("got %T instead of *state.Unit", pu)
+	}
+	ru, err := s.Relation.Unit(u)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return ru, nil
 }

--- a/migration/precheck_test.go
+++ b/migration/precheck_test.go
@@ -315,6 +315,76 @@ func (s *SourcePrecheckSuite) TestProvisioningControllerMachine(c *gc.C) {
 	c.Assert(err.Error(), gc.Equals, "controller: machine 0 not running (allocating)")
 }
 
+func (s *SourcePrecheckSuite) TestUnitsAllInScope(c *gc.C) {
+	backend := newHappyBackend()
+	backend.relations = []migration.PrecheckRelation{&fakeRelation{
+		endpoints: []state.Endpoint{
+			{ApplicationName: "foo"},
+			{ApplicationName: "bar"},
+		},
+		relUnits: map[string]*fakeRelationUnit{
+			"foo/0": {valid: true, inScope: true},
+			"bar/0": {valid: true, inScope: true},
+			"bar/1": {valid: true, inScope: true},
+		},
+	}}
+	err := migration.SourcePrecheck(backend)
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *SourcePrecheckSuite) TestSubordinatesNotYetInScope(c *gc.C) {
+	backend := newHappyBackend()
+	backend.relations = []migration.PrecheckRelation{&fakeRelation{
+		key: "foo:db bar:db",
+		endpoints: []state.Endpoint{
+			{ApplicationName: "foo"},
+			{ApplicationName: "bar"},
+		},
+		relUnits: map[string]*fakeRelationUnit{
+			"foo/0": {valid: true, inScope: true},
+			"bar/0": {valid: true, inScope: true},
+			"bar/1": {valid: true, inScope: false},
+		},
+	}}
+	err := migration.SourcePrecheck(backend)
+	c.Assert(err, gc.ErrorMatches, "unit bar/1 hasn't joined relation foo:db bar:db yet")
+}
+
+func (s *SourcePrecheckSuite) TestSubordinatesInvalidUnitsNotYetInScope(c *gc.C) {
+	backend := newHappyBackend()
+	backend.relations = []migration.PrecheckRelation{&fakeRelation{
+		key: "foo:db bar:db",
+		endpoints: []state.Endpoint{
+			{ApplicationName: "foo"},
+			{ApplicationName: "bar"},
+		},
+		relUnits: map[string]*fakeRelationUnit{
+			"foo/0": {valid: true, inScope: true},
+			"bar/0": {valid: true, inScope: true},
+			"bar/1": {valid: false, inScope: false},
+		},
+	}}
+	err := migration.SourcePrecheck(backend)
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *SourcePrecheckSuite) TestCrossModelUnitsNotYetInScope(c *gc.C) {
+	backend := newHappyBackend()
+	backend.relations = []migration.PrecheckRelation{&fakeRelation{
+		key:        "foo:db bar:db",
+		crossModel: true,
+		endpoints: []state.Endpoint{
+			{ApplicationName: "foo"},
+			{ApplicationName: "remote-mysql"},
+		},
+		relUnits: map[string]*fakeRelationUnit{
+			"foo/0": {valid: true, inScope: false},
+		},
+	}}
+	err := migration.SourcePrecheck(backend)
+	c.Assert(err, jc.ErrorIsNil)
+}
+
 type TargetPrecheckSuite struct {
 	precheckBaseSuite
 	modelInfo coremigration.ModelInfo
@@ -661,6 +731,9 @@ type fakeBackend struct {
 	apps       []migration.PrecheckApplication
 	allAppsErr error
 
+	relations  []migration.PrecheckRelation
+	allRelsErr error
+
 	credentials    cloud.Credential
 	credentialsErr error
 
@@ -708,7 +781,10 @@ func (b *fakeBackend) AllMachines() ([]migration.PrecheckMachine, error) {
 
 func (b *fakeBackend) AllApplications() ([]migration.PrecheckApplication, error) {
 	return b.apps, b.allAppsErr
+}
 
+func (b *fakeBackend) AllRelations() ([]migration.PrecheckRelation, error) {
+	return b.relations, b.allRelsErr
 }
 
 func (b *fakeBackend) ListPendingResources(app string) ([]resource.Resource, error) {
@@ -922,4 +998,42 @@ func (u *fakeUnit) Status() (status.StatusInfo, error) {
 
 func (u *fakeUnit) AgentPresence() (bool, error) {
 	return !u.lost, nil
+}
+
+type fakeRelation struct {
+	key           string
+	crossModel    bool
+	crossModelErr error
+	endpoints     []state.Endpoint
+	relUnits      map[string]*fakeRelationUnit
+	unitErr       error
+}
+
+func (r *fakeRelation) String() string {
+	return r.key
+}
+
+func (r *fakeRelation) IsCrossModel() (bool, error) {
+	return r.crossModel, r.crossModelErr
+}
+
+func (r *fakeRelation) Endpoints() []state.Endpoint {
+	return r.endpoints
+}
+
+func (r *fakeRelation) Unit(u migration.PrecheckUnit) (migration.PrecheckRelationUnit, error) {
+	return r.relUnits[u.Name()], r.unitErr
+}
+
+type fakeRelationUnit struct {
+	valid, inScope     bool
+	validErr, scopeErr error
+}
+
+func (ru *fakeRelationUnit) Valid() (bool, error) {
+	return ru.valid, ru.validErr
+}
+
+func (ru *fakeRelationUnit) InScope() (bool, error) {
+	return ru.inScope, ru.scopeErr
 }


### PR DESCRIPTION
## Description of change

We were seeing CI migration tests fail because the migration was being
started before subordinate units had entered their relation's scope. Add
a precheck for this situation so that the user can see that they need to
wait for the units to finish coming up (rather than the migration
aborting for a cryptic reason).

## QA steps

Bootstrap 2 controllers A and B.
Create model m in A.
Deploy ubuntu and ntp to m but don't relate them immediately.
Once the ubuntu unit is fully ready and idle, relate ntp and ubuntu, and immediately start repeatedly trying to migrate m to B.
You'll see a variety of pre-migration check errors, including:
`ERROR source prechecks failed: unit ntp/0 hasn't joined relation ntp:ntp-peers yet`
Eventually the unit will be ready and the migration will run successfully.

## Bug reference
Example of failed test run:
http://qa.jujucharms.com/releases/5851/job/model-migration-lxd/attempt/2111
