### PR TITLE
state: destroy backing volumes with machines

### DIFF
--- a/state/filesystem.go
+++ b/state/filesystem.go
@@ -425,7 +425,6 @@ func (st *State) removeMachineFilesystemsOps(m *Machine) ([]txn.Op, error) {
 		})
 	}
 	for _, f := range machineFilesystems {
-		filesystemId := f.Tag().Id()
 		if f.doc.StorageId != "" {
 			// The volume is assigned to a storage instance;
 			// make sure we also remove the storage instance.
@@ -442,15 +441,11 @@ func (st *State) removeMachineFilesystemsOps(m *Machine) ([]txn.Op, error) {
 				},
 			)
 		}
-		ops = append(ops,
-			txn.Op{
-				C:      filesystemsC,
-				Id:     filesystemId,
-				Assert: txn.DocExists,
-				Remove: true,
-			},
-			removeModelFilesystemRefOp(st, filesystemId),
-		)
+		fsOps, err := removeFilesystemOps(st, f)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		ops = append(ops, fsOps...)
 	}
 	return ops, nil
 }


### PR DESCRIPTION
## Description of change

When progressing a machine to Dead, where the
machine has volume-backed filesystems, ensure
we destroy the backing filesystem. The method
for removing machine-scoped filesystems had a
partial/broken approach to removing filesystems;
we now use the "removeFilesystemOps method for
consistency; a "removeVolumeOps" method has
been extracted, and is used similarly.

## QA steps

1. juju bootstrap openstack
2. juju deploy jenkins --storage jenkins=cinder
(wait)
3. juju remove-machine --force 0

It's not entirely repeatable, because there's a race involved. I modified the storage provisioner to prevent it from removing the filesystem before the machine was progressed to Dead and removed.

## Documentation changes

None.

## Bug reference

Fixes the main issue in https://bugs.launchpad.net/juju/+bug/1722818.