### PR TITLE
Support application config

### DIFF
--- a/api/application/client.go
+++ b/api/application/client.go
@@ -188,7 +188,7 @@ func (c *Client) GetConfig(appNames ...string) ([]map[string]interface{}, error)
 		return allSettings, nil
 	}
 
-	apiName := "GetCharmConfig"
+	apiName := "CharmConfig"
 	if c.BestAPIVersion() < 6 {
 		apiName = "GetConfig"
 	}

--- a/api/application/client_test.go
+++ b/api/application/client_test.go
@@ -708,7 +708,7 @@ func (s *applicationSuite) TestGetConfigV5(c *gc.C) {
 }
 
 func (s *applicationSuite) TestGetConfigV6(c *gc.C) {
-	s.assertGetConfig(c, "GetCharmConfig", 6)
+	s.assertGetConfig(c, "CharmConfig", 6)
 }
 
 func (s *applicationSuite) assertGetConfig(c *gc.C, method string, version int) {

--- a/api/application/client_test.go
+++ b/api/application/client_test.go
@@ -246,7 +246,7 @@ func (s *applicationSuite) TestServiceGetCharmURL(c *gc.C) {
 	c.Assert(called, jc.IsTrue)
 }
 
-func (s *applicationSuite) TestServiceSetCharm(c *gc.C) {
+func (s *applicationSuite) TestSetCharm(c *gc.C) {
 	var called bool
 	toUint64Ptr := func(v uint64) *uint64 {
 		return &v
@@ -703,7 +703,15 @@ func (s *applicationSuite) TestAddRelation(c *gc.C) {
 	})
 }
 
-func (s *applicationSuite) TestGetConfig(c *gc.C) {
+func (s *applicationSuite) TestGetConfigV5(c *gc.C) {
+	s.assertGetConfig(c, "GetConfig", 5)
+}
+
+func (s *applicationSuite) TestGetConfigV6(c *gc.C) {
+	s.assertGetConfig(c, "GetCharmConfig", 6)
+}
+
+func (s *applicationSuite) assertGetConfig(c *gc.C, method string, version int) {
 	fooConfig := map[string]interface{}{
 		"outlook": map[string]interface{}{
 			"description": "No default outlook.",
@@ -736,7 +744,7 @@ func (s *applicationSuite) TestGetConfig(c *gc.C) {
 	client := application.NewClient(basetesting.BestVersionCaller{
 		APICallerFunc: basetesting.APICallerFunc(
 			func(objType string, version int, id, request string, a, response interface{}) error {
-				c.Assert(request, gc.Equals, "GetConfig")
+				c.Assert(request, gc.Equals, method)
 				args, ok := a.(params.Entities)
 				c.Assert(ok, jc.IsTrue)
 				c.Assert(args, jc.DeepEquals, params.Entities{
@@ -752,7 +760,7 @@ func (s *applicationSuite) TestGetConfig(c *gc.C) {
 				return nil
 			},
 		),
-		BestVersion: 5,
+		BestVersion: version,
 	})
 
 	results, err := client.GetConfig("foo", "bar")
@@ -800,9 +808,9 @@ func (s *applicationSuite) TestGetConfigAPIv4(c *gc.C) {
 
 				switch args.ApplicationName {
 				case "foo":
-					result.Config = fooConfig
+					result.CharmConfig = fooConfig
 				case "bar":
-					result.Config = barConfig
+					result.CharmConfig = barConfig
 				default:
 					return errors.New("unexpected app name")
 				}
@@ -945,4 +953,91 @@ func (s *applicationSuite) TestGetConstraintsAPIv4(c *gc.C) {
 	c.Assert(results, jc.DeepEquals, []constraints.Value{
 		fooConstraints, barConstraints,
 	})
+}
+
+func (s *applicationSuite) TestSetApplicationConfig(c *gc.C) {
+	fooConfig := map[string]string{
+		"foo":   "bar",
+		"level": "high",
+	}
+
+	client := application.NewClient(basetesting.BestVersionCaller{
+		APICallerFunc: basetesting.APICallerFunc(
+			func(objType string, version int, id, request string, a, response interface{}) error {
+				c.Assert(request, gc.Equals, "SetApplicationsConfig")
+				args, ok := a.(params.ApplicationConfigSetArgs)
+				c.Assert(ok, jc.IsTrue)
+				c.Assert(args, jc.DeepEquals, params.ApplicationConfigSetArgs{
+					Args: []params.ApplicationConfigSet{{
+						ApplicationName: "foo",
+						Config:          fooConfig,
+					}}})
+				result, ok := response.(*params.ErrorResults)
+				c.Assert(ok, jc.IsTrue)
+				result.Results = []params.ErrorResult{
+					{Error: &params.Error{Message: "FAIL"}},
+				}
+				return nil
+			},
+		),
+		BestVersion: 6,
+	})
+
+	err := client.SetApplicationConfig("foo", fooConfig)
+	c.Assert(err, gc.ErrorMatches, "FAIL")
+}
+
+func (s *applicationSuite) TestUnsetApplicationConfig(c *gc.C) {
+	client := application.NewClient(basetesting.BestVersionCaller{
+		APICallerFunc: basetesting.APICallerFunc(
+			func(objType string, version int, id, request string, a, response interface{}) error {
+				c.Assert(request, gc.Equals, "UnsetApplicationsConfig")
+				args, ok := a.(params.ApplicationConfigUnsetArgs)
+				c.Assert(ok, jc.IsTrue)
+				c.Assert(args, jc.DeepEquals, params.ApplicationConfigUnsetArgs{
+					Args: []params.ApplicationUnset{{
+						ApplicationName: "foo",
+						Options:         []string{"option"},
+					}}})
+				result, ok := response.(*params.ErrorResults)
+				c.Assert(ok, jc.IsTrue)
+				result.Results = []params.ErrorResult{
+					{Error: &params.Error{Message: "FAIL"}},
+				}
+				return nil
+			},
+		),
+		BestVersion: 6,
+	})
+
+	err := client.UnsetApplicationConfig("foo", []string{"option"})
+	c.Assert(err, gc.ErrorMatches, "FAIL")
+}
+
+func (s *applicationSuite) TestSetApplicationConfigAPIv5(c *gc.C) {
+	client := application.NewClient(basetesting.BestVersionCaller{
+		APICallerFunc: basetesting.APICallerFunc(
+			func(objType string, version int, id, request string, a, response interface{}) error {
+				c.Fail()
+				return errors.NotSupportedf("")
+			}),
+		BestVersion: 5,
+	})
+
+	err := client.SetApplicationConfig("foo", map[string]string{})
+	c.Assert(err, jc.Satisfies, errors.IsNotSupported)
+}
+
+func (s *applicationSuite) TestUnsetApplicationConfigAPIv5(c *gc.C) {
+	client := application.NewClient(basetesting.BestVersionCaller{
+		APICallerFunc: basetesting.APICallerFunc(
+			func(objType string, version int, id, request string, a, response interface{}) error {
+				c.Fail()
+				return errors.NotSupportedf("")
+			}),
+		BestVersion: 5,
+	})
+
+	err := client.UnsetApplicationConfig("foo", []string{})
+	c.Assert(err, jc.Satisfies, errors.IsNotSupported)
 }

--- a/api/facadeversions.go
+++ b/api/facadeversions.go
@@ -18,7 +18,7 @@ var facadeVersions = map[string]int{
 	"AllModelWatcher":              2,
 	"AllWatcher":                   1,
 	"Annotations":                  2,
-	"Application":                  5,
+	"Application":                  6,
 	"ApplicationOffers":            1,
 	"ApplicationScaler":            1,
 	"Backups":                      1,

--- a/apiserver/allfacades.go
+++ b/apiserver/allfacades.go
@@ -135,7 +135,7 @@ func AllFacades() *facade.Registry {
 	reg("Application", 2, application.NewFacadeV4)
 	reg("Application", 3, application.NewFacadeV4)
 	reg("Application", 4, application.NewFacadeV4)
-	reg("Application", 5, application.NewFacade) // adds AttachStorage & UpdateApplicationSeries & SetRelationStatus
+	reg("Application", 5, application.NewFacadeV5) // adds AttachStorage & UpdateApplicationSeries & SetRelationStatus
 
 	reg("ApplicationOffers", 1, applicationoffers.NewOffersAPI)
 	reg("ApplicationScaler", 1, applicationscaler.NewAPI)
@@ -150,6 +150,7 @@ func AllFacades() *facade.Registry {
 	if featureflag.Enabled(feature.CAAS) {
 		// CAAS related facades.
 		// Move these to the correct place above once the feature flag disappears.
+		reg("Application", 6, application.NewFacadeV6)
 		reg("Cloud", 2, cloud.NewFacadeV2)
 		reg("CAASFirewaller", 1, caasfirewaller.NewStateFacade)
 		reg("CAASOperator", 1, caasoperator.NewStateFacade)

--- a/apiserver/facades/client/application/application.go
+++ b/apiserver/facades/client/application/application.go
@@ -1533,8 +1533,8 @@ func (api *APIv4) GetConstraints(args params.GetApplicationConstraints) (params.
 	return params.GetConstraintsResults{cons}, errors.Trace(err)
 }
 
-// GetCharmConfig is a shim to GetConfig on APIv5. It returns just the charm config.
-func (api *APIv6) GetCharmConfig(args params.Entities) (params.ApplicationGetConfigResults, error) {
+// CharmConfig is a shim to GetConfig on APIv5. It returns just the charm config.
+func (api *APIv6) CharmConfig(args params.Entities) (params.ApplicationGetConfigResults, error) {
 	return api.GetConfig(args)
 }
 
@@ -1570,7 +1570,7 @@ func (api *APIv6) setApplicationConfig(arg params.ApplicationConfigSet) error {
 	providerSchema, providerDefaults := providerConfigSchema()
 
 	if len(appConfigAttrs) > 0 {
-		if err := app.UpdateApplicationConfig(appConfigAttrs, providerSchema, providerDefaults); err != nil {
+		if err := app.UpdateApplicationConfig(appConfigAttrs, nil, providerSchema, providerDefaults); err != nil {
 			return errors.Annotate(err, "updating application config values")
 		}
 	}
@@ -1621,18 +1621,18 @@ func (api *APIv6) unsetApplicationConfig(arg params.ApplicationUnset) error {
 	}
 	appConfigFields := appSchema.KnownConfigKeys()
 
-	appConfigAttrs := make(map[string]interface{})
+	var appConfigKeys []string
 	charmSettings := make(charm.Settings)
 	for _, name := range arg.Options {
 		if appConfigFields.Contains(name) {
-			appConfigAttrs[name] = nil
+			appConfigKeys = append(appConfigKeys, name)
 		} else {
 			charmSettings[name] = nil
 		}
 	}
 
-	if len(appConfigAttrs) > 0 {
-		if err := app.UpdateApplicationConfig(appConfigAttrs, providerSchema, providerDefaults); err != nil {
+	if len(appConfigKeys) > 0 {
+		if err := app.UpdateApplicationConfig(nil, appConfigKeys, providerSchema, providerDefaults); err != nil {
 			return errors.Annotate(err, "updating application config values")
 		}
 	}

--- a/apiserver/facades/client/application/application.go
+++ b/apiserver/facades/client/application/application.go
@@ -12,9 +12,11 @@ import (
 
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
+	"github.com/juju/schema"
 	"github.com/juju/utils/set"
 	"gopkg.in/juju/charm.v6"
 	csparams "gopkg.in/juju/charmrepo.v2/csclient/params"
+	"gopkg.in/juju/environschema.v1"
 	"gopkg.in/juju/names.v2"
 	"gopkg.in/macaroon.v1"
 	goyaml "gopkg.in/yaml.v2"
@@ -23,7 +25,9 @@ import (
 	"github.com/juju/juju/apiserver/common/storagecommon"
 	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/apiserver/params"
+	k8s "github.com/juju/juju/caas/kubernetes/provider"
 	"github.com/juju/juju/constraints"
+	"github.com/juju/juju/core/application"
 	"github.com/juju/juju/core/crossmodel"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/instance"
@@ -38,14 +42,19 @@ var logger = loggo.GetLogger("juju.apiserver.application")
 
 // APIv4 provides the Application API facade for versions 1-4.
 type APIv4 struct {
-	*API
+	*APIv5
+}
+
+// APIv6 provides the Application API facade for version 6.
+type APIv6 struct {
+	*APIv5
 }
 
 // API implements the application interface and is the concrete
 // implementation of the api end point.
 //
 // API provides the Application API facade for version 5.
-type API struct {
+type APIv5 struct {
 	backend    Backend
 	authorizer facade.Authorizer
 	check      BlockChecker
@@ -63,22 +72,32 @@ type API struct {
 // NewFacadeV4 provides the signature required for facade registration
 // for versions 1-4.
 func NewFacadeV4(ctx facade.Context) (*APIv4, error) {
-	api, err := NewFacade(ctx)
+	api, err := NewFacadeV5(ctx)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
 	return &APIv4{api}, nil
 }
 
+// NewFacadeV6 provides the signature required for facade registration
+// for versions 6.
+func NewFacadeV6(ctx facade.Context) (*APIv6, error) {
+	apiV5, err := NewFacadeV5(ctx)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return &APIv6{apiV5}, nil
+}
+
 // NewFacade provides the signature required for facade registration.
-func NewFacade(ctx facade.Context) (*API, error) {
+func NewFacadeV5(ctx facade.Context) (*APIv5, error) {
 	backend, err := NewStateBackend(ctx.State())
 	if err != nil {
 		return nil, errors.Annotate(err, "getting state")
 	}
 	blockChecker := common.NewBlockChecker(ctx.State())
 	stateCharm := CharmToStateCharm
-	return NewAPI(
+	return NewAPIV5(
 		backend,
 		ctx.Auth(),
 		blockChecker,
@@ -88,17 +107,17 @@ func NewFacade(ctx facade.Context) (*API, error) {
 }
 
 // NewAPI returns a new application API facade.
-func NewAPI(
+func NewAPIV5(
 	backend Backend,
 	authorizer facade.Authorizer,
 	blockChecker BlockChecker,
 	stateCharm func(Charm) *state.Charm,
 	deployApplication func(ApplicationDeployer, DeployApplicationParams) (Application, error),
-) (*API, error) {
+) (*APIv5, error) {
 	if !authorizer.AuthClient() {
 		return nil, common.ErrPerm
 	}
-	return &API{
+	return &APIv5{
 		backend:               backend,
 		authorizer:            authorizer,
 		check:                 blockChecker,
@@ -107,7 +126,7 @@ func NewAPI(
 	}, nil
 }
 
-func (api *API) checkPermission(tag names.Tag, perm permission.Access) error {
+func (api *APIv5) checkPermission(tag names.Tag, perm permission.Access) error {
 	allowed, err := api.authorizer.HasPermission(perm, tag)
 	if err != nil {
 		return errors.Trace(err)
@@ -118,16 +137,16 @@ func (api *API) checkPermission(tag names.Tag, perm permission.Access) error {
 	return nil
 }
 
-func (api *API) checkCanRead() error {
+func (api *APIv5) checkCanRead() error {
 	return api.checkPermission(api.backend.ModelTag(), permission.ReadAccess)
 }
 
-func (api *API) checkCanWrite() error {
+func (api *APIv5) checkCanWrite() error {
 	return api.checkPermission(api.backend.ModelTag(), permission.WriteAccess)
 }
 
 // SetMetricCredentials sets credentials on the application.
-func (api *API) SetMetricCredentials(args params.ApplicationMetricCredentials) (params.ErrorResults, error) {
+func (api *APIv5) SetMetricCredentials(args params.ApplicationMetricCredentials) (params.ErrorResults, error) {
 	if err := api.checkCanWrite(); err != nil {
 		return params.ErrorResults{}, errors.Trace(err)
 	}
@@ -153,7 +172,7 @@ func (api *API) SetMetricCredentials(args params.ApplicationMetricCredentials) (
 
 // Deploy fetches the charms from the charm store and deploys them
 // using the specified placement directives.
-func (api *API) Deploy(args params.ApplicationsDeploy) (params.ErrorResults, error) {
+func (api *APIv5) Deploy(args params.ApplicationsDeploy) (params.ErrorResults, error) {
 	if err := api.checkCanWrite(); err != nil {
 		return params.ErrorResults{}, errors.Trace(err)
 	}
@@ -187,6 +206,36 @@ func (api *API) Deploy(args params.ApplicationsDeploy) (params.ErrorResults, err
 		}
 	}
 	return result, nil
+}
+
+func providerConfigSchema() (environschema.Fields, schema.Defaults) {
+	// TODO(caas) - get the schema from the provider
+	return k8s.ConfigSchema(), k8s.ConfigDefaults()
+}
+
+func splitApplicationAndCharmConfig(inConfig map[string]string) (
+	appCfg map[string]interface{},
+	charmCfg map[string]string,
+	_ error,
+) {
+
+	providerSchema, _ := providerConfigSchema()
+	appSchema, err := application.ConfigSchema(providerSchema)
+	if err != nil {
+		return nil, nil, errors.Trace(err)
+	}
+	appConfigKeys := appSchema.KnownConfigKeys()
+
+	appConfigAttrs := make(map[string]interface{})
+	charmConfig := make(map[string]string)
+	for k, v := range inConfig {
+		if appConfigKeys.Contains(k) {
+			appConfigAttrs[k] = v
+		} else {
+			charmConfig[k] = v
+		}
+	}
+	return appConfigAttrs, charmConfig, nil
 }
 
 // deployApplication fetches the charm from the charm store and deploys it.
@@ -242,15 +291,37 @@ func deployApplication(
 		return errors.Trace(err)
 	}
 
-	var settings charm.Settings
-	if len(args.ConfigYAML) > 0 {
-		settings, err = ch.Config().ParseSettingsYAML([]byte(args.ConfigYAML), args.ApplicationName)
-	} else if len(args.Config) > 0 {
-		// Parse config in a compatible way (see function comment).
-		settings, err = parseSettingsCompatible(ch.Config(), args.Config)
-	}
+	appConfigAttrs, charmConfig, err := splitApplicationAndCharmConfig(args.Config)
 	if err != nil {
 		return errors.Trace(err)
+	}
+
+	var applicationConfig *application.Config
+	if len(appConfigAttrs) > 0 {
+		// TODO(caas) - get the schema from the provider
+		applicationConfig, err = application.NewConfig(appConfigAttrs, k8s.ConfigSchema(), k8s.ConfigDefaults())
+		if err != nil {
+			return errors.Trace(err)
+		}
+	}
+
+	var settings = make(charm.Settings)
+	if len(args.ConfigYAML) > 0 {
+		settings, err = ch.Config().ParseSettingsYAML([]byte(args.ConfigYAML), args.ApplicationName)
+		if err != nil {
+			return errors.Trace(err)
+		}
+	}
+	// Overlay any settings in YAML with those from config map.
+	if len(charmConfig) > 0 {
+		// Parse config in a compatible way (see function comment).
+		overrideSettings, err := parseSettingsCompatible(ch.Config(), charmConfig)
+		if err != nil {
+			return errors.Trace(err)
+		}
+		for k, v := range overrideSettings {
+			settings[k] = v
+		}
 	}
 
 	// Parse storage tags in AttachStorage.
@@ -267,18 +338,19 @@ func deployApplication(
 	}
 
 	_, err = deployApplicationFunc(backend, DeployApplicationParams{
-		ApplicationName:  args.ApplicationName,
-		Series:           args.Series,
-		Charm:            stateCharm(ch),
-		Channel:          csparams.Channel(args.Channel),
-		NumUnits:         args.NumUnits,
-		CharmConfig:      settings,
-		Constraints:      args.Constraints,
-		Placement:        args.Placement,
-		Storage:          args.Storage,
-		AttachStorage:    attachStorage,
-		EndpointBindings: args.EndpointBindings,
-		Resources:        args.Resources,
+		ApplicationName:   args.ApplicationName,
+		Series:            args.Series,
+		Charm:             stateCharm(ch),
+		Channel:           csparams.Channel(args.Channel),
+		NumUnits:          args.NumUnits,
+		ApplicationConfig: applicationConfig,
+		CharmConfig:       settings,
+		Constraints:       args.Constraints,
+		Placement:         args.Placement,
+		Storage:           args.Storage,
+		AttachStorage:     attachStorage,
+		EndpointBindings:  args.EndpointBindings,
+		Resources:         args.Resources,
 	})
 	return errors.Trace(err)
 }
@@ -334,7 +406,7 @@ func parseSettingsCompatible(charmConfig *charm.Config, settings map[string]stri
 // Update updates the application attributes, including charm URL,
 // minimum number of units, charm config and constraints.
 // All parameters in params.ApplicationUpdate except the application name are optional.
-func (api *API) Update(args params.ApplicationUpdate) error {
+func (api *APIv5) Update(args params.ApplicationUpdate) error {
 	if err := api.checkCanWrite(); err != nil {
 		return err
 	}
@@ -392,7 +464,7 @@ func (api *API) Update(args params.ApplicationUpdate) error {
 
 // UpdateApplicationSeries updates the application series. Series for
 // subordinates updated too.
-func (api *API) UpdateApplicationSeries(args params.UpdateSeriesArgs) (params.ErrorResults, error) {
+func (api *APIv5) UpdateApplicationSeries(args params.UpdateSeriesArgs) (params.ErrorResults, error) {
 	if err := api.checkCanWrite(); err != nil {
 		return params.ErrorResults{}, err
 	}
@@ -409,7 +481,7 @@ func (api *API) UpdateApplicationSeries(args params.UpdateSeriesArgs) (params.Er
 	return results, nil
 }
 
-func (api *API) updateOneApplicationSeries(arg params.UpdateSeriesArg) error {
+func (api *APIv5) updateOneApplicationSeries(arg params.UpdateSeriesArg) error {
 	if arg.Series == "" {
 		return &params.Error{
 			Message: "series missing from args",
@@ -437,7 +509,7 @@ func (api *API) updateOneApplicationSeries(arg params.UpdateSeriesArg) error {
 }
 
 // SetCharm sets the charm for a given for the application.
-func (api *API) SetCharm(args params.ApplicationSetCharm) error {
+func (api *APIv5) SetCharm(args params.ApplicationSetCharm) error {
 	if err := api.checkCanWrite(); err != nil {
 		return err
 	}
@@ -468,7 +540,7 @@ func (api *API) SetCharm(args params.ApplicationSetCharm) error {
 
 // GetConfig returns the charm config for each of the
 // applications asked for.
-func (api *API) GetConfig(args params.Entities) (params.ApplicationGetConfigResults, error) {
+func (api *APIv5) GetConfig(args params.Entities) (params.ApplicationGetConfigResults, error) {
 	if err := api.checkCanRead(); err != nil {
 		return params.ApplicationGetConfigResults{}, err
 	}
@@ -476,14 +548,14 @@ func (api *API) GetConfig(args params.Entities) (params.ApplicationGetConfigResu
 		Results: make([]params.ConfigResult, len(args.Entities)),
 	}
 	for i, arg := range args.Entities {
-		config, err := api.getConfig(arg.Tag)
+		config, err := api.getCharmConfig(arg.Tag)
 		results.Results[i].Config = config
 		results.Results[i].Error = common.ServerError(err)
 	}
 	return results, nil
 }
 
-func (api *API) getConfig(entity string) (map[string]interface{}, error) {
+func (api *APIv5) getCharmConfig(entity string) (map[string]interface{}, error) {
 	tag, err := names.ParseTag(entity)
 	if err != nil {
 		return nil, err
@@ -509,7 +581,7 @@ func (api *API) getConfig(entity string) (map[string]interface{}, error) {
 }
 
 // applicationSetCharm sets the charm for the given for the application.
-func (api *API) applicationSetCharm(
+func (api *APIv5) applicationSetCharm(
 	appName string,
 	application Application,
 	url string,
@@ -623,7 +695,7 @@ func applicationSetCharmConfigYAML(appName string, application Application, sett
 
 // GetCharmURL returns the charm URL the given application is
 // running at present.
-func (api *API) GetCharmURL(args params.ApplicationGet) (params.StringResult, error) {
+func (api *APIv5) GetCharmURL(args params.ApplicationGet) (params.StringResult, error) {
 	if err := api.checkCanWrite(); err != nil {
 		return params.StringResult{}, errors.Trace(err)
 	}
@@ -638,7 +710,7 @@ func (api *API) GetCharmURL(args params.ApplicationGet) (params.StringResult, er
 // Set implements the server side of Application.Set.
 // It does not unset values that are set to an empty string.
 // Unset should be used for that.
-func (api *API) Set(p params.ApplicationSet) error {
+func (api *APIv5) Set(p params.ApplicationSet) error {
 	if err := api.checkCanWrite(); err != nil {
 		return err
 	}
@@ -664,7 +736,7 @@ func (api *API) Set(p params.ApplicationSet) error {
 }
 
 // Unset implements the server side of Client.Unset.
-func (api *API) Unset(p params.ApplicationUnset) error {
+func (api *APIv5) Unset(p params.ApplicationUnset) error {
 	if err := api.checkCanWrite(); err != nil {
 		return err
 	}
@@ -683,7 +755,7 @@ func (api *API) Unset(p params.ApplicationUnset) error {
 }
 
 // CharmRelations implements the server side of Application.CharmRelations.
-func (api *API) CharmRelations(p params.ApplicationCharmRelations) (params.ApplicationCharmRelationsResults, error) {
+func (api *APIv5) CharmRelations(p params.ApplicationCharmRelations) (params.ApplicationCharmRelationsResults, error) {
 	var results params.ApplicationCharmRelationsResults
 	if err := api.checkCanRead(); err != nil {
 		return results, errors.Trace(err)
@@ -706,7 +778,7 @@ func (api *API) CharmRelations(p params.ApplicationCharmRelations) (params.Appli
 
 // Expose changes the juju-managed firewall to expose any ports that
 // were also explicitly marked by units as open.
-func (api *API) Expose(args params.ApplicationExpose) error {
+func (api *APIv5) Expose(args params.ApplicationExpose) error {
 	if err := api.checkCanWrite(); err != nil {
 		return err
 	}
@@ -722,7 +794,7 @@ func (api *API) Expose(args params.ApplicationExpose) error {
 
 // Unexpose changes the juju-managed firewall to unexpose any ports that
 // were also explicitly marked by units as open.
-func (api *API) Unexpose(args params.ApplicationUnexpose) error {
+func (api *APIv5) Unexpose(args params.ApplicationUnexpose) error {
 	if err := api.checkCanWrite(); err != nil {
 		return err
 	}
@@ -737,7 +809,7 @@ func (api *API) Unexpose(args params.ApplicationUnexpose) error {
 }
 
 // AddUnits adds a given number of units to an application.
-func (api *API) AddUnits(args params.AddApplicationUnits) (params.AddApplicationUnitsResults, error) {
+func (api *APIv5) AddUnits(args params.AddApplicationUnits) (params.AddApplicationUnitsResults, error) {
 	if err := api.checkCanWrite(); err != nil {
 		return params.AddApplicationUnitsResults{}, errors.Trace(err)
 	}
@@ -816,7 +888,7 @@ func addApplicationUnits(backend Backend, args params.AddApplicationUnits) ([]Un
 //
 // TODO(axw) 2017-03-16 #1673323
 // Drop this in Juju 3.0.
-func (api *API) DestroyUnits(args params.DestroyApplicationUnits) error {
+func (api *APIv5) DestroyUnits(args params.DestroyApplicationUnits) error {
 	var errs []error
 	entities := params.DestroyUnitsParams{
 		Units: make([]params.DestroyUnitParams, 0, len(args.UnitNames)),
@@ -852,11 +924,11 @@ func (api *APIv4) DestroyUnit(args params.Entities) (params.DestroyUnitResults, 
 	for i, arg := range args.Entities {
 		v5args.Units[i].UnitTag = arg.Tag
 	}
-	return api.API.DestroyUnit(v5args)
+	return api.APIv5.DestroyUnit(v5args)
 }
 
 // DestroyUnit removes a given set of application units.
-func (api *API) DestroyUnit(args params.DestroyUnitsParams) (params.DestroyUnitResults, error) {
+func (api *APIv5) DestroyUnit(args params.DestroyUnitsParams) (params.DestroyUnitResults, error) {
 	if err := api.checkCanWrite(); err != nil {
 		return params.DestroyUnitResults{}, errors.Trace(err)
 	}
@@ -929,7 +1001,7 @@ func (api *API) DestroyUnit(args params.DestroyUnitsParams) (params.DestroyUnitR
 //
 // TODO(axw) 2017-03-16 #1673323
 // Drop this in Juju 3.0.
-func (api *API) Destroy(in params.ApplicationDestroy) error {
+func (api *APIv5) Destroy(in params.ApplicationDestroy) error {
 	if !names.IsValidApplication(in.ApplicationName) {
 		return errors.NotValidf("application name %q", in.ApplicationName)
 	}
@@ -958,11 +1030,11 @@ func (api *APIv4) DestroyApplication(args params.Entities) (params.DestroyApplic
 	for i, arg := range args.Entities {
 		v5args.Applications[i].ApplicationTag = arg.Tag
 	}
-	return api.API.DestroyApplication(v5args)
+	return api.APIv5.DestroyApplication(v5args)
 }
 
 // DestroyApplication removes a given set of applications.
-func (api *API) DestroyApplication(args params.DestroyApplicationsParams) (params.DestroyApplicationResults, error) {
+func (api *APIv5) DestroyApplication(args params.DestroyApplicationsParams) (params.DestroyApplicationResults, error) {
 	if err := api.checkCanWrite(); err != nil {
 		return params.DestroyApplicationResults{}, err
 	}
@@ -1049,7 +1121,7 @@ func (api *API) DestroyApplication(args params.DestroyApplicationsParams) (param
 }
 
 // DestroyConsumedApplications removes a given set of consumed (remote) applications.
-func (api *API) DestroyConsumedApplications(args params.DestroyConsumedApplicationsParams) (params.ErrorResults, error) {
+func (api *APIv5) DestroyConsumedApplications(args params.DestroyConsumedApplicationsParams) (params.ErrorResults, error) {
 	if err := api.checkCanWrite(); err != nil {
 		return params.ErrorResults{}, err
 	}
@@ -1078,7 +1150,7 @@ func (api *API) DestroyConsumedApplications(args params.DestroyConsumedApplicati
 }
 
 // GetConstraints returns the constraints for a given application.
-func (api *API) GetConstraints(args params.Entities) (params.ApplicationGetConstraintsResults, error) {
+func (api *APIv5) GetConstraints(args params.Entities) (params.ApplicationGetConstraintsResults, error) {
 	if err := api.checkCanRead(); err != nil {
 		return params.ApplicationGetConstraintsResults{}, errors.Trace(err)
 	}
@@ -1093,7 +1165,7 @@ func (api *API) GetConstraints(args params.Entities) (params.ApplicationGetConst
 	return results, nil
 }
 
-func (api *API) getConstraints(entity string) (constraints.Value, error) {
+func (api *APIv5) getConstraints(entity string) (constraints.Value, error) {
 	tag, err := names.ParseTag(entity)
 	if err != nil {
 		return constraints.Value{}, err
@@ -1111,7 +1183,7 @@ func (api *API) getConstraints(entity string) (constraints.Value, error) {
 }
 
 // SetConstraints sets the constraints for a given application.
-func (api *API) SetConstraints(args params.SetConstraints) error {
+func (api *APIv5) SetConstraints(args params.SetConstraints) error {
 	if err := api.checkCanWrite(); err != nil {
 		return err
 	}
@@ -1126,7 +1198,7 @@ func (api *API) SetConstraints(args params.SetConstraints) error {
 }
 
 // AddRelation adds a relation between the specified endpoints and returns the relation info.
-func (api *API) AddRelation(args params.AddRelation) (_ params.AddRelationResults, err error) {
+func (api *APIv5) AddRelation(args params.AddRelation) (_ params.AddRelationResults, err error) {
 	var rel Relation
 	defer func() {
 		if err != nil && rel != nil {
@@ -1184,7 +1256,7 @@ func (api *API) AddRelation(args params.AddRelation) (_ params.AddRelationResult
 
 // DestroyRelation removes the relation between the
 // specified endpoints or an id.
-func (api *API) DestroyRelation(args params.DestroyRelation) (err error) {
+func (api *APIv5) DestroyRelation(args params.DestroyRelation) (err error) {
 	if err := api.checkCanWrite(); err != nil {
 		return err
 	}
@@ -1211,7 +1283,7 @@ func (api *API) DestroyRelation(args params.DestroyRelation) (err error) {
 }
 
 // SetRelationsSuspended sets the suspended status of the specified relations.
-func (api *API) SetRelationsSuspended(args params.RelationSuspendedArgs) (params.ErrorResults, error) {
+func (api *APIv5) SetRelationsSuspended(args params.RelationSuspendedArgs) (params.ErrorResults, error) {
 	var statusResults params.ErrorResults
 	if err := api.checkCanWrite(); err != nil {
 		return statusResults, errors.Trace(err)
@@ -1261,7 +1333,7 @@ func (api *API) SetRelationsSuspended(args params.RelationSuspendedArgs) (params
 
 // Consume adds remote applications to the model without creating any
 // relations.
-func (api *API) Consume(args params.ConsumeApplicationArgs) (params.ErrorResults, error) {
+func (api *APIv5) Consume(args params.ConsumeApplicationArgs) (params.ErrorResults, error) {
 	var consumeResults params.ErrorResults
 	if err := api.checkCanWrite(); err != nil {
 		return consumeResults, errors.Trace(err)
@@ -1279,7 +1351,7 @@ func (api *API) Consume(args params.ConsumeApplicationArgs) (params.ErrorResults
 	return consumeResults, nil
 }
 
-func (api *API) consumeOne(arg params.ConsumeApplicationArg) error {
+func (api *APIv5) consumeOne(arg params.ConsumeApplicationArg) error {
 	sourceModelTag, err := names.ParseModelTag(arg.SourceModelTag)
 	if err != nil {
 		return errors.Trace(err)
@@ -1315,7 +1387,7 @@ func (api *API) consumeOne(arg params.ConsumeApplicationArg) error {
 
 // saveRemoteApplication saves the details of the specified remote application and its endpoints
 // to the state model so relations to the remote application can be created.
-func (api *API) saveRemoteApplication(
+func (api *APIv5) saveRemoteApplication(
 	sourceModelTag names.ModelTag,
 	applicationName string,
 	offer params.ApplicationOfferDetails,
@@ -1385,7 +1457,7 @@ func providerSpaceInfoFromParams(space params.RemoteSpace) *environs.ProviderSpa
 // specified name and source model tag and tries to update its endpoints with the
 // new ones specified. If the endpoints are compatible, the newly updated remote
 // application is returned.
-func (api *API) maybeUpdateExistingApplicationEndpoints(
+func (api *APIv5) maybeUpdateExistingApplicationEndpoints(
 	applicationName string, sourceModelTag names.ModelTag, remoteEps []charm.Relation,
 ) (RemoteApplication, error) {
 	existingRemoteApp, err := api.backend.RemoteApplication(applicationName)
@@ -1459,4 +1531,115 @@ func (api *APIv4) GetConstraints(args params.GetApplicationConstraints) (params.
 	}
 	cons, err := app.Constraints()
 	return params.GetConstraintsResults{cons}, errors.Trace(err)
+}
+
+// GetCharmConfig is a shim to GetConfig on APIv5. It returns just the charm config.
+func (api *APIv6) GetCharmConfig(args params.Entities) (params.ApplicationGetConfigResults, error) {
+	return api.GetConfig(args)
+}
+
+// SetApplicationsConfig implements the server side of Application.SetApplicationsConfig.
+// It does not unset values that are set to an empty string.
+// Unset should be used for that.
+func (api *APIv6) SetApplicationsConfig(args params.ApplicationConfigSetArgs) (params.ErrorResults, error) {
+	var result params.ErrorResults
+	if err := api.checkCanWrite(); err != nil {
+		return result, errors.Trace(err)
+	}
+	if err := api.check.ChangeAllowed(); err != nil {
+		return result, errors.Trace(err)
+	}
+	result.Results = make([]params.ErrorResult, len(args.Args))
+	for i, arg := range args.Args {
+		err := api.setApplicationConfig(arg)
+		result.Results[i].Error = common.ServerError(err)
+	}
+	return result, nil
+}
+
+func (api *APIv6) setApplicationConfig(arg params.ApplicationConfigSet) error {
+	app, err := api.backend.Application(arg.ApplicationName)
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	appConfigAttrs, charmConfig, err := splitApplicationAndCharmConfig(arg.Config)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	providerSchema, providerDefaults := providerConfigSchema()
+
+	if len(appConfigAttrs) > 0 {
+		if err := app.UpdateApplicationConfig(appConfigAttrs, providerSchema, providerDefaults); err != nil {
+			return errors.Annotate(err, "updating application config values")
+		}
+	}
+	if len(charmConfig) > 0 {
+		ch, _, err := app.Charm()
+		if err != nil {
+			return err
+		}
+		// Validate the charm and application config.
+		charmConfigChanges, err := ch.Config().ParseSettingsStrings(charmConfig)
+		if err != nil {
+			return err
+		}
+		if err := app.UpdateCharmConfig(charmConfigChanges); err != nil {
+			return errors.Annotate(err, "updating application charm settings")
+		}
+	}
+	return nil
+}
+
+// UnsetApplicationsConfig implements the server side of Application.UnsetApplicationsConfig.
+func (api *APIv6) UnsetApplicationsConfig(args params.ApplicationConfigUnsetArgs) (params.ErrorResults, error) {
+	var result params.ErrorResults
+	if err := api.checkCanWrite(); err != nil {
+		return result, errors.Trace(err)
+	}
+	if err := api.check.ChangeAllowed(); err != nil {
+		return result, errors.Trace(err)
+	}
+	result.Results = make([]params.ErrorResult, len(args.Args))
+	for i, arg := range args.Args {
+		err := api.unsetApplicationConfig(arg)
+		result.Results[i].Error = common.ServerError(err)
+	}
+	return result, nil
+}
+
+func (api *APIv6) unsetApplicationConfig(arg params.ApplicationUnset) error {
+	app, err := api.backend.Application(arg.ApplicationName)
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	providerSchema, providerDefaults := providerConfigSchema()
+	appSchema, err := application.ConfigSchema(providerSchema)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	appConfigFields := appSchema.KnownConfigKeys()
+
+	appConfigAttrs := make(map[string]interface{})
+	charmSettings := make(charm.Settings)
+	for _, name := range arg.Options {
+		if appConfigFields.Contains(name) {
+			appConfigAttrs[name] = nil
+		} else {
+			charmSettings[name] = nil
+		}
+	}
+
+	if len(appConfigAttrs) > 0 {
+		if err := app.UpdateApplicationConfig(appConfigAttrs, providerSchema, providerDefaults); err != nil {
+			return errors.Annotate(err, "updating application config values")
+		}
+	}
+	if len(charmSettings) > 0 {
+		if err := app.UpdateCharmConfig(charmSettings); err != nil {
+			return errors.Annotate(err, "updating application charm settings")
+		}
+	}
+	return nil
 }

--- a/apiserver/facades/client/application/application_test.go
+++ b/apiserver/facades/client/application/application_test.go
@@ -47,7 +47,7 @@ type applicationSuite struct {
 	apiservertesting.CharmStoreSuite
 	commontesting.BlockHelper
 
-	applicationAPI *application.API
+	applicationAPI *application.APIv6
 	application    *state.Application
 	authorizer     *apiservertesting.FakeAuthorizer
 }
@@ -84,13 +84,13 @@ func (s *applicationSuite) TearDownTest(c *gc.C) {
 	s.JujuConnSuite.TearDownTest(c)
 }
 
-func (s *applicationSuite) makeAPI(c *gc.C) *application.API {
+func (s *applicationSuite) makeAPI(c *gc.C) *application.APIv6 {
 	resources := common.NewResources()
 	resources.RegisterNamed("dataDir", common.StringResource(c.MkDir()))
 	backend, err := application.NewStateBackend(s.State)
 	c.Assert(err, jc.ErrorIsNil)
 	blockChecker := common.NewBlockChecker(s.State)
-	api, err := application.NewAPI(
+	api, err := application.NewAPIV5(
 		backend,
 		s.authorizer,
 		blockChecker,
@@ -98,7 +98,7 @@ func (s *applicationSuite) makeAPI(c *gc.C) *application.API {
 		application.DeployApplication,
 	)
 	c.Assert(err, jc.ErrorIsNil)
-	return api
+	return &application.APIv6{api}
 }
 
 func (s *applicationSuite) TestGetConfig(c *gc.C) {

--- a/apiserver/facades/client/application/application_unit_test.go
+++ b/apiserver/facades/client/application/application_unit_test.go
@@ -1077,7 +1077,7 @@ func (s *ApplicationSuite) TestSetApplicationConfig(c *gc.C) {
 	app.CheckCallNames(c, "UpdateApplicationConfig", "UpdateCharmConfig")
 	app.CheckCall(c, 0, "UpdateApplicationConfig", coreapplication.ConfigAttributes{
 		"juju-external-hostname": "value",
-	}, k8s.ConfigSchema(), k8s.ConfigDefaults())
+	}, []string(nil), k8s.ConfigSchema(), k8s.ConfigDefaults())
 	app.CheckCall(c, 1, "UpdateCharmConfig", charm.Settings{"stringOption": "stringVal"})
 }
 
@@ -1124,9 +1124,8 @@ func (s *ApplicationSuite) TestUnsetApplicationConfig(c *gc.C) {
 	s.backend.CheckCallNames(c, "Application")
 	app := s.backend.applications["postgresql"]
 	app.CheckCallNames(c, "UpdateApplicationConfig", "UpdateCharmConfig")
-	app.CheckCall(c, 0, "UpdateApplicationConfig", coreapplication.ConfigAttributes{
-		"juju-external-hostname": nil,
-	}, k8s.ConfigSchema(), k8s.ConfigDefaults())
+	app.CheckCall(c, 0, "UpdateApplicationConfig", coreapplication.ConfigAttributes(nil),
+		[]string{"juju-external-hostname"}, k8s.ConfigSchema(), k8s.ConfigDefaults())
 	app.CheckCall(c, 1, "UpdateCharmConfig", charm.Settings{"stringVal": nil})
 }
 

--- a/apiserver/facades/client/application/application_unit_test.go
+++ b/apiserver/facades/client/application/application_unit_test.go
@@ -16,6 +16,8 @@ import (
 	"github.com/juju/juju/apiserver/facades/client/application"
 	"github.com/juju/juju/apiserver/params"
 	apiservertesting "github.com/juju/juju/apiserver/testing"
+	k8s "github.com/juju/juju/caas/kubernetes/provider"
+	coreapplication "github.com/juju/juju/core/application"
 	"github.com/juju/juju/core/crossmodel"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/instance"
@@ -28,21 +30,22 @@ import (
 type ApplicationSuite struct {
 	testing.IsolationSuite
 	coretesting.JujuOSEnvSuite
-	backend   mockBackend
-	endpoints []state.Endpoint
-	relation  mockRelation
+	backend     mockBackend
+	endpoints   []state.Endpoint
+	relation    mockRelation
+	application mockApplication
 
 	env          environs.Environ
 	blockChecker mockBlockChecker
 	authorizer   apiservertesting.FakeAuthorizer
-	api          *application.API
+	api          *application.APIv6
 }
 
 var _ = gc.Suite(&ApplicationSuite{})
 
 func (s *ApplicationSuite) setAPIUser(c *gc.C, user names.UserTag) {
 	s.authorizer.Tag = user
-	api, err := application.NewAPI(
+	api, err := application.NewAPIV5(
 		&s.backend,
 		s.authorizer,
 		&s.blockChecker,
@@ -54,7 +57,7 @@ func (s *ApplicationSuite) setAPIUser(c *gc.C, user names.UserTag) {
 		},
 	)
 	c.Assert(err, jc.ErrorIsNil)
-	s.api = api
+	s.api = &application.APIv6{api}
 }
 
 func (s *ApplicationSuite) SetUpTest(c *gc.C) {
@@ -157,7 +160,7 @@ func (s *ApplicationSuite) SetUpTest(c *gc.C) {
 		},
 	}
 	s.blockChecker = mockBlockChecker{}
-	api, err := application.NewAPI(
+	api, err := application.NewAPIV5(
 		&s.backend,
 		s.authorizer,
 		&s.blockChecker,
@@ -169,7 +172,7 @@ func (s *ApplicationSuite) SetUpTest(c *gc.C) {
 		},
 	)
 	c.Assert(err, jc.ErrorIsNil)
-	s.api = api
+	s.api = &application.APIv6{api}
 }
 
 func (s *ApplicationSuite) TearDownTest(c *gc.C) {
@@ -663,7 +666,7 @@ func (s *ApplicationSuite) TestBlockSetRelationSuspended(c *gc.C) {
 
 func (s *ApplicationSuite) TestSetRelationSuspendedPermissionDenied(c *gc.C) {
 	s.authorizer.Tag = names.NewUserTag("fred")
-	api, err := application.NewAPI(
+	apiv5, err := application.NewAPIV5(
 		&s.backend,
 		s.authorizer,
 		&s.blockChecker,
@@ -675,6 +678,7 @@ func (s *ApplicationSuite) TestSetRelationSuspendedPermissionDenied(c *gc.C) {
 		},
 	)
 	c.Assert(err, jc.ErrorIsNil)
+	api := &application.APIv6{apiv5}
 	_, err = api.SetRelationsSuspended(params.RelationSuspendedArgs{
 		Args: []params.RelationSuspendedArg{{
 			RelationId: 123,
@@ -1056,4 +1060,104 @@ func (s *ApplicationSuite) TestRemoteRelationDisAllowedCIDR(c *gc.C) {
 	endpoints := []string{"wordpress", "hosted-mysql:nope"}
 	_, err := s.api.AddRelation(params.AddRelation{Endpoints: endpoints, ViaCIDRs: []string{"0.0.0.0/0"}})
 	c.Assert(err, gc.ErrorMatches, `CIDR "0.0.0.0/0" not allowed`)
+}
+
+func (s *ApplicationSuite) TestSetApplicationConfig(c *gc.C) {
+	result, err := s.api.SetApplicationsConfig(params.ApplicationConfigSetArgs{
+		Args: []params.ApplicationConfigSet{{
+			ApplicationName: "postgresql",
+			Config: map[string]string{
+				"juju-external-hostname": "value",
+				"stringOption":           "stringVal"},
+		}}})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result.OneError(), jc.ErrorIsNil)
+	s.backend.CheckCallNames(c, "Application")
+	app := s.backend.applications["postgresql"]
+	app.CheckCallNames(c, "UpdateApplicationConfig", "UpdateCharmConfig")
+	app.CheckCall(c, 0, "UpdateApplicationConfig", coreapplication.ConfigAttributes{
+		"juju-external-hostname": "value",
+	}, k8s.ConfigSchema(), k8s.ConfigDefaults())
+	app.CheckCall(c, 1, "UpdateCharmConfig", charm.Settings{"stringOption": "stringVal"})
+}
+
+func (s *ApplicationSuite) TestBlockSetApplicationConfig(c *gc.C) {
+	s.blockChecker.SetErrors(errors.New("blocked"))
+	_, err := s.api.SetApplicationsConfig(params.ApplicationConfigSetArgs{})
+	c.Assert(err, gc.ErrorMatches, "blocked")
+	s.blockChecker.CheckCallNames(c, "ChangeAllowed")
+	s.relation.CheckNoCalls(c)
+}
+
+func (s *ApplicationSuite) TestSetApplicationConfigPermissionDenied(c *gc.C) {
+	s.authorizer.Tag = names.NewUserTag("fred")
+	apiv5, err := application.NewAPIV5(
+		&s.backend,
+		s.authorizer,
+		&s.blockChecker,
+		func(application.Charm) *state.Charm {
+			return &state.Charm{}
+		},
+		func(application.ApplicationDeployer, application.DeployApplicationParams) (application.Application, error) {
+			return nil, nil
+		},
+	)
+	c.Assert(err, jc.ErrorIsNil)
+	api := &application.APIv6{apiv5}
+	_, err = api.SetApplicationsConfig(params.ApplicationConfigSetArgs{
+		Args: []params.ApplicationConfigSet{{
+			ApplicationName: "postgresql",
+		}}})
+	c.Assert(err, gc.ErrorMatches, "permission denied")
+	s.application.CheckNoCalls(c)
+}
+
+func (s *ApplicationSuite) TestUnsetApplicationConfig(c *gc.C) {
+	result, err := s.api.UnsetApplicationsConfig(params.ApplicationConfigUnsetArgs{
+		Args: []params.ApplicationUnset{{
+			ApplicationName: "postgresql",
+			Options:         []string{"juju-external-hostname", "stringVal"},
+		}}})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result.OneError(), jc.ErrorIsNil)
+	c.Assert(err, jc.ErrorIsNil)
+	s.backend.CheckCallNames(c, "Application")
+	app := s.backend.applications["postgresql"]
+	app.CheckCallNames(c, "UpdateApplicationConfig", "UpdateCharmConfig")
+	app.CheckCall(c, 0, "UpdateApplicationConfig", coreapplication.ConfigAttributes{
+		"juju-external-hostname": nil,
+	}, k8s.ConfigSchema(), k8s.ConfigDefaults())
+	app.CheckCall(c, 1, "UpdateCharmConfig", charm.Settings{"stringVal": nil})
+}
+
+func (s *ApplicationSuite) TestBlockUnsetApplicationConfig(c *gc.C) {
+	s.blockChecker.SetErrors(errors.New("blocked"))
+	_, err := s.api.UnsetApplicationsConfig(params.ApplicationConfigUnsetArgs{})
+	c.Assert(err, gc.ErrorMatches, "blocked")
+	s.blockChecker.CheckCallNames(c, "ChangeAllowed")
+	s.relation.CheckNoCalls(c)
+}
+
+func (s *ApplicationSuite) TestUnsetApplicationConfigPermissionDenied(c *gc.C) {
+	s.authorizer.Tag = names.NewUserTag("fred")
+	apiv5, err := application.NewAPIV5(
+		&s.backend,
+		s.authorizer,
+		&s.blockChecker,
+		func(application.Charm) *state.Charm {
+			return &state.Charm{}
+		},
+		func(application.ApplicationDeployer, application.DeployApplicationParams) (application.Application, error) {
+			return nil, nil
+		},
+	)
+	c.Assert(err, jc.ErrorIsNil)
+	api := &application.APIv6{apiv5}
+	_, err = api.UnsetApplicationsConfig(params.ApplicationConfigUnsetArgs{
+		Args: []params.ApplicationUnset{{
+			ApplicationName: "postgresql",
+			Options:         []string{"option"},
+		}}})
+	c.Assert(err, gc.ErrorMatches, "permission denied")
+	s.application.CheckNoCalls(c)
 }

--- a/apiserver/facades/client/application/backend.go
+++ b/apiserver/facades/client/application/backend.go
@@ -83,7 +83,7 @@ type Application interface {
 	UpdateApplicationSeries(string, bool) error
 	UpdateCharmConfig(charm.Settings) error
 	ApplicationConfig() (application.ConfigAttributes, error)
-	UpdateApplicationConfig(application.ConfigAttributes, environschema.Fields, schema.Defaults) error
+	UpdateApplicationConfig(application.ConfigAttributes, []string, environschema.Fields, schema.Defaults) error
 }
 
 // Charm defines a subset of the functionality provided by the

--- a/apiserver/facades/client/application/backend.go
+++ b/apiserver/facades/client/application/backend.go
@@ -5,12 +5,15 @@ package application
 
 import (
 	"github.com/juju/errors"
+	"github.com/juju/schema"
 	"gopkg.in/juju/charm.v6"
 	csparams "gopkg.in/juju/charmrepo.v2/csclient/params"
+	"gopkg.in/juju/environschema.v1"
 	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/apiserver/common/storagecommon"
 	"github.com/juju/juju/constraints"
+	"github.com/juju/juju/core/application"
 	"github.com/juju/juju/core/crossmodel"
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/network"
@@ -79,6 +82,8 @@ type Application interface {
 	SetMinUnits(int) error
 	UpdateApplicationSeries(string, bool) error
 	UpdateCharmConfig(charm.Settings) error
+	ApplicationConfig() (application.ConfigAttributes, error)
+	UpdateApplicationConfig(application.ConfigAttributes, environschema.Fields, schema.Defaults) error
 }
 
 // Charm defines a subset of the functionality provided by the

--- a/apiserver/facades/client/application/deploy.go
+++ b/apiserver/facades/client/application/deploy.go
@@ -15,6 +15,7 @@ import (
 	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/constraints"
+	"github.com/juju/juju/core/application"
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/storage"
@@ -23,13 +24,14 @@ import (
 // DeployApplicationParams contains the arguments required to deploy the referenced
 // charm.
 type DeployApplicationParams struct {
-	ApplicationName string
-	Series          string
-	Charm           *state.Charm
-	Channel         csparams.Channel
-	CharmConfig     charm.Settings
-	Constraints     constraints.Value
-	NumUnits        int
+	ApplicationName   string
+	Series            string
+	Charm             *state.Charm
+	Channel           csparams.Channel
+	ApplicationConfig *application.Config
+	CharmConfig       charm.Settings
+	Constraints       constraints.Value
+	NumUnits          int
 	// Placement is a list of placement directives which may be used
 	// instead of a machine spec.
 	Placement        []*instance.Placement
@@ -71,17 +73,18 @@ func DeployApplication(st ApplicationDeployer, args DeployApplicationParams) (Ap
 	}
 
 	asa := state.AddApplicationArgs{
-		Name:             args.ApplicationName,
-		Series:           args.Series,
-		Charm:            args.Charm,
-		Channel:          args.Channel,
-		Storage:          stateStorageConstraints(args.Storage),
-		AttachStorage:    args.AttachStorage,
-		CharmConfig:      charmConfig,
-		NumUnits:         args.NumUnits,
-		Placement:        args.Placement,
-		Resources:        args.Resources,
-		EndpointBindings: effectiveBindings,
+		Name:              args.ApplicationName,
+		Series:            args.Series,
+		Charm:             args.Charm,
+		Channel:           args.Channel,
+		Storage:           stateStorageConstraints(args.Storage),
+		AttachStorage:     args.AttachStorage,
+		ApplicationConfig: args.ApplicationConfig,
+		CharmConfig:       charmConfig,
+		NumUnits:          args.NumUnits,
+		Placement:         args.Placement,
+		Resources:         args.Resources,
+		EndpointBindings:  effectiveBindings,
 	}
 
 	if !args.Charm.Meta().Subordinate {

--- a/apiserver/facades/client/application/get_test.go
+++ b/apiserver/facades/client/application/get_test.go
@@ -98,7 +98,7 @@ func (s *getSuite) TestClientApplicationGetSmoketest(c *gc.C) {
 	defaults := coreapplication.ConfigDefaults(k8s.ConfigDefaults())
 	appConfig, err := coreapplication.NewConfig(map[string]interface{}{"juju-external-hostname": "ext"}, extra, defaults)
 	c.Assert(err, jc.ErrorIsNil)
-	err = app.UpdateApplicationConfig(appConfig.Attributes(), extra, nil)
+	err = app.UpdateApplicationConfig(appConfig.Attributes(), nil, extra, nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	schemaFields, err := coreapplication.ConfigSchema(extra)

--- a/apiserver/facades/client/application/get_test.go
+++ b/apiserver/facades/client/application/get_test.go
@@ -15,14 +15,16 @@ import (
 	"github.com/juju/juju/apiserver/facades/client/application"
 	"github.com/juju/juju/apiserver/params"
 	apiservertesting "github.com/juju/juju/apiserver/testing"
+	k8s "github.com/juju/juju/caas/kubernetes/provider"
 	"github.com/juju/juju/constraints"
+	coreapplication "github.com/juju/juju/core/application"
 	jujutesting "github.com/juju/juju/juju/testing"
 )
 
 type getSuite struct {
 	jujutesting.JujuConnSuite
 
-	applicationAPI *application.API
+	applicationAPI *application.APIv6
 	authorizer     apiservertesting.FakeAuthorizer
 }
 
@@ -37,7 +39,7 @@ func (s *getSuite) SetUpTest(c *gc.C) {
 	backend, err := application.NewStateBackend(s.State)
 	c.Assert(err, jc.ErrorIsNil)
 	blockChecker := common.NewBlockChecker(s.State)
-	s.applicationAPI, err = application.NewAPI(
+	api, err := application.NewAPIV5(
 		backend,
 		s.authorizer,
 		blockChecker,
@@ -45,17 +47,18 @@ func (s *getSuite) SetUpTest(c *gc.C) {
 		application.DeployApplication,
 	)
 	c.Assert(err, jc.ErrorIsNil)
+	s.applicationAPI = &application.APIv6{api}
 }
 
 func (s *getSuite) TestClientApplicationGetSmoketestV4(c *gc.C) {
 	s.AddTestingApplication(c, "wordpress", s.AddTestingCharm(c, "wordpress"))
-	v4 := &application.APIv4{s.applicationAPI}
+	v4 := &application.APIv4{s.applicationAPI.APIv5}
 	results, err := v4.Get(params.ApplicationGet{"wordpress"})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, gc.DeepEquals, params.ApplicationGetResults{
 		Application: "wordpress",
 		Charm:       "wordpress",
-		Config: map[string]interface{}{
+		CharmConfig: map[string]interface{}{
 			"blog-title": map[string]interface{}{
 				"default":     true,
 				"description": "A descriptive title used for the blog.",
@@ -67,14 +70,15 @@ func (s *getSuite) TestClientApplicationGetSmoketestV4(c *gc.C) {
 	})
 }
 
-func (s *getSuite) TestClientApplicationGetSmoketest(c *gc.C) {
+func (s *getSuite) TestClientApplicationGetSmoketestV5(c *gc.C) {
 	s.AddTestingApplication(c, "wordpress", s.AddTestingCharm(c, "wordpress"))
-	results, err := s.applicationAPI.Get(params.ApplicationGet{"wordpress"})
+	v5 := s.applicationAPI.APIv5
+	results, err := v5.Get(params.ApplicationGet{"wordpress"})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, gc.DeepEquals, params.ApplicationGetResults{
 		Application: "wordpress",
 		Charm:       "wordpress",
-		Config: map[string]interface{}{
+		CharmConfig: map[string]interface{}{
 			"blog-title": map[string]interface{}{
 				"default":     "My Title",
 				"description": "A descriptive title used for the blog.",
@@ -84,6 +88,68 @@ func (s *getSuite) TestClientApplicationGetSmoketest(c *gc.C) {
 			},
 		},
 		Series: "quantal",
+	})
+}
+
+func (s *getSuite) TestClientApplicationGetSmoketest(c *gc.C) {
+	app := s.AddTestingApplication(c, "wordpress", s.AddTestingCharm(c, "wordpress"))
+
+	extra := k8s.ConfigSchema()
+	defaults := coreapplication.ConfigDefaults(k8s.ConfigDefaults())
+	appConfig, err := coreapplication.NewConfig(map[string]interface{}{"juju-external-hostname": "ext"}, extra, defaults)
+	c.Assert(err, jc.ErrorIsNil)
+	err = app.UpdateApplicationConfig(appConfig.Attributes(), extra, nil)
+	c.Assert(err, jc.ErrorIsNil)
+
+	schemaFields, err := coreapplication.ConfigSchema(extra)
+	c.Assert(err, jc.ErrorIsNil)
+	expectedAppConfig := make(map[string]interface{})
+	for name, field := range schemaFields {
+		info := map[string]interface{}{
+			"description": field.Description,
+			"source":      "unset",
+			"type":        field.Type,
+		}
+		expectedAppConfig[name] = info
+	}
+
+	for name, val := range appConfig.Attributes() {
+		field := schemaFields[name]
+		info := map[string]interface{}{
+			"description": field.Description,
+			"source":      "unset",
+			"type":        field.Type,
+		}
+		if val != nil {
+			info["source"] = "user"
+			info["value"] = val
+		}
+		if defaultVal := defaults[name]; defaultVal != nil {
+			info["default"] = defaultVal
+			info["source"] = "default"
+			if val != defaultVal {
+				info["source"] = "user"
+			}
+		}
+		expectedAppConfig[name] = info
+	}
+
+	results, err := s.applicationAPI.Get(params.ApplicationGet{"wordpress"})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(results, jc.DeepEquals, params.ApplicationGetResults{
+		Application: "wordpress",
+		Charm:       "wordpress",
+		CharmConfig: map[string]interface{}{
+			"blog-title": map[string]interface{}{
+				"default":     "My Title",
+				"description": "A descriptive title used for the blog.",
+				"source":      "default",
+				"type":        "string",
+				"value":       "My Title",
+			},
+		},
+		ApplicationConfig: expectedAppConfig,
+		Series:            "quantal",
 	})
 }
 
@@ -112,7 +178,7 @@ var getTests = []struct {
 		// Outlook is left unset.
 	},
 	expect: params.ApplicationGetResults{
-		Config: map[string]interface{}{
+		CharmConfig: map[string]interface{}{
 			"title": map[string]interface{}{
 				"default":     "My Title",
 				"description": "A descriptive title used for the application.",
@@ -154,7 +220,7 @@ var getTests = []struct {
 		"outlook": "phlegmatic",
 	},
 	expect: params.ApplicationGetResults{
-		Config: map[string]interface{}{
+		CharmConfig: map[string]interface{}{
 			"title": map[string]interface{}{
 				"default":     "My Title",
 				"description": "A descriptive title used for the application.",
@@ -193,8 +259,8 @@ var getTests = []struct {
 	about: "subordinate application",
 	charm: "logging",
 	expect: params.ApplicationGetResults{
-		Config: map[string]interface{}{},
-		Series: "quantal",
+		CharmConfig: map[string]interface{}{},
+		Series:      "quantal",
 	},
 }}
 
@@ -244,7 +310,7 @@ func (s *getSuite) TestGetMaxResolutionInt(c *gc.C) {
 	client := apiapplication.NewClient(s.APIState)
 	got, err := client.Get(app.Name())
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(got.Config["skill-level"], jc.DeepEquals, map[string]interface{}{
+	c.Assert(got.CharmConfig["skill-level"], jc.DeepEquals, map[string]interface{}{
 		"description": "A number indicating skill.",
 		"source":      "user",
 		"type":        "int",

--- a/apiserver/facades/client/application/mock_test.go
+++ b/apiserver/facades/client/application/mock_test.go
@@ -170,11 +170,12 @@ func (a *mockApplication) ApplicationConfig() (coreapplication.ConfigAttributes,
 }
 
 func (a *mockApplication) UpdateApplicationConfig(
-	config coreapplication.ConfigAttributes,
+	changes coreapplication.ConfigAttributes,
+	reset []string,
 	extra environschema.Fields,
 	defaults schema.Defaults,
 ) error {
-	a.MethodCall(a, "UpdateApplicationConfig", config, extra, defaults)
+	a.MethodCall(a, "UpdateApplicationConfig", changes, reset, extra, defaults)
 	return a.NextErr()
 }
 

--- a/apiserver/facades/client/application/mock_test.go
+++ b/apiserver/facades/client/application/mock_test.go
@@ -9,13 +9,16 @@ import (
 	"sync"
 
 	"github.com/juju/errors"
+	"github.com/juju/schema"
 	jtesting "github.com/juju/testing"
 	"github.com/juju/utils/set"
 	"gopkg.in/juju/charm.v6"
+	"gopkg.in/juju/environschema.v1"
 	"gopkg.in/juju/names.v2"
 	"gopkg.in/macaroon.v1"
 
 	"github.com/juju/juju/apiserver/facades/client/application"
+	coreapplication "github.com/juju/juju/core/application"
 	"github.com/juju/juju/core/crossmodel"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/instance"
@@ -91,6 +94,7 @@ type mockApplication struct {
 	series      string
 	units       []mockUnit
 	addedUnit   mockUnit
+	config      coreapplication.ConfigAttributes
 }
 
 func (m *mockApplication) Name() string {
@@ -158,6 +162,25 @@ func (a *mockApplication) Series() string {
 	a.MethodCall(a, "Series")
 	a.PopNoErr()
 	return a.series
+}
+
+func (a *mockApplication) ApplicationConfig() (coreapplication.ConfigAttributes, error) {
+	a.MethodCall(a, "ApplicationConfig")
+	return a.config, a.NextErr()
+}
+
+func (a *mockApplication) UpdateApplicationConfig(
+	config coreapplication.ConfigAttributes,
+	extra environschema.Fields,
+	defaults schema.Defaults,
+) error {
+	a.MethodCall(a, "UpdateApplicationConfig", config, extra, defaults)
+	return a.NextErr()
+}
+
+func (a *mockApplication) UpdateCharmConfig(settings charm.Settings) error {
+	a.MethodCall(a, "UpdateCharmConfig", settings)
+	return a.NextErr()
 }
 
 type mockRemoteApplication struct {

--- a/apiserver/params/params.go
+++ b/apiserver/params/params.go
@@ -363,11 +363,31 @@ type ApplicationGet struct {
 
 // ApplicationGetResults holds results of the application Get call.
 type ApplicationGetResults struct {
-	Application string                 `json:"application"`
-	Charm       string                 `json:"charm"`
-	Config      map[string]interface{} `json:"config"`
-	Constraints constraints.Value      `json:"constraints"`
-	Series      string                 `json:"series"`
+	Application       string                 `json:"application"`
+	Charm             string                 `json:"charm"`
+	CharmConfig       map[string]interface{} `json:"config"`
+	ApplicationConfig map[string]interface{} `json:"application-config,omitempty"`
+	Constraints       constraints.Value      `json:"constraints"`
+	Series            string                 `json:"series"`
+}
+
+// ApplicationConfigSetArgs holds the parameters for
+// setting application config values for specified applications.
+type ApplicationConfigSetArgs struct {
+	Args []ApplicationConfigSet
+}
+
+// ApplicationConfigSet holds the parameters for an application
+// config set command.
+type ApplicationConfigSet struct {
+	ApplicationName string            `json:"application"`
+	Config          map[string]string `json:"config"`
+}
+
+// ApplicationConfigUnsetArgs holds the parameters for
+// resetting application config values for specified applications.
+type ApplicationConfigUnsetArgs struct {
+	Args []ApplicationUnset
 }
 
 // ApplicationCharmRelations holds parameters for making the application CharmRelations call.

--- a/caas/kubernetes/provider/config.go
+++ b/caas/kubernetes/provider/config.go
@@ -1,0 +1,103 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package provider
+
+import (
+	"github.com/juju/schema"
+	"gopkg.in/juju/environschema.v1"
+	"k8s.io/client-go/pkg/api/v1"
+)
+
+const (
+	// TODO(caas) - use these defaults in the schema
+	defaultServiceType           = v1.ServiceTypeClusterIP
+	defaultIngressClass          = "nginx"
+	defaultIngressSSLRedirect    = true
+	defaultIngressSSLPassthrough = false
+	defaultIngressAllowHTTPKey   = false
+	defaultApplicationPath       = "/"
+
+	serviceTypeConfigKey               = "kubernetes-service-type"
+	serviceExternalIPsConfigKey        = "kubernetes-service-external-ips"
+	serviceTargetPortConfigKey         = "kubernetes-service-target-port"
+	serviceLoadBalancerIPKey           = "kubernetes-service-loadbalancer-ip"
+	serviceLoadBalancerSourceRangesKey = "kubernetes-service-loadbalancer-sourceranges"
+	serviceExternalNameKey             = "kubernetes-service-externalname"
+
+	ingressClassKey          = "kubernetes-ingress-class"
+	ingressSSLRedirectKey    = "kubernetes-ingress-ssl-redirect"
+	ingressSSLPassthroughKey = "ingress.kubernetes.io/ssl-passthrough"
+	ingressAllowHTTPKey      = "kubernetes.io/ingress.allow-http"
+)
+
+var configFields = environschema.Fields{
+	serviceTypeConfigKey: {
+		Description: "determines how the Service is exposed",
+		Type:        environschema.Tstring,
+		Group:       environschema.ProviderGroup,
+	},
+	serviceExternalIPsConfigKey: {
+		Description: "list of IP addresses for which nodes in the cluster will also accept traffic",
+		Type:        environschema.Tstring,
+		Group:       environschema.ProviderGroup,
+	},
+	serviceTargetPortConfigKey: {
+		Description: "name or number of the port to access on the pods targeted by the service",
+		Type:        environschema.Tstring,
+		Group:       environschema.ProviderGroup,
+	},
+	serviceLoadBalancerIPKey: {
+		Description: "LoadBalancer will get created with the IP specified in this field",
+		Type:        environschema.Tstring,
+		Group:       environschema.ProviderGroup,
+	},
+	serviceLoadBalancerSourceRangesKey: {
+		Description: "traffic through the load-balancer will be restricted to the specified client IPs",
+		Type:        environschema.Tstring,
+		Group:       environschema.ProviderGroup,
+	},
+	serviceExternalNameKey: {
+		Description: "external reference that kubedns or equivalent will return as a CNAME record",
+		Type:        environschema.Tstring,
+		Group:       environschema.ProviderGroup,
+	},
+	ingressClassKey: {
+		Description: "the class of the ingress controller to be used by the ingress resource",
+		Type:        environschema.Tstring,
+		Group:       environschema.ProviderGroup,
+	},
+	ingressSSLRedirectKey: {
+		Description: "whether to redirect SSL traffic to the ingress controller",
+		Type:        environschema.Tbool,
+		Group:       environschema.ProviderGroup,
+	},
+	ingressSSLPassthroughKey: {
+		Description: "whether to passthrough SSL traffic to the ingress controller",
+		Type:        environschema.Tbool,
+		Group:       environschema.ProviderGroup,
+	},
+	ingressAllowHTTPKey: {
+		Description: "whether to allow insecure HTTP traffic to the ingress controller",
+		Type:        environschema.Tbool,
+		Group:       environschema.ProviderGroup,
+	},
+}
+
+var schemaDefaults = schema.Defaults{
+	serviceTypeConfigKey:     defaultServiceType,
+	ingressClassKey:          defaultIngressClass,
+	ingressSSLRedirectKey:    defaultIngressSSLRedirect,
+	ingressSSLPassthroughKey: defaultIngressSSLPassthrough,
+	ingressAllowHTTPKey:      defaultIngressAllowHTTPKey,
+}
+
+// ConfigSchema returns the configuration schema for
+// a kubernetes provider config.
+func ConfigSchema() environschema.Fields {
+	return configFields
+}
+
+func ConfigDefaults() schema.Defaults {
+	return schemaDefaults
+}

--- a/caas/kubernetes/provider/k8s.go
+++ b/caas/kubernetes/provider/k8s.go
@@ -36,23 +36,6 @@ const (
 	labelApplication = "juju-application"
 )
 
-const (
-	defaultServiceType        = v1.ServiceTypeClusterIP
-	defaultIngressClass       = "nginx"
-	defaultIngressSSLRedirect = true
-	defaultApplicationPath    = "/"
-
-	serviceTypeConfigKey               = "kubernetes-service-type"
-	serviceExternalIPsConfigKey        = "kubernetes-service-external-ips"
-	serviceTargetPortConfigKey         = "kubernetes-service-target-port"
-	serviceLoadBalancerIPKey           = "kubernetes-service-loadbalancer-ip"
-	serviceLoadBalancerSourceRangesKey = "kubernetes-service-loadbalancer-sourceranges"
-	serviceExternalNameKey             = "kubernetes-service-externalname"
-
-	ingressClassKey       = "kubernetes-ingress-class"
-	ingressSSLRedirectKey = "kubernetes-ingress-ssl-redirect"
-)
-
 // TODO(caas) - add unit tests
 
 type kubernetesClient struct {
@@ -282,6 +265,8 @@ func (k *kubernetesClient) ExposeService(appName string, config caas.ResourceCon
 	}
 	ingressClass := config.GetString(ingressClassKey, defaultIngressClass)
 	ingressSSLRedirect := config.GetBool(ingressSSLRedirectKey, defaultIngressSSLRedirect)
+	ingressSSLPassthrough := config.GetBool(ingressSSLRedirectKey, defaultIngressSSLPassthrough)
+	ingressAllowHTTP := config.GetBool(ingressSSLRedirectKey, defaultIngressAllowHTTPKey)
 	httpPath := config.GetString(caas.JujuApplicationPath, defaultApplicationPath)
 	if httpPath == "$appname" {
 		httpPath = appName
@@ -302,9 +287,11 @@ func (k *kubernetesClient) ExposeService(appName string, config caas.ResourceCon
 			Name:   deploymentName(appName),
 			Labels: map[string]string{labelApplication: appName},
 			Annotations: map[string]string{
-				"ingress.kubernetes.io/rewrite-target": "",
-				"ingress.kubernetes.io/ssl-redirect":   strconv.FormatBool(ingressSSLRedirect),
-				"kubernetes.io/ingress.class":          ingressClass,
+				"ingress.kubernetes.io/rewrite-target":  "",
+				"ingress.kubernetes.io/ssl-redirect":    strconv.FormatBool(ingressSSLRedirect),
+				"kubernetes.io/ingress.class":           ingressClass,
+				"kubernetes.io/ingress.allow-http":      strconv.FormatBool(ingressAllowHTTP),
+				"ingress.kubernetes.io/ssl-passthrough": strconv.FormatBool(ingressSSLPassthrough),
 			},
 		},
 		Spec: v1beta1.IngressSpec{

--- a/cmd/juju/application/config.go
+++ b/cmd/juju/application/config.go
@@ -49,13 +49,13 @@ See also:
 )
 
 // NewConfigCommand returns a command used to get, reset, and set application
-// attributes.
+// charm attributes.
 func NewConfigCommand() cmd.Command {
 	return modelcmd.Wrap(&configCommand{})
 }
 
 // NewConfigCommandForTest returns a SetCommand with the api provided as specified.
-func NewConfigCommandForTest(api configCommandAPI) modelcmd.ModelCommand {
+func NewConfigCommandForTest(api applicationAPI) modelcmd.ModelCommand {
 	return modelcmd.Wrap(&configCommand{
 		api: api,
 	})
@@ -63,13 +63,13 @@ func NewConfigCommandForTest(api configCommandAPI) modelcmd.ModelCommand {
 
 type attributes map[string]string
 
-// configCommand get, sets, and resets configuration values of an application.
+// configCommand get, sets, and resets configuration values of an application' charm.
 type configCommand struct {
-	api configCommandAPI
+	api applicationAPI
 	modelcmd.ModelCommandBase
 	out cmd.Output
 
-	action          func(configCommandAPI, *cmd.Context) error // get, set, or reset action set in  Init
+	action          func(applicationAPI, *cmd.Context) error // get, set, or reset action set in  Init
 	applicationName string
 	configFile      cmd.FileVar
 	keys            []string
@@ -79,13 +79,19 @@ type configCommand struct {
 	values          attributes
 }
 
-// configCommandAPI is an interface to allow passing in a fake implementation under test.
-type configCommandAPI interface {
+// applicationAPI is an interface to allow passing in a fake implementation under test.
+type applicationAPI interface {
 	Close() error
 	Update(args params.ApplicationUpdate) error
 	Get(application string) (*params.ApplicationGetResults, error)
 	Set(application string, options map[string]string) error
 	Unset(application string, options []string) error
+	BestAPIVersion() int
+
+	// These methods are on API V6.
+
+	SetApplicationConfig(application string, config map[string]string) error
+	UnsetApplicationConfig(application string, options []string) error
 }
 
 // Info is part of the cmd.Command interface.
@@ -108,7 +114,7 @@ func (c *configCommand) SetFlags(f *gnuflag.FlagSet) {
 
 // getAPI either uses the fake API set at test time or that is nil, gets a real
 // API and sets that as the API.
-func (c *configCommand) getAPI() (configCommandAPI, error) {
+func (c *configCommand) getAPI() (applicationAPI, error) {
 	if c.api != nil {
 		return c.api, nil
 	}
@@ -263,13 +269,19 @@ func (c *configCommand) Run(ctx *cmd.Context) error {
 }
 
 // resetConfig is the run action when we are resetting attributes.
-func (c *configCommand) resetConfig(client configCommandAPI, ctx *cmd.Context) error {
-	return block.ProcessBlockedError(client.Unset(c.applicationName, c.resetKeys), block.BlockChange)
+func (c *configCommand) resetConfig(client applicationAPI, ctx *cmd.Context) error {
+	var err error
+	if client.BestAPIVersion() < 6 {
+		err = client.Unset(c.applicationName, c.resetKeys)
+	} else {
+		err = client.UnsetApplicationConfig(c.applicationName, c.resetKeys)
+	}
+	return block.ProcessBlockedError(err, block.BlockChange)
 }
 
 // setConfig is the run action when we are setting new attribute values as args
 // or as a file passed in.
-func (c *configCommand) setConfig(client configCommandAPI, ctx *cmd.Context) error {
+func (c *configCommand) setConfig(client applicationAPI, ctx *cmd.Context) error {
 	if c.useFile {
 		return c.setConfigFromFile(client, ctx)
 	}
@@ -285,7 +297,7 @@ func (c *configCommand) setConfig(client configCommandAPI, ctx *cmd.Context) err
 	}
 
 	for k, v := range settings {
-		configValue := result.Config[k]
+		configValue := result.CharmConfig[k]
 
 		configValueMap, ok := configValue.(map[string]interface{})
 		if ok {
@@ -296,12 +308,17 @@ func (c *configCommand) setConfig(client configCommandAPI, ctx *cmd.Context) err
 		}
 	}
 
-	return block.ProcessBlockedError(client.Set(c.applicationName, settings), block.BlockChange)
+	if client.BestAPIVersion() < 6 {
+		err = client.Set(c.applicationName, settings)
+	} else {
+		err = client.SetApplicationConfig(c.applicationName, settings)
+	}
+	return block.ProcessBlockedError(err, block.BlockChange)
 }
 
 // setConfigFromFile sets the application configuration from settings passed
 // in a YAML file.
-func (c *configCommand) setConfigFromFile(client configCommandAPI, ctx *cmd.Context) error {
+func (c *configCommand) setConfigFromFile(client applicationAPI, ctx *cmd.Context) error {
 	var (
 		b   []byte
 		err error
@@ -324,16 +341,19 @@ func (c *configCommand) setConfigFromFile(client configCommandAPI, ctx *cmd.Cont
 }
 
 // getConfig is the run action to return one or all configuration values.
-func (c *configCommand) getConfig(client configCommandAPI, ctx *cmd.Context) error {
+func (c *configCommand) getConfig(client applicationAPI, ctx *cmd.Context) error {
 	results, err := client.Get(c.applicationName)
 	if err != nil {
 		return err
 	}
 	if len(c.keys) == 1 {
 		key := c.keys[0]
-		info, found := results.Config[key].(map[string]interface{})
+		info, found := results.CharmConfig[key].(map[string]interface{})
+		if !found && len(results.ApplicationConfig) > 0 {
+			info, found = results.ApplicationConfig[key].(map[string]interface{})
+		}
 		if !found {
-			return errors.Errorf("key %q not found in %q application settings.", key, c.applicationName)
+			return errors.Errorf("key %q not found in %q application config or charm settings.", key, c.applicationName)
 		}
 		out := &bytes.Buffer{}
 		err := cmd.FormatYaml(out, info["value"])
@@ -347,7 +367,8 @@ func (c *configCommand) getConfig(client configCommandAPI, ctx *cmd.Context) err
 	resultsMap := map[string]interface{}{
 		"application": results.Application,
 		"charm":       results.Charm,
-		"settings":    results.Config,
+		"settings":    results.CharmConfig,
+		"config":      results.ApplicationConfig,
 	}
 	return c.out.Write(ctx, resultsMap)
 }

--- a/cmd/juju/application/config_test.go
+++ b/cmd/juju/application/config_test.go
@@ -24,8 +24,10 @@ import (
 
 type configCommandSuite struct {
 	coretesting.FakeJujuXDGDataHomeSuite
-	dir  string
-	fake *fakeApplicationAPI
+	dir                string
+	fake               *fakeApplicationAPI
+	defaultCharmValues map[string]interface{}
+	defaultAppValues   map[string]interface{}
 }
 
 var (
@@ -45,6 +47,13 @@ var getTests = []struct {
 		map[string]interface{}{
 			"application": "dummy-application",
 			"charm":       "dummy",
+			"config": map[string]interface{}{
+				"juju-external-hostname": map[string]interface{}{
+					"description": "Specifies juju-external-hostname",
+					"type":        "string",
+					"value":       "ext-host",
+				},
+			},
 			"settings": map[string]interface{}{
 				"title": map[string]interface{}{
 					"description": "Specifies title",
@@ -73,13 +82,20 @@ var getTests = []struct {
 
 func (s *configCommandSuite) SetUpTest(c *gc.C) {
 	s.FakeJujuXDGDataHomeSuite.SetUpTest(c)
+	s.defaultCharmValues = map[string]interface{}{
+		"title":       "Nearly There",
+		"skill-level": 100,
+		"username":    "admin001",
+		"outlook":     "true",
+	}
+	s.defaultAppValues = map[string]interface{}{
+		"juju-external-hostname": "ext-host",
+	}
+
 	s.fake = &fakeApplicationAPI{name: "dummy-application", charmName: "dummy",
-		values: map[string]interface{}{
-			"title":       "Nearly There",
-			"skill-level": 100,
-			"username":    "admin001",
-			"outlook":     "true",
-		}}
+		charmValues: s.defaultCharmValues,
+		appValues:   s.defaultAppValues,
+		version:     6}
 	s.FakeJujuXDGDataHomeSuite.SetUpTest(c)
 
 	s.dir = c.MkDir()
@@ -131,7 +147,7 @@ func (s *configCommandSuite) TestGetConfig(c *gc.C) {
 	}
 }
 
-func (s *configCommandSuite) TestGetConfigKey(c *gc.C) {
+func (s *configCommandSuite) TestGetCharmConfigKey(c *gc.C) {
 	ctx := cmdtesting.Context(c)
 	code := cmd.Main(application.NewConfigCommandForTest(s.fake), ctx, []string{"dummy-application", "title"})
 	c.Check(code, gc.Equals, 0)
@@ -139,9 +155,17 @@ func (s *configCommandSuite) TestGetConfigKey(c *gc.C) {
 	c.Assert(ctx.Stdout.(*bytes.Buffer).String(), gc.Equals, "Nearly There\n")
 }
 
+func (s *configCommandSuite) TestGetAppConfigKey(c *gc.C) {
+	ctx := cmdtesting.Context(c)
+	code := cmd.Main(application.NewConfigCommandForTest(s.fake), ctx, []string{"dummy-application", "juju-external-hostname"})
+	c.Check(code, gc.Equals, 0)
+	c.Assert(ctx.Stderr.(*bytes.Buffer).String(), gc.Equals, "")
+	c.Assert(ctx.Stdout.(*bytes.Buffer).String(), gc.Equals, "ext-host\n")
+}
+
 func (s *configCommandSuite) TestGetConfigKeyNotFound(c *gc.C) {
 	_, err := cmdtesting.RunCommand(c, application.NewConfigCommandForTest(s.fake), "dummy-application", "invalid")
-	c.Assert(err, gc.ErrorMatches, `key "invalid" not found in "dummy-application" application settings.`, gc.Commentf("details: %v", errors.Details(err)))
+	c.Assert(err, gc.ErrorMatches, `key "invalid" not found in "dummy-application" application config or charm settings.`, gc.Commentf("details: %v", errors.Details(err)))
 }
 
 var setCommandInitErrorTests = []struct {
@@ -196,39 +220,52 @@ func (s *configCommandSuite) TestSetCommandInitError(c *gc.C) {
 	}
 }
 
-func (s *configCommandSuite) TestSetOptionSuccess(c *gc.C) {
+func (s *configCommandSuite) TestSetCharmConfigSuccess(c *gc.C) {
 	s.assertSetSuccess(c, s.dir, []string{
 		"username=hello",
 		"outlook=hello@world.tld",
-	}, map[string]interface{}{
+	}, s.defaultAppValues, map[string]interface{}{
 		"username": "hello",
 		"outlook":  "hello@world.tld",
 	})
 	s.assertSetSuccess(c, s.dir, []string{
 		"username=hello=foo",
-	}, map[string]interface{}{
+	}, s.defaultAppValues, map[string]interface{}{
 		"username": "hello=foo",
 		"outlook":  "hello@world.tld",
 	})
 	s.assertSetSuccess(c, s.dir, []string{
 		"username=@valid.txt",
-	}, map[string]interface{}{
+	}, s.defaultAppValues, map[string]interface{}{
 		"username": validSetTestValue,
 		"outlook":  "hello@world.tld",
 	})
 	s.assertSetSuccess(c, s.dir, []string{
 		"username=",
-	}, map[string]interface{}{
+	}, s.defaultAppValues, map[string]interface{}{
 		"username": "",
 		"outlook":  "hello@world.tld",
 	})
+}
+
+func (s *configCommandSuite) TestSetAppConfigSuccess(c *gc.C) {
+	s.assertSetSuccess(c, s.dir, []string{
+		"juju-external-hostname=hello",
+	}, map[string]interface{}{
+		"juju-external-hostname": "hello",
+	}, s.defaultCharmValues)
+	s.assertSetSuccess(c, s.dir, []string{
+		"juju-external-hostname=",
+	}, map[string]interface{}{
+		"juju-external-hostname": "",
+	}, s.defaultCharmValues)
 }
 
 func (s *configCommandSuite) TestSetSameValue(c *gc.C) {
 	s.assertSetSuccess(c, s.dir, []string{
 		"username=hello",
 		"outlook=hello@world.tld",
-	}, map[string]interface{}{
+	}, s.defaultAppValues, map[string]interface{}{
 		"username": "hello",
 		"outlook":  "hello@world.tld",
 	})
@@ -241,7 +278,7 @@ func (s *configCommandSuite) TestSetSameValue(c *gc.C) {
 
 }
 
-func (s *configCommandSuite) TestSetOptionFail(c *gc.C) {
+func (s *configCommandSuite) TestSetConfigFail(c *gc.C) {
 	s.assertSetFail(c, s.dir, []string{"foo", "bar"},
 		"can only retrieve a single value, or all values")
 	s.assertSetFail(c, s.dir, []string{"=bar"}, "expected \"key=value\", got \"=bar\"")
@@ -256,7 +293,7 @@ func (s *configCommandSuite) TestSetOptionFail(c *gc.C) {
 	}, "value for option \"username\" contains non-UTF-8 sequences")
 }
 
-func (s *configCommandSuite) TestSetConfig(c *gc.C) {
+func (s *configCommandSuite) TestSetCharmConfigFromYAML(c *gc.C) {
 	s.assertSetFail(c, s.dir, []string{
 		"--file",
 		"missing.yaml",
@@ -285,14 +322,24 @@ func (s *configCommandSuite) TestSetFromStdin(c *gc.C) {
 	c.Check(s.fake.config, jc.DeepEquals, "settings:\n  username:\n  value: world\n")
 }
 
-func (s *configCommandSuite) TestResetConfigToDefault(c *gc.C) {
-	s.fake = &fakeApplicationAPI{name: "dummy-application", values: map[string]interface{}{
+func (s *configCommandSuite) TestResetCharmConfigToDefault(c *gc.C) {
+	s.fake = &fakeApplicationAPI{name: "dummy-application", charmValues: map[string]interface{}{
 		"username": "hello",
 	}}
-	s.assertSetSuccess(c, s.dir, []string{
+	s.assertResetSuccess(c, s.dir, []string{
 		"--reset",
 		"username",
-	}, make(map[string]interface{}))
+	}, nil, make(map[string]interface{}))
+}
+
+func (s *configCommandSuite) TestResetAppConfig(c *gc.C) {
+	s.fake = &fakeApplicationAPI{name: "dummy-application", appValues: map[string]interface{}{
+		"juju-external-hostname": "app-value",
+	}}
+	s.assertResetSuccess(c, s.dir, []string{
+		"--reset",
+		"juju-external-hostname",
+	}, make(map[string]interface{}), nil)
 }
 
 func (s *configCommandSuite) TestBlockSetConfig(c *gc.C) {
@@ -310,15 +357,47 @@ func (s *configCommandSuite) TestBlockSetConfig(c *gc.C) {
 }
 
 // assertSetSuccess sets configuration options and checks the expected settings.
-// TODO(rog) the expect parameter is ignored here - presumably
-// it's meant to be checked somehow.
-func (s *configCommandSuite) assertSetSuccess(c *gc.C, dir string, args []string, expect map[string]interface{}) {
+func (s *configCommandSuite) assertSetSuccess(
+	c *gc.C, dir string, args []string,
+	expectAppValues map[string]interface{}, expectCharmValues map[string]interface{},
+) {
 	cmd := application.NewConfigCommandForTest(s.fake)
 	cmd.SetClientStore(application.NewMockStore())
 
 	args = append([]string{"dummy-application"}, args...)
 	_, err := cmdtesting.RunCommandInDir(c, cmd, args, dir)
 	c.Assert(err, jc.ErrorIsNil)
+	appValues := make(map[string]interface{})
+	for k, v := range s.defaultAppValues {
+		appValues[k] = v
+	}
+	for k, v := range expectAppValues {
+		appValues[k] = v
+	}
+	c.Assert(s.fake.appValues, jc.DeepEquals, appValues)
+
+	charmValues := make(map[string]interface{})
+	for k, v := range s.defaultCharmValues {
+		charmValues[k] = v
+	}
+	for k, v := range expectCharmValues {
+		charmValues[k] = v
+	}
+	c.Assert(s.fake.charmValues, jc.DeepEquals, charmValues)
+}
+
+func (s *configCommandSuite) assertResetSuccess(
+	c *gc.C, dir string, args []string,
+	expectAppValues map[string]interface{}, expectCharmValues map[string]interface{},
+) {
+	cmd := application.NewConfigCommandForTest(s.fake)
+	cmd.SetClientStore(application.NewMockStore())
+
+	args = append([]string{"dummy-application"}, args...)
+	_, err := cmdtesting.RunCommandInDir(c, cmd, args, dir)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(s.fake.appValues, jc.DeepEquals, expectAppValues)
+	c.Assert(s.fake.charmValues, jc.DeepEquals, expectCharmValues)
 }
 
 // assertSetFail sets configuration options and checks the expected error.

--- a/cmd/juju/application/deploy.go
+++ b/cmd/juju/application/deploy.go
@@ -803,6 +803,9 @@ func (c *DeployCommand) deployCharm(
 		return errors.Trace(err)
 	}
 
+	if len(appConfig) == 0 {
+		appConfig = nil
+	}
 	args := application.DeployArgs{
 		CharmID:          id,
 		Cons:             c.Constraints,
@@ -810,6 +813,7 @@ func (c *DeployCommand) deployCharm(
 		Series:           series,
 		NumUnits:         numUnits,
 		ConfigYAML:       string(configYAML),
+		Config:           appConfig,
 		Placement:        c.Placement,
 		Storage:          c.Storage,
 		AttachStorage:    c.AttachStorage,

--- a/core/application/config.go
+++ b/core/application/config.go
@@ -1,0 +1,184 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package application
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/schema"
+	"github.com/juju/utils/set"
+	"gopkg.in/juju/environschema.v1"
+)
+
+const (
+	// JujuExternalHostNameKey specifies the hostname of a CAAS application.
+	JujuExternalHostNameKey = "juju-external-hostname"
+
+	// JujuApplicationPath specifies the relative http path used to access a CAAS application.
+	JujuApplicationPath = "juju-application-path"
+
+	defaultApplicationPath = "/"
+)
+
+var configFields = environschema.Fields{
+	JujuExternalHostNameKey: {
+		Description: "the external hostname of an exposed application",
+		Type:        environschema.Tstring,
+		Group:       environschema.EnvironGroup,
+	},
+	JujuApplicationPath: {
+		Description: "the relative http path used to access an application",
+		Type:        environschema.Tstring,
+		Group:       environschema.EnvironGroup,
+	},
+}
+
+// ConfigAttributes is the config for an application.
+type ConfigAttributes map[string]interface{}
+
+// Config encapsulates config for an application.
+type Config struct {
+	attributes map[string]interface{}
+	schema     environschema.Fields
+	defaults   schema.Defaults
+}
+
+// NewConfig returns a new config instance with the given attributes and
+// allowing for the extra provider attributes.
+func NewConfig(attrs map[string]interface{}, extra environschema.Fields, extraDefaults schema.Defaults) (*Config, error) {
+	cfg := &Config{}
+	var err error
+	if cfg.schema, err = configSchema(extra); err != nil {
+		return nil, errors.Trace(err)
+	}
+	cfg.defaults = ConfigDefaults(extraDefaults)
+	if err := cfg.setAttributes(attrs); err != nil {
+		return nil, errors.Trace(err)
+	}
+	return cfg, nil
+}
+
+func (c *Config) setAttributes(attrs map[string]interface{}) error {
+	checker, err := c.schemaChecker()
+	if err != nil {
+		return errors.Trace(err)
+	}
+	m := make(map[string]interface{})
+	for k, v := range attrs {
+		m[k] = v
+	}
+	result, err := checker.Coerce(m, nil)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	c.attributes = result.(map[string]interface{})
+	return nil
+}
+
+type ConfigFields environschema.Fields
+
+// KnownConfigKeys returns the valid application config keys.
+func (c ConfigFields) KnownConfigKeys() set.Strings {
+	result := set.NewStrings()
+	for name := range c {
+		result.Add(name)
+	}
+	return result
+}
+
+// Fields casts c to environSchema.Fields.
+func (c ConfigFields) Fields() environschema.Fields {
+	return environschema.Fields(c)
+}
+
+// ConfigSchema returns the valid fields for an application config.
+func ConfigSchema(extra environschema.Fields) (ConfigFields, error) {
+	fields, err := configSchema(extra)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return ConfigFields(fields), nil
+}
+
+// ConfigDefaults returns the default values for an application config.
+func ConfigDefaults(extra schema.Defaults) schema.Defaults {
+	defaults := schema.Defaults{JujuApplicationPath: defaultApplicationPath}
+	for key, value := range extra {
+		defaults[key] = value
+	}
+	return defaults
+}
+
+func configSchema(extra environschema.Fields) (environschema.Fields, error) {
+	fields := make(environschema.Fields)
+	for name, field := range configFields {
+		fields[name] = field
+	}
+	for name, field := range extra {
+		if _, ok := configFields[name]; ok {
+			return nil, errors.Errorf("config field %q clashes with common config", name)
+		}
+		fields[name] = field
+	}
+	return fields, nil
+}
+
+func (c *Config) schemaChecker() (schema.Checker, error) {
+	schemaFields, schemaDefaults, err := c.schema.ValidationSchema()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	for key, value := range c.defaults {
+		schemaDefaults[key] = value
+	}
+	return schema.StrictFieldMap(schemaFields, schemaDefaults), nil
+}
+
+// Validate returns an error if the config is not valid.
+func (c *Config) Validate() error {
+	return nil
+}
+
+// Attributes returns all the config attributes.
+func (c *Config) Attributes() ConfigAttributes {
+	if c == nil {
+		return nil
+	}
+	result := make(ConfigAttributes)
+	for k, v := range c.attributes {
+		result[k] = v
+	}
+	return result
+}
+
+// Get gets the specified attribute.
+func (c *Config) Get(attrName string) interface{} {
+	return c.attributes[attrName]
+}
+
+// GetInt gets the specified bool attribute.
+func (c *Config) GetBool(attrName string) bool {
+	if val, ok := c.attributes[attrName]; ok {
+		return val.(bool)
+	}
+	return false
+}
+
+// GetInt gets the specified int attribute.
+func (c *Config) GetInt(attrName string) int {
+	if val, ok := c.attributes[attrName]; ok {
+		if value, ok := val.(float64); ok {
+			return int(value)
+		}
+		return val.(int)
+	}
+	return 0
+}
+
+// GetString gets the specified string attribute.
+func (c *Config) GetString(attrName string) string {
+	if val, ok := c.attributes[attrName]; ok {
+		return val.(string)
+	}
+	return ""
+}

--- a/core/application/config.go
+++ b/core/application/config.go
@@ -10,6 +10,7 @@ import (
 	"gopkg.in/juju/environschema.v1"
 )
 
+// TODO(caas) - these are CAAS specific, figure out a better way
 const (
 	// JujuExternalHostNameKey specifies the hostname of a CAAS application.
 	JujuExternalHostNameKey = "juju-external-hostname"
@@ -152,33 +153,36 @@ func (c *Config) Attributes() ConfigAttributes {
 }
 
 // Get gets the specified attribute.
-func (c *Config) Get(attrName string) interface{} {
-	return c.attributes[attrName]
+func (c ConfigAttributes) Get(attrName string, defaultValue interface{}) interface{} {
+	if val, ok := c[attrName]; ok {
+		return val
+	}
+	return defaultValue
 }
 
 // GetInt gets the specified bool attribute.
-func (c *Config) GetBool(attrName string) bool {
-	if val, ok := c.attributes[attrName]; ok {
+func (c ConfigAttributes) GetBool(attrName string, defaultValue bool) bool {
+	if val, ok := c[attrName]; ok {
 		return val.(bool)
 	}
-	return false
+	return defaultValue
 }
 
 // GetInt gets the specified int attribute.
-func (c *Config) GetInt(attrName string) int {
-	if val, ok := c.attributes[attrName]; ok {
+func (c ConfigAttributes) GetInt(attrName string, defaultValue int) int {
+	if val, ok := c[attrName]; ok {
 		if value, ok := val.(float64); ok {
 			return int(value)
 		}
 		return val.(int)
 	}
-	return 0
+	return defaultValue
 }
 
 // GetString gets the specified string attribute.
-func (c *Config) GetString(attrName string) string {
-	if val, ok := c.attributes[attrName]; ok {
+func (c ConfigAttributes) GetString(attrName string, defaultValue string) string {
+	if val, ok := c[attrName]; ok {
 		return val.(string)
 	}
-	return ""
+	return defaultValue
 }

--- a/core/application/config_test.go
+++ b/core/application/config_test.go
@@ -116,15 +116,15 @@ func (s *ApplicationSuite) TestExtraAttributes(c *gc.C) {
 func (s *ApplicationSuite) TestGet(c *gc.C) {
 	cfg, err := application.NewConfig(map[string]interface{}{"juju-external-hostname": "ext-host"}, nil, nil)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(cfg.Get("juju-external-hostname"), gc.Equals, "ext-host")
-	c.Assert(cfg.Get("missing"), gc.IsNil)
+	c.Assert(cfg.Attributes().Get("juju-external-hostname", nil), gc.Equals, "ext-host")
+	c.Assert(cfg.Attributes().Get("missing", "default"), gc.Equals, "default")
 }
 
 func (s *ApplicationSuite) TestGetString(c *gc.C) {
 	cfg, err := application.NewConfig(map[string]interface{}{"juju-external-hostname": "ext-host"}, nil, nil)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(cfg.GetString("juju-external-hostname"), gc.Equals, "ext-host")
-	c.Assert(cfg.GetString("missing"), gc.Equals, "")
+	c.Assert(cfg.Attributes().GetString("juju-external-hostname", ""), gc.Equals, "ext-host")
+	c.Assert(cfg.Attributes().GetString("missing", "default"), gc.Equals, "default")
 }
 
 func (s *ApplicationSuite) TestGetInt(c *gc.C) {
@@ -136,8 +136,8 @@ func (s *ApplicationSuite) TestGetInt(c *gc.C) {
 	}
 	cfg, err := application.NewConfig(map[string]interface{}{"extra": 456}, extraFields, nil)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(cfg.GetInt("extra"), gc.Equals, 456)
-	c.Assert(cfg.GetInt("missing"), gc.Equals, 0)
+	c.Assert(cfg.Attributes().GetInt("extra", -1), gc.Equals, 456)
+	c.Assert(cfg.Attributes().GetInt("missing", -1), gc.Equals, -1)
 }
 
 func (s *ApplicationSuite) TestGetBool(c *gc.C) {
@@ -149,6 +149,6 @@ func (s *ApplicationSuite) TestGetBool(c *gc.C) {
 	}
 	cfg, err := application.NewConfig(map[string]interface{}{"extra": true}, extraFields, nil)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(cfg.GetBool("extra"), gc.Equals, true)
-	c.Assert(cfg.GetBool("missing"), gc.Equals, false)
+	c.Assert(cfg.Attributes().GetBool("extra", false), gc.Equals, true)
+	c.Assert(cfg.Attributes().GetBool("missing", true), gc.Equals, true)
 }

--- a/core/application/config_test.go
+++ b/core/application/config_test.go
@@ -1,0 +1,154 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package application_test
+
+import (
+	"github.com/juju/schema"
+	jc "github.com/juju/testing/checkers"
+	"github.com/juju/utils/set"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/environschema.v1"
+
+	"github.com/juju/juju/core/application"
+	coretesting "github.com/juju/juju/testing"
+)
+
+type ApplicationSuite struct {
+	coretesting.BaseSuite
+}
+
+var _ = gc.Suite(&ApplicationSuite{})
+
+var baseFields = environschema.Fields{
+	application.JujuExternalHostNameKey: {
+		Description: "the external hostname of an exposed application",
+		Type:        environschema.Tstring,
+		Group:       environschema.EnvironGroup,
+	},
+	application.JujuApplicationPath: {
+		Description: "the relative http path used to access an application",
+		Type:        environschema.Tstring,
+		Group:       environschema.EnvironGroup,
+	},
+}
+
+func (s *ApplicationSuite) TestConfigSchemaNoExtra(c *gc.C) {
+	fields, err := application.ConfigSchema(nil)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(fields, jc.DeepEquals, application.ConfigFields(baseFields))
+}
+
+func (s *ApplicationSuite) TestConfigSchemaExtra(c *gc.C) {
+	extraFields := environschema.Fields{
+		"extra": {
+			Description: "some field",
+			Type:        environschema.Tstring,
+		},
+	}
+	fields, err := application.ConfigSchema(extraFields)
+	c.Assert(err, jc.ErrorIsNil)
+
+	expectedFields := make(application.ConfigFields)
+	for name, f := range baseFields {
+		expectedFields[name] = f
+	}
+	for name, f := range extraFields {
+		expectedFields[name] = f
+	}
+	c.Assert(fields, jc.DeepEquals, expectedFields)
+}
+
+func (s *ApplicationSuite) TestConfigSchemaKnownConfigKeys(c *gc.C) {
+	fields, err := application.ConfigSchema(nil)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(fields.KnownConfigKeys(),
+		gc.DeepEquals, set.NewStrings([]string{"juju-external-hostname", "juju-application-path"}...))
+}
+
+func (s *ApplicationSuite) TestNewConfigUnknownAttribute(c *gc.C) {
+	_, err := application.NewConfig(map[string]interface{}{"some-attr": "value"}, nil, nil)
+	c.Assert(err, gc.ErrorMatches, `unknown key "some-attr" \(value "value"\)`)
+}
+
+func (s *ApplicationSuite) TestAttributes(c *gc.C) {
+	cfg, err := application.NewConfig(
+		map[string]interface{}{"juju-external-hostname": "value", "juju-application-path": "path"}, nil, nil)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(cfg.Attributes(), jc.DeepEquals, application.ConfigAttributes{
+		"juju-external-hostname": "value",
+		"juju-application-path":  "path"})
+}
+
+func (s *ApplicationSuite) TestAttributesNil(c *gc.C) {
+	cfg := (*application.Config)(nil)
+	c.Assert(cfg.Attributes(), gc.IsNil)
+}
+
+func (s *ApplicationSuite) TestAttributeWithDefault(c *gc.C) {
+	cfg, err := application.NewConfig(nil, nil, nil)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(cfg.Attributes(), jc.DeepEquals, application.ConfigAttributes{"juju-application-path": "/"})
+}
+
+func (s *ApplicationSuite) TestExtraAttributes(c *gc.C) {
+	extraFields := environschema.Fields{
+		"extra": {
+			Description: "some field",
+			Type:        environschema.Tstring,
+		},
+		"extra2": {
+			Description: "some field",
+			Type:        environschema.Tstring,
+		},
+	}
+	extraDefaults := schema.Defaults{
+		"extra": "fred",
+	}
+	cfg, err := application.NewConfig(nil, extraFields, extraDefaults)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(cfg.Attributes(), jc.DeepEquals, application.ConfigAttributes{
+		"juju-application-path": "/",
+		"extra":                 "fred",
+	})
+}
+
+func (s *ApplicationSuite) TestGet(c *gc.C) {
+	cfg, err := application.NewConfig(map[string]interface{}{"juju-external-hostname": "ext-host"}, nil, nil)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(cfg.Get("juju-external-hostname"), gc.Equals, "ext-host")
+	c.Assert(cfg.Get("missing"), gc.IsNil)
+}
+
+func (s *ApplicationSuite) TestGetString(c *gc.C) {
+	cfg, err := application.NewConfig(map[string]interface{}{"juju-external-hostname": "ext-host"}, nil, nil)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(cfg.GetString("juju-external-hostname"), gc.Equals, "ext-host")
+	c.Assert(cfg.GetString("missing"), gc.Equals, "")
+}
+
+func (s *ApplicationSuite) TestGetInt(c *gc.C) {
+	extraFields := environschema.Fields{
+		"extra": {
+			Description: "some field",
+			Type:        environschema.Tint,
+		},
+	}
+	cfg, err := application.NewConfig(map[string]interface{}{"extra": 456}, extraFields, nil)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(cfg.GetInt("extra"), gc.Equals, 456)
+	c.Assert(cfg.GetInt("missing"), gc.Equals, 0)
+}
+
+func (s *ApplicationSuite) TestGetBool(c *gc.C) {
+	extraFields := environschema.Fields{
+		"extra": {
+			Description: "some field",
+			Type:        environschema.Tbool,
+		},
+	}
+	cfg, err := application.NewConfig(map[string]interface{}{"extra": true}, extraFields, nil)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(cfg.GetBool("extra"), gc.Equals, true)
+	c.Assert(cfg.GetBool("missing"), gc.Equals, false)
+}

--- a/core/application/package_test.go
+++ b/core/application/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package application_test
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func TestAll(t *testing.T) {
+	gc.TestingT(t)
+}

--- a/featuretests/cmdjuju_test.go
+++ b/featuretests/cmdjuju_test.go
@@ -12,6 +12,8 @@ import (
 	"github.com/juju/juju/cmd/juju/application"
 	"github.com/juju/juju/cmd/juju/model"
 	"github.com/juju/juju/constraints"
+	coreapplication "github.com/juju/juju/core/application"
+	"github.com/juju/juju/feature"
 	"github.com/juju/juju/instance"
 	jujutesting "github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/state"
@@ -27,6 +29,11 @@ type cmdJujuSuite struct {
 
 func uint64p(val uint64) *uint64 {
 	return &val
+}
+
+func (s *cmdJujuSuite) SetUpSuite(c *gc.C) {
+	s.SetInitialFeatureFlags(feature.CAAS)
+	s.JujuConnSuite.SetUpSuite(c)
 }
 
 func (s *cmdJujuSuite) TestSetConstraints(c *gc.C) {
@@ -103,6 +110,72 @@ func (s *cmdJujuSuite) TestApplicationUnset(c *gc.C) {
 func (s *cmdJujuSuite) TestApplicationGet(c *gc.C) {
 	expected := `application: dummy-application
 charm: dummy
+config:
+  ingress.kubernetes.io/ssl-passthrough:
+    default: false
+    description: whether to passthrough SSL traffic to the ingress controller
+    source: default
+    type: bool
+    value: false
+  juju-application-path:
+    default: /
+    description: the relative http path used to access an application
+    source: default
+    type: string
+    value: /
+  juju-external-hostname:
+    description: the external hostname of an exposed application
+    source: user
+    type: string
+    value: ext-host
+  kubernetes-ingress-class:
+    default: nginx
+    description: the class of the ingress controller to be used by the ingress resource
+    source: default
+    type: string
+    value: nginx
+  kubernetes-ingress-ssl-redirect:
+    default: true
+    description: whether to redirect SSL traffic to the ingress controller
+    source: default
+    type: bool
+    value: true
+  kubernetes-service-external-ips:
+    description: list of IP addresses for which nodes in the cluster will also accept
+      traffic
+    source: unset
+    type: string
+  kubernetes-service-externalname:
+    description: external reference that kubedns or equivalent will return as a CNAME
+      record
+    source: unset
+    type: string
+  kubernetes-service-loadbalancer-ip:
+    description: LoadBalancer will get created with the IP specified in this field
+    source: unset
+    type: string
+  kubernetes-service-loadbalancer-sourceranges:
+    description: traffic through the load-balancer will be restricted to the specified
+      client IPs
+    source: unset
+    type: string
+  kubernetes-service-target-port:
+    description: name or number of the port to access on the pods targeted by the
+      service
+    source: unset
+    type: string
+  kubernetes-service-type:
+    default: ClusterIP
+    description: determines how the Service is exposed
+    source: default
+    type: string
+    value: ClusterIP
+  kubernetes.io/ingress.allow-http:
+    default: false
+    description: whether to allow insecure HTTP traffic to the ingress controller
+    source: default
+    type: bool
+    value: false
 settings:
   outlook:
     description: No default outlook.
@@ -126,7 +199,9 @@ settings:
     value: admin001
 `
 	ch := s.AddTestingCharm(c, "dummy")
-	s.AddTestingApplication(c, "dummy-application", ch)
+	app := s.AddTestingApplication(c, "dummy-application", ch)
+	err := app.UpdateApplicationConfig(coreapplication.ConfigAttributes{"juju-external-hostname": "ext-host"}, nil, nil)
+	c.Assert(err, jc.ErrorIsNil)
 
 	context, err := cmdtesting.RunCommand(c, application.NewConfigCommand(), "dummy-application")
 	c.Assert(err, jc.ErrorIsNil)
@@ -189,4 +264,44 @@ func (s *cmdJujuSuite) TestApplicationAddUnitExistingContainer(c *gc.C) {
 	mid, err := units[0].AssignedMachineId()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(mid, gc.Equals, container.Id())
+}
+
+type cmdJujuSuiteNoCAAS struct {
+	jujutesting.JujuConnSuite
+}
+
+func (s *cmdJujuSuiteNoCAAS) TestApplicationGet(c *gc.C) {
+	expected := `application: dummy-application
+charm: dummy
+config: {}
+settings:
+  outlook:
+    description: No default outlook.
+    source: unset
+    type: string
+  skill-level:
+    description: A number indicating skill.
+    source: unset
+    type: int
+  title:
+    default: My Title
+    description: A descriptive title used for the application.
+    source: default
+    type: string
+    value: My Title
+  username:
+    default: admin001
+    description: The name of the initial account (given admin permissions).
+    source: default
+    type: string
+    value: admin001
+`
+	ch := s.AddTestingCharm(c, "dummy")
+	app := s.AddTestingApplication(c, "dummy-application", ch)
+	err := app.UpdateApplicationConfig(coreapplication.ConfigAttributes{"juju-external-hostname": "ext-host"}, nil, nil)
+	c.Assert(err, jc.ErrorIsNil)
+
+	context, err := cmdtesting.RunCommand(c, application.NewConfigCommand(), "dummy-application")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(cmdtesting.Stdout(context), jc.DeepEquals, expected)
 }

--- a/featuretests/cmdjuju_test.go
+++ b/featuretests/cmdjuju_test.go
@@ -200,7 +200,7 @@ settings:
 `
 	ch := s.AddTestingCharm(c, "dummy")
 	app := s.AddTestingApplication(c, "dummy-application", ch)
-	err := app.UpdateApplicationConfig(coreapplication.ConfigAttributes{"juju-external-hostname": "ext-host"}, nil, nil)
+	err := app.UpdateApplicationConfig(coreapplication.ConfigAttributes{"juju-external-hostname": "ext-host"}, nil, nil, nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	context, err := cmdtesting.RunCommand(c, application.NewConfigCommand(), "dummy-application")
@@ -298,7 +298,7 @@ settings:
 `
 	ch := s.AddTestingCharm(c, "dummy")
 	app := s.AddTestingApplication(c, "dummy-application", ch)
-	err := app.UpdateApplicationConfig(coreapplication.ConfigAttributes{"juju-external-hostname": "ext-host"}, nil, nil)
+	err := app.UpdateApplicationConfig(coreapplication.ConfigAttributes{"juju-external-hostname": "ext-host"}, nil, nil, nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	context, err := cmdtesting.RunCommand(c, application.NewConfigCommand(), "dummy-application")

--- a/featuretests/package_test.go
+++ b/featuretests/package_test.go
@@ -41,6 +41,7 @@ func init() {
 	gc.Suite(&cmdControllerSuite{})
 	gc.Suite(&cmdCredentialSuite{})
 	gc.Suite(&cmdJujuSuite{})
+	gc.Suite(&cmdJujuSuiteNoCAAS{})
 	gc.Suite(&cmdLoginSuite{})
 	gc.Suite(&cmdModelSuite{})
 	gc.Suite(&cmdRegistrationSuite{})

--- a/state/application.go
+++ b/state/application.go
@@ -11,17 +11,20 @@ import (
 	"strings"
 
 	"github.com/juju/errors"
+	"github.com/juju/schema"
 	jujutxn "github.com/juju/txn"
 	"github.com/juju/utils"
 	"github.com/juju/utils/series"
 	"gopkg.in/juju/charm.v6"
 	csparams "gopkg.in/juju/charmrepo.v2/csclient/params"
+	"gopkg.in/juju/environschema.v1"
 	"gopkg.in/juju/names.v2"
 	"gopkg.in/mgo.v2"
 	"gopkg.in/mgo.v2/bson"
 	"gopkg.in/mgo.v2/txn"
 
 	"github.com/juju/juju/constraints"
+	"github.com/juju/juju/core/application"
 	"github.com/juju/juju/core/leadership"
 	"github.com/juju/juju/status"
 )
@@ -104,6 +107,16 @@ func applicationCharmConfigKey(appName string, curl *charm.URL) string {
 // key for the application.
 func (a *Application) charmConfigKey() string {
 	return applicationCharmConfigKey(a.doc.Name, a.doc.CharmURL)
+}
+
+func applicationConfigKey(appName string) string {
+	return fmt.Sprintf("a#%s#application", appName)
+}
+
+// applicationConfigKey returns the charm-version-specific settings collection
+// key for the application.
+func (a *Application) applicationConfigKey() string {
+	return applicationConfigKey(a.doc.Name)
 }
 
 func applicationStorageConstraintsKey(appName string, curl *charm.URL) string {
@@ -348,6 +361,7 @@ func (a *Application) removeOps(asserts bson.D) ([]txn.Op, error) {
 		annotationRemoveOp(a.st, globalKey),
 		removeLeadershipSettingsOp(name),
 		removeStatusOp(a.st, globalKey),
+		removeSettingsOp(settingsC, a.applicationConfigKey()),
 		removeModelApplicationRefOp(a.st, name),
 		removeContainerSpecOp(a.Tag()),
 	)
@@ -1744,6 +1758,48 @@ func (a *Application) UpdateCharmConfig(changes charm.Settings) error {
 	return err
 }
 
+// ApplicationConfig returns the configuration for the application itself.
+func (a *Application) ApplicationConfig() (application.ConfigAttributes, error) {
+	config, err := readSettings(a.st.db(), settingsC, a.applicationConfigKey())
+	if errors.IsNotFound(err) || len(config.Keys()) == 0 {
+		return application.ConfigAttributes(nil), nil
+	} else if err != nil {
+		return nil, err
+	}
+	return application.ConfigAttributes(config.Map()), nil
+}
+
+// UpdateApplicationConfig changes an application's config settings. Values set
+// to nil will be deleted; unknown and invalid values will return an error.
+func (a *Application) UpdateApplicationConfig(
+	changes application.ConfigAttributes,
+	extra environschema.Fields,
+	defaults schema.Defaults,
+) error {
+	node, err := readSettings(a.st.db(), settingsC, a.applicationConfigKey())
+	if errors.IsNotFound(err) {
+		return errors.Errorf("cannot update application config since no config exists")
+	} else if err != nil {
+		return err
+	}
+	for name, value := range changes {
+		if value == nil {
+			node.Delete(name)
+		} else {
+			node.Set(name, value)
+		}
+	}
+	newConfig, err := application.NewConfig(node.Map(), extra, defaults)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	if err := newConfig.Validate(); err != nil {
+		return errors.Trace(err)
+	}
+	_, err = node.Write()
+	return err
+}
+
 // LeaderSettings returns a application's leader settings. If nothing has been set
 // yet, it will return an empty map; this is not an error.
 func (a *Application) LeaderSettings() (map[string]string, error) {
@@ -2066,11 +2122,12 @@ var statusServerities = map[status.Status]int{
 }
 
 type addApplicationOpsArgs struct {
-	applicationDoc *applicationDoc
-	statusDoc      statusDoc
-	constraints    constraints.Value
-	storage        map[string]StorageConstraints
-	charmConfig    map[string]interface{}
+	applicationDoc    *applicationDoc
+	statusDoc         statusDoc
+	constraints       constraints.Value
+	storage           map[string]StorageConstraints
+	applicationConfig map[string]interface{}
+	charmConfig       map[string]interface{}
 	// These are nil when adding a new application, and most likely
 	// non-nil when migrating.
 	leadershipSettings map[string]interface{}
@@ -2088,6 +2145,7 @@ func addApplicationOps(mb modelBackend, app *Application, args addApplicationOps
 
 	globalKey := app.globalKey()
 	charmConfigKey := app.charmConfigKey()
+	applicationConfigKey := app.applicationConfigKey()
 	storageConstraintsKey := app.storageConstraintsKey()
 	leadershipKey := leadershipSettingsKey(app.Name())
 
@@ -2095,6 +2153,7 @@ func addApplicationOps(mb modelBackend, app *Application, args addApplicationOps
 		createConstraintsOp(globalKey, args.constraints),
 		createStorageConstraintsOp(storageConstraintsKey, args.storage),
 		createSettingsOp(settingsC, charmConfigKey, args.charmConfig),
+		createSettingsOp(settingsC, applicationConfigKey, args.applicationConfig),
 		createSettingsOp(settingsC, leadershipKey, args.leadershipSettings),
 		createStatusOp(mb, globalKey, args.statusDoc),
 		addModelApplicationRefOp(mb, app.Name()),

--- a/state/application_test.go
+++ b/state/application_test.go
@@ -3198,10 +3198,19 @@ func (s *ApplicationSuite) TestUpdateApplicationConfig(c *gc.C) {
 		c.Logf("test %d. %s", i, t.about)
 		app := s.AddTestingApplication(c, "dummy-application", sch)
 		if t.initial != nil {
-			err := app.UpdateApplicationConfig(t.initial, sampleApplicationConfigSchema(), nil)
+			err := app.UpdateApplicationConfig(t.initial, nil, sampleApplicationConfigSchema(), nil)
 			c.Assert(err, jc.ErrorIsNil)
 		}
-		err := app.UpdateApplicationConfig(t.update, sampleApplicationConfigSchema(), nil)
+		updates := make(map[string]interface{})
+		var resets []string
+		for k, v := range t.update {
+			if v == nil {
+				resets = append(resets, k)
+			} else {
+				updates[k] = v
+			}
+		}
+		err := app.UpdateApplicationConfig(updates, resets, sampleApplicationConfigSchema(), nil)
 		if t.err != "" {
 			c.Assert(err, gc.ErrorMatches, t.err)
 		} else {
@@ -3231,12 +3240,12 @@ func (s *ApplicationSuite) TestUpdateApplicationConfigWithDyingApplication(c *gc
 	err = s.mysql.Destroy()
 	c.Assert(err, jc.ErrorIsNil)
 	assertLife(c, s.mysql, state.Dying)
-	err = s.mysql.UpdateApplicationConfig(application.ConfigAttributes{"title": "value"}, sampleApplicationConfigSchema(), nil)
+	err = s.mysql.UpdateApplicationConfig(application.ConfigAttributes{"title": "value"}, nil, sampleApplicationConfigSchema(), nil)
 	c.Assert(err, jc.ErrorIsNil)
 }
 
 func (s *ApplicationSuite) TestDestroyApplicationRemovesConfig(c *gc.C) {
-	err := s.mysql.UpdateApplicationConfig(application.ConfigAttributes{"title": "value"}, sampleApplicationConfigSchema(), nil)
+	err := s.mysql.UpdateApplicationConfig(application.ConfigAttributes{"title": "value"}, nil, sampleApplicationConfigSchema(), nil)
 	c.Assert(err, jc.ErrorIsNil)
 	appConfig := state.GetApplicationConfig(s.State, s.mysql)
 	err = appConfig.Read()

--- a/state/export_test.go
+++ b/state/export_test.go
@@ -707,6 +707,12 @@ func GetApplicationCharmConfig(st *State, app *Application) *Settings {
 	return newSettings(st.db(), settingsC, app.charmConfigKey())
 }
 
+// GetApplicationConfig allows access to settings collection for a
+// given application in order to get the application config.
+func GetApplicationConfig(st *State, app *Application) *Settings {
+	return newSettings(st.db(), settingsC, app.applicationConfigKey())
+}
+
 // GetControllerSettings allows access to settings collection for
 // the controller.
 func GetControllerSettings(st *State) *Settings {

--- a/testing/factory/factory.go
+++ b/testing/factory/factory.go
@@ -21,6 +21,7 @@ import (
 	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/constraints"
+	"github.com/juju/juju/core/application"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/network"
@@ -91,13 +92,14 @@ type MachineParams struct {
 
 // ApplicationParams is used when specifying parameters for a new application.
 type ApplicationParams struct {
-	Name             string
-	Charm            *state.Charm
-	Status           *status.StatusInfo
-	CharmConfig      map[string]interface{}
-	Storage          map[string]state.StorageConstraints
-	Constraints      constraints.Value
-	EndpointBindings map[string]string
+	Name              string
+	Charm             *state.Charm
+	Status            *status.StatusInfo
+	ApplicationConfig map[string]interface{}
+	CharmConfig       map[string]interface{}
+	Storage           map[string]state.StorageConstraints
+	Constraints       constraints.Value
+	EndpointBindings  map[string]string
 }
 
 // UnitParams are used to create units.
@@ -448,14 +450,17 @@ func (factory *Factory) MakeApplication(c *gc.C, params *ApplicationParams) *sta
 		resourceMap[name] = pendingID
 	}
 
+	appConfig, err := application.NewConfig(params.ApplicationConfig, nil, nil)
+	c.Assert(err, jc.ErrorIsNil)
 	application, err := factory.st.AddApplication(state.AddApplicationArgs{
-		Name:             params.Name,
-		Charm:            params.Charm,
-		CharmConfig:      charm.Settings(params.CharmConfig),
-		Storage:          params.Storage,
-		Constraints:      params.Constraints,
-		Resources:        resourceMap,
-		EndpointBindings: params.EndpointBindings,
+		Name:              params.Name,
+		Charm:             params.Charm,
+		CharmConfig:       charm.Settings(params.CharmConfig),
+		ApplicationConfig: appConfig,
+		Storage:           params.Storage,
+		Constraints:       params.Constraints,
+		Resources:         resourceMap,
+		EndpointBindings:  params.EndpointBindings,
 	})
 	c.Assert(err, jc.ErrorIsNil)
 


### PR DESCRIPTION
## Description of change

Add support for managing distinct application config separate from charm config.
Broken up into a few commits:
- Add schema for application config values
- Additional config for k8s provisioning of various resources
- Add support for storing application config in state database
- Add api facade methods for new application config APIs
- Add support for juju config and deploy to support application config

Next PRs will wire up the k8s provisioning side of things and use the proper config schema.

## QA steps

bootstrap
juju deploy mysql --config juju-external-hostname=exthost --config vip=foo
juju config mysql
-> check that output has application config and charm config correctly set

juju config --reset vip,juju-external-hostname
-> check that values are reset

juju config juju-external-hostname=foo
-> check value is set

