### PR TITLE
Adds model UUID substring + ellipsis to cleanup debug logs, and full …

### DIFF
--- a/state/cleanup.go
+++ b/state/cleanup.go
@@ -103,11 +103,15 @@ func (st *State) Cleanup() (err error) {
 	var doc cleanupDoc
 	cleanups, closer := st.db().GetCollection(cleanupsC)
 	defer closer()
+
+	modelUUID := st.ModelUUID()
+	modelId := modelUUID[:6] + "..."
+
 	iter := cleanups.Find(nil).Iter()
 	defer closeIter(iter, &err, "reading cleanup document")
 	for iter.Next(&doc) {
 		var err error
-		logger.Debugf("running %q cleanup: %q", doc.Kind, doc.Prefix)
+		logger.Debugf("model %q cleanup: %v(%q)", modelId, doc.Kind, doc.Prefix)
 		args := make([]bson.Raw, len(doc.Args))
 		for i, arg := range doc.Args {
 			args[i] = arg.Value.(bson.Raw)
@@ -147,7 +151,10 @@ func (st *State) Cleanup() (err error) {
 			err = errors.Errorf("unknown cleanup kind %q", doc.Kind)
 		}
 		if err != nil {
-			logger.Errorf("cleanup failed for %v(%q): %v", doc.Kind, doc.Prefix, err)
+			logger.Errorf(
+				"cleanup failed for %v(%q) in model %q: %v",
+				doc.Kind, doc.Prefix, modelUUID, err,
+			)
 			continue
 		}
 		ops := []txn.Op{{

--- a/state/cleanup.go
+++ b/state/cleanup.go
@@ -105,13 +105,13 @@ func (st *State) Cleanup() (err error) {
 	defer closer()
 
 	modelUUID := st.ModelUUID()
-	modelId := modelUUID[:6] + "..."
+	modelId := modelUUID[:6]
 
 	iter := cleanups.Find(nil).Iter()
 	defer closeIter(iter, &err, "reading cleanup document")
 	for iter.Next(&doc) {
 		var err error
-		logger.Debugf("model %q cleanup: %v(%q)", modelId, doc.Kind, doc.Prefix)
+		logger.Debugf("model %v cleanup: %v(%q)", modelId, doc.Kind, doc.Prefix)
 		args := make([]bson.Raw, len(doc.Args))
 		for i, arg := range doc.Args {
 			args[i] = arg.Value.(bson.Raw)
@@ -152,8 +152,8 @@ func (st *State) Cleanup() (err error) {
 		}
 		if err != nil {
 			logger.Errorf(
-				"cleanup failed for %v(%q) in model %q: %v",
-				doc.Kind, doc.Prefix, modelUUID, err,
+				"cleanup failed in model %v for %v(%q): %v",
+				modelUUID, doc.Kind, doc.Prefix, err,
 			)
 			continue
 		}

--- a/state/cleanup_test.go
+++ b/state/cleanup_test.go
@@ -504,6 +504,7 @@ func (s *CleanupSuite) TestCleanupDyingUnitAlreadyRemoved(c *gc.C) {
 
 	// Check the cleanup still runs happily.
 	s.assertCleanupCount(c, 1)
+	s.assertCleanupRuns(c)
 }
 
 func (s *CleanupSuite) TestCleanupActions(c *gc.C) {


### PR DESCRIPTION
## Description of change

Adds model UUID substring to state cleanup debug log entries.
Adds full model UUID to state cleanup error messages.

## QA steps

Observed output via verbose test runs.

## Documentation changes

None.

## Bug reference

Addresses: https://bugs.launchpad.net/juju/+bug/1733791
