### PR TITLE
 worker/caasunitprovisioner: add worker

### DIFF
--- a/worker/caasunitprovisioner/application_worker.go
+++ b/worker/caasunitprovisioner/application_worker.go
@@ -1,0 +1,98 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package caasunitprovisioner
+
+import (
+	"github.com/juju/errors"
+	"gopkg.in/juju/worker.v1"
+
+	"github.com/juju/juju/core/life"
+	"github.com/juju/juju/worker/catacomb"
+)
+
+type applicationWorker struct {
+	catacomb            catacomb.Catacomb
+	application         string
+	containerSpecGetter ContainerSpecGetter
+	lifeGetter          LifeGetter
+	unitGetter          UnitGetter
+}
+
+func newApplicationWorker(
+	application string,
+	containerSpecGetter ContainerSpecGetter,
+	lifeGetter LifeGetter,
+	unitGetter UnitGetter,
+) (worker.Worker, error) {
+	w := &applicationWorker{
+		application:         application,
+		containerSpecGetter: containerSpecGetter,
+		lifeGetter:          lifeGetter,
+		unitGetter:          unitGetter,
+	}
+	if err := catacomb.Invoke(catacomb.Plan{
+		Site: &w.catacomb,
+		Work: w.loop,
+	}); err != nil {
+		return nil, errors.Trace(err)
+	}
+	return w, nil
+}
+
+// Kill is part of the worker.Worker interface.
+func (w *applicationWorker) Kill() {
+	w.catacomb.Kill(nil)
+}
+
+// Wait is part of the worker.Worker interface.
+func (w *applicationWorker) Wait() error {
+	return w.catacomb.Wait()
+}
+
+func (aw *applicationWorker) loop() error {
+	uw, err := aw.unitGetter.WatchApplicationUnits(aw.application)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	aw.catacomb.Add(uw)
+
+	unitWorkers := make(map[string]worker.Worker)
+	for {
+		select {
+		case <-aw.catacomb.Dying():
+			return aw.catacomb.ErrDying()
+		case units, ok := <-uw.Changes():
+			if !ok {
+				return errors.New("watcher closed channel")
+			}
+			for _, unitId := range units {
+				unitLife, err := aw.lifeGetter.Life(unitId)
+				if errors.IsNotFound(err) {
+					w, ok := unitWorkers[unitId]
+					if ok {
+						if err := worker.Stop(w); err != nil {
+							return errors.Trace(err)
+						}
+						delete(unitWorkers, unitId)
+					}
+					continue
+				}
+				if err != nil {
+					return errors.Trace(err)
+				}
+				if _, ok := unitWorkers[unitId]; ok || unitLife == life.Dead {
+					// Already watching the unit. or we're
+					// not yet watching it and it's dead.
+					continue
+				}
+				w, err := newUnitWorker(unitId, aw.containerSpecGetter)
+				if err != nil {
+					return errors.Trace(err)
+				}
+				unitWorkers[unitId] = w
+				aw.catacomb.Add(w)
+			}
+		}
+	}
+}

--- a/worker/caasunitprovisioner/broker.go
+++ b/worker/caasunitprovisioner/broker.go
@@ -1,0 +1,10 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package caasunitprovisioner
+
+type ContainerBroker interface {
+	// TODO(caas) update the caas.Broker type with a method
+	// for creating/updating a unit container, and expose
+	// it here.
+}

