### PR TITLE
environs: introduce AvailabilityZoneError

### DIFF
--- a/environs/broker.go
+++ b/environs/broker.go
@@ -123,11 +123,18 @@ type StartInstanceResult struct {
 // stop that from being possible right now.
 type InstanceBroker interface {
 	// StartInstance asks for a new instance to be created, associated with
-	// the provided config in machineConfig. The given config describes the juju
-	// state for the new instance to connect to. The config MachineNonce, which must be
-	// unique within an environment, is used by juju to protect against the
-	// consequences of multiple instances being started with the same machine
-	// id.
+	// the provided config in machineConfig. The given config describes the
+	// juju state for the new instance to connect to. The config
+	// MachineNonce, which must be unique within an environment, is used by
+	// juju to protect against the consequences of multiple instances being
+	// started with the same machine id.
+	//
+	// Callers may attempt to distribute instances across a set of
+	// availability zones. If one zone fails, then the caller is expected
+	// to attempt in another zone. If the provider can determine that
+	// the StartInstanceParams can never be fulfilled in any zone, then
+	// it may return an error satisfying the IsAvailabilityZoneIndependent
+	// function in this package.
 	StartInstance(args StartInstanceParams) (*StartInstanceResult, error)
 
 	// StopInstances shuts down the instances with the specified IDs.

--- a/environs/errors.go
+++ b/environs/errors.go
@@ -8,8 +8,36 @@ import (
 )
 
 var (
-	ErrNotBootstrapped        = errors.New("model is not bootstrapped")
-	ErrNoInstances            = errors.NotFoundf("instances")
-	ErrPartialInstances       = errors.New("only some instances were found")
-	ErrAvailabilityZoneFailed = errors.New("failed to start instance in provided availability zone")
+	ErrNotBootstrapped  = errors.New("model is not bootstrapped")
+	ErrNoInstances      = errors.NotFoundf("instances")
+	ErrPartialInstances = errors.New("only some instances were found")
 )
+
+// AvailabilityZoneError provides an interface for compute providers
+// to indicate whether or not an error is specific to, or independent
+// of, any particular availability zone.
+type AvailabilityZoneError interface {
+	error
+
+	// AvailabilityZoneIndependent reports whether or not the
+	// error is related to a specific availability zone.
+	AvailabilityZoneIndependent() bool
+}
+
+// IsAvailabilityZoneIndependent reports whether or not the given error,
+// or its cause, is independent of any particular availability zone.
+// Juju uses this to decide whether or not to attempt the failed operation
+// in another availability zone; zone-independent failures will not be
+// reattempted.
+//
+// If the error implements AvailabilityZoneError, then the result of
+// calling its AvailabilityZoneIndependent method will be returned;
+// otherwise this function returns false. That is, errors are assumed
+// to be specific to an availability zone by default, so that they can
+// be retried in another availability zone.
+func IsAvailabilityZoneIndependent(err error) bool {
+	if err, ok := errors.Cause(err).(AvailabilityZoneError); ok {
+		return err.AvailabilityZoneIndependent()
+	}
+	return false
+}

--- a/provider/common/bootstrap_test.go
+++ b/provider/common/bootstrap_test.go
@@ -212,7 +212,7 @@ func (s *BootstrapSuite) TestStartInstanceDerivedZone(c *gc.C) {
 		error,
 	) {
 		c.Assert(args.AvailabilityZone, gc.Equals, "derived-zone")
-		return nil, nil, nil, environs.ErrAvailabilityZoneFailed
+		return nil, nil, nil, errors.New("bloop")
 	}
 
 	ctx := envtesting.BootstrapContext(c)
@@ -221,7 +221,7 @@ func (s *BootstrapSuite) TestStartInstanceDerivedZone(c *gc.C) {
 		AvailableTools:   fakeAvailableTools(),
 	})
 	c.Assert(err, gc.ErrorMatches,
-		`cannot start bootstrap instance: failed to start instance in availability zone "derived-zone"`,
+		`cannot start bootstrap instance in availability zone "derived-zone": bloop`,
 	)
 }
 
@@ -251,7 +251,7 @@ func (s *BootstrapSuite) TestStartInstanceAttemptAllZones(c *gc.C) {
 		error,
 	) {
 		callZones = append(callZones, args.AvailabilityZone)
-		return nil, nil, nil, environs.ErrAvailabilityZoneFailed
+		return nil, nil, nil, errors.New("bloop")
 	}
 
 	ctx := envtesting.BootstrapContext(c)
@@ -260,8 +260,49 @@ func (s *BootstrapSuite) TestStartInstanceAttemptAllZones(c *gc.C) {
 		AvailableTools:   fakeAvailableTools(),
 	})
 	c.Assert(err, gc.ErrorMatches,
-		`cannot start bootstrap instance: failed to start instance in any availability zone`,
+		`cannot start bootstrap instance in any availability zone \(z0, z2\)`,
 	)
