### PR TITLE
worker/raft: worker for managing a Raft instance

### DIFF
--- a/agent/agentbootstrap/bootstrap_test.go
+++ b/agent/agentbootstrap/bootstrap_test.go
@@ -439,7 +439,7 @@ func (s *bootstrapSuite) TestInitializeStateFailsSecondTime(c *gc.C) {
 	if err == nil {
 		st.Close()
 	}
-	c.Assert(err, gc.ErrorMatches, "failed to initialize mongo: cannot set admin password: not authorized .*")
+	c.Assert(err, gc.ErrorMatches, "bootstrapping raft cluster: bootstrap only works on new clusters")
 }
 
 func (s *bootstrapSuite) TestMachineJobFromParams(c *gc.C) {

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -3,8 +3,10 @@ github.com/Azure/go-autorest	git	10cfe58defab0c9a33be1f7b3ee656857670b509	2017-0
 github.com/EvilSuperstars/go-cidrman	git	4e5a4a63d9b78757b4891b8de60be2606d8972ee	2017-02-11T23:11:53Z
 github.com/ajstarks/svgo	git	89e3ac64b5b3e403a5e7c35ea4f98d45db7b4518	2014-10-04T21:11:59Z
 github.com/altoros/gosigma	git	31228935eec685587914528585da4eb9b073c76d	2015-04-08T14:52:32Z
+github.com/armon/go-metrics	git	93f237eba9b0602f3e73710416558854a81d9337	2017-01-14T13:47:37Z
 github.com/beorn7/perks	git	3ac7bf7a47d159a033b107610db8a1b6575507a4	2016-02-29T21:34:45Z
 github.com/bmizerany/pat	git	c068ca2f0aacee5ac3681d68e4d0a003b7d1fd2c	2016-02-17T10:32:42Z
+github.com/boltdb/bolt	git	e9cf4fae01b5a8ff89d0ec6b32f0d9c9f79aefdd	2017-01-31T19:20:18Z
 github.com/coreos/go-systemd	git	7b2428fec40033549c68f54e26e89e7ca9a9ce31	2016-02-02T21:14:25Z
 github.com/dgrijalva/jwt-go	git	01aeca54ebda6e0fbfafd0a524d234159c05ec20	2016-07-05T20:30:06Z
 github.com/dustin/go-humanize	git	145fabdb1ab757076a70a886d092a3af27f66f4c	2014-12-28T07:11:48Z
@@ -15,6 +17,9 @@ github.com/gorilla/handlers	git	13d73096a474cac93275c679c7b8a2dc17ddba82	2017-02
 github.com/gorilla/schema	git	08023a0215e7fc27a9aecd8b8c50913c40019478	2016-04-26T23:15:12Z
 github.com/gorilla/websocket	git	804cb600d06b10672f2fbc0a336a7bee507a428e	2017-02-14T17:41:18Z
 github.com/gosuri/uitable	git	36ee7e946282a3fb1cfecd476ddc9b35d8847e42	2016-04-04T20:39:58Z
+github.com/hashicorp/go-msgpack	git	fa3f63826f7c23912c15263591e65d54d080b458	2015-05-18T23:42:57Z
+github.com/hashicorp/raft	git	077966dbc90f342107eb723ec52fdb0463ec789b	2018-01-17T20:29:25Z
+github.com/hashicorp/raft-boltdb	git	6e5ba93211eaf8d9a2ad7e41ffad8c6f160f9fe3	2017-10-10T15:18:10Z
 github.com/joyent/gocommon	git	ade826b8b54e81a779ccb29d358a45ba24b7809c	2016-03-20T19:31:33Z
 github.com/joyent/gosdc	git	2f11feadd2d9891e92296a1077c3e2e56939547d	2014-05-24T00:08:15Z
 github.com/joyent/gosign	git	0da0d5f1342065321c97812b1f4ac0c2b0bab56c	2014-05-24T00:07:34Z

--- a/worker/raft/manifold.go
+++ b/worker/raft/manifold.go
@@ -1,0 +1,108 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package raft
+
+import (
+	"path/filepath"
+
+	"github.com/hashicorp/raft"
+	"github.com/juju/errors"
+	"github.com/juju/loggo"
+	"gopkg.in/juju/worker.v1"
+
+	"github.com/juju/juju/agent"
+	"github.com/juju/juju/worker/dependency"
+)
+
+// ManifoldConfig holds the information necessary to run a raft
+// worker in a dependency.Engine.
+type ManifoldConfig struct {
+	AgentName     string
+	TransportName string
+
+	FSM       raft.FSM
+	Logger    loggo.Logger
+	NewWorker func(Config) (worker.Worker, error)
+}
+
+// Validate validates the manifold configuration.
+func (config ManifoldConfig) Validate() error {
+	if config.AgentName == "" {
+		return errors.NotValidf("empty AgentName")
+	}
+	if config.TransportName == "" {
+		return errors.NotValidf("empty TransportName")
+	}
+	if config.FSM == nil {
+		return errors.NotValidf("nil FSM")
+	}
+	if config.NewWorker == nil {
+		return errors.NotValidf("nil NewWorker")
+	}
+	return nil
+}
+
+// Manifold returns a dependency.Manifold that will run a raft worker.
+func Manifold(config ManifoldConfig) dependency.Manifold {
+	return dependency.Manifold{
+		Inputs: []string{
+			config.AgentName,
+			config.TransportName,
+		},
+		Start:  config.start,
+		Output: raftOutput,
+	}
+}
+
+// start is a method on ManifoldConfig because it's more readable than a closure.
+func (config ManifoldConfig) start(context dependency.Context) (worker.Worker, error) {
+	if err := config.Validate(); err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	var agent agent.Agent
+	if err := context.Get(config.AgentName, &agent); err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	var transport raft.Transport
+	if err := context.Get(config.TransportName, &transport); err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	// TODO(axw) make the directory path configurable, so we can
+	// potentially have multiple Rafts. The dqlite raft should go
+	// in <data-dir>/dqlite.
+	agentConfig := agent.CurrentConfig()
+	raftDir := filepath.Join(agentConfig.DataDir(), "raft")
+
+	return config.NewWorker(Config{
+		FSM:        config.FSM,
+		Logger:     config.Logger,
+		StorageDir: raftDir,
+		Tag:        agentConfig.Tag(),
+		Transport:  transport,
+	})
+}
+
+func raftOutput(in worker.Worker, out interface{}) error {
+	w, ok := in.(withRaft)
+	if !ok {
+		return errors.Errorf("expected input of type %T, got %T", w, in)
+	}
+	rout, ok := out.(**raft.Raft)
+	if ok {
+		r, err := w.Raft()
+		if err != nil {
+			return err
+		}
+		*rout = r
+		return nil
+	}
+	return errors.Errorf("expected output of type %T, got %T", rout, out)
+}
+
+type withRaft interface {
+	Raft() (*raft.Raft, error)
+}

--- a/worker/raft/manifold_test.go
+++ b/worker/raft/manifold_test.go
@@ -1,0 +1,154 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package raft_test
+
+import (
+	"path/filepath"
+
+	coreraft "github.com/hashicorp/raft"
+	"github.com/juju/errors"
+	"github.com/juju/loggo"
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/names.v2"
+	worker "gopkg.in/juju/worker.v1"
+
+	"github.com/juju/juju/worker/dependency"
+	dt "github.com/juju/juju/worker/dependency/testing"
+	"github.com/juju/juju/worker/raft"
+	"github.com/juju/juju/worker/raft/rafttest"
+)
+
+type ManifoldSuite struct {
+	testing.IsolationSuite
+
+	manifold  dependency.Manifold
+	context   dependency.Context
+	agent     *mockAgent
+	transport *coreraft.InmemTransport
+	fsm       *rafttest.FSM
+	logger    loggo.Logger
+	worker    *mockRaftWorker
+	stub      testing.Stub
+}
+
+var _ = gc.Suite(&ManifoldSuite{})
+
+func (s *ManifoldSuite) SetUpTest(c *gc.C) {
+	s.IsolationSuite.SetUpTest(c)
+
+	s.agent = &mockAgent{
+		conf: mockAgentConfig{
+			tag:     names.NewMachineTag("99"),
+			dataDir: filepath.Join("data", "dir"),
+		},
+	}
+	s.fsm = &rafttest.FSM{}
+	s.logger = loggo.GetLogger("juju.worker.raft_test")
+	s.worker = &mockRaftWorker{
+		r: &coreraft.Raft{},
+	}
+	s.stub.ResetCalls()
+
+	_, transport := coreraft.NewInmemTransport(coreraft.ServerAddress(
+		s.agent.conf.tag.String(),
+	))
+	s.transport = transport
+	s.AddCleanup(func(c *gc.C) {
+		s.transport.Close()
+	})
+
+	s.context = s.newContext(nil)
+	s.manifold = raft.Manifold(raft.ManifoldConfig{
+		AgentName:     "agent",
+		TransportName: "transport",
+		FSM:           s.fsm,
+		Logger:        s.logger,
+		NewWorker:     s.newWorker,
+	})
+}
+
+func (s *ManifoldSuite) newContext(overlay map[string]interface{}) dependency.Context {
+	resources := map[string]interface{}{
+		"agent":     s.agent,
+		"transport": s.transport,
+	}
+	for k, v := range overlay {
+		resources[k] = v
+	}
+	return dt.StubContext(nil, resources)
+}
+
+func (s *ManifoldSuite) newWorker(config raft.Config) (worker.Worker, error) {
+	s.stub.MethodCall(s, "NewWorker", config)
+	if err := s.stub.NextErr(); err != nil {
+		return nil, err
+	}
+	return s.worker, nil
+}
+
+var expectedInputs = []string{
+	"agent", "transport",
+}
+
+func (s *ManifoldSuite) TestInputs(c *gc.C) {
+	c.Assert(s.manifold.Inputs, jc.SameContents, expectedInputs)
+}
+
+func (s *ManifoldSuite) TestMissingInputs(c *gc.C) {
+	for _, input := range expectedInputs {
+		context := s.newContext(map[string]interface{}{
+			input: dependency.ErrMissing,
+		})
+		_, err := s.manifold.Start(context)
+		c.Assert(errors.Cause(err), gc.Equals, dependency.ErrMissing)
+	}
+}
+
+func (s *ManifoldSuite) TestStart(c *gc.C) {
+	s.startWorkerClean(c)
+
+	s.stub.CheckCallNames(c, "NewWorker")
+	args := s.stub.Calls()[0].Args
+	c.Assert(args, gc.HasLen, 1)
+	c.Assert(args[0], gc.FitsTypeOf, raft.Config{})
+	config := args[0].(raft.Config)
+
+	c.Assert(config, jc.DeepEquals, raft.Config{
+		FSM:        s.fsm,
+		Logger:     s.logger,
+		StorageDir: filepath.Join(s.agent.conf.dataDir, "raft"),
+		Tag:        s.agent.conf.tag,
+		Transport:  s.transport,
+	})
+}
+
+func (s *ManifoldSuite) TestOutput(c *gc.C) {
+	w := s.startWorkerClean(c)
+
+	var r *coreraft.Raft
+	err := s.manifold.Output(w, &r)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(r, gc.Equals, s.worker.r)
+
+	s.worker.CheckCallNames(c, "Raft")
+}
+
+func (s *ManifoldSuite) TestOutputRaftError(c *gc.C) {
+	w := s.startWorkerClean(c)
+
+	s.worker.SetErrors(errors.New("no Raft for you"))
+
+	var r *coreraft.Raft
+	err := s.manifold.Output(w, &r)
+	c.Assert(err, gc.ErrorMatches, "no Raft for you")
+}
+
+func (s *ManifoldSuite) startWorkerClean(c *gc.C) worker.Worker {
+	w, err := s.manifold.Start(s.context)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(w, gc.Equals, s.worker)
+	return w
+}

--- a/worker/raft/mock_test.go
+++ b/worker/raft/mock_test.go
@@ -1,0 +1,47 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package raft_test
+
+import (
+	"github.com/hashicorp/raft"
+	"gopkg.in/juju/names.v2"
+	worker "gopkg.in/juju/worker.v1"
+
+	"github.com/juju/juju/agent"
+	"github.com/juju/testing"
+)
+
+type mockAgent struct {
+	agent.Agent
+	conf mockAgentConfig
+}
+
+func (ma *mockAgent) CurrentConfig() agent.Config {
+	return &ma.conf
+}
+
+type mockAgentConfig struct {
+	agent.Config
+	dataDir string
+	tag     names.Tag
+}
+
+func (c *mockAgentConfig) Tag() names.Tag {
+	return c.tag
+}
+
+func (c *mockAgentConfig) DataDir() string {
+	return c.dataDir
+}
+
+type mockRaftWorker struct {
+	worker.Worker
+	testing.Stub
+	r *raft.Raft
+}
+
+func (r *mockRaftWorker) Raft() (*raft.Raft, error) {
+	r.MethodCall(r, "Raft")
+	return r.r, r.NextErr()
+}

--- a/worker/raft/package_test.go
+++ b/worker/raft/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package raft_test
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func TestPackage(t *testing.T) {
+	gc.TestingT(t)
+}

--- a/worker/raft/rafttest/fixtures.go
+++ b/worker/raft/rafttest/fixtures.go
@@ -1,0 +1,71 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package rafttest
+
+import (
+	"log"
+	"time"
+
+	"github.com/hashicorp/raft"
+	"github.com/juju/loggo"
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	coretesting "github.com/juju/juju/testing"
+	"github.com/juju/juju/worker/raft/raftutil"
+)
+
+// RaftFixture is a fixture to embed into test suites, providing
+// a raft.Raft and in-memory transport.
+type RaftFixture struct {
+	testing.IsolationSuite
+
+	FSM           raft.FSM
+	Transport     *raft.InmemTransport
+	Store         *raft.InmemStore
+	SnapshotStore *raft.InmemSnapshotStore
+	Raft          *raft.Raft
+}
+
+func (s *RaftFixture) SetUpTest(c *gc.C) {
+	s.IsolationSuite.SetUpTest(c)
+	c.Assert(s.FSM, gc.NotNil, gc.Commentf("FSM must be set by embedding test suite"))
+
+	s.Store = raft.NewInmemStore()
+	s.SnapshotStore = raft.NewInmemSnapshotStore()
+	addr, transport := raft.NewInmemTransport("machine-0")
+	s.Transport = transport
+	s.AddCleanup(func(*gc.C) { s.Transport.Close() })
+
+	raftConfig := raft.DefaultConfig()
+	raftConfig.HeartbeatTimeout = 100 * time.Millisecond
+	raftConfig.ElectionTimeout = raftConfig.HeartbeatTimeout
+	raftConfig.LeaderLeaseTimeout = raftConfig.HeartbeatTimeout
+	raftConfig.LocalID = raft.ServerID(string(addr))
+	raftConfig.Logger = log.New(&raftutil.LoggoWriter{
+		loggo.GetLogger("juju.worker.raft.raftclusterer_test"),
+		loggo.DEBUG,
+	}, "", 0)
+
+	r, err := raft.NewRaft(raftConfig, s.FSM, s.Store, s.Store, s.SnapshotStore, s.Transport)
+	c.Assert(err, jc.ErrorIsNil)
+	s.AddCleanup(func(c *gc.C) {
+		f := r.Shutdown()
+		c.Assert(f.Error(), jc.ErrorIsNil)
+	})
+	s.Raft = r
+
+	c.Assert(s.Raft.BootstrapCluster(raft.Configuration{
+		Servers: []raft.Server{{
+			ID:      raftConfig.LocalID,
+			Address: addr,
+		}},
+	}).Error(), jc.ErrorIsNil)
+	select {
+	case <-s.Raft.LeaderCh():
+	case <-time.After(coretesting.LongWait):
+		c.Fatal("timed out waiting for raft leadership")
+	}
+}

--- a/worker/raft/rafttest/fsm.go
+++ b/worker/raft/rafttest/fsm.go
@@ -1,0 +1,78 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package rafttest
+
+import (
+	"encoding/gob"
+	"io"
+	"sync"
+
+	"github.com/hashicorp/raft"
+)
+
+// FSM is an implementation of raft.FSM, which simply appends
+// the log data to a slice.
+type FSM struct {
+	mu   sync.Mutex
+	logs [][]byte
+}
+
+// Logs returns the accumulated log data.
+func (fsm *FSM) Logs() [][]byte {
+	fsm.mu.Lock()
+	defer fsm.mu.Unlock()
+	copied := make([][]byte, len(fsm.logs))
+	copy(copied, fsm.logs)
+	return copied
+}
+
+// Apply is part of the raft.FSM interface.
+func (fsm *FSM) Apply(log *raft.Log) interface{} {
+	fsm.mu.Lock()
+	defer fsm.mu.Unlock()
+	fsm.logs = append(fsm.logs, log.Data)
+	return len(fsm.logs)
+}
+
+// Snapshot is part of the raft.FSM interface.
+func (fsm *FSM) Snapshot() (raft.FSMSnapshot, error) {
+	fsm.mu.Lock()
+	defer fsm.mu.Unlock()
+	copied := make([][]byte, len(fsm.logs))
+	copy(copied, fsm.logs)
+	return &Snapshot{copied, len(copied)}, nil
+}
+
+// Restore is part of the raft.FSM interface.
+func (fsm *FSM) Restore(rc io.ReadCloser) error {
+	defer rc.Close()
+	var logs [][]byte
+	if err := gob.NewDecoder(rc).Decode(&logs); err != nil {
+		return err
+	}
+	fsm.mu.Lock()
+	fsm.logs = logs
+	fsm.mu.Unlock()
+	return nil
+}
+
+// Snapshot is an implementation of raft.FSMSnapshot, returned
+// by the FSM.Snapshot in this package.
+type Snapshot struct {
+	logs [][]byte
+	n    int
+}
+
+// Persist is part of the raft.FSMSnapshot interface.
+func (snap *Snapshot) Persist(sink raft.SnapshotSink) error {
+	if err := gob.NewEncoder(sink).Encode(snap.logs[:snap.n]); err != nil {
+		sink.Cancel()
+		return err
+	}
+	sink.Close()
+	return nil
+}
+
+// Release is part of the raft.FSMSnapshot interface.
+func (*Snapshot) Release() {}

--- a/worker/raft/raftutil/logging.go
+++ b/worker/raft/raftutil/logging.go
@@ -1,0 +1,20 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package raftutil
+
+import "github.com/juju/loggo"
+
+// LoggoWriter is an io.Writer that will call the embedded
+// logger's Log method for each Write, using the specified
+// log level.
+type LoggoWriter struct {
+	Logger loggo.Logger
+	Level  loggo.Level
+}
+
+// Write is part of the io.Writer interface.
+func (w *LoggoWriter) Write(p []byte) (int, error) {
+	w.Logger.Logf(w.Level, "%s", p[:len(p)-1]) // omit trailing newline
+	return len(p), nil
+}

--- a/worker/raft/shim.go
+++ b/worker/raft/shim.go
@@ -1,0 +1,12 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package raft
+
+import "gopkg.in/juju/worker.v1"
+
+// NewWorkerShim is suitable for use in ManifoldConfig.NewWorker,
+// and simply calls through to NewWorker.
+func NewWorkerShim(config Config) (worker.Worker, error) {
+	return NewWorker(config)
+}

--- a/worker/raft/worker.go
+++ b/worker/raft/worker.go
@@ -1,0 +1,322 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package raft
+
+import (
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/hashicorp/raft"
+	"github.com/hashicorp/raft-boltdb"
+	"github.com/juju/errors"
+	"github.com/juju/loggo"
+	"gopkg.in/juju/names.v2"
+	"gopkg.in/juju/worker.v1"
+
+	"github.com/juju/juju/worker/catacomb"
+	"github.com/juju/juju/worker/raft/raftutil"
+)
+
+const (
+	// defaultSnapshotRetention is the number of
+	// snapshots to retain on disk by default.
+	defaultSnapshotRetention = 2
+)
+
+var (
+	// ErrWorkerStopped is returned by Worker.Raft if the
+	// worker has been explicitly stopped.
+	ErrWorkerStopped = errors.New("raft worker stopped")
+)
+
+// Config is the configuration required for running a raft worker.
+type Config struct {
+	// FSM is the raft.FSM to use for this raft worker. This
+	// must be non-nil for NewWorker, and nil for Bootstrap.
+	FSM raft.FSM
+
+	// Logger is the logger for this worker.
+	Logger loggo.Logger
+
+	// StorageDir is the directory in which to store raft
+	// artifacts: logs, snapshots, etc. It is expected that
+	// this directory is under the full control of the raft
+	// worker.
+	StorageDir string
+
+	// Tag is the tag of the agent running this worker.
+	Tag names.Tag
+
+	// Transport is the raft.Transport to use for communication
+	// between raft servers. This must be non-nil for NewWorker,
+	// and nil for Bootstrap.
+	//
+	// The raft worker expects the server address to exactly
+	// match the server ID, which is the stringified agent tag.
+	// The transport internally maps the server address to one
+	// or more network addresses, i.e. by looking up the API
+	// connection information in the state database.
+	Transport raft.Transport
+
+	// ElectionTimeout, if non-zero, will override the default
+	// raft election timeout.
+	ElectionTimeout time.Duration
+
+	// HeartbeatTimeout, if non-zero, will override the default
+	// raft heartbeat timeout.
+	HeartbeatTimeout time.Duration
+
+	// LeaderLeaseTimeout, if non-zero, will override the default
+	// raft leader lease timeout.
+	LeaderLeaseTimeout time.Duration
+
+	// SnapshotRetention is the non-negative number of snapshots
+	// to retain on disk. If zero, defaults to 2.
+	SnapshotRetention int
+}
+
+// Validate validates the raft worker configuration.
+func (config Config) Validate() error {
+	if config.FSM == nil {
+		return errors.NotValidf("nil FSM")
+	}
+	if config.StorageDir == "" {
+		return errors.NotValidf("empty StorageDir")
+	}
+	if config.Tag == nil {
+		return errors.NotValidf("nil Tag")
+	}
+	if config.SnapshotRetention < 0 {
+		return errors.NotValidf("negative SnapshotRetention")
+	}
+	if config.Transport == nil {
+		return errors.NotValidf("nil Transport")
+	}
+	expectedLocalAddr := raft.ServerAddress(config.Tag.String())
+	transportLocalAddr := config.Transport.LocalAddr()
+	if transportLocalAddr != expectedLocalAddr {
+		return errors.NewNotValid(nil, fmt.Sprintf(
+			"transport local address %q not valid, expected %q",
+			transportLocalAddr, expectedLocalAddr,
+		))
+	}
+	return nil
+}
+
+// Bootstrap bootstraps the raft cluster, using the given configuration.
+//
+// This is only to be called once, at the beginning of the raft cluster's
+// lifetime, by the bootstrap machine agent.
+func Bootstrap(config Config) error {
+	if config.FSM != nil {
+		return errors.NotValidf("non-nil FSM during Bootstrap")
+	}
+	if config.Transport != nil {
+		return errors.NotValidf("non-nil Transport during Bootstrap")
+	}
+
+	// During bootstrap we use an in-memory transport. We just need
+	// to make sure we use the same local address as we'll use later.
+	localID := raft.ServerID(config.Tag.String())
+	localAddr := raft.ServerAddress(localID)
+	_, transport := raft.NewInmemTransport(localAddr)
+	defer transport.Close()
+	config.Transport = transport
+
+	// During bootstrap, we do not require an FSM.
+	config.FSM = bootstrapFSM{}
+
+	w, err := NewWorker(config)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	defer worker.Stop(w)
+
+	r, err := w.Raft()
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	if err := r.BootstrapCluster(raft.Configuration{
+		Servers: []raft.Server{{
+			ID:      localID,
+			Address: localAddr,
+		}},
+	}).Error(); err != nil {
+		return errors.Annotate(err, "bootstrapping raft cluster")
+	}
+	return errors.Annotate(worker.Stop(w), "stopping bootstrap raft worker")
+}
+
+// NewWorker returns a new raft worker, with the given configuration.
+func NewWorker(config Config) (*Worker, error) {
+	if err := config.Validate(); err != nil {
+		return nil, errors.Trace(err)
+	}
+	raftConfig, err := newRaftConfig(config)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	w := &Worker{
+		config: config,
+		raftCh: make(chan *raft.Raft),
+	}
+	if err := catacomb.Invoke(catacomb.Plan{
+		Site: &w.catacomb,
+		Work: func() error {
+			return w.loop(raftConfig)
+		},
+	}); err != nil {
+		return nil, errors.Trace(err)
+	}
+	return w, nil
+}
+
+// Worker is a worker that manages a raft.Raft instance.
+type Worker struct {
+	catacomb catacomb.Catacomb
+	config   Config
+
+	raftCh chan *raft.Raft
+}
+
+// Raft returns the raft.Raft managed by this worker, or
+// an error if the worker has stopped.
+func (w *Worker) Raft() (*raft.Raft, error) {
+	// Give precedence to the worker dying.
+	select {
+	case <-w.catacomb.Dying():
+	default:
+		select {
+		case raft := <-w.raftCh:
+			return raft, nil
+		case <-w.catacomb.Dying():
+		}
+	}
+	err := w.catacomb.Err()
+	if err != nil && err != w.catacomb.ErrDying() {
+		return nil, err
+	}
+	return nil, ErrWorkerStopped
+}
+
+// Kill is part of the worker.Worker interface.
+func (w *Worker) Kill() {
+	w.catacomb.Kill(nil)
+}
+
+// Wait is part of the worker.Worker interface.
+func (w *Worker) Wait() error {
+	return w.catacomb.Wait()
+}
+
+func (w *Worker) loop(raftConfig *raft.Config) (loopErr error) {
+	if err := os.MkdirAll(w.config.StorageDir, 0700); err != nil {
+		return errors.Trace(err)
+	}
+	logStore, err := newLogStore(w.config.StorageDir)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	defer logStore.Close()
+
+	snapshotRetention := w.config.SnapshotRetention
+	if snapshotRetention == 0 {
+		snapshotRetention = defaultSnapshotRetention
+	}
+	snapshotStore, err := newSnapshotStore(w.config.StorageDir, snapshotRetention, w.config.Logger)
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	r, err := raft.NewRaft(raftConfig, w.config.FSM, logStore, logStore, snapshotStore, w.config.Transport)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	defer func() {
+		if err := r.Shutdown().Error(); err != nil {
+			if loopErr == nil {
+				loopErr = err
+			} else {
+				w.config.Logger.Warningf("raft shutdown failed: %s", err)
+			}
+		}
+	}()
+
+	for {
+		select {
+		case <-w.catacomb.Dying():
+			return w.catacomb.ErrDying()
+		case w.raftCh <- r:
+		}
+	}
+}
+
+func newRaftConfig(config Config) (*raft.Config, error) {
+	raftConfig := raft.DefaultConfig()
+	raftConfig.LocalID = raft.ServerID(config.Tag.String())
+
+	logWriter := &raftutil.LoggoWriter{config.Logger, loggo.DEBUG}
+	raftConfig.Logger = log.New(logWriter, "", 0)
+
+	maybeOverrideDuration := func(d time.Duration, target *time.Duration) {
+		if d != 0 {
+			*target = d
+		}
+	}
+	maybeOverrideDuration(config.ElectionTimeout, &raftConfig.ElectionTimeout)
+	maybeOverrideDuration(config.HeartbeatTimeout, &raftConfig.HeartbeatTimeout)
+	maybeOverrideDuration(config.LeaderLeaseTimeout, &raftConfig.LeaderLeaseTimeout)
+
+	if err := raft.ValidateConfig(raftConfig); err != nil {
+		return nil, errors.Annotate(err, "validating raft config")
+	}
+	return raftConfig, nil
+}
+
+func newLogStore(dir string) (*raftboltdb.BoltStore, error) {
+	logs, err := raftboltdb.New(raftboltdb.Options{
+		Path: filepath.Join(dir, "logs"),
+	})
+	if err != nil {
+		return nil, errors.Annotate(err, "failed to create bolt store for raft logs")
+	}
+	return logs, nil
+}
+
+func newSnapshotStore(
+	dir string,
+	retain int,
+	logger loggo.Logger,
+) (raft.SnapshotStore, error) {
+	const logPrefix = "[snapshot] "
+	logWriter := &raftutil.LoggoWriter{logger, loggo.DEBUG}
+	logLogger := log.New(logWriter, logPrefix, 0)
+
+	snaps, err := raft.NewFileSnapshotStoreWithLogger(dir, retain, logLogger)
+	if err != nil {
+		return nil, errors.Annotate(err, "failed to create file snapshot store")
+	}
+	return snaps, nil
+}
+
+// bootstrapFSM is a minimal implementation of raft.FSM for use during
+// bootstrap. Its methods should never be invoked.
+type bootstrapFSM struct{}
+
+func (bootstrapFSM) Apply(log *raft.Log) interface{} {
+	panic("Apply should not be called during bootstrap")
+}
+
+func (bootstrapFSM) Snapshot() (raft.FSMSnapshot, error) {
+	panic("Snapshot should not be called during bootstrap")
+}
+
+func (bootstrapFSM) Restore(io.ReadCloser) error {
+	panic("Restore should not be called during bootstrap")
+}

--- a/worker/raft/worker_test.go
+++ b/worker/raft/worker_test.go
@@ -1,0 +1,205 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package raft_test
+
+import (
+	"time"
+
+	coreraft "github.com/hashicorp/raft"
+	"github.com/juju/loggo"
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/names.v2"
+
+	coretesting "github.com/juju/juju/testing"
+	"github.com/juju/juju/worker/raft"
+	"github.com/juju/juju/worker/raft/rafttest"
+	"github.com/juju/juju/worker/workertest"
+)
+
+type workerFixture struct {
+	testing.IsolationSuite
+	fsm    *rafttest.FSM
+	config raft.Config
+}
+
+func (s *workerFixture) SetUpTest(c *gc.C) {
+	s.IsolationSuite.SetUpTest(c)
+	s.fsm = &rafttest.FSM{}
+	_, transport := coreraft.NewInmemTransport("machine-123")
+	s.AddCleanup(func(c *gc.C) {
+		c.Assert(transport.Close(), jc.ErrorIsNil)
+	})
+	s.config = raft.Config{
+		FSM:        s.fsm,
+		Logger:     loggo.GetLogger("juju.worker.raft_test"),
+		StorageDir: c.MkDir(),
+		Tag:        names.NewMachineTag("123"),
+		Transport:  transport,
+	}
+}
+
+type WorkerValidationSuite struct {
+	workerFixture
+}
+
+var _ = gc.Suite(&WorkerValidationSuite{})
+
+func (s *WorkerValidationSuite) TestValidateErrors(c *gc.C) {
+	type test struct {
+		f      func(*raft.Config)
+		expect string
+	}
+	tests := []test{{
+		func(cfg *raft.Config) { cfg.FSM = nil },
+		"nil FSM not valid",
+	}, {
+		func(cfg *raft.Config) { cfg.StorageDir = "" },
+		"empty StorageDir not valid",
+	}, {
+		func(cfg *raft.Config) { cfg.Tag = nil },
+		"nil Tag not valid",
+	}, {
+		func(cfg *raft.Config) { cfg.HeartbeatTimeout = time.Millisecond },
+		"validating raft config: Heartbeat timeout is too low",
+	}, {
+		func(cfg *raft.Config) { cfg.Transport = nil },
+		"nil Transport not valid",
+	}, {
+		func(cfg *raft.Config) {
+			_, transport := coreraft.NewInmemTransport("321-enihcam")
+			cfg.Transport = transport
+		},
+		`transport local address "321-enihcam" not valid, expected "machine-123"`,
+	}}
+	for i, test := range tests {
+		c.Logf("test #%d (%s)", i, test.expect)
+		s.testValidateError(c, test.f, test.expect)
+	}
+}
+
+func (s *WorkerValidationSuite) testValidateError(c *gc.C, f func(*raft.Config), expect string) {
+	config := s.config
+	f(&config)
+	w, err := raft.NewWorker(config)
+	if !c.Check(err, gc.NotNil) {
+		workertest.DirtyKill(c, w)
+		return
+	}
+	c.Check(w, gc.IsNil)
+	c.Check(err, gc.ErrorMatches, expect)
+}
+
+func (s *WorkerValidationSuite) TestBootstrapFSM(c *gc.C) {
+	s.config.Transport = nil
+	err := raft.Bootstrap(s.config)
+	c.Assert(err, gc.ErrorMatches, "non-nil FSM during Bootstrap not valid")
+}
+
+func (s *WorkerValidationSuite) TestBootstrapTransport(c *gc.C) {
+	s.config.FSM = nil
+	err := raft.Bootstrap(s.config)
+	c.Assert(err, gc.ErrorMatches, "non-nil Transport during Bootstrap not valid")
+}
+
+type WorkerSuite struct {
+	workerFixture
+	worker *raft.Worker
+}
+
+var _ = gc.Suite(&WorkerSuite{})
+
+func (s *WorkerSuite) SetUpTest(c *gc.C) {
+	s.workerFixture.SetUpTest(c)
+
+	// Speed up the tests.
+	s.config.HeartbeatTimeout = 100 * time.Millisecond
+	s.config.ElectionTimeout = s.config.HeartbeatTimeout
+	s.config.LeaderLeaseTimeout = s.config.HeartbeatTimeout
+
+	// Bootstrap before starting the worker.
+	transport := s.config.Transport
+	fsm := s.config.FSM
+	s.config.Transport = nil
+	s.config.FSM = nil
+	err := raft.Bootstrap(s.config)
+	c.Assert(err, jc.ErrorIsNil)
+
+	s.config.Transport = transport
+	s.config.FSM = fsm
+	worker, err := raft.NewWorker(s.config)
+	c.Assert(err, jc.ErrorIsNil)
+	s.AddCleanup(func(c *gc.C) {
+		workertest.DirtyKill(c, worker)
+	})
+	s.worker = worker
+}
+
+func (s *WorkerSuite) waitLeader(c *gc.C) *coreraft.Raft {
+	r, err := s.worker.Raft()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(r, gc.NotNil)
+
+	select {
+	case leader := <-r.LeaderCh():
+		c.Assert(leader, jc.IsTrue)
+	case <-time.After(coretesting.LongWait):
+		c.Fatal("timed out waiting for leadership change")
+	}
+	return r
+}
+
+func (s *WorkerSuite) TestRaft(c *gc.C) {
+	r := s.waitLeader(c)
+
+	f := r.Apply([]byte("command1"), time.Minute)
+	c.Assert(f.Error(), jc.ErrorIsNil)
+	c.Assert(f.Index(), gc.Equals, uint64(3))
+	c.Assert(f.Response(), gc.Equals, 1)
+
+	f = r.Apply([]byte("command2"), time.Minute)
+	c.Assert(f.Error(), jc.ErrorIsNil)
+	c.Assert(f.Index(), gc.Equals, uint64(4))
+	c.Assert(f.Response(), gc.Equals, 2)
+
+	c.Assert(s.fsm.Logs(), jc.DeepEquals, [][]byte{
+		[]byte("command1"),
+		[]byte("command2"),
+	})
+}
+
+func (s *WorkerSuite) TestRaftWorkerStopped(c *gc.C) {
+	s.worker.Kill()
+
+	r, err := s.worker.Raft()
+	c.Assert(err, gc.Equals, raft.ErrWorkerStopped)
+	c.Assert(r, gc.IsNil)
+}
+
+func (s *WorkerSuite) TestRestoreSnapshot(c *gc.C) {
+	r := s.waitLeader(c)
+
+	f := r.Apply([]byte("command1"), time.Minute)
+	c.Assert(f.Error(), jc.ErrorIsNil)
+	c.Assert(f.Index(), gc.Equals, uint64(3))
+	c.Assert(f.Response(), gc.Equals, 1)
+
+	sf := r.Snapshot()
+	c.Assert(sf.Error(), jc.ErrorIsNil)
+	meta, rc, err := sf.Open()
+	c.Assert(err, jc.ErrorIsNil)
+	defer rc.Close()
+
+	f = r.Apply([]byte("command2"), time.Minute)
+	c.Assert(f.Error(), jc.ErrorIsNil)
+	c.Assert(f.Index(), gc.Equals, uint64(4))
+	c.Assert(f.Response(), gc.Equals, 2)
+
+	err = r.Restore(meta, rc, time.Minute)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(s.fsm.Logs(), jc.DeepEquals, [][]byte{
+		[]byte("command1"),
+	})
+}


### PR DESCRIPTION
## Description of change

This is part of a series of PRs that will introduce
Raft infrastructure into Juju. On top of this we
intend to build higher-level primitives, such as
application leadership.

We introduce a new package, worker/raft, which
contains a manifold and worker for managing a
Raft node in a controller agent. The manifold
expects a raft.Transport and raft.FSM as inputs;
a transport implementation will be provided in
a separate commit/PR.

## QA steps

1. juju bootstrap
2. juju enable-ha
3. juju destroy-controller

## Documentation changes

None.

## Bug reference

None.