### PR TITLE
LP #1744469 upgrade juju  dry run

### DIFF
--- a/cmd/juju/commands/upgradejuju.go
+++ b/cmd/juju/commands/upgradejuju.go
@@ -270,6 +270,9 @@ func (c *upgradeJujuCommand) Run(ctx *cmd.Context) (err error) {
 		c.Version = jujuversion.Current
 	}
 	warnCompat := false
+
+	// TODO (agprado:01/30/2018):
+	// This logic seems to be overly complicated and it checks the same condition multiple times.
 	switch {
 	case !canUpgradeRunningVersion(agentVersion):
 		// This version of upgrade-juju cannot upgrade the running

--- a/cmd/juju/commands/upgradejuju.go
+++ b/cmd/juju/commands/upgradejuju.go
@@ -358,7 +358,7 @@ func (c *upgradeJujuCommand) Run(ctx *cmd.Context) (err error) {
 		return err
 	}
 	ctx.Verbosef("available agent binaries:\n%s", formatTools(context.tools))
-	ctx.Verbosef("best version:\n    %s", context.chosen)
+	fmt.Fprintf(ctx.Stderr, "best version:\n    %v\n", context.chosen)
 	if warnCompat {
 		fmt.Fprintf(ctx.Stderr, "version %s incompatible with this client (%s)\n", context.chosen, jujuversion.Current)
 	}

--- a/cmd/juju/commands/upgradejuju_test.go
+++ b/cmd/juju/commands/upgradejuju_test.go
@@ -592,6 +592,7 @@ type DryRunTest struct {
 }
 
 func (s *UpgradeJujuSuite) TestUpgradeDryRun(c *gc.C) {
+
 	tests := []DryRunTest{
 		{
 			about:          "dry run outputs and doesn't change anything when uploading agent binaries",
@@ -599,7 +600,9 @@ func (s *UpgradeJujuSuite) TestUpgradeDryRun(c *gc.C) {
 			tools:          []string{"2.1.0-quantal-amd64", "2.1.2-quantal-i386", "2.1.3-quantal-amd64", "2.1-dev1-quantal-amd64", "2.2.3-quantal-amd64"},
 			currentVersion: "2.1.3-quantal-amd64",
 			agentVersion:   "2.0.0",
-			expectedCmdOutput: `upgrade to this version by running
+			expectedCmdOutput: `best version:
+    2.1.3.1
+upgrade to this version by running
     juju upgrade-juju --build-agent
 `,
 		},
@@ -609,7 +612,9 @@ func (s *UpgradeJujuSuite) TestUpgradeDryRun(c *gc.C) {
 			tools:          []string{"2.1.0-quantal-amd64", "2.1.2-quantal-i386", "2.1.3-quantal-amd64", "2.1-dev1-quantal-amd64", "2.2.3-quantal-amd64"},
 			currentVersion: "2.0.0-quantal-amd64",
 			agentVersion:   "2.0.0",
-			expectedCmdOutput: `upgrade to this version by running
+			expectedCmdOutput: `best version:
+    2.1.3
+upgrade to this version by running
     juju upgrade-juju
 `,
 		},
@@ -619,7 +624,9 @@ func (s *UpgradeJujuSuite) TestUpgradeDryRun(c *gc.C) {
 			tools:          []string{"2.1.0-quantal-amd64", "2.1.2-quantal-i386", "2.1.3-quantal-amd64", "1.2.3-myawesomeseries-amd64"},
 			currentVersion: "2.0.0-quantal-amd64",
 			agentVersion:   "2.0.0",
-			expectedCmdOutput: `upgrade to this version by running
+			expectedCmdOutput: `best version:
+    2.1.3
+upgrade to this version by running
     juju upgrade-juju
 `,
 		},


### PR DESCRIPTION
## LP [#1744469](https://bugs.launchpad.net/juju/+bug/1744469)
`juju upgrade-juju --dry-run` does not show available versions, but shows "upgrade to this version"

----

## Description of change
file `./cmd/juju/commands/upgradejuju.go` modify output to specify best version to upgrade to.

Why is this change needed?
Improve user experience.

## QA steps

How do we verify that the change works?

Bootstrap a controller specifying an old juju version.
     
     $ juju bootstrap lxd --agent-version=2.3.1

Upon correct bootstrap. Upgrade juju with `--dry-run` option.

     $ juju upgrade-juju --dry-run

Expected output.

     best version:
         2.1.3
     upgrade to this version by running
        juju upgrade-juju



## Documentation changes

Does it affect current user workflow? CLI? API?
No.

## Bug reference

LP [#1744469](https://bugs.launchpad.net/juju/+bug/1744469)
