### PR TITLE
worker/uniter: watch update status interval

### DIFF
--- a/api/common/modelwatcher.go
+++ b/api/common/modelwatcher.go
@@ -81,3 +81,11 @@ func (e *ModelWatcher) UpdateStatusHookInterval() (time.Duration, error) {
 	}
 	return modelConfig.UpdateStatusHookInterval(), nil
 }
+
+// WatchUpdateStatusHookInterval returns a NotifyWatcher that fires when the
+// update status hook interval changes.
+func (e *ModelWatcher) WatchUpdateStatusHookInterval() (watcher.NotifyWatcher, error) {
+	// TODO(wallyworld) - lp:1602237 - this needs to have it's own backend implementation.
+	// For now, we'll piggyback off the ModelConfig API.
+	return e.WatchForModelConfigChanges()
+}

--- a/worker/uniter/remotestate/mock_test.go
+++ b/worker/uniter/remotestate/mock_test.go
@@ -98,11 +98,13 @@ func (w *mockRelationUnitsWatcher) Changes() watcher.RelationUnitsChannel {
 }
 
 type mockState struct {
-	unit                      mockUnit
-	relations                 map[names.RelationTag]*mockRelation
-	storageAttachment         map[params.StorageAttachmentId]params.StorageAttachment
-	relationUnitsWatchers     map[names.RelationTag]*mockRelationUnitsWatcher
-	storageAttachmentWatchers map[names.StorageTag]*mockNotifyWatcher
+	unit                        mockUnit
+	relations                   map[names.RelationTag]*mockRelation
+	storageAttachment           map[params.StorageAttachmentId]params.StorageAttachment
+	relationUnitsWatchers       map[names.RelationTag]*mockRelationUnitsWatcher
+	storageAttachmentWatchers   map[names.StorageTag]*mockNotifyWatcher
+	updateStatusInterval        time.Duration
+	updateStatusIntervalWatcher *mockNotifyWatcher
 }
 
 func (st *mockState) Relation(tag names.RelationTag) (remotestate.Relation, error) {
@@ -183,7 +185,11 @@ func (st *mockState) WatchStorageAttachment(
 }
 
 func (st *mockState) UpdateStatusHookInterval() (time.Duration, error) {
-	return 5 * time.Minute, nil
+	return st.updateStatusInterval, nil
+}
+
+func (st *mockState) WatchUpdateStatusHookInterval() (watcher.NotifyWatcher, error) {
+	return st.updateStatusIntervalWatcher, nil
 }
 
 type mockUnit struct {

--- a/worker/uniter/remotestate/state.go
+++ b/worker/uniter/remotestate/state.go
@@ -27,6 +27,7 @@ type State interface {
 	Unit(names.UnitTag) (Unit, error)
 	WatchRelationUnits(names.RelationTag, names.UnitTag) (watcher.RelationUnitsWatcher, error)
 	WatchStorageAttachment(names.StorageTag, names.UnitTag) (watcher.NotifyWatcher, error)
+	WatchUpdateStatusHookInterval() (watcher.NotifyWatcher, error)
 	UpdateStatusHookInterval() (time.Duration, error)
 }
 


### PR DESCRIPTION
## Description of change

The uniter now watches for changes to the
update status interval, and adjusts the
timer accordingly.

Also, restart the timer only when it fires,
not after every (unrelated) change. Before,
it could be an arbitrarily long time between
update status hooks, if the uniter were very
busy.

## QA steps

1. juju bootstrap localhost
2. juju deploy ubuntu
3. juju debug-log
(watch for a while, observe that times between update-status hooks firing are between 4 and 6 minutes.)
4. juju model-config update-status-hook-interval=1m
(watch for a while, observe that times between update-status hooks firing are around 1 minute, -/+ ~12s.)

## Documentation changes

None.

## Bug reference

Fixes https://bugs.launchpad.net/juju/+bug/1734863