### PR TITLE
Introduce CAASUnitProvisioner API facade/client

### DIFF
--- a/api/caasunitprovisioner/client.go
+++ b/api/caasunitprovisioner/client.go
@@ -1,0 +1,170 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package caasunitprovisioner
+
+import (
+	"github.com/juju/errors"
+	"gopkg.in/juju/names.v2"
+
+	"github.com/juju/juju/api/base"
+	apiwatcher "github.com/juju/juju/api/watcher"
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/core/life"
+	"github.com/juju/juju/watcher"
+)
+
+// Client allows access to the CAAS unit provisioner API endpoint.
+type Client struct {
+	facade base.FacadeCaller
+}
+
+// NewClient returns a client used to access the CAAS unit provisioner API.
+func NewClient(caller base.APICaller) *Client {
+	facadeCaller := base.NewFacadeCaller(caller, "CAASUnitProvisioner")
+	return &Client{
+		facade: facadeCaller,
+	}
+}
+
+func applicationTag(application string) (names.ApplicationTag, error) {
+	if !names.IsValidApplication(application) {
+		return names.ApplicationTag{}, errors.NotValidf("application name %q", application)
+	}
+	return names.NewApplicationTag(application), nil
+}
+
+func unitTag(unit string) (names.UnitTag, error) {
+	if !names.IsValidUnit(unit) {
+		return names.UnitTag{}, errors.NotValidf("unit name %q", unit)
+	}
+	return names.NewUnitTag(unit), nil
+}
+
+func entities(tags ...names.Tag) params.Entities {
+	entities := params.Entities{
+		Entities: make([]params.Entity, len(tags)),
+	}
+	for i, tag := range tags {
+		entities.Entities[i].Tag = tag.String()
+	}
+	return entities
+}
+
+// WatchApplications returns a StringsWatcher that notifies of
+// changes to the lifecycles of CAAS applications in the current model.
+func (c *Client) WatchApplications() (watcher.StringsWatcher, error) {
+	var result params.StringsWatchResult
+	if err := c.facade.FacadeCall("WatchApplications", nil, &result); err != nil {
+		return nil, err
+	}
+	if err := result.Error; err != nil {
+		return nil, result.Error
+	}
+	w := apiwatcher.NewStringsWatcher(c.facade.RawAPICaller(), result)
+	return w, nil
+}
+
+// WatchUnits returns a StringsWatcher that notifies of
+// changes to the lifecycles of units of the specified
+// CAAS application in the current model.
+func (c *Client) WatchUnits(application string) (watcher.StringsWatcher, error) {
+	applicationTag, err := applicationTag(application)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	args := entities(applicationTag)
+
+	var results params.StringsWatchResults
+	if err := c.facade.FacadeCall("WatchUnits", args, &results); err != nil {
+		return nil, err
+	}
+	if n := len(results.Results); n != 1 {
+		return nil, errors.Errorf("expected 1 result, got %d", n)
+	}
+	if err := results.Results[0].Error; err != nil {
+		return nil, errors.Trace(err)
+	}
+	w := apiwatcher.NewStringsWatcher(c.facade.RawAPICaller(), results.Results[0])
+	return w, nil
+}
+
+// WatchContainerSpec returns a NotifyWatcher that notifies of
+// changes to the container spec of the specified CAAS units in
+// the current model.
+func (c *Client) WatchContainerSpec(unit string) (watcher.NotifyWatcher, error) {
+	unitTag, err := unitTag(unit)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	args := entities(unitTag)
+
+	var results params.NotifyWatchResults
+	if err := c.facade.FacadeCall("WatchContainerSpec", args, &results); err != nil {
+		return nil, err
+	}
+	if n := len(results.Results); n != 1 {
+		return nil, errors.Errorf("expected 1 result, got %d", n)
+	}
+	if err := results.Results[0].Error; err != nil {
+		return nil, errors.Trace(err)
+	}
+	w := apiwatcher.NewNotifyWatcher(c.facade.RawAPICaller(), results.Results[0])
+	return w, nil
+}
+
+// ContainerSpec returns the container spec for the specified CAAS
+// unit in the current model.
+func (c *Client) ContainerSpec(unit string) (string, error) {
+	unitTag, err := unitTag(unit)
+	if err != nil {
+		return "", errors.Trace(err)
+	}
+	args := entities(unitTag)
+
+	var results params.StringResults
+	if err := c.facade.FacadeCall("ContainerSpec", args, &results); err != nil {
+		return "", err
+	}
+	if n := len(results.Results); n != 1 {
+		return "", errors.Errorf("expected 1 result, got %d", n)
+	}
+	if err := results.Results[0].Error; err != nil {
+		return "", maybeNotFound(err)
+	}
+	return results.Results[0].Result, nil
+}
+
+// Life returns the lifecycle state for the specified CAAS application
+// or unit in the current model.
+func (c *Client) Life(entityName string) (life.Value, error) {
+	var tag names.Tag
+	switch {
+	case names.IsValidApplication(entityName):
+		tag = names.NewApplicationTag(entityName)
+	case names.IsValidUnit(entityName):
+		tag = names.NewUnitTag(entityName)
+	default:
+		return "", errors.NotValidf("application or unit name %q", entityName)
+	}
+	args := entities(tag)
+
+	var results params.LifeResults
+	if err := c.facade.FacadeCall("Life", args, &results); err != nil {
+		return "", err
+	}
+	if n := len(results.Results); n != 1 {
+		return "", errors.Errorf("expected 1 result, got %d", n)
+	}
+	if err := results.Results[0].Error; err != nil {
+		return "", maybeNotFound(err)
+	}
+	return life.Value(results.Results[0].Life), nil
+}
+
+func maybeNotFound(err *params.Error) error {
+	if !params.IsCodeNotFound(err) {
+		return err
+	}
+	return errors.NewNotFound(err, "")
+}

