### PR TITLE
Caas provisioner part 2

### DIFF
--- a/api/common/cloudspec/cloudspec.go
+++ b/api/common/cloudspec/cloudspec.go
@@ -66,6 +66,7 @@ func (api *CloudSpecAPI) MakeCloudSpec(pSpec *params.CloudSpec) (environs.CloudS
 		Endpoint:         pSpec.Endpoint,
 		IdentityEndpoint: pSpec.IdentityEndpoint,
 		StorageEndpoint:  pSpec.StorageEndpoint,
+		CACertificates:   pSpec.CACertificates,
 		Credential:       credential,
 	}
 	if err := spec.Validate(); err != nil {

--- a/api/common/cloudspec/cloudspec_test.go
+++ b/api/common/cloudspec/cloudspec_test.go
@@ -33,11 +33,11 @@ func (s *CloudSpecSuite) TestCloudSpec(c *gc.C) {
 	facadeCaller := apitesting.StubFacadeCaller{Stub: &testing.Stub{}}
 	facadeCaller.FacadeCallFn = func(name string, args, response interface{}) error {
 		c.Assert(name, gc.Equals, "CloudSpec")
-		c.Assert(args, jc.DeepEquals, params.Entities{[]params.Entity{
-			{coretesting.ModelTag.String()},
+		c.Assert(args, jc.DeepEquals, params.Entities{Entities: []params.Entity{
+			{Tag: coretesting.ModelTag.String()},
 		}})
 		*(response.(*params.CloudSpecResults)) = params.CloudSpecResults{
-			[]params.CloudSpecResult{{
+			Results: []params.CloudSpecResult{{
 				Result: &params.CloudSpec{
 					Type:             "type",
 					Name:             "name",
@@ -49,6 +49,7 @@ func (s *CloudSpecSuite) TestCloudSpec(c *gc.C) {
 						AuthType:   "auth-type",
 						Attributes: map[string]string{"k": "v"},
 					},
+					CACertificates: []string{coretesting.CACert},
 				},
 			}},
 		}
@@ -70,6 +71,7 @@ func (s *CloudSpecSuite) TestCloudSpec(c *gc.C) {
 		IdentityEndpoint: "identity-endpoint",
 		StorageEndpoint:  "storage-endpoint",
 		Credential:       &credential,
+		CACertificates:   []string{coretesting.CACert},
 	})
 }
 
@@ -98,7 +100,7 @@ func (s *CloudSpecSuite) TestCloudSpecResultError(c *gc.C) {
 	facadeCaller := apitesting.StubFacadeCaller{Stub: &testing.Stub{}}
 	facadeCaller.FacadeCallFn = func(name string, args, response interface{}) error {
 		*(response.(*params.CloudSpecResults)) = params.CloudSpecResults{
-			[]params.CloudSpecResult{{
+			Results: []params.CloudSpecResult{{
 				Error: &params.Error{
 					Code:    params.CodeUnauthorized,
 					Message: "dang",
@@ -116,7 +118,7 @@ func (s *CloudSpecSuite) TestCloudSpecResultError(c *gc.C) {
 func (s *CloudSpecSuite) TestCloudSpecInvalidCloudSpec(c *gc.C) {
 	facadeCaller := apitesting.StubFacadeCaller{Stub: &testing.Stub{}}
 	facadeCaller.FacadeCallFn = func(name string, args, response interface{}) error {
-		*(response.(*params.CloudSpecResults)) = params.CloudSpecResults{[]params.CloudSpecResult{{
+		*(response.(*params.CloudSpecResults)) = params.CloudSpecResults{Results: []params.CloudSpecResult{{
 			Result: &params.CloudSpec{
 				Type: "",
 			},

--- a/apiserver/common/cloudspec/cloudspec.go
+++ b/apiserver/common/cloudspec/cloudspec.go
@@ -74,13 +74,14 @@ func (s cloudSpecAPI) GetCloudSpec(tag names.ModelTag) params.CloudSpecResult {
 		}
 	}
 	result.Result = &params.CloudSpec{
-		spec.Type,
-		spec.Name,
-		spec.Region,
-		spec.Endpoint,
-		spec.IdentityEndpoint,
-		spec.StorageEndpoint,
-		paramsCloudCredential,
+		Type:             spec.Type,
+		Name:             spec.Name,
+		Region:           spec.Region,
+		Endpoint:         spec.Endpoint,
+		IdentityEndpoint: spec.IdentityEndpoint,
+		StorageEndpoint:  spec.StorageEndpoint,
+		Credential:       paramsCloudCredential,
+		CACertificates:   spec.CACertificates,
 	}
 	return result
 }

--- a/apiserver/common/cloudspec/cloudspec_test.go
+++ b/apiserver/common/cloudspec/cloudspec_test.go
@@ -10,7 +10,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils"
 	gc "gopkg.in/check.v1"
-	names "gopkg.in/juju/names.v2"
+	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/common/cloudspec"
@@ -51,13 +51,14 @@ func (s *CloudSpecSuite) SetUpTest(c *gc.C) {
 		map[string]string{"k": "v"},
 	)
 	s.result = environs.CloudSpec{
-		"type",
-		"name",
-		"region",
-		"endpoint",
-		"identity-endpoint",
-		"storage-endpoint",
-		&credential,
+		Type:             "type",
+		Name:             "name",
+		Region:           "region",
+		Endpoint:         "endpoint",
+		IdentityEndpoint: "identity-endpoint",
+		StorageEndpoint:  "storage-endpoint",
+		Credential:       &credential,
+		CACertificates:   []string{coretesting.CACert},
 	}
 }
 
@@ -72,16 +73,17 @@ func (s *CloudSpecSuite) TestCloudSpec(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.Results, jc.DeepEquals, []params.CloudSpecResult{{
 		Result: &params.CloudSpec{
-			"type",
-			"name",
-			"region",
-			"endpoint",
-			"identity-endpoint",
-			"storage-endpoint",
-			&params.CloudCredential{
+			Type:             "type",
+			Name:             "name",
+			Region:           "region",
+			Endpoint:         "endpoint",
+			IdentityEndpoint: "identity-endpoint",
+			StorageEndpoint:  "storage-endpoint",
+			Credential: &params.CloudCredential{
 				AuthType:   "auth-type",
 				Attributes: map[string]string{"k": "v"},
 			},
+			CACertificates: []string{coretesting.CACert},
 		},
 	}, {
 		Error: &params.Error{
@@ -109,13 +111,14 @@ func (s *CloudSpecSuite) TestCloudSpecNilCredential(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.Results, jc.DeepEquals, []params.CloudSpecResult{{
 		Result: &params.CloudSpec{
-			"type",
-			"name",
-			"region",
-			"endpoint",
-			"identity-endpoint",
-			"storage-endpoint",
-			nil,
+			Type:             "type",
+			Name:             "name",
+			Region:           "region",
+			Endpoint:         "endpoint",
+			IdentityEndpoint: "identity-endpoint",
+			StorageEndpoint:  "storage-endpoint",
+			Credential:       nil,
+			CACertificates:   []string{coretesting.CACert},
 		},
 	}})
 }

--- a/apiserver/params/cloud.go
+++ b/apiserver/params/cloud.go
@@ -101,6 +101,7 @@ type CloudSpec struct {
 	IdentityEndpoint string           `json:"identity-endpoint,omitempty"`
 	StorageEndpoint  string           `json:"storage-endpoint,omitempty"`
 	Credential       *CloudCredential `json:"credential,omitempty"`
+	CACertificates   []string         `json:"cacertificates,omitempty"`
 }
 
 // CloudSpecResult contains a CloudSpec or an error.

--- a/caas/broker.go
+++ b/caas/broker.go
@@ -1,0 +1,26 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package caas
+
+import "github.com/juju/juju/environs"
+
+// NewContainerBrokerFunc returns a Container Broker.
+type NewContainerBrokerFunc func(environs.CloudSpec) (Broker, error)
+
+// NewOperatorConfigFunc functions return the agent config to use for
+// a CAAS jujud operator.
+type NewOperatorConfigFunc func(appName string) (*OperatorConfig, error)
+
+// Broker instances interact with the CAAS substrate.
+type Broker interface {
+	// EnsureOperator creates an operator for running a charm for the specified application.
+	// If the operator exists, this does nothing.
+	EnsureOperator(appName, agentPath string, newConfig NewOperatorConfigFunc) error
+}
+
+// OperatorConfig is the config to use when creating an operator.
+type OperatorConfig struct {
+	// AgentConf is the contents of the agent.conf file.
+	AgentConf []byte
+}

--- a/caas/kubernetes/clientconfig/k8s.go
+++ b/caas/kubernetes/clientconfig/k8s.go
@@ -1,4 +1,4 @@
-package caas
+package clientconfig
 
 import (
 	"os"
@@ -11,7 +11,7 @@ import (
 	"github.com/juju/juju/cloud"
 )
 
-var logger = loggo.GetLogger("juju.caas.clientconfig")
+var logger = loggo.GetLogger("juju.caas.kubernetes.clientconfig")
 
 // K8SClientConfig parses Kubernetes client configuration from the default location or $KUBECONFIG.
 func K8SClientConfig() (*ClientConfig, error) {

--- a/caas/kubernetes/clientconfig/k8s_test.go
+++ b/caas/kubernetes/clientconfig/k8s_test.go
@@ -1,7 +1,7 @@
 // Copyright 2017 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package caas_test
+package clientconfig_test
 
 import (
 	"io/ioutil"
@@ -11,7 +11,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
-	caascfg "github.com/juju/juju/caas/clientconfig"
+	"github.com/juju/juju/caas/kubernetes/clientconfig"
 	"github.com/juju/juju/cloud"
 	"github.com/juju/testing"
 )
@@ -127,14 +127,14 @@ func (s *k8sConfigSuite) writeTempKubeConfig(c *gc.C, filename string, data stri
 func (s *k8sConfigSuite) TestGetEmptyConfig(c *gc.C) {
 	s.writeTempKubeConfig(c, "emptyConfig", emptyConfig)
 
-	cfg, err := caascfg.K8SClientConfig()
+	cfg, err := clientconfig.K8SClientConfig()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cfg, jc.DeepEquals,
-		&caascfg.ClientConfig{
+		&clientconfig.ClientConfig{
 			Type:           "kubernetes",
-			Contexts:       map[string]caascfg.Context{},
+			Contexts:       map[string]clientconfig.Context{},
 			CurrentContext: "",
-			Clouds:         map[string]caascfg.CloudConfig{},
+			Clouds:         map[string]clientconfig.CloudConfig{},
 			Credentials:    map[string]cloud.Credential{},
 		})
 }
@@ -142,19 +142,19 @@ func (s *k8sConfigSuite) TestGetEmptyConfig(c *gc.C) {
 func (s *k8sConfigSuite) TestGetSingleConfig(c *gc.C) {
 	s.writeTempKubeConfig(c, "singleConfig", singleConfig)
 
-	cfg, err := caascfg.K8SClientConfig()
+	cfg, err := clientconfig.K8SClientConfig()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cfg, jc.DeepEquals,
-		&caascfg.ClientConfig{
+		&clientconfig.ClientConfig{
 
 			Type: "kubernetes",
-			Contexts: map[string]caascfg.Context{
-				"the-context": caascfg.Context{
+			Contexts: map[string]clientconfig.Context{
+				"the-context": clientconfig.Context{
 					CloudName:      "the-cluster",
 					CredentialName: "the-user"}},
 			CurrentContext: "the-context",
-			Clouds: map[string]caascfg.CloudConfig{
-				"the-cluster": caascfg.CloudConfig{
+			Clouds: map[string]clientconfig.CloudConfig{
+				"the-cluster": clientconfig.CloudConfig{
 					Endpoint:   "https://1.1.1.1:8888",
 					Attributes: map[string]interface{}{"CAData": "A"}}},
 			Credentials: map[string]cloud.Credential{
@@ -167,26 +167,26 @@ func (s *k8sConfigSuite) TestGetSingleConfig(c *gc.C) {
 func (s *k8sConfigSuite) TestGetMultiConfig(c *gc.C) {
 	s.writeTempKubeConfig(c, "multiConfig", multiConfig)
 
-	cfg, err := caascfg.K8SClientConfig()
+	cfg, err := clientconfig.K8SClientConfig()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cfg, jc.DeepEquals,
-		&caascfg.ClientConfig{
+		&clientconfig.ClientConfig{
 
 			Type: "kubernetes",
-			Contexts: map[string]caascfg.Context{
-				"default-context": caascfg.Context{
+			Contexts: map[string]clientconfig.Context{
+				"default-context": clientconfig.Context{
 					CloudName:      "default-cluster",
 					CredentialName: "default-user"},
-				"the-context": caascfg.Context{
+				"the-context": clientconfig.Context{
 					CloudName:      "the-cluster",
 					CredentialName: "the-user"},
 			},
 			CurrentContext: "default-context",
-			Clouds: map[string]caascfg.CloudConfig{
-				"default-cluster": caascfg.CloudConfig{
+			Clouds: map[string]clientconfig.CloudConfig{
+				"default-cluster": clientconfig.CloudConfig{
 					Endpoint:   "https://10.10.10.10:1010",
 					Attributes: map[string]interface{}{"CAData": ""}},
-				"the-cluster": caascfg.CloudConfig{
+				"the-cluster": clientconfig.CloudConfig{
 					Endpoint:   "https://1.1.1.1:8888",
 					Attributes: map[string]interface{}{"CAData": "A"}}},
 			Credentials: map[string]cloud.Credential{

--- a/caas/kubernetes/clientconfig/package_test.go
+++ b/caas/kubernetes/clientconfig/package_test.go
@@ -1,7 +1,7 @@
 // Copyright 2017 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package caas_test
+package clientconfig
 
 import (
 	"testing"

--- a/caas/kubernetes/clientconfig/types.go
+++ b/caas/kubernetes/clientconfig/types.go
@@ -1,4 +1,4 @@
-package caas
+package clientconfig
 
 import (
 	"github.com/juju/errors"

--- a/caas/kubernetes/provider/k8s.go
+++ b/caas/kubernetes/provider/k8s.go
@@ -1,0 +1,185 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package provider
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/loggo"
+	"gopkg.in/juju/names.v2"
+	"k8s.io/client-go/kubernetes"
+	k8serrors "k8s.io/client-go/pkg/api/errors"
+	"k8s.io/client-go/pkg/api/v1"
+	"k8s.io/client-go/rest"
+
+	"github.com/juju/juju/agent"
+	"github.com/juju/juju/caas"
+	"github.com/juju/juju/environs"
+)
+
+var logger = loggo.GetLogger("juju.kubernetes.provider")
+
+// TODO(caas) should be using a juju specific namespace
+const namespace = "default"
+
+// TODO(caas) - add unit tests
+
+type kubernetesClient struct {
+	*kubernetes.Clientset
+}
+
+// NewK8sProvider returns a kubernetes client for the specified cloud.
+func NewK8sProvider(cloudSpec environs.CloudSpec) (caas.Broker, error) {
+	config, err := newK8sConfig(cloudSpec)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	client, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return &kubernetesClient{client}, nil
+}
+
+func newK8sConfig(cloudSpec environs.CloudSpec) (*rest.Config, error) {
+	if cloudSpec.Credential == nil {
+		return nil, errors.Errorf("cloud %v has no credential", cloudSpec.Name)
+	}
+
+	var CAData []byte
+	for _, cacert := range cloudSpec.CACertificates {
+		CAData = append(CAData, cacert...)
+	}
+
+	credentialAttrs := cloudSpec.Credential.Attributes()
+	return &rest.Config{
+		Host:     cloudSpec.Endpoint,
+		Username: credentialAttrs["Username"],
+		Password: credentialAttrs["Password"],
+		TLSClientConfig: rest.TLSClientConfig{
+			CertData: []byte(credentialAttrs["ClientCertificateData"]),
+			KeyData:  []byte(credentialAttrs["ClientKeyData"]),
+			CAData:   CAData,
+		},
+	}, nil
+}
+
+// EnsureOperator creates a new operator for appName if it doesn't exist.
+func (k *kubernetesClient) EnsureOperator(appName, agentPath string, newConfig caas.NewOperatorConfigFunc) error {
+	if exists, err := k.operatorExists(appName); err != nil {
+		return errors.Trace(err)
+	} else if exists {
+		logger.Debugf("%s operator already deployed", appName)
+		return nil
+	}
+	logger.Infof("deploying %s operator", appName)
+
+	// TODO(caas) use secrets for storing agent password?
+	configMapName, err := k.ensureConfigMap(appName, newConfig)
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	return k.deployOperator(appName, agentPath, configMapName)
+}
+
+func (k *kubernetesClient) ensureConfigMap(appName string, newConfig caas.NewOperatorConfigFunc) (string, error) {
+	mapName := podName(appName) + "-config"
+
+	exists, err := k.configMapExists(mapName)
+	if err != nil {
+		return "", errors.Trace(err)
+	}
+	if exists {
+		logger.Infof("ConfigMap %s already exists", mapName)
+	} else {
+		config, err := newConfig(appName)
+		if err != nil {
+			return "", errors.Annotate(err, "creating config")
+		}
+		if err := k.createConfigMap(mapName, config); err != nil {
+			return "", errors.Annotate(err, "creating ConfigMap")
+		}
+	}
+	return mapName, nil
+}
+
+func (k *kubernetesClient) configMapExists(configMapName string) (bool, error) {
+	_, err := k.CoreV1().ConfigMaps(namespace).Get(configMapName)
+	if k8serrors.IsNotFound(err) {
+		return false, nil
+	} else if err != nil {
+		return false, errors.Trace(err)
+	}
+	return true, nil
+}
+
+func (k *kubernetesClient) createConfigMap(configMapName string, config *caas.OperatorConfig) error {
+	_, err := k.CoreV1().ConfigMaps(namespace).Create(&v1.ConfigMap{
+		ObjectMeta: v1.ObjectMeta{
+			Name: configMapName,
+		},
+		Data: map[string]string{
+			"agent.conf": string(config.AgentConf),
+		},
+	})
+	return errors.Trace(err)
+}
+
+func (k *kubernetesClient) operatorExists(appName string) (bool, error) {
+	_, err := k.CoreV1().Pods(namespace).Get(podName(appName))
+	if k8serrors.IsNotFound(err) {
+		return false, nil
+	} else if err != nil {
+		return false, errors.Trace(err)
+	}
+	return true, nil
+}
+
+func (k *kubernetesClient) deployOperator(appName, agentPath string, configMapName string) error {
+	configVolName := configMapName + "-volume"
+
+	appTag := names.NewApplicationTag(appName)
+	spec := &v1.Pod{
+		ObjectMeta: v1.ObjectMeta{
+			Name: podName(appName),
+		},
+		Spec: v1.PodSpec{
+			Containers: []v1.Container{{
+				Name:            "juju-operator",
+				ImagePullPolicy: v1.PullIfNotPresent,
+				// TODO(caas) use proper image
+				Image:   "ubuntu:16.04",
+				Command: []string{"sleep"},
+				Args:    []string{"infinity"},
+				//Args:    []string{"caasoperator", "--application-name", appName, "--debug"},
+
+				VolumeMounts: []v1.VolumeMount{{
+					Name:      configVolName,
+					MountPath: agent.Dir(agentPath, appTag) + "/agent.conf",
+					SubPath:   "agent.conf",
+				}},
+			}},
+			Volumes: []v1.Volume{{
+				Name: configVolName,
+				VolumeSource: v1.VolumeSource{
+					ConfigMap: &v1.ConfigMapVolumeSource{
+						LocalObjectReference: v1.LocalObjectReference{
+							Name: configMapName,
+						},
+						Items: []v1.KeyToPath{{
+							Key:  "agent.conf",
+							Path: "agent.conf",
+						}},
+					},
+				},
+			}},
+		},
+	}
+	_, err := k.CoreV1().Pods(namespace).Create(spec)
+	return errors.Trace(err)
+}
+
+func podName(appName string) string {
+	return "juju-operator-" + appName
+}

--- a/cmd/juju/caas/add.go
+++ b/cmd/juju/caas/add.go
@@ -15,7 +15,7 @@ import (
 	"github.com/juju/juju/api"
 	"github.com/juju/juju/api/base"
 	cloudapi "github.com/juju/juju/api/cloud"
-	caascfg "github.com/juju/juju/caas/clientconfig"
+	"github.com/juju/juju/caas/kubernetes/clientconfig"
 	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/cmd/juju/common"
 	"github.com/juju/juju/cmd/modelcmd"
@@ -67,7 +67,7 @@ type AddCAASCommand struct {
 	fileCredentialStore   jujuclient.CredentialStore
 	apiRoot               api.Connection
 	newCloudAPI           func(base.APICallCloser) CloudAPI
-	newClientConfigReader func(string) (caascfg.ClientConfigFunc, error)
+	newClientConfigReader func(string) (clientconfig.ClientConfigFunc, error)
 }
 
 // NewAddCAASCommand returns a command to add caas information.
@@ -78,13 +78,13 @@ func NewAddCAASCommand(cloudMetadataStore CloudMetadataStore) cmd.Command {
 		newCloudAPI: func(caller base.APICallCloser) CloudAPI {
 			return cloudapi.NewClient(caller)
 		},
-		newClientConfigReader: func(caasType string) (caascfg.ClientConfigFunc, error) {
-			return caascfg.NewClientConfigReader(caasType)
+		newClientConfigReader: func(caasType string) (clientconfig.ClientConfigFunc, error) {
+			return clientconfig.NewClientConfigReader(caasType)
 		},
 	}
 	return modelcmd.Wrap(cmd)
 }
-func NewAddCAASCommandForTest(cloudMetadataStore CloudMetadataStore, fileCredentialStore jujuclient.CredentialStore, clientStore jujuclient.ClientStore, apiRoot api.Connection, newCloudAPIFunc func(base.APICallCloser) CloudAPI, newClientConfigReaderFunc func(string) (caascfg.ClientConfigFunc, error)) cmd.Command {
+func NewAddCAASCommandForTest(cloudMetadataStore CloudMetadataStore, fileCredentialStore jujuclient.CredentialStore, clientStore jujuclient.ClientStore, apiRoot api.Connection, newCloudAPIFunc func(base.APICallCloser) CloudAPI, newClientConfigReaderFunc func(string) (clientconfig.ClientConfigFunc, error)) cmd.Command {
 	cmd := &AddCAASCommand{
 		cloudMetadataStore:    cloudMetadataStore,
 		fileCredentialStore:   fileCredentialStore,

--- a/cmd/juju/caas/add_test.go
+++ b/cmd/juju/caas/add_test.go
@@ -15,7 +15,7 @@ import (
 
 	"github.com/juju/juju/api"
 	"github.com/juju/juju/api/base"
-	caascfg "github.com/juju/juju/caas/clientconfig"
+	"github.com/juju/juju/caas/kubernetes/clientconfig"
 	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/cmd/juju/caas"
 	"github.com/juju/juju/jujuclient"
@@ -26,7 +26,7 @@ type addCAASSuite struct {
 	fakeCloudAPI        *fakeCloudAPI
 	store               *fakeCloudMetadataStore
 	fileCredentialStore *fakeCredentialStore
-	fakeK8SConfigFunc   caascfg.ClientConfigFunc
+	fakeK8SConfigFunc   clientconfig.ClientConfigFunc
 }
 
 var _ = gc.Suite(&addCAASSuite{})
@@ -83,15 +83,15 @@ func (api *fakeCloudAPI) AddCredential(tag string, credential cloud.Credential) 
 	return nil
 }
 
-func fakeK8SClientConfig() (*caascfg.ClientConfig, error) {
-	return &caascfg.ClientConfig{
-		Contexts: map[string]caascfg.Context{"somekey": caascfg.Context{
+func fakeK8SClientConfig() (*clientconfig.ClientConfig, error) {
+	return &clientconfig.ClientConfig{
+		Contexts: map[string]clientconfig.Context{"somekey": clientconfig.Context{
 			CloudName:      "mrcloud",
 			CredentialName: "credname",
 		},
 		},
 		CurrentContext: "somekey",
-		Clouds: map[string]caascfg.CloudConfig{"mrcloud": caascfg.CloudConfig{
+		Clouds: map[string]clientconfig.CloudConfig{"mrcloud": clientconfig.CloudConfig{
 			Endpoint: "fakeendpoint",
 			Attributes: map[string]interface{}{
 				"CAData": "fakecadata",
@@ -101,8 +101,8 @@ func fakeK8SClientConfig() (*caascfg.ClientConfig, error) {
 	}, nil
 }
 
-func fakeEmptyK8SClientConfig() (*caascfg.ClientConfig, error) {
-	return &caascfg.ClientConfig{}, nil
+func fakeEmptyK8SClientConfig() (*clientconfig.ClientConfig, error) {
+	return &clientconfig.ClientConfig{}, nil
 }
 
 type fakeCredentialStore struct {
@@ -177,7 +177,7 @@ func (s *addCAASSuite) makeCommand(c *gc.C, cloudTypeExists bool, emptyClientCon
 		func(caller base.APICallCloser) caas.CloudAPI {
 			return s.fakeCloudAPI
 		},
-		func(caasType string) (caascfg.ClientConfigFunc, error) {
+		func(caasType string) (clientconfig.ClientConfigFunc, error) {
 			if !cloudTypeExists {
 				return nil, errors.Errorf("unsupported cloud type '%s'", caasType)
 			}

--- a/cmd/jujud/agent/machine_test.go
+++ b/cmd/jujud/agent/machine_test.go
@@ -1247,8 +1247,8 @@ func (s *MachineSuite) TestControllerModelWorkers(c *gc.C) {
 	uuid := s.BackingState.ModelUUID()
 
 	tracker := NewEngineTracker()
-	instrumented := TrackModels(c, tracker, modelManifolds)
-	s.PatchValue(&modelManifolds, instrumented)
+	instrumented := TrackModels(c, tracker, iaasModelManifolds)
+	s.PatchValue(&iaasModelManifolds, instrumented)
 
 	matcher := NewWorkerMatcher(c, tracker, uuid,
 		append(alwaysModelWorkers, aliveModelWorkers...))
@@ -1270,8 +1270,8 @@ func (s *MachineSuite) TestHostedModelWorkers(c *gc.C) {
 	uuid := st.ModelUUID()
 
 	tracker := NewEngineTracker()
-	instrumented := TrackModels(c, tracker, modelManifolds)
-	s.PatchValue(&modelManifolds, instrumented)
+	instrumented := TrackModels(c, tracker, iaasModelManifolds)
+	s.PatchValue(&iaasModelManifolds, instrumented)
 
 	matcher := NewWorkerMatcher(c, tracker, uuid,
 		append(alwaysModelWorkers, aliveModelWorkers...))
@@ -1295,7 +1295,7 @@ func (s *MachineSuite) TestMigratingModelWorkers(c *gc.C) {
 	// TODO(mjs) - an alternative might be to provide a fake Facade
 	// and api.Open to the real migrationmaster but this test is
 	// awfully far away from the low level details of the worker.
-	origModelManifolds := modelManifolds
+	origModelManifolds := iaasModelManifolds
 	modelManifoldsDisablingMigrationMaster := func(config model.ManifoldsConfig) dependency.Manifolds {
 		config.NewMigrationMaster = func(config migrationmaster.Config) (worker.Worker, error) {
 			return &nullWorker{}, nil
@@ -1303,7 +1303,7 @@ func (s *MachineSuite) TestMigratingModelWorkers(c *gc.C) {
 		return origModelManifolds(config)
 	}
 	instrumented := TrackModels(c, tracker, modelManifoldsDisablingMigrationMaster)
-	s.PatchValue(&modelManifolds, instrumented)
+	s.PatchValue(&iaasModelManifolds, instrumented)
 
 	targetControllerTag := names.NewControllerTag(utils.MustNewUUID().String())
 	_, err := st.CreateMigration(state.MigrationSpec{
@@ -1369,8 +1369,8 @@ func (s *MachineSuite) TestModelWorkersRespectSingularResponsibilityFlag(c *gc.C
 	// Then run a normal model-tracking test, just checking for
 	// a different set of workers.
 	tracker := NewEngineTracker()
-	instrumented := TrackModels(c, tracker, modelManifolds)
-	s.PatchValue(&modelManifolds, instrumented)
+	instrumented := TrackModels(c, tracker, iaasModelManifolds)
+	s.PatchValue(&iaasModelManifolds, instrumented)
 
 	matcher := NewWorkerMatcher(c, tracker, uuid, alwaysModelWorkers)
 	s.assertJobWithState(c, state.JobManageModel, func(agent.Config, *state.State) {

--- a/cmd/jujud/agent/model/manifolds.go
+++ b/cmd/jujud/agent/model/manifolds.go
@@ -14,6 +14,7 @@ import (
 	coreagent "github.com/juju/juju/agent"
 	"github.com/juju/juju/api"
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/caas"
 	"github.com/juju/juju/cmd/jujud/agent/engine"
 	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/environs"
@@ -22,6 +23,8 @@ import (
 	"github.com/juju/juju/worker/apicaller"
 	"github.com/juju/juju/worker/apiconfigwatcher"
 	"github.com/juju/juju/worker/applicationscaler"
+	"github.com/juju/juju/worker/caasbroker"
+	"github.com/juju/juju/worker/caasprovisioner"
 	"github.com/juju/juju/worker/charmrevision"
 	"github.com/juju/juju/worker/charmrevision/charmrevisionmanifold"
 	"github.com/juju/juju/worker/cleaner"
@@ -96,18 +99,21 @@ type ManifoldsConfig struct {
 	// (typically environs.New).
 	NewEnvironFunc environs.NewEnvironFunc
 
+	// NewContainerBrokerFunc is a function opens a CAAS provider.
+	NewContainerBrokerFunc caas.NewContainerBrokerFunc
+
 	// NewMigrationMaster is called to create a new migrationmaster
 	// worker.
 	NewMigrationMaster func(migrationmaster.Config) (worker.Worker, error)
 }
 
-// Manifolds returns a set of interdependent dependency manifolds that will
-// run together to administer a model, as configured.
-func Manifolds(config ManifoldsConfig) dependency.Manifolds {
+// commonManifolds returns a set of interdependent dependency manifolds that will
+// run together to administer a model, as configured. These manifolds are used
+// by both IAAS and CAAS models.
+func commonManifolds(config ManifoldsConfig) dependency.Manifolds {
 	agentConfig := config.Agent.CurrentConfig()
 	machineTag := agentConfig.Tag().(names.MachineTag)
 	modelTag := agentConfig.Model()
-	controllerTag := agentConfig.Controller()
 	result := dependency.Manifolds{
 
 		// The first group are foundational; the agent and clock
@@ -157,34 +163,6 @@ func Manifolds(config ManifoldsConfig) dependency.Manifolds {
 
 			NewFacade: singular.NewFacade,
 			NewWorker: singular.NewWorker,
-		}),
-
-		// The environ tracker could/should be used by several other
-		// workers (firewaller, provisioners, address-cleaner?).
-		environTrackerName: ifResponsible(environ.Manifold(environ.ManifoldConfig{
-			APICallerName:  apiCallerName,
-			NewEnvironFunc: config.NewEnvironFunc,
-		})),
-
-		// The model upgrader runs on all controller agents, and
-		// unlocks the gate when the model is up-to-date. The
-		// environ tracker will be supplied only to the leader,
-		// which is the agent that will run the upgrade steps;
-		// the other controller agents will wait for it to complete
-		// running those steps before allowing logins to the model.
-		modelUpgradeGateName: gate.Manifold(),
-		modelUpgradedFlagName: gate.FlagManifold(gate.FlagManifoldConfig{
-			GateName:  modelUpgradeGateName,
-			NewWorker: gate.NewFlagWorker,
-		}),
-		modelUpgraderName: modelupgrader.Manifold(modelupgrader.ManifoldConfig{
-			APICallerName: apiCallerName,
-			EnvironName:   environTrackerName,
-			GateName:      modelUpgradeGateName,
-			ControllerTag: controllerTag,
-			ModelTag:      modelTag,
-			NewFacade:     modelupgrader.NewFacade,
-			NewWorker:     modelupgrader.NewWorker,
 		}),
 
 		// The migration workers collaborate to run migrations;
@@ -248,6 +226,90 @@ func Manifolds(config ManifoldsConfig) dependency.Manifolds {
 			NewWorker: undertaker.NewWorker,
 		}))),
 
+		charmRevisionUpdaterName: ifNotMigrating(charmrevisionmanifold.Manifold(charmrevisionmanifold.ManifoldConfig{
+			APICallerName: apiCallerName,
+			ClockName:     clockName,
+			Period:        config.CharmRevisionUpdateInterval,
+
+			NewFacade: charmrevisionmanifold.NewAPIFacade,
+			NewWorker: charmrevision.NewWorker,
+		})),
+		remoteRelationsName: ifNotMigrating(remoterelations.Manifold(remoterelations.ManifoldConfig{
+			AgentName:                agentName,
+			APICallerName:            apiCallerName,
+			NewControllerConnection:  apicaller.NewExternalControllerConnection,
+			NewRemoteRelationsFacade: remoterelations.NewRemoteRelationsFacade,
+			NewWorker:                remoterelations.NewWorker,
+		})),
+		stateCleanerName: ifNotMigrating(cleaner.Manifold(cleaner.ManifoldConfig{
+			APICallerName: apiCallerName,
+			ClockName:     clockName,
+		})),
+		statusHistoryPrunerName: ifNotMigrating(pruner.Manifold(pruner.ManifoldConfig{
+			APICallerName: apiCallerName,
+			EnvironName:   environTrackerName,
+			ClockName:     clockName,
+			NewWorker:     statushistorypruner.New,
+			NewFacade:     statushistorypruner.NewFacade,
+			PruneInterval: config.StatusHistoryPrunerInterval,
+		})),
+		actionPrunerName: ifNotMigrating(pruner.Manifold(pruner.ManifoldConfig{
+			APICallerName: apiCallerName,
+			EnvironName:   environTrackerName,
+			ClockName:     clockName,
+			NewWorker:     actionpruner.New,
+			NewFacade:     actionpruner.NewFacade,
+			PruneInterval: config.ActionPrunerInterval,
+		})),
+		logForwarderName: ifNotDead(logforwarder.Manifold(logforwarder.ManifoldConfig{
+			APICallerName: apiCallerName,
+			Sinks: []logforwarder.LogSinkSpec{{
+				Name:   "juju-log-forward",
+				OpenFn: sinks.OpenSyslog,
+			}},
+		})),
+	}
+	return result
+}
+
+// IAASManifolds returns a set of interdependent dependency manifolds that will
+// run together to administer an IAAS model, as configured.
+func IAASManifolds(config ManifoldsConfig) dependency.Manifolds {
+	agentConfig := config.Agent.CurrentConfig()
+	controllerTag := agentConfig.Controller()
+	modelTag := agentConfig.Model()
+	manifolds := dependency.Manifolds{
+
+		// The environ tracker could/should be used by several other
+		// workers (firewaller, provisioners, address-cleaner?).
+		environTrackerName: ifResponsible(environ.Manifold(environ.ManifoldConfig{
+			APICallerName:  apiCallerName,
+			NewEnvironFunc: config.NewEnvironFunc,
+		})),
+
+		// Everything else should be wrapped in ifResponsible,
+		// ifNotAlive, ifNotDead, or ifNotMigrating (which also
+		// implies NotDead), to ensure that only a single
+		// controller is attempting to administer this model at
+		// any one time.
+		//
+		// NOTE: not perfectly reliable at this stage? i.e. a
+		// worker that ignores its stop signal for "too long"
+		// might continue to take admin actions after the window
+		// of responsibility closes. This *is* a pre-existing
+		// problem, but demands some thought/care: e.g. should
+		// we make sure the apiserver also closes any
+		// connections that lose responsibility..? can we make
+		// sure all possible environ operations are either time-
+		// bounded or interruptible? etc
+		//
+		// On the other hand, all workers *should* be written in
+		// the expectation of dealing with sucky infrastructure
+		// running things in parallel unexpectedly, just because
+		// the universe hates us and will engineer matters such
+		// that it happens sometimes, even when we try to avoid
+		// it.
+
 		// All the rest depend on ifNotMigrating.
 		computeProvisionerName: ifNotMigrating(provisioner.Manifold(provisioner.ManifoldConfig{
 			AgentName:          agentName,
@@ -285,57 +347,63 @@ func Manifolds(config ManifoldsConfig) dependency.Manifolds {
 			ClockName:     clockName,
 			Delay:         config.InstPollerAggregationDelay,
 		})),
-		charmRevisionUpdaterName: ifNotMigrating(charmrevisionmanifold.Manifold(charmrevisionmanifold.ManifoldConfig{
-			APICallerName: apiCallerName,
-			ClockName:     clockName,
-			Period:        config.CharmRevisionUpdateInterval,
-
-			NewFacade: charmrevisionmanifold.NewAPIFacade,
-			NewWorker: charmrevision.NewWorker,
-		})),
 		metricWorkerName: ifNotMigrating(metricworker.Manifold(metricworker.ManifoldConfig{
 			APICallerName: apiCallerName,
-		})),
-		stateCleanerName: ifNotMigrating(cleaner.Manifold(cleaner.ManifoldConfig{
-			APICallerName: apiCallerName,
-			ClockName:     clockName,
-		})),
-		statusHistoryPrunerName: ifNotMigrating(pruner.Manifold(pruner.ManifoldConfig{
-			APICallerName: apiCallerName,
-			EnvironName:   environTrackerName,
-			ClockName:     clockName,
-			NewWorker:     statushistorypruner.New,
-			NewFacade:     statushistorypruner.NewFacade,
-			PruneInterval: config.StatusHistoryPrunerInterval,
-		})),
-		actionPrunerName: ifNotMigrating(pruner.Manifold(pruner.ManifoldConfig{
-			APICallerName: apiCallerName,
-			EnvironName:   environTrackerName,
-			ClockName:     clockName,
-			NewWorker:     actionpruner.New,
-			NewFacade:     actionpruner.NewFacade,
-			PruneInterval: config.ActionPrunerInterval,
 		})),
 		machineUndertakerName: ifNotMigrating(machineundertaker.Manifold(machineundertaker.ManifoldConfig{
 			APICallerName: apiCallerName,
 			EnvironName:   environTrackerName,
 			NewWorker:     machineundertaker.NewWorker,
 		})),
-		logForwarderName: ifNotDead(logforwarder.Manifold(logforwarder.ManifoldConfig{
+		// The model upgrader runs on all controller agents, and
+		// unlocks the gate when the model is up-to-date. The
+		// environ tracker will be supplied only to the leader,
+		// which is the agent that will run the upgrade steps;
+		// the other controller agents will wait for it to complete
+		// running those steps before allowing logins to the model.
+		modelUpgradeGateName: gate.Manifold(),
+		modelUpgradedFlagName: gate.FlagManifold(gate.FlagManifoldConfig{
+			GateName:  modelUpgradeGateName,
+			NewWorker: gate.NewFlagWorker,
+		}),
+		modelUpgraderName: modelupgrader.Manifold(modelupgrader.ManifoldConfig{
 			APICallerName: apiCallerName,
-			Sinks: []logforwarder.LogSinkSpec{{
-				Name:   "juju-log-forward",
-				OpenFn: sinks.OpenSyslog,
-			}},
-		})),
+			EnvironName:   environTrackerName,
+			GateName:      modelUpgradeGateName,
+			ControllerTag: controllerTag,
+			ModelTag:      modelTag,
+			NewFacade:     modelupgrader.NewFacade,
+			NewWorker:     modelupgrader.NewWorker,
+		}),
 	}
-	result[remoteRelationsName] = ifNotMigrating(remoterelations.Manifold(remoterelations.ManifoldConfig{
-		AgentName:                agentName,
-		APICallerName:            apiCallerName,
-		NewControllerConnection:  apicaller.NewExternalControllerConnection,
-		NewRemoteRelationsFacade: remoterelations.NewRemoteRelationsFacade,
-		NewWorker:                remoterelations.NewWorker,
-	}))
+	result := commonManifolds(config)
+	for name, manifold := range manifolds {
+		result[name] = manifold
+	}
+	return result
+}
+
+// CAASManifolds returns a set of interdependent dependency manifolds that will
+// run together to administer a CAAS model, as configured.
+func CAASManifolds(config ManifoldsConfig) dependency.Manifolds {
+	manifolds := dependency.Manifolds{
+		caasBrokerTrackerName: ifResponsible(caasbroker.Manifold(caasbroker.ManifoldConfig{
+			APICallerName:          apiCallerName,
+			NewContainerBrokerFunc: config.NewContainerBrokerFunc,
+		})),
+
+		caasProvisionerName: ifNotMigrating(caasprovisioner.Manifold(
+			caasprovisioner.ManifoldConfig{
+				AgentName:     agentName,
+				APICallerName: apiCallerName,
+				NewWorker:     caasprovisioner.NewProvisionerWorker,
+			},
+		)),
+	}
+	result := commonManifolds(config)
+	for name, manifold := range manifolds {
+		result[name] = manifold
+	}
 	return result
 }
 
@@ -442,4 +510,7 @@ const (
 	machineUndertakerName    = "machine-undertaker"
 	remoteRelationsName      = "remote-relations"
 	logForwarderName         = "log-forwarder"
+
+	caasProvisionerName   = "caas-provisioner"
+	caasBrokerTrackerName = "caas-broker-tracker"
 )

--- a/cmd/jujud/agent/model/manifolds_test.go
+++ b/cmd/jujud/agent/model/manifolds_test.go
@@ -20,9 +20,9 @@ type ManifoldsSuite struct {
 
 var _ = gc.Suite(&ManifoldsSuite{})
 
-func (s *ManifoldsSuite) TestNames(c *gc.C) {
+func (s *ManifoldsSuite) TestIAASNames(c *gc.C) {
 	actual := set.NewStrings()
-	manifolds := model.Manifolds(model.ManifoldsConfig{
+	manifolds := model.IAASManifolds(model.ManifoldsConfig{
 		Agent: &mockAgent{},
 	})
 	for name := range manifolds {
@@ -60,6 +60,39 @@ func (s *ManifoldsSuite) TestNames(c *gc.C) {
 		"storage-provisioner",
 		"undertaker",
 		"unit-assigner",
+	})
+}
+
+func (s *ManifoldsSuite) TestCAASNames(c *gc.C) {
+	actual := set.NewStrings()
+	manifolds := model.CAASManifolds(model.ManifoldsConfig{
+		Agent: &mockAgent{},
+	})
+	for name := range manifolds {
+		actual.Add(name)
+	}
+	// NOTE: if this test failed, the cmd/jujud/agent tests will
+	// also fail. Search for 'ModelWorkers' to find affected vars.
+	c.Check(actual.SortedValues(), jc.DeepEquals, []string{
+		"action-pruner",
+		"agent",
+		"api-caller",
+		"api-config-watcher",
+		"caas-broker-tracker",
+		"caas-provisioner",
+		"charm-revision-updater",
+		"clock",
+		"is-responsible-flag",
+		"log-forwarder",
+		"migration-fortress",
+		"migration-inactive-flag",
+		"migration-master",
+		"not-alive-flag",
+		"not-dead-flag",
+		"remote-relations",
+		"state-cleaner",
+		"status-history-pruner",
+		"undertaker",
 	})
 }
 
@@ -78,7 +111,7 @@ func (s *ManifoldsSuite) TestFlagDependencies(c *gc.C) {
 		"model-upgraded-flag",
 		"model-upgrader",
 	)
-	manifolds := model.Manifolds(model.ManifoldsConfig{
+	manifolds := model.IAASManifolds(model.ManifoldsConfig{
 		Agent: &mockAgent{},
 	})
 	for name, manifold := range manifolds {
@@ -95,7 +128,7 @@ func (s *ManifoldsSuite) TestFlagDependencies(c *gc.C) {
 }
 
 func (s *ManifoldsSuite) TestStateCleanerIgnoresLifeFlags(c *gc.C) {
-	manifolds := model.Manifolds(model.ManifoldsConfig{
+	manifolds := model.IAASManifolds(model.ManifoldsConfig{
 		Agent: &mockAgent{},
 	})
 	manifold, found := manifolds["state-cleaner"]
@@ -108,7 +141,7 @@ func (s *ManifoldsSuite) TestStateCleanerIgnoresLifeFlags(c *gc.C) {
 
 func (s *ManifoldsSuite) TestClockWrapper(c *gc.C) {
 	expectClock := &fakeClock{}
-	manifolds := model.Manifolds(model.ManifoldsConfig{
+	manifolds := model.IAASManifolds(model.ManifoldsConfig{
 		Agent: &mockAgent{},
 		Clock: expectClock,
 	})
@@ -125,56 +158,3 @@ func (s *ManifoldsSuite) TestClockWrapper(c *gc.C) {
 }
 
 type fakeClock struct{ clock.Clock }
-
-type ManifoldsCrossModelSuite struct {
-	testing.BaseSuite
-}
-
-var _ = gc.Suite(&ManifoldsCrossModelSuite{})
-
-func (s *ManifoldsCrossModelSuite) SetUpTest(c *gc.C) {
-	s.BaseSuite.SetUpTest(c)
-}
-
-func (s *ManifoldsCrossModelSuite) TestNames(c *gc.C) {
-	actual := set.NewStrings()
-	manifolds := model.Manifolds(model.ManifoldsConfig{
-		Agent: &mockAgent{},
-	})
-	for name := range manifolds {
-		actual.Add(name)
-	}
-	// NOTE: if this test failed, the cmd/jujud/agent tests will
-	// also fail. Search for 'ModelWorkers' to find affected vars.
-	c.Check(actual.SortedValues(), jc.DeepEquals, []string{
-		"action-pruner",
-		"agent",
-		"api-caller",
-		"api-config-watcher",
-		"application-scaler",
-		"charm-revision-updater",
-		"clock",
-		"compute-provisioner",
-		"environ-tracker",
-		"firewaller",
-		"instance-poller",
-		"is-responsible-flag",
-		"log-forwarder",
-		"machine-undertaker",
-		"metric-worker",
-		"migration-fortress",
-		"migration-inactive-flag",
-		"migration-master",
-		"model-upgrade-gate",
-		"model-upgraded-flag",
-		"model-upgrader",
-		"not-alive-flag",
-		"not-dead-flag",
-		"remote-relations",
-		"state-cleaner",
-		"status-history-pruner",
-		"storage-provisioner",
-		"undertaker",
-		"unit-assigner",
-	})
-}

--- a/cmd/modelcmd/base.go
+++ b/cmd/modelcmd/base.go
@@ -523,16 +523,16 @@ func (g bootstrapConfigGetter) getBootstrapConfigParams(controllerName string) (
 		return nil, nil, errors.Trace(err)
 	}
 	return bootstrapConfig, &environs.PrepareConfigParams{
-		environs.CloudSpec{
-			bootstrapConfig.CloudType,
-			bootstrapConfig.Cloud,
-			bootstrapConfig.CloudRegion,
-			bootstrapConfig.CloudEndpoint,
-			bootstrapConfig.CloudIdentityEndpoint,
-			bootstrapConfig.CloudStorageEndpoint,
-			credential,
+		Cloud: environs.CloudSpec{
+			Type:             bootstrapConfig.CloudType,
+			Name:             bootstrapConfig.Cloud,
+			Region:           bootstrapConfig.CloudRegion,
+			Endpoint:         bootstrapConfig.CloudEndpoint,
+			IdentityEndpoint: bootstrapConfig.CloudIdentityEndpoint,
+			StorageEndpoint:  bootstrapConfig.CloudStorageEndpoint,
+			Credential:       credential,
 		},
-		cfg,
+		Config: cfg,
 	}, nil
 }
 

--- a/environs/cloudspec.go
+++ b/environs/cloudspec.go
@@ -36,6 +36,12 @@ type CloudSpec struct {
 	// with the cloud, or nil if the cloud does not require any
 	// credentials.
 	Credential *jujucloud.Credential
+
+	// CACertificates contains an optional list of Certificate
+	// Authority certificates to be used to validate certificates
+	// of cloud infrastructure components
+	// The contents are Base64 encoded x.509 certs.
+	CACertificates []string
 }
 
 // Validate validates that the CloudSpec is well-formed. It does
@@ -60,6 +66,7 @@ func MakeCloudSpec(cloud jujucloud.Cloud, cloudRegionName string, credential *ju
 		Endpoint:         cloud.Endpoint,
 		IdentityEndpoint: cloud.IdentityEndpoint,
 		StorageEndpoint:  cloud.StorageEndpoint,
+		CACertificates:   cloud.CACertificates,
 		Credential:       credential,
 	}
 	if cloudRegionName != "" {

--- a/state/iaasmodel.go
+++ b/state/iaasmodel.go
@@ -25,6 +25,11 @@ func (m *Model) IAASModel() (*IAASModel, error) {
 	}, nil
 }
 
+// CloudRegion returns the name of the cloud region to which the model is deployed.
+func (m *IAASModel) CloudRegion() string {
+	return m.doc.CloudRegion
+}
+
 // IAASModel returns an Infrastructure-As-A-Service (IAAS) model.
 //
 // TODO(caas): This is a convenience helper only and will go away

--- a/state/iaasmodel.go
+++ b/state/iaasmodel.go
@@ -25,11 +25,6 @@ func (m *Model) IAASModel() (*IAASModel, error) {
 	}, nil
 }
 
-// CloudRegion returns the name of the cloud region to which the model is deployed.
-func (m *IAASModel) CloudRegion() string {
-	return m.doc.CloudRegion
-}
-
 // IAASModel returns an Infrastructure-As-A-Service (IAAS) model.
 //
 // TODO(caas): This is a convenience helper only and will go away

--- a/worker/caasbroker/broker.go
+++ b/worker/caasbroker/broker.go
@@ -1,0 +1,108 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package caasbroker
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/loggo"
+
+	"github.com/juju/juju/caas"
+	"github.com/juju/juju/environs"
+	"github.com/juju/juju/worker/catacomb"
+)
+
+var logger = loggo.GetLogger("juju.worker.caas")
+
+// ConfigObserver exposes a model configuration and a watch constructor
+// that allows clients to be informed of changes to the configuration.
+type ConfigObserver interface {
+	CloudSpec() (environs.CloudSpec, error)
+}
+
+// Config describes the dependencies of a Tracker.
+//
+// It's arguable that it should be called TrackerConfig, because of the heavy
+// use of model config in this package.
+type Config struct {
+	Observer               ConfigObserver
+	NewContainerBrokerFunc caas.NewContainerBrokerFunc
+}
+
+// Validate returns an error if the config cannot be used to start a Tracker.
+func (config Config) Validate() error {
+	if config.Observer == nil {
+		return errors.NotValidf("nil Observer")
+	}
+	if config.NewContainerBrokerFunc == nil {
+		return errors.NotValidf("nil NewContainerBrokerFunc")
+	}
+	return nil
+}
+
+// Tracker loads a caas broker, makes it available to clients, and updates
+// the broker in response to config changes until it is killed.
+type Tracker struct {
+	config   Config
+	catacomb catacomb.Catacomb
+	broker   caas.Broker
+}
+
+// NewTracker returns a new Tracker, or an error if anything goes wrong.
+// If a tracker is returned, its Broker() method is immediately usable.
+//
+// The caller is responsible for Kill()ing the returned Tracker and Wait()ing
+// for any errors it might return.
+func NewTracker(config Config) (*Tracker, error) {
+	if err := config.Validate(); err != nil {
+		return nil, errors.Trace(err)
+	}
+	cloudSpec, err := config.Observer.CloudSpec()
+	if err != nil {
+		return nil, errors.Annotate(err, "cannot get cloud information")
+	}
+	broker, err := config.NewContainerBrokerFunc(cloudSpec)
+	if err != nil {
+		return nil, errors.Annotate(err, "cannot create caas broker")
+	}
+
+	t := &Tracker{
+		config: config,
+		broker: broker,
+	}
+	err = catacomb.Invoke(catacomb.Plan{
+		Site: &t.catacomb,
+		Work: t.loop,
+	})
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return t, nil
+}
+
+// Broker returns the encapsulated Broker. It will continue to be updated in
+// the background for as long as the Tracker continues to run.
+func (t *Tracker) Broker() caas.Broker {
+	return t.broker
+}
+
+func (t *Tracker) loop() error {
+	// TODO(caas) - watch for config and credential changes
+	for {
+		logger.Debugf("waiting for config and credential notifications")
+		select {
+		case <-t.catacomb.Dying():
+			return t.catacomb.ErrDying()
+		}
+	}
+}
+
+// Kill is part of the worker.Worker interface.
+func (t *Tracker) Kill() {
+	t.catacomb.Kill(nil)
+}
+
+// Wait is part of the worker.Worker interface.
+func (t *Tracker) Wait() error {
+	return t.catacomb.Wait()
+}

--- a/worker/caasbroker/broker_test.go
+++ b/worker/caasbroker/broker_test.go
@@ -1,0 +1,102 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package caasbroker_test
+
+import (
+	"github.com/juju/errors"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/caas"
+	"github.com/juju/juju/environs"
+	coretesting "github.com/juju/juju/testing"
+	"github.com/juju/juju/worker/caasbroker"
+	"github.com/juju/juju/worker/workertest"
+)
+
+type TrackerSuite struct {
+	coretesting.BaseSuite
+}
+
+var _ = gc.Suite(&TrackerSuite{})
+
+func (s *TrackerSuite) TestValidateObserver(c *gc.C) {
+	config := caasbroker.Config{}
+	s.testValidate(c, config, func(err error) {
+		c.Check(err, jc.Satisfies, errors.IsNotValid)
+		c.Check(err, gc.ErrorMatches, "nil Observer not valid")
+	})
+}
+
+func (s *TrackerSuite) TestValidateNewBrokerFunc(c *gc.C) {
+	config := caasbroker.Config{
+		Observer: &runContext{},
+	}
+	s.testValidate(c, config, func(err error) {
+		c.Check(err, jc.Satisfies, errors.IsNotValid)
+		c.Check(err, gc.ErrorMatches, "nil NewContainerBrokerFunc not valid")
+	})
+}
+
+func (s *TrackerSuite) testValidate(c *gc.C, config caasbroker.Config, check func(err error)) {
+	err := config.Validate()
+	check(err)
+
+	tracker, err := caasbroker.NewTracker(config)
+	c.Check(tracker, gc.IsNil)
+	check(err)
+}
+
+func (s *TrackerSuite) TestCloudSpecFails(c *gc.C) {
+	fix := &fixture{
+		observerErrs: []error{
+			errors.New("no yuo"),
+		},
+	}
+	fix.Run(c, func(context *runContext) {
+		tracker, err := caasbroker.NewTracker(caasbroker.Config{
+			Observer:               context,
+			NewContainerBrokerFunc: newMockBroker,
+		})
+		c.Check(err, gc.ErrorMatches, "cannot get cloud information: no yuo")
+		c.Check(tracker, gc.IsNil)
+		context.CheckCallNames(c, "CloudSpec")
+	})
+}
+
+func (s *TrackerSuite) TestSuccess(c *gc.C) {
+	fix := &fixture{}
+	fix.Run(c, func(context *runContext) {
+		tracker, err := caasbroker.NewTracker(caasbroker.Config{
+			Observer:               context,
+			NewContainerBrokerFunc: newMockBroker,
+		})
+		c.Assert(err, jc.ErrorIsNil)
+		defer workertest.CleanKill(c, tracker)
+
+		gotBroker := tracker.Broker()
+		c.Assert(gotBroker, gc.NotNil)
+	})
+}
+
+func (s *TrackerSuite) TestCloudSpec(c *gc.C) {
+	cloudSpec := environs.CloudSpec{
+		Name:   "foo",
+		Type:   "bar",
+		Region: "baz",
+	}
+	fix := &fixture{cloud: cloudSpec}
+	fix.Run(c, func(context *runContext) {
+		tracker, err := caasbroker.NewTracker(caasbroker.Config{
+			Observer: context,
+			NewContainerBrokerFunc: func(spec environs.CloudSpec) (caas.Broker, error) {
+				c.Assert(spec, jc.DeepEquals, cloudSpec)
+				return nil, errors.NotValidf("cloud spec")
+			},
+		})
+		c.Check(err, gc.ErrorMatches, `cannot create caas broker: cloud spec not valid`)
+		c.Check(tracker, gc.IsNil)
+		context.CheckCallNames(c, "CloudSpec")
+	})
+}

--- a/worker/caasbroker/fixture_test.go
+++ b/worker/caasbroker/fixture_test.go
@@ -1,0 +1,62 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package caasbroker_test
+
+import (
+	"sync"
+
+	"github.com/juju/testing"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/caas"
+	"github.com/juju/juju/environs"
+)
+
+type fixture struct {
+	watcherErr   error
+	observerErrs []error
+	cloud        environs.CloudSpec
+}
+
+func (fix *fixture) Run(c *gc.C, test func(*runContext)) {
+	context := &runContext{
+		cloud: fix.cloud,
+	}
+	context.stub.SetErrors(fix.observerErrs...)
+	test(context)
+}
+
+type runContext struct {
+	mu     sync.Mutex
+	stub   testing.Stub
+	cloud  environs.CloudSpec
+	config map[string]interface{}
+}
+
+func (context *runContext) CloudSpec() (environs.CloudSpec, error) {
+	context.mu.Lock()
+	defer context.mu.Unlock()
+	context.stub.AddCall("CloudSpec")
+	if err := context.stub.NextErr(); err != nil {
+		return environs.CloudSpec{}, err
+	}
+	return context.cloud, nil
+}
+
+func (context *runContext) CheckCallNames(c *gc.C, names ...string) {
+	context.mu.Lock()
+	defer context.mu.Unlock()
+	context.stub.CheckCallNames(c, names...)
+}
+
+type mockBroker struct {
+	caas.Broker
+	testing.Stub
+	spec environs.CloudSpec
+	mu   sync.Mutex
+}
+
+func newMockBroker(spec environs.CloudSpec) (caas.Broker, error) {
+	return &mockBroker{spec: spec}, nil
+}

--- a/worker/caasbroker/manifold.go
+++ b/worker/caasbroker/manifold.go
@@ -1,0 +1,65 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package caasbroker
+
+import (
+	"github.com/juju/errors"
+	"gopkg.in/juju/worker.v1"
+
+	"github.com/juju/juju/api/agent"
+	"github.com/juju/juju/api/base"
+	"github.com/juju/juju/caas"
+	"github.com/juju/juju/worker/dependency"
+)
+
+// ManifoldConfig describes the resources used by a Tracker.
+type ManifoldConfig struct {
+	APICallerName          string
+	NewContainerBrokerFunc caas.NewContainerBrokerFunc
+}
+
+// Manifold returns a Manifold that encapsulates a *Tracker and exposes it as
+// an caas,Broker resource.
+func Manifold(config ManifoldConfig) dependency.Manifold {
+	manifold := dependency.Manifold{
+		Inputs: []string{
+			config.APICallerName,
+		},
+		Output: manifoldOutput,
+		Start: func(context dependency.Context) (worker.Worker, error) {
+			var apiCaller base.APICaller
+			if err := context.Get(config.APICallerName, &apiCaller); err != nil {
+				return nil, errors.Trace(err)
+			}
+			// TODO(caas) introduce a caasbroker API
+			apiSt, err := agent.NewState(apiCaller)
+			if err != nil {
+				return nil, errors.Trace(err)
+			}
+			w, err := NewTracker(Config{
+				Observer:               apiSt,
+				NewContainerBrokerFunc: config.NewContainerBrokerFunc,
+			})
+			if err != nil {
+				return nil, errors.Trace(err)
+			}
+			return w, nil
+		},
+	}
+	return manifold
+}
+
+// manifoldOutput extracts an caas.Broker resource from a *Tracker.
+func manifoldOutput(in worker.Worker, out interface{}) error {
+	inTracker, ok := in.(*Tracker)
+	if !ok {
+		return errors.Errorf("expected *broker.Tracker, got %T", in)
+	}
+	outBroker, ok := out.(*caas.Broker)
+	if !ok {
+		return errors.Errorf("expected *caas.Broker, got %T", out)
+	}
+	*outBroker = inTracker.Broker()
+	return nil
+}

--- a/worker/caasbroker/package_test.go
+++ b/worker/caasbroker/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package caasbroker_test
+
+import (
+	stdtesting "testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func TestPackage(t *stdtesting.T) {
+	gc.TestingT(t)
+}

--- a/worker/caasprovisioner/manifold.go
+++ b/worker/caasprovisioner/manifold.go
@@ -1,0 +1,89 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package caasprovisioner
+
+import (
+	"github.com/juju/errors"
+	"gopkg.in/juju/names.v2"
+	"gopkg.in/juju/worker.v1"
+
+	"github.com/juju/juju/agent"
+	"github.com/juju/juju/api/base"
+	"github.com/juju/juju/caas"
+	"github.com/juju/juju/worker/dependency"
+)
+
+// ManifoldConfig defines a CAAS environment provisioner's dependencies.
+type ManifoldConfig struct {
+	AgentName     string
+	APICallerName string
+	BrokerName    string
+
+	NewWorker func(CAASProvisionerFacade, caas.Broker, names.ModelTag, agent.Config) (worker.Worker, error)
+}
+
+// Validate is called by start to check for bad configuration.
+func (config ManifoldConfig) Validate() error {
+	if config.AgentName == "" {
+		return errors.NotValidf("empty AgentName")
+	}
+	if config.APICallerName == "" {
+		return errors.NotValidf("empty APICallerName")
+	}
+	if config.BrokerName == "" {
+		return errors.NotValidf("empty BrokerName")
+	}
+	if config.NewWorker == nil {
+		return errors.NotValidf("nil NewWorker")
+	}
+	return nil
+}
+
+func (config ManifoldConfig) start(context dependency.Context) (worker.Worker, error) {
+	if err := config.Validate(); err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	var agent agent.Agent
+	if err := context.Get(config.AgentName, &agent); err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	var apiCaller base.APICaller
+	if err := context.Get(config.APICallerName, &apiCaller); err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	var broker caas.Broker
+	if err := context.Get(config.BrokerName, &broker); err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	modelTag, ok := apiCaller.ModelTag()
+	if !ok {
+		return nil, errors.New("API connection is controller-only (should never happen)")
+	}
+
+	// TODO(caas) - construct new facade from apiCaller.
+	api := CAASProvisionerFacade(nil)
+
+	agentConfig := agent.CurrentConfig()
+	w, err := config.NewWorker(api, broker, modelTag, agentConfig)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return w, nil
+}
+
+// Manifold creates a manifold that runs a CAAS provisioner. See the
+// ManifoldConfig type for discussion about how this can/should evolve.
+func Manifold(config ManifoldConfig) dependency.Manifold {
+	return dependency.Manifold{
+		Inputs: []string{
+			config.AgentName,
+			config.APICallerName,
+		},
+		Start: config.start,
+	}
+}

--- a/worker/caasprovisioner/manifold_test.go
+++ b/worker/caasprovisioner/manifold_test.go
@@ -1,0 +1,70 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package caasprovisioner_test
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/juju/caas"
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/names.v2"
+	"gopkg.in/juju/worker.v1"
+
+	"github.com/juju/juju/agent"
+	"github.com/juju/juju/worker/caasprovisioner"
+)
+
+type ManifoldConfigSuite struct {
+	testing.IsolationSuite
+	config caasprovisioner.ManifoldConfig
+}
+
+var _ = gc.Suite(&ManifoldConfigSuite{})
+
+func (s *ManifoldConfigSuite) SetUpTest(c *gc.C) {
+	s.IsolationSuite.SetUpTest(c)
+	s.config = s.validConfig()
+}
+
+func (s *ManifoldConfigSuite) validConfig() caasprovisioner.ManifoldConfig {
+	return caasprovisioner.ManifoldConfig{
+		AgentName:     "agent",
+		APICallerName: "api-caller",
+		BrokerName:    "broker",
+		NewWorker: func(caasprovisioner.CAASProvisionerFacade, caas.Broker, names.ModelTag, agent.Config) (worker.Worker, error) {
+			return nil, nil
+		},
+	}
+}
+
+func (s *ManifoldConfigSuite) TestValid(c *gc.C) {
+	c.Check(s.config.Validate(), jc.ErrorIsNil)
+}
+
+func (s *ManifoldConfigSuite) TestMissingAgentName(c *gc.C) {
+	s.config.AgentName = ""
+	s.checkNotValid(c, "empty AgentName not valid")
+}
+
+func (s *ManifoldConfigSuite) TestMissingAPICallerName(c *gc.C) {
+	s.config.APICallerName = ""
+	s.checkNotValid(c, "empty APICallerName not valid")
+}
+
+func (s *ManifoldConfigSuite) TestMissingBrokerName(c *gc.C) {
+	s.config.BrokerName = ""
+	s.checkNotValid(c, "empty BrokerName not valid")
+}
+
+func (s *ManifoldConfigSuite) TestMissingNewWorker(c *gc.C) {
+	s.config.NewWorker = nil
+	s.checkNotValid(c, "nil NewWorker not valid")
+}
+
+func (s *ManifoldConfigSuite) checkNotValid(c *gc.C, expect string) {
+	err := s.config.Validate()
+	c.Check(err, gc.ErrorMatches, expect)
+	c.Check(err, jc.Satisfies, errors.IsNotValid)
+}

--- a/worker/caasprovisioner/mock_test.go
+++ b/worker/caasprovisioner/mock_test.go
@@ -1,0 +1,137 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package caasprovisioner_test
+
+import (
+	"sync"
+
+	"github.com/juju/testing"
+	"gopkg.in/juju/names.v2"
+	"gopkg.in/tomb.v1"
+
+	"github.com/juju/juju/agent"
+	"github.com/juju/juju/caas"
+	coretesting "github.com/juju/juju/testing"
+	"github.com/juju/juju/watcher"
+	"github.com/juju/juju/worker/caasprovisioner"
+)
+
+type mockProvisionerFacade struct {
+	mu   sync.Mutex
+	stub *testing.Stub
+	caasprovisioner.CAASProvisionerFacade
+	applicationsWatcher *mockStringsWatcher
+}
+
+func newMockProvisionerFacade(stub *testing.Stub) *mockProvisionerFacade {
+	return &mockProvisionerFacade{
+		stub:                stub,
+		applicationsWatcher: newMockStringsWatcher(),
+	}
+}
+
+func (m *mockProvisionerFacade) WatchApplications() (watcher.StringsWatcher, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.stub.MethodCall(m, "WatchApplications")
+	if err := m.stub.NextErr(); err != nil {
+		return nil, err
+	}
+	return m.applicationsWatcher, nil
+}
+
+type mockAgentConfig struct {
+	agent.Config
+}
+
+func (m *mockAgentConfig) Controller() names.ControllerTag {
+	return coretesting.ControllerTag
+}
+
+func (m *mockAgentConfig) DataDir() string {
+	return "/var/lib/juju"
+}
+
+func (m *mockAgentConfig) LogDir() string {
+	return "/var/log/juju"
+}
+
+func (m *mockAgentConfig) OldPassword() string {
+	return "old password"
+}
+
+func (m *mockAgentConfig) CACert() string {
+	return coretesting.CACert
+}
+
+func (m *mockAgentConfig) APIAddresses() ([]string, error) {
+	return []string{"10.0.0.1:17070"}, nil
+}
+
+type mockBroker struct {
+	appName   string
+	agentPath string
+	config    *caas.OperatorConfig
+}
+
+func (m *mockBroker) EnsureOperator(appName, agentPath string, newConfig caas.NewOperatorConfigFunc) error {
+	m.appName = appName
+	m.agentPath = agentPath
+	config, err := newConfig(appName)
+	if err != nil {
+		return err
+	}
+	m.config = config
+	return nil
+}
+
+type mockWatcher struct {
+	testing.Stub
+	tomb.Tomb
+	mu         sync.Mutex
+	terminated bool
+}
+
+func (w *mockWatcher) doneWhenDying() {
+	<-w.Tomb.Dying()
+	w.Tomb.Done()
+}
+
+func (w *mockWatcher) killed() bool {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.terminated
+}
+
+func (w *mockWatcher) Kill() {
+	w.MethodCall(w, "Kill")
+	w.Tomb.Kill(nil)
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.terminated = true
+}
+
+func (w *mockWatcher) Stop() error {
+	w.MethodCall(w, "Stop")
+	if err := w.NextErr(); err != nil {
+		return err
+	}
+	w.Tomb.Kill(nil)
+	return w.Tomb.Wait()
+}
+
+type mockStringsWatcher struct {
+	mockWatcher
+	changes chan []string
+}
+
+func newMockStringsWatcher() *mockStringsWatcher {
+	w := &mockStringsWatcher{changes: make(chan []string, 5)}
+	go w.doneWhenDying()
+	return w
+}
+
+func (w *mockStringsWatcher) Changes() watcher.StringsChannel {
+	return w.changes
+}

--- a/worker/caasprovisioner/package_test.go
+++ b/worker/caasprovisioner/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package caasprovisioner_test
+
+import (
+	stdtesting "testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func TestPackage(t *stdtesting.T) {
+	gc.TestingT(t)
+}

--- a/worker/caasprovisioner/worker.go
+++ b/worker/caasprovisioner/worker.go
@@ -1,0 +1,154 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package caasprovisioner
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/juju/caas"
+	"github.com/juju/juju/watcher"
+	"github.com/juju/loggo"
+	"gopkg.in/juju/names.v2"
+	"gopkg.in/juju/worker.v1"
+
+	"github.com/juju/juju/agent"
+	"github.com/juju/juju/version"
+	"github.com/juju/juju/worker/catacomb"
+)
+
+var logger = loggo.GetLogger("juju.workers.caasprovisioner")
+
+// CAASProvisionerFacade exposes CAAS provisioning functionality to a worker.
+type CAASProvisionerFacade interface {
+	WatchApplications() (watcher.StringsWatcher, error)
+}
+
+// NewProvisionerWorker starts and returns a new CAAS provisioner worker.
+func NewProvisionerWorker(
+	facade CAASProvisionerFacade,
+	broker caas.Broker,
+	modelTag names.ModelTag,
+	agentConfig agent.Config,
+) (worker.Worker, error) {
+	p := &provisioner{
+		provisionerFacade: facade,
+		broker:            broker,
+		modelTag:          modelTag,
+		agentConfig:       agentConfig,
+	}
+	err := catacomb.Invoke(catacomb.Plan{
+		Site: &p.catacomb,
+		Work: p.loop,
+	})
+	return p, err
+}
+
+type provisioner struct {
+	catacomb          catacomb.Catacomb
+	provisionerFacade CAASProvisionerFacade
+	broker            caas.Broker
+
+	modelTag    names.ModelTag
+	agentConfig agent.Config
+}
+
+// Kill is part of the worker.Worker interface.
+func (p *provisioner) Kill() {
+	p.catacomb.Kill(nil)
+}
+
+// Wait is part of the worker.Worker interface.
+func (p *provisioner) Wait() error {
+	return p.catacomb.Wait()
+}
+
+// TODO(caas) - remove
+type fakeFacade struct {
+	watcher.CoreWatcher
+}
+
+func (f *fakeFacade) WatchApplications() (watcher.StringsWatcher, error) {
+	return f, nil
+}
+
+func (f *fakeFacade) Changes() watcher.StringsChannel {
+	return make(watcher.StringsChannel)
+}
+
+func (p *provisioner) loop() error {
+	// TODO(caas) - remove
+	if p.provisionerFacade == nil {
+		logger.Criticalf("Started CAAS Provisioner worker with fake facade and broker %v", p.broker)
+		p.provisionerFacade = &fakeFacade{}
+	}
+
+	newConfig := func(appName string) (*caas.OperatorConfig, error) {
+		return p.newOperatorConfig(appName)
+	}
+
+	// TODO(caas) -  this loop should also keep an eye on kubernetes and ensure
+	// that the operator stays up, redeploying it if the pod goes
+	// away. For some runtimes we *could* rely on the the runtime's
+	// features to do this.
+
+	w, err := p.provisionerFacade.WatchApplications()
+	if err != nil {
+		return errors.Trace(err)
+	}
+	if err := p.catacomb.Add(w); err != nil {
+		return errors.Trace(err)
+	}
+
+	for {
+		select {
+		case <-p.catacomb.Dying():
+			return p.catacomb.ErrDying()
+		case apps, ok := <-w.Changes():
+			if !ok {
+				return errors.New("watcher closed channel")
+			}
+			for _, app := range apps {
+				logger.Debugf("Received change notification for app: %s", app)
+				if err := p.broker.EnsureOperator(app, p.agentConfig.DataDir(), newConfig); err != nil {
+					return errors.Annotatef(err, "failed to start operator for %q", app)
+				}
+			}
+		}
+	}
+}
+
+func (p *provisioner) newOperatorConfig(appName string) (*caas.OperatorConfig, error) {
+	appTag := names.NewApplicationTag(appName)
+
+	// TODO(caas) - restart operator when api addresses change
+	apiAddrs, err := p.agentConfig.APIAddresses()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	conf, err := agent.NewAgentConfig(
+		agent.AgentConfigParams{
+			Paths: agent.Paths{
+				DataDir: p.agentConfig.DataDir(),
+				LogDir:  p.agentConfig.LogDir(),
+			},
+			// This isn't actually used but needs to be supplied.
+			UpgradedToVersion: version.Current,
+			Tag:               appTag,
+			Password:          p.agentConfig.OldPassword(),
+			Controller:        p.agentConfig.Controller(),
+			Model:             p.modelTag,
+			APIAddresses:      apiAddrs,
+			CACert:            p.agentConfig.CACert(),
+		},
+	)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	confBytes, err := conf.Render()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return &caas.OperatorConfig{AgentConf: confBytes}, nil
+}

--- a/worker/caasprovisioner/worker_test.go
+++ b/worker/caasprovisioner/worker_test.go
@@ -1,0 +1,107 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package caasprovisioner_test
+
+import (
+	"io/ioutil"
+	"path/filepath"
+	"reflect"
+
+	jujutesting "github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/names.v2"
+	"gopkg.in/juju/worker.v1"
+
+	"github.com/juju/juju/agent"
+	coretesting "github.com/juju/juju/testing"
+	"github.com/juju/juju/worker/caasprovisioner"
+	"github.com/juju/juju/worker/workertest"
+)
+
+var _ = gc.Suite(&CAASProvisionerSuite{})
+
+type CAASProvisionerSuite struct {
+	coretesting.BaseSuite
+	stub *jujutesting.Stub
+
+	provisionerFacade *mockProvisionerFacade
+	caasClient        *mockBroker
+	agentConfig       agent.Config
+	modelTag          names.ModelTag
+}
+
+func (s *CAASProvisionerSuite) SetUpTest(c *gc.C) {
+	s.BaseSuite.SetUpTest(c)
+
+	s.stub = new(jujutesting.Stub)
+	s.provisionerFacade = newMockProvisionerFacade(s.stub)
+	s.caasClient = &mockBroker{}
+	s.agentConfig = &mockAgentConfig{}
+	s.modelTag = coretesting.ModelTag
+}
+
+func (s *CAASProvisionerSuite) waitForWorkerStubCalls(c *gc.C, expected []jujutesting.StubCall) {
+	waitForStubCalls(c, s.stub, expected)
+}
+
+func waitForStubCalls(c *gc.C, stub *jujutesting.Stub, expected []jujutesting.StubCall) {
+	var calls []jujutesting.StubCall
+	for a := coretesting.LongAttempt.Start(); a.Next(); {
+		calls = stub.Calls()
+		if reflect.DeepEqual(calls, expected) {
+			return
+		}
+	}
+	c.Fatalf("failed to see expected calls. saw: %v", calls)
+}
+
+func (s *CAASProvisionerSuite) assertWorker(c *gc.C) worker.Worker {
+	w, err := caasprovisioner.NewProvisionerWorker(s.provisionerFacade, s.caasClient, s.modelTag, s.agentConfig)
+	c.Assert(err, jc.ErrorIsNil)
+	expected := []jujutesting.StubCall{
+		{"WatchApplications", nil},
+	}
+	s.waitForWorkerStubCalls(c, expected)
+	s.stub.ResetCalls()
+	return w
+}
+
+func (s *CAASProvisionerSuite) TestWorkerStarts(c *gc.C) {
+	w := s.assertWorker(c)
+	workertest.CleanKill(c, w)
+}
+
+func (s *CAASProvisionerSuite) TestOperatorCreated(c *gc.C) {
+	w := s.assertWorker(c)
+	defer workertest.CleanKill(c, w)
+
+	s.provisionerFacade.applicationsWatcher.changes <- []string{"myApp"}
+
+	waitForResult := func() bool {
+		if s.caasClient.appName != "myApp" {
+			return false
+		}
+		if s.caasClient.agentPath != "/var/lib/juju" {
+			return false
+		}
+		return true
+	}
+	gotResult := false
+	for a := coretesting.LongAttempt.Start(); a.Next(); {
+		if gotResult = waitForResult(); gotResult {
+			return
+		}
+	}
+	c.Assert(gotResult, jc.IsTrue)
+	agentFile := filepath.Join(c.MkDir(), "agent.config")
+	err := ioutil.WriteFile(agentFile, []byte(s.caasClient.config.AgentConf), 0644)
+	c.Assert(err, jc.ErrorIsNil)
+	cfg, err := agent.ReadConfig(agentFile)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(cfg.CACert(), gc.Equals, coretesting.CACert)
+	addr, err := cfg.APIAddresses()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(addr, jc.DeepEquals, []string{"10.0.0.1:17070"})
+}


### PR DESCRIPTION
## Description of change

Introduce a CAAS provisioner worker and infrastructure needed to start it.
There are now separate IAAS and CAAS manifold configs to start only the relevant workers for a given model type.
Under the top level juju/juju/caas package, create a kubernetes package and move kubernetes specific stuff there. Add a kubernetes provider/broker which is created by a tracker worker and passed to the caas provisioner.

A followup PR will add the real facades and finish wiring everything up.

## QA steps

Smoke test an IAAS deployment.

