### PR TITLE
storageprovisioner: ignore incoherent volumes

### DIFF
--- a/worker/storageprovisioner/mock_test.go
+++ b/worker/storageprovisioner/mock_test.go
@@ -22,6 +22,7 @@ import (
 
 const attachedVolumeId = "1"
 const needsInstanceVolumeId = "23"
+const noAttachmentVolumeId = "66"
 
 var dyingVolumeAttachmentId = params.MachineStorageId{
 	MachineTag:    "machine-0",
@@ -182,12 +183,14 @@ func (v *mockVolumeAccessor) VolumeParams(volumes []names.VolumeTag) ([]params.V
 				"very": "fancy",
 			},
 		}
-		volumeParams.Attachment = &params.VolumeAttachmentParams{
-			VolumeTag:  tag.String(),
-			MachineTag: "machine-1",
-			InstanceId: string(v.provisionedMachines["machine-1"]),
-			Provider:   "dummy",
-			ReadOnly:   tag.String() == "volume-1",
+		if tag.Id() != noAttachmentVolumeId {
+			volumeParams.Attachment = &params.VolumeAttachmentParams{
+				VolumeTag:  tag.String(),
+				MachineTag: "machine-1",
+				InstanceId: string(v.provisionedMachines["machine-1"]),
+				Provider:   "dummy",
+				ReadOnly:   tag.String() == "volume-1",
+			}
 		}
 		result = append(result, params.VolumeParamsResult{Result: volumeParams})
 	}

--- a/worker/storageprovisioner/storageprovisioner_test.go
+++ b/worker/storageprovisioner/storageprovisioner_test.go
@@ -19,6 +19,7 @@ import (
 	coretesting "github.com/juju/juju/testing"
 	"github.com/juju/juju/watcher"
 	"github.com/juju/juju/worker/storageprovisioner"
+	"github.com/juju/juju/worker/workertest"
 )
 
 type storageProvisionerSuite struct {
@@ -755,6 +756,28 @@ func (s *storageProvisionerSuite) TestVolumeNeedsInstance(c *gc.C) {
 	args.machines.instanceIds[names.NewMachineTag("1")] = "inst-id"
 	args.machines.watcher.changes <- struct{}{}
 	waitChannel(c, volumeInfoSet, "waiting for volume info to be set")
+}
+
+// TestVolumeIncoherent tests that we do not panic when observing
+// a pending volume that has no attachments. We send a volume
+// update for a volume that is alive and unprovisioned, but has
+// no machine attachment. Such volumes are ignored by the storage
+// provisioner.
+//
+// See: https://bugs.launchpad.net/juju/+bug/1732616
+func (s *storageProvisionerSuite) TestVolumeIncoherent(c *gc.C) {
+	volumeAccessor := newMockVolumeAccessor()
+	args := &workerArgs{volumes: volumeAccessor, registry: s.registry}
+	worker := newStorageProvisioner(c, args)
+	defer workertest.CleanKill(c, worker)
+
+	// Send 3 times, because the channel has a buffer size of 1.
+	// The third send guarantees we've sent at least the 2nd one
+	// through, which means at least the 1st has been processed
+	// (and ignored).
+	for i := 0; i < 3; i++ {
+		volumeAccessor.volumesWatcher.changes <- []string{noAttachmentVolumeId}
+	}
 }
 
 func (s *storageProvisionerSuite) TestVolumeNonDynamic(c *gc.C) {

--- a/worker/storageprovisioner/volume_events.go
+++ b/worker/storageprovisioner/volume_events.go
@@ -120,6 +120,16 @@ func updateVolume(ctx *context, info storage.Volume) {
 // ID, updatePendingVolume will request that the machine be watched so its
 // instance ID can be learned.
 func updatePendingVolume(ctx *context, params storage.VolumeParams) {
+	if params.Attachment == nil {
+		// NOTE(axw) this would only happen if the model is
+		// in an incoherent state; we should never have an
+		// alive, unprovisioned, and unattached volume.
+		logger.Warningf(
+			"%s is in an incoherent state, ignoring",
+			names.ReadableString(params.Tag),
+		)
+		return
+	}
 	if params.Attachment.InstanceId == "" {
 		watchMachine(ctx, params.Attachment.Machine)
 		ctx.incompleteVolumeParams[params.Tag] = params


### PR DESCRIPTION
## Description of change

In Juju, volumes cannot be provisioned without
an attachment to a machine. This is because
volumes are typically required to exist in the
same availability zone as the machine; so we
create the volume in the same AZ as the machine
to which it is intitially attached.

Because of this, the storage provisioner and
storage providers assume that an unprovisioned,
Alive, volume will have an attachment. It has
been observed in the wild that this does not
always hold true.

This change prevents the storage provisioner
from panicking upon seeing such volumes, but
does nothing to prevent the incoherent state
from occurring in the first place. It is not
clear how this can happen yet; it is possibly
an artifact of upgrading from an older version.

## QA steps

(does not mimic a realistic scenario, as we have no reproduction steps; --disks is not an advertised feature)
1. juju bootstrap openstack
2. juju add-machine --disks cinder,1G && juju remove-machine 0
3. juju debug-log -m controller
(should not be any panics)

## Documentation changes

None.

## Bug reference

Partially fixes https://bugs.launchpad.net/juju/+bug/1732616