### PR TITLE
audit-logging: Add core.auditlog package

### DIFF
--- a/core/auditlog/auditlog.go
+++ b/core/auditlog/auditlog.go
@@ -1,0 +1,251 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+package auditlog
+
+import (
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"math/rand"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/juju/errors"
+	"github.com/juju/loggo"
+	"github.com/juju/utils"
+	"gopkg.in/natefinch/lumberjack.v2"
+)
+
+var logger = loggo.GetLogger("core.auditlog")
+
+// Conversation represents a high-level juju command from the juju
+// client (or other client). There'll be one Conversation per API
+// connection from the client, with zero or more associated
+// Request/ResponseErrors pairs.
+type Conversation struct {
+	Who            string `json:"who"`        // username@idm
+	What           string `json:"what"`       // "juju deploy ./foo/bar"
+	When           string `json:"when"`       // ISO 8601 to second precision
+	ModelName      string `json:"model-name"` // full representation "user/name"
+	ModelUUID      string `json:"model-uuid"`
+	ConversationID string `json:"conversation-id"` // uint64 in hex
+	ConnectionID   string `json:"connection-id"`   // uint64 in hex (using %X to match the value in log files)
+}
+
+// ConversationArgs is the information needed to create a method recorder.
+type ConversationArgs struct {
+	Who          string
+	What         string
+	When         time.Time
+	ModelName    string
+	ModelUUID    string
+	ConnectionID uint64
+}
+
+// Request represents a call to an API facade made as part of
+// a specific conversation.
+type Request struct {
+	ConversationID string `json:"conversation-id"`
+	ConnectionID   string `json:"connection-id"`
+	RequestID      uint64 `json:"request-id"`
+	Facade         string `json:"facade"`
+	Method         string `json:"method"`
+	Version        int    `json:"version"`
+	Args           string `json:"args,omitempty"`
+}
+
+// RequestArgs is the information about an API call that we want to
+// record.
+type RequestArgs struct {
+	Facade    string
+	Method    string
+	Version   int
+	Args      string
+	RequestID uint64
+}
+
+// ResponseErrors captures any errors coming back from the API in
+// response to a request.
+type ResponseErrors struct {
+	ConversationID string   `json:"conversation-id"`
+	ConnectionID   string   `json:"connection-id"`
+	RequestID      uint64   `json:"request-id"`
+	Errors         []*Error `json:"errors"`
+}
+
+// ResponseErrorsArgs has errors from an API response to record in the
+// audit log.
+type ResponseErrorsArgs struct {
+	RequestID uint64
+	Errors    []*Error
+}
+
+// Error holds the details of an error sent back from the API.
+type Error struct {
+	Message string `json:"message"`
+	Code    string `json:"code"`
+}
+
+// Record is the top-level entry type in an audit log, which serves as
+// a type discriminator. Only one of Conversation/Request/Errors should be set.
+type Record struct {
+	Conversation *Conversation   `json:"conversation,omitempty"`
+	Request      *Request        `json:"request,omitempty"`
+	Errors       *ResponseErrors `json:"errors,omitempty"`
+}
+
+// AuditLog represents something that can store calls, requests and
+// responses somewhere.
+type AuditLog interface {
+	AddConversation(c Conversation) error
+	AddRequest(r Request) error
+	AddResponse(r ResponseErrors) error
+	Close() error
+}
+
+// Recorder records method calls for a specific API connection.
+type Recorder struct {
+	log          AuditLog
+	connectionID string
+	callID       string
+}
+
+// NewRecorder creates a Recorder for the connection described (and
+// stores details of the initial call in the log).
+func NewRecorder(log AuditLog, c ConversationArgs) (*Recorder, error) {
+	callID := newConversationID()
+	connectionID := idString(c.ConnectionID)
+	err := log.AddConversation(Conversation{
+		ConversationID: callID,
+		ConnectionID:   connectionID,
+		Who:            c.Who,
+		What:           c.What,
+		When:           c.When.Format(time.RFC3339),
+		ModelName:      c.ModelName,
+		ModelUUID:      c.ModelUUID,
+	})
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return &Recorder{
+		log:          log,
+		callID:       callID,
+		connectionID: connectionID,
+	}, nil
+}
+
+// AddRequest records a method call to the API.
+func (r *Recorder) AddRequest(m RequestArgs) error {
+	return errors.Trace(r.log.AddRequest(Request{
+		ConversationID: r.callID,
+		ConnectionID:   r.connectionID,
+		RequestID:      m.RequestID,
+		Facade:         m.Facade,
+		Method:         m.Method,
+		Version:        m.Version,
+		Args:           m.Args,
+	}))
+}
+
+// AddResponse records the result of a method call to the API.
+func (r *Recorder) AddResponse(m ResponseErrorsArgs) error {
+	return errors.Trace(r.log.AddResponse(ResponseErrors{
+		ConversationID: r.callID,
+		ConnectionID:   r.connectionID,
+		RequestID:      m.RequestID,
+		Errors:         m.Errors,
+	}))
+}
+
+// newConversationID generates a random 64bit integer as hex - this
+// will be used to link the requests and responses with the command
+// the user issued. We don't use the API server's connection ID here
+// because that starts from 0 and increments, so it resets when the
+// API server is restarted. The conversation ID needs to be unique
+// across restarts, otherwise we'd attribute requests to the wrong
+// conversation.
+func newConversationID() string {
+	buf := make([]byte, 8)
+	rand.Read(buf) // Can't fail
+	return hex.EncodeToString(buf)
+}
+
+type auditLogFile struct {
+	fileLogger io.WriteCloser
+}
+
+// NewLogFile returns an audit entry sink which writes to an audit.log
+// file in the specified directory. maxSize is the maximum size (in
+// megabytes) of the log file before it gets rotated. maxBackups is
+// the maximum number of old compressed log files to keep (or 0 to
+// keep all of them).
+func NewLogFile(logDir string, maxSize, maxBackups int) AuditLog {
+	logPath := filepath.Join(logDir, "audit.log")
+	if err := primeLogFile(logPath); err != nil {
+		// This isn't a fatal error so log and continue if priming
+		// fails.
+		logger.Errorf("Unable to prime %s (proceeding anyway): %v", logPath, err)
+	}
+
+	return &auditLogFile{
+		fileLogger: &lumberjack.Logger{
+			Filename:   logPath,
+			MaxSize:    maxSize,
+			MaxBackups: maxBackups,
+			Compress:   true,
+		},
+	}
+}
+
+// AddConversation implements AuditLog.
+func (a *auditLogFile) AddConversation(c Conversation) error {
+	return errors.Trace(a.addRecord(Record{Conversation: &c}))
+}
+
+// AddRequest implements AuditLog.
+func (a *auditLogFile) AddRequest(m Request) error {
+	return errors.Trace(a.addRecord(Record{Request: &m}))
+
+}
+
+// AddResponse implements AuditLog.
+func (a *auditLogFile) AddResponse(m ResponseErrors) error {
+	return errors.Trace(a.addRecord(Record{Errors: &m}))
+}
+
+// Close implements AuditLog.
+func (a *auditLogFile) Close() error {
+	return errors.Trace(a.fileLogger.Close())
+}
+
+func (a *auditLogFile) addRecord(r Record) error {
+	bytes, err := json.Marshal(r)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	// Add a linebreak to bytes rather than doing two calls to write
+	// just in case lumberjack rolls the file between them.
+	bytes = append(bytes, byte('\n'))
+	_, err = a.fileLogger.Write(bytes)
+	return errors.Trace(err)
+}
+
+func idString(id uint64) string {
+	return fmt.Sprintf("%X", id)
+}
+
+// primeLogFile ensures the logsink log file is created with the
+// correct mode and ownership.
+func primeLogFile(path string) error {
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY, 0600)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	if err := f.Close(); err != nil {
+		return errors.Trace(err)
+	}
+	err = utils.ChownPath(path, "syslog")
+	return errors.Trace(err)
+}

