### PR TITLE
Create a helper script for generating password entries for users and agents.

### DIFF
--- a/scripts/generate-password/main.go
+++ b/scripts/generate-password/main.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"strings"
+
+	"github.com/juju/gnuflag"
+	"github.com/juju/utils"
+)
+
+func main() {
+	gnuflag.Usage = func() {
+		fmt.Fprintf(os.Stderr, "Usage: %s [modeluuid agent|--user <username>]\n", os.Args[0])
+		gnuflag.PrintDefaults()
+	}
+	user := gnuflag.String("user", "", "supply a username to generate a password instead of modeluuid and agent")
+	gnuflag.Parse(true)
+	args := gnuflag.Args()
+	var modelUUID string
+	var agent string
+	if *user == "" {
+		if len(args) < 2 {
+			gnuflag.Usage()
+			os.Exit(1)
+		}
+		modelUUID = args[0]
+		agent = args[1]
+	}
+	passwd, err := utils.RandomPassword()
+	if err != nil {
+		log.Fatal(err)
+	}
+	if *user != "" {
+		salt, err := utils.RandomSalt()
+		if err != nil {
+			log.Fatal(err)
+		}
+		hash := utils.UserPasswordHash(passwd, salt)
+		fmt.Printf("Password line for ~/.local/share/juju/accounts.yaml\n")
+		fmt.Printf("  password: %s\n", passwd)
+		fmt.Printf(`db.users.update({"_id": "%s"}, {"$set": {"passwordsalt": "%s", "passwordhash": "%s"}})`+"\n",
+			*user, salt, hash)
+	} else {
+		hash := utils.AgentPasswordHash(passwd)
+		fmt.Printf("oldpassword: %s\n", passwd)
+		collection := "UNKNOWN"
+		if strings.Index(agent, "/") < 0 {
+			// must be a machine
+			collection = "machines"
+		} else {
+			collection = "units"
+		}
+		fmt.Printf(`db.%s.update({"_id": "%s:%s"}, {$set: {"passwordhash": "%s"}})`+"\n",
+			collection, modelUUID, agent, hash)
+	}
+}


### PR DESCRIPTION
## Description of change

If you ever need to reset a user or agent password during maintenance, it can be hard to figure out exactly what needs to go in the various password hash fields.
This is a helper that uses our existing utils package to generate a new random user password and machine password.

## QA steps

```
$ juju bootstrap
$ juju deploy foo
$ juju models --uuid
$ generate-password UUID foo/0
# Should give you a database record to update and a value to update in agent.conf
# If you do both, the agent unit-foo-0 should still be able to connect to the database.
$ generate-password --user admin
# should generate similar mongo updates and values for ~/.local/share/accounts.yaml.
```

## Documentation changes

I don't think we document unofficial scripts.

## Bug reference

None
