### PR TITLE
Introduce operator runner infrastructure

### DIFF
--- a/worker/caasoperator/commands/context.go
+++ b/worker/caasoperator/commands/context.go
@@ -84,10 +84,10 @@ type ContextApplication interface {
 	ConfigSettings() (charm.Settings, error)
 }
 
-// ContextStatus is the part of a hook context related to the unit's status.
+// ContextStatus is the part of a hook context related to the application's status.
 type ContextStatus interface {
 	// ApplicationStatus returns the executing application status.
-	ApplicationStatus() (ApplicationStatusInfo, error)
+	ApplicationStatus() (StatusInfo, error)
 
 	// SetApplicationStatus updates the status for the application.
 	SetApplicationStatus(appStatus StatusInfo) error

--- a/worker/caasoperator/commands/context.go
+++ b/worker/caasoperator/commands/context.go
@@ -1,0 +1,119 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package commands
+
+import (
+	"gopkg.in/juju/charm.v6"
+
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/core/relation"
+)
+
+// ContextRelation expresses the capabilities of a hook with respect to a relation.
+type ContextRelation interface {
+
+	// Id returns an integer which uniquely identifies the relation.
+	Id() int
+
+	// Name returns the name the locally executing charm assigned to this relation.
+	Name() string
+
+	// FakeId returns a string of the form "relation-name:123", which uniquely
+	// identifies the relation to the hook. In reality, the identification
+	// of the relation is the integer following the colon, but the composed
+	// name is useful to humans observing it.
+	FakeId() string
+
+	// Settings allows read/write access to the local unit's settings in
+	// this relation.
+	LocalSettings() (Settings, error)
+
+	// UnitNames returns a list of the remote units in the relation.
+	UnitNames() []string
+
+	// RemoteSettings returns the settings of any remote unit in the relation.
+	RemoteSettings(unit string) (Settings, error)
+
+	// Suspended returns true if the relation is suspended.
+	Suspended() bool
+
+	// SetStatus sets the relation's status.
+	SetStatus(relation.Status) error
+}
+
+// Context is the interface that all hook helper commands
+// depend on to interact with the rest of the system.
+type Context interface {
+	hookContext
+	relationHookContext
+}
+
+// HookContext represents the information and functionality that is
+// common to all charm hooks.
+type hookContext interface {
+	ContextApplication
+	ContextNetworking
+	ContextRelations
+	ContextStatus
+}
+
+// RelationHookContext is the context for a relation hook.
+type RelationHookContext interface {
+	hookContext
+	relationHookContext
+}
+
+type relationHookContext interface {
+	// HookRelation returns the ContextRelation associated with the executing
+	// hook if it was found, or an error if it was not found (or is not available).
+	HookRelation() (ContextRelation, error)
+
+	// RemoteUnitName returns the name of the remote unit the hook execution
+	// is associated with if it was found, and an error if it was not found or is not
+	// available.
+	RemoteUnitName() (string, error)
+}
+
+// ContextApplication is the part of a hook context related to the application.
+type ContextApplication interface {
+	// ApplicationName returns the executing application's name.
+	ApplicationName() string
+
+	// ConfigSettings returns the current configuration of the executing unit.
+	ConfigSettings() (charm.Settings, error)
+}
+
+// ContextStatus is the part of a hook context related to the unit's status.
+type ContextStatus interface {
+	// ApplicationStatus returns the executing application status.
+	ApplicationStatus() (ApplicationStatusInfo, error)
+
+	// SetApplicationStatus updates the status for the application.
+	SetApplicationStatus(appStatus StatusInfo) error
+}
+
+// ContextNetworking is the part of a hook context related to network
+// interface of the unit's instance.
+type ContextNetworking interface {
+	// NetworkInfo returns the network info for the given bindings on the given relation.
+	NetworkInfo(bindingNames []string, relationId int) (map[string]params.NetworkInfoResult, error)
+}
+
+// ContextRelations exposes the relations associated with the unit.
+type ContextRelations interface {
+	// Relation returns the relation with the supplied id if it was found, and
+	// an error if it was not found or is not available.
+	Relation(id int) (ContextRelation, error)
+
+	// RelationIds returns the ids of all relations the executing unit is
+	// currently participating in or an error if they are not available.
+	RelationIds() ([]int, error)
+}
+
+// Settings is implemented by types that manipulate unit settings.
+type Settings interface {
+	Map() map[string]string
+	Set(string, string)
+	Delete(string)
+}

--- a/worker/caasoperator/commands/interface.go
+++ b/worker/caasoperator/commands/interface.go
@@ -10,9 +10,3 @@ type StatusInfo struct {
 	Info   string
 	Data   map[string]interface{}
 }
-
-// ApplicationStatusInfo holds StatusInfo for an application and all its units.
-type ApplicationStatusInfo struct {
-	Application StatusInfo
-	Units       []StatusInfo
-}

--- a/worker/caasoperator/commands/interface.go
+++ b/worker/caasoperator/commands/interface.go
@@ -1,0 +1,18 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package commands
+
+// StatusInfo is a record of the status information for an application or a unit's workload.
+type StatusInfo struct {
+	Tag    string
+	Status string
+	Info   string
+	Data   map[string]interface{}
+}
+
+// ApplicationStatusInfo holds StatusInfo for an application and all its units.
+type ApplicationStatusInfo struct {
+	Application StatusInfo
+	Units       []StatusInfo
+}

--- a/worker/caasoperator/hook/hook.go
+++ b/worker/caasoperator/hook/hook.go
@@ -1,7 +1,7 @@
 // Copyright 2017 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-// hook provides types that define the hooks known to the operator
+// Package hook provides types that define the hooks known to the operator
 package hook
 
 import (

--- a/worker/caasoperator/hook/hook.go
+++ b/worker/caasoperator/hook/hook.go
@@ -1,0 +1,55 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+// hook provides types that define the hooks known to the operator
+package hook
+
+import (
+	"fmt"
+
+	"gopkg.in/juju/charm.v6/hooks"
+)
+
+// Info holds details required to execute a hook. Not all fields are
+// relevant to all Kind values.
+type Info struct {
+	Kind hooks.Kind `yaml:"kind"`
+
+	// RelationId identifies the relation associated with the hook. It is
+	// only set when Kind indicates a relation hook.
+	RelationId int `yaml:"relation-id,omitempty"`
+
+	// RemoteUnit is the name of the unit that triggered the hook. It is only
+	// set when Kind indicates a relation hook other than relation-broken.
+	RemoteUnit string `yaml:"remote-unit,omitempty"`
+
+	// ChangeVersion identifies the most recent unit settings change
+	// associated with RemoteUnit. It is only set when RemoteUnit is set.
+	ChangeVersion int64 `yaml:"change-version,omitempty"`
+}
+
+// Validate returns an error if the info is not valid.
+func (hi Info) Validate() error {
+	switch hi.Kind {
+	case hooks.RelationChanged:
+		if hi.RemoteUnit == "" {
+			return fmt.Errorf("%q hook requires a remote unit", hi.Kind)
+		}
+		fallthrough
+	case hooks.ConfigChanged:
+		return nil
+	}
+	return fmt.Errorf("unknown hook kind %q", hi.Kind)
+}
+
+// Committer is an interface that may be used to convey the fact that the
+// specified hook has been successfully executed, and committed.
+type Committer interface {
+	CommitHook(Info) error
+}
+
+// Validator is an interface that may be used to validate a hook execution
+// request prior to executing it.
+type Validator interface {
+	ValidateHook(Info) error
+}

--- a/worker/caasoperator/hook/hook_test.go
+++ b/worker/caasoperator/hook/hook_test.go
@@ -1,0 +1,45 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package hook_test
+
+import (
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/charm.v6/hooks"
+
+	"github.com/juju/juju/testing"
+	"github.com/juju/juju/worker/caasoperator/hook"
+)
+
+type InfoSuite struct {
+	testing.BaseSuite
+}
+
+var _ = gc.Suite(&InfoSuite{})
+
+var validateTests = []struct {
+	info hook.Info
+	err  string
+}{
+	{
+		hook.Info{Kind: hooks.RelationChanged},
+		`"relation-changed" hook requires a remote unit`,
+	}, {
+		hook.Info{Kind: hooks.Kind("grok")},
+		`unknown hook kind "grok"`,
+	},
+	{hook.Info{Kind: hooks.ConfigChanged}, ""},
+}
+
+func (s *InfoSuite) TestValidate(c *gc.C) {
+	for i, t := range validateTests {
+		c.Logf("test %d", i)
+		err := t.info.Validate()
+		if t.err == "" {
+			c.Assert(err, jc.ErrorIsNil)
+		} else {
+			c.Assert(err, gc.ErrorMatches, t.err)
+		}
+	}
+}

--- a/worker/caasoperator/hook/package_test.go
+++ b/worker/caasoperator/hook/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2014 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package hook_test
+
+import (
+	stdtesting "testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func TestPackage(t *stdtesting.T) {
+	gc.TestingT(t)
+}

--- a/worker/caasoperator/runner/args.go
+++ b/worker/caasoperator/runner/args.go
@@ -1,0 +1,27 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package runner
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+
+	"github.com/juju/juju/worker/common/charmrunner"
+)
+
+// searchHook will search, in order, hooks suffixed with extensions
+// in windowsSuffixOrder. As windows cares about extensions to determine
+// how to execute a file, we will allow several suffixes, with powershell
+// being default.
+func searchHook(charmDir, hook string) (string, error) {
+	hookFile, err := exec.LookPath(filepath.Join(charmDir, hook))
+	if err != nil {
+		if ee, ok := err.(*exec.Error); ok && os.IsNotExist(ee.Err) {
+			return "", charmrunner.NewMissingHookError(hook)
+		}
+		return "", err
+	}
+	return hookFile, nil
+}

--- a/worker/caasoperator/runner/args_test.go
+++ b/worker/caasoperator/runner/args_test.go
@@ -1,0 +1,39 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package runner_test
+
+import (
+	"path/filepath"
+	"runtime"
+
+	envtesting "github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	"github.com/juju/utils/os"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/worker/caasoperator/runner"
+)
+
+type ArgsSuite struct{}
+
+var _ = gc.Suite(&ArgsSuite{})
+
+func (s *ArgsSuite) TestSearchHookUbuntu(c *gc.C) {
+	if runtime.GOOS == "windows" {
+		c.Skip("Cannot search for executables without extension on windows")
+	}
+	restorer := envtesting.PatchValue(&os.HostOS, func() os.OSType { return os.Ubuntu })
+	defer restorer()
+
+	charmDir := c.MkDir()
+	makeCharm(c, hookSpec{
+		dir:  "hooks",
+		name: "something-happened",
+		perm: 0755,
+	}, charmDir)
+
+	obtained, err := runner.SearchHook(charmDir, filepath.Join("hooks", "something-happened"))
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(obtained, gc.Equals, filepath.Join(charmDir, "hooks", "something-happened"))
+}

--- a/worker/caasoperator/runner/context/cache.go
+++ b/worker/caasoperator/runner/context/cache.go
@@ -1,0 +1,97 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package context
+
+import (
+	"sort"
+
+	"github.com/juju/juju/worker/caasoperator/commands"
+)
+
+// SettingsFunc returns the relation settings for a unit.
+type SettingsFunc func(unitName string) (commands.Settings, error)
+
+// SettingsMap is a map from unit name to relation settings.
+type SettingsMap map[string]commands.Settings
+
+// RelationCache stores a relation's remote unit membership and settings.
+// Member settings are stored until invalidated or removed by name; settings
+// of non-member units are stored only until the cache is pruned.
+type RelationCache struct {
+	// RemoteSettings is used to get settings data if when not already present.
+	RemoteSettings SettingsFunc
+	// members' keys define the relation's membership; non-nil values hold
+	// cached settings.
+	members SettingsMap
+	// others is a short-term cache for non-member settings.
+	others SettingsMap
+}
+
+// NewRelationCache creates a new RelationCache that will use the supplied
+// SettingsFunc to populate itself on demand. Initial membership is determined
+// by memberNames.
+func NewRelationCache(RemoteSettings SettingsFunc, memberNames []string) *RelationCache {
+	cache := &RelationCache{
+		RemoteSettings: RemoteSettings,
+	}
+	cache.Prune(memberNames)
+	return cache
+}
+
+// Prune resets the membership to the supplied list, and discards the settings
+// of all non-member units.
+func (cache *RelationCache) Prune(memberNames []string) {
+	newMembers := SettingsMap{}
+	for _, memberName := range memberNames {
+		newMembers[memberName] = cache.members[memberName]
+	}
+	cache.members = newMembers
+	cache.others = SettingsMap{}
+}
+
+// MemberNames returns the names of the remote units present in the relation.
+func (cache *RelationCache) MemberNames() (memberNames []string) {
+	for memberName := range cache.members {
+		memberNames = append(memberNames, memberName)
+	}
+	sort.Strings(memberNames)
+	return memberNames
+}
+
+// Settings returns the settings of the named remote unit. It's valid to get
+// the settings of any unit that has ever been in the relation.
+func (cache *RelationCache) Settings(unitName string) (commands.Settings, error) {
+	settings, isMember := cache.members[unitName]
+	if settings == nil {
+		if !isMember {
+			settings = cache.others[unitName]
+		}
+		if settings == nil {
+			var err error
+			settings, err = cache.RemoteSettings(unitName)
+			if err != nil {
+				return nil, err
+			}
+		}
+	}
+	if isMember {
+		cache.members[unitName] = settings
+	} else {
+		cache.others[unitName] = settings
+	}
+	return settings, nil
+}
+
+// InvalidateMember ensures that the named remote unit will be considered a
+// member of the relation, and that the next attempt to read its settings will
+// use fresh data.
+func (cache *RelationCache) InvalidateMember(memberName string) {
+	cache.members[memberName] = nil
+}
+
+// RemoveMember ensures that the named remote unit will not be considered a
+// member of the relation,
+func (cache *RelationCache) RemoveMember(memberName string) {
+	delete(cache.members, memberName)
+}

--- a/worker/caasoperator/runner/context/cache_test.go
+++ b/worker/caasoperator/runner/context/cache_test.go
@@ -1,0 +1,216 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package context_test
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/worker/caasoperator/commands"
+	"github.com/juju/juju/worker/caasoperator/runner/context"
+	"github.com/juju/juju/worker/caasoperator/runner/runnertesting"
+)
+
+type settingsResult struct {
+	settings commands.Settings
+	err      error
+}
+
+type RelationCacheSuite struct {
+	testing.IsolationSuite
+	calls   []string
+	results []settingsResult
+}
+
+var _ = gc.Suite(&RelationCacheSuite{})
+
+func (s *RelationCacheSuite) SetUpTest(c *gc.C) {
+	s.calls = []string{}
+	s.results = []settingsResult{}
+}
+
+func (s *RelationCacheSuite) RemoteSettings(unitName string) (commands.Settings, error) {
+	result := s.results[len(s.calls)]
+	s.calls = append(s.calls, unitName)
+	return result.settings, result.err
+}
+
+func (s *RelationCacheSuite) TestCreateEmpty(c *gc.C) {
+	cache := context.NewRelationCache(s.RemoteSettings, nil)
+	c.Assert(cache.MemberNames(), gc.HasLen, 0)
+	c.Assert(s.calls, gc.HasLen, 0)
+}
+
+func (s *RelationCacheSuite) TestCreateWithMembers(c *gc.C) {
+	cache := context.NewRelationCache(s.RemoteSettings, []string{"u/3", "u/2", "u/1"})
+	c.Assert(cache.MemberNames(), jc.DeepEquals, []string{"u/1", "u/2", "u/3"})
+	c.Assert(s.calls, gc.HasLen, 0)
+}
+
+func (s *RelationCacheSuite) TestInvalidateMemberChangesMembership(c *gc.C) {
+	cache := context.NewRelationCache(s.RemoteSettings, nil)
+	cache.InvalidateMember("foo/1")
+	c.Assert(cache.MemberNames(), jc.DeepEquals, []string{"foo/1"})
+	cache.InvalidateMember("foo/2")
+	c.Assert(cache.MemberNames(), jc.DeepEquals, []string{"foo/1", "foo/2"})
+	cache.InvalidateMember("foo/2")
+	c.Assert(cache.MemberNames(), jc.DeepEquals, []string{"foo/1", "foo/2"})
+	c.Assert(s.calls, gc.HasLen, 0)
+}
+
+func (s *RelationCacheSuite) TestRemoveMemberChangesMembership(c *gc.C) {
+	cache := context.NewRelationCache(s.RemoteSettings, []string{"x/2"})
+	cache.RemoveMember("x/1")
+	c.Assert(cache.MemberNames(), jc.DeepEquals, []string{"x/2"})
+	cache.RemoveMember("x/2")
+	c.Assert(cache.MemberNames(), gc.HasLen, 0)
+	c.Assert(s.calls, gc.HasLen, 0)
+}
+
+func (s *RelationCacheSuite) TestPruneChangesMembership(c *gc.C) {
+	cache := context.NewRelationCache(s.RemoteSettings, []string{"u/1", "u/2", "u/3"})
+	cache.Prune([]string{"u/3", "u/4", "u/5"})
+	c.Assert(cache.MemberNames(), jc.DeepEquals, []string{"u/3", "u/4", "u/5"})
+	c.Assert(s.calls, gc.HasLen, 0)
+}
+
+func (s *RelationCacheSuite) TestSettingsPropagatesError(c *gc.C) {
+	s.results = []settingsResult{{
+		nil, errors.New("blam"),
+	}}
+	cache := context.NewRelationCache(s.RemoteSettings, nil)
+
+	settings, err := cache.Settings("whatever")
+	c.Assert(settings, gc.IsNil)
+	c.Assert(err, gc.ErrorMatches, "blam")
+	c.Assert(s.calls, jc.DeepEquals, []string{"whatever"})
+}
+
+func (s *RelationCacheSuite) TestSettingsCachesMemberSettings(c *gc.C) {
+	s.results = []settingsResult{{
+		runnertesting.Settings{"foo": "bar"}, nil,
+	}}
+	cache := context.NewRelationCache(s.RemoteSettings, []string{"x/2"})
+
+	for i := 0; i < 2; i++ {
+		settings, err := cache.Settings("x/2")
+		c.Assert(err, jc.ErrorIsNil)
+		c.Assert(settings, jc.DeepEquals, runnertesting.Settings{"foo": "bar"})
+		c.Assert(s.calls, jc.DeepEquals, []string{"x/2"})
+	}
+}
+
+func (s *RelationCacheSuite) TestInvalidateMemberUncachesMemberSettings(c *gc.C) {
+	s.results = []settingsResult{{
+		runnertesting.Settings{"foo": "bar"}, nil,
+	}, {
+		runnertesting.Settings{"baz": "qux"}, nil,
+	}}
+	cache := context.NewRelationCache(s.RemoteSettings, []string{"x/2"})
+
+	settings, err := cache.Settings("x/2")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(settings, jc.DeepEquals, runnertesting.Settings{"foo": "bar"})
+	c.Assert(s.calls, jc.DeepEquals, []string{"x/2"})
+
+	cache.InvalidateMember("x/2")
+	settings, err = cache.Settings("x/2")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(settings, jc.DeepEquals, runnertesting.Settings{"baz": "qux"})
+	c.Assert(s.calls, jc.DeepEquals, []string{"x/2", "x/2"})
+}
+
+func (s *RelationCacheSuite) TestInvalidateMemberUncachesOtherSettings(c *gc.C) {
+	s.results = []settingsResult{{
+		runnertesting.Settings{"foo": "bar"}, nil,
+	}, {
+		runnertesting.Settings{"baz": "qux"}, nil,
+	}}
+	cache := context.NewRelationCache(s.RemoteSettings, nil)
+
+	settings, err := cache.Settings("x/2")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(settings, jc.DeepEquals, runnertesting.Settings{"foo": "bar"})
+	c.Assert(s.calls, jc.DeepEquals, []string{"x/2"})
+
+	cache.InvalidateMember("x/2")
+	settings, err = cache.Settings("x/2")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(settings, jc.DeepEquals, runnertesting.Settings{"baz": "qux"})
+	c.Assert(s.calls, jc.DeepEquals, []string{"x/2", "x/2"})
+}
+
+func (s *RelationCacheSuite) TestRemoveMemberUncachesMemberSettings(c *gc.C) {
+	s.results = []settingsResult{{
+		runnertesting.Settings{"foo": "bar"}, nil,
+	}, {
+		runnertesting.Settings{"baz": "qux"}, nil,
+	}}
+	cache := context.NewRelationCache(s.RemoteSettings, []string{"x/2"})
+
+	settings, err := cache.Settings("x/2")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(settings, jc.DeepEquals, runnertesting.Settings{"foo": "bar"})
+	c.Assert(s.calls, jc.DeepEquals, []string{"x/2"})
+
+	cache.RemoveMember("x/2")
+	settings, err = cache.Settings("x/2")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(settings, jc.DeepEquals, runnertesting.Settings{"baz": "qux"})
+	c.Assert(s.calls, jc.DeepEquals, []string{"x/2", "x/2"})
+}
+
+func (s *RelationCacheSuite) TestSettingsCachesOtherSettings(c *gc.C) {
+	s.results = []settingsResult{{
+		runnertesting.Settings{"foo": "bar"}, nil,
+	}}
+	cache := context.NewRelationCache(s.RemoteSettings, nil)
+
+	for i := 0; i < 2; i++ {
+		settings, err := cache.Settings("x/2")
+		c.Assert(err, jc.ErrorIsNil)
+		c.Assert(settings, jc.DeepEquals, runnertesting.Settings{"foo": "bar"})
+		c.Assert(s.calls, jc.DeepEquals, []string{"x/2"})
+	}
+}
+
+func (s *RelationCacheSuite) TestPrunePreservesMemberSettings(c *gc.C) {
+	s.results = []settingsResult{{
+		runnertesting.Settings{"foo": "bar"}, nil,
+	}}
+	cache := context.NewRelationCache(s.RemoteSettings, []string{"foo/2"})
+
+	settings, err := cache.Settings("foo/2")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(settings, jc.DeepEquals, runnertesting.Settings{"foo": "bar"})
+	c.Assert(s.calls, jc.DeepEquals, []string{"foo/2"})
+
+	cache.Prune([]string{"foo/2"})
+	settings, err = cache.Settings("foo/2")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(settings, jc.DeepEquals, runnertesting.Settings{"foo": "bar"})
+	c.Assert(s.calls, jc.DeepEquals, []string{"foo/2"})
+}
+
+func (s *RelationCacheSuite) TestPruneUncachesOtherSettings(c *gc.C) {
+	s.results = []settingsResult{{
+		runnertesting.Settings{"foo": "bar"}, nil,
+	}, {
+		runnertesting.Settings{"baz": "qux"}, nil,
+	}}
+	cache := context.NewRelationCache(s.RemoteSettings, nil)
+
+	settings, err := cache.Settings("x/2")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(settings, jc.DeepEquals, runnertesting.Settings{"foo": "bar"})
+	c.Assert(s.calls, jc.DeepEquals, []string{"x/2"})
+
+	cache.Prune(nil)
+	settings, err = cache.Settings("x/2")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(settings, jc.DeepEquals, runnertesting.Settings{"baz": "qux"})
+	c.Assert(s.calls, jc.DeepEquals, []string{"x/2", "x/2"})
+}

