### PR TITLE
Bug 1591962 mgmt space usage

### DIFF
--- a/agent/agentbootstrap/bootstrap_test.go
+++ b/agent/agentbootstrap/bootstrap_test.go
@@ -289,7 +289,7 @@ LXC_BRIDGE="ignored"`[1:])
 	c.Assert(*gotHW, gc.DeepEquals, expectHW)
 
 	// Check that the API host ports are initialised correctly.
-	apiHostPorts, err := st.APIHostPorts()
+	apiHostPorts, err := st.APIHostPortsForClients()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(apiHostPorts, jc.DeepEquals, [][]network.HostPort{
 		network.AddressesWithPort(filteredAddrs, 1234),

--- a/apiserver/admin.go
+++ b/apiserver/admin.go
@@ -101,7 +101,13 @@ func (a *admin) login(req params.LoginRequest, loginVersion int) (params.LoginRe
 	}
 
 	// Fetch the API server addresses from state.
-	hostPorts, err := a.root.state.APIHostPortsForAgents()
+	// If the login comes from a client, return all available addresses.
+	// Otherwise return the addresses suitable for agent use.
+	getHostPorts := a.root.state.APIHostPortsForAgents
+	if k, _ := names.TagKind(req.AuthTag); k == names.UserTagKind {
+		getHostPorts = a.root.state.APIHostPortsForClients
+	}
+	hostPorts, err := getHostPorts()
 	if err != nil {
 		return fail, errors.Trace(err)
 	}

--- a/apiserver/admin.go
+++ b/apiserver/admin.go
@@ -101,7 +101,7 @@ func (a *admin) login(req params.LoginRequest, loginVersion int) (params.LoginRe
 	}
 
 	// Fetch the API server addresses from state.
-	hostPorts, err := a.root.state.APIHostPorts()
+	hostPorts, err := a.root.state.APIHostPortsForAgents()
 	if err != nil {
 		return fail, errors.Trace(err)
 	}

--- a/apiserver/common/addresses.go
+++ b/apiserver/common/addresses.go
@@ -39,8 +39,8 @@ func NewAPIAddresser(getter AddressAndCertGetter, resources facade.Resources) *A
 }
 
 // APIHostPorts returns the API server addresses.
-func (api *APIAddresser) APIHostPorts() (params.APIHostPortsResult, error) {
-	servers, err := api.getter.APIHostPortsForAgents()
+func (a *APIAddresser) APIHostPorts() (params.APIHostPortsResult, error) {
+	servers, err := a.getter.APIHostPortsForAgents()
 	if err != nil {
 		return params.APIHostPortsResult{}, err
 	}
@@ -50,19 +50,19 @@ func (api *APIAddresser) APIHostPorts() (params.APIHostPortsResult, error) {
 }
 
 // WatchAPIHostPorts watches the API server addresses.
-func (api *APIAddresser) WatchAPIHostPorts() (params.NotifyWatchResult, error) {
-	watch := api.getter.WatchAPIHostPortsForAgents()
+func (a *APIAddresser) WatchAPIHostPorts() (params.NotifyWatchResult, error) {
+	watch := a.getter.WatchAPIHostPortsForAgents()
 	if _, ok := <-watch.Changes(); ok {
 		return params.NotifyWatchResult{
-			NotifyWatcherId: api.resources.Register(watch),
+			NotifyWatcherId: a.resources.Register(watch),
 		}, nil
 	}
 	return params.NotifyWatchResult{}, watcher.EnsureErr(watch)
 }
 
 // APIAddresses returns the list of addresses used to connect to the API.
-func (api *APIAddresser) APIAddresses() (params.StringsResult, error) {
-	addrs, err := apiAddresses(api.getter)
+func (a *APIAddresser) APIAddresses() (params.StringsResult, error) {
+	addrs, err := apiAddresses(a.getter)
 	if err != nil {
 		return params.StringsResult{}, err
 	}

--- a/apiserver/common/addresses_test.go
+++ b/apiserver/common/addresses_test.go
@@ -113,10 +113,10 @@ func (fakeAddresses) ModelUUID() string {
 	return "the environ uuid"
 }
 
-func (f fakeAddresses) APIHostPorts() ([][]network.HostPort, error) {
+func (f fakeAddresses) APIHostPortsForAgents() ([][]network.HostPort, error) {
 	return f.hostPorts, nil
 }
 
-func (fakeAddresses) WatchAPIHostPorts() state.NotifyWatcher {
+func (fakeAddresses) WatchAPIHostPortsForAgents() state.NotifyWatcher {
 	panic("should never be called")
 }

--- a/apiserver/common/controllerconfig_test.go
+++ b/apiserver/common/controllerconfig_test.go
@@ -121,7 +121,7 @@ func (s *controllerInfoSuite) TestControllerInfoLocalModel(c *gc.C) {
 		Entities: []params.Entity{{Tag: s.localModel.ModelTag().String()}}})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results.Results, gc.HasLen, 1)
-	apiAddr, err := s.State.APIHostPorts()
+	apiAddr, err := s.State.APIHostPortsForClients()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results.Results[0].Addresses, gc.HasLen, 1)
 	c.Assert(results.Results[0].Addresses[0], gc.Equals, apiAddr[0][0].String())

--- a/apiserver/common/modelmanagerinterface.go
+++ b/apiserver/common/modelmanagerinterface.go
@@ -23,7 +23,7 @@ import (
 // All the interface methods are defined directly on state.State
 // and are reproduced here for use in tests.
 type ModelManagerBackend interface {
-	APIHostPortsGetter
+	APIHostPortsForAgentsGetter
 	ToolsStorageGetter
 	BlockGetter
 	state.CloudAccessor

--- a/apiserver/common/tools.go
+++ b/apiserver/common/tools.go
@@ -29,10 +29,13 @@ type ToolsURLGetter interface {
 	ToolsURLs(v version.Binary) ([]string, error)
 }
 
-// APIHostPortsGetter is an interface providing the APIHostPorts method.
-type APIHostPortsGetter interface {
-	// APIHostPorst returns the HostPorts for each API server.
-	APIHostPorts() ([][]network.HostPort, error)
+// APIHostPortsGetter is an interface providing the APIHostPortsForAgents
+// method.
+type APIHostPortsForAgentsGetter interface {
+	// APIHostPortsForAgents returns the HostPorts for each API server that
+	// are suitable for agent-to-controller API communication based on the
+	// configured (if any) controller management space.
+	APIHostPortsForAgents() ([][]network.HostPort, error)
 }
 
 // ToolsStorageGetter is an interface providing the ToolsStorage method.
@@ -335,12 +338,12 @@ func toolsFilter(args params.FindToolsParams) coretools.Filter {
 
 type toolsURLGetter struct {
 	modelUUID          string
-	apiHostPortsGetter APIHostPortsGetter
+	apiHostPortsGetter APIHostPortsForAgentsGetter
 }
 
 // NewToolsURLGetter creates a new ToolsURLGetter that
 // returns tools URLs pointing at an API server.
-func NewToolsURLGetter(modelUUID string, a APIHostPortsGetter) *toolsURLGetter {
+func NewToolsURLGetter(modelUUID string, a APIHostPortsForAgentsGetter) *toolsURLGetter {
 	return &toolsURLGetter{modelUUID, a}
 }
 

--- a/apiserver/common/tools_test.go
+++ b/apiserver/common/tools_test.go
@@ -328,7 +328,7 @@ type mockAPIHostPortsGetter struct {
 	err       error
 }
 
-func (g mockAPIHostPortsGetter) APIHostPorts() ([][]network.HostPort, error) {
+func (g mockAPIHostPortsGetter) APIHostPortsForAgents() ([][]network.HostPort, error) {
 	return g.hostPorts, g.err
 }
 

--- a/apiserver/facades/agent/caasoperator/mock_test.go
+++ b/apiserver/facades/agent/caasoperator/mock_test.go
@@ -55,8 +55,8 @@ func (st *mockState) Model() (caasoperator.Model, error) {
 	return &st.model, nil
 }
 
-func (st *mockState) APIHostPorts() ([][]network.HostPort, error) {
-	st.MethodCall(st, "APIHostPorts")
+func (st *mockState) APIHostPortsForAgents() ([][]network.HostPort, error) {
+	st.MethodCall(st, "APIHostPortsForAgents")
 	if err := st.NextErr(); err != nil {
 		return nil, err
 	}

--- a/apiserver/facades/agent/caasoperator/operator.go
+++ b/apiserver/facades/agent/caasoperator/operator.go
@@ -70,7 +70,7 @@ func (f *Facade) APIAddresses() (params.StringsResult, error) {
 }
 
 func apiAddresses(getter CAASOperatorState) ([]string, error) {
-	apiHostPorts, err := getter.APIHostPorts()
+	apiHostPorts, err := getter.APIHostPortsForAgents()
 	if err != nil {
 		return nil, err
 	}

--- a/apiserver/facades/agent/caasoperator/state.go
+++ b/apiserver/facades/agent/caasoperator/state.go
@@ -18,7 +18,7 @@ import (
 type CAASOperatorState interface {
 	Application(string) (Application, error)
 	Model() (Model, error)
-	APIHostPorts() ([][]network.HostPort, error)
+	APIHostPortsForAgents() ([][]network.HostPort, error)
 }
 
 // Model provides the subset of CAAS model state required

--- a/apiserver/facades/agent/proxyupdater/proxyupdater.go
+++ b/apiserver/facades/agent/proxyupdater/proxyupdater.go
@@ -20,8 +20,8 @@ import (
 // mocked for testing.
 type Backend interface {
 	ModelConfig() (*config.Config, error)
-	APIHostPorts() ([][]network.HostPort, error)
-	WatchAPIHostPorts() state.NotifyWatcher
+	APIHostPortsForAgents() ([][]network.HostPort, error)
+	WatchAPIHostPortsForAgents() state.NotifyWatcher
 	WatchForModelConfigChanges() state.NotifyWatcher
 }
 
@@ -48,7 +48,7 @@ func (api *ProxyUpdaterAPI) oneWatch() params.NotifyWatchResult {
 
 	watch := common.NewMultiNotifyWatcher(
 		api.backend.WatchForModelConfigChanges(),
-		api.backend.WatchAPIHostPorts())
+		api.backend.WatchAPIHostPortsForAgents())
 
 	if _, ok := <-watch.Changes(); ok {
 		result = params.NotifyWatchResult{
@@ -118,7 +118,7 @@ func (api *ProxyUpdaterAPI) proxyConfig() params.ProxyConfigResult {
 		return result
 	}
 
-	apiHostPorts, err := api.backend.APIHostPorts()
+	apiHostPorts, err := api.backend.APIHostPortsForAgents()
 	if err != nil {
 		result.Error = common.ServerError(err)
 		return result

--- a/apiserver/facades/agent/proxyupdater/proxyupdater_test.go
+++ b/apiserver/facades/agent/proxyupdater/proxyupdater_test.go
@@ -71,7 +71,7 @@ func (s *ProxyUpdaterSuite) TestWatchForProxyConfigAndAPIHostPortChanges(c *gc.C
 
 	s.state.Stub.CheckCallNames(c,
 		"WatchForModelConfigChanges",
-		"WatchAPIHostPorts",
+		"WatchAPIHostPortsForAgents",
 	)
 
 	// Verify the watcher resource was registered.
@@ -102,7 +102,7 @@ func (s *ProxyUpdaterSuite) TestProxyConfig(c *gc.C) {
 
 	s.state.Stub.CheckCallNames(c,
 		"ModelConfig",
-		"APIHostPorts",
+		"APIHostPortsForAgents",
 	)
 
 	noProxy := "0.1.2.3,0.1.2.4,0.1.2.5"
@@ -128,7 +128,7 @@ func (s *ProxyUpdaterSuite) TestProxyConfigExtendsExisting(c *gc.C) {
 	cfg := s.facade.ProxyConfig(s.oneEntity())
 	s.state.Stub.CheckCallNames(c,
 		"ModelConfig",
-		"APIHostPorts",
+		"APIHostPortsForAgents",
 	)
 
 	expectedNoProxy := "0.1.2.3,0.1.2.4,0.1.2.5,9.9.9.9"
@@ -154,7 +154,7 @@ func (s *ProxyUpdaterSuite) TestProxyConfigNoDuplicates(c *gc.C) {
 	cfg := s.facade.ProxyConfig(s.oneEntity())
 	s.state.Stub.CheckCallNames(c,
 		"ModelConfig",
-		"APIHostPorts",
+		"APIHostPortsForAgents",
 	)
 
 	expectedNoProxy := "0.1.2.3,0.1.2.4,0.1.2.5"
@@ -208,8 +208,8 @@ func (sb *stubBackend) ModelConfig() (*config.Config, error) {
 	return coretesting.CustomModelConfig(sb.c, sb.configAttrs), nil
 }
 
-func (sb *stubBackend) APIHostPorts() ([][]network.HostPort, error) {
-	sb.MethodCall(sb, "APIHostPorts")
+func (sb *stubBackend) APIHostPortsForAgents() ([][]network.HostPort, error) {
+	sb.MethodCall(sb, "APIHostPortsForAgents")
 	if err := sb.NextErr(); err != nil {
 		return nil, err
 	}
@@ -221,8 +221,8 @@ func (sb *stubBackend) APIHostPorts() ([][]network.HostPort, error) {
 	return hps, nil
 }
 
-func (sb *stubBackend) WatchAPIHostPorts() state.NotifyWatcher {
-	sb.MethodCall(sb, "WatchAPIHostPorts")
+func (sb *stubBackend) WatchAPIHostPortsForAgents() state.NotifyWatcher {
+	sb.MethodCall(sb, "WatchAPIHostPortsForAgents")
 	return sb.hpWatcher
 }
 

--- a/apiserver/facades/agent/proxyupdater/shims.go
+++ b/apiserver/facades/agent/proxyupdater/shims.go
@@ -21,12 +21,12 @@ func (s *stateShim) ModelConfig() (*config.Config, error) {
 	return s.m.ModelConfig()
 }
 
-func (s *stateShim) APIHostPorts() ([][]network.HostPort, error) {
-	return s.st.APIHostPorts()
+func (s *stateShim) APIHostPortsForAgents() ([][]network.HostPort, error) {
+	return s.st.APIHostPortsForAgents()
 }
 
-func (s *stateShim) WatchAPIHostPorts() state.NotifyWatcher {
-	return s.st.WatchAPIHostPorts()
+func (s *stateShim) WatchAPIHostPortsForAgents() state.NotifyWatcher {
+	return s.st.WatchAPIHostPortsForAgents()
 }
 
 func (s *stateShim) WatchForModelConfigChanges() state.NotifyWatcher {

--- a/apiserver/facades/client/client/backend.go
+++ b/apiserver/facades/client/client/backend.go
@@ -39,7 +39,7 @@ type Backend interface {
 	AllRelations() ([]*state.Relation, error)
 	AllSubnets() ([]*state.Subnet, error)
 	Annotations(state.GlobalEntity) (map[string]string, error)
-	APIHostPorts() ([][]network.HostPort, error)
+	APIHostPortsForClients() ([][]network.HostPort, error)
 	Application(string) (*state.Application, error)
 	ApplicationLeaders() (map[string]string, error)
 	Charm(*charm.URL) (*state.Charm, error)

--- a/apiserver/facades/client/client/client.go
+++ b/apiserver/facades/client/client/client.go
@@ -688,7 +688,7 @@ func (c *Client) APIHostPorts() (result params.APIHostPortsResult, err error) {
 	}
 
 	var servers [][]network.HostPort
-	if servers, err = c.api.stateAccessor.APIHostPorts(); err != nil {
+	if servers, err = c.api.stateAccessor.APIHostPortsForClients(); err != nil {
 		return params.APIHostPortsResult{}, err
 	}
 	result.Servers = params.FromNetworkHostsPorts(servers)

--- a/apiserver/facades/client/client/instanceconfig.go
+++ b/apiserver/facades/client/client/instanceconfig.go
@@ -77,7 +77,7 @@ func InstanceConfig(st *state.State, machineId, nonce, dataDir string) (*instanc
 	caCert, _ := controllerConfig.CACert()
 
 	// Get the API connection info; attempt all API addresses.
-	apiHostPorts, err := st.APIHostPorts()
+	apiHostPorts, err := st.APIHostPortsForAgents()
 	if err != nil {
 		return nil, errors.Annotate(err, "getting API addresses")
 	}

--- a/apiserver/facades/client/modelmanager/modelinfo_test.go
+++ b/apiserver/facades/client/modelmanager/modelinfo_test.go
@@ -539,7 +539,7 @@ type mockState struct {
 	gitjujutesting.Stub
 
 	environs.EnvironConfigGetter
-	common.APIHostPortsGetter
+	common.APIHostPortsForAgentsGetter
 	common.ToolsStorageGetter
 	common.BlockGetter
 	metricSender

--- a/apiserver/facades/controller/crosscontroller/crosscontroller.go
+++ b/apiserver/facades/controller/crosscontroller/crosscontroller.go
@@ -32,7 +32,7 @@ func NewStateCrossControllerAPI(ctx facade.Context) (*CrossControllerAPI, error)
 	return NewCrossControllerAPI(
 		ctx.Resources(),
 		func() ([]string, string, error) { return common.StateControllerInfo(st) },
-		st.WatchAPIHostPorts,
+		st.WatchAPIHostPortsForClients,
 	)
 }
 

--- a/apiserver/watcher.go
+++ b/apiserver/watcher.go
@@ -457,7 +457,7 @@ var getMigrationBackend = func(st *state.State) migrationBackend {
 // migration watchers.
 type migrationBackend interface {
 	LatestMigration() (state.ModelMigration, error)
-	APIHostPorts() ([][]network.HostPort, error)
+	APIHostPortsForClients() ([][]network.HostPort, error)
 	ControllerConfig() (controller.Config, error)
 }
 
@@ -542,7 +542,7 @@ func (w *srvMigrationStatusWatcher) Next() (params.MigrationStatus, error) {
 }
 
 func (w *srvMigrationStatusWatcher) getLocalHostPorts() ([]string, error) {
-	hostports, err := w.st.APIHostPorts()
+	hostports, err := w.st.APIHostPortsForClients()
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/apiserver/watcher_test.go
+++ b/apiserver/watcher_test.go
@@ -182,7 +182,7 @@ func (b *fakeMigrationBackend) LatestMigration() (state.ModelMigration, error) {
 	return new(fakeModelMigration), nil
 }
 
-func (b *fakeMigrationBackend) APIHostPorts() ([][]network.HostPort, error) {
+func (b *fakeMigrationBackend) APIHostPortsForClients() ([][]network.HostPort, error) {
 	return [][]network.HostPort{
 		MustParseHostPorts("1.2.3.4:5", "2.3.4.5:6"),
 		MustParseHostPorts("3.4.5.6:7"),

--- a/state/address.go
+++ b/state/address.go
@@ -210,8 +210,8 @@ func (st *State) filterHostPortsForManagementSpace(apiHostPorts [][]network.Host
 	return hostPortsForAgents, nil
 }
 
-// APIHostPorts returns the collection of *all* API addresses as set by SetAPIHostPorts.
-func (st *State) APIHostPorts() ([][]network.HostPort, error) {
+// APIHostPortsForClients returns the collection of *all* known API addresses.
+func (st *State) APIHostPortsForClients() ([][]network.HostPort, error) {
 	hp, err := st.apiHostPortsForKey(apiHostPortsKey)
 	if err != nil {
 		err = errors.Trace(err)
@@ -219,18 +219,19 @@ func (st *State) APIHostPorts() ([][]network.HostPort, error) {
 	return hp, err
 }
 
-// APIHostPortsForAgents returns the collection of API addresses that should be used
-// by agents.
-// If there is no management network space configured for the controller
-// or if the space is misconfigured, the return will be the same as APIHostPorts.
+// APIHostPortsForAgents returns the collection of API addresses that should
+// be used by agents.
+// If there is no management network space configured for the controller,
+// or if the space is misconfigured, the return will be the same as
+// APIHostPortsForClients.
 // Otherwise the returned addresses will correspond with the management net space.
-// If there is no document at all, we simply fall back to APIHostPorts.
+// If there is no document at all, we simply fall back to APIHostPortsForClients.
 func (st *State) APIHostPortsForAgents() ([][]network.HostPort, error) {
 	hp, err := st.apiHostPortsForKey(apiHostPortsForAgentsKey)
 	if err != nil {
 		if err == mgo.ErrNotFound {
 			logger.Debugf("No document for %s; using %s", apiHostPortsForAgentsKey, apiHostPortsKey)
-			return st.APIHostPorts()
+			return st.APIHostPortsForClients()
 		}
 		return nil, errors.Trace(err)
 	}

--- a/state/conn_test.go
+++ b/state/conn_test.go
@@ -10,6 +10,7 @@ import (
 	"gopkg.in/juju/names.v2"
 	"gopkg.in/mgo.v2"
 
+	"github.com/juju/juju/controller"
 	"github.com/juju/juju/provider/dummy"
 	"github.com/juju/juju/state"
 	statetesting "github.com/juju/juju/state/testing"
@@ -130,12 +131,12 @@ func (s *ConnSuite) NewStateForModelNamed(c *gc.C, modelName string) *state.Stat
 }
 
 // SetJujuManagementSpace mimics a controller having been configured with a
-// management space. It is the space name that constrains the set of
-// addresses agents should use for controller communication.
+// management space name. This is the space that constrains the set of
+// addresses that agents should use for controller communication.
 func (s *ConnSuite) SetJujuManagementSpace(c *gc.C, space string) {
-	controllerSettings, err := s.State.ReadSettings("controllers", "controllerSettings")
+	controllerSettings, err := s.State.ReadSettings(state.ControllersC, "controllerSettings")
 	c.Assert(err, jc.ErrorIsNil)
-	controllerSettings.Set("juju-mgmt-space", space)
+	controllerSettings.Set(controller.JujuManagementSpace, space)
 	_, err = controllerSettings.Write()
 	c.Assert(err, jc.ErrorIsNil)
 }

--- a/state/initialize_test.go
+++ b/state/initialize_test.go
@@ -167,7 +167,7 @@ func (s *InitializeSuite) TestInitialize(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(&cons, jc.Satisfies, constraints.IsEmpty)
 
-	addrs, err := s.State.APIHostPorts()
+	addrs, err := s.State.APIHostPortsForClients()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(addrs, gc.HasLen, 0)
 

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -4531,11 +4531,7 @@ func (s *StateSuite) TestSetAPIHostPortsNoMgmtSpaceConcurrentDifferent(c *gc.C) 
 }
 
 func (s *StateSuite) TestSetAPIHostPortsWithMgmtSpace(c *gc.C) {
-	// Simulate a controller configured with a management network space.
-	controllerSettings, err := s.State.ReadSettings(state.ControllersC, "controllerSettings")
-	c.Assert(err, jc.ErrorIsNil)
-	controllerSettings.Set("juju-mgmt-space", "mgmt01")
-	_, err = controllerSettings.Write()
+	s.SetJujuManagementSpace(c, "mgmt01")
 
 	addrs, err := s.State.APIHostPorts()
 	c.Assert(err, jc.ErrorIsNil)

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -4680,6 +4680,7 @@ func (s *StateSuite) TestWatchAPIHostPortsForAgents(c *gc.C) {
 		mgmtHP,
 	}})
 	c.Assert(err, jc.ErrorIsNil)
+	wc.AssertOneChange()
 
 	// This should cause no change to APIHostPortsForAgents.
 	// We expect only one watcher notification.
@@ -4695,8 +4696,7 @@ func (s *StateSuite) TestWatchAPIHostPortsForAgents(c *gc.C) {
 		},
 	}})
 	c.Assert(err, jc.ErrorIsNil)
-
-	wc.AssertOneChange()
+	wc.AssertNoChange()
 
 	// Stop, check closed.
 	statetesting.AssertStop(c, w)

--- a/state/watcher.go
+++ b/state/watcher.go
@@ -1565,10 +1565,16 @@ func (st *State) WatchForUnitAssignment() StringsWatcher {
 	return newCollectionWatcher(st, colWCfg{col: assignUnitC})
 }
 
-// WatchAPIHostPorts returns a NotifyWatcher that notifies
+// WatchAPIHostPortsForClients returns a NotifyWatcher that notifies
 // when the set of API addresses changes.
-func (st *State) WatchAPIHostPorts() NotifyWatcher {
+func (st *State) WatchAPIHostPortsForClients() NotifyWatcher {
 	return newEntityWatcher(st, controllersC, apiHostPortsKey)
+}
+
+// WatchAPIHostPortsForAgents returns a NotifyWatcher that notifies
+// when the set of API addresses usable by agents changes.
+func (st *State) WatchAPIHostPortsForAgents() NotifyWatcher {
+	return newEntityWatcher(st, controllersC, apiHostPortsForAgentsKey)
 }
 
 // WatchStorageAttachment returns a watcher for observing changes

--- a/worker/certupdater/certupdater.go
+++ b/worker/certupdater/certupdater.go
@@ -59,9 +59,9 @@ type StateServingInfoGetter interface {
 type StateServingInfoSetter func(info params.StateServingInfo) error
 
 // APIHostPortsGetter is an interface that is provided to NewCertificateUpdater.
-// It provides addresses suitable for agent-to-controller API communication.
+// It returns all known API addresses.
 type APIHostPortsGetter interface {
-	APIHostPortsForAgents() ([][]network.HostPort, error)
+	APIHostPortsForClients() ([][]network.HostPort, error)
 }
 
 // Config holds the configuration for the certificate updater worker.
@@ -89,7 +89,7 @@ func NewCertificateUpdater(config Config) worker.Worker {
 // SetUp is defined on the NotifyWatchHandler interface.
 func (c *CertificateUpdater) SetUp() (state.NotifyWatcher, error) {
 	// Populate certificate SAN with any addresses we know about now.
-	apiHostPorts, err := c.hostPortsGetter.APIHostPortsForAgents()
+	apiHostPorts, err := c.hostPortsGetter.APIHostPortsForClients()
 	if err != nil {
 		return nil, errors.Annotate(err, "retrieving initial server addresses")
 	}
@@ -171,8 +171,8 @@ func (c *CertificateUpdater) updateCertificate(addresses []network.Address) erro
 	if err != nil {
 		return errors.Annotate(err, "cannot generate controller certificate")
 	}
-	stateInfo.Cert = string(newCert)
-	stateInfo.PrivateKey = string(newKey)
+	stateInfo.Cert = newCert
+	stateInfo.PrivateKey = newKey
 	err = c.setter(stateInfo)
 	if err != nil {
 		return errors.Annotate(err, "cannot write agent config")

--- a/worker/certupdater/certupdater.go
+++ b/worker/certupdater/certupdater.go
@@ -58,10 +58,10 @@ type StateServingInfoGetter interface {
 // StateServingInfo value with a newly generated certificate.
 type StateServingInfoSetter func(info params.StateServingInfo) error
 
-// APIHostPortsGetter is an interface that is provided to NewCertificateUpdater
-// whose APIHostPorts method will be invoked to get controller addresses.
+// APIHostPortsGetter is an interface that is provided to NewCertificateUpdater.
+// It provides addresses suitable for agent-to-controller API communication.
 type APIHostPortsGetter interface {
-	APIHostPorts() ([][]network.HostPort, error)
+	APIHostPortsForAgents() ([][]network.HostPort, error)
 }
 
 // Config holds the configuration for the certificate updater worker.
@@ -89,9 +89,9 @@ func NewCertificateUpdater(config Config) worker.Worker {
 // SetUp is defined on the NotifyWatchHandler interface.
 func (c *CertificateUpdater) SetUp() (state.NotifyWatcher, error) {
 	// Populate certificate SAN with any addresses we know about now.
-	apiHostPorts, err := c.hostPortsGetter.APIHostPorts()
+	apiHostPorts, err := c.hostPortsGetter.APIHostPortsForAgents()
 	if err != nil {
-		return nil, errors.Annotate(err, "retrieving initial server addesses")
+		return nil, errors.Annotate(err, "retrieving initial server addresses")
 	}
 	var initialSANAddresses []network.Address
 	for _, server := range apiHostPorts {
@@ -103,7 +103,7 @@ func (c *CertificateUpdater) SetUp() (state.NotifyWatcher, error) {
 		}
 	}
 	if err := c.updateCertificate(initialSANAddresses); err != nil {
-		return nil, errors.Annotate(err, "setting initial cerificate SAN list")
+		return nil, errors.Annotate(err, "setting initial certificate SAN list")
 	}
 	return c.addressWatcher.WatchAddresses(), nil
 }
@@ -143,7 +143,7 @@ func (c *CertificateUpdater) updateCertificate(addresses []network.Address) erro
 
 	// For backwards compatibility, we must include "anything", "juju-apiserver"
 	// and "juju-mongodb" as hostnames as that is what clients specify
-	// as the hostname for verification (this certicate is used both
+	// as the hostname for verification (this certificate is used both
 	// for serving MongoDB and API server connections).  We also
 	// explicitly include localhost.
 	serverAddrs := []string{"localhost", "juju-apiserver", "juju-mongodb", "anything"}
@@ -177,7 +177,7 @@ func (c *CertificateUpdater) updateCertificate(addresses []network.Address) erro
 	if err != nil {
 		return errors.Annotate(err, "cannot write agent config")
 	}
-	logger.Infof("controller cerificate addresses updated to %q", newServerAddrs)
+	logger.Infof("controller certificate addresses updated to %q", newServerAddrs)
 	return nil
 }
 

--- a/worker/certupdater/certupdater_test.go
+++ b/worker/certupdater/certupdater_test.go
@@ -99,7 +99,7 @@ func (g *mockConfigGetter) ControllerConfig() (jujucontroller.Config, error) {
 
 type mockAPIHostGetter struct{}
 
-func (g *mockAPIHostGetter) APIHostPortsForAgents() ([][]network.HostPort, error) {
+func (g *mockAPIHostGetter) APIHostPortsForClients() ([][]network.HostPort, error) {
 	return [][]network.HostPort{
 		{
 			{Address: network.Address{Value: "192.168.1.1", Scope: network.ScopeCloudLocal}, Port: 17070},

--- a/worker/certupdater/certupdater_test.go
+++ b/worker/certupdater/certupdater_test.go
@@ -99,7 +99,7 @@ func (g *mockConfigGetter) ControllerConfig() (jujucontroller.Config, error) {
 
 type mockAPIHostGetter struct{}
 
-func (g *mockAPIHostGetter) APIHostPorts() ([][]network.HostPort, error) {
+func (g *mockAPIHostGetter) APIHostPortsForAgents() ([][]network.HostPort, error) {
 	return [][]network.HostPort{
 		{
 			{Address: network.Address{Value: "192.168.1.1", Scope: network.ScopeCloudLocal}, Port: 17070},
@@ -175,7 +175,7 @@ func (s *CertUpdaterSuite) TestAddressChange(c *gc.C) {
 
 	// The server certificates must report "juju-apiserver" as a DNS
 	// name for backwards-compatibility with API clients. They must
-	// also report "juju-mongodb" because these certicates are also
+	// also report "juju-mongodb" because these certificates are also
 	// used for serving MongoDB connections.
 	c.Assert(srvCert.DNSNames, jc.SameContents,
 		[]string{"localhost", "juju-apiserver", "juju-mongodb", "anything"})

--- a/worker/uniter/util_test.go
+++ b/worker/uniter/util_test.go
@@ -283,7 +283,7 @@ func addControllerMachine(c *gc.C, st *state.State) {
 	// The AddControllerMachine call will update the API host ports
 	// to made-up addresses. We need valid addresses so that the uniter
 	// can download charms from the API server.
-	apiHostPorts, err := st.APIHostPorts()
+	apiHostPorts, err := st.APIHostPortsForClients()
 	c.Assert(err, gc.IsNil)
 	testing.AddControllerMachine(c, st)
 	err = st.SetAPIHostPorts(apiHostPorts)


### PR DESCRIPTION
## Description of change

Previous PRs for this ticket introduced changes to ensure that when controller API addresses were reported to state, a new document is maintained that filters the addresses according to the _juju-mgmt-space_ controller config setting (if present).

This PR contains the following changes:
- WatchAPIHostPortsForAgents is added to _state_.
- _state_ methods APIHostPorts and WatchAPIHostPorts are renamed with "ForClients" as a suffix. This is in order to maintain an API facade with APIHostPorts and WatchAPIHostPorts, backed by the appropriate ForAgents/ForClients methods, and without the ambiguitiy of having the same method names on the facade and client performing different logic.
- APIAddresser in _apiserver/common_ is backed by the ...ForAgents methods.

## QA steps

Unit tests.
Working with test MAAS deployments to check addresses observed while provisioning, for agent config etc are from the configured management space.

## Documentation changes

No.

## Bug reference

Progresses:
https://bugs.launchpad.net/juju/+bug/1591962
