### PR TITLE
On Xenial, we don't actually want to fall back to juju-mongodb.

### DIFF
--- a/mongo/mongo.go
+++ b/mongo/mongo.go
@@ -711,12 +711,12 @@ func installMongod(operatingsystem string, numaCtl bool) error {
 // yet be.
 func packagesForSeries(series string) ([]string, []string) {
 	switch series {
-	case "precise", "quantal", "raring", "saucy", "centos7":
+	case "precise", "centos7":
 		return []string{"mongodb-server"}, []string{}
-	case "trusty", "wily":
-		return []string{JujuMongoPackage, JujuMongoToolsPackage}, []string{"juju-mongodb"}
+	case "trusty":
+		return []string{"juju-mongodb"}, []string{}
 	default:
-		// y and onwards
+		// xenial and onwards
 		return []string{JujuMongoPackage, JujuMongoToolsPackage}, []string{}
 	}
 }

--- a/mongo/mongo.go
+++ b/mongo/mongo.go
@@ -713,7 +713,7 @@ func packagesForSeries(series string) ([]string, []string) {
 	switch series {
 	case "precise", "quantal", "raring", "saucy", "centos7":
 		return []string{"mongodb-server"}, []string{}
-	case "trusty", "wily", "xenial":
+	case "trusty", "wily":
 		return []string{JujuMongoPackage, JujuMongoToolsPackage}, []string{"juju-mongodb"}
 	default:
 		// y and onwards

--- a/mongo/mongo_test.go
+++ b/mongo/mongo_test.go
@@ -434,7 +434,8 @@ func (s *MongoSuite) TestInstallMongodFallsBack(c *gc.C) {
 		{"precise", "mongodb-server"},
 		{"trusty", "juju-mongodb3.2\njuju-mongodb"},
 		{"wily", "juju-mongodb3.2\njuju-mongodb"},
-		{"xenial", "juju-mongodb3.2\njuju-mongodb"},
+		{"xenial", "juju-mongodb3.2"},
+		{"bionic", "juju-mongodb3.2"},
 	}
 
 	dataDir := c.MkDir()

--- a/mongo/mongo_test.go
+++ b/mongo/mongo_test.go
@@ -372,9 +372,9 @@ func (s *MongoSuite) TestInstallMongod(c *gc.C) {
 
 	tests := []installs{
 		{"precise", [][]string{{"--target-release", "precise-updates/cloud-tools", "mongodb-server"}}},
-		{"trusty", [][]string{{"juju-mongodb3.2"}, {"juju-mongo-tools3.2"}}},
-		{"wily", [][]string{{"juju-mongodb3.2"}, {"juju-mongo-tools3.2"}}},
+		{"trusty", [][]string{{"juju-mongodb"}}},
 		{"xenial", [][]string{{"juju-mongodb3.2"}, {"juju-mongo-tools3.2"}}},
+		{"bionic", [][]string{{"juju-mongodb3.2"}, {"juju-mongo-tools3.2"}}},
 	}
 
 	testing.PatchExecutableAsEchoArgs(c, s, "add-apt-repository")
@@ -432,8 +432,7 @@ func (s *MongoSuite) TestInstallMongodFallsBack(c *gc.C) {
 
 	tests := []installs{
 		{"precise", "mongodb-server"},
-		{"trusty", "juju-mongodb3.2\njuju-mongodb"},
-		{"wily", "juju-mongodb3.2\njuju-mongodb"},
+		{"trusty", "juju-mongodb"},
 		{"xenial", "juju-mongodb3.2"},
 		{"bionic", "juju-mongodb3.2"},
 	}


### PR DESCRIPTION
## Description of change

There was probably a transition period where this was useful, but we
actually don't want to be running juju-mongodb on Xenial.
See https://bugs.launchpad.net/juju/+bug/1743901 where we fell back to
juju-mongodb because there was a temporary problem with the archive
mirror. But eventually juju-mongodb3.2 was found and juju started trying
to use that instead of the old mongo 2.4, and that just breaks
everything because it tries to launch the new mongo on the old database.

## QA steps

The actual underlying bug meant having an archive mirror that *has* juju-mongodb but *doesn't* have juju-mongodb3.2. I'm not sure we need to go to that level to test this. But ideally we would just fail to install and people can go fix their mirror, rather than succeeding but with a version that will break us in the future.

## Documentation changes

None.

## Bug reference

[lp:1743901](https://bugs.launchpad.net/juju/+bug/1743901)