### PR TITLE
Add initial caas provisioner worker

### DIFF
--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -261,7 +261,7 @@ var agentConfigTests = []struct {
 		UpgradedToVersion: jujuversion.Current,
 		Password:          "sekrit",
 	},
-	checkErr: "entity tag must be MachineTag or UnitTag, got names.UserTag",
+	checkErr: "entity tag must be MachineTag, UnitTag or ApplicationTag, got names.UserTag",
 }, {
 	about: "agentConfig accepts a Unit tag",
 	params: agent.AgentConfigParams{
@@ -277,6 +277,22 @@ var agentConfigTests = []struct {
 	},
 	inspectConfig: func(c *gc.C, cfg agent.Config) {
 		c.Check(cfg.Dir(), gc.Equals, "/data/dir/agents/unit-ubuntu-1")
+	},
+}, {
+	about: "agentConfig accepts an Application tag",
+	params: agent.AgentConfigParams{
+		Paths:             agent.Paths{DataDir: "/data/dir"},
+		Tag:               names.NewApplicationTag("ubuntu"),
+		Password:          "sekrit",
+		UpgradedToVersion: jujuversion.Current,
+		Controller:        testing.ControllerTag,
+		Model:             testing.ModelTag,
+		CACert:            "ca cert",
+		StateAddresses:    []string{"localhost:1234"},
+		APIAddresses:      []string{"localhost:1235"},
+	},
+	inspectConfig: func(c *gc.C, cfg agent.Config) {
+		c.Check(cfg.Dir(), gc.Equals, "/data/dir/agents/application-ubuntu")
 	},
 }}
 

--- a/api/caasprovisioner/client.go
+++ b/api/caasprovisioner/client.go
@@ -1,0 +1,65 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package caasprovisioner
+
+import (
+	"github.com/juju/juju/api/base"
+	apiwatcher "github.com/juju/juju/api/watcher"
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/watcher"
+)
+
+// Client allows access to the CAAS provisioner API end point.
+type Client struct {
+	facade base.FacadeCaller
+}
+
+// NewClient returns a client used to access the CAAS Provisioner API.
+func NewClient(caller base.APICaller) *Client {
+	facadeCaller := base.NewFacadeCaller(caller, "CAASProvisioner")
+	return &Client{
+		facade: facadeCaller,
+	}
+}
+
+// ConnectionConfig holds attributes needed to connect to the CAAS cloud.
+type ConnectionConfig struct {
+	Endpoint       string
+	CACertificates []string
+	CertData       []byte
+	KeyData        []byte
+	Username       string
+	Password       string
+}
+
+// ConnectionConfig returns the config info required for the
+// provisioner to connect to the CAAS cloud
+func (st *Client) ConnectionConfig() (*ConnectionConfig, error) {
+	var result params.CAASConnectionConfig
+	if err := st.facade.FacadeCall("ConnectionConfig", nil, &result); err != nil {
+		return nil, err
+	}
+	return &ConnectionConfig{
+		Endpoint:       result.Endpoint,
+		CACertificates: result.CACertificates,
+		CertData:       result.CertData,
+		KeyData:        result.KeyData,
+		Username:       result.Username,
+		Password:       result.Password,
+	}, nil
+}
+
+// WatchApplications returns a StringsWatcher that notifies of
+// changes to the lifecycles of CAAS applications in the current model.
+func (st *Client) WatchApplications() (watcher.StringsWatcher, error) {
+	var result params.StringsWatchResult
+	if err := st.facade.FacadeCall("WatchApplications", nil, &result); err != nil {
+		return nil, err
+	}
+	if err := result.Error; err != nil {
+		return nil, result.Error
+	}
+	w := apiwatcher.NewStringsWatcher(st.facade.RawAPICaller(), result)
+	return w, nil
+}

--- a/api/caasprovisioner/client_test.go
+++ b/api/caasprovisioner/client_test.go
@@ -1,0 +1,75 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package caasprovisioner_test
+
+import (
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	basetesting "github.com/juju/juju/api/base/testing"
+	"github.com/juju/juju/api/caasprovisioner"
+	"github.com/juju/juju/apiserver/params"
+)
+
+type provisionerSuite struct {
+	testing.IsolationSuite
+}
+
+var _ = gc.Suite(&provisionerSuite{})
+
+func newClient(f basetesting.APICallerFunc) *caasprovisioner.Client {
+	return caasprovisioner.NewClient(basetesting.BestVersionCaller{f, 5})
+}
+
+func (s *provisionerSuite) TestConnectionConfig(c *gc.C) {
+	var called bool
+	client := newClient(func(objType string, version int, id, request string, a, result interface{}) error {
+		called = true
+		c.Check(objType, gc.Equals, "CAASProvisioner")
+		c.Check(id, gc.Equals, "")
+		c.Assert(request, gc.Equals, "ConnectionConfig")
+		c.Assert(a, gc.IsNil)
+		c.Assert(result, gc.FitsTypeOf, &params.CAASConnectionConfig{})
+		*(result.(*params.CAASConnectionConfig)) = params.CAASConnectionConfig{
+			Endpoint:       "endpoint",
+			Username:       "fred",
+			Password:       "password",
+			CACertificates: []string{"cert"},
+			CertData:       []byte("certdata"),
+			KeyData:        []byte("keydata"),
+		}
+		return nil
+	})
+	config, err := client.ConnectionConfig()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(called, jc.IsTrue)
+	c.Assert(config, jc.DeepEquals, &caasprovisioner.ConnectionConfig{
+		Endpoint:       "endpoint",
+		Username:       "fred",
+		Password:       "password",
+		CACertificates: []string{"cert"},
+		CertData:       []byte("certdata"),
+		KeyData:        []byte("keydata"),
+	})
+}
+
+func (s *provisionerSuite) TestWatchApplications(c *gc.C) {
+	var called bool
+	client := newClient(func(objType string, version int, id, request string, a, result interface{}) error {
+		called = true
+		c.Check(objType, gc.Equals, "CAASProvisioner")
+		c.Check(id, gc.Equals, "")
+		c.Assert(request, gc.Equals, "WatchApplications")
+		c.Assert(a, gc.IsNil)
+		c.Assert(result, gc.FitsTypeOf, &params.StringsWatchResult{})
+		*(result.(*params.StringsWatchResult)) = params.StringsWatchResult{
+			Error: &params.Error{Message: "FAIL"},
+		}
+		return nil
+	})
+	_, err := client.WatchApplications()
+	c.Check(err, gc.ErrorMatches, "FAIL")
+	c.Check(called, jc.IsTrue)
+}

--- a/api/caasprovisioner/package_test.go
+++ b/api/caasprovisioner/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package caasprovisioner_test
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func TestAll(t *testing.T) {
+	gc.TestingT(t)
+}

