### PR TITLE
fix bug 1721604 

### DIFF
--- a/cmd/juju/commands/bootstrap.go
+++ b/cmd/juju/commands/bootstrap.go
@@ -408,6 +408,10 @@ func (c *bootstrapCommand) Run(ctx *cmd.Context) (resultErr error) {
 	if c.controllerName == "" {
 		c.controllerName = defaultControllerName(cloud.Name, region.Name)
 	}
+	// set a Region so it's config can be found below.
+	if c.Region == "" {
+		c.Region = region.Name
+	}
 
 	config, err := c.bootstrapConfigs(ctx, cloud, provider)
 	if err != nil {


### PR DESCRIPTION
## Description of change

Juju bootstrap cli results should be the same as running bootstrap interactive.  If bootstrap, cli only, doesn't specify a region, but finds one to use, use it for config too.

## QA steps

One:
1. set region config for an openstack cloud, suggest network since you can't bootstrap without it most of the time.
2. juju bootstrap <openstack-cloud>

Two:
bootstrap a cloud without regions, such as localhost

## Documentation changes

n/a

## Bug reference

https://bugs.launchpad.net/juju/+bug/1721604