### PR TITLE
Add model-config cloudinit-userdata to actual machine cloudconfig.

### DIFF
--- a/apiserver/facades/agent/provisioner/provisioninginfo.go
+++ b/apiserver/facades/agent/provisioner/provisioninginfo.go
@@ -108,6 +108,7 @@ func (p *ProvisionerAPI) getProvisioningInfo(m *state.Machine, env environs.Envi
 		EndpointBindings:  endpointBindings,
 		ImageMetadata:     imageMetadata,
 		ControllerConfig:  controllerCfg,
+		CloudInitUserData: env.Config().CloudInitUserData(),
 	}, nil
 }
 

--- a/apiserver/params/internal.go
+++ b/apiserver/params/internal.go
@@ -685,6 +685,7 @@ type ProvisioningInfo struct {
 	ImageMetadata     []CloudImageMetadata      `json:"image-metadata,omitempty"`
 	EndpointBindings  map[string]string         `json:"endpoint-bindings,omitempty"`
 	ControllerConfig  map[string]interface{}    `json:"controller-config,omitempty"`
+	CloudInitUserData map[string]interface{}    `json:"cloudinit-userdata,omitempty"`
 }
 
 // ProvisioningInfoResult holds machine provisioning info or an error.

--- a/cloudconfig/cloudinit/cloudinit.go
+++ b/cloudconfig/cloudinit/cloudinit.go
@@ -197,6 +197,11 @@ func (cfg *cloudConfig) AddScripts(script ...string) {
 	}
 }
 
