### PR TITLE
Bug 1591962 ctrl space validation

### DIFF
--- a/controller/config.go
+++ b/controller/config.go
@@ -116,8 +116,8 @@ const (
 	// should communicate.
 	JujuHASpace = "juju-ha-space"
 
-	// JujuManagementSpace is the network space within which controllers in a HA
-	// set-up should communicate.
+	// JujuManagementSpace is the network space that agents should use to
+	// communicate with controllers.
 	JujuManagementSpace = "juju-mgmt-space"
 )
 
@@ -334,8 +334,8 @@ func (c Config) JujuHASpace() string {
 	return c.asString(JujuHASpace)
 }
 
-// JujuManagementSpace is the network space within which controllers in a HA
-// set-up should communicate.
+// JujuManagementSpace is the network space that agents should use to
+// communicate with controllers.
 func (c Config) JujuManagementSpace() string {
 	return c.asString(JujuManagementSpace)
 }
@@ -400,11 +400,11 @@ func Validate(c Config) error {
 	}
 
 	if err := validateSpaceConfig(c, JujuHASpace, "juju HA"); err != nil {
-		return err
+		return errors.Trace(err)
 	}
 
 	if err := validateSpaceConfig(c, JujuManagementSpace, "juju mgmt"); err != nil {
-		return err
+		return errors.Trace(err)
 	}
 
 	return nil
