### PR TITLE
Add cloudinit-userdata key to model-config.

### DIFF
--- a/environs/config/config.go
+++ b/environs/config/config.go
@@ -20,6 +20,7 @@ import (
 	"gopkg.in/juju/charmrepo.v2"
 	"gopkg.in/juju/environschema.v1"
 	"gopkg.in/juju/names.v2"
+	"gopkg.in/yaml.v2"
 
 	"github.com/juju/juju/controller"
 	"github.com/juju/juju/environs/tags"
@@ -175,6 +176,10 @@ const (
 
 	// FanConfig defines the configuration for FAN network running in the model.
 	FanConfig = "fan-config"
+
+	// CloudInitUserDataKey is the key to specify cloud-init yaml the user wants to add
+	// into the cloud-config data produced by Juju when provisioning machines.
+	CloudInitUserDataKey = "cloudinit-userdata"
 
 	//
 	// Deprecated Settings Attributes
@@ -382,6 +387,7 @@ var defaultConfigValues = map[string]interface{}{
 	UpdateStatusHookInterval:   DefaultUpdateStatusHookInterval,
 	EgressSubnets:              "",
 	FanConfig:                  "",
+	CloudInitUserDataKey:       "",
 
 	// Image and agent streams and URLs.
 	"image-stream":       "released",
@@ -595,6 +601,34 @@ func Validate(cfg, old *Config) error {
 			return fmt.Errorf("Invalid value for container-networking-method - %v", v)
 		}
 	}
+
+	if raw, ok := cfg.defined[CloudInitUserDataKey].(string); ok && raw != "" {
+		userDataMap := make(map[string]interface{})
+		if err := yaml.Unmarshal([]byte(raw), &userDataMap); err != nil {
+			return errors.Annotate(err, "cloudinit-userdata: must be valid YAML")
+		}
+
+		// if there packages, ensure they are strings
+		if packages, ok := userDataMap["packages"].([]interface{}); ok {
+			for _, v := range packages {
+				checker := schema.String()
+				if _, err := checker.Coerce(v, nil); err != nil {
+					return errors.Annotate(err, "cloudinit-userdata: packages must be a list of strings")
+				}
+			}
+		}
+
+		// error if users is specified
+		if _, ok := userDataMap["users"]; ok {
+			return errors.New("cloudinit-userdata: users not allowed")
+		}
+
+		// error if runcmd is specified
+		if _, ok := userDataMap["runcmd"]; ok {
+			return errors.New("cloudinit-userdata: runcmd not allowed, use preruncmd or postruncmd instead")
+		}
+	}
+
 	// Check the immutable config values.  These can't change
 	if old != nil {
 		for _, attr := range immutableAttributes {
@@ -1095,6 +1129,18 @@ func (c *Config) FanConfig() (network.FanConfig, error) {
 	return network.ParseFanConfig(c.asString(FanConfig))
 }
 
+// CloudInitUserData returns a copy of the raw user data attributes
+// that were specified by the user.
+func (c *Config) CloudInitUserData() map[string]interface{} {
+	raw := c.asString(CloudInitUserDataKey)
+	if raw == "" {
+		return map[string]interface{}{}
+	}
+	userDataMap := make(map[string]interface{})
+	yaml.Unmarshal([]byte(raw), &userDataMap)
+	return userDataMap
+}
+
 // UnknownAttrs returns a copy of the raw configuration attributes
 // that are supposedly specific to the environment type. They could
 // also be wrong attributes, though. Only the specific environment
@@ -1209,6 +1255,7 @@ var alwaysOptional = schema.Defaults{
 	UpdateStatusHookInterval:     schema.Omit,
 	EgressSubnets:                schema.Omit,
 	FanConfig:                    schema.Omit,
+	CloudInitUserDataKey:         schema.Omit,
 }
 
 func allowEmpty(attr string) bool {
@@ -1631,6 +1678,11 @@ data of the store. (default false)`,
 	},
 	FanConfig: {
 		Description: "Configuration for fan networking for this model",
+		Type:        environschema.Tstring,
+		Group:       environschema.EnvironGroup,
+	},
+	CloudInitUserDataKey: {
+		Description: "Cloud-init user-data (in yaml format) to be added to userdata for new machines created in this model",
 		Type:        environschema.Tstring,
 		Group:       environschema.EnvironGroup,
 	},

--- a/environs/config/config_test.go
+++ b/environs/config/config_test.go
@@ -840,6 +840,65 @@ func (s *ConfigSuite) TestValidateChange(c *gc.C) {
 	}
 }
 
+type configValidateCloudInitUserDataTest struct {
+	about string
+	value string
+	err   string
+}
+
+var configValidateCloudInitUserDataTests = []configValidateCloudInitUserDataTest{
+	{
+		about: "Valid cloud init user data values",
+		value: validCloudInitUserData,
+	}, {
+		about: "Invalid cloud init user data values: package int",
+		value: invalidCloudInitUserDataPackageInt,
+		err:   `cloudinit-userdata: packages must be a list of strings: expected string, got int\(76\)`,
+	}, {
+		about: "Invalid cloud init user data values: users",
+		value: invalidCloudInitUserDataUsers,
+		err:   `cloudinit-userdata: users not allowed`,
+	}, {
+		about: "Invalid cloud init user data values: runcmd",
+		value: invalidCloudInitUserDataRuncmd,
+		err:   `cloudinit-userdata: runcmd not allowed, use preruncmd or postruncmd instead`,
+	}, {
+		about: "Invalid cloud init user data: yaml",
+		value: invalidCloudInitUserDataInvalidYAML,
+		err:   `cloudinit-userdata: must be valid YAML: yaml: line 2: did not find expected '-' indicator`,
+	},
+}
+
+func (s *ConfigSuite) TestValidateCloudInitUserData(c *gc.C) {
+	files := []gitjujutesting.TestFile{
+		{".ssh/id_dsa.pub", "dsa"},
+		{".ssh/id_rsa.pub", "rsa\n"},
+		{".ssh/identity.pub", "identity"},
+		{".ssh/authorized_keys", "auth0\n# first\nauth1\n\n"},
+		{".ssh/authorized_keys2", "auth2\nauth3\n"},
+	}
+	s.FakeHomeSuite.Home.AddFiles(c, files...)
+	for i, test := range configValidateCloudInitUserDataTests {
+		c.Logf("test %d. %s", i, test.about)
+		test.checkNew(c)
+	}
+}
+
+func (test configValidateCloudInitUserDataTest) checkNew(c *gc.C) {
+	final := testing.Attrs{
+		"type": "my-type", "name": "my-name",
+		"uuid": testing.ModelTag.Id(),
+		config.CloudInitUserDataKey: test.value,
+	}
+
+	_, err := config.New(config.UseDefaults, final)
+	if test.err != "" {
+		c.Assert(err, gc.ErrorMatches, test.err)
+		return
+	}
+	c.Assert(err, jc.ErrorIsNil)
+}
+
 func (s *ConfigSuite) addJujuFiles(c *gc.C) {
 	s.FakeHomeSuite.Home.AddFiles(c, []gitjujutesting.TestFile{
 		{".ssh/id_rsa.pub", "rsa\n"},
@@ -1131,6 +1190,18 @@ func (s *ConfigSuite) TestEgressSubnets(c *gc.C) {
 	c.Assert(cfg.EgressSubnets(), gc.DeepEquals, []string{"10.0.0.1/32", "192.168.1.1/16"})
 }
 
+func (s *ConfigSuite) TestCloudInitUserDataFromEnvironment(c *gc.C) {
+	cfg := newTestConfig(c, testing.Attrs{
+		config.CloudInitUserDataKey: validCloudInitUserData,
+	})
+	c.Assert(cfg.CloudInitUserData(), gc.DeepEquals, map[string]interface{}{
+		"packages":        []interface{}{"python-keystoneclient", "python-glanceclient"},
+		"preruncmd":       []interface{}{"mkdir /tmp/preruncmd", "mkdir /tmp/preruncmd2"},
+		"postruncmd":      []interface{}{"mkdir /tmp/postruncmd", "mkdir /tmp/postruncmd2"},
+		"package_upgrade": false},
+	)
+}
+
 func (s *ConfigSuite) TestSchemaNoExtra(c *gc.C) {
 	schema, err := config.Schema(nil)
 	c.Assert(err, gc.IsNil)
@@ -1243,3 +1314,46 @@ var invalidCACert = `
 MIIBOgIBAAJAZabKgKInuOxj5vDWLwHHQtK3/45KB+32D15w94Nt83BmuGxo90lw
 -----END CERTIFICATE-----
 `[1:]
+
+var validCloudInitUserData = `packages:
+  - 'python-keystoneclient'
+  - 'python-glanceclient'
+preruncmd:
+  - mkdir /tmp/preruncmd
+  - mkdir /tmp/preruncmd2
+postruncmd:
+  - mkdir /tmp/postruncmd
+  - mkdir /tmp/postruncmd2
+package_upgrade: false
+`
+
+var invalidCloudInitUserDataPackageInt = `packages:
+    - 76
+postruncmd:
+    - mkdir /tmp/runcmd
+package_upgrade: true
+`
+
+var invalidCloudInitUserDataRuncmd = `packages:
+    - 'string1'
+    - 'string2'
+runcmd:
+    - mkdir /tmp/runcmd
+package_upgrade: true
+`
+
+var invalidCloudInitUserDataUsers = `packages:
+    - 'string1'
+    - 'string2'
+users:
+    name: test-user
+package_upgrade: true
+`
+
+var invalidCloudInitUserDataInvalidYAML = `packages:
+    - 'string1'
+     'string2'
+runcmd:
+    - mkdir /tmp/runcmd
+package_upgrade: true
+`


### PR DESCRIPTION
## Description of change

First commit as part of work to allow user augmentation of cloud-init user data passed to juju created machines.  Key added to model-config and validated.

## QA steps

1. Unit Tests
2. See cloudinit-userdata key in model-config, try to modify it, recommend using a yaml file.

## Documentation changes

Perhaps later, once work is complete.

## Bug reference
