### PR TITLE
DeriveAvailabilityZones should return slice of zone names

### DIFF
--- a/provider/common/availabilityzones.go
+++ b/provider/common/availabilityzones.go
@@ -34,15 +34,16 @@ type ZonedEnviron interface {
 	// rules as Environ.Instances.
 	InstanceAvailabilityZoneNames(ids []instance.Id) ([]string, error)
 
-	// DeriveAvailabilityZone attempts to derive an availability zone from
+	// DeriveAvailabilityZones attempts to derive availability zones from
 	// the specified StartInstanceParams.
 	//
 	// The parameters for starting an instance may imply (or explicitly
-	// specify) an availability zone, e.g. due to placement, or due to the
-	// attachment of existing volumes. If there is no such restriction,
-	// then DeriveAvailabilityZone should return an empty string to
-	// indicate that the caller should choose an availability zone.
-	DeriveAvailabilityZone(args environs.StartInstanceParams) (string, error)
+	// specify) availability zones, e.g. due to placement, or due to the
+	// attachment of existing volumes, or due to subnet placement. If
+	// there is no such restriction, then DeriveAvailabilityZones should
+	// return an empty string slice to indicate that the caller should
+	// choose an availability zone.
+	DeriveAvailabilityZones(args environs.StartInstanceParams) ([]string, error)
 }
 
 // AvailabilityZoneInstances describes an availability zone and

--- a/provider/common/bootstrap.go
+++ b/provider/common/bootstrap.go
@@ -250,14 +250,13 @@ func startInstanceZones(env environs.Environ, args environs.StartInstanceParams)
 
 	// Attempt creating the instance in each of the availability
 	// zones, unless the args imply a specific zone.
