### PR TITLE
provider/maas: fix zone logic in node selection

### DIFF
--- a/provider/maas/constraints_test.go
+++ b/provider/maas/constraints_test.go
@@ -207,8 +207,8 @@ func (suite *environSuite) TestSelectNodeValidZone(c *gc.C) {
 	suite.testMAASObject.TestServer.NewNode(`{"system_id": "node0", "hostname": "host0", "zone": "bar"}`)
 
 	snArgs := selectNodeArgs{
-		AvailabilityZones: []string{"bar", "foo"},
-		Constraints:       constraints.Value{},
+		AvailabilityZone: "bar",
+		Constraints:      constraints.Value{},
 	}
 
 	node, err := env.selectNode(snArgs)
@@ -220,8 +220,8 @@ func (suite *environSuite) TestSelectNodeInvalidZone(c *gc.C) {
 	env := suite.makeEnviron()
 
 	snArgs := selectNodeArgs{
-		AvailabilityZones: []string{"foo", "bar"},
-		Constraints:       constraints.Value{},
+		AvailabilityZone: "foo",
+		Constraints:      constraints.Value{},
 	}
 
 	_, err := env.selectNode(snArgs)

--- a/provider/maas/environ.go
+++ b/provider/maas/environ.go
@@ -902,26 +902,31 @@ func (*maasEnviron) MaintainInstance(args environs.StartInstanceParams) error {
 func (environ *maasEnviron) StartInstance(args environs.StartInstanceParams) (
 	*environs.StartInstanceResult, error,
 ) {
-	var availabilityZone, nodeName, systemId string
+	availabilityZone := args.AvailabilityZone
+	var nodeName, systemId string
 	if args.Placement != "" {
 		placement, err := environ.parsePlacement(args.Placement)
 		if err != nil {
 			return nil, err
 		}
+		// NOTE(axw) we wipe out args.AvailabilityZone if the
+		// user specified a specific node or system ID via
+		// placement, as placement must always take precedence.
 		switch {
-		case placement.zoneName != "":
-			availabilityZone = placement.zoneName
 		case placement.systemId != "":
+			availabilityZone = ""
 			systemId = placement.systemId
-		default:
+		case placement.nodeName != "":
+			availabilityZone = ""
 			nodeName = placement.nodeName
 		}
-	} else if args.AvailabilityZone != "" {
-		availabilityZone = args.AvailabilityZone
+	}
+	if availabilityZone != "" {
 		if err := common.ValidateAvailabilityZone(environ, availabilityZone); err != nil {
 			logger.Errorf(err.Error())
 			return nil, errors.Wrap(err, environs.ErrAvailabilityZoneFailed)
 		}
+		logger.Debugf("attempting to acquire node in zone %q", availabilityZone)
 	}
 
 	// Storage.
@@ -940,12 +945,12 @@ func (environ *maasEnviron) StartInstance(args environs.StartInstanceParams) (
 		}
 	}
 	snArgs := selectNodeArgs{
-		Constraints:       args.Constraints,
-		AvailabilityZones: []string{availabilityZone},
-		NodeName:          nodeName,
-		SystemId:          systemId,
-		Interfaces:        interfaceBindings,
-		Volumes:           volumes,
+		Constraints:      args.Constraints,
+		AvailabilityZone: availabilityZone,
+		NodeName:         nodeName,
+		SystemId:         systemId,
+		Interfaces:       interfaceBindings,
+		Volumes:          volumes,
 	}
 	var inst maasInstance
 	if !environ.usingMAAS2() {
@@ -1266,70 +1271,53 @@ func deploymentStatusCall(nodes gomaasapi.MAASObject, ids ...instance.Id) (gomaa
 }
 
 type selectNodeArgs struct {
-	AvailabilityZones []string
-	NodeName          string
-	SystemId          string
-	Constraints       constraints.Value
-	Interfaces        []interfaceBinding
-	Volumes           []volumeInfo
+	AvailabilityZone string
+	NodeName         string
+	SystemId         string
+	Constraints      constraints.Value
+	Interfaces       []interfaceBinding
+	Volumes          []volumeInfo
 }
 
 func (environ *maasEnviron) selectNode(args selectNodeArgs) (*gomaasapi.MAASObject, error) {
-	var err error
-	var node gomaasapi.MAASObject
-
-	for i, zoneName := range args.AvailabilityZones {
-		node, err = environ.acquireNode(
-			args.NodeName,
-			zoneName,
-			args.SystemId,
-			args.Constraints,
-			args.Interfaces,
-			args.Volumes,
-		)
-
-		if err, ok := errors.Cause(err).(gomaasapi.ServerError); ok && err.StatusCode == http.StatusConflict {
-			if i+1 < len(args.AvailabilityZones) {
-				logger.Infof("could not acquire a node in zone %q, trying another zone", zoneName)
-				return nil, environs.ErrAvailabilityZoneFailed
-			}
-		}
-		if err != nil {
-			return nil, errors.Errorf("cannot run instances: %v", err)
-		}
-		// Since a return at the end of the function is required
-		// just break here.
-		break
+	node, err := environ.acquireNode(
+		args.NodeName,
+		args.AvailabilityZone,
+		args.SystemId,
+		args.Constraints,
+		args.Interfaces,
+		args.Volumes,
+	)
+	if args.AvailabilityZone != "" && isConflictError(err) {
+		logger.Debugf("could not acquire a node in zone %q", args.AvailabilityZone)
+		return nil, environs.ErrAvailabilityZoneFailed
+	}
+	if err != nil {
+		return nil, errors.Errorf("cannot run instances: %v", err)
 	}
 	return &node, nil
 }
 
+func isConflictError(err error) bool {
+	serverErr, ok := errors.Cause(err).(gomaasapi.ServerError)
+	return ok && serverErr.StatusCode == http.StatusConflict
+}
+
 func (environ *maasEnviron) selectNode2(args selectNodeArgs) (maasInstance, error) {
-	var err error
-	var inst maasInstance
-
-	for i, zoneName := range args.AvailabilityZones {
-		inst, err = environ.acquireNode2(
-			args.NodeName,
-			zoneName,
-			args.SystemId,
-			args.Constraints,
-			args.Interfaces,
-			args.Volumes,
-		)
-
-		if gomaasapi.IsNoMatchError(err) {
-			if i+1 < len(args.AvailabilityZones) {
-				logger.Infof("could not acquire a node in zone %q, trying another zone", zoneName)
-				return nil, environs.ErrAvailabilityZoneFailed
-			}
-		}
-		if err != nil {
-			return nil, errors.Annotatef(err, "cannot run instance")
-		}
-		// Since a return at the end of the function is required
-		// just break here.
-		break
+	inst, err := environ.acquireNode2(
+		args.NodeName,
+		args.AvailabilityZone,
+		args.SystemId,
+		args.Constraints,
+		args.Interfaces,
+		args.Volumes,
+	)
+	if args.AvailabilityZone != "" && gomaasapi.IsNoMatchError(err) {
+		logger.Debugf("could not acquire a node in zone %q", args.AvailabilityZone)
+		return nil, environs.ErrAvailabilityZoneFailed
+	}
+	if err != nil {
+		return nil, errors.Annotatef(err, "cannot run instance")
 	}
 	return inst, nil
 }

--- a/provider/maas/maas2_environ_whitebox_test.go
+++ b/provider/maas/maas2_environ_whitebox_test.go
@@ -347,9 +347,9 @@ func (suite *maas2EnvironSuite) TestStartInstanceParams(c *gc.C) {
 	suite.setupFakeTools(c)
 	env = suite.makeEnviron(c, nil)
 	params := environs.StartInstanceParams{
-		ControllerUUID: suite.controllerUUID,
-		Placement:      "zone=foo",
-		Constraints:    constraints.MustParse("mem=8G"),
+		ControllerUUID:   suite.controllerUUID,
+		AvailabilityZone: "foo",
+		Constraints:      constraints.MustParse("mem=8G"),
 	}
 	result, err := jujutesting.StartInstanceWithParams(env, "1", params)
 	c.Assert(err, jc.ErrorIsNil)
@@ -2295,7 +2295,7 @@ func (suite *maas2EnvironSuite) TestBootstrapFailsIfNoNodes(c *gc.C) {
 	})
 	// Since there are no nodes, the attempt to allocate one returns a
 	// 409: Conflict.
-	c.Check(err, gc.ErrorMatches, ".*cannot run instances.*")
+	c.Check(err, gc.ErrorMatches, "cannot start bootstrap instance: failed to start instance in any availability zone")
 }
 
 func (suite *maas2EnvironSuite) TestGetToolsMetadataSources(c *gc.C) {


### PR DESCRIPTION
## Description of change

Update the selectNode methods to accept a single
availability zone (or none), and return the special
ErrAvailabilityZoneFailed error iff a zone was
specified and acquiring a node in that zone failed
to find a node matching the constraints. This makes
the code simpler, and eliminates the code that
contained an off-by-one error.

## QA steps

1. Create an empty zone in MAAS called "azone" (or anything else lexicographically < "default")
2. juju bootstrap
(should fail before the change, succeed after)
3. juju deploy -n 2 ubuntu
(should get 2 units in "default" zone, since "azone" has no nodes)

## Documentation changes

None.

## Bug reference

Fixes https://bugs.launchpad.net/juju/+bug/1732021