### PR TITLE
acceptancetests: Don't start migration until unit agents are idle

### DIFF
--- a/apiserver/facades/client/client/status_test.go
+++ b/apiserver/facades/client/client/status_test.go
@@ -444,7 +444,7 @@ func assertApplicationRelations(c *gc.C, appName string, expectedNumber int, rel
 			}
 		}
 		if !belongs {
-			c.Fatal("application %v is not part of the relation %v as expected", appName, relation.Id)
+			c.Fatalf("application %v is not part of the relation %v as expected", appName, relation.Id)
 		}
 	}
 }


### PR DESCRIPTION
## Description of change

We were seeing failures because a migration would be started before
subordinate units had entered scope - this meant that the export would
fail. The migration source prechecks were updated to make the failure
occur earlier (#8018), but this test
also needs to be updated to wait for the unit agents to be finished,
otherwise it will sometimes fail because of the precheck.

An example failure:
http://qa.jujucharms.com/releases/5924/job/model-migration-lxd/attempt/2234

Includes a driveby fix for a go vet error.

## QA steps

Run the acceptance test (ideally multiple times), ensure that it doesn't fail with 
the migration precheck error.
