### PR TITLE
state: escape region name subdocument keys

### DIFF
--- a/mongo/utils/data_cleansing.go
+++ b/mongo/utils/data_cleansing.go
@@ -17,14 +17,14 @@ func UnescapeKeys(input map[string]interface{}) map[string]interface{} {
 	return mapKeys(unescapeReplacer.Replace, input)
 }
 
-// EscapeString escapes a string to be safe to store in Mongo.
-func EscapeString(s string) string {
+// EscapeKey escapes a string to be safe to store in Mongo as a document key.
+func EscapeKey(s string) string {
 	return escapeReplacer.Replace(s)
 }
 
-// UnescapeString restores escaped characters from a string to their
+// UnescapeKey restores escaped characters from a key to their
 // original values.
-func UnescapeString(s string) string {
+func UnescapeKey(s string) string {
 	return unescapeReplacer.Replace(s)
 }
 

--- a/mongo/utils/data_cleansing_test.go
+++ b/mongo/utils/data_cleansing_test.go
@@ -66,7 +66,7 @@ func (s *dataCleansingSuite) TestUnescapeKey_UnescapesPeriods(c *gc.C) {
 	})
 }
 
-func (s *dataCleansingSuite) TestUnescapeKey_UnescapesDollarSigns(c *gc.C) {
+func (s *dataCleansingSuite) TestUnescapeKeys_UnescapesDollarSigns(c *gc.C) {
 	before := map[string]interface{}{
 		"\uff04" + "a": "c",
 	}
@@ -94,18 +94,18 @@ func (s *dataCleansingSuite) TestUnescapeKeys_RecursivelyUnescapes(c *gc.C) {
 	})
 }
 
