### PR TITLE
state/watcher: adaptive timing

### DIFF
--- a/cmd/juju/application/bundle.go
+++ b/cmd/juju/application/bundle.go
@@ -35,7 +35,6 @@ import (
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/resource/resourceadapters"
 	"github.com/juju/juju/state/multiwatcher"
-	"github.com/juju/juju/state/watcher"
 	"github.com/juju/juju/storage"
 )
 
@@ -932,11 +931,12 @@ mainloop:
 }
 
 // updateUnitStatusPeriod is the time duration used to wait for a mega-watcher
-// change to be available.
-var updateUnitStatusPeriod = watcher.Period + 5*time.Second
+// change to be available. It's pretty arbitrary because we don't
+// know what the actual maximum delay on the server is.
+var updateUnitStatusPeriod = 10 * time.Second
 
 // updateUnitStatus uses the mega-watcher to update units and machines info
-// (h.unitStatus) so that it reflects the current environment status.
+// (h.unitStatus) so that it reflects the current model status.
 // This function must be called assuming new delta changes are available or
 // will be available within the watcher time period. Otherwise, the function
 // unblocks and an error is returned.

--- a/cmd/juju/application/bundle_test.go
+++ b/cmd/juju/application/bundle_test.go
@@ -27,7 +27,6 @@ import (
 	"github.com/juju/juju/resource"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/multiwatcher"
-	"github.com/juju/juju/state/watcher"
 	"github.com/juju/juju/testcharms"
 	coretesting "github.com/juju/juju/testing"
 	"github.com/juju/juju/testing/factory"
@@ -438,11 +437,6 @@ type BundleDeployCharmStoreSuite struct {
 }
 
 var _ = gc.Suite(&BundleDeployCharmStoreSuite{})
-
-func (s *BundleDeployCharmStoreSuite) SetUpSuite(c *gc.C) {
-	s.charmStoreSuite.SetUpSuite(c)
-	s.PatchValue(&watcher.Period, 10*time.Millisecond)
-}
 
 func (s *BundleDeployCharmStoreSuite) Client() *csclient.Client {
 	return s.client

--- a/cmd/jujud/agent/agenttest/engine.go
+++ b/cmd/jujud/agent/agenttest/engine.go
@@ -75,7 +75,7 @@ func (m *WorkerMatcher) checkOnce() bool {
 }
 
 // WaitMatch returns only when the match func succeeds, or it times out.
-func WaitMatch(c *gc.C, match func() bool, maxWait time.Duration, sync func()) {
+func WaitMatch(c *gc.C, match func() bool, maxWait time.Duration) {
 	timeout := time.After(maxWait)
 	for {
 		if match() {
@@ -83,7 +83,6 @@ func WaitMatch(c *gc.C, match func() bool, maxWait time.Duration, sync func()) {
 		}
 		select {
 		case <-time.After(coretesting.ShortWait):
-			sync()
 		case <-timeout:
 			c.Fatalf("timed out waiting for workers")
 		}

--- a/cmd/jujud/agent/deploy_test.go
+++ b/cmd/jujud/agent/deploy_test.go
@@ -14,20 +14,14 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/agent"
-	"github.com/juju/juju/state"
 	"github.com/juju/juju/testing"
 )
 
 // fakeManager allows us to test deployments without actually deploying units
-// to the local system. It's slightly uncomfortably complex because it needs
-// to use the *state.State opened within the agent's runOnce -- not the one
-// created in the test -- to StartSync and cause the task to actually start
-// a sync and observe changes to the set of desired units (and thereby run
-// deployment tests in a reasonable amount of time).
+// to the local system.
 type fakeContext struct {
 	mu          sync.Mutex
 	deployed    set.Strings
-	st          *state.State
 	agentConfig agent.Config
 	inited      *signal
 }
@@ -63,7 +57,6 @@ func (ctx *fakeContext) waitDeployed(c *gc.C, want ...string) {
 	case <-ctx.inited.triggered():
 		timeout := time.After(testing.LongWait)
 		for {
-			ctx.st.StartSync()
 			select {
 			case <-timeout:
 				got, err := ctx.DeployedUnits()

--- a/cmd/jujud/agent/engine_test.go
+++ b/cmd/jujud/agent/engine_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/juju/juju/cmd/jujud/agent/machine"
 	"github.com/juju/juju/cmd/jujud/agent/model"
 	"github.com/juju/juju/cmd/jujud/agent/unit"
-	coretesting "github.com/juju/juju/testing"
 	"github.com/juju/juju/worker/dependency"
 )
 
@@ -59,12 +58,6 @@ var (
 		"model-upgraded-flag",
 		"log-forwarder",
 	}
-	// ReallyLongTimeout should be long enough for the model-tracker
-	// tests that depend on a hosted model; its backing state is not
-	// accessible for StartSyncs, so we generally have to wait for at
-	// least two 5s ticks to pass, and should expect rare circumstances
-	// to take even longer.
-	ReallyLongWait = coretesting.LongWait * 3
 
 	alwaysUnitWorkers = []string{
 		"agent",

--- a/cmd/jujud/agent/unit_test.go
+++ b/cmd/jujud/agent/unit_test.go
@@ -179,7 +179,6 @@ func waitForUnitActive(stateConn *state.State, unit *state.Unit, c *gc.C) {
 				c.Logf("waiting...")
 				continue
 			case status.Error:
-				stateConn.StartSync()
 				c.Logf("unit is still down")
 			default:
 				c.Fatalf("unexpected status %s %s %v", statusInfo.Status, statusInfo.Message, statusInfo.Data)
@@ -328,7 +327,6 @@ func (s *UnitSuite) TestUnitAgentRunsAPIAddressUpdaterWorker(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Wait for config to be updated.
-	s.BackingState.StartSync()
 	for attempt := coretesting.LongAttempt.Start(); attempt.Next(); {
 		addrs, err := a.CurrentConfig().APIAddresses()
 		c.Assert(err, jc.ErrorIsNil)
@@ -431,5 +429,5 @@ func (s *UnitSuite) TestWorkers(c *gc.C) {
 
 	matcher := agenttest.NewWorkerMatcher(c, tracker, a.Tag().String(),
 		append(alwaysUnitWorkers, notMigratingUnitWorkers...))
-	agenttest.WaitMatch(c, matcher.Check, coretesting.LongWait, s.BackingState.StartSync)
+	agenttest.WaitMatch(c, matcher.Check, coretesting.LongWait)
 }

--- a/cmd/jujud/agent/util_test.go
+++ b/cmd/jujud/agent/util_test.go
@@ -234,7 +234,6 @@ func patchDeployContext(c *gc.C, st *state.State) (*fakeContext, func()) {
 	}
 	orig := newDeployContext
 	newDeployContext = func(dst *apideployer.State, agentConfig agent.Config) deployer.Context {
-		ctx.st = st
 		ctx.agentConfig = agentConfig
 		ctx.inited.trigger()
 		return ctx
@@ -257,9 +256,7 @@ func (s *commonMachineSuite) setFakeMachineAddresses(c *gc.C, machine *state.Mac
 
 // opRecvTimeout waits for any of the given kinds of operation to
 // be received from ops, and times out if not.
-func opRecvTimeout(c *gc.C, st *state.State, opc <-chan dummy.Operation, kinds ...dummy.Operation) dummy.Operation {
-	st.StartSync()
-	timeout := time.After(coretesting.LongWait)
+func opRecvTimeout(c *gc.C, opc <-chan dummy.Operation, kinds ...dummy.Operation) dummy.Operation {
 	for {
 		select {
 		case op := <-opc:
@@ -269,9 +266,7 @@ func opRecvTimeout(c *gc.C, st *state.State, opc <-chan dummy.Operation, kinds .
 				}
 			}
 			c.Logf("discarding unknown event %#v", op)
-		case <-time.After(coretesting.ShortWait):
-			st.StartSync()
-		case <-timeout:
+		case <-time.After(coretesting.LongWait):
 			c.Fatalf("time out wating for operation")
 		}
 	}

--- a/featuretests/agent_caasoperator_test.go
+++ b/featuretests/agent_caasoperator_test.go
@@ -144,5 +144,5 @@ func (s *CAASOperatorSuite) TestWorkers(c *gc.C) {
 
 	matcher := agenttest.NewWorkerMatcher(c, tracker, a.Tag().String(),
 		append(alwaysCAASWorkers, notMigratingCAASWorkers...))
-	agenttest.WaitMatch(c, matcher.Check, coretesting.LongWait, s.BackingState.StartSync)
+	agenttest.WaitMatch(c, matcher.Check, coretesting.LongWait)
 }

--- a/featuretests/upgrade_test.go
+++ b/featuretests/upgrade_test.go
@@ -31,7 +31,6 @@ import (
 	jujutesting "github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/mongo"
 	"github.com/juju/juju/state"
-	"github.com/juju/juju/state/watcher"
 	coretesting "github.com/juju/juju/testing"
 	"github.com/juju/juju/testing/factory"
 	"github.com/juju/juju/tools"
@@ -56,12 +55,6 @@ var ShortAttempt = &utils.AttemptStrategy{
 type upgradeSuite struct {
 	agenttest.AgentSuite
 	oldVersion version.Binary
-}
-
-func (s *upgradeSuite) SetUpSuite(c *gc.C) {
-	s.AgentSuite.SetUpSuite(c)
-	// Speed up the watcher frequency to make the test much faster.
-	s.PatchValue(&watcher.Period, 200*time.Millisecond)
 }
 
 func (s *upgradeSuite) SetUpTest(c *gc.C) {


### PR DESCRIPTION
Experimental change. Explicit tests in watcher.go are still needed, and QA on real Juju controllers.

This makes the watcher polling speed adapt to recent activity - when there have been recent changes, it polls faster, exponentially backing off up to a maximum poll interval of 5 seconds when everything is inactive. This could speed up Juju reaction time for quite a few operations.

Theoretically this removes the need for the StartSync method (used only in tests) although not all calls to it have been removed yet. A sample change was made in cmd/jujud/agent to remove all StartSync calls - the resulting tests ran at the same speed as the tests with StartSync included.

Fixes https://bugs.launchpad.net/juju-core/+bug/1163983

