### PR TITLE
Deal with bug #1737480.

### DIFF
--- a/state/modelsummaries.go
+++ b/state/modelsummaries.go
@@ -129,7 +129,6 @@ func (p *modelSummaryProcessor) fillInFromConfig() error {
 	rawSettings, closer := p.st.database.GetRawCollection(settingsC)
 	defer closer()
 
-	remaining := set.NewStrings(p.modelUUIDs...)
 	settingIds := make([]string, len(p.modelUUIDs))
 	for i, uuid := range p.modelUUIDs {
 		settingIds[i] = uuid + ":" + modelGlobalKey
@@ -143,7 +142,6 @@ func (p *modelSummaryProcessor) fillInFromConfig() error {
 			// How could it return a doc that we don't have?
 			continue
 		}
-		remaining.Remove(doc.ModelUUID)
 
 		cfg, err := config.New(config.NoDefaults, doc.Settings)
 		if err != nil {
@@ -159,10 +157,6 @@ func (p *modelSummaryProcessor) fillInFromConfig() error {
 	}
 	if err := iter.Close(); err != nil {
 		return errors.Trace(err)
-	}
-	if !remaining.IsEmpty() {
-		// XXX: What error is appropriate? Do we need to care about models that its ok to be missing?
-		return errors.Errorf("could not find settings/config for models: %v", remaining.SortedValues())
 	}
 	return nil
 }


### PR DESCRIPTION
## Description of change

When tearing down a model, it seems we immediately go to "Dead" even though there is still valid information that is useful for a user (destroying resources, etc).

However, it seems fairly early on we remove the "settings" entry for the model. Don't error out when we see that happen. Instead, continue to flesh out the model as much as we can.

## QA steps

You can see the reproduction steps in the associated bug. The quick form is:
```
$ juju bootstrap
$ for i in `seq 50`; do juju add-model m$i; juju destroy-model m$i -y; done
```
and in another window use something like:
```
while true: juju models || break; done
```

Note that we already have CI tests that fail intermittently because of this.

## Documentation changes

None.

## Bug reference

[lp:1737480](https://bugs.launchpad.net/juju/2.3/+bug/1737480)
