### PR TITLE
Ignore interface-local and link-local addresses when discovering subnets

### DIFF
--- a/state/spacesdiscovery.go
+++ b/state/spacesdiscovery.go
@@ -68,11 +68,18 @@ func (st *State) SaveSubnetsFromProvider(subnets []network.SubnetInfo, spaceName
 		if modelSubnetIds.Contains(string(subnet.ProviderId)) {
 			continue
 		}
+		ip, _, err := net.ParseCIDR(subnet.CIDR)
+		if err != nil {
+			return errors.Trace(err)
+		}
+		if ip.IsInterfaceLocalMulticast() || ip.IsLinkLocalMulticast() || ip.IsLinkLocalUnicast() {
+			continue
+		}
 		var firstZone string
 		if len(subnet.AvailabilityZones) > 0 {
 			firstZone = subnet.AvailabilityZones[0]
 		}
-		_, err := st.AddSubnet(SubnetInfo{
+		_, err = st.AddSubnet(SubnetInfo{
 			ProviderId:        subnet.ProviderId,
 			ProviderNetworkId: subnet.ProviderNetworkId,
 			CIDR:              subnet.CIDR,


### PR DESCRIPTION
## Description of change
Juju should ignore link-local and interface-local subnets when doing subnet discovery

## QA steps
Reload spaces on openstack providing link-local subnet, check that juju subnets doesn't show this subnet.

## Bug reference
https://bugs.launchpad.net/juju/+bug/1733266