### PR TITLE
Support adding CAAS units

### DIFF
--- a/apiserver/facades/client/application/deploy.go
+++ b/apiserver/facades/client/application/deploy.go
@@ -162,6 +162,7 @@ func addUnits(
 	n int,
 	placement []*instance.Placement,
 	attachStorage []names.StorageTag,
+	assignUnits bool,
 ) ([]Unit, error) {
 	units := make([]Unit, n)
 	// Hard code for now till we implement a different approach.
@@ -174,18 +175,21 @@ func addUnits(
 		if err != nil {
 			return nil, errors.Annotatef(err, "cannot add unit %d/%d to application %q", i+1, n, appName)
 		}
+		units[i] = unit
+		if !assignUnits {
+			continue
+		}
+
 		// Are there still placement directives to use?
 		if i > len(placement)-1 {
 			if err := unit.AssignWithPolicy(policy); err != nil {
 				return nil, errors.Trace(err)
 			}
-			units[i] = unit
 			continue
 		}
 		if err := unit.AssignWithPlacement(placement[i]); err != nil {
 			return nil, errors.Annotatef(err, "adding new machine to host unit %q", unit.UnitTag().Id())
 		}
-		units[i] = unit
 	}
 	return units, nil
 }

--- a/apiserver/facades/client/application/mock_test.go
+++ b/apiserver/facades/client/application/mock_test.go
@@ -90,6 +90,7 @@ type mockApplication struct {
 	subordinate bool
 	series      string
 	units       []mockUnit
+	addedUnit   mockUnit
 }
 
 func (m *mockApplication) Name() string {
@@ -139,8 +140,7 @@ func (a *mockApplication) AddUnit(args state.AddUnitParams) (application.Unit, e
 	if err := a.NextErr(); err != nil {
 		return nil, err
 	}
-	unitTag := names.NewUnitTag(a.name + "/99")
-	return &mockUnit{tag: unitTag}, nil
+	return &a.addedUnit, nil
 }
 
 func (a *mockApplication) IsPrincipal() bool {
@@ -258,7 +258,7 @@ type mockBackend struct {
 	charm                      *mockCharm
 	allmodels                  []application.Model
 	users                      set.Strings
-	applications               map[string]application.Application
+	applications               map[string]*mockApplication
 	remoteApplications         map[string]application.RemoteApplication
 	spaces                     map[string]application.Space
 	endpoints                  *[]state.Endpoint
@@ -297,7 +297,7 @@ func (m *mockBackend) Unit(name string) (application.Unit, error) {
 	var unitApp *mockApplication
 	for appName, app := range m.applications {
 		if strings.HasPrefix(name, appName+"/") {
-			unitApp = app.(*mockApplication)
+			unitApp = app
 			break
 		}
 	}

--- a/apiserver/facades/client/application/mock_test.go
+++ b/apiserver/facades/client/application/mock_test.go
@@ -254,7 +254,7 @@ type mockBackend struct {
 	application.Backend
 
 	modelUUID                  string
-	model                      application.Model
+	modelType                  state.ModelType
 	charm                      *mockCharm
 	allmodels                  []application.Model
 	users                      set.Strings
@@ -491,18 +491,16 @@ func (m *mockBackend) Space(name string) (application.Space, error) {
 	return space, nil
 }
 
-func (m *mockBackend) Model() (application.Model, error) {
-	return m.model, nil
-}
-
 func (m *mockBackend) ModelUUID() string {
 	return m.modelUUID
 }
 
 func (m *mockBackend) ModelTag() names.ModelTag {
-	m.MethodCall(m, "ModelTag")
-	m.PopNoErr()
 	return names.NewModelTag(m.modelUUID)
+}
+
+func (m *mockBackend) ModelType() state.ModelType {
+	return m.modelType
 }
 
 type mockBlockChecker struct {

--- a/state/state.go
+++ b/state/state.go
@@ -1335,9 +1335,6 @@ func (st *State) processIAASModelApplicationArgs(args *AddApplicationArgs) error
 }
 
 func (st *State) processCAASModelApplicationArgs(args *AddApplicationArgs) error {
-	// TODO(caas) - remove once units are supported.
-	args.NumUnits = 0
-
 	if args.Series == "" {
 		// args.Series is not set, so use the series in the URL.
 		args.Series = args.Charm.URL().Series
@@ -1348,6 +1345,8 @@ func (st *State) processCAASModelApplicationArgs(args *AddApplicationArgs) error
 	}
 
 	// TODO(caas) restrict the series to CAAS series.
+	// TODO(caas) check that AddApplicationArgs doesn't
+	// contain IAAS-specific things.
 
 	return nil
 }

--- a/state/stateenvirons/policy.go
+++ b/state/stateenvirons/policy.go
@@ -34,17 +34,43 @@ func GetNewPolicyFunc(getEnviron func(*state.State) (environs.Environ, error)) s
 
 // Prechecker implements state.Policy.
 func (p environStatePolicy) Prechecker() (environs.InstancePrechecker, error) {
+	model, err := p.st.Model()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	if model.Type() != state.ModelTypeIAAS {
+		// Only IAAS models support machines, hence prechecking.
+		return nil, errors.NotImplementedf("Prechecker")
+	}
 	// Environ implements environs.InstancePrechecker.
 	return p.getEnviron(p.st)
 }
 
 // ConfigValidator implements state.Policy.
 func (p environStatePolicy) ConfigValidator() (config.Validator, error) {
+	model, err := p.st.Model()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	if model.Type() != state.ModelTypeIAAS {
+		// TODO(caas) CAAS providers should also support
+		// config validation.
+		return nil, errors.NotImplementedf("ConfigValidator")
+	}
 	return environProvider(p.st)
 }
 
 // ProviderConfigSchemaSource implements state.Policy.
 func (p environStatePolicy) ProviderConfigSchemaSource() (config.ConfigSchemaSource, error) {
+	model, err := p.st.Model()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	if model.Type() != state.ModelTypeIAAS {
+		// TODO(caas) CAAS providers should also provide
+		// a config schema.
+		return nil, errors.NotImplementedf("ProviderConfigSchemaSource")
+	}
 	provider, err := environProvider(p.st)
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -57,6 +83,15 @@ func (p environStatePolicy) ProviderConfigSchemaSource() (config.ConfigSchemaSou
 
 // ConstraintsValidator implements state.Policy.
 func (p environStatePolicy) ConstraintsValidator() (constraints.Validator, error) {
+	model, err := p.st.Model()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	if model.Type() != state.ModelTypeIAAS {
+		// TODO(caas) CAAS providers should also provide
+		// constraints validation.
+		return nil, errors.NotImplementedf("ConstraintsValidator")
+	}
 	env, err := p.getEnviron(p.st)
 	if err != nil {
 		return nil, err
@@ -66,6 +101,14 @@ func (p environStatePolicy) ConstraintsValidator() (constraints.Validator, error
 
 // InstanceDistributor implements state.Policy.
 func (p environStatePolicy) InstanceDistributor() (instance.Distributor, error) {
+	model, err := p.st.Model()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	if model.Type() != state.ModelTypeIAAS {
+		// Only IAAS models support machines, hence distribution.
+		return nil, errors.NotImplementedf("InstanceDistributor")
+	}
 	env, err := p.getEnviron(p.st)
 	if err != nil {
 		return nil, err
@@ -78,6 +121,14 @@ func (p environStatePolicy) InstanceDistributor() (instance.Distributor, error) 
 
 // StorageProviderRegistry implements state.Policy.
 func (p environStatePolicy) StorageProviderRegistry() (storage.ProviderRegistry, error) {
+	model, err := p.st.Model()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	if model.Type() != state.ModelTypeIAAS {
+		// Only IAAS models support storage.
+		return nil, errors.NotImplementedf("StorageProviderRegistry")
+	}
 	env, err := p.getEnviron(p.st)
 	if err != nil {
 		return nil, errors.Trace(err)


### PR DESCRIPTION
## Description of change

Fixes to state and the Application facade to support "juju add-unit" in CAAS models.

- Adding a CAAS application no longer ignores the NumUnits parameter.
- The state/stateenvirons policy returns "not implemented" for CAAS models. TODO(caas) added where we should add policies later.
- The add-unit facade method doesn't attempt to assign CAAS units to machines

## QA steps

1. juju bootstrap localhost
2. juju add-caas kubernetes k8s
3. juju add-model k8s k8s
4. juju deploy path/to/gitlab
5. watch kubectl get all
(the operator should come up, and set a container spec; the unit provisioner should then create a pod)
6. juju add-unit gitlab
(another pod should be created)

## Documentation changes

None.

## Bug reference

None.