### PR TITLE
Wire up CAAS unit provisioner

### DIFF
--- a/caas/broker.go
+++ b/caas/broker.go
@@ -8,15 +8,14 @@ import "github.com/juju/juju/environs"
 // NewContainerBrokerFunc returns a Container Broker.
 type NewContainerBrokerFunc func(environs.CloudSpec) (Broker, error)
 
-// NewOperatorConfigFunc functions return the agent config to use for
-// a CAAS jujud operator.
-type NewOperatorConfigFunc func() (*OperatorConfig, error)
-
 // Broker instances interact with the CAAS substrate.
 type Broker interface {
-	// EnsureOperator creates an operator for running a charm for the specified application.
-	// If the operator exists, this does nothing.
-	EnsureOperator(appName, agentPath string, newConfig NewOperatorConfigFunc) error
+	// EnsureOperator creates or updates an operator pod for running
+	// a charm for the specified application.
+	EnsureOperator(appName, agentPath string, config *OperatorConfig) error
+
+	// EnsureUnit creates or updates a pod with the given spec.
+	EnsureUnit(unitName, spec string) error
 }
 
 // OperatorConfig is the config to use when creating an operator.

--- a/cmd/jujud/agent/model/manifolds.go
+++ b/cmd/jujud/agent/model/manifolds.go
@@ -13,6 +13,8 @@ import (
 
 	coreagent "github.com/juju/juju/agent"
 	"github.com/juju/juju/api"
+	"github.com/juju/juju/api/base"
+	caasunitprovisionerapi "github.com/juju/juju/api/caasunitprovisioner"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/caas"
 	"github.com/juju/juju/cmd/jujud/agent/engine"
@@ -26,6 +28,7 @@ import (
 	"github.com/juju/juju/worker/caasbroker"
 	"github.com/juju/juju/worker/caasmodelupgrader"
 	"github.com/juju/juju/worker/caasoperatorprovisioner"
+	"github.com/juju/juju/worker/caasunitprovisioner"
 	"github.com/juju/juju/worker/charmrevision"
 	"github.com/juju/juju/worker/charmrevision/charmrevisionmanifold"
 	"github.com/juju/juju/worker/cleaner"
@@ -402,6 +405,16 @@ func CAASManifolds(config ManifoldsConfig) dependency.Manifolds {
 				NewWorker:     caasoperatorprovisioner.NewProvisionerWorker,
 			},
 		)),
