### PR TITLE
Increase timeout for api connection in worker/pubsub.

### DIFF
--- a/worker/pubsub/messagewriter.go
+++ b/worker/pubsub/messagewriter.go
@@ -22,8 +22,8 @@ type MessageWriter interface {
 
 var dialOpts = api.DialOpts{
 	DialAddressInterval: 20 * time.Millisecond,
-	Timeout:             50 * time.Millisecond,
-	RetryDelay:          50 * time.Millisecond,
+	Timeout:             2 * time.Second,
+	RetryDelay:          500 * time.Millisecond,
 }
 
 // NewMessageWriter will connect to the remote defined by the info,


### PR DESCRIPTION
From the time the pubsub workers until now, something has caused api.Open to take longer than 50ms. The 50ms number was a somewhat arbitrarily small number. This branch takes it to two seconds. This is the maximum amount of time we expect an api.Open call to take from one controller machine to another in the HA cluster. It *should* be way shorter than that, but it taking over 50ms just now.

This is causing a pinger to be leaked, which creates another pinger.being. This underlying bug still needs to be fixed, but this change stops irritating that other bug.

## QA steps

```
juju bootstrap lxd test-pinger
juju enable-ha
# wait for the machines to start
juju ssh -m controller 0
juju-pubsub-report
```
The other controller machines should show as connected.
## Bug reference

Partial fix for https://bugs.launchpad.net/juju/+bug/1731745
