### PR TITLE
controller-config: Allow changing (some) controller configuration post-bootstrap

### DIFF
--- a/api/controller/controller.go
+++ b/api/controller/controller.go
@@ -239,6 +239,15 @@ func (c *Client) GetControllerAccess(user string) (permission.Access, error) {
 	return permission.Access(results.Results[0].Result.Access), nil
 }
 
+// ConfigSet updates the passed controller configuration values. Any
+// settings that aren't passed will be left with their previous
+// values.
+func (c *Client) ConfigSet(values map[string]interface{}) error {
+	return errors.Trace(
+		c.facade.FacadeCall("ConfigSet", params.ControllerConfigSet{Config: values}, nil),
+	)
+}
+
 // MigrationSpec holds the details required to start the migration of
 // a single model.
 type MigrationSpec struct {

--- a/api/controller/controller.go
+++ b/api/controller/controller.go
@@ -243,6 +243,9 @@ func (c *Client) GetControllerAccess(user string) (permission.Access, error) {
 // settings that aren't passed will be left with their previous
 // values.
 func (c *Client) ConfigSet(values map[string]interface{}) error {
+	if c.BestAPIVersion() < 5 {
+		return errors.Errorf("controller must be version 2.3.3 or higher to update controller config")
+	}
 	return errors.Trace(
 		c.facade.FacadeCall("ConfigSet", params.ControllerConfigSet{Config: values}, nil),
 	)

--- a/api/controller/controller.go
+++ b/api/controller/controller.go
@@ -244,7 +244,7 @@ func (c *Client) GetControllerAccess(user string) (permission.Access, error) {
 // values.
 func (c *Client) ConfigSet(values map[string]interface{}) error {
 	if c.BestAPIVersion() < 5 {
-		return errors.Errorf("controller must be version 2.3.3 or higher to update controller config")
+		return errors.Errorf("this controller version doesn't support updating controller config")
 	}
 	return errors.Trace(
 		c.facade.FacadeCall("ConfigSet", params.ControllerConfigSet{Config: values}, nil),

--- a/api/controller/controller_test.go
+++ b/api/controller/controller_test.go
@@ -355,6 +355,10 @@ func (s *Suite) TestConfigSet(c *gc.C) {
 	apiCaller := apitesting.BestVersionCaller{
 		BestVersion: 5,
 		APICallerFunc: func(objType string, version int, id, request string, args, result interface{}) error {
+			c.Assert(objType, gc.Equals, "Controller")
+			c.Assert(version, gc.Equals, 5)
+			c.Assert(request, gc.Equals, "ConfigSet")
+			c.Assert(result, gc.IsNil)
 			c.Assert(args, gc.DeepEquals, params.ControllerConfigSet{Config: map[string]interface{}{
 				"some-setting": 345,
 			}})
@@ -374,5 +378,5 @@ func (s *Suite) TestConfigSetAgainstOlderAPIVersion(c *gc.C) {
 	err := client.ConfigSet(map[string]interface{}{
 		"some-setting": 345,
 	})
-	c.Assert(err, gc.ErrorMatches, "controller must be version 2.3.3 or higher to update controller config")
+	c.Assert(err, gc.ErrorMatches, "this controller version doesn't support updating controller config")
 }

--- a/api/controller/controller_test.go
+++ b/api/controller/controller_test.go
@@ -350,3 +350,18 @@ func (s *Suite) TestModelStatusError(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, "model error")
 	c.Assert(out, gc.IsNil)
 }
+
+func (s *Suite) TestConfigSet(c *gc.C) {
+	apiCaller := apitesting.APICallerFunc(
+		func(objType string, version int, id, request string, args, result interface{}) error {
+			c.Assert(args, gc.DeepEquals, params.ControllerConfigSet{Config: map[string]interface{}{
+				"some-setting": 345,
+			}})
+			return errors.New("ruth mundy")
+		})
+	client := controller.NewClient(apiCaller)
+	err := client.ConfigSet(map[string]interface{}{
+		"some-setting": 345,
+	})
+	c.Assert(err, gc.ErrorMatches, "ruth mundy")
+}

--- a/api/facadeversions.go
+++ b/api/facadeversions.go
@@ -29,7 +29,7 @@ var facadeVersions = map[string]int{
 	"Cleaner":                      2,
 	"Client":                       1,
 	"Cloud":                        2,
-	"Controller":                   4,
+	"Controller":                   5,
 	"CrossController":              1,
 	"CrossModelRelations":          1,
 	"Deployer":                     1,

--- a/apiserver/allfacades.go
+++ b/apiserver/allfacades.go
@@ -149,6 +149,7 @@ func AllFacades() *facade.Registry {
 
 	reg("Controller", 3, controller.NewControllerAPIv3)
 	reg("Controller", 4, controller.NewControllerAPIv4)
+	reg("Controller", 5, controller.NewControllerAPIv5)
 	reg("CrossModelRelations", 1, crossmodelrelations.NewStateCrossModelRelationsAPI)
 	reg("CrossController", 1, crosscontroller.NewStateCrossControllerAPI)
 	reg("ExternalControllerUpdater", 1, externalcontrollerupdater.NewStateAPI)

--- a/apiserver/common/modelstatus_test.go
+++ b/apiserver/common/modelstatus_test.go
@@ -55,7 +55,7 @@ func (s *modelStatusSuite) SetUpTest(c *gc.C) {
 		AdminTag: s.Owner,
 	}
 
-	controller, err := controller.NewControllerAPIv4(
+	controller, err := controller.NewControllerAPIv5(
 		facadetest.Context{
 			State_:     s.State,
 			Resources_: s.resources,
@@ -74,7 +74,7 @@ func (s *modelStatusSuite) TestModelStatusNonAuth(c *gc.C) {
 	anAuthoriser := apiservertesting.FakeAuthorizer{
 		Tag: user.Tag(),
 	}
-	endpoint, err := controller.NewControllerAPIv4(
+	endpoint, err := controller.NewControllerAPIv5(
 		facadetest.Context{
 			State_:     s.State,
 			Resources_: s.resources,
@@ -99,7 +99,7 @@ func (s *modelStatusSuite) TestModelStatusOwnerAllowed(c *gc.C) {
 	}
 	st := s.Factory.MakeModel(c, &factory.ModelParams{Owner: owner.Tag()})
 	defer st.Close()
-	endpoint, err := controller.NewControllerAPIv4(
+	endpoint, err := controller.NewControllerAPIv5(
 		facadetest.Context{
 			State_:     s.State,
 			Resources_: s.resources,

--- a/apiserver/facades/client/controller/controller_test.go
+++ b/apiserver/facades/client/controller/controller_test.go
@@ -109,7 +109,7 @@ func (s *controllerSuite) TestAllModels(c *gc.C) {
 			User:        admin.UserTag(),
 			CreatedBy:   remoteUserTag,
 			DisplayName: "Foo Bar",
-			Access:      permission.ReadAccess})
+			Access:      permission.WriteAccess})
 
 	s.Factory.MakeModel(c, &factory.ModelParams{
 		Name: "no-access", Owner: remoteUserTag}).Close()

--- a/apiserver/facades/client/controller/destroy_test.go
+++ b/apiserver/facades/client/controller/destroy_test.go
@@ -54,7 +54,7 @@ func (s *destroyControllerSuite) SetUpTest(c *gc.C) {
 	s.authorizer = apiservertesting.FakeAuthorizer{
 		Tag: s.AdminUserTag(c),
 	}
-	controller, err := controller.NewControllerAPIv4(
+	controller, err := controller.NewControllerAPIv5(
 		facadetest.Context{
 			State_:     s.State,
 			StatePool_: s.StatePool,

--- a/apiserver/params/controller.go
+++ b/apiserver/params/controller.go
@@ -90,6 +90,12 @@ type UserAccessResults struct {
 	Results []UserAccessResult `json:"results,omitempty"`
 }
 
+// ControllerConfigSet holds new config values for
+// Controller.ConfigSet.
+type ControllerConfigSet struct {
+	Config map[string]interface{} `json:"config"`
+}
+
 // ControllerAction is an action that can be performed on a model.
 type ControllerAction string
 

--- a/cmd/juju/commands/main.go
+++ b/cmd/juju/commands/main.go
@@ -436,7 +436,7 @@ func registerCommands(r commandRegistry, ctx *cmd.Context) {
 	r.Register(controller.NewUnregisterCommand(jujuclient.NewFileClientStore()))
 	r.Register(controller.NewEnableDestroyControllerCommand())
 	r.Register(controller.NewShowControllerCommand())
-	r.Register(controller.NewGetConfigCommand())
+	r.Register(controller.NewConfigCommand())
 
 	// Debug Metrics
 	r.Register(metricsdebug.New())

--- a/cmd/juju/controller/configcommand.go
+++ b/cmd/juju/controller/configcommand.go
@@ -67,6 +67,8 @@ See also:
     show-cloud
 `
 
+// Info returns information about this commmand - it's part of
+// cmd.Command.
 func (c *configCommand) Info() *cmd.Info {
 	return &cmd.Info{
 		Name:    "controller-config",
@@ -76,6 +78,8 @@ func (c *configCommand) Info() *cmd.Info {
 	}
 }
 
+// SetFlags adds command-specific flags to the flag set. It's part of
+// cmd.Command.
 func (c *configCommand) SetFlags(f *gnuflag.FlagSet) {
 	c.ControllerCommandBase.SetFlags(f)
 	c.out.AddFlags(f, "tabular", map[string]cmd.Formatter{
@@ -85,6 +89,8 @@ func (c *configCommand) SetFlags(f *gnuflag.FlagSet) {
 	})
 }
 
+// Init initialised the command from the arguments - it's part of
+// cmd.Command.
 func (c *configCommand) Init(args []string) error {
 	switch len(args) {
 	case 0:
@@ -155,6 +161,8 @@ func (c *configCommand) getAPI() (controllerAPI, error) {
 	return apicontroller.NewClient(root), nil
 }
 
+// Run executes the command as directed by the options and
+// arguments. It's part of cmd.Command.
 func (c *configCommand) Run(ctx *cmd.Context) error {
 	client, err := c.getAPI()
 	if err != nil {

--- a/cmd/juju/controller/configcommand.go
+++ b/cmd/juju/controller/configcommand.go
@@ -6,6 +6,7 @@ package controller
 import (
 	"bytes"
 	"io"
+	"os"
 	"strings"
 
 	"github.com/juju/cmd"
@@ -14,37 +15,51 @@ import (
 	"github.com/juju/utils/set"
 
 	apicontroller "github.com/juju/juju/api/controller"
+	"github.com/juju/juju/cmd/juju/common"
 	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/cmd/output"
 	"github.com/juju/juju/controller"
 )
 
+// NewConfigCommand returns a new command that can retrieve or update
+// controller configuration.
 func NewConfigCommand() cmd.Command {
 	return modelcmd.WrapController(&configCommand{})
 }
 
-// getConfigCommand is able to output either the entire environment or
+// configCommand is able to output either the entire environment or
 // the requested value in a format of the user's choosing.
 type configCommand struct {
 	modelcmd.ControllerCommandBase
 	api controllerAPI
-	key string
 	out cmd.Output
+
+	action     func(controllerAPI, *cmd.Context) error // The action we want to perform, set in cmd.Init.
+	key        string                                  // One config key to read.
+	setOptions common.ConfigFlag                       // Config values to set.
 }
 
 const configCommandHelpDoc = `
 By default, all configuration (keys and values) for the controller are
-displayed if a key is not specified.
+displayed if a key is not specified. Supplying one key name returns
+only the value for that key.
 
-The controller configuration is set during bootstrap, available keys
-and values can be found here:
-  https://jujucharms.com/docs/stable/controllers-config
+Supplying key=value will set the supplied key to the supplied value;
+this can be repeated for multiple keys. You can also specify a yaml
+file containing key values. Not all keys can be updated after
+bootstrap time.
+
+Available keys and values can be found here:
+https://jujucharms.com/docs/stable/controllers-config
 
 Examples:
 
     juju controller-config
     juju controller-config api-port
     juju controller-config -c mycontroller
+    juju controller-config auditing-enabled=true audit-log-max-backups=5
+    juju controller-config auditing-enabled=true path/to/file.yaml
+    juju controller-config path/to/file.yaml
 
 See also:
     controllers
@@ -55,8 +70,8 @@ See also:
 func (c *configCommand) Info() *cmd.Info {
 	return &cmd.Info{
 		Name:    "controller-config",
-		Args:    "[<attribute key>]",
-		Purpose: "Displays configuration settings for a controller.",
+		Args:    "[<attribute key>[=<value>] ...]",
+		Purpose: "Displays or sets configuration settings for a controller.",
 		Doc:     strings.TrimSpace(configCommandHelpDoc),
 	}
 }
@@ -70,14 +85,63 @@ func (c *configCommand) SetFlags(f *gnuflag.FlagSet) {
 	})
 }
 
-func (c *configCommand) Init(args []string) (err error) {
-	c.key, err = cmd.ZeroOrOneArgs(args)
-	return
+func (c *configCommand) Init(args []string) error {
+	switch len(args) {
+	case 0:
+		return c.handleZeroArgs()
+	case 1:
+		return c.handleOneArg(args[0])
+	default:
+		return c.handleArgs(args)
+	}
+}
+
+func (c *configCommand) handleZeroArgs() error {
+	c.action = c.getConfig
+	return nil
+}
+
+func (c *configCommand) handleOneArg(arg string) error {
+	// We may have a single config.yaml file
+	_, err := os.Stat(arg)
+	if err == nil || strings.Contains(arg, "=") {
+		return c.parseSetKeys([]string{arg})
+	}
+	c.key = arg
+	c.action = c.getConfig
+	return nil
+}
+
+func (c *configCommand) handleArgs(args []string) error {
+	if err := c.parseSetKeys(args); err != nil {
+		return errors.Trace(err)
+	}
+	for _, arg := range args {
+		// We may have a config.yaml file.
+		_, err := os.Stat(arg)
+		if err != nil && !strings.Contains(arg, "=") {
+			return errors.New("can only retrieve a single value, or all values")
+		}
+	}
+	return nil
+}
+
+// parseSetKeys iterates over the args and make sure that the key=value pairs
+// are valid.
+func (c *configCommand) parseSetKeys(args []string) error {
+	for _, arg := range args {
+		if err := c.setOptions.Set(arg); err != nil {
+			return errors.Trace(err)
+		}
+	}
+	c.action = c.setConfig
+	return nil
 }
 
 type controllerAPI interface {
 	Close() error
 	ControllerConfig() (controller.Config, error)
+	ConfigSet(map[string]interface{}) error
 }
 
 func (c *configCommand) getAPI() (controllerAPI, error) {
@@ -92,16 +156,19 @@ func (c *configCommand) getAPI() (controllerAPI, error) {
 }
 
 func (c *configCommand) Run(ctx *cmd.Context) error {
-	controllerName, err := c.ControllerName()
-	if err != nil {
-		return errors.Trace(err)
-	}
 	client, err := c.getAPI()
 	if err != nil {
 		return err
 	}
 	defer client.Close()
+	return c.action(client, ctx)
+}
 
+func (c *configCommand) getConfig(client controllerAPI, ctx *cmd.Context) error {
+	controllerName, err := c.ControllerName()
+	if err != nil {
+		return errors.Trace(err)
+	}
 	attrs, err := client.ControllerConfig()
 	if err != nil {
 		return err
@@ -117,10 +184,18 @@ func (c *configCommand) Run(ctx *cmd.Context) error {
 			}
 			return c.out.Write(ctx, value)
 		}
-		return errors.Errorf("key %q not found in %q controller.", c.key, controllerName)
+		return errors.Errorf("key %q not found in %q controller", c.key, controllerName)
 	}
 	// If key is empty, write out the whole lot.
 	return c.out.Write(ctx, attrs)
+}
+
+func (c *configCommand) setConfig(client controllerAPI, ctx *cmd.Context) error {
+	attrs, err := c.setOptions.ReadAttrs(ctx)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	return errors.Trace(client.ConfigSet(attrs))
 }
 
 func formatConfigTabular(writer io.Writer, value interface{}) error {

--- a/cmd/juju/controller/configcommand.go
+++ b/cmd/juju/controller/configcommand.go
@@ -19,20 +19,20 @@ import (
 	"github.com/juju/juju/controller"
 )
 
-func NewGetConfigCommand() cmd.Command {
-	return modelcmd.WrapController(&getConfigCommand{})
+func NewConfigCommand() cmd.Command {
+	return modelcmd.WrapController(&configCommand{})
 }
 
 // getConfigCommand is able to output either the entire environment or
 // the requested value in a format of the user's choosing.
-type getConfigCommand struct {
+type configCommand struct {
 	modelcmd.ControllerCommandBase
 	api controllerAPI
 	key string
 	out cmd.Output
 }
 
-const getControllerHelpDoc = `
+const configCommandHelpDoc = `
 By default, all configuration (keys and values) for the controller are
 displayed if a key is not specified.
 
@@ -52,16 +52,16 @@ See also:
     show-cloud
 `
 
-func (c *getConfigCommand) Info() *cmd.Info {
+func (c *configCommand) Info() *cmd.Info {
 	return &cmd.Info{
 		Name:    "controller-config",
 		Args:    "[<attribute key>]",
 		Purpose: "Displays configuration settings for a controller.",
-		Doc:     strings.TrimSpace(getControllerHelpDoc),
+		Doc:     strings.TrimSpace(configCommandHelpDoc),
 	}
 }
 
-func (c *getConfigCommand) SetFlags(f *gnuflag.FlagSet) {
+func (c *configCommand) SetFlags(f *gnuflag.FlagSet) {
 	c.ControllerCommandBase.SetFlags(f)
 	c.out.AddFlags(f, "tabular", map[string]cmd.Formatter{
 		"json":    cmd.FormatJson,
@@ -70,7 +70,7 @@ func (c *getConfigCommand) SetFlags(f *gnuflag.FlagSet) {
 	})
 }
 
-func (c *getConfigCommand) Init(args []string) (err error) {
+func (c *configCommand) Init(args []string) (err error) {
 	c.key, err = cmd.ZeroOrOneArgs(args)
 	return
 }
@@ -80,7 +80,7 @@ type controllerAPI interface {
 	ControllerConfig() (controller.Config, error)
 }
 
-func (c *getConfigCommand) getAPI() (controllerAPI, error) {
+func (c *configCommand) getAPI() (controllerAPI, error) {
 	if c.api != nil {
 		return c.api, nil
 	}
@@ -91,7 +91,7 @@ func (c *getConfigCommand) getAPI() (controllerAPI, error) {
 	return apicontroller.NewClient(root), nil
 }
 
-func (c *getConfigCommand) Run(ctx *cmd.Context) error {
+func (c *configCommand) Run(ctx *cmd.Context) error {
 	controllerName, err := c.ControllerName()
 	if err != nil {
 		return errors.Trace(err)

--- a/cmd/juju/controller/configcommand_test.go
+++ b/cmd/juju/controller/configcommand_test.go
@@ -4,6 +4,8 @@
 package controller_test
 
 import (
+	"io/ioutil"
+	"path/filepath"
 	"strings"
 
 	"github.com/juju/cmd"
@@ -28,19 +30,53 @@ func (s *ConfigSuite) SetUpTest(c *gc.C) {
 }
 
 func (s *ConfigSuite) run(c *gc.C, args ...string) (*cmd.Context, error) {
-	command := controller.NewConfigCommandForTest(&fakeControllerAPI{}, s.store)
+	return s.runWithAPI(c, &fakeControllerAPI{}, args...)
+}
+
+func (s *ConfigSuite) runWithAPI(c *gc.C, api *fakeControllerAPI, args ...string) (*cmd.Context, error) {
+	command := controller.NewConfigCommandForTest(api, s.store)
 	return cmdtesting.RunCommand(c, command, args...)
 }
 
 func (s *ConfigSuite) TestInit(c *gc.C) {
-	// zero or one args is fine.
-	err := cmdtesting.InitCommand(controller.NewConfigCommandForTest(&fakeControllerAPI{}, s.store), nil)
-	c.Check(err, jc.ErrorIsNil)
-	err = cmdtesting.InitCommand(controller.NewConfigCommandForTest(&fakeControllerAPI{}, s.store), []string{"one"})
-	c.Check(err, jc.ErrorIsNil)
-	// More than one is not allowed.
-	err = cmdtesting.InitCommand(controller.NewConfigCommandForTest(&fakeControllerAPI{}, s.store), []string{"one", "two"})
-	c.Check(err, gc.ErrorMatches, `unrecognized args: \["two"\]`)
+	path := writeFile(c, "yamlfile", "")
+
+	tests := []struct {
+		desc string
+		args []string
+		err  string
+	}{{
+		desc: "no args",
+	}, {
+		desc: "get one key",
+		args: []string{"one"},
+	}, {
+		desc: "can't get two keys",
+		args: []string{"one", "two"},
+		err:  "can only retrieve a single value, or all values",
+	}, {
+		desc: "set one key",
+		args: []string{"key=value"},
+	}, {
+		desc: "set two keys",
+		args: []string{"key1=value", "key2=value"},
+	}, {
+		desc: "can't mix setting and getting",
+		args: []string{"key1=value", "hey2"},
+		err:  "can only retrieve a single value, or all values",
+	}, {
+		desc: "can mix setting with files",
+		args: []string{"key1=value", path},
+	}}
+	for i, test := range tests {
+		c.Logf("%d - %s", i, test.desc)
+		err := cmdtesting.InitCommand(controller.NewConfigCommandForTest(&fakeControllerAPI{}, s.store), test.args)
+		if test.err == "" {
+			c.Check(err, jc.ErrorIsNil)
+		} else {
+			c.Check(err, gc.ErrorMatches, test.err)
+		}
+	}
 }
 
 func (s *ConfigSuite) TestSingleValue(c *gc.C) {
@@ -83,14 +119,138 @@ func (s *ConfigSuite) TestAllValuesJSON(c *gc.C) {
 	c.Assert(output, gc.Equals, expected)
 }
 
+func (s *ConfigSuite) TestNonexistentValue(c *gc.C) {
+	context, err := s.run(c, "courtney-barnett")
+	c.Assert(err, gc.ErrorMatches, `key "courtney-barnett" not found in "mallards" controller`)
+
+	output := strings.TrimSpace(cmdtesting.Stdout(context))
+	c.Assert(output, gc.Equals, "")
+}
+
 func (s *ConfigSuite) TestError(c *gc.C) {
 	command := controller.NewConfigCommandForTest(&fakeControllerAPI{err: errors.New("error")}, s.store)
 	_, err := cmdtesting.RunCommand(c, command)
 	c.Assert(err, gc.ErrorMatches, "error")
 }
 
+func (s *ConfigSuite) TestSettingKey(c *gc.C) {
+	var api fakeControllerAPI
+	context, err := s.runWithAPI(c, &api, "key1=value")
+	c.Assert(err, jc.ErrorIsNil)
+
+	output := strings.TrimSpace(cmdtesting.Stdout(context))
+	c.Assert(output, gc.Equals, "")
+
+	c.Assert(api.values, gc.DeepEquals, map[string]interface{}{"key1": "value"})
+}
+
+func (s *ConfigSuite) TestSettingComplexKey(c *gc.C) {
+	var api fakeControllerAPI
+	context, err := s.runWithAPI(c, &api, "key1=[value1,value2]")
+	c.Assert(err, jc.ErrorIsNil)
+
+	output := strings.TrimSpace(cmdtesting.Stdout(context))
+	c.Assert(output, gc.Equals, "")
+
+	c.Assert(api.values, gc.DeepEquals, map[string]interface{}{
+		"key1": []interface{}{"value1", "value2"},
+	})
+}
+
+func (s *ConfigSuite) TestSettingFromFile(c *gc.C) {
+	path := writeFile(c, "yaml", "key1: value\n")
+	var api fakeControllerAPI
+	context, err := s.runWithAPI(c, &api, path)
+	c.Assert(err, jc.ErrorIsNil)
+
+	output := strings.TrimSpace(cmdtesting.Stdout(context))
+	c.Assert(output, gc.Equals, "")
+
+	c.Assert(api.values, gc.DeepEquals, map[string]interface{}{"key1": "value"})
+}
+
+func (s *ConfigSuite) TestSettingFromBothNoOverlap(c *gc.C) {
+	path := writeFile(c, "yaml", "key1: value\n")
+	var api fakeControllerAPI
+	context, err := s.runWithAPI(c, &api, path, "key2=123")
+	c.Assert(err, jc.ErrorIsNil)
+
+	output := strings.TrimSpace(cmdtesting.Stdout(context))
+	c.Assert(output, gc.Equals, "")
+
+	c.Assert(api.values, gc.DeepEquals, map[string]interface{}{
+		"key1": "value",
+		"key2": 123,
+	})
+}
+
+func (s *ConfigSuite) TestSettingFromBothArgFirst(c *gc.C) {
+	path := writeFile(c, "yaml", "key1: value\n")
+	var api fakeControllerAPI
+	context, err := s.runWithAPI(c, &api, "key1=123", path)
+	c.Assert(err, jc.ErrorIsNil)
+
+	output := strings.TrimSpace(cmdtesting.Stdout(context))
+	c.Assert(output, gc.Equals, "")
+
+	// This is a consequence of ConfigFlag reading input files first
+	// and then overlaying with values from args. It's surprising but
+	// probably not worth fixing - I don't think people will try to
+	// set an option from a file and then override it from an arg.
+	c.Assert(api.values, gc.DeepEquals, map[string]interface{}{
+		"key1": 123,
+	})
+}
+
+func (s *ConfigSuite) TestSettingFromBothFileFirst(c *gc.C) {
+	path := writeFile(c, "yaml", "key1: value\n")
+	var api fakeControllerAPI
+	context, err := s.runWithAPI(c, &api, path, "key1=123")
+	c.Assert(err, jc.ErrorIsNil)
+
+	output := strings.TrimSpace(cmdtesting.Stdout(context))
+	c.Assert(output, gc.Equals, "")
+
+	c.Assert(api.values, gc.DeepEquals, map[string]interface{}{
+		"key1": 123,
+	})
+}
+
+func (s *ConfigSuite) TestSettingMultipleFiles(c *gc.C) {
+	path1 := writeFile(c, "yaml1", "key1: value\n")
+	path2 := writeFile(c, "yaml2", "key1: 123\n")
+
+	var api fakeControllerAPI
+	context, err := s.runWithAPI(c, &api, path1, path2)
+	c.Assert(err, jc.ErrorIsNil)
+
+	output := strings.TrimSpace(cmdtesting.Stdout(context))
+	c.Assert(output, gc.Equals, "")
+
+	c.Assert(api.values, gc.DeepEquals, map[string]interface{}{
+		"key1": 123,
+	})
+}
+
+func (s *ConfigSuite) TestErrorOnSetting(c *gc.C) {
+	api := fakeControllerAPI{err: errors.Errorf("kablooie")}
+	context, err := s.runWithAPI(c, &api, "key=value")
+	c.Assert(err, gc.ErrorMatches, "kablooie")
+
+	c.Assert(strings.TrimSpace(cmdtesting.Stdout(context)), gc.Equals, "")
+	c.Assert(api.values, gc.DeepEquals, map[string]interface{}{"key": "value"})
+}
+
+func writeFile(c *gc.C, name, content string) string {
+	path := filepath.Join(c.MkDir(), name)
+	err := ioutil.WriteFile(path, []byte(content), 0777)
+	c.Assert(err, jc.ErrorIsNil)
+	return path
+}
+
 type fakeControllerAPI struct {
-	err error
+	err    error
+	values map[string]interface{}
 }
 
 func (f *fakeControllerAPI) Close() error {
@@ -106,4 +266,9 @@ func (f *fakeControllerAPI) ControllerConfig() (jujucontroller.Config, error) {
 		"api-port":        1234,
 		"ca-cert":         "multi\nline",
 	}, nil
+}
+
+func (f *fakeControllerAPI) ConfigSet(values map[string]interface{}) error {
+	f.values = values
+	return f.err
 }

--- a/cmd/juju/controller/configcommand_test.go
+++ b/cmd/juju/controller/configcommand_test.go
@@ -16,34 +16,34 @@ import (
 	jujucontroller "github.com/juju/juju/controller"
 )
 
-type GetConfigSuite struct {
+type ConfigSuite struct {
 	baseControllerSuite
 }
 
-var _ = gc.Suite(&GetConfigSuite{})
+var _ = gc.Suite(&ConfigSuite{})
 
-func (s *GetConfigSuite) SetUpTest(c *gc.C) {
+func (s *ConfigSuite) SetUpTest(c *gc.C) {
 	s.baseControllerSuite.SetUpTest(c)
 	s.createTestClientStore(c)
 }
 
-func (s *GetConfigSuite) run(c *gc.C, args ...string) (*cmd.Context, error) {
-	command := controller.NewGetConfigCommandForTest(&fakeControllerAPI{}, s.store)
+func (s *ConfigSuite) run(c *gc.C, args ...string) (*cmd.Context, error) {
+	command := controller.NewConfigCommandForTest(&fakeControllerAPI{}, s.store)
 	return cmdtesting.RunCommand(c, command, args...)
 }
 
-func (s *GetConfigSuite) TestInit(c *gc.C) {
+func (s *ConfigSuite) TestInit(c *gc.C) {
 	// zero or one args is fine.
-	err := cmdtesting.InitCommand(controller.NewGetConfigCommandForTest(&fakeControllerAPI{}, s.store), nil)
+	err := cmdtesting.InitCommand(controller.NewConfigCommandForTest(&fakeControllerAPI{}, s.store), nil)
 	c.Check(err, jc.ErrorIsNil)
-	err = cmdtesting.InitCommand(controller.NewGetConfigCommandForTest(&fakeControllerAPI{}, s.store), []string{"one"})
+	err = cmdtesting.InitCommand(controller.NewConfigCommandForTest(&fakeControllerAPI{}, s.store), []string{"one"})
 	c.Check(err, jc.ErrorIsNil)
 	// More than one is not allowed.
-	err = cmdtesting.InitCommand(controller.NewGetConfigCommandForTest(&fakeControllerAPI{}, s.store), []string{"one", "two"})
+	err = cmdtesting.InitCommand(controller.NewConfigCommandForTest(&fakeControllerAPI{}, s.store), []string{"one", "two"})
 	c.Check(err, gc.ErrorMatches, `unrecognized args: \["two"\]`)
 }
 
-func (s *GetConfigSuite) TestSingleValue(c *gc.C) {
+func (s *ConfigSuite) TestSingleValue(c *gc.C) {
 	context, err := s.run(c, "ca-cert")
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -51,7 +51,7 @@ func (s *GetConfigSuite) TestSingleValue(c *gc.C) {
 	c.Assert(output, gc.Equals, "multi\nline")
 }
 
-func (s *GetConfigSuite) TestSingleValueJSON(c *gc.C) {
+func (s *ConfigSuite) TestSingleValueJSON(c *gc.C) {
 	context, err := s.run(c, "--format=json", "controller-uuid")
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -59,7 +59,7 @@ func (s *GetConfigSuite) TestSingleValueJSON(c *gc.C) {
 	c.Assert(output, gc.Equals, `"uuid"`)
 }
 
-func (s *GetConfigSuite) TestAllValues(c *gc.C) {
+func (s *ConfigSuite) TestAllValues(c *gc.C) {
 	context, err := s.run(c)
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -74,7 +74,7 @@ controller-uuid  uuid`[1:]
 	c.Assert(output, gc.Equals, expected)
 }
 
-func (s *GetConfigSuite) TestAllValuesJSON(c *gc.C) {
+func (s *ConfigSuite) TestAllValuesJSON(c *gc.C) {
 	context, err := s.run(c, "--format=json")
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -83,8 +83,8 @@ func (s *GetConfigSuite) TestAllValuesJSON(c *gc.C) {
 	c.Assert(output, gc.Equals, expected)
 }
 
-func (s *GetConfigSuite) TestError(c *gc.C) {
-	command := controller.NewGetConfigCommandForTest(&fakeControllerAPI{err: errors.New("error")}, s.store)
+func (s *ConfigSuite) TestError(c *gc.C) {
+	command := controller.NewConfigCommandForTest(&fakeControllerAPI{err: errors.New("error")}, s.store)
 	_, err := cmdtesting.RunCommand(c, command)
 	c.Assert(err, gc.ErrorMatches, "error")
 }

--- a/cmd/juju/controller/export_test.go
+++ b/cmd/juju/controller/export_test.go
@@ -153,10 +153,10 @@ func KillWaitForModels(command cmd.Command, ctx *cmd.Context, api destroyControl
 	return modelcmd.InnerCommand(command).(*killCommand).WaitForModels(ctx, api, uuid)
 }
 
-// NewGetConfigCommandCommandForTest returns a GetConfigCommandCommand with
+// NewConfigCommandCommandForTest returns a ConfigCommand with
 // the api provided as specified.
-func NewGetConfigCommandForTest(api controllerAPI, store jujuclient.ClientStore) cmd.Command {
-	c := &getConfigCommand{api: api}
+func NewConfigCommandForTest(api controllerAPI, store jujuclient.ClientStore) cmd.Command {
+	c := &configCommand{api: api}
 	c.SetClientStore(store)
 	return modelcmd.WrapController(c)
 }

--- a/cmd/juju/model/configcommand.go
+++ b/cmd/juju/model/configcommand.go
@@ -87,7 +87,7 @@ type configCommandAPI interface {
 // Info implements part of the cmd.Command interface.
 func (c *configCommand) Info() *cmd.Info {
 	info := &cmd.Info{
-		Args:    "[<model-key>[<=value>] ...]",
+		Args:    "[<model-key>[=<value>] ...]",
 		Name:    "model-config",
 		Purpose: modelConfigSummary,
 	}
@@ -184,7 +184,7 @@ func (c *configCommand) handleArgs(args []string) error {
 }
 
 // parseSetKeys iterates over the args and make sure that the key=value pairs
-// are valid. It also checks that the same key isn't being reset.
+// are valid.
 func (c *configCommand) parseSetKeys(args []string) error {
 	for _, arg := range args {
 		if err := c.setOptions.Set(arg); err != nil {

--- a/controller/config.go
+++ b/controller/config.go
@@ -170,6 +170,20 @@ var (
 		AuditLogExcludeMethods,
 	}
 
+	// AllowedUpdateConfigAttributes contains all of the controller
+	// config attributes that are allowed to be updated after the
+	// controller has been restarted.
+	// TODO(babbageclunk): initially this will only be audit log
+	// values, but we should work out which others can also be changed
+	// safely.
+	AllowedUpdateConfigAttributes = set.NewStrings(
+		AuditingEnabled,
+		AuditLogCaptureArgs,
+		AuditLogMaxSize,
+		AuditLogMaxBackups,
+		AuditLogExcludeMethods,
+	)
+
 	// DefaultAuditLogExcludeMethods is the default list of methods to
 	// exclude from the audit log.
 	DefaultAuditLogExcludeMethods = []string{

--- a/controller/config.go
+++ b/controller/config.go
@@ -172,7 +172,7 @@ var (
 
 	// AllowedUpdateConfigAttributes contains all of the controller
 	// config attributes that are allowed to be updated after the
-	// controller has been restarted.
+	// controller has been created.
 	// TODO(babbageclunk): initially this will only be audit log
 	// values, but we should work out which others can also be changed
 	// safely.

--- a/state/settings.go
+++ b/state/settings.go
@@ -5,6 +5,7 @@ package state
 
 import (
 	"fmt"
+	"reflect"
 	"sort"
 	"strings"
 
@@ -172,7 +173,7 @@ func (s *Settings) settingsUpdateOps() ([]ItemChange, []txn.Op) {
 	for key := range cacheKeys(s.disk, s.core) {
 		old, ondisk := s.disk[key]
 		new, incore := s.core[key]
-		if new == old {
+		if reflect.DeepEqual(new, old) {
 			continue
 		}
 		var change ItemChange

--- a/state/settings_test.go
+++ b/state/settings_test.go
@@ -484,3 +484,27 @@ func (s *SettingsSuite) TestList(c *gc.C) {
 		"key#2": {"foo2": "bar2"},
 	})
 }
+
+func (s *SettingsSuite) TestUpdatingInterfaceSliceValue(c *gc.C) {
+	// When storing config values that are coerced from schemas as
+	// List(Something), the value will always be a []interface{}. Make
+	// sure we can safely update settings with those values.
+	s1, err := s.createSettings(s.key, map[string]interface{}{
+		"foo1": []interface{}{"bar1"},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	_, err = s1.Write()
+	c.Assert(err, jc.ErrorIsNil)
+
+	s2, err := s.readSettings()
+	c.Assert(err, jc.ErrorIsNil)
+	s2.Set("foo1", []interface{}{"bar1", "bar2"})
+	_, err = s2.Write()
+	c.Assert(err, jc.ErrorIsNil)
+
+	s3, err := s.readSettings()
+	c.Assert(err, jc.ErrorIsNil)
+	value, found := s3.Get("foo1")
+	c.Assert(found, gc.Equals, true)
+	c.Assert(value, gc.DeepEquals, []interface{}{"bar1", "bar2"})
+}


### PR DESCRIPTION
## Description of change

The `controller-config` command now accepts `key=value` arguments to update controller configuration, in the same way as the `model-config` command. For the moment only audit logging configuration values can be changed - other keys might be allowed in the future (we'd need to make sure the controller handles the change correctly).

YAML config files can also be used to set the values, as with `model-config`.

This PR doesn't include changing the audit logging to respond to the updated config, that will be in a subsequent PR.

## QA steps

Bootstrap a controller with auditing-enabled=false.
See the updated usage: `juju controller-config --help`
Check that it's false: `juju controller-config auditing-enabled`
Run `juju controller-config auditing-enabled=true`
See that it's updated: `juju controller-config auditing-enabled`
Running `juju controller-config api-port=9001` fails.

## Documentation changes
Yes - documentation for `controller-config` should be updated to show changing configuration, and keys that can be changed (`auditing-enabled`, `audit-log-capture-args`, `audit-log-max-size`, `audit-log-max-backups`, `audit-log-exclude-methods`).

