### PR TITLE
Bug 1591962 maas instance addrs

### DIFF
--- a/agent/agentbootstrap/bootstrap.go
+++ b/agent/agentbootstrap/bootstrap.go
@@ -54,7 +54,7 @@ type InitializeStateParams struct {
 	StorageProviderRegistry storage.ProviderRegistry
 }
 
-// InitializeState should be called on the bootstrap machine's agent
+// InitializeState should be called with the bootstrap machine's agent
 // configuration. It uses that information to create the controller, dial the
 // controller, and initialize it. It also generates a new password for the
 // bootstrap machine and calls Write to save the the configuration.
@@ -327,18 +327,7 @@ func initBootstrapMachine(c agent.ConfigSetter, st *state.State, args Initialize
 
 // initAPIHostPorts sets the initial API host/port addresses in state.
 func initAPIHostPorts(c agent.ConfigSetter, st *state.State, addrs []network.Address, apiPort int) error {
-	var hostPorts []network.HostPort
-	// First try to select the correct address using the default space where all
-	// API servers should be accessible on.
-	spaceAddr, ok := network.SelectAddressBySpaceNames(addrs)
-	if ok {
-		logger.Debugf("selected %q as API address", spaceAddr.Value)
-		hostPorts = network.AddressesWithPort([]network.Address{spaceAddr}, apiPort)
-	} else {
-		// Fallback to using all instead.
-		hostPorts = network.AddressesWithPort(addrs, apiPort)
-	}
-
+	hostPorts := network.AddressesWithPort(addrs, apiPort)
 	return st.SetAPIHostPorts([][]network.HostPort{hostPorts})
 }
 

--- a/agent/agentbootstrap/bootstrap.go
+++ b/agent/agentbootstrap/bootstrap.go
@@ -330,7 +330,7 @@ func initAPIHostPorts(c agent.ConfigSetter, st *state.State, addrs []network.Add
 	var hostPorts []network.HostPort
 	// First try to select the correct address using the default space where all
 	// API servers should be accessible on.
-	spaceAddr, ok := network.SelectAddressBySpaces(addrs)
+	spaceAddr, ok := network.SelectAddressBySpaceNames(addrs)
 	if ok {
 		logger.Debugf("selected %q as API address", spaceAddr.Value)
 		hostPorts = network.AddressesWithPort([]network.Address{spaceAddr}, apiPort)

--- a/mongo/mongo.go
+++ b/mongo/mongo.go
@@ -49,7 +49,7 @@ const (
 	// installing mongo.
 	JujuMongoPackage = "juju-mongodb3.2"
 
-	// JujuMongoTooldPackage is the mongo package Juju uses when
+	// JujuMongoToolsPackage is the mongo package Juju uses when
 	// installing mongo tools to get mongodump etc.
 	JujuMongoToolsPackage = "juju-mongo-tools3.2"
 
@@ -299,7 +299,8 @@ func SelectPeerHostPort(hostPorts []network.HostPort) string {
 func SelectPeerHostPortBySpace(hostPorts []network.HostPort, space network.SpaceName) string {
 	logger.Debugf("selecting mongo peer hostPort in space %s from %+v", space, hostPorts)
 	// ScopeMachineLocal addresses are OK if we can't pick by space.
-	suitableHostPorts, foundHostPortsInSpaces := network.SelectMongoHostPortsBySpaces(hostPorts, []network.SpaceName{space})
+	suitableHostPorts, foundHostPortsInSpaces :=
+		network.SelectMongoHostPortsBySpaces(hostPorts, []network.SpaceName{space})
 
 	if !foundHostPortsInSpaces {
 		logger.Debugf("Failed to select hostPort by space - trying by scope from %+v", hostPorts)
@@ -328,7 +329,11 @@ func Path(version Version) (string, error) {
 	return mongoPath(version, os.Stat, exec.LookPath)
 }
 
-func mongoPath(version Version, stat func(string) (os.FileInfo, error), lookPath func(string) (string, error)) (string, error) {
+func mongoPath(
+	version Version,
+	stat func(string) (os.FileInfo, error),
+	lookPath func(string) (string, error),
+) (string, error) {
 	switch version {
 	case Mongo24:
 		if _, err := stat(JujuMongod24Path); err == nil {

--- a/mongo/mongo.go
+++ b/mongo/mongo.go
@@ -300,7 +300,7 @@ func SelectPeerHostPortBySpace(hostPorts []network.HostPort, space network.Space
 	logger.Debugf("selecting mongo peer hostPort in space %s from %+v", space, hostPorts)
 	// ScopeMachineLocal addresses are OK if we can't pick by space.
 	suitableHostPorts, foundHostPortsInSpaces :=
-		network.SelectMongoHostPortsBySpaces(hostPorts, []network.SpaceName{space})
+		network.SelectMongoHostPortsBySpaceNames(hostPorts, []network.SpaceName{space})
 
 	if !foundHostPortsInSpaces {
 		logger.Debugf("Failed to select hostPort by space - trying by scope from %+v", hostPorts)

--- a/network/address.go
+++ b/network/address.go
@@ -275,9 +275,9 @@ func ExactScopeMatch(addr Address, addrScopes ...Scope) bool {
 	return false
 }
 
-// SelectAddressBySpaces picks the first address from the given slice that has
+// SelectAddressBySpaceNames picks the first address from the given slice that has
 // the given space name associated.
-func SelectAddressBySpaces(addresses []Address, spaceNames ...SpaceName) (Address, bool) {
+func SelectAddressBySpaceNames(addresses []Address, spaceNames ...SpaceName) (Address, bool) {
 	for _, addr := range addresses {
 		if spaceNameList(spaceNames).IndexOf(addr.SpaceName) >= 0 {
 			logger.Debugf("selected %q as first address in space %q", addr.Value, addr.SpaceName)
@@ -293,9 +293,9 @@ func SelectAddressBySpaces(addresses []Address, spaceNames ...SpaceName) (Addres
 	return Address{}, false
 }
 
-// SelectHostPortsBySpaces filters the input slice of HostPorts down to
+// SelectHostPortsBySpaceNames filters the input slice of HostPorts down to
 // those in the inpu space name.
-func SelectHostPortsBySpaces(hps []HostPort, spaceNames ...SpaceName) ([]HostPort, bool) {
+func SelectHostPortsBySpaceNames(hps []HostPort, spaceNames ...SpaceName) ([]HostPort, bool) {
 	if len(spaceNames) == 0 {
 		logger.Errorf("host ports not filtered - no spaces given.")
 		return hps, false
@@ -331,15 +331,15 @@ func SelectControllerAddress(addresses []Address, machineLocal bool) (Address, b
 	return internalAddress, ok
 }
 
-// SelectMongoHostPortsBySpaces returns the most suitable HostPort (as string) to
+// SelectMongoHostPortsBySpaceNames returns the most suitable HostPort (as string) to
 // use as a Juju Controller (API/state server) endpoint given the list of
 // hostPorts. It first tries to find the first HostPort bound to the
 // spaces provided, then, if that fails, uses the older selection method based on scope.
 // When machineLocal is true and an address can't be selected by space both
 // ScopeCloudLocal and ScopeMachineLocal addresses are considered during the
 // selection, otherwise just ScopeCloudLocal are.
-func SelectMongoHostPortsBySpaces(hostPorts []HostPort, spaces []SpaceName) ([]string, bool) {
-	filteredHostPorts, ok := SelectHostPortsBySpaces(hostPorts, spaces...)
+func SelectMongoHostPortsBySpaceNames(hostPorts []HostPort, spaces []SpaceName) ([]string, bool) {
+	filteredHostPorts, ok := SelectHostPortsBySpaceNames(hostPorts, spaces...)
 	if ok {
 		logger.Debugf(
 			"selected %q as controller host:port, using spaces %q",

--- a/network/address.go
+++ b/network/address.go
@@ -293,9 +293,9 @@ func SelectAddressBySpaces(addresses []Address, spaceNames ...SpaceName) (Addres
 	return Address{}, false
 }
 
-// SelectHostsPortBySpaces picks the first HostPort from the given slice that has
-// the given space name associated.
-func SelectHostsPortBySpaces(hps []HostPort, spaceNames ...SpaceName) ([]HostPort, bool) {
+// SelectHostPortsBySpaces filters the input slice of HostPorts down to
+// those in the inpu space name.
+func SelectHostPortsBySpaces(hps []HostPort, spaceNames ...SpaceName) ([]HostPort, bool) {
 	if len(spaceNames) == 0 {
 		logger.Errorf("host ports not filtered - no spaces given.")
 		return hps, false
@@ -331,7 +331,7 @@ func SelectControllerAddress(addresses []Address, machineLocal bool) (Address, b
 	return internalAddress, ok
 }
 
-// SelectMongoHostPorts returns the most suitable HostPort (as string) to
+// SelectMongoHostPortsBySpaces returns the most suitable HostPort (as string) to
 // use as a Juju Controller (API/state server) endpoint given the list of
 // hostPorts. It first tries to find the first HostPort bound to the
 // spaces provided, then, if that fails, uses the older selection method based on scope.
@@ -339,7 +339,7 @@ func SelectControllerAddress(addresses []Address, machineLocal bool) (Address, b
 // ScopeCloudLocal and ScopeMachineLocal addresses are considered during the
 // selection, otherwise just ScopeCloudLocal are.
 func SelectMongoHostPortsBySpaces(hostPorts []HostPort, spaces []SpaceName) ([]string, bool) {
-	filteredHostPorts, ok := SelectHostsPortBySpaces(hostPorts, spaces...)
+	filteredHostPorts, ok := SelectHostPortsBySpaces(hostPorts, spaces...)
 	if ok {
 		logger.Debugf(
 			"selected %q as controller host:port, using spaces %q",

--- a/network/address.go
+++ b/network/address.go
@@ -294,7 +294,7 @@ func SelectAddressBySpaceNames(addresses []Address, spaceNames ...SpaceName) (Ad
 }
 
 // SelectHostPortsBySpaceNames filters the input slice of HostPorts down to
-// those in the inpu space name.
+// those in the input space name.
 func SelectHostPortsBySpaceNames(hps []HostPort, spaceNames ...SpaceName) ([]HostPort, bool) {
 	if len(spaceNames) == 0 {
 		logger.Errorf("host ports not filtered - no spaces given.")

--- a/provider/maas/interfaces.go
+++ b/provider/maas/interfaces.go
@@ -207,7 +207,6 @@ func maasObjectNetworkInterfaces(maasObject *gomaasapi.MAASObject, subnetsMap ma
 			} else {
 				nicInfo.Address.SpaceProviderId = spaceId
 				nicInfo.ProviderSpaceId = spaceId
-				logger.Debugf("interface %q link %d space %q", iface.Name, link.ID, sub.Space)
 			}
 
 			gwAddr := network.NewAddressOnSpace(sub.Space, sub.GatewayIP)
@@ -313,7 +312,6 @@ func maas2NetworkInterfaces(instance *maas2Instance, subnetsMap map[string]netwo
 			} else {
 				nicInfo.Address.SpaceProviderId = spaceId
 				nicInfo.ProviderSpaceId = spaceId
-				logger.Debugf("interface %q link %d space %q", iface.Name(), link.ID(), sub.Space())
 			}
 
 			gwAddr := network.NewAddressOnSpace(sub.Space(), sub.Gateway())

--- a/provider/maas/maas2instance.go
+++ b/provider/maas/maas2instance.go
@@ -69,12 +69,13 @@ func (mi *maas2Instance) Addresses() ([]network.Address, error) {
 	var addresses []network.Address
 	for _, iface := range interfaces {
 		if iface.Address.Value != "" {
-			logger.Debugf("found address %q on interface %q", iface.Address, iface.InterfaceName)
 			addresses = append(addresses, iface.Address)
 		} else {
-			logger.Infof("no address found on interface %q", iface.InterfaceName)
+			logger.Debugf("no address found on interface %q", iface.InterfaceName)
 		}
 	}
+
+	logger.Debugf("%q has addresses %q", mi.machine.Hostname(), addresses)
 	return addresses, nil
 }
 

--- a/state/address.go
+++ b/state/address.go
@@ -198,7 +198,7 @@ func (st *State) filterHostPortsForManagementSpace(apiHostPorts [][]network.Host
 		hostPortsForAgents = make([][]network.HostPort, len(apiHostPorts))
 		sp := network.SpaceName(mgmtSpace)
 		for i := range apiHostPorts {
-			if filtered, ok := network.SelectHostPortsBySpaces(apiHostPorts[i], sp); ok {
+			if filtered, ok := network.SelectHostPortsBySpaceNames(apiHostPorts[i], sp); ok {
 				hostPortsForAgents[i] = filtered
 			} else {
 				hostPortsForAgents[i] = apiHostPorts[i]

--- a/state/address.go
+++ b/state/address.go
@@ -198,7 +198,7 @@ func (st *State) filterHostPortsForManagementSpace(apiHostPorts [][]network.Host
 		hostPortsForAgents = make([][]network.HostPort, len(apiHostPorts))
 		sp := network.SpaceName(mgmtSpace)
 		for i := range apiHostPorts {
-			if filtered, ok := network.SelectHostsPortBySpaces(apiHostPorts[i], sp); ok {
+			if filtered, ok := network.SelectHostPortsBySpaces(apiHostPorts[i], sp); ok {
 				hostPortsForAgents[i] = filtered
 			} else {
 				hostPortsForAgents[i] = apiHostPorts[i]

--- a/state/machine.go
+++ b/state/machine.go
@@ -1196,7 +1196,11 @@ func (m *Machine) DesiredSpaces() (set.Strings, error) {
 // that if the provisioner crashes (or its connection to the state is
 // lost) after starting the instance, we can be sure that only a single
 // instance will be able to act for that machine.
-func (m *Machine) SetProvisioned(id instance.Id, nonce string, characteristics *instance.HardwareCharacteristics) (err error) {
+func (m *Machine) SetProvisioned(
+	id instance.Id,
+	nonce string,
+	characteristics *instance.HardwareCharacteristics,
+) (err error) {
 	defer errors.DeferredAnnotatef(&err, "cannot set instance data for machine %q", m)
 
 	if id == "" || nonce == "" {
@@ -1266,7 +1270,9 @@ func (m *Machine) SetInstanceInfo(
 	volumes map[names.VolumeTag]VolumeInfo,
 	volumeAttachments map[names.VolumeTag]VolumeAttachmentInfo,
 ) error {
-	logger.Tracef("setting instance info: machine %v, deviceAddrs: %#v, devicesArgs: %#v", m.Id(), devicesAddrs, devicesArgs)
+	logger.Tracef(
+		"setting instance info: machine %v, deviceAddrs: %#v, devicesArgs: %#v",
+		m.Id(), devicesAddrs, devicesArgs)
 
 	if err := m.SetParentLinkLayerDevicesBeforeTheirChildren(devicesArgs); err != nil {
 		return errors.Trace(err)
@@ -1341,7 +1347,13 @@ func (m *Machine) PublicAddress() (network.Address, error) {
 // match, and if not it selects the best from the slice of all available
 // addresses. It returns the new address and a bool indicating if a different
 // one was picked.
-func maybeGetNewAddress(addr address, providerAddresses, machineAddresses []address, getAddr func([]address) network.Address, checkScope func(address) bool) (address, bool) {
+func maybeGetNewAddress(
+	addr address,
+	providerAddresses,
+	machineAddresses []address,
+	getAddr func([]address) network.Address,
+	checkScope func(address) bool,
+) (address, bool) {
 	// For picking the best address, try provider addresses first.
 	var newAddr address
 	netAddr := getAddr(providerAddresses)
@@ -1433,7 +1445,10 @@ func (m *Machine) setPreferredAddressOps(addr address, isPublic bool) []txn.Op {
 
 func (m *Machine) setPublicAddressOps(providerAddresses []address, machineAddresses []address) ([]txn.Op, *address) {
 	publicAddress := m.doc.PreferredPublicAddress
-	logger.Tracef("machine %v: current public address: %#v \nprovider addresses: %#v \nmachine addresses: %#v", m.Id(), publicAddress, providerAddresses, machineAddresses)
+	logger.Tracef(
+		"machine %v: current public address: %#v \nprovider addresses: %#v \nmachine addresses: %#v",
+		m.Id(), publicAddress, providerAddresses, machineAddresses)
+
 	// Always prefer an exact match if available.
 	checkScope := func(addr address) bool {
 		return network.ExactScopeMatch(addr.networkAddress(), network.ScopePublic)
@@ -1458,7 +1473,8 @@ func (m *Machine) setPrivateAddressOps(providerAddresses []address, machineAddre
 	privateAddress := m.doc.PreferredPrivateAddress
 	// Always prefer an exact match if available.
 	checkScope := func(addr address) bool {
-		return network.ExactScopeMatch(addr.networkAddress(), network.ScopeMachineLocal, network.ScopeCloudLocal, network.ScopeFanLocal)
+		return network.ExactScopeMatch(
+			addr.networkAddress(), network.ScopeMachineLocal, network.ScopeCloudLocal, network.ScopeFanLocal)
 	}
 	// Without an exact match, prefer a fallback match.
 	getAddr := func(addresses []address) network.Address {

--- a/worker/peergrouper/worker.go
+++ b/worker/peergrouper/worker.go
@@ -438,13 +438,13 @@ func (w *pgWorker) getMongoSpace(addrs [][]network.Address) (network.SpaceName, 
 			}
 			logger.Warningf("couldn't find a space containing all peer group machines")
 			return unset, nil
-		} else {
-			spaceName, err := w.config.State.SetOrGetMongoSpaceName(spaceStats.LargestSpace)
-			if err != nil {
-				return unset, errors.Annotate(err, "error setting/getting Mongo space")
-			}
-			return spaceName, nil
 		}
+
+		spaceName, err := w.config.State.SetOrGetMongoSpaceName(spaceStats.LargestSpace)
+		if err != nil {
+			return unset, errors.Annotate(err, "error setting/getting Mongo space")
+		}
+		return spaceName, nil
 
 	case state.MongoSpaceValid:
 		space, err := w.config.State.Space(stateInfo.MongoSpaceName)


### PR DESCRIPTION
## Description of change

maas2instance.Addresses() now sources addresses from the environ in similar fashion to the MAAS V1 instance. Relying on the machine IP Addresses sourced from the MAAS API meant these were not decorated with information required for space filtering by name. 

Removed redundant block from initAPIHostPorts in agentbootstrap. It was a call to filter addresses by space, with no supplied spaces.

Methods for address filtering by space names are explicitly named as such. This disambiguates their behaviour.

## QA steps

Accompanying unit test changes.

Set up GUIMAAS with vlan/subnet/space.
Bootstrapped onto an instance setting the Juju management space and setting the same space as a constraint.
Verified that the apiHostPostsForAgents document only contained the address in the specified management space.

## Documentation changes

None

## Bug reference

Progresses https://bugs.launchpad.net/juju/+bug/1591962
