### PR TITLE
Fix model representation for bundle deployments.

### DIFF
--- a/cmd/juju/application/bundle.go
+++ b/cmd/juju/application/bundle.go
@@ -1330,11 +1330,14 @@ func buildModelRepresentation(
 				Machine: unit.Machine,
 			})
 		}
-		// TODO: application constraints
 		applications[name] = application
 		annotationTags = append(annotationTags, names.NewApplicationTag(name).String())
 		appNames = append(appNames, name)
-		if len(appStatus.SubordinateTo) == 0 {
+		if len(appStatus.Units) > 0 {
+			// While this isn't entirely accurate, because an application
+			// without any units is still a principal, it is less bad than
+			// just using 'SubordinateTo' as a subordinate charm that isn't
+			// related to anything has that empty too.
 			principalApps = append(principalApps, name)
 		}
 	}

--- a/testing/factory/factory.go
+++ b/testing/factory/factory.go
@@ -489,13 +489,16 @@ func (factory *Factory) MakeUnitReturningPassword(c *gc.C, params *UnitParams) (
 	if params == nil {
 		params = &UnitParams{}
 	}
-	if params.Machine == nil {
-		params.Machine = factory.MakeMachine(c, nil)
-	}
 	if params.Application == nil {
 		params.Application = factory.MakeApplication(c, &ApplicationParams{
 			Constraints: params.Constraints,
 		})
+	}
+	if params.Machine == nil {
+		mParams := MachineParams{
+			Series: params.Application.Series(),
+		}
+		params.Machine = factory.MakeMachine(c, &mParams)
 	}
 	if params.Password == "" {
 		var err error


### PR DESCRIPTION
If there was a subordinate application that wasn't related to anything, the client would try to get application constraints for it, and error out.

## QA steps

Deploy a subordinate application to a model.
Use --dry-run on any bundle deploy.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1736592
