### PR TITLE
Don't expose a CAAS application if there is no external host name set

### DIFF
--- a/apiserver/facades/client/application/mock_test.go
+++ b/apiserver/facades/client/application/mock_test.go
@@ -184,6 +184,11 @@ func (a *mockApplication) UpdateCharmConfig(settings charm.Settings) error {
 	return a.NextErr()
 }
 
+func (a *mockApplication) SetExposed() error {
+	a.MethodCall(a, "SetExposed")
+	return a.NextErr()
+}
+
 type mockRemoteApplication struct {
 	jtesting.Stub
 	name           string


### PR DESCRIPTION
## Description of change

When exposing a CAAS application, you need to ensure the juju-external-hostname config attribute is set.

## QA steps

Try and expose an app without setting the juju-external-hostname -> error.

