### PR TITLE
Ensure credential paths are "Finalized"  to their contents.

### DIFF
--- a/cmd/juju/commands/bootstrap_test.go
+++ b/cmd/juju/commands/bootstrap_test.go
@@ -1394,6 +1394,38 @@ func (s *BootstrapSuite) TestBootstrapProviderManyDetectedCredentials(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, ambiguousDetectedCredentialError.Error())
 }
 
+func (s *BootstrapSuite) TestBootstrapProviderFileCredential(c *gc.C) {
+	dummyProvider, err := environs.Provider("dummy")
+	c.Assert(err, jc.ErrorIsNil)
+
+	tmpFile, err := ioutil.TempFile("", "juju-bootstrap-test")
+	c.Assert(err, jc.ErrorIsNil)
+	defer func() { err := os.Remove(tmpFile.Name()); c.Assert(err, jc.ErrorIsNil) }()
+
+	contents := []byte("{something: special}\n")
+	err = ioutil.WriteFile(tmpFile.Name(), contents, 0644)
+
+	unfinalizedCredential := cloud.NewEmptyCredential()
+	finalizedCredential := cloud.NewEmptyCredential()
+	fp := fileCredentialProvider{dummyProvider, tmpFile.Name(), &unfinalizedCredential, &finalizedCredential}
+	environs.RegisterProvider("file-credentials", fp)
+
+	resetJujuXDGDataHome(c)
+	_, err = cmdtesting.RunCommand(
+		c, s.newBootstrapCommand(), "file-credentials", "ctrl",
+		"--config", "default-series=precise",
+	)
+	c.Assert(err, jc.ErrorIsNil)
+
+	// When credentials are "finalized" any credential attribute indicated
+	// to be a file path is replaced by that file's contents. Here we check to see
+	// that the state of the credential under test before finalization is
+	// indeed the file path itself and that the state of the credential
+	// after finalization is the contents of that file.
+	c.Assert(unfinalizedCredential.Attributes()["file"], gc.Matches, tmpFile.Name())
+	c.Assert(finalizedCredential.Attributes()["file"], gc.Matches, string(contents))
+}
+
 func (s *BootstrapSuite) TestBootstrapProviderDetectRegionsInvalid(c *gc.C) {
 	s.patchVersionAndSeries(c, "raring")
 	ctx, err := cmdtesting.RunCommand(c, s.newBootstrapCommand(), "dummy/not-dummy", "ctrl")
@@ -1986,7 +2018,7 @@ func (noCloudRegionsProvider) DetectRegions() ([]cloud.Region, error) {
 }
 
 func (noCloudRegionsProvider) CredentialSchemas() map[cloud.AuthType]cloud.CredentialSchema {
-	return nil
+	return map[cloud.AuthType]cloud.CredentialSchema{cloud.EmptyAuthType: cloud.CredentialSchema{}}
 }
 
 type noCredentialsProvider struct {
@@ -2027,6 +2059,41 @@ func (manyCredentialsProvider) CredentialSchemas() map[cloud.AuthType]cloud.Cred
 }
 
 type cloudDetectorFunc func() ([]cloud.Cloud, error)
+
+type fileCredentialProvider struct {
+	environs.EnvironProvider
+	testFileName          string
+	unFinalizedCredential *cloud.Credential
+	finalizedCredential   *cloud.Credential
+}
+
+func (f fileCredentialProvider) DetectRegions() ([]cloud.Region, error) {
+	return []cloud.Region{{Name: "region"}}, nil
+}
+
+func (f fileCredentialProvider) DetectCredentials() (*cloud.CloudCredential, error) {
+	credential := cloud.NewCredential(cloud.JSONFileAuthType,
+		map[string]string{"file": f.testFileName})
+	cc := &cloud.CloudCredential{AuthCredentials: map[string]cloud.Credential{
+		"cred": credential,
+	}}
+	*f.unFinalizedCredential = credential
+	return cc, nil
+}
+
+func (fileCredentialProvider) CredentialSchemas() map[cloud.AuthType]cloud.CredentialSchema {
+	return map[cloud.AuthType]cloud.CredentialSchema{cloud.JSONFileAuthType: cloud.CredentialSchema{cloud.NamedCredentialAttr{
+		Name: "file",
+		CredentialAttr: cloud.CredentialAttr{
+			FilePath: true,
+		}},
+	}}
+}
+
+func (f fileCredentialProvider) FinalizeCredential(_ environs.FinalizeCredentialContext, fp environs.FinalizeCredentialParams) (*cloud.Credential, error) {
+	*f.finalizedCredential = fp.Credential
+	return &fp.Credential, nil
+}
 
 func (c cloudDetectorFunc) DetectCloud(name string) (cloud.Cloud, error) {
 	clouds, err := c.DetectClouds()

--- a/cmd/juju/common/cloudcredential.go
+++ b/cmd/juju/common/cloudcredential.go
@@ -71,9 +71,15 @@ func GetOrDetectCredential(
 	if err != nil {
 		return fail(err)
 	}
+
+	credential, err = modelcmd.FinalizeFileContent(&oneCredential, provider)
+	if err != nil {
+		return nil, "", "", false, modelcmd.AnnotateWithFinalizationError(err, chosenCredentialName, args.Cloud.Name)
+	}
+
 	credential, err = provider.FinalizeCredential(
 		ctx, environs.FinalizeCredentialParams{
-			Credential:            oneCredential,
+			Credential:            *credential,
 			CloudEndpoint:         region.Endpoint,
 			CloudStorageEndpoint:  region.StorageEndpoint,
 			CloudIdentityEndpoint: region.IdentityEndpoint,

--- a/cmd/juju/controller/addmodel_test.go
+++ b/cmd/juju/controller/addmodel_test.go
@@ -700,3 +700,7 @@ func (p *fakeProvider) FinalizeCredential(
 	out.Label = "finalized"
 	return &out, p.NextErr()
 }
+
+func (p *fakeProvider) CredentialSchemas() map[cloud.AuthType]cloud.CredentialSchema {
+	return map[cloud.AuthType]cloud.CredentialSchema{cloud.EmptyAuthType: cloud.CredentialSchema{}}
+}

--- a/cmd/modelcmd/base_test.go
+++ b/cmd/modelcmd/base_test.go
@@ -132,3 +132,7 @@ func (p *mockEnvironProvider) FinalizeCredential(
 	out.Label = "finalized"
 	return &out, nil
 }
+
+func (p *mockEnvironProvider) CredentialSchemas() map[cloud.AuthType]cloud.CredentialSchema {
+	return map[cloud.AuthType]cloud.CredentialSchema{cloud.EmptyAuthType: cloud.CredentialSchema{}}
+}


### PR DESCRIPTION
## Description of change

When bootstrapping a controller on `GCE` with `JUJU_DATA` set to the path of an empty directory, Juju will try to look for a path to a file holding `GCE` credentials in the environment variable `GOOGLE_APPLICATION_CREDENTIALS`. Juju incorrectly tries to use the file path itself as the credentials instead of using the contents of that file. This PR fixes that error.  

## Why is this change needed?

Fixes referenced bug.

## QA steps

1. set `GOOGLE_APPLICATION_CREDENTIALS` to the path of your application credentials.
2. set `JUJU_DATA` to an empty directory (This way `Juju` ignores its current set of credentials.)
3. You should see your controller successfully bootstrap on `GCE` whereas without this patch it would error expecting the file path string to be valid `JSON`.

## Documentation changes

N/A

## Does it affect current user workflow? CLI? API?

No

## Bug reference

https://bugs.launchpad.net/juju/+bug/1726226
