### PR TITLE
fix bug 1732614

### DIFF
--- a/provider/openstack/firewaller.go
+++ b/provider/openstack/firewaller.go
@@ -856,7 +856,9 @@ func (c *neutronFirewaller) openPortsInGroup(nameRegExp string, rules []network.
 
 // secGroupMatchesIngressRule checks if supplied nova security group rule matches the ingress rule
 func secGroupMatchesIngressRule(secGroupRule neutron.SecurityGroupRuleV2, rule network.IngressRule) bool {
-	if secGroupRule.IPProtocol == nil || *secGroupRule.PortRangeMax == 0 || *secGroupRule.PortRangeMin == 0 {
+	if secGroupRule.IPProtocol == nil ||
+		secGroupRule.PortRangeMax == nil || *secGroupRule.PortRangeMax == 0 ||
+		secGroupRule.PortRangeMin == nil || *secGroupRule.PortRangeMin == 0 {
 		return false
 	}
 	portsMatch := *secGroupRule.IPProtocol == rule.Protocol &&

--- a/provider/openstack/provider_test.go
+++ b/provider/openstack/provider_test.go
@@ -310,6 +310,26 @@ func (*localTests) TestSecGroupMatchesIngressRule(c *gc.C) {
 		},
 		expected: false,
 	}, {
+		about: "nil rule component: PortRangeMin",
+		rule:  network.MustNewIngressRule(proto_tcp, 80, 85, "0.0.0.0/0", "192.168.1.0/24"),
+		secGroupRule: neutron.SecurityGroupRuleV2{
+			IPProtocol:     &proto_tcp,
+			PortRangeMin:   nil,
+			PortRangeMax:   &port_85,
+			RemoteIPPrefix: "192.168.100.0/24",
+		},
+		expected: false,
+	}, {
+		about: "nil rule component: PortRangeMax",
+		rule:  network.MustNewIngressRule(proto_tcp, 80, 85, "0.0.0.0/0", "192.168.1.0/24"),
+		secGroupRule: neutron.SecurityGroupRuleV2{
+			IPProtocol:     &proto_tcp,
+			PortRangeMin:   &port_85,
+			PortRangeMax:   nil,
+			RemoteIPPrefix: "192.168.100.0/24",
+		},
+		expected: false,
+	}, {
 		about: "mismatched port range and rule",
 		rule:  network.MustNewIngressRule(proto_tcp, 80, 85),
 		secGroupRule: neutron.SecurityGroupRuleV2{


### PR DESCRIPTION
## Description of change

Prevent panics in firewaller, check pointers in neutron security group rules are not nil before using.

## QA steps

new unit tests

## Documentation changes

n/a

## Bug reference

https://bugs.launchpad.net/juju/+bug/1732614