### PR TITLE
audit-logging: Filter uninteresting conversations out of audit log

### DIFF
--- a/apiserver/admin.go
+++ b/apiserver/admin.go
@@ -160,8 +160,11 @@ func (a *admin) getAuditRecorder(req params.LoginRequest, authResult *authResult
 	if !authResult.userLogin || a.srv.auditLogger == nil {
 		return nil, nil
 	}
+	// Wrap the audit logger in a filter that prevents us from logging
+	// lots of readonly conversations (like juju status requests).
 	result, err := auditlog.NewRecorder(
-		a.srv.auditLogger,
+		observer.NewAuditLogFilter(
+			a.srv.auditLogger, observer.InterestingRequest),
 		a.srv.clock,
 		auditlog.ConversationArgs{
 			Who:          req.AuthTag,

--- a/apiserver/admin.go
+++ b/apiserver/admin.go
@@ -161,7 +161,7 @@ func (a *admin) getAuditRecorder(req params.LoginRequest, authResult *authResult
 		return nil, nil
 	}
 	// Wrap the audit logger in a filter that prevents us from logging
-	// lots of readonly conversations (like juju status requests).
+	// lots of readonly conversations (like "juju status" requests).
 	result, err := auditlog.NewRecorder(
 		observer.NewAuditLogFilter(
 			a.srv.auditLogger, observer.InterestingRequest),

--- a/apiserver/admin_test.go
+++ b/apiserver/admin_test.go
@@ -1032,8 +1032,7 @@ func (s *loginSuite) TestAuditLoggingFailureOnInterestingRequest(c *gc.C) {
 	request := &params.LoginRequest{
 		AuthTag:     user.Tag().String(),
 		Credentials: password,
-
-		CLIArgs: "hey you guys",
+		CLIArgs:     "hey you guys",
 	}
 	err := conn.APICall("Admin", 3, "", "Login", request, &result)
 	// No error yet since logging the conversation is deferred until

--- a/apiserver/observer/auditfilter.go
+++ b/apiserver/observer/auditfilter.go
@@ -1,0 +1,143 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package observer
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/juju/errors"
+	"github.com/juju/utils/set"
+
+	"github.com/juju/juju/core/auditlog"
+)
+
+var readOnlyMethods = set.NewStrings(
+	"Client.FullStatus",
+
+	// All client facade methods that start with List.
+	"Action.ListAll",
+	"Action.ListPending",
+	"Action.ListRunning",
+	"Action.ListComplete",
+	"ApplicationOffers.ListApplicationOffers",
+	"Backups.List",
+	"Block.List",
+	"Charms.List",
+	"Controller.ListBlockedModels",
+	"FirewallRules.ListFirewallRules",
+	"ImageManager.ListImages",
+	"ImageMetadata.List",
+	"KeyManager.ListKeys",
+	"ModelManager.ListModels",
+	"ModelManager.ListModelSummaries",
+	"Payloads.List",
+	"PayloadsHookContext.List",
+	"Resources.ListResources",
+	"ResourcesHookContext.ListResources",
+	"Spaces.ListSpaces",
+	"Storage.ListStorageDetails",
+	"Storage.ListPools",
+	"Storage.ListVolumes",
+	"Storage.ListFilesystems",
+	"Subnets.ListSubnets",
+)
+
+// InterestingRequest returns whether this API request is interesting enough
+// to write the conversation to the audit log.
+func InterestingRequest(req auditlog.Request) bool {
+	return !readOnlyMethods.Contains(fmt.Sprintf("%s.%s", req.Facade, req.Method))
+}
+
+// bufferedLog defers writing records to its destination audit log
+// until it sees an interesting request - then all buffered messages
+// and subsequent ones get forwarded on.
+type bufferedLog struct {
+	mu          sync.Mutex
+	buffer      []interface{}
+	dest        auditlog.AuditLog
+	interesting func(auditlog.Request) bool
+}
+
+// NewAuditLogFilter returns an auditlog.AuditLog that will only log
+// conversations to the underlying log passed in if they include a
+// request that satisfies the filter function passed in.
+func NewAuditLogFilter(log auditlog.AuditLog, filter func(auditlog.Request) bool) auditlog.AuditLog {
+	return &bufferedLog{
+		dest:        log,
+		interesting: filter,
+	}
+}
+
+// AddConversation implements auditlog.AuditLog.
+func (l *bufferedLog) AddConversation(c auditlog.Conversation) error {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	// We always buffer the conversation, since we don't know whether
+	// it will have any interesting requests yet.
+	l.deferMessage(c)
+	return nil
+}
+
+// AddRequest implements auditlog.AuditLog.
+func (l *bufferedLog) AddRequest(r auditlog.Request) error {
+	l.mu.Lock()
+	if len(l.buffer) > 0 {
+		l.deferMessage(r)
+		var err error
+		if l.interesting(r) {
+			err = l.flush()
+		}
+		l.mu.Unlock()
+		return err
+	}
+	l.mu.Unlock()
+	// We've already flushed messages, forward this on
+	// immediately.
+	return l.dest.AddRequest(r)
+}
+
+// AddResponse implements auditlog.AuditLog.
+func (l *bufferedLog) AddResponse(r auditlog.ResponseErrors) error {
+	l.mu.Lock()
+	if len(l.buffer) > 0 {
+		l.deferMessage(r)
+		l.mu.Unlock()
+		return nil
+	}
+	l.mu.Unlock()
+	// We've already flushed messages, forward this on
+	// immediately.
+	return l.dest.AddResponse(r)
+}
+
+// Close implements auditlog.AuditLog.
+func (l *bufferedLog) Close() error {
+	return errors.Trace(l.dest.Close())
+}
+
+func (l *bufferedLog) deferMessage(m interface{}) {
+	l.buffer = append(l.buffer, m)
+}
+
+func (l *bufferedLog) flush() error {
+	for _, message := range l.buffer {
+		var err error
+		switch m := message.(type) {
+		case auditlog.Conversation:
+			err = l.dest.AddConversation(m)
+		case auditlog.Request:
+			err = l.dest.AddRequest(m)
+		case auditlog.ResponseErrors:
+			err = l.dest.AddResponse(m)
+		default:
+			err = errors.Errorf("unknown audit log message type %T %+v", m, m)
+		}
+		if err != nil {
+			return errors.Trace(err)
+		}
+	}
+	l.buffer = nil
+	return nil
+}

--- a/apiserver/observer/auditfilter.go
+++ b/apiserver/observer/auditfilter.go
@@ -13,43 +13,6 @@ import (
 	"github.com/juju/juju/core/auditlog"
 )
 
-var readOnlyMethods = set.NewStrings(
-	"Client.FullStatus",
-
-	// All client facade methods that start with List.
-	"Action.ListAll",
-	"Action.ListPending",
-	"Action.ListRunning",
-	"Action.ListComplete",
-	"ApplicationOffers.ListApplicationOffers",
-	"Backups.List",
-	"Block.List",
-	"Charms.List",
-	"Controller.ListBlockedModels",
-	"FirewallRules.ListFirewallRules",
-	"ImageManager.ListImages",
-	"ImageMetadata.List",
-	"KeyManager.ListKeys",
-	"ModelManager.ListModels",
-	"ModelManager.ListModelSummaries",
-	"Payloads.List",
-	"PayloadsHookContext.List",
-	"Resources.ListResources",
-	"ResourcesHookContext.ListResources",
-	"Spaces.ListSpaces",
-	"Storage.ListStorageDetails",
-	"Storage.ListPools",
-	"Storage.ListVolumes",
-	"Storage.ListFilesystems",
-	"Subnets.ListSubnets",
-)
-
-// InterestingRequest returns whether this API request is interesting enough
-// to write the conversation to the audit log.
-func InterestingRequest(req auditlog.Request) bool {
-	return !readOnlyMethods.Contains(fmt.Sprintf("%s.%s", req.Facade, req.Method))
-}
-
 // bufferedLog defers writing records to its destination audit log
 // until it sees an interesting request - then all buffered messages
 // and subsequent ones get forwarded on.
@@ -141,3 +104,62 @@ func (l *bufferedLog) flush() error {
 	l.buffer = nil
 	return nil
 }
+
+// InterestingRequest returns whether this API request is interesting enough
+// to write the conversation to the audit log.
+func InterestingRequest(req auditlog.Request) bool {
+	return !readOnlyMethods.Contains(fmt.Sprintf("%s.%s", req.Facade, req.Method))
+}
+
+var readOnlyMethods = set.NewStrings(
+	// Collected by running read-only commands.
+	"Action.Actions",
+	"Action.ApplicationsCharmsActions",
+	"Action.FindActionsByNames",
+	"Action.FindActionTagsByPrefix",
+	"Application.Get",
+	"Application.GetConstraints",
+	"ApplicationOffers.ApplicationOffers",
+	"Backups.Info",
+	"Client.FullStatus",
+	"Client.GetModelConstraints",
+	"Client.StatusHistory",
+	"Controller.AllModels",
+	"Controller.ControllerConfig",
+	"Controller.GetControllerAccess",
+	"Controller.ModelConfig",
+	"Controller.ModelStatus",
+	"MetricsDebug.GetMetrics",
+	"ModelConfig.ModelGet",
+	"ModelManager.ModelInfo",
+	"ModelManager.ModelDefaults",
+	"Pinger.Ping",
+	"UserManager.UserInfo",
+
+	// All client facade methods that start with List.
+	"Action.ListAll",
+	"Action.ListPending",
+	"Action.ListRunning",
+	"Action.ListComplete",
+	"ApplicationOffers.ListApplicationOffers",
+	"Backups.List",
+	"Block.List",
+	"Charms.List",
+	"Controller.ListBlockedModels",
+	"FirewallRules.ListFirewallRules",
+	"ImageManager.ListImages",
+	"ImageMetadata.List",
+	"KeyManager.ListKeys",
+	"ModelManager.ListModels",
+	"ModelManager.ListModelSummaries",
+	"Payloads.List",
+	"PayloadsHookContext.List",
+	"Resources.ListResources",
+	"ResourcesHookContext.ListResources",
+	"Spaces.ListSpaces",
+	"Storage.ListStorageDetails",
+	"Storage.ListPools",
+	"Storage.ListVolumes",
+	"Storage.ListFilesystems",
+	"Subnets.ListSubnets",
+)

--- a/apiserver/observer/auditfilter.go
+++ b/apiserver/observer/auditfilter.go
@@ -117,7 +117,6 @@ var readOnlyMethods = set.NewStrings(
 	"Action.ApplicationsCharmsActions",
 	"Action.FindActionsByNames",
 	"Action.FindActionTagsByPrefix",
-	"Application.Get",
 	"Application.GetConstraints",
 	"ApplicationOffers.ApplicationOffers",
 	"Backups.Info",
@@ -135,6 +134,10 @@ var readOnlyMethods = set.NewStrings(
 	"ModelManager.ModelDefaults",
 	"Pinger.Ping",
 	"UserManager.UserInfo",
+
+	// Don't filter out Application.Get - since it includes secrets
+	// it's worthwhile to track when it's run, and it's not likely to
+	// swamp the log.
 
 	// All client facade methods that start with List.
 	"Action.ListAll",

--- a/apiserver/observer/auditfilter.go
+++ b/apiserver/observer/auditfilter.go
@@ -112,57 +112,5 @@ func InterestingRequest(req auditlog.Request) bool {
 }
 
 var readOnlyMethods = set.NewStrings(
-	// Collected by running read-only commands.
-	"Action.Actions",
-	"Action.ApplicationsCharmsActions",
-	"Action.FindActionsByNames",
-	"Action.FindActionTagsByPrefix",
-	"Application.GetConstraints",
-	"ApplicationOffers.ApplicationOffers",
-	"Backups.Info",
 	"Client.FullStatus",
-	"Client.GetModelConstraints",
-	"Client.StatusHistory",
-	"Controller.AllModels",
-	"Controller.ControllerConfig",
-	"Controller.GetControllerAccess",
-	"Controller.ModelConfig",
-	"Controller.ModelStatus",
-	"MetricsDebug.GetMetrics",
-	"ModelConfig.ModelGet",
-	"ModelManager.ModelInfo",
-	"ModelManager.ModelDefaults",
-	"Pinger.Ping",
-	"UserManager.UserInfo",
-
-	// Don't filter out Application.Get - since it includes secrets
-	// it's worthwhile to track when it's run, and it's not likely to
-	// swamp the log.
-
-	// All client facade methods that start with List.
-	"Action.ListAll",
-	"Action.ListPending",
-	"Action.ListRunning",
-	"Action.ListComplete",
-	"ApplicationOffers.ListApplicationOffers",
-	"Backups.List",
-	"Block.List",
-	"Charms.List",
-	"Controller.ListBlockedModels",
-	"FirewallRules.ListFirewallRules",
-	"ImageManager.ListImages",
-	"ImageMetadata.List",
-	"KeyManager.ListKeys",
-	"ModelManager.ListModels",
-	"ModelManager.ListModelSummaries",
-	"Payloads.List",
-	"PayloadsHookContext.List",
-	"Resources.ListResources",
-	"ResourcesHookContext.ListResources",
-	"Spaces.ListSpaces",
-	"Storage.ListStorageDetails",
-	"Storage.ListPools",
-	"Storage.ListVolumes",
-	"Storage.ListFilesystems",
-	"Subnets.ListSubnets",
 )

--- a/apiserver/observer/auditfilter_test.go
+++ b/apiserver/observer/auditfilter_test.go
@@ -1,0 +1,75 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package observer_test
+
+import (
+	"strings"
+
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/apiserver/observer"
+	apitesting "github.com/juju/juju/apiserver/testing"
+	"github.com/juju/juju/core/auditlog"
+)
+
+type auditFilterSuite struct {
+	testing.IsolationSuite
+}
+
+var _ = gc.Suite(&auditFilterSuite{})
+
+func (s *auditFilterSuite) TestFiltersUninterestingConversations(c *gc.C) {
+	target := &apitesting.FakeAuditLog{}
+	filter := func(r auditlog.Request) bool {
+		return !strings.HasPrefix(r.Method, "List")
+	}
+	log := observer.NewAuditLogFilter(target, filter)
+
+	err := log.AddConversation(auditlog.Conversation{})
+	c.Assert(err, jc.ErrorIsNil)
+	// Nothing written out yet.
+	target.CheckCallNames(c)
+
+	err = log.AddRequest(auditlog.Request{Method: "ListBuckets"})
+	c.Assert(err, jc.ErrorIsNil)
+	target.CheckCallNames(c)
+
+	err = log.AddResponse(auditlog.ResponseErrors{})
+	c.Assert(err, jc.ErrorIsNil)
+	target.CheckCallNames(c)
+
+	err = log.AddRequest(auditlog.Request{Method: "ListSpades"})
+	c.Assert(err, jc.ErrorIsNil)
+	target.CheckCallNames(c)
+
+	err = log.AddRequest(auditlog.Request{Method: "BuildCastle"})
+	c.Assert(err, jc.ErrorIsNil)
+	// Everything gets written now.
+	target.CheckCallNames(c,
+		"AddConversation", "AddRequest", "AddResponse", "AddRequest",
+		"AddRequest")
+	calls := target.Calls()
+	getMethod := func(i int) string {
+		return calls[i].Args[0].(auditlog.Request).Method
+	}
+	requests := []string{getMethod(1), getMethod(3), getMethod(4)}
+	c.Assert(requests, gc.DeepEquals, []string{"ListBuckets", "ListSpades", "BuildCastle"})
+
+	// Subsequent messages are passed through directly even if they're
+	// not inherently interesting.
+	target.ResetCalls()
+
+	err = log.AddRequest(auditlog.Request{Method: "ListTrowels"})
+	c.Assert(err, jc.ErrorIsNil)
+	target.CheckCallNames(c, "AddRequest")
+
+	calls = target.Calls()
+	c.Assert(getMethod(0), gc.Equals, "ListTrowels")
+
+	err = log.AddResponse(auditlog.ResponseErrors{})
+	c.Assert(err, jc.ErrorIsNil)
+	target.CheckCallNames(c, "AddRequest", "AddResponse")
+}


### PR DESCRIPTION
## Description of change
Read-only API requests (like status) aren't interesting from the perspective of audit logging. To avoid burying important information in the log we buffer the conversation and any uninteresting requests/responses until we see an interesting request, at which point we flush the buffer and write out any later messages immediately.

This means that any logged conversation will have the full set of requests even if some of them are only read-only.

## QA steps

Bootstrap a controller with auditing enabled. Run various read-only commands, check that none of them generate audit log entries. Run commands that change state (setting config, deploying apps, adding and removing models, units and machines). Check that all of those show up in the audit log.