### PR TITLE
Consider model in upgrade/restore login checks

### DIFF
--- a/api/apiclient_test.go
+++ b/api/apiclient_test.go
@@ -581,6 +581,8 @@ func (s *apiclientSuite) TestPublicDNSName(c *gc.C) {
 		NewObserver:     func() observer.Observer { return &fakeobserver.Instance{} },
 		AutocertURL:     "https://0.1.2.3/no-autocert-here",
 		RateLimitConfig: apiserver.DefaultRateLimitConfig(),
+		UpgradeComplete: func() bool { return true },
+		RestoreStatus:   func() state.RestoreStatus { return state.RestoreNotActive },
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	defer worker.Stop(srv)

--- a/api/controller/legacy_test.go
+++ b/api/controller/legacy_test.go
@@ -229,6 +229,8 @@ func (s *legacySuite) TestAPIServerCanShutdownWithOutstandingNext(c *gc.C) {
 		NewObserver:     func() observer.Observer { return &fakeobserver.Instance{} },
 		AutocertURL:     "https://0.1.2.3/no-autocert-here",
 		RateLimitConfig: apiserver.DefaultRateLimitConfig(),
+		UpgradeComplete: func() bool { return true },
+		RestoreStatus:   func() state.RestoreStatus { return state.RestoreNotActive },
 	})
 	c.Assert(err, gc.IsNil)
 

