### PR TITLE
audit-log: Make method exclusions configurable

### DIFF
--- a/apiserver/admin.go
+++ b/apiserver/admin.go
@@ -162,7 +162,7 @@ func (a *admin) getAuditRecorder(req params.LoginRequest, authResult *authResult
 	}
 	// Wrap the audit logger in a filter that prevents us from logging
 	// lots of readonly conversations (like "juju status" requests).
-	filter := observer.MakeExclusionFilter(a.srv.auditLogConfig.ExcludeMethods)
+	filter := observer.MakeInterestingRequestFilter(a.srv.auditLogConfig.ExcludeMethods)
 	result, err := auditlog.NewRecorder(
 		observer.NewAuditLogFilter(
 			a.srv.auditLogger, filter),

--- a/apiserver/admin.go
+++ b/apiserver/admin.go
@@ -162,7 +162,7 @@ func (a *admin) getAuditRecorder(req params.LoginRequest, authResult *authResult
 	}
 	// Wrap the audit logger in a filter that prevents us from logging
 	// lots of readonly conversations (like "juju status" requests).
-	filter := observer.MakeExclusionFilter(observer.DefaultExcludeMethods)
+	filter := observer.MakeExclusionFilter(a.srv.auditLogConfig.ExcludeMethods)
 	result, err := auditlog.NewRecorder(
 		observer.NewAuditLogFilter(
 			a.srv.auditLogger, filter),

--- a/apiserver/admin.go
+++ b/apiserver/admin.go
@@ -162,9 +162,10 @@ func (a *admin) getAuditRecorder(req params.LoginRequest, authResult *authResult
 	}
 	// Wrap the audit logger in a filter that prevents us from logging
 	// lots of readonly conversations (like "juju status" requests).
+	filter := observer.MakeExclusionFilter(observer.DefaultExcludeMethods)
 	result, err := auditlog.NewRecorder(
 		observer.NewAuditLogFilter(
-			a.srv.auditLogger, observer.InterestingRequest),
+			a.srv.auditLogger, filter),
 		a.srv.clock,
 		auditlog.ConversationArgs{
 			Who:          req.AuthTag,

--- a/apiserver/admin_test.go
+++ b/apiserver/admin_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/juju/loggo"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils"
+	"github.com/juju/utils/set"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/names.v2"
 	"gopkg.in/macaroon-bakery.v1/httpbakery"
@@ -973,13 +974,13 @@ func (s *loginSuite) TestLoginAddsAuditConversationEventually(c *gc.C) {
 	// interesting requests.
 	log.CheckCallNames(c)
 
-	var addResult params.AddMachinesResult
+	var addResults params.AddMachinesResults
 	addReq := &params.AddMachines{
 		MachineParams: []params.AddMachineParams{{
 			Jobs: []multiwatcher.MachineJob{"JobHostUnits"},
 		}},
 	}
-	err = conn.APICall("Client", 1, "", "AddMachines", addReq, &addResult)
+	err = conn.APICall("Client", 1, "", "AddMachines", addReq, &addResults)
 	c.Assert(err, jc.ErrorIsNil)
 
 	log.CheckCallNames(c, "AddConversation", "AddRequest", "AddResponse")
@@ -1039,15 +1040,74 @@ func (s *loginSuite) TestAuditLoggingFailureOnInterestingRequest(c *gc.C) {
 	// something happens.
 	c.Assert(err, jc.ErrorIsNil)
 
-	var addResult params.AddMachinesResult
+	var addResults params.AddMachinesResults
 	addReq := &params.AddMachines{
 		MachineParams: []params.AddMachineParams{{
 			Jobs: []multiwatcher.MachineJob{"JobHostUnits"},
 		}},
 	}
-	err = conn.APICall("Client", 1, "", "AddMachines", addReq, &addResult)
+	err = conn.APICall("Client", 1, "", "AddMachines", addReq, &addResults)
 	c.Assert(err, gc.ErrorMatches, "bad news bears")
+}
 
+func (s *loginSuite) TestAuditLoggingUsesExcludeMethods(c *gc.C) {
+	log := &servertesting.FakeAuditLog{}
+	cfg := defaultServerConfig(c)
+	cfg.AuditLogConfig.Enabled = true
+	cfg.AuditLogConfig.ExcludeMethods = set.NewStrings("Client.AddMachines")
+	cfg.AuditLog = log
+	info, srv := newServerWithConfig(c, s.StatePool, cfg)
+	defer assertStop(c, srv)
+	info.ModelTag = s.IAASModel.Tag().(names.ModelTag)
+
+	password := "shhh..."
+	user := s.Factory.MakeUser(c, &factory.UserParams{
+		Password: password,
+	})
+	conn := s.openAPIWithoutLogin(c, info)
+
+	var result params.LoginResult
+	request := &params.LoginRequest{
+		AuthTag:     user.Tag().String(),
+		Credentials: password,
+		CLIArgs:     "hey you guys",
+	}
+	err := conn.APICall("Admin", 3, "", "Login", request, &result)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result.UserInfo, gc.NotNil)
+	// Nothing's logged at this point because there haven't been any
+	// interesting requests.
+	log.CheckCallNames(c)
+
+	var addResults params.AddMachinesResults
+	addReq := &params.AddMachines{
+		MachineParams: []params.AddMachineParams{{
+			Jobs: []multiwatcher.MachineJob{"JobHostUnits"},
+		}},
+	}
+	err = conn.APICall("Client", 1, "", "AddMachines", addReq, &addResults)
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Still nothing logged - the AddMachines call has been filtered out.
+	log.CheckCallNames(c)
+
+	// Call something else.
+	destroyReq := &params.DestroyMachines{
+		MachineNames: []string{addResults.Machines[0].Machine},
+	}
+	err = conn.APICall("Client", 1, "", "DestroyMachines", destroyReq, nil)
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Now the conversation and both requests are logged.
+	log.CheckCallNames(c, "AddConversation", "AddRequest", "AddResponse", "AddRequest", "AddResponse")
+
+	req1 := log.Calls()[1].Args[0].(auditlog.Request)
+	c.Assert(req1.Facade, gc.Equals, "Client")
+	c.Assert(req1.Method, gc.Equals, "AddMachines")
+
+	req2 := log.Calls()[3].Args[0].(auditlog.Request)
+	c.Assert(req2.Facade, gc.Equals, "Client")
+	c.Assert(req2.Method, gc.Equals, "DestroyMachines")
 }
 
 var _ = gc.Suite(&macaroonLoginSuite{})

--- a/apiserver/config.go
+++ b/apiserver/config.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/juju/errors"
+	"github.com/juju/utils/set"
 )
 
 // These vars define how we rate limit incoming connections.
@@ -95,17 +96,11 @@ type AuditLogConfig struct {
 
 	// MaxBackups determines how many files back to keep.
 	MaxBackups int
-}
 
-// DefaultAuditLogConfig returns an AuditLogConfig with default
-// values.
-func DefaultAuditLogConfig() AuditLogConfig {
-	return AuditLogConfig{
-		Enabled:        true,
-		CaptureAPIArgs: false,
-		MaxSizeMB:      300,
-		MaxBackups:     10,
-	}
+	// ExcludeMethods is a set of facade.method names that we
+	// shouldn't consider to be interesting: if a conversation only
+	// consists of these method calls we won't log it.
+	ExcludeMethods set.Strings
 }
 
 // LogSinkConfig holds parameters to control the API server's

--- a/apiserver/observer/auditfilter.go
+++ b/apiserver/observer/auditfilter.go
@@ -105,10 +105,12 @@ func (l *bufferedLog) flush() error {
 	return nil
 }
 
-// MakeExclusionFilter returns a filter function for audit logging
-// that will return false if the request's method matches any of the
-// passed names.
-func MakeExclusionFilter(excludeMethods set.Strings) func(auditlog.Request) bool {
+// MakeInterestingRequestFilter takes a set of method names (as
+// facade.method, e.g. "Client.FullStatus") that aren't very
+// interesting from an auditing perspective, and returns a filter
+// function for audit logging that will mark the request as
+// interesting if it's a call to a method that isn't listed.
+func MakeInterestingRequestFilter(excludeMethods set.Strings) func(auditlog.Request) bool {
 	return func(req auditlog.Request) bool {
 		return !excludeMethods.Contains(fmt.Sprintf("%s.%s", req.Facade, req.Method))
 	}

--- a/apiserver/observer/auditfilter.go
+++ b/apiserver/observer/auditfilter.go
@@ -105,12 +105,17 @@ func (l *bufferedLog) flush() error {
 	return nil
 }
 
-// InterestingRequest returns whether this API request is interesting enough
-// to write the conversation to the audit log.
-func InterestingRequest(req auditlog.Request) bool {
-	return !readOnlyMethods.Contains(fmt.Sprintf("%s.%s", req.Facade, req.Method))
+// MakeExclusionFilter returns a filter function for audit logging
+// that will return false if the request's method matches any of the
+// passed names.
+func MakeExclusionFilter(excludeMethods set.Strings) func(auditlog.Request) bool {
+	return func(req auditlog.Request) bool {
+		return !excludeMethods.Contains(fmt.Sprintf("%s.%s", req.Facade, req.Method))
+	}
 }
 
-var readOnlyMethods = set.NewStrings(
+// DefaultExcludeMethods is a set of the API methods we exclude from
+// the audit log by default.
+var DefaultExcludeMethods = set.NewStrings(
 	"Client.FullStatus",
 )

--- a/apiserver/observer/auditfilter.go
+++ b/apiserver/observer/auditfilter.go
@@ -115,9 +115,3 @@ func MakeInterestingRequestFilter(excludeMethods set.Strings) func(auditlog.Requ
 		return !excludeMethods.Contains(fmt.Sprintf("%s.%s", req.Facade, req.Method))
 	}
 }
-
-// DefaultExcludeMethods is a set of the API methods we exclude from
-// the audit log by default.
-var DefaultExcludeMethods = set.NewStrings(
-	"Client.FullStatus",
-)

--- a/apiserver/observer/auditfilter_test.go
+++ b/apiserver/observer/auditfilter_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
+	"github.com/juju/utils/set"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/apiserver/observer"
@@ -72,4 +73,11 @@ func (s *auditFilterSuite) TestFiltersUninterestingConversations(c *gc.C) {
 	err = log.AddResponse(auditlog.ResponseErrors{})
 	c.Assert(err, jc.ErrorIsNil)
 	target.CheckCallNames(c, "AddRequest", "AddResponse")
+}
+
+func (s *auditFilterSuite) TestMakeFilter(c *gc.C) {
+	f1 := observer.MakeExclusionFilter(set.NewStrings("Battery.Kinzie", "Helplessness.Blues"))
+	c.Assert(f1(auditlog.Request{Facade: "Battery", Method: "Kinzie"}), jc.IsFalse)
+	c.Assert(f1(auditlog.Request{Facade: "Helplessness", Method: "Blues"}), jc.IsFalse)
+	c.Assert(f1(auditlog.Request{Facade: "The", Method: "Shrine"}), jc.IsTrue)
 }

--- a/apiserver/observer/auditfilter_test.go
+++ b/apiserver/observer/auditfilter_test.go
@@ -76,7 +76,7 @@ func (s *auditFilterSuite) TestFiltersUninterestingConversations(c *gc.C) {
 }
 
 func (s *auditFilterSuite) TestMakeFilter(c *gc.C) {
-	f1 := observer.MakeExclusionFilter(set.NewStrings("Battery.Kinzie", "Helplessness.Blues"))
+	f1 := observer.MakeInterestingRequestFilter(set.NewStrings("Battery.Kinzie", "Helplessness.Blues"))
 	c.Assert(f1(auditlog.Request{Facade: "Battery", Method: "Kinzie"}), jc.IsFalse)
 	c.Assert(f1(auditlog.Request{Facade: "Helplessness", Method: "Blues"}), jc.IsFalse)
 	c.Assert(f1(auditlog.Request{Facade: "The", Method: "Shrine"}), jc.IsTrue)

--- a/cmd/juju/backups/restore_test.go
+++ b/cmd/juju/backups/restore_test.go
@@ -292,7 +292,7 @@ func (s *restoreSuite) TestRestoreReboostrapControllerConfigDefaults(c *gc.C) {
 			"max-logs-age":              "72h",
 			"max-logs-size":             "4096M",
 			"max-txn-log-size":          "10M",
-			"auditing-enabled":          false,
+			"auditing-enabled":          true,
 			"audit-log-capture-args":    false,
 			"audit-log-max-size":        "300M",
 			"audit-log-max-backups":     10,

--- a/cmd/juju/backups/restore_test.go
+++ b/cmd/juju/backups/restore_test.go
@@ -278,6 +278,10 @@ func (s *restoreSuite) TestRestoreReboostrapControllerConfigDefaults(c *gc.C) {
 		nil,
 	)
 	boostrapped := false
+	var expectedExcludes []interface{}
+	for _, exclude := range controller.DefaultAuditLogExcludeMethods {
+		expectedExcludes = append(expectedExcludes, exclude)
+	}
 	s.PatchValue(&backups.BootstrapFunc, func(ctx environs.BootstrapContext, environ environs.Environ, args bootstrap.BootstrapParams) error {
 		c.Assert(args.ControllerConfig, jc.DeepEquals, controller.Config{
 			"controller-uuid":           "deadbeef-0bad-400d-8000-5b1d0d06f00d",
@@ -292,7 +296,7 @@ func (s *restoreSuite) TestRestoreReboostrapControllerConfigDefaults(c *gc.C) {
 			"audit-log-capture-args":    false,
 			"audit-log-max-size":        "300M",
 			"audit-log-max-backups":     10,
-			"audit-log-exclude-methods": []interface{}{"Client.FullStatus"},
+			"audit-log-exclude-methods": expectedExcludes,
 		})
 		boostrapped = true
 		return nil

--- a/cmd/juju/backups/restore_test.go
+++ b/cmd/juju/backups/restore_test.go
@@ -280,18 +280,19 @@ func (s *restoreSuite) TestRestoreReboostrapControllerConfigDefaults(c *gc.C) {
 	boostrapped := false
 	s.PatchValue(&backups.BootstrapFunc, func(ctx environs.BootstrapContext, environ environs.Environ, args bootstrap.BootstrapParams) error {
 		c.Assert(args.ControllerConfig, jc.DeepEquals, controller.Config{
-			"controller-uuid":         "deadbeef-0bad-400d-8000-5b1d0d06f00d",
-			"ca-cert":                 testing.CACert,
-			"state-port":              37017,
-			"api-port":                17070,
-			"set-numa-control-policy": false,
-			"max-logs-age":            "72h",
-			"max-logs-size":           "4096M",
-			"max-txn-log-size":        "10M",
-			"auditing-enabled":        false,
-			"audit-log-capture-args":  false,
-			"audit-log-max-size":      "300M",
-			"audit-log-max-backups":   10,
+			"controller-uuid":           "deadbeef-0bad-400d-8000-5b1d0d06f00d",
+			"ca-cert":                   testing.CACert,
+			"state-port":                37017,
+			"api-port":                  17070,
+			"set-numa-control-policy":   false,
+			"max-logs-age":              "72h",
+			"max-logs-size":             "4096M",
+			"max-txn-log-size":          "10M",
+			"auditing-enabled":          false,
+			"audit-log-capture-args":    false,
+			"audit-log-max-size":        "300M",
+			"audit-log-max-backups":     10,
+			"audit-log-exclude-methods": []interface{}{"Client.FullStatus"},
 		})
 		boostrapped = true
 		return nil

--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -1793,5 +1793,6 @@ func getAuditLogConfig(cfg controller.Config) apiserver.AuditLogConfig {
 		CaptureAPIArgs: cfg.AuditLogCaptureArgs(),
 		MaxSizeMB:      cfg.AuditLogMaxSizeMB(),
 		MaxBackups:     cfg.AuditLogMaxBackups(),
+		ExcludeMethods: cfg.AuditLogExcludeMethods(),
 	}
 }

--- a/cmd/jujud/agent/machine_test.go
+++ b/cmd/jujud/agent/machine_test.go
@@ -37,6 +37,7 @@ import (
 	"github.com/juju/juju/api"
 	"github.com/juju/juju/api/imagemetadata"
 	apimachiner "github.com/juju/juju/api/machiner"
+	"github.com/juju/juju/apiserver"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/cmd/jujud/agent/model"
 	"github.com/juju/juju/core/migration"
@@ -1363,6 +1364,20 @@ func (s *MachineSuite) TestReplicasetInitForNewController(c *gc.C) {
 
 	c.Assert(s.fakeEnsureMongo.EnsureCount, gc.Equals, 1)
 	c.Assert(s.fakeEnsureMongo.InitiateCount, gc.Equals, 0)
+}
+
+func (s *MachineSuite) TestGetAuditLogConfig(c *gc.C) {
+	cfg := coretesting.FakeControllerConfig()
+	cfg["auditing-enabled"] = true
+	cfg["audit-log-exclude-methods"] = []interface{}{"Exclude.This"}
+	result := getAuditLogConfig(cfg)
+	c.Assert(result, gc.DeepEquals, apiserver.AuditLogConfig{
+		Enabled:        true,
+		CaptureAPIArgs: true,
+		MaxSizeMB:      200,
+		MaxBackups:     5,
+		ExcludeMethods: set.NewStrings("Exclude.This"),
+	})
 }
 
 type nullWorker struct {

--- a/controller/config.go
+++ b/controller/config.go
@@ -107,7 +107,7 @@ const (
 
 	// DefaultAuditingEnabled contains the default value for the
 	// AuditingEnabled config value.
-	DefaultAuditingEnabled = false
+	DefaultAuditingEnabled = true
 
 	// DefaultAuditLogCaptureArgs is the default for the
 	// AuditLogCaptureArgs setting (which is not to capture them).

--- a/controller/config.go
+++ b/controller/config.go
@@ -171,8 +171,62 @@ var (
 	}
 
 	// DefaultAuditLogExcludeMethods is the default list of methods to
-	// exclude from the audit log - just the one for `juju status`.
-	DefaultAuditLogExcludeMethods = []string{"Client.FullStatus"}
+	// exclude from the audit log.
+	DefaultAuditLogExcludeMethods = []string{
+		// Collected by running read-only commands.
+		"Action.Actions",
+		"Action.ApplicationsCharmsActions",
+		"Action.FindActionsByNames",
+		"Action.FindActionTagsByPrefix",
+		"Application.GetConstraints",
+		"ApplicationOffers.ApplicationOffers",
+		"Backups.Info",
+		"Client.FullStatus",
+		"Client.GetModelConstraints",
+		"Client.StatusHistory",
+		"Controller.AllModels",
+		"Controller.ControllerConfig",
+		"Controller.GetControllerAccess",
+		"Controller.ModelConfig",
+		"Controller.ModelStatus",
+		"MetricsDebug.GetMetrics",
+		"ModelConfig.ModelGet",
+		"ModelManager.ModelInfo",
+		"ModelManager.ModelDefaults",
+		"Pinger.Ping",
+		"UserManager.UserInfo",
+
+		// Don't filter out Application.Get - since it includes secrets
+		// it's worthwhile to track when it's run, and it's not likely to
+		// swamp the log.
+
+		// All client facade methods that start with List.
+		"Action.ListAll",
+		"Action.ListPending",
+		"Action.ListRunning",
+		"Action.ListComplete",
+		"ApplicationOffers.ListApplicationOffers",
+		"Backups.List",
+		"Block.List",
+		"Charms.List",
+		"Controller.ListBlockedModels",
+		"FirewallRules.ListFirewallRules",
+		"ImageManager.ListImages",
+		"ImageMetadata.List",
+		"KeyManager.ListKeys",
+		"ModelManager.ListModels",
+		"ModelManager.ListModelSummaries",
+		"Payloads.List",
+		"PayloadsHookContext.List",
+		"Resources.ListResources",
+		"ResourcesHookContext.ListResources",
+		"Spaces.ListSpaces",
+		"Storage.ListStorageDetails",
+		"Storage.ListPools",
+		"Storage.ListVolumes",
+		"Storage.ListFilesystems",
+		"Subnets.ListSubnets",
+	}
 
 	methodNameRE = regexp.MustCompile(`[[:alpha:]][[:alnum:]]*\.[[:alpha:]][[:alnum:]]*`)
 )

--- a/controller/config_test.go
+++ b/controller/config_test.go
@@ -144,6 +144,13 @@ var validateTests = []struct {
 		controller.AuditLogMaxBackups: -10,
 	},
 	expectError: `invalid audit log max backups: should be a number of files \(or 0 to keep all\), got -10`,
+}, {
+	about: "invalid audit log exclude",
+	config: controller.Config{
+		controller.CACertKey:              testing.CACert,
+		controller.AuditLogExcludeMethods: []interface{}{"Dap.Kings", "Sharon Jones"},
+	},
+	expectError: `invalid audit log exclude methods: should be a list of "Facade.Method" names, got "Sharon Jones" at position 2`,
 }}
 
 func (s *ConfigSuite) TestValidate(c *gc.C) {

--- a/controller/config_test.go
+++ b/controller/config_test.go
@@ -207,7 +207,7 @@ func (s *ConfigSuite) TestTxnLogConfigValue(c *gc.C) {
 func (s *ConfigSuite) TestAuditLogDefaults(c *gc.C) {
 	cfg, err := controller.NewConfig(testing.ControllerTag.Id(), testing.CACert, nil)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(cfg.AuditingEnabled(), gc.Equals, false)
+	c.Assert(cfg.AuditingEnabled(), gc.Equals, true)
 	c.Assert(cfg.AuditLogCaptureArgs(), gc.Equals, false)
 	c.Assert(cfg.AuditLogMaxSizeMB(), gc.Equals, 300)
 	c.Assert(cfg.AuditLogMaxBackups(), gc.Equals, 10)
@@ -220,7 +220,7 @@ func (s *ConfigSuite) TestAuditLogValues(c *gc.C) {
 		testing.ControllerTag.Id(),
 		testing.CACert,
 		map[string]interface{}{
-			"auditing-enabled":          true,
+			"auditing-enabled":          false,
 			"audit-log-capture-args":    true,
 			"audit-log-max-size":        "100M",
 			"audit-log-max-backups":     10.0,
@@ -228,7 +228,7 @@ func (s *ConfigSuite) TestAuditLogValues(c *gc.C) {
 		},
 	)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(cfg.AuditingEnabled(), gc.Equals, true)
+	c.Assert(cfg.AuditingEnabled(), gc.Equals, false)
 	c.Assert(cfg.AuditLogCaptureArgs(), gc.Equals, true)
 	c.Assert(cfg.AuditLogMaxSizeMB(), gc.Equals, 100)
 	c.Assert(cfg.AuditLogMaxBackups(), gc.Equals, 10)

--- a/controller/config_test.go
+++ b/controller/config_test.go
@@ -211,7 +211,8 @@ func (s *ConfigSuite) TestAuditLogDefaults(c *gc.C) {
 	c.Assert(cfg.AuditLogCaptureArgs(), gc.Equals, false)
 	c.Assert(cfg.AuditLogMaxSizeMB(), gc.Equals, 300)
 	c.Assert(cfg.AuditLogMaxBackups(), gc.Equals, 10)
-	c.Assert(cfg.AuditLogExcludeMethods(), gc.DeepEquals, set.NewStrings("Client.FullStatus"))
+	c.Assert(cfg.AuditLogExcludeMethods(), gc.DeepEquals,
+		set.NewStrings(controller.DefaultAuditLogExcludeMethods...))
 }
 
 func (s *ConfigSuite) TestAuditLogValues(c *gc.C) {

--- a/state/controller_test.go
+++ b/state/controller_test.go
@@ -6,6 +6,7 @@ package state_test
 import (
 	gitjujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
+	"github.com/juju/utils/set"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/controller"
@@ -24,18 +25,19 @@ func (s *ControllerSuite) TestControllerAndModelConfigInitialisation(c *gc.C) {
 	controllerSettings, err := s.State.ReadSettings(state.ControllersC, "controllerSettings")
 	c.Assert(err, jc.ErrorIsNil)
 
-	optional := map[string]bool{
-		controller.IdentityURL:         true,
-		controller.IdentityPublicKey:   true,
-		controller.AutocertURLKey:      true,
-		controller.AutocertDNSNameKey:  true,
-		controller.AllowModelAccessKey: true,
-		controller.MongoMemoryProfile:  true,
-	}
+	optional := set.NewStrings(
+		controller.IdentityURL,
+		controller.IdentityPublicKey,
+		controller.AutocertURLKey,
+		controller.AutocertDNSNameKey,
+		controller.AllowModelAccessKey,
+		controller.MongoMemoryProfile,
+		controller.AuditLogExcludeMethods,
+	)
 	for _, controllerAttr := range controller.ControllerOnlyConfigAttributes {
 		v, ok := controllerSettings.Get(controllerAttr)
 		c.Logf(controllerAttr)
-		if !optional[controllerAttr] {
+		if !optional.Contains(controllerAttr) {
 			c.Assert(ok, jc.IsTrue)
 			c.Assert(v, gc.Not(gc.Equals), "")
 		}


### PR DESCRIPTION
## Description of change

Instead of the method exclusion list being fixed, it now defaults to `[Client.FullStatus]` but can be changed by specifying the `audit-log-exclude-methods` controller config value.

This enables operators to determine which API methods should be suppressed from the audit log.

## QA steps

* Bootstrap a controller with auditing enabled and `--config="audit-log-exclude-methods=[ModelManager.ListModelSummaries]"`. 
* See that the custom value is listed in `juju controller-config`. 
* Watch the audit log while running `juju models` and see that no conversation is logged for it (while running `juju status` does get logged).

## Documentation changes
This should be documented with the other audit logging changes.
