### PR TITLE
Don't issue no-op txn on settings write

### DIFF
--- a/state/cleanup.go
+++ b/state/cleanup.go
@@ -624,7 +624,7 @@ func (st *State) cleanupForceDestroyedMachine(machineId string) error {
 		return err
 	}
 	removePortsOps, err := machine.removePortsOps()
-	if err != nil {
+	if len(removePortsOps) == 0 || err != nil {
 		return err
 	}
 	return st.db().RunTransaction(removePortsOps)

--- a/state/settings.go
+++ b/state/settings.go
@@ -222,9 +222,11 @@ func (s *Settings) write(ops []txn.Op) error {
 // overwriting unrelated changes made to the node since it was last read.
 func (s *Settings) Write() ([]ItemChange, error) {
 	changes, ops := s.settingsUpdateOps()
-	err := s.write(ops)
-	if err != nil {
-		return nil, err
+	if len(ops) > 0 {
+		err := s.write(ops)
+		if err != nil {
+			return nil, err
+		}
 	}
 	return changes, nil
 }


### PR DESCRIPTION
## Description of change
Don't issue txn when writing settings would be a no-op

## QA steps
Bootstrap juju, deploy large bundle, verify that there're no empty txns - connect to mongo and issue db.txns.find({o:[]}).count() - it should be 0.

## Bug reference
https://bugs.launchpad.net/juju/+bug/1738209