### PR TITLE
2.3 container default route inherited from host

### DIFF
--- a/apiserver/common/networkingcommon/networkconfigapi.go
+++ b/apiserver/common/networkingcommon/networkconfigapi.go
@@ -206,6 +206,7 @@ func (api *NetworkConfigAPI) SetObservedNetworkConfig(args params.SetMachineNetw
 }
 
 func (api *NetworkConfigAPI) SetProviderNetworkConfig(args params.Entities) (params.ErrorResults, error) {
+	logger.Tracef("SetProviderNetworkConfig %+v", args)
 	result := params.ErrorResults{
 		Results: make([]params.ErrorResult, len(args.Entities)),
 	}

--- a/apiserver/common/networkingcommon/types.go
+++ b/apiserver/common/networkingcommon/types.go
@@ -187,6 +187,7 @@ func NetworkConfigFromInterfaceInfo(interfaceInfos []network.InterfaceInfo) []pa
 			DNSSearchDomains:    v.DNSSearchDomains,
 			GatewayAddress:      v.GatewayAddress.Value,
 			Routes:              routes,
+			IsDefaultGateway:    v.IsDefaultGateway,
 		}
 	}
 	return result
@@ -267,6 +268,7 @@ func NetworkConfigsToStateArgs(networkConfig []params.NetworkConfig) (
 			DNSServers:       netConfig.DNSServers,
 			DNSSearchDomains: netConfig.DNSSearchDomains,
 			GatewayAddress:   netConfig.GatewayAddress,
+			IsDefaultGateway: netConfig.IsDefaultGateway,
 		}
 		logger.Tracef("state address args for device: %+v", addr)
 		devicesAddrs = append(devicesAddrs, addr)
