### PR TITLE
Address bug #1733920, don't tread model NotFound as an error

### DIFF
--- a/cmd/juju/model/destroy.go
+++ b/cmd/juju/model/destroy.go
@@ -338,10 +338,12 @@ func newTimedModelStatus(ctx *cmd.Context, api DestroyModelAPI, tag names.ModelT
 			return nil
 		}
 		if status[0].Error != nil {
-			if !errors.IsNotFound(status[0].Error) {
-				// No need to give the user a warning that the model they asked
-				// to destroy is no longer there.
-				ctx.Infof("Could not get the model status from the API: %v.", status[0].Error)
+			// No need to give the user a warning that the model they asked
+			// to destroy is no longer there.
+			if errors.IsNotFound(status[0].Error) || params.IsCodeNotFound(status[0].Error) {
+				ctx.Infof("Model destroyed.")
+			} else {
+				ctx.Infof("Could not get the model status from the API: %v", status[0].Error)
 			}
 			return nil
 		}

--- a/cmd/juju/model/destroy.go
+++ b/cmd/juju/model/destroy.go
@@ -338,9 +338,11 @@ func newTimedModelStatus(ctx *cmd.Context, api DestroyModelAPI, tag names.ModelT
 			return nil
 		}
 		if status[0].Error != nil {
-			// This most likely occurred because a model was
-			// destroyed half-way through the call.
-			ctx.Infof("Could not get the model status from the API: %v.", status[0].Error)
+			if !errors.IsNotFound(status[0].Error) {
+				// No need to give the user a warning that the model they asked
+				// to destroy is no longer there.
+				ctx.Infof("Could not get the model status from the API: %v.", status[0].Error)
+			}
 			return nil
 		}
 		return &modelData{


### PR DESCRIPTION
## Description of change

When destroying a model, we should expect it to eventually go away.
Don't treat NotFound as a real error.

## QA steps

```
$ juju add-model testing
$ juju destroy-model testing
Added 'testing' model with credential 'localhost' for user 'admin'
Destroying model
Waiting on model to be removed...
Waiting on model to be removed...
Waiting on model to be removed...
Model destroyed.
```

It used to give
```
$ juju destroy-model testing -y
Destroying model
Waiting on model to be removed...
Waiting on model to be removed...
Could not get the model status from the API: model 815f0b8c-c1f2-4838-8f7c-2b516fdda155 has been removed.
```

## Documentation changes

None

## Bug reference

[lp:1733920](https://bugs.launchpad.net/juju/+bug/1733920)