### PR TITLE
Fix a couple indices.

### DIFF
--- a/state/allcollections.go
+++ b/state/allcollections.go
@@ -120,7 +120,7 @@ func allCollections() collectionSchema {
 		migrationsC: {
 			global: true,
 			indexes: []mgo.Index{{
-				Key: []string{"model-uuid"},
+				Key: []string{"model-uuid", "-attempt"},
 			}},
 		},
 
@@ -218,7 +218,11 @@ func allCollections() collectionSchema {
 
 		// This collection holds users related to a model and will be used as one
 		// of the intersection axis of permissionsC
-		modelUsersC: {},
+		modelUsersC: {
+			indexes: []mgo.Index{{
+				Key: []string{"model-uuid"},
+			}},
+		},
 
 		// This collection contains governors that prevent certain kinds of
 		// changes from being accepted.
@@ -440,8 +444,6 @@ func allCollections() collectionSchema {
 		remoteEntitiesC: {
 			indexes: []mgo.Index{{
 				Key: []string{"model-uuid", "token"},
-			}, {
-				Key: []string{"model-uuid"},
 			}},
 		},
 		// externalControllersC holds connection information for other


### PR DESCRIPTION
## Description of change

For Migrations, if we just want the most recent,
we can put that information directly into the index,
and it will still use the model-uuid portion for other
queries that don't touch attempts.

Similarly we don't need two indexes that both cover
the same prefix.

## QA steps

I found this by looking at mongotop load when doing `juju models` calls on an LXD system that had 200 models. With the change to this index on migrations the load dropped from being the highest cost to being nonexistant.

## Documentation changes

None

## Bug reference

None (though there are plenty of bugs around 'juju models' being slow, and this should help.)