### PR TITLE
audit-log: Include times on API requests and errors

### DIFF
--- a/apiserver/admin.go
+++ b/apiserver/admin.go
@@ -162,10 +162,10 @@ func (a *admin) getAuditRecorder(req params.LoginRequest, authResult *authResult
 	}
 	result, err := auditlog.NewRecorder(
 		a.srv.auditLogger,
+		a.srv.clock,
 		auditlog.ConversationArgs{
 			Who:          req.AuthTag,
 			What:         req.CLIArgs,
-			When:         a.srv.clock.Now(),
 			ModelName:    a.root.model.Name(),
 			ModelUUID:    a.root.model.UUID(),
 			ConnectionID: a.root.connectionID,

--- a/apiserver/observer/recorder_test.go
+++ b/apiserver/observer/recorder_test.go
@@ -4,6 +4,8 @@
 package observer_test
 
 import (
+	"time"
+
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
@@ -24,7 +26,8 @@ var _ = gc.Suite(&recorderSuite{})
 func (s *recorderSuite) TestServerRequest(c *gc.C) {
 	fake := &fakeobserver.Instance{}
 	log := &apitesting.FakeAuditLog{}
-	auditRecorder, err := auditlog.NewRecorder(log, auditlog.ConversationArgs{
+	clock := testing.NewClock(time.Now())
+	auditRecorder, err := auditlog.NewRecorder(log, clock, auditlog.ConversationArgs{
 		ConnectionID: 4567,
 	})
 	c.Assert(err, jc.ErrorIsNil)
@@ -51,6 +54,7 @@ func (s *recorderSuite) TestServerRequest(c *gc.C) {
 		ConversationID: "abcdef0123456789",
 		ConnectionID:   "11D7",
 		RequestID:      123,
+		When:           clock.Now().Format(time.RFC3339),
 		Facade:         "Type",
 		Method:         "Action",
 		Version:        5,
@@ -61,7 +65,8 @@ func (s *recorderSuite) TestServerRequest(c *gc.C) {
 func (s *recorderSuite) TestServerReply(c *gc.C) {
 	fake := &fakeobserver.Instance{}
 	log := &apitesting.FakeAuditLog{}
-	auditRecorder, err := auditlog.NewRecorder(log, auditlog.ConversationArgs{
+	clock := testing.NewClock(time.Now())
+	auditRecorder, err := auditlog.NewRecorder(log, clock, auditlog.ConversationArgs{
 		ConnectionID: 4567,
 	})
 	c.Assert(err, jc.ErrorIsNil)
@@ -87,6 +92,7 @@ func (s *recorderSuite) TestServerReply(c *gc.C) {
 		ConversationID: "abcdef0123456789",
 		ConnectionID:   "11D7",
 		RequestID:      123,
+		When:           clock.Now().Format(time.RFC3339),
 		Errors:         nil,
 	})
 }


### PR DESCRIPTION
## Description of change
Some commands can take a non-negligible amount of time, so it's useful to know when the API requests are happening. Add a timestamp to request and error records. (Previously only the top-level conversation record had a timestamp.)

## QA steps
Run a few commands against a controller that has audit logging on. The API requests and responses will also have timestamps.