### PR TITLE
Juju should not prune incomplete actions.

### DIFF
--- a/state/prune.go
+++ b/state/prune.go
@@ -84,16 +84,19 @@ func (p *collectionPruner) pruneByAge() error {
 
 	t := p.st.clock().Now().Add(-p.maxAge)
 	var age interface{}
+	var notSet interface{}
 
 	if p.timeUnit == NanoSeconds {
 		age = t.UnixNano()
+		notSet = 0
 	} else {
 		age = t
+		notSet = time.Time{}
 	}
 
 	iter := p.coll.Find(bson.D{
 		{"model-uuid", p.st.modelUUID()},
-		{p.ageField, bson.M{"$lt": age}},
+		{p.ageField, bson.M{"$gt": notSet, "$lt": age}},
 	}).Select(bson.M{"_id": 1}).Iter()
 
 	modelName, err := p.st.modelName()


### PR DESCRIPTION
## Please provide the following details to expedite Pull Request review:


## Description of change

Pruner is pruning seemingly newer actions while leaving older ones in place. The opposite of its intended behavior.

see: referenced bug 

## QA steps

Rig your setup so that the pruner runs frequently by faking out your system clock or altering the code (or by some other method)

deploy something simple like ubuntu:

```
juju deploy ubuntu
```

run

```
for i in {1..100}; do juju run --unit=ubuntu/0 sleep 5 && hostname; done
```

You should get intermittent errors like this

```
unit-ubuntu-0: 17:53:49 ERROR juju.worker.dependency "uniter" manifold worker returned unexpected error: executing operation "run action fb3613e4-6858-42d5-8c03-92e0009bbfc0": running action "juju-run": action "fb3613e4-6858-42d5-8c03-92e0009bbfc0" not found
```

Once this commit is applied we see the problem goes away.

## Documentation changes

N/A

## Bug reference

https://bugs.launchpad.net/juju/+bug/1729880
