### PR TITLE
Find agent binaries using fallback across streams

### DIFF
--- a/apiserver/common/tools.go
+++ b/apiserver/common/tools.go
@@ -259,9 +259,9 @@ func (f *ToolsFinder) findMatchingTools(args params.FindToolsParams) (coretools.
 	}
 	filter := toolsFilter(args)
 	cfg := env.Config()
-	stream := envtools.PreferredStreams(&args.Number, cfg.Development(), cfg.AgentStream())[0]
+	streams := envtools.PreferredStreams(&args.Number, cfg.Development(), cfg.AgentStream())
 	simplestreamsList, err := envtoolsFindTools(
-		env, args.MajorVersion, args.MinorVersion, stream, filter,
+		env, args.MajorVersion, args.MinorVersion, streams, filter,
 	)
 	if len(storageList) == 0 && err != nil {
 		return nil, err

--- a/apiserver/common/tools.go
+++ b/apiserver/common/tools.go
@@ -259,7 +259,7 @@ func (f *ToolsFinder) findMatchingTools(args params.FindToolsParams) (coretools.
 	}
 	filter := toolsFilter(args)
 	cfg := env.Config()
-	stream := envtools.PreferredStream(&args.Number, cfg.Development(), cfg.AgentStream())
+	stream := envtools.PreferredStreams(&args.Number, cfg.Development(), cfg.AgentStream())[0]
 	simplestreamsList, err := envtoolsFindTools(
 		env, args.MajorVersion, args.MinorVersion, stream, filter,
 	)

--- a/apiserver/common/tools_test.go
+++ b/apiserver/common/tools_test.go
@@ -172,10 +172,10 @@ func (s *toolsSuite) TestFindTools(c *gc.C) {
 		SHA256:  "feedface",
 	}}
 
