### PR TITLE
Add a controller instance to state pool; remove prod cases of state.ForModel()

### DIFF
--- a/api/apiclient_test.go
+++ b/api/apiclient_test.go
@@ -567,7 +567,7 @@ func (s *apiclientSuite) TestPublicDNSName(c *gc.C) {
 	listener, err := net.Listen("tcp", "localhost:0")
 	c.Assert(err, gc.IsNil)
 	machineTag := names.NewMachineTag("0")
-	statePool := state.NewStatePool(s.State)
+	statePool := state.NewStatePool(s.Controller)
 	defer statePool.Close()
 	srv, err := apiserver.NewServer(statePool, listener, apiserver.ServerConfig{
 		Clock:           clock.WallClock,

--- a/api/controller/legacy_test.go
+++ b/api/controller/legacy_test.go
@@ -215,7 +215,7 @@ func (s *legacySuite) TestAPIServerCanShutdownWithOutstandingNext(c *gc.C) {
 	lis, err := net.Listen("tcp", "localhost:0")
 	c.Assert(err, jc.ErrorIsNil)
 
-	statePool := state.NewStatePool(s.State)
+	statePool := state.NewStatePool(s.Controller)
 	defer statePool.Close()
 
 	srv, err := apiserver.NewServer(statePool, lis, apiserver.ServerConfig{

--- a/api/pubsub/pubsub_test.go
+++ b/api/pubsub/pubsub_test.go
@@ -155,7 +155,7 @@ func (s *PubSubIntegrationSuite) SetUpTest(c *gc.C) {
 	s.password = password
 	s.hub = pubsub.NewStructuredHub(nil)
 
-	statePool := state.NewStatePool(s.State)
+	statePool := state.NewStatePool(s.Controller)
 	s.AddCleanup(func(*gc.C) { statePool.Close() })
 	s.server, s.address = newServerWithHub(c, statePool, s.hub)
 	s.AddCleanup(func(*gc.C) { s.server.Stop() })

--- a/apiserver/admin.go
+++ b/apiserver/admin.go
@@ -404,7 +404,8 @@ func (a *admin) checkCreds(req params.LoginRequest, lookForModelUser bool) (stat
 }
 
 func (a *admin) checkControllerMachineCreds(req params.LoginRequest) (state.Entity, error) {
-	return checkControllerMachineCreds(a.srv.statePool.SystemState(), req, a.authenticator())
+	st := a.srv.statePool.GetController().ControllerState()
+	return checkControllerMachineCreds(st, req, a.authenticator())
 }
 
 func (a *admin) authenticator() authentication.EntityAuthenticator {

--- a/apiserver/admin_test.go
+++ b/apiserver/admin_test.go
@@ -51,7 +51,7 @@ var _ = gc.Suite(&loginSuite{})
 func (s *baseLoginSuite) SetUpTest(c *gc.C) {
 	s.JujuConnSuite.SetUpTest(c)
 	loggo.GetLogger("juju.apiserver").SetLogLevel(loggo.TRACE)
-	s.pool = state.NewStatePool(s.State)
+	s.pool = state.NewStatePool(s.Controller)
 	s.AddCleanup(func(*gc.C) { s.pool.Close() })
 }
 
@@ -913,7 +913,7 @@ type macaroonLoginSuite struct {
 
 func (s *macaroonLoginSuite) SetUpTest(c *gc.C) {
 	s.MacaroonSuite.SetUpTest(c)
-	s.pool = state.NewStatePool(s.State)
+	s.pool = state.NewStatePool(s.Controller)
 	s.AddCleanup(func(*gc.C) { s.pool.Close() })
 }
 

--- a/apiserver/apiserver_test.go
+++ b/apiserver/apiserver_test.go
@@ -41,7 +41,7 @@ func (s *apiserverBaseSuite) SetUpTest(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	err = u.SetPassword(ownerPassword)
 	c.Assert(err, jc.ErrorIsNil)
-	s.pool = state.NewStatePool(s.State)
+	s.pool = state.NewStatePool(s.Controller)
 	s.AddCleanup(func(*gc.C) { s.pool.Close() })
 }
 

--- a/apiserver/authenticator_test.go
+++ b/apiserver/authenticator_test.go
@@ -33,7 +33,7 @@ var _ = gc.Suite(&agentAuthenticatorSuite{})
 
 func (s *agentAuthenticatorSuite) SetUpTest(c *gc.C) {
 	s.JujuConnSuite.SetUpTest(c)
-	s.pool = state.NewStatePool(s.State)
+	s.pool = state.NewStatePool(s.Controller)
 	s.AddCleanup(func(*gc.C) { s.pool.Close() })
 }
 

--- a/apiserver/common/modelstatus_test.go
+++ b/apiserver/common/modelstatus_test.go
@@ -56,7 +56,7 @@ func (s *modelStatusSuite) SetUpTest(c *gc.C) {
 		AdminTag: s.Owner,
 	}
 
-	s.pool = state.NewStatePool(s.State)
+	s.pool = state.NewStatePool(s.Controller)
 	s.AddCleanup(func(*gc.C) { s.pool.Close() })
 
 	controller, err := controller.NewControllerAPIv4(

--- a/apiserver/export_test.go
+++ b/apiserver/export_test.go
@@ -95,7 +95,7 @@ func TestingAPIRoot(facades *facade.Registry) rpc.Root {
 // TestingAPIHandler gives you an APIHandler that isn't connected to
 // anything real. It's enough to let test some basic functionality though.
 func TestingAPIHandler(c *gc.C, pool *state.StatePool, st *state.State) (*apiHandler, *common.Resources) {
-	loginAuthCtxt, err := newAuthContext(pool.SystemState())
+	loginAuthCtxt, err := newAuthContext(pool.GetController().ControllerState())
 	c.Assert(err, jc.ErrorIsNil)
 	offerAuthCtxt, err := newOfferAuthcontext(pool)
 	c.Assert(err, jc.ErrorIsNil)

--- a/apiserver/facades/client/cloud/cloud.go
+++ b/apiserver/facades/client/cloud/cloud.go
@@ -52,13 +52,13 @@ var (
 // NewFacade provides the required signature for facade registration.
 func NewFacade(context facade.Context) (*CloudAPI, error) {
 	st := NewStateBackend(context.State())
-	ctlrSt := NewStateBackend(context.StatePool().SystemState())
+	ctlrSt := NewStateBackend(context.StatePool().GetController().ControllerState())
 	return NewCloudAPI(st, ctlrSt, context.Auth())
 }
 
 func NewFacadeV2(context facade.Context) (*CloudAPIV2, error) {
 	st := NewStateBackend(context.State())
-	ctlrSt := NewStateBackend(context.StatePool().SystemState())
+	ctlrSt := NewStateBackend(context.StatePool().GetController().ControllerState())
 	return NewCloudAPIV2(st, ctlrSt, context.Auth())
 }
 

--- a/apiserver/facades/client/controller/controller.go
+++ b/apiserver/facades/client/controller/controller.go
@@ -245,7 +245,7 @@ func (s *ControllerAPI) ModelConfig() (params.ModelConfigResults, error) {
 		return result, errors.Trace(err)
 	}
 
-	controllerState := s.statePool.SystemState()
+	controllerState := s.statePool.GetController().ControllerState()
 	controllerModel, err := controllerState.Model()
 	if err != nil {
 		return result, errors.Trace(err)
@@ -445,7 +445,8 @@ func (c *ControllerAPI) initiateOneMigration(spec params.MigrationSpec) (string,
 	}
 
 	// Check if the migration is likely to succeed.
-	if err := runMigrationPrechecks(hostedState, c.statePool.SystemState(), &targetInfo); err != nil {
+	ctrlSt := c.statePool.GetController().ControllerState()
+	if err := runMigrationPrechecks(hostedState, ctrlSt, &targetInfo); err != nil {
 		return "", errors.Trace(err)
 	}
 
@@ -503,7 +504,7 @@ func (c *ControllerAPI) ModifyControllerAccess(args params.ModifyControllerAcces
 // retrieved from the target controller.
 var runMigrationPrechecks = func(st, ctlrSt *state.State, targetInfo *coremigration.TargetInfo) error {
 	// Check model and source controller.
-	backend, err := migration.PrecheckShim(st)
+	backend, err := migration.PrecheckShim(st, ctlrSt)
 	if err != nil {
 		return errors.Annotate(err, "creating backend")
 	}

--- a/apiserver/facades/client/controller/controller_test.go
+++ b/apiserver/facades/client/controller/controller_test.go
@@ -52,7 +52,7 @@ func (s *controllerSuite) SetUpTest(c *gc.C) {
 
 	s.StateSuite.SetUpTest(c)
 
-	s.statePool = state.NewStatePool(s.State)
+	s.statePool = state.NewStatePool(s.Controller)
 	s.AddCleanup(func(c *gc.C) {
 		err := s.statePool.Close()
 		c.Assert(err, jc.ErrorIsNil)

--- a/apiserver/facades/client/modelmanager/modelmanager.go
+++ b/apiserver/facades/client/modelmanager/modelmanager.go
@@ -103,7 +103,7 @@ var (
 func NewFacadeV4(ctx facade.Context) (*ModelManagerAPI, error) {
 	st := ctx.State()
 	pool := ctx.StatePool()
-	ctlrSt := pool.SystemState()
+	ctlrSt := pool.GetController().ControllerState()
 	auth := ctx.Auth()
 
 	var err error

--- a/apiserver/facades/controller/migrationmaster/shim.go
+++ b/apiserver/facades/controller/migrationmaster/shim.go
@@ -16,7 +16,7 @@ import (
 // NewFacade exists to provide the required signature for API
 // registration, converting st to backend.
 func NewFacade(ctx facade.Context) (*API, error) {
-	precheckBackend, err := migration.PrecheckShim(ctx.State())
+	precheckBackend, err := migration.PrecheckShim(ctx.State(), ctx.State())
 	if err != nil {
 		return nil, errors.Annotate(err, "creating precheck backend")
 	}

--- a/apiserver/facades/controller/migrationtarget/migrationtarget.go
+++ b/apiserver/facades/controller/migrationtarget/migrationtarget.go
@@ -84,7 +84,7 @@ func (api *API) Prechecks(model params.MigrationModelInfo) error {
 	if err != nil {
 		return errors.Trace(err)
 	}
-	backend, err := migration.PrecheckShim(api.state)
+	backend, err := migration.PrecheckShim(api.state, api.state)
 	if err != nil {
 		return errors.Annotate(err, "creating backend")
 	}

--- a/apiserver/gui.go
+++ b/apiserver/gui.go
@@ -137,7 +137,7 @@ func (gr *guiRouter) ensureFileHandler(h func(gh *guiHandler, w http.ResponseWri
 // and archive hash.
 func (gr *guiRouter) ensureFiles(req *http.Request) (rootDir string, hash string, err error) {
 	// Retrieve the Juju GUI info from the GUI storage.
-	st := gr.ctxt.srv.statePool.SystemState()
+	st := gr.ctxt.srv.statePool.GetController().ControllerState()
 	storage, err := st.GUIStorage()
 	if err != nil {
 		return "", "", errors.Annotate(err, "cannot open GUI storage")
@@ -361,7 +361,7 @@ func getConfigPath(path string, ctxt httpContext) string {
 	if uuid != "" {
 		return fmt.Sprintf("%[1]s?model-uuid=%[2]s&base-postfix=%[2]s/", configPath, uuid)
 	}
-	st := ctxt.srv.statePool.SystemState()
+	st := ctxt.srv.statePool.GetController().ControllerState()
 	if isNewGUI(st) {
 		// This is the proper case in which a new GUI is being served from a
 		// new URL. No query must be included in the config path.

--- a/apiserver/httpcontext.go
+++ b/apiserver/httpcontext.go
@@ -84,7 +84,8 @@ func (ctxt *httpContext) stateForRequestAuthenticated(r *http.Request) (
 		// Handle the special case of a worker on a controller machine
 		// acting on behalf of a hosted model.
 		if isMachineTag(req.AuthTag) {
-			entity, err := checkControllerMachineCreds(ctxt.srv.statePool.SystemState(), req, authenticator)
+			entity, err := checkControllerMachineCreds(
+				ctxt.srv.statePool.GetController().ControllerState(), req, authenticator)
 			if err != nil {
 				return nil, nil, nil, errors.NewUnauthorized(err, "")
 			}

--- a/apiserver/localofferauth.go
+++ b/apiserver/localofferauth.go
@@ -25,7 +25,7 @@ func newOfferAuthcontext(pool *state.StatePool) (*crossmodel.AuthContext, error)
 	// Create a bakery service for discharging third-party caveats for
 	// local offer access authentication. This service does not persist keys;
 	// its macaroons should be very short-lived.
-	st := pool.SystemState()
+	st := pool.GetController().ControllerState()
 	localOfferThirdPartyBakeryService, _, err := newBakeryService(st, nil, nil)
 	if err != nil {
 		return nil, errors.Trace(err)

--- a/apiserver/logsink_test.go
+++ b/apiserver/logsink_test.go
@@ -214,7 +214,7 @@ func (s *logsinkSuite) TestNewServerValidatesLogSinkConfig(c *gc.C) {
 	type dummyListener struct {
 		net.Listener
 	}
-	pool := state.NewStatePool(s.State)
+	pool := state.NewStatePool(s.Controller)
 	defer pool.Close()
 
 	cfg := defaultServerConfig(c)

--- a/apiserver/pubsub_test.go
+++ b/apiserver/pubsub_test.go
@@ -49,7 +49,7 @@ func (s *pubsubSuite) SetUpTest(c *gc.C) {
 	s.machineTag = m.Tag()
 	s.password = password
 	s.hub = pubsub.NewStructuredHub(nil)
-	s.pool = state.NewStatePool(s.State)
+	s.pool = state.NewStatePool(s.Controller)
 	s.AddCleanup(func(*gc.C) { s.pool.Close() })
 	_, s.server = newServerWithHub(c, s.pool, s.hub)
 	s.AddCleanup(func(*gc.C) { s.server.Stop() })

--- a/apiserver/server_test.go
+++ b/apiserver/server_test.go
@@ -56,7 +56,7 @@ var _ = gc.Suite(&serverSuite{})
 
 func (s *serverSuite) SetUpTest(c *gc.C) {
 	s.JujuConnSuite.SetUpTest(c)
-	s.pool = state.NewStatePool(s.State)
+	s.pool = state.NewStatePool(s.Controller)
 	s.AddCleanup(func(*gc.C) { s.pool.Close() })
 }
 
@@ -214,10 +214,10 @@ func (s *serverSuite) TestNewServerDoesNotAccessState(c *gc.C) {
 		MongoInfo:          mongoInfo,
 		MongoDialOpts:      dialOpts,
 	})
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, jc.ErrorIsNil)
 	defer st.Close()
 
-	pool := state.NewStatePool(st)
+	pool := state.NewStatePool(s.Controller)
 	defer pool.Close()
 
 	// Now close the proxy so that any attempts to use the
@@ -374,7 +374,7 @@ func (s *macaroonServerSuite) SetUpTest(c *gc.C) {
 		controller.IdentityURL: s.discharger.Location(),
 	}
 	s.JujuConnSuite.SetUpTest(c)
-	s.pool = state.NewStatePool(s.State)
+	s.pool = state.NewStatePool(s.Controller)
 	s.AddCleanup(func(*gc.C) { s.pool.Close() })
 }
 
@@ -428,7 +428,7 @@ func (s *macaroonServerWrongPublicKeySuite) SetUpTest(c *gc.C) {
 		controller.IdentityPublicKey: wrongKey.Public.String(),
 	}
 	s.JujuConnSuite.SetUpTest(c)
-	s.pool = state.NewStatePool(s.State)
+	s.pool = state.NewStatePool(s.Controller)
 	s.AddCleanup(func(*gc.C) { s.pool.Close() })
 }
 
@@ -545,7 +545,7 @@ func (s *serverSuite) TestAPIHandlerConnectedModel(c *gc.C) {
 
 func (s *serverSuite) TestClosesStateFromPool(c *gc.C) {
 	coretesting.SkipFlaky(c, "lp:1702215")
-	pool := state.NewStatePool(s.State)
+	pool := state.NewStatePool(s.Controller)
 	defer pool.Close()
 	cfg := defaultServerConfig(c)
 	_, server := newServerWithConfig(c, pool, cfg)

--- a/apiserver/utils.go
+++ b/apiserver/utils.go
@@ -43,7 +43,7 @@ type validateArgs struct {
 //
 // It returns the validated model UUID.
 func validateModelUUID(args validateArgs) (string, error) {
-	controllerModelUUID := args.statePool.SystemState().ModelUUID()
+	controllerModelUUID := args.statePool.GetController().ModelUUID()
 	if args.modelUUID == "" {
 		// We allow the modelUUID to be empty so that:
 		//    TODO: server a limited API at the root (empty modelUUID)

--- a/apiserver/utils_test.go
+++ b/apiserver/utils_test.go
@@ -20,7 +20,7 @@ var _ = gc.Suite(&utilsSuite{})
 
 func (s *utilsSuite) SetUpTest(c *gc.C) {
 	s.StateSuite.SetUpTest(c)
-	s.pool = state.NewStatePool(s.State)
+	s.pool = state.NewStatePool(s.Controller)
 	s.AddCleanup(func(*gc.C) { s.pool.Close() })
 }
 

--- a/migration/precheck.go
+++ b/migration/precheck.go
@@ -32,16 +32,9 @@ type PrecheckBackend interface {
 	AllMachines() ([]PrecheckMachine, error)
 	AllApplications() ([]PrecheckApplication, error)
 	AllRelations() ([]PrecheckRelation, error)
-	ControllerBackend() (PrecheckBackendCloser, error)
+	ControllerBackend() (PrecheckBackend, error)
 	CloudCredential(tag names.CloudCredentialTag) (cloud.Credential, error)
 	ListPendingResources(string) ([]resource.Resource, error)
-}
-
-// PrecheckBackendCloser adds the Close method to the standard
-// PrecheckBackend.
-type PrecheckBackendCloser interface {
-	PrecheckBackend
-	Close() error
 }
 
 // Pool defines the interface to a StatePool used by the migration
@@ -143,7 +136,6 @@ func SourcePrecheck(backend PrecheckBackend) error {
 	if err != nil {
 		return errors.Trace(err)
 	}
-	defer controllerBackend.Close()
 	if err := checkController(controllerBackend); err != nil {
 		return errors.Annotate(err, "controller")
 	}

--- a/migration/precheck_test.go
+++ b/migration/precheck_test.go
@@ -791,7 +791,7 @@ func (b *fakeBackend) ListPendingResources(app string) ([]resource.Resource, err
 	return b.pendingResources, b.pendingResourcesErr
 }
 
-func (b *fakeBackend) ControllerBackend() (migration.PrecheckBackendCloser, error) {
+func (b *fakeBackend) ControllerBackend() (migration.PrecheckBackend, error) {
 	if b.controllerBackend == nil {
 		return b, nil
 	}

--- a/provider/dummy/environs.go
+++ b/provider/dummy/environs.go
@@ -246,6 +246,7 @@ type environState struct {
 	insts          map[instance.Id]*dummyInstance
 	globalRules    network.IngressRuleSlice
 	bootstrapped   bool
+	controller     *state.Controller
 	apiListener    net.Listener
 	apiServer      *apiserver.Server
 	apiState       *state.State
@@ -347,12 +348,18 @@ func (state *environState) destroyLocked() {
 	if !state.bootstrapped {
 		return
 	}
+	controller := state.controller
+	state.controller = nil
+
 	apiServer := state.apiServer
-	apiStatePool := state.apiStatePool
-	apiState := state.apiState
 	state.apiServer = nil
+
+	apiStatePool := state.apiStatePool
 	state.apiStatePool = nil
+
+	apiState := state.apiState
 	state.apiState = nil
+
 	state.bootstrapped = false
 
 	// Release the lock while we close resources. In particular,
@@ -372,10 +379,19 @@ func (state *environState) destroyLocked() {
 		if err := apiStatePool.Close(); err != nil && mongoAlive() {
 			panic(err)
 		}
+		if err := apiStatePool.GetController().Close(); err != nil && mongoAlive() {
+			panic(err)
+		}
 	}
 
 	if apiState != nil {
 		if err := apiState.Close(); err != nil && mongoAlive() {
+			panic(err)
+		}
+	}
+
+	if controller != nil {
+		if err := controller.Close(); err != nil && mongoAlive() {
 			panic(err)
 		}
 	}
@@ -801,27 +817,31 @@ func (e *environ) Bootstrap(ctx environs.BootstrapContext, args environs.Bootstr
 			if err != nil {
 				return err
 			}
-			ctlr.Close()
 			if err := st.SetModelConstraints(args.ModelConstraints); err != nil {
 				st.Close()
+				ctlr.Close()
 				return err
 			}
 			if err := st.SetAdminMongoPassword(icfg.Controller.MongoInfo.Password); err != nil {
 				st.Close()
+				ctlr.Close()
 				return err
 			}
 			if err := st.MongoSession().DB("admin").Login("admin", icfg.Controller.MongoInfo.Password); err != nil {
 				st.Close()
+				ctlr.Close()
 				return err
 			}
 			env, err := st.Model()
 			if err != nil {
 				st.Close()
+				ctlr.Close()
 				return err
 			}
 			owner, err := st.User(env.Owner())
 			if err != nil {
 				st.Close()
+				ctlr.Close()
 				return err
 			}
 			// We log this out for test purposes only. No one in real life can use
@@ -830,7 +850,7 @@ func (e *environ) Bootstrap(ctx environs.BootstrapContext, args environs.Bootstr
 			logger.Debugf("setting password for %q to %q", owner.Name(), icfg.Controller.MongoInfo.Password)
 			owner.SetPassword(icfg.Controller.MongoInfo.Password)
 
-			statePool := state.NewStatePool(st)
+			statePool := state.NewStatePool(ctlr)
 			machineTag := names.NewMachineTag("0")
 			estate.apiServer, err = apiserver.NewServer(statePool, estate.apiListener, apiserver.ServerConfig{
 				Clock:       clock.WallClock,
@@ -852,9 +872,12 @@ func (e *environ) Bootstrap(ctx environs.BootstrapContext, args environs.Bootstr
 			})
 			if err != nil {
 				statePool.Close()
+				ctlr.Close()
 				st.Close()
+				ctlr.Close()
 				panic(err)
 			}
+			estate.controller = ctlr
 			estate.apiState = st
 			estate.apiStatePool = statePool
 		}

--- a/state/allwatcher_internal_test.go
+++ b/state/allwatcher_internal_test.go
@@ -1313,11 +1313,15 @@ var _ = gc.Suite(&allModelWatcherStateSuite{})
 
 type allModelWatcherStateSuite struct {
 	allWatcherBaseSuite
+	pool   *StatePool
 	state1 *State
 }
 
 func (s *allModelWatcherStateSuite) SetUpTest(c *gc.C) {
 	s.allWatcherBaseSuite.SetUpTest(c)
+	pool := NewStatePool(s.controller)
+	s.AddCleanup(func(*gc.C) { pool.Close() })
+	s.pool = pool
 	s.state1 = s.newState(c)
 }
 
@@ -1331,9 +1335,7 @@ func (s *allModelWatcherStateSuite) NewAllModelWatcherStateBacking() Backing {
 }
 
 func (s *allModelWatcherStateSuite) NewAllModelWatcherStateBackingForState(st *State) Backing {
-	pool := NewStatePool(st)
-	s.AddCleanup(func(*gc.C) { pool.Close() })
-	return NewAllModelWatcherStateBacking(st, pool)
+	return NewAllModelWatcherStateBacking(st, s.pool)
 }
 
 // performChangeTestCases runs a passed number of test cases for changes.

--- a/state/controller.go
+++ b/state/controller.go
@@ -8,8 +8,8 @@ import (
 
 	"github.com/juju/errors"
 	"github.com/juju/utils/clock"
-	names "gopkg.in/juju/names.v2"
-	mgo "gopkg.in/mgo.v2"
+	"gopkg.in/juju/names.v2"
+	"gopkg.in/mgo.v2"
 
 	jujucontroller "github.com/juju/juju/controller"
 	"github.com/juju/juju/mongo"
@@ -32,9 +32,11 @@ func controllerKey(controllerUUID string) string {
 // Controller encapsulates state for the Juju controller as a whole,
 // as opposed to model specific functionality.
 //
-// TODO(menn0) - this is currently unused, pending further refactoring
-// of State.
 type Controller struct {
+	// st is the controller state.
+	// TODO(wallyworld) - remove this once all the controller related methods are moved
+	st *State
+
 	clock                  clock.Clock
 	controllerModelTag     names.ModelTag
 	controllerTag          names.ControllerTag
@@ -49,6 +51,13 @@ type Controller struct {
 func (ctlr *Controller) Close() error {
 	ctlr.session.Close()
 	return nil
+}
+
+// ControllerState returns the State associated with the controller model.
+// Its use is deprecated and indicates that any methods invoked on the
+// returned State need to be moved to this controller struct.
+func (ctlr *Controller) ControllerState() *State {
+	return ctlr.st
 }
 
 // NewState returns a new State instance for the specified model. The
@@ -77,6 +86,16 @@ func (ctlr *Controller) NewState(modelTag names.ModelTag) (*State, error) {
 // is still alive.
 func (ctlr *Controller) Ping() error {
 	return ctlr.session.Ping()
+}
+
+// ControllerTag returns the tag of the controller itself.
+func (ctlr *Controller) ControllerTag() names.ControllerTag {
+	return ctlr.controllerTag
+}
+
+// ModelUUID returns the UUID of the controller model.
+func (ctlr *Controller) ModelUUID() string {
+	return ctlr.controllerModelTag.Id()
 }
 
 // ControllerConfig returns the config values for the controller.

--- a/state/initialize.go
+++ b/state/initialize.go
@@ -159,6 +159,9 @@ func Initialize(args InitializeParams) (_ *Controller, _ *State, err error) {
 		}
 	}()
 	st.controllerModelTag = modelTag
+	// Set the controller state.
+	// TODO(wallyworld) - controller state is deprecated
+	ctlr.st = st
 
 	// A valid model is used as a signal that the
 	// state has already been initalized. If this is the case

--- a/state/open.go
+++ b/state/open.go
@@ -114,6 +114,27 @@ func OpenController(args OpenParams) (*Controller, error) {
 	}, nil
 }
 
+// OpenControllerForState returns a controller using the controller state.
+// TODO(wallyworld) - use this method until we can weave Controller through the code.
+func OpenControllerForState(ctrlSt *State) (*Controller, error) {
+	if ctrlSt.modelTag.Id() != ctrlSt.controllerModelTag.Id() {
+		return nil, errors.New("must use controller model state when opening controller")
+	}
+	ctrl, err := OpenController(OpenParams{
+		Clock:              clock.WallClock,
+		ControllerTag:      ctrlSt.controllerTag,
+		ControllerModelTag: ctrlSt.modelTag,
+		MongoInfo:          ctrlSt.mongoInfo,
+		MongoDialOpts:      mongo.DefaultDialOpts(),
+		NewPolicy:          func(*State) Policy { return ctrlSt.policy },
+	})
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	ctrl.st = ctrlSt
+	return ctrl, nil
+}
+
 // Open connects to the server with the given parameters, waits for it
 // to be initialized, and returns a new State representing the model
 // connected to.

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -276,7 +276,7 @@ func (s *StateSuite) TestWatchAllModels(c *gc.C) {
 	// The allModelWatcher infrastructure is comprehensively tested
 	// elsewhere. This just ensures things are hooked up correctly in
 	// State.WatchAllModels()
-	pool := state.NewStatePool(s.State)
+	pool := state.NewStatePool(s.Controller)
 	defer pool.Close()
 	w := s.State.WatchAllModels(pool)
 	defer w.Stop()

--- a/state/statemetrics/mock_test.go
+++ b/state/statemetrics/mock_test.go
@@ -16,12 +16,12 @@ import (
 
 type mockStatePool struct {
 	testing.Stub
-	system *mockState
-	models []*mockModel
+	controllerState *mockState
+	models          []*mockModel
 }
 
-func (p *mockStatePool) SystemState() statemetrics.State {
-	return p.system
+func (p *mockStatePool) GetController() statemetrics.Controller {
+	return &mockController{p.controllerState, p.controllerState.ControllerTag()}
 }
 
 func (p *mockStatePool) Get(modelUUID string) (statemetrics.State, state.StatePoolReleaser, error) {
@@ -60,6 +60,19 @@ func (p *mockStatePool) modelUUIDs() []string {
 		out[i] = m.tag.Id()
 	}
 	return out
+}
+
+type mockController struct {
+	st  statemetrics.State
+	tag names.ControllerTag
+}
+
+func (c *mockController) ControllerTag() names.ControllerTag {
+	return c.tag
+}
+
+func (c *mockController) ControllerState() statemetrics.State {
+	return c.st
 }
 
 type mockState struct {

--- a/state/statemetrics/statemetrics.go
+++ b/state/statemetrics/statemetrics.go
@@ -136,7 +136,8 @@ func (c *Collector) updateMetrics() {
 	logger.Tracef("updating state metrics")
 	defer logger.Tracef("updated state metrics")
 
-	st := c.pool.SystemState()
+	ctrl := c.pool.GetController()
+	st := ctrl.ControllerState()
 	modelUUIDs, err := st.AllModelUUIDs()
 	if err != nil {
 		logger.Debugf("error getting models: %v", err)
@@ -149,7 +150,7 @@ func (c *Collector) updateMetrics() {
 	// TODO(axw) AllUsers only returns *local* users. We do not have User
 	// records for external users. To obtain external users, we will need
 	// to get all of the controller and model-level access documents.
-	controllerTag := st.ControllerTag()
+	controllerTag := ctrl.ControllerTag()
 	localUsers, err := st.AllUsers()
 	if err != nil {
 		logger.Debugf("error getting local users: %v", err)

--- a/state/statemetrics/statemetrics_test.go
+++ b/state/statemetrics/statemetrics_test.go
@@ -68,7 +68,7 @@ func (s *collectorSuite) SetUpTest(c *gc.C) {
 			}},
 		}},
 	}
-	s.pool.system = &mockState{
+	s.pool.controllerState = &mockState{
 		users:      users,
 		modelUUIDs: s.pool.modelUUIDs(),
 	}
@@ -227,7 +227,7 @@ func (s *collectorSuite) TestCollect(c *gc.C) {
 }
 
 func (s *collectorSuite) TestCollectErrors(c *gc.C) {
-	s.pool.system.SetErrors(
+	s.pool.controllerState.SetErrors(
 		errors.New("no models for you"),
 		errors.New("no users for you"),
 	)

--- a/state/testing/suite.go
+++ b/state/testing/suite.go
@@ -66,7 +66,7 @@ func (s *StateSuite) SetUpTest(c *gc.C) {
 		s.Controller.Close()
 	})
 
-	s.StatePool = state.NewStatePool(s.State)
+	s.StatePool = state.NewStatePool(s.Controller)
 	s.AddCleanup(func(*gc.C) { s.StatePool.Close() })
 
 	model, err := s.State.Model()


### PR DESCRIPTION
## Description of change

This picks up on work Menno started to extract controller functionality from state. It's a work in progress. 
StatePool gains a controller instance. All uses of state.ForModel() in non-test code is now gone.

Subsequent work will include:
- Add a StatePool to Controller so that State creation always goes via the pool.
- Move all MongoDB and Controller specific functionality onto Controller

## QA steps

Run up a couple of controllers
Deploy apps and relate
Migrate model between controllers
