### PR TITLE
Caas operator hook executor

### DIFF
--- a/api/caasoperator/client.go
+++ b/api/caasoperator/client.go
@@ -18,13 +18,17 @@ import (
 // Client allows access to the CAAS operator API endpoint.
 type Client struct {
 	facade base.FacadeCaller
+
+	// TODO(caas) - add only the bits we need
+	modelWatcher *common.ModelWatcher
 }
 
 // NewClient returns a client used to access the CAAS Operator API.
 func NewClient(caller base.APICaller) *Client {
 	facadeCaller := base.NewFacadeCaller(caller, "CAASOperator")
 	return &Client{
-		facade: facadeCaller,
+		facade:       facadeCaller,
+		modelWatcher: common.NewModelWatcher(facadeCaller),
 	}
 }
 
@@ -33,6 +37,15 @@ func (c *Client) appTag(application string) (names.ApplicationTag, error) {
 		return names.ApplicationTag{}, errors.NotValidf("application name %q", application)
 	}
 	return names.NewApplicationTag(application), nil
+}
+
+// ModelName returns the name of the model.
+func (c *Client) ModelName() (string, error) {
+	cfg, err := c.modelWatcher.ModelConfig()
+	if err != nil {
+		return "", errors.Trace(err)
+	}
+	return cfg.Name(), nil
 }
 
 // SetStatus sets the status of the specified application.

--- a/api/caasoperator/client.go
+++ b/api/caasoperator/client.go
@@ -18,17 +18,13 @@ import (
 // Client allows access to the CAAS operator API endpoint.
 type Client struct {
 	facade base.FacadeCaller
-
-	// TODO(caas) - add only the bits we need
-	modelWatcher *common.ModelWatcher
 }
 
 // NewClient returns a client used to access the CAAS Operator API.
 func NewClient(caller base.APICaller) *Client {
 	facadeCaller := base.NewFacadeCaller(caller, "CAASOperator")
 	return &Client{
-		facade:       facadeCaller,
-		modelWatcher: common.NewModelWatcher(facadeCaller),
+		facade: facadeCaller,
 	}
 }
 
@@ -41,11 +37,15 @@ func (c *Client) appTag(application string) (names.ApplicationTag, error) {
 
 // ModelName returns the name of the model.
 func (c *Client) ModelName() (string, error) {
-	cfg, err := c.modelWatcher.ModelConfig()
+	var result params.StringResult
+	err := c.facade.FacadeCall("ModelName", nil, &result)
 	if err != nil {
 		return "", errors.Trace(err)
 	}
-	return cfg.Name(), nil
+	if err := result.Error; err != nil {
+		return "", err
+	}
+	return result.Result, nil
 }
 
 // SetStatus sets the status of the specified application.

--- a/api/caasoperator/client_test.go
+++ b/api/caasoperator/client_test.go
@@ -5,7 +5,6 @@ package caasoperator_test
 
 import (
 	"github.com/juju/errors"
-	coretesting "github.com/juju/juju/testing"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
@@ -207,15 +206,11 @@ func (s *operatorSuite) TestModelName(c *gc.C) {
 		c.Check(objType, gc.Equals, "CAASOperator")
 		c.Check(version, gc.Equals, 0)
 		c.Check(id, gc.Equals, "")
-		c.Check(request, gc.Equals, "ModelConfig")
+		c.Check(request, gc.Equals, "ModelName")
 		c.Check(arg, gc.IsNil)
-		c.Assert(result, gc.FitsTypeOf, &params.ModelConfigResult{})
-		*(result.(*params.ModelConfigResult)) = params.ModelConfigResult{
-			Config: params.ModelConfig{
-				"name": "some-model",
-				"uuid": coretesting.ModelTag.Id(),
-				"type": "caas",
-			},
+		c.Assert(result, gc.FitsTypeOf, &params.StringResult{})
+		*(result.(*params.StringResult)) = params.StringResult{
+			Result: "some-model",
 		}
 		return nil
 	})

--- a/apiserver/facades/agent/caasoperator/mock_test.go
+++ b/apiserver/facades/agent/caasoperator/mock_test.go
@@ -9,9 +9,11 @@ import (
 	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/apiserver/facades/agent/caasoperator"
+	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/state"
 	statetesting "github.com/juju/juju/state/testing"
 	"github.com/juju/juju/status"
+	coretesting "github.com/juju/juju/testing"
 )
 
 type mockState struct {
@@ -59,6 +61,15 @@ type mockModel struct {
 func (m *mockModel) SetContainerSpec(tag names.Tag, spec string) error {
 	m.MethodCall(m, "SetContainerSpec", tag, spec)
 	return m.NextErr()
+}
+
+func (st *mockModel) WatchForModelConfigChanges() state.NotifyWatcher {
+	return nil
+}
+
+func (st *mockModel) ModelConfig() (*config.Config, error) {
+	attrs := coretesting.FakeConfig()
+	return config.New(config.NoDefaults, attrs)
 }
 
 type mockApplication struct {

--- a/apiserver/facades/agent/caasoperator/mock_test.go
+++ b/apiserver/facades/agent/caasoperator/mock_test.go
@@ -9,11 +9,9 @@ import (
 	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/apiserver/facades/agent/caasoperator"
-	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/state"
 	statetesting "github.com/juju/juju/state/testing"
 	"github.com/juju/juju/status"
-	coretesting "github.com/juju/juju/testing"
 )
 
 type mockState struct {
@@ -63,13 +61,8 @@ func (m *mockModel) SetContainerSpec(tag names.Tag, spec string) error {
 	return m.NextErr()
 }
 
-func (st *mockModel) WatchForModelConfigChanges() state.NotifyWatcher {
-	return nil
-}
-
-func (st *mockModel) ModelConfig() (*config.Config, error) {
-	attrs := coretesting.FakeConfig()
-	return config.New(config.NoDefaults, attrs)
+func (st *mockModel) Name() string {
+	return "some-model"
 }
 
 type mockApplication struct {

--- a/apiserver/facades/agent/caasoperator/operator.go
+++ b/apiserver/facades/agent/caasoperator/operator.go
@@ -20,7 +20,6 @@ type Facade struct {
 	state     CAASOperatorState
 
 	model Model
-	*common.ModelWatcher
 }
 
 // NewStateFacade provides the signature required for facade registration.
@@ -44,12 +43,16 @@ func NewFacade(
 		return nil, errors.Trace(err)
 	}
 	return &Facade{
-		auth:         authorizer,
-		resources:    resources,
-		state:        st,
-		model:        model,
-		ModelWatcher: common.NewModelWatcher(model, resources, authorizer),
+		auth:      authorizer,
+		resources: resources,
+		state:     st,
+		model:     model,
 	}, nil
+}
+
+// ModelName returns the name of the model.
+func (f *Facade) ModelName() (params.StringResult, error) {
+	return params.StringResult{Result: f.model.Name()}, nil
 }
 
 // SetStatus sets the status of each given entity.

--- a/apiserver/facades/agent/caasoperator/operator_test.go
+++ b/apiserver/facades/agent/caasoperator/operator_test.go
@@ -81,8 +81,8 @@ func (s *CAASOperatorSuite) TestSetStatus(c *gc.C) {
 		},
 	})
 
-	s.st.CheckCallNames(c, "Application")
-	s.st.CheckCall(c, 0, "Application", "gitlab")
+	s.st.CheckCallNames(c, "Model", "Application")
+	s.st.CheckCall(c, 1, "Application", "gitlab")
 	s.st.app.CheckCallNames(c, "SetStatus")
 	s.st.app.CheckCall(c, 0, "SetStatus", status.StatusInfo{
 		Status:  "bar",
@@ -121,8 +121,8 @@ func (s *CAASOperatorSuite) TestCharm(c *gc.C) {
 		}},
 	})
 
-	s.st.CheckCallNames(c, "Application")
-	s.st.CheckCall(c, 0, "Application", "gitlab")
+	s.st.CheckCallNames(c, "Model", "Application")
+	s.st.CheckCall(c, 1, "Application", "gitlab")
 	s.st.app.CheckCallNames(c, "Charm")
 }
 
@@ -150,8 +150,8 @@ func (s *CAASOperatorSuite) TestApplicationConfig(c *gc.C) {
 		}},
 	})
 
-	s.st.CheckCallNames(c, "Application")
-	s.st.CheckCall(c, 0, "Application", "gitlab")
+	s.st.CheckCallNames(c, "Model", "Application")
+	s.st.CheckCall(c, 1, "Application", "gitlab")
 	s.st.app.CheckCallNames(c, "ConfigSettings")
 }
 
@@ -179,8 +179,8 @@ func (s *CAASOperatorSuite) TestWatchApplicationConfig(c *gc.C) {
 		}},
 	})
 
-	s.st.CheckCallNames(c, "Application")
-	s.st.CheckCall(c, 0, "Application", "gitlab")
+	s.st.CheckCallNames(c, "Model", "Application")
+	s.st.CheckCall(c, 1, "Application", "gitlab")
 	s.st.app.CheckCallNames(c, "WatchConfigSettings")
 	c.Assert(s.resources.Get("1"), gc.Equals, s.st.app.settingsWatcher)
 }

--- a/apiserver/facades/agent/caasoperator/operator_test.go
+++ b/apiserver/facades/agent/caasoperator/operator_test.go
@@ -234,3 +234,9 @@ func (s *CAASOperatorSuite) TestSetContainerSpec(c *gc.C) {
 	s.st.model.CheckCall(c, 1, "SetContainerSpec", names.NewUnitTag("gitlab/0"), "bar")
 	s.st.model.CheckCall(c, 2, "SetContainerSpec", names.NewUnitTag("gitlab/1"), "baz")
 }
+
+func (s *CAASOperatorSuite) TestModelName(c *gc.C) {
+	result, err := s.facade.ModelName()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result.Result, gc.Equals, "some-model")
+}

