### PR TITLE
Only have one top level $addToSet

### DIFF
--- a/state/addmachine.go
+++ b/state/addmachine.go
@@ -802,8 +802,12 @@ func (st *State) maintainControllersOps(mdocs []*machineDoc, currentInfo *Contro
 			},
 		}},
 		Update: bson.D{
-			{"$addToSet", bson.D{{"machineids", bson.D{{"$each", newIds}}}}},
-			{"$addToSet", bson.D{{"votingmachineids", bson.D{{"$each", newVotingIds}}}}},
+			{"$addToSet",
+				bson.D{
+					{"machineids", bson.D{{"$each", newIds}}},
+					{"votingmachineids", bson.D{{"$each", newVotingIds}}},
+				},
+			},
 		},
 	}}
 	return ops, nil
@@ -1078,8 +1082,10 @@ func convertControllerOps(m *Machine) []txn.Op {
 		C:  controllersC,
 		Id: modelGlobalKey,
 		Update: bson.D{
-			{"$addToSet", bson.D{{"votingmachineids", m.doc.Id}}},
-			{"$addToSet", bson.D{{"machineids", m.doc.Id}}},
+			{"$addToSet", bson.D{
+				{"votingmachineids", m.doc.Id},
+				{"machineids", m.doc.Id},
+			}},
 		},
 	}}
 }


### PR DESCRIPTION
Solutions QA were hitting a situation where regularly their enable-ha command wouldn't result in a mongo replicaset being set up.

Debugging lead to the observation that the controller document had
  "machineids": ["0"],
and
  "votingmachineids":["0", "1", "2"]

The code always expects that "machineids" is a superset of "votingmachineids".

The transaction ops that were created specified the "$addToSet" mongo operator as a key for two different bson.D values. When this transaction is stashed and recovered, this is flattened to a bson.M that just has a single value.

## QA steps
```
juju bootstrap
juju enable-ha
```
You get a replica-set enabled juju.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1720251