--- a/worker/caasunitprovisioner/client.go
+++ b/worker/caasunitprovisioner/client.go
@@ -1,0 +1,49 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package caasunitprovisioner
+
+import (
+	"github.com/juju/juju/core/life"
+	"github.com/juju/juju/watcher"
+)
+
+// Client provides an interface for interacting with the
+// CAASUnitProvisioner API. Subsets of this should be passed
+// to the CAASUnitProvisioner worker.
+type Client interface {
+	ApplicationGetter
+	ContainerSpecGetter
+	LifeGetter
+	UnitGetter
+}
+
+// ApplicationGetter provides an interface for
+// watching for the lifecycle state changes
+// (including addition) of applications in the
+// model, and fetching their details.
+type ApplicationGetter interface {
+	WatchApplications() (watcher.StringsWatcher, error)
+}
+
+// ContainerSpecGetter provides an interface for
+// watching and getting the container spec for a
+// unit.
+type ContainerSpecGetter interface {
+	ContainerSpec(entityName string) (string, error)
+	WatchContainerSpec(entityName string) (watcher.NotifyWatcher, error)
+}
+
+// LifeGetter provides an interface for getting the
+// lifecycle state value for an application or unit.
+type LifeGetter interface {
+	Life(string) (life.Value, error)
+}
+
+// UnitGetter provides an interface for watching for
+// the lifecycle state changes (including addition)
+// of a specified application's units, and fetching
+// their details.
+type UnitGetter interface {
+	WatchApplicationUnits(string) (watcher.StringsWatcher, error)
+}

--- a/worker/caasunitprovisioner/manifold.go
+++ b/worker/caasunitprovisioner/manifold.go
@@ -1,0 +1,73 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package caasunitprovisioner
+
+import (
+	"github.com/juju/errors"
+	"gopkg.in/juju/worker.v1"
+
+	"github.com/juju/juju/api/base"
+	"github.com/juju/juju/caas"
+	"github.com/juju/juju/worker/dependency"
+)
+
+// ManifoldConfig defines a CAAS unit provisioner's dependencies.
+type ManifoldConfig struct {
+	APICallerName string
+	BrokerName    string
+
+	NewWorker func(Config) (worker.Worker, error)
+}
+
+// Validate is called by start to check for bad configuration.
+func (config ManifoldConfig) Validate() error {
+	if config.APICallerName == "" {
+		return errors.NotValidf("empty APICallerName")
+	}
+	if config.BrokerName == "" {
+		return errors.NotValidf("empty BrokerName")
+	}
+	if config.NewWorker == nil {
+		return errors.NotValidf("nil NewWorker")
+	}
+	return nil
+}
+
+func (config ManifoldConfig) start(context dependency.Context) (worker.Worker, error) {
+	if err := config.Validate(); err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	var apiCaller base.APICaller
+	if err := context.Get(config.APICallerName, &apiCaller); err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	var broker caas.Broker
+	if err := context.Get(config.BrokerName, &broker); err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	//api := caasunitprovisioner.NewClient(apiCaller)
+	w, err := config.NewWorker(Config{
+		// TODO(axw) pass in interfaces implemented by the API client.
+		ContainerBroker: broker,
+	})
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return w, nil
+}
+
+// Manifold creates a manifold that runs a CAAS unit provisioner. See the
+// ManifoldConfig type for discussion about how this can/should evolve.
+func Manifold(config ManifoldConfig) dependency.Manifold {
+	return dependency.Manifold{
+		Inputs: []string{
+			config.APICallerName,
+			config.BrokerName,
+		},
+		Start: config.start,
+	}
+}

