### PR TITLE
Support k8s deployment controllers

### DIFF
--- a/caas/broker.go
+++ b/caas/broker.go
@@ -14,8 +14,17 @@ type Broker interface {
 	// a charm for the specified application.
 	EnsureOperator(appName, agentPath string, config *OperatorConfig) error
 
+	// EnsureService creates or updates a service for pods with the given spec.
+	EnsureService(appName, unitSpec string, numUnits int, config ResourceConfig) error
+
+	// DeleteService deletes the specified service.
+	DeleteService(appName string) error
+
+	// ExposeService sets up external access to the specified service.
+	ExposeService(appName string, config ResourceConfig) error
+
 	// EnsureUnit creates or updates a pod with the given spec.
-	EnsureUnit(unitName, spec string) error
+	EnsureUnit(appName, unitName, spec string) error
 }
 
 // OperatorConfig is the config to use when creating an operator.

--- a/caas/config.go
+++ b/caas/config.go
@@ -1,0 +1,54 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package caas
+
+import "strings"
+
+// TODO(caas) - use a broker specific schema and then add tests
+
+// ResourceConfig encapsulates config for CAAS resources like services.
+type ResourceConfig map[string]interface{}
+
+const (
+	// JujuExternalHostNameKey specifies the hostname of a CAAS application.
+	JujuExternalHostNameKey = "juju-external-hostname"
+
+	// JujuApplicationPath specifies the relative http path used to access a CAAS application.
+	JujuApplicationPath = "juju-application-path"
+)
+
+// Get gets the specified attribute.
+func (r ResourceConfig) Get(attrName string, defaultValue interface{}) interface{} {
+	if val, ok := r[attrName]; ok {
+		return val
+	}
+	return defaultValue
+}
+
+// GetInt gets the specified int attribute.
+func (r ResourceConfig) GetInt(attrName string, defaultValue int) int {
+	if val, ok := r[attrName]; ok {
+		if value, ok := val.(float64); ok {
+			return int(value)
+		}
+		return val.(int)
+	}
+	return defaultValue
+}
+
+// GetString gets the specified string attribute.
+func (r ResourceConfig) GetString(attrName string, defaultValue string) string {
+	if val, ok := r[attrName]; ok {
+		return val.(string)
+	}
+	return defaultValue
+}
+
+// GetStringSlice gets the specified []string attribute.
+func (r ResourceConfig) GetStringSlice(attrName string, defaultValue []string) []string {
+	if val, ok := r[attrName]; ok {
+		return strings.Split(val.(string), ",")
+	}
+	return defaultValue
+}

--- a/worker/caasunitprovisioner/broker.go
+++ b/worker/caasunitprovisioner/broker.go
@@ -3,6 +3,18 @@
 
 package caasunitprovisioner
 
+import "github.com/juju/juju/caas"
+
 type ContainerBroker interface {
-	EnsureUnit(unitName, spec string) error
+	EnsureUnit(appName, unitName, spec string) error
+}
+
+type ServiceBroker interface {
+	EnsureService(appName, unitSpec string, numUnits int, config caas.ResourceConfig) error
+	DeleteService(appName string) error
+}
+
+// TODO(caas) - move to a firewaller worker
+type ServiceExposer interface {
+	ExposeService(appName string, config caas.ResourceConfig) error
 }

