### PR TITLE
Implement operator facade apis used to make the hook context

### DIFF
--- a/api/caasoperator/client.go
+++ b/api/caasoperator/client.go
@@ -5,6 +5,7 @@ package caasoperator
 
 import (
 	"github.com/juju/errors"
+	"github.com/juju/utils/proxy"
 	"gopkg.in/juju/charm.v6"
 	"gopkg.in/juju/names.v2"
 
@@ -157,4 +158,38 @@ func (c *Client) SetContainerSpec(entityName string, spec string) error {
 		return errors.Trace(err)
 	}
 	return result.OneError()
+}
+
+// APIAddresses returns the list of addresses used to connect to the API.
+func (c *Client) APIAddresses() ([]string, error) {
+	var result params.StringsResult
+	err := c.facade.FacadeCall("APIAddresses", nil, &result)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := result.Error; err != nil {
+		return nil, err
+	}
+	return result.Result, nil
+}
+
+// ProxySettings returns the proxy settings for the model.
+func (c *Client) ProxySettings() (proxy.Settings, error) {
+	var results params.ProxyConfig
+	err := c.facade.FacadeCall("ProxyConfig", nil, &results)
+	if err != nil {
+		return proxy.Settings{}, err
+	}
+	proxySettings := proxySettingsParamToProxySettings(results)
+	return proxySettings, nil
+}
+
+func proxySettingsParamToProxySettings(cfg params.ProxyConfig) proxy.Settings {
+	return proxy.Settings{
+		Http:    cfg.HTTP,
+		Https:   cfg.HTTPS,
+		Ftp:     cfg.FTP,
+		NoProxy: cfg.NoProxy,
+	}
 }

--- a/apiserver/facades/agent/caasoperator/operator.go
+++ b/apiserver/facades/agent/caasoperator/operator.go
@@ -5,11 +5,13 @@ package caasoperator
 
 import (
 	"github.com/juju/errors"
+	"github.com/juju/utils/proxy"
 	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/network"
 	"github.com/juju/juju/state/watcher"
 	"github.com/juju/juju/status"
 )
@@ -53,6 +55,57 @@ func NewFacade(
 // ModelName returns the name of the model.
 func (f *Facade) ModelName() (params.StringResult, error) {
 	return params.StringResult{Result: f.model.Name()}, nil
+}
+
+// APIAddresses returns the API addresses of the controller.
+func (f *Facade) APIAddresses() (params.StringsResult, error) {
+	addrs, err := apiAddresses(f.state)
+	if err != nil {
+		return params.StringsResult{}, err
+	}
+	return params.StringsResult{
+		Result: addrs,
+	}, nil
+}
+
+func apiAddresses(getter CAASOperatorState) ([]string, error) {
+	apiHostPorts, err := getter.APIHostPorts()
+	if err != nil {
+		return nil, err
+	}
+	var addrs = make([]string, 0, len(apiHostPorts))
+	for _, hostPorts := range apiHostPorts {
+		ordered := network.PrioritizeInternalHostPorts(hostPorts, false)
+		for _, addr := range ordered {
+			if addr != "" {
+				addrs = append(addrs, addr)
+			}
+		}
+	}
+	return addrs, nil
+}
+
+// ProxyConfig returns the proxy config for the current model.
+func (f *Facade) ProxyConfig() (params.ProxyConfig, error) {
+	var result params.ProxyConfig
+	cfg, err := f.model.Config()
+	if err != nil {
+		return result, err
+	}
+
+	proxySettings := cfg.ProxySettings()
+	result = proxyUtilsSettingsToProxySettingsParam(proxySettings)
+	return result, nil
+
+}
+
+func proxyUtilsSettingsToProxySettingsParam(settings proxy.Settings) params.ProxyConfig {
+	return params.ProxyConfig{
+		HTTP:    settings.Http,
+		HTTPS:   settings.Https,
+		FTP:     settings.Ftp,
+		NoProxy: settings.FullNoProxy(),
+	}
 }
 
 // SetStatus sets the status of each given entity.

--- a/apiserver/facades/agent/caasoperator/operator_test.go
+++ b/apiserver/facades/agent/caasoperator/operator_test.go
@@ -240,3 +240,18 @@ func (s *CAASOperatorSuite) TestModelName(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.Result, gc.Equals, "some-model")
 }
+
+func (s *CAASOperatorSuite) TestAPIAddresses(c *gc.C) {
+	result, err := s.facade.APIAddresses()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result.Result, gc.DeepEquals, []string{"0.1.2.3:1234", "0.1.2.4:1234", "0.1.2.5:1234"})
+}
+
+func (s *CAASOperatorSuite) TestProxyConfig(c *gc.C) {
+	result, err := s.facade.ProxyConfig()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result, gc.DeepEquals, params.ProxyConfig{
+		HTTP:    "http.proxy",
+		NoProxy: "127.0.0.1,::1,localhost",
+	})
+}

