### PR TITLE
Handle unknown, uncared about series when adding applications.

### DIFF
--- a/state/state.go
+++ b/state/state.go
@@ -1110,7 +1110,9 @@ func (st *State) AddApplication(args AddApplicationArgs) (_ *Application, err er
 			for _, supportedSeries := range supportedSeries {
 				os, err := series.GetOSFromSeries(supportedSeries)
 				if err != nil {
-					return nil, errors.Trace(err)
+					// If we can't figure out a series written in the charm
+					// just skip it.
+					continue
 				}
 				supportedOperatingSystems[os] = true
 			}


### PR DESCRIPTION
When deploying an application that specifies support for a series that the client doesn't understand, when asking for a series that it does understand, will raise an error.

This is particularly hard to test because the local charm uploads always specify a series in the URL, and the charmstore code prevents uploading charms with series it doesn't understand.

The use case was deploying a charm that supported bionic with a version of juju that didn't inherintly know about bionic, and it had out of date distro-info-data.

## QA steps

There is no easy way to QA this.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1736207
