### PR TITLE
Fix two agent wedgies.

### DIFF
--- a/worker/apicaller/connect.go
+++ b/worker/apicaller/connect.go
@@ -89,12 +89,18 @@ func connectFallback(
 	// than the alternatives.
 	var tryConnect = func() {
 		conn, err = apiOpen(info, api.DialOpts{
-			// NOTE we set DialTimeout but not Timeout, because
-			// the server may apply server-side rate-limiting
-			// before responding to the Login request. The dial
-			// should be fast, but the login may not be.
-			DialTimeout: time.Second,
+			// The DialTimeout is for connecting to the underlying
+			// socket. We use three seconds because it should be fast
+			// but it is possible to add a manual machine to a distant
+			// controller such that the round trip time could be as high
+			// as 500ms.
+			DialTimeout: 3 * time.Second,
 			RetryDelay:  200 * time.Millisecond,
+			// The timeout is for the complete login handshake.
+			// If the server is rate limiting, it will normally pause
+			// before responding to the login request, but the pause is
+			// in the realm of five to ten seconds.
+			Timeout: time.Minute,
 		})
 	}
 

--- a/worker/apicaller/util_test.go
+++ b/worker/apicaller/util_test.go
@@ -190,8 +190,9 @@ func openCalls(model names.ModelTag, entity names.Tag, passwords ...string) []te
 		calls[i] = testing.StubCall{
 			FuncName: "apiOpen",
 			Args: []interface{}{info, api.DialOpts{
-				DialTimeout: time.Second,
+				DialTimeout: 3 * time.Second,
 				RetryDelay:  200 * time.Millisecond,
+				Timeout:     time.Minute,
 			}},
 		}
 	}


### PR DESCRIPTION
Fixes two places where agents can get wedged, which stops the agents from restarting.

First, the apicaller can get itself into a situation where it is waiting forever for a login response.
Secondly, the logsender can get itself stuck waiting for the websocket to be initialized.

This bug adds a timeout to the first, and handles the second by getting the LogSender in another goroutine and also waiting on the stop channel.

## QA steps

Unit tests continue to work, and CI passes. Nothing spectacular.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1732588
https://bugs.launchpad.net/juju/+bug/1732587