--- a/worker/caasoperator/runner/context/context.go
+++ b/worker/caasoperator/runner/context/context.go
@@ -1,0 +1,304 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+// Package context contains the ContextFactory and Context definitions. Context implements
+// hooks.Context and is used together with caasoperator.Runner to run hooks, commands and actions.
+package context
+
+import (
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/juju/errors"
+	"github.com/juju/loggo"
+	"github.com/juju/utils/clock"
+	"github.com/juju/utils/proxy"
+	"gopkg.in/juju/charm.v6"
+	"gopkg.in/juju/names.v2"
+
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/status"
+	"github.com/juju/juju/version"
+	"github.com/juju/juju/worker/caasoperator/commands"
+)
+
+// Paths exposes the paths needed by Context.
+type Paths interface {
+
+	// GetToolsDir returns the filesystem path to the dirctory containing
+	// the hook tool symlinks.
+	GetToolsDir() string
+
+	// GetCharmDir returns the filesystem path to the directory in which
+	// the charm is installed.
+	GetCharmDir() string
+
+	// GetJujucSocket returns the path to the socket used by the hook tools
+	// to communicate back to the executing operator process. It might be a
+	// filesystem path, or it might be abstract.
+	GetJujucSocket() string
+
+	// GetMetricsSpoolDir returns the path to a metrics spool dir, used
+	// to store metrics recorded during a single hook run.
+	GetMetricsSpoolDir() string
+
+	// ComponentDir returns the filesystem path to the directory
+	// containing all data files for a component.
+	ComponentDir(name string) string
+}
+
+var logger = loggo.GetLogger("juju.worker.caasoperator.runner.context")
+var mutex = sync.Mutex{}
+
+// meterStatus describes the unit's meter status.
+type meterStatus struct {
+	code string
+	info string
+}
+
+// HookProcess is an interface representing a process running a hook.
+type HookProcess interface {
+	Pid() int
+	Kill() error
+}
+
+// HookContext is the implementation of hooks.Context.
+type HookContext struct {
+	hookAPI hookAPI
+
+	// configSettings holds the service configuration.
+	configSettings charm.Settings
+
+	// id identifies the context.
+	id string
+
+	// uuid is the universally unique identifier of the environment.
+	uuid string
+
+	// modelName is the human friendly name of the environment.
+	modelName string
+
+	// applicationName is the name of the application.
+	applicationName string
+
+	// status is the status of the application.
+	status *commands.ApplicationStatusInfo
+
+	// relationId identifies the relation for which a relation hook is
+	// executing. If it is -1, the context is not running a relation hook;
+	// otherwise, its value must be a valid key into the relations map.
+	relationId int
+
+	// remoteUnitName identifies the changing unit of the executing relation
+	// hook. It will be empty if the context is not running a relation hook,
+	// or if it is running a relation-broken hook.
+	remoteUnitName string
+
+	// relations contains the context for every relation the unit is a member
+	// of, keyed on relation id.
+	relations map[int]*ContextRelation
+
+	// apiAddrs contains the API server addresses.
+	apiAddrs []string
+
+	// proxySettings are the current proxy settings that the operator knows about.
+	proxySettings proxy.Settings
+
+	// process is the process of the command that is being run in the local context,
+	// like a juju-run command or a hook
+	process HookProcess
+
+	// clock is used for any time operations.
+	clock clock.Clock
+}
+
+func (ctx *HookContext) GetProcess() HookProcess {
+	mutex.Lock()
+	defer mutex.Unlock()
+	return ctx.process
+}
+
+func (ctx *HookContext) SetProcess(process HookProcess) {
+	mutex.Lock()
+	defer mutex.Unlock()
+	ctx.process = process
+}
+
+func (ctx *HookContext) Id() string {
+	return ctx.id
+}
+
+func (ctx *HookContext) ApplicationName() string {
+	return ctx.applicationName
+}
+
+// ApplicationStatus returns the status for the application and all the units on
+// the service to which this context unit belongs, only if this unit is
+// the leader.
+func (ctx *HookContext) ApplicationStatus() (commands.ApplicationStatusInfo, error) {
+	if ctx.status != nil {
+		return *ctx.status, nil
+	}
+	var err error
+	status, err := ctx.hookAPI.ApplicationStatus(ctx.applicationName)
+	if err == nil && status.Error != nil {
+		err = status.Error
+	}
+	if err != nil {
+		return commands.ApplicationStatusInfo{}, errors.Trace(err)
+	}
+	us := make([]commands.StatusInfo, len(status.Units))
+	i := 0
+	for t, s := range status.Units {
+		us[i] = commands.StatusInfo{
+			Tag:    t,
+			Status: string(s.Status),
+			Info:   s.Info,
+			Data:   s.Data,
+		}
+		i++
+	}
+	ctx.status = &commands.ApplicationStatusInfo{
+		Application: commands.StatusInfo{
+			Tag:    names.NewApplicationTag(ctx.applicationName).String(),
+			Status: string(status.Application.Status),
+			Info:   status.Application.Info,
+			Data:   status.Application.Data,
+		},
+		Units: us,
+	}
+	return *ctx.status, nil
+}
+
+// SetApplicationStatus will set the given status to the service to which this
+// unit's belong, only if this unit is the leader.
+func (ctx *HookContext) SetApplicationStatus(appStatus commands.StatusInfo) error {
+	logger.Tracef("[APPLICATION-STATUS] %s: %s", appStatus.Status, appStatus.Info)
+
+	return ctx.hookAPI.SetApplicationStatus(
+		ctx.applicationName,
+		status.Status(appStatus.Status),
+		appStatus.Info,
+		appStatus.Data,
+	)
+}
+
+func (ctx *HookContext) ConfigSettings() (charm.Settings, error) {
+	if ctx.configSettings == nil {
+		var err error
+		ctx.configSettings, err = ctx.hookAPI.ConfigSettings()
+		if err != nil {
+			return nil, err
+		}
+	}
+	result := charm.Settings{}
+	for name, value := range ctx.configSettings {
+		result[name] = value
+	}
+	return result, nil
+}
+
+func (ctx *HookContext) HookRelation() (commands.ContextRelation, error) {
+	return ctx.Relation(ctx.relationId)
+}
+
+func (ctx *HookContext) RemoteUnitName() (string, error) {
+	if ctx.remoteUnitName == "" {
+		return "", errors.NotFoundf("remote unit")
+	}
+	return ctx.remoteUnitName, nil
+}
+
+func (ctx *HookContext) Relation(id int) (commands.ContextRelation, error) {
+	r, found := ctx.relations[id]
+	if !found {
+		return nil, errors.NotFoundf("relation")
+	}
+	return r, nil
+}
+
+func (ctx *HookContext) RelationIds() ([]int, error) {
+	ids := []int{}
+	for id := range ctx.relations {
+		ids = append(ids, id)
+	}
+	return ids, nil
+}
+
+// AddMetric adds metrics to the hook context.
+func (ctx *HookContext) AddMetric(key, value string, created time.Time) error {
+	return errors.New("metrics not allowed in this context")
+}
+
+// HookVars returns an os.Environ-style list of strings necessary to run a hook
+// such that it can know what environment it's operating in, and can call back
+// into context.
+func (context *HookContext) HookVars(paths Paths) ([]string, error) {
+	vars := context.proxySettings.AsEnvironmentValues()
+	vars = append(vars,
+		"CHARM_DIR="+paths.GetCharmDir(), // legacy, embarrassing
+		"JUJU_CHARM_DIR="+paths.GetCharmDir(),
+		"JUJU_CONTEXT_ID="+context.id,
+		"JUJU_AGENT_SOCKET="+paths.GetJujucSocket(),
+		"JUJU_APPLICATION_NAME="+context.applicationName,
+		"JUJU_MODEL_UUID="+context.uuid,
+		"JUJU_MODEL_NAME="+context.modelName,
+		"JUJU_API_ADDRESSES="+strings.Join(context.apiAddrs, " "),
+		"JUJU_VERSION="+version.Current.String(),
+	)
+	if r, err := context.HookRelation(); err == nil {
+		vars = append(vars,
+			"JUJU_RELATION="+r.Name(),
+			"JUJU_RELATION_ID="+r.FakeId(),
+			"JUJU_REMOTE_UNIT="+context.remoteUnitName,
+		)
+	} else if !errors.IsNotFound(err) {
+		return nil, errors.Trace(err)
+	}
+	return append(vars, OSDependentEnvVars(paths)...), nil
+}
+
+// Prepare implements the Context interface.
+func (ctx *HookContext) Prepare() error {
+	return nil
+}
+
+// Flush implements the Context interface.
+func (ctx *HookContext) Flush(process string, ctxErr error) (err error) {
+	writeChanges := ctxErr == nil
+
+	for id, rctx := range ctx.relations {
+		if writeChanges {
+			if e := rctx.WriteSettings(); e != nil {
+				e = errors.Errorf(
+					"could not write settings from %q to relation %d: %v",
+					process, id, e,
+				)
+				logger.Errorf("%v", e)
+				if ctxErr == nil {
+					ctxErr = e
+				}
+			}
+		}
+	}
+
+	// TODO (tasdomas) 2014 09 03: context finalization needs to modified to apply all
+	//                             changes in one api call to minimize the risk
+	//                             of partial failures.
+
+	if !writeChanges {
+		return ctxErr
+	}
+
+	return ctxErr
+}
+
+// NetworkInfo returns the network info for the given bindings on the given relation.
+func (ctx *HookContext) NetworkInfo(bindingNames []string, relationId int) (map[string]params.NetworkInfoResult, error) {
+	var relId *int
+	if relationId != -1 {
+		relId = &relationId
+	}
+	return ctx.hookAPI.NetworkInfo(bindingNames, relId)
+}

