### PR TITLE
Introduce state CAASModel and other base level infrastruture for CAAS…

### DIFF
--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -219,7 +219,7 @@ var agentConfigTests = []struct {
 		UpgradedToVersion: jujuversion.Current,
 		Password:          "sekrit",
 	},
-	checkErr: "entity tag must be MachineTag or UnitTag, got names.UserTag",
+	checkErr: "entity tag must be MachineTag, UnitTag or ApplicationTag, got names.UserTag",
 }, {
 	about: "agentConfig accepts a Unit tag",
 	params: agent.AgentConfigParams{
@@ -234,6 +234,21 @@ var agentConfigTests = []struct {
 	},
 	inspectConfig: func(c *gc.C, cfg agent.Config) {
 		c.Check(cfg.Dir(), gc.Equals, "/data/dir/agents/unit-ubuntu-1")
+	},
+}, {
+	about: "agentConfig accepts an Application tag",
+	params: agent.AgentConfigParams{
+		Paths:             agent.Paths{DataDir: "/data/dir"},
+		Tag:               names.NewApplicationTag("ubuntu"),
+		Password:          "sekrit",
+		UpgradedToVersion: jujuversion.Current,
+		Controller:        testing.ControllerTag,
+		Model:             testing.ModelTag,
+		CACert:            "ca cert",
+		APIAddresses:      []string{"localhost:1235"},
+	},
+	inspectConfig: func(c *gc.C, cfg agent.Config) {
+		c.Check(cfg.Dir(), gc.Equals, "/data/dir/agents/application-ubuntu")
 	},
 }}
 

--- a/apiserver/admin.go
+++ b/apiserver/admin.go
@@ -154,6 +154,9 @@ func (a *admin) login(req params.LoginRequest, loginVersion int) (params.LoginRe
 		loginResult.ModelTag = model.Tag().String()
 		loginResult.Facades = filterFacades(a.srv.facades, append(filters, IsModelFacade)...)
 		apiRoot = restrictRoot(apiRoot, modelFacadesOnly)
+		if model.Type() == state.ModelTypeCAAS {
+			apiRoot = restrictRoot(apiRoot, caasModelFacadesOnly)
+		}
 	}
 
 	a.root.rpcConn.ServeRoot(apiRoot, serverError)

