### PR TITLE
CI: Add user permission CMR test, use actual DB app.

### DIFF
--- a/acceptancetests/jujupy/client.py
+++ b/acceptancetests/jujupy/client.py
@@ -569,6 +569,9 @@ class ModelClient:
 
     controller_permissions = frozenset(['login', 'addmodel', 'superuser'])
 
+    # Granting 'login' will error as a created user has that at creation.
+    ignore_permissions = frozenset(['login'])
+
     reserved_spaces = frozenset([
         'endpoint-bindings-data', 'endpoint-bindings-public'])
 
@@ -1935,6 +1938,9 @@ class ModelClient:
 
     def grant(self, user_name, permission, model=None):
         """Grant the user with model or controller permission."""
+        if permission in self.ignore_permissions:
+            log.info('Ignoring permission "{}".'.format(permission))
+            return
         if permission in self.controller_permissions:
             self.juju(
                 'grant',

--- a/acceptancetests/jujupy/tests/test_client.py
+++ b/acceptancetests/jujupy/tests/test_client.py
@@ -3035,11 +3035,12 @@ class TestModelClient(ClientTest):
                 get_output.assert_called_with(
                     'add-user', *expected_args, include_e=False)
                 if permissions == 'login':
-                    mock_juju.assert_called_once_with(
-                        'grant',
-                        ('fakeuser', permissions,
-                         '-c', fake_client.env.controller.name),
-                        include_e=False)
+                    # Granting login is ignored, it's implicit when adding
+                    # a user.
+                    if mock_juju.call_count != 0:
+                        raise Exception(
+                            'Call count {} != 0'.format(
+                                mock_juju.call_count))
                 else:
                     mock_juju.assert_called_once_with(
                         'grant',


### PR DESCRIPTION
This addition to the existing CMR functional tests changes out the dummy charms used to 'actual' charms that have workloads etc. 
The charms used are mediawiki and mysql.

It also adds the scenario of an admin user granting a normal user (with login perms) access to an offer. This user consumes the offer  from another model (and potentially controller) where they have permissions to do so.