### PR TITLE
Fixes lp#1745231: do not proceed if model was not found.

### DIFF
--- a/state/allwatcher.go
+++ b/state/allwatcher.go
@@ -1350,6 +1350,14 @@ func (b *allModelWatcherStateBacking) GetAll(all *multiwatcherStore) error {
 func (b *allModelWatcherStateBacking) loadAllWatcherEntitiesForModel(modelUUID string, all *multiwatcherStore) error {
 	st, releaser, err := b.stPool.Get(modelUUID)
 	if err != nil {
+		if errors.IsNotFound(err) {
+			// This can occur if the model has been destroyed since
+			// the moment when model uuid has been retrieved.
+			// If we cannot find the model in the above call,
+			// we do not want to err out and we do not want to proceed
+			// with this call - just leave.
+			return nil
+		}
 		return errors.Trace(err)
 	}
 	defer releaser()


### PR DESCRIPTION
## Description of change

It is possible that the model has been destroyed between the call to get all models and the call to get a watcher. In this case, we'd get a NotFound error. This patch ensures that we'll skip loading watchers for models that can no longer be found.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1745231
