### PR TITLE
firewaller: egress watcher fixes

### DIFF
--- a/apiserver/common/firewall/egressaddresswatcher.go
+++ b/apiserver/common/firewall/egressaddresswatcher.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/network"
-	"github.com/juju/juju/state/watcher"
 	"github.com/juju/juju/worker/catacomb"
 )
 
@@ -58,14 +57,15 @@ type machineData struct {
 // NewEgressAddressWatcher creates an EgressAddressWatcher.
 func NewEgressAddressWatcher(backend State, rel Relation, appName string) (*EgressAddressWatcher, error) {
 	w := &EgressAddressWatcher{
-		backend:        backend,
-		appName:        appName,
-		rel:            rel,
-		known:          make(map[string]string),
-		out:            make(chan []string),
-		addressChanges: make(chan string),
-		machines:       make(map[string]*machineData),
-		unitToMachine:  make(map[string]string),
+		backend:          backend,
+		appName:          appName,
+		rel:              rel,
+		known:            make(map[string]string),
+		out:              make(chan []string),
+		addressChanges:   make(chan string),
+		machines:         make(map[string]*machineData),
+		unitToMachine:    make(map[string]string),
+		knownModelEgress: set.NewStrings(),
 	}
 	err := catacomb.Invoke(catacomb.Plan{
 		Site: &w.catacomb,
@@ -74,45 +74,9 @@ func NewEgressAddressWatcher(backend State, rel Relation, appName string) (*Egre
 	return w, err
 }
 
-func (w *EgressAddressWatcher) initialise() error {
-	app, err := w.backend.Application(w.appName)
-	if err != nil {
-		return errors.Trace(err)
-	}
-	units, err := app.AllUnits()
-	if err != nil {
-		return errors.Trace(err)
-	}
-	for _, u := range units {
-		inScope, err := w.rel.UnitInScope(u)
-		if err != nil {
-			return errors.Trace(err)
-		}
-		if !inScope {
-			continue
-		}
-
-		addr, ok, err := w.unitAddress(u)
-		if err != nil {
-			return errors.Trace(err)
-		}
-		if ok {
-			w.known[u.Name()] = addr
-		}
-		if err := w.trackUnit(u); err != nil {
-			return errors.Trace(err)
-		}
-	}
-	cfg, err := w.backend.ModelConfig()
-	if err != nil {
-		return err
-	}
-	w.knownModelEgress = set.NewStrings(cfg.EgressSubnets()...)
-	return nil
-}
-
 func (w *EgressAddressWatcher) loop() error {
 	defer close(w.out)
+
 	ruw, err := w.rel.WatchUnits(w.appName)
 	if errors.IsNotFound(err) {
 		return nil
@@ -131,67 +95,70 @@ func (w *EgressAddressWatcher) loop() error {
 	if err := w.catacomb.Add(mw); err != nil {
 		return errors.Trace(err)
 	}
-	// Consume initial event.
-	if _, ok := <-mw.Changes(); !ok {
-		return watcher.EnsureErr(mw)
-	}
 
 	rw := w.rel.WatchRelationEgressNetworks()
 	if err := w.catacomb.Add(rw); err != nil {
 		return errors.Trace(err)
 	}
-	// Consume initial event.
-	if networks, ok := <-rw.Changes(); !ok {
-		return watcher.EnsureErr(rw)
-	} else {
-		w.knownRelationEgress = set.NewStrings(networks...)
-	}
 
 	var (
-		sentInitial bool
-		out         chan<- []string
-		addresses   []string
+		changed       bool
+		sentInitial   bool
+		out           chan<- []string
+		addresses     set.Strings
+		lastAddresses set.Strings
+		addressesCIDR []string
 	)
-	err = w.initialise()
-	if errors.IsNotFound(err) {
-		return nil
-	}
-	if err != nil {
-		return errors.Trace(err)
-	}
-	unitAddressesChanged := false
-	userConfiguredEgressChanged := false
+
+	// Wait for each of the watchers started above to
+	// send an initial change before sending any changes
+	// from this watcher.
+	var haveInitialRelationUnits bool
+	var haveInitialRelationEgressNetworks bool
+	var haveInitialModelConfig bool
+
 	for {
-		if !sentInitial || unitAddressesChanged || (userConfiguredEgressChanged && len(w.known) > 0) {
-			var addressSet set.Strings
-			// Egress cidrs, if configured, override unit machine addresses.
+		var ready bool
+		if !sentInitial {
+			ready = haveInitialRelationUnits && haveInitialRelationEgressNetworks && haveInitialModelConfig
+		}
+		if ready || changed {
+			addresses = nil
 			if len(w.known) > 0 {
-				// Try relation cidrs first.
-				addressSet = set.NewStrings(w.knownRelationEgress.Values()...)
-				if addressSet.Size() == 0 {
-					// If none of those, try model cidrs.
-					addressSet = set.NewStrings(w.knownModelEgress.Values()...)
+				// Egress CIDRs, if configured, override unit
+				// machine addresses. Relation CIDRs take
+				// precedence over those specified in model
+				// config.
+				addresses = set.NewStrings(w.knownRelationEgress.Values()...)
+				if addresses.Size() == 0 {
+					addresses = set.NewStrings(w.knownModelEgress.Values()...)
 				}
-				if addressSet.Size() == 0 {
+				if addresses.Size() == 0 {
 					// No user configured egress so just use the unit addresses.
 					for _, addr := range w.known {
-						addressSet.Add(addr)
+						addresses.Add(addr)
 					}
 				}
 			}
-			unitAddressesChanged = false
-			addresses = network.FormatAsCIDR(addressSet.Values())
+			changed = false
+			if !setEquals(addresses, lastAddresses) {
+				addressesCIDR = network.FormatAsCIDR(addresses.Values())
+				ready = ready || sentInitial
+			}
+		}
+		if ready {
 			out = w.out
 		}
-		userConfiguredEgressChanged = false
 
 		select {
 		case <-w.catacomb.Dying():
 			return w.catacomb.ErrDying()
-		// Send initial event or subsequent changes.
-		case out <- addresses:
+
+		case out <- addressesCIDR:
 			sentInitial = true
+			lastAddresses = addresses
 			out = nil
+
 		case _, ok := <-mw.Changes():
 			if !ok {
 				return w.catacomb.ErrDying()
@@ -200,25 +167,34 @@ func (w *EgressAddressWatcher) loop() error {
 			if err != nil {
 				return err
 			}
+			haveInitialModelConfig = true
 			egress := set.NewStrings(cfg.EgressSubnets()...)
-			// Have the egress addresses changed.
-			if egress.Size() != w.knownModelEgress.Size() ||
-				egress.Difference(w.knownModelEgress).Size() != 0 || w.knownModelEgress.Difference(egress).Size() != 0 {
-				// We only care about model egress changes if there's no relation specific egress.
-				userConfiguredEgressChanged = w.knownRelationEgress.Size() == 0
+			if !setEquals(egress, w.knownModelEgress) {
+				logger.Debugf(
+					"model config egress subnets changed to %s (was %s)",
+					egress.SortedValues(),
+					w.knownModelEgress.SortedValues(),
+				)
+				changed = true
 				w.knownModelEgress = egress
 			}
+
 		case changes, ok := <-rw.Changes():
 			if !ok {
 				return w.catacomb.ErrDying()
 			}
+			haveInitialRelationEgressNetworks = true
 			egress := set.NewStrings(changes...)
-			// Have the egress addresses changed.
-			if egress.Size() != w.knownRelationEgress.Size() ||
-				egress.Difference(w.knownRelationEgress).Size() != 0 || w.knownRelationEgress.Difference(egress).Size() != 0 {
-				userConfiguredEgressChanged = true
+			if !setEquals(egress, w.knownRelationEgress) {
+				logger.Debugf(
+					"relation egress subnets changed to %s (was %s)",
+					egress.SortedValues(),
+					w.knownRelationEgress.SortedValues(),
+				)
+				changed = true
 				w.knownRelationEgress = egress
 			}
+
 		case c, ok := <-ruw.Changes():
 			if !ok {
 				return w.catacomb.ErrDying()
@@ -226,20 +202,23 @@ func (w *EgressAddressWatcher) loop() error {
 			// A unit has entered or left scope.
 			// Get the new set of addresses resulting from that
 			// change, and if different to what we know, send the change.
-			unitAddressesChanged, err = w.processUnitChanges(c)
+			haveInitialRelationUnits = true
+			addressesChanged, err := w.processUnitChanges(c)
 			if err != nil {
 				return err
 			}
+			changed = changed || addressesChanged
+
 		case machineId, ok := <-w.addressChanges:
 			if !ok {
 				continue
 			}
-			unitAddressesChanged, err = w.processMachineAddresses(machineId)
+			addressesChanged, err := w.processMachineAddresses(machineId)
 			if err != nil {
 				return errors.Trace(err)
 			}
+			changed = changed || addressesChanged
 		}
-
 	}
 }
 
@@ -486,4 +465,11 @@ func (w *machineAddressWorker) Kill() {
 
 func (w *machineAddressWorker) Wait() error {
 	return w.catacomb.Wait()
+}
+
+func setEquals(a, b set.Strings) bool {
+	if a.Size() != b.Size() {
+		return false
+	}
+	return a.Intersection(b).Size() == a.Size()
 }

--- a/apiserver/common/firewall/firewall_test.go
+++ b/apiserver/common/firewall/firewall_test.go
@@ -6,7 +6,6 @@ package firewall_test
 import (
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
-	"github.com/juju/utils/set"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/charm.v6"
 	"gopkg.in/juju/names.v2"
@@ -61,9 +60,15 @@ func (s *FirewallSuite) TestWatchEgressAddressesForRelations(c *gc.C) {
 			},
 		},
 	}
-	db2Relation.inScope = set.NewStrings("django/0", "django/1")
 	s.st.relations["remote-db2:db django:db"] = db2Relation
 	s.st.remoteEntities[names.NewRelationTag("remote-db2:db django:db")] = "token-db2:db django:db"
+	// django/0 and django/1 are initially in scope
+	db2Relation.ruw.changes <- params.RelationUnitsChange{
+		Changed: map[string]params.UnitSettings{
+			"django/0": {},
+			"django/1": {},
+		},
+	}
 
 	unit := newMockUnit("django/0")
 	unit.publicAddress = network.NewScopedAddress("1.2.3.4", network.ScopePublic)
@@ -97,8 +102,9 @@ func (s *FirewallSuite) TestWatchEgressAddressesForRelations(c *gc.C) {
 	s.st.CheckCalls(c, []testing.StubCall{
 		{"KeyRelation", []interface{}{"remote-db2:db django:db"}},
 		{"Application", []interface{}{"django"}},
-		{"Application", []interface{}{"django"}},
+		{"Unit", []interface{}{"django/0"}},
 		{"Machine", []interface{}{"0"}},
+		{"Unit", []interface{}{"django/1"}},
 		{"Machine", []interface{}{"1"}},
 	})
 }

--- a/apiserver/common/firewall/mock_test.go
+++ b/apiserver/common/firewall/mock_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/juju/errors"
 	"github.com/juju/testing"
-	"github.com/juju/utils/set"
 	"gopkg.in/juju/names.v2"
 	"gopkg.in/macaroon.v1"
 	"gopkg.in/tomb.v1"
@@ -268,15 +267,13 @@ type mockRelation struct {
 	ruw       *mockRelationUnitsWatcher
 	ew        *mockStringsWatcher
 	ruwApp    string
-	inScope   set.Strings
 }
 
 func newMockRelation(id int) *mockRelation {
 	return &mockRelation{
-		id:      id,
-		ruw:     newMockRelationUnitsWatcher(),
-		ew:      newMockStringsWatcher(),
-		inScope: make(set.Strings),
+		id:  id,
+		ruw: newMockRelationUnitsWatcher(),
+		ew:  newMockStringsWatcher(),
 	}
 }
 
@@ -295,10 +292,6 @@ func (r *mockRelation) WatchUnits(applicationName string) (state.RelationUnitsWa
 		return nil, errors.Errorf("unexpected app %v", applicationName)
 	}
 	return r.ruw, nil
-}
-
-func (r *mockRelation) UnitInScope(u firewall.Unit) (bool, error) {
-	return r.inScope.Contains(u.Name()), nil
 }
 
 func (r *mockRelation) WatchRelationEgressNetworks() state.StringsWatcher {

--- a/apiserver/common/firewall/state.go
+++ b/apiserver/common/firewall/state.go
@@ -52,21 +52,12 @@ type Relation interface {
 	status.StatusSetter
 	Endpoints() []state.Endpoint
 	WatchUnits(applicationName string) (state.RelationUnitsWatcher, error)
-	UnitInScope(Unit) (bool, error)
 	WatchRelationIngressNetworks() state.StringsWatcher
 	WatchRelationEgressNetworks() state.StringsWatcher
 }
 
 type relationShim struct {
 	*state.Relation
-}
-
-func (r relationShim) UnitInScope(u Unit) (bool, error) {
-	ru, err := r.Relation.Unit(u.(*state.Unit))
-	if err != nil {
-		return false, errors.Trace(err)
-	}
-	return ru.InScope()
 }
 
 func (st stateShim) Application(name string) (Application, error) {
@@ -79,22 +70,10 @@ func (st stateShim) Application(name string) (Application, error) {
 
 type Application interface {
 	Name() string
-	AllUnits() ([]Unit, error)
 }
 
 type applicationShim struct {
 	*state.Application
-}
-
-func (a applicationShim) AllUnits() (results []Unit, err error) {
-	units, err := a.Application.AllUnits()
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	for _, unit := range units {
-		results = append(results, unit)
-	}
-	return results, nil
 }
 
 type Unit interface {

--- a/worker/firewaller/firewaller.go
+++ b/worker/firewaller/firewaller.go
@@ -1387,7 +1387,7 @@ func (rd *remoteRelationData) providerEndpointLoop() error {
 		case <-rd.catacomb.Dying():
 			return rd.catacomb.ErrDying()
 		case cidrs := <-ingressAddressWatcher.Changes():
-			logger.Debugf("relation egress addresses for %v changed in model %v: %v", rd.tag, rd.fw.modelUUID, cidrs)
+			logger.Debugf("relation ingress addresses for %v changed in model %v: %v", rd.tag, rd.fw.modelUUID, cidrs)
 			if err := rd.updateIngressNetworks(cidrs); err != nil {
 				return errors.Trace(err)
 			}

--- a/worker/firewaller/firewaller_test.go
+++ b/worker/firewaller/firewaller_test.go
@@ -829,6 +829,7 @@ func (s *InstanceModeSuite) TestRemoteRelationRequirerRoleConsumingSide(c *gc.C)
 	// This will trigger the firewaller to publish the changes.
 	err := ru.EnterScope(map[string]interface{}{})
 	c.Assert(err, jc.ErrorIsNil)
+	s.BackingState.StartSync()
 	select {
 	case <-time.After(coretesting.LongWait):
 		c.Fatal("time out waiting for ingress change to be published on enter scope")
@@ -842,6 +843,7 @@ func (s *InstanceModeSuite) TestRemoteRelationRequirerRoleConsumingSide(c *gc.C)
 	ingressRequired = false
 	err = ru.LeaveScope()
 	c.Assert(err, jc.ErrorIsNil)
+	s.BackingState.StartSync()
 	select {
 	case <-time.After(coretesting.LongWait):
 		c.Fatal("time out waiting for ingress change to be published on leave scope")
@@ -860,6 +862,7 @@ func (s *InstanceModeSuite) TestRemoteRelationWorkerError(c *gc.C) {
 	// This will trigger the firewaller to try and publish the changes.
 	err := ru.EnterScope(map[string]interface{}{})
 	c.Assert(err, jc.ErrorIsNil)
+	s.BackingState.StartSync()
 
 	// We should not have published any ingress events yet - no changed published.
 	select {
@@ -1026,6 +1029,7 @@ func (s *InstanceModeSuite) TestRemoteRelationIngressRejected(c *gc.C) {
 	// This will trigger the firewaller to publish the changes.
 	err = ru.EnterScope(map[string]interface{}{})
 	c.Assert(err, jc.ErrorIsNil)
+	s.BackingState.StartSync()
 	select {
 	case <-time.After(coretesting.LongWait):
 		c.Fatal("time out waiting for ingress change to be published on enter scope")


### PR DESCRIPTION
## Description of change

The firewaller's egress address watcher has
been changed to wait for the initial event
of each watcher before doing sending any
output. It was previously waiting for some
initial events, but missed the relation units.
Due to this, tests would intermittently fail.

By waiting for the initial event of each
watcher, we can also eliminate the explicit
initialisation step in the watcher.

Also, fix a bug in the firewaller's egress
address watcher, where the embedded
machine address watcher was performing
bare channel sends. During worker
termination, this could lead to deadlock
(and was causing tests to timeout).

## QA steps

1. juju bootstrap aws c1
2. juju bootstrap google c2
3. juju switch c2 && juju deploy mysql && juju offer mysql:db
4. juju switch c1 && juju deploy wordpress && juju relate wordpress c2:admin/mysql.db
(check that they become functional)

## Documentation changes

None.

## Bug reference

None.