### PR TITLE
Backport status history deletion and mongo iterator closure to 2.2

### DIFF
--- a/mongo/collections.go
+++ b/mongo/collections.go
@@ -68,7 +68,7 @@ type Query interface {
 	Explain(result interface{}) error
 	For(result interface{}, f func() error) error
 	Hint(indexKey ...string) Query
-	Iter() *mgo.Iter
+	Iter() Iterator
 	Limit(n int) Query
 	LogReplay() Query
 	MapReduce(job *mgo.MapReduce, result interface{}) (info *mgo.MapReduceInfo, err error)
@@ -81,6 +81,14 @@ type Query interface {
 	Snapshot() Query
 	Sort(fields ...string) Query
 	Tail(timeout time.Duration) *mgo.Iter
+}
+
+// Iterator defines the parts of the mgo.Iter that we use - this
+// interface allows us to switch out the querying for testing.
+type Iterator interface {
+	Next(interface{}) bool
+	Timeout() bool
+	Close() error
 }
 
 // WrapCollection returns a Collection that wraps the supplied *mgo.Collection.
@@ -169,4 +177,8 @@ func (qw queryWrapper) Snapshot() Query {
 
 func (qw queryWrapper) Sort(fields ...string) Query {
 	return queryWrapper{qw.Query.Sort(fields...)}
+}
+
+func (qw queryWrapper) Iter() Iterator {
+	return qw.Query.Iter()
 }

--- a/mongo/oplog.go
+++ b/mongo/oplog.go
@@ -89,7 +89,6 @@ func isRealOplog(c *mgo.Collection) bool {
 // interface allows us to switch out the querying for testing.
 type Iterator interface {
 	Next(interface{}) bool
-	Err() error
 	Timeout() bool
 	Close() error
 }
@@ -220,8 +219,6 @@ func (t *OplogTailer) Err() error {
 }
 
 func (t *OplogTailer) loop() error {
-	var iter Iterator
-
 	// lastTimestamp tracks the most recent oplog timestamp reported.
 	lastTimestamp := t.initialTs
 
@@ -236,15 +233,16 @@ func (t *OplogTailer) loop() error {
 	// See: http://docs.mongodb.org/v2.4/reference/bson-types/#timestamps
 	var idsForLastTimestamp []int64
 
+	newIter := func() Iterator {
+		return t.session.NewIter(lastTimestamp, idsForLastTimestamp)
+	}
+	iter := newIter()
+	defer func() { iter.Close() }() // iter may be replaced, hence closure
+
 	for {
 		if t.dying() {
 			return tomb.ErrDying
 		}
-
-		if iter == nil {
-			iter = t.session.NewIter(lastTimestamp, idsForLastTimestamp)
-		}
-
 		var doc OplogDoc
 		if iter.Next(&doc) {
 			select {
@@ -252,23 +250,21 @@ func (t *OplogTailer) loop() error {
 				return tomb.ErrDying
 			case t.outCh <- &doc:
 			}
-
 			if doc.Timestamp > lastTimestamp {
 				lastTimestamp = doc.Timestamp
 				idsForLastTimestamp = nil
 			}
 			idsForLastTimestamp = append(idsForLastTimestamp, doc.OperationId)
 		} else {
-			if err := iter.Err(); err != nil && err != mgo.ErrCursor {
-				return err
-			}
 			if iter.Timeout() {
 				continue
 			}
+			if err := iter.Close(); err != nil && err != mgo.ErrCursor {
+				return err
+			}
 			// Either there's no error or the error is an expired
-			// cursor. Force recreating the iterator next loop by
-			// marking it as nil.
-			iter = nil
+			// cursor; Recreate the iterator.
+			iter = newIter()
 		}
 	}
 }

--- a/mongo/oplog.go
+++ b/mongo/oplog.go
@@ -85,14 +85,6 @@ func isRealOplog(c *mgo.Collection) bool {
 	return c.Database.Name == "local" && c.Name == "oplog.rs"
 }
 
-// Iterator defines the parts of the mgo.Iter that we use - this
-// interface allows us to switch out the querying for testing.
-type Iterator interface {
-	Next(interface{}) bool
-	Timeout() bool
-	Close() error
-}
-
 // OplogSession represents a connection to the oplog store, used
 // to create an iterator to get oplog documents (and recreate it if it
 // gets killed or times out).

--- a/mongo/oplog_test.go
+++ b/mongo/oplog_test.go
@@ -332,13 +332,6 @@ func (i *fakeIterator) Next(result interface{}) bool {
 	return true
 }
 
-func (i *fakeIterator) Err() error {
-	if i.pos < len(i.docs) {
-		return nil
-	}
-	return i.err
-}
-
 func (i *fakeIterator) Timeout() bool {
 	if i.pos < len(i.docs) {
 		return false
@@ -347,7 +340,10 @@ func (i *fakeIterator) Timeout() bool {
 }
 
 func (i *fakeIterator) Close() error {
-	return nil
+	if i.pos < len(i.docs) {
+		return nil
+	}
+	return i.err
 }
 
 func newFakeIterator(err error, docs ...*mongo.OplogDoc) *fakeIterator {

--- a/state/cleanup.go
+++ b/state/cleanup.go
@@ -10,11 +10,11 @@ import (
 	"github.com/juju/utils/featureflag"
 	"gopkg.in/juju/charm.v6-unstable"
 	"gopkg.in/juju/names.v2"
-	"gopkg.in/mgo.v2"
 	"gopkg.in/mgo.v2/bson"
 	"gopkg.in/mgo.v2/txn"
 
 	"github.com/juju/juju/feature"
+	"github.com/juju/juju/mongo"
 )
 
 type cleanupKind string
@@ -739,7 +739,7 @@ func (st *State) cleanupAttachmentsForDyingFilesystem(filesystemId string) (err 
 	return nil
 }
 
-func closeIter(iter *mgo.Iter, errOut *error, message string) {
+func closeIter(iter mongo.Iterator, errOut *error, message string) {
 	err := iter.Close()
 	if err == nil {
 		return

--- a/state/cloud.go
+++ b/state/cloud.go
@@ -109,7 +109,7 @@ func (st *State) Clouds() (map[names.CloudTag]cloud.Cloud, error) {
 	for iter.Next(&doc) {
 		clouds[names.NewCloudTag(doc.Name)] = doc.toCloud()
 	}
-	if err := iter.Err(); err != nil {
+	if err := iter.Close(); err != nil {
 		return nil, errors.Annotate(err, "getting clouds")
 	}
 	return clouds, nil

--- a/state/dump.go
+++ b/state/dump.go
@@ -58,7 +58,7 @@ func getAllModelDocs(st *State, collectionName string) ([]map[string]interface{}
 		doc = nil
 	}
 
-	if err := iter.Err(); err != nil {
+	if err := iter.Close(); err != nil {
 		return nil, errors.Annotatef(err, "reading collection %q", collectionName)
 	}
 	return result, nil

--- a/state/export_test.go
+++ b/state/export_test.go
@@ -336,7 +336,7 @@ func GetAllUpgradeInfos(st *State) ([]*UpgradeInfo, error) {
 	for iter.Next(&doc) {
 		out = append(out, &UpgradeInfo{st: st, doc: doc})
 	}
-	if err := iter.Err(); err != nil {
+	if err := iter.Close(); err != nil {
 		return nil, err
 	}
 	return out, nil

--- a/state/logs.go
+++ b/state/logs.go
@@ -444,6 +444,7 @@ func (t *logTailer) processReversed(query *mgo.Query) error {
 	query.Sort("-t", "-_id")
 	query.Limit(t.params.InitialLines)
 	iter := query.Iter()
+	defer iter.Close()
 	queue := make([]logDoc, t.params.InitialLines)
 	cur := t.params.InitialLines
 	var doc logDoc
@@ -507,6 +508,7 @@ func (t *logTailer) processCollection() error {
 	// a good value, or end the method.
 	deserialisationFailures := 0
 	iter := query.Sort("t", "_id").Iter()
+	defer iter.Close()
 	for iter.Next(&doc) {
 		rec, err := logDocToRecord(t.modelUUID, &doc)
 		if err != nil {

--- a/state/migration_export.go
+++ b/state/migration_export.go
@@ -610,7 +610,7 @@ func (e *exporter) readAllStorageConstraints() error {
 	for iter.Next(&doc) {
 		storageConstraints[e.st.localID(doc.DocID)] = doc
 	}
-	if err := iter.Err(); err != nil {
+	if err := iter.Close(); err != nil {
 		return errors.Annotate(err, "failed to read storage constraints")
 	}
 	e.logger.Debugf("read %d storage constraint documents", len(storageConstraints))
@@ -1328,7 +1328,7 @@ func (e *exporter) readAllStatusHistory() error {
 		count++
 	}
 
-	if err := iter.Err(); err != nil {
+	if err := iter.Close(); err != nil {
 		return errors.Annotate(err, "failed to read status history collection")
 	}
 
@@ -1545,7 +1545,7 @@ func (e *exporter) volumes() error {
 			return errors.Trace(err)
 		}
 	}
-	if err := iter.Err(); err != nil {
+	if err := iter.Close(); err != nil {
 		return errors.Annotate(err, "failed to read volumes")
 	}
 	return nil
@@ -1630,7 +1630,7 @@ func (e *exporter) readVolumeAttachments() (map[string][]volumeAttachmentDoc, er
 		result[doc.Volume] = append(result[doc.Volume], doc)
 		count++
 	}
-	if err := iter.Err(); err != nil {
+	if err := iter.Close(); err != nil {
 		return nil, errors.Annotate(err, "failed to read volumes attachments")
 	}
 	e.logger.Debugf("read %d volume attachment documents", count)
@@ -1655,7 +1655,7 @@ func (e *exporter) filesystems() error {
 			return errors.Trace(err)
 		}
 	}
-	if err := iter.Err(); err != nil {
+	if err := iter.Close(); err != nil {
 		return errors.Annotate(err, "failed to read filesystems")
 	}
 	return nil
@@ -1733,7 +1733,7 @@ func (e *exporter) readFilesystemAttachments() (map[string][]filesystemAttachmen
 		result[doc.Filesystem] = append(result[doc.Filesystem], doc)
 		count++
 	}
-	if err := iter.Err(); err != nil {
+	if err := iter.Close(); err != nil {
 		return nil, errors.Annotate(err, "failed to read filesystem attachments")
 	}
 	e.logger.Debugf("read %d filesystem attachment documents", count)
@@ -1758,7 +1758,7 @@ func (e *exporter) storageInstances() error {
 			return errors.Trace(err)
 		}
 	}
-	if err := iter.Err(); err != nil {
+	if err := iter.Close(); err != nil {
 		return errors.Annotate(err, "failed to read storage instances")
 	}
 	return nil
@@ -1796,7 +1796,7 @@ func (e *exporter) readStorageAttachments() (map[string][]names.UnitTag, error) 
 		result[doc.StorageInstance] = append(result[doc.StorageInstance], unit)
 		count++
 	}
-	if err := iter.Err(); err != nil {
+	if err := iter.Close(); err != nil {
 		return nil, errors.Annotate(err, "failed to read storage attachments")
 	}
 	e.logger.Debugf("read %d storage attachment documents", count)

--- a/state/presence/pruner.go
+++ b/state/presence/pruner.go
@@ -109,6 +109,7 @@ func (p *Pruner) removeUnusedBeings() error {
 	keyCount := 0
 	seqCount := 0
 	iter := p.iterKeys()
+	defer iter.Close()
 	for iter.Next(&keyInfo) {
 		keyCount += 1
 		// Find the max

--- a/state/prune.go
+++ b/state/prune.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/juju/errors"
+	"github.com/juju/juju/mongo"
 	"github.com/juju/loggo"
 	"gopkg.in/mgo.v2"
 	"gopkg.in/mgo.v2/bson"
@@ -178,7 +179,7 @@ func (p *collectionPruner) pruneBySize() error {
 
 func deleteInBatches(
 	coll *mgo.Collection,
-	iter *mgo.Iter,
+	iter mongo.Iterator,
 	logTemplate string,
 	logLevel loggo.Level,
 	shouldStop doneCheck,

--- a/state/spaces.go
+++ b/state/spaces.go
@@ -67,7 +67,7 @@ func (s *Space) Subnets() (results []*Subnet, err error) {
 		subnet := &Subnet{s.st, doc}
 		results = append(results, subnet)
 	}
-	if err := iter.Err(); err != nil {
+	if err := iter.Close(); err != nil {
 		return nil, err
 	}
 	return results, nil

--- a/state/state.go
+++ b/state/state.go
@@ -619,6 +619,7 @@ func (st *State) checkCanUpgrade(currentVersion, newVersion string) error {
 			DocID string `bson:"_id"`
 		}
 		iter := collection.Find(sel).Select(bson.D{{"_id", 1}}).Iter()
+		defer iter.Close()
 		for iter.Next(&doc) {
 			localID, err := st.strictLocalID(doc.DocID)
 			if err != nil {

--- a/state/status.go
+++ b/state/status.go
@@ -4,9 +4,11 @@
 package state
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/juju/errors"
+	"github.com/juju/loggo"
 	jujutxn "github.com/juju/txn"
 	"github.com/juju/utils/clock"
 	"gopkg.in/mgo.v2"
@@ -363,13 +365,36 @@ func probablyUpdateStatusHistory(db Database, globalKey string, doc statusDoc) {
 	}
 }
 
+// eraseStatusHistory removes all status history documents for
+// the given global key. The documents are removed in batches
+// to avoid locking the status history collection for extended
+// periods of time, preventing status history being recorded
+// for other entities.
 func eraseStatusHistory(st *State, globalKey string) error {
+	// TODO(axw) restructure status history so we have one
+	// document per global key, and sub-documents per status
+	// recording. This method would then become a single
+	// Remove operation.
+
 	history, closer := st.db().GetCollection(statusesHistoryC)
 	defer closer()
-	historyW := history.Writeable()
 
-	if _, err := historyW.RemoveAll(bson.D{{globalKeyField, globalKey}}); err != nil {
-		return err
+	iter := history.Find(bson.D{{
+		globalKeyField, globalKey,
+	}}).Select(bson.M{"_id": 1}).Iter()
+	defer iter.Close()
+
+	logFormat := "deleted %d status history documents for " + fmt.Sprintf("%q", globalKey)
+	deleted, err := deleteInBatches(
+		history.Writeable().Underlying(), iter,
+		logFormat, loggo.DEBUG,
+		noEarlyFinish,
+	)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	if deleted > 0 {
+		logger.Debugf(logFormat, deleted)
 	}
 	return nil
 }

--- a/state/user.go
+++ b/state/user.go
@@ -254,7 +254,7 @@ func (st *State) AllUsers(includeDeactivated bool) ([]*User, error) {
 	for iter.Next(&doc) {
 		result = append(result, &User{st: st, doc: doc})
 	}
-	if err := iter.Err(); err != nil {
+	if err := iter.Close(); err != nil {
 		return nil, errors.Trace(err)
 	}
 	// Always return a predictable order, sort by Name.

--- a/state/watcher.go
+++ b/state/watcher.go
@@ -2322,6 +2322,7 @@ func (w *openedPortsWatcher) initial() (set.Strings, error) {
 	portDocs := set.NewStrings()
 	var doc portsDoc
 	iter := ports.Find(nil).Select(bson.D{{"_id", 1}, {"txn-revno", 1}}).Iter()
+	defer iter.Close()
 	for iter.Next(&doc) {
 		id, err := w.backend.strictLocalID(doc.DocID)
 		if err != nil {


### PR DESCRIPTION
## Description of change

Backport #8254 and #8255 to the 2.2 branch.

## QA steps

Smoke test bootstrap/deploy/destroy-controller.

## Documentation changes

None.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1733708
https://bugs.launchpad.net/juju/+bug/1739380