### PR TITLE
Fix bug 1728738, don't over write failure status if aborting model migration.

### DIFF
--- a/worker/migrationmaster/worker_test.go
+++ b/worker/migrationmaster/worker_test.go
@@ -571,7 +571,7 @@ func (s *Suite) TestVALIDATIONCheckMachinesOneError(c *gc.C) {
 	lastMessages := s.facade.statuses[len(s.facade.statuses)-2:]
 	c.Assert(lastMessages, gc.DeepEquals, []string{
 		"machine sanity check failed, 1 error found",
-		"aborted, removing model from target controller",
+		"aborted, removing model from target controller: machine sanity check failed, 1 error found",
 	})
 }
 
@@ -594,7 +594,7 @@ func (s *Suite) TestVALIDATIONCheckMachinesSeveralErrors(c *gc.C) {
 	lastMessages := s.facade.statuses[len(s.facade.statuses)-2:]
 	c.Assert(lastMessages, gc.DeepEquals, []string{
 		"machine sanity check failed, 2 errors found",
-		"aborted, removing model from target controller",
+		"aborted, removing model from target controller: machine sanity check failed, 2 errors found",
 	})
 }
 


### PR DESCRIPTION
## Description of change

Skip setting migration status when aborting to facilitate finding the cause of the migration failure without hunting in the log file.  Do continue to log the abort.

## QA steps

Add a migrationmaster wrench with "die-in-export", try to migrate a model.  The show-model, migration status should not be "aborted, removing model from target controller".

## Documentation changes

N/A

## Bug reference

https://bugs.launchpad.net/juju/+bug/1728738