### PR TITLE
Add container-spec-set hook tool to uniter; for use with CAAS models

### DIFF
--- a/api/facadeversions.go
+++ b/api/facadeversions.go
@@ -97,7 +97,7 @@ var facadeVersions = map[string]int{
 	"Subnets":                      2,
 	"Undertaker":                   1,
 	"UnitAssigner":                 1,
-	"Uniter":                       7,
+	"Uniter":                       8,
 	"Upgrader":                     1,
 	"UserManager":                  2,
 	"VolumeAttachmentsWatcher":     2,

--- a/api/uniter/sla_test.go
+++ b/api/uniter/sla_test.go
@@ -23,6 +23,10 @@ func (s *slaSuiteV4) SetUpTest(c *gc.C) {
 	s.PatchValue(&uniter.NewState, uniter.NewStateV4)
 }
 
+func (s *slaSuiteV4) TestSetContainerSpecApplication(c *gc.C) {
+	c.Skip("this API not present in V4")
+}
+
 func (s *slaSuiteV4) TestSLALevelOldFacadeVersion(c *gc.C) {
 	apiCaller := testing.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
 		return nil

--- a/api/uniter/storage_test.go
+++ b/api/uniter/storage_test.go
@@ -21,7 +21,7 @@ type storageSuite struct {
 	coretesting.BaseSuite
 }
 
-const expectedVersion = 7
+const expectedVersion = 8
 
 func (s *storageSuite) TestUnitStorageAttachments(c *gc.C) {
 	storageAttachmentIds := []params.StorageAttachmentId{{

--- a/apiserver/allfacades.go
+++ b/apiserver/allfacades.go
@@ -258,7 +258,8 @@ func AllFacades() *facade.Registry {
 	reg("Uniter", 4, uniter.NewUniterAPIV4)
 	reg("Uniter", 5, uniter.NewUniterAPIV5)
 	reg("Uniter", 6, uniter.NewUniterAPIV6)
-	reg("Uniter", 7, uniter.NewUniterAPI)
+	reg("Uniter", 7, uniter.NewUniterAPIV7)
+	reg("Uniter", 8, uniter.NewUniterAPI)
 
 	reg("Upgrader", 1, upgrader.NewUpgraderFacade)
 	reg("UserManager", 1, usermanager.NewUserManagerAPI)

--- a/apiserver/authhttp_test.go
+++ b/apiserver/authhttp_test.go
@@ -279,8 +279,10 @@ func assertResponse(c *gc.C, resp *http.Response, expHTTPStatus int, expContentT
 	resp.Body.Close()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(resp.StatusCode, gc.Equals, expHTTPStatus, gc.Commentf("body: %s", body))
-	ctype := resp.Header.Get("Content-Type")
-	c.Assert(ctype, gc.Equals, expContentType)
+	if len(body) > 0 {
+		ctype := resp.Header.Get("Content-Type")
+		c.Assert(ctype, gc.Equals, expContentType)
+	}
 	return body
 }
 

--- a/apiserver/facades/agent/migrationflag/facade.go
+++ b/apiserver/facades/agent/migrationflag/facade.go
@@ -32,7 +32,7 @@ type Facade struct {
 // doesn't identity the client as a machine agent or a unit agent,
 // it will return common.ErrPerm.
 func New(backend Backend, resources facade.Resources, auth facade.Authorizer) (*Facade, error) {
-	if !auth.AuthMachineAgent() && !auth.AuthUnitAgent() {
+	if !auth.AuthMachineAgent() && !auth.AuthUnitAgent() && !auth.AuthApplicationAgent() {
 		return nil, common.ErrPerm
 	}
 	return &Facade{

--- a/apiserver/facades/agent/migrationflag/facade_test.go
+++ b/apiserver/facades/agent/migrationflag/facade_test.go
@@ -33,6 +33,12 @@ func (*FacadeSuite) TestAcceptsUnitAgent(c *gc.C) {
 	c.Check(facade, gc.NotNil)
 }
 
+func (*FacadeSuite) TestAcceptsApplicationAgent(c *gc.C) {
+	facade, err := migrationflag.New(nil, nil, agentAuth{application: true})
+	c.Check(err, jc.ErrorIsNil)
+	c.Check(facade, gc.NotNil)
+}
+
 func (*FacadeSuite) TestRejectsNonAgent(c *gc.C) {
 	facade, err := migrationflag.New(nil, nil, agentAuth{})
 	c.Check(err, gc.Equals, common.ErrPerm)

--- a/apiserver/facades/agent/migrationflag/util_test.go
+++ b/apiserver/facades/agent/migrationflag/util_test.go
@@ -16,8 +16,9 @@ import (
 // agentAuth implements facade.Authorizer for use in the tests.
 type agentAuth struct {
 	facade.Authorizer
-	machine bool
-	unit    bool
+	machine     bool
+	unit        bool
+	application bool
 }
 
 // AuthMachineAgent is part of the facade.Authorizer interface.
@@ -28,6 +29,11 @@ func (auth agentAuth) AuthMachineAgent() bool {
 // AuthUnitAgent is part of the facade.Authorizer interface.
 func (auth agentAuth) AuthUnitAgent() bool {
 	return auth.unit
+}
+
+// AuthApplicationAgent is part of the facade.Authorizer interface.
+func (auth agentAuth) AuthApplicationAgent() bool {
+	return auth.application
 }
 
 // newMockBackend returns a mock Backend that will add calls to the

--- a/apiserver/restrict_caasmodel.go
+++ b/apiserver/restrict_caasmodel.go
@@ -36,6 +36,7 @@ var commonModelFacadeNames = set.NewStrings(
 	"Singular",
 	"StatusHistory",
 	"StringsWatcher",
+	"Uniter",
 )
 
 // caasModelFacadeNames lists facades that are only used with CAAS

--- a/cmd/juju/commands/helptool.go
+++ b/cmd/juju/commands/helptool.go
@@ -27,6 +27,9 @@ func (dummyHookContext) AddMetrics(_, _ string, _ time.Time) error {
 func (dummyHookContext) UnitName() string {
 	return ""
 }
+func (dummyHookContext) SetContainerSpec(specYaml string, application bool) error {
+	return nil
+}
 func (dummyHookContext) PublicAddress() (string, error) {
 	return "", errors.NotFoundf("PublicAddress")
 }

--- a/cmd/juju/commands/helptool_test.go
+++ b/cmd/juju/commands/helptool_test.go
@@ -38,6 +38,7 @@ Currently available charm hook tools are:
     application-version-set  specify which version of the application is deployed
     close-port               ensure a port or range is always closed
     config-get               print application configuration
+    container-spec-set       set container spec information
     is-leader                print application leadership status
     juju-log                 write a message to the juju log
     juju-reboot              Reboot the host machine
@@ -75,6 +76,7 @@ var expectedCommands = []string{
 	"application-version-set",
 	"close-port",
 	"config-get",
+	"container-spec-set",
 	"is-leader",
 	"juju-log",
 	"juju-reboot",

--- a/worker/uniter/relation/relations_test.go
+++ b/worker/uniter/relation/relations_test.go
@@ -81,7 +81,7 @@ func mockAPICaller(c *gc.C, callNumber *int32, apiCalls ...apiCall) apitesting.A
 			c.Check(index < len(apiCalls), jc.IsTrue)
 			call := apiCalls[index]
 			c.Logf("request %d, %s", index, request)
-			c.Check(version, gc.Equals, 7)
+			c.Check(version, gc.Equals, 8)
 			c.Check(id, gc.Equals, "")
 			c.Check(request, gc.Equals, call.request)
 			c.Check(arg, jc.DeepEquals, call.args)

--- a/worker/uniter/runner/context/context.go
+++ b/worker/uniter/runner/context/context.go
@@ -483,6 +483,21 @@ func (ctx *HookContext) ConfigSettings() (charm.Settings, error) {
 	return result, nil
 }
 
+func (ctx *HookContext) SetContainerSpec(specYaml string, application bool) error {
+	entityName := ctx.unitName
+	if application {
+		isLeader, err := ctx.IsLeader()
+		if err != nil {
+			return errors.Annotatef(err, "cannot determine leadership")
+		}
+		if !isLeader {
+			return ErrIsNotLeader
+		}
+		entityName = ctx.unit.ApplicationName()
+	}
+	return ctx.state.SetContainerSpec(entityName, specYaml)
+}
+
 // ActionName returns the name of the action.
 func (ctx *HookContext) ActionName() (string, error) {
 	if ctx.actionData == nil {

--- a/worker/uniter/runner/jujuc/container-spec-set.go
+++ b/worker/uniter/runner/jujuc/container-spec-set.go
@@ -1,0 +1,69 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package jujuc
+
+import (
+	"github.com/juju/cmd"
+	"github.com/juju/errors"
+	"github.com/juju/gnuflag"
+)
+
+// ContainerspecSetCommand implements the container-spec-set command.
+type ContainerspecSetCommand struct {
+	cmd.CommandBase
+	ctx Context
+
+	specFile    cmd.FileVar
+	application bool
+}
+
+// NewContainerspecSetCommand makes a container-spec-set command.
+func NewContainerspecSetCommand(ctx Context) (cmd.Command, error) {
+	return &ContainerspecSetCommand{ctx: ctx}, nil
+}
+
+func (c *ContainerspecSetCommand) Info() *cmd.Info {
+	doc := `
+Sets configuration data to use for a container.
+By default, the spec applies to all units for the
+application. However, if a unit name is specified,
+the spec is used for just that unit.
+`
+	return &cmd.Info{
+		Name:    "container-spec-set",
+		Args:    "--file <container spec file> [--application]",
+		Purpose: "set container spec information",
+		Doc:     doc,
+	}
+}
+
+func (c *ContainerspecSetCommand) SetFlags(f *gnuflag.FlagSet) {
+	c.specFile.SetStdin()
+	c.specFile.Path = "-"
+	f.Var(&c.specFile, "file", "file containing container spec")
+	f.BoolVar(&c.application, "application", false, "set the spec for the application to which the unit belongs if the unit is the leader")
+}
+
+func (c *ContainerspecSetCommand) Init(args []string) error {
+	return cmd.CheckEmpty(args)
+}
+
+func (c *ContainerspecSetCommand) Run(ctx *cmd.Context) error {
+	specData, err := c.handleSpecFile(ctx)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	return c.ctx.SetContainerSpec(specData, c.application)
+}
+
+func (c *ContainerspecSetCommand) handleSpecFile(ctx *cmd.Context) (string, error) {
+	specData, err := c.specFile.Read(ctx)
+	if err != nil {
+		return "", errors.Trace(err)
+	}
+	if len(specData) == 0 {
+		return "", errors.New("no container spec specified: pipe container spec to command, or specify a file with --file")
+	}
+	return string(specData), nil
+}

--- a/worker/uniter/runner/jujuc/container-spec-set_test.go
+++ b/worker/uniter/runner/jujuc/container-spec-set_test.go
@@ -1,0 +1,126 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package jujuc_test
+
+import (
+	"bytes"
+	"io/ioutil"
+	"path/filepath"
+
+	"github.com/juju/cmd"
+	"github.com/juju/cmd/cmdtesting"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/worker/uniter/runner/jujuc"
+)
+
+type ContainerspecSetSuite struct {
+	ContextSuite
+}
+
+var _ = gc.Suite(&ContainerspecSetSuite{})
+
+var containerSpecYaml = `
+containerspec:
+  foo: bar
+`[1:]
+
+var containerSpecSetInitTests = []struct {
+	args []string
+	err  string
+}{
+	{[]string{"--file", "file", "extra"}, `unrecognized args: \["extra"\]`},
+}
+
+func (s *ContainerspecSetSuite) TestContainerSpecSetInit(c *gc.C) {
+	for i, t := range containerSpecSetInitTests {
+		c.Logf("test %d: %#v", i, t.args)
+		hctx := s.GetHookContext(c, -1, "")
+		com, err := jujuc.NewCommand(hctx, "container-spec-set")
+		c.Assert(err, jc.ErrorIsNil)
+		cmdtesting.TestInit(c, com, t.args, t.err)
+	}
+}
+
+func (s *ContainerspecSetSuite) TestHelp(c *gc.C) {
+	hctx := s.GetHookContext(c, -1, "")
+	com, err := jujuc.NewCommand(hctx, "container-spec-set")
+	c.Assert(err, jc.ErrorIsNil)
+	ctx := cmdtesting.Context(c)
+	code := cmd.Main(com, ctx, []string{"--help"})
+	c.Assert(code, gc.Equals, 0)
+	expectedHelp := "" +
+		"Usage: container-spec-set [options] --file <container spec file> [--application]\n" +
+		"\n" +
+		"Summary:\n" +
+		"set container spec information\n" +
+		"\n" +
+		"Options:\n" +
+		"--application  (= false)\n" +
+		"    set the spec for the application to which the unit belongs if the unit is the leader\n" +
+		"--file  (= -)\n" +
+		"    file containing container spec\n" +
+		"\n" +
+		"Details:\n" +
+		"Sets configuration data to use for a container.\n" +
+		"By default, the spec applies to all units for the\n" +
+		"application. However, if a unit name is specified,\n" +
+		"the spec is used for just that unit.\n"
+
+	c.Assert(bufferString(ctx.Stdout), gc.Equals, expectedHelp)
+	c.Assert(bufferString(ctx.Stderr), gc.Equals, "")
+}
+
+func (s *ContainerspecSetSuite) TestContainerSpecSetNoData(c *gc.C) {
+	hctx := s.GetHookContext(c, -1, "")
+	com, err := jujuc.NewCommand(hctx, "container-spec-set")
+	c.Assert(err, jc.ErrorIsNil)
+	ctx := cmdtesting.Context(c)
+
+	code := cmd.Main(com, ctx, nil)
+	c.Check(code, gc.Equals, 1)
+	c.Assert(bufferString(
+		ctx.Stderr), gc.Matches,
+		".*no container spec specified: pipe container spec to command, or specify a file with --file\n")
+	c.Assert(bufferString(ctx.Stdout), gc.Equals, "")
+}
+
+func (s *ContainerspecSetSuite) TestContainerSpecSet(c *gc.C) {
+	s.assertContainerSpecSet(c, "specfile.yaml")
+}
+
+func (s *ContainerspecSetSuite) TestContainerSpecSetStdIn(c *gc.C) {
+	s.assertContainerSpecSet(c, "-")
+}
+
+func (s *ContainerspecSetSuite) assertContainerSpecSet(c *gc.C, filename string) {
+	hctx := s.GetHookContext(c, -1, "")
+	com, args, ctx := s.initCommand(c, hctx, containerSpecYaml, filename)
+	code := cmd.Main(com, ctx, append(args, "--application"))
+	c.Check(code, gc.Equals, 0)
+	c.Assert(bufferString(ctx.Stderr), gc.Equals, "")
+	c.Assert(bufferString(ctx.Stdout), gc.Equals, "")
+	c.Assert(hctx.info.ContainerSpec, gc.Equals, containerSpecYaml)
+	c.Assert(hctx.info.Application, jc.IsTrue)
+}
+
+func (s *ContainerspecSetSuite) initCommand(
+	c *gc.C, hctx jujuc.Context, yaml string, filename string,
+) (cmd.Command, []string, *cmd.Context) {
+	com, err := jujuc.NewCommand(hctx, "container-spec-set")
+	c.Assert(err, jc.ErrorIsNil)
+	ctx := cmdtesting.Context(c)
+
+	var args []string
+	if filename == "-" {
+		ctx.Stdin = bytes.NewBufferString(yaml)
+	} else if filename != "" {
+		filename = filepath.Join(c.MkDir(), filename)
+		args = append(args, "--file", filename)
+		err := ioutil.WriteFile(filename, []byte(yaml), 0644)
+		c.Assert(err, jc.ErrorIsNil)
+	}
+	return com, args, ctx
+}

--- a/worker/uniter/runner/jujuc/context.go
+++ b/worker/uniter/runner/jujuc/context.go
@@ -93,6 +93,9 @@ type ContextUnit interface {
 
 	// Config returns the current service configuration of the executing unit.
 	ConfigSettings() (charm.Settings, error)
+
+	// SetContainerSpec updates the yaml spec used to create a container.
+	SetContainerSpec(specYaml string, application bool) error
 }
 
 // ContextStatus is the part of a hook context related to the unit's status.

--- a/worker/uniter/runner/jujuc/jujuctesting/unit.go
+++ b/worker/uniter/runner/jujuc/jujuctesting/unit.go
@@ -12,6 +12,8 @@ import (
 type Unit struct {
 	Name           string
 	ConfigSettings charm.Settings
+	ContainerSpec  string
+	Application    bool
 }
 
 // ContextUnit is a test double for jujuc.ContextUnit.
@@ -36,4 +38,14 @@ func (c *ContextUnit) ConfigSettings() (charm.Settings, error) {
 	}
 
 	return c.info.ConfigSettings, nil
+}
+
+func (c *ContextUnit) SetContainerSpec(specYaml string, application bool) error {
+	c.stub.AddCall("SetContainerSpec", specYaml, application)
+	if err := c.stub.NextErr(); err != nil {
+		return errors.Trace(err)
+	}
+	c.info.Application = application
+	c.info.ContainerSpec = specYaml
+	return nil
 }

--- a/worker/uniter/runner/jujuc/restricted.go
+++ b/worker/uniter/runner/jujuc/restricted.go
@@ -30,6 +30,11 @@ func (*RestrictedContext) UnitStatus() (*StatusInfo, error) {
 	return nil, ErrRestrictedContext
 }
 
+// SetContainerSpec implements hooks.Context.
+func (c *RestrictedContext) SetContainerSpec(specYaml string, application bool) error {
+	return ErrRestrictedContext
+}
+
 // SetUnitStatus implements hooks.Context.
 func (*RestrictedContext) SetUnitStatus(StatusInfo) error { return ErrRestrictedContext }
 

--- a/worker/uniter/runner/jujuc/server.go
+++ b/worker/uniter/runner/jujuc/server.go
@@ -63,6 +63,7 @@ var baseCommands = map[string]creator{
 	"status-set" + cmdSuffix:              NewStatusSetCommand,
 	"network-get" + cmdSuffix:             NewNetworkGetCommand,
 	"application-version-set" + cmdSuffix: NewApplicationVersionSetCommand,
+	"container-spec-set" + cmdSuffix:      NewContainerspecSetCommand,
 }
 
 var storageCommands = map[string]creator{


### PR DESCRIPTION

## Description of change

The container-spec-set hook tool is copied across from the caas operator to the uniter. This is in preparation for some refactoring. The hook tool is existing code - the uniter hook context and facades are updated to include the necessary api methods.

As a driveby, fix a test which fails in go-lang 1.10

## QA steps

run up a deployment and ensure nothing breaks - nothing uses the new hook tool yet

