### PR TITLE
Dump model needs to deal with model not found.

### DIFF
--- a/cmd/jujud/dumplogs/dumplogs.go
+++ b/cmd/jujud/dumplogs/dumplogs.go
@@ -154,6 +154,9 @@ func (c *dumpLogsCommand) findMachineId(dataDir string) (string, error) {
 func (c *dumpLogsCommand) dumpLogsForEnv(ctx *cmd.Context, st0 *state.State, tag names.ModelTag) error {
 	st, err := st0.ForModel(tag)
 	if err != nil {
+		if errors.IsNotFound(err) {
+			ctx.Infof("model with uuid %v has been removed", tag.Id())
+		}
 		return errors.Annotate(err, "failed open model")
 	}
 	defer st.Close()


### PR DESCRIPTION
## Description of change

Fix to deal with situations where listing of models returned a uuid for a model that has been destroyed since.