### PR TITLE
worker/state: change output to *StatePool

### DIFF
--- a/cmd/juju/model/destroy.go
+++ b/cmd/juju/model/destroy.go
@@ -338,9 +338,9 @@ func newTimedModelStatus(ctx *cmd.Context, api DestroyModelAPI, tag names.ModelT
 			return nil
 		}
 		if status[0].Error != nil {
-			// This most likely occurred because a model was
-			// destroyed half-way through the call.
-			ctx.Infof("Could not get the model status from the API: %v.", err)
+			if params.ErrCode(status[0].Error) != params.CodeNotFound {
+				ctx.Infof("Could not get the model status from the API: %v.", status[0].Error)
+			}
 			return nil
 		}
 		return &modelData{

--- a/cmd/jujud/agent/introspection.go
+++ b/cmd/jujud/agent/introspection.go
@@ -6,6 +6,7 @@ package agent
 import (
 	"os"
 	"runtime"
+	"sync"
 
 	"github.com/juju/errors"
 	"github.com/prometheus/client_golang/prometheus"
@@ -13,6 +14,7 @@ import (
 	worker "gopkg.in/juju/worker.v1"
 
 	"github.com/juju/juju/agent"
+	"github.com/juju/juju/state"
 	"github.com/juju/juju/worker/dependency"
 	"github.com/juju/juju/worker/introspection"
 )
@@ -85,7 +87,21 @@ func newPrometheusRegistry() (*prometheus.Registry, error) {
 	return r, nil
 }
 
-func (h *statePoolHolder) IntrospectionReport() string {
+// statePoolIntrospectionReporter wraps a (possibly nil) state.StatePool,
+// calling its IntrospectionReport method or returning a message if it
+// is nil.
+type statePoolIntrospectionReporter struct {
+	mu   sync.Mutex
+	pool *state.StatePool
+}
+
+func (h *statePoolIntrospectionReporter) set(pool *state.StatePool) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.pool = pool
+}
+
+func (h *statePoolIntrospectionReporter) IntrospectionReport() string {
 	h.mu.Lock()
 	defer h.mu.Unlock()
 	if h.pool == nil {

--- a/cmd/jujud/agent/machine/manifolds.go
+++ b/cmd/jujud/agent/machine/manifolds.go
@@ -191,14 +191,9 @@ type ManifoldsConfig struct {
 	// to API server instances for validating logins.
 	LoginValidator apiserver.LoginValidator
 
-	// SetStatePool is used bythe API server for informing the agent of the
-	// StatePool that it creates, so we can pass it to the introspection
-	// worker.
-	//
-	// TODO(axw) we should have a manifold that maintains a StatePool, and
-	// pass that into the API server. We would also pass the StatePool into
-	// another manifold that will be responsible for un/registering the
-	// StatePool with an introspection reporter.
+	// SetStatePool is used by the state worker for informing the agent of
+	// the StatePool that it creates, so we can pass it to the introspection
+	// worker running outside of the dependency engine.
 	SetStatePool func(*state.StatePool)
 
 	// RegisterIntrospectionHTTPHandlers is a function that calls the
@@ -331,6 +326,8 @@ func Manifolds(config ManifoldsConfig) dependency.Manifolds {
 			AgentName:              agentName,
 			StateConfigWatcherName: stateConfigWatcherName,
 			OpenState:              config.OpenState,
+			PrometheusRegisterer:   config.PrometheusRegisterer,
+			SetStatePool:           config.SetStatePool,
 		}),
 
 		// The stateworkers manifold starts workers which rely on a
@@ -663,7 +660,6 @@ func Manifolds(config ManifoldsConfig) dependency.Manifolds {
 			RegisterIntrospectionHTTPHandlers: config.RegisterIntrospectionHTTPHandlers,
 			LoginValidator:                    config.LoginValidator,
 			Hub:                               config.CentralHub,
-			SetStatePool:                      config.SetStatePool,
 			NewWorker:                         apiserver.NewWorker,
 			NewStoreAuditEntryFunc:            apiserver.NewStateStoreAuditEntryFunc,
 		}),

--- a/cmd/jujud/agent/machine/stateworkers.go
+++ b/cmd/jujud/agent/machine/stateworkers.go
@@ -41,12 +41,12 @@ func StateWorkersManifold(config StateWorkersConfig) dependency.Manifold {
 				return nil, err
 			}
 
-			st, err := stTracker.Use()
+			stPool, err := stTracker.Use()
 			if err != nil {
 				return nil, errors.Annotate(err, "acquiring state")
 			}
 
-			w, err := config.StartStateWorkers(st)
+			w, err := config.StartStateWorkers(stPool.SystemState())
 			if err != nil {
 				stTracker.Done()
 				return nil, errors.Annotate(err, "worker startup")

--- a/cmd/jujud/agent/machine/stateworkers_test.go
+++ b/cmd/jujud/agent/machine/stateworkers_test.go
@@ -104,10 +104,10 @@ type mockStateTracker struct {
 	doneCalled bool
 }
 
-func (t *mockStateTracker) Use() (*state.State, error) {
+func (t *mockStateTracker) Use() (*state.StatePool, error) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
-	return new(state.State), nil
+	return new(state.StatePool), nil
 }
 
 func (t *mockStateTracker) Done() error {

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -2135,9 +2135,11 @@ func (s *StateSuite) TestWatchModelsLifecycle(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	err = st1.ProcessDyingModel()
 	c.Assert(err, jc.ErrorIsNil)
+	wc.AssertChange(model.UUID())
+	wc.AssertNoChange()
+
 	err = st1.RemoveAllModelDocs()
 	c.Assert(err, jc.ErrorIsNil)
-	wc.AssertChange(model.UUID())
 	wc.AssertNoChange()
 }
 

--- a/state/watcher.go
+++ b/state/watcher.go
@@ -210,9 +210,8 @@ func (st *State) WatchModels() StringsWatcher {
 }
 
 // WatchModelLives returns a StringsWatcher that notifies of changes
-// to any model life values. The most important difference between
-// this and WatchModels is that this will signal one last time if a
-// model is removed.
+// to any model life values. The watcher will not send any more events
+// for a model after it has been observed to be Dead.
 func (st *State) WatchModelLives() StringsWatcher {
 	return newLifecycleWatcher(st, modelsC, nil, nil, nil)
 }

--- a/worker/apiserver/worker.go
+++ b/worker/apiserver/worker.go
@@ -19,8 +19,6 @@ import (
 	"github.com/juju/juju/agent"
 	"github.com/juju/juju/apiserver"
 	"github.com/juju/juju/state"
-	"github.com/juju/juju/state/statemetrics"
-	"github.com/juju/juju/worker/catacomb"
 )
 
 var logger = loggo.GetLogger("juju.worker.apiserver")
@@ -30,10 +28,9 @@ type Config struct {
 	AgentConfig                       agent.Config
 	Clock                             clock.Clock
 	Hub                               *pubsub.StructuredHub
-	State                             *state.State
+	StatePool                         *state.StatePool
 	PrometheusRegisterer              prometheus.Registerer
 	RegisterIntrospectionHTTPHandlers func(func(path string, _ http.Handler))
-	SetStatePool                      func(*state.StatePool)
 	LoginValidator                    LoginValidator
 	GetCertificate                    func() *tls.Certificate
 	StoreAuditEntry                   StoreAuditEntryFunc
@@ -42,10 +39,6 @@ type Config struct {
 
 // NewServerFunc is the type of function that will be used
 // by the worker to create a new API server.
-//
-// NOTE(axw) when we manage a StatePool in a manifold, we
-// can get rid of the worker in this package and return
-// the juju/apiserver worker directly from the manifold.
 type NewServerFunc func(*state.StatePool, net.Listener, apiserver.ServerConfig) (worker.Worker, error)
 
 // Validate validates the API server configuration.
@@ -59,17 +52,14 @@ func (config Config) Validate() error {
 	if config.Hub == nil {
 		return errors.NotValidf("nil Hub")
 	}
-	if config.State == nil {
-		return errors.NotValidf("nil State")
+	if config.StatePool == nil {
+		return errors.NotValidf("nil StatePool")
 	}
 	if config.PrometheusRegisterer == nil {
 		return errors.NotValidf("nil PrometheusRegisterer")
 	}
 	if config.RegisterIntrospectionHTTPHandlers == nil {
 		return errors.NotValidf("nil RegisterIntrospectionHTTPHandlers")
-	}
-	if config.SetStatePool == nil {
-		return errors.NotValidf("nil SetStatePool")
 	}
 	if config.LoginValidator == nil {
 		return errors.NotValidf("nil LoginValidator")
@@ -110,7 +100,7 @@ func NewWorker(config Config) (worker.Worker, error) {
 		return nil, errors.Annotate(err, "getting log sink config")
 	}
 
-	controllerConfig, err := config.State.ControllerConfig()
+	controllerConfig, err := config.StatePool.SystemState().ControllerConfig()
 	if err != nil {
 		return nil, errors.Annotate(err, "cannot fetch the controller config")
 	}
@@ -145,72 +135,18 @@ func NewWorker(config Config) (worker.Worker, error) {
 		PrometheusRegisterer:          config.PrometheusRegisterer,
 	}
 
-	w := apiserverWorker{
-		st:           config.State,
-		listenAddr:   listenAddr,
-		setStatePool: config.SetStatePool,
-		config:       serverConfig,
-		newServer:    config.NewServer,
-	}
-	if err := catacomb.Invoke(catacomb.Plan{
-		Site: &w.catacomb,
-		Work: w.loop,
-	}); err != nil {
+	listener, err := net.Listen("tcp", listenAddr)
+	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	return &w, nil
-}
-
-// apiserverWorker is a worker.Worker that wraps an
-// apiserver.Server, and the resources it requires.
-type apiserverWorker struct {
-	catacomb     catacomb.Catacomb
-	st           *state.State
-	listenAddr   string
-	setStatePool func(*state.StatePool)
-	config       apiserver.ServerConfig
-	newServer    NewServerFunc
-}
-
-// Kill is part of the worker.Worker interface.
-func (w *apiserverWorker) Kill() {
-	w.catacomb.Kill(nil)
-}
-
-// Wait is part of the worker.Wait interface.
-func (w *apiserverWorker) Wait() error {
-	return w.catacomb.Wait()
-}
-
-func (w *apiserverWorker) loop() error {
-	// TODO(axw) the API server should be accepting a StatePool
-	// as a manifold input, and the manifold that accepts the
-	// state pool should be un/registering the state pool with
-	// the Prometheus registry.
-	statePool := state.NewStatePool(w.st)
-	defer statePool.Close()
-	w.setStatePool(statePool)
-	defer w.setStatePool(nil)
-	collector := statemetrics.New(statemetrics.NewStatePool(statePool))
-	w.config.PrometheusRegisterer.Register(collector)
-	defer w.config.PrometheusRegisterer.Unregister(collector)
-
-	listener, err := net.Listen("tcp", w.listenAddr)
+	server, err := config.NewServer(config.StatePool, listener, serverConfig)
 	if err != nil {
-		return errors.Trace(err)
+		if err := listener.Close(); err != nil {
+			logger.Warningf("failed to close listener: %s", err)
+		}
+		return nil, errors.Trace(err)
 	}
-	server, err := w.newServer(statePool, listener, w.config)
-	if err != nil {
-		listener.Close()
-		return errors.Trace(err)
-	}
-	w.catacomb.Add(server)
-
-	// Wait for server to finish before returning,
-	// so we don't tear out the server pool from
-	// underneath them.
-	server.Wait()
-	return w.catacomb.ErrDying()
+	return server, nil
 }
 
 func newServerShim(

--- a/worker/apiserver/worker_state_test.go
+++ b/worker/apiserver/worker_state_test.go
@@ -43,7 +43,7 @@ func (s *WorkerStateSuite) TearDownSuite(c *gc.C) {
 func (s *WorkerStateSuite) SetUpTest(c *gc.C) {
 	s.workerFixture.SetUpTest(c)
 	s.StateSuite.SetUpTest(c)
-	s.config.State = s.State
+	s.config.StatePool = s.StatePool
 }
 
 func (s *WorkerStateSuite) TearDownTest(c *gc.C) {

--- a/worker/apiserver/worker_test.go
+++ b/worker/apiserver/worker_test.go
@@ -54,10 +54,9 @@ func (s *workerFixture) SetUpTest(c *gc.C) {
 		AgentConfig:                       &s.agentConfig,
 		Clock:                             s.clock,
 		Hub:                               &s.hub,
-		State:                             &state.State{},
+		StatePool:                         &state.StatePool{},
 		PrometheusRegisterer:              &s.prometheusRegisterer,
 		RegisterIntrospectionHTTPHandlers: func(func(string, http.Handler)) {},
-		SetStatePool:                      func(*state.StatePool) {},
 		LoginValidator:                    func(names.Tag) error { return nil },
 		GetCertificate:                    func() *tls.Certificate { return nil },
 		StoreAuditEntry:                   s.storeAuditEntry,
@@ -105,17 +104,14 @@ func (s *WorkerValidationSuite) TestValidateErrors(c *gc.C) {
 		func(cfg *apiserver.Config) { cfg.Hub = nil },
 		"nil Hub not valid",
 	}, {
-		func(cfg *apiserver.Config) { cfg.State = nil },
-		"nil State not valid",
+		func(cfg *apiserver.Config) { cfg.StatePool = nil },
+		"nil StatePool not valid",
 	}, {
 		func(cfg *apiserver.Config) { cfg.PrometheusRegisterer = nil },
 		"nil PrometheusRegisterer not valid",
 	}, {
 		func(cfg *apiserver.Config) { cfg.RegisterIntrospectionHTTPHandlers = nil },
 		"nil RegisterIntrospectionHTTPHandlers not valid",
-	}, {
-		func(cfg *apiserver.Config) { cfg.SetStatePool = nil },
-		"nil SetStatePool not valid",
 	}, {
 		func(cfg *apiserver.Config) { cfg.LoginValidator = nil },
 		"nil LoginValidator not valid",

--- a/worker/dblogpruner/manifold.go
+++ b/worker/dblogpruner/manifold.go
@@ -67,13 +67,13 @@ func (config ManifoldConfig) start(context dependency.Context) (worker.Worker, e
 	if err := context.Get(config.StateName, &stTracker); err != nil {
 		return nil, errors.Trace(err)
 	}
-	st, err := stTracker.Use()
+	statePool, err := stTracker.Use()
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
 
 	worker, err := config.NewWorker(Config{
-		State:         st,
+		State:         statePool.SystemState(),
 		Clock:         clock,
 		PruneInterval: config.PruneInterval,
 	})

--- a/worker/globalclockupdater/manifold.go
+++ b/worker/globalclockupdater/manifold.go
@@ -71,13 +71,13 @@ func (config ManifoldConfig) start(context dependency.Context) (worker.Worker, e
 	if err := context.Get(config.StateName, &stTracker); err != nil {
 		return nil, errors.Trace(err)
 	}
-	st, err := stTracker.Use()
+	statePool, err := stTracker.Use()
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
 
 	worker, err := config.NewWorker(Config{
-		NewUpdater:     st.GlobalClockUpdater,
+		NewUpdater:     statePool.SystemState().GlobalClockUpdater,
 		LocalClock:     clock,
 		UpdateInterval: config.UpdateInterval,
 		BackoffDelay:   config.BackoffDelay,

--- a/worker/globalclockupdater/manifold_test.go
+++ b/worker/globalclockupdater/manifold_test.go
@@ -192,13 +192,13 @@ type fakeClock struct {
 
 type stubStateTracker struct {
 	testing.Stub
-	st   state.State
+	pool state.StatePool
 	done chan struct{}
 }
 
-func (s *stubStateTracker) Use() (*state.State, error) {
+func (s *stubStateTracker) Use() (*state.StatePool, error) {
 	s.MethodCall(s, "Use")
-	return &s.st, s.NextErr()
+	return &s.pool, s.NextErr()
 }
 
 func (s *stubStateTracker) Done() error {

--- a/worker/state/manifold.go
+++ b/worker/state/manifold.go
@@ -4,15 +4,19 @@
 package state
 
 import (
+	"sync"
 	"time"
 
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
+	"github.com/prometheus/client_golang/prometheus"
 	worker "gopkg.in/juju/worker.v1"
 	"gopkg.in/tomb.v1"
 
 	coreagent "github.com/juju/juju/agent"
 	"github.com/juju/juju/state"
+	"github.com/juju/juju/state/statemetrics"
+	"github.com/juju/juju/worker/catacomb"
 	"github.com/juju/juju/worker/dependency"
 )
 
@@ -24,6 +28,34 @@ type ManifoldConfig struct {
 	StateConfigWatcherName string
 	OpenState              func(coreagent.Config) (*state.State, error)
 	PingInterval           time.Duration
+	PrometheusRegisterer   prometheus.Registerer
+
+	// SetStatePool is called with the state pool when it is created,
+	// and called again with nil just before the state pool is closed.
+	// This is used for publishing the state pool to the agent's
+	// introspection worker, which runs outside of the dependency
+	// engine; hence the manifold's Output cannot be relied upon.
+	SetStatePool func(*state.StatePool)
+}
+
+// Validate validates the manifold configuration.
+func (config ManifoldConfig) Validate() error {
+	if config.AgentName == "" {
+		return errors.NotValidf("empty AgentName")
+	}
+	if config.StateConfigWatcherName == "" {
+		return errors.NotValidf("empty StateConfigWatcherName")
+	}
+	if config.OpenState == nil {
+		return errors.NotValidf("nil OpenState")
+	}
+	if config.PrometheusRegisterer == nil {
+		return errors.NotValidf("nil PrometheusRegisterer")
+	}
+	if config.SetStatePool == nil {
+		return errors.NotValidf("nil SetStatePool")
+	}
+	return nil
 }
 
 const defaultPingInterval = 15 * time.Second
@@ -38,9 +70,8 @@ func Manifold(config ManifoldConfig) dependency.Manifold {
 			config.StateConfigWatcherName,
 		},
 		Start: func(context dependency.Context) (worker.Worker, error) {
-			// First, a sanity check.
-			if config.OpenState == nil {
-				return nil, errors.New("OpenState is nil in config")
+			if err := config.Validate(); err != nil {
+				return nil, errors.Trace(err)
 			}
 
 			// Get the agent.
@@ -71,16 +102,20 @@ func Manifold(config ManifoldConfig) dependency.Manifold {
 			}
 
 			w := &stateWorker{
-				stTracker:    stTracker,
-				pingInterval: pingInterval,
+				stTracker:            stTracker,
+				pingInterval:         pingInterval,
+				prometheusRegisterer: config.PrometheusRegisterer,
+				setStatePool:         config.SetStatePool,
 			}
-			go func() {
-				defer w.tomb.Done()
-				w.tomb.Kill(w.loop())
+			if err := catacomb.Invoke(catacomb.Plan{
+				Site: &w.catacomb,
+				Work: w.loop,
+			}); err != nil {
 				if err := stTracker.Done(); err != nil {
-					logger.Errorf("error releasing state: %v", err)
+					logger.Warningf("error releasing state: %v", err)
 				}
-			}()
+				return nil, errors.Trace(err)
+			}
 			return w, nil
 		},
 		Output: outputFunc,
@@ -104,17 +139,140 @@ func outputFunc(in worker.Worker, out interface{}) error {
 }
 
 type stateWorker struct {
-	tomb         tomb.Tomb
-	stTracker    StateTracker
-	pingInterval time.Duration
+	catacomb             catacomb.Catacomb
+	stTracker            StateTracker
+	pingInterval         time.Duration
+	prometheusRegisterer prometheus.Registerer
+	setStatePool         func(*state.StatePool)
+	cleanupOnce          sync.Once
 }
 
 func (w *stateWorker) loop() error {
-	st, err := w.stTracker.Use()
+	pool, err := w.stTracker.Use()
 	if err != nil {
-		return errors.Annotate(err, "failed to obtain state")
+		return errors.Trace(err)
 	}
 	defer w.stTracker.Done()
+
+	collector := statemetrics.New(statemetrics.NewStatePool(pool))
+	w.prometheusRegisterer.Register(collector)
+	defer w.prometheusRegisterer.Unregister(collector)
+
+	w.setStatePool(pool)
+	defer w.setStatePool(nil)
+
+	modelWatcher := pool.SystemState().WatchModelLives()
+	w.catacomb.Add(modelWatcher)
+
+	modelStateWorkers := make(map[string]worker.Worker)
+	for {
+		select {
+		case <-w.catacomb.Dying():
+			return w.catacomb.ErrDying()
+
+		case modelUUIDs := <-modelWatcher.Changes():
+			for _, modelUUID := range modelUUIDs {
+				if err := w.processModelLifeChange(
+					modelUUID,
+					modelStateWorkers,
+					pool,
+				); err != nil {
+					return errors.Trace(err)
+				}
+			}
+		}
+	}
+}
+
+func (w *stateWorker) processModelLifeChange(
+	modelUUID string,
+	modelStateWorkers map[string]worker.Worker,
+	pool *state.StatePool,
+) error {
+	remove := func() {
+		if w, ok := modelStateWorkers[modelUUID]; ok {
+			w.Kill()
+			delete(modelStateWorkers, modelUUID)
+		}
+		pool.Remove(modelUUID)
+	}
+
+	model, release, err := pool.GetModel(modelUUID)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			// Model has been removed from state.
+			logger.Debugf("model %q removed from state", modelUUID)
+			remove()
+			return nil
+		}
+		return errors.Trace(err)
+	}
+	defer release()
+
+	if model.Life() == state.Dead {
+		// Model is Dead, and will soon be removed from state.
+		logger.Debugf("model %q is dead", modelUUID)
+		remove()
+		return nil
+	}
+
+	if modelStateWorkers[modelUUID] == nil {
+		mw := newModelStateWorker(pool, modelUUID, w.pingInterval)
+		modelStateWorkers[modelUUID] = mw
+		w.catacomb.Add(mw)
+	}
+
+	return nil
+}
+
+// Kill is part of the worker.Worker interface.
+func (w *stateWorker) Kill() {
+	w.catacomb.Kill(nil)
+}
+
+// Wait is part of the worker.Worker interface.
+func (w *stateWorker) Wait() error {
+	err := w.catacomb.Wait()
+	w.cleanupOnce.Do(func() {
+		// Make sure the worker has exited before closing state.
+		if err := w.stTracker.Done(); err != nil {
+			logger.Warningf("error releasing state: %v", err)
+		}
+	})
+	return err
+}
+
+type modelStateWorker struct {
+	tomb         tomb.Tomb
+	pool         *state.StatePool
+	modelUUID    string
+	pingInterval time.Duration
+}
+
+func newModelStateWorker(
+	pool *state.StatePool,
+	modelUUID string,
+	pingInterval time.Duration,
+) worker.Worker {
+	w := &modelStateWorker{
+		pool:         pool,
+		modelUUID:    modelUUID,
+		pingInterval: pingInterval,
+	}
+	go func() {
+		defer w.tomb.Done()
+		w.tomb.Kill(w.loop())
+	}()
+	return w
+}
+
+func (w *modelStateWorker) loop() error {
+	st, release, err := w.pool.Get(w.modelUUID)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	defer release()
+	defer w.pool.Remove(w.modelUUID)
 
 	for {
 		select {
@@ -129,11 +287,11 @@ func (w *stateWorker) loop() error {
 }
 
 // Kill is part of the worker.Worker interface.
-func (w *stateWorker) Kill() {
+func (w *modelStateWorker) Kill() {
 	w.tomb.Kill(nil)
 }
 
 // Wait is part of the worker.Worker interface.
-func (w *stateWorker) Wait() error {
+func (w *modelStateWorker) Wait() error {
 	return w.tomb.Wait()
 }

--- a/worker/state/manifold_test.go
+++ b/worker/state/manifold_test.go
@@ -4,11 +4,12 @@
 package state_test
 
 import (
-	"errors"
 	"time"
 
+	"github.com/juju/errors"
 	jujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
+	"github.com/prometheus/client_golang/prometheus"
 	gc "gopkg.in/check.v1"
 	worker "gopkg.in/juju/worker.v1"
 
@@ -19,16 +20,18 @@ import (
 	"github.com/juju/juju/worker/dependency"
 	dt "github.com/juju/juju/worker/dependency/testing"
 	workerstate "github.com/juju/juju/worker/state"
+	"github.com/juju/juju/worker/workertest"
 )
 
 type ManifoldSuite struct {
 	statetesting.StateSuite
-	manifold        dependency.Manifold
-	openStateCalled bool
-	openStateErr    error
-	config          workerstate.ManifoldConfig
-	agent           *mockAgent
-	resources       dt.StubResources
+	manifold          dependency.Manifold
+	openStateCalled   bool
+	openStateErr      error
+	config            workerstate.ManifoldConfig
+	agent             *mockAgent
+	resources         dt.StubResources
+	setStatePoolCalls []*state.StatePool
 }
 
 var _ = gc.Suite(&ManifoldSuite{})
@@ -38,12 +41,17 @@ func (s *ManifoldSuite) SetUpTest(c *gc.C) {
 
 	s.openStateCalled = false
 	s.openStateErr = nil
+	s.setStatePoolCalls = nil
 
 	s.config = workerstate.ManifoldConfig{
 		AgentName:              "agent",
 		StateConfigWatcherName: "state-config-watcher",
 		OpenState:              s.fakeOpenState,
 		PingInterval:           10 * time.Millisecond,
+		PrometheusRegisterer:   prometheus.NewRegistry(),
+		SetStatePool: func(pool *state.StatePool) {
+			s.setStatePoolCalls = append(s.setStatePoolCalls, pool)
+		},
 	}
 	s.manifold = workerstate.Manifold(s.config)
 	s.resources = dt.StubResources{
@@ -84,10 +92,24 @@ func (s *ManifoldSuite) TestStateConfigWatcherMissing(c *gc.C) {
 
 func (s *ManifoldSuite) TestStartOpenStateNil(c *gc.C) {
 	s.config.OpenState = nil
-	manifold := workerstate.Manifold(s.config)
+	s.startManifoldInvalidConfig(c, s.config, "nil OpenState not valid")
+}
+
+func (s *ManifoldSuite) TestStartPrometheusRegistererNil(c *gc.C) {
+	s.config.PrometheusRegisterer = nil
+	s.startManifoldInvalidConfig(c, s.config, "nil PrometheusRegisterer not valid")
+}
+
+func (s *ManifoldSuite) TestStartSetStatePoolNil(c *gc.C) {
+	s.config.SetStatePool = nil
+	s.startManifoldInvalidConfig(c, s.config, "nil SetStatePool not valid")
+}
+
+func (s *ManifoldSuite) startManifoldInvalidConfig(c *gc.C, config workerstate.ManifoldConfig, expect string) {
+	manifold := workerstate.Manifold(config)
 	w, err := manifold.Start(s.resources.Context())
 	c.Check(w, gc.IsNil)
-	c.Check(err, gc.ErrorMatches, "OpenState is nil in config")
+	c.Check(err, gc.ErrorMatches, expect)
 }
 
 func (s *ManifoldSuite) TestStartNotStateServer(c *gc.C) {
@@ -108,7 +130,7 @@ func (s *ManifoldSuite) TestStartSuccess(c *gc.C) {
 	w := s.mustStartManifold(c)
 	c.Check(s.openStateCalled, jc.IsTrue)
 	checkNotExiting(c, w)
-	checkStop(c, w)
+	workertest.CleanKill(c, w)
 }
 
 func (s *ManifoldSuite) TestStatePinging(c *gc.C) {
@@ -144,13 +166,13 @@ func (s *ManifoldSuite) TestOutputSuccess(c *gc.C) {
 	err := s.manifold.Output(w, &stTracker)
 	c.Assert(err, jc.ErrorIsNil)
 
-	st, err := stTracker.Use()
+	pool, err := stTracker.Use()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Check(st, gc.Equals, s.State)
+	c.Check(pool.SystemState(), gc.Equals, s.State)
 	c.Assert(stTracker.Done(), jc.ErrorIsNil)
 
 	// Ensure State is closed when the worker is done.
-	checkStop(c, w)
+	workertest.CleanKill(c, w)
 	assertStateClosed(c, s.State)
 }
 
@@ -161,16 +183,62 @@ func (s *ManifoldSuite) TestStateStillInUse(c *gc.C) {
 	err := s.manifold.Output(w, &stTracker)
 	c.Assert(err, jc.ErrorIsNil)
 
-	st, err := stTracker.Use()
+	pool, err := stTracker.Use()
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Close the worker while the State is still in use.
-	checkStop(c, w)
-	assertStateNotClosed(c, st)
+	workertest.CleanKill(c, w)
+	assertStateNotClosed(c, pool.SystemState())
 
 	// Now signal that the State is no longer needed.
 	c.Assert(stTracker.Done(), jc.ErrorIsNil)
-	assertStateClosed(c, st)
+	assertStateClosed(c, pool.SystemState())
+}
+
+func (s *ManifoldSuite) TestDeadStateRemoved(c *gc.C) {
+	// Create an additional state *before* we start
+	// the worker, so the worker's lifecycle watcher
+	// is guaranteed to observe it in both the Alive
+	// state and the Dead state.
+	newSt := s.Factory.MakeModel(c, nil)
+	defer newSt.Close()
+	model, err := newSt.Model()
+	c.Assert(err, jc.ErrorIsNil)
+
+	w := s.mustStartManifold(c)
+	defer workertest.CleanKill(c, w)
+
+	var stTracker workerstate.StateTracker
+	err = s.manifold.Output(w, &stTracker)
+	c.Assert(err, jc.ErrorIsNil)
+	pool, err := stTracker.Use()
+	c.Assert(err, jc.ErrorIsNil)
+	defer stTracker.Done()
+
+	// Get a reference to the state pool entry, so we can
+	// prevent it from being fully removed from the pool.
+	_, release, err := pool.Get(newSt.ModelUUID())
+	c.Assert(err, jc.ErrorIsNil)
+	defer release()
+
+	// Progress the model to Dead.
+	err = model.Destroy(state.DestroyModelParams{})
+	c.Assert(err, jc.ErrorIsNil)
+	err = model.Refresh()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(model.Life(), gc.Equals, state.Dead)
+	s.State.StartSync()
+
+	for a := coretesting.LongAttempt.Start(); a.Next(); {
+		_, release, err := pool.Get(newSt.ModelUUID())
+		if errors.IsNotFound(err) {
+			c.Assert(err, gc.ErrorMatches, "model .* has been removed")
+			return
+		}
+		c.Assert(err, jc.ErrorIsNil)
+		release()
+	}
+	c.Fatal("timed out waiting for model state to be removed from pool")
 }
 
 func (s *ManifoldSuite) mustStartManifold(c *gc.C) worker.Worker {
@@ -185,11 +253,6 @@ func (s *ManifoldSuite) startManifold(c *gc.C) (worker.Worker, error) {
 		s.AddCleanup(func(*gc.C) { worker.Stop(w) })
 	}
 	return w, err
-}
-
-func checkStop(c *gc.C, w worker.Worker) {
-	err := worker.Stop(w)
-	c.Check(err, jc.ErrorIsNil)
 }
 
 func checkNotExiting(c *gc.C, w worker.Worker) {

--- a/worker/state/statetracker_test.go
+++ b/worker/state/statetracker_test.go
@@ -14,7 +14,7 @@ import (
 
 type StateTrackerSuite struct {
 	statetesting.StateSuite
-	st           *state.State
+	pool         *state.State
 	stateTracker workerstate.StateTracker
 }
 
@@ -42,12 +42,12 @@ func (s *StateTrackerSuite) TestTooManyDones(c *gc.C) {
 }
 
 func (s *StateTrackerSuite) TestUse(c *gc.C) {
-	st, err := s.stateTracker.Use()
-	c.Check(st, gc.Equals, s.State)
+	pool, err := s.stateTracker.Use()
+	c.Check(pool.SystemState(), gc.Equals, s.State)
 	c.Check(err, jc.ErrorIsNil)
 
-	st, err = s.stateTracker.Use()
-	c.Check(st, gc.Equals, s.State)
+	pool, err = s.stateTracker.Use()
+	c.Check(pool.SystemState(), gc.Equals, s.State)
 	c.Check(err, jc.ErrorIsNil)
 }
 
@@ -86,8 +86,8 @@ func (s *StateTrackerSuite) TestUseAndDone(c *gc.C) {
 func (s *StateTrackerSuite) TestUseWhenClosed(c *gc.C) {
 	c.Assert(s.stateTracker.Done(), jc.ErrorIsNil)
 
-	st, err := s.stateTracker.Use()
-	c.Check(st, gc.IsNil)
+	pool, err := s.stateTracker.Use()
+	c.Check(pool, gc.IsNil)
 	c.Check(err, gc.Equals, workerstate.ErrStateClosed)
 }
 

--- a/worker/txnpruner/manifold.go
+++ b/worker/txnpruner/manifold.go
@@ -67,12 +67,12 @@ func (config ManifoldConfig) start(context dependency.Context) (worker.Worker, e
 	if err := context.Get(config.StateName, &stTracker); err != nil {
 		return nil, errors.Trace(err)
 	}
-	st, err := stTracker.Use()
+	statePool, err := stTracker.Use()
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
 
-	worker := config.NewWorker(st, config.PruneInterval, clock)
+	worker := config.NewWorker(statePool.SystemState(), config.PruneInterval, clock)
 	go func() {
 		worker.Wait()
 		stTracker.Done()


### PR DESCRIPTION
## Description of change

Change worker/state to output a *state.StatePool,
rather than *state.State, and make that worker
responsible for registering state metrics and
communicating the StatePool back up to the agent
for introspection.

The other workers are updated to take a StatePool.
Of particular note, worker/apiserver now accepts
a StatePool and passes that directly to the
apiserver.NewServer call. worker/apiserver no
longer contains a worker; its manifold just calls
through to apiserver.NewServer with the configuration
derived from manifold inputs.

The worker/state worker is now responsible for
pinging all of the state objects, and removing them
from the pool when the corresponding model becomes
Dead or is removed from state.

## QA steps

1. juju bootstrap localhost
2. juju add-model foo
3. juju ssh -m controller 0 juju-introspect statepool
(should show there are two model states; the "system state" is excluded)
4. juju destroy-model -y foo
5. juju ssh -m controller 0 juju-introspect statepool
(should show there is just one model state, i.e. the state for "foo" should have been removed)

## Documentation changes

None.

## Bug reference

None.