### PR TITLE
Fixes lp#1745951: When auto-upgrade is asked, deal with nil agent version.

### DIFF
--- a/cmd/juju/commands/bootstrap.go
+++ b/cmd/juju/commands/bootstrap.go
@@ -104,6 +104,15 @@ In other words, a 2.2.1 client can bootstrap any 2.2.x agents but cannot
 bootstrap any 2.0.x or 2.1.x agents.
 The agent version can be specified a simple numeric version, e.g. 2.2.4.
 
+For example, at the time when 2.3.0, 2.3.1 and 2.3.2 are released and your
+agent stream is 'released' (default), then a 2.3.1 client can bootstrap:
+ * 2.3.0 controller by running '... bootstrap --agent-version=2.3.0 ...';
+ * 2.3.1 controller by running '... bootstrap ...';
+ * 2.3.2 controller by running 'bootstrap --auto-upgrade'.
+However, if this client has a copy of codebase, then a local copy of Juju 
+will be built and bootstrapped - 2.3.1.1.
+
+
 Examples:
     juju bootstrap
     juju bootstrap --clouds

--- a/environs/bootstrap/bootstrap.go
+++ b/environs/bootstrap/bootstrap.go
@@ -305,6 +305,11 @@ func Bootstrap(ctx environs.BootstrapContext, environ environs.Environ, args Boo
 		if err != nil && !errors.IsNotFound(err) {
 			return err
 		}
+		if args.AgentVersion == nil {
+			// If agent version was not specified in the arguments,
+			// we always want the latest/newest available.
+			agentVersion, availableTools = availableTools.Newest()
+		}
 	}
 	// If there are no prepackaged tools and a specific version has not been
 	// requested, look for or build a local binary.
@@ -364,17 +369,6 @@ func Bootstrap(ctx environs.BootstrapContext, environ environs.Environ, args Boo
 	// agent-version to the correct thing.
 	if args.AgentVersion != nil {
 		agentVersion = *args.AgentVersion
-	} else {
-		// We will fall here when bootstrap command is given an
-		// --auto-upgrade option, meaning that any major.minor client
-		// can bootstrap a controller with the same major.minor version
-		// with the latest patch.
-		// For example, at the time when 2.3.0, 2.3.1 and 2.3.2 are released,
-		// a 2.3.1 client can bootstrap:
-		// * 2.3.0 controller by running 'bootstrap --agent-version=2.3.0';
-		// * 2.3.1 controller by running 'bootstrap' (on a machine that does not have codebase locally);
-		// * 2.3.2 controller by running 'bootstrap --auto-upgrade'.
-		agentVersion, availableTools = availableTools.Newest()
 	}
 	if cfg, err = cfg.Apply(map[string]interface{}{
 		"agent-version": agentVersion.String(),

--- a/environs/bootstrap/bootstrap.go
+++ b/environs/bootstrap/bootstrap.go
@@ -305,7 +305,7 @@ func Bootstrap(ctx environs.BootstrapContext, environ environs.Environ, args Boo
 		if err != nil && !errors.IsNotFound(err) {
 			return err
 		}
-		if args.AgentVersion == nil {
+		if len(availableTools) != 0 && args.AgentVersion == nil {
 			// If agent version was not specified in the arguments,
 			// we always want the latest/newest available.
 			agentVersion, availableTools = availableTools.Newest()

--- a/environs/bootstrap/bootstrap.go
+++ b/environs/bootstrap/bootstrap.go
@@ -362,6 +362,13 @@ func Bootstrap(ctx environs.BootstrapContext, environ environs.Environ, args Boo
 		return errors.New(noToolsMessage)
 	}
 
+	// TODO (anastasiamac 2018-02-02) By this stage, we will have a list
+	// of available tools (agent binaries) but they should all be the same
+	// version. Need to do check here, otherwise the provider.Bootstrap call
+	// may fail. This also means that compatibility check, currently done
+	// after provider.Bootstrap call in getBootstrapToolsVersion,
+	// should be done here.
+
 	// If we're uploading, we must override agent-version;
 	// if we're not uploading, we want to ensure we have an
 	// agent-version set anyway, to appease FinishInstanceConfig.


### PR DESCRIPTION
## Description of change

Juju client can bootstrap a controller with a latest patch automatically applied. To do that, bootstrap command needs to have '--auto-upgrade' option on.

This will ensure that a desired agent version sent to bootstrap on provider side remains unset. Logically, this pulls all available agent binaries version. However, at some point, before we provision the very first instance (bootstrap machine), we need to narrow this list down to the latest major.minor.patch.

This PR (1) adds to bootstrap command help by clearly defining how to bootstrap different controller versions with different bootstrap options; (2) fixes --auto-upgrade agent binary selection; (3) cleans up the message to the user that signals what binary version is being sought.

## QA steps

1. bootstrap with --auto-upgrade option // should succeed

I have also run a sanity check to ensure that I can bootstrap with/without --agent-version as well as my local copy.

## Documentation changes

We might want to revisit our bootstrap documentation to ensure that different options and the implications of their omissions are well understood.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1745951
