### PR TITLE
Added a pre/post-deploy steps to budle deploy for metric registration.

### DIFF
--- a/cmd/juju/application/deploy.go
+++ b/cmd/juju/application/deploy.go
@@ -508,6 +508,7 @@ type DeploymentInfo struct {
 	ApplicationName string
 	ModelUUID       string
 	CharmInfo       *apicharms.CharmInfo
+	ApplicationPlan string
 }
 
 func (c *DeployCommand) Info() *cmd.Info {
@@ -640,7 +641,47 @@ func (c *DeployCommand) deployBundle(
 	channel params.Channel,
 	apiRoot DeployAPI,
 	bundleStorage map[string]map[string]storage.Constraints,
-) error {
+) (rErr error) {
+	bakeryClient, err := c.BakeryClient()
+	if err != nil {
+		return errors.Trace(err)
+	}
+	modelUUID, ok := apiRoot.ModelUUID()
+	if !ok {
+		return errors.New("API connection is controller-only (should never happen)")
+	}
+
+	for application, applicationSpec := range data.Applications {
+		if applicationSpec.Plan != "" {
+			for _, step := range c.Steps {
+				s := step
+				charmURL, err := charm.ParseURL(applicationSpec.Charm)
+				if err != nil {
+					return errors.Trace(err)
+				}
+
+				deployInfo := DeploymentInfo{
+					CharmID:         charmstore.CharmID{URL: charmURL},
+					ApplicationName: application,
+					ApplicationPlan: applicationSpec.Plan,
+					ModelUUID:       modelUUID,
+				}
+
+				err = s.RunPre(apiRoot, bakeryClient, ctx, deployInfo)
+				if err != nil {
+					return errors.Trace(err)
+				}
+
+				defer func() {
+					err = errors.Trace(s.RunPost(apiRoot, bakeryClient, ctx, deployInfo, rErr))
+					if err != nil {
+						rErr = err
+					}
+				}()
+			}
+		}
+	}
+
 	// TODO(ericsnow) Do something with the CS macaroons that were returned?
 	if _, err := deployBundle(
 		filePath,

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -86,7 +86,6 @@ github.com/vmware/govmomi	git	17b8c9ccb7f8c7b015d44c4ea39305c970a7bf31	2017-09-0
 golang.org/x/crypto	git	96846453c37f0876340a66a47f3f75b1f3a6cd2d	2017-04-21T04:31:20Z
 golang.org/x/net	git	ea47fc708ee3e20177f3ca3716217c4ab75942cb	2015-08-29T23:03:18Z
 golang.org/x/oauth2	git	11c60b6f71a6ad48ed6f93c65fa4c6f9b1b5b46a	2015-03-25T02:00:22Z
-golang.org/x/sync	git	f52d1811a62927559de87708c8913c1650ce4f26	2017-05-17T21:12:32Z
 golang.org/x/sys	git	7a6e5648d140666db5d920909e082ca00a87ba2c	2017-02-01T05:12:45Z
 golang.org/x/text	git	2910a502d2bf9e43193af9d68ca516529614eed3	2016-07-26T16:48:57Z
 google.golang.org/api	git	ed10e890a8366167a7ce33fac2b12447987bcb1c	2017-08-17T20:34:27Z
@@ -97,7 +96,7 @@ gopkg.in/errgo.v1	git	442357a80af5c6bf9b6d51ae791a39c3421004f3	2016-12-22T12:58:
 gopkg.in/goose.v2	git	7eb5c96ccec1c7617badcb4098313bdb90e654bf	2017-10-31T22:15:48Z
 gopkg.in/ini.v1	git	776aa739ce9373377cd16f526cdf06cb4c89b40f	2016-02-22T23:24:41Z
 gopkg.in/juju/blobstore.v2	git	51fa6e26128d74e445c72d3a91af555151cc3654	2016-01-25T02:37:03Z
-gopkg.in/juju/charm.v6	git	d93cf8b75cf4017ace4b3bf6af3bd03003e11cfa	2017-11-14T08:46:58Z
+gopkg.in/juju/charm.v6	git	b0ec23ec519f5151ea29e1a1f3108baeee4e6314	2017-12-05T12:18:46Z
 gopkg.in/juju/charm.v6-unstable	git	514bb811b021ebeb3e7ffcf1c267e9803968f59d	2017-07-28T19:41:00Z
 gopkg.in/juju/charmrepo.v2	git	653bbd81990d2d7d48e0fb931a3b0f52c694572f	2017-11-14T18:40:45Z
 gopkg.in/juju/charmrepo.v2-unstable	git	e79aa298df89ea887c9bffec46063c24bfb730f7	2016-11-17T15:25:28Z

--- a/testcharms/charm-repo/bundle/wordpress-with-plans/README.md
+++ b/testcharms/charm-repo/bundle/wordpress-with-plans/README.md
@@ -1,0 +1,1 @@
+A dummy bundle

--- a/testcharms/charm-repo/bundle/wordpress-with-plans/bundle.yaml
+++ b/testcharms/charm-repo/bundle/wordpress-with-plans/bundle.yaml
@@ -1,0 +1,11 @@
+services:
+    wordpress:
+        charm: wordpress
+        num_units: 1
+        plan: "default"
+    mysql:
+        charm: mysql
+        num_units: 1
+        plan: "test/plan"
+relations:
+    - ["wordpress:db", "mysql:server"]


### PR DESCRIPTION
## Description of change

With the latest changes to the bundle file format, authors are able to specify the plans under which individual applications are to be deployed.

Why is this change needed?

To improve the UX of bundle deployment for bundles that
contain charms that must be deployed under a specific plan.

## QA steps

1) set up charms and plans
2) create a bundle that specifies a plan for at least one application
3) deploy the bundle
4) verify that charms were deployed under specified plans

## Documentation changes

Need to add docs to describe changes in the bundle format.

## Bug reference

N/A