### PR TITLE
cmd/juju/controller: fix add-model region usage

### DIFF
--- a/cmd/juju/controller/addmodel_test.go
+++ b/cmd/juju/controller/addmodel_test.go
@@ -260,10 +260,13 @@ func (s *AddModelSuite) TestCredentialsOneCached(c *gc.C) {
 	credentialTag := names.NewCloudCredentialTag("aws/foo/secrets")
 	s.PatchValue(&s.fakeCloudAPI.credentials, []names.CloudCredentialTag{credentialTag})
 
-	_, err := s.run(c, "test")
+	_, err := s.run(c, "test", "aws/us-west-1")
 	c.Assert(err, jc.ErrorIsNil)
 
+	// The cached credential should be used, along with
+	// the user-specified cloud region.
 	c.Assert(s.fakeAddModelAPI.cloudCredential, gc.Equals, credentialTag)
+	c.Assert(s.fakeAddModelAPI.cloudRegion, gc.Equals, "us-west-1")
 }
 
 func (s *AddModelSuite) TestCredentialsDetected(c *gc.C) {


### PR DESCRIPTION
## Description of change

Fix add-model to use the user-specified region
when a credential is not named, one is stored
at the server, and it doesn't also exist in the
user's local credentials file. The user-specified
region should always be used.

## QA steps

1. juju add-credential google
2. juju login jaas
3. juju add-model m1 google/us-east1
4. remove google credential from local file: juju remove-credential google \<name\>
5. juju add-model m2 google/asia-east1 --debug --logging-config \<root\>=TRACE

(the trace logging should show a ModelManager.CreateModel API call with cloud-region=asia-east1)

Repeat with the credential stored locally, with and without a default region set. In all cases, the user-specified region should be used.

## Documentation changes

None.

## Bug reference

Fixes https://bugs.launchpad.net/juju/+bug/1734725