### PR TITLE
Bug 1591962 network config

### DIFF
--- a/apiserver/common/networkingcommon/networkconfigapi.go
+++ b/apiserver/common/networkingcommon/networkconfigapi.go
@@ -30,6 +30,146 @@ func NewNetworkConfigAPI(st *state.State, getCanModify common.GetAuthFunc) *Netw
 	}
 }
 
+// SetObservedNetworkConfig reads the network config for the machine identified
+// by the input args. This config is merged with the new network config supplied
+// in the same args and updated if it has changed.
+func (api *NetworkConfigAPI) SetObservedNetworkConfig(args params.SetMachineNetworkConfig) error {
+	m, err := api.getMachineForSettingNetworkConfig(args.Tag)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	if m.IsContainer() {
+		return nil
+	}
+	observedConfig := args.Config
+	logger.Tracef("observed network config of machine %q: %+v", m.Id(), observedConfig)
+	if len(observedConfig) == 0 {
+		logger.Infof("not updating machine %q network config: no observed network config found", m.Id())
+		return nil
+	}
+
+	providerConfig, err := api.getOneMachineProviderNetworkConfig(m)
+	if errors.IsNotProvisioned(err) {
+		logger.Infof("not updating machine %q network config: %v", m.Id(), err)
+		return nil
+	}
+	if err != nil {
+		return errors.Trace(err)
+	}
+	mergedConfig := observedConfig
+	if len(providerConfig) != 0 {
+		mergedConfig = MergeProviderAndObservedNetworkConfigs(providerConfig, observedConfig)
+		logger.Tracef("merged observed and provider network config for machine %q: %+v", m.Id(), mergedConfig)
+	}
+
+	mergedConfig, err = api.fixUpFanSubnets(mergedConfig)
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	return api.setOneMachineNetworkConfig(m, mergedConfig)
+}
+
+// fixUpFanSubnets takes network config and updates FAN subnets with proper CIDR, providerId and providerSubnetId.
+// The method how fan overlay is cut into segments is described in network/fan.go.
+func (api *NetworkConfigAPI) fixUpFanSubnets(networkConfig []params.NetworkConfig) ([]params.NetworkConfig, error) {
+	subnets, err := api.st.AllSubnets()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	var fanSubnets []*state.Subnet
+	var fanCIDRs []*net.IPNet
+	for _, subnet := range subnets {
+		if subnet.FanOverlay() != "" {
+			fanSubnets = append(fanSubnets, subnet)
+			_, net, err := net.ParseCIDR(subnet.CIDR())
+			if err != nil {
+				return nil, errors.Trace(err)
+			}
+			fanCIDRs = append(fanCIDRs, net)
+		}
+	}
+	for i := range networkConfig {
+		localIP := net.ParseIP(networkConfig[i].Address)
+		for j, fanSubnet := range fanSubnets {
+			if fanCIDRs[j].Contains(localIP) {
+				networkConfig[i].CIDR = fanSubnet.CIDR()
+				networkConfig[i].ProviderId = string(fanSubnet.ProviderId())
+				networkConfig[i].ProviderSubnetId = string(fanSubnet.ProviderNetworkId())
+				break
+			}
+		}
+	}
+	logger.Tracef("Final network config after fixing up FAN subnets %+v", networkConfig)
+	return networkConfig, nil
+}
+
+// SetProviderNetworkConfig sets the provider supplied network configuration
+// contained in the input args against each machine supplied with said args.
+func (api *NetworkConfigAPI) SetProviderNetworkConfig(args params.Entities) (params.ErrorResults, error) {
+	logger.Tracef("SetProviderNetworkConfig %+v", args)
+	result := params.ErrorResults{
+		Results: make([]params.ErrorResult, len(args.Entities)),
+	}
+
+	for i, arg := range args.Entities {
+		m, err := api.getMachineForSettingNetworkConfig(arg.Tag)
+		if err != nil {
+			result.Results[i].Error = common.ServerError(err)
+			continue
+		}
+
+		if m.IsContainer() {
+			continue
+		}
+
+		providerConfig, err := api.getOneMachineProviderNetworkConfig(m)
+		if err != nil {
+			result.Results[i].Error = common.ServerError(err)
+			continue
+		} else if len(providerConfig) == 0 {
+			continue
+		}
+		logger.Tracef("provider network config for %q: %+v", m.Id(), providerConfig)
+
+		if err := api.setOneMachineNetworkConfig(m, providerConfig); err != nil {
+			result.Results[i].Error = common.ServerError(err)
+			continue
+		}
+	}
+	return result, nil
+}
+
+func (api *NetworkConfigAPI) getMachineForSettingNetworkConfig(machineTag string) (*state.Machine, error) {
+	logger.Debugf("TAG: %q", machineTag)
+	canModify, err := api.getCanModify()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	tag, err := names.ParseMachineTag(machineTag)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	if !canModify(tag) {
+		return nil, errors.Trace(common.ErrPerm)
+	}
+
+	m, err := api.getMachine(tag)
+	if errors.IsNotFound(err) {
+		return nil, errors.Trace(common.ErrPerm)
+	} else if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	if m.IsContainer() {
+		logger.Debugf("not updating network config for container %q", m.Id())
+	}
+
+	return m, nil
+}
+
 func (api *NetworkConfigAPI) getMachine(tag names.MachineTag) (*state.Machine, error) {
 	entity, err := api.st.FindEntity(tag)
 	if err != nil {
@@ -91,42 +231,9 @@ func (api *NetworkConfigAPI) getOneMachineProviderNetworkConfig(m *state.Machine
 	return providerConfig, nil
 }
 
-// fixUpFanSubnets takes network config and updates FAN subnets with proper CIDR, providerId and providerSubnetId.
-// The method how fan overlay is cut into segments is described in network/fan.go.
-func (api *NetworkConfigAPI) fixUpFanSubnets(networkConfig []params.NetworkConfig) ([]params.NetworkConfig, error) {
-	subnets, err := api.st.AllSubnets()
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-
-	var fanSubnets []*state.Subnet
-	var fanCIDRs []*net.IPNet
-	for _, subnet := range subnets {
-		if subnet.FanOverlay() != "" {
-			fanSubnets = append(fanSubnets, subnet)
-			_, net, err := net.ParseCIDR(subnet.CIDR())
-			if err != nil {
-				return nil, errors.Trace(err)
-			}
-			fanCIDRs = append(fanCIDRs, net)
-		}
-	}
-	for i := range networkConfig {
-		localIP := net.ParseIP(networkConfig[i].Address)
-		for j, fanSubnet := range fanSubnets {
-			if fanCIDRs[j].Contains(localIP) {
-				networkConfig[i].CIDR = fanSubnet.CIDR()
-				networkConfig[i].ProviderId = string(fanSubnet.ProviderId())
-				networkConfig[i].ProviderSubnetId = string(fanSubnet.ProviderNetworkId())
-				break
-			}
-		}
-	}
-	logger.Tracef("Final network config after fixing up FAN subnets %+v", networkConfig)
-	return networkConfig, nil
-}
-
-func (api *NetworkConfigAPI) setOneMachineNetworkConfig(m *state.Machine, networkConfig []params.NetworkConfig) error {
+func (api *NetworkConfigAPI) setOneMachineNetworkConfig(
+	m *state.Machine, networkConfig []params.NetworkConfig,
+) error {
 	devicesArgs, devicesAddrs := NetworkConfigsToStateArgs(networkConfig)
 
 	logger.Debugf("setting devices: %+v", devicesArgs)
@@ -141,110 +248,4 @@ func (api *NetworkConfigAPI) setOneMachineNetworkConfig(m *state.Machine, networ
 
 	logger.Debugf("updated machine %q network config", m.Id())
 	return nil
-}
-
-func (api *NetworkConfigAPI) getMachineForSettingNetworkConfig(machineTag string) (*state.Machine, error) {
-	logger.Debugf("TAG: %q", machineTag)
-	canModify, err := api.getCanModify()
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-
-	tag, err := names.ParseMachineTag(machineTag)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	if !canModify(tag) {
-		return nil, errors.Trace(common.ErrPerm)
-	}
-
-	m, err := api.getMachine(tag)
-	if errors.IsNotFound(err) {
-		return nil, errors.Trace(common.ErrPerm)
-	} else if err != nil {
-		return nil, errors.Trace(err)
-	}
-
-	if m.IsContainer() {
-		logger.Debugf("not updating network config for container %q", m.Id())
-	}
-
-	return m, nil
-}
-
-// SetObservedNetworkConfig reads the network config for the machine identified
-// by the input args. This config is merged with the new network config supplied
-// in the same args and updated if it has changed.
-func (api *NetworkConfigAPI) SetObservedNetworkConfig(args params.SetMachineNetworkConfig) error {
-	m, err := api.getMachineForSettingNetworkConfig(args.Tag)
-	if err != nil {
-		return errors.Trace(err)
-	}
-	if m.IsContainer() {
-		return nil
-	}
-	observedConfig := args.Config
-	logger.Tracef("observed network config of machine %q: %+v", m.Id(), observedConfig)
-	if len(observedConfig) == 0 {
-		logger.Infof("not updating machine %q network config: no observed network config found", m.Id())
-		return nil
-	}
-
-	providerConfig, err := api.getOneMachineProviderNetworkConfig(m)
-	if errors.IsNotProvisioned(err) {
-		logger.Infof("not updating machine %q network config: %v", m.Id(), err)
-		return nil
-	}
-	if err != nil {
-		return errors.Trace(err)
-	}
-	mergedConfig := observedConfig
-	if len(providerConfig) != 0 {
-		mergedConfig = MergeProviderAndObservedNetworkConfigs(providerConfig, observedConfig)
-		logger.Tracef("merged observed and provider network config for machine %q: %+v", m.Id(), mergedConfig)
-	}
-
-	mergedConfig, err = api.fixUpFanSubnets(mergedConfig)
-	if err != nil {
-		return errors.Trace(err)
-	}
-
-	return api.setOneMachineNetworkConfig(m, mergedConfig)
-}
-
-// SetProviderNetworkConfig sets the provider supplied network configuration
-// contained in the input args against each machine supplied with said args.
-func (api *NetworkConfigAPI) SetProviderNetworkConfig(args params.Entities) (params.ErrorResults, error) {
-	logger.Tracef("SetProviderNetworkConfig %+v", args)
-	result := params.ErrorResults{
-		Results: make([]params.ErrorResult, len(args.Entities)),
-	}
-
-	for i, arg := range args.Entities {
-		m, err := api.getMachineForSettingNetworkConfig(arg.Tag)
-		if err != nil {
-			result.Results[i].Error = common.ServerError(err)
-			continue
-		}
-
-		if m.IsContainer() {
-			continue
-		}
-
-		providerConfig, err := api.getOneMachineProviderNetworkConfig(m)
-		if err != nil {
-			result.Results[i].Error = common.ServerError(err)
-			continue
-		} else if len(providerConfig) == 0 {
-			continue
-		}
-
-		logger.Tracef("provider network config for %q: %+v", m.Id(), providerConfig)
-
-		if err := api.setOneMachineNetworkConfig(m, providerConfig); err != nil {
-			result.Results[i].Error = common.ServerError(err)
-			continue
-		}
-	}
-	return result, nil
 }

--- a/apiserver/common/networkingcommon/networkconfigapi.go
+++ b/apiserver/common/networkingcommon/networkconfigapi.go
@@ -142,7 +142,6 @@ func (api *NetworkConfigAPI) SetProviderNetworkConfig(args params.Entities) (par
 }
 
 func (api *NetworkConfigAPI) getMachineForSettingNetworkConfig(machineTag string) (*state.Machine, error) {
-	logger.Debugf("TAG: %q", machineTag)
 	canModify, err := api.getCanModify()
 	if err != nil {
 		return nil, errors.Trace(err)

--- a/apiserver/common/networkingcommon/networkconfigapi_test.go
+++ b/apiserver/common/networkingcommon/networkconfigapi_test.go
@@ -11,27 +11,35 @@ import (
 	"github.com/juju/juju/apiserver/common/networkingcommon"
 	"github.com/juju/juju/apiserver/params"
 	apiservertesting "github.com/juju/juju/apiserver/testing"
-	"github.com/juju/juju/juju/testing"
+	jujutesting "github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/state"
 )
 
-type networkconfigSuite struct {
-	testing.JujuConnSuite
+type networkConfigSuite struct {
+	jujutesting.JujuConnSuite
 
 	machine       *state.Machine
 	resources     *common.Resources
 	networkconfig *networkingcommon.NetworkConfigAPI
 }
 
-func (s *networkconfigSuite) SetUpTest(c *gc.C) {
+var _ = gc.Suite(&networkConfigSuite{})
+
+func (s *networkConfigSuite) SetUpTest(c *gc.C) {
 	s.JujuConnSuite.SetUpTest(c)
+
 	var err error
 	s.machine, err = s.State.AddMachine("quantal", state.JobHostUnits)
+
 	c.Assert(err, jc.ErrorIsNil)
+
+	s.networkconfig = networkingcommon.NewNetworkConfigAPI(
+		s.State,
+		common.AuthAlways(),
+	)
 }
 
-func (s *networkconfigSuite) TestSetObservedNetworkConfig(c *gc.C) {
-	c.Skip("dimitern: Test disabled until dummy provider is fixed properly")
+func (s *networkConfigSuite) TestSetObservedNetworkConfig(c *gc.C) {
 	devices, err := s.machine.AllLinkLayerDevices()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(devices, gc.HasLen, 0)
@@ -76,9 +84,9 @@ func (s *networkconfigSuite) TestSetObservedNetworkConfig(c *gc.C) {
 	}
 }
 
-func (s *networkconfigSuite) TestSetObservedNetworkConfigPermissions(c *gc.C) {
+func (s *networkConfigSuite) TestSetObservedNetworkConfigPermissions(c *gc.C) {
 	args := params.SetMachineNetworkConfig{
-		Tag:    "machine-0",
+		Tag:    "machine-1",
 		Config: nil,
 	}
 
@@ -86,8 +94,7 @@ func (s *networkconfigSuite) TestSetObservedNetworkConfigPermissions(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, "permission denied")
 }
 
-func (s *networkconfigSuite) TestSetProviderNetworkConfig(c *gc.C) {
-	c.Skip("dimitern: Test disabled until dummy provider is fixed properly")
+func (s *networkConfigSuite) TestSetProviderNetworkConfig(c *gc.C) {
 	devices, err := s.machine.AllLinkLayerDevices()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(devices, gc.HasLen, 0)
@@ -119,10 +126,10 @@ func (s *networkconfigSuite) TestSetProviderNetworkConfig(c *gc.C) {
 	}
 }
 
-func (s *networkconfigSuite) TestSetProviderNetworkConfigPermissions(c *gc.C) {
+func (s *networkConfigSuite) TestSetProviderNetworkConfigPermissions(c *gc.C) {
 	args := params.Entities{Entities: []params.Entity{
-		{Tag: "machine-1"},
 		{Tag: "machine-0"},
+		{Tag: "machine-1"},
 		{Tag: "machine-42"},
 	}}
 

--- a/apiserver/common/networkingcommon/package_test.go
+++ b/apiserver/common/networkingcommon/package_test.go
@@ -6,9 +6,9 @@ package networkingcommon_test
 import (
 	stdtesting "testing"
 
-	gc "gopkg.in/check.v1"
+	coretesting "github.com/juju/juju/testing"
 )
 
 func TestAll(t *stdtesting.T) {
-	gc.TestingT(t)
+	coretesting.MgoTestPackage(t)
 }

--- a/apiserver/common/networkingcommon/types.go
+++ b/apiserver/common/networkingcommon/types.go
@@ -318,7 +318,9 @@ type NetworkConfigSource interface {
 // MergeProviderAndObservedNetworkConfigs returns the effective network configs,
 // using observedConfigs as a base and selectively updating it using the
 // matching providerConfigs for each interface.
-func MergeProviderAndObservedNetworkConfigs(providerConfigs, observedConfigs []params.NetworkConfig) []params.NetworkConfig {
+func MergeProviderAndObservedNetworkConfigs(
+	providerConfigs, observedConfigs []params.NetworkConfig,
+) []params.NetworkConfig {
 
 	providerConfigByName := networkConfigsByName(providerConfigs)
 	logger.Tracef("known provider config by name: %+v", providerConfigByName)

--- a/apiserver/common/networkingcommon/types.go
+++ b/apiserver/common/networkingcommon/types.go
@@ -287,9 +287,6 @@ func NetworkingEnvironFromModelConfig(configGetter environs.EnvironConfigGetter)
 	if err != nil {
 		return nil, errors.Annotate(err, "failed to get model config")
 	}
-	if modelConfig.Type() == "dummy" {
-		return nil, errors.NotSupportedf("dummy provider network config")
-	}
 	env, err := environs.GetEnviron(configGetter, environs.New)
 	if err != nil {
 		return nil, errors.Annotate(err, "failed to construct a model from config")


### PR DESCRIPTION
## Description of change

Non-functional change.

Tests in apiserver/common/networkingcommon/networkconfigapi_test.go were not previously being run due to the suite not being initialised. Package tests are now run with MgoTestPackage as necessitated by this file.

Skipped tests are restored to running and presently green.

Some code reorganisation accompanies, in preparation for an incoming patch.

## QA steps

Restored unit tests.

## Documentation changes

None

## Bug reference

Part of work for https://bugs.launchpad.net/juju/+bug/1591962.
