### PR TITLE
2.2 into 2.3

### DIFF
--- a/network/debinterfaces/activate.go
+++ b/network/debinterfaces/activate.go
@@ -48,7 +48,7 @@ func activationCmd(oldContent, newContent string, params *ActivationParams) stri
 		i++
 	}
 	sort.Strings(deviceNames)
-	backupFilename := fmt.Sprintf("%s.backup-%d", params.Filename, time.Now().Unix())
+	backupFilename := fmt.Sprintf("%s.backup-%d", params.Filename, params.Clock.Now().Unix())
 	// The magic value of 25694 here causes the script to sleep for 30 seconds, simulating timeout
 	// The value of 25695 causes the script to fail.
 	return fmt.Sprintf(`

--- a/network/debinterfaces/activate_test.go
+++ b/network/debinterfaces/activate_test.go
@@ -45,18 +45,17 @@ func (*BridgeSuite) TestActivateNonExistentDevice(c *gc.C) {
 	c.Check(result, gc.IsNil)
 }
 
-func (*BridgeSuite) TestActivateEth0(c *gc.C) {
+func (s *BridgeSuite) TestActivateEth0(c *gc.C) {
 	filename := "testdata/TestInputSourceStanza/interfaces"
 
 	params := debinterfaces.ActivationParams{
-		Clock:            clock.WallClock,
+		Clock:            testing.NewClock(time.Now()),
 		Devices:          map[string]string{"eth0": "br-eth0", "eth1": "br-eth1"},
 		DryRun:           true,
 		Filename:         filename,
 		ReconfigureDelay: 10,
 		Timeout:          5 * time.Minute,
 	}
-
 	result, err := debinterfaces.BridgeAndActivate(params)
 	c.Assert(err, gc.IsNil)
 	c.Check(result, gc.NotNil)
@@ -69,15 +68,15 @@ ifdown --interfaces=testdata/TestInputSourceStanza/interfaces eth0 eth1
 sleep 10
 cp testdata/TestInputSourceStanza/interfaces.new testdata/TestInputSourceStanza/interfaces
 ifup --interfaces=testdata/TestInputSourceStanza/interfaces -a
-`, time.Now().Unix())
+`, params.Clock.Now().Unix())
 	c.Check(string(result.Stdout), gc.Equals, expected[1:])
 }
 
-func (*BridgeSuite) TestActivateEth0WithoutBackup(c *gc.C) {
+func (s *BridgeSuite) TestActivateEth0WithoutBackup(c *gc.C) {
 	filename := "testdata/TestInputSourceStanza/interfaces"
 
 	params := debinterfaces.ActivationParams{
-		Clock:            clock.WallClock,
+		Clock:            testing.NewClock(time.Now()),
 		Devices:          map[string]string{"eth0": "br-eth0", "eth1": "br-eth1"},
 		DryRun:           true,
 		Filename:         filename,
@@ -97,15 +96,15 @@ ifdown --interfaces=testdata/TestInputSourceStanza/interfaces eth0 eth1
 sleep 100
 cp testdata/TestInputSourceStanza/interfaces.new testdata/TestInputSourceStanza/interfaces
 ifup --interfaces=testdata/TestInputSourceStanza/interfaces -a
-`, time.Now().Unix())
+`, params.Clock.Now().Unix())
 	c.Check(string(result.Stdout), gc.Equals, expected[1:])
 }
 
-func (*BridgeSuite) TestActivateWithNegativeReconfigureDelay(c *gc.C) {
+func (s *BridgeSuite) TestActivateWithNegativeReconfigureDelay(c *gc.C) {
 	filename := "testdata/TestInputSourceStanza/interfaces"
 
 	params := debinterfaces.ActivationParams{
-		Clock:            clock.WallClock,
+		Clock:            testing.NewClock(time.Now()),
 		Devices:          map[string]string{"eth0": "br-eth0", "eth1": "br-eth1"},
 		DryRun:           true,
 		Filename:         filename,
@@ -125,7 +124,7 @@ ifdown --interfaces=testdata/TestInputSourceStanza/interfaces eth0 eth1
 sleep 0
 cp testdata/TestInputSourceStanza/interfaces.new testdata/TestInputSourceStanza/interfaces
 ifup --interfaces=testdata/TestInputSourceStanza/interfaces -a
-`, time.Now().Unix())
+`, params.Clock.Now().Unix())
 	c.Check(string(result.Stdout), gc.Equals, expected[1:])
 }
 


### PR DESCRIPTION
## Description of change

Merge the tip of 2.2 into 2.3. This brings in Tim's log watcher fix (which was already cherrypicked) and Christian's debinterfaces fix.

## QA steps

See original merges.

## Documentation changes

None

## Bug reference

None
