### PR TITLE
caasoperator: add SetContainerSpec

### DIFF
--- a/apiserver/facades/agent/caasoperator/mock_test.go
+++ b/apiserver/facades/agent/caasoperator/mock_test.go
@@ -6,6 +6,7 @@ package caasoperator_test
 import (
 	"github.com/juju/testing"
 	"gopkg.in/juju/charm.v6"
+	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/apiserver/facades/agent/caasoperator"
 	"github.com/juju/juju/state"
@@ -15,7 +16,8 @@ import (
 
 type mockState struct {
 	testing.Stub
-	app mockApplication
+	app   mockApplication
+	model mockModel
 }
 
 func newMockState() *mockState {
@@ -40,6 +42,23 @@ func (st *mockState) Application(id string) (caasoperator.Application, error) {
 		return nil, err
 	}
 	return &st.app, nil
+}
+
+func (st *mockState) Model() (caasoperator.Model, error) {
+	st.MethodCall(st, "Model")
+	if err := st.NextErr(); err != nil {
+		return nil, err
+	}
+	return &st.model, nil
+}
+
+type mockModel struct {
+	testing.Stub
+}
+
+func (m *mockModel) SetContainerSpec(tag names.Tag, spec string) error {
+	m.MethodCall(m, "SetContainerSpec", tag, spec)
+	return m.NextErr()
 }
 
 type mockApplication struct {

--- a/apiserver/facades/agent/caasoperator/state.go
+++ b/apiserver/facades/agent/caasoperator/state.go
@@ -5,6 +5,7 @@ package caasoperator
 
 import (
 	"gopkg.in/juju/charm.v6"
+	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/status"
@@ -14,6 +15,13 @@ import (
 // required by the CAAS operator facade.
 type CAASOperatorState interface {
 	Application(string) (Application, error)
+	Model() (Model, error)
+}
+
+// Model provides the subset of CAAS model state required
+// by the CAAS operator facade.
+type Model interface {
+	SetContainerSpec(names.Tag, string) error
 }
 
 // Application provides the subset of application state
@@ -42,6 +50,14 @@ func (s stateShim) Application(id string) (Application, error) {
 		return nil, err
 	}
 	return applicationShim{app}, nil
+}
+
+func (s stateShim) Model() (Model, error) {
+	model, err := s.State.Model()
+	if err != nil {
+		return nil, err
+	}
+	return model.CAASModel()
 }
 
 type applicationShim struct {

--- a/apiserver/params/internal.go
+++ b/apiserver/params/internal.go
@@ -819,3 +819,15 @@ type UnitRefreshResult struct {
 type UnitRefreshResults struct {
 	Results []UnitRefreshResult
 }
+
+// EntityString holds an entity tag and a string value.
+type EntityString struct {
+	Tag   string `json:"tag"`
+	Value string `json:"value"`
+}
+
+// SetContainerSpecParams holds the arguments for setting the container
+// spec for a set of entities.
+type SetContainerSpecParams struct {
+	Entities []EntityString `json:"entities"`
+}

--- a/state/allcollections.go
+++ b/state/allcollections.go
@@ -457,6 +457,10 @@ func allCollections() collectionSchema {
 		// firewallRulesC holds firewall rules for defined service types.
 		firewallRulesC: {},
 
+		// containerSpecsC holds the CAAS container specifications,
+		// for applications and units.
+		containerSpecsC: {},
+
 		// ----------------------
 
 		// Raw-access collections
@@ -489,6 +493,7 @@ const (
 	cloudCredentialsC        = "cloudCredentials"
 	constraintsC             = "constraints"
 	containerRefsC           = "containerRefs"
+	containerSpecsC          = "containerSpecs"
 	controllersC             = "controllers"
 	controllerUsersC         = "controllerusers"
 	filesystemAttachmentsC   = "filesystemAttachments"

--- a/state/containerspec.go
+++ b/state/containerspec.go
@@ -1,0 +1,144 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package state
+
+import (
+	"github.com/juju/errors"
+	jujutxn "github.com/juju/txn"
+	"gopkg.in/juju/names.v2"
+	mgo "gopkg.in/mgo.v2"
+	"gopkg.in/mgo.v2/bson"
+	"gopkg.in/mgo.v2/txn"
+)
+
+type containerSpecDoc struct {
+	Tag       string `bson:"_id"`
+	ModelUUID string `bson:"model-uuid"`
+	Spec      string `bson:"spec"`
+}
+
+// SetContainerSpec sets the container spec for the given entity tag.
+//
+// The entity must be either an application or a unit. If an application
+// is specified, then the container spec is the default container spec
+// for all units in the application. A unit-specific container spec may
+// be set to override this default.
+//
+// An error will be returned if the specified entity is not alive.
+func (m *CAASModel) SetContainerSpec(entity names.Tag, spec string) error {
+	buildTxn := func(attempt int) ([]txn.Op, error) {
+		var prereqOps []txn.Op
+		switch entity.(type) {
+		case names.ApplicationTag:
+			app, err := m.State().Application(entity.Id())
+			if err != nil {
+				return nil, errors.Trace(err)
+			}
+			if app.Life() != Alive {
+				return nil, errors.Errorf("%s not alive", names.ReadableString(entity))
+			}
+			prereqOps = append(prereqOps, txn.Op{
+				C:      applicationsC,
+				Id:     app.doc.DocID,
+				Assert: isAliveDoc,
+			})
+		case names.UnitTag:
+			u, err := m.State().Unit(entity.Id())
+			if err != nil {
+				return nil, errors.Trace(err)
+			}
+			if u.Life() != Alive {
+				return nil, errors.Errorf("%s not alive", names.ReadableString(entity))
+			}
+			prereqOps = append(prereqOps, txn.Op{
+				C:      unitsC,
+				Id:     u.doc.DocID,
+				Assert: isAliveDoc,
+			})
+		default:
+			return nil, errors.NotSupportedf(
+				"setting container spec for %s entity",
+				entity.Kind(),
+			)
+		}
+
+		op := txn.Op{
+			C:  containerSpecsC,
+			Id: entity.String(),
+		}
+		existing, err := m.containerSpec(entity)
+		if err == nil {
+			if existing == spec {
+				return nil, jujutxn.ErrNoOperations
+			}
+			op.Assert = txn.DocExists
+			op.Update = bson.D{{"$set", bson.D{{"spec", spec}}}}
+		} else if errors.IsNotFound(err) {
+			op.Assert = txn.DocMissing
+			op.Insert = containerSpecDoc{Spec: spec}
+		} else {
+			return nil, err
+		}
+		return append(prereqOps, op), nil
+	}
+	return m.mb.db().Run(buildTxn)
+}
+
+// ContainerSpec returns the container spec for the given entity tag.
+//
+// The entity must be either an application or a unit. If a unit is
+// specified and there is a unit-specific container spec, it will
+// be returned; otherwise the application default container spec
+// will be returned, if there is one.
+func (m *CAASModel) ContainerSpec(entity names.Tag) (string, error) {
+	switch entity := entity.(type) {
+	case names.UnitTag:
+		spec, unitErr := m.containerSpec(entity)
+		if !errors.IsNotFound(unitErr) {
+			return spec, unitErr
+		}
+		// No unit-specific container spec found, so check
+		// for an application container spec.
+		appName, err := names.UnitApplication(entity.Id())
+		if err != nil {
+			return "", errors.Trace(err)
+		}
+		spec, err = m.containerSpec(names.NewApplicationTag(appName))
+		if err != nil {
+			return "", unitErr
+		}
+		return spec, nil
+	case names.ApplicationTag:
+		return m.containerSpec(entity)
+	default:
+		return "", errors.NotSupportedf(
+			"getting container spec for %s",
+			names.ReadableString(entity),
+		)
+	}
+}
+
+func (m *CAASModel) containerSpec(entity names.Tag) (string, error) {
+	coll, cleanup := m.mb.db().GetCollection(containerSpecsC)
+	defer cleanup()
+	var doc containerSpecDoc
+	if err := coll.FindId(entity.String()).One(&doc); err != nil {
+		if err == mgo.ErrNotFound {
+			return "", errors.NotFoundf(
+				"container spec for %s",
+				names.ReadableString(entity),
+			)
+		}
+		return "", errors.Trace(err)
+	}
+	return doc.Spec, nil
+}
+
+func removeContainerSpecOp(entity names.Tag) txn.Op {
+	return txn.Op{
+		C:      containerSpecsC,
+		Id:     entity.String(),
+		Remove: true,
+	}
+}

--- a/state/containerspec_test.go
+++ b/state/containerspec_test.go
@@ -1,0 +1,192 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package state_test
+
+import (
+	gc "gopkg.in/check.v1"
+	names "gopkg.in/juju/names.v2"
+
+	"github.com/juju/errors"
+	"github.com/juju/juju/state"
+	statetesting "github.com/juju/juju/state/testing"
+	"github.com/juju/juju/testing/factory"
+	jc "github.com/juju/testing/checkers"
+	"github.com/juju/utils/arch"
+)
+
+type ContainerSpecSuite struct {
+	CAASFixture
+
+	Model   *state.CAASModel
+	State   *state.State
+	Factory *factory.Factory
+}
+
+var _ = gc.Suite(&ContainerSpecSuite{})
+
+func (s *ContainerSpecSuite) SetUpTest(c *gc.C) {
+	s.CAASFixture.SetUpTest(c)
+	s.Model, s.State = s.newCAASModel(c)
+	s.Factory = factory.NewFactory(s.State)
+	s.PatchValue(&arch.HostArch, func() string { return arch.AMD64 })
+}
+
+func (s *ContainerSpecSuite) assertContainerSpec(c *gc.C, tag names.Tag, expect string) {
+	spec, err := s.Model.ContainerSpec(tag)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(spec, gc.Equals, spec)
+}
+
+func (s *ContainerSpecSuite) assertContainerSpecNotFound(c *gc.C, tag names.Tag) {
+	_, err := s.Model.ContainerSpec(tag)
+	c.Assert(err, jc.Satisfies, errors.IsNotFound)
+}
+
+func (s *ContainerSpecSuite) TestSetContainerSpecApplication(c *gc.C) {
+	app := s.Factory.MakeApplication(c, nil)
+	err := s.Model.SetContainerSpec(app.Tag(), "foo")
+	c.Assert(err, jc.ErrorIsNil)
+	s.assertContainerSpec(c, app.Tag(), "foo")
+}
+
+func (s *ContainerSpecSuite) TestSetContainerSpecApplicationDying(c *gc.C) {
+	app := s.Factory.MakeApplication(c, nil)
+	// create a unit to prevent app from being removed
+	s.Factory.MakeUnit(c, &factory.UnitParams{Application: app})
+	err := app.Destroy()
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = s.Model.SetContainerSpec(app.Tag(), "foo")
+	c.Assert(err, gc.ErrorMatches, "application mysql not alive")
+	s.assertContainerSpecNotFound(c, app.Tag())
+}
+
+func (s *ContainerSpecSuite) TestSetContainerSpecUnit(c *gc.C) {
+	u := s.Factory.MakeUnit(c, nil)
+	err := s.Model.SetContainerSpec(u.Tag(), "foo")
+	c.Assert(err, jc.ErrorIsNil)
+	s.assertContainerSpec(c, u.Tag(), "foo")
+}
+
+func (s *ContainerSpecSuite) TestSetContainerSpecUnitNotFound(c *gc.C) {
+	u := s.Factory.MakeUnit(c, nil)
+	// TODO(caas) destroying the unit will remove it, because
+	// it is not assigned to a machine. We'll need to prevent
+	// CAAS units from being removed immediately, as they will
+	// never be assigned to machines.
+	err := u.Destroy()
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = s.Model.SetContainerSpec(u.Tag(), "foo")
+	c.Assert(err, gc.ErrorMatches, `unit "mysql/0" not found`)
+	s.assertContainerSpecNotFound(c, u.Tag())
+}
+
+func (s *ContainerSpecSuite) TestSetContainerSpecInvalidEntity(c *gc.C) {
+	err := s.Model.SetContainerSpec(names.NewMachineTag("0"), "foo")
+	c.Assert(err, gc.ErrorMatches, "setting container spec for machine entity not supported")
+}
+
+func (s *ContainerSpecSuite) TestContainerSpecHierarchy(c *gc.C) {
+	app := s.Factory.MakeApplication(c, nil)
+	u0 := s.Factory.MakeUnit(c, &factory.UnitParams{Application: app})
+	u1 := s.Factory.MakeUnit(c, &factory.UnitParams{Application: app})
+
+	err := s.Model.SetContainerSpec(app.Tag(), "app-spec")
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = s.Model.SetContainerSpec(u0.Tag(), "u0-spec")
+	c.Assert(err, jc.ErrorIsNil)
+
+	s.assertContainerSpec(c, app.Tag(), "app-spec")
+	s.assertContainerSpec(c, u0.Tag(), "u0-spec")
+	s.assertContainerSpec(c, u1.Tag(), "app-sec")
+}
+
+func (s *ContainerSpecSuite) TestSetContainerSpecUpdates(c *gc.C) {
+	app := s.Factory.MakeApplication(c, nil)
+	for _, spec := range []string{"spec0", "spec1"} {
+		err := s.Model.SetContainerSpec(app.Tag(), spec)
+		c.Assert(err, jc.ErrorIsNil)
+		s.assertContainerSpec(c, app.Tag(), spec)
+	}
+}
+
+func (s *ContainerSpecSuite) TestRemoveApplicationRemovesContainerSpec(c *gc.C) {
+	app := s.Factory.MakeApplication(c, nil)
+	err := s.Model.SetContainerSpec(app.Tag(), "spec")
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = app.Destroy()
+	c.Assert(err, jc.ErrorIsNil)
+	s.assertContainerSpecNotFound(c, app.Tag())
+}
+
+func (s *ContainerSpecSuite) TestRemoveUnitRemovesContainerSpec(c *gc.C) {
+	u := s.Factory.MakeUnit(c, nil)
+	err := s.Model.SetContainerSpec(u.Tag(), "spec")
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = u.Destroy()
+	c.Assert(err, jc.ErrorIsNil)
+	s.assertContainerSpecNotFound(c, u.Tag())
+}
+
+func (s *ContainerSpecSuite) TestWatchContainerSpecApplication(c *gc.C) {
+	app := s.Factory.MakeApplication(c, nil)
+	w, err := s.Model.WatchContainerSpec(app.Tag())
+	c.Assert(err, jc.ErrorIsNil)
+	wc := statetesting.NewNotifyWatcherC(c, s.State, w)
+	wc.AssertOneChange()
+
+	// No spec -> spec set.
+	err = s.Model.SetContainerSpec(app.Tag(), "spec0")
+	c.Assert(err, jc.ErrorIsNil)
+	wc.AssertOneChange()
+
+	// No change.
+	err = s.Model.SetContainerSpec(app.Tag(), "spec0")
+	c.Assert(err, jc.ErrorIsNil)
+	wc.AssertNoChange()
+
+	// Multiple changes coalesced.
+	err = s.Model.SetContainerSpec(app.Tag(), "spec1")
+	c.Assert(err, jc.ErrorIsNil)
+	err = s.Model.SetContainerSpec(app.Tag(), "spec2")
+	c.Assert(err, jc.ErrorIsNil)
+	wc.AssertOneChange()
+}
+
+func (s *ContainerSpecSuite) TestWatchContainerSpecUnit(c *gc.C) {
+	app := s.Factory.MakeApplication(c, nil)
+	u := s.Factory.MakeUnit(c, &factory.UnitParams{Application: app})
+	w, err := s.Model.WatchContainerSpec(u.Tag())
+	c.Assert(err, jc.ErrorIsNil)
+	wc := statetesting.NewNotifyWatcherC(c, s.State, w)
+	wc.AssertOneChange()
+
+	// Set application container spec.
+	err = s.Model.SetContainerSpec(app.Tag(), "spec0")
+	c.Assert(err, jc.ErrorIsNil)
+	wc.AssertOneChange()
+
+	// Set unit container spec. It's the same as the
+	// application's, but still triggers a change as
+	// it's from a different doc.
+	//
+	// TODO(caas) we should not trigger a change in this
+	// case, as it will cause unnecessary worker activity.
+	err = s.Model.SetContainerSpec(u.Tag(), "spec0")
+	c.Assert(err, jc.ErrorIsNil)
+	wc.AssertOneChange()
+
+	// Changing the application's container spec triggers
+	// a change even if there's a unit container spec.
+	//
+	// TODO(caas) we should not trigger a change in this
+	// case, as it will cause unnecessary worker activity.
+	err = s.Model.SetContainerSpec(app.Tag(), "spec1")
+	c.Assert(err, jc.ErrorIsNil)
+	wc.AssertOneChange()
+}

--- a/state/migration_internal_test.go
+++ b/state/migration_internal_test.go
@@ -195,6 +195,9 @@ func (s *MigrationSuite) TestKnownCollections(c *gc.C) {
 		externalControllersC,
 		relationNetworksC,
 		firewallRulesC,
+
+		// TODO(caas)
+		containerSpecsC,
 	)
 
 	envCollections := set.NewStrings()

--- a/state/state.go
+++ b/state/state.go
@@ -1047,13 +1047,15 @@ func (st *State) AddApplication(args AddApplicationArgs) (_ *Application, err er
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	if model.Type() == ModelTypeIAAS {
+	switch model.Type() {
+	case ModelTypeIAAS:
 		if err := st.processIAASModelApplicationArgs(&args); err != nil {
 			return nil, errors.Trace(err)
 		}
-	} else {
-		// TODO(caas) - remove once units are supported.
-		args.NumUnits = 0
+	case ModelTypeCAAS:
+		if err := st.processCAASModelApplicationArgs(&args); err != nil {
+			return nil, errors.Trace(err)
+		}
 	}
 
 	applicationID := st.docID(args.Name)
@@ -1329,6 +1331,24 @@ func (st *State) processIAASModelApplicationArgs(args *AddApplicationArgs) error
 			}
 		}
 	}
+	return nil
+}
+
+func (st *State) processCAASModelApplicationArgs(args *AddApplicationArgs) error {
+	// TODO(caas) - remove once units are supported.
+	args.NumUnits = 0
+
+	if args.Series == "" {
+		// args.Series is not set, so use the series in the URL.
+		args.Series = args.Charm.URL().Series
+		if args.Series == "" {
+			// Should not happen, but just in case.
+			return errors.New("series is empty")
+		}
+	}
+
+	// TODO(caas) restrict the series to CAAS series.
+
 	return nil
 }
 

--- a/worker/caasoperator/caasoperator.go
+++ b/worker/caasoperator/caasoperator.go
@@ -51,13 +51,18 @@ type Config struct {
 	// watching and getting the application's config settings.
 	ApplicationConfigGetter ApplicationConfigGetter
 
+	// CharmGetter is an interface used for getting the
+	// application's charm URL and SHA256 hash.
+	CharmGetter CharmGetter
+
 	// Clock holds the clock to be used by the CAAS operator
 	// for time-related operations.
 	Clock clock.Clock
 
-	// CharmGetter is an interface used for getting the
-	// application's charm URL and SHA256 hash.
-	CharmGetter CharmGetter
+	// ContainerSpecSetter provides an interface for
+	// setting the container spec for the application
+	// or unit thereof.
+	ContainerSpecSetter ContainerSpecSetter
 
 	// DataDir holds the path to the Juju "data directory",
 	// i.e. "/var/lib/juju" (by default). The CAAS operator
@@ -80,11 +85,14 @@ func (config Config) Validate() error {
 	if config.ApplicationConfigGetter == nil {
 		return errors.NotValidf("missing ApplicationConfigGetter")
 	}
+	if config.CharmGetter == nil {
+		return errors.NotValidf("missing CharmGetter")
+	}
 	if config.Clock == nil {
 		return errors.NotValidf("missing Clock")
 	}
-	if config.CharmGetter == nil {
-		return errors.NotValidf("missing CharmGetter")
+	if config.ContainerSpecSetter == nil {
+		return errors.NotValidf("missing ContainerSpecSetter")
 	}
 	if config.DataDir == "" {
 		return errors.NotValidf("missing DataDir")

--- a/worker/caasoperator/caasoperator_test.go
+++ b/worker/caasoperator/caasoperator_test.go
@@ -68,6 +68,7 @@ func (s *WorkerSuite) SetUpTest(c *gc.C) {
 		ApplicationConfigGetter: &s.client,
 		CharmGetter:             &s.client,
 		Clock:                   s.clock,
+		ContainerSpecSetter:     &s.client,
 		DataDir:                 c.MkDir(),
 		Downloader:              &s.charmDownloader,
 		StatusSetter:            &s.client,
@@ -94,6 +95,10 @@ func (s *WorkerSuite) TestValidateConfig(c *gc.C) {
 	s.testValidateConfig(c, func(config *caasoperator.Config) {
 		config.Clock = nil
 	}, `missing Clock not valid`)
+
+	s.testValidateConfig(c, func(config *caasoperator.Config) {
+		config.ContainerSpecSetter = nil
+	}, `missing ContainerSpecSetter not valid`)
 
 	s.testValidateConfig(c, func(config *caasoperator.Config) {
 		config.DataDir = ""

--- a/worker/caasoperator/client.go
+++ b/worker/caasoperator/client.go
@@ -16,6 +16,7 @@ import (
 type Client interface {
 	ApplicationConfigGetter
 	CharmGetter
+	ContainerSpecSetter
 	StatusSetter
 }
 
@@ -24,6 +25,13 @@ type Client interface {
 // assigned to the application.
 type CharmGetter interface {
 	Charm(application string) (_ *charm.URL, sha256 string, _ error)
+}
+
+// ContainerSpecSetter provides an interface for
+// setting the container spec for the application
+// or unit thereof.
+type ContainerSpecSetter interface {
+	SetContainerSpec(entityName, spec string) error
 }
 
 // StatusSetter provides an interface for setting

--- a/worker/caasoperator/manifold.go
+++ b/worker/caasoperator/manifold.go
@@ -89,11 +89,12 @@ func Manifold(config ManifoldConfig) dependency.Manifold {
 			w, err := config.NewWorker(Config{
 				Application:             applicationTag.Id(),
 				ApplicationConfigGetter: client,
-				Clock:        clock,
-				CharmGetter:  client,
-				DataDir:      agentConfig.DataDir(),
-				Downloader:   downloader,
-				StatusSetter: client,
+				CharmGetter:             client,
+				Clock:                   clock,
+				ContainerSpecSetter:     client,
+				DataDir:                 agentConfig.DataDir(),
+				Downloader:              downloader,
+				StatusSetter:            client,
 			})
 			if err != nil {
 				return nil, errors.Trace(err)

--- a/worker/caasoperator/manifold_test.go
+++ b/worker/caasoperator/manifold_test.go
@@ -125,9 +125,10 @@ func (s *ManifoldSuite) TestStart(c *gc.C) {
 		Application:             "gitlab",
 		ApplicationConfigGetter: &s.client,
 		DataDir:                 s.dataDir,
-		Clock:                   s.clock,
-		Downloader:              &s.charmDownloader,
 		CharmGetter:             &s.client,
+		Clock:                   s.clock,
+		ContainerSpecSetter:     &s.client,
+		Downloader:              &s.charmDownloader,
 		StatusSetter:            &s.client,
 	})
 }

--- a/worker/caasoperator/mock_test.go
+++ b/worker/caasoperator/mock_test.go
@@ -71,6 +71,11 @@ func (c *fakeClient) Charm(application string) (*charm.URL, string, error) {
 	return gitlabCharmURL, fakeCharmSHA256, nil
 }
 
+func (c *fakeClient) SetContainerSpec(entityName, spec string) error {
+	c.MethodCall(c, "SetContainerSpec", entityName, spec)
+	return c.NextErr()
+}
+
 func (c *fakeClient) ApplicationConfig(application string) (charm.Settings, error) {
 	c.MethodCall(c, "ApplicationConfig", application)
 	if err := c.NextErr(); err != nil {


### PR DESCRIPTION
## Description of change

Add methods to state.CAASModel for getting,
setting, and watching the container spec for
applications and units in CAAS models.

Fix a bug when creating applications in
CAAS models, causing the series to not
be inherited from the charm.

Add basic support for adding units in a
CAAS model. Very much incomplete,
just enough for testing the basics.

Add a SetContainerSpec method to the
CAASOperator API facade and client.
Add an ContainerSpecSetter interface
as a dependency of the caasoperator
worker (currently unused).

## QA steps

smoke test IAAS model  / deploy, to make sure nothing is broken

## Documentation changes

None.

## Bug reference

None.