### PR TITLE
upgrades: upgrade step to add relation status

### DIFF
--- a/state/upgrades.go
+++ b/state/upgrades.go
@@ -22,6 +22,7 @@ import (
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/state/globalclock"
 	"github.com/juju/juju/state/lease"
+	"github.com/juju/juju/status"
 	"github.com/juju/juju/storage/provider"
 )
 
@@ -1261,4 +1262,52 @@ func migrateModelLeasesToGlobalTime(st *State) error {
 		return ops, nil
 	})
 	return errors.Annotate(err, "upgrading legacy lease documents")
+}
+
+// AddRelationStatus sets the initial status for existing relations
+// without a status.
+func AddRelationStatus(st *State) error {
+	return runForAllModelStates(st, addRelationStatus)
+}
+
+func addRelationStatus(st *State) error {
+	// Newly created relations will have a status doc,
+	// so it suffices to just get the collection once
+	// up front.
+	relations, err := st.AllRelations()
+	if err != nil {
+		return errors.Trace(err)
+	}
+	now := st.clock().Now()
+	err = st.db().Run(func(int) ([]txn.Op, error) {
+		var ops []txn.Op
+		for _, rel := range relations {
+			_, err := rel.Status()
+			if err == nil {
+				continue
+			}
+			if !errors.IsNotFound(err) {
+				return nil, err
+			}
+			// Relations are marked as either
+			// joining or joined, depending
+			// on whether there are any units
+			// in scope.
+			relStatus := status.Joining
+			if rel.doc.UnitCount > 0 {
+				relStatus = status.Joined
+			}
+			relationStatusDoc := statusDoc{
+				Status:    relStatus,
+				ModelUUID: st.ModelUUID(),
+				Updated:   now.UnixNano(),
+			}
+			ops = append(ops, createStatusOp(
+				st, relationGlobalScope(rel.Id()),
+				relationStatusDoc,
+			))
+		}
+		return ops, nil
+	})
+	return errors.Annotate(err, "adding relation status")
 }

--- a/state/upgrades_test.go
+++ b/state/upgrades_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
+	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils"
 	"github.com/juju/utils/set"
@@ -20,7 +21,7 @@ import (
 	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/storage/provider"
-	"github.com/juju/juju/testing"
+	coretesting "github.com/juju/juju/testing"
 )
 
 type upgradesSuite struct {
@@ -976,9 +977,9 @@ func (s *upgradesSuite) TestAddControllerLogCollectionsSizeSettings(c *gc.C) {
 	)
 }
 
