### PR TITLE
Fixes lp#1729874: Clarify what exactly -keep-broken does and where to from here.

### DIFF
--- a/cmd/juju/commands/bootstrap.go
+++ b/cmd/juju/commands/bootstrap.go
@@ -503,11 +503,12 @@ func (c *bootstrapCommand) Run(ctx *cmd.Context) (resultErr error) {
 			if c.KeepBrokenEnvironment {
 				ctx.Infof(`
 bootstrap failed but --keep-broken was specified. 
-This means that this controller is no longer registered on your client. However,
-some cloud resources were not destroyed - you can ssh into
-the machines via their IP addresses for diagnosis and investigations.
+This means that cloud resources are left behind, but not registered to 
+your local client, as the controller was not successfully created. 
+However, you should be able to ssh into the machine using the user "ubuntu" and 
+their IP address for diagnosis and investigation.
 When you are ready to clean up the failed controller, use your cloud console or 
-equivalent CLI tools to terminate instances and remove resources. 
+equivalent CLI tools to terminate the instances and remove remaining resources. 
 
 See `[1:] + "`juju kill-controller`" + `.`)
 			} else {

--- a/cmd/juju/commands/bootstrap.go
+++ b/cmd/juju/commands/bootstrap.go
@@ -502,8 +502,13 @@ func (c *bootstrapCommand) Run(ctx *cmd.Context) (resultErr error) {
 		if resultErr != nil {
 			if c.KeepBrokenEnvironment {
 				ctx.Infof(`
-bootstrap failed but --keep-broken was specified so resources are not being destroyed.
-When you have finished diagnosing the problem, remember to clean up the failed controller.
+bootstrap failed but --keep-broken was specified. 
+This means that this controller is no longer registered on your client. However,
+some cloud resources were not destroyed - you can ssh into
+the machines via their IP addresses for diagnosis and investigations.
+When you are ready to clean up the failed controller, use your cloud console or 
+equivalent CLI tools to terminate instances and remove resources. 
+
 See `[1:] + "`juju kill-controller`" + `.`)
 			} else {
 				logger.Errorf("%v", resultErr)


### PR DESCRIPTION
## Description of change

whilst -keep-broken is an admin tool and is useful in diagnosing bootstrap failures, it's unclear what the option does and how to actually get rid of the failed controller.

This PR adds more information to failure message.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1729874
