### PR TITLE
vsphere: handle "object not found" when destroying

### DIFF
--- a/provider/vsphere/internal/vsphereclient/client_test.go
+++ b/provider/vsphere/internal/vsphereclient/client_test.go
@@ -458,6 +458,15 @@ func (s *clientSuite) TestDestroyVMFolder(c *gc.C) {
 	})
 }
 
+func (s *clientSuite) TestDestroyVMFolderRace(c *gc.C) {
+	s.roundTripper.taskError[destroyTask] = &types.LocalizedMethodFault{
+		Fault: &types.ManagedObjectNotFound{},
+	}
+	client := s.newFakeClient(&s.roundTripper, "dc0")
+	err := client.DestroyVMFolder(context.Background(), "foo")
+	c.Assert(err, jc.ErrorIsNil)
+}
+
 func (s *clientSuite) TestEnsureVMFolder(c *gc.C) {
 	client := s.newFakeClient(&s.roundTripper, "dc0")
 	folder, err := client.EnsureVMFolder(context.Background(), "foo/bar")
@@ -555,6 +564,15 @@ func (s *clientSuite) TestRemoveVirtualMachines(c *gc.C) {
 		testing.StubCall{"CreateFilter", nil},
 		testing.StubCall{"WaitForUpdatesEx", nil},
 	})
+}
+
+func (s *clientSuite) TestRemoveVirtualMachinesDestroyRace(c *gc.C) {
+	s.roundTripper.taskError[destroyTask] = &types.LocalizedMethodFault{
+		Fault: &types.ManagedObjectNotFound{},
+	}
+	client := s.newFakeClient(&s.roundTripper, "dc0")
+	err := client.RemoveVirtualMachines(context.Background(), "foo/bar/*")
+	c.Assert(err, jc.ErrorIsNil)
 }
 
 func (s *clientSuite) TestUpdateVirtualMachineExtraConfig(c *gc.C) {


### PR DESCRIPTION
## Description of change

When destroying VMs and folders, handle "ManagedObjectNotFound"
faults. We consider this to be successful removal.

## QA steps

In a loop:
  1. juju bootstrap vsphere
  2. juju destroy-controller vsphere

while also running "govc vm.destroy juju-*" in a loop.

I forced the issue by modifying the Juju code to issue two Destroy_Tasks. The second one fails with the error, which we now ignore.

## Documentation changes

None.

## Bug reference

Fixes https://bugs.launchpad.net/juju/+bug/1701142