### PR TITLE
[RFC] rpc: optional context.Context in methods

### DIFF
--- a/api/leadership/client.go
+++ b/api/leadership/client.go
@@ -48,9 +48,12 @@ func (c *client) ClaimLeadership(serviceId, unitId string, duration time.Duratio
 }
 
 // BlockUntilLeadershipReleased is part of the leadership.Claimer interface.
-func (c *client) BlockUntilLeadershipReleased(serviceId string) error {
+func (c *client) BlockUntilLeadershipReleased(serviceId string, cancel <-chan struct{}) error {
 	const friendlyErrMsg = "error blocking on leadership release"
 	var result params.ErrorResult
+	// TODO(axw) make it possible to plumb a context.Context
+	// through the API/RPC client, so we can cancel or abandon
+	// requests.
 	err := c.FacadeCall("BlockUntilLeadershipReleased", names.NewApplicationTag(serviceId), &result)
 	if err != nil {
 		return errors.Annotate(err, friendlyErrMsg)

--- a/api/leadership/client_test.go
+++ b/api/leadership/client_test.go
@@ -151,7 +151,7 @@ func (s *ClientSuite) TestBlockUntilLeadershipReleasedTranslation(c *gc.C) {
 	})
 
 	client := leadership.NewClient(apiCaller)
-	err := client.BlockUntilLeadershipReleased(StubServiceNm)
+	err := client.BlockUntilLeadershipReleased(StubServiceNm, nil)
 
 	c.Check(numStubCalls, gc.Equals, 1)
 	c.Check(err, jc.ErrorIsNil)
@@ -172,7 +172,7 @@ func (s *ClientSuite) TestBlockUntilLeadershipReleasedError(c *gc.C) {
 	})
 
 	client := leadership.NewClient(apiCaller)
-	err := client.BlockUntilLeadershipReleased(StubServiceNm)
+	err := client.BlockUntilLeadershipReleased(StubServiceNm, nil)
 
 	c.Check(numStubCalls, gc.Equals, 1)
 	c.Check(err, gc.ErrorMatches, "error blocking on leadership release: splat")
@@ -187,7 +187,7 @@ func (s *ClientSuite) TestBlockUntilLeadershipReleasedFacadeCallError(c *gc.C) {
 	})
 
 	client := leadership.NewClient(apiCaller)
-	err := client.BlockUntilLeadershipReleased(StubServiceNm)
+	err := client.BlockUntilLeadershipReleased(StubServiceNm, nil)
 	c.Check(numStubCalls, gc.Equals, 1)
 	c.Check(err, gc.ErrorMatches, "error blocking on leadership release: "+errMsg)
 }