--- a/worker/caasunitprovisioner/manifold_test.go
+++ b/worker/caasunitprovisioner/manifold_test.go
@@ -1,0 +1,122 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package caasunitprovisioner_test
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/worker.v1"
+
+	"github.com/juju/juju/worker/caasunitprovisioner"
+	"github.com/juju/juju/worker/dependency"
+	dt "github.com/juju/juju/worker/dependency/testing"
+	"github.com/juju/juju/worker/workertest"
+)
+
+type ManifoldSuite struct {
+	testing.IsolationSuite
+	testing.Stub
+	manifold dependency.Manifold
+	context  dependency.Context
+
+	apiCaller fakeAPICaller
+	broker    fakeBroker
+}
+
+var _ = gc.Suite(&ManifoldSuite{})
+
+func (s *ManifoldSuite) SetUpTest(c *gc.C) {
+	s.IsolationSuite.SetUpTest(c)
+	s.ResetCalls()
+
+	s.context = s.newContext(nil)
+	s.manifold = caasunitprovisioner.Manifold(s.validConfig())
+}
+
+func (s *ManifoldSuite) validConfig() caasunitprovisioner.ManifoldConfig {
+	return caasunitprovisioner.ManifoldConfig{
+		APICallerName: "api-caller",
+		BrokerName:    "broker",
+		NewWorker:     s.newWorker,
+	}
+}
+
+func (s *ManifoldSuite) newWorker(config caasunitprovisioner.Config) (worker.Worker, error) {
+	s.MethodCall(s, "NewWorker", config)
+	if err := s.NextErr(); err != nil {
+		return nil, err
+	}
+	w := worker.NewRunner(worker.RunnerParams{})
+	s.AddCleanup(func(c *gc.C) { workertest.DirtyKill(c, w) })
+	return w, nil
+}
+
+func (s *ManifoldSuite) newContext(overlay map[string]interface{}) dependency.Context {
+	resources := map[string]interface{}{
+		"api-caller": &s.apiCaller,
+		"broker":     &s.broker,
+	}
+	for k, v := range overlay {
+		resources[k] = v
+	}
+	return dt.StubContext(nil, resources)
+}
+
+func (s *ManifoldSuite) TestMissingAPICallerName(c *gc.C) {
+	config := s.validConfig()
+	config.APICallerName = ""
+	s.checkConfigInvalid(c, config, "empty APICallerName not valid")
+}
+
+func (s *ManifoldSuite) TestMissingBrokerName(c *gc.C) {
+	config := s.validConfig()
+	config.BrokerName = ""
+	s.checkConfigInvalid(c, config, "empty BrokerName not valid")
+}
+
+func (s *ManifoldSuite) TestMissingNewWorker(c *gc.C) {
+	config := s.validConfig()
+	config.NewWorker = nil
+	s.checkConfigInvalid(c, config, "nil NewWorker not valid")
+}
+
+func (s *ManifoldSuite) checkConfigInvalid(c *gc.C, config caasunitprovisioner.ManifoldConfig, expect string) {
+	err := config.Validate()
+	c.Check(err, gc.ErrorMatches, expect)
+	c.Check(err, jc.Satisfies, errors.IsNotValid)
+}
+
+var expectedInputs = []string{"api-caller", "broker"}
+
+func (s *ManifoldSuite) TestInputs(c *gc.C) {
+	c.Assert(s.manifold.Inputs, jc.SameContents, expectedInputs)
+}
+
+func (s *ManifoldSuite) TestMissingInputs(c *gc.C) {
+	for _, input := range expectedInputs {
+		context := s.newContext(map[string]interface{}{
+			input: dependency.ErrMissing,
+		})
+		_, err := s.manifold.Start(context)
+		c.Assert(errors.Cause(err), gc.Equals, dependency.ErrMissing)
+	}
+}
+
+func (s *ManifoldSuite) TestStart(c *gc.C) {
+	w, err := s.manifold.Start(s.context)
+	c.Assert(err, jc.ErrorIsNil)
+	workertest.CleanKill(c, w)
+
+	s.CheckCallNames(c, "NewWorker")
+	args := s.Calls()[0].Args
+	c.Assert(args, gc.HasLen, 1)
+	c.Assert(args[0], gc.FitsTypeOf, caasunitprovisioner.Config{})
+	config := args[0].(caasunitprovisioner.Config)
+
+	c.Assert(config, jc.DeepEquals, caasunitprovisioner.Config{
+		ContainerBroker: &s.broker,
+	})
+}

