### PR TITLE
Initial status fixes for CAAS models

### DIFF
--- a/api/apiclient_test.go
+++ b/api/apiclient_test.go
@@ -415,7 +415,7 @@ func (s *apiclientSuite) TestFallbackToSNIHostnameOnCertErrorAndNonNumericHostna
 			CACert:      jtesting.CACert,
 			SNIHostName: "foo.com",
 		},
-		expectOpenError: `unable to connect to API: x509: a root or intermediate certificate is not authorized to sign in this domain`,
+		expectOpenError: `unable to connect to API: x509: a root or intermediate certificate is not authorized to sign.*`,
 		expectDials: []dialAttempt{{
 			// The first dial attempt should use the private CA cert.
 			check: func(info dialInfo) {
@@ -448,7 +448,7 @@ func (s *apiclientSuite) TestFailImmediatelyOnCertErrorAndNumericHostname(c *gc.
 			Addrs:  []string{"0.1.2.3:1234"},
 			CACert: jtesting.CACert,
 		},
-		expectOpenError: `unable to connect to API: x509: a root or intermediate certificate is not authorized to sign in this domain`,
+		expectOpenError: `unable to connect to API: x509: a root or intermediate certificate is not authorized to sign.*`,
 		expectDials: []dialAttempt{{
 			// The first dial attempt should use the private CA cert.
 			check: func(info dialInfo) {

--- a/api/client.go
+++ b/api/client.go
@@ -45,6 +45,11 @@ func (c *Client) Status(patterns []string) (*params.FullStatus, error) {
 	if err := c.facade.FacadeCall("FullStatus", p, &result); err != nil {
 		return nil, err
 	}
+	// Older servers don't fill out model type, but
+	// we know a missing type is an "iaas" model.
+	if result.Model.Type == "" {
+		result.Model.Type = "iaas"
+	}
 	return &result, nil
 }
 

--- a/apiserver/facades/client/client/api_test.go
+++ b/apiserver/facades/client/client/api_test.go
@@ -101,6 +101,7 @@ func (s *baseSuite) openAs(c *gc.C, tag names.Tag) api.Connection {
 var scenarioStatus = &params.FullStatus{
 	Model: params.ModelStatusInfo{
 		Name:        "controller",
+		Type:        "iaas",
 		CloudTag:    "cloud-dummy",
 		CloudRegion: "dummy-region",
 		Version:     "1.2.3",

--- a/apiserver/facades/client/client/client_test.go
+++ b/apiserver/facades/client/client/client_test.go
@@ -1374,7 +1374,7 @@ func (s *clientRepoSuite) TestResolveCharm(c *gc.C) {
 	}, {
 		about:    "invalid charm name",
 		url:      "cs:",
-		parseErr: `cannot parse URL "cs://": name "" not valid`,
+		parseErr: `cannot parse URL "cs:(\/\/)?": name "" not valid`,
 	}, {
 		about:      "local charm",
 		url:        "local:wordpress",

--- a/apiserver/facades/client/client/status.go
+++ b/apiserver/facades/client/client/status.go
@@ -333,6 +333,7 @@ func (c *Client) modelStatus() (params.ModelStatusInfo, error) {
 		return info, errors.Annotate(err, "cannot get model")
 	}
 	info.Name = m.Name()
+	info.Type = string(m.Type())
 	info.CloudTag = names.NewCloudTag(m.Cloud()).String()
 	info.CloudRegion = m.CloudRegion()
 

--- a/apiserver/facades/client/client/status_test.go
+++ b/apiserver/facades/client/client/status_test.go
@@ -46,6 +46,7 @@ func (s *statusSuite) TestFullStatus(c *gc.C) {
 	status, err := client.Status(nil)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(status.Model.Name, gc.Equals, "controller")
+	c.Check(status.Model.Type, gc.Equals, "iaas")
 	c.Check(status.Model.CloudTag, gc.Equals, "cloud-dummy")
 	c.Check(status.Model.SLA, gc.Equals, "essential")
 	c.Check(status.Applications, gc.HasLen, 0)

--- a/apiserver/params/status.go
+++ b/apiserver/params/status.go
@@ -33,6 +33,7 @@ type FullStatus struct {
 // ModelStatusInfo holds status information about the model itself.
 type ModelStatusInfo struct {
 	Name             string         `json:"name"`
+	Type             string         `json:"type"`
 	CloudTag         string         `json:"cloud-tag"`
 	CloudRegion      string         `json:"region,omitempty"`
 	Version          string         `json:"version"`

--- a/caas/kubernetes/provider/k8s.go
+++ b/caas/kubernetes/provider/k8s.go
@@ -35,6 +35,7 @@ const (
 	namespace = "default"
 
 	labelApplication = "juju-application"
+	labelUnit        = "juju-unit"
 )
 
 // TODO(caas) - add unit tests
@@ -351,8 +352,10 @@ func (k *kubernetesClient) EnsureUnit(appName, unitName, spec string) error {
 	}
 	pod := &v1.Pod{
 		ObjectMeta: v1.ObjectMeta{
-			Name:   podName,
-			Labels: map[string]string{labelApplication: appName}},
+			Name: podName,
+			Labels: map[string]string{
+				labelApplication: appName,
+				labelUnit:        unitName}},
 		Spec: unitSpec.Pod,
 	}
 	return k.createPod(pod)

--- a/cmd/juju/status/formatted.go
+++ b/cmd/juju/status/formatted.go
@@ -33,6 +33,7 @@ type errorStatus struct {
 
 type modelStatus struct {
 	Name             string             `json:"name" yaml:"name"`
+	Type             string             `json:"type" yaml:"type"`
 	Controller       string             `json:"controller" yaml:"controller"`
 	Cloud            string             `json:"cloud" yaml:"cloud"`
 	CloudRegion      string             `json:"region,omitempty" yaml:"region,omitempty"`
@@ -184,8 +185,8 @@ type meterStatus struct {
 
 type unitStatus struct {
 	// New Juju Health Status fields.
-	WorkloadStatusInfo statusInfoContents `json:"workload-status,omitempty" yaml:"workload-status"`
-	JujuStatusInfo     statusInfoContents `json:"juju-status,omitempty" yaml:"juju-status"`
+	WorkloadStatusInfo statusInfoContents `json:"workload-status,omitempty" yaml:"workload-status,omitempty"`
+	JujuStatusInfo     statusInfoContents `json:"juju-status,omitempty" yaml:"juju-status,omitempty"`
 	MeterStatus        *meterStatus       `json:"meter-status,omitempty" yaml:"meter-status,omitempty"`
 
 	Leader        bool                  `json:"leader,omitempty" yaml:"leader,omitempty"`
@@ -193,6 +194,7 @@ type unitStatus struct {
 	Machine       string                `json:"machine,omitempty" yaml:"machine,omitempty"`
 	OpenedPorts   []string              `json:"open-ports,omitempty" yaml:"open-ports,omitempty"`
 	PublicAddress string                `json:"public-address,omitempty" yaml:"public-address,omitempty"`
+	Address       string                `json:"address,omitempty" yaml:"address,omitempty"`
 	Subordinates  map[string]unitStatus `json:"subordinates,omitempty" yaml:"subordinates,omitempty"`
 }
 

--- a/cmd/juju/status/formatter.go
+++ b/cmd/juju/status/formatter.go
@@ -54,6 +54,7 @@ func (sf *statusFormatter) format() (formattedStatus, error) {
 	out := formattedStatus{
 		Model: modelStatus{
 			Name:             sf.status.Model.Name,
+			Type:             sf.status.Model.Type,
 			Controller:       sf.controllerName,
 			Cloud:            cloudTag.Id(),
 			CloudRegion:      sf.status.Model.CloudRegion,
@@ -363,6 +364,9 @@ func (sf *statusFormatter) getStatusInfoContents(inst params.DetailedStatus) sta
 }
 
 func (sf *statusFormatter) getWorkloadStatusInfo(unit params.UnitStatus) statusInfoContents {
+	if unit.WorkloadStatus.Status == "" {
+		return statusInfoContents{}
+	}
 	// TODO(perrito66) add status validation.
 	info := statusInfoContents{
 		Err:     unit.WorkloadStatus.Err,

--- a/cmd/juju/status/status_test.go
+++ b/cmd/juju/status/status_test.go
@@ -161,6 +161,7 @@ func (s *StatusSuite) resetContext(c *gc.C, ctx *context) {
 var (
 	model = M{
 		"name":       "controller",
+		"type":       "iaas",
 		"controller": "kontroll",
 		"cloud":      "dummy",
 		"region":     "dummy-region",
@@ -2570,6 +2571,7 @@ var statusTests = []testCase{
 			M{
 				"model": M{
 					"name":              "controller",
+					"type":              "iaas",
 					"controller":        "kontroll",
 					"cloud":             "dummy",
 					"region":            "dummy-region",
@@ -2866,6 +2868,7 @@ var statusTests = []testCase{
 			M{
 				"model": M{
 					"name":       "controller",
+					"type":       "iaas",
 					"controller": "kontroll",
 					"cloud":      "dummy",
 					"region":     "dummy-region",
@@ -2893,6 +2896,7 @@ var statusTests = []testCase{
 			M{
 				"model": M{
 					"name":       "controller",
+					"type":       "iaas",
 					"controller": "kontroll",
 					"cloud":      "dummy",
 					"region":     "dummy-region",
@@ -3738,6 +3742,7 @@ func (s *StatusSuite) TestMigrationInProgress(c *gc.C) {
 	expected := M{
 		"model": M{
 			"name":       "hosted",
+			"type":       "iaas",
 			"controller": "kontroll",
 			"cloud":      "dummy",
 			"region":     "dummy-region",
@@ -4169,6 +4174,44 @@ Machine  State  DNS  Inst id  Series  AZ  Message
 `[1:])
 }
 
+func (s *StatusSuite) TestFormatTabularCAASModel(c *gc.C) {
+	status := formattedStatus{
+		Model: modelStatus{
+			Type: "caas",
+		},
+		Applications: map[string]applicationStatus{
+			"foo": {
+				Units: map[string]unitStatus{
+					"foo/0": {
+						JujuStatusInfo: statusInfoContents{
+							Current: status.Active,
+						},
+					},
+					"foo/1": {
+						JujuStatusInfo: statusInfoContents{
+							Current: status.Active,
+						},
+					},
+				},
+			},
+		},
+	}
+	out := &bytes.Buffer{}
+	err := FormatTabular(out, false, status)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(out.String(), gc.Equals, `
+Model  Controller  Cloud/Region  Version
+                                 
+
+App  Version  Status  Scale  Charm  Store  Rev  OS  Notes
+foo                     0/2                  0      
+
+Unit   Status  Address  Ports  Message
+foo/0  <todo>                  
+foo/1  <todo>                  
+`[1:])
+}
+
 func (s *StatusSuite) TestStatusWithNilStatusAPI(c *gc.C) {
 	ctx := s.newContext(c)
 	defer s.resetContext(c, ctx)
@@ -4383,6 +4426,7 @@ func (s *StatusSuite) TestFilterToContainer(c *gc.C) {
 	const expected = "" +
 		"model:\n" +
 		"  name: controller\n" +
+		"  type: iaas\n" +
 		"  controller: kontroll\n" +
 		"  cloud: dummy\n" +
 		"  region: dummy-region\n" +
@@ -4688,6 +4732,7 @@ var statusTimeTest = test(
 		M{
 			"model": M{
 				"name":       "controller",
+				"type":       "iaas",
 				"controller": "kontroll",
 				"cloud":      "dummy",
 				"region":     "dummy-region",

--- a/state/migration_import.go
+++ b/state/migration_import.go
@@ -899,6 +899,7 @@ func (i *importer) unit(s description.Application, u description.Unit) error {
 	}
 	agentStatusDoc := i.makeStatusDoc(agentStatus)
 
+	// TODO(caas) - don't import workload status or version for CAAS models
 	workloadStatus := u.WorkloadStatus()
 	if workloadStatus == nil {
 		return errors.NotValidf("missing workload status")
@@ -918,8 +919,8 @@ func (i *importer) unit(s description.Application, u description.Unit) error {
 	ops, err := addUnitOps(i.st, addUnitOpsArgs{
 		unitDoc:            udoc,
 		agentStatusDoc:     agentStatusDoc,
-		workloadStatusDoc:  workloadStatusDoc,
-		workloadVersionDoc: workloadVersionDoc,
+		workloadStatusDoc:  &workloadStatusDoc,
+		workloadVersionDoc: &workloadVersionDoc,
 		meterStatusDoc: &meterStatusDoc{
 			Code: u.MeterStatusCode(),
 			Info: u.MeterStatusInfo(),

--- a/state/state.go
+++ b/state/state.go
@@ -1100,8 +1100,11 @@ func (st *State) AddApplication(args AddApplicationArgs) (_ *Application, err er
 		Updated:    st.clock().Now().UnixNano(),
 		// This exists to preserve questionable unit-aggregation behaviour
 		// while we work out how to switch to an implementation that makes
-		// sense.
-		NeverSet: true,
+		// sense. It is only relevant for IAAS models.
+		NeverSet: model.Type() == ModelTypeIAAS,
+	}
+	if model.Type() == ModelTypeCAAS {
+		statusDoc.StatusInfo = status.MessageWaitForContainer
 	}
 
 	if err := args.ApplicationConfig.Validate(); err != nil {

--- a/status/status.go
+++ b/status/status.go
@@ -114,7 +114,7 @@ const (
 )
 
 const (
-	// Status values specific to services and units, reflecting the
+	// Status values specific to applications and units, reflecting the
 	// state of the software itself.
 
 	// Maintenance is set when:
@@ -223,6 +223,7 @@ const (
 
 const (
 	MessageWaitForMachine    = "waiting for machine"
+	MessageWaitForContainer  = "waiting for container"
 	MessageInstallingAgent   = "installing agent"
 	MessageInitializingAgent = "agent initializing"
 	MessageInstallingCharm   = "installing charm software"


### PR DESCRIPTION
## Description of change

CAAS models don't support unit version status, meter status, or workload status. So we don't record these. We also extend status output to display CAAS specific attributes. For now, these are not populated. Another PR will talk to the container substrate to get the necessary information needed to populate the Juju data model.

## QA steps

bootstrap IAAS model
check status works as expected
check show-status-log works as expected

bootstrap caas model
check status shows <todo> for units
check show-status-log just shows "allocating"
