### PR TITLE
Add uniter API upward compatibility for "NetworkInfo" endpoint.

### DIFF
--- a/apiserver/facades/agent/uniter/uniter.go
+++ b/apiserver/facades/agent/uniter/uniter.go
@@ -2189,3 +2189,20 @@ func (u *UniterAPIV4) NetworkInfo(_, _ struct{}) {}
 
 // WatchUnitRelations isn't on the V4 API.
 func (u *UniterAPIV4) WatchUnitRelations(_, _ struct{}) {}
+
+func networkInfoResultsToV6(v7Results params.NetworkInfoResults) params.NetworkInfoResultsV6 {
+	results := make(map[string]params.NetworkInfoResultV6)
+	for k, v6Result := range v7Results.Results {
+		results[k] = params.NetworkInfoResultV6{Error: v6Result.Error, Info: v6Result.Info}
+	}
+	return params.NetworkInfoResultsV6{Results: results}
+}
+
+// Network Info implements UniterAPIV6 version of NetworkInfo by constructing an API V6 compatible result.
+func (u *UniterAPIV6) NetworkInfo(args params.NetworkInfoParams) (params.NetworkInfoResultsV6, error) {
+	v6Results, err := u.UniterAPI.NetworkInfo(args)
+	if err != nil {
+		return params.NetworkInfoResultsV6{}, errors.Trace(err)
+	}
+	return networkInfoResultsToV6(v6Results), nil
+}

--- a/apiserver/facades/agent/uniter/uniter_test.go
+++ b/apiserver/facades/agent/uniter/uniter_test.go
@@ -3921,3 +3921,36 @@ func (s *uniterNetworkInfoSuite) TestNetworkInfoUsesRelationAddressDefaultBindin
 		},
 	})
 }
+
+func (s *uniterNetworkInfoSuite) TestNetworkInfoV6Results(c *gc.C) {
+	s.addRelationAndAssertInScope(c)
+
+	args := params.NetworkInfoParams{
+		Unit:     s.base.wordpressUnit.Tag().String(),
+		Bindings: []string{"db"},
+	}
+
+	expectedResult := params.NetworkInfoResultsV6{
+		Results: map[string]params.NetworkInfoResultV6{
+			"db": params.NetworkInfoResultV6{
+				Info: []params.NetworkInfo{
+					params.NetworkInfo{
+						MACAddress:    "00:11:22:33:10:50",
+						InterfaceName: "eth0.100",
+						Addresses:     []params.InterfaceAddress{params.InterfaceAddress{Address: "10.0.0.10", CIDR: "10.0.0.0/24"}}},
+					params.NetworkInfo{
+						MACAddress:    "00:11:22:33:10:51",
+						InterfaceName: "eth1.100",
+						Addresses:     []params.InterfaceAddress{params.InterfaceAddress{Address: "10.0.0.11", CIDR: "10.0.0.0/24"}}},
+				},
+			}},
+	}
+
+	apiV6, err := uniter.NewUniterAPIV6(s.base.State, s.base.resources, s.base.authorizer)
+	c.Assert(err, jc.ErrorIsNil)
+
+	result, err := apiV6.NetworkInfo(args)
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Check(result, jc.DeepEquals, expectedResult)
+}

--- a/apiserver/params/network.go
+++ b/apiserver/params/network.go
@@ -689,7 +689,8 @@ type NetworkInfo struct {
 	Addresses []InterfaceAddress `json:"addresses"`
 }
 
-// NetworkInfoResult holds either and error or a list of NetworkInfos for given binding.
+// NetworkInfoResult Adds egress and ingress subnets and changes the serialized
+// `Info` key name in the yaml/json API protocol.
 type NetworkInfoResult struct {
 	Error            *Error        `json:"error,omitempty" yaml:"error,omitempty"`
 	Info             []NetworkInfo `json:"bind-addresses,omitempty" yaml:"bind-addresses,omitempty"`
@@ -700,6 +701,17 @@ type NetworkInfoResult struct {
 // NetworkInfoResults holds a mapping from binding name to NetworkInfoResult.
 type NetworkInfoResults struct {
 	Results map[string]NetworkInfoResult `json:"results"`
+}
+
+// NetworkInfoResultV6 holds either and error or a list of NetworkInfos for given binding.
+type NetworkInfoResultV6 struct {
+	Error *Error        `json:"error,omitempty" yaml:"error,omitempty"`
+	Info  []NetworkInfo `json:"network-info" yaml:"info"`
+}
+
+// NetworkInfoResults holds a mapping from binding name to NetworkInfoResultV6.
+type NetworkInfoResultsV6 struct {
+	Results map[string]NetworkInfoResultV6 `json:"results"`
 }
 
 // NetworkInfoParams holds a name of the unit and list of bindings for which we want to get NetworkInfos.


### PR DESCRIPTION
## Description of change

2.2.x agents are not upward compatible with 2.3.x api servers with respect to the uniter API's `NetworkInfo` endpoint. 

## QA steps

1. Bootstrap a 2.2.x controller
2. Deploy a charm with network bindings
3. Upgrade the controller's model to 2.3.x
4. `juju run` a `network-get` action on one of the deployed units to inspect the binding
5. `network-get` should successfully find the binding.

## Documentation changes

N/A

## Bug reference

https://bugs.launchpad.net/juju/+bug/1737058