### PR TITLE
apiserver: ping presence for other controllers

### DIFF
--- a/apiserver/admin.go
+++ b/apiserver/admin.go
@@ -227,11 +227,14 @@ func (a *admin) authenticate(req params.LoginRequest) (*authResult, error) {
 	if entity != nil {
 		if machine, ok := entity.(*state.Machine); ok && machine.IsManager() {
 			result.controllerMachineLogin = true
-			if machine.Tag() != a.srv.tag {
-				// We don't want to run pingers for other
-				// controller machines; they run their own.
-				startPinger = false
-			}
+			// TODO(axw) we shouldn't have to run pingers for
+			// other controller machines; all controllers should
+			// be connecting to at least their own API server
+			// instance, but that isn't currently guaranteed.
+			//
+			// When we move the API server to the dependency
+			// engine, each controller agent should run its own
+			// presence pinger in the dependency engine also.
 		}
 		a.root.entity = entity
 		a.apiObserver.Login(entity.Tag(), a.root.model.ModelTag(), result.controllerMachineLogin, req.UserData)


### PR DESCRIPTION
## Description of change

Controllers are not currently guaranteed to
connect to their own API server, so for now
we ping presence for any connected controller.

## QA steps

1. juju bootstrap localhost
2. juju enable-ha
3. watch juju status -m controller
(all controllers should eventually show up as "started")

Without this change, the secondary controllers may stay "down".

## Documentation changes

None.

## Bug reference

None.