### PR TITLE
Fix add-credential help documentation.

### DIFF
--- a/cmd/juju/cloud/addcredential.go
+++ b/cmd/juju/cloud/addcredential.go
@@ -34,11 +34,10 @@ credentials:
       secret-key: <key>
   azure:
     <credential name>:
-      auth-type: userpass
+      auth-type: service-principal-secret
       application-id: <uuid1>
       application-password: <password>
       subscription-id: <uuid2>
-      tenant-id: <uuid3>
 
 A "credential name" is arbitrary and is used solely to represent a set of
 credentials, of which there may be multiple per cloud.


### PR DESCRIPTION
## Description of change

The `juju add-credentail` help documentation is incorrect.

## QA steps

The following simple bash command, which feeds the example credential file to a juju command that uses it, should work:

```
juju add-credential -h | grep -A12 'credentials:' | juju add-credential azure -f /dev/stdin
```

If you run the following command:

```
juju add-credential -h | grep -A12 'credentials:' > example_creds.yaml
```
Then edit `example_creds.yaml` with [valid azure credentials](https://jujucharms.com/docs/2.2/help-azure#manually-adding-credentials)

The you should be able to bootstrap a controller on azure. Notice how before this patch bootstrapping using this method would fail since `tenant_id` is not recognized by juju's  credential validation and adding it to the file will result in the following error when bootstrapping:

```
ERROR finalizing "bug" credential for cloud "azure": unknown key "tenant-id" (value "d68eec40-62f8-446f-9da8-a9094b2cbdee")
```
 
## Documentation changes

The [online documentation](https://jujucharms.com/docs/2.2/credentials) is also incorrect. A [PR is has been opened](https://github.com/juju/docs/pull/2312) with the relevant fix.


## Bug reference

https://bugs.launchpad.net/juju/+bug/1690920
