### PR TITLE
Backport 2.4 fixes

### DIFF
--- a/api/application/client.go
+++ b/api/application/client.go
@@ -78,6 +78,10 @@ type DeployArgs struct {
 	// ConfigYAML is a string that overrides the default config.yml.
 	ConfigYAML string
 
+	// Config are values that override those in the default config.yaml
+	// or configure the application itself.
+	Config map[string]string
+
 	// Cons contains constraints on where units of this application
 	// may be placed.
 	Cons constraints.Value
@@ -131,6 +135,7 @@ func (c *Client) Deploy(args DeployArgs) error {
 			Channel:          string(args.CharmID.Channel),
 			NumUnits:         args.NumUnits,
 			ConfigYAML:       args.ConfigYAML,
+			Config:           args.Config,
 			Constraints:      args.Cons,
 			Placement:        args.Placement,
 			Storage:          args.Storage,

--- a/api/application/client_test.go
+++ b/api/application/client_test.go
@@ -92,6 +92,7 @@ func (s *applicationSuite) TestDeploy(c *gc.C) {
 				c.Assert(app.Series, gc.Equals, "series")
 				c.Assert(app.NumUnits, gc.Equals, 1)
 				c.Assert(app.ConfigYAML, gc.Equals, "configYAML")
+				c.Assert(app.Config, gc.DeepEquals, map[string]string{"foo": "bar"})
 				c.Assert(app.Constraints, gc.DeepEquals, constraints.MustParse("mem=4G"))
 				c.Assert(app.Placement, gc.DeepEquals, []*instance.Placement{{"scope", "directive"}})
 				c.Assert(app.EndpointBindings, gc.DeepEquals, map[string]string{"foo": "bar"})
@@ -115,6 +116,7 @@ func (s *applicationSuite) TestDeploy(c *gc.C) {
 		Series:           "series",
 		NumUnits:         1,
 		ConfigYAML:       "configYAML",
+		Config:           map[string]string{"foo": "bar"},
 		Cons:             constraints.MustParse("mem=4G"),
 		Placement:        []*instance.Placement{{"scope", "directive"}},
 		Storage:          map[string]storage.Constraints{"data": storage.Constraints{Pool: "pool"}},

--- a/cloud/personalclouds.go
+++ b/cloud/personalclouds.go
@@ -46,7 +46,7 @@ func ParseCloudMetadataFile(file string) (map[string]Cloud, error) {
 	return clouds, err
 }
 
-// WritePersonalCloudMetadata marshals to YAMl and writes the cloud metadata
+// WritePersonalCloudMetadata marshals to YAML and writes the cloud metadata
 // to the personal cloud file.
 func WritePersonalCloudMetadata(cloudsMap map[string]Cloud) error {
 	data, err := marshalCloudMetadata(cloudsMap)

--- a/cmd/juju/application/cmd_test.go
+++ b/cmd/juju/application/cmd_test.go
@@ -4,6 +4,8 @@
 package application
 
 import (
+	"path/filepath"
+
 	"github.com/juju/cmd/cmdtesting"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
@@ -86,7 +88,13 @@ func (s *CmdSuite) TestDeployCommandInit(c *gc.C) {
 		c.Assert(deployCmd.ApplicationName, gc.Equals, t.expectApplicationName)
 		c.Assert(deployCmd.CharmOrBundle, gc.Equals, t.expectCharmOrBundle)
 		c.Assert(deployCmd.NumUnits, gc.Equals, t.expectNumUnits)
-		c.Assert(deployCmd.Config.Path, gc.Equals, t.expectConfigFile)
+		if t.expectConfigFile != "" {
+			ctx := cmdtesting.Context(c)
+			absFiles, err := deployCmd.ConfigOptions.AbsoluteFileNames(ctx)
+			c.Check(err, jc.ErrorIsNil)
+			c.Check(absFiles, gc.HasLen, 1)
+			c.Assert(absFiles[0], gc.Equals, filepath.Join(ctx.Dir, t.expectConfigFile))
+		}
 	}
 }
 

--- a/cmd/juju/application/deploy.go
+++ b/cmd/juju/application/deploy.go
@@ -5,6 +5,7 @@ package application
 
 import (
 	"archive/zip"
+	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -20,6 +21,7 @@ import (
 	"gopkg.in/juju/names.v2"
 	"gopkg.in/macaroon-bakery.v1/httpbakery"
 	"gopkg.in/macaroon.v1"
+	"gopkg.in/yaml.v2"
 
 	"github.com/juju/juju/api"
 	"github.com/juju/juju/api/annotations"
@@ -54,7 +56,7 @@ type ApplicationAPI interface {
 	GetAnnotations(tags []string) ([]apiparams.AnnotationsGetResult, error)
 	GetConfig(appNames ...string) ([]map[string]interface{}, error)
 	GetConstraints(appNames ...string) ([]constraints.Value, error)
-	GetCharmURL(serviceName string) (*charm.URL, error)
+	GetCharmURL(applicationName string) (*charm.URL, error)
 	SetAnnotation(annotations map[string]map[string]string) ([]apiparams.ErrorResult, error)
 	SetCharm(application.SetCharmConfig) error
 	SetConstraints(application string, constraints constraints.Value) error
@@ -70,7 +72,7 @@ type ModelAPI interface {
 // command needs for metered charms.
 type MeteredDeployAPI interface {
 	IsMetered(charmURL string) (bool, error)
-	SetMetricCredentials(service string, credentials []byte) error
+	SetMetricCredentials(application string, credentials []byte) error
 }
 
 // DeployAPI represents the methods of the API the deploy
@@ -186,7 +188,7 @@ func (a *deployAPIAdapter) GetAnnotations(tags []string) ([]apiparams.Annotation
 	return a.annotationsClient.Get(tags)
 }
 
-// NewDeployCommandForTest returns a command to deploy services inteded to be used only in tests.
+// NewDeployCommandForTest returns a command to deploy applications inteded to be used only in tests.
 func NewDeployCommandForTest(newAPIRoot func() (DeployAPI, error), steps []DeployStep) modelcmd.ModelCommand {
 	deployCmd := &DeployCommand{
 		Steps:      steps,
@@ -219,7 +221,7 @@ func NewDeployCommandForTest(newAPIRoot func() (DeployAPI, error), steps []Deplo
 	return modelcmd.Wrap(deployCmd)
 }
 
-// NewDeployCommand returns a command to deploy services.
+// NewDeployCommand returns a command to deploy applications.
 func NewDeployCommand() modelcmd.ModelCommand {
 	steps := []DeployStep{
 		&RegisterMeteredCharm{
@@ -284,7 +286,7 @@ type DeployCommand struct {
 	DryRun bool
 
 	ApplicationName string
-	Config          cmd.FileVar
+	ConfigOptions   common.ConfigFlag
 	ConstraintsStr  string
 	Constraints     constraints.Value
 	BindToSpaces    string
@@ -533,13 +535,14 @@ var (
 )
 
 func (c *DeployCommand) SetFlags(f *gnuflag.FlagSet) {
+	c.ConfigOptions.SetPreserveStringValue(true)
 	// Keep above charmOnlyFlags and bundleOnlyFlags lists updated when adding
 	// new flags.
 	c.UnitCommandBase.SetFlags(f)
 	c.ModelCommandBase.SetFlags(f)
 	f.IntVar(&c.NumUnits, "n", 1, "Number of application units to deploy for principal charms")
 	f.StringVar((*string)(&c.Channel), "channel", "", "Channel to use when getting the charm or bundle from the charm store")
-	f.Var(&c.Config, "config", "Either a path to yaml-formatted application config file or a key=value pair ")
+	f.Var(&c.ConfigOptions, "config", "Either a path to yaml-formatted application config file or a key=value pair ")
 	f.Var(cmd.NewAppendStringsValue(&c.BundleOverlayFile), "overlay", "Bundles to overlay on the primary bundle, applied in order")
 	f.StringVar(&c.ConstraintsStr, "constraints", "", "Set application constraints")
 	f.StringVar(&c.Series, "series", "", "The series on which to deploy")
@@ -688,13 +691,63 @@ func (c *DeployCommand) deployCharm(
 			return errors.New("cannot use --num-units or --to with subordinate application")
 		}
 	}
-	serviceName := c.ApplicationName
-	if serviceName == "" {
-		serviceName = charmInfo.Meta.Name
+	applicationName := c.ApplicationName
+	if applicationName == "" {
+		applicationName = charmInfo.Meta.Name
 	}
+
+	// Process the --config args.
+	// We may have a single file arg specified, in which case
+	// it points to a YAML file keyed on the charm name and
+	// containing values for any charm settings.
+	// We may also have key/value pairs representing
+	// charm settings which overrides anything in the YAML file.
+	// If more than one file is specified, that is an error.
 	var configYAML []byte
-	if c.Config.Path != "" {
-		configYAML, err = c.Config.Read(ctx)
+	files, err := c.ConfigOptions.AbsoluteFileNames(ctx)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	if len(files) > 1 {
+		return errors.Errorf("only a single config YAML file can be specified, got %d", len(files))
+	}
+	if len(files) == 1 {
+		configYAML, err = ioutil.ReadFile(files[0])
+		if err != nil {
+			return errors.Trace(err)
+		}
+	}
+	attr, err := c.ConfigOptions.ReadConfigPairs(ctx)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	appConfig := make(map[string]string)
+	for k, v := range attr {
+		appConfig[k] = v.(string)
+	}
+
+	// Application facade V5 expects charm config to either all be in YAML
+	// or config map. If config map is specified, that overrides YAML.
+	// So we need to combine the two here to have only one.
+	if apiRoot.BestFacadeVersion("Application") < 6 && len(appConfig) > 0 {
+		var configFromFile map[string]map[string]string
+		err := yaml.Unmarshal(configYAML, &configFromFile)
+		if err != nil {
+			return errors.Annotate(err, "badly formatted YAML config file")
+		}
+		if configFromFile == nil {
+			configFromFile = make(map[string]map[string]string)
+		}
+		charmSettings, ok := configFromFile[applicationName]
+		if !ok {
+			charmSettings = make(map[string]string)
+		}
+		for k, v := range appConfig {
+			charmSettings[k] = v
+		}
+		appConfig = nil
+		configFromFile[applicationName] = charmSettings
+		configYAML, err = yaml.Marshal(configFromFile)
 		if err != nil {
 			return errors.Trace(err)
 		}
@@ -712,7 +765,7 @@ func (c *DeployCommand) deployCharm(
 
 	deployInfo := DeploymentInfo{
 		CharmID:         id,
-		ApplicationName: serviceName,
+		ApplicationName: applicationName,
 		ModelUUID:       uuid,
 		CharmInfo:       charmInfo,
 	}
@@ -739,7 +792,7 @@ func (c *DeployCommand) deployCharm(
 	}
 
 	ids, err := resourceadapters.DeployResources(
-		serviceName,
+		applicationName,
 		id,
 		csMac,
 		c.Resources,
@@ -750,10 +803,10 @@ func (c *DeployCommand) deployCharm(
 		return errors.Trace(err)
 	}
 
-	return errors.Trace(apiRoot.Deploy(application.DeployArgs{
+	args := application.DeployArgs{
 		CharmID:          id,
 		Cons:             c.Constraints,
-		ApplicationName:  serviceName,
+		ApplicationName:  applicationName,
 		Series:           series,
 		NumUnits:         numUnits,
 		ConfigYAML:       string(configYAML),
@@ -762,7 +815,11 @@ func (c *DeployCommand) deployCharm(
 		AttachStorage:    c.AttachStorage,
 		Resources:        ids,
 		EndpointBindings: c.Bindings,
-	}))
+	}
+	if len(appConfig) > 0 {
+		args.Config = appConfig
+	}
+	return errors.Trace(apiRoot.Deploy(args))
 }
 
 const parseBindErrorPrefix = "--bind must be in the form '[<default-space>] [<endpoint-name>=<space> ...]'. "

--- a/cmd/juju/application/deploy_test.go
+++ b/cmd/juju/application/deploy_test.go
@@ -273,7 +273,7 @@ func (s *DeploySuite) TestSubordinateCharm(c *gc.C) {
 	s.AssertService(c, "logging", curl, 0, 0)
 }
 
-func (s *DeploySuite) TestConfig(c *gc.C) {
+func (s *DeploySuite) TestSingleConfigFile(c *gc.C) {
 	ch := testcharms.Repo.CharmArchivePath(s.CharmsPath, "multi-series")
 	path := setupConfigFile(c, c.MkDir())
 	err := runDeploy(c, ch, "dummy-application", "--config", path, "--series", "precise")
@@ -294,6 +294,42 @@ func (s *DeploySuite) TestRelativeConfigPath(c *gc.C) {
 	setupConfigFile(c, utils.Home())
 	err := runDeploy(c, ch, "dummy-application", "--config", "~/testconfig.yaml")
 	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *DeploySuite) TestConfigValues(c *gc.C) {
+	ch := testcharms.Repo.CharmArchivePath(s.CharmsPath, "multi-series")
+	err := runDeploy(c, ch, "dummy-application", "--config", "skill-level=9000", "--config", "outlook=good", "--series", "precise")
+	c.Assert(err, jc.ErrorIsNil)
+	application, err := s.State.Application("dummy-application")
+	c.Assert(err, jc.ErrorIsNil)
+	settings, err := application.ConfigSettings()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(settings, gc.DeepEquals, charm.Settings{
+		"outlook":     "good",
+		"skill-level": int64(9000),
+	})
+}
+
+func (s *DeploySuite) TestConfigValuesWithFile(c *gc.C) {
+	ch := testcharms.Repo.CharmArchivePath(s.CharmsPath, "multi-series")
+	path := setupConfigFile(c, c.MkDir())
+	err := runDeploy(c, ch, "dummy-application", "--config", path, "--config", "outlook=good", "--config", "skill-level=8000", "--series", "precise")
+	c.Assert(err, jc.ErrorIsNil)
+	application, err := s.State.Application("dummy-application")
+	c.Assert(err, jc.ErrorIsNil)
+	settings, err := application.ConfigSettings()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(settings, gc.DeepEquals, charm.Settings{
+		"outlook":     "good",
+		"skill-level": int64(8000),
+		"username":    "admin001",
+	})
+}
+
+func (s *DeploySuite) TestSingleConfigMoreThanOneFile(c *gc.C) {
+	ch := testcharms.Repo.CharmArchivePath(s.CharmsPath, "multi-series")
+	err := runDeploy(c, ch, "dummy-application", "--config", "one", "--config", "another", "--series", "precise")
+	c.Assert(err, gc.ErrorMatches, "only a single config YAML file can be specified, got 2")
 }
 
 func (s *DeploySuite) TestConfigError(c *gc.C) {
@@ -1511,7 +1547,7 @@ func (s *DeployUnitTestSuite) TestDeployAttachStorage(c *gc.C) {
 		"uuid": "deadbeef-0bad-400d-8000-4b1d0d06f00d",
 		"type": "foo",
 	})
-	fakeAPI.Call("BestFacadeVersion", "Application").Returns(5)
+
 	dummyURL := charm.MustParseURL("local:trusty/dummy-0")
 	withLocalCharmDeployable(fakeAPI, dummyURL, charmDir)
 	withCharmDeployable(
@@ -1637,6 +1673,9 @@ func (f *fakeDeployAPI) CharmInfo(url string) (*charms.CharmInfo, error) {
 
 func (f *fakeDeployAPI) Deploy(args application.DeployArgs) error {
 	results := f.MethodCall(f, "Deploy", args)
+	if len(results) != 1 {
+		return errors.Errorf("expected 1 result, got %d: %v", len(results), results)
+	}
 	return jujutesting.TypeAssertError(results[0])
 }
 
@@ -1725,6 +1764,7 @@ func vanillaFakeModelAPI(cfgAttrs map[string]interface{}) *fakeDeployAPI {
 	fakeAPI.Call("Close").Returns(error(nil))
 	fakeAPI.Call("ModelGet").Returns(cfgAttrs, error(nil))
 	fakeAPI.Call("ModelUUID").Returns("deadbeef-0bad-400d-8000-4b1d0d06f00d", true)
+	fakeAPI.Call("BestFacadeVersion", "Application").Returns(5)
 
 	return fakeAPI
 }

--- a/cmd/juju/common/flags.go
+++ b/cmd/juju/common/flags.go
@@ -19,8 +19,18 @@ import (
 // ConfigFlag records k=v attributes from command arguments
 // and/or specified files containing key values.
 type ConfigFlag struct {
-	files []string
-	attrs map[string]interface{}
+	files               []string
+	attrs               map[string]interface{}
+	preserveStringValue bool
+}
+
+// SetPreserveStringValue sets whether name values should be
+// converted to a type that is inferred from their
+// string value, by way of YAML unmarshalling,or kept as
+// the original string value. The default behaviour is to
+// apply YAML unmarshalling to the value.
+func (f *ConfigFlag) SetPreserveStringValue(val bool) {
+	f.preserveStringValue = val
 }
 
 // Set implements gnuflag.Value.Set.
@@ -34,8 +44,8 @@ func (f *ConfigFlag) Set(s string) error {
 		return nil
 	}
 	var value interface{}
-	if fields[1] == "" {
-		value = ""
+	if fields[1] == "" || f.preserveStringValue {
+		value = fields[1]
 	} else {
 		if err := yaml.Unmarshal([]byte(fields[1]), &value); err != nil {
 			return errors.Trace(err)
@@ -69,6 +79,28 @@ func (f *ConfigFlag) ReadAttrs(ctx *cmd.Context) (map[string]interface{}, error)
 		attrs[k] = v
 	}
 	return attrs, nil
+}
+
+// ReadConfigPairs returns just the k=v attributes.
+func (f *ConfigFlag) ReadConfigPairs(ctx *cmd.Context) (map[string]interface{}, error) {
+	attrs := make(map[string]interface{})
+	for k, v := range f.attrs {
+		attrs[k] = v
+	}
+	return attrs, nil
+}
+
+// AbsoluteFileNames returns the absolute path of any file names specified.
+func (f *ConfigFlag) AbsoluteFileNames(ctx *cmd.Context) ([]string, error) {
+	files := make([]string, len(f.files))
+	for i, f := range f.files {
+		path, err := utils.NormalizePath(f)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		files[i] = ctx.AbsPath(path)
+	}
+	return files, nil
 }
 
 // String implements gnuflag.Value.String.

--- a/state/migration_import.go
+++ b/state/migration_import.go
@@ -1100,10 +1100,24 @@ func (i *importer) relation(rel description.Relation) error {
 			Insert: relationDoc,
 		},
 	}
-	if rel.Status() != nil {
-		status := i.makeStatusDoc(rel.Status())
-		ops = append(ops, createStatusOp(i.im.mb, relationGlobalScope(rel.Id()), status))
+
+	var relStatusDoc statusDoc
+	relStatus := rel.Status()
+	if relStatus != nil {
+		relStatusDoc = i.makeStatusDoc(relStatus)
+	} else {
+		// Relations are marked as either
+		// joining or joined, depending on
+		// whether there are any units in scope.
+		relStatusDoc = statusDoc{
+			Status:  status.Joining,
+			Updated: time.Now().UnixNano(),
+		}
+		if relationDoc.UnitCount > 0 {
+			relStatusDoc.Status = status.Joined
+		}
 	}
+	ops = append(ops, createStatusOp(i.im.mb, relationGlobalScope(rel.Id()), relStatusDoc))
 
 	dbRelation := newRelation(i.st, relationDoc)
 	// Add an op that adds the relation scope document for each

--- a/state/migration_import_test.go
+++ b/state/migration_import_test.go
@@ -672,6 +672,8 @@ func (s *MigrationImportSuite) TestRelations(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	rel, err := s.State.AddRelation(eps...)
 	c.Assert(err, jc.ErrorIsNil)
+	err = rel.SetStatus(status.StatusInfo{Status: status.Joined})
+	c.Assert(err, jc.ErrorIsNil)
 	wordpress_0 := s.Factory.MakeUnit(c, &factory.UnitParams{Application: wordpress})
 
 	ru, err := rel.Unit(wordpress_0)
@@ -696,7 +698,7 @@ func (s *MigrationImportSuite) TestRelations(c *gc.C) {
 
 	relStatus, err := rels[0].Status()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(relStatus.Status, gc.Equals, status.Joining)
+	c.Assert(relStatus.Status, gc.Equals, status.Joined)
 
 	ru, err = rels[0].Unit(units[0])
 	c.Assert(err, jc.ErrorIsNil)
@@ -704,6 +706,57 @@ func (s *MigrationImportSuite) TestRelations(c *gc.C) {
 	settings, err := ru.Settings()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(settings.Map(), gc.DeepEquals, relSettings)
+}
+
+func (s *MigrationImportSuite) assertRelationsMissingStatus(c *gc.C, hasUnits bool) {
+	wordpress := state.AddTestingApplication(c, s.State, "wordpress", state.AddTestingCharm(c, s.State, "wordpress"))
+	state.AddTestingApplication(c, s.State, "mysql", state.AddTestingCharm(c, s.State, "mysql"))
+	eps, err := s.State.InferEndpoints("mysql", "wordpress")
+	c.Assert(err, jc.ErrorIsNil)
+	rel, err := s.State.AddRelation(eps...)
+	c.Assert(err, jc.ErrorIsNil)
+
+	if hasUnits {
+		wordpress_0 := s.Factory.MakeUnit(c, &factory.UnitParams{Application: wordpress})
+		ru, err := rel.Unit(wordpress_0)
+		c.Assert(err, jc.ErrorIsNil)
+		relSettings := map[string]interface{}{
+			"name": "wordpress/0",
+		}
+		err = ru.EnterScope(relSettings)
+		c.Assert(err, jc.ErrorIsNil)
+	}
+
+	_, newSt := s.importModel(c, func(desc map[string]interface{}) {
+		relations := desc["relations"].(map[interface{}]interface{})
+		for _, item := range relations["relations"].([]interface{}) {
+			relation := item.(map[interface{}]interface{})
+			delete(relation, "status")
+		}
+	})
+
+	newWordpress, err := newSt.Application("wordpress")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(state.RelationCount(newWordpress), gc.Equals, 1)
+	rels, err := newWordpress.Relations()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(rels, gc.HasLen, 1)
+
+	relStatus, err := rels[0].Status()
+	c.Assert(err, jc.ErrorIsNil)
+	if hasUnits {
+		c.Assert(relStatus.Status, gc.Equals, status.Joined)
+	} else {
+		c.Assert(relStatus.Status, gc.Equals, status.Joining)
+	}
+}
+
+func (s *MigrationImportSuite) TestRelationsMissingStatusWithUnits(c *gc.C) {
+	s.assertRelationsMissingStatus(c, true)
+}
+
+func (s *MigrationImportSuite) TestRelationsMissingStatusNoUnits(c *gc.C) {
+	s.assertRelationsMissingStatus(c, false)
 }
 
 func (s *MigrationImportSuite) TestEndpointBindings(c *gc.C) {


### PR DESCRIPTION
## Description of change

Backport 2 fixes:
https://github.com/juju/juju/pull/8206 which adds support for juju deploy --config name=value
https://github.com/juju/juju/pull/8227 which adds relation status on import if they are missing
