### PR TITLE
cloud: add google/asia-south1 region

### DIFF
--- a/cloud/fallback-public-cloud.yaml
+++ b/cloud/fallback-public-cloud.yaml
@@ -72,6 +72,8 @@ clouds:
         endpoint: https://www.googleapis.com
       asia-southeast1:
         endpoint: https://www.googleapis.com
+      asia-south1:
+        endpoint: https://www.googleapis.com
       australia-southeast1:
         endpoint: https://www.googleapis.com
       southamerica-east1:

--- a/cloud/fallback_public_cloud.go
+++ b/cloud/fallback_public_cloud.go
@@ -79,6 +79,8 @@ clouds:
         endpoint: https://www.googleapis.com
       asia-southeast1:
         endpoint: https://www.googleapis.com
+      asia-south1:
+        endpoint: https://www.googleapis.com
       australia-southeast1:
         endpoint: https://www.googleapis.com
       southamerica-east1:

--- a/cmd/juju/cloud/regions_test.go
+++ b/cmd/juju/cloud/regions_test.go
@@ -112,6 +112,7 @@ europe-west3
 asia-east1
 asia-northeast1
 asia-southeast1
+asia-south1
 australia-southeast1
 southamerica-east1
 
@@ -142,6 +143,8 @@ asia-east1:
 asia-northeast1:
   endpoint: https://www.googleapis.com
 asia-southeast1:
+  endpoint: https://www.googleapis.com
+asia-south1:
   endpoint: https://www.googleapis.com
 australia-southeast1:
   endpoint: https://www.googleapis.com


### PR DESCRIPTION
## Description of change

Add the google/asia-south1 region to fallback-public-clouds.yaml.

## QA steps

1. juju bootstrap google/asia-south1
2. juju destroy-controller -y google-asia-south1

## Documentation changes

None.

## Bug reference

Fixes https://bugs.launchpad.net/juju/+bug/1729097