### PR TITLE
1640223 action name numeric characters

### DIFF
--- a/cmd/juju/action/run.go
+++ b/cmd/juju/action/run.go
@@ -4,13 +4,13 @@
 package action
 
 import (
-	"regexp"
 	"strings"
 	"time"
 
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
 	"github.com/juju/gnuflag"
+	"gopkg.in/juju/charm.v6"
 	"gopkg.in/juju/names.v2"
 	yaml "gopkg.in/yaml.v2"
 
@@ -20,7 +20,7 @@ import (
 	"github.com/juju/juju/cmd/output"
 )
 
-var keyRule = regexp.MustCompile("^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$")
+var keyRule *regexp.Regexp = charm.GetActionNameRule()
 
 func NewRunCommand() cmd.Command {
 	return modelcmd.Wrap(&runCommand{})
@@ -43,8 +43,8 @@ const runDoc = `
 Queue an Action for execution on a given unit, with a given set of params.
 The Action ID is returned for use with 'juju show-action-output <ID>' or
 'juju show-action-status <ID>'.
- 
-Params are validated according to the charm for the unit's application.  The 
+
+Params are validated according to the charm for the unit's application.  The
 valid params can be seen using "juju actions <application> --schema".
 Params may be in a yaml file which is passed with the --params flag, or they
 may be specified by a key.key.key...=value format (see examples below.)
@@ -68,7 +68,7 @@ result:
     name: foo.sql
 
 
-$ juju run-action mysql/3 backup 
+$ juju run-action mysql/3 backup
 action: <ID>
 
 $ juju show-action-output <ID>
@@ -119,7 +119,7 @@ The value for the "time" param will be the string literal "1000".
 `
 
 // ActionNameRule describes the format an action name must match to be valid.
-var ActionNameRule = regexp.MustCompile("^[a-z](?:[a-z-]*[a-z])?$")
+var ActionNameRule = regexp.MustCompile("^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$")
 
 // SetFlags offers an option for YAML output.
 func (c *runCommand) SetFlags(f *gnuflag.FlagSet) {

--- a/cmd/juju/action/run.go
+++ b/cmd/juju/action/run.go
@@ -20,7 +20,8 @@ import (
 	"github.com/juju/juju/cmd/output"
 )
 
-var keyRule *regexp.Regexp = charm.GetActionNameRule()
+// nameRule describes the name format of an action or keyName must match to be valid.
+var nameRule = charm.GetActionNameRule()
 
 func NewRunCommand() cmd.Command {
 	return modelcmd.Wrap(&runCommand{})
@@ -118,9 +119,6 @@ $ juju run-action sleeper/0 pause --string-args time=1000
 The value for the "time" param will be the string literal "1000".
 `
 
-// ActionNameRule describes the format an action name must match to be valid.
-var ActionNameRule = regexp.MustCompile("^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$")
-
 // SetFlags offers an option for YAML output.
 func (c *runCommand) SetFlags(f *gnuflag.FlagSet) {
 	c.ActionCommandBase.SetFlags(f)
@@ -145,7 +143,7 @@ func (c *runCommand) Init(args []string) error {
 	for idx, arg := range args {
 		if names.IsValidUnit(arg) {
 			unitNames = args[:idx+1]
-		} else if ActionNameRule.MatchString(arg) {
+		} else if nameRule.MatchString(arg) {
 			c.actionName = arg
 			break
 		} else {
@@ -173,7 +171,7 @@ func (c *runCommand) Init(args []string) error {
 		keySlice := strings.Split(thisArg[0], ".")
 		// check each key for validity
 		for _, key := range keySlice {
-			if valid := keyRule.MatchString(key); !valid {
+			if valid := nameRule.MatchString(key); !valid {
 				return errors.Errorf("key %q must start and end with lowercase alphanumeric, and contain only lowercase alphanumeric and hyphens", key)
 			}
 		}

--- a/cmd/juju/action/run_test.go
+++ b/cmd/juju/action/run_test.go
@@ -97,6 +97,10 @@ func (s *RunSuite) TestInit(c *gc.C) {
 		args:        []string{validUnitId, "BadName"},
 		expectError: "invalid unit or action name \"BadName\"",
 	}, {
+		should:      "fail with invalid action name ending in \"-\"",
+		args:        []string{validUnitId, "name-end-with-dash-"},
+		expectError: "invalid unit or action name \"name-end-with-dash-\"",
+	}, {
 		should:      "fail with wrong formatting of k-v args",
 		args:        []string{validUnitId, "valid-action-name", "uh"},
 		expectError: "argument \"uh\" must be of the form key...=value",
@@ -108,6 +112,21 @@ func (s *RunSuite) TestInit(c *gc.C) {
 		should:      "fail with wrong formatting of k-v args",
 		args:        []string{validUnitId, "valid-action-name", "no-go?od=3"},
 		expectError: "key \"no-go\\?od\" must start and end with lowercase alphanumeric, and contain only lowercase alphanumeric and hyphens",
+	}, {
+		should:       "work with action name ending in numeric values",
+		args:         []string{validUnitId, "action-01"},
+		expectUnits:  []names.UnitTag{names.NewUnitTag(validUnitId)},
+		expectAction: "action-01",
+	}, {
+		should:       "work with numeric values within action name",
+		args:         []string{validUnitId, "action-00-foo"},
+		expectUnits:  []names.UnitTag{names.NewUnitTag(validUnitId)},
+		expectAction: "action-00-foo",
+	}, {
+		should:       "work with action name starting with numeric values",
+		args:         []string{validUnitId, "00-action"},
+		expectUnits:  []names.UnitTag{names.NewUnitTag(validUnitId)},
+		expectAction: "00-action",
 	}, {
 		should:       "work with empty values",
 		args:         []string{validUnitId, "valid-action-name", "ok="},

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -96,7 +96,7 @@ gopkg.in/errgo.v1	git	442357a80af5c6bf9b6d51ae791a39c3421004f3	2016-12-22T12:58:
 gopkg.in/goose.v2	git	e3fb91ea8c933a6c92361a2f6849962fe37f21a2	2017-12-13T00:39:39Z
 gopkg.in/ini.v1	git	776aa739ce9373377cd16f526cdf06cb4c89b40f	2016-02-22T23:24:41Z
 gopkg.in/juju/blobstore.v2	git	51fa6e26128d74e445c72d3a91af555151cc3654	2016-01-25T02:37:03Z
-gopkg.in/juju/charm.v6	git	b0ec23ec519f5151ea29e1a1f3108baeee4e6314	2017-12-05T12:18:46Z
+gopkg.in/juju/charm.v6	git	96786fc3f8695207515eb6be307ff37901a7254f	2018-01-19T23:10:43Z
 gopkg.in/juju/charm.v6-unstable	git	514bb811b021ebeb3e7ffcf1c267e9803968f59d	2017-07-28T19:41:00Z
 gopkg.in/juju/charmrepo.v2	git	653bbd81990d2d7d48e0fb931a3b0f52c694572f	2017-11-14T18:40:45Z
 gopkg.in/juju/charmrepo.v2-unstable	git	e79aa298df89ea887c9bffec46063c24bfb730f7	2016-11-17T15:25:28Z

--- a/worker/uniter/runner/jujuc/action-set.go
+++ b/worker/uniter/runner/jujuc/action-set.go
@@ -5,14 +5,14 @@ package jujuc
 
 import (
 	"fmt"
-	"regexp"
 	"strings"
 
 	"github.com/juju/cmd"
 	"github.com/juju/gnuflag"
+	"gopkg.in/juju/charm.v6"
 )
 
-var keyRule = regexp.MustCompile("^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$")
+var keyRule = charm.GetActionNameRule()
 
 // ActionSetCommand implements the action-set command.
 type ActionSetCommand struct {


### PR DESCRIPTION
## Action name doesn't allow numeric characters:
Launchpad description [1640223](https://bugs.launchpad.net/juju/+bug/1640223)
----

## Description of change
  - [x] Update `dependencies.tsv` as this bug links with [juju/charm PR 238](https://github.com/juju/charm/pull/238) repository.
  - [x] Create test to ensure that we can use numeric characters in the action name.
    - [x] Numeric characters starting the action name.
    - [x] Numeric characters within the action name.
    - [x] Numeric characters ending the action name.
  - [x] Modify regular expression to validate numeric characters in the action name.

Why is this change needed?
Ability to use numeric characters in actions names. 

## QA steps

How do we verify that the change works?
Create a juju action with a numeric character in the name.

## Documentation changes

Does it affect current user workflow? CLI? API?

## Bug reference
LP [1640223](https://bugs.launchpad.net/juju/+bug/1640223)