### PR TITLE
apiserver: allow all controller logins

### DIFF
--- a/apiserver/admin.go
+++ b/apiserver/admin.go
@@ -21,6 +21,7 @@ import (
 	"github.com/juju/juju/apiserver/observer"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/permission"
+	"github.com/juju/juju/rpc"
 	"github.com/juju/juju/rpc/rpcreflect"
 	"github.com/juju/juju/state"
 	statepresence "github.com/juju/juju/state/presence"
@@ -85,20 +86,6 @@ func (a *admin) login(req params.LoginRequest, loginVersion int) (params.LoginRe
 		return fail, errAlreadyLoggedIn
 	}
 
-	var authTag names.Tag
-	if req.AuthTag != "" {
-		var err error
-		authTag, err = names.ParseTag(req.AuthTag)
-		if err != nil {
-			return fail, errors.Annotate(err, "could not parse auth tag")
-		}
-	}
-	// apiRoot is the API root exposed to the client after login.
-	apiRoot, err := rpcRoot(a.srv, a.root, authTag)
-	if err != nil {
-		return fail, errors.Trace(err)
-	}
-
 	authResult, err := a.authenticate(req)
 	if err, ok := errors.Cause(err).(*common.DischargeRequiredError); ok {
 		loginResult := params.LoginResult{
@@ -118,48 +105,51 @@ func (a *admin) login(req params.LoginRequest, loginVersion int) (params.LoginRe
 		return fail, errors.Trace(err)
 	}
 
-	model := a.root.model
-
-	if authResult.userLogin || authResult.anonymousLogin {
-		switch model.MigrationMode() {
-		case state.MigrationModeImporting:
-			// The user is not able to access a model that is currently being
-			// imported until the model has been activated.
-			apiRoot = restrictAll(apiRoot, errors.New("migration in progress, model is importing"))
-		case state.MigrationModeExporting:
-			// The user is not allowed to change anything in a model that is
-			// currently being moved to another controller.
-			apiRoot = restrictRoot(apiRoot, migrationClientMethodsOnly)
-		}
+	// apiRoot is the API root exposed to the client after login.
+	var apiRoot rpc.Root = newAPIRoot(
+		a.root.state,
+		a.srv.statePool,
+		a.srv.facades,
+		a.root.resources,
+		a.root,
+	)
+	apiRoot, err = restrictAPIRoot(
+		a.srv,
+		apiRoot,
+		a.root.model,
+		a.root.state.IsController(),
+		*authResult,
+	)
+	if err != nil {
+		return fail, errors.Trace(err)
 	}
 
-	loginResult := params.LoginResult{
-		Servers:       params.FromNetworkHostsPorts(hostPorts),
-		ControllerTag: model.ControllerTag().String(),
-		UserInfo:      authResult.userInfo,
-		ServerVersion: jujuversion.Current.String(),
-		PublicDNSName: a.srv.publicDNSName(),
-	}
-
-	var filters []facadeFilterFunc
+	var facadeFilters []facadeFilterFunc
+	var modelTag string
 	if authResult.anonymousLogin {
-		filters = append(filters, IsAnonymousFacade)
+		facadeFilters = append(facadeFilters, IsAnonymousFacade)
 	}
 	if authResult.controllerOnlyLogin {
-		loginResult.Facades = filterFacades(a.srv.facades, append(filters, IsControllerFacade)...)
-		apiRoot = restrictRoot(apiRoot, controllerFacadesOnly)
+		facadeFilters = append(facadeFilters, IsControllerFacade)
 	} else {
-		loginResult.ModelTag = model.Tag().String()
-		loginResult.Facades = filterFacades(a.srv.facades, append(filters, IsModelFacade)...)
-		apiRoot = restrictRoot(apiRoot, modelFacadesOnly)
+		facadeFilters = append(facadeFilters, IsModelFacade)
+		modelTag = a.root.model.Tag().String()
 	}
 
 	a.root.rpcConn.ServeRoot(apiRoot, serverError)
-
-	return loginResult, nil
+	return params.LoginResult{
+		Servers:       params.FromNetworkHostsPorts(hostPorts),
+		ControllerTag: a.root.model.ControllerTag().String(),
+		UserInfo:      authResult.userInfo,
+		ServerVersion: jujuversion.Current.String(),
+		PublicDNSName: a.srv.publicDNSName(),
+		ModelTag:      modelTag,
+		Facades:       filterFacades(a.srv.facades, facadeFilters...),
+	}, nil
 }
 
 type authResult struct {
+	tag                 names.Tag
 	anonymousLogin      bool
 	userLogin           bool
 	controllerOnlyLogin bool
@@ -173,28 +163,17 @@ func (a *admin) authenticate(req params.LoginRequest) (*authResult, error) {
 	}
 
 	// Maybe rate limit non-user auth attempts.
-	machineAgent := false
 	if req.AuthTag != "" {
-		var err error
-		kind, err := names.TagKind(req.AuthTag)
-		// Check for anonymous user login.
-		if kind == names.UserTagKind {
-			userTag, err := names.ParseUserTag(req.AuthTag)
-			if err != nil {
-				return nil, errors.Trace(err)
-			}
-			result.anonymousLogin = userTag.Id() == api.AnonymousUsername && len(req.Macaroons) == 0
-			result.userLogin = !result.anonymousLogin
+		tag, err := names.ParseTag(req.AuthTag)
+		if err == nil {
+			result.tag = tag
 		}
-		if err != nil || kind != names.UserTagKind {
-			addCount := func(delta int64) {
-				atomic.AddInt64(&a.srv.loginAttempts, delta)
-			}
-			addCount(1)
-			defer addCount(-1)
+		if err != nil || tag.Kind() != names.UserTagKind {
+			// Either the tag is invalid, or
+			// it's not a user; rate limit it.
+			atomic.AddInt64(&a.srv.loginAttempts, 1)
+			defer atomic.AddInt64(&a.srv.loginAttempts, -1)
 
-			result.userLogin = false
-			machineAgent = kind == names.MachineTagKind
 			// Users are not rate limited, all other entities are.
 			if !a.srv.limiter.Acquire() {
 				logger.Debugf("rate limiting for agent %s", req.AuthTag)
@@ -205,6 +184,20 @@ func (a *admin) authenticate(req params.LoginRequest) (*authResult, error) {
 			}
 			defer a.srv.limiter.Release()
 		}
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+	}
+
+	switch result.tag.(type) {
+	case nil:
+	case names.UserTag:
+		if result.tag.Id() == api.AnonymousUsername && len(req.Macaroons) == 0 {
+			result.anonymousLogin = true
+			result.userLogin = false
+		}
+	default:
+		result.userLogin = false
 	}
 
 	// Only attempt to login with credentials if we are not doing an anonymous login.
@@ -213,12 +206,12 @@ func (a *admin) authenticate(req params.LoginRequest) (*authResult, error) {
 		err            error
 	)
 	if !result.anonymousLogin {
-		a.root.entity, lastConnection, err = a.checkCreds(req, result.userLogin)
+		a.root.entity, lastConnection, err = a.checkCreds(req, result.tag, result.userLogin)
 	}
 
 	// If above login fails, we may still be a login to a controller
 	// machine in the controller model.
-	controllerMachineLogin, err := a.handleAuthError(req, machineAgent, err)
+	controllerMachineLogin, err := a.handleAuthError(req, result.tag, err)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -243,7 +236,7 @@ func (a *admin) authenticate(req params.LoginRequest) (*authResult, error) {
 	return result, nil
 }
 
-func (a *admin) handleAuthError(req params.LoginRequest, machineAgent bool, err error) (controllerLogin bool, _ error) {
+func (a *admin) handleAuthError(req params.LoginRequest, authTag names.Tag, err error) (controllerLogin bool, _ error) {
 	if err == nil {
 		return false, nil
 	}
@@ -267,7 +260,8 @@ func (a *admin) handleAuthError(req params.LoginRequest, machineAgent bool, err 
 	// machine has the manage state job.  If all those parts are valid, we
 	// can then check the credentials against the controller model
 	// machine.
-	if !machineAgent {
+	machineTag, ok := authTag.(names.MachineTag)
+	if !ok {
 		return false, errors.Trace(err)
 	}
 	if errors.Cause(err) != common.ErrBadCreds {
@@ -275,7 +269,7 @@ func (a *admin) handleAuthError(req params.LoginRequest, machineAgent bool, err 
 	}
 	// If we are here, we may be logging into a controller machine
 	// in the controller model.
-	a.root.entity, err = a.checkControllerMachineCreds(req)
+	a.root.entity, err = a.checkControllerMachineCreds(req, machineTag)
 	if err != nil {
 		return false, errors.Trace(err)
 	}
@@ -397,12 +391,12 @@ func filterFacades(registry *facade.Registry, allowFacadeAllMustMatch ...facadeF
 	return out
 }
 
-func (a *admin) checkCreds(req params.LoginRequest, lookForModelUser bool) (state.Entity, *time.Time, error) {
-	return doCheckCreds(a.root.state, req, lookForModelUser, a.authenticator())
+func (a *admin) checkCreds(req params.LoginRequest, authTag names.Tag, userLogin bool) (state.Entity, *time.Time, error) {
+	return doCheckCreds(a.root.state, req, authTag, userLogin, a.authenticator())
 }
 
-func (a *admin) checkControllerMachineCreds(req params.LoginRequest) (state.Entity, error) {
-	return checkControllerMachineCreds(a.srv.statePool.SystemState(), req, a.authenticator())
+func (a *admin) checkControllerMachineCreds(req params.LoginRequest, authTag names.MachineTag) (state.Entity, error) {
+	return checkControllerMachineCreds(a.srv.statePool.SystemState(), req, authTag, a.authenticator())
 }
 
 func (a *admin) authenticator() authentication.EntityAuthenticator {
@@ -423,32 +417,30 @@ func (a *admin) maintenanceInProgress() bool {
 var doCheckCreds = checkCreds
 
 // checkCreds validates the entities credentials in the current model.
-// If the entity is a user, and lookForModelUser is true, a model user must exist
-// for the model.  In the case of a user logging in to the controller, but
-// not a model, there is no env user needed.  While we have the env
+// If the entity is a user, and userLogin==true, a model user must exist
+// for the model. In the case of a user logging in to the controller,
+// but not a model, there is no env user needed.  While we have the env
 // user, if we do have it, update the last login time.
 //
-// Note that when logging in with lookForModelUser true, the returned
-// entity will be modelUserEntity, not *state.User (external users
-// don't have user entries) or *state.ModelUser (we
-// don't want to lose the local user information associated with that).
-func checkCreds(st *state.State, req params.LoginRequest, lookForModelUser bool, authenticator authentication.EntityAuthenticator) (state.Entity, *time.Time, error) {
-	var tag names.Tag
-	if req.AuthTag != "" {
-		var err error
-		tag, err = names.ParseTag(req.AuthTag)
-		if err != nil {
-			return nil, nil, errors.Trace(err)
-		}
-	}
+// Note that when logging in with userLogin==true, the returned entity
+// will be modelUserEntity, not *state.User (external users don't have
+// user entries) or *state.ModelUser (we don't want to lose the local
+// user information associated with that).
+func checkCreds(
+	st *state.State,
+	req params.LoginRequest,
+	authTag names.Tag,
+	userLogin bool,
+	authenticator authentication.EntityAuthenticator,
+) (state.Entity, *time.Time, error) {
 	var entityFinder authentication.EntityFinder = st
-	if lookForModelUser {
+	if userLogin {
 		// When looking up model users, use a custom
 		// entity finder that looks up both the local user (if the user
 		// tag is in the local domain) and the model user.
 		entityFinder = modelUserEntityFinder{st}
 	}
-	entity, err := authenticator.Authenticate(entityFinder, tag, req)
+	entity, err := authenticator.Authenticate(entityFinder, authTag, req)
 	if err != nil {
 		return nil, nil, errors.Trace(err)
 	}
@@ -472,9 +464,16 @@ func checkCreds(st *state.State, req params.LoginRequest, lookForModelUser bool,
 func checkControllerMachineCreds(
 	controllerSt *state.State,
 	req params.LoginRequest,
+	authTag names.MachineTag,
 	authenticator authentication.EntityAuthenticator,
 ) (state.Entity, error) {
-	entity, _, err := doCheckCreds(controllerSt, req, false, authenticator)
+	entity, _, err := doCheckCreds(
+		controllerSt,
+		req,
+		authTag,
+		false,
+		authenticator,
+	)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/apiserver/admin.go
+++ b/apiserver/admin.go
@@ -227,6 +227,11 @@ func (a *admin) authenticate(req params.LoginRequest) (*authResult, error) {
 	if entity != nil {
 		if machine, ok := entity.(*state.Machine); ok && machine.IsManager() {
 			result.controllerMachineLogin = true
+			if machine.Tag() != a.srv.tag {
+				// We don't want to run pingers for other
+				// controller machines; they run their own.
+				startPinger = false
+			}
 		}
 		a.root.entity = entity
 		a.apiObserver.Login(entity.Tag(), a.root.model.ModelTag(), result.controllerMachineLogin, req.UserData)

--- a/apiserver/export_test.go
+++ b/apiserver/export_test.go
@@ -73,9 +73,15 @@ func DelayLogins() (nextChan chan struct{}, cleanup func()) {
 	cleanup = func() {
 		doCheckCreds = checkCreds
 	}
-	delayedCheckCreds := func(st *state.State, c params.LoginRequest, lookForModelUser bool, authenticator authentication.EntityAuthenticator) (state.Entity, *time.Time, error) {
+	delayedCheckCreds := func(
+		st *state.State,
+		c params.LoginRequest,
+		authTag names.Tag,
+		lookForModelUser bool,
+		authenticator authentication.EntityAuthenticator,
+	) (state.Entity, *time.Time, error) {
 		<-nextChan
-		return checkCreds(st, c, lookForModelUser, authenticator)
+		return checkCreds(st, c, authTag, lookForModelUser, authenticator)
 	}
 	doCheckCreds = delayedCheckCreds
 	return

--- a/apiserver/root.go
+++ b/apiserver/root.go
@@ -175,21 +175,37 @@ func newAPIRoot(st *state.State, pool *state.StatePool, facades *facade.Registry
 	return r
 }
 
-func rpcRoot(srv *Server, root *apiHandler, authTag names.Tag) (rpc.Root, error) {
-	// apiRoot is the API root exposed to the client.
-	var apiRoot rpc.Root = newAPIRoot(
-		root.state,
-		srv.statePool,
-		srv.facades,
-		root.resources,
-		root,
-	)
-	return maybeRestrictRoot(srv, apiRoot, root.state.IsController(), authTag)
-}
-
-func maybeRestrictRoot(
+// restrictAPIRoot calls restrictAPIRootDuringMaintenance, and
+// then restricts the result further to the contoller or model
+// facades, depending on the type of login.
+func restrictAPIRoot(
 	srv *Server,
 	apiRoot rpc.Root,
+	model *state.Model,
+	isControllerModel bool,
+	auth authResult,
+) (rpc.Root, error) {
+	apiRoot, err := restrictAPIRootDuringMaintenance(
+		srv, apiRoot, model, isControllerModel, auth.tag,
+	)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	if auth.controllerOnlyLogin {
+		apiRoot = restrictRoot(apiRoot, controllerFacadesOnly)
+	} else {
+		apiRoot = restrictRoot(apiRoot, modelFacadesOnly)
+	}
+	return apiRoot, nil
+}
+
+// restrictAPIRootDuringMaintenance restricts the API root during
+// maintenance events (upgrade, restore, or migration), depending
+// on the authenticated client.
+func restrictAPIRootDuringMaintenance(
+	srv *Server,
+	apiRoot rpc.Root,
+	model *state.Model,
 	isControllerModel bool,
 	authTag names.Tag,
 ) (rpc.Root, error) {
@@ -233,6 +249,20 @@ func maybeRestrictRoot(
 		}
 		// Agent and anonymous logins are blocked during upgrade.
 		return nil, errors.Errorf("%s blocked because upgrade is in progress", describeLogin())
+	}
+
+	// For user logins, we limit access during migrations.
+	if _, ok := authTag.(names.UserTag); ok {
+		switch model.MigrationMode() {
+		case state.MigrationModeImporting:
+			// The user is not able to access a model that is currently being
+			// imported until the model has been activated.
+			apiRoot = restrictAll(apiRoot, errors.New("migration in progress, model is importing"))
+		case state.MigrationModeExporting:
+			// The user is not allowed to change anything in a model that is
+			// currently being moved to another controller.
+			apiRoot = restrictRoot(apiRoot, migrationClientMethodsOnly)
+		}
 	}
 
 	return apiRoot, nil


### PR DESCRIPTION
## Description of change

Do not restrict any controller agents from
logging in during a maintenance event.
API root restriction has been moved to after
rate limiting and authentication.

Incidentally fixes an issue where we inform     
login observers that a login to the controller  
model is not from a controller agent when it is.

## QA steps

1. juju bootstrap localhost
2. juju enable-ha
(wait)
3. juju upgrade-model -m controller --build-agent
(juju debug-log -m controller; there should be no login errors)

## Documentation changes

None.

## Bug reference

Fixes https://bugs.launchpad.net/juju/+bug/1733259