--- a/api/caasunitprovisioner/client_test.go
+++ b/api/caasunitprovisioner/client_test.go
@@ -1,0 +1,205 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package caasunitprovisioner_test
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	names "gopkg.in/juju/names.v2"
+
+	basetesting "github.com/juju/juju/api/base/testing"
+	"github.com/juju/juju/api/caasunitprovisioner"
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/core/life"
+)
+
+type unitprovisionerSuite struct {
+	testing.IsolationSuite
+}
+
+var _ = gc.Suite(&unitprovisionerSuite{})
+
+func newClient(f basetesting.APICallerFunc) *caasunitprovisioner.Client {
+	return caasunitprovisioner.NewClient(basetesting.BestVersionCaller{f, 1})
+}
+
+func (s *unitprovisionerSuite) TestContainerSpec(c *gc.C) {
+	apiCaller := basetesting.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
+		c.Check(objType, gc.Equals, "CAASUnitProvisioner")
+		c.Check(version, gc.Equals, 0)
+		c.Check(id, gc.Equals, "")
+		c.Check(request, gc.Equals, "ContainerSpec")
+		c.Check(arg, jc.DeepEquals, params.Entities{
+			Entities: []params.Entity{{
+				Tag: "unit-gitlab-0",
+			}},
+		})
+		c.Assert(result, gc.FitsTypeOf, &params.StringResults{})
+		*(result.(*params.StringResults)) = params.StringResults{
+			Results: []params.StringResult{{
+				Result: "foo",
+			}},
+		}
+		return nil
+	})
+
+	client := caasunitprovisioner.NewClient(apiCaller)
+	spec, err := client.ContainerSpec("gitlab/0")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(spec, gc.Equals, "foo")
+}
+
+func (s *unitprovisionerSuite) TestContainerSpecError(c *gc.C) {
+	apiCaller := basetesting.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
+		*(result.(*params.StringResults)) = params.StringResults{
+			Results: []params.StringResult{{Error: &params.Error{
+				Code:    params.CodeNotFound,
+				Message: "bletch",
+			}}},
+		}
+		return nil
+	})
+
+	client := caasunitprovisioner.NewClient(apiCaller)
+	_, err := client.ContainerSpec("gitlab/0")
+	c.Assert(err, gc.ErrorMatches, "bletch")
+	c.Assert(err, jc.Satisfies, errors.IsNotFound)
+}
+
+func (s *unitprovisionerSuite) TestContainerSpecInvalidEntityame(c *gc.C) {
+	client := caasunitprovisioner.NewClient(basetesting.APICallerFunc(func(_ string, _ int, _, _ string, _, _ interface{}) error {
+		return errors.New("should not be called")
+	}))
+	_, err := client.ContainerSpec("gitlab")
+	c.Assert(err, gc.ErrorMatches, `unit name "gitlab" not valid`)
+}
+
+func (s *unitprovisionerSuite) TestLife(c *gc.C) {
+	s.testLife(c, names.NewApplicationTag("gitlab"))
+	s.testLife(c, names.NewUnitTag("gitlab/0"))
+}
+
+func (s *unitprovisionerSuite) testLife(c *gc.C, tag names.Tag) {
+	apiCaller := basetesting.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
+		c.Check(objType, gc.Equals, "CAASUnitProvisioner")
+		c.Check(version, gc.Equals, 0)
+		c.Check(id, gc.Equals, "")
+		c.Check(request, gc.Equals, "Life")
+		c.Check(arg, jc.DeepEquals, params.Entities{
+			Entities: []params.Entity{{
+				Tag: tag.String(),
+			}},
+		})
+		c.Assert(result, gc.FitsTypeOf, &params.LifeResults{})
+		*(result.(*params.LifeResults)) = params.LifeResults{
+			Results: []params.LifeResult{{
+				Life: params.Alive,
+			}},
+		}
+		return nil
+	})
+
+	client := caasunitprovisioner.NewClient(apiCaller)
+	lifeValue, err := client.Life(tag.Id())
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(lifeValue, gc.Equals, life.Alive)
+}
+
+func (s *unitprovisionerSuite) TestLifeError(c *gc.C) {
+	apiCaller := basetesting.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
+		*(result.(*params.LifeResults)) = params.LifeResults{
+			Results: []params.LifeResult{{Error: &params.Error{
+				Code:    params.CodeNotFound,
+				Message: "bletch",
+			}}},
+		}
+		return nil
+	})
+
+	client := caasunitprovisioner.NewClient(apiCaller)
+	_, err := client.Life("gitlab/0")
+	c.Assert(err, gc.ErrorMatches, "bletch")
+	c.Assert(err, jc.Satisfies, errors.IsNotFound)
+}
+
+func (s *unitprovisionerSuite) TestLifeInvalidEntityame(c *gc.C) {
+	client := caasunitprovisioner.NewClient(basetesting.APICallerFunc(func(_ string, _ int, _, _ string, _, _ interface{}) error {
+		return errors.New("should not be called")
+	}))
+	_, err := client.Life("")
+	c.Assert(err, gc.ErrorMatches, `application or unit name "" not valid`)
+}
+
+func (s *unitprovisionerSuite) TestWatchApplications(c *gc.C) {
+	apiCaller := basetesting.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
+		c.Check(objType, gc.Equals, "CAASUnitProvisioner")
+		c.Check(version, gc.Equals, 0)
+		c.Check(id, gc.Equals, "")
+		c.Check(request, gc.Equals, "WatchApplications")
+		c.Assert(result, gc.FitsTypeOf, &params.StringsWatchResult{})
+		*(result.(*params.StringsWatchResult)) = params.StringsWatchResult{
+			Error: &params.Error{Message: "FAIL"},
+		}
+		return nil
+	})
+
+	client := caasunitprovisioner.NewClient(apiCaller)
+	watcher, err := client.WatchApplications()
+	c.Assert(watcher, gc.IsNil)
+	c.Assert(err, gc.ErrorMatches, "FAIL")
+}
+
+func (s *unitprovisionerSuite) TestWatchUnits(c *gc.C) {
+	apiCaller := basetesting.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
+		c.Check(objType, gc.Equals, "CAASUnitProvisioner")
+		c.Check(version, gc.Equals, 0)
+		c.Check(id, gc.Equals, "")
+		c.Check(request, gc.Equals, "WatchUnits")
+		c.Assert(arg, jc.DeepEquals, params.Entities{
+			Entities: []params.Entity{{
+				Tag: "application-gitlab",
+			}},
+		})
+		c.Assert(result, gc.FitsTypeOf, &params.StringsWatchResults{})
+		*(result.(*params.StringsWatchResults)) = params.StringsWatchResults{
+			Results: []params.StringsWatchResult{{
+				Error: &params.Error{Message: "FAIL"},
+			}},
+		}
+		return nil
+	})
+
+	client := caasunitprovisioner.NewClient(apiCaller)
+	watcher, err := client.WatchUnits("gitlab")
+	c.Assert(watcher, gc.IsNil)
+	c.Assert(err, gc.ErrorMatches, "FAIL")
+}
+
+func (s *unitprovisionerSuite) TestWatchContainerSpec(c *gc.C) {
+	apiCaller := basetesting.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
+		c.Check(objType, gc.Equals, "CAASUnitProvisioner")
+		c.Check(version, gc.Equals, 0)
+		c.Check(id, gc.Equals, "")
+		c.Check(request, gc.Equals, "WatchContainerSpec")
+		c.Assert(arg, jc.DeepEquals, params.Entities{
+			Entities: []params.Entity{{
+				Tag: "unit-gitlab-0",
+			}},
+		})
+		c.Assert(result, gc.FitsTypeOf, &params.NotifyWatchResults{})
+		*(result.(*params.NotifyWatchResults)) = params.NotifyWatchResults{
+			Results: []params.NotifyWatchResult{{
+				Error: &params.Error{Message: "FAIL"},
+			}},
+		}
+		return nil
+	})
+
+	client := caasunitprovisioner.NewClient(apiCaller)
+	watcher, err := client.WatchContainerSpec("gitlab/0")
+	c.Assert(watcher, gc.IsNil)
+	c.Assert(err, gc.ErrorMatches, "FAIL")
+}

