### PR TITLE
worker/uniter: fix debug-hooks exit status output

### DIFF
--- a/worker/uniter/runner/debug/server.go
+++ b/worker/uniter/runner/debug/server.go
@@ -182,7 +182,7 @@ https://jujucharms.com/docs/authors-hook-debug.html
 
 const debugHooksInitScript = `#!/bin/bash
 envsubst < $JUJU_DEBUG/welcome.msg
-trap 'echo \$? > $JUJU_DEBUG/hook_exit_status' EXIT
+trap 'echo $? > $JUJU_DEBUG/hook_exit_status' EXIT
 `
 
 const debugHooksHookScript = `#!/bin/bash


### PR DESCRIPTION
## Description of change

Fix the debug-hooks bash scripts to return the
exit status correctly. We previously sent the
script to bash stdin, which meant a $ had to
be escaped; now it's written to disk, and does
not.

## QA steps

1. juju bootstrap && juju deploy ubuntu
2. juju debug-hooks ubuntu/0
3. juju config ubuntu hostname=foo
4. (in debug-hooks) exit 0
(check `juju status` output -- unit should be idle/not in error)
5. juju config ubuntu hostname=bar
6. (in debug hooks) exit 1
(check `juju status` output -- unit should be in error)

## Documentation changes

None.

## Bug reference

Fixes https://bugs.launchpad.net/juju/+bug/1732233