### PR TITLE
Fix vSphere firewalling

### DIFF
--- a/network/iptables/iptables.go
+++ b/network/iptables/iptables.go
@@ -1,0 +1,306 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package iptables
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+
+	"github.com/juju/errors"
+	"github.com/juju/loggo"
+
+	"github.com/juju/juju/network"
+)
+
+var logger = loggo.GetLogger("juju.network.iptables")
+
+const (
+	// iptablesIngressCommand is the comment attached to iptables
+	// rules directly related to ingress rules.
+	iptablesIngressComment = "juju ingress"
+
+	// iptablesInternalCommand is the comment attached to iptables
+	// rules that are not directly related to ingress rules.
+	iptablesInternalComment = "juju internal"
+)
+
+// DropCommand represents an iptables DROP target command.
+type DropCommand struct {
+	DestinationAddress string
+	Interface          string
+}
+
+// Render renders the command to a string which can be executed via
+// bash in order to install the iptables rule.
+func (c DropCommand) Render() string {
+	args := []string{
+		"sudo iptables",
+		"-I INPUT",
+		"-m state --state NEW",
+		"-j DROP",
+		"-m comment --comment", fmt.Sprintf("'%s'", iptablesInternalComment),
+	}
+	if c.DestinationAddress != "" {
+		args = append(args, "-d", c.DestinationAddress)
+	}
+	if c.Interface != "" {
+		args = append(args, "-i", c.Interface)
+	}
+	return strings.Join(args, " ")
+}
+
+// AcceptInternalCommand represents an iptables ACCEPT target command,
+// for accepting traffic, optionally specifying a protocol, destination
+// address, and destination port.
+//
+// This is intended only for allowing traffic according to Juju's internal
+// rules, e.g. for API or SSH. This should not be used for managing the
+// ingress rules for exposing applications.
+type AcceptInternalCommand struct {
+	DestinationAddress string
+	DestinationPort    int
+	Protocol           string
+}
+
+// Render renders the command to a string which can be executed via
+// bash in order to install the iptables rule.
+func (c AcceptInternalCommand) Render() string {
+	args := []string{
+		"sudo iptables",
+		"-I INPUT",
+		"-j ACCEPT",
+		"-m comment --comment", fmt.Sprintf("'%s'", iptablesInternalComment),
+	}
+	if c.Protocol != "" {
+		args = append(args, "-p", c.Protocol)
+	}
+	if c.DestinationAddress != "" {
+		args = append(args, "-d", c.DestinationAddress)
+	}
+	if c.DestinationPort > 0 {
+		args = append(args, "--dport", fmt.Sprint(c.DestinationPort))
+	}
+	return strings.Join(args, " ")
+}
+
+// IngressRuleCommand represents an iptables ACCEPT target command
+// for ingress rules.
+type IngressRuleCommand struct {
+	Rule               network.IngressRule
+	DestinationAddress string
+	Delete             bool
+}
+
+// Render renders the command to a string which can be executed via
+// bash in order to install the iptables rule.
+func (c IngressRuleCommand) Render() string {
+	// TODO(axw) 2017-12-11 #1737472
+	// We shouldn't need to check for existing rules;
+	// the firewaller is supposed to check the instance's
+	// existing rules first, and only insert or remove as
+	// needed. Fixing the firewaller is much more difficult,
+	// and it really needs an overhaul.
+	checkCommand := c.render("-C")
+	if c.Delete {
+		deleteCommand := c.render("-D")
+		return fmt.Sprintf("(%s) && (%s)", checkCommand, deleteCommand)
+	}
+	insertCommand := c.render("-I")
+	return fmt.Sprintf("(%s) || (%s)", checkCommand, insertCommand)
+}
+
+func (c IngressRuleCommand) render(commandFlag string) string {
+	args := []string{
+		"sudo", "iptables",
+		commandFlag, "INPUT",
+		"-j ACCEPT",
+		"-p", c.Rule.Protocol,
+	}
+	if c.DestinationAddress != "" {
+		args = append(args, "-d", c.DestinationAddress)
+	}
+	if c.Rule.Protocol == "icmp" {
+		args = append(args, "--icmp-type 8")
+	} else {
+		if c.Rule.ToPort-c.Rule.FromPort > 0 {
+			args = append(args,
+				"-m multiport --dports",
+				fmt.Sprintf("%d:%d", c.Rule.FromPort, c.Rule.ToPort),
+			)
+		} else {
+			args = append(args, "--dport", fmt.Sprint(c.Rule.FromPort))
+		}
+	}
+	if len(c.Rule.SourceCIDRs) > 0 {
+		args = append(args, "-s", strings.Join(c.Rule.SourceCIDRs, ","))
+	}
+	// Comment always comes last.
+	args = append(args,
+		"-m comment --comment", fmt.Sprintf("'%s'", iptablesIngressComment),
+	)
+	return strings.Join(args, " ")
+}
+
+// ParseIngressRules parses the output of "iptables -L INPUT -n",
+// extracting previously added ingress rules, as rendered by
+// IngressRuleCommand.
+func ParseIngressRules(r io.Reader) ([]network.IngressRule, error) {
+	var rules []network.IngressRule
+	scanner := bufio.NewScanner(r)
+	for scanner.Scan() {
+		line := scanner.Text()
+		rule, ok, err := parseIngressRule(strings.TrimSpace(line))
+		if err != nil {
+			logger.Warningf("failed to parse iptables line %q: %v", line, err)
+			continue
+		}
+		if !ok {
+			continue
+		}
+		rules = append(rules, rule)
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, errors.Annotate(err, "reading iptables output")
+	}
+	return rules, nil
+}
+
+// parseIngressRule parses a single iptables output line, extracting
+// an ingress rule if the line represents one, or returning false
+// otherwise.
+//
+// The iptables rules we care about have the following format, and we
+// will skip all other rules:
+//
+//    Chain INPUT (policy ACCEPT)
+//    target     prot opt source               destination
+//    ACCEPT     tcp  --  0.0.0.0/0            192.168.0.1  multiport dports 3456:3458 /* juju ingress */
+//    ACCEPT     tcp  --  0.0.0.0/0            192.168.0.2  tcp dpt:12345 /* juju ingress */
+//    ACCEPT     icmp --  0.0.0.0/0            10.0.0.1     icmptype 8 /* juju ingress */
+//
+func parseIngressRule(line string) (network.IngressRule, bool, error) {
+	fail := func(err error) (network.IngressRule, bool, error) {
+		return network.IngressRule{}, false, err
+	}
+	if !strings.HasPrefix(line, "ACCEPT") {
+		return network.IngressRule{}, false, nil
+	}
+
+	// We only care about rules with the comment "juju ingress".
+	if !strings.HasSuffix(line, "*/") {
+		return network.IngressRule{}, false, nil
+	}
+	commentStart := strings.LastIndex(line, "/*")
+	if commentStart == -1 {
+		return network.IngressRule{}, false, nil
+	}
+	line, comment := line[:commentStart], line[commentStart+2:]
+	comment = comment[:len(comment)-2]
+	if strings.TrimSpace(comment) != iptablesIngressComment {
+		return network.IngressRule{}, false, nil
+	}
+
+	const (
+		fieldTarget      = 0
+		fieldProtocol    = 1
+		fieldOptions     = 2
+		fieldSource      = 3
+		fieldDestination = 4
+	)
+	fields := make([]string, 5)
+	for i := range fields {
+		field, remainder, ok := popField(line)
+		if !ok {
+			return fail(errors.Errorf("could not extract field %d", i))
+		}
+		fields[i] = field
+		line = remainder
+	}
+
+	source := fields[fieldSource]
+	proto := strings.ToLower(fields[fieldProtocol])
+
+	var fromPort, toPort int
+	if strings.HasPrefix(line, "multiport dports") {
+		_, line, _ = popField(line) // pop "multiport"
+		_, line, _ = popField(line) // pop "dports"
+		portRange, _, ok := popField(line)
+		if !ok {
+			return fail(errors.New("could not extract port range"))
+		}
+		var err error
+		fromPort, toPort, err = parsePortRange(portRange)
+		if err != nil {
+			return fail(errors.Trace(err))
+		}
+	} else if proto == "icmp" {
+		fromPort, toPort = -1, -1
+	} else {
+		field, line, ok := popField(line)
+		if !ok {
+			return fail(errors.New("could not extract parameters"))
+		}
+		if field != proto {
+			// parameters should look like
+			// "tcp dpt:N" or "udp dpt:N".
+			return fail(errors.New("unexpected parameter prefix"))
+		}
+		field, line, ok = popField(line)
+		if !ok || !strings.HasPrefix(field, "dpt:") {
+			return fail(errors.New("could not extract destination port"))
+		}
+		port, err := parsePort(strings.TrimPrefix(field, "dpt:"))
+		if err != nil {
+			return fail(errors.Trace(err))
+		}
+		fromPort = port
+		toPort = port
+	}
+
+	rule, err := network.NewIngressRule(proto, fromPort, toPort, source)
+	if err != nil {
+		return fail(errors.Trace(err))
+	}
+	return rule, true, nil
+}
+
+// popField pops a pops a field off the front of the given string
+// by splitting on the first run of whitespace, and returns the
+// field and remainder. A boolean result is returned indicating
+// whether or not a field was found.
+func popField(s string) (field, remainder string, ok bool) {
+	i := strings.IndexRune(s, ' ')
+	if i == -1 {
+		return s, "", s != ""
+	}
+	field, remainder = s[:i], strings.TrimLeft(s[i+1:], " ")
+	return field, remainder, true
+}
+
+func parsePortRange(s string) (int, int, error) {
+	fields := strings.Split(s, ":")
+	if len(fields) != 2 {
+		return -1, -1, errors.New("expected M:N")
+	}
+	from, err := parsePort(fields[0])
+	if err != nil {
+		return -1, -1, errors.Trace(err)
+	}
+	to, err := parsePort(fields[1])
+	if err != nil {
+		return -1, -1, errors.Trace(err)
+	}
+	return from, to, nil
+}
+
+func parsePort(s string) (int, error) {
+	n, err := strconv.ParseUint(s, 10, 16)
+	if err != nil {
+		return -1, errors.Trace(err)
+	}
+	return int(n), nil
+}

