### PR TITLE
Add the option of a shared txn watcher for state objects.

### DIFF
--- a/state/controller.go
+++ b/state/controller.go
@@ -67,7 +67,7 @@ func (ctlr *Controller) NewState(modelTag names.ModelTag) (*State, error) {
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	if err := st.start(ctlr.controllerTag); err != nil {
+	if err := st.start(ctlr.controllerTag, nil); err != nil {
 		return nil, errors.Trace(err)
 	}
 	return st, nil

--- a/state/model.go
+++ b/state/model.go
@@ -432,7 +432,7 @@ func (st *State) NewModel(args ModelArgs) (_ *Model, _ *State, err error) {
 		return nil, nil, errors.Trace(err)
 	}
 
-	err = newSt.start(st.controllerTag)
+	err = newSt.start(st.controllerTag, nil)
 	if err != nil {
 		return nil, nil, errors.Annotate(err, "could not start state for new model")
 	}

--- a/state/open.go
+++ b/state/open.go
@@ -145,7 +145,7 @@ func Open(args OpenParams) (*State, error) {
 
 	// State should only be Opened on behalf of a controller environ; all
 	// other *States should be created via ForModel.
-	if err := st.start(args.ControllerTag); err != nil {
+	if err := st.start(args.ControllerTag, nil); err != nil {
 		return nil, errors.Trace(err)
 	}
 	return st, nil

--- a/state/state.go
+++ b/state/state.go
@@ -344,7 +344,7 @@ func (st *State) ForModel(modelTag names.ModelTag) (*State, error) {
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	if err := newSt.start(st.controllerTag); err != nil {
+	if err := newSt.start(st.controllerTag, st.txnLogWatcher()); err != nil {
 		return nil, errors.Trace(err)
 	}
 	return newSt, nil
@@ -356,7 +356,7 @@ func (st *State) ForModel(modelTag names.ModelTag) (*State, error) {
 //   * creating cloud metadata storage
 //
 // start will close the *State if it fails.
-func (st *State) start(controllerTag names.ControllerTag) (err error) {
+func (st *State) start(controllerTag names.ControllerTag, txnWatcher *watcher.Watcher) (err error) {
 	defer func() {
 		if err == nil {
 			return
@@ -388,7 +388,7 @@ func (st *State) start(controllerTag names.ControllerTag) (err error) {
 	// now we've set up leaseClientId, we can use workersFactory
 
 	logger.Infof("starting standard state workers")
-	workers, err := newWorkers(st)
+	workers, err := newWorkers(st, txnWatcher)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -2323,7 +2323,7 @@ func (st *State) SetClockForTesting(clock clock.Clock) error {
 		return errors.Trace(err)
 	}
 	st.stateClock = clock
-	err = st.start(st.controllerTag)
+	err = st.start(st.controllerTag, nil)
 	if err != nil {
 		return errors.Trace(err)
 	}


### PR DESCRIPTION
Whenever juju creates a new state object, it starts a txn log watcher. This watcher polls the txns.log collection every five seconds. This watcher is the basis of most other document watchers.

Problems occur when we have many models. For example, prodstack had 184 models and 3 api servers. Every model was in every state pool, so there were 552 objects each with a worker that was polling the transaction log. When a spike of transactions were added, like in the removal of an application, the i/o load on the mongo database went through the roof as all the objects read the txns.log collection. This then caused slow downs on other documents, and caused juju status on an unrelated model go from half a second to 20 seconds.

This change uses the current state objects txn log watcher when creating a new state instance for the state pool.

## QA steps

Deploy a bunch of models into a controller, and add units and machines. Relate things.

## Documentation changes

No documentation change here, this is just an internal optimisation.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1733708