### PR TITLE
Fix bug 1735684: Don't watch manual machines from the firewaller.

### DIFF
--- a/api/facadeversions.go
+++ b/api/facadeversions.go
@@ -38,7 +38,7 @@ var facadeVersions = map[string]int{
 	"ExternalControllerUpdater":    1,
 	"FanConfigurer":                1,
 	"FilesystemAttachmentsWatcher": 2,
-	"Firewaller":                   4,
+	"Firewaller":                   5,
 	"FirewallRules":                1,
 	"HighAvailability":             2,
 	"HostKeyReporter":              1,

--- a/api/firewaller/machine.go
+++ b/api/firewaller/machine.go
@@ -143,3 +143,23 @@ func (m *Machine) OpenedPorts(subnetTag names.SubnetTag) (map[network.PortRange]
 	}
 	return endResult, nil
 }
+
+// IsManual returns true if the machine was manually provisioned.
+func (m *Machine) IsManual() (bool, error) {
+	var results params.BoolResults
+	args := params.Entities{
+		Entities: []params.Entity{{Tag: m.tag.String()}},
+	}
+	err := m.st.facade.FacadeCall("AreManuallyProvisioned", args, &results)
+	if err != nil {
+		return false, err
+	}
+	if len(results.Results) != 1 {
+		return false, fmt.Errorf("expected 1 result, got %d", len(results.Results))
+	}
+	result := results.Results[0]
+	if result.Error != nil {
+		return false, result.Error
+	}
+	return result.Result, nil
+}

--- a/api/firewaller/machine_test.go
+++ b/api/firewaller/machine_test.go
@@ -134,3 +134,21 @@ func (s *machineSuite) TestOpenedPorts(c *gc.C) {
 		network.PortRange{FromPort: 1234, ToPort: 1234, Protocol: "tcp"}: unitTag,
 	})
 }
+
+func (s *machineSuite) TestIsManual(c *gc.C) {
+	answer, err := s.machines[0].IsManual()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(answer, jc.IsFalse)
+
+	m, err := s.State.AddOneMachine(state.MachineTemplate{
+		Series:     "quantal",
+		Jobs:       []state.MachineJob{state.JobHostUnits},
+		InstanceId: "2",
+		Nonce:      "manual:",
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	answer, err = m.IsManual()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(answer, jc.IsTrue)
+
+}

--- a/apiserver/allfacades.go
+++ b/apiserver/allfacades.go
@@ -158,6 +158,7 @@ func AllFacades() *facade.Registry {
 	reg("FanConfigurer", 1, fanconfigurer.NewFanConfigurerAPI)
 	reg("Firewaller", 3, firewaller.NewStateFirewallerAPIV3)
 	reg("Firewaller", 4, firewaller.NewStateFirewallerAPIV4)
+	reg("Firewaller", 5, firewaller.NewStateFirewallerAPIV5)
 	reg("FirewallRules", 1, firewallrules.NewFacade)
 	reg("HighAvailability", 2, highavailability.NewHighAvailabilityAPI)
 	reg("HostKeyReporter", 1, hostkeyreporter.NewFacade)

--- a/apiserver/facades/controller/firewaller/firewaller.go
+++ b/apiserver/facades/controller/firewaller/firewaller.go
@@ -46,7 +46,12 @@ type FirewallerAPIV4 struct {
 	*common.ControllerConfigAPI
 }
 
-// NewStateFirewallerAPIv3 creates a new server-side FirewallerAPIV3 facade.
+// FirewallerAPIV5 provides access to the Firewaller v5 API facade.
+type FirewallerAPIV5 struct {
+	*FirewallerAPIV4
+}
+
+// NewStateFirewallerAPIV3 creates a new server-side FirewallerAPIV3 facade.
 func NewStateFirewallerAPIV3(context facade.Context) (*FirewallerAPIV3, error) {
 	st := context.State()
 
@@ -62,7 +67,7 @@ func NewStateFirewallerAPIV3(context facade.Context) (*FirewallerAPIV3, error) {
 	return NewFirewallerAPI(stateShim{st: st, State: firewall.StateShim(st, m)}, context.Resources(), context.Auth(), cloudSpecAPI)
 }
 
-// NewStateFirewallerAPIv4 creates a new server-side FirewallerAPIV4 facade.
+// NewStateFirewallerAPIV4 creates a new server-side FirewallerAPIV4 facade.
 func NewStateFirewallerAPIV4(context facade.Context) (*FirewallerAPIV4, error) {
 	facadev3, err := NewStateFirewallerAPIV3(context)
 	if err != nil {
@@ -71,6 +76,17 @@ func NewStateFirewallerAPIV4(context facade.Context) (*FirewallerAPIV4, error) {
 	return &FirewallerAPIV4{
 		ControllerConfigAPI: common.NewStateControllerConfig(context.State()),
 		FirewallerAPIV3:     facadev3,
+	}, nil
+}
+
+// NewStateFirewallerAPIV5 creates a new server-side FirewallerAPIV5 facade.
+func NewStateFirewallerAPIV5(context facade.Context) (*FirewallerAPIV5, error) {
+	facadev4, err := NewStateFirewallerAPIV4(context)
+	if err != nil {
+		return nil, err
+	}
+	return &FirewallerAPIV5{
+		FirewallerAPIV4: facadev4,
 	}, nil
 }
 
@@ -488,6 +504,31 @@ func (f *FirewallerAPIV4) FirewallRules(args params.KnownServiceArgs) (params.Li
 			KnownService:   params.KnownServiceValue(knownService),
 			WhitelistCIDRS: rule.WhitelistCIDRs,
 		})
+	}
+	return result, nil
+}
+
+// AreManuallyProvisioned returns whether each given entity is
+// manually provisioned or not. Only machine tags are accepted.
+func (f *FirewallerAPIV5) AreManuallyProvisioned(args params.Entities) (params.BoolResults, error) {
+	result := params.BoolResults{
+		Results: make([]params.BoolResult, len(args.Entities)),
+	}
+	canAccess, err := f.accessMachine()
+	if err != nil {
+		return result, err
+	}
+	for i, arg := range args.Entities {
+		machineTag, err := names.ParseMachineTag(arg.Tag)
+		if err != nil {
+			result.Results[i].Error = common.ServerError(err)
+			continue
+		}
+		machine, err := f.getMachine(canAccess, machineTag)
+		if err == nil {
+			result.Results[i].Result, err = machine.IsManual()
+		}
+		result.Results[i].Error = common.ServerError(err)
 	}
 	return result, nil
 }

--- a/worker/firewaller/export_test.go
+++ b/worker/firewaller/export_test.go
@@ -1,0 +1,16 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package firewaller
+
+import (
+	"gopkg.in/juju/names.v2"
+)
+
+func StartMachine(fw *Firewaller, tag names.MachineTag) error {
+	return fw.startMachine(tag)
+}
+
+func GetMachineds(fw *Firewaller) map[names.MachineTag]*machineData {
+	return fw.machineds
+}


### PR DESCRIPTION
## Description of change

Since juju shouldn't be touching ports on a manually provisioned machine, don't start watching them.

## QA steps

1. bootstrap an openstack cloud with debug logging-config
1. Create a container which can be added to juju
2. juju add-machine ssh:ubuntu@<new container>
3. juju deploy ghost --to <new manual machine>
4. juju export ghost
5. look at debug-log from controller

No provider or firewater error like those in bug should be seen.  There should be a debug message: "not watching machine-#".

## Documentation changes

N/A

## Bug reference

https://bugs.launchpad.net/juju/+bug/1735684
