### PR TITLE
CI: Update and fix test and template re: --existing usage.

### DIFF
--- a/acceptancetests/assess_persistent_storage.py
+++ b/acceptancetests/assess_persistent_storage.py
@@ -11,7 +11,6 @@ import time
 
 from deploy_stack import (
     BootstrapManager,
-    test_on_controller,
     )
 from jujucharm import local_charm_path
 from utility import (
@@ -456,7 +455,8 @@ def main(argv=None):
         # PR7635 is for persistent storage feature on lxd.
         log.error('Incorrect substrate, must be AWS.')
         sys.exit(1)
-    test_on_controller(assess_persistent_storage, args)
+    with bs_manager.booted_context(args.upload_tools):
+        assess_persistent_storage(bs_manager.client)
     return 0
 
 

--- a/acceptancetests/template_assess.py.tmpl
+++ b/acceptancetests/template_assess.py.tmpl
@@ -15,7 +15,7 @@ import logging
 import sys
 
 from deploy_stack import (
-    test_on_controller,
+    BootstrapManager,
     )
 from utility import (
     add_basic_testing_arguments,
@@ -41,6 +41,8 @@ def parse_args(argv):
     """Parse all arguments."""
     parser = argparse.ArgumentParser(description="TODO: script info")
     # TODO: Add additional positional arguments.
+    # NOTE: If this test does *not* support running on an existing bootstrapped
+    #   controller, pass `existing=False` to add_basic_testing_arguments.
     add_basic_testing_arguments(parser)
     # TODO: Add additional optional arguments.
     return parser.parse_args(argv)
@@ -49,7 +51,9 @@ def parse_args(argv):
 def main(argv=None):
     args = parse_args(argv)
     configure_logging(args.verbose)
-    test_on_controller(assess_TEMPLATE, args)
+    bs_manager = BootstrapManager.from_args(args)
+    with bs_manager.booted_context(args.upload_tools):
+        assess_TEMPLATE(bs_manager.client)
     return 0
 
 


### PR DESCRIPTION
Fix assess_persistent_storage.py and template_assess.py.tmpl to reflect changes to --existing usage.

assess_persistent_storage.py and the template were using the old way of using an existing controller (test_on_controller no longer exists).