### PR TITLE
Fix lp:1740969, don't fail if the mgo role has been created already

### DIFF
--- a/apiserver/facades/client/backups/restore.go
+++ b/apiserver/facades/client/backups/restore.go
@@ -140,8 +140,8 @@ func (a *API) FinishRestore() error {
 		if err := info.SetStatus(state.RestoreFailed); err != nil {
 			return errors.Trace(err)
 		}
-		return errors.Errorf("Restore did not finish succesfuly")
+		return errors.Errorf("Restore did not finish successfully")
 	}
-	logger.Infof("Succesfully restored")
+	logger.Infof("Successfully restored")
 	return info.SetStatus(state.RestoreChecked)
 }

--- a/state/backups/db.go
+++ b/state/backups/db.go
@@ -426,12 +426,12 @@ func (md *mongoRestorer32) ensureOplogPermissions(dialInfo *mgo.DialInfo) error 
 	}
 	var mgoErr bson.M
 	err = s.Run(roles, &mgoErr)
-	if err != nil {
+	if err != nil && !mgo.IsDup(err) {
 		return errors.Trace(err)
 	}
 	result, ok := mgoErr["ok"]
 	success, isFloat := result.(float64)
-	if (!ok || !isFloat || success != 1) && mgoErr != nil {
+	if (!ok || !isFloat || success != 1) && mgoErr != nil && !mgo.IsDup(err) {
 		return errors.Errorf("could not create special role to replay oplog, result was: %#v", mgoErr)
 	}
 


### PR DESCRIPTION
## Description of change

Fix lp:1740969, don't fail if the oploger role has been created already in a restore operation.
Fix misspellings in Error output.

## QA steps

1. juju create-backup -m controller
2. juju restore-backup -m controller --id <id from create in step 1>
3. repeat step 2, should succeed the 2nd time as well.

## Documentation changes

N/A

## Bug reference

https://bugs.launchpad.net/juju/+bug/1740969