--- a/worker/caasunitprovisioner/deployment_worker.go
+++ b/worker/caasunitprovisioner/deployment_worker.go
@@ -1,0 +1,140 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package caasunitprovisioner
+
+import (
+	"github.com/juju/errors"
+	"gopkg.in/juju/worker.v1"
+
+	"github.com/juju/juju/caas"
+	"github.com/juju/juju/watcher"
+	"github.com/juju/juju/worker/catacomb"
+)
+
+// deploymentWorker informs the CAAS broker of how many pods to run and their spec, and
+// lets the broker figure out how to make that all happen.
+type deploymentWorker struct {
+	catacomb            catacomb.Catacomb
+	application         string
+	broker              ServiceBroker
+	exposer             ServiceExposer
+	containerSpecGetter ContainerSpecGetter
+
+	aliveUnitsChan <-chan []string
+
+	// TODO(caas) - watch for config changes
+	config caas.ResourceConfig
+}
+
+func newDeploymentWorker(
+	application string,
+	broker ServiceBroker,
+	exposer ServiceExposer,
+	containerSpecGetter ContainerSpecGetter,
+	config caas.ResourceConfig,
+	aliveUnitsChan <-chan []string,
+) (worker.Worker, error) {
+	w := &deploymentWorker{
+		application:         application,
+		broker:              broker,
+		exposer:             exposer,
+		containerSpecGetter: containerSpecGetter,
+		config:              config,
+		aliveUnitsChan:      aliveUnitsChan,
+	}
+	if err := catacomb.Invoke(catacomb.Plan{
+		Site: &w.catacomb,
+		Work: w.loop,
+	}); err != nil {
+		return nil, errors.Trace(err)
+	}
+	return w, nil
+}
+
+// Kill is part of the worker.Worker interface.
+func (w *deploymentWorker) Kill() {
+	w.catacomb.Kill(nil)
+}
+
+// Wait is part of the worker.Worker interface.
+func (w *deploymentWorker) Wait() error {
+	return w.catacomb.Wait()
+}
+
+func (w *deploymentWorker) loop() error {
+
+	var (
+		aliveUnits []string
+		cw         watcher.NotifyWatcher
+		specChan   watcher.NotifyChannel
+
+		currentAliveCount int
+		currentSpec       string
+	)
+
+	gotSpecNotify := false
+	for {
+		select {
+		case <-w.catacomb.Dying():
+			return w.catacomb.ErrDying()
+		case aliveUnits = <-w.aliveUnitsChan:
+			if len(aliveUnits) > 0 && specChan == nil {
+				var err error
+				cw, err = w.containerSpecGetter.WatchContainerSpec(aliveUnits[0])
+				if err != nil {
+					return errors.Trace(err)
+				}
+				w.catacomb.Add(cw)
+				specChan = cw.Changes()
+			}
+		case _, ok := <-specChan:
+			if !ok {
+				return errors.New("watcher closed channel")
+			}
+			gotSpecNotify = true
+		}
+		if len(aliveUnits) == 0 {
+			if cw != nil {
+				worker.Stop(cw)
+				specChan = nil
+			}
+			if err := w.broker.DeleteService(w.application); err != nil {
+				return errors.Trace(err)
+			}
+			continue
+		}
+
+		// TODO(caas) - for now, we assume all units are homogeneous
+		// so we just need to get the first spec and use that one.
+		if !gotSpecNotify {
+			continue
+		}
+		unitSpec, err := w.containerSpecGetter.ContainerSpec(aliveUnits[0])
+		if errors.IsNotFound(err) {
+			// No container spec defined for a unit yet;
+			// wait for one to be set.
+			continue
+		} else if err != nil {
+			return errors.Trace(err)
+		}
+
+		numUnits := len(aliveUnits)
+		if numUnits == currentAliveCount && unitSpec == currentSpec {
+			continue
+		}
+
+		currentAliveCount = numUnits
+		currentSpec = unitSpec
+
+		err = w.broker.EnsureService(w.application, unitSpec, numUnits, w.config)
+		if err != nil {
+			return errors.Trace(err)
+		}
+		// TODO(caas) - move to firewaller worker but just make things work for now
+		if err := w.exposer.ExposeService(w.application, w.config); err != nil {
+			return errors.Trace(err)
+		}
+		logger.Debugf("created/updated deployment for %s for %d units", w.application, numUnits)
+	}
+}

