### PR TITLE
When listing models, exclude all dead ones.

### DIFF
--- a/state/model.go
+++ b/state/model.go
@@ -200,12 +200,14 @@ func (st *State) Model() (*Model, error) {
 
 // AllModelUUIDs returns the UUIDs for all models in the controller.
 // Results are sorted by (name, owner).
+// All dead models are excluded.
 func (st *State) AllModelUUIDs() ([]string, error) {
 	models, closer := st.db().GetCollection(modelsC)
 	defer closer()
 
+	notDead := bson.M{"life": bson.M{"$ne": Dead}}
 	var docs []bson.M
-	err := models.Find(nil).Sort("name", "owner").Select(bson.M{"_id": 1}).All(&docs)
+	err := models.Find(notDead).Sort("name", "owner").Select(bson.M{"_id": 1}).All(&docs)
 	if err != nil {
 		return nil, err
 	}

--- a/state/model.go
+++ b/state/model.go
@@ -206,14 +206,14 @@ func (st *State) AllModelUUIDs() ([]string, error) {
 	defer closer()
 
 	var docs []bson.M
-	err := models.Find(nil).Sort("name", "owner").Select(bson.M{"_id": 1}).All(&docs)
+	err := models.Find(nil).Sort("name", "owner").Select(bson.M{"life": 1, "_id": 1}).All(&docs)
 	if err != nil {
 		return nil, err
 	}
 
 	out := []string{}
 	for _, doc := range docs {
-		if doc["life"] != Dead {
+		if doc["life"] != int(Dead) {
 			out = append(out, doc["_id"].(string))
 		}
 	}

--- a/state/model.go
+++ b/state/model.go
@@ -205,16 +205,17 @@ func (st *State) AllModelUUIDs() ([]string, error) {
 	models, closer := st.db().GetCollection(modelsC)
 	defer closer()
 
-	notDead := bson.M{"life": bson.M{"$ne": Dead}}
 	var docs []bson.M
-	err := models.Find(notDead).Sort("name", "owner").Select(bson.M{"_id": 1}).All(&docs)
+	err := models.Find(nil).Sort("name", "owner").Select(bson.M{"_id": 1}).All(&docs)
 	if err != nil {
 		return nil, err
 	}
 
-	out := make([]string, len(docs))
-	for i, doc := range docs {
-		out[i] = doc["_id"].(string)
+	out := []string{}
+	for _, doc := range docs {
+		if doc["life"] != Dead {
+			out = append(out, doc["_id"].(string))
+		}
 	}
 	return out, nil
 }

--- a/state/model.go
+++ b/state/model.go
@@ -198,24 +198,31 @@ func (st *State) Model() (*Model, error) {
 	return model, nil
 }
 
-// AllModelUUIDs returns the UUIDs for all models in the controller.
+// AllModelUUIDs returns the UUIDs for all non-dead models in the controller.
 // Results are sorted by (name, owner).
-// All dead models are excluded.
 func (st *State) AllModelUUIDs() ([]string, error) {
+	return st.filteredModelUUIDs(notDeadDoc)
+}
+
+// AllModelUUIDsIncludingDead returns the UUIDs for all models in the controller.
+// Results are sorted by (name, owner).
+func (st *State) AllModelUUIDsIncludingDead() ([]string, error) {
+	return st.filteredModelUUIDs(nil)
+}
+
+// filteredModelUUIDs returns all model uuids that match the filter.
+func (st *State) filteredModelUUIDs(filter bson.D) ([]string, error) {
 	models, closer := st.db().GetCollection(modelsC)
 	defer closer()
 
 	var docs []bson.M
-	err := models.Find(nil).Sort("name", "owner").Select(bson.M{"life": 1, "_id": 1}).All(&docs)
+	err := models.Find(filter).Sort("name", "owner").Select(bson.M{"_id": 1}).All(&docs)
 	if err != nil {
 		return nil, err
 	}
-
-	out := []string{}
-	for _, doc := range docs {
-		if doc["life"] != int(Dead) {
-			out = append(out, doc["_id"].(string))
-		}
+	out := make([]string, len(docs))
+	for i, doc := range docs {
+		out[i] = doc["_id"].(string)
 	}
 	return out, nil
 }
@@ -1106,7 +1113,7 @@ func (m *Model) destroyOps(
 				im, modelEntityRefs,
 			)
 			if err != nil {
-				return nil, err
+				return nil, errors.Trace(err)
 			}
 			prereqOps = storageOps
 		}
@@ -1134,18 +1141,18 @@ func (m *Model) destroyOps(
 		pool := NewStatePool(m.st)
 		defer pool.Close()
 
-		modelUUIDs, err := m.st.AllModelUUIDs()
+		modelUUIDs, err := m.st.AllModelUUIDsIncludingDead()
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
 		var aliveEmpty, aliveNonEmpty, dying, dead int
-		for _, modelUUID := range modelUUIDs {
-			if modelUUID == m.UUID() {
+		for _, aModelUUID := range modelUUIDs {
+			if aModelUUID == m.UUID() {
 				// Ignore the controller model.
 				continue
 			}
 
-			st, release, err := pool.Get(modelUUID)
+			st, release, err := pool.Get(aModelUUID)
 			if err != nil {
 				// This model could have been removed.
 				if errors.IsNotFound(err) {

--- a/state/model_test.go
+++ b/state/model_test.go
@@ -1309,6 +1309,29 @@ func (s *ModelSuite) TestAllModelUUIDs(c *gc.C) {
 	c.Assert(obtained, jc.DeepEquals, expected)
 }
 
+func (s *ModelSuite) TestAllModelUUIDsExcludesDead(c *gc.C) {
+	expected := []string{
+		s.State.ModelUUID(),
+	}
+
+	st1 := s.Factory.MakeModel(c, nil)
+	defer st1.Close()
+
+	m1, err := st1.Model()
+	c.Assert(err, jc.ErrorIsNil)
+	expectedWithAddition := append(expected, m1.UUID())
+	obtained, err := s.State.AllModelUUIDs()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(obtained, jc.DeepEquals, expectedWithAddition)
+
+	err = m1.SetDead()
+	c.Assert(err, jc.ErrorIsNil)
+
+	obtained, err = s.State.AllModelUUIDs()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(obtained, jc.DeepEquals, expected)
+}
+
 func (s *ModelSuite) TestHostedModelCount(c *gc.C) {
 	c.Assert(state.HostedModelCount(c, s.State), gc.Equals, 0)
 

--- a/state/model_test.go
+++ b/state/model_test.go
@@ -1330,6 +1330,10 @@ func (s *ModelSuite) TestAllModelUUIDsExcludesDead(c *gc.C) {
 	obtained, err = s.State.AllModelUUIDs()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(obtained, jc.DeepEquals, expected)
+
+	obtained, err = s.State.AllModelUUIDsIncludingDead()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(obtained, jc.DeepEquals, expectedWithAddition)
 }
 
 func (s *ModelSuite) TestHostedModelCount(c *gc.C) {

--- a/state/undertaker.go
+++ b/state/undertaker.go
@@ -32,8 +32,8 @@ func (st *State) ProcessDyingModel() (err error) {
 		if st.IsController() {
 			// We should not mark the controller model as Dead until
 			// all hosted models have been removed, otherwise the
-			// hosted model environs may not have beeen destroyed.
-			modelUUIDs, err := st.AllModelUUIDs()
+			// hosted model environs may not have been destroyed.
+			modelUUIDs, err := st.AllModelUUIDsIncludingDead()
 			if err != nil {
 				return nil, errors.Trace(err)
 			}


### PR DESCRIPTION
## Description of change

In our code, whenever we ask for a list of models, we have always implied that we want all models that are not dead (since we deal with dead models separately and individually when needed).

This patch ensures that model list query returns all non-dead models.

There are only couple of places where we want to know about dead models. These are all at the code path that ensures destruction of a controller. This patch modifies the calls that are made at destruction to retrieve all models, including the dead ones.

Added a unit test for sanity.

## Bug reference

Related to a fix for bug https://bugs.launchpad.net/juju/+bug/1745231, although there will be another patch that deals with "not found" error explicitly in the code path described in the bug.