--- a/worker/caasoperator/runner/context/context_test.go
+++ b/worker/caasoperator/runner/context/context_test.go
@@ -1,0 +1,131 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package context_test
+
+import (
+	"github.com/juju/juju/status"
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/charm.v6"
+
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/worker/caasoperator/commands"
+	"github.com/juju/juju/worker/caasoperator/runner/context"
+)
+
+type InterfaceSuite struct {
+	HookContextSuite
+	stub testing.Stub
+}
+
+var _ = gc.Suite(&InterfaceSuite{})
+
+func (s *InterfaceSuite) TestApplicationName(c *gc.C) {
+	ctx := s.GetContext(c, -1, "")
+	c.Assert(ctx.ApplicationName(), gc.Equals, "gitlab")
+}
+
+func (s *InterfaceSuite) TestHookRelation(c *gc.C) {
+	ctx := s.GetContext(c, -1, "")
+	r, err := ctx.HookRelation()
+	c.Assert(err, gc.ErrorMatches, ".*")
+	c.Assert(r, gc.IsNil)
+}
+
+func (s *InterfaceSuite) TestRemoteUnitName(c *gc.C) {
+	ctx := s.GetContext(c, -1, "")
+	name, err := ctx.RemoteUnitName()
+	c.Assert(err, gc.ErrorMatches, ".*")
+	c.Assert(name, gc.Equals, "")
+}
+
+func (s *InterfaceSuite) TestRelationIds(c *gc.C) {
+	ctx := s.GetContext(c, -1, "")
+	relIds, err := ctx.RelationIds()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(relIds, gc.HasLen, 2)
+	r, err := ctx.Relation(0)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(r.Name(), gc.Equals, "db")
+	c.Assert(r.FakeId(), gc.Equals, "db:0")
+	r, err = ctx.Relation(123)
+	c.Assert(err, gc.ErrorMatches, ".*")
+	c.Assert(r, gc.IsNil)
+}
+
+func (s *InterfaceSuite) TestRelationContext(c *gc.C) {
+	ctx := s.GetContext(c, 1, "")
+	r, err := ctx.HookRelation()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(r.Name(), gc.Equals, "db")
+	c.Assert(r.FakeId(), gc.Equals, "db:1")
+}
+
+func (s *InterfaceSuite) TestRelationContextWithRemoteUnitName(c *gc.C) {
+	ctx := s.GetContext(c, 1, "u/123")
+	name, err := ctx.RemoteUnitName()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(name, gc.Equals, "u/123")
+}
+
+func (s *InterfaceSuite) TestNetworkInfo(c *gc.C) {
+	// Only the error case is tested, the rest
+	// of the cases are tested separately elsewhere.
+	ctx := s.GetContext(c, -1, "")
+	netInfo, err := ctx.NetworkInfo([]string{"unknown"}, -1)
+	c.Check(err, jc.ErrorIsNil)
+	c.Check(netInfo, gc.DeepEquals, map[string]params.NetworkInfoResult{
+		"db": {
+			IngressAddresses: []string{"10.0.0.1"},
+		},
+	},
+	)
+}
+
+func (s *InterfaceSuite) TestApplicationStatus(c *gc.C) {
+	ctx := s.GetContext(c, -1, "")
+	defer context.PatchCachedStatus(ctx.(commands.Context), "maintenance", "working", map[string]interface{}{"hello": "world"})()
+	appStatus, err := ctx.ApplicationStatus()
+	c.Check(err, jc.ErrorIsNil)
+	c.Check(appStatus.Application.Status, gc.Equals, "maintenance")
+	c.Check(appStatus.Application.Info, gc.Equals, "working")
+	c.Check(appStatus.Application.Data, gc.DeepEquals, map[string]interface{}{"hello": "world"})
+}
+
+func (s *InterfaceSuite) TestStatusCaching(c *gc.C) {
+	ctx := s.GetContext(c, -1, "")
+	appStatus, err := ctx.ApplicationStatus()
+	c.Check(err, jc.ErrorIsNil)
+	c.Check(appStatus.Application.Status, gc.Equals, "maintenance")
+	c.Check(appStatus.Application.Info, gc.Equals, "initialising")
+	c.Check(appStatus.Application.Data, gc.DeepEquals, map[string]interface{}{})
+
+	// Change remote state.
+	err = s.contextAPI.SetApplicationStatus("gitlab", status.Blocked, "broken", nil)
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Local view is unchanged.
+	appStatus, err = ctx.ApplicationStatus()
+	c.Check(err, jc.ErrorIsNil)
+	c.Check(appStatus.Application.Status, gc.Equals, "maintenance")
+	c.Check(appStatus.Application.Info, gc.Equals, "initialising")
+	c.Check(appStatus.Application.Data, gc.DeepEquals, map[string]interface{}{})
+}
+
+func (s *InterfaceSuite) TestConfigCaching(c *gc.C) {
+	s.contextAPI.UpdateConfigSettings(charm.Settings{"blog-title": "My Title"})
+	ctx := s.GetContext(c, -1, "")
+	settings, err := ctx.ConfigSettings()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(settings, gc.DeepEquals, charm.Settings{"blog-title": "My Title"})
+
+	// Change remote config.
+	s.contextAPI.UpdateConfigSettings(charm.Settings{"blog-title": "Something Else"})
+
+	// Local view is not changed.
+	settings, err = ctx.ConfigSettings()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(settings, gc.DeepEquals, charm.Settings{"blog-title": "My Title"})
+}

