### PR TITLE
worker/raft/{raftclusterer,raftflag}: introduce packages

### DIFF
--- a/pubsub/apiserver/messages.go
+++ b/pubsub/apiserver/messages.go
@@ -10,8 +10,20 @@ const DetailsTopic = "apiserver.details"
 
 // APIServer contains the machine id and addresses of a single API server machine.
 type APIServer struct {
-	ID        string   `yaml:"id"`
+	// ID contains the Juju machine ID for the apiserver.
+	ID string `yaml:"id"`
+
+	// Addresses contains all of the usable addresses of the
+	// apiserver machine.
 	Addresses []string `yaml:"addresses"`
+
+	// InternalAddress, if non-empty, is the address that
+	// other API servers should use to connect to this API
+	// server, in the form addr:port.
+	//
+	// This may be empty if the API server is not fully
+	// initialised.
+	InternalAddress string `yaml:"internal-address,omitempty"`
 }
 
 // Details contains the ids and addresses of all the current API server

--- a/worker/peergrouper/worker_test.go
+++ b/worker/peergrouper/worker_test.go
@@ -441,7 +441,7 @@ func (s *workerSuite) TestControllersArePublishedOverHub(c *gc.C) {
 
 	expected := apiserver.Details{
 		Servers: map[string]apiserver.APIServer{
-			"10": apiserver.APIServer{ID: "10", Addresses: []string{"0.1.2.10:5678"}},
+			"10": apiserver.APIServer{ID: "10", Addresses: []string{"0.1.2.10:5678"}, InternalAddress: "0.1.2.10:5678"},
 			"11": apiserver.APIServer{ID: "11", Addresses: []string{"0.1.2.11:5678"}},
 			"12": apiserver.APIServer{ID: "12", Addresses: []string{"0.1.2.12:5678"}},
 		},

--- a/worker/raft/raftclusterer/manifold.go
+++ b/worker/raft/raftclusterer/manifold.go
@@ -1,0 +1,49 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package raftclusterer
+
+import (
+	"github.com/hashicorp/raft"
+	"github.com/juju/errors"
+	"github.com/juju/pubsub"
+	"gopkg.in/juju/worker.v1"
+
+	"github.com/juju/juju/worker/dependency"
+)
+
+// ManifoldConfig holds the information necessary to run a worker for
+// maintaining the raft cluster configuration in a dependency.Engine.
+type ManifoldConfig struct {
+	RaftName       string
+	CentralHubName string
+
+	NewWorker func(Config) (worker.Worker, error)
+}
+
+func (config ManifoldConfig) start(context dependency.Context) (worker.Worker, error) {
+	var r *raft.Raft
+	if err := context.Get(config.RaftName, &r); err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	var hub *pubsub.StructuredHub
+	if err := context.Get(config.CentralHubName, &hub); err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	return config.NewWorker(Config{
+		Raft: r,
+		Hub:  hub,
+	})
+}
+
+func Manifold(config ManifoldConfig) dependency.Manifold {
+	return dependency.Manifold{
+		Inputs: []string{
+			config.RaftName,
+			config.CentralHubName,
+		},
+		Start: config.start,
+	}
+}

--- a/worker/raft/raftclusterer/manifold_test.go
+++ b/worker/raft/raftclusterer/manifold_test.go
@@ -1,0 +1,110 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package raftclusterer_test
+
+import (
+	"github.com/hashicorp/raft"
+	"github.com/juju/errors"
+	"github.com/juju/pubsub"
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	worker "gopkg.in/juju/worker.v1"
+
+	"github.com/juju/juju/worker/dependency"
+	dt "github.com/juju/juju/worker/dependency/testing"
+	"github.com/juju/juju/worker/raft/raftclusterer"
+)
+
+type ManifoldSuite struct {
+	testing.IsolationSuite
+
+	manifold dependency.Manifold
+	context  dependency.Context
+	raft     *raft.Raft
+	hub      *pubsub.StructuredHub
+	worker   worker.Worker
+	stub     testing.Stub
+}
+
+var _ = gc.Suite(&ManifoldSuite{})
+
+func (s *ManifoldSuite) SetUpTest(c *gc.C) {
+	s.IsolationSuite.SetUpTest(c)
+
+	s.raft = &raft.Raft{}
+	s.hub = &pubsub.StructuredHub{}
+	s.stub.ResetCalls()
+
+	type mockWorker struct {
+		worker.Worker
+	}
+	s.worker = &mockWorker{}
+
+	s.context = s.newContext(nil)
+	s.manifold = raftclusterer.Manifold(raftclusterer.ManifoldConfig{
+		RaftName:       "raft",
+		CentralHubName: "central-hub",
+		NewWorker:      s.newWorker,
+	})
+}
+
+func (s *ManifoldSuite) newContext(overlay map[string]interface{}) dependency.Context {
+	resources := map[string]interface{}{
+		"raft":        s.raft,
+		"central-hub": s.hub,
+	}
+	for k, v := range overlay {
+		resources[k] = v
+	}
+	return dt.StubContext(nil, resources)
+}
+
+func (s *ManifoldSuite) newWorker(config raftclusterer.Config) (worker.Worker, error) {
+	s.stub.MethodCall(s, "NewWorker", config)
+	if err := s.stub.NextErr(); err != nil {
+		return nil, err
+	}
+	return s.worker, nil
+}
+
+var expectedInputs = []string{
+	"raft", "central-hub",
+}
+
+func (s *ManifoldSuite) TestInputs(c *gc.C) {
+	c.Assert(s.manifold.Inputs, jc.SameContents, expectedInputs)
+}
+
+func (s *ManifoldSuite) TestMissingInputs(c *gc.C) {
+	for _, input := range expectedInputs {
+		context := s.newContext(map[string]interface{}{
+			input: dependency.ErrMissing,
+		})
+		_, err := s.manifold.Start(context)
+		c.Assert(errors.Cause(err), gc.Equals, dependency.ErrMissing)
+	}
+}
+
+func (s *ManifoldSuite) TestStart(c *gc.C) {
+	s.startWorkerClean(c)
+
+	s.stub.CheckCallNames(c, "NewWorker")
+	args := s.stub.Calls()[0].Args
+	c.Assert(args, gc.HasLen, 1)
+	c.Assert(args[0], gc.FitsTypeOf, raftclusterer.Config{})
+	config := args[0].(raftclusterer.Config)
+
+	c.Assert(config, jc.DeepEquals, raftclusterer.Config{
+		Raft: s.raft,
+		Hub:  s.hub,
+	})
+}
+
+func (s *ManifoldSuite) startWorkerClean(c *gc.C) worker.Worker {
+	w, err := s.manifold.Start(s.context)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(w, gc.Equals, s.worker)
+	return w
+}

--- a/worker/raft/raftclusterer/package_test.go
+++ b/worker/raft/raftclusterer/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package raftclusterer_test
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func TestPackage(t *testing.T) {
+	gc.TestingT(t)
+}

--- a/worker/raft/raftclusterer/worker.go
+++ b/worker/raft/raftclusterer/worker.go
@@ -1,0 +1,174 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package raftclusterer
+
+import (
+	"sync"
+
+	"github.com/hashicorp/raft"
+	"github.com/juju/errors"
+	"github.com/juju/loggo"
+	"github.com/juju/pubsub"
+	"github.com/juju/utils/set"
+	"gopkg.in/juju/names.v2"
+	worker "gopkg.in/juju/worker.v1"
+
+	"github.com/juju/juju/pubsub/apiserver"
+	"github.com/juju/juju/worker/catacomb"
+)
+
+var (
+	logger = loggo.GetLogger("juju.worker.raft.raftclusterer")
+)
+
+// Config holds the configuration necessary to run a worker for
+// maintaining the raft cluster configuration.
+type Config struct {
+	Raft *raft.Raft
+	Hub  *pubsub.StructuredHub
+}
+
+// Validate validates the raft worker configuration.
+func (config Config) Validate() error {
+	if config.Hub == nil {
+		return errors.NotValidf("nil Hub")
+	}
+	if config.Raft == nil {
+		return errors.NotValidf("nil Raft")
+	}
+	return nil
+}
+
+// NewWorker returns a new worker responsible for maintaining
+// the raft cluster configuration.
+func NewWorker(config Config) (worker.Worker, error) {
+	if err := config.Validate(); err != nil {
+		return nil, errors.Trace(err)
+	}
+	w := &Worker{
+		config:        config,
+		serverDetails: make(chan apiserver.Details),
+	}
+	if err := catacomb.Invoke(catacomb.Plan{
+		Site: &w.catacomb,
+		Work: w.loop,
+	}); err != nil {
+		return nil, errors.Trace(err)
+	}
+	return w, nil
+}
+
+// Worker is a worker that manages raft cluster configuration.
+type Worker struct {
+	catacomb catacomb.Catacomb
+	config   Config
+
+	mu            sync.Mutex
+	serverDetails chan apiserver.Details
+}
+
+// Kill is part of the worker.Worker interface.
+func (w *Worker) Kill() {
+	w.catacomb.Kill(nil)
+}
+
+// Wait is part of the worker.Worker interface.
+func (w *Worker) Wait() error {
+	return w.catacomb.Wait()
+}
+
+func (w *Worker) loop() error {
+	// Subscribe to API server address changes.
+	unsubscribe, err := w.config.Hub.Subscribe(
+		apiserver.DetailsTopic,
+		w.apiserverDetailsChanged,
+	)
+	if err != nil {
+		return errors.Annotate(err, "subscribing to apiserver details")
+	}
+	defer unsubscribe()
+
+	// Get the initial raft cluster configuration.
+	serverIDs, err := w.getConfiguration()
+	if err != nil {
+		return errors.Annotate(err, "getting raft configuration")
+	}
+
+	for {
+		select {
+		case <-w.catacomb.Dying():
+			return w.catacomb.ErrDying()
+		case details := <-w.serverDetails:
+			if err := w.updateConfiguration(serverIDs, details); err != nil {
+				return errors.Annotate(err, "updating raft configuration")
+			}
+		}
+	}
+}
+
+func (w *Worker) getConfiguration() (serverIDs set.Strings, _ error) {
+	future := w.config.Raft.GetConfiguration()
+	if _, err := w.waitIndexFuture(future); err != nil {
+		return nil, errors.Trace(err)
+	}
+	serverIDs = set.NewStrings()
+	for _, server := range future.Configuration().Servers {
+		serverIDs.Add(string(server.ID))
+	}
+	return serverIDs, nil
+}
+
+func (w *Worker) updateConfiguration(configuredServerIDs set.Strings, details apiserver.Details) error {
+	newServerIDs := set.NewStrings()
+	for _, server := range details.Servers {
+		newServerIDs.Add(names.NewMachineTag(server.ID).String())
+	}
+	var futures []raft.IndexFuture
+	for _, serverID := range configuredServerIDs.Difference(newServerIDs).Values() {
+		configuredServerIDs.Remove(serverID)
+		f := w.config.Raft.RemoveServer(raft.ServerID(serverID), 0, 0)
+		futures = append(futures, f)
+	}
+	for _, serverID := range newServerIDs.Difference(configuredServerIDs).Values() {
+		configuredServerIDs.Add(serverID)
+		raftServerID := raft.ServerID(serverID)
+		raftServerAddress := raft.ServerAddress(serverID)
+		f := w.config.Raft.AddVoter(raftServerID, raftServerAddress, 0, 0)
+		futures = append(futures, f)
+	}
+	for _, f := range futures {
+		if _, err := w.waitIndexFuture(f); err != nil {
+			return errors.Trace(err)
+		}
+	}
+	return nil
+}
+
+// waitIndexFuture waits for the future to return, or for the worker
+// to be killed, whichever happens first. If the worker is dying, then
+// the catacomb's ErrDying() is returned.
+func (w *Worker) waitIndexFuture(f raft.IndexFuture) (uint64, error) {
+	errch := make(chan error, 1)
+	go func() {
+		errch <- f.Error()
+	}()
+	select {
+	case <-w.catacomb.Dying():
+		return 0, w.catacomb.ErrDying()
+	case err := <-errch:
+		return f.Index(), err
+	}
+}
+
+func (w *Worker) apiserverDetailsChanged(topic string, details apiserver.Details, err error) {
+	if err != nil {
+		// This should never happen, so treat it as fatal.
+		w.catacomb.Kill(errors.Annotate(err, "apiserver details callback failed"))
+		return
+	}
+	select {
+	case w.serverDetails <- details:
+	case <-w.catacomb.Dying():
+	}
+}

--- a/worker/raft/raftclusterer/worker_test.go
+++ b/worker/raft/raftclusterer/worker_test.go
@@ -1,0 +1,149 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package raftclusterer_test
+
+import (
+	"time"
+
+	"github.com/hashicorp/raft"
+	"github.com/juju/pubsub"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/names.v2"
+	worker "gopkg.in/juju/worker.v1"
+
+	"github.com/juju/juju/pubsub/apiserver"
+	"github.com/juju/juju/pubsub/centralhub"
+	coretesting "github.com/juju/juju/testing"
+	"github.com/juju/juju/worker/raft/raftclusterer"
+	"github.com/juju/juju/worker/raft/rafttest"
+	"github.com/juju/juju/worker/workertest"
+)
+
+type workerFixture struct {
+	rafttest.RaftFixture
+	hub    *pubsub.StructuredHub
+	config raftclusterer.Config
+}
+
+func (s *workerFixture) SetUpTest(c *gc.C) {
+	s.FSM = &rafttest.FSM{}
+	s.RaftFixture.SetUpTest(c)
+	s.hub = centralhub.New(names.NewMachineTag("0"))
+	s.config = raftclusterer.Config{
+		Raft: s.Raft,
+		Hub:  s.hub,
+	}
+}
+
+type WorkerValidationSuite struct {
+	workerFixture
+}
+
+var _ = gc.Suite(&WorkerValidationSuite{})
+
+func (s *WorkerValidationSuite) TestValidateErrors(c *gc.C) {
+	type test struct {
+		f      func(*raftclusterer.Config)
+		expect string
+	}
+	tests := []test{{
+		func(cfg *raftclusterer.Config) { cfg.Raft = nil },
+		"nil Raft not valid",
+	}, {
+		func(cfg *raftclusterer.Config) { cfg.Hub = nil },
+		"nil Hub not valid",
+	}}
+	for i, test := range tests {
+		c.Logf("test #%d (%s)", i, test.expect)
+		s.testValidateError(c, test.f, test.expect)
+	}
+}
+
+func (s *WorkerValidationSuite) testValidateError(c *gc.C, f func(*raftclusterer.Config), expect string) {
+	config := s.config
+	f(&config)
+	w, err := raftclusterer.NewWorker(config)
+	if !c.Check(err, gc.NotNil) {
+		workertest.DirtyKill(c, w)
+		return
+	}
+	c.Check(w, gc.IsNil)
+	c.Check(err, gc.ErrorMatches, expect)
+}
+
+type WorkerSuite struct {
+	workerFixture
+	worker worker.Worker
+}
+
+var _ = gc.Suite(&WorkerSuite{})
+
+func (s *WorkerSuite) SetUpTest(c *gc.C) {
+	s.workerFixture.SetUpTest(c)
+	worker, err := raftclusterer.NewWorker(s.config)
+	c.Assert(err, jc.ErrorIsNil)
+	s.AddCleanup(func(c *gc.C) {
+		workertest.DirtyKill(c, worker)
+	})
+	s.worker = worker
+}
+
+func (s *WorkerSuite) TestCleanKill(c *gc.C) {
+	workertest.CleanKill(c, s.worker)
+}
+
+func (s *WorkerSuite) TestAddRemoveServers(c *gc.C) {
+	// Add machine-1.
+	s.publishDetails(c, apiserver.Details{
+		Servers: map[string]apiserver.APIServer{
+			"0": {ID: "0"},
+			"1": {ID: "1"},
+		},
+	})
+	s.waitConfiguration(c, []raft.Server{{
+		ID:       "machine-0",
+		Address:  "machine-0",
+		Suffrage: raft.Voter,
+	}, {
+		ID:       "machine-1",
+		Address:  "machine-1",
+		Suffrage: raft.Voter,
+	}})
+
+	// Remove machine-1.
+	s.publishDetails(c, apiserver.Details{
+		Servers: map[string]apiserver.APIServer{
+			"0": {ID: "0"},
+		},
+	})
+	s.waitConfiguration(c, []raft.Server{{
+		ID:       "machine-0",
+		Address:  "machine-0",
+		Suffrage: raft.Voter,
+	}})
+}
+
+func (s *WorkerSuite) publishDetails(c *gc.C, details apiserver.Details) {
+	received, err := s.hub.Publish(apiserver.DetailsTopic, details)
+	c.Assert(err, jc.ErrorIsNil)
+	select {
+	case <-received:
+	case <-time.After(coretesting.LongWait):
+		c.Fatal("timed out waiting for details to be received")
+	}
+}
+
+func (s *WorkerSuite) waitConfiguration(c *gc.C, expectedServers []raft.Server) {
+	var configuration raft.Configuration
+	for a := coretesting.LongAttempt.Start(); a.Next(); {
+		f := s.Raft.GetConfiguration()
+		c.Assert(f.Error(), jc.ErrorIsNil)
+		configuration = f.Configuration()
+		if len(configuration.Servers) == len(expectedServers) {
+			break
+		}
+	}
+	c.Assert(configuration.Servers, jc.SameContents, expectedServers)
+}

--- a/worker/raft/raftclusterer/worker_test.go
+++ b/worker/raft/raftclusterer/worker_test.go
@@ -4,6 +4,7 @@
 package raftclusterer_test
 
 import (
+	"reflect"
 	"time"
 
 	"github.com/hashicorp/raft"
@@ -95,34 +96,186 @@ func (s *WorkerSuite) TestCleanKill(c *gc.C) {
 }
 
 func (s *WorkerSuite) TestAddRemoveServers(c *gc.C) {
-	// Add machine-1.
+	// Create 4 servers: machine-0, machine-1, machine-2,
+	// and machine-3, where all servers can connect
+	// bidirectionally.
+	raft1, _, transport1, _, _ := s.NewRaft(c, "machine-1", &rafttest.FSM{})
+	_, _, transport2, _, _ := s.NewRaft(c, "machine-2", &rafttest.FSM{})
+	_, _, transport3, _, _ := s.NewRaft(c, "machine-3", &rafttest.FSM{})
+	transports := []raft.LoopbackTransport{s.Transport, transport1, transport2, transport3}
+	for _, t1 := range transports {
+		for _, t2 := range transports {
+			if t1 == t2 {
+				continue
+			}
+			t1.Connect(t2.LocalAddr(), t2)
+		}
+	}
+
+	machine0Address := string(s.Transport.LocalAddr())
+	machine1Address := string(transport1.LocalAddr())
+	machine2Address := string(transport2.LocalAddr())
+	machine3Address := string(transport3.LocalAddr())
+
+	raft1Observations := make(chan raft.Observation, 1)
+	raft1Observer := raft.NewObserver(raft1Observations, false, func(o *raft.Observation) bool {
+		_, ok := o.Data.(raft.LeaderObservation)
+		return ok
+	})
+	raft1.RegisterObserver(raft1Observer)
+	defer raft1.DeregisterObserver(raft1Observer)
+
+	// Add machine-1, machine-2.
 	s.publishDetails(c, apiserver.Details{
 		Servers: map[string]apiserver.APIServer{
-			"0": {ID: "0"},
-			"1": {ID: "1"},
+			"0": {
+				ID:              "0",
+				InternalAddress: machine0Address,
+			},
+			"1": {
+				ID:              "1",
+				InternalAddress: machine1Address,
+			},
+			"2": {
+				ID:              "2",
+				InternalAddress: machine2Address,
+			},
 		},
 	})
-	s.waitConfiguration(c, []raft.Server{{
+	waitConfiguration(c, s.Raft, []raft.Server{{
 		ID:       "machine-0",
-		Address:  "machine-0",
+		Address:  raft.ServerAddress(machine0Address),
 		Suffrage: raft.Voter,
 	}, {
 		ID:       "machine-1",
-		Address:  "machine-1",
+		Address:  raft.ServerAddress(machine1Address),
+		Suffrage: raft.Voter,
+	}, {
+		ID:       "machine-2",
+		Address:  raft.ServerAddress(machine2Address),
 		Suffrage: raft.Voter,
 	}})
 
-	// Remove machine-1.
+	select {
+	case <-raft1Observations:
+		c.Assert(raft1.Leader(), gc.Equals, s.Transport.LocalAddr())
+	case <-time.After(coretesting.LongWait):
+		c.Fatal("timed out waiting for leader observation")
+	}
+
+	// Remove machine-1, add machine-3.
 	s.publishDetails(c, apiserver.Details{
 		Servers: map[string]apiserver.APIServer{
-			"0": {ID: "0"},
+			"0": {
+				ID:              "0",
+				InternalAddress: machine0Address,
+			},
+			"2": {
+				ID:              "2",
+				InternalAddress: machine2Address,
+			},
+			"3": {
+				ID:              "3",
+				InternalAddress: machine3Address,
+			},
 		},
 	})
-	s.waitConfiguration(c, []raft.Server{{
+	waitConfiguration(c, raft1, []raft.Server{{
 		ID:       "machine-0",
-		Address:  "machine-0",
+		Address:  raft.ServerAddress(machine0Address),
+		Suffrage: raft.Voter,
+	}, {
+		ID:       "machine-2",
+		Address:  raft.ServerAddress(machine2Address),
+		Suffrage: raft.Voter,
+	}, {
+		ID:       "machine-3",
+		Address:  raft.ServerAddress(machine3Address),
 		Suffrage: raft.Voter,
 	}})
+}
+
+func (s *WorkerSuite) TestChangeLocalServer(c *gc.C) {
+	// Create 3 servers, machine-0, machine-1, and machine-2.
+	// The latter two servers can communicate bidirectionally;
+	// only machine-0 can dial the others, and not the other
+	// way around.
+	raft1, _, transport1, _, _ := s.NewRaft(c, "machine-1", &rafttest.FSM{})
+	_, _, transport2, _, _ := s.NewRaft(c, "machine-2", &rafttest.FSM{})
+	s.Transport.Connect(transport1.LocalAddr(), transport1)
+	s.Transport.Connect(transport2.LocalAddr(), transport2)
+	transport1.Connect(transport2.LocalAddr(), transport2)
+	transport2.Connect(transport1.LocalAddr(), transport1)
+	machine1Address := string(transport1.LocalAddr())
+	machine2Address := string(transport2.LocalAddr())
+
+	raft1Observations := make(chan raft.Observation, 10)
+	raft1Observer := raft.NewObserver(raft1Observations, false, func(o *raft.Observation) bool {
+		_, ok := o.Data.(raft.LeaderObservation)
+		return ok
+	})
+	raft1.RegisterObserver(raft1Observer)
+	defer close(raft1Observations)
+	defer raft1.DeregisterObserver(raft1Observer)
+
+	newLeaderElected := make(chan struct{})
+	go func() {
+		for {
+			select {
+			case _, ok := <-raft1Observations:
+				if !ok {
+					return
+				}
+			}
+			leaderAddr := raft1.Leader()
+			if leaderAddr != "" && leaderAddr != s.Transport.LocalAddr() {
+				close(newLeaderElected)
+				return
+			}
+		}
+	}()
+
+	// Here we simulate "ensure-ha": machine-0's address will
+	// be updated to a non-localhost address, and two new
+	// servers are added.
+	//
+	// We add machine-1 and machine-2, and change machine-0's
+	// address. The new machines should be added first, and
+	// then machine-0 should be *removed* from the configuration,
+	// under the expectation that one of the new servers will
+	// become leader and add it back to the configuration with
+	// its new address.
+	s.publishDetails(c, apiserver.Details{
+		Servers: map[string]apiserver.APIServer{
+			"0": {
+				ID:              "0",
+				InternalAddress: "testing.invalid:1234",
+			},
+			"1": {
+				ID:              "1",
+				InternalAddress: machine1Address,
+			},
+			"2": {
+				ID:              "2",
+				InternalAddress: machine2Address,
+			},
+		},
+	})
+	waitConfiguration(c, raft1, []raft.Server{{
+		ID:       "machine-1",
+		Address:  raft.ServerAddress(machine1Address),
+		Suffrage: raft.Voter,
+	}, {
+		ID:       "machine-2",
+		Address:  raft.ServerAddress(machine2Address),
+		Suffrage: raft.Voter,
+	}})
+
+	select {
+	case <-newLeaderElected:
+	case <-time.After(coretesting.LongWait):
+		c.Fatal("timed out waiting for leader observation")
+	}
 }
 
 func (s *WorkerSuite) publishDetails(c *gc.C, details apiserver.Details) {
@@ -135,14 +288,14 @@ func (s *WorkerSuite) publishDetails(c *gc.C, details apiserver.Details) {
 	}
 }
 
-func (s *WorkerSuite) waitConfiguration(c *gc.C, expectedServers []raft.Server) {
+func waitConfiguration(c *gc.C, r *raft.Raft, expectedServers []raft.Server) {
 	var configuration raft.Configuration
 	for a := coretesting.LongAttempt.Start(); a.Next(); {
-		f := s.Raft.GetConfiguration()
+		f := r.GetConfiguration()
 		c.Assert(f.Error(), jc.ErrorIsNil)
 		configuration = f.Configuration()
-		if len(configuration.Servers) == len(expectedServers) {
-			break
+		if reflect.DeepEqual(configuration.Servers, expectedServers) {
+			return
 		}
 	}
 	c.Assert(configuration.Servers, jc.SameContents, expectedServers)

--- a/worker/raft/raftclusterer/worker_test.go
+++ b/worker/raft/raftclusterer/worker_test.go
@@ -4,7 +4,6 @@
 package raftclusterer_test
 
 import (
-	"reflect"
 	"time"
 
 	"github.com/hashicorp/raft"
@@ -142,7 +141,7 @@ func (s *WorkerSuite) TestAddRemoveServers(c *gc.C) {
 			},
 		},
 	})
-	waitConfiguration(c, s.Raft, []raft.Server{{
+	rafttest.CheckConfiguration(c, s.Raft, []raft.Server{{
 		ID:       "machine-0",
 		Address:  raft.ServerAddress(machine0Address),
 		Suffrage: raft.Voter,
@@ -180,7 +179,7 @@ func (s *WorkerSuite) TestAddRemoveServers(c *gc.C) {
 			},
 		},
 	})
-	waitConfiguration(c, raft1, []raft.Server{{
+	rafttest.CheckConfiguration(c, raft1, []raft.Server{{
 		ID:       "machine-0",
 		Address:  raft.ServerAddress(machine0Address),
 		Suffrage: raft.Voter,
@@ -258,7 +257,7 @@ func (s *WorkerSuite) TestChangeLocalServer(c *gc.C) {
 			},
 		},
 	})
-	waitConfiguration(c, raft1, []raft.Server{{
+	rafttest.CheckConfiguration(c, raft1, []raft.Server{{
 		ID:       "machine-0",
 		Address:  "testing.invalid:1234",
 		Suffrage: raft.Voter,
@@ -286,23 +285,4 @@ func (s *WorkerSuite) publishDetails(c *gc.C, details apiserver.Details) {
 	case <-time.After(coretesting.LongWait):
 		c.Fatal("timed out waiting for details to be received")
 	}
-}
-
-func waitConfiguration(c *gc.C, r *raft.Raft, expectedServers []raft.Server) {
-	var configuration raft.Configuration
-	for a := coretesting.LongAttempt.Start(); a.Next(); {
-		f := r.GetConfiguration()
-		c.Assert(f.Error(), jc.ErrorIsNil)
-		configuration = f.Configuration()
-		if reflect.DeepEqual(configuration.Servers, expectedServers) {
-			return
-		}
-	}
-	c.Assert(
-		configuration.Servers, jc.SameContents, expectedServers,
-		gc.Commentf(
-			"waited %s and still did not see the expected configuration",
-			coretesting.LongAttempt.Total,
-		),
-	)
 }

--- a/worker/raft/raftflag/flag.go
+++ b/worker/raft/raftflag/flag.go
@@ -1,0 +1,103 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package raftflag
+
+import (
+	"github.com/hashicorp/raft"
+	"github.com/juju/errors"
+	worker "gopkg.in/juju/worker.v1"
+
+	"github.com/juju/juju/worker/catacomb"
+)
+
+// Config holds a raftflag.Worker's dependencies and resources.
+type Config struct {
+	Raft *raft.Raft
+}
+
+// Validate returns an error if the config cannot be expected to run a
+// raftflag.Worker.
+func (config Config) Validate() error {
+	if config.Raft == nil {
+		return errors.NotValidf("nil Raft")
+	}
+	return nil
+}
+
+// ErrRefresh indicates that the flag's Check result is no longer valid,
+// and a new raftflag.Worker must be started to get a valid result.
+var ErrRefresh = errors.New("raft leadership changed, restart worker")
+
+// Worker implements worker.Worker and util.Flag, representing
+// controller ownership of a model, such that the Flag's validity is
+// tied to the Worker's lifetime.
+type Worker struct {
+	catacomb catacomb.Catacomb
+	config   Config
+	leader   bool
+}
+
+func NewWorker(config Config) (worker.Worker, error) {
+	if err := config.Validate(); err != nil {
+		return nil, errors.Trace(err)
+	}
+	flag := &Worker{
+		config: config,
+		leader: check(config.Raft),
+	}
+	if err := catacomb.Invoke(catacomb.Plan{
+		Site: &flag.catacomb,
+		Work: flag.loop,
+	}); err != nil {
+		return nil, errors.Trace(err)
+	}
+	return flag, nil
+}
+
+// Kill is part of the worker.Worker interface.
+func (flag *Worker) Kill() {
+	flag.catacomb.Kill(nil)
+}
+
+// Wait is part of the worker.Worker interface.
+func (flag *Worker) Wait() error {
+	return flag.catacomb.Wait()
+}
+
+// Check is part of the util.Flag interface.
+//
+// Check returns true if the flag indicates that the controller agent is
+// the current raft leader.
+//
+// The validity of this result is tied to the lifetime of the Worker;
+// once the worker has stopped, no inferences may be drawn from any Check
+// result.
+func (flag *Worker) Check() bool {
+	return flag.leader
+}
+
+func (flag *Worker) loop() error {
+	ch := make(chan raft.Observation, 1)
+	or := raft.NewObserver(ch, false, func(o *raft.Observation) bool {
+		_, ok := o.Data.(raft.RaftState)
+		return ok
+	})
+	flag.config.Raft.RegisterObserver(or)
+	defer flag.config.Raft.DeregisterObserver(or)
+
+	for {
+		select {
+		case <-flag.catacomb.Dying():
+			return flag.catacomb.ErrDying()
+		case <-ch:
+			if check(flag.config.Raft) != flag.leader {
+				return ErrRefresh
+			}
+		}
+	}
+}
+
+func check(r *raft.Raft) bool {
+	return r.State() == raft.Leader
+}

--- a/worker/raft/raftflag/flag.go
+++ b/worker/raft/raftflag/flag.go
@@ -6,10 +6,13 @@ package raftflag
 import (
 	"github.com/hashicorp/raft"
 	"github.com/juju/errors"
+	"github.com/juju/loggo"
 	worker "gopkg.in/juju/worker.v1"
 
 	"github.com/juju/juju/worker/catacomb"
 )
+
+var logger = loggo.GetLogger("juju.worker.raft.raftflag")
 
 // Config holds a raftflag.Worker's dependencies and resources.
 type Config struct {
@@ -91,6 +94,7 @@ func (flag *Worker) loop() error {
 		case <-flag.catacomb.Dying():
 			return flag.catacomb.ErrDying()
 		case <-ch:
+			logger.Debugf("raft state changed: %s", flag.config.Raft.State())
 			if check(flag.config.Raft) != flag.leader {
 				return ErrRefresh
 			}

--- a/worker/raft/raftflag/flag_test.go
+++ b/worker/raft/raftflag/flag_test.go
@@ -1,0 +1,134 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package raftflag_test
+
+import (
+	"github.com/hashicorp/raft"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	worker "gopkg.in/juju/worker.v1"
+
+	"github.com/juju/juju/cmd/jujud/agent/engine"
+	"github.com/juju/juju/worker/raft/raftflag"
+	"github.com/juju/juju/worker/raft/rafttest"
+	"github.com/juju/juju/worker/workertest"
+)
+
+type workerFixture struct {
+	rafttest.RaftFixture
+	config raftflag.Config
+}
+
+func (s *workerFixture) SetUpTest(c *gc.C) {
+	s.FSM = &rafttest.FSM{}
+	s.RaftFixture.SetUpTest(c)
+	s.config = raftflag.Config{
+		Raft: s.Raft,
+	}
+}
+
+type WorkerValidationSuite struct {
+	workerFixture
+}
+
+var _ = gc.Suite(&WorkerValidationSuite{})
+
+func (s *WorkerValidationSuite) TestValidateErrors(c *gc.C) {
+	type test struct {
+		f      func(*raftflag.Config)
+		expect string
+	}
+	tests := []test{{
+		func(cfg *raftflag.Config) { cfg.Raft = nil },
+		"nil Raft not valid",
+	}}
+	for i, test := range tests {
+		c.Logf("test #%d (%s)", i, test.expect)
+		s.testValidateError(c, test.f, test.expect)
+	}
+}
+
+func (s *WorkerValidationSuite) testValidateError(c *gc.C, f func(*raftflag.Config), expect string) {
+	config := s.config
+	f(&config)
+	w, err := raftflag.NewWorker(config)
+	if !c.Check(err, gc.NotNil) {
+		workertest.DirtyKill(c, w)
+		return
+	}
+	c.Check(w, gc.IsNil)
+	c.Check(err, gc.ErrorMatches, expect)
+}
+
+type WorkerSuite struct {
+	workerFixture
+	worker worker.Worker
+	flag   engine.Flag
+}
+
+var _ = gc.Suite(&WorkerSuite{})
+
+func (s *WorkerSuite) SetUpTest(c *gc.C) {
+	s.workerFixture.SetUpTest(c)
+	worker, err := raftflag.NewWorker(s.config)
+	c.Assert(err, jc.ErrorIsNil)
+	s.AddCleanup(func(c *gc.C) {
+		workertest.DirtyKill(c, worker)
+	})
+	s.worker = worker
+	s.flag = worker.(engine.Flag)
+}
+
+func (s *WorkerSuite) TestCleanKill(c *gc.C) {
+	workertest.CleanKill(c, s.worker)
+}
+
+func (s *WorkerSuite) TestCheckLeader(c *gc.C) {
+	c.Assert(s.Raft.VerifyLeader().Error(), jc.ErrorIsNil)
+	c.Assert(s.flag.Check(), jc.IsTrue)
+}
+
+func (s *WorkerSuite) TestErrRefresh(c *gc.C) {
+	addr, transport := raft.NewInmemTransport("machine-1")
+	defer transport.Close()
+	s.Transport.Connect(addr, transport)
+	defer s.Transport.Disconnect(addr)
+
+	store := raft.NewInmemStore()
+	snapshotStore := raft.NewInmemSnapshotStore()
+	raftConfig := s.DefaultConfig()
+	raftConfig.LocalID = raft.ServerID(string(addr))
+	fsm := &rafttest.FSM{}
+	raft2, err := raft.NewRaft(raftConfig, fsm, store, store, snapshotStore, transport)
+	c.Assert(err, jc.ErrorIsNil)
+	defer func() {
+		f := raft2.Shutdown()
+		c.Assert(f.Error(), jc.ErrorIsNil)
+	}()
+	f := s.Raft.AddVoter("machine-1", addr, 0, 0)
+	c.Assert(f.Error(), jc.ErrorIsNil)
+
+	// Start a new raftflag worker for the second raft.
+	config2 := s.config
+	config2.Raft = raft2
+	worker2, err := raftflag.NewWorker(config2)
+	c.Assert(err, jc.ErrorIsNil)
+	defer func() {
+		workertest.DirtyKill(c, worker2)
+	}()
+	flag2 := worker2.(engine.Flag)
+	c.Assert(flag2.Check(), jc.IsFalse)
+
+	// Demote the original node, causing the new node to
+	// become the leader.
+	f = s.Raft.DemoteVoter(raft.ServerID(string(s.Transport.LocalAddr())), 0, 0)
+	c.Assert(f.Error(), jc.ErrorIsNil)
+
+	// When the raft node toggles between leader/follower,
+	// then the worker will exit with ErrRefresh.
+	err = s.worker.Wait()
+	c.Assert(err, gc.Equals, raftflag.ErrRefresh)
+	err = worker2.Wait()
+	c.Assert(err, gc.Equals, raftflag.ErrRefresh)
+}

--- a/worker/raft/raftflag/manifold.go
+++ b/worker/raft/raftflag/manifold.go
@@ -1,0 +1,66 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package raftflag
+
+import (
+	"github.com/hashicorp/raft"
+	"github.com/juju/errors"
+	worker "gopkg.in/juju/worker.v1"
+
+	"github.com/juju/juju/cmd/jujud/agent/engine"
+	"github.com/juju/juju/worker/dependency"
+)
+
+// ManifoldConfig holds the information necessary to run a raftflag.Worker in
+// a dependency.Engine.
+type ManifoldConfig struct {
+	RaftName string
+
+	NewWorker func(Config) (worker.Worker, error)
+}
+
+func (config ManifoldConfig) start(context dependency.Context) (worker.Worker, error) {
+	var r *raft.Raft
+	if err := context.Get(config.RaftName, &r); err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	flag, err := config.NewWorker(Config{Raft: r})
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return wrappedWorker{flag}, nil
+}
+
+// wrappedWorker wraps a flag worker, translating ErrRefresh into
+// dependency.ErrBounce.
+type wrappedWorker struct {
+	worker.Worker
+}
+
+// Wait is part of the worker.Worker interface.
+func (w wrappedWorker) Wait() error {
+	err := w.Worker.Wait()
+	if err == ErrRefresh {
+		err = dependency.ErrBounce
+	}
+	return err
+}
+
+// Manifold returns a dependency.Manifold that will run a FlagWorker and
+// expose it to clients as a engine.Flag resource.
+func Manifold(config ManifoldConfig) dependency.Manifold {
+	return dependency.Manifold{
+		Inputs: []string{
+			config.RaftName,
+		},
+		Start: config.start,
+		Output: func(in worker.Worker, out interface{}) error {
+			if w, ok := in.(wrappedWorker); ok {
+				in = w.Worker
+			}
+			return engine.FlagOutput(in, out)
+		},
+	}
+}

--- a/worker/raft/raftflag/manifold_test.go
+++ b/worker/raft/raftflag/manifold_test.go
@@ -1,0 +1,122 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package raftflag_test
+
+import (
+	"github.com/hashicorp/raft"
+	"github.com/juju/errors"
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	worker "gopkg.in/juju/worker.v1"
+
+	"github.com/juju/juju/cmd/jujud/agent/engine"
+	"github.com/juju/juju/worker/dependency"
+	dt "github.com/juju/juju/worker/dependency/testing"
+	"github.com/juju/juju/worker/raft/raftflag"
+)
+
+type ManifoldSuite struct {
+	testing.IsolationSuite
+
+	manifold dependency.Manifold
+	context  dependency.Context
+	raft     *raft.Raft
+	worker   *mockWorker
+	stub     testing.Stub
+}
+
+var _ = gc.Suite(&ManifoldSuite{})
+
+func (s *ManifoldSuite) SetUpTest(c *gc.C) {
+	s.IsolationSuite.SetUpTest(c)
+
+	s.raft = &raft.Raft{}
+	s.worker = &mockWorker{}
+	s.stub.ResetCalls()
+
+	s.context = s.newContext(nil)
+	s.manifold = raftflag.Manifold(raftflag.ManifoldConfig{
+		RaftName:  "raft",
+		NewWorker: s.newWorker,
+	})
+}
+
+func (s *ManifoldSuite) newContext(overlay map[string]interface{}) dependency.Context {
+	resources := map[string]interface{}{
+		"raft": s.raft,
+	}
+	for k, v := range overlay {
+		resources[k] = v
+	}
+	return dt.StubContext(nil, resources)
+}
+
+func (s *ManifoldSuite) newWorker(config raftflag.Config) (worker.Worker, error) {
+	s.stub.MethodCall(s, "NewWorker", config)
+	if err := s.stub.NextErr(); err != nil {
+		return nil, err
+	}
+	return s.worker, nil
+}
+
+var expectedInputs = []string{"raft"}
+
+func (s *ManifoldSuite) TestInputs(c *gc.C) {
+	c.Assert(s.manifold.Inputs, jc.SameContents, expectedInputs)
+}
+
+func (s *ManifoldSuite) TestMissingInputs(c *gc.C) {
+	for _, input := range expectedInputs {
+		context := s.newContext(map[string]interface{}{
+			input: dependency.ErrMissing,
+		})
+		_, err := s.manifold.Start(context)
+		c.Assert(errors.Cause(err), gc.Equals, dependency.ErrMissing)
+	}
+}
+
+func (s *ManifoldSuite) TestStart(c *gc.C) {
+	s.startWorkerClean(c)
+
+	s.stub.CheckCallNames(c, "NewWorker")
+	args := s.stub.Calls()[0].Args
+	c.Assert(args, gc.HasLen, 1)
+	c.Assert(args[0], jc.DeepEquals, raftflag.Config{
+		Raft: s.raft,
+	})
+}
+
+func (s *ManifoldSuite) TestErrRefresh(c *gc.C) {
+	w := s.startWorkerClean(c)
+
+	s.worker.SetErrors(raftflag.ErrRefresh)
+	err := w.Wait()
+	c.Assert(err, gc.Equals, dependency.ErrBounce)
+}
+
+func (s *ManifoldSuite) TestOutput(c *gc.C) {
+	s.startWorkerClean(c)
+
+	var flag engine.Flag
+	err := s.manifold.Output(s.worker, &flag)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(flag, gc.Equals, s.worker)
+}
+
+func (s *ManifoldSuite) startWorkerClean(c *gc.C) worker.Worker {
+	w, err := s.manifold.Start(s.context)
+	c.Assert(err, jc.ErrorIsNil)
+	return w
+}
+
+type mockWorker struct {
+	testing.Stub
+	worker.Worker
+	engine.Flag
+}
+
+func (w *mockWorker) Wait() error {
+	return w.NextErr()
+}

--- a/worker/raft/raftflag/package_test.go
+++ b/worker/raft/raftflag/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package raftflag_test
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func TestPackage(t *testing.T) {
+	gc.TestingT(t)
+}

--- a/worker/raft/rafttest/fixtures.go
+++ b/worker/raft/rafttest/fixtures.go
@@ -39,15 +39,8 @@ func (s *RaftFixture) SetUpTest(c *gc.C) {
 	s.Transport = transport
 	s.AddCleanup(func(*gc.C) { s.Transport.Close() })
 
-	raftConfig := raft.DefaultConfig()
-	raftConfig.HeartbeatTimeout = 100 * time.Millisecond
-	raftConfig.ElectionTimeout = raftConfig.HeartbeatTimeout
-	raftConfig.LeaderLeaseTimeout = raftConfig.HeartbeatTimeout
+	raftConfig := s.DefaultConfig()
 	raftConfig.LocalID = raft.ServerID(string(addr))
-	raftConfig.Logger = log.New(&raftutil.LoggoWriter{
-		loggo.GetLogger("juju.worker.raft.raftclusterer_test"),
-		loggo.DEBUG,
-	}, "", 0)
 
 	r, err := raft.NewRaft(raftConfig, s.FSM, s.Store, s.Store, s.SnapshotStore, s.Transport)
 	c.Assert(err, jc.ErrorIsNil)
@@ -68,4 +61,16 @@ func (s *RaftFixture) SetUpTest(c *gc.C) {
 	case <-time.After(coretesting.LongWait):
 		c.Fatal("timed out waiting for raft leadership")
 	}
+}
+
+func (s *RaftFixture) DefaultConfig() *raft.Config {
+	raftConfig := raft.DefaultConfig()
+	raftConfig.HeartbeatTimeout = 100 * time.Millisecond
+	raftConfig.ElectionTimeout = raftConfig.HeartbeatTimeout
+	raftConfig.LeaderLeaseTimeout = raftConfig.HeartbeatTimeout
+	raftConfig.Logger = log.New(&raftutil.LoggoWriter{
+		loggo.GetLogger("juju.worker.raft.raftclusterer_test"),
+		loggo.DEBUG,
+	}, "", 0)
+	return raftConfig
 }

--- a/worker/raft/rafttest/fixtures.go
+++ b/worker/raft/rafttest/fixtures.go
@@ -23,6 +23,7 @@ type RaftFixture struct {
 	testing.IsolationSuite
 
 	FSM           raft.FSM
+	Config        *raft.Config
 	Transport     *raft.InmemTransport
 	Store         *raft.InmemStore
 	SnapshotStore *raft.InmemSnapshotStore
@@ -33,43 +34,52 @@ func (s *RaftFixture) SetUpTest(c *gc.C) {
 	s.IsolationSuite.SetUpTest(c)
 	c.Assert(s.FSM, gc.NotNil, gc.Commentf("FSM must be set by embedding test suite"))
 
-	s.Store = raft.NewInmemStore()
-	s.SnapshotStore = raft.NewInmemSnapshotStore()
-	addr, transport := raft.NewInmemTransport("machine-0")
-	s.Transport = transport
-	s.AddCleanup(func(*gc.C) { s.Transport.Close() })
-
-	raftConfig := s.DefaultConfig()
-	raftConfig.LocalID = raft.ServerID(string(addr))
-
-	r, err := raft.NewRaft(raftConfig, s.FSM, s.Store, s.Store, s.SnapshotStore, s.Transport)
-	c.Assert(err, jc.ErrorIsNil)
-	s.AddCleanup(func(c *gc.C) {
-		f := r.Shutdown()
-		c.Assert(f.Error(), jc.ErrorIsNil)
-	})
-	s.Raft = r
-
+	s.Raft, s.Config, s.Transport, s.Store, s.SnapshotStore = s.NewRaft(c, "machine-0", s.FSM)
 	c.Assert(s.Raft.BootstrapCluster(raft.Configuration{
 		Servers: []raft.Server{{
-			ID:      raftConfig.LocalID,
-			Address: addr,
+			ID:      s.Config.LocalID,
+			Address: s.Transport.LocalAddr(),
 		}},
 	}).Error(), jc.ErrorIsNil)
 	select {
-	case <-s.Raft.LeaderCh():
+	case leader := <-s.Raft.LeaderCh():
+		c.Assert(leader, jc.IsTrue)
 	case <-time.After(coretesting.LongWait):
 		c.Fatal("timed out waiting for raft leadership")
 	}
 }
 
-func (s *RaftFixture) DefaultConfig() *raft.Config {
+func (s *RaftFixture) NewRaft(c *gc.C, id raft.ServerID, fsm raft.FSM) (
+	*raft.Raft,
+	*raft.Config,
+	*raft.InmemTransport,
+	*raft.InmemStore,
+	*raft.InmemSnapshotStore,
+) {
+	_, transport := raft.NewInmemTransport("")
+	s.AddCleanup(func(*gc.C) { transport.Close() })
+
+	store := raft.NewInmemStore()
+	snapshotStore := raft.NewInmemSnapshotStore()
+	config := s.DefaultConfig(id)
+
+	r, err := raft.NewRaft(config, fsm, store, store, snapshotStore, transport)
+	c.Assert(err, jc.ErrorIsNil)
+	s.AddCleanup(func(c *gc.C) {
+		f := r.Shutdown()
+		c.Assert(f.Error(), jc.ErrorIsNil)
+	})
+	return r, config, transport, store, snapshotStore
+}
+
+func (s *RaftFixture) DefaultConfig(id raft.ServerID) *raft.Config {
 	raftConfig := raft.DefaultConfig()
+	raftConfig.LocalID = id
 	raftConfig.HeartbeatTimeout = 100 * time.Millisecond
 	raftConfig.ElectionTimeout = raftConfig.HeartbeatTimeout
 	raftConfig.LeaderLeaseTimeout = raftConfig.HeartbeatTimeout
 	raftConfig.Logger = log.New(&raftutil.LoggoWriter{
-		loggo.GetLogger("juju.worker.raft.raftclusterer_test"),
+		loggo.GetLogger("juju.worker.raft.raftclusterer_test_" + string(id)),
 		loggo.DEBUG,
 	}, "", 0)
 	return raftConfig

--- a/worker/raft/rafttest/helpers.go
+++ b/worker/raft/rafttest/helpers.go
@@ -1,0 +1,35 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package rafttest
+
+import (
+	"reflect"
+
+	"github.com/hashicorp/raft"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	coretesting "github.com/juju/juju/testing"
+)
+
+// CheckConfiguration waits some time for the Raft
+// to have the expected server configuration.
+func CheckConfiguration(c *gc.C, r *raft.Raft, expectedServers []raft.Server) {
+	var configuration raft.Configuration
+	for a := coretesting.LongAttempt.Start(); a.Next(); {
+		f := r.GetConfiguration()
+		c.Assert(f.Error(), jc.ErrorIsNil)
+		configuration = f.Configuration()
+		if reflect.DeepEqual(configuration.Servers, expectedServers) {
+			return
+		}
+	}
+	c.Assert(
+		configuration.Servers, jc.SameContents, expectedServers,
+		gc.Commentf(
+			"waited %s and still did not see the expected configuration",
+			coretesting.LongAttempt.Total,
+		),
+	)
+}

--- a/worker/raft/reporter.go
+++ b/worker/raft/reporter.go
@@ -1,0 +1,53 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package raft
+
+import (
+	humanize "github.com/dustin/go-humanize"
+	"github.com/hashicorp/raft"
+	"github.com/juju/juju/worker/dependency"
+)
+
+// Report is part of the dependency.Reporter interface.
+func (w *Worker) Report() map[string]interface{} {
+	out := make(map[string]interface{})
+	r, err := w.Raft()
+	if err != nil {
+		out[dependency.KeyError] = err.Error()
+		return out
+	}
+
+	state := r.State()
+	out[dependency.KeyState] = state.String()
+	out["leader"] = r.Leader()
+	out["index"] = map[string]interface{}{
+		"applied": r.AppliedIndex(),
+		"last":    r.LastIndex(),
+	}
+	if state != raft.Leader {
+		lastContact := "never"
+		if t := r.LastContact(); !t.IsZero() {
+			lastContact = humanize.Time(t)
+		}
+		out["last-contact"] = lastContact
+	}
+
+	config := make(map[string]interface{})
+	future := r.GetConfiguration()
+	if err := future.Error(); err != nil {
+		config[dependency.KeyError] = err.Error()
+	} else {
+		servers := make(map[string]interface{})
+		for _, server := range future.Configuration().Servers {
+			servers[string(server.ID)] = map[string]interface{}{
+				"suffrage": server.Suffrage.String(),
+				"address":  server.Address,
+			}
+		}
+		config["servers"] = servers
+	}
+	out["cluster-config"] = config
+
+	return out
+}

--- a/worker/raft/worker.go
+++ b/worker/raft/worker.go
@@ -28,13 +28,9 @@ const (
 
 	// bootstrapAddress is the raft server address
 	// configured for the bootstrap node. This address
-	// will (must) be used at least until the cluster
-	// is grown beyond a single node.
-	//
-	// The .localhost label ensures that the address
-	// will not resolve globally. We do not require
-	// or expect the address to be resolvable at all.
-	bootstrapAddress raft.ServerAddress = "juju.localhost"
+	// will be replaced once the raftclusterer worker
+	// observes an address for the server.
+	bootstrapAddress raft.ServerAddress = "localhost"
 )
 
 var (

--- a/worker/raft/worker_test.go
+++ b/worker/raft/worker_test.go
@@ -209,3 +209,15 @@ func (s *WorkerSuite) TestRestoreSnapshot(c *gc.C) {
 		[]byte("command1"),
 	})
 }
+
+func (s *WorkerSuite) TestStartStop(c *gc.C) {
+	workertest.CleanKill(c, s.worker)
+}
+
+func (s *WorkerSuite) TestShutdownRaftKillsWorker(c *gc.C) {
+	r := s.waitLeader(c)
+	c.Assert(r.Shutdown().Error(), jc.ErrorIsNil)
+
+	err := workertest.CheckKilled(c, s.worker)
+	c.Assert(err, gc.ErrorMatches, "raft shutdown")
+}

--- a/worker/raft/worker_test.go
+++ b/worker/raft/worker_test.go
@@ -67,12 +67,6 @@ func (s *WorkerValidationSuite) TestValidateErrors(c *gc.C) {
 	}, {
 		func(cfg *raft.Config) { cfg.Transport = nil },
 		"nil Transport not valid",
-	}, {
-		func(cfg *raft.Config) {
-			_, transport := coreraft.NewInmemTransport("321-enihcam")
-			cfg.Transport = transport
-		},
-		`transport local address "321-enihcam" not valid, expected "machine-123"`,
 	}}
 	for i, test := range tests {
 		c.Logf("test #%d (%s)", i, test.expect)
@@ -149,6 +143,18 @@ func (s *WorkerSuite) waitLeader(c *gc.C) *coreraft.Raft {
 		c.Fatal("timed out waiting for leadership change")
 	}
 	return r
+}
+
+func (s *WorkerSuite) TestBootstrapAddress(c *gc.C) {
+	r := s.waitLeader(c)
+
+	f := r.GetConfiguration()
+	c.Assert(f.Error(), jc.ErrorIsNil)
+	c.Assert(f.Configuration().Servers, jc.DeepEquals, []coreraft.Server{{
+		Suffrage: coreraft.Voter,
+		ID:       "machine-123",
+		Address:  "juju.localhost",
+	}})
 }
 
 func (s *WorkerSuite) TestRaft(c *gc.C) {

--- a/worker/raft/worker_test.go
+++ b/worker/raft/worker_test.go
@@ -153,7 +153,7 @@ func (s *WorkerSuite) TestBootstrapAddress(c *gc.C) {
 	c.Assert(f.Configuration().Servers, jc.DeepEquals, []coreraft.Server{{
 		Suffrage: coreraft.Voter,
 		ID:       "machine-123",
-		Address:  "juju.localhost",
+		Address:  "localhost",
 	}})
 }
 


### PR DESCRIPTION
## Description of change

Package worker/raft/raftclusterer contains a manifold and worker that maintains the Raft cluster configuration. The worker watches the central hub for API server address changes, and updates the cluster with the IDs and addresses of the servers. Cluster configuration is only updated when the cluster grows beyond a single node.

Package worker/raft/raftflag contains a manifold and worker that implements cmd/jujud/engine.Flag in terms of raft leadership. This can be used for implementing engine housing to run certain raft-related workers, e.g. raftclusterer, only on the leader.

worker/raft.Worker now implements worker/dependency.Reporter, reporting various details of the local raft node: its state (leader, follower, etc.), last/applied index values, leader ID, and cluster configuration.

## QA steps

None: the workers are not yet wired up.

(I have a branch which wires them all up, with a demo raft.FSM and worker that periodically applies a message.)

## Documentation changes

None.

## Bug reference

None.