### PR TITLE
upgrade-juju: Reject a version downgrade when using --build-agent

### DIFF
--- a/cmd/juju/commands/upgradejuju.go
+++ b/cmd/juju/commands/upgradejuju.go
@@ -132,7 +132,7 @@ func (c *upgradeJujuCommand) Init(args []string) error {
 
 var (
 	errUpToDate            = stderrors.New("no upgrades available")
-	downgradeErrMsg        = "cannot change version from %s to %s"
+	downgradeErrMsg        = "cannot change version from %s to lower version %s"
 	minMajorUpgradeVersion = map[int]version.Number{
 		2: version.MustParse("1.25.4"),
 	}
@@ -276,7 +276,7 @@ func (c *upgradeJujuCommand) Run(ctx *cmd.Context) (err error) {
 		// environment version (can't guarantee API compatibility).
 		return errors.Errorf("cannot upgrade a %s model with a %s client",
 			agentVersion, jujuversion.Current)
-	case c.Version != version.Zero && c.Version.Major < agentVersion.Major:
+	case c.Version != version.Zero && compareNoBuild(agentVersion, c.Version) == 1:
 		// The specified version would downgrade the environment.
 		// Don't upgrade and return an error.
 		return errors.Errorf(downgradeErrMsg, agentVersion, c.Version)
@@ -651,4 +651,10 @@ func makeUploadVersion(vers version.Number, existing coretools.List) version.Num
 		}
 	}
 	return vers
+}
+
+func compareNoBuild(a, b version.Number) int {
+	a.Build = 0
+	b.Build = 0
+	return a.Compare(b)
 }

--- a/cmd/juju/commands/upgradejuju.go
+++ b/cmd/juju/commands/upgradejuju.go
@@ -366,7 +366,7 @@ func (c *upgradeJujuCommand) Run(ctx *cmd.Context) (err error) {
 		if c.BuildAgent {
 			fmt.Fprint(ctx.Stderr, "upgrade to this version by running\n    juju upgrade-juju --build-agent\n")
 		} else {
-			fmt.Fprintf(ctx.Stderr, "upgrade to this version by running\n    juju upgrade-juju --agent-version=\"%s\"\n", context.chosen)
+			fmt.Fprintf(ctx.Stderr, "upgrade to this version by running\n    juju upgrade-juju\n")
 		}
 	} else {
 		if c.ResetPrevious {

--- a/cmd/juju/commands/upgradejuju_test.go
+++ b/cmd/juju/commands/upgradejuju_test.go
@@ -610,7 +610,7 @@ func (s *UpgradeJujuSuite) TestUpgradeDryRun(c *gc.C) {
 			currentVersion: "2.0.0-quantal-amd64",
 			agentVersion:   "2.0.0",
 			expectedCmdOutput: `upgrade to this version by running
-    juju upgrade-juju --agent-version="2.1.3"
+    juju upgrade-juju
 `,
 		},
 		{
@@ -620,7 +620,7 @@ func (s *UpgradeJujuSuite) TestUpgradeDryRun(c *gc.C) {
 			currentVersion: "2.0.0-quantal-amd64",
 			agentVersion:   "2.0.0",
 			expectedCmdOutput: `upgrade to this version by running
-    juju upgrade-juju --agent-version="2.1.3"
+    juju upgrade-juju
 `,
 		},
 	}

--- a/cmd/juju/commands/upgradejuju_test.go
+++ b/cmd/juju/commands/upgradejuju_test.go
@@ -100,17 +100,18 @@ var upgradeJujuTests = []struct {
 	args:           []string{"--agent-version", "5.2.0"},
 	expectErr:      `unknown version "5.2.0"`,
 }, {
-	about:          "major version downgrade to incompatible version",
+	about:          "version downgrade",
+	tools:          []string{"4.2-beta2-quantal-amd64"},
 	currentVersion: "4.2.0-quantal-amd64",
 	agentVersion:   "4.2.0",
-	args:           []string{"--agent-version", "3.2.0"},
-	expectErr:      "cannot change version from 4.2.0 to 3.2.0",
+	args:           []string{"--agent-version", "4.2-beta2"},
+	expectErr:      "cannot change version from 4.2.0 to lower version 4.2-beta2",
 }, {
 	about:          "--build-agent with inappropriate version 1",
 	currentVersion: "4.2.0-quantal-amd64",
 	agentVersion:   "4.2.0",
 	args:           []string{"--build-agent", "--agent-version", "3.1.0"},
-	expectErr:      "cannot change version from 4.2.0 to 3.1.0",
+	expectErr:      "cannot change version from 4.2.0 to lower version 3.1.0",
 }, {
 	about:          "--build-agent with inappropriate version 2",
 	currentVersion: "3.2.7-quantal-amd64",
@@ -241,7 +242,7 @@ var upgradeJujuTests = []struct {
 	currentVersion: "3.2.0-quantal-amd64",
 	agentVersion:   "3.3-dev0",
 	args:           []string{"--agent-version", "3.2.0"},
-	expectErr:      "cannot change version from 3.3-dev0 to 3.2.0",
+	expectErr:      "cannot change version from 3.3-dev0 to lower version 3.2.0",
 }, {
 	about:          "nothing available",
 	currentVersion: "2.0.0-quantal-amd64",


### PR DESCRIPTION
## Description of change

If you bootstrapped a controller with one version of Juju and then ran `juju upgrade-juju --build-agent` on the controller model with a juju binary with a lower version (e.g. from changing branches), it would successfully upload the binary and set the agent-version. Thenthe upgrade would stall when the worker actually tried to do the upgrade, with the error: `cannot sanely upgrade from 2.3-beta4.1 to 2.3-beta3.1`. The controller would then be stuck in the upgrade-in-progress state.

Prevent this by checking that the version is an upgrade in state before setting the new AgentVersion, and also check for it in the `upgrade-juju` command for quicker feedback.

## QA steps

Bootstrap a controller with 2.3-rc2, then change the version number to be 2.3-rc1, by editing `version/version.go` and rebuilding juju.
Running `juju upgrade-juju -m controller --build-agent` should refuse the downgrade without building and uploading the binary.

## Bug reference

Fixes https://bugs.launchpad.net/juju/+bug/1732156