### PR TITLE
Container spec sent by charm is generic

### DIFF
--- a/apiserver/facades/agent/caasoperator/operator.go
+++ b/apiserver/facades/agent/caasoperator/operator.go
@@ -11,6 +11,7 @@ import (
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/caas"
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/state/watcher"
 	"github.com/juju/juju/status"
@@ -275,6 +276,10 @@ func (f *Facade) SetContainerSpec(args params.SetContainerSpecParams) (params.Er
 		}
 		if !canAccess(tag) {
 			results.Results[i].Error = common.ServerError(common.ErrPerm)
+			continue
+		}
+		if _, err := caas.ParseContainerSpec(arg.Value); err != nil {
+			results.Results[i].Error = common.ServerError(errors.New("invalid container spec"))
 			continue
 		}
 		results.Results[i].Error = common.ServerError(

--- a/apiserver/facades/agent/caasoperator/operator_test.go
+++ b/apiserver/facades/agent/caasoperator/operator_test.go
@@ -186,11 +186,17 @@ func (s *CAASOperatorSuite) TestWatchCharmConfig(c *gc.C) {
 }
 
 func (s *CAASOperatorSuite) TestSetContainerSpec(c *gc.C) {
+	validSpecStr := `
+name: gitlab
+image-name: gitlab/latest
+`[1:]
+
 	args := params.SetContainerSpecParams{
 		Entities: []params.EntityString{
-			{Tag: "application-gitlab", Value: "foo"},
-			{Tag: "unit-gitlab-0", Value: "bar"},
-			{Tag: "unit-gitlab-1", Value: "baz"},
+			{Tag: "application-gitlab", Value: validSpecStr},
+			{Tag: "unit-gitlab-0", Value: validSpecStr},
+			{Tag: "unit-gitlab-1", Value: "bad spec"},
+			{Tag: "unit-gitlab-2", Value: validSpecStr},
 			{Tag: "application-other"},
 			{Tag: "unit-other-0"},
 			{Tag: "machine-0"},
@@ -206,6 +212,10 @@ func (s *CAASOperatorSuite) TestSetContainerSpec(c *gc.C) {
 			Error: nil,
 		}, {
 			Error: nil,
+		}, {
+			Error: &params.Error{
+				Message: "invalid container spec",
+			},
 		}, {
 			Error: &params.Error{
 				Message: "bloop",
@@ -230,9 +240,9 @@ func (s *CAASOperatorSuite) TestSetContainerSpec(c *gc.C) {
 
 	s.st.CheckCallNames(c, "Model")
 	s.st.model.CheckCallNames(c, "SetContainerSpec", "SetContainerSpec", "SetContainerSpec")
-	s.st.model.CheckCall(c, 0, "SetContainerSpec", names.NewApplicationTag("gitlab"), "foo")
-	s.st.model.CheckCall(c, 1, "SetContainerSpec", names.NewUnitTag("gitlab/0"), "bar")
-	s.st.model.CheckCall(c, 2, "SetContainerSpec", names.NewUnitTag("gitlab/1"), "baz")
+	s.st.model.CheckCall(c, 0, "SetContainerSpec", names.NewApplicationTag("gitlab"), validSpecStr)
+	s.st.model.CheckCall(c, 1, "SetContainerSpec", names.NewUnitTag("gitlab/0"), validSpecStr)
+	s.st.model.CheckCall(c, 2, "SetContainerSpec", names.NewUnitTag("gitlab/2"), validSpecStr)
 }
 
 func (s *CAASOperatorSuite) TestModelName(c *gc.C) {

--- a/caas/broker.go
+++ b/caas/broker.go
@@ -20,7 +20,7 @@ type Broker interface {
 	EnsureOperator(appName, agentPath string, config *OperatorConfig) error
 
 	// EnsureService creates or updates a service for pods with the given spec.
-	EnsureService(appName, unitSpec string, numUnits int, config application.ConfigAttributes) error
+	EnsureService(appName string, spec *ContainerSpec, numUnits int, config application.ConfigAttributes) error
 
 	// DeleteService deletes the specified service.
 	DeleteService(appName string) error
@@ -32,7 +32,7 @@ type Broker interface {
 	UnexposeService(appName string) error
 
 	// EnsureUnit creates or updates a pod with the given spec.
-	EnsureUnit(appName, unitName, spec string) error
+	EnsureUnit(appName, unitName string, spec *ContainerSpec) error
 
 	// WatchUnits returns a watcher which notifies when there
 	// are changes to units of the specified application.

--- a/caas/containers.go
+++ b/caas/containers.go
@@ -1,0 +1,40 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package caas
+
+import (
+	"github.com/juju/errors"
+	"gopkg.in/yaml.v2"
+)
+
+// ContainerPort defines the attributes used to configure
+// an open port for the container.
+type ContainerPort struct {
+	ContainerPort int    `yaml:"container-port"`
+	Protocol      string `yaml:"protocol"`
+}
+
+// ContainerSpec defines the data values used to configure
+// a container on the CAAS substrate.
+type ContainerSpec struct {
+	Name      string            `yaml:"name"`
+	ImageName string            `yaml:"image-name"`
+	Ports     []ContainerPort   `yaml:"ports,omitempty"`
+	Config    map[string]string `yaml:"config,omitempty"`
+}
+
+// ParseContainerSpec parses a YAML string into a ContainerSpec struct.
+func ParseContainerSpec(in string) (*ContainerSpec, error) {
+	var spec ContainerSpec
+	if err := yaml.Unmarshal([]byte(in), &spec); err != nil {
+		return nil, errors.Trace(err)
+	}
+	if spec.Name == "" {
+		return nil, errors.New("spec name is missing")
+	}
+	if spec.ImageName == "" {
+		return nil, errors.New("spec image name is missing")
+	}
+	return &spec, nil
+}

--- a/caas/containers_test.go
+++ b/caas/containers_test.go
@@ -1,0 +1,68 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package caas_test
+
+import (
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/caas"
+	"github.com/juju/juju/testing"
+)
+
+type ContainersSuite struct {
+	testing.BaseSuite
+}
+
+var _ = gc.Suite(&ContainersSuite{})
+
+func (s *ContainersSuite) TestParse(c *gc.C) {
+
+	specStr := `
+name: gitlab
+image-name: gitlab/latest
+ports:
+- container-port: 80
+  protocol: TCP
+- container-port: 443
+config:
+  attr: foo=bar; fred=blogs
+  foo: bar
+`[1:]
+
+	spec, err := caas.ParseContainerSpec(specStr)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(spec, jc.DeepEquals, &caas.ContainerSpec{
+		Name:      "gitlab",
+		ImageName: "gitlab/latest",
+		Ports: []caas.ContainerPort{
+			{ContainerPort: 80, Protocol: "TCP"},
+			{ContainerPort: 443},
+		},
+		Config: map[string]string{
+			"attr": "foo=bar; fred=blogs",
+			"foo":  "bar",
+		},
+	})
+}
+
+func (s *ContainersSuite) TestParseMissingName(c *gc.C) {
+
+	specStr := `
+image-name: gitlab/latest
+`[1:]
+
+	_, err := caas.ParseContainerSpec(specStr)
+	c.Assert(err, gc.ErrorMatches, "spec name is missing")
+}
+
+func (s *ContainersSuite) TestParseMissingImage(c *gc.C) {
+
+	specStr := `
+name: gitlab
+`[1:]
+
+	_, err := caas.ParseContainerSpec(specStr)
+	c.Assert(err, gc.ErrorMatches, "spec image name is missing")
+}

--- a/worker/caasunitprovisioner/broker.go
+++ b/worker/caasunitprovisioner/broker.go
@@ -10,12 +10,12 @@ import (
 )
 
 type ContainerBroker interface {
-	EnsureUnit(appName, unitName, spec string) error
+	EnsureUnit(appName, unitName string, spec *caas.ContainerSpec) error
 	WatchUnits(appName string) (watcher.NotifyWatcher, error)
 	Units(appName string) ([]caas.Unit, error)
 }
 
 type ServiceBroker interface {
-	EnsureService(appName, unitSpec string, numUnits int, config application.ConfigAttributes) error
+	EnsureService(appName string, unitSpec *caas.ContainerSpec, numUnits int, config application.ConfigAttributes) error
 	DeleteService(appName string) error
 }

--- a/worker/caasunitprovisioner/mock_test.go
+++ b/worker/caasunitprovisioner/mock_test.go
@@ -38,7 +38,7 @@ type mockServiceBroker struct {
 	ensured chan<- struct{}
 }
 
-func (m *mockServiceBroker) EnsureService(appName, unitSpec string, numUnits int, config application.ConfigAttributes) error {
+func (m *mockServiceBroker) EnsureService(appName string, unitSpec *caas.ContainerSpec, numUnits int, config application.ConfigAttributes) error {
 	m.MethodCall(m, "EnsureService", appName, unitSpec, numUnits, config)
 	m.ensured <- struct{}{}
 	return m.NextErr()
@@ -55,7 +55,7 @@ type mockContainerBroker struct {
 	unitsWatcher *watchertest.MockNotifyWatcher
 }
 
-func (m *mockContainerBroker) EnsureUnit(appName, unitName, spec string) error {
+func (m *mockContainerBroker) EnsureUnit(appName, unitName string, spec *caas.ContainerSpec) error {
 	m.MethodCall(m, "EnsureUnit", appName, unitName, spec)
 	m.ensured <- struct{}{}
 	return m.NextErr()

--- a/worker/caasunitprovisioner/unit_worker.go
+++ b/worker/caasunitprovisioner/unit_worker.go
@@ -5,6 +5,7 @@ package caasunitprovisioner
 
 import (
 	"github.com/juju/errors"
+	"github.com/juju/juju/caas"
 	"gopkg.in/juju/worker.v1"
 
 	"github.com/juju/juju/worker/catacomb"
@@ -68,7 +69,7 @@ func (w *unitWorker) loop() error {
 			if !ok {
 				return errors.New("watcher closed channel")
 			}
-			spec, err := w.containerSpecGetter.ContainerSpec(w.unit)
+			specStr, err := w.containerSpecGetter.ContainerSpec(w.unit)
 			if errors.IsNotFound(err) {
 				// No container spec defined for this unit yet;
 				// wait for one to be set.
@@ -76,6 +77,10 @@ func (w *unitWorker) loop() error {
 			}
 			if err != nil {
 				return errors.Trace(err)
+			}
+			spec, err := caas.ParseContainerSpec(specStr)
+			if err != nil {
+				return errors.Annotate(err, "cannot parse container spec")
 			}
 			if err := w.broker.EnsureUnit(w.application, w.unit, spec); err != nil {
 				return errors.Trace(err)


### PR DESCRIPTION
## Description of change

When a caas charm sends to juju the spec used to configure how a container should be created, make the spec generic and not k8s specific. The k8s unit provisioner will take the generic info and make a k8s pods spec from it.

## QA steps

Run up a caas scenario using a modified gitlab charm.