### PR TITLE
Attempt to check and use configured juju-ha-space for mongo space bef…

### DIFF
--- a/worker/peergrouper/worker.go
+++ b/worker/peergrouper/worker.go
@@ -460,7 +460,7 @@ func (w *pgWorker) getMongoSpace(addrs [][]network.Address) (network.SpaceName, 
 
 		// Check to see if a HA space was set in the controller config.
 		space := unsetSpace
-		space, err = w.tryGetMongoSpaceFromConfig(addrs)
+		space, err = w.tryGetMongoSpaceFromConfig()
 		if err != nil {
 			return space, errors.Annotate(err, "getting Mongo space from config")
 		}
@@ -495,7 +495,7 @@ func (w *pgWorker) getMongoSpace(addrs [][]network.Address) (network.SpaceName, 
 // trySetMongoSpaceFromConfig checks whether a value was supplied for
 // juju-ha-space in the controllers config.
 // If so, an attempt is made to use that value as the Mongo space name.
-func (w *pgWorker) tryGetMongoSpaceFromConfig(addrs [][]network.Address) (network.SpaceName, error) {
+func (w *pgWorker) tryGetMongoSpaceFromConfig() (network.SpaceName, error) {
 	config, err := w.config.State.ControllerConfig()
 	if err != nil {
 		return unsetSpace, err


### PR DESCRIPTION
## Description of change

If a controller configuration has a value set for _juju-ha-space_, we want to use this value for the Mongo space in controller info instead of attempting to automatically determine such a space.

## QA steps

Accompanying unit test changes.

## Documentation changes

No.

## Bug reference

N/A.