--- a/worker/caasunitprovisioner/mock_test.go
+++ b/worker/caasunitprovisioner/mock_test.go
@@ -1,0 +1,87 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package caasunitprovisioner_test
+
+import (
+	"github.com/juju/testing"
+
+	"github.com/juju/juju/api/base"
+	"github.com/juju/juju/caas"
+	"github.com/juju/juju/core/life"
+	"github.com/juju/juju/watcher"
+	"github.com/juju/juju/watcher/watchertest"
+)
+
+type fakeAPICaller struct {
+	base.APICaller
+}
+
+type fakeBroker struct {
+	caas.Broker
+}
+
+type mockContainerBroker struct {
+	testing.Stub
+}
+
+type mockApplicationGetter struct {
+	testing.Stub
+	watcher *watchertest.MockStringsWatcher
+}
+
+func (m *mockApplicationGetter) WatchApplications() (watcher.StringsWatcher, error) {
+	m.MethodCall(m, "WatchApplications")
+	if err := m.NextErr(); err != nil {
+		return nil, err
+	}
+	return m.watcher, nil
+}
+
+type mockContainerSpecGetter struct {
+	testing.Stub
+	spec    string
+	watcher *watchertest.MockNotifyWatcher
+}
+
+func (m *mockContainerSpecGetter) ContainerSpec(entityName string) (string, error) {
+	m.MethodCall(m, "ContainerSpec", entityName)
+	if err := m.NextErr(); err != nil {
+		return "", err
+	}
+	return m.spec, nil
+}
+
+func (m *mockContainerSpecGetter) WatchContainerSpec(entityName string) (watcher.NotifyWatcher, error) {
+	m.MethodCall(m, "WatchContainerSpec", entityName)
+	if err := m.NextErr(); err != nil {
+		return nil, err
+	}
+	return m.watcher, nil
+}
+
+type mockLifeGetter struct {
+	testing.Stub
+	life life.Value
+}
+
+func (m *mockLifeGetter) Life(entityName string) (life.Value, error) {
+	m.MethodCall(m, "Life", entityName)
+	if err := m.NextErr(); err != nil {
+		return "", err
+	}
+	return m.life, nil
+}
+
+type mockUnitGetter struct {
+	testing.Stub
+	watcher *watchertest.MockStringsWatcher
+}
+
+func (m *mockUnitGetter) WatchApplicationUnits(application string) (watcher.StringsWatcher, error) {
+	m.MethodCall(m, "WatchApplicationUnits", application)
+	if err := m.NextErr(); err != nil {
+		return nil, err
+	}
+	return m.watcher, nil
+}

--- a/worker/caasunitprovisioner/package_test.go
+++ b/worker/caasunitprovisioner/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package caasunitprovisioner_test
+
+import (
+	stdtesting "testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func TestPackage(t *stdtesting.T) {
+	gc.TestingT(t)
+}

--- a/worker/caasunitprovisioner/unit_worker.go
+++ b/worker/caasunitprovisioner/unit_worker.go
@@ -1,0 +1,83 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package caasunitprovisioner
+
+import (
+	"github.com/juju/errors"
+	"github.com/kr/pretty"
+	"gopkg.in/juju/worker.v1"
+
+	"github.com/juju/juju/worker/catacomb"
+)
+
+type unitWorker struct {
+	catacomb            catacomb.Catacomb
+	unit                string
+	containerSpecGetter ContainerSpecGetter
+}
+
+func newUnitWorker(
+	unit string,
+	containerSpecGetter ContainerSpecGetter,
+) (worker.Worker, error) {
+	w := &unitWorker{
+		unit:                unit,
+		containerSpecGetter: containerSpecGetter,
+	}
+	if err := catacomb.Invoke(catacomb.Plan{
+		Site: &w.catacomb,
+		Work: w.loop,
+	}); err != nil {
+		return nil, errors.Trace(err)
+	}
+	return w, nil
+}
+
+// Kill is part of the worker.Worker interface.
+func (w *unitWorker) Kill() {
+	w.catacomb.Kill(nil)
+}
+
+// Wait is part of the worker.Worker interface.
+func (w *unitWorker) Wait() error {
+	return w.catacomb.Wait()
+}
+
+func (w *unitWorker) loop() error {
+	cw, err := w.containerSpecGetter.WatchContainerSpec(w.unit)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	w.catacomb.Add(cw)
+
+	// TODO(caas) -  this loop should also keep an eye on kubernetes and
+	// ensure that the unit pod stays up, redeploying it if the pod goes
+	// away. For some runtimes we *could* rely on the the runtime's
+	// features to do this.
+	for {
+		select {
+		case <-w.catacomb.Dying():
+			return w.catacomb.ErrDying()
+		case _, ok := <-cw.Changes():
+			if !ok {
+				return errors.New("watcher closed channel")
+			}
+			spec, err := w.containerSpecGetter.ContainerSpec(w.unit)
+			if errors.IsNotFound(err) {
+				// No container spec defined for this unit yet;
+				// wait for one to be set.
+				continue
+			}
+			if err != nil {
+				return errors.Trace(err)
+			}
+			// TODO(caas) create/update the unit container.
+			logger.Debugf(
+				"container spec for %s: %s",
+				w.unit,
+				pretty.Sprint(spec),
+			)
+		}
+	}
+}

