### PR TITLE
mongo: SelectPeer* should not use local addresses

### DIFF
--- a/cmd/jujud/bootstrap_test.go
+++ b/cmd/jujud/bootstrap_test.go
@@ -366,12 +366,11 @@ func (s *BootstrapSuite) TestInitializeEnvironment(c *gc.C) {
 	gotDialAddrs := s.fakeEnsureMongo.InitiateParams.DialInfo.Addrs
 	c.Assert(gotDialAddrs, gc.DeepEquals, expectDialAddrs)
 
-	// TODO(macgreagoir) IPv6. This MemberHostPort check assumes a loopback
-	// address returned by mongo.SelectPeerAddress(), not the 'localhost'
-	// name we use for IPv4 and IPv6 compatibility. Replace it with
-	// something potentially useful, a loopback:port match, in the meantime.
-	// c.Assert(s.fakeEnsureMongo.InitiateParams.MemberHostPort, gc.Equals, expectDialAddrs[0])
-	c.Assert(s.fakeEnsureMongo.InitiateParams.MemberHostPort, gc.Matches, fmt.Sprintf("(127.0.0.1|::1):%d$", expectInfo.StatePort))
+	c.Assert(
+		s.fakeEnsureMongo.InitiateParams.MemberHostPort,
+		gc.Matches,
+		fmt.Sprintf("only-0.dns:%d$", expectInfo.StatePort),
+	)
 	c.Assert(s.fakeEnsureMongo.InitiateParams.User, gc.Equals, "")
 	c.Assert(s.fakeEnsureMongo.InitiateParams.Password, gc.Equals, "")
 

--- a/mongo/mongo.go
+++ b/mongo/mongo.go
@@ -271,22 +271,26 @@ func IsMaster(session *mgo.Session, obj WithAddresses) (bool, error) {
 // available an empty string is returned.
 func SelectPeerAddress(addrs []network.Address) string {
 	logger.Debugf("selecting mongo peer address from %+v", addrs)
-	// ScopeMachineLocal addresses are OK if we can't pick by space, also the
-	// second bool return is ignored intentionally.
-	addr, _ := network.SelectControllerAddress(addrs, true)
+
+	// ScopeMachineLocal addresses are never suitable for mongo peers,
+	// as each controller runs on a separate machine.
+	const allowMachineLocal = false
+
+	// The second bool result is ignored intentionally (we return an empty
+	// string if no suitable address is available.)
+	addr, _ := network.SelectControllerAddress(addrs, allowMachineLocal)
 	return addr.Value
 }
 
 // SelectPeerHostPort returns the HostPort to use as the mongo replica set peer
 // by selecting it from the given hostPorts.
 func SelectPeerHostPort(hostPorts []network.HostPort) string {
-	// TODO(macgreagoir) IPv6. We were always choosing a cloud-local or
-	// falling back to machine-local here (with true arg) but this doesn't
-	// make sense in IPv6, where the IPv6 [public] address is ignored in
-	// favour of ip6-localhost. Only pass true if we find an IPv4 address
-	// in the slice.
 	logger.Debugf("selecting mongo peer hostPort by scope from %+v", hostPorts)
-	allowMachineLocal := network.HostPortsHasIPv4Address(hostPorts)
+
+	// ScopeMachineLocal addresses are never suitable for mongo peers,
+	// as each controller runs on a separate machine.
+	const allowMachineLocal = false
+
 	return network.SelectMongoHostPortsByScope(hostPorts, allowMachineLocal)[0]
 }
 

--- a/mongo/mongo_test.go
+++ b/mongo/mongo_test.go
@@ -683,6 +683,10 @@ func (s *MongoSuite) TestNoMongoDir(c *gc.C) {
 
 func (s *MongoSuite) TestSelectPeerAddress(c *gc.C) {
 	addresses := []network.Address{{
+		Value: "127.0.0.1",
+		Type:  network.IPv4Address,
+		Scope: network.ScopeMachineLocal,
+	}, {
 		Value: "10.0.0.1",
 		Type:  network.IPv4Address,
 		Scope: network.ScopeCloudLocal,
@@ -700,17 +704,26 @@ func (s *MongoSuite) TestSelectPeerHostPort(c *gc.C) {
 
 	hostPorts := []network.HostPort{{
 		Address: network.Address{
+			Value: "127.0.0.1",
+			Type:  network.IPv4Address,
+			Scope: network.ScopeMachineLocal,
+		},
+		Port: controller.DefaultStatePort,
+	}, {
+		Address: network.Address{
 			Value: "10.0.0.1",
 			Type:  network.IPv4Address,
 			Scope: network.ScopeCloudLocal,
 		},
-		Port: controller.DefaultStatePort}, {
+		Port: controller.DefaultStatePort,
+	}, {
 		Address: network.Address{
 			Value: "8.8.8.8",
 			Type:  network.IPv4Address,
 			Scope: network.ScopePublic,
 		},
-		Port: controller.DefaultStatePort}}
+		Port: controller.DefaultStatePort,
+	}}
 
 	address := mongo.SelectPeerHostPort(hostPorts)
 	c.Assert(address, gc.Equals, "10.0.0.1:"+strconv.Itoa(controller.DefaultStatePort))


### PR DESCRIPTION
## Description of change

The mongo.SelectPeer* functions should not
use local addresses, as they will never be
suitable for communicating across machines
to other MongoDB servers. Filter out machine-
local addresses.

## QA steps

1. juju bootstrap localhost
2. lxc launch ubuntu:xenial x1
3. lxc launch ubuntu:xenial x2
4. juju switch controller
5. juju add-machine ssh:x1.lxd
6. juju add-machine ssh:x2.lxd
7. juju enable-ha --to 1,2
(machines 1 and 2 should eventually become voting replica set members)

## Documentation changes

None.

## Bug reference

Fixes https://bugs.launchpad.net/juju/+bug/1642618