### PR TITLE
audit-logging: Add core.auditlog package

### DIFF
--- a/core/auditlog/auditlog.go
+++ b/core/auditlog/auditlog.go
@@ -1,0 +1,98 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+package auditlog
+
+import (
+	"encoding/hex"
+	"math/rand"
+
+	"github.com/juju/errors"
+)
+
+// Call represents a high-level juju command from the juju client (or
+// other client). There'll be one Call per API connection, with zero
+// or more associated FacadeMethods.
+type Call struct {
+	Who          string `yaml:"who"`        // username@idm
+	What         string `yaml:"what"`       // "juju deploy ./foo/bar"
+	When         string `yaml:"when"`       // ISO 8601 to second precision
+	ModelName    string `yaml:"model-name"` // full representation "user/name"
+	ModelUUID    string `yaml:"model-uuid"`
+	ConnectionID string `yaml:"connection-id"` // uint64 in hex
+}
+
+// CallArgs is the information needed to create a method recorder.
+type CallArgs struct {
+	Who       string
+	What      string
+	When      string
+	ModelName string
+	ModelUUID string
+}
+
+// FacadeMethod represents a call to an API facade made as part of
+// executing a specific high-level command.
+type FacadeMethod struct {
+	ConnectionID string `yaml:"connection-id"`
+	Facade       string `yaml:"facade"`
+	Method       string `yaml:"method"`
+	Version      int    `yaml:"version"`
+	Args         string `yaml:"args"`
+}
+
+// MethodArgs is the information about an API call that we want to
+// record.
+type MethodArgs struct {
+	Facade  string
+	Method  string
+	Version int
+	Args    string
+}
+
+// AuditLog represents something that can store calls and methods
+// somewhere.
+type AuditLog interface {
+	AddCall(c Call) error
+	AddMethod(m FacadeMethod) error
+}
+
+// Recorder records method calls for a specific API connection.
+type Recorder struct {
+	log          AuditLog
+	connectionID string
+}
+
+// NewRecorder creates a Recorder for the connection described (and
+// stores details of the initial call in the log).
+func NewRecorder(log AuditLog, c CallArgs) (*Recorder, error) {
+	connectionID := newConnectionID()
+	err := log.AddCall(Call{
+		ConnectionID: connectionID,
+		Who:          c.Who,
+		What:         c.What,
+		When:         c.When,
+		ModelName:    c.ModelName,
+		ModelUUID:    c.ModelUUID,
+	})
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return &Recorder{log: log, connectionID: connectionID}, nil
+}
+
+// Add records a method call to the API.
+func (r *Recorder) Add(m MethodArgs) error {
+	return errors.Trace(r.log.AddMethod(FacadeMethod{
+		ConnectionID: r.connectionID,
+		Facade:       m.Facade,
+		Method:       m.Method,
+		Version:      m.Version,
+		Args:         m.Args,
+	}))
+}
+
+func newConnectionID() string {
+	buf := make([]byte, 8)
+	rand.Read(buf) // Can't fail
+	return hex.EncodeToString(buf)
+}

--- a/core/auditlog/auditlog.go
+++ b/core/auditlog/auditlog.go
@@ -4,97 +4,143 @@ package auditlog
 
 import (
 	"encoding/hex"
+	"encoding/json"
+	"fmt"
 	"io"
 	"math/rand"
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/juju/errors"
+	"github.com/juju/loggo"
 	"github.com/juju/utils"
 	"gopkg.in/natefinch/lumberjack.v2"
-	"gopkg.in/yaml.v2"
 )
+
+var logger = loggo.GetLogger("core.auditlog")
 
 // Call represents a high-level juju command from the juju client (or
 // other client). There'll be one Call per API connection, with zero
 // or more associated FacadeMethods.
 type Call struct {
-	Who          string `yaml:"who"`        // username@idm
-	What         string `yaml:"what"`       // "juju deploy ./foo/bar"
-	When         string `yaml:"when"`       // ISO 8601 to second precision
-	ModelName    string `yaml:"model-name"` // full representation "user/name"
-	ModelUUID    string `yaml:"model-uuid"`
-	ConnectionID string `yaml:"connection-id"` // uint64 in hex
+	Who          string `json:"who"`        // username@idm
+	What         string `json:"what"`       // "juju deploy ./foo/bar"
+	When         string `json:"when"`       // ISO 8601 to second precision
+	ModelName    string `json:"model-name"` // full representation "user/name"
+	ModelUUID    string `json:"model-uuid"`
+	CallID       string `json:"call-id"`       // uint64 in hex
+	ConnectionID string `json:"connection-id"` // uint64 in hex (using %X to match the value in log files)
 }
 
 // CallArgs is the information needed to create a method recorder.
 type CallArgs struct {
-	Who       string
-	What      string
-	When      string
-	ModelName string
-	ModelUUID string
+	Who          string
+	What         string
+	When         time.Time
+	ModelName    string
+	ModelUUID    string
+	ConnectionID uint64
 }
 
