### PR TITLE
Possible fix for #1734903.

### DIFF
--- a/state/state.go
+++ b/state/state.go
@@ -503,6 +503,9 @@ func (st *State) getPingBatcher() *presence.PingBatcher {
 // getTxnLogCollection returns the raw mongodb txns collection, which is
 // needed to interact with the state/watcher package.
 func (st *State) getTxnLogCollection() *mgo.Collection {
+	if st.Ping() != nil {
+		st.session.Refresh()
+	}
 	return st.session.DB(jujuDB).C(txnLogC)
 }
 


### PR DESCRIPTION
## Description of change

When getting the TxnLog collection, make sure our connection is working
before we hand it back.
Without this fix, we never Refresh or Copy or Clone the underlying connection, which means if st.session ends up closed, we fail to ever work again.

## QA steps

I haven't quite worked out how to test this, actually kill specific connections. Maybe there would be something with watching what Ports end up connecting to the local Mongo server, and then firewalling particular ports until you see the txn log watcher start dying indefinitely. This should allow that connection to get working again.

## Documentation changes

None.

## Bug reference

[lp:1734903](https://bugs.launchpad.net/juju/+bug/1734903)