### PR TITLE
worker/state: fix test failures

### DIFF
--- a/worker/state/manifold_test.go
+++ b/worker/state/manifold_test.go
@@ -36,6 +36,14 @@ var _ = gc.Suite(&ManifoldSuite{})
 func (s *ManifoldSuite) SetUpTest(c *gc.C) {
 	s.StateSuite.SetUpTest(c)
 
+	// Close the state pool, as it's not needed, and it
+	// refers to the state object's mongo session. If we
+	// do not close the pool, its embedded watcher may
+	// attempt to access mongo after it has been closed
+	// by the state tracker.
+	err := s.StatePool.Close()
+	c.Assert(err, jc.ErrorIsNil)
+
 	s.openStateCalled = false
 	s.openStateErr = nil
 

--- a/worker/state/statetracker_test.go
+++ b/worker/state/statetracker_test.go
@@ -22,6 +22,15 @@ var _ = gc.Suite(&StateTrackerSuite{})
 
 func (s *StateTrackerSuite) SetUpTest(c *gc.C) {
 	s.StateSuite.SetUpTest(c)
+
+	// Close the state pool, as it's not needed, and it
+	// refers to the state object's mongo session. If we
+	// do not close the pool, its embedded watcher may
+	// attempt to access mongo after it has been closed
+	// by the state tracker.
+	err := s.StatePool.Close()
+	c.Assert(err, jc.ErrorIsNil)
+
 	s.stateTracker = workerstate.NewStateTracker(s.State)
 }
 


### PR DESCRIPTION
## Description of change

Fix intermittent test failures caused
by state pool workers referring to the
state's mongo after it has been closed.

The pool is not needed, so it can be
closed early, before the state/mongo
could possibly be closed.

## QA steps

$ go test -count 1000 github.com/juju/juju/worker/state

## Documentation changes

None.

## Bug reference

Fixes https://bugs.launchpad.net/juju/+bug/1741819