### PR TITLE
apiserver: NotFound -> UnknownModelError

### DIFF
--- a/apiserver/utils.go
+++ b/apiserver/utils.go
@@ -66,7 +66,10 @@ func validateModelUUID(args validateArgs) (string, error) {
 
 	_, release, err := args.statePool.GetModel(args.modelUUID)
 	if err != nil {
-		return "", errors.Wrap(err, common.UnknownModelError(args.modelUUID))
+		if errors.IsNotFound(err) {
+			return "", errors.Wrap(err, common.UnknownModelError(args.modelUUID))
+		}
+		return "", errors.Trace(err)
 	}
 	release()
 	return args.modelUUID, nil


### PR DESCRIPTION
## Description of change

Don't convert all state.StatePool.GetModel
errors to "UnknownModelError" (which in turn
leads to a CodeModelNotFound API error code).
Instead, only do this for NotFound errors.

## QA steps

Smoke test that existing logic works:

1. juju bootstrap
2. juju add-model foo
3. cp ~/.local/share/juju/models.yaml /tmp
4. juju destroy-model -y foo
5. mv /tmp/models.yaml ~/.local/share/juju
6. juju status -m foo

(should see `ERROR model "admin/foo" has been removed from the controller, run 'juju models' and switch to one of them.`)

## Documentation changes

None.

## Bug reference

Might help diagnose https://bugs.launchpad.net/juju/+bug/1740815