--- a/network/iptables/iptables_test.go
+++ b/network/iptables/iptables_test.go
@@ -1,0 +1,206 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package iptables_test
+
+import (
+	"strings"
+
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/network"
+	"github.com/juju/juju/network/iptables"
+)
+
+type IptablesSuite struct {
+	testing.IsolationSuite
+}
+
+var _ = gc.Suite(&IptablesSuite{})
+
+func (*IptablesSuite) TestDropCommand(c *gc.C) {
+	assertRender(c,
+		iptables.DropCommand{},
+		"sudo iptables -I INPUT -m state --state NEW -j DROP -m comment --comment 'juju internal'",
+	)
+	assertRender(c,
+		iptables.DropCommand{DestinationAddress: "1.2.3.4"},
+		"sudo iptables -I INPUT -m state --state NEW -j DROP -m comment --comment 'juju internal' -d 1.2.3.4",
+	)
+	assertRender(c,
+		iptables.DropCommand{Interface: "eth0"},
+		"sudo iptables -I INPUT -m state --state NEW -j DROP -m comment --comment 'juju internal' -i eth0",
+	)
+}
+
+func (*IptablesSuite) TestAcceptInternalPortCommand(c *gc.C) {
+	assertRender(c,
+		iptables.AcceptInternalCommand{},
+		"sudo iptables -I INPUT -j ACCEPT -m comment --comment 'juju internal'",
+	)
+	assertRender(c,
+		iptables.AcceptInternalCommand{
+			DestinationAddress: "1.2.3.4",
+			DestinationPort:    17070,
+			Protocol:           "tcp",
+		},
+		"sudo iptables -I INPUT -j ACCEPT -m comment --comment 'juju internal' -p tcp -d 1.2.3.4 --dport 17070",
+	)
+}
+
+func (*IptablesSuite) TestIngressRuleCommand(c *gc.C) {
+	assertRender(c,
+		iptables.IngressRuleCommand{
+			Rule: network.IngressRule{
+				PortRange: network.PortRange{Protocol: "icmp"},
+			},
+		},
+		"(sudo iptables -C INPUT -j ACCEPT -p icmp --icmp-type 8 -m comment --comment 'juju ingress') || "+
+			"(sudo iptables -I INPUT -j ACCEPT -p icmp --icmp-type 8 -m comment --comment 'juju ingress')",
+	)
+
+	// Same as above, but with "Delete: true". The only difference in
+	// output is that "-D" is specified in place of "-I".
+	assertRender(c,
+		iptables.IngressRuleCommand{
+			Rule: network.IngressRule{
+				PortRange: network.PortRange{Protocol: "icmp"},
+			},
+			Delete: true,
+		},
+		"(sudo iptables -C INPUT -j ACCEPT -p icmp --icmp-type 8 -m comment --comment 'juju ingress') && "+
+			"(sudo iptables -D INPUT -j ACCEPT -p icmp --icmp-type 8 -m comment --comment 'juju ingress')",
+	)
+
+	// If SourceCIDRs is non-empty, then the CIDRs will be
+	// specified in the rule with "-s". Multiple CIDRs are
+	// joined with a comma.
+	assertRender(c,
+		iptables.IngressRuleCommand{
+			Rule: network.IngressRule{
+				PortRange:   network.PortRange{Protocol: "icmp"},
+				SourceCIDRs: []string{"1.2.3.4", "5.6.7.8"},
+			},
+		},
+		"(sudo iptables -C INPUT -j ACCEPT -p icmp --icmp-type 8 -s 1.2.3.4,5.6.7.8 -m comment --comment 'juju ingress') || "+
+			"(sudo iptables -I INPUT -j ACCEPT -p icmp --icmp-type 8 -s 1.2.3.4,5.6.7.8 -m comment --comment 'juju ingress')",
+	)
+
+	// UDP, single port.
+	assertRender(c,
+		iptables.IngressRuleCommand{
+			Rule: network.IngressRule{
+				PortRange: network.PortRange{
+					Protocol: "udp",
+					FromPort: 53,
+					ToPort:   53,
+				},
+			},
+		},
+		"(sudo iptables -C INPUT -j ACCEPT -p udp --dport 53 -m comment --comment 'juju ingress') || "+
+			"(sudo iptables -I INPUT -j ACCEPT -p udp --dport 53 -m comment --comment 'juju ingress')",
+	)
+
+	// TCP, port range.
+	assertRender(c,
+		iptables.IngressRuleCommand{
+			Rule: network.IngressRule{
+				PortRange: network.PortRange{
+					Protocol: "tcp",
+					FromPort: 6001,
+					ToPort:   6007,
+				},
+			},
+		},
+		"(sudo iptables -C INPUT -j ACCEPT -p tcp -m multiport --dports 6001:6007 -m comment --comment 'juju ingress') || "+
+			"(sudo iptables -I INPUT -j ACCEPT -p tcp -m multiport --dports 6001:6007 -m comment --comment 'juju ingress')",
+	)
+}
+
+func (*IptablesSuite) TestParseIngressRulesEmpty(c *gc.C) {
+	assertParseIngressRules(c, ``, []network.IngressRule{})
+}
+
+func (*IptablesSuite) TestParseIngressRulesGarbage(c *gc.C) {
+	assertParseIngressRules(c, `a
+b
+ACCEPT zing
+blargh
+
+`, []network.IngressRule{})
+}
+
+func (*IptablesSuite) TestParseIngressRulesChecksComment(c *gc.C) {
+	assertParseIngressRules(c, `
+Chain INPUT (policy ACCEPT)
+target     prot opt source               destination         
+ACCEPT     tcp  --  0.0.0.0/0            0.0.0.0/0            tcp dpt:53 /* managed by lxd-bridge */
+ACCEPT     tcp  --  0.0.0.0/0            0.0.0.0/0            tcp dpt:53 /* juju ingress */
+ACCEPT     udp  --  0.0.0.0/0            0.0.0.0/0            udp dpt:53 /* managed by lxd-bridge */
+ACCEPT     udp  --  0.0.0.0/0            0.0.0.0/0            udp dpt:67
+`[1:], []network.IngressRule{{
+		PortRange: network.PortRange{
+			Protocol: "tcp",
+			FromPort: 53,
+			ToPort:   53,
+		},
+		SourceCIDRs: []string{"0.0.0.0/0"},
+	}})
+}
+
+func (*IptablesSuite) TestParseIngressRules(c *gc.C) {
+	assertParseIngressRules(c, `
+Chain INPUT (policy ACCEPT)
+target     prot opt source               destination         
+ACCEPT     tcp  --  0.0.0.0/0            0.0.0.0/0    multiport dports 3456:3458 /* juju ingress */
+ACCEPT     tcp  --  1.2.3.4/20           0.0.0.0/0    tcp dpt:12345 /* juju ingress */
+ACCEPT     udp  --  1.2.3.4/20           0.0.0.0/0    udp dpt:12345 /* juju ingress */
+ACCEPT     icmp --  0.0.0.0/0            0.0.0.0/0    icmptype 8 /* juju ingress */
+`[1:],
+		[]network.IngressRule{{
+			PortRange: network.PortRange{
+				Protocol: "tcp",
+				FromPort: 3456,
+				ToPort:   3458,
+			},
+			SourceCIDRs: []string{"0.0.0.0/0"},
+		}, {
+			PortRange: network.PortRange{
+				Protocol: "tcp",
+				FromPort: 12345,
+				ToPort:   12345,
+			},
+			SourceCIDRs: []string{"1.2.3.4/20"},
+		}, {
+			PortRange: network.PortRange{
+				Protocol: "udp",
+				FromPort: 12345,
+				ToPort:   12345,
+			},
+			SourceCIDRs: []string{"1.2.3.4/20"},
+		}, {
+			PortRange: network.PortRange{
+				Protocol: "icmp",
+				FromPort: -1,
+				ToPort:   -1,
+			},
+			SourceCIDRs: []string{"0.0.0.0/0"},
+		}},
+	)
+}
+
+func assertParseIngressRules(c *gc.C, in string, expect []network.IngressRule) {
+	rules, err := iptables.ParseIngressRules(strings.NewReader(in))
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(rules, jc.DeepEquals, expect)
+}
+
+type renderer interface {
+	Render() string
+}
+
+func assertRender(c *gc.C, r renderer, expect string) {
+	c.Assert(r.Render(), gc.Equals, expect)
+}