-// FacadeMethod represents a call to an API facade made as part of
+// FacadeRequest represents a call to an API facade made as part of
 // executing a specific high-level command.
-type FacadeMethod struct {
-	ConnectionID string `yaml:"connection-id"`
-	Facade       string `yaml:"facade"`
-	Method       string `yaml:"method"`
-	Version      int    `yaml:"version"`
-	Args         string `yaml:"args"`
+type FacadeRequest struct {
+	CallID       string `json:"call-id"`
+	ConnectionID string `json:"connection-id"`
+	RequestID    uint64 `json:"request-id"`
+	Facade       string `json:"facade"`
+	Method       string `json:"method"`
+	Version      int    `json:"version"`
+	Args         string `json:"args,omitempty"`
 }
 
-// MethodArgs is the information about an API call that we want to
+// RequestArgs is the information about an API call that we want to
 // record.
-type MethodArgs struct {
-	Facade  string
-	Method  string
-	Version int
-	Args    string
+type RequestArgs struct {
+	Facade    string
+	Method    string
+	Version   int
+	Args      string
+	RequestID uint64
 }
 
+// FacadeResponse captures any errors coming back from the API in
+// response to a request.
+type FacadeResponse struct {
+	CallID       string   `json:"call-id"`
+	ConnectionID string   `json:"connection-id"`
+	RequestID    uint64   `json:"request-id"`
+	Errors       []*Error `json:"errors"`
+}
+
+// ResponseArgs is the information about an API response to record in
+// the audit log.
+type ResponseArgs struct {
+	RequestID uint64
+	Errors    []*Error
+}
+
+// Error holds the details of an error sent back from the API.
+type Error struct {
+	Message string `json:"message"`
+	Code    string `json:"code"`
+}
+
+// Record is the top-level entry type in an audit log, which serves as
+// a type discriminator. Only one of Call/Request/Response should be set.
 type Record struct {
-	Call   Call         `yaml:"call"`
-	Method FacadeMethod `yaml:"method"`
+	Call     *Call           `json:"call,omitempty"`
+	Request  *FacadeRequest  `json:"request,omitempty"`
+	Response *FacadeResponse `json:"response,omitempty"`
 }
 
-// AuditLog represents something that can store calls and methods
-// somewhere.
+// AuditLog represents something that can store calls, requests and
+// responses somewhere.
 type AuditLog interface {
 	AddCall(c Call) error
-	AddMethod(m FacadeMethod) error
+	AddRequest(r FacadeRequest) error
+	AddResponse(r FacadeResponse) error
+	Close() error
 }
 
 // Recorder records method calls for a specific API connection.
 type Recorder struct {
 	log          AuditLog
 	connectionID string
+	callID       string
 }
 
 // NewRecorder creates a Recorder for the connection described (and
 // stores details of the initial call in the log).
 func NewRecorder(log AuditLog, c CallArgs) (*Recorder, error) {
-	connectionID := newConnectionID()
+	callID := newCallID()
+	connectionID := idString(c.ConnectionID)
 	err := log.AddCall(Call{
+		CallID:       callID,
 		ConnectionID: connectionID,
 		Who:          c.Who,
 		What:         c.What,
-		When:         c.When,
+		When:         c.When.Format(time.RFC3339),
 		ModelName:    c.ModelName,
 		ModelUUID:    c.ModelUUID,
 	})
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	return &Recorder{log: log, connectionID: connectionID}, nil
+	return &Recorder{
+		log:          log,
+		callID:       callID,
+		connectionID: connectionID,
+	}, nil
 }
 
-// Add records a method call to the API.
-func (r *Recorder) Add(m MethodArgs) error {
-	return errors.Trace(r.log.AddMethod(FacadeMethod{
+// AddRequest records a method call to the API.
+func (r *Recorder) AddRequest(m RequestArgs) error {
+	return errors.Trace(r.log.AddRequest(FacadeRequest{
+		CallID:       r.callID,
 		ConnectionID: r.connectionID,
+		RequestID:    m.RequestID,
 		Facade:       m.Facade,
 		Method:       m.Method,
 		Version:      m.Version,
@@ -102,7 +148,17 @@ func (r *Recorder) Add(m MethodArgs) error {
 	}))
 }
 
-func newConnectionID() string {
+// AddResponse records the result of a method call to the API.
+func (r *Recorder) AddResponse(m ResponseArgs) error {
+	return errors.Trace(r.log.AddResponse(FacadeResponse{
+		CallID:       r.callID,
+		ConnectionID: r.connectionID,
+		RequestID:    m.RequestID,
+		Errors:       m.Errors,
+	}))
+}
+
+func newCallID() string {
 	buf := make([]byte, 8)
 	rand.Read(buf) // Can't fail
 	return hex.EncodeToString(buf)
@@ -112,10 +168,10 @@ type AuditLogFile struct {
 	fileLogger io.WriteCloser
 }
 
-// NewLogFileSink returns an audit entry sink which writes
-// to an audit.log file in the specified directory.
+// NewLogFile returns an audit entry sink which writes to an audit.log
+// file in the specified directory.
 func NewLogFile(logDir string) *AuditLogFile {
-	logPath := filepath.Join(logDir, "audit-log.yaml")
+	logPath := filepath.Join(logDir, "audit.log")
 	if err := primeLogFile(logPath); err != nil {
 		// This isn't a fatal error so log and continue if priming
 		// fails.
@@ -132,32 +188,41 @@ func NewLogFile(logDir string) *AuditLogFile {
 	}
 }
 
+// AddCall implements AuditLog.
 func (a *AuditLogFile) AddCall(c Call) error {
-	return errors.Trace(a.addRecord(Record{Call: c}))
+	return errors.Trace(a.addRecord(Record{Call: &c}))
 }
 
-func (a *AuditLogFile) AddMethod(m FacadeMethod) error {
-	return errors.Trace(a.addRecord(Record{Method: m}))
+// AddRequest implements AuditLog.
+func (a *AuditLogFile) AddRequest(m FacadeRequest) error {
+	return errors.Trace(a.addRecord(Record{Request: &m}))
+
 }
 
+// AddResponse implements AuditLog.
+func (a *AuditLogFile) AddResponse(m FacadeResponse) error {
+	return errors.Trace(a.addRecord(Record{Response: &m}))
+}
+
+// Close implements AuditLog.
 func (a *AuditLogFile) Close() error {
 	return errors.Trace(a.fileLogger.Close())
 }
 
-const documentStart = "---\n"
-
 func (a *AuditLogFile) addRecord(r Record) error {
-	bytes, err := yaml.Marshal(r)
+	bytes, err := json.Marshal(r)
 	if err != nil {
 		return errors.Trace(err)
 	}
-	// Combining the start and document together in one write to
-	// prevent lumberjack from rolling the file between them.
-	withStart := make([]byte, 0, len(documentStart)+len(bytes))
-	withStart = append(withStart, []byte(documentStart)...)
-	withStart = append(withStart, bytes...)
-	_, err = a.fileLogger.Write(withStart)
+	// Add a linebreak to bytes rather than doing two calls to write
+	// just in case lumberjack rolls the file between them.
+	bytes = append(bytes, byte('\n'))
+	_, err = a.fileLogger.Write(bytes)
 	return errors.Trace(err)
+}
+
+func idString(id uint64) string {
+	return fmt.Sprintf("%X", id)
 }
 
 // primeLogFile ensures the logsink log file is created with the

--- a/core/auditlog/auditlog.go
+++ b/core/auditlog/auditlog.go
@@ -4,9 +4,15 @@ package auditlog
 
 import (
 	"encoding/hex"
+	"io"
 	"math/rand"
+	"os"
+	"path/filepath"
 
 	"github.com/juju/errors"
+	"github.com/juju/utils"
+	"gopkg.in/natefinch/lumberjack.v2"
+	"gopkg.in/yaml.v2"
 )
 
 // Call represents a high-level juju command from the juju client (or
@@ -47,6 +53,11 @@ type MethodArgs struct {
 	Method  string
 	Version int
 	Args    string
+}
+
+type Record struct {
+	Call   Call         `yaml:"call"`
+	Method FacadeMethod `yaml:"method"`
 }
 
 // AuditLog represents something that can store calls and methods
@@ -95,4 +106,70 @@ func newConnectionID() string {
 	buf := make([]byte, 8)
 	rand.Read(buf) // Can't fail
 	return hex.EncodeToString(buf)
+}
+
+type AuditLogFile struct {
+	fileLogger io.WriteCloser
+}
+
+// NewLogFileSink returns an audit entry sink which writes
+// to an audit.log file in the specified directory.
+func NewLogFile(logDir string) *AuditLogFile {
+	logPath := filepath.Join(logDir, "audit-log.yaml")
+	if err := primeLogFile(logPath); err != nil {
+		// This isn't a fatal error so log and continue if priming
+		// fails.
+		logger.Errorf("Unable to prime %s (proceeding anyway): %v", logPath, err)
+	}
+
+	return &AuditLogFile{
+		fileLogger: &lumberjack.Logger{
+			Filename:   logPath,
+			MaxSize:    300, // MB
+			MaxBackups: 10,
+			Compress:   true,
+		},
+	}
+}
+
+func (a *AuditLogFile) AddCall(c Call) error {
+	return errors.Trace(a.addRecord(Record{Call: c}))
+}
+
+func (a *AuditLogFile) AddMethod(m FacadeMethod) error {
+	return errors.Trace(a.addRecord(Record{Method: m}))
+}
+
+func (a *AuditLogFile) Close() error {
+	return errors.Trace(a.fileLogger.Close())
+}
+
+const documentStart = "---\n"
+
+func (a *AuditLogFile) addRecord(r Record) error {
+	bytes, err := yaml.Marshal(r)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	// Combining the start and document together in one write to
+	// prevent lumberjack from rolling the file between them.
+	withStart := make([]byte, 0, len(documentStart)+len(bytes))
+	withStart = append(withStart, []byte(documentStart)...)
+	withStart = append(withStart, bytes...)
+	_, err = a.fileLogger.Write(withStart)
+	return errors.Trace(err)
+}
+
+// primeLogFile ensures the logsink log file is created with the
+// correct mode and ownership.
+func primeLogFile(path string) error {
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY, 0600)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	if err := f.Close(); err != nil {
+		return errors.Trace(err)
+	}
+	err = utils.ChownPath(path, "syslog")
+	return errors.Trace(err)
 }

--- a/core/auditlog/auditlog_test.go
+++ b/core/auditlog/auditlog_test.go
@@ -23,30 +23,30 @@ var _ = gc.Suite(&AuditLogSuite{})
 
 func (s *AuditLogSuite) TestAuditLogFile(c *gc.C) {
 	dir := c.MkDir()
-	logFile := auditlog.NewLogFile(dir)
-	err := logFile.AddCall(auditlog.Call{
-		Who:          "deerhoof",
-		What:         "gojira",
-		When:         "2017-11-27T13:21:24Z",
-		ModelName:    "admin/default",
-		CallID:       "0123456789abcdef",
-		ConnectionID: "AC1",
+	logFile := auditlog.NewLogFile(dir, 300, 10)
+	err := logFile.AddConversation(auditlog.Conversation{
+		Who:            "deerhoof",
+		What:           "gojira",
+		When:           "2017-11-27T13:21:24Z",
+		ModelName:      "admin/default",
+		ConversationID: "0123456789abcdef",
+		ConnectionID:   "AC1",
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	err = logFile.AddRequest(auditlog.FacadeRequest{
-		CallID:       "0123456789abcdef",
-		ConnectionID: "AC1",
-		RequestID:    25,
-		Facade:       "Application",
-		Method:       "Deploy",
-		Version:      4,
-		Args:         `{"applications": [{"application": "prometheus"}]}`,
+	err = logFile.AddRequest(auditlog.Request{
+		ConversationID: "0123456789abcdef",
+		ConnectionID:   "AC1",
+		RequestID:      25,
+		Facade:         "Application",
+		Method:         "Deploy",
+		Version:        4,
+		Args:           `{"applications": [{"application": "prometheus"}]}`,
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	err = logFile.AddResponse(auditlog.FacadeResponse{
-		CallID:       "0123456789abcdef",
-		ConnectionID: "AC1",
-		RequestID:    25,
+	err = logFile.AddResponse(auditlog.ResponseErrors{
+		ConversationID: "0123456789abcdef",
+		ConnectionID:   "AC1",
+		RequestID:      25,
 		Errors: []*auditlog.Error{
 			{Message: "oops", Code: "unauthorized access"},
 		},
@@ -61,7 +61,7 @@ func (s *AuditLogSuite) TestAuditLogFile(c *gc.C) {
 
 func (s *AuditLogSuite) TestAuditLogFilePriming(c *gc.C) {
 	dir := c.MkDir()
-	logFile := auditlog.NewLogFile(dir)
+	logFile := auditlog.NewLogFile(dir, 300, 10)
 	err := logFile.Close()
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -75,7 +75,7 @@ func (s *AuditLogSuite) TestRecorder(c *gc.C) {
 	var log fakeLog
 	logTime, err := time.Parse(time.RFC3339, "2017-11-27T15:45:23Z")
 	c.Assert(err, jc.ErrorIsNil)
-	rec, err := auditlog.NewRecorder(&log, auditlog.CallArgs{
+	rec, err := auditlog.NewRecorder(&log, auditlog.ConversationArgs{
 		Who:          "wildbirds and peacedrums",
 		What:         "Doubt/Hope",
 		When:         logTime,
@@ -91,7 +91,7 @@ func (s *AuditLogSuite) TestRecorder(c *gc.C) {
 		Args:      `{"a": "something"}`,
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	err = rec.AddResponse(auditlog.ResponseArgs{
+	err = rec.AddResponse(auditlog.ResponseErrorsArgs{
 		RequestID: 246,
 		Errors: []*auditlog.Error{{
 			Message: "something bad",
@@ -99,31 +99,31 @@ func (s *AuditLogSuite) TestRecorder(c *gc.C) {
 		}},
 	})
 
-	log.stub.CheckCallNames(c, "AddCall", "AddRequest", "AddResponse")
+	log.stub.CheckCallNames(c, "AddConversation", "AddRequest", "AddResponse")
 	calls := log.stub.Calls()
-	rec0 := calls[0].Args[0].(auditlog.Call)
-	callID := rec0.CallID
-	c.Assert(rec0, gc.DeepEquals, auditlog.Call{
-		Who:          "wildbirds and peacedrums",
-		What:         "Doubt/Hope",
-		When:         "2017-11-27T15:45:23Z",
-		ModelName:    "admin/default",
-		ConnectionID: "2AF",
-		CallID:       callID,
+	rec0 := calls[0].Args[0].(auditlog.Conversation)
+	callID := rec0.ConversationID
+	c.Assert(rec0, gc.DeepEquals, auditlog.Conversation{
+		Who:            "wildbirds and peacedrums",
+		What:           "Doubt/Hope",
+		When:           "2017-11-27T15:45:23Z",
+		ModelName:      "admin/default",
+		ConnectionID:   "2AF",
+		ConversationID: callID,
 	})
-	c.Assert(calls[1].Args[0], gc.DeepEquals, auditlog.FacadeRequest{
-		CallID:       callID,
-		ConnectionID: "2AF",
-		RequestID:    246,
-		Facade:       "Death Vessel",
-		Method:       "Horchata",
-		Version:      5,
-		Args:         `{"a": "something"}`,
+	c.Assert(calls[1].Args[0], gc.DeepEquals, auditlog.Request{
+		ConversationID: callID,
+		ConnectionID:   "2AF",
+		RequestID:      246,
+		Facade:         "Death Vessel",
+		Method:         "Horchata",
+		Version:        5,
+		Args:           `{"a": "something"}`,
 	})
-	c.Assert(calls[2].Args[0], gc.DeepEquals, auditlog.FacadeResponse{
-		CallID:       callID,
-		ConnectionID: "2AF",
-		RequestID:    246,
+	c.Assert(calls[2].Args[0], gc.DeepEquals, auditlog.ResponseErrors{
+		ConversationID: callID,
+		ConnectionID:   "2AF",
+		RequestID:      246,
 		Errors: []*auditlog.Error{{
 			Message: "something bad",
 			Code:    "bad request",
@@ -135,17 +135,17 @@ type fakeLog struct {
 	stub testing.Stub
 }
 
-func (l *fakeLog) AddCall(m auditlog.Call) error {
-	l.stub.AddCall("AddCall", m)
+func (l *fakeLog) AddConversation(m auditlog.Conversation) error {
+	l.stub.AddCall("AddConversation", m)
 	return l.stub.NextErr()
 }
 
-func (l *fakeLog) AddRequest(m auditlog.FacadeRequest) error {
+func (l *fakeLog) AddRequest(m auditlog.Request) error {
 	l.stub.AddCall("AddRequest", m)
 	return l.stub.NextErr()
 }
 
-func (l *fakeLog) AddResponse(m auditlog.FacadeResponse) error {
+func (l *fakeLog) AddResponse(m auditlog.ResponseErrors) error {
 	l.stub.AddCall("AddResponse", m)
 	return l.stub.NextErr()
 }
@@ -157,8 +157,8 @@ func (l *fakeLog) Close() error {
 
 var (
 	expectedLogContents = `
-{"call":{"who":"deerhoof","what":"gojira","when":"2017-11-27T13:21:24Z","model-name":"admin/default","model-uuid":"","call-id":"0123456789abcdef","connection-id":"AC1"}}
-{"request":{"call-id":"0123456789abcdef","connection-id":"AC1","request-id":25,"facade":"Application","method":"Deploy","version":4,"args":"{\"applications\": [{\"application\": \"prometheus\"}]}"}}
-{"response":{"call-id":"0123456789abcdef","connection-id":"AC1","request-id":25,"errors":[{"message":"oops","code":"unauthorized access"}]}}
+{"conversation":{"who":"deerhoof","what":"gojira","when":"2017-11-27T13:21:24Z","model-name":"admin/default","model-uuid":"","conversation-id":"0123456789abcdef","connection-id":"AC1"}}
+{"request":{"conversation-id":"0123456789abcdef","connection-id":"AC1","request-id":25,"facade":"Application","method":"Deploy","version":4,"args":"{\"applications\": [{\"application\": \"prometheus\"}]}"}}
+{"errors":{"conversation-id":"0123456789abcdef","connection-id":"AC1","request-id":25,"errors":[{"message":"oops","code":"unauthorized access"}]}}
 `[1:]
 )

--- a/core/auditlog/auditlog_test.go
+++ b/core/auditlog/auditlog_test.go
@@ -1,0 +1,164 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+package auditlog_test
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/core/auditlog"
+)
+
+type AuditLogSuite struct {
+	testing.IsolationSuite
+}
+
+var _ = gc.Suite(&AuditLogSuite{})
+
+func (s *AuditLogSuite) TestAuditLogFile(c *gc.C) {
+	dir := c.MkDir()
+	logFile := auditlog.NewLogFile(dir)
+	err := logFile.AddCall(auditlog.Call{
+		Who:          "deerhoof",
+		What:         "gojira",
+		When:         "2017-11-27T13:21:24Z",
+		ModelName:    "admin/default",
+		CallID:       "0123456789abcdef",
+		ConnectionID: "AC1",
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	err = logFile.AddRequest(auditlog.FacadeRequest{
+		CallID:       "0123456789abcdef",
+		ConnectionID: "AC1",
+		RequestID:    25,
+		Facade:       "Application",
+		Method:       "Deploy",
+		Version:      4,
+		Args:         `{"applications": [{"application": "prometheus"}]}`,
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	err = logFile.AddResponse(auditlog.FacadeResponse{
+		CallID:       "0123456789abcdef",
+		ConnectionID: "AC1",
+		RequestID:    25,
+		Errors: []*auditlog.Error{
+			{Message: "oops", Code: "unauthorized access"},
+		},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	err = logFile.Close()
+	c.Assert(err, jc.ErrorIsNil)
+
+	bytes, err := ioutil.ReadFile(filepath.Join(dir, "audit.log"))
+	c.Assert(string(bytes), gc.Equals, expectedLogContents)
+}
+
+func (s *AuditLogSuite) TestAuditLogFilePriming(c *gc.C) {
+	dir := c.MkDir()
+	logFile := auditlog.NewLogFile(dir)
+	err := logFile.Close()
+	c.Assert(err, jc.ErrorIsNil)
+
+	info, err := os.Stat(filepath.Join(dir, "audit.log"))
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(info.Mode(), gc.Equals, os.FileMode(0600))
+	// The chown will only work when run as root.
+}
+
+func (s *AuditLogSuite) TestRecorder(c *gc.C) {
+	var log fakeLog
+	logTime, err := time.Parse(time.RFC3339, "2017-11-27T15:45:23Z")
+	c.Assert(err, jc.ErrorIsNil)
+	rec, err := auditlog.NewRecorder(&log, auditlog.CallArgs{
+		Who:          "wildbirds and peacedrums",
+		What:         "Doubt/Hope",
+		When:         logTime,
+		ModelName:    "admin/default",
+		ConnectionID: 687,
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	err = rec.AddRequest(auditlog.RequestArgs{
+		RequestID: 246,
+		Facade:    "Death Vessel",
+		Method:    "Horchata",
+		Version:   5,
+		Args:      `{"a": "something"}`,
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	err = rec.AddResponse(auditlog.ResponseArgs{
+		RequestID: 246,
+		Errors: []*auditlog.Error{{
+			Message: "something bad",
+			Code:    "bad request",
+		}},
+	})
+
+	log.stub.CheckCallNames(c, "AddCall", "AddRequest", "AddResponse")
+	calls := log.stub.Calls()
+	rec0 := calls[0].Args[0].(auditlog.Call)
+	callID := rec0.CallID
+	c.Assert(rec0, gc.DeepEquals, auditlog.Call{
+		Who:          "wildbirds and peacedrums",
+		What:         "Doubt/Hope",
+		When:         "2017-11-27T15:45:23Z",
+		ModelName:    "admin/default",
+		ConnectionID: "2AF",
+		CallID:       callID,
+	})
+	c.Assert(calls[1].Args[0], gc.DeepEquals, auditlog.FacadeRequest{
+		CallID:       callID,
+		ConnectionID: "2AF",
+		RequestID:    246,
+		Facade:       "Death Vessel",
+		Method:       "Horchata",
+		Version:      5,
+		Args:         `{"a": "something"}`,
+	})
+	c.Assert(calls[2].Args[0], gc.DeepEquals, auditlog.FacadeResponse{
+		CallID:       callID,
+		ConnectionID: "2AF",
+		RequestID:    246,
+		Errors: []*auditlog.Error{{
+			Message: "something bad",
+			Code:    "bad request",
+		}},
+	})
+}
+
+type fakeLog struct {
+	stub testing.Stub
+}
+
+func (l *fakeLog) AddCall(m auditlog.Call) error {
+	l.stub.AddCall("AddCall", m)
+	return l.stub.NextErr()
+}
+
+func (l *fakeLog) AddRequest(m auditlog.FacadeRequest) error {
+	l.stub.AddCall("AddRequest", m)
+	return l.stub.NextErr()
+}
+
+func (l *fakeLog) AddResponse(m auditlog.FacadeResponse) error {
+	l.stub.AddCall("AddResponse", m)
+	return l.stub.NextErr()
+}
+
+func (l *fakeLog) Close() error {
+	l.stub.AddCall("Close")
+	return l.stub.NextErr()
+}
+
+var (
+	expectedLogContents = `
+{"call":{"who":"deerhoof","what":"gojira","when":"2017-11-27T13:21:24Z","model-name":"admin/default","model-uuid":"","call-id":"0123456789abcdef","connection-id":"AC1"}}
+{"request":{"call-id":"0123456789abcdef","connection-id":"AC1","request-id":25,"facade":"Application","method":"Deploy","version":4,"args":"{\"applications\": [{\"application\": \"prometheus\"}]}"}}
+{"response":{"call-id":"0123456789abcdef","connection-id":"AC1","request-id":25,"errors":[{"message":"oops","code":"unauthorized access"}]}}
+`[1:]
+)

--- a/core/auditlog/package_test.go
+++ b/core/auditlog/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package auditlog_test
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func TestPackage(t *testing.T) {
+	gc.TestingT(t)
+}


### PR DESCRIPTION
## Description of change

core.auditlog contains the `AuditLogFile` and `Recorder`, which will be used in the apiserver (in a subsequent PR) to write audit log information as API methods are called.

## QA steps

No behaviour change - not integrated into apiserver yet.
