### PR TITLE
Cache being sequences that are 'old'.

### DIFF
--- a/state/presence/export_test.go
+++ b/state/presence/export_test.go
@@ -53,3 +53,7 @@ func (pb *PingBatcher) ForceUpdatesUsingInc() {
 	logger.Debugf("forcing $inc operations from (was %t)", pb.useInc)
 	pb.useInc = true
 }
+
+func (w *Watcher) BeingLoads() uint64 {
+	return w.beingLoads
+}


### PR DESCRIPTION
## Description of change

It turns out that we actually have lots of ways to have old beings. We
don't want to have to read them from the database every time we do a
Sync. So instead we cache them as 'known-to-be-superseded', and we can
skip reading them from the database.

Even though we'll fix the bug that makes us leak 100s of agent pingers, we'll still always have a few extra connections for each controller agent (we currently have 4 for each agent). So it still allows Watcher.Sync() to be performed without hitting presence.beings at all (it still needs to read in the latest Pings() of course).

## QA steps

In our current codebase, we have a bug where we are leaking Pingers, which causes us to start reading presence.presence.beings more than we would expect. Running this branch (without merging develop) should show that we don't actually trigger presence.beings reads. I included a test as well.

## Documentation changes

Not significantly.

## Bug reference

At least related to:
[lp:1731745](https://bugs.launchpad.net/bugs/1731745)
