### PR TITLE
Added test coverage for command output for errors or empty model list.

### DIFF
--- a/cmd/juju/controller/export_test.go
+++ b/cmd/juju/controller/export_test.go
@@ -175,3 +175,7 @@ func FmtModelStatus(data ModelData) string {
 func NewData(api destroyControllerAPI, ctrUUID string) (ctrData, []modelData, error) {
 	return newData(api, ctrUUID)
 }
+
+var (
+	NoModelsMessage = noModelsMessage
+)

--- a/cmd/juju/controller/listmodels_test.go
+++ b/cmd/juju/controller/listmodels_test.go
@@ -459,8 +459,8 @@ func (s *BaseModelsSuite) assertAgentVersionPresent(c *gc.C, testInfo *params.Mo
 	}
 	context, err := cmdtesting.RunCommand(c, s.newCommand(), "--format=yaml")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(cmdtesting.Stderr(context), gc.Equals, "")
 	c.Assert(cmdtesting.Stdout(context), checker, "agent-version")
+	c.Assert(cmdtesting.Stderr(context), gc.Equals, "")
 }
 
 func (s *BaseModelsSuite) checkAPICalls(c *gc.C, expectedCalls ...string) {


### PR DESCRIPTION
## Description of change

We were not checking whether a user is getting consistent feedback when errors occurs or when model list is empty.

This PR expands unit tests coverage as well as ensures that helpful errors are surfaced/visible to the user.

Need for 2nd opinion - When model list is empty, should we display an empty table? I.e. only column headers... It may not be misleading but is certainly redundant since we also provide an empty-model-list message.