### PR TITLE
audit-log: Only capture API method args when asked

### DIFF
--- a/apiserver/admin.go
+++ b/apiserver/admin.go
@@ -142,7 +142,7 @@ func (a *admin) login(req params.LoginRequest, loginVersion int) (params.LoginRe
 	}
 
 	recorderFactory := observer.NewRecorderFactory(
-		a.apiObserver, auditRecorder)
+		a.srv.auditLogConfig.CaptureAPIArgs, a.apiObserver, auditRecorder)
 
 	a.root.rpcConn.ServeRoot(apiRoot, recorderFactory, serverError)
 	return params.LoginResult{

--- a/apiserver/admin.go
+++ b/apiserver/admin.go
@@ -142,7 +142,7 @@ func (a *admin) login(req params.LoginRequest, loginVersion int) (params.LoginRe
 	}
 
 	recorderFactory := observer.NewRecorderFactory(
-		a.srv.auditLogConfig.CaptureAPIArgs, a.apiObserver, auditRecorder)
+		a.apiObserver, auditRecorder, a.srv.auditLogConfig.CaptureAPIArgs)
 
 	a.root.rpcConn.ServeRoot(apiRoot, recorderFactory, serverError)
 	return params.LoginResult{

--- a/apiserver/apiserver.go
+++ b/apiserver/apiserver.go
@@ -827,7 +827,7 @@ func (srv *Server) serveConn(
 	host string,
 ) error {
 	codec := jsoncodec.NewWebsocket(wsConn.Conn)
-	recorderFactory := observer.NewRecorderFactory(apiObserver, nil)
+	recorderFactory := observer.NewRecorderFactory(false, apiObserver, nil)
 	conn := rpc.NewConn(codec, recorderFactory)
 
 	// Note that we don't overwrite modelUUID here because

--- a/apiserver/apiserver.go
+++ b/apiserver/apiserver.go
@@ -827,7 +827,8 @@ func (srv *Server) serveConn(
 	host string,
 ) error {
 	codec := jsoncodec.NewWebsocket(wsConn.Conn)
-	recorderFactory := observer.NewRecorderFactory(false, apiObserver, nil)
+	recorderFactory := observer.NewRecorderFactory(
+		apiObserver, nil, observer.NoCaptureArgs)
 	conn := rpc.NewConn(codec, recorderFactory)
 
 	// Note that we don't overwrite modelUUID here because

--- a/apiserver/observer/recorder.go
+++ b/apiserver/observer/recorder.go
@@ -12,20 +12,29 @@ import (
 	"github.com/juju/juju/rpc"
 )
 
+const (
+	// CaptureArgs means we'll serialize the API arguments and store
+	// them in the audit log.
+	CaptureArgs = true
+
+	// NoCaptureArgs means don't do that.
+	NoCaptureArgs = false
+)
+
 // NewRecorderFactory makes a new rpc.RecorderFactory to make
 // recorders that that will update the observer and the auditlog
 // recorder when it records a request or reply. The auditlog recorder
 // can be nil.
 func NewRecorderFactory(
-	captureArgs bool,
 	observerFactory rpc.ObserverFactory,
 	recorder *auditlog.Recorder,
+	captureArgs bool,
 ) rpc.RecorderFactory {
 	return func() rpc.Recorder {
 		return &combinedRecorder{
-			captureArgs: captureArgs,
 			observer:    observerFactory.RPCObserver(),
 			recorder:    recorder,
+			captureArgs: captureArgs,
 		}
 	}
 }
@@ -33,9 +42,9 @@ func NewRecorderFactory(
 // combinedRecorder wraps an observer (which might be a multiplexer)
 // up with an auditlog recorder into an rpc.Recorder.
 type combinedRecorder struct {
-	captureArgs bool
 	observer    rpc.Observer
 	recorder    *auditlog.Recorder
+	captureArgs bool
 }
 
 // HandleRequest implements rpc.Recorder.

--- a/apiserver/observer/recorder_test.go
+++ b/apiserver/observer/recorder_test.go
@@ -31,7 +31,7 @@ func (s *recorderSuite) TestServerRequest(c *gc.C) {
 		ConnectionID: 4567,
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	factory := observer.NewRecorderFactory(true, fake, auditRecorder)
+	factory := observer.NewRecorderFactory(fake, auditRecorder, observer.CaptureArgs)
 	recorder := factory()
 	hdr := &rpc.Header{
 		RequestId: 123,
@@ -70,7 +70,7 @@ func (s *recorderSuite) TestServerRequestNoArgs(c *gc.C) {
 		ConnectionID: 4567,
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	factory := observer.NewRecorderFactory(false, fake, auditRecorder)
+	factory := observer.NewRecorderFactory(fake, auditRecorder, observer.NoCaptureArgs)
 	recorder := factory()
 	hdr := &rpc.Header{
 		RequestId: 123,
@@ -103,7 +103,7 @@ func (s *recorderSuite) TestServerReply(c *gc.C) {
 		ConnectionID: 4567,
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	factory := observer.NewRecorderFactory(true, fake, auditRecorder)
+	factory := observer.NewRecorderFactory(fake, auditRecorder, observer.CaptureArgs)
 	recorder := factory()
 
 	req := rpc.Request{"Type", 5, "", "Action"}
@@ -132,7 +132,7 @@ func (s *recorderSuite) TestServerReply(c *gc.C) {
 
 func (s *recorderSuite) TestNoAuditRequest(c *gc.C) {
 	fake := &fakeobserver.Instance{}
-	factory := observer.NewRecorderFactory(false, fake, nil)
+	factory := observer.NewRecorderFactory(fake, nil, observer.NoCaptureArgs)
 	recorder := factory()
 	hdr := &rpc.Header{
 		RequestId: 123,
@@ -144,7 +144,7 @@ func (s *recorderSuite) TestNoAuditRequest(c *gc.C) {
 
 func (s *recorderSuite) TestNoAuditReply(c *gc.C) {
 	fake := &fakeobserver.Instance{}
-	factory := observer.NewRecorderFactory(false, fake, nil)
+	factory := observer.NewRecorderFactory(fake, nil, observer.NoCaptureArgs)
 	recorder := factory()
 	req := rpc.Request{"Type", 0, "", "Action"}
 	hdr := &rpc.Header{RequestId: 123}

--- a/apiserver/testing/fakeapi.go
+++ b/apiserver/testing/fakeapi.go
@@ -78,7 +78,8 @@ func (srv *Server) serveAPI(w http.ResponseWriter, req *http.Request) {
 
 func (srv *Server) serveConn(wsConn *websocket.Conn, modelUUID string) {
 	codec := jsoncodec.NewWebsocket(wsConn)
-	conn := rpc.NewConn(codec, observer.NewRecorderFactory(&fakeobserver.Instance{}, nil))
+	conn := rpc.NewConn(codec, observer.NewRecorderFactory(
+		false, &fakeobserver.Instance{}, nil))
 
 	root := allVersions{
 		rpcreflect.ValueOf(reflect.ValueOf(srv.newRoot(modelUUID))),

--- a/apiserver/testing/fakeapi.go
+++ b/apiserver/testing/fakeapi.go
@@ -79,7 +79,7 @@ func (srv *Server) serveAPI(w http.ResponseWriter, req *http.Request) {
 func (srv *Server) serveConn(wsConn *websocket.Conn, modelUUID string) {
 	codec := jsoncodec.NewWebsocket(wsConn)
 	conn := rpc.NewConn(codec, observer.NewRecorderFactory(
-		false, &fakeobserver.Instance{}, nil))
+		&fakeobserver.Instance{}, nil, observer.NoCaptureArgs))
 
 	root := allVersions{
 		rpcreflect.ValueOf(reflect.ValueOf(srv.newRoot(modelUUID))),


### PR DESCRIPTION
## Description of change

In general we don't think it will be necessary to save the API method arguments in the audit log (because people using it will be more interested in the client commands), and there's some risk of there being secrets in the log.  If `audit-log-capture-args=true` is specified in the controller config then we still capture them, but by default we don't.

## QA steps

Bootstrap with `--config="auditing-enabled=true"`. The `request` messages in the audit log don't include arguments for the API calls.

Bootstrap with `--config="auditing-enabled=true" --config="audit-log-capture-args=true"`. `request` messages include serialised JSON method parameters.
