### PR TITLE
Fix BUG 1721545 oracle provider should clean up with same id used

### DIFF
--- a/provider/oracle/environ.go
+++ b/provider/oracle/environ.go
@@ -79,15 +79,6 @@ type EnvironAPI interface {
 	StorageAPI
 }
 
-func (o *OracleEnviron) SetEnvironAPI(client EnvironAPI) {
-	if o == nil {
-		return
-	}
-	o.mutex.Lock()
-	defer o.mutex.Unlock()
-	o.client = client
-}
-
 // AvailabilityZones is defined in the common.ZonedEnviron interface
 func (o *OracleEnviron) AvailabilityZones() ([]common.AvailabilityZone, error) {
 	return []common.AvailabilityZone{

--- a/provider/oracle/export_test.go
+++ b/provider/oracle/export_test.go
@@ -3,7 +3,9 @@
 
 package oracle
 
-import "github.com/juju/juju/storage"
+import (
+	"github.com/juju/juju/storage"
+)
 
 var (
 	DefaultTypes               = []storage.ProviderType{DefaultStorageProviderType}
@@ -20,3 +22,16 @@ var (
 	ParseImageName             = parseImageName
 	CheckImageList             = checkImageList
 )
+
+func SetEnvironAPI(o *OracleEnviron, client EnvironAPI) {
+	if o == nil {
+		return
+	}
+	o.mutex.Lock()
+	defer o.mutex.Unlock()
+	o.client = client
+}
+
+func CreateHostname(o *OracleEnviron, id string) (string, error) {
+	return o.namespace.Hostname(id)
+}

--- a/provider/oracle/instance.go
+++ b/provider/oracle/instance.go
@@ -204,17 +204,28 @@ func (o *oracleInstance) deleteInstanceAndResources(cleanup bool) error {
 			break
 		}
 
+		//
+		// seclist, vnicset, secrules, and acl created with
+		// StartInstanceParams.InstanceConfig.MachineId,
+		// convert o.Id() to machineId for deletion.
+		// o.Id() returns a string in hostname form.
+		tag, err := o.env.namespace.MachineTag(string(o.Id()))
+		if err != nil {
+			return errors.Annotatef(err, "failed to get a machine tag to complete cleanup of instance")
+		}
+		machineId := tag.Id()
+
 		// the VM association is now gone, now we can delete the
 		// machine sec list
-		logger.Debugf("deleting seclist for instance: %s", string(o.Id()))
-		if err := o.env.DeleteMachineSecList(string(o.Id())); err != nil {
+		logger.Debugf("deleting seclist for instance: %s", machineId)
+		if err := o.env.DeleteMachineSecList(machineId); err != nil {
 			logger.Errorf("failed to delete seclist: %s", err)
 			if !oci.IsMethodNotAllowed(err) {
 				return errors.Trace(err)
 			}
 		}
-		logger.Debugf("deleting vnic set for instance: %s", string(o.Id()))
-		if err := o.env.DeleteMachineVnicSet(string(o.Id())); err != nil {
+		logger.Debugf("deleting vnic set for instance: %s", machineId)
+		if err := o.env.DeleteMachineVnicSet(machineId); err != nil {
 			logger.Errorf("failed to delete vnic set: %s", err)
 			if !oci.IsMethodNotAllowed(err) {
 				return errors.Trace(err)

--- a/provider/oracle/instance_test.go
+++ b/provider/oracle/instance_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/config"
+	"github.com/juju/juju/instance"
 	jujunetwork "github.com/juju/juju/network"
 	"github.com/juju/juju/provider/oracle"
 	oracletesting "github.com/juju/juju/provider/oracle/testing"
@@ -41,7 +42,7 @@ func (i *instanceSuite) SetUpTest(c *gc.C) {
 func (i *instanceSuite) setEnvironAPI(client oracle.EnvironAPI) {
 	i.mutex.Lock()
 	defer i.mutex.Unlock()
-	i.env.SetEnvironAPI(client)
+	oracle.SetEnvironAPI(i.env, client)
 }
 
 var _ = gc.Suite(&instanceSuite{})
@@ -59,13 +60,11 @@ func (i instanceSuite) TestNewOracleInstance(c *gc.C) {
 }
 
 func (i instanceSuite) TestId(c *gc.C) {
-	instance, err := oracle.NewOracleInstance(oracletesting.DefaultFakeInstancer.Instance, i.env)
+	inst, err := oracle.NewOracleInstance(oracletesting.DefaultFakeInstancer.Instance, i.env)
 	c.Assert(err, gc.IsNil)
-	c.Assert(instance, gc.NotNil)
-
-	id := instance.Id()
-	ok := (len(id) > 0)
-	c.Assert(ok, gc.Equals, true)
+	c.Assert(inst, gc.NotNil)
+	id := inst.Id()
+	c.Assert(id, gc.Equals, instance.Id("0"))
 }
 
 func (i instanceSuite) TestStatus(c *gc.C) {
@@ -112,7 +111,7 @@ func (i instanceSuite) TestAddressesWithErrors(c *gc.C) {
 	c.Assert(instance, gc.NotNil)
 
 	_, err = instance.Addresses()
-	c.Assert(err, gc.NotNil)
+	c.Assert(err, gc.ErrorMatches, "FakeEnvironAPI")
 }
 
 func (i instanceSuite) TestOpenPorts(c *gc.C) {

--- a/provider/oracle/storage_volumes_test.go
+++ b/provider/oracle/storage_volumes_test.go
@@ -29,6 +29,9 @@ var _ = gc.Suite(&oracleVolumeSource{})
 func (s *oracleVolumeSource) SetUpTest(c *gc.C) {
 	s.BaseSuite.SetUpTest(c)
 	oracletesting.DefaultFakeStorageAPI.ResetCalls()
+	// Reset name from changes in environ_test SetUpTest()
+	// not required here.
+	oracletesting.DefaultEnvironAPI.FakeInstance.All.Result[0].Name = "/Compute-a432100/sgiulitti@cloudbase.com/0/ebc4ce91-56bb-4120-ba78-13762597f837"
 }
 
 func (o *oracleVolumeSource) NewVolumeSource(


### PR DESCRIPTION
to create seclists, secrules, vnicsets and acls.

## Description of change

Why is this change needed?

## QA steps

Bootstrap and destroy a controller in the oracle cloud.
Check count of vnicsets, acls, sec lists and secrules, should be 0, provided cleaned up before starting.

## Documentation changes

N/A

## Bug reference

https://bugs.launchpad.net/juju/+bug/1721545