### PR TITLE
Bug 1729702, don't fail on delete azure secury groups if not found.

### DIFF
--- a/provider/azure/environ_test.go
+++ b/provider/azure/environ_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/arm/network"
 	"github.com/Azure/azure-sdk-for-go/arm/resources/resources"
 	"github.com/Azure/azure-sdk-for-go/arm/storage"
+	"github.com/Azure/go-autorest/autorest"
 	"github.com/Azure/go-autorest/autorest/adal"
 	"github.com/Azure/go-autorest/autorest/mocks"
 	"github.com/Azure/go-autorest/autorest/to"
@@ -1199,6 +1200,29 @@ func (s *environSuite) TestStopInstancesNotFound(c *gc.C) {
 	))
 	s.sender = azuretesting.Senders{sender0, sender1}
 	err := env.StopInstances("a", "b")
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *environSuite) TestStopInstancesResourceGroupNotFound(c *gc.C) {
+	// skip storage, so we get to deleting security rules
+	s.PatchValue(&s.storageAccountKeys.Keys, nil)
+	env := s.openEnviron(c)
+
+	nsgSender := s.makeSender(".*/networkSecurityGroups/juju-internal-nsg", makeSecurityGroup())
+	nsgSender.SetError(autorest.NewErrorWithError(errors.New("autorest/azure: Service returned an error."), "network.SecurityGroupsClient", "Get", &http.Response{StatusCode: http.StatusNotFound}, "Failure responding to request"))
+
+	s.sender = azuretesting.Senders{
+		s.makeSender("/deployments/machine-0", s.deployment), // Cancel
+		s.storageAccountSender(),
+		s.storageAccountKeysSender(),
+		s.networkInterfacesSender(),                       // GET: no NICs
+		s.publicIPAddressesSender(),                       // GET: no public IPs
+		s.makeSender(".*/virtualMachines/machine-0", nil), // DELETE
+		s.makeSender(".*/disks/machine-0", nil),           // DELETE
+		nsgSender, // GET with failure
+		s.makeSender(".*/deployments/machine-0", nil), // DELETE
+	}
+	err := env.StopInstances("machine-0")
 	c.Assert(err, jc.ErrorIsNil)
 }
 

--- a/provider/azure/instance.go
+++ b/provider/azure/instance.go
@@ -5,9 +5,11 @@ package azure
 
 import (
 	"fmt"
+	"net/http"
 	"strings"
 
 	"github.com/Azure/azure-sdk-for-go/arm/network"
+	"github.com/Azure/go-autorest/autorest"
 	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/juju/errors"
 	"gopkg.in/juju/names.v2"
@@ -414,6 +416,9 @@ func deleteInstanceNetworkSecurityRules(
 ) error {
 	nsg, err := nsgClient.Get(resourceGroup, internalSecurityGroupName, "")
 	if err != nil {
+		if err.(autorest.DetailedError).Response.StatusCode == http.StatusNotFound {
+			return nil
+		}
 		return errors.Annotate(err, "querying network security group")
 	}
 	if nsg.SecurityRules == nil {


### PR DESCRIPTION
## Description of change

Given that cloud resources can be deleted by the user on the cloud's portal, when trying to delete a machine, model, etc, don't fail with on a not found error.

## QA steps

1. Bootstrap azure
1. Deploy at least one unit to a model
1. From the azure portal, delete all for the resources for the model, but not the resource group itself.
1. Check that the juju status shows the machine in a down state.
1. juju destroy-model should succeed.

## Documentation changes

N/A

## Bug reference

https://bugs.launchpad.net/juju/+bug/1729702