-	s.PatchValue(common.EnvtoolsFindTools, func(e environs.Environ, major, minor int, stream string, filter coretools.Filter) (coretools.List, error) {
+	s.PatchValue(common.EnvtoolsFindTools, func(e environs.Environ, major, minor int, streams []string, filter coretools.Filter) (coretools.List, error) {
 		c.Assert(major, gc.Equals, 123)
 		c.Assert(minor, gc.Equals, 456)
-		c.Assert(stream, gc.Equals, "released")
+		c.Assert(streams, gc.DeepEquals, []string{"released"})
 		c.Assert(filter.Series, gc.Equals, "win81")
 		c.Assert(filter.Arch, gc.Equals, "alpha")
 		return envtoolsList, nil
@@ -206,7 +206,7 @@ func (s *toolsSuite) TestFindTools(c *gc.C) {
 }
 
 func (s *toolsSuite) TestFindToolsNotFound(c *gc.C) {
-	s.PatchValue(common.EnvtoolsFindTools, func(e environs.Environ, major, minor int, stream string, filter coretools.Filter) (list coretools.List, err error) {
+	s.PatchValue(common.EnvtoolsFindTools, func(e environs.Environ, major, minor int, stream []string, filter coretools.Filter) (list coretools.List, err error) {
 		return nil, errors.NotFoundf("tools")
 	})
 	toolsFinder := common.NewToolsFinder(stateenvirons.EnvironConfigGetter{s.State, s.IAASModel.Model}, s.State, sprintfURLGetter("%s"))
@@ -241,15 +241,15 @@ func (s *toolsSuite) TestFindToolsExactNotInStorage(c *gc.C) {
 
 func (s *toolsSuite) testFindToolsExact(c *gc.C, t common.ToolsStorageGetter, inStorage bool, develVersion bool) {
 	var called bool
-	s.PatchValue(common.EnvtoolsFindTools, func(e environs.Environ, major, minor int, stream string, filter coretools.Filter) (list coretools.List, err error) {
+	s.PatchValue(common.EnvtoolsFindTools, func(e environs.Environ, major, minor int, stream []string, filter coretools.Filter) (list coretools.List, err error) {
 		called = true
 		c.Assert(filter.Number, gc.Equals, jujuversion.Current)
 		c.Assert(filter.Series, gc.Equals, series.MustHostSeries())
 		c.Assert(filter.Arch, gc.Equals, arch.HostArch())
 		if develVersion {
-			c.Assert(stream, gc.Equals, "devel")
+			c.Assert(stream, gc.DeepEquals, []string{"devel", "proposed", "released"})
 		} else {
-			c.Assert(stream, gc.Equals, "released")
+			c.Assert(stream, gc.DeepEquals, []string{"released"})
 		}
 		return nil, errors.NotFoundf("tools")
 	})
@@ -273,7 +273,7 @@ func (s *toolsSuite) testFindToolsExact(c *gc.C, t common.ToolsStorageGetter, in
 
 func (s *toolsSuite) TestFindToolsToolsStorageError(c *gc.C) {
 	var called bool
-	s.PatchValue(common.EnvtoolsFindTools, func(e environs.Environ, major, minor int, stream string, filter coretools.Filter) (list coretools.List, err error) {
+	s.PatchValue(common.EnvtoolsFindTools, func(e environs.Environ, major, minor int, stream []string, filter coretools.Filter) (list coretools.List, err error) {
 		called = true
 		return nil, errors.NotFoundf("tools")
 	})

--- a/apiserver/facades/controller/agenttools/agenttools.go
+++ b/apiserver/facades/controller/agenttools/agenttools.go
@@ -47,7 +47,7 @@ func NewFacade(st *state.State, resources facade.Resources, authorizer facade.Au
 func NewAgentToolsAPI(
 	modelGetter ModelGetter,
 	newEnviron func() (environs.Environ, error),
-	findTools func(environs.Environ, int, int, string, coretools.Filter) (coretools.List, error),
+	findTools func(environs.Environ, int, int, []string, coretools.Filter) (coretools.List, error),
 	envVersionUpdate func(*state.Model, version.Number) error,
 	authorizer facade.Authorizer,
 ) (*AgentToolsAPI, error) {
@@ -66,7 +66,7 @@ type ModelGetter interface {
 }
 
 type newEnvironFunc func() (environs.Environ, error)
-type toolsFinder func(environs.Environ, int, int, string, coretools.Filter) (coretools.List, error)
+type toolsFinder func(environs.Environ, int, int, []string, coretools.Filter) (coretools.List, error)
 type envVersionUpdater func(*state.Model, version.Number) error
 
 func checkToolsAvailability(newEnviron newEnvironFunc, modelCfg *config.Config, finder toolsFinder) (version.Number, error) {
@@ -84,10 +84,10 @@ func checkToolsAvailability(newEnviron newEnvironFunc, modelCfg *config.Config, 
 	// only return patches for the passed major.minor (from major.minor.patch).
 	// We'll try the released stream first, then fall back to the current configured stream
 	// if no released tools are found.
-	vers, err := finder(env, currentVersion.Major, currentVersion.Minor, tools.ReleasedStream, coretools.Filter{})
+	vers, err := finder(env, currentVersion.Major, currentVersion.Minor, []string{tools.ReleasedStream}, coretools.Filter{})
 	preferredStream := tools.PreferredStreams(&currentVersion, modelCfg.Development(), modelCfg.AgentStream())[0]
 	if preferredStream != tools.ReleasedStream && errors.Cause(err) == coretools.ErrNoMatches {
-		vers, err = finder(env, currentVersion.Major, currentVersion.Minor, preferredStream, coretools.Filter{})
+		vers, err = finder(env, currentVersion.Major, currentVersion.Minor, []string{preferredStream}, coretools.Filter{})
 	}
 	if err != nil {
 		return version.Zero, errors.Annotatef(err, "cannot find available agent binaries")

--- a/apiserver/facades/controller/agenttools/agenttools.go
+++ b/apiserver/facades/controller/agenttools/agenttools.go
@@ -85,7 +85,7 @@ func checkToolsAvailability(newEnviron newEnvironFunc, modelCfg *config.Config, 
 	// We'll try the released stream first, then fall back to the current configured stream
 	// if no released tools are found.
 	vers, err := finder(env, currentVersion.Major, currentVersion.Minor, tools.ReleasedStream, coretools.Filter{})
-	preferredStream := tools.PreferredStream(&currentVersion, modelCfg.Development(), modelCfg.AgentStream())
+	preferredStream := tools.PreferredStreams(&currentVersion, modelCfg.Development(), modelCfg.AgentStream())[0]
 	if preferredStream != tools.ReleasedStream && errors.Cause(err) == coretools.ErrNoMatches {
 		vers, err = finder(env, currentVersion.Major, currentVersion.Minor, preferredStream, coretools.Filter{})
 	}

--- a/cmd/juju/commands/bootstrap_test.go
+++ b/cmd/juju/commands/bootstrap_test.go
@@ -1903,7 +1903,7 @@ clouds:
 // checkTools check if the environment contains the passed envtools.
 func checkTools(c *gc.C, env environs.Environ, expected []version.Binary) {
 	list, err := envtools.FindTools(
-		env, jujuversion.Current.Major, jujuversion.Current.Minor, "released", coretools.Filter{})
+		env, jujuversion.Current.Major, jujuversion.Current.Minor, []string{"released"}, coretools.Filter{})
 	c.Check(err, jc.ErrorIsNil)
 	c.Logf("found: " + list.String())
 	urls := list.URLs()

--- a/cmd/jujud/bootstrap.go
+++ b/cmd/jujud/bootstrap.go
@@ -150,7 +150,7 @@ func (c *BootstrapCommand) Run(_ *cmd.Context) error {
 	if ok && desiredVersion != jujuversion.Current {
 		// If we have been asked for a newer version, ensure the newer
 		// tools can actually be found, or else bootstrap won't complete.
-		stream := envtools.PreferredStream(&desiredVersion, args.ControllerModelConfig.Development(), args.ControllerModelConfig.AgentStream())
+		stream := envtools.PreferredStreams(&desiredVersion, args.ControllerModelConfig.Development(), args.ControllerModelConfig.AgentStream())[0]
 		logger.Infof("newer agent binaries requested, looking for %v in stream %v", desiredVersion, stream)
 		hostSeries, err := series.HostSeries()
 		if err != nil {

--- a/cmd/jujud/bootstrap.go
+++ b/cmd/jujud/bootstrap.go
@@ -150,8 +150,8 @@ func (c *BootstrapCommand) Run(_ *cmd.Context) error {
 	if ok && desiredVersion != jujuversion.Current {
 		// If we have been asked for a newer version, ensure the newer
 		// tools can actually be found, or else bootstrap won't complete.
-		stream := envtools.PreferredStreams(&desiredVersion, args.ControllerModelConfig.Development(), args.ControllerModelConfig.AgentStream())[0]
-		logger.Infof("newer agent binaries requested, looking for %v in stream %v", desiredVersion, stream)
+		streams := envtools.PreferredStreams(&desiredVersion, args.ControllerModelConfig.Development(), args.ControllerModelConfig.AgentStream())
+		logger.Infof("newer agent binaries requested, looking for %v in streams: %v", desiredVersion, strings.Join(streams, ","))
 		hostSeries, err := series.HostSeries()
 		if err != nil {
 			return errors.Trace(err)
@@ -161,7 +161,7 @@ func (c *BootstrapCommand) Run(_ *cmd.Context) error {
 			Arch:   arch.HostArch(),
 			Series: hostSeries,
 		}
-		_, toolsErr := envtools.FindTools(env, -1, -1, stream, filter)
+		_, toolsErr := envtools.FindTools(env, -1, -1, streams, filter)
 		if toolsErr == nil {
 			logger.Infof("agent binaries are available, upgrade will occur after bootstrap")
 		}

--- a/cmd/plugins/juju-metadata/toolsmetadata.go
+++ b/cmd/plugins/juju-metadata/toolsmetadata.go
@@ -118,7 +118,7 @@ func (c *toolsMetadataCommand) Run(context *cmd.Context) error {
 		if err != nil {
 			return errors.Trace(err)
 		}
-		toolsList, err = envtools.FindToolsForCloud(toolsDataSources(source), simplestreams.CloudSpec{}, c.stream, -1, -1, coretools.Filter{})
+		toolsList, err = envtools.FindToolsForCloud(toolsDataSources(source), simplestreams.CloudSpec{}, []string{c.stream}, -1, -1, coretools.Filter{})
 	}
 	if err != nil {
 		return errors.Trace(err)

--- a/environs/bootstrap/bootstrap_test.go
+++ b/environs/bootstrap/bootstrap_test.go
@@ -424,7 +424,7 @@ func (s *bootstrapSuite) TestBootstrapLocalTools(c *gc.C) {
 
 	s.PatchValue(&jujuos.HostOS, func() jujuos.OSType { return jujuos.CentOS })
 	s.PatchValue(&arch.HostArch, func() string { return arch.AMD64 })
-	s.PatchValue(bootstrap.FindTools, func(environs.Environ, int, int, string, tools.Filter) (tools.List, error) {
+	s.PatchValue(bootstrap.FindTools, func(environs.Environ, int, int, []string, tools.Filter) (tools.List, error) {
 		return nil, errors.NotFoundf("tools")
 	})
 	env := newEnviron("foo", useDefaultKeys, nil)
@@ -454,7 +454,7 @@ func (s *bootstrapSuite) TestBootstrapLocalToolsMismatchingOS(c *gc.C) {
 
 	s.PatchValue(&jujuos.HostOS, func() jujuos.OSType { return jujuos.Windows })
 	s.PatchValue(&arch.HostArch, func() string { return arch.AMD64 })
-	s.PatchValue(bootstrap.FindTools, func(environs.Environ, int, int, string, tools.Filter) (tools.List, error) {
+	s.PatchValue(bootstrap.FindTools, func(environs.Environ, int, int, []string, tools.Filter) (tools.List, error) {
 		return nil, errors.NotFoundf("tools")
 	})
 	env := newEnviron("foo", useDefaultKeys, nil)
@@ -481,7 +481,7 @@ func (s *bootstrapSuite) TestBootstrapLocalToolsDifferentLinuxes(c *gc.C) {
 
 	s.PatchValue(&jujuos.HostOS, func() jujuos.OSType { return jujuos.GenericLinux })
 	s.PatchValue(&arch.HostArch, func() string { return arch.AMD64 })
-	s.PatchValue(bootstrap.FindTools, func(environs.Environ, int, int, string, tools.Filter) (tools.List, error) {
+	s.PatchValue(bootstrap.FindTools, func(environs.Environ, int, int, []string, tools.Filter) (tools.List, error) {
 		return nil, errors.NotFoundf("tools")
 	})
 	env := newEnviron("foo", useDefaultKeys, nil)
@@ -509,7 +509,7 @@ func (s *bootstrapSuite) TestBootstrapBuildAgent(c *gc.C) {
 	// Patch out HostArch and FindTools to allow the test to pass on other architectures,
 	// such as s390.
 	s.PatchValue(&arch.HostArch, func() string { return arch.ARM64 })
-	s.PatchValue(bootstrap.FindTools, func(environs.Environ, int, int, string, tools.Filter) (tools.List, error) {
+	s.PatchValue(bootstrap.FindTools, func(environs.Environ, int, int, []string, tools.Filter) (tools.List, error) {
 		c.Fatal("should not call FindTools if BuildAgent is specified")
 		return nil, errors.NotFoundf("tools")
 	})
@@ -555,7 +555,7 @@ func (s *bootstrapSuite) assertBootstrapPackagedToolsAvailable(c *gc.C, clientAr
 		toolsArch = "amd64"
 	}
 	findToolsOk := false
-	s.PatchValue(bootstrap.FindTools, func(_ environs.Environ, _ int, _ int, _ string, filter tools.Filter) (tools.List, error) {
+	s.PatchValue(bootstrap.FindTools, func(_ environs.Environ, _ int, _ int, _ []string, filter tools.Filter) (tools.List, error) {
 		c.Assert(filter.Arch, gc.Equals, toolsArch)
 		c.Assert(filter.Series, gc.Equals, "quantal")
 		findToolsOk = true
@@ -601,7 +601,7 @@ func (s *bootstrapSuite) TestBootstrapNoToolsNonReleaseStream(c *gc.C) {
 	// Patch out HostArch and FindTools to allow the test to pass on other architectures,
 	// such as s390.
 	s.PatchValue(&arch.HostArch, func() string { return arch.ARM64 })
-	s.PatchValue(bootstrap.FindTools, func(environs.Environ, int, int, string, tools.Filter) (tools.List, error) {
+	s.PatchValue(bootstrap.FindTools, func(environs.Environ, int, int, []string, tools.Filter) (tools.List, error) {
 		return nil, errors.NotFoundf("tools")
 	})
 	env := newEnviron("foo", useDefaultKeys, map[string]interface{}{
@@ -625,7 +625,7 @@ func (s *bootstrapSuite) TestBootstrapNoToolsDevelopmentConfig(c *gc.C) {
 	}
 
 	s.PatchValue(&arch.HostArch, func() string { return arch.ARM64 })
-	s.PatchValue(bootstrap.FindTools, func(environs.Environ, int, int, string, tools.Filter) (tools.List, error) {
+	s.PatchValue(bootstrap.FindTools, func(environs.Environ, int, int, []string, tools.Filter) (tools.List, error) {
 		return nil, errors.NotFoundf("tools")
 	})
 	env := newEnviron("foo", useDefaultKeys, map[string]interface{}{
@@ -1260,7 +1260,7 @@ func (s *bootstrapSuite) TestAvailableToolsInvalidArch(c *gc.C) {
 	s.PatchValue(&arch.HostArch, func() string {
 		return arch.S390X
 	})
-	s.PatchValue(bootstrap.FindTools, func(environs.Environ, int, int, string, tools.Filter) (tools.List, error) {
+	s.PatchValue(bootstrap.FindTools, func(environs.Environ, int, int, []string, tools.Filter) (tools.List, error) {
 		c.Fatal("find packaged tools should not be called")
 		return nil, errors.New("unexpected")
 	})

--- a/environs/bootstrap/tools.go
+++ b/environs/bootstrap/tools.go
@@ -119,5 +119,5 @@ func findBootstrapTools(env environs.Environ, vers *version.Number, arch, series
 		filter.Number = *vers
 	}
 	streams := envtools.PreferredStreams(vers, env.Config().Development(), env.Config().AgentStream())
-	return findTools(env, cliVersion.Major, cliVersion.Minor, streams[0], filter)
+	return findTools(env, cliVersion.Major, cliVersion.Minor, streams, filter)
 }

--- a/environs/bootstrap/tools.go
+++ b/environs/bootstrap/tools.go
@@ -118,6 +118,6 @@ func findBootstrapTools(env environs.Environ, vers *version.Number, arch, series
 	if vers != nil {
 		filter.Number = *vers
 	}
-	stream := envtools.PreferredStream(vers, env.Config().Development(), env.Config().AgentStream())
-	return findTools(env, cliVersion.Major, cliVersion.Minor, stream, filter)
+	streams := envtools.PreferredStreams(vers, env.Config().Development(), env.Config().AgentStream())
+	return findTools(env, cliVersion.Major, cliVersion.Minor, streams[0], filter)
 }

--- a/environs/sync/sync.go
+++ b/environs/sync/sync.go
@@ -94,7 +94,9 @@ func SyncTools(syncContext *SyncContext) error {
 		// We now store the tools in a directory named after their stream, but the
 		// legacy behaviour is to store all tools in a single "releases" directory.
 		toolsDir = envtools.ReleasedStream
-		syncContext.Stream = envtools.PreferredStream(&jujuversion.Current, false, "")
+		// Always use the primary stream here - the user can specify
+		// to override that decision.
+		syncContext.Stream = envtools.PreferredStreams(&jujuversion.Current, false, "")[0]
 	}
 	sourceTools, err := envtools.FindToolsForCloud(
 		[]simplestreams.DataSource{sourceDataSource}, simplestreams.CloudSpec{},

--- a/environs/sync/sync.go
+++ b/environs/sync/sync.go
@@ -98,17 +98,13 @@ func SyncTools(syncContext *SyncContext) error {
 		// to override that decision.
 		syncContext.Stream = envtools.PreferredStreams(&jujuversion.Current, false, "")[0]
 	}
-	sourceTools, err := envtools.FindToolsForCloud(
-		[]simplestreams.DataSource{sourceDataSource}, simplestreams.CloudSpec{},
-		syncContext.Stream, syncContext.MajorVersion, syncContext.MinorVersion, coretools.Filter{})
 	// For backwards compatibility with cloud storage, if there are no tools in the specified stream,
 	// double check the release stream.
 	// TODO - remove this when we no longer need to support cloud storage upgrades.
-	if err == envtools.ErrNoTools {
-		sourceTools, err = envtools.FindToolsForCloud(
-			[]simplestreams.DataSource{sourceDataSource}, simplestreams.CloudSpec{},
-			envtools.ReleasedStream, syncContext.MajorVersion, syncContext.MinorVersion, coretools.Filter{})
-	}
+	streams := []string{syncContext.Stream, envtools.ReleasedStream}
+	sourceTools, err := envtools.FindToolsForCloud(
+		[]simplestreams.DataSource{sourceDataSource}, simplestreams.CloudSpec{},
+		streams, syncContext.MajorVersion, syncContext.MinorVersion, coretools.Filter{})
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/environs/tools/tools_test.go
+++ b/environs/tools/tools_test.go
@@ -88,11 +88,15 @@ func (s *SimpleStreamsToolsSuite) removeTools(c *gc.C) {
 }
 
 func (s *SimpleStreamsToolsSuite) uploadCustom(c *gc.C, verses ...version.Binary) map[version.Binary]string {
-	return toolstesting.UploadToDirectory(c, "proposed", s.customToolsDir, verses...)
+	return toolstesting.UploadToDirectory(c, s.customToolsDir, toolstesting.StreamVersions{"proposed": verses})["proposed"]
 }
 
 func (s *SimpleStreamsToolsSuite) uploadPublic(c *gc.C, verses ...version.Binary) map[version.Binary]string {
-	return toolstesting.UploadToDirectory(c, "proposed", s.publicToolsDir, verses...)
+	return toolstesting.UploadToDirectory(c, s.publicToolsDir, toolstesting.StreamVersions{"proposed": verses})["proposed"]
+}
+
+func (s *SimpleStreamsToolsSuite) uploadStreams(c *gc.C, versions toolstesting.StreamVersions) map[string]map[version.Binary]string {
+	return toolstesting.UploadToDirectory(c, s.publicToolsDir, versions)
 }
 
 func (s *SimpleStreamsToolsSuite) resetEnv(c *gc.C, attrs map[string]interface{}) {
@@ -172,8 +176,8 @@ func (s *SimpleStreamsToolsSuite) TestFindTools(c *gc.C) {
 		s.reset(c, nil)
 		custom := s.uploadCustom(c, test.custom...)
 		public := s.uploadPublic(c, test.public...)
-		stream := envtools.PreferredStreams(&jujuversion.Current, s.env.Config().Development(), s.env.Config().AgentStream())[0]
-		actual, err := envtools.FindTools(s.env, test.major, test.minor, stream, coretools.Filter{})
+		streams := envtools.PreferredStreams(&jujuversion.Current, s.env.Config().Development(), s.env.Config().AgentStream())
+		actual, err := envtools.FindTools(s.env, test.major, test.minor, streams, coretools.Filter{})
 		if test.err != nil {
 			if len(actual) > 0 {
 				c.Logf(actual.String())
@@ -203,7 +207,7 @@ func (s *SimpleStreamsToolsSuite) TestFindToolsFiltering(c *gc.C) {
 	logger.SetLogLevel(loggo.TRACE)
 
 	_, err := envtools.FindTools(
-		s.env, 1, -1, "released", coretools.Filter{Number: version.Number{Major: 1, Minor: 2, Patch: 3}})
+		s.env, 1, -1, []string{"released"}, coretools.Filter{Number: version.Number{Major: 1, Minor: 2, Patch: 3}})
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 	// This is slightly overly prescriptive, but feel free to change or add
 	// messages. This still helps to ensure that all log messages are
@@ -225,7 +229,8 @@ func (s *SimpleStreamsToolsSuite) TestFindToolsFiltering(c *gc.C) {
 }
 
 var findExactToolsTests = []struct {
-	info   string
+	info string
+	// These are the contents of the proposed streams in each source.
 	custom []version.Binary
 	public []version.Binary
 	seek   version.Binary
@@ -279,6 +284,92 @@ func (s *SimpleStreamsToolsSuite) TestFindExactTools(c *gc.C) {
 		} else {
 			c.Check(err, jc.Satisfies, errors.IsNotFound)
 		}
+	}
+}
+
+func copyAndAppend(vs []version.Binary, more ...[]version.Binary) []version.Binary {
+	// TODO(babbageclunk): I think the append(someversions,
+	// moreversions...) technique used in environs/testing/tools.go
+	// might be wrong because it can mutate someversions if there's
+	// enough capacity. Use this there.
+	// https://medium.com/@Jarema./golang-slice-append-gotcha-e9020ff37374
+	result := make([]version.Binary, len(vs))
+	copy(result, vs)
+	for _, items := range more {
+		result = append(result, items...)
+	}
+	return result
+}
+
+var findToolsFallbackTests = []struct {
+	info     string
+	major    int
+	minor    int
+	streams  []string
+	devel    []version.Binary
+	proposed []version.Binary
+	released []version.Binary
+	expect   []version.Binary
+	err      error
+}{{
+	info:    "nothing available",
+	major:   1,
+	streams: []string{"released"},
+	err:     envtools.ErrNoTools,
+}, {
+	info:    "only available in non-selected stream",
+	major:   1,
+	minor:   2,
+	streams: []string{"released"},
+	devel:   envtesting.VAll,
+	err:     coretools.ErrNoMatches,
+}, {
+	info:     "finds things in devel and released, ignores proposed",
+	major:    1,
+	minor:    -1,
+	streams:  []string{"devel", "released"},
+	devel:    envtesting.V120all,
+	proposed: envtesting.V110all,
+	released: envtesting.V100all,
+	expect:   copyAndAppend(envtesting.V120all, envtesting.V100all),
+}, {
+	info:     "finds matching things everywhere",
+	major:    1,
+	minor:    2,
+	streams:  []string{"devel", "proposed", "released"},
+	devel:    []version.Binary{envtesting.V110q64, envtesting.V120q64},
+	proposed: []version.Binary{envtesting.V110p64, envtesting.V120p64},
+	released: []version.Binary{envtesting.V100p64, envtesting.V120t64},
+	expect:   []version.Binary{envtesting.V120p64, envtesting.V120q64, envtesting.V120t64},
+}}
+
+func (s *SimpleStreamsToolsSuite) TestFindToolsWithStreamFallback(c *gc.C) {
+	for i, test := range findToolsFallbackTests {
+		c.Logf("\ntest %d: %s", i, test.info)
+		s.reset(c, nil)
+		streams := s.uploadStreams(c, toolstesting.StreamVersions{
+			"devel":    test.devel,
+			"proposed": test.proposed,
+			"released": test.released,
+		})
+		actual, err := envtools.FindTools(s.env, test.major, test.minor, test.streams, coretools.Filter{})
+		if test.err != nil {
+			if len(actual) > 0 {
+				c.Logf(actual.String())
+			}
+			c.Check(err, jc.Satisfies, errors.IsNotFound)
+			continue
+		}
+		expect := map[version.Binary][]string{}
+		for _, expected := range test.expect {
+			for _, stream := range []string{"devel", "proposed", "released"} {
+				if url, ok := streams[stream][expected]; ok {
+					expect[expected] = []string{url}
+					break
+				}
+			}
+		}
+		c.Check(actual.URLs(), gc.DeepEquals, expect)
 	}
 }
 

--- a/juju/testing/instance.go
+++ b/juju/testing/instance.go
@@ -160,8 +160,8 @@ func fillinStartInstanceParams(env environs.Environ, machineId string, isControl
 	if params.Constraints.Arch != nil {
 		filter.Arch = *params.Constraints.Arch
 	}
-	stream := tools.PreferredStreams(&agentVersion, env.Config().Development(), env.Config().AgentStream())[0]
-	possibleTools, err := tools.FindTools(env, -1, -1, stream, filter)
+	streams := tools.PreferredStreams(&agentVersion, env.Config().Development(), env.Config().AgentStream())
+	possibleTools, err := tools.FindTools(env, -1, -1, streams, filter)
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/juju/testing/instance.go
+++ b/juju/testing/instance.go
@@ -160,7 +160,7 @@ func fillinStartInstanceParams(env environs.Environ, machineId string, isControl
 	if params.Constraints.Arch != nil {
 		filter.Arch = *params.Constraints.Arch
 	}
-	stream := tools.PreferredStream(&agentVersion, env.Config().Development(), env.Config().AgentStream())
+	stream := tools.PreferredStreams(&agentVersion, env.Config().Development(), env.Config().AgentStream())[0]
 	possibleTools, err := tools.FindTools(env, -1, -1, stream, filter)
 	if err != nil {
 		return errors.Trace(err)

--- a/worker/provisioner/provisioner_test.go
+++ b/worker/provisioner/provisioner_test.go
@@ -564,7 +564,7 @@ func (s *ProvisionerSuite) TestPossibleTools(c *gc.C) {
 	envtesting.AssertUploadFakeToolsVersions(c, stor, s.cfg.AgentStream(), s.cfg.AgentStream(), availableVersions...)
 
 	// Extract the tools that we expect to actually match.
-	expectedList, err := tools.FindTools(s.Environ, -1, -1, s.cfg.AgentStream(), coretools.Filter{
+	expectedList, err := tools.FindTools(s.Environ, -1, -1, []string{s.cfg.AgentStream()}, coretools.Filter{
 		Number: currentVersion.Number,
 		Series: currentVersion.Series,
 	})


### PR DESCRIPTION
### Description of change

If someone bootstraps with a beta or with an explicitly set devel stream, we weren't then considering released agent binaries as possible candidates for upgrades (because they are on the released stream). 
Change the metadata lookup so that we check the released stream if a controller is on the devel stream.

This is another go at #8080 without trying to change the simplestreams code - handling mirrors and resolve info was too involved. This version combines the results just above `tools/simplestreams/Fetch`, which means it handles mirrors right for each stream and doesn't need to combine resolve info because it's thrown away at that point anyway.

## QA steps

Bootstrap a controller with 2.2-beta3 (using a released 2.2 binary). Then run `juju upgrade-juju -m controller`. The controller should be upgraded to 2.2.6.

## Documentation changes

It's possible this needs documentation? I couldn't find any documentation for how we find agent binaries in streams, but if there is we should add a mention of the fallback to it.
