### PR TITLE
worker/leadership: check for ErrBlockCancelled

### DIFF
--- a/worker/leadership/tracker.go
+++ b/worker/leadership/tracker.go
@@ -26,7 +26,7 @@ type Tracker struct {
 	duration        time.Duration
 	isMinion        bool
 
-	claimLease        chan struct{}
+	claimLease        chan error
 	renewLease        <-chan time.Time
 	claimTickets      chan chan bool
 	waitLeaderTickets chan chan bool
@@ -136,9 +136,19 @@ func (t *Tracker) loop() error {
 		select {
 		case <-t.tomb.Dying():
 			return tomb.ErrDying
-		case <-t.claimLease:
-			logger.Tracef("%s claiming lease for %s leadership", t.unitName, t.applicationName)
+		case err := <-t.claimLease:
 			t.claimLease = nil
+			if errors.Cause(err) == leadership.ErrBlockCancelled {
+				// BlockUntilLeadershipReleased was cancelled,
+				// which means that the tracker is terminating.
+				continue
+			} else if err != nil {
+				return errors.Annotatef(err,
+					"error while %s waiting for %s leadership release",
+					t.unitName, t.applicationName,
+				)
+			}
+			logger.Tracef("%s claiming lease for %s leadership", t.unitName, t.applicationName)
 			if err := t.refresh(); err != nil {
 				return errors.Trace(err)
 			}
@@ -214,20 +224,12 @@ func (t *Tracker) setMinion() error {
 	t.isMinion = true
 	t.renewLease = nil
 	if t.claimLease == nil {
-		t.claimLease = make(chan struct{})
+		t.claimLease = make(chan error, 1)
 		go func() {
 			defer close(t.claimLease)
 			logger.Debugf("%s waiting for %s leadership release", t.unitName, t.applicationName)
 			err := t.claimer.BlockUntilLeadershipReleased(t.applicationName, t.tomb.Dying())
-			if err != nil {
-				logger.Debugf("error while %s waiting for %s leadership release: %v", t.unitName, t.applicationName, err)
-			}
-			// We don't need to do anything else with the error, because we just
-			// close the claimLease channel and trigger a leadership claim on the
-			// main loop; if anything's gone seriously wrong we'll find out right
-			// away and shut down anyway. (And if this goroutine outlives the
-			// Tracker, it keeps it around as a zombie, but I don't see a way
-			// around that...)
+			t.claimLease <- err
 		}()
 	}
 

--- a/worker/leadership/tracker_test.go
+++ b/worker/leadership/tracker_test.go
@@ -364,6 +364,15 @@ func (s *TrackerSuite) TestWaitMinionAlreadyMinion(c *gc.C) {
 	}})
 }
 
+func (s *TrackerSuite) TestWaitMinionClaimerFails(c *gc.C) {
+	s.claimer.Stub.SetErrors(coreleadership.ErrClaimDenied, errors.New("mein leben!"))
+	tracker := s.newTrackerDirtyKill()
+	s.unblockRelease(c)
+
+	err := workertest.CheckKilled(c, tracker)
+	c.Assert(err, gc.ErrorMatches, "error while led-service/123 waiting for led-service leadership release: mein leben!")
+}
+
 func (s *TrackerSuite) TestWaitMinionBecomeMinion(c *gc.C) {
 	s.claimer.Stub.SetErrors(nil, coreleadership.ErrClaimDenied, nil)
 	tracker := s.newTracker()


### PR DESCRIPTION
## Description of change

If BlockUntilLeadershipReleased is cancelled because
the worker is terminating, we should immediately
terminate rather than refreshing again and then
terminating. Treat ErrBlockCancelled the same as
if tomb.Dying() were signalled. Fixes intermittent test
failures.

## QA steps

go test -test.count=100 github.com/juju/juju/worker/leadership

## Documentation changes

None.

## Bug reference

None.