### PR TITLE
Add dockerfile and associated config to make juju operator image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -124,6 +124,32 @@ GOCHECK_COUNT="$(shell go list -f '{{join .Deps "\n"}}' github.com/juju/juju/...
 check-deps:
 	@echo "$(GOCHECK_COUNT) instances of gocheck not in test code"
 
+# CAAS related targets
+DOCKER_USERNAME?=juju
+JUJUD_STAGING_DIR=/tmp/jujud-operator
+JUJUD_BIN_DIR=${GOPATH}/bin
+
+operator-image: install
+	rm -rf ${JUJUD_STAGING_DIR}
+	mkdir ${JUJUD_STAGING_DIR}
+	cp ${JUJUD_BIN_DIR}/jujud ${JUJUD_STAGING_DIR}
+	cp jujud-operator-dockerfile ${JUJUD_STAGING_DIR}
+	cp jujud-operator-requirements.txt ${JUJUD_STAGING_DIR}
+	docker build -f ${JUJUD_STAGING_DIR}/jujud-operator-dockerfile -t ${DOCKER_USERNAME}/caas-jujud-operator ${JUJUD_STAGING_DIR}
+
+push-operator-image: operator-image
+	docker push ${DOCKER_USERNAME}/caas-jujud-operator
+	
+check-k8s-model:
+	@:$(if $(value JUJU_K8S_MODEL),, $(error Undefined JUJU_K8S_MODEL))
+	@juju show-model ${JUJU_K8S_MODEL} > /dev/null
+
+local-operator-update: check-k8s-model operator-image
+	$(eval kubeworkers != juju status -m ${JUJU_K8S_MODEL} kubernetes-worker --format json | jq -c '.machines | keys' | tr  -c '[:digit:]' ' ' 2>&1)
+	docker save ${DOCKER_USERNAME}/caas-jujud-operator | gzip > /tmp/caas-jujud-operator-image.tar.gz
+	$(foreach wm,$(kubeworkers), juju scp -m ${JUJU_K8S_MODEL} /tmp/caas-jujud-operator-image.tar.gz $(wm):/tmp/caas-jujud-operator-image.tar.gz ; )
+	$(foreach wm,$(kubeworkers), juju ssh -m ${JUJU_K8S_MODEL} $(wm) -- "zcat /tmp/caas-jujud-operator-image.tar.gz | docker load" ; )
+
 .PHONY: build check install
 .PHONY: clean format simplify
 .PHONY: install-dependencies

--- a/caas/kubernetes/provider/k8s.go
+++ b/caas/kubernetes/provider/k8s.go
@@ -188,11 +188,10 @@ func (k *kubernetesClient) deployOperator(appName, agentPath string, configMapNa
 				Name:            "juju-operator",
 				ImagePullPolicy: v1.PullIfNotPresent,
 				// TODO(caas) use proper image
-				Image:   "ubuntu:16.04",
-				Command: []string{"sleep"},
-				Args:    []string{"infinity"},
-				//Args:    []string{"caasoperator", "--application-name", appName, "--debug"},
-
+				Image: "wallyworld/caas-jujud-operator",
+				Env: []v1.EnvVar{
+					{Name: "JUJU_APPLICATION", Value: appName},
+				},
 				VolumeMounts: []v1.VolumeMount{{
 					Name:      configVolName,
 					MountPath: agent.Dir(agentPath, appTag) + "/agent.conf",

--- a/jujud-operator-dockerfile
+++ b/jujud-operator-dockerfile
@@ -1,0 +1,26 @@
+FROM ubuntu:latest
+
+# Some Python dependencies.
+RUN apt-get update && apt-get install -y \
+    python3-dev \
+    python3-yaml \
+    python3-pip \
+ && pip3 install --upgrade pip setuptools \
+ && rm -rf /var/lib/apt/lists/* \
+ && rm -r /root/.cache
+
+# Install the standard charm dependencies.
+ENV WHEELHOUSE=/tmp/wheelhouse
+ENV PIP_WHEEL_DIR=/tmp/wheelhouse
+ENV PIP_FIND_LINKS=/tmp/wheelhouse
+
+COPY jujud-operator-requirements.txt /tmp/wheelhouse/jujud-operator-requirements.txt
+RUN pip3 wheel -r /tmp/wheelhouse/jujud-operator-requirements.txt
+
+# Finally jujud
+ARG JUJUD_DIR=/var/lib/juju/tools
+WORKDIR $JUJUD_DIR
+COPY jujud $JUJUD_DIR
+
+ENTRYPOINT ["sh", "-c"]
+CMD ["./jujud caasoperator --application-name ${JUJU_APPLICATION}"]

--- a/jujud-operator-requirements.txt
+++ b/jujud-operator-requirements.txt
@@ -1,0 +1,4 @@
+pip>=7.0.0,<8.2.0
+charmhelpers>=0.4.0,<1.0.0
+charms.reactive>=0.1.0,<2.0.0
+


### PR DESCRIPTION
## Description of change

Add make target to create the jujud operator docker file.
make operator-image

There's also targets to push the image to docker hub and update a locally running caas model with a new locally compiled image.

