### PR TITLE
audit-log: Add controller config for audit logging

### DIFF
--- a/agent/agentbootstrap/bootstrap_test.go
+++ b/agent/agentbootstrap/bootstrap_test.go
@@ -227,6 +227,10 @@ LXC_BRIDGE="ignored"`[1:])
 		"max-logs-age":            "72h",
 		"max-logs-size":           "4G",
 		"max-txn-log-size":        "10M",
+		"auditing-enabled":        false,
+		"audit-log-capture-args":  true,
+		"audit-log-max-size":      "200M",
+		"audit-log-max-backups":   5,
 	})
 
 	// Check that controller model configuration has been added, and

--- a/cmd/juju/backups/restore_test.go
+++ b/cmd/juju/backups/restore_test.go
@@ -237,6 +237,10 @@ func (s *restoreSuite) TestRestoreReboostrapWritesUpdatedControllerInfo(c *gc.C)
 			"max-logs-age":            "72h",
 			"max-logs-size":           "4G",
 			"max-txn-log-size":        "10M",
+			"auditing-enabled":        false,
+			"audit-log-capture-args":  true,
+			"audit-log-max-size":      "200M",
+			"audit-log-max-backups":   5,
 		})
 		boostrapped = true
 		return nil
@@ -285,6 +289,9 @@ func (s *restoreSuite) TestRestoreReboostrapControllerConfigDefaults(c *gc.C) {
 			"max-logs-size":           "4096M",
 			"max-txn-log-size":        "10M",
 			"auditing-enabled":        false,
+			"audit-log-capture-args":  false,
+			"audit-log-max-size":      "300M",
+			"audit-log-max-backups":   10,
 		})
 		boostrapped = true
 		return nil

--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -1290,8 +1290,7 @@ func (a *MachineAgent) newAPIserverWorker(
 		return nil, errors.Annotate(err, "getting log sink config")
 	}
 
-	// TODO(babbageclunk): get this from agent config.
-	auditConfig := apiserver.DefaultAuditLogConfig()
+	auditConfig := getAuditLogConfig(controllerConfig)
 
 	serverConfig := apiserver.ServerConfig{
 		Clock:                         clock.WallClock,
@@ -1786,4 +1785,13 @@ func getLogSinkConfig(cfg agent.Config) (apiserver.LogSinkConfig, error) {
 		}
 	}
 	return result, nil
+}
+
+func getAuditLogConfig(cfg controller.Config) apiserver.AuditLogConfig {
+	return apiserver.AuditLogConfig{
+		Enabled:        cfg.AuditingEnabled(),
+		CaptureAPIArgs: cfg.AuditLogCaptureArgs(),
+		MaxSizeMB:      cfg.AuditLogMaxSizeMB(),
+		MaxBackups:     cfg.AuditLogMaxBackups(),
+	}
 }

--- a/controller/config.go
+++ b/controller/config.go
@@ -32,6 +32,18 @@ const (
 	// auditing information.
 	AuditingEnabled = "auditing-enabled"
 
+	// AuditLogCaptureArgs determines whether the audit log will
+	// contain the arguments passed to API methods.
+	AuditLogCaptureArgs = "audit-log-capture-args"
+
+	// AuditLogMaxSize is the maximum size for the current audit log
+	// file, eg "250M".
+	AuditLogMaxSize = "audit-log-max-size"
+
+	// AuditLogMaxBackups is the number of old audit log files to keep
+	// (compressed).
+	AuditLogMaxBackups = "audit-log-max-backups"
+
 	// StatePort is the port used for mongo connections.
 	StatePort = "state-port"
 
@@ -72,7 +84,7 @@ const (
 	// detault
 	MongoMemoryProfile = "mongo-memory-profile"
 
-	// MaxLogsAge is the maximum age for log entries, ef "72h"
+	// MaxLogsAge is the maximum age for log entries, eg "72h"
 	MaxLogsAge = "max-logs-age"
 
 	// MaxLogsSize is the maximum size the log collection can grow to
@@ -87,6 +99,18 @@ const (
 	// DefaultAuditingEnabled contains the default value for the
 	// AuditingEnabled config value.
 	DefaultAuditingEnabled = false
+
+	// DefaultAuditLogCaptureArgs is the default for the
+	// AuditLogCaptureArgs setting (which is not to capture them).
+	DefaultAuditLogCaptureArgs = false
+
+	// DefaultAuditLogMaxSizeMB is the default size in MB at which we
+	// roll the audit log file.
+	DefaultAuditLogMaxSizeMB = 300
+
+	// DefaultAuditLogMaxBackups is the default number of files to
+	// keep.
+	DefaultAuditLogMaxBackups = 10
 
 	// DefaultNUMAControlPolicy should not be used by default.
 	// Only use numactl if user specifically requests it
@@ -129,6 +153,10 @@ var ControllerOnlyConfigAttributes = []string{
 	MaxLogsSize,
 	MaxLogsAge,
 	MaxTxnLogSize,
+	AuditingEnabled,
+	AuditLogCaptureArgs,
+	AuditLogMaxSize,
+	AuditLogMaxBackups,
 }
 
 // ControllerOnlyAttribute returns true if the specified attribute name
@@ -216,7 +244,33 @@ func (c Config) AuditingEnabled() bool {
 	if v, ok := c[AuditingEnabled]; ok {
 		return v.(bool)
 	}
-	return false
+	return DefaultAuditingEnabled
+}
+
+// AuditLogCaptureArgs returns whether audit logging should capture
+// the arguments to API methods. The default is false.
+func (c Config) AuditLogCaptureArgs() bool {
+	if v, ok := c[AuditLogCaptureArgs]; ok {
+		return v.(bool)
+	}
+	return DefaultAuditLogCaptureArgs
+}
+
+// AuditLogMaxSizeMB returns the maximum size for an audit log file in
+// MB.
+func (c Config) AuditLogMaxSizeMB() int {
+	// Value has already been validated.
+	value, _ := utils.ParseSize(c.asString(AuditLogMaxSize))
+	return int(value)
+}
+
+// AuditLogMaxBackups returns the maximum number of backup audit log
+// files to keep.
+func (c Config) AuditLogMaxBackups() int {
+	if value, ok := c[AuditLogMaxBackups]; ok {
+		return value.(int)
+	}
+	return DefaultAuditLogMaxBackups
 }
 
 // ControllerUUID returns the uuid for the model's controller.
@@ -372,6 +426,27 @@ func Validate(c Config) error {
 		}
 	}
 
+	var auditLogMaxSize int
+	if v, ok := c[AuditLogMaxSize].(string); ok {
+		if size, err := utils.ParseSize(v); err != nil {
+			return errors.Annotate(err, "invalid audit log max size in configuration")
+		} else {
+			auditLogMaxSize = int(size)
+		}
+	}
+
+	if v, ok := c[AuditingEnabled].(bool); ok {
+		if v && auditLogMaxSize == 0 {
+			return errors.Errorf("invalid audit log max size: can't be 0 if auditing is enabled")
+		}
+	}
+
+	if v, ok := c[AuditLogMaxBackups].(int); ok {
+		if v < 0 {
+			return errors.Errorf("invalid audit log max backups: should be a number of files (or 0 to keep all), got %d", v)
+		}
+	}
+
 	return nil
 }
 
@@ -383,6 +458,9 @@ func GenerateControllerCertAndKey(caCert, caKey string, hostAddresses []string) 
 
 var configChecker = schema.FieldMap(schema.Fields{
 	AuditingEnabled:         schema.Bool(),
+	AuditLogCaptureArgs:     schema.Bool(),
+	AuditLogMaxSize:         schema.String(),
+	AuditLogMaxBackups:      schema.ForceInt(),
 	APIPort:                 schema.ForceInt(),
 	StatePort:               schema.ForceInt(),
 	IdentityURL:             schema.String(),
@@ -398,6 +476,9 @@ var configChecker = schema.FieldMap(schema.Fields{
 }, schema.Defaults{
 	APIPort:                 DefaultAPIPort,
 	AuditingEnabled:         DefaultAuditingEnabled,
+	AuditLogCaptureArgs:     DefaultAuditLogCaptureArgs,
+	AuditLogMaxSize:         fmt.Sprintf("%vM", DefaultAuditLogMaxSizeMB),
+	AuditLogMaxBackups:      DefaultAuditLogMaxBackups,
 	StatePort:               DefaultStatePort,
 	IdentityURL:             schema.Omit,
 	IdentityPublicKey:       schema.Omit,

--- a/state/controller_test.go
+++ b/state/controller_test.go
@@ -34,6 +34,7 @@ func (s *ControllerSuite) TestControllerAndModelConfigInitialisation(c *gc.C) {
 	}
 	for _, controllerAttr := range controller.ControllerOnlyConfigAttributes {
 		v, ok := controllerSettings.Get(controllerAttr)
+		c.Logf(controllerAttr)
 		if !optional[controllerAttr] {
 			c.Assert(ok, jc.IsTrue)
 			c.Assert(v, gc.Not(gc.Equals), "")

--- a/testing/environ.go
+++ b/testing/environ.go
@@ -50,6 +50,10 @@ func FakeControllerConfig() controller.Config {
 		"max-logs-age":            "72h",
 		"max-logs-size":           "4G",
 		"max-txn-log-size":        "10M",
+		"auditing-enabled":        false,
+		"audit-log-capture-args":  true,
+		"audit-log-max-size":      "200M",
+		"audit-log-max-backups":   5,
 	}
 }
 


### PR DESCRIPTION
## Description of change

Plumb the audit logging configuration options into  controller config.

## QA steps

Bootstrap a controller without auditing enabled (the default) - `/var/log/juju/audit.log` isn't created. Kill the controller and bootstrap again with config settings:
```
auditing-enabled=true
audit-log-max-size=100M
audit-log-max-backups=5
audit-log-capture-args=true
```
See that the audit log file is created and it contains audit log entries.
Check that the options above are shown in the output of `juju controller-config`.

## Documentation changes
These controller config options will need to be documented.
