### PR TITLE
Final cloudinit-userdata changes

### DIFF
--- a/cloudconfig/userdatacfg_unix.go
+++ b/cloudconfig/userdatacfg_unix.go
@@ -354,11 +354,22 @@ func (w *unixConfigure) ConfigureJuju() error {
 	return w.addMachineAgentToBoot()
 }
 
+// Not all cloudinit-userdata attr are allowed to override, these attr have been
+// dealt with in ConfigureBasic() and ConfigureJuju().
+func isAllowedOverrideAttr(attr string) bool {
+	switch attr {
+	case "packages", "preruncmd", "postruncmd":
+		return false
+	}
+	return true
+}
+
+// ConfigureCustomOverrides implements UserdataConfig.ConfigureCustomOverrides
 func (w *unixConfigure) ConfigureCustomOverrides() error {
 	for k, v := range w.icfg.CloudInitUserData {
 		// preruncmd was handled in ConfigureBasic()
 		// packages and postruncmd have been handled in ConfigureJuju()
-		if k != "packages" && k != "preruncmd" && k != "postruncmd" {
+		if isAllowedOverrideAttr(k) {
 			w.conf.SetAttr(k, v)
 		}
 	}

--- a/cloudconfig/userdatacfg_win.go
+++ b/cloudconfig/userdatacfg_win.go
@@ -48,6 +48,7 @@ func (w *windowsConfigure) Configure() error {
 	return w.ConfigureCustomOverrides()
 }
 
+// ConfigureBasic implements UserdataConfig.ConfigureBasic
 func (w *windowsConfigure) ConfigureBasic() error {
 
 	tmpDir, err := paths.TempDir(w.icfg.Series)
@@ -93,6 +94,7 @@ func (w *windowsConfigure) ConfigureBasic() error {
 	return nil
 }
 
+// ConfigureJuju implements UserdataConfig.ConfigureJuju
 func (w *windowsConfigure) ConfigureJuju() error {
 	if err := w.icfg.VerifyConfig(); err != nil {
 		return errors.Trace(err)
@@ -144,6 +146,7 @@ func (w *windowsConfigure) ConfigureJuju() error {
 	return w.addMachineAgentToBoot()
 }
 
+// ConfigureCustomOverrides implements UserdataConfig.ConfigureCustomOverrides
 func (w *windowsConfigure) ConfigureCustomOverrides() error {
 	// TODO HML 2017-12-08
 	// Implement for Windows support of model-config cloudinit-userdata.

--- a/cmd/juju/model/configcommand.go
+++ b/cmd/juju/model/configcommand.go
@@ -335,7 +335,17 @@ func (c *configCommand) getConfig(client configCommandAPI, ctx *cmd.Context) err
 		} else {
 			return errors.Errorf("key %q not found in %q model.", key, attrs["name"])
 		}
+	} else {
+		// In tabular format, don't print "cloudinit-userdata" it can be very long,
+		// instead give instructions on how to print specifically.
+		if value, ok := attrs[config.CloudInitUserDataKey]; ok && c.out.Name() == "tabular" {
+			if value.Value.(string) != "" {
+				value.Value = "<value set, see juju model-config cloudinit-userdata>"
+				attrs["cloudinit-userdata"] = value
+			}
+		}
 	}
+
 	return c.out.Write(ctx, attrs)
 }
 

--- a/cmd/juju/model/configcommand_test.go
+++ b/cmd/juju/model/configcommand_test.go
@@ -220,6 +220,47 @@ func (s *ConfigCommandSuite) TestPassesValues(c *gc.C) {
 	c.Assert(s.fake.values, jc.DeepEquals, expected)
 }
 
+func (s *ConfigCommandSuite) TestPassesCloudInitUserDataLong(c *gc.C) {
+	modelCfg, err := s.fake.ModelGet()
+	modelCfg["cloudinit-userdata"] = "test data"
+	err = s.fake.ModelSet(modelCfg)
+	c.Assert(err, jc.ErrorIsNil)
+
+	context, err := s.run(c, "cloudinit-userdata")
+	c.Assert(err, jc.ErrorIsNil)
+	output := cmdtesting.Stdout(context)
+	c.Assert(output, gc.Equals, "test data\n")
+
+	context2, err := s.run(c)
+	c.Assert(err, jc.ErrorIsNil)
+	output2 := cmdtesting.Stdout(context2)
+	expected2 := "" +
+		"Attribute           From   Value\n" +
+		"cloudinit-userdata  model  <value set, see juju model-config cloudinit-userdata>\n" +
+		"running             model  true\n" +
+		"special             model  special value\n" +
+		"\n"
+	c.Assert(output2, gc.Equals, expected2)
+}
+
+func (s *ConfigCommandSuite) TestPassesCloudInitUserDataShort(c *gc.C) {
+	modelCfg, err := s.fake.ModelGet()
+	modelCfg["cloudinit-userdata"] = ""
+	err = s.fake.ModelSet(modelCfg)
+	c.Assert(err, jc.ErrorIsNil)
+
+	context, err := s.run(c)
+	c.Assert(err, jc.ErrorIsNil)
+	output := cmdtesting.Stdout(context)
+	expected := "" +
+		"Attribute           From   Value\n" +
+		"cloudinit-userdata  model  \"\"\n" +
+		"running             model  true\n" +
+		"special             model  special value\n" +
+		"\n"
+	c.Assert(output, gc.Equals, expected)
+}
+
 func (s *ConfigCommandSuite) TestSettingUnknownValue(c *gc.C) {
 	_, err := s.run(c, "special=extra", "unknown=foo")
 	c.Assert(err, jc.ErrorIsNil)

--- a/environs/config/config.go
+++ b/environs/config/config.go
@@ -627,6 +627,11 @@ func Validate(cfg, old *Config) error {
 		if _, ok := userDataMap["runcmd"]; ok {
 			return errors.New("cloudinit-userdata: runcmd not allowed, use preruncmd or postruncmd instead")
 		}
+
+		// error if bootcmd is specified
+		if _, ok := userDataMap["bootcmd"]; ok {
+			return errors.New("cloudinit-userdata: bootcmd not allowed")
+		}
 	}
 
 	// Check the immutable config values.  These can't change

--- a/environs/config/config_test.go
+++ b/environs/config/config_test.go
@@ -860,8 +860,12 @@ var configValidateCloudInitUserDataTests = []configValidateCloudInitUserDataTest
 		err:   `cloudinit-userdata: users not allowed`,
 	}, {
 		about: "Invalid cloud init user data values: runcmd",
-		value: invalidCloudInitUserDataRuncmd,
+		value: invalidCloudInitUserDataRunCmd,
 		err:   `cloudinit-userdata: runcmd not allowed, use preruncmd or postruncmd instead`,
+	}, {
+		about: "Invalid cloud init user data values: bootcmd",
+		value: invalidCloudInitUserDataBootCmd,
+		err:   `cloudinit-userdata: bootcmd not allowed`,
 	}, {
 		about: "Invalid cloud init user data: yaml",
 		value: invalidCloudInitUserDataInvalidYAML,
@@ -1336,12 +1340,21 @@ postruncmd:
 package_upgrade: true
 `[1:]
 
-var invalidCloudInitUserDataRuncmd = `
+var invalidCloudInitUserDataRunCmd = `
 packages:
     - 'string1'
     - 'string2'
 runcmd:
     - mkdir /tmp/runcmd
+package_upgrade: true
+`[1:]
+
+var invalidCloudInitUserDataBootCmd = `
+packages:
+    - 'string1'
+    - 'string2'
+bootcmd:
+    - mkdir /tmp/bootcmd
 package_upgrade: true
 `[1:]
 

--- a/worker/provisioner/provisioner_test.go
+++ b/worker/provisioner/provisioner_test.go
@@ -855,7 +855,6 @@ type MockMachine struct {
 	idErr         error
 	ensureDeadErr error
 	statusErr     error
-	//	pInfo         *params.ProvisioningInfo
 }
 
 func (m *MockMachine) Life() params.Life {
@@ -881,10 +880,6 @@ func (m *MockMachine) InstanceStatus() (status.Status, string, error) {
 func (m *MockMachine) Id() string {
 	return m.id
 }
-
-//func (m *MockMachine) ProvisioningInfo() (*params.ProvisioningInfo, error) {
-//	return m.pInfo, nil
-//}
 
 type machineClassificationTest struct {
 	description    string


### PR DESCRIPTION
## Description of change

Don't allow bootcmd with model-config's cloudinit-userdata. 
Shorten output of model-config cloudinit-userdata in tabular format only.
A little clean up of prior cloudrnit-userdata commits.
Follow on to PR 8211 and final in the series.

## QA steps

1. setup cloudinit-userdata within model-config
2. juju model-config should have "<value set, see juju model-config cloudinit-userdata>"
3. juju model-config cloudinit-userdata and juju model-config --format yaml should both include the full text.
4. Attempting to add bootcmd as a key to model-config cloudinit-userdata should result in an error.

## Documentation changes

n/a

## Bug reference

n/a
