### PR TITLE
Check for /sbin/ifup, not for /e/n/i, to detect if system is using e/n/i or netplan. 

### DIFF
--- a/worker/provisioner/container_initialisation.go
+++ b/worker/provisioner/container_initialisation.go
@@ -32,6 +32,7 @@ import (
 
 var (
 	systemNetworkInterfacesFile = "/etc/network/interfaces"
+	systemSbinIfup              = "/sbin/ifup"
 	systemNetplanDirectory      = "/etc/netplan"
 	activateBridgesTimeout      = 5 * time.Minute
 )
@@ -218,7 +219,7 @@ func observeNetwork() ([]params.NetworkConfig, error) {
 }
 
 func defaultBridger() (network.Bridger, error) {
-	if _, err := os.Stat(systemNetworkInterfacesFile); err == nil {
+	if _, err := os.Stat(systemSbinIfup); err == nil {
 		return network.DefaultEtcNetworkInterfacesBridger(activateBridgesTimeout, systemNetworkInterfacesFile)
 	} else {
 		return network.DefaultNetplanBridger(activateBridgesTimeout, systemNetplanDirectory)


### PR DESCRIPTION
## Description of change
Netplan wants to add a 'dummy' e/n/i file telling that the system is configured with Netplan, we are now using existence of /sbin/ifup to detect if system is netplan compatible or not

## QA steps
Add an artful machine, create a dummy /etc/network/interfaces file on it, add a container on it, check if networking works.