### PR TITLE
[1.25] state: restart leadership worker if it fails

### DIFF
--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -43,11 +43,13 @@ gopkg.in/goose.v1	git	8f055ce635d660f9b7827a1ff398c360715df261	2016-11-30T14:51:
 gopkg.in/juju/charm.v5	git	949f52b3948c64bcd79dff3fdb2c7477fc11120a	2016-11-09T08:40:14Z
 gopkg.in/juju/charmstore.v4	git	b90d24652753eeb1f7d209483d499f6b24dcf25e	2015-07-10T10:24:09Z
 gopkg.in/juju/environschema.v1	git	16cc59268c09c22870cb4de8eb6248652535f315	2015-08-24T13:22:26Z
+gopkg.in/juju/worker.v1	git	6965b9d826717287bb002e02d1fd4d079978083e	2017-03-08T00:24:58Z
 gopkg.in/macaroon-bakery.v0	git	9593b80b01ba04b519769d045dffd6abd827d2fd	2015-04-10T07:46:55Z
 gopkg.in/macaroon.v1	git	ab3940c6c16510a850e1c2dd628b919f0f3f1464	2015-01-21T11:42:31Z
 gopkg.in/mgo.v2	git	3569c88678d88179dcbd68d02ab081cbca3cd4d0	2015-06-04T15:26:27Z
 gopkg.in/natefinch/lumberjack.v2	git	588a21fb0fa0ebdfde42670fa214576b6f0f22df	2015-05-21T01:59:18Z
 gopkg.in/natefinch/npipe.v2	git	c1b8fa8bdccecb0b8db834ee0b92fdbcfa606dd6	2016-06-21T03:49:01Z
+gopkg.in/tomb.v1	git	dd632973f1e7218eb1089048e0798ec9ae7dceb8	2014-10-24T13:56:13Z
 gopkg.in/yaml.v1	git	9f9df34309c04878acc86042b16630b0f696e1de	2014-09-24T16:16:07Z
 gopkg.in/yaml.v2	git	a83829b6f1293c91addabc89d0571c246397bbf4	2016-03-01T20:40:22Z
 launchpad.net/gnuflag	bzr	roger.peppe@canonical.com-20140716064605-pk32dnmfust02yab	13

