### PR TITLE
juju ssh: client terminal implies --pty=true

### DIFF
--- a/cmd/juju/commands/debughooks_test.go
+++ b/cmd/juju/commands/debughooks_test.go
@@ -35,7 +35,6 @@ var debugHooksTests = []struct {
 	expected: &argsSpec{
 		hostKeyChecking: "yes",
 		knownHosts:      "0",
-		enablePty:       true,
 		args:            "ubuntu@0.public sudo /bin/bash -c 'F=$(mktemp); echo IyEvYmluL2Jhc2gKKApjbGVhbnVwX29uX2V4aXQoKSAKeyAKCWVjaG8gIkNsZWFuaW5nIHVwIHRoZSBkZWJ1ZyBzZXNzaW9uIgoJdG11eCBraWxsLXNlc3Npb24gLXQgbXlzcWwvMDsgCn0KdHJhcCBjbGVhbnVwX29uX2V4aXQgRVhJVAoKIyBMb2NrIHRoZSBqdWp1LTx1bml0Pi1kZWJ1ZyBsb2NrZmlsZS4KZmxvY2sgLW4gOCB8fCAoCgllY2hvICJGb3VuZCBleGlzdGluZyBkZWJ1ZyBzZXNzaW9ucywgYXR0ZW1wdGluZyB0byByZWNvbm5lY3QiIDI+JjEKCWV4ZWMgdG11eCBhdHRhY2gtc2Vzc2lvbiAtdCBteXNxbC8wCglleGl0ICQ/CgkpCigKIyBDbG9zZSB0aGUgaW5oZXJpdGVkIGxvY2sgRkQsIG9yIHRtdXggd2lsbCBrZWVwIGl0IG9wZW4uCmV4ZWMgOD4mLQoKIyBXcml0ZSBvdXQgdGhlIGRlYnVnLWhvb2tzIGFyZ3MuCmVjaG8gImUzMEsiIHwgYmFzZTY0IC1kID4gL3RtcC9qdWp1LXVuaXQtbXlzcWwtMC1kZWJ1Zy1ob29rcwoKIyBMb2NrIHRoZSBqdWp1LTx1bml0Pi1kZWJ1Zy1leGl0IGxvY2tmaWxlLgpmbG9jayAtbiA5IHx8IGV4aXQgMQoKIyBXYWl0IGZvciB0bXV4IHRvIGJlIGluc3RhbGxlZC4Kd2hpbGUgWyAhIC1mIC91c3IvYmluL3RtdXggXTsgZG8KICAgIHNsZWVwIDEKZG9uZQoKaWYgWyAhIC1mIH4vLnRtdXguY29uZiBdOyB0aGVuCiAgICAgICAgaWYgWyAtZiAvdXNyL3NoYXJlL2J5b2J1L3Byb2ZpbGVzL3RtdXggXTsgdGhlbgogICAgICAgICAgICAgICAgIyBVc2UgYnlvYnUvdG11eCBwcm9maWxlIGZvciBmYW1pbGlhciBrZXliaW5kaW5ncyBhbmQgYnJhbmRpbmcKICAgICAgICAgICAgICAgIGVjaG8gInNvdXJjZS1maWxlIC91c3Ivc2hhcmUvYnlvYnUvcHJvZmlsZXMvdG11eCIgPiB+Ly50bXV4LmNvbmYKICAgICAgICBlbHNlCiAgICAgICAgICAgICAgICAjIE90aGVyd2lzZSwgdXNlIHRoZSBsZWdhY3kganVqdS90bXV4IGNvbmZpZ3VyYXRpb24KICAgICAgICAgICAgICAgIGNhdCA+IH4vLnRtdXguY29uZiA8PEVORAogICAgICAgICAgICAgICAgCiMgU3RhdHVzIGJhcgpzZXQtb3B0aW9uIC1nIHN0YXR1cy1iZyBibGFjawpzZXQtb3B0aW9uIC1nIHN0YXR1cy1mZyB3aGl0ZQoKc2V0LXdpbmRvdy1vcHRpb24gLWcgd2luZG93LXN0YXR1cy1jdXJyZW50LWJnIHJlZApzZXQtd2luZG93LW9wdGlvbiAtZyB3aW5kb3ctc3RhdHVzLWN1cnJlbnQtYXR0ciBicmlnaHQKCnNldC1vcHRpb24gLWcgc3RhdHVzLXJpZ2h0ICcnCgojIFBhbmVzCnNldC1vcHRpb24gLWcgcGFuZS1ib3JkZXItZmcgd2hpdGUKc2V0LW9wdGlvbiAtZyBwYW5lLWFjdGl2ZS1ib3JkZXItZmcgd2hpdGUKCiMgTW9uaXRvciBhY3Rpdml0eSBvbiB3aW5kb3dzCnNldC13aW5kb3ctb3B0aW9uIC1nIG1vbml0b3ItYWN0aXZpdHkgb24KCiMgU2NyZWVuIGJpbmRpbmdzLCBzaW5jZSBwZW9wbGUgYXJlIG1vcmUgZmFtaWxpYXIgd2l0aCB0aGF0LgpzZXQtb3B0aW9uIC1nIHByZWZpeCBDLWEKYmluZCBDLWEgbGFzdC13aW5kb3cKYmluZCBhIHNlbmQta2V5IEMtYQoKYmluZCB8IHNwbGl0LXdpbmRvdyAtaApiaW5kIC0gc3BsaXQtd2luZG93IC12CgojIEZpeCBDVFJMLVBHVVAvUEdET1dOIGZvciB2aW0Kc2V0LXdpbmRvdy1vcHRpb24gLWcgeHRlcm0ta2V5cyBvbgoKIyBQcmV2ZW50IEVTQyBrZXkgZnJvbSBhZGRpbmcgZGVsYXkgYW5kIGJyZWFraW5nIFZpbSdzIEVTQyA+IGFycm93IGtleQpzZXQtb3B0aW9uIC1zIGVzY2FwZS10aW1lIDAKCkVORAogICAgICAgIGZpCmZpCgooCiAgICAjIENsb3NlIHRoZSBpbmhlcml0ZWQgbG9jayBGRCwgb3IgdG11eCB3aWxsIGtlZXAgaXQgb3Blbi4KICAgIGV4ZWMgOT4mLQogICAgaWYgISB0bXV4IGhhcy1zZXNzaW9uIC10IG15c3FsLzA7IHRoZW4KCQl0bXV4IG5ldy1zZXNzaW9uIC1kIC1zIG15c3FsLzAKCWZpCgljbGllbnRfY291bnQ9JCh0bXV4IGxpc3QtY2xpZW50cyB8IHdjIC1sKQoJaWYgWyAkY2xpZW50X2NvdW50IC1nZSAxIF07IHRoZW4KCQlzZXNzaW9uX25hbWU9bXlzcWwvMCItIiRjbGllbnRfY250CgkJZXhlYyB0bXV4IG5ldy1zZXNzaW9uIC1kIC10IG15c3FsLzAgLXMgJHNlc3Npb25fbmFtZQoJCWV4ZWMgdG11eCBhdHRhY2gtc2Vzc2lvbiAtdCAkc2Vzc2lvbl9uYW1lIFw7IHNldC1vcHRpb24gZGVzdHJveS11bmF0dGFjaGVkCgllbHNlCgkgICAgZXhlYyB0bXV4IGF0dGFjaC1zZXNzaW9uIC10IG15c3FsLzAKCWZpCikKKSA5Pi90bXAvanVqdS11bml0LW15c3FsLTAtZGVidWctaG9va3MtZXhpdAopIDg+L3RtcC9qdWp1LXVuaXQtbXlzcWwtMC1kZWJ1Zy1ob29rcwpleGl0ICQ/Cg== | base64 -d > $F; . $F'",
 	},
 }, {
@@ -46,7 +45,6 @@ var debugHooksTests = []struct {
 	expected: &argsSpec{
 		hostKeyChecking: "yes",
 		knownHosts:      "0",
-		enablePty:       true,
 		argsMatch:       `ubuntu@0\.public sudo /bin/bash .+`,
 	},
 }, {
@@ -57,7 +55,6 @@ var debugHooksTests = []struct {
 	expected: &argsSpec{
 		hostKeyChecking: "yes",
 		knownHosts:      "0",
-		enablePty:       true,
 		argsMatch:       `ubuntu@0\.(private|public|1\.2\.3) sudo .+`, // can be any of the 3
 	},
 }, {
@@ -68,7 +65,6 @@ var debugHooksTests = []struct {
 	expected: &argsSpec{
 		hostKeyChecking: "yes",
 		knownHosts:      "0",
-		enablePty:       true,
 		withProxy:       true,
 		argsMatch:       `ubuntu@0\.private sudo /bin/bash .+`,
 	},
@@ -80,8 +76,18 @@ var debugHooksTests = []struct {
 	expected: &argsSpec{
 		hostKeyChecking: "yes",
 		knownHosts:      "0",
-		enablePty:       true,
 		withProxy:       true,
+		argsMatch:       `ubuntu@0\.(private|public|1\.2\.3) sudo .+`, // can be any of the 3
+	},
+}, {
+	info:        "pty enabled",
+	args:        []string{"--pty=true", "mysql/0"},
+	hostChecker: validAddresses("0.private", "0.public", "0.1.2.3"), // set by setAddresses() and setLinkLayerDevicesAddresses()
+	forceAPIv1:  false,
+	expected: &argsSpec{
+		hostKeyChecking: "yes",
+		knownHosts:      "0",
+		enablePty:       true,
 		argsMatch:       `ubuntu@0\.(private|public|1\.2\.3) sudo .+`, // can be any of the 3
 	},
 }, {

--- a/cmd/juju/commands/debuglog.go
+++ b/cmd/juju/commands/debuglog.go
@@ -5,7 +5,6 @@ package commands
 
 import (
 	"fmt"
-	"io"
 	"os"
 	"strings"
 	"time"
@@ -229,12 +228,12 @@ var getDebugLogAPI = func(c *debugLogCommand) (DebugLogAPI, error) {
 	return c.NewAPIClient()
 }
 
-func isTerminal(out io.Writer) bool {
-	f, ok := out.(*os.File)
+func isTerminal(f interface{}) bool {
+	f_, ok := f.(*os.File)
 	if !ok {
 		return false
 	}
-	return isatty.IsTerminal(f.Fd())
+	return isatty.IsTerminal(f_.Fd())
 }
 
 // Run retrieves the debug log via the API.

--- a/cmd/juju/commands/main.go
+++ b/cmd/juju/commands/main.go
@@ -302,7 +302,7 @@ func registerCommands(r commandRegistry, ctx *cmd.Context) {
 	// Error resolution and debugging commands.
 	r.Register(newDefaultRunCommand())
 	r.Register(newSCPCommand(nil))
-	r.Register(newSSHCommand(nil))
+	r.Register(newSSHCommand(nil, nil))
 	r.Register(newResolvedCommand())
 	r.Register(newDebugLogCommand())
 	r.Register(newDebugHooksCommand(nil))

--- a/cmd/juju/commands/ssh_common.go
+++ b/cmd/juju/commands/ssh_common.go
@@ -32,7 +32,6 @@ import (
 type SSHCommon struct {
 	modelcmd.ModelCommandBase
 	proxy           bool
-	pty             bool
 	noHostKeyChecks bool
 	Target          string
 	Args            []string
@@ -112,7 +111,6 @@ var sshHostFromTargetAttemptStrategy attemptStarter = attemptStrategy{
 func (c *SSHCommon) SetFlags(f *gnuflag.FlagSet) {
 	c.ModelCommandBase.SetFlags(f)
 	f.BoolVar(&c.proxy, "proxy", false, "Proxy through the API server")
-	f.BoolVar(&c.pty, "pty", true, "Enable pseudo-tty allocation")
 	f.BoolVar(&c.noHostKeyChecks, "no-host-key-checks", false, "Skip host key checking (INSECURE)")
 }
 

--- a/cmd/juju/commands/ssh_unix_test.go
+++ b/cmd/juju/commands/ssh_unix_test.go
@@ -29,6 +29,7 @@ var sshTests = []struct {
 	about       string
 	args        []string
 	hostChecker jujussh.ReachableChecker
+	isTerminal  bool
 	forceAPIv1  bool
 	expected    argsSpec
 	expectedErr string
@@ -41,7 +42,6 @@ var sshTests = []struct {
 		expected: argsSpec{
 			hostKeyChecking: "yes",
 			knownHosts:      "0",
-			enablePty:       true,
 			args:            "ubuntu@0.public",
 		},
 	},
@@ -53,7 +53,6 @@ var sshTests = []struct {
 		expected: argsSpec{
 			hostKeyChecking: "yes",
 			knownHosts:      "0",
-			enablePty:       true,
 			argsMatch:       `ubuntu@0.(public|private|1\.2\.3)`, // can be any of the 3
 		},
 	},
@@ -64,18 +63,41 @@ var sshTests = []struct {
 		expected: argsSpec{
 			hostKeyChecking: "yes",
 			knownHosts:      "0",
-			enablePty:       true,
 			args:            "ubuntu@0.public uname -a",
 		},
 	},
 	{
-		about:       "connect to machine 0 with no pseudo-tty",
-		args:        []string{"--pty=false", "0"},
+		about:       "connect to machine 0 with implied pseudo-tty",
+		args:        []string{"0"},
+		hostChecker: validAddresses("0.public"),
+		isTerminal:  true,
+		expected: argsSpec{
+			hostKeyChecking: "yes",
+			knownHosts:      "0",
+			enablePty:       true, // implied by client's terminal
+			args:            "ubuntu@0.public",
+		},
+	},
+	{
+		about:       "connect to machine 0 with pseudo-tty",
+		args:        []string{"--pty=true", "0"},
 		hostChecker: validAddresses("0.public"),
 		expected: argsSpec{
 			hostKeyChecking: "yes",
 			knownHosts:      "0",
-			enablePty:       false,
+			enablePty:       true,
+			args:            "ubuntu@0.public",
+		},
+	},
+	{
+		about:       "connect to machine 0 without pseudo-tty",
+		args:        []string{"--pty=false", "0"},
+		hostChecker: validAddresses("0.public"),
+		isTerminal:  true,
+		expected: argsSpec{
+			hostKeyChecking: "yes",
+			knownHosts:      "0",
+			enablePty:       false, // explicitly disabled
 			args:            "ubuntu@0.public",
 		},
 	},
@@ -92,7 +114,6 @@ var sshTests = []struct {
 		expected: argsSpec{
 			hostKeyChecking: "no",
 			knownHosts:      "null",
-			enablePty:       true,
 			args:            "ubuntu@1.public",
 		},
 	},
@@ -105,7 +126,6 @@ var sshTests = []struct {
 			// StrictHostKeyChecking config.
 			hostKeyChecking: "",
 			knownHosts:      "",
-			enablePty:       true,
 			args:            "foo@some.host",
 		},
 	},
@@ -116,7 +136,6 @@ var sshTests = []struct {
 		expected: argsSpec{
 			hostKeyChecking: "yes",
 			knownHosts:      "0",
-			enablePty:       true,
 			args:            "ubuntu@0.public",
 		},
 	},
@@ -127,7 +146,6 @@ var sshTests = []struct {
 		expected: argsSpec{
 			hostKeyChecking: "yes",
 			knownHosts:      "0",
-			enablePty:       true,
 			args:            "mongo@0.public",
 		},
 	},
@@ -138,7 +156,6 @@ var sshTests = []struct {
 		expected: argsSpec{
 			hostKeyChecking: "yes",
 			knownHosts:      "0",
-			enablePty:       true,
 			args:            "ubuntu@0.public ls /",
 		},
 	},
@@ -150,7 +167,6 @@ var sshTests = []struct {
 		expected: argsSpec{
 			hostKeyChecking: "yes",
 			knownHosts:      "0",
-			enablePty:       true,
 			withProxy:       true,
 			args:            "ubuntu@0.private",
 		},
@@ -163,7 +179,6 @@ var sshTests = []struct {
 		expected: argsSpec{
 			hostKeyChecking: "yes",
 			knownHosts:      "0",
-			enablePty:       true,
 			withProxy:       true,
 			argsMatch:       `ubuntu@0.private`,
 		},
@@ -176,10 +191,14 @@ func (s *SSHSuite) TestSSHCommand(c *gc.C) {
 	for i, t := range sshTests {
 		c.Logf("test %d: %s -> %s", i, t.about, t.args)
 
-		s.setHostChecker(t.hostChecker)
 		s.setForceAPIv1(t.forceAPIv1)
 
-		ctx, err := cmdtesting.RunCommand(c, newSSHCommand(s.hostChecker), t.args...)
+		isTerminal := func(stdin interface{}) bool {
+			return t.isTerminal
+		}
+		cmd := newSSHCommand(t.hostChecker, isTerminal)
+
+		ctx, err := cmdtesting.RunCommand(c, cmd, t.args...)
 		if t.expectedErr != "" {
 			c.Check(err, gc.ErrorMatches, t.expectedErr)
 		} else {
@@ -200,20 +219,19 @@ func (s *SSHSuite) TestSSHCommandModelConfigProxySSH(c *gc.C) {
 
 	s.setForceAPIv1(true)
 
-	ctx, err := cmdtesting.RunCommand(c, newSSHCommand(s.hostChecker), "0")
+	ctx, err := cmdtesting.RunCommand(c, newSSHCommand(s.hostChecker, nil), "0")
 	c.Check(err, jc.ErrorIsNil)
 	c.Check(cmdtesting.Stderr(ctx), gc.Equals, "")
 	expectedArgs := argsSpec{
 		hostKeyChecking: "yes",
 		knownHosts:      "0",
-		enablePty:       true,
 		withProxy:       true,
 		args:            "ubuntu@0.private", // as set by setAddresses()
 	}
 	expectedArgs.check(c, cmdtesting.Stdout(ctx))
 
 	s.setForceAPIv1(false)
-	ctx, err = cmdtesting.RunCommand(c, newSSHCommand(s.hostChecker), "0")
+	ctx, err = cmdtesting.RunCommand(c, newSSHCommand(s.hostChecker, nil), "0")
 	c.Check(err, jc.ErrorIsNil)
 	c.Check(cmdtesting.Stderr(ctx), gc.Equals, "")
 	expectedArgs.argsMatch = `ubuntu@0.(public|private|1\.2\.3)` // can be any of the 3 with api v2.
@@ -287,7 +305,7 @@ func (s *SSHSuite) testSSHCommandHostAddressRetry(c *gc.C, proxy bool) {
 	// Ensure that the ssh command waits for a public (private with proxy=true)
 	// address, or the attempt strategy's Done method returns false.
 	args := []string{"--proxy=" + fmt.Sprint(proxy), "0"}
-	_, err := cmdtesting.RunCommand(c, newSSHCommand(s.hostChecker), args...)
+	_, err := cmdtesting.RunCommand(c, newSSHCommand(s.hostChecker, nil), args...)
 	c.Assert(err, gc.ErrorMatches, `no .+ address\(es\)`)
 	c.Assert(called, gc.Equals, 2)
 
@@ -306,7 +324,7 @@ func (s *SSHSuite) testSSHCommandHostAddressRetry(c *gc.C, proxy bool) {
 		return true
 	}
 
-	_, err = cmdtesting.RunCommand(c, newSSHCommand(s.hostChecker), args...)
+	_, err = cmdtesting.RunCommand(c, newSSHCommand(s.hostChecker, nil), args...)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(called, gc.Equals, 2)
 }


### PR DESCRIPTION
## Description of change

If the client has a terminal, then "juju ssh"
(and "juju debug-hooks") will have --pty=true
set implicitly. If the user specifies a value
using --pty[=true] or --pty=false explicitly,
that value will always take precedence.

## QA steps

1. juju bootstrap localhost
2. juju add-machine
3. juju ssh 0
(should get an interactive terminal)
4. Make sure pty is not allocated if stdin is not a terminal:

```
$ juju ssh 0 'sleep 1; grep blah; asdf' <<EOF
foo
blah
bar
EOF
```

Expected output:
```
blah
bash: asdf: command not found
```

## Documentation changes

Help text for "juju ssh" has been updated. https://jujucharms.com/docs/stable/commands will need updating. Note the default value for --pty is shown as `<auto>` in the command help output now, and there's a new paragraph explaining the behaviour.

## Bug reference

Fixes https://bugs.launchpad.net/juju/+bug/1734221