### PR TITLE
Fix non-finalizing update-credential command.

### DIFF
--- a/cmd/juju/cloud/updatecredential.go
+++ b/cmd/juju/cloud/updatecredential.go
@@ -100,34 +100,38 @@ func (c *updateCredentialCommand) getAPI() (credentialAPI, error) {
 
 // Run implements Command.Run
 func (c *updateCredentialCommand) Run(ctx *cmd.Context) error {
-	cred, err := c.ClientStore().CredentialForCloud(c.cloud)
+	cloud, err := common.CloudByName(c.cloud)
 	if errors.IsNotFound(err) {
-		ctx.Infof("No credentials exist for cloud %q", c.cloud)
+		ctx.Infof("Cloud %q not found", c.cloud)
 		return nil
 	} else if err != nil {
 		return err
 	}
-	credToUpdate, ok := cred.AuthCredentials[c.credential]
-	if !ok {
+	getCredentialsParams := modelcmd.GetCredentialsParams{
+		Cloud:          *cloud,
+		CredentialName: c.credential,
+	}
+	credToUpdate, _, _, err := modelcmd.GetCredentials(ctx, c.ClientStore(), getCredentialsParams)
+	if errors.IsNotFound(err) {
 		ctx.Infof("No credential called %q exists for cloud %q", c.credential, c.cloud)
 		return nil
+	} else if err != nil {
+		return err
 	}
-
 	accountDetails, err := c.CurrentAccountDetails()
 	if err != nil {
-		return errors.Trace(err)
+		return err
 	}
 	credentialTag, err := common.ResolveCloudCredentialTag(
 		names.NewUserTag(accountDetails.User), names.NewCloudTag(c.cloud), c.credential,
 	)
-
 	client, err := c.getAPI()
 	if err != nil {
 		return err
 	}
 	defer client.Close()
 
-	if err := client.UpdateCredential(credentialTag, credToUpdate); err != nil {
+	if err := client.UpdateCredential(credentialTag, *credToUpdate); err != nil {
 		return err
 	}
 	ctx.Infof("Updated credential %q for user %q on cloud %q.", c.credential, accountDetails.User, c.cloud)

--- a/provider/dummy/environs.go
+++ b/provider/dummy/environs.go
@@ -82,7 +82,7 @@ var errNotPrepared = errors.New("model is not prepared")
 // SampleCloudSpec returns an environs.CloudSpec that can be used to
 // open a dummy Environ.
 func SampleCloudSpec() environs.CloudSpec {
-	cred := cloud.NewCredential(cloud.UserPassAuthType, map[string]string{"username": "dummy", "passeord": "secret"})
+	cred := cloud.NewCredential(cloud.UserPassAuthType, map[string]string{"username": "dummy", "password": "secret"})
 	return environs.CloudSpec{
 		Type:             "dummy",
 		Name:             "dummy",


### PR DESCRIPTION
## Description of change

The `juju update-credential` command does not process credentials in the same way as other commands. The difference leaves file paths in place in user's YAML credentials file when updating credentials for JSON file based cloud credentials.

## QA steps

1. Bootstrap a controller with credentials that are read from file.
2. Do a dry run update `juju upgrade-juju --dry-run` - everything should work fine
3. Update the credentials using `juju update-credential`
4. Try a dry run upgrade again - It should fail 
5. After applying this commit, then step 4 should work.

## Documentation changes

N/A

## Bug reference

https://bugs.launchpad.net/juju/+bug/1738991