--- a/apiserver/common/modelmanagerinterface.go
+++ b/apiserver/common/modelmanagerinterface.go
@@ -77,6 +77,7 @@ type ModelManagerBackend interface {
 // All the interface methods are defined directly on state.Model
 // and are reproduced here for use in tests.
 type Model interface {
+	Type() state.ModelType
 	Config() (*config.Config, error)
 	Life() state.Life
 	ModelTag() names.ModelTag

--- a/apiserver/export_test.go
+++ b/apiserver/export_test.go
@@ -153,6 +153,13 @@ func TestingModelOnlyRoot() rpc.Root {
 	return restrictRoot(r, modelFacadesOnly)
 }
 
+// TestingCAASModelOnlyRoot returns a restricted srvRoot as if
+// logged in to a CAAS model.
+func TestingCAASModelOnlyRoot() rpc.Root {
+	r := TestingAPIRoot(AllFacades())
+	return restrictRoot(r, caasModelFacadesOnly)
+}
+
 // TestingRestrictedRoot returns a restricted srvRoot.
 func TestingRestrictedRoot(check func(string, string) error) rpc.Root {
 	r := TestingAPIRoot(AllFacades())

--- a/apiserver/facades/client/application/backend.go
+++ b/apiserver/facades/client/application/backend.go
@@ -4,6 +4,7 @@
 package application
 
 import (
+	"github.com/juju/errors"
 	"gopkg.in/juju/charm.v6-unstable"
 	csparams "gopkg.in/juju/charmrepo.v2-unstable/csclient/params"
 	"gopkg.in/juju/names.v2"
@@ -145,6 +146,7 @@ type Resources interface {
 type stateShim struct {
 	*state.State
 	*state.IAASModel
+	*state.CAASModel
 }
 
 type ExternalController state.ExternalController
@@ -154,16 +156,32 @@ func (s stateShim) SaveController(controllerInfo crossmodel.ControllerInfo, mode
 	return api.Save(controllerInfo, modelUUID)
 }
 
+func (s stateShim) ModelTag() names.ModelTag {
+	m, err := s.State.Model()
+	if err != nil {
+		return names.ModelTag{}
+	}
+	return m.ModelTag()
+}
+
 // NewStateBackend converts a state.State into a Backend.
 func NewStateBackend(st *state.State) (Backend, error) {
-	im, err := st.IAASModel()
+	m, err := st.Model()
 	if err != nil {
-		return nil, err
+		return nil, errors.Trace(err)
 	}
-	return &stateShim{
-		State:     st,
-		IAASModel: im,
-	}, nil
+
+	result := &stateShim{State: st}
+	if m.Type() == state.ModelTypeIAAS {
+		result.IAASModel, err = m.IAASModel()
+	} else {
+		result.CAASModel, err = m.CAASModel()
+	}
+	if err != nil {
+		return nil, errors.Annotatef(err, "could not convert state into either IAAS or CAASModel")
+	}
+
+	return result, nil
 }
 
 // NewStateApplication converts a state.Application into an Application.

--- a/apiserver/facades/client/modelmanager/modelinfo_test.go
+++ b/apiserver/facades/client/modelmanager/modelinfo_test.go
@@ -922,6 +922,11 @@ func (m *mockModel) ModelTag() names.ModelTag {
 	return m.tag
 }
 
+func (m *mockModel) Type() state.ModelType {
+	m.MethodCall(m, "Type")
+	return state.ModelTypeIAAS
+}
+
 func (m *mockModel) Life() state.Life {
 	m.MethodCall(m, "Life")
 	return m.life

--- a/apiserver/restrict_caasmodel.go
+++ b/apiserver/restrict_caasmodel.go
@@ -1,0 +1,56 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package apiserver
+
+import (
+	"fmt"
+
+	"github.com/juju/errors"
+	"github.com/juju/utils/set"
+)
+
+// commonModelFacadeNames lists facades that are shared between CAAS
+// and IAAS models.
+var commonModelFacadeNames = set.NewStrings(
+	"Agent",
+	"Application",
+	"Charms",
+	"Cleaner",
+	"Client",
+	"Cloud",
+	"LifeFlag",
+	"MigrationFlag",
+	"MigrationMaster",
+	"MigrationMinion",
+	"MigrationStatusWatcher",
+	"MigrationTarget",
+	"ModelConfig",
+	"ModelUpgrader",
+	"Pinger",
+	"RelationUnitsWatcher",
+	"RemoteRelations",
+	"Singular",
+	"StringsWatcher",
+)
+
+// caasModelFacadeNames lists facades that are only used with CAAS
+// models.
+var caasModelFacadeNames = set.NewStrings(
+	"CAASProvisioner",
+)
+
+func caasModelFacadesOnly(facadeName, _ string) error {
+	if !isCAASModelFacade(facadeName) {
+		return errors.NewNotSupported(nil, fmt.Sprintf("facade %q not supported for a CAAS model API connection", facadeName))
+	}
+	return nil
+}
+
+// isCAASModelFacade reports whether the given facade name can be accessed
+// using the controller connection.
+func isCAASModelFacade(facadeName string) bool {
+	return caasModelFacadeNames.Contains(facadeName) ||
+		commonModelFacadeNames.Contains(facadeName) ||
+		commonFacadeNames.Contains(facadeName)
+}

--- a/apiserver/restrict_caasmodel_test.go
+++ b/apiserver/restrict_caasmodel_test.go
@@ -1,0 +1,46 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package apiserver_test
+
+import (
+	"github.com/juju/errors"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/apiserver"
+	"github.com/juju/juju/feature"
+	"github.com/juju/juju/rpc"
+	"github.com/juju/juju/testing"
+)
+
+type RestrictCAASModelSuite struct {
+	testing.BaseSuite
+	root rpc.Root
+}
+
+var _ = gc.Suite(&RestrictCAASModelSuite{})
+
+func (s *RestrictCAASModelSuite) SetUpSuite(c *gc.C) {
+	s.BaseSuite.SetUpSuite(c)
+	s.SetFeatureFlags(feature.CAAS)
+	s.root = apiserver.TestingCAASModelOnlyRoot()
+}
+
+func (s *RestrictCAASModelSuite) TestAllowed(c *gc.C) {
+	// TODO(caas) - replace with "CAASProvisioner.WatchApplications" when that bit lands
+	s.assertMethod(c, "Client", 1, "FullStatus")
+}
+
+func (s *RestrictCAASModelSuite) TestNotAllowed(c *gc.C) {
+	caller, err := s.root.FindMethod("Firewaller", 1, "WatchOpenedPorts")
+	c.Assert(err, gc.ErrorMatches, `facade "Firewaller" not supported for a CAAS model API connection`)
+	c.Assert(errors.IsNotSupported(err), jc.IsTrue)
+	c.Assert(caller, gc.IsNil)
+}
+
+func (s *RestrictCAASModelSuite) assertMethod(c *gc.C, facadeName string, version int, method string) {
+	caller, err := s.root.FindMethod(facadeName, version, method)
+	c.Check(err, jc.ErrorIsNil)
+	c.Check(caller, gc.NotNil)
+}

--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -1131,8 +1131,8 @@ func (a *MachineAgent) startStateWorkers(
 }
 
 // startModelWorkers starts the set of workers that run for every model
-// in each controller.
-func (a *MachineAgent) startModelWorkers(modelUUID string) (worker.Worker, error) {
+// in each controller, both IAAS and CAAS.
+func (a *MachineAgent) startModelWorkers(modelUUID string, modelType state.ModelType) (worker.Worker, error) {
 	controllerUUID := a.CurrentConfig().Controller().Id()
 	modelAgent, err := model.WrapAgent(a, controllerUUID, modelUUID)
 	if err != nil {

--- a/cmd/jujud/agent/machine/manifolds.go
+++ b/cmd/jujud/agent/machine/manifolds.go
@@ -204,8 +204,8 @@ type ManifoldsConfig struct {
 	RegisterIntrospectionHTTPHandlers func(func(path string, _ http.Handler))
 
 	// NewModelWorker returns a new worker for managing the model with
-	// the specified UUID.
-	NewModelWorker func(modelUUID string) (worker.Worker, error)
+	// the specified UUID and type.
+	NewModelWorker func(modelUUID string, modelType state.ModelType) (worker.Worker, error)
 }
 
 // Manifolds returns a set of co-configured manifolds covering the

--- a/state/caasmodel.go
+++ b/state/caasmodel.go
@@ -1,0 +1,26 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package state
+
+import "github.com/juju/errors"
+
+// CAASModel contains functionality that is specific to an
+// Containers-As-A-Service (CAAS) model. It embeds a Model so that
+// all generic Model functionality is also available.
+type CAASModel struct {
+	// TODO(caas) - this is all still messy until things shake out.
+	*Model
+	mb modelBackend
+}
+
+// CAASModel returns an Containers-As-A-Service (CAAS) model.
+func (m *Model) CAASModel() (*CAASModel, error) {
+	if m.Type() != ModelTypeCAAS {
+		return nil, errors.NotSupportedf("called CAASModel() on a non-CAAS Model")
+	}
+	return &CAASModel{
+		Model: m,
+		mb:    m.st,
+	}, nil
+}

--- a/state/caasmodel_test.go
+++ b/state/caasmodel_test.go
@@ -1,0 +1,213 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package state_test
+
+import (
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/names.v2"
+
+	"github.com/juju/juju/environs/config"
+	"github.com/juju/juju/feature"
+	"github.com/juju/juju/state"
+	"github.com/juju/juju/storage"
+	"github.com/juju/juju/testing/factory"
+)
+
+type CAASModelSuite struct {
+	ConnSuite
+}
+
+var _ = gc.Suite(&CAASModelSuite{})
+
+// createTestModelConfig returns a new model config and its UUID for testing.
+func (s *CAASModelSuite) createTestModelConfig(c *gc.C) (*config.Config, string) {
+	return createTestModelConfig(c, s.modelTag.Id())
+}
+
+func (s *CAASModelSuite) newCAASModel(c *gc.C) (*state.Model, names.ModelTag, names.UserTag) {
+	cfg, uuid := s.createTestModelConfig(c)
+	modelTag := names.NewModelTag(uuid)
+	owner := names.NewUserTag("test@remote")
+	model, st, err := s.State.NewModel(state.ModelArgs{
+		Type:      state.ModelTypeCAAS,
+		CloudName: "dummy",
+		Config:    cfg,
+		Owner:     owner,
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	s.AddCleanup(func(*gc.C) { st.Close() })
+	return model, modelTag, owner
+}
+
+func (s *CAASModelSuite) TestNewModel(c *gc.C) {
+	s.SetFeatureFlags(feature.CAAS)
+
+	model, modelTag, owner := s.newCAASModel(c)
+	c.Assert(model.Type(), gc.Equals, state.ModelTypeCAAS)
+	c.Assert(model.UUID(), gc.Equals, modelTag.Id())
+	c.Assert(model.Tag(), gc.Equals, modelTag)
+	c.Assert(model.ControllerTag(), gc.Equals, s.State.ControllerTag())
+	c.Assert(model.Owner(), gc.Equals, owner)
+	c.Assert(model.Name(), gc.Equals, "testing")
+	c.Assert(model.Life(), gc.Equals, state.Alive)
+	c.Assert(model.CloudRegion(), gc.Equals, "")
+}
+
+func (s *CAASModelSuite) TestModelDestroy(c *gc.C) {
+	s.SetFeatureFlags(feature.CAAS)
+
+	model, _, _ := s.newCAASModel(c)
+	err := model.Destroy(state.DestroyModelParams{})
+	c.Assert(err, jc.ErrorIsNil)
+	err = model.Refresh()
+	c.Assert(err, jc.ErrorIsNil)
+	// TODO(caas) - this will be dying when we add cleanup steps.
+	c.Assert(model.Life(), gc.Equals, state.Dead)
+}
+
+func (s *CAASModelSuite) TestCAASModelsCantHaveCloudRegion(c *gc.C) {
+	s.SetFeatureFlags(feature.CAAS)
+	cfg, _ := s.createTestModelConfig(c)
+	_, _, err := s.State.NewModel(state.ModelArgs{
+		Type:        state.ModelTypeCAAS,
+		CloudName:   "dummy",
+		CloudRegion: "fork",
+		Config:      cfg,
+		Owner:       names.NewUserTag("test@remote"),
+	})
+	c.Assert(err, gc.ErrorMatches, "CAAS model with CloudRegion not supported")
+}
+
+func (s *CAASModelSuite) TestNewModelCAASNeedsFeature(c *gc.C) {
+	cfg, _ := s.createTestModelConfig(c)
+	owner := names.NewUserTag("test@remote")
+	_, _, err := s.State.NewModel(state.ModelArgs{
+		Type:      state.ModelTypeCAAS,
+		CloudName: "dummy",
+		Config:    cfg,
+		Owner:     owner,
+	})
+	c.Assert(err, gc.ErrorMatches, "model type not supported")
+}
+
+func (s *CAASModelSuite) TestNewModelCAASWithStorageRegistry(c *gc.C) {
+	s.SetFeatureFlags(feature.CAAS)
+
+	cfg, _ := s.createTestModelConfig(c)
+	owner := names.NewUserTag("test@remote")
+	_, _, err := s.State.NewModel(state.ModelArgs{
+		Type:      state.ModelTypeCAAS,
+		CloudName: "dummy",
+		Config:    cfg,
+		Owner:     owner,
+		StorageProviderRegistry: storage.StaticProviderRegistry{},
+	})
+	c.Assert(err, gc.ErrorMatches, "CAAS model with StorageProviderRegistry not valid")
+}
+
+func (s *CAASModelSuite) TestDestroyControllerAndHostedCAASModels(c *gc.C) {
+	s.SetFeatureFlags(feature.CAAS)
+	st2 := s.Factory.MakeModel(c, &factory.ModelParams{
+		Type: state.ModelTypeCAAS, CloudRegion: "<none>", StorageProviderRegistry: factory.NilStorageProviderRegistry{}})
+	defer st2.Close()
+	factory.NewFactory(st2).MakeApplication(c, nil)
+
+	controllerModel, err := s.State.Model()
+	c.Assert(err, jc.ErrorIsNil)
+	destroyStorage := true
+	c.Assert(controllerModel.Destroy(state.DestroyModelParams{
+		DestroyHostedModels: true,
+		DestroyStorage:      &destroyStorage,
+	}), jc.ErrorIsNil)
+
+	model, err := s.State.Model()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(model.Life(), gc.Equals, state.Dying)
+
+	assertNeedsCleanup(c, s.State)
+	assertCleanupRuns(c, s.State)
+
+	// Cleanups for hosted model enqueued by controller model cleanups.
+	assertNeedsCleanup(c, st2)
+	assertCleanupRuns(c, st2)
+
+	model2, err := st2.Model()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(model2.Life(), gc.Equals, state.Dying)
+
+	c.Assert(st2.ProcessDyingModel(), jc.ErrorIsNil)
+
+	c.Assert(model2.Refresh(), jc.ErrorIsNil)
+	c.Assert(model2.Life(), gc.Equals, state.Dead)
+	err = st2.RemoveAllModelDocs()
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Assert(s.State.ProcessDyingModel(), jc.ErrorIsNil)
+	c.Assert(model.Refresh(), jc.ErrorIsNil)
+	c.Assert(model2.Life(), gc.Equals, state.Dead)
+}
+
+func (s *CAASModelSuite) TestDestroyControllerAndHostedCAASModelsWithResources(c *gc.C) {
+	s.SetFeatureFlags(feature.CAAS)
+	otherSt := s.Factory.MakeModel(c, &factory.ModelParams{
+		Type: state.ModelTypeCAAS, CloudRegion: "<none>", StorageProviderRegistry: factory.NilStorageProviderRegistry{}})
+	defer otherSt.Close()
+
+	assertModel := func(model *state.Model, st *state.State, life state.Life, expectedApps int) {
+		c.Assert(model.Refresh(), jc.ErrorIsNil)
+		c.Assert(model.Life(), gc.Equals, life)
+
+		apps, err := st.AllApplications()
+		c.Assert(err, jc.ErrorIsNil)
+		c.Assert(apps, gc.HasLen, expectedApps)
+	}
+
+	// add some applications
+	otherModel, err := otherSt.Model()
+	c.Assert(err, jc.ErrorIsNil)
+	service := s.Factory.MakeApplication(c, nil)
+	ch, _, err := service.Charm()
+	c.Assert(err, jc.ErrorIsNil)
+
+	args := state.AddApplicationArgs{
+		Name:  service.Name(),
+		Charm: ch,
+	}
+	service, err = otherSt.AddApplication(args)
+	c.Assert(err, jc.ErrorIsNil)
+
+	controllerModel, err := s.State.Model()
+	c.Assert(err, jc.ErrorIsNil)
+	destroyStorage := true
+	c.Assert(controllerModel.Destroy(state.DestroyModelParams{
+		DestroyHostedModels: true,
+		DestroyStorage:      &destroyStorage,
+	}), jc.ErrorIsNil)
+
+	assertCleanupCount(c, s.State, 2)
+	assertAllMachinesDeadAndRemove(c, s.State)
+	assertModel(controllerModel, s.State, state.Dying, 0)
+
+	err = s.State.ProcessDyingModel()
+	c.Assert(err, jc.Satisfies, state.IsHasHostedModelsError)
+	c.Assert(err, gc.ErrorMatches, `hosting 1 other model`)
+
+	assertCleanupCount(c, otherSt, 2)
+	assertModel(otherModel, otherSt, state.Dying, 0)
+	c.Assert(otherSt.ProcessDyingModel(), jc.ErrorIsNil)
+
+	c.Assert(otherModel.Refresh(), jc.ErrorIsNil)
+	c.Assert(otherModel.Life(), gc.Equals, state.Dead)
+
+	// Until the model is removed, we can't mark the controller model Dead.
+	err = s.State.ProcessDyingModel()
+	c.Assert(err, gc.ErrorMatches, `hosting 1 other model`)
+
+	err = otherSt.RemoveAllModelDocs()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(s.State.ProcessDyingModel(), jc.ErrorIsNil)
+	c.Assert(controllerModel.Refresh(), jc.ErrorIsNil)
+	c.Assert(controllerModel.Life(), gc.Equals, state.Dead)
+}

--- a/state/iaasmodel.go
+++ b/state/iaasmodel.go
@@ -9,13 +9,9 @@ import "github.com/juju/errors"
 // Infrastructure-As-A-Service (IAAS) model. It embeds a Model so that
 // all generic Model functionality is also available.
 type IAASModel struct {
+	// TODO(caas) - this is all still messy until things shake out.
 	*Model
-
 	mb modelBackend
-
-	// TODO(caas): This should be removed once things
-	// have been sufficiently untangled.
-	st *State
 }
 
 // IAASModel returns an Infrastructure-As-A-Service (IAAS) model.
@@ -26,7 +22,6 @@ func (m *Model) IAASModel() (*IAASModel, error) {
 	return &IAASModel{
 		Model: m,
 		mb:    m.st,
-		st:    m.st,
 	}, nil
 }
 

--- a/state/model.go
+++ b/state/model.go
@@ -1244,21 +1244,23 @@ func (m *Model) destroyOps(
 		// that case we'll get errors if we try to enqueue hosted-model
 		// cleanups, because the cleanups collection is non-global.
 		ops = append(ops,
-			newCleanupOp(cleanupMachinesForDyingModel, modelUUID),
 			newCleanupOp(cleanupApplicationsForDyingModel, modelUUID),
 		)
-		if args.DestroyStorage != nil {
-			// The user has specified that the storage should be destroyed
-			// or released, which we can do in a cleanup. If the user did
-			// not specify either, then we have already added prereq ops
-			// to assert that there is no storage in the model.
-			ops = append(ops, newCleanupOp(
-				cleanupStorageForDyingModel, modelUUID,
-				// pass through DestroyModelArgs.DestroyStorage to the
-				// cleanup, so the storage can be destroyed/released
-				// according to the parameters.
-				*args.DestroyStorage,
-			))
+		if m.Type() == ModelTypeIAAS {
+			ops = append(ops, newCleanupOp(cleanupMachinesForDyingModel, modelUUID))
+			if args.DestroyStorage != nil {
+				// The user has specified that the storage should be destroyed
+				// or released, which we can do in a cleanup. If the user did
+				// not specify either, then we have already added prereq ops
+				// to assert that there is no storage in the model.
+				ops = append(ops, newCleanupOp(
+					cleanupStorageForDyingModel, modelUUID,
+					// pass through DestroyModelArgs.DestroyStorage to the
+					// cleanup, so the storage can be destroyed/released
+					// according to the parameters.
+					*args.DestroyStorage,
+				))
+			}
 		}
 	}
 	return append(prereqOps, ops...), nil

--- a/state/model_test.go
+++ b/state/model_test.go
@@ -18,7 +18,6 @@ import (
 	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/core/crossmodel"
 	"github.com/juju/juju/environs/config"
-	"github.com/juju/juju/feature"
 	"github.com/juju/juju/permission"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/storage"
@@ -200,71 +199,6 @@ func (s *ModelSuite) TestNewModel(c *gc.C) {
 	// Ensure the model is functional by adding a machine
 	_, err = st.AddMachine("quantal", state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)
-}
-
-func (s *ModelSuite) TestNewModelCAAS(c *gc.C) {
-	s.SetFeatureFlags(feature.CAAS)
-
-	cfg, uuid := s.createTestModelConfig(c)
-	modelTag := names.NewModelTag(uuid)
-	owner := names.NewUserTag("test@remote")
-	model, st, err := s.State.NewModel(state.ModelArgs{
-		Type:      state.ModelTypeCAAS,
-		CloudName: "dummy",
-		Config:    cfg,
-		Owner:     owner,
-	})
-	c.Assert(err, jc.ErrorIsNil)
-	defer st.Close()
-
-	c.Assert(model.Type(), gc.Equals, state.ModelTypeCAAS)
-	c.Assert(model.UUID(), gc.Equals, modelTag.Id())
-	c.Assert(model.Tag(), gc.Equals, modelTag)
-	c.Assert(model.ControllerTag(), gc.Equals, s.State.ControllerTag())
-	c.Assert(model.Owner(), gc.Equals, owner)
-	c.Assert(model.Name(), gc.Equals, "testing")
-	c.Assert(model.Life(), gc.Equals, state.Alive)
-	c.Assert(model.CloudRegion(), gc.Equals, "")
-}
-
-func (s *ModelSuite) TestCAASModelsCantHaveCloudRegion(c *gc.C) {
-	s.SetFeatureFlags(feature.CAAS)
-	cfg, _ := s.createTestModelConfig(c)
-	_, _, err := s.State.NewModel(state.ModelArgs{
-		Type:        state.ModelTypeCAAS,
-		CloudName:   "dummy",
-		CloudRegion: "fork",
-		Config:      cfg,
-		Owner:       names.NewUserTag("test@remote"),
-	})
-	c.Assert(err, gc.ErrorMatches, "CAAS model with CloudRegion not supported")
-}
-
-func (s *ModelSuite) TestNewModelCAASNeedsFeature(c *gc.C) {
-	cfg, _ := s.createTestModelConfig(c)
-	owner := names.NewUserTag("test@remote")
-	_, _, err := s.State.NewModel(state.ModelArgs{
-		Type:      state.ModelTypeCAAS,
-		CloudName: "dummy",
-		Config:    cfg,
-		Owner:     owner,
-	})
-	c.Assert(err, gc.ErrorMatches, "model type not supported")
-}
-
-func (s *ModelSuite) TestNewModelCAASWithStorageRegistry(c *gc.C) {
-	s.SetFeatureFlags(feature.CAAS)
-
-	cfg, _ := s.createTestModelConfig(c)
-	owner := names.NewUserTag("test@remote")
-	_, _, err := s.State.NewModel(state.ModelArgs{
-		Type:      state.ModelTypeCAAS,
-		CloudName: "dummy",
-		Config:    cfg,
-		Owner:     owner,
-		StorageProviderRegistry: storage.StaticProviderRegistry{},
-	})
-	c.Assert(err, gc.ErrorMatches, "CAAS model with StorageProviderRegistry not valid")
 }
 
 func (s *ModelSuite) TestNewModelImportingMode(c *gc.C) {

--- a/testing/factory/factory.go
+++ b/testing/factory/factory.go
@@ -613,6 +613,12 @@ func (factory *Factory) MakeRelation(c *gc.C, params *RelationParams) *state.Rel
 	return relation
 }
 
+// NilStorageProviderRegistry is used to specify a model
+// should be created with a nil storage.ProviderRegistry.
+type NilStorageProviderRegistry struct {
+	storage.ProviderRegistry
+}
+
 // MakeModel creates an model with specified params,
 // filling in sane defaults for missing values. If params is nil,
 // defaults are used for all values.
@@ -636,6 +642,9 @@ func (factory *Factory) MakeModel(c *gc.C, params *ModelParams) *state.State {
 	if params.CloudRegion == "" {
 		params.CloudRegion = "dummy-region"
 	}
+	if params.CloudRegion == "<none>" {
+		params.CloudRegion = ""
+	}
 	if params.Owner == nil {
 		origEnv, err := factory.st.Model()
 		c.Assert(err, jc.ErrorIsNil)
@@ -643,6 +652,10 @@ func (factory *Factory) MakeModel(c *gc.C, params *ModelParams) *state.State {
 	}
 	if params.StorageProviderRegistry == nil {
 		params.StorageProviderRegistry = provider.CommonStorageProviders()
+	}
+	nilRegistry := NilStorageProviderRegistry{}
+	if params.StorageProviderRegistry == nilRegistry {
+		params.StorageProviderRegistry = nil
 	}
 	// It only makes sense to make an model with the same provider
 	// as the initial model, or things will break elsewhere.

--- a/worker/modelworkermanager/manifold_test.go
+++ b/worker/modelworkermanager/manifold_test.go
@@ -64,8 +64,8 @@ func (s *ManifoldSuite) newWorker(config modelworkermanager.Config) (worker.Work
 	return worker.NewRunner(worker.RunnerParams{}), nil
 }
 
-func (s *ManifoldSuite) newModelWorker(modelUUID string) (worker.Worker, error) {
-	s.stub.MethodCall(s, "NewModelWorker", modelUUID)
+func (s *ManifoldSuite) newModelWorker(modelUUID string, modelType state.ModelType) (worker.Worker, error) {
+	s.stub.MethodCall(s, "NewModelWorker", modelUUID, modelType)
 	if err := s.stub.NextErr(); err != nil {
 		return nil, err
 	}
@@ -99,11 +99,11 @@ func (s *ManifoldSuite) TestStart(c *gc.C) {
 	config := args[0].(modelworkermanager.Config)
 
 	c.Assert(config.NewModelWorker, gc.NotNil)
-	mw, err := config.NewModelWorker("foo")
+	mw, err := config.NewModelWorker("foo", state.ModelTypeIAAS)
 	c.Assert(err, jc.ErrorIsNil)
 	workertest.CleanKill(c, mw)
 	s.stub.CheckCallNames(c, "NewWorker", "NewModelWorker")
-	s.stub.CheckCall(c, 1, "NewModelWorker", "foo")
+	s.stub.CheckCall(c, 1, "NewModelWorker", "foo", state.ModelTypeIAAS)
 	config.NewModelWorker = nil
 
 	c.Assert(config, jc.DeepEquals, modelworkermanager.Config{


### PR DESCRIPTION
## Description of change

Preparation for implementing a CAAS provisioner.
The key changes include:
- restricted CAAS facade support for logins to CAAS models
- pass model type when getting manifolds to start (next PR will use it)
- CAAS model entity (includes moving CAAS model tests off ModelSuite)
- allow agents to accept an application tag as well as unit or machine
- driveby fixes to stop errors on CAAS model destroy

## QA steps

Smoke test an IAAS deployment
