### PR TITLE
2.3 into develop

### DIFF
--- a/agent/agentbootstrap/bootstrap.go
+++ b/agent/agentbootstrap/bootstrap.go
@@ -222,11 +222,7 @@ func InitializeState(
 	defer hostedModelState.Close()
 
 	if err := model.AutoConfigureContainerNetworking(hostedModelEnv); err != nil {
-		if errors.IsNotSupported(err) {
-			logger.Debugf("Not performing container networking autoconfiguration on a non-networking environment")
-		} else {
-			return nil, nil, errors.Annotate(err, "autoconfiguring container networking")
-		}
+		return nil, nil, errors.Annotate(err, "autoconfiguring container networking")
 	}
 
 	// TODO(wpk) 2017-05-24 Copy subnets/spaces from controller model

--- a/agent/agentbootstrap/bootstrap_test.go
+++ b/agent/agentbootstrap/bootstrap_test.go
@@ -331,13 +331,16 @@ LXC_BRIDGE="ignored"`[1:])
 		"Provider",
 		"Version",
 	)
+	// Those attritbutes are configured during initialization, after "Open".
+	expectedCalledCfg, err := hostedCfg.Apply(map[string]interface{}{"container-networking-method": ""})
+	c.Assert(err, jc.ErrorIsNil)
 	envProvider.CheckCall(c, 2, "Open", environs.OpenParams{
 		Cloud: environs.CloudSpec{
 			Type:   "dummy",
 			Name:   "dummy",
 			Region: "dummy-region",
 		},
-		Config: hostedCfg,
+		Config: expectedCalledCfg,
 	})
 	envProvider.CheckCall(c, 3, "Create", environs.CreateParams{
 		ControllerUUID: controllerCfg.ControllerUUID(),

--- a/container/kvm/live_test.go
+++ b/container/kvm/live_test.go
@@ -6,6 +6,7 @@ package kvm_test
 import (
 	"fmt"
 	"os"
+	"os/exec"
 	"runtime"
 
 	"github.com/juju/loggo"
@@ -41,6 +42,10 @@ func (s *LiveSuite) SetUpTest(c *gc.C) {
 	// Skip if not linux
 	if runtime.GOOS != "linux" {
 		c.Skip("not running linux")
+	}
+	// Skip if virsh is not installed.
+	if _, err := exec.LookPath("virsh"); err != nil {
+		c.Skip("virsh not found")
 	}
 	// Skip if not running as root.
 	if os.Getuid() != 0 {

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -47,7 +47,7 @@ github.com/juju/rfc	git	ebdbbdb950cd039a531d15cdc2ac2cbd94f068ee	2016-07-11T02:4
 github.com/juju/romulus	git	624b9e2be59f28601b29652ca710e21d51e51949	2018-01-03T14:24:45Z
 github.com/juju/schema	git	075de04f9b7d7580d60a1e12a0b3f50bb18e6998	2016-04-20T04:42:03Z
 github.com/juju/terms-client	git	9b925afd677234e4146dde3cb1a11e187cbed64e	2016-08-09T13:19:00Z
-github.com/juju/testing	git	799dbfe87f1a3c7fec5ab5638302b3bf853acee5	2018-01-15T00:53:07Z
+github.com/juju/testing	git	c1418baa9f3df16f7a900af4e3f579333a8acd78	2018-01-15T06:36:48Z
 github.com/juju/txn	git	dbb63c620814d1a0f96260f4cad3e2cca14f702b	2017-06-13T23:44:54Z
 github.com/juju/usso	git	68a59c96c178fbbad65926e7f93db50a2cd14f33	2016-04-01T10:44:24Z
 github.com/juju/utils	git	9b65c33e54c793d74a4ed99c15111c44faddb8e4	2017-10-25T16:38:56Z

--- a/state/containernetworking_test.go
+++ b/state/containernetworking_test.go
@@ -43,7 +43,25 @@ var _ environs.NetworkingEnviron = (*containerTestNetworkedEnviron)(nil)
 
 func (s *ContainerNetworkingSuite) TestAutoConfigureContainerNetworkingNetworkless(c *gc.C) {
 	err := s.Model.AutoConfigureContainerNetworking(containerTestNetworkLessEnviron{})
-	c.Check(err, gc.ErrorMatches, "fan configuration in a non-networking environ not supported")
+	c.Assert(err, jc.ErrorIsNil)
+	config, err := s.Model.ModelConfig()
+	c.Assert(err, jc.ErrorIsNil)
+	attrs := config.AllAttrs()
+	c.Check(attrs["container-networking-method"], gc.Equals, "local")
+	c.Check(attrs["fan-config"], gc.Equals, "")
+}
+
+func (s *ContainerNetworkingSuite) TestAutoConfigureContainerNetworkingDoesntChangeDefault(c *gc.C) {
+	err := s.IAASModel.UpdateModelConfig(map[string]interface{}{
+		"container-networking-method": "provider",
+	}, nil)
+	err = s.Model.AutoConfigureContainerNetworking(containerTestNetworkLessEnviron{})
+	c.Assert(err, jc.ErrorIsNil)
+	config, err := s.Model.ModelConfig()
+	c.Assert(err, jc.ErrorIsNil)
+	attrs := config.AllAttrs()
+	c.Check(attrs["container-networking-method"], gc.Equals, "provider")
+	c.Check(attrs["fan-config"], gc.Equals, "")
 }
 
 func (s *ContainerNetworkingSuite) TestAutoConfigureContainerNetworkingAlreadyConfigured(c *gc.C) {

--- a/state/database.go
+++ b/state/database.go
@@ -5,6 +5,7 @@ package state
 
 import (
 	"runtime/debug"
+	"strings"
 
 	"github.com/juju/errors"
 	jujutxn "github.com/juju/txn"
@@ -203,7 +204,7 @@ func createCollection(raw *mgo.Collection, spec *mgo.CollectionInfo) error {
 	err := raw.Create(spec)
 	// The lack of error code for this error was reported upstream:
 	//     https://jira.mongodb.org/browse/SERVER-6992
-	if err == nil || err.Error() == "collection already exists" {
+	if err == nil || strings.HasSuffix(err.Error(), "already exists") {
 		return nil
 	}
 	return err


### PR DESCRIPTION
## Description of change

Sync 2.3 into develop. This brings in a couple of patches wrt
* networking on vmware
* supporting mongo 3.4
* fixing various tests
* updating budget ux around wallets

## QA steps

None. QA should have been done on the original PR.

## Documentation changes

None.

## Bug reference

None.