--- a/apiserver/facades/agent/caasoperator/state.go
+++ b/apiserver/facades/agent/caasoperator/state.go
@@ -21,6 +21,7 @@ type CAASOperatorState interface {
 // Model provides the subset of CAAS model state required
 // by the CAAS operator facade.
 type Model interface {
+	state.ModelAccessor
 	SetContainerSpec(names.Tag, string) error
 }
 

--- a/apiserver/facades/agent/caasoperator/state.go
+++ b/apiserver/facades/agent/caasoperator/state.go
@@ -21,8 +21,8 @@ type CAASOperatorState interface {
 // Model provides the subset of CAAS model state required
 // by the CAAS operator facade.
 type Model interface {
-	state.ModelAccessor
 	SetContainerSpec(names.Tag, string) error
+	Name() string
 }
 
 // Application provides the subset of application state

--- a/caas/kubernetes/provider/k8s.go
+++ b/caas/kubernetes/provider/k8s.go
@@ -188,7 +188,7 @@ func (k *kubernetesClient) deployOperator(appName, agentPath string, configMapNa
 				Name:            "juju-operator",
 				ImagePullPolicy: v1.PullIfNotPresent,
 				// TODO(caas) use proper image
-				Image: "wallyworld/caas-jujud-operator",
+				Image: "wallyworld/caas-jujud-operator:latest",
 				Env: []v1.EnvVar{
 					{Name: "JUJU_APPLICATION", Value: appName},
 				},

--- a/featuretests/agent_caasoperator_test.go
+++ b/featuretests/agent_caasoperator_test.go
@@ -10,14 +10,18 @@ import (
 
 	"github.com/juju/cmd/cmdtesting"
 	jc "github.com/juju/testing/checkers"
+	"github.com/juju/utils"
 	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/agent"
+	"github.com/juju/juju/cloud"
 	jujudagent "github.com/juju/juju/cmd/jujud/agent"
 	"github.com/juju/juju/cmd/jujud/agent/agenttest"
 	"github.com/juju/juju/cmd/jujud/agent/caasoperator"
 	"github.com/juju/juju/feature"
 	"github.com/juju/juju/state"
+	"github.com/juju/juju/testing"
 	coretesting "github.com/juju/juju/testing"
 	"github.com/juju/juju/tools"
 	"github.com/juju/juju/worker/caasoperator/commands"
@@ -38,6 +42,33 @@ var _ = gc.Suite(&CAASOperatorSuite{})
 func (s *CAASOperatorSuite) SetUpSuite(c *gc.C) {
 	s.SetInitialFeatureFlags(feature.CAAS)
 	s.AgentSuite.SetUpSuite(c)
+}
+
+func (s *CAASOperatorSuite) SetUpTest(c *gc.C) {
+	s.AgentSuite.SetUpTest(c)
+
+	// Set up a CAAS model to replace the IAAS one.
+	err := s.State.AddCloud(cloud.Cloud{
+		Name:      "caascloud",
+		Type:      "kubernetes",
+		AuthTypes: []cloud.AuthType{cloud.EmptyAuthType},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	cfg := testing.CustomModelConfig(c, testing.Attrs{
+		"name": "caas-model",
+		"uuid": utils.MustNewUUID().String(),
+	})
+	_, st, err := s.State.NewModel(state.ModelArgs{
+		Type:      state.ModelTypeCAAS,
+		Owner:     names.NewUserTag("admin"),
+		CloudName: "caascloud",
+		Config:    cfg,
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	s.CleanupSuite.AddCleanup(func(*gc.C) { st.Close() })
+	err = s.State.Close()
+	c.Assert(err, jc.ErrorIsNil)
+	s.State = st
 }
 
 // primeAgent creates an application, and sets up the application agent's directory.

--- a/worker/caasoperator/agent.go
+++ b/worker/caasoperator/agent.go
@@ -5,7 +5,7 @@ package caasoperator
 
 import "github.com/juju/juju/status"
 
-// setAgentStatus sets the unit's status if it has changed since last time this method was called.
+// setAgentStatus sets the application's status if it has changed since last time this method was called.
 func setAgentStatus(op *caasOperator, agentStatus status.Status, info string, data map[string]interface{}) error {
 	op.setStatusMutex.Lock()
 	defer op.setStatusMutex.Unlock()

--- a/worker/caasoperator/agent.go
+++ b/worker/caasoperator/agent.go
@@ -1,0 +1,34 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package caasoperator
+
+import "github.com/juju/juju/status"
+
+// setAgentStatus sets the unit's status if it has changed since last time this method was called.
+func setAgentStatus(op *caasOperator, agentStatus status.Status, info string, data map[string]interface{}) error {
+	op.setStatusMutex.Lock()
+	defer op.setStatusMutex.Unlock()
+	if op.lastReportedStatus == agentStatus && op.lastReportedMessage == info {
+		return nil
+	}
+	op.lastReportedStatus = agentStatus
+	op.lastReportedMessage = info
+	logger.Infof("[AGENT-STATUS] %s: %s", agentStatus, info)
+	// TODO(caas)
+	return nil //op.SetAgentStatus(agentStatus, info, data)
+}
+
+// reportAgentError reports if there was an error performing an agent operation.
+func reportAgentError(op *caasOperator, userMessage string, err error) {
+	// If a non-nil error is reported (e.g. due to an operation failing),
+	// set the agent status to Failed.
+	if err == nil {
+		return
+	}
+	logger.Errorf("%s: %v", userMessage, err)
+	err2 := setAgentStatus(op, status.Failed, userMessage, nil)
+	if err2 != nil {
+		logger.Errorf("updating agent status: %v", err2)
+	}
+}

--- a/worker/caasoperator/client.go
+++ b/worker/caasoperator/client.go
@@ -71,15 +71,15 @@ func (h *hookAPIAdaptor) ApplicationConfig() (charm.Settings, error) {
 	return h.ApplicationConfigGetter.ApplicationConfig(h.appName)
 }
 
+func (h *hookAPIAdaptor) SetApplicationStatus(status status.Status, info string, data map[string]interface{}) error {
+	return h.StatusSetter.SetStatus(h.appName, status, info, data)
+}
+
 // dummyHookAPI is an API placeholder
 type dummyHookAPI struct{}
 
-func (h *dummyHookAPI) ApplicationStatus(appName string) (params.ApplicationStatusResult, error) {
+func (h *dummyHookAPI) ApplicationStatus() (params.ApplicationStatusResult, error) {
 	return params.ApplicationStatusResult{Application: params.StatusResult{Status: "unknown"}}, nil
-}
-
-func (h *dummyHookAPI) SetApplicationStatus(string, status.Status, string, map[string]interface{}) error {
-	return nil
 }
 
 func (h *dummyHookAPI) NetworkInfo(bindings []string, relId *int) (map[string]params.NetworkInfoResult, error) {

--- a/worker/caasoperator/client.go
+++ b/worker/caasoperator/client.go
@@ -4,8 +4,10 @@
 package caasoperator
 
 import (
+	"github.com/juju/utils/proxy"
 	"gopkg.in/juju/charm.v6"
 
+	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/status"
 	"github.com/juju/juju/watcher"
 )
@@ -18,6 +20,7 @@ type Client interface {
 	CharmGetter
 	ContainerSpecSetter
 	StatusSetter
+	ModelName() (string, error)
 }
 
 // CharmGetter provides an interface for getting
@@ -51,4 +54,45 @@ type StatusSetter interface {
 type ApplicationConfigGetter interface {
 	ApplicationConfig(string) (charm.Settings, error)
 	WatchApplicationConfig(string) (watcher.NotifyWatcher, error)
+}
+
+// TODO(caas) - split this up
+type hookAPIAdaptor struct {
+	StatusSetter
+	ApplicationConfigGetter
+	ContainerSpecSetter
+
+	appName string
+
+	dummyHookAPI
+}
+
+func (h *hookAPIAdaptor) ApplicationConfig() (charm.Settings, error) {
+	return h.ApplicationConfigGetter.ApplicationConfig(h.appName)
+}
+
+// dummyHookAPI is an API placeholder
+type dummyHookAPI struct{}
+
+func (h *dummyHookAPI) ApplicationStatus(appName string) (params.ApplicationStatusResult, error) {
+	return params.ApplicationStatusResult{Application: params.StatusResult{Status: "unknown"}}, nil
+}
+
+func (h *dummyHookAPI) SetApplicationStatus(string, status.Status, string, map[string]interface{}) error {
+	return nil
+}
+
+func (h *dummyHookAPI) NetworkInfo(bindings []string, relId *int) (map[string]params.NetworkInfoResult, error) {
+	return make(map[string]params.NetworkInfoResult), nil
+}
+
+// TODO(caas) implement this API
+type dummyContextFactoryAPI struct{}
+
+func (c *dummyContextFactoryAPI) APIAddresses() ([]string, error) {
+	return []string{}, nil
+}
+
+func (c *dummyContextFactoryAPI) ProxySettings() (proxy.Settings, error) {
+	return proxy.Settings{}, nil
 }

--- a/worker/caasoperator/commands/config-get.go
+++ b/worker/caasoperator/commands/config-get.go
@@ -57,7 +57,7 @@ func (c *ConfigGetCommand) Init(args []string) error {
 }
 
 func (c *ConfigGetCommand) Run(ctx *cmd.Context) error {
-	settings, err := c.ctx.ConfigSettings()
+	settings, err := c.ctx.ApplicationConfig()
 	if err != nil {
 		return err
 	}

--- a/worker/caasoperator/commands/context.go
+++ b/worker/caasoperator/commands/context.go
@@ -81,7 +81,7 @@ type ContextApplication interface {
 	ApplicationName() string
 
 	// ConfigSettings returns the current configuration of the executing unit.
-	ConfigSettings() (charm.Settings, error)
+	ApplicationConfig() (charm.Settings, error)
 
 	// SetContainerSpec updates the yaml spec used to create a container.
 	SetContainerSpec(specYaml, unitName string) error

--- a/worker/caasoperator/commands/server_test.go
+++ b/worker/caasoperator/commands/server_test.go
@@ -122,7 +122,7 @@ func (s *ServerSuite) Call(c *gc.C, req commands.Request) (resp exec.ExecRespons
 	client, err := sockets.Dial(s.sockPath)
 	c.Assert(err, jc.ErrorIsNil)
 	defer client.Close()
-	err = client.Call("HookCommand.Main", req, &resp)
+	err = client.Call("Jujuc.Main", req, &resp)
 	return resp, err
 }
 

--- a/worker/caasoperator/commands/util_test.go
+++ b/worker/caasoperator/commands/util_test.go
@@ -64,7 +64,7 @@ func (m *mockHookContext) SetApplicationStatus(appStatus commands.StatusInfo) er
 	return nil
 }
 
-func (m *mockHookContext) ConfigSettings() (charm.Settings, error) {
+func (m *mockHookContext) ApplicationConfig() (charm.Settings, error) {
 	settingsCopy := make(charm.Settings)
 	for k, v := range m.config {
 		settingsCopy[k] = v

--- a/worker/caasoperator/hook/hook.go
+++ b/worker/caasoperator/hook/hook.go
@@ -36,7 +36,7 @@ func (hi Info) Validate() error {
 			return fmt.Errorf("%q hook requires a remote unit", hi.Kind)
 		}
 		fallthrough
-	case hooks.ConfigChanged:
+	case hooks.ConfigChanged, hooks.UpdateStatus:
 		return nil
 	}
 	return fmt.Errorf("unknown hook kind %q", hi.Kind)

--- a/worker/caasoperator/manifold.go
+++ b/worker/caasoperator/manifold.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/juju/juju/agent"
 	"github.com/juju/juju/api/base"
+	"github.com/juju/juju/worker/caasoperator/runner"
 	"github.com/juju/juju/worker/dependency"
 )
 
@@ -79,6 +80,11 @@ func Manifold(config ManifoldConfig) dependency.Manifold {
 				return nil, errors.Trace(err)
 			}
 
+			modelName, err := client.ModelName()
+			if err != nil {
+				return nil, errors.Trace(err)
+			}
+
 			// Configure and start the caasoperator worker.
 			agentConfig := agent.CurrentConfig()
 			tag := agentConfig.Tag()
@@ -87,6 +93,9 @@ func Manifold(config ManifoldConfig) dependency.Manifold {
 				return nil, errors.Errorf("expected an application tag, got %v", tag)
 			}
 			w, err := config.NewWorker(Config{
+				ModelUUID:               agentConfig.Model().Id(),
+				ModelName:               modelName,
+				NewRunnerFactoryFunc:    runner.NewFactory,
 				Application:             applicationTag.Id(),
 				ApplicationConfigGetter: client,
 				CharmGetter:             client,

--- a/worker/caasoperator/manifold_test.go
+++ b/worker/caasoperator/manifold_test.go
@@ -11,9 +11,10 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/names.v2"
-	worker "gopkg.in/juju/worker.v1"
+	"gopkg.in/juju/worker.v1"
 
 	"github.com/juju/juju/api/base"
+	coretesting "github.com/juju/juju/testing"
 	"github.com/juju/juju/worker/caasoperator"
 	"github.com/juju/juju/worker/dependency"
 	dt "github.com/juju/juju/worker/dependency/testing"
@@ -121,7 +122,11 @@ func (s *ManifoldSuite) TestStart(c *gc.C) {
 	c.Assert(args[0], gc.FitsTypeOf, caasoperator.Config{})
 	config := args[0].(caasoperator.Config)
 
+	// Don't care about new runner factory func here.
+	config.NewRunnerFactoryFunc = nil
 	c.Assert(config, jc.DeepEquals, caasoperator.Config{
+		ModelUUID:               coretesting.ModelTag.Id(),
+		ModelName:               "gitlab-model",
 		Application:             "gitlab",
 		ApplicationConfigGetter: &s.client,
 		DataDir:                 s.dataDir,

--- a/worker/caasoperator/op_callbacks.go
+++ b/worker/caasoperator/op_callbacks.go
@@ -6,7 +6,6 @@ package caasoperator
 import (
 	"github.com/juju/juju/status"
 	"github.com/juju/juju/worker/caasoperator/hook"
-	"github.com/juju/juju/worker/caasoperator/runner"
 )
 
 // operationCallbacks implements operation.Callbacks, and exists entirely to
@@ -38,31 +37,6 @@ func (opc *operationCallbacks) CommitHook(hi hook.Info) error {
 	//	return opc.op.relations.CommitHook(hi)
 	//}
 	return nil
-}
-
-func notifyHook(hook string, ctx runner.Context, method func(string)) {
-	if r, err := ctx.HookRelation(); err == nil {
-		remote, _ := ctx.RemoteUnitName()
-		if remote != "" {
-			remote = " " + remote
-		}
-		hook = hook + remote + " " + r.FakeId()
-	}
-	method(hook)
-}
-
-// NotifyHookCompleted is part of the operation.Callbacks interface.
-func (opc *operationCallbacks) NotifyHookCompleted(hook string, ctx runner.Context) {
-	if opc.op.observer != nil {
-		notifyHook(hook, ctx, opc.op.observer.HookCompleted)
-	}
-}
-
-// NotifyHookFailed is part of the operation.Callbacks interface.
-func (opc *operationCallbacks) NotifyHookFailed(hook string, ctx runner.Context) {
-	if opc.op.observer != nil {
-		notifyHook(hook, ctx, opc.op.observer.HookFailed)
-	}
 }
 
 // SetExecutingStatus is part of the operation.Callbacks interface.

--- a/worker/caasoperator/op_callbacks.go
+++ b/worker/caasoperator/op_callbacks.go
@@ -1,0 +1,71 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package caasoperator
+
+import (
+	"github.com/juju/juju/status"
+	"github.com/juju/juju/worker/caasoperator/hook"
+	"github.com/juju/juju/worker/caasoperator/runner"
+)
+
+// operationCallbacks implements operation.Callbacks, and exists entirely to
+// keep those methods off the operator itself.
+type operationCallbacks struct {
+	op *caasOperator
+}
+
+// PrepareHook is part of the operation.Callbacks interface.
+func (opc *operationCallbacks) PrepareHook(hi hook.Info) (string, error) {
+	name := string(hi.Kind)
+	switch {
+	case hi.Kind.IsRelation():
+		// TODO(caas)
+		//var err error
+		//name, err = opc.op.relations.PrepareHook(hi)
+		//if err != nil {
+		//	return "", err
+		//}
+	}
+	return name, nil
+}
+
+// CommitHook is part of the operation.Callbacks interface.
+func (opc *operationCallbacks) CommitHook(hi hook.Info) error {
+	// TODO(caas)
+	//switch {
+	//case hi.Kind.IsRelation():
+	//	return opc.op.relations.CommitHook(hi)
+	//}
+	return nil
+}
+
+func notifyHook(hook string, ctx runner.Context, method func(string)) {
+	if r, err := ctx.HookRelation(); err == nil {
+		remote, _ := ctx.RemoteUnitName()
+		if remote != "" {
+			remote = " " + remote
+		}
+		hook = hook + remote + " " + r.FakeId()
+	}
+	method(hook)
+}
+
+// NotifyHookCompleted is part of the operation.Callbacks interface.
+func (opc *operationCallbacks) NotifyHookCompleted(hook string, ctx runner.Context) {
+	if opc.op.observer != nil {
+		notifyHook(hook, ctx, opc.op.observer.HookCompleted)
+	}
+}
+
+// NotifyHookFailed is part of the operation.Callbacks interface.
+func (opc *operationCallbacks) NotifyHookFailed(hook string, ctx runner.Context) {
+	if opc.op.observer != nil {
+		notifyHook(hook, ctx, opc.op.observer.HookFailed)
+	}
+}
+
+// SetExecutingStatus is part of the operation.Callbacks interface.
+func (opc *operationCallbacks) SetExecutingStatus(message string) error {
+	return setAgentStatus(opc.op, status.Executing, message, nil)
+}

--- a/worker/caasoperator/operation/errors.go
+++ b/worker/caasoperator/operation/errors.go
@@ -1,0 +1,11 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE store for details.
+
+package operation
+
+import "github.com/juju/errors"
+
+var (
+	ErrSkipExecute = errors.New("operation already executed")
+	ErrHookFailed  = errors.New("hook failed")
+)

--- a/worker/caasoperator/operation/executor.go
+++ b/worker/caasoperator/operation/executor.go
@@ -1,0 +1,95 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE store for details.
+
+package operation
+
+import (
+	"fmt"
+
+	"github.com/juju/errors"
+	"github.com/juju/mutex"
+)
+
+type executorStep struct {
+	verb string
+	run  func(op Operation, state State) (*State, error)
+}
+
+func (step executorStep) message(op Operation) string {
+	return fmt.Sprintf("%s operation %q", step.verb, op)
+}
+
+var (
+	stepPrepare = executorStep{"preparing", Operation.Prepare}
+	stepExecute = executorStep{"executing", Operation.Execute}
+	stepCommit  = executorStep{"committing", Operation.Commit}
+)
+
+type executor struct {
+	state              *State
+	acquireMachineLock func() (mutex.Releaser, error)
+}
+
+// NewExecutor returns an Executor which takes its starting state from the
+// supplied path, and records state changes there. If no state store exists,
+// the executor's starting state will include a queued Install hook, for
+// the charm identified by the supplied func.
+func NewExecutor() (Executor, error) {
+	state := &State{
+		Kind: Continue,
+		Step: Pending,
+	}
+	return &executor{
+		state: state,
+	}, nil
+}
+
+// State is part of the Executor interface.
+func (x *executor) State() State {
+	return *x.state
+}
+
+// Run is part of the Executor interface.
+func (x *executor) Run(op Operation) error {
+	logger.Debugf("running operation %v", op)
+
+	switch err := x.do(op, stepPrepare); errors.Cause(err) {
+	case ErrSkipExecute:
+	case nil:
+		if err := x.do(op, stepExecute); err != nil {
+			return err
+		}
+	default:
+		return err
+	}
+	return x.do(op, stepCommit)
+}
+
+// Skip is part of the Executor interface.
+func (x *executor) Skip(op Operation) error {
+	logger.Debugf("skipping operation %v", op)
+	return x.do(op, stepCommit)
+}
+
+func (x *executor) do(op Operation, step executorStep) (err error) {
+	message := step.message(op)
+	logger.Debugf(message)
+	newState, firstErr := step.run(op, *x.state)
+	if newState != nil {
+		writeErr := x.updateState(*newState)
+		if firstErr == nil {
+			firstErr = writeErr
+		} else if writeErr != nil {
+			logger.Errorf("after %s: %v", message, writeErr)
+		}
+	}
+	return errors.Annotatef(firstErr, message)
+}
+
+func (x *executor) updateState(newState State) error {
+	if err := newState.validate(); err != nil {
+		return err
+	}
+	x.state = &newState
+	return nil
+}

--- a/worker/caasoperator/operation/executor_test.go
+++ b/worker/caasoperator/operation/executor_test.go
@@ -1,0 +1,283 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package operation_test
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/charm.v6/hooks"
+
+	"github.com/juju/juju/worker/caasoperator/hook"
+	"github.com/juju/juju/worker/caasoperator/operation"
+)
+
+type ExecutorSuite struct {
+	testing.IsolationSuite
+}
+
+var _ = gc.Suite(&ExecutorSuite{})
+
+func (s *ExecutorSuite) SetUpTest(c *gc.C) {
+	s.IsolationSuite.SetUpTest(c)
+}
+
+func (s *ExecutorSuite) TestNewExecutor(c *gc.C) {
+	executor, err := operation.NewExecutor()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(executor.State(), gc.DeepEquals, operation.State{
+		Kind: operation.Continue,
+		Step: operation.Pending,
+	})
+}
+
+func newExecutor(c *gc.C) operation.Executor {
+	executor, err := operation.NewExecutor()
+	c.Assert(err, jc.ErrorIsNil)
+	return executor
+}
+
+func justStartedState() operation.State {
+	return operation.State{
+		Kind: operation.Continue,
+		Step: operation.Pending,
+	}
+}
+
+func (s *ExecutorSuite) TestSucceedNoStateChanges(c *gc.C) {
+	initialState := justStartedState()
+	executor := newExecutor(c)
+
+	op := &mockOperation{
+		prepare: newStep(nil, nil),
+		execute: newStep(nil, nil),
+		commit:  newStep(nil, nil),
+	}
+
+	err := executor.Run(op)
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Assert(op.prepare.gotState, gc.DeepEquals, initialState)
+	c.Assert(op.execute.gotState, gc.DeepEquals, initialState)
+	c.Assert(op.commit.gotState, gc.DeepEquals, initialState)
+	c.Assert(executor.State(), gc.DeepEquals, initialState)
+}
+
+func (s *ExecutorSuite) TestSucceedWithStateChanges(c *gc.C) {
+	initialState := justStartedState()
+	executor := newExecutor(c)
+	op := &mockOperation{
+		prepare: newStep(&operation.State{
+			Kind: operation.RunHook,
+			Step: operation.Pending,
+			Hook: &hook.Info{Kind: hooks.ConfigChanged},
+		}, nil),
+		execute: newStep(&operation.State{
+			Kind: operation.RunHook,
+			Step: operation.Done,
+			Hook: &hook.Info{Kind: hooks.ConfigChanged},
+		}, nil),
+		commit: newStep(&operation.State{
+			Kind: operation.Continue,
+			Step: operation.Pending,
+		}, nil),
+	}
+
+	err := executor.Run(op)
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Assert(op.prepare.gotState, gc.DeepEquals, initialState)
+	c.Assert(op.execute.gotState, gc.DeepEquals, *op.prepare.newState)
+	c.Assert(op.commit.gotState, gc.DeepEquals, *op.execute.newState)
+	c.Assert(executor.State(), gc.DeepEquals, *op.commit.newState)
+}
+
+func (s *ExecutorSuite) TestErrSkipExecute(c *gc.C) {
+	initialState := justStartedState()
+	executor := newExecutor(c)
+	op := &mockOperation{
+		prepare: newStep(&operation.State{
+			Kind: operation.RunHook,
+			Step: operation.Pending,
+			Hook: &hook.Info{Kind: hooks.ConfigChanged},
+		}, operation.ErrSkipExecute),
+		commit: newStep(&operation.State{
+			Kind: operation.Continue,
+			Step: operation.Pending,
+		}, nil),
+	}
+
+	err := executor.Run(op)
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Assert(op.prepare.gotState, gc.DeepEquals, initialState)
+	c.Assert(op.commit.gotState, gc.DeepEquals, *op.prepare.newState)
+	c.Assert(executor.State(), gc.DeepEquals, *op.commit.newState)
+}
+
+func (s *ExecutorSuite) TestValidateStateChange(c *gc.C) {
+	initialState := justStartedState()
+	executor := newExecutor(c)
+	op := &mockOperation{
+		prepare: newStep(&operation.State{
+			Kind: operation.RunHook,
+			Step: operation.Pending,
+		}, nil),
+	}
+
+	err := executor.Run(op)
+	c.Assert(err, gc.ErrorMatches, `preparing operation "mock operation": invalid operation state: missing hook info with Kind RunHook`)
+	c.Assert(errors.Cause(err), gc.ErrorMatches, "missing hook info with Kind RunHook")
+
+	c.Assert(executor.State(), gc.DeepEquals, initialState)
+}
+
+func (s *ExecutorSuite) TestFailPrepareNoStateChange(c *gc.C) {
+	initialState := justStartedState()
+	executor := newExecutor(c)
+	op := &mockOperation{
+		prepare: newStep(nil, errors.New("pow")),
+	}
+
+	err := executor.Run(op)
+	c.Assert(err, gc.ErrorMatches, `preparing operation "mock operation": pow`)
+	c.Assert(errors.Cause(err), gc.ErrorMatches, "pow")
+
+	c.Assert(op.prepare.gotState, gc.DeepEquals, initialState)
+	c.Assert(executor.State(), gc.DeepEquals, initialState)
+}
+
+func (s *ExecutorSuite) TestFailPrepareWithStateChange(c *gc.C) {
+	initialState := justStartedState()
+	executor := newExecutor(c)
+	op := &mockOperation{
+		prepare: newStep(&operation.State{
+			Kind: operation.RunHook,
+			Step: operation.Pending,
+			Hook: &hook.Info{Kind: hooks.ConfigChanged},
+		}, errors.New("blam")),
+	}
+
+	err := executor.Run(op)
+	c.Assert(err, gc.ErrorMatches, `preparing operation "mock operation": blam`)
+	c.Assert(errors.Cause(err), gc.ErrorMatches, "blam")
+
+	c.Assert(op.prepare.gotState, gc.DeepEquals, initialState)
+	c.Assert(executor.State(), gc.DeepEquals, *op.prepare.newState)
+}
+
+func (s *ExecutorSuite) TestFailExecuteNoStateChange(c *gc.C) {
+	initialState := justStartedState()
+	executor := newExecutor(c)
+	op := &mockOperation{
+		prepare: newStep(nil, nil),
+		execute: newStep(nil, errors.New("splat")),
+	}
+
+	err := executor.Run(op)
+	c.Assert(err, gc.ErrorMatches, `executing operation "mock operation": splat`)
+	c.Assert(errors.Cause(err), gc.ErrorMatches, "splat")
+
+	c.Assert(op.prepare.gotState, gc.DeepEquals, initialState)
+	c.Assert(executor.State(), gc.DeepEquals, initialState)
+}
+
+func (s *ExecutorSuite) TestFailExecuteWithStateChange(c *gc.C) {
+	initialState := justStartedState()
+	executor := newExecutor(c)
+	op := &mockOperation{
+		prepare: newStep(nil, nil),
+		execute: newStep(&operation.State{
+			Kind: operation.RunHook,
+			Step: operation.Pending,
+			Hook: &hook.Info{Kind: hooks.ConfigChanged},
+		}, errors.New("kerblooie")),
+	}
+
+	err := executor.Run(op)
+	c.Assert(err, gc.ErrorMatches, `executing operation "mock operation": kerblooie`)
+	c.Assert(errors.Cause(err), gc.ErrorMatches, "kerblooie")
+
+	c.Assert(op.prepare.gotState, gc.DeepEquals, initialState)
+	c.Assert(executor.State(), gc.DeepEquals, *op.execute.newState)
+}
+
+func (s *ExecutorSuite) TestFailCommitNoStateChange(c *gc.C) {
+	initialState := justStartedState()
+	executor := newExecutor(c)
+	op := &mockOperation{
+		prepare: newStep(nil, nil),
+		execute: newStep(nil, nil),
+		commit:  newStep(nil, errors.New("whack")),
+	}
+
+	err := executor.Run(op)
+	c.Assert(err, gc.ErrorMatches, `committing operation "mock operation": whack`)
+	c.Assert(errors.Cause(err), gc.ErrorMatches, "whack")
+
+	c.Assert(op.prepare.gotState, gc.DeepEquals, initialState)
+	c.Assert(executor.State(), gc.DeepEquals, initialState)
+}
+
+func (s *ExecutorSuite) TestFailCommitWithStateChange(c *gc.C) {
+	initialState := justStartedState()
+	executor := newExecutor(c)
+	op := &mockOperation{
+		prepare: newStep(nil, nil),
+		execute: newStep(nil, nil),
+		commit: newStep(&operation.State{
+			Kind: operation.RunHook,
+			Step: operation.Pending,
+			Hook: &hook.Info{Kind: hooks.ConfigChanged},
+		}, errors.New("take that you bandit")),
+	}
+
+	err := executor.Run(op)
+	c.Assert(err, gc.ErrorMatches, `committing operation "mock operation": take that you bandit`)
+	c.Assert(errors.Cause(err), gc.ErrorMatches, "take that you bandit")
+
+	c.Assert(op.prepare.gotState, gc.DeepEquals, initialState)
+	c.Assert(executor.State(), gc.DeepEquals, *op.commit.newState)
+}
+
+type mockStep struct {
+	gotState operation.State
+	newState *operation.State
+	err      error
+	called   bool
+}
+
+func newStep(newState *operation.State, err error) *mockStep {
+	return &mockStep{newState: newState, err: err}
+}
+
+func (step *mockStep) run(state operation.State) (*operation.State, error) {
+	step.called = true
+	step.gotState = state
+	return step.newState, step.err
+}
+
+type mockOperation struct {
+	needsLock bool
+	prepare   *mockStep
+	execute   *mockStep
+	commit    *mockStep
+}
+
+func (op *mockOperation) String() string {
+	return "mock operation"
+}
+
+func (op *mockOperation) Prepare(state operation.State) (*operation.State, error) {
+	return op.prepare.run(state)
+}
+
+func (op *mockOperation) Execute(state operation.State) (*operation.State, error) {
+	return op.execute.run(state)
+}
+
+func (op *mockOperation) Commit(state operation.State) (*operation.State, error) {
+	return op.commit.run(state)
+}

--- a/worker/caasoperator/operation/factory.go
+++ b/worker/caasoperator/operation/factory.go
@@ -1,0 +1,49 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE store for details.
+
+package operation
+
+import (
+	"github.com/juju/juju/worker/caasoperator/hook"
+	"github.com/juju/juju/worker/caasoperator/runner"
+)
+
+// FactoryParams holds all the necessary parameters for a new operation factory.
+type FactoryParams struct {
+	RunnerFactory runner.Factory
+	Abort         <-chan struct{}
+	Callbacks     Callbacks
+}
+
+// NewFactory returns a Factory that creates Operations backed by the supplied
+// parameters.
+func NewFactory(params FactoryParams) Factory {
+	return &factory{
+		config: params,
+	}
+}
+
+type factory struct {
+	config FactoryParams
+}
+
+// NewRunHook is part of the Factory interface.
+func (f *factory) NewRunHook(hookInfo hook.Info) (Operation, error) {
+	if err := hookInfo.Validate(); err != nil {
+		return nil, err
+	}
+	return &runHook{
+		info:          hookInfo,
+		callbacks:     f.config.Callbacks,
+		runnerFactory: f.config.RunnerFactory,
+	}, nil
+}
+
+// NewSkipHook is part of the Factory interface.
+func (f *factory) NewSkipHook(hookInfo hook.Info) (Operation, error) {
+	hookOp, err := f.NewRunHook(hookInfo)
+	if err != nil {
+		return nil, err
+	}
+	return &skipOperation{hookOp}, nil
+}

--- a/worker/caasoperator/operation/factory_test.go
+++ b/worker/caasoperator/operation/factory_test.go
@@ -1,0 +1,60 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package operation_test
+
+import (
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/charm.v6/hooks"
+
+	"github.com/juju/juju/worker/caasoperator/hook"
+	"github.com/juju/juju/worker/caasoperator/operation"
+)
+
+type FactorySuite struct {
+	testing.IsolationSuite
+	factory operation.Factory
+}
+
+var _ = gc.Suite(&FactorySuite{})
+
+func (s *FactorySuite) SetUpTest(c *gc.C) {
+	s.IsolationSuite.SetUpTest(c)
+	// Yes, this factory will produce useless ops; this suite is just for
+	// verifying that inadequate args to the factory methods will produce
+	// the expected errors; and that the results of same get a string
+	// representation that does not depend on the factory attributes.
+	s.factory = operation.NewFactory(operation.FactoryParams{})
+}
+
+func (s *FactorySuite) testNewHookError(c *gc.C, newHook newHook) {
+	op, err := newHook(s.factory, hook.Info{Kind: hooks.Kind("gibberish")})
+	c.Check(op, gc.IsNil)
+	c.Check(err, gc.ErrorMatches, `unknown hook kind "gibberish"`)
+}
+
+func (s *FactorySuite) TestNewHookError_Run(c *gc.C) {
+	s.testNewHookError(c, (operation.Factory).NewRunHook)
+}
+
+func (s *FactorySuite) TestNewHookError_Skip(c *gc.C) {
+	s.testNewHookError(c, (operation.Factory).NewSkipHook)
+}
+
+func (s *FactorySuite) TestNewHookString_Run(c *gc.C) {
+	op, err := s.factory.NewRunHook(hook.Info{Kind: hooks.ConfigChanged})
+	c.Check(err, jc.ErrorIsNil)
+	c.Check(op.String(), gc.Equals, "run config-changed hook")
+}
+
+func (s *FactorySuite) TestNewHookString_Skip(c *gc.C) {
+	op, err := s.factory.NewSkipHook(hook.Info{
+		Kind:       hooks.RelationChanged,
+		RemoteUnit: "foo/22",
+		RelationId: 123,
+	})
+	c.Check(err, jc.ErrorIsNil)
+	c.Check(op.String(), gc.Equals, "skip run relation-changed (123; foo/22) hook")
+}

--- a/worker/caasoperator/operation/interface.go
+++ b/worker/caasoperator/operation/interface.go
@@ -8,7 +8,6 @@ import (
 	utilexec "github.com/juju/utils/exec"
 
 	"github.com/juju/juju/worker/caasoperator/hook"
-	"github.com/juju/juju/worker/caasoperator/runner"
 )
 
 var logger = loggo.GetLogger("juju.worker.caasoperator.operation")
@@ -88,9 +87,4 @@ type Callbacks interface {
 
 	// SetExecutingStatus sets the agent state to "Executing" with a message.
 	SetExecutingStatus(string) error
-
-	// NotifyHook* exist so that we can defer worrying about how to untangle the
-	// callbacks inserted for caasoperator_test. They're only used by RunHook operations.
-	NotifyHookCompleted(string, runner.Context)
-	NotifyHookFailed(string, runner.Context)
 }

--- a/worker/caasoperator/operation/interface.go
+++ b/worker/caasoperator/operation/interface.go
@@ -1,0 +1,96 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE store for details.
+
+package operation
+
+import (
+	"github.com/juju/loggo"
+	utilexec "github.com/juju/utils/exec"
+
+	"github.com/juju/juju/worker/caasoperator/hook"
+	"github.com/juju/juju/worker/caasoperator/runner"
+)
+
+var logger = loggo.GetLogger("juju.worker.caasoperator.operation")
+
+// Operation encapsulates the stages of the various things the operatoran do,
+// and the state changes that need to be recorded as they happen. Operations
+// are designed to be Run (or Skipped) by an Executor, which supplies starting
+// state and records the changes returned.
+type Operation interface {
+
+	// String returns a short representation of the operation.
+	String() string
+
+	// Prepare ensures that the operation is valid and ready to be executed.
+	// If it returns a non-nil state, that state will be validated and recorded.
+	// If it returns ErrSkipExecute, it indicates that the operation can be
+	// committed directly.
+	Prepare(state State) (*State, error)
+
+	// Execute carries out the operation. It must not be called without having
+	// called Prepare first. If it returns a non-nil state, that state will be
+	// validated and recorded.
+	Execute(state State) (*State, error)
+
+	// Commit ensures that the operation's completion is recorded. If it returns
+	// a non-nil state, that state will be validated and recorded.
+	Commit(state State) (*State, error)
+}
+
+// Executor records and exposes operator state, and applies suitable changes as
+// operations are run or skipped.
+type Executor interface {
+
+	// State returns a copy of the executor's current operation state.
+	State() State
+
+	// Run will Prepare, Execute, and Commit the supplied operation, writing
+	// indicated state changes between steps. If any step returns an unknown
+	// error, the run will be aborted and an error will be returned.
+	Run(Operation) error
+
+	// Skip will Commit the supplied operation, and write any state change
+	// indicated. If Commit returns an error, so will Skip.
+	Skip(Operation) error
+}
+
+// Factory creates operations.
+type Factory interface {
+	// NewRunHook creates an operation to execute the supplied hook.
+	NewRunHook(hookInfo hook.Info) (Operation, error)
+
+	// NewSkipHook creates an operation to mark the supplied hook as
+	// completed successfully, without executing the hook.
+	NewSkipHook(hookInfo hook.Info) (Operation, error)
+}
+
+// CommandArgs stores the arguments for a Command operation.
+type CommandArgs struct {
+	// Commands is the arbitrary commands to execute on the unit
+	Commands string
+	// RelationId is the relation context to execute the commands in.
+	RelationId int
+	// RemoteUnitName is the remote unit for the relation context.
+	RemoteUnitName string
+	// ForceRemoteUnit skips unit inference and existence validation.
+	ForceRemoteUnit bool
+}
+
+// CommandResponseFunc is for marshalling command responses back to the source
+// of the original request.
+type CommandResponseFunc func(*utilexec.ExecResponse, error)
+
+// Callbacks exposes all the operator code that's required by the various operations.
+type Callbacks interface {
+	PrepareHook(info hook.Info) (name string, err error)
+	CommitHook(info hook.Info) error
+
+	// SetExecutingStatus sets the agent state to "Executing" with a message.
+	SetExecutingStatus(string) error
+
+	// NotifyHook* exist so that we can defer worrying about how to untangle the
+	// callbacks inserted for caasoperator_test. They're only used by RunHook operations.
+	NotifyHookCompleted(string, runner.Context)
+	NotifyHookFailed(string, runner.Context)
+}

--- a/worker/caasoperator/operation/package_test.go
+++ b/worker/caasoperator/operation/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package operation_test
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func TestPackage(t *testing.T) {
+	gc.TestingT(t)
+}

--- a/worker/caasoperator/operation/runhook.go
+++ b/worker/caasoperator/operation/runhook.go
@@ -88,14 +88,11 @@ func (rh *runHook) Execute(state State) (*State, error) {
 	case err == nil:
 	default:
 		logger.Errorf("hook %q failed: %v", rh.name, err)
-		rh.callbacks.NotifyHookFailed(rh.name, rh.runner.Context())
 		return nil, ErrHookFailed
 	}
 
 	if ranHook {
 		logger.Infof("ran %q hook", rh.name)
-
-		rh.callbacks.NotifyHookCompleted(rh.name, rh.runner.Context())
 	} else {
 		logger.Infof("skipped %q hook (missing)", rh.name)
 	}

--- a/worker/caasoperator/operation/runhook.go
+++ b/worker/caasoperator/operation/runhook.go
@@ -1,0 +1,125 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE store for details.
+
+package operation
+
+import (
+	"fmt"
+
+	"github.com/juju/errors"
+	"gopkg.in/juju/charm.v6/hooks"
+
+	"github.com/juju/juju/worker/caasoperator/hook"
+	"github.com/juju/juju/worker/caasoperator/runner"
+	"github.com/juju/juju/worker/common/charmrunner"
+)
+
+type runHook struct {
+	info hook.Info
+
+	callbacks     Callbacks
+	runnerFactory runner.Factory
+
+	name   string
+	runner runner.Runner
+}
+
+// String is part of the Operation interface.
+func (rh *runHook) String() string {
+	suffix := ""
+	switch {
+	case rh.info.Kind.IsRelation():
+		if rh.info.RemoteUnit == "" {
+			suffix = fmt.Sprintf(" (%d)", rh.info.RelationId)
+		} else {
+			suffix = fmt.Sprintf(" (%d; %s)", rh.info.RelationId, rh.info.RemoteUnit)
+		}
+	}
+	return fmt.Sprintf("run %s%s hook", rh.info.Kind, suffix)
+}
+
+// Prepare ensures the hook can be executed.
+// Prepare is part of the Operation interface.
+func (rh *runHook) Prepare(state State) (*State, error) {
+	name, err := rh.callbacks.PrepareHook(rh.info)
+	if err != nil {
+		return nil, err
+	}
+	rnr, err := rh.runnerFactory.NewHookRunner(rh.info)
+	if err != nil {
+		return nil, err
+	}
+	err = rnr.Context().Prepare()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	rh.name = name
+	rh.runner = rnr
+
+	return stateChange{
+		Kind: RunHook,
+		Step: Pending,
+		Hook: &rh.info,
+	}.apply(state), nil
+}
+
+// RunningHookMessage returns the info message to print when running a hook.
+func RunningHookMessage(hookName string) string {
+	return fmt.Sprintf("running %s hook", hookName)
+}
+
+// Execute runs the hook.
+// Execute is part of the Operation interface.
+func (rh *runHook) Execute(state State) (*State, error) {
+	message := RunningHookMessage(rh.name)
+	if hooks.Kind(rh.name) != hooks.UpdateStatus {
+		if err := rh.callbacks.SetExecutingStatus(message); err != nil {
+			return nil, err
+		}
+	}
+
+	ranHook := true
+	err := rh.runner.RunHook(rh.name)
+	cause := errors.Cause(err)
+	switch {
+	case charmrunner.IsMissingHookError(cause):
+		ranHook = false
+		err = nil
+	case err == nil:
+	default:
+		logger.Errorf("hook %q failed: %v", rh.name, err)
+		rh.callbacks.NotifyHookFailed(rh.name, rh.runner.Context())
+		return nil, ErrHookFailed
+	}
+
+	if ranHook {
+		logger.Infof("ran %q hook", rh.name)
+
+		rh.callbacks.NotifyHookCompleted(rh.name, rh.runner.Context())
+	} else {
+		logger.Infof("skipped %q hook (missing)", rh.name)
+	}
+
+	return stateChange{
+		Kind: RunHook,
+		Step: Done,
+		Hook: &rh.info,
+	}.apply(state), err
+}
+
+// Commit updates relation state to include the fact of the hook's execution,
+// records the impact of start and collect-metrics hooks, and queues follow-up
+// config-changed hooks to directly follow install and upgrade-charm hooks.
+// Commit is part of the Operation interface.
+func (rh *runHook) Commit(state State) (*State, error) {
+	if err := rh.callbacks.CommitHook(rh.info); err != nil {
+		return nil, err
+	}
+
+	change := stateChange{
+		Kind: Continue,
+		Step: Pending,
+	}
+	newState := change.apply(state)
+	return newState, nil
+}

--- a/worker/caasoperator/operation/runhook_test.go
+++ b/worker/caasoperator/operation/runhook_test.go
@@ -1,0 +1,452 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package operation_test
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/charm.v6/hooks"
+
+	"github.com/juju/juju/worker/caasoperator/hook"
+	"github.com/juju/juju/worker/caasoperator/operation"
+	"github.com/juju/juju/worker/common/charmrunner"
+)
+
+type RunHookSuite struct {
+	testing.IsolationSuite
+}
+
+var _ = gc.Suite(&RunHookSuite{})
+
+type newHook func(operation.Factory, hook.Info) (operation.Operation, error)
+
+func (s *RunHookSuite) testPrepareHookError(
+	c *gc.C, newHook newHook, expectClearResolvedFlag, expectSkip bool,
+) {
+	callbacks := &PrepareHookCallbacks{
+		MockPrepareHook: &MockPrepareHook{err: errors.New("pow")},
+	}
+	factory := operation.NewFactory(operation.FactoryParams{
+		Callbacks: callbacks,
+	})
+	op, err := newHook(factory, hook.Info{Kind: hooks.ConfigChanged})
+	c.Assert(err, jc.ErrorIsNil)
+
+	newState, err := op.Prepare(operation.State{})
+	c.Check(newState, gc.IsNil)
+	if expectSkip {
+		c.Check(err, gc.Equals, operation.ErrSkipExecute)
+		c.Check(callbacks.MockPrepareHook.gotHook, gc.IsNil)
+		return
+	}
+	c.Check(err, gc.ErrorMatches, "pow")
+	c.Check(callbacks.MockPrepareHook.gotHook, gc.DeepEquals, &hook.Info{
+		Kind: hooks.ConfigChanged,
+	})
+}
+
+func (s *RunHookSuite) TestPrepareHookCtxCalled(c *gc.C) {
+	ctx := &MockContext{}
+	callbacks := &PrepareHookCallbacks{
+		MockPrepareHook: &MockPrepareHook{},
+	}
+	runnerFactory := &MockRunnerFactory{
+		MockNewHookRunner: &MockNewHookRunner{
+			runner: &MockRunner{
+				context: ctx,
+			},
+		},
+	}
+	factory := operation.NewFactory(operation.FactoryParams{
+		RunnerFactory: runnerFactory,
+		Callbacks:     callbacks,
+	})
+
+	op, err := factory.NewRunHook(hook.Info{Kind: hooks.ConfigChanged})
+	c.Assert(err, jc.ErrorIsNil)
+
+	newState, err := op.Prepare(operation.State{})
+	c.Check(newState, gc.NotNil)
+	c.Assert(err, jc.ErrorIsNil)
+
+	ctx.CheckCall(c, 0, "Prepare")
+}
+
+func (s *RunHookSuite) TestPrepareHookCtxError(c *gc.C) {
+	ctx := &MockContext{}
+	ctx.SetErrors(errors.New("ctx prepare error"))
+	callbacks := &PrepareHookCallbacks{
+		MockPrepareHook: &MockPrepareHook{},
+	}
+	runnerFactory := &MockRunnerFactory{
+		MockNewHookRunner: &MockNewHookRunner{
+			runner: &MockRunner{
+				context: ctx,
+			},
+		},
+	}
+	factory := operation.NewFactory(operation.FactoryParams{
+		RunnerFactory: runnerFactory,
+		Callbacks:     callbacks,
+	})
+
+	op, err := factory.NewRunHook(hook.Info{Kind: hooks.ConfigChanged})
+	c.Assert(err, jc.ErrorIsNil)
+
+	newState, err := op.Prepare(operation.State{})
+	c.Check(newState, gc.IsNil)
+	c.Assert(err, gc.ErrorMatches, `ctx prepare error`)
+
+	ctx.CheckCall(c, 0, "Prepare")
+}
+
+func (s *RunHookSuite) TestPrepareHookError_Run(c *gc.C) {
+	s.testPrepareHookError(c, (operation.Factory).NewRunHook, false, false)
+}
+
+func (s *RunHookSuite) TestPrepareHookError_Skip(c *gc.C) {
+	s.testPrepareHookError(c, (operation.Factory).NewSkipHook, true, true)
+}
+
+func (s *RunHookSuite) testPrepareRunnerError(c *gc.C, newHook newHook) {
+	callbacks := NewPrepareHookCallbacks()
+	runnerFactory := &MockRunnerFactory{
+		MockNewHookRunner: &MockNewHookRunner{err: errors.New("splat")},
+	}
+	factory := operation.NewFactory(operation.FactoryParams{
+		RunnerFactory: runnerFactory,
+		Callbacks:     callbacks,
+	})
+	op, err := newHook(factory, hook.Info{Kind: hooks.ConfigChanged})
+	c.Assert(err, jc.ErrorIsNil)
+
+	newState, err := op.Prepare(operation.State{})
+	c.Check(newState, gc.IsNil)
+	c.Check(err, gc.ErrorMatches, "splat")
+	c.Check(runnerFactory.MockNewHookRunner.gotHook, gc.DeepEquals, &hook.Info{
+		Kind: hooks.ConfigChanged,
+	})
+}
+
+func (s *RunHookSuite) TestPrepareRunnerError_Run(c *gc.C) {
+	s.testPrepareRunnerError(c, (operation.Factory).NewRunHook)
+}
+
+func (s *RunHookSuite) testPrepareSuccess(
+	c *gc.C, newHook newHook, before, after operation.State,
+) {
+	runnerFactory := NewRunHookRunnerFactory(errors.New("should not call"))
+	callbacks := NewPrepareHookCallbacks()
+	factory := operation.NewFactory(operation.FactoryParams{
+		RunnerFactory: runnerFactory,
+		Callbacks:     callbacks,
+	})
+	op, err := newHook(factory, hook.Info{Kind: hooks.ConfigChanged})
+	c.Assert(err, jc.ErrorIsNil)
+
+	newState, err := op.Prepare(before)
+	c.Check(err, jc.ErrorIsNil)
+	c.Check(newState, gc.DeepEquals, &after)
+}
+
+func (s *RunHookSuite) TestPrepareSuccess_BlankSlate(c *gc.C) {
+	s.testPrepareSuccess(c,
+		(operation.Factory).NewRunHook,
+		operation.State{},
+		operation.State{
+			Kind: operation.RunHook,
+			Step: operation.Pending,
+			Hook: &hook.Info{Kind: hooks.ConfigChanged},
+		},
+	)
+}
+
+func (s *RunHookSuite) TestPrepareSuccess_Preserve(c *gc.C) {
+	s.testPrepareSuccess(c,
+		(operation.Factory).NewRunHook,
+		overwriteState,
+		operation.State{
+			Kind: operation.RunHook,
+			Step: operation.Pending,
+			Hook: &hook.Info{Kind: hooks.ConfigChanged},
+		},
+	)
+}
+
+func (s *RunHookSuite) getExecuteRunnerTest(c *gc.C, newHook newHook, kind hooks.Kind, runErr error) (operation.Operation, *ExecuteHookCallbacks, *MockRunnerFactory) {
+	runnerFactory := NewRunHookRunnerFactory(runErr)
+	callbacks := &ExecuteHookCallbacks{
+		PrepareHookCallbacks:    NewPrepareHookCallbacks(),
+		MockNotifyHookCompleted: &MockNotify{},
+		MockNotifyHookFailed:    &MockNotify{},
+	}
+	factory := operation.NewFactory(operation.FactoryParams{
+		RunnerFactory: runnerFactory,
+		Callbacks:     callbacks,
+	})
+	op, err := newHook(factory, hook.Info{Kind: kind})
+	c.Assert(err, jc.ErrorIsNil)
+	return op, callbacks, runnerFactory
+}
+
+func (s *RunHookSuite) TestExecuteMissingHookError(c *gc.C) {
+	runErr := charmrunner.NewMissingHookError("blah-blah")
+	for _, kind := range unitHooks() {
+		c.Logf("hook %v", kind)
+		op, callbacks, runnerFactory := s.getExecuteRunnerTest(c, (operation.Factory).NewRunHook, kind, runErr)
+		_, err := op.Prepare(operation.State{})
+		c.Assert(err, jc.ErrorIsNil)
+
+		newState, err := op.Execute(operation.State{})
+		c.Assert(err, jc.ErrorIsNil)
+		c.Assert(newState, gc.DeepEquals, &operation.State{
+			Kind: operation.RunHook,
+			Step: operation.Done,
+			Hook: &hook.Info{Kind: kind},
+		})
+		c.Assert(*runnerFactory.MockNewHookRunner.runner.MockRunHook.gotName, gc.Equals, "some-hook-name")
+		c.Assert(callbacks.MockNotifyHookCompleted.gotName, gc.IsNil)
+		c.Assert(callbacks.MockNotifyHookFailed.gotName, gc.IsNil)
+	}
+}
+
+func (s *RunHookSuite) TestExecuteOtherError(c *gc.C) {
+	runErr := errors.New("graaargh")
+	op, callbacks, runnerFactory := s.getExecuteRunnerTest(c, (operation.Factory).NewRunHook, hooks.ConfigChanged, runErr)
+	_, err := op.Prepare(operation.State{})
+	c.Assert(err, jc.ErrorIsNil)
+
+	newState, err := op.Execute(operation.State{})
+	c.Assert(err, gc.Equals, operation.ErrHookFailed)
+	c.Assert(newState, gc.IsNil)
+	c.Assert(*runnerFactory.MockNewHookRunner.runner.MockRunHook.gotName, gc.Equals, "some-hook-name")
+	c.Assert(*callbacks.MockNotifyHookFailed.gotName, gc.Equals, "some-hook-name")
+	c.Assert(*callbacks.MockNotifyHookFailed.gotContext, gc.Equals, runnerFactory.MockNewHookRunner.runner.context)
+	c.Assert(callbacks.MockNotifyHookCompleted.gotName, gc.IsNil)
+}
+
+func (s *RunHookSuite) testExecuteSuccess(c *gc.C, before, after operation.State) {
+	op, callbacks, _ := s.getExecuteRunnerTest(c, (operation.Factory).NewRunHook, hooks.ConfigChanged, nil)
+	midState, err := op.Prepare(before)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(midState, gc.NotNil)
+
+	newState, err := op.Execute(*midState)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(newState, gc.DeepEquals, &after)
+	c.Check(callbacks.executingMessage, gc.Equals, "running some-hook-name hook")
+}
+
+func (s *RunHookSuite) TestExecuteSuccess_BlankSlate(c *gc.C) {
+	s.testExecuteSuccess(c,
+		operation.State{},
+		operation.State{
+			Kind: operation.RunHook,
+			Step: operation.Done,
+			Hook: &hook.Info{Kind: hooks.ConfigChanged},
+		},
+	)
+}
+
+func (s *RunHookSuite) TestExecuteSuccess_Preserve(c *gc.C) {
+	s.testExecuteSuccess(c,
+		overwriteState,
+		operation.State{
+			Kind: operation.RunHook,
+			Step: operation.Done,
+			Hook: &hook.Info{Kind: hooks.ConfigChanged},
+		},
+	)
+}
+
+func (s *RunHookSuite) testBeforeHookExecute(c *gc.C, newHook newHook, kind hooks.Kind) {
+	// To check what happens in the beforeHook() call, we run a hook with an error
+	// so that it does not complete successfully and thus afterHook() does not run,
+	// overwriting the values.
+	runErr := errors.New("graaargh")
+	op, _, _ := s.getExecuteRunnerTest(c, newHook, kind, runErr)
+	_, err := op.Prepare(operation.State{})
+	c.Assert(err, jc.ErrorIsNil)
+
+	newState, err := op.Execute(operation.State{})
+	c.Assert(err, gc.Equals, operation.ErrHookFailed)
+	c.Assert(newState, gc.IsNil)
+}
+
+func (s *RunHookSuite) TestBeforeHookStatus(c *gc.C) {
+	for _, kind := range unitHooks() {
+		c.Logf("hook %v", kind)
+		s.testBeforeHookExecute(c, (operation.Factory).NewRunHook, kind)
+	}
+}
+
+func (s *RunHookSuite) testCommitError(c *gc.C, newHook newHook) {
+	callbacks := &CommitHookCallbacks{
+		MockCommitHook: &MockCommitHook{nil, errors.New("pow")},
+	}
+	factory := operation.NewFactory(operation.FactoryParams{
+		Callbacks: callbacks,
+	})
+	op, err := newHook(factory, hook.Info{Kind: hooks.ConfigChanged})
+	c.Assert(err, jc.ErrorIsNil)
+
+	newState, err := op.Commit(operation.State{})
+	c.Assert(newState, gc.IsNil)
+	c.Assert(err, gc.ErrorMatches, "pow")
+}
+
+func (s *RunHookSuite) TestCommitError_Run(c *gc.C) {
+	s.testCommitError(c, (operation.Factory).NewRunHook)
+}
+
+func (s *RunHookSuite) TestCommitError_Skip(c *gc.C) {
+	s.testCommitError(c, (operation.Factory).NewSkipHook)
+}
+
+func (s *RunHookSuite) testCommitSuccess(c *gc.C, newHook newHook, hookInfo hook.Info, before, after operation.State) {
+	callbacks := &CommitHookCallbacks{
+		MockCommitHook: &MockCommitHook{},
+	}
+	factory := operation.NewFactory(operation.FactoryParams{
+		Callbacks: callbacks,
+	})
+	op, err := newHook(factory, hookInfo)
+	c.Assert(err, jc.ErrorIsNil)
+
+	newState, err := op.Commit(before)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(newState, gc.DeepEquals, &after)
+}
+
+func (s *RunHookSuite) TestCommitSuccess_ConfigChanged_QueueStartHook(c *gc.C) {
+	for i, newHook := range []newHook{
+		(operation.Factory).NewRunHook,
+		(operation.Factory).NewSkipHook,
+	} {
+		c.Logf("variant %d", i)
+		s.testCommitSuccess(c,
+			newHook,
+			hook.Info{Kind: hooks.ConfigChanged},
+			operation.State{},
+			operation.State{
+				Kind: operation.Continue,
+				Step: operation.Pending,
+			},
+		)
+	}
+}
+
+func (s *RunHookSuite) TestCommitSuccess_ConfigChanged_Preserve(c *gc.C) {
+	for i, newHook := range []newHook{
+		(operation.Factory).NewRunHook,
+		(operation.Factory).NewSkipHook,
+	} {
+		c.Logf("variant %d", i)
+		s.testCommitSuccess(c,
+			newHook,
+			hook.Info{Kind: hooks.ConfigChanged},
+			overwriteState,
+			operation.State{
+				Kind: operation.Continue,
+				Step: operation.Pending,
+			},
+		)
+	}
+}
+
+func (s *RunHookSuite) testQueueHook_BlankSlate(c *gc.C, cause hooks.Kind) {
+	for i, newHook := range []newHook{
+		(operation.Factory).NewRunHook,
+		(operation.Factory).NewSkipHook,
+	} {
+		c.Logf("variant %d", i)
+		var hi *hook.Info
+		switch cause {
+		case hooks.UpgradeCharm:
+			hi = &hook.Info{Kind: hooks.ConfigChanged}
+		default:
+			hi = nil
+		}
+		s.testCommitSuccess(c,
+			newHook,
+			hook.Info{Kind: cause},
+			operation.State{},
+			operation.State{
+				Kind: operation.RunHook,
+				Step: operation.Queued,
+				Hook: hi,
+			},
+		)
+	}
+}
+
+func (s *RunHookSuite) testQueueHook_Preserve(c *gc.C, cause hooks.Kind) {
+	for i, newHook := range []newHook{
+		(operation.Factory).NewRunHook,
+		(operation.Factory).NewSkipHook,
+	} {
+		c.Logf("variant %d", i)
+		s.testCommitSuccess(c,
+			newHook,
+			hook.Info{Kind: cause},
+			overwriteState,
+			operation.State{
+				Kind: operation.RunHook,
+				Step: operation.Queued,
+			},
+		)
+	}
+}
+
+func (s *RunHookSuite) testQueueNothing_BlankSlate(c *gc.C, hookInfo hook.Info) {
+	for i, newHook := range []newHook{
+		(operation.Factory).NewRunHook,
+		(operation.Factory).NewSkipHook,
+	} {
+		c.Logf("variant %d", i)
+		s.testCommitSuccess(c,
+			newHook,
+			hookInfo,
+			operation.State{},
+			operation.State{
+				Kind: operation.Continue,
+				Step: operation.Pending,
+			},
+		)
+	}
+}
+
+func (s *RunHookSuite) testQueueNothing_Preserve(c *gc.C, hookInfo hook.Info) {
+	for i, newHook := range []newHook{
+		(operation.Factory).NewRunHook,
+		(operation.Factory).NewSkipHook,
+	} {
+		c.Logf("variant %d", i)
+		s.testCommitSuccess(c,
+			newHook,
+			hookInfo,
+			overwriteState,
+			operation.State{
+				Kind: operation.Continue,
+				Step: operation.Pending,
+			},
+		)
+	}
+}
+
+func (s *RunHookSuite) TestQueueNothing_RelationChanged_BlankSlate(c *gc.C) {
+	s.testQueueNothing_BlankSlate(c, hook.Info{
+		Kind:       hooks.RelationChanged,
+		RemoteUnit: "u/0",
+	})
+}
+
+func (s *RunHookSuite) TestQueueNothing_RelationChanged_Preserve(c *gc.C) {
+	s.testQueueNothing_Preserve(c, hook.Info{
+		Kind:       hooks.RelationChanged,
+		RemoteUnit: "u/0",
+	})
+}

--- a/worker/caasoperator/operation/skip.go
+++ b/worker/caasoperator/operation/skip.go
@@ -1,0 +1,27 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package operation
+
+import (
+	"fmt"
+)
+
+type skipOperation struct {
+	Operation
+}
+
+// String is part of the Operation interface.
+func (op *skipOperation) String() string {
+	return fmt.Sprintf("skip %s", op.Operation)
+}
+
+// Prepare is part of the Operation interface.
+func (op *skipOperation) Prepare(state State) (*State, error) {
+	return nil, ErrSkipExecute
+}
+
+// Execute is part of the Operation interface.
+func (op *skipOperation) Execute(state State) (*State, error) {
+	return nil, ErrSkipExecute
+}

--- a/worker/caasoperator/operation/state.go
+++ b/worker/caasoperator/operation/state.go
@@ -1,0 +1,96 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE store for details.
+
+package operation
+
+import (
+	"github.com/juju/errors"
+
+	"github.com/juju/juju/worker/caasoperator/hook"
+)
+
+// Kind enumerates the operations the operator can perform.
+type Kind string
+
+const (
+	// RunHook indicates that the operator is running a hook.
+	RunHook Kind = "run-hook"
+
+	// Continue indicates that the operator should run ModeContinue
+	// to determine the next operation.
+	Continue Kind = "continue"
+)
+
+// Step describes the recorded progression of an operation.
+type Step string
+
+const (
+	// Queued indicates that the operator should undertake the operation
+	// as soon as possible.
+	Queued Step = "queued"
+
+	// Pending indicates that the operator has started, but not completed,
+	// the operation.
+	Pending Step = "pending"
+
+	// Done indicates that the operator has completed the operation,
+	// but may not yet have synchronized all necessary secondary state.
+	Done Step = "done"
+)
+
+// State defines the local state of the operator, excluding relation state.
+type State struct {
+
+	// Kind indicates the current operation.
+	Kind Kind
+
+	// Step indicates the current operation's progression.
+	Step Step
+
+	// Hook holds hook information relevant to the current operation. If Kind
+	// is Continue, it holds the last hook that was executed; if Kind is RunHook,
+	// it holds the running hook.
+	Hook *hook.Info
+}
+
+// validate returns an error if the state violates expectations.
+func (st State) validate() (err error) {
+	defer errors.DeferredAnnotatef(&err, "invalid operation state")
+	hasHook := st.Hook != nil
+	switch st.Kind {
+	case RunHook:
+		switch {
+		case !hasHook:
+			return errors.New("missing hook info with Kind RunHook")
+		}
+	case Continue:
+		if hasHook {
+			logger.Errorf("unexpected hook info with Kind Continue")
+		}
+	default:
+		return errors.Errorf("unknown operation %q", st.Kind)
+	}
+	switch st.Step {
+	case Queued, Pending, Done:
+	default:
+		return errors.Errorf("unknown operation step %q", st.Step)
+	}
+	if hasHook {
+		return st.Hook.Validate()
+	}
+	return nil
+}
+
+// stateChange is useful for a variety of Operation implementations.
+type stateChange struct {
+	Kind Kind
+	Step Step
+	Hook *hook.Info
+}
+
+func (change stateChange) apply(state State) *State {
+	state.Kind = change.Kind
+	state.Step = change.Step
+	state.Hook = change.Hook
+	return &state
+}

--- a/worker/caasoperator/operation/util_test.go
+++ b/worker/caasoperator/operation/util_test.go
@@ -34,43 +34,19 @@ func (mock *MockPrepareHook) Call(hookInfo hook.Info) (string, error) {
 	return mock.name, mock.err
 }
 
-type PrepareHookCallbacks struct {
+type ExecuteHookCallbacks struct {
 	operation.Callbacks
 	*MockPrepareHook
 	executingMessage string
 }
 
-func (cb *PrepareHookCallbacks) PrepareHook(hookInfo hook.Info) (string, error) {
+func (cb *ExecuteHookCallbacks) PrepareHook(hookInfo hook.Info) (string, error) {
 	return cb.MockPrepareHook.Call(hookInfo)
 }
 
-func (cb *PrepareHookCallbacks) SetExecutingStatus(message string) error {
+func (cb *ExecuteHookCallbacks) SetExecutingStatus(message string) error {
 	cb.executingMessage = message
 	return nil
-}
-
-type MockNotify struct {
-	gotName    *string
-	gotContext *runner.Context
-}
-
-func (mock *MockNotify) Call(hookName string, ctx runner.Context) {
-	mock.gotName = &hookName
-	mock.gotContext = &ctx
-}
-
-type ExecuteHookCallbacks struct {
-	*PrepareHookCallbacks
-	MockNotifyHookCompleted *MockNotify
-	MockNotifyHookFailed    *MockNotify
-}
-
-func (cb *ExecuteHookCallbacks) NotifyHookCompleted(hookName string, ctx runner.Context) {
-	cb.MockNotifyHookCompleted.Call(hookName, ctx)
-}
-
-func (cb *ExecuteHookCallbacks) NotifyHookFailed(hookName string, ctx runner.Context) {
-	cb.MockNotifyHookFailed.Call(hookName, ctx)
 }
 
 type MockCommitHook struct {
@@ -213,8 +189,8 @@ func (r *MockRunner) RunHook(hookName string) error {
 	return r.MockRunHook.Call(hookName)
 }
 
-func NewPrepareHookCallbacks() *PrepareHookCallbacks {
-	return &PrepareHookCallbacks{
+func newExecuteHookCallbacks() *ExecuteHookCallbacks {
+	return &ExecuteHookCallbacks{
 		MockPrepareHook: &MockPrepareHook{nil, "some-hook-name", nil},
 	}
 }

--- a/worker/caasoperator/operation/util_test.go
+++ b/worker/caasoperator/operation/util_test.go
@@ -1,0 +1,237 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package operation_test
+
+import (
+	"github.com/juju/juju/worker/caasoperator/runner/context"
+	"github.com/juju/testing"
+	utilexec "github.com/juju/utils/exec"
+	"gopkg.in/juju/charm.v6/hooks"
+
+	"github.com/juju/juju/core/relation"
+	"github.com/juju/juju/worker/caasoperator/commands"
+	"github.com/juju/juju/worker/caasoperator/hook"
+	"github.com/juju/juju/worker/caasoperator/operation"
+	"github.com/juju/juju/worker/caasoperator/runner"
+)
+
+func unitHooks() []hooks.Kind {
+	return []hooks.Kind{
+		hooks.ConfigChanged,
+		hooks.UpdateStatus,
+	}
+}
+
+type MockPrepareHook struct {
+	gotHook *hook.Info
+	name    string
+	err     error
+}
+
+func (mock *MockPrepareHook) Call(hookInfo hook.Info) (string, error) {
+	mock.gotHook = &hookInfo
+	return mock.name, mock.err
+}
+
+type PrepareHookCallbacks struct {
+	operation.Callbacks
+	*MockPrepareHook
+	executingMessage string
+}
+
+func (cb *PrepareHookCallbacks) PrepareHook(hookInfo hook.Info) (string, error) {
+	return cb.MockPrepareHook.Call(hookInfo)
+}
+
+func (cb *PrepareHookCallbacks) SetExecutingStatus(message string) error {
+	cb.executingMessage = message
+	return nil
+}
+
+type MockNotify struct {
+	gotName    *string
+	gotContext *runner.Context
+}
+
+func (mock *MockNotify) Call(hookName string, ctx runner.Context) {
+	mock.gotName = &hookName
+	mock.gotContext = &ctx
+}
+
+type ExecuteHookCallbacks struct {
+	*PrepareHookCallbacks
+	MockNotifyHookCompleted *MockNotify
+	MockNotifyHookFailed    *MockNotify
+}
+
+func (cb *ExecuteHookCallbacks) NotifyHookCompleted(hookName string, ctx runner.Context) {
+	cb.MockNotifyHookCompleted.Call(hookName, ctx)
+}
+
+func (cb *ExecuteHookCallbacks) NotifyHookFailed(hookName string, ctx runner.Context) {
+	cb.MockNotifyHookFailed.Call(hookName, ctx)
+}
+
+type MockCommitHook struct {
+	gotHook *hook.Info
+	err     error
+}
+
+func (mock *MockCommitHook) Call(hookInfo hook.Info) error {
+	mock.gotHook = &hookInfo
+	return mock.err
+}
+
+type CommitHookCallbacks struct {
+	operation.Callbacks
+	*MockCommitHook
+}
+
+func (cb *CommitHookCallbacks) CommitHook(hookInfo hook.Info) error {
+	return cb.MockCommitHook.Call(hookInfo)
+}
+
+type MockNewHookRunner struct {
+	gotHook *hook.Info
+	runner  *MockRunner
+	err     error
+}
+
+func (mock *MockNewHookRunner) Call(hookInfo hook.Info) (runner.Runner, error) {
+	mock.gotHook = &hookInfo
+	return mock.runner, mock.err
+}
+
+type MockNewCommandRunner struct {
+	gotInfo *context.CommandInfo
+	runner  *MockRunner
+	err     error
+}
+
+func (mock *MockNewCommandRunner) Call(info context.CommandInfo) (runner.Runner, error) {
+	mock.gotInfo = &info
+	return mock.runner, mock.err
+}
+
+type MockRunnerFactory struct {
+	*MockNewHookRunner
+	*MockNewCommandRunner
+}
+
+func (f *MockRunnerFactory) NewHookRunner(hookInfo hook.Info) (runner.Runner, error) {
+	return f.MockNewHookRunner.Call(hookInfo)
+}
+
+func (f *MockRunnerFactory) NewCommandRunner(commandInfo context.CommandInfo) (runner.Runner, error) {
+	return f.MockNewCommandRunner.Call(commandInfo)
+}
+
+type MockContext struct {
+	runner.Context
+	testing.Stub
+	setStatusCalled bool
+	status          commands.StatusInfo
+	isLeader        bool
+	relation        *MockRelation
+}
+
+func (mock *MockContext) SetUnitStatus(status commands.StatusInfo) error {
+	mock.setStatusCalled = true
+	mock.status = status
+	return nil
+}
+
+func (mock *MockContext) UnitName() string {
+	return "unit/0"
+}
+
+func (mock *MockContext) UnitStatus() (*commands.StatusInfo, error) {
+	return &mock.status, nil
+}
+
+func (mock *MockContext) Prepare() error {
+	mock.MethodCall(mock, "Prepare")
+	return mock.NextErr()
+}
+
+func (mock *MockContext) Relation(id int) (commands.ContextRelation, error) {
+	return mock.relation, nil
+}
+
+type MockRelation struct {
+	commands.ContextRelation
+	suspended bool
+	status    relation.Status
+}
+
+func (mock *MockRelation) Suspended() bool {
+	return mock.suspended
+}
+
+func (mock *MockRelation) SetStatus(status relation.Status) error {
+	mock.status = status
+	return nil
+}
+
+type MockRunCommands struct {
+	gotCommands *string
+	response    *utilexec.ExecResponse
+	err         error
+}
+
+func (mock *MockRunCommands) Call(commands string) (*utilexec.ExecResponse, error) {
+	mock.gotCommands = &commands
+	return mock.response, mock.err
+}
+
+type MockRunHook struct {
+	gotName *string
+	err     error
+}
+
+func (mock *MockRunHook) Call(hookName string) error {
+	mock.gotName = &hookName
+	return mock.err
+}
+
+type MockRunner struct {
+	*MockRunCommands
+	*MockRunHook
+	context runner.Context
+}
+
+func (r *MockRunner) Context() runner.Context {
+	return r.context
+}
+
+func (r *MockRunner) RunCommands(commands string) (*utilexec.ExecResponse, error) {
+	return r.MockRunCommands.Call(commands)
+}
+
+func (r *MockRunner) RunHook(hookName string) error {
+	return r.MockRunHook.Call(hookName)
+}
+
+func NewPrepareHookCallbacks() *PrepareHookCallbacks {
+	return &PrepareHookCallbacks{
+		MockPrepareHook: &MockPrepareHook{nil, "some-hook-name", nil},
+	}
+}
+
+func NewRunHookRunnerFactory(runErr error) *MockRunnerFactory {
+	return &MockRunnerFactory{
+		MockNewHookRunner: &MockNewHookRunner{
+			runner: &MockRunner{
+				MockRunHook: &MockRunHook{err: runErr},
+				context:     &MockContext{},
+			},
+		},
+	}
+}
+
+var overwriteState = operation.State{
+	Kind: operation.Continue,
+	Step: operation.Pending,
+	Hook: &hook.Info{Kind: hooks.ConfigChanged},
+}

--- a/worker/caasoperator/paths.go
+++ b/worker/caasoperator/paths.go
@@ -7,6 +7,8 @@ package caasoperator
 import (
 	"path/filepath"
 
+	"gopkg.in/juju/names.v2"
+
 	"github.com/juju/juju/agent/tools"
 )
 
@@ -82,12 +84,13 @@ type StatePaths struct {
 
 // NewPaths returns the set of filesystem paths that the supplied unit should
 // use, given the supplied root juju data directory path.
-func NewPaths(dataDir string) Paths {
+func NewPaths(dataDir string, applicationTag names.ApplicationTag) Paths {
 	join := filepath.Join
-	stateDir := join(dataDir, "state")
+	baseDir := join(dataDir, "agents", applicationTag.String())
+	stateDir := join(baseDir, "state")
 
 	socket := func(name string, abstract bool) string {
-		path := join(dataDir, name+".socket")
+		path := join(baseDir, name+".socket")
 		if abstract {
 			path = "@" + path
 		}
@@ -102,8 +105,8 @@ func NewPaths(dataDir string) Paths {
 			HookCommandServerSocket: socket("agent", true),
 		},
 		State: StatePaths{
-			BaseDir:         dataDir,
-			CharmDir:        join(dataDir, "charm"),
+			BaseDir:         baseDir,
+			CharmDir:        join(baseDir, "charm"),
 			RelationsDir:    join(stateDir, "relations"),
 			MetricsSpoolDir: join(stateDir, "spool", "metrics"),
 		},

--- a/worker/caasoperator/paths.go
+++ b/worker/caasoperator/paths.go
@@ -1,0 +1,111 @@
+// Copyright 2017 Canonical Ltd.
+
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package caasoperator
+
+import (
+	"path/filepath"
+
+	"github.com/juju/juju/agent/tools"
+)
+
+// Paths represents the set of filesystem paths a caasoperator worker has reason to
+// care about.
+type Paths struct {
+
+	// ToolsDir is the directory containing the jujud executable running this
+	// process; and also containing hook tool symlinks to that executable. It's
+	// the only path in this struct that is not typically pointing inside the
+	// directory reserved for the exclusive use of this worker (typically
+	// /var/lib/juju/tools )
+	ToolsDir string
+
+	// Runtime represents the set of paths that are relevant at runtime.
+	Runtime RuntimePaths
+
+	// State represents the set of paths that hold persistent local state for
+	// the operator.
+	State StatePaths
+}
+
+// GetToolsDir exists to satisfy the context.Paths interface.
+func (paths Paths) GetToolsDir() string {
+	return paths.ToolsDir
+}
+
+// GetCharmDir exists to satisfy the context.Paths interface.
+func (paths Paths) GetCharmDir() string {
+	return paths.State.CharmDir
+}
+
+// GetHookCommandSocket exists to satisfy the context.Paths interface.
+func (paths Paths) GetHookCommandSocket() string {
+	return paths.Runtime.HookCommandServerSocket
+}
+
+// GetMetricsSpoolDir exists to satisfy the runner.Paths interface.
+func (paths Paths) GetMetricsSpoolDir() string {
+	return paths.State.MetricsSpoolDir
+}
+
+// RuntimePaths represents the set of paths that are relevant at runtime.
+type RuntimePaths struct {
+
+	// JujuRunSocket listens for juju-run invocations, and is always
+	// active.
+	JujuRunSocket string
+
+	// HookCommandServerSocket listens for hook command invocations, and is only
+	// active when supporting a hook execution context.
+	HookCommandServerSocket string
+}
+
+// StatePaths represents the set of paths that hold persistent local state for
+// the operator.
+type StatePaths struct {
+
+	// BaseDir is the operator's base directory.
+	BaseDir string
+
+	// CharmDir is the directory to which the charm the operator runs is deployed.
+	CharmDir string
+
+	// RelationsDir holds relation-specific information about what the
+	// operator is doing and/or has done.
+	RelationsDir string
+
+	// MetricsSpoolDir acts as temporary storage for metrics being sent from
+	// the operator to state.
+	MetricsSpoolDir string
+}
+
+// NewPaths returns the set of filesystem paths that the supplied unit should
+// use, given the supplied root juju data directory path.
+func NewPaths(dataDir string) Paths {
+	join := filepath.Join
+	stateDir := join(dataDir, "state")
+
+	socket := func(name string, abstract bool) string {
+		path := join(dataDir, name+".socket")
+		if abstract {
+			path = "@" + path
+		}
+		return path
+	}
+
+	toolsDir := tools.ToolsDir(dataDir, "")
+	return Paths{
+		ToolsDir: filepath.FromSlash(toolsDir),
+		Runtime: RuntimePaths{
+			JujuRunSocket:           socket("run", false),
+			HookCommandServerSocket: socket("agent", true),
+		},
+		State: StatePaths{
+			BaseDir:         dataDir,
+			CharmDir:        join(dataDir, "charm"),
+			RelationsDir:    join(stateDir, "relations"),
+			MetricsSpoolDir: join(stateDir, "spool", "metrics"),
+		},
+	}
+}

--- a/worker/caasoperator/paths_test.go
+++ b/worker/caasoperator/paths_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/worker/caasoperator"
 )
@@ -28,20 +29,21 @@ func relPathFunc(base string) func(parts ...string) string {
 
 func (s *PathsSuite) TestPaths(c *gc.C) {
 	dataDir := c.MkDir()
-	paths := caasoperator.NewPaths(dataDir)
+	paths := caasoperator.NewPaths(dataDir, names.NewApplicationTag("foo"))
 
 	relData := relPathFunc(dataDir)
+	relAgent := relPathFunc(relData("agents", "application-foo"))
 	c.Assert(paths, jc.DeepEquals, caasoperator.Paths{
 		ToolsDir: relData("tools"),
 		Runtime: caasoperator.RuntimePaths{
-			JujuRunSocket:           relData("run.socket"),
-			HookCommandServerSocket: "@" + relData("agent.socket"),
+			JujuRunSocket:           relAgent("run.socket"),
+			HookCommandServerSocket: "@" + relAgent("agent.socket"),
 		},
 		State: caasoperator.StatePaths{
-			BaseDir:         relData(),
-			CharmDir:        relData("charm"),
-			RelationsDir:    relData("state", "relations"),
-			MetricsSpoolDir: relData("state", "spool", "metrics"),
+			BaseDir:         relAgent(),
+			CharmDir:        relAgent("charm"),
+			RelationsDir:    relAgent("state", "relations"),
+			MetricsSpoolDir: relAgent("state", "spool", "metrics"),
 		},
 	})
 }

--- a/worker/caasoperator/paths_test.go
+++ b/worker/caasoperator/paths_test.go
@@ -1,0 +1,64 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package caasoperator_test
+
+import (
+	"path/filepath"
+
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/worker/caasoperator"
+)
+
+type PathsSuite struct {
+	testing.IsolationSuite
+}
+
+var _ = gc.Suite(&PathsSuite{})
+
+func relPathFunc(base string) func(parts ...string) string {
+	return func(parts ...string) string {
+		allParts := append([]string{base}, parts...)
+		return filepath.Join(allParts...)
+	}
+}
+
+func (s *PathsSuite) TestPaths(c *gc.C) {
+	dataDir := c.MkDir()
+	paths := caasoperator.NewPaths(dataDir)
+
+	relData := relPathFunc(dataDir)
+	c.Assert(paths, jc.DeepEquals, caasoperator.Paths{
+		ToolsDir: relData("tools"),
+		Runtime: caasoperator.RuntimePaths{
+			JujuRunSocket:           relData("run.socket"),
+			HookCommandServerSocket: "@" + relData("agent.socket"),
+		},
+		State: caasoperator.StatePaths{
+			BaseDir:         relData(),
+			CharmDir:        relData("charm"),
+			RelationsDir:    relData("state", "relations"),
+			MetricsSpoolDir: relData("state", "spool", "metrics"),
+		},
+	})
+}
+
+func (s *PathsSuite) TestContextInterface(c *gc.C) {
+	paths := caasoperator.Paths{
+		ToolsDir: "/path/to/tools",
+		Runtime: caasoperator.RuntimePaths{
+			HookCommandServerSocket: "/path/to/socket",
+		},
+		State: caasoperator.StatePaths{
+			CharmDir:        "/path/to/charm",
+			MetricsSpoolDir: "/path/to/spool/metrics",
+		},
+	}
+	c.Assert(paths.GetToolsDir(), gc.Equals, "/path/to/tools")
+	c.Assert(paths.GetCharmDir(), gc.Equals, "/path/to/charm")
+	c.Assert(paths.GetHookCommandSocket(), gc.Equals, "/path/to/socket")
+	c.Assert(paths.GetMetricsSpoolDir(), gc.Equals, "/path/to/spool/metrics")
+}

--- a/worker/caasoperator/runner/context/context.go
+++ b/worker/caasoperator/runner/context/context.go
@@ -128,7 +128,7 @@ func (ctx *HookContext) ApplicationStatus() (commands.StatusInfo, error) {
 		return *ctx.status, nil
 	}
 	var err error
-	status, err := ctx.hookAPI.ApplicationStatus(ctx.applicationName)
+	status, err := ctx.hookAPI.ApplicationStatus()
 	if err == nil && status.Error != nil {
 		err = status.Error
 	}
@@ -149,7 +149,6 @@ func (ctx *HookContext) SetApplicationStatus(appStatus commands.StatusInfo) erro
 	logger.Tracef("[APPLICATION-STATUS] %s: %s", appStatus.Status, appStatus.Info)
 
 	return ctx.hookAPI.SetApplicationStatus(
-		ctx.applicationName,
 		status.Status(appStatus.Status),
 		appStatus.Info,
 		appStatus.Data,

--- a/worker/caasoperator/runner/context/context.go
+++ b/worker/caasoperator/runner/context/context.go
@@ -33,18 +33,14 @@ type Paths interface {
 	// the charm is installed.
 	GetCharmDir() string
 
-	// GetJujucSocket returns the path to the socket used by the hook tools
+	// GetHookCommandSocket returns the path to the socket used by the hook tools
 	// to communicate back to the executing operator process. It might be a
 	// filesystem path, or it might be abstract.
-	GetJujucSocket() string
+	GetHookCommandSocket() string
 
 	// GetMetricsSpoolDir returns the path to a metrics spool dir, used
 	// to store metrics recorded during a single hook run.
 	GetMetricsSpoolDir() string
-
-	// ComponentDir returns the filesystem path to the directory
-	// containing all data files for a component.
-	ComponentDir(name string) string
 }
 
 var logger = loggo.GetLogger("juju.worker.caasoperator.runner.context")
@@ -160,10 +156,10 @@ func (ctx *HookContext) SetApplicationStatus(appStatus commands.StatusInfo) erro
 	)
 }
 
-func (ctx *HookContext) ConfigSettings() (charm.Settings, error) {
+func (ctx *HookContext) ApplicationConfig() (charm.Settings, error) {
 	if ctx.configSettings == nil {
 		var err error
-		ctx.configSettings, err = ctx.hookAPI.ConfigSettings()
+		ctx.configSettings, err = ctx.hookAPI.ApplicationConfig()
 		if err != nil {
 			return nil, err
 		}
@@ -211,7 +207,7 @@ func (context *HookContext) HookVars(paths Paths) ([]string, error) {
 		"CHARM_DIR="+paths.GetCharmDir(), // legacy, embarrassing
 		"JUJU_CHARM_DIR="+paths.GetCharmDir(),
 		"JUJU_CONTEXT_ID="+context.id,
-		"JUJU_AGENT_SOCKET="+paths.GetJujucSocket(),
+		"JUJU_AGENT_SOCKET="+paths.GetHookCommandSocket(),
 		"JUJU_APPLICATION_NAME="+context.applicationName,
 		"JUJU_MODEL_UUID="+context.uuid,
 		"JUJU_MODEL_NAME="+context.modelName,

--- a/worker/caasoperator/runner/context/context_test.go
+++ b/worker/caasoperator/runner/context/context_test.go
@@ -101,7 +101,7 @@ func (s *InterfaceSuite) TestStatusCaching(c *gc.C) {
 	c.Check(appStatus.Data, gc.DeepEquals, map[string]interface{}{})
 
 	// Change remote state.
-	err = s.contextAPI.SetApplicationStatus("gitlab", status.Blocked, "broken", nil)
+	err = s.contextAPI.SetApplicationStatus(status.Blocked, "broken", nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Local view is unchanged.

--- a/worker/caasoperator/runner/context/context_test.go
+++ b/worker/caasoperator/runner/context/context_test.go
@@ -115,7 +115,7 @@ func (s *InterfaceSuite) TestStatusCaching(c *gc.C) {
 func (s *InterfaceSuite) TestConfigCaching(c *gc.C) {
 	s.contextAPI.UpdateConfigSettings(charm.Settings{"blog-title": "My Title"})
 	ctx := s.GetContext(c, -1, "")
-	settings, err := ctx.ConfigSettings()
+	settings, err := ctx.ApplicationConfig()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(settings, gc.DeepEquals, charm.Settings{"blog-title": "My Title"})
 
@@ -123,7 +123,7 @@ func (s *InterfaceSuite) TestConfigCaching(c *gc.C) {
 	s.contextAPI.UpdateConfigSettings(charm.Settings{"blog-title": "Something Else"})
 
 	// Local view is not changed.
-	settings, err = ctx.ConfigSettings()
+	settings, err = ctx.ApplicationConfig()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(settings, gc.DeepEquals, charm.Settings{"blog-title": "My Title"})
 }

--- a/worker/caasoperator/runner/context/contextfactory.go
+++ b/worker/caasoperator/runner/context/contextfactory.go
@@ -162,6 +162,11 @@ func (f *contextFactory) CommandContext(commandInfo CommandInfo) (*HookContext, 
 // to construct ContextRelations for a fresh context.
 func (f *contextFactory) getContextRelations() map[int]*ContextRelation {
 	contextRelations := map[int]*ContextRelation{}
+	// TODO(caas)
+	if f.getRelationInfos == nil {
+		return contextRelations
+	}
+
 	relationInfos := f.getRelationInfos()
 	relationCaches := map[int]*RelationCache{}
 	for id, info := range relationInfos {

--- a/worker/caasoperator/runner/context/env_test.go
+++ b/worker/caasoperator/runner/context/env_test.go
@@ -36,11 +36,10 @@ func (s *EnvSuite) assertVars(c *gc.C, actual []string, expect ...[]string) {
 }
 
 func (s *EnvSuite) getPaths() (paths context.Paths, expectVars []string) {
-	// note: path-munging is os-dependent, not included in expectVars
 	return MockFakePaths{}, []string{
 		"CHARM_DIR=path-to-charm",
 		"JUJU_CHARM_DIR=path-to-charm",
-		"JUJU_AGENT_SOCKET=path-to-jujuc.socket",
+		"JUJU_AGENT_SOCKET=path-to-hookcommand.socket",
 	}
 }
 

--- a/worker/caasoperator/runner/context/interface.go
+++ b/worker/caasoperator/runner/context/interface.go
@@ -16,8 +16,8 @@ import (
 type hookAPI interface {
 	ApplicationConfig() (charm.Settings, error)
 	NetworkInfo([]string, *int) (map[string]params.NetworkInfoResult, error)
-	ApplicationStatus(string) (params.ApplicationStatusResult, error)
-	SetApplicationStatus(string, status.Status, string, map[string]interface{}) error
+	ApplicationStatus() (params.ApplicationStatusResult, error)
+	SetApplicationStatus(status.Status, string, map[string]interface{}) error
 	SetContainerSpec(string, string) error
 }
 

--- a/worker/caasoperator/runner/context/interface.go
+++ b/worker/caasoperator/runner/context/interface.go
@@ -14,7 +14,7 @@ import (
 )
 
 type hookAPI interface {
-	ConfigSettings() (charm.Settings, error)
+	ApplicationConfig() (charm.Settings, error)
 	NetworkInfo([]string, *int) (map[string]params.NetworkInfoResult, error)
 	ApplicationStatus(string) (params.ApplicationStatusResult, error)
 	SetApplicationStatus(string, status.Status, string, map[string]interface{}) error

--- a/worker/caasoperator/runner/context/util_test.go
+++ b/worker/caasoperator/runner/context/util_test.go
@@ -4,7 +4,6 @@
 package context_test
 
 import (
-	"path/filepath"
 	"runtime"
 	"time"
 
@@ -144,14 +143,10 @@ func (MockFakePaths) GetCharmDir() string {
 	return "path-to-charm"
 }
 
-func (MockFakePaths) GetJujucSocket() string {
-	return "path-to-jujuc.socket"
+func (MockFakePaths) GetHookCommandSocket() string {
+	return "path-to-hookcommand.socket"
 }
 
 func (MockFakePaths) GetMetricsSpoolDir() string {
 	return "path-to-metrics-spool-dir"
-}
-
-func (MockFakePaths) ComponentDir(name string) string {
-	return filepath.Join("path-to-base-dir", name)
 }

--- a/worker/caasoperator/runner/context/util_test.go
+++ b/worker/caasoperator/runner/context/util_test.go
@@ -49,7 +49,7 @@ func (s *HookContextSuite) SetUpTest(c *gc.C) {
 	s.relIdCounter = 0
 	s.relationAPIs = make(map[int]*runnertesting.MockRelationUnitAPI)
 	s.contextAPI = runnertesting.NewMockContextAPI(apiAddrs, proxy.Settings{})
-	err := s.contextAPI.SetApplicationStatus("gitlab", status.Maintenance, "initialising", nil)
+	err := s.contextAPI.SetApplicationStatus(status.Maintenance, "initialising", nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.AddContextRelation(c, "db0")

--- a/worker/caasoperator/runner/factory.go
+++ b/worker/caasoperator/runner/factory.go
@@ -23,6 +23,9 @@ type Factory interface {
 	NewHookRunner(hookInfo hook.Info) (Runner, error)
 }
 
+// NewRunnerFactoryFunc is a function that returns a hook/cmd/action runner factory.
+type NewRunnerFactoryFunc func(context.Paths, context.ContextFactory) (Factory, error)
+
 // NewFactory returns a Factory capable of creating runners for executing
 // charm hooks, actions and commands.
 func NewFactory(

--- a/worker/caasoperator/runner/runner.go
+++ b/worker/caasoperator/runner/runner.go
@@ -167,7 +167,7 @@ func (runner *runner) startHookCommandServer() (*commands.Server, error) {
 	}
 	srv, err := commands.NewServer(getCmd, runner.paths.GetHookCommandSocket())
 	if err != nil {
-		return nil, errors.Annotate(err, "starting jujuc server")
+		return nil, errors.Annotate(err, "starting hook command server")
 	}
 	go srv.Run()
 	return srv, nil

--- a/worker/caasoperator/runner/runner.go
+++ b/worker/caasoperator/runner/runner.go
@@ -4,13 +4,11 @@
 package runner
 
 import (
-	"encoding/base64"
 	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"time"
-	"unicode/utf8"
 
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
@@ -109,17 +107,6 @@ func (runner *runner) runCommandsWithTimeout(commands string, timeout time.Durat
 	return command.WaitWithCancel(cancel)
 }
 
-func encodeBytes(input []byte) (value string, encoding string) {
-	if utf8.Valid(input) {
-		value = string(input)
-		encoding = "utf8"
-	} else {
-		value = base64.StdEncoding.EncodeToString(input)
-		encoding = "base64"
-	}
-	return value, encoding
-}
-
 // RunHook exists to satisfy the Runner interface.
 func (runner *runner) RunHook(hookName string) error {
 	return runner.runCharmHookWithLocation(hookName, "hooks")
@@ -178,7 +165,7 @@ func (runner *runner) startHookCommandServer() (*commands.Server, error) {
 		}
 		return commands.NewCommand(runner.context, cmdName)
 	}
-	srv, err := commands.NewServer(getCmd, runner.paths.GetJujucSocket())
+	srv, err := commands.NewServer(getCmd, runner.paths.GetHookCommandSocket())
 	if err != nil {
 		return nil, errors.Annotate(err, "starting jujuc server")
 	}

--- a/worker/caasoperator/runner/runnertesting/mock.go
+++ b/worker/caasoperator/runner/runnertesting/mock.go
@@ -4,7 +4,6 @@
 package runnertesting
 
 import (
-	"github.com/juju/errors"
 	"github.com/juju/utils/proxy"
 	"gopkg.in/juju/charm.v6"
 
@@ -17,14 +16,13 @@ import (
 func NewMockContextAPI(apiAddresses []string, settings proxy.Settings) *MockContextAPI {
 	return &MockContextAPI{
 		apiAddresses: apiAddresses, settings: settings,
-		appStatus: make(map[string]status.StatusInfo),
 	}
 }
 
 type MockContextAPI struct {
 	apiAddresses   []string
 	settings       proxy.Settings
-	appStatus      map[string]status.StatusInfo
+	appStatus      status.StatusInfo
 	configSettings charm.Settings
 	SpecYaml       string
 	SpecUnitName   string
@@ -52,23 +50,19 @@ func (m *MockContextAPI) NetworkInfo([]string, *int) (map[string]params.NetworkI
 	}, nil
 }
 
-func (m *MockContextAPI) ApplicationStatus(applicationName string) (params.ApplicationStatusResult, error) {
-	statusInfo, ok := m.appStatus[applicationName]
-	if !ok {
-		return params.ApplicationStatusResult{}, errors.NotFoundf("application %v", applicationName)
-	}
+func (m *MockContextAPI) ApplicationStatus() (params.ApplicationStatusResult, error) {
 	return params.ApplicationStatusResult{Application: params.StatusResult{
-		Status: string(statusInfo.Status),
-		Info:   statusInfo.Message,
-		Data:   statusInfo.Data,
+		Status: string(m.appStatus.Status),
+		Info:   m.appStatus.Message,
+		Data:   m.appStatus.Data,
 	}}, nil
 }
 
-func (m *MockContextAPI) SetApplicationStatus(applicationName string, s status.Status, info string, data map[string]interface{}) error {
+func (m *MockContextAPI) SetApplicationStatus(s status.Status, info string, data map[string]interface{}) error {
 	if data == nil {
 		data = map[string]interface{}{}
 	}
-	m.appStatus[applicationName] = status.StatusInfo{
+	m.appStatus = status.StatusInfo{
 		Status:  s,
 		Message: info,
 		Data:    data,

--- a/worker/caasoperator/runner/runnertesting/mock.go
+++ b/worker/caasoperator/runner/runnertesting/mock.go
@@ -38,7 +38,7 @@ func (m *MockContextAPI) ProxySettings() (proxy.Settings, error) {
 	return m.settings, nil
 }
 
-func (m *MockContextAPI) ConfigSettings() (charm.Settings, error) {
+func (m *MockContextAPI) ApplicationConfig() (charm.Settings, error) {
 	return m.configSettings, nil
 }
 

--- a/worker/caasoperator/runner/runnertesting/paths.go
+++ b/worker/caasoperator/runner/runnertesting/paths.go
@@ -47,14 +47,6 @@ func (p MockPaths) GetCharmDir() string {
 	return p.charm
 }
 
-func (p MockPaths) GetJujucSocket() string {
+func (p MockPaths) GetHookCommandSocket() string {
 	return p.socket
-}
-
-func (p MockPaths) ComponentDir(name string) string {
-	if dirname, ok := p.componentDirs[name]; ok {
-		return dirname
-	}
-	p.componentDirs[name] = filepath.Join(p.fops.MkDir(), name)
-	return p.componentDirs[name]
 }

--- a/worker/caasoperator/util_test.go
+++ b/worker/caasoperator/util_test.go
@@ -7,8 +7,9 @@ import (
 	"sync"
 	"time"
 
-	"github.com/juju/juju/testing"
 	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/testing"
 )
 
 type hookObserver struct {

--- a/worker/caasoperator/util_test.go
+++ b/worker/caasoperator/util_test.go
@@ -1,0 +1,60 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package caasoperator_test
+
+import (
+	"sync"
+	"time"
+
+	"github.com/juju/juju/testing"
+	gc "gopkg.in/check.v1"
+)
+
+type hookObserver struct {
+	mu             sync.Mutex
+	hooksCompleted []string
+}
+
+func (ctx *hookObserver) HookCompleted(hookName string) {
+	ctx.mu.Lock()
+	ctx.hooksCompleted = append(ctx.hooksCompleted, hookName)
+	ctx.mu.Unlock()
+}
+
+func (ctx *hookObserver) HookFailed(hookName string) {
+	ctx.mu.Lock()
+	ctx.hooksCompleted = append(ctx.hooksCompleted, "fail-"+hookName)
+	ctx.mu.Unlock()
+}
+
+func (ctx *hookObserver) matchHooks(c *gc.C, hooks []string) bool {
+	ctx.mu.Lock()
+	defer ctx.mu.Unlock()
+	c.Logf("actual hooks: %#v", ctx.hooksCompleted)
+	c.Logf("expected hooks: %#v", hooks)
+	if len(ctx.hooksCompleted) < len(hooks) {
+		return false
+	}
+	for i, e := range hooks {
+		if ctx.hooksCompleted[i] != e {
+			return false
+		}
+	}
+	return true
+}
+
+func (ctx *hookObserver) waitForHooks(c *gc.C, hooks []string) {
+	c.Logf("waiting for hooks: %#v", hooks)
+	timeout := time.After(testing.LongWait)
+	for {
+		select {
+		case <-time.After(testing.ShortWait):
+			if ctx.matchHooks(c, hooks) {
+				return
+			}
+		case <-timeout:
+			c.Fatalf("never got expected hooks")
+		}
+	}
+}


### PR DESCRIPTION
## Description of change

The CAAS operator gains the ability to run hooks.
It runs the config-changed hook initially.

There's still  several APIs to wire up - these currently have dummy implementations. There's also work needed to split things up a bit.

PR is split across several commits:
1. add new ModelName() API facade method
2. port across operations functionality from uniter - no need to persistent local state and just the hook runner bit; also no need for machine lock
3. add tests for the above
4. new top level caas operator infrastructure
5. wire everything up

## QA steps

CAAS smoke test.

