### PR TITLE
wrench: log at TRACE level

### DIFF
--- a/wrench/wrench.go
+++ b/wrench/wrench.go
@@ -109,7 +109,7 @@ var stat = os.Stat // To support patching
 func checkWrenchDir(dirName string) bool {
 	dirinfo, err := stat(dirName)
 	if err != nil {
-		logger.Debugf("couldn't read wrench directory: %v", err)
+		logger.Tracef("couldn't read wrench directory: %v", err)
 		return false
 	}
 	if !isOwnedByJujuUser(dirinfo) {
@@ -123,7 +123,7 @@ func checkWrenchDir(dirName string) bool {
 func checkWrenchFile(category, feature, fileName string) bool {
 	fileinfo, err := stat(fileName)
 	if err != nil {
-		logger.Debugf("no wrench data for %s/%s (ignored): %v",
+		logger.Tracef("no wrench data for %s/%s (ignored): %v",
 			category, feature, err)
 		return false
 	}


### PR DESCRIPTION
## Description of change

Wrench logging is too noisy at DEBUG level, and not that interesting. Change to TRACE, except for unexpected errors which are already at ERROR level.

## QA steps

1. juju bootstrap
2. juju model-config logging-config='<root>=DEBUG'
3. juju debug-log --include-module juju.wrench
(confirm nothing comes through)
4. juju model-config logging-config='<root>=TRACE'
5. juju debug-log --include-module juju.wrench
(confirm periodic messages due to lease manager)

## Documentation changes

None.

## Bug reference

None.