### PR TITLE
If we are reporting an error object, report the right one.

### DIFF
--- a/cmd/juju/model/destroy.go
+++ b/cmd/juju/model/destroy.go
@@ -340,7 +340,7 @@ func newTimedModelStatus(ctx *cmd.Context, api DestroyModelAPI, tag names.ModelT
 		if status[0].Error != nil {
 			// This most likely occurred because a model was
 			// destroyed half-way through the call.
-			ctx.Infof("Could not get the model status from the API: %v.", err)
+			ctx.Infof("Could not get the model status from the API: %v.", status[0].Error)
 			return nil
 		}
 		return &modelData{


### PR DESCRIPTION
## Description of change

We just checked that 'err' is nil, and then check that status[0].Error is not nil, and then we report the former instead of the latter.

## QA steps

Failures during model destruction should report the error that we get, instead of 'nil' as reported in the original bug.

## Documentation changes

None.

## Bug reference

[lp:1732779](https://bugs.launchpad.net/juju/+bug/1732779)