### PR TITLE
If metrics workers error, ensure socket listeners are stopped

### DIFF
--- a/worker/metrics/sender/export_test.go
+++ b/worker/metrics/sender/export_test.go
@@ -3,8 +3,22 @@
 
 package sender
 
+import "github.com/juju/juju/worker/metrics/spool"
+
 var (
 	NewSender            = newSender
+	NewListener          = &newListener
 	NewMetricAdderClient = newMetricAdderClient
 	SocketName           = &socketName
 )
+
+type handlerStopper interface {
+	spool.ConnectionHandler
+	Stop() error
+}
+
+func NewListenerFunc(listener handlerStopper) func(spool.ConnectionHandler, string, string) (stopper, error) {
+	return func(spool.ConnectionHandler, string, string) (stopper, error) {
+		return listener, nil
+	}
+}

--- a/worker/metrics/sender/manifold_test.go
+++ b/worker/metrics/sender/manifold_test.go
@@ -9,12 +9,13 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/juju/errors"
 	"github.com/juju/httprequest"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/names.v2"
-	worker "gopkg.in/juju/worker.v1"
+	"gopkg.in/juju/worker.v1"
 	"gopkg.in/macaroon-bakery.v1/httpbakery"
 
 	"github.com/juju/juju/agent"
@@ -30,6 +31,7 @@ type ManifoldSuite struct {
 	testing.IsolationSuite
 	factory   spool.MetricFactory
 	client    metricsadder.MetricsAdderClient
+	apiCaller *stubAPICaller
 	manifold  dependency.Manifold
 	resources dt.StubResources
 }
@@ -60,9 +62,10 @@ func (s *ManifoldSuite) SetUpTest(c *gc.C) {
 	err := os.MkdirAll(filepath.Join(dataDir, "agents", "unit-u-0"), 0777)
 	c.Assert(err, jc.ErrorIsNil)
 
+	s.apiCaller = &stubAPICaller{&testing.Stub{}}
 	s.resources = dt.StubResources{
 		"agent":        dt.StubResource{Output: &dummyAgent{dataDir: dataDir}},
-		"api-caller":   dt.StubResource{Output: &stubAPICaller{&testing.Stub{}}},
+		"api-caller":   dt.StubResource{Output: s.apiCaller},
 		"metric-spool": dt.StubResource{Output: s.factory},
 	}
 }
@@ -107,6 +110,31 @@ func (s *ManifoldSuite) setupWorkerTest(c *gc.C) worker.Worker {
 	return worker
 }
 
+type mockListener struct {
+	testing.Stub
+	spool.ConnectionHandler
+}
+
+// Stop implements the stopper interface.
+func (l *mockListener) Stop() error {
+	l.AddCall("Stop")
+	return nil
+}
+
+func (s *ManifoldSuite) TestWorkerErrorStopsSender(c *gc.C) {
+	listener := &mockListener{}
+	s.PatchValue(sender.NewListener, sender.NewListenerFunc(listener))
+
+	s.apiCaller.SetErrors(errors.New("blah"))
+
+	worker, err := s.manifold.Start(s.resources.Context())
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(worker, gc.NotNil)
+	err = worker.Wait()
+	c.Assert(err, gc.ErrorMatches, ".*blah")
+	listener.CheckCallNames(c, "Stop")
+}
+
 var _ base.APICaller = (*stubAPICaller)(nil)
 
 type stubAPICaller struct {
@@ -115,7 +143,7 @@ type stubAPICaller struct {
 
 func (s *stubAPICaller) APICall(objType string, version int, id, request string, params, response interface{}) error {
 	s.MethodCall(s, "APICall", objType, version, id, request, params, response)
-	return nil
+	return s.NextErr()
 }
 
 func (s *stubAPICaller) BestFacadeVersion(facade string) int {

--- a/worker/metrics/sender/sender.go
+++ b/worker/metrics/sender/sender.go
@@ -35,7 +35,17 @@ type sender struct {
 
 // Do sends metrics from the metric spool to the
 // controller via an api call.
-func (s *sender) Do(stop <-chan struct{}) error {
+func (s *sender) Do(stop <-chan struct{}) (err error) {
+	defer func() {
+		// See bug https://pad/lv/1733469
+		// If this function which is run by a PeriodicWorker
+		// exits with an error, we need to call stop() to
+		// ensure the sender socket is closed.
+		if err != nil {
+			s.stop()
+		}
+	}()
+
 	reader, err := s.factory.Reader()
 	if err != nil {
 		return errors.Trace(err)
@@ -116,10 +126,18 @@ func newSender(client metricsadder.MetricsAdderClient, factory spool.MetricFacto
 		client:  client,
 		factory: factory,
 	}
-	listener, err := spool.NewSocketListener(socketName(baseDir, unitTag), s)
+	listener, err := newListener(s, baseDir, unitTag)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
 	s.listener = listener
 	return s, nil
+}
+
+var newListener = func(s spool.ConnectionHandler, baseDir, unitTag string) (stopper, error) {
+	listener, err := spool.NewSocketListener(socketName(baseDir, unitTag), s)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return listener, nil
 }


### PR DESCRIPTION
## Description of change

Bad data, eg zero length files in /var/lib/juju/metricspool/, cause the metric workers to bounce. But upon doing so, they don't close their socket. We add error handling to the "run" func passed to the periodic workers so that if there's an error, stop is called on the particular metrics structs, which stops the listener.

Also, if there's an error creating the content of the metric file, don't try and use it.

## QA steps

https://bugs.launchpad.net/juju/+bug/1733469/comments/6
Create zero length files and check for leaks.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1733469
