### PR TITLE
Fixes lp#1742222: intermittent failure in BundleDeployCharmStoreSuite.TestAddMetricCredentials

### DIFF
--- a/cmd/juju/application/bundle_test.go
+++ b/cmd/juju/application/bundle_test.go
@@ -93,7 +93,9 @@ func (s *BundleDeployCharmStoreSuite) TestAddMetricCredentials(c *gc.C) {
 	_, err := cmdtesting.RunCommand(c, deploy, "bundle/wordpress-with-plans")
 	c.Assert(err, jc.ErrorIsNil)
 
-	stub.CheckCalls(c, []testing.StubCall{{
+	// The order of calls here does not matter and is, in fact, not guaranteed.
+	// All we care about here is that the calls exist.
+	stub.CheckCallsUnordered(c, []testing.StubCall{{
 		FuncName: "DefaultPlan",
 		Args:     []interface{}{"cs:wordpress"},
 	}, {

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -47,7 +47,7 @@ github.com/juju/rfc	git	ebdbbdb950cd039a531d15cdc2ac2cbd94f068ee	2016-07-11T02:4
 github.com/juju/romulus	git	eede3e29dd7784b7265bb2cc175eca35420d37e7	2017-05-19T13:49:06Z
 github.com/juju/schema	git	075de04f9b7d7580d60a1e12a0b3f50bb18e6998	2016-04-20T04:42:03Z
 github.com/juju/terms-client	git	9b925afd677234e4146dde3cb1a11e187cbed64e	2016-08-09T13:19:00Z
-github.com/juju/testing	git	2fe0e88cf2321d801acedd2b4f0d7f63735fb732	2017-06-08T05:44:51Z
+github.com/juju/testing	git	799dbfe87f1a3c7fec5ab5638302b3bf853acee5	2018-01-15T00:53:07Z
 github.com/juju/txn	git	dbb63c620814d1a0f96260f4cad3e2cca14f702b	2017-06-13T23:44:54Z
 github.com/juju/usso	git	68a59c96c178fbbad65926e7f93db50a2cd14f33	2016-04-01T10:44:24Z
 github.com/juju/utils	git	9b65c33e54c793d74a4ed99c15111c44faddb8e4	2017-10-25T16:38:56Z


### PR DESCRIPTION
## Description of change

This change brings in a new testing stub check that allows to check for calls made irrespective of their order.
This PR also uses this new call in a test that failed intermittently, specifically because it did not matter in what order the calls were made to the stub... We only cared about the fact that calls were made.

## QA steps

BundleDeployCharmStoreSuite.TestAddMetricCredentials does not fail.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1742222
