### PR TITLE
audit-log: Handle changes to audit configuration in the API server

### DIFF
--- a/apiserver/admin.go
+++ b/apiserver/admin.go
@@ -136,10 +136,7 @@ func (a *admin) login(req params.LoginRequest, loginVersion int) (params.LoginRe
 		modelTag = a.root.model.Tag().String()
 	}
 
-	auditConfig, err := a.srv.getAuditConfig()
-	if err != nil {
-		return fail, errors.Trace(err)
-	}
+	auditConfig := a.srv.GetAuditConfig()
 	auditRecorder, err := a.getAuditRecorder(req, authResult, auditConfig)
 	if err != nil {
 		return fail, errors.Trace(err)

--- a/apiserver/admin.go
+++ b/apiserver/admin.go
@@ -158,7 +158,7 @@ func (a *admin) login(req params.LoginRequest, loginVersion int) (params.LoginRe
 }
 
 func (a *admin) getAuditRecorder(req params.LoginRequest, authResult *authResult, cfg auditlog.Config) (*auditlog.Recorder, error) {
-	if !authResult.userLogin || cfg.Enabled == false {
+	if !authResult.userLogin || !cfg.Enabled {
 		return nil, nil
 	}
 	// Wrap the audit logger in a filter that prevents us from logging

--- a/apiserver/admin.go
+++ b/apiserver/admin.go
@@ -157,7 +157,7 @@ func (a *admin) login(req params.LoginRequest, loginVersion int) (params.LoginRe
 	}, nil
 }
 
-func (a *admin) getAuditRecorder(req params.LoginRequest, authResult *authResult, cfg AuditLogConfig) (*auditlog.Recorder, error) {
+func (a *admin) getAuditRecorder(req params.LoginRequest, authResult *authResult, cfg auditlog.Config) (*auditlog.Recorder, error) {
 	if !authResult.userLogin || cfg.Enabled == false {
 		return nil, nil
 	}

--- a/apiserver/admin_test.go
+++ b/apiserver/admin_test.go
@@ -951,7 +951,7 @@ func (s *loginSuite) TestLoginAddsAuditConversationEventually(c *gc.C) {
 	log := &servertesting.FakeAuditLog{}
 	cfg := defaultServerConfig(c)
 	cfg.AuditLogConfig.Enabled = true
-	cfg.AuditLog = log
+	cfg.AuditLogConfig.Target = log
 	cfg.Clock = jt.NewClock(cfg.Clock.Now())
 	info, srv := newServerWithConfig(c, s.StatePool, cfg)
 	defer assertStop(c, srv)
@@ -1019,7 +1019,7 @@ func (s *loginSuite) TestAuditLoggingFailureOnInterestingRequest(c *gc.C) {
 	log.SetErrors(errors.Errorf("bad news bears"))
 	cfg := defaultServerConfig(c)
 	cfg.AuditLogConfig.Enabled = true
-	cfg.AuditLog = log
+	cfg.AuditLogConfig.Target = log
 	info, srv := newServerWithConfig(c, s.StatePool, cfg)
 	defer assertStop(c, srv)
 
@@ -1057,7 +1057,7 @@ func (s *loginSuite) TestAuditLoggingUsesExcludeMethods(c *gc.C) {
 	cfg := defaultServerConfig(c)
 	cfg.AuditLogConfig.Enabled = true
 	cfg.AuditLogConfig.ExcludeMethods = set.NewStrings("Client.AddMachines")
-	cfg.AuditLog = log
+	cfg.AuditLogConfig.Target = log
 	info, srv := newServerWithConfig(c, s.StatePool, cfg)
 	defer assertStop(c, srv)
 	info.ModelTag = s.IAASModel.Tag().(names.ModelTag)

--- a/apiserver/admin_test.go
+++ b/apiserver/admin_test.go
@@ -950,8 +950,8 @@ func (s *loginSuite) TestLoginUpdatesLastLoginAndConnection(c *gc.C) {
 func (s *loginSuite) TestLoginAddsAuditConversationEventually(c *gc.C) {
 	log := &servertesting.FakeAuditLog{}
 	cfg := defaultServerConfig(c)
-	cfg.AuditLogConfig.Enabled = true
-	cfg.AuditLogConfig.Target = log
+	cfg.AuditConfig.Enabled = true
+	cfg.AuditConfig.Target = log
 	cfg.Clock = jt.NewClock(cfg.Clock.Now())
 	info, srv := newServerWithConfig(c, s.StatePool, cfg)
 	defer assertStop(c, srv)
@@ -1018,8 +1018,8 @@ func (s *loginSuite) TestAuditLoggingFailureOnInterestingRequest(c *gc.C) {
 	log := &servertesting.FakeAuditLog{}
 	log.SetErrors(errors.Errorf("bad news bears"))
 	cfg := defaultServerConfig(c)
-	cfg.AuditLogConfig.Enabled = true
-	cfg.AuditLogConfig.Target = log
+	cfg.AuditConfig.Enabled = true
+	cfg.AuditConfig.Target = log
 	info, srv := newServerWithConfig(c, s.StatePool, cfg)
 	defer assertStop(c, srv)
 
@@ -1055,9 +1055,9 @@ func (s *loginSuite) TestAuditLoggingFailureOnInterestingRequest(c *gc.C) {
 func (s *loginSuite) TestAuditLoggingUsesExcludeMethods(c *gc.C) {
 	log := &servertesting.FakeAuditLog{}
 	cfg := defaultServerConfig(c)
-	cfg.AuditLogConfig.Enabled = true
-	cfg.AuditLogConfig.ExcludeMethods = set.NewStrings("Client.AddMachines")
-	cfg.AuditLogConfig.Target = log
+	cfg.AuditConfig.Enabled = true
+	cfg.AuditConfig.ExcludeMethods = set.NewStrings("Client.AddMachines")
+	cfg.AuditConfig.Target = log
 	info, srv := newServerWithConfig(c, s.StatePool, cfg)
 	defer assertStop(c, srv)
 	info.ModelTag = s.IAASModel.Tag().(names.ModelTag)

--- a/apiserver/apiserver.go
+++ b/apiserver/apiserver.go
@@ -1021,7 +1021,7 @@ func (srv *Server) processAuditConfigChanges() error {
 			return tomb.ErrDying
 		case auditConfig := <-srv.auditConfigChanged:
 			if err := auditConfig.Validate(); err != nil {
-				logger.Criticalf("discarding invalid audit config: %s", err)
+				logger.Warningf("discarding invalid audit config: %s", err)
 			} else {
 				srv.updateAuditConfig(auditConfig)
 			}
@@ -1035,7 +1035,8 @@ func (srv *Server) updateAuditConfig(newConfig auditlog.Config) {
 	srv.currentAuditConfig = newConfig
 }
 
-// GetAuditConfig returns the current audit logging configuration.
+// GetAuditConfig returns a copy of the current audit logging
+// configuration.
 func (srv *Server) GetAuditConfig() auditlog.Config {
 	srv.mu.Lock()
 	defer srv.mu.Unlock()

--- a/apiserver/apiserver.go
+++ b/apiserver/apiserver.go
@@ -40,6 +40,7 @@ import (
 	"github.com/juju/juju/apiserver/observer"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/apiserver/websocket"
+	"github.com/juju/juju/core/auditlog"
 	"github.com/juju/juju/resource"
 	"github.com/juju/juju/resource/resourceadapters"
 	"github.com/juju/juju/rpc"
@@ -80,8 +81,8 @@ type Server struct {
 	logSinkWriter          io.WriteCloser
 	logsinkRateLimitConfig logsink.RateLimitConfig
 	dbloggers              dbloggers
-	auditConfigChanged     <-chan AuditLogConfig
-	currentAuditConfig     AuditLogConfig
+	auditConfigChanged     <-chan auditlog.Config
+	currentAuditConfig     auditlog.Config
 	upgradeComplete        func() bool
 	restoreStatus          func() state.RestoreStatus
 
@@ -169,11 +170,11 @@ type ServerConfig struct {
 
 	// AuditConfig controls whether and how we track user-initiated
 	// API requests for auditing purposes.
-	AuditConfig AuditLogConfig
+	AuditConfig auditlog.Config
 
 	// AuditConfigChanged is a channel which reports the new audit
 	// configuration whenever it changes.
-	AuditConfigChanged <-chan AuditLogConfig
+	AuditConfigChanged <-chan auditlog.Config
 
 	// PrometheusRegisterer registers Prometheus collectors.
 	PrometheusRegisterer prometheus.Registerer
@@ -1028,14 +1029,14 @@ func (srv *Server) processAuditConfigChanges() error {
 	}
 }
 
-func (srv *Server) updateAuditConfig(newConfig AuditLogConfig) {
+func (srv *Server) updateAuditConfig(newConfig auditlog.Config) {
 	srv.mu.Lock()
 	defer srv.mu.Unlock()
 	srv.currentAuditConfig = newConfig
 }
 
 // GetAuditConfig returns the current audit logging configuration.
-func (srv *Server) GetAuditConfig() AuditLogConfig {
+func (srv *Server) GetAuditConfig() auditlog.Config {
 	srv.mu.Lock()
 	defer srv.mu.Unlock()
 	return srv.currentAuditConfig

--- a/apiserver/auditconfig_test.go
+++ b/apiserver/auditconfig_test.go
@@ -24,21 +24,21 @@ var _ = gc.Suite(&auditConfigSuite{})
 
 func (s *auditConfigSuite) TestUpdateConfig(c *gc.C) {
 	config := s.sampleConfig(c)
-	auditConfigChanged := make(chan apiserver.AuditLogConfig)
+	auditConfigChanged := make(chan auditlog.Config)
 	config.AuditConfigChanged = auditConfigChanged
-	config.AuditConfig = apiserver.AuditLogConfig{
+	config.AuditConfig = auditlog.Config{
 		ExcludeMethods: set.NewStrings("Midlake.Bandits"),
 	}
 
 	srv := s.newServer(c, config)
 
 	auditConfig := srv.GetAuditConfig()
-	c.Assert(auditConfig, gc.DeepEquals, apiserver.AuditLogConfig{
+	c.Assert(auditConfig, gc.DeepEquals, auditlog.Config{
 		ExcludeMethods: set.NewStrings("Midlake.Bandits"),
 	})
 
 	fakeLog := &servertesting.FakeAuditLog{}
-	newConfig := apiserver.AuditLogConfig{
+	newConfig := auditlog.Config{
 		Enabled:        true,
 		ExcludeMethods: set.NewStrings("ModelManager.ListModels"),
 		Target:         fakeLog,
@@ -62,7 +62,7 @@ func (s *auditConfigSuite) TestUpdateConfig(c *gc.C) {
 	})
 
 	auditConfig.Target = nil
-	c.Assert(auditConfig, gc.DeepEquals, apiserver.AuditLogConfig{
+	c.Assert(auditConfig, gc.DeepEquals, auditlog.Config{
 		Enabled:        true,
 		ExcludeMethods: set.NewStrings("ModelManager.ListModels"),
 	})
@@ -70,7 +70,7 @@ func (s *auditConfigSuite) TestUpdateConfig(c *gc.C) {
 
 func (s *auditConfigSuite) TestNewServerValidatesConfig(c *gc.C) {
 	config := s.sampleConfig(c)
-	config.AuditConfig = apiserver.AuditLogConfig{
+	config.AuditConfig = auditlog.Config{
 		Enabled: true,
 	}
 
@@ -85,11 +85,11 @@ func (s *auditConfigSuite) TestNewServerValidatesConfig(c *gc.C) {
 
 func (s *auditConfigSuite) TestInvalidConfigLogsAndDiscards(c *gc.C) {
 	config := s.sampleConfig(c)
-	auditConfigChanged := make(chan apiserver.AuditLogConfig)
+	auditConfigChanged := make(chan auditlog.Config)
 	config.AuditConfigChanged = auditConfigChanged
 
 	srv := s.newServer(c, config)
-	newConfig := apiserver.AuditLogConfig{
+	newConfig := auditlog.Config{
 		Enabled:        true,
 		ExcludeMethods: set.NewStrings("ModelManager.ListModels"),
 	}

--- a/apiserver/auditconfig_test.go
+++ b/apiserver/auditconfig_test.go
@@ -108,6 +108,6 @@ func (s *auditConfigSuite) TestInvalidConfigLogsAndDiscards(c *gc.C) {
 
 	messages := logWriter.Log()
 	c.Assert(messages[len(messages)-1:], jc.LogMatches, []jc.SimpleMessage{{
-		loggo.CRITICAL, "discarding invalid audit config: logging enabled but no target provided",
+		loggo.WARNING, "discarding invalid audit config: logging enabled but no target provided",
 	}})
 }

--- a/apiserver/auditconfig_test.go
+++ b/apiserver/auditconfig_test.go
@@ -1,0 +1,113 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package apiserver_test
+
+import (
+	"net"
+
+	"github.com/juju/loggo"
+	jc "github.com/juju/testing/checkers"
+	"github.com/juju/utils/set"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/apiserver"
+	servertesting "github.com/juju/juju/apiserver/testing"
+	"github.com/juju/juju/core/auditlog"
+)
+
+type auditConfigSuite struct {
+	apiserverBaseSuite
+}
+
+var _ = gc.Suite(&auditConfigSuite{})
+
+func (s *auditConfigSuite) TestUpdateConfig(c *gc.C) {
+	config := s.sampleConfig(c)
+	auditConfigChanged := make(chan apiserver.AuditLogConfig)
+	config.AuditConfigChanged = auditConfigChanged
+	config.AuditConfig = apiserver.AuditLogConfig{
+		ExcludeMethods: set.NewStrings("Midlake.Bandits"),
+	}
+
+	srv := s.newServer(c, config)
+
+	auditConfig := srv.GetAuditConfig()
+	c.Assert(auditConfig, gc.DeepEquals, apiserver.AuditLogConfig{
+		ExcludeMethods: set.NewStrings("Midlake.Bandits"),
+	})
+
+	fakeLog := &servertesting.FakeAuditLog{}
+	newConfig := apiserver.AuditLogConfig{
+		Enabled:        true,
+		ExcludeMethods: set.NewStrings("ModelManager.ListModels"),
+		Target:         fakeLog,
+	}
+
+	// Sending the config in twice is a simple way to ensure the
+	// config has been picked up and applied wihout explicitly
+	// waiting.
+	auditConfigChanged <- newConfig
+	auditConfigChanged <- newConfig
+
+	auditConfig = srv.GetAuditConfig()
+	// Check that target's right.
+	err := auditConfig.Target.AddResponse(auditlog.ResponseErrors{
+		ConversationID: "heynow",
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	fakeLog.CheckCallNames(c, "AddResponse")
+	fakeLog.CheckCall(c, 0, "AddResponse", auditlog.ResponseErrors{
+		ConversationID: "heynow",
+	})
+
+	auditConfig.Target = nil
+	c.Assert(auditConfig, gc.DeepEquals, apiserver.AuditLogConfig{
+		Enabled:        true,
+		ExcludeMethods: set.NewStrings("ModelManager.ListModels"),
+	})
+}
+
+func (s *auditConfigSuite) TestNewServerValidatesConfig(c *gc.C) {
+	config := s.sampleConfig(c)
+	config.AuditConfig = apiserver.AuditLogConfig{
+		Enabled: true,
+	}
+
+	listener, err := net.Listen("tcp", ":0")
+	c.Assert(err, jc.ErrorIsNil)
+	defer listener.Close()
+
+	srv, err := apiserver.NewServer(s.StatePool, listener, config)
+	c.Assert(err, gc.ErrorMatches, "validating audit log configuration: logging enabled but no target provided")
+	c.Assert(srv, gc.IsNil)
+}
+
+func (s *auditConfigSuite) TestInvalidConfigLogsAndDiscards(c *gc.C) {
+	config := s.sampleConfig(c)
+	auditConfigChanged := make(chan apiserver.AuditLogConfig)
+	config.AuditConfigChanged = auditConfigChanged
+
+	srv := s.newServer(c, config)
+	newConfig := apiserver.AuditLogConfig{
+		Enabled:        true,
+		ExcludeMethods: set.NewStrings("ModelManager.ListModels"),
+	}
+	var logWriter loggo.TestWriter
+	c.Assert(loggo.RegisterWriter("auditconfig-tests", &logWriter), jc.ErrorIsNil)
+	defer func() {
+		logWriter.Clear()
+	}()
+
+	auditConfigChanged <- newConfig
+	auditConfigChanged <- newConfig
+	loggo.RemoveWriter("auditconfig-tests")
+
+	// Update to invalid config is discarded.
+	c.Assert(srv.GetAuditConfig().Enabled, gc.Equals, false)
+
+	messages := logWriter.Log()
+	c.Assert(messages[len(messages)-1:], jc.LogMatches, []jc.SimpleMessage{{
+		loggo.CRITICAL, "discarding invalid audit config: logging enabled but no target provided",
+	}})
+}

--- a/apiserver/config.go
+++ b/apiserver/config.go
@@ -7,9 +7,6 @@ import (
 	"time"
 
 	"github.com/juju/errors"
-	"github.com/juju/utils/set"
-
-	"github.com/juju/juju/core/auditlog"
 )
 
 // These vars define how we rate limit incoming connections.
@@ -81,37 +78,6 @@ func (c RateLimitConfig) Validate() error {
 	}
 	if c.ConnLookbackWindow < 0 || c.ConnLookbackWindow > 5*time.Second {
 		return errors.NotValidf("conn-lookback-window %d < 0 or > 5s", c.ConnMaxPause)
-	}
-	return nil
-}
-
-// AuditLogConfig holds parameters to control audit logging.
-type AuditLogConfig struct {
-	Enabled bool
-
-	// CaptureAPIArgs says whether to capture API method args (command
-	// line args will always be captured).
-	CaptureAPIArgs bool
-
-	// MaxSizeMB defines the maximum log file size.
-	MaxSizeMB int
-
-	// MaxBackups determines how many files back to keep.
-	MaxBackups int
-
-	// ExcludeMethods is a set of facade.method names that we
-	// shouldn't consider to be interesting: if a conversation only
-	// consists of these method calls we won't log it.
-	ExcludeMethods set.Strings
-
-	// Target is the AuditLog entries should be written to.
-	Target auditlog.AuditLog
-}
-
-// Validate checks the audit logging configuration.
-func (cfg AuditLogConfig) Validate() error {
-	if cfg.Enabled && cfg.Target == nil {
-		return errors.NewNotValid(nil, "logging enabled but no target provided")
 	}
 	return nil
 }

--- a/apiserver/config.go
+++ b/apiserver/config.go
@@ -8,6 +8,8 @@ import (
 
 	"github.com/juju/errors"
 	"github.com/juju/utils/set"
+
+	"github.com/juju/juju/core/auditlog"
 )
 
 // These vars define how we rate limit incoming connections.
@@ -101,6 +103,17 @@ type AuditLogConfig struct {
 	// shouldn't consider to be interesting: if a conversation only
 	// consists of these method calls we won't log it.
 	ExcludeMethods set.Strings
+
+	// Target is the AuditLog entries should be written to.
+	Target auditlog.AuditLog
+}
+
+// Validate checks the audit logging configuration.
+func (cfg AuditLogConfig) Validate() error {
+	if cfg.Enabled && cfg.Target == nil {
+		return errors.NotValidf("logging enabled but no target provided")
+	}
+	return nil
 }
 
 // LogSinkConfig holds parameters to control the API server's

--- a/apiserver/config.go
+++ b/apiserver/config.go
@@ -111,7 +111,7 @@ type AuditLogConfig struct {
 // Validate checks the audit logging configuration.
 func (cfg AuditLogConfig) Validate() error {
 	if cfg.Enabled && cfg.Target == nil {
-		return errors.NotValidf("logging enabled but no target provided")
+		return errors.NewNotValid(nil, "logging enabled but no target provided")
 	}
 	return nil
 }

--- a/apiserver/server_test.go
+++ b/apiserver/server_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/juju/juju/apiserver/observer/fakeobserver"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/controller"
+	"github.com/juju/juju/core/auditlog"
 	jujutesting "github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/mongo"
 	"github.com/juju/juju/network"
@@ -623,7 +624,7 @@ func defaultServerConfig(c *gc.C) apiserver.ServerConfig {
 		NewObserver:     func() observer.Observer { return &fakeobserver.Instance{} },
 		AutocertURL:     "https://0.1.2.3/no-autocert-here",
 		RateLimitConfig: apiserver.DefaultRateLimitConfig(),
-		AuditConfig:     apiserver.AuditLogConfig{Enabled: false},
+		AuditConfig:     auditlog.Config{Enabled: false},
 		UpgradeComplete: func() bool { return true },
 		RestoreStatus: func() state.RestoreStatus {
 			return state.RestoreNotActive

--- a/apiserver/server_test.go
+++ b/apiserver/server_test.go
@@ -623,7 +623,7 @@ func defaultServerConfig(c *gc.C) apiserver.ServerConfig {
 		NewObserver:     func() observer.Observer { return &fakeobserver.Instance{} },
 		AutocertURL:     "https://0.1.2.3/no-autocert-here",
 		RateLimitConfig: apiserver.DefaultRateLimitConfig(),
-		AuditLogConfig:  apiserver.AuditLogConfig{Enabled: false},
+		AuditConfig:     apiserver.AuditLogConfig{Enabled: false},
 		UpgradeComplete: func() bool { return true },
 		RestoreStatus: func() state.RestoreStatus {
 			return state.RestoreNotActive

--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -1117,7 +1117,7 @@ func (a *MachineAgent) startStateWorkers(
 			// TODO(babbageclunk): add a worker that watches the
 			// controller config and publishes to this chan when it
 			// changes.
-			auditConfigChan := make(chan apiserver.AuditLogConfig, 1)
+			auditConfigChan := make(chan auditlog.Config, 1)
 
 			// Each time apiserver worker is restarted, we need a fresh copy of state due
 			// to the fact that state holds lease managers which are killed and need to be reset.
@@ -1217,7 +1217,7 @@ var stateWorkerDialOpts mongo.DialOpts
 func (a *MachineAgent) apiserverWorkerStarter(
 	stateOpener func() (*state.State, error),
 	certChanged <-chan params.StateServingInfo,
-	auditConfigChanged <-chan apiserver.AuditLogConfig,
+	auditConfigChanged <-chan auditlog.Config,
 	dependencyReporter dependency.Reporter,
 ) func() (worker.Worker, error) {
 	return func() (worker.Worker, error) {
@@ -1242,7 +1242,7 @@ func (a *MachineAgent) newAPIserverWorker(
 	st *state.State,
 	statePool *state.StatePool,
 	certChanged <-chan params.StateServingInfo,
-	auditConfigChanged <-chan apiserver.AuditLogConfig,
+	auditConfigChanged <-chan auditlog.Config,
 	dependencyReporter dependency.Reporter,
 ) (worker.Worker, error) {
 	agentConfig := a.CurrentConfig()
@@ -1794,8 +1794,8 @@ func getLogSinkConfig(cfg agent.Config) (apiserver.LogSinkConfig, error) {
 	return result, nil
 }
 
-func getAuditLogConfig(cfg controller.Config, logDir string) apiserver.AuditLogConfig {
-	result := apiserver.AuditLogConfig{
+func getAuditLogConfig(cfg controller.Config, logDir string) auditlog.Config {
+	result := auditlog.Config{
 		Enabled:        cfg.AuditingEnabled(),
 		CaptureAPIArgs: cfg.AuditLogCaptureArgs(),
 		MaxSizeMB:      cfg.AuditLogMaxSizeMB(),

--- a/cmd/jujud/agent/machine_test.go
+++ b/cmd/jujud/agent/machine_test.go
@@ -1426,7 +1426,9 @@ func (s *MachineSuite) TestGetAuditLogConfig(c *gc.C) {
 	cfg := coretesting.FakeControllerConfig()
 	cfg["auditing-enabled"] = true
 	cfg["audit-log-exclude-methods"] = []interface{}{"Exclude.This"}
-	result := getAuditLogConfig(cfg)
+	result := getAuditLogConfig(cfg, c.MkDir())
+	c.Assert(result.Target, gc.NotNil)
+	result.Target = nil
 	c.Assert(result, gc.DeepEquals, apiserver.AuditLogConfig{
 		Enabled:        true,
 		CaptureAPIArgs: true,

--- a/cmd/jujud/agent/machine_test.go
+++ b/cmd/jujud/agent/machine_test.go
@@ -649,29 +649,65 @@ func (s *MachineSuite) TestManageModelAuditsAPI(c *gc.C) {
 		Password: password,
 	})
 
+	err := s.State.UpdateControllerConfig(map[string]interface{}{
+		"audit-log-exclude-methods": []interface{}{"Client.FullStatus"},
+	}, nil)
+	c.Assert(err, jc.ErrorIsNil)
+
 	s.assertJobWithState(c, state.JobManageModel, func(conf agent.Config, agentState *state.State) {
 		logPath := filepath.Join(conf.LogDir(), "audit.log")
 
-		apiInfo, ok := conf.APIInfo()
-		c.Assert(ok, jc.IsTrue)
-		apiInfo.Tag = user.Tag()
-		apiInfo.Password = password
-		st, err := api.Open(apiInfo, fastDialOpts)
-		c.Assert(err, jc.ErrorIsNil)
-		defer st.Close()
+		makeAPIRequest := func(doRequest func(*api.Client)) {
+			apiInfo, ok := conf.APIInfo()
+			c.Assert(ok, jc.IsTrue)
+			apiInfo.Tag = user.Tag()
+			apiInfo.Password = password
+			st, err := api.Open(apiInfo, fastDialOpts)
+			c.Assert(err, jc.ErrorIsNil)
+			defer st.Close()
+			doRequest(st.Client())
+		}
 
-		client := st.Client()
-		_, err = client.AddMachines([]params.AddMachineParams{{
-			Jobs: []multiwatcher.MachineJob{"JobHostUnits"},
-		}})
-		c.Assert(err, jc.ErrorIsNil)
+		// Make requests in separate API connections so they're separate conversations.
+		makeAPIRequest(func(client *api.Client) {
+			_, err = client.Status(nil)
+			c.Assert(err, jc.ErrorIsNil)
+		})
+		makeAPIRequest(func(client *api.Client) {
+			_, err = client.AddMachines([]params.AddMachineParams{{
+				Jobs: []multiwatcher.MachineJob{"JobHostUnits"},
+			}})
+			c.Assert(err, jc.ErrorIsNil)
+		})
 
-		// Check that there's a call to Client.AddMachinesV2 in the log.
+		// Check that there's a call to Client.AddMachinesV2 in the
+		// log, but no call to Client.FullStatus.
 		records := readAuditLog(c, logPath)
 		c.Assert(records, gc.HasLen, 3)
 		c.Assert(records[1].Request, gc.NotNil)
 		c.Assert(records[1].Request.Facade, gc.Equals, "Client")
 		c.Assert(records[1].Request.Method, gc.Equals, "AddMachinesV2")
+
+		// Now update the controller config to remove the exclusion.
+		err := s.State.UpdateControllerConfig(map[string]interface{}{
+			"audit-log-exclude-methods": []interface{}{},
+		}, nil)
+		c.Assert(err, jc.ErrorIsNil)
+		// Wait until the controller config change is propagated to
+		// the apiserver.
+		// TODO(babbageclunk): do this better!
+		time.Sleep(2 * time.Second)
+
+		makeAPIRequest(func(client *api.Client) {
+			_, err = client.Status(nil)
+			c.Assert(err, jc.ErrorIsNil)
+		})
+		// Now there's also a call to Client.FullStatus.
+		records = readAuditLog(c, logPath)
+		c.Assert(records, gc.HasLen, 6)
+		c.Assert(records[4].Request, gc.NotNil)
+		c.Assert(records[4].Request.Facade, gc.Equals, "Client")
+		c.Assert(records[4].Request.Method, gc.Equals, "FullStatus")
 	})
 }
 

--- a/cmd/jujud/agent/machine_test.go
+++ b/cmd/jujud/agent/machine_test.go
@@ -39,7 +39,6 @@ import (
 	"github.com/juju/juju/api"
 	"github.com/juju/juju/api/imagemetadata"
 	apimachiner "github.com/juju/juju/api/machiner"
-	"github.com/juju/juju/apiserver"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/cmd/jujud/agent/model"
 	"github.com/juju/juju/controller"
@@ -1429,7 +1428,7 @@ func (s *MachineSuite) TestGetAuditLogConfig(c *gc.C) {
 	result := getAuditLogConfig(cfg, c.MkDir())
 	c.Assert(result.Target, gc.NotNil)
 	result.Target = nil
-	c.Assert(result, gc.DeepEquals, apiserver.AuditLogConfig{
+	c.Assert(result, gc.DeepEquals, auditlog.Config{
 		Enabled:        true,
 		CaptureAPIArgs: true,
 		MaxSizeMB:      200,

--- a/controller/config.go
+++ b/controller/config.go
@@ -352,7 +352,11 @@ func (c Config) AuditLogMaxSizeMB() int {
 // files to keep.
 func (c Config) AuditLogMaxBackups() int {
 	if value, ok := c[AuditLogMaxBackups]; ok {
-		return value.(int)
+		if intValue, ok := value.(int); ok {
+			return intValue
+		}
+		return int(value.(float64))
+
 	}
 	return DefaultAuditLogMaxBackups
 }

--- a/controller/config.go
+++ b/controller/config.go
@@ -179,8 +179,6 @@ var (
 	AllowedUpdateConfigAttributes = set.NewStrings(
 		AuditingEnabled,
 		AuditLogCaptureArgs,
-		AuditLogMaxSize,
-		AuditLogMaxBackups,
 		AuditLogExcludeMethods,
 	)
 

--- a/controller/config.go
+++ b/controller/config.go
@@ -352,11 +352,11 @@ func (c Config) AuditLogMaxSizeMB() int {
 // files to keep.
 func (c Config) AuditLogMaxBackups() int {
 	if value, ok := c[AuditLogMaxBackups]; ok {
-		if intValue, ok := value.(int); ok {
-			return intValue
+		// Values obtained over the API are encoded as float64.
+		if floatValue, ok := value.(float64); ok {
+			return int(floatValue)
 		}
-		return int(value.(float64))
-
+		return value.(int)
 	}
 	return DefaultAuditLogMaxBackups
 }

--- a/controller/config_test.go
+++ b/controller/config_test.go
@@ -248,3 +248,11 @@ func (s *ConfigSuite) TestAuditLogExcludeMethodsType(c *gc.C) {
 	)
 	c.Assert(err, gc.ErrorMatches, `audit-log-exclude-methods\[0\]: expected string, got int\(2\)`)
 }
+
+func (s *ConfigSuite) TestAuditLogFloatBackupsLoadedDirectly(c *gc.C) {
+	// We still need to be able to handle floats in data loaded from the DB.
+	cfg := controller.Config{
+		controller.AuditLogMaxBackups: 10.0,
+	}
+	c.Assert(cfg.AuditLogMaxBackups(), gc.Equals, 10)
+}

--- a/core/auditlog/config.go
+++ b/core/auditlog/config.go
@@ -10,6 +10,8 @@ import (
 
 // Config holds parameters to control audit logging.
 type Config struct {
+	// Enabled determines whether API requests should be audited at
+	// all.
 	Enabled bool
 
 	// CaptureAPIArgs says whether to capture API method args (command

--- a/core/auditlog/config.go
+++ b/core/auditlog/config.go
@@ -1,0 +1,40 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package auditlog
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/utils/set"
+)
+
+// Config holds parameters to control audit logging.
+type Config struct {
+	Enabled bool
+
+	// CaptureAPIArgs says whether to capture API method args (command
+	// line args will always be captured).
+	CaptureAPIArgs bool
+
+	// MaxSizeMB defines the maximum log file size.
+	MaxSizeMB int
+
+	// MaxBackups determines how many files back to keep.
+	MaxBackups int
+
+	// ExcludeMethods is a set of facade.method names that we
+	// shouldn't consider to be interesting: if a conversation only
+	// consists of these method calls we won't log it.
+	ExcludeMethods set.Strings
+
+	// Target is the AuditLog entries should be written to.
+	Target AuditLog
+}
+
+// Validate checks the audit logging configuration.
+func (cfg Config) Validate() error {
+	if cfg.Enabled && cfg.Target == nil {
+		return errors.NewNotValid(nil, "logging enabled but no target provided")
+	}
+	return nil
+}

--- a/state/controller_test.go
+++ b/state/controller_test.go
@@ -70,12 +70,10 @@ func (s *ControllerSuite) TestUpdateControllerConfig(c *gc.C) {
 	// Sanity check.
 	c.Check(cfg.AuditingEnabled(), gc.Equals, false)
 	c.Check(cfg.AuditLogCaptureArgs(), gc.Equals, true)
-	c.Check(cfg.AuditLogMaxBackups(), gc.Equals, 5)
 
 	err = s.State.UpdateControllerConfig(map[string]interface{}{
 		controller.AuditingEnabled:     true,
 		controller.AuditLogCaptureArgs: false,
-		controller.AuditLogMaxBackups:  10,
 	}, nil)
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -84,20 +82,17 @@ func (s *ControllerSuite) TestUpdateControllerConfig(c *gc.C) {
 
 	c.Assert(newCfg.AuditingEnabled(), gc.Equals, true)
 	c.Assert(newCfg.AuditLogCaptureArgs(), gc.Equals, false)
-	c.Assert(newCfg.AuditLogMaxBackups(), gc.Equals, 10)
 }
 
 func (s *ControllerSuite) TestUpdateControllerConfigRemoveYieldsDefaults(c *gc.C) {
 	err := s.State.UpdateControllerConfig(map[string]interface{}{
 		controller.AuditingEnabled:     true,
 		controller.AuditLogCaptureArgs: true,
-		controller.AuditLogMaxBackups:  5,
 	}, nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	err = s.State.UpdateControllerConfig(nil, []string{
 		controller.AuditLogCaptureArgs,
-		controller.AuditLogMaxBackups,
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -105,7 +100,6 @@ func (s *ControllerSuite) TestUpdateControllerConfigRemoveYieldsDefaults(c *gc.C
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Assert(newCfg.AuditLogCaptureArgs(), gc.Equals, false)
-	c.Assert(newCfg.AuditLogMaxBackups(), gc.Equals, 10)
 }
 
 func (s *ControllerSuite) TestUpdateControllerConfigRejectsNonAuditUpdates(c *gc.C) {
@@ -130,7 +124,7 @@ func (s *ControllerSuite) TestUpdateControllerConfigChecksSchema(c *gc.C) {
 
 func (s *ControllerSuite) TestUpdateControllerConfigValidates(c *gc.C) {
 	err := s.State.UpdateControllerConfig(map[string]interface{}{
-		controller.AuditLogMaxSize: "45ZipMorps",
+		controller.AuditLogExcludeMethods: []string{"thing"},
 	}, nil)
-	c.Assert(err, gc.ErrorMatches, `invalid audit log max size in configuration: invalid multiplier suffix "ZipMorps", expected one of MGTPEZY`)
+	c.Assert(err, gc.ErrorMatches, `invalid audit log exclude methods: should be a list of "Facade.Method" names, got "thing" at position 1`)
 }

--- a/state/watcher/watchertest/notify.go
+++ b/state/watcher/watchertest/notify.go
@@ -1,0 +1,50 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package watchertest
+
+import (
+	tomb "gopkg.in/tomb.v1"
+)
+
+type NotifyWatcher struct {
+	tomb tomb.Tomb
+	ch   <-chan struct{}
+}
+
+func NewNotifyWatcher(ch <-chan struct{}) *NotifyWatcher {
+	w := &NotifyWatcher{ch: ch}
+	go func() {
+		defer w.tomb.Done()
+		<-w.tomb.Dying()
+		w.tomb.Kill(tomb.ErrDying)
+	}()
+	return w
+}
+
+func (w *NotifyWatcher) Changes() <-chan struct{} {
+	return w.ch
+}
+
+func (w *NotifyWatcher) Stop() error {
+	w.Kill()
+	return w.Wait()
+}
+
+func (w *NotifyWatcher) Kill() {
+	w.tomb.Kill(nil)
+}
+
+// KillErr can be used to kill the worker with
+// an error, to simulate a failing watcher.
+func (w *NotifyWatcher) KillErr(err error) {
+	w.tomb.Kill(err)
+}
+
+func (w *NotifyWatcher) Err() error {
+	return w.tomb.Err()
+}
+
+func (w *NotifyWatcher) Wait() error {
+	return w.tomb.Wait()
+}

--- a/worker/auditconfigupdater/package_test.go
+++ b/worker/auditconfigupdater/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package auditconfigupdater_test
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func TestPackage(t *testing.T) {
+	gc.TestingT(t)
+}

--- a/worker/auditconfigupdater/worker.go
+++ b/worker/auditconfigupdater/worker.go
@@ -1,0 +1,104 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package auditconfigupdater
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/utils/set"
+	"gopkg.in/juju/worker.v1"
+
+	"github.com/juju/juju/controller"
+	"github.com/juju/juju/core/auditlog"
+	"github.com/juju/juju/state"
+	"github.com/juju/juju/watcher/legacy"
+)
+
+type updater struct {
+	source     ConfigSource
+	current    auditlog.Config
+	logFactory AuditLogFactory
+	changes    chan<- auditlog.Config
+}
+
+// ConfigSource lets us get notifications of changes to controller
+// configuration, and then get the changed config. (Primary
+// implementation is State.)
+type ConfigSource interface {
+	WatchControllerConfig() state.NotifyWatcher
+	ControllerConfig() (controller.Config, error)
+}
+
+// AuditLogFactory is a function that will return an audit log given
+// config.
+type AuditLogFactory func(auditlog.Config) auditlog.AuditLog
+
+// New returns a worker that will publish changed audit log config to
+// the channel passed in.
+func New(source ConfigSource, initial auditlog.Config, logFactory AuditLogFactory, changes chan<- auditlog.Config) (worker.Worker, error) {
+	// This uses legacy.NewNotifyWorker because it needs to run
+	// against State - it feeds audit config changes to the API
+	// server, so it can't make requests via the API
+	// server. (legacy.NewNotifyWorker exists because the
+	// state.NotifyWorker and watcher.NotifyWorker interfaces are
+	// incompatible, Changes returns different types.)
+	return legacy.NewNotifyWorker(&updater{
+		source:     source,
+		current:    initial,
+		logFactory: logFactory,
+		changes:    changes,
+	}), nil
+}
+
+// Setup implements watcher.NotifyHandler.
+func (u *updater) SetUp() (state.NotifyWatcher, error) {
+	return u.source.WatchControllerConfig(), nil
+}
+
+// Handle implements watcher.NotifyHandler.
+func (u *updater) Handle(abort <-chan struct{}) error {
+	cConfig, err := u.source.ControllerConfig()
+	if err != nil {
+		return errors.Trace(err)
+	}
+	newConfig := u.auditConfigFrom(cConfig)
+	if changed(u.current, newConfig) {
+		u.current = newConfig
+		u.changes <- newConfig
+	}
+	return nil
+}
+
+// TearDown implements watcher.NotifyHandler.
+func (u *updater) TearDown() error {
+	return nil
+}
+
+func (u *updater) auditConfigFrom(cfg controller.Config) auditlog.Config {
+	result := auditlog.Config{
+		Enabled:        cfg.AuditingEnabled(),
+		CaptureAPIArgs: cfg.AuditLogCaptureArgs(),
+		MaxSizeMB:      cfg.AuditLogMaxSizeMB(),
+		MaxBackups:     cfg.AuditLogMaxBackups(),
+		ExcludeMethods: cfg.AuditLogExcludeMethods(),
+	}
+	if result.Enabled && u.current.Target == nil {
+		result.Target = u.logFactory(result)
+	} else {
+		// Keep the existing target to avoid file handle leaks from
+		// disabling and enabling auditing - we'll still stop logging
+		// because enabled is false.
+		result.Target = u.current.Target
+	}
+	return result
+}
+
+func changed(old, new auditlog.Config) bool {
+	return old.Enabled != new.Enabled ||
+		old.CaptureAPIArgs != new.CaptureAPIArgs ||
+		setsDiffer(old.ExcludeMethods, new.ExcludeMethods)
+}
+
+func setsDiffer(a, b set.Strings) bool {
+	return !a.Difference(b).IsEmpty() || !b.Difference(a).IsEmpty()
+}

--- a/worker/auditconfigupdater/worker_test.go
+++ b/worker/auditconfigupdater/worker_test.go
@@ -6,7 +6,6 @@ package auditconfigupdater_test
 import (
 	"time"
 
-	// "github.com/juju/errors"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils/set"

--- a/worker/auditconfigupdater/worker_test.go
+++ b/worker/auditconfigupdater/worker_test.go
@@ -1,0 +1,291 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package auditconfigupdater_test
+
+import (
+	"time"
+
+	// "github.com/juju/errors"
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	"github.com/juju/utils/set"
+	gc "gopkg.in/check.v1"
+
+	apitesting "github.com/juju/juju/apiserver/testing"
+	"github.com/juju/juju/controller"
+	"github.com/juju/juju/core/auditlog"
+	"github.com/juju/juju/state"
+	"github.com/juju/juju/state/watcher/watchertest"
+	jujutesting "github.com/juju/juju/testing"
+	"github.com/juju/juju/worker/auditconfigupdater"
+	"github.com/juju/juju/worker/workertest"
+)
+
+type updaterSuite struct {
+	jujutesting.BaseSuite
+}
+
+var _ = gc.Suite(&updaterSuite{})
+
+var ding = struct{}{}
+
+func (s *updaterSuite) TestWorker(c *gc.C) {
+	configChanged := make(chan struct{}, 1)
+	output := make(chan auditlog.Config)
+	initial := auditlog.Config{
+		Enabled: false,
+	}
+	source := configSource{
+		watcher: watchertest.NewNotifyWatcher(configChanged),
+		cfg:     makeControllerConfig(false, false),
+	}
+
+	fakeTarget := apitesting.FakeAuditLog{}
+	var calls []auditlog.Config
+	factory := func(cfg auditlog.Config) auditlog.AuditLog {
+		calls = append(calls, cfg)
+		return &fakeTarget
+	}
+
+	w, err := auditconfigupdater.New(&source, initial, factory, output)
+	c.Assert(err, jc.ErrorIsNil)
+	defer workertest.CleanKill(c, w)
+
+	source.cfg["auditing-enabled"] = true
+	configChanged <- ding
+
+	var newConfig auditlog.Config
+	select {
+	case <-time.After(jujutesting.LongWait):
+		c.Fatalf("took too long to send change")
+	case newConfig = <-output:
+	}
+
+	c.Assert(newConfig.Enabled, gc.Equals, true)
+	c.Assert(newConfig.CaptureAPIArgs, gc.Equals, false)
+	c.Assert(newConfig.ExcludeMethods, gc.DeepEquals, set.NewStrings())
+	c.Assert(newConfig.Target, gc.Equals, auditlog.AuditLog(&fakeTarget))
+	c.Assert(calls, gc.HasLen, 1)
+}
+
+func (s *updaterSuite) TestIgnoresIrrelevantChange(c *gc.C) {
+	configChanged := make(chan struct{}, 1)
+	output := make(chan auditlog.Config)
+	initial := auditlog.Config{
+		Enabled: false,
+	}
+	source := configSource{
+		watcher: watchertest.NewNotifyWatcher(configChanged),
+		cfg:     makeControllerConfig(false, false),
+	}
+
+	fakeTarget := apitesting.FakeAuditLog{}
+	var calls []auditlog.Config
+	factory := func(cfg auditlog.Config) auditlog.AuditLog {
+		calls = append(calls, cfg)
+		return &fakeTarget
+	}
+
+	w, err := auditconfigupdater.New(&source, initial, factory, output)
+	c.Assert(err, jc.ErrorIsNil)
+	defer workertest.CleanKill(c, w)
+
+	// No change.
+	configChanged <- ding
+
+	select {
+	case <-time.After(jujutesting.ShortWait):
+	case <-output:
+		c.Fatalf("irrelevant change shouldn't have triggered audit config change")
+	}
+
+	source.cfg = makeControllerConfig(true, false)
+	configChanged <- ding
+
+	var newConfig auditlog.Config
+	select {
+	case <-time.After(jujutesting.LongWait):
+		c.Fatalf("change ignored")
+	case newConfig = <-output:
+	}
+
+	c.Assert(newConfig.Enabled, gc.Equals, true)
+	c.Assert(newConfig.CaptureAPIArgs, gc.Equals, false)
+	c.Assert(newConfig.ExcludeMethods, gc.DeepEquals, set.NewStrings())
+	c.Assert(newConfig.Target, gc.Equals, auditlog.AuditLog(&fakeTarget))
+	c.Assert(calls, gc.HasLen, 1)
+
+	// No change.
+	configChanged <- ding
+
+	select {
+	case <-time.After(jujutesting.ShortWait):
+	case <-output:
+		c.Fatalf("subsequent change shouldn't have triggered audit config change")
+	}
+}
+
+func (s *updaterSuite) TestKeepsLogFileWhenAuditingDisabled(c *gc.C) {
+	configChanged := make(chan struct{}, 1)
+	output := make(chan auditlog.Config)
+	initial := auditlog.Config{
+		Enabled: true,
+		Target:  &apitesting.FakeAuditLog{},
+	}
+	source := configSource{
+		watcher: watchertest.NewNotifyWatcher(configChanged),
+		cfg:     makeControllerConfig(true, false),
+	}
+
+	// Passing a nil factory means we can be sure it didn't try to
+	// create a new logfile.
+	w, err := auditconfigupdater.New(&source, initial, nil, output)
+	c.Assert(err, jc.ErrorIsNil)
+	defer workertest.CleanKill(c, w)
+
+	source.cfg = makeControllerConfig(false, false)
+	configChanged <- ding
+
+	var newConfig auditlog.Config
+	select {
+	case <-time.After(jujutesting.LongWait):
+		c.Fatalf("change ignored")
+	case newConfig = <-output:
+	}
+
+	c.Assert(newConfig.Enabled, gc.Equals, false)
+	c.Assert(newConfig.Target, gc.Equals, initial.Target)
+}
+
+func (s *updaterSuite) TestKeepsLogFileWhenEnabled(c *gc.C) {
+	configChanged := make(chan struct{}, 1)
+	output := make(chan auditlog.Config)
+	initial := auditlog.Config{
+		Enabled: false,
+		Target:  &apitesting.FakeAuditLog{},
+	}
+	source := configSource{
+		watcher: watchertest.NewNotifyWatcher(configChanged),
+		cfg:     makeControllerConfig(false, false),
+	}
+
+	// Passing a nil factory means we can be sure it didn't try to
+	// create a new logfile.
+	w, err := auditconfigupdater.New(&source, initial, nil, output)
+	c.Assert(err, jc.ErrorIsNil)
+	defer workertest.CleanKill(c, w)
+
+	source.cfg = makeControllerConfig(true, false)
+	configChanged <- ding
+
+	var newConfig auditlog.Config
+	select {
+	case <-time.After(jujutesting.LongWait):
+		c.Fatalf("change ignored")
+	case newConfig = <-output:
+	}
+
+	c.Assert(newConfig.Enabled, gc.Equals, true)
+	c.Assert(newConfig.Target, gc.Equals, initial.Target)
+}
+
+func (s *updaterSuite) TestChangingExcludeMethod(c *gc.C) {
+	configChanged := make(chan struct{}, 1)
+	output := make(chan auditlog.Config)
+	initial := auditlog.Config{
+		Enabled:        true,
+		ExcludeMethods: set.NewStrings("Pink.Floyd"),
+		Target:         &apitesting.FakeAuditLog{},
+	}
+	source := configSource{
+		watcher: watchertest.NewNotifyWatcher(configChanged),
+		cfg:     makeControllerConfig(true, false, "Pink.Floyd"),
+	}
+
+	w, err := auditconfigupdater.New(&source, initial, nil, output)
+	c.Assert(err, jc.ErrorIsNil)
+	defer workertest.CleanKill(c, w)
+
+	source.cfg = makeControllerConfig(true, false, "Pink.Floyd", "Led.Zeppelin")
+	configChanged <- ding
+
+	var newConfig auditlog.Config
+	select {
+	case <-time.After(jujutesting.LongWait):
+		c.Fatalf("change ignored")
+	case newConfig = <-output:
+	}
+
+	c.Assert(newConfig.ExcludeMethods, gc.DeepEquals, set.NewStrings("Pink.Floyd", "Led.Zeppelin"))
+
+	source.cfg = makeControllerConfig(true, false, "Led.Zeppelin")
+	configChanged <- ding
+
+	select {
+	case <-time.After(jujutesting.LongWait):
+		c.Fatalf("change ignored")
+	case newConfig = <-output:
+	}
+
+	c.Assert(newConfig.ExcludeMethods, gc.DeepEquals, set.NewStrings("Led.Zeppelin"))
+}
+
+func (s *updaterSuite) TestChangingCaptureArgs(c *gc.C) {
+	configChanged := make(chan struct{}, 1)
+	output := make(chan auditlog.Config)
+	initial := auditlog.Config{
+		Enabled:        true,
+		CaptureAPIArgs: false,
+		Target:         &apitesting.FakeAuditLog{},
+	}
+	source := configSource{
+		watcher: watchertest.NewNotifyWatcher(configChanged),
+		cfg:     makeControllerConfig(true, false, "Pink.Floyd"),
+	}
+
+	w, err := auditconfigupdater.New(&source, initial, nil, output)
+	c.Assert(err, jc.ErrorIsNil)
+	defer workertest.CleanKill(c, w)
+
+	source.cfg = makeControllerConfig(true, true)
+	configChanged <- ding
+
+	var newConfig auditlog.Config
+	select {
+	case <-time.After(jujutesting.LongWait):
+		c.Fatalf("change ignored")
+	case newConfig = <-output:
+	}
+
+	c.Assert(newConfig.CaptureAPIArgs, gc.Equals, true)
+}
+
+func makeControllerConfig(auditEnabled bool, captureArgs bool, methods ...interface{}) controller.Config {
+	result := map[string]interface{}{
+		"other-setting":             "something",
+		"auditing-enabled":          auditEnabled,
+		"audit-log-capture-args":    captureArgs,
+		"audit-log-exclude-methods": methods,
+	}
+	return result
+}
+
+type configSource struct {
+	stub    testing.Stub
+	watcher *watchertest.NotifyWatcher
+	cfg     controller.Config
+}
+
+func (s *configSource) WatchControllerConfig() state.NotifyWatcher {
+	s.stub.AddCall("WatchControllerConfig")
+	return s.watcher
+}
+
+func (s *configSource) ControllerConfig() (controller.Config, error) {
+	s.stub.AddCall("ControllerConfig")
+	if err := s.stub.NextErr(); err != nil {
+		return nil, err
+	}
+	return s.cfg, nil
+}


### PR DESCRIPTION
## Description of change

The changes in #8315 allowed updating the controller config for audit logging. This PR changes the machine agent and API server to watch controller config for changes in the audit logging settings, and use them in new API connections.

It disallows changing `audit-log-max-backups` and `-max-size` - handling these properly would require some more architectural changes to make sure that the log file gets closed and re-opened correctly for requests that are in progress.

## QA steps

Bootstrap a controller with `auditing-enabled=false`.
Deploy some applications and add relations and check that API requests aren't written to the audit log.
Run `juju controller-config auditing-enabled=true`.
Make some more changes to the model (add/remove units and relations).
See that those changes are now being written to the audit log.
Change the values of `audit-log-exclude-methods` and `audit-log-capture-args` - check that the changes are reflected in the records written out.
Turn audit logging off, and make more changes.
Turn it on again, and make more changes. 
