### PR TITLE
audit-logging: Send the command line with login

### DIFF
--- a/api/apiclient_test.go
+++ b/api/apiclient_test.go
@@ -11,6 +11,8 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"reflect"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -1087,6 +1089,39 @@ func (s *apiclientSuite) TestIsBrokenPingFailed(c *gc.C) {
 	c.Assert(conn.IsBroken(), jc.IsTrue)
 }
 
+func (s *apiclientSuite) TestLoginCapturesCLIArgs(c *gc.C) {
+	s.PatchValue(&os.Args, []string{"this", "is", "the test", "command"})
+
+	info := s.APIInfo(c)
+	conn := newRPCConnection()
+	conn.response = &params.LoginResult{
+		ControllerTag: "controller-" + s.ControllerConfig.ControllerUUID(),
+		ServerVersion: "2.3-rc2",
+	}
+	// Pass an already-closed channel so we don't wait for the monitor
+	// to signal the rpc connection is dead when closing the state
+	// (because there's no monitor running).
+	broken := make(chan struct{})
+	close(broken)
+	testState := api.NewTestingState(api.TestingStateParams{
+		RPCConnection: conn,
+		Clock:         &fakeClock{},
+		Address:       "localhost:1234",
+		Broken:        broken,
+		Closed:        make(chan struct{}),
+	})
+	err := testState.Login(info.Tag, info.Password, "", nil)
+	c.Assert(err, jc.ErrorIsNil)
+
+	calls := conn.stub.Calls()
+	c.Assert(calls, gc.HasLen, 1)
+	call := calls[0]
+	c.Assert(call.FuncName, gc.Equals, "Admin.Login")
+	c.Assert(call.Args, gc.HasLen, 2)
+	request := call.Args[1].(*params.LoginRequest)
+	c.Assert(request.CLIArgs, gc.Equals, `this is "the test" command`)
+}
+
 type fakeClock struct {
 	clock.Clock
 
@@ -1123,7 +1158,8 @@ func newRPCConnection(errs ...error) *fakeRPCConnection {
 }
 
 type fakeRPCConnection struct {
-	stub testing.Stub
+	stub     testing.Stub
+	response interface{}
 }
 
 func (f *fakeRPCConnection) Dead() <-chan struct{} {
@@ -1136,6 +1172,11 @@ func (f *fakeRPCConnection) Close() error {
 
 func (f *fakeRPCConnection) Call(req rpc.Request, params, response interface{}) error {
 	f.stub.AddCall(req.Type+"."+req.Action, req.Version, params)
+	if f.response != nil {
+		rv := reflect.ValueOf(response)
+		target := reflect.Indirect(rv)
+		target.Set(reflect.Indirect(reflect.ValueOf(f.response)))
+	}
 	return f.stub.NextErr()
 }
 

--- a/api/export_test.go
+++ b/api/export_test.go
@@ -70,7 +70,7 @@ type TestingStateParams struct {
 	ServerRoot     string
 	RPCConnection  RPCConnection
 	Clock          clock.Clock
-	Broken         chan struct{}
+	Broken, Closed chan struct{}
 }
 
 // NewTestingState creates an api.State object that can be used for testing. It
@@ -95,6 +95,7 @@ func NewTestingState(params TestingStateParams) Connection {
 		serverScheme:      params.ServerScheme,
 		serverRootAddress: params.ServerRoot,
 		broken:            params.Broken,
+		closed:            params.Closed,
 	}
 	return st
 }

--- a/api/state.go
+++ b/api/state.go
@@ -6,10 +6,12 @@ package api
 import (
 	"net"
 	"net/url"
+	"os"
 	"runtime/debug"
 	"strconv"
 
 	"github.com/juju/errors"
+	"github.com/juju/utils"
 	"github.com/juju/utils/featureflag"
 	"github.com/juju/version"
 	"gopkg.in/juju/names.v2"
@@ -42,6 +44,7 @@ func (st *state) Login(tag names.Tag, password, nonce string, macaroons []macaro
 		Credentials: password,
 		Nonce:       nonce,
 		Macaroons:   macaroons,
+		CLIArgs:     utils.CommandString(os.Args...),
 	}
 	// If we are in developer mode, add the stack location as user data to the
 	// login request. This will allow the apiserver to connect connection ids

--- a/apiserver/params/params.go
+++ b/apiserver/params/params.go
@@ -529,6 +529,7 @@ type LoginRequest struct {
 	Credentials string           `json:"credentials"`
 	Nonce       string           `json:"nonce"`
 	Macaroons   []macaroon.Slice `json:"macaroons"`
+	CLIArgs     string           `json:"cli-args,omitempty"`
 	UserData    string           `json:"user-data"`
 }
 


### PR DESCRIPTION
## Description of change

Adds CLIArgs to LoginRequest, and populates it with os.Args when sending the login request from the client. (The controller doesn't do anything with it yet - eventually it'll write it into the audit log along with
facade method calls.)

This will let us tie API method calls to the command that was run to generate them.

## QA steps

Run a series of commands against a controller with trace logging turned on. Check that the logged API requests include the cli-args key with the command that was run.

(Backport of #8130 to the 2.3 branch.)