### PR TITLE
audit-log: Walk reply structs to collect errors

### DIFF
--- a/apiserver/observer/recorder_test.go
+++ b/apiserver/observer/recorder_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/juju/juju/apiserver/observer"
 	"github.com/juju/juju/apiserver/observer/fakeobserver"
+	"github.com/juju/juju/apiserver/params"
 	apitesting "github.com/juju/juju/apiserver/testing"
 	"github.com/juju/juju/core/auditlog"
 	"github.com/juju/juju/rpc"
@@ -127,6 +128,102 @@ func (s *recorderSuite) TestServerReply(c *gc.C) {
 		RequestID:      123,
 		When:           clock.Now().Format(time.RFC3339),
 		Errors:         nil,
+	})
+}
+
+func (s *recorderSuite) TestReplyResultNotAStruct(c *gc.C) {
+	s.checkServerReplyErrors(c, 12345, nil)
+}
+
+func (s *recorderSuite) TestReplyResultNoErrorAttrs(c *gc.C) {
+	s.checkServerReplyErrors(c,
+		params.ApplicationCharmRelationsResults{
+			CharmRelations: []string{"abc", "123"},
+		},
+		nil,
+	)
+}
+
+func (s *recorderSuite) TestReplyResultErrorSlice(c *gc.C) {
+	s.checkServerReplyErrors(c,
+		params.ErrorResults{
+			Results: []params.ErrorResult{{
+				Error: &params.Error{
+					Message: "antiphon",
+					Code:    "midlake",
+				},
+			}, {
+				Error: nil,
+			}},
+		},
+		[]*auditlog.Error{{
+			Message: "antiphon",
+			Code:    "midlake",
+		}, nil},
+	)
+}
+
+func (s *recorderSuite) TestReplyResultError(c *gc.C) {
+	s.checkServerReplyErrors(c,
+		params.ErrorResult{
+			Error: &params.Error{
+				Message: "antiphon",
+				Code:    "midlake",
+			},
+		},
+		[]*auditlog.Error{{
+			Message: "antiphon",
+			Code:    "midlake",
+		}},
+	)
+}
+
+func (s *recorderSuite) TestReplyResultSlice(c *gc.C) {
+	s.checkServerReplyErrors(c,
+		params.AddMachinesResults{
+			Machines: []params.AddMachinesResult{{
+				Machine: "some-machine",
+			}, {
+				Error: &params.Error{
+					Message: "something bad",
+					Code:    "fall-down-go-boom",
+					Info:    &params.ErrorInfo{MacaroonPath: "somewhere"},
+				},
+			}},
+		},
+		[]*auditlog.Error{nil, {
+			Message: "something bad",
+			Code:    "fall-down-go-boom",
+		}},
+	)
+}
+
+func (s *recorderSuite) checkServerReplyErrors(c *gc.C, result interface{}, expected []*auditlog.Error) {
+	fake := &fakeobserver.Instance{}
+	log := &apitesting.FakeAuditLog{}
+	clock := testing.NewClock(time.Now())
+	auditRecorder, err := auditlog.NewRecorder(log, clock, auditlog.ConversationArgs{
+		ConnectionID: 4567,
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	factory := observer.NewRecorderFactory(fake, auditRecorder, observer.CaptureArgs)
+	recorder := factory()
+
+	req := rpc.Request{"Type", 5, "", "Action"}
+	hdr := &rpc.Header{RequestId: 123}
+	err = recorder.HandleReply(req, hdr, result)
+	c.Assert(err, jc.ErrorIsNil)
+
+	log.CheckCallNames(c, "AddConversation", "AddResponse")
+
+	respErrors := log.Calls()[1].Args[0].(auditlog.ResponseErrors)
+	c.Assert(respErrors.ConversationID, gc.HasLen, 16)
+	respErrors.ConversationID = ""
+	c.Assert(respErrors, gc.DeepEquals, auditlog.ResponseErrors{
+		ConnectionID: "11D7",
+		RequestID:    123,
+		When:         clock.Now().Format(time.RFC3339),
+		Errors:       expected,
 	})
 }
 


### PR DESCRIPTION
## Description of change
We want to be able to reflect any errors from API methods in the audit log. Since the responses could have any number of errors, we collect them from the response by looking for `*Error` attributes or slices of result objects with `*Error` attributes.

## QA steps
Bootstrap a controller with auditing enabled. Deploy 2 units of ubuntu. Then run `juju remove-unit ubuntu/3 ubuntu/1 ubuntu/2`. In the audit log you should see the conversation with the `remove-unit` command, the corresponding `Application.DestroyUnit` method call, and the error response with:
```
[{"message":"unit \"ubuntu/3" does not exist","code":""},null,{"message":"unit \"ubuntu/2\" does not exist","code":""}]]
```
The null in the middle corresponds to the successful removal of ubuntu/1.