--- a/core/auditlog/auditlog_test.go
+++ b/core/auditlog/auditlog_test.go
@@ -1,0 +1,164 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+package auditlog_test
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/core/auditlog"
+)
+
+type AuditLogSuite struct {
+	testing.IsolationSuite
+}
+
+var _ = gc.Suite(&AuditLogSuite{})
+
+func (s *AuditLogSuite) TestAuditLogFile(c *gc.C) {
+	dir := c.MkDir()
+	logFile := auditlog.NewLogFile(dir, 300, 10)
+	err := logFile.AddConversation(auditlog.Conversation{
+		Who:            "deerhoof",
+		What:           "gojira",
+		When:           "2017-11-27T13:21:24Z",
+		ModelName:      "admin/default",
+		ConversationID: "0123456789abcdef",
+		ConnectionID:   "AC1",
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	err = logFile.AddRequest(auditlog.Request{
+		ConversationID: "0123456789abcdef",
+		ConnectionID:   "AC1",
+		RequestID:      25,
+		Facade:         "Application",
+		Method:         "Deploy",
+		Version:        4,
+		Args:           `{"applications": [{"application": "prometheus"}]}`,
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	err = logFile.AddResponse(auditlog.ResponseErrors{
+		ConversationID: "0123456789abcdef",
+		ConnectionID:   "AC1",
+		RequestID:      25,
+		Errors: []*auditlog.Error{
+			{Message: "oops", Code: "unauthorized access"},
+		},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	err = logFile.Close()
+	c.Assert(err, jc.ErrorIsNil)
+
+	bytes, err := ioutil.ReadFile(filepath.Join(dir, "audit.log"))
+	c.Assert(string(bytes), gc.Equals, expectedLogContents)
+}
+
+func (s *AuditLogSuite) TestAuditLogFilePriming(c *gc.C) {
+	dir := c.MkDir()
+	logFile := auditlog.NewLogFile(dir, 300, 10)
+	err := logFile.Close()
+	c.Assert(err, jc.ErrorIsNil)
+
+	info, err := os.Stat(filepath.Join(dir, "audit.log"))
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(info.Mode(), gc.Equals, os.FileMode(0600))
+	// The chown will only work when run as root.
+}
+
+func (s *AuditLogSuite) TestRecorder(c *gc.C) {
+	var log fakeLog
+	logTime, err := time.Parse(time.RFC3339, "2017-11-27T15:45:23Z")
+	c.Assert(err, jc.ErrorIsNil)
+	rec, err := auditlog.NewRecorder(&log, auditlog.ConversationArgs{
+		Who:          "wildbirds and peacedrums",
+		What:         "Doubt/Hope",
+		When:         logTime,
+		ModelName:    "admin/default",
+		ConnectionID: 687,
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	err = rec.AddRequest(auditlog.RequestArgs{
+		RequestID: 246,
+		Facade:    "Death Vessel",
+		Method:    "Horchata",
+		Version:   5,
+		Args:      `{"a": "something"}`,
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	err = rec.AddResponse(auditlog.ResponseErrorsArgs{
+		RequestID: 246,
+		Errors: []*auditlog.Error{{
+			Message: "something bad",
+			Code:    "bad request",
+		}},
+	})
+
+	log.stub.CheckCallNames(c, "AddConversation", "AddRequest", "AddResponse")
+	calls := log.stub.Calls()
+	rec0 := calls[0].Args[0].(auditlog.Conversation)
+	callID := rec0.ConversationID
+	c.Assert(rec0, gc.DeepEquals, auditlog.Conversation{
+		Who:            "wildbirds and peacedrums",
+		What:           "Doubt/Hope",
+		When:           "2017-11-27T15:45:23Z",
+		ModelName:      "admin/default",
+		ConnectionID:   "2AF",
+		ConversationID: callID,
+	})
+	c.Assert(calls[1].Args[0], gc.DeepEquals, auditlog.Request{
+		ConversationID: callID,
+		ConnectionID:   "2AF",
+		RequestID:      246,
+		Facade:         "Death Vessel",
+		Method:         "Horchata",
+		Version:        5,
+		Args:           `{"a": "something"}`,
+	})
+	c.Assert(calls[2].Args[0], gc.DeepEquals, auditlog.ResponseErrors{
+		ConversationID: callID,
+		ConnectionID:   "2AF",
+		RequestID:      246,
+		Errors: []*auditlog.Error{{
+			Message: "something bad",
+			Code:    "bad request",
+		}},
+	})
+}
+
+type fakeLog struct {
+	stub testing.Stub
+}
+
+func (l *fakeLog) AddConversation(m auditlog.Conversation) error {
+	l.stub.AddCall("AddConversation", m)
+	return l.stub.NextErr()
+}
+
+func (l *fakeLog) AddRequest(m auditlog.Request) error {
+	l.stub.AddCall("AddRequest", m)
+	return l.stub.NextErr()
+}
+
+func (l *fakeLog) AddResponse(m auditlog.ResponseErrors) error {
+	l.stub.AddCall("AddResponse", m)
+	return l.stub.NextErr()
+}
+
+func (l *fakeLog) Close() error {
+	l.stub.AddCall("Close")
+	return l.stub.NextErr()
+}
+
+var (
+	expectedLogContents = `
+{"conversation":{"who":"deerhoof","what":"gojira","when":"2017-11-27T13:21:24Z","model-name":"admin/default","model-uuid":"","conversation-id":"0123456789abcdef","connection-id":"AC1"}}
+{"request":{"conversation-id":"0123456789abcdef","connection-id":"AC1","request-id":25,"facade":"Application","method":"Deploy","version":4,"args":"{\"applications\": [{\"application\": \"prometheus\"}]}"}}
+{"errors":{"conversation-id":"0123456789abcdef","connection-id":"AC1","request-id":25,"errors":[{"message":"oops","code":"unauthorized access"}]}}
+`[1:]
+)

--- a/core/auditlog/package_test.go
+++ b/core/auditlog/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package auditlog_test
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func TestPackage(t *testing.T) {
+	gc.TestingT(t)
+}


### PR DESCRIPTION
## Description of change

core.auditlog contains the `AuditLogFile` and `Recorder`, which will be used in the apiserver (in a subsequent PR) to write audit log information as API methods are called.

## QA steps

No behaviour change - not integrated into apiserver yet.

(This is a backport of #8138 to the 2.3 branch.)