--- a/worker/caasunitprovisioner/worker.go
+++ b/worker/caasunitprovisioner/worker.go
@@ -1,0 +1,126 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package caasunitprovisioner
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/loggo"
+	"gopkg.in/juju/worker.v1"
+
+	"github.com/juju/juju/core/life"
+	"github.com/juju/juju/worker/catacomb"
+)
+
+var logger = loggo.GetLogger("juju.workers.caasunitprovisioner")
+
+// Config holds configuration for the CAAS unit provisioner worker.
+type Config struct {
+	ApplicationGetter   ApplicationGetter
+	ContainerBroker     ContainerBroker
+	ContainerSpecGetter ContainerSpecGetter
+	LifeGetter          LifeGetter
+	UnitGetter          UnitGetter
+}
+
+// Validate validates the worker configuration.
+func (config Config) Validate() error {
+	if config.ApplicationGetter == nil {
+		return errors.NotValidf("missing ApplicationGetter")
+	}
+	if config.ContainerBroker == nil {
+		return errors.NotValidf("missing ContainerBroker")
+	}
+	if config.ContainerSpecGetter == nil {
+		return errors.NotValidf("missing ContainerSpecGetter")
+	}
+	if config.LifeGetter == nil {
+		return errors.NotValidf("missing LifeGetter")
+	}
+	if config.UnitGetter == nil {
+		return errors.NotValidf("missing UnitGetter")
+	}
+	return nil
+}
+
+// NewWorker starts and returns a new CAAS unit provisioner worker.
+func NewWorker(config Config) (worker.Worker, error) {
+	if err := config.Validate(); err != nil {
+		return nil, errors.Trace(err)
+	}
+	p := &provisioner{config: config}
+	err := catacomb.Invoke(catacomb.Plan{
+		Site: &p.catacomb,
+		Work: p.loop,
+	})
+	return p, err
+}
+
+type provisioner struct {
+	catacomb catacomb.Catacomb
+	config   Config
+}
+
+// Kill is part of the worker.Worker interface.
+func (p *provisioner) Kill() {
+	p.catacomb.Kill(nil)
+}
+
+// Wait is part of the worker.Worker interface.
+func (p *provisioner) Wait() error {
+	return p.catacomb.Wait()
+}
+
+func (p *provisioner) loop() error {
+	w, err := p.config.ApplicationGetter.WatchApplications()
+	if err != nil {
+		return errors.Trace(err)
+	}
+	if err := p.catacomb.Add(w); err != nil {
+		return errors.Trace(err)
+	}
+
+	appWorkers := make(map[string]worker.Worker)
+	for {
+		select {
+		case <-p.catacomb.Dying():
+			return p.catacomb.ErrDying()
+		case apps, ok := <-w.Changes():
+			if !ok {
+				return errors.New("watcher closed channel")
+			}
+			for _, appId := range apps {
+				appLife, err := p.config.LifeGetter.Life(appId)
+				if errors.IsNotFound(err) {
+					w, ok := appWorkers[appId]
+					if ok {
+						if err := worker.Stop(w); err != nil {
+							return errors.Trace(err)
+						}
+						delete(appWorkers, appId)
+					}
+					continue
+				}
+				if err != nil {
+					return errors.Trace(err)
+				}
+				if _, ok := appWorkers[appId]; ok || appLife == life.Dead {
+					// Already watching the application. or we're
+					// not yet watching it and it's dead.
+					continue
+				}
+				w, err := newApplicationWorker(
+					appId,
+					p.config.ContainerSpecGetter,
+					p.config.LifeGetter,
+					p.config.UnitGetter,
+				)
+				if err != nil {
+					return errors.Trace(err)
+				}
+				appWorkers[appId] = w
+				p.catacomb.Add(w)
+			}
+		}
+	}
+}

