### PR TITLE
Use base state pools.

### DIFF
--- a/api/apiclient_test.go
+++ b/api/apiclient_test.go
@@ -36,7 +36,6 @@ import (
 	"github.com/juju/juju/pubsub/centralhub"
 	"github.com/juju/juju/rpc"
 	"github.com/juju/juju/rpc/jsoncodec"
-	"github.com/juju/juju/state"
 	jtesting "github.com/juju/juju/testing"
 	"github.com/juju/juju/utils/proxy"
 	jujuversion "github.com/juju/juju/version"
@@ -567,9 +566,7 @@ func (s *apiclientSuite) TestPublicDNSName(c *gc.C) {
 	listener, err := net.Listen("tcp", "localhost:0")
 	c.Assert(err, gc.IsNil)
 	machineTag := names.NewMachineTag("0")
-	statePool := state.NewStatePool(s.State)
-	defer statePool.Close()
-	srv, err := apiserver.NewServer(statePool, listener, apiserver.ServerConfig{
+	srv, err := apiserver.NewServer(s.StatePool, listener, apiserver.ServerConfig{
 		Clock:           clock.WallClock,
 		Cert:            jtesting.ServerCert,
 		Key:             jtesting.ServerKey,

--- a/api/controller/legacy_test.go
+++ b/api/controller/legacy_test.go
@@ -216,10 +216,7 @@ func (s *legacySuite) TestAPIServerCanShutdownWithOutstandingNext(c *gc.C) {
 	lis, err := net.Listen("tcp", "localhost:0")
 	c.Assert(err, jc.ErrorIsNil)
 
-	statePool := state.NewStatePool(s.State)
-	defer statePool.Close()
-
-	srv, err := apiserver.NewServer(statePool, lis, apiserver.ServerConfig{
+	srv, err := apiserver.NewServer(s.StatePool, lis, apiserver.ServerConfig{
 		Clock:           clock.WallClock,
 		Cert:            testing.ServerCert,
 		Key:             testing.ServerKey,

--- a/apiserver/apiserver_test.go
+++ b/apiserver/apiserver_test.go
@@ -31,7 +31,6 @@ const (
 
 type apiserverBaseSuite struct {
 	statetesting.StateSuite
-	pool *state.StatePool
 }
 
 func (s *apiserverBaseSuite) SetUpTest(c *gc.C) {
@@ -41,8 +40,6 @@ func (s *apiserverBaseSuite) SetUpTest(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	err = u.SetPassword(ownerPassword)
 	c.Assert(err, jc.ErrorIsNil)
-	s.pool = state.NewStatePool(s.State)
-	s.AddCleanup(func(*gc.C) { s.pool.Close() })
 }
 
 func (s *apiserverBaseSuite) sampleConfig(c *gc.C) apiserver.ServerConfig {
@@ -63,7 +60,7 @@ func (s *apiserverBaseSuite) sampleConfig(c *gc.C) apiserver.ServerConfig {
 func (s *apiserverBaseSuite) newServerNoCleanup(c *gc.C, config apiserver.ServerConfig) *apiserver.Server {
 	listener, err := net.Listen("tcp", ":0")
 	c.Assert(err, jc.ErrorIsNil)
-	srv, err := apiserver.NewServer(s.pool, listener, config)
+	srv, err := apiserver.NewServer(s.StatePool, listener, config)
 	c.Assert(err, jc.ErrorIsNil)
 	return srv
 }

--- a/apiserver/authenticator_test.go
+++ b/apiserver/authenticator_test.go
@@ -18,7 +18,6 @@ import (
 
 type agentAuthenticatorSuite struct {
 	testing.JujuConnSuite
-	pool *state.StatePool
 }
 
 type userFinder struct {
@@ -33,14 +32,12 @@ var _ = gc.Suite(&agentAuthenticatorSuite{})
 
 func (s *agentAuthenticatorSuite) SetUpTest(c *gc.C) {
 	s.JujuConnSuite.SetUpTest(c)
-	s.pool = state.NewStatePool(s.State)
-	s.AddCleanup(func(*gc.C) { s.pool.Close() })
 }
 
 func (s *agentAuthenticatorSuite) TestAuthenticatorForTag(c *gc.C) {
 	fact := factory.NewFactory(s.State)
 	user := fact.MakeUser(c, &factory.UserParams{Password: "password"})
-	_, srv := newServer(c, s.pool)
+	_, srv := newServer(c, s.StatePool)
 	defer assertStop(c, srv)
 
 	authenticator, err := apiserver.ServerAuthenticatorForTag(srv, user.Tag())
@@ -57,7 +54,7 @@ func (s *agentAuthenticatorSuite) TestAuthenticatorForTag(c *gc.C) {
 }
 
 func (s *agentAuthenticatorSuite) TestMachineGetsAgentAuthenticator(c *gc.C) {
-	_, srv := newServer(c, s.pool)
+	_, srv := newServer(c, s.StatePool)
 	defer srv.Stop()
 	authenticator, err := apiserver.ServerAuthenticatorForTag(srv, names.NewMachineTag("0"))
 	c.Assert(err, jc.ErrorIsNil)
@@ -66,7 +63,7 @@ func (s *agentAuthenticatorSuite) TestMachineGetsAgentAuthenticator(c *gc.C) {
 }
 
 func (s *agentAuthenticatorSuite) TestUnitGetsAgentAuthenticator(c *gc.C) {
-	_, srv := newServer(c, s.pool)
+	_, srv := newServer(c, s.StatePool)
 	defer srv.Stop()
 	authenticator, err := apiserver.ServerAuthenticatorForTag(srv, names.NewUnitTag("wordpress/0"))
 	c.Assert(err, jc.ErrorIsNil)
@@ -75,7 +72,7 @@ func (s *agentAuthenticatorSuite) TestUnitGetsAgentAuthenticator(c *gc.C) {
 }
 
 func (s *agentAuthenticatorSuite) TestNotSupportedTag(c *gc.C) {
-	_, srv := newServer(c, s.pool)
+	_, srv := newServer(c, s.StatePool)
 	defer srv.Stop()
 	authenticator, err := apiserver.ServerAuthenticatorForTag(srv, names.NewApplicationTag("not-support"))
 	c.Assert(err, gc.ErrorMatches, "unexpected login entity tag: invalid request")

--- a/apiserver/common/modelstatus_test.go
+++ b/apiserver/common/modelstatus_test.go
@@ -26,7 +26,6 @@ type modelStatusSuite struct {
 	controller *controller.ControllerAPI
 	resources  *common.Resources
 	authorizer apiservertesting.FakeAuthorizer
-	pool       *state.StatePool
 }
 
 var _ = gc.Suite(&modelStatusSuite{})
@@ -46,15 +45,12 @@ func (s *modelStatusSuite) SetUpTest(c *gc.C) {
 		AdminTag: s.Owner,
 	}
 
-	s.pool = state.NewStatePool(s.State)
-	s.AddCleanup(func(*gc.C) { s.pool.Close() })
-
 	controller, err := controller.NewControllerAPI(
 		facadetest.Context{
 			State_:     s.State,
 			Resources_: s.resources,
 			Auth_:      s.authorizer,
-			StatePool_: s.pool,
+			StatePool_: s.StatePool,
 		})
 	c.Assert(err, jc.ErrorIsNil)
 	s.controller = controller
@@ -97,7 +93,7 @@ func (s *modelStatusSuite) TestModelStatusOwnerAllowed(c *gc.C) {
 			State_:     s.State,
 			Resources_: s.resources,
 			Auth_:      anAuthoriser,
-			StatePool_: s.pool,
+			StatePool_: s.StatePool,
 		})
 	c.Assert(err, jc.ErrorIsNil)
 

--- a/apiserver/controller/controller_test.go
+++ b/apiserver/controller/controller_test.go
@@ -36,7 +36,6 @@ import (
 type controllerSuite struct {
 	statetesting.StateSuite
 
-	statePool  *state.StatePool
 	controller *controller.ControllerAPI
 	resources  *common.Resources
 	authorizer apiservertesting.FakeAuthorizer
@@ -52,12 +51,6 @@ func (s *controllerSuite) SetUpTest(c *gc.C) {
 
 	s.StateSuite.SetUpTest(c)
 
-	s.statePool = state.NewStatePool(s.State)
-	s.AddCleanup(func(c *gc.C) {
-		err := s.statePool.Close()
-		c.Assert(err, jc.ErrorIsNil)
-	})
-
 	s.resources = common.NewResources()
 	s.AddCleanup(func(_ *gc.C) { s.resources.StopAll() })
 
@@ -69,7 +62,7 @@ func (s *controllerSuite) SetUpTest(c *gc.C) {
 	controller, err := controller.NewControllerAPI(
 		facadetest.Context{
 			State_:     s.State,
-			StatePool_: s.statePool,
+			StatePool_: s.StatePool,
 			Resources_: s.resources,
 			Auth_:      s.authorizer,
 		})

--- a/apiserver/logsink_test.go
+++ b/apiserver/logsink_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/juju/juju/apiserver"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/apiserver/websocket/websockettest"
-	"github.com/juju/juju/state"
 	coretesting "github.com/juju/juju/testing"
 	"github.com/juju/juju/testing/factory"
 	"github.com/juju/juju/version"
@@ -214,33 +213,31 @@ func (s *logsinkSuite) TestNewServerValidatesLogSinkConfig(c *gc.C) {
 	type dummyListener struct {
 		net.Listener
 	}
-	pool := state.NewStatePool(s.State)
-	defer pool.Close()
 
 	cfg := defaultServerConfig(c)
 	cfg.LogSinkConfig = &apiserver.LogSinkConfig{}
 
-	_, err := apiserver.NewServer(pool, dummyListener{}, cfg)
+	_, err := apiserver.NewServer(s.StatePool, dummyListener{}, cfg)
 	c.Assert(err, gc.ErrorMatches, "validating logsink configuration: DBLoggerBufferSize 0 <= 0 or > 1000 not valid")
 
 	cfg.LogSinkConfig.DBLoggerBufferSize = 1001
-	_, err = apiserver.NewServer(pool, dummyListener{}, cfg)
+	_, err = apiserver.NewServer(s.StatePool, dummyListener{}, cfg)
 	c.Assert(err, gc.ErrorMatches, "validating logsink configuration: DBLoggerBufferSize 1001 <= 0 or > 1000 not valid")
 
 	cfg.LogSinkConfig.DBLoggerBufferSize = 1
-	_, err = apiserver.NewServer(pool, dummyListener{}, cfg)
+	_, err = apiserver.NewServer(s.StatePool, dummyListener{}, cfg)
 	c.Assert(err, gc.ErrorMatches, "validating logsink configuration: DBLoggerFlushInterval 0s <= 0 or > 10 seconds not valid")
 
 	cfg.LogSinkConfig.DBLoggerFlushInterval = 30 * time.Second
-	_, err = apiserver.NewServer(pool, dummyListener{}, cfg)
+	_, err = apiserver.NewServer(s.StatePool, dummyListener{}, cfg)
 	c.Assert(err, gc.ErrorMatches, "validating logsink configuration: DBLoggerFlushInterval 30s <= 0 or > 10 seconds not valid")
 
 	cfg.LogSinkConfig.DBLoggerFlushInterval = 10 * time.Second
-	_, err = apiserver.NewServer(pool, dummyListener{}, cfg)
+	_, err = apiserver.NewServer(s.StatePool, dummyListener{}, cfg)
 	c.Assert(err, gc.ErrorMatches, "validating logsink configuration: RateLimitBurst 0 <= 0 not valid")
 
 	cfg.LogSinkConfig.RateLimitBurst = 1000
-	_, err = apiserver.NewServer(pool, dummyListener{}, cfg)
+	_, err = apiserver.NewServer(s.StatePool, dummyListener{}, cfg)
 	c.Assert(err, gc.ErrorMatches, "validating logsink configuration: RateLimitRefill 0s <= 0 not valid")
 }
 

--- a/apiserver/migrationtarget/migrationtarget_test.go
+++ b/apiserver/migrationtarget/migrationtarget_test.go
@@ -402,10 +402,9 @@ func (s *Suite) newAPI(environFunc stateenvirons.NewEnvironFunc) (*migrationtarg
 		State_:     s.State,
 		Resources_: s.resources,
 		Auth_:      s.authorizer,
-		StatePool_: state.NewStatePool(s.State),
+		StatePool_: s.StatePool,
 	}
 	api, err := migrationtarget.NewAPI(ctx, environFunc)
-	s.AddCleanup(func(*gc.C) { ctx.StatePool().Close() })
 	return api, err
 }
 

--- a/apiserver/pubsub_test.go
+++ b/apiserver/pubsub_test.go
@@ -28,7 +28,6 @@ import (
 
 type pubsubSuite struct {
 	statetesting.StateSuite
-	pool       *state.StatePool
 	machineTag names.Tag
 	password   string
 	nonce      string
@@ -49,9 +48,7 @@ func (s *pubsubSuite) SetUpTest(c *gc.C) {
 	s.machineTag = m.Tag()
 	s.password = password
 	s.hub = pubsub.NewStructuredHub(nil)
-	s.pool = state.NewStatePool(s.State)
-	s.AddCleanup(func(*gc.C) { s.pool.Close() })
-	_, s.server = newServerWithHub(c, s.pool, s.hub)
+	_, s.server = newServerWithHub(c, s.StatePool, s.hub)
 	s.AddCleanup(func(*gc.C) { s.server.Stop() })
 
 	// A net.TCPAddr cannot be directly stringified into a valid hostname.

--- a/apiserver/server_test.go
+++ b/apiserver/server_test.go
@@ -49,21 +49,14 @@ var fastDialOpts = api.DialOpts{}
 
 type serverSuite struct {
 	jujutesting.JujuConnSuite
-	pool *state.StatePool
 }
 
 var _ = gc.Suite(&serverSuite{})
 
-func (s *serverSuite) SetUpTest(c *gc.C) {
-	s.JujuConnSuite.SetUpTest(c)
-	s.pool = state.NewStatePool(s.State)
-	s.AddCleanup(func(*gc.C) { s.pool.Close() })
-}
-
 func (s *serverSuite) TestStop(c *gc.C) {
 	// Start our own instance of the server so we have
 	// a handle on it to stop it.
-	_, srv := newServer(c, s.pool)
+	_, srv := newServer(c, s.StatePool)
 	defer assertStop(c, srv)
 
 	machine, password := s.Factory.MakeMachineReturningPassword(
@@ -108,7 +101,7 @@ func (s *serverSuite) TestAPIServerCanListenOnBothIPv4AndIPv6(c *gc.C) {
 
 	// Start our own instance of the server listening on
 	// both IPv4 and IPv6 localhost addresses and an ephemeral port.
-	_, srv := newServer(c, s.pool)
+	_, srv := newServer(c, s.StatePool)
 	defer assertStop(c, srv)
 
 	port := srv.Addr().Port
@@ -217,9 +210,6 @@ func (s *serverSuite) TestNewServerDoesNotAccessState(c *gc.C) {
 	c.Assert(err, gc.IsNil)
 	defer st.Close()
 
-	pool := state.NewStatePool(st)
-	defer pool.Close()
-
 	// Now close the proxy so that any attempts to use the
 	// controller will fail.
 	proxy.Close()
@@ -227,7 +217,7 @@ func (s *serverSuite) TestNewServerDoesNotAccessState(c *gc.C) {
 	// Creating the server should succeed because it doesn't
 	// access the state (note that newServer does not log in,
 	// which *would* access the state).
-	_, srv := newServer(c, pool)
+	_, srv := newServer(c, s.StatePool)
 	srv.Stop()
 }
 
@@ -303,7 +293,7 @@ func dialWebsocket(c *gc.C, addr, path string, tlsVersion uint16) (*websocket.Co
 
 func (s *serverSuite) TestMinTLSVersion(c *gc.C) {
 	loggo.GetLogger("juju.apiserver").SetLogLevel(loggo.TRACE)
-	_, srv := newServer(c, s.pool)
+	_, srv := newServer(c, s.StatePool)
 	defer assertStop(c, srv)
 
 	// We have to use 'localhost' because that is what the TLS cert says.
@@ -319,7 +309,7 @@ func (s *serverSuite) TestNonCompatiblePathsAre404(c *gc.C) {
 	// We expose the API at '/api', '/' (controller-only), and at '/ModelUUID/api'
 	// for the correct location, but other paths should fail.
 	loggo.GetLogger("juju.apiserver").SetLogLevel(loggo.TRACE)
-	_, srv := newServer(c, s.pool)
+	_, srv := newServer(c, s.StatePool)
 	defer assertStop(c, srv)
 
 	// We have to use 'localhost' because that is what the TLS cert says.
@@ -350,7 +340,7 @@ func (s *serverSuite) TestNonCompatiblePathsAre404(c *gc.C) {
 }
 
 func (s *serverSuite) TestNoBakeryWhenNoIdentityURL(c *gc.C) {
-	_, srv := newServer(c, s.pool)
+	_, srv := newServer(c, s.StatePool)
 	defer assertStop(c, srv)
 	// By default, when there is no identity location, no
 	// bakery service or macaroon is created.
@@ -363,7 +353,6 @@ func (s *serverSuite) TestNoBakeryWhenNoIdentityURL(c *gc.C) {
 type macaroonServerSuite struct {
 	jujutesting.JujuConnSuite
 	discharger *bakerytest.Discharger
-	pool       *state.StatePool
 }
 
 var _ = gc.Suite(&macaroonServerSuite{})
@@ -374,8 +363,6 @@ func (s *macaroonServerSuite) SetUpTest(c *gc.C) {
 		controller.IdentityURL: s.discharger.Location(),
 	}
 	s.JujuConnSuite.SetUpTest(c)
-	s.pool = state.NewStatePool(s.State)
-	s.AddCleanup(func(*gc.C) { s.pool.Close() })
 }
 
 func (s *macaroonServerSuite) TearDownTest(c *gc.C) {
@@ -384,7 +371,7 @@ func (s *macaroonServerSuite) TearDownTest(c *gc.C) {
 }
 
 func (s *macaroonServerSuite) TestServerBakery(c *gc.C) {
-	_, srv := newServer(c, s.pool)
+	_, srv := newServer(c, s.StatePool)
 	defer assertStop(c, srv)
 	m, err := apiserver.ServerMacaroon(srv)
 	c.Assert(err, gc.IsNil)
@@ -414,7 +401,6 @@ func (s *macaroonServerSuite) TestServerBakery(c *gc.C) {
 type macaroonServerWrongPublicKeySuite struct {
 	jujutesting.JujuConnSuite
 	discharger *bakerytest.Discharger
-	pool       *state.StatePool
 }
 
 var _ = gc.Suite(&macaroonServerWrongPublicKeySuite{})
@@ -428,8 +414,6 @@ func (s *macaroonServerWrongPublicKeySuite) SetUpTest(c *gc.C) {
 		controller.IdentityPublicKey: wrongKey.Public.String(),
 	}
 	s.JujuConnSuite.SetUpTest(c)
-	s.pool = state.NewStatePool(s.State)
-	s.AddCleanup(func(*gc.C) { s.pool.Close() })
 }
 
 func (s *macaroonServerWrongPublicKeySuite) TearDownTest(c *gc.C) {
@@ -438,7 +422,7 @@ func (s *macaroonServerWrongPublicKeySuite) TearDownTest(c *gc.C) {
 }
 
 func (s *macaroonServerWrongPublicKeySuite) TestDischargeFailsWithWrongPublicKey(c *gc.C) {
-	_, srv := newServer(c, s.pool)
+	_, srv := newServer(c, s.StatePool)
 	defer assertStop(c, srv)
 	m, err := apiserver.ServerMacaroon(srv)
 	c.Assert(err, gc.IsNil)
@@ -485,7 +469,7 @@ func (s *serverSuite) bootstrapHasPermissionTest(c *gc.C) (*state.User, names.Co
 func (s *serverSuite) TestAPIHandlerHasPermissionLogin(c *gc.C) {
 	u, ctag := s.bootstrapHasPermissionTest(c)
 
-	handler, _ := apiserver.TestingAPIHandlerWithEntity(c, s.pool, s.State, u)
+	handler, _ := apiserver.TestingAPIHandlerWithEntity(c, s.StatePool, s.State, u)
 	defer handler.Kill()
 
 	apiserver.AssertHasPermission(c, handler, permission.LoginAccess, ctag, true)
@@ -497,7 +481,7 @@ func (s *serverSuite) TestAPIHandlerHasPermissionAddmodel(c *gc.C) {
 	u, ctag := s.bootstrapHasPermissionTest(c)
 	user := u.UserTag()
 
-	handler, _ := apiserver.TestingAPIHandlerWithEntity(c, s.pool, s.State, u)
+	handler, _ := apiserver.TestingAPIHandlerWithEntity(c, s.StatePool, s.State, u)
 	defer handler.Kill()
 
 	ua, err := s.State.SetUserAccess(user, ctag, permission.AddModelAccess)
@@ -513,7 +497,7 @@ func (s *serverSuite) TestAPIHandlerHasPermissionSuperUser(c *gc.C) {
 	u, ctag := s.bootstrapHasPermissionTest(c)
 	user := u.UserTag()
 
-	handler, _ := apiserver.TestingAPIHandlerWithEntity(c, s.pool, s.State, u)
+	handler, _ := apiserver.TestingAPIHandlerWithEntity(c, s.StatePool, s.State, u)
 	defer handler.Kill()
 
 	ua, err := s.State.SetUserAccess(user, ctag, permission.SuperuserAccess)
@@ -538,17 +522,15 @@ func (s *serverSuite) TestAPIHandlerTeardownOtherEnviron(c *gc.C) {
 func (s *serverSuite) TestAPIHandlerConnectedModel(c *gc.C) {
 	otherState := s.Factory.MakeModel(c, nil)
 	defer otherState.Close()
-	handler, _ := apiserver.TestingAPIHandler(c, s.pool, otherState)
+	handler, _ := apiserver.TestingAPIHandler(c, s.StatePool, otherState)
 	defer handler.Kill()
 	c.Check(handler.ConnectedModel(), gc.Equals, otherState.ModelUUID())
 }
 
 func (s *serverSuite) TestClosesStateFromPool(c *gc.C) {
 	coretesting.SkipFlaky(c, "lp:1702215")
-	pool := state.NewStatePool(s.State)
-	defer pool.Close()
 	cfg := defaultServerConfig(c)
-	_, server := newServerWithConfig(c, pool, cfg)
+	_, server := newServerWithConfig(c, s.StatePool, cfg)
 	defer assertStop(c, server)
 
 	w := s.State.WatchModels()
@@ -571,7 +553,7 @@ func (s *serverSuite) TestClosesStateFromPool(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Ensure the model's in the pool but not referenced.
-	st, releaser, err := pool.Get(otherState.ModelUUID())
+	st, releaser, err := s.StatePool.Get(otherState.ModelUUID())
 	c.Assert(err, jc.ErrorIsNil)
 	releaser()
 
@@ -618,7 +600,7 @@ func assertStateBecomesClosed(c *gc.C, st *state.State) {
 }
 
 func (s *serverSuite) checkAPIHandlerTeardown(c *gc.C, srvSt, st *state.State) {
-	handler, resources := apiserver.TestingAPIHandler(c, s.pool, st)
+	handler, resources := apiserver.TestingAPIHandler(c, s.StatePool, st)
 	resource := new(fakeResource)
 	resources.Register(resource)
 

--- a/apiserver/utils_test.go
+++ b/apiserver/utils_test.go
@@ -7,27 +7,23 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
-	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/testing"
 )
 
 type utilsSuite struct {
 	testing.StateSuite
-	pool *state.StatePool
 }
 
 var _ = gc.Suite(&utilsSuite{})
 
 func (s *utilsSuite) SetUpTest(c *gc.C) {
 	s.StateSuite.SetUpTest(c)
-	s.pool = state.NewStatePool(s.State)
-	s.AddCleanup(func(*gc.C) { s.pool.Close() })
 }
 
 func (s *utilsSuite) TestValidateEmpty(c *gc.C) {
 	uuid, err := validateModelUUID(
 		validateArgs{
-			statePool: s.pool,
+			statePool: s.StatePool,
 		})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(uuid, gc.Equals, s.State.ModelUUID())
@@ -36,7 +32,7 @@ func (s *utilsSuite) TestValidateEmpty(c *gc.C) {
 func (s *utilsSuite) TestValidateEmptyStrict(c *gc.C) {
 	_, err := validateModelUUID(
 		validateArgs{
-			statePool: s.pool,
+			statePool: s.StatePool,
 			strict:    true,
 		})
 	c.Assert(err, gc.ErrorMatches, `unknown model: ""`)
@@ -45,7 +41,7 @@ func (s *utilsSuite) TestValidateEmptyStrict(c *gc.C) {
 func (s *utilsSuite) TestValidateController(c *gc.C) {
 	uuid, err := validateModelUUID(
 		validateArgs{
-			statePool: s.pool,
+			statePool: s.StatePool,
 			modelUUID: s.State.ModelUUID(),
 		})
 	c.Assert(err, jc.ErrorIsNil)
@@ -55,7 +51,7 @@ func (s *utilsSuite) TestValidateController(c *gc.C) {
 func (s *utilsSuite) TestValidateControllerStrict(c *gc.C) {
 	uuid, err := validateModelUUID(
 		validateArgs{
-			statePool: s.pool,
+			statePool: s.StatePool,
 			modelUUID: s.State.ModelUUID(),
 			strict:    true,
 		})
@@ -66,7 +62,7 @@ func (s *utilsSuite) TestValidateControllerStrict(c *gc.C) {
 func (s *utilsSuite) TestValidateBadModelUUID(c *gc.C) {
 	_, err := validateModelUUID(
 		validateArgs{
-			statePool: s.pool,
+			statePool: s.StatePool,
 			modelUUID: "bad",
 		})
 	c.Assert(err, gc.ErrorMatches, `unknown model: "bad"`)
@@ -78,7 +74,7 @@ func (s *utilsSuite) TestValidateOtherModel(c *gc.C) {
 
 	uuid, err := validateModelUUID(
 		validateArgs{
-			statePool: s.pool,
+			statePool: s.StatePool,
 			modelUUID: envState.ModelUUID(),
 		})
 	c.Assert(err, jc.ErrorIsNil)
@@ -91,7 +87,7 @@ func (s *utilsSuite) TestValidateOtherModelControllerOnly(c *gc.C) {
 
 	_, err := validateModelUUID(
 		validateArgs{
-			statePool:           s.pool,
+			statePool:           s.StatePool,
 			modelUUID:           envState.ModelUUID(),
 			controllerModelOnly: true,
 		})

--- a/state/pool_test.go
+++ b/state/pool_test.go
@@ -35,27 +35,24 @@ func (s *statePoolSuite) SetUpTest(c *gc.C) {
 	s.State2 = s.Factory.MakeModel(c, nil)
 	s.AddCleanup(func(*gc.C) { s.State2.Close() })
 	s.ModelUUID2 = s.State2.ModelUUID()
-
-	s.Pool = state.NewStatePool(s.State)
-	s.AddCleanup(func(*gc.C) { s.Pool.Close() })
 }
 
 func (s *statePoolSuite) TestGet(c *gc.C) {
-	st1, _, err := s.Pool.Get(s.ModelUUID1)
+	st1, _, err := s.StatePool.Get(s.ModelUUID1)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(st1.ModelUUID(), gc.Equals, s.ModelUUID1)
 
-	st2, _, err := s.Pool.Get(s.ModelUUID2)
+	st2, _, err := s.StatePool.Get(s.ModelUUID2)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(st2.ModelUUID(), gc.Equals, s.ModelUUID2)
 
 	// Check that the same instances are returned
 	// when a State for the same model is re-requested.
-	st1_, _, err := s.Pool.Get(s.ModelUUID1)
+	st1_, _, err := s.StatePool.Get(s.ModelUUID1)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(st1_, gc.Equals, st1)
 
-	st2_, _, err := s.Pool.Get(s.ModelUUID2)
+	st2_, _, err := s.StatePool.Get(s.ModelUUID2)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(st2_, gc.Equals, st2)
 }
@@ -63,31 +60,31 @@ func (s *statePoolSuite) TestGet(c *gc.C) {
 func (s *statePoolSuite) TestGetWithControllerModel(c *gc.C) {
 	// When a State for the controller model is requested, the same
 	// State that was original passed in should be returned.
-	st0, _, err := s.Pool.Get(s.ModelUUID)
+	st0, _, err := s.StatePool.Get(s.ModelUUID)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(st0, gc.Equals, s.State)
 }
 
 func (s *statePoolSuite) TestGetSystemState(c *gc.C) {
-	st0 := s.Pool.SystemState()
+	st0 := s.StatePool.SystemState()
 	c.Assert(st0, gc.Equals, s.State)
 }
 
 func (s *statePoolSuite) TestKillWorkers(c *gc.C) {
 	// Get some State instances via the pool and extract their
 	// internal workers.
-	st1, _, err := s.Pool.Get(s.ModelUUID1)
+	st1, _, err := s.StatePool.Get(s.ModelUUID1)
 	c.Assert(err, jc.ErrorIsNil)
 	w1 := state.GetInternalWorkers(st1)
 	workertest.CheckAlive(c, w1)
 
-	st2, _, err := s.Pool.Get(s.ModelUUID2)
+	st2, _, err := s.StatePool.Get(s.ModelUUID2)
 	c.Assert(err, jc.ErrorIsNil)
 	w2 := state.GetInternalWorkers(st2)
 	workertest.CheckAlive(c, w2)
 
 	// Now kill their workers.
-	s.Pool.KillWorkers()
+	s.StatePool.KillWorkers()
 
 	// Ensure the internal workers for each State died.
 	c.Check(workertest.CheckKilled(c, w1), jc.ErrorIsNil)
@@ -96,14 +93,14 @@ func (s *statePoolSuite) TestKillWorkers(c *gc.C) {
 
 func (s *statePoolSuite) TestClose(c *gc.C) {
 	// Get some State instances.
-	st1, _, err := s.Pool.Get(s.ModelUUID1)
+	st1, _, err := s.StatePool.Get(s.ModelUUID1)
 	c.Assert(err, jc.ErrorIsNil)
 
-	st2, _, err := s.Pool.Get(s.ModelUUID2)
+	st2, _, err := s.StatePool.Get(s.ModelUUID2)
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Now close them.
-	err = s.Pool.Close()
+	err = s.StatePool.Close()
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Confirm that controller State isn't closed.
@@ -112,27 +109,27 @@ func (s *statePoolSuite) TestClose(c *gc.C) {
 
 	// Ensure that new ones are returned if further States are
 	// requested.
-	st1_, _, err := s.Pool.Get(s.ModelUUID1)
+	st1_, _, err := s.StatePool.Get(s.ModelUUID1)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(st1_, gc.Not(gc.Equals), st1)
 
-	st2_, _, err := s.Pool.Get(s.ModelUUID2)
+	st2_, _, err := s.StatePool.Get(s.ModelUUID2)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(st2_, gc.Not(gc.Equals), st2)
 }
 
 func (s *statePoolSuite) TestTooManyReleases(c *gc.C) {
-	st, firstRelease, err := s.Pool.Get(s.ModelUUID1)
+	st, firstRelease, err := s.StatePool.Get(s.ModelUUID1)
 	c.Assert(err, jc.ErrorIsNil)
 	// Get a second reference to the same model
-	_, secondRelease, err := s.Pool.Get(s.ModelUUID1)
+	_, secondRelease, err := s.StatePool.Get(s.ModelUUID1)
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Try to call the first releaser twice.
 	firstRelease()
 	firstRelease()
 
-	removed, err := s.Pool.Remove(s.ModelUUID1)
+	removed, err := s.StatePool.Remove(s.ModelUUID1)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(removed, jc.IsFalse)
 
@@ -145,7 +142,7 @@ func (s *statePoolSuite) TestTooManyReleases(c *gc.C) {
 }
 
 func (s *statePoolSuite) TestReleaseOnSystemStateUUID(c *gc.C) {
-	st, releaser, err := s.Pool.Get(s.ModelUUID)
+	st, releaser, err := s.StatePool.Get(s.ModelUUID)
 	c.Assert(err, jc.ErrorIsNil)
 	removed := releaser()
 	c.Assert(removed, jc.IsFalse)
@@ -153,7 +150,7 @@ func (s *statePoolSuite) TestReleaseOnSystemStateUUID(c *gc.C) {
 }
 
 func (s *statePoolSuite) TestRemoveSystemStateUUID(c *gc.C) {
-	removed, err := s.Pool.Remove(s.ModelUUID)
+	removed, err := s.StatePool.Remove(s.ModelUUID)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(removed, jc.IsFalse)
 	assertNotClosed(c, s.State)
@@ -170,7 +167,7 @@ func assertClosed(c *gc.C, st *state.State) {
 }
 
 func (s *statePoolSuite) TestRemoveWithNoRefsCloses(c *gc.C) {
-	st, releaser, err := s.Pool.Get(s.ModelUUID1)
+	st, releaser, err := s.StatePool.Get(s.ModelUUID1)
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Confirm the state isn't closed.
@@ -178,7 +175,7 @@ func (s *statePoolSuite) TestRemoveWithNoRefsCloses(c *gc.C) {
 	c.Assert(removed, jc.IsFalse)
 	assertNotClosed(c, st)
 
-	removed, err = s.Pool.Remove(s.ModelUUID1)
+	removed, err = s.StatePool.Remove(s.ModelUUID1)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(removed, jc.IsTrue)
 
@@ -186,16 +183,16 @@ func (s *statePoolSuite) TestRemoveWithNoRefsCloses(c *gc.C) {
 }
 
 func (s *statePoolSuite) TestRemoveWithRefsClosesOnLastRelease(c *gc.C) {
-	st, firstRelease, err := s.Pool.Get(s.ModelUUID1)
+	st, firstRelease, err := s.StatePool.Get(s.ModelUUID1)
 	c.Assert(err, jc.ErrorIsNil)
-	_, secondRelease, err := s.Pool.Get(s.ModelUUID1)
+	_, secondRelease, err := s.StatePool.Get(s.ModelUUID1)
 	c.Assert(err, jc.ErrorIsNil)
 	// Now there are two references to the state.
 	// Sanity check!
 	assertNotClosed(c, st)
 
 	// Doesn't close while there are refs still held.
-	removed, err := s.Pool.Remove(s.ModelUUID1)
+	removed, err := s.StatePool.Remove(s.ModelUUID1)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(removed, jc.IsFalse)
 	assertNotClosed(c, st)
@@ -212,11 +209,11 @@ func (s *statePoolSuite) TestRemoveWithRefsClosesOnLastRelease(c *gc.C) {
 }
 
 func (s *statePoolSuite) TestGetRemovedNotAllowed(c *gc.C) {
-	_, _, err := s.Pool.Get(s.ModelUUID1)
+	_, _, err := s.StatePool.Get(s.ModelUUID1)
 	c.Assert(err, jc.ErrorIsNil)
-	_, err = s.Pool.Remove(s.ModelUUID1)
+	_, err = s.StatePool.Remove(s.ModelUUID1)
 	c.Assert(err, jc.ErrorIsNil)
-	_, _, err = s.Pool.Get(s.ModelUUID1)
+	_, _, err = s.StatePool.Get(s.ModelUUID1)
 	c.Assert(err, gc.ErrorMatches, fmt.Sprintf("model %v has been removed", s.ModelUUID1))
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 }

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -257,9 +257,7 @@ func (s *StateSuite) TestWatchAllModels(c *gc.C) {
 	// The allModelWatcher infrastructure is comprehensively tested
 	// elsewhere. This just ensures things are hooked up correctly in
 	// State.WatchAllModels()
-	pool := state.NewStatePool(s.State)
-	defer pool.Close()
-	w := s.State.WatchAllModels(pool)
+	w := s.State.WatchAllModels(s.StatePool)
 	defer w.Stop()
 	deltasC := makeMultiwatcherOutput(w)
 

--- a/state/testing/suite.go
+++ b/state/testing/suite.go
@@ -25,6 +25,7 @@ type StateSuite struct {
 	testing.BaseSuite
 	NewPolicy                 state.NewPolicyFunc
 	State                     *state.State
+	StatePool                 *state.StatePool
 	Owner                     names.UserTag
 	Factory                   *factory.Factory
 	InitialConfig             *config.Config
@@ -59,6 +60,8 @@ func (s *StateSuite) SetUpTest(c *gc.C) {
 		Clock:                     s.Clock,
 	})
 	s.AddCleanup(func(*gc.C) { s.State.Close() })
+	s.StatePool = state.NewStatePool(s.State)
+	s.AddCleanup(func(*gc.C) { s.StatePool.Close() })
 	s.Factory = factory.NewFactory(s.State)
 }
 


### PR DESCRIPTION
A backport of a 2.3 fix. Had to introduce some state pools into the base tests.