### PR TITLE
Do not bounce metrics workers if there's a data error

### DIFF
--- a/worker/metrics/collect/manifold.go
+++ b/worker/metrics/collect/manifold.go
@@ -239,6 +239,10 @@ func (w *collect) Do(stop <-chan struct{}) (err error) {
 		logger.Tracef("cannot execute collect-metrics: %v", err)
 		return nil
 	}
+	if spool.IsMetricsDataError(err) {
+		logger.Debugf("cannot record metrics: %v", err)
+		return nil
+	}
 	return err
 }
 

--- a/worker/metrics/sender/sender.go
+++ b/worker/metrics/sender/sender.go
@@ -51,7 +51,12 @@ func (s *sender) Do(stop <-chan struct{}) (err error) {
 		return errors.Trace(err)
 	}
 	defer reader.Close()
-	return s.sendMetrics(reader)
+	err = s.sendMetrics(reader)
+	if spool.IsMetricsDataError(err) {
+		logger.Debugf("cannot send metrics: %v", err)
+		return nil
+	}
+	return err
 }
 
 func (s *sender) sendMetrics(reader spool.MetricReader) error {

--- a/worker/metrics/spool/manifold.go
+++ b/worker/metrics/spool/manifold.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/juju/errors"
 	corecharm "gopkg.in/juju/charm.v6"
-	worker "gopkg.in/juju/worker.v1"
+	"gopkg.in/juju/worker.v1"
 	"gopkg.in/tomb.v1"
 
 	"github.com/juju/juju/agent"


### PR DESCRIPTION
## Description of change

If the metrics collection or sender workers error due to a data encoding or other issue like that, there's no point in bouncing the workers as it won't correct the problem. To make the logs quieter, log at debug level and don't return an error.

## QA steps

Create an empty metrics file and check logs.

