### PR TITLE
Agent binary streaming

### DIFF
--- a/apiserver/apiserver.go
+++ b/apiserver/apiserver.go
@@ -877,8 +877,5 @@ func (srv *Server) localCertificate(serverName string) (*tls.Certificate, bool) 
 }
 
 func serverError(err error) error {
-	if err := common.ServerError(err); err != nil {
-		return err
-	}
-	return nil
+	return common.ServerError(err)
 }

--- a/environs/testing/tools.go
+++ b/environs/testing/tools.go
@@ -178,7 +178,7 @@ func UploadFakeToolsVersions(stor storage.Storage, toolsDir, stream string, vers
 	for _, tools := range existing {
 		existingTools[tools.Version] = tools
 	}
-	var agentTools coretools.List = make(coretools.List, len(versions))
+	var agentTools = make(coretools.List, len(versions))
 	for i, version := range versions {
 		if tools, ok := existingTools[version]; ok {
 			agentTools[i] = tools
@@ -243,8 +243,6 @@ func SignFileData(stor storage.Storage, fileName string) error {
 // AssertUploadFakeToolsVersions puts fake tools in the supplied storage for the supplied versions.
 func AssertUploadFakeToolsVersions(c *gc.C, stor storage.Storage, toolsDir, stream string, versions ...version.Binary) []*coretools.Tools {
 	agentTools, err := UploadFakeToolsVersions(stor, toolsDir, stream, versions...)
-	c.Assert(err, jc.ErrorIsNil)
-	err = envtools.MergeAndWriteMetadata(stor, toolsDir, stream, agentTools, envtools.DoNotWriteMirrors)
 	c.Assert(err, jc.ErrorIsNil)
 	return agentTools
 }


### PR DESCRIPTION
## Description of change

Instead of reading agent binary tarballs from state, into a byte slice, then streaming to clients via HTTP responses, we can use less memory by avoiding the slice creation and streaming directly from state with io.Copy.

## QA steps

Existing unit tests cover this functionality.
Bootstrapping and deploying to MAAS works with these changes.

## Documentation changes

No.

## Bug reference

Mentioned in https://bugs.launchpad.net/juju/+bug/1712071, but probably not directly related.
