### PR TITLE
Add CACertificates field to Cloud in State.

### DIFF
--- a/apiserver/common/cloud.go
+++ b/apiserver/common/cloud.go
@@ -29,6 +29,7 @@ func CloudToParams(cloud jujucloud.Cloud) params.Cloud {
 		IdentityEndpoint: cloud.IdentityEndpoint,
 		StorageEndpoint:  cloud.StorageEndpoint,
 		Regions:          regions,
+		CACertificates:   cloud.CACertificates,
 	}
 }
 
@@ -54,5 +55,6 @@ func CloudFromParams(cloudName string, p params.Cloud) jujucloud.Cloud {
 		IdentityEndpoint: p.IdentityEndpoint,
 		StorageEndpoint:  p.StorageEndpoint,
 		Regions:          regions,
+		CACertificates:   p.CACertificates,
 	}
 }

--- a/apiserver/params/cloud.go
+++ b/apiserver/params/cloud.go
@@ -11,6 +11,7 @@ type Cloud struct {
 	IdentityEndpoint string        `json:"identity-endpoint,omitempty"`
 	StorageEndpoint  string        `json:"storage-endpoint,omitempty"`
 	Regions          []CloudRegion `json:"regions,omitempty"`
+	CACertificates   []string      `json:"ca-certificates,omitempty"`
 }
 
 // CloudRegion holds information about a cloud region.

--- a/cloud/clouds.go
+++ b/cloud/clouds.go
@@ -131,6 +131,12 @@ type Cloud struct {
 	// Like Config above, this will be combined with Juju-generated and user
 	// supplied values; with user supplied values taking precedence.
 	RegionConfig RegionConfig
+
+	// CACertificates contains an optional list of Certificate
+	// Authority certificates to be used to validate certificates
+	// of cloud infrastructure components
+	// The contents are Base64 encoded x.509 certs.
+	CACertificates []string
 }
 
 // Region is a cloud region.
@@ -171,6 +177,7 @@ type cloud struct {
 	Regions          regions                `yaml:"regions,omitempty"`
 	Config           map[string]interface{} `yaml:"config,omitempty"`
 	RegionConfig     RegionConfig           `yaml:"region-config,omitempty"`
+	CACertificates   []string               `yaml:"ca-certificates,omitempty"`
 }
 
 // regions is a collection of regions, either as a map and/or
@@ -411,6 +418,7 @@ func cloudToInternal(in Cloud, withName bool) *cloud {
 		Regions:          regions,
 		Config:           in.Config,
 		RegionConfig:     in.RegionConfig,
+		CACertificates:   in.CACertificates,
 	}
 }
 
@@ -445,6 +453,7 @@ func cloudFromInternal(in *cloud) Cloud {
 		Config:           in.Config,
 		RegionConfig:     in.RegionConfig,
 		Description:      in.Description,
+		CACertificates:   in.CACertificates,
 	}
 	meta.denormaliseMetadata()
 	return meta

--- a/cloud/clouds_test.go
+++ b/cloud/clouds_test.go
@@ -286,10 +286,11 @@ func (s *cloudSuite) TestRegionNames(c *gc.C) {
 
 func (s *cloudSuite) TestMarshalCloud(c *gc.C) {
 	in := cloud.Cloud{
-		Name:      "foo",
-		Type:      "bar",
-		AuthTypes: []cloud.AuthType{"baz"},
-		Endpoint:  "qux",
+		Name:           "foo",
+		Type:           "bar",
+		AuthTypes:      []cloud.AuthType{"baz"},
+		Endpoint:       "qux",
+		CACertificates: []string{"fakecacert"},
 	}
 	marshalled, err := cloud.MarshalCloud(in)
 	c.Assert(err, jc.ErrorIsNil)
@@ -298,6 +299,8 @@ name: foo
 type: bar
 auth-types: [baz]
 endpoint: qux
+ca-certificates:
+- fakecacert
 `[1:])
 }
 
@@ -307,13 +310,15 @@ name: foo
 type: bar
 auth-types: [baz]
 endpoint: qux
+ca-certificates: [fakecacert]
 `)
 	out, err := cloud.UnmarshalCloud(in)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(out, jc.DeepEquals, cloud.Cloud{
-		Name:      "foo",
-		Type:      "bar",
-		AuthTypes: []cloud.AuthType{"baz"},
-		Endpoint:  "qux",
+		Name:           "foo",
+		Type:           "bar",
+		AuthTypes:      []cloud.AuthType{"baz"},
+		Endpoint:       "qux",
+		CACertificates: []string{"fakecacert"},
 	})
 }

