### PR TITLE
Add support for migrating applications with passwords

### DIFF
--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -22,7 +22,7 @@ github.com/juju/ansiterm	git	b99631de12cf04a906c1d4e4ec54fb86eae5863d	2016-09-07
 github.com/juju/blobstore	git	06056004b3d7b54bbb7984d830c537bad00fec21	2015-07-29T11:18:58Z
 github.com/juju/bundlechanges	git	0c5bf25fb942c29b84f53b8f741d64b8a6c8521f	2017-11-20T22:23:05Z
 github.com/juju/cmd	git	e74f39857ca013cf63947ba2843806f7afdd380d	2017-11-07T07:04:56Z
-github.com/juju/description	git	a270bd4612158eb6df123dc49e2b86fb85e63b7d	2017-12-14T20:57:08Z
+github.com/juju/description	git	7506fa6c5e06d45cc9e287fa6307fa204effe3fd	2017-12-15T03:52:04Z
 github.com/juju/errors	git	1b5e39b83d1835fa480e0c2ddefb040ee82d58b3	2015-09-16T12:56:42Z
 github.com/juju/gnuflag	git	2ce1bb71843d6d179b3f1c1c9cb4a72cd067fc65	2017-11-13T08:59:48Z
 github.com/juju/go-oracle-cloud	git	932a8cea00a1cd5cba3829a672c823955db674ae	2017-04-21T13:45:47Z

--- a/state/migration_export.go
+++ b/state/migration_export.go
@@ -692,6 +692,7 @@ func (e *exporter) addApplication(ctx addApplicationContext) error {
 		CharmModifiedVersion: application.doc.CharmModifiedVersion,
 		ForceCharm:           application.doc.ForceCharm,
 		Exposed:              application.doc.Exposed,
+		PasswordHash:         application.doc.PasswordHash,
 		MinUnits:             application.doc.MinUnits,
 		EndpointBindings:     map[string]string(ctx.endpoingBindings[globalKey]),
 		ApplicationConfig:    applicationConfigDoc.Settings,

--- a/state/migration_import.go
+++ b/state/migration_import.go
@@ -997,26 +997,27 @@ func (i *importer) importUnitPayloads(unit *Unit, payloads []description.Payload
 	return nil
 }
 
-func (i *importer) makeApplicationDoc(s description.Application) (*applicationDoc, error) {
-	charmURL, err := charm.ParseURL(s.CharmURL())
+func (i *importer) makeApplicationDoc(a description.Application) (*applicationDoc, error) {
+	charmURL, err := charm.ParseURL(a.CharmURL())
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
 
 	return &applicationDoc{
-		Name:                 s.Name(),
-		Series:               s.Series(),
-		Subordinate:          s.Subordinate(),
+		Name:                 a.Name(),
+		Series:               a.Series(),
+		Subordinate:          a.Subordinate(),
 		CharmURL:             charmURL,
-		Channel:              s.Channel(),
-		CharmModifiedVersion: s.CharmModifiedVersion(),
-		ForceCharm:           s.ForceCharm(),
+		Channel:              a.Channel(),
+		CharmModifiedVersion: a.CharmModifiedVersion(),
+		ForceCharm:           a.ForceCharm(),
+		PasswordHash:         a.PasswordHash(),
 		Life:                 Alive,
-		UnitCount:            len(s.Units()),
-		RelationCount:        i.relationCount(s.Name()),
-		Exposed:              s.Exposed(),
-		MinUnits:             s.MinUnits(),
-		MetricCredentials:    s.MetricsCredentials(),
+		UnitCount:            len(a.Units()),
+		RelationCount:        i.relationCount(a.Name()),
+		Exposed:              a.Exposed(),
+		MinUnits:             a.MinUnits(),
+		MetricCredentials:    a.MetricsCredentials(),
 	}, nil
 }
 

--- a/state/migration_import_test.go
+++ b/state/migration_import_test.go
@@ -422,7 +422,7 @@ func (s *MigrationImportSuite) TestApplications(c *gc.C) {
 		Name: "starsay", // it has resources
 	})
 	c.Assert(charm.Meta().Resources, gc.HasLen, 3)
-	application := s.Factory.MakeApplication(c, &factory.ApplicationParams{
+	application, pwd := s.Factory.MakeApplicationReturningPassword(c, &factory.ApplicationParams{
 		Charm: charm,
 		CharmConfig: map[string]interface{}{
 			"foo": "bar",
@@ -471,6 +471,7 @@ func (s *MigrationImportSuite) TestApplications(c *gc.C) {
 	c.Assert(imported.Series(), gc.Equals, exported.Series())
 	c.Assert(imported.IsExposed(), gc.Equals, exported.IsExposed())
 	c.Assert(imported.MetricCredentials(), jc.DeepEquals, exported.MetricCredentials())
+	c.Assert(imported.PasswordValid(pwd), jc.IsTrue)
 
 	exportedCharmConfig, err := exported.CharmConfig()
 	c.Assert(err, jc.ErrorIsNil)

--- a/state/migration_internal_test.go
+++ b/state/migration_internal_test.go
@@ -366,8 +366,6 @@ func (s *MigrationSuite) TestApplicationDocFields(c *gc.C) {
 		// RelationCount is handled by the number of times the application name
 		// appears in relation endpoints.
 		"RelationCount",
-		// TODO(caas) - add to export/import
-		"PasswordHash",
 	)
 	migrated := set.NewStrings(
 		"Name",
@@ -380,6 +378,7 @@ func (s *MigrationSuite) TestApplicationDocFields(c *gc.C) {
 		"Exposed",
 		"MinUnits",
 		"MetricCredentials",
+		"PasswordHash",
 	)
 	s.AssertExportedFields(c, applicationDoc{}, migrated.Union(ignored))
 }


### PR DESCRIPTION
## Description of change

Applications with passwords are now supported for migration.

## QA steps

Migrate a model with an application with a password

