### PR TITLE
Fix the deadlock in pubsub remote worker

### DIFF
--- a/worker/introspection/script.go
+++ b/worker/introspection/script.go
@@ -84,15 +84,19 @@ juju-heap-profile () {
 }
 
 juju-engine-report () {
-  jujuMachineOrUnit depengine/ $@
+  jujuMachineOrUnit depengine $@
 }
 
 juju-statepool-report () {
-  jujuMachineOrUnit statepool/ $@
+  jujuMachineOrUnit statepool $@
 }
 
 juju-pubsub-report () {
-  jujuMachineOrUnit pubsub/ $@
+  jujuMachineOrUnit pubsub $@
+}
+
+juju-metrics () {
+  jujuMachineOrUnit metrics $@
 }
 
 juju-statetracker-report () {
@@ -106,6 +110,7 @@ export -f juju-goroutines
 export -f juju-cpu-profile
 export -f juju-heap-profile
 export -f juju-engine-report
+export -f juju-metrics
 export -f juju-statepool-report
 export -f juju-statetracker-report
 export -f juju-pubsub-report

--- a/worker/introspection/socket.go
+++ b/worker/introspection/socket.go
@@ -159,12 +159,12 @@ func RegisterHTTPHandlers(
 	handle("/debug/pprof/cmdline", http.HandlerFunc(pprof.Cmdline))
 	handle("/debug/pprof/profile", http.HandlerFunc(pprof.Profile))
 	handle("/debug/pprof/symbol", http.HandlerFunc(pprof.Symbol))
-	handle("/depengine/", depengineHandler{sources.DependencyEngine})
-	handle("/statepool/", introspectionReporterHandler{
+	handle("/depengine", depengineHandler{sources.DependencyEngine})
+	handle("/statepool", introspectionReporterHandler{
 		name:     "State Pool Report",
 		reporter: sources.StatePool,
 	})
-	handle("/pubsub/", introspectionReporterHandler{
+	handle("/pubsub", introspectionReporterHandler{
 		name:     "PubSub Report",
 		reporter: sources.PubSub,
 	})

--- a/worker/introspection/socket_test.go
+++ b/worker/introspection/socket_test.go
@@ -113,19 +113,19 @@ func (s *introspectionSuite) TestGoroutineProfile(c *gc.C) {
 }
 
 func (s *introspectionSuite) TestMissingDepEngineReporter(c *gc.C) {
-	buf := s.call(c, "/depengine/")
+	buf := s.call(c, "/depengine")
 	matches(c, buf, "404 Not Found")
 	matches(c, buf, "missing dependency engine reporter")
 }
 
 func (s *introspectionSuite) TestMissingStatePoolReporter(c *gc.C) {
-	buf := s.call(c, "/statepool/")
+	buf := s.call(c, "/statepool")
 	matches(c, buf, "404 Not Found")
 	matches(c, buf, "State Pool Report: missing reporter")
 }
 
 func (s *introspectionSuite) TestMissingPubSubReporter(c *gc.C) {
-	buf := s.call(c, "/pubsub/")
+	buf := s.call(c, "/pubsub")
 	matches(c, buf, "404 Not Found")
 	matches(c, buf, "PubSub Report: missing reporter")
 }
@@ -146,7 +146,7 @@ func (s *introspectionSuite) TestEngineReporter(c *gc.C) {
 		},
 	}
 	s.startWorker(c)
-	buf := s.call(c, "/depengine/")
+	buf := s.call(c, "/depengine")
 
 	matches(c, buf, "200 OK")
 	matches(c, buf, "working: true")


### PR DESCRIPTION
Don't hold the lock while trying to send a value down the data channel.

Also drive by fix for the metrics endpoint, and to add an exported function.