--- a/worker/caasoperator/runner/context/context_test.go
+++ b/worker/caasoperator/runner/context/context_test.go
@@ -89,18 +89,18 @@ func (s *InterfaceSuite) TestApplicationStatus(c *gc.C) {
 	defer context.PatchCachedStatus(ctx.(commands.Context), "maintenance", "working", map[string]interface{}{"hello": "world"})()
 	appStatus, err := ctx.ApplicationStatus()
 	c.Check(err, jc.ErrorIsNil)
-	c.Check(appStatus.Application.Status, gc.Equals, "maintenance")
-	c.Check(appStatus.Application.Info, gc.Equals, "working")
-	c.Check(appStatus.Application.Data, gc.DeepEquals, map[string]interface{}{"hello": "world"})
+	c.Check(appStatus.Status, gc.Equals, "maintenance")
+	c.Check(appStatus.Info, gc.Equals, "working")
+	c.Check(appStatus.Data, gc.DeepEquals, map[string]interface{}{"hello": "world"})
 }
 
 func (s *InterfaceSuite) TestStatusCaching(c *gc.C) {
 	ctx := s.GetContext(c, -1, "")
 	appStatus, err := ctx.ApplicationStatus()
 	c.Check(err, jc.ErrorIsNil)
-	c.Check(appStatus.Application.Status, gc.Equals, "maintenance")
-	c.Check(appStatus.Application.Info, gc.Equals, "initialising")
-	c.Check(appStatus.Application.Data, gc.DeepEquals, map[string]interface{}{})
+	c.Check(appStatus.Status, gc.Equals, "maintenance")
+	c.Check(appStatus.Info, gc.Equals, "initialising")
+	c.Check(appStatus.Data, gc.DeepEquals, map[string]interface{}{})
 
 	// Change remote state.
 	err = s.contextAPI.SetApplicationStatus("gitlab", status.Blocked, "broken", nil)
@@ -109,9 +109,9 @@ func (s *InterfaceSuite) TestStatusCaching(c *gc.C) {
 	// Local view is unchanged.
 	appStatus, err = ctx.ApplicationStatus()
 	c.Check(err, jc.ErrorIsNil)
-	c.Check(appStatus.Application.Status, gc.Equals, "maintenance")
-	c.Check(appStatus.Application.Info, gc.Equals, "initialising")
-	c.Check(appStatus.Application.Data, gc.DeepEquals, map[string]interface{}{})
+	c.Check(appStatus.Status, gc.Equals, "maintenance")
+	c.Check(appStatus.Info, gc.Equals, "initialising")
+	c.Check(appStatus.Data, gc.DeepEquals, map[string]interface{}{})
 }
 
 func (s *InterfaceSuite) TestConfigCaching(c *gc.C) {

--- a/worker/caasoperator/runner/context/contextfactory.go
+++ b/worker/caasoperator/runner/context/contextfactory.go
@@ -1,0 +1,252 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package context
+
+import (
+	"fmt"
+	"math/rand"
+	"time"
+
+	"github.com/juju/errors"
+	"github.com/juju/utils/clock"
+	"gopkg.in/juju/charm.v6/hooks"
+	"gopkg.in/juju/names.v2"
+
+	"github.com/juju/juju/worker/caasoperator/hook"
+)
+
+// CommandInfo specifies the information necessary to run a command.
+type CommandInfo struct {
+	// RelationId is the relation context to execute the commands in.
+	RelationId int
+	// RemoteUnitName is the remote unit for the relation context.
+	RemoteUnitName string
+	// ForceRemoteUnit skips unit inference and existence validation.
+	ForceRemoteUnit bool
+}
+
+// ContextFactory represents a long-lived object that can create execution contexts
+// relevant to a specific unit.
+type ContextFactory interface {
+	// CommandContext creates a new context for running a juju command.
+	CommandContext(commandInfo CommandInfo) (*HookContext, error)
+
+	// HookContext creates a new context for running a juju hook.
+	HookContext(hookInfo hook.Info) (*HookContext, error)
+}
+
+// RelationsFunc is used to get snapshots of relation membership at context
+// creation time.
+type RelationsFunc func() map[int]*RelationInfo
+
+type contextFactory struct {
+	contextFactoryAPI contextFactoryAPI
+	hookAPI           hookAPI
+
+	// Fields that shouldn't change in a factory's lifetime.
+	applicationTag names.ApplicationTag
+	paths          Paths
+	modelUUID      string
+	modelName      string
+	clock          clock.Clock
+
+	// Callback to get relation state snapshot.
+	getRelationInfos RelationsFunc
+	relationCaches   map[int]*RelationCache
+
+	// For generating "unique" context ids.
+	rand *rand.Rand
+}
+
+// FactoryConfig contains configuration values
+// for the context factory.
+type FactoryConfig struct {
+	// These API attributes define the interface the backend.
+	ContextFactoryAPI contextFactoryAPI
+	HookAPI           hookAPI
+	GetRelationInfos  RelationsFunc
+
+	ModelUUID      string
+	ModelName      string
+	ApplicationTag names.ApplicationTag
+	Paths          Paths
+	Clock          clock.Clock
+}
+
+// NewContextFactory returns a ContextFactory capable of creating execution contexts backed
+// by the supplied unit's supplied API connection.
+func NewContextFactory(config FactoryConfig) (ContextFactory, error) {
+	f := &contextFactory{
+		contextFactoryAPI: config.ContextFactoryAPI,
+		hookAPI:           config.HookAPI,
+		applicationTag:    config.ApplicationTag,
+		paths:             config.Paths,
+		modelUUID:         config.ModelUUID,
+		modelName:         config.ModelName,
+		getRelationInfos:  config.GetRelationInfos,
+		relationCaches:    map[int]*RelationCache{},
+		rand:              rand.New(rand.NewSource(time.Now().Unix())),
+		clock:             config.Clock,
+	}
+	return f, nil
+}
+
+// newId returns a probably-unique identifier for a new context, containing the
+// supplied string.
+func (f *contextFactory) newId(name string) string {
+	return fmt.Sprintf("%s-%s-%d", f.applicationTag.Id(), name, f.rand.Int63())
+}
+
+// coreContext creates a new context with all unspecialised fields filled in.
+func (f *contextFactory) coreContext() (*HookContext, error) {
+	ctx := &HookContext{
+		hookAPI:         f.hookAPI,
+		uuid:            f.modelUUID,
+		modelName:       f.modelName,
+		applicationName: f.applicationTag.Id(),
+		relations:       f.getContextRelations(),
+		relationId:      -1,
+		clock:           f.clock,
+	}
+	if err := f.updateContext(ctx); err != nil {
+		return nil, err
+	}
+	return ctx, nil
+}
+
+// HookContext is part of the ContextFactory interface.
+func (f *contextFactory) HookContext(hookInfo hook.Info) (*HookContext, error) {
+	ctx, err := f.coreContext()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	hookName := string(hookInfo.Kind)
+	if hookInfo.Kind.IsRelation() {
+		ctx.relationId = hookInfo.RelationId
+		ctx.remoteUnitName = hookInfo.RemoteUnit
+		relation, found := ctx.relations[hookInfo.RelationId]
+		if !found {
+			return nil, errors.Errorf("unknown relation id: %v", hookInfo.RelationId)
+		}
+		// TODO(caas) - we don't run departed hooks so figure out when to clear cache
+		if hookInfo.Kind == hooks.RelationDeparted {
+			relation.cache.RemoveMember(hookInfo.RemoteUnit)
+		} else if hookInfo.RemoteUnit != "" {
+			// Clear remote settings cache for changing remote unit.
+			relation.cache.InvalidateMember(hookInfo.RemoteUnit)
+		}
+		hookName = fmt.Sprintf("%s-%s", relation.Name(), hookInfo.Kind)
+	}
+	ctx.id = f.newId(hookName)
+	return ctx, nil
+}
+
+// CommandContext is part of the ContextFactory interface.
+func (f *contextFactory) CommandContext(commandInfo CommandInfo) (*HookContext, error) {
+	ctx, err := f.coreContext()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	relationId, remoteUnitName, err := inferRemoteUnit(ctx.relations, commandInfo)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	ctx.relationId = relationId
+	ctx.remoteUnitName = remoteUnitName
+	ctx.id = f.newId("run-commands")
+	return ctx, nil
+}
+
+// getContextRelations updates the factory's relation caches, and uses them
+// to construct ContextRelations for a fresh context.
+func (f *contextFactory) getContextRelations() map[int]*ContextRelation {
+	contextRelations := map[int]*ContextRelation{}
+	relationInfos := f.getRelationInfos()
+	relationCaches := map[int]*RelationCache{}
+	for id, info := range relationInfos {
+		memberNames := info.MemberNames
+		cache, found := f.relationCaches[id]
+		if found {
+			cache.Prune(memberNames)
+		} else {
+			cache = NewRelationCache(info.RelationUnitAPI.RemoteSettings, memberNames)
+		}
+		relationCaches[id] = cache
+		contextRelations[id] = NewContextRelation(info.RelationUnitAPI, cache)
+	}
+	f.relationCaches = relationCaches
+	return contextRelations
+}
+
+// updateContext fills in all unspecialized fields that require an API call to
+// discover.
+//
+// Approximately *every* line of code in this function represents a bug: ie, some
+// piece of information we expose to the charm but which we fail to report changes
+// to via hooks. Furthermore, the fact that we make multiple API calls at this
+// time, rather than grabbing everything we need in one go, is unforgivably yucky.
+func (f *contextFactory) updateContext(ctx *HookContext) (err error) {
+	defer errors.Trace(err)
+
+	ctx.apiAddrs, err = f.contextFactoryAPI.APIAddresses()
+	if err != nil {
+		return err
+	}
+
+	proxySettings, err := f.contextFactoryAPI.ProxySettings()
+	if err != nil {
+		return err
+	}
+	ctx.proxySettings = proxySettings
+
+	return nil
+}
+
+func inferRemoteUnit(rctxs map[int]*ContextRelation, info CommandInfo) (int, string, error) {
+	relationId := info.RelationId
+	hasRelation := relationId != -1
+	remoteUnit := info.RemoteUnitName
+	hasRemoteUnit := remoteUnit != ""
+
+	// Check baseline sanity of remote unit, if supplied.
+	if hasRemoteUnit {
+		if !names.IsValidUnit(remoteUnit) {
+			return -1, "", errors.Errorf(`invalid remote unit: %s`, remoteUnit)
+		} else if !hasRelation {
+			return -1, "", errors.Errorf("remote unit provided without a relation: %s", remoteUnit)
+		}
+	}
+
+	// Check sanity of relation, if supplied, otherwise easy early return.
+	if !hasRelation {
+		return relationId, remoteUnit, nil
+	}
+	rctx, found := rctxs[relationId]
+	if !found {
+		return -1, "", errors.Errorf("unknown relation id: %d", relationId)
+	}
+
+	// Past basic sanity checks; if forced, accept what we're given.
+	if info.ForceRemoteUnit {
+		return relationId, remoteUnit, nil
+	}
+
+	// Infer an appropriate remote unit if we can.
+	possibles := rctx.UnitNames()
+	if remoteUnit == "" {
+		switch len(possibles) {
+		case 0:
+			return -1, "", errors.Errorf("cannot infer remote unit in empty relation %d", relationId)
+		case 1:
+			return relationId, possibles[0], nil
+		}
+		return -1, "", errors.Errorf("ambiguous remote unit; possibilities are %+v", possibles)
+	}
+	for _, possible := range possibles {
+		if remoteUnit == possible {
+			return relationId, remoteUnit, nil
+		}
+	}
+	return -1, "", errors.Errorf("unknown remote unit %s; possibilities are %+v", remoteUnit, possibles)
+}

--- a/worker/caasoperator/runner/context/contextfactory_test.go
+++ b/worker/caasoperator/runner/context/contextfactory_test.go
@@ -1,0 +1,200 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package context_test
+
+import (
+	"os"
+	"time"
+
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	"github.com/juju/utils/fs"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/charm.v6/hooks"
+	"gopkg.in/juju/names.v2"
+
+	"github.com/juju/juju/testcharms"
+	coretesting "github.com/juju/juju/testing"
+	"github.com/juju/juju/worker/caasoperator/commands"
+	"github.com/juju/juju/worker/caasoperator/hook"
+	"github.com/juju/juju/worker/caasoperator/runner/context"
+	"github.com/juju/juju/worker/caasoperator/runner/runnertesting"
+)
+
+type ContextFactorySuite struct {
+	HookContextSuite
+
+	paths      runnertesting.MockPaths
+	factory    context.ContextFactory
+	membership map[int][]string
+}
+
+var _ = gc.Suite(&ContextFactorySuite{})
+
+func (s *ContextFactorySuite) SetUpTest(c *gc.C) {
+	s.HookContextSuite.SetUpTest(c)
+	s.paths = runnertesting.NewMockPaths(c)
+	s.membership = map[int][]string{}
+
+	contextFactory, err := context.NewContextFactory(context.FactoryConfig{
+		ContextFactoryAPI: s.contextAPI,
+		ApplicationTag:    names.NewApplicationTag("gitlab"),
+		ModelName:         "gitlab-model",
+		ModelUUID:         coretesting.ModelTag.Id(),
+		GetRelationInfos:  s.getRelationInfos,
+		Paths:             s.paths,
+		Clock:             testing.NewClock(time.Time{}),
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	s.factory = contextFactory
+}
+
+func (s *ContextFactorySuite) setUpCacheMethods(c *gc.C) {
+	// The factory's caches are created lazily, so it doesn't have any at all to
+	// begin with. Creating and discarding a context lets us call updateCache
+	// without panicking. (IMO this is less invasive that making updateCache
+	// responsible for creating missing caches etc.)
+	_, err := s.factory.HookContext(hook.Info{Kind: hooks.ConfigChanged})
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *ContextFactorySuite) updateCache(relId int, unitName string, settings map[string]string) {
+	context.UpdateCachedSettings(s.factory, relId, unitName, settings)
+}
+
+func (s *ContextFactorySuite) getCache(relId int, unitName string) (commands.Settings, bool) {
+	return context.CachedSettings(s.factory, relId, unitName)
+}
+
+func (s *ContextFactorySuite) SetCharm(c *gc.C, name string) {
+	err := os.RemoveAll(s.paths.GetCharmDir())
+	c.Assert(err, jc.ErrorIsNil)
+	err = fs.Copy(testcharms.Repo.CharmDirPath(name), s.paths.GetCharmDir())
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *ContextFactorySuite) getRelationInfos() map[int]*context.RelationInfo {
+	info := map[int]*context.RelationInfo{}
+	for relId, relUnit := range s.relationAPIs {
+		info[relId] = &context.RelationInfo{
+			RelationUnitAPI: relUnit,
+			MemberNames:     s.membership[relId],
+		}
+	}
+	return info
+}
+
+func (s *ContextFactorySuite) TestRelationHookContext(c *gc.C) {
+	hi := hook.Info{
+		Kind:       hooks.RelationChanged,
+		RelationId: 1,
+		RemoteUnit: "mysql",
+	}
+	ctx, err := s.factory.HookContext(hi)
+	c.Assert(err, jc.ErrorIsNil)
+	s.AssertCoreContext(c, ctx)
+	s.AssertRelationContext(c, ctx, 1, "mysql")
+}
+
+func (s *ContextFactorySuite) TestCommandContext(c *gc.C) {
+	ctx, err := s.factory.CommandContext(context.CommandInfo{RelationId: -1})
+	c.Assert(err, jc.ErrorIsNil)
+
+	s.AssertCoreContext(c, ctx)
+	s.AssertNotRelationContext(c, ctx)
+}
+
+func (s *ContextFactorySuite) TestCommandContextNoRelation(c *gc.C) {
+	ctx, err := s.factory.CommandContext(context.CommandInfo{RelationId: -1})
+	c.Assert(err, jc.ErrorIsNil)
+	s.AssertCoreContext(c, ctx)
+	s.AssertNotRelationContext(c, ctx)
+}
+
+func (s *ContextFactorySuite) TestNewCommandContextForceNoRemoteUnit(c *gc.C) {
+	ctx, err := s.factory.CommandContext(context.CommandInfo{
+		RelationId: 0, ForceRemoteUnit: true,
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	s.AssertCoreContext(c, ctx)
+	s.AssertRelationContext(c, ctx, 0, "")
+}
+
+func (s *ContextFactorySuite) TestNewCommandContextForceRemoteUnitMissing(c *gc.C) {
+	ctx, err := s.factory.CommandContext(context.CommandInfo{
+		RelationId: 0, RemoteUnitName: "blah/123", ForceRemoteUnit: true,
+	})
+	c.Assert(err, gc.IsNil)
+	s.AssertCoreContext(c, ctx)
+	s.AssertRelationContext(c, ctx, 0, "blah/123")
+}
+
+func (s *ContextFactorySuite) TestNewCommandContextInferRemoteUnit(c *gc.C) {
+	s.membership[0] = []string{"foo/2"}
+	ctx, err := s.factory.CommandContext(context.CommandInfo{RelationId: 0})
+	c.Assert(err, jc.ErrorIsNil)
+	s.AssertCoreContext(c, ctx)
+	s.AssertRelationContext(c, ctx, 0, "foo/2")
+}
+
+func (s *ContextFactorySuite) TestNewHookContextPrunesNonMemberCaches(c *gc.C) {
+
+	// Write cached member settings for a member and a non-member.
+	s.setUpCacheMethods(c)
+	s.membership[0] = []string{"rel0/0"}
+	s.updateCache(0, "rel0/0", map[string]string{"keep": "me"})
+	s.updateCache(0, "rel0/1", map[string]string{"drop": "me"})
+
+	ctx, err := s.factory.HookContext(hook.Info{Kind: hooks.ConfigChanged})
+	c.Assert(err, jc.ErrorIsNil)
+
+	settings0, found := s.getCache(0, "rel0/0")
+	c.Assert(found, jc.IsTrue)
+	c.Assert(settings0.Map(), jc.DeepEquals, map[string]string{"keep": "me"})
+
+	settings1, found := s.getCache(0, "rel0/1")
+	c.Assert(found, jc.IsFalse)
+	c.Assert(settings1, gc.IsNil)
+
+	// Check the caches are being used by the context relations.
+	relCtx, err := ctx.Relation(0)
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Verify that the settings really were cached by trying to look them up.
+	// Nothing's really in scope, so the call would fail if they weren't.
+	settings0, err = relCtx.RemoteSettings("rel0/0")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(settings0.Map(), jc.DeepEquals, map[string]string{"keep": "me"})
+
+	// Verify that the non-member settings were purged by looking them up and
+	// checking for the expected error.
+	settings1, err = relCtx.RemoteSettings("rel0/1")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(settings1, gc.HasLen, 0)
+}
+
+func (s *ContextFactorySuite) TestNewHookContextRelationChangedUpdatesRelationContextAndCaches(c *gc.C) {
+	// Update member settings to have actual values, so we can check that
+	// the change for r/4 clears its cache but leaves r/0's alone.
+	s.setUpCacheMethods(c)
+	s.membership[1] = []string{"r/0", "r/4"}
+	s.updateCache(1, "r/0", map[string]string{"foo": "bar"})
+	s.updateCache(1, "r/4", map[string]string{"baz": "qux"})
+
+	ctx, err := s.factory.HookContext(hook.Info{
+		Kind:       hooks.RelationChanged,
+		RelationId: 1,
+		RemoteUnit: "r/4",
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	s.AssertCoreContext(c, ctx)
+	rel := s.AssertRelationContext(c, ctx, 1, "r/4")
+	c.Assert(rel.UnitNames(), jc.DeepEquals, []string{"r/0", "r/4"})
+	cached0, member := s.getCache(1, "r/0")
+	c.Assert(cached0.Map(), jc.DeepEquals, map[string]string{"foo": "bar"})
+	c.Assert(member, jc.IsTrue)
+	cached4, member := s.getCache(1, "r/4")
+	c.Assert(cached4, gc.IsNil)
+	c.Assert(member, jc.IsTrue)
+}

--- a/worker/caasoperator/runner/context/env.go
+++ b/worker/caasoperator/runner/context/env.go
@@ -9,9 +9,9 @@ import (
 	jujuos "github.com/juju/utils/os"
 )
 
-// OSDependentEnvVars returns the OS-dependent environment variables that
+// OSEnvVars returns the OS environment variables that
 // should be set for a hook context.
-func OSDependentEnvVars(paths Paths) []string {
+func OSEnvVars(paths Paths) []string {
 	switch jujuos.HostOS() {
 	case jujuos.Ubuntu, jujuos.CentOS, jujuos.OpenSUSE:
 		return appendPath(paths)

--- a/worker/caasoperator/runner/context/env.go
+++ b/worker/caasoperator/runner/context/env.go
@@ -1,0 +1,26 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package context
+
+import (
+	"os"
+
+	jujuos "github.com/juju/utils/os"
+)
+
+// OSDependentEnvVars returns the OS-dependent environment variables that
+// should be set for a hook context.
+func OSDependentEnvVars(paths Paths) []string {
+	switch jujuos.HostOS() {
+	case jujuos.Ubuntu, jujuos.CentOS, jujuos.OpenSUSE:
+		return appendPath(paths)
+	}
+	return nil
+}
+
+func appendPath(paths Paths) []string {
+	return []string{
+		"PATH=" + paths.GetToolsDir() + ":" + os.Getenv("PATH"),
+	}
+}

--- a/worker/caasoperator/runner/context/env_test.go
+++ b/worker/caasoperator/runner/context/env_test.go
@@ -1,0 +1,115 @@
+// Copyright 2012-2014 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package context_test
+
+import (
+	"os"
+	"sort"
+
+	envtesting "github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	"github.com/juju/utils/keyvalues"
+	jujuos "github.com/juju/utils/os"
+	"github.com/juju/utils/proxy"
+	"github.com/juju/version"
+	gc "gopkg.in/check.v1"
+
+	jujuversion "github.com/juju/juju/version"
+	"github.com/juju/juju/worker/caasoperator/runner/context"
+)
+
+type EnvSuite struct {
+	envtesting.IsolationSuite
+}
+
+var _ = gc.Suite(&EnvSuite{})
+
+func (s *EnvSuite) assertVars(c *gc.C, actual []string, expect ...[]string) {
+	var fullExpect []string
+	for _, someExpect := range expect {
+		fullExpect = append(fullExpect, someExpect...)
+	}
+	sort.Strings(actual)
+	sort.Strings(fullExpect)
+	c.Assert(actual, jc.DeepEquals, fullExpect)
+}
+
+func (s *EnvSuite) getPaths() (paths context.Paths, expectVars []string) {
+	// note: path-munging is os-dependent, not included in expectVars
+	return MockFakePaths{}, []string{
+		"CHARM_DIR=path-to-charm",
+		"JUJU_CHARM_DIR=path-to-charm",
+		"JUJU_AGENT_SOCKET=path-to-jujuc.socket",
+	}
+}
+
+func (s *EnvSuite) getContext() (ctx *context.HookContext, expectVars []string) {
+	return context.NewModelHookContext(
+			"some-context-id",
+			"model-uuid-deadbeef",
+			"some-model-name",
+			"this-app",
+			[]string{"he.re:12345", "the.re:23456"},
+			proxy.Settings{
+				Http:    "some-http-proxy",
+				Https:   "some-https-proxy",
+				Ftp:     "some-ftp-proxy",
+				NoProxy: "some-no-proxy",
+			},
+		), []string{
+			"JUJU_CONTEXT_ID=some-context-id",
+			"JUJU_MODEL_UUID=model-uuid-deadbeef",
+			"JUJU_MODEL_NAME=some-model-name",
+			"JUJU_APPLICATION_NAME=this-app",
+			"JUJU_API_ADDRESSES=he.re:12345 the.re:23456",
+			"JUJU_VERSION=1.2.3",
+			"http_proxy=some-http-proxy",
+			"HTTP_PROXY=some-http-proxy",
+			"https_proxy=some-https-proxy",
+			"HTTPS_PROXY=some-https-proxy",
+			"ftp_proxy=some-ftp-proxy",
+			"FTP_PROXY=some-ftp-proxy",
+			"no_proxy=some-no-proxy",
+			"NO_PROXY=some-no-proxy",
+		}
+}
+
+func (s *EnvSuite) setRelation(ctx *context.HookContext) (expectVars []string) {
+	context.SetEnvironmentHookContextRelation(
+		ctx, 22, "an-endpoint", "that-unit/456",
+	)
+	return []string{
+		"JUJU_RELATION=an-endpoint",
+		"JUJU_RELATION_ID=an-endpoint:22",
+		"JUJU_REMOTE_UNIT=that-unit/456",
+	}
+}
+
+func (s *EnvSuite) TestEnvSetsPath(c *gc.C) {
+	paths := context.OSDependentEnvVars(MockFakePaths{})
+	c.Assert(paths, gc.Not(gc.HasLen), 0)
+	vars, err := keyvalues.Parse(paths, true)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(vars["PATH"], gc.Not(gc.Equals), "")
+}
+
+func (s *EnvSuite) TestEnv(c *gc.C) {
+	s.PatchValue(&jujuos.HostOS, func() jujuos.OSType { return jujuos.Ubuntu })
+	s.PatchValue(&jujuversion.Current, version.MustParse("1.2.3"))
+	os.Setenv("PATH", "foo:bar")
+	vars := []string{
+		"PATH=path-to-tools:foo:bar",
+	}
+
+	ctx, contextVars := s.getContext()
+	paths, pathsVars := s.getPaths()
+	actualVars, err := ctx.HookVars(paths)
+	c.Assert(err, jc.ErrorIsNil)
+	s.assertVars(c, actualVars, contextVars, pathsVars, vars)
+
+	relationVars := s.setRelation(ctx)
+	actualVars, err = ctx.HookVars(paths)
+	c.Assert(err, jc.ErrorIsNil)
+	s.assertVars(c, actualVars, contextVars, pathsVars, vars, relationVars)
+}

--- a/worker/caasoperator/runner/context/env_test.go
+++ b/worker/caasoperator/runner/context/env_test.go
@@ -87,7 +87,7 @@ func (s *EnvSuite) setRelation(ctx *context.HookContext) (expectVars []string) {
 }
 
 func (s *EnvSuite) TestEnvSetsPath(c *gc.C) {
-	paths := context.OSDependentEnvVars(MockFakePaths{})
+	paths := context.OSEnvVars(MockFakePaths{})
 	c.Assert(paths, gc.Not(gc.HasLen), 0)
 	vars, err := keyvalues.Parse(paths, true)
 	c.Assert(err, jc.ErrorIsNil)

--- a/worker/caasoperator/runner/context/export_test.go
+++ b/worker/caasoperator/runner/context/export_test.go
@@ -1,0 +1,111 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package context
+
+import (
+	"github.com/juju/utils/clock"
+	"github.com/juju/utils/proxy"
+
+	"github.com/juju/juju/worker/caasoperator/commands"
+	"github.com/juju/juju/worker/caasoperator/runner/runnertesting"
+)
+
+func NewHookContext(
+	hookAPI hookAPI,
+	id,
+	uuid,
+	applicationName string,
+	modelName string,
+	relationId int,
+	remoteUnitName string,
+	relations map[int]*ContextRelation,
+	apiAddrs []string,
+	proxySettings proxy.Settings,
+	clock clock.Clock,
+) (*HookContext, error) {
+	ctx := &HookContext{
+		hookAPI:         hookAPI,
+		id:              id,
+		uuid:            uuid,
+		modelName:       modelName,
+		applicationName: applicationName,
+		relationId:      relationId,
+		remoteUnitName:  remoteUnitName,
+		relations:       relations,
+		apiAddrs:        apiAddrs,
+		proxySettings:   proxySettings,
+		clock:           clock,
+	}
+	return ctx, nil
+}
+
+// SetEnvironmentHookContextRelation exists purely to set the fields used in hookVars.
+// It makes no assumptions about the validity of context.
+func SetEnvironmentHookContextRelation(
+	context *HookContext,
+	relationId int, endpointName, remoteUnitName string,
+) {
+	context.relationId = relationId
+	context.remoteUnitName = remoteUnitName
+	context.relations = map[int]*ContextRelation{
+		relationId: {
+			endpointName: endpointName,
+			relationId:   relationId,
+		},
+	}
+}
+
+func PatchCachedStatus(ctx commands.Context, status, info string, data map[string]interface{}) func() {
+	hctx := ctx.(*HookContext)
+	oldStatus := hctx.status
+	appStatusInfo := &commands.ApplicationStatusInfo{
+		Application: commands.StatusInfo{
+			Status: status,
+			Info:   info,
+			Data:   data,
+		},
+	}
+	hctx.status = appStatusInfo
+	return func() {
+		hctx.status = oldStatus
+	}
+}
+
+// NewModelHookContext exists purely to set the fields used in rs.
+// The returned value is not otherwise valid.
+func NewModelHookContext(
+	id, modelUUID, modelName, applicationName string,
+	apiAddresses []string, proxySettings proxy.Settings,
+) *HookContext {
+	return &HookContext{
+		id:              id,
+		applicationName: applicationName,
+		uuid:            modelUUID,
+		modelName:       modelName,
+		apiAddrs:        apiAddresses,
+		proxySettings:   proxySettings,
+		relationId:      -1,
+	}
+}
+
+func ContextModelInfo(hctx *HookContext) (name, uuid string) {
+	return hctx.modelName, hctx.uuid
+}
+
+func UpdateCachedSettings(cf0 ContextFactory, relId int, unitName string, settings map[string]string) {
+	cf := cf0.(*contextFactory)
+	members := cf.relationCaches[relId].members
+	if members[unitName] == nil {
+		members[unitName] = make(runnertesting.Settings)
+	}
+	for key, value := range settings {
+		members[unitName].Set(key, value)
+	}
+}
+
+func CachedSettings(cf0 ContextFactory, relId int, unitName string) (commands.Settings, bool) {
+	cf := cf0.(*contextFactory)
+	settings, found := cf.relationCaches[relId].members[unitName]
+	return settings, found
+}

--- a/worker/caasoperator/runner/context/export_test.go
+++ b/worker/caasoperator/runner/context/export_test.go
@@ -59,12 +59,10 @@ func SetEnvironmentHookContextRelation(
 func PatchCachedStatus(ctx commands.Context, status, info string, data map[string]interface{}) func() {
 	hctx := ctx.(*HookContext)
 	oldStatus := hctx.status
-	appStatusInfo := &commands.ApplicationStatusInfo{
-		Application: commands.StatusInfo{
-			Status: status,
-			Info:   info,
-			Data:   data,
-		},
+	appStatusInfo := &commands.StatusInfo{
+		Status: status,
+		Info:   info,
+		Data:   data,
 	}
 	hctx.status = appStatusInfo
 	return func() {

--- a/worker/caasoperator/runner/context/interface.go
+++ b/worker/caasoperator/runner/context/interface.go
@@ -1,0 +1,36 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package context
+
+import (
+	"github.com/juju/utils/proxy"
+	"gopkg.in/juju/charm.v6"
+
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/core/relation"
+	"github.com/juju/juju/status"
+	"github.com/juju/juju/worker/caasoperator/commands"
+)
+
+type hookAPI interface {
+	ConfigSettings() (charm.Settings, error)
+	NetworkInfo([]string, *int) (map[string]params.NetworkInfoResult, error)
+	ApplicationStatus(string) (params.ApplicationStatusResult, error)
+	SetApplicationStatus(string, status.Status, string, map[string]interface{}) error
+}
+
+type contextFactoryAPI interface {
+	APIAddresses() ([]string, error)
+	ProxySettings() (proxy.Settings, error)
+}
+
+type relationUnitAPI interface {
+	Id() int
+	Endpoint() string
+	Suspended() bool
+	SetStatus(status relation.Status) error
+	LocalSettings() (commands.Settings, error)
+	RemoteSettings(string) (commands.Settings, error)
+	WriteSettings(commands.Settings) error
+}

--- a/worker/caasoperator/runner/context/package_test.go
+++ b/worker/caasoperator/runner/context/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package context_test
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func TestPackage(t *testing.T) {
+	gc.TestingT(t)
+}

--- a/worker/caasoperator/runner/context/relation.go
+++ b/worker/caasoperator/runner/context/relation.go
@@ -1,0 +1,89 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package context
+
+import (
+	"fmt"
+
+	"github.com/juju/juju/core/relation"
+	"github.com/juju/juju/worker/caasoperator/commands"
+)
+
+type RelationInfo struct {
+	RelationUnitAPI relationUnitAPI
+	MemberNames     []string
+}
+
+// ContextRelation is the implementation of hooks.ContextRelation.
+type ContextRelation struct {
+	relationUnitAPI relationUnitAPI
+	relationId      int
+	endpointName    string
+
+	// settings allows read and write access to the relation unit settings.
+	settings commands.Settings
+
+	// cache holds remote unit membership and settings.
+	cache *RelationCache
+}
+
+// NewContextRelation creates a new context for the given relation unit.
+// The unit-name keys of members supplies the initial membership.
+func NewContextRelation(relationAPI relationUnitAPI, cache *RelationCache) *ContextRelation {
+	return &ContextRelation{
+		relationUnitAPI: relationAPI,
+		relationId:      relationAPI.Id(),
+		endpointName:    relationAPI.Endpoint(),
+		cache:           cache,
+	}
+}
+
+func (ctx *ContextRelation) Id() int {
+	return ctx.relationId
+}
+
+func (ctx *ContextRelation) Name() string {
+	return ctx.endpointName
+}
+
+func (ctx *ContextRelation) FakeId() string {
+	return fmt.Sprintf("%s:%d", ctx.endpointName, ctx.relationId)
+}
+
+func (ctx *ContextRelation) UnitNames() []string {
+	return ctx.cache.MemberNames()
+}
+
+func (ctx *ContextRelation) RemoteSettings(unit string) (commands.Settings, error) {
+	return ctx.cache.Settings(unit)
+}
+
+func (ctx *ContextRelation) LocalSettings() (commands.Settings, error) {
+	if ctx.settings == nil {
+		node, err := ctx.relationUnitAPI.LocalSettings()
+		if err != nil {
+			return nil, err
+		}
+		ctx.settings = node
+	}
+	return ctx.settings, nil
+}
+
+// WriteSettings persists all changes made to the unit's relation settings.
+func (ctx *ContextRelation) WriteSettings() (err error) {
+	if ctx.settings != nil {
+		err = ctx.relationUnitAPI.WriteSettings(ctx.settings)
+	}
+	return
+}
+
+// Suspended returns true if the relation is suspended.
+func (ctx *ContextRelation) Suspended() bool {
+	return ctx.relationUnitAPI.Suspended()
+}
+
+// SetStatus sets the relation's status.
+func (ctx *ContextRelation) SetStatus(status relation.Status) error {
+	return ctx.relationUnitAPI.SetStatus(status)
+}

--- a/worker/caasoperator/runner/context/relation_test.go
+++ b/worker/caasoperator/runner/context/relation_test.go
@@ -1,0 +1,116 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package context_test
+
+import (
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/core/relation"
+	"github.com/juju/juju/testing"
+	"github.com/juju/juju/worker/caasoperator/runner/context"
+	"github.com/juju/juju/worker/caasoperator/runner/runnertesting"
+)
+
+type ContextRelationSuite struct {
+	testing.BaseSuite
+
+	relationAPI  *runnertesting.MockRelationUnitAPI
+	relIdCounter int
+}
+
+var _ = gc.Suite(&ContextRelationSuite{})
+
+func (s *ContextRelationSuite) SetUpTest(c *gc.C) {
+	s.BaseSuite.SetUpTest(c)
+
+	s.relationAPI = runnertesting.NewMockRelationUnitAPI(0, "db", true)
+}
+
+func (s *ContextRelationSuite) TestMemberCaching(c *gc.C) {
+	cache := context.NewRelationCache(s.relationAPI.RemoteSettings, []string{"u/1"})
+	ctx := context.NewContextRelation(s.relationAPI, cache)
+
+	settings := runnertesting.Settings{}
+	// Check that uncached settings are read from state.
+	m, err := ctx.RemoteSettings("u/1")
+	c.Assert(err, jc.ErrorIsNil)
+	expectMap := settings.Map()
+	c.Assert(m.Map(), gc.DeepEquals, expectMap)
+
+	// Check that changes to state do not affect the cached settings.
+	settings.Set("ping", "pow")
+	err = s.relationAPI.WriteSettings(settings)
+	c.Assert(err, jc.ErrorIsNil)
+
+	m, err = ctx.RemoteSettings("u/1")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(m.Map(), gc.DeepEquals, expectMap)
+}
+
+func (s *ContextRelationSuite) TestNonMemberCaching(c *gc.C) {
+	cache := context.NewRelationCache(s.relationAPI.RemoteSettings, nil)
+	ctx := context.NewContextRelation(s.relationAPI, cache)
+
+	settings := runnertesting.Settings{}
+	// Check that settings are read from state.
+	m, err := ctx.RemoteSettings("u/1")
+	c.Assert(err, jc.ErrorIsNil)
+	expectMap := settings.Map()
+	c.Assert(m.Map(), gc.DeepEquals, expectMap)
+
+	// Check that changes to state do not affect the obtained settings.
+	settings.Set("ping", "pow")
+	err = s.relationAPI.WriteSettings(settings)
+	c.Assert(err, jc.ErrorIsNil)
+
+	m, err = ctx.RemoteSettings("u/1")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(m.Map(), gc.DeepEquals, expectMap)
+}
+
+func (s *ContextRelationSuite) TestLocalSettings(c *gc.C) {
+	ctx := context.NewContextRelation(s.relationAPI, nil)
+
+	// Change Settings...
+	node, err := ctx.LocalSettings()
+	c.Assert(err, jc.ErrorIsNil)
+	expectOldMap := node.Map()
+	node.Set("change", "exciting")
+
+	// ...and check it's not written to state.
+	settings, err := s.relationAPI.RemoteSettings("u/0")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(settings.Map(), gc.DeepEquals, expectOldMap)
+
+	// Write settings...
+	err = ctx.WriteSettings()
+	c.Assert(err, jc.ErrorIsNil)
+
+	// ...and check it was written to state.
+	settings, err = s.relationAPI.RemoteSettings("u/0")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(settings.Map(), gc.DeepEquals, map[string]string{"change": "exciting"})
+}
+
+func convertSettings(settings map[string]interface{}) map[string]interface{} {
+	result := make(map[string]interface{})
+	for k, v := range settings {
+		result[k] = v
+	}
+	return result
+}
+
+func (s *ContextRelationSuite) TestSuspended(c *gc.C) {
+	ctx := context.NewContextRelation(s.relationAPI, nil)
+	c.Assert(ctx.Suspended(), jc.IsTrue)
+}
+
+func (s *ContextRelationSuite) TestSetStatus(c *gc.C) {
+	ctx := context.NewContextRelation(s.relationAPI, nil)
+	err := ctx.SetStatus(relation.Suspended)
+	c.Assert(err, jc.ErrorIsNil)
+	relStatus := s.relationAPI.Status()
+	c.Assert(relStatus, gc.Equals, relation.Suspended)
+}

--- a/worker/caasoperator/runner/context/util_test.go
+++ b/worker/caasoperator/runner/context/util_test.go
@@ -1,0 +1,157 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package context_test
+
+import (
+	"path/filepath"
+	"runtime"
+	"time"
+
+	jujutesting "github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	"github.com/juju/utils"
+	"github.com/juju/utils/proxy"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/status"
+	"github.com/juju/juju/testing"
+	"github.com/juju/juju/worker/caasoperator/commands"
+	"github.com/juju/juju/worker/caasoperator/runner/context"
+	"github.com/juju/juju/worker/caasoperator/runner/runnertesting"
+)
+
+var noProxies = proxy.Settings{}
+var apiAddrs = []string{"a1:123", "a2:123"}
+
+// HookContextSuite contains shared setup for various other test suites. Test
+// methods should not be added to this type, because they'll get run repeatedly.
+type HookContextSuite struct {
+	testing.BaseSuite
+
+	applicationName string
+	relIdCounter    int
+	clock           *jujutesting.Clock
+
+	contextAPI   *runnertesting.MockContextAPI
+	relationAPIs map[int]*runnertesting.MockRelationUnitAPI
+}
+
+func (s *HookContextSuite) SetUpSuite(c *gc.C) {
+	if runtime.GOOS == "windows" {
+		c.Skip("non windows functionality")
+	}
+	s.BaseSuite.SetUpSuite(c)
+}
+
+func (s *HookContextSuite) SetUpTest(c *gc.C) {
+	s.BaseSuite.SetUpTest(c)
+
+	s.relIdCounter = 0
+	s.relationAPIs = make(map[int]*runnertesting.MockRelationUnitAPI)
+	s.contextAPI = runnertesting.NewMockContextAPI(apiAddrs, proxy.Settings{})
+	err := s.contextAPI.SetApplicationStatus("gitlab", status.Maintenance, "initialising", nil)
+	c.Assert(err, jc.ErrorIsNil)
+
+	s.AddContextRelation(c, "db0")
+	s.AddContextRelation(c, "db1")
+
+	s.clock = jujutesting.NewClock(time.Time{})
+}
+
+func (s *HookContextSuite) GetContext(
+	c *gc.C, relId int, remoteName string,
+) commands.Context {
+	uuid, err := utils.NewUUID()
+	c.Assert(err, jc.ErrorIsNil)
+	return s.getHookContext(
+		c, uuid.String(), relId, remoteName, noProxies,
+	)
+}
+
+func (s *HookContextSuite) AddContextRelation(c *gc.C, name string) {
+	s.applicationName = name
+	s.relationAPIs[s.relIdCounter] = runnertesting.NewMockRelationUnitAPI(s.relIdCounter, "db", false)
+	s.relIdCounter++
+}
+
+func (s *HookContextSuite) getHookContext(c *gc.C, uuid string, relid int,
+	remote string, proxies proxy.Settings) *context.HookContext {
+	if relid != -1 {
+		_, found := s.relationAPIs[relid]
+		c.Assert(found, jc.IsTrue)
+	}
+
+	relctxs := map[int]*context.ContextRelation{}
+	for relId, relUnit := range s.relationAPIs {
+		cache := context.NewRelationCache(relUnit.RemoteSettings, nil)
+		relctxs[relId] = context.NewContextRelation(relUnit, cache)
+	}
+
+	context, err := context.NewHookContext(s.contextAPI, "TestCtx", uuid, "gitlab",
+		"gitlab-model", relid, remote, relctxs, apiAddrs,
+		proxies, s.clock)
+	c.Assert(err, jc.ErrorIsNil)
+	return context
+}
+
+func (s *HookContextSuite) AssertCoreContext(c *gc.C, ctx *context.HookContext) {
+	c.Assert(ctx.ApplicationName(), gc.Equals, "gitlab")
+
+	name, uuid := context.ContextModelInfo(ctx)
+	c.Assert(name, gc.Equals, "gitlab-model")
+	c.Assert(uuid, gc.Equals, testing.ModelTag.Id())
+
+	ids, err := ctx.RelationIds()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(ids, gc.HasLen, 2)
+
+	r, err := ctx.Relation(0)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(r.Name(), gc.Equals, "db")
+	c.Assert(r.FakeId(), gc.Equals, "db:0")
+
+	r, err = ctx.Relation(1)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(r.Name(), gc.Equals, "db")
+	c.Assert(r.FakeId(), gc.Equals, "db:1")
+}
+
+func (s *HookContextSuite) AssertRelationContext(c *gc.C, ctx *context.HookContext, relId int, remoteUnit string) *context.ContextRelation {
+	actualRemoteUnit, _ := ctx.RemoteUnitName()
+	c.Assert(actualRemoteUnit, gc.Equals, remoteUnit)
+	rel, err := ctx.HookRelation()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(rel.Id(), gc.Equals, relId)
+	return rel.(*context.ContextRelation)
+}
+
+func (s *HookContextSuite) AssertNotRelationContext(c *gc.C, ctx *context.HookContext) {
+	rel, err := ctx.HookRelation()
+	c.Assert(rel, gc.IsNil)
+	c.Assert(err, gc.ErrorMatches, ".*")
+}
+
+// MockFakePaths implements Paths for tests that don't need to actually touch
+// the filesystem.
+type MockFakePaths struct{}
+
+func (MockFakePaths) GetToolsDir() string {
+	return "path-to-tools"
+}
+
+func (MockFakePaths) GetCharmDir() string {
+	return "path-to-charm"
+}
+
+func (MockFakePaths) GetJujucSocket() string {
+	return "path-to-jujuc.socket"
+}
+
+func (MockFakePaths) GetMetricsSpoolDir() string {
+	return "path-to-metrics-spool-dir"
+}
+
+func (MockFakePaths) ComponentDir(name string) string {
+	return filepath.Join("path-to-base-dir", name)
+}

--- a/worker/caasoperator/runner/export_test.go
+++ b/worker/caasoperator/runner/export_test.go
@@ -1,0 +1,16 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package runner
+
+import (
+	"github.com/juju/juju/worker/caasoperator/runner/context"
+)
+
+var (
+	SearchHook = searchHook
+)
+
+func RunnerPaths(rnr Runner) context.Paths {
+	return rnr.(*runner).paths
+}

--- a/worker/caasoperator/runner/factory.go
+++ b/worker/caasoperator/runner/factory.go
@@ -1,0 +1,71 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package runner
+
+import (
+	"github.com/juju/errors"
+
+	"github.com/juju/juju/worker/caasoperator/hook"
+	"github.com/juju/juju/worker/caasoperator/runner/context"
+)
+
+// Factory represents a long-lived object that can create runners
+// relevant to a specific unit.
+type Factory interface {
+
+	// NewCommandRunner returns an execution context suitable for running
+	// an arbitrary script.
+	NewCommandRunner(commandInfo context.CommandInfo) (Runner, error)
+
+	// NewHookRunner returns an execution context suitable for running the
+	// supplied hook definition (which must be valid).
+	NewHookRunner(hookInfo hook.Info) (Runner, error)
+}
+
+// NewFactory returns a Factory capable of creating runners for executing
+// charm hooks, actions and commands.
+func NewFactory(
+	paths context.Paths,
+	contextFactory context.ContextFactory,
+) (
+	Factory, error,
+) {
+	f := &factory{
+		paths:          paths,
+		contextFactory: contextFactory,
+	}
+
+	return f, nil
+}
+
+type factory struct {
+	contextFactory context.ContextFactory
+
+	// Fields that shouldn't change in a factory's lifetime.
+	paths context.Paths
+}
+
+// NewCommandRunner exists to satisfy the Factory interface.
+func (f *factory) NewCommandRunner(commandInfo context.CommandInfo) (Runner, error) {
+	ctx, err := f.contextFactory.CommandContext(commandInfo)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	runner := NewRunner(ctx, f.paths)
+	return runner, nil
+}
+
+// NewHookRunner exists to satisfy the Factory interface.
+func (f *factory) NewHookRunner(hookInfo hook.Info) (Runner, error) {
+	if err := hookInfo.Validate(); err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	ctx, err := f.contextFactory.HookContext(hookInfo)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	runner := NewRunner(ctx, f.paths)
+	return runner, nil
+}

--- a/worker/caasoperator/runner/factory_test.go
+++ b/worker/caasoperator/runner/factory_test.go
@@ -1,0 +1,130 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package runner_test
+
+import (
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/charm.v6/hooks"
+
+	"github.com/juju/juju/worker/caasoperator/hook"
+	"github.com/juju/juju/worker/caasoperator/runner"
+	"github.com/juju/juju/worker/caasoperator/runner/context"
+)
+
+type FactorySuite struct {
+	ContextSuite
+}
+
+var _ = gc.Suite(&FactorySuite{})
+
+func (s *FactorySuite) AssertPaths(c *gc.C, rnr runner.Runner) {
+	c.Assert(runner.RunnerPaths(rnr), gc.DeepEquals, s.paths)
+}
+
+func (s *FactorySuite) TestNewCommandRunnerNoRelation(c *gc.C) {
+	rnr, err := s.factory.NewCommandRunner(context.CommandInfo{RelationId: -1})
+	c.Assert(err, jc.ErrorIsNil)
+	s.AssertPaths(c, rnr)
+}
+
+func (s *FactorySuite) TestNewCommandRunnerRelationIdDoesNotExist(c *gc.C) {
+	for _, value := range []bool{true, false} {
+		_, err := s.factory.NewCommandRunner(context.CommandInfo{
+			RelationId: 12, ForceRemoteUnit: value,
+		})
+		c.Check(err, gc.ErrorMatches, `unknown relation id: 12`)
+	}
+}
+
+func (s *FactorySuite) TestNewCommandRunnerRemoteUnitInvalid(c *gc.C) {
+	for _, value := range []bool{true, false} {
+		_, err := s.factory.NewCommandRunner(context.CommandInfo{
+			RelationId: 0, RemoteUnitName: "blah", ForceRemoteUnit: value,
+		})
+		c.Check(err, gc.ErrorMatches, `invalid remote unit: blah`)
+	}
+}
+
+func (s *FactorySuite) TestNewCommandRunnerRemoteUnitInappropriate(c *gc.C) {
+	for _, value := range []bool{true, false} {
+		_, err := s.factory.NewCommandRunner(context.CommandInfo{
+			RelationId: -1, RemoteUnitName: "blah/123", ForceRemoteUnit: value,
+		})
+		c.Check(err, gc.ErrorMatches, `remote unit provided without a relation: blah/123`)
+	}
+}
+
+func (s *FactorySuite) TestNewCommandRunnerEmptyRelation(c *gc.C) {
+	_, err := s.factory.NewCommandRunner(context.CommandInfo{RelationId: 1})
+	c.Check(err, gc.ErrorMatches, `cannot infer remote unit in empty relation 1`)
+}
+
+func (s *FactorySuite) TestNewCommandRunnerRemoteUnitAmbiguous(c *gc.C) {
+	s.membership[1] = []string{"foo/0", "foo/1"}
+	_, err := s.factory.NewCommandRunner(context.CommandInfo{RelationId: 1})
+	c.Check(err, gc.ErrorMatches, `ambiguous remote unit; possibilities are \[foo/0 foo/1\]`)
+}
+
+func (s *FactorySuite) TestNewCommandRunnerRemoteUnitMissing(c *gc.C) {
+	s.membership[0] = []string{"foo/0", "foo/1"}
+	_, err := s.factory.NewCommandRunner(context.CommandInfo{
+		RelationId: 0, RemoteUnitName: "blah/123",
+	})
+	c.Check(err, gc.ErrorMatches, `unknown remote unit blah/123; possibilities are \[foo/0 foo/1\]`)
+}
+
+func (s *FactorySuite) TestNewCommandRunnerForceNoRemoteUnit(c *gc.C) {
+	rnr, err := s.factory.NewCommandRunner(context.CommandInfo{
+		RelationId: 0, ForceRemoteUnit: true,
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	s.AssertPaths(c, rnr)
+}
+
+func (s *FactorySuite) TestNewCommandRunnerForceRemoteUnitMissing(c *gc.C) {
+	_, err := s.factory.NewCommandRunner(context.CommandInfo{
+		RelationId: 0, RemoteUnitName: "blah/123", ForceRemoteUnit: true,
+	})
+	c.Assert(err, gc.IsNil)
+}
+
+func (s *FactorySuite) TestNewCommandRunnerInferRemoteUnit(c *gc.C) {
+	s.membership[0] = []string{"foo/2"}
+	rnr, err := s.factory.NewCommandRunner(context.CommandInfo{RelationId: 0})
+	c.Assert(err, jc.ErrorIsNil)
+	s.AssertPaths(c, rnr)
+}
+
+func (s *FactorySuite) TestNewHookRunner(c *gc.C) {
+	rnr, err := s.factory.NewHookRunner(hook.Info{Kind: hooks.ConfigChanged})
+	c.Assert(err, jc.ErrorIsNil)
+	s.AssertPaths(c, rnr)
+}
+
+func (s *FactorySuite) TestNewHookRunnerWithBadHook(c *gc.C) {
+	rnr, err := s.factory.NewHookRunner(hook.Info{})
+	c.Assert(rnr, gc.IsNil)
+	c.Assert(err, gc.ErrorMatches, `unknown hook kind ""`)
+}
+
+func (s *FactorySuite) TestNewHookRunnerWithRelation(c *gc.C) {
+	rnr, err := s.factory.NewHookRunner(hook.Info{
+		Kind:       hooks.RelationChanged,
+		RelationId: 1,
+		RemoteUnit: "mysql",
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	s.AssertPaths(c, rnr)
+}
+
+func (s *FactorySuite) TestNewHookRunnerWithBadRelation(c *gc.C) {
+	rnr, err := s.factory.NewHookRunner(hook.Info{
+		Kind:       hooks.RelationChanged,
+		RelationId: 12345,
+		RemoteUnit: "mysql",
+	})
+	c.Assert(rnr, gc.IsNil)
+	c.Assert(err, gc.ErrorMatches, `unknown relation id: 12345`)
+}

--- a/worker/caasoperator/runner/package_test.go
+++ b/worker/caasoperator/runner/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package runner_test
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func TestPackage(t *testing.T) {
+	gc.TestingT(t)
+}

--- a/worker/caasoperator/runner/runner.go
+++ b/worker/caasoperator/runner/runner.go
@@ -1,0 +1,199 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package runner
+
+import (
+	"encoding/base64"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"time"
+	"unicode/utf8"
+
+	"github.com/juju/cmd"
+	"github.com/juju/errors"
+	"github.com/juju/juju/worker/caasoperator/commands"
+	"github.com/juju/loggo"
+	"github.com/juju/utils/clock"
+	utilexec "github.com/juju/utils/exec"
+
+	"github.com/juju/juju/worker/caasoperator/runner/context"
+	"github.com/juju/juju/worker/common/charmrunner"
+)
+
+var logger = loggo.GetLogger("juju.worker.caasoperator.runner")
+
+// Runner is responsible for invoking commands in a context.
+type Runner interface {
+
+	// Context returns the context against which the runner executes.
+	Context() Context
+
+	// RunHook executes the hook with the supplied name.
+	RunHook(name string) error
+
+	// RunCommands executes the supplied script.
+	RunCommands(commands string) (*utilexec.ExecResponse, error)
+}
+
+// Context exposes hooks.Context, and additional methods needed by Runner.
+type Context interface {
+	commands.Context
+	Id() string
+	HookVars(paths context.Paths) ([]string, error)
+	SetProcess(process context.HookProcess)
+
+	Prepare() error
+	Flush(badge string, failure error) error
+}
+
+// NewRunner returns a Runner backed by the supplied context and paths.
+func NewRunner(context Context, paths context.Paths) Runner {
+	return &runner{context, paths}
+}
+
+// runner implements Runner.
+type runner struct {
+	context Context
+	paths   context.Paths
+}
+
+func (runner *runner) Context() Context {
+	return runner.context
+}
+
+// RunCommands exists to satisfy the Runner interface.
+func (runner *runner) RunCommands(commands string) (*utilexec.ExecResponse, error) {
+	result, err := runner.runCommandsWithTimeout(commands, 0, clock.WallClock)
+	return result, runner.context.Flush("run commands", err)
+}
+
+// runCommandsWithTimeout is a helper to abstract common code between run commands and
+// juju-run as an action
+func (runner *runner) runCommandsWithTimeout(commands string, timeout time.Duration, clock clock.Clock) (*utilexec.ExecResponse, error) {
+	srv, err := runner.startHookCommandServer()
+	if err != nil {
+		return nil, err
+	}
+	defer srv.Close()
+
+	env, err := runner.context.HookVars(runner.paths)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	command := utilexec.RunParams{
+		Commands:    commands,
+		WorkingDir:  runner.paths.GetCharmDir(),
+		Environment: env,
+		Clock:       clock,
+	}
+
+	err = command.Run()
+	if err != nil {
+		return nil, err
+	}
+	runner.context.SetProcess(hookProcess{command.Process()})
+
+	var cancel chan struct{}
+	if timeout != 0 {
+		cancel = make(chan struct{})
+		go func() {
+			<-clock.After(timeout)
+			close(cancel)
+		}()
+	}
+
+	// Block and wait for process to finish
+	return command.WaitWithCancel(cancel)
+}
+
+func encodeBytes(input []byte) (value string, encoding string) {
+	if utf8.Valid(input) {
+		value = string(input)
+		encoding = "utf8"
+	} else {
+		value = base64.StdEncoding.EncodeToString(input)
+		encoding = "base64"
+	}
+	return value, encoding
+}
+
+// RunHook exists to satisfy the Runner interface.
+func (runner *runner) RunHook(hookName string) error {
+	return runner.runCharmHookWithLocation(hookName, "hooks")
+}
+
+func (runner *runner) runCharmHookWithLocation(hookName, charmLocation string) error {
+	srv, err := runner.startHookCommandServer()
+	if err != nil {
+		return err
+	}
+	defer srv.Close()
+
+	env, err := runner.context.HookVars(runner.paths)
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	err = runner.runCharmHook(hookName, env, charmLocation)
+	return runner.context.Flush(hookName, err)
+}
+
+func (runner *runner) runCharmHook(hookName string, env []string, charmLocation string) error {
+	charmDir := runner.paths.GetCharmDir()
+	hook, err := searchHook(charmDir, filepath.Join(charmLocation, hookName))
+	if err != nil {
+		return err
+	}
+	ps := exec.Command(hook)
+	ps.Env = env
+	ps.Dir = charmDir
+	outReader, outWriter, err := os.Pipe()
+	if err != nil {
+		return errors.Errorf("cannot make logging pipe: %v", err)
+	}
+	ps.Stdout = outWriter
+	ps.Stderr = outWriter
+	hookLogger := charmrunner.NewHookLogger(runner.getLogger(hookName), outReader)
+	go hookLogger.Run()
+	err = ps.Start()
+	outWriter.Close()
+	if err == nil {
+		// Record the *os.Process of the hook
+		runner.context.SetProcess(hookProcess{ps.Process})
+		// Block until execution finishes
+		err = ps.Wait()
+	}
+	hookLogger.Stop()
+	return errors.Trace(err)
+}
+
+func (runner *runner) startHookCommandServer() (*commands.Server, error) {
+	// Prepare server.
+	getCmd := func(ctxId, cmdName string) (cmd.Command, error) {
+		if ctxId != runner.context.Id() {
+			return nil, errors.Errorf("expected context id %q, got %q", runner.context.Id(), ctxId)
+		}
+		return commands.NewCommand(runner.context, cmdName)
+	}
+	srv, err := commands.NewServer(getCmd, runner.paths.GetJujucSocket())
+	if err != nil {
+		return nil, errors.Annotate(err, "starting jujuc server")
+	}
+	go srv.Run()
+	return srv, nil
+}
+
+func (runner *runner) getLogger(hookName string) loggo.Logger {
+	return loggo.GetLogger(fmt.Sprintf("application.%s.%s", runner.context.ApplicationName(), hookName))
+}
+
+type hookProcess struct {
+	*os.Process
+}
+
+func (p hookProcess) Pid() int {
+	return p.Process.Pid
+}

--- a/worker/caasoperator/runner/runner_test.go
+++ b/worker/caasoperator/runner/runner_test.go
@@ -1,0 +1,248 @@
+// Copyright 2012-2014 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package runner_test
+
+import (
+	"fmt"
+	"io/ioutil"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/juju/errors"
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	"github.com/juju/utils/proxy"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/charm.v6/hooks"
+
+	"github.com/juju/juju/worker/caasoperator/hook"
+	"github.com/juju/juju/worker/caasoperator/runner"
+	"github.com/juju/juju/worker/caasoperator/runner/context"
+	"github.com/juju/juju/worker/caasoperator/runner/runnertesting"
+	"github.com/juju/juju/worker/common/charmrunner"
+)
+
+type RunCommandSuite struct {
+	ContextSuite
+}
+
+var _ = gc.Suite(&RunCommandSuite{})
+
+var noProxies = proxy.Settings{}
+
+func (s *RunCommandSuite) TestRunCommandsEnvStdOutAndErrAndRC(c *gc.C) {
+	ctx, err := s.contextFactory.HookContext(hook.Info{Kind: hooks.ConfigChanged})
+	c.Assert(err, jc.ErrorIsNil)
+	paths := runnertesting.NewMockPaths(c)
+	runner := runner.NewRunner(ctx, paths)
+
+	commands := `
+echo $JUJU_CHARM_DIR
+echo this is standard err >&2
+exit 42
+`
+	result, err := runner.RunCommands(commands)
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Assert(result.Code, gc.Equals, 42)
+	c.Assert(strings.TrimRight(string(result.Stdout), "\r\n"), gc.Equals, paths.GetCharmDir())
+	c.Assert(strings.TrimRight(string(result.Stderr), "\r\n"), gc.Equals, "this is standard err")
+	c.Assert(ctx.GetProcess(), gc.NotNil)
+}
+
+type RunHookSuite struct {
+	ContextSuite
+}
+
+var _ = gc.Suite(&RunHookSuite{})
+
+// LineBufferSize matches the constant used when creating
+// the bufio line reader.
+const lineBufferSize = 4096
+
+var runHookTests = []struct {
+	summary string
+	relid   int
+	remote  string
+	spec    hookSpec
+	err     string
+}{
+	{
+		summary: "missing hook is not an error",
+		relid:   -1,
+	}, {
+		summary: "report error indicated by hook's exit status",
+		relid:   -1,
+		spec: hookSpec{
+			perm: 0700,
+			code: 99,
+		},
+		err: "exit status 99",
+	}, {
+		summary: "output logging",
+		relid:   -1,
+		spec: hookSpec{
+			perm:   0700,
+			stdout: "stdout",
+			stderr: "stderr",
+		},
+	}, {
+		summary: "output logging with background process",
+		relid:   -1,
+		spec: hookSpec{
+			perm:       0700,
+			stdout:     "stdout",
+			background: "not printed",
+		},
+	}, {
+		summary: "long line split",
+		relid:   -1,
+		spec: hookSpec{
+			perm:   0700,
+			stdout: strings.Repeat("a", lineBufferSize+10),
+		},
+	},
+}
+
+func (s *RunHookSuite) TestRunHook(c *gc.C) {
+	for i, t := range runHookTests {
+		c.Logf("\ntest %d: %s; perm %v", i, t.summary, t.spec.perm)
+		ctx, err := s.contextFactory.HookContext(hook.Info{Kind: hooks.ConfigChanged})
+		c.Assert(err, jc.ErrorIsNil)
+
+		paths := runnertesting.NewMockPaths(c)
+		rnr := runner.NewRunner(ctx, paths)
+		var hookExists bool
+		if t.spec.perm != 0 {
+			spec := t.spec
+			spec.dir = "hooks"
+			spec.name = hookName
+			c.Logf("makeCharm %#v", spec)
+			makeCharm(c, spec, paths.GetCharmDir())
+			hookExists = true
+		}
+		t0 := time.Now()
+		err = rnr.RunHook("something-happened")
+		if t.err == "" && hookExists {
+			c.Assert(err, jc.ErrorIsNil)
+		} else if !hookExists {
+			c.Assert(charmrunner.IsMissingHookError(err), jc.IsTrue)
+		} else {
+			c.Assert(err, gc.ErrorMatches, t.err)
+		}
+		if t.spec.background != "" && time.Now().Sub(t0) > 5*time.Second {
+			c.Errorf("background process holding up hook execution")
+		}
+	}
+}
+
+type MockContext struct {
+	runner.Context
+	expectPid    int
+	flushBadge   string
+	flushFailure error
+	flushResult  error
+}
+
+func (ctx *MockContext) ApplicationName() string {
+	return "some-application"
+}
+
+func (ctx *MockContext) HookVars(paths context.Paths) ([]string, error) {
+	return []string{"VAR=value"}, nil
+}
+
+func (ctx *MockContext) SetProcess(process context.HookProcess) {
+	ctx.expectPid = process.Pid()
+}
+
+func (ctx *MockContext) Prepare() error {
+	return nil
+}
+
+func (ctx *MockContext) Flush(badge string, failure error) error {
+	ctx.flushBadge = badge
+	ctx.flushFailure = failure
+	return ctx.flushResult
+}
+
+type RunMockContextSuite struct {
+	testing.IsolationSuite
+	paths runnertesting.MockPaths
+}
+
+var _ = gc.Suite(&RunMockContextSuite{})
+
+func (s *RunMockContextSuite) SetUpTest(c *gc.C) {
+	s.IsolationSuite.SetUpTest(c)
+	s.paths = runnertesting.NewMockPaths(c)
+}
+
+func (s *RunMockContextSuite) assertRecordedPid(c *gc.C, expectPid int) {
+	path := filepath.Join(s.paths.GetCharmDir(), "pid")
+	content, err := ioutil.ReadFile(path)
+	c.Assert(err, jc.ErrorIsNil)
+	expectContent := fmt.Sprintf("%d", expectPid)
+	c.Assert(strings.TrimRight(string(content), "\r\n"), gc.Equals, expectContent)
+}
+
+func (s *RunMockContextSuite) TestRunHookFlushSuccess(c *gc.C) {
+	expectErr := errors.New("pew pew pew")
+	ctx := &MockContext{
+		flushResult: expectErr,
+	}
+	makeCharm(c, hookSpec{
+		dir:  "hooks",
+		name: hookName,
+		perm: 0700,
+	}, s.paths.GetCharmDir())
+	actualErr := runner.NewRunner(ctx, s.paths).RunHook("something-happened")
+	c.Assert(actualErr, gc.Equals, expectErr)
+	c.Assert(ctx.flushBadge, gc.Equals, "something-happened")
+	c.Assert(ctx.flushFailure, gc.IsNil)
+	s.assertRecordedPid(c, ctx.expectPid)
+}
+
+func (s *RunMockContextSuite) TestRunHookFlushFailure(c *gc.C) {
+	expectErr := errors.New("pew pew pew")
+	ctx := &MockContext{
+		flushResult: expectErr,
+	}
+	makeCharm(c, hookSpec{
+		dir:  "hooks",
+		name: hookName,
+		perm: 0700,
+		code: 123,
+	}, s.paths.GetCharmDir())
+	actualErr := runner.NewRunner(ctx, s.paths).RunHook("something-happened")
+	c.Assert(actualErr, gc.Equals, expectErr)
+	c.Assert(ctx.flushBadge, gc.Equals, "something-happened")
+	c.Assert(ctx.flushFailure, gc.ErrorMatches, "exit status 123")
+	s.assertRecordedPid(c, ctx.expectPid)
+}
+
+func (s *RunMockContextSuite) TestRunCommandsFlushSuccess(c *gc.C) {
+	expectErr := errors.New("pew pew pew")
+	ctx := &MockContext{
+		flushResult: expectErr,
+	}
+	_, actualErr := runner.NewRunner(ctx, s.paths).RunCommands(echoPidScript)
+	c.Assert(actualErr, gc.Equals, expectErr)
+	c.Assert(ctx.flushBadge, gc.Equals, "run commands")
+	c.Assert(ctx.flushFailure, gc.IsNil)
+	s.assertRecordedPid(c, ctx.expectPid)
+}
+
+func (s *RunMockContextSuite) TestRunCommandsFlushFailure(c *gc.C) {
+	expectErr := errors.New("pew pew pew")
+	ctx := &MockContext{
+		flushResult: expectErr,
+	}
+	_, actualErr := runner.NewRunner(ctx, s.paths).RunCommands(echoPidScript + "; exit 123")
+	c.Assert(actualErr, gc.Equals, expectErr)
+	c.Assert(ctx.flushBadge, gc.Equals, "run commands")
+	c.Assert(ctx.flushFailure, gc.IsNil) // exit code in _ result, as tested elsewhere
+	s.assertRecordedPid(c, ctx.expectPid)
+}

--- a/worker/caasoperator/runner/runnertesting/mock.go
+++ b/worker/caasoperator/runner/runnertesting/mock.go
@@ -1,0 +1,154 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package runnertesting
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/utils/proxy"
+	"gopkg.in/juju/charm.v6"
+
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/core/relation"
+	"github.com/juju/juju/status"
+	"github.com/juju/juju/worker/caasoperator/commands"
+)
+
+func NewMockContextAPI(apiAddresses []string, settings proxy.Settings) *MockContextAPI {
+	return &MockContextAPI{
+		apiAddresses: apiAddresses, settings: settings,
+		appStatus: make(map[string]status.StatusInfo),
+	}
+}
+
+type MockContextAPI struct {
+	apiAddresses   []string
+	settings       proxy.Settings
+	appStatus      map[string]status.StatusInfo
+	configSettings charm.Settings
+}
+
+func (m *MockContextAPI) APIAddresses() ([]string, error) {
+	return m.apiAddresses, nil
+}
+
+func (m *MockContextAPI) ProxySettings() (proxy.Settings, error) {
+	return m.settings, nil
+}
+
+func (m *MockContextAPI) ConfigSettings() (charm.Settings, error) {
+	return m.configSettings, nil
+}
+
+func (m *MockContextAPI) UpdateConfigSettings(settings charm.Settings) {
+	m.configSettings = settings
+}
+
+func (m *MockContextAPI) NetworkInfo([]string, *int) (map[string]params.NetworkInfoResult, error) {
+	return map[string]params.NetworkInfoResult{
+		"db": {IngressAddresses: []string{"10.0.0.1"}},
+	}, nil
+}
+
+func (m *MockContextAPI) ApplicationStatus(applicationName string) (params.ApplicationStatusResult, error) {
+	statusInfo, ok := m.appStatus[applicationName]
+	if !ok {
+		return params.ApplicationStatusResult{}, errors.NotFoundf("application %v", applicationName)
+	}
+	return params.ApplicationStatusResult{Application: params.StatusResult{
+		Status: string(statusInfo.Status),
+		Info:   statusInfo.Message,
+		Data:   statusInfo.Data,
+	}}, nil
+}
+
+func (m *MockContextAPI) SetApplicationStatus(applicationName string, s status.Status, info string, data map[string]interface{}) error {
+	if data == nil {
+		data = map[string]interface{}{}
+	}
+	m.appStatus[applicationName] = status.StatusInfo{
+		Status:  s,
+		Message: info,
+		Data:    data,
+	}
+	return nil
+}
+
+func NewMockRelationUnitAPI(id int, endpoint string, suspended bool) *MockRelationUnitAPI {
+	return &MockRelationUnitAPI{
+		id:            id,
+		endpoint:      endpoint,
+		suspended:     suspended,
+		localSettings: make(Settings),
+	}
+}
+
+type MockRelationUnitAPI struct {
+	id             int
+	endpoint       string
+	localSettings  Settings
+	remoteSettings Settings
+	status         relation.Status
+	suspended      bool
+}
+
+func (m *MockRelationUnitAPI) Id() int {
+	return m.id
+}
+
+func (m *MockRelationUnitAPI) Endpoint() string {
+	return m.endpoint
+}
+
+func (m *MockRelationUnitAPI) LocalSettings() (commands.Settings, error) {
+	return m.localSettings, nil
+}
+
+func (m *MockRelationUnitAPI) Suspended() bool {
+	return m.suspended
+}
+
+func (m *MockRelationUnitAPI) SetStatus(status relation.Status) error {
+	m.status = status
+	return nil
+}
+
+func (m *MockRelationUnitAPI) Status() relation.Status {
+	return m.status
+}
+
+func (m *MockRelationUnitAPI) RemoteSettings(unitName string) (commands.Settings, error) {
+	result := make(Settings)
+	for k, v := range m.remoteSettings {
+		result[k] = v
+	}
+	return result, nil
+}
+
+func (m *MockRelationUnitAPI) WriteSettings(s commands.Settings) error {
+	m.remoteSettings = Settings(s.Map())
+	return nil
+}
+
+type Settings map[string]string
+
+func (s Settings) Get(k string) (interface{}, bool) {
+	v, f := s[k]
+	return v, f
+}
+
+func (s Settings) Set(k, v string) {
+	s[k] = v
+}
+
+func (s Settings) Delete(k string) {
+	delete(s, k)
+}
+
+func (s Settings) Map() map[string]string {
+	r := map[string]string{}
+	for k, v := range s {
+		r[k] = v
+	}
+	return r
+}

--- a/worker/caasoperator/runner/runnertesting/paths.go
+++ b/worker/caasoperator/runner/runnertesting/paths.go
@@ -1,0 +1,60 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package runnertesting
+
+import (
+	"path/filepath"
+
+	gc "gopkg.in/check.v1"
+)
+
+type fops interface {
+	// MkDir provides the functionality of gc.C.MkDir().
+	MkDir() string
+}
+
+// MockPaths implements Paths for tests that do touch the filesystem.
+type MockPaths struct {
+	tools         string
+	charm         string
+	socket        string
+	metricsspool  string
+	componentDirs map[string]string
+	fops          fops
+}
+
+func NewMockPaths(c *gc.C) MockPaths {
+	return MockPaths{
+		tools:         c.MkDir(),
+		charm:         c.MkDir(),
+		socket:        filepath.Join(c.MkDir(), "test.sock"),
+		metricsspool:  c.MkDir(),
+		componentDirs: make(map[string]string),
+		fops:          c,
+	}
+}
+
+func (p MockPaths) GetMetricsSpoolDir() string {
+	return p.metricsspool
+}
+
+func (p MockPaths) GetToolsDir() string {
+	return p.tools
+}
+
+func (p MockPaths) GetCharmDir() string {
+	return p.charm
+}
+
+func (p MockPaths) GetJujucSocket() string {
+	return p.socket
+}
+
+func (p MockPaths) ComponentDir(name string) string {
+	if dirname, ok := p.componentDirs[name]; ok {
+		return dirname
+	}
+	p.componentDirs[name] = filepath.Join(p.fops.MkDir(), name)
+	return p.componentDirs[name]
+}

--- a/worker/caasoperator/runner/util_test.go
+++ b/worker/caasoperator/runner/util_test.go
@@ -1,0 +1,155 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package runner_test
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"time"
+
+	"github.com/juju/juju/testing"
+	jujutesting "github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	"github.com/juju/utils/proxy"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/worker/caasoperator/runner"
+	"github.com/juju/juju/worker/caasoperator/runner/context"
+	"github.com/juju/juju/worker/caasoperator/runner/runnertesting"
+)
+
+var (
+	apiAddrs      = []string{"a1:123", "a2:123"}
+	hookName      = "something-happened"
+	echoPidScript = "echo $$ > pid"
+)
+
+type ContextSuite struct {
+	testing.BaseSuite
+
+	paths          runnertesting.MockPaths
+	factory        runner.Factory
+	contextFactory context.ContextFactory
+	membership     map[int][]string
+
+	relationUnitAPIs map[int]*runnertesting.MockRelationUnitAPI
+	relIdCounter     int
+}
+
+func (s *ContextSuite) SetUpSuite(c *gc.C) {
+	if runtime.GOOS == "windows" {
+		c.Skip("non windows functionality")
+	}
+	s.BaseSuite.SetUpSuite(c)
+}
+
+func (s *ContextSuite) SetUpTest(c *gc.C) {
+	s.BaseSuite.SetUpTest(c)
+
+	s.paths = runnertesting.NewMockPaths(c)
+	s.membership = map[int][]string{}
+	s.relIdCounter = 0
+	s.relationUnitAPIs = make(map[int]*runnertesting.MockRelationUnitAPI)
+	s.AddContextRelation(c, "db0")
+	s.AddContextRelation(c, "db1")
+
+	mockAPI := runnertesting.NewMockContextAPI(apiAddrs, proxy.Settings{})
+	var err error
+	s.contextFactory, err = context.NewContextFactory(context.FactoryConfig{
+		ContextFactoryAPI: mockAPI,
+		HookAPI:           mockAPI,
+		ModelUUID:         testing.ModelTag.Id(),
+		ModelName:         "kate",
+		GetRelationInfos:  s.getRelationInfos,
+		Paths:             s.paths,
+		Clock:             jujutesting.NewClock(time.Time{}),
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	factory, err := runner.NewFactory(
+		s.paths,
+		s.contextFactory,
+	)
+	c.Assert(err, jc.ErrorIsNil)
+	s.factory = factory
+}
+
+func (s *ContextSuite) AddContextRelation(c *gc.C, name string) {
+	s.relationUnitAPIs[s.relIdCounter] = runnertesting.NewMockRelationUnitAPI(s.relIdCounter, "relation-name", false)
+	s.relIdCounter++
+}
+
+func (s *ContextSuite) getRelationInfos() map[int]*context.RelationInfo {
+	info := map[int]*context.RelationInfo{}
+	for relId, relAPI := range s.relationUnitAPIs {
+		info[relId] = &context.RelationInfo{
+			RelationUnitAPI: relAPI,
+			MemberNames:     s.membership[relId],
+		}
+	}
+	return info
+}
+
+// hookSpec supports makeCharm.
+type hookSpec struct {
+	// dir is the directory to create the hook in.
+	dir string
+	// name is the name of the hook.
+	name string
+	// perm is the file permissions of the hook.
+	perm os.FileMode
+	// code is the exit status of the hook.
+	code int
+	// stdout holds a string to print to stdout
+	stdout string
+	// stderr holds a string to print to stderr
+	stderr string
+	// background holds a string to print in the background after 0.2s.
+	background string
+}
+
+// makeCharm constructs a fake charm dir containing a single named hook
+// with permissions perm and exit code code. If output is non-empty,
+// the charm will write it to stdout and stderr, with each one prefixed
+// by name of the stream.
+func makeCharm(c *gc.C, spec hookSpec, charmDir string) {
+	dir := charmDir
+	if spec.dir != "" {
+		dir = filepath.Join(dir, spec.dir)
+		err := os.Mkdir(dir, 0755)
+		c.Assert(err, jc.ErrorIsNil)
+	}
+	c.Logf("openfile perm %v", spec.perm)
+	hook, err := os.OpenFile(
+		filepath.Join(dir, spec.name), os.O_CREATE|os.O_WRONLY, spec.perm,
+	)
+	c.Assert(err, jc.ErrorIsNil)
+	defer func() {
+		c.Assert(hook.Close(), gc.IsNil)
+	}()
+
+	printf := func(f string, a ...interface{}) {
+		_, err := fmt.Fprintf(hook, f+"\n", a...)
+		c.Assert(err, jc.ErrorIsNil)
+	}
+	printf("#!/bin/bash")
+	printf(echoPidScript)
+	if spec.stdout != "" {
+		printf("echo %s", spec.stdout)
+	}
+	if spec.stderr != "" {
+		printf("echo %s >&2", spec.stderr)
+	}
+	if spec.background != "" {
+		// Print something fairly quickly, then sleep for
+		// quite a long time - if the hook execution is
+		// blocking because of the background process,
+		// the hook execution will take much longer than
+		// expected.
+		printf("(sleep 0.2; echo %s; sleep 10) &", spec.background)
+	}
+	printf("exit %d", spec.code)
+}

--- a/worker/uniter/hook/hook.go
+++ b/worker/uniter/hook/hook.go
@@ -1,7 +1,7 @@
 // Copyright 2012, 2013 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-// hook provides types that define the hooks known to the Uniter
+// Package hook provides types that define the hooks known to the Uniter
 package hook
 
 import (


### PR DESCRIPTION
## Description of change

The hook runner infrastructure is added for the caas operator.
The core logic is ported across from the unit but with necessary tweaks:
- no action runner for now (so actions not supported)
- the context interfaces are slightly different (eg no storage context)
- the context doesn't have things like assigned machine, public/private address (not needed)
- the tests are converted to unit tests (no jujuconnsuite)
- some of the backend interface names have been sanitised eg we have LocalSettings() and RemoteSettings() instead of Settings() and ReadSettings()
- support windows is removed

The backend interfaces are all defined in caasoperator/runner/context/interfaces.go
The operator just needs to supply implementation of these when it makes a factory config.

## QA steps

Run the unit tests
