### PR TITLE
state: delete status history in batches

### DIFF
--- a/state/prune.go
+++ b/state/prune.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/juju/errors"
+	"github.com/juju/loggo"
 	"gopkg.in/mgo.v2"
 	"gopkg.in/mgo.v2/bson"
 )
@@ -98,13 +99,14 @@ func (p *collectionPruner) pruneByAge() error {
 		{"model-uuid", p.st.modelUUID()},
 		{p.ageField, bson.M{"$gt": notSet, "$lt": age}},
 	}).Select(bson.M{"_id": 1}).Iter()
+	defer iter.Close()
 
 	modelName, err := p.st.modelName()
 	if err != nil {
 		return errors.Trace(err)
 	}
 	logTemplate := fmt.Sprintf("%s age pruning (%s): %%d rows deleted", p.coll.Name, modelName)
-	deleted, err := p.deleteInBatches(iter, logTemplate, noEarlyFinish)
+	deleted, err := deleteInBatches(p.coll, iter, logTemplate, loggo.INFO, noEarlyFinish)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -153,9 +155,10 @@ func (p *collectionPruner) pruneBySize() error {
 	toDelete := int(float64(collMB-p.maxSize) / sizePerStatus)
 
 	iter := p.coll.Find(nil).Sort(p.ageField).Limit(toDelete).Select(bson.M{"_id": 1}).Iter()
+	defer iter.Close()
 
 	template := fmt.Sprintf("%s size pruning: deleted %%d of %d (estimated)", p.coll.Name, toDelete)
-	deleted, err := p.deleteInBatches(iter, template, func() (bool, error) {
+	deleted, err := deleteInBatches(p.coll, iter, template, loggo.INFO, func() (bool, error) {
 		// Check that we still need to delete more
 		collMB, err := getCollectionMB(p.coll)
 		if err != nil {
@@ -176,9 +179,15 @@ func (p *collectionPruner) pruneBySize() error {
 	return nil
 }
 
-func (p *collectionPruner) deleteInBatches(iter *mgo.Iter, logTemplate string, shouldStop doneCheck) (int, error) {
+func deleteInBatches(
+	coll *mgo.Collection,
+	iter *mgo.Iter,
+	logTemplate string,
+	logLevel loggo.Level,
+	shouldStop doneCheck,
+) (int, error) {
 	var doc bson.M
-	chunk := p.coll.Bulk()
+	chunk := coll.Bulk()
 	chunkSize := 0
 
 	lastUpdate := time.Now()
@@ -190,11 +199,11 @@ func (p *collectionPruner) deleteInBatches(iter *mgo.Iter, logTemplate string, s
 			_, err := chunk.Run()
 			// NotFound indicates that records were already deleted.
 			if err != nil && err != mgo.ErrNotFound {
-				return 0, errors.Annotate(err, "removing status history batch")
+				return 0, errors.Annotate(err, "removing batch")
 			}
 
 			deleted += chunkSize
-			chunk = p.coll.Bulk()
+			chunk = coll.Bulk()
 			chunkSize = 0
 
 			// Check that we still need to delete more
@@ -208,16 +217,19 @@ func (p *collectionPruner) deleteInBatches(iter *mgo.Iter, logTemplate string, s
 
 			now := time.Now()
 			if now.Sub(lastUpdate) >= historyPruneProgressSeconds*time.Second {
-				logger.Infof(logTemplate, deleted)
+				logger.Logf(logLevel, logTemplate, deleted)
 				lastUpdate = now
 			}
 		}
+	}
+	if err := iter.Close(); err != nil {
+		return 0, errors.Annotate(err, "closing iterator")
 	}
 
 	if chunkSize > 0 {
 		_, err := chunk.Run()
 		if err != nil && err != mgo.ErrNotFound {
-			return 0, errors.Annotate(err, "removing status history remainder")
+			return 0, errors.Annotate(err, "removing remainder")
 		}
 	}
 


### PR DESCRIPTION
## Description of change

When removing status history docs because
a unit was destroyed, remove the docs in
batches to avoid locking the collection
for a long period of time.

## QA steps

smoke test bootstrap / deploy / remove-application
(check status history docs removed)

Also, I ran a before/after experiment:
 - write 10000 status history docs for unit 1
 - concurrently destroy unit 1, and write 10000 status history docs for unit 2
After the change, takes ~10s less time overall (~80s -> ~70s)

## Documentation changes

None.

## Bug reference

May help with https://bugs.launchpad.net/juju/+bug/1733708
Also partially addresses https://bugs.launchpad.net/juju/+bug/1739380 (closes iterators in pruning code)