### PR TITLE
Make it a faster to get the full list of models.

### DIFF
--- a/apiserver/common/modelmanagerinterface.go
+++ b/apiserver/common/modelmanagerinterface.go
@@ -160,11 +160,7 @@ func (st modelManagerStateShim) GetModel(modelUUID string) (Model, func() bool, 
 
 // Model implements ModelManagerBackend.
 func (st modelManagerStateShim) Model() (Model, error) {
-	m, err := st.State.Model()
-	if err != nil {
-		return nil, err
-	}
-	return modelShim{m}, nil
+	return modelShim{st.model}, nil
 }
 
 var _ Model = (*modelShim)(nil)

--- a/apiserver/facades/client/modelmanager/modelmanager.go
+++ b/apiserver/facades/client/modelmanager/modelmanager.go
@@ -718,11 +718,6 @@ func (m *ModelManagerAPI) ListModels(user params.Entity) (params.UserModelList, 
 			lastConn = &userLastConn
 		}
 
-		model, err = st.Model()
-		if err != nil {
-			return result, errors.Trace(err)
-		}
-
 		result.UserModels = append(result.UserModels, params.UserModel{
 			Model: params.Model{
 				Name:     model.Name(),


### PR DESCRIPTION
## Description of change

We were loading the models 3 times, when we could just load it one time.

This has 2 fixes. One is clearly uncontroversial because we are just removing a call to st.Model when we already had the model.

The second changes the backend shim, which has more wide ranging impact. But if calling GetBackend has to read the database anyway, it doesn't make a lot of sense to not make use of that object.

## QA steps

No change in the test suite.
```
juju bootstrap
for I in `seq 200`; do juju add-model m$I; done
time juju models >/dev/null
```

Should average out to be a fair bit faster.
On my system it's a couple hundred ms faster.

## Documentation changes

Does it affect current user workflow? CLI? API?

## Bug reference

[lp:1732384](https://bugs.launchpad.net/bugs/1732384)