--- a/apiserver/facades/agent/caasoperator/state.go
+++ b/apiserver/facades/agent/caasoperator/state.go
@@ -7,6 +7,8 @@ import (
 	"gopkg.in/juju/charm.v6"
 	"gopkg.in/juju/names.v2"
 
+	"github.com/juju/juju/environs/config"
+	"github.com/juju/juju/network"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/status"
 )
@@ -16,6 +18,7 @@ import (
 type CAASOperatorState interface {
 	Application(string) (Application, error)
 	Model() (Model, error)
+	APIHostPorts() ([][]network.HostPort, error)
 }
 
 // Model provides the subset of CAAS model state required
@@ -23,6 +26,7 @@ type CAASOperatorState interface {
 type Model interface {
 	SetContainerSpec(names.Tag, string) error
 	Name() string
+	Config() (*config.Config, error)
 }
 
 // Application provides the subset of application state

--- a/worker/caasoperator/caasoperator.go
+++ b/worker/caasoperator/caasoperator.go
@@ -92,6 +92,14 @@ type Config struct {
 	// StatusSetter is an interface used for setting the
 	// application status.
 	StatusSetter StatusSetter
+
+	// APIAddressGetter is an interface for getting the
+	// controller API addresses.
+	APIAddressGetter APIAddressGetter
+
+	// ProxySettingsGetter is an interface for getting the
+	// model proxy settings.
+	ProxySettingsGetter ProxySettingsGetter
 }
 
 func (config Config) Validate() error {
@@ -118,6 +126,12 @@ func (config Config) Validate() error {
 	}
 	if config.StatusSetter == nil {
 		return errors.NotValidf("missing StatusSetter")
+	}
+	if config.APIAddressGetter == nil {
+		return errors.NotValidf("missing APIAddressGetter")
+	}
+	if config.ProxySettingsGetter == nil {
+		return errors.NotValidf("missing ProxySettingsGetter")
 	}
 	return nil
 }
@@ -197,8 +211,10 @@ func (op *caasOperator) init() (err error) {
 	}
 
 	contextFactory, err := context.NewContextFactory(context.FactoryConfig{
-		// TODO(caas)
-		ContextFactoryAPI: &dummyContextFactoryAPI{},
+		ContextFactoryAPI: &contextFactoryAPIAdaptor{
+			APIAddressGetter:    op.config.APIAddressGetter,
+			ProxySettingsGetter: op.config.ProxySettingsGetter,
+		},
 		HookAPI: &hookAPIAdaptor{
 			appName:                 op.config.Application,
 			StatusSetter:            op.config.StatusSetter,

--- a/worker/caasoperator/caasoperator_test.go
+++ b/worker/caasoperator/caasoperator_test.go
@@ -74,6 +74,8 @@ func (s *WorkerSuite) SetUpTest(c *gc.C) {
 		DataDir:                 c.MkDir(),
 		Downloader:              &s.charmDownloader,
 		StatusSetter:            &s.client,
+		APIAddressGetter:        &s.client,
+		ProxySettingsGetter:     &s.client,
 	}
 
 	agentBinaryDir := agenttools.ToolsDir(s.config.DataDir, "application-gitlab")
@@ -113,6 +115,12 @@ func (s *WorkerSuite) TestValidateConfig(c *gc.C) {
 	s.testValidateConfig(c, func(config *caasoperator.Config) {
 		config.StatusSetter = nil
 	}, `missing StatusSetter not valid`)
+	s.testValidateConfig(c, func(config *caasoperator.Config) {
+		config.APIAddressGetter = nil
+	}, `missing APIAddressGetter not valid`)
+	s.testValidateConfig(c, func(config *caasoperator.Config) {
+		config.ProxySettingsGetter = nil
+	}, `missing ProxySettingsGetter not valid`)
 }
 
 func (s *WorkerSuite) testValidateConfig(c *gc.C, f func(*caasoperator.Config), expect string) {
@@ -133,11 +141,15 @@ func (s *WorkerSuite) TestStartStop(c *gc.C) {
 }
 
 func (s *WorkerSuite) TestWorkerDownloadsCharm(c *gc.C) {
+	ctx := &hookObserver{}
+	s.config.NewRunnerFactoryFunc = newRunnerFactoryFunc(ctx)
 	w, err := caasoperator.NewWorker(s.config)
 	c.Assert(err, jc.ErrorIsNil)
 	defer workertest.CleanKill(c, w)
 
 	s.settingsChanges <- struct{}{}
+	ctx.waitForHooks(c, []string{"config-changed"})
+
 	s.client.CheckCallNames(c, "Charm", "SetStatus", "WatchApplicationConfig", "ApplicationConfig")
 	s.client.CheckCall(c, 0, "Charm", "gitlab")
 

--- a/worker/caasoperator/client.go
+++ b/worker/caasoperator/client.go
@@ -20,6 +20,8 @@ type Client interface {
 	CharmGetter
 	ContainerSpecSetter
 	StatusSetter
+	APIAddressGetter
+	ProxySettingsGetter
 	ModelName() (string, error)
 }
 
@@ -49,6 +51,18 @@ type StatusSetter interface {
 	) error
 }
 
+// APIAddressGetter provides an interface for getting
+// the API addresses of the controller(s).
+type APIAddressGetter interface {
+	APIAddresses() ([]string, error)
+}
+
+// ProxySettingsGetter provides an interface for getting
+// the proxy settings of the model.
+type ProxySettingsGetter interface {
+	ProxySettings() (proxy.Settings, error)
+}
+
 // ApplicationConfigGetter provides an interface for
 // watching and getting the application's config settings.
 type ApplicationConfigGetter interface {
@@ -57,6 +71,11 @@ type ApplicationConfigGetter interface {
 }
 
 // TODO(caas) - split this up
+type contextFactoryAPIAdaptor struct {
+	APIAddressGetter
+	ProxySettingsGetter
+}
+
 type hookAPIAdaptor struct {
 	StatusSetter
 	ApplicationConfigGetter
@@ -84,15 +103,4 @@ func (h *dummyHookAPI) ApplicationStatus() (params.ApplicationStatusResult, erro
 
 func (h *dummyHookAPI) NetworkInfo(bindings []string, relId *int) (map[string]params.NetworkInfoResult, error) {
 	return make(map[string]params.NetworkInfoResult), nil
-}
-
-// TODO(caas) implement this API
-type dummyContextFactoryAPI struct{}
-
-func (c *dummyContextFactoryAPI) APIAddresses() ([]string, error) {
-	return []string{}, nil
-}
-
-func (c *dummyContextFactoryAPI) ProxySettings() (proxy.Settings, error) {
-	return proxy.Settings{}, nil
 }

--- a/worker/caasoperator/manifold.go
+++ b/worker/caasoperator/manifold.go
@@ -104,6 +104,8 @@ func Manifold(config ManifoldConfig) dependency.Manifold {
 				DataDir:                 agentConfig.DataDir(),
 				Downloader:              downloader,
 				StatusSetter:            client,
+				APIAddressGetter:        client,
+				ProxySettingsGetter:     client,
 			})
 			if err != nil {
 				return nil, errors.Trace(err)

--- a/worker/caasoperator/manifold_test.go
+++ b/worker/caasoperator/manifold_test.go
@@ -135,6 +135,8 @@ func (s *ManifoldSuite) TestStart(c *gc.C) {
 		ContainerSpecSetter:     &s.client,
 		Downloader:              &s.charmDownloader,
 		StatusSetter:            &s.client,
+		APIAddressGetter:        &s.client,
+		ProxySettingsGetter:     &s.client,
 	})
 }
 

--- a/worker/caasoperator/mock_test.go
+++ b/worker/caasoperator/mock_test.go
@@ -5,6 +5,7 @@ package caasoperator_test
 
 import (
 	"github.com/juju/testing"
+	"github.com/juju/utils/proxy"
 	"gopkg.in/juju/charm.v6"
 	"gopkg.in/juju/names.v2"
 
@@ -98,6 +99,22 @@ func (c *fakeClient) WatchApplicationConfig(application string) (watcher.NotifyW
 		return nil, err
 	}
 	return c.settingsWatcher, nil
+}
+
+func (c *fakeClient) APIAddresses() ([]string, error) {
+	c.MethodCall(c, "APIAddresses", nil)
+	if err := c.NextErr(); err != nil {
+		return nil, err
+	}
+	return []string{"10.0.0.1:10000"}, nil
+}
+
+func (c *fakeClient) ProxySettings() (proxy.Settings, error) {
+	c.MethodCall(c, "ProxySettings", nil)
+	if err := c.NextErr(); err != nil {
+		return proxy.Settings{}, err
+	}
+	return proxy.Settings{Http: "http.proxy"}, nil
 }
 
 func (c *fakeClient) ModelName() (string, error) {


### PR DESCRIPTION
## Description of change

Add the caas operator facade APIs used to make a context factory and wire them up.

## QA steps

smoketest a caas deployment

