### PR TITLE
Quick improvement for bug #1732509.

### DIFF
--- a/state/allcollections.go
+++ b/state/allcollections.go
@@ -218,7 +218,11 @@ func allCollections() collectionSchema {
 
 		// This collection holds users related to a model and will be used as one
 		// of the intersection axis of permissionsC
-		modelUsersC: {},
+		modelUsersC: {
+			indexes: []mgo.Index{{
+				Key: []string{"model-uuid"},
+			}},
+		},
 
 		// This collection contains governors that prevent certain kinds of
 		// changes from being accepted.


### PR DESCRIPTION
## Description of change

Model.Users() does a lookup based on model-uuid, but we don't have an
index. So on controllers with many models (but maybe not many users in
any given model), it has to do a collection scan over all model*users
for every model, leading to model*(model*users) = M^2. This at least
improves that bit, though we can do much better with some rewrites.

I'm working on a much more complete rewrite and fix that shows significant promise, but this is a *very* quick win that will still help.

https://github.com/jameinel/juju/tree/2.3-direct-models-1732384

## QA steps

```
$ juju bootstrap lxd
$ for i in `seq 200`; do juju add-model m$i; done
$ time juju models # repeat a few times
$ # create the index
$ time juju models # much better
```

## Documentation changes

No

## Bug reference

[lp:1732509](https://bugs.launchpad.net/juju/+bug/1732509)