### PR TITLE
Handle the case where remove-offer gets a bogus offer

### DIFF
--- a/apiserver/facades/client/applicationoffers/applicationoffers.go
+++ b/apiserver/facades/client/applicationoffers/applicationoffers.go
@@ -529,6 +529,10 @@ func (api *OffersAPI) DestroyOffers(args params.DestroyApplicationOffers) (param
 			result[i].Error = common.ServerError(err)
 			continue
 		}
+		if models[i].err != nil {
+			result[i].Error = common.ServerError(models[i].err)
+			continue
+		}
 		backend, releaser, err := api.StatePool.Get(models[i].model.UUID())
 		if err != nil {
 			result[i].Error = common.ServerError(err)

--- a/apiserver/facades/client/applicationoffers/applicationoffers_test.go
+++ b/apiserver/facades/client/applicationoffers/applicationoffers_test.go
@@ -1270,15 +1270,20 @@ func (s *consumeSuite) TestDestroyOffers(c *gc.C) {
 
 	s.authorizer.Tag = names.NewUserTag("admin")
 	results, err := s.api.DestroyOffers(params.DestroyApplicationOffers{
-		OfferURLs: []string{"fred/prod.hosted-mysql", "fred/prod.unknown"},
+		OfferURLs: []string{
+			"fred/prod.hosted-mysql", "fred/prod.unknown", "garbage/badmodel.someoffer", "badmodel.someoffer"},
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(results.Results, gc.HasLen, 2)
+	c.Assert(results.Results, gc.HasLen, 4)
 	c.Assert(results.Results[0].Error, gc.IsNil)
 	c.Assert(results.Results, jc.DeepEquals, []params.ErrorResult{
 		{},
 		{
 			Error: &params.Error{Message: `application offer "unknown" not found`, Code: "not found"},
+		}, {
+			Error: &params.Error{Message: `model "garbage/badmodel" not found`, Code: "not found"},
+		}, {
+			Error: &params.Error{Message: `model "admin/badmodel" not found`, Code: "not found"},
 		},
 	})
 

--- a/apiserver/facades/client/applicationoffers/base.go
+++ b/apiserver/facades/client/applicationoffers/base.go
@@ -59,21 +59,24 @@ func (api *BaseAPI) checkAdmin(backend Backend) error {
 	return nil
 }
 
-// modelForName looks up the model details for the named model.
-func (api *BaseAPI) modelForName(modelName, ownerName string) (Model, bool, error) {
+// modelForName looks up the model details for the named model and returns
+// the model (if found), the absolute model model path which was used in the lookup,
+// and a bool indicating if the model was found,
+func (api *BaseAPI) modelForName(modelName, ownerName string) (Model, string, bool, error) {
 	user := api.Authorizer.GetAuthTag()
 	if ownerName == "" {
 		ownerName = user.Id()
 	}
+	modelPath := fmt.Sprintf("%s/%s", ownerName, modelName)
 	var model Model
 	uuids, err := api.ControllerModel.AllModelUUIDs()
 	if err != nil {
-		return nil, false, errors.Trace(err)
+		return nil, modelPath, false, errors.Trace(err)
 	}
 	for _, uuid := range uuids {
 		m, release, err := api.StatePool.GetModel(uuid)
 		if err != nil {
-			return nil, false, errors.Trace(err)
+			return nil, modelPath, false, errors.Trace(err)
 		}
 		defer release()
 		if m.Name() == modelName && m.Owner().Id() == ownerName {
@@ -81,7 +84,7 @@ func (api *BaseAPI) modelForName(modelName, ownerName string) (Model, bool, erro
 			break
 		}
 	}
-	return model, model != nil, nil
+	return model, modelPath, model != nil, nil
 }
 
 func (api *BaseAPI) userDisplayName(backend Backend, userTag names.UserTag) (string, error) {
@@ -269,12 +272,12 @@ func (api *BaseAPI) getModelsFromOffers(offerURLs ...string) ([]offerModel, erro
 			return model, nil
 		}
 
-		model, ok, err := api.modelForName(url.ModelName, url.User)
+		model, absModelPath, ok, err := api.modelForName(url.ModelName, url.User)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
 		if !ok {
-			return nil, errors.NotFoundf("model %q", modelPath)
+			return nil, errors.NotFoundf("model %q", absModelPath)
 		}
 		return model, nil
 	}
@@ -311,12 +314,12 @@ func (api *BaseAPI) getModelFilters(filters params.OfferFilters) (
 		)
 		if modelUUID, ok = modelUUIDs[f.ModelName]; !ok {
 			var err error
-			model, ok, err := api.modelForName(f.ModelName, f.OwnerName)
+			model, absModelPath, ok, err := api.modelForName(f.ModelName, f.OwnerName)
 			if err != nil {
 				return nil, nil, errors.Trace(err)
 			}
 			if !ok {
-				err := errors.NotFoundf("model %q", f.ModelName)
+				err := errors.NotFoundf("model %q", absModelPath)
 				return nil, nil, errors.Trace(err)
 			}
 			// Record the UUID and model for next time.


### PR DESCRIPTION
## Description of change

When removing an offer what was properly formed but the model didn't exist, we were not catching that error. This fixes that.

## QA steps

bootstrap
$ juju remove-offer bogusmode/someoffer
ERROR model "admin/bogusmodel" not found

## Bug reference

https://bugs.launchpad.net/juju/+bug/1731812
