### PR TITLE
On the consuming side of cmr, fix handling of offer revocation

### DIFF
--- a/api/crossmodelrelations/crossmodelrelations.go
+++ b/api/crossmodelrelations/crossmodelrelations.go
@@ -170,6 +170,8 @@ func (c *Client) RegisterRemoteRelations(relations ...params.RegisterRemoteRelat
 
 	var results params.RegisterRemoteRelationResults
 	apiCall := func() error {
+		// Reset the results struct before each api call.
+		results = params.RegisterRemoteRelationResults{}
 		err := c.facade.FacadeCall("RegisterRemoteRelations", args, &results)
 		if err != nil {
 			return errors.Trace(err)
@@ -210,7 +212,6 @@ func (c *Client) RegisterRemoteRelations(relations ...params.RegisterRemoteRelat
 		return result, nil
 	}
 
-	results = params.RegisterRemoteRelationResults{}
 	if err := apiCall(); err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -233,6 +234,8 @@ func (c *Client) WatchRelationUnits(remoteRelationArg params.RemoteEntityArg) (w
 
 	var results params.RelationUnitsWatchResults
 	apiCall := func() error {
+		// Reset the results struct before each api call.
+		results = params.RelationUnitsWatchResults{}
 		if err := c.facade.FacadeCall("WatchRelationUnits", args, &results); err != nil {
 			return errors.Trace(err)
 		}
@@ -290,6 +293,8 @@ func (c *Client) RelationUnitSettings(relationUnits []params.RemoteRelationUnit)
 
 	var results params.SettingsResults
 	apiCall := func() error {
+		// Reset the results struct before each api call.
+		results = params.SettingsResults{}
 		err := c.facade.FacadeCall("RelationUnitSettings", args, &results)
 		if err != nil {
 			return errors.Trace(err)
@@ -330,7 +335,6 @@ func (c *Client) RelationUnitSettings(relationUnits []params.RemoteRelationUnit)
 		return result, nil
 	}
 
-	results = params.SettingsResults{}
 	if err := apiCall(); err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -355,6 +359,8 @@ func (c *Client) WatchEgressAddressesForRelation(remoteRelationArg params.Remote
 
 	var results params.StringsWatchResults
 	apiCall := func() error {
+		// Reset the results struct before each api call.
+		results = params.StringsWatchResults{}
 		if err := c.facade.FacadeCall("WatchEgressAddressesForRelations", args, &results); err != nil {
 			return errors.Trace(err)
 		}
@@ -404,6 +410,8 @@ func (c *Client) WatchRelationSuspendedStatus(arg params.RemoteEntityArg) (watch
 
 	var results params.RelationStatusWatchResults
 	apiCall := func() error {
+		// Reset the results struct before each api call.
+		results = params.RelationStatusWatchResults{}
 		if err := c.facade.FacadeCall("WatchRelationsSuspendedStatus", args, &results); err != nil {
 			return errors.Trace(err)
 		}
@@ -453,6 +461,8 @@ func (c *Client) WatchOfferStatus(arg params.OfferArg) (watcher.OfferStatusWatch
 
 	var results params.OfferStatusWatchResults
 	apiCall := func() error {
+		// Reset the results struct before each api call.
+		results = params.OfferStatusWatchResults{}
 		if err := c.facade.FacadeCall("WatchOfferStatus", args, &results); err != nil {
 			return errors.Trace(err)
 		}

--- a/apiserver/common/crossmodel/auth.go
+++ b/apiserver/common/crossmodel/auth.go
@@ -34,7 +34,7 @@ const (
 	// be provisioned so that the macaroon is still valid when the macaroon
 	// is next used. If a machine takes longer, that's ok, a new discharge
 	// will be obtained.
-	localOfferPermissionExpiryTime = 5 * time.Minute
+	localOfferPermissionExpiryTime = 3 * time.Minute
 )
 
 // AuthContext is used to validate macaroons used to access

--- a/network/hostport.go
+++ b/network/hostport.go
@@ -7,10 +7,10 @@ import (
 	"net"
 	"sort"
 	"strconv"
+	"strings"
 
 	"github.com/juju/errors"
 	"github.com/juju/utils/set"
-	"strings"
 )
 
 // HostPort associates an address with a port.


### PR DESCRIPTION
## Description of change

There were 2 issues caused by revoking consume permission on an offer.
1. The consuming side needs to reflect that the SAAS entry is now in an an error state
2. There was a bug in the crossmodelrelations api facade so that when permission was granted again, the discharge handling still produced an error.

Issue 2 was due to json unmarshalling and not clearing results structs between calls. The unit tests have been changed to better reflect actual implementation behaviour to demonstrate the issue is fixed.

The macaroon expiry time has been reduced to 3 minutes also so that offer revocation is reflected faster in the consuming model.

## QA steps

Run up a cmr scenario.
Revoke consume permission
upgrade juju (or restart jujud) on consuming side
observe the SAAS entry go into an error state
grant consume again
worker restart on consume side should eventually set things straight again

## Bug reference

https://bugs.launchpad.net/juju/+bug/1727289
