### PR TITLE
Add initial jujud operator

### DIFF
--- a/agent/tools/symlinks.go
+++ b/agent/tools/symlinks.go
@@ -1,7 +1,7 @@
-// Copyright 2012, 2013 Canonical Ltd.
+// Copyright 2017 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package jujuc
+package tools
 
 import (
 	"os"
@@ -13,14 +13,14 @@ import (
 	"github.com/juju/juju/juju/names"
 )
 
-// EnsureSymlinks creates a symbolic link to jujuc within dir for each
-// hook command. If the commands already exist, this operation does nothing.
+// EnsureSymlinks creates a symbolic link to jujud within dir for each
+// command. If the commands already exist, this operation does nothing.
 // If dir is a symbolic link, it will be dereferenced first.
-func EnsureSymlinks(dir string) (err error) {
+func EnsureSymlinks(jujuDir, dir string, commands []string) (err error) {
 	logger.Infof("ensure jujuc symlinks in %s", dir)
 	defer func() {
 		if err != nil {
-			err = errors.Annotatef(err, "cannot initialize hook commands in %q", dir)
+			err = errors.Annotatef(err, "cannot initialize commands in %q", dir)
 		}
 	}()
 	isSymlink, err := symlink.IsSymlink(dir)
@@ -40,9 +40,9 @@ func EnsureSymlinks(dir string) (err error) {
 		logger.Infof("was a symlink, now looking at %s", dir)
 	}
 
-	jujudPath := filepath.Join(dir, names.Jujud)
+	jujudPath := filepath.Join(jujuDir, names.Jujud)
 	logger.Debugf("jujud path %s", jujudPath)
-	for _, name := range CommandNames() {
+	for _, name := range commands {
 		// The link operation fails when the target already exists,
 		// so this is a no-op when the command names already
 		// exist.

--- a/agent/tools/tools_test.go
+++ b/agent/tools/tools_test.go
@@ -40,7 +40,7 @@ func (t *ToolsSuite) TestPackageDependencies(c *gc.C) {
 	// resulting slice has that prefix removed to keep the output short.
 	c.Assert(testing.FindJujuCoreImports(c, "github.com/juju/juju/agent/tools"),
 		gc.DeepEquals,
-		[]string{"tools"})
+		[]string{"juju/names", "tools"})
 }
 
 // gzyesses holds the result of running:

--- a/api/caasprovisioner/client.go
+++ b/api/caasprovisioner/client.go
@@ -8,6 +8,7 @@ import (
 	apiwatcher "github.com/juju/juju/api/watcher"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/watcher"
+	"gopkg.in/juju/names.v2"
 )
 
 // Client allows access to the CAAS provisioner API endpoint.
@@ -25,14 +26,37 @@ func NewClient(caller base.APICaller) *Client {
 
 // WatchApplications returns a StringsWatcher that notifies of
 // changes to the lifecycles of CAAS applications in the current model.
-func (st *Client) WatchApplications() (watcher.StringsWatcher, error) {
+func (c *Client) WatchApplications() (watcher.StringsWatcher, error) {
 	var result params.StringsWatchResult
-	if err := st.facade.FacadeCall("WatchApplications", nil, &result); err != nil {
+	if err := c.facade.FacadeCall("WatchApplications", nil, &result); err != nil {
 		return nil, err
 	}
 	if err := result.Error; err != nil {
 		return nil, result.Error
 	}
-	w := apiwatcher.NewStringsWatcher(st.facade.RawAPICaller(), result)
+	w := apiwatcher.NewStringsWatcher(c.facade.RawAPICaller(), result)
 	return w, nil
+}
+
+// ApplicationPassword holds parameters for setting
+// an application password.
+type ApplicationPassword struct {
+	Name     string
+	Password string
+}
+
+// SetPasswords sets API passwords for the specified applications.
+func (c *Client) SetPasswords(appPasswords []ApplicationPassword) error {
+	var result params.ErrorResults
+	args := params.EntityPasswords{Changes: make([]params.EntityPassword, len(appPasswords))}
+	for i, p := range appPasswords {
+		args.Changes[i] = params.EntityPassword{
+			Tag: names.NewApplicationTag(p.Name).String(), Password: p.Password,
+		}
+	}
+	err := c.facade.FacadeCall("SetPasswords", args, &result)
+	if err != nil {
+		return err
+	}
+	return result.Combine()
 }

--- a/apiserver/authcontext.go
+++ b/apiserver/authcontext.go
@@ -169,7 +169,7 @@ func (a authenticator) authenticatorForTag(tag names.Tag) (authentication.Entity
 		return auth, nil
 	}
 	switch tag.Kind() {
-	case names.UnitTagKind, names.MachineTagKind:
+	case names.UnitTagKind, names.MachineTagKind, names.ApplicationTagKind:
 		return &a.ctxt.agentAuth, nil
 	case names.UserTagKind:
 		return a.localUserAuth(), nil

--- a/apiserver/authenticator_test.go
+++ b/apiserver/authenticator_test.go
@@ -77,7 +77,7 @@ func (s *agentAuthenticatorSuite) TestUnitGetsAgentAuthenticator(c *gc.C) {
 func (s *agentAuthenticatorSuite) TestNotSupportedTag(c *gc.C) {
 	_, srv := newServer(c, s.pool)
 	defer srv.Stop()
-	authenticator, err := apiserver.ServerAuthenticatorForTag(srv, names.NewApplicationTag("not-support"))
+	authenticator, err := apiserver.ServerAuthenticatorForTag(srv, names.NewCloudTag("not-support"))
 	c.Assert(err, gc.ErrorMatches, "unexpected login entity tag: invalid request")
 	c.Assert(authenticator, gc.IsNil)
 }

--- a/apiserver/facades/agent/caasprovisioner/mock_test.go
+++ b/apiserver/facades/agent/caasprovisioner/mock_test.go
@@ -4,7 +4,9 @@
 package caasprovisioner_test
 
 import (
+	"github.com/juju/errors"
 	"github.com/juju/testing"
+	"gopkg.in/juju/names.v2"
 	"gopkg.in/tomb.v1"
 
 	"github.com/juju/juju/state"
@@ -13,6 +15,7 @@ import (
 type mockState struct {
 	testing.Stub
 	applicationWatcher *mockStringsWatcher
+	app                *mockApplication
 }
 
 func newMockState() *mockState {
@@ -24,6 +27,28 @@ func newMockState() *mockState {
 func (st *mockState) WatchApplications() state.StringsWatcher {
 	st.MethodCall(st, "WatchApplications")
 	return st.applicationWatcher
+}
+
+func (st *mockState) FindEntity(tag names.Tag) (state.Entity, error) {
+	if st.app.tag == tag {
+		return st.app, nil
+	}
+	return nil, errors.NotFoundf("entity %v", tag)
+}
+
+type mockApplication struct {
+	state.Authenticator
+	tag      names.Tag
+	password string
+}
+
+func (m *mockApplication) Tag() names.Tag {
+	return m.tag
+}
+
+func (m *mockApplication) SetPassword(password string) error {
+	m.password = password
+	return nil
 }
 
 type mockWatcher struct {

--- a/apiserver/facades/agent/caasprovisioner/provisioner.go
+++ b/apiserver/facades/agent/caasprovisioner/provisioner.go
@@ -4,8 +4,6 @@
 package caasprovisioner
 
 import (
-	"gopkg.in/juju/names.v2"
-
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/apiserver/params"
@@ -38,14 +36,8 @@ func NewCAASProvisionerAPI(
 	if !authorizer.AuthController() {
 		return nil, common.ErrPerm
 	}
-	getAuthFunc := func() (common.AuthFunc, error) {
-		return func(names.Tag) bool {
-			return authorizer.AuthController()
-		}, nil
-	}
-
 	return &API{
-		PasswordChanger: common.NewPasswordChanger(st, getAuthFunc),
+		PasswordChanger: common.NewPasswordChanger(st, common.AuthAlways()),
 		auth:            authorizer,
 		resources:       resources,
 		state:           st,

--- a/apiserver/facades/agent/caasprovisioner/provisioner.go
+++ b/apiserver/facades/agent/caasprovisioner/provisioner.go
@@ -4,6 +4,8 @@
 package caasprovisioner
 
 import (
+	"gopkg.in/juju/names.v2"
+
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/apiserver/params"
@@ -11,6 +13,8 @@ import (
 )
 
 type API struct {
+	*common.PasswordChanger
+
 	auth      facade.Authorizer
 	resources facade.Resources
 
@@ -34,11 +38,17 @@ func NewCAASProvisionerAPI(
 	if !authorizer.AuthController() {
 		return nil, common.ErrPerm
 	}
+	getAuthFunc := func() (common.AuthFunc, error) {
+		return func(names.Tag) bool {
+			return authorizer.AuthController()
+		}, nil
+	}
 
 	return &API{
-		auth:      authorizer,
-		resources: resources,
-		state:     st,
+		PasswordChanger: common.NewPasswordChanger(st, getAuthFunc),
+		auth:            authorizer,
+		resources:       resources,
+		state:           st,
 	}, nil
 }
 

--- a/apiserver/facades/agent/caasprovisioner/provisioner_test.go
+++ b/apiserver/facades/agent/caasprovisioner/provisioner_test.go
@@ -68,8 +68,8 @@ func (s *CAASProvisionerSuite) TestWatchApplications(c *gc.C) {
 
 func (s *CAASProvisionerSuite) TestSetPasswords(c *gc.C) {
 	s.st.app = &mockApplication{
-		tag: names.NewApplicationTag("app")}
-	s.authorizer.Controller = true
+		tag: names.NewApplicationTag("app"),
+	}
 
 	args := params.EntityPasswords{
 		Changes: []params.EntityPassword{

--- a/apiserver/facades/agent/caasprovisioner/state.go
+++ b/apiserver/facades/agent/caasprovisioner/state.go
@@ -4,6 +4,8 @@
 package caasprovisioner
 
 import (
+	"gopkg.in/juju/names.v2"
+
 	"github.com/juju/juju/state"
 )
 
@@ -11,4 +13,5 @@ import (
 // required by the CAAS provisioner facade.
 type CAASProvisionerState interface {
 	WatchApplications() state.StringsWatcher
+	FindEntity(tag names.Tag) (state.Entity, error)
 }

--- a/caas/broker.go
+++ b/caas/broker.go
@@ -10,7 +10,7 @@ type NewContainerBrokerFunc func(environs.CloudSpec) (Broker, error)
 
 // NewOperatorConfigFunc functions return the agent config to use for
 // a CAAS jujud operator.
-type NewOperatorConfigFunc func(appName string) (*OperatorConfig, error)
+type NewOperatorConfigFunc func() (*OperatorConfig, error)
 
 // Broker instances interact with the CAAS substrate.
 type Broker interface {

--- a/cmd/jujud/agent/agenttest/engine.go
+++ b/cmd/jujud/agent/agenttest/engine.go
@@ -1,0 +1,189 @@
+// Copyright 2012, 2013 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package agenttest
+
+import (
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/juju/errors"
+	"github.com/juju/utils/set"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/worker.v1"
+	goyaml "gopkg.in/yaml.v2"
+
+	coretesting "github.com/juju/juju/testing"
+	"github.com/juju/juju/worker/dependency"
+)
+
+// NewWorkerMatcher takes an EngineTracker, an engine manager id to
+// monitor and the workers that are expected to be running and sets up
+// a WorkerMatcher.
+func NewWorkerMatcher(c *gc.C, tracker *EngineTracker, id string, workers []string) *WorkerMatcher {
+	return &WorkerMatcher{
+		c:       c,
+		tracker: tracker,
+		id:      id,
+		expect:  set.NewStrings(workers...),
+	}
+}
+
+// WorkerMatcher monitors the workers of a single engine manager,
+// using an EngineTracker, for a given set of workers to be running.
+type WorkerMatcher struct {
+	c         *gc.C
+	tracker   *EngineTracker
+	id        string
+	expect    set.Strings
+	matchTime time.Time
+}
+
+// Check returns true if the workers which are expected to be running
+// (as specified in the call to NewWorkerMatcher) are running and have
+// been running for a short period (i.e. some indication of stability).
+func (m *WorkerMatcher) Check() bool {
+	if m.checkOnce() {
+		now := time.Now()
+		if m.matchTime.IsZero() {
+			m.matchTime = now
+			return false
+		}
+		// Only return that the required workers have started if they
+		// have been stable for a little while.
+		return now.Sub(m.matchTime) >= time.Second
+	}
+	// Required workers not running, reset the timestamp.
+	m.matchTime = time.Time{}
+	return false
+}
+
+func (m *WorkerMatcher) checkOnce() bool {
+	actual := m.tracker.Workers(m.id)
+	m.c.Logf("\n%s: has workers %v", m.id, actual.SortedValues())
+	extras := actual.Difference(m.expect)
+	missed := m.expect.Difference(actual)
+	if len(extras) == 0 && len(missed) == 0 {
+		return true
+	}
+	m.c.Logf("%s: waiting for %v", m.id, missed.SortedValues())
+	m.c.Logf("%s: unexpected %v", m.id, extras.SortedValues())
+	report, _ := goyaml.Marshal(m.tracker.Report(m.id))
+	m.c.Logf("%s: report: \n%s\n", m.id, report)
+	return false
+}
+
+// WaitMatch returns only when the match func succeeds, or it times out.
+func WaitMatch(c *gc.C, match func() bool, maxWait time.Duration, sync func()) {
+	timeout := time.After(maxWait)
+	for {
+		if match() {
+			return
+		}
+		select {
+		case <-time.After(coretesting.ShortWait):
+			sync()
+		case <-timeout:
+			c.Fatalf("timed out waiting for workers")
+		}
+	}
+}
+
+// NewEngineTracker creates a type that can Install itself into a
+// Manifolds map, and expose recent snapshots of running Workers.
+func NewEngineTracker() *EngineTracker {
+	return &EngineTracker{
+		current: make(map[string]set.Strings),
+		reports: make(map[string]map[string]interface{}),
+	}
+}
+
+// EngineTracker tracks workers which have started.
+type EngineTracker struct {
+	mu      sync.Mutex
+	current map[string]set.Strings
+	reports map[string]map[string]interface{}
+}
+
+// Workers returns the most-recently-reported set of running workers.
+func (tracker *EngineTracker) Workers(id string) set.Strings {
+	tracker.mu.Lock()
+	defer tracker.mu.Unlock()
+	return tracker.current[id]
+}
+
+// Report returns the most-recently-reported self-report. It will
+// only work if you hack up the relevant engine-starting code to
+// include:
+//
+//    manifolds["self"] = dependency.SelfManifold(engine)
+//
+// or otherwise inject a suitable "self" manifold.
+func (tracker *EngineTracker) Report(id string) map[string]interface{} {
+	tracker.mu.Lock()
+	defer tracker.mu.Unlock()
+	return tracker.reports[id]
+}
+
+// Install injects a manifold named TEST-TRACKER into raw, which will
+// depend on all other manifolds in raw and write currently-available
+// worker information to the tracker (differentiating it from other
+// tracked engines via the id param).
+func (tracker *EngineTracker) Install(raw dependency.Manifolds, id string) error {
+	const trackerName = "TEST-TRACKER"
+
+	names := make([]string, 0, len(raw))
+	for name := range raw {
+		if name == trackerName {
+			return errors.New("engine tracker installed repeatedly")
+		}
+		names = append(names, name)
+	}
+
+	tracker.mu.Lock()
+	defer tracker.mu.Unlock()
+	if _, exists := tracker.current[id]; exists {
+		return errors.Errorf("manifolds for %s created repeatedly", id)
+	}
+	raw[trackerName] = dependency.Manifold{
+		Inputs: append(names, "self"),
+		Start:  tracker.startFunc(id, names),
+	}
+	return nil
+}
+
+func (tracker *EngineTracker) startFunc(id string, names []string) dependency.StartFunc {
+	return func(context dependency.Context) (worker.Worker, error) {
+
+		seen := set.NewStrings()
+		for _, name := range names {
+			err := context.Get(name, nil)
+			switch errors.Cause(err) {
+			case nil:
+			case dependency.ErrMissing:
+				continue
+			default:
+				name = fmt.Sprintf("%s [%v]", name, err)
+			}
+			seen.Add(name)
+		}
+
+		var report map[string]interface{}
+		var reporter dependency.Reporter
+		if err := context.Get("self", &reporter); err == nil {
+			report = reporter.Report()
+		}
+
+		select {
+		case <-context.Abort():
+			// don't bother to report if it's about to change
+		default:
+			tracker.mu.Lock()
+			defer tracker.mu.Unlock()
+			tracker.current[id] = seen
+			tracker.reports[id] = report
+		}
+		return nil, dependency.ErrMissing
+	}
+}

--- a/cmd/jujud/agent/caasoperator.go
+++ b/cmd/jujud/agent/caasoperator.go
@@ -30,9 +30,9 @@ import (
 )
 
 var (
-
-	// should be an explicit dependency, can't do it cleanly yet
-	caasOperatorManifolds = caasoperator.Manifolds
+	// Should be an explicit dependency, can't do it cleanly yet.
+	// Exported for testing.
+	CaasOperatorManifolds = caasoperator.Manifolds
 )
 
 // CaasOperatorAgent is a cmd.Command responsible for running a CAAS operator agent.
@@ -133,15 +133,15 @@ func (op *CaasOperatorAgent) Run(ctx *cmd.Context) error {
 		logger.Warningf("developer feature flags enabled: %s", flags)
 	}
 
-	op.runner.StartWorker("api", op.APIWorkers)
+	op.runner.StartWorker("api", op.Workers)
 	err := cmdutil.AgentDone(logger, op.runner.Wait())
 	op.tomb.Kill(err)
 	return err
 }
 
-// APIWorkers returns a dependency.Engine running the operator's responsibilities.
-func (op *CaasOperatorAgent) APIWorkers() (worker.Worker, error) {
-	manifolds := caasOperatorManifolds(caasoperator.ManifoldsConfig{
+// Workers returns a dependency.Engine running the operator's responsibilities.
+func (op *CaasOperatorAgent) Workers() (worker.Worker, error) {
+	manifolds := CaasOperatorManifolds(caasoperator.ManifoldsConfig{
 		Agent:                op,
 		AgentDir:             filepath.Dir(os.Args[0]),
 		LogSource:            op.bufferedLogger.Logs(),

--- a/cmd/jujud/agent/caasoperator.go
+++ b/cmd/jujud/agent/caasoperator.go
@@ -1,0 +1,186 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package agent
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"time"
+
+	"github.com/juju/cmd"
+	"github.com/juju/errors"
+	"github.com/juju/gnuflag"
+	"github.com/juju/utils/featureflag"
+	"github.com/prometheus/client_golang/prometheus"
+	"gopkg.in/juju/names.v2"
+	"gopkg.in/juju/worker.v1"
+	"gopkg.in/natefinch/lumberjack.v2"
+	"gopkg.in/tomb.v1"
+
+	"github.com/juju/juju/agent"
+	"github.com/juju/juju/cmd/jujud/agent/caasoperator"
+	cmdutil "github.com/juju/juju/cmd/jujud/util"
+	jujuversion "github.com/juju/juju/version"
+	jworker "github.com/juju/juju/worker"
+	"github.com/juju/juju/worker/dependency"
+	"github.com/juju/juju/worker/introspection"
+	"github.com/juju/juju/worker/logsender"
+)
+
+var (
+
+	// should be an explicit dependency, can't do it cleanly yet
+	caasOperatorManifolds = caasoperator.Manifolds
+)
+
+// CaasOperatorAgent is a cmd.Command responsible for running a CAAS operator agent.
+type CaasOperatorAgent struct {
+	cmd.CommandBase
+	tomb tomb.Tomb
+	AgentConf
+	ApplicationName string
+	runner          *worker.Runner
+	bufferedLogger  *logsender.BufferedLogWriter
+	setupLogging    func(agent.Config) error
+	logToStdErr     bool
+	ctx             *cmd.Context
+
+	// Used to signal that the upgrade worker will not
+	// reboot the agent on startup because there are no
+	// longer any immediately pending agent upgrades.
+	// Channel used as a selectable bool (closed means true).
+	initialUpgradeCheckComplete chan struct{}
+
+	prometheusRegistry *prometheus.Registry
+}
+
+// NewCaasOperatorAgent creates a new CAASOperatorAgent instance properly initialized.
+func NewCaasOperatorAgent(ctx *cmd.Context, bufferedLogger *logsender.BufferedLogWriter) (*CaasOperatorAgent, error) {
+	prometheusRegistry, err := newPrometheusRegistry()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return &CaasOperatorAgent{
+		AgentConf: NewAgentConf(""),
+		ctx:       ctx,
+		initialUpgradeCheckComplete: make(chan struct{}),
+		bufferedLogger:              bufferedLogger,
+		prometheusRegistry:          prometheusRegistry,
+	}, nil
+}
+
+// Info implements Command.
+func (op *CaasOperatorAgent) Info() *cmd.Info {
+	return &cmd.Info{
+		Name:    "caasoperator",
+		Purpose: "run a juju CAAS Operator",
+	}
+}
+
+// SetFlags implements Command.
+func (op *CaasOperatorAgent) SetFlags(f *gnuflag.FlagSet) {
+	op.AgentConf.AddFlags(f)
+	f.StringVar(&op.ApplicationName, "application-name", "", "name of the application")
+	f.BoolVar(&op.logToStdErr, "log-to-stderr", false, "whether to log to standard error instead of log files")
+}
+
+// Init initializes the command for running.
+func (op *CaasOperatorAgent) Init(args []string) error {
+	if op.ApplicationName == "" {
+		return cmdutil.RequiredError("application-name")
+	}
+	if !names.IsValidApplication(op.ApplicationName) {
+		return errors.Errorf(`--application-name option expects "<application>" argument`)
+	}
+	if err := op.AgentConf.CheckArgs(args); err != nil {
+		return err
+	}
+	op.runner = worker.NewRunner(worker.RunnerParams{IsFatal: cmdutil.IsFatal, MoreImportant: cmdutil.MoreImportant, RestartDelay: jworker.RestartDelay})
+
+	if !op.logToStdErr {
+		if err := op.ReadConfig(op.Tag().String()); err != nil {
+			return err
+		}
+		operatorConfig := op.CurrentConfig()
+
+		// the writer in ctx.stderr gets set as the loggo writer in github.com/juju/cmd/logging.go
+		op.ctx.Stderr = &lumberjack.Logger{
+			Filename:   agent.LogFilename(operatorConfig),
+			MaxSize:    300, // megabytes
+			MaxBackups: 2,
+		}
+
+	}
+	return nil
+}
+
+// Stop implements Worker.
+func (op *CaasOperatorAgent) Stop() error {
+	op.runner.Kill()
+	return op.tomb.Wait()
+}
+
+// Run implements Command.
+func (op *CaasOperatorAgent) Run(ctx *cmd.Context) error {
+	defer op.tomb.Done()
+	if err := op.ReadConfig(op.Tag().String()); err != nil {
+		return err
+	}
+	logger.Infof("caas operator %v start (%s [%s])", op.Tag().String(), jujuversion.Current, runtime.Compiler)
+	if flags := featureflag.String(); flags != "" {
+		logger.Warningf("developer feature flags enabled: %s", flags)
+	}
+
+	op.runner.StartWorker("api", op.APIWorkers)
+	err := cmdutil.AgentDone(logger, op.runner.Wait())
+	op.tomb.Kill(err)
+	return err
+}
+
+// APIWorkers returns a dependency.Engine running the operator's responsibilities.
+func (op *CaasOperatorAgent) APIWorkers() (worker.Worker, error) {
+	manifolds := caasOperatorManifolds(caasoperator.ManifoldsConfig{
+		Agent:                op,
+		AgentDir:             filepath.Dir(os.Args[0]),
+		LogSource:            op.bufferedLogger.Logs(),
+		PrometheusRegisterer: op.prometheusRegistry,
+	})
+
+	config := dependency.EngineConfig{
+		IsFatal:     cmdutil.IsFatal,
+		WorstError:  cmdutil.MoreImportantError,
+		ErrorDelay:  3 * time.Second,
+		BounceDelay: 10 * time.Millisecond,
+	}
+	engine, err := dependency.NewEngine(config)
+	if err != nil {
+		return nil, err
+	}
+	if err := dependency.Install(engine, manifolds); err != nil {
+		if err := worker.Stop(engine); err != nil {
+			logger.Errorf("while stopping engine with bad manifolds: %v", err)
+		}
+		return nil, err
+	}
+	if err := startIntrospection(introspectionConfig{
+		Agent:              op,
+		Engine:             engine,
+		NewSocketName:      DefaultIntrospectionSocketName,
+		PrometheusGatherer: op.prometheusRegistry,
+		WorkerFunc:         introspection.NewWorker,
+	}); err != nil {
+		// If the introspection worker failed to start, we just log error
+		// but continue. It is very unlikely to happen in the real world
+		// as the only issue is connecting to the abstract domain socket
+		// and the agent is controlled by by the OS to only have one.
+		logger.Errorf("failed to start introspection worker: %v", err)
+	}
+	return engine, nil
+}
+
+// Tag implements Agent.
+func (op *CaasOperatorAgent) Tag() names.Tag {
+	return names.NewApplicationTag(op.ApplicationName)
+}

--- a/cmd/jujud/agent/caasoperator/manifolds.go
+++ b/cmd/jujud/agent/caasoperator/manifolds.go
@@ -1,0 +1,77 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package caasoperator
+
+import (
+	"github.com/juju/utils/clock"
+	"github.com/prometheus/client_golang/prometheus"
+
+	coreagent "github.com/juju/juju/agent"
+	"github.com/juju/juju/api"
+	"github.com/juju/juju/worker/agent"
+	"github.com/juju/juju/worker/apicaller"
+	"github.com/juju/juju/worker/caasoperator"
+	"github.com/juju/juju/worker/dependency"
+	"github.com/juju/juju/worker/logsender"
+)
+
+// ManifoldsConfig allows specialisation of the result of Manifolds.
+type ManifoldsConfig struct {
+
+	// Agent contains the agent that will be wrapped and made available to
+	// its dependencies via a dependency.Engine.
+	Agent coreagent.Agent
+
+	// AgentDir is the location of the jujud binary.
+	AgentDir string
+
+	// LogSource will be read from by the logsender component.
+	LogSource logsender.LogRecordCh
+
+	// PrometheusRegisterer is a prometheus.Registerer that may be used
+	// by workers to register Prometheus metric collectors.
+	PrometheusRegisterer prometheus.Registerer
+}
+
+// Manifolds returns a set of co-configured manifolds covering the various
+// responsibilities of a caasoperator agent. It also accepts the logSource
+// argument because we haven't figured out how to thread all the logging bits
+// through a dependency engine yet.
+//
+// Thou Shalt Not Use String Literals In This Function. Or Else.
+func Manifolds(config ManifoldsConfig) dependency.Manifolds {
+
+	return dependency.Manifolds{
+
+		// The agent manifold references the enclosing agent, and is the
+		// foundation stone on which most other manifolds ultimately depend.
+		// (Currently, that is "all manifolds", but consider a shared clock.)
+		agentName: agent.Manifold(config.Agent),
+
+		apiCallerName: apicaller.Manifold(apicaller.ManifoldConfig{
+			AgentName:     agentName,
+			APIOpen:       api.Open,
+			NewConnection: apicaller.OnlyConnect,
+		}),
+
+		// The operator installs and deploys charm containers;
+		// manages the unit's presence in its relations;
+		// creates suboordinate units; runs all the hooks;
+		// sends metrics; etc etc etc.
+
+		operatorName: caasoperator.Manifold(caasoperator.ManifoldConfig{
+			AgentName:            agentName,
+			APICallerName:        apiCallerName,
+			Clock:                clock.WallClock,
+			TranslateResolverErr: caasoperator.TranslateFortressErrors,
+			AgentDir:             config.AgentDir,
+		}),
+	}
+}
+
+const (
+	agentName     = "agent"
+	apiCallerName = "api-caller"
+	operatorName  = "operator"
+)

--- a/cmd/jujud/agent/caasoperator/manifolds_test.go
+++ b/cmd/jujud/agent/caasoperator/manifolds_test.go
@@ -1,0 +1,49 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package caasoperator_test
+
+import (
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/agent"
+	"github.com/juju/juju/cmd/jujud/agent/caasoperator"
+	"github.com/juju/juju/testing"
+)
+
+type ManifoldsSuite struct {
+	testing.BaseSuite
+}
+
+var _ = gc.Suite(&ManifoldsSuite{})
+
+func (s *ManifoldsSuite) TestStartFuncs(c *gc.C) {
+	manifolds := caasoperator.Manifolds(caasoperator.ManifoldsConfig{
+		Agent: fakeAgent{},
+	})
+
+	for name, manifold := range manifolds {
+		c.Logf("checking %q manifold", name)
+		c.Check(manifold.Start, gc.NotNil)
+	}
+}
+
+func (s *ManifoldsSuite) TestManifoldNames(c *gc.C) {
+	config := caasoperator.ManifoldsConfig{}
+	manifolds := caasoperator.Manifolds(config)
+	expectedKeys := []string{
+		"agent",
+		"api-caller",
+		"operator",
+	}
+	keys := make([]string, 0, len(manifolds))
+	for k := range manifolds {
+		keys = append(keys, k)
+	}
+	c.Assert(expectedKeys, jc.SameContents, keys)
+}
+
+type fakeAgent struct {
+	agent.Agent
+}

--- a/cmd/jujud/agent/caasoperator/package_test.go
+++ b/cmd/jujud/agent/caasoperator/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package caasoperator_test
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func TestPackage(t *testing.T) {
+	gc.TestingT(t)
+}

--- a/cmd/jujud/agent/caasoperator_test.go
+++ b/cmd/jujud/agent/caasoperator_test.go
@@ -1,0 +1,228 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package agent
+
+import (
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/juju/cmd"
+	"github.com/juju/cmd/cmdtesting"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/natefinch/lumberjack.v2"
+
+	"github.com/juju/juju/agent"
+	"github.com/juju/juju/cmd/jujud/agent/agenttest"
+	"github.com/juju/juju/state"
+	coretesting "github.com/juju/juju/testing"
+	"github.com/juju/juju/tools"
+	"github.com/juju/juju/worker/caasoperator/commands"
+	"github.com/juju/juju/worker/logsender"
+)
+
+type CAASOperatorSuite struct {
+	coretesting.GitSuite
+	agenttest.AgentSuite
+}
+
+var _ = gc.Suite(&CAASOperatorSuite{})
+
+func (s *CAASOperatorSuite) SetUpSuite(c *gc.C) {
+	s.GitSuite.SetUpSuite(c)
+	s.AgentSuite.SetUpSuite(c)
+}
+
+func (s *CAASOperatorSuite) TearDownSuite(c *gc.C) {
+	s.AgentSuite.TearDownSuite(c)
+	s.GitSuite.TearDownSuite(c)
+}
+
+func (s *CAASOperatorSuite) SetUpTest(c *gc.C) {
+	s.GitSuite.SetUpTest(c)
+	s.AgentSuite.SetUpTest(c)
+}
+
+func (s *CAASOperatorSuite) TearDownTest(c *gc.C) {
+	s.AgentSuite.TearDownTest(c)
+	s.GitSuite.TearDownTest(c)
+}
+
+// primeAgent creates an application, and sets up the application agent's directory.
+// It returns new application and the agent's configuration.
+func (s *CAASOperatorSuite) primeAgent(c *gc.C) (*state.Application, agent.Config, *tools.Tools) {
+	app := s.AddTestingApplication(c, "wordpress", s.AddTestingCharm(c, "wordpress"))
+	err := app.SetPassword(initialApplicationPassword)
+	c.Assert(err, jc.ErrorIsNil)
+	conf, tools := s.PrimeAgent(c, app.Tag(), initialApplicationPassword)
+	return app, conf, tools
+}
+
+func (s *CAASOperatorSuite) newAgent(c *gc.C, app *state.Application) *CaasOperatorAgent {
+	a, err := NewCaasOperatorAgent(nil, s.newBufferedLogWriter())
+	c.Assert(err, jc.ErrorIsNil)
+	s.InitAgent(c, a, "--application-name", app.Name(), "--log-to-stderr=true")
+	err = a.ReadConfig(app.Tag().String())
+	c.Assert(err, jc.ErrorIsNil)
+	return a
+}
+
+func (s *CAASOperatorSuite) newBufferedLogWriter() *logsender.BufferedLogWriter {
+	logger := logsender.NewBufferedLogWriter(1024)
+	s.AddCleanup(func(*gc.C) { logger.Close() })
+	return logger
+}
+
+func (s *CAASOperatorSuite) TestParseSuccess(c *gc.C) {
+	s.primeAgent(c)
+	// Now init actually reads the agent configuration file.
+	// So use the prime agent call which installs a wordpress unit.
+	a, err := NewCaasOperatorAgent(nil, s.newBufferedLogWriter())
+	c.Assert(err, jc.ErrorIsNil)
+	err = cmdtesting.InitCommand(a, []string{
+		"--data-dir", s.DataDir(),
+		"--application-name", "wordpress",
+		"--log-to-stderr",
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(a.AgentConf.DataDir(), gc.Equals, s.DataDir())
+	c.Check(a.ApplicationName, gc.Equals, "wordpress")
+}
+
+func (s *CAASOperatorSuite) TestParseMissing(c *gc.C) {
+	uc, err := NewCaasOperatorAgent(nil, s.newBufferedLogWriter())
+	c.Assert(err, jc.ErrorIsNil)
+	err = cmdtesting.InitCommand(uc, []string{
+		"--data-dir", "jc",
+	})
+
+	c.Assert(err, gc.ErrorMatches, "--application-name option must be set")
+}
+
+func (s *CAASOperatorSuite) TestParseNonsense(c *gc.C) {
+	for _, args := range [][]string{
+		{"--application-name", "wordpress/0"},
+		{"--application-name", "wordpress/seventeen"},
+		{"--application-name", "wordpress/-32"},
+		{"--application-name", "wordpress/wild/9"},
+		{"--application-name", "20"},
+	} {
+		a, err := NewCaasOperatorAgent(nil, s.newBufferedLogWriter())
+		c.Assert(err, jc.ErrorIsNil)
+
+		err = cmdtesting.InitCommand(a, append(args, "--data-dir", "jc"))
+		c.Check(err, gc.ErrorMatches, `--application-name option expects "<application>" argument`)
+	}
+}
+
+func (s *CAASOperatorSuite) TestParseUnknown(c *gc.C) {
+	a, err := NewCaasOperatorAgent(nil, s.newBufferedLogWriter())
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = cmdtesting.InitCommand(a, []string{
+		"--application-name", "wordpress",
+		"thundering typhoons",
+	})
+	c.Check(err, gc.ErrorMatches, `unrecognized args: \["thundering typhoons"\]`)
+}
+
+func waitForApplicationActive(c *gc.C, agentDir string) {
+	timeout := time.After(coretesting.LongWait)
+
+	for {
+		select {
+		case <-timeout:
+			c.Fatalf("no activity detected")
+		case <-time.After(coretesting.ShortWait):
+			link := filepath.Join(agentDir, commands.CommandNames()[0])
+			if _, err := os.Lstat(link); err == nil {
+				target, err := os.Readlink(link)
+				c.Assert(err, jc.ErrorIsNil)
+				c.Assert(target, gc.Equals, filepath.Join(filepath.Dir(os.Args[0]), "jujud"))
+				return
+			}
+		}
+	}
+}
+
+func (s *CAASOperatorSuite) TestRunStop(c *gc.C) {
+	app, config, _ := s.primeAgent(c)
+	a := s.newAgent(c, app)
+	go func() { c.Check(a.Run(nil), gc.IsNil) }()
+	defer func() { c.Check(a.Stop(), gc.IsNil) }()
+	waitForApplicationActive(c, filepath.Join(config.DataDir(), "tools"))
+}
+
+func (s *CAASOperatorSuite) TestOpenStateFails(c *gc.C) {
+	app, config, _ := s.primeAgent(c)
+	a := s.newAgent(c, app)
+	go func() { c.Check(a.Run(nil), gc.IsNil) }()
+	defer func() { c.Check(a.Stop(), gc.IsNil) }()
+	waitForApplicationActive(c, filepath.Join(config.DataDir(), "tools"))
+
+	s.AssertCannotOpenState(c, config.Tag(), config.DataDir())
+}
+
+func (s *CAASOperatorSuite) TestUseLumberjack(c *gc.C) {
+	ctx, err := cmd.DefaultContext()
+	c.Assert(err, gc.IsNil)
+
+	a := CaasOperatorAgent{
+		AgentConf:       FakeAgentConfig{},
+		ctx:             ctx,
+		ApplicationName: "mysql",
+	}
+
+	err = a.Init(nil)
+	c.Assert(err, gc.IsNil)
+
+	l, ok := ctx.Stderr.(*lumberjack.Logger)
+	c.Assert(ok, jc.IsTrue)
+	c.Check(l.MaxAge, gc.Equals, 0)
+	c.Check(l.MaxBackups, gc.Equals, 2)
+	c.Check(l.Filename, gc.Equals, filepath.FromSlash("/var/log/juju/machine-42.log"))
+	c.Check(l.MaxSize, gc.Equals, 300)
+}
+
+func (s *CAASOperatorSuite) TestDontUseLumberjack(c *gc.C) {
+	ctx, err := cmd.DefaultContext()
+	c.Assert(err, gc.IsNil)
+
+	a := CaasOperatorAgent{
+		AgentConf:       FakeAgentConfig{},
+		ctx:             ctx,
+		ApplicationName: "mysql",
+
+		// this is what would get set by the CLI flags to tell us not to log to
+		// the file.
+		logToStdErr: true,
+	}
+
+	err = a.Init(nil)
+	c.Assert(err, gc.IsNil)
+
+	_, ok := ctx.Stderr.(*lumberjack.Logger)
+	c.Assert(ok, jc.IsFalse)
+}
+
+func (s *CAASOperatorSuite) TestWorkers(c *gc.C) {
+	coretesting.SkipIfWindowsBug(c, "lp:1610993")
+	tracker := NewEngineTracker()
+	instrumented := TrackCAASOperator(c, tracker, caasOperatorManifolds)
+	s.PatchValue(&caasOperatorManifolds, instrumented)
+
+	app, _, _ := s.primeAgent(c)
+	ctx := cmdtesting.Context(c)
+	a, err := NewCaasOperatorAgent(ctx, s.newBufferedLogWriter())
+	c.Assert(err, jc.ErrorIsNil)
+	s.InitAgent(c, a, "--application-name", app.Name())
+
+	go func() { c.Check(a.Run(nil), gc.IsNil) }()
+	defer func() { c.Check(a.Stop(), gc.IsNil) }()
+
+	matcher := NewWorkerMatcher(c, tracker, a.Tag().String(),
+		append(alwaysCAASWorkers, notMigratingCAASWorkers...))
+	WaitMatch(c, matcher.Check, coretesting.LongWait, s.BackingState.StartSync)
+}

--- a/cmd/jujud/agent/caasoperator_test.go
+++ b/cmd/jujud/agent/caasoperator_test.go
@@ -24,31 +24,10 @@ import (
 )
 
 type CAASOperatorSuite struct {
-	coretesting.GitSuite
 	agenttest.AgentSuite
 }
 
 var _ = gc.Suite(&CAASOperatorSuite{})
-
-func (s *CAASOperatorSuite) SetUpSuite(c *gc.C) {
-	s.GitSuite.SetUpSuite(c)
-	s.AgentSuite.SetUpSuite(c)
-}
-
-func (s *CAASOperatorSuite) TearDownSuite(c *gc.C) {
-	s.AgentSuite.TearDownSuite(c)
-	s.GitSuite.TearDownSuite(c)
-}
-
-func (s *CAASOperatorSuite) SetUpTest(c *gc.C) {
-	s.GitSuite.SetUpTest(c)
-	s.AgentSuite.SetUpTest(c)
-}
-
-func (s *CAASOperatorSuite) TearDownTest(c *gc.C) {
-	s.AgentSuite.TearDownTest(c)
-	s.GitSuite.TearDownTest(c)
-}
 
 // primeAgent creates an application, and sets up the application agent's directory.
 // It returns new application and the agent's configuration.

--- a/cmd/jujud/agent/engine_test.go
+++ b/cmd/jujud/agent/engine_test.go
@@ -4,17 +4,9 @@
 package agent
 
 import (
-	"fmt"
-	"sync"
-	"time"
-
-	"github.com/juju/errors"
-	"github.com/juju/utils/set"
 	gc "gopkg.in/check.v1"
-	"gopkg.in/juju/worker.v1"
-	goyaml "gopkg.in/yaml.v2"
 
-	"github.com/juju/juju/cmd/jujud/agent/caasoperator"
+	"github.com/juju/juju/cmd/jujud/agent/agenttest"
 	"github.com/juju/juju/cmd/jujud/agent/machine"
 	"github.com/juju/juju/cmd/jujud/agent/model"
 	"github.com/juju/juju/cmd/jujud/agent/unit"
@@ -134,20 +126,11 @@ var (
 		"unconverted-api-workers",
 		"unit-agent-deployer",
 	}
-
-	alwaysCAASWorkers = []string{
-		"agent",
-		"api-caller",
-		"operator",
-	}
-	notMigratingCAASWorkers = []string{
-	// TODO(caas)
-	}
 )
 
 type ModelManifoldsFunc func(config model.ManifoldsConfig) dependency.Manifolds
 
-func TrackModels(c *gc.C, tracker *engineTracker, inner ModelManifoldsFunc) ModelManifoldsFunc {
+func TrackModels(c *gc.C, tracker *agenttest.EngineTracker, inner ModelManifoldsFunc) ModelManifoldsFunc {
 	return func(config model.ManifoldsConfig) dependency.Manifolds {
 		raw := inner(config)
 		id := config.Agent.CurrentConfig().Model().Id()
@@ -160,7 +143,7 @@ func TrackModels(c *gc.C, tracker *engineTracker, inner ModelManifoldsFunc) Mode
 
 type MachineManifoldsFunc func(config machine.ManifoldsConfig) dependency.Manifolds
 
-func TrackMachines(c *gc.C, tracker *engineTracker, inner MachineManifoldsFunc) MachineManifoldsFunc {
+func TrackMachines(c *gc.C, tracker *agenttest.EngineTracker, inner MachineManifoldsFunc) MachineManifoldsFunc {
 	return func(config machine.ManifoldsConfig) dependency.Manifolds {
 		raw := inner(config)
 		id := config.Agent.CurrentConfig().Tag().String()
@@ -173,7 +156,7 @@ func TrackMachines(c *gc.C, tracker *engineTracker, inner MachineManifoldsFunc) 
 
 type UnitManifoldsFunc func(config unit.ManifoldsConfig) dependency.Manifolds
 
-func TrackUnits(c *gc.C, tracker *engineTracker, inner UnitManifoldsFunc) UnitManifoldsFunc {
+func TrackUnits(c *gc.C, tracker *agenttest.EngineTracker, inner UnitManifoldsFunc) UnitManifoldsFunc {
 	return func(config unit.ManifoldsConfig) dependency.Manifolds {
 		raw := inner(config)
 		id := config.Agent.CurrentConfig().Tag().String()
@@ -181,187 +164,5 @@ func TrackUnits(c *gc.C, tracker *engineTracker, inner UnitManifoldsFunc) UnitMa
 			c.Errorf("cannot install tracker: %v", err)
 		}
 		return raw
-	}
-}
-
-type CAASOperatorManifoldsFunc func(config caasoperator.ManifoldsConfig) dependency.Manifolds
-
-func TrackCAASOperator(c *gc.C, tracker *engineTracker, inner CAASOperatorManifoldsFunc) CAASOperatorManifoldsFunc {
-	return func(config caasoperator.ManifoldsConfig) dependency.Manifolds {
-		raw := inner(config)
-		id := config.Agent.CurrentConfig().Tag().String()
-		if err := tracker.Install(raw, id); err != nil {
-			c.Errorf("cannot install tracker: %v", err)
-		}
-		return raw
-	}
-}
-
-// NewWorkerManager takes an engineTracker, an engine manager id to
-// monitor and the workers that are expected to be running and sets up
-// a WorkerManager.
-func NewWorkerMatcher(c *gc.C, tracker *engineTracker, id string, workers []string) *WorkerMatcher {
-	return &WorkerMatcher{
-		c:       c,
-		tracker: tracker,
-		id:      id,
-		expect:  set.NewStrings(workers...),
-	}
-}
-
-// WorkerMatcher monitors the workers of a single engine manager,
-// using an engineTracker, for a given set of workers to be running.
-type WorkerMatcher struct {
-	c         *gc.C
-	tracker   *engineTracker
-	id        string
-	expect    set.Strings
-	matchTime time.Time
-}
-
-// Check returns true if the workers which are expected to be running
-// (as specified in the call to NewWorkerMatcher) are running and have
-// been running for a short period (i.e. some indication of stability).
-func (m *WorkerMatcher) Check() bool {
-	if m.checkOnce() {
-		now := time.Now()
-		if m.matchTime.IsZero() {
-			m.matchTime = now
-			return false
-		}
-		// Only return that the required workers have started if they
-		// have been stable for a little while.
-		return now.Sub(m.matchTime) >= time.Second
-	}
-	// Required workers not running, reset the timestamp.
-	m.matchTime = time.Time{}
-	return false
-}
-
-func (m *WorkerMatcher) checkOnce() bool {
-	actual := m.tracker.Workers(m.id)
-	m.c.Logf("\n%s: has workers %v", m.id, actual.SortedValues())
-	extras := actual.Difference(m.expect)
-	missed := m.expect.Difference(actual)
-	if len(extras) == 0 && len(missed) == 0 {
-		return true
-	}
-	m.c.Logf("%s: waiting for %v", m.id, missed.SortedValues())
-	m.c.Logf("%s: unexpected %v", m.id, extras.SortedValues())
-	report, _ := goyaml.Marshal(m.tracker.Report(m.id))
-	m.c.Logf("%s: report: \n%s\n", m.id, report)
-	return false
-}
-
-// WaitMatch returns only when the match func succeeds, or it times out.
-func WaitMatch(c *gc.C, match func() bool, maxWait time.Duration, sync func()) {
-	timeout := time.After(maxWait)
-	for {
-		if match() {
-			return
-		}
-		select {
-		case <-time.After(coretesting.ShortWait):
-			sync()
-		case <-timeout:
-			c.Fatalf("timed out waiting for workers")
-		}
-	}
-}
-
-// NewEngineTracker creates a type that can Install itself into a
-// Manifolds map, and expose recent snapshots of running Workers.
-func NewEngineTracker() *engineTracker {
-	return &engineTracker{
-		current: make(map[string]set.Strings),
-		reports: make(map[string]map[string]interface{}),
-	}
-}
-
-type engineTracker struct {
-	mu      sync.Mutex
-	current map[string]set.Strings
-	reports map[string]map[string]interface{}
-}
-
-// Workers returns the most-recently-reported set of running workers.
-func (tracker *engineTracker) Workers(id string) set.Strings {
-	tracker.mu.Lock()
-	defer tracker.mu.Unlock()
-	return tracker.current[id]
-}
-
-// Report returns the most-recently-reported self-report. It will
-// only work if you hack up the relevant engine-starting code to
-// include:
-//
-//    manifolds["self"] = dependency.SelfManifold(engine)
-//
-// or otherwise inject a suitable "self" manifold.
-func (tracker *engineTracker) Report(id string) map[string]interface{} {
-	tracker.mu.Lock()
-	defer tracker.mu.Unlock()
-	return tracker.reports[id]
-}
-
-// Install injects a manifold named TEST-TRACKER into raw, which will
-// depend on all other manifolds in raw and write currently-available
-// worker information to the tracker (differentiating it from other
-// tracked engines via the id param).
-func (tracker *engineTracker) Install(raw dependency.Manifolds, id string) error {
-	const trackerName = "TEST-TRACKER"
-
-	names := make([]string, 0, len(raw))
-	for name := range raw {
-		if name == trackerName {
-			return errors.New("engine tracker installed repeatedly")
-		}
-		names = append(names, name)
-	}
-
-	tracker.mu.Lock()
-	defer tracker.mu.Unlock()
-	if _, exists := tracker.current[id]; exists {
-		return errors.Errorf("manifolds for %s created repeatedly", id)
-	}
-	raw[trackerName] = dependency.Manifold{
-		Inputs: append(names, "self"),
-		Start:  tracker.startFunc(id, names),
-	}
-	return nil
-}
-
-func (tracker *engineTracker) startFunc(id string, names []string) dependency.StartFunc {
-	return func(context dependency.Context) (worker.Worker, error) {
-
-		seen := set.NewStrings()
-		for _, name := range names {
-			err := context.Get(name, nil)
-			switch errors.Cause(err) {
-			case nil:
-			case dependency.ErrMissing:
-				continue
-			default:
-				name = fmt.Sprintf("%s [%v]", name, err)
-			}
-			seen.Add(name)
-		}
-
-		var report map[string]interface{}
-		var reporter dependency.Reporter
-		if err := context.Get("self", &reporter); err == nil {
-			report = reporter.Report()
-		}
-
-		select {
-		case <-context.Abort():
-			// don't bother to report if it's about to change
-		default:
-			tracker.mu.Lock()
-			defer tracker.mu.Unlock()
-			tracker.current[id] = seen
-			tracker.reports[id] = report
-		}
-		return nil, dependency.ErrMissing
 	}
 }

--- a/cmd/jujud/agent/machine_test.go
+++ b/cmd/jujud/agent/machine_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/juju/cmd"
 	"github.com/juju/cmd/cmdtesting"
 	"github.com/juju/errors"
+	"github.com/juju/juju/cmd/jujud/agent/agenttest"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils"
 	"github.com/juju/utils/arch"
@@ -1101,7 +1102,7 @@ func (s *MachineSuite) TestMachineAgentRestoreRequiresPrepare(c *gc.C) {
 }
 
 func (s *MachineSuite) TestMachineWorkers(c *gc.C) {
-	tracker := NewEngineTracker()
+	tracker := agenttest.NewEngineTracker()
 	instrumented := TrackMachines(c, tracker, machineManifolds)
 	s.PatchValue(&machineManifolds, instrumented)
 
@@ -1111,22 +1112,22 @@ func (s *MachineSuite) TestMachineWorkers(c *gc.C) {
 	defer func() { c.Check(a.Stop(), jc.ErrorIsNil) }()
 
 	// Wait for it to stabilise, running as normal.
-	matcher := NewWorkerMatcher(c, tracker, a.Tag().String(),
+	matcher := agenttest.NewWorkerMatcher(c, tracker, a.Tag().String(),
 		append(alwaysMachineWorkers, notMigratingMachineWorkers...))
-	WaitMatch(c, matcher.Check, coretesting.LongWait, s.BackingState.StartSync)
+	agenttest.WaitMatch(c, matcher.Check, coretesting.LongWait, s.BackingState.StartSync)
 }
 
 func (s *MachineSuite) TestControllerModelWorkers(c *gc.C) {
 	uuid := s.BackingState.ModelUUID()
 
-	tracker := NewEngineTracker()
+	tracker := agenttest.NewEngineTracker()
 	instrumented := TrackModels(c, tracker, iaasModelManifolds)
 	s.PatchValue(&iaasModelManifolds, instrumented)
 
-	matcher := NewWorkerMatcher(c, tracker, uuid,
+	matcher := agenttest.NewWorkerMatcher(c, tracker, uuid,
 		append(alwaysModelWorkers, aliveModelWorkers...))
 	s.assertJobWithState(c, state.JobManageModel, func(agent.Config, *state.State) {
-		WaitMatch(c, matcher.Check, coretesting.LongWait, s.BackingState.StartSync)
+		agenttest.WaitMatch(c, matcher.Check, coretesting.LongWait, s.BackingState.StartSync)
 	})
 }
 
@@ -1142,14 +1143,14 @@ func (s *MachineSuite) TestHostedModelWorkers(c *gc.C) {
 	defer closer()
 	uuid := st.ModelUUID()
 
-	tracker := NewEngineTracker()
+	tracker := agenttest.NewEngineTracker()
 	instrumented := TrackModels(c, tracker, iaasModelManifolds)
 	s.PatchValue(&iaasModelManifolds, instrumented)
 
-	matcher := NewWorkerMatcher(c, tracker, uuid,
+	matcher := agenttest.NewWorkerMatcher(c, tracker, uuid,
 		append(alwaysModelWorkers, aliveModelWorkers...))
 	s.assertJobWithState(c, state.JobManageModel, func(agent.Config, *state.State) {
-		WaitMatch(c, matcher.Check, ReallyLongWait, st.StartSync)
+		agenttest.WaitMatch(c, matcher.Check, ReallyLongWait, st.StartSync)
 	})
 }
 
@@ -1158,7 +1159,7 @@ func (s *MachineSuite) TestMigratingModelWorkers(c *gc.C) {
 	defer closer()
 	uuid := st.ModelUUID()
 
-	tracker := NewEngineTracker()
+	tracker := agenttest.NewEngineTracker()
 
 	// Replace the real migrationmaster worker with a fake one which
 	// does nothing. This is required to make this test be reliable as
@@ -1191,10 +1192,10 @@ func (s *MachineSuite) TestMigratingModelWorkers(c *gc.C) {
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
-	matcher := NewWorkerMatcher(c, tracker, uuid,
+	matcher := agenttest.NewWorkerMatcher(c, tracker, uuid,
 		append(alwaysModelWorkers, migratingModelWorkers...))
 	s.assertJobWithState(c, state.JobManageModel, func(agent.Config, *state.State) {
-		WaitMatch(c, matcher.Check, ReallyLongWait, st.StartSync)
+		agenttest.WaitMatch(c, matcher.Check, ReallyLongWait, st.StartSync)
 	})
 }
 
@@ -1241,13 +1242,13 @@ func (s *MachineSuite) TestModelWorkersRespectSingularResponsibilityFlag(c *gc.C
 
 	// Then run a normal model-tracking test, just checking for
 	// a different set of workers.
-	tracker := NewEngineTracker()
+	tracker := agenttest.NewEngineTracker()
 	instrumented := TrackModels(c, tracker, iaasModelManifolds)
 	s.PatchValue(&iaasModelManifolds, instrumented)
 
-	matcher := NewWorkerMatcher(c, tracker, uuid, alwaysModelWorkers)
+	matcher := agenttest.NewWorkerMatcher(c, tracker, uuid, alwaysModelWorkers)
 	s.assertJobWithState(c, state.JobManageModel, func(agent.Config, *state.State) {
-		WaitMatch(c, matcher.Check, coretesting.LongWait, s.BackingState.StartSync)
+		agenttest.WaitMatch(c, matcher.Check, coretesting.LongWait, s.BackingState.StartSync)
 	})
 }
 

--- a/cmd/jujud/agent/unit_test.go
+++ b/cmd/jujud/agent/unit_test.go
@@ -416,7 +416,7 @@ func (s *UnitSuite) TestChangeConfig(c *gc.C) {
 
 func (s *UnitSuite) TestWorkers(c *gc.C) {
 	coretesting.SkipIfWindowsBug(c, "lp:1610993")
-	tracker := NewEngineTracker()
+	tracker := agenttest.NewEngineTracker()
 	instrumented := TrackUnits(c, tracker, unitManifolds)
 	s.PatchValue(&unitManifolds, instrumented)
 
@@ -429,7 +429,7 @@ func (s *UnitSuite) TestWorkers(c *gc.C) {
 	go func() { c.Check(a.Run(nil), gc.IsNil) }()
 	defer func() { c.Check(a.Stop(), gc.IsNil) }()
 
-	matcher := NewWorkerMatcher(c, tracker, a.Tag().String(),
+	matcher := agenttest.NewWorkerMatcher(c, tracker, a.Tag().String(),
 		append(alwaysUnitWorkers, notMigratingUnitWorkers...))
-	WaitMatch(c, matcher.Check, coretesting.LongWait, s.BackingState.StartSync)
+	agenttest.WaitMatch(c, matcher.Check, coretesting.LongWait, s.BackingState.StartSync)
 }

--- a/cmd/jujud/agent/util_test.go
+++ b/cmd/jujud/agent/util_test.go
@@ -46,10 +46,9 @@ import (
 )
 
 const (
-	initialMachinePassword     = "machine-password-1234567890"
-	initialUnitPassword        = "unit-password-1234567890"
-	initialApplicationPassword = "application-password-1234567890"
-	startWorkerWait            = 250 * time.Millisecond
+	initialMachinePassword = "machine-password-1234567890"
+	initialUnitPassword    = "unit-password-1234567890"
+	startWorkerWait        = 250 * time.Millisecond
 )
 
 var fastDialOpts = api.DialOpts{
@@ -276,23 +275,6 @@ func opRecvTimeout(c *gc.C, st *state.State, opc <-chan dummy.Operation, kinds .
 			c.Fatalf("time out wating for operation")
 		}
 	}
-}
-
-type mockAgentConfig struct {
-	agent.Config
-	providerType string
-	tag          names.Tag
-}
-
-func (m *mockAgentConfig) Tag() names.Tag {
-	return m.tag
-}
-
-func (m *mockAgentConfig) Value(key string) string {
-	if key == agent.ProviderType {
-		return m.providerType
-	}
-	return ""
 }
 
 type mockLoopDeviceManager struct {

--- a/cmd/jujud/agent/util_test.go
+++ b/cmd/jujud/agent/util_test.go
@@ -46,9 +46,10 @@ import (
 )
 
 const (
-	initialMachinePassword = "machine-password-1234567890"
-	initialUnitPassword    = "unit-password-1234567890"
-	startWorkerWait        = 250 * time.Millisecond
+	initialMachinePassword     = "machine-password-1234567890"
+	initialUnitPassword        = "unit-password-1234567890"
+	initialApplicationPassword = "application-password-1234567890"
+	startWorkerWait            = 250 * time.Millisecond
 )
 
 var fastDialOpts = api.DialOpts{

--- a/cmd/jujud/main.go
+++ b/cmd/jujud/main.go
@@ -180,6 +180,12 @@ func jujuDMain(args []string, ctx *cmd.Context) (code int, err error) {
 	}
 	jujud.Register(unitAgent)
 
+	caasOperatorAgent, err := agentcmd.NewCaasOperatorAgent(ctx, bufferedLogger)
+	if err != nil {
+		return -1, errors.Trace(err)
+	}
+	jujud.Register(caasOperatorAgent)
+
 	jujud.Register(NewUpgradeMongoCommand())
 	jujud.Register(agentcmd.NewCheckConnectionCommand(agentConf, agentcmd.ConnectAsAgent))
 

--- a/cmd/jujud/main_test.go
+++ b/cmd/jujud/main_test.go
@@ -82,6 +82,9 @@ func (s *MainSuite) TestParseErrors(c *gc.C) {
 	checkMessage(c, msga, "machine",
 		"--machine-id", "42",
 		"toastie")
+	checkMessage(c, msga, "caasoperator",
+		"--application-name", "app",
+		"toastie")
 }
 
 var expectedProviders = []string{

--- a/featuretests/agent_caasoperator_test.go
+++ b/featuretests/agent_caasoperator_test.go
@@ -1,0 +1,141 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package featuretests
+
+import (
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/juju/cmd/cmdtesting"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/agent"
+	jujudagent "github.com/juju/juju/cmd/jujud/agent"
+	"github.com/juju/juju/cmd/jujud/agent/agenttest"
+	"github.com/juju/juju/cmd/jujud/agent/caasoperator"
+	"github.com/juju/juju/state"
+	coretesting "github.com/juju/juju/testing"
+	"github.com/juju/juju/tools"
+	"github.com/juju/juju/worker/caasoperator/commands"
+	"github.com/juju/juju/worker/dependency"
+	"github.com/juju/juju/worker/logsender"
+)
+
+const (
+	initialApplicationPassword = "application-password-1234567890"
+)
+
+type CAASOperatorSuite struct {
+	agenttest.AgentSuite
+}
+
+var _ = gc.Suite(&CAASOperatorSuite{})
+
+// primeAgent creates an application, and sets up the application agent's directory.
+// It returns new application and the agent's configuration.
+func (s *CAASOperatorSuite) primeAgent(c *gc.C) (*state.Application, agent.Config, *tools.Tools) {
+	app := s.AddTestingApplication(c, "wordpress", s.AddTestingCharm(c, "wordpress"))
+	err := app.SetPassword(initialApplicationPassword)
+	c.Assert(err, jc.ErrorIsNil)
+	conf, tools := s.PrimeAgent(c, app.Tag(), initialApplicationPassword)
+	return app, conf, tools
+}
+
+func (s *CAASOperatorSuite) newAgent(c *gc.C, app *state.Application) *jujudagent.CaasOperatorAgent {
+	a, err := jujudagent.NewCaasOperatorAgent(nil, s.newBufferedLogWriter())
+	c.Assert(err, jc.ErrorIsNil)
+	s.InitAgent(c, a, "--application-name", app.Name(), "--log-to-stderr=true")
+	err = a.ReadConfig(app.Tag().String())
+	c.Assert(err, jc.ErrorIsNil)
+	return a
+}
+
+func (s *CAASOperatorSuite) newBufferedLogWriter() *logsender.BufferedLogWriter {
+	logger := logsender.NewBufferedLogWriter(1024)
+	s.AddCleanup(func(*gc.C) { logger.Close() })
+	return logger
+}
+
+func waitForApplicationActive(c *gc.C, agentDir string) {
+	timeout := time.After(coretesting.LongWait)
+
+	for {
+		select {
+		case <-timeout:
+			c.Fatalf("no activity detected")
+		case <-time.After(coretesting.ShortWait):
+			link := filepath.Join(agentDir, commands.CommandNames()[0])
+			if _, err := os.Lstat(link); err == nil {
+				target, err := os.Readlink(link)
+				c.Assert(err, jc.ErrorIsNil)
+				c.Assert(target, gc.Equals, filepath.Join(filepath.Dir(os.Args[0]), "jujud"))
+				return
+			}
+		}
+	}
+}
+
+func (s *CAASOperatorSuite) TestRunStop(c *gc.C) {
+	app, config, _ := s.primeAgent(c)
+	a := s.newAgent(c, app)
+	go func() { c.Check(a.Run(nil), gc.IsNil) }()
+	defer func() { c.Check(a.Stop(), gc.IsNil) }()
+	waitForApplicationActive(c, filepath.Join(config.DataDir(), "tools"))
+}
+
+func (s *CAASOperatorSuite) TestOpenStateFails(c *gc.C) {
+	app, config, _ := s.primeAgent(c)
+	a := s.newAgent(c, app)
+	go func() { c.Check(a.Run(nil), gc.IsNil) }()
+	defer func() { c.Check(a.Stop(), gc.IsNil) }()
+	waitForApplicationActive(c, filepath.Join(config.DataDir(), "tools"))
+
+	s.AssertCannotOpenState(c, config.Tag(), config.DataDir())
+}
+
+type CAASOperatorManifoldsFunc func(config caasoperator.ManifoldsConfig) dependency.Manifolds
+
+func TrackCAASOperator(c *gc.C, tracker *agenttest.EngineTracker, inner CAASOperatorManifoldsFunc) CAASOperatorManifoldsFunc {
+	return func(config caasoperator.ManifoldsConfig) dependency.Manifolds {
+		raw := inner(config)
+		id := config.Agent.CurrentConfig().Tag().String()
+		if err := tracker.Install(raw, id); err != nil {
+			c.Errorf("cannot install tracker: %v", err)
+		}
+		return raw
+	}
+}
+
+var (
+	alwaysCAASWorkers = []string{
+		"agent",
+		"api-caller",
+		"operator",
+	}
+	notMigratingCAASWorkers = []string{
+	// TODO(caas)
+	}
+)
+
+func (s *CAASOperatorSuite) TestWorkers(c *gc.C) {
+	coretesting.SkipIfWindowsBug(c, "lp:1610993")
+	tracker := agenttest.NewEngineTracker()
+	instrumented := TrackCAASOperator(c, tracker, jujudagent.CaasOperatorManifolds)
+	s.PatchValue(&jujudagent.CaasOperatorManifolds, instrumented)
+
+	app, _, _ := s.primeAgent(c)
+	ctx := cmdtesting.Context(c)
+	a, err := jujudagent.NewCaasOperatorAgent(ctx, s.newBufferedLogWriter())
+	c.Assert(err, jc.ErrorIsNil)
+	s.InitAgent(c, a, "--application-name", app.Name())
+
+	go func() { c.Check(a.Run(nil), gc.IsNil) }()
+	defer func() { c.Check(a.Stop(), gc.IsNil) }()
+
+	matcher := agenttest.NewWorkerMatcher(c, tracker, a.Tag().String(),
+		append(alwaysCAASWorkers, notMigratingCAASWorkers...))
+	agenttest.WaitMatch(c, matcher.Check, coretesting.LongWait, s.BackingState.StartSync)
+}

--- a/state/application.go
+++ b/state/application.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/juju/errors"
 	jujutxn "github.com/juju/txn"
+	"github.com/juju/utils"
 	"github.com/juju/utils/series"
 	"gopkg.in/juju/charm.v6-unstable"
 	csparams "gopkg.in/juju/charmrepo.v2-unstable/csclient/params"
@@ -50,6 +51,7 @@ type applicationDoc struct {
 	MinUnits             int        `bson:"minunits"`
 	TxnRevno             int64      `bson:"txn-revno"`
 	MetricCredentials    []byte     `bson:"metric-credentials"`
+	PasswordHash         string     `bson:"passwordhash"`
 }
 
 func newApplication(st *State, doc *applicationDoc) *Application {
@@ -2060,4 +2062,35 @@ func addApplicationOps(mb modelBackend, app *Application, args addApplicationOps
 		Assert: txn.DocMissing,
 	})
 	return ops, nil
+}
+
+// SetPassword sets the password for the application's agent.
+// TODO(caas) - consider a separate CAAS application entity
+func (a *Application) SetPassword(password string) error {
+	if len(password) < utils.MinAgentPasswordLength {
+		return fmt.Errorf("password is only %d bytes long, and is not a valid Agent password", len(password))
+	}
+	passwordHash := utils.AgentPasswordHash(password)
+	ops := []txn.Op{{
+		C:      applicationsC,
+		Id:     a.doc.DocID,
+		Assert: notDeadDoc,
+		Update: bson.D{{"$set", bson.D{{"passwordhash", passwordHash}}}},
+	}}
+	err := a.st.db().RunTransaction(ops)
+	if err != nil {
+		return fmt.Errorf("cannot set password of application %q: %v", a, onAbort(err, ErrDead))
+	}
+	a.doc.PasswordHash = passwordHash
+	return nil
+}
+
+// PasswordValid returns whether the given password is valid
+// for the given application.
+func (a *Application) PasswordValid(password string) bool {
+	agentHash := utils.AgentPasswordHash(password)
+	if agentHash == a.doc.PasswordHash {
+		return true
+	}
+	return false
 }

--- a/state/application_test.go
+++ b/state/application_test.go
@@ -1723,6 +1723,12 @@ func (s *ApplicationSuite) TestServiceRefresh(c *gc.C) {
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 }
 
+func (s *ApplicationSuite) TestSetPassword(c *gc.C) {
+	testSetPassword(c, func() (state.Authenticator, error) {
+		return s.State.Application(s.mysql.Name())
+	})
+}
+
 func (s *ApplicationSuite) TestServiceExposed(c *gc.C) {
 	// Check that querying for the exposed flag works correctly.
 	c.Assert(s.mysql.IsExposed(), jc.IsFalse)

--- a/state/migration_internal_test.go
+++ b/state/migration_internal_test.go
@@ -368,6 +368,8 @@ func (s *MigrationSuite) TestApplicationDocFields(c *gc.C) {
 		// RelationCount is handled by the number of times the application name
 		// appears in relation endpoints.
 		"RelationCount",
+		// TODO(caas) - add to export/import
+		"PasswordHash",
 	)
 	migrated := set.NewStrings(
 		"Name",

--- a/worker/caasoperator/caasoperator.go
+++ b/worker/caasoperator/caasoperator.go
@@ -1,0 +1,105 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package caasoperator
+
+import (
+	"path/filepath"
+
+	"github.com/juju/errors"
+	"github.com/juju/loggo"
+	"github.com/juju/utils/clock"
+	"gopkg.in/juju/names.v2"
+
+	"github.com/juju/juju/agent/tools"
+	jworker "github.com/juju/juju/worker"
+	"github.com/juju/juju/worker/caasoperator/commands"
+	"github.com/juju/juju/worker/catacomb"
+)
+
+var logger = loggo.GetLogger("juju.worker.caasoperator")
+
+// A CaasOperatorExecutionObserver gets the appropriate methods called when a hook
+// is executed and either succeeds or fails.  Missing hooks don't get reported
+// in this way.
+type CaasOperatorExecutionObserver interface {
+	HookCompleted(hookName string)
+	HookFailed(hookName string)
+}
+
+// CaasOperator implements the capabilities of the caasoperator agent. It is not intended to
+// implement the actual *behaviour* of the caasoperator agent; that responsibility is
+// delegated to Mode values, which are expected to react to events and direct
+// the caasoperator's responses to them.
+type CaasOperator struct {
+	catacomb    catacomb.Catacomb
+	clock       clock.Clock
+	agentDir    string
+	hookToolDir string
+	dataDir     string
+}
+
+// CaasOperatorParams hold all the necessary parameters for a new CaasOperator.
+type CaasOperatorParams struct {
+	CaasOperatorTag      names.ApplicationTag
+	AgentDir             string
+	DataDir              string
+	TranslateResolverErr func(error) error
+	Clock                clock.Clock
+}
+
+// NewCaasOperator creates a new CaasOperator which will install, run, and upgrade
+// a charm on behalf of the unit with the given unitTag, by executing
+// hooks and operations provoked by changes in st.
+func NewCaasOperator(caasoperatorParams *CaasOperatorParams) (*CaasOperator, error) {
+	translateResolverErr := caasoperatorParams.TranslateResolverErr
+	if translateResolverErr == nil {
+		translateResolverErr = func(err error) error { return err }
+	}
+
+	op := &CaasOperator{
+		clock:       caasoperatorParams.Clock,
+		agentDir:    caasoperatorParams.AgentDir,
+		dataDir:     caasoperatorParams.DataDir,
+		hookToolDir: filepath.Join(caasoperatorParams.DataDir, "tools"),
+	}
+	err := catacomb.Invoke(catacomb.Plan{
+		Site: &op.catacomb,
+		Work: func() error {
+			return op.loop(caasoperatorParams.CaasOperatorTag)
+		},
+	})
+	return op, errors.Trace(err)
+}
+
+func (op *CaasOperator) loop(applicationTag names.ApplicationTag) (err error) {
+	if err := op.init(applicationTag); err != nil {
+		if err == jworker.ErrTerminateAgent {
+			return err
+		}
+		return errors.Annotatef(err, "failed to initialize caasoperator for %q", applicationTag)
+	}
+
+	for {
+		select {
+		case <-op.catacomb.Dying():
+			return op.catacomb.ErrDying()
+		}
+	}
+}
+
+func (op *CaasOperator) init(caasapplicationtag names.ApplicationTag) (err error) {
+	logger.Criticalf("creating caas operator symlinks in %v", op.agentDir)
+	if err := tools.EnsureSymlinks(op.agentDir, op.hookToolDir, commands.CommandNames()); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (op *CaasOperator) Kill() {
+	op.catacomb.Kill(nil)
+}
+
+func (op *CaasOperator) Wait() error {
+	return op.catacomb.Wait()
+}

--- a/worker/caasoperator/commands/names.go
+++ b/worker/caasoperator/commands/names.go
@@ -1,0 +1,50 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package commands
+
+import (
+	"sort"
+)
+
+// CmdSuffix is the filename suffix to use for executables.
+const cmdSuffix = ""
+
+type command interface{}
+
+var registeredCommands = map[string]command{}
+
+// baseCommands maps Command names to creators.
+var baseCommands = map[string]command{
+	"config-get" + cmdSuffix:              nil,
+	"juju-log" + cmdSuffix:                nil,
+	"status-get" + cmdSuffix:              nil,
+	"status-set" + cmdSuffix:              nil,
+	"application-version-set" + cmdSuffix: nil,
+	"relation-ids" + cmdSuffix:            nil,
+	"relation-list" + cmdSuffix:           nil,
+	"relation-set" + cmdSuffix:            nil,
+	"relation-get" + cmdSuffix:            nil,
+	"container-spec-set" + cmdSuffix:      nil,
+}
+
+func allEnabledCommands() map[string]command {
+	all := map[string]command{}
+	add := func(m map[string]command) {
+		for k, v := range m {
+			all[k] = v
+		}
+	}
+	add(baseCommands)
+	add(registeredCommands)
+	return all
+}
+
+// CommandNames returns the names of all hook commands.
+func CommandNames() (names []string) {
+	for name := range allEnabledCommands() {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return
+}

--- a/worker/caasoperator/manifold.go
+++ b/worker/caasoperator/manifold.go
@@ -1,0 +1,84 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package caasoperator
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/utils/clock"
+	"gopkg.in/juju/names.v2"
+	"gopkg.in/juju/worker.v1"
+
+	"github.com/juju/juju/agent"
+	"github.com/juju/juju/api"
+	"github.com/juju/juju/worker/dependency"
+	"github.com/juju/juju/worker/fortress"
+	"github.com/juju/juju/worker/uniter/resolver"
+)
+
+// ManifoldConfig defines the names of the manifolds on which a
+// Manifold will depend.
+type ManifoldConfig struct {
+	AgentName            string
+	APICallerName        string
+	Clock                clock.Clock
+	TranslateResolverErr func(error) error
+	AgentDir             string
+}
+
+// Manifold returns a dependency manifold that runs a caasoperator worker,
+// using the resource names defined in the supplied config.
+func Manifold(config ManifoldConfig) dependency.Manifold {
+	return dependency.Manifold{
+		Inputs: []string{
+			config.AgentName,
+			config.APICallerName,
+		},
+		Start: func(context dependency.Context) (worker.Worker, error) {
+			if config.Clock == nil {
+				return nil, errors.NotValidf("missing Clock")
+			}
+			logger.Errorf("collecting resources")
+			// Collect all required resources.
+			var agent agent.Agent
+			if err := context.Get(config.AgentName, &agent); err != nil {
+				return nil, err
+			}
+			var apiConn api.Connection
+			if err := context.Get(config.APICallerName, &apiConn); err != nil {
+				return nil, err
+			}
+
+			manifoldConfig := config
+			// Configure and start the caasoperator.
+			agentConfig := agent.CurrentConfig()
+			tag := agentConfig.Tag()
+			caasoperatorTag, ok := tag.(names.ApplicationTag)
+			if !ok {
+				return nil, errors.Errorf("expected a caasoperator tag, got %v", tag)
+			}
+			caasoperator, err := NewCaasOperator(&CaasOperatorParams{
+				CaasOperatorTag:      caasoperatorTag,
+				DataDir:              agentConfig.DataDir(),
+				AgentDir:             manifoldConfig.AgentDir,
+				TranslateResolverErr: config.TranslateResolverErr,
+				Clock:                manifoldConfig.Clock,
+			})
+			if err != nil {
+				return nil, errors.Trace(err)
+			}
+			return caasoperator, nil
+		},
+	}
+}
+
+// TranslateFortressErrors turns errors returned by dependent
+// manifolds due to fortress lockdown (i.e. model migration) into an
+// error which causes the resolver loop to be restarted. When this
+// happens the caasoperator is about to be shut down anyway.
+func TranslateFortressErrors(err error) error {
+	if fortress.IsFortressError(err) {
+		return resolver.ErrRestart
+	}
+	return err
+}

--- a/worker/caasprovisioner/mock_test.go
+++ b/worker/caasprovisioner/mock_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/juju/juju/agent"
 	apicaasprovisioner "github.com/juju/juju/api/caasprovisioner"
+	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/caas"
 	coretesting "github.com/juju/juju/testing"
 	"github.com/juju/juju/watcher"
@@ -43,15 +44,15 @@ func (m *mockProvisionerFacade) WatchApplications() (watcher.StringsWatcher, err
 	return m.applicationsWatcher, nil
 }
 
-func (m *mockProvisionerFacade) SetPasswords(passwords []apicaasprovisioner.ApplicationPassword) error {
+func (m *mockProvisionerFacade) SetPasswords(passwords []apicaasprovisioner.ApplicationPassword) (params.ErrorResults, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.stub.MethodCall(m, "SetPasswords", passwords)
 	if err := m.stub.NextErr(); err != nil {
-		return err
+		return params.ErrorResults{}, err
 	}
 	m.passwords = passwords
-	return nil
+	return params.ErrorResults{}, nil
 }
 
 type mockAgentConfig struct {

--- a/worker/caasprovisioner/worker_test.go
+++ b/worker/caasprovisioner/worker_test.go
@@ -104,4 +104,9 @@ func (s *CAASProvisionerSuite) TestOperatorCreated(c *gc.C) {
 	addr, err := cfg.APIAddresses()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(addr, jc.DeepEquals, []string{"10.0.0.1:17070"})
+
+	passwords := s.provisionerFacade.passwords
+	c.Assert(passwords, gc.HasLen, 1)
+	c.Assert(passwords[0].Name, gc.Equals, "myApp")
+	c.Assert(passwords[0].Password, gc.Not(gc.Equals), "")
 }

--- a/worker/uniter/uniter.go
+++ b/worker/uniter/uniter.go
@@ -19,6 +19,7 @@ import (
 	"gopkg.in/juju/names.v2"
 	"gopkg.in/juju/worker.v1"
 
+	"github.com/juju/juju/agent/tools"
 	"github.com/juju/juju/api/uniter"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/core/leadership"
@@ -423,7 +424,7 @@ func (u *Uniter) init(unitTag names.UnitTag) (err error) {
 			return errors.Trace(err)
 		}
 	}
-	if err := jujuc.EnsureSymlinks(u.paths.ToolsDir); err != nil {
+	if err := tools.EnsureSymlinks(u.paths.ToolsDir, u.paths.ToolsDir, jujuc.CommandNames()); err != nil {
 		return err
 	}
 	if err := os.MkdirAll(u.paths.State.RelationsDir, 0755); err != nil {


### PR DESCRIPTION
## Description of change

Add a skeleton jujud operator. The operator starts essentially a no-op worker which can be fleshed out going forward. Some small common bits from uniter were extracted out, namely the symlink creation.

The CAAS provisioner facade and state model gets support for setting a password on the application entity. This will allow the operator via the associated facade (not yet written) to make api calls back to the controller.

The k8s client is improved to delete and re-create config map and pod so allow for changed config to be applied as needed. The pod delete gets a retry loop to allow for the terminating phase to complete.

## QA steps

Run up a CAAS model and deploy a charm.
Run upgrade-juju and check that the operator pod is deleted and restarted.

