### PR TITLE
Issue #1742257: Juju installation using go

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,21 @@ If you want to know more about contributing to `juju`, please read the
 Installing prerequisites
 ------------------------
 
+### *Making use of Makefile*
+
+The `juju` repository contains a `Makefile`, which is the preferred way to install dependencies and other features.
+It is advisable, when installing `juju` from source, to look at the [Makefile](./Makefile), located in `$GOPATH/src/github.com/juju/juju/Makefile`.
+
+### *Dependencies*
+
+Juju needs some dependencies in order to be installed and the preferred way to 
+collect the necessary packages is to use the provided `Makefile`.
+The target `godeps` will download the go packages listed in `dependencies.tsv`. The following bash code will install the dependencies.
+
+    cd $GOPATH/src/github.com/juju/juju
+    export JUJU_MAKE_GODEPS=true
+    make godeps
+
 ### *Runtime Dependencies*
 
 You can use `make install-dependencies` or, if you prefer to install


### PR DESCRIPTION
## Please provide the following details to expedite Pull Request review:

Launchpad but [#1742257](https://bugs.launchpad.net/juju/+bug/1742257)

----

## Description of change

The instructions to install juju using `go` don't work due to the lack of some juju dependencies. This is solvable by installing `godeps` and downloading the dependencies listed in `dependencies.tsv`.

## QA steps

Check the previous steps:

    go get -d -v github.com/juju/juju/...
    go install -v github.com/juju/juju/...

The install command should throw an error, because it can't find some dependencies

    go get github.com/rogpeppe/godeps
    go get -d -v github.com/juju/juju/...
    godeps -u $GOPATH/src/github.com/juju/juju/dependencies.tsv
    go install -v github.com/juju/juju/...

Now the installation should complete correctly.

## Documentation changes

README.md

## Bug reference

 [#1742257](https://bugs.launchpad.net/juju/+bug/1742257)
