### PR TITLE
acceptancetests: Really make migration test wait for subordinates to be ready

### DIFF
--- a/acceptancetests/jujupy/status.py
+++ b/acceptancetests/jujupy/status.py
@@ -297,8 +297,15 @@ class Status:
     def get_unit(self, unit_name):
         """Return metadata about a unit."""
         for name, service in sorted(self.get_applications().items()):
-            if unit_name in service.get('units', {}):
+            units = service.get('units', {})
+            if unit_name in units:
                 return service['units'][unit_name]
+            # The unit might be a subordinate, in which case it won't
+            # be under its application, but under the principal
+            # unit.
+            for _, unit in units.items():
+                if unit_name in unit.get('subordinates', {}):
+                    return unit['subordinates'][unit_name]
         raise KeyError(unit_name)
 
     def service_subordinate_units(self, service_name):


### PR DESCRIPTION
## Description of change

The previous PR #8073 didn't work - the test would still sometimes fail on the precheck for missing scopes, because the ntp units hadn't finished entering the relation scope. Waiting for all existing units to be idle didn't work because the ntp units hadn't been created at that point.

Explicitly wait for the ntp/0 and ntp/1 units to be idle instead.

## QA steps

Run the model migration acceptance test (ideally multiple times) and see that it doesn't fail because of prechecks.