-	zone, err := zonedEnviron.DeriveAvailabilityZone(args)
+	zones, err := zonedEnviron.DeriveAvailabilityZones(args)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	if zone != "" {
-		return []string{zone}, nil
+	if len(zones) > 0 {
+		return zones, nil
 	}
-	var zones []string
 	allZones, err := zonedEnviron.AvailabilityZones()
 	if err != nil {
 		return nil, errors.Trace(err)

--- a/provider/common/bootstrap_test.go
+++ b/provider/common/bootstrap_test.go
@@ -200,8 +200,8 @@ func (s *BootstrapSuite) TestStartInstanceDerivedZone(c *gc.C) {
 			storage: newStorage(s, c),
 			config:  configGetter(c),
 		},
-		deriveAvailabilityZone: func(environs.StartInstanceParams) (string, error) {
-			return "derived-zone", nil
+		deriveAvailabilityZones: func(environs.StartInstanceParams) ([]string, error) {
+			return []string{"derived-zone"}, nil
 		},
 	}
 
@@ -232,8 +232,8 @@ func (s *BootstrapSuite) TestStartInstanceAttemptAllZones(c *gc.C) {
 			storage: newStorage(s, c),
 			config:  configGetter(c),
 		},
-		deriveAvailabilityZone: func(environs.StartInstanceParams) (string, error) {
-			return "", nil
+		deriveAvailabilityZones: func(environs.StartInstanceParams) ([]string, error) {
+			return nil, nil
 		},
 		availabilityZones: func() ([]common.AvailabilityZone, error) {
 			z0 := &mockAvailabilityZone{"z0", true}
@@ -271,8 +271,8 @@ func (s *BootstrapSuite) TestStartInstanceNoUsableZones(c *gc.C) {
 			storage: newStorage(s, c),
 			config:  configGetter(c),
 		},
-		deriveAvailabilityZone: func(environs.StartInstanceParams) (string, error) {
-			return "", nil
+		deriveAvailabilityZones: func(environs.StartInstanceParams) ([]string, error) {
+			return nil, nil
 		},
 		availabilityZones: func() ([]common.AvailabilityZone, error) {
 			z0 := &mockAvailabilityZone{"z0", false}

--- a/provider/common/mock_test.go
+++ b/provider/common/mock_test.go
@@ -94,13 +94,13 @@ func (env *mockEnviron) StorageProvider(t jujustorage.ProviderType) (jujustorage
 
 type availabilityZonesFunc func() ([]common.AvailabilityZone, error)
 type instanceAvailabilityZoneNamesFunc func([]instance.Id) ([]string, error)
-type deriveAvailabilityZoneFunc func(environs.StartInstanceParams) (string, error)
+type deriveAvailabilityZonesFunc func(environs.StartInstanceParams) ([]string, error)
 
 type mockZonedEnviron struct {
 	mockEnviron
 	availabilityZones             availabilityZonesFunc
 	instanceAvailabilityZoneNames instanceAvailabilityZoneNamesFunc
-	deriveAvailabilityZone        deriveAvailabilityZoneFunc
+	deriveAvailabilityZones       deriveAvailabilityZonesFunc
 }
 
 func (env *mockZonedEnviron) AvailabilityZones() ([]common.AvailabilityZone, error) {
@@ -111,8 +111,8 @@ func (env *mockZonedEnviron) InstanceAvailabilityZoneNames(ids []instance.Id) ([
 	return env.instanceAvailabilityZoneNames(ids)
 }
 
-func (env *mockZonedEnviron) DeriveAvailabilityZone(args environs.StartInstanceParams) (string, error) {
-	return env.deriveAvailabilityZone(args)
+func (env *mockZonedEnviron) DeriveAvailabilityZones(args environs.StartInstanceParams) ([]string, error) {
+	return env.deriveAvailabilityZones(args)
 }
 
 type mockInstance struct {

--- a/provider/dummy/environs.go
+++ b/provider/dummy/environs.go
@@ -1031,15 +1031,29 @@ func (e *environ) StartInstance(args environs.StartInstanceParams) (*environs.St
 	// To match current system capability, only provide hardware characteristics for
 	// environ machines, not containers.
 	if state.ParentId(machineId) == "" {
+		// Assume that the provided Availability Zone won't fail,
+		// though one is required.
+		var zone string
+		if args.Placement != "" {
+			split := strings.Split(args.Placement, "=")
+			if len(split) == 2 && split[0] == "zone" {
+				zone = split[1]
+			}
+		}
+		if zone == "" && args.AvailabilityZone != "" {
+			zone = args.AvailabilityZone
+		}
+
 		// We will just assume the instance hardware characteristics exactly matches
 		// the supplied constraints (if specified).
 		hc = &instance.HardwareCharacteristics{
-			Arch:     args.Constraints.Arch,
-			Mem:      args.Constraints.Mem,
-			RootDisk: args.Constraints.RootDisk,
-			CpuCores: args.Constraints.CpuCores,
-			CpuPower: args.Constraints.CpuPower,
-			Tags:     args.Constraints.Tags,
+			Arch:             args.Constraints.Arch,
+			Mem:              args.Constraints.Mem,
+			RootDisk:         args.Constraints.RootDisk,
+			CpuCores:         args.Constraints.CpuCores,
+			CpuPower:         args.Constraints.CpuPower,
+			Tags:             args.Constraints.Tags,
+			AvailabilityZone: &zone,
 		}
 		// Fill in some expected instance hardware characteristics if constraints not specified.
 		if hc.Arch == nil {
@@ -1341,9 +1355,9 @@ func (env *environ) InstanceAvailabilityZoneNames(ids []instance.Id) ([]string, 
 	return returnValue, nil
 }
 
-// DeriveAvailabilityZone is part of the common.ZonedEnviron interface.
-func (env *environ) DeriveAvailabilityZone(args environs.StartInstanceParams) (string, error) {
-	return "", nil
+// DeriveAvailabilityZones is part of the common.ZonedEnviron interface.
+func (env *environ) DeriveAvailabilityZones(args environs.StartInstanceParams) ([]string, error) {
+	return nil, nil
 }
 
 // Subnets implements environs.Environ.Subnets.

--- a/provider/dummy/environs_test.go
+++ b/provider/dummy/environs_test.go
@@ -153,7 +153,7 @@ func (s *suite) TestAvailabilityZone(c *gc.C) {
 
 	inst, hwc := jujutesting.AssertStartInstance(c, e, s.ControllerUUID, "0")
 	c.Assert(inst, gc.NotNil)
-	c.Check(hwc.AvailabilityZone, gc.IsNil)
+	c.Check(hwc.AvailabilityZone, gc.NotNil)
 }
 
 func (s *suite) TestSupportsSpaces(c *gc.C) {

--- a/provider/ec2/export_test.go
+++ b/provider/ec2/export_test.go
@@ -54,13 +54,12 @@ func AllModelGroups(e environs.Environ) ([]string, error) {
 }
 
 var (
-	EC2AvailabilityZones        = &ec2AvailabilityZones
-	AvailabilityZoneAllocations = &availabilityZoneAllocations
-	RunInstances                = &runInstances
-	BlockDeviceNamer            = blockDeviceNamer
-	GetBlockDeviceMappings      = getBlockDeviceMappings
-	IsVPCNotUsableError         = isVPCNotUsableError
-	IsVPCNotRecommendedError    = isVPCNotRecommendedError
+	EC2AvailabilityZones     = &ec2AvailabilityZones
+	RunInstances             = &runInstances
+	BlockDeviceNamer         = blockDeviceNamer
+	GetBlockDeviceMappings   = getBlockDeviceMappings
+	IsVPCNotUsableError      = isVPCNotUsableError
+	IsVPCNotRecommendedError = isVPCNotRecommendedError
 )
 
 const VPCIDNone = vpcIDNone

--- a/provider/gce/environ_availzones.go
+++ b/provider/gce/environ_availzones.go
@@ -54,9 +54,13 @@ func (env *environ) InstanceAvailabilityZoneNames(ids []instance.Id) ([]string, 
 	return results, err
 }
 
-// DeriveAvailabilityZone is part of the common.ZonedEnviron interface.
-func (env *environ) DeriveAvailabilityZone(args environs.StartInstanceParams) (string, error) {
-	return env.deriveAvailabilityZone(args.Placement, args.VolumeAttachments)
+// DeriveAvailabilityZones is part of the common.ZonedEnviron interface.
+func (env *environ) DeriveAvailabilityZones(args environs.StartInstanceParams) ([]string, error) {
+	zone, err := env.deriveAvailabilityZones(args.Placement, args.VolumeAttachments)
+	if zone != "" {
+		return []string{zone}, errors.Trace(err)
+	}
+	return nil, errors.Trace(err)
 }
 
 func (env *environ) availZone(name string) (*google.AvailabilityZone, error) {
@@ -125,7 +129,7 @@ func (env *environ) instancePlacementZone(placement string, volumeAttachmentsZon
 	return instPlacement.Zone.Name(), nil
 }
 
-func (e *environ) deriveAvailabilityZone(
+func (e *environ) deriveAvailabilityZones(
 	placement string,
 	volumeAttachments []storage.VolumeAttachmentParams,
 ) (string, error) {

--- a/provider/gce/environ_broker.go
+++ b/provider/gce/environ_broker.go
@@ -47,7 +47,7 @@ func (env *environ) StartInstance(args environs.StartInstanceParams) (*environs.
 		return nil, errors.Trace(err)
 	}
 	if err := validateAvailabilityZoneConsistency(args.AvailabilityZone, volumeAttachmentsZone); err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Wrap(errors.Trace(err), environs.ErrAvailabilityZoneFailed)
 	}
 
 	raw, err := newRawInstance(env, args, spec)

--- a/provider/gce/environ_broker_test.go
+++ b/provider/gce/environ_broker_test.go
@@ -102,15 +102,15 @@ func (s *environBrokerSuite) TestStartInstanceVolumeAvailabilityZone(c *gc.C) {
 	s.StartInstArgs.VolumeAttachments = []storage.VolumeAttachmentParams{{
 		VolumeId: "home-zone--c930380d-8337-4bf5-b07a-9dbb5ae771e4",
 	}}
-	derivedZone, err := s.Env.DeriveAvailabilityZone(s.StartInstArgs)
+	derivedZones, err := s.Env.DeriveAvailabilityZones(s.StartInstArgs)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(len(derivedZone), jc.GreaterThan, 0)
-	s.StartInstArgs.AvailabilityZone = derivedZone
+	c.Assert(derivedZones, gc.HasLen, 1)
+	s.StartInstArgs.AvailabilityZone = derivedZones[0]
 
 	result, err := s.Env.StartInstance(s.StartInstArgs)
 
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(*result.Hardware.AvailabilityZone, gc.Equals, derivedZone)
+	c.Assert(*result.Hardware.AvailabilityZone, gc.Equals, derivedZones[0])
 }
 
 func (s *environBrokerSuite) TestFinishInstanceConfig(c *gc.C) {

--- a/provider/gce/google/conn_instance.go
+++ b/provider/gce/google/conn_instance.go
@@ -35,8 +35,8 @@ func (gce *Connection) addInstance(requestedInst *compute.Instance, machineType 
 		if waitErr == nil {
 			return errors.Trace(err)
 		}
-		// Try the next zone.
 		logger.Errorf("failed to get new instance in zone %q: %v", zone, waitErr)
+		// Let the provisioner or bootstrap know to try the next zone.
 		return errors.Wrap(waitErr, environs.ErrAvailabilityZoneFailed)
 	}
 

--- a/provider/maas/environ.go
+++ b/provider/maas/environ.go
@@ -580,13 +580,18 @@ func (e *maasEnviron) InstanceAvailabilityZoneNames(ids []instance.Id) ([]string
 	return zones, nil
 }
 
-// DeriveAvailabilityZone is part of the common.ZonedEnviron interface.
-func (e *maasEnviron) DeriveAvailabilityZone(args environs.StartInstanceParams) (string, error) {
-	placement, err := e.parsePlacement(args.Placement)
-	if err != nil {
-		return "", err
+// DeriveAvailabilityZones is part of the common.ZonedEnviron interface.
+func (e *maasEnviron) DeriveAvailabilityZones(args environs.StartInstanceParams) ([]string, error) {
+	if args.Placement != "" {
+		placement, err := e.parsePlacement(args.Placement)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		if placement.zoneName != "" {
+			return []string{placement.zoneName}, nil
+		}
 	}
-	return placement.zoneName, nil
+	return nil, nil
 }
 
 type maasPlacement struct {

--- a/provider/maas/environ_whitebox_test.go
+++ b/provider/maas/environ_whitebox_test.go
@@ -700,35 +700,35 @@ func (s *environSuite) TestPrecheckNodePlacement(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 }
 
-func (s *environSuite) TestDeriveAvailabilityZone(c *gc.C) {
+func (s *environSuite) TestDeriveAvailabilityZones(c *gc.C) {
 	s.testMAASObject.TestServer.AddZone("zone1", "the grass is greener in zone1")
 	env := s.makeEnviron()
-	zone, err := env.DeriveAvailabilityZone(environs.StartInstanceParams{Placement: "zone=zone1"})
+	zones, err := env.DeriveAvailabilityZones(environs.StartInstanceParams{Placement: "zone=zone1"})
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(zone, gc.Equals, "zone1")
+	c.Assert(zones, gc.DeepEquals, []string{"zone1"})
 }
 
-func (s *environSuite) TestDeriveAvailabilityZoneUnknown(c *gc.C) {
+func (s *environSuite) TestDeriveAvailabilityZonesUnknown(c *gc.C) {
 	s.testMAASObject.TestServer.AddZone("zone1", "the grass is greener in zone1")
 	env := s.makeEnviron()
-	zone, err := env.DeriveAvailabilityZone(environs.StartInstanceParams{Placement: "zone=zone2"})
+	zones, err := env.DeriveAvailabilityZones(environs.StartInstanceParams{Placement: "zone=zone2"})
 	c.Assert(err, gc.ErrorMatches, `availability zone "zone2" not valid`)
-	c.Assert(zone, gc.Equals, "")
+	c.Assert(zones, gc.HasLen, 0)
 }
 
-func (s *environSuite) TestDeriveAvailabilityZoneInvalidPlacement(c *gc.C) {
+func (s *environSuite) TestDeriveAvailabilityZonesInvalidPlacement(c *gc.C) {
 	env := s.makeEnviron()
-	zone, err := env.DeriveAvailabilityZone(environs.StartInstanceParams{Placement: "notzone=anything"})
+	zones, err := env.DeriveAvailabilityZones(environs.StartInstanceParams{Placement: "notzone=anything"})
 	c.Assert(err, gc.ErrorMatches, "unknown placement directive: notzone=anything")
-	c.Assert(zone, gc.Equals, "")
+	c.Assert(zones, gc.HasLen, 0)
 }
 
-func (s *environSuite) TestDeriveAvailabilityZoneNoPlacement(c *gc.C) {
+func (s *environSuite) TestDeriveAvailabilityZonesNoPlacement(c *gc.C) {
 	s.testMAASObject.TestServer.AddZone("zone1", "the grass is greener in zone1")
 	env := s.makeEnviron()
-	zone, err := env.DeriveAvailabilityZone(environs.StartInstanceParams{})
+	zones, err := env.DeriveAvailabilityZones(environs.StartInstanceParams{})
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(zone, gc.Equals, "")
+	c.Assert(zones, gc.HasLen, 0)
 }
 
 func (s *environSuite) TestStartInstanceAvailZone(c *gc.C) {

--- a/provider/openstack/provider.go
+++ b/provider/openstack/provider.go
@@ -574,13 +574,16 @@ type openstackPlacement struct {
 	zoneName string
 }
 
-// DeriveAvailabilityZone is part of the common.ZonedEnviron interface.
-func (e *Environ) DeriveAvailabilityZone(args environs.StartInstanceParams) (string, error) {
+// DeriveAvailabilityZones is part of the common.ZonedEnviron interface.
+func (e *Environ) DeriveAvailabilityZones(args environs.StartInstanceParams) ([]string, error) {
 	availabilityZone, err := e.deriveAvailabilityZone(args.Placement, args.VolumeAttachments)
 	if err != nil && !errors.IsNotImplemented(err) {
-		return "", errors.Trace(err)
+		return nil, errors.Trace(err)
 	}
-	return availabilityZone, nil
+	if availabilityZone != "" {
+		return []string{availabilityZone}, nil
+	}
+	return nil, nil
 }
 
 func (e *Environ) parsePlacement(placement string) (*openstackPlacement, error) {

--- a/provider/vsphere/environ_availzones.go
+++ b/provider/vsphere/environ_availzones.go
@@ -93,26 +93,28 @@ func (env *sessionEnviron) InstanceAvailabilityZoneNames(ids []instance.Id) ([]s
 	return results, err
 }
 
-// DeriveAvailabilityZone is part of the common.ZonedEnviron interface.
-func (env *environ) DeriveAvailabilityZone(args environs.StartInstanceParams) (name string, err error) {
+// DeriveAvailabilityZones is part of the common.ZonedEnviron interface.
+func (env *environ) DeriveAvailabilityZones(args environs.StartInstanceParams) (names []string, err error) {
 	err = env.withSession(func(env *sessionEnviron) error {
-		name, err = env.DeriveAvailabilityZone(args)
+		names, err = env.DeriveAvailabilityZones(args)
 		return err
 	})
-	return name, err
+	return names, err
 }
 
-// DeriveAvailabilityZone is part of the common.ZonedEnviron interface.
-func (env *sessionEnviron) DeriveAvailabilityZone(args environs.StartInstanceParams) (string, error) {
+// DeriveAvailabilityZones is part of the common.ZonedEnviron interface.
+func (env *sessionEnviron) DeriveAvailabilityZones(args environs.StartInstanceParams) ([]string, error) {
 	if args.Placement != "" {
 		// args.Placement will always be a zone name or empty.
 		placement, err := env.parsePlacement(args.Placement)
 		if err != nil {
-			return "", errors.Trace(err)
+			return nil, errors.Trace(err)
 		}
-		return placement.Name(), nil
+		if placement.Name() != "" {
+			return []string{placement.Name()}, nil
+		}
 	}
-	return "", nil
+	return nil, nil
 }
 
 func (env *sessionEnviron) availZone(name string) (common.AvailabilityZone, error) {

--- a/provider/vsphere/environ_availzones_test.go
+++ b/provider/vsphere/environ_availzones_test.go
@@ -58,7 +58,7 @@ func (s *environAvailzonesSuite) TestInstanceAvailabilityZoneNamesNoInstances(c 
 	c.Assert(err, gc.Equals, environs.ErrNoInstances)
 }
 
-func (s *environAvailzonesSuite) TestDeriveAvailabilityZone(c *gc.C) {
+func (s *environAvailzonesSuite) TestDeriveAvailabilityZones(c *gc.C) {
 	s.client.computeResources = []*mo.ComputeResource{
 		newComputeResource("test-available"),
 	}
@@ -66,29 +66,29 @@ func (s *environAvailzonesSuite) TestDeriveAvailabilityZone(c *gc.C) {
 	c.Assert(s.env, gc.Implements, new(common.ZonedEnviron))
 	zonedEnviron := s.env.(common.ZonedEnviron)
 
-	zone, err := zonedEnviron.DeriveAvailabilityZone(
+	zones, err := zonedEnviron.DeriveAvailabilityZones(
 		environs.StartInstanceParams{Placement: "zone=test-available"})
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(zone, gc.Equals, "test-available")
+	c.Assert(zones, gc.DeepEquals, []string{"test-available"})
 }
 
-func (s *environAvailzonesSuite) TestDeriveAvailabilityZoneUnknown(c *gc.C) {
+func (s *environAvailzonesSuite) TestDeriveAvailabilityZonesUnknown(c *gc.C) {
 	c.Assert(s.env, gc.Implements, new(common.ZonedEnviron))
 	zonedEnviron := s.env.(common.ZonedEnviron)
 
-	zone, err := zonedEnviron.DeriveAvailabilityZone(
+	zones, err := zonedEnviron.DeriveAvailabilityZones(
 		environs.StartInstanceParams{Placement: "zone=test-unknown"})
 	c.Assert(err, gc.ErrorMatches, `availability zone "test-unknown" not found`)
-	c.Assert(zone, gc.Equals, "")
+	c.Assert(zones, gc.HasLen, 0)
 }
 
-func (s *environAvailzonesSuite) TestDeriveAvailabilityZoneInvalidPlacement(c *gc.C) {
+func (s *environAvailzonesSuite) TestDeriveAvailabilityZonesInvalidPlacement(c *gc.C) {
 	c.Assert(s.env, gc.Implements, new(common.ZonedEnviron))
 	zonedEnviron := s.env.(common.ZonedEnviron)
 
-	zone, err := zonedEnviron.DeriveAvailabilityZone(environs.StartInstanceParams{
+	zones, err := zonedEnviron.DeriveAvailabilityZones(environs.StartInstanceParams{
 		Placement: "invalid-placement",
 	})
 	c.Assert(err, gc.ErrorMatches, `unknown placement directive: invalid-placement`)
-	c.Assert(zone, gc.Equals, "")
+	c.Assert(zones, gc.HasLen, 0)
 }

--- a/worker/provisioner/provisioner_test.go
+++ b/worker/provisioner/provisioner_test.go
@@ -298,6 +298,10 @@ func (s *CommonProvisionerSuite) checkStartInstancesCustom(
 					c.Assert(o.Constraints, gc.DeepEquals, cons)
 					hc, err := m.HardwareCharacteristics()
 					c.Assert(err, jc.ErrorIsNil)
+					// At this point we don't care what the AvailabilityZone is,
+					// it can be a few different valid things.
+					zone := hc.AvailabilityZone
+					hc.AvailabilityZone = nil
 					c.Assert(*hc, gc.DeepEquals, instance.HardwareCharacteristics{
 						Arch:     cons.Arch,
 						Mem:      cons.Mem,
@@ -306,6 +310,7 @@ func (s *CommonProvisionerSuite) checkStartInstancesCustom(
 						CpuPower: cons.CpuPower,
 						Tags:     cons.Tags,
 					})
+					hc.AvailabilityZone = zone
 				}
 				returnInstances[m.Id()] = inst
 				if found == len(machines) {
@@ -818,10 +823,6 @@ func (m *MockMachine) InstanceStatus() (status.Status, string, error) {
 
 func (m *MockMachine) Id() string {
 	return m.id
-}
-
-func (m *MockMachine) AvailabilityZone() (string, error) {
-	return "zone1", nil
 }
 
 type machineClassificationTest struct {
@@ -1517,12 +1518,14 @@ func assertAvailabilityZoneMachines(c *gc.C,
 		for _, m := range machines {
 			zone, err := m.AvailabilityZone()
 			c.Assert(err, jc.ErrorIsNil)
+			found := 0
 			for _, zoneInfo := range obtained {
 				if zone == zoneInfo.ZoneName {
-					c.Assert(zoneInfo.MachineIds.Contains(zone), gc.Equals, true)
-
+					c.Assert(zoneInfo.MachineIds.Contains(m.Id()), gc.Equals, true)
+					found += 1
 				}
 			}
+			c.Assert(found, gc.Equals, 1)
 		}
 	}
 	if len(failedAZMachines) > 0 {
@@ -1782,6 +1785,72 @@ func (s *ProvisionerSuite) TestAvailabilityZoneMachinesRestartTask(c *gc.C) {
 	c.Assert(availabilityZoneMachinesBefore, jc.DeepEquals, availabilityZoneMachinesAfter)
 }
 
+func (s *ProvisionerSuite) TestProvisioningMachinesClearAZFailures(c *gc.C) {
+	s.PatchValue(&apiserverprovisioner.ErrorRetryWaitDelay, 5*time.Millisecond)
+	e := &mockBroker{
+		Environ:    s.Environ,
+		retryCount: make(map[string]int),
+		startInstanceFailureInfo: map[string]mockBrokerFailures{
+			"1": {whenSucceed: 3, err: environs.ErrAvailabilityZoneFailed},
+		},
+	}
+	retryStrategy := provisioner.NewRetryStrategy(5*time.Millisecond, 4)
+	task := s.newProvisionerTaskWithRetryStrategy(c, config.HarvestDestroyed,
+		e, s.provisioner, &mockDistributionGroupFinder{}, mockToolsFinder{}, retryStrategy)
+	defer workertest.CleanKill(c, task)
+
+	machine, err := s.addMachine()
+	c.Assert(err, jc.ErrorIsNil)
+	s.checkStartInstance(c, machine)
+	count := e.retryCount[machine.Id()]
+	c.Assert(count, gc.Equals, 3)
+	machineAZ, err := machine.AvailabilityZone()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(machineAZ, gc.Equals, "zone1")
+}
+
+func (s *ProvisionerSuite) TestProvisioningMachinesDerivedAZ(c *gc.C) {
+	s.PatchValue(&apiserverprovisioner.ErrorRetryWaitDelay, 5*time.Millisecond)
+	e := &mockBroker{
+		Environ:    s.Environ,
+		retryCount: make(map[string]int),
+		startInstanceFailureInfo: map[string]mockBrokerFailures{
+			"1": {whenSucceed: 3, err: environs.ErrAvailabilityZoneFailed},
+			"2": {whenSucceed: 1, err: environs.ErrAvailabilityZoneFailed},
+			"4": {whenSucceed: 1, err: errors.New("fail me once.")},
+		},
+		derivedAZ: map[string][]string{
+			"1": []string{"fail-zone"},
+			"2": []string{"zone1", "zone4"},
+			"3": []string{"zone1"},
+			"4": []string{"zone3"},
+		},
+	}
+	retryStrategy := provisioner.NewRetryStrategy(5*time.Millisecond, 2)
+	task := s.newProvisionerTaskWithRetryStrategy(c, config.HarvestDestroyed,
+		e, s.provisioner, &mockDistributionGroupFinder{}, mockToolsFinder{}, retryStrategy)
+	defer workertest.CleanKill(c, task)
+
+	machines, err := s.addMachines(4)
+	c.Assert(err, jc.ErrorIsNil)
+	mFail := machines[0]
+	mSucceed := machines[1:]
+
+	s.checkStartInstances(c, mSucceed)
+
+	_, err = mFail.InstanceId()
+	c.Assert(err, jc.Satisfies, errors.IsNotProvisioned)
+
+	availabilityZoneMachines := provisioner.GetCopyAvailabilityZoneMachines(task)
+	assertAvailabilityZoneMachines(c, mSucceed, nil, availabilityZoneMachines)
+
+	for i, zone := range []string{"zone4", "zone1", "zone3"} {
+		machineAZ, err := mSucceed[i].AvailabilityZone()
+		c.Assert(err, jc.ErrorIsNil)
+		c.Assert(machineAZ, gc.Equals, zone)
+	}
+}
+
 func (s *ProvisionerSuite) TestProvisioningMachinesNoZonedEnviron(c *gc.C) {
 	// Make sure the provisioner still works for providers which do not
 	// implement the ZonedEnviron interface.
@@ -1816,6 +1885,7 @@ type mockBroker struct {
 	mu                       sync.Mutex
 	retryCount               map[string]int
 	startInstanceFailureInfo map[string]mockBrokerFailures
+	derivedAZ                map[string][]string
 }
 
 type mockBrokerFailures struct {
@@ -1856,8 +1926,14 @@ func (b *mockBroker) InstanceAvailabilityZoneNames(ids []instance.Id) ([]string,
 	return b.Environ.(providercommon.ZonedEnviron).InstanceAvailabilityZoneNames(ids)
 }
 
-func (b *mockBroker) DeriveAvailabilityZone(args environs.StartInstanceParams) (string, error) {
-	return b.Environ.(providercommon.ZonedEnviron).DeriveAvailabilityZone(args)
+func (b *mockBroker) DeriveAvailabilityZones(args environs.StartInstanceParams) ([]string, error) {
+	id := args.InstanceConfig.MachineId
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if derivedAZ, ok := b.derivedAZ[id]; ok {
+		return derivedAZ, nil
+	}
+	return b.Environ.(providercommon.ZonedEnviron).DeriveAvailabilityZones(args)
 }
 
 type mockToolsFinder struct {


### PR DESCRIPTION
## Description of change

It's possible that a placement directive machines for could yield more than one availability zone possibility, therefore update DeriveAvailabilityZones to return a slice of zone names.  When provisioning a machine, try each zone.

## QA steps

No bootstrap or provisioning of a machine should fail.
Unit tests shouldn't fail.

## Documentation changes

N/A

## Bug reference

N/A