### PR TITLE
Add a timeout to the state pool for calls to release.

### DIFF
--- a/state/pool.go
+++ b/state/pool.go
@@ -19,15 +19,54 @@ import (
 	"github.com/juju/juju/state/watcher"
 )
 
+// This is the default time to wait after calling remove for a model's
+// pooled state before it is forcibly removed.
+const defaultRemoveTimeout = 5 * time.Minute
+
 var errPoolClosed = errors.New("pool closed")
 
-// NewStatePool returns a new StatePool instance. It takes a State
-// connected to the system (controller model).
+// StatePool is a cache of State instances for multiple
+// models. Clients should call Release when they have finished with any
+// state.
+type StatePool struct {
+	systemState *State
+	// mu protects pool
+	mu   sync.Mutex
+	pool map[string]*PoolItem
+	// sourceKey is used to provide a unique number as a key for the
+	// referencesSources structure in the pool.
+	sourceKey uint64
+
+	// hub is used to pass the transaction changes from the TxnWatcher
+	// to the various HubWatchers that are used in each state object created
+	// by the state pool.
+	hub *pubsub.SimpleHub
+
+	// watcherRunner makes sure the TxnWatcher stays running.
+	watcherRunner *worker.Runner
+
+	// forceRemoveTimeout is the time after which calling Remove with a return
+	// value of false, will forcibly remove a model's PoolItem.
+	forceRemoveTimeout time.Duration
+}
+
+// NewStatePool builds and returns a new StatePool instance.
+// The input State should be connected to the system (controller model).
 func NewStatePool(systemState *State) *StatePool {
+	return NewStatePoolWithTimeout(systemState, defaultRemoveTimeout)
+}
+
+// NewStatePool builds and returns a new StatePool instance from the input
+// state and duration.
+// The input State should be connected to the system (controller model).
+// The timeout is the maximum time to wait after requesting pool item removal,
+// before forcibly removing it.
+func NewStatePoolWithTimeout(systemState *State, timeout time.Duration) *StatePool {
 	pool := &StatePool{
-		systemState: systemState,
-		pool:        make(map[string]*PoolItem),
-		hub:         pubsub.NewSimpleHub(nil),
+		systemState:        systemState,
+		pool:               make(map[string]*PoolItem),
+		hub:                pubsub.NewSimpleHub(nil),
+		forceRemoveTimeout: timeout,
 	}
 	// If systemState is nil, this is clearly a test, and a poorly
 	// isolated one. However now is not the time to fix all those broken
@@ -68,27 +107,6 @@ func (i *PoolItem) refCount() int {
 	return len(i.referenceSources)
 }
 
-// StatePool is a cache of State instances for multiple
-// models. Clients should call Release when they have finished with any
-// state.
-type StatePool struct {
-	systemState *State
-	// mu protects pool
-	mu   sync.Mutex
-	pool map[string]*PoolItem
-	// sourceKey is used to provide a unique number as a key for the
-	// referencesSources structure in the pool.
-	sourceKey uint64
-
-	// hub is used to pass the transaction changes from the TxnWatcher
-	// to the various HubWatchers that are used in each state object created
-	// by the state pool.
-	hub *pubsub.SimpleHub
-
-	// watcherRunner makes sure the TxnWatcher stays running.
-	watcherRunner *worker.Runner
-}
-
 // StatePoolReleaser is the type of a function returned by StatePool.Get,
 // for releasing the State back into the pool. The boolean result indicates
 // whether or not releasing the State also caused it to be removed from
@@ -115,10 +133,10 @@ func (p *StatePool) Get(modelUUID string) (*State, StatePoolReleaser, error) {
 
 	p.sourceKey++
 	key := p.sourceKey
+
 	// released is here to be captured by the closure for the releaser.
 	// This is to ensure that the releaser function can only be called once.
 	released := false
-
 	releaser := func() bool {
 		if released {
 			return false
@@ -228,15 +246,39 @@ func (p *StatePool) Remove(modelUUID string) (bool, error) {
 		return false, nil
 	}
 	item.remove = true
-	return p.maybeRemoveItem(modelUUID, item)
+	removed, err := p.maybeRemoveItem(modelUUID, item)
+
+	// If the item was not removed, set a deadline to forcibly remove it.
+	if !removed {
+		go func() {
+			time.Sleep(p.forceRemoveTimeout)
+			if p.forceRemoveItem(modelUUID, item) == nil {
+				logger.Debugf("state pool item for %s forcibly removed.")
+			}
+		}()
+	}
+
+	return removed, err
 }
 
 func (p *StatePool) maybeRemoveItem(modelUUID string, item *PoolItem) (bool, error) {
 	if item.remove && item.refCount() == 0 {
-		delete(p.pool, modelUUID)
-		return true, item.state.Close()
+		return true, p.removeItem(modelUUID, item)
 	}
 	return false, nil
+}
+
+// forceRemoveItem is used to call removeItem "out of band".
+// As such it negotiates the state pool mutex.
+func (p *StatePool) forceRemoveItem(modelUUID string, item *PoolItem) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.removeItem(modelUUID, item)
+}
+
+func (p *StatePool) removeItem(modelUUID string, item *PoolItem) error {
+	delete(p.pool, modelUUID)
+	return item.state.Close()
 }
 
 // SystemState returns the State passed in to NewStatePool.

--- a/state/pool_test.go
+++ b/state/pool_test.go
@@ -9,11 +9,12 @@ import (
 	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
+	"time"
 
 	"github.com/juju/juju/state"
 	statetesting "github.com/juju/juju/state/testing"
+	"github.com/juju/juju/testing"
 	"github.com/juju/juju/worker/workertest"
-	"time"
 )
 
 type statePoolSuite struct {
@@ -204,6 +205,7 @@ func (s *statePoolSuite) TestRemoveWithoutReleaseTimeoutClose(c *gc.C) {
 	// Call remove without release and wait for forced removal.
 	_, err = s.StatePool.Remove(s.ModelUUID1)
 	c.Assert(err, jc.ErrorIsNil)
-	time.Sleep(60 * time.Millisecond)
+	assertNotClosed(c, st)
+	time.Sleep(testing.ShortWait)
 	assertClosed(c, st)
 }

--- a/state/testing/suite.go
+++ b/state/testing/suite.go
@@ -14,6 +14,7 @@ import (
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/testing"
 	"github.com/juju/juju/testing/factory"
+	"time"
 )
 
 var _ = gc.Suite(&StateSuite{})
@@ -68,7 +69,7 @@ func (s *StateSuite) SetUpTest(c *gc.C) {
 		s.Controller.Close()
 	})
 
-	s.StatePool = state.NewStatePool(s.State)
+	s.StatePool = state.NewStatePoolWithTimeout(s.State, 50*time.Millisecond)
 	s.AddCleanup(func(*gc.C) { s.StatePool.Close() })
 
 	model, err := s.State.Model()

--- a/state/testing/suite.go
+++ b/state/testing/suite.go
@@ -69,7 +69,7 @@ func (s *StateSuite) SetUpTest(c *gc.C) {
 		s.Controller.Close()
 	})
 
-	s.StatePool = state.NewStatePoolWithTimeout(s.State, 50*time.Millisecond)
+	s.StatePool = state.NewStatePoolWithTimeout(s.State, 10*time.Millisecond)
 	s.AddCleanup(func(*gc.C) { s.StatePool.Close() })
 
 	model, err := s.State.Model()

--- a/worker/state/manifold.go
+++ b/worker/state/manifold.go
@@ -271,8 +271,10 @@ func (w *modelStateWorker) loop() error {
 	if err != nil {
 		return errors.Trace(err)
 	}
-	defer release()
-	defer w.pool.Remove(w.modelUUID)
+	defer func() {
+		release()
+		w.pool.Remove(w.modelUUID)
+	}()
 
 	for {
 		select {


### PR DESCRIPTION
## Description of change

There have been observations from the field, for long-lived deployments, of state connections leaking from _StatePool_.

The stated goal is to enforce the definite release and closure of pool items at some point after a call to _Release_.

If the result of a release is false, a goroutine is started that will forcibly remove a model's pool item and close it's state instance when the timeout is expired.

## QA steps

Accompanying unit testing.

## Documentation changes

No.

## Bug reference

TBD.
