### PR TITLE
Be more defensive on ResourceGroup not found error check in azure provider

### DIFF
--- a/provider/azure/instance.go
+++ b/provider/azure/instance.go
@@ -416,7 +416,7 @@ func deleteInstanceNetworkSecurityRules(
 ) error {
 	nsg, err := nsgClient.Get(resourceGroup, internalSecurityGroupName, "")
 	if err != nil {
-		if err.(autorest.DetailedError).Response.StatusCode == http.StatusNotFound {
+		if err2, ok := err.(autorest.DetailedError); ok && err2.Response.StatusCode == http.StatusNotFound {
 			return nil
 		}
 		return errors.Annotate(err, "querying network security group")


### PR DESCRIPTION
## Description of change

Prevent panic in case nsgClient.Get returns an error that isn't an instance of autorest.DetailedError.  Related to comment after merge in PR8064.

## QA steps

unit tests

## Documentation changes

N/A

## Bug reference

N/A