### PR TITLE
Fix some networking issues with containers and FAN

### DIFF
--- a/network/debinterfaces/activate_test.go
+++ b/network/debinterfaces/activate_test.go
@@ -201,3 +201,22 @@ func (*BridgeSuite) TestActivateFailure(c *gc.C) {
 	c.Check(err, gc.ErrorMatches, "bridge activation failed: artificial failure\n")
 	c.Check(result.Code, gc.Equals, 1)
 }
+
+func (*BridgeSuite) TestActivateFailureShortMessage(c *gc.C) {
+	filename := "testdata/TestInputSourceStanza/interfaces"
+
+	params := debinterfaces.ActivationParams{
+		Clock:    clock.WallClock,
+		Devices:  map[string]string{"eth0": "br-eth0", "eth1": "br-eth1"},
+		DryRun:   true,
+		Filename: filename,
+		// magic value causing the bash script to fail
+		ReconfigureDelay: 25696,
+		Timeout:          5 * time.Minute,
+	}
+
+	result, err := debinterfaces.BridgeAndActivate(params)
+	c.Assert(err, gc.NotNil)
+	c.Check(err, gc.ErrorMatches, "bridge activation failed, see logs for details")
+	c.Check(result.Code, gc.Equals, 1)
+}


### PR DESCRIPTION
## Description of change
This PR fixes a bunch of small issues with container networking and FAN:
1. Don't put long ifup/ifdown failure output to status line, just redirect user to log
2. Try a few times before failing on ifdown/ifup
3. Detect fan bridge by 'fan-' prefix instead of subnet property (for FAN to work on networkless envs)
4. Detect spaces with FAN support on machine properly

## QA steps
1. Do something to make ifdown fail (e.g put some garbage option in e/n/i) try to deploy a container on a machine in 'provider' mode - juju status should redirect to log and not show full stderr of ifdown/ifup
2. That's a fix for spurious errors we've been observing in the field
3. Try deploying FAN on e.g. vsphere environment, verify that everything is working correctly.
4. Deploy a machine with 2 spaces and FAN, deploy container to the FAN space, verify that it's set up correctly

## Documentation changes
None
