### PR TITLE
Add container support for model-config cloudinit-userdata.

### DIFF
--- a/apiserver/facades/agent/provisioner/provisioner.go
+++ b/apiserver/facades/agent/provisioner/provisioner.go
@@ -291,7 +291,7 @@ func (p *ProvisionerAPI) ContainerConfig() (params.ContainerConfig, error) {
 	result.Proxy = config.ProxySettings()
 	result.AptProxy = config.AptProxySettings()
 	result.AptMirror = config.AptMirror()
-
+	result.CloudInitUserData = config.CloudInitUserData()
 	return result, nil
 }
 

--- a/apiserver/facades/agent/provisioner/provisioner_test.go
+++ b/apiserver/facades/agent/provisioner/provisioner_test.go
@@ -1355,6 +1355,7 @@ func (s *withoutControllerSuite) TestContainerConfig(c *gc.C) {
 		"apt-https-proxy":       "https://proxy.example.com:9000",
 		"allow-lxd-loop-mounts": true,
 		"apt-mirror":            "http://example.mirror.com",
+		"cloudinit-userdata":    validCloudInitUserData,
 	}
 	err := s.Model.UpdateModelConfig(attrs, nil)
 	c.Assert(err, jc.ErrorIsNil)
@@ -1378,6 +1379,11 @@ func (s *withoutControllerSuite) TestContainerConfig(c *gc.C) {
 	c.Check(results.Proxy, gc.DeepEquals, expectedProxy)
 	c.Check(results.AptProxy, gc.DeepEquals, expectedAPTProxy)
 	c.Check(results.AptMirror, gc.DeepEquals, "http://example.mirror.com")
+	c.Check(results.CloudInitUserData, gc.DeepEquals, map[string]interface{}{
+		"packages":        []interface{}{"python-keystoneclient", "python-glanceclient"},
+		"preruncmd":       []interface{}{"mkdir /tmp/preruncmd", "mkdir /tmp/preruncmd2"},
+		"postruncmd":      []interface{}{"mkdir /tmp/postruncmd", "mkdir /tmp/postruncmd2"},
+		"package_upgrade": false})
 }
 
 func (s *withoutControllerSuite) TestSetSupportedContainers(c *gc.C) {

--- a/apiserver/params/params.go
+++ b/apiserver/params/params.go
@@ -669,12 +669,13 @@ type UpdateBehavior struct {
 // ContainerConfig contains information from the model config that is
 // needed for container cloud-init.
 type ContainerConfig struct {
-	ProviderType            string         `json:"provider-type"`
-	AuthorizedKeys          string         `json:"authorized-keys"`
-	SSLHostnameVerification bool           `json:"ssl-hostname-verification"`
-	Proxy                   proxy.Settings `json:"proxy"`
-	AptProxy                proxy.Settings `json:"apt-proxy"`
-	AptMirror               string         `json:"apt-mirror"`
+	ProviderType            string                 `json:"provider-type"`
+	AuthorizedKeys          string                 `json:"authorized-keys"`
+	SSLHostnameVerification bool                   `json:"ssl-hostname-verification"`
+	Proxy                   proxy.Settings         `json:"proxy"`
+	AptProxy                proxy.Settings         `json:"apt-proxy"`
+	AptMirror               string                 `json:"apt-mirror"`
+	CloudInitUserData       map[string]interface{} `json:"cloudinit-userdata,omitempty"`
 	*UpdateBehavior
 }
 

--- a/worker/provisioner/kvm-broker.go
+++ b/worker/provisioner/kvm-broker.go
@@ -114,9 +114,6 @@ func (broker *kvmBroker) StartInstance(args environs.StartInstanceParams) (*envi
 		return nil, errors.Trace(err)
 	}
 
-	// TODO HML 2017-12-07
-	// Find the CloudInitUserData to fill in the last arg of
-	// instancecfg.PopulateInstanceConfig
 	if err := instancecfg.PopulateInstanceConfig(
 		args.InstanceConfig,
 		config.ProviderType,
@@ -127,7 +124,7 @@ func (broker *kvmBroker) StartInstance(args environs.StartInstanceParams) (*envi
 		config.AptMirror,
 		config.EnableOSRefreshUpdate,
 		config.EnableOSUpgrade,
-		make(map[string]interface{}),
+		config.CloudInitUserData,
 	); err != nil {
 		kvmLogger.Errorf("failed to populate machine config: %v", err)
 		return nil, err

--- a/worker/provisioner/lxd-broker.go
+++ b/worker/provisioner/lxd-broker.go
@@ -104,9 +104,6 @@ func (broker *lxdBroker) StartInstance(args environs.StartInstanceParams) (*envi
 		return nil, errors.Trace(err)
 	}
 
-	// TODO HML 2017-12-07
-	// Find the CloudInitUserData to fill in the last arg of
-	// instancecfg.PopulateInstanceConfig
 	if err := instancecfg.PopulateInstanceConfig(
 		args.InstanceConfig,
 		config.ProviderType,
@@ -117,7 +114,7 @@ func (broker *lxdBroker) StartInstance(args environs.StartInstanceParams) (*envi
 		config.AptMirror,
 		config.EnableOSRefreshUpdate,
 		config.EnableOSUpgrade,
-		make(map[string]interface{}),
+		config.CloudInitUserData,
 	); err != nil {
 		lxdLogger.Errorf("failed to populate machine config: %v", err)
 		return nil, err


### PR DESCRIPTION
## Description of change

Use the data provided in model-config cloudinit-userdata by adding it to the juju created
cloudinit files used for containers provisioned on juju machines. This is a follow-on to PR 8188.

This PR will be followed up with changes to handle bootcmd like runcmd is.

## QA steps

1. unit tests
2. create a yaml file with cloudinit-userdata defined.
3. bootstrap with the bootstrap config and the model default config using the above yaml
4. add a machine with a container to the default model.
5. ssh to the controller, the juju machine, and the juju container to verify things specified in the yaml file happened.

## Documentation changes

N/A

## Bug reference

N/A