### PR TITLE
Return from call when no model found.

### DIFF
--- a/cmd/jujud/dumplogs/dumplogs.go
+++ b/cmd/jujud/dumplogs/dumplogs.go
@@ -162,6 +162,10 @@ func (c *dumpLogsCommand) findMachineId(dataDir string) (string, error) {
 func (c *dumpLogsCommand) dumpLogsForEnv(ctx *cmd.Context, statePool *state.StatePool, tag names.ModelTag) error {
 	st, release, err := statePool.Get(tag.Id())
 	if err != nil {
+		if errors.IsNotFound(err) {
+			ctx.Infof("model with uuid %v has been removed", tag.Id())
+			return nil
+		}
 		return errors.Annotate(err, "failed open model")
 	}
 	defer release()


### PR DESCRIPTION
## Description of change

Fix to deal with situations where listing of models returned a uuid for a model that has been destroyed since.
