### PR TITLE
Add k8s pods watcher

### DIFF
--- a/caas/broker.go
+++ b/caas/broker.go
@@ -6,6 +6,8 @@ package caas
 import (
 	"github.com/juju/juju/core/application"
 	"github.com/juju/juju/environs"
+	"github.com/juju/juju/status"
+	"github.com/juju/juju/watcher"
 )
 
 // NewContainerBrokerFunc returns a Container Broker.
@@ -31,6 +33,21 @@ type Broker interface {
 
 	// EnsureUnit creates or updates a pod with the given spec.
 	EnsureUnit(appName, unitName, spec string) error
+
+	// WatchUnits returns a watcher which notifies when there
+	// are changes to units of the specified application.
+	WatchUnits(appName string) (watcher.NotifyWatcher, error)
+
+	// Units returns all units of the specified application.
+	Units(appName string) ([]Unit, error)
+}
+
+// Unit represents information about the status of a "pod".
+type Unit struct {
+	Id      string
+	Address string
+	Ports   []string
+	Status  status.StatusInfo
 }
 
 // OperatorConfig is the config to use when creating an operator.

--- a/caas/kubernetes/provider/k8swatcher.go
+++ b/caas/kubernetes/provider/k8swatcher.go
@@ -1,0 +1,93 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package provider
+
+import (
+	"time"
+
+	"github.com/juju/errors"
+	"gopkg.in/tomb.v1"
+	apierrs "k8s.io/client-go/pkg/api/errors"
+	"k8s.io/client-go/pkg/watch"
+
+	"github.com/juju/juju/watcher"
+	"github.com/juju/juju/worker/catacomb"
+)
+
+// kubernetesWatcher reports changes to kubernetes
+// resources. A native kubernetes watcher is passed
+// in to generate change events from the kubernetes
+// model. These events are consolidated into a Juju
+// notification watcher event.
+type kubernetesWatcher struct {
+	catacomb catacomb.Catacomb
+
+	out       chan struct{}
+	name      string
+	k8watcher watch.Interface
+}
+
+func newKubernetesWatcher(wi watch.Interface, name string) (*kubernetesWatcher, error) {
+	w := &kubernetesWatcher{
+		out:       make(chan struct{}),
+		k8watcher: wi,
+		name:      name,
+	}
+	err := catacomb.Invoke(catacomb.Plan{
+		Site: &w.catacomb,
+		Work: w.loop,
+	})
+	return w, err
+}
+
+const sendDelay = 1 * time.Second
+
+func (w *kubernetesWatcher) loop() error {
+	defer close(w.out)
+	defer w.k8watcher.Stop()
+
+	var out chan struct{}
+	// Set delayCh now so that initial event is sent.
+	delayCh := time.After(sendDelay)
+	for {
+		select {
+		case <-w.catacomb.Dying():
+			return tomb.ErrDying
+		case evt, ok := <-w.k8watcher.ResultChan():
+			// This can happen if the k8s API connection drops.
+			if !ok {
+				return errors.Errorf("k8s event watcher closed, restarting")
+			}
+			logger.Tracef("received k8s event: %+v", evt)
+			if evt.Type == watch.Error {
+				return errors.Errorf("kubernetes watcher error: %v", apierrs.FromObject(evt.Object))
+			}
+			if delayCh == nil {
+				delayCh = time.After(sendDelay)
+			}
+		case <-delayCh:
+			out = w.out
+		case out <- struct{}{}:
+			logger.Debugf("fire notify watcher for %v", w.name)
+			out = nil
+			delayCh = nil
+		}
+	}
+}
+
+// Changes returns the event channel for this watcher.
+func (w *kubernetesWatcher) Changes() watcher.NotifyChannel {
+	return w.out
+}
+
+// Kill asks the watcher to stop without waiting for it do so.
+func (w *kubernetesWatcher) Kill() {
+	w.catacomb.Kill(nil)
+}
+
+// Wait waits for the watcher to die and returns any
+// error encountered when it was running.
+func (w *kubernetesWatcher) Wait() error {
+	return w.catacomb.Wait()
+}

--- a/worker/caasoperatorprovisioner/applicationworker.go
+++ b/worker/caasoperatorprovisioner/applicationworker.go
@@ -1,0 +1,60 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package caasoperatorprovisioner
+
+import (
+	"github.com/juju/errors"
+
+	"github.com/juju/juju/caas"
+	"github.com/juju/juju/worker/catacomb"
+)
+
+// applicationWorker listens for changes to caas units
+// associated with the application and records these in
+// the Juju model.
+type applicationWorker struct {
+	catacomb catacomb.Catacomb
+
+	applicationName string
+	broker          caas.Broker
+	facade          CAASProvisionerFacade
+}
+
+// Kill is defined on worker.Worker
+func (w *applicationWorker) Kill() {
+	w.catacomb.Kill(nil)
+}
+
+// Wait is defined on worker.Worker
+func (w *applicationWorker) Wait() error {
+	return w.catacomb.Wait()
+}
+
+func (w *applicationWorker) loop() (err error) {
+	unitsWatcher, err := w.broker.WatchUnits(w.applicationName)
+	if err != nil {
+		return errors.Annotatef(err, "failed to start unit watcher for %q", w.applicationName)
+	}
+	if err := w.catacomb.Add(unitsWatcher); err != nil {
+		return errors.Trace(err)
+	}
+
+	for {
+		select {
+		case <-w.catacomb.Dying():
+			return w.catacomb.ErrDying()
+		case _, ok := <-unitsWatcher.Changes():
+			logger.Debugf("units changed: %#v", ok)
+			if !ok {
+				return unitsWatcher.Wait()
+			}
+			units, err := w.broker.Units(w.applicationName)
+			if err != nil {
+				return errors.Trace(err)
+			}
+			logger.Infof("units for %v: %+v", w.applicationName, units)
+			// TODO(caas) - record changes in Juju model.
+		}
+	}
+}