--- a/api/facadeversions.go
+++ b/api/facadeversions.go
@@ -24,6 +24,7 @@ var facadeVersions = map[string]int{
 	"Backups":                      1,
 	"Block":                        2,
 	"Bundle":                       1,
+	"CAASProvisioner":              1,
 	"CharmRevisionUpdater":         2,
 	"Charms":                       2,
 	"Cleaner":                      2,

--- a/apiserver/admin.go
+++ b/apiserver/admin.go
@@ -154,6 +154,9 @@ func (a *admin) login(req params.LoginRequest, loginVersion int) (params.LoginRe
 		loginResult.ModelTag = model.Tag().String()
 		loginResult.Facades = filterFacades(a.srv.facades, append(filters, IsModelFacade)...)
 		apiRoot = restrictRoot(apiRoot, modelFacadesOnly)
+		if model.Type() == state.ModelTypeCAAS {
+			apiRoot = restrictRoot(apiRoot, caasModelFacadesOnly)
+		}
 	}
 
 	a.root.rpcConn.ServeRoot(apiRoot, serverError)

--- a/apiserver/allfacades.go
+++ b/apiserver/allfacades.go
@@ -13,6 +13,7 @@ import (
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/apiserver/facades/agent/agent" // ModelUser Write
+	"github.com/juju/juju/apiserver/facades/agent/caasprovisioner"
 	"github.com/juju/juju/apiserver/facades/agent/deployer"
 	"github.com/juju/juju/apiserver/facades/agent/diskmanager"
 	"github.com/juju/juju/apiserver/facades/agent/fanconfigurer"
@@ -143,9 +144,6 @@ func AllFacades() *facade.Registry {
 	reg("Cleaner", 2, cleaner.NewCleanerAPI)
 	reg("Client", 1, client.NewFacade)
 	reg("Cloud", 1, cloud.NewFacade)
-	if featureflag.Enabled(feature.CAAS) {
-		reg("Cloud", 2, cloud.NewFacadeV2)
-	}
 
 	reg("Controller", 3, controller.NewControllerAPIv3)
 	reg("Controller", 4, controller.NewControllerAPIv4)
@@ -251,6 +249,13 @@ func AllFacades() *facade.Registry {
 	reg("Upgrader", 1, upgrader.NewUpgraderFacade)
 	reg("UserManager", 1, usermanager.NewUserManagerAPI)
 	reg("UserManager", 2, usermanager.NewUserManagerAPI) // Adds ResetPassword
+
+	// CAAS related facades.
+	// Move these to the correct place above once the feature flag disappears.
+	if featureflag.Enabled(feature.CAAS) {
+		reg("Cloud", 2, cloud.NewFacadeV2)
+		reg("CAASProvisioner", 1, caasprovisioner.NewStateCAASProvisionerAPI)
+	}
 
 	regRaw("AllWatcher", 1, NewAllWatcher, reflect.TypeOf((*SrvAllWatcher)(nil)))
 	// Note: AllModelWatcher uses the same infrastructure as AllWatcher

--- a/apiserver/common/modelmanagerinterface.go
+++ b/apiserver/common/modelmanagerinterface.go
@@ -77,6 +77,7 @@ type ModelManagerBackend interface {
 // All the interface methods are defined directly on state.Model
 // and are reproduced here for use in tests.
 type Model interface {
+	Type() state.ModelType
 	Config() (*config.Config, error)
 	Life() state.Life
 	ModelTag() names.ModelTag

--- a/apiserver/export_test.go
+++ b/apiserver/export_test.go
@@ -147,10 +147,17 @@ func TestingControllerOnlyRoot() rpc.Root {
 }
 
 // TestingModelOnlyRoot returns a restricted srvRoot as if
-// logged in to a model.
+// logged in to an IAAS model.
 func TestingModelOnlyRoot() rpc.Root {
 	r := TestingAPIRoot(AllFacades())
 	return restrictRoot(r, modelFacadesOnly)
+}
+
+// TestingCAASModelOnlyRoot returns a restricted srvRoot as if
+// logged in to a CAAS model.
+func TestingCAASModelOnlyRoot() rpc.Root {
+	r := TestingAPIRoot(AllFacades())
+	return restrictRoot(r, caasModelFacadesOnly)
 }
 
 // TestingRestrictedRoot returns a restricted srvRoot.

--- a/apiserver/facades/agent/caasprovisioner/mock_test.go
+++ b/apiserver/facades/agent/caasprovisioner/mock_test.go
@@ -1,0 +1,82 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package caasprovisioner_test
+
+import (
+	"github.com/juju/testing"
+	"gopkg.in/tomb.v1"
+
+	"github.com/juju/juju/apiserver/facades/agent/caasprovisioner"
+	"github.com/juju/juju/state"
+)
+
+type mockState struct {
+	testing.Stub
+	applicationWatcher *mockStringsWatcher
+	caasModel          *mockCAASModel
+}
+
+func newMockState() *mockState {
+	return &mockState{
+		applicationWatcher: newMockStringsWatcher(),
+	}
+}
+
+func (st *mockState) CAASModel() (caasprovisioner.CAASModel, error) {
+	st.MethodCall(st, "CAASModel")
+	return st.caasModel, nil
+}
+
+func (st *mockState) WatchApplications() state.StringsWatcher {
+	st.MethodCall(st, "WatchApplications")
+	return st.applicationWatcher
+}
+
+type mockCAASModel struct {
+	connectionCfg state.CAASConnectionConfig
+}
+
+func (m *mockCAASModel) ConnectionConfig() (state.CAASConnectionConfig, error) {
+	return m.connectionCfg, nil
+}
+
+type mockWatcher struct {
+	testing.Stub
+	tomb.Tomb
+}
+
+func (w *mockWatcher) doneWhenDying() {
+	<-w.Tomb.Dying()
+	w.Tomb.Done()
+}
+
+func (w *mockWatcher) Kill() {
+	w.MethodCall(w, "Kill")
+	w.Tomb.Kill(nil)
+}
+
+func (w *mockWatcher) Stop() error {
+	w.MethodCall(w, "Stop")
+	if err := w.NextErr(); err != nil {
+		return err
+	}
+	w.Tomb.Kill(nil)
+	return w.Tomb.Wait()
+}
+
+type mockStringsWatcher struct {
+	mockWatcher
+	changes chan []string
+}
+
+func newMockStringsWatcher() *mockStringsWatcher {
+	w := &mockStringsWatcher{changes: make(chan []string, 1)}
+	go w.doneWhenDying()
+	return w
+}
+
+func (w *mockStringsWatcher) Changes() <-chan []string {
+	w.MethodCall(w, "Changes")
+	return w.changes
+}

--- a/apiserver/facades/agent/caasprovisioner/package_test.go
+++ b/apiserver/facades/agent/caasprovisioner/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package caasprovisioner_test
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func TestAll(t *testing.T) {
+	gc.TestingT(t)
+}

--- a/apiserver/facades/agent/caasprovisioner/provisioner.go
+++ b/apiserver/facades/agent/caasprovisioner/provisioner.go
@@ -1,0 +1,83 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package caasprovisioner
+
+import (
+	"github.com/juju/errors"
+
+	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/facade"
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/state/watcher"
+)
+
+type API struct {
+	auth      facade.Authorizer
+	resources facade.Resources
+
+	state     CAASProvisionerState
+	caasModel CAASModel
+}
+
+// NewStateCAASProvisionerAPI provides the signature required for facade registration.
+func NewStateCAASProvisionerAPI(ctx facade.Context) (*API, error) {
+
+	authorizer := ctx.Auth()
+	if !authorizer.AuthMachineAgent() && !authorizer.AuthController() {
+		return nil, common.ErrPerm
+	}
+
+	resources := ctx.Resources()
+	return NewCAASProvisionerAPI(resources, authorizer, stateShim{ctx.State()})
+}
+
+// NewCAASProvisionerAPI returns a new CAASProvisionerAPI facade.
+func NewCAASProvisionerAPI(
+	resources facade.Resources,
+	authorizer facade.Authorizer,
+	st CAASProvisionerState,
+) (*API, error) {
+	caasModel, err := st.CAASModel()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	return &API{
+		auth:      authorizer,
+		resources: resources,
+		caasModel: caasModel,
+		state:     st,
+	}, nil
+}
+
+// ConnectionConfig returns the configuration to be used
+// when provisioning applications.
+func (a *API) ConnectionConfig() (params.CAASConnectionConfig, error) {
+	cfg, err := a.caasModel.ConnectionConfig()
+	if err != nil {
+		return params.CAASConnectionConfig{}, common.ServerError(err)
+	}
+	return params.CAASConnectionConfig{
+		Endpoint:       cfg.Endpoint,
+		Username:       cfg.Username,
+		Password:       cfg.Password,
+		CACertificates: cfg.CACertificates,
+		CertData:       cfg.CertData,
+		KeyData:        cfg.KeyData,
+	}, nil
+}
+
+// WatchApplications starts a StringsWatcher to watch CAAS applications
+// deployed to this model.
+func (a *API) WatchApplications() (params.StringsWatchResult, error) {
+	watch := a.state.WatchApplications()
+	// Consume the initial event and forward it to the result.
+	if changes, ok := <-watch.Changes(); ok {
+		return params.StringsWatchResult{
+			StringsWatcherId: a.resources.Register(watch),
+			Changes:          changes,
+		}, nil
+	}
+	return params.StringsWatchResult{}, watcher.EnsureErr(watch)
+}

--- a/apiserver/facades/agent/caasprovisioner/provisioner_test.go
+++ b/apiserver/facades/agent/caasprovisioner/provisioner_test.go
@@ -1,0 +1,81 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package caasprovisioner_test
+
+import (
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/names.v2"
+
+	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/facades/agent/caasprovisioner"
+	"github.com/juju/juju/apiserver/params"
+	apiservertesting "github.com/juju/juju/apiserver/testing"
+	"github.com/juju/juju/state"
+	coretesting "github.com/juju/juju/testing"
+)
+
+var _ = gc.Suite(&CAASProvisionerSuite{})
+
+type CAASProvisionerSuite struct {
+	coretesting.BaseSuite
+
+	resources  *common.Resources
+	authorizer *apiservertesting.FakeAuthorizer
+	api        *caasprovisioner.API
+	st         *mockState
+}
+
+func (s *CAASProvisionerSuite) SetUpTest(c *gc.C) {
+	s.BaseSuite.SetUpTest(c)
+
+	s.resources = common.NewResources()
+	s.AddCleanup(func(_ *gc.C) { s.resources.StopAll() })
+
+	s.authorizer = &apiservertesting.FakeAuthorizer{
+		Tag:        names.NewMachineTag("0"),
+		Controller: true,
+	}
+
+	s.st = newMockState()
+	cfg := state.CAASConnectionConfig{
+		Endpoint:       "endpoint",
+		Username:       "fred",
+		Password:       "password",
+		CACertificates: []string{"cert"},
+		CertData:       []byte("cert"),
+		KeyData:        []byte("key"),
+	}
+	s.st.caasModel = &mockCAASModel{connectionCfg: cfg}
+	api, err := caasprovisioner.NewCAASProvisionerAPI(s.resources, s.authorizer, s.st)
+	c.Assert(err, jc.ErrorIsNil)
+	s.api = api
+}
+
+func (s *CAASProvisionerSuite) TestWatchApplications(c *gc.C) {
+	applicationNames := []string{"db2", "hadoop"}
+	s.st.applicationWatcher.changes <- applicationNames
+	result, err := s.api.WatchApplications()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result.Error, gc.IsNil)
+	c.Assert(result.StringsWatcherId, gc.Equals, "1")
+	c.Assert(result.Changes, jc.DeepEquals, applicationNames)
+
+	resource := s.resources.Get("1")
+	c.Assert(resource, gc.NotNil)
+	c.Assert(resource, gc.Implements, new(state.StringsWatcher))
+}
+
+func (s *CAASProvisionerSuite) TestConnectionConfig(c *gc.C) {
+	result, err := s.api.ConnectionConfig()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result, jc.DeepEquals, params.CAASConnectionConfig{
+		Endpoint:       "endpoint",
+		Username:       "fred",
+		Password:       "password",
+		CACertificates: []string{"cert"},
+		CertData:       []byte("cert"),
+		KeyData:        []byte("key"),
+	})
+}

--- a/apiserver/facades/agent/caasprovisioner/state.go
+++ b/apiserver/facades/agent/caasprovisioner/state.go
@@ -1,0 +1,27 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package caasprovisioner
+
+import (
+	"github.com/juju/juju/state"
+)
+
+// CAASProvisionerState provides the subset of global state
+// required by the CAAS provisioner facade.
+type CAASProvisionerState interface {
+	CAASModel() (CAASModel, error)
+	WatchApplications() state.StringsWatcher
+}
+
+type stateShim struct {
+	*state.State
+}
+
+type CAASModel interface {
+	ConnectionConfig() (state.CAASConnectionConfig, error)
+}
+
+func (st stateShim) CAASModel() (CAASModel, error) {
+	return st.State.CAASModel()
+}

--- a/apiserver/facades/client/modelmanager/modelinfo_test.go
+++ b/apiserver/facades/client/modelmanager/modelinfo_test.go
@@ -922,6 +922,11 @@ func (m *mockModel) ModelTag() names.ModelTag {
 	return m.tag
 }
 
+func (m *mockModel) Type() state.ModelType {
+	m.MethodCall(m, "Type")
+	return state.ModelTypeIAAS
+}
+
 func (m *mockModel) Life() state.Life {
 	m.MethodCall(m, "Life")
 	return m.life

--- a/apiserver/params/caas.go
+++ b/apiserver/params/caas.go
@@ -1,0 +1,14 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package params
+
+// CAASConnectionConfig holds CAAS connection config.
+type CAASConnectionConfig struct {
+	Endpoint       string   `json:"endpoint"`
+	CACertificates []string `json:"ca-certificates,omitempty"`
+	CertData       []byte   `json:"cert-data,omitempty"`
+	KeyData        []byte   `json:"key-data,omitempty"`
+	Username       string   `json:"username"`
+	Password       string   `json:"password"`
+}

--- a/apiserver/restrict_caasmodel.go
+++ b/apiserver/restrict_caasmodel.go
@@ -1,0 +1,56 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package apiserver
+
+import (
+	"fmt"
+
+	"github.com/juju/errors"
+	"github.com/juju/utils/set"
+)
+
+// commonModelFacadeNames lists facades that are shared between CAAS
+// and IAAS models.
+var commonModelFacadeNames = set.NewStrings(
+	"Agent",
+	"Application",
+	"Charms",
+	"Cleaner",
+	"Client",
+	"Cloud",
+	"LifeFlag",
+	"MigrationFlag",
+	"MigrationMaster",
+	"MigrationMinion",
+	"MigrationStatusWatcher",
+	"MigrationTarget",
+	"ModelConfig",
+	"ModelUpgrader",
+	"Pinger",
+	"RelationUnitsWatcher",
+	"RemoteRelations",
+	"Singular",
+	"StringsWatcher",
+)
+
+// caasModelFacadeNames lists facades that are only used with CAAS
+// models.
+var caasModelFacadeNames = set.NewStrings(
+	"CAASProvisioner",
+)
+
+func caasModelFacadesOnly(facadeName, _ string) error {
+	if !isCAASModelFacade(facadeName) {
+		return errors.NewNotSupported(nil, fmt.Sprintf("facade %q not supported for a CAAS model API connection", facadeName))
+	}
+	return nil
+}
+
+// isCAASModelFacade reports whether the given facade name can be accessed
+// using the controller connection.
+func isCAASModelFacade(facadeName string) bool {
+	return caasModelFacadeNames.Contains(facadeName) ||
+		commonModelFacadeNames.Contains(facadeName) ||
+		commonFacadeNames.Contains(facadeName)
+}

--- a/apiserver/restrict_caasmodel_test.go
+++ b/apiserver/restrict_caasmodel_test.go
@@ -1,0 +1,45 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package apiserver_test
+
+import (
+	"github.com/juju/errors"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/apiserver"
+	"github.com/juju/juju/feature"
+	"github.com/juju/juju/rpc"
+	"github.com/juju/juju/testing"
+)
+
+type restrictCAASModelSuite struct {
+	testing.BaseSuite
+	root rpc.Root
+}
+
+var _ = gc.Suite(&restrictCAASModelSuite{})
+
+func (s *restrictCAASModelSuite) SetUpSuite(c *gc.C) {
+	s.BaseSuite.SetUpSuite(c)
+	s.SetFeatureFlags(feature.CAAS)
+	s.root = apiserver.TestingCAASModelOnlyRoot()
+}
+
+func (s *restrictCAASModelSuite) TestAllowed(c *gc.C) {
+	s.assertMethod(c, "CAASProvisioner", 1, "ConnectionConfig")
+}
+
+func (s *restrictCAASModelSuite) TestNotAllowed(c *gc.C) {
+	caller, err := s.root.FindMethod("Firewaller", 1, "WatchOpenedPorts")
+	c.Assert(err, gc.ErrorMatches, `facade "Firewaller" not supported for a CAAS model API connection`)
+	c.Assert(errors.IsNotSupported(err), jc.IsTrue)
+	c.Assert(caller, gc.IsNil)
+}
+
+func (s *restrictCAASModelSuite) assertMethod(c *gc.C, facadeName string, version int, method string) {
+	caller, err := s.root.FindMethod(facadeName, version, method)
+	c.Check(err, jc.ErrorIsNil)
+	c.Check(caller, gc.NotNil)
+}

--- a/cmd/jujud/agent/machine_test.go
+++ b/cmd/jujud/agent/machine_test.go
@@ -1247,8 +1247,8 @@ func (s *MachineSuite) TestControllerModelWorkers(c *gc.C) {
 	uuid := s.BackingState.ModelUUID()
 
 	tracker := NewEngineTracker()
-	instrumented := TrackModels(c, tracker, modelManifolds)
-	s.PatchValue(&modelManifolds, instrumented)
+	instrumented := TrackModels(c, tracker, iaasModelManifolds)
+	s.PatchValue(&iaasModelManifolds, instrumented)
 
 	matcher := NewWorkerMatcher(c, tracker, uuid,
 		append(alwaysModelWorkers, aliveModelWorkers...))
@@ -1270,8 +1270,8 @@ func (s *MachineSuite) TestHostedModelWorkers(c *gc.C) {
 	uuid := st.ModelUUID()
 
 	tracker := NewEngineTracker()
-	instrumented := TrackModels(c, tracker, modelManifolds)
-	s.PatchValue(&modelManifolds, instrumented)
+	instrumented := TrackModels(c, tracker, iaasModelManifolds)
+	s.PatchValue(&iaasModelManifolds, instrumented)
 
 	matcher := NewWorkerMatcher(c, tracker, uuid,
 		append(alwaysModelWorkers, aliveModelWorkers...))
@@ -1295,7 +1295,7 @@ func (s *MachineSuite) TestMigratingModelWorkers(c *gc.C) {
 	// TODO(mjs) - an alternative might be to provide a fake Facade
 	// and api.Open to the real migrationmaster but this test is
 	// awfully far away from the low level details of the worker.
-	origModelManifolds := modelManifolds
+	origModelManifolds := iaasModelManifolds
 	modelManifoldsDisablingMigrationMaster := func(config model.ManifoldsConfig) dependency.Manifolds {
 		config.NewMigrationMaster = func(config migrationmaster.Config) (worker.Worker, error) {
 			return &nullWorker{}, nil
@@ -1303,7 +1303,7 @@ func (s *MachineSuite) TestMigratingModelWorkers(c *gc.C) {
 		return origModelManifolds(config)
 	}
 	instrumented := TrackModels(c, tracker, modelManifoldsDisablingMigrationMaster)
-	s.PatchValue(&modelManifolds, instrumented)
+	s.PatchValue(&iaasModelManifolds, instrumented)
 
 	targetControllerTag := names.NewControllerTag(utils.MustNewUUID().String())
 	_, err := st.CreateMigration(state.MigrationSpec{
@@ -1369,8 +1369,8 @@ func (s *MachineSuite) TestModelWorkersRespectSingularResponsibilityFlag(c *gc.C
 	// Then run a normal model-tracking test, just checking for
 	// a different set of workers.
 	tracker := NewEngineTracker()
-	instrumented := TrackModels(c, tracker, modelManifolds)
-	s.PatchValue(&modelManifolds, instrumented)
+	instrumented := TrackModels(c, tracker, iaasModelManifolds)
+	s.PatchValue(&iaasModelManifolds, instrumented)
 
 	matcher := NewWorkerMatcher(c, tracker, uuid, alwaysModelWorkers)
 	s.assertJobWithState(c, state.JobManageModel, func(agent.Config, *state.State) {

--- a/cmd/jujud/agent/model/manifolds.go
+++ b/cmd/jujud/agent/model/manifolds.go
@@ -22,6 +22,7 @@ import (
 	"github.com/juju/juju/worker/apicaller"
 	"github.com/juju/juju/worker/apiconfigwatcher"
 	"github.com/juju/juju/worker/applicationscaler"
+	"github.com/juju/juju/worker/caasprovisioner"
 	"github.com/juju/juju/worker/charmrevision"
 	"github.com/juju/juju/worker/charmrevision/charmrevisionmanifold"
 	"github.com/juju/juju/worker/cleaner"
@@ -101,13 +102,13 @@ type ManifoldsConfig struct {
 	NewMigrationMaster func(migrationmaster.Config) (worker.Worker, error)
 }
 
-// Manifolds returns a set of interdependent dependency manifolds that will
-// run together to administer a model, as configured.
-func Manifolds(config ManifoldsConfig) dependency.Manifolds {
+// commonManifolds returns a set of interdependent dependency manifolds that will
+// run together to administer a model, as configured. These manifolds are used
+// by both IAAS and CAAS models.
+func commonManifolds(config ManifoldsConfig) dependency.Manifolds {
 	agentConfig := config.Agent.CurrentConfig()
 	machineTag := agentConfig.Tag().(names.MachineTag)
 	modelTag := agentConfig.Model()
-	controllerTag := agentConfig.Controller()
 	result := dependency.Manifolds{
 
 		// The first group are foundational; the agent and clock
@@ -157,34 +158,6 @@ func Manifolds(config ManifoldsConfig) dependency.Manifolds {
 
 			NewFacade: singular.NewFacade,
 			NewWorker: singular.NewWorker,
-		}),
-
-		// The environ tracker could/should be used by several other
-		// workers (firewaller, provisioners, address-cleaner?).
-		environTrackerName: ifResponsible(environ.Manifold(environ.ManifoldConfig{
-			APICallerName:  apiCallerName,
-			NewEnvironFunc: config.NewEnvironFunc,
-		})),
-
-		// The model upgrader runs on all controller agents, and
-		// unlocks the gate when the model is up-to-date. The
-		// environ tracker will be supplied only to the leader,
-		// which is the agent that will run the upgrade steps;
-		// the other controller agents will wait for it to complete
-		// running those steps before allowing logins to the model.
-		modelUpgradeGateName: gate.Manifold(),
-		modelUpgradedFlagName: gate.FlagManifold(gate.FlagManifoldConfig{
-			GateName:  modelUpgradeGateName,
-			NewWorker: gate.NewFlagWorker,
-		}),
-		modelUpgraderName: modelupgrader.Manifold(modelupgrader.ManifoldConfig{
-			APICallerName: apiCallerName,
-			EnvironName:   environTrackerName,
-			GateName:      modelUpgradeGateName,
-			ControllerTag: controllerTag,
-			ModelTag:      modelTag,
-			NewFacade:     modelupgrader.NewFacade,
-			NewWorker:     modelupgrader.NewWorker,
 		}),
 
 		// The migration workers collaborate to run migrations;
@@ -248,6 +221,90 @@ func Manifolds(config ManifoldsConfig) dependency.Manifolds {
 			NewWorker: undertaker.NewWorker,
 		}))),
 
+		charmRevisionUpdaterName: ifNotMigrating(charmrevisionmanifold.Manifold(charmrevisionmanifold.ManifoldConfig{
+			APICallerName: apiCallerName,
+			ClockName:     clockName,
+			Period:        config.CharmRevisionUpdateInterval,
+
+			NewFacade: charmrevisionmanifold.NewAPIFacade,
+			NewWorker: charmrevision.NewWorker,
+		})),
+		remoteRelationsName: ifNotMigrating(remoterelations.Manifold(remoterelations.ManifoldConfig{
+			AgentName:                agentName,
+			APICallerName:            apiCallerName,
+			NewControllerConnection:  apicaller.NewExternalControllerConnection,
+			NewRemoteRelationsFacade: remoterelations.NewRemoteRelationsFacade,
+			NewWorker:                remoterelations.NewWorker,
+		})),
+		stateCleanerName: ifNotMigrating(cleaner.Manifold(cleaner.ManifoldConfig{
+			APICallerName: apiCallerName,
+			ClockName:     clockName,
+		})),
+		statusHistoryPrunerName: ifNotMigrating(pruner.Manifold(pruner.ManifoldConfig{
+			APICallerName: apiCallerName,
+			EnvironName:   environTrackerName,
+			ClockName:     clockName,
+			NewWorker:     statushistorypruner.New,
+			NewFacade:     statushistorypruner.NewFacade,
+			PruneInterval: config.StatusHistoryPrunerInterval,
+		})),
+		actionPrunerName: ifNotMigrating(pruner.Manifold(pruner.ManifoldConfig{
+			APICallerName: apiCallerName,
+			EnvironName:   environTrackerName,
+			ClockName:     clockName,
+			NewWorker:     actionpruner.New,
+			NewFacade:     actionpruner.NewFacade,
+			PruneInterval: config.ActionPrunerInterval,
+		})),
+		logForwarderName: ifNotDead(logforwarder.Manifold(logforwarder.ManifoldConfig{
+			APICallerName: apiCallerName,
+			Sinks: []logforwarder.LogSinkSpec{{
+				Name:   "juju-log-forward",
+				OpenFn: sinks.OpenSyslog,
+			}},
+		})),
+	}
+	return result
+}
+
+// IAASManifolds returns a set of interdependent dependency manifolds that will
+// run together to administer an IAAS model, as configured.
+func IAASManifolds(config ManifoldsConfig) dependency.Manifolds {
+	agentConfig := config.Agent.CurrentConfig()
+	controllerTag := agentConfig.Controller()
+	modelTag := agentConfig.Model()
+	manifolds := dependency.Manifolds{
+
+		// The environ tracker could/should be used by several other
+		// workers (firewaller, provisioners, address-cleaner?).
+		environTrackerName: ifResponsible(environ.Manifold(environ.ManifoldConfig{
+			APICallerName:  apiCallerName,
+			NewEnvironFunc: config.NewEnvironFunc,
+		})),
+
+		// Everything else should be wrapped in ifResponsible,
+		// ifNotAlive, ifNotDead, or ifNotMigrating (which also
+		// implies NotDead), to ensure that only a single
+		// controller is attempting to administer this model at
+		// any one time.
+		//
+		// NOTE: not perfectly reliable at this stage? i.e. a
+		// worker that ignores its stop signal for "too long"
+		// might continue to take admin actions after the window
+		// of responsibility closes. This *is* a pre-existing
+		// problem, but demands some thought/care: e.g. should
+		// we make sure the apiserver also closes any
+		// connections that lose responsibility..? can we make
+		// sure all possible environ operations are either time-
+		// bounded or interruptible? etc
+		//
+		// On the other hand, all workers *should* be written in
+		// the expectation of dealing with sucky infrastructure
+		// running things in parallel unexpectedly, just because
+		// the universe hates us and will engineer matters such
+		// that it happens sometimes, even when we try to avoid
+		// it.
+
 		// All the rest depend on ifNotMigrating.
 		computeProvisionerName: ifNotMigrating(provisioner.Manifold(provisioner.ManifoldConfig{
 			AgentName:          agentName,
@@ -285,57 +342,58 @@ func Manifolds(config ManifoldsConfig) dependency.Manifolds {
 			ClockName:     clockName,
 			Delay:         config.InstPollerAggregationDelay,
 		})),
-		charmRevisionUpdaterName: ifNotMigrating(charmrevisionmanifold.Manifold(charmrevisionmanifold.ManifoldConfig{
-			APICallerName: apiCallerName,
-			ClockName:     clockName,
-			Period:        config.CharmRevisionUpdateInterval,
-
-			NewFacade: charmrevisionmanifold.NewAPIFacade,
-			NewWorker: charmrevision.NewWorker,
-		})),
 		metricWorkerName: ifNotMigrating(metricworker.Manifold(metricworker.ManifoldConfig{
 			APICallerName: apiCallerName,
-		})),
-		stateCleanerName: ifNotMigrating(cleaner.Manifold(cleaner.ManifoldConfig{
-			APICallerName: apiCallerName,
-			ClockName:     clockName,
-		})),
-		statusHistoryPrunerName: ifNotMigrating(pruner.Manifold(pruner.ManifoldConfig{
-			APICallerName: apiCallerName,
-			EnvironName:   environTrackerName,
-			ClockName:     clockName,
-			NewWorker:     statushistorypruner.New,
-			NewFacade:     statushistorypruner.NewFacade,
-			PruneInterval: config.StatusHistoryPrunerInterval,
-		})),
-		actionPrunerName: ifNotMigrating(pruner.Manifold(pruner.ManifoldConfig{
-			APICallerName: apiCallerName,
-			EnvironName:   environTrackerName,
-			ClockName:     clockName,
-			NewWorker:     actionpruner.New,
-			NewFacade:     actionpruner.NewFacade,
-			PruneInterval: config.ActionPrunerInterval,
 		})),
 		machineUndertakerName: ifNotMigrating(machineundertaker.Manifold(machineundertaker.ManifoldConfig{
 			APICallerName: apiCallerName,
 			EnvironName:   environTrackerName,
 			NewWorker:     machineundertaker.NewWorker,
 		})),
-		logForwarderName: ifNotDead(logforwarder.Manifold(logforwarder.ManifoldConfig{
+		// The model upgrader runs on all controller agents, and
+		// unlocks the gate when the model is up-to-date. The
+		// environ tracker will be supplied only to the leader,
+		// which is the agent that will run the upgrade steps;
+		// the other controller agents will wait for it to complete
+		// running those steps before allowing logins to the model.
+		modelUpgradeGateName: gate.Manifold(),
+		modelUpgradedFlagName: gate.FlagManifold(gate.FlagManifoldConfig{
+			GateName:  modelUpgradeGateName,
+			NewWorker: gate.NewFlagWorker,
+		}),
+		modelUpgraderName: modelupgrader.Manifold(modelupgrader.ManifoldConfig{
 			APICallerName: apiCallerName,
-			Sinks: []logforwarder.LogSinkSpec{{
-				Name:   "juju-log-forward",
-				OpenFn: sinks.OpenSyslog,
-			}},
-		})),
+			EnvironName:   environTrackerName,
+			GateName:      modelUpgradeGateName,
+			ControllerTag: controllerTag,
+			ModelTag:      modelTag,
+			NewFacade:     modelupgrader.NewFacade,
+			NewWorker:     modelupgrader.NewWorker,
+		}),
 	}
-	result[remoteRelationsName] = ifNotMigrating(remoterelations.Manifold(remoterelations.ManifoldConfig{
-		AgentName:                agentName,
-		APICallerName:            apiCallerName,
-		NewControllerConnection:  apicaller.NewExternalControllerConnection,
-		NewRemoteRelationsFacade: remoterelations.NewRemoteRelationsFacade,
-		NewWorker:                remoterelations.NewWorker,
-	}))
+	result := commonManifolds(config)
+	for name, manifold := range manifolds {
+		result[name] = manifold
+	}
+	return result
+}
+
+// CAASManifolds returns a set of interdependent dependency manifolds that will
+// run together to administer a CAAS model, as configured.
+func CAASManifolds(config ManifoldsConfig) dependency.Manifolds {
+	manifolds := dependency.Manifolds{
+		caasProvisionerName: ifNotMigrating(caasprovisioner.Manifold(
+			caasprovisioner.ManifoldConfig{
+				AgentName:     agentName,
+				APICallerName: apiCallerName,
+				NewWorker:     caasprovisioner.NewProvisionerWorker,
+			},
+		)),
+	}
+	result := commonManifolds(config)
+	for name, manifold := range manifolds {
+		result[name] = manifold
+	}
 	return result
 }
 
@@ -442,4 +500,5 @@ const (
 	machineUndertakerName    = "machine-undertaker"
 	remoteRelationsName      = "remote-relations"
 	logForwarderName         = "log-forwarder"
+	caasProvisionerName      = "caas-provisioner"
 )

--- a/cmd/jujud/agent/model/manifolds_test.go
+++ b/cmd/jujud/agent/model/manifolds_test.go
@@ -20,9 +20,9 @@ type ManifoldsSuite struct {
 
 var _ = gc.Suite(&ManifoldsSuite{})
 
-func (s *ManifoldsSuite) TestNames(c *gc.C) {
+func (s *ManifoldsSuite) TestIAASNames(c *gc.C) {
 	actual := set.NewStrings()
-	manifolds := model.Manifolds(model.ManifoldsConfig{
+	manifolds := model.IAASManifolds(model.ManifoldsConfig{
 		Agent: &mockAgent{},
 	})
 	for name := range manifolds {
@@ -60,6 +60,38 @@ func (s *ManifoldsSuite) TestNames(c *gc.C) {
 		"storage-provisioner",
 		"undertaker",
 		"unit-assigner",
+	})
+}
+
+func (s *ManifoldsSuite) TestCAASNames(c *gc.C) {
+	actual := set.NewStrings()
+	manifolds := model.CAASManifolds(model.ManifoldsConfig{
+		Agent: &mockAgent{},
+	})
+	for name := range manifolds {
+		actual.Add(name)
+	}
+	// NOTE: if this test failed, the cmd/jujud/agent tests will
+	// also fail. Search for 'ModelWorkers' to find affected vars.
+	c.Check(actual.SortedValues(), jc.DeepEquals, []string{
+		"action-pruner",
+		"agent",
+		"api-caller",
+		"api-config-watcher",
+		"caas-provisioner",
+		"charm-revision-updater",
+		"clock",
+		"is-responsible-flag",
+		"log-forwarder",
+		"migration-fortress",
+		"migration-inactive-flag",
+		"migration-master",
+		"not-alive-flag",
+		"not-dead-flag",
+		"remote-relations",
+		"state-cleaner",
+		"status-history-pruner",
+		"undertaker",
 	})
 }
 
@@ -78,7 +110,7 @@ func (s *ManifoldsSuite) TestFlagDependencies(c *gc.C) {
 		"model-upgraded-flag",
 		"model-upgrader",
 	)
-	manifolds := model.Manifolds(model.ManifoldsConfig{
+	manifolds := model.IAASManifolds(model.ManifoldsConfig{
 		Agent: &mockAgent{},
 	})
 	for name, manifold := range manifolds {
@@ -95,7 +127,7 @@ func (s *ManifoldsSuite) TestFlagDependencies(c *gc.C) {
 }
 
 func (s *ManifoldsSuite) TestStateCleanerIgnoresLifeFlags(c *gc.C) {
-	manifolds := model.Manifolds(model.ManifoldsConfig{
+	manifolds := model.IAASManifolds(model.ManifoldsConfig{
 		Agent: &mockAgent{},
 	})
 	manifold, found := manifolds["state-cleaner"]
@@ -108,7 +140,7 @@ func (s *ManifoldsSuite) TestStateCleanerIgnoresLifeFlags(c *gc.C) {
 
 func (s *ManifoldsSuite) TestClockWrapper(c *gc.C) {
 	expectClock := &fakeClock{}
-	manifolds := model.Manifolds(model.ManifoldsConfig{
+	manifolds := model.IAASManifolds(model.ManifoldsConfig{
 		Agent: &mockAgent{},
 		Clock: expectClock,
 	})
@@ -125,56 +157,3 @@ func (s *ManifoldsSuite) TestClockWrapper(c *gc.C) {
 }
 
 type fakeClock struct{ clock.Clock }
-
-type ManifoldsCrossModelSuite struct {
-	testing.BaseSuite
-}
-
-var _ = gc.Suite(&ManifoldsCrossModelSuite{})
-
-func (s *ManifoldsCrossModelSuite) SetUpTest(c *gc.C) {
-	s.BaseSuite.SetUpTest(c)
-}
-
-func (s *ManifoldsCrossModelSuite) TestNames(c *gc.C) {
-	actual := set.NewStrings()
-	manifolds := model.Manifolds(model.ManifoldsConfig{
-		Agent: &mockAgent{},
-	})
-	for name := range manifolds {
-		actual.Add(name)
-	}
-	// NOTE: if this test failed, the cmd/jujud/agent tests will
-	// also fail. Search for 'ModelWorkers' to find affected vars.
-	c.Check(actual.SortedValues(), jc.DeepEquals, []string{
-		"action-pruner",
-		"agent",
-		"api-caller",
-		"api-config-watcher",
-		"application-scaler",
-		"charm-revision-updater",
-		"clock",
-		"compute-provisioner",
-		"environ-tracker",
-		"firewaller",
-		"instance-poller",
-		"is-responsible-flag",
-		"log-forwarder",
-		"machine-undertaker",
-		"metric-worker",
-		"migration-fortress",
-		"migration-inactive-flag",
-		"migration-master",
-		"model-upgrade-gate",
-		"model-upgraded-flag",
-		"model-upgrader",
-		"not-alive-flag",
-		"not-dead-flag",
-		"remote-relations",
-		"state-cleaner",
-		"status-history-pruner",
-		"storage-provisioner",
-		"undertaker",
-		"unit-assigner",
-	})
-}

--- a/state/caasmodel.go
+++ b/state/caasmodel.go
@@ -1,0 +1,89 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package state
+
+import "github.com/juju/errors"
+
+// CAASModel contains functionality that is specific to an
+// Containers-As-A-Service (CAAS) model. It embeds a Model so that
+// all generic Model functionality is also available.
+type CAASModel struct {
+	*Model
+
+	mb modelBackend
+
+	// TODO(caas): This should be removed once things
+	// have been sufficiently untangled.
+	st *State
+}
+
+// CAASModel returns an Containers-As-A-Service (CAAS) model.
+func (m *Model) CAASModel() (*CAASModel, error) {
+	if m.Type() != ModelTypeCAAS {
+		return nil, errors.NotSupportedf("called CAASModel() on a non-CAAS Model")
+	}
+	return &CAASModel{
+		Model: m,
+		mb:    m.st,
+		st:    m.st,
+	}, nil
+}
+
+// CAASModel returns Containers-As-A-Service (CAAS) model.
+//
+// TODO(caas): This is a convenience helper only and will go away
+// once most model related functionality has been moved from State to
+// Model/CAASModel. Model.CAASModel() should be preferred where-ever
+// possible.
+func (st *State) CAASModel() (*CAASModel, error) {
+	m, err := st.Model()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	im, err := m.CAASModel()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return im, nil
+}
+
+// CAASConnectionConfig holds the attributes needed to connect
+// to a CAAS model.
+type CAASConnectionConfig struct {
+	Endpoint       string
+	CACertificates []string
+	CertData       []byte
+	KeyData        []byte
+	Username       string
+	Password       string
+}
+
+// ConnectionConfig returns the attributes needed to connect to the CAAS model.
+func (m *CAASModel) ConnectionConfig() (CAASConnectionConfig, error) {
+	cloud, err := m.st.Cloud(m.Cloud())
+	if err != nil {
+		return CAASConnectionConfig{}, errors.Trace(err)
+	}
+
+	credentialTag, is_set := m.CloudCredential()
+	if !is_set {
+		return CAASConnectionConfig{}, errors.Errorf("CAAS cloud with no CloudCredential set")
+	}
+
+	credential, err := m.st.CloudCredential(credentialTag)
+	if err != nil {
+		return CAASConnectionConfig{}, errors.Trace(err)
+	}
+
+	credentialAttrs := credential.Attributes()
+
+	return CAASConnectionConfig{
+		Endpoint:       cloud.Endpoint, // TODO(caas) fix this if region support is added
+		CACertificates: cloud.CACertificates,
+		CertData:       []byte(credentialAttrs["ClientCertificateData"]),
+		KeyData:        []byte(credentialAttrs["ClientKeyData"]),
+		Username:       credentialAttrs["Username"],
+		Password:       credentialAttrs["Password"],
+	}, nil
+}

--- a/state/caasmodel_test.go
+++ b/state/caasmodel_test.go
@@ -1,0 +1,213 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package state_test
+
+import (
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/names.v2"
+
+	"github.com/juju/juju/environs/config"
+	"github.com/juju/juju/feature"
+	"github.com/juju/juju/state"
+	"github.com/juju/juju/storage"
+	"github.com/juju/juju/testing/factory"
+)
+
+type CAASModelSuite struct {
+	ConnSuite
+}
+
+var _ = gc.Suite(&CAASModelSuite{})
+
+// createTestModelConfig returns a new model config and its UUID for testing.
+func (s *CAASModelSuite) createTestModelConfig(c *gc.C) (*config.Config, string) {
+	return createTestModelConfig(c, s.modelTag.Id())
+}
+
+func (s *CAASModelSuite) newCAASModel(c *gc.C) (*state.Model, names.ModelTag, names.UserTag) {
+	cfg, uuid := s.createTestModelConfig(c)
+	modelTag := names.NewModelTag(uuid)
+	owner := names.NewUserTag("test@remote")
+	model, st, err := s.State.NewModel(state.ModelArgs{
+		Type:      state.ModelTypeCAAS,
+		CloudName: "dummy",
+		Config:    cfg,
+		Owner:     owner,
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	s.AddCleanup(func(*gc.C) { st.Close() })
+	return model, modelTag, owner
+}
+
+func (s *CAASModelSuite) TestNewModel(c *gc.C) {
+	s.SetFeatureFlags(feature.CAAS)
+
+	model, modelTag, owner := s.newCAASModel(c)
+	c.Assert(model.Type(), gc.Equals, state.ModelTypeCAAS)
+	c.Assert(model.UUID(), gc.Equals, modelTag.Id())
+	c.Assert(model.Tag(), gc.Equals, modelTag)
+	c.Assert(model.ControllerTag(), gc.Equals, s.State.ControllerTag())
+	c.Assert(model.Owner(), gc.Equals, owner)
+	c.Assert(model.Name(), gc.Equals, "testing")
+	c.Assert(model.Life(), gc.Equals, state.Alive)
+	c.Assert(model.CloudRegion(), gc.Equals, "")
+}
+
+func (s *CAASModelSuite) TestModelDestroy(c *gc.C) {
+	s.SetFeatureFlags(feature.CAAS)
+
+	model, _, _ := s.newCAASModel(c)
+	err := model.Destroy(state.DestroyModelParams{})
+	c.Assert(err, jc.ErrorIsNil)
+	err = model.Refresh()
+	c.Assert(err, jc.ErrorIsNil)
+	// TODO(caas) - this will be dying when we add cleanup steps.
+	c.Assert(model.Life(), gc.Equals, state.Dead)
+}
+
+func (s *CAASModelSuite) TestCAASModelsCantHaveCloudRegion(c *gc.C) {
+	s.SetFeatureFlags(feature.CAAS)
+	cfg, _ := s.createTestModelConfig(c)
+	_, _, err := s.State.NewModel(state.ModelArgs{
+		Type:        state.ModelTypeCAAS,
+		CloudName:   "dummy",
+		CloudRegion: "fork",
+		Config:      cfg,
+		Owner:       names.NewUserTag("test@remote"),
+	})
+	c.Assert(err, gc.ErrorMatches, "CAAS model with CloudRegion not supported")
+}
+
+func (s *CAASModelSuite) TestNewModelCAASNeedsFeature(c *gc.C) {
+	cfg, _ := s.createTestModelConfig(c)
+	owner := names.NewUserTag("test@remote")
+	_, _, err := s.State.NewModel(state.ModelArgs{
+		Type:      state.ModelTypeCAAS,
+		CloudName: "dummy",
+		Config:    cfg,
+		Owner:     owner,
+	})
+	c.Assert(err, gc.ErrorMatches, "model type not supported")
+}
+
+func (s *CAASModelSuite) TestNewModelCAASWithStorageRegistry(c *gc.C) {
+	s.SetFeatureFlags(feature.CAAS)
+
+	cfg, _ := s.createTestModelConfig(c)
+	owner := names.NewUserTag("test@remote")
+	_, _, err := s.State.NewModel(state.ModelArgs{
+		Type:      state.ModelTypeCAAS,
+		CloudName: "dummy",
+		Config:    cfg,
+		Owner:     owner,
+		StorageProviderRegistry: storage.StaticProviderRegistry{},
+	})
+	c.Assert(err, gc.ErrorMatches, "CAAS model with StorageProviderRegistry not valid")
+}
+
+func (s *CAASModelSuite) TestDestroyControllerAndHostedCAASModels(c *gc.C) {
+	s.SetFeatureFlags(feature.CAAS)
+	st2 := s.Factory.MakeModel(c, &factory.ModelParams{
+		Type: state.ModelTypeCAAS, CloudRegion: "<none>", StorageProviderRegistry: factory.NilStorageProviderRegistry{}})
+	defer st2.Close()
+	factory.NewFactory(st2).MakeApplication(c, nil)
+
+	controllerModel, err := s.State.Model()
+	c.Assert(err, jc.ErrorIsNil)
+	destroyStorage := true
+	c.Assert(controllerModel.Destroy(state.DestroyModelParams{
+		DestroyHostedModels: true,
+		DestroyStorage:      &destroyStorage,
+	}), jc.ErrorIsNil)
+
+	model, err := s.State.Model()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(model.Life(), gc.Equals, state.Dying)
+
+	assertNeedsCleanup(c, s.State)
+	assertCleanupRuns(c, s.State)
+
+	// Cleanups for hosted model enqueued by controller model cleanups.
+	assertNeedsCleanup(c, st2)
+	assertCleanupRuns(c, st2)
+
+	model2, err := st2.Model()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(model2.Life(), gc.Equals, state.Dying)
+
+	c.Assert(st2.ProcessDyingModel(), jc.ErrorIsNil)
+
+	c.Assert(model2.Refresh(), jc.ErrorIsNil)
+	c.Assert(model2.Life(), gc.Equals, state.Dead)
+	err = st2.RemoveAllModelDocs()
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Assert(s.State.ProcessDyingModel(), jc.ErrorIsNil)
+	c.Assert(model.Refresh(), jc.ErrorIsNil)
+	c.Assert(model2.Life(), gc.Equals, state.Dead)
+}
+
+func (s *CAASModelSuite) TestDestroyControllerAndHostedCAASModelsWithResources(c *gc.C) {
+	s.SetFeatureFlags(feature.CAAS)
+	otherSt := s.Factory.MakeModel(c, &factory.ModelParams{
+		Type: state.ModelTypeCAAS, CloudRegion: "<none>", StorageProviderRegistry: factory.NilStorageProviderRegistry{}})
+	defer otherSt.Close()
+
+	assertModel := func(model *state.Model, st *state.State, life state.Life, expectedApps int) {
+		c.Assert(model.Refresh(), jc.ErrorIsNil)
+		c.Assert(model.Life(), gc.Equals, life)
+
+		apps, err := st.AllApplications()
+		c.Assert(err, jc.ErrorIsNil)
+		c.Assert(apps, gc.HasLen, expectedApps)
+	}
+
+	// add some applications
+	otherModel, err := otherSt.Model()
+	c.Assert(err, jc.ErrorIsNil)
+	service := s.Factory.MakeApplication(c, nil)
+	ch, _, err := service.Charm()
+	c.Assert(err, jc.ErrorIsNil)
+
+	args := state.AddApplicationArgs{
+		Name:  service.Name(),
+		Charm: ch,
+	}
+	service, err = otherSt.AddApplication(args)
+	c.Assert(err, jc.ErrorIsNil)
+
+	controllerModel, err := s.State.Model()
+	c.Assert(err, jc.ErrorIsNil)
+	destroyStorage := true
+	c.Assert(controllerModel.Destroy(state.DestroyModelParams{
+		DestroyHostedModels: true,
+		DestroyStorage:      &destroyStorage,
+	}), jc.ErrorIsNil)
+
+	assertCleanupCount(c, s.State, 2)
+	assertAllMachinesDeadAndRemove(c, s.State)
+	assertModel(controllerModel, s.State, state.Dying, 0)
+
+	err = s.State.ProcessDyingModel()
+	c.Assert(err, jc.Satisfies, state.IsHasHostedModelsError)
+	c.Assert(err, gc.ErrorMatches, `hosting 1 other model`)
+
+	assertCleanupCount(c, otherSt, 2)
+	assertModel(otherModel, otherSt, state.Dying, 0)
+	c.Assert(otherSt.ProcessDyingModel(), jc.ErrorIsNil)
+
+	c.Assert(otherModel.Refresh(), jc.ErrorIsNil)
+	c.Assert(otherModel.Life(), gc.Equals, state.Dead)
+
+	// Until the model is removed, we can't mark the controller model Dead.
+	err = s.State.ProcessDyingModel()
+	c.Assert(err, gc.ErrorMatches, `hosting 1 other model`)
+
+	err = otherSt.RemoveAllModelDocs()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(s.State.ProcessDyingModel(), jc.ErrorIsNil)
+	c.Assert(controllerModel.Refresh(), jc.ErrorIsNil)
+	c.Assert(controllerModel.Life(), gc.Equals, state.Dead)
+}

--- a/state/model_test.go
+++ b/state/model_test.go
@@ -18,7 +18,6 @@ import (
 	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/core/crossmodel"
 	"github.com/juju/juju/environs/config"
-	"github.com/juju/juju/feature"
 	"github.com/juju/juju/permission"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/storage"
@@ -202,71 +201,6 @@ func (s *ModelSuite) TestNewModel(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 }
 
-func (s *ModelSuite) TestNewModelCAAS(c *gc.C) {
-	s.SetFeatureFlags(feature.CAAS)
-
-	cfg, uuid := s.createTestModelConfig(c)
-	modelTag := names.NewModelTag(uuid)
-	owner := names.NewUserTag("test@remote")
-	model, st, err := s.State.NewModel(state.ModelArgs{
-		Type:      state.ModelTypeCAAS,
-		CloudName: "dummy",
-		Config:    cfg,
-		Owner:     owner,
-	})
-	c.Assert(err, jc.ErrorIsNil)
-	defer st.Close()
-
-	c.Assert(model.Type(), gc.Equals, state.ModelTypeCAAS)
-	c.Assert(model.UUID(), gc.Equals, modelTag.Id())
-	c.Assert(model.Tag(), gc.Equals, modelTag)
-	c.Assert(model.ControllerTag(), gc.Equals, s.State.ControllerTag())
-	c.Assert(model.Owner(), gc.Equals, owner)
-	c.Assert(model.Name(), gc.Equals, "testing")
-	c.Assert(model.Life(), gc.Equals, state.Alive)
-	c.Assert(model.CloudRegion(), gc.Equals, "")
-}
-
-func (s *ModelSuite) TestCAASModelsCantHaveCloudRegion(c *gc.C) {
-	s.SetFeatureFlags(feature.CAAS)
-	cfg, _ := s.createTestModelConfig(c)
-	_, _, err := s.State.NewModel(state.ModelArgs{
-		Type:        state.ModelTypeCAAS,
-		CloudName:   "dummy",
-		CloudRegion: "fork",
-		Config:      cfg,
-		Owner:       names.NewUserTag("test@remote"),
-	})
-	c.Assert(err, gc.ErrorMatches, "CAAS model with CloudRegion not supported")
-}
-
-func (s *ModelSuite) TestNewModelCAASNeedsFeature(c *gc.C) {
-	cfg, _ := s.createTestModelConfig(c)
-	owner := names.NewUserTag("test@remote")
-	_, _, err := s.State.NewModel(state.ModelArgs{
-		Type:      state.ModelTypeCAAS,
-		CloudName: "dummy",
-		Config:    cfg,
-		Owner:     owner,
-	})
-	c.Assert(err, gc.ErrorMatches, "model type not supported")
-}
-
-func (s *ModelSuite) TestNewModelCAASWithStorageRegistry(c *gc.C) {
-	s.SetFeatureFlags(feature.CAAS)
-
-	cfg, _ := s.createTestModelConfig(c)
-	owner := names.NewUserTag("test@remote")
-	_, _, err := s.State.NewModel(state.ModelArgs{
-		Type:      state.ModelTypeCAAS,
-		CloudName: "dummy",
-		Config:    cfg,
-		Owner:     owner,
-		StorageProviderRegistry: storage.StaticProviderRegistry{},
-	})
-	c.Assert(err, gc.ErrorMatches, "CAAS model with StorageProviderRegistry not valid")
-}
-
 func (s *ModelSuite) TestNewModelImportingMode(c *gc.C) {
 	cfg, _ := s.createTestModelConfig(c)
 	owner := names.NewUserTag("test@remote")
@@ -319,13 +253,14 @@ func (s *ModelSuite) TestModelExistsNoModel(c *gc.C) {
 }
 
 func (s *ModelSuite) TestModelActive(c *gc.C) {
-	modelActive, err := s.State.ModelActive(s.State.ModelUUID())
+	modelActive, modelType, err := s.State.ModelActive(s.State.ModelUUID())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(modelActive, jc.IsTrue)
+	c.Assert(modelType, gc.Equals, state.ModelTypeIAAS)
 }
 
 func (s *ModelSuite) TestModelActiveNoModel(c *gc.C) {
-	modelActive, err := s.State.ModelActive("foo")
+	modelActive, _, err := s.State.ModelActive("foo")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(modelActive, jc.IsFalse)
 }
@@ -337,7 +272,7 @@ func (s *ModelSuite) TestModelActiveImporting(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(model.SetMigrationMode(state.MigrationModeImporting), jc.ErrorIsNil)
 
-	modelActive, err := s.State.ModelActive(model.UUID())
+	modelActive, _, err := s.State.ModelActive(model.UUID())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(modelActive, jc.IsFalse)
 }
@@ -349,9 +284,10 @@ func (s *ModelSuite) TestModelActiveExporting(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(model.SetMigrationMode(state.MigrationModeExporting), jc.ErrorIsNil)
 
-	modelActive, err := s.State.ModelActive(model.UUID())
+	modelActive, modelType, err := s.State.ModelActive(model.UUID())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(modelActive, jc.IsTrue)
+	c.Assert(modelType, gc.Equals, state.ModelTypeIAAS)
 }
 
 func (s *ModelSuite) TestSLA(c *gc.C) {

--- a/state/state.go
+++ b/state/state.go
@@ -1060,139 +1060,19 @@ func (st *State) AddApplication(args AddApplicationArgs) (_ *Application, err er
 	if args.Storage == nil {
 		args.Storage = make(map[string]StorageConstraints)
 	}
-	im, err := st.IAASModel()
+
+	// Perform model specific arg processing.
+	model, err := st.Model()
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	if err := addDefaultStorageConstraints(im, args.Storage, args.Charm.Meta()); err != nil {
-		return nil, errors.Trace(err)
-	}
-	if err := validateStorageConstraints(im, args.Storage, args.Charm.Meta()); err != nil {
-		return nil, errors.Trace(err)
-	}
-	storagePools := make(set.Strings)
-	for _, storageParams := range args.Storage {
-		storagePools.Add(storageParams.Pool)
-	}
-
-	if args.Series == "" {
-		// args.Series is not set, so use the series in the URL.
-		args.Series = args.Charm.URL().Series
-		if args.Series == "" {
-			// Should not happen, but just in case.
-			return nil, errors.New("series is empty")
-		}
-	} else {
-		// User has specified series. Overriding supported series is
-		// handled by the client, so args.Series is not necessarily
-		// one of the charm's supported series. We require that the
-		// specified series is of the same operating system as one of
-		// the supported series. For old-style charms with the series
-		// in the URL, that series is the one and only supported
-		// series.
-		var supportedSeries []string
-		if series := args.Charm.URL().Series; series != "" {
-			supportedSeries = []string{series}
-		} else {
-			supportedSeries = args.Charm.Meta().Series
-		}
-		if len(supportedSeries) > 0 {
-			seriesOS, err := series.GetOSFromSeries(args.Series)
-			if err != nil {
-				return nil, errors.Trace(err)
-			}
-			supportedOperatingSystems := make(map[os.OSType]bool)
-			for _, supportedSeries := range supportedSeries {
-				os, err := series.GetOSFromSeries(supportedSeries)
-				if err != nil {
-					return nil, errors.Trace(err)
-				}
-				supportedOperatingSystems[os] = true
-			}
-			if !supportedOperatingSystems[seriesOS] {
-				return nil, errors.NewNotSupported(errors.Errorf(
-					"series %q (OS %q) not supported by charm, supported series are %q",
-					args.Series, seriesOS, strings.Join(supportedSeries, ", "),
-				), "")
-			}
-		}
-	}
-
-	// Ignore constraints that result from this call as
-	// these would be accumulation of model and application constraints
-	// but we only want application constraints to be persisted here.
-	_, err = st.resolveConstraints(args.Constraints)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-
-	for _, placement := range args.Placement {
-		data, err := st.parsePlacement(placement)
-		if err != nil {
+	if model.Type() == ModelTypeIAAS {
+		if err := st.processIAASModelApplicationArgs(&args); err != nil {
 			return nil, errors.Trace(err)
 		}
-		switch data.placementType() {
-		case machinePlacement:
-			// Ensure that the machine and charm series match.
-			m, err := st.Machine(data.machineId)
-			if err != nil {
-				return nil, errors.Trace(err)
-			}
-			subordinate := args.Charm.Meta().Subordinate
-			if err := validateUnitMachineAssignment(
-				m, args.Series, subordinate, storagePools,
-			); err != nil {
-				return nil, errors.Annotatef(
-					err, "cannot deploy to machine %s", m,
-				)
-			}
-
-		case directivePlacement:
-			// Obtain volume attachment params corresponding to storage being
-			// attached. We need to pass them along to precheckInstance, in
-			// case the volumes cannot be attached to a machine with the given
-			// placement directive.
-			im, err := st.IAASModel()
-			if err != nil {
-				return nil, errors.Trace(err)
-			}
-			volumeAttachments := make([]storage.VolumeAttachmentParams, 0, len(args.AttachStorage))
-			for _, storageTag := range args.AttachStorage {
-				v, err := im.StorageInstanceVolume(storageTag)
-				if errors.IsNotFound(err) {
-					continue
-				} else if err != nil {
-					return nil, errors.Trace(err)
-				}
-				volumeInfo, err := v.Info()
-				if err != nil {
-					// Volume has not been provisioned yet,
-					// so it cannot be attached.
-					continue
-				}
-				providerType, _, err := poolStorageProvider(im, volumeInfo.Pool)
-				if err != nil {
-					return nil, errors.Annotatef(err, "cannot attach %s", names.ReadableString(storageTag))
-				}
-				storageName, _ := names.StorageName(storageTag.Id())
-				volumeAttachments = append(volumeAttachments, storage.VolumeAttachmentParams{
-					AttachmentParams: storage.AttachmentParams{
-						Provider: providerType,
-						ReadOnly: args.Charm.Meta().Storage[storageName].ReadOnly,
-					},
-					Volume:   v.VolumeTag(),
-					VolumeId: volumeInfo.VolumeId,
-				})
-			}
-			if err := st.precheckInstance(
-				args.Series,
-				args.Constraints,
-				data.directive,
-				volumeAttachments,
-			); err != nil {
-				return nil, errors.Trace(err)
-			}
-		}
+	} else {
+		// TODO(caas) - remove once units are supported.
+		args.NumUnits = 0
 	}
 
 	applicationID := st.docID(args.Name)
@@ -1331,6 +1211,144 @@ func (st *State) AddApplication(args AddApplicationArgs) (_ *Application, err er
 		return app, nil
 	}
 	return nil, errors.Trace(err)
+}
+
+func (st *State) processIAASModelApplicationArgs(args *AddApplicationArgs) error {
+	im, err := st.IAASModel()
+	if err != nil {
+		return errors.Trace(err)
+	}
+	if err := addDefaultStorageConstraints(im, args.Storage, args.Charm.Meta()); err != nil {
+		return errors.Trace(err)
+	}
+	if err := validateStorageConstraints(im, args.Storage, args.Charm.Meta()); err != nil {
+		return errors.Trace(err)
+	}
+	storagePools := make(set.Strings)
+	for _, storageParams := range args.Storage {
+		storagePools.Add(storageParams.Pool)
+	}
+
+	if args.Series == "" {
+		// args.Series is not set, so use the series in the URL.
+		args.Series = args.Charm.URL().Series
+		if args.Series == "" {
+			// Should not happen, but just in case.
+			return errors.New("series is empty")
+		}
+	} else {
+		// User has specified series. Overriding supported series is
+		// handled by the client, so args.Series is not necessarily
+		// one of the charm's supported series. We require that the
+		// specified series is of the same operating system as one of
+		// the supported series. For old-style charms with the series
+		// in the URL, that series is the one and only supported
+		// series.
+		var supportedSeries []string
+		if series := args.Charm.URL().Series; series != "" {
+			supportedSeries = []string{series}
+		} else {
+			supportedSeries = args.Charm.Meta().Series
+		}
+		if len(supportedSeries) > 0 {
+			seriesOS, err := series.GetOSFromSeries(args.Series)
+			if err != nil {
+				return errors.Trace(err)
+			}
+			supportedOperatingSystems := make(map[os.OSType]bool)
+			for _, supportedSeries := range supportedSeries {
+				os, err := series.GetOSFromSeries(supportedSeries)
+				if err != nil {
+					return errors.Trace(err)
+				}
+				supportedOperatingSystems[os] = true
+			}
+			if !supportedOperatingSystems[seriesOS] {
+				return errors.NewNotSupported(errors.Errorf(
+					"series %q (OS %q) not supported by charm, supported series are %q",
+					args.Series, seriesOS, strings.Join(supportedSeries, ", "),
+				), "")
+			}
+		}
+	}
+
+	// Ignore constraints that result from this call as
+	// these would be accumulation of model and application constraints
+	// but we only want application constraints to be persisted here.
+	_, err = st.resolveConstraints(args.Constraints)
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	for _, placement := range args.Placement {
+		data, err := st.parsePlacement(placement)
+		if err != nil {
+			return errors.Trace(err)
+		}
+		switch data.placementType() {
+		case machinePlacement:
+			// Ensure that the machine and charm series match.
+			m, err := st.Machine(data.machineId)
+			if err != nil {
+				return errors.Trace(err)
+			}
+			subordinate := args.Charm.Meta().Subordinate
+			if err := validateUnitMachineAssignment(
+				m, args.Series, subordinate, storagePools,
+			); err != nil {
+				return errors.Annotatef(
+					err, "cannot deploy to machine %s", m,
+				)
+			}
+
+		case directivePlacement:
+			// Obtain volume attachment params corresponding to storage being
+			// attached. We need to pass them along to precheckInstance, in
+			// case the volumes cannot be attached to a machine with the given
+			// placement directive.
+			im, err := st.IAASModel()
+			if err != nil {
+				return errors.Trace(err)
+			}
+			volumeAttachments := make([]storage.VolumeAttachmentParams, 0, len(args.AttachStorage))
+			for _, storageTag := range args.AttachStorage {
+				v, err := im.StorageInstanceVolume(storageTag)
+				if errors.IsNotFound(err) {
+					continue
+				} else if err != nil {
+					return errors.Trace(err)
+				}
+				volumeInfo, err := v.Info()
+				if err != nil {
+					// Volume has not been provisioned yet,
+					// so it cannot be attached.
+					continue
+				}
+				providerType, _, err := poolStorageProvider(im, volumeInfo.Pool)
+				if err != nil {
+					return errors.Annotatef(err, "cannot attach %s", names.ReadableString(storageTag))
+				}
+				storageName, _ := names.StorageName(storageTag.Id())
+				volumeAttachments = append(volumeAttachments, storage.VolumeAttachmentParams{
+					AttachmentParams: storage.AttachmentParams{
+						Provider: providerType,
+						ReadOnly: args.Charm.Meta().Storage[storageName].ReadOnly,
+					},
+					Volume:   v.VolumeTag(),
+					VolumeId: volumeInfo.VolumeId,
+				})
+			}
+			if err := st.precheckInstance(
+				args.Series,
+				args.Constraints,
+				data.directive,
+				volumeAttachments,
+			); err != nil {
+				return errors.Trace(err)
+			}
+		}
+	}
+	return nil
 }
 
 // removeNils removes any keys with nil values from the given map.

--- a/testing/factory/factory.go
+++ b/testing/factory/factory.go
@@ -613,6 +613,12 @@ func (factory *Factory) MakeRelation(c *gc.C, params *RelationParams) *state.Rel
 	return relation
 }
 
+// NilStorageProviderRegistry is used to specify a model
+// should be created with a nil storage.ProviderRegistry.
+type NilStorageProviderRegistry struct {
+	storage.ProviderRegistry
+}
+
 // MakeModel creates an model with specified params,
 // filling in sane defaults for missing values. If params is nil,
 // defaults are used for all values.
@@ -636,6 +642,9 @@ func (factory *Factory) MakeModel(c *gc.C, params *ModelParams) *state.State {
 	if params.CloudRegion == "" {
 		params.CloudRegion = "dummy-region"
 	}
+	if params.CloudRegion == "<none>" {
+		params.CloudRegion = ""
+	}
 	if params.Owner == nil {
 		origEnv, err := factory.st.Model()
 		c.Assert(err, jc.ErrorIsNil)
@@ -643,6 +652,10 @@ func (factory *Factory) MakeModel(c *gc.C, params *ModelParams) *state.State {
 	}
 	if params.StorageProviderRegistry == nil {
 		params.StorageProviderRegistry = provider.CommonStorageProviders()
+	}
+	nilRegistry := NilStorageProviderRegistry{}
+	if params.StorageProviderRegistry == nilRegistry {
+		params.StorageProviderRegistry = nil
 	}
 	// It only makes sense to make an model with the same provider
 	// as the initial model, or things will break elsewhere.

--- a/worker/caasprovisioner/k8s.go
+++ b/worker/caasprovisioner/k8s.go
@@ -1,0 +1,175 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package caasprovisioner
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/juju/agent"
+	"gopkg.in/juju/names.v2"
+	"k8s.io/client-go/kubernetes"
+	k8serrors "k8s.io/client-go/pkg/api/errors"
+	"k8s.io/client-go/pkg/api/v1"
+	"k8s.io/client-go/rest"
+)
+
+// TODO(caas) should be using a juju specific namespace
+const namespace = "default"
+
+type kubernetesClient struct {
+	*kubernetes.Clientset
+}
+
+func newK8sClient(facade CAASProvisionerFacade) (CAASClient, error) {
+	config, err := newK8sConfig(facade)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	client, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return &kubernetesClient{client}, nil
+}
+
+func newK8sConfig(facade CAASProvisionerFacade) (*rest.Config, error) {
+	config, err := facade.ConnectionConfig()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	var CAData []byte
+	for _, cacert := range config.CACertificates {
+		CAData = append(CAData, cacert...)
+	}
+
+	return &rest.Config{
+		Host:     config.Endpoint,
+		Username: config.Username,
+		Password: config.Password,
+		TLSClientConfig: rest.TLSClientConfig{
+			CertData: config.CertData,
+			KeyData:  config.KeyData,
+			CAData:   CAData,
+		},
+	}, nil
+}
+
+// EnsureOperator creates a new operator for appName if it doesn't exist.
+func (k *kubernetesClient) EnsureOperator(appName, agentPath string, newConfig NewOperatorConfigFunc) error {
+	if exists, err := k.operatorExists(appName); err != nil {
+		return errors.Trace(err)
+	} else if exists {
+		logger.Debugf("%s operator already deployed", appName)
+		return nil
+	}
+	logger.Infof("deploying %s operator", appName)
+
+	configMapName, err := k.ensureConfigMap(appName, newConfig)
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	return k.deployOperator(appName, agentPath, configMapName)
+}
+
+func (k *kubernetesClient) ensureConfigMap(appName string, newConfig NewOperatorConfigFunc) (string, error) {
+	mapName := podName(appName) + "-config"
+
+	exists, err := k.configMapExists(mapName)
+	if err != nil {
+		return "", errors.Trace(err)
+	}
+	if exists {
+		logger.Infof("ConfigMap %s already exists", mapName)
+	} else {
+		config, err := newConfig(appName)
+		if err != nil {
+			return "", errors.Annotate(err, "creating config")
+		}
+		if err := k.createConfigMap(mapName, config); err != nil {
+			return "", errors.Annotate(err, "creating ConfigMap")
+		}
+	}
+	return mapName, nil
+}
+
+func (k *kubernetesClient) configMapExists(configMapName string) (bool, error) {
+	_, err := k.CoreV1().ConfigMaps(namespace).Get(configMapName)
+	if k8serrors.IsNotFound(err) {
+		return false, nil
+	} else if err != nil {
+		return false, errors.Trace(err)
+	}
+	return true, nil
+}
+
+func (k *kubernetesClient) createConfigMap(configMapName string, config []byte) error {
+	_, err := k.CoreV1().ConfigMaps(namespace).Create(&v1.ConfigMap{
+		ObjectMeta: v1.ObjectMeta{
+			Name: configMapName,
+		},
+		Data: map[string]string{
+			"agent.conf": string(config),
+		},
+	})
+	return errors.Trace(err)
+}
+
+func (k *kubernetesClient) operatorExists(appName string) (bool, error) {
+	_, err := k.CoreV1().Pods(namespace).Get(podName(appName))
+	if k8serrors.IsNotFound(err) {
+		return false, nil
+	} else if err != nil {
+		return false, errors.Trace(err)
+	}
+	return true, nil
+}
+
+func (k *kubernetesClient) deployOperator(appName, agentPath string, configMapName string) error {
+	configVolName := configMapName + "-volume"
+
+	appTag := names.NewApplicationTag(appName)
+	spec := &v1.Pod{
+		ObjectMeta: v1.ObjectMeta{
+			Name: podName(appName),
+		},
+		Spec: v1.PodSpec{
+			Containers: []v1.Container{{
+				Name:            "juju-operator",
+				ImagePullPolicy: v1.PullIfNotPresent,
+				// TODO(caas) use proper image
+				Image:   "ubuntu:16.04",
+				Command: []string{"sleep"},
+				Args:    []string{"infinity"},
+				//Args:    []string{"caasoperator", "--application-name", appName, "--debug"},
+
+				VolumeMounts: []v1.VolumeMount{{
+					Name:      configVolName,
+					MountPath: agent.Dir(agentPath, appTag) + "/agent.conf",
+					SubPath:   "agent.conf",
+				}},
+			}},
+			Volumes: []v1.Volume{{
+				Name: configVolName,
+				VolumeSource: v1.VolumeSource{
+					ConfigMap: &v1.ConfigMapVolumeSource{
+						LocalObjectReference: v1.LocalObjectReference{
+							Name: configMapName,
+						},
+						Items: []v1.KeyToPath{{
+							Key:  "agent.conf",
+							Path: "agent.conf",
+						}},
+					},
+				},
+			}},
+		},
+	}
+	_, err := k.CoreV1().Pods(namespace).Create(spec)
+	return errors.Trace(err)
+}
+
+func podName(appName string) string {
+	return "juju-operator-" + appName
+}

--- a/worker/caasprovisioner/manifold.go
+++ b/worker/caasprovisioner/manifold.go
@@ -1,0 +1,78 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package caasprovisioner
+
+import (
+	"github.com/juju/errors"
+	"gopkg.in/juju/names.v2"
+	"gopkg.in/juju/worker.v1"
+
+	"github.com/juju/juju/agent"
+	"github.com/juju/juju/api/base"
+	apicaasprovisioner "github.com/juju/juju/api/caasprovisioner"
+	"github.com/juju/juju/worker/dependency"
+)
+
+// ManifoldConfig defines a CAAS environment provisioner's dependencies.
+type ManifoldConfig struct {
+	AgentName     string
+	APICallerName string
+	// TODO(caas) - add cloud type, fetched from cloud attr eg "kubernetes"
+
+	NewWorker func(CAASProvisionerFacade, NewCAASClientFunc, names.ModelTag, agent.Config) (worker.Worker, error)
+}
+
+// Validate is called by start to check for bad configuration.
+func (config ManifoldConfig) Validate() error {
+	if config.AgentName == "" {
+		return errors.NotValidf("empty AgentName")
+	}
+	if config.APICallerName == "" {
+		return errors.NotValidf("empty APICallerName")
+	}
+	if config.NewWorker == nil {
+		return errors.NotValidf("nil NewWorker")
+	}
+	return nil
+}
+
+func (config ManifoldConfig) start(context dependency.Context) (worker.Worker, error) {
+	if err := config.Validate(); err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	var agent agent.Agent
+	if err := context.Get(config.AgentName, &agent); err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	var apiCaller base.APICaller
+	if err := context.Get(config.APICallerName, &apiCaller); err != nil {
+		return nil, errors.Trace(err)
+	}
+	modelTag, ok := apiCaller.ModelTag()
+	if !ok {
+		return nil, errors.New("API connection is controller-only (should never happen)")
+	}
+
+	api := apicaasprovisioner.NewClient(apiCaller)
+	agentConfig := agent.CurrentConfig()
+	w, err := config.NewWorker(api, newCAASClient, modelTag, agentConfig)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return w, nil
+}
+
+// Manifold creates a manifold that runs a CAAS provisioner. See the
+// ManifoldConfig type for discussion about how this can/should evolve.
+func Manifold(config ManifoldConfig) dependency.Manifold {
+	return dependency.Manifold{
+		Inputs: []string{
+			config.AgentName,
+			config.APICallerName,
+		},
+		Start: config.start,
+	}
+}

--- a/worker/caasprovisioner/manifold_test.go
+++ b/worker/caasprovisioner/manifold_test.go
@@ -1,0 +1,63 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package caasprovisioner_test
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/names.v2"
+	"gopkg.in/juju/worker.v1"
+
+	"github.com/juju/juju/agent"
+	"github.com/juju/juju/worker/caasprovisioner"
+)
+
+type ManifoldConfigSuite struct {
+	testing.IsolationSuite
+	config caasprovisioner.ManifoldConfig
+}
+
+var _ = gc.Suite(&ManifoldConfigSuite{})
+
+func (s *ManifoldConfigSuite) SetUpTest(c *gc.C) {
+	s.IsolationSuite.SetUpTest(c)
+	s.config = s.validConfig()
+}
+
+func (s *ManifoldConfigSuite) validConfig() caasprovisioner.ManifoldConfig {
+	return caasprovisioner.ManifoldConfig{
+		AgentName:     "agent",
+		APICallerName: "api-caller",
+		NewWorker: func(caasprovisioner.CAASProvisionerFacade, caasprovisioner.NewCAASClientFunc, names.ModelTag, agent.Config) (worker.Worker, error) {
+			return nil, nil
+		},
+	}
+}
+
+func (s *ManifoldConfigSuite) TestValid(c *gc.C) {
+	c.Check(s.config.Validate(), jc.ErrorIsNil)
+}
+
+func (s *ManifoldConfigSuite) TestMissingAgentName(c *gc.C) {
+	s.config.AgentName = ""
+	s.checkNotValid(c, "empty AgentName not valid")
+}
+
+func (s *ManifoldConfigSuite) TestMissingAPICallerName(c *gc.C) {
+	s.config.APICallerName = ""
+	s.checkNotValid(c, "empty APICallerName not valid")
+}
+
+func (s *ManifoldConfigSuite) TestMissingNewWorker(c *gc.C) {
+	s.config.NewWorker = nil
+	s.checkNotValid(c, "nil NewWorker not valid")
+}
+
+func (s *ManifoldConfigSuite) checkNotValid(c *gc.C, expect string) {
+	err := s.config.Validate()
+	c.Check(err, gc.ErrorMatches, expect)
+	c.Check(err, jc.Satisfies, errors.IsNotValid)
+}

--- a/worker/caasprovisioner/mock_test.go
+++ b/worker/caasprovisioner/mock_test.go
@@ -1,0 +1,151 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package caasprovisioner_test
+
+import (
+	"sync"
+
+	"github.com/juju/testing"
+	"gopkg.in/juju/names.v2"
+	"gopkg.in/tomb.v1"
+
+	"github.com/juju/juju/agent"
+	apicaasprovisioner "github.com/juju/juju/api/caasprovisioner"
+	coretesting "github.com/juju/juju/testing"
+	"github.com/juju/juju/watcher"
+	"github.com/juju/juju/worker/caasprovisioner"
+)
+
+type mockProvisionerFacade struct {
+	mu   sync.Mutex
+	stub *testing.Stub
+	caasprovisioner.CAASProvisionerFacade
+	applicationsWatcher *mockStringsWatcher
+}
+
+func newMockProvisionerFacade(stub *testing.Stub) *mockProvisionerFacade {
+	return &mockProvisionerFacade{
+		stub:                stub,
+		applicationsWatcher: newMockStringsWatcher(),
+	}
+}
+
+func (m *mockProvisionerFacade) WatchApplications() (watcher.StringsWatcher, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.stub.MethodCall(m, "WatchApplications")
+	if err := m.stub.NextErr(); err != nil {
+		return nil, err
+	}
+	return m.applicationsWatcher, nil
+}
+
+func (m *mockProvisionerFacade) ConnectionConfig() (*apicaasprovisioner.ConnectionConfig, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.stub.MethodCall(m, "ConnectionConfig")
+	if err := m.stub.NextErr(); err != nil {
+		return nil, err
+	}
+	return &apicaasprovisioner.ConnectionConfig{
+		Username: "fred",
+		Password: "password",
+	}, nil
+}
+
+type mockAgentConfig struct {
+	agent.Config
+}
+
+func (m *mockAgentConfig) Controller() names.ControllerTag {
+	return coretesting.ControllerTag
+}
+
+func (m *mockAgentConfig) DataDir() string {
+	return "/var/lib/juju"
+}
+
+func (m *mockAgentConfig) LogDir() string {
+	return "/var/log/juju"
+}
+
+func (m *mockAgentConfig) OldPassword() string {
+	return "old password"
+}
+
+func (m *mockAgentConfig) CACert() string {
+	return coretesting.CACert
+}
+
+func (m *mockAgentConfig) APIAddresses() ([]string, error) {
+	return []string{"10.0.0.1:17070"}, nil
+}
+
+type mockCAASClient struct {
+	connectionConfig *apicaasprovisioner.ConnectionConfig
+	appName          string
+	agentPath        string
+	agentConfig      string
+}
+
+func (m *mockCAASClient) EnsureOperator(appName, agentPath string, newConfig caasprovisioner.NewOperatorConfigFunc) error {
+	m.appName = appName
+	m.agentPath = agentPath
+	agentCfg, err := newConfig(appName)
+	if err != nil {
+		return err
+	}
+	m.agentConfig = string(agentCfg)
+	return nil
+}
+
+type mockWatcher struct {
+	testing.Stub
+	tomb.Tomb
+	mu         sync.Mutex
+	terminated bool
+}
+
+func (w *mockWatcher) doneWhenDying() {
+	<-w.Tomb.Dying()
+	w.Tomb.Done()
+}
+
+func (w *mockWatcher) killed() bool {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.terminated
+}
+
+func (w *mockWatcher) Kill() {
+	w.MethodCall(w, "Kill")
+	w.Tomb.Kill(nil)
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.terminated = true
+}
+
+func (w *mockWatcher) Stop() error {
+	w.MethodCall(w, "Stop")
+	if err := w.NextErr(); err != nil {
+		return err
+	}
+	w.Tomb.Kill(nil)
+	return w.Tomb.Wait()
+}
+
+type mockStringsWatcher struct {
+	mockWatcher
+	changes chan []string
+}
+
+func newMockStringsWatcher() *mockStringsWatcher {
+	w := &mockStringsWatcher{changes: make(chan []string, 5)}
+	go w.doneWhenDying()
+	return w
+}
+
+func (w *mockStringsWatcher) Changes() watcher.StringsChannel {
+	return w.changes
+}

--- a/worker/caasprovisioner/package_test.go
+++ b/worker/caasprovisioner/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package caasprovisioner_test
+
+import (
+	stdtesting "testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func TestPackage(t *stdtesting.T) {
+	gc.TestingT(t)
+}

--- a/worker/caasprovisioner/worker.go
+++ b/worker/caasprovisioner/worker.go
@@ -1,0 +1,161 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package caasprovisioner
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/juju/watcher"
+	"github.com/juju/loggo"
+	"gopkg.in/juju/names.v2"
+	"gopkg.in/juju/worker.v1"
+
+	"github.com/juju/juju/agent"
+	apicaasprovisioner "github.com/juju/juju/api/caasprovisioner"
+	"github.com/juju/juju/version"
+	"github.com/juju/juju/worker/catacomb"
+)
+
+var logger = loggo.GetLogger("juju.workers.caasprovisioner")
+
+// CAASProvisionerFacade exposes CAAS provisioning functionality to a worker.
+type CAASProvisionerFacade interface {
+	WatchApplications() (watcher.StringsWatcher, error)
+	ConnectionConfig() (*apicaasprovisioner.ConnectionConfig, error)
+}
+
+// CAASClient instances are used to control the CAAS cloud.
+type CAASClient interface {
+	EnsureOperator(appName, agentPath string, newConfig NewOperatorConfigFunc) error
+}
+
+// NewOperatorConfigFunc functions return the agent config to use for
+// a CAAS jujud operator.
+type NewOperatorConfigFunc func(appName string) ([]byte, error)
+
+// NewCAASClientFunc functions return a client used to control the CAAS cloud.
+type NewCAASClientFunc func(f CAASProvisionerFacade) (CAASClient, error)
+
+// NewProvisionerWorker starts and returns a new CAAS provisioner worker.
+func NewProvisionerWorker(
+	facade CAASProvisionerFacade,
+	newCAASClient NewCAASClientFunc,
+	modelTag names.ModelTag,
+	agentConfig agent.Config,
+) (worker.Worker, error) {
+	p := &provisioner{
+		provisionerFacade: facade,
+		newCAASClientFunc: newCAASClient,
+		modelTag:          modelTag,
+		agentConfig:       agentConfig,
+	}
+	err := catacomb.Invoke(catacomb.Plan{
+		Site: &p.catacomb,
+		Work: p.loop,
+	})
+	return p, err
+}
+
+// newCAASClient creates a new client object to talk to the CAAS cloud.
+func newCAASClient(f CAASProvisionerFacade) (CAASClient, error) {
+	// TODO(caas) - abstract out kubernetes specific functionality
+	return newK8sClient(f)
+}
+
+type provisioner struct {
+	catacomb          catacomb.Catacomb
+	provisionerFacade CAASProvisionerFacade
+	newCAASClientFunc func(f CAASProvisionerFacade) (CAASClient, error)
+
+	modelTag    names.ModelTag
+	agentConfig agent.Config
+}
+
+// Kill is part of the worker.Worker interface.
+func (p *provisioner) Kill() {
+	p.catacomb.Kill(nil)
+}
+
+// Wait is part of the worker.Worker interface.
+func (p *provisioner) Wait() error {
+	return p.catacomb.Wait()
+}
+
+func (p *provisioner) loop() error {
+	client, err := p.newCAASClientFunc(p.provisionerFacade)
+	if err != nil {
+		return errors.Annotate(err, "creating k8s client")
+	}
+
+	newConfig := func(appName string) ([]byte, error) {
+		return p.newOperatorConfig(appName)
+	}
+
+	// TODO(caas) -  this loop should also keep an eye on kubernetes and ensure
+	// that the operator stays up, redeploying it if the pod goes
+	// away. For some runtimes we *could* rely on the the runtime's
+	// features to do this.
+
+	// TODO(caas) - add watcher for cloud credential changes, create new client
+
+	w, err := p.provisionerFacade.WatchApplications()
+	if err != nil {
+		return errors.Trace(err)
+	}
+	if err := p.catacomb.Add(w); err != nil {
+		return errors.Trace(err)
+	}
+
+	for {
+		select {
+		case <-p.catacomb.Dying():
+			return p.catacomb.ErrDying()
+		case apps, ok := <-w.Changes():
+			if !ok {
+				return errors.New("watcher closed channel")
+			}
+			for _, app := range apps {
+				logger.Debugf("Received change notification for app: %s", app)
+				if err := client.EnsureOperator(app, p.agentConfig.DataDir(), newConfig); err != nil {
+					return errors.Annotatef(err, "failed to start operator for %q", app)
+				}
+			}
+		}
+	}
+}
+
+func (p *provisioner) newOperatorConfig(appName string) ([]byte, error) {
+	appTag := names.NewApplicationTag(appName)
+
+	// TODO(caas) - restart operator when api addresses change
+	apiAddrs, err := p.agentConfig.APIAddresses()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	conf, err := agent.NewAgentConfig(
+		agent.AgentConfigParams{
+			Paths: agent.Paths{
+				DataDir: p.agentConfig.DataDir(),
+				LogDir:  p.agentConfig.LogDir(),
+			},
+			// This isn't actually used but needs to be supplied.
+			UpgradedToVersion: version.Current,
+			Tag:               appTag,
+			Password:          p.agentConfig.OldPassword(),
+			Controller:        p.agentConfig.Controller(),
+			Model:             p.modelTag,
+			APIAddresses:      apiAddrs,
+			CACert:            p.agentConfig.CACert(),
+		},
+	)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	confBytes, err := conf.Render()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return confBytes, nil
+}

--- a/worker/caasprovisioner/worker_test.go
+++ b/worker/caasprovisioner/worker_test.go
@@ -1,0 +1,115 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package caasprovisioner_test
+
+import (
+	"io/ioutil"
+	"path/filepath"
+	"reflect"
+
+	jujutesting "github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/names.v2"
+	"gopkg.in/juju/worker.v1"
+
+	"github.com/juju/juju/agent"
+	coretesting "github.com/juju/juju/testing"
+	"github.com/juju/juju/worker/caasprovisioner"
+	"github.com/juju/juju/worker/workertest"
+)
+
+var _ = gc.Suite(&CAASProvisionerSuite{})
+
+type CAASProvisionerSuite struct {
+	coretesting.BaseSuite
+	stub *jujutesting.Stub
+
+	provisionerFacade *mockProvisionerFacade
+	caasClient        *mockCAASClient
+	agentConfig       agent.Config
+	modelTag          names.ModelTag
+}
+
+func (s *CAASProvisionerSuite) SetUpTest(c *gc.C) {
+	s.BaseSuite.SetUpTest(c)
+
+	s.stub = new(jujutesting.Stub)
+	s.provisionerFacade = newMockProvisionerFacade(s.stub)
+	s.agentConfig = &mockAgentConfig{}
+	s.modelTag = coretesting.ModelTag
+}
+
+func (s *CAASProvisionerSuite) waitForWorkerStubCalls(c *gc.C, expected []jujutesting.StubCall) {
+	waitForStubCalls(c, s.stub, expected)
+}
+
+func waitForStubCalls(c *gc.C, stub *jujutesting.Stub, expected []jujutesting.StubCall) {
+	var calls []jujutesting.StubCall
+	for a := coretesting.LongAttempt.Start(); a.Next(); {
+		calls = stub.Calls()
+		if reflect.DeepEqual(calls, expected) {
+			return
+		}
+	}
+	c.Fatalf("failed to see expected calls. saw: %v", calls)
+}
+
+func (s *CAASProvisionerSuite) assertWorker(c *gc.C) worker.Worker {
+	newClientFunc := func(f caasprovisioner.CAASProvisionerFacade) (caasprovisioner.CAASClient, error) {
+		cfg, err := f.ConnectionConfig()
+		if err != nil {
+			return nil, err
+		}
+		s.caasClient = &mockCAASClient{connectionConfig: cfg}
+		return s.caasClient, nil
+	}
+	w, err := caasprovisioner.NewProvisionerWorker(s.provisionerFacade, newClientFunc, s.modelTag, s.agentConfig)
+	c.Assert(err, jc.ErrorIsNil)
+	expected := []jujutesting.StubCall{
+		{"ConnectionConfig", nil},
+		{"WatchApplications", nil},
+	}
+	s.waitForWorkerStubCalls(c, expected)
+	s.stub.ResetCalls()
+	return w
+}
+
+func (s *CAASProvisionerSuite) TestWorkerStarts(c *gc.C) {
+	w := s.assertWorker(c)
+	workertest.CleanKill(c, w)
+}
+
+func (s *CAASProvisionerSuite) TestOperatorCreated(c *gc.C) {
+	w := s.assertWorker(c)
+	defer workertest.CleanKill(c, w)
+
+	s.provisionerFacade.applicationsWatcher.changes <- []string{"myApp"}
+
+	waitForResult := func() bool {
+		if s.caasClient.appName != "myApp" {
+			return false
+		}
+		if s.caasClient.agentPath != "/var/lib/juju" {
+			return false
+		}
+		return true
+	}
+	gotResult := false
+	for a := coretesting.LongAttempt.Start(); a.Next(); {
+		if gotResult = waitForResult(); gotResult {
+			return
+		}
+	}
+	c.Assert(gotResult, jc.IsTrue)
+	agentFile := filepath.Join(c.MkDir(), "agent.config")
+	err := ioutil.WriteFile(agentFile, []byte(s.caasClient.agentConfig), 0644)
+	c.Assert(err, jc.ErrorIsNil)
+	cfg, err := agent.ReadConfig(agentFile)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(cfg.CACert(), gc.Equals, coretesting.CACert)
+	addr, err := cfg.APIAddresses()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(addr, jc.DeepEquals, []string{"10.0.0.1:17070"})
+}

--- a/worker/provisioner/manifold_test.go
+++ b/worker/provisioner/manifold_test.go
@@ -32,7 +32,7 @@ func (s *ManifoldSuite) makeManifold() dependency.Manifold {
 		agentConf agent.Config,
 		environ environs.Environ,
 	) (provisioner.Provisioner, error) {
-		s.stub.AddCall("NewProvisionerFunc")
+		s.stub.AddCall("NewWorker")
 		return struct{ provisioner.Provisioner }{}, nil
 	}
 	return provisioner.Manifold(provisioner.ManifoldConfig{
@@ -92,7 +92,7 @@ func (s *ManifoldSuite) TestStarts(c *gc.C) {
 	}))
 	c.Check(w, gc.NotNil)
 	c.Check(err, jc.ErrorIsNil)
-	s.stub.CheckCallNames(c, "NewProvisionerFunc")
+	s.stub.CheckCallNames(c, "NewWorker")
 }
 
 type fakeAgent struct {


### PR DESCRIPTION
## Description of change

Introduce the CAAS provioner worker and associated facades. Based on initial work by @mjs and @mikemccracken 

For now, any deployed charm will result in no-op operator running in a pod named after the application.

As is the case when adding new facades/workers, there's a lot of boilerplate. The key changes include:

- worker which (for now) deploys an operator running a stock Ubuntu image
- facade which allows to worker to watch  for new applications and ask for config
- restricted CAAS facade support for logins to CAAS models
- new manifold config for CAAS models
- CAAS model entity (includes moving CAAS model tests off ModelSuite)
- driveby fixes to stop errors on CAAS model destroy

## QA steps

juju deploy kubernetes-core
juju add-caas kubernetes caascloud
juju add-model mycaas caascloud
juju deploy <any charm>
kubectl get all

see that a new juju-operator-<appname> is created
