### PR TITLE
Fixes lp#1627030: Renaming *-tools commands to *-agents, making old names into aliases.

### DIFF
--- a/cmd/juju/block/doc.go
+++ b/cmd/juju/block/doc.go
@@ -44,7 +44,7 @@ Commands that can be disabled are grouped based on logical operations as follows
     retry-provisioning
     run
     set-constraints
-    sync-tools
+    sync-agents
     unexpose
     upgrade-charm
     upgrade-juju

--- a/cmd/juju/commands/main_test.go
+++ b/cmd/juju/commands/main_test.go
@@ -47,7 +47,7 @@ func configHelpText() string {
 }
 
 func syncToolsHelpText() string {
-	return cmdtesting.HelpText(newSyncToolsCommand(), "juju sync-tools")
+	return cmdtesting.HelpText(newSyncToolsCommand(), "juju sync-agents")
 }
 
 func (s *MainSuite) TestRunMain(c *gc.C) {
@@ -113,8 +113,8 @@ func (s *MainSuite) TestRunMain(c *gc.C) {
 		code:    2,
 		out:     "ERROR flag provided but not defined: --model\n",
 	}, {
-		summary: "juju sync-tools registered properly",
-		args:    []string{"sync-tools", "--help"},
+		summary: "juju sync-agents registered properly",
+		args:    []string{"sync-agents", "--help"},
 		code:    0,
 		out:     syncToolsHelpText(),
 	}, {
@@ -544,6 +544,7 @@ var commandNames = []string{
 	"subnets",
 	"suspend-relation",
 	"switch",
+	"sync-agents",
 	"sync-tools",
 	"unexpose",
 	"unregister",

--- a/cmd/juju/commands/main_test.go
+++ b/cmd/juju/commands/main_test.go
@@ -47,7 +47,7 @@ func configHelpText() string {
 }
 
 func syncToolsHelpText() string {
-	return cmdtesting.HelpText(newSyncToolsCommand(), "juju sync-agents")
+	return cmdtesting.HelpText(newSyncToolsCommand(), "juju sync-agent-binaries")
 }
 
 func (s *MainSuite) TestRunMain(c *gc.C) {
@@ -113,8 +113,8 @@ func (s *MainSuite) TestRunMain(c *gc.C) {
 		code:    2,
 		out:     "ERROR flag provided but not defined: --model\n",
 	}, {
-		summary: "juju sync-agents registered properly",
-		args:    []string{"sync-agents", "--help"},
+		summary: "juju sync-agent-binaries registered properly",
+		args:    []string{"sync-agent-binaries", "--help"},
 		code:    0,
 		out:     syncToolsHelpText(),
 	}, {
@@ -544,7 +544,7 @@ var commandNames = []string{
 	"subnets",
 	"suspend-relation",
 	"switch",
-	"sync-agents",
+	"sync-agent-binaries",
 	"sync-tools",
 	"unexpose",
 	"unregister",

--- a/cmd/juju/commands/synctools.go
+++ b/cmd/juju/commands/synctools.go
@@ -57,13 +57,13 @@ the software.
 
 Examples:
     # Download the software (version auto-selected) to the model:
-    juju sync-agents --debug
+    juju sync-agent-binaries --debug
 
     # Download a specific version of the software locally:
-    juju sync-agents --debug --version 2.0 --local-dir=/home/ubuntu/sync-agents
+    juju sync-agent-binaries --debug --version 2.0 --local-dir=/home/ubuntu/sync-agent-binaries
 
     # Get locally available software to the model:
-    juju sync-agents --debug --source=/home/ubuntu/sync-agents
+    juju sync-agent-binaries --debug --source=/home/ubuntu/sync-agent-binaries
 
 See also:
     upgrade-juju
@@ -72,7 +72,7 @@ See also:
 
 func (c *syncToolsCommand) Info() *cmd.Info {
 	return &cmd.Info{
-		Name:    "sync-agents",
+		Name:    "sync-agent-binaries",
 		Purpose: "Copy agent binaries from the official agent store into a local model.",
 		Doc:     synctoolsDoc,
 		Aliases: []string{"sync-tools"},
@@ -127,8 +127,8 @@ func (c *syncToolsCommand) Run(ctx *cmd.Context) (resultErr error) {
 	writer := loggo.NewMinimumLevelWriter(
 		cmd.NewCommandLogWriter("juju.environs.sync", ctx.Stdout, ctx.Stderr),
 		loggo.INFO)
-	loggo.RegisterWriter("synctools", writer)
-	defer loggo.RemoveWriter("synctools")
+	loggo.RegisterWriter("syncagentbinaries", writer)
+	defer loggo.RemoveWriter("syncagentbinaries")
 
 	sctx := &sync.SyncContext{
 		AllVersions:  c.allVersions,

--- a/cmd/juju/commands/synctools.go
+++ b/cmd/juju/commands/synctools.go
@@ -57,13 +57,13 @@ the software.
 
 Examples:
     # Download the software (version auto-selected) to the model:
-    juju sync-tools --debug
+    juju sync-agents --debug
 
     # Download a specific version of the software locally:
-    juju sync-tools --debug --version 2.0 --local-dir=/home/ubuntu/sync-tools
+    juju sync-agents --debug --version 2.0 --local-dir=/home/ubuntu/sync-agents
 
     # Get locally available software to the model:
-    juju sync-tools --debug --source=/home/ubuntu/sync-tools
+    juju sync-agents --debug --source=/home/ubuntu/sync-agents
 
 See also:
     upgrade-juju
@@ -72,9 +72,10 @@ See also:
 
 func (c *syncToolsCommand) Info() *cmd.Info {
 	return &cmd.Info{
-		Name:    "sync-tools",
+		Name:    "sync-agents",
 		Purpose: "Copy agent binaries from the official agent store into a local model.",
 		Doc:     synctoolsDoc,
+		Aliases: []string{"sync-tools"},
 	}
 }
 

--- a/cmd/juju/commands/synctools_test.go
+++ b/cmd/juju/commands/synctools_test.go
@@ -55,7 +55,7 @@ func (s *syncToolsSuite) Reset(c *gc.C) {
 	s.SetUpTest(c)
 }
 
-func (s *syncToolsSuite) runSyncToolsCommand(c *gc.C, args ...string) (*cmd.Context, error) {
+func (s *syncToolsSuite) runSyncAgentBinariesCommand(c *gc.C, args ...string) (*cmd.Context, error) {
 	cmd := &syncToolsCommand{}
 	cmd.SetClientStore(s.store)
 	return cmdtesting.RunCommand(c, modelcmd.Wrap(cmd), args...)
@@ -132,7 +132,7 @@ func (s *syncToolsSuite) TestSyncToolsCommand(c *gc.C) {
 			called = true
 			return nil
 		}
-		ctx, err := s.runSyncToolsCommand(c, test.args...)
+		ctx, err := s.runSyncAgentBinariesCommand(c, test.args...)
 		c.Assert(err, jc.ErrorIsNil)
 		c.Assert(ctx, gc.NotNil)
 		c.Assert(called, jc.IsTrue)
@@ -157,7 +157,7 @@ func (s *syncToolsSuite) TestSyncToolsCommandTargetDirectory(c *gc.C) {
 		called = true
 		return nil
 	}
-	ctx, err := s.runSyncToolsCommand(c, "-m", "test-target", "--local-dir", dir, "--stream", "proposed")
+	ctx, err := s.runSyncAgentBinariesCommand(c, "-m", "test-target", "--local-dir", dir, "--stream", "proposed")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(ctx, gc.NotNil)
 	c.Assert(called, jc.IsTrue)
@@ -173,7 +173,7 @@ func (s *syncToolsSuite) TestSyncToolsCommandTargetDirectoryPublic(c *gc.C) {
 		called = true
 		return nil
 	}
-	ctx, err := s.runSyncToolsCommand(c, "-m", "test-target", "--local-dir", dir, "--public")
+	ctx, err := s.runSyncAgentBinariesCommand(c, "-m", "test-target", "--local-dir", dir, "--public")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(ctx, gc.NotNil)
 	c.Assert(called, jc.IsTrue)
@@ -204,7 +204,7 @@ func (s *syncToolsSuite) TestSyncToolsCommandDeprecatedDestination(c *gc.C) {
 		{loggo.INFO, "Use of the --destination flag is deprecated in 1.18. Please use --local-dir instead."},
 	}
 	// Run sync-agents command with --destination flag.
-	ctx, err := s.runSyncToolsCommand(c, "-m", "test-target", "--destination", dir, "--stream", "released")
+	ctx, err := s.runSyncAgentBinariesCommand(c, "-m", "test-target", "--destination", dir, "--stream", "released")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(ctx, gc.NotNil)
 	c.Assert(called, jc.IsTrue)
@@ -284,7 +284,7 @@ func (s *syncToolsSuite) TestAPIAdapterBlockUploadTools(c *gc.C) {
 		// Block operation
 		return common.OperationBlockedError("TestAPIAdapterBlockUploadTools")
 	}
-	_, err := s.runSyncToolsCommand(c, "-m", "test-target", "--destination", c.MkDir(), "--stream", "released")
+	_, err := s.runSyncAgentBinariesCommand(c, "-m", "test-target", "--destination", c.MkDir(), "--stream", "released")
 	coretesting.AssertOperationWasBlocked(c, err, ".*TestAPIAdapterBlockUploadTools.*")
 }
 

--- a/cmd/juju/commands/synctools_test.go
+++ b/cmd/juju/commands/synctools_test.go
@@ -203,7 +203,7 @@ func (s *syncToolsSuite) TestSyncToolsCommandDeprecatedDestination(c *gc.C) {
 	messages := []jc.SimpleMessage{
 		{loggo.INFO, "Use of the --destination flag is deprecated in 1.18. Please use --local-dir instead."},
 	}
-	// Run sync-tools command with --destination flag.
+	// Run sync-agents command with --destination flag.
 	ctx, err := s.runSyncToolsCommand(c, "-m", "test-target", "--destination", dir, "--stream", "released")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(ctx, gc.NotNil)

--- a/cmd/juju/commands/upgradejuju.go
+++ b/cmd/juju/commands/upgradejuju.go
@@ -47,7 +47,7 @@ specified:
  - If the server major version does not match the client major version,
  the version selected is that of the client version.
 If the controller is without internet access, the client must first supply
-the software to the controller's cache via the ` + "`juju sync-tools`" + ` command.
+the software to the controller's cache via the ` + "`juju sync-agents`" + ` command.
 The command will abort if an upgrade is in progress. It will also abort if
 a previous upgrade was not fully completed (e.g.: if one of the
 controllers in a high availability model failed to upgrade).
@@ -60,7 +60,7 @@ Examples:
     juju upgrade-juju --agent-version 2.0.1
     
 See also: 
-    sync-tools`
+    sync-agents`
 
 func newUpgradeJujuCommand(minUpgradeVers map[int]version.Number, options ...modelcmd.WrapOption) cmd.Command {
 	if minUpgradeVers == nil {

--- a/cmd/juju/commands/upgradejuju.go
+++ b/cmd/juju/commands/upgradejuju.go
@@ -47,7 +47,7 @@ specified:
  - If the server major version does not match the client major version,
  the version selected is that of the client version.
 If the controller is without internet access, the client must first supply
-the software to the controller's cache via the ` + "`juju sync-agents`" + ` command.
+the software to the controller's cache via the ` + "`juju sync-agent-binaries`" + ` command.
 The command will abort if an upgrade is in progress. It will also abort if
 a previous upgrade was not fully completed (e.g.: if one of the
 controllers in a high availability model failed to upgrade).
@@ -60,7 +60,7 @@ Examples:
     juju upgrade-juju --agent-version 2.0.1
     
 See also: 
-    sync-agents`
+    sync-agent-binaries`
 
 func newUpgradeJujuCommand(minUpgradeVers map[int]version.Number, options ...modelcmd.WrapOption) cmd.Command {
 	if minUpgradeVers == nil {

--- a/cmd/plugins/juju-metadata/metadataplugin_test.go
+++ b/cmd/plugins/juju-metadata/metadataplugin_test.go
@@ -32,11 +32,13 @@ var _ = gc.Suite(&MetadataSuite{})
 var metadataCommandNames = []string{
 	"add-image",
 	"delete-image",
+	"generate-agents",
 	"generate-image",
 	"generate-tools",
 	"help",
 	"list-images",
 	"sign",
+	"validate-agents",
 	"validate-images",
 	"validate-tools",
 }
@@ -111,7 +113,7 @@ func (s *MetadataSuite) TestHelpValidateImages(c *gc.C) {
 }
 
 func (s *MetadataSuite) TestHelpValidateTools(c *gc.C) {
-	s.assertHelpOutput(c, "validate-tools")
+	s.assertHelpOutput(c, "validate-agents")
 }
 
 func (s *MetadataSuite) TestHelpGenerateImage(c *gc.C) {

--- a/cmd/plugins/juju-metadata/toolsmetadata.go
+++ b/cmd/plugins/juju-metadata/toolsmetadata.go
@@ -26,7 +26,7 @@ func newToolsMetadataCommand() cmd.Command {
 	return modelcmd.Wrap(&toolsMetadataCommand{})
 }
 
-// toolsMetadataCommand is used to generate simplestreams metadata for juju tools.
+// toolsMetadataCommand is used to generate simplestreams metadata for juju agents.
 type toolsMetadataCommand struct {
 	modelcmd.ModelCommandBase
 	fetch       bool
@@ -37,7 +37,7 @@ type toolsMetadataCommand struct {
 }
 
 const toolsMetadataDoc = `
-generate-tools creates the simplestreams metadata for agents.
+generate-agents creates the simplestreams metadata for agents.
 
 This command works by scanning a directory for agent binary tarballs from which to generate
 simplestreams agent metadata. The working directory is specified using the -d argument
@@ -62,23 +62,24 @@ use the --clean option.
 Examples:
 
 # generate metadata for "released":
-juju metadata generate-tools -d <workingdir>
+juju metadata generate-agents -d <workingdir>
 
 # generate metadata for "released":
-juju metadata generate-tools -d <workingdir> --stream released
+juju metadata generate-agents -d <workingdir> --stream released
 
 # generate metadata for "proposed":
-juju metadata generate-tools -d <workingdir> --stream proposed
+juju metadata generate-agents -d <workingdir> --stream proposed
 
 # generate metadata for "proposed", first removing existing "proposed" metadata:
-juju metadata generate-tools -d <workingdir> --stream proposed --clean
+juju metadata generate-agents -d <workingdir> --stream proposed --clean
 `
 
 func (c *toolsMetadataCommand) Info() *cmd.Info {
 	return &cmd.Info{
-		Name:    "generate-tools",
+		Name:    "generate-agents",
 		Purpose: "generate simplestreams agent metadata",
 		Doc:     toolsMetadataDoc,
+		Aliases: []string{"generate-tools"},
 	}
 }
 
@@ -149,7 +150,7 @@ func toolsDataSources(urls ...string) []simplestreams.DataSource {
 }
 
 // This is essentially the same as tools.MergeAndWriteMetadata, but also
-// resolves metadata for existing tools by fetching them and computing
+// resolves metadata for existing agents by fetching them and computing
 // size/sha256 locally.
 func mergeAndWriteMetadata(
 	stor storage.Storage, toolsDir, stream string, clean bool, toolsList coretools.List, writeMirrors envtools.ShouldWriteMirrors,

--- a/cmd/plugins/juju-metadata/validatetoolsmetadata.go
+++ b/cmd/plugins/juju-metadata/validatetoolsmetadata.go
@@ -44,7 +44,7 @@ type validateToolsMetadataCommand struct {
 }
 
 var validateToolsMetadataDoc = `
-validate-tools loads simplestreams metadata and validates the contents by
+validate-agents loads simplestreams metadata and validates the contents by
 looking for agent binaries belonging to the specified series, architecture, for the
 specified cloud. If version is specified, agent binaries matching the exact specified
 version are found. It is also possible to just specify the major (and optionally
@@ -64,31 +64,31 @@ Examples:
 
  - validate using the current model settings but with series raring
   
-  juju metadata validate-tools -s raring
+  juju metadata validate-agents -s raring
 
  - validate using the current model settings but with Juju version 1.11.4
   
-  juju metadata validate-tools -j 1.11.4
+  juju metadata validate-agents -j 1.11.4
 
  - validate using the current model settings but with Juju major version 2
   
-  juju metadata validate-tools -m 2
+  juju metadata validate-agents -m 2
 
  - validate using the current model settings but with Juju major.minor version 2.1
  
-  juju metadata validate-tools -m 2.1
+  juju metadata validate-agents -m 2.1
 
  - validate using the current model settings and list all agent binaries found for any series
  
-  juju metadata validate-tools --series=
+  juju metadata validate-agents --series=
 
  - validate with series raring and using metadata from local directory
  
-  juju metadata validate-tools -s raring -d <some directory>
+  juju metadata validate-agents -s raring -d <some directory>
 
  - validate for the proposed stream
 
-  juju metadata validate-tools --stream proposed
+  juju metadata validate-agents --stream proposed
 
 A key use case is to validate newly generated metadata prior to deployment to
 production. In this case, the metadata is placed in a local directory, a cloud
@@ -99,7 +99,7 @@ Example bash snippet:
 
 #!/bin/bash
 
-juju metadata validate-tools -p ec2 -r us-east-1 -s precise --juju-version 1.12.0 -d <some directory>
+juju metadata validate-agents -p ec2 -r us-east-1 -s precise --juju-version 1.12.0 -d <some directory>
 RETVAL=$?
 [ $RETVAL -eq 0 ] && echo Success
 [ $RETVAL -ne 0 ] && echo Failure
@@ -107,9 +107,10 @@ RETVAL=$?
 
 func (c *validateToolsMetadataCommand) Info() *cmd.Info {
 	return &cmd.Info{
-		Name:    "validate-tools",
+		Name:    "validate-agents",
 		Purpose: "validate agent metadata and ensure agent binary tarball(s) exist for Juju version(s)",
 		Doc:     validateToolsMetadataDoc,
+		Aliases: []string{"validate-tools"},
 	}
 }
 

--- a/component/all/payload.go
+++ b/component/all/payload.go
@@ -28,7 +28,7 @@ func (c payloads) registerForServer() error {
 
 func (c payloads) registerForClient() error {
 	c.registerPublicCommands()
-	// needed for help-tool
+	// needed for hook-tool
 	c.registerHookContextCommands()
 	return nil
 }

--- a/component/all/resource.go
+++ b/component/all/resource.go
@@ -35,7 +35,7 @@ func (r resources) registerForServer() error {
 // RegisterForClient is the top-level registration method
 // for the component in a "juju" command context.
 func (r resources) registerForClient() error {
-	// needed for help-tool
+	// needed for hook-tool
 	r.registerHookContextCommands()
 	return nil
 }

--- a/doc/simplestreams-metadata.txt
+++ b/doc/simplestreams-metadata.txt
@@ -224,7 +224,7 @@ in the model config.
 
 Generally, agent binaries and related metadata are mirrored from https://streams.canonical.com/juju/tools. However,
 it is possible to manually generate metadata for a custom built agent binary tarball using:
-  juju generate-tools -d <metadata_dir> --stream <stream>
+  juju generate-agents -d <metadata_dir> --stream <stream>
 
 where the required agent binary tarballs are first placed in a directory <metadata_dir>/tools/<stream>.
 If unspecified, <stream> defaults to "released".
@@ -242,8 +242,8 @@ Note that image and agent metadata are generally written into the same local dir
 --metadata-source option will upload both types of metadata.
 
 As with image metadata, the validation command is used to ensure tools are available for Juju to use:
-  juju metadata validate-tools
+  juju metadata validate-agents
 
 The same comments apply. Run the validation tool without parameters to use details from the Juju
-model, or override values as required on the command line. See juju help metadata validate-tools
+model, or override values as required on the command line. See juju help metadata validate-agents
 for more details.


### PR DESCRIPTION
## Description of change

Command names that contain *-tools are now misleading. This PR changes their official names to contain *-agents while preserving their original names as aliases to avoid breaking scripts.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1627030
