### PR TITLE
worker/raft/rafttransport: introduce API server-based Raft transport

### DIFF
--- a/api/apiclient.go
+++ b/api/apiclient.go
@@ -829,14 +829,9 @@ func (d dialer) dial(_ <-chan struct{}) (io.Closer, error) {
 
 // dial1 makes a single dial attempt.
 func (d dialer) dial1() (jsoncodec.JSONConn, *tls.Config, error) {
-	tlsConfig := utils.SecureTLSConfig()
+	tlsConfig := NewTLSConfig(d.opts.certPool)
 	tlsConfig.InsecureSkipVerify = d.opts.InsecureSkipVerify
-	if d.opts.certPool != nil {
-		// We want to be specific here (rather than just using "anything").
-		// See commit 7fc118f015d8480dfad7831788e4b8c0432205e8 (PR 899).
-		tlsConfig.RootCAs = d.opts.certPool
-		tlsConfig.ServerName = "juju-apiserver"
-	} else {
+	if d.opts.certPool == nil {
 		tlsConfig.ServerName = d.serverName
 	}
 	conn, err := d.opts.DialWebsocket(d.ctx, d.urlStr, tlsConfig, d.ipAddr)
@@ -873,6 +868,20 @@ func (d dialer) dial1() (jsoncodec.JSONConn, *tls.Config, error) {
 		return nil, nil, errors.Trace(err)
 	}
 	return conn, tlsConfig, nil
+}
+
+// NewTLSConfig returns a new *tls.Config suitable for connecting to a Juju
+// API server. If certPool is non-nil, we use it as the config's RootCAs,
+// and the server name is set to "juju-apiserver".
+func NewTLSConfig(certPool *x509.CertPool) *tls.Config {
+	tlsConfig := utils.SecureTLSConfig()
+	if certPool != nil {
+		// We want to be specific here (rather than just using "anything").
+		// See commit 7fc118f015d8480dfad7831788e4b8c0432205e8 (PR 899).
+		tlsConfig.RootCAs = certPool
+		tlsConfig.ServerName = "juju-apiserver"
+	}
+	return tlsConfig
 }
 
 // isNumericHost reports whether the given host name is

--- a/api/http_test.go
+++ b/api/http_test.go
@@ -10,9 +10,9 @@ import (
 
 	"github.com/juju/errors"
 	"github.com/juju/httprequest"
-	"github.com/juju/names"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/names.v2"
 	"gopkg.in/macaroon-bakery.v1/httpbakery"
 	"gopkg.in/macaroon.v1"
 

--- a/apiserver/apiserverhttp/auth.go
+++ b/apiserver/apiserverhttp/auth.go
@@ -1,0 +1,16 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package apiserverhttp
+
+import "gopkg.in/juju/names.v2"
+
+// Auth is returned by Mux.Authenticate
+type Auth struct {
+	// Tag returns the tag of the authenticated entity.
+	Tag names.Tag
+
+	// Controller reports whether or not the authenticated
+	// entity is a controller agent.
+	Controller bool
+}

--- a/apiserver/apiserverhttp/mux.go
+++ b/apiserver/apiserverhttp/mux.go
@@ -1,0 +1,168 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package apiserverhttp
+
+import (
+	"context"
+	"net/http"
+	"sync"
+	"sync/atomic"
+	"unsafe"
+
+	"github.com/bmizerany/pat"
+	"github.com/juju/errors"
+	"gopkg.in/juju/names.v2"
+)
+
+type authKey struct{}
+
+var (
+	errNoAuthFunc = errors.New("no authentication handler found")
+)
+
+// Mux is a pattern-based HTTP muxer, based on top of
+// bmizerany/pat, adding support for dynamic registration
+// and deregistration of handlers. When a handler is
+// added or removed, the underlying pat mux is swapped
+// out with a new one.
+//
+// Adding and removing handlers is expensive: each of those
+// calls will create a new mux underneath. These operations
+// are not expected to be frequently occurring.
+type Mux struct {
+	// p is accessed atomically.
+	p *pat.PatternServeMux
+
+	auth authFunc
+
+	// mu protects added; added records the handlers
+	// added by AddHandler, so we can recreate the
+	// mux as necessary. The handlers are recorded
+	// in the order they are added, per method, as
+	// is done by pat.
+	mu    sync.Mutex
+	added map[string][]patternHandler
+}
+
+type authFunc func(*http.Request) (AuthInfo, error)
+
+type patternHandler struct {
+	pat string
+	h   http.Handler
+}
+
+// NewMux returns a new, empty mux.
+func NewMux(opts ...muxOption) *Mux {
+	m := &Mux{
+		p:     pat.New(),
+		added: make(map[string][]patternHandler),
+	}
+	for _, opt := range opts {
+		opt(m)
+	}
+	return m
+}
+
+type muxOption func(*Mux)
+
+// WithAuth returns a Mux constructor option function,
+// which, when applied to a Mux, will configure the Mux
+// to use the given function for authentication.
+func WithAuth(f func(req *http.Request) (AuthInfo, error)) muxOption {
+	return func(m *Mux) {
+		m.auth = f
+	}
+}
+
+// ServeHTTP is part of the http.Handler interface.
+//
+// ServeHTTP routes the request to a handler registered with
+// AddHandler, according to the rules defined by bmizerany/pat.
+func (m *Mux) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	p := (*pat.PatternServeMux)(atomic.LoadPointer((*unsafe.Pointer)(unsafe.Pointer(&m.p))))
+	if m.auth != nil {
+		ctx := r.Context()
+		ctx = context.WithValue(ctx, authKey{}, m.auth)
+		r = r.WithContext(ctx)
+	}
+	p.ServeHTTP(w, r)
+}
+
+// Authenticate checks the request for Juju entity credentials, and
+// returns the tag of the authenticated entity, or an error if the
+// authentication failed.
+//
+// The request must be one being handled by an http.Handler
+// registered with this mux's AddHandler.
+func (m *Mux) Authenticate(req *http.Request) (AuthInfo, error) {
+	ctx := req.Context()
+	if v := ctx.Value(authKey{}); v != nil {
+		f := v.(authFunc)
+		return f(req)
+	}
+	return AuthInfo{}, errNoAuthFunc
+}
+
+// AddHandler adds an http.Handler for the given method and pattern.
+// AddHandler returns an error if there already exists a handler for
+// the method and pattern.
+//
+// This is safe to call concurrently with m.ServeHTTP and m.RemoveHandler.
+func (m *Mux) AddHandler(meth, pat string, h http.Handler) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for _, ph := range m.added[meth] {
+		if ph.pat == pat {
+			return errors.AlreadyExistsf("handler for %s %q", meth, pat)
+		}
+	}
+	m.added[meth] = append(m.added[meth], patternHandler{pat, h})
+	m.recreate()
+	return nil
+}
+
+// RemoveHandler removes the http.Handler for the given method and pattern,
+// if any. If there is no handler registered with the method and pattern,
+// this is a no-op.
+//
+// This is safe to call concurrently with m.ServeHTTP and m.AddHandler.
+func (m *Mux) RemoveHandler(meth, pat string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	phs, ok := m.added[meth]
+	if !ok {
+		return
+	}
+	for i, ph := range phs {
+		if ph.pat != pat {
+			continue
+		}
+		head, tail := phs[:i], phs[i+1:]
+		m.added[meth] = append(head, tail...)
+		m.recreate()
+		return
+	}
+}
+
+func (m *Mux) recreate() {
+	p := pat.New()
+	for meth, phs := range m.added {
+		for _, ph := range phs {
+			p.Add(meth, ph.pat, ph.h)
+		}
+	}
+	atomic.StorePointer((*unsafe.Pointer)((unsafe.Pointer)(&m.p)), unsafe.Pointer(p))
+}
+
+// Auth is returned by Mux.Authenticate to identify the
+// authenticated entity.
+type AuthInfo struct {
+	// Tag holds the tag of the authenticated entity.
+	Tag names.Tag
+
+	// Controller holds a boolean value indicating
+	// whether or not the authenticated entity is a
+	// controller agent.
+	Controller bool
+}

--- a/apiserver/apiserverhttp/mux_bench_test.go
+++ b/apiserver/apiserverhttp/mux_bench_test.go
@@ -1,0 +1,49 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package apiserverhttp_test
+
+import (
+	"io"
+	"net/http"
+
+	"github.com/bmizerany/pat"
+	"github.com/juju/testing"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/apiserver/apiserverhttp"
+)
+
+type MuxBenchSuite struct {
+	testing.IsolationSuite
+}
+
+var _ = gc.Suite(&MuxBenchSuite{})
+
+func (s *MuxBenchSuite) BenchmarkMux(c *gc.C) {
+	mux := apiserverhttp.NewMux()
+	mux.AddHandler("GET", "/hello/:name", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	s.benchmarkMux(c, mux)
+}
+
+func (s *MuxBenchSuite) BenchmarkPatMux(c *gc.C) {
+	mux := pat.New()
+	mux.Add("GET", "/hello/:name", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	s.benchmarkMux(c, mux)
+}
+
+func (s *MuxBenchSuite) benchmarkMux(c *gc.C, mux http.Handler) {
+	req := newRequest("GET", "/hello/blake", nil)
+	c.ResetTimer()
+	for n := 0; n < c.N; n++ {
+		mux.ServeHTTP(nil, req)
+	}
+}
+
+func newRequest(method, urlStr string, body io.Reader) *http.Request {
+	req, err := http.NewRequest(method, urlStr, body)
+	if err != nil {
+		panic(err)
+	}
+	return req
+}

--- a/apiserver/apiserverhttp/mux_test.go
+++ b/apiserver/apiserverhttp/mux_test.go
@@ -1,0 +1,83 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package apiserverhttp_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/apiserver/apiserverhttp"
+)
+
+type MuxSuite struct {
+	testing.IsolationSuite
+	mux    *apiserverhttp.Mux
+	server *httptest.Server
+	client *http.Client
+}
+
+var _ = gc.Suite(&MuxSuite{})
+
+func (s *MuxSuite) SetUpTest(c *gc.C) {
+	s.IsolationSuite.SetUpTest(c)
+	s.mux = apiserverhttp.NewMux()
+	s.server = httptest.NewServer(s.mux)
+	s.client = s.server.Client()
+	s.AddCleanup(func(c *gc.C) {
+		s.server.Close()
+	})
+}
+
+func (s *MuxSuite) TestNotFound(c *gc.C) {
+	resp, err := s.client.Get(s.server.URL + "/")
+	c.Assert(err, jc.ErrorIsNil)
+	defer resp.Body.Close()
+
+	c.Assert(resp.StatusCode, gc.Equals, http.StatusNotFound)
+}
+
+func (s *MuxSuite) TestAddHandler(c *gc.C) {
+	err := s.mux.AddHandler("GET", "/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	c.Assert(err, jc.ErrorIsNil)
+
+	resp, err := s.client.Get(s.server.URL + "/")
+	c.Assert(err, jc.ErrorIsNil)
+	defer resp.Body.Close()
+
+	c.Assert(resp.StatusCode, gc.Equals, http.StatusOK)
+}
+
+func (s *MuxSuite) TestAddRemoveNotFound(c *gc.C) {
+	s.mux.AddHandler("GET", "/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	s.mux.RemoveHandler("GET", "/")
+
+	resp, err := s.client.Get(s.server.URL + "/")
+	c.Assert(err, jc.ErrorIsNil)
+	defer resp.Body.Close()
+
+	c.Assert(resp.StatusCode, gc.Equals, http.StatusNotFound)
+}
+
+func (s *MuxSuite) TestAddHandlerExists(c *gc.C) {
+	s.mux.AddHandler("GET", "/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	err := s.mux.AddHandler("GET", "/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	c.Assert(err, gc.ErrorMatches, `handler for GET "/" already exists`)
+}
+
+func (s *MuxSuite) TestRemoveHandlerMissing(c *gc.C) {
+	s.mux.RemoveHandler("GET", "/") // no-op
+}
+
+func (s *MuxSuite) TestMethodNotSupported(c *gc.C) {
+	s.mux.AddHandler("POST", "/", http.NotFoundHandler())
+	resp, err := s.client.Get(s.server.URL + "/")
+	c.Assert(err, jc.ErrorIsNil)
+	defer resp.Body.Close()
+
+	c.Assert(resp.StatusCode, gc.Equals, http.StatusMethodNotAllowed)
+}

--- a/apiserver/apiserverhttp/package_test.go
+++ b/apiserver/apiserverhttp/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package apiserverhttp_test
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func TestPackage(t *testing.T) {
+	gc.TestingT(t)
+}

--- a/worker/raft/rafttransport/dialer.go
+++ b/worker/raft/rafttransport/dialer.go
@@ -1,0 +1,80 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package rafttransport
+
+import (
+	"bufio"
+	"io/ioutil"
+	"net"
+	"net/http"
+	"net/url"
+	"time"
+
+	"github.com/hashicorp/raft"
+	"github.com/juju/errors"
+
+	"github.com/juju/juju/api"
+)
+
+// Dialer is a type that can be used for dialling a connection
+// connecting to a raft endpoint using the configured path, and
+// upgrading to a raft connection.
+type Dialer struct {
+	// APIInfo is used for authentication.
+	APIInfo *api.Info
+
+	// DialRaw returns a connection to the HTTP server
+	// that is serving the raft endpoint.
+	DialRaw func(raft.ServerAddress, time.Duration) (net.Conn, error)
+
+	// Path is the path of the raft HTTP endpoint.
+	Path string
+}
+
+// Dial dials a new raft network connection to the controller agent
+// with the tag identified by the given address.
+func (d *Dialer) Dial(addr raft.ServerAddress, timeout time.Duration) (net.Conn, error) {
+	request := &http.Request{
+		Method:     "GET",
+		URL:        &url.URL{Path: d.Path},
+		Proto:      "HTTP/1.1",
+		ProtoMajor: 1,
+		ProtoMinor: 1,
+		Header:     make(http.Header),
+	}
+	request.Header.Set("Upgrade", "raft")
+	if err := api.AuthHTTPRequest(request, d.APIInfo); err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	logger.Infof("dialing %s", addr)
+	conn, err := d.DialRaw(addr, timeout)
+	if err != nil {
+		return nil, errors.Annotate(err, "dial failed")
+	}
+
+	if err := request.Write(conn); err != nil {
+		return nil, errors.Annotate(err, "sending HTTP request failed")
+	}
+
+	response, err := http.ReadResponse(bufio.NewReader(conn), request)
+	if err != nil {
+		return nil, errors.Annotate(err, "failed to read response")
+	}
+	defer response.Body.Close()
+	if response.StatusCode != http.StatusSwitchingProtocols {
+		if body, err := ioutil.ReadAll(response.Body); err == nil && len(body) != 0 {
+			logger.Tracef("response: %s", body)
+		}
+		return nil, errors.Errorf(
+			"expected status code %d, got %d",
+			http.StatusSwitchingProtocols,
+			response.StatusCode,
+		)
+	}
+	if response.Header.Get("Upgrade") != "raft" {
+		return nil, errors.New("missing or unexpected Upgrade header in response")
+	}
+	return conn, err
+}

--- a/worker/raft/rafttransport/dialer.go
+++ b/worker/raft/rafttransport/dialer.go
@@ -34,6 +34,8 @@ type Dialer struct {
 
 // Dial dials a new raft network connection to the controller agent
 // with the tag identified by the given address.
+//
+// Based on code from https://github.com/CanonicalLtd/raft-http.
 func (d *Dialer) Dial(addr raft.ServerAddress, timeout time.Duration) (net.Conn, error) {
 	request := &http.Request{
 		Method:     "GET",

--- a/worker/raft/rafttransport/doc.go
+++ b/worker/raft/rafttransport/doc.go
@@ -1,0 +1,13 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+// Package rafttransport provides a manifold and worker that manages
+// an apiserver-based raft.Transport. The Worker type, returned by
+// NewWorker, implements raft.Transport.
+//
+// The rafttransport worker installs an HTTP handler into the provided
+// apiserverhttp.Mux at a configured path. The worker watches the
+// central hub for notification of API server addresses, and uses this
+// for dialing connections to those API servers.
+
+package rafttransport

--- a/worker/raft/rafttransport/errors.go
+++ b/worker/raft/rafttransport/errors.go
@@ -1,0 +1,35 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package rafttransport
+
+// dialRequestTimeoutError is an error type used when
+// sending a dial request times out.
+type dialRequestTimeoutError struct{}
+
+func (dialRequestTimeoutError) Error() string {
+	return "timed out dialing"
+}
+
+func (dialRequestTimeoutError) Temporary() bool {
+	return true
+}
+
+func (dialRequestTimeoutError) Timeout() bool {
+	return true
+}
+
+// dialWorkerStoppedError wraps an error that indicates
+// the dial worker has stopped as the reason why dialling
+// failed.
+type dialWorkerStoppedError struct {
+	error
+}
+
+func (dialWorkerStoppedError) Temporary() bool {
+	return true
+}
+
+func (dialWorkerStoppedError) Timeout() bool {
+	return false
+}

--- a/worker/raft/rafttransport/handler.go
+++ b/worker/raft/rafttransport/handler.go
@@ -1,0 +1,110 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package rafttransport
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+
+	"github.com/juju/errors"
+	"github.com/juju/juju/apiserver/apiserverhttp"
+)
+
+// Handler is an http.Handler suitable for serving an endpoint that
+// upgrades to raft transport connections.
+type Handler struct {
+	connections chan<- net.Conn
+	abort       <-chan struct{}
+}
+
+// NewHandler returns a new Handler that sends connections to the
+// given connections channel, and stops accepting connections after
+// the abort channel is closed.
+func NewHandler(
+	connections chan<- net.Conn,
+	abort <-chan struct{},
+) *Handler {
+	return &Handler{
+		connections: connections,
+		abort:       abort,
+	}
+}
+
+// ServeHTTP is part of the http.Handler interface.
+//
+// ServeHTTP checks for "raft" upgrade requests, and hijacks
+// those connections for use as a raw connection for raft
+// communications.
+//
+// Based on code from https://github.com/CanonicalLtd/raft-http.
+func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	// Fail immediately if we've been closed.
+	select {
+	case <-h.abort:
+		http.Error(w, "raft transport closed", http.StatusForbidden)
+		return
+	default:
+	}
+
+	if r.Header.Get("Upgrade") != "raft" {
+		http.Error(w, "missing or invalid upgrade header", http.StatusBadRequest)
+		return
+	}
+
+	hijacker, ok := w.(http.Hijacker)
+	if !ok {
+		http.Error(w, "webserver doesn't support hijacking", http.StatusInternalServerError)
+		return
+	}
+
+	conn, _, err := hijacker.Hijack()
+	if err != nil {
+		message := fmt.Sprintf("failed to hijack connection: %s", err)
+		http.Error(w, message, http.StatusInternalServerError)
+		return
+	}
+
+	// Write the status line and upgrade header by hand since w.WriteHeader()
+	// would fail after Hijack()
+	data := []byte("HTTP/1.1 101 Switching Protocols\r\nUpgrade: raft\r\n\r\n")
+	if n, err := conn.Write(data); err != nil || n != len(data) {
+		conn.Close()
+		return
+	}
+
+	select {
+	case h.connections <- conn:
+	case <-r.Context().Done():
+		conn.Close()
+	}
+}
+
+// ControllerHandler wraps an apiserverhttp.Mux, into which it will be
+// installed, and another http.Handler. This handler will ensure that the
+// request is authenticated as a controller agent, and only then will
+// delegate to the wrapped handler.
+type ControllerHandler struct {
+	Mux     *apiserverhttp.Mux
+	Handler http.Handler
+}
+
+// ServeHTTP is part of the http.Handler interface.
+func (h *ControllerHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	auth, err := h.Mux.Authenticate(r)
+	if err != nil {
+		code := http.StatusInternalServerError
+		if errors.IsUnauthorized(err) {
+			w.Header().Set("WWW-Authenticate", `Basic realm="juju"`)
+			code = http.StatusUnauthorized
+		}
+		http.Error(w, err.Error(), code)
+		return
+	}
+	if !auth.Controller {
+		http.Error(w, "controller agents only", http.StatusForbidden)
+		return
+	}
+	h.Handler.ServeHTTP(w, r)
+}

--- a/worker/raft/rafttransport/handler_test.go
+++ b/worker/raft/rafttransport/handler_test.go
@@ -1,0 +1,178 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package rafttransport_test
+
+import (
+	"crypto/tls"
+	"io"
+	"io/ioutil"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"time"
+
+	"github.com/hashicorp/raft"
+	"github.com/juju/errors"
+	"github.com/juju/names"
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/api"
+	"github.com/juju/juju/apiserver/apiserverhttp"
+	coretesting "github.com/juju/juju/testing"
+	"github.com/juju/juju/worker/raft/rafttransport"
+)
+
+type HandlerSuite struct {
+	testing.IsolationSuite
+	connections chan net.Conn
+	handler     *rafttransport.Handler
+	server      *httptest.Server
+}
+
+var _ = gc.Suite(&HandlerSuite{})
+
+func (s *HandlerSuite) SetUpTest(c *gc.C) {
+	s.IsolationSuite.SetUpTest(c)
+	s.connections = make(chan net.Conn)
+	s.handler = rafttransport.NewHandler(s.connections, nil)
+	s.server = httptest.NewTLSServer(s.handler)
+	s.AddCleanup(func(c *gc.C) {
+		s.server.Close()
+	})
+}
+
+func (s *HandlerSuite) TestHandler(c *gc.C) {
+	u, err := url.Parse(s.server.URL)
+	c.Assert(err, jc.ErrorIsNil)
+	dialRaw := func(addr raft.ServerAddress, timeout time.Duration) (net.Conn, error) {
+		tlsConfig := s.server.Client().Transport.(*http.Transport).TLSClientConfig
+		return tls.Dial("tcp", u.Host, tlsConfig)
+	}
+	dialer := rafttransport.Dialer{
+		APIInfo: &api.Info{},
+		Path:    "/raft",
+		DialRaw: dialRaw,
+	}
+	clientConn, err := dialer.Dial("", 0)
+	c.Assert(err, jc.ErrorIsNil)
+	defer clientConn.Close()
+
+	var serverConn net.Conn
+	select {
+	case conn := <-s.connections:
+		serverConn = conn
+	case <-time.After(coretesting.LongWait):
+		c.Fatal("timed out waiting for server connection")
+	}
+	defer serverConn.Close()
+
+	payload := "hello, server!"
+	n, err := clientConn.Write([]byte(payload))
+	c.Assert(err, jc.ErrorIsNil)
+
+	read := make([]byte, n)
+	n, err = serverConn.Read(read)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(n, gc.Equals, len(payload))
+	c.Assert(string(read), gc.Equals, payload)
+}
+
+type ControllerHandlerSuite struct {
+	testing.IsolationSuite
+	stub     testing.Stub
+	mux      *apiserverhttp.Mux
+	authInfo apiserverhttp.AuthInfo
+	handler  *rafttransport.ControllerHandler
+	server   *httptest.Server
+}
+
+var _ = gc.Suite(&ControllerHandlerSuite{})
+
+func (s *ControllerHandlerSuite) SetUpTest(c *gc.C) {
+	s.IsolationSuite.SetUpTest(c)
+
+	s.stub.ResetCalls()
+	s.authInfo = apiserverhttp.AuthInfo{
+		Tag:        names.NewMachineTag("99"),
+		Controller: true,
+	}
+	s.handler = &rafttransport.ControllerHandler{
+		Mux: s.mux,
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			io.WriteString(w, "hello!")
+		}),
+	}
+	s.mux = apiserverhttp.NewMux(apiserverhttp.WithAuth(func(req *http.Request) (apiserverhttp.AuthInfo, error) {
+		s.stub.AddCall("Auth", req)
+		return s.authInfo, s.stub.NextErr()
+	}))
+	s.mux.AddHandler("GET", "/auth", s.handler)
+
+	mux := http.NewServeMux()
+	mux.Handle("/auth", s.mux)
+	mux.Handle("/noauth", s.handler)
+	s.server = httptest.NewTLSServer(mux)
+	s.AddCleanup(func(c *gc.C) {
+		s.server.Close()
+	})
+}
+
+func (s *ControllerHandlerSuite) TestControllerHandler(c *gc.C) {
+	client := s.server.Client()
+	resp, err := client.Get(s.server.URL + "/auth")
+	c.Assert(err, jc.ErrorIsNil)
+	defer resp.Body.Close()
+
+	data, err := ioutil.ReadAll(resp.Body)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(string(data), gc.Equals, "hello!")
+}
+
+func (s *ControllerHandlerSuite) TestControllerHandlerNoAuthHandler(c *gc.C) {
+	client := s.server.Client()
+	resp, err := client.Get(s.server.URL + "/noauth")
+	c.Assert(err, jc.ErrorIsNil)
+	defer resp.Body.Close()
+
+	// /noauth points to the ControllerHandler, but without going through
+	// the required apiserverhttp.Mux. This is a programming error.
+	data, err := ioutil.ReadAll(resp.Body)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(resp.StatusCode, gc.Equals, http.StatusInternalServerError)
+	c.Assert(string(data), gc.Equals, "no authentication handler found\n")
+}
+
+func (s *ControllerHandlerSuite) TestControllerHandlerAuthFailure(c *gc.C) {
+	s.stub.SetErrors(errors.NewUnauthorized(nil, "i say nay sir"))
+
+	client := s.server.Client()
+	resp, err := client.Get(s.server.URL + "/auth")
+	c.Assert(err, jc.ErrorIsNil)
+	defer resp.Body.Close()
+
+	c.Assert(resp.StatusCode, gc.Equals, http.StatusUnauthorized)
+	c.Assert(resp.Header.Get("WWW-Authenticate"), gc.Equals, `Basic realm="juju"`)
+
+	data, err := ioutil.ReadAll(resp.Body)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(string(data), gc.Equals, "i say nay sir\n")
+}
+
+func (s *ControllerHandlerSuite) TestControllerHandlerNonController(c *gc.C) {
+	s.authInfo.Controller = false
+
+	client := s.server.Client()
+	resp, err := client.Get(s.server.URL + "/auth")
+	c.Assert(err, jc.ErrorIsNil)
+	defer resp.Body.Close()
+
+	c.Assert(resp.StatusCode, gc.Equals, http.StatusForbidden)
+	data, err := ioutil.ReadAll(resp.Body)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(string(data), gc.Equals, "controller agents only\n")
+}

--- a/worker/raft/rafttransport/handler_test.go
+++ b/worker/raft/rafttransport/handler_test.go
@@ -15,10 +15,10 @@ import (
 
 	"github.com/hashicorp/raft"
 	"github.com/juju/errors"
-	"github.com/juju/names"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/api"
 	"github.com/juju/juju/apiserver/apiserverhttp"

--- a/worker/raft/rafttransport/manifold.go
+++ b/worker/raft/rafttransport/manifold.go
@@ -1,0 +1,118 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package rafttransport
+
+import (
+	"github.com/hashicorp/raft"
+	"github.com/juju/errors"
+	"github.com/juju/pubsub"
+	"gopkg.in/juju/worker.v1"
+
+	"github.com/juju/juju/agent"
+	"github.com/juju/juju/api"
+	"github.com/juju/juju/apiserver/apiserverhttp"
+	"github.com/juju/juju/worker/dependency"
+)
+
+// ManifoldConfig holds the information necessary to run an apiserver-based
+// raft transport worker in a dependency.Engine.
+type ManifoldConfig struct {
+	AgentName      string
+	CentralHubName string
+	MuxName        string
+
+	APIOpen   api.OpenFunc
+	NewWorker func(Config) (worker.Worker, error)
+
+	// Path is the path of the raft HTTP endpoint.
+	Path string
+}
+
+// Validate validates the manifold configuration.
+func (config ManifoldConfig) Validate() error {
+	if config.AgentName == "" {
+		return errors.NotValidf("empty AgentName")
+	}
+	if config.CentralHubName == "" {
+		return errors.NotValidf("empty CentralHubName")
+	}
+	if config.MuxName == "" {
+		return errors.NotValidf("empty MuxName")
+	}
+	if config.APIOpen == nil {
+		return errors.NotValidf("nil APIOpen")
+	}
+	if config.NewWorker == nil {
+		return errors.NotValidf("nil NewWorker")
+	}
+	if config.Path == "" {
+		return errors.NotValidf("empty Path")
+	}
+	return nil
+}
+
+// Manifold returns a dependency.Manifold that will run an apiserver-based
+// raft transport worker.
+func Manifold(config ManifoldConfig) dependency.Manifold {
+	return dependency.Manifold{
+		Inputs: []string{
+			config.AgentName,
+			config.CentralHubName,
+			config.MuxName,
+		},
+		Start:  config.start,
+		Output: transportOutput,
+	}
+}
+
+// start is a method on ManifoldConfig because it's more readable than a closure.
+func (config ManifoldConfig) start(context dependency.Context) (worker.Worker, error) {
+	if err := config.Validate(); err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	var agent agent.Agent
+	if err := context.Get(config.AgentName, &agent); err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	var mux *apiserverhttp.Mux
+	if err := context.Get(config.MuxName, &mux); err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	var hub *pubsub.StructuredHub
+	if err := context.Get(config.CentralHubName, &hub); err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	apiInfo, ok := agent.CurrentConfig().APIInfo()
+	if !ok {
+		return nil, dependency.ErrMissing
+	}
+	apiInfo.Addrs = nil
+	apiInfo.SNIHostName = ""
+
+	return config.NewWorker(Config{
+		APIInfo: apiInfo,
+		APIOpen: config.APIOpen,
+		Hub:     hub,
+		Mux:     mux,
+		Path:    config.Path,
+		Tag:     agent.CurrentConfig().Tag(),
+	})
+}
+
+func transportOutput(in worker.Worker, out interface{}) error {
+	t, ok := in.(raft.Transport)
+	if !ok {
+		return errors.Errorf("expected input of type %T, got %T", t, in)
+	}
+	tout, ok := out.(*raft.Transport)
+	if ok {
+		*tout = t
+		return nil
+	}
+	return errors.Errorf("expected output of type %T, got %T", tout, out)
+}

--- a/worker/raft/rafttransport/manifold_test.go
+++ b/worker/raft/rafttransport/manifold_test.go
@@ -1,0 +1,147 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package rafttransport_test
+
+import (
+	"github.com/hashicorp/raft"
+	"github.com/juju/errors"
+	"github.com/juju/pubsub"
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/names.v2"
+	"gopkg.in/juju/worker.v1"
+
+	"github.com/juju/juju/api"
+	"github.com/juju/juju/apiserver/apiserverhttp"
+	"github.com/juju/juju/worker/dependency"
+	dt "github.com/juju/juju/worker/dependency/testing"
+	"github.com/juju/juju/worker/raft/rafttransport"
+)
+
+type ManifoldSuite struct {
+	testing.IsolationSuite
+
+	manifold dependency.Manifold
+	context  dependency.Context
+	agent    *mockAgent
+	hub      *pubsub.StructuredHub
+	mux      *apiserverhttp.Mux
+	worker   worker.Worker
+	stub     testing.Stub
+}
+
+var _ = gc.Suite(&ManifoldSuite{})
+
+func (s *ManifoldSuite) SetUpTest(c *gc.C) {
+	s.IsolationSuite.SetUpTest(c)
+
+	s.agent = &mockAgent{
+		conf: mockAgentConfig{
+			tag: names.NewMachineTag("123"),
+			apiInfo: &api.Info{
+				Addrs:  []string{"testing.invalid:1234"},
+				CACert: "ca-cert",
+			},
+		},
+	}
+	s.hub = &pubsub.StructuredHub{}
+	s.mux = &apiserverhttp.Mux{}
+	s.stub.ResetCalls()
+	s.worker = &mockTransportWorker{
+		Transport: &raft.InmemTransport{},
+	}
+
+	s.context = s.newContext(nil)
+	s.manifold = rafttransport.Manifold(rafttransport.ManifoldConfig{
+		AgentName:      "agent",
+		CentralHubName: "central-hub",
+		MuxName:        "mux",
+		APIOpen:        s.apiOpen,
+		NewWorker:      s.newWorker,
+		Path:           "raft/path",
+	})
+}
+
+func (s *ManifoldSuite) newContext(overlay map[string]interface{}) dependency.Context {
+	resources := map[string]interface{}{
+		"agent":       s.agent,
+		"central-hub": s.hub,
+		"mux":         s.mux,
+	}
+	for k, v := range overlay {
+		resources[k] = v
+	}
+	return dt.StubContext(nil, resources)
+}
+
+func (s *ManifoldSuite) newWorker(config rafttransport.Config) (worker.Worker, error) {
+	s.stub.MethodCall(s, "NewWorker", config)
+	if err := s.stub.NextErr(); err != nil {
+		return nil, err
+	}
+	return s.worker, nil
+}
+
+func (s *ManifoldSuite) apiOpen(info *api.Info, opts api.DialOpts) (api.Connection, error) {
+	s.stub.MethodCall(s, "APIOpen", info, opts)
+	return nil, s.stub.NextErr()
+}
+
+var expectedInputs = []string{
+	"agent", "central-hub", "mux",
+}
+
+func (s *ManifoldSuite) TestInputs(c *gc.C) {
+	c.Assert(s.manifold.Inputs, jc.SameContents, expectedInputs)
+}
+
+func (s *ManifoldSuite) TestMissingInputs(c *gc.C) {
+	for _, input := range expectedInputs {
+		context := s.newContext(map[string]interface{}{
+			input: dependency.ErrMissing,
+		})
+		_, err := s.manifold.Start(context)
+		c.Assert(errors.Cause(err), gc.Equals, dependency.ErrMissing)
+	}
+}
+
+func (s *ManifoldSuite) TestStart(c *gc.C) {
+	s.startWorkerClean(c)
+
+	s.stub.CheckCallNames(c, "NewWorker")
+	args := s.stub.Calls()[0].Args
+	c.Assert(args, gc.HasLen, 1)
+	c.Assert(args[0], gc.FitsTypeOf, rafttransport.Config{})
+	config := args[0].(rafttransport.Config)
+
+	c.Assert(config.APIOpen, gc.NotNil)
+	config.APIOpen(config.APIInfo, api.DefaultDialOpts())
+	s.stub.CheckCallNames(c, "NewWorker", "APIOpen")
+	config.APIOpen = nil
+
+	c.Assert(config, jc.DeepEquals, rafttransport.Config{
+		APIInfo: &api.Info{CACert: "ca-cert"},
+		Hub:     s.hub,
+		Mux:     s.mux,
+		Path:    "raft/path",
+		Tag:     s.agent.conf.tag,
+	})
+}
+
+func (s *ManifoldSuite) TestOutput(c *gc.C) {
+	w := s.startWorkerClean(c)
+
+	var t raft.Transport
+	err := s.manifold.Output(w, &t)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(t, gc.Equals, s.worker)
+}
+
+func (s *ManifoldSuite) startWorkerClean(c *gc.C) worker.Worker {
+	w, err := s.manifold.Start(s.context)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(w, gc.Equals, s.worker)
+	return w
+}

--- a/worker/raft/rafttransport/mock_test.go
+++ b/worker/raft/rafttransport/mock_test.go
@@ -1,0 +1,64 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package rafttransport_test
+
+import (
+	"context"
+	"net"
+
+	"github.com/hashicorp/raft"
+	"gopkg.in/juju/names.v2"
+	"gopkg.in/juju/worker.v1"
+
+	"github.com/juju/juju/agent"
+	"github.com/juju/juju/api"
+	"github.com/juju/testing"
+)
+
+type mockAgent struct {
+	agent.Agent
+	conf mockAgentConfig
+}
+
+func (ma *mockAgent) CurrentConfig() agent.Config {
+	return &ma.conf
+}
+
+type mockAgentConfig struct {
+	agent.Config
+	tag     names.Tag
+	apiInfo *api.Info
+}
+
+func (c *mockAgentConfig) Tag() names.Tag {
+	return c.tag
+}
+
+func (c *mockAgentConfig) APIInfo() (*api.Info, bool) {
+	return c.apiInfo, c.apiInfo != nil
+}
+
+type mockTransportWorker struct {
+	worker.Worker
+	raft.Transport
+}
+
+type mockAPIConnection struct {
+	api.Connection
+	testing.Stub
+	dialContext func(context.Context) (net.Conn, error)
+}
+
+func (c *mockAPIConnection) Close() error {
+	c.MethodCall(c, "Close")
+	return c.NextErr()
+}
+
+func (c *mockAPIConnection) DialConn(ctx context.Context) (net.Conn, error) {
+	c.MethodCall(c, "DialConn", ctx)
+	if err := c.NextErr(); err != nil {
+		return nil, err
+	}
+	return c.dialContext(ctx)
+}

--- a/worker/raft/rafttransport/package_test.go
+++ b/worker/raft/rafttransport/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package rafttransport_test
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func TestPackage(t *testing.T) {
+	gc.TestingT(t)
+}

--- a/worker/raft/rafttransport/shim.go
+++ b/worker/raft/rafttransport/shim.go
@@ -1,0 +1,10 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package rafttransport
+
+import "gopkg.in/juju/worker.v1"
+
+func NewWorkerShim(config Config) (worker.Worker, error) {
+	return NewWorker(config)
+}

--- a/worker/raft/rafttransport/shim.go
+++ b/worker/raft/rafttransport/shim.go
@@ -5,6 +5,8 @@ package rafttransport
 
 import "gopkg.in/juju/worker.v1"
 
+// NewWorkerShim calls straight through to NewWorker. This exists
+// only to adapt to the signature of ManifoldConfig.NewWorker.
 func NewWorkerShim(config Config) (worker.Worker, error) {
 	return NewWorker(config)
 }

--- a/worker/raft/rafttransport/streamlayer.go
+++ b/worker/raft/rafttransport/streamlayer.go
@@ -1,0 +1,76 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package rafttransport
+
+import (
+	"net"
+	"time"
+
+	"github.com/hashicorp/raft"
+	"github.com/juju/names"
+	"github.com/pkg/errors"
+	"gopkg.in/tomb.v1"
+)
+
+func newStreamLayer(
+	tag names.Tag,
+	connections <-chan net.Conn,
+	dialer *Dialer,
+) *streamLayer {
+	l := &streamLayer{
+		addr:        jujuAddr{tag},
+		connections: connections,
+		dialer:      dialer,
+	}
+	go func() {
+		defer l.tomb.Done()
+		<-l.tomb.Dying()
+		l.tomb.Kill(tomb.ErrDying)
+	}()
+	return l
+}
+
+// streamLayer represents the connection between raft nodes.
+type streamLayer struct {
+	tomb        tomb.Tomb
+	addr        jujuAddr
+	connections <-chan net.Conn
+	dialer      *Dialer
+}
+
+// Accept waits for the next connection.
+func (l *streamLayer) Accept() (net.Conn, error) {
+	select {
+	case <-l.tomb.Dying():
+		return nil, errors.New("transport closed")
+	case conn := <-l.connections:
+		return conn, nil
+	}
+}
+
+// Close closes the layer.
+func (l *streamLayer) Close() error {
+	l.tomb.Kill(nil)
+	return l.tomb.Wait()
+}
+
+// Addr returns the local address for the layer.
+func (l *streamLayer) Addr() net.Addr {
+	return l.addr
+}
+
+// Dial creates a new network connection.
+func (l *streamLayer) Dial(addr raft.ServerAddress, timeout time.Duration) (net.Conn, error) {
+	return l.dialer.Dial(addr, timeout)
+}
+
+// jujuAddr implements net.Addr in terms of a tag.
+type jujuAddr struct {
+	names.Tag
+}
+
+// Network is part of the net.Addr interface.
+func (jujuAddr) Network() string {
+	return "juju"
+}

--- a/worker/raft/rafttransport/streamlayer.go
+++ b/worker/raft/rafttransport/streamlayer.go
@@ -8,8 +8,8 @@ import (
 	"time"
 
 	"github.com/hashicorp/raft"
-	"github.com/juju/names"
 	"github.com/pkg/errors"
+	"gopkg.in/juju/names.v2"
 	"gopkg.in/tomb.v1"
 )
 

--- a/worker/raft/rafttransport/worker.go
+++ b/worker/raft/rafttransport/worker.go
@@ -1,0 +1,341 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package rafttransport
+
+import (
+	"context"
+	"log"
+	"net"
+	"sync"
+	"time"
+
+	"github.com/hashicorp/raft"
+	"github.com/juju/errors"
+	"github.com/juju/loggo"
+	"github.com/juju/pubsub"
+	"github.com/juju/replicaset"
+	"gopkg.in/juju/names.v2"
+
+	"github.com/juju/juju/api"
+	"github.com/juju/juju/apiserver/apiserverhttp"
+	pubsubapiserver "github.com/juju/juju/pubsub/apiserver"
+	"github.com/juju/juju/worker/catacomb"
+	"github.com/juju/juju/worker/raft/raftutil"
+)
+
+var (
+	logger = loggo.GetLogger("juju.worker.raft.rafttransport")
+)
+
+const (
+	maxPoolSize = replicaset.MaxPeers
+)
+
+// Config is the configuration required for running an apiserver-based
+// raft transport worker.
+type Config struct {
+	// APIInfo contains the information, excluding addresses,
+	// required to connect to an API server.
+	APIInfo *api.Info
+
+	// APIOpen is the function used to dial an API connection.
+	APIOpen api.OpenFunc
+
+	// Hub is the structured hub to which the worker will subscribe
+	// for API server address updates.
+	Hub *pubsub.StructuredHub
+
+	// Mux is the API server HTTP mux into which the handler will
+	// be installed.
+	Mux *apiserverhttp.Mux
+
+	// Path is the path of the raft HTTP endpoint.
+	Path string
+
+	// Tag is the tag of the agent running this worker.
+	Tag names.Tag
+
+	// Timeout, if non-zero, is the timeout to apply to transport
+	// operations. See raft.NetworkTransportConfig.Timeout for more
+	// details.
+	Timeout time.Duration
+}
+
+// Validate validates the raft worker configuration.
+func (config Config) Validate() error {
+	if config.APIInfo == nil {
+		return errors.NotValidf("nil APIInfo")
+	}
+	if config.APIOpen == nil {
+		return errors.NotValidf("nil APIOpen")
+	}
+	if config.Hub == nil {
+		return errors.NotValidf("nil Hub")
+	}
+	if config.Mux == nil {
+		return errors.NotValidf("nil Mux")
+	}
+	if config.Path == "" {
+		return errors.NotValidf("empty Path")
+	}
+	if config.Tag == nil {
+		return errors.NotValidf("nil Tag")
+	}
+	return nil
+}
+
+// NewWorker returns a new apiserver-based raft transport worker,
+// with the given configuration. The worker itself implements
+// raft.Transport.
+func NewWorker(config Config) (*Worker, error) {
+	if err := config.Validate(); err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	w := &Worker{
+		config:         config,
+		connections:    make(chan net.Conn),
+		dialRequests:   make(chan dialRequest),
+		serversUpdated: make(chan struct{}),
+	}
+
+	const logPrefix = "[transport] "
+	logWriter := &raftutil.LoggoWriter{logger, loggo.DEBUG}
+	logLogger := log.New(logWriter, logPrefix, 0)
+	transport := raft.NewNetworkTransportWithConfig(&raft.NetworkTransportConfig{
+		Logger:                logLogger,
+		MaxPool:               maxPoolSize,
+		ServerAddressProvider: serverAddressProvider{},
+		Stream: newStreamLayer(config.Tag, w.connections, &Dialer{
+			APIInfo: config.APIInfo,
+			DialRaw: w.dialRaw,
+			Path:    config.Path,
+		}),
+		Timeout: config.Timeout,
+	})
+	w.Transport = transport
+
+	// Subscribe to API server address changes.
+	unsubscribeHub, err := w.config.Hub.Subscribe(
+		pubsubapiserver.DetailsTopic,
+		w.apiserverDetailsChanged,
+	)
+	if err != nil {
+		return nil, errors.Annotate(err, "subscribing to apiserver details")
+	}
+
+	if err := catacomb.Invoke(catacomb.Plan{
+		Site: &w.catacomb,
+		Work: func() error {
+			defer transport.Close()
+			defer unsubscribeHub()
+			return w.loop()
+		},
+	}); err != nil {
+		transport.Close()
+		unsubscribeHub()
+		return nil, errors.Trace(err)
+	}
+	return w, nil
+}
+
+// Worker is a worker that manages a raft.Transport.
+type Worker struct {
+	raft.Transport
+
+	catacomb     catacomb.Catacomb
+	config       Config
+	connections  chan net.Conn
+	dialRequests chan dialRequest
+
+	mu             sync.Mutex
+	servers        pubsubapiserver.Details
+	serversUpdated chan struct{}
+}
+
+type dialRequest struct {
+	ctx    context.Context
+	tag    names.MachineTag
+	result chan<- dialResult
+}
+
+type dialResult struct {
+	conn net.Conn
+	err  error
+}
+
+// Kill is part of the worker.Worker interface.
+func (w *Worker) Kill() {
+	w.catacomb.Kill(nil)
+}
+
+// Wait is part of the worker.Worker interface.
+func (w *Worker) Wait() error {
+	return w.catacomb.Wait()
+}
+
+// dialRaw dials a new TLS connection to the controller identified
+// by the given address. The address is expected to be the stringified
+// tag of a controller machine agent. The resulting connection is
+// appropriate for use as Dialer.DialRaw.
+func (w *Worker) dialRaw(address raft.ServerAddress, timeout time.Duration) (net.Conn, error) {
+	tag, err := names.ParseMachineTag(string(address))
+	if err != nil {
+		return nil, net.InvalidAddrError(err.Error())
+	}
+
+	// Give precedence to the worker dying.
+	select {
+	case <-w.catacomb.Dying():
+		return nil, w.errDialWorkerStopped()
+	default:
+	}
+
+	ctx := context.Background()
+	if timeout != 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, timeout)
+		defer cancel()
+	}
+
+	resultCh := make(chan dialResult)
+	req := dialRequest{
+		ctx:    ctx,
+		tag:    tag,
+		result: resultCh,
+	}
+	select {
+	case <-w.catacomb.Dying():
+		return nil, w.errDialWorkerStopped()
+	case <-ctx.Done():
+		return nil, dialRequestTimeoutError{}
+	case w.dialRequests <- req:
+	}
+
+	select {
+	case res := <-resultCh:
+		return res.conn, res.err
+	case <-ctx.Done():
+		return nil, dialRequestTimeoutError{}
+	case <-w.catacomb.Dying():
+		return nil, w.errDialWorkerStopped()
+	}
+}
+
+func (w *Worker) errDialWorkerStopped() error {
+	err := w.catacomb.Err()
+	if err != nil && err != w.catacomb.ErrDying() {
+		return dialWorkerStoppedError{err}
+	}
+	return dialWorkerStoppedError{
+		errors.New("worker stopped"),
+	}
+}
+
+func (w *Worker) loop() error {
+	h := NewHandler(w.connections, w.catacomb.Dying())
+	w.config.Mux.AddHandler("GET", w.config.Path, &ControllerHandler{
+		Mux:     w.config.Mux,
+		Handler: h,
+	})
+	defer w.config.Mux.RemoveHandler("GET", w.config.Path)
+
+	for {
+		select {
+		case <-w.catacomb.Dying():
+			return w.catacomb.ErrDying()
+		case req := <-w.dialRequests:
+			go w.handleDial(req)
+		}
+	}
+}
+
+func (w *Worker) apiserverDetailsChanged(topic string, details pubsubapiserver.Details, err error) {
+	if err != nil {
+		// This should never happen, so treat it as fatal.
+		w.catacomb.Kill(errors.Annotate(err, "apiserver details callback failed"))
+		return
+	}
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.servers = details
+	close(w.serversUpdated)
+	w.serversUpdated = make(chan struct{})
+}
+
+func (w *Worker) handleDial(req dialRequest) {
+	addrs := w.serverAddresses(req.ctx, req.tag)
+	if addrs == nil {
+		// context expired or canceled
+		return
+	}
+
+	dial := func() (net.Conn, error) {
+		// Dial an api.Connection first, so we get the
+		// right address to connect to. The multi-address
+		// connection logic should be refactored so we
+		// can do without this.
+		apiInfo := *w.config.APIInfo
+		apiInfo.SkipLogin = true
+		apiInfo.Tag = nil
+		apiInfo.Password = ""
+		apiInfo.Macaroons = nil
+		apiInfo.Addrs = addrs
+		dialOpts := api.DefaultDialOpts()
+		if deadline, ok := req.ctx.Deadline(); ok {
+			dialOpts.Timeout = time.Until(deadline)
+		}
+		apiConn, err := w.config.APIOpen(&apiInfo, dialOpts)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		defer apiConn.Close()
+		return apiConn.DialConn(req.ctx)
+	}
+
+	conn, err := dial()
+	select {
+	case req.result <- dialResult{conn, err}:
+		return
+	case <-req.ctx.Done():
+	case <-w.catacomb.Dying():
+	}
+	if err == nil {
+		// result wasn't delivered, close connection
+		conn.Close()
+	}
+}
+
+func (w *Worker) serverAddresses(ctx context.Context, tag names.MachineTag) []string {
+	for {
+		w.mu.Lock()
+		server, ok := w.servers.Servers[tag.Id()]
+		serversUpdated := w.serversUpdated
+		w.mu.Unlock()
+		if ok {
+			return server.Addresses
+		}
+		logger.Tracef("waiting for address for %s", tag)
+		select {
+		case <-serversUpdated:
+			continue
+		case <-ctx.Done():
+		case <-w.catacomb.Dying():
+		}
+		// context expired or canceled
+		return nil
+	}
+}
+
+// serverAddressProvider is an implementation of raft.ServerAddressProvider
+// that returns the provided server ID as the address, verbatim, so long as
+// it is valid machine tag.
+type serverAddressProvider struct{}
+
+func (serverAddressProvider) ServerAddr(id raft.ServerID) (raft.ServerAddress, error) {
+	if _, err := names.ParseMachineTag(string(id)); err != nil {
+		return "", err
+	}
+	return raft.ServerAddress(string(id)), nil
+}

--- a/worker/raft/rafttransport/worker_test.go
+++ b/worker/raft/rafttransport/worker_test.go
@@ -1,0 +1,256 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package rafttransport_test
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"time"
+
+	"github.com/hashicorp/raft"
+	"github.com/juju/errors"
+	"github.com/juju/loggo"
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/names.v2"
+
+	"github.com/juju/juju/api"
+	"github.com/juju/juju/apiserver/apiserverhttp"
+	"github.com/juju/juju/pubsub/apiserver"
+	"github.com/juju/juju/pubsub/centralhub"
+	coretesting "github.com/juju/juju/testing"
+	"github.com/juju/juju/worker/raft/rafttransport"
+	"github.com/juju/juju/worker/workertest"
+)
+
+var controllerTag = names.NewMachineTag("123")
+
+type workerFixture struct {
+	testing.IsolationSuite
+	config   rafttransport.Config
+	authInfo apiserverhttp.AuthInfo
+}
+
+func (s *workerFixture) SetUpTest(c *gc.C) {
+	s.IsolationSuite.SetUpTest(c)
+
+	tag := names.NewMachineTag("123")
+	s.config = rafttransport.Config{
+		APIInfo: &api.Info{
+			Tag:      tag,
+			Password: "valid-password",
+		},
+		APIOpen: api.Open,
+		Hub:     centralhub.New(tag),
+		Mux: apiserverhttp.NewMux(
+			apiserverhttp.WithAuth(s.auth),
+		),
+		Path:    "/raft/path",
+		Tag:     tag,
+		Timeout: coretesting.LongWait,
+	}
+
+	logger := loggo.GetLogger("juju.worker.raft")
+	oldLevel := logger.LogLevel()
+	logger.SetLogLevel(loggo.TRACE)
+	s.AddCleanup(func(c *gc.C) {
+		logger.SetLogLevel(oldLevel)
+	})
+}
+
+func (s *workerFixture) auth(req *http.Request) (apiserverhttp.AuthInfo, error) {
+	user, pass, ok := req.BasicAuth()
+	if !ok || pass != "valid-password" {
+		return apiserverhttp.AuthInfo{}, errors.Unauthorizedf("request")
+	}
+	tag, err := names.ParseTag(user)
+	if err != nil {
+		return apiserverhttp.AuthInfo{}, errors.Trace(err)
+	}
+	return apiserverhttp.AuthInfo{
+		Tag:        tag,
+		Controller: tag == controllerTag,
+	}, nil
+}
+
+type WorkerValidationSuite struct {
+	workerFixture
+}
+
+var _ = gc.Suite(&WorkerValidationSuite{})
+
+func (s *WorkerValidationSuite) TestValidateErrors(c *gc.C) {
+	type test struct {
+		f      func(*rafttransport.Config)
+		expect string
+	}
+	tests := []test{{
+		func(cfg *rafttransport.Config) { cfg.APIInfo = nil },
+		"nil APIInfo not valid",
+	}, {
+		func(cfg *rafttransport.Config) { cfg.APIOpen = nil },
+		"nil APIOpen not valid",
+	}, {
+		func(cfg *rafttransport.Config) { cfg.Hub = nil },
+		"nil Hub not valid",
+	}, {
+		func(cfg *rafttransport.Config) { cfg.Mux = nil },
+		"nil Mux not valid",
+	}, {
+		func(cfg *rafttransport.Config) { cfg.Path = "" },
+		"empty Path not valid",
+	}, {
+		func(cfg *rafttransport.Config) { cfg.Tag = nil },
+		"nil Tag not valid",
+	}}
+	for i, test := range tests {
+		c.Logf("test #%d (%s)", i, test.expect)
+		s.testValidateError(c, test.f, test.expect)
+	}
+}
+
+func (s *WorkerValidationSuite) testValidateError(c *gc.C, f func(*rafttransport.Config), expect string) {
+	config := s.config
+	f(&config)
+	w, err := rafttransport.NewWorker(config)
+	if !c.Check(err, gc.NotNil) {
+		workertest.DirtyKill(c, w)
+		return
+	}
+	c.Check(w, gc.IsNil)
+	c.Check(err, gc.ErrorMatches, expect)
+}
+
+type WorkerSuite struct {
+	workerFixture
+	stub    testing.Stub
+	apiConn *mockAPIConnection
+	server  *httptest.Server
+	worker  *rafttransport.Worker
+}
+
+var _ = gc.Suite(&WorkerSuite{})
+
+func (s *WorkerSuite) SetUpTest(c *gc.C) {
+	s.workerFixture.SetUpTest(c)
+
+	s.stub.ResetCalls()
+	s.server = httptest.NewServer(s.config.Mux)
+	s.AddCleanup(func(c *gc.C) {
+		s.server.Close()
+	})
+	dialContext := func(ctx context.Context) (net.Conn, error) {
+		var dialer net.Dialer
+		addr := s.server.Listener.Addr()
+		return dialer.DialContext(ctx, addr.Network(), addr.String())
+	}
+	s.apiConn = &mockAPIConnection{
+		dialContext: dialContext,
+	}
+	s.config.APIOpen = s.apiOpen
+	s.worker = s.newWorker(c, s.config)
+	s.config.Hub.Publish(apiserver.DetailsTopic, apiserver.Details{
+		Servers: map[string]apiserver.APIServer{
+			"123": apiserver.APIServer{
+				ID:        "123",
+				Addresses: []string{"testing.invalid:1234"},
+			},
+		},
+	})
+}
+
+// newWorker returns a new rafttransport.Worker. The caller is expected to
+// publish apiserver.Details changes to the hub after the worker starts.
+func (s *WorkerSuite) newWorker(c *gc.C, config rafttransport.Config) *rafttransport.Worker {
+	worker, err := rafttransport.NewWorker(config)
+	c.Assert(err, jc.ErrorIsNil)
+	s.AddCleanup(func(c *gc.C) {
+		workertest.DirtyKill(c, worker)
+	})
+	return worker
+}
+
+func (s *WorkerSuite) apiOpen(info *api.Info, opts api.DialOpts) (api.Connection, error) {
+	s.stub.MethodCall(s, "APIOpen", info, opts)
+	return s.apiConn, s.stub.NextErr()
+}
+
+func (s *WorkerSuite) requestVote(t raft.Transport, tag string) (raft.RequestVoteResponse, error) {
+	var resp raft.RequestVoteResponse
+	req := &raft.RequestVoteRequest{}
+	return resp, t.RequestVote(raft.ServerID(tag), raft.ServerAddress(tag), req, &resp)
+}
+
+func (s *WorkerSuite) TestStartStop(c *gc.C) {
+	workertest.CleanKill(c, s.worker)
+}
+
+func (s *WorkerSuite) TestLocalAddr(c *gc.C) {
+	addr := s.worker.LocalAddr()
+	c.Assert(addr, gc.Equals, raft.ServerAddress("machine-123"))
+}
+
+func (s *WorkerSuite) TestInvalidAddr(c *gc.C) {
+	_, err := s.requestVote(s.worker, "zoink123")
+	c.Assert(err, gc.ErrorMatches, `dial failed: "zoink123" is not a valid tag`)
+	c.Assert(errors.Cause(err), jc.DeepEquals, net.InvalidAddrError(`"zoink123" is not a valid tag`))
+}
+
+func (s *WorkerSuite) TestTransportWorkerStopped(c *gc.C) {
+	workertest.CleanKill(c, s.worker)
+
+	_, err := s.requestVote(s.worker, "machine-123")
+	c.Assert(err, gc.ErrorMatches, "dial failed: worker stopped")
+
+	c.Assert(errors.Cause(err), gc.Implements, new(net.Error))
+	netErr := errors.Cause(err).(net.Error)
+	c.Assert(netErr.Temporary(), jc.IsTrue)
+	c.Assert(netErr.Timeout(), jc.IsFalse)
+}
+
+func (s *WorkerSuite) TestTransportTimeout(c *gc.C) {
+	config := s.config
+	config.Timeout = time.Millisecond
+	worker := s.newWorker(c, config)
+
+	_, err := s.requestVote(worker, "machine-123")
+	c.Assert(err, gc.ErrorMatches, "dial failed: timed out dialing")
+
+	c.Assert(errors.Cause(err), gc.Implements, new(net.Error))
+	netErr := errors.Cause(err).(net.Error)
+	c.Assert(netErr.Temporary(), jc.IsTrue)
+	c.Assert(netErr.Timeout(), jc.IsTrue)
+}
+
+func (s *WorkerSuite) TestAPIOpen(c *gc.C) {
+	s.apiConn.SetErrors(errors.New("DialConn failed"))
+
+	_, err := s.requestVote(s.worker, "machine-123")
+	c.Assert(err, gc.ErrorMatches, "dial failed: DialConn failed")
+
+	s.stub.CheckCallNames(c, "APIOpen")
+	args := s.stub.Calls()[0].Args
+	c.Assert(args, gc.HasLen, 2)
+
+	c.Assert(args[0], jc.DeepEquals, &api.Info{
+		Addrs:     []string{"testing.invalid:1234"},
+		SkipLogin: true,
+	})
+}
+
+func (s *WorkerSuite) TestRoundTrip(c *gc.C) {
+	go func() {
+		rpc := <-s.worker.Consumer()
+		resp := &raft.RequestVoteResponse{
+			Granted: true,
+		}
+		rpc.Respond(resp, nil)
+	}()
+	resp, err := s.requestVote(s.worker, "machine-123")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(resp.Granted, jc.IsTrue)
+}


### PR DESCRIPTION
## Description of change

This PR builds on top of #8308. Disregard commits prior to "apiserver: introduce new dynamic mux" during review of this PR.

We introduce a new package, worker/raft/rafttransport,
which contains a manifold and worker which implements
raft.Transport. The transport operates over the Juju
API server.

The worker installs an HTTP handler into the API
server's mux at a configurable path, hijacking the
connections that request that endpoint. The handler
requires clients to authenticate as controllers.

Parts of the code (handler and stream layer) in this
commit are based on https://github.com/CanonicalLtd/raft-http.

## QA steps

1. juju bootstrap localhost
2. juju enable-ha
3. juju destroy-controller

## Documentation changes

None.

## Bug reference

None.