+// PrependRunCmd is defined on the RunCmdsConfig interface.
+func (cfg *cloudConfig) PrependRunCmd(args ...string) {
+	cfg.attrs["runcmd"] = append([]string{strings.Join(args, " ")}, cfg.RunCmds()...)
+}
+
 // RemoveRunCmd is defined on the RunCmdsConfig interface.
 func (cfg *cloudConfig) RemoveRunCmd(cmd string) {
 	cfg.attrs["runcmd"] = removeStringFromSlice(cfg.RunCmds(), cmd)

--- a/cloudconfig/cloudinit/cloudinit_test.go
+++ b/cloudconfig/cloudinit/cloudinit_test.go
@@ -310,6 +310,18 @@ var ctests = []struct {
 		cfg.AddRunCmd("ifconfig")
 	},
 }, {
+	"PrependRunCmd",
+	map[string]interface{}{"runcmd": []string{
+		"echo 'Hello World'",
+		"ifconfig",
+	}},
+	func(cfg cloudinit.CloudConfig) {
+		cfg.AddRunCmd("ifconfig")
+		cfg.PrependRunCmd(
+			"echo 'Hello World'",
+		)
+	},
+}, {
 	"AddScripts",
 	map[string]interface{}{"runcmd": []string{
 		"echo 'Hello World'",

--- a/cloudconfig/cloudinit/interface.go
+++ b/cloudconfig/cloudinit/interface.go
@@ -164,6 +164,10 @@ type RunCmdsConfig interface {
 	// NOTE: metacharacters will not be escaped.
 	AddScripts(...string)
 
+	// PrependRunCmd adds a command to the beginning of the list of commands
+	// to be run on first boot.
+	PrependRunCmd(...string)
+
 	// RemoveRunCmd removes the given command from the list of commands to be
 	// run on first boot. If it has not been previously added, no error occurs.
 	RemoveRunCmd(string)

--- a/cloudconfig/instancecfg/instancecfg.go
+++ b/cloudconfig/instancecfg/instancecfg.go
@@ -94,6 +94,10 @@ type InstanceConfig struct {
 	// The directory containing the log file must already exist.
 	CloudInitOutputLog string
 
+	// CloudInitUserData defines key/value pairs from the model-config
+	// specified by the user.
+	CloudInitUserData map[string]interface{}
+
 	// MachineId identifies the new machine.
 	MachineId string
 
@@ -780,6 +784,7 @@ func PopulateInstanceConfig(icfg *InstanceConfig,
 	aptMirror string,
 	enableOSRefreshUpdates bool,
 	enableOSUpgrade bool,
+	cloudInitUserData map[string]interface{},
 ) error {
 	icfg.AuthorizedKeys = authorizedKeys
 	if icfg.AgentEnvironment == nil {
@@ -794,6 +799,7 @@ func PopulateInstanceConfig(icfg *InstanceConfig,
 	icfg.AptMirror = aptMirror
 	icfg.EnableOSRefreshUpdate = enableOSRefreshUpdates
 	icfg.EnableOSUpgrade = enableOSUpgrade
+	icfg.CloudInitUserData = cloudInitUserData
 	return nil
 }
 
@@ -819,6 +825,7 @@ func FinishInstanceConfig(icfg *InstanceConfig, cfg *config.Config) (err error) 
 		cfg.AptMirror(),
 		cfg.EnableOSRefreshUpdate(),
 		cfg.EnableOSUpgrade(),
+		cfg.CloudInitUserData(),
 	); err != nil {
 		return errors.Trace(err)
 	}

--- a/cloudconfig/providerinit/providerinit.go
+++ b/cloudconfig/providerinit/providerinit.go
@@ -31,6 +31,10 @@ func configureCloudinit(icfg *instancecfg.InstanceConfig, cloudcfg cloudinit.Clo
 		if err != nil {
 			return nil, err
 		}
+		err = udata.ConfigureCustomOverrides()
+		if err != nil {
+			return nil, err
+		}
 		return udata, nil
 	}
 	err = udata.Configure()

--- a/cloudconfig/userdatacfg.go
+++ b/cloudconfig/userdatacfg.go
@@ -35,12 +35,20 @@ type UserdataConfig interface {
 	// with appropriate configuration. It will run ConfigureBasic() and
 	// ConfigureJuju()
 	Configure() error
+
 	// ConfigureBasic updates the provided cloudinit.Config with
 	// basic configuration to initialise an OS image.
 	ConfigureBasic() error
+
 	// ConfigureJuju updates the provided cloudinit.Config with configuration
 	// to initialise a Juju machine agent.
 	ConfigureJuju() error
+
+	// ConfigureCustomOverrides updates the provided cloudinit.Config with
+	// user provided cloudinit data.  Data provided will overwrite current
+	// values with three exceptions: preruncmd was handled in ConfigureBasic()
+	// and packages and postruncmd were handled in ConfigureJuju().
+	ConfigureCustomOverrides() error
 }
 
 // NewUserdataConfig is supposed to take in an instanceConfig as well as a

--- a/cloudconfig/userdatacfg_unix.go
+++ b/cloudconfig/userdatacfg_unix.go
@@ -84,7 +84,10 @@ func (w *unixConfigure) Configure() error {
 	if err := w.ConfigureBasic(); err != nil {
 		return err
 	}
-	return w.ConfigureJuju()
+	if err := w.ConfigureJuju(); err != nil {
+		return err
+	}
+	return w.ConfigureCustomOverrides()
 }
 
 // ConfigureBasic updates the provided cloudinit.Config with
@@ -100,7 +103,15 @@ func (w *unixConfigure) Configure() error {
 // but adds to the running time of initialisation due to lack of activity
 // between image bringup and start of agent installation.
 func (w *unixConfigure) ConfigureBasic() error {
-	w.conf.AddScripts(
+	// Keep preruncmd at the beginning of any runcmd's that juju adds
+	if preruncmds, ok := w.icfg.CloudInitUserData["preruncmd"].([]interface{}); ok {
+		for i := len(preruncmds) - 1; i >= 0; i -= 1 {
+			if cmd, ok := preruncmds[i].(string); ok {
+				w.conf.PrependRunCmd(cmd)
+			}
+		}
+	}
+	w.conf.AddRunCmd(
 		"set -xe", // ensure we run all the scripts or abort.
 	)
 	switch w.os {
@@ -196,6 +207,16 @@ func (w *unixConfigure) setDataDirPermissions() string {
 func (w *unixConfigure) ConfigureJuju() error {
 	if err := w.icfg.VerifyConfig(); err != nil {
 		return err
+	}
+
+	// To keep postruncmd at the end of any runcmd's that juju adds,
+	// this block must stay at the top.
+	if postruncmds, ok := w.icfg.CloudInitUserData["postruncmd"].([]interface{}); ok {
+		cmds := make([]string, len(postruncmds))
+		for i, v := range postruncmds {
+			cmds[i] = v.(string)
+		}
+		defer w.conf.AddScripts(cmds...)
 	}
 
 	// Initialise progress reporting. We need to do separately for runcmd
@@ -321,7 +342,27 @@ func (w *unixConfigure) ConfigureJuju() error {
 		}
 	}
 
+	// Append cloudinit-userdata packages to the end of the juju created ones.
+	if packagesToAdd, ok := w.icfg.CloudInitUserData["packages"].([]interface{}); ok {
+		for _, v := range packagesToAdd {
+			if pack, ok := v.(string); ok {
+				w.conf.AddPackage(pack)
+			}
+		}
+	}
+
 	return w.addMachineAgentToBoot()
+}
+
+func (w *unixConfigure) ConfigureCustomOverrides() error {
+	for k, v := range w.icfg.CloudInitUserData {
+		// preruncmd was handled in ConfigureBasic()
+		// packages and postruncmd have been handled in ConfigureJuju()
+		if k != "packages" && k != "preruncmd" && k != "postruncmd" {
+			w.conf.SetAttr(k, v)
+		}
+	}
+	return nil
 }
 
 func (w *unixConfigure) configureBootstrap() error {

--- a/cloudconfig/userdatacfg_win.go
+++ b/cloudconfig/userdatacfg_win.go
@@ -42,7 +42,10 @@ func (w *windowsConfigure) Configure() error {
 	if err := w.ConfigureBasic(); err != nil {
 		return err
 	}
-	return w.ConfigureJuju()
+	if err := w.ConfigureJuju(); err != nil {
+		return err
+	}
+	return w.ConfigureCustomOverrides()
 }
 
 func (w *windowsConfigure) ConfigureBasic() error {
@@ -139,6 +142,12 @@ func (w *windowsConfigure) ConfigureJuju() error {
 		return errors.Trace(err)
 	}
 	return w.addMachineAgentToBoot()
+}
+
+func (w *windowsConfigure) ConfigureCustomOverrides() error {
+	// TODO HML 2017-12-08
+	// Implement for Windows support of model-config cloudinit-userdata.
+	return nil
 }
 
 // createJujuRegistryKeyCmds is going to create a juju registry key and set

--- a/environs/config/config.go
+++ b/environs/config/config.go
@@ -1134,7 +1134,7 @@ func (c *Config) FanConfig() (network.FanConfig, error) {
 func (c *Config) CloudInitUserData() map[string]interface{} {
 	raw := c.asString(CloudInitUserDataKey)
 	if raw == "" {
-		return map[string]interface{}{}
+		return nil
 	}
 	userDataMap := make(map[string]interface{})
 	yaml.Unmarshal([]byte(raw), &userDataMap)

--- a/environs/config/config_test.go
+++ b/environs/config/config_test.go
@@ -1315,7 +1315,8 @@ MIIBOgIBAAJAZabKgKInuOxj5vDWLwHHQtK3/45KB+32D15w94Nt83BmuGxo90lw
 -----END CERTIFICATE-----
 `[1:]
 
-var validCloudInitUserData = `packages:
+var validCloudInitUserData = `
+packages:
   - 'python-keystoneclient'
   - 'python-glanceclient'
 preruncmd:
@@ -1325,35 +1326,39 @@ postruncmd:
   - mkdir /tmp/postruncmd
   - mkdir /tmp/postruncmd2
 package_upgrade: false
-`
+`[1:]
 
-var invalidCloudInitUserDataPackageInt = `packages:
+var invalidCloudInitUserDataPackageInt = `
+packages:
     - 76
 postruncmd:
     - mkdir /tmp/runcmd
 package_upgrade: true
-`
+`[1:]
 
-var invalidCloudInitUserDataRuncmd = `packages:
+var invalidCloudInitUserDataRuncmd = `
+packages:
     - 'string1'
     - 'string2'
 runcmd:
     - mkdir /tmp/runcmd
 package_upgrade: true
-`
+`[1:]
 
-var invalidCloudInitUserDataUsers = `packages:
+var invalidCloudInitUserDataUsers = `
+packages:
     - 'string1'
     - 'string2'
 users:
     name: test-user
 package_upgrade: true
-`
+`[1:]
 
-var invalidCloudInitUserDataInvalidYAML = `packages:
+var invalidCloudInitUserDataInvalidYAML = `
+packages:
     - 'string1'
      'string2'
 runcmd:
     - mkdir /tmp/runcmd
 package_upgrade: true
-`
+`[1:]

--- a/provider/common/bootstrap.go
+++ b/provider/common/bootstrap.go
@@ -392,6 +392,9 @@ func ConfigureMachine(
 	if err := udata.ConfigureJuju(); err != nil {
 		return err
 	}
+	if err := udata.ConfigureCustomOverrides(); err != nil {
+		return err
+	}
 	configScript, err := cloudcfg.RenderScript()
 	if err != nil {
 		return err

--- a/worker/provisioner/export_test.go
+++ b/worker/provisioner/export_test.go
@@ -6,6 +6,10 @@ package provisioner
 import (
 	"sort"
 
+	"github.com/juju/version"
+
+	apiprovisioner "github.com/juju/juju/api/provisioner"
+	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/watcher"
 )
@@ -51,4 +55,15 @@ func GetCopyAvailabilityZoneMachines(p ProvisionerTask) []AvailabilityZoneMachin
 		retvalues[i] = *task.availabilityZoneMachines[i]
 	}
 	return retvalues
+}
+
+func SetupToStartMachine(p ProvisionerTask, machine *apiprovisioner.Machine, version *version.Number) (
+	environs.StartInstanceParams,
+	error,
+) {
+	return p.(*provisionerTask).setupToStartMachine(machine, version)
+}
+
+func GetAPIProvisionerState(p Provisioner) *apiprovisioner.State {
+	return p.(*environProvisioner).st
 }

--- a/worker/provisioner/kvm-broker.go
+++ b/worker/provisioner/kvm-broker.go
@@ -114,6 +114,9 @@ func (broker *kvmBroker) StartInstance(args environs.StartInstanceParams) (*envi
 		return nil, errors.Trace(err)
 	}
 
+	// TODO HML 2017-12-07
+	// Find the CloudInitUserData to fill in the last arg of
+	// instancecfg.PopulateInstanceConfig
 	if err := instancecfg.PopulateInstanceConfig(
 		args.InstanceConfig,
 		config.ProviderType,
@@ -124,6 +127,7 @@ func (broker *kvmBroker) StartInstance(args environs.StartInstanceParams) (*envi
 		config.AptMirror,
 		config.EnableOSRefreshUpdate,
 		config.EnableOSUpgrade,
+		make(map[string]interface{}),
 	); err != nil {
 		kvmLogger.Errorf("failed to populate machine config: %v", err)
 		return nil, err

--- a/worker/provisioner/lxd-broker.go
+++ b/worker/provisioner/lxd-broker.go
@@ -104,6 +104,9 @@ func (broker *lxdBroker) StartInstance(args environs.StartInstanceParams) (*envi
 		return nil, errors.Trace(err)
 	}
 
+	// TODO HML 2017-12-07
+	// Find the CloudInitUserData to fill in the last arg of
+	// instancecfg.PopulateInstanceConfig
 	if err := instancecfg.PopulateInstanceConfig(
 		args.InstanceConfig,
 		config.ProviderType,
@@ -114,6 +117,7 @@ func (broker *lxdBroker) StartInstance(args environs.StartInstanceParams) (*envi
 		config.AptMirror,
 		config.EnableOSRefreshUpdate,
 		config.EnableOSUpgrade,
+		make(map[string]interface{}),
 	); err != nil {
 		lxdLogger.Errorf("failed to populate machine config: %v", err)
 		return nil, err

--- a/worker/provisioner/provisioner_task.go
+++ b/worker/provisioner/provisioner_task.go
@@ -576,6 +576,8 @@ func (task *provisionerTask) constructInstanceConfig(
 		}
 	}
 
+	instanceConfig.CloudInitUserData = pInfo.CloudInitUserData
+
 	return instanceConfig, nil
 }
 


### PR DESCRIPTION
## Description of change

Use the data provided in model-config cloudinit-userdata by adding it to the juju created
cloudinit files used for the bootstrap machine and other juju machines.  This is a follow-on to PR 8177. 

This PR will be followed up with cloudinit updates for containers on juju machines.

Tests are not ready for review.

## QA steps

1. unit tests
2. create a yaml file with cloudinit-userdata defined.
3. bootstrap with the bootstrap config and the model default config using the above yaml
4. add a machine to the default model.
5. ssh to the controller and the juju machine to verify things specified in the yaml file happened.

## Documentation changes

N/A

## Bug reference

N/A