--- a/api/caasunitprovisioner/package_test.go
+++ b/api/caasunitprovisioner/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package caasunitprovisioner_test
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func TestAll(t *testing.T) {
+	gc.TestingT(t)
+}

--- a/api/facadeversions.go
+++ b/api/facadeversions.go
@@ -26,6 +26,7 @@ var facadeVersions = map[string]int{
 	"Bundle":                       1,
 	"CAASOperator":                 1,
 	"CAASOperatorProvisioner":      1,
+	"CAASUnitProvisioner":          1,
 	"CharmRevisionUpdater":         2,
 	"Charms":                       2,
 	"Cleaner":                      2,

--- a/apiserver/allfacades.go
+++ b/apiserver/allfacades.go
@@ -68,6 +68,7 @@ import (
 	"github.com/juju/juju/apiserver/facades/controller/agenttools"
 	"github.com/juju/juju/apiserver/facades/controller/applicationscaler"
 	"github.com/juju/juju/apiserver/facades/controller/caasoperatorprovisioner"
+	"github.com/juju/juju/apiserver/facades/controller/caasunitprovisioner"
 	"github.com/juju/juju/apiserver/facades/controller/charmrevisionupdater"
 	"github.com/juju/juju/apiserver/facades/controller/cleaner"
 	"github.com/juju/juju/apiserver/facades/controller/crosscontroller"
@@ -151,6 +152,7 @@ func AllFacades() *facade.Registry {
 		reg("Cloud", 2, cloud.NewFacadeV2)
 		reg("CAASOperator", 1, caasoperator.NewStateFacade)
 		reg("CAASOperatorProvisioner", 1, caasoperatorprovisioner.NewStateCAASOperatorProvisionerAPI)
+		reg("CAASUnitProvisioner", 1, caasunitprovisioner.NewStateFacade)
 	}
 
 	reg("Controller", 3, controller.NewControllerAPIv3)

--- a/apiserver/facades/controller/caasunitprovisioner/mock_test.go
+++ b/apiserver/facades/controller/caasunitprovisioner/mock_test.go
@@ -1,0 +1,113 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package caasunitprovisioner_test
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/testing"
+	"gopkg.in/juju/names.v2"
+
+	"github.com/juju/juju/apiserver/facades/controller/caasunitprovisioner"
+	"github.com/juju/juju/state"
+	statetesting "github.com/juju/juju/state/testing"
+)
+
+type mockState struct {
+	testing.Stub
+	application         mockApplication
+	applicationsWatcher *statetesting.MockStringsWatcher
+	model               mockModel
+	unit                mockUnit
+}
+
+func (st *mockState) WatchApplications() state.StringsWatcher {
+	st.MethodCall(st, "WatchApplications")
+	return st.applicationsWatcher
+}
+
+func (st *mockState) Application(name string) (caasunitprovisioner.Application, error) {
+	st.MethodCall(st, "Application", name)
+	if err := st.NextErr(); err != nil {
+		return nil, err
+	}
+	return &st.application, nil
+}
+
+func (st *mockState) FindEntity(tag names.Tag) (state.Entity, error) {
+	st.MethodCall(st, "FindEntity", tag)
+	if err := st.NextErr(); err != nil {
+		return nil, err
+	}
+	switch tag.(type) {
+	case names.ApplicationTag:
+		return &st.application, nil
+	case names.UnitTag:
+		return &st.unit, nil
+	default:
+		return nil, errors.NotFoundf("%s", names.ReadableString(tag))
+	}
+}
+
+func (st *mockState) Model() (caasunitprovisioner.Model, error) {
+	st.MethodCall(st, "Model")
+	if err := st.NextErr(); err != nil {
+		return nil, err
+	}
+	return &st.model, nil
+}
+
+type mockModel struct {
+	testing.Stub
+	containerSpecWatcher *statetesting.MockNotifyWatcher
+}
+
+func (m *mockModel) ContainerSpec(tag names.Tag) (string, error) {
+	m.MethodCall(m, "ContainerSpec", tag)
+	if err := m.NextErr(); err != nil {
+		return "", err
+	}
+	return "spec(" + tag.Id() + ")", nil
+}
+
+func (m *mockModel) WatchContainerSpec(tag names.Tag) (state.NotifyWatcher, error) {
+	m.MethodCall(m, "WatchContainerSpec", tag)
+	if err := m.NextErr(); err != nil {
+		return nil, err
+	}
+	return m.containerSpecWatcher, nil
+}
+
+type mockApplication struct {
+	testing.Stub
+	life         state.Life
+	unitsWatcher *statetesting.MockStringsWatcher
+}
+
+func (*mockApplication) Tag() names.Tag {
+	panic("should not be called")
+}
+
+func (a *mockApplication) Life() state.Life {
+	a.MethodCall(a, "Life")
+	return a.life
+}
+
+func (a *mockApplication) WatchUnits() state.StringsWatcher {
+	a.MethodCall(a, "WatchUnits")
+	return a.unitsWatcher
+}
+
+type mockUnit struct {
+	testing.Stub
+	life state.Life
+}
+
+func (*mockUnit) Tag() names.Tag {
+	panic("should not be called")
+}
+
+func (u *mockUnit) Life() state.Life {
+	u.MethodCall(u, "Life")
+	return u.life
+}

--- a/apiserver/facades/controller/caasunitprovisioner/package_test.go
+++ b/apiserver/facades/controller/caasunitprovisioner/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package caasunitprovisioner_test
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func TestAll(t *testing.T) {
+	gc.TestingT(t)
+}

--- a/apiserver/facades/controller/caasunitprovisioner/provisioner.go
+++ b/apiserver/facades/controller/caasunitprovisioner/provisioner.go
@@ -1,0 +1,164 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package caasunitprovisioner
+
+import (
+	"github.com/juju/errors"
+	"gopkg.in/juju/names.v2"
+
+	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/facade"
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/state/watcher"
+)
+
+type Facade struct {
+	*common.LifeGetter
+	resources facade.Resources
+	state     CAASUnitProvisionerState
+}
+
+// NewStateFacade provides the signature required for facade registration.
+func NewStateFacade(ctx facade.Context) (*Facade, error) {
+	authorizer := ctx.Auth()
+	resources := ctx.Resources()
+	return NewFacade(
+		resources,
+		authorizer,
+		stateShim{ctx.State()},
+	)
+}
+
+// NewFacade returns a new CAAS unit provisioner Facade facade.
+func NewFacade(
+	resources facade.Resources,
+	authorizer facade.Authorizer,
+	st CAASUnitProvisionerState,
+) (*Facade, error) {
+	if !authorizer.AuthController() {
+		return nil, common.ErrPerm
+	}
+	return &Facade{
+		LifeGetter: common.NewLifeGetter(
+			st, common.AuthAny(
+				common.AuthFuncForTagKind(names.ApplicationTagKind),
+				common.AuthFuncForTagKind(names.UnitTagKind),
+			),
+		),
+		resources: resources,
+		state:     st,
+	}, nil
+}
+
+// WatchApplications starts a StringsWatcher to watch CAAS applications
+// deployed to this model.
+func (f *Facade) WatchApplications() (params.StringsWatchResult, error) {
+	watch := f.state.WatchApplications()
+	if changes, ok := <-watch.Changes(); ok {
+		return params.StringsWatchResult{
+			StringsWatcherId: f.resources.Register(watch),
+			Changes:          changes,
+		}, nil
+	}
+	return params.StringsWatchResult{}, watcher.EnsureErr(watch)
+}
+
+// WatchUnits starts a StringsWatcher to watch changes to the
+// lifecycle states of units for the specified applications in
+// this model.
+func (f *Facade) WatchUnits(args params.Entities) (params.StringsWatchResults, error) {
+	results := params.StringsWatchResults{
+		Results: make([]params.StringsWatchResult, len(args.Entities)),
+	}
+	for i, arg := range args.Entities {
+		id, changes, err := f.watchUnits(arg.Tag)
+		if err != nil {
+			results.Results[i].Error = common.ServerError(err)
+			continue
+		}
+		results.Results[i].StringsWatcherId = id
+		results.Results[i].Changes = changes
+	}
+	return results, nil
+}
+
+func (f *Facade) watchUnits(tagString string) (string, []string, error) {
+	tag, err := names.ParseApplicationTag(tagString)
+	if err != nil {
+		return "", nil, errors.Trace(err)
+	}
+	app, err := f.state.Application(tag.Id())
+	if err != nil {
+		return "", nil, errors.Trace(err)
+	}
+	w := app.WatchUnits()
+	if changes, ok := <-w.Changes(); ok {
+		return f.resources.Register(w), changes, nil
+	}
+	return "", nil, watcher.EnsureErr(w)
+}
+
+// WatchContainerSpec starts a NotifyWatcher to watch changes to the
+// container spec for specified units in this model.
+func (f *Facade) WatchContainerSpec(args params.Entities) (params.NotifyWatchResults, error) {
+	model, err := f.state.Model()
+	if err != nil {
+		return params.NotifyWatchResults{}, errors.Trace(err)
+	}
+	results := params.NotifyWatchResults{
+		Results: make([]params.NotifyWatchResult, len(args.Entities)),
+	}
+	for i, arg := range args.Entities {
+		id, err := f.watchContainerSpec(model, arg.Tag)
+		if err != nil {
+			results.Results[i].Error = common.ServerError(err)
+			continue
+		}
+		results.Results[i].NotifyWatcherId = id
+	}
+	return results, nil
+}
+
+func (f *Facade) watchContainerSpec(model Model, tagString string) (string, error) {
+	tag, err := names.ParseUnitTag(tagString)
+	if err != nil {
+		return "", errors.Trace(err)
+	}
+	w, err := model.WatchContainerSpec(tag)
+	if err != nil {
+		return "", errors.Trace(err)
+	}
+	if _, ok := <-w.Changes(); ok {
+		return f.resources.Register(w), nil
+	}
+	return "", watcher.EnsureErr(w)
+}
+
+// ContainerSpec returns the container spec for specified units in this model.
+func (f *Facade) ContainerSpec(args params.Entities) (params.StringResults, error) {
+	model, err := f.state.Model()
+	if err != nil {
+		return params.StringResults{}, errors.Trace(err)
+	}
+	results := params.StringResults{
+		Results: make([]params.StringResult, len(args.Entities)),
+	}
+	for i, arg := range args.Entities {
+		spec, err := f.containerSpec(model, arg.Tag)
+		if err != nil {
+			results.Results[i].Error = common.ServerError(err)
+			continue
+		}
+		results.Results[i].Result = spec
+	}
+	return results, nil
+}
+
+func (f *Facade) containerSpec(model Model, tagString string) (string, error) {
+	tag, err := names.ParseUnitTag(tagString)
+	if err != nil {
+		return "", errors.Trace(err)
+	}
+	return model.ContainerSpec(tag)
+}

--- a/apiserver/facades/controller/caasunitprovisioner/provisioner_test.go
+++ b/apiserver/facades/controller/caasunitprovisioner/provisioner_test.go
@@ -1,0 +1,174 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package caasunitprovisioner_test
+
+import (
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/names.v2"
+
+	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/facades/controller/caasunitprovisioner"
+	"github.com/juju/juju/apiserver/params"
+	apiservertesting "github.com/juju/juju/apiserver/testing"
+	"github.com/juju/juju/state"
+	statetesting "github.com/juju/juju/state/testing"
+	coretesting "github.com/juju/juju/testing"
+	"github.com/juju/juju/worker/workertest"
+)
+
+var _ = gc.Suite(&CAASProvisionerSuite{})
+
+type CAASProvisionerSuite struct {
+	coretesting.BaseSuite
+
+	st                   *mockState
+	applicationsChanges  chan []string
+	containerSpecChanges chan struct{}
+	unitsChanges         chan []string
+
+	resources  *common.Resources
+	authorizer *apiservertesting.FakeAuthorizer
+	facade     *caasunitprovisioner.Facade
+}
+
+func (s *CAASProvisionerSuite) SetUpTest(c *gc.C) {
+	s.BaseSuite.SetUpTest(c)
+
+	s.applicationsChanges = make(chan []string, 1)
+	s.containerSpecChanges = make(chan struct{}, 1)
+	s.unitsChanges = make(chan []string, 1)
+	s.st = &mockState{
+		application: mockApplication{
+			life:         state.Alive,
+			unitsWatcher: statetesting.NewMockStringsWatcher(s.unitsChanges),
+		},
+		applicationsWatcher: statetesting.NewMockStringsWatcher(s.applicationsChanges),
+		model: mockModel{
+			containerSpecWatcher: statetesting.NewMockNotifyWatcher(s.containerSpecChanges),
+		},
+		unit: mockUnit{
+			life: state.Dying,
+		},
+	}
+	s.AddCleanup(func(c *gc.C) { workertest.DirtyKill(c, s.st.applicationsWatcher) })
+	s.AddCleanup(func(c *gc.C) { workertest.DirtyKill(c, s.st.application.unitsWatcher) })
+	s.AddCleanup(func(c *gc.C) { workertest.DirtyKill(c, s.st.model.containerSpecWatcher) })
+
+	s.resources = common.NewResources()
+	s.authorizer = &apiservertesting.FakeAuthorizer{
+		Tag:        names.NewMachineTag("0"),
+		Controller: true,
+	}
+
+	facade, err := caasunitprovisioner.NewFacade(s.resources, s.authorizer, s.st)
+	c.Assert(err, jc.ErrorIsNil)
+	s.facade = facade
+}
+
+func (s *CAASProvisionerSuite) TestPermission(c *gc.C) {
+	s.authorizer = &apiservertesting.FakeAuthorizer{
+		Tag: names.NewMachineTag("0"),
+	}
+	_, err := caasunitprovisioner.NewFacade(s.resources, s.authorizer, s.st)
+	c.Assert(err, gc.ErrorMatches, "permission denied")
+}
+
+func (s *CAASProvisionerSuite) TestWatchApplications(c *gc.C) {
+	applicationNames := []string{"db2", "hadoop"}
+	s.applicationsChanges <- applicationNames
+	result, err := s.facade.WatchApplications()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result.Error, gc.IsNil)
+	c.Assert(result.StringsWatcherId, gc.Equals, "1")
+	c.Assert(result.Changes, jc.DeepEquals, applicationNames)
+
+	resource := s.resources.Get("1")
+	c.Assert(resource, gc.Equals, s.st.applicationsWatcher)
+}
+
+func (s *CAASProvisionerSuite) TestWatchContainerSpec(c *gc.C) {
+	s.containerSpecChanges <- struct{}{}
+
+	results, err := s.facade.WatchContainerSpec(params.Entities{
+		Entities: []params.Entity{
+			{Tag: "unit-gitlab-0"},
+			{Tag: "application-gitlab"},
+		},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(results.Results, gc.HasLen, 2)
+	c.Assert(results.Results[0].Error, gc.IsNil)
+	c.Assert(results.Results[1].Error, jc.DeepEquals, &params.Error{
+		Message: `"application-gitlab" is not a valid unit tag`,
+	})
+
+	c.Assert(results.Results[0].NotifyWatcherId, gc.Equals, "1")
+	resource := s.resources.Get("1")
+	c.Assert(resource, gc.Equals, s.st.model.containerSpecWatcher)
+}
+
+func (s *CAASProvisionerSuite) TestWatchUnits(c *gc.C) {
+	s.unitsChanges <- []string{"gitlab/0", "gitlab/1"}
+
+	results, err := s.facade.WatchUnits(params.Entities{
+		Entities: []params.Entity{
+			{Tag: "application-gitlab"},
+			{Tag: "unit-gitlab-0"},
+		},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(results.Results, gc.HasLen, 2)
+	c.Assert(results.Results[0].Error, gc.IsNil)
+	c.Assert(results.Results[1].Error, jc.DeepEquals, &params.Error{
+		Message: `"unit-gitlab-0" is not a valid application tag`,
+	})
+
+	c.Assert(results.Results[0].StringsWatcherId, gc.Equals, "1")
+	c.Assert(results.Results[0].Changes, jc.DeepEquals, []string{"gitlab/0", "gitlab/1"})
+	resource := s.resources.Get("1")
+	c.Assert(resource, gc.Equals, s.st.application.unitsWatcher)
+}
+
+func (s *CAASProvisionerSuite) TestContainerSpec(c *gc.C) {
+	results, err := s.facade.ContainerSpec(params.Entities{
+		Entities: []params.Entity{
+			{Tag: "unit-gitlab-0"},
+			{Tag: "application-gitlab"},
+		},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(results, jc.DeepEquals, params.StringResults{
+		Results: []params.StringResult{{
+			Result: "spec(gitlab/0)",
+		}, {
+			Error: &params.Error{
+				Message: `"application-gitlab" is not a valid unit tag`,
+			},
+		}},
+	})
+}
+
+func (s *CAASProvisionerSuite) TestLife(c *gc.C) {
+	results, err := s.facade.Life(params.Entities{
+		Entities: []params.Entity{
+			{Tag: "unit-gitlab-0"},
+			{Tag: "application-gitlab"},
+			{Tag: "machine-0"},
+		},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(results, jc.DeepEquals, params.LifeResults{
+		Results: []params.LifeResult{{
+			Life: params.Dying,
+		}, {
+			Life: params.Alive,
+		}, {
+			Error: &params.Error{
+				Code:    "unauthorized access",
+				Message: "permission denied",
+			},
+		}},
+	})
+}

--- a/apiserver/facades/controller/caasunitprovisioner/state.go
+++ b/apiserver/facades/controller/caasunitprovisioner/state.go
@@ -1,0 +1,52 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package caasunitprovisioner
+
+import (
+	"gopkg.in/juju/names.v2"
+
+	"github.com/juju/juju/state"
+)
+
+// CAASUnitProvisionerState provides the subset of global state
+// required by the CAAS operator facade.
+type CAASUnitProvisionerState interface {
+	Application(string) (Application, error)
+	FindEntity(names.Tag) (state.Entity, error)
+	Model() (Model, error)
+	WatchApplications() state.StringsWatcher
+}
+
+// Model provides the subset of CAAS model state required
+// by the CAAS operator facade.
+type Model interface {
+	ContainerSpec(names.Tag) (string, error)
+	WatchContainerSpec(names.Tag) (state.NotifyWatcher, error)
+}
+
+// Application provides the subset of application state
+// required by the CAAS operator facade.
+type Application interface {
+	WatchUnits() state.StringsWatcher
+}
+
+type stateShim struct {
+	*state.State
+}
+
+func (s stateShim) Application(id string) (Application, error) {
+	app, err := s.State.Application(id)
+	if err != nil {
+		return nil, err
+	}
+	return app, nil
+}
+
+func (s stateShim) Model() (Model, error) {
+	model, err := s.State.Model()
+	if err != nil {
+		return nil, err
+	}
+	return model.CAASModel()
+}

--- a/apiserver/restrict_caasmodel.go
+++ b/apiserver/restrict_caasmodel.go
@@ -43,6 +43,7 @@ var commonModelFacadeNames = set.NewStrings(
 var caasModelFacadeNames = set.NewStrings(
 	"CAASOperator",
 	"CAASOperatorProvisioner",
+	"CAASUnitProvisioner",
 )
 
 func caasModelFacadesOnly(facadeName, _ string) error {

--- a/state/testing/watcher.go
+++ b/state/testing/watcher.go
@@ -349,3 +349,40 @@ func (w *MockNotifyWatcher) Err() error {
 func (w *MockNotifyWatcher) Wait() error {
 	return w.tomb.Wait()
 }
+
+// MockStringsWatcher implements state.StringsWatcher.
+type MockStringsWatcher struct {
+	tomb tomb.Tomb
+	ch   <-chan []string
+}
+
+func NewMockStringsWatcher(ch <-chan []string) *MockStringsWatcher {
+	w := &MockStringsWatcher{ch: ch}
+	go func() {
+		defer w.tomb.Done()
+		<-w.tomb.Dying()
+		w.tomb.Kill(tomb.ErrDying)
+	}()
+	return w
+}
+
+func (w *MockStringsWatcher) Changes() <-chan []string {
+	return w.ch
+}
+
+func (w *MockStringsWatcher) Stop() error {
+	w.Kill()
+	return w.Wait()
+}
+
+func (w *MockStringsWatcher) Kill() {
+	w.tomb.Kill(nil)
+}
+
+func (w *MockStringsWatcher) Err() error {
+	return w.tomb.Err()
+}
+
+func (w *MockStringsWatcher) Wait() error {
+	return w.tomb.Wait()
+}

--- a/worker/caasunitprovisioner/application_worker.go
+++ b/worker/caasunitprovisioner/application_worker.go
@@ -51,7 +51,7 @@ func (w *applicationWorker) Wait() error {
 }
 
 func (aw *applicationWorker) loop() error {
-	uw, err := aw.unitGetter.WatchApplicationUnits(aw.application)
+	uw, err := aw.unitGetter.WatchUnits(aw.application)
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/worker/caasunitprovisioner/client.go
+++ b/worker/caasunitprovisioner/client.go
@@ -45,5 +45,5 @@ type LifeGetter interface {
 // of a specified application's units, and fetching
 // their details.
 type UnitGetter interface {
-	WatchApplicationUnits(string) (watcher.StringsWatcher, error)
+	WatchUnits(string) (watcher.StringsWatcher, error)
 }

--- a/worker/caasunitprovisioner/mock_test.go
+++ b/worker/caasunitprovisioner/mock_test.go
@@ -78,8 +78,8 @@ type mockUnitGetter struct {
 	watcher *watchertest.MockStringsWatcher
 }
 
-func (m *mockUnitGetter) WatchApplicationUnits(application string) (watcher.StringsWatcher, error) {
-	m.MethodCall(m, "WatchApplicationUnits", application)
+func (m *mockUnitGetter) WatchUnits(application string) (watcher.StringsWatcher, error) {
+	m.MethodCall(m, "WatchUnits", application)
 	if err := m.NextErr(); err != nil {
 		return nil, err
 	}

--- a/worker/caasunitprovisioner/mock_test.go
+++ b/worker/caasunitprovisioner/mock_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/watcher"
 	"github.com/juju/juju/watcher/watchertest"
+	"github.com/juju/juju/worker/caasunitprovisioner"
 )
 
 type fakeAPICaller struct {
@@ -19,6 +20,10 @@ type fakeAPICaller struct {
 
 type fakeBroker struct {
 	caas.Broker
+}
+
+type fakeClient struct {
+	caasunitprovisioner.Client
 }
 
 type mockContainerBroker struct {

--- a/worker/caasunitprovisioner/worker_test.go
+++ b/worker/caasunitprovisioner/worker_test.go
@@ -141,8 +141,8 @@ func (s *WorkerSuite) TestWatchContainerSpec(c *gc.C) {
 
 	workertest.CleanKill(c, w)
 	s.applicationGetter.CheckCallNames(c, "WatchApplications")
-	s.unitGetter.CheckCallNames(c, "WatchApplicationUnits")
-	s.unitGetter.CheckCall(c, 0, "WatchApplicationUnits", "gitlab")
+	s.unitGetter.CheckCallNames(c, "WatchUnits")
+	s.unitGetter.CheckCall(c, 0, "WatchUnits", "gitlab")
 	s.containerSpecGetter.CheckCallNames(c, "WatchContainerSpec", "ContainerSpec")
 	s.containerSpecGetter.CheckCall(c, 0, "WatchContainerSpec", "gitlab/0")
 	s.containerSpecGetter.CheckCall(c, 1, "ContainerSpec", "gitlab/0")


### PR DESCRIPTION
## Description of change

Introduce the CAASUnitProvisioner API facade and client.

Update the caasunprovisioner worker's manifold config to accept a method for constructing a client, and rename the WatchApplicationUnits method to WatchUnits. The worker's Client interface is implemented by the API client, but it is not yet wired up.

## QA steps

None -- not yet wired up.

## Documentation changes

None.

## Bug reference

None.