--- a/state/export_test.go
+++ b/state/export_test.go
@@ -448,3 +448,12 @@ func SpaceDoc(s *Space) spaceDoc {
 func DeleteCharm(st *State, curl *charm.URL) error {
 	return st.deleteCharm(curl)
 }
+
+func RestartLeadershipManager(st *State) {
+	w, err := st.leadershipWorker.Worker(leadershipWorkerName, nil)
+	if err == nil {
+		st.leadershipWorker.StopWorker(leadershipWorkerName)
+		w.Wait()
+	}
+	st.leadershipWorker.startWorker(st)
+}

--- a/state/leadership/dead_manager_test.go
+++ b/state/leadership/dead_manager_test.go
@@ -1,0 +1,35 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package leadership_test
+
+import (
+	"time"
+
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/errors"
+	"github.com/juju/juju/state/leadership"
+)
+
+type deadManagerSuite struct{}
+
+var _ = gc.Suite(&deadManagerSuite{})
+
+func (s *deadManagerSuite) TestDeadManager(c *gc.C) {
+	deadManagerErr := errors.New("DeadManagerError")
+	deadManager := leadership.NewDeadManager(deadManagerErr)
+
+	err := deadManager.BlockUntilLeadershipReleased("foo")
+	c.Assert(err, gc.ErrorMatches, "leadership manager stopped")
+
+	err = deadManager.ClaimLeadership("foo", "foo/0", time.Minute)
+	c.Assert(err, gc.ErrorMatches, "leadership manager stopped")
+
+	token := deadManager.LeadershipCheck("foo", "foo/0")
+	err = token.Check(nil)
+	c.Assert(err, gc.ErrorMatches, "leadership manager stopped")
+
+	err = deadManager.Wait()
+	c.Assert(err, gc.Equals, deadManagerErr)
+}

--- a/state/leadership/manager.go
+++ b/state/leadership/manager.go
@@ -41,6 +41,15 @@ func NewManager(config ManagerConfig) (ManagerWorker, error) {
 	return manager, nil
 }
 
+// NewDeadManager returns a manager that's already dead
+// and always returns the given error.
+func NewDeadManager(err error) ManagerWorker {
+	m := manager{}
+	m.tomb.Kill(err)
+	m.tomb.Done()
+	return &m
+}
+
 // manager implements ManagerWorker.
 type manager struct {
 	tomb tomb.Tomb

--- a/state/lease/client.go
+++ b/state/lease/client.go
@@ -15,6 +15,7 @@ import (
 	"gopkg.in/mgo.v2/txn"
 
 	"github.com/juju/juju/mongo"
+	"github.com/juju/juju/wrench"
 )
 
 // NewClient returns a new Client using the supplied config, or an error. Any
@@ -177,6 +178,9 @@ func (client *client) ExpireLease(name string) error {
 // Refresh is part of the Client interface.
 func (client *client) Refresh() error {
 	client.logger.Tracef("refreshing")
+	if wrench.IsActive("lease", "refresh") {
+		return errors.New("wrench active")
+	}
 
 	// Always read entries before skews, because skews are written before
 	// entries; we increase the risk of reading older skew data, but (should)

--- a/state/open.go
+++ b/state/open.go
@@ -280,9 +280,9 @@ func (st *State) Close() (err error) {
 	if st.pwatcher != nil {
 		handle("presence watcher", st.pwatcher.Stop())
 	}
-	if st.leadershipManager != nil {
-		st.leadershipManager.Kill()
-		handle("leadership manager", st.leadershipManager.Wait())
+	if st.leadershipWorker != nil {
+		st.leadershipWorker.Kill()
+		handle("leadership manager", st.leadershipWorker.Wait())
 	}
 	st.mu.Lock()
 	if st.allManager != nil {

--- a/state/state_leader_test.go
+++ b/state/state_leader_test.go
@@ -6,6 +6,7 @@ package state_test
 import (
 	"time"
 
+	"github.com/juju/juju/state"
 	coretesting "github.com/juju/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
@@ -35,4 +36,28 @@ func (s *StateLeadershipSuite) TestHackLeadershipUnblocksClaimer(c *gc.C) {
 		c.Fatalf("timed out while waiting for unblock")
 	case <-unblocked:
 	}
+}
+
+func (s *StateLeadershipSuite) TestLeadershipClaimerRestarts(c *gc.C) {
+	claimer := s.State.LeadershipClaimer()
+	err := claimer.ClaimLeadership("blah", "blah/0", time.Minute)
+	c.Assert(err, jc.ErrorIsNil)
+
+	state.RestartLeadershipManager(s.State)
+
+	err = claimer.ClaimLeadership("blah", "blah/0", time.Minute)
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *StateLeadershipSuite) TestLeadershipCheckerRestarts(c *gc.C) {
+	claimer := s.State.LeadershipClaimer()
+	checker := s.State.LeadershipChecker()
+	err := claimer.ClaimLeadership("application", "application/0", time.Minute)
+	c.Assert(err, jc.ErrorIsNil)
+
+	state.RestartLeadershipManager(s.State)
+
+	token := checker.LeadershipCheck("application", "application/0")
+	err = token.Check(nil)
+	c.Assert(err, jc.ErrorIsNil)
 }


### PR DESCRIPTION
## Description of change

Run the leadership manager in a worker.Runner,
restarting it if it fails. The methods on State
for returning leadership claimers and checkers
defer obtaining the current worker until the
claim/check methods are invoked, to avoid
pinning to broken workers.

## QA steps

1. juju bootstrap --upload-tools (I used manual provider, doesn't matter though)
2. juju deploy ubuntu
3. juju add-unit ubuntu --to 1
(wait)
4. juju ssh 0 "sudo mkdir /var/lib/juju/wrench && echo refresh | sudo tee /var/lib/juju/wrench/lease"
(observe leadership manager failures in log)
5. juju ssh 0 "sudo rm /var/lib/juju/wrench/lease"
(observe some time later that the leadership manager is restarted)

## Documentation changes

None.

## Bug reference

https://bugs.launchpad.net/juju-core/+bug/1729930