### PR TITLE
provider/openstack: handle NotFound cinder errors

### DIFF
--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -94,7 +94,7 @@ google.golang.org/cloud	git	f20d6dcccb44ed49de45ae3703312cb46e627db1	2015-03-19T
 gopkg.in/amz.v3	git	8c3190dff075bf5442c9eedbf8f8ed6144a099e7	2016-12-15T13:08:49Z
 gopkg.in/check.v1	git	4f90aeace3a26ad7021961c297b22c42160c7b25	2016-01-05T16:49:36Z
 gopkg.in/errgo.v1	git	442357a80af5c6bf9b6d51ae791a39c3421004f3	2016-12-22T12:58:16Z
-gopkg.in/goose.v2	git	7eb5c96ccec1c7617badcb4098313bdb90e654bf	2017-10-31T22:15:48Z
+gopkg.in/goose.v2	git	e3fb91ea8c933a6c92361a2f6849962fe37f21a2	2017-12-13T00:39:39Z
 gopkg.in/ini.v1	git	776aa739ce9373377cd16f526cdf06cb4c89b40f	2016-02-22T23:24:41Z
 gopkg.in/juju/blobstore.v2	git	51fa6e26128d74e445c72d3a91af555151cc3654	2016-01-25T02:37:03Z
 gopkg.in/juju/charm.v6	git	d93cf8b75cf4017ace4b3bf6af3bd03003e11cfa	2017-11-14T08:46:58Z


### PR DESCRIPTION
## Description of change

When detaching or destroying volumes, handle NotFound
errors by treating them as success. Simplify detachment
by performing a blind detach.

## QA steps

1. juju bootstrap openstack
2. juju deploy cs:~axwalk/storagetest --storage disks=2,1G
(wait for all to be provisioned)
3. openstack server remove volume \<server\> \<volume-1\>
4. openstack server remove volume \<server\> \<volume-2\>
5. openstack volume delete \<server\> \<volume-2\>
(wait for volume to be deleted)
6. juju remove-storage disks/0
7. juju remove-storage disks/1
(wait for storage to be removed from juju)
8. openstack volume list
(should be empty)

## Documentation changes

None.

## Bug reference

Fixes https://bugs.launchpad.net/juju/+bug/1733756