### PR TITLE
Remove script mention.

### DIFF
--- a/cmd/juju/commands/upgradejuju.go
+++ b/cmd/juju/commands/upgradejuju.go
@@ -107,7 +107,7 @@ func (c *upgradeJujuCommand) SetFlags(f *gnuflag.FlagSet) {
 	f.BoolVar(&c.AssumeYes, "y", false, "Answer 'yes' to confirmation prompts")
 	f.BoolVar(&c.AssumeYes, "yes", false, "")
 	f.BoolVar(&c.IgnoreAgentVersions, "ignore-agent-versions", false,
-		"Don't check if all agents have already reached the current version (pre-2.2.6 controllers will ignore this flag, use 'juju-force-upgrade' script)")
+		"Don't check if all agents have already reached the current version")
 }
 
 func (c *upgradeJujuCommand) Init(args []string) error {


### PR DESCRIPTION
## Description of change

Some internal scripts exist for troubleshooting and support. None of them are part of the official Juju build.
We should not mention them in commands help. 
