### PR TITLE
Bug 1591962 mgmt space state changes

### DIFF
--- a/state/address.go
+++ b/state/address.go
@@ -150,6 +150,8 @@ func (st *State) SetAPIHostPorts(newHostPorts [][]network.HostPort) error {
 					newHostPortsForAgents[i] = newHostPorts[i]
 				}
 			}
+		} else {
+			newHostPortsForAgents = newHostPorts
 		}
 
 		// Retrieve the current API addresses for agents document.

--- a/state/address.go
+++ b/state/address.go
@@ -143,8 +143,9 @@ func (st *State) SetAPIHostPorts(newHostPorts [][]network.HostPort) error {
 		}
 		if mgmtSpace := config.JujuManagementSpace(); mgmtSpace != "" {
 			newHostPortsForAgents = make([][]network.HostPort, len(newHostPorts))
+			sp := network.SpaceName(mgmtSpace)
 			for i := range newHostPorts {
-				if filtered, ok := network.SelectHostsPortBySpaces(newHostPorts[i], network.SpaceName(mgmtSpace)); ok {
+				if filtered, ok := network.SelectHostsPortBySpaces(newHostPorts[i], sp); ok {
 					newHostPortsForAgents[i] = filtered
 				} else {
 					newHostPortsForAgents[i] = newHostPorts[i]

--- a/state/initialize.go
+++ b/state/initialize.go
@@ -214,6 +214,12 @@ func Initialize(args InitializeParams) (_ *Controller, _ *State, err error) {
 		},
 		txn.Op{
 			C:      controllersC,
+			Id:     apiHostPortsForAgentsKey,
+			Assert: txn.DocMissing,
+			Insert: &apiHostPortsDoc{},
+		},
+		txn.Op{
+			C:      controllersC,
 			Id:     stateServingInfoKey,
 			Assert: txn.DocMissing,
 			Insert: &StateServingInfo{},

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -4326,7 +4326,7 @@ func (s *StateSuite) TestSetStateServingInfoWithInvalidInfo(c *gc.C) {
 	}
 }
 
-func (s *StateSuite) TestSetAPIHostPorts(c *gc.C) {
+func (s *StateSuite) TestSetAPIHostPortsNoMgmtSpace(c *gc.C) {
 	addrs, err := s.State.APIHostPorts()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(addrs, gc.HasLen, 0)
@@ -4360,6 +4360,10 @@ func (s *StateSuite) TestSetAPIHostPorts(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(gotHostPorts, jc.DeepEquals, newHostPorts)
 
+	gotHostPorts, err = s.State.APIHostPortsForAgents()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(gotHostPorts, jc.DeepEquals, newHostPorts)
+
 	newHostPorts = [][]network.HostPort{{{
 		Address: network.Address{
 			Value: "0.2.4.6",
@@ -4374,9 +4378,13 @@ func (s *StateSuite) TestSetAPIHostPorts(c *gc.C) {
 	gotHostPorts, err = s.State.APIHostPorts()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(gotHostPorts, jc.DeepEquals, newHostPorts)
+
+	gotHostPorts, err = s.State.APIHostPortsForAgents()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(gotHostPorts, jc.DeepEquals, newHostPorts)
 }
 
-func (s *StateSuite) TestSetAPIHostPortsConcurrentSame(c *gc.C) {
+func (s *StateSuite) TestSetAPIHostPortsNoMgmtSpaceConcurrentSame(c *gc.C) {
 	hostPorts := [][]network.HostPort{{{
 		Address: network.Address{
 			Value: "0.4.8.16",
@@ -4397,25 +4405,34 @@ func (s *StateSuite) TestSetAPIHostPortsConcurrentSame(c *gc.C) {
 	// desired value; second arrival will fail its assertion,
 	// refresh finding nothing to do, and then issue a
 	// read-only assertion that suceeds.
-
+	ctrC := state.ControllersC
 	var prevRevno int64
+	var prevAgentsRevno int64
 	defer state.SetBeforeHooks(c, s.State, func() {
 		err := s.State.SetAPIHostPorts(hostPorts)
 		c.Assert(err, jc.ErrorIsNil)
-		revno, err := state.TxnRevno(s.State, "controllers", "apiHostPorts")
+		revno, err := state.TxnRevno(s.State, ctrC, "apiHostPorts")
 		c.Assert(err, jc.ErrorIsNil)
 		prevRevno = revno
+		revno, err = state.TxnRevno(s.State, ctrC, "apiHostPortsForAgents")
+		c.Assert(err, jc.ErrorIsNil)
+		prevAgentsRevno = revno
 	}).Check()
 
 	err := s.State.SetAPIHostPorts(hostPorts)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(prevRevno, gc.Not(gc.Equals), 0)
-	revno, err := state.TxnRevno(s.State, "controllers", "apiHostPorts")
+
+	revno, err := state.TxnRevno(s.State, ctrC, "apiHostPorts")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(revno, gc.Equals, prevRevno)
+
+	revno, err = state.TxnRevno(s.State, ctrC, "apiHostPortsForAgents")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(revno, gc.Equals, prevAgentsRevno)
 }
 
-func (s *StateSuite) TestSetAPIHostPortsConcurrentDifferent(c *gc.C) {
+func (s *StateSuite) TestSetAPIHostPortsNoMgmtSpaceConcurrentDifferent(c *gc.C) {
 	hostPorts0 := []network.HostPort{{
 		Address: network.Address{
 			Value: "0.4.8.16",
@@ -4437,25 +4454,91 @@ func (s *StateSuite) TestSetAPIHostPortsConcurrentDifferent(c *gc.C) {
 	// values; second arrival will fail its assertion, refresh
 	// finding and reattempt.
 
+	ctrC := state.ControllersC
 	var prevRevno int64
+	var prevAgentsRevno int64
 	defer state.SetBeforeHooks(c, s.State, func() {
 		err := s.State.SetAPIHostPorts([][]network.HostPort{hostPorts0})
 		c.Assert(err, jc.ErrorIsNil)
-		revno, err := state.TxnRevno(s.State, "controllers", "apiHostPorts")
+		revno, err := state.TxnRevno(s.State, ctrC, "apiHostPorts")
 		c.Assert(err, jc.ErrorIsNil)
 		prevRevno = revno
+		revno, err = state.TxnRevno(s.State, ctrC, "apiHostPortsForAgents")
+		c.Assert(err, jc.ErrorIsNil)
+		prevAgentsRevno = revno
 	}).Check()
 
 	err := s.State.SetAPIHostPorts([][]network.HostPort{hostPorts1})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(prevRevno, gc.Not(gc.Equals), 0)
-	revno, err := state.TxnRevno(s.State, "controllers", "apiHostPorts")
+
+	revno, err := state.TxnRevno(s.State, ctrC, "apiHostPorts")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(revno, gc.Not(gc.Equals), prevRevno)
+
+	revno, err = state.TxnRevno(s.State, ctrC, "apiHostPortsForAgents")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(revno, gc.Not(gc.Equals), prevAgentsRevno)
 
 	hostPorts, err := s.State.APIHostPorts()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(hostPorts, gc.DeepEquals, [][]network.HostPort{hostPorts1})
+
+	hostPorts, err = s.State.APIHostPortsForAgents()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(hostPorts, gc.DeepEquals, [][]network.HostPort{hostPorts1})
+}
+
+func (s *StateSuite) TestSetAPIHostPortsWithMgmtSpace(c *gc.C) {
+	// Simulate a controller configured with a management network space.
+	controllerSettings, err := s.State.ReadSettings(state.ControllersC, "controllerSettings")
+	c.Assert(err, jc.ErrorIsNil)
+	controllerSettings.Set("juju-mgmt-space", "mgmt01")
+	_, err = controllerSettings.Write()
+
+	addrs, err := s.State.APIHostPorts()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(addrs, gc.HasLen, 0)
+
+	hostPort1 := network.HostPort{
+		Address: network.Address{
+			Value: "0.2.4.6",
+			Type:  network.IPv4Address,
+			Scope: network.ScopeCloudLocal,
+		},
+		Port: 1,
+	}
+	hostPort2 := network.HostPort{
+		Address: network.Address{
+			Value:     "0.4.8.16",
+			Type:      network.IPv4Address,
+			Scope:     network.ScopePublic,
+			SpaceName: "mgmt01",
+		},
+		Port: 2,
+	}
+	hostPort3 := network.HostPort{
+		Address: network.Address{
+			Value: "0.6.1.2",
+			Type:  network.IPv4Address,
+			Scope: network.ScopeCloudLocal,
+		},
+		Port: 5,
+	}
+	newHostPorts := [][]network.HostPort{{hostPort1, hostPort2}, {hostPort3}}
+
+	err = s.State.SetAPIHostPorts(newHostPorts)
+	c.Assert(err, jc.ErrorIsNil)
+
+	gotHostPorts, err := s.State.APIHostPorts()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(gotHostPorts, jc.DeepEquals, newHostPorts)
+
+	gotHostPorts, err = s.State.APIHostPortsForAgents()
+	c.Assert(err, jc.ErrorIsNil)
+	// First slice filtered down to the address in the management space.
+	// Second filtered to zero elements, so retains the supplied slice.
+	c.Assert(gotHostPorts, jc.DeepEquals, [][]network.HostPort{{hostPort2}, {hostPort3}})
 }
 
 func (s *StateSuite) TestWatchAPIHostPorts(c *gc.C) {

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -4560,9 +4560,7 @@ func (s *StateSuite) TestSetAPIHostPortsForAgentsNoDocument(c *gc.C) {
 	key := "apiHostPortsForAgents"
 	err = col.RemoveId(key)
 	c.Assert(err, jc.ErrorIsNil)
-	cnt, err := col.FindId(key).Count()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(cnt, gc.Equals, 0)
+	c.Assert(col.FindId(key).One(&bson.D{}), gc.Equals, mgo.ErrNotFound)
 
 	err = s.State.SetAPIHostPorts(newHostPorts)
 	c.Assert(err, jc.ErrorIsNil)
@@ -4594,9 +4592,7 @@ func (s *StateSuite) TestAPIHostPortsForAgentsNoDocument(c *gc.C) {
 	key := "apiHostPortsForAgents"
 	err = col.RemoveId(key)
 	c.Assert(err, jc.ErrorIsNil)
-	cnt, err := col.FindId(key).Count()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(cnt, gc.Equals, 0)
+	c.Assert(col.FindId(key).One(&bson.D{}), gc.Equals, mgo.ErrNotFound)
 
 	gotHostPorts, err := s.State.APIHostPortsForAgents()
 	c.Assert(err, jc.ErrorIsNil)

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -4541,6 +4541,37 @@ func (s *StateSuite) TestSetAPIHostPortsWithMgmtSpace(c *gc.C) {
 	c.Assert(gotHostPorts, jc.DeepEquals, [][]network.HostPort{{hostPort2}, {hostPort3}})
 }
 
+func (s *StateSuite) TestSetAPIHostPortsForAgentsNoDocument(c *gc.C) {
+	addrs, err := s.State.APIHostPorts()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(addrs, gc.HasLen, 0)
+
+	newHostPorts := [][]network.HostPort{{{
+		Address: network.Address{
+			Value: "0.2.4.6",
+			Type:  network.IPv4Address,
+			Scope: network.ScopeCloudLocal,
+		},
+		Port: 1,
+	}}}
+
+	// Delete the addresses for agents document before setting.
+	col := s.State.MongoSession().DB("juju").C(state.ControllersC)
+	key := "apiHostPortsForAgents"
+	err = col.RemoveId(key)
+	c.Assert(err, jc.ErrorIsNil)
+	cnt, err := col.FindId(key).Count()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(cnt, gc.Equals, 0)
+
+	err = s.State.SetAPIHostPorts(newHostPorts)
+	c.Assert(err, jc.ErrorIsNil)
+
+	gotHostPorts, err := s.State.APIHostPortsForAgents()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(gotHostPorts, jc.DeepEquals, newHostPorts)
+}
+
 func (s *StateSuite) TestAPIHostPortsForAgentsNoDocument(c *gc.C) {
 	addrs, err := s.State.APIHostPorts()
 	c.Assert(err, jc.ErrorIsNil)
@@ -4553,19 +4584,12 @@ func (s *StateSuite) TestAPIHostPortsForAgentsNoDocument(c *gc.C) {
 			Scope: network.ScopeCloudLocal,
 		},
 		Port: 1,
-	}, {
-		Address: network.Address{
-			Value: "0.4.8.16",
-			Type:  network.IPv4Address,
-			Scope: network.ScopePublic,
-		},
-		Port: 2,
 	}}}
 
 	err = s.State.SetAPIHostPorts(newHostPorts)
 	c.Assert(err, jc.ErrorIsNil)
 
-	// Delete the addresses for agents document.
+	// Delete the addresses for agents document after setting.
 	col := s.State.MongoSession().DB("juju").C(state.ControllersC)
 	key := "apiHostPortsForAgents"
 	err = col.RemoveId(key)


### PR DESCRIPTION
## Description of change

In addition to the normal functionality to persist all available controller addresses, a call to state.SetAPIHostPorts will maintain a new collection of host/port, based on the controller's configured management space (if any).

## QA steps

Accompanying unit tests.

## Documentation changes

No.

## Bug reference

Progresses:
https://bugs.launchpad.net/juju/+bug/1591962