-func (s *dataCleansingSuite) TestEscapeString_EscapesPeriods(c *gc.C) {
-	c.Check("a"+"\uff0e"+"b", gc.Equals, utils.EscapeString("a.b"))
+func (s *dataCleansingSuite) TestEscapeKey_EscapesPeriods(c *gc.C) {
+	c.Check("a"+"\uff0e"+"b", gc.Equals, utils.EscapeKey("a.b"))
 }
 
-func (s *dataCleansingSuite) TestEscapeString_EscapesDollarSigns(c *gc.C) {
-	c.Check("\uff04"+"a", gc.Equals, utils.EscapeString("$a"))
+func (s *dataCleansingSuite) TestEscapeKey_EscapesDollarSigns(c *gc.C) {
+	c.Check("\uff04"+"a", gc.Equals, utils.EscapeKey("$a"))
 }
 
-func (s *dataCleansingSuite) TestUnescapeString_UnescapesPeriod(c *gc.C) {
-	c.Check(utils.UnescapeString("a"+"\uff0e"+"b"), gc.Equals, "a.b")
+func (s *dataCleansingSuite) TestUnescapeKey_UnescapesPeriod(c *gc.C) {
+	c.Check(utils.UnescapeKey("a"+"\uff0e"+"b"), gc.Equals, "a.b")
 }
 
-func (s *dataCleansingSuite) TestUnescapeString_UnescapesDollarSigns(c *gc.C) {
-	c.Check(utils.UnescapeString("\uff04"+"a"), gc.Equals, "$a")
+func (s *dataCleansingSuite) TestUnescapeKey_UnescapesDollarSigns(c *gc.C) {
+	c.Check(utils.UnescapeKey("\uff04"+"a"), gc.Equals, "$a")
 }

--- a/state/cloud.go
+++ b/state/cloud.go
@@ -11,6 +11,7 @@ import (
 	"gopkg.in/mgo.v2/txn"
 
 	"github.com/juju/juju/cloud"
+	"github.com/juju/juju/mongo/utils"
 )
 
 // cloudDoc records information about the cloud that the controller operates in.
@@ -42,7 +43,7 @@ func createCloudOp(cloud cloud.Cloud) txn.Op {
 	}
 	regions := make(map[string]cloudRegionSubdoc)
 	for _, region := range cloud.Regions {
-		regions[region.Name] = cloudRegionSubdoc{
+		regions[utils.EscapeKey(region.Name)] = cloudRegionSubdoc{
 			region.Endpoint,
 			region.IdentityEndpoint,
 			region.StorageEndpoint,
@@ -78,7 +79,7 @@ func (d cloudDoc) toCloud() cloud.Cloud {
 	for i, name := range regionNames.SortedValues() {
 		region := d.Regions[name]
 		regions[i] = cloud.Region{
-			name,
+			utils.UnescapeKey(name),
 			region.Endpoint,
 			region.IdentityEndpoint,
 			region.StorageEndpoint,

--- a/state/model.go
+++ b/state/model.go
@@ -20,6 +20,7 @@ import (
 	"github.com/juju/juju/constraints"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/feature"
+	"github.com/juju/juju/mongo/utils"
 	"github.com/juju/juju/permission"
 	"github.com/juju/juju/status"
 	"github.com/juju/juju/storage"
@@ -425,7 +426,7 @@ func (st *State) NewModel(args ModelArgs) (_ *Model, _ *State, err error) {
 		} else if envCount > 0 {
 			err = errors.AlreadyExistsf("model %q for %s", name, owner.Id())
 		} else {
-			err = errors.New("model already exists")
+			err = errors.Annotate(err, "failed to create new model")
 		}
 	}
 	if err != nil {
@@ -472,7 +473,7 @@ func validateCloudRegion(cloud jujucloud.Cloud, regionName string) (txn.Op, erro
 			return txn.Op{}, errors.Trace(err)
 		}
 		assertCloudRegionOp.Assert = bson.D{
-			{"regions." + region.Name, bson.D{{"$exists", true}}},
+			{"regions." + utils.EscapeKey(region.Name), bson.D{{"$exists", true}}},
 		}
 	} else {
 		if len(cloud.Regions) > 0 {

--- a/state/model_test.go
+++ b/state/model_test.go
@@ -204,6 +204,21 @@ func (s *ModelSuite) TestNewModel(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 }
 
+func (s *ModelSuite) TestNewModelRegionNameEscaped(c *gc.C) {
+	cfg, _ := s.createTestModelConfig(c)
+	model, st, err := s.State.NewModel(state.ModelArgs{
+		Type:        state.ModelTypeIAAS,
+		CloudName:   "dummy",
+		CloudRegion: "dotty.region",
+		Config:      cfg,
+		Owner:       names.NewUserTag("test@remote"),
+		StorageProviderRegistry: storage.StaticProviderRegistry{},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	defer st.Close()
+	c.Assert(model.CloudRegion(), gc.Equals, "dotty.region")
+}
+
 func (s *ModelSuite) TestNewModelCAAS(c *gc.C) {
 	s.SetFeatureFlags(feature.CAAS)
 

--- a/state/testing/conn.go
+++ b/state/testing/conn.go
@@ -99,6 +99,12 @@ func InitializeWithArgs(c *gc.C, args InitializeArgs) (*state.Controller, *state
 					IdentityEndpoint: "unused-identity-endpoint",
 					StorageEndpoint:  "unused-storage-endpoint",
 				},
+				{
+					Name:             "dotty.region",
+					Endpoint:         "dotty.endpoint",
+					IdentityEndpoint: "dotty.identity-endpoint",
+					StorageEndpoint:  "dotty.storage-endpoint",
+				},
 			},
 			RegionConfig: args.RegionConfig,
 		},

--- a/state/upgrades.go
+++ b/state/upgrades.go
@@ -20,6 +20,7 @@ import (
 	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/controller"
 	"github.com/juju/juju/environs/config"
+	"github.com/juju/juju/mongo/utils"
 	"github.com/juju/juju/state/globalclock"
 	"github.com/juju/juju/state/lease"
 	"github.com/juju/juju/status"
@@ -408,7 +409,7 @@ func updateLegacyLXDCloudsOps(st *State, endpoint string) ([]txn.Op, error) {
 		for _, region := range c.Regions {
 			if region.Endpoint == "" {
 				set = append(set, bson.DocElem{
-					"regions." + region.Name + ".endpoint",
+					"regions." + utils.EscapeKey(region.Name) + ".endpoint",
 					endpoint,
 				})
 			}


### PR DESCRIPTION
## Description of change

In the "clouds" collection we store regions
as subdocuments of each cloud, with the
subdocuments keyed by region name. We must
escape the keys to permit dots in the region
name.

## QA steps

1. Define a local cloud:
```yaml
clouds:
  localhost:
    type: lxd
    regions:
      foo.bar:
```

2. juju bootstrap localhost/foo.bar
3. juju deploy ubuntu
4. juju destroy-controller -y localhost-foo.bar --destroy-all-models

## Documentation changes

None.

## Bug reference

Fixes https://bugs.launchpad.net/juju/+bug/1738993