### PR TITLE
Fix race condition in model creation.

### DIFF
--- a/provider/lxd/storage.go
+++ b/provider/lxd/storage.go
@@ -9,7 +9,9 @@ import (
 	"time"
 
 	"github.com/juju/errors"
+	"github.com/juju/retry"
 	"github.com/juju/schema"
+	"github.com/juju/utils/clock"
 	"github.com/juju/utils/set"
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/api"
@@ -189,6 +191,9 @@ func (e *lxdStorageProvider) FilesystemSource(cfg *storage.Config) (storage.File
 }
 
 func ensureLXDStoragePool(env *environ, cfg *lxdStorageConfig) error {
+	// [TODO](externalreality) remove the error classification by string
+	// search found here. We should classify the error in the lxd api
+	// wrapper when lxd provides a more specific return code for the error.
 	err := env.raw.CreateStoragePool(cfg.lxdPool, cfg.driver, cfg.attrs)
 	if err == nil {
 		return nil
@@ -202,26 +207,28 @@ func ensureLXDStoragePool(env *environ, cfg *lxdStorageConfig) error {
 	// encountered when multiple pools are created concurrently.
 	logger.Infof("Attempted to create storage pool %q but it already exists", cfg.lxdPool)
 	var pool api.StoragePool
-	retryCount := 5
-	for retryCount > 0 {
+	retryFn := func() error {
 		pool, err = env.raw.StoragePool(cfg.lxdPool)
+		return err
+	}
+	notifyFn := func(last error, attempt int) {
 		if errors.IsNotFound(err) {
-			logger.Warningf("storage pool not found, %d attempts left", retryCount)
-			time.Sleep(time.Millisecond * 250)
-			retryCount--
-
-			if retryCount > 0 {
-				continue
-			} else {
-				return err
-			}
+			logger.Warningf("storage pool %q not found, %d attempts left", cfg.lxdPool, attempt)
 		}
-
-		if err != nil {
-			return errors.Annotatef(err, "getting storage pool %q", cfg.lxdPool)
-		}
-
-		break
+	}
+	fatalErrorFn := func(err error) bool {
+		return !errors.IsNotFound(err)
+	}
+	err = retry.Call(retry.CallArgs{
+		Func:         retryFn,
+		NotifyFunc:   notifyFn,
+		IsFatalError: fatalErrorFn,
+		Attempts:     5,
+		Delay:        time.Millisecond * 250,
+		Clock:        clock.WallClock,
+	})
+	if err != nil {
+		return errors.Annotatef(err, "getting storage pool %q", cfg.lxdPool)
 	}
 
 	// The storage pool already exists: check that the existing pool's


### PR DESCRIPTION
## Description of change

Model creating isn't thread safe in that if multiple processes run an `add-model` command at the same time aberrant behavior will occur. 

## QA steps

Get Gnu Parallel (you can use `xargs`, a loop, or something else instead)
```
apt install parallel
```

Run a bunch of model create commands at the same time:
```
$ parallel 'juju add-model m{1}{2} --no-switch' ::: `seq 0 9` ::: `seq 0 9`
```

Count the newly created models; we should get 100 which signifies they were all created correctly: 
```
$ [ `juju models | grep ^m[0-9][0-9]  | wc -l` -eq "100" ]
```

Destroy the models:
```
$ parallel 'juju destroy-model m{1}{2}' ::: `seq 0 9` ::: `seq 0 9`
```

Try this a few more times to ensure that no errors caused by races occur

## Documentation changes

N/A

## Bug reference

https://bugs.launchpad.net/juju/+bug/1738614
  
  