### PR TITLE
Merge 2.3 up to PR 8184 into develop

### DIFF
--- a/api/apiclient.go
+++ b/api/apiclient.go
@@ -31,7 +31,6 @@ import (
 	"gopkg.in/retry.v1"
 
 	"github.com/juju/juju/api/base"
-	"github.com/juju/juju/apiserver/observer"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/rpc"
@@ -197,7 +196,7 @@ func Open(info *Info, opts DialOpts) (Connection, error) {
 		return nil, errors.Trace(err)
 	}
 
-	client := rpc.NewConn(jsoncodec.New(dialResult.conn), observer.None())
+	client := rpc.NewConn(jsoncodec.New(dialResult.conn), nil)
 	client.Start(ctx)
 
 	bakeryClient := opts.BakeryClient

--- a/api/testing/fakeserver.go
+++ b/api/testing/fakeserver.go
@@ -18,7 +18,7 @@ func FakeAPIServer(root interface{}) net.Conn {
 	c0, c1 := net.Pipe()
 	serverCodec := jsoncodec.NewNet(c1)
 	serverRPC := rpc.NewConn(serverCodec, nil)
-	serverRPC.Serve(root, nil)
+	serverRPC.Serve(root, nil, nil)
 	serverRPC.Start(context.TODO())
 	go func() {
 		<-serverRPC.Dead()

--- a/apiserver/admin.go
+++ b/apiserver/admin.go
@@ -20,6 +20,7 @@ import (
 	"github.com/juju/juju/apiserver/facades/agent/presence"
 	"github.com/juju/juju/apiserver/observer"
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/core/auditlog"
 	"github.com/juju/juju/permission"
 	"github.com/juju/juju/rpc"
 	"github.com/juju/juju/rpc/rpcreflect"
@@ -51,12 +52,12 @@ func newAdminAPIV3(srv *Server, root *apiHandler, apiObserver observer.Observer)
 
 // Admin returns an object that provides API access to methods that can be
 // called even when not authenticated.
-func (r *admin) Admin(id string) (*admin, error) {
+func (a *admin) Admin(id string) (*admin, error) {
 	if id != "" {
 		// Safeguard id for possible future use.
 		return nil, common.ErrBadId
 	}
-	return r, nil
+	return a, nil
 }
 
 // Login logs in with the provided credentials.  All subsequent requests on the
@@ -135,7 +136,15 @@ func (a *admin) login(req params.LoginRequest, loginVersion int) (params.LoginRe
 		modelTag = a.root.model.Tag().String()
 	}
 
-	a.root.rpcConn.ServeRoot(apiRoot, serverError)
+	auditRecorder, err := a.getAuditRecorder(req, authResult)
+	if err != nil {
+		return fail, errors.Trace(err)
+	}
+
+	recorderFactory := observer.NewRecorderFactory(
+		a.apiObserver, auditRecorder)
+
+	a.root.rpcConn.ServeRoot(apiRoot, recorderFactory, serverError)
 	return params.LoginResult{
 		Servers:       params.FromNetworkHostsPorts(hostPorts),
 		ControllerTag: a.root.model.ControllerTag().String(),
@@ -145,6 +154,28 @@ func (a *admin) login(req params.LoginRequest, loginVersion int) (params.LoginRe
 		ModelTag:      modelTag,
 		Facades:       filterFacades(a.srv.facades, facadeFilters...),
 	}, nil
+}
+
+func (a *admin) getAuditRecorder(req params.LoginRequest, authResult *authResult) (*auditlog.Recorder, error) {
+	if !authResult.userLogin || a.srv.auditLogger == nil {
+		return nil, nil
+	}
+	result, err := auditlog.NewRecorder(
+		a.srv.auditLogger,
+		auditlog.ConversationArgs{
+			Who:          req.AuthTag,
+			What:         req.CLIArgs,
+			When:         a.srv.clock.Now(),
+			ModelName:    a.root.model.Name(),
+			ModelUUID:    a.root.model.UUID(),
+			ConnectionID: a.root.connectionID,
+		},
+	)
+	if err != nil {
+		logger.Errorf("couldn't add login to audit log: %+v", err)
+		return nil, errors.Trace(err)
+	}
+	return result, nil
 }
 
 type authResult struct {

--- a/apiserver/config.go
+++ b/apiserver/config.go
@@ -1,0 +1,155 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package apiserver
+
+import (
+	"time"
+
+	"github.com/juju/errors"
+)
+
+// These vars define how we rate limit incoming connections.
+const (
+	defaultLoginRateLimit         = 10 // concurrent login operations
+	defaultLoginMinPause          = 100 * time.Millisecond
+	defaultLoginMaxPause          = 1 * time.Second
+	defaultLoginRetryPause        = 5 * time.Second
+	defaultConnMinPause           = 0 * time.Millisecond
+	defaultConnMaxPause           = 5 * time.Second
+	defaultConnLookbackWindow     = 1 * time.Second
+	defaultConnLowerThreshold     = 1000   // connections per second
+	defaultConnUpperThreshold     = 100000 // connections per second
+	defaultLogSinkRateLimitBurst  = 1000
+	defaultLogSinkRateLimitRefill = time.Millisecond
+)
+
+// RateLimitConfig holds parameters to control
+// aspects of rate limiting connections and logins.
+type RateLimitConfig struct {
+	LoginRateLimit     int
+	LoginMinPause      time.Duration
+	LoginMaxPause      time.Duration
+	LoginRetryPause    time.Duration
+	ConnMinPause       time.Duration
+	ConnMaxPause       time.Duration
+	ConnLookbackWindow time.Duration
+	ConnLowerThreshold int
+	ConnUpperThreshold int
+}
+
+// DefaultRateLimitConfig returns a RateLimtConfig struct with
+// all attributes set to their default values.
+func DefaultRateLimitConfig() RateLimitConfig {
+	return RateLimitConfig{
+		LoginRateLimit:     defaultLoginRateLimit,
+		LoginMinPause:      defaultLoginMinPause,
+		LoginMaxPause:      defaultLoginMaxPause,
+		LoginRetryPause:    defaultLoginRetryPause,
+		ConnMinPause:       defaultConnMinPause,
+		ConnMaxPause:       defaultConnMaxPause,
+		ConnLookbackWindow: defaultConnLookbackWindow,
+		ConnLowerThreshold: defaultConnLowerThreshold,
+		ConnUpperThreshold: defaultConnUpperThreshold,
+	}
+}
+
+// Validate validates the rate limit configuration.
+// We apply arbitrary but sensible upper limits to prevent
+// typos from introducing obviously bad config.
+func (c RateLimitConfig) Validate() error {
+	if c.LoginRateLimit <= 0 || c.LoginRateLimit > 100 {
+		return errors.NotValidf("login-rate-limit %d <= 0 or > 100", c.LoginRateLimit)
+	}
+	if c.LoginMinPause < 0 || c.LoginMinPause > 100*time.Millisecond {
+		return errors.NotValidf("login-min-pause %d < 0 or > 100ms", c.LoginMinPause)
+	}
+	if c.LoginMaxPause < 0 || c.LoginMaxPause > 5*time.Second {
+		return errors.NotValidf("login-max-pause %d < 0 or > 5s", c.LoginMaxPause)
+	}
+	if c.LoginRetryPause < 0 || c.LoginRetryPause > 10*time.Second {
+		return errors.NotValidf("login-retry-pause %d < 0 or > 10s", c.LoginRetryPause)
+	}
+	if c.ConnMinPause < 0 || c.ConnMinPause > 100*time.Millisecond {
+		return errors.NotValidf("conn-min-pause %d < 0 or > 100ms", c.ConnMinPause)
+	}
+	if c.ConnMaxPause < 0 || c.ConnMaxPause > 10*time.Second {
+		return errors.NotValidf("conn-max-pause %d < 0 or > 10s", c.ConnMaxPause)
+	}
+	if c.ConnLookbackWindow < 0 || c.ConnLookbackWindow > 5*time.Second {
+		return errors.NotValidf("conn-lookback-window %d < 0 or > 5s", c.ConnMaxPause)
+	}
+	return nil
+}
+
+// AuditLogConfig holds parameters to control audit logging.
+type AuditLogConfig struct {
+	Enabled bool
+
+	// CaptureAPIArgs says whether to capture API method args (command
+	// line args will always be captured).
+	CaptureAPIArgs bool
+
+	// MaxSizeMB defines the maximum log file size.
+	MaxSizeMB int
+
+	// MaxBackups determines how many files back to keep.
+	MaxBackups int
+}
+
+// DefaultAuditLogConfig returns an AuditLogConfig with default
+// values.
+func DefaultAuditLogConfig() AuditLogConfig {
+	return AuditLogConfig{
+		Enabled:        true,
+		CaptureAPIArgs: false,
+		MaxSizeMB:      300,
+		MaxBackups:     10,
+	}
+}
+
+// LogSinkConfig holds parameters to control the API server's
+// logsink endpoint behaviour.
+type LogSinkConfig struct {
+	// DBLoggerBufferSize is the capacity of the database logger's buffer.
+	DBLoggerBufferSize int
+
+	// DBLoggerFlushInterval is the amount of time to allow a log record
+	// to sit in the buffer before being flushed to the database.
+	DBLoggerFlushInterval time.Duration
+
+	// RateLimitBurst defines the number of log messages that will be let
+	// through before we start rate limiting.
+	RateLimitBurst int64
+
+	// RateLimitRefill defines the rate at which log messages will be let
+	// through once the initial burst amount has been depleted.
+	RateLimitRefill time.Duration
+}
+
+// Validate validates the logsink endpoint configuration.
+func (cfg LogSinkConfig) Validate() error {
+	if cfg.DBLoggerBufferSize <= 0 || cfg.DBLoggerBufferSize > 1000 {
+		return errors.NotValidf("DBLoggerBufferSize %d <= 0 or > 1000", cfg.DBLoggerBufferSize)
+	}
+	if cfg.DBLoggerFlushInterval <= 0 || cfg.DBLoggerFlushInterval > 10*time.Second {
+		return errors.NotValidf("DBLoggerFlushInterval %s <= 0 or > 10 seconds", cfg.DBLoggerFlushInterval)
+	}
+	if cfg.RateLimitBurst <= 0 {
+		return errors.NotValidf("RateLimitBurst %d <= 0", cfg.RateLimitBurst)
+	}
+	if cfg.RateLimitRefill <= 0 {
+		return errors.NotValidf("RateLimitRefill %s <= 0", cfg.RateLimitRefill)
+	}
+	return nil
+}
+
+// DefaultLogSinkConfig returns a LogSinkConfig with default values.
+func DefaultLogSinkConfig() LogSinkConfig {
+	return LogSinkConfig{
+		DBLoggerBufferSize:    defaultDBLoggerBufferSize,
+		DBLoggerFlushInterval: defaultDBLoggerFlushInterval,
+		RateLimitBurst:        defaultLogSinkRateLimitBurst,
+		RateLimitRefill:       defaultLogSinkRateLimitRefill,
+	}
+}

--- a/apiserver/export_test.go
+++ b/apiserver/export_test.go
@@ -110,7 +110,7 @@ func TestingAPIHandler(c *gc.C, pool *state.StatePool, st *state.State) (*apiHan
 		statePool:     pool,
 		tag:           names.NewMachineTag("0"),
 	}
-	h, err := newAPIHandler(srv, st, nil, st.ModelUUID(), "testing.invalid:1234")
+	h, err := newAPIHandler(srv, st, nil, st.ModelUUID(), 6543, "testing.invalid:1234")
 	c.Assert(err, jc.ErrorIsNil)
 	return h, h.getResources()
 }

--- a/apiserver/logsink_test.go
+++ b/apiserver/logsink_test.go
@@ -213,7 +213,6 @@ func (s *logsinkSuite) TestNewServerValidatesLogSinkConfig(c *gc.C) {
 	type dummyListener struct {
 		net.Listener
 	}
-
 	cfg := defaultServerConfig(c)
 	cfg.LogSinkConfig = &apiserver.LogSinkConfig{}
 

--- a/apiserver/observer/fakeobserver/instance.go
+++ b/apiserver/observer/fakeobserver/instance.go
@@ -36,8 +36,11 @@ func (f *Instance) Login(entity names.Tag, model names.ModelTag, fromController 
 
 // RPCObserver implements Observer.
 func (f *Instance) RPCObserver() rpc.Observer {
-	f.AddCall(funcName())
-	return &RPCInstance{}
+	// Stash the instance away in the call so that we can check calls
+	// on it later.
+	result := &RPCInstance{}
+	f.AddCall(funcName(), result)
+	return result
 }
 
 // RPCInstance is a fake RPCObserver used for testing.

--- a/apiserver/observer/observer_test.go
+++ b/apiserver/observer/observer_test.go
@@ -74,7 +74,7 @@ func (*multiplexerSuite) TestRPCObserver_CallsAllObservers(c *gc.C) {
 	o.RPCObserver()
 
 	for _, f := range observers {
-		f.CheckCall(c, 0, "RPCObserver")
+		f.CheckCallNames(c, "RPCObserver")
 	}
 }
 

--- a/apiserver/observer/recorder.go
+++ b/apiserver/observer/recorder.go
@@ -1,0 +1,83 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package observer
+
+import (
+	"encoding/json"
+
+	"github.com/juju/errors"
+
+	"github.com/juju/juju/core/auditlog"
+	"github.com/juju/juju/rpc"
+)
+
+// NewRecorderFactory makes a new rpc.RecorderFactory to make
+// recorders that that will update the observer and the auditlog
+// recorder when it records a request or reply. The auditlog recorder
+// can be nil.
+func NewRecorderFactory(observerFactory rpc.ObserverFactory, recorder *auditlog.Recorder) rpc.RecorderFactory {
+	return func() rpc.Recorder {
+		return &combinedRecorder{
+			observer: observerFactory.RPCObserver(),
+			recorder: recorder,
+		}
+	}
+}
+
+// combinedRecorder wraps an observer (which might be a multiplexer)
+// up with an auditlog recorder into an rpc.Recorder.
+type combinedRecorder struct {
+	observer rpc.Observer
+	recorder *auditlog.Recorder
+}
+
+// HandleRequest implements rpc.Recorder.
+func (cr *combinedRecorder) HandleRequest(hdr *rpc.Header, body interface{}) error {
+	cr.observer.ServerRequest(hdr, body)
+	if cr.recorder == nil {
+		return nil
+	}
+	// TODO(babbageclunk): make this configurable.
+	jsonArgs, err := json.Marshal(body)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	return errors.Trace(cr.recorder.AddRequest(auditlog.RequestArgs{
+		RequestID: hdr.RequestId,
+		Facade:    hdr.Request.Type,
+		Method:    hdr.Request.Action,
+		Version:   hdr.Request.Version,
+		Args:      string(jsonArgs),
+	}))
+}
+
+// HandleReply implements rpc.Recorder.
+func (cr *combinedRecorder) HandleReply(req rpc.Request, replyHdr *rpc.Header, body interface{}) error {
+	cr.observer.ServerReply(req, replyHdr, body)
+	if cr.recorder == nil {
+		return nil
+	}
+	var responseErrors []*auditlog.Error
+	if replyHdr.Error == "" {
+		var err error
+		responseErrors, err = extractErrors(body)
+		if err != nil {
+			return errors.Trace(err)
+		}
+	} else {
+		responseErrors = []*auditlog.Error{{
+			Message: replyHdr.Error,
+			Code:    replyHdr.ErrorCode,
+		}}
+	}
+	return errors.Trace(cr.recorder.AddResponse(auditlog.ResponseErrorsArgs{
+		RequestID: replyHdr.RequestId,
+		Errors:    responseErrors,
+	}))
+}
+
+func extractErrors(body interface{}) ([]*auditlog.Error, error) {
+	// TODO(babbageclunk): use reflection to find errors in the response body.
+	return nil, nil
+}

--- a/apiserver/observer/recorder_test.go
+++ b/apiserver/observer/recorder_test.go
@@ -1,0 +1,114 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package observer_test
+
+import (
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/apiserver/observer"
+	"github.com/juju/juju/apiserver/observer/fakeobserver"
+	apitesting "github.com/juju/juju/apiserver/testing"
+	"github.com/juju/juju/core/auditlog"
+	"github.com/juju/juju/rpc"
+)
+
+type recorderSuite struct {
+	testing.IsolationSuite
+}
+
+var _ = gc.Suite(&recorderSuite{})
+
+func (s *recorderSuite) TestServerRequest(c *gc.C) {
+	fake := &fakeobserver.Instance{}
+	log := &apitesting.FakeAuditLog{}
+	auditRecorder, err := auditlog.NewRecorder(log, auditlog.ConversationArgs{
+		ConnectionID: 4567,
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	factory := observer.NewRecorderFactory(fake, auditRecorder)
+	recorder := factory()
+	hdr := &rpc.Header{
+		RequestId: 123,
+		Request:   rpc.Request{"Type", 5, "", "Action"},
+	}
+	err = recorder.HandleRequest(hdr, "the args")
+	c.Assert(err, jc.ErrorIsNil)
+
+	fake.CheckCallNames(c, "RPCObserver")
+	fakeOb := fake.Calls()[0].Args[0].(*fakeobserver.RPCInstance)
+	fakeOb.CheckCallNames(c, "ServerRequest")
+	fakeOb.CheckCall(c, 0, "ServerRequest", hdr, "the args")
+
+	log.CheckCallNames(c, "AddConversation", "AddRequest")
+
+	request := log.Calls()[1].Args[0].(auditlog.Request)
+	c.Assert(request.ConversationID, gc.HasLen, 16)
+	request.ConversationID = "abcdef0123456789"
+	c.Assert(request, gc.Equals, auditlog.Request{
+		ConversationID: "abcdef0123456789",
+		ConnectionID:   "11D7",
+		RequestID:      123,
+		Facade:         "Type",
+		Method:         "Action",
+		Version:        5,
+		Args:           `"the args"`,
+	})
+}
+
+func (s *recorderSuite) TestServerReply(c *gc.C) {
+	fake := &fakeobserver.Instance{}
+	log := &apitesting.FakeAuditLog{}
+	auditRecorder, err := auditlog.NewRecorder(log, auditlog.ConversationArgs{
+		ConnectionID: 4567,
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	factory := observer.NewRecorderFactory(fake, auditRecorder)
+	recorder := factory()
+
+	req := rpc.Request{"Type", 5, "", "Action"}
+	hdr := &rpc.Header{RequestId: 123}
+	err = recorder.HandleReply(req, hdr, "the response")
+	c.Assert(err, jc.ErrorIsNil)
+
+	fake.CheckCallNames(c, "RPCObserver")
+	fakeOb := fake.Calls()[0].Args[0].(*fakeobserver.RPCInstance)
+	fakeOb.CheckCallNames(c, "ServerReply")
+	fakeOb.CheckCall(c, 0, "ServerReply", req, hdr, "the response")
+
+	log.CheckCallNames(c, "AddConversation", "AddResponse")
+
+	respErrors := log.Calls()[1].Args[0].(auditlog.ResponseErrors)
+	c.Assert(respErrors.ConversationID, gc.HasLen, 16)
+	respErrors.ConversationID = "abcdef0123456789"
+	c.Assert(respErrors, gc.DeepEquals, auditlog.ResponseErrors{
+		ConversationID: "abcdef0123456789",
+		ConnectionID:   "11D7",
+		RequestID:      123,
+		Errors:         nil,
+	})
+}
+
+func (s *recorderSuite) TestNoAuditRequest(c *gc.C) {
+	fake := &fakeobserver.Instance{}
+	factory := observer.NewRecorderFactory(fake, nil)
+	recorder := factory()
+	hdr := &rpc.Header{
+		RequestId: 123,
+		Request:   rpc.Request{"Type", 0, "", "Action"},
+	}
+	err := recorder.HandleRequest(hdr, "the body")
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *recorderSuite) TestNoAuditReply(c *gc.C) {
+	fake := &fakeobserver.Instance{}
+	factory := observer.NewRecorderFactory(fake, nil)
+	recorder := factory()
+	req := rpc.Request{"Type", 0, "", "Action"}
+	hdr := &rpc.Header{RequestId: 123}
+	err := recorder.HandleReply(req, hdr, "the body")
+	c.Assert(err, jc.ErrorIsNil)
+}

--- a/apiserver/root.go
+++ b/apiserver/root.go
@@ -53,6 +53,10 @@ type apiHandler struct {
 	// user manager and model manager api endpoints from here.
 	modelUUID string
 
+	// connectionID is shared between the API observer (including API
+	// requests and responses in the agent log) and the audit logger.
+	connectionID uint64
+
 	// serverHost is the host:port of the API server that the client
 	// connected to.
 	serverHost string
@@ -61,18 +65,19 @@ type apiHandler struct {
 var _ = (*apiHandler)(nil)
 
 // newAPIHandler returns a new apiHandler.
-func newAPIHandler(srv *Server, st *state.State, rpcConn *rpc.Conn, modelUUID string, serverHost string) (*apiHandler, error) {
+func newAPIHandler(srv *Server, st *state.State, rpcConn *rpc.Conn, modelUUID string, connectionID uint64, serverHost string) (*apiHandler, error) {
 	m, err := st.Model()
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
 	r := &apiHandler{
-		state:      st,
-		model:      m,
-		resources:  common.NewResources(),
-		rpcConn:    rpcConn,
-		modelUUID:  modelUUID,
-		serverHost: serverHost,
+		state:        st,
+		model:        m,
+		resources:    common.NewResources(),
+		rpcConn:      rpcConn,
+		modelUUID:    modelUUID,
+		connectionID: connectionID,
+		serverHost:   serverHost,
 	}
 
 	if err := r.resources.RegisterNamed("machineID", common.StringResource(srv.tag.Id())); err != nil {

--- a/apiserver/server_test.go
+++ b/apiserver/server_test.go
@@ -625,6 +625,7 @@ func defaultServerConfig(c *gc.C) apiserver.ServerConfig {
 		NewObserver:     func() observer.Observer { return &fakeobserver.Instance{} },
 		AutocertURL:     "https://0.1.2.3/no-autocert-here",
 		RateLimitConfig: apiserver.DefaultRateLimitConfig(),
+		AuditLogConfig:  apiserver.AuditLogConfig{Enabled: false},
 		UpgradeComplete: func() bool { return true },
 		RestoreStatus: func() state.RestoreStatus {
 			return state.RestoreNotActive

--- a/apiserver/testing/fakeapi.go
+++ b/apiserver/testing/fakeapi.go
@@ -12,6 +12,7 @@ import (
 	"github.com/gorilla/websocket"
 	"github.com/juju/utils"
 
+	"github.com/juju/juju/apiserver/observer"
 	"github.com/juju/juju/apiserver/observer/fakeobserver"
 	"github.com/juju/juju/rpc"
 	"github.com/juju/juju/rpc/jsoncodec"
@@ -78,12 +79,12 @@ func (srv *Server) serveAPI(w http.ResponseWriter, req *http.Request) {
 
 func (srv *Server) serveConn(ctx context.Context, wsConn *websocket.Conn, modelUUID string) {
 	codec := jsoncodec.NewWebsocket(wsConn)
-	conn := rpc.NewConn(codec, &fakeobserver.Instance{})
+	conn := rpc.NewConn(codec, observer.NewRecorderFactory(&fakeobserver.Instance{}, nil))
 
 	root := allVersions{
 		rpcreflect.ValueOf(reflect.ValueOf(srv.newRoot(modelUUID))),
 	}
-	conn.ServeRoot(root, nil)
+	conn.ServeRoot(root, nil, nil)
 	conn.Start(ctx)
 	<-conn.Dead()
 	conn.Close()

--- a/apiserver/testing/fakeauditlog.go
+++ b/apiserver/testing/fakeauditlog.go
@@ -1,0 +1,35 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package testing
+
+import (
+	"github.com/juju/testing"
+
+	"github.com/juju/juju/core/auditlog"
+)
+
+// FakeAuditLog implements auditlog.AuditLog.
+type FakeAuditLog struct {
+	testing.Stub
+}
+
+func (l *FakeAuditLog) AddConversation(m auditlog.Conversation) error {
+	l.Stub.AddCall("AddConversation", m)
+	return l.Stub.NextErr()
+}
+
+func (l *FakeAuditLog) AddRequest(m auditlog.Request) error {
+	l.Stub.AddCall("AddRequest", m)
+	return l.Stub.NextErr()
+}
+
+func (l *FakeAuditLog) AddResponse(m auditlog.ResponseErrors) error {
+	l.Stub.AddCall("AddResponse", m)
+	return l.Stub.NextErr()
+}
+
+func (l *FakeAuditLog) Close() error {
+	l.Stub.AddCall("Close")
+	return l.Stub.NextErr()
+}

--- a/cmd/juju/status/history_test.go
+++ b/cmd/juju/status/history_test.go
@@ -31,7 +31,6 @@ func (s *StatusHistorySuite) SetUpTest(c *gc.C) {
 	s.IsolationSuite.SetUpTest(c)
 	s.api = nil
 	s.now = time.Date(2017, 11, 28, 12, 34, 56, 0, time.UTC)
-	s.PatchValue(&time.Local, time.UTC)
 }
 
 func (s *StatusHistorySuite) newCommand() cmd.Command {
@@ -95,16 +94,16 @@ func (s *StatusHistorySuite) TestResults(c *gc.C) {
 		},
 	}
 	expected := "" +
-		"Time                   Type       Status       Message\n" +
-		"28 Nov 2017 12:34:56Z  juju-unit  allocating   \n" +
-		"28 Nov 2017 12:35:56Z  workload   waiting      waiting for machine\n" +
-		"28 Nov 2017 12:36:56Z  workload   waiting      installing agent\n" +
-		"28 Nov 2017 12:37:56Z  workload   waiting      agent initializing\n" +
-		"28 Nov 2017 12:38:56Z  workload   maintenance  installing charm software\n" +
-		"28 Nov 2017 12:39:56Z  juju-unit  executing    running install hoook\n" +
-		"28 Nov 2017 12:40:56Z  juju-unit  executing    running config-changed hoook\n"
+		"Time                  Type       Status       Message\n" +
+		"2017-11-28 12:34:56Z  juju-unit  allocating   \n" +
+		"2017-11-28 12:35:56Z  workload   waiting      waiting for machine\n" +
+		"2017-11-28 12:36:56Z  workload   waiting      installing agent\n" +
+		"2017-11-28 12:37:56Z  workload   waiting      agent initializing\n" +
+		"2017-11-28 12:38:56Z  workload   maintenance  installing charm software\n" +
+		"2017-11-28 12:39:56Z  juju-unit  executing    running install hoook\n" +
+		"2017-11-28 12:40:56Z  juju-unit  executing    running config-changed hoook\n"
 
-	ctx, err := cmdtesting.RunCommand(c, s.newCommand(), "missing/0")
+	ctx, err := cmdtesting.RunCommand(c, s.newCommand(), "missing/0", "--utc")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(cmdtesting.Stderr(ctx), gc.Equals, "")
 	c.Check(cmdtesting.Stdout(ctx), gc.Equals, expected)

--- a/cmd/jujud/agent/agenttest/agent.go
+++ b/cmd/jujud/agent/agenttest/agent.go
@@ -137,6 +137,7 @@ func (s *AgentSuite) PrimeAgentVersion(c *gc.C, tag names.Tag, password string, 
 	apiInfo := s.APIInfo(c)
 	paths := agent.DefaultPaths
 	paths.DataDir = s.DataDir()
+	paths.LogDir = s.LogDir
 	paths.MetricsSpoolDir = c.MkDir()
 	conf, err := agent.NewAgentConfig(
 		agent.AgentConfigParams{
@@ -203,7 +204,10 @@ func (s *AgentSuite) WriteStateAgentConfig(
 	apiAddr := []string{fmt.Sprintf("localhost:%d", apiPort)}
 	conf, err := agent.NewStateMachineConfig(
 		agent.AgentConfigParams{
-			Paths:             agent.NewPathsWithDefaults(agent.Paths{DataDir: s.DataDir()}),
+			Paths: agent.NewPathsWithDefaults(agent.Paths{
+				DataDir: s.DataDir(),
+				LogDir:  s.LogDir,
+			}),
 			Tag:               tag,
 			UpgradedToVersion: vers.Number,
 			Password:          password,

--- a/environs/config/config_test.go
+++ b/environs/config/config_test.go
@@ -840,6 +840,65 @@ func (s *ConfigSuite) TestValidateChange(c *gc.C) {
 	}
 }
 
+type configValidateCloudInitUserDataTest struct {
+	about string
+	value string
+	err   string
+}
+
+var configValidateCloudInitUserDataTests = []configValidateCloudInitUserDataTest{
+	{
+		about: "Valid cloud init user data values",
+		value: validCloudInitUserData,
+	}, {
+		about: "Invalid cloud init user data values: package int",
+		value: invalidCloudInitUserDataPackageInt,
+		err:   `cloudinit-userdata: packages must be a list of strings: expected string, got int\(76\)`,
+	}, {
+		about: "Invalid cloud init user data values: users",
+		value: invalidCloudInitUserDataUsers,
+		err:   `cloudinit-userdata: users not allowed`,
+	}, {
+		about: "Invalid cloud init user data values: runcmd",
+		value: invalidCloudInitUserDataRuncmd,
+		err:   `cloudinit-userdata: runcmd not allowed, use preruncmd or postruncmd instead`,
+	}, {
+		about: "Invalid cloud init user data: yaml",
+		value: invalidCloudInitUserDataInvalidYAML,
+		err:   `cloudinit-userdata: must be valid YAML: yaml: line 2: did not find expected '-' indicator`,
+	},
+}
+
+func (s *ConfigSuite) TestValidateCloudInitUserData(c *gc.C) {
+	files := []gitjujutesting.TestFile{
+		{".ssh/id_dsa.pub", "dsa"},
+		{".ssh/id_rsa.pub", "rsa\n"},
+		{".ssh/identity.pub", "identity"},
+		{".ssh/authorized_keys", "auth0\n# first\nauth1\n\n"},
+		{".ssh/authorized_keys2", "auth2\nauth3\n"},
+	}
+	s.FakeHomeSuite.Home.AddFiles(c, files...)
+	for i, test := range configValidateCloudInitUserDataTests {
+		c.Logf("test %d. %s", i, test.about)
+		test.checkNew(c)
+	}
+}
+
+func (test configValidateCloudInitUserDataTest) checkNew(c *gc.C) {
+	final := testing.Attrs{
+		"type": "my-type", "name": "my-name",
+		"uuid": testing.ModelTag.Id(),
+		config.CloudInitUserDataKey: test.value,
+	}
+
+	_, err := config.New(config.UseDefaults, final)
+	if test.err != "" {
+		c.Assert(err, gc.ErrorMatches, test.err)
+		return
+	}
+	c.Assert(err, jc.ErrorIsNil)
+}
+
 func (s *ConfigSuite) addJujuFiles(c *gc.C) {
 	s.FakeHomeSuite.Home.AddFiles(c, []gitjujutesting.TestFile{
 		{".ssh/id_rsa.pub", "rsa\n"},
@@ -1145,6 +1204,18 @@ func (s *ConfigSuite) TestEgressSubnets(c *gc.C) {
 	c.Assert(cfg.EgressSubnets(), gc.DeepEquals, []string{"10.0.0.1/32", "192.168.1.1/16"})
 }
 
+func (s *ConfigSuite) TestCloudInitUserDataFromEnvironment(c *gc.C) {
+	cfg := newTestConfig(c, testing.Attrs{
+		config.CloudInitUserDataKey: validCloudInitUserData,
+	})
+	c.Assert(cfg.CloudInitUserData(), gc.DeepEquals, map[string]interface{}{
+		"packages":        []interface{}{"python-keystoneclient", "python-glanceclient"},
+		"preruncmd":       []interface{}{"mkdir /tmp/preruncmd", "mkdir /tmp/preruncmd2"},
+		"postruncmd":      []interface{}{"mkdir /tmp/postruncmd", "mkdir /tmp/postruncmd2"},
+		"package_upgrade": false},
+	)
+}
+
 func (s *ConfigSuite) TestSchemaNoExtra(c *gc.C) {
 	schema, err := config.Schema(nil)
 	c.Assert(err, gc.IsNil)
@@ -1257,3 +1328,46 @@ var invalidCACert = `
 MIIBOgIBAAJAZabKgKInuOxj5vDWLwHHQtK3/45KB+32D15w94Nt83BmuGxo90lw
 -----END CERTIFICATE-----
 `[1:]
+
+var validCloudInitUserData = `packages:
+  - 'python-keystoneclient'
+  - 'python-glanceclient'
+preruncmd:
+  - mkdir /tmp/preruncmd
+  - mkdir /tmp/preruncmd2
+postruncmd:
+  - mkdir /tmp/postruncmd
+  - mkdir /tmp/postruncmd2
+package_upgrade: false
+`
+
+var invalidCloudInitUserDataPackageInt = `packages:
+    - 76
+postruncmd:
+    - mkdir /tmp/runcmd
+package_upgrade: true
+`
+
+var invalidCloudInitUserDataRuncmd = `packages:
+    - 'string1'
+    - 'string2'
+runcmd:
+    - mkdir /tmp/runcmd
+package_upgrade: true
+`
+
+var invalidCloudInitUserDataUsers = `packages:
+    - 'string1'
+    - 'string2'
+users:
+    name: test-user
+package_upgrade: true
+`
+
+var invalidCloudInitUserDataInvalidYAML = `packages:
+    - 'string1'
+     'string2'
+runcmd:
+    - mkdir /tmp/runcmd
+package_upgrade: true
+`

--- a/juju/testing/conn.go
+++ b/juju/testing/conn.go
@@ -647,12 +647,14 @@ func (s *JujuConnSuite) tearDownConn(c *gc.C) {
 			)
 		}
 	}
+
 	// Close the state pool before we close the underlying state.
 	if s.StatePool != nil {
 		err := s.StatePool.Close()
 		c.Check(err, jc.ErrorIsNil)
 		s.StatePool = nil
 	}
+
 	// Close state.
 	if s.State != nil {
 		err := s.State.Close()

--- a/rpc/dispatch_test.go
+++ b/rpc/dispatch_test.go
@@ -33,9 +33,9 @@ func (s *dispatchSuite) SetUpSuite(c *gc.C) {
 	s.BaseSuite.SetUpSuite(c)
 	rpcServer := func(ws *websocket.Conn) {
 		codec := jsoncodec.NewWebsocket(ws)
-		conn := rpc.NewConn(codec, &notifier{})
+		conn := rpc.NewConn(codec, nil)
 
-		conn.Serve(&DispatchRoot{}, nil)
+		conn.Serve(&DispatchRoot{}, nil, nil)
 		conn.Start(context.Background())
 
 		<-conn.Dead()

--- a/rpc/observers.go
+++ b/rpc/observers.go
@@ -28,6 +28,14 @@ type Observer interface {
 	ServerReply(req Request, hdr *Header, body interface{})
 }
 
+// ObserverFactory is a type which can construct a new Observer.
+type ObserverFactory interface {
+	// RPCObserver will return a new Observer usually constructed
+	// from the state previously built up in the Observer. The
+	// returned instance will be utilized per RPC request.
+	RPCObserver() Observer
+}
+
 // NewObserverMultiplexer returns a new ObserverMultiplexer
 // with the provided RequestNotifiers.
 func NewObserverMultiplexer(rpcObservers ...Observer) *ObserverMultiplexer {

--- a/state/modelsummaries.go
+++ b/state/modelsummaries.go
@@ -129,7 +129,6 @@ func (p *modelSummaryProcessor) fillInFromConfig() error {
 	rawSettings, closer := p.st.database.GetRawCollection(settingsC)
 	defer closer()
 
-	remaining := set.NewStrings(p.modelUUIDs...)
 	settingIds := make([]string, len(p.modelUUIDs))
 	for i, uuid := range p.modelUUIDs {
 		settingIds[i] = uuid + ":" + modelGlobalKey
@@ -143,7 +142,6 @@ func (p *modelSummaryProcessor) fillInFromConfig() error {
 			// How could it return a doc that we don't have?
 			continue
 		}
-		remaining.Remove(doc.ModelUUID)
 
 		cfg, err := config.New(config.NoDefaults, doc.Settings)
 		if err != nil {
@@ -159,10 +157,6 @@ func (p *modelSummaryProcessor) fillInFromConfig() error {
 	}
 	if err := iter.Close(); err != nil {
 		return errors.Trace(err)
-	}
-	if !remaining.IsEmpty() {
-		// XXX: What error is appropriate? Do we need to care about models that its ok to be missing?
-		return errors.Errorf("could not find settings/config for models: %v", remaining.SortedValues())
 	}
 	return nil
 }

--- a/state/upgrades.go
+++ b/state/upgrades.go
@@ -22,6 +22,7 @@ import (
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/state/globalclock"
 	"github.com/juju/juju/state/lease"
+	"github.com/juju/juju/status"
 	"github.com/juju/juju/storage/provider"
 )
 
@@ -1263,6 +1264,54 @@ func migrateModelLeasesToGlobalTime(st *State) error {
 		return ops, nil
 	})
 	return errors.Annotate(err, "upgrading legacy lease documents")
+}
+
+// AddRelationStatus sets the initial status for existing relations
+// without a status.
+func AddRelationStatus(st *State) error {
+	return runForAllModelStates(st, addRelationStatus)
+}
+
+func addRelationStatus(st *State) error {
+	// Newly created relations will have a status doc,
+	// so it suffices to just get the collection once
+	// up front.
+	relations, err := st.AllRelations()
+	if err != nil {
+		return errors.Trace(err)
+	}
+	now := st.clock().Now()
+	err = st.db().Run(func(int) ([]txn.Op, error) {
+		var ops []txn.Op
+		for _, rel := range relations {
+			_, err := rel.Status()
+			if err == nil {
+				continue
+			}
+			if !errors.IsNotFound(err) {
+				return nil, err
+			}
+			// Relations are marked as either
+			// joining or joined, depending
+			// on whether there are any units
+			// in scope.
+			relStatus := status.Joining
+			if rel.doc.UnitCount > 0 {
+				relStatus = status.Joined
+			}
+			relationStatusDoc := statusDoc{
+				Status:    relStatus,
+				ModelUUID: st.ModelUUID(),
+				Updated:   now.UnixNano(),
+			}
+			ops = append(ops, createStatusOp(
+				st, relationGlobalScope(rel.Id()),
+				relationStatusDoc,
+			))
+		}
+		return ops, nil
+	})
+	return errors.Annotate(err, "adding relation status")
 }
 
 // MoveOldAuditLog renames the no-longer-needed audit.log collection

--- a/state/upgrades_test.go
+++ b/state/upgrades_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
+	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils"
 	"github.com/juju/utils/set"
@@ -20,7 +21,7 @@ import (
 	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/storage/provider"
-	"github.com/juju/juju/testing"
+	coretesting "github.com/juju/juju/testing"
 )
 
 type upgradesSuite struct {
@@ -976,9 +977,9 @@ func (s *upgradesSuite) TestAddControllerLogCollectionsSizeSettings(c *gc.C) {
 	)
 }
 
-func (s *upgradesSuite) makeModel(c *gc.C, name string, attr testing.Attrs) *State {
+func (s *upgradesSuite) makeModel(c *gc.C, name string, attr coretesting.Attrs) *State {
 	uuid := utils.MustNewUUID()
-	cfg := testing.CustomModelConfig(c, testing.Attrs{
+	cfg := coretesting.CustomModelConfig(c, coretesting.Attrs{
 		"name": name,
 		"uuid": uuid.String(),
 	}.Merge(attr))
@@ -1011,13 +1012,13 @@ func (s *upgradesSuite) TestAddUpdateStatusHookSettings(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	// One model has a valid setting that is not default.
-	m1 := s.makeModel(c, "m1", testing.Attrs{
+	m1 := s.makeModel(c, "m1", coretesting.Attrs{
 		"update-status-hook-interval": "20m",
 	})
 	defer m1.Close()
 
 	// This model is missing a setting entirely.
-	m2 := s.makeModel(c, "m2", testing.Attrs{})
+	m2 := s.makeModel(c, "m2", coretesting.Attrs{})
 	defer m2.Close()
 	// We remove the 'update-status-hook-interval' value to
 	// represent an old-style model that needs updating.
@@ -1318,7 +1319,7 @@ func (s *upgradesSuite) TestSplitLogCollection(c *gc.C) {
 			"e":   modelUUID,
 			"r":   "2.1.2",
 			"n":   fmt.Sprintf("fake-entitiy-%d", i),
-			"m":   "juju.testing",
+			"m":   "juju.coretesting",
 			"l":   "fake-file.go:1234",
 			"v":   int(loggo.DEBUG),
 			"x":   "test message",
@@ -1389,7 +1390,7 @@ func (s *upgradesSuite) TestSplitLogsIgnoresDupeRecordsAlreadyThere(c *gc.C) {
 			"e":   modelUUID,
 			"r":   "2.1.2",
 			"n":   fmt.Sprintf("fake-entitiy-%d", i),
-			"m":   "juju.testing",
+			"m":   "juju.coretesting",
 			"l":   "fake-file.go:1234",
 			"v":   int(loggo.DEBUG),
 			"x":   "test message",
@@ -1453,7 +1454,7 @@ func (s *upgradesSuite) TestCorrectRelationUnitCounts(c *gc.C) {
 
 	// Use the non-controller model to ensure we can run the function
 	// across multiple models.
-	otherState := s.makeModel(c, "crack-up", testing.Attrs{})
+	otherState := s.makeModel(c, "crack-up", coretesting.Attrs{})
 	defer otherState.Close()
 
 	uuid := otherState.ModelUUID()
@@ -1802,13 +1803,13 @@ func (s *upgradesSuite) checkAddPruneSettings(c *gc.C, ageProp, sizeProp, defaul
 	_, err := settingsColl.RemoveAll(nil)
 	c.Assert(err, jc.ErrorIsNil)
 
-	m1 := s.makeModel(c, "m1", testing.Attrs{
+	m1 := s.makeModel(c, "m1", coretesting.Attrs{
 		ageProp:  "96h",
 		sizeProp: "4G",
 	})
 	defer m1.Close()
 
-	m2 := s.makeModel(c, "m2", testing.Attrs{})
+	m2 := s.makeModel(c, "m2", coretesting.Attrs{})
 	defer m2.Close()
 
 	err = settingsColl.Insert(bson.M{
@@ -1861,7 +1862,7 @@ func (s *upgradesSuite) TestMigrateLeasesToGlobalTime(c *gc.C) {
 
 	// Use the non-controller model to ensure we can run the function
 	// across multiple models.
-	otherState := s.makeModel(c, "crack-up", testing.Attrs{})
+	otherState := s.makeModel(c, "crack-up", coretesting.Attrs{})
 	defer otherState.Close()
 
 	uuid := otherState.ModelUUID()
@@ -1903,6 +1904,78 @@ func (s *upgradesSuite) TestMigrateLeasesToGlobalTime(c *gc.C) {
 	}}
 	s.assertUpgradedData(c, MigrateLeasesToGlobalTime,
 		expectUpgradedData{leases, expectedLeases},
+	)
+}
+
+func (s *upgradesSuite) TestAddRelationStatus(c *gc.C) {
+	// Set a test clock so we can dictate the
+	// time set in the new status doc.
+	clock := testing.NewClock(time.Unix(0, 123))
+	s.state.SetClockForTesting(clock)
+
+	relations, closer := s.state.db().GetRawCollection(relationsC)
+	defer closer()
+
+	statuses, closer := s.state.db().GetRawCollection(statusesC)
+	defer closer()
+
+	err := relations.Insert(bson.M{
+		"_id":        s.state.ModelUUID() + ":0",
+		"id":         0,
+		"model-uuid": s.state.ModelUUID(),
+	}, bson.M{
+		"_id":        s.state.ModelUUID() + ":1",
+		"id":         1,
+		"model-uuid": s.state.ModelUUID(),
+		"unitcount":  1,
+	}, bson.M{
+		"_id":        s.state.ModelUUID() + ":2",
+		"id":         2,
+		"model-uuid": s.state.ModelUUID(),
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	_, err = statuses.RemoveAll(nil)
+	c.Assert(err, jc.ErrorIsNil)
+	err = statuses.Insert(bson.M{
+		"_id":        s.state.ModelUUID() + ":r#2",
+		"model-uuid": s.state.ModelUUID(),
+		"status":     "broken",
+		"statusdata": bson.M{},
+		"statusinfo": "",
+		"updated":    int64(321),
+		"neverset":   false,
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	expectedStatuses := []bson.M{{
+		"_id":        s.state.ModelUUID() + ":r#0",
+		"model-uuid": s.state.ModelUUID(),
+		"status":     "joining",
+		"statusdata": bson.M{},
+		"statusinfo": "",
+		"updated":    int64(123),
+		"neverset":   false,
+	}, {
+		"_id":        s.state.ModelUUID() + ":r#1",
+		"model-uuid": s.state.ModelUUID(),
+		"status":     "joined",
+		"statusdata": bson.M{},
+		"statusinfo": "",
+		"updated":    int64(123),
+		"neverset":   false,
+	}, {
+		"_id":        s.state.ModelUUID() + ":r#2",
+		"model-uuid": s.state.ModelUUID(),
+		"status":     "broken",
+		"statusdata": bson.M{},
+		"statusinfo": "",
+		"updated":    int64(321),
+		"neverset":   false,
+	}}
+
+	s.assertUpgradedData(c, AddRelationStatus,
+		expectUpgradedData{statuses, expectedStatuses},
 	)
 }
 

--- a/upgrades/backend.go
+++ b/upgrades/backend.go
@@ -33,6 +33,7 @@ type StateBackend interface {
 	AddModelEnvironVersion() error
 	AddModelType() error
 	MigrateLeasesToGlobalTime() error
+	AddRelationStatus() error
 	MoveOldAuditLog() error
 }
 
@@ -126,6 +127,10 @@ func (s stateBackend) AddModelType() error {
 
 func (s stateBackend) MigrateLeasesToGlobalTime() error {
 	return state.MigrateLeasesToGlobalTime(s.st)
+}
+
+func (s stateBackend) AddRelationStatus() error {
+	return state.AddRelationStatus(s.st)
 }
 
 func (s stateBackend) MoveOldAuditLog() error {

--- a/upgrades/operations.go
+++ b/upgrades/operations.go
@@ -26,7 +26,8 @@ var stateUpgradeOperations = func() []Operation {
 		upgradeToVersion{version.MustParse("2.2.2"), stateStepsFor222()},
 		upgradeToVersion{version.MustParse("2.2.3"), stateStepsFor223()},
 		upgradeToVersion{version.MustParse("2.3.0"), stateStepsFor23()},
-		upgradeToVersion{version.MustParse("2.4.0"), stateStepsFor24()},
+		upgradeToVersion{version.MustParse("2.3.1"), stateStepsFor231()},
+		upgradeToVersion{version.MustParse("2.3.2"), stateStepsFor232()},
 	}
 	return steps
 }

--- a/upgrades/steps_23.go
+++ b/upgrades/steps_23.go
@@ -22,3 +22,16 @@ func stateStepsFor23() []Step {
 		},
 	}
 }
+
+// stateStepsFor231 returns upgrade steps for Juju 2.3.1 that manipulate state directly.
+func stateStepsFor231() []Step {
+	return []Step{
+		&upgradeStep{
+			description: "add status to relations",
+			targets:     []Target{DatabaseMaster},
+			run: func(context Context) error {
+				return context.State().AddRelationStatus()
+			},
+		},
+	}
+}

--- a/upgrades/steps_232.go
+++ b/upgrades/steps_232.go
@@ -3,8 +3,8 @@
 
 package upgrades
 
-// stateStepsFor24 returns upgrade steps for Juju 2.4.0 that manipulate state directly.
-func stateStepsFor24() []Step {
+// stateStepsFor232 returns upgrade steps for Juju 2.3.2 that manipulate state directly.
+func stateStepsFor232() []Step {
 	return []Step{
 		&upgradeStep{
 			description: "move or drop the old audit log collection",

--- a/upgrades/steps_232_test.go
+++ b/upgrades/steps_232_test.go
@@ -12,16 +12,16 @@ import (
 	"github.com/juju/juju/upgrades"
 )
 
-var v24 = version.MustParse("2.4.0")
+var v232 = version.MustParse("2.3.2")
 
-type steps24Suite struct {
+type steps232Suite struct {
 	testing.BaseSuite
 }
 
-var _ = gc.Suite(&steps24Suite{})
+var _ = gc.Suite(&steps232Suite{})
 
-func (s *steps24Suite) TestMoveOldAuditLog(c *gc.C) {
-	step := findStateStep(c, v24, "move or drop the old audit log collection")
+func (s *steps232Suite) TestMoveOldAuditLog(c *gc.C) {
+	step := findStateStep(c, v232, "move or drop the old audit log collection")
 	// Logic for step itself is tested in state package.
 	c.Assert(step.Targets(), jc.DeepEquals, []upgrades.Target{upgrades.DatabaseMaster})
 }

--- a/upgrades/steps_23_test.go
+++ b/upgrades/steps_23_test.go
@@ -12,7 +12,10 @@ import (
 	"github.com/juju/juju/upgrades"
 )
 
-var v23 = version.MustParse("2.3.0")
+var (
+	v23  = version.MustParse("2.3.0")
+	v231 = version.MustParse("2.3.1")
+)
 
 type steps23Suite struct {
 	testing.BaseSuite
@@ -28,6 +31,12 @@ func (s *steps23Suite) TestAddModelType(c *gc.C) {
 
 func (s *steps23Suite) TestMigrateLeases(c *gc.C) {
 	step := findStateStep(c, v23, "migrate old leases")
+	// Logic for step itself is tested in state package.
+	c.Assert(step.Targets(), jc.DeepEquals, []upgrades.Target{upgrades.DatabaseMaster})
+}
+
+func (s *steps23Suite) TestAddRelationStatus(c *gc.C) {
+	step := findStateStep(c, v231, "add status to relations")
 	// Logic for step itself is tested in state package.
 	c.Assert(step.Targets(), jc.DeepEquals, []upgrades.Target{upgrades.DatabaseMaster})
 }

--- a/upgrades/upgrade_test.go
+++ b/upgrades/upgrade_test.go
@@ -642,7 +642,8 @@ func (s *upgradeSuite) TestStateUpgradeOperationsVersions(c *gc.C) {
 		"2.2.2",
 		"2.2.3",
 		"2.3.0",
-		"2.4.0",
+		"2.3.1",
+		"2.3.2",
 	})
 }
 

--- a/worker/apiserver/worker_state_test.go
+++ b/worker/apiserver/worker_state_test.go
@@ -89,8 +89,12 @@ func (s *WorkerStateSuite) TestStart(c *gc.C) {
 	c.Assert(config.NewObserver, gc.NotNil)
 	config.NewObserver = nil
 
+	c.Assert(config.AuditLog, gc.NotNil)
+	config.AuditLog = nil
+
 	rateLimitConfig := coreapiserver.DefaultRateLimitConfig()
 	logSinkConfig := coreapiserver.DefaultLogSinkConfig()
+	auditLogConfig := coreapiserver.DefaultAuditLogConfig()
 
 	c.Assert(config, jc.DeepEquals, coreapiserver.ServerConfig{
 		Clock:                s.clock,
@@ -104,5 +108,6 @@ func (s *WorkerStateSuite) TestStart(c *gc.C) {
 		RateLimitConfig:      rateLimitConfig,
 		LogSinkConfig:        &logSinkConfig,
 		PrometheusRegisterer: &s.prometheusRegisterer,
+		AuditLogConfig:       auditLogConfig,
 	})
 }


### PR DESCRIPTION
This is the first part of getting 2.3 merged into the develop branch. It stops at the merge commit for #8184 to make the merge more manageable - those conflicts are fiddly because they interact with the code that creates the API server, which moved from the machine agent into a dependency engine worker. After this is landed the other merges should be more straightforward.