### PR TITLE
state: use database name prefix

### DIFF
--- a/apiserver/facades/client/backups/backups.go
+++ b/apiserver/facades/client/backups/backups.go
@@ -29,6 +29,7 @@ type Backend interface {
 	Machine(id string) (*state.Machine, error)
 	MachineSeries(id string) (string, error)
 	MongoSession() *mgo.Session
+	DBPrefix() string
 	MongoVersion() (string, error)
 	ModelTag() names.ModelTag
 	ControllerTag() names.ControllerTag

--- a/apiserver/server_test.go
+++ b/apiserver/server_test.go
@@ -209,6 +209,7 @@ func (s *serverSuite) TestNewServerDoesNotAccessState(c *gc.C) {
 		ControllerTag:      s.State.ControllerTag(),
 		ControllerModelTag: s.IAASModel.ModelTag(),
 		MongoSession:       session,
+		DBPrefix:           s.State.DBPrefix(),
 	})
 	c.Assert(err, gc.IsNil)
 	defer st.Close()

--- a/state/backups/storage.go
+++ b/state/backups/storage.go
@@ -536,6 +536,8 @@ type DB interface {
 	// MongoSession returns the underlying mongodb session.
 	MongoSession() *mgo.Session
 
+	DBPrefix() string
+
 	// ModelTag is the concrete model tag for this database.
 	ModelTag() names.ModelTag
 
@@ -553,7 +555,7 @@ type DB interface {
 // archives (and metadata).
 func NewStorage(st DB) filestorage.FileStorage {
 	modelUUID := st.ModelTag().Id()
-	db := st.MongoSession().DB(storageDBName)
+	db := st.MongoSession().DB(st.DBPrefix() + storageDBName)
 	dbWrap := newStorageDBWrapper(db, storageMetaName, modelUUID)
 	defer dbWrap.Close()
 

--- a/state/binarystorage_test.go
+++ b/state/binarystorage_test.go
@@ -118,8 +118,7 @@ func (s *binaryStorageSuite) TestGUIArchiveStorageParams(c *gc.C) {
 }
 
 func (s *binaryStorageSuite) testStorage(c *gc.C, collName string, openStorage storageOpener) {
-	session := s.State.MongoSession()
-	collectionNames, err := session.DB("juju").CollectionNames()
+	collectionNames, err := s.DB("juju").CollectionNames()
 	c.Assert(err, jc.ErrorIsNil)
 	nameSet := set.NewStrings(collectionNames...)
 	c.Assert(nameSet.Contains(collName), jc.IsFalse)
@@ -134,7 +133,7 @@ func (s *binaryStorageSuite) testStorage(c *gc.C, collName string, openStorage s
 	err = storage.Add(strings.NewReader(""), binarystorage.Metadata{})
 	c.Assert(err, jc.ErrorIsNil)
 
-	collectionNames, err = session.DB("juju").CollectionNames()
+	collectionNames, err = s.DB("juju").CollectionNames()
 	c.Assert(err, jc.ErrorIsNil)
 	nameSet = set.NewStrings(collectionNames...)
 	c.Assert(nameSet.Contains(collName), jc.IsTrue)

--- a/state/conn_test.go
+++ b/state/conn_test.go
@@ -51,7 +51,7 @@ func (cs *ConnSuite) SetUpTest(c *gc.C) {
 
 	cs.modelTag = cs.IAASModel.ModelTag()
 
-	jujuDB := cs.MgoSuite.Session.DB("juju")
+	jujuDB := cs.DB("juju")
 	cs.annotations = jujuDB.C("annotations")
 	cs.charms = jujuDB.C("charms")
 	cs.machines = jujuDB.C("machines")

--- a/state/conn_wallclock_test.go
+++ b/state/conn_wallclock_test.go
@@ -53,7 +53,7 @@ func (cs *ConnWithWallClockSuite) SetUpTest(c *gc.C) {
 
 	cs.modelTag = cs.IAASModel.ModelTag()
 
-	jujuDB := cs.MgoSuite.Session.DB("juju")
+	jujuDB := cs.DB("juju")
 	cs.annotations = jujuDB.C("annotations")
 	cs.charms = jujuDB.C("charms")
 	cs.machines = jujuDB.C("machines")

--- a/state/controller.go
+++ b/state/controller.go
@@ -38,6 +38,7 @@ type Controller struct {
 	controllerModelTag     names.ModelTag
 	controllerTag          names.ControllerTag
 	session                *mgo.Session
+	dbPrefix               string
 	policy                 Policy
 	newPolicy              NewPolicyFunc
 	runTransactionObserver RunTransactionObserverFunc
@@ -57,6 +58,7 @@ func (ctlr *Controller) NewState(modelTag names.ModelTag) (*State, error) {
 		modelTag,
 		ctlr.controllerModelTag,
 		session,
+		ctlr.dbPrefix,
 		ctlr.newPolicy,
 		ctlr.clock,
 		ctlr.runTransactionObserver,

--- a/state/gui_test.go
+++ b/state/gui_test.go
@@ -76,7 +76,7 @@ func (s *guiVersionSuite) addArchive(c *gc.C, vers string) version.Number {
 // checkCount ensures that there is only one document in the GUI settings
 // mongo collection.
 func (s *guiVersionSuite) checkCount(c *gc.C) {
-	settings := s.State.MongoSession().DB("juju").C(state.GUISettingsC)
+	settings := s.DB("juju").C(state.GUISettingsC)
 	count, err := settings.Find(nil).Count()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(count, gc.Equals, 1)

--- a/state/images.go
+++ b/state/images.go
@@ -14,5 +14,5 @@ var (
 // ImageStorage returns a new imagestorage.Storage
 // that stores image metadata.
 func (st *State) ImageStorage() imagestorage.Storage {
-	return imageStorageNewStorage(st.session, st.ModelUUID())
+	return imageStorageNewStorage(st.session, st.dbPrefix, st.ModelUUID())
 }

--- a/state/imagestorage/export_test.go
+++ b/state/imagestorage/export_test.go
@@ -21,9 +21,9 @@ func MetadataCollection(s Storage) *mgo.Collection {
 
 // RemoveFailsManagedStorage returns a patched managedStorage,
 // which fails when Remove is called.
-var RemoveFailsManagedStorage = func(session *mgo.Session) blobstore.ManagedStorage {
-	rs := blobstore.NewGridFS(ImagesDB, ImagesDB, session)
-	db := session.DB(ImagesDB)
+var RemoveFailsManagedStorage = func(session *mgo.Session, dbPrefix string) blobstore.ManagedStorage {
+	rs := blobstore.NewGridFS(dbPrefix+ImagesDB, ImagesDB, session)
+	db := session.DB(dbPrefix + ImagesDB)
 	metadataDb := db.With(session)
 	return removeFailsManagedStorage{blobstore.NewManagedStorage(metadataDb, rs)}
 }

--- a/state/imagestorage/image_test.go
+++ b/state/imagestorage/image_test.go
@@ -48,7 +48,7 @@ func (s *ImageSuite) SetUpTest(c *gc.C) {
 	var err error
 	s.session, err = s.mongo.Dial()
 	c.Assert(err, gc.IsNil)
-	s.storage = imagestorage.NewStorage(s.session, "my-uuid")
+	s.storage = imagestorage.NewStorage(s.session, "", "my-uuid")
 	s.metadataCollection = imagestorage.MetadataCollection(s.storage)
 	s.txnRunner = jujutxn.NewRunner(jujutxn.RunnerParams{Database: s.metadataCollection.Database})
 	s.patchTransactionRunner()
@@ -185,7 +185,7 @@ func (s *ImageSuite) TestAddImageRemovesExistingRemoveFails(c *gc.C) {
 	err := managedStorage.PutForBucket("my-uuid", "path", strings.NewReader("blah"), 4)
 	c.Assert(err, gc.IsNil)
 
-	storage := imagestorage.NewStorage(s.session, "my-uuid")
+	storage := imagestorage.NewStorage(s.session, "", "my-uuid")
 	s.PatchValue(imagestorage.GetManagedStorage, imagestorage.RemoveFailsManagedStorage)
 	addedMetadata := &imagestorage.Metadata{
 		ModelUUID: "my-uuid",
@@ -216,7 +216,7 @@ func (errorTransactionRunner) Run(transactions txn.TransactionSource) error {
 }
 
 func (s *ImageSuite) TestAddImageRemovesBlobOnFailure(c *gc.C) {
-	storage := imagestorage.NewStorage(s.session, "my-uuid")
+	storage := imagestorage.NewStorage(s.session, "", "my-uuid")
 	s.txnRunner = errorTransactionRunner{s.txnRunner}
 	addedMetadata := &imagestorage.Metadata{
 		ModelUUID: "my-uuid",
@@ -237,7 +237,7 @@ func (s *ImageSuite) TestAddImageRemovesBlobOnFailure(c *gc.C) {
 }
 
 func (s *ImageSuite) TestAddImageRemovesBlobOnFailureRemoveFails(c *gc.C) {
-	storage := imagestorage.NewStorage(s.session, "my-uuid")
+	storage := imagestorage.NewStorage(s.session, "", "my-uuid")
 	s.PatchValue(imagestorage.GetManagedStorage, imagestorage.RemoveFailsManagedStorage)
 	s.txnRunner = errorTransactionRunner{s.txnRunner}
 	addedMetadata := &imagestorage.Metadata{

--- a/state/internal_test.go
+++ b/state/internal_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/juju/utils/clock"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/names.v2"
+	mgo "gopkg.in/mgo.v2"
 
 	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/constraints"
@@ -98,6 +99,10 @@ func (s *internalStateSuite) SetUpTest(c *gc.C) {
 func (s *internalStateSuite) TearDownTest(c *gc.C) {
 	s.BaseSuite.TearDownTest(c)
 	s.MgoSuite.TearDownTest(c)
+}
+
+func (s *internalStateSuite) DB(name string) *mgo.Database {
+	return s.state.MongoSession().DB(s.state.DBPrefix() + name)
 }
 
 func (s *internalStateSuite) newState(c *gc.C) *State {

--- a/state/life_test.go
+++ b/state/life_test.go
@@ -119,7 +119,7 @@ func (l *machineLife) setup(s *LifeSuite, c *gc.C) state.AgentLiving {
 
 func (s *LifeSuite) prepareFixture(living state.Living, lfix lifeFixture, cached, dbinitial state.Life, c *gc.C) {
 	collName, id := lfix.id()
-	coll := s.MgoSuite.Session.DB("juju").C(collName)
+	coll := s.DB("juju").C(collName)
 
 	err := coll.UpdateId(id, bson.D{{"$set", bson.D{
 		{"life", cached},

--- a/state/logs_test.go
+++ b/state/logs_test.go
@@ -35,8 +35,7 @@ func (s *LogsSuite) SetUpTest(c *gc.C) {
 }
 
 func (s *LogsSuite) logCollFor(st *state.State) *mgo.Collection {
-	session := st.MongoSession()
-	return session.DB("logs").C("logs." + st.ModelUUID())
+	return s.DB("logs").C("logs." + st.ModelUUID())
 }
 
 func (s *LogsSuite) TestLastSentLogTrackerSetGet(c *gc.C) {
@@ -308,9 +307,8 @@ var _ = gc.Suite(&LogTailerSuite{})
 func (s *LogTailerSuite) SetUpTest(c *gc.C) {
 	s.ConnWithWallClockSuite.SetUpTest(c)
 
-	session := s.State.MongoSession()
 	// Create a fake oplog collection.
-	s.oplogColl = session.DB("logs").C("oplog.fake")
+	s.oplogColl = s.DB("logs").C("oplog.fake")
 	err := s.oplogColl.Create(&mgo.CollectionInfo{
 		Capped:   true,
 		MaxBytes: 1024 * 1024,
@@ -329,7 +327,7 @@ func (s *LogTailerSuite) SetUpTest(c *gc.C) {
 }
 
 func (s *LogTailerSuite) getCollection(modelUUID string) *mgo.Collection {
-	return s.State.MongoSession().DB("logs").C("logs." + modelUUID)
+	return s.DB("logs").C("logs." + modelUUID)
 }
 
 func (s *LogTailerSuite) TestLogDeletionDuringTailing(c *gc.C) {

--- a/state/meterstatus_test.go
+++ b/state/meterstatus_test.go
@@ -46,7 +46,7 @@ func (s *MeterStateSuite) TestMeterStatus(c *gc.C) {
 }
 
 func (s *MeterStateSuite) TestMeterStatusIncludesModelUUID(c *gc.C) {
-	jujuDB := s.MgoSuite.Session.DB("juju")
+	jujuDB := s.DB("juju")
 	meterStatus := jujuDB.C("meterStatus")
 	var docs []bson.M
 	err := meterStatus.Find(nil).All(&docs)

--- a/state/model.go
+++ b/state/model.go
@@ -370,6 +370,7 @@ func (st *State) NewModel(args ModelArgs) (_ *Model, _ *State, err error) {
 		names.NewModelTag(uuid),
 		controllerInfo.ModelTag,
 		session,
+		st.dbPrefix,
 		st.newPolicy,
 		st.clock(),
 		st.runTransactionObserver,
@@ -434,7 +435,7 @@ func (st *State) NewModel(args ModelArgs) (_ *Model, _ *State, err error) {
 		return nil, nil, errors.Annotate(err, "granting admin permission to the owner")
 	}
 
-	if err := InitDbLogs(session, uuid); err != nil {
+	if err := InitDbLogs(session, st.dbPrefix, uuid); err != nil {
 		return nil, nil, errors.Annotate(err, "initialising model logs collection")
 	}
 	return newModel, newSt, nil

--- a/state/modelconfig_test.go
+++ b/state/modelconfig_test.go
@@ -449,6 +449,7 @@ func (s *ModelConfigSourceSuite) TestUpdateModelConfigDefaults(c *gc.C) {
 		ControllerTag:      s.State.ControllerTag(),
 		ControllerModelTag: s.modelTag,
 		MongoSession:       s.Session,
+		DBPrefix:           s.State.DBPrefix(),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	defer anotherState.Close()
@@ -503,6 +504,7 @@ func (s *ModelConfigSourceSuite) TestUpdateModelConfigRegionDefaults(c *gc.C) {
 		ControllerTag:      s.State.ControllerTag(),
 		ControllerModelTag: s.modelTag,
 		MongoSession:       s.Session,
+		DBPrefix:           s.State.DBPrefix(),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	defer anotherState.Close()

--- a/state/modelsummaries_test.go
+++ b/state/modelsummaries_test.go
@@ -436,7 +436,7 @@ func (s *ModelSummariesSuite) TestModelsWithNoSettings(c *gc.C) {
 	c.Check(userSummary.Status.Message, gc.Equals, "stopping")
 
 	// Now we start tearing down some of the collections for this model, and see that it still shows up.
-	settings := s.Session.DB("juju").C("settings")
+	settings := s.DB("juju").C("settings")
 	// The settings document for this model
 	err = settings.Remove(bson.M{"_id": m2uuid + ":e"})
 	c.Assert(err, jc.ErrorIsNil)

--- a/state/pool.go
+++ b/state/pool.go
@@ -155,7 +155,8 @@ func (p *StatePool) openState(modelUUID string) (*State, error) {
 	session := p.systemState.session.Copy()
 	newSt, err := newState(
 		modelTag, p.systemState.controllerModelTag,
-		session, p.systemState.newPolicy, p.systemState.stateClock,
+		session, p.systemState.dbPrefix,
+		p.systemState.newPolicy, p.systemState.stateClock,
 		p.systemState.runTransactionObserver,
 	)
 	if err != nil {

--- a/state/relationunit_test.go
+++ b/state/relationunit_test.go
@@ -463,7 +463,7 @@ func (s *RelationUnitSuite) TestAliveRelationScope(c *gc.C) {
 }
 
 func (s *StateSuite) TestWatchWatchScopeDiesOnStateClose(c *gc.C) {
-	testWatcherDiesWhenStateCloses(c, s.Session, s.modelTag, s.State.ControllerTag(), func(c *gc.C, st *state.State) waiter {
+	testWatcherDiesWhenStateCloses(c, s.Session, s.State.DBPrefix(), s.modelTag, s.State.ControllerTag(), func(c *gc.C, st *state.State) waiter {
 		pr := newPeerRelation(c, st)
 		w := pr.ru0.WatchScope()
 		<-w.Changes()

--- a/state/testing/conn.go
+++ b/state/testing/conn.go
@@ -22,6 +22,7 @@ import (
 
 type InitializeArgs struct {
 	Owner                     names.UserTag
+	DBPrefix                  string
 	InitialConfig             *config.Config
 	ControllerConfig          map[string]interface{}
 	ControllerInheritedConfig map[string]interface{}
@@ -110,6 +111,7 @@ func InitializeWithArgs(c *gc.C, args InitializeArgs) (*state.Controller, *state
 			RegionConfig: args.RegionConfig,
 		},
 		MongoSession:  session,
+		DBPrefix:      args.DBPrefix,
 		NewPolicy:     args.NewPolicy,
 		AdminPassword: "admin-secret",
 	})

--- a/state/testing/suite.go
+++ b/state/testing/suite.go
@@ -8,6 +8,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/names.v2"
+	mgo "gopkg.in/mgo.v2"
 
 	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/environs/config"
@@ -85,4 +86,8 @@ func (s *StateSuite) SetUpTest(c *gc.C) {
 func (s *StateSuite) TearDownTest(c *gc.C) {
 	s.BaseSuite.TearDownTest(c)
 	s.MgoSuite.TearDownTest(c)
+}
+
+func (s *StateSuite) DB(name string) *mgo.Database {
+	return s.State.MongoSession().DB(s.State.DBPrefix() + name)
 }

--- a/state/upgrades_test.go
+++ b/state/upgrades_test.go
@@ -1304,7 +1304,7 @@ func (x bsonMById) Less(i, j int) bool {
 }
 
 func (s *upgradesSuite) TestSplitLogCollection(c *gc.C) {
-	db := s.state.MongoSession().DB(logsDB)
+	db := s.DB(logsDB)
 	oldLogs := db.C("logs")
 
 	uuids := []string{"fake-1", "fake-2", "fake-3"}
@@ -1376,7 +1376,7 @@ func (s *upgradesSuite) TestSplitLogCollection(c *gc.C) {
 }
 
 func (s *upgradesSuite) TestSplitLogsIgnoresDupeRecordsAlreadyThere(c *gc.C) {
-	db := s.state.MongoSession().DB(logsDB)
+	db := s.DB(logsDB)
 	oldLogs := db.C("logs")
 
 	uuids := []string{"fake-1", "fake-2", "fake-3"}
@@ -1435,7 +1435,7 @@ func (s *upgradesSuite) TestSplitLogsIgnoresDupeRecordsAlreadyThere(c *gc.C) {
 }
 
 func (s *upgradesSuite) TestSplitLogsHandlesNoLogsCollection(c *gc.C) {
-	db := s.state.MongoSession().DB(logsDB)
+	db := s.DB(logsDB)
 	names, err := db.CollectionNames()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(set.NewStrings(names...).Contains("logs"), jc.IsFalse)
@@ -1922,7 +1922,7 @@ func (s *upgradesSuite) TestMoveOldAuditLogNoRecords(c *gc.C) {
 	err = MoveOldAuditLog(s.state)
 	c.Assert(err, jc.ErrorIsNil)
 
-	db := s.state.MongoSession().DB("juju")
+	db := s.DB(logsDB)
 	names, err := db.CollectionNames()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(set.NewStrings(names...).Contains("audit.log"), jc.IsFalse)
@@ -1948,7 +1948,7 @@ func (s *upgradesSuite) TestMoveOldAuditLogRename(c *gc.C) {
 		expectUpgradedData{oldLog, data},
 	)
 
-	db := s.state.MongoSession().DB("juju")
+	db := s.DB("juju")
 	names, err := db.CollectionNames()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(set.NewStrings(names...).Contains("audit.log"), jc.IsFalse)

--- a/worker/upgradesteps/worker_test.go
+++ b/worker/upgradesteps/worker_test.go
@@ -332,7 +332,7 @@ func (s *UpgradeSuite) checkSuccess(c *gc.C, target string, mungeInfo func(*stat
 
 	workerErr, config, statusCalls, doneLock := s.runUpgradeWorker(c, multiwatcher.JobManageModel)
 
-	c.Check(workerErr, gc.IsNil)
+	c.Check(workerErr, jc.ErrorIsNil)
 	c.Check(*attemptsP, gc.Equals, 1)
 	c.Check(config.Version, gc.Equals, jujuversion.Current) // Upgrade finished
 	c.Assert(statusCalls, jc.DeepEquals, s.makeExpectedStatusCalls(0, succeeds, ""))
@@ -421,6 +421,7 @@ func (s *UpgradeSuite) openStateForUpgrade() (*state.State, error) {
 		ControllerTag:      s.State.ControllerTag(),
 		ControllerModelTag: s.IAASModel.ModelTag(),
 		MongoSession:       s.State.MongoSession(),
+		DBPrefix:           s.State.DBPrefix(),
 		NewPolicy:          newPolicy,
 	})
 	if err != nil {


### PR DESCRIPTION
This means that we can potentially have two instances of State
using the same mongo instance, which is desired for testing
higher level functionality such as the JIMM service.

It also potentially means that we could have tests that
run in parallel or tests in different juju packages that
reuse the same MongoDB server instance rather than
starting a server for every package.

This is not everything that needs to be done - the SetAdminMongoPassword
method requires access to the admin database, which is
unique to a mongo server, so doing that is incompatible
with sharing. However most tests do not need to set the
admin password, so placing a hard requirement on non-shared
mongo because of that seems like overkill. Perhaps
in a future PR, the password-setting methods can be moved
out of the State type, so the State type always operates
within the DBPrefix constraints. For now, just make SetAdminMongoPassword
fail when there's a non-empty prefix set.