--- a/network/iptables/package_test.go
+++ b/network/iptables/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package iptables_test
+
+import (
+	stdtesting "testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func TestAll(t *stdtesting.T) {
+	gc.TestingT(t)
+}

--- a/network/iptables/parse.go
+++ b/network/iptables/parse.go
@@ -1,0 +1,23 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+// +build ignore
+
+package main
+
+import (
+	"log"
+	"os"
+
+	"github.com/kr/pretty"
+
+	"github.com/juju/juju/network/iptables"
+)
+
+func main() {
+	rules, err := iptables.ParseIngressRules(os.Stdin)
+	if err != nil {
+		log.Fatal(err)
+	}
+	pretty.Println(rules)
+}

--- a/provider/common/instance_configurator.go
+++ b/provider/common/instance_configurator.go
@@ -4,14 +4,18 @@
 package common
 
 import (
-	"fmt"
-	"strconv"
+	"os"
 	"strings"
 
 	"github.com/juju/errors"
 	"github.com/juju/utils/ssh"
 
 	"github.com/juju/juju/network"
+	"github.com/juju/juju/network/iptables"
+)
+
+const (
+	iptablesComment = "managed by juju"
 )
 
 // Implementations of this interface should provide a way to configure external
@@ -30,12 +34,6 @@ type InstanceConfigurator interface {
 
 	// List all ingress rules.
 	FindIngressRules() ([]network.IngressRule, error)
-
-	// Add Ip address.
-	AddIpAddress(nic string, addr string) error
-
-	// Release Ip address.
-	ReleaseIpAddress(addr string) error
 }
 
 type sshInstanceConfigurator struct {
@@ -48,6 +46,17 @@ type sshInstanceConfigurator struct {
 func NewSshInstanceConfigurator(host string) InstanceConfigurator {
 	options := ssh.Options{}
 	options.SetIdentities("/var/lib/juju/system-identity")
+
+	// Disable host key checking. We're not sending any sensitive data
+	// across, and we don't have access to the host's keys from here.
+	//
+	// TODO(axw) 2017-12-07 #1732665
+	// Stop using SSH, instead manage iptables on the machine
+	// itself. This will also provide firewalling for MAAS and
+	// LXD machines.
+	options.SetStrictHostKeyChecking(ssh.StrictHostChecksNo)
+	options.SetKnownHostsFile(os.DevNull)
+
 	return &sshInstanceConfigurator{
 		client:  ssh.DefaultClient,
 		host:    "ubuntu@" + host,
@@ -55,17 +64,30 @@ func NewSshInstanceConfigurator(host string) InstanceConfigurator {
 	}
 }
 
-// DropAllPorts implements InstanceConfigurator interface.
-func (c *sshInstanceConfigurator) DropAllPorts(exceptPorts []int, addr string) error {
-	cmd := fmt.Sprintf("sudo iptables -d %s -I INPUT -m state --state NEW -j DROP", addr)
-
-	for _, port := range exceptPorts {
-		cmd += fmt.Sprintf("\nsudo iptables -I INPUT -p tcp --dport %d -j ACCEPT", port)
-	}
-
+func (c *sshInstanceConfigurator) runCommand(cmd string) (string, error) {
 	command := c.client.Command(c.host, []string{"/bin/bash"}, c.options)
 	command.Stdin = strings.NewReader(cmd)
 	output, err := command.CombinedOutput()
+	if err != nil {
+		return "", errors.Trace(err)
+	}
+	return string(output), nil
+}
+
+// DropAllPorts implements InstanceConfigurator interface.
+func (c *sshInstanceConfigurator) DropAllPorts(exceptPorts []int, addr string) error {
+	cmds := []string{
+		iptables.DropCommand{DestinationAddress: addr}.Render(),
+	}
+	for _, port := range exceptPorts {
+		cmds = append(cmds, iptables.AcceptInternalCommand{
+			Protocol:           "tcp",
+			DestinationAddress: addr,
+			DestinationPort:    port,
+		}.Render())
+	}
+
+	output, err := c.runCommand(strings.Join(cmds, "\n"))
 	if err != nil {
 		return errors.Errorf("failed to drop all ports: %s", output)
 	}
@@ -79,22 +101,24 @@ func ConfigureExternalIpAddressCommands(apiPort int) []string {
 	commands := []string{
 		`printf 'auto eth1\niface eth1 inet dhcp' | sudo tee -a /etc/network/interfaces.d/eth1.cfg`,
 		"sudo ifup eth1",
-		"sudo iptables -i eth1 -I INPUT -m state --state NEW -j DROP",
+		iptables.DropCommand{Interface: "eth1"}.Render(),
 	}
 	if apiPort > 0 {
-		commands = append(commands, fmt.Sprintf(
-			"sudo iptables -I INPUT -p tcp --dport %d -j ACCEPT", apiPort,
-		))
+		commands = append(commands, iptables.AcceptInternalCommand{
+			Protocol:        "tcp",
+			DestinationPort: apiPort,
+		}.Render())
 	}
 	return commands
 }
 
 // ConfigureExternalIpAddress implements InstanceConfigurator interface.
 func (c *sshInstanceConfigurator) ConfigureExternalIpAddress(apiPort int) error {
-	cmd := strings.Join(ConfigureExternalIpAddressCommands(apiPort), "\n")
-	command := c.client.Command(c.host, []string{"/bin/bash"}, c.options)
-	command.Stdin = strings.NewReader(cmd)
-	output, err := command.CombinedOutput()
+	cmds := ConfigureExternalIpAddressCommands(apiPort)
+	output, err := c.runCommand(strings.Join(cmds, "\n"))
+	if err != nil {
+		return errors.Errorf("failed to drop all ports: %s", output)
+	}
 	if err != nil {
 		return errors.Errorf("failed to allocate external IP address: %s", output)
 	}
@@ -104,25 +128,16 @@ func (c *sshInstanceConfigurator) ConfigureExternalIpAddress(apiPort int) error 
 
 // ChangeIngressRules implements InstanceConfigurator interface.
 func (c *sshInstanceConfigurator) ChangeIngressRules(ipAddress string, insert bool, rules []network.IngressRule) error {
-	cmd := ""
-	insertArg := "-I"
-	if !insert {
-		insertArg = "-D"
+	var cmds []string
+	for _, rule := range rules {
+		cmds = append(cmds, iptables.IngressRuleCommand{
+			Rule:               rule,
+			DestinationAddress: ipAddress,
+			Delete:             !insert,
+		}.Render())
 	}
-	for _, port := range rules {
-		if port.Protocol == "icmp" {
-			cmd += fmt.Sprintf("sudo iptables -d %s %s INPUT -p %s --icmp-type 8 -j ACCEPT\n", ipAddress, insertArg, port.Protocol)
-		} else if port.ToPort-port.FromPort > 0 {
-			cmd += fmt.Sprintf("sudo iptables -d %s %s INPUT -p %s --match multiport --dports %d:%d -j ACCEPT\n", ipAddress, insertArg, port.Protocol, port.FromPort, port.ToPort)
-		} else {
 
-			cmd += fmt.Sprintf("sudo iptables -d %s %s INPUT -p %s --dport %d -j ACCEPT\n", ipAddress, insertArg, port.Protocol, port.FromPort)
-		}
-	}
-	cmd += "sudo /etc/init.d/iptables-persistent save\n"
-	command := c.client.Command(c.host, []string{"/bin/bash"}, c.options)
-	command.Stdin = strings.NewReader(cmd)
-	output, err := command.CombinedOutput()
+	output, err := c.runCommand(strings.Join(cmds, "\n"))
 	if err != nil {
 		return errors.Errorf("failed to configure ports on external network: %s", output)
 	}
@@ -132,114 +147,10 @@ func (c *sshInstanceConfigurator) ChangeIngressRules(ipAddress string, insert bo
 
 // FindIngressRules implements InstanceConfigurator interface.
 func (c *sshInstanceConfigurator) FindIngressRules() ([]network.IngressRule, error) {
-	cmd := "sudo iptables -L INPUT -n"
-	command := c.client.Command(c.host, []string{"/bin/bash"}, c.options)
-	command.Stdin = strings.NewReader(cmd)
-	output, err := command.CombinedOutput()
+	output, err := c.runCommand("sudo iptables -L INPUT -n")
 	if err != nil {
 		return nil, errors.Errorf("failed to list open ports: %s", output)
 	}
 	logger.Tracef("find open ports output: %s", output)
-
-	//the output have the following format, we will skip all other rules
-	//Chain INPUT (policy ACCEPT)
-	//target     prot opt source               destination
-	//ACCEPT     tcp  --  0.0.0.0/0            192.168.0.1  multiport dports 3456:3458
-	//ACCEPT     tcp  --  0.0.0.0/0            192.168.0.2  tcp dpt:12345
-	//ACCEPT     icmp --  0.0.0.0/0            10.0.0.1     icmptype 8
-
-	res := make([]network.IngressRule, 0)
-	var addSinglePortRange = func(items []string) {
-		ports := strings.Split(items[6], ":")
-		if len(ports) != 2 {
-			return
-		}
-		to, err := strconv.ParseInt(ports[1], 10, 32)
-		if err != nil {
-			return
-		}
-
-		res = append(res, network.NewOpenIngressRule(items[1], int(to), int(to)))
-	}
-	var addMultiplePortRange = func(items []string) {
-		ports := strings.Split(items[7], ":")
-		if len(ports) != 2 {
-			return
-		}
-		from, err := strconv.ParseInt(ports[0], 10, 32)
-		if err != nil {
-			return
-		}
-		to, err := strconv.ParseInt(ports[1], 10, 32)
-		if err != nil {
-			return
-		}
-
-		res = append(res, network.NewOpenIngressRule(items[1], int(from), int(to)))
-	}
-
-	for i, line := range strings.Split(string(output), "\n") {
-		if i == 1 || i == 0 {
-			continue
-		}
-		items := strings.Split(line, " ")
-		proto := strings.ToLower(items[1])
-		if proto == "icmp" && items[3] == "0.0.0.0/0" {
-			res = append(res, network.NewOpenIngressRule(proto, -1, -1))
-		}
-		if len(items) == 7 && items[0] == "ACCEPT" && items[3] == "0.0.0.0/0" {
-			addSinglePortRange(items)
-		}
-		if len(items) == 8 && items[0] == "ACCEPT" && items[3] == "0.0.0.0/0" && items[5] != "multiport" && items[6] != "dports" {
-			addMultiplePortRange(items)
-		}
-	}
-	return res, nil
-}
-
-// AddIpAddress implements InstanceConfigurator interface.
-func (c *sshInstanceConfigurator) AddIpAddress(nic string, addr string) error {
-	cmd := fmt.Sprintf("ls /etc/network/interfaces.d | grep %s: | sed 's/%s://' | sed 's/.cfg//' | tail -1", nic, nic)
-	command := c.client.Command(c.host, []string{"/bin/bash"}, c.options)
-	command.Stdin = strings.NewReader(cmd)
-	lastIndStr, err := command.CombinedOutput()
-	if err != nil {
-		return errors.Errorf("failed to obtain last device index: %s", lastIndStr)
-	}
-	lastInd := 0
-	if ind, err := strconv.ParseInt(string(lastIndStr), 10, 64); err != nil {
-		lastInd = int(ind) + 1
-	}
-	nic = fmt.Sprintf("%s:%d", nic, lastInd)
-	cmd = fmt.Sprintf("printf 'auto %s\\niface %s inet static\\naddress %s' | sudo tee -a /etc/network/interfaces.d/%s.cfg\nsudo ifup %s", nic, nic, addr, nic, nic)
-
-	command = c.client.Command(c.host, []string{"/bin/bash"}, c.options)
-	command.Stdin = strings.NewReader(cmd)
-	output, err := command.CombinedOutput()
-	if err != nil {
-		return errors.Errorf("failed to add IP address: %s", output)
-	}
-	logger.Tracef("add ip address output: %s", output)
-	return nil
-}
-
-// ReleaseIpAddress implements InstanceConfigurator interface.
-func (c *sshInstanceConfigurator) ReleaseIpAddress(addr string) error {
-	cmd := fmt.Sprintf("ip addr show | grep %s | awk '{print $7}'", addr)
-	command := c.client.Command(c.host, []string{"/bin/bash"}, c.options)
-	command.Stdin = strings.NewReader(cmd)
-	nic, err := command.CombinedOutput()
-	if err != nil {
-		return errors.Errorf("faild to get nic by ip address: %s", nic)
-	}
-
-	cmd = fmt.Sprintf("sudo rm %s.cfg \nsudo ifdown %s", nic, nic)
-	command = c.client.Command(c.host, []string{"/bin/bash"}, c.options)
-	command.Stdin = strings.NewReader(cmd)
-	output, err := command.CombinedOutput()
-	if err != nil {
-		return errors.Errorf("failed to release IP address: %s", output)
-	}
-	logger.Tracef("release ip address output: %s", output)
-	return nil
+	return iptables.ParseIngressRules(strings.NewReader(output))
 }

--- a/provider/rackspace/environ_test.go
+++ b/provider/rackspace/environ_test.go
@@ -267,16 +267,6 @@ func (e *fakeConfigurator) FindIngressRules() ([]network.IngressRule, error) {
 	return nil, nil
 }
 
-func (e *fakeConfigurator) AddIpAddress(nic string, addr string) error {
-	e.Push("AddIpAddress", nic, addr)
-	return nil
-}
-
-func (e *fakeConfigurator) ReleaseIpAddress(addr string) error {
-	e.Push("AddIpAddress", addr)
-	return nil
-}
-
 type fakeInstance struct {
 	methodCalls []methodCall
 }

--- a/provider/vsphere/instance.go
+++ b/provider/vsphere/instance.go
@@ -94,11 +94,12 @@ func (inst *environInstance) changeIngressRules(insert bool, rules []network.Ing
 	}
 
 	for _, addr := range addresses {
-		if addr.Scope == network.ScopePublic {
-			err = client.ChangeIngressRules(addr.Value, insert, rules)
-			if err != nil {
-				return errors.Trace(err)
-			}
+		if addr.Type == network.IPv6Address || addr.Scope != network.ScopePublic {
+			// TODO(axw) support firewalling IPv6
+			continue
+		}
+		if err := client.ChangeIngressRules(addr.Value, insert, rules); err != nil {
+			return errors.Trace(err)
 		}
 	}
 	return nil


### PR DESCRIPTION
## Description of change

This PR fixes the regression in functionality of the vsphere instance firewalling code. We disable strict host checking in the SSH connections from the controller to machine hosts made for iptables management. We also fix iptables parsing and rule creation/deletion command rendering. Abstractions around iptables have been moved to a new package, network/iptables.

## QA steps

1. juju bootstrap vsphere --config external-network="<external-network>"
2. juju deploy ubuntu
3. juju run --unit ubuntu -- open-port 1234
(check on the ubuntu/0 unit's machine that no iptables rules are added)
4. juju expose ubuntu
(check on ubuntu/0's machine that an iptables rule is added)
5. juju ssh -m controller 0 "sudo service jujud-machine-0 restart"
(check that no duplicate rules are added)
6. juju unexpose ubuntu
(check on ubuntu/0's machine that the iptables rule is removed)

## Documentation changes

None.

## Bug reference

Partially fixes https://bugs.launchpad.net/juju/+bug/1732665