@@ -369,6 +371,7 @@ func networkConfigsByAddress(input []params.NetworkConfig) map[string]params.Net
 }
 
 func mergeObservedAndProviderInterfaceConfig(observedConfig, providerConfig params.NetworkConfig) params.NetworkConfig {
+	logger.Debugf("mergeObservedAndProviderInterfaceConfig %+v %+v", observedConfig, providerConfig)
 	finalConfig := observedConfig
 
 	// The following fields cannot be observed and are only known by the
@@ -391,6 +394,7 @@ func mergeObservedAndProviderInterfaceConfig(observedConfig, providerConfig para
 	if observedConfig.ParentInterfaceName == "" {
 		finalConfig.ParentInterfaceName = providerConfig.ParentInterfaceName
 	}
+	logger.Debugf("mergeObservedAndProviderInterfaceConfig %+v", finalConfig)
 
 	return finalConfig
 }

--- a/apiserver/facades/agent/provisioner/provisioner.go
+++ b/apiserver/facades/agent/provisioner/provisioner.go
@@ -871,6 +871,7 @@ func (ctx *prepareOrGetContext) ProcessOneContainer(env environs.Environ, idx in
 				info.CIDR = parentDeviceSubnet.CIDR()
 				info.ProviderSubnetId = parentDeviceSubnet.ProviderId()
 				info.VLANTag = parentDeviceSubnet.VLANTag()
+				info.IsDefaultGateway = firstAddress.IsDefaultGateway()
 			} else {
 				info.ConfigType = network.ConfigDHCP
 				info.CIDR = firstAddress.SubnetCIDR()

--- a/apiserver/params/network.go
+++ b/apiserver/params/network.go
@@ -156,6 +156,9 @@ type NetworkConfig struct {
 	// Routes is a list of routes that should be applied when this interface is
 	// active.
 	Routes []NetworkRoute `json:"routes,omitempty"`
+
+	// IsDefaultGateway marks an interface that is a default gateway for a machine.
+	IsDefaultGateway bool `json:"is-default-gateway,omitempty"`
 }
 
 // DeviceBridgeInfo lists the host device and the expected bridge to be

--- a/cloudconfig/containerinit/container_userdata.go
+++ b/cloudconfig/containerinit/container_userdata.go
@@ -261,6 +261,20 @@ func PrepareNetworkConfigFromInterfaces(interfaces []network.InterfaceInfo) *Pre
 	namesInOrder[0] = "lo"
 	autoStarted := set.NewStrings("lo")
 
+	// We need to check if we have a host-provided default GW and use it.
+	// Otherwise we'll use the first device with a gateway address,
+	// it'll be filled in the second loop.
+	for _, info := range interfaces {
+		if info.IsDefaultGateway {
+			switch info.GatewayAddress.Type {
+			case network.IPv4Address:
+				gateway4Address = info.GatewayAddress.Value
+			case network.IPv6Address:
+				gateway6Address = info.GatewayAddress.Value
+			}
+		}
+	}
+
 	for _, info := range interfaces {
 		ifaceName := strings.Replace(info.MACAddress, ":", "_", -1)
 		// prepend eth because .format of python wont like a tag starting with numbers.

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -22,7 +22,7 @@ github.com/juju/ansiterm	git	b99631de12cf04a906c1d4e4ec54fb86eae5863d	2016-09-07
 github.com/juju/blobstore	git	06056004b3d7b54bbb7984d830c537bad00fec21	2015-07-29T11:18:58Z
 github.com/juju/bundlechanges	git	3e438134ef5f0e77da65fc267da680e61bc42d1a	2017-10-20T03:36:51Z
 github.com/juju/cmd	git	e74f39857ca013cf63947ba2843806f7afdd380d	2017-11-07T07:04:56Z
-github.com/juju/description	git	fc3fd7dfc2ebcda03985d7b741596bb42bc9a666	2017-09-27T13:38:51Z
+github.com/juju/description	git	89ac0c6cc7670ddcc764fc2452cf77fc3478875f	2017-11-27T22:37:19Z
 github.com/juju/errors	git	1b5e39b83d1835fa480e0c2ddefb040ee82d58b3	2015-09-16T12:56:42Z
 github.com/juju/gnuflag	git	2ce1bb71843d6d179b3f1c1c9cb4a72cd067fc65	2017-11-13T08:59:48Z
 github.com/juju/go-oracle-cloud	git	932a8cea00a1cd5cba3829a672c823955db674ae	2017-04-21T13:45:47Z

--- a/network/export_test.go
+++ b/network/export_test.go
@@ -8,4 +8,7 @@ var (
 	NetListen                      = &netListen
 	RunCommand                     = runCommand
 	NewEtcNetworkInterfacesBridger = newEtcNetworkInterfacesBridger
+	SimulatedOS                    = &simulatedOS
+	LaunchIpRouteShow              = &launchIpRouteShow
+	LaunchIpRouteShowReal          = launchIpRouteShowReal
 )

--- a/network/gateway.go
+++ b/network/gateway.go
@@ -18,7 +18,7 @@ func GetDefaultRoute() (net.IP, string, error) {
 		os = runtime.GOOS
 	}
 	// TODO(wpk) 2017-11-20 Add Windows support here, hence the switch.
-	switch simulatedOS {
+	switch os {
 	case "linux":
 		return getDefaultRouteLinux()
 	default:
@@ -54,7 +54,6 @@ func getDefaultRouteLinux() (net.IP, string, error) {
 	if err != nil {
 		return nil, "", err
 	}
-
 	var defaultRouteMetric = ^uint64(0)
 	var defaultRoute string
 	var defaultRouteDevice string

--- a/network/gateway.go
+++ b/network/gateway.go
@@ -54,22 +54,21 @@ func getDefaultRouteLinux() (net.IP, string, error) {
 	if err != nil {
 		return nil, "", err
 	}
+	logger.Tracef("ip route show output:\n%s", output)
 	var defaultRouteMetric = ^uint64(0)
 	var defaultRoute string
 	var defaultRouteDevice string
 	for _, line := range strings.Split(output, "\n") {
 		to, values := parseIpRouteShowLine(line)
+		logger.Tracef("parsing ip r s line to %q, values %+v ", to, values)
 		if to == "default" {
-			var metric = ^uint64(0)
+			var metric = uint64(0)
 			if v, ok := values["metric"]; ok {
 				if i, err := strconv.ParseUint(v, 10, 64); err == nil {
 					metric = i
 				} else {
 					return nil, "", err
 				}
-			} else {
-				// No "metric" field means 0.
-				metric = 0
 			}
 			if metric < defaultRouteMetric {
 				// We want to replace our current default route if it's valid.

--- a/network/gateway.go
+++ b/network/gateway.go
@@ -1,0 +1,96 @@
+package network
+
+import (
+	"net"
+	"os/exec"
+	"runtime"
+	"strconv"
+	"strings"
+)
+
+var simulatedOS = ""
+
+// GetDefaultRoute returns the IP address and device name of default gateway on the machine.
+// If we don't support OS, or we don't have a default route, we return nothing (not an error!).
+func GetDefaultRoute() (net.IP, string, error) {
+	os := simulatedOS
+	if os == "" {
+		os = runtime.GOOS
+	}
+	// TODO(wpk) 2017-11-20 Add Windows support here, hence the switch.
+	switch simulatedOS {
+	case "linux":
+		return getDefaultRouteLinux()
+	default:
+		return nil, "", nil
+	}
+}
+
+func parseIpRouteShowLine(line string) (string, map[string]string) {
+	values := make(map[string]string)
+	fields := strings.Fields(line)
+	if len(fields) < 2 {
+		return "", values
+	}
+	to, fields := fields[0], fields[1:]
+	for ; len(fields) >= 2; fields = fields[2:] {
+		values[fields[0]] = fields[1]
+	}
+	return to, values
+}
+
+func launchIpRouteShowReal() (string, error) {
+	output, err := exec.Command("ip", "route", "show").CombinedOutput()
+	if err != nil {
+		return "", err
+	}
+	return string(output), nil
+}
+
+var launchIpRouteShow = launchIpRouteShowReal
+
+func getDefaultRouteLinux() (net.IP, string, error) {
+	output, err := launchIpRouteShow()
+	if err != nil {
+		return nil, "", err
+	}
+
+	var defaultRouteMetric = ^uint64(0)
+	var defaultRoute string
+	var defaultRouteDevice string
+	for _, line := range strings.Split(output, "\n") {
+		to, values := parseIpRouteShowLine(line)
+		if to == "default" {
+			var metric = ^uint64(0)
+			if v, ok := values["metric"]; ok {
+				if i, err := strconv.ParseUint(v, 10, 64); err == nil {
+					metric = i
+				} else {
+					return nil, "", err
+				}
+			} else {
+				// No "metric" field means 0.
+				metric = 0
+			}
+			if metric < defaultRouteMetric {
+				// We want to replace our current default route if it's valid.
+				via, hasVia := values["via"]
+				dev, hasDev := values["dev"]
+				if hasVia || hasDev {
+					defaultRouteMetric = metric
+					if hasVia {
+						defaultRoute = via
+					} else {
+						defaultRoute = ""
+					}
+					if hasDev {
+						defaultRouteDevice = dev
+					} else {
+						defaultRouteDevice = ""
+					}
+				}
+			}
+		}
+	}
+	return net.ParseIP(defaultRoute), defaultRouteDevice, nil
+}

--- a/network/gateway_test.go
+++ b/network/gateway_test.go
@@ -1,0 +1,132 @@
+package network_test
+
+import (
+	"fmt"
+	"net"
+	"runtime"
+
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/network"
+	"github.com/juju/juju/testing"
+)
+
+type GatewaySuite struct {
+	testing.BaseSuite
+}
+
+var _ = gc.Suite(&GatewaySuite{})
+
+func (s *GatewaySuite) TestDefaultRouteOnMachine(c *gc.C) {
+	if runtime.GOOS != "linux" {
+		c.Skip("skipping default route on-machine test on non-linux")
+	}
+	s.PatchValue(network.LaunchIpRouteShow, network.LaunchIpRouteShowReal)
+	_, _, err := network.GetDefaultRoute()
+	c.Check(err, gc.IsNil)
+}
+
+func (s *GatewaySuite) TestDefaultRouteLinuxSimple(c *gc.C) {
+	s.PatchValue(network.SimulatedOS, "linux")
+	s.PatchValue(network.LaunchIpRouteShow, func() (string, error) {
+		return "default via 10.0.0.1 dev wlp2s0 proto static\n" +
+			"10.0.0.0/24 dev wlp2s0 proto kernel scope link src 10.0.0.66 metric 600\n", nil
+	})
+	ip, dev, err := network.GetDefaultRoute()
+	c.Assert(err, gc.IsNil)
+	c.Check(ip, gc.DeepEquals, net.ParseIP("10.0.0.1"))
+	c.Check(dev, gc.Equals, "wlp2s0")
+}
+
+func (s *GatewaySuite) TestDefaultRouteLinuxTwoRoutes(c *gc.C) {
+	s.PatchValue(network.SimulatedOS, "linux")
+	s.PatchValue(network.LaunchIpRouteShow, func() (string, error) {
+		return "default via 10.0.0.1 dev wlp2s0 proto static metric 800\n" +
+			"default via 10.100.1.10 dev lxdbr0 metric 700\n" +
+			"10.0.0.0/24 dev wlp2s0 proto kernel scope link src 10.0.0.66 metric 600\n" +
+			"10.100.1.0/24 dev lxdbr0 proto kernel scope link src 10.100.1.1\n", nil
+	})
+	ip, dev, err := network.GetDefaultRoute()
+	c.Assert(err, gc.IsNil)
+	c.Check(ip, gc.DeepEquals, net.ParseIP("10.100.1.10"))
+	c.Check(dev, gc.Equals, "lxdbr0")
+}
+
+func (s *GatewaySuite) TestDefaultRouteLinuxNoMetric(c *gc.C) {
+	s.PatchValue(network.SimulatedOS, "linux")
+	s.PatchValue(network.LaunchIpRouteShow, func() (string, error) {
+		return "default via 10.0.0.1 dev wlp2s0 proto static metric 800\n" +
+			"default via 10.100.1.10 dev lxdbr0\n" +
+			"10.0.0.0/24 dev wlp2s0 proto kernel scope link src 10.0.0.66 metric 600\n" +
+			"10.100.1.0/24 dev lxdbr0 proto kernel scope link src 10.100.1.1\n", nil
+	})
+	ip, dev, err := network.GetDefaultRoute()
+	c.Assert(err, gc.IsNil)
+	c.Check(ip, gc.DeepEquals, net.ParseIP("10.100.1.10"))
+	c.Check(dev, gc.Equals, "lxdbr0")
+}
+
+func (s *GatewaySuite) TestDefaultRouteLinuxNoGW(c *gc.C) {
+	s.PatchValue(network.SimulatedOS, "linux")
+	s.PatchValue(network.LaunchIpRouteShow, func() (string, error) {
+		return "default via 10.0.0.1 dev wlp2s0 proto static metric 800\n" +
+			"default dev lxdbr0\n" +
+			"10.0.0.0/24 dev wlp2s0 proto kernel scope link src 10.0.0.66 metric 600\n" +
+			"10.100.1.0/24 dev lxdbr0 proto kernel scope link src 10.100.1.1\n", nil
+	})
+	ip, dev, err := network.GetDefaultRoute()
+	c.Assert(err, gc.IsNil)
+	c.Check(ip, gc.IsNil)
+	c.Check(dev, gc.Equals, "lxdbr0")
+}
+
+func (s *GatewaySuite) TestDefaultRouteLinuxNoDev(c *gc.C) {
+	s.PatchValue(network.SimulatedOS, "linux")
+	s.PatchValue(network.LaunchIpRouteShow, func() (string, error) {
+		return "default via 10.0.0.1 dev wlp2s0 proto static metric 800\n" +
+			"default via 10.100.1.10 metric 500\n" +
+			"10.0.0.0/24 dev wlp2s0 proto kernel scope link src 10.0.0.66 metric 600\n" +
+			"10.100.1.0/24 dev lxdbr0 proto kernel scope link src 10.100.1.1\n", nil
+	})
+	ip, dev, err := network.GetDefaultRoute()
+	c.Assert(err, gc.IsNil)
+	c.Check(ip, gc.DeepEquals, net.ParseIP("10.100.1.10"))
+	c.Check(dev, gc.Equals, "")
+}
+
+func (s *GatewaySuite) TestDefaultRouteLinuxError(c *gc.C) {
+	s.PatchValue(network.SimulatedOS, "linux")
+	s.PatchValue(network.LaunchIpRouteShow, func() (string, error) {
+		return "", fmt.Errorf("no can do")
+	})
+	ip, dev, err := network.GetDefaultRoute()
+	c.Check(ip, gc.IsNil)
+	c.Check(dev, gc.Equals, "")
+	c.Check(err, gc.ErrorMatches, "no can do")
+}
+
+func (s *GatewaySuite) TestDefaultRouteLinuxWrongOutput(c *gc.C) {
+	s.PatchValue(network.SimulatedOS, "linux")
+	s.PatchValue(network.LaunchIpRouteShow, func() (string, error) {
+		return "default via 10.0.0.1 dev wlp2s0 proto static metric chewbacca\n" +
+			"default dev lxdbr0\n" +
+			"10.0.0.0/24 dev wlp2s0 proto kernel scope link src 10.0.0.66 metric 600\n" +
+			"10.100.1.0/24 dev lxdbr0 proto kernel scope link src 10.100.1.1\n", nil
+	})
+	ip, dev, err := network.GetDefaultRoute()
+	c.Check(ip, gc.IsNil)
+	c.Check(dev, gc.Equals, "")
+	c.Check(err, gc.ErrorMatches, ".*chewbacca.*")
+}
+
+// We don't return 'not supported' error, we simply give no output
+func (s *GatewaySuite) TestDefaultRouteWindowsEmpty(c *gc.C) {
+	s.PatchValue(network.SimulatedOS, "windows")
+	s.PatchValue(network.LaunchIpRouteShow, func() (string, error) {
+		return "", fmt.Errorf("why someone calls me?")
+	})
+	ip, dev, err := network.GetDefaultRoute()
+	c.Check(ip, gc.IsNil)
+	c.Check(dev, gc.Equals, "")
+	c.Check(err, gc.IsNil)
+}

--- a/network/network.go
+++ b/network/network.go
@@ -262,6 +262,9 @@ type InterfaceInfo struct {
 	// Routes defines a list of routes that should be added when this interface
 	// is brought up, and removed when this interface is stopped.
 	Routes []Route
+
+	// IsDefaultGateway is set if this device is a default gw on a machine.
+	IsDefaultGateway bool
 }
 
 // Route defines a single route to a subnet via a defined gateway.

--- a/state/linklayerdevices_ipaddresses.go
+++ b/state/linklayerdevices_ipaddresses.go
@@ -56,6 +56,9 @@ type ipAddressDoc struct {
 	// GatewayAddress is the IP address of the gateway this IP address's device
 	// uses. Can be empty.
 	GatewayAddress string `bson:"gateway-address,omitempty"`
+
+	// IsDefaultGateway is set to true if that device/subnet is the default gw for the machine
+	IsDefaultGateway bool `bson:"is-default-gateway,omitempty"`
 }
 
 // AddressConfigMethod is the method used to configure a link-layer device's IP
@@ -182,6 +185,11 @@ func (addr *Address) DNSSearchDomains() []string {
 // GatewayAddress returns the gateway address to use, which can be empty.
 func (addr *Address) GatewayAddress() string {
 	return addr.doc.GatewayAddress
+}
+
+// IsDefaultGateway returns true if this address is used for the default gw on the machine.
+func (addr *Address) IsDefaultGateway() bool {
+	return addr.doc.IsDefaultGateway
 }
 
 // String returns a human-readable representation of the IP address.

--- a/state/machine_linklayerdevices.go
+++ b/state/machine_linklayerdevices.go
@@ -590,6 +590,10 @@ type LinkLayerDeviceAddress struct {
 
 	// GatewayAddress is the address of the gateway to use, which can be empty.
 	GatewayAddress string
+
+	// IsDefaultGateway is set to true if this address on this device is the
+	// default gw on a machine.
+	IsDefaultGateway bool
 }
 
 // SetDevicesAddresses sets the addresses of all devices in devicesAddresses,
@@ -760,6 +764,7 @@ func (m *Machine) newIPAddressDocFromArgs(args *LinkLayerDeviceAddress) (*ipAddr
 		DNSServers:       args.DNSServers,
 		DNSSearchDomains: args.DNSSearchDomains,
 		GatewayAddress:   args.GatewayAddress,
+		IsDefaultGateway: args.IsDefaultGateway,
 	}
 	return newDoc, nil
 }

--- a/state/migration_import.go
+++ b/state/migration_import.go
@@ -1349,6 +1349,7 @@ func (i *importer) addIPAddress(addr description.IPAddress) error {
 		DNSServers:       addr.DNSServers(),
 		DNSSearchDomains: addr.DNSSearchDomains(),
 		GatewayAddress:   addr.GatewayAddress(),
+		IsDefaultGateway: addr.IsDefaultGateway(),
 	}
 
 	ops := []txn.Op{{

--- a/state/migration_internal_test.go
+++ b/state/migration_internal_test.go
@@ -641,6 +641,7 @@ func (s *MigrationSuite) TestIPAddressDocFields(c *gc.C) {
 		"MachineID",
 		"DNSSearchDomains",
 		"GatewayAddress",
+		"IsDefaultGateway",
 		"ProviderID",
 		"DNSServers",
 		"SubnetCIDR",

--- a/worker/machiner/machiner.go
+++ b/worker/machiner/machiner.go
@@ -169,7 +169,7 @@ func (mr *Machiner) Handle(_ <-chan struct{}) error {
 				return errors.Annotate(err, "cannot update observed network config")
 			}
 		}
-		logger.Debugf("observed network config updated for %q to %v", mr.config.Tag, observedConfig)
+		logger.Debugf("observed network config updated for %q to %+v", mr.config.Tag, observedConfig)
 
 		return nil
 	}


### PR DESCRIPTION
## Description of change
When connecting multiple interfaces to an LXD container on a MAAS host we always pick the first one (alphabetically) for a default gateway. This changes makes Juju pick the default gateway on the host machine for gw in container (if that's possible).

## QA steps
Create a machine in MAAS with several interfaces with default gateways, create a container on this machine, verify that default GW in a container is the same as on host.

## Bug reference
https://bugs.launchpad.net/juju/+bug/1710055