### PR TITLE
Set up container networking on networkless environs properly

### DIFF
--- a/agent/agentbootstrap/bootstrap.go
+++ b/agent/agentbootstrap/bootstrap.go
@@ -219,11 +219,7 @@ func InitializeState(
 	defer hostedModelState.Close()
 
 	if err := model.AutoConfigureContainerNetworking(hostedModelEnv); err != nil {
-		if errors.IsNotSupported(err) {
-			logger.Debugf("Not performing container networking autoconfiguration on a non-networking environment")
-		} else {
-			return nil, nil, errors.Annotate(err, "autoconfiguring container networking")
-		}
+		return nil, nil, errors.Annotate(err, "autoconfiguring container networking")
 	}
 
 	// TODO(wpk) 2017-05-24 Copy subnets/spaces from controller model

--- a/agent/agentbootstrap/bootstrap_test.go
+++ b/agent/agentbootstrap/bootstrap_test.go
@@ -335,13 +335,16 @@ LXC_BRIDGE="ignored"`[1:])
 		"Provider",
 		"Version",
 	)
+	// Those attritbutes are configured during initialization, after "Open".
+	expectedCalledCfg, err := hostedCfg.Apply(map[string]interface{}{"container-networking-method": ""})
+	c.Assert(err, jc.ErrorIsNil)
 	envProvider.CheckCall(c, 2, "Open", environs.OpenParams{
 		Cloud: environs.CloudSpec{
 			Type:   "dummy",
 			Name:   "dummy",
 			Region: "dummy-region",
 		},
-		Config: hostedCfg,
+		Config: expectedCalledCfg,
 	})
 	envProvider.CheckCall(c, 3, "Create", environs.CreateParams{
 		ControllerUUID: controllerCfg.ControllerUUID(),

--- a/state/containernetworking_test.go
+++ b/state/containernetworking_test.go
@@ -43,7 +43,25 @@ var _ environs.NetworkingEnviron = (*containerTestNetworkedEnviron)(nil)
 
 func (s *ContainerNetworkingSuite) TestAutoConfigureContainerNetworkingNetworkless(c *gc.C) {
 	err := s.Model.AutoConfigureContainerNetworking(containerTestNetworkLessEnviron{})
-	c.Check(err, gc.ErrorMatches, "fan configuration in a non-networking environ not supported")
+	c.Assert(err, jc.ErrorIsNil)
+	config, err := s.Model.ModelConfig()
+	c.Assert(err, jc.ErrorIsNil)
+	attrs := config.AllAttrs()
+	c.Check(attrs["container-networking-method"], gc.Equals, "local")
+	c.Check(attrs["fan-config"], gc.Equals, "")
+}
+
+func (s *ContainerNetworkingSuite) TestAutoConfigureContainerNetworkingDoesntChangeDefault(c *gc.C) {
+	err := s.IAASModel.UpdateModelConfig(map[string]interface{}{
+		"container-networking-method": "provider",
+	}, nil)
+	err = s.Model.AutoConfigureContainerNetworking(containerTestNetworkLessEnviron{})
+	c.Assert(err, jc.ErrorIsNil)
+	config, err := s.Model.ModelConfig()
+	c.Assert(err, jc.ErrorIsNil)
+	attrs := config.AllAttrs()
+	c.Check(attrs["container-networking-method"], gc.Equals, "provider")
+	c.Check(attrs["fan-config"], gc.Equals, "")
 }
 
 func (s *ContainerNetworkingSuite) TestAutoConfigureContainerNetworkingAlreadyConfigured(c *gc.C) {


### PR DESCRIPTION
## Description of change
Initialize container networking properly on networkless environments.

## QA steps
Bootstrap juju on e.g. vsphere, see that networking-method is set to 'local'.

## Documentation changes
None

## Bug reference
https://bugs.launchpad.net/juju/+bug/1733882