### PR TITLE
Make the state pool own the main txn log watcher.

### DIFF
--- a/state/controller.go
+++ b/state/controller.go
@@ -67,7 +67,7 @@ func (ctlr *Controller) NewState(modelTag names.ModelTag) (*State, error) {
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	if err := st.start(ctlr.controllerTag); err != nil {
+	if err := st.start(ctlr.controllerTag, nil); err != nil {
 		return nil, errors.Trace(err)
 	}
 	return st, nil

--- a/state/model.go
+++ b/state/model.go
@@ -432,7 +432,7 @@ func (st *State) NewModel(args ModelArgs) (_ *Model, _ *State, err error) {
 		return nil, nil, errors.Trace(err)
 	}
 
-	err = newSt.start(st.controllerTag)
+	err = newSt.start(st.controllerTag, nil)
 	if err != nil {
 		return nil, nil, errors.Annotate(err, "could not start state for new model")
 	}

--- a/state/open.go
+++ b/state/open.go
@@ -145,7 +145,7 @@ func Open(args OpenParams) (*State, error) {
 
 	// State should only be Opened on behalf of a controller environ; all
 	// other *States should be created via ForModel.
-	if err := st.start(args.ControllerTag); err != nil {
+	if err := st.start(args.ControllerTag, nil); err != nil {
 		return nil, errors.Trace(err)
 	}
 	return st, nil

--- a/state/pool.go
+++ b/state/pool.go
@@ -8,18 +8,49 @@ import (
 	"fmt"
 	"runtime/debug"
 	"sync"
+	"time"
 
 	"github.com/juju/errors"
+	"github.com/juju/loggo"
+	"github.com/juju/pubsub"
 	"gopkg.in/juju/names.v2"
+	"gopkg.in/juju/worker.v1"
+
+	"github.com/juju/juju/state/watcher"
 )
+
+var errPoolClosed = errors.New("pool closed")
 
 // NewStatePool returns a new StatePool instance. It takes a State
 // connected to the system (controller model).
 func NewStatePool(systemState *State) *StatePool {
-	return &StatePool{
+	pool := &StatePool{
 		systemState: systemState,
 		pool:        make(map[string]*PoolItem),
+		hub:         pubsub.NewSimpleHub(nil),
 	}
+	// If systemState is nil, this is clearly a test, and a poorly
+	// isolated one. However now is not the time to fix all those broken
+	// tests.
+	if systemState != nil {
+		pool.watcherRunner = worker.NewRunner(worker.RunnerParams{
+			// TODO add a Logger parameter to RunnerParams:
+			// Logger: loggo.GetLogger(logger.Name() + ".txnwatcher"),
+			IsFatal:      func(err error) bool { return errors.Cause(err) == errPoolClosed },
+			RestartDelay: time.Second,
+			Clock:        systemState.clock(),
+		})
+		pool.watcherRunner.StartWorker(txnLogWorker, func() (worker.Worker, error) {
+			return watcher.NewTxnWatcher(
+				watcher.TxnWatcherConfig{
+					ChangeLog: systemState.getTxnLogCollection(),
+					Hub:       pool.hub,
+					Clock:     systemState.clock(),
+					Logger:    loggo.GetLogger("juju.state.pool.txnwatcher"),
+				})
+		})
+	}
+	return pool
 }
 
 // PoolItem holds a State and tracks how many requests are using it
@@ -45,6 +76,14 @@ type StatePool struct {
 	// sourceKey is used to provide a unique number as a key for the
 	// referencesSources structure in the pool.
 	sourceKey uint64
+
+	// hub is used to pass the transaction changes from the TxnWatcher
+	// to the various HubWatchers that are used in each state object created
+	// by the state pool.
+	hub *pubsub.SimpleHub
+
+	// watcherRunner makes sure the TxnWatcher stays running.
+	watcherRunner *worker.Runner
 }
 
 // StatePoolReleaser is the type of a function returned by StatePool.Get,
@@ -95,7 +134,7 @@ func (p *StatePool) Get(modelUUID string) (*State, StatePoolReleaser, error) {
 		return item.state, releaser, nil
 	}
 
-	st, err := p.systemState.ForModel(names.NewModelTag(modelUUID))
+	st, err := p.openState(modelUUID)
 	if err != nil {
 		return nil, nil, errors.Annotatef(err, "failed to create state for model %v", modelUUID)
 	}
@@ -106,6 +145,24 @@ func (p *StatePool) Get(modelUUID string) (*State, StatePoolReleaser, error) {
 		},
 	}
 	return st, releaser, nil
+}
+
+func (p *StatePool) openState(modelUUID string) (*State, error) {
+	modelTag := names.NewModelTag(modelUUID)
+	session := p.systemState.session.Copy()
+	newSt, err := newState(
+		modelTag, p.systemState.controllerModelTag,
+		session, p.systemState.mongoInfo,
+		p.systemState.newPolicy,
+		p.systemState.stateClock,
+		p.systemState.runTransactionObserver)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	if err := newSt.start(p.systemState.controllerTag, p.hub); err != nil {
+		return nil, errors.Trace(err)
+	}
+	return newSt, nil
 }
 
 // GetModel is a convenience method for getting a Model for a State.
@@ -216,6 +273,9 @@ func (p *StatePool) Close() error {
 		}
 	}
 	p.pool = make(map[string]*PoolItem)
+	if p.watcherRunner != nil {
+		worker.Stop(p.watcherRunner)
+	}
 	return errors.Annotate(lastErr, "at least one error closing a state")
 }
 

--- a/state/state.go
+++ b/state/state.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
+	"github.com/juju/pubsub"
 	jujutxn "github.com/juju/txn"
 	"github.com/juju/utils"
 	"github.com/juju/utils/clock"
@@ -344,7 +345,7 @@ func (st *State) ForModel(modelTag names.ModelTag) (*State, error) {
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	if err := newSt.start(st.controllerTag); err != nil {
+	if err := newSt.start(st.controllerTag, nil); err != nil {
 		return nil, errors.Trace(err)
 	}
 	return newSt, nil
@@ -356,7 +357,7 @@ func (st *State) ForModel(modelTag names.ModelTag) (*State, error) {
 //   * creating cloud metadata storage
 //
 // start will close the *State if it fails.
-func (st *State) start(controllerTag names.ControllerTag) (err error) {
+func (st *State) start(controllerTag names.ControllerTag, hub *pubsub.SimpleHub) (err error) {
 	defer func() {
 		if err == nil {
 			return
@@ -388,7 +389,7 @@ func (st *State) start(controllerTag names.ControllerTag) (err error) {
 	// now we've set up leaseClientId, we can use workersFactory
 
 	logger.Infof("starting standard state workers")
-	workers, err := newWorkers(st)
+	workers, err := newWorkers(st, hub)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -2329,7 +2330,7 @@ func (st *State) SetClockForTesting(clock clock.Clock) error {
 		return errors.Trace(err)
 	}
 	st.stateClock = clock
-	err = st.start(st.controllerTag)
+	err = st.start(st.controllerTag, nil)
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/state/watcher/export_text.go
+++ b/state/watcher/export_text.go
@@ -9,6 +9,16 @@ import (
 	"github.com/juju/juju/mongo"
 )
 
+const (
+	TxnWatcherStarting   = txnWatcherStarting
+	TxnWatcherCollection = txnWatcherCollection
+	TxnWatcherShortWait  = txnWatcherShortWait
+)
+
 func NewTestWatcher(changelog *mgo.Collection, iteratorFunc func() mongo.Iterator) *Watcher {
 	return newWatcher(changelog, iteratorFunc)
+}
+
+func NewTestHubWatcher(hub HubSource, logger Logger) (*HubWatcher, <-chan struct{}) {
+	return newHubWatcher(hub, logger)
 }

--- a/state/watcher/hubwatcher.go
+++ b/state/watcher/hubwatcher.go
@@ -1,0 +1,320 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package watcher
+
+import (
+	"fmt"
+
+	"github.com/juju/errors"
+	"gopkg.in/juju/worker.v1"
+	"gopkg.in/tomb.v1"
+)
+
+// HubSource represents the listening aspects of the pubsub hub.
+type HubSource interface {
+	SubscribeMatch(matcher func(string) bool, handler func(string, interface{})) func()
+}
+
+// HubWatcher listents to events from the hub and passes them on to the registered
+// watchers.
+type HubWatcher struct {
+	hub    HubSource
+	logger Logger
+
+	tomb tomb.Tomb
+
+	// watches holds the observers managed by Watch/Unwatch.
+	watches map[watchKey][]watchInfo
+
+	// current holds the current txn-revno values for all the observed
+	// documents known to exist. Documents not observed or deleted are
+	// omitted from this map and are considered to have revno -1.
+	current map[watchKey]int64
+
+	// syncEvents and requestEvents contain the events to be
+	// dispatched to the watcher channels. They're queued during
+	// processing and flushed at the end to simplify the algorithm.
+	// The two queues are separated because events from sync are
+	// handled in reverse order due to the way the algorithm works.
+	syncEvents, requestEvents []event
+
+	// request is used to deliver requests from the public API into
+	// the the goroutine loop.
+	request chan interface{}
+
+	// changes are events published to the hub.
+	changes chan Change
+}
+
+// NewHubWatcher returns a new watcher observing Change events published to the
+// hub.
+func NewHubWatcher(hub HubSource, logger Logger) *HubWatcher {
+	watcher, _ := newHubWatcher(hub, logger)
+	return watcher
+}
+
+func newHubWatcher(hub HubSource, logger Logger) (*HubWatcher, <-chan struct{}) {
+	if logger == nil {
+		logger = noOpLogger{}
+	}
+	started := make(chan struct{})
+	w := &HubWatcher{
+		hub:     hub,
+		logger:  logger,
+		watches: make(map[watchKey][]watchInfo),
+		current: make(map[watchKey]int64),
+		request: make(chan interface{}),
+		changes: make(chan Change),
+	}
+	go func() {
+		unsub := hub.SubscribeMatch(
+			func(string) bool { return true }, w.receiveEvent,
+		)
+		defer unsub()
+		close(started)
+		err := w.loop()
+		cause := errors.Cause(err)
+		// tomb expects ErrDying or ErrStillAlive as
+		// exact values, so we need to log and unwrap
+		// the error first.
+		if err != nil && cause != tomb.ErrDying {
+			logger.Infof("watcher loop failed: %v", err)
+		}
+		w.tomb.Kill(cause)
+		w.tomb.Done()
+	}()
+	return w, started
+}
+
+func (w *HubWatcher) receiveEvent(topic string, data interface{}) {
+	switch topic {
+	case txnWatcherStarting:
+		// This message is published when the main txns.log watcher starts. If
+		// this message is received here it means that the main watcher has
+		// restarted. It is highly likely that it restarted because it lost
+		// track of where it was, or the connection shut down. Either way, we
+		// need to stop this worker to release all the watchers.
+		w.tomb.Kill(errors.New("txn watcher restarted"))
+	case txnWatcherCollection:
+		change, ok := data.(Change)
+		if !ok {
+			w.logger.Warningf("incoming event not a Chage")
+			return
+		}
+		select {
+		case w.changes <- change:
+		case <-w.tomb.Dying():
+		}
+	default:
+		w.logger.Warningf("programming error, unknown topic: %q", topic)
+	}
+}
+
+// Kill is part of the worker.Worker interface.
+func (w *HubWatcher) Kill() {
+	w.tomb.Kill(nil)
+}
+
+// Wait is part of the worker.Worker interface.
+func (w *HubWatcher) Wait() error {
+	return w.tomb.Wait()
+}
+
+// Stop stops all the watcher activities.
+func (w *HubWatcher) Stop() error {
+	return worker.Stop(w)
+}
+
+// Dead returns a channel that is closed when the watcher has stopped.
+func (w *HubWatcher) Dead() <-chan struct{} {
+	return w.tomb.Dead()
+}
+
+// Err returns the error with which the watcher stopped.
+// It returns nil if the watcher stopped cleanly, tomb.ErrStillAlive
+// if the watcher is still running properly, or the respective error
+// if the watcher is terminating or has terminated with an error.
+func (w *HubWatcher) Err() error {
+	return w.tomb.Err()
+}
+
+func (w *HubWatcher) sendReq(req interface{}) {
+	select {
+	case w.request <- req:
+	case <-w.tomb.Dying():
+	}
+}
+
+// Watch starts watching the given collection and document id.
+// An event will be sent onto ch whenever a matching document's txn-revno
+// field is observed to change after a transaction is applied. The revno
+// parameter holds the currently known revision number for the document.
+// Non-existent documents are represented by a -1 revno.
+func (w *HubWatcher) Watch(collection string, id interface{}, revno int64, ch chan<- Change) {
+	if id == nil {
+		panic("watcher: cannot watch a document with nil id")
+	}
+	w.sendReq(reqWatch{watchKey{collection, id}, watchInfo{ch, revno, nil}})
+}
+
+// WatchCollection starts watching the given collection.
+// An event will be sent onto ch whenever the txn-revno field is observed
+// to change after a transaction is applied for any document in the collection.
+func (w *HubWatcher) WatchCollection(collection string, ch chan<- Change) {
+	w.WatchCollectionWithFilter(collection, ch, nil)
+}
+
+// WatchCollectionWithFilter starts watching the given collection.
+// An event will be sent onto ch whenever the txn-revno field is observed
+// to change after a transaction is applied for any document in the collection, so long as the
+// specified filter function returns true when called with the document id value.
+func (w *HubWatcher) WatchCollectionWithFilter(collection string, ch chan<- Change, filter func(interface{}) bool) {
+	w.sendReq(reqWatch{watchKey{collection, nil}, watchInfo{ch, 0, filter}})
+}
+
+// Unwatch stops watching the given collection and document id via ch.
+func (w *HubWatcher) Unwatch(collection string, id interface{}, ch chan<- Change) {
+	if id == nil {
+		panic("watcher: cannot unwatch a document with nil id")
+	}
+	w.sendReq(reqUnwatch{watchKey{collection, id}, ch})
+}
+
+// UnwatchCollection stops watching the given collection via ch.
+func (w *HubWatcher) UnwatchCollection(collection string, ch chan<- Change) {
+	w.sendReq(reqUnwatch{watchKey{collection, nil}, ch})
+}
+
+// loop implements the main watcher loop.
+// period is the delay between each sync.
+func (w *HubWatcher) loop() error {
+	for {
+		select {
+		case <-w.tomb.Dying():
+			return errors.Trace(tomb.ErrDying)
+		case change := <-w.changes:
+			w.queueChange(change)
+		case req := <-w.request:
+			w.handle(req)
+		}
+		for (len(w.syncEvents) + len(w.requestEvents)) > 0 {
+			w.flush()
+		}
+	}
+}
+
+func (w *HubWatcher) flush() {
+	// syncEvents are stored first in first out.
+	for i := 0; i < len(w.syncEvents); i++ {
+		e := &w.syncEvents[i]
+		for e.ch != nil {
+			select {
+			case <-w.tomb.Dying():
+				return
+			case req := <-w.request:
+				w.handle(req)
+				continue
+			case change := <-w.changes:
+				w.queueChange(change)
+				continue
+			case e.ch <- Change{e.key.c, e.key.id, e.revno}:
+			}
+			break
+		}
+	}
+	w.syncEvents = w.syncEvents[:0]
+
+	// requestEvents are stored oldest first, and
+	// may grow during the loop.
+	for i := 0; i < len(w.requestEvents); i++ {
+		e := &w.requestEvents[i]
+		for e.ch != nil {
+			select {
+			case <-w.tomb.Dying():
+				return
+			case req := <-w.request:
+				w.handle(req)
+				continue
+			case change := <-w.changes:
+				w.queueChange(change)
+				continue
+			case e.ch <- Change{e.key.c, e.key.id, e.revno}:
+			}
+			break
+		}
+	}
+	w.requestEvents = w.requestEvents[:0]
+}
+
+// handle deals with requests delivered by the public API
+// onto the background watcher goroutine.
+func (w *HubWatcher) handle(req interface{}) {
+	w.logger.Tracef("got request: %#v", req)
+	switch r := req.(type) {
+	case reqWatch:
+		for _, info := range w.watches[r.key] {
+			if info.ch == r.info.ch {
+				panic(fmt.Errorf("tried to re-add channel %v for %s", info.ch, r.key))
+			}
+		}
+		if revno, ok := w.current[r.key]; ok && (revno > r.info.revno || revno == -1 && r.info.revno >= 0) {
+			r.info.revno = revno
+			w.requestEvents = append(w.requestEvents, event{r.info.ch, r.key, revno})
+		}
+		w.watches[r.key] = append(w.watches[r.key], r.info)
+	case reqUnwatch:
+		watches := w.watches[r.key]
+		removed := false
+		for i, info := range watches {
+			if info.ch == r.ch {
+				watches[i] = watches[len(watches)-1]
+				w.watches[r.key] = watches[:len(watches)-1]
+				removed = true
+				break
+			}
+		}
+		if !removed {
+			panic(fmt.Errorf("tried to remove missing channel %v for %s", r.ch, r.key))
+		}
+		for i := range w.requestEvents {
+			e := &w.requestEvents[i]
+			if r.key.match(e.key) && e.ch == r.ch {
+				e.ch = nil
+			}
+		}
+		for i := range w.syncEvents {
+			e := &w.syncEvents[i]
+			if r.key.match(e.key) && e.ch == r.ch {
+				e.ch = nil
+			}
+		}
+	default:
+		panic(fmt.Errorf("unknown request: %T", req))
+	}
+}
+
+// queueChange queues up the change for the registered watchers.
+func (w *HubWatcher) queueChange(change Change) {
+	w.logger.Tracef("got change document: %#v", change)
+	key := watchKey{change.C, change.Id}
+	revno := change.Revno
+	w.current[key] = revno
+
+	// Queue notifications for per-collection watches.
+	for _, info := range w.watches[watchKey{change.C, nil}] {
+		if info.filter != nil && !info.filter(change.Id) {
+			continue
+		}
+		w.syncEvents = append(w.syncEvents, event{info.ch, key, revno})
+	}
+
+	// Queue notifications for per-document watches.
+	infos := w.watches[key]
+	for i, info := range infos {
+		if revno > info.revno || revno < 0 && info.revno >= 0 {
+			infos[i].revno = revno
+			w.syncEvents = append(w.syncEvents, event{info.ch, key, revno})
+		}
+	}
+}

--- a/state/watcher/hubwatcher_test.go
+++ b/state/watcher/hubwatcher_test.go
@@ -1,0 +1,293 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package watcher_test
+
+import (
+	"time"
+
+	"github.com/juju/loggo"
+	"github.com/juju/pubsub"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/worker.v1"
+	"gopkg.in/tomb.v1"
+
+	"github.com/juju/juju/state/watcher"
+	"github.com/juju/juju/testing"
+)
+
+type HubWatcherSuite struct {
+	testing.BaseSuite
+
+	w   watcher.BaseWatcher
+	hub *pubsub.SimpleHub
+	ch  chan watcher.Change
+}
+
+var _ = gc.Suite(&HubWatcherSuite{})
+
+func (s *HubWatcherSuite) SetUpTest(c *gc.C) {
+	s.BaseSuite.SetUpTest(c)
+
+	logger := loggo.GetLogger("HubWatcherSuite")
+	logger.SetLogLevel(loggo.TRACE)
+
+	s.hub = pubsub.NewSimpleHub(nil)
+	s.ch = make(chan watcher.Change)
+	var started <-chan struct{}
+	s.w, started = watcher.NewTestHubWatcher(s.hub, logger)
+	s.AddCleanup(func(c *gc.C) {
+		worker.Stop(s.w)
+	})
+	select {
+	case <-started:
+		// all good
+	case <-time.After(testing.LongWait):
+		c.Error("hub watcher worker didn't start")
+	}
+}
+
+func (s *HubWatcherSuite) publish(c *gc.C, changes ...watcher.Change) {
+	var processed <-chan struct{}
+	for _, change := range changes {
+		processed = s.hub.Publish(watcher.TxnWatcherCollection, change)
+	}
+	select {
+	case <-processed:
+		// all good.
+	case <-time.After(testing.LongWait):
+		c.Error("event not processed")
+	}
+
+}
+
+func (s *HubWatcherSuite) TestErrAndDead(c *gc.C) {
+	c.Assert(s.w.Err(), gc.Equals, tomb.ErrStillAlive)
+	select {
+	case <-s.w.Dead():
+		c.Fatalf("Dead channel fired unexpectedly")
+	default:
+	}
+	c.Assert(worker.Stop(s.w), jc.ErrorIsNil)
+	select {
+	case <-s.w.Dead():
+	default:
+		c.Fatalf("Dead channel should have fired")
+	}
+}
+
+func (s *HubWatcherSuite) TestTxnWatcherStartingKillsWorker(c *gc.C) {
+	// When the TxnWatcher restarts, the hub watcher needs to restart
+	// too as there may be missed events, so all the watches this hub
+	// has need to be invalidated. This happens by the worker dying.
+	s.hub.Publish(watcher.TxnWatcherStarting, nil)
+
+	select {
+	case <-s.w.Dead():
+	case <-time.After(testing.LongWait):
+		c.Fatalf("Dead channel should have fired")
+	}
+
+	c.Assert(s.w.Err(), gc.ErrorMatches, "txn watcher restarted")
+}
+
+func (s *HubWatcherSuite) TestWatchBeforeKnown(c *gc.C) {
+	s.w.Watch("test", "a", -1, s.ch)
+	assertNoChange(c, s.ch)
+
+	change := watcher.Change{"test", "a", 5}
+	s.publish(c, change)
+
+	assertChange(c, s.ch, change)
+	assertNoChange(c, s.ch)
+}
+
+func (s *HubWatcherSuite) TestWatchAfterKnown(c *gc.C) {
+	change := watcher.Change{"test", "a", 5}
+	s.publish(c, change)
+
+	s.w.Watch("test", "a", -1, s.ch)
+	assertChange(c, s.ch, change)
+	assertNoChange(c, s.ch)
+}
+
+func (s *HubWatcherSuite) TestWatchIgnoreUnwatched(c *gc.C) {
+	s.w.Watch("test", "a", -1, s.ch)
+
+	s.publish(c, watcher.Change{"test", "b", 5})
+
+	assertNoChange(c, s.ch)
+}
+
+func (s *HubWatcherSuite) TestWatchOrder(c *gc.C) {
+	first := watcher.Change{"test", "a", 3}
+	second := watcher.Change{"test", "b", 4}
+	third := watcher.Change{"test", "c", 5}
+
+	for _, id := range []string{"a", "b", "c", "d"} {
+		s.w.Watch("test", id, -1, s.ch)
+	}
+
+	s.publish(c, first, second, third)
+
+	assertChange(c, s.ch, first)
+	assertChange(c, s.ch, second)
+	assertChange(c, s.ch, third)
+	assertNoChange(c, s.ch)
+}
+
+func (s *HubWatcherSuite) TestWatchMultipleChannels(c *gc.C) {
+	ch1 := make(chan watcher.Change)
+	ch2 := make(chan watcher.Change)
+	ch3 := make(chan watcher.Change)
+	s.w.Watch("test1", 1, -1, ch1)
+	s.w.Watch("test2", 2, -1, ch2)
+	s.w.Watch("test3", 3, -1, ch3)
+
+	first := watcher.Change{"test1", 1, 3}
+	second := watcher.Change{"test2", 2, 4}
+	third := watcher.Change{"test3", 3, 5}
+	s.publish(c, first, second, third)
+
+	s.w.Unwatch("test2", 2, ch2)
+	assertChange(c, ch1, first)
+	assertChange(c, ch3, third)
+	assertNoChange(c, ch1)
+	assertNoChange(c, ch2)
+	assertNoChange(c, ch3)
+}
+
+func (s *HubWatcherSuite) TestWatchKnownRemove(c *gc.C) {
+	change := watcher.Change{"test", "a", -1}
+	s.publish(c, change)
+
+	s.w.Watch("test", "a", 2, s.ch)
+	assertChange(c, s.ch, change)
+	assertNoChange(c, s.ch)
+}
+
+func (s *HubWatcherSuite) TestWatchUnwatchOnQueue(c *gc.C) {
+	const N = 10
+	for i := 0; i < N; i++ {
+		s.publish(c, watcher.Change{"test", i, int64(i + 3)})
+	}
+	for i := 0; i < N; i++ {
+		s.w.Watch("test", i, -1, s.ch)
+	}
+	for i := 1; i < N; i += 2 {
+		s.w.Unwatch("test", i, s.ch)
+	}
+	seen := make(map[interface{}]bool)
+	for i := 0; i < N/2; i++ {
+		select {
+		case change := <-s.ch:
+			seen[change.Id] = true
+		case <-time.After(worstCase):
+			c.Fatalf("not enough changes: got %d, want %d", len(seen), N/2)
+		}
+	}
+	c.Assert(len(seen), gc.Equals, N/2)
+	assertNoChange(c, s.ch)
+}
+
+func (s *HubWatcherSuite) TestWatchCollection(c *gc.C) {
+	chA1 := make(chan watcher.Change)
+	chB1 := make(chan watcher.Change)
+	chA := make(chan watcher.Change)
+	chB := make(chan watcher.Change)
+
+	s.w.Watch("testA", 1, -1, chA1)
+	s.w.Watch("testB", 1, -1, chB1)
+	s.w.WatchCollection("testA", chA)
+	s.w.WatchCollection("testB", chB)
+
+	changes := []watcher.Change{
+		{"testA", 1, 3},
+		{"testA", 2, 2},
+		{"testB", 1, 5},
+		{"testB", 2, 6},
+	}
+	s.publish(c, changes...)
+
+	seen := map[chan<- watcher.Change][]watcher.Change{}
+
+	waitForChanges := func(count int, seen map[chan<- watcher.Change][]watcher.Change, timeout time.Duration) {
+		tooLong := time.After(timeout)
+		for n := 0; n < count; n++ {
+			select {
+			case chg := <-chA1:
+				seen[chA1] = append(seen[chA1], chg)
+			case chg := <-chB1:
+				seen[chB1] = append(seen[chB1], chg)
+			case chg := <-chA:
+				seen[chA] = append(seen[chA], chg)
+			case chg := <-chB:
+				seen[chB] = append(seen[chB], chg)
+			case <-tooLong:
+				return
+			}
+		}
+	}
+
+	waitForChanges(6, seen, testing.LongWait)
+
+	c.Check(seen[chA1], jc.DeepEquals, []watcher.Change{changes[0]})
+	c.Check(seen[chB1], jc.DeepEquals, []watcher.Change{changes[2]})
+	c.Check(seen[chA], jc.DeepEquals, []watcher.Change{changes[0], changes[1]})
+	c.Assert(seen[chB], jc.DeepEquals, []watcher.Change{changes[2], changes[3]})
+
+	s.w.UnwatchCollection("testB", chB)
+	s.w.Unwatch("testB", 1, chB1)
+
+	next := watcher.Change{"testA", 1, 4}
+	s.publish(c, next)
+
+	seen = map[chan<- watcher.Change][]watcher.Change{}
+	waitForChanges(2, seen, testing.LongWait)
+
+	c.Check(seen[chA1], gc.DeepEquals, []watcher.Change{next})
+	c.Check(seen[chB1], gc.IsNil)
+	c.Check(seen[chA], gc.DeepEquals, []watcher.Change{next})
+	c.Assert(seen[chB], gc.IsNil)
+
+	// Check that no extra events arrive.
+	seen = map[chan<- watcher.Change][]watcher.Change{}
+	waitForChanges(1, seen, testing.ShortWait)
+
+	c.Check(seen[chA1], gc.IsNil)
+	c.Check(seen[chB1], gc.IsNil)
+	c.Check(seen[chA], gc.IsNil)
+	c.Check(seen[chB], gc.IsNil)
+}
+
+func (s *HubWatcherSuite) TestUnwatchCollectionWithFilter(c *gc.C) {
+	filter := func(key interface{}) bool {
+		id := key.(int)
+		return id != 2
+	}
+
+	change := watcher.Change{"testA", 1, 3}
+	s.w.WatchCollectionWithFilter("testA", s.ch, filter)
+	s.publish(c, change)
+	assertChange(c, s.ch, change)
+	s.publish(c, watcher.Change{"testA", 2, 2})
+	assertNoChange(c, s.ch)
+
+	change = watcher.Change{"testA", 3, 3}
+	s.publish(c, change)
+	assertChange(c, s.ch, change)
+}
+
+func (s *HubWatcherSuite) TestWatchBeforeRemoveKnown(c *gc.C) {
+	added := watcher.Change{"test", "a", 2}
+	s.publish(c, added)
+
+	s.w.Watch("test", "a", -1, s.ch)
+
+	removed := watcher.Change{"test", "a", -1}
+	s.publish(c, removed)
+
+	assertChange(c, s.ch, added)
+	assertChange(c, s.ch, removed)
+}

--- a/state/watcher/logger.go
+++ b/state/watcher/logger.go
@@ -1,0 +1,20 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENCE file for details.
+
+package watcher
+
+// Logger represents methods called by this package to a logging
+// system.
+type Logger interface {
+	Warningf(format string, values ...interface{})
+	Infof(format string, values ...interface{})
+	Debugf(format string, values ...interface{})
+	Tracef(format string, values ...interface{})
+}
+
+type noOpLogger struct{}
+
+func (noOpLogger) Warningf(format string, values ...interface{}) {}
+func (noOpLogger) Infof(format string, values ...interface{})    {}
+func (noOpLogger) Debugf(format string, values ...interface{})   {}
+func (noOpLogger) Tracef(format string, values ...interface{})   {}

--- a/state/watcher/txnwatcher.go
+++ b/state/watcher/txnwatcher.go
@@ -1,0 +1,308 @@
+// Copyright 2012, 2013 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package watcher
+
+import (
+	"time"
+
+	"github.com/juju/errors"
+	"gopkg.in/juju/worker.v1"
+	"gopkg.in/mgo.v2"
+	"gopkg.in/mgo.v2/bson"
+	"gopkg.in/retry.v1"
+	"gopkg.in/tomb.v1"
+
+	"github.com/juju/juju/mongo"
+)
+
+// Hub represents a pubsub hub. The TxnWatcher only ever publishes
+// events to the hub.
+type Hub interface {
+	Publish(topic string, data interface{}) <-chan struct{}
+}
+
+// Clock represents the time methods used.
+type Clock interface {
+	Now() time.Time
+	After(time.Duration) <-chan time.Time
+}
+
+const (
+	txnWatcherStarting   = "starting"
+	txnWatcherCollection = "collection"
+
+	txnWatcherShortWait = 10 * time.Millisecond
+)
+
+// PollStrategy is used to determine how long
+// to delay between poll intervals. A new timer
+// is created each time some watcher event is
+// fired or if the old timer completes.
+//
+// It must not be changed when any watchers are active.
+var PollStrategy retry.Strategy = retry.Exponential{
+	Initial:  10 * time.Millisecond,
+	Factor:   1.5,
+	MaxDelay: 5 * time.Second,
+}
+
+type txnChange struct {
+	collection string
+	docID      interface{}
+	revID      int64
+}
+
+// A TxnWatcher watches the txns.log collection and publishes all change events
+// to the hub.
+type TxnWatcher struct {
+	hub    Hub
+	clock  Clock
+	logger Logger
+
+	tomb         tomb.Tomb
+	iteratorFunc func() mongo.Iterator
+	log          *mgo.Collection
+
+	// syncEvents contain the events to be
+	// dispatched to the watcher channels. They're queued during
+	// processing and flushed at the end to simplify the algorithm.
+	// The two queues are separated because events from sync are
+	// handled in reverse order due to the way the algorithm works.
+	syncEvents []Change
+
+	// lastId is the most recent transaction id observed by a sync.
+	lastId interface{}
+}
+
+// TxnWatcherConfig container the configuration parameters required
+// for a NewTxnWatcher.
+type TxnWatcherConfig struct {
+	// ChangeLog is usually the tnxs.log collection.
+	ChangeLog *mgo.Collection
+	// Hub is where the changes are published to.
+	Hub Hub
+	// Clock allows tests to control the advancing of time.
+	Clock Clock
+	// Logger is used to control where the log messages for this watcher go.
+	Logger Logger
+	// IteratorFunc can be overridden in tests to control what values the
+	// watcher sees.
+	IteratorFunc func() mongo.Iterator
+}
+
+// Validate ensures that all the values that have to be set are set.
+func (config TxnWatcherConfig) Validate() error {
+	if config.ChangeLog == nil {
+		return errors.NotValidf("missing ChangeLog")
+	}
+	if config.Hub == nil {
+		return errors.NotValidf("missing Hub")
+	}
+	if config.Clock == nil {
+		return errors.NotValidf("missing Clock")
+	}
+	return nil
+}
+
+// New returns a new Watcher observing the changelog collection,
+// which must be a capped collection maintained by mgo/txn.
+func NewTxnWatcher(config TxnWatcherConfig) (*TxnWatcher, error) {
+	if err := config.Validate(); err != nil {
+		return nil, errors.Annotate(err, "new TxnWatcher invalid config")
+	}
+
+	w := &TxnWatcher{
+		hub:          config.Hub,
+		clock:        config.Clock,
+		logger:       config.Logger,
+		log:          config.ChangeLog,
+		iteratorFunc: config.IteratorFunc,
+	}
+	if w.iteratorFunc == nil {
+		w.iteratorFunc = w.iter
+	}
+	if w.logger == nil {
+		w.logger = noOpLogger{}
+	}
+	go func() {
+		err := w.loop()
+		cause := errors.Cause(err)
+		// tomb expects ErrDying or ErrStillAlive as
+		// exact values, so we need to log and unwrap
+		// the error first.
+		if err != nil && cause != tomb.ErrDying {
+			w.logger.Infof("watcher loop failed: %v", err)
+		}
+		w.tomb.Kill(cause)
+		w.tomb.Done()
+	}()
+	return w, nil
+}
+
+// Kill is part of the worker.Worker interface.
+func (w *TxnWatcher) Kill() {
+	w.tomb.Kill(nil)
+}
+
+// Wait is part of the worker.Worker interface.
+func (w *TxnWatcher) Wait() error {
+	return w.tomb.Wait()
+}
+
+// Stop stops all the watcher activities.
+func (w *TxnWatcher) Stop() error {
+	return worker.Stop(w)
+}
+
+// Dead returns a channel that is closed when the watcher has stopped.
+func (w *TxnWatcher) Dead() <-chan struct{} {
+	return w.tomb.Dead()
+}
+
+// Err returns the error with which the watcher stopped.
+// It returns nil if the watcher stopped cleanly, tomb.ErrStillAlive
+// if the watcher is still running properly, or the respective error
+// if the watcher is terminating or has terminated with an error.
+func (w *TxnWatcher) Err() error {
+	return w.tomb.Err()
+}
+
+// loop implements the main watcher loop.
+// period is the delay between each sync.
+func (w *TxnWatcher) loop() error {
+	if err := w.initLastId(); err != nil {
+		return errors.Trace(err)
+	}
+	// Make sure we have read the last ID before telling people
+	// we have started.
+	w.hub.Publish(txnWatcherStarting, nil)
+	backoff := PollStrategy.NewTimer(w.clock.Now())
+	next := w.clock.After(txnWatcherShortWait)
+	for {
+		select {
+		case <-w.tomb.Dying():
+			return errors.Trace(tomb.ErrDying)
+		case <-next:
+			d, ok := backoff.NextSleep(w.clock.Now())
+			if !ok {
+				// This shouldn't happen, but be defensive.
+				backoff = PollStrategy.NewTimer(w.clock.Now())
+			}
+			next = w.clock.After(d)
+		}
+
+		added, err := w.sync()
+		if err != nil {
+			return errors.Trace(err)
+		}
+		w.flush()
+		if added {
+			// Something's happened, so reset the exponential backoff
+			// so we'll retry again quickly.
+			backoff = PollStrategy.NewTimer(w.clock.Now())
+			next = w.clock.After(txnWatcherShortWait)
+		}
+	}
+}
+
+// flush sends all pending events to their respective channels.
+func (w *TxnWatcher) flush() {
+	// refreshEvents are stored newest first.
+	for i := len(w.syncEvents) - 1; i >= 0; i-- {
+		e := w.syncEvents[i]
+		w.hub.Publish(txnWatcherCollection, e)
+	}
+	w.syncEvents = w.syncEvents[:0]
+}
+
+// initLastId reads the most recent changelog document and initializes
+// lastId with it. This causes all history that precedes the creation
+// of the watcher to be ignored.
+func (w *TxnWatcher) initLastId() error {
+	var entry struct {
+		Id interface{} `bson:"_id"`
+	}
+	err := w.log.Find(nil).Sort("-$natural").One(&entry)
+	if err != nil && err != mgo.ErrNotFound {
+		return errors.Trace(err)
+	}
+	w.lastId = entry.Id
+	return nil
+}
+
+func (w *TxnWatcher) iter() mongo.Iterator {
+	return w.log.Find(nil).Batch(10).Sort("-$natural").Iter()
+}
+
+// sync updates the watcher knowledge from the database, and
+// queues events to observing channels.
+func (w *TxnWatcher) sync() (bool, error) {
+	added := false
+	// Iterate through log events in reverse insertion order (newest first).
+	iter := w.iteratorFunc()
+	seen := make(map[watchKey]bool)
+	first := true
+	lastId := w.lastId
+	var entry bson.D
+	for iter.Next(&entry) {
+		if len(entry) == 0 {
+			w.logger.Tracef("got empty changelog document")
+		}
+		id := entry[0]
+		if id.Name != "_id" {
+			w.logger.Warningf("watcher: _id field isn't first entry")
+			continue
+		}
+		if first {
+			w.lastId = id.Value
+			first = false
+		}
+		if id.Value == lastId {
+			break
+		}
+		w.logger.Tracef("got changelog document: %#v", entry)
+		for _, c := range entry[1:] {
+			// See txn's Runner.ChangeLog for the structure of log entries.
+			var d, r []interface{}
+			dr, _ := c.Value.(bson.D)
+			for _, item := range dr {
+				switch item.Name {
+				case "d":
+					d, _ = item.Value.([]interface{})
+				case "r":
+					r, _ = item.Value.([]interface{})
+				}
+			}
+			if len(d) == 0 || len(d) != len(r) {
+				w.logger.Warningf("changelog has invalid collection document: %#v", c)
+				continue
+			}
+			for i := len(d) - 1; i >= 0; i-- {
+				key := watchKey{c.Name, d[i]}
+				if seen[key] {
+					continue
+				}
+				seen[key] = true
+				revno, ok := r[i].(int64)
+				if !ok {
+					w.logger.Warningf("changelog has revno with type %T: %#v", r[i], r[i])
+					continue
+				}
+				if revno < 0 {
+					revno = -1
+				}
+				w.syncEvents = append(w.syncEvents, Change{
+					C:     c.Name,
+					Id:    d[i],
+					Revno: revno,
+				})
+				added = true
+			}
+		}
+	}
+	if err := iter.Close(); err != nil {
+		return false, errors.Annotate(err, "watcher iteration error")
+	}
+	return added, nil
+}

--- a/state/watcher/txnwatcher_test.go
+++ b/state/watcher/txnwatcher_test.go
@@ -1,0 +1,335 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package watcher_test
+
+import (
+	"time"
+
+	gitjujutesting "github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/mgo.v2"
+	"gopkg.in/mgo.v2/txn"
+	"gopkg.in/tomb.v1"
+
+	"github.com/juju/juju/mongo"
+	"github.com/juju/juju/state/watcher"
+	"github.com/juju/juju/testing"
+)
+
+type TxnWatcherSuite struct {
+	gitjujutesting.MgoSuite
+	testing.BaseSuite
+
+	log          *mgo.Collection
+	stash        *mgo.Collection
+	runner       *txn.Runner
+	w            *watcher.TxnWatcher
+	ch           chan watcher.Change
+	iteratorFunc func() mongo.Iterator
+	clock        *gitjujutesting.Clock
+}
+
+var _ = gc.Suite(&TxnWatcherSuite{})
+
+func (s *TxnWatcherSuite) SetUpSuite(c *gc.C) {
+	s.MgoSuite.SetUpSuite(c)
+	s.BaseSuite.SetUpSuite(c)
+}
+
+func (s *TxnWatcherSuite) TearDownSuite(c *gc.C) {
+	s.BaseSuite.TearDownSuite(c)
+	s.MgoSuite.TearDownSuite(c)
+}
+
+func (s *TxnWatcherSuite) SetUpTest(c *gc.C) {
+	s.MgoSuite.SetUpTest(c)
+	s.BaseSuite.SetUpTest(c)
+
+	db := s.MgoSuite.Session.DB("juju")
+	s.log = db.C("txnlog")
+	s.log.Create(&mgo.CollectionInfo{
+		Capped:   true,
+		MaxBytes: 1000000,
+	})
+	s.stash = db.C("txn.stash")
+	s.runner = txn.NewRunner(db.C("txn"))
+	s.runner.ChangeLog(s.log)
+	s.clock = gitjujutesting.NewClock(time.Now())
+}
+
+func (s *TxnWatcherSuite) TearDownTest(c *gc.C) {
+	s.BaseSuite.TearDownTest(c)
+	s.MgoSuite.TearDownTest(c)
+}
+
+func (s *TxnWatcherSuite) advanceTime(c *gc.C, d time.Duration) {
+	// Here we are assuming that there is one and only one thing
+	// using the After function on the testing clock, that being our
+	// watcher.
+	s.clock.WaitAdvance(d, testing.ShortWait, 1)
+}
+
+func (s *TxnWatcherSuite) newWatcher(c *gc.C, expect int) (*watcher.TxnWatcher, *fakeHub) {
+	hub := newFakeHub(c, expect)
+	w, err := watcher.NewTxnWatcher(watcher.TxnWatcherConfig{
+		ChangeLog: s.log,
+		Hub:       hub,
+		Clock:     s.clock,
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	// Wait for the main loop to have started.
+	select {
+	case <-hub.started:
+	case <-time.After(testing.LongWait):
+		c.Error("txn worker failed to start")
+	}
+	s.AddCleanup(func(c *gc.C) {
+		c.Assert(w.Stop(), jc.ErrorIsNil)
+	})
+	return w, hub
+}
+
+func (s *TxnWatcherSuite) revno(c *gc.C, coll string, id interface{}) (revno int64) {
+	var doc struct {
+		Revno int64 `bson:"txn-revno"`
+	}
+	err := s.log.Database.C(coll).FindId(id).One(&doc)
+	c.Assert(err, jc.ErrorIsNil)
+	return doc.Revno
+}
+
+func (s *TxnWatcherSuite) insert(c *gc.C, coll string, id interface{}) (revno int64) {
+	ops := []txn.Op{{C: coll, Id: id, Insert: M{"n": 1}}}
+	err := s.runner.Run(ops, "", nil)
+	c.Assert(err, jc.ErrorIsNil)
+	revno = s.revno(c, coll, id)
+	c.Logf("insert(%#v, %#v) => revno %d", coll, id, revno)
+	return revno
+}
+
+func (s *TxnWatcherSuite) insertAll(c *gc.C, coll string, ids ...interface{}) (revnos []int64) {
+	var ops []txn.Op
+	for _, id := range ids {
+		ops = append(ops, txn.Op{C: coll, Id: id, Insert: M{"n": 1}})
+	}
+	err := s.runner.Run(ops, "", nil)
+	c.Assert(err, jc.ErrorIsNil)
+	for _, id := range ids {
+		revnos = append(revnos, s.revno(c, coll, id))
+	}
+	c.Logf("insertAll(%#v, %v) => revnos %v", coll, ids, revnos)
+	return revnos
+}
+
+func (s *TxnWatcherSuite) update(c *gc.C, coll string, id interface{}) (revno int64) {
+	ops := []txn.Op{{C: coll, Id: id, Update: M{"$inc": M{"n": 1}}}}
+	err := s.runner.Run(ops, "", nil)
+	c.Assert(err, jc.ErrorIsNil)
+	revno = s.revno(c, coll, id)
+	c.Logf("update(%#v, %#v) => revno %d", coll, id, revno)
+	return revno
+}
+
+func (s *TxnWatcherSuite) remove(c *gc.C, coll string, id interface{}) (revno int64) {
+	ops := []txn.Op{{C: coll, Id: id, Remove: true}}
+	err := s.runner.Run(ops, "", nil)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Logf("remove(%#v, %#v) => revno -1", coll, id)
+	return -1
+}
+
+func (s *TxnWatcherSuite) TestErrAndDead(c *gc.C) {
+	w, _ := s.newWatcher(c, 0)
+	c.Assert(w.Err(), gc.Equals, tomb.ErrStillAlive)
+	select {
+	case <-w.Dead():
+		c.Fatalf("Dead channel fired unexpectedly")
+	default:
+	}
+	c.Assert(w.Stop(), jc.ErrorIsNil)
+	c.Assert(w.Err(), jc.ErrorIsNil)
+	select {
+	case <-w.Dead():
+	default:
+		c.Fatalf("Dead channel should have fired")
+	}
+}
+
+func (s *TxnWatcherSuite) TestInsert(c *gc.C) {
+	_, hub := s.newWatcher(c, 1)
+
+	revno := s.insert(c, "test", "a")
+
+	s.advanceTime(c, watcher.TxnWatcherShortWait)
+	hub.waitForExpected(c)
+
+	c.Assert(hub.values, jc.DeepEquals, []watcher.Change{
+		{"test", "a", revno},
+	})
+}
+
+func (s *TxnWatcherSuite) TestUpdate(c *gc.C) {
+	s.insert(c, "test", "a")
+
+	_, hub := s.newWatcher(c, 1)
+	revno := s.update(c, "test", "a")
+
+	s.advanceTime(c, watcher.TxnWatcherShortWait)
+	hub.waitForExpected(c)
+
+	c.Assert(hub.values, jc.DeepEquals, []watcher.Change{
+		{"test", "a", revno},
+	})
+}
+
+func (s *TxnWatcherSuite) TestRemove(c *gc.C) {
+	s.insert(c, "test", "a")
+
+	_, hub := s.newWatcher(c, 1)
+	revno := s.remove(c, "test", "a")
+
+	s.advanceTime(c, watcher.TxnWatcherShortWait)
+	hub.waitForExpected(c)
+
+	c.Assert(hub.values, jc.DeepEquals, []watcher.Change{
+		{"test", "a", revno},
+	})
+}
+
+func (s *TxnWatcherSuite) TestWatchOrder(c *gc.C) {
+	_, hub := s.newWatcher(c, 3)
+
+	revno1 := s.insert(c, "test", "a")
+	revno2 := s.insert(c, "test", "b")
+	revno3 := s.insert(c, "test", "c")
+
+	s.advanceTime(c, watcher.TxnWatcherShortWait)
+	hub.waitForExpected(c)
+
+	c.Assert(hub.values, jc.DeepEquals, []watcher.Change{
+		{"test", "a", revno1},
+		{"test", "b", revno2},
+		{"test", "c", revno3},
+	})
+}
+
+func (s *TxnWatcherSuite) TestTransactionWithMultiple(c *gc.C) {
+	_, hub := s.newWatcher(c, 3)
+
+	revnos := s.insertAll(c, "test", "a", "b", "c")
+
+	s.advanceTime(c, watcher.TxnWatcherShortWait)
+	hub.waitForExpected(c)
+
+	c.Assert(hub.values, jc.DeepEquals, []watcher.Change{
+		{"test", "a", revnos[0]},
+		{"test", "b", revnos[1]},
+		{"test", "c", revnos[2]},
+	})
+}
+
+func (s *TxnWatcherSuite) TestScale(c *gc.C) {
+	const N = 500
+	const T = 10
+
+	_, hub := s.newWatcher(c, N)
+
+	c.Logf("Creating %d documents, %d per transaction...", N, T)
+	ops := make([]txn.Op, T)
+	for i := 0; i < (N / T); i++ {
+		ops = ops[:0]
+		for j := 0; j < T && i*T+j < N; j++ {
+			ops = append(ops, txn.Op{C: "test", Id: i*T + j, Insert: M{"n": 1}})
+		}
+		err := s.runner.Run(ops, "", nil)
+		c.Assert(err, jc.ErrorIsNil)
+	}
+
+	count, err := s.Session.DB("juju").C("test").Count()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Logf("Got %d documents in the collection...", count)
+	c.Assert(count, gc.Equals, N)
+
+	s.advanceTime(c, watcher.TxnWatcherShortWait)
+	hub.waitForExpected(c)
+
+	for i := 0; i < N; i++ {
+		c.Assert(hub.values[i].Id, gc.Equals, i)
+	}
+}
+
+func (s *TxnWatcherSuite) TestInsertThenRemove(c *gc.C) {
+	_, hub := s.newWatcher(c, 2)
+
+	revno1 := s.insert(c, "test", "a")
+	s.advanceTime(c, watcher.TxnWatcherShortWait)
+	revno2 := s.remove(c, "test", "a")
+	s.advanceTime(c, watcher.TxnWatcherShortWait)
+
+	hub.waitForExpected(c)
+
+	c.Assert(hub.values, jc.DeepEquals, []watcher.Change{
+		{"test", "a", revno1},
+		{"test", "a", revno2},
+	})
+}
+
+func (s *TxnWatcherSuite) TestDoubleUpdate(c *gc.C) {
+	_, hub := s.newWatcher(c, 2)
+
+	revno1 := s.insert(c, "test", "a")
+	s.advanceTime(c, watcher.TxnWatcherShortWait)
+	s.update(c, "test", "a")
+	revno3 := s.update(c, "test", "a")
+	s.advanceTime(c, watcher.TxnWatcherShortWait)
+
+	hub.waitForExpected(c)
+
+	c.Assert(hub.values, jc.DeepEquals, []watcher.Change{
+		{"test", "a", revno1},
+		{"test", "a", revno3},
+	})
+}
+
+type fakeHub struct {
+	c       *gc.C
+	expect  int
+	values  []watcher.Change
+	started chan struct{}
+	done    chan struct{}
+}
+
+func newFakeHub(c *gc.C, expected int) *fakeHub {
+	return &fakeHub{
+		c:       c,
+		expect:  expected,
+		started: make(chan struct{}),
+		done:    make(chan struct{}),
+	}
+}
+
+func (hub *fakeHub) Publish(topic string, data interface{}) <-chan struct{} {
+	switch topic {
+	case watcher.TxnWatcherStarting:
+		close(hub.started)
+	case watcher.TxnWatcherCollection:
+		change := data.(watcher.Change)
+		hub.values = append(hub.values, change)
+		if len(hub.values) == hub.expect {
+			close(hub.done)
+		}
+	default:
+		hub.c.Errorf("unknown topic %q", topic)
+	}
+	return nil
+}
+
+func (hub *fakeHub) waitForExpected(c *gc.C) {
+	select {
+	case <-hub.done:
+	case <-time.After(testing.LongWait):
+		c.Error("hub didn't get the expected number of changes")
+	}
+}

--- a/state/workers.go
+++ b/state/workers.go
@@ -7,6 +7,8 @@ import (
 	"time"
 
 	"github.com/juju/errors"
+	"github.com/juju/loggo"
+	"github.com/juju/pubsub"
 	"gopkg.in/juju/worker.v1"
 
 	corelease "github.com/juju/juju/core/lease"
@@ -37,7 +39,7 @@ type workers struct {
 
 const pingFlushInterval = time.Second
 
-func newWorkers(st *State) (*workers, error) {
+func newWorkers(st *State, hub *pubsub.SimpleHub) (*workers, error) {
 	ws := &workers{
 		state: st,
 		Runner: worker.NewRunner(worker.RunnerParams{
@@ -48,9 +50,15 @@ func newWorkers(st *State) (*workers, error) {
 			Clock:        st.clock(),
 		}),
 	}
-	ws.StartWorker(txnLogWorker, func() (worker.Worker, error) {
-		return watcher.New(st.getTxnLogCollection()), nil
-	})
+	if hub == nil {
+		ws.StartWorker(txnLogWorker, func() (worker.Worker, error) {
+			return watcher.New(st.getTxnLogCollection()), nil
+		})
+	} else {
+		ws.StartWorker(txnLogWorker, func() (worker.Worker, error) {
+			return watcher.NewHubWatcher(hub, loggo.GetLogger("juju.state.watcher")), nil
+		})
+	}
 	ws.StartWorker(presenceWorker, func() (worker.Worker, error) {
 		return presence.NewWatcher(st.getPresenceCollection(), st.modelTag), nil
 	})


### PR DESCRIPTION
Back in the dawn of time, there was only a single model, and a single State instance. As the controller concept became a thing, we had additional State instances for each model. A core aspect of how the event model works in Juju is watching of the txns.log collection. As documents are added, updated, and removed by the transaction system, documents are added to the txns.log capped collection. Each document refers to the documents that were touched a single transaction. Each State instance has its own txn watcher. Each one of these tails the txns.log collection to watch for changes. As the number of models grows in a single controller, so does the number of things watching the txns.log collection. If the controller is HA, then there is n x m watchers where n is the number of models and m is the number of API servers. This creates quite a bit of idle load on mongo as the number of models grows above a small number. As numbers approach 200, there is a LOT of load. Especially when actions occur that trigger a bunch of transactions that touch a bunch of documents, such as removing an application. Particularly an application that has a bunch of subordinates.

So... this branch changes how the polling of the database is done. The state pool now has a watcher, that publishes all document changes to a hub that is also owned by the state pool. Whenever the state pool creates a new State instance, the base watcher for that State instance listens to the hub for changes rather than polling the database.

This drastically reduces the mongo load.

## QA steps

I verified this by starting with a 2.2.6 controller, deploying 55 units to each of four models, and adding 700 empty models. This showed significant i/o load on the juju.txns.log collection.

After upgrading the controller, the load dropped significantly. From ~1000ms read / 10s to 15ms read / 10s.

## Documentation changes

This is internal only, no documentation changes are necessary.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1733708
