### PR TITLE
CI: log-rotation: Fail early if charm fails to deploy. 

### DIFF
--- a/acceptancetests/assess_log_rotation.py
+++ b/acceptancetests/assess_log_rotation.py
@@ -233,6 +233,7 @@ def main():
         charm_path = local_charm_path(
             charm='fill-logs', juju_ver=client.version, series='trusty')
         client.deploy(charm_path)
+        client.wait_for_workloads()
         if args.agent == "unit":
             test_unit_rotation(client)
         if args.agent == "machine":

--- a/acceptancetests/jujupy/client.py
+++ b/acceptancetests/jujupy/client.py
@@ -1682,12 +1682,10 @@ class ModelClient:
         out = self.get_juju_output("show-action-output", id, "--wait", timeout)
         status = yaml.safe_load(out)["status"]
         if status != "completed":
-            name = ""
-            if action is not None:
-                name = " " + action
+            action_name = '' if not action else ' "{}"'.format(action)
             raise Exception(
-                "timed out waiting for action%s to complete during fetch" %
-                name)
+                'Timed out waiting for action{} to complete during fetch '
+                'with status: {}.'.format(action_name, status))
         return out
 
     def action_do(self, unit, action, *args):


### PR DESCRIPTION
Ensures the test fails early if pre-reqs fail (i.e. charm install). The latest failures where due to Joyent having out of date apt mirrors and thus the install failed.

This branch also clarifies the error message coming from the fetch action.