### PR TITLE
Handle zero size resource uploads.

### DIFF
--- a/apiserver/resources.go
+++ b/apiserver/resources.go
@@ -190,7 +190,12 @@ func extractUploadRequest(req *http.Request) (api.UploadRequest, error) {
 	var ur api.UploadRequest
 
 	if req.Header.Get(api.HeaderContentLength) == "" {
-		req.Header.Set(api.HeaderContentLength, fmt.Sprint(req.ContentLength))
+		size := req.ContentLength
+		// size will be negative if there is no content.
+		if size < 0 {
+			size = 0
+		}
+		req.Header.Set(api.HeaderContentLength, fmt.Sprint(size))
 	}
 
 	ctype := req.Header.Get(api.HeaderContentType)

--- a/featuretests/cmd_juju_resources_test.go
+++ b/featuretests/cmd_juju_resources_test.go
@@ -4,6 +4,8 @@
 package featuretests
 
 import (
+	"io/ioutil"
+	"path/filepath"
 	"strings"
 
 	"github.com/juju/cmd/cmdtesting"
@@ -96,6 +98,13 @@ upload-resource   -
 	c.Assert(err, gc.ErrorMatches, "cmd: error out silently")
 	c.Assert(cmdtesting.Stderr(context), jc.Contains, `ERROR failed to upload resource "install-resource": open oops: no such file or directory`)
 	c.Assert(cmdtesting.Stdout(context), gc.Equals, "")
+
+	// Empty files are fine.
+	filename := filepath.Join(c.MkDir(), "empty.txt")
+	err = ioutil.WriteFile(filename, []byte{}, 0755)
+	c.Assert(err, jc.ErrorIsNil)
+	_, err = runCommand(c, "attach-resource", s.appOneName, "install-resource="+filename)
+	c.Check(err, jc.ErrorIsNil)
 }
 
 func (s *ResourcesCmdSuite) runCharmResourcesCommand(c *gc.C) {


### PR DESCRIPTION
There is an error when trying to upload a zero length resource.

The problem looks to be that the HTTP handler was overriding the Content-Length that was set by the client. The client set zero, but by the time it reached the serer, the lenth was -1, which I'm assuming means "no body".

We handle this by setting the size to zero if it is negative.

All the unit tests are too mocked out to trigger this bug, so an addition was made to the feature tests for resources.

## QA steps

```
juju deploy ./acceptancetests/charms/dummy-resource
touch ~/empty.txt
juju attach-resource dummy-resource foo=~/empty.txt
```

## Bug reference

https://bugs.launchpad.net/juju/+bug/1723970