### PR TITLE
Fix the tests to not create unneeded statepools.

### DIFF
--- a/apiserver/apiserver_test.go
+++ b/apiserver/apiserver_test.go
@@ -31,7 +31,6 @@ const (
 
 type apiserverBaseSuite struct {
 	statetesting.StateSuite
-	pool *state.StatePool
 }
 
 func (s *apiserverBaseSuite) SetUpTest(c *gc.C) {
@@ -41,8 +40,6 @@ func (s *apiserverBaseSuite) SetUpTest(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	err = u.SetPassword(ownerPassword)
 	c.Assert(err, jc.ErrorIsNil)
-	s.pool = state.NewStatePool(s.State)
-	s.AddCleanup(func(*gc.C) { s.pool.Close() })
 }
 
 func (s *apiserverBaseSuite) sampleConfig(c *gc.C) apiserver.ServerConfig {
@@ -67,7 +64,7 @@ func (s *apiserverBaseSuite) sampleConfig(c *gc.C) apiserver.ServerConfig {
 func (s *apiserverBaseSuite) newServerNoCleanup(c *gc.C, config apiserver.ServerConfig) *apiserver.Server {
 	listener, err := net.Listen("tcp", ":0")
 	c.Assert(err, jc.ErrorIsNil)
-	srv, err := apiserver.NewServer(s.pool, listener, config)
+	srv, err := apiserver.NewServer(s.StatePool, listener, config)
 	c.Assert(err, jc.ErrorIsNil)
 	return srv
 }

--- a/apiserver/authenticator_test.go
+++ b/apiserver/authenticator_test.go
@@ -18,7 +18,6 @@ import (
 
 type agentAuthenticatorSuite struct {
 	testing.JujuConnSuite
-	pool *state.StatePool
 }
 
 type userFinder struct {
@@ -33,14 +32,12 @@ var _ = gc.Suite(&agentAuthenticatorSuite{})
 
 func (s *agentAuthenticatorSuite) SetUpTest(c *gc.C) {
 	s.JujuConnSuite.SetUpTest(c)
-	s.pool = state.NewStatePool(s.State)
-	s.AddCleanup(func(*gc.C) { s.pool.Close() })
 }
 
 func (s *agentAuthenticatorSuite) TestAuthenticatorForTag(c *gc.C) {
 	fact := factory.NewFactory(s.State)
 	user := fact.MakeUser(c, &factory.UserParams{Password: "password"})
-	_, srv := newServer(c, s.pool)
+	_, srv := newServer(c, s.StatePool)
 	defer assertStop(c, srv)
 
 	authenticator, err := apiserver.ServerAuthenticatorForTag(srv, user.Tag())
@@ -57,7 +54,7 @@ func (s *agentAuthenticatorSuite) TestAuthenticatorForTag(c *gc.C) {
 }
 
 func (s *agentAuthenticatorSuite) TestMachineGetsAgentAuthenticator(c *gc.C) {
-	_, srv := newServer(c, s.pool)
+	_, srv := newServer(c, s.StatePool)
 	defer srv.Stop()
 	authenticator, err := apiserver.ServerAuthenticatorForTag(srv, names.NewMachineTag("0"))
 	c.Assert(err, jc.ErrorIsNil)
@@ -66,7 +63,7 @@ func (s *agentAuthenticatorSuite) TestMachineGetsAgentAuthenticator(c *gc.C) {
 }
 
 func (s *agentAuthenticatorSuite) TestUnitGetsAgentAuthenticator(c *gc.C) {
-	_, srv := newServer(c, s.pool)
+	_, srv := newServer(c, s.StatePool)
 	defer srv.Stop()
 	authenticator, err := apiserver.ServerAuthenticatorForTag(srv, names.NewUnitTag("wordpress/0"))
 	c.Assert(err, jc.ErrorIsNil)
@@ -75,7 +72,7 @@ func (s *agentAuthenticatorSuite) TestUnitGetsAgentAuthenticator(c *gc.C) {
 }
 
 func (s *agentAuthenticatorSuite) TestNotSupportedTag(c *gc.C) {
-	_, srv := newServer(c, s.pool)
+	_, srv := newServer(c, s.StatePool)
 	defer srv.Stop()
 	authenticator, err := apiserver.ServerAuthenticatorForTag(srv, names.NewApplicationTag("not-support"))
 	c.Assert(err, gc.ErrorMatches, "unexpected login entity tag: invalid request")

--- a/apiserver/common/modelstatus_test.go
+++ b/apiserver/common/modelstatus_test.go
@@ -33,7 +33,6 @@ type modelStatusSuite struct {
 	controller *controller.ControllerAPI
 	resources  *common.Resources
 	authorizer apiservertesting.FakeAuthorizer
-	pool       *state.StatePool
 }
 
 var _ = gc.Suite(&modelStatusSuite{})
@@ -56,15 +55,12 @@ func (s *modelStatusSuite) SetUpTest(c *gc.C) {
 		AdminTag: s.Owner,
 	}
 
-	s.pool = state.NewStatePool(s.State)
-	s.AddCleanup(func(*gc.C) { s.pool.Close() })
-
 	controller, err := controller.NewControllerAPIv4(
 		facadetest.Context{
 			State_:     s.State,
 			Resources_: s.resources,
 			Auth_:      s.authorizer,
-			StatePool_: s.pool,
+			StatePool_: s.StatePool,
 		})
 	c.Assert(err, jc.ErrorIsNil)
 	s.controller = controller
@@ -108,7 +104,7 @@ func (s *modelStatusSuite) TestModelStatusOwnerAllowed(c *gc.C) {
 			State_:     s.State,
 			Resources_: s.resources,
 			Auth_:      anAuthoriser,
-			StatePool_: s.pool,
+			StatePool_: s.StatePool,
 		})
 	c.Assert(err, jc.ErrorIsNil)
 

--- a/apiserver/facades/client/controller/controller_test.go
+++ b/apiserver/facades/client/controller/controller_test.go
@@ -36,7 +36,6 @@ import (
 type controllerSuite struct {
 	statetesting.StateSuite
 
-	statePool  *state.StatePool
 	controller *controller.ControllerAPI
 	resources  *common.Resources
 	authorizer apiservertesting.FakeAuthorizer
@@ -52,12 +51,6 @@ func (s *controllerSuite) SetUpTest(c *gc.C) {
 
 	s.StateSuite.SetUpTest(c)
 
-	s.statePool = state.NewStatePool(s.State)
-	s.AddCleanup(func(c *gc.C) {
-		err := s.statePool.Close()
-		c.Assert(err, jc.ErrorIsNil)
-	})
-
 	s.resources = common.NewResources()
 	s.AddCleanup(func(_ *gc.C) { s.resources.StopAll() })
 
@@ -69,7 +62,7 @@ func (s *controllerSuite) SetUpTest(c *gc.C) {
 	controller, err := controller.NewControllerAPIv4(
 		facadetest.Context{
 			State_:     s.State,
-			StatePool_: s.statePool,
+			StatePool_: s.StatePool,
 			Resources_: s.resources,
 			Auth_:      s.authorizer,
 		})
@@ -266,7 +259,7 @@ func (s *controllerSuite) TestModelConfigFromNonController(c *gc.C) {
 	controller, err := controller.NewControllerAPIv4(
 		facadetest.Context{
 			State_:     st,
-			StatePool_: s.statePool,
+			StatePool_: s.StatePool,
 			Resources_: common.NewResources(),
 			Auth_:      authorizer,
 		})
@@ -847,7 +840,7 @@ func (s *controllerSuite) TestModelStatusV3(c *gc.C) {
 	api, err := controller.NewControllerAPIv3(
 		facadetest.Context{
 			State_:     s.State,
-			StatePool_: s.statePool,
+			StatePool_: s.StatePool,
 			Resources_: s.resources,
 			Auth_:      s.authorizer,
 		})

--- a/apiserver/logsink_test.go
+++ b/apiserver/logsink_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/juju/juju/apiserver"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/apiserver/websocket/websockettest"
-	"github.com/juju/juju/state"
 	coretesting "github.com/juju/juju/testing"
 	"github.com/juju/juju/testing/factory"
 	"github.com/juju/juju/version"
@@ -214,33 +213,30 @@ func (s *logsinkSuite) TestNewServerValidatesLogSinkConfig(c *gc.C) {
 	type dummyListener struct {
 		net.Listener
 	}
-	pool := state.NewStatePool(s.State)
-	defer pool.Close()
-
 	cfg := defaultServerConfig(c)
 	cfg.LogSinkConfig = &apiserver.LogSinkConfig{}
 
-	_, err := apiserver.NewServer(pool, dummyListener{}, cfg)
+	_, err := apiserver.NewServer(s.StatePool, dummyListener{}, cfg)
 	c.Assert(err, gc.ErrorMatches, "validating logsink configuration: DBLoggerBufferSize 0 <= 0 or > 1000 not valid")
 
 	cfg.LogSinkConfig.DBLoggerBufferSize = 1001
-	_, err = apiserver.NewServer(pool, dummyListener{}, cfg)
+	_, err = apiserver.NewServer(s.StatePool, dummyListener{}, cfg)
 	c.Assert(err, gc.ErrorMatches, "validating logsink configuration: DBLoggerBufferSize 1001 <= 0 or > 1000 not valid")
 
 	cfg.LogSinkConfig.DBLoggerBufferSize = 1
-	_, err = apiserver.NewServer(pool, dummyListener{}, cfg)
+	_, err = apiserver.NewServer(s.StatePool, dummyListener{}, cfg)
 	c.Assert(err, gc.ErrorMatches, "validating logsink configuration: DBLoggerFlushInterval 0s <= 0 or > 10 seconds not valid")
 
 	cfg.LogSinkConfig.DBLoggerFlushInterval = 30 * time.Second
-	_, err = apiserver.NewServer(pool, dummyListener{}, cfg)
+	_, err = apiserver.NewServer(s.StatePool, dummyListener{}, cfg)
 	c.Assert(err, gc.ErrorMatches, "validating logsink configuration: DBLoggerFlushInterval 30s <= 0 or > 10 seconds not valid")
 
 	cfg.LogSinkConfig.DBLoggerFlushInterval = 10 * time.Second
-	_, err = apiserver.NewServer(pool, dummyListener{}, cfg)
+	_, err = apiserver.NewServer(s.StatePool, dummyListener{}, cfg)
 	c.Assert(err, gc.ErrorMatches, "validating logsink configuration: RateLimitBurst 0 <= 0 not valid")
 
 	cfg.LogSinkConfig.RateLimitBurst = 1000
-	_, err = apiserver.NewServer(pool, dummyListener{}, cfg)
+	_, err = apiserver.NewServer(s.StatePool, dummyListener{}, cfg)
 	c.Assert(err, gc.ErrorMatches, "validating logsink configuration: RateLimitRefill 0s <= 0 not valid")
 }
 

--- a/apiserver/pubsub_test.go
+++ b/apiserver/pubsub_test.go
@@ -28,7 +28,6 @@ import (
 
 type pubsubSuite struct {
 	statetesting.StateSuite
-	pool       *state.StatePool
 	machineTag names.Tag
 	password   string
 	nonce      string
@@ -49,9 +48,7 @@ func (s *pubsubSuite) SetUpTest(c *gc.C) {
 	s.machineTag = m.Tag()
 	s.password = password
 	s.hub = pubsub.NewStructuredHub(nil)
-	s.pool = state.NewStatePool(s.State)
-	s.AddCleanup(func(*gc.C) { s.pool.Close() })
-	_, s.server = newServerWithHub(c, s.pool, s.hub)
+	_, s.server = newServerWithHub(c, s.StatePool, s.hub)
 	s.AddCleanup(func(*gc.C) { s.server.Stop() })
 
 	// A net.TCPAddr cannot be directly stringified into a valid hostname.

--- a/apiserver/utils_test.go
+++ b/apiserver/utils_test.go
@@ -7,27 +7,23 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
-	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/testing"
 )
 
 type utilsSuite struct {
 	testing.StateSuite
-	pool *state.StatePool
 }
 
 var _ = gc.Suite(&utilsSuite{})
 
 func (s *utilsSuite) SetUpTest(c *gc.C) {
 	s.StateSuite.SetUpTest(c)
-	s.pool = state.NewStatePool(s.State)
-	s.AddCleanup(func(*gc.C) { s.pool.Close() })
 }
 
 func (s *utilsSuite) TestValidateEmpty(c *gc.C) {
 	uuid, err := validateModelUUID(
 		validateArgs{
-			statePool: s.pool,
+			statePool: s.StatePool,
 		})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(uuid, gc.Equals, s.State.ModelUUID())
@@ -36,7 +32,7 @@ func (s *utilsSuite) TestValidateEmpty(c *gc.C) {
 func (s *utilsSuite) TestValidateEmptyStrict(c *gc.C) {
 	_, err := validateModelUUID(
 		validateArgs{
-			statePool: s.pool,
+			statePool: s.StatePool,
 			strict:    true,
 		})
 	c.Assert(err, gc.ErrorMatches, `unknown model: ""`)
@@ -45,7 +41,7 @@ func (s *utilsSuite) TestValidateEmptyStrict(c *gc.C) {
 func (s *utilsSuite) TestValidateController(c *gc.C) {
 	uuid, err := validateModelUUID(
 		validateArgs{
-			statePool: s.pool,
+			statePool: s.StatePool,
 			modelUUID: s.State.ModelUUID(),
 		})
 	c.Assert(err, jc.ErrorIsNil)
@@ -55,7 +51,7 @@ func (s *utilsSuite) TestValidateController(c *gc.C) {
 func (s *utilsSuite) TestValidateControllerStrict(c *gc.C) {
 	uuid, err := validateModelUUID(
 		validateArgs{
-			statePool: s.pool,
+			statePool: s.StatePool,
 			modelUUID: s.State.ModelUUID(),
 			strict:    true,
 		})
@@ -66,7 +62,7 @@ func (s *utilsSuite) TestValidateControllerStrict(c *gc.C) {
 func (s *utilsSuite) TestValidateBadModelUUID(c *gc.C) {
 	_, err := validateModelUUID(
 		validateArgs{
-			statePool: s.pool,
+			statePool: s.StatePool,
 			modelUUID: "bad",
 		})
 	c.Assert(err, gc.ErrorMatches, `unknown model: "bad"`)
@@ -78,7 +74,7 @@ func (s *utilsSuite) TestValidateOtherModel(c *gc.C) {
 
 	uuid, err := validateModelUUID(
 		validateArgs{
-			statePool: s.pool,
+			statePool: s.StatePool,
 			modelUUID: envState.ModelUUID(),
 		})
 	c.Assert(err, jc.ErrorIsNil)
@@ -91,7 +87,7 @@ func (s *utilsSuite) TestValidateOtherModelControllerOnly(c *gc.C) {
 
 	_, err := validateModelUUID(
 		validateArgs{
-			statePool:           s.pool,
+			statePool:           s.StatePool,
 			modelUUID:           envState.ModelUUID(),
 			controllerModelOnly: true,
 		})

--- a/juju/testing/conn.go
+++ b/juju/testing/conn.go
@@ -400,7 +400,6 @@ func (s *JujuConnSuite) setUpConn(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.StatePool = state.NewStatePool(s.State)
-	s.AddCleanup(func(*gc.C) { s.StatePool.Close() })
 
 	s.Model, err = s.State.Model()
 	c.Assert(err, jc.ErrorIsNil)
@@ -646,6 +645,14 @@ func (s *JujuConnSuite) tearDownConn(c *gc.C) {
 			)
 		}
 	}
+
+	// Close the state pool before we close the underlying state.
+	if s.StatePool != nil {
+		err := s.StatePool.Close()
+		c.Check(err, jc.ErrorIsNil)
+		s.StatePool = nil
+	}
+
 	// Close state.
 	if s.State != nil {
 		err := s.State.Close()


### PR DESCRIPTION
Many tests were creating state pool instances when the base suite already had one.