@@ -417,7 +417,7 @@ func validateSpaceConfig(c Config, key, topic string) error {
 	}
 	if v, ok := val.(string); ok {
 		if !names.IsValidSpace(v) {
-			return errors.NotValidf("%s space name %s", topic, val)
+			return errors.NotValidf("%s space name %q", topic, val)
 		}
 	} else {
 		return errors.NotValidf("type for %s space name %v", topic, val)

--- a/controller/config.go
+++ b/controller/config.go
@@ -48,7 +48,7 @@ const (
 	// IdentityPublicKey sets the public key of the identity manager.
 	IdentityPublicKey = "identity-public-key"
 
-	// NUMAControlPolicyKey stores the value for this setting
+	// SetNUMAControlPolicyKey stores the value for this setting
 	SetNUMAControlPolicyKey = "set-numa-control-policy"
 
 	// AutocertDNSNameKey sets the DNS name of the controller. If a
@@ -112,7 +112,12 @@ const (
 	// DefaultMaxTxnLogCollectionMB is the maximum size the txn log collection.
 	DefaultMaxTxnLogCollectionMB = 10 // 10 MB
 
-	JujuHASpace         = "juju-ha-space"
+	// JujuHASpace is the network space within which the MongoDB replica-set
+	// should communicate.
+	JujuHASpace = "juju-ha-space"
+
+	// JujuManagementSpace is the network space within which controllers in a HA
+	// set-up should communicate.
 	JujuManagementSpace = "juju-mgmt-space"
 )
 
@@ -148,6 +153,7 @@ func ControllerOnlyAttribute(attr string) bool {
 	return false
 }
 
+// Config is a string-keyed map of controller configuration attributes.
 type Config map[string]interface{}
 
 // Validate validates the controller configuration.
@@ -322,12 +328,14 @@ func (c Config) MaxTxnLogSizeMB() int {
 	return int(val)
 }
 
-// JujuHASpace is the network space where on which MongoDB lives.
+// JujuHASpace is the network space within which the MongoDB replica-set
+// should communicate.
 func (c Config) JujuHASpace() string {
 	return c.asString(JujuHASpace)
 }
 
-// JujuManagementSpace is the network space where controllers live.
+// JujuManagementSpace is the network space within which controllers in a HA
+// set-up should communicate.
 func (c Config) JujuManagementSpace() string {
 	return c.asString(JujuManagementSpace)
 }

--- a/controller/config.go
+++ b/controller/config.go
@@ -399,18 +399,28 @@ func Validate(c Config) error {
 		}
 	}
 
-	if v, ok := c[JujuHASpace].(string); ok {
-		if !names.IsValidSpace(v) {
-			return errors.NewNotValid(nil, "invalid juju HA space name")
-		}
-
+	if err := validateSpaceConfig(c, JujuHASpace, "juju HA"); err != nil {
+		return err
 	}
 
-	if v, ok := c[JujuManagementSpace].(string); ok {
-		if !names.IsValidSpace(v) {
-			return errors.NewNotValid(nil, "invalid juju mgmt space name")
-		}
+	if err := validateSpaceConfig(c, JujuManagementSpace, "juju mgmt"); err != nil {
+		return err
+	}
 
+	return nil
+}
+
+func validateSpaceConfig(c Config, key, topic string) error {
+	val := c[key]
+	if val == nil {
+		return nil
+	}
+	if v, ok := val.(string); ok {
+		if !names.IsValidSpace(v) {
+			return errors.NotValidf("%s space name %s", topic, val)
+		}
+	} else {
+		return errors.NotValidf("type for %s space name %v", topic, val)
 	}
 
 	return nil

--- a/controller/config_test.go
+++ b/controller/config_test.go
@@ -38,7 +38,7 @@ func (s *ConfigSuite) SetUpTest(c *gc.C) {
 
 func (s *ConfigSuite) TestGenerateControllerCertAndKey(c *gc.C) {
 	// Add a cert.
-	s.FakeHomeSuite.Home.AddFiles(c, gitjujutesting.TestFile{".ssh/id_rsa.pub", "rsa\n"})
+	s.FakeHomeSuite.Home.AddFiles(c, gitjujutesting.TestFile{Name: ".ssh/id_rsa.pub", Data: "rsa\n"})
 
 	for _, test := range []struct {
 		caCert    string

--- a/controller/config_test.go
+++ b/controller/config_test.go
@@ -122,26 +122,40 @@ var validateTests = []struct {
 	},
 	expectError: `invalid identity public key: wrong length for base64 key, got 3 want 32`,
 }, {
-	about: "invalid management space name",
+	about: "invalid management space name - whitespace",
 	config: controller.Config{
 		controller.CACertKey:           testing.CACert,
-		controller.JujuManagementSpace: ` `,
+		controller.JujuManagementSpace: " ",
 	},
-	expectError: `invalid juju mgmt space name`,
+	expectError: `juju mgmt space name   not valid`,
 }, {
-	about: "invalid management space name",
+	about: "invalid management space name - caps",
 	config: controller.Config{
 		controller.CACertKey:           testing.CACert,
-		controller.JujuManagementSpace: "Space",
+		controller.JujuManagementSpace: "CAPS",
 	},
-	expectError: `invalid juju mgmt space name`,
+	expectError: `juju mgmt space name CAPS not valid`,
 }, {
-	about: "invalid management space name",
+	about: "invalid management space name - carriage return",
 	config: controller.Config{
 		controller.CACertKey:           testing.CACert,
 		controller.JujuManagementSpace: "\n",
 	},
-	expectError: `invalid juju mgmt space name`,
+	expectError: "juju mgmt space name \n not valid",
+}, {
+	about: "invalid HA space name - number",
+	config: controller.Config{
+		controller.CACertKey:   testing.CACert,
+		controller.JujuHASpace: 666,
+	},
+	expectError: `type for juju HA space name 666 not valid`,
+}, {
+	about: "invalid HA space name - bool",
+	config: controller.Config{
+		controller.CACertKey:   testing.CACert,
+		controller.JujuHASpace: true,
+	},
+	expectError: `type for juju HA space name true not valid`,
 }}
 
 func (s *ConfigSuite) TestValidate(c *gc.C) {

--- a/controller/config_test.go
+++ b/controller/config_test.go
@@ -127,21 +127,21 @@ var validateTests = []struct {
 		controller.CACertKey:           testing.CACert,
 		controller.JujuManagementSpace: " ",
 	},
-	expectError: `juju mgmt space name   not valid`,
+	expectError: `juju mgmt space name " " not valid`,
 }, {
 	about: "invalid management space name - caps",
 	config: controller.Config{
 		controller.CACertKey:           testing.CACert,
 		controller.JujuManagementSpace: "CAPS",
 	},
-	expectError: `juju mgmt space name CAPS not valid`,
+	expectError: `juju mgmt space name "CAPS" not valid`,
 }, {
 	about: "invalid management space name - carriage return",
 	config: controller.Config{
 		controller.CACertKey:           testing.CACert,
 		controller.JujuManagementSpace: "\n",
 	},
-	expectError: "juju mgmt space name \n not valid",
+	expectError: `juju mgmt space name "\\n" not valid`,
 }, {
 	about: "invalid HA space name - number",
 	config: controller.Config{


### PR DESCRIPTION
## Description of change

In addition to valid space names, checking of the type is required in order that invalid types do not silently result in nil config values.

## QA steps

Accompanying unit tests.

## Documentation changes

No.

## Bug reference

Progresses:
https://bugs.launchpad.net/juju/+bug/1591962
