### PR TITLE
state: short-circuit remove machine filesystems

### DIFF
--- a/state/cleanup.go
+++ b/state/cleanup.go
@@ -542,6 +542,64 @@ func (st *State) cleanupContainers(machine *Machine) error {
 }
 
 func cleanupDyingMachineResources(m *Machine) error {
+	// Destroy non-detachable machine filesystems first.
+	filesystems, err := m.st.filesystems(bson.D{{"machineid", m.Id()}})
+	if err != nil {
+		return errors.Annotate(err, "getting machine filesystems")
+	}
+	for _, f := range filesystems {
+		if err := m.st.DestroyFilesystem(f.FilesystemTag()); err != nil {
+			return errors.Trace(err)
+		}
+	}
+
+	// Check if the machine is manual, to decide whether or not to
+	// short circuit the removal of non-detachable filesystems.
+	manual, err := m.IsManual()
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	// Detach all filesystems from the machine.
+	filesystemAttachments, err := m.st.MachineFilesystemAttachments(m.MachineTag())
+	if err != nil {
+		return errors.Annotate(err, "getting machine filesystem attachments")
+	}
+	for _, fsa := range filesystemAttachments {
+		detachable, err := isDetachableFilesystemTag(m.st, fsa.Filesystem())
+		if err != nil {
+			return errors.Trace(err)
+		}
+		if detachable {
+			if err := m.st.DetachFilesystem(fsa.Machine(), fsa.Filesystem()); err != nil {
+				return errors.Trace(err)
+			}
+		} else if !manual {
+			// For non-manual machines we immediately remove the non-detachable
+			// filesystem attachments, which should have been set to Dying by
+			// the destruction of the machine filesystems above.
+			if err := m.st.RemoveFilesystemAttachment(fsa.Machine(), fsa.Filesystem()); err != nil {
+				return errors.Trace(err)
+			}
+		}
+	}
+
+	// For non-manual machines we immediately remove the non-detachable
+	// filesystems, which should have been detached above. Short circuiting
+	// the removal of machine filesystems means we can avoid stuck
+	// filesystems preventing any model-scoped backing volumes from being
+	// detached and destroyed. For non-manual machines this is safe, because
+	// the machine is about to be terminated. For manual machines, stuck
+	// filesystems will have to be fixed manually.
+	if !manual {
+		for _, f := range filesystems {
+			if err := m.st.RemoveFilesystem(f.FilesystemTag()); err != nil {
+				return errors.Trace(err)
+			}
+		}
+	}
+
+	// Detach all remaining volumes from the machine.
 	volumeAttachments, err := m.st.MachineVolumeAttachments(m.MachineTag())
 	if err != nil {
 		return errors.Annotate(err, "getting machine volume attachments")
@@ -560,21 +618,6 @@ func cleanupDyingMachineResources(m *Machine) error {
 				// destruction is initiated below.
 				continue
 			}
-			return errors.Trace(err)
-		}
-	}
-	filesystemAttachments, err := m.st.MachineFilesystemAttachments(m.MachineTag())
-	if err != nil {
-		return errors.Annotate(err, "getting machine filesystem attachments")
-	}
-	for _, fsa := range filesystemAttachments {
-		if detachable, err := isDetachableFilesystemTag(m.st, fsa.Filesystem()); err != nil {
-			return errors.Trace(err)
-		} else if !detachable {
-			// Non-detachable filesystems will be removed along with the machine.
-			continue
-		}
-		if err := m.st.DetachFilesystem(fsa.Machine(), fsa.Filesystem()); err != nil {
 			return errors.Trace(err)
 		}
 	}


### PR DESCRIPTION
## Description of change

When a machine is destroyed and its cleanup is
run, short-circuit the removal of non-detachable
filesystems as long as the machine is non-manual.
For manual machines, the machine is not going
anywhere, so the filesystem must be detached and
destroyed by the machine's storage provisioner.

Note that the cleanup will still continue to fail
while the filesystem has a related a storage instance,
meaning the unit has not run the storage-detaching
hook. This ensures that we don't pull the filesystem
out from underneath the unit during destruction.

## QA steps

1. juju bootstrap openstack
2. juju deploy jenkins --storage jenkins=cinder
(wait)
3. juju ssh 0
cd /srv/mnt/jenkins
(just sit there to prevent the filesystem being unmounted)
4. juju remove-application jenkins
(the machine should be removed successfully, and the cinder volume should be removed)

## Documentation changes

None.

## Bug reference

Fixes the other half of https://bugs.launchpad.net/juju/+bug/1722818