--- a/worker/caasunitprovisioner/worker_test.go
+++ b/worker/caasunitprovisioner/worker_test.go
@@ -1,0 +1,269 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package caasunitprovisioner_test
+
+import (
+	"time"
+
+	"github.com/juju/errors"
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/core/life"
+	coretesting "github.com/juju/juju/testing"
+	"github.com/juju/juju/watcher/watchertest"
+	"github.com/juju/juju/worker/caasunitprovisioner"
+	"github.com/juju/juju/worker/workertest"
+)
+
+type WorkerSuite struct {
+	testing.IsolationSuite
+
+	config              caasunitprovisioner.Config
+	applicationGetter   mockApplicationGetter
+	containerBroker     mockContainerBroker
+	containerSpecGetter mockContainerSpecGetter
+	lifeGetter          mockLifeGetter
+	unitGetter          mockUnitGetter
+
+	applicationChanges   chan []string
+	unitChanges          chan []string
+	containerSpecChanges chan struct{}
+}
+
+var _ = gc.Suite(&WorkerSuite{})
+
+func (s *WorkerSuite) SetUpTest(c *gc.C) {
+	s.IsolationSuite.SetUpTest(c)
+
+	s.applicationChanges = make(chan []string)
+	s.unitChanges = make(chan []string)
+	s.containerSpecChanges = make(chan struct{})
+
+	s.applicationGetter = mockApplicationGetter{
+		watcher: watchertest.NewMockStringsWatcher(s.applicationChanges),
+	}
+	s.AddCleanup(func(c *gc.C) { workertest.DirtyKill(c, s.applicationGetter.watcher) })
+
+	s.containerSpecGetter = mockContainerSpecGetter{
+		watcher: watchertest.NewMockNotifyWatcher(s.containerSpecChanges),
+	}
+	s.AddCleanup(func(c *gc.C) { workertest.DirtyKill(c, s.containerSpecGetter.watcher) })
+
+	s.unitGetter = mockUnitGetter{
+		watcher: watchertest.NewMockStringsWatcher(s.unitChanges),
+	}
+	s.AddCleanup(func(c *gc.C) { workertest.DirtyKill(c, s.unitGetter.watcher) })
+
+	s.containerBroker = mockContainerBroker{}
+	s.lifeGetter = mockLifeGetter{
+		life: life.Alive,
+	}
+
+	s.config = caasunitprovisioner.Config{
+		ApplicationGetter:   &s.applicationGetter,
+		ContainerBroker:     &s.containerBroker,
+		ContainerSpecGetter: &s.containerSpecGetter,
+		LifeGetter:          &s.lifeGetter,
+		UnitGetter:          &s.unitGetter,
+	}
+}
+
+func (s *WorkerSuite) TestValidateConfig(c *gc.C) {
+	s.testValidateConfig(c, func(config *caasunitprovisioner.Config) {
+		config.ApplicationGetter = nil
+	}, `missing ApplicationGetter not valid`)
+
+	s.testValidateConfig(c, func(config *caasunitprovisioner.Config) {
+		config.ContainerBroker = nil
+	}, `missing ContainerBroker not valid`)
+
+	s.testValidateConfig(c, func(config *caasunitprovisioner.Config) {
+		config.ContainerSpecGetter = nil
+	}, `missing ContainerSpecGetter not valid`)
+
+	s.testValidateConfig(c, func(config *caasunitprovisioner.Config) {
+		config.LifeGetter = nil
+	}, `missing LifeGetter not valid`)
+
+	s.testValidateConfig(c, func(config *caasunitprovisioner.Config) {
+		config.UnitGetter = nil
+	}, `missing UnitGetter not valid`)
+}
+
+func (s *WorkerSuite) testValidateConfig(c *gc.C, f func(*caasunitprovisioner.Config), expect string) {
+	config := s.config
+	f(&config)
+	w, err := caasunitprovisioner.NewWorker(config)
+	if err == nil {
+		workertest.DirtyKill(c, w)
+	}
+	c.Check(err, gc.ErrorMatches, expect)
+}
+
+func (s *WorkerSuite) TestStartStop(c *gc.C) {
+	w, err := caasunitprovisioner.NewWorker(s.config)
+	c.Assert(err, jc.ErrorIsNil)
+	workertest.CheckAlive(c, w)
+	workertest.CleanKill(c, w)
+}
+
+func (s *WorkerSuite) TestWatchContainerSpec(c *gc.C) {
+	w, err := caasunitprovisioner.NewWorker(s.config)
+	c.Assert(err, jc.ErrorIsNil)
+	defer workertest.CleanKill(c, w)
+
+	s.containerSpecGetter.SetErrors(nil, errors.NotFoundf("spec"))
+
+	select {
+	case s.applicationChanges <- []string{"gitlab"}:
+	case <-time.After(coretesting.LongWait):
+		c.Fatal("timed out sending applications change")
+	}
+
+	select {
+	case s.unitChanges <- []string{"gitlab/0"}:
+	case <-time.After(coretesting.LongWait):
+		c.Fatal("timed out sending units change")
+	}
+
+	select {
+	case s.containerSpecChanges <- struct{}{}:
+	case <-time.After(coretesting.LongWait):
+		c.Fatal("timed out sending container spec change")
+	}
+
+	// TODO(caas) when we have a container broker capable
+	// of provisioning unit containers, check that no unit
+	// is created yet (since there's not yet a spec).
+
+	workertest.CleanKill(c, w)
+	s.applicationGetter.CheckCallNames(c, "WatchApplications")
+	s.unitGetter.CheckCallNames(c, "WatchApplicationUnits")
+	s.unitGetter.CheckCall(c, 0, "WatchApplicationUnits", "gitlab")
+	s.containerSpecGetter.CheckCallNames(c, "WatchContainerSpec", "ContainerSpec")
+	s.containerSpecGetter.CheckCall(c, 0, "WatchContainerSpec", "gitlab/0")
+	s.containerSpecGetter.CheckCall(c, 1, "ContainerSpec", "gitlab/0")
+	s.lifeGetter.CheckCallNames(c, "Life", "Life")
+	s.lifeGetter.CheckCall(c, 0, "Life", "gitlab")
+	s.lifeGetter.CheckCall(c, 1, "Life", "gitlab/0")
+}
+
+func (s *WorkerSuite) TestWatchApplicationDead(c *gc.C) {
+	w, err := caasunitprovisioner.NewWorker(s.config)
+	c.Assert(err, jc.ErrorIsNil)
+	defer workertest.CleanKill(c, w)
+
+	s.lifeGetter.life = life.Dead
+	select {
+	case s.applicationChanges <- []string{"gitlab"}:
+	case <-time.After(coretesting.LongWait):
+		c.Fatal("timed out sending applications change")
+	}
+
+	select {
+	case s.unitChanges <- []string{"gitlab/0"}:
+		c.Fatal("unexpected watch for units")
+	case <-time.After(coretesting.ShortWait):
+	}
+
+	workertest.CleanKill(c, w)
+	s.unitGetter.CheckNoCalls(c)
+}
+
+func (s *WorkerSuite) TestWatchUnitDead(c *gc.C) {
+	w, err := caasunitprovisioner.NewWorker(s.config)
+	c.Assert(err, jc.ErrorIsNil)
+	defer workertest.CleanKill(c, w)
+
+	select {
+	case s.applicationChanges <- []string{"gitlab"}:
+	case <-time.After(coretesting.LongWait):
+		c.Fatal("timed out sending applications change")
+	}
+
+	s.lifeGetter.life = life.Dead
+	select {
+	case s.unitChanges <- []string{"gitlab/0"}:
+	case <-time.After(coretesting.LongWait):
+		c.Fatal("timed out sending units change")
+	}
+
+	workertest.CleanKill(c, w)
+	s.containerSpecGetter.CheckNoCalls(c)
+}
+
+func (s *WorkerSuite) TestRemoveApplicationStopsWatchingApplication(c *gc.C) {
+	w, err := caasunitprovisioner.NewWorker(s.config)
+	c.Assert(err, jc.ErrorIsNil)
+	defer workertest.CleanKill(c, w)
+
+	select {
+	case s.applicationChanges <- []string{"gitlab"}:
+	case <-time.After(coretesting.LongWait):
+		c.Fatal("timed out sending applications change")
+	}
+
+	s.lifeGetter.SetErrors(errors.NotFoundf("application"))
+	select {
+	case s.applicationChanges <- []string{"gitlab"}:
+	case <-time.After(coretesting.LongWait):
+		c.Fatal("timed out sending applications change")
+	}
+
+	workertest.CheckKilled(c, s.unitGetter.watcher)
+}
+
+func (s *WorkerSuite) TestRemoveUnitStopsWatchingContainerSpec(c *gc.C) {
+	w, err := caasunitprovisioner.NewWorker(s.config)
+	c.Assert(err, jc.ErrorIsNil)
+	defer workertest.CleanKill(c, w)
+
+	select {
+	case s.applicationChanges <- []string{"gitlab"}:
+	case <-time.After(coretesting.LongWait):
+		c.Fatal("timed out sending applications change")
+	}
+
+	select {
+	case s.unitChanges <- []string{"gitlab/0"}:
+	case <-time.After(coretesting.LongWait):
+		c.Fatal("timed out sending units change")
+	}
+
+	s.lifeGetter.SetErrors(errors.NotFoundf("unit"))
+	select {
+	case s.unitChanges <- []string{"gitlab/0"}:
+	case <-time.After(coretesting.LongWait):
+		c.Fatal("timed out sending units change")
+	}
+
+	workertest.CheckKilled(c, s.containerSpecGetter.watcher)
+}
+
+func (s *WorkerSuite) TestWatcherErrorStopsWorker(c *gc.C) {
+	w, err := caasunitprovisioner.NewWorker(s.config)
+	c.Assert(err, jc.ErrorIsNil)
+	defer workertest.DirtyKill(c, w)
+
+	select {
+	case s.applicationChanges <- []string{"gitlab"}:
+	case <-time.After(coretesting.LongWait):
+		c.Fatal("timed out sending applications change")
+	}
+
+	select {
+	case s.unitChanges <- []string{"gitlab/0"}:
+	case <-time.After(coretesting.LongWait):
+		c.Fatal("timed out sending units change")
+	}
+
+	s.containerSpecGetter.watcher.KillErr(errors.New("splat"))
+	workertest.CheckKilled(c, s.containerSpecGetter.watcher)
+	workertest.CheckKilled(c, s.unitGetter.watcher)
+	workertest.CheckKilled(c, s.applicationGetter.watcher)
+	err = workertest.CheckKilled(c, w)
+	c.Assert(err, gc.ErrorMatches, "splat")
+}


### PR DESCRIPTION
## Description of change

Add the CAAS unit provisioner worker.
The worker watches for units in the
model, and watches each unit's
container spec. Later we will call into
the CAAS broker to create or update
the container/pod given the spec.

There is currently no API or broker
implementation backing this, so it
cannot yet be wired up.

## QA steps

None - code is not yet wired up.

## Documentation changes

None.

## Bug reference

None.