-func (s *upgradesSuite) makeModel(c *gc.C, name string, attr testing.Attrs) *State {
+func (s *upgradesSuite) makeModel(c *gc.C, name string, attr coretesting.Attrs) *State {
 	uuid := utils.MustNewUUID()
-	cfg := testing.CustomModelConfig(c, testing.Attrs{
+	cfg := coretesting.CustomModelConfig(c, coretesting.Attrs{
 		"name": name,
 		"uuid": uuid.String(),
 	}.Merge(attr))
@@ -1011,13 +1012,13 @@ func (s *upgradesSuite) TestAddUpdateStatusHookSettings(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	// One model has a valid setting that is not default.
-	m1 := s.makeModel(c, "m1", testing.Attrs{
+	m1 := s.makeModel(c, "m1", coretesting.Attrs{
 		"update-status-hook-interval": "20m",
 	})
 	defer m1.Close()
 
 	// This model is missing a setting entirely.
-	m2 := s.makeModel(c, "m2", testing.Attrs{})
+	m2 := s.makeModel(c, "m2", coretesting.Attrs{})
 	defer m2.Close()
 	// We remove the 'update-status-hook-interval' value to
 	// represent an old-style model that needs updating.
@@ -1318,7 +1319,7 @@ func (s *upgradesSuite) TestSplitLogCollection(c *gc.C) {
 			"e":   modelUUID,
 			"r":   "2.1.2",
 			"n":   fmt.Sprintf("fake-entitiy-%d", i),
-			"m":   "juju.testing",
+			"m":   "juju.coretesting",
 			"l":   "fake-file.go:1234",
 			"v":   int(loggo.DEBUG),
 			"x":   "test message",
@@ -1389,7 +1390,7 @@ func (s *upgradesSuite) TestSplitLogsIgnoresDupeRecordsAlreadyThere(c *gc.C) {
 			"e":   modelUUID,
 			"r":   "2.1.2",
 			"n":   fmt.Sprintf("fake-entitiy-%d", i),
-			"m":   "juju.testing",
+			"m":   "juju.coretesting",
 			"l":   "fake-file.go:1234",
 			"v":   int(loggo.DEBUG),
 			"x":   "test message",
@@ -1453,7 +1454,7 @@ func (s *upgradesSuite) TestCorrectRelationUnitCounts(c *gc.C) {
 
 	// Use the non-controller model to ensure we can run the function
 	// across multiple models.
-	otherState := s.makeModel(c, "crack-up", testing.Attrs{})
+	otherState := s.makeModel(c, "crack-up", coretesting.Attrs{})
 	defer otherState.Close()
 
 	uuid := otherState.ModelUUID()
@@ -1802,13 +1803,13 @@ func (s *upgradesSuite) checkAddPruneSettings(c *gc.C, ageProp, sizeProp, defaul
 	_, err := settingsColl.RemoveAll(nil)
 	c.Assert(err, jc.ErrorIsNil)
 
-	m1 := s.makeModel(c, "m1", testing.Attrs{
+	m1 := s.makeModel(c, "m1", coretesting.Attrs{
 		ageProp:  "96h",
 		sizeProp: "4G",
 	})
 	defer m1.Close()
 
-	m2 := s.makeModel(c, "m2", testing.Attrs{})
+	m2 := s.makeModel(c, "m2", coretesting.Attrs{})
 	defer m2.Close()
 
 	err = settingsColl.Insert(bson.M{
@@ -1861,7 +1862,7 @@ func (s *upgradesSuite) TestMigrateLeasesToGlobalTime(c *gc.C) {
 
 	// Use the non-controller model to ensure we can run the function
 	// across multiple models.
-	otherState := s.makeModel(c, "crack-up", testing.Attrs{})
+	otherState := s.makeModel(c, "crack-up", coretesting.Attrs{})
 	defer otherState.Close()
 
 	uuid := otherState.ModelUUID()
@@ -1903,5 +1904,77 @@ func (s *upgradesSuite) TestMigrateLeasesToGlobalTime(c *gc.C) {
 	}}
 	s.assertUpgradedData(c, MigrateLeasesToGlobalTime,
 		expectUpgradedData{leases, expectedLeases},
+	)
+}
+
+func (s *upgradesSuite) TestAddRelationStatus(c *gc.C) {
+	// Set a test clock so we can dictate the
+	// time set in the new status doc.
+	clock := testing.NewClock(time.Unix(0, 123))
+	s.state.SetClockForTesting(clock)
+
+	relations, closer := s.state.db().GetRawCollection(relationsC)
+	defer closer()
+
+	statuses, closer := s.state.db().GetRawCollection(statusesC)
+	defer closer()
+
+	err := relations.Insert(bson.M{
+		"_id":        s.state.ModelUUID() + ":0",
+		"id":         0,
+		"model-uuid": s.state.ModelUUID(),
+	}, bson.M{
+		"_id":        s.state.ModelUUID() + ":1",
+		"id":         1,
+		"model-uuid": s.state.ModelUUID(),
+		"unitcount":  1,
+	}, bson.M{
+		"_id":        s.state.ModelUUID() + ":2",
+		"id":         2,
+		"model-uuid": s.state.ModelUUID(),
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	_, err = statuses.RemoveAll(nil)
+	c.Assert(err, jc.ErrorIsNil)
+	err = statuses.Insert(bson.M{
+		"_id":        s.state.ModelUUID() + ":r#2",
+		"model-uuid": s.state.ModelUUID(),
+		"status":     "broken",
+		"statusdata": bson.M{},
+		"statusinfo": "",
+		"updated":    int64(321),
+		"neverset":   false,
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	expectedStatuses := []bson.M{{
+		"_id":        s.state.ModelUUID() + ":r#0",
+		"model-uuid": s.state.ModelUUID(),
+		"status":     "joining",
+		"statusdata": bson.M{},
+		"statusinfo": "",
+		"updated":    int64(123),
+		"neverset":   false,
+	}, {
+		"_id":        s.state.ModelUUID() + ":r#1",
+		"model-uuid": s.state.ModelUUID(),
+		"status":     "joined",
+		"statusdata": bson.M{},
+		"statusinfo": "",
+		"updated":    int64(123),
+		"neverset":   false,
+	}, {
+		"_id":        s.state.ModelUUID() + ":r#2",
+		"model-uuid": s.state.ModelUUID(),
+		"status":     "broken",
+		"statusdata": bson.M{},
+		"statusinfo": "",
+		"updated":    int64(321),
+		"neverset":   false,
+	}}
+
+	s.assertUpgradedData(c, AddRelationStatus,
+		expectUpgradedData{statuses, expectedStatuses},
 	)
 }

--- a/upgrades/backend.go
+++ b/upgrades/backend.go
@@ -33,6 +33,7 @@ type StateBackend interface {
 	AddModelEnvironVersion() error
 	AddModelType() error
 	MigrateLeasesToGlobalTime() error
+	AddRelationStatus() error
 }
 
 // Model is an interface providing access to the details of a model within the
@@ -125,6 +126,10 @@ func (s stateBackend) AddModelType() error {
 
 func (s stateBackend) MigrateLeasesToGlobalTime() error {
 	return state.MigrateLeasesToGlobalTime(s.st)
+}
+
+func (s stateBackend) AddRelationStatus() error {
+	return state.AddRelationStatus(s.st)
 }
 
 type modelShim struct {

--- a/upgrades/operations.go
+++ b/upgrades/operations.go
@@ -26,6 +26,7 @@ var stateUpgradeOperations = func() []Operation {
 		upgradeToVersion{version.MustParse("2.2.2"), stateStepsFor222()},
 		upgradeToVersion{version.MustParse("2.2.3"), stateStepsFor223()},
 		upgradeToVersion{version.MustParse("2.3.0"), stateStepsFor23()},
+		upgradeToVersion{version.MustParse("2.3.1"), stateStepsFor231()},
 	}
 	return steps
 }

--- a/upgrades/steps_23.go
+++ b/upgrades/steps_23.go
@@ -22,3 +22,16 @@ func stateStepsFor23() []Step {
 		},
 	}
 }
+
+// stateStepsFor231 returns upgrade steps for Juju 2.3.1 that manipulate state directly.
+func stateStepsFor231() []Step {
+	return []Step{
+		&upgradeStep{
+			description: "add status to relations",
+			targets:     []Target{DatabaseMaster},
+			run: func(context Context) error {
+				return context.State().AddRelationStatus()
+			},
+		},
+	}
+}

--- a/upgrades/steps_23_test.go
+++ b/upgrades/steps_23_test.go
@@ -12,7 +12,10 @@ import (
 	"github.com/juju/juju/upgrades"
 )
 
-var v23 = version.MustParse("2.3.0")
+var (
+	v23  = version.MustParse("2.3.0")
+	v231 = version.MustParse("2.3.1")
+)
 
 type steps23Suite struct {
 	testing.BaseSuite
@@ -28,6 +31,12 @@ func (s *steps23Suite) TestAddModelType(c *gc.C) {
 
 func (s *steps23Suite) TestMigrateLeases(c *gc.C) {
 	step := findStateStep(c, v23, "migrate old leases")
+	// Logic for step itself is tested in state package.
+	c.Assert(step.Targets(), jc.DeepEquals, []upgrades.Target{upgrades.DatabaseMaster})
+}
+
+func (s *steps23Suite) TestAddRelationStatus(c *gc.C) {
+	step := findStateStep(c, v231, "add status to relations")
 	// Logic for step itself is tested in state package.
 	c.Assert(step.Targets(), jc.DeepEquals, []upgrades.Target{upgrades.DatabaseMaster})
 }

--- a/upgrades/upgrade_test.go
+++ b/upgrades/upgrade_test.go
@@ -642,6 +642,7 @@ func (s *upgradeSuite) TestStateUpgradeOperationsVersions(c *gc.C) {
 		"2.2.2",
 		"2.2.3",
 		"2.3.0",
+		"2.3.1",
 	})
 }
 


### PR DESCRIPTION
## Description of change

Add an upgrade step to set relation status for
old relations. All new relations have status,
and there are assumptions that all relations
have status.

## QA steps

1. juju bootstrap --agent-version=2.2.6
2. juju deploy cs:ubuntu
3. juju deploy cs:telegraf
4. juju add-relation ubuntu telegraf
5. juju upgrade-juju -m controller
6. juju upgrade-juju
7. juju debug-log
(should not be any uniter errors)

## Documentation changes

None.

## Bug reference

Fixes https://bugs.launchpad.net/juju/+bug/1737107