### PR TITLE
application ConfigSettings() now populates any charm defaults

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -139,7 +139,7 @@ check-deps:
 	@echo "$(GOCHECK_COUNT) instances of gocheck not in test code"
 
 # CAAS related targets
-DOCKER_USERNAME?=juju
+DOCKER_USERNAME?=jujusolutions
 JUJUD_STAGING_DIR=/tmp/jujud-operator
 JUJUD_BIN_DIR=${GOPATH}/bin
 

--- a/apiserver/facades/client/application/deploy_test.go
+++ b/apiserver/facades/client/application/deploy_test.go
@@ -430,10 +430,14 @@ func (s *DeployLocalSuite) assertCharm(c *gc.C, app application.Application, exp
 	c.Assert(force, jc.IsFalse)
 }
 
-func (s *DeployLocalSuite) assertSettings(c *gc.C, app application.Application, expect charm.Settings) {
+func (s *DeployLocalSuite) assertSettings(c *gc.C, app application.Application, settings charm.Settings) {
 	settings, err := app.ConfigSettings()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(settings, gc.DeepEquals, expect)
+	expected := s.charm.Config().DefaultSettings()
+	for name, value := range settings {
+		expected[name] = value
+	}
+	c.Assert(settings, gc.DeepEquals, expected)
 }
 
 func (s *DeployLocalSuite) assertConstraints(c *gc.C, app application.Application, expect constraints.Value) {

--- a/apiserver/facades/client/application/get.go
+++ b/apiserver/facades/client/application/get.go
@@ -68,7 +68,7 @@ func describe(settings charm.Settings, config *charm.Config) map[string]interfac
 			"source":      "unset",
 		}
 		set := false
-		if value := settings[name]; value != nil {
+		if value := settings[name]; value != nil && option.Default != value {
 			set = true
 			info["value"] = value
 			info["source"] = "user"
@@ -92,7 +92,7 @@ func describeV4(settings charm.Settings, config *charm.Config) map[string]interf
 			"description": option.Description,
 			"type":        option.Type,
 		}
-		if value := settings[name]; value != nil {
+		if value := settings[name]; value != nil && option.Default != value {
 			info["value"] = value
 		} else {
 			if option.Default != nil {

--- a/apiserver/facades/client/application/get_test.go
+++ b/apiserver/facades/client/application/get_test.go
@@ -22,8 +22,8 @@ import (
 type getSuite struct {
 	jujutesting.JujuConnSuite
 
-	serviceAPI *application.API
-	authorizer apiservertesting.FakeAuthorizer
+	applicationAPI *application.API
+	authorizer     apiservertesting.FakeAuthorizer
 }
 
 var _ = gc.Suite(&getSuite{})
@@ -37,7 +37,7 @@ func (s *getSuite) SetUpTest(c *gc.C) {
 	backend, err := application.NewStateBackend(s.State)
 	c.Assert(err, jc.ErrorIsNil)
 	blockChecker := common.NewBlockChecker(s.State)
-	s.serviceAPI, err = application.NewAPI(
+	s.applicationAPI, err = application.NewAPI(
 		backend,
 		s.authorizer,
 		blockChecker,
@@ -47,9 +47,9 @@ func (s *getSuite) SetUpTest(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 }
 
-func (s *getSuite) TestClientServiceGetSmoketestV4(c *gc.C) {
+func (s *getSuite) TestClientApplicationGetSmoketestV4(c *gc.C) {
 	s.AddTestingApplication(c, "wordpress", s.AddTestingCharm(c, "wordpress"))
-	v4 := &application.APIv4{s.serviceAPI}
+	v4 := &application.APIv4{s.applicationAPI}
 	results, err := v4.Get(params.ApplicationGet{"wordpress"})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, gc.DeepEquals, params.ApplicationGetResults{
@@ -67,9 +67,9 @@ func (s *getSuite) TestClientServiceGetSmoketestV4(c *gc.C) {
 	})
 }
 
-func (s *getSuite) TestClientServiceGetSmoketest(c *gc.C) {
+func (s *getSuite) TestClientApplicationGetSmoketest(c *gc.C) {
 	s.AddTestingApplication(c, "wordpress", s.AddTestingCharm(c, "wordpress"))
-	results, err := s.serviceAPI.Get(params.ApplicationGet{"wordpress"})
+	results, err := s.applicationAPI.Get(params.ApplicationGet{"wordpress"})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, gc.DeepEquals, params.ApplicationGetResults{
 		Application: "wordpress",
@@ -87,8 +87,8 @@ func (s *getSuite) TestClientServiceGetSmoketest(c *gc.C) {
 	})
 }
 
-func (s *getSuite) TestServiceGetUnknownService(c *gc.C) {
-	_, err := s.serviceAPI.Get(params.ApplicationGet{"unknown"})
+func (s *getSuite) TestApplicationGetUnknownApplication(c *gc.C) {
+	_, err := s.applicationAPI.Get(params.ApplicationGet{"unknown"})
 	c.Assert(err, gc.ErrorMatches, `application "unknown" not found`)
 }
 
@@ -99,7 +99,7 @@ var getTests = []struct {
 	config      charm.Settings
 	expect      params.ApplicationGetResults
 }{{
-	about:       "deployed service",
+	about:       "deployed application",
 	charm:       "dummy",
 	constraints: "mem=2G cpu-power=400",
 	config: charm.Settings{
@@ -128,7 +128,7 @@ var getTests = []struct {
 			"username": map[string]interface{}{
 				"default":     "admin001",
 				"description": "The name of the initial account (given admin permissions).",
-				"source":      "user",
+				"source":      "default",
 				"type":        "string",
 				"value":       "admin001",
 			},
@@ -141,7 +141,7 @@ var getTests = []struct {
 		Series: "quantal",
 	},
 }, {
-	about: "deployed service  #2",
+	about: "deployed application  #2",
 	charm: "dummy",
 	config: charm.Settings{
 		// Set title to default.
@@ -190,7 +190,7 @@ var getTests = []struct {
 		Series: "quantal",
 	},
 }, {
-	about: "subordinate service",
+	about: "subordinate application",
 	charm: "logging",
 	expect: params.ApplicationGetResults{
 		Config: map[string]interface{}{},
@@ -198,7 +198,7 @@ var getTests = []struct {
 	},
 }}
 
-func (s *getSuite) TestServiceGet(c *gc.C) {
+func (s *getSuite) TestApplicationGet(c *gc.C) {
 	for i, t := range getTests {
 		c.Logf("test %d. %s", i, t.about)
 		ch := s.AddTestingCharm(c, t.charm)
@@ -237,7 +237,7 @@ func (s *getSuite) TestGetMaxResolutionInt(c *gc.C) {
 	c.Assert(int64(asFloat)+1, gc.Equals, nonFloatInt)
 
 	ch := s.AddTestingCharm(c, "dummy")
-	app := s.AddTestingApplication(c, "test-service", ch)
+	app := s.AddTestingApplication(c, "test-application", ch)
 
 	err := app.UpdateConfigSettings(map[string]interface{}{"skill-level": nonFloatInt})
 	c.Assert(err, jc.ErrorIsNil)

--- a/caas/kubernetes/provider/k8s.go
+++ b/caas/kubernetes/provider/k8s.go
@@ -171,8 +171,7 @@ func operatorPod(appName, agentPath string) *v1.Pod {
 			Containers: []v1.Container{{
 				Name:            "juju-operator",
 				ImagePullPolicy: v1.PullIfNotPresent,
-				// TODO(caas) use proper image
-				Image: "wallyworld/caas-jujud-operator:latest",
+				Image:           "jujusolutions/caas-jujud-operator:latest",
 				Env: []v1.EnvVar{
 					{Name: "JUJU_APPLICATION", Value: appName},
 				},

--- a/cmd/juju/application/upgradecharm_test.go
+++ b/cmd/juju/application/upgradecharm_test.go
@@ -24,10 +24,10 @@ import (
 	"gopkg.in/juju/charmrepo.v2"
 	"gopkg.in/juju/charmrepo.v2/csclient"
 	csclientparams "gopkg.in/juju/charmrepo.v2/csclient/params"
-	charmstore "gopkg.in/juju/charmstore.v5-unstable"
+	"gopkg.in/juju/charmstore.v5-unstable"
 	"gopkg.in/juju/names.v2"
 	"gopkg.in/macaroon-bakery.v1/httpbakery"
-	macaroon "gopkg.in/macaroon.v1"
+	"gopkg.in/macaroon.v1"
 
 	"github.com/juju/juju/api"
 	"github.com/juju/juju/api/application"
@@ -650,8 +650,8 @@ func (s *UpgradeCharmCharmStoreStateSuite) TestUpgradeCharmWithChannel(c *gc.C) 
 	c.Assert(err, gc.IsNil)
 
 	s.assertCharmsUploaded(c, "cs:~client-username/trusty/wordpress-0", "cs:~client-username/trusty/wordpress-1")
-	s.assertApplicationsDeployed(c, map[string]serviceInfo{
-		"wordpress": {charm: "cs:~client-username/trusty/wordpress-1"},
+	s.assertApplicationsDeployed(c, map[string]applicationInfo{
+		"wordpress": {charm: "cs:~client-username/trusty/wordpress-1", config: ch.Config().DefaultSettings()},
 	})
 }
 

--- a/featuretests/application_config_test.go
+++ b/featuretests/application_config_test.go
@@ -187,13 +187,13 @@ var (
 	updatedConfig = settingsMap{
 		"booleandefault":   {false, "user"},
 		"booleannodefault": {true, "user"},
-		"booleanoverwrite": {true, "user"}, // this should be true since user-specified value is the same as default
+		"booleanoverwrite": {true, "default"},
 		"floatdefault":     {7.2, "user"},
 		"floatnodefault":   {10.2, "user"},
-		"floatoverwrite":   {11.1, "user"}, // this should be true since user-specified value is the same as default
+		"floatoverwrite":   {11.1, "default"},
 		"intdefault":       {22, "user"},
 		"intnodefault":     {11, "user"},
-		"intoverwrite":     {111, "user"}, // this should be true since user-specified value is the same as default
+		"intoverwrite":     {111, "default"},
 		"strdefault":       {"not", "user"},
 		"strnodefault":     {"maybe", "user"},
 		"stroverwrite":     {"me", "user"},

--- a/state/migration_import_test.go
+++ b/state/migration_import_test.go
@@ -5,6 +5,7 @@ package state_test
 
 import (
 	"fmt"
+	"strconv"
 	"time" // only uses time.Time values
 
 	"github.com/juju/description"
@@ -444,6 +445,14 @@ func (s *MigrationImportSuite) TestApplications(c *gc.C) {
 	c.Assert(allApplications, gc.HasLen, 1)
 
 	newModel, newSt := s.importModel(c)
+	// Manually copy across the charm from the old model
+	// as it's normally done later.
+	f := factory.NewFactory(newSt)
+	f.MakeCharm(c, &factory.CharmParams{
+		Name:     "starsay", // it has resources
+		URL:      charm.URL().String(),
+		Revision: strconv.Itoa(charm.Revision()),
+	})
 
 	importedApplications, err := newSt.AllApplications()
 	c.Assert(err, jc.ErrorIsNil)

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -1499,7 +1499,11 @@ func (s *StateSuite) TestAddApplication(c *gc.C) {
 	c.Assert(wordpress.Name(), gc.Equals, "wordpress")
 	outsettings, err := wordpress.ConfigSettings()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(outsettings, gc.DeepEquals, insettings)
+	expected := ch.Config().DefaultSettings()
+	for name, value := range insettings {
+		expected[name] = value
+	}
+	c.Assert(outsettings, gc.DeepEquals, expected)
 
 	mysql, err := s.State.AddApplication(state.AddApplicationArgs{Name: "mysql", Charm: ch})
 	c.Assert(err, jc.ErrorIsNil)
@@ -1531,7 +1535,11 @@ func (s *StateSuite) TestAddApplicationWithNilConfigValues(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	outsettings, err := wordpress.ConfigSettings()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(outsettings, gc.DeepEquals, insettings)
+	expected := ch.Config().DefaultSettings()
+	for name, value := range insettings {
+		expected[name] = value
+	}
+	c.Assert(outsettings, gc.DeepEquals, expected)
 
 	// Ensure that during creation, application settings with nil config values
 	// were stripped and not written into database.

--- a/state/unit.go
+++ b/state/unit.go
@@ -121,19 +121,7 @@ func (u *Unit) ConfigSettings() (charm.Settings, error) {
 	if u.doc.CharmURL == nil {
 		return nil, fmt.Errorf("unit charm not set")
 	}
-	settings, err := readSettings(u.st.db(), settingsC, applicationSettingsKey(u.doc.Application, u.doc.CharmURL))
-	if err != nil {
-		return nil, err
-	}
-	chrm, err := u.st.Charm(u.doc.CharmURL)
-	if err != nil {
-		return nil, err
-	}
-	result := chrm.Config().DefaultSettings()
-	for name, value := range settings.Map() {
-		result[name] = value
-	}
-	return result, nil
+	return charmSettingsWithDefaults(u.st, u.doc.CharmURL, applicationSettingsKey(u.doc.Application, u.doc.CharmURL))
 }
 
 // ApplicationName returns the application name.


### PR DESCRIPTION
## Description of change

The application ConfigSettings() API now fills in any charm defaults.
The client application facade which provides "get config" functionality changes to compare any obtained values with the defaults so that the "source" attribute is correctly filled out.
There was a test which was filling in source as "user" even when the app value and charm default was the same so this has been fixed.

As a driveby, change the source of operator images to the jujusolutions repo.

## QA steps

deploy a CAAS charm