--- a/worker/caasoperatorprovisioner/manifold.go
+++ b/worker/caasoperatorprovisioner/manifold.go
@@ -5,12 +5,12 @@ package caasoperatorprovisioner
 
 import (
 	"github.com/juju/errors"
-	"github.com/juju/juju/api/caasoperatorprovisioner"
-	"gopkg.in/juju/names.v2"
+	"github.com/juju/utils/clock"
 	"gopkg.in/juju/worker.v1"
 
 	"github.com/juju/juju/agent"
 	"github.com/juju/juju/api/base"
+	"github.com/juju/juju/api/caasoperatorprovisioner"
 	"github.com/juju/juju/caas"
 	"github.com/juju/juju/worker/dependency"
 )
@@ -21,7 +21,7 @@ type ManifoldConfig struct {
 	APICallerName string
 	BrokerName    string
 
-	NewWorker func(CAASProvisionerFacade, caas.Broker, names.ModelTag, agent.Config) (worker.Worker, error)
+	NewWorker func(Config) (worker.Worker, error)
 }
 
 // Validate is called by start to check for bad configuration.
@@ -68,7 +68,13 @@ func (config ManifoldConfig) start(context dependency.Context) (worker.Worker, e
 
 	api := caasoperatorprovisioner.NewClient(apiCaller)
 	agentConfig := agent.CurrentConfig()
-	w, err := config.NewWorker(api, broker, modelTag, agentConfig)
+	w, err := config.NewWorker(Config{
+		Facade:      api,
+		Broker:      broker,
+		ModelTag:    modelTag,
+		AgentConfig: agentConfig,
+		Clock:       clock.WallClock,
+	})
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/worker/caasoperatorprovisioner/manifold_test.go
+++ b/worker/caasoperatorprovisioner/manifold_test.go
@@ -5,14 +5,11 @@ package caasoperatorprovisioner_test
 
 import (
 	"github.com/juju/errors"
-	"github.com/juju/juju/caas"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
-	"gopkg.in/juju/names.v2"
 	"gopkg.in/juju/worker.v1"
 
-	"github.com/juju/juju/agent"
 	"github.com/juju/juju/worker/caasoperatorprovisioner"
 )
 
@@ -33,7 +30,7 @@ func (s *ManifoldConfigSuite) validConfig() caasoperatorprovisioner.ManifoldConf
 		AgentName:     "agent",
 		APICallerName: "api-caller",
 		BrokerName:    "broker",
-		NewWorker: func(caasoperatorprovisioner.CAASProvisionerFacade, caas.Broker, names.ModelTag, agent.Config) (worker.Worker, error) {
+		NewWorker: func(config caasoperatorprovisioner.Config) (worker.Worker, error) {
 			return nil, nil
 		},
 	}

--- a/worker/caasoperatorprovisioner/mock_test.go
+++ b/worker/caasoperatorprovisioner/mock_test.go
@@ -6,6 +6,8 @@ package caasoperatorprovisioner_test
 import (
 	"sync"
 
+	"github.com/juju/juju/status"
+	"github.com/juju/juju/watcher/watchertest"
 	"github.com/juju/testing"
 	"gopkg.in/juju/names.v2"
 	"gopkg.in/tomb.v1"
@@ -84,11 +86,28 @@ func (m *mockAgentConfig) APIAddresses() ([]string, error) {
 type mockBroker struct {
 	testing.Stub
 	caas.Broker
+	unitsWatcher *watchertest.MockNotifyWatcher
 }
 
 func (m *mockBroker) EnsureOperator(appName, agentPath string, config *caas.OperatorConfig) error {
 	m.MethodCall(m, "EnsureOperator", appName, agentPath, config)
 	return m.NextErr()
+}
+
+func (m *mockBroker) WatchUnits(appName string) (watcher.NotifyWatcher, error) {
+	m.MethodCall(m, "WatchUnits", appName)
+	return m.unitsWatcher, m.NextErr()
+}
+
+func (m *mockBroker) Units(appName string) ([]caas.Unit, error) {
+	m.MethodCall(m, "Units", appName)
+	return []caas.Unit{
+		{
+			Id:      "u1",
+			Address: "10.0.0.1",
+			Status:  status.StatusInfo{Status: status.Allocating},
+		},
+	}, m.NextErr()
 }
 
 type mockWatcher struct {


### PR DESCRIPTION
## Description of change

For the k8s broker, add a watcher to notify when pods change.
Start the watcher when a CAAS application is provisioned.

## QA steps

Run up a CAAS model.
Look at debug-log
Check that unit changes are logged when an application is deployed or a unit is added/removed.