--- a/cmd/juju/caas/add.go
+++ b/cmd/juju/caas/add.go
@@ -160,16 +160,17 @@ func (c *AddCAASCommand) Run(ctxt *cmd.Context) error {
 	defaultCredential := caasConfig.Credentials[defaultContext.CredentialName]
 	defaultCloud := caasConfig.Clouds[defaultContext.CloudName]
 
-	cloudConfig := map[string]interface{}{
-		"CAData": defaultCloud.Attributes["CAData"],
+	defaultCloudCAData, ok := defaultCloud.Attributes["CAData"].(string)
+	if !ok {
+		return errors.Errorf("CAData attribute should be a string")
 	}
 
 	newCloud := cloud.Cloud{
-		Name:      c.caasName,
-		Type:      c.caasType,
-		Endpoint:  defaultCloud.Endpoint,
-		Config:    cloudConfig,
-		AuthTypes: []cloud.AuthType{defaultCredential.AuthType()},
+		Name:           c.caasName,
+		Type:           c.caasType,
+		Endpoint:       defaultCloud.Endpoint,
+		AuthTypes:      []cloud.AuthType{defaultCredential.AuthType()},
+		CACertificates: []string{defaultCloudCAData},
 	}
 
 	if err := addCloudToLocal(c.cloudMetadataStore, newCloud); err != nil {

--- a/cmd/juju/caas/add_test.go
+++ b/cmd/juju/caas/add_test.go
@@ -256,8 +256,8 @@ func (s *addCAASSuite) TestCorrect(c *gc.C) {
 				IdentityEndpoint: "",
 				StorageEndpoint:  "",
 				Regions:          []cloud.Region(nil),
-				Config: map[string]interface{}{
-					"CAData": "fakecadata",
-				},
-				RegionConfig: cloud.RegionConfig(nil)}})
+				Config:           map[string]interface{}(nil),
+				RegionConfig:     cloud.RegionConfig(nil),
+				CACertificates:   []string{"fakecadata"},
+			}})
 }

--- a/state/cloud.go
+++ b/state/cloud.go
@@ -23,6 +23,7 @@ type cloudDoc struct {
 	IdentityEndpoint string                       `bson:"identity-endpoint,omitempty"`
 	StorageEndpoint  string                       `bson:"storage-endpoint,omitempty"`
 	Regions          map[string]cloudRegionSubdoc `bson:"regions,omitempty"`
+	CACertificates   []string                     `bson:"ca-certificates,omitempty"`
 }
 
 // cloudRegionSubdoc records information about cloud regions.
@@ -59,6 +60,7 @@ func createCloudOp(cloud cloud.Cloud) txn.Op {
 			IdentityEndpoint: cloud.IdentityEndpoint,
 			StorageEndpoint:  cloud.StorageEndpoint,
 			Regions:          regions,
+			CACertificates:   cloud.CACertificates,
 		},
 	}
 }
@@ -90,6 +92,7 @@ func (d cloudDoc) toCloud() cloud.Cloud {
 		IdentityEndpoint: d.IdentityEndpoint,
 		StorageEndpoint:  d.StorageEndpoint,
 		Regions:          regions,
+		CACertificates:   d.CACertificates,
 	}
 }
 

--- a/state/cloud_test.go
+++ b/state/cloud_test.go
@@ -36,6 +36,7 @@ var lowCloud = cloud.Cloud{
 		IdentityEndpoint: "region2-identity",
 		StorageEndpoint:  "region2-storage",
 	}},
+	CACertificates: []string{"cert1", "cert2"},
 }
 
 func (s *CloudSuite) TestCloudNotFound(c *gc.C) {


### PR DESCRIPTION
Some CAAS clouds use a private certificate authority, and the
controller needs to store the CA Certificate for the cloud in state in
order to connect to the CAAS cloud.

Adds an array of strings to support multiple CACertificates (encoded
as base-64 x.509 certs). It's valid to have an empty array.

Signed-off-by: Michael McCracken <mike.mccracken@canonical.com>
