### PR TITLE
Dump logs when no model.

### DIFF
--- a/cmd/jujud/dumplogs/dumplogs.go
+++ b/cmd/jujud/dumplogs/dumplogs.go
@@ -156,6 +156,7 @@ func (c *dumpLogsCommand) dumpLogsForEnv(ctx *cmd.Context, st0 *state.State, tag
 	if err != nil {
 		if errors.IsNotFound(err) {
 			ctx.Infof("model with uuid %v has been removed", tag.Id())
+			return nil
 		}
 		return errors.Annotate(err, "failed open model")
 	}


### PR DESCRIPTION
## Description of change

There is a potential for model uuid to be retrieved, model to be destroyed and then we still try to do something with this model - in this case, dump db/logs from it. This patch ensures that, in this scenario, we return cleanly from the call without erring out.
Most of the fixes of this type have been committed previously, except for this place. 


