### PR TITLE
Always qualify model name with model owner.

### DIFF
--- a/cmd/juju/common/model.go
+++ b/cmd/juju/common/model.go
@@ -181,10 +181,9 @@ func modelSLAOwnerFromParams(sla *params.ModelSLAInfo) string {
 }
 
 // OwnerQualifiedModelName returns the model name qualified with the
-// model owner if the owner is not the same as the given canonical
-// user name. If the owner is a local user, we omit the domain.
+// model owner.
 func OwnerQualifiedModelName(modelName string, owner, user names.UserTag) string {
-	if owner.Id() == user.Id() {
+	if jujuclient.IsQualifiedModelName(modelName) {
 		return modelName
 	}
 	return jujuclient.JoinOwnerModelName(owner, modelName)

--- a/cmd/juju/controller/listcontrollers_test.go
+++ b/cmd/juju/controller/listcontrollers_test.go
@@ -50,7 +50,7 @@ Use --refresh flag with this command to see the latest information.
 
 Controller           Model             User   Access     Cloud/Region        Models  Machines  HA  Version
 aws-test             admin/controller  -      -          aws/us-east-1            1         5   -  2.0.1      
-mallards*            my-model          admin  superuser  mallards/mallards1       2         -   -  (unknown)  
+mallards*            admin/my-model    admin  superuser  mallards/mallards1       2         -   -  (unknown)  
 mark-test-prodstack  -                 admin  (unknown)  prodstack                -         -   -  (unknown)  
 
 `[1:]
@@ -75,10 +75,10 @@ func (s *ListControllersSuite) TestListControllersRefresh(c *gc.C) {
 		return fakeController
 	}
 	s.expectedOutput = `
-Controller           Model       User   Access     Cloud/Region        Models  Machines  HA  Version
-aws-test             controller  admin  (unknown)  aws/us-east-1            1         2   -  2.0.1      
-mallards*            my-model    admin  superuser  mallards/mallards1       2         4   -  (unknown)  
-mark-test-prodstack  -           admin  (unknown)  prodstack                -         -   -  (unknown)  
+Controller           Model             User   Access     Cloud/Region        Models  Machines  HA  Version
+aws-test             admin/controller  admin  (unknown)  aws/us-east-1            1         2   -  2.0.1      
+mallards*            admin/my-model    admin  superuser  mallards/mallards1       2         4   -  (unknown)  
+mark-test-prodstack  -                 admin  (unknown)  prodstack                -         -   -  (unknown)  
 
 `[1:]
 	s.assertListControllers(c, "--refresh")
@@ -122,10 +122,10 @@ func (s *ListControllersSuite) TestListControllersKnownHAStatus(c *gc.C) {
 	s.createTestClientStore(c)
 	s.setupAPIForControllerMachines()
 	s.expectedOutput = `
-Controller           Model       User   Access     Cloud/Region        Models  Machines    HA  Version
-aws-test             controller  admin  (unknown)  aws/us-east-1            1         2   1/3  2.0.1      
-mallards*            my-model    admin  superuser  mallards/mallards1       2         4  none  (unknown)  
-mark-test-prodstack  -           admin  (unknown)  prodstack                -         -     -  (unknown)  
+Controller           Model             User   Access     Cloud/Region        Models  Machines    HA  Version
+aws-test             admin/controller  admin  (unknown)  aws/us-east-1            1         2   1/3  2.0.1      
+mallards*            admin/my-model    admin  superuser  mallards/mallards1       2         4  none  (unknown)  
+mark-test-prodstack  -                 admin  (unknown)  prodstack                -         -     -  (unknown)  
 
 `[1:]
 	s.assertListControllers(c, "--refresh")
@@ -135,7 +135,7 @@ func (s *ListControllersSuite) TestListControllersYaml(c *gc.C) {
 	s.expectedOutput = `
 controllers:
   aws-test:
-    current-model: controller
+    current-model: admin/controller
     user: admin
     recent-server: this-is-aws-test-of-many-api-endpoints
     uuid: this-is-the-aws-test-uuid
@@ -150,7 +150,7 @@ controllers:
       active: 1
       total: 3
   mallards:
-    current-model: my-model
+    current-model: admin/my-model
     user: admin
     access: superuser
     recent-server: this-is-another-of-many-api-endpoints
@@ -194,7 +194,7 @@ func (s *ListControllersSuite) TestListControllersJson(c *gc.C) {
 		Controllers: map[string]controller.ControllerItem{
 			"aws-test": {
 				ControllerUUID: "this-is-the-aws-test-uuid",
-				ModelName:      "controller",
+				ModelName:      "admin/controller",
 				User:           "admin",
 				Server:         "this-is-aws-test-of-many-api-endpoints",
 				APIEndpoints:   []string{"this-is-aws-test-of-many-api-endpoints"},
@@ -207,7 +207,7 @@ func (s *ListControllersSuite) TestListControllersJson(c *gc.C) {
 			},
 			"mallards": {
 				ControllerUUID: "this-is-another-uuid",
-				ModelName:      "my-model",
+				ModelName:      "admin/my-model",
 				User:           "admin",
 				Access:         "superuser",
 				Server:         "this-is-another-of-many-api-endpoints",

--- a/cmd/juju/controller/listmodels_test.go
+++ b/cmd/juju/controller/listmodels_test.go
@@ -221,7 +221,7 @@ models:
   status:
     current: destroying
   agent-version: 2.55.5
-current-model: test-model1
+current-model: admin/test-model1
 `[1:])
 }
 
@@ -229,7 +229,7 @@ func (s *ModelsSuite) TestModelsJson(c *gc.C) {
 	context, err := cmdtesting.RunCommand(c, s.newCommand(), "--format", "json")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(s.api.user, gc.Equals, "admin")
-	c.Assert(cmdtesting.Stdout(context), gc.Equals, `{"models":[{"name":"admin/test-model1","short-name":"test-model1","model-uuid":"test-model1-UUID","controller-uuid":"","controller-name":"fake","owner":"admin","cloud":"dummy","life":"","status":{"current":"active"},"users":{"admin":{"access":"read","last-connection":"2015-03-20"}},"agent-version":"2.55.5"},{"name":"carlotta/test-model2","short-name":"test-model2","model-uuid":"test-model2-UUID","controller-uuid":"","controller-name":"fake","owner":"carlotta","cloud":"dummy","life":"","status":{"current":"active"},"users":{"admin":{"access":"write","last-connection":"2015-03-01"}},"agent-version":"2.55.5"},{"name":"daiwik@external/test-model3","short-name":"test-model3","model-uuid":"test-model3-UUID","controller-uuid":"","controller-name":"fake","owner":"daiwik@external","cloud":"dummy","life":"","status":{"current":"destroying"},"agent-version":"2.55.5"}],"current-model":"test-model1"}
+	c.Assert(cmdtesting.Stdout(context), gc.Equals, `{"models":[{"name":"admin/test-model1","short-name":"test-model1","model-uuid":"test-model1-UUID","controller-uuid":"","controller-name":"fake","owner":"admin","cloud":"dummy","life":"","status":{"current":"active"},"users":{"admin":{"access":"read","last-connection":"2015-03-20"}},"agent-version":"2.55.5"},{"name":"carlotta/test-model2","short-name":"test-model2","model-uuid":"test-model2-UUID","controller-uuid":"","controller-name":"fake","owner":"carlotta","cloud":"dummy","life":"","status":{"current":"active"},"users":{"admin":{"access":"write","last-connection":"2015-03-01"}},"agent-version":"2.55.5"},{"name":"daiwik@external/test-model3","short-name":"test-model3","model-uuid":"test-model3-UUID","controller-uuid":"","controller-name":"fake","owner":"daiwik@external","cloud":"dummy","life":"","status":{"current":"destroying"},"agent-version":"2.55.5"}],"current-model":"admin/test-model1"}
 `)
 }
 

--- a/cmd/juju/user/whoami_test.go
+++ b/cmd/juju/user/whoami_test.go
@@ -126,7 +126,7 @@ func (s *WhoAmITestSuite) assertWhoAmIForUser(c *gc.C, user, format string) {
 func (s *WhoAmITestSuite) TestWhoAmISameUser(c *gc.C) {
 	s.expectedOutput = `
 Controller:  controller
-Model:       model
+Model:       admin/model
 User:        admin
 `[1:]
 	s.assertWhoAmIForUser(c, "admin", "tabular")
@@ -135,7 +135,7 @@ User:        admin
 func (s *WhoAmITestSuite) TestWhoAmIYaml(c *gc.C) {
 	s.expectedOutput = `
 controller: controller
-model: model
+model: admin/model
 user: admin
 `[1:]
 	s.assertWhoAmIForUser(c, "admin", "yaml")
@@ -143,7 +143,7 @@ user: admin
 
 func (s *WhoAmITestSuite) TestWhoAmIJson(c *gc.C) {
 	s.expectedOutput = `
-{"controller":"controller","model":"model","user":"admin"}
+{"controller":"controller","model":"admin/model","user":"admin"}
 `[1:]
 	s.assertWhoAmIForUser(c, "admin", "json")
 }

--- a/featuretests/cmd_juju_controller_test.go
+++ b/featuretests/cmd_juju_controller_test.go
@@ -77,8 +77,8 @@ func (s *cmdControllerSuite) TestControllerListCommand(c *gc.C) {
 	expectedOutput := `
 Use --refresh flag with this command to see the latest information.
 
-Controller  Model       User   Access     Cloud/Region        Models  Machines  HA  Version
-kontroll*   controller  admin  superuser  dummy/dummy-region       1         -   -  (unknown)  
+Controller  Model             User   Access     Cloud/Region        Models  Machines  HA  Version
+kontroll*   admin/controller  admin  superuser  dummy/dummy-region       1         -   -  (unknown)  
 
 `[1:]
 	c.Assert(cmdtesting.Stdout(context), gc.Equals, expectedOutput)
@@ -140,7 +140,7 @@ models:
       cores: 2
   sla: unsupported
   agent-version: %v
-current-model: controller
+current-model: admin/controller
 `[1:]
 	c.Assert(cmdtesting.Stdout(context), gc.Matches, fmt.Sprintf(expectedOutput, version.Current))
 }


### PR DESCRIPTION
## Description of change

As we will move into the world where model.owner is just one of the model admins, the "owner" on the model will be renamed to be a "label" This "label", for example, will allow to group models.
This PR ensures that we always qualify the model to avoid surprises in the future output.