--- a/api/pubsub/pubsub_test.go
+++ b/api/pubsub/pubsub_test.go
@@ -233,6 +233,8 @@ func newServerWithHub(c *gc.C, statePool *state.StatePool, hub *pubsub.Structure
 		Hub:             hub,
 		NewObserver:     func() observer.Observer { return &fakeobserver.Instance{} },
 		RateLimitConfig: apiserver.DefaultRateLimitConfig(),
+		UpgradeComplete: func() bool { return true },
+		RestoreStatus:   func() state.RestoreStatus { return state.RestoreNotActive },
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	port := listener.Addr().(*net.TCPAddr).Port

--- a/apiserver/admin.go
+++ b/apiserver/admin.go
@@ -71,8 +71,6 @@ func (a *admin) RedirectInfo() (params.RedirectInfoResult, error) {
 	return params.RedirectInfoResult{}, fmt.Errorf("not redirected")
 }
 
-var AboutToRestoreError = errors.New("restore preparation in progress")
-var RestoreInProgressError = errors.New("restore in progress")
 var MaintenanceNoLoginError = errors.New("login failed - maintenance in progress")
 var errAlreadyLoggedIn = errors.New("already logged in")
 
@@ -412,19 +410,14 @@ func (a *admin) authenticator() authentication.EntityAuthenticator {
 }
 
 func (a *admin) maintenanceInProgress() bool {
-	if a.srv.validator == nil {
-		return false
+	if !a.srv.upgradeComplete() {
+		return true
 	}
-	// jujud's login validator will return an error for any user tag
-	// if jujud is upgrading or restoring. The tag of the entity
-	// trying to log in can't be used because jujud's login validator
-	// will always return nil for the local machine agent and here we
-	// need to know if maintenance is in progress irrespective of the
-	// the authenticating entity.
-	//
-	// TODO(mjs): 2014-09-29 bug 1375110
-	// This needs improving but I don't have the cycles right now.
-	return a.srv.validator(names.NewUserTag("arbitrary")) != nil
+	switch a.srv.restoreStatus() {
+	case state.RestorePending, state.RestoreInProgress:
+		return true
+	}
+	return false
 }
 
 var doCheckCreds = checkCreds

--- a/apiserver/admin_test.go
+++ b/apiserver/admin_test.go
@@ -449,90 +449,62 @@ func (s *loginSuite) TestNonModelUserLoginFails(c *gc.C) {
 	assertInvalidEntityPassword(c, err)
 }
 
-func (s *loginSuite) TestLoginValidationSuccess(c *gc.C) {
-	validator := func(names.Tag) error {
-		return nil
-	}
-	checker := func(c *gc.C, loginErr error, st api.Connection) {
-		c.Assert(loginErr, gc.IsNil)
-
-		// Ensure an API call that would be restricted during
-		// upgrades works after a normal login.
-		err := st.APICall("Client", 1, "", "ModelSet", params.ModelSet{}, nil)
-		c.Assert(err, jc.ErrorIsNil)
-	}
-	s.checkLoginWithValidator(c, validator, checker)
-}
-
-func (s *loginSuite) TestLoginValidationFail(c *gc.C) {
-	validator := func(names.Tag) error {
-		return errors.New("Login not allowed")
-	}
-	checker := func(c *gc.C, loginErr error, _ api.Connection) {
-		// error is wrapped in API server
-		c.Assert(loginErr, gc.ErrorMatches, "Login not allowed")
-	}
-	s.checkLoginWithValidator(c, validator, checker)
-}
-
 func (s *loginSuite) TestLoginValidationDuringUpgrade(c *gc.C) {
-	validator := func(names.Tag) error {
-		return params.UpgradeInProgressError
+	cfg := defaultServerConfig(c)
+	cfg.UpgradeComplete = func() bool {
+		// upgrade is in progress
+		return false
 	}
-	checker := func(c *gc.C, loginErr error, st api.Connection) {
-		c.Assert(loginErr, gc.IsNil)
-
+	s.testLoginDuringMaintenance(c, cfg, func(st api.Connection) {
 		var statusResult params.FullStatus
 		err := st.APICall("Client", 1, "", "FullStatus", params.StatusParams{}, &statusResult)
 		c.Assert(err, jc.ErrorIsNil)
 
 		err = st.APICall("Client", 1, "", "ModelSet", params.ModelSet{}, nil)
 		c.Assert(err, jc.Satisfies, params.IsCodeUpgradeInProgress)
-	}
-	s.checkLoginWithValidator(c, validator, checker)
+	})
 }
 
-func (s *loginSuite) TestFailedLoginDuringMaintenance(c *gc.C) {
+func (s *loginSuite) TestLoginWhileRestorePending(c *gc.C) {
 	cfg := defaultServerConfig(c)
-	cfg.Validator = func(names.Tag) error {
-		return errors.New("something")
+	cfg.RestoreStatus = func() state.RestoreStatus {
+		return state.RestorePending
 	}
-	info, srv := newServerWithConfig(c, s.pool, cfg)
-	defer assertStop(c, srv)
-	info.ModelTag = s.IAASModel.ModelTag()
+	s.testLoginDuringMaintenance(c, cfg, func(st api.Connection) {
+		var statusResult params.FullStatus
+		err := st.APICall("Client", 1, "", "FullStatus", params.StatusParams{}, &statusResult)
+		c.Assert(err, jc.ErrorIsNil)
 
-	checkLogin := func(tag names.Tag) {
-		st := s.openAPIWithoutLogin(c, info)
-		err := st.Login(tag, "dummy-secret", "nonce", nil)
-		c.Assert(err, gc.ErrorMatches, "something")
-	}
-	checkLogin(names.NewUserTag("definitelywontexist"))
-	checkLogin(names.NewMachineTag("99999"))
+		err = st.APICall("Client", 1, "", "ModelSet", params.ModelSet{}, nil)
+		c.Assert(err, gc.ErrorMatches, `juju restore is in progress - functionality is limited to avoid data loss`)
+	})
 }
 
-type validationChecker func(c *gc.C, err error, st api.Connection)
-
-func (s *baseLoginSuite) checkLoginWithValidator(c *gc.C, validator apiserver.LoginValidator, checker validationChecker) {
+func (s *loginSuite) TestLoginWhileRestoreInProgress(c *gc.C) {
 	cfg := defaultServerConfig(c)
-	cfg.Validator = validator
+	cfg.RestoreStatus = func() state.RestoreStatus {
+		return state.RestoreInProgress
+	}
+	s.testLoginDuringMaintenance(c, cfg, func(st api.Connection) {
+		var statusResult params.FullStatus
+		err := st.APICall("Client", 1, "", "FullStatus", params.StatusParams{}, &statusResult)
+		c.Assert(err, gc.ErrorMatches, `juju restore is in progress - API is disabled to prevent data loss`)
+
+		err = st.APICall("Client", 1, "", "ModelSet", params.ModelSet{}, nil)
+		c.Assert(err, gc.ErrorMatches, `juju restore is in progress - API is disabled to prevent data loss`)
+	})
+}
+
+func (s *loginSuite) testLoginDuringMaintenance(c *gc.C, cfg apiserver.ServerConfig, check func(api.Connection)) {
 	info, srv := newServerWithConfig(c, s.pool, cfg)
 	defer assertStop(c, srv)
 	info.ModelTag = s.IAASModel.ModelTag()
 
 	st := s.openAPIWithoutLogin(c, info)
+	err := st.Login(s.AdminUserTag(c), "dummy-secret", "", nil)
+	c.Assert(err, jc.ErrorIsNil)
 
-	// Ensure not already logged in.
-	_, err := apimachiner.NewState(st).Machine(names.NewMachineTag("0"))
-	c.Assert(errors.Cause(err), gc.DeepEquals, &rpc.RequestError{
-		Message: `unknown object type "Machiner"`,
-		Code:    "not implemented",
-	})
-
-	adminUser := s.AdminUserTag(c)
-	// Since these are user login tests, the nonce is empty.
-	err = st.Login(adminUser, "dummy-secret", "", nil)
-
-	checker(c, err, st)
+	check(st)
 }
 
 func (s *baseLoginSuite) openAPIWithoutLogin(c *gc.C, info0 *api.Info) api.Connection {

--- a/apiserver/apiserver.go
+++ b/apiserver/apiserver.go
@@ -27,6 +27,7 @@ import (
 	"golang.org/x/crypto/acme"
 	"golang.org/x/crypto/acme/autocert"
 	"gopkg.in/juju/names.v2"
+	"gopkg.in/macaroon-bakery.v1/bakery"
 	"gopkg.in/macaroon-bakery.v1/httpbakery"
 	"gopkg.in/tomb.v1"
 
@@ -44,7 +45,6 @@ import (
 	"github.com/juju/juju/rpc"
 	"github.com/juju/juju/rpc/jsoncodec"
 	"github.com/juju/juju/state"
-	"gopkg.in/macaroon-bakery.v1/bakery"
 )
 
 var logger = loggo.GetLogger("juju.apiserver")
@@ -79,7 +79,6 @@ type Server struct {
 	logDir                 string
 	limiter                utils.Limiter
 	loginRetryPause        time.Duration
-	validator              LoginValidator
 	facades                *facade.Registry
 	modelUUID              string
 	loginAuthCtxt          *authContext
@@ -96,6 +95,8 @@ type Server struct {
 	logSinkWriter          io.WriteCloser
 	logsinkRateLimitConfig logsink.RateLimitConfig
 	dbloggers              dbloggers
+	upgradeComplete        func() bool
+	restoreStatus          func() state.RestoreStatus
 
 	// mu guards the fields below it.
 	mu sync.Mutex
@@ -120,11 +121,6 @@ type Server struct {
 	registerIntrospectionHandlers func(func(string, http.Handler))
 }
 
-// LoginValidator functions are used to decide whether login requests
-// are to be allowed. The validator is called before credentials are
-// checked.
-type LoginValidator func(authUser names.Tag) error
-
 // ServerConfig holds parameters required to set up an API server.
 type ServerConfig struct {
 	Clock       clock.Clock
@@ -134,9 +130,20 @@ type ServerConfig struct {
 	Tag         names.Tag
 	DataDir     string
 	LogDir      string
-	Validator   LoginValidator
 	Hub         *pubsub.StructuredHub
 	CertChanged <-chan params.StateServingInfo
+
+	// UpgradeComplete is a function that reports whether or not
+	// the if the agent running the API server has completed
+	// running upgrade steps. This is used by the API server to
+	// limit logins during upgrades.
+	UpgradeComplete func() bool
+
+	// RestoreStatus is a function that reports the restore
+	// status most recently observed by the agent running the
+	// API server. This is used by the API server to limit logins
+	// during a restore.
+	RestoreStatus func() state.RestoreStatus
 
 	// AutocertDNSName holds the DNS name for which
 	// official TLS certificates will be obtained. If this is
@@ -187,6 +194,12 @@ func (c ServerConfig) Validate() error {
 	}
 	if c.NewObserver == nil {
 		return errors.NotValidf("missing NewObserver")
+	}
+	if c.UpgradeComplete == nil {
+		return errors.NotValidf("nil UpgradeComplete")
+	}
+	if c.RestoreStatus == nil {
+		return errors.NotValidf("nil RestoreStatus")
 	}
 	if err := c.RateLimitConfig.Validate(); err != nil {
 		return errors.Annotate(err, "validating rate limit configuration")
@@ -357,7 +370,8 @@ func newServer(stPool *state.StatePool, lis net.Listener, cfg ServerConfig) (_ *
 		logDir:                        cfg.LogDir,
 		limiter:                       limiter,
 		loginRetryPause:               cfg.RateLimitConfig.LoginRetryPause,
-		validator:                     cfg.Validator,
+		upgradeComplete:               cfg.UpgradeComplete,
+		restoreStatus:                 cfg.RestoreStatus,
 		facades:                       AllFacades(),
 		centralHub:                    cfg.Hub,
 		certChanged:                   cfg.CertChanged,

--- a/apiserver/apiserver_test.go
+++ b/apiserver/apiserver_test.go
@@ -57,6 +57,10 @@ func (s *apiserverBaseSuite) sampleConfig(c *gc.C) apiserver.ServerConfig {
 		NewObserver:     func() observer.Observer { return &fakeobserver.Instance{} },
 		AutocertURL:     "https://0.1.2.3/no-autocert-here",
 		RateLimitConfig: apiserver.DefaultRateLimitConfig(),
+		UpgradeComplete: func() bool { return true },
+		RestoreStatus: func() state.RestoreStatus {
+			return state.RestoreNotActive
+		},
 	}
 }
 

--- a/apiserver/server_test.go
+++ b/apiserver/server_test.go
@@ -641,6 +641,10 @@ func defaultServerConfig(c *gc.C) apiserver.ServerConfig {
 		NewObserver:     func() observer.Observer { return &fakeobserver.Instance{} },
 		AutocertURL:     "https://0.1.2.3/no-autocert-here",
 		RateLimitConfig: apiserver.DefaultRateLimitConfig(),
+		UpgradeComplete: func() bool { return true },
+		RestoreStatus: func() state.RestoreStatus {
+			return state.RestoreNotActive
+		},
 	}
 }
 

--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -309,6 +309,7 @@ func NewMachineAgent(
 		mongoDialCollector:          mongometrics.NewDialCollector(),
 		preUpgradeSteps:             preUpgradeSteps,
 		statePool:                   &statePoolHolder{},
+		restoreStatus:               state.RestoreNotActive,
 	}
 	if err := a.registerPrometheusCollectors(); err != nil {
 		return nil, errors.Trace(err)
@@ -355,9 +356,8 @@ type MachineAgent struct {
 	upgradeComplete  gate.Lock
 	workersStarted   chan struct{}
 
-	// XXX(fwereade): these smell strongly of goroutine-unsafeness.
-	restoreMode bool
-	restoring   bool
+	restoreStatusMu sync.Mutex
+	restoreStatus   state.RestoreStatus
 
 	// Used to signal that the upgrade worker will not
 	// reboot the agent on startup because there are no
@@ -395,26 +395,6 @@ func (h *statePoolHolder) set(pool *state.StatePool) {
 	h.mu.Lock()
 	defer h.mu.Unlock()
 	h.pool = pool
-}
-
-// IsRestorePreparing returns bool representing if we are in restore mode
-// but not running restore.
-func (a *MachineAgent) IsRestorePreparing() bool {
-	return a.restoreMode && !a.restoring
-}
-
-// IsRestoreRunning returns bool representing if we are in restore mode
-// and running the actual restore process.
-func (a *MachineAgent) IsRestoreRunning() bool {
-	return a.restoring
-}
-
-func (a *MachineAgent) isUpgradeRunning() bool {
-	return !a.upgradeComplete.IsUnlocked()
-}
-
-func (a *MachineAgent) isInitialUpgradeCheckPending() bool {
-	return !a.initialUpgradeCheckComplete.IsUnlocked()
 }
 
 // Wait waits for the machine agent to finish.
@@ -667,43 +647,6 @@ func (a *MachineAgent) maybeStopMongo(ver mongo.Version, isMaster bool) error {
 
 }
 
-// PrepareRestore will flag the agent to allow only a limited set
-// of commands defined in
-// "github.com/juju/juju/apiserver".allowedMethodsAboutToRestore
-// the most noteworthy is:
-// Backups.Restore: this will ensure that we can do all the file movements
-// required for restore and no one will do changes while we do that.
-// it will return error if the machine is already in this state.
-func (a *MachineAgent) PrepareRestore() error {
-	if a.restoreMode {
-		return errors.Errorf("already in restore mode")
-	}
-	a.restoreMode = true
-	return nil
-}
-
-// BeginRestore will flag the agent to disallow all commands since
-// restore should be running and therefore making changes that
-// would override anything done.
-func (a *MachineAgent) BeginRestore() error {
-	switch {
-	case !a.restoreMode:
-		return errors.Errorf("not in restore mode, cannot begin restoration")
-	case a.restoring:
-		return errors.Errorf("already restoring")
-	}
-	a.restoring = true
-	return nil
-}
-
-// EndRestore will flag the agent to allow all commands
-// This being invoked means that restore process failed
-// since success restarts the agent.
-func (a *MachineAgent) EndRestore() {
-	a.restoreMode = false
-	a.restoring = false
-}
-
 // newRestoreStateWatcherWorker will return a worker or err if there
 // is a failure, the worker takes care of watching the state of
 // restoreInfo doc and put the agent in the different restore modes.
@@ -714,6 +657,12 @@ func (a *MachineAgent) newRestoreStateWatcherWorker(st *state.State) (worker.Wor
 	return jworker.NewSimpleWorker(rWorker), nil
 }
 
+func (a *MachineAgent) getRestoreStatus() state.RestoreStatus {
+	a.restoreStatusMu.Lock()
+	defer a.restoreStatusMu.Unlock()
+	return a.restoreStatus
+}
+
 // restoreChanged will be called whenever restoreInfo doc changes signaling a new
 // step in the restore process.
 func (a *MachineAgent) restoreChanged(st *state.State) error {
@@ -721,14 +670,9 @@ func (a *MachineAgent) restoreChanged(st *state.State) error {
 	if err != nil {
 		return errors.Annotate(err, "cannot read restore state")
 	}
-	switch status {
-	case state.RestorePending:
-		a.PrepareRestore()
-	case state.RestoreInProgress:
-		a.BeginRestore()
-	case state.RestoreFailed:
-		a.EndRestore()
-	}
+	a.restoreStatusMu.Lock()
+	a.restoreStatus = status
+	a.restoreStatusMu.Unlock()
 	return nil
 }
 
@@ -1363,9 +1307,10 @@ func (a *MachineAgent) newAPIserverWorker(
 		Tag:                           tag,
 		DataDir:                       dataDir,
 		LogDir:                        logDir,
-		Validator:                     a.limitLogins,
 		Hub:                           a.centralHub,
 		CertChanged:                   certChanged,
+		UpgradeComplete:               a.upgradeComplete.IsUnlocked,
+		RestoreStatus:                 a.getRestoreStatus,
 		AutocertURL:                   controllerConfig.AutocertURL(),
 		AutocertDNSName:               controllerConfig.AutocertDNSName(),
 		AllowModelAccess:              controllerConfig.AllowModelAccess(),
@@ -1576,70 +1521,6 @@ func newObserverFn(
 
 	return observer.ObserverFactoryMultiplexer(observerFactories...), nil
 
-}
-
-// limitLogins is called by the API server for each login attempt.
-// it returns an error if upgrades or restore are running.
-func (a *MachineAgent) limitLogins(authTag names.Tag) error {
-	if err := a.limitLoginsDuringRestore(authTag); err != nil {
-		return err
-	}
-	return a.limitLoginsDuringUpgrade(authTag)
-}
-
-// limitLoginsDuringRestore will only allow logins for restore related purposes
-// while the different steps of restore are running.
-func (a *MachineAgent) limitLoginsDuringRestore(authTag names.Tag) error {
-	var err error
-	switch {
-	case a.IsRestoreRunning():
-		err = apiserver.RestoreInProgressError
-	case a.IsRestorePreparing():
-		err = apiserver.AboutToRestoreError
-	}
-	if err != nil {
-		// If anonymous login, disallow.
-		if authTag == nil {
-			return errors.Errorf("anonymous login blocked because restore is in progress")
-		}
-		switch authTag := authTag.(type) {
-		case names.UserTag:
-			// use a restricted API mode
-			return err
-		case names.MachineTag:
-			if authTag == a.Tag() {
-				// allow logins from the local machine
-				return nil
-			}
-		}
-		return errors.Errorf("login for %q blocked because restore is in progress", authTag)
-	}
-	return nil
-}
-
-// limitLoginsDuringUpgrade is called by the API server for each login
-// attempt. It returns an error if upgrades are in progress unless the
-// login is for a user (i.e. a client) or the local machine.
-func (a *MachineAgent) limitLoginsDuringUpgrade(authTag names.Tag) error {
-	if a.isUpgradeRunning() || a.isInitialUpgradeCheckPending() {
-		// If anonymous login, disallow.
-		if authTag == nil {
-			return errors.Errorf("anonymous login blocked because %s", params.CodeUpgradeInProgress)
-		}
-		switch authTag := authTag.(type) {
-		case names.UserTag:
-			// use a restricted API mode
-			return params.UpgradeInProgressError
-		case names.MachineTag:
-			if authTag == a.Tag() {
-				// allow logins from the local machine
-				return nil
-			}
-		}
-		return errors.Errorf("login for %q blocked because %s", authTag, params.CodeUpgradeInProgress)
-	} else {
-		return nil // allow all logins
-	}
 }
 
 // ensureMongoServer ensures that mongo is installed and running,

--- a/cmd/jujud/agent/machine_test.go
+++ b/cmd/jujud/agent/machine_test.go
@@ -61,7 +61,6 @@ import (
 	"github.com/juju/juju/worker/instancepoller"
 	"github.com/juju/juju/worker/machiner"
 	"github.com/juju/juju/worker/migrationmaster"
-	"github.com/juju/juju/worker/mongoupgrader"
 	"github.com/juju/juju/worker/peergrouper"
 	"github.com/juju/juju/worker/storageprovisioner"
 	"github.com/juju/juju/worker/upgrader"
@@ -895,30 +894,6 @@ func (s *MachineSuite) TestMachineAgentRunsDiskManagerWorker(c *gc.C) {
 	go func() { c.Check(a.Run(nil), jc.ErrorIsNil) }()
 	defer func() { c.Check(a.Stop(), jc.ErrorIsNil) }()
 	started.assertTriggered(c, "diskmanager worker to start")
-}
-
-func (s *MachineSuite) TestMongoUpgradeWorker(c *gc.C) {
-	// Patch out the worker func before starting the agent.
-	started := make(chan struct{})
-	newWorker := func(*state.State, string, mongoupgrader.StopMongo) (worker.Worker, error) {
-		close(started)
-		return jworker.NewNoOpWorker(), nil
-	}
-	s.PatchValue(&newUpgradeMongoWorker, newWorker)
-
-	// Start the machine agent.
-	m, _, _ := s.primeAgent(c, state.JobManageModel)
-	a := s.newAgent(c, m)
-	go func() { c.Check(a.Run(nil), jc.ErrorIsNil) }()
-	defer func() { c.Check(a.Stop(), jc.ErrorIsNil) }()
-
-	// Wait for worker to be started.
-	s.State.StartSync()
-	select {
-	case <-started:
-	case <-time.After(coretesting.LongWait):
-		c.Fatalf("timeout while waiting for mongo upgrader worker to start")
-	}
 }
 
 func (s *MachineSuite) TestDiskManagerWorkerUpdatesState(c *gc.C) {

--- a/cmd/jujud/agent/machine_test.go
+++ b/cmd/jujud/agent/machine_test.go
@@ -528,7 +528,7 @@ func (s *MachineSuite) TestUpgradeRequest(c *gc.C) {
 	m, _, currentTools := s.primeAgent(c, state.JobManageModel, state.JobHostUnits)
 	a := s.newAgent(c, m)
 	s.testUpgradeRequest(c, a, m.Tag().String(), currentTools)
-	c.Assert(a.isInitialUpgradeCheckPending(), jc.IsTrue)
+	c.Assert(a.initialUpgradeCheckComplete.IsUnlocked(), jc.IsFalse)
 }
 
 func (s *MachineSuite) TestNoUpgradeRequired(c *gc.C) {
@@ -543,7 +543,7 @@ func (s *MachineSuite) TestNoUpgradeRequired(c *gc.C) {
 	}
 	defer a.Stop() // in case of failure
 	s.waitStopped(c, state.JobManageModel, a, done)
-	c.Assert(a.isInitialUpgradeCheckPending(), jc.IsFalse)
+	c.Assert(a.initialUpgradeCheckComplete.IsUnlocked(), jc.IsTrue)
 }
 
 func (s *MachineSuite) waitStopped(c *gc.C, job state.MachineJob, a *MachineAgent, done chan error) {
@@ -1178,53 +1178,6 @@ func (s *MachineSuite) TestMachineAgentIgnoreAddressesContainer(c *gc.C) {
 		c.Fatalf("timed out waiting for the machiner to start")
 	}
 	s.waitStopped(c, state.JobHostUnits, a, doneCh)
-}
-
-func (s *MachineSuite) TestMachineAgentSetsPrepareRestore(c *gc.C) {
-	// Start the machine agent.
-	m, _, _ := s.primeAgent(c, state.JobHostUnits)
-	a := s.newAgent(c, m)
-	go func() { c.Check(a.Run(nil), jc.ErrorIsNil) }()
-	defer func() { c.Check(a.Stop(), jc.ErrorIsNil) }()
-	c.Check(a.IsRestorePreparing(), jc.IsFalse)
-	c.Check(a.IsRestoreRunning(), jc.IsFalse)
-	err := a.PrepareRestore()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(a.IsRestorePreparing(), jc.IsTrue)
-	c.Assert(a.IsRestoreRunning(), jc.IsFalse)
-	err = a.PrepareRestore()
-	c.Assert(err, gc.ErrorMatches, "already in restore mode")
-}
-
-func (s *MachineSuite) TestMachineAgentSetsRestoreInProgress(c *gc.C) {
-	// Start the machine agent.
-	m, _, _ := s.primeAgent(c, state.JobHostUnits)
-	a := s.newAgent(c, m)
-	go func() { c.Check(a.Run(nil), jc.ErrorIsNil) }()
-	defer func() { c.Check(a.Stop(), jc.ErrorIsNil) }()
-	c.Check(a.IsRestorePreparing(), jc.IsFalse)
-	c.Check(a.IsRestoreRunning(), jc.IsFalse)
-	err := a.PrepareRestore()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(a.IsRestorePreparing(), jc.IsTrue)
-	err = a.BeginRestore()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(a.IsRestoreRunning(), jc.IsTrue)
-	err = a.BeginRestore()
-	c.Assert(err, gc.ErrorMatches, "already restoring")
-}
-
-func (s *MachineSuite) TestMachineAgentRestoreRequiresPrepare(c *gc.C) {
-	// Start the machine agent.
-	m, _, _ := s.primeAgent(c, state.JobHostUnits)
-	a := s.newAgent(c, m)
-	go func() { c.Check(a.Run(nil), jc.ErrorIsNil) }()
-	defer func() { c.Check(a.Stop(), jc.ErrorIsNil) }()
-	c.Check(a.IsRestorePreparing(), jc.IsFalse)
-	c.Check(a.IsRestoreRunning(), jc.IsFalse)
-	err := a.BeginRestore()
-	c.Assert(err, gc.ErrorMatches, "not in restore mode, cannot begin restoration")
-	c.Assert(a.IsRestoreRunning(), jc.IsFalse)
 }
 
 func (s *MachineSuite) TestMachineWorkers(c *gc.C) {

--- a/provider/dummy/environs.go
+++ b/provider/dummy/environs.go
@@ -849,6 +849,12 @@ func (e *environ) Bootstrap(ctx environs.BootstrapContext, args environs.Bootstr
 					}))
 				},
 				RateLimitConfig: apiserver.DefaultRateLimitConfig(),
+				UpgradeComplete: func() bool {
+					return true
+				},
+				RestoreStatus: func() state.RestoreStatus {
+					return state.RestoreNotActive
+				},
 			})
 			if err != nil {
 				statePool.Close()


### PR DESCRIPTION
## Description of change

When a controller machine agent is running
upgrade steps, or is restoring, we now check
the model when allowing through agents with
the same tag as the controller machine agent.

Move the upgrade/restore checks into the
apiserver package itself, and get rid of
the "LoginValidator". The agent just passes
in functions that the API server can call
to check the current upgrade or restore
status. The "mongoupgrade" worker is no
longer run by the machine agent; it is no
longer required, and allows us to simplify
the login logic.

Removed some tests from the machine agent
related to restore status, which weren't really
testing anything meaningful. We should move the
restore watching code to the API server in 2.4,
and test it properly. See:
  https://bugs.launchpad.net/juju/+bug/1733552

## QA steps

1. juju bootstrap localhost
2. juju enable-ha
3. juju deploy ubuntu
4. juju upgrade-juju -m controller --build-agent
(tail logs, check for errors indicating that agents can't log into each other)

## Documentation changes

None.

## Bug reference

Fixes https://bugs.launchpad.net/juju/+bug/1733250