### PR TITLE
Fixes lp#1640242: debug-hook for actions.

### DIFF
--- a/cmd/juju/commands/debughooks.go
+++ b/cmd/juju/commands/debughooks.go
@@ -6,14 +6,16 @@ package commands
 import (
 	"encoding/base64"
 	"fmt"
-	"sort"
 
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
+	"github.com/juju/utils/set"
 	"gopkg.in/juju/charm.v6-unstable/hooks"
 	"gopkg.in/juju/names.v2"
 
+	"github.com/juju/juju/api/action"
 	"github.com/juju/juju/api/application"
+	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/network/ssh"
 	unitdebug "github.com/juju/juju/worker/uniter/runner/debug"
@@ -21,6 +23,9 @@ import (
 
 func newDebugHooksCommand(hostChecker ssh.ReachableChecker) cmd.Command {
 	c := new(debugHooksCommand)
+	c.newActionAPIF = func() (ActionsAPI, error) {
+		return c.newActionsAPI()
+	}
 	c.setHostChecker(hostChecker)
 	return modelcmd.Wrap(c)
 }
@@ -29,10 +34,12 @@ func newDebugHooksCommand(hostChecker ssh.ReachableChecker) cmd.Command {
 type debugHooksCommand struct {
 	sshCommand
 	hooks []string
+
+	newActionAPIF func() (ActionsAPI, error)
 }
 
 const debugHooksDoc = `
-Interactively debug a hook remotely on an application unit.
+Interactively debug hooks or actions remotely on an application unit.
 
 See the "juju help ssh" for information about SSH related options
 accepted by the debug-hooks command.
@@ -41,8 +48,8 @@ accepted by the debug-hooks command.
 func (c *debugHooksCommand) Info() *cmd.Info {
 	return &cmd.Info{
 		Name:    "debug-hooks",
-		Args:    "<unit name> [hook names]",
-		Purpose: "Launch a tmux session to debug a hook.",
+		Args:    "<application or unit name> [hook or action names]",
+		Purpose: "Launch a tmux session to debug hooks and/or actions.",
 		Doc:     debugHooksDoc,
 	}
 }
@@ -68,10 +75,14 @@ func (c *debugHooksCommand) Init(args []string) error {
 }
 
 type charmRelationsAPI interface {
-	CharmRelations(serviceName string) ([]string, error)
+	CharmRelations(applicationName string) ([]string, error)
 }
 
-func (c *debugHooksCommand) getServiceAPI() (charmRelationsAPI, error) {
+type ActionsAPI interface {
+	ApplicationCharmActions(params.Entity) (map[string]params.ActionSpec, error)
+}
+
+func (c *debugHooksCommand) getApplicationAPI() (charmRelationsAPI, error) {
 	root, err := c.NewAPIRoot()
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -79,45 +90,87 @@ func (c *debugHooksCommand) getServiceAPI() (charmRelationsAPI, error) {
 	return application.NewClient(root), nil
 }
 
-func (c *debugHooksCommand) validateHooks() error {
+func (c *debugHooksCommand) newActionsAPI() (ActionsAPI, error) {
+	root, err := c.NewAPIRoot()
+	if err != nil {
+		return nil, err
+	}
+	return action.NewClient(root), nil
+}
+
+func (c *debugHooksCommand) validateHooksOrActions() error {
 	if len(c.hooks) == 0 {
 		return nil
 	}
-	service, err := names.UnitApplication(c.Target)
-	if err != nil {
-		return err
-	}
-	serviceAPI, err := c.getServiceAPI()
-	if err != nil {
-		return err
-	}
-	relations, err := serviceAPI.CharmRelations(service)
+	appName, err := names.UnitApplication(c.Target)
 	if err != nil {
 		return err
 	}
 
-	validHooks := make(map[string]bool)
+	// Get a set of valid hooks.
+	validHooks, err := c.getValidHooks(appName)
+	if err != nil {
+		return err
+	}
+
+	// Get a set of valid actions.
+	validActions, err := c.getValidActions(appName)
+	if err != nil {
+		return err
+	}
+
+	// Is passed argument a valid hook or action name?
+	// If not valid, err out.
+	allValid := validHooks.Union(validActions)
+	for _, hook := range c.hooks {
+		if !allValid.Contains(hook) {
+			logger.Infof("unknown hook or action %s, valid hook or action names: %v", hook, allValid.SortedValues())
+			return errors.Errorf("unit %q does not contain hook nor action %q", c.Target, hook)
+		}
+	}
+	return nil
+}
+
+func (c *debugHooksCommand) getValidActions(appName string) (set.Strings, error) {
+	appTag := names.NewApplicationTag(appName)
+	actionAPI, err := c.newActionAPIF()
+	if err != nil {
+		return nil, err
+	}
+
+	allActions, err := actionAPI.ApplicationCharmActions(params.Entity{Tag: appTag.String()})
+	if err != nil {
+		return nil, err
+	}
+
+	validActions := set.NewStrings()
+	for name, _ := range allActions {
+		validActions.Add(name)
+	}
+	return validActions, nil
+}
+
+func (c *debugHooksCommand) getValidHooks(appName string) (set.Strings, error) {
+	applicationAPI, err := c.getApplicationAPI()
+	if err != nil {
+		return nil, err
+	}
+	relations, err := applicationAPI.CharmRelations(appName)
+	if err != nil {
+		return nil, err
+	}
+
+	validHooks := set.NewStrings()
 	for _, hook := range hooks.UnitHooks() {
-		validHooks[string(hook)] = true
+		validHooks.Add(string(hook))
 	}
 	for _, relation := range relations {
 		for _, hook := range hooks.RelationHooks() {
 			hook := fmt.Sprintf("%s-%s", relation, hook)
-			validHooks[hook] = true
+			validHooks.Add(hook)
 		}
 	}
-	for _, hook := range c.hooks {
-		if !validHooks[hook] {
-			names := make([]string, 0, len(validHooks))
-			for hookName := range validHooks {
-				names = append(names, hookName)
-			}
-			sort.Strings(names)
-			logger.Infof("unknown hook %s, valid hook names: %v", hook, names)
-			return errors.Errorf("unit %q does not contain hook %q", c.Target, hook)
-		}
-	}
-	return nil
+	return validHooks, nil
 }
 
 // Run ensures c.Target is a unit, and resolves its address,
@@ -129,7 +182,7 @@ func (c *debugHooksCommand) Run(ctx *cmd.Context) error {
 		return err
 	}
 	defer c.cleanupRun()
-	err = c.validateHooks()
+	err = c.validateHooksOrActions()
 	if err != nil {
 		return err
 	}

--- a/cmd/juju/commands/debughooks_test.go
+++ b/cmd/juju/commands/debughooks_test.go
@@ -4,6 +4,7 @@
 package commands
 
 import (
+	"regexp"
 	"runtime"
 
 	"github.com/juju/cmd/cmdtesting"
@@ -114,7 +115,7 @@ var debugHooksTests = []struct {
 }, {
 	info:  `invalid hook`,
 	args:  []string{"mysql/0", "invalid-hook"},
-	error: `unit "mysql/0" does not contain hook nor action "invalid-hook"`,
+	error: `unit "mysql/0" contains neither hook nor action "invalid-hook", valid actions are [fakeaction] and valid hooks are [collect-metrics config-changed install juju-info-relation-broken juju-info-relation-changed juju-info-relation-departed juju-info-relation-joined leader-deposed leader-elected leader-settings-changed meter-status-changed server-admin-relation-broken server-admin-relation-changed server-admin-relation-departed server-admin-relation-joined server-relation-broken server-relation-changed server-relation-departed server-relation-joined start stop update-status upgrade-charm]`,
 }, {
 	info:  `no args at all`,
 	args:  nil,
@@ -137,7 +138,7 @@ func (s *DebugHooksSuite) TestDebugHooksCommand(c *gc.C) {
 
 		ctx, err := cmdtesting.RunCommand(c, newDebugHooksCommand(s.hostChecker), t.args...)
 		if t.error != "" {
-			c.Check(err, gc.ErrorMatches, t.error)
+			c.Check(err, gc.ErrorMatches, regexp.QuoteMeta(t.error))
 		} else {
 			c.Check(err, jc.ErrorIsNil)
 			if t.expected != nil {

--- a/cmd/juju/commands/debughooks_test.go
+++ b/cmd/juju/commands/debughooks_test.go
@@ -114,7 +114,7 @@ var debugHooksTests = []struct {
 }, {
 	info:  `invalid hook`,
 	args:  []string{"mysql/0", "invalid-hook"},
-	error: `unit "mysql/0" does not contain hook "invalid-hook"`,
+	error: `unit "mysql/0" does not contain hook nor action "invalid-hook"`,
 }, {
 	info:  `no args at all`,
 	args:  nil,

--- a/worker/uniter/runner/debug/client.go
+++ b/worker/uniter/runner/debug/client.go
@@ -15,12 +15,12 @@ type hookArgs struct {
 }
 
 // ClientScript returns a bash script suitable for executing
-// on the unit system to intercept hooks via tmux shell.
-func ClientScript(c *HooksContext, hooks []string) string {
-	// If any hook is "*", then the client is interested in all.
-	for _, hook := range hooks {
-		if hook == "*" {
-			hooks = nil
+// on the unit system to intercept hooks or actions via tmux shell.
+func ClientScript(c *HooksContext, args []string) string {
+	// If any argument is "*", then the client is interested in all.
+	for _, arg := range args {
+		if arg == "*" {
+			args = nil
 			break
 		}
 	}
@@ -30,15 +30,15 @@ func ClientScript(c *HooksContext, hooks []string) string {
 	s = strings.Replace(s, "{entry_flock}", c.ClientFileLock(), -1)
 	s = strings.Replace(s, "{exit_flock}", c.ClientExitFileLock(), -1)
 
-	yamlArgs := encodeArgs(hooks)
+	yamlArgs := encodeArgs(args)
 	base64Args := base64.StdEncoding.EncodeToString(yamlArgs)
 	s = strings.Replace(s, "{hook_args}", base64Args, 1)
 	return s
 }
 
-func encodeArgs(hooks []string) []byte {
+func encodeArgs(args []string) []byte {
 	// Marshal to YAML, then encode in base64 to avoid shell escapes.
-	yamlArgs, err := goyaml.Marshal(hookArgs{Hooks: hooks})
+	yamlArgs, err := goyaml.Marshal(hookArgs{Hooks: args})
 	if err != nil {
 		// This should not happen: we're in full control.
 		panic(err)

--- a/worker/uniter/runner/debug/client.go
+++ b/worker/uniter/runner/debug/client.go
@@ -15,12 +15,12 @@ type hookArgs struct {
 }
 
 // ClientScript returns a bash script suitable for executing
-// on the unit system to intercept hooks or actions via tmux shell.
-func ClientScript(c *HooksContext, args []string) string {
+// on the unit system to intercept matching hooks or actions via tmux shell.
+func ClientScript(c *HooksContext, match []string) string {
 	// If any argument is "*", then the client is interested in all.
-	for _, arg := range args {
-		if arg == "*" {
-			args = nil
+	for _, m := range match {
+		if m == "*" {
+			match = nil
 			break
 		}
 	}
@@ -30,7 +30,7 @@ func ClientScript(c *HooksContext, args []string) string {
 	s = strings.Replace(s, "{entry_flock}", c.ClientFileLock(), -1)
 	s = strings.Replace(s, "{exit_flock}", c.ClientExitFileLock(), -1)
 
-	yamlArgs := encodeArgs(args)
+	yamlArgs := encodeArgs(match)
 	base64Args := base64.StdEncoding.EncodeToString(yamlArgs)
 	s = strings.Replace(s, "{hook_args}", base64Args, 1)
 	return s

--- a/worker/uniter/runner/debug/server.go
+++ b/worker/uniter/runner/debug/server.go
@@ -165,12 +165,12 @@ exit $exitstatus
 `
 
 const debugHooksWelcomeMessage = `This is a Juju debug-hooks tmux session. Remember:
-1. You need to execute hooks manually if you want them to run for trapped events.
+1. You need to execute hooks/actions manually if you want them to run for trapped events.
 2. When you are finished with an event, you can run 'exit' to close the current window and allow Juju to continue processing
 new events for this unit without exiting a current debug-session.
-3. To run a hook and end the debugging session avoiding processing any more events manually, use:
+3. To run an action or hook and end the debugging session avoiding processing any more events manually, use:
 
-./hooks/$JUJU_HOOK_NAME
+./hooks/$JUJU_HOOK_NAME # or, equivalently, ./actions/$JUJU_HOOK_NAME
 tmux kill-session -t $JUJU_UNIT_NAME # or, equivalently, CTRL+a d
 
 4. CTRL+a is tmux prefix.


### PR DESCRIPTION
## Description of change

'debug-hooks' historically was used for hooks only. There is no reason why it should not be used for actions.

This PR allows for that to happen. 

## QA steps

1. bootstrap
2. deploy a charm with actions (I've used 'cs:~aisrael/netutils-4' to stay close to the linked bug)
3. use 'debug-hooks' to work with action (in my case - 'juju debug-hooks netutils/0 ping')
4. wait for the charm to finish deploying, we should not drop into the debug shell for any of the existing hooks (install, etc)
5. in another terminal run 'juju run-action netutils/0 ping destination=127.0.0.1' and see that it traps the action and opens another tmux window in the debug-hooks session.

## Documentation changes

As per linked bug, the documentation is ahead of us.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1640242
