### PR TITLE
Close mongo iterators

### DIFF
--- a/mongo/collections.go
+++ b/mongo/collections.go
@@ -69,7 +69,7 @@ type Query interface {
 	Explain(result interface{}) error
 	For(result interface{}, f func() error) error
 	Hint(indexKey ...string) Query
-	Iter() *mgo.Iter
+	Iter() Iterator
 	Limit(n int) Query
 	LogReplay() Query
 	MapReduce(job *mgo.MapReduce, result interface{}) (info *mgo.MapReduceInfo, err error)
@@ -82,6 +82,14 @@ type Query interface {
 	Snapshot() Query
 	Sort(fields ...string) Query
 	Tail(timeout time.Duration) *mgo.Iter
+}
+
+// Iterator defines the parts of the mgo.Iter that we use - this
+// interface allows us to switch out the querying for testing.
+type Iterator interface {
+	Next(interface{}) bool
+	Timeout() bool
+	Close() error
 }
 
 // WrapCollection returns a Collection that wraps the supplied *mgo.Collection.
@@ -175,4 +183,8 @@ func (qw queryWrapper) Snapshot() Query {
 
 func (qw queryWrapper) Sort(fields ...string) Query {
 	return queryWrapper{qw.Query.Sort(fields...)}
+}
+
+func (qw queryWrapper) Iter() Iterator {
+	return qw.Query.Iter()
 }

--- a/mongo/oplog.go
+++ b/mongo/oplog.go
@@ -89,7 +89,6 @@ func isRealOplog(c *mgo.Collection) bool {
 // interface allows us to switch out the querying for testing.
 type Iterator interface {
 	Next(interface{}) bool
-	Err() error
 	Timeout() bool
 	Close() error
 }
@@ -220,8 +219,6 @@ func (t *OplogTailer) Err() error {
 }
 
 func (t *OplogTailer) loop() error {
-	var iter Iterator
-
 	// lastTimestamp tracks the most recent oplog timestamp reported.
 	lastTimestamp := t.initialTs
 
@@ -236,15 +233,16 @@ func (t *OplogTailer) loop() error {
 	// See: http://docs.mongodb.org/v2.4/reference/bson-types/#timestamps
 	var idsForLastTimestamp []int64
 
+	newIter := func() Iterator {
+		return t.session.NewIter(lastTimestamp, idsForLastTimestamp)
+	}
+	iter := newIter()
+	defer func() { iter.Close() }() // iter may be replaced, hence closure
+
 	for {
 		if t.dying() {
 			return tomb.ErrDying
 		}
-
-		if iter == nil {
-			iter = t.session.NewIter(lastTimestamp, idsForLastTimestamp)
-		}
-
 		var doc OplogDoc
 		if iter.Next(&doc) {
 			select {
@@ -252,23 +250,21 @@ func (t *OplogTailer) loop() error {
 				return tomb.ErrDying
 			case t.outCh <- &doc:
 			}
-
 			if doc.Timestamp > lastTimestamp {
 				lastTimestamp = doc.Timestamp
 				idsForLastTimestamp = nil
 			}
 			idsForLastTimestamp = append(idsForLastTimestamp, doc.OperationId)
 		} else {
-			if err := iter.Err(); err != nil && err != mgo.ErrCursor {
-				return err
-			}
 			if iter.Timeout() {
 				continue
 			}
+			if err := iter.Close(); err != nil && err != mgo.ErrCursor {
+				return err
+			}
 			// Either there's no error or the error is an expired
-			// cursor. Force recreating the iterator next loop by
-			// marking it as nil.
-			iter = nil
+			// cursor; Recreate the iterator.
+			iter = newIter()
 		}
 	}
 }

--- a/mongo/oplog.go
+++ b/mongo/oplog.go
@@ -85,14 +85,6 @@ func isRealOplog(c *mgo.Collection) bool {
 	return c.Database.Name == "local" && c.Name == "oplog.rs"
 }
 
-// Iterator defines the parts of the mgo.Iter that we use - this
-// interface allows us to switch out the querying for testing.
-type Iterator interface {
-	Next(interface{}) bool
-	Timeout() bool
-	Close() error
-}
-
 // OplogSession represents a connection to the oplog store, used
 // to create an iterator to get oplog documents (and recreate it if it
 // gets killed or times out).

--- a/mongo/oplog_test.go
+++ b/mongo/oplog_test.go
@@ -325,13 +325,6 @@ func (i *fakeIterator) Next(result interface{}) bool {
 	return true
 }
 
-func (i *fakeIterator) Err() error {
-	if i.pos < len(i.docs) {
-		return nil
-	}
-	return i.err
-}
-
 func (i *fakeIterator) Timeout() bool {
 	if i.pos < len(i.docs) {
 		return false
@@ -340,7 +333,10 @@ func (i *fakeIterator) Timeout() bool {
 }
 
 func (i *fakeIterator) Close() error {
-	return nil
+	if i.pos < len(i.docs) {
+		return nil
+	}
+	return i.err
 }
 
 func newFakeIterator(err error, docs ...*mongo.OplogDoc) *fakeIterator {

--- a/state/cleanup.go
+++ b/state/cleanup.go
@@ -9,10 +9,10 @@ import (
 	"github.com/juju/errors"
 	"gopkg.in/juju/charm.v6"
 	"gopkg.in/juju/names.v2"
-	"gopkg.in/mgo.v2"
 	"gopkg.in/mgo.v2/bson"
 	"gopkg.in/mgo.v2/txn"
 
+	"github.com/juju/juju/mongo"
 	"github.com/juju/juju/status"
 )
 
@@ -906,7 +906,7 @@ func (st *State) cleanupAttachmentsForDyingFilesystem(filesystemId string) (err 
 	return nil
 }
 
-func closeIter(iter *mgo.Iter, errOut *error, message string) {
+func closeIter(iter mongo.Iterator, errOut *error, message string) {
 	err := iter.Close()
 	if err == nil {
 		return

--- a/state/cloud.go
+++ b/state/cloud.go
@@ -107,7 +107,7 @@ func (st *State) Clouds() (map[names.CloudTag]cloud.Cloud, error) {
 	for iter.Next(&doc) {
 		clouds[names.NewCloudTag(doc.Name)] = doc.toCloud()
 	}
-	if err := iter.Err(); err != nil {
+	if err := iter.Close(); err != nil {
 		return nil, errors.Annotate(err, "getting clouds")
 	}
 	return clouds, nil

--- a/state/dump.go
+++ b/state/dump.go
@@ -58,7 +58,7 @@ func getAllModelDocs(mb modelBackend, collectionName string) ([]map[string]inter
 		doc = nil
 	}
 
-	if err := iter.Err(); err != nil {
+	if err := iter.Close(); err != nil {
 		return nil, errors.Annotatef(err, "reading collection %q", collectionName)
 	}
 	return result, nil

--- a/state/export_test.go
+++ b/state/export_test.go
@@ -308,7 +308,7 @@ func GetAllUpgradeInfos(st *State) ([]*UpgradeInfo, error) {
 	for iter.Next(&doc) {
 		out = append(out, &UpgradeInfo{st: st, doc: doc})
 	}
-	if err := iter.Err(); err != nil {
+	if err := iter.Close(); err != nil {
 		return nil, err
 	}
 	return out, nil

--- a/state/logs.go
+++ b/state/logs.go
@@ -444,6 +444,7 @@ func (t *logTailer) processReversed(query *mgo.Query) error {
 	query.Sort("-t", "-_id")
 	query.Limit(t.params.InitialLines)
 	iter := query.Iter()
+	defer iter.Close()
 	queue := make([]logDoc, t.params.InitialLines)
 	cur := t.params.InitialLines
 	var doc logDoc
@@ -507,6 +508,7 @@ func (t *logTailer) processCollection() error {
 	// a good value, or end the method.
 	deserialisationFailures := 0
 	iter := query.Sort("t", "_id").Iter()
+	defer iter.Close()
 	for iter.Next(&doc) {
 		rec, err := logDocToRecord(t.modelUUID, &doc)
 		if err != nil {

--- a/state/migration_export.go
+++ b/state/migration_export.go
@@ -615,7 +615,7 @@ func (e *exporter) readAllStorageConstraints() error {
 	for iter.Next(&doc) {
 		storageConstraints[e.st.localID(doc.DocID)] = doc
 	}
-	if err := iter.Err(); err != nil {
+	if err := iter.Close(); err != nil {
 		return errors.Annotate(err, "failed to read storage constraints")
 	}
 	e.logger.Debugf("read %d storage constraint documents", len(storageConstraints))
@@ -1364,7 +1364,7 @@ func (e *exporter) readAllStatusHistory() error {
 		count++
 	}
 
-	if err := iter.Err(); err != nil {
+	if err := iter.Close(); err != nil {
 		return errors.Annotate(err, "failed to read status history collection")
 	}
 
@@ -1631,7 +1631,7 @@ func (e *exporter) volumes() error {
 			return errors.Trace(err)
 		}
 	}
-	if err := iter.Err(); err != nil {
+	if err := iter.Close(); err != nil {
 		return errors.Annotate(err, "failed to read volumes")
 	}
 	return nil
@@ -1716,7 +1716,7 @@ func (e *exporter) readVolumeAttachments() (map[string][]volumeAttachmentDoc, er
 		result[doc.Volume] = append(result[doc.Volume], doc)
 		count++
 	}
-	if err := iter.Err(); err != nil {
+	if err := iter.Close(); err != nil {
 		return nil, errors.Annotate(err, "failed to read volumes attachments")
 	}
 	e.logger.Debugf("read %d volume attachment documents", count)
@@ -1740,7 +1740,7 @@ func (e *exporter) filesystems() error {
 			return errors.Trace(err)
 		}
 	}
-	if err := iter.Err(); err != nil {
+	if err := iter.Close(); err != nil {
 		return errors.Annotate(err, "failed to read filesystems")
 	}
 	return nil
@@ -1818,7 +1818,7 @@ func (e *exporter) readFilesystemAttachments() (map[string][]filesystemAttachmen
 		result[doc.Filesystem] = append(result[doc.Filesystem], doc)
 		count++
 	}
-	if err := iter.Err(); err != nil {
+	if err := iter.Close(); err != nil {
 		return nil, errors.Annotate(err, "failed to read filesystem attachments")
 	}
 	e.logger.Debugf("read %d filesystem attachment documents", count)
@@ -1842,7 +1842,7 @@ func (e *exporter) storageInstances() error {
 			return errors.Trace(err)
 		}
 	}
-	if err := iter.Err(); err != nil {
+	if err := iter.Close(); err != nil {
 		return errors.Annotate(err, "failed to read storage instances")
 	}
 	return nil
@@ -1880,7 +1880,7 @@ func (e *exporter) readStorageAttachments() (map[string][]names.UnitTag, error) 
 		result[doc.StorageInstance] = append(result[doc.StorageInstance], unit)
 		count++
 	}
-	if err := iter.Err(); err != nil {
+	if err := iter.Close(); err != nil {
 		return nil, errors.Annotate(err, "failed to read storage attachments")
 	}
 	e.logger.Debugf("read %d storage attachment documents", count)

--- a/state/modelsummaries.go
+++ b/state/modelsummaries.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/instance"
+	"github.com/juju/juju/mongo"
 	"github.com/juju/juju/mongo/utils"
 	"github.com/juju/juju/permission"
 	"github.com/juju/juju/status"
@@ -316,7 +317,7 @@ func (p *modelSummaryProcessor) fillInMigration() error {
 		}},
 	})
 	pipe.Batch(100)
-	iter := pipe.Iter()
+	var iter mongo.Iterator = pipe.Iter()
 	defer iter.Close()
 	modelMigDocs := make(map[string]modelMigDoc)
 	docIds := make([]string, 0)

--- a/state/modelsummaries.go
+++ b/state/modelsummaries.go
@@ -136,6 +136,7 @@ func (p *modelSummaryProcessor) fillInFromConfig() error {
 	query := rawSettings.Find(bson.M{"_id": bson.M{"$in": settingIds}})
 	var doc settingsDoc
 	iter := query.Iter()
+	defer iter.Close()
 	for iter.Next(&doc) {
 		idx, ok := p.indexByUUID[doc.ModelUUID]
 		if !ok {
@@ -173,6 +174,7 @@ func (p *modelSummaryProcessor) fillInFromStatus() error {
 	query := rawStatus.Find(bson.M{"_id": bson.M{"$in": statusIds}})
 	var doc statusDoc
 	iter := query.Iter()
+	defer iter.Close()
 	for iter.Next(&doc) {
 		idx, ok := p.indexByUUID[doc.ModelUUID]
 		if !ok {
@@ -198,6 +200,7 @@ func (p *modelSummaryProcessor) fillInPermissions(permissionIds []string) error 
 	defer closer()
 	query := perms.Find(bson.M{"_id": bson.M{"$in": permissionIds}})
 	iter := query.Iter()
+	defer iter.Close()
 
 	var doc permissionDoc
 	for iter.Next(&doc) {
@@ -235,6 +238,7 @@ func (p *modelSummaryProcessor) fillInMachineSummary() error {
 	})
 	query.Select(bson.M{"life": 1, "model-uuid": 1, "_id": 1, "machineid": 1})
 	iter := query.Iter()
+	defer iter.Close()
 	var doc machineDoc
 	machineIds := make([]string, 0)
 	for iter.Next(&doc) {
@@ -259,6 +263,7 @@ func (p *modelSummaryProcessor) fillInMachineSummary() error {
 	query = instances.Find(bson.M{"_id": bson.M{"$in": machineIds}})
 	query.Select(bson.M{"cpucores": 1, "model-uuid": 1})
 	iter = query.Iter()
+	defer iter.Close()
 	var instData instanceData
 	for iter.Next(&instData) {
 		idx, ok := p.indexByUUID[instData.ModelUUID]
@@ -312,6 +317,7 @@ func (p *modelSummaryProcessor) fillInMigration() error {
 	})
 	pipe.Batch(100)
 	iter := pipe.Iter()
+	defer iter.Close()
 	modelMigDocs := make(map[string]modelMigDoc)
 	docIds := make([]string, 0)
 	var doc modelMigDoc
@@ -331,6 +337,7 @@ func (p *modelSummaryProcessor) fillInMigration() error {
 	query := migStatus.Find(bson.M{"_id": bson.M{"$in": docIds}})
 	query.Batch(100)
 	iter = query.Iter()
+	defer iter.Close()
 	var statusDoc modelMigStatusDoc
 	for iter.Next(&statusDoc) {
 		doc, ok := modelMigDocs[statusDoc.Id]
@@ -387,6 +394,7 @@ func (p *modelSummaryProcessor) fillInLastAccess() error {
 	query.Select(bson.M{"_id": 1, "model-uuid": 1, "last-connection": 1})
 	query.Batch(100)
 	iter := query.Iter()
+	defer iter.Close()
 	var connInfo modelUserLastConnectionDoc
 	for iter.Next(&connInfo) {
 		idx, ok := p.indexByUUID[connInfo.ModelUUID]

--- a/state/presence/pruner.go
+++ b/state/presence/pruner.go
@@ -109,6 +109,7 @@ func (p *Pruner) removeUnusedBeings(memCache map[int64]string) error {
 	keyCount := 0
 	seqCount := 0
 	iter := p.iterKeys()
+	defer iter.Close()
 	for iter.Next(&keyInfo) {
 		keyCount += 1
 		// Find the max

--- a/state/prune.go
+++ b/state/prune.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/juju/errors"
+	"github.com/juju/juju/mongo"
 	"github.com/juju/loggo"
 	"gopkg.in/mgo.v2"
 	"gopkg.in/mgo.v2/bson"
@@ -181,7 +182,7 @@ func (p *collectionPruner) pruneBySize() error {
 
 func deleteInBatches(
 	coll *mgo.Collection,
-	iter *mgo.Iter,
+	iter mongo.Iterator,
 	logTemplate string,
 	logLevel loggo.Level,
 	shouldStop doneCheck,

--- a/state/spaces.go
+++ b/state/spaces.go
@@ -74,7 +74,7 @@ func (s *Space) Subnets() (results []*Subnet, err error) {
 			results = append(results, subnet)
 		}
 	}
-	if err := iter.Err(); err != nil {
+	if err := iter.Close(); err != nil {
 		return nil, err
 	}
 	return results, nil

--- a/state/state.go
+++ b/state/state.go
@@ -652,6 +652,7 @@ func (st *State) checkCanUpgrade(currentVersion, newVersion string) error {
 			DocID string `bson:"_id"`
 		}
 		iter := collection.Find(sel).Select(bson.D{{"_id", 1}}).Iter()
+		defer iter.Close()
 		for iter.Next(&doc) {
 			localID, err := st.strictLocalID(doc.DocID)
 			if err != nil {

--- a/state/user.go
+++ b/state/user.go
@@ -256,7 +256,7 @@ func (st *State) AllUsers(includeDeactivated bool) ([]*User, error) {
 	for iter.Next(&doc) {
 		result = append(result, &User{st: st, doc: doc})
 	}
-	if err := iter.Err(); err != nil {
+	if err := iter.Close(); err != nil {
 		return nil, errors.Trace(err)
 	}
 	// Always return a predictable order, sort by Name.

--- a/state/watcher.go
+++ b/state/watcher.go
@@ -2505,6 +2505,7 @@ func (w *openedPortsWatcher) initial() (set.Strings, error) {
 	portDocs := set.NewStrings()
 	var doc portsDoc
 	iter := ports.Find(nil).Select(bson.D{{"_id", 1}, {"txn-revno", 1}}).Iter()
+	defer iter.Close()
 	for iter.Next(&doc) {
 		id, err := w.backend.strictLocalID(doc.DocID)
 		if err != nil {


### PR DESCRIPTION
## Description of change

Update the juju/mongo.Query interface to return a juju/mongo.Iterator, and drop its Err() method. Consumers are changed to use the Close() method in call cases (only one required a small logic change; checking Timeout() before closing).

Audit all uses of Iter, adding deferred Close() calls where the closure is otherwise far from creation, and may have early, intervening returns.

## QA steps

juju bootstrap / destroy-controller

## Documentation changes

None.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1739380