### PR TITLE
Limit length of unit service name

### DIFF
--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -102,7 +102,7 @@ gopkg.in/juju/charmrepo.v2-unstable	git	e79aa298df89ea887c9bffec46063c24bfb730f7
 gopkg.in/juju/charmstore.v5-unstable	git	fd1eef3002fc6b6daff5e97efab6f5056d22dcc7	2016-09-16T10:09:07Z
 gopkg.in/juju/environschema.v1	git	7359fc7857abe2b11b5b3e23811a9c64cb6b01e0	2015-11-04T11:58:10Z
 gopkg.in/juju/jujusvg.v2	git	d82160011935ef79fc7aca84aba2c6f74700fe75	2016-06-09T10:52:15Z
-gopkg.in/juju/names.v2	git	93d5a81232702d4fbf5ef4abdf69f95f35307752	2017-10-19T20:35:57Z
+gopkg.in/juju/names.v2	git	54f00845ae470a362430a966fe17f35f8784ac92	2017-11-13T11:20:47Z
 gopkg.in/juju/worker.v1	git	6965b9d826717287bb002e02d1fd4d079978083e	2017-03-08T00:24:58Z
 gopkg.in/macaroon-bakery.v1	git	469b44e6f1f9479e115c8ae879ef80695be624d5	2016-06-22T12:14:21Z
 gopkg.in/macaroon.v1	git	ab3940c6c16510a850e1c2dd628b919f0f3f1464	2015-01-21T11:42:31Z

--- a/worker/deployer/simple.go
+++ b/worker/deployer/simple.go
@@ -268,7 +268,12 @@ func (ctx *SimpleContext) DeployedUnits() ([]string, error) {
 // service returns a service.Service corresponding to the specified
 // unit.
 func (ctx *SimpleContext) service(unitName string, renderer shell.Renderer) (deployerService, error) {
-	tag := names.NewUnitTag(unitName).String()
+	// Service name can be at most 64 characters long, we limit it to 56 just to be safe.
+	tag, err := names.NewUnitTag(unitName).ShortenedString(56)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
 	svcName := "jujud-" + tag
 
 	info := service.NewAgentInfo(


### PR DESCRIPTION
## Description of change
Limit length of service name for unit for systemd/upstart

## QA steps
Create an application with long (>50 chars) name, see that 1. it works 2. the systemd service file has the app name shortened

## Bug reference
https://bugs.launchpad.net/juju/+bug/1731027