### PR TITLE
Use testing clock in TestLoginAddsAuditConversationEventually

### DIFF
--- a/apiserver/admin_test.go
+++ b/apiserver/admin_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
+	jt "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils"
 	gc "gopkg.in/check.v1"
@@ -950,6 +951,7 @@ func (s *loginSuite) TestLoginAddsAuditConversationEventually(c *gc.C) {
 	cfg := defaultServerConfig(c)
 	cfg.AuditLogConfig.Enabled = true
 	cfg.AuditLog = log
+	cfg.Clock = jt.NewClock(cfg.Clock.Now())
 	info, srv := newServerWithConfig(c, s.StatePool, cfg)
 	defer assertStop(c, srv)
 	info.ModelTag = s.IAASModel.Tag().(names.ModelTag)


### PR DESCRIPTION
## Description of change
TestLoginAddsAuditConversationEventually used wallclock which caused test failure when the test was executed 'at the tick', this PR fixes it.

## QA steps
Only a test fix.

## Bug reference
https://bugs.launchpad.net/juju/+bug/1742697/