### PR TITLE
Mongo 3.4 changes the error string when a collection exists.

### DIFF
--- a/state/database.go
+++ b/state/database.go
@@ -6,6 +6,7 @@ package state
 import (
 	"fmt"
 	"runtime/debug"
+	"strings"
 
 	"github.com/juju/errors"
 	jujutxn "github.com/juju/txn"
@@ -205,7 +206,7 @@ func createCollection(raw *mgo.Collection, spec *mgo.CollectionInfo) error {
 	err := raw.Create(spec)
 	// The lack of error code for this error was reported upstream:
 	//     https://jira.mongodb.org/browse/SERVER-6992
-	if err == nil || err.Error() == "collection already exists" {
+	if err == nil || strings.HasSuffix(err.Error(), "already exists") {
 		return nil
 	}
 	return err


### PR DESCRIPTION
## Description of change

Instead of being "collection already exists" it returns "collection
'foo' already exists". But in both cases they end with "already exists",
so we'll live with it and just move on.

This should make it possible to be compatible with both mongo 3.2 and mongo 3.4.

## QA steps

``$ cd state
$ go test -check.v
``

While having a mongo 3.4 in your $PATH.

## Documentation changes

None.

## Bug reference

None.