--- a/worker/caasunitprovisioner/manifold.go
+++ b/worker/caasunitprovisioner/manifold.go
@@ -55,8 +55,17 @@ func (config ManifoldConfig) start(context dependency.Context) (worker.Worker, e
 
 	client := config.NewClient(apiCaller)
 	w, err := config.NewWorker(Config{
-		ApplicationGetter:   client,
-		ContainerBroker:     broker,
+		ApplicationGetter: client,
+
+		// TODO(caas) - get this based on the CAAS substrate
+		BrokerManagedUnits: true,
+
+		ServiceBroker:   broker,
+		ContainerBroker: broker,
+
+		// TODO(caas) - move to a firewaller worker
+		ServiceExposer: broker,
+
 		ContainerSpecGetter: client,
 		LifeGetter:          client,
 		UnitGetter:          client,

--- a/worker/caasunitprovisioner/manifold_test.go
+++ b/worker/caasunitprovisioner/manifold_test.go
@@ -127,8 +127,11 @@ func (s *ManifoldSuite) TestStart(c *gc.C) {
 	config := args[0].(caasunitprovisioner.Config)
 
 	c.Assert(config, jc.DeepEquals, caasunitprovisioner.Config{
+		BrokerManagedUnits:  true,
 		ApplicationGetter:   &s.client,
+		ServiceBroker:       &s.broker,
 		ContainerBroker:     &s.broker,
+		ServiceExposer:      &s.broker,
 		ContainerSpecGetter: &s.client,
 		LifeGetter:          &s.client,
 		UnitGetter:          &s.client,

--- a/worker/caasunitprovisioner/mock_test.go
+++ b/worker/caasunitprovisioner/mock_test.go
@@ -26,13 +26,38 @@ type fakeClient struct {
 	caasunitprovisioner.Client
 }
 
+type mockServiceBroker struct {
+	testing.Stub
+	ensured chan<- struct{}
+}
+
+func (m *mockServiceBroker) EnsureService(appName, unitSpec string, numUnits int, config caas.ResourceConfig) error {
+	m.MethodCall(m, "EnsureService", appName, unitSpec, numUnits, config)
+	m.ensured <- struct{}{}
+	return m.NextErr()
+}
+
+func (m *mockServiceBroker) DeleteService(appName string) error {
+	m.MethodCall(m, "DeleteService", appName)
+	return m.NextErr()
+}
+
+type mockServiceExposer struct {
+	testing.Stub
+}
+
+func (m *mockServiceExposer) ExposeService(appName string, config caas.ResourceConfig) error {
+	m.MethodCall(m, "ExposeService", appName, config)
+	return m.NextErr()
+}
+
 type mockContainerBroker struct {
 	testing.Stub
 	ensured chan<- struct{}
 }
 
-func (m *mockContainerBroker) EnsureUnit(unitName, spec string) error {
-	m.MethodCall(m, "EnsureUnit", unitName, spec)
+func (m *mockContainerBroker) EnsureUnit(appName, unitName, spec string) error {
+	m.MethodCall(m, "EnsureUnit", appName, unitName, spec)
 	m.ensured <- struct{}{}
 	return m.NextErr()
 }

--- a/worker/caasunitprovisioner/unit_worker.go
+++ b/worker/caasunitprovisioner/unit_worker.go
@@ -12,17 +12,20 @@ import (
 
 type unitWorker struct {
 	catacomb            catacomb.Catacomb
+	application         string
 	unit                string
 	broker              ContainerBroker
 	containerSpecGetter ContainerSpecGetter
 }
 
 func newUnitWorker(
+	application string,
 	unit string,
 	broker ContainerBroker,
 	containerSpecGetter ContainerSpecGetter,
 ) (worker.Worker, error) {
 	w := &unitWorker{
+		application:         application,
 		unit:                unit,
 		broker:              broker,
 		containerSpecGetter: containerSpecGetter,
@@ -74,7 +77,7 @@ func (w *unitWorker) loop() error {
 			if err != nil {
 				return errors.Trace(err)
 			}
-			if err := w.broker.EnsureUnit(w.unit, spec); err != nil {
+			if err := w.broker.EnsureUnit(w.application, w.unit, spec); err != nil {
 				return errors.Trace(err)
 			}
 			logger.Debugf("created/updated unit %s", w.unit)


### PR DESCRIPTION
## Description of change

Now when a CAAS charm is deployed, we:
- create a k8s service for the pods
- allow external access by creating an ingress resource
- use a k8s deployment controller to simplify the management of the pods

There's also initial infrastructure to allow aspects of the deployment to be user configured once we support recording those settings for the app.

## QA steps

deploy a caas model on a k8s with a running nginx ingress controller
juju deploy gitlab
->check 1 pod
add/remove units
-> check pod count matches
remove all units
-> check deployment controller and service are deleted

check ingress works (assuming external address is hardwired into the code)
