### PR TITLE
Add network space controller configuration variables.

### DIFF
--- a/controller/config.go
+++ b/controller/config.go
@@ -12,6 +12,7 @@ import (
 	"github.com/juju/schema"
 	"github.com/juju/utils"
 	utilscert "github.com/juju/utils/cert"
+	"gopkg.in/juju/names.v2"
 	"gopkg.in/macaroon-bakery.v1/bakery"
 
 	"github.com/juju/juju/cert"
@@ -110,6 +111,9 @@ const (
 
 	// DefaultMaxTxnLogCollectionMB is the maximum size the txn log collection.
 	DefaultMaxTxnLogCollectionMB = 10 // 10 MB
+
+	JujuHASpace         = "juju-ha-space"
+	JujuManagementSpace = "juju-mgmt-space"
 )
 
 // ControllerOnlyConfigAttributes are attributes which are only relevant
@@ -129,6 +133,8 @@ var ControllerOnlyConfigAttributes = []string{
 	MaxLogsSize,
 	MaxLogsAge,
 	MaxTxnLogSize,
+	JujuHASpace,
+	JujuManagementSpace,
 }
 
 // ControllerOnlyAttribute returns true if the specified attribute name
@@ -316,6 +322,16 @@ func (c Config) MaxTxnLogSizeMB() int {
 	return int(val)
 }
 
+// JujuHASpace is the network space where on which MongoDB lives.
+func (c Config) JujuHASpace() string {
+	return c.asString(JujuHASpace)
+}
+
+// JujuManagementSpace is the network space where controllers live.
+func (c Config) JujuManagementSpace() string {
+	return c.asString(JujuManagementSpace)
+}
+
 // Validate ensures that config is a valid configuration.
 func Validate(c Config) error {
 	if v, ok := c[IdentityPublicKey].(string); ok {
@@ -375,6 +391,20 @@ func Validate(c Config) error {
 		}
 	}
 
+	if v, ok := c[JujuHASpace].(string); ok {
+		if !names.IsValidSpace(v) {
+			return errors.NewNotValid(nil, "invalid juju HA space name")
+		}
+
+	}
+
+	if v, ok := c[JujuManagementSpace].(string); ok {
+		if !names.IsValidSpace(v) {
+			return errors.NewNotValid(nil, "invalid juju mgmt space name")
+		}
+
+	}
+
 	return nil
 }
 
@@ -398,6 +428,8 @@ var configChecker = schema.FieldMap(schema.Fields{
 	MaxLogsAge:              schema.String(),
 	MaxLogsSize:             schema.String(),
 	MaxTxnLogSize:           schema.String(),
+	JujuHASpace:             schema.String(),
+	JujuManagementSpace:     schema.String(),
 }, schema.Defaults{
 	APIPort:                 DefaultAPIPort,
 	AuditingEnabled:         DefaultAuditingEnabled,
@@ -412,4 +444,6 @@ var configChecker = schema.FieldMap(schema.Fields{
 	MaxLogsAge:              fmt.Sprintf("%vh", DefaultMaxLogsAgeDays*24),
 	MaxLogsSize:             fmt.Sprintf("%vM", DefaultMaxLogCollectionMB),
 	MaxTxnLogSize:           fmt.Sprintf("%vM", DefaultMaxTxnLogCollectionMB),
+	JujuHASpace:             schema.Omit,
+	JujuManagementSpace:     schema.Omit,
 })

--- a/controller/config_test.go
+++ b/controller/config_test.go
@@ -121,6 +121,27 @@ var validateTests = []struct {
 		controller.CACertKey:         testing.CACert,
 	},
 	expectError: `invalid identity public key: wrong length for base64 key, got 3 want 32`,
+}, {
+	about: "invalid management space name",
+	config: controller.Config{
+		controller.CACertKey:           testing.CACert,
+		controller.JujuManagementSpace: ` `,
+	},
+	expectError: `invalid juju mgmt space name`,
+}, {
+	about: "invalid management space name",
+	config: controller.Config{
+		controller.CACertKey:           testing.CACert,
+		controller.JujuManagementSpace: "Space",
+	},
+	expectError: `invalid juju mgmt space name`,
+}, {
+	about: "invalid management space name",
+	config: controller.Config{
+		controller.CACertKey:           testing.CACert,
+		controller.JujuManagementSpace: "\n",
+	},
+	expectError: `invalid juju mgmt space name`,
 }}
 
 func (s *ConfigSuite) TestValidate(c *gc.C) {
@@ -172,4 +193,32 @@ func (s *ConfigSuite) TestTxnLogConfigValue(c *gc.C) {
 	)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cfg.MaxTxnLogSizeMB(), gc.Equals, 8192)
+}
+
+func (s *ConfigSuite) TestNetworkSpaceConfigValues(c *gc.C) {
+	haSpace := "space1"
+	managementSpace := "space2"
+
+	cfg, err := controller.NewConfig(
+		testing.ControllerTag.Id(),
+		testing.CACert,
+		map[string]interface{}{
+			controller.JujuHASpace:         haSpace,
+			controller.JujuManagementSpace: managementSpace,
+		},
+	)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(cfg.JujuHASpace(), gc.Equals, haSpace)
+	c.Assert(cfg.JujuManagementSpace(), gc.Equals, managementSpace)
+}
+
+func (s *ConfigSuite) TestNetworkSpaceConfigDefaults(c *gc.C) {
+	cfg, err := controller.NewConfig(
+		testing.ControllerTag.Id(),
+		testing.CACert,
+		map[string]interface{}{},
+	)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(cfg.JujuHASpace(), gc.Equals, "")
+	c.Assert(cfg.JujuManagementSpace(), gc.Equals, "")
 }

--- a/state/controller_test.go
+++ b/state/controller_test.go
@@ -31,6 +31,8 @@ func (s *ControllerSuite) TestControllerAndModelConfigInitialisation(c *gc.C) {
 		controller.AutocertDNSNameKey:  true,
 		controller.AllowModelAccessKey: true,
 		controller.MongoMemoryProfile:  true,
+		controller.JujuHASpace:         true,
+		controller.JujuManagementSpace: true,
 	}
 	for _, controllerAttr := range controller.ControllerOnlyConfigAttributes {
 		v, ok := controllerSettings.Get(controllerAttr)


### PR DESCRIPTION
## Description of change

This changes is needed to give users the ability to specify network spaces to hold controllers and db HA sets.

## QA steps

Bootstrap a controller with the following configuration parameters:

```
juju bootstrap lxd controller --config juju-ha-space=somespace --config juju-mgmt-space=anotherspace
```

You should see no warnings.

Now check the controller configuration of the newly bootstrapped model.
```
juju controller-config | grep space
```

```
juju-ha-space            somespace
juju-mgmt-space          space
```

You should see that the new values are populated with the appropriate values.

## Documentation changes

Yes, the new config variables should be documented.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1591962