### PR TITLE
WIP: stream fallback

### DIFF
--- a/environs/bootstrap/bootstrap.go
+++ b/environs/bootstrap/bootstrap.go
@@ -585,7 +585,7 @@ func bootstrapImageMetadata(
 	// This constraint will search image metadata for all supported architectures and series.
 	imageConstraint := imagemetadata.NewImageConstraint(simplestreams.LookupParams{
 		CloudSpec: region,
-		Stream:    environ.Config().ImageStream(),
+		Streams:   []string{environ.Config().ImageStream()},
 	})
 	logger.Debugf("constraints for image metadata lookup %v", imageConstraint)
 

--- a/environs/gui/export_test.go
+++ b/environs/gui/export_test.go
@@ -14,7 +14,7 @@ var (
 
 func NewConstraint(stream string, majorVersion int) *constraint {
 	return &constraint{
-		LookupParams: simplestreams.LookupParams{Stream: stream},
+		LookupParams: simplestreams.LookupParams{Streams: []string{stream}},
 		majorVersion: majorVersion,
 	}
 }

--- a/environs/gui/simplestreams.go
+++ b/environs/gui/simplestreams.go
@@ -63,12 +63,16 @@ func FetchMetadata(stream string, sources ...simplestreams.DataSource) ([]*Metad
 			ValueTemplate:   Metadata{},
 		},
 	}
-	items, _, err := simplestreams.GetMetadata(sources, params)
+	results, err := simplestreams.GetMetadata(sources, params)
 	if err != nil {
 		return nil, errors.Annotate(err, "error fetching simplestreams metadata")
 	}
-	allMeta := make([]*Metadata, len(items))
-	for i, item := range items {
+	if len(results) < 1 {
+		return nil, errors.NotFoundf("simplestreams metadata results")
+	}
+	result := results[0]
+	allMeta := make([]*Metadata, len(result.Items))
+	for i, item := range result.Items {
 		allMeta[i] = item.(*Metadata)
 	}
 	sort.Sort(byVersion(allMeta))

--- a/environs/gui/simplestreams.go
+++ b/environs/gui/simplestreams.go
@@ -67,9 +67,7 @@ func FetchMetadata(stream string, sources ...simplestreams.DataSource) ([]*Metad
 	if err != nil {
 		return nil, errors.Annotate(err, "error fetching simplestreams metadata")
 	}
-	if len(results) < 1 {
-		return nil, errors.NotFoundf("simplestreams metadata results")
-	}
+	// GetMetadata returns NotFound if there are 0 results.
 	result := results[0]
 	allMeta := make([]*Metadata, len(result.Items))
 	for i, item := range result.Items {

--- a/environs/gui/simplestreams.go
+++ b/environs/gui/simplestreams.go
@@ -53,7 +53,7 @@ func FetchMetadata(stream string, sources ...simplestreams.DataSource) ([]*Metad
 	params := simplestreams.GetMetadataParams{
 		StreamsVersion: streamsVersion,
 		LookupConstraint: &constraint{
-			LookupParams: simplestreams.LookupParams{Stream: stream},
+			LookupParams: simplestreams.LookupParams{Streams: []string{stream}},
 			majorVersion: jujuversion.Current.Major,
 		},
 		ValueParams: simplestreams.ValueParams{
@@ -116,7 +116,11 @@ type constraint struct {
 // IndexIds generates a string array representing index ids formed similarly to
 // an ISCSI qualified name (IQN).
 func (c *constraint) IndexIds() []string {
-	return []string{contentId(c.Stream)}
+	var results []string
+	for _, stream := range c.Streams {
+		results = append(results, contentId(stream))
+	}
+	return results
 }
 
 // ProductIds generates a string array representing product ids formed

--- a/environs/gui/simplestreams_test.go
+++ b/environs/gui/simplestreams_test.go
@@ -218,7 +218,7 @@ func (s *simplestreamsSuite) TestConstraint(c *gc.C) {
 
 	c.Assert(constraint.Endpoint, gc.Equals, "")
 	c.Assert(constraint.Region, gc.Equals, "")
-	c.Assert(constraint.Stream, gc.Equals, "test-stream")
+	c.Assert(constraint.Streams, gc.DeepEquals, []string{"test-stream"})
 }
 
 var guiData = map[string]string{

--- a/environs/imagedownloads/simplestreams.go
+++ b/environs/imagedownloads/simplestreams.go
@@ -103,9 +103,7 @@ func Fetch(
 	if err != nil {
 		return nil, nil, err
 	}
-	if len(results) < 1 {
-		return nil, nil, errors.NotFoundf("simplestreams metadata results")
-	}
+	// GetMetadata returns NotFound if there are no results.
 	md := make([]*Metadata, len(results[0].Items))
 	for i, im := range results[0].Items {
 		md[i] = im.(*Metadata)

--- a/environs/imagedownloads/simplestreams.go
+++ b/environs/imagedownloads/simplestreams.go
@@ -99,18 +99,21 @@ func Fetch(
 			ValueTemplate: Metadata{},
 		},
 	}
-	items, resolveInfo, err := simplestreams.GetMetadata(src, params)
+	results, err := simplestreams.GetMetadata(src, params)
 	if err != nil {
-		return nil, resolveInfo, err
+		return nil, nil, err
 	}
-	md := make([]*Metadata, len(items))
-	for i, im := range items {
+	if len(results) < 1 {
+		return nil, nil, errors.NotFoundf("simplestreams metadata results")
+	}
+	md := make([]*Metadata, len(results[0].Items))
+	for i, im := range results[0].Items {
 		md[i] = im.(*Metadata)
 	}
 
 	Sort(md)
 
-	return md, resolveInfo, nil
+	return md, results[0].ResolveInfo, nil
 }
 
 func validateArgs(arch, release, ftype string) error {

--- a/environs/imagemetadata/simplestreams.go
+++ b/environs/imagemetadata/simplestreams.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"sort"
 
+	"github.com/juju/errors"
 	"github.com/juju/utils"
 	"github.com/juju/utils/arch"
 	"github.com/juju/utils/series"
@@ -244,18 +245,21 @@ func Fetch(
 			ValueTemplate: ImageMetadata{},
 		},
 	}
-	items, resolveInfo, err := simplestreams.GetMetadata(sources, params)
+	results, err := simplestreams.GetMetadata(sources, params)
 	if err != nil {
-		return nil, resolveInfo, err
+		return nil, nil, err
 	}
-	metadata := make([]*ImageMetadata, len(items))
-	for i, md := range items {
+	if len(results) < 1 {
+		return nil, nil, errors.NotFoundf("simplestreams metadata results")
+	}
+	metadata := make([]*ImageMetadata, len(results[0].Items))
+	for i, md := range results[0].Items {
 		metadata[i] = md.(*ImageMetadata)
 	}
 	// Sorting the metadata is not strictly necessary, but it ensures consistent ordering for
 	// all compilers, and it just makes it easier to look at the data.
 	Sort(metadata)
-	return metadata, resolveInfo, nil
+	return metadata, results[0].ResolveInfo, nil
 }
 
 // Sort sorts a slice of ImageMetadata in ascending order of their id

--- a/environs/imagemetadata/simplestreams_test.go
+++ b/environs/imagemetadata/simplestreams_test.go
@@ -319,7 +319,7 @@ func (s *productSpecSuite) TestIdWithDefaultStream(c *gc.C) {
 		Arches: []string{"amd64"},
 	})
 	for _, stream := range []string{"", "released"} {
-		imageConstraint.Stream = stream
+		imageConstraint.Streams = []string{stream}
 		ids, err := imageConstraint.ProductIds()
 		c.Assert(err, jc.ErrorIsNil)
 		c.Assert(ids, gc.DeepEquals, []string{"com.ubuntu.cloud:server:12.04:amd64"})
@@ -328,9 +328,9 @@ func (s *productSpecSuite) TestIdWithDefaultStream(c *gc.C) {
 
 func (s *productSpecSuite) TestId(c *gc.C) {
 	imageConstraint := imagemetadata.NewImageConstraint(simplestreams.LookupParams{
-		Series: []string{"precise"},
-		Arches: []string{"amd64"},
-		Stream: "daily",
+		Series:  []string{"precise"},
+		Arches:  []string{"amd64"},
+		Streams: []string{"daily"},
 	})
 	ids, err := imageConstraint.ProductIds()
 	c.Assert(err, jc.ErrorIsNil)
@@ -339,9 +339,9 @@ func (s *productSpecSuite) TestId(c *gc.C) {
 
 func (s *productSpecSuite) TestIdMultiArch(c *gc.C) {
 	imageConstraint := imagemetadata.NewImageConstraint(simplestreams.LookupParams{
-		Series: []string{"precise"},
-		Arches: []string{"amd64", "i386"},
-		Stream: "daily",
+		Series:  []string{"precise"},
+		Arches:  []string{"amd64", "i386"},
+		Streams: []string{"daily"},
 	})
 	ids, err := imageConstraint.ProductIds()
 	c.Assert(err, jc.ErrorIsNil)

--- a/environs/imagemetadata/validation.go
+++ b/environs/imagemetadata/validation.go
@@ -29,9 +29,9 @@ func ValidateImageMetadata(params *simplestreams.MetadataLookupParams) ([]string
 			Region:   params.Region,
 			Endpoint: params.Endpoint,
 		},
-		Series: []string{params.Series},
-		Arches: params.Architectures,
-		Stream: params.Stream,
+		Series:  []string{params.Series},
+		Arches:  params.Architectures,
+		Streams: []string{params.Stream},
 	})
 	matchingImages, resolveInfo, err := Fetch(params.Sources, imageConstraint)
 	if err != nil {

--- a/environs/simplestreams/simplestreams.go
+++ b/environs/simplestreams/simplestreams.go
@@ -96,10 +96,10 @@ type LookupParams struct {
 	CloudSpec
 	Series []string
 	Arches []string
-	// Stream can be "" or "released" for the default "released" stream,
+	// Streams can be "" or "released" for the default "released" stream,
 	// or "daily" for daily images, or any other stream that the available
 	// simplestreams metadata supports.
-	Stream string
+	Streams []string
 }
 
 func (p LookupParams) Params() LookupParams {

--- a/environs/simplestreams/simplestreams.go
+++ b/environs/simplestreams/simplestreams.go
@@ -384,7 +384,7 @@ type GetMetadataParams struct {
 	StreamsVersion   string
 	LookupConstraint LookupConstraint
 	ValueParams      ValueParams
-	AllResults       bool
+	UseAllSources    bool
 }
 
 type MetadataResult struct {
@@ -397,8 +397,9 @@ type MetadataResult struct {
 // onlySigned is false and no signed metadata is found in a source,
 // the source is used to look for unsigned metadata. Each source is
 // tried in turn - if AllResults is false then the results from the
-// first signed (or unsigned) match are returned. If AllResults is
-// true all of the matching results are returned.
+// first signed (or unsigned) datasource containing an index are
+// returned. If UseAllSources is true results are returned for all
+// sources with an index.
 func GetMetadata(sources []DataSource, params GetMetadataParams) ([]MetadataResult, error) {
 	var (
 		items       []interface{}

--- a/environs/simplestreams/simplestreams_test.go
+++ b/environs/simplestreams/simplestreams_test.go
@@ -350,10 +350,11 @@ func (s *simplestreamsSuite) TestGetMetadataNoMatching(c *gc.C) {
 		ValueParams:      simplestreams.ValueParams{DataType: "image-ids"},
 	}
 
-	items, resolveInfo, err := simplestreams.GetMetadata(sources, params)
+	results, err := simplestreams.GetMetadata(sources, params)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(items, gc.HasLen, 0)
-	c.Assert(resolveInfo, gc.DeepEquals, &simplestreams.ResolveInfo{
+	c.Assert(results, gc.HasLen, 1)
+	c.Assert(results[0].Items, gc.HasLen, 0)
+	c.Assert(results[0].ResolveInfo, gc.DeepEquals, &simplestreams.ResolveInfo{
 		Source:    "test",
 		Signed:    false,
 		IndexURL:  "test:/daily/streams/v1/index.json",

--- a/environs/simplestreams/testing/testing.go
+++ b/environs/simplestreams/testing/testing.go
@@ -790,7 +790,7 @@ func (s *LocalLiveSimplestreamsSuite) TestGetProductsPathInvalidProductSpec(c *g
 		CloudSpec: s.ValidConstraint.Params().CloudSpec,
 		Series:    []string{"precise"},
 		Arches:    []string{"bad"},
-		Stream:    "spec",
+		Streams:   []string{"spec"},
 	})
 	_, err = indexRef.GetProductsPath(ic)
 	c.Assert(err, gc.NotNil)

--- a/environs/tools/simplestreams.go
+++ b/environs/tools/simplestreams.go
@@ -199,18 +199,21 @@ func Fetch(
 			ValueTemplate:   ToolsMetadata{},
 		},
 	}
-	items, resolveInfo, err := simplestreams.GetMetadata(sources, params)
+	results, err := simplestreams.GetMetadata(sources, params)
 	if err != nil {
 		return nil, nil, err
 	}
-	metadata := make([]*ToolsMetadata, len(items))
-	for i, md := range items {
+	if len(results) < 1 {
+		return nil, nil, errors.NotFoundf("simplestreams metadata results")
+	}
+	metadata := make([]*ToolsMetadata, len(results[0].Items))
+	for i, md := range results[0].Items {
 		metadata[i] = md.(*ToolsMetadata)
 	}
 	// Sorting the metadata is not strictly necessary, but it ensures consistent ordering for
 	// all compilers, and it just makes it easier to look at the data.
 	Sort(metadata)
-	return metadata, resolveInfo, nil
+	return metadata, results[0].ResolveInfo, nil
 }
 
 // Sort sorts a slice of ToolsMetadata in ascending order of their version

--- a/environs/tools/simplestreams.go
+++ b/environs/tools/simplestreams.go
@@ -185,9 +185,7 @@ func Fetch(
 	if err != nil {
 		return nil, nil, err
 	}
-	if len(results) < 1 {
-		return nil, nil, errors.NotFoundf("simplestreams metadata results")
-	}
+	// GetMetadata returns NotFound if there are no results.
 	metadata := make([]*ToolsMetadata, len(results[0].Items))
 	for i, md := range results[0].Items {
 		metadata[i] = md.(*ToolsMetadata)

--- a/environs/tools/simplestreams_test.go
+++ b/environs/tools/simplestreams_test.go
@@ -70,11 +70,11 @@ func setupSimpleStreamsTests(t *testing.T) {
 			t.Fatalf("Unknown vendor %s. Must be one of %s", *vendor, keys)
 		}
 		registerLiveSimpleStreamsTests(testData.baseURL,
-			tools.NewVersionedToolsConstraint(version.MustParse("1.13.0"), true, simplestreams.LookupParams{
+			tools.NewVersionedToolsConstraint(version.MustParse("1.13.0"), simplestreams.LookupParams{
 				CloudSpec: testData.validCloudSpec,
 				Series:    []string{series.MustHostSeries()},
 				Arches:    []string{"amd64"},
-				Stream:    "released",
+				Streams:   []string{"released"},
 			}), testData.requireSigned)
 	}
 	registerSimpleStreamsTests()
@@ -87,14 +87,14 @@ func registerSimpleStreamsTests() {
 			RequireSigned:  false,
 			DataType:       tools.ContentDownload,
 			StreamsVersion: tools.CurrentStreamsVersion,
-			ValidConstraint: tools.NewVersionedToolsConstraint(version.MustParse("1.13.0"), true, simplestreams.LookupParams{
+			ValidConstraint: tools.NewVersionedToolsConstraint(version.MustParse("1.13.0"), simplestreams.LookupParams{
 				CloudSpec: simplestreams.CloudSpec{
 					Region:   "us-east-1",
 					Endpoint: "https://ec2.us-east-1.amazonaws.com",
 				},
-				Series: []string{"precise"},
-				Arches: []string{"amd64", "arm"},
-				Stream: "released",
+				Series:  []string{"precise"},
+				Arches:  []string{"amd64", "arm"},
+				Streams: []string{"released"},
 			}),
 		},
 	})
@@ -130,7 +130,7 @@ var fetchTests = []struct {
 	region  string
 	series  string
 	version string
-	stream  string
+	streams []string
 	major   int
 	minor   int
 	arches  []string
@@ -224,7 +224,7 @@ var fetchTests = []struct {
 	series:  "trusty",
 	arches:  []string{"amd64"},
 	version: "1.16.0",
-	stream:  "testing",
+	streams: []string{"testing", "devel", "proposed", "released"},
 	tools: []*tools.ToolsMetadata{
 		{
 			Release:  "trusty",
@@ -241,24 +241,24 @@ var fetchTests = []struct {
 func (s *simplestreamsSuite) TestFetch(c *gc.C) {
 	for i, t := range fetchTests {
 		c.Logf("test %d", i)
-		if t.stream == "" {
-			t.stream = "released"
+		if t.streams == nil {
+			t.streams = []string{"released"}
 		}
 		var toolsConstraint *tools.ToolsConstraint
 		if t.version == "" {
-			toolsConstraint = tools.NewGeneralToolsConstraint(t.major, t.minor, true, simplestreams.LookupParams{
+			toolsConstraint = tools.NewGeneralToolsConstraint(t.major, t.minor, simplestreams.LookupParams{
 				CloudSpec: simplestreams.CloudSpec{"us-east-1", "https://ec2.us-east-1.amazonaws.com"},
 				Series:    []string{t.series},
 				Arches:    t.arches,
-				Stream:    t.stream,
+				Streams:   t.streams,
 			})
 		} else {
-			toolsConstraint = tools.NewVersionedToolsConstraint(version.MustParse(t.version), true,
+			toolsConstraint = tools.NewVersionedToolsConstraint(version.MustParse(t.version),
 				simplestreams.LookupParams{
 					CloudSpec: simplestreams.CloudSpec{"us-east-1", "https://ec2.us-east-1.amazonaws.com"},
 					Series:    []string{t.series},
 					Arches:    t.arches,
-					Stream:    t.stream,
+					Streams:   t.streams,
 				})
 		}
 		// Add invalid datasource and check later that resolveInfo is correct.
@@ -283,11 +283,11 @@ func (s *simplestreamsSuite) TestFetch(c *gc.C) {
 }
 
 func (s *simplestreamsSuite) TestFetchNoMatchingStream(c *gc.C) {
-	toolsConstraint := tools.NewGeneralToolsConstraint(2, -1, false, simplestreams.LookupParams{
+	toolsConstraint := tools.NewGeneralToolsConstraint(2, -1, simplestreams.LookupParams{
 		CloudSpec: simplestreams.CloudSpec{"us-east-1", "https://ec2.us-east-1.amazonaws.com"},
 		Series:    []string{"precise"},
 		Arches:    []string{},
-		Stream:    "proposed",
+		Streams:   []string{"proposed"},
 	})
 	_, _, err := tools.Fetch(
 		[]simplestreams.DataSource{s.Source}, toolsConstraint)
@@ -295,11 +295,11 @@ func (s *simplestreamsSuite) TestFetchNoMatchingStream(c *gc.C) {
 }
 
 func (s *simplestreamsSuite) TestFetchWithMirror(c *gc.C) {
-	toolsConstraint := tools.NewGeneralToolsConstraint(1, 13, true, simplestreams.LookupParams{
+	toolsConstraint := tools.NewGeneralToolsConstraint(1, 13, simplestreams.LookupParams{
 		CloudSpec: simplestreams.CloudSpec{"us-west-2", "https://ec2.us-west-2.amazonaws.com"},
 		Series:    []string{"precise"},
 		Arches:    []string{"amd64"},
-		Stream:    "released",
+		Streams:   []string{"released"},
 	})
 	toolsMetadata, resolveInfo, err := tools.Fetch(
 		[]simplestreams.DataSource{s.Source}, toolsConstraint)
@@ -464,7 +464,7 @@ type productSpecSuite struct{}
 var _ = gc.Suite(&productSpecSuite{})
 
 func (s *productSpecSuite) TestIndexIdNoStream(c *gc.C) {
-	toolsConstraint := tools.NewVersionedToolsConstraint(version.MustParse("1.13.0"), true, simplestreams.LookupParams{
+	toolsConstraint := tools.NewVersionedToolsConstraint(version.MustParse("1.13.0"), simplestreams.LookupParams{
 		Series: []string{"precise"},
 		Arches: []string{"amd64"},
 	})
@@ -473,17 +473,17 @@ func (s *productSpecSuite) TestIndexIdNoStream(c *gc.C) {
 }
 
 func (s *productSpecSuite) TestIndexId(c *gc.C) {
-	toolsConstraint := tools.NewVersionedToolsConstraint(version.MustParse("1.13.0"), true, simplestreams.LookupParams{
-		Series: []string{"precise"},
-		Arches: []string{"amd64"},
-		Stream: "proposed",
+	toolsConstraint := tools.NewVersionedToolsConstraint(version.MustParse("1.13.0"), simplestreams.LookupParams{
+		Series:  []string{"precise"},
+		Arches:  []string{"amd64"},
+		Streams: []string{"proposed", "released"},
 	})
 	ids := toolsConstraint.IndexIds()
 	c.Assert(ids, gc.DeepEquals, []string{"com.ubuntu.juju:proposed:tools", "com.ubuntu.juju:released:tools"})
 }
 
 func (s *productSpecSuite) TestProductId(c *gc.C) {
-	toolsConstraint := tools.NewVersionedToolsConstraint(version.MustParse("1.13.0"), true, simplestreams.LookupParams{
+	toolsConstraint := tools.NewVersionedToolsConstraint(version.MustParse("1.13.0"), simplestreams.LookupParams{
 		Series: []string{"precise"},
 		Arches: []string{"amd64"},
 	})
@@ -493,7 +493,7 @@ func (s *productSpecSuite) TestProductId(c *gc.C) {
 }
 
 func (s *productSpecSuite) TestIdMultiArch(c *gc.C) {
-	toolsConstraint := tools.NewVersionedToolsConstraint(version.MustParse("1.11.3"), true, simplestreams.LookupParams{
+	toolsConstraint := tools.NewVersionedToolsConstraint(version.MustParse("1.11.3"), simplestreams.LookupParams{
 		Series: []string{"precise"},
 		Arches: []string{"amd64", "arm"},
 	})
@@ -505,10 +505,10 @@ func (s *productSpecSuite) TestIdMultiArch(c *gc.C) {
 }
 
 func (s *productSpecSuite) TestIdMultiSeries(c *gc.C) {
-	toolsConstraint := tools.NewVersionedToolsConstraint(version.MustParse("1.11.3"), true, simplestreams.LookupParams{
-		Series: []string{"precise", "raring"},
-		Arches: []string{"amd64"},
-		Stream: "released",
+	toolsConstraint := tools.NewVersionedToolsConstraint(version.MustParse("1.11.3"), simplestreams.LookupParams{
+		Series:  []string{"precise", "raring"},
+		Arches:  []string{"amd64"},
+		Streams: []string{"released"},
 	})
 	ids, err := toolsConstraint.ProductIds()
 	c.Assert(err, jc.ErrorIsNil)
@@ -518,10 +518,10 @@ func (s *productSpecSuite) TestIdMultiSeries(c *gc.C) {
 }
 
 func (s *productSpecSuite) TestIdIgnoresInvalidSeries(c *gc.C) {
-	toolsConstraint := tools.NewVersionedToolsConstraint(version.MustParse("1.11.3"), true, simplestreams.LookupParams{
-		Series: []string{"precise", "foobar"},
-		Arches: []string{"amd64"},
-		Stream: "released",
+	toolsConstraint := tools.NewVersionedToolsConstraint(version.MustParse("1.11.3"), simplestreams.LookupParams{
+		Series:  []string{"precise", "foobar"},
+		Arches:  []string{"amd64"},
+		Streams: []string{"released"},
 	})
 	ids, err := toolsConstraint.ProductIds()
 	c.Assert(err, jc.ErrorIsNil)
@@ -529,10 +529,10 @@ func (s *productSpecSuite) TestIdIgnoresInvalidSeries(c *gc.C) {
 }
 
 func (s *productSpecSuite) TestIdWithMajorVersionOnly(c *gc.C) {
-	toolsConstraint := tools.NewGeneralToolsConstraint(1, -1, true, simplestreams.LookupParams{
-		Series: []string{"precise"},
-		Arches: []string{"amd64"},
-		Stream: "released",
+	toolsConstraint := tools.NewGeneralToolsConstraint(1, -1, simplestreams.LookupParams{
+		Series:  []string{"precise"},
+		Arches:  []string{"amd64"},
+		Streams: []string{"released"},
 	})
 	ids, err := toolsConstraint.ProductIds()
 	c.Assert(err, jc.ErrorIsNil)
@@ -540,10 +540,10 @@ func (s *productSpecSuite) TestIdWithMajorVersionOnly(c *gc.C) {
 }
 
 func (s *productSpecSuite) TestIdWithMajorMinorVersion(c *gc.C) {
-	toolsConstraint := tools.NewGeneralToolsConstraint(1, 2, true, simplestreams.LookupParams{
-		Series: []string{"precise"},
-		Arches: []string{"amd64"},
-		Stream: "released",
+	toolsConstraint := tools.NewGeneralToolsConstraint(1, 2, simplestreams.LookupParams{
+		Series:  []string{"precise"},
+		Arches:  []string{"amd64"},
+		Streams: []string{"released"},
 	})
 	ids, err := toolsConstraint.ProductIds()
 	c.Assert(err, jc.ErrorIsNil)
@@ -1062,11 +1062,11 @@ func (s *signedSuite) TestSignedToolsMetadata(c *gc.C) {
 	signedSource := simplestreams.NewURLSignedDataSource(
 		"test", "signedtest://host/signed", sstesting.SignedMetadataPublicKey,
 		utils.VerifySSLHostnames, simplestreams.DEFAULT_CLOUD_DATA, true)
-	toolsConstraint := tools.NewVersionedToolsConstraint(version.MustParse("1.13.0"), true, simplestreams.LookupParams{
+	toolsConstraint := tools.NewVersionedToolsConstraint(version.MustParse("1.13.0"), simplestreams.LookupParams{
 		CloudSpec: simplestreams.CloudSpec{"us-east-1", "https://ec2.us-east-1.amazonaws.com"},
 		Series:    []string{"precise"},
 		Arches:    []string{"amd64"},
-		Stream:    "released",
+		Streams:   []string{"released"},
 	})
 	toolsMetadata, resolveInfo, err := tools.Fetch(
 		[]simplestreams.DataSource{signedSource}, toolsConstraint)

--- a/environs/tools/simplestreams_test.go
+++ b/environs/tools/simplestreams_test.go
@@ -70,7 +70,7 @@ func setupSimpleStreamsTests(t *testing.T) {
 			t.Fatalf("Unknown vendor %s. Must be one of %s", *vendor, keys)
 		}
 		registerLiveSimpleStreamsTests(testData.baseURL,
-			tools.NewVersionedToolsConstraint(version.MustParse("1.13.0"), simplestreams.LookupParams{
+			tools.NewVersionedToolsConstraint(version.MustParse("1.13.0"), true, simplestreams.LookupParams{
 				CloudSpec: testData.validCloudSpec,
 				Series:    []string{series.MustHostSeries()},
 				Arches:    []string{"amd64"},
@@ -87,7 +87,7 @@ func registerSimpleStreamsTests() {
 			RequireSigned:  false,
 			DataType:       tools.ContentDownload,
 			StreamsVersion: tools.CurrentStreamsVersion,
-			ValidConstraint: tools.NewVersionedToolsConstraint(version.MustParse("1.13.0"), simplestreams.LookupParams{
+			ValidConstraint: tools.NewVersionedToolsConstraint(version.MustParse("1.13.0"), true, simplestreams.LookupParams{
 				CloudSpec: simplestreams.CloudSpec{
 					Region:   "us-east-1",
 					Endpoint: "https://ec2.us-east-1.amazonaws.com",
@@ -246,14 +246,14 @@ func (s *simplestreamsSuite) TestFetch(c *gc.C) {
 		}
 		var toolsConstraint *tools.ToolsConstraint
 		if t.version == "" {
-			toolsConstraint = tools.NewGeneralToolsConstraint(t.major, t.minor, simplestreams.LookupParams{
+			toolsConstraint = tools.NewGeneralToolsConstraint(t.major, t.minor, true, simplestreams.LookupParams{
 				CloudSpec: simplestreams.CloudSpec{"us-east-1", "https://ec2.us-east-1.amazonaws.com"},
 				Series:    []string{t.series},
 				Arches:    t.arches,
 				Stream:    t.stream,
 			})
 		} else {
-			toolsConstraint = tools.NewVersionedToolsConstraint(version.MustParse(t.version),
+			toolsConstraint = tools.NewVersionedToolsConstraint(version.MustParse(t.version), true,
 				simplestreams.LookupParams{
 					CloudSpec: simplestreams.CloudSpec{"us-east-1", "https://ec2.us-east-1.amazonaws.com"},
 					Series:    []string{t.series},
@@ -283,7 +283,7 @@ func (s *simplestreamsSuite) TestFetch(c *gc.C) {
 }
 
 func (s *simplestreamsSuite) TestFetchNoMatchingStream(c *gc.C) {
-	toolsConstraint := tools.NewGeneralToolsConstraint(2, -1, simplestreams.LookupParams{
+	toolsConstraint := tools.NewGeneralToolsConstraint(2, -1, false, simplestreams.LookupParams{
 		CloudSpec: simplestreams.CloudSpec{"us-east-1", "https://ec2.us-east-1.amazonaws.com"},
 		Series:    []string{"precise"},
 		Arches:    []string{},
@@ -295,7 +295,7 @@ func (s *simplestreamsSuite) TestFetchNoMatchingStream(c *gc.C) {
 }
 
 func (s *simplestreamsSuite) TestFetchWithMirror(c *gc.C) {
-	toolsConstraint := tools.NewGeneralToolsConstraint(1, 13, simplestreams.LookupParams{
+	toolsConstraint := tools.NewGeneralToolsConstraint(1, 13, true, simplestreams.LookupParams{
 		CloudSpec: simplestreams.CloudSpec{"us-west-2", "https://ec2.us-west-2.amazonaws.com"},
 		Series:    []string{"precise"},
 		Arches:    []string{"amd64"},
@@ -464,7 +464,7 @@ type productSpecSuite struct{}
 var _ = gc.Suite(&productSpecSuite{})
 
 func (s *productSpecSuite) TestIndexIdNoStream(c *gc.C) {
-	toolsConstraint := tools.NewVersionedToolsConstraint(version.MustParse("1.13.0"), simplestreams.LookupParams{
+	toolsConstraint := tools.NewVersionedToolsConstraint(version.MustParse("1.13.0"), true, simplestreams.LookupParams{
 		Series: []string{"precise"},
 		Arches: []string{"amd64"},
 	})
@@ -473,17 +473,17 @@ func (s *productSpecSuite) TestIndexIdNoStream(c *gc.C) {
 }
 
 func (s *productSpecSuite) TestIndexId(c *gc.C) {
-	toolsConstraint := tools.NewVersionedToolsConstraint(version.MustParse("1.13.0"), simplestreams.LookupParams{
+	toolsConstraint := tools.NewVersionedToolsConstraint(version.MustParse("1.13.0"), true, simplestreams.LookupParams{
 		Series: []string{"precise"},
 		Arches: []string{"amd64"},
 		Stream: "proposed",
 	})
 	ids := toolsConstraint.IndexIds()
-	c.Assert(ids, gc.DeepEquals, []string{"com.ubuntu.juju:proposed:tools"})
+	c.Assert(ids, gc.DeepEquals, []string{"com.ubuntu.juju:proposed:tools", "com.ubuntu.juju:released:tools"})
 }
 
 func (s *productSpecSuite) TestProductId(c *gc.C) {
-	toolsConstraint := tools.NewVersionedToolsConstraint(version.MustParse("1.13.0"), simplestreams.LookupParams{
+	toolsConstraint := tools.NewVersionedToolsConstraint(version.MustParse("1.13.0"), true, simplestreams.LookupParams{
 		Series: []string{"precise"},
 		Arches: []string{"amd64"},
 	})
@@ -493,7 +493,7 @@ func (s *productSpecSuite) TestProductId(c *gc.C) {
 }
 
 func (s *productSpecSuite) TestIdMultiArch(c *gc.C) {
-	toolsConstraint := tools.NewVersionedToolsConstraint(version.MustParse("1.11.3"), simplestreams.LookupParams{
+	toolsConstraint := tools.NewVersionedToolsConstraint(version.MustParse("1.11.3"), true, simplestreams.LookupParams{
 		Series: []string{"precise"},
 		Arches: []string{"amd64", "arm"},
 	})
@@ -505,7 +505,7 @@ func (s *productSpecSuite) TestIdMultiArch(c *gc.C) {
 }
 
 func (s *productSpecSuite) TestIdMultiSeries(c *gc.C) {
-	toolsConstraint := tools.NewVersionedToolsConstraint(version.MustParse("1.11.3"), simplestreams.LookupParams{
+	toolsConstraint := tools.NewVersionedToolsConstraint(version.MustParse("1.11.3"), true, simplestreams.LookupParams{
 		Series: []string{"precise", "raring"},
 		Arches: []string{"amd64"},
 		Stream: "released",
@@ -518,7 +518,7 @@ func (s *productSpecSuite) TestIdMultiSeries(c *gc.C) {
 }
 
 func (s *productSpecSuite) TestIdIgnoresInvalidSeries(c *gc.C) {
-	toolsConstraint := tools.NewVersionedToolsConstraint(version.MustParse("1.11.3"), simplestreams.LookupParams{
+	toolsConstraint := tools.NewVersionedToolsConstraint(version.MustParse("1.11.3"), true, simplestreams.LookupParams{
 		Series: []string{"precise", "foobar"},
 		Arches: []string{"amd64"},
 		Stream: "released",
@@ -529,7 +529,7 @@ func (s *productSpecSuite) TestIdIgnoresInvalidSeries(c *gc.C) {
 }
 
 func (s *productSpecSuite) TestIdWithMajorVersionOnly(c *gc.C) {
-	toolsConstraint := tools.NewGeneralToolsConstraint(1, -1, simplestreams.LookupParams{
+	toolsConstraint := tools.NewGeneralToolsConstraint(1, -1, true, simplestreams.LookupParams{
 		Series: []string{"precise"},
 		Arches: []string{"amd64"},
 		Stream: "released",
@@ -540,7 +540,7 @@ func (s *productSpecSuite) TestIdWithMajorVersionOnly(c *gc.C) {
 }
 
 func (s *productSpecSuite) TestIdWithMajorMinorVersion(c *gc.C) {
-	toolsConstraint := tools.NewGeneralToolsConstraint(1, 2, simplestreams.LookupParams{
+	toolsConstraint := tools.NewGeneralToolsConstraint(1, 2, true, simplestreams.LookupParams{
 		Series: []string{"precise"},
 		Arches: []string{"amd64"},
 		Stream: "released",
@@ -1062,7 +1062,7 @@ func (s *signedSuite) TestSignedToolsMetadata(c *gc.C) {
 	signedSource := simplestreams.NewURLSignedDataSource(
 		"test", "signedtest://host/signed", sstesting.SignedMetadataPublicKey,
 		utils.VerifySSLHostnames, simplestreams.DEFAULT_CLOUD_DATA, true)
-	toolsConstraint := tools.NewVersionedToolsConstraint(version.MustParse("1.13.0"), simplestreams.LookupParams{
+	toolsConstraint := tools.NewVersionedToolsConstraint(version.MustParse("1.13.0"), true, simplestreams.LookupParams{
 		CloudSpec: simplestreams.CloudSpec{"us-east-1", "https://ec2.us-east-1.amazonaws.com"},
 		Series:    []string{"precise"},
 		Arches:    []string{"amd64"},

--- a/environs/tools/tools.go
+++ b/environs/tools/tools.go
@@ -34,7 +34,9 @@ func makeToolsConstraint(cloudSpec simplestreams.CloudSpec, stream string, fallb
 
 	streams := []string{stream}
 	if fallback {
-		streams = streamFallbacks[stream]
+		if fallbacks, ok := streamFallbacks[stream]; ok {
+			streams = fallbacks
+		}
 	}
 
 	if filter.Number != version.Zero {

--- a/environs/tools/tools.go
+++ b/environs/tools/tools.go
@@ -20,7 +20,7 @@ import (
 
 var logger = loggo.GetLogger("juju.environs.tools")
 
-func makeToolsConstraint(cloudSpec simplestreams.CloudSpec, stream string, majorVersion, minorVersion int,
+func makeToolsConstraint(cloudSpec simplestreams.CloudSpec, stream string, fallback bool, majorVersion, minorVersion int,
 	filter coretools.Filter) (*ToolsConstraint, error) {
 
 	var toolsConstraint *ToolsConstraint
@@ -35,10 +35,10 @@ func makeToolsConstraint(cloudSpec simplestreams.CloudSpec, stream string, major
 		if majorMismatch || minorMismacth {
 			return nil, coretools.ErrNoMatches
 		}
-		toolsConstraint = NewVersionedToolsConstraint(filter.Number,
+		toolsConstraint = NewVersionedToolsConstraint(filter.Number, fallback,
 			simplestreams.LookupParams{CloudSpec: cloudSpec, Stream: stream})
 	} else {
-		toolsConstraint = NewGeneralToolsConstraint(majorVersion, minorVersion,
+		toolsConstraint = NewGeneralToolsConstraint(majorVersion, minorVersion, fallback,
 			simplestreams.LookupParams{CloudSpec: cloudSpec, Stream: stream})
 	}
 	if filter.Arch != "" {
@@ -131,7 +131,7 @@ func FindTools(env environs.Environ, majorVersion, minorVersion int, stream stri
 func FindToolsForCloud(sources []simplestreams.DataSource, cloudSpec simplestreams.CloudSpec, stream string,
 	majorVersion, minorVersion int, filter coretools.Filter) (list coretools.List, err error) {
 
-	toolsConstraint, err := makeToolsConstraint(cloudSpec, stream, majorVersion, minorVersion, filter)
+	toolsConstraint, err := makeToolsConstraint(cloudSpec, stream, true, majorVersion, minorVersion, filter)
 	if err != nil {
 		return nil, err
 	}

--- a/environs/tools/tools.go
+++ b/environs/tools/tools.go
@@ -20,10 +20,23 @@ import (
 
 var logger = loggo.GetLogger("juju.environs.tools")
 
+var streamFallbacks = map[string][]string{
+	ReleasedStream: {ReleasedStream},
+	ProposedStream: {ProposedStream, ReleasedStream},
+	DevelStream:    {DevelStream, ProposedStream, ReleasedStream},
+	TestingStream:  {TestingStream, DevelStream, ProposedStream, ReleasedStream},
+}
+
 func makeToolsConstraint(cloudSpec simplestreams.CloudSpec, stream string, fallback bool, majorVersion, minorVersion int,
 	filter coretools.Filter) (*ToolsConstraint, error) {
 
 	var toolsConstraint *ToolsConstraint
+
+	streams := []string{stream}
+	if fallback {
+		streams = streamFallbacks[stream]
+	}
+
 	if filter.Number != version.Zero {
 		// A specific tools version is required, however, a general match based on major/minor
 		// version may also have been requested. This is used to ensure any agent version currently
@@ -35,11 +48,11 @@ func makeToolsConstraint(cloudSpec simplestreams.CloudSpec, stream string, fallb
 		if majorMismatch || minorMismacth {
 			return nil, coretools.ErrNoMatches
 		}
-		toolsConstraint = NewVersionedToolsConstraint(filter.Number, fallback,
-			simplestreams.LookupParams{CloudSpec: cloudSpec, Stream: stream})
+		toolsConstraint = NewVersionedToolsConstraint(filter.Number,
+			simplestreams.LookupParams{CloudSpec: cloudSpec, Streams: streams})
 	} else {
-		toolsConstraint = NewGeneralToolsConstraint(majorVersion, minorVersion, fallback,
-			simplestreams.LookupParams{CloudSpec: cloudSpec, Stream: stream})
+		toolsConstraint = NewGeneralToolsConstraint(majorVersion, minorVersion,
+			simplestreams.LookupParams{CloudSpec: cloudSpec, Streams: streams})
 	}
 	if filter.Arch != "" {
 		toolsConstraint.Arches = []string{filter.Arch}

--- a/environs/tools/validation.go
+++ b/environs/tools/validation.go
@@ -31,28 +31,28 @@ func ValidateToolsMetadata(params *ToolsMetadataLookupParams) ([]string, *simple
 	}
 	var toolsConstraint *ToolsConstraint
 	if params.Version == "" {
-		toolsConstraint = NewGeneralToolsConstraint(params.Major, params.Minor, true, simplestreams.LookupParams{
+		toolsConstraint = NewGeneralToolsConstraint(params.Major, params.Minor, simplestreams.LookupParams{
 			CloudSpec: simplestreams.CloudSpec{
 				Region:   params.Region,
 				Endpoint: params.Endpoint,
 			},
-			Stream: params.Stream,
-			Series: []string{params.Series},
-			Arches: params.Architectures,
+			Streams: streamFallbacks[params.Stream],
+			Series:  []string{params.Series},
+			Arches:  params.Architectures,
 		})
 	} else {
 		versNum, err := version.Parse(params.Version)
 		if err != nil {
 			return nil, nil, err
 		}
-		toolsConstraint = NewVersionedToolsConstraint(versNum, true, simplestreams.LookupParams{
+		toolsConstraint = NewVersionedToolsConstraint(versNum, simplestreams.LookupParams{
 			CloudSpec: simplestreams.CloudSpec{
 				Region:   params.Region,
 				Endpoint: params.Endpoint,
 			},
-			Stream: params.Stream,
-			Series: []string{params.Series},
-			Arches: params.Architectures,
+			Streams: streamFallbacks[params.Stream],
+			Series:  []string{params.Series},
+			Arches:  params.Architectures,
 		})
 	}
 	matchingTools, resolveInfo, err := Fetch(params.Sources, toolsConstraint)

--- a/environs/tools/validation.go
+++ b/environs/tools/validation.go
@@ -31,7 +31,7 @@ func ValidateToolsMetadata(params *ToolsMetadataLookupParams) ([]string, *simple
 	}
 	var toolsConstraint *ToolsConstraint
 	if params.Version == "" {
-		toolsConstraint = NewGeneralToolsConstraint(params.Major, params.Minor, simplestreams.LookupParams{
+		toolsConstraint = NewGeneralToolsConstraint(params.Major, params.Minor, true, simplestreams.LookupParams{
 			CloudSpec: simplestreams.CloudSpec{
 				Region:   params.Region,
 				Endpoint: params.Endpoint,
@@ -45,7 +45,7 @@ func ValidateToolsMetadata(params *ToolsMetadataLookupParams) ([]string, *simple
 		if err != nil {
 			return nil, nil, err
 		}
-		toolsConstraint = NewVersionedToolsConstraint(versNum, simplestreams.LookupParams{
+		toolsConstraint = NewVersionedToolsConstraint(versNum, true, simplestreams.LookupParams{
 			CloudSpec: simplestreams.CloudSpec{
 				Region:   params.Region,
 				Endpoint: params.Endpoint,

--- a/environs/tools/validation_test.go
+++ b/environs/tools/validation_test.go
@@ -156,7 +156,7 @@ func (s *ValidateSuite) TestStreamsNoMatch(c *gc.C) {
 			Series:        "raring",
 			Architectures: []string{"amd64"},
 			Endpoint:      "some-auth-url",
-			Stream:        "testing",
+			Stream:        "released",
 			Sources: []simplestreams.DataSource{
 				simplestreams.NewURLDataSource("test", s.toolsURL(), utils.VerifySSLHostnames, simplestreams.DEFAULT_CLOUD_DATA, false)},
 		},

--- a/juju/testing/instance.go
+++ b/juju/testing/instance.go
@@ -231,7 +231,7 @@ func SetImageMetadata(env environs.Environ, series, arches []string, out *[]*ima
 		CloudSpec: region,
 		Series:    series,
 		Arches:    arches,
-		Stream:    env.Config().ImageStream(),
+		Streams:   []string{env.Config().ImageStream()},
 	})
 	imageMetadata, _, err := imagemetadata.Fetch(sources, imageConstraint)
 	if err != nil {

--- a/provider/vsphere/image_metadata.go
+++ b/provider/vsphere/image_metadata.go
@@ -67,12 +67,15 @@ func imageMetadataFetch(sources []simplestreams.DataSource, cons *imagemetadata.
 			ValueTemplate: OvaFileMetadata{},
 		},
 	}
-	items, _, err := simplestreams.GetMetadata(sources, params)
+	results, err := simplestreams.GetMetadata(sources, params)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	metadata := make([]*OvaFileMetadata, len(items))
-	for i, md := range items {
+	if len(results) < 1 {
+		return nil, errors.NotFoundf("simplestreams metadata results")
+	}
+	metadata := make([]*OvaFileMetadata, len(results[0].Items))
+	for i, md := range results[0].Items {
 		metadata[i] = md.(*OvaFileMetadata)
 	}
 	return metadata, nil

--- a/provider/vsphere/image_metadata.go
+++ b/provider/vsphere/image_metadata.go
@@ -36,9 +36,9 @@ func findImageMetadata(env environs.Environ, args environs.StartInstanceParams) 
 	series := args.Tools.OneSeries()
 	ic := &imagemetadata.ImageConstraint{
 		LookupParams: simplestreams.LookupParams{
-			Series: []string{series},
-			Arches: arches,
-			Stream: env.Config().ImageStream(),
+			Series:  []string{series},
+			Arches:  arches,
+			Streams: []string{env.Config().ImageStream()},
 		},
 	}
 	sources, err := environs.ImageMetadataSources(env)

--- a/provider/vsphere/image_metadata.go
+++ b/provider/vsphere/image_metadata.go
@@ -71,9 +71,8 @@ func imageMetadataFetch(sources []simplestreams.DataSource, cons *imagemetadata.
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	if len(results) < 1 {
-		return nil, errors.NotFoundf("simplestreams metadata results")
-	}
+	// If there were no results, GetMetadata would have returned a
+	// NotFound error.
 	metadata := make([]*OvaFileMetadata, len(results[0].Items))
 	for i, md := range results[0].Items {
 		metadata[i] = md.(*OvaFileMetadata)


### PR DESCRIPTION
**Work in progress** The stream fallback is done, but searching for agents across multiple datasources isn't yet.

### Description of change

If someone bootstraps with a beta or with an explicitly set devel stream, we weren't then considering released agent binaries as possible candidates for upgrades (because they are on the released stream). 
Change the metadata lookup so that we check the released stream if a controller is on the devel stream.

Similarly, if someone has configured an agent source, we should still be able to check the cloud datasource and the public streams for better binary versions.

## QA steps

Bootstrap a controller with 2.2-beta3 (using a released 2.2 binary). Then run `juju upgrade-juju -m controller`. The controller should be upgraded to 2.2.6.

## Documentation changes
It's possible this needs documentation? I couldn't find any documentation for how we find agent binaries in streams, but if there is we should add a mention of the fallback to it.

