### PR TITLE
Don't release resources until all current requests are complete.

### DIFF
--- a/rpc/server.go
+++ b/rpc/server.go
@@ -283,14 +283,17 @@ func (conn *Conn) Close() error {
 		return nil
 	}
 	conn.closing = true
-	if conn.root != nil {
-		conn.root.Kill()
-	}
 	conn.mutex.Unlock()
 
 	// Wait for any outstanding server requests to complete
 	// and write their replies before closing the codec.
 	conn.srvPending.Wait()
+
+	conn.mutex.Lock()
+	if conn.root != nil {
+		conn.root.Kill()
+	}
+	conn.mutex.Unlock()
 
 	// Closing the codec should cause the input loop to terminate.
 	if err := conn.codec.Close(); err != nil {


### PR DESCRIPTION
If a websocket connection is closed while the login is in process, the rpc package was releasing the apiHandler resources before all the current requests were finished. If one of those requests would add resources, like an agent pinger, these would be leaked.

This branch changes the connection code to wait for all current requests to be finished before it kills the root object (which calls StopAll on the resources).

## Bug reference

Other part of the fix for https://bugs.launchpad.net/juju/+bug/1731745