--- a/api/testing/fakeserver.go
+++ b/api/testing/fakeserver.go
@@ -4,6 +4,7 @@
 package testing
 
 import (
+	"context"
 	"net"
 
 	"github.com/juju/juju/rpc"
@@ -18,7 +19,7 @@ func FakeAPIServer(root interface{}) net.Conn {
 	serverCodec := jsoncodec.NewNet(c1)
 	serverRPC := rpc.NewConn(serverCodec, nil)
 	serverRPC.Serve(root, nil)
-	serverRPC.Start()
+	serverRPC.Start(context.TODO())
 	go func() {
 		<-serverRPC.Dead()
 		serverRPC.Close()

--- a/apiserver/apiserver.go
+++ b/apiserver/apiserver.go
@@ -4,6 +4,7 @@
 package apiserver
 
 import (
+	"context"
 	"crypto/tls"
 	"crypto/x509"
 	"io"
@@ -900,13 +901,25 @@ func (srv *Server) apiHandler(w http.ResponseWriter, req *http.Request) {
 	websocket.Serve(w, req, func(conn *websocket.Conn) {
 		modelUUID := req.URL.Query().Get(":modeluuid")
 		logger.Tracef("got a request for model %q", modelUUID)
-		if err := srv.serveConn(conn, modelUUID, apiObserver, req.Host); err != nil {
+		if err := srv.serveConn(
+			req.Context(),
+			conn,
+			modelUUID,
+			apiObserver,
+			req.Host,
+		); err != nil {
 			logger.Errorf("error serving RPCs: %v", err)
 		}
 	})
 }
 
-func (srv *Server) serveConn(wsConn *websocket.Conn, modelUUID string, apiObserver observer.Observer, host string) error {
+func (srv *Server) serveConn(
+	ctx context.Context,
+	wsConn *websocket.Conn,
+	modelUUID string,
+	apiObserver observer.Observer,
+	host string,
+) error {
 	codec := jsoncodec.NewWebsocket(wsConn.Conn)
 	conn := rpc.NewConn(codec, apiObserver)
 
@@ -944,7 +957,7 @@ func (srv *Server) serveConn(wsConn *websocket.Conn, modelUUID string, apiObserv
 		}
 		conn.ServeRoot(newAdminRoot(h, adminAPIs), serverError)
 	}
-	conn.Start()
+	conn.Start(ctx)
 	select {
 	case <-conn.Dead():
 	case <-srv.tomb.Dying():

--- a/apiserver/apiserver.go
+++ b/apiserver/apiserver.go
@@ -534,10 +534,6 @@ func (srv *Server) run() {
 		err := srv.lis.Close()
 		logger.Infof("closed listening socket %q with final error: %v", addr, err)
 
-		// Break deadlocks caused by leadership BlockUntil... calls.
-		srv.statePool.KillWorkers()
-		srv.statePool.SystemState().KillWorkers()
-
 		srv.wg.Wait() // wait for any outstanding requests to complete.
 		srv.tomb.Done()
 		srv.dbloggers.dispose()

--- a/apiserver/facade/facadetest/context.go
+++ b/apiserver/facade/facadetest/context.go
@@ -10,7 +10,6 @@ import (
 
 // Context implements facade.Context in the simplest possible way.
 type Context struct {
-	Abort_     <-chan struct{}
 	Auth_      facade.Authorizer
 	Dispose_   func()
 	Resources_ facade.Resources
@@ -20,11 +19,6 @@ type Context struct {
 	// Identity is not part of the facade.Context interface, but is instead
 	// used to make sure that the context objects are the same.
 	Identity string
-}
-
-// Abort is part of the facade.Context interface.
-func (context Context) Abort() <-chan struct{} {
-	return context.Abort_
 }
 
 // Auth is part of the facade.Context interface.

--- a/apiserver/facade/interface.go
+++ b/apiserver/facade/interface.go
@@ -21,11 +21,6 @@ type Factory func(Context) (Facade, error)
 // Context exposes useful capabilities to a Facade.
 type Context interface {
 
-	// Abort will be closed with the client connection. Any long-
-	// running methods should pay attention to Abort, and terminate
-	// with a sensible (non-nil) error when requested.
-	Abort() <-chan struct{}
-
 	// Auth represents information about the connected client. You
 	// should always be checking individual requests against Auth:
 	// both state changes *and* data retrieval should be blocked

--- a/apiserver/facades/agent/leadership/interface.go
+++ b/apiserver/facades/agent/leadership/interface.go
@@ -4,6 +4,8 @@
 package leadership
 
 import (
+	"context"
+
 	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/apiserver/params"
@@ -18,5 +20,5 @@ type LeadershipService interface {
 
 	// BlockUntilLeadershipReleased blocks the caller until leadership is
 	// released for the given service.
-	BlockUntilLeadershipReleased(ApplicationTag names.ApplicationTag) (params.ErrorResult, error)
+	BlockUntilLeadershipReleased(ctx context.Context, ApplicationTag names.ApplicationTag) (params.ErrorResult, error)
 }

--- a/apiserver/facades/controller/singular/fixture_test.go
+++ b/apiserver/facades/controller/singular/fixture_test.go
@@ -57,7 +57,12 @@ func (mock *mockBackend) Claim(lease, holder string, duration time.Duration) err
 }
 
 // WaitUntilExpired is part of the lease.Claimer interface.
-func (mock *mockBackend) WaitUntilExpired(lease string) error {
-	mock.stub.AddCall("WaitUntilExpired", lease)
+func (mock *mockBackend) WaitUntilExpired(leaseId string, cancel <-chan struct{}) error {
+	mock.stub.AddCall("WaitUntilExpired", leaseId)
+	select {
+	case <-cancel:
+		return lease.ErrWaitCancelled
+	default:
+	}
 	return mock.stub.NextErr()
 }

--- a/apiserver/root.go
+++ b/apiserver/root.go
@@ -4,6 +4,7 @@
 package apiserver
 
 import (
+	"context"
 	"net/url"
 	"reflect"
 	"sync"
@@ -142,12 +143,12 @@ func (s *srvCaller) ResultType() reflect.Type {
 
 // Call takes the object Id and an instance of ParamsType to create an object and place
 // a call on its method. It then returns an instance of ResultType.
-func (s *srvCaller) Call(objId string, arg reflect.Value) (reflect.Value, error) {
+func (s *srvCaller) Call(ctx context.Context, objId string, arg reflect.Value) (reflect.Value, error) {
 	objVal, err := s.creator(objId)
 	if err != nil {
 		return reflect.Value{}, err
 	}
-	return s.objMethod.Call(objVal, arg)
+	return s.objMethod.Call(ctx, objVal, arg)
 }
 
 // apiRoot implements basic method dispatching to the facade registry.
@@ -315,11 +316,6 @@ func (r *apiRoot) facadeContext(key objectKey) *facadeContext {
 type facadeContext struct {
 	r   *apiRoot
 	key objectKey
-}
-
-// Abort is part of of the facade.Context interface.
-func (ctx *facadeContext) Abort() <-chan struct{} {
-	return nil
 }
 
 // Auth is part of of the facade.Context interface.

--- a/apiserver/root_test.go
+++ b/apiserver/root_test.go
@@ -4,6 +4,7 @@
 package apiserver_test
 
 import (
+	"context"
 	"fmt"
 	"reflect"
 	"sync"
@@ -163,14 +164,14 @@ func (r *rootSuite) TestFindMethodEnsuresTypeMatch(c *gc.C) {
 	// fine
 	caller, err := srvRoot.FindMethod("my-testing-facade", 1, "Exposed")
 	c.Assert(err, jc.ErrorIsNil)
-	_, err = caller.Call("", reflect.Value{})
+	_, err = caller.Call(context.TODO(), "", reflect.Value{})
 	c.Check(err, gc.ErrorMatches, "Exposed was bogus")
 
 	// However, myBadFacade returns the wrong type, so trying to access it
 	// should create an error
 	caller, err = srvRoot.FindMethod("my-testing-facade", 0, "Exposed")
 	c.Assert(err, jc.ErrorIsNil)
-	_, err = caller.Call("", reflect.Value{})
+	_, err = caller.Call(context.TODO(), "", reflect.Value{})
 	c.Check(err, gc.ErrorMatches,
 		`internal error, my-testing-facade\(0\) claimed to return \*apiserver_test.testingType but returned \*apiserver_test.badType`)
 
@@ -178,7 +179,7 @@ func (r *rootSuite) TestFindMethodEnsuresTypeMatch(c *gc.C) {
 	// error, but that shouldn't trigger the type checking code.
 	caller, err = srvRoot.FindMethod("my-testing-facade", 2, "Exposed")
 	c.Assert(err, jc.ErrorIsNil)
-	res, err := caller.Call("", reflect.Value{})
+	res, err := caller.Call(context.TODO(), "", reflect.Value{})
 	c.Check(err, gc.ErrorMatches, `you shall not pass`)
 	c.Check(res.IsValid(), jc.IsFalse)
 }
@@ -201,7 +202,7 @@ func (ct *countingType) AltCount() stringVar {
 }
 
 func assertCallResult(c *gc.C, caller rpcreflect.MethodCaller, id string, expected string) {
-	v, err := caller.Call(id, reflect.Value{})
+	v, err := caller.Call(context.TODO(), id, reflect.Value{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(v.Interface(), gc.Equals, stringVar{expected})
 }
@@ -291,10 +292,10 @@ func (r *rootSuite) TestFindMethodCacheRaceSafe(c *gc.C) {
 	// This is designed to trigger the race detector
 	var wg sync.WaitGroup
 	wg.Add(4)
-	go func() { caller.Call("first", reflect.Value{}); wg.Done() }()
-	go func() { caller.Call("second", reflect.Value{}); wg.Done() }()
-	go func() { caller.Call("first", reflect.Value{}); wg.Done() }()
-	go func() { caller.Call("second", reflect.Value{}); wg.Done() }()
+	go func() { caller.Call(context.TODO(), "first", reflect.Value{}); wg.Done() }()
+	go func() { caller.Call(context.TODO(), "second", reflect.Value{}); wg.Done() }()
+	go func() { caller.Call(context.TODO(), "first", reflect.Value{}); wg.Done() }()
+	go func() { caller.Call(context.TODO(), "second", reflect.Value{}); wg.Done() }()
 	wg.Wait()
 	// Once we're done, we should have only instantiated 2 different
 	// objects. If we pass a different Id, we should be at 3 total count.

--- a/apiserver/testing/fakeapi.go
+++ b/apiserver/testing/fakeapi.go
@@ -1,6 +1,7 @@
 package testing
 
 import (
+	"context"
 	"crypto/tls"
 	"net/http"
 	"net/http/httptest"
@@ -72,10 +73,10 @@ func (srv *Server) serveAPI(w http.ResponseWriter, req *http.Request) {
 	if err != nil {
 		return
 	}
-	srv.serveConn(conn, req.URL.Query().Get(":modeluuid"))
+	srv.serveConn(req.Context(), conn, req.URL.Query().Get(":modeluuid"))
 }
 
-func (srv *Server) serveConn(wsConn *websocket.Conn, modelUUID string) {
+func (srv *Server) serveConn(ctx context.Context, wsConn *websocket.Conn, modelUUID string) {
 	codec := jsoncodec.NewWebsocket(wsConn)
 	conn := rpc.NewConn(codec, &fakeobserver.Instance{})
 
@@ -83,7 +84,7 @@ func (srv *Server) serveConn(wsConn *websocket.Conn, modelUUID string) {
 		rpcreflect.ValueOf(reflect.ValueOf(srv.newRoot(modelUUID))),
 	}
 	conn.ServeRoot(root, nil)
-	conn.Start()
+	conn.Start(ctx)
 	<-conn.Dead()
 	conn.Close()
 }

--- a/core/leadership/interface.go
+++ b/core/leadership/interface.go
@@ -20,6 +20,10 @@ import (
 // leadership claim has been denied.
 var ErrClaimDenied = errors.New("leadership claim denied")
 
+// ErrBlockCancelled is returned from BlockUntilLeadershipReleased
+// if the client cancels the request by closing the cancel channel.
+var ErrBlockCancelled = errors.New("waiting for leadership cancelled by client")
+
 // Claimer exposes leadership acquisition capabilities.
 type Claimer interface {
 
@@ -31,7 +35,7 @@ type Claimer interface {
 	// BlockUntilLeadershipReleased blocks until the named application is known
 	// to have no leader, in which case it returns no error; or until the
 	// manager is stopped, in which case it will fail.
-	BlockUntilLeadershipReleased(applicationId string) (err error)
+	BlockUntilLeadershipReleased(applicationId string, cancel <-chan struct{}) (err error)
 }
 
 // Token represents a unit's leadership of its application.

--- a/core/lease/claimer.go
+++ b/core/lease/claimer.go
@@ -15,6 +15,10 @@ var ErrClaimDenied = errors.New("lease claim denied")
 // ErrNotHeld indicates that some holder does not hold some lease.
 var ErrNotHeld = errors.New("lease not held")
 
+// ErrWaitCancelled is returned by Claimer.WaitUntilExpired if the
+// cancel channel is closed.
+var ErrWaitCancelled = errors.New("waiting for lease cancelled by client")
+
 // Claimer exposes lease acquisition and expiry notification capabilities.
 type Claimer interface {
 
@@ -26,8 +30,10 @@ type Claimer interface {
 	Claim(leaseName, holderName string, duration time.Duration) error
 
 	// WaitUntilExpired returns nil when the named lease is no longer held. If it
-	// returns any other error, no reasonable inferences may be made.
-	WaitUntilExpired(leaseName string) error
+	// returns any error, no reasonable inferences may be made. If the supplied
+	// cancel channel is non-nil, it can be used to cancel the request; in this
+	// case, the method will return ErrWaitCancelled.
+	WaitUntilExpired(leaseName string, cancel <-chan struct{}) error
 }
 
 // Checker exposes facts about lease ownership.

--- a/rpc/dispatch_test.go
+++ b/rpc/dispatch_test.go
@@ -4,6 +4,7 @@
 package rpc_test
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -35,7 +36,7 @@ func (s *dispatchSuite) SetUpSuite(c *gc.C) {
 		conn := rpc.NewConn(codec, &notifier{})
 
 		conn.Serve(&DispatchRoot{}, nil)
-		conn.Start()
+		conn.Start(context.Background())
 
 		<-conn.Dead()
 	}

--- a/rpc/reflect_test.go
+++ b/rpc/reflect_test.go
@@ -4,6 +4,7 @@
 package rpc_test
 
 import (
+	"context"
 	"reflect"
 
 	jc "github.com/juju/testing/checkers"
@@ -36,6 +37,7 @@ func (*reflectSuite) TestTypeOf(c *gc.C) {
 		"ErrorMethods":     reflect.TypeOf(&ErrorMethods{}),
 		"InterfaceMethods": reflect.TypeOf((*InterfaceMethods)(nil)).Elem(),
 		"SimpleMethods":    reflect.TypeOf(&SimpleMethods{}),
+		"ContextMethods":   reflect.TypeOf(&ContextMethods{}),
 	}
 	c.Assert(rtype.MethodNames(), gc.HasLen, len(expect))
 	for name, expectGoType := range expect {
@@ -130,7 +132,7 @@ func (*reflectSuite) TestFindMethod(c *gc.C) {
 	c.Assert(m.ParamsType(), gc.Equals, reflect.TypeOf(stringVal{}))
 	c.Assert(m.ResultType(), gc.Equals, reflect.TypeOf(stringVal{}))
 
-	ret, err := m.Call("a99", reflect.ValueOf(stringVal{"foo"}))
+	ret, err := m.Call(context.TODO(), "a99", reflect.ValueOf(stringVal{"foo"}))
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(ret.Interface(), gc.Equals, stringVal{"Call1r1e ret"})
 }

--- a/rpc/rpcreflect/value.go
+++ b/rpc/rpcreflect/value.go
@@ -4,6 +4,7 @@
 package rpcreflect
 
 import (
+	"context"
 	"fmt"
 	"reflect"
 )
@@ -117,12 +118,15 @@ func (v Value) Kill() {
 	}
 }
 
-func (caller methodCaller) Call(objId string, arg reflect.Value) (reflect.Value, error) {
+func (caller methodCaller) Call(ctx context.Context, objId string, arg reflect.Value) (reflect.Value, error) {
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
 	obj, err := caller.rootMethod.Call(caller.rootValue, objId)
 	if err != nil {
 		return reflect.Value{}, err
 	}
-	return caller.objMethod.Call(obj, arg)
+	return caller.objMethod.Call(ctx, obj, arg)
 }
 
 func (caller methodCaller) ParamsType() reflect.Type {
@@ -142,5 +146,5 @@ type MethodCaller interface {
 
 	// Call is actually placing a call to instantiate an given instance and
 	// call the method on that instance.
-	Call(objId string, arg reflect.Value) (reflect.Value, error)
+	Call(ctx context.Context, objId string, arg reflect.Value) (reflect.Value, error)
 }

--- a/state/leadership.go
+++ b/state/leadership.go
@@ -137,7 +137,10 @@ func (m leadershipClaimer) ClaimLeadership(applicationname, unitName string, dur
 }
 
 // BlockUntilLeadershipReleased is part of the leadership.Claimer interface.
-func (m leadershipClaimer) BlockUntilLeadershipReleased(applicationname string) error {
-	err := m.claimer.WaitUntilExpired(applicationname)
+func (m leadershipClaimer) BlockUntilLeadershipReleased(applicationname string, cancel <-chan struct{}) error {
+	err := m.claimer.WaitUntilExpired(applicationname, cancel)
+	if errors.Cause(err) == corelease.ErrWaitCancelled {
+		return leadership.ErrBlockCancelled
+	}
 	return errors.Trace(err)
 }

--- a/state/pool.go
+++ b/state/pool.go
@@ -185,16 +185,6 @@ func (p *StatePool) SystemState() *State {
 	return p.systemState
 }
 
-// KillWorkers tells the internal worker for all cached State
-// instances in the pool to die.
-func (p *StatePool) KillWorkers() {
-	p.mu.Lock()
-	defer p.mu.Unlock()
-	for _, item := range p.pool {
-		item.state.KillWorkers()
-	}
-}
-
 // Close closes all State instances in the pool.
 func (p *StatePool) Close() error {
 	p.mu.Lock()

--- a/state/pool_test.go
+++ b/state/pool_test.go
@@ -73,27 +73,6 @@ func (s *statePoolSuite) TestGetSystemState(c *gc.C) {
 	c.Assert(st0, gc.Equals, s.State)
 }
 
-func (s *statePoolSuite) TestKillWorkers(c *gc.C) {
-	// Get some State instances via the pool and extract their
-	// internal workers.
-	st1, _, err := s.Pool.Get(s.ModelUUID1)
-	c.Assert(err, jc.ErrorIsNil)
-	w1 := state.GetInternalWorkers(st1)
-	workertest.CheckAlive(c, w1)
-
-	st2, _, err := s.Pool.Get(s.ModelUUID2)
-	c.Assert(err, jc.ErrorIsNil)
-	w2 := state.GetInternalWorkers(st2)
-	workertest.CheckAlive(c, w2)
-
-	// Now kill their workers.
-	s.Pool.KillWorkers()
-
-	// Ensure the internal workers for each State died.
-	c.Check(workertest.CheckKilled(c, w1), jc.ErrorIsNil)
-	c.Check(workertest.CheckKilled(c, w2), jc.ErrorIsNil)
-}
-
 func (s *statePoolSuite) TestClose(c *gc.C) {
 	// Get some State instances.
 	st1, _, err := s.Pool.Get(s.ModelUUID1)

--- a/state/singular_test.go
+++ b/state/singular_test.go
@@ -71,7 +71,7 @@ func (s *SingularSuite) TestExpire(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	wait := make(chan error)
 	go func() {
-		wait <- claimer.WaitUntilExpired(s.modelTag.Id())
+		wait <- claimer.WaitUntilExpired(s.modelTag.Id(), nil)
 	}()
 
 	g, err := s.State.GlobalClockUpdater()

--- a/state/state.go
+++ b/state/state.go
@@ -404,26 +404,6 @@ func (st *State) start(controllerTag names.ControllerTag) (err error) {
 	return nil
 }
 
-// KillWorkers tells the state's internal workers to die. This is
-// mainly used to kill the leadership manager to prevent it from
-// interfering with apiserver shutdown.
-func (st *State) KillWorkers() {
-	// TODO(fwereade): 2015-08-07 lp:1482634
-	// obviously, this should not exist: it's a quick hack to address lp:1481368 in
-	// 1.24.4, and should be quickly replaced with something that isn't so heinous.
-	//
-	// But.
-	//
-	// I *believe* that what it'll take to fix this is to extract the mongo-session-
-	// opening from state.Open, so we can create a mongosessioner Manifold on which
-	// state, leadership, watching, tools storage, etc etc etc can all independently
-	// depend. (Each dependency would/should have a separate session so they can
-	// close them all on their own schedule, without panics -- but the failure of
-	// the shared component should successfully goose them all into shutting down,
-	// in parallel, of their own accord.)
-	st.workers.Kill()
-}
-
 // ApplicationLeaders returns a map of the application name to the
 // unit name that is the current leader.
 func (st *State) ApplicationLeaders() (map[string]string, error) {

--- a/state/workers.go
+++ b/state/workers.go
@@ -184,8 +184,8 @@ func (l lazyLeaseManager) Claim(leaseName, holderName string, duration time.Dura
 }
 
 // WaitUntilExpired is part of the lease.Claimer interface.
-func (l lazyLeaseManager) WaitUntilExpired(leaseName string) error {
-	return l.leaseManager().WaitUntilExpired(leaseName)
+func (l lazyLeaseManager) WaitUntilExpired(leaseName string, cancel <-chan struct{}) error {
+	return l.leaseManager().WaitUntilExpired(leaseName, cancel)
 }
 
 // Token is part of the lease.Checker interface.

--- a/worker/leadership/tracker_test.go
+++ b/worker/leadership/tracker_test.go
@@ -55,16 +55,6 @@ func (s *TrackerSuite) SetUpTest(c *gc.C) {
 	}
 }
 
-func (s *TrackerSuite) TearDownTest(c *gc.C) {
-	if s.claimer != nil {
-		// It's not impossible that there's a goroutine waiting for a
-		// BlockUntilLeadershipReleased. Make sure it completes.
-		close(s.claimer.releases)
-		s.claimer = nil
-	}
-	s.IsolationSuite.TearDownTest(c)
-}
-
 func (s *TrackerSuite) unblockRelease(c *gc.C) {
 	select {
 	case s.claimer.releases <- struct{}{}:
@@ -124,9 +114,6 @@ func (s *TrackerSuite) TestOnLeaderFailure(c *gc.C) {
 	// Stop the tracker before trying to look at its mocks.
 	workertest.CleanKill(c, tracker)
 
-	// Unblock the release goroutine, lest data races.
-	s.unblockRelease(c)
-
 	s.claimer.CheckCalls(c, []testing.StubCall{{
 		FuncName: "ClaimLeadership",
 		Args: []interface{}{
@@ -172,9 +159,6 @@ func (s *TrackerSuite) TestLoseLeadership(c *gc.C) {
 
 	// Stop the tracker before trying to look at its stub.
 	workertest.CleanKill(c, tracker)
-
-	// Unblock the release goroutine, lest data races.
-	s.unblockRelease(c)
 
 	s.claimer.CheckCalls(c, []testing.StubCall{{
 		FuncName: "ClaimLeadership",
@@ -254,9 +238,6 @@ func (s *TrackerSuite) TestFailGainLeadership(c *gc.C) {
 
 	// ...but it won't, because we Stop the tracker...
 	workertest.CleanKill(c, tracker)
-
-	// ...and clear out the release goroutine before we look at the stub.
-	s.unblockRelease(c)
 
 	s.claimer.CheckCalls(c, []testing.StubCall{{
 		FuncName: "ClaimLeadership",
@@ -348,9 +329,6 @@ func (s *TrackerSuite) TestWaitLeaderNeverBecomeLeader(c *gc.C) {
 	assertTicket(c, ticket, false)
 	assertTicket(c, ticket, false)
 
-	// Unblock the release goroutine and stop the tracker before trying to
-	// look at its stub.
-	s.unblockRelease(c)
 	s.claimer.CheckCalls(c, []testing.StubCall{{
 		FuncName: "ClaimLeadership",
 		Args: []interface{}{
@@ -400,9 +378,6 @@ func (s *TrackerSuite) TestWaitMinionBecomeMinion(c *gc.C) {
 
 	// Stop the tracker before trying to look at its stub.
 	workertest.CleanKill(c, tracker)
-
-	// Unblock the release goroutine, lest data races.
-	s.unblockRelease(c)
 
 	s.claimer.CheckCalls(c, []testing.StubCall{{
 		FuncName: "ClaimLeadership",

--- a/worker/leadership/util_test.go
+++ b/worker/leadership/util_test.go
@@ -22,8 +22,12 @@ func (stub *StubClaimer) ClaimLeadership(serviceName, unitName string, duration 
 	return stub.NextErr()
 }
 
-func (stub *StubClaimer) BlockUntilLeadershipReleased(serviceName string) error {
+func (stub *StubClaimer) BlockUntilLeadershipReleased(serviceName string, cancel <-chan struct{}) error {
 	stub.MethodCall(stub, "BlockUntilLeadershipReleased", serviceName)
-	<-stub.releases
+	select {
+	case <-cancel:
+		return leadership.ErrBlockCancelled
+	case <-stub.releases:
+	}
 	return stub.NextErr()
 }

--- a/worker/lease/claim.go
+++ b/worker/lease/claim.go
@@ -16,14 +16,14 @@ type claim struct {
 	holderName string
 	duration   time.Duration
 	response   chan bool
-	abort      <-chan struct{}
+	stop       <-chan struct{}
 }
 
 // invoke sends the claim on the supplied channel and waits for a response.
 func (c claim) invoke(ch chan<- claim) error {
 	for {
 		select {
-		case <-c.abort:
+		case <-c.stop:
 			return errStopped
 		case ch <- c:
 			ch = nil
@@ -39,7 +39,7 @@ func (c claim) invoke(ch chan<- claim) error {
 // respond causes the supplied success value to be sent back to invoke.
 func (c claim) respond(success bool) {
 	select {
-	case <-c.abort:
+	case <-c.stop:
 	case c.response <- success:
 	}
 }

--- a/worker/lease/manager_validation_test.go
+++ b/worker/lease/manager_validation_test.go
@@ -154,7 +154,7 @@ func (s *ValidationSuite) TestToken_OutPtr(c *gc.C) {
 func (s *ValidationSuite) TestWaitUntilExpired_LeaseName(c *gc.C) {
 	fix := &Fixture{}
 	fix.RunTest(c, func(manager *lease.Manager, _ *testing.Clock) {
-		err := manager.WaitUntilExpired("INVALID")
+		err := manager.WaitUntilExpired("INVALID", nil)
 		c.Check(err, gc.ErrorMatches, `cannot wait for lease "INVALID" expiry: name not valid`)
 		c.Check(err, jc.Satisfies, errors.IsNotValid)
 	})


### PR DESCRIPTION
## Description of change

This PR adds the capability to include a context.Context parameter in methods exposed via a juju/rpc connection. When the connection is closed or the request completes normally, the context will be cancelled.

The singular/leadership API calls are updated to use the context to cancel lease/leadership claims, rather than relying on the lease managers in state being killed. State.KillWorkers is removed. This change paves the way for moving the API server to the dependency engine, reducing the number of active MongoDB connections we maintain, and simplifying how we thread the state pool through to the introspection worker.

This change will also enable us to introduce OpenTracing calls to the API server, and later the API client.

## QA steps

1. juju bootstrap localhost
2. juju enable-ha
(wait)
3. juju upgrade-juju -m controller --build-agent (forces agents to restart gracefully, exercising server shutdown code)

## Documentation changes

None.

## Bug reference

None.