### PR TITLE
caasoperator: watch application config settings

### DIFF
--- a/apiserver/facades/agent/caasoperator/state.go
+++ b/apiserver/facades/agent/caasoperator/state.go
@@ -20,7 +20,9 @@ type CAASOperatorState interface {
 // required by the CAAS operator facade.
 type Application interface {
 	Charm() (Charm, bool, error)
+	ConfigSettings() (charm.Settings, error)
 	SetStatus(status.StatusInfo) error
+	WatchConfigSettings() (state.NotifyWatcher, error)
 }
 
 // Charm provides the subset of charm state required by the

--- a/apiserver/watcher.go
+++ b/apiserver/watcher.go
@@ -93,7 +93,7 @@ type srvNotifyWatcher struct {
 }
 
 func isAgent(auth facade.Authorizer) bool {
-	return auth.AuthMachineAgent() || auth.AuthUnitAgent()
+	return auth.AuthMachineAgent() || auth.AuthUnitAgent() || auth.AuthApplicationAgent()
 }
 
 func newNotifyWatcher(context facade.Context) (facade.Facade, error) {

--- a/state/testing/watcher.go
+++ b/state/testing/watcher.go
@@ -9,6 +9,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils/set"
 	gc "gopkg.in/check.v1"
+	tomb "gopkg.in/tomb.v1"
 
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/testing"
@@ -310,4 +311,41 @@ func (c RelationUnitsWatcherC) AssertClosed() {
 	default:
 		c.Fatalf("watcher not closed")
 	}
+}
+
+// MockNotifyWatcher implements state.NotifyWatcher.
+type MockNotifyWatcher struct {
+	tomb tomb.Tomb
+	ch   <-chan struct{}
+}
+
+func NewMockNotifyWatcher(ch <-chan struct{}) *MockNotifyWatcher {
+	w := &MockNotifyWatcher{ch: ch}
+	go func() {
+		defer w.tomb.Done()
+		<-w.tomb.Dying()
+		w.tomb.Kill(tomb.ErrDying)
+	}()
+	return w
+}
+
+func (w *MockNotifyWatcher) Changes() <-chan struct{} {
+	return w.ch
+}
+
+func (w *MockNotifyWatcher) Stop() error {
+	w.Kill()
+	return w.Wait()
+}
+
+func (w *MockNotifyWatcher) Kill() {
+	w.tomb.Kill(nil)
+}
+
+func (w *MockNotifyWatcher) Err() error {
+	return w.tomb.Err()
+}
+
+func (w *MockNotifyWatcher) Wait() error {
+	return w.tomb.Wait()
 }

--- a/state/watcher.go
+++ b/state/watcher.go
@@ -1593,6 +1593,14 @@ func (im *IAASModel) WatchFilesystemAttachment(m names.MachineTag, f names.Files
 }
 
 // WatchConfigSettings returns a watcher for observing changes to the
+// application's configuration settings. The returned watcher will be
+// valid only while the application's charm URL is not changed.
+func (a *Application) WatchConfigSettings() (NotifyWatcher, error) {
+	settingsKey := a.settingsKey()
+	return newEntityWatcher(a.st, settingsC, a.st.docID(settingsKey)), nil
+}
+
+// WatchConfigSettings returns a watcher for observing changes to the
 // unit's service configuration settings. The unit must have a charm URL
 // set before this method is called, and the returned watcher will be
 // valid only while the unit's charm URL is not changed.

--- a/watcher/watchertest/notify.go
+++ b/watcher/watchertest/notify.go
@@ -29,8 +29,8 @@ func NewMockNotifyWatcher(ch <-chan struct{}) *MockNotifyWatcher {
 	return w
 }
 
-func (w *MockNotifyWatcher) Changes() <-chan struct{} {
-	return w.ch
+func (w *MockNotifyWatcher) Changes() watcher.NotifyChannel {
+	return watcher.NotifyChannel(w.ch)
 }
 
 func (w *MockNotifyWatcher) Stop() error {
@@ -40,6 +40,12 @@ func (w *MockNotifyWatcher) Stop() error {
 
 func (w *MockNotifyWatcher) Kill() {
 	w.tomb.Kill(nil)
+}
+
+// KillErr can be used to kill the worker with
+// an error, to simulate a failing watcher.
+func (w *MockNotifyWatcher) KillErr(err error) {
+	w.tomb.Kill(err)
 }
 
 func (w *MockNotifyWatcher) Err() error {

--- a/worker/caasoperator/client.go
+++ b/worker/caasoperator/client.go
@@ -7,12 +7,14 @@ import (
 	"gopkg.in/juju/charm.v6"
 
 	"github.com/juju/juju/status"
+	"github.com/juju/juju/watcher"
 )
 
 // Client provides an interface for interacting
 // with the CAASOperator API. Subsets of this
 // should be passed to the CAASOperator worker.
 type Client interface {
+	ApplicationConfigGetter
 	CharmGetter
 	StatusSetter
 }
@@ -34,4 +36,11 @@ type StatusSetter interface {
 		info string,
 		data map[string]interface{},
 	) error
+}
+
+// ApplicationConfigGetter provides an interface for
+// watching and getting the application's config settings.
+type ApplicationConfigGetter interface {
+	ApplicationConfig(string) (charm.Settings, error)
+	WatchApplicationConfig(string) (watcher.NotifyWatcher, error)
 }

--- a/worker/caasoperator/manifold.go
+++ b/worker/caasoperator/manifold.go
@@ -87,7 +87,8 @@ func Manifold(config ManifoldConfig) dependency.Manifold {
 				return nil, errors.Errorf("expected an application tag, got %v", tag)
 			}
 			w, err := config.NewWorker(Config{
-				Application:  applicationTag.Id(),
+				Application:             applicationTag.Id(),
+				ApplicationConfigGetter: client,
 				Clock:        clock,
 				CharmGetter:  client,
 				DataDir:      agentConfig.DataDir(),

--- a/worker/caasoperator/manifold_test.go
+++ b/worker/caasoperator/manifold_test.go
@@ -122,12 +122,13 @@ func (s *ManifoldSuite) TestStart(c *gc.C) {
 	config := args[0].(caasoperator.Config)
 
 	c.Assert(config, jc.DeepEquals, caasoperator.Config{
-		Application:  "gitlab",
-		DataDir:      s.dataDir,
-		Clock:        s.clock,
-		Downloader:   &s.charmDownloader,
-		CharmGetter:  &s.client,
-		StatusSetter: &s.client,
+		Application:             "gitlab",
+		ApplicationConfigGetter: &s.client,
+		DataDir:                 s.dataDir,
+		Clock:                   s.clock,
+		Downloader:              &s.charmDownloader,
+		CharmGetter:             &s.client,
+		StatusSetter:            &s.client,
 	})
 }
 

--- a/worker/restorewatcher/worker_test.go
+++ b/worker/restorewatcher/worker_test.go
@@ -12,8 +12,8 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/state"
+	statetesting "github.com/juju/juju/state/testing"
 	coretesting "github.com/juju/juju/testing"
-	"github.com/juju/juju/watcher/watchertest"
 	"github.com/juju/juju/worker/restorewatcher"
 	"github.com/juju/juju/worker/workertest"
 )
@@ -96,7 +96,7 @@ type mockRestoreInfoWatcher struct {
 
 func (w *mockRestoreInfoWatcher) WatchRestoreInfoChanges() state.NotifyWatcher {
 	w.MethodCall(w, "WatchRestoreInfoChanges")
-	return watchertest.NewMockNotifyWatcher(w.changes)
+	return statetesting.NewMockNotifyWatcher(w.changes)
 }
 
 func (w *mockRestoreInfoWatcher) RestoreStatus() (state.RestoreStatus, error) {


### PR DESCRIPTION
## Description of change

Update the CAASOperator API with methods to
watch and get the application's config settings.
Update worker/caasoperator to watch and get
the application's config settings. For now we
just log the settings.

## QA steps

1. bootstrap / add CAAS model
2. juju deploy ubuntu
(wait for pod to come online)
3. kubectl logs -f po/juju-operator-ubuntu
(see that the worker logs the initial empty config)
4. juju config ubuntu hostname=foo
(see in the logs that the updated config is observed and logged)

## Documentation changes

None.

## Bug reference

None.