### PR TITLE
cert: drop bogus DNSName in Verify

### DIFF
--- a/cert/cert.go
+++ b/cert/cert.go
@@ -26,7 +26,6 @@ func Verify(srvCertPEM, caCertPEM string, when time.Time) error {
 	pool := x509.NewCertPool()
 	pool.AddCert(caCert)
 	opts := x509.VerifyOptions{
-		DNSName:     "anyServer",
 		Roots:       pool,
 		CurrentTime: when,
 	}


### PR DESCRIPTION
## Description of change
When verifying certs, we were verifying
that the certificate would accept any
host name. There's no point in that,
as the client can just skip hostname
checking anyway, which would provide
the same (zero) value.

Drop the "anyServer" DNSName, which
fails due to a change in Go 1.9, where
the Common Name is ignored when there
are subject alternative names in the
certificate.

## QA steps
* run the unit tests
* smoke test bootstrap on localhost

This is a backport of #7935 to the 2.2 branch.