+		caasUnitProvisionerName: ifNotMigrating(caasunitprovisioner.Manifold(
+			caasunitprovisioner.ManifoldConfig{
+				APICallerName: apiCallerName,
+				BrokerName:    caasBrokerTrackerName,
+				NewClient: func(caller base.APICaller) caasunitprovisioner.Client {
+					return caasunitprovisionerapi.NewClient(caller)
+				},
+				NewWorker: caasunitprovisioner.NewWorker,
+			},
+		)),
 		modelUpgraderName: caasmodelupgrader.Manifold(caasmodelupgrader.ManifoldConfig{
 			APICallerName: apiCallerName,
 			GateName:      modelUpgradeGateName,
@@ -522,5 +535,6 @@ const (
 	logForwarderName         = "log-forwarder"
 
 	caasOperatorProvisionerName = "caas-operator-provisioner"
+	caasUnitProvisionerName     = "caas-unit-provisioner"
 	caasBrokerTrackerName       = "caas-broker-tracker"
 )

--- a/cmd/jujud/agent/model/manifolds_test.go
+++ b/cmd/jujud/agent/model/manifolds_test.go
@@ -80,6 +80,7 @@ func (s *ManifoldsSuite) TestCAASNames(c *gc.C) {
 		"api-config-watcher",
 		"caas-broker-tracker",
 		"caas-operator-provisioner",
+		"caas-unit-provisioner",
 		"charm-revision-updater",
 		"clock",
 		"is-responsible-flag",

--- a/worker/caasoperator/commands/container-spec-set.go
+++ b/worker/caasoperator/commands/container-spec-set.go
@@ -58,7 +58,7 @@ func (c *ContainerspecSetCommand) Run(ctx *cmd.Context) error {
 	if err != nil {
 		return errors.Trace(err)
 	}
-	return c.ctx.SetContainerSpec(specData, c.unitName)
+	return c.ctx.SetContainerSpec(c.unitName, specData)
 }
 
 func (c *ContainerspecSetCommand) handleSpecFile(ctx *cmd.Context) (string, error) {

--- a/worker/caasoperator/commands/util_test.go
+++ b/worker/caasoperator/commands/util_test.go
@@ -72,8 +72,8 @@ func (m *mockHookContext) ApplicationConfig() (charm.Settings, error) {
 	return settingsCopy, nil
 }
 
-func (m *mockHookContext) SetContainerSpec(specYaml, unitName string) error {
-	m.containerSpec = specYaml
+func (m *mockHookContext) SetContainerSpec(unitName, spec string) error {
+	m.containerSpec = spec
 	m.containerSpecUnit = unitName
 	return nil
 }

--- a/worker/caasoperator/runner/context/context.go
+++ b/worker/caasoperator/runner/context/context.go
@@ -269,7 +269,12 @@ func (ctx *HookContext) NetworkInfo(bindingNames []string, relationId int) (map[
 	return ctx.hookAPI.NetworkInfo(bindingNames, relId)
 }
 
-// SetContainerSpec updates the yaml spec used to create a container.
-func (ctx *HookContext) SetContainerSpec(specYaml, unitName string) error {
-	return ctx.hookAPI.SetContainerSpec(specYaml, unitName)
+// SetContainerSpec updates the container spec for the specified unit. If no
+// unit name is specified, then the container spec is set for the application.
+func (ctx *HookContext) SetContainerSpec(unitName, spec string) error {
+	entityName := unitName
+	if entityName == "" {
+		entityName = ctx.applicationName
+	}
+	return ctx.hookAPI.SetContainerSpec(entityName, spec)
 }

--- a/worker/caasoperator/runner/context/context_test.go
+++ b/worker/caasoperator/runner/context/context_test.go
@@ -130,8 +130,16 @@ func (s *InterfaceSuite) TestConfigCaching(c *gc.C) {
 
 func (s *InterfaceSuite) TestSetContainerSpec(c *gc.C) {
 	ctx := s.GetContext(c, -1, "")
-	err := ctx.SetContainerSpec("yaml", "unit")
+	err := ctx.SetContainerSpec("gitlab/0", "spec")
 	c.Check(err, jc.ErrorIsNil)
-	c.Assert(s.contextAPI.SpecYaml, gc.Equals, "yaml")
-	c.Assert(s.contextAPI.SpecUnitName, gc.Equals, "unit")
+	c.Assert(s.contextAPI.Spec, gc.Equals, "spec")
+	c.Assert(s.contextAPI.SpecEntityName, gc.Equals, "gitlab/0")
+}
+
+func (s *InterfaceSuite) TestSetContainerSpecApplication(c *gc.C) {
+	ctx := s.GetContext(c, -1, "")
+	err := ctx.SetContainerSpec("", "spec")
+	c.Check(err, jc.ErrorIsNil)
+	c.Assert(s.contextAPI.Spec, gc.Equals, "spec")
+	c.Assert(s.contextAPI.SpecEntityName, gc.Equals, "gitlab")
 }

--- a/worker/caasoperator/runner/runnertesting/mock.go
+++ b/worker/caasoperator/runner/runnertesting/mock.go
@@ -24,8 +24,8 @@ type MockContextAPI struct {
 	settings       proxy.Settings
 	appStatus      status.StatusInfo
 	configSettings charm.Settings
-	SpecYaml       string
-	SpecUnitName   string
+	Spec           string
+	SpecEntityName string
 }
 
 func (m *MockContextAPI) APIAddresses() ([]string, error) {
@@ -70,9 +70,9 @@ func (m *MockContextAPI) SetApplicationStatus(s status.Status, info string, data
 	return nil
 }
 
-func (m *MockContextAPI) SetContainerSpec(specYaml, unitName string) error {
-	m.SpecYaml = specYaml
-	m.SpecUnitName = unitName
+func (m *MockContextAPI) SetContainerSpec(entityName, spec string) error {
+	m.Spec = spec
+	m.SpecEntityName = entityName
 	return nil
 }
 

--- a/worker/caasoperatorprovisioner/mock_test.go
+++ b/worker/caasoperatorprovisioner/mock_test.go
@@ -84,18 +84,16 @@ func (m *mockAgentConfig) APIAddresses() ([]string, error) {
 }
 
 type mockBroker struct {
+	caas.Broker
+
 	appName   string
 	agentPath string
 	config    *caas.OperatorConfig
 }
 
-func (m *mockBroker) EnsureOperator(appName, agentPath string, newConfig caas.NewOperatorConfigFunc) error {
+func (m *mockBroker) EnsureOperator(appName, agentPath string, config *caas.OperatorConfig) error {
 	m.appName = appName
 	m.agentPath = agentPath
-	config, err := newConfig()
-	if err != nil {
-		return err
-	}
 	m.config = config
 	return nil
 }

--- a/worker/caasunitprovisioner/application_worker.go
+++ b/worker/caasunitprovisioner/application_worker.go
@@ -14,6 +14,7 @@ import (
 type applicationWorker struct {
 	catacomb            catacomb.Catacomb
 	application         string
+	broker              ContainerBroker
 	containerSpecGetter ContainerSpecGetter
 	lifeGetter          LifeGetter
 	unitGetter          UnitGetter
@@ -21,12 +22,14 @@ type applicationWorker struct {
 
 func newApplicationWorker(
 	application string,
+	broker ContainerBroker,
 	containerSpecGetter ContainerSpecGetter,
 	lifeGetter LifeGetter,
 	unitGetter UnitGetter,
 ) (worker.Worker, error) {
 	w := &applicationWorker{
 		application:         application,
+		broker:              broker,
 		containerSpecGetter: containerSpecGetter,
 		lifeGetter:          lifeGetter,
 		unitGetter:          unitGetter,
@@ -86,7 +89,7 @@ func (aw *applicationWorker) loop() error {
 					// not yet watching it and it's dead.
 					continue
 				}
-				w, err := newUnitWorker(unitId, aw.containerSpecGetter)
+				w, err := newUnitWorker(unitId, aw.broker, aw.containerSpecGetter)
 				if err != nil {
 					return errors.Trace(err)
 				}

--- a/worker/caasunitprovisioner/broker.go
+++ b/worker/caasunitprovisioner/broker.go
@@ -4,7 +4,5 @@
 package caasunitprovisioner
 
 type ContainerBroker interface {
-	// TODO(caas) update the caas.Broker type with a method
-	// for creating/updating a unit container, and expose
-	// it here.
+	EnsureUnit(unitName, spec string) error
 }

--- a/worker/caasunitprovisioner/mock_test.go
+++ b/worker/caasunitprovisioner/mock_test.go
@@ -28,6 +28,13 @@ type fakeClient struct {
 
 type mockContainerBroker struct {
 	testing.Stub
+	ensured chan<- struct{}
+}
+
+func (m *mockContainerBroker) EnsureUnit(unitName, spec string) error {
+	m.MethodCall(m, "EnsureUnit", unitName, spec)
+	m.ensured <- struct{}{}
+	return m.NextErr()
 }
 
 type mockApplicationGetter struct {

--- a/worker/caasunitprovisioner/worker.go
+++ b/worker/caasunitprovisioner/worker.go
@@ -111,6 +111,7 @@ func (p *provisioner) loop() error {
 				}
 				w, err := newApplicationWorker(
 					appId,
+					p.config.ContainerBroker,
 					p.config.ContainerSpecGetter,
 					p.config.LifeGetter,
 					p.config.UnitGetter,


### PR DESCRIPTION
## Description of change

Wire the CAAS unit provisioner into the manifolds. Update the CAAS broker interface with a method for creating unit pods, and implement it for k8s; call it in the provisioner.

## QA steps

None - cannot yet create CAAS units.

## Documentation changes

None.

## Bug reference

None.