### PR TITLE
audit-log: UI polish and tweaking

### DIFF
--- a/apiserver/admin.go
+++ b/apiserver/admin.go
@@ -168,7 +168,7 @@ func (a *admin) getAuditRecorder(req params.LoginRequest, authResult *authResult
 			a.srv.auditLogger, filter),
 		a.srv.clock,
 		auditlog.ConversationArgs{
-			Who:          req.AuthTag,
+			Who:          a.root.entity.Tag().Id(),
 			What:         req.CLIArgs,
 			ModelName:    a.root.model.Name(),
 			ModelUUID:    a.root.model.UUID(),

--- a/apiserver/admin_test.go
+++ b/apiserver/admin_test.go
@@ -993,7 +993,7 @@ func (s *loginSuite) TestLoginAddsAuditConversationEventually(c *gc.C) {
 	convo.ConversationID = "0123456789abcdef"
 	convo.ConnectionID = "something"
 	c.Assert(convo, gc.Equals, auditlog.Conversation{
-		Who:            user.Tag().String(),
+		Who:            user.Tag().Id(),
 		What:           "hey you guys",
 		When:           cfg.Clock.Now().Format(time.RFC3339),
 		ModelName:      s.IAASModel.Name(),

--- a/cmd/juju/controller/configcommand.go
+++ b/cmd/juju/controller/configcommand.go
@@ -232,6 +232,16 @@ func formatConfigTabular(writer io.Writer, value interface{}) error {
 		// Some attribute values have a newline appended
 		// which makes the output messy.
 		valString := strings.TrimSuffix(out.String(), "\n")
+
+		// Special formatting for multiline exclude-methods lists.
+		if name == controller.AuditLogExcludeMethods {
+			if strings.Contains(valString, "\n") {
+				valString = "\n" + valString
+			} else {
+				valString = strings.TrimLeft(valString, "- ")
+			}
+		}
+
 		w.Println(name, valString)
 	}
 

--- a/state/controller.go
+++ b/state/controller.go
@@ -124,14 +124,24 @@ func (st *State) UpdateControllerConfig(updateAttrs map[string]interface{}, remo
 
 func checkControllerConfigNames(updateAttrs map[string]interface{}, removeAttrs []string) error {
 	for k := range updateAttrs {
-		if !jujucontroller.AllowedUpdateConfigAttributes.Contains(k) {
-			return errors.Errorf("can't change %q after bootstrap", k)
+		if err := checkUpdateControllerConfig(k); err != nil {
+			return errors.Trace(err)
 		}
 	}
 	for _, r := range removeAttrs {
-		if !jujucontroller.AllowedUpdateConfigAttributes.Contains(r) {
-			return errors.Errorf("can't change %q after bootstrap", r)
+		if err := checkUpdateControllerConfig(r); err != nil {
+			return errors.Trace(err)
 		}
+	}
+	return nil
+}
+
+func checkUpdateControllerConfig(name string) error {
+	if !jujucontroller.ControllerOnlyAttribute(name) {
+		return errors.Errorf("unknown controller config setting %q", name)
+	}
+	if !jujucontroller.AllowedUpdateConfigAttributes.Contains(name) {
+		return errors.Errorf("can't change %q after bootstrap", name)
 	}
 	return nil
 }

--- a/state/controller_test.go
+++ b/state/controller_test.go
@@ -134,3 +134,15 @@ func (s *ControllerSuite) TestUpdateControllerConfigValidates(c *gc.C) {
 	}, nil)
 	c.Assert(err, gc.ErrorMatches, `invalid audit log max size in configuration: invalid multiplier suffix "ZipMorps", expected one of MGTPEZY`)
 }
+
+func (s *ControllerSuite) TestUpdatingUnknownName(c *gc.C) {
+	err := s.State.UpdateControllerConfig(map[string]interface{}{
+		"ana-ng": "majestic",
+	}, nil)
+	c.Assert(err, gc.ErrorMatches, `unknown controller config setting "ana-ng"`)
+}
+
+func (s *ControllerSuite) TestRemovingUnknownName(c *gc.C) {
+	err := s.State.UpdateControllerConfig(nil, []string{"dr-worm"})
+	c.Assert(err, gc.ErrorMatches, `unknown controller config setting "dr-worm"`)
+}


### PR DESCRIPTION
## Description of change
Some minor changes to audit logging behaviour and the `controller-config` command.
* Store the username of the user making the change in the log, rather than the tag.
* Display a less confusing error when setting a non-existent controller config key - it used to report `can't change [non-existent key] after bootstrap`.
* Better formatting for the exclude method list in the `controller-config` output - add a newline when there are multiple values, display a single value sensibly.

## QA steps
* Bootstrap with audit logging and do some stuff to the model.
* Check the logged usernames.
* Try to set a non-existent controller config value
* Check the output of `controller-config`
