### PR TITLE
Fix bug#1726226

### DIFF
--- a/provider/gce/credentials_test.go
+++ b/provider/gce/credentials_test.go
@@ -72,7 +72,7 @@ func (s *credentialsSuite) TestJSONFileCredentialsValid(c *gc.C) {
 	})
 }
 
-func createCredsFile(c *gc.C, path string) string {
+func createCredsFile(c *gc.C, path string) (string, string) {
 	if path == "" {
 		dir := c.MkDir()
 		path = filepath.Join(dir, "creds.json")
@@ -81,29 +81,29 @@ func createCredsFile(c *gc.C, path string) string {
 	c.Assert(err, jc.ErrorIsNil)
 	err = ioutil.WriteFile(path, creds.JSONKey, 0644)
 	c.Assert(err, jc.ErrorIsNil)
-	return path
+	return path, string(creds.JSONKey)
 }
 
 func (s *credentialsSuite) TestDetectCredentialsFromEnvVar(c *gc.C) {
-	jsonpath := createCredsFile(c, "")
+	jsonpath, json := createCredsFile(c, "")
 	s.PatchEnvironment("USER", "fred")
 	s.PatchEnvironment("GOOGLE_APPLICATION_CREDENTIALS", jsonpath)
 	s.PatchEnvironment("CLOUDSDK_COMPUTE_REGION", "region")
 	credentials, err := s.provider.DetectCredentials()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(credentials.DefaultRegion, gc.Equals, "region")
-	expected := cloud.NewCredential(cloud.JSONFileAuthType, map[string]string{"file": jsonpath})
+	expected := cloud.NewCredential(cloud.JSONFileAuthType, map[string]string{"file": json})
 	expected.Label = `google credential "test@example.com"`
 	c.Assert(credentials.AuthCredentials["fred"], jc.DeepEquals, expected)
 }
 
-func (s *credentialsSuite) assertDetectCredentialsKnownLocation(c *gc.C, jsonpath string) {
+func (s *credentialsSuite) assertDetectCredentialsKnownLocation(c *gc.C, jsonpath string, jsonContent string) {
 	s.PatchEnvironment("USER", "fred")
 	s.PatchEnvironment("CLOUDSDK_COMPUTE_REGION", "region")
 	credentials, err := s.provider.DetectCredentials()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(credentials.DefaultRegion, gc.Equals, "region")
-	expected := cloud.NewCredential(cloud.JSONFileAuthType, map[string]string{"file": jsonpath})
+	expected := cloud.NewCredential(cloud.JSONFileAuthType, map[string]string{"file": jsonContent})
 	expected.Label = `google credential "test@example.com"`
 	c.Assert(credentials.AuthCredentials["fred"], jc.DeepEquals, expected)
 }
@@ -123,8 +123,8 @@ func (s *credentialsSuite) TestDetectCredentialsKnownLocationUnix(c *gc.C) {
 	path := filepath.Join(dir, ".config", "gcloud")
 	err = os.MkdirAll(path, 0700)
 	c.Assert(err, jc.ErrorIsNil)
-	jsonpath := createCredsFile(c, filepath.Join(path, "application_default_credentials.json"))
-	s.assertDetectCredentialsKnownLocation(c, jsonpath)
+	jsonpath, json := createCredsFile(c, filepath.Join(path, "application_default_credentials.json"))
+	s.assertDetectCredentialsKnownLocation(c, jsonpath, json)
 }
 
 func (s *credentialsSuite) TestDetectCredentialsKnownLocationWindows(c *gc.C) {
@@ -136,6 +136,6 @@ func (s *credentialsSuite) TestDetectCredentialsKnownLocationWindows(c *gc.C) {
 	path := filepath.Join(dir, "gcloud")
 	err := os.MkdirAll(path, 0700)
 	c.Assert(err, jc.ErrorIsNil)
-	jsonpath := createCredsFile(c, filepath.Join(path, "application_default_credentials.json"))
-	s.assertDetectCredentialsKnownLocation(c, jsonpath)
+	jsonpath, json := createCredsFile(c, filepath.Join(path, "application_default_credentials.json"))
+	s.assertDetectCredentialsKnownLocation(c, jsonpath, json)
 }

--- a/provider/gce/environ.go
+++ b/provider/gce/environ.go
@@ -105,7 +105,7 @@ func newEnviron(cloud environs.CloudSpec, cfg *config.Config) (*environ, error) 
 	credAttrs := cloud.Credential.Attributes()
 	if cloud.Credential.AuthType() == jujucloud.JSONFileAuthType {
 		contents := credAttrs[credAttrFile]
-		credential, err := parseJSONAuthFile(strings.NewReader(contents))
+		credential, _, err := parseJSONAuthFile(strings.NewReader(contents))
 		if err != nil {
 			return nil, errors.Trace(err)
 		}


### PR DESCRIPTION
## Description of change

When bootstrapiping a controller on `GCE` with `JUJU_DATA` set to the path of an empty directory, Juju will try to look for a path to a file holding `GCE` credentials in the environment variable `GOOGLE_APPLICATION_CREDENTIALS`. Juju incorrectly tries to use the file path itself as the credentials instead of using the contents of that file. This PR fixes that error.  

## Why is this change needed?

Fixes referenced bug.

## QA steps

1. set `GOOGLE_APPLICATION_CREDENTIALS` to the path of your application credentials.
2. set `JUJU_DATA` to an empty directory (this way juju looks in that directory and not the place where it might have been configured to look which may hold the correct credentials file. `Juju`will find nothing in the empty directory and defer to the environment.)
3. You should see your controller successfully bootstrap on `GCE` whereas without this patch it would error expecting the file path string to be valid `JSON`.

## Documentation changes

N/A

## Does it affect current user workflow? CLI? API?

No

## Bug reference

https://bugs.launchpad.net/juju/+bug/1726226