+	c.Assert(callZones, jc.SameContents, []string{"z0", "z2"})
+}
+
+func (s *BootstrapSuite) TestStartInstanceStopOnZoneIndependentError(c *gc.C) {
+	s.PatchValue(&jujuversion.Current, coretesting.FakeVersionNumber)
+	env := &mockZonedEnviron{
+		mockEnviron: mockEnviron{
+			storage: newStorage(s, c),
+			config:  configGetter(c),
+		},
+		deriveAvailabilityZones: func(environs.StartInstanceParams) ([]string, error) {
+			return nil, nil
+		},
+		availabilityZones: func() ([]common.AvailabilityZone, error) {
+			z0 := &mockAvailabilityZone{"z0", true}
+			z1 := &mockAvailabilityZone{"z1", true}
+			return []common.AvailabilityZone{z0, z1}, nil
+		},
+	}
+
+	var callZones []string
+	env.startInstance = func(args environs.StartInstanceParams) (
+		instance.Instance,
+		*instance.HardwareCharacteristics,
+		[]network.InterfaceInfo,
+		error,
+	) {
+		callZones = append(callZones, args.AvailabilityZone)
+		return nil, nil, nil, &common.StartInstanceError{
+			Err:             errors.New("bloop"),
+			ZoneIndependent: true,
+		}
+	}
+
+	ctx := envtesting.BootstrapContext(c)
+	_, err := common.Bootstrap(ctx, env, environs.BootstrapParams{
+		ControllerConfig: coretesting.FakeControllerConfig(),
+		AvailableTools:   fakeAvailableTools(),
+	})
+	c.Assert(err, gc.ErrorMatches, `cannot start bootstrap instance: bloop`)
+	c.Assert(callZones, jc.SameContents, []string{"z0"})
 }
 
 func (s *BootstrapSuite) TestStartInstanceNoUsableZones(c *gc.C) {

--- a/provider/common/bootstrap_test.go
+++ b/provider/common/bootstrap_test.go
@@ -290,10 +290,7 @@ func (s *BootstrapSuite) TestStartInstanceStopOnZoneIndependentError(c *gc.C) {
 		error,
 	) {
 		callZones = append(callZones, args.AvailabilityZone)
-		return nil, nil, nil, &common.StartInstanceError{
-			Err:             errors.New("bloop"),
-			ZoneIndependent: true,
-		}
+		return nil, nil, nil, common.ZoneIndependentError(errors.New("bloop"))
 	}
 
 	ctx := envtesting.BootstrapContext(c)

--- a/provider/common/errors.go
+++ b/provider/common/errors.go
@@ -1,0 +1,26 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package common
+
+// StartInstanceError is an error type that may be returned from providers'
+// StartInstance methods to include more details of the error.
+type StartInstanceError struct {
+	// Err is the underlying error that caused StartInstance to fail.
+	Err error
+
+	// ZoneIndependent, if true, indicates that the error is due to some
+	// condition that holds regardless of the availability zone specified.
+	ZoneIndependent bool
+}
+
+// Error is part of the error interface.
+func (err *StartInstanceError) Error() string {
+	return err.Err.Error()
+}
+
+// AvailabilityZoneIndependent is part of the environs.AvailabilityZoneError
+// interface.
+func (err *StartInstanceError) AvailabilityZoneIndependent() bool {
+	return err.ZoneIndependent
+}

--- a/provider/common/errors.go
+++ b/provider/common/errors.go
@@ -3,24 +3,25 @@
 
 package common
 
-// StartInstanceError is an error type that may be returned from providers'
-// StartInstance methods to include more details of the error.
-type StartInstanceError struct {
-	// Err is the underlying error that caused StartInstance to fail.
-	Err error
+import "github.com/juju/errors"
 
-	// ZoneIndependent, if true, indicates that the error is due to some
-	// condition that holds regardless of the availability zone specified.
-	ZoneIndependent bool
+// ZoneIndependentError wraps the given error such that it
+// satisfies environs.IsAvailabilityZoneIndependent.
+func ZoneIndependentError(err error) error {
+	if err == nil {
+		return nil
+	}
+	wrapped := errors.Wrap(err, zoneIndependentError{err})
+	wrapped.(*errors.Err).SetLocation(1)
+	return wrapped
 }
 
-// Error is part of the error interface.
-func (err *StartInstanceError) Error() string {
-	return err.Err.Error()
+type zoneIndependentError struct {
+	error
 }
 
-// AvailabilityZoneIndependent is part of the environs.AvailabilityZoneError
-// interface.
-func (err *StartInstanceError) AvailabilityZoneIndependent() bool {
-	return err.ZoneIndependent
+// AvailabilityZoneIndependent is part of the
+// environs.AvailabilityZoneError interface.
+func (zoneIndependentError) AvailabilityZoneIndependent() bool {
+	return true
 }

--- a/provider/common/errors_test.go
+++ b/provider/common/errors_test.go
@@ -1,0 +1,34 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package common_test
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/environs"
+	"github.com/juju/juju/provider/common"
+)
+
+type ErrorsSuite struct {
+	testing.IsolationSuite
+}
+
+var _ = gc.Suite(&ErrorsSuite{})
+
+func (*ErrorsSuite) TestWrapZoneIndependentError(c *gc.C) {
+	err1 := errors.New("foo")
+	err2 := errors.Annotate(err1, "bar")
+	wrapped := common.ZoneIndependentError(err2)
+	c.Assert(wrapped, jc.Satisfies, environs.IsAvailabilityZoneIndependent)
+	c.Assert(wrapped, gc.ErrorMatches, "bar: foo")
+
+	stack := errors.ErrorStack(wrapped)
+	c.Assert(stack, gc.Matches, `
+github.com/juju/juju/provider/common/errors_test.go:.*: foo
+github.com/juju/juju/provider/common/errors_test.go:.*: bar
+github.com/juju/juju/provider/common/errors_test.go:.*: bar: foo`[1:])
+}

--- a/provider/gce/environ.go
+++ b/provider/gce/environ.go
@@ -27,7 +27,7 @@ type gceConnection interface {
 	// and returns it.
 	Instance(id, zone string) (google.Instance, error)
 	Instances(prefix string, statuses ...string) ([]google.Instance, error)
-	AddInstance(spec google.InstanceSpec, zone string) (*google.Instance, error)
+	AddInstance(spec google.InstanceSpec) (*google.Instance, error)
 	RemoveInstances(prefix string, ids ...string) error
 	UpdateMetadata(key, value string, ids ...string) error
 

--- a/provider/gce/environ_broker.go
+++ b/provider/gce/environ_broker.go
@@ -34,32 +34,20 @@ func (env *environ) StartInstance(args environs.StartInstanceParams) (*environs.
 
 	spec, err := buildInstanceSpec(env, args)
 	if err != nil {
-		return nil, &common.StartInstanceError{
-			Err:             errors.Trace(err),
-			ZoneIndependent: true,
-		}
+		return nil, common.ZoneIndependentError(err)
 	}
 
 	if err := env.finishInstanceConfig(args, spec); err != nil {
-		return nil, &common.StartInstanceError{
-			Err:             errors.Trace(err),
-			ZoneIndependent: true,
-		}
+		return nil, common.ZoneIndependentError(err)
 	}
 
 	// Validate availability zone.
 	volumeAttachmentsZone, err := volumeAttachmentsZone(args.VolumeAttachments)
 	if err != nil {
-		return nil, &common.StartInstanceError{
-			Err:             errors.Trace(err),
-			ZoneIndependent: true,
-		}
+		return nil, common.ZoneIndependentError(err)
 	}
 	if err := validateAvailabilityZoneConsistency(args.AvailabilityZone, volumeAttachmentsZone); err != nil {
-		return nil, &common.StartInstanceError{
-			Err:             errors.Trace(err),
-			ZoneIndependent: false,
-		}
+		return nil, errors.Trace(err)
 	}
 
 	raw, err := newRawInstance(env, args, spec)
@@ -149,26 +137,17 @@ func (env *environ) newRawInstance(args environs.StartInstanceParams, spec *inst
 
 	hostname, err := env.namespace.Hostname(args.InstanceConfig.MachineId)
 	if err != nil {
-		return nil, &common.StartInstanceError{
-			Err:             errors.Trace(err),
-			ZoneIndependent: true,
-		}
+		return nil, common.ZoneIndependentError(err)
 	}
 
 	os, err := series.GetOSFromSeries(args.InstanceConfig.Series)
 	if err != nil {
-		return nil, &common.StartInstanceError{
-			Err:             errors.Trace(err),
-			ZoneIndependent: true,
-		}
+		return nil, common.ZoneIndependentError(err)
 	}
 
 	metadata, err := getMetadata(args, os)
 	if err != nil {
-		return nil, &common.StartInstanceError{
-			Err:             errors.Trace(err),
-			ZoneIndependent: true,
-		}
+		return nil, common.ZoneIndependentError(err)
 	}
 	tags := []string{
 		env.globalFirewallName(),
@@ -182,10 +161,7 @@ func (env *environ) newRawInstance(args environs.StartInstanceParams, spec *inst
 		env.Config().ImageStream() == "daily",
 	)
 	if err != nil {
-		return nil, &common.StartInstanceError{
-			Err:             errors.Trace(err),
-			ZoneIndependent: true,
-		}
+		return nil, common.ZoneIndependentError(err)
 	}
 
 	// TODO(ericsnow) Use the env ID for the network name (instead of default)?
@@ -206,10 +182,7 @@ func (env *environ) newRawInstance(args environs.StartInstanceParams, spec *inst
 		// We currently treat all AddInstance failures
 		// as being zone-specific, so we'll retry in
 		// another zone.
-		return nil, &common.StartInstanceError{
-			Err:             errors.Trace(err),
-			ZoneIndependent: false,
-		}
+		return nil, errors.Trace(err)
 	}
 	return inst, nil
 }

--- a/provider/gce/environ_broker.go
+++ b/provider/gce/environ_broker.go
@@ -34,20 +34,32 @@ func (env *environ) StartInstance(args environs.StartInstanceParams) (*environs.
 
 	spec, err := buildInstanceSpec(env, args)
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, &common.StartInstanceError{
+			Err:             errors.Trace(err),
+			ZoneIndependent: true,
+		}
 	}
 
 	if err := env.finishInstanceConfig(args, spec); err != nil {
-		return nil, errors.Trace(err)
+		return nil, &common.StartInstanceError{
+			Err:             errors.Trace(err),
+			ZoneIndependent: true,
+		}
 	}
 
 	// Validate availability zone.
 	volumeAttachmentsZone, err := volumeAttachmentsZone(args.VolumeAttachments)
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, &common.StartInstanceError{
+			Err:             errors.Trace(err),
+			ZoneIndependent: true,
+		}
 	}
 	if err := validateAvailabilityZoneConsistency(args.AvailabilityZone, volumeAttachmentsZone); err != nil {
-		return nil, errors.Wrap(errors.Trace(err), environs.ErrAvailabilityZoneFailed)
+		return nil, &common.StartInstanceError{
+			Err:             errors.Trace(err),
+			ZoneIndependent: false,
+		}
 	}
 
 	raw, err := newRawInstance(env, args, spec)
@@ -133,20 +145,30 @@ func (env *environ) findInstanceSpec(
 // newRawInstance is where the new physical instance is actually
 // provisioned, relative to the provided args and spec. Info for that
 // low-level instance is returned.
-func (env *environ) newRawInstance(args environs.StartInstanceParams, spec *instances.InstanceSpec) (*google.Instance, error) {
+func (env *environ) newRawInstance(args environs.StartInstanceParams, spec *instances.InstanceSpec) (_ *google.Instance, err error) {
+
 	hostname, err := env.namespace.Hostname(args.InstanceConfig.MachineId)
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, &common.StartInstanceError{
+			Err:             errors.Trace(err),
+			ZoneIndependent: true,
+		}
 	}
 
 	os, err := series.GetOSFromSeries(args.InstanceConfig.Series)
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, &common.StartInstanceError{
+			Err:             errors.Trace(err),
+			ZoneIndependent: true,
+		}
 	}
 
 	metadata, err := getMetadata(args, os)
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, &common.StartInstanceError{
+			Err:             errors.Trace(err),
+			ZoneIndependent: true,
+		}
 	}
 	tags := []string{
 		env.globalFirewallName(),
@@ -154,28 +176,42 @@ func (env *environ) newRawInstance(args environs.StartInstanceParams, spec *inst
 	}
 
 	disks, err := getDisks(
-		spec, args.Constraints, args.InstanceConfig.Series, env.Config().UUID(), env.Config().ImageStream() == "daily",
+		spec, args.Constraints,
+		args.InstanceConfig.Series,
+		env.Config().UUID(),
+		env.Config().ImageStream() == "daily",
 	)
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, &common.StartInstanceError{
+			Err:             errors.Trace(err),
+			ZoneIndependent: true,
+		}
 	}
 
 	// TODO(ericsnow) Use the env ID for the network name (instead of default)?
 	// TODO(ericsnow) Make the network name configurable?
 	// TODO(ericsnow) Support multiple networks?
 	// TODO(ericsnow) Use a different net interface name? Configurable?
-	instSpec := google.InstanceSpec{
+	inst, err := env.gce.AddInstance(google.InstanceSpec{
 		ID:                hostname,
 		Type:              spec.InstanceType.Name,
 		Disks:             disks,
 		NetworkInterfaces: []string{"ExternalNAT"},
 		Metadata:          metadata,
 		Tags:              tags,
+		AvailabilityZone:  args.AvailabilityZone,
 		// Network is omitted (left empty).
+	})
+	if err != nil {
+		// We currently treat all AddInstance failures
+		// as being zone-specific, so we'll retry in
+		// another zone.
+		return nil, &common.StartInstanceError{
+			Err:             errors.Trace(err),
+			ZoneIndependent: false,
+		}
 	}
-
-	inst, err := env.gce.AddInstance(instSpec, args.AvailabilityZone)
-	return inst, errors.Trace(err)
+	return inst, nil
 }
 
 // getMetadata builds the raw "user-defined" metadata for the new

--- a/provider/gce/google/conn_instance_test.go
+++ b/provider/gce/google/conn_instance_test.go
@@ -45,7 +45,7 @@ func (s *connSuite) TestConnectionSimpleAddInstanceAPI(c *gc.C) {
 func (s *instanceSuite) TestConnectionAddInstance(c *gc.C) {
 	s.FakeConn.Instance = &s.RawInstanceFull
 
-	inst, err := s.Conn.AddInstance(s.InstanceSpec, "a-zone")
+	inst, err := s.Conn.AddInstance(s.InstanceSpec)
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Check(inst.ID, gc.Equals, "spam")
@@ -60,7 +60,7 @@ func (s *instanceSuite) TestConnectionAddInstance(c *gc.C) {
 func (s *instanceSuite) TestConnectionAddInstanceAPI(c *gc.C) {
 	s.FakeConn.Instance = &s.RawInstanceFull
 
-	_, err := s.Conn.AddInstance(s.InstanceSpec, "a-zone")
+	_, err := s.Conn.AddInstance(s.InstanceSpec)
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Check(s.FakeConn.Calls, gc.HasLen, 2)

--- a/provider/gce/google/instance.go
+++ b/provider/gce/google/instance.go
@@ -12,37 +12,46 @@ import (
 	"github.com/juju/juju/network"
 )
 
-// InstanceSpec holds all the information needed to create a new GCE
-// instance within some zone.
+// InstanceSpec holds all the information needed to create a new GCE instance.
 // TODO(ericsnow) Validate the invariants?
 type InstanceSpec struct {
 	// ID is the "name" of the instance.
 	ID string
+
 	// Type is the name of the GCE instance type. The value is resolved
 	// relative to an availability zone when the API request is sent.
 	// The type must match one of the GCE-recognized types.
 	Type string
+
 	// Disks holds the information needed to request each of the disks
 	// that should be attached to a new instance. This must include a
 	// single root disk.
 	Disks []DiskSpec
+
 	// Network identifies the information for the network that a new
 	// instance should use. If the network does not exist then it will
 	// be added when the instance is. At least the network's name must
 	// be set.
 	Network NetworkSpec
+
 	// NetworkInterfaces is the names of the network interfaces to
 	// associate with the instance. They will be connected to the the
 	// network identified by the instance spec. At least one name must
 	// be provided.
 	NetworkInterfaces []string
+
 	// Metadata is the GCE instance "user-specified" metadata that will
 	// be initialized on the new instance.
 	Metadata map[string]string
+
 	// Tags are the labels to associate with the instance. This is
 	// useful when making bulk calls or in relation to some API methods
 	// (e.g. related to firewalls access rules).
 	Tags []string
+
+	// AvailabilityZone holds the name of the availability zone in which
+	// to create the instance.
+	AvailabilityZone string
 }
 
 func (is InstanceSpec) raw() *compute.Instance {

--- a/provider/gce/google/testing_test.go
+++ b/provider/gce/google/testing_test.go
@@ -127,6 +127,7 @@ func (s *BaseSuite) SetUpTest(c *gc.C) {
 		NetworkInterfaces: []string{"somenetif"},
 		Metadata:          s.Metadata,
 		Tags:              []string{"spam"},
+		AvailabilityZone:  "a-zone",
 	}
 	s.Instance = Instance{
 		InstanceSummary: InstanceSummary{

--- a/provider/gce/testing_test.go
+++ b/provider/gce/testing_test.go
@@ -538,11 +538,10 @@ func (fc *fakeConn) Instances(prefix string, statuses ...string) ([]google.Insta
 	return fc.Insts, fc.err()
 }
 
-func (fc *fakeConn) AddInstance(spec google.InstanceSpec, zone string) (*google.Instance, error) {
+func (fc *fakeConn) AddInstance(spec google.InstanceSpec) (*google.Instance, error) {
 	fc.Calls = append(fc.Calls, fakeConnCall{
 		FuncName:     "AddInstance",
 		InstanceSpec: spec,
-		ZoneName:     zone,
 	})
 	return fc.Inst, fc.err()
 }

--- a/provider/maas/constraints_test.go
+++ b/provider/maas/constraints_test.go
@@ -12,7 +12,6 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/constraints"
-	"github.com/juju/juju/environs"
 )
 
 func (*environSuite) TestConvertConstraints(c *gc.C) {
@@ -212,7 +211,7 @@ func (suite *environSuite) TestSelectNodeValidZone(c *gc.C) {
 	}
 
 	node, err := env.selectNode(snArgs)
-	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(err, gc.IsNil)
 	c.Assert(node, gc.NotNil)
 }
 
@@ -225,7 +224,9 @@ func (suite *environSuite) TestSelectNodeInvalidZone(c *gc.C) {
 	}
 
 	_, err := env.selectNode(snArgs)
-	c.Assert(errors.Cause(err), gc.Equals, environs.ErrAvailabilityZoneFailed)
+	c.Assert(err, gc.NotNil)
+	c.Assert(err.noMatch, jc.IsTrue)
+	c.Assert(err, gc.ErrorMatches, ".*409.*")
 }
 
 func (suite *environSuite) TestAcquireNode(c *gc.C) {

--- a/provider/maas/maas2_environ_whitebox_test.go
+++ b/provider/maas/maas2_environ_whitebox_test.go
@@ -298,7 +298,7 @@ func (suite *maas2EnvironSuite) TestStartInstanceError(c *gc.C) {
 	})
 	env := suite.makeEnviron(c, nil)
 	_, err := env.StartInstance(environs.StartInstanceParams{})
-	c.Assert(err, gc.ErrorMatches, ".* cannot run instance: Charles Babbage")
+	c.Assert(err, gc.ErrorMatches, "failed to acquire node: Charles Babbage")
 }
 
 func (suite *maas2EnvironSuite) TestStartInstance(c *gc.C) {
@@ -2267,7 +2267,7 @@ func (suite *maas2EnvironSuite) TestBootstrapFailsIfNoNodes(c *gc.C) {
 	})
 	// Since there are no nodes, the attempt to allocate one returns a
 	// 409: Conflict.
-	c.Check(err, gc.ErrorMatches, "cannot start bootstrap instance: failed to start instance in any availability zone")
+	c.Check(err, gc.ErrorMatches, "cannot start bootstrap instance in any availability zone \\(mossack, fonseca\\)")
 }
 
 func (suite *maas2EnvironSuite) TestGetToolsMetadataSources(c *gc.C) {

--- a/provider/openstack/local_test.go
+++ b/provider/openstack/local_test.go
@@ -637,6 +637,7 @@ func (s *localServerSuite) TestStartInstanceGetServerFail(c *gc.C) {
 		"caused by: "+
 		"request \\(.*/servers\\) returned unexpected status: "+
 		"500; error info: .*GetServer failed on purpose")
+	c.Assert(err, jc.Satisfies, environs.IsAvailabilityZoneIndependent)
 }
 
 func (s *localServerSuite) TestStartInstanceWaitForActiveDetails(c *gc.C) {
@@ -1987,12 +1988,12 @@ func (t *localServerSuite) TestStartInstanceAvailZone(c *gc.C) {
 
 func (t *localServerSuite) TestStartInstanceAvailZoneUnavailable(c *gc.C) {
 	_, err := t.testStartInstanceAvailZone(c, "test-unavailable")
-	c.Assert(errors.Cause(err), gc.Equals, environs.ErrAvailabilityZoneFailed)
+	c.Assert(err, gc.Not(jc.Satisfies), environs.IsAvailabilityZoneIndependent)
 }
 
 func (t *localServerSuite) TestStartInstanceAvailZoneUnknown(c *gc.C) {
 	_, err := t.testStartInstanceAvailZone(c, "test-unknown")
-	c.Assert(errors.Cause(err), gc.Equals, environs.ErrAvailabilityZoneFailed)
+	c.Assert(err, gc.Not(jc.Satisfies), environs.IsAvailabilityZoneIndependent)
 }
 
 func (t *localServerSuite) testStartInstanceAvailZone(c *gc.C, zone string) (instance.Instance, error) {

--- a/provider/openstack/provider.go
+++ b/provider/openstack/provider.go
@@ -936,9 +936,18 @@ func (*Environ) MaintainInstance(args environs.StartInstanceParams) error {
 }
 
 // StartInstance is specified in the InstanceBroker interface.
-func (e *Environ) StartInstance(args environs.StartInstanceParams) (*environs.StartInstanceResult, error) {
-	if args.ControllerUUID == "" {
-		return nil, errors.New("missing controller UUID")
+func (e *Environ) StartInstance(args environs.StartInstanceParams) (_ *environs.StartInstanceResult, err error) {
+	zoneIndependentError := func(err error) error {
+		if err == nil {
+			return nil
+		}
+		return &common.StartInstanceError{
+			Err:             err,
+			ZoneIndependent: true,
+		}
+	}
+	zoneSpecificError := func(err error) error {
+		return err
 	}
 
 	if args.AvailabilityZone != "" {
@@ -946,14 +955,13 @@ func (e *Environ) StartInstance(args environs.StartInstanceParams) (*environs.St
 		// supports zones; validate the zone.
 		volumeAttachmentsZone, err := e.volumeAttachmentsZone(args.VolumeAttachments)
 		if err != nil {
-			return nil, errors.Trace(err)
+			return nil, zoneIndependentError(errors.Trace(err))
 		}
 		if err := validateAvailabilityZoneConsistency(args.AvailabilityZone, volumeAttachmentsZone); err != nil {
-			return nil, errors.Trace(err)
+			return nil, zoneIndependentError(errors.Trace(err))
 		}
 		if err := common.ValidateAvailabilityZone(e, args.AvailabilityZone); err != nil {
-			logger.Errorf(err.Error())
-			return nil, errors.Wrap(err, environs.ErrAvailabilityZoneFailed)
+			return nil, zoneSpecificError(errors.Trace(err))
 		}
 	}
 
@@ -966,39 +974,41 @@ func (e *Environ) StartInstance(args environs.StartInstanceParams) (*environs.St
 		Constraints: args.Constraints,
 	}, args.ImageMetadata)
 	if err != nil {
-		return nil, err
+		return nil, zoneIndependentError(errors.Trace(err))
 	}
 	tools, err := args.Tools.Match(tools.Filter{Arch: spec.Image.Arch})
 	if err != nil {
-		return nil, errors.Errorf("chosen architecture %v not present in %v", spec.Image.Arch, arches)
+		return nil, zoneIndependentError(
+			errors.Errorf("chosen architecture %v not present in %v", spec.Image.Arch, arches),
+		)
 	}
 
 	if err := args.InstanceConfig.SetTools(tools); err != nil {
-		return nil, errors.Trace(err)
+		return nil, zoneIndependentError(errors.Trace(err))
 	}
 
 	if err := instancecfg.FinishInstanceConfig(args.InstanceConfig, e.Config()); err != nil {
-		return nil, err
+		return nil, zoneIndependentError(errors.Trace(err))
 	}
 	cloudcfg, err := e.configurator.GetCloudConfig(args)
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, zoneIndependentError(errors.Trace(err))
 	}
 	userData, err := providerinit.ComposeUserData(args.InstanceConfig, cloudcfg, OpenstackRenderer{})
 	if err != nil {
-		return nil, errors.Annotate(err, "cannot make user data")
+		return nil, zoneIndependentError(errors.Annotate(err, "cannot make user data"))
 	}
 	logger.Debugf("openstack user data; %d bytes", len(userData))
 
 	networks, err := e.networking.DefaultNetworks()
 	if err != nil {
-		return nil, errors.Annotate(err, "getting initial networks")
+		return nil, zoneIndependentError(errors.Annotate(err, "getting initial networks"))
 	}
 	usingNetwork := e.ecfg().network()
 	if usingNetwork != "" {
 		networkId, err := e.networking.ResolveNetwork(usingNetwork, false)
 		if err != nil {
-			return nil, err
+			return nil, zoneIndependentError(errors.Trace(err))
 		}
 		logger.Debugf("using network id %q", networkId)
 		networks = append(networks, nova.ServerNetworks{NetworkId: networkId})
@@ -1014,7 +1024,7 @@ func (e *Environ) StartInstance(args environs.StartInstanceParams) (*environs.St
 		for _, n := range networks {
 			net, err := client.GetNetworkV2(n.NetworkId)
 			if err != nil {
-				return nil, err
+				return nil, zoneIndependentError(errors.Trace(err))
 			}
 			if net.PortSecurityEnabled != nil &&
 				*net.PortSecurityEnabled == false {
@@ -1036,7 +1046,7 @@ func (e *Environ) StartInstance(args environs.StartInstanceParams) (*environs.St
 		}
 		groupNames, err := e.firewaller.SetUpGroups(args.ControllerUUID, args.InstanceConfig.MachineId, apiPort)
 		if err != nil {
-			return nil, errors.Annotate(err, "cannot set up groups")
+			return nil, zoneIndependentError(errors.Annotate(err, "cannot set up groups"))
 		}
 		novaGroupNames = make([]nova.SecurityGroupName, len(groupNames))
 		for i, name := range groupNames {
@@ -1130,19 +1140,21 @@ func (e *Environ) StartInstance(args environs.StartInstanceParams) (*environs.St
 	e.configurator.ModifyRunServerOptions(&opts)
 
 	server, err := tryStartNovaInstance(shortAttempt, e.nova(), opts)
-	if isNoValidHostsError(err) {
+	if err != nil {
 		// 'No valid host available' is typically a resource error,
 		// let the provisioner know it is a good idea to try another
 		// AZ if available.
-		return nil, errors.Wrap(err, environs.ErrAvailabilityZoneFailed)
-	}
-	if err != nil {
-		return nil, errors.Trace(errors.Annotate(err, "cannot run instance"))
+		err := errors.Annotate(err, "cannot run instance")
+		zoneSpecific := isNoValidHostsError(err)
+		if !zoneSpecific {
+			err = zoneIndependentError(err)
+		}
+		return nil, err
 	}
 
 	detail, err := e.nova().GetServer(server.Id)
 	if err != nil {
-		return nil, errors.Annotate(err, "cannot get started instance")
+		return nil, zoneIndependentError(errors.Annotate(err, "cannot get started instance"))
 	}
 
 	inst := &openstackInstance{
@@ -1162,7 +1174,7 @@ func (e *Environ) StartInstance(args environs.StartInstanceParams) (*environs.St
 		var publicIP *string
 		logger.Debugf("allocating public IP address for openstack node")
 		if fip, err := e.networking.AllocatePublicIP(inst.Id()); err != nil {
-			return nil, errors.Annotate(err, "cannot allocate a public IP as needed")
+			return nil, zoneIndependentError(errors.Annotate(err, "cannot allocate a public IP as needed"))
 		} else {
 			publicIP = fip
 			logger.Infof("allocated public IP %s", *publicIP)
@@ -1172,7 +1184,10 @@ func (e *Environ) StartInstance(args environs.StartInstanceParams) (*environs.St
 				// ignore the failure at this stage, just log it
 				logger.Debugf("failed to terminate instance %q: %v", inst.Id(), err)
 			}
-			return nil, errors.Annotatef(err, "cannot assign public address %s to instance %q", publicIP, inst.Id())
+			return nil, zoneIndependentError(errors.Annotatef(err,
+				"cannot assign public address %s to instance %q",
+				publicIP, inst.Id(),
+			))
 		}
 		inst.floatingIP = publicIP
 	}

--- a/provider/vsphere/environ_broker_test.go
+++ b/provider/vsphere/environ_broker_test.go
@@ -192,6 +192,7 @@ func (s *environBrokerSuite) TestStartInstanceWithUnsupportedConstraints(c *gc.C
 	startInstArgs.Tools[0].Version.Arch = "someArch"
 	_, err := s.env.StartInstance(startInstArgs)
 	c.Assert(err, gc.ErrorMatches, "no matching images found for given constraints: .*")
+	c.Assert(err, jc.Satisfies, environs.IsAvailabilityZoneIndependent)
 }
 
 // if tools for multiple architectures are avaliable, provider should filter tools by arch of the selected image
@@ -298,7 +299,7 @@ func (s *environBrokerSuite) TestStartInstanceFailsWithAvailabilityZone(c *gc.C)
 	s.client.SetErrors(nil, errors.New("nope"))
 	startInstArgs := s.createStartInstanceArgs(c)
 	_, err := s.env.StartInstance(startInstArgs)
-	c.Assert(errors.Cause(err), gc.Equals, environs.ErrAvailabilityZoneFailed)
+	c.Assert(err, gc.Not(jc.Satisfies), environs.IsAvailabilityZoneIndependent)
 
 	s.client.CheckCallNames(c, "ComputeResources", "CreateVirtualMachine", "Close")
 	createVMCall1 := s.client.Calls()[1]

--- a/worker/provisioner/provisioner_test.go
+++ b/worker/provisioner/provisioner_test.go
@@ -653,14 +653,12 @@ func (s *ProvisionerSuite) TestProvisionerFailedStartInstanceWithInjectedCreatio
 	cleanup := dummy.PatchTransientErrorInjectionChannel(errorInjectionChannel)
 	defer cleanup()
 
-	retryableError := &providercommon.StartInstanceError{
-		Err:             errors.New("container failed to start and was destroyed"),
-		ZoneIndependent: true,
-	}
-	destroyError := &providercommon.StartInstanceError{
-		Err:             errors.New("container failed to start and failed to destroy: manual cleanup of containers needed"),
-		ZoneIndependent: true,
-	}
+	retryableError := providercommon.ZoneIndependentError(
+		errors.New("container failed to start and was destroyed"),
+	)
+	destroyError := providercommon.ZoneIndependentError(
+		errors.New("container failed to start and failed to destroy: manual cleanup of containers needed"),
+	)
 	// send the error message three times, because the provisioner will retry twice as patched above.
 	errorInjectionChannel <- retryableError
 	errorInjectionChannel <- retryableError
@@ -1823,10 +1821,7 @@ func (s *ProvisionerSuite) TestProvisioningMachinesDerivedAZ(c *gc.C) {
 		startInstanceFailureInfo: map[string]mockBrokerFailures{
 			"2": {whenSucceed: 3, err: errors.New("zing")},
 			"3": {whenSucceed: 1, err: errors.New("zing")},
-			"5": {whenSucceed: 1, err: &providercommon.StartInstanceError{
-				Err:             errors.New("arf"),
-				ZoneIndependent: true,
-			}},
+			"5": {whenSucceed: 1, err: providercommon.ZoneIndependentError(errors.New("arf"))},
 		},
 		derivedAZ: map[string][]string{
 			"1": []string{"fail-zone"},

--- a/worker/provisioner/provisioner_test.go
+++ b/worker/provisioner/provisioner_test.go
@@ -653,8 +653,14 @@ func (s *ProvisionerSuite) TestProvisionerFailedStartInstanceWithInjectedCreatio
 	cleanup := dummy.PatchTransientErrorInjectionChannel(errorInjectionChannel)
 	defer cleanup()
 
-	retryableError := errors.New("container failed to start and was destroyed")
-	destroyError := errors.New("container failed to start and failed to destroy: manual cleanup of containers needed")
+	retryableError := &providercommon.StartInstanceError{
+		Err:             errors.New("container failed to start and was destroyed"),
+		ZoneIndependent: true,
+	}
+	destroyError := &providercommon.StartInstanceError{
+		Err:             errors.New("container failed to start and failed to destroy: manual cleanup of containers needed"),
+		ZoneIndependent: true,
+	}
 	// send the error message three times, because the provisioner will retry twice as patched above.
 	errorInjectionChannel <- retryableError
 	errorInjectionChannel <- retryableError
@@ -1620,7 +1626,7 @@ func (s *ProvisionerSuite) TestAvailabilityZoneMachinesStartMachinesAZFailures(c
 		Environ:    s.Environ,
 		retryCount: make(map[string]int),
 		startInstanceFailureInfo: map[string]mockBrokerFailures{
-			"2": {whenSucceed: 1, err: environs.ErrAvailabilityZoneFailed},
+			"2": {whenSucceed: 1, err: errors.New("zing")},
 		},
 	}
 	retryStrategy := provisioner.NewRetryStrategy(5*time.Millisecond, 2)
@@ -1668,7 +1674,7 @@ func (s *ProvisionerSuite) TestAvailabilityZoneMachinesStartMachinesAZFailuresWi
 		Environ:    s.Environ,
 		retryCount: make(map[string]int),
 		startInstanceFailureInfo: map[string]mockBrokerFailures{
-			"2": {whenSucceed: 1, err: environs.ErrAvailabilityZoneFailed},
+			"2": {whenSucceed: 1, err: errors.New("zing")},
 		},
 	}
 	dgFinder := &mockDistributionGroupFinder{groups: map[names.MachineTag][]string{
@@ -1791,7 +1797,7 @@ func (s *ProvisionerSuite) TestProvisioningMachinesClearAZFailures(c *gc.C) {
 		Environ:    s.Environ,
 		retryCount: make(map[string]int),
 		startInstanceFailureInfo: map[string]mockBrokerFailures{
-			"1": {whenSucceed: 3, err: environs.ErrAvailabilityZoneFailed},
+			"1": {whenSucceed: 3, err: errors.New("zing")},
 		},
 	}
 	retryStrategy := provisioner.NewRetryStrategy(5*time.Millisecond, 4)
@@ -1815,9 +1821,12 @@ func (s *ProvisionerSuite) TestProvisioningMachinesDerivedAZ(c *gc.C) {
 		Environ:    s.Environ,
 		retryCount: make(map[string]int),
 		startInstanceFailureInfo: map[string]mockBrokerFailures{
-			"2": {whenSucceed: 3, err: environs.ErrAvailabilityZoneFailed},
-			"3": {whenSucceed: 1, err: environs.ErrAvailabilityZoneFailed},
-			"5": {whenSucceed: 1, err: errors.New("fail me once.")},
+			"2": {whenSucceed: 3, err: errors.New("zing")},
+			"3": {whenSucceed: 1, err: errors.New("zing")},
+			"5": {whenSucceed: 1, err: &providercommon.StartInstanceError{
+				Err:             errors.New("arf"),
+				ZoneIndependent: true,
+			}},
 		},
 		derivedAZ: map[string][]string{
 			"1": []string{"fail-zone"},


### PR DESCRIPTION
## Description of change

Introduce the environs.AvailabilityZoneError
interface, and an accompanying helper function
IsAvailabilityZoneIndependent. Providers'
StartInstance methods may return an error
implementing environs.AvailabilityZoneError
to indicate that an error was not influenced
by the specified availability zone. This is
used by the provisioner and bootstrap code
to decide whether or not to attempt with an
alternative availability zone.

The existing ErrAvailabilityZoneFailed error
value has been removed, and all providers
have been updated to use the new interface
where appropriate. A helper function,
ZoneIndependentError, has been added to the
provider/common package which wraps a given
function such that it satisfies
environs.IsAvailabilityZoneIndependent.

## QA steps

bootstrap
deploy ubuntu -n 3
(check units spread over AZs)
destroy-controller

repeat in a cloud with broken AZs, check that the provisioner retries after failing in one AZ

## Documentation changes

None.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1732564