### PR TITLE
When listing models, exclude all dead ones.

### DIFF
--- a/state/model_test.go
+++ b/state/model_test.go
@@ -1205,6 +1205,33 @@ func (s *ModelSuite) TestAllModelUUIDs(c *gc.C) {
 	c.Assert(obtained, jc.DeepEquals, expected)
 }
 
+func (s *ModelSuite) TestAllModelUUIDsExcludesDead(c *gc.C) {
+	expected := []string{
+		s.State.ModelUUID(),
+	}
+
+	st1 := s.Factory.MakeModel(c, nil)
+	defer st1.Close()
+
+	m1, err := st1.Model()
+	c.Assert(err, jc.ErrorIsNil)
+	expectedWithAddition := append(expected, m1.UUID())
+	obtained, err := s.State.AllModelUUIDs()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(obtained, jc.DeepEquals, expectedWithAddition)
+
+	err = m1.SetDead()
+	c.Assert(err, jc.ErrorIsNil)
+
+	obtained, err = s.State.AllModelUUIDs()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(obtained, jc.DeepEquals, expected)
+
+	obtained, err = s.State.AllModelUUIDsIncludingDead()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(obtained, jc.DeepEquals, expectedWithAddition)
+}
+
 func (s *ModelSuite) TestHostedModelCount(c *gc.C) {
 	c.Assert(state.HostedModelCount(c, s.State), gc.Equals, 0)
 

--- a/state/undertaker.go
+++ b/state/undertaker.go
@@ -32,8 +32,8 @@ func (st *State) ProcessDyingModel() (err error) {
 		if st.IsController() {
 			// We should not mark the controller model as Dead until
 			// all hosted models have been removed, otherwise the
-			// hosted model environs may not have beeen destroyed.
-			modelUUIDs, err := st.AllModelUUIDs()
+			// hosted model environs may not have been destroyed.
+			modelUUIDs, err := st.AllModelUUIDsIncludingDead()
 			if err != nil {
 				return nil, errors.Trace(err)
 			}


### PR DESCRIPTION
## Description of change

Forward port of merge #8313 .

In our code, whenever we ask for a list of models, we have always implied that we want all models that are not dead (since we deal with dead models separately and individually when needed).

This patch ensures that model list query returns all non-dead models.

There are only couple of places where we want to know about dead models. These are all at the code path that ensures destruction of a controller. This patch modifies the calls that are made at destruction to retrieve all models, including the dead ones.

Added a unit test for sanity.

