### PR TITLE
Ensure k8s provider works with Juju managed units

### DIFF
--- a/api/caasunitprovisioner/client_test.go
+++ b/api/caasunitprovisioner/client_test.go
@@ -243,7 +243,7 @@ func (s *unitprovisionerSuite) TestUpdateUnits(c *gc.C) {
 				{
 					ApplicationTag: "application-app",
 					Units: []params.ApplicationUnitParams{
-						{Id: "uuid", Address: "address", Ports: []string{"port"},
+						{ProviderId: "uuid", UnitTag: "unit-gitlab-0", Address: "address", Ports: []string{"port"},
 							Status: "active", Info: "message"},
 					},
 				},
@@ -258,7 +258,7 @@ func (s *unitprovisionerSuite) TestUpdateUnits(c *gc.C) {
 	err := client.UpdateUnits(params.UpdateApplicationUnits{
 		ApplicationTag: names.NewApplicationTag("app").String(),
 		Units: []params.ApplicationUnitParams{
-			{Id: "uuid", Address: "address", Ports: []string{"port"},
+			{ProviderId: "uuid", UnitTag: "unit-gitlab-0", Address: "address", Ports: []string{"port"},
 				Status: "active", Info: "message"},
 		},
 	})
@@ -279,7 +279,7 @@ func (s *unitprovisionerSuite) TestUpdateUnitsCount(c *gc.C) {
 	err := client.UpdateUnits(params.UpdateApplicationUnits{
 		ApplicationTag: names.NewApplicationTag("app").String(),
 		Units: []params.ApplicationUnitParams{
-			{Id: "uuid", Address: "address"},
+			{ProviderId: "uuid", Address: "address"},
 		},
 	})
 	c.Check(err, gc.ErrorMatches, `expected 1 result\(s\), got 2`)

--- a/apiserver/facades/controller/caasunitprovisioner/mock_test.go
+++ b/apiserver/facades/controller/caasunitprovisioner/mock_test.go
@@ -136,6 +136,10 @@ func (*mockUnit) Tag() names.Tag {
 	panic("should not be called")
 }
 
+func (u *mockUnit) UnitTag() names.UnitTag {
+	return names.NewUnitTag(u.name)
+}
+
 func (u *mockUnit) Life() state.Life {
 	u.MethodCall(u, "Life")
 	return u.life

--- a/apiserver/facades/controller/caasunitprovisioner/state.go
+++ b/apiserver/facades/controller/caasunitprovisioner/state.go
@@ -77,6 +77,7 @@ func (a applicationShim) AllUnits() ([]Unit, error) {
 type Unit interface {
 	Name() string
 	Life() state.Life
+	UnitTag() names.UnitTag
 	ProviderId() string
 	AgentStatus() (status.StatusInfo, error)
 	UpdateOperation(props state.UnitUpdateProperties) *state.UpdateUnitOperation

--- a/apiserver/params/params.go
+++ b/apiserver/params/params.go
@@ -488,12 +488,13 @@ type UpdateApplicationUnits struct {
 
 // ApplicationUnitParams holds unit parameters used to update a unit.
 type ApplicationUnitParams struct {
-	Id      string                 `json:"id"`
-	Address string                 `json:"address"`
-	Ports   []string               `json:"ports"`
-	Status  string                 `json:"status"`
-	Info    string                 `json:"info"`
-	Data    map[string]interface{} `json:"data"`
+	ProviderId string                 `json:"provider-id"`
+	UnitTag    string                 `json:"unit-tag"`
+	Address    string                 `json:"address"`
+	Ports      []string               `json:"ports"`
+	Status     string                 `json:"status"`
+	Info       string                 `json:"info"`
+	Data       map[string]interface{} `json:"data"`
 }
 
 // DestroyApplicationUnits holds parameters for the deprecated

--- a/caas/broker.go
+++ b/caas/broker.go
@@ -34,6 +34,9 @@ type Broker interface {
 	// EnsureUnit creates or updates a pod with the given spec.
 	EnsureUnit(appName, unitName string, spec *ContainerSpec) error
 
+	// DeleteUnit deletes a unit pod with the given unit name.
+	DeleteUnit(unitName string) error
+
 	// WatchUnits returns a watcher which notifies when there
 	// are changes to units of the specified application.
 	WatchUnits(appName string) (watcher.NotifyWatcher, error)
@@ -45,6 +48,7 @@ type Broker interface {
 // Unit represents information about the status of a "pod".
 type Unit struct {
 	Id      string
+	UnitTag string
 	Address string
 	Ports   []string
 	Status  status.StatusInfo

--- a/caas/kubernetes/provider/k8swatcher.go
+++ b/caas/kubernetes/provider/k8swatcher.go
@@ -9,6 +9,7 @@ import (
 	"github.com/juju/errors"
 	"gopkg.in/tomb.v1"
 	apierrs "k8s.io/client-go/pkg/api/errors"
+	"k8s.io/client-go/pkg/api/v1"
 	"k8s.io/client-go/pkg/watch"
 
 	"github.com/juju/juju/watcher"
@@ -59,7 +60,10 @@ func (w *kubernetesWatcher) loop() error {
 			if !ok {
 				return errors.Errorf("k8s event watcher closed, restarting")
 			}
-			logger.Tracef("received k8s event: %+v", evt)
+			logger.Tracef("received k8s event: %+v", evt.Type)
+			if pod, ok := evt.Object.(*v1.Pod); ok {
+				logger.Tracef("%v(%v) = %v, status=%+v", pod.Name, pod.UID, pod.Labels, pod.Status)
+			}
 			if evt.Type == watch.Error {
 				return errors.Errorf("kubernetes watcher error: %v", apierrs.FromObject(evt.Object))
 			}

--- a/worker/caasunitprovisioner/broker.go
+++ b/worker/caasunitprovisioner/broker.go
@@ -11,6 +11,7 @@ import (
 
 type ContainerBroker interface {
 	EnsureUnit(appName, unitName string, spec *caas.ContainerSpec) error
+	DeleteUnit(unitName string) error
 	WatchUnits(appName string) (watcher.NotifyWatcher, error)
 	Units(appName string) ([]caas.Unit, error)
 }

--- a/worker/caasunitprovisioner/manifold.go
+++ b/worker/caasunitprovisioner/manifold.go
@@ -58,7 +58,7 @@ func (config ManifoldConfig) start(context dependency.Context) (worker.Worker, e
 		ApplicationGetter: client,
 
 		// TODO(caas) - get this based on the CAAS substrate
-		BrokerManagedUnits: true,
+		BrokerManagedUnits: false,
 
 		ServiceBroker:   broker,
 		ContainerBroker: broker,

--- a/worker/caasunitprovisioner/manifold_test.go
+++ b/worker/caasunitprovisioner/manifold_test.go
@@ -127,7 +127,7 @@ func (s *ManifoldSuite) TestStart(c *gc.C) {
 	config := args[0].(caasunitprovisioner.Config)
 
 	c.Assert(config, jc.DeepEquals, caasunitprovisioner.Config{
-		BrokerManagedUnits:  true,
+		BrokerManagedUnits:  false,
 		ApplicationGetter:   &s.client,
 		ServiceBroker:       &s.broker,
 		ContainerBroker:     &s.broker,


### PR DESCRIPTION
## Description of change

The k8s CAAS provider is switched to having Juju mange pod creation, rather than using a deployment controller and having k8s do all that.
The main changes are passing back to the caasunitprovisioner facade the unit tag from the pod (placed there by Juju) and using that instead of provider id to sync up the juju model with the k8s state.
As a driveby, we avoid always deleting and restarting the Juju operator upon agent restart.

## QA steps

Run up a CAAS deployment.
Add/delete units from juju, check that the service is created and the pods are created/deleted.
Delete a pod and check that this is reflected in Juju.
