### PR TITLE
Update backup-restore error message when not using the controller model.

### DIFF
--- a/apiserver/facades/client/backups/backups.go
+++ b/apiserver/facades/client/backups/backups.go
@@ -60,7 +60,7 @@ func NewAPI(backend Backend, resources facade.Resources, authorizer facade.Autho
 
 	// For now, backup operations are only permitted on the controller environment.
 	if !backend.IsController() {
-		return nil, errors.New("backups are not supported for hosted models")
+		return nil, errors.New("backups are only supported from the controller model\nUse juju switch to select the controller model")
 	}
 
 	// Get the backup paths.

--- a/apiserver/facades/client/backups/backups_test.go
+++ b/apiserver/facades/client/backups/backups_test.go
@@ -98,5 +98,5 @@ func (s *backupsSuite) TestNewAPIHostedEnvironmentFails(c *gc.C) {
 	otherModel, err := otherState.Model()
 	c.Assert(err, jc.ErrorIsNil)
 	_, err = backupsAPI.NewAPI(&stateShim{otherState, otherModel}, s.resources, s.authorizer)
-	c.Check(err, gc.ErrorMatches, "backups are not supported for hosted models")
+	c.Check(err, gc.ErrorMatches, "backups are only supported from the controller model\nUse juju switch to select the controller model")
 }


### PR DESCRIPTION
## Description of change

Rewriting the error message when running a backup or restore cmd from a model other than
the controller to reduce confusion. 

## QA steps

Run any backup-restore command from a model other than controller to see new error output.

## Documentation changes

n/a

## Bug reference

https://bugs.launchpad.net/juju/+bug/1576184