### PR TITLE
state: pass in mgo.Session when opening State

### DIFF
--- a/agent/agentbootstrap/bootstrap_test.go
+++ b/agent/agentbootstrap/bootstrap_test.go
@@ -11,7 +11,6 @@ import (
 	gitjujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils"
-	"github.com/juju/utils/clock"
 	"github.com/juju/utils/series"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/names.v2"
@@ -304,7 +303,7 @@ LXC_BRIDGE="ignored"`[1:])
 	})
 
 	// Check that the machine agent's config has been written
-	// and that we can use it to connect to the state.
+	// and that we can use it to connect to mongo.
 	machine0 := names.NewMachineTag("0")
 	newCfg, err := agent.ReadConfig(agent.ConfigPath(dataDir, machine0))
 	c.Assert(err, jc.ErrorIsNil)
@@ -312,15 +311,10 @@ LXC_BRIDGE="ignored"`[1:])
 	info, ok := cfg.MongoInfo()
 	c.Assert(ok, jc.IsTrue)
 	c.Assert(info.Password, gc.Not(gc.Equals), testing.DefaultMongoPassword)
-	st1, err := state.Open(state.OpenParams{
-		Clock:              clock.WallClock,
-		ControllerTag:      newCfg.Controller(),
-		ControllerModelTag: newCfg.Model(),
-		MongoInfo:          info,
-		MongoDialOpts:      mongotest.DialOpts(),
-	})
+
+	session, err := mongo.DialWithInfo(*info, mongotest.DialOpts())
 	c.Assert(err, jc.ErrorIsNil)
-	defer st1.Close()
+	session.Close()
 
 	// Make sure that the hosted model Environ's Create method is called.
 	envProvider.CheckCallNames(c,
@@ -436,7 +430,7 @@ func (s *bootstrapSuite) TestInitializeStateFailsSecondTime(c *gc.C) {
 	if err == nil {
 		st.Close()
 	}
-	c.Assert(err, gc.ErrorMatches, "failed to initialize mongo admin user: cannot set admin password: not authorized .*")
+	c.Assert(err, gc.ErrorMatches, "failed to initialize mongo: cannot set admin password: not authorized .*")
 }
 
 func (s *bootstrapSuite) TestMachineJobFromParams(c *gc.C) {
@@ -465,25 +459,16 @@ func (s *bootstrapSuite) TestMachineJobFromParams(c *gc.C) {
 }
 
 func (s *bootstrapSuite) assertCanLogInAsAdmin(c *gc.C, modelTag names.ModelTag, controllerTag names.ControllerTag, password string) {
-	info := &mongo.MongoInfo{
+	session, err := mongo.DialWithInfo(mongo.MongoInfo{
 		Info: mongo.Info{
 			Addrs:  []string{s.mgoInst.Addr()},
 			CACert: testing.CACert,
 		},
 		Tag:      nil, // admin user
 		Password: password,
-	}
-	st, err := state.Open(state.OpenParams{
-		Clock:              clock.WallClock,
-		ControllerTag:      controllerTag,
-		ControllerModelTag: modelTag,
-		MongoInfo:          info,
-		MongoDialOpts:      mongotest.DialOpts(),
-	})
+	}, mongotest.DialOpts())
 	c.Assert(err, jc.ErrorIsNil)
-	defer st.Close()
-	_, err = st.Machine("0")
-	c.Assert(err, jc.ErrorIsNil)
+	session.Close()
 }
 
 type fakeProvider struct {

--- a/api/agent/machine_test.go
+++ b/api/agent/machine_test.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
-	"github.com/juju/utils/clock"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/names.v2"
 	"gopkg.in/mgo.v2"
@@ -173,8 +172,9 @@ func (s *machineSuite) TestEntitySetPassword(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	info.Tag = tag
 	info.Password = "foo-12345678901234567890"
-	err = tryOpenState(s.IAASModel.ModelTag(), s.State.ControllerTag(), info)
-	c.Assert(errors.Cause(err), jc.Satisfies, errors.IsUnauthorized)
+	session, err := mongo.DialWithInfo(*info, mongotest.DialOpts())
+	c.Assert(err, jc.Satisfies, errors.IsUnauthorized)
+	c.Assert(session, gc.IsNil)
 }
 
 func (s *machineSuite) TestClearReboot(c *gc.C) {
@@ -195,18 +195,4 @@ func (s *machineSuite) TestClearReboot(c *gc.C) {
 	rFlag, err = s.machine.GetRebootFlag()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(rFlag, jc.IsFalse)
-}
-
-func tryOpenState(modelTag names.ModelTag, controllerTag names.ControllerTag, info *mongo.MongoInfo) error {
-	st, err := state.Open(state.OpenParams{
-		Clock:              clock.WallClock,
-		ControllerTag:      controllerTag,
-		ControllerModelTag: modelTag,
-		MongoInfo:          info,
-		MongoDialOpts:      mongotest.DialOpts(),
-	})
-	if err == nil {
-		st.Close()
-	}
-	return err
 }

--- a/api/client.go
+++ b/api/client.go
@@ -48,12 +48,6 @@ func (c *Client) Status(patterns []string) (*params.FullStatus, error) {
 	return &result, nil
 }
 
-// CACert returns the CA certificate associated with
-// the connection.
-func (c *Client) CACert() (string, error) {
-	return common.NewAPIAddresser(c.facade).CACert()
-}
-
 // StatusHistory retrieves the last <size> results of
 // <kind:combined|agent|workload|machine|machineinstance|container|containerinstance> status
 // for <name> unit

--- a/api/common/apiaddresser.go
+++ b/api/common/apiaddresser.go
@@ -41,6 +41,10 @@ func (a *APIAddresser) APIAddresses() ([]string, error) {
 
 // ModelUUID returns the model UUID to connect to the model
 // that the current connection is for.
+//
+// TODO(axw) this has bugger all to do with addresses, and
+// so should not be on this type. Get it from somewhere else,
+// e.g. by passing it into the model-specific workers.
 func (a *APIAddresser) ModelUUID() (string, error) {
 	var result params.StringResult
 	err := a.facade.FacadeCall("ModelUUID", nil, &result)
@@ -48,16 +52,6 @@ func (a *APIAddresser) ModelUUID() (string, error) {
 		return "", err
 	}
 	return result.Result, nil
-}
-
-// CACert returns the certificate used to validate the API and state connections.
-func (a *APIAddresser) CACert() (string, error) {
-	var result params.BytesResult
-	err := a.facade.FacadeCall("CACert", nil, &result)
-	if err != nil {
-		return "", err
-	}
-	return string(result.Result), nil
 }
 
 // APIHostPorts returns the host/port addresses of the API servers.

--- a/api/deployer/deployer.go
+++ b/api/deployer/deployer.go
@@ -16,17 +16,13 @@ const deployerFacade = "Deployer"
 // State provides access to the deployer worker's idea of the state.
 type State struct {
 	facade base.FacadeCaller
-	*common.APIAddresser
 }
 
 // NewState creates a new State instance that makes API calls
 // through the given caller.
 func NewState(caller base.APICaller) *State {
 	facadeCaller := base.NewFacadeCaller(caller, deployerFacade)
-	return &State{
-		facade:       facadeCaller,
-		APIAddresser: common.NewAPIAddresser(facadeCaller),
-	}
+	return &State{facade: facadeCaller}
 
 }
 
@@ -55,16 +51,6 @@ func (st *State) Machine(tag names.MachineTag) (*Machine, error) {
 		tag: tag,
 		st:  st,
 	}, nil
-}
-
-// StateAddresses returns the list of addresses used to connect to the state.
-func (st *State) StateAddresses() ([]string, error) {
-	var result params.StringsResult
-	err := st.facade.FacadeCall("StateAddresses", nil, &result)
-	if err != nil {
-		return nil, err
-	}
-	return result.Result, nil
 }
 
 // ConnectionInfo returns all the address information that the deployer task

--- a/api/deployer/deployer_test.go
+++ b/api/deployer/deployer_test.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/juju/juju/api"
 	"github.com/juju/juju/api/deployer"
-	apitesting "github.com/juju/juju/api/testing"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/network"
@@ -28,7 +27,6 @@ func TestAll(t *stdtesting.T) {
 
 type deployerSuite struct {
 	testing.JujuConnSuite
-	*apitesting.APIAddresserTests
 
 	stateAPI api.Connection
 
@@ -74,8 +72,6 @@ func (s *deployerSuite) SetUpTest(c *gc.C) {
 	// Create the deployer facade.
 	s.st = deployer.NewState(s.stateAPI)
 	c.Assert(s.st, gc.NotNil)
-
-	s.APIAddresserTests = apitesting.NewAPIAddresserTests(s.st, s.BackingState)
 }
 
 // Note: This is really meant as a unit-test, this isn't a test that
@@ -224,19 +220,6 @@ func (s *deployerSuite) TestUnitSetPassword(c *gc.C) {
 	err = s.subordinate.Refresh()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(s.subordinate.PasswordValid("phony-12345678901234567890"), jc.IsTrue)
-}
-
-func (s *deployerSuite) TestStateAddresses(c *gc.C) {
-	err := s.machine.SetProviderAddresses(network.NewAddress("0.1.2.3"))
-	c.Assert(err, jc.ErrorIsNil)
-
-	stateAddresses, err := s.State.Addresses()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(len(stateAddresses), gc.Equals, 1)
-
-	addresses, err := s.st.StateAddresses()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(addresses, gc.DeepEquals, stateAddresses)
 }
 
 func (s *deployerSuite) TestUnitSetStatus(c *gc.C) {

--- a/api/migrationtarget/client.go
+++ b/api/migrationtarget/client.go
@@ -19,7 +19,6 @@ import (
 	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/api/base"
-	"github.com/juju/juju/api/common"
 	"github.com/juju/juju/apiserver/params"
 	coremigration "github.com/juju/juju/core/migration"
 	"github.com/juju/juju/resource"
@@ -225,7 +224,12 @@ func (c *Client) AdoptResources(modelUUID string) error {
 // CACert returns the CA certificate associated with
 // the connection.
 func (c *Client) CACert() (string, error) {
-	return common.NewAPIAddresser(c.caller).CACert()
+	var result params.BytesResult
+	err := c.caller.FacadeCall("CACert", nil, &result)
+	if err != nil {
+		return "", err
+	}
+	return string(result.Result), nil
 }
 
 // CheckMachines compares the machines in state with the ones reported

--- a/api/provisioner/provisioner.go
+++ b/api/provisioner/provisioner.go
@@ -341,3 +341,13 @@ func (st *State) DistributionGroupByMachineId(tags ...names.MachineTag) ([]Distr
 	}
 	return results, nil
 }
+
+// CACert returns the certificate used to validate the API and state connections.
+func (a *State) CACert() (string, error) {
+	var result params.BytesResult
+	err := a.facade.FacadeCall("CACert", nil, &result)
+	if err != nil {
+		return "", err
+	}
+	return string(result.Result), nil
+}

--- a/api/testing/apiaddresser.go
+++ b/api/testing/apiaddresser.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/state"
+	"github.com/juju/juju/testing"
 	"github.com/juju/juju/watcher"
 	"github.com/juju/juju/watcher/watchertest"
 )
@@ -66,7 +67,7 @@ func (s *APIAddresserTests) TestAPIHostPorts(c *gc.C) {
 func (s *APIAddresserTests) TestCACert(c *gc.C) {
 	caCert, err := s.facade.CACert()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(caCert, gc.DeepEquals, s.state.CACert())
+	c.Assert(caCert, gc.DeepEquals, testing.CACert)
 }
 
 func (s *APIAddresserTests) TestWatchAPIHostPorts(c *gc.C) {

--- a/api/testing/apiaddresser.go
+++ b/api/testing/apiaddresser.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/state"
-	"github.com/juju/juju/testing"
 	"github.com/juju/juju/watcher"
 	"github.com/juju/juju/watcher/watchertest"
 )
@@ -28,7 +27,6 @@ func NewAPIAddresserTests(facade APIAddresserFacade, st *state.State) *APIAddres
 
 type APIAddresserFacade interface {
 	APIAddresses() ([]string, error)
-	CACert() (string, error)
 	APIHostPorts() ([][]network.HostPort, error)
 	WatchAPIHostPorts() (watcher.NotifyWatcher, error)
 }
@@ -62,12 +60,6 @@ func (s *APIAddresserTests) TestAPIHostPorts(c *gc.C) {
 	serverAddrs, err := s.facade.APIHostPorts()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(serverAddrs, gc.DeepEquals, expectServerAddrs)
-}
-
-func (s *APIAddresserTests) TestCACert(c *gc.C) {
-	caCert, err := s.facade.CACert()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(caCert, gc.DeepEquals, testing.CACert)
 }
 
 func (s *APIAddresserTests) TestWatchAPIHostPorts(c *gc.C) {

--- a/apiserver/common/addresses.go
+++ b/apiserver/common/addresses.go
@@ -7,6 +7,7 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/controller"
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/watcher"
@@ -16,6 +17,7 @@ import (
 // controller addresses and the CA public certificate.
 type AddressAndCertGetter interface {
 	Addresses() ([]string, error)
+	ControllerConfig() (controller.Config, error)
 	ModelUUID() string
 	APIHostPorts() ([][]network.HostPort, error)
 	WatchAPIHostPorts() state.NotifyWatcher

--- a/apiserver/common/addresses.go
+++ b/apiserver/common/addresses.go
@@ -4,10 +4,8 @@
 package common
 
 import (
-	"github.com/juju/errors"
 	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/apiserver/params"
-	"github.com/juju/juju/controller"
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/watcher"
@@ -17,7 +15,6 @@ import (
 // controller addresses and the CA public certificate.
 type AddressAndCertGetter interface {
 	Addresses() ([]string, error)
-	ControllerConfig() (controller.Config, error)
 	ModelUUID() string
 	APIHostPorts() ([][]network.HostPort, error)
 	WatchAPIHostPorts() state.NotifyWatcher
@@ -86,16 +83,6 @@ func apiAddresses(getter APIHostPortsGetter) ([]string, error) {
 		}
 	}
 	return addrs, nil
-}
-
-// CACert returns the certificate used to validate the state connection.
-func (a *APIAddresser) CACert() (params.BytesResult, error) {
-	cfg, err := a.getter.ControllerConfig()
-	if err != nil {
-		return params.BytesResult{}, errors.Trace(err)
-	}
-	caCert, _ := cfg.CACert()
-	return params.BytesResult{Result: []byte(caCert)}, nil
 }
 
 // ModelUUID returns the model UUID to connect to the environment

--- a/apiserver/common/addresses_test.go
+++ b/apiserver/common/addresses_test.go
@@ -90,11 +90,6 @@ func (s *apiAddresserSuite) TestAPIAddressesPrivateFirst(c *gc.C) {
 	})
 }
 
-func (s *apiAddresserSuite) TestCACert(c *gc.C) {
-	result := s.addresser.CACert()
-	c.Assert(string(result.Result), gc.Equals, coretesting.CACert)
-}
-
 func (s *apiAddresserSuite) TestModelUUID(c *gc.C) {
 	result := s.addresser.ModelUUID()
 	c.Assert(string(result.Result), gc.Equals, "the environ uuid")

--- a/apiserver/common/addresses_test.go
+++ b/apiserver/common/addresses_test.go
@@ -8,8 +8,10 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/controller"
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/state"
+	coretesting "github.com/juju/juju/testing"
 )
 
 type stateAddresserSuite struct {
@@ -90,7 +92,7 @@ func (s *apiAddresserSuite) TestAPIAddressesPrivateFirst(c *gc.C) {
 
 func (s *apiAddresserSuite) TestCACert(c *gc.C) {
 	result := s.addresser.CACert()
-	c.Assert(string(result.Result), gc.Equals, "a cert")
+	c.Assert(string(result.Result), gc.Equals, coretesting.CACert)
 }
 
 func (s *apiAddresserSuite) TestModelUUID(c *gc.C) {
@@ -108,8 +110,8 @@ func (fakeAddresses) Addresses() ([]string, error) {
 	return []string{"addresses:1", "addresses:2"}, nil
 }
 
-func (fakeAddresses) CACert() string {
-	return "a cert"
+func (fakeAddresses) ControllerConfig() (controller.Config, error) {
+	return coretesting.FakeControllerConfig(), nil
 }
 
 func (fakeAddresses) ModelUUID() string {

--- a/apiserver/common/controllerconfig.go
+++ b/apiserver/common/controllerconfig.go
@@ -91,5 +91,13 @@ func StateControllerInfo(st *state.State) (addrs []string, caCert string, _ erro
 	if err != nil {
 		return nil, "", errors.Trace(err)
 	}
-	return addr, st.CACert(), nil
+	controllerConfig, err := st.ControllerConfig()
+	if err != nil {
+		return nil, "", errors.Trace(err)
+	}
+	caCert, ok := controllerConfig.CACert()
+	if !ok {
+		return nil, "", errors.New("CA certificate missing from controller config")
+	}
+	return addr, caCert, nil
 }

--- a/apiserver/common/controllerconfig.go
+++ b/apiserver/common/controllerconfig.go
@@ -95,9 +95,6 @@ func StateControllerInfo(st *state.State) (addrs []string, caCert string, _ erro
 	if err != nil {
 		return nil, "", errors.Trace(err)
 	}
-	caCert, ok := controllerConfig.CACert()
-	if !ok {
-		return nil, "", errors.New("CA certificate missing from controller config")
-	}
+	caCert, _ = controllerConfig.CACert()
 	return addr, caCert, nil
 }

--- a/apiserver/common/controllerconfig_test.go
+++ b/apiserver/common/controllerconfig_test.go
@@ -125,7 +125,7 @@ func (s *controllerInfoSuite) TestControllerInfoLocalModel(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results.Results[0].Addresses, gc.HasLen, 1)
 	c.Assert(results.Results[0].Addresses[0], gc.Equals, apiAddr[0][0].String())
-	c.Assert(results.Results[0].CACert, gc.Equals, s.State.CACert())
+	c.Assert(results.Results[0].CACert, gc.Equals, testing.CACert)
 }
 
 func (s *controllerInfoSuite) TestControllerInfoExternalModel(c *gc.C) {

--- a/apiserver/facades/agent/deployer/deployer.go
+++ b/apiserver/facades/agent/deployer/deployer.go
@@ -19,8 +19,6 @@ type DeployerAPI struct {
 	*common.Remover
 	*common.PasswordChanger
 	*common.LifeGetter
-	*common.StateAddresser
-	*common.APIAddresser
 	*common.UnitsWatcher
 	*common.StatusSetter
 
@@ -64,8 +62,6 @@ func NewDeployerAPI(
 		Remover:         common.NewRemover(st, true, getAuthFunc),
 		PasswordChanger: common.NewPasswordChanger(st, getAuthFunc),
 		LifeGetter:      common.NewLifeGetter(st, getAuthFunc),
-		StateAddresser:  common.NewStateAddresser(st),
-		APIAddresser:    common.NewAPIAddresser(st, resources),
 		UnitsWatcher:    common.NewUnitsWatcher(st, resources, getCanWatch),
 		StatusSetter:    common.NewStatusSetter(st, getAuthFunc),
 		st:              st,
@@ -77,12 +73,14 @@ func NewDeployerAPI(
 // ConnectionInfo returns all the address information that the
 // deployer task needs in one call.
 func (d *DeployerAPI) ConnectionInfo() (result params.DeployerConnectionValues, err error) {
-	stateAddrs, err := d.StateAddresses()
+	stateAddresser := common.NewStateAddresser(d.st)
+	stateAddrs, err := stateAddresser.StateAddresses()
 	if err != nil {
 		return result, err
 	}
 
-	apiAddrs, err := d.APIAddresses()
+	apiAddresser := common.NewAPIAddresser(d.st, d.resources)
+	apiAddrs, err := apiAddresser.APIAddresses()
 	if err != nil {
 		return result, err
 	}

--- a/apiserver/facades/agent/deployer/deployer_test.go
+++ b/apiserver/facades/agent/deployer/deployer_test.go
@@ -330,7 +330,7 @@ func (s *deployerSuite) TestAPIAddresses(c *gc.C) {
 func (s *deployerSuite) TestCACert(c *gc.C) {
 	result := s.deployer.CACert()
 	c.Assert(result, gc.DeepEquals, params.BytesResult{
-		Result: []byte(s.State.CACert()),
+		Result: []byte(coretesting.CACert),
 	})
 }
 

--- a/apiserver/facades/agent/deployer/deployer_test.go
+++ b/apiserver/facades/agent/deployer/deployer_test.go
@@ -299,41 +299,6 @@ func (s *deployerSuite) TestRemove(c *gc.C) {
 	})
 }
 
-func (s *deployerSuite) TestStateAddresses(c *gc.C) {
-	err := s.machine0.SetProviderAddresses(network.NewAddress("0.1.2.3"))
-	c.Assert(err, jc.ErrorIsNil)
-
-	addresses, err := s.State.Addresses()
-	c.Assert(err, jc.ErrorIsNil)
-
-	result, err := s.deployer.StateAddresses()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(result, gc.DeepEquals, params.StringsResult{
-		Result: addresses,
-	})
-}
-
-func (s *deployerSuite) TestAPIAddresses(c *gc.C) {
-	hostPorts := [][]network.HostPort{
-		network.NewHostPorts(1234, "0.1.2.3"),
-	}
-	err := s.State.SetAPIHostPorts(hostPorts)
-	c.Assert(err, jc.ErrorIsNil)
-
-	result, err := s.deployer.APIAddresses()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(result, gc.DeepEquals, params.StringsResult{
-		Result: []string{"0.1.2.3:1234"},
-	})
-}
-
-func (s *deployerSuite) TestCACert(c *gc.C) {
-	result := s.deployer.CACert()
-	c.Assert(result, gc.DeepEquals, params.BytesResult{
-		Result: []byte(coretesting.CACert),
-	})
-}
-
 func (s *deployerSuite) TestConnectionInfo(c *gc.C) {
 	err := s.machine0.SetProviderAddresses(network.NewScopedAddress("0.1.2.3", network.ScopePublic),
 		network.NewScopedAddress("1.2.3.4", network.ScopeCloudLocal))

--- a/apiserver/facades/agent/provisioner/provisioner.go
+++ b/apiserver/facades/agent/provisioner/provisioner.go
@@ -1124,3 +1124,13 @@ func (p *ProvisionerAPI) markOneMachineForRemoval(machineTag string, canAccess c
 func (p *ProvisionerAPI) SetHostMachineNetworkConfig(args params.SetMachineNetworkConfig) error {
 	return p.SetObservedNetworkConfig(args)
 }
+
+// CACert returns the certificate used to validate the state connection.
+func (a *ProvisionerAPI) CACert() (params.BytesResult, error) {
+	cfg, err := a.st.ControllerConfig()
+	if err != nil {
+		return params.BytesResult{}, errors.Trace(err)
+	}
+	caCert, _ := cfg.CACert()
+	return params.BytesResult{Result: []byte(caCert)}, nil
+}

--- a/apiserver/facades/agent/provisioner/provisioner_test.go
+++ b/apiserver/facades/agent/provisioner/provisioner_test.go
@@ -1496,7 +1496,7 @@ func (s *withControllerSuite) TestStateAddresses(c *gc.C) {
 func (s *withControllerSuite) TestCACert(c *gc.C) {
 	result := s.provisioner.CACert()
 	c.Assert(result, gc.DeepEquals, params.BytesResult{
-		Result: []byte(s.State.CACert()),
+		Result: []byte(coretesting.CACert),
 	})
 }
 

--- a/apiserver/facades/agent/provisioner/provisioner_test.go
+++ b/apiserver/facades/agent/provisioner/provisioner_test.go
@@ -1494,7 +1494,8 @@ func (s *withControllerSuite) TestStateAddresses(c *gc.C) {
 }
 
 func (s *withControllerSuite) TestCACert(c *gc.C) {
-	result := s.provisioner.CACert()
+	result, err := s.provisioner.CACert()
+	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, params.BytesResult{
 		Result: []byte(coretesting.CACert),
 	})

--- a/apiserver/facades/client/applicationoffers/access_test.go
+++ b/apiserver/facades/client/applicationoffers/access_test.go
@@ -39,7 +39,8 @@ func (s *offerAccessSuite) SetUpTest(c *gc.C) {
 	s.authContext, err = crossmodel.NewAuthContext(&mockCommonStatePool{s.mockStatePool}, s.bakery, s.bakery)
 	c.Assert(err, jc.ErrorIsNil)
 	s.api, err = applicationoffers.CreateOffersAPI(
-		getApplicationOffers, nil, s.mockState, s.mockStatePool, s.authorizer, resources, s.authContext,
+		getApplicationOffers, nil, getFakeControllerInfo,
+		s.mockState, s.mockStatePool, s.authorizer, resources, s.authContext,
 	)
 	c.Assert(err, jc.ErrorIsNil)
 }

--- a/apiserver/facades/client/applicationoffers/applicationoffers.go
+++ b/apiserver/facades/client/applicationoffers/applicationoffers.go
@@ -433,10 +433,15 @@ func (api *OffersAPI) GetConsumeDetails(args params.OfferURLs) (params.ConsumeOf
 	if addr.Error != nil {
 		return consumeResults, common.ServerError(err)
 	}
+	caCertResult, err := api.APIAddresser.CACert()
+	if err != nil {
+		return consumeResults, common.ServerError(err)
+	}
+
 	controllerInfo := &params.ExternalControllerInfo{
 		ControllerTag: api.ControllerModel.ControllerTag().String(),
 		Addrs:         addr.Result,
-		CACert:        string(api.APIAddresser.CACert().Result),
+		CACert:        string(caCertResult.Result),
 	}
 
 	for i, result := range offers.Results {

--- a/apiserver/facades/client/applicationoffers/applicationoffers_test.go
+++ b/apiserver/facades/client/applicationoffers/applicationoffers_test.go
@@ -51,7 +51,8 @@ func (s *applicationOffersSuite) SetUpTest(c *gc.C) {
 	s.authContext, err = crossmodel.NewAuthContext(&mockCommonStatePool{s.mockStatePool}, s.bakery, s.bakery)
 	c.Assert(err, jc.ErrorIsNil)
 	s.api, err = applicationoffers.CreateOffersAPI(
-		getApplicationOffers, getEnviron, s.mockState, s.mockStatePool, s.authorizer, resources, s.authContext,
+		getApplicationOffers, getEnviron, getFakeControllerInfo,
+		s.mockState, s.mockStatePool, s.authorizer, resources, s.authContext,
 	)
 	c.Assert(err, jc.ErrorIsNil)
 }
@@ -1043,7 +1044,8 @@ func (s *consumeSuite) SetUpTest(c *gc.C) {
 	s.authContext, err = crossmodel.NewAuthContext(&mockCommonStatePool{s.mockStatePool}, s.bakery, s.bakery)
 	c.Assert(err, jc.ErrorIsNil)
 	s.api, err = applicationoffers.CreateOffersAPI(
-		getApplicationOffers, getEnviron, s.mockState, s.mockStatePool, s.authorizer, resources, s.authContext,
+		getApplicationOffers, getEnviron, getFakeControllerInfo,
+		s.mockState, s.mockStatePool, s.authorizer, resources, s.authContext,
 	)
 	c.Assert(err, jc.ErrorIsNil)
 }

--- a/apiserver/facades/client/applicationoffers/base.go
+++ b/apiserver/facades/client/applicationoffers/base.go
@@ -27,6 +27,7 @@ type BaseAPI struct {
 	ControllerModel      Backend
 	StatePool            StatePool
 	getEnviron           environFromModelFunc
+	getControllerInfo    func() (apiAddrs []string, caCert string, _ error)
 }
 
 // checkPermission ensures that the logged in user holds the given permission on an entity.

--- a/apiserver/facades/client/applicationoffers/mock_test.go
+++ b/apiserver/facades/client/applicationoffers/mock_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/common/crossmodel"
 	"github.com/juju/juju/apiserver/facades/client/applicationoffers"
+	"github.com/juju/juju/controller"
 	jujucrossmodel "github.com/juju/juju/core/crossmodel"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/network"
@@ -492,8 +493,8 @@ func (m *mockState) APIHostPorts() ([][]network.HostPort, error) {
 	}, nil
 }
 
-func (m *mockState) CACert() string {
-	return testing.CACert
+func (m *mockState) ControllerConfig() (controller.Config, error) {
+	return testing.FakeControllerConfig(), nil
 }
 
 type mockStatePool struct {

--- a/apiserver/facades/client/applicationoffers/mock_test.go
+++ b/apiserver/facades/client/applicationoffers/mock_test.go
@@ -18,7 +18,6 @@ import (
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/common/crossmodel"
 	"github.com/juju/juju/apiserver/facades/client/applicationoffers"
-	"github.com/juju/juju/controller"
 	jujucrossmodel "github.com/juju/juju/core/crossmodel"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/network"
@@ -484,19 +483,6 @@ func (m *mockState) GetOfferUsers(offerUUID string) (map[string]permission.Acces
 	return result, nil
 }
 
-func (m *mockState) APIHostPorts() ([][]network.HostPort, error) {
-	return [][]network.HostPort{
-		{
-			{Address: network.Address{Value: "192.168.1.1", Scope: network.ScopeCloudLocal}, Port: 17070},
-			{Address: network.Address{Value: "10.1.1.1", Scope: network.ScopeMachineLocal}, Port: 17070},
-		},
-	}, nil
-}
-
-func (m *mockState) ControllerConfig() (controller.Config, error) {
-	return testing.FakeControllerConfig(), nil
-}
-
 type mockStatePool struct {
 	st map[string]applicationoffers.Backend
 }
@@ -544,4 +530,8 @@ func (s *mockBakeryService) NewMacaroon(id string, key []byte, caveats []checker
 func (s *mockBakeryService) ExpireStorageAt(when time.Time) (authentication.ExpirableStorageBakeryService, error) {
 	s.MethodCall(s, "ExpireStorageAt", when)
 	return s, nil
+}
+
+func getFakeControllerInfo() ([]string, string, error) {
+	return []string{"192.168.1.1:17070"}, testing.CACert, nil
 }

--- a/apiserver/facades/client/applicationoffers/state.go
+++ b/apiserver/facades/client/applicationoffers/state.go
@@ -8,7 +8,6 @@ import (
 	"gopkg.in/juju/charm.v6-unstable"
 	"gopkg.in/juju/names.v2"
 
-	"github.com/juju/juju/apiserver/common"
 	commoncrossmodel "github.com/juju/juju/apiserver/common/crossmodel"
 	"github.com/juju/juju/core/crossmodel"
 	"github.com/juju/juju/network"
@@ -56,7 +55,6 @@ func (pool statePoolShim) GetModel(modelUUID string) (Model, func(), error) {
 // Backend provides selected methods off the state.State struct.
 type Backend interface {
 	commoncrossmodel.Backend
-	GetAddressAndCertGetter() common.AddressAndCertGetter
 	Charm(*charm.URL) (commoncrossmodel.Charm, error)
 	ApplicationOffer(name string) (*crossmodel.ApplicationOffer, error)
 	Model() (Model, error)
@@ -80,10 +78,6 @@ var GetStateAccess = func(st *state.State) Backend {
 type stateShim struct {
 	commoncrossmodel.Backend
 	st *state.State
-}
-
-func (s stateShim) GetAddressAndCertGetter() common.AddressAndCertGetter {
-	return s.st
 }
 
 func (s stateShim) CreateOfferAccess(offer names.ApplicationOfferTag, user names.UserTag, access permission.Access) error {

--- a/apiserver/facades/client/backups/backups.go
+++ b/apiserver/facades/client/backups/backups.go
@@ -16,7 +16,6 @@ import (
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/controller"
 	"github.com/juju/juju/environs/config"
-	"github.com/juju/juju/mongo"
 	"github.com/juju/juju/permission"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/backups"
@@ -29,7 +28,6 @@ type Backend interface {
 	IsController() bool
 	Machine(id string) (*state.Machine, error)
 	MachineSeries(id string) (string, error)
-	MongoConnectionInfo() *mongo.MongoInfo
 	MongoSession() *mgo.Session
 	MongoVersion() (string, error)
 	ModelTag() names.ModelTag

--- a/apiserver/facades/client/backups/backups_test.go
+++ b/apiserver/facades/client/backups/backups_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/juju/juju/apiserver/common"
 	backupsAPI "github.com/juju/juju/apiserver/facades/client/backups"
+	"github.com/juju/juju/apiserver/params"
 	apiservertesting "github.com/juju/juju/apiserver/testing"
 	"github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/state/backups"
@@ -27,17 +28,35 @@ type backupsSuite struct {
 	authorizer *apiservertesting.FakeAuthorizer
 	api        *backupsAPI.API
 	meta       *backups.Metadata
+	machineTag names.MachineTag
 }
 
 var _ = gc.Suite(&backupsSuite{})
 
 func (s *backupsSuite) SetUpTest(c *gc.C) {
 	s.JujuConnSuite.SetUpTest(c)
+
+	s.machineTag = names.NewMachineTag("0")
 	s.resources = common.NewResources()
-	s.resources.RegisterNamed("dataDir", common.StringResource("/var/lib/juju"))
+	s.resources.RegisterNamed("dataDir", common.StringResource(s.DataDir()))
+	s.resources.RegisterNamed("machineID", common.StringResource(s.machineTag.Id()))
+
+	ssInfo, err := s.State.StateServingInfo()
+	c.Assert(err, jc.ErrorIsNil)
+	agentConfig := s.AgentConfigForTag(c, s.machineTag)
+	agentConfig.SetStateServingInfo(params.StateServingInfo{
+		PrivateKey:   ssInfo.PrivateKey,
+		Cert:         ssInfo.Cert,
+		CAPrivateKey: ssInfo.CAPrivateKey,
+		SharedSecret: ssInfo.SharedSecret,
+		APIPort:      ssInfo.APIPort,
+		StatePort:    ssInfo.StatePort,
+	})
+	err = agentConfig.Write()
+	c.Assert(err, jc.ErrorIsNil)
+
 	tag := names.NewLocalUserTag("admin")
 	s.authorizer = &apiservertesting.FakeAuthorizer{Tag: tag}
-	var err error
 	s.api, err = backupsAPI.NewAPI(&stateShim{s.State, s.IAASModel.Model}, s.resources, s.authorizer)
 	c.Assert(err, jc.ErrorIsNil)
 	s.meta = backupstesting.NewMetadataStarted()

--- a/apiserver/facades/client/backups/create.go
+++ b/apiserver/facades/client/backups/create.go
@@ -29,7 +29,10 @@ func (a *API) Create(args params.BackupsCreateArgs) (p params.BackupsMetadataRes
 		return p, errors.Annotatef(err, "HA not ready; try again later")
 	}
 
-	mgoInfo := a.backend.MongoConnectionInfo()
+	mgoInfo, err := mongoInfo(a.paths.DataDir, a.machineID)
+	if err != nil {
+		return p, errors.Annotatef(err, "getting mongo info")
+	}
 	v, err := a.backend.MongoVersion()
 	if err != nil {
 		return p, errors.Annotatef(err, "discovering mongo version")

--- a/apiserver/facades/client/backups/mongoinfo.go
+++ b/apiserver/facades/client/backups/mongoinfo.go
@@ -1,0 +1,29 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package backups
+
+import (
+	"github.com/juju/errors"
+	"gopkg.in/juju/names.v2"
+
+	"github.com/juju/juju/agent"
+	"github.com/juju/juju/mongo"
+)
+
+// TODO(axw) find a better way to pass the mongo info to the facade,
+// without necessarily making it available to all facades. This was
+// moved here so that we could remove the MongoConnectionInfo method
+// from State.
+func mongoInfo(dataDir, machineId string) (*mongo.MongoInfo, error) {
+	path := agent.ConfigPath(dataDir, names.NewMachineTag(machineId))
+	config, err := agent.ReadConfig(path)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	info, ok := config.MongoInfo()
+	if !ok {
+		return nil, errors.Errorf("no mongo info found in %q", path)
+	}
+	return info, nil
+}

--- a/apiserver/facades/client/backups/restore.go
+++ b/apiserver/facades/client/backups/restore.go
@@ -80,7 +80,10 @@ func (a *API) Restore(p params.RestoreArgs) error {
 		return errors.Annotatef(err, "HA not ready; try again later")
 	}
 
-	mgoInfo := a.backend.MongoConnectionInfo()
+	mgoInfo, err := mongoInfo(a.paths.DataDir, a.machineID)
+	if err != nil {
+		return errors.Annotatef(err, "getting mongo info")
+	}
 	logger.Debugf("mongo info from state %+v", mgoInfo)
 	v, err := a.backend.MongoVersion()
 	if err != nil {

--- a/apiserver/facades/client/backups/restore.go
+++ b/apiserver/facades/client/backups/restore.go
@@ -11,7 +11,6 @@ import (
 	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/apiserver/params"
-	"github.com/juju/juju/mongo"
 	"github.com/juju/juju/service"
 	"github.com/juju/juju/service/common"
 	"github.com/juju/juju/state"
@@ -80,26 +79,7 @@ func (a *API) Restore(p params.RestoreArgs) error {
 		return errors.Annotatef(err, "HA not ready; try again later")
 	}
 
-	mgoInfo, err := mongoInfo(a.paths.DataDir, a.machineID)
-	if err != nil {
-		return errors.Annotatef(err, "getting mongo info")
-	}
-	logger.Debugf("mongo info from state %+v", mgoInfo)
-	v, err := a.backend.MongoVersion()
-	if err != nil {
-		return errors.Annotatef(err, "discovering mongo version")
-	}
-	mongoVersion, err := mongo.NewVersion(v)
-	if err != nil {
-		return errors.Trace(err)
-	}
-
-	dbInfo, err := backups.NewDBInfo(mgoInfo, session, mongoVersion)
-	if err != nil {
-		return errors.Trace(err)
-	}
-
-	oldTagString, err := backup.Restore(p.BackupId, dbInfo, restoreArgs)
+	oldTagString, err := backup.Restore(p.BackupId, restoreArgs)
 	if err != nil {
 		return errors.Annotate(err, "restore failed")
 	}

--- a/apiserver/facades/client/client/backend.go
+++ b/apiserver/facades/client/client/backend.go
@@ -10,6 +10,7 @@ import (
 	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/constraints"
+	"github.com/juju/juju/controller"
 	"github.com/juju/juju/core/crossmodel"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/instance"
@@ -42,6 +43,7 @@ type Backend interface {
 	Application(string) (*state.Application, error)
 	ApplicationLeaders() (map[string]string, error)
 	Charm(*charm.URL) (*state.Charm, error)
+	ControllerConfig() (controller.Config, error)
 	ControllerTag() names.ControllerTag
 	EndpointsRelation(...state.Endpoint) (*state.Relation, error)
 	FindEntity(names.Tag) (state.Entity, error)

--- a/apiserver/facades/client/client/client.go
+++ b/apiserver/facades/client/client/client.go
@@ -53,7 +53,7 @@ func (api *API) state() *state.State {
 // caCerter implements the subset of common.APIAddresser
 // methods that we choose to expose in the client facade.
 type caCerter interface {
-	CACert() params.BytesResult
+	CACert() (params.BytesResult, error)
 }
 
 // Client serves client-specific API methods.

--- a/apiserver/facades/client/client/client_test.go
+++ b/apiserver/facades/client/client/client_test.go
@@ -628,12 +628,6 @@ func (s *clientSuite) assertResolvedBlocked(c *gc.C, u *state.Unit, msg string) 
 	s.AssertBlocked(c, err, msg)
 }
 
-func (s *serverSuite) TestCACert(c *gc.C) {
-	r, err := s.APIState.Client().CACert()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(r, gc.Equals, coretesting.CACert)
-}
-
 func (s *clientSuite) TestBlockDestroyUnitResolved(c *gc.C) {
 	u := s.setupResolved(c)
 	s.BlockDestroyModel(c, "TestBlockDestroyUnitResolved")

--- a/apiserver/facades/client/client/instanceconfig.go
+++ b/apiserver/facades/client/client/instanceconfig.go
@@ -87,8 +87,7 @@ func InstanceConfig(st *state.State, machineId, nonce, dataDir string) (*instanc
 		ModelTag: model.ModelTag(),
 	}
 
-	auth := authentication.NewAuthenticator(st.MongoConnectionInfo(), apiInfo)
-	_, apiInfo, err = auth.SetupAuthentication(machine)
+	_, apiInfo, err = authentication.SetupAuthentication(machine, nil, apiInfo)
 	if err != nil {
 		return nil, errors.Annotate(err, "setting up machine authentication")
 	}

--- a/apiserver/facades/client/client/instanceconfig.go
+++ b/apiserver/facades/client/client/instanceconfig.go
@@ -70,6 +70,15 @@ func InstanceConfig(st *state.State, machineId, nonce, dataDir string) (*instanc
 	}
 	toolsList := findToolsResult.List
 
+	controllerConfig, err := st.ControllerConfig()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	caCert, ok := controllerConfig.CACert()
+	if !ok {
+		return nil, errors.New("CA certificate missing from controller config")
+	}
+
 	// Get the API connection info; attempt all API addresses.
 	apiHostPorts, err := st.APIHostPorts()
 	if err != nil {
@@ -83,7 +92,7 @@ func InstanceConfig(st *state.State, machineId, nonce, dataDir string) (*instanc
 	}
 	apiInfo := &api.Info{
 		Addrs:    apiAddrs.SortedValues(),
-		CACert:   st.CACert(),
+		CACert:   caCert,
 		ModelTag: model.ModelTag(),
 	}
 

--- a/apiserver/facades/client/client/instanceconfig.go
+++ b/apiserver/facades/client/client/instanceconfig.go
@@ -74,10 +74,7 @@ func InstanceConfig(st *state.State, machineId, nonce, dataDir string) (*instanc
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	caCert, ok := controllerConfig.CACert()
-	if !ok {
-		return nil, errors.New("CA certificate missing from controller config")
-	}
+	caCert, _ := controllerConfig.CACert()
 
 	// Get the API connection info; attempt all API addresses.
 	apiHostPorts, err := st.APIHostPorts()

--- a/apiserver/facades/client/client/statushistory_test.go
+++ b/apiserver/facades/client/client/statushistory_test.go
@@ -41,7 +41,6 @@ func (s *statusHistoryTestSuite) SetUpTest(c *gc.C) {
 		nil, // toolsFinder
 		nil, // newEnviron
 		nil, // blockChecker
-		nil, // addresser
 	)
 	c.Assert(err, jc.ErrorIsNil)
 }

--- a/apiserver/facades/controller/migrationtarget/migrationtarget.go
+++ b/apiserver/facades/controller/migrationtarget/migrationtarget.go
@@ -36,7 +36,7 @@ type API struct {
 // addresser implements the subset of common.APIAddresser
 // methods that we choose to expose in the MigrationTarget facade.
 type addresser interface {
-	CACert() params.BytesResult
+	CACert() (params.BytesResult, error)
 }
 
 // NewFacade is used for API registration.

--- a/apiserver/facades/controller/migrationtarget/migrationtarget_test.go
+++ b/apiserver/facades/controller/migrationtarget/migrationtarget_test.go
@@ -104,7 +104,8 @@ func (s *Suite) TestPrechecks(c *gc.C) {
 
 func (s *Suite) TestCACert(c *gc.C) {
 	api := s.mustNewAPI(c)
-	r := api.CACert()
+	r, err := api.CACert()
+	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(string(r.Result), gc.Equals, jujutesting.CACert)
 }
 

--- a/apiserver/registration.go
+++ b/apiserver/registration.go
@@ -181,8 +181,16 @@ func (h *registerUserHandler) getSecretKeyLoginResponsePayload(
 	if !st.IsController() {
 		return nil, errors.New("state is not for a controller")
 	}
+	controllerConfig, err := st.ControllerConfig()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	caCert, ok := controllerConfig.CACert()
+	if !ok {
+		return nil, errors.New("CA certificate missing from controller config")
+	}
 	payload := params.SecretKeyLoginResponsePayload{
-		CACert:         st.CACert(),
+		CACert:         caCert,
 		ControllerUUID: st.ControllerUUID(),
 	}
 	return &payload, nil

--- a/apiserver/registration.go
+++ b/apiserver/registration.go
@@ -185,10 +185,7 @@ func (h *registerUserHandler) getSecretKeyLoginResponsePayload(
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	caCert, ok := controllerConfig.CACert()
-	if !ok {
-		return nil, errors.New("CA certificate missing from controller config")
-	}
+	caCert, _ := controllerConfig.CACert()
 	payload := params.SecretKeyLoginResponsePayload{
 		CACert:         caCert,
 		ControllerUUID: st.ControllerUUID(),

--- a/apiserver/registration_test.go
+++ b/apiserver/registration_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/state"
+	coretesting "github.com/juju/juju/testing"
 )
 
 type registrationSuite struct {
@@ -83,7 +84,7 @@ func (s *registrationSuite) TestRegister(c *gc.C) {
 	var responsePayload params.SecretKeyLoginResponsePayload
 	err = json.Unmarshal(plaintext, &responsePayload)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(responsePayload.CACert, gc.Equals, s.BackingState.CACert())
+	c.Assert(responsePayload.CACert, gc.Equals, coretesting.CACert)
 	model, err := s.BackingState.Model()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(responsePayload.ControllerUUID, gc.Equals, model.ControllerUUID())

--- a/apiserver/root.go
+++ b/apiserver/root.go
@@ -73,6 +73,16 @@ func newAPIHandler(srv *Server, st *state.State, rpcConn *rpc.Conn, modelUUID st
 		modelUUID:  modelUUID,
 		serverHost: serverHost,
 	}
+
+	controllerConfig, err := st.ControllerConfig()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	caCert, ok := controllerConfig.CACert()
+	if !ok {
+		return nil, errors.New("CA certificate missing from controller config")
+	}
+
 	if err := r.resources.RegisterNamed("machineID", common.StringResource(srv.tag.Id())); err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -82,6 +92,10 @@ func newAPIHandler(srv *Server, st *state.State, rpcConn *rpc.Conn, modelUUID st
 	if err := r.resources.RegisterNamed("logDir", common.StringResource(srv.logDir)); err != nil {
 		return nil, errors.Trace(err)
 	}
+	if err := r.resources.RegisterNamed("caCert", common.StringResource(caCert)); err != nil {
+		return nil, errors.Trace(err)
+	}
+
 	// Facades involved with managing application offers need the auth context
 	// to mint and validate macaroons.
 	localOfferAccessEndpoint := url.URL{

--- a/apiserver/root.go
+++ b/apiserver/root.go
@@ -74,15 +74,6 @@ func newAPIHandler(srv *Server, st *state.State, rpcConn *rpc.Conn, modelUUID st
 		serverHost: serverHost,
 	}
 
-	controllerConfig, err := st.ControllerConfig()
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	caCert, ok := controllerConfig.CACert()
-	if !ok {
-		return nil, errors.New("CA certificate missing from controller config")
-	}
-
 	if err := r.resources.RegisterNamed("machineID", common.StringResource(srv.tag.Id())); err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -90,9 +81,6 @@ func newAPIHandler(srv *Server, st *state.State, rpcConn *rpc.Conn, modelUUID st
 		return nil, errors.Trace(err)
 	}
 	if err := r.resources.RegisterNamed("logDir", common.StringResource(srv.logDir)); err != nil {
-		return nil, errors.Trace(err)
-	}
-	if err := r.resources.RegisterNamed("caCert", common.StringResource(caCert)); err != nil {
 		return nil, errors.Trace(err)
 	}
 

--- a/apiserver/server_test.go
+++ b/apiserver/server_test.go
@@ -207,12 +207,15 @@ func (s *serverSuite) TestNewServerDoesNotAccessState(c *gc.C) {
 		Timeout:       5 * time.Second,
 		SocketTimeout: 5 * time.Second,
 	}
+	session, err := mongo.DialWithInfo(*mongoInfo, dialOpts)
+	c.Assert(err, jc.ErrorIsNil)
+	defer session.Close()
+
 	st, err := state.Open(state.OpenParams{
 		Clock:              clock.WallClock,
 		ControllerTag:      s.State.ControllerTag(),
 		ControllerModelTag: s.IAASModel.ModelTag(),
-		MongoInfo:          mongoInfo,
-		MongoDialOpts:      dialOpts,
+		MongoSession:       session,
 	})
 	c.Assert(err, gc.IsNil)
 	defer st.Close()

--- a/cmd/jujud/agent/agenttest/agent.go
+++ b/cmd/jujud/agent/agenttest/agent.go
@@ -254,12 +254,14 @@ func (s *AgentSuite) AssertCanOpenState(c *gc.C, tag names.Tag, dataDir string) 
 	c.Assert(err, jc.ErrorIsNil)
 	info, ok := config.MongoInfo()
 	c.Assert(ok, jc.IsTrue)
+	session, err := mongo.DialWithInfo(*info, mongotest.DialOpts())
+	c.Assert(err, jc.ErrorIsNil)
+	defer session.Close()
 	st, err := state.Open(state.OpenParams{
 		Clock:              clock.WallClock,
 		ControllerTag:      config.Controller(),
 		ControllerModelTag: config.Model(),
-		MongoInfo:          info,
-		MongoDialOpts:      mongotest.DialOpts(),
+		MongoSession:       session,
 		NewPolicy: stateenvirons.GetNewPolicyFunc(
 			stateenvirons.GetNewEnvironFunc(environs.New),
 		),

--- a/cmd/jujud/agent/agenttest/agent.go
+++ b/cmd/jujud/agent/agenttest/agent.go
@@ -199,7 +199,7 @@ func (s *AgentSuite) WriteStateAgentConfig(
 	vers version.Binary,
 	modelTag names.ModelTag,
 ) agent.ConfigSetterWriter {
-	stateInfo := s.State.MongoConnectionInfo()
+	stateInfo := s.MongoInfo(c)
 	apiPort := gitjujutesting.FindTCPPort()
 	apiAddr := []string{fmt.Sprintf("localhost:%d", apiPort)}
 	conf, err := agent.NewStateMachineConfig(

--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -884,12 +884,17 @@ func (a *MachineAgent) openStateForUpgrade() (*state.State, error) {
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
+	session, err := mongo.DialWithInfo(*info, dialOpts)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	defer session.Close()
+
 	st, err := state.Open(state.OpenParams{
 		Clock:              clock.WallClock,
 		ControllerTag:      agentConfig.Controller(),
 		ControllerModelTag: agentConfig.Model(),
-		MongoInfo:          info,
-		MongoDialOpts:      dialOpts,
+		MongoSession:       session,
 		NewPolicy: stateenvirons.GetNewPolicyFunc(
 			stateenvirons.GetNewEnvironFunc(environs.New),
 		),
@@ -1034,13 +1039,17 @@ func (a *MachineAgent) initController(agentConfig agent.Config) (*state.Controll
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
+	session, err := mongo.DialWithInfo(*info, dialOpts)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	defer session.Close()
 
 	ctlr, err := state.OpenController(state.OpenParams{
 		Clock:              clock.WallClock,
 		ControllerTag:      agentConfig.Controller(),
 		ControllerModelTag: agentConfig.Model(),
-		MongoInfo:          info,
-		MongoDialOpts:      dialOpts,
+		MongoSession:       session,
 		NewPolicy: stateenvirons.GetNewPolicyFunc(
 			stateenvirons.GetNewEnvironFunc(environs.New),
 		),
@@ -1324,12 +1333,17 @@ func openState(
 	if !ok {
 		return nil, nil, errors.Errorf("no state info available")
 	}
+	session, err := mongo.DialWithInfo(*info, dialOpts)
+	if err != nil {
+		return nil, nil, errors.Trace(err)
+	}
+	defer session.Close()
+
 	st, err := state.Open(state.OpenParams{
 		Clock:              clock.WallClock,
 		ControllerTag:      agentConfig.Controller(),
 		ControllerModelTag: agentConfig.Model(),
-		MongoInfo:          info,
-		MongoDialOpts:      dialOpts,
+		MongoSession:       session,
 		NewPolicy: stateenvirons.GetNewPolicyFunc(
 			stateenvirons.GetNewEnvironFunc(environs.New),
 		),

--- a/cmd/jujud/agent/mongo_test.go
+++ b/cmd/jujud/agent/mongo_test.go
@@ -52,9 +52,11 @@ func (s *mongoSuite) testStateWorkerDialSetsWriteMajority(c *gc.C, configureRepl
 		dialOpts.Direct = true
 	}
 
-	mongoInfo := mongo.Info{
-		Addrs:  []string{inst.Addr()},
-		CACert: coretesting.CACert,
+	mongoInfo := mongo.MongoInfo{
+		Info: mongo.Info{
+			Addrs:  []string{inst.Addr()},
+			CACert: coretesting.CACert,
+		},
 	}
 	session, err := mongo.DialWithInfo(mongoInfo, dialOpts)
 	c.Assert(err, jc.ErrorIsNil)

--- a/cmd/jujud/dumplogs/dumplogs.go
+++ b/cmd/jujud/dumplogs/dumplogs.go
@@ -109,12 +109,17 @@ func (c *dumpLogsCommand) Run(ctx *cmd.Context) error {
 		return errors.New("no database connection info available (is this a controller host?)")
 	}
 
+	session, err := mongo.DialWithInfo(*info, mongo.DefaultDialOpts())
+	if err != nil {
+		return errors.Trace(err)
+	}
+	defer session.Close()
+
 	st0, err := state.Open(state.OpenParams{
 		Clock:              clock.WallClock,
 		ControllerTag:      config.Controller(),
 		ControllerModelTag: config.Model(),
-		MongoInfo:          info,
-		MongoDialOpts:      mongo.DefaultDialOpts(),
+		MongoSession:       session,
 	})
 	if err != nil {
 		return errors.Annotate(err, "failed to connect to database")

--- a/cmd/jujud/upgrade_mongo.go
+++ b/cmd/jujud/upgrade_mongo.go
@@ -553,7 +553,7 @@ func dialAndLogin(mongoInfo *mongo.MongoInfo, callArgs retry.CallArgs) (mgoSessi
 	callArgs.Func = func() error {
 		// Try to connect, retry a few times until the db comes up.
 		var err error
-		session, err = mongo.DialWithInfo(mongoInfo.Info, opts)
+		session, err = mongo.DialWithInfo(*mongoInfo, opts)
 		if err == nil {
 			return nil
 		}

--- a/controller/config.go
+++ b/controller/config.go
@@ -226,6 +226,9 @@ func (c Config) ControllerUUID() string {
 
 // CACert returns the certificate of the CA that signed the controller
 // certificate, in PEM format, and whether the setting is available.
+//
+// TODO(axw) once the controller config is completely constructed,
+// there will always be a CA certificate. Get rid of the bool result.
 func (c Config) CACert() (string, bool) {
 	if s, ok := c[CACertKey]; ok {
 		return s.(string), true

--- a/juju/testing/conn.go
+++ b/juju/testing/conn.go
@@ -50,6 +50,7 @@ import (
 	"github.com/juju/juju/state/binarystorage"
 	"github.com/juju/juju/state/stateenvirons"
 	statestorage "github.com/juju/juju/state/storage"
+	statetesting "github.com/juju/juju/state/testing"
 	"github.com/juju/juju/testcharms"
 	"github.com/juju/juju/testing"
 	"github.com/juju/juju/testing/factory"
@@ -153,8 +154,8 @@ func (s *JujuConnSuite) AdminUserTag(c *gc.C) names.UserTag {
 }
 
 func (s *JujuConnSuite) MongoInfo(c *gc.C) *mongo.MongoInfo {
-	info := s.State.MongoConnectionInfo()
-	info.Password = "dummy-secret"
+	info := statetesting.NewMongoInfo()
+	info.Password = AdminSecret
 	return info
 }
 
@@ -396,7 +397,7 @@ func (s *JujuConnSuite) setUpConn(c *gc.C) {
 	s.BackingState = getStater.GetStateInAPIServer()
 	s.BackingStatePool = getStater.GetStatePoolInAPIServer()
 
-	s.State, err = newState(s.ControllerConfig.ControllerUUID(), environ, s.BackingState.MongoConnectionInfo())
+	s.State, err = newState(s.ControllerConfig.ControllerUUID(), environ, s.MongoInfo(c))
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.StatePool = state.NewStatePool(s.State)
@@ -479,9 +480,6 @@ func newState(controllerUUID string, environ environs.Environ, mongoInfo *mongo.
 	}
 	config := environ.Config()
 	password := AdminSecret
-	if password == "" {
-		return nil, errors.Errorf("cannot connect without admin-secret")
-	}
 	modelTag := names.NewModelTag(config.UUID())
 
 	mongoInfo.Password = password

--- a/scripts/juju-force-upgrade/main.go
+++ b/scripts/juju-force-upgrade/main.go
@@ -49,12 +49,17 @@ func getState() (*state.State, error) {
 	if !available {
 		return nil, errors.New("mongo info not available from agent config")
 	}
+	session, err := mongo.DialWithInfo(*mongoInfo, mongo.DefaultDialOpts())
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	defer session.Close()
+
 	st, err := state.Open(state.OpenParams{
 		Clock:              clock.WallClock,
 		ControllerTag:      config.Controller(),
 		ControllerModelTag: config.Model(),
-		MongoInfo:          mongoInfo,
-		MongoDialOpts:      mongo.DefaultDialOpts(),
+		MongoSession:       session,
 	})
 	if err != nil {
 		return nil, errors.Annotate(err, "opening state connection")

--- a/state/backups/backups.go
+++ b/state/backups/backups.go
@@ -102,7 +102,7 @@ type Backups interface {
 	// Restore updates juju's state to the contents of the backup archive,
 	// it returns the tag string for the machine where the backup originated
 	// or error if the process fails.
-	Restore(backupId string, dbInfo *DBInfo, args RestoreArgs) (names.Tag, error)
+	Restore(backupId string, args RestoreArgs) (names.Tag, error)
 }
 
 type backups struct {

--- a/state/backups/backups_linux.go
+++ b/state/backups/backups_linux.go
@@ -68,7 +68,7 @@ func ensureMongoService(agentConfig agent.Config) error {
 // * updates existing db entries to make sure they hold no references to
 // old instances
 // * updates config in all agents.
-func (b *backups) Restore(backupId string, dbInfo *DBInfo, args RestoreArgs) (names.Tag, error) {
+func (b *backups) Restore(backupId string, args RestoreArgs) (names.Tag, error) {
 	meta, backupReader, err := b.Get(backupId)
 	if err != nil {
 		return nil, errors.Annotatef(err, "could not fetch backup %q", backupId)

--- a/state/backups/testing/fakes.go
+++ b/state/backups/testing/fakes.go
@@ -97,7 +97,7 @@ func (b *FakeBackups) Remove(id string) error {
 }
 
 // Restore restores a machine to a backed up status.
-func (b *FakeBackups) Restore(bkpId string, dbInfo *backups.DBInfo, args backups.RestoreArgs) (names.Tag, error) {
+func (b *FakeBackups) Restore(bkpId string, args backups.RestoreArgs) (names.Tag, error) {
 	b.Calls = append(b.Calls, "Restore")
 	b.PrivateAddr = args.PrivateAddress
 	b.InstanceId = args.NewInstId

--- a/state/controller.go
+++ b/state/controller.go
@@ -12,7 +12,6 @@ import (
 	mgo "gopkg.in/mgo.v2"
 
 	jujucontroller "github.com/juju/juju/controller"
-	"github.com/juju/juju/mongo"
 )
 
 const (
@@ -38,7 +37,6 @@ type Controller struct {
 	clock                  clock.Clock
 	controllerModelTag     names.ModelTag
 	controllerTag          names.ControllerTag
-	mongoInfo              *mongo.MongoInfo
 	session                *mgo.Session
 	policy                 Policy
 	newPolicy              NewPolicyFunc
@@ -59,7 +57,6 @@ func (ctlr *Controller) NewState(modelTag names.ModelTag) (*State, error) {
 		modelTag,
 		ctlr.controllerModelTag,
 		session,
-		ctlr.mongoInfo,
 		ctlr.newPolicy,
 		ctlr.clock,
 		ctlr.runTransactionObserver,

--- a/state/database.go
+++ b/state/database.go
@@ -4,7 +4,6 @@
 package state
 
 import (
-	"fmt"
 	"runtime/debug"
 
 	"github.com/juju/errors"
@@ -187,13 +186,12 @@ func (schema collectionSchema) Create(
 				}
 			}
 			if err := createCollection(rawCollection, spec); err != nil {
-				message := fmt.Sprintf("cannot create collection %q", name)
-				return maybeUnauthorized(err, message)
+				return mongo.MaybeUnauthorizedf(err, "cannot create collection %q", name)
 			}
 		}
 		for _, index := range info.indexes {
 			if err := rawCollection.EnsureIndex(index); err != nil {
-				return maybeUnauthorized(err, "cannot create index")
+				return mongo.MaybeUnauthorizedf(err, "cannot create index")
 			}
 		}
 	}

--- a/state/internal_test.go
+++ b/state/internal_test.go
@@ -19,8 +19,6 @@ import (
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/instance"
-	"github.com/juju/juju/mongo"
-	"github.com/juju/juju/mongo/mongotest"
 	"github.com/juju/juju/storage"
 	"github.com/juju/juju/storage/provider"
 	"github.com/juju/juju/storage/provider/dummy"
@@ -56,14 +54,6 @@ func (s *internalStateSuite) SetUpTest(c *gc.C) {
 	s.BaseSuite.SetUpTest(c)
 
 	s.owner = names.NewLocalUserTag("test-admin")
-	// Copied from NewMongoInfo (due to import loops).
-	info := &mongo.MongoInfo{
-		Info: mongo.Info{
-			Addrs:      []string{jujutesting.MgoServer.Addr()},
-			CACert:     testing.CACert,
-			DisableTLS: !jujutesting.MgoServer.SSLEnabled(),
-		},
-	}
 	modelCfg := testing.ModelConfig(c)
 	controllerCfg := testing.FakeControllerConfig()
 	ctlr, st, err := Initialize(InitializeParams{
@@ -90,8 +80,8 @@ func (s *internalStateSuite) SetUpTest(c *gc.C) {
 				},
 			},
 		},
-		MongoInfo:     info,
-		MongoDialOpts: mongotest.DialOpts(),
+		MongoSession:  s.Session,
+		AdminPassword: "dummy-secret",
 		NewPolicy: func(*State) Policy {
 			return internalStatePolicy{}
 		},

--- a/state/model.go
+++ b/state/model.go
@@ -385,7 +385,6 @@ func (st *State) NewModel(args ModelArgs) (_ *Model, _ *State, err error) {
 		names.NewModelTag(uuid),
 		controllerInfo.ModelTag,
 		session,
-		st.mongoInfo,
 		st.newPolicy,
 		st.clock(),
 		st.runTransactionObserver,

--- a/state/model_test.go
+++ b/state/model_test.go
@@ -19,10 +19,8 @@ import (
 	"github.com/juju/juju/core/crossmodel"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/feature"
-	"github.com/juju/juju/mongo/mongotest"
 	"github.com/juju/juju/permission"
 	"github.com/juju/juju/state"
-	statetesting "github.com/juju/juju/state/testing"
 	"github.com/juju/juju/storage"
 	"github.com/juju/juju/testing"
 	"github.com/juju/juju/testing/factory"
@@ -1541,8 +1539,8 @@ func (s *ModelCloudValidationSuite) initializeState(
 			Regions:   regions,
 		},
 		CloudCredentials: credentials,
-		MongoInfo:        statetesting.NewMongoInfo(),
-		MongoDialOpts:    mongotest.DialOpts(),
+		MongoSession:     s.Session,
+		AdminPassword:    "dummy-secret",
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(ctlr.Close(), jc.ErrorIsNil)

--- a/state/modelconfig_test.go
+++ b/state/modelconfig_test.go
@@ -18,7 +18,6 @@ import (
 	"github.com/juju/juju/constraints"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/config"
-	"github.com/juju/juju/mongo/mongotest"
 	"github.com/juju/juju/state"
 	statetesting "github.com/juju/juju/state/testing"
 	"github.com/juju/juju/storage"
@@ -445,13 +444,11 @@ func (s *ModelConfigSourceSuite) TestUpdateModelConfigDefaults(c *gc.C) {
 	err = s.IAASModel.UpdateModelConfigDefaultValues(attrs, []string{"http-proxy", "https-proxy"}, nil)
 	c.Assert(err, jc.ErrorIsNil)
 
-	info := statetesting.NewMongoInfo()
 	anotherState, err := state.Open(state.OpenParams{
 		Clock:              clock.WallClock,
 		ControllerTag:      s.State.ControllerTag(),
 		ControllerModelTag: s.modelTag,
-		MongoInfo:          info,
-		MongoDialOpts:      mongotest.DialOpts(),
+		MongoSession:       s.Session,
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	defer anotherState.Close()
@@ -501,13 +498,11 @@ func (s *ModelConfigSourceSuite) TestUpdateModelConfigRegionDefaults(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Then check in another state.
-	info := statetesting.NewMongoInfo()
 	anotherState, err := state.Open(state.OpenParams{
 		Clock:              clock.WallClock,
 		ControllerTag:      s.State.ControllerTag(),
 		ControllerModelTag: s.modelTag,
-		MongoInfo:          info,
-		MongoDialOpts:      mongotest.DialOpts(),
+		MongoSession:       s.Session,
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	defer anotherState.Close()

--- a/state/open.go
+++ b/state/open.go
@@ -283,11 +283,6 @@ func newState(
 	return st, nil
 }
 
-// MongoConnectionInfo returns information for connecting to mongo
-func (st *State) MongoConnectionInfo() *mongo.MongoInfo {
-	return st.mongoInfo
-}
-
 // CACert returns the certificate used to validate the state connection.
 func (st *State) CACert() string {
 	return st.mongoInfo.CACert

--- a/state/open.go
+++ b/state/open.go
@@ -283,11 +283,6 @@ func newState(
 	return st, nil
 }
 
-// CACert returns the certificate used to validate the state connection.
-func (st *State) CACert() string {
-	return st.mongoInfo.CACert
-}
-
 // Close the connection to the database.
 func (st *State) Close() (err error) {
 	defer errors.DeferredAnnotatef(&err, "closing state failed")

--- a/state/open.go
+++ b/state/open.go
@@ -107,7 +107,6 @@ func OpenController(args OpenParams) (*Controller, error) {
 		clock:                  args.Clock,
 		controllerTag:          args.ControllerTag,
 		controllerModelTag:     args.ControllerModelTag,
-		mongoInfo:              args.MongoInfo,
 		session:                session,
 		newPolicy:              args.NewPolicy,
 		runTransactionObserver: args.RunTransactionObserver,
@@ -175,7 +174,7 @@ func open(
 	}
 	logger.Debugf("mongodb login successful")
 
-	st, err := newState(controllerModelTag, controllerModelTag, session, info, newPolicy, clock, runTransactionObserver)
+	st, err := newState(controllerModelTag, controllerModelTag, session, newPolicy, clock, runTransactionObserver)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -245,7 +244,7 @@ func isUnauthorized(err error) bool {
 // close it if it cannot be returned under the aegis of a *State.
 func newState(
 	modelTag, controllerModelTag names.ModelTag,
-	session *mgo.Session, mongoInfo *mongo.MongoInfo,
+	session *mgo.Session,
 	newPolicy NewPolicyFunc,
 	clock clock.Clock,
 	runTransactionObserver RunTransactionObserverFunc,
@@ -269,7 +268,6 @@ func newState(
 		stateClock:             clock,
 		modelTag:               modelTag,
 		controllerModelTag:     controllerModelTag,
-		mongoInfo:              mongoInfo,
 		session:                session,
 		database:               db,
 		newPolicy:              newPolicy,

--- a/state/open.go
+++ b/state/open.go
@@ -4,9 +4,7 @@
 package state
 
 import (
-	"fmt"
 	"runtime/pprof"
-	"strings"
 
 	"github.com/juju/errors"
 	"github.com/juju/utils/clock"
@@ -32,13 +30,10 @@ type OpenParams struct {
 	// ControllerModelTag is the tag of the controller model.
 	ControllerModelTag names.ModelTag
 
-	// MongoInfo is the mongo.MongoInfo used for dialling the
-	// Mongo connection.
-	MongoInfo *mongo.MongoInfo
-
-	// MongoDialOpts is the mongo.DialOpts used to control how
-	// Mongo connections are made.
-	MongoDialOpts mongo.DialOpts
+	// MongoSession is the mgo.Session to use for storing and
+	// accessing state data. The caller remains responsible
+	// for closing this session; Open will copy it.
+	MongoSession *mgo.Session
 
 	// NewPolicy, if non-nil, returns a policy which will be used to
 	// validate and modify behaviour of certain operations in state.
@@ -65,8 +60,8 @@ func (p OpenParams) Validate() error {
 	if p.ControllerModelTag == (names.ModelTag{}) {
 		return errors.NotValidf("empty ControllerModelTag")
 	}
-	if p.MongoInfo == nil {
-		return errors.NotValidf("nil MongoInfo")
+	if p.MongoSession == nil {
+		return errors.NotValidf("nil MongoSession")
 	}
 	return nil
 }
@@ -80,24 +75,9 @@ func OpenController(args OpenParams) (*Controller, error) {
 		return nil, errors.Annotate(err, "validating args")
 	}
 
-	logger.Infof("opening controller state, mongo addresses: %q; entity %v",
-		args.MongoInfo.Addrs, args.MongoInfo.Tag)
-	logger.Debugf("dialing mongo")
-	session, err := mongo.DialWithInfo(args.MongoInfo.Info, args.MongoDialOpts)
-	if err != nil {
-		return nil, maybeUnauthorized(err, "cannot connect to mongodb")
-	}
-	logger.Debugf("connection established")
-
-	if err := mongodbLogin(session, args.MongoInfo); err != nil {
-		session.Close()
-		return nil, errors.Trace(err)
-	}
-	logger.Debugf("mongodb login successful")
-
+	session := args.MongoSession.Copy()
 	if args.InitDatabaseFunc != nil {
 		if err := args.InitDatabaseFunc(session, args.ControllerModelTag.Id(), nil); err != nil {
-			session.Close()
 			return nil, errors.Trace(err)
 		}
 		logger.Debugf("mongodb initialised")
@@ -122,10 +102,10 @@ func Open(args OpenParams) (*State, error) {
 	if err := args.Validate(); err != nil {
 		return nil, errors.Annotate(err, "validating args")
 	}
+	session := args.MongoSession.Copy()
 	st, err := open(
 		args.ControllerModelTag,
-		args.MongoInfo,
-		args.MongoDialOpts,
+		session,
 		args.InitDatabaseFunc,
 		nil,
 		args.NewPolicy,
@@ -133,13 +113,14 @@ func Open(args OpenParams) (*State, error) {
 		args.RunTransactionObserver,
 	)
 	if err != nil {
+		session.Close()
 		return nil, errors.Trace(err)
 	}
 	if _, err := st.Model(); err != nil {
 		if err := st.Close(); err != nil {
 			logger.Errorf("closing State for %s: %v", args.ControllerModelTag, err)
 		}
-		return nil, maybeUnauthorized(err, fmt.Sprintf("cannot read model %s", args.ControllerModelTag.Id()))
+		return nil, mongo.MaybeUnauthorizedf(err, "cannot read model %s", args.ControllerModelTag.Id())
 	}
 
 	// State should only be Opened on behalf of a controller environ; all
@@ -152,28 +133,13 @@ func Open(args OpenParams) (*State, error) {
 
 func open(
 	controllerModelTag names.ModelTag,
-	info *mongo.MongoInfo, opts mongo.DialOpts,
+	session *mgo.Session,
 	initDatabase InitDatabaseFunc,
 	controllerConfig *controller.Config,
 	newPolicy NewPolicyFunc,
 	clock clock.Clock,
 	runTransactionObserver RunTransactionObserverFunc,
 ) (*State, error) {
-	logger.Infof("opening state, mongo addresses: %q; entity %v", info.Addrs, info.Tag)
-	logger.Debugf("dialing mongo")
-	session, err := mongo.DialWithInfo(info.Info, opts)
-	if err != nil {
-		return nil, maybeUnauthorized(err, "cannot connect to mongodb")
-	}
-	logger.Debugf("connection established")
-
-	err = mongodbLogin(session, info)
-	if err != nil {
-		session.Close()
-		return nil, errors.Trace(err)
-	}
-	logger.Debugf("mongodb login successful")
-
 	st, err := newState(controllerModelTag, controllerModelTag, session, newPolicy, clock, runTransactionObserver)
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -187,52 +153,6 @@ func open(
 	}
 
 	return st, nil
-}
-
-// mongodbLogin logs in to the mongodb admin database.
-func mongodbLogin(session *mgo.Session, mongoInfo *mongo.MongoInfo) error {
-	admin := session.DB("admin")
-	if mongoInfo.Tag != nil {
-		if err := admin.Login(mongoInfo.Tag.String(), mongoInfo.Password); err != nil {
-			return maybeUnauthorized(err, fmt.Sprintf("cannot log in to admin database as %q", mongoInfo.Tag))
-		}
-	} else if mongoInfo.Password != "" {
-		if err := admin.Login(mongo.AdminUser, mongoInfo.Password); err != nil {
-			return maybeUnauthorized(err, "cannot log in to admin database")
-		}
-	}
-	return nil
-}
-
-func maybeUnauthorized(err error, msg string) error {
-	if err == nil {
-		return nil
-	}
-	if isUnauthorized(err) {
-		return errors.Unauthorizedf("%s: unauthorized mongo access: %v", msg, err)
-	}
-	return errors.Annotatef(err, msg)
-}
-
-func isUnauthorized(err error) bool {
-	if err == nil {
-		return false
-	}
-	// Some unauthorized access errors have no error code,
-	// just a simple error string; and some do have error codes
-	// but are not of consistent types (LastError/QueryError).
-	for _, prefix := range []string{"auth fail", "not authorized", "server returned error on SASL authentication step: Authentication failed."} {
-		if strings.HasPrefix(err.Error(), prefix) {
-			return true
-		}
-	}
-	if err, ok := err.(*mgo.QueryError); ok {
-		return err.Code == 10057 ||
-			err.Code == 13 ||
-			err.Message == "need to login" ||
-			err.Message == "unauthorized"
-	}
-	return false
 }
 
 // newState creates an incomplete *State, with no running workers or

--- a/state/relationunit_test.go
+++ b/state/relationunit_test.go
@@ -463,7 +463,7 @@ func (s *RelationUnitSuite) TestAliveRelationScope(c *gc.C) {
 }
 
 func (s *StateSuite) TestWatchWatchScopeDiesOnStateClose(c *gc.C) {
-	testWatcherDiesWhenStateCloses(c, s.modelTag, s.State.ControllerTag(), func(c *gc.C, st *state.State) waiter {
+	testWatcherDiesWhenStateCloses(c, s.Session, s.modelTag, s.State.ControllerTag(), func(c *gc.C, st *state.State) waiter {
 		pr := newPeerRelation(c, st)
 		w := pr.ru0.WatchScope()
 		<-w.Changes()

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -24,6 +24,7 @@ import (
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/charm.v6-unstable"
 	"gopkg.in/juju/names.v2"
+	"gopkg.in/mgo.v2"
 	"gopkg.in/mgo.v2/bson"
 	mgotxn "gopkg.in/mgo.v2/txn"
 
@@ -2211,7 +2212,7 @@ func (s *StateSuite) TestWatchApplicationsDiesOnStateClose(c *gc.C) {
 	//     Application.WatchUnits
 	//     Application.WatchRelations
 	//     Machine.WatchContainers
-	testWatcherDiesWhenStateCloses(c, s.modelTag, s.State.ControllerTag(), func(c *gc.C, st *state.State) waiter {
+	testWatcherDiesWhenStateCloses(c, s.Session, s.modelTag, s.State.ControllerTag(), func(c *gc.C, st *state.State) waiter {
 		w := st.WatchApplications()
 		<-w.Changes()
 		return w
@@ -2985,12 +2986,16 @@ func (s *StateSuite) TestAddAndGetEquivalence(c *gc.C) {
 }
 
 func tryOpenState(modelTag names.ModelTag, controllerTag names.ControllerTag, info *mongo.MongoInfo) error {
+	session, err := mongo.DialWithInfo(*info, mongotest.DialOpts())
+	if err != nil {
+		return err
+	}
+	defer session.Close()
 	st, err := state.Open(state.OpenParams{
 		Clock:              clock.WallClock,
 		ControllerTag:      controllerTag,
 		ControllerModelTag: modelTag,
-		MongoInfo:          info,
-		MongoDialOpts:      mongotest.DialOpts(),
+		MongoSession:       session,
 	})
 	if err == nil {
 		err = st.Close()
@@ -3013,39 +3018,6 @@ func (s *StateSuite) TestOpenWithoutSetMongoPassword(c *gc.C) {
 	info.Tag, info.Password = nil, ""
 	err = tryOpenState(s.modelTag, s.State.ControllerTag(), info)
 	c.Check(err, jc.ErrorIsNil)
-}
-
-func (s *StateSuite) TestOpenBadAddress(c *gc.C) {
-	info := statetesting.NewMongoInfo()
-	info.Addrs = []string{"0.1.2.3:1234"}
-	params := s.testOpenParams()
-	params.MongoInfo.Addrs = []string{"0.1.2.3:1234"}
-	params.MongoDialOpts.Timeout = time.Millisecond
-	st, err := state.Open(params)
-	if err == nil {
-		st.Close()
-	}
-	c.Assert(err, gc.ErrorMatches, "cannot connect to mongodb: no reachable servers")
-}
-
-func (s *StateSuite) TestOpenDelaysRetryBadAddress(c *gc.C) {
-	// Default mgo retry delay
-	retryDelay := 500 * time.Millisecond
-	info := statetesting.NewMongoInfo()
-	info.Addrs = []string{"0.1.2.3:1234"}
-
-	t0 := time.Now()
-	params := s.testOpenParams()
-	params.MongoInfo.Addrs = []string{"0.1.2.3:1234"}
-	params.MongoDialOpts.Timeout = time.Millisecond
-	st, err := state.Open(params)
-	if err == nil {
-		st.Close()
-	}
-	c.Assert(err, gc.ErrorMatches, "cannot connect to mongodb: no reachable servers")
-	if t1 := time.Since(t0); t1 < retryDelay {
-		c.Errorf("mgo.Dial only paused for %v, expected at least %v", t1, retryDelay)
-	}
 }
 
 func testSetPassword(c *gc.C, getEntity func() (state.Authenticator, error)) {
@@ -3285,7 +3257,7 @@ func (s *StateSuite) TestWatchCleanups(c *gc.C) {
 }
 
 func (s *StateSuite) TestWatchCleanupsDiesOnStateClose(c *gc.C) {
-	testWatcherDiesWhenStateCloses(c, s.modelTag, s.State.ControllerTag(), func(c *gc.C, st *state.State) waiter {
+	testWatcherDiesWhenStateCloses(c, s.Session, s.modelTag, s.State.ControllerTag(), func(c *gc.C, st *state.State) waiter {
 		w := st.WatchCleanups()
 		<-w.Changes()
 		return w
@@ -3408,7 +3380,7 @@ func (s *StateSuite) TestWatchMinUnits(c *gc.C) {
 }
 
 func (s *StateSuite) TestWatchMinUnitsDiesOnStateClose(c *gc.C) {
-	testWatcherDiesWhenStateCloses(c, s.modelTag, s.State.ControllerTag(), func(c *gc.C, st *state.State) waiter {
+	testWatcherDiesWhenStateCloses(c, s.Session, s.modelTag, s.State.ControllerTag(), func(c *gc.C, st *state.State) waiter {
 		w := st.WatchMinUnits()
 		<-w.Changes()
 		return w
@@ -3435,7 +3407,7 @@ func (s *StateSuite) TestWatchSubnets(c *gc.C) {
 }
 
 func (s *StateSuite) TestWatchSubnetsDiesOnStateClose(c *gc.C) {
-	testWatcherDiesWhenStateCloses(c, s.modelTag, s.State.ControllerTag(), func(c *gc.C, st *state.State) waiter {
+	testWatcherDiesWhenStateCloses(c, s.Session, s.modelTag, s.State.ControllerTag(), func(c *gc.C, st *state.State) waiter {
 		w := st.WatchSubnets(nil)
 		<-w.Changes()
 		return w
@@ -3540,7 +3512,7 @@ func (s *StateSuite) TestWatchRemoteRelationsDestroyLocalApplication(c *gc.C) {
 }
 
 func (s *StateSuite) TestWatchRemoteRelationsDiesOnStateClose(c *gc.C) {
-	testWatcherDiesWhenStateCloses(c, s.modelTag, s.State.ControllerTag(), func(c *gc.C, st *state.State) waiter {
+	testWatcherDiesWhenStateCloses(c, s.Session, s.modelTag, s.State.ControllerTag(), func(c *gc.C, st *state.State) waiter {
 		w := st.WatchRemoteRelations()
 		<-w.Changes()
 		return w
@@ -3855,13 +3827,18 @@ type waiter interface {
 // event, otherwise the watcher's initialisation logic may
 // interact with the closed state, causing it to return an
 // unexpected error (often "Closed explictly").
-func testWatcherDiesWhenStateCloses(c *gc.C, modelTag names.ModelTag, controllerTag names.ControllerTag, startWatcher func(c *gc.C, st *state.State) waiter) {
+func testWatcherDiesWhenStateCloses(
+	c *gc.C,
+	session *mgo.Session,
+	modelTag names.ModelTag,
+	controllerTag names.ControllerTag,
+	startWatcher func(c *gc.C, st *state.State) waiter,
+) {
 	st, err := state.Open(state.OpenParams{
 		Clock:              clock.WallClock,
 		ControllerTag:      controllerTag,
 		ControllerModelTag: modelTag,
-		MongoInfo:          statetesting.NewMongoInfo(),
-		MongoDialOpts:      mongotest.DialOpts(),
+		MongoSession:       session,
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	watcher := startWatcher(c, st)
@@ -4710,11 +4687,15 @@ func (s *SetAdminMongoPasswordSuite) TestSetAdminMongoPassword(c *gc.C) {
 			DisableTLS: true,
 		},
 	}
-	authInfo := &mongo.MongoInfo{
+
+	session, err := mongo.DialWithInfo(mongo.MongoInfo{
 		Info:     noAuthInfo.Info,
 		Tag:      owner,
 		Password: password,
-	}
+	}, mongotest.DialOpts())
+	c.Assert(err, jc.ErrorIsNil)
+	defer session.Close()
+
 	cfg := testing.ModelConfig(c)
 	controllerCfg := testing.FakeControllerConfig()
 	ctlr, st, err := state.Initialize(state.InitializeParams{
@@ -4732,8 +4713,8 @@ func (s *SetAdminMongoPasswordSuite) TestSetAdminMongoPassword(c *gc.C) {
 			Type:      "dummy",
 			AuthTypes: []cloud.AuthType{cloud.EmptyAuthType},
 		},
-		MongoInfo:     authInfo,
-		MongoDialOpts: mongotest.DialOpts(),
+		MongoSession:  session,
+		AdminPassword: password,
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	defer st.Close()
@@ -4916,7 +4897,6 @@ func (s *StateSuite) testOpenParams() state.OpenParams {
 		Clock:              clock.WallClock,
 		ControllerTag:      s.State.ControllerTag(),
 		ControllerModelTag: s.modelTag,
-		MongoInfo:          statetesting.NewMongoInfo(),
-		MongoDialOpts:      mongotest.DialOpts(),
+		MongoSession:       s.Session,
 	}
 }

--- a/worker/upgradesteps/worker_test.go
+++ b/worker/upgradesteps/worker_test.go
@@ -414,7 +414,6 @@ func (s *UpgradeSuite) runUpgradeWorker(c *gc.C, jobs ...multiwatcher.MachineJob
 }
 
 func (s *UpgradeSuite) openStateForUpgrade() (*state.State, error) {
-	mongoInfo := s.State.MongoConnectionInfo()
 	newPolicy := stateenvirons.GetNewPolicyFunc(
 		stateenvirons.GetNewEnvironFunc(environs.New),
 	)
@@ -422,7 +421,7 @@ func (s *UpgradeSuite) openStateForUpgrade() (*state.State, error) {
 		Clock:              clock.WallClock,
 		ControllerTag:      s.State.ControllerTag(),
 		ControllerModelTag: s.IAASModel.ModelTag(),
-		MongoInfo:          mongoInfo,
+		MongoInfo:          statetesting.NewMongoInfo(),
 		MongoDialOpts:      mongotest.DialOpts(),
 		NewPolicy:          newPolicy,
 	})

--- a/worker/upgradesteps/worker_test.go
+++ b/worker/upgradesteps/worker_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/juju/juju/constraints"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/instance"
-	"github.com/juju/juju/mongo/mongotest"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/multiwatcher"
 	"github.com/juju/juju/state/stateenvirons"
@@ -421,8 +420,7 @@ func (s *UpgradeSuite) openStateForUpgrade() (*state.State, error) {
 		Clock:              clock.WallClock,
 		ControllerTag:      s.State.ControllerTag(),
 		ControllerModelTag: s.IAASModel.ModelTag(),
-		MongoInfo:          statetesting.NewMongoInfo(),
-		MongoDialOpts:      mongotest.DialOpts(),
+		MongoSession:       s.State.MongoSession(),
 		NewPolicy:          newPolicy,
 	})
 	if err != nil {


### PR DESCRIPTION
## Description of change

- update state openers (Open, OpenController, Initialize) to accept an mgo.Session, rather than dialling from those methods. The session is copied, so the caller retains ownership of the session it passes in.
- remove the State.MongoConnectionInfo and State.CACert methods, as they were relying on recording mongo connection info on the State object

## QA steps

Smoke test: bootstrap, destroy.

## Documentation changes

None.

## Bug reference

None.