### PR TITLE
cmd/juju: don't run winrm code in ssh: path

### DIFF
--- a/cmd/juju/machine/add.go
+++ b/cmd/juju/machine/add.go
@@ -353,7 +353,7 @@ func (c *addCommand) tryManualProvision(client AddMachineAPI, config *config.Con
 	case sshScope:
 		provisionMachine = sshProvisioner
 	case winrmScope:
-		provisionMachine = winrmProvisioner
+		provisionMachine = c.provisionWinRM
 	default:
 		return errNonManualScope
 	}
@@ -378,14 +378,23 @@ func (c *addCommand) tryManualProvision(client AddMachineAPI, config *config.Con
 		},
 	}
 
+	machineId, err := provisionMachine(args)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	ctx.Infof("created machine %v", machineId)
+	return nil
+}
+
+func (c *addCommand) provisionWinRM(args manual.ProvisionMachineArgs) (string, error) {
 	base := osenv.JujuXDGDataHomePath("x509")
 	keyPath := filepath.Join(base, "winrmkey.pem")
 	certPath := filepath.Join(base, "winrmcert.crt")
 	cert := winrm.NewX509()
 	if err := cert.LoadClientCert(keyPath, certPath); err != nil {
-		return errors.Annotatef(err, "connot load/create x509 client certs for winrm connection")
+		return "", errors.Annotatef(err, "connot load/create x509 client certs for winrm connection")
 	}
-	if err = cert.LoadCACert(filepath.Join(base, "winrmcacert.crt")); err != nil {
+	if err := cert.LoadCACert(filepath.Join(base, "winrmcacert.crt")); err != nil {
 		logger.Infof("cannot not find any CA cert to load")
 	}
 
@@ -402,22 +411,17 @@ func (c *addCommand) tryManualProvision(client AddMachineAPI, config *config.Con
 	if caCert == nil {
 		logger.Infof("Skipping winrm CA validation")
 		cfg.Insecure = true
-
 	} else {
 		cfg.CACert = caCert
 	}
 
-	args.WinRM = manual.WinRMArgs{}
-	args.WinRM.Keys = cert
-	args.WinRM.Client, err = winrm.NewClient(cfg)
+	client, err := winrm.NewClient(cfg)
 	if err != nil {
-		return errors.Annotatef(err, "cannot create secure winrm client conn")
+		return "", errors.Annotatef(err, "cannot create WinRM client connection")
 	}
-
-	machineId, err := provisionMachine(args)
-	if err == nil {
-		ctx.Infof("created machine %v", machineId)
+	args.WinRM = manual.WinRMArgs{
+		Keys:   cert,
+		Client: client,
 	}
-
-	return err
+	return winrmProvisioner(args)
 }


### PR DESCRIPTION
## Description of change

We currently perform WinRM-related initalisation
when manually adding a machine with add-machine
winrm:... or ssh:...

We should only run the WinRM-related code when
using winrm:...

## QA steps

1. juju bootstrap localhost
2. lxc launch ubuntu:xenial
(wait for IP, add SSH authorized key)
3. juju add-machine ssh:\<ip\>
(confirm no WinRM related warnings displayed)
4. juju add-machine winrm:\<ip\>
(confirm WinRM related warnings displayed; error expected as this is not a Windows target)

## Documentation changes

None.

## Bug reference

Fixes https://bugs.launchpad.net/juju/+bug/1724230