### PR TITLE
systemd/cmdline : do not ellipsize unit names when listing them

### DIFF
--- a/service/service_test.go
+++ b/service/service_test.go
@@ -84,7 +84,7 @@ func (*serviceSuite) TestListServicesScript(c *gc.C) {
 	expected = append(expected,
 		`case "$init_system" in`,
 		`systemd)`,
-		`    /bin/systemctl list-unit-files --no-legend --no-page -t service`+
+		`    /bin/systemctl list-unit-files --no-legend --no-page -l -t service`+
 			` | grep -o -P '^\w[\S]*(?=\.service)'`,
 		`    ;;`,
 		`upstart)`,

--- a/service/systemd/cmdline.go
+++ b/service/systemd/cmdline.go
@@ -35,7 +35,7 @@ func (c commands) unitFilename(name, dirname string) string {
 func (c commands) listAll() string {
 	// We can't just use the same command as listRunning (with an extra
 	// "--all" because it misses some inactive units.
-	args := `list-unit-files --no-legend --no-page -t service` +
+	args := `list-unit-files --no-legend --no-page -l -t service` +
 		` | grep -o -P '^\w[\S]*(?=\.service)'`
 	return c.resolve(args)
 }

--- a/service/systemd/service_test.go
+++ b/service/systemd/service_test.go
@@ -47,7 +47,7 @@ WantedBy=multi-user.target
 const jujud = "/var/lib/juju/bin/jujud"
 
 var listCmdArg = exec.RunParams{
-	Commands: `/bin/systemctl list-unit-files --no-legend --no-page -t service | grep -o -P '^\w[\S]*(?=\.service)'`,
+	Commands: `/bin/systemctl list-unit-files --no-legend --no-page -l -t service | grep -o -P '^\w[\S]*(?=\.service)'`,
 }
 
 type initSystemSuite struct {


### PR DESCRIPTION
A better fix for LP#1731027

## Please provide the following details to expedite Pull Request review:

----

## Description of change

Creating an application with a long name was failing, and got fixed by limiting the application name in https://github.com/juju/juju/pull/8060

However, systemd does not have a limit on unit filenames. The bug above is because systemd starts ellipsizing unit names if you don't ask it to not do it.

## QA steps

Deploy an application with a long name (without https://github.com/juju/juju/pull/8060 applied). It should work.

Command output before : 
```
$ sudo systemctl list-unit-files --no-legend --no-page -t service| grep -o -P '^\w[\S]*(?=\.service)'
[...]
jujud-unit-longlonglong...onglonglonglonglonglonglonglonglong-0
[...]
```

After : 
```
sudo systemctl list-unit-files --no-legend --no-page -l -t service| grep -o -P '^\w[\S]*(?=\.service)'
[...]
jujud-unit-longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglong-0
[...]
```


## Documentation changes

No

## Bug reference

https://bugs